### PR TITLE
Reduce DKG node RPC load across startup and steady-state polling

### DIFF
--- a/devnet/rpc-quiet-window/automated.test.ts
+++ b/devnet/rpc-quiet-window/automated.test.ts
@@ -1,0 +1,271 @@
+import { describe, it, expect } from 'vitest';
+import {
+  closeSync,
+  existsSync,
+  openSync,
+  readFileSync,
+  readSync,
+  readdirSync,
+  statSync,
+} from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const REPO_ROOT = resolve(import.meta.dirname, '../..');
+const DEVNET_DIR = join(REPO_ROOT, '.devnet');
+
+const OBSERVATION_MS = Number(process.env.RPC_QUIET_WINDOW_MS ?? 185_000);
+const MIN_EVALUATED_WINDOWS = Number(process.env.RPC_QUIET_MIN_WINDOWS ?? 1);
+const MAX_ETH_GETLOGS = Number(process.env.RPC_QUIET_MAX_ETH_GETLOGS ?? 20);
+const MAX_ETH_CHAINID = Number(process.env.RPC_QUIET_MAX_ETH_CHAINID ?? 5);
+const MAX_TOTAL = Number(process.env.RPC_QUIET_MAX_TOTAL ?? 120);
+const EXPECTED_DEVNET_NODES = Number(process.env.RPC_QUIET_EXPECTED_NODES ?? 6);
+const EXPECTED_RPC_USAGE_WINDOW_SECONDS = Number(process.env.RPC_QUIET_EXPECTED_WINDOW_SECONDS ?? 60);
+
+type UsageWindow = {
+  node: string;
+  timestamp: string;
+  windowSeconds: number;
+  mixedWindowSeconds?: boolean;
+  byMethod: Record<string, number>;
+};
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolveSleep) => setTimeout(resolveSleep, ms));
+}
+
+function discoverDaemonLogs(): Array<{ node: string; path: string }> {
+  if (!existsSync(DEVNET_DIR)) {
+    throw new Error('No .devnet directory found. Start a publisher-enabled devnet before running this suite.');
+  }
+
+  return readdirSync(DEVNET_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && /^node\d+$/.test(entry.name))
+    .map((entry) => ({ node: entry.name, path: join(DEVNET_DIR, entry.name, 'daemon.log') }))
+    .filter((entry) => existsSync(entry.path))
+    .sort((a, b) => a.node.localeCompare(b.node, undefined, { numeric: true }));
+}
+
+function expectedDevnetNodes(count = EXPECTED_DEVNET_NODES): string[] {
+  if (!Number.isInteger(count) || count <= 0) {
+    throw new Error(`RPC_QUIET_EXPECTED_NODES must be a positive integer (got ${count})`);
+  }
+  return Array.from({ length: count }, (_, index) => `node${index + 1}`);
+}
+
+function missingExpectedDaemonLogs(
+  logs: Array<{ node: string }>,
+  expectedNodes = expectedDevnetNodes(),
+): string[] {
+  const observed = new Set(logs.map((log) => log.node));
+  return expectedNodes
+    .filter((node) => !observed.has(node))
+    .map((node) => `${node}/daemon.log`);
+}
+
+function nodesWithoutPostWarmupWindows(
+  windowsByNode: Map<string, UsageWindow[]>,
+  expectedNodes = expectedDevnetNodes(),
+  minWindows = MIN_EVALUATED_WINDOWS,
+): string[] {
+  return expectedNodes.filter((node) => {
+    const windows = windowsByNode.get(node) ?? [];
+    return windows.slice(1).length < minWindows;
+  });
+}
+
+function invalidRpcUsageWindowDurations(
+  windowsByNode: Map<string, UsageWindow[]>,
+  expectedSeconds = EXPECTED_RPC_USAGE_WINDOW_SECONDS,
+): string[] {
+  if (!Number.isInteger(expectedSeconds) || expectedSeconds <= 0) {
+    throw new Error(`RPC_QUIET_EXPECTED_WINDOW_SECONDS must be a positive integer (got ${expectedSeconds})`);
+  }
+
+  const invalid: string[] = [];
+  for (const [node, windows] of windowsByNode) {
+    for (const window of windows) {
+      if (window.mixedWindowSeconds) {
+        invalid.push(`${node} ${window.timestamp}: mixed window_s values`);
+      } else if (window.windowSeconds !== expectedSeconds) {
+        invalid.push(`${node} ${window.timestamp}: window_s=${window.windowSeconds}`);
+      }
+    }
+  }
+  return invalid;
+}
+
+function readNewText(path: string, startOffset: number): string {
+  const endOffset = statSync(path).size;
+  if (endOffset <= startOffset) return '';
+
+  const length = endOffset - startOffset;
+  const buffer = Buffer.alloc(length);
+  const fd = openSync(path, 'r');
+  try {
+    readSync(fd, buffer, 0, length, startOffset);
+  } finally {
+    closeSync(fd);
+  }
+  return buffer.toString('utf8');
+}
+
+function parseRpcUsageWindows(node: string, text: string): UsageWindow[] {
+  const windows = new Map<string, UsageWindow>();
+  const lineRe = /^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}).*\brpc_usage method=([A-Za-z0-9_.:-]+) count=(\d+) window_s=(\d+)(?: chain=([A-Za-z0-9_.:-]+))?/gm;
+
+  for (const match of text.matchAll(lineRe)) {
+    const [, timestamp, method, countRaw, windowSecondsRaw] = match;
+    const windowSeconds = Number(windowSecondsRaw);
+    const key = `${node}:${timestamp}`;
+    let window = windows.get(key);
+    if (!window) {
+      window = { node, timestamp, windowSeconds, byMethod: {} };
+      windows.set(key, window);
+    } else if (window.windowSeconds !== windowSeconds) {
+      window.mixedWindowSeconds = true;
+    }
+    window.byMethod[method] = (window.byMethod[method] ?? 0) + Number(countRaw);
+  }
+
+  return [...windows.values()].sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+}
+
+function windowTotal(window: UsageWindow): number {
+  return Object.values(window.byMethod).reduce((sum, count) => sum + count, 0);
+}
+
+describe('devnet RPC quiet-window budget', () => {
+  it('keeps idle daemon rpc_usage under the lane-aware poller budget', async () => {
+    const logs = discoverDaemonLogs();
+    const missingLogs = missingExpectedDaemonLogs(logs);
+    expect(missingLogs, `missing expected devnet daemon logs: ${missingLogs.join(', ')}`).toEqual([]);
+
+    const offsets = new Map(logs.map((log) => [log.path, statSync(log.path).size]));
+    await sleep(OBSERVATION_MS);
+
+    const evaluated: UsageWindow[] = [];
+    const missingTelemetry: string[] = [];
+    const activityHints: string[] = [];
+    const windowsByNode = new Map<string, UsageWindow[]>();
+
+    for (const log of logs) {
+      const chunk = readNewText(log.path, offsets.get(log.path) ?? 0);
+      if (/\bChain event: (KCCreated|KnowledgeAssetCreated|ContextGraphCreated|KnowledgeAssetRegisteredToContextGraph)\b/.test(chunk)) {
+        activityHints.push(log.node);
+      }
+
+      const windows = parseRpcUsageWindows(log.node, chunk);
+      windowsByNode.set(log.node, windows);
+      if (windows.length === 0) {
+        missingTelemetry.push(log.node);
+        continue;
+      }
+
+      evaluated.push(...windows.slice(1));
+    }
+
+    expect(
+      activityHints,
+      `quiet-window suite saw chain events in daemon logs: ${activityHints.join(', ')}; rerun without concurrent publishes or graph registrations`,
+    ).toEqual([]);
+    expect(missingTelemetry, `nodes without rpc_usage lines during observation: ${missingTelemetry.join(', ')}`).toEqual([]);
+    const unevaluatedNodes = nodesWithoutPostWarmupWindows(windowsByNode);
+    expect(
+      unevaluatedNodes,
+      `nodes without enough post-warmup rpc_usage windows: ${unevaluatedNodes.join(', ')}; increase RPC_QUIET_WINDOW_MS`,
+    ).toEqual([]);
+    const invalidWindowDurations = invalidRpcUsageWindowDurations(windowsByNode);
+    expect(
+      invalidWindowDurations,
+      `rpc_usage window_s mismatch: ${invalidWindowDurations.join(', ')}`,
+    ).toEqual([]);
+    expect(evaluated.length, 'not enough post-warmup rpc_usage windows; increase RPC_QUIET_WINDOW_MS').toBeGreaterThanOrEqual(
+      MIN_EVALUATED_WINDOWS * EXPECTED_DEVNET_NODES,
+    );
+
+    for (const window of evaluated) {
+      const getLogs = window.byMethod.eth_getLogs ?? 0;
+      const chainId = window.byMethod.eth_chainId ?? 0;
+      const total = windowTotal(window);
+      const label = `${window.node} ${window.timestamp} ${JSON.stringify(window.byMethod)}`;
+
+      expect(getLogs, `${label}: eth_getLogs should be idle except slow context discovery`).toBeLessThanOrEqual(MAX_ETH_GETLOGS);
+      expect(chainId, `${label}: static-network providers should suppress steady eth_chainId`).toBeLessThanOrEqual(MAX_ETH_CHAINID);
+      expect(total, `${label}: total quiet-window RPC volume`).toBeLessThanOrEqual(MAX_TOTAL);
+    }
+  });
+
+  it('parses the committed rpc_usage contract shape used by daemon logs', () => {
+    const sample = readFileSync(resolve(import.meta.dirname, 'package.json'), 'utf8');
+    expect(sample).toContain('dkg-devnet-rpc-quiet-window');
+
+    const windows = parseRpcUsageWindows(
+      'node1',
+      '2026-07-04 10:00:00 system abc [chain-rpc] rpc_usage method=eth_getLogs count=2 window_s=60 chain=hardhat:31337\n' +
+      '2026-07-04 10:00:00 system def [chain-rpc] rpc_usage method=eth_chainId count=0 window_s=60 chain=hardhat:31337\n',
+    );
+
+    expect(windows).toEqual([
+      {
+        node: 'node1',
+        timestamp: '2026-07-04 10:00:00',
+        windowSeconds: 60,
+        byMethod: { eth_getLogs: 2, eth_chainId: 0 },
+      },
+    ]);
+  });
+
+  it('reports rpc_usage windows with unexpected durations', () => {
+    const windows = parseRpcUsageWindows(
+      'node1',
+      '2026-07-04 10:00:00 system abc [chain-rpc] rpc_usage method=eth_getLogs count=2 window_s=10 chain=hardhat:31337\n',
+    );
+
+    expect(invalidRpcUsageWindowDurations(
+      new Map([['node1', windows]]),
+      60,
+    )).toEqual(['node1 2026-07-04 10:00:00: window_s=10']);
+  });
+
+  it('reports mixed rpc_usage durations in the same timestamp bucket', () => {
+    const windows = parseRpcUsageWindows(
+      'node1',
+      '2026-07-04 10:00:00 system abc [chain-rpc] rpc_usage method=eth_getLogs count=2 window_s=60 chain=hardhat:31337\n' +
+      '2026-07-04 10:00:00 system def [chain-rpc] rpc_usage method=eth_chainId count=0 window_s=10 chain=hardhat:31337\n',
+    );
+
+    expect(windows).toHaveLength(1);
+    expect(invalidRpcUsageWindowDurations(
+      new Map([['node1', windows]]),
+      60,
+    )).toEqual(['node1 2026-07-04 10:00:00: mixed window_s values']);
+  });
+
+  it('fails preflight when expected devnet daemon logs are missing', () => {
+    expect(missingExpectedDaemonLogs(
+      [{ node: 'node1' }, { node: 'node3' }],
+      ['node1', 'node2', 'node3'],
+    )).toEqual(['node2/daemon.log']);
+  });
+
+  it('reports nodes that lack post-warmup rpc_usage windows', () => {
+    const node1 = parseRpcUsageWindows(
+      'node1',
+      '2026-07-04 10:00:00 system abc [chain-rpc] rpc_usage method=eth_getLogs count=2 window_s=60 chain=hardhat:31337\n' +
+      '2026-07-04 10:01:00 system abc [chain-rpc] rpc_usage method=eth_getLogs count=1 window_s=60 chain=hardhat:31337\n',
+    );
+    const node2 = parseRpcUsageWindows(
+      'node2',
+      '2026-07-04 10:00:00 system abc [chain-rpc] rpc_usage method=eth_getLogs count=50 window_s=60 chain=hardhat:31337\n',
+    );
+
+    expect(nodesWithoutPostWarmupWindows(
+      new Map([
+        ['node1', node1],
+        ['node2', node2],
+      ]),
+      ['node1', 'node2'],
+      1,
+    )).toEqual(['node2']);
+  });
+});

--- a/devnet/rpc-quiet-window/package.json
+++ b/devnet/rpc-quiet-window/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@origintrail-official/dkg-devnet-rpc-quiet-window",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test:devnet": "vitest run --config vitest.config.ts"
+  },
+  "devDependencies": {
+    "vitest": "^4.0.18"
+  }
+}

--- a/devnet/rpc-quiet-window/vitest.config.ts
+++ b/devnet/rpc-quiet-window/vitest.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'node:path';
+
+const automatedTest = resolve(import.meta.dirname, 'automated.test.ts').replace(/\\/g, '/');
+
+/**
+ * RPC quiet-window budget validation.
+ *
+ * Run on an already-started, idle devnet:
+ *   pnpm run build
+ *   DEVNET_ENABLE_PUBLISHER=1 ./scripts/devnet.sh start 6
+ *   pnpm test:devnet:rpc-quiet-window
+ *
+ * The suite tails daemon rpc_usage logs only; route probes and publishes should
+ * not run during the observation window.
+ */
+export default defineConfig({
+  test: {
+    include: [automatedTest],
+    testTimeout: Number(process.env.RPC_QUIET_TEST_TIMEOUT_MS ?? 300_000),
+    hookTimeout: 60_000,
+    pool: 'forks',
+    sequence: { concurrent: false },
+    globals: false,
+  },
+  resolve: {
+    modules: [resolve(import.meta.dirname, '../../node_modules'), 'node_modules'],
+  },
+});

--- a/devnet/suites.json
+++ b/devnet/suites.json
@@ -29,6 +29,7 @@
     "ka-lifecycle-cli",
     "rfc51-publishing-allocation",
     "rich-scenario",
+    "rpc-quiet-window",
     "v10-core-flows",
     "v10-end-to-end",
     "v10-rs-prune",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "test:devnet:edge-update-flow": "vitest run --config devnet/edge-update-flow/vitest.config.ts",
     "test:devnet:greenfield-10min": "vitest run --config devnet/greenfield-10min/vitest.config.ts",
     "test:devnet:rich-scenario": "vitest run --config devnet/rich-scenario/vitest.config.ts",
+    "test:devnet:rpc-quiet-window": "vitest run --config devnet/rpc-quiet-window/vitest.config.ts",
     "test:devnet:v10-rs-prune": "vitest run --config devnet/v10-rs-prune/vitest.config.ts",
     "test:all": "pnpm test && pnpm test:evm",
     "test:devnet:pr1386-term-canon": "vitest run --config devnet/pr1386-term-canon/vitest.config.ts",

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -1440,6 +1440,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       this.chainPoller = new ChainEventPoller({
         chain: this.chain,
         publishHandler,
+        cursorPersistence: this.config.chainEventCursorStore,
         onContextGraphCreated: async ({ contextGraphId, creator, accessPolicy, publishPolicy, nameHash, blockNumber }) => {
           this.log.info(ctx, `Discovered on-chain context graph ${contextGraphId.slice(0, 16)}… (block ${blockNumber}, creator ${creator.slice(0, 10)}…, policy ${accessPolicy}, publishPolicy ${publishPolicy ?? '?'}, nameHash ${nameHash ? nameHash.slice(0, 10) + '…' : '(opt-out)'})`);
 

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -33,8 +33,9 @@ import type {
   LiftTransitionType,
   LiftAuthorityProof,
   SharedMemoryPublicSnapshotStorageConfig,
+  CursorPersistence as ChainEventCursorPersistence,
 } from '@origintrail-official/dkg-publisher';
-import type { ApprovalPolicy, ChainAdapter } from '@origintrail-official/dkg-chain';
+import type { ApprovalPolicy, ChainAdapter, ContextGraphRegistryScanCursorStore } from '@origintrail-official/dkg-chain';
 import type { QueryAccessConfig } from '@origintrail-official/dkg-query';
 import type { SkillHandler } from './messaging.js';
 import type { CclFactResolutionMode } from './ccl-fact-resolution.js';
@@ -1143,6 +1144,10 @@ export interface DKGAgentConfig {
   contextGraphSubscriptionStore?: ContextGraphSubscriptionStore;
   /** Durable local store for paged sync checkpoints. Defaults to in-memory. */
   syncCheckpointStore?: SyncCheckpointStore;
+  /** Durable lane cursor store for the chain event poller. Defaults to in-memory. */
+  chainEventCursorStore?: ChainEventCursorPersistence;
+  /** Durable ContextGraphNameRegistry discovery cursor store. Defaults to in-memory adapter state. */
+  contextGraphRegistryScanCursorStore?: ContextGraphRegistryScanCursorStore;
   /**
    * Intentional cap on how many persisted context-graph subscriptions are
    * *activated* (gossip-subscribed + sync-tracked) when rehydrating at startup.

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1214,11 +1214,26 @@ export class DKGAgent extends DKGAgentBase {
       // Also compute expected hash for locally-known context graph IDs
       knownOnChainIds.add(ethers.keccak256(ethers.toUtf8Bytes(localId)));
     }
+    const readDurableContextGraphOnChainId = async (contextGraphId: string): Promise<string | null> => {
+      const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+      const contextGraphUri = contextGraphDataGraphUri(contextGraphId);
+      const result = await this.store.query(
+        `SELECT ?id WHERE { GRAPH <${ontologyGraph}> { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId> ?id } } LIMIT 1`,
+      );
+      if (result.type !== 'bindings' || result.bindings.length === 0) return null;
+      const value = result.bindings[0]?.['id'];
+      return typeof value === 'string' ? value.replace(/^"|"$/g, '') : null;
+    };
 
     let discovered = 0;
     const applyDiscoveredContextGraphs = async (contextGraphs: ContextGraphOnChain[]): Promise<void> => {
       for (const p of contextGraphs) {
-        if (knownOnChainIds.has(p.contextGraphId)) continue;
+        if (knownOnChainIds.has(p.contextGraphId)) {
+          if (!p.name) continue;
+          const durableOnChainId = await readDurableContextGraphOnChainId(p.name);
+          if (durableOnChainId === p.contextGraphId) continue;
+          knownOnChainIds.delete(p.contextGraphId);
+        }
 
         if (!p.name) {
           // Hash-only entry (metadata not revealed) — record for dedup but don't
@@ -1244,15 +1259,6 @@ export class DKGAgent extends DKGAgentBase {
           }
         }
 
-        this.setContextGraphSubscription(p.name, {
-          name: p.name,
-          subscribed: true,
-          synced: false,
-          metaSynced: false,
-          onChainId: p.contextGraphId,
-        });
-        this.subscribeToContextGraph(p.name, { trackSyncScope: false });
-
         // Persist the on-chain ID to the ontology graph so the publisher's
         // VM registration guard can find it via RDF (it has no access to
         // the in-memory subscribedContextGraphs map).
@@ -1261,6 +1267,9 @@ export class DKGAgent extends DKGAgentBase {
         // Single-valued binding guard (RS heal): on-chain id is immutable; clear
         // any prior value so the cgId resolver / heal never read a multi-valued
         // (LIMIT-1-nondeterministic) binding.
+        // Keep this durable write before subscription/gossip mutation: cursor
+        // pages are acked after this function returns, and an in-memory onChainId
+        // alone must not make a retry skip the RDF binding.
         await this.store.deleteByPattern({
           graph: ontoGraph,
           subject: cgUri,
@@ -1273,6 +1282,14 @@ export class DKGAgent extends DKGAgentBase {
           graph: ontoGraph,
         }]);
 
+        this.setContextGraphSubscription(p.name, {
+          name: p.name,
+          subscribed: true,
+          synced: false,
+          metaSynced: false,
+          onChainId: p.contextGraphId,
+        });
+        this.subscribeToContextGraph(p.name, { trackSyncScope: false });
         this.contextGraphMetaProjection.markDirty(p.name);
         this.log.info(ctx, `Discovered on-chain context graph "${p.name}" (${p.contextGraphId.slice(0, 16)}…) — auto-subscribed (synced=false)`);
         knownOnChainIds.add(p.contextGraphId);

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -85,7 +85,7 @@ import {
   ENTITY_PRED_ALT,
 } from '@origintrail-official/dkg-core';
 import { GraphManager, PrivateContentStore, createTripleStore, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig } from '@origintrail-official/dkg-storage';
-import { EVMChainAdapter, NoChainAdapter, enrichEvmError, buildKnowledgeAssetUal, isContextGraphChainScanPartialError, type EVMAdapterConfig, type ChainAdapter, type ContextGraphOnChain, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo } from '@origintrail-official/dkg-chain';
+import { EVMChainAdapter, NoChainAdapter, enrichEvmError, buildKnowledgeAssetUal, isContextGraphChainScanPartialError, type EVMAdapterConfig, type ChainAdapter, type ContextGraphOnChain, type ContextGraphChainScanOptions, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo } from '@origintrail-official/dkg-chain';
 import {
   DKGPublisher, PublishHandler, SharedMemoryHandler, UpdateHandler, ChainEventPoller, AccessHandler, AccessClient,
   PublishJournal, StaleWriteError,
@@ -460,10 +460,80 @@ export interface AssertionHistoryDescriptor extends AssertionDescriptor {
   publishedUal?: string;
 }
 
-export interface DiscoverContextGraphsFromChainOptions {
+export type DiscoverContextGraphsFromChainOptions = {
+  throwOnChainScanFailure?: boolean;
+  pageBudget?: number;
+  mode?: 'listAll' | 'incremental' | 'seedFull' | 'seedFromCursor';
   incremental?: boolean;
   seedIncrementalWatermark?: boolean;
-  throwOnChainScanFailure?: boolean;
+  resumeFromCursor?: boolean;
+};
+
+type NormalizedContextGraphDiscoveryScan =
+  | { mode: 'listAll' }
+  | { mode: 'incremental'; pageBudget?: number }
+  | { mode: 'seedFull' }
+  | { mode: 'seedFromCursor'; pageBudget?: number };
+
+function normalizeContextGraphDiscoveryScan(
+  options: DiscoverContextGraphsFromChainOptions,
+): NormalizedContextGraphDiscoveryScan {
+  if (options.mode !== undefined) {
+    if (options.mode === 'incremental') {
+      return {
+        mode: 'incremental',
+        ...(options.pageBudget !== undefined ? { pageBudget: options.pageBudget } : {}),
+      };
+    }
+    if (options.mode === 'seedFull') return { mode: 'seedFull' };
+    if (options.mode === 'seedFromCursor') {
+      return {
+        mode: 'seedFromCursor',
+        ...(options.pageBudget !== undefined ? { pageBudget: options.pageBudget } : {}),
+      };
+    }
+    if (options.mode === 'listAll') return { mode: 'listAll' };
+    throw new Error(`Unsupported context graph chain discovery scan mode: ${String(options.mode)}`);
+  }
+
+  if (options.incremental === true) {
+    return {
+      mode: 'incremental',
+      ...(options.pageBudget !== undefined ? { pageBudget: options.pageBudget } : {}),
+    };
+  }
+
+  if (options.seedIncrementalWatermark === true) {
+    if (options.resumeFromCursor === true) {
+      return {
+        mode: 'seedFromCursor',
+        ...(options.pageBudget !== undefined ? { pageBudget: options.pageBudget } : {}),
+      };
+    }
+    return { mode: 'seedFull' };
+  }
+
+  return { mode: 'listAll' };
+}
+
+function legacyChainListScanOptions(
+  options: DiscoverContextGraphsFromChainOptions,
+): ContextGraphChainScanOptions | undefined {
+  if (options.mode !== undefined) return undefined;
+  if (options.incremental === true) {
+    return {
+      incremental: true,
+      ...(options.pageBudget !== undefined ? { pageBudget: options.pageBudget } : {}),
+    };
+  }
+  if (options.seedIncrementalWatermark === true) {
+    return {
+      seedIncrementalWatermark: true,
+      ...(options.resumeFromCursor !== undefined ? { resumeFromCursor: options.resumeFromCursor } : {}),
+      ...(options.pageBudget !== undefined ? { pageBudget: options.pageBudget } : {}),
+    };
+  }
+  return undefined;
 }
 
 /**
@@ -536,6 +606,7 @@ export class DKGAgent extends DKGAgentBase {
         chainId: config.chainConfig.chainId,
         approvalPolicy: config.chainConfig.approvalPolicy,
         cgRegistryScanPageSize: config.chainConfig.cgRegistryScanPageSize,
+        contextGraphRegistryScanCursorStore: config.contextGraphRegistryScanCursorStore,
       };
       if (config.chainConfig.adminPrivateKey) {
         chain = new EVMChainAdapter({ ...evmConfigBase, adminPrivateKey: config.chainConfig.adminPrivateKey });
@@ -1089,7 +1160,7 @@ export class DKGAgent extends DKGAgentBase {
    *
    * Defaults to a full scan so SDK callers can rebuild missing local state.
    * Background daemon loops may opt into incremental scans to reuse the
-   * in-memory chain adapter watermark.
+   * chain adapter watermark.
    *
    * Returns the number of newly discovered context graphs.
    */
@@ -1097,26 +1168,26 @@ export class DKGAgent extends DKGAgentBase {
     options: DiscoverContextGraphsFromChainOptions = {},
   ): Promise<number> {
     const ctx = createOperationContext('system');
-    if (!this.chain.listContextGraphsFromChain) {
+    const scanMode = normalizeContextGraphDiscoveryScan(options);
+    const legacyListOptions = legacyChainListScanOptions(options);
+    const useLegacyListFallback =
+      scanMode.mode !== 'listAll' &&
+      legacyListOptions !== undefined &&
+      !this.chain.scanContextGraphRegistryPages &&
+      !!this.chain.listContextGraphsFromChain;
+    if (scanMode.mode === 'listAll' && !this.chain.listContextGraphsFromChain) {
       this.log.info(ctx, 'Chain adapter does not support listContextGraphsFromChain — skipping');
       return 0;
     }
+    if (scanMode.mode !== 'listAll' && !this.chain.scanContextGraphRegistryPages && !useLegacyListFallback) {
+      this.log.info(ctx, 'Chain adapter does not support scanContextGraphRegistryPages — skipping');
+      return 0;
+    }
 
-    let onChainContextGraphs;
+    let onChainContextGraphs: ContextGraphOnChain[] = [];
     let partialChainScan = false;
     let partialChainScanError: unknown;
-    try {
-      const scanOptions = options.incremental
-        ? {
-            incremental: true as const,
-          }
-        : options.seedIncrementalWatermark
-          ? {
-              seedIncrementalWatermark: true as const,
-            }
-          : undefined;
-      onChainContextGraphs = await this.chain.listContextGraphsFromChain(undefined, scanOptions);
-    } catch (err) {
+    const handleChainScanFailure = (err: unknown): ContextGraphOnChain[] | undefined => {
       const message = err instanceof Error ? err.message : String(err);
       const signature = message
         .replace(/stopped after block \d+/g, 'stopped after block N')
@@ -1130,18 +1201,11 @@ export class DKGAgent extends DKGAgentBase {
       }
       const partialError = isContextGraphChainScanPartialError(err);
       if (options.throwOnChainScanFailure && !partialError) throw err;
-      if (!partialError) return 0;
+      if (!partialError) return undefined;
       partialChainScan = true;
       partialChainScanError = err;
-      onChainContextGraphs = err.partialResults;
-    }
-    if (!partialChainScan && this.chainContextGraphScanFailure) {
-      this.log.info(
-        ctx,
-        `Chain context graph scan recovered after ${this.chainContextGraphScanFailure.count} failed attempt(s)`,
-      );
-      this.chainContextGraphScanFailure = undefined;
-    }
+      return err.partialResults;
+    };
 
     // Build a set of all known on-chain IDs (stored and computed) for fast dedup
     const knownOnChainIds = new Set<string>();
@@ -1152,65 +1216,108 @@ export class DKGAgent extends DKGAgentBase {
     }
 
     let discovered = 0;
-    for (const p of onChainContextGraphs) {
-      if (knownOnChainIds.has(p.contextGraphId)) continue;
+    const applyDiscoveredContextGraphs = async (contextGraphs: ContextGraphOnChain[]): Promise<void> => {
+      for (const p of contextGraphs) {
+        if (knownOnChainIds.has(p.contextGraphId)) continue;
 
-      if (!p.name) {
-        // Hash-only entry (metadata not revealed) — record for dedup but don't
-        // subscribe to gossip topics since hash-keyed topics are unusable.
-        this.log.info(ctx, `Noted unresolved on-chain context graph ${p.contextGraphId.slice(0, 16)}… (no metadata)`);
-        knownOnChainIds.add(p.contextGraphId);
-        continue;
-      }
-
-      // Curated CGs (accessPolicy=1) must not silently land in non-participants' lists.
-      // We can't query the V10 ContextGraphs participant set from a NameRegistry event alone,
-      // so apply the strict default: only auto-subscribe when this node's wallet matches
-      // `creator` (the address that called claimName). Real participants will have the CG
-      // surfaced through manual subscribe / catch-up triggered by their curator.
-      if (Number(p.accessPolicy) === 1) {
-        const isCurator = !!this.defaultAgentAddress
-          && typeof p.creator === 'string'
-          && p.creator.toLowerCase() === this.defaultAgentAddress.toLowerCase();
-        if (!isCurator) {
-          this.log.info(ctx, `Skipping auto-subscribe to curated chain entry "${p.name}" (${p.contextGraphId.slice(0, 16)}…) — not curator`);
+        if (!p.name) {
+          // Hash-only entry (metadata not revealed) — record for dedup but don't
+          // subscribe to gossip topics since hash-keyed topics are unusable.
+          this.log.info(ctx, `Noted unresolved on-chain context graph ${p.contextGraphId.slice(0, 16)}… (no metadata)`);
           knownOnChainIds.add(p.contextGraphId);
           continue;
         }
+
+        // Curated CGs (accessPolicy=1) must not silently land in non-participants' lists.
+        // We can't query the V10 ContextGraphs participant set from a NameRegistry event alone,
+        // so apply the strict default: only auto-subscribe when this node's wallet matches
+        // `creator` (the address that called claimName). Real participants will have the CG
+        // surfaced through manual subscribe / catch-up triggered by their curator.
+        if (Number(p.accessPolicy) === 1) {
+          const isCurator = !!this.defaultAgentAddress
+            && typeof p.creator === 'string'
+            && p.creator.toLowerCase() === this.defaultAgentAddress.toLowerCase();
+          if (!isCurator) {
+            this.log.info(ctx, `Skipping auto-subscribe to curated chain entry "${p.name}" (${p.contextGraphId.slice(0, 16)}…) — not curator`);
+            knownOnChainIds.add(p.contextGraphId);
+            continue;
+          }
+        }
+
+        this.setContextGraphSubscription(p.name, {
+          name: p.name,
+          subscribed: true,
+          synced: false,
+          metaSynced: false,
+          onChainId: p.contextGraphId,
+        });
+        this.subscribeToContextGraph(p.name, { trackSyncScope: false });
+
+        // Persist the on-chain ID to the ontology graph so the publisher's
+        // VM registration guard can find it via RDF (it has no access to
+        // the in-memory subscribedContextGraphs map).
+        const cgUri = contextGraphDataGraphUri(p.name);
+        const ontoGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+        // Single-valued binding guard (RS heal): on-chain id is immutable; clear
+        // any prior value so the cgId resolver / heal never read a multi-valued
+        // (LIMIT-1-nondeterministic) binding.
+        await this.store.deleteByPattern({
+          graph: ontoGraph,
+          subject: cgUri,
+          predicate: `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`,
+        });
+        await this.store.insert([{
+          subject: cgUri,
+          predicate: `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`,
+          object: `"${p.contextGraphId}"`,
+          graph: ontoGraph,
+        }]);
+
+        this.contextGraphMetaProjection.markDirty(p.name);
+        this.log.info(ctx, `Discovered on-chain context graph "${p.name}" (${p.contextGraphId.slice(0, 16)}…) — auto-subscribed (synced=false)`);
+        knownOnChainIds.add(p.contextGraphId);
+        discovered++;
       }
+    };
 
-      this.setContextGraphSubscription(p.name, {
-        name: p.name,
-        subscribed: true,
-        synced: false,
-        metaSynced: false,
-        onChainId: p.contextGraphId,
-      });
-      this.subscribeToContextGraph(p.name, { trackSyncScope: false });
-
-      // Persist the on-chain ID to the ontology graph so the publisher's
-      // VM registration guard can find it via RDF (it has no access to
-      // the in-memory subscribedContextGraphs map).
-      const cgUri = contextGraphDataGraphUri(p.name);
-      const ontoGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
-      // Single-valued binding guard (RS heal): on-chain id is immutable; clear
-      // any prior value so the cgId resolver / heal never read a multi-valued
-      // (LIMIT-1-nondeterministic) binding.
-      await this.store.deleteByPattern({
-        graph: ontoGraph,
-        subject: cgUri,
-        predicate: `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`,
-      });
-      await this.store.insert([{
-        subject: cgUri,
-        predicate: `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`,
-        object: `"${p.contextGraphId}"`,
-        graph: ontoGraph,
-      }]);
-
-      this.contextGraphMetaProjection.markDirty(p.name);
-      this.log.info(ctx, `Discovered on-chain context graph "${p.name}" (${p.contextGraphId.slice(0, 16)}…) — auto-subscribed (synced=false)`);
-      discovered++;
+    if (scanMode.mode === 'listAll' || useLegacyListFallback) {
+      try {
+        onChainContextGraphs = await this.chain.listContextGraphsFromChain!(
+          undefined,
+          useLegacyListFallback ? legacyListOptions : undefined,
+        );
+      } catch (err) {
+        const partialResults = handleChainScanFailure(err);
+        if (!partialResults) return 0;
+        onChainContextGraphs = partialResults;
+      }
+      await applyDiscoveredContextGraphs(onChainContextGraphs);
+    } else {
+      const iterator = this.chain.scanContextGraphRegistryPages!(scanMode)[Symbol.asyncIterator]();
+      try {
+        while (true) {
+          let next: Awaited<ReturnType<typeof iterator.next>>;
+          try {
+            next = await iterator.next();
+          } catch (err) {
+            const partialResults = handleChainScanFailure(err);
+            if (!partialResults) return 0;
+            break;
+          }
+          if (next.done) break;
+          await applyDiscoveredContextGraphs(next.value.contextGraphs);
+          await next.value.ack();
+        }
+      } finally {
+        await iterator.return?.();
+      }
+    }
+    if (!partialChainScan && this.chainContextGraphScanFailure) {
+      this.log.info(
+        ctx,
+        `Chain context graph scan recovered after ${this.chainContextGraphScanFailure.count} failed attempt(s)`,
+      );
+      this.chainContextGraphScanFailure = undefined;
     }
 
     if (discovered > 0) {

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -463,8 +463,6 @@ export interface AssertionHistoryDescriptor extends AssertionDescriptor {
 export interface DiscoverContextGraphsFromChainOptions {
   incremental?: boolean;
   seedIncrementalWatermark?: boolean;
-  liveTailOnly?: boolean;
-  liveTailLookbackBlocks?: number;
   throwOnChainScanFailure?: boolean;
 }
 
@@ -1108,16 +1106,15 @@ export class DKGAgent extends DKGAgentBase {
     let partialChainScan = false;
     let partialChainScanError: unknown;
     try {
-      const scanOptions = options.incremental || options.seedIncrementalWatermark || options.liveTailOnly
+      const scanOptions = options.incremental
         ? {
-            ...(options.incremental ? { incremental: true } : {}),
-            ...(options.seedIncrementalWatermark ? { seedIncrementalWatermark: true } : {}),
-            ...(options.liveTailOnly ? { liveTailOnly: true } : {}),
-            ...(options.liveTailLookbackBlocks !== undefined
-              ? { liveTailLookbackBlocks: options.liveTailLookbackBlocks }
-              : {}),
+            incremental: true as const,
           }
-        : undefined;
+        : options.seedIncrementalWatermark
+          ? {
+              seedIncrementalWatermark: true as const,
+            }
+          : undefined;
       onChainContextGraphs = await this.chain.listContextGraphsFromChain(undefined, scanOptions);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -463,6 +463,8 @@ export interface AssertionHistoryDescriptor extends AssertionDescriptor {
 export interface DiscoverContextGraphsFromChainOptions {
   incremental?: boolean;
   seedIncrementalWatermark?: boolean;
+  liveTailOnly?: boolean;
+  liveTailLookbackBlocks?: number;
   throwOnChainScanFailure?: boolean;
 }
 
@@ -1106,11 +1108,16 @@ export class DKGAgent extends DKGAgentBase {
     let partialChainScan = false;
     let partialChainScanError: unknown;
     try {
-      const scanOptions = options.incremental
-        ? { incremental: true }
-        : options.seedIncrementalWatermark
-          ? { seedIncrementalWatermark: true }
-          : undefined;
+      const scanOptions = options.incremental || options.seedIncrementalWatermark || options.liveTailOnly
+        ? {
+            ...(options.incremental ? { incremental: true } : {}),
+            ...(options.seedIncrementalWatermark ? { seedIncrementalWatermark: true } : {}),
+            ...(options.liveTailOnly ? { liveTailOnly: true } : {}),
+            ...(options.liveTailLookbackBlocks !== undefined
+              ? { liveTailLookbackBlocks: options.liveTailLookbackBlocks }
+              : {}),
+          }
+        : undefined;
       onChainContextGraphs = await this.chain.listContextGraphsFromChain(undefined, scanOptions);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/packages/agent/test/chain-cursor-wiring.test.ts
+++ b/packages/agent/test/chain-cursor-wiring.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { MockChainAdapter } from '@origintrail-official/dkg-chain';
+import { DKGAgent } from '../src/index.js';
+
+const OPERATIONAL_KEY =
+  '0x59c6995e998f97a5a0044966f0945388c9e82d88a3fdf0e0c7b33e0d2d2d8b2f';
+
+describe('DKGAgent chain cursor wiring', () => {
+  let agent: DKGAgent | undefined;
+
+  afterEach(async () => {
+    await agent?.stop().catch(() => {});
+    agent = undefined;
+  });
+
+  it('passes the registry scan cursor store into an EVM adapter built from chainConfig', async () => {
+    const registryCursorStore = {
+      load: vi.fn(async () => undefined),
+      save: vi.fn(async () => {}),
+    };
+
+    agent = await DKGAgent.create({
+      name: 'RegistryCursorWiring',
+      listenPort: 0,
+      chainConfig: {
+        rpcUrl: 'http://127.0.0.1:59998',
+        hubAddress: '0x0000000000000000000000000000000000000001',
+        operationalKeys: [OPERATIONAL_KEY],
+        chainId: 'evm:31337',
+      },
+      contextGraphRegistryScanCursorStore: registryCursorStore,
+    });
+
+    expect((agent as any).chain.contextGraphRegistryScanCursor?.input?.store).toBe(registryCursorStore);
+  });
+
+  it('passes the chain-event lane cursor store into the poller on start', async () => {
+    const chainEventCursorStore = {
+      loadLane: vi.fn(async () => undefined),
+      saveLane: vi.fn(async () => {}),
+    };
+
+    agent = await DKGAgent.create({
+      name: 'LaneCursorWiring',
+      listenPort: 0,
+      chainAdapter: new MockChainAdapter('mock:31337'),
+      chainEventCursorStore,
+    });
+    await agent.start();
+
+    expect(chainEventCursorStore.loadLane).toHaveBeenCalled();
+    expect(chainEventCursorStore.loadLane.mock.calls.map(([lane]) => lane)).toContain('contextGraphDiscovery');
+  });
+});

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -2549,6 +2549,77 @@ describe('discoverContextGraphsFromChain', () => {
     expect((agent as any).chainContextGraphScanFailure).toBeUndefined();
   }, 15000);
 
+  it('retries cursor pages after partial local apply without acknowledging until RDF binding exists', async () => {
+    const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
+    const contextGraphId = '0xfeed000000000000000000000000000000000000000000000000000000000003';
+    const revealed: ContextGraphOnChain = {
+      contextGraphId,
+      name: 'retry-safe-revealed',
+      creator: '0x1234',
+      accessPolicy: 0,
+      blockNumber: 100,
+      metadataRevealed: true,
+    };
+    let acked = 0;
+    (chain as any).listContextGraphsFromChain = async () => [];
+    (chain as any).scanContextGraphRegistryPages = async function* () {
+      yield {
+        contextGraphs: [revealed],
+        ack: async () => {
+          acked += 1;
+        },
+      };
+    };
+
+    const result = await createTestAgent({ chainAdapter: chain });
+    agent = result.agent;
+    await agent.start();
+    const originalInsert = result.store.insert.bind(result.store);
+    let failOnChainIdInsert = true;
+    (result.store as any).insert = async (quads: Parameters<typeof originalInsert>[0]) => {
+      if (
+        failOnChainIdInsert &&
+        quads.some((quad) => quad.predicate === `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`)
+      ) {
+        failOnChainIdInsert = false;
+        throw new Error('transient local on-chain id insert failed');
+      }
+      return originalInsert(quads);
+    };
+
+    await expect(agent.discoverContextGraphsFromChain({ mode: 'incremental' }))
+      .rejects.toThrow('transient local on-chain id insert failed');
+    expect(acked).toBe(0);
+    expect(agent.getSubscribedContextGraphs().get('retry-safe-revealed')).toBeUndefined();
+    (agent as any).setContextGraphSubscription('retry-safe-revealed', {
+      name: 'retry-safe-revealed',
+      subscribed: true,
+      synced: false,
+      metaSynced: false,
+      onChainId: contextGraphId,
+    });
+
+    await expect(agent.discoverContextGraphsFromChain({ mode: 'incremental' }))
+      .resolves.toBe(1);
+    expect(acked).toBe(1);
+    expect(agent.getSubscribedContextGraphs().get('retry-safe-revealed')?.onChainId)
+      .toBe(contextGraphId);
+
+    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+    const contextGraphUri = contextGraphDataGraphUri('retry-safe-revealed');
+    const onChainIdBinding = await result.store.query(`
+      ASK WHERE {
+        GRAPH <${ontologyGraph}> {
+          <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId> "${contextGraphId}" .
+        }
+      }
+    `);
+    expect(onChainIdBinding.type).toBe('boolean');
+    if (onChainIdBinding.type === 'boolean') {
+      expect(onChainIdBinding.value).toBe(true);
+    }
+  }, 15000);
+
   it('warns once for repeated chain scan failures and logs recovery', async () => {
     const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
     let fail = true;

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -2354,17 +2354,11 @@ describe('discoverContextGraphsFromChain', () => {
     expect(await agent.discoverContextGraphsFromChain()).toBe(0);
     expect(await agent.discoverContextGraphsFromChain({ incremental: true })).toBe(0);
     expect(await agent.discoverContextGraphsFromChain({ seedIncrementalWatermark: true })).toBe(0);
-    expect(await agent.discoverContextGraphsFromChain({
-      liveTailOnly: true,
-      liveTailLookbackBlocks: 123,
-      seedIncrementalWatermark: true,
-    })).toBe(0);
 
     expect(calls).toEqual([
       undefined,
       { incremental: true },
       { seedIncrementalWatermark: true },
-      { seedIncrementalWatermark: true, liveTailOnly: true, liveTailLookbackBlocks: 123 },
     ]);
   }, 15000);
 

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -2341,10 +2341,14 @@ describe('discoverContextGraphsFromChain', () => {
 
   it('keeps full chain discovery as the default and makes incremental opt-in', async () => {
     const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
-    const calls: unknown[] = [];
+    const listCalls: unknown[] = [];
+    const scanCalls: unknown[] = [];
     (chain as any).listContextGraphsFromChain = async (_fromBlock?: number, options?: unknown) => {
-      calls.push(options);
+      listCalls.push(options);
       return [];
+    };
+    (chain as any).scanContextGraphRegistryPages = async function* (options: unknown) {
+      scanCalls.push(options);
     };
 
     const result = await createTestAgent({ chainAdapter: chain });
@@ -2352,14 +2356,197 @@ describe('discoverContextGraphsFromChain', () => {
     await agent.start();
 
     expect(await agent.discoverContextGraphsFromChain()).toBe(0);
-    expect(await agent.discoverContextGraphsFromChain({ incremental: true })).toBe(0);
-    expect(await agent.discoverContextGraphsFromChain({ seedIncrementalWatermark: true })).toBe(0);
+    expect(await agent.discoverContextGraphsFromChain({ mode: 'incremental' })).toBe(0);
+    expect(await agent.discoverContextGraphsFromChain({ mode: 'incremental', pageBudget: 7 })).toBe(0);
+    expect(await agent.discoverContextGraphsFromChain({ mode: 'seedFull' })).toBe(0);
+    expect(await agent.discoverContextGraphsFromChain({
+      mode: 'seedFromCursor',
+      pageBudget: 11,
+    })).toBe(0);
 
-    expect(calls).toEqual([
+    expect(listCalls).toEqual([
       undefined,
-      { incremental: true },
+    ]);
+    expect(scanCalls).toEqual([
+      { mode: 'incremental' },
+      { mode: 'incremental', pageBudget: 7 },
+      { mode: 'seedFull' },
+      { mode: 'seedFromCursor', pageBudget: 11 },
+    ]);
+  }, 15000);
+
+  it('keeps legacy chain discovery scan options as explicit cursor-mode aliases', async () => {
+    const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
+    const scanCalls: unknown[] = [];
+    (chain as any).listContextGraphsFromChain = async () => [];
+    (chain as any).scanContextGraphRegistryPages = async function* (options: unknown) {
+      scanCalls.push(options);
+    };
+
+    const result = await createTestAgent({ chainAdapter: chain });
+    agent = result.agent;
+    await agent.start();
+
+    expect(await agent.discoverContextGraphsFromChain({ incremental: true })).toBe(0);
+    expect(await agent.discoverContextGraphsFromChain({ incremental: true, pageBudget: 5 })).toBe(0);
+    expect(await agent.discoverContextGraphsFromChain({ seedIncrementalWatermark: true })).toBe(0);
+    expect(await agent.discoverContextGraphsFromChain({
+      seedIncrementalWatermark: true,
+      resumeFromCursor: true,
+      pageBudget: 6,
+    })).toBe(0);
+
+    expect(scanCalls).toEqual([
+      { mode: 'incremental' },
+      { mode: 'incremental', pageBudget: 5 },
+      { mode: 'seedFull' },
+      { mode: 'seedFromCursor', pageBudget: 6 },
+    ]);
+  }, 15000);
+
+  it('falls back to legacy list scan options for adapters without the paged scanner', async () => {
+    const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
+    const listCalls: unknown[] = [];
+    const entries: ContextGraphOnChain[] = [
+      {
+        contextGraphId: '0xfeed000000000000000000000000000000000000000000000000000000000010',
+        name: 'legacy-list-incremental',
+        creator: '0x1234',
+        accessPolicy: 0,
+        blockNumber: 100,
+        metadataRevealed: true,
+      },
+      {
+        contextGraphId: '0xfeed000000000000000000000000000000000000000000000000000000000011',
+        name: 'legacy-list-seed',
+        creator: '0x1234',
+        accessPolicy: 0,
+        blockNumber: 200,
+        metadataRevealed: true,
+      },
+    ];
+    (chain as any).listContextGraphsFromChain = async (_fromBlock?: number, options?: unknown) => {
+      listCalls.push(options);
+      return [entries[listCalls.length - 1]];
+    };
+    (chain as any).scanContextGraphRegistryPages = undefined;
+
+    const result = await createTestAgent({ chainAdapter: chain });
+    agent = result.agent;
+    await agent.start();
+
+    expect(await agent.discoverContextGraphsFromChain({
+      incremental: true,
+      pageBudget: 5,
+    })).toBe(1);
+    expect(await agent.discoverContextGraphsFromChain({
+      seedIncrementalWatermark: true,
+    })).toBe(1);
+
+    expect(listCalls).toEqual([
+      { incremental: true, pageBudget: 5 },
       { seedIncrementalWatermark: true },
     ]);
+    expect(agent.getSubscribedContextGraphs().has('legacy-list-incremental')).toBe(true);
+    expect(agent.getSubscribedContextGraphs().has('legacy-list-seed')).toBe(true);
+  }, 15000);
+
+  it('applies cursor scan pages once and acknowledges after local discovery work', async () => {
+    const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
+    const contextGraphId = '0xfeed000000000000000000000000000000000000000000000000000000000001';
+    const revealed: ContextGraphOnChain = {
+      contextGraphId,
+      name: 'paged-revealed',
+      creator: '0x1234',
+      accessPolicy: 0,
+      blockNumber: 100,
+      metadataRevealed: true,
+    };
+    const scanCalls: unknown[] = [];
+    const ackedCounts: number[] = [];
+    (chain as any).listContextGraphsFromChain = async () => [];
+    (chain as any).scanContextGraphRegistryPages = async function* (options: unknown) {
+      scanCalls.push(options);
+      yield {
+        contextGraphs: [revealed],
+        ack: async () => {
+          ackedCounts.push(1);
+        },
+      };
+      yield {
+        contextGraphs: [revealed],
+        ack: async () => {
+          ackedCounts.push(2);
+        },
+      };
+    };
+
+    const result = await createTestAgent({ chainAdapter: chain });
+    agent = result.agent;
+    await agent.start();
+
+    const discovered = await agent.discoverContextGraphsFromChain({
+      mode: 'seedFromCursor',
+      pageBudget: 1,
+    });
+
+    expect(discovered).toBe(1);
+    expect(scanCalls).toEqual([{ mode: 'seedFromCursor', pageBudget: 1 }]);
+    expect(ackedCounts).toEqual([1, 2]);
+    const entry = agent.getSubscribedContextGraphs().get('paged-revealed');
+    expect(entry).toBeDefined();
+    expect(entry!.onChainId).toBe(contextGraphId);
+    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+    const contextGraphUri = contextGraphDataGraphUri('paged-revealed');
+    const onChainIdBinding = await result.store.query(`
+      ASK WHERE {
+        GRAPH <${ontologyGraph}> {
+          <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId> "${contextGraphId}" .
+        }
+      }
+    `);
+    expect(onChainIdBinding.type).toBe('boolean');
+    if (onChainIdBinding.type === 'boolean') {
+      expect(onChainIdBinding.value).toBe(true);
+    }
+  }, 15000);
+
+  it('propagates cursor scan page apply failures without acknowledging progress', async () => {
+    const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
+    const revealed: ContextGraphOnChain = {
+      contextGraphId: '0xfeed000000000000000000000000000000000000000000000000000000000002',
+      name: 'apply-failure-revealed',
+      creator: '0x1234',
+      accessPolicy: 0,
+      blockNumber: 100,
+      metadataRevealed: true,
+    };
+    let acked = 0;
+    (chain as any).listContextGraphsFromChain = async () => [];
+    (chain as any).scanContextGraphRegistryPages = async function* () {
+      yield {
+        contextGraphs: [revealed],
+        ack: async () => {
+          acked += 1;
+        },
+      };
+    };
+
+    const result = await createTestAgent({ chainAdapter: chain });
+    agent = result.agent;
+    await agent.start();
+    const originalInsert = result.store.insert.bind(result.store);
+    (result.store as any).insert = async (quads: Parameters<typeof originalInsert>[0]) => {
+      if (quads.some((quad) => quad.predicate === `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`)) {
+        throw new Error('local on-chain id insert failed');
+      }
+      return originalInsert(quads);
+    };
+
+    await expect(agent.discoverContextGraphsFromChain({ mode: 'incremental' }))
+      .rejects.toThrow('local on-chain id insert failed');
+    expect(acked).toBe(0);
+    expect((agent as any).chainContextGraphScanFailure).toBeUndefined();
   }, 15000);
 
   it('warns once for repeated chain scan failures and logs recovery', async () => {
@@ -2399,6 +2586,9 @@ describe('discoverContextGraphsFromChain', () => {
     (chain as any).listContextGraphsFromChain = async () => {
       throw failure;
     };
+    (chain as any).scanContextGraphRegistryPages = async function* () {
+      throw failure;
+    };
 
     const result = await createTestAgent({ chainAdapter: chain });
     agent = result.agent;
@@ -2407,7 +2597,7 @@ describe('discoverContextGraphsFromChain', () => {
     expect(await agent.discoverContextGraphsFromChain()).toBe(0);
     await expect(
       agent.discoverContextGraphsFromChain({
-        seedIncrementalWatermark: true,
+        mode: 'seedFull',
         throwOnChainScanFailure: true,
       }),
     ).rejects.toThrow('seed scan failed');
@@ -2416,7 +2606,8 @@ describe('discoverContextGraphsFromChain', () => {
   it('processes partial chain scan prefixes without marking the scan recovered', async () => {
     const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
     let calls = 0;
-    (chain as any).listContextGraphsFromChain = async () => {
+    (chain as any).listContextGraphsFromChain = async () => [];
+    (chain as any).scanContextGraphRegistryPages = async function* () {
       calls += 1;
       const stopped = calls === 1 ? 1_999 : 3_999;
       const failedFrom = calls === 1 ? 2_000 : 4_000;
@@ -2444,6 +2635,10 @@ describe('discoverContextGraphsFromChain', () => {
       err.scannedToBlock = stopped;
       err.failedFromBlock = failedFrom;
       err.failedToBlock = failedTo;
+      yield {
+        contextGraphs: err.partialResults,
+        ack: async () => {},
+      };
       throw err;
     };
     const entries: Array<{ level: string; message: string }> = [];
@@ -2454,10 +2649,10 @@ describe('discoverContextGraphsFromChain', () => {
       await agent.start();
 
       await expect(agent.discoverContextGraphsFromChain({
-        incremental: true,
+        mode: 'seedFull',
         throwOnChainScanFailure: true,
       })).rejects.toThrow('partial ContextGraphNameRegistry scan');
-      expect(await agent.discoverContextGraphsFromChain({ incremental: true })).toBe(0);
+      expect(await agent.discoverContextGraphsFromChain({ mode: 'incremental' })).toBe(0);
     } finally {
       Logger.setSink(null);
     }

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -2354,8 +2354,18 @@ describe('discoverContextGraphsFromChain', () => {
     expect(await agent.discoverContextGraphsFromChain()).toBe(0);
     expect(await agent.discoverContextGraphsFromChain({ incremental: true })).toBe(0);
     expect(await agent.discoverContextGraphsFromChain({ seedIncrementalWatermark: true })).toBe(0);
+    expect(await agent.discoverContextGraphsFromChain({
+      liveTailOnly: true,
+      liveTailLookbackBlocks: 123,
+      seedIncrementalWatermark: true,
+    })).toBe(0);
 
-    expect(calls).toEqual([undefined, { incremental: true }, { seedIncrementalWatermark: true }]);
+    expect(calls).toEqual([
+      undefined,
+      { incremental: true },
+      { seedIncrementalWatermark: true },
+      { seedIncrementalWatermark: true, liveTailOnly: true, liveTailLookbackBlocks: 123 },
+    ]);
   }, 15000);
 
   it('warns once for repeated chain scan failures and logs recovery', async () => {

--- a/packages/agent/test/rpc-usage-boundary.test.ts
+++ b/packages/agent/test/rpc-usage-boundary.test.ts
@@ -17,7 +17,11 @@ const drain = DKGAgentBase.prototype.drainRpcUsage;
 
 describe('DKGAgent.drainRpcUsage — the adapter→agent telemetry boundary', () => {
   it('delegates to the adapter and passes the window through VERBATIM', () => {
-    const window = { byMethod: { eth_call: 42, eth_getLogs: 7 }, lifetimeTotal: 49 };
+    const window = {
+      byMethod: { eth_call: 42, eth_getLogs: 7 },
+      ethCallByConsumer: { 'pcaNFT.getAccountInfo': 42 },
+      lifetimeTotal: 49,
+    };
     const out = drain.call({ chain: { drainRpcUsage: () => window } } as never);
     expect(out).toBe(window); // same object — no reshaping/copying in the boundary
   });
@@ -25,19 +29,19 @@ describe('DKGAgent.drainRpcUsage — the adapter→agent telemetry boundary', ()
   it('returns the real MockChainAdapter empty window (capability present, no transport)', () => {
     const chain = new MockChainAdapter();
     const out = drain.call({ chain } as never);
-    expect(out).toEqual({ byMethod: {}, lifetimeTotal: 0 });
+    expect(out).toEqual({ byMethod: {}, ethCallByConsumer: {}, lifetimeTotal: 0 });
   });
 
   it('collapses a missing adapter capability to a concrete EMPTY window (consumers never see undefined)', () => {
     const out = drain.call({ chain: {} } as never);
-    expect(out).toEqual({ byMethod: {}, lifetimeTotal: 0 });
+    expect(out).toEqual({ byMethod: {}, ethCallByConsumer: {}, lifetimeTotal: 0 });
   });
 
   it('is inherited by the composed DKGAgent class (the daemon consumes agent, not the base)', () => {
     // The daemon passes the DKGAgent instance as the telemetry source — the
     // method must exist on the composed class's prototype chain.
     expect(typeof DKGAgent.prototype.drainRpcUsage).toBe('function');
-    const window = { byMethod: { eth_sendRawTransaction: 3 }, lifetimeTotal: 3 };
+    const window = { byMethod: { eth_sendRawTransaction: 3 }, ethCallByConsumer: {}, lifetimeTotal: 3 };
     const out = DKGAgent.prototype.drainRpcUsage.call({ chain: { drainRpcUsage: () => window } } as never);
     expect(out).toBe(window);
   });

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -39,6 +39,7 @@ export default defineConfig({
       "test/swm-fanout-peer-selection.test.ts",
       "test/publish-literal-size.test.ts",
       "test/verify-batch.test.ts",
+      "test/chain-cursor-wiring.test.ts",
     ],
     testTimeout: 60_000,
     maxWorkers: 1,

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -363,18 +363,22 @@ export function isContextGraphChainScanPartialError(
  *
  * Default calls use `listAll` semantics and never mutate daemon watermarks.
  * The two boolean shapes are retained as legacy compatibility wrappers around
- * the paged cursor scanner. New cursor-backed daemon scans should use
+ * the paged cursor scanner. Optional and false values remain accepted for
+ * source compatibility; only an explicit `true` enables legacy cursor-backed
+ * behavior. New cursor-backed daemon scans should use
  * `scanContextGraphRegistryPages`, where callers explicitly acknowledge a page
  * after local apply succeeds.
  */
 export type ContextGraphChainListOptions = { mode?: 'listAll' };
 export type ContextGraphLegacyIncrementalScanOptions =
   | {
-      incremental: true;
+      mode?: never;
+      incremental?: boolean;
       pageBudget?: number;
     }
   | {
-      seedIncrementalWatermark: true;
+      mode?: never;
+      seedIncrementalWatermark?: boolean;
       resumeFromCursor?: boolean;
       pageBudget?: number;
     };

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -358,19 +358,62 @@ export function isContextGraphChainScanPartialError(
   );
 }
 
-export interface ContextGraphChainScanOptions {
-  /**
-   * When true and `fromBlock` is omitted, adapters may resume from an
-   * in-memory watermark with a reorg buffer. The default preserves public
-   * list-all semantics for SDK callers.
-   */
-  incremental?: boolean;
-  /**
-   * When true on a successful full scan, adapters may seed the in-memory
-   * incremental watermark for later daemon background scans. This is opt-in so
-   * public SDK list-all calls remain side-effect free by default.
-   */
-  seedIncrementalWatermark?: boolean;
+/**
+ * Public ContextGraphNameRegistry list options.
+ *
+ * Default calls use `listAll` semantics and never mutate daemon watermarks.
+ * The two boolean shapes are retained as legacy compatibility wrappers around
+ * the paged cursor scanner. New cursor-backed daemon scans should use
+ * `scanContextGraphRegistryPages`, where callers explicitly acknowledge a page
+ * after local apply succeeds.
+ */
+export type ContextGraphChainListOptions = { mode?: 'listAll' };
+export type ContextGraphLegacyIncrementalScanOptions =
+  | {
+      incremental: true;
+      pageBudget?: number;
+    }
+  | {
+      seedIncrementalWatermark: true;
+      resumeFromCursor?: boolean;
+      pageBudget?: number;
+    };
+export type ContextGraphChainScanOptions =
+  | ContextGraphChainListOptions
+  | ContextGraphLegacyIncrementalScanOptions;
+
+/** Cursor-backed daemon ContextGraphNameRegistry scan modes. */
+export type ContextGraphRegistryScanOptions =
+  | {
+      mode: 'incremental';
+      pageBudget?: number;
+    }
+  | {
+      mode: 'seedFull';
+    }
+  | {
+      mode: 'seedFromCursor';
+      pageBudget?: number;
+    };
+
+export interface ContextGraphRegistryScanPage {
+  contextGraphs: ContextGraphOnChain[];
+  ack(): Promise<void>;
+}
+
+export function buildEvmDeploymentId(input: { chainId: string; hubAddress: string }): string {
+  return `${input.chainId}:hub=${input.hubAddress.toLowerCase()}`;
+}
+
+export interface ContextGraphRegistryScanCursorKey {
+  chainId: string;
+  deploymentId: string;
+  registryAddress: string;
+}
+
+export interface ContextGraphRegistryScanCursorStore {
+  load(key: ContextGraphRegistryScanCursorKey): Promise<number | undefined>;
+  save(key: ContextGraphRegistryScanCursorKey, nextBlock: number): Promise<void>;
 }
 
 // ----- On-Chain Context Graph types (ContextGraphs contract) -----
@@ -927,13 +970,19 @@ export interface ChainAdapter {
 
   // Context Graphs (name-hash commitment via ContextGraphNameRegistry)
   createContextGraph(params: CreateContextGraphParams): Promise<TxResult>;
-  submitToContextGraph(kaId: string, contextGraphId: string): Promise<TxResult>;
-  /** Reveal cleartext name+description on-chain for a context graph you created. Optional. */
-  revealContextGraphMetadata?(contextGraphId: string, name: string, description: string): Promise<TxResult>;
-  /** List context graphs from chain via `NameClaimed` events. Optional; not supported on no-chain/mock. */
-  listContextGraphsFromChain?(fromBlock?: number, options?: ContextGraphChainScanOptions): Promise<ContextGraphOnChain[]>;
-  /** True when the adapter has a registry scan watermark for its currently bound ContextGraphNameRegistry. */
-  hasContextGraphRegistryScanWatermark?(): Promise<boolean>;
+    submitToContextGraph(kaId: string, contextGraphId: string): Promise<TxResult>;
+    /** Reveal cleartext name+description on-chain for a context graph you created. Optional. */
+    revealContextGraphMetadata?(contextGraphId: string, name: string, description: string): Promise<TxResult>;
+    /** List context graphs from chain via `NameClaimed` events. Optional; not supported on no-chain/mock. */
+    listContextGraphsFromChain?(fromBlock?: number, options?: ContextGraphChainScanOptions): Promise<ContextGraphOnChain[]>;
+    /**
+     * Daemon cursor-backed ContextGraphNameRegistry scan. Each yielded page must
+     * be acknowledged after the caller has applied it locally; only then may the
+     * adapter advance durable scan progress.
+     */
+    scanContextGraphRegistryPages?(options: ContextGraphRegistryScanOptions): AsyncIterable<ContextGraphRegistryScanPage>;
+    /** True when the adapter has a registry scan watermark for its currently bound ContextGraphNameRegistry. */
+    hasContextGraphRegistryScanWatermark?(): Promise<boolean>;
 
   /**
    * Live owner lookup for a PCA NFT — wraps `DKGPublishingConvictionNFT.ownerOf(accountId)`.

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -371,6 +371,14 @@ export interface ContextGraphChainScanOptions {
    * public SDK list-all calls remain side-effect free by default.
    */
   seedIncrementalWatermark?: boolean;
+  /**
+   * Daemon-oriented mode: scan only a bounded live-tail window near the current
+   * head when no incremental watermark exists. Public list-all calls should
+   * omit this so they retain full historical semantics.
+   */
+  liveTailOnly?: boolean;
+  /** Number of recent blocks to scan when `liveTailOnly` is set. */
+  liveTailLookbackBlocks?: number;
 }
 
 // ----- On-Chain Context Graph types (ContextGraphs contract) -----

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -371,14 +371,6 @@ export interface ContextGraphChainScanOptions {
    * public SDK list-all calls remain side-effect free by default.
    */
   seedIncrementalWatermark?: boolean;
-  /**
-   * Daemon-oriented mode: scan only a bounded live-tail window near the current
-   * head when no incremental watermark exists. Public list-all calls should
-   * omit this so they retain full historical semantics.
-   */
-  liveTailOnly?: boolean;
-  /** Number of recent blocks to scan when `liveTailOnly` is set. */
-  liveTailLookbackBlocks?: number;
 }
 
 // ----- On-Chain Context Graph types (ContextGraphs contract) -----

--- a/packages/chain/src/context-graph-registry-scan-cursor.ts
+++ b/packages/chain/src/context-graph-registry-scan-cursor.ts
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import type {
+  ContextGraphRegistryScanCursorKey,
+  ContextGraphRegistryScanCursorStore,
+} from './chain-adapter.js';
+
+/**
+ * Durable cursor policy for ContextGraphNameRegistry scans.
+ *
+ * The cursor is feature-owned rather than generic EVM plumbing: it is scoped by
+ * chain, deployment, and registry address, and it intentionally tolerates store
+ * failures by falling back to process-local state.
+ */
+export class ContextGraphRegistryScanCursor {
+  private readonly watermarks: Map<string, number> = new Map();
+
+  constructor(
+    private readonly input: {
+      chainId: string;
+      deploymentId: string;
+      store?: ContextGraphRegistryScanCursorStore;
+    },
+  ) {}
+
+  clearMemoryCache(): void {
+    this.watermarks.clear();
+  }
+
+  getCachedWatermark(registryAddress: string): number | undefined {
+    return this.normalize(this.watermarks.get(this.cacheKey(registryAddress)));
+  }
+
+  async loadWatermark(registryAddress: string): Promise<number | undefined> {
+    const cacheKey = this.cacheKey(registryAddress);
+    const cached = this.normalize(this.watermarks.get(cacheKey));
+    if (cached != null) return cached;
+
+    if (!this.input.store) return undefined;
+    try {
+      const persisted = await this.input.store.load(this.cursorKey(cacheKey));
+      const normalized = this.normalize(persisted);
+      if (normalized != null) {
+        this.watermarks.set(cacheKey, normalized);
+      }
+      return normalized;
+    } catch (err) {
+      console.warn(
+        `[chain] ContextGraphNameRegistry scan cursor load failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return undefined;
+    }
+  }
+
+  async saveWatermark(registryAddress: string, nextBlock: number): Promise<void> {
+    const normalized = this.normalize(nextBlock);
+    if (normalized == null) return;
+
+    const cacheKey = this.cacheKey(registryAddress);
+    const existing = this.normalize(this.watermarks.get(cacheKey));
+    if (existing != null && existing >= normalized) return;
+
+    this.watermarks.set(cacheKey, normalized);
+    if (!this.input.store) return;
+    try {
+      await this.input.store.save(this.cursorKey(cacheKey), normalized);
+    } catch (err) {
+      console.warn(
+        `[chain] ContextGraphNameRegistry scan cursor save failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  private cacheKey(registryAddress: string): string {
+    return registryAddress.toLowerCase();
+  }
+
+  private cursorKey(registryAddress: string): ContextGraphRegistryScanCursorKey {
+    return {
+      chainId: this.input.chainId,
+      deploymentId: this.input.deploymentId,
+      registryAddress,
+    };
+  }
+
+  private normalize(value: number | undefined): number | undefined {
+    if (value == null) return undefined;
+    if (!Number.isSafeInteger(value) || value <= 0) return undefined;
+    return value;
+  }
+}

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -118,6 +118,11 @@ export const CG_REGISTRY_MAX_SCAN_PAGES = Math.ceil(
 
 export const CG_REGISTRY_REORG_BUFFER_BLOCKS = 50;
 
+export const CG_REGISTRY_LIVE_TAIL_LOOKBACK_BLOCKS = 9_000;
+
+const HUB_ROTATION_POLL_INTERVAL_MS = DEFAULT_RANDOM_SAMPLING_HUB_REFRESH_MS;
+const HUB_ROTATION_REORG_BUFFER_BLOCKS = 50;
+
 /**
  * Per-backend timeout for a single KnowledgeAssetCreated scan page before
  * failing over to the next eligible backend — generous enough for a slow
@@ -522,6 +527,12 @@ export class EVMChainAdapterBase {
   protected readonly pcaReadCache = new PcaReadCache();
 
   protected hubRotationListenerStarted = false;
+
+  protected hubRotationPollTimer: ReturnType<typeof setInterval> | null = null;
+
+  protected hubRotationPollInFlight: Promise<void> | null = null;
+
+  protected hubRotationLastScannedBlock: number | undefined;
 
   /**
    * Single-flight guard for the best-effort
@@ -3108,53 +3119,108 @@ export class EVMChainAdapterBase {
    * on the update path it emits both `ContractChanged` AND
    * `NewContract`. Storage bindings resolved through
    * `getAssetStorageAddress(...)` emit the parallel `AssetStorageChanged`
-   * / `NewAssetStorage` events. We listen to all four events so the cache
+   * / `NewAssetStorage` events. We poll all four event topics so the cache
    * invalidates regardless of which Hub set owns the name, and both the
    * RS-pair invalidation and the generic boot-bound invalidation are
    * idempotent so duplicate notifications are harmless.
    *
-   * `Contract.on(...)` is async in ethers v6: a sync `try/catch` would
-   * miss provider rejections (e.g. HTTP-only endpoints that can't
-   * install filter subscriptions) and leave us with an unhandled
-   * rejection. We `await` every subscription and only set
-   * `hubRotationListenerStarted` after all succeed, so a failed
-   * provider can be retried by a future call site if we ever need to
-   * — and meanwhile the TTL refresh path (for RS) and the
-   * `withHubStaleRetry` write-side fallback (for all boot-bound
-   * contracts) still keep stale bindings recoverable without a
-   * working event subscription.
+   * We deliberately avoid `Contract.on(...)` here. With `polling: true`,
+   * ethers implements each subscription as its own steady `eth_getLogs`
+   * poller. One adapter-owned poller with an OR-topic filter preserves
+   * rotation detection without four hidden idle log streams.
    */
   protected async startHubRotationListener(): Promise<void> {
     if (this.hubRotationListenerStarted) return;
-    const onChange = (name: unknown): void => {
-      if (typeof name !== 'string') return;
-      if (name === 'RandomSampling' || name === 'RandomSamplingStorage') {
-        this.invalidateRandomSamplingPair();
-        return;
-      }
-      if (BOUND_CONTRACT_INVALIDATORS.has(name)) {
-        this.invalidatePublishPreflightCache();
-        // Force the next public-method entry through `init()` so it
-        // re-resolves every binding. Do not clear the current handle
-        // here: the callback can fire between a public method's
-        // `await init()` and its first `this.contracts.X` read.
-        this.initialized = false;
-      }
-    };
     try {
-      await withTimeout(
-        this.ensureConfiguredStaticChainIdValidated(this.primaryProvider),
-        RPC_READ_STALL_TIMEOUT_MS,
-        'Hub rotation listener chainId validation',
-      );
-      await this.contracts.hub.on('ContractChanged', onChange);
-      await this.contracts.hub.on('NewContract', onChange);
-      await this.contracts.hub.on('AssetStorageChanged', onChange);
-      await this.contracts.hub.on('NewAssetStorage', onChange);
+      await this.pollHubRotationEvents();
+      this.hubRotationPollTimer = setInterval(() => {
+        if (this.hubRotationPollInFlight) return;
+        this.hubRotationPollInFlight = this.pollHubRotationEvents()
+          .catch(() => { /* optional listener path */ })
+          .finally(() => { this.hubRotationPollInFlight = null; });
+      }, HUB_ROTATION_POLL_INTERVAL_MS);
+      if (this.hubRotationPollTimer.unref) this.hubRotationPollTimer.unref();
       this.hubRotationListenerStarted = true;
     } catch {
-      /* provider doesn't support filter subscriptions — TTL refresh (RS)
+      /* provider doesn't support log polling — TTL refresh (RS)
        * and `withHubStaleRetry` (writes) are the fallbacks */
+    }
+  }
+
+  protected async pollHubRotationEvents(): Promise<void> {
+    const hub = this.contracts.hub;
+    if (!hub) return;
+
+    const topics = this.hubRotationEventTopics(hub);
+    if (topics.length === 0) return;
+
+    const head = await this.readProvider(
+      'Hub rotation poll getBlockNumber',
+      (provider) => provider.getBlockNumber(),
+    );
+    const candidateFromBlock = this.hubRotationLastScannedBlock == null
+      ? head - HUB_ROTATION_REORG_BUFFER_BLOCKS
+      : this.hubRotationLastScannedBlock + 1 - HUB_ROTATION_REORG_BUFFER_BLOCKS;
+    const recentFromBlock = head - HUB_ROTATION_REORG_BUFFER_BLOCKS;
+    const fromBlock = Math.max(
+      0,
+      Math.min(candidateFromBlock, recentFromBlock),
+    );
+    const hubAddress = await this.hubContractAddress(hub);
+    const logs = await this.readProvider<ethers.Log[]>(
+      'Hub rotation poll getLogs',
+      (provider) => provider.getLogs({
+        address: hubAddress,
+        fromBlock,
+        toBlock: head,
+        topics: [topics],
+      }),
+      { policy: 'wideLogScan' },
+    );
+
+    for (const log of logs) {
+      try {
+        const parsed = hub.interface.parseLog({ topics: [...log.topics], data: log.data });
+        if (!parsed) continue;
+        this.applyHubRotationEventName(parsed.args?.contractName ?? parsed.args?.[0]);
+      } catch {
+        // Ignore malformed/unexpected Hub logs. The topic filter should already
+        // constrain these, but a parse miss must not wedge the poll cursor.
+      }
+    }
+    this.hubRotationLastScannedBlock = head;
+  }
+
+  protected hubRotationEventTopics(hub: Contract): string[] {
+    return [
+      'ContractChanged',
+      'NewContract',
+      'AssetStorageChanged',
+      'NewAssetStorage',
+    ].flatMap((eventName) => {
+      const event = hub.interface.getEvent(eventName);
+      return event?.topicHash ? [event.topicHash] : [];
+    });
+  }
+
+  protected async hubContractAddress(hub: Contract): Promise<string> {
+    const target = (hub as unknown as { target?: unknown }).target;
+    return typeof target === 'string' ? target : hub.getAddress();
+  }
+
+  protected applyHubRotationEventName(name: unknown): void {
+    if (typeof name !== 'string') return;
+    if (name === 'RandomSampling' || name === 'RandomSamplingStorage') {
+      this.invalidateRandomSamplingPair();
+      return;
+    }
+    if (BOUND_CONTRACT_INVALIDATORS.has(name)) {
+      this.invalidatePublishPreflightCache();
+      // Force the next public-method entry through `init()` so it re-resolves
+      // every binding. Do not clear the current handle here: the callback can
+      // fire between a public method's `await init()` and its first
+      // `this.contracts.X` read.
+      this.initialized = false;
     }
   }
 
@@ -3212,6 +3278,11 @@ export class EVMChainAdapterBase {
    * so destroying once flushes everything).
    */
   destroy(): void {
+    if (this.hubRotationPollTimer) {
+      clearInterval(this.hubRotationPollTimer);
+      this.hubRotationPollTimer = null;
+    }
+    this.hubRotationListenerStarted = false;
     for (const provider of this.providers) {
       try { provider.destroy(); } catch { /* already destroyed / not destroyable */ }
     }

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -15,7 +15,12 @@ import { JsonRpcProvider, Wallet, Contract, ethers } from 'ethers';
 import { createFilterErrorSilencer, installFilterNotFoundConsoleSuppressor, formatProviderError } from './filter-error-silencer.js';
 import type { FilterErrorSilencer } from './filter-error-silencer.js';
 import { DEFAULT_APPROVAL_POLICY } from './chain-adapter.js';
-import type { ApprovalPolicy, V10PublishParams, OnChainPublishResult, ConvictionReader } from './chain-adapter.js';
+import type {
+  ApprovalPolicy,
+  V10PublishParams,
+  OnChainPublishResult,
+  ConvictionReader,
+} from './chain-adapter.js';
 import { HubResolutionCache } from './hub-resolution-cache.js';
 import { KeyedSerializer } from './keyed-mutex.js';
 import { floorPublishTokenAmount, withSpan, getMetrics } from '@origintrail-official/dkg-core';
@@ -28,6 +33,8 @@ import { RpcFailoverClient, type ReadOpts } from './rpc-failover-client.js';
 import { RpcUsageTracker, createCountingJsonRpcProvider, type RpcUsageWindow } from './rpc-usage.js';
 import { computeApprovalAction, effectivePublishAllowance, V10_PUBLISH_ONCHAIN_MIN_ALLOWANCE } from './evm-adapter-allowance.js';
 import { formatProviderContext } from './evm-adapter-types.js';
+import { ReadThroughTtlCache } from './keyed-ttl-single-flight-cache.js';
+import { PcaReadCache } from './pca-read-cache.js';
 import type { ContractCache, EVMAdapterConfig } from './evm-adapter-types.js';
 import { RPC_READ_STALL_TIMEOUT_MS, DEFAULT_RANDOM_SAMPLING_HUB_REFRESH_MS, RPC_RECEIPT_TIMEOUT_MS, RPC_RECEIPT_POLL_INTERVAL_MS, RPC_ENDPOINT_SET_RETRIES, RPC_ENDPOINT_SET_RETRY_BACKOFF_MS, ADMIN_KEY_PURPOSE, OPERATIONAL_KEY_PURPOSE, PUBLISHER_FUNDING_CACHE_TTL_MS } from './evm-adapter-constants.js';
 
@@ -160,6 +167,25 @@ function normalizeScanPageSize(value: unknown, fallback: number): number {
   return typeof value === 'number' && Number.isFinite(value) && value >= 1
     ? Math.floor(value)
     : fallback;
+}
+
+function configuredStaticChainId(config: Pick<EVMAdapterConfig, 'chainId' | 'staticNetwork'>): bigint | undefined {
+  if (config.staticNetwork === false) return undefined;
+  const { chainId } = config;
+  if (!chainId) return undefined;
+  const tail = chainId.includes(':') ? chainId.split(':').pop() : chainId;
+  if (!tail || !/^[0-9]+$/.test(tail)) {
+    return undefined;
+  }
+  try {
+    const numeric = BigInt(tail);
+    if (numeric > 0n) return numeric;
+  } catch {
+    // Fall through to the uniform configuration error below.
+  }
+  throw new Error(
+    `EVMAdapterConfig.chainId must end with a positive decimal chain id when staticNetwork is enabled (got ${chainId}); set staticNetwork: false to use dynamic detection`,
+  );
 }
 
 /**
@@ -383,6 +409,8 @@ export class EVMChainAdapterBase {
   /** Raw JSON-RPC request accounting (provider-billing unit). See rpc-usage.ts. */
   protected readonly rpcUsage: RpcUsageTracker;
 
+  protected readonly configuredStaticChainId?: bigint;
+
   protected readonly filterErrorSilencer: FilterErrorSilencer;
 
   /** Primary signer — used for identity/profile/staking operations. */
@@ -474,12 +502,24 @@ export class EVMChainAdapterBase {
    */
   protected readonly randomSamplingPairCache: HubResolutionCache<{ rs: Contract; rss: Contract }>;
 
+  protected static readonly IDENTITY_ID_POSITIVE_TTL_MS = 5 * 60 * 1000;
+
+  protected static readonly IDENTITY_ID_NEGATIVE_TTL_MS = 0;
+
   /**
    * OT-RFC-39 — per-process cache for `getIdentityIdForAddress`.
-   * Only positive (non-zero) hits are memoised; see the method body
-   * for the rationale (negative-hit invalidation hazard).
+   * Positive hits are memoised with a bounded TTL; negative hits are only
+   * single-flighted so a later external registration is visible immediately.
+   * Local mutations seed/invalidate through the cache so stale in-flight reads
+   * cannot win.
    */
-  protected readonly identityIdByAddressCache: Map<string, bigint> = new Map();
+  protected readonly identityIdByAddressCache = new ReadThroughTtlCache<string, bigint>({
+    ttlMs: (value) => value > 0n
+      ? EVMChainAdapterBase.IDENTITY_ID_POSITIVE_TTL_MS
+      : EVMChainAdapterBase.IDENTITY_ID_NEGATIVE_TTL_MS,
+  });
+
+  protected readonly pcaReadCache = new PcaReadCache();
 
   protected hubRotationListenerStarted = false;
 
@@ -556,6 +596,16 @@ export class EVMChainAdapterBase {
 
   protected cachedChainId: { value: bigint; cachedAt: number } | undefined;
 
+  protected readonly configuredStaticChainIdsByProvider = new Map<
+    JsonRpcProvider,
+    { value: bigint; cachedAt: number }
+  >();
+
+  protected readonly configuredStaticChainIdValidationsByProvider = new Map<
+    JsonRpcProvider,
+    Promise<bigint>
+  >();
+
   protected cachedKav10Address: { value: string; cachedAt: number } | undefined;
 
   protected cachedMinRequiredSignatures: { value: number; cachedAt: number } | undefined;
@@ -591,10 +641,22 @@ export class EVMChainAdapterBase {
    */
   invalidatePublishPreflightCache(): void {
     this.cachedChainId = undefined;
+    this.configuredStaticChainIdsByProvider.clear();
+    this.configuredStaticChainIdValidationsByProvider.clear();
     this.cachedKav10Address = undefined;
     this.cachedMinRequiredSignatures = undefined;
     this.cachedContractDeployBlocks.clear();
     this.contextGraphRegistryScanWatermarks.clear();
+  }
+
+  protected clearIdentityIdForAddress(address: string): void {
+    const cacheKey = ethers.getAddress(address).toLowerCase();
+    this.identityIdByAddressCache.invalidate(cacheKey);
+  }
+
+  protected seedIdentityIdForAddress(address: string, identityId: bigint): void {
+    const cacheKey = ethers.getAddress(address).toLowerCase();
+    this.identityIdByAddressCache.seed(cacheKey, identityId);
   }
 
   protected static preflightCacheFresh(
@@ -677,12 +739,16 @@ export class EVMChainAdapterBase {
     // One transport factory wires BOTH billing-exact accounting hooks (first
     // attempt at `_send` + every ethers-internal retry attempt) to the tracker —
     // see createCountingJsonRpcProvider for the invariant.
+    this.configuredStaticChainId = configuredStaticChainId(config);
+    const staticNetwork = this.configuredStaticChainId == null
+      ? undefined
+      : ethers.Network.from(this.configuredStaticChainId);
     this.providers = this.rpcUrls.map(
       (url) => createCountingJsonRpcProvider(url, perEndpointRetries, this.rpcUsage, {
         cacheTimeout: -1,
         polling: true,
         batchMaxCount: 1,
-      }),
+      }, staticNetwork),
     );
     this.primaryProvider = this.providers[0];
     // No `FallbackProvider`: reads route through the `RpcFailoverClient` read
@@ -717,6 +783,7 @@ export class EVMChainAdapterBase {
       // built), so pass a LIVE thunk — resolved at metric-record time — rather
       // than capturing the still-undefined field value here.
       () => this.chainId,
+      async (endpoint) => { await this.ensureConfiguredStaticChainIdValidated(endpoint.provider); },
     );
     const providerContext = formatProviderContext(config);
     // PR-8: install the filter-not-found silencer. Without this, RPC
@@ -1103,7 +1170,7 @@ export class EVMChainAdapterBase {
    * pre-broadcast — the caller owns the WAL split and broadcasts the single
    * returned tx.
    */
-  protected populateAndSignAcrossProviders(
+  protected async populateAndSignAcrossProviders(
     contract: Contract,
     method: string,
     args: readonly unknown[],
@@ -2113,12 +2180,17 @@ export class EVMChainAdapterBase {
             : eligible;
         let pageError: unknown;
         for (const { provider } of ordered) {
-          let contract = connected.get(provider);
-          if (!contract) {
-            contract = baseContract.connect(provider) as Contract;
-            connected.set(provider, contract);
-          }
           try {
+            await withTimeout(
+              this.ensureConfiguredStaticChainIdValidated(provider),
+              RPC_READ_STALL_TIMEOUT_MS,
+              `${label} chainId validation`,
+            );
+            let contract = connected.get(provider);
+            if (!contract) {
+              contract = baseContract.connect(provider) as Contract;
+              connected.set(provider, contract);
+            }
             const logs = await withTimeout(
               contract.queryFilter(filter as any, lo, hi),
               KA_HIGH_WATER_PAGE_TIMEOUT_MS,
@@ -2209,6 +2281,11 @@ export class EVMChainAdapterBase {
     const reachable: ScanProvider[] = [];
     for (const provider of this.providers) {
       try {
+        await withTimeout(
+          this.ensureConfiguredStaticChainIdValidated(provider),
+          RPC_READ_STALL_TIMEOUT_MS,
+          `${operationLabel} chainId validation`,
+        );
         const backendHead = await withTimeout(
           provider.getBlockNumber(),
           RPC_READ_STALL_TIMEOUT_MS,
@@ -2245,6 +2322,11 @@ export class EVMChainAdapterBase {
     const reachable: ScanProvider[] = [];
     for (const provider of this.providers) {
       try {
+        await withTimeout(
+          this.ensureConfiguredStaticChainIdValidated(provider),
+          RPC_READ_STALL_TIMEOUT_MS,
+          `${operationLabel} chainId validation`,
+        );
         // Bound the probe: these are direct per-backend reads (not via the
         // FallbackProvider), so without a timeout a hung `getBlockNumber()` would
         // stall the whole resolution instead of failing over. A stall rejects and
@@ -2418,9 +2500,44 @@ export class EVMChainAdapterBase {
     if (EVMChainAdapterBase.preflightCacheFresh(this.cachedChainId, now)) {
       return this.cachedChainId!.value;
     }
-    const network = await this.readProvider('getNetwork (chainId)', (p) => p.getNetwork());
-    this.cachedChainId = { value: network.chainId, cachedAt: now };
-    return network.chainId;
+    const chainId = this.configuredStaticChainId == null
+      ? (await this.readProvider('getNetwork (chainId)', (p) => p.getNetwork())).chainId
+      : await this.rpcFailover.read(
+          'validate configured chainId',
+          (p) => this.ensureConfiguredStaticChainIdValidated(p),
+        );
+    this.cachedChainId = { value: chainId, cachedAt: now };
+    return chainId;
+  }
+
+  protected async ensureConfiguredStaticChainIdValidated(provider: JsonRpcProvider): Promise<bigint> {
+    if (this.configuredStaticChainId == null) return 0n;
+    const now = Date.now();
+    const cached = this.configuredStaticChainIdsByProvider.get(provider);
+    if (EVMChainAdapterBase.preflightCacheFresh(cached, now)) {
+      return cached!.value;
+    }
+
+    let validation = this.configuredStaticChainIdValidationsByProvider.get(provider);
+    if (!validation) {
+      validation = (async () => {
+        const raw = await provider.send('eth_chainId', []);
+        const live = BigInt(raw);
+        if (live !== this.configuredStaticChainId) {
+          throw new Error(
+            `Configured chainId ${this.configuredStaticChainId} does not match RPC chainId ${live}`,
+          );
+        }
+        this.configuredStaticChainIdsByProvider.set(provider, { value: live, cachedAt: Date.now() });
+        this.cachedChainId = { value: live, cachedAt: Date.now() };
+        return live;
+      })().finally(() => {
+        this.configuredStaticChainIdValidationsByProvider.delete(provider);
+      });
+      this.configuredStaticChainIdValidationsByProvider.set(provider, validation);
+    }
+
+    return validation;
   }
 
   /**
@@ -3025,6 +3142,11 @@ export class EVMChainAdapterBase {
       }
     };
     try {
+      await withTimeout(
+        this.ensureConfiguredStaticChainIdValidated(this.primaryProvider),
+        RPC_READ_STALL_TIMEOUT_MS,
+        'Hub rotation listener chainId validation',
+      );
       await this.contracts.hub.on('ContractChanged', onChange);
       await this.contracts.hub.on('NewContract', onChange);
       await this.contracts.hub.on('AssetStorageChanged', onChange);

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -41,8 +41,7 @@ import type { ContractCache, EVMAdapterConfig } from './evm-adapter-types.js';
 import { RPC_READ_STALL_TIMEOUT_MS, DEFAULT_RANDOM_SAMPLING_HUB_REFRESH_MS, RPC_RECEIPT_TIMEOUT_MS, RPC_RECEIPT_POLL_INTERVAL_MS, RPC_ENDPOINT_SET_RETRIES, RPC_ENDPOINT_SET_RETRY_BACKOFF_MS, ADMIN_KEY_PURPOSE, OPERATIONAL_KEY_PURPOSE, PUBLISHER_FUNDING_CACHE_TTL_MS } from './evm-adapter-constants.js';
 
 /**
- * Maps a Hub-registered contract name to the function that invalidates
- * the corresponding boot-bound field on `EVMChainAdapter.contracts`.
+ * Maps a Hub-registered contract name to its local binding invalidation policy.
  *
  * Used by:
  *   1. `startHubRotationListener` — when the Hub rotation poller sees
@@ -58,33 +57,36 @@ import { RPC_READ_STALL_TIMEOUT_MS, DEFAULT_RANDOM_SAMPLING_HUB_REFRESH_MS, RPC_
  * which owns side-channel state (in-flight probe, ready flag) that
  * a simple field reset wouldn't touch.
  *
- * Names listed here MUST match boot-bound contracts that `init()` resolves via
- * `Hub.getContractAddress(name)` / `Hub.getAssetStorageAddress(name)`
- * — keep these in sync when adding/removing bindings in `init()`.
+ * Boot-bound names listed here MUST match contracts that `init()` resolves via
+ * `Hub.getContractAddress(name)` / `Hub.getAssetStorageAddress(name)`. Lazy
+ * names listed here MUST match helpers such as `getIdentityStorage()`.
  */
-type ContractInvalidator = (adapter: EVMChainAdapterBase) => void;
+type HubBindingInvalidationPolicy = {
+  invalidate: (adapter: EVMChainAdapterBase) => void;
+  invalidateOnRotation?: (adapter: EVMChainAdapterBase) => void;
+};
 
-const BOOT_BOUND_CONTRACT_INVALIDATORS = new Map<string, ContractInvalidator>([
-  ['Identity',                   (a) => { (a as any).contracts.identity = undefined; }],
-  ['Profile',                    (a) => { (a as any).contracts.profile = undefined; }],
-  ['ProfileStorage',             (a) => { (a as any).contracts.profileStorage = undefined; }],
-  ['ParametersStorage',          (a) => { (a as any).contracts.parametersStorage = undefined; }],
-  ['Staking',                    (a) => { (a as any).contracts.staking = undefined; }],
-  ['Token',                      (a) => { (a as any).contracts.token = undefined; }],
-  ['AskStorage',                 (a) => { (a as any).contracts.askStorage = undefined; }],
-  ['KnowledgeAssets',            (a) => { (a as any).contracts.knowledgeAssets = undefined; }],
-  ['KnowledgeAssetsStorage',     (a) => { (a as any).contracts.knowledgeAssetsStorage = undefined; }],
-  ['KnowledgeAssetsLifecycle',   (a) => { (a as any).contracts.knowledgeAssetsLifecycle = undefined; }],
-  ['DKGKnowledgeAssets',         (a) => { (a as any).contracts.knowledgeAssetStorage = undefined; }],
-  ['ContextGraphNameRegistry',   (a) => { (a as any).contracts.contextGraphNameRegistry = undefined; }],
-  ['ContextGraphs',              (a) => { (a as any).contracts.contextGraphs = undefined; }],
-  ['ContextGraphStorage',        (a) => { (a as any).contracts.contextGraphStorage = undefined; }],
-  ['DKGPublishingConvictionNFT', (a) => { (a as any).contracts.dkgPublishingConvictionNFT = undefined; }],
-  ['Chronos',                    (a) => { (a as any).contracts.chronos = undefined; }],
-]);
-
-const LAZY_BINDING_INVALIDATORS = new Map<string, ContractInvalidator>([
-  ['IdentityStorage',            (a) => { (a as any).invalidateIdentityStorageBinding(); }],
+const HUB_BINDING_INVALIDATORS = new Map<string, HubBindingInvalidationPolicy>([
+  ['Identity',                   { invalidate: (a) => { (a as any).contracts.identity = undefined; } }],
+  ['IdentityStorage',            {
+    invalidate: (a) => { (a as any).invalidateIdentityStorageBinding(); },
+    invalidateOnRotation: (a) => { (a as any).invalidateIdentityStorageBinding(); },
+  }],
+  ['Profile',                    { invalidate: (a) => { (a as any).contracts.profile = undefined; } }],
+  ['ProfileStorage',             { invalidate: (a) => { (a as any).contracts.profileStorage = undefined; } }],
+  ['ParametersStorage',          { invalidate: (a) => { (a as any).contracts.parametersStorage = undefined; } }],
+  ['Staking',                    { invalidate: (a) => { (a as any).contracts.staking = undefined; } }],
+  ['Token',                      { invalidate: (a) => { (a as any).contracts.token = undefined; } }],
+  ['AskStorage',                 { invalidate: (a) => { (a as any).contracts.askStorage = undefined; } }],
+  ['KnowledgeAssets',            { invalidate: (a) => { (a as any).contracts.knowledgeAssets = undefined; } }],
+  ['KnowledgeAssetsStorage',     { invalidate: (a) => { (a as any).contracts.knowledgeAssetsStorage = undefined; } }],
+  ['KnowledgeAssetsLifecycle',   { invalidate: (a) => { (a as any).contracts.knowledgeAssetsLifecycle = undefined; } }],
+  ['DKGKnowledgeAssets',         { invalidate: (a) => { (a as any).contracts.knowledgeAssetStorage = undefined; } }],
+  ['ContextGraphNameRegistry',   { invalidate: (a) => { (a as any).contracts.contextGraphNameRegistry = undefined; } }],
+  ['ContextGraphs',              { invalidate: (a) => { (a as any).contracts.contextGraphs = undefined; } }],
+  ['ContextGraphStorage',        { invalidate: (a) => { (a as any).contracts.contextGraphStorage = undefined; } }],
+  ['DKGPublishingConvictionNFT', { invalidate: (a) => { (a as any).contracts.dkgPublishingConvictionNFT = undefined; } }],
+  ['Chronos',                    { invalidate: (a) => { (a as any).contracts.chronos = undefined; } }],
 ]);
 
 const KA_HIGH_WATER_VIEW_SIGNATURE = 'getMaxKaNumberForAuthor(address)';
@@ -720,19 +722,46 @@ export class EVMChainAdapterBase {
     this.identityIdCache.invalidateAll();
   }
 
+  protected async identityStorageAddressChanged(
+    previous: Contract | undefined,
+    next: Contract,
+  ): Promise<boolean> {
+    if (!previous) return false;
+    if (previous === next) return false;
+    try {
+      return (await contractAddress(previous)).toLowerCase() !== (await contractAddress(next)).toLowerCase();
+    } catch {
+      return true;
+    }
+  }
+
   protected async readIdentityIdFromStorage(address: string): Promise<bigint> {
     if (!ethers.isAddress(address)) return 0n;
     const checksum = ethers.getAddress(address);
     await this.init();
-    const identityStorage = await this.getIdentityStorage();
+    const previousIdentityStorage = this.contracts.identityStorage;
+    const identityStorage = await this.getIdentityStorage({ refresh: true });
+    const identityStorageChanged = await this.identityStorageAddressChanged(previousIdentityStorage, identityStorage);
+    if (identityStorageChanged) this.identityIdCache.invalidateAll();
     const id: bigint = await this.readContract(
       identityStorage, 'identityStorage.getIdentityId', 'getIdentityId', checksum,
     );
-    return BigInt(id);
+    const identityId = BigInt(id);
+    if (identityStorageChanged) this.identityIdCache.seed(checksum, identityId);
+    return identityId;
   }
 
   protected async readIdentityIdForAddress(address: string): Promise<bigint> {
     return this.identityIdCache.getOrLoad(address, (checksum) => this.readIdentityIdFromStorage(checksum));
+  }
+
+  protected async refreshIdentityIdForAddress(address: string): Promise<bigint> {
+    if (!ethers.isAddress(address)) return 0n;
+    const checksum = ethers.getAddress(address);
+    this.identityIdCache.invalidate(checksum);
+    const identityId = await this.readIdentityIdFromStorage(checksum);
+    this.identityIdCache.seed(checksum, identityId);
+    return identityId;
   }
 
   protected static preflightCacheFresh(
@@ -1785,8 +1814,8 @@ export class EVMChainAdapterBase {
     return ethers.keccak256(ethers.solidityPacked(['address'], [ethers.getAddress(address)]));
   }
 
-  protected async getIdentityStorage(): Promise<Contract> {
-    if (!this.contracts.identityStorage) {
+  protected async getIdentityStorage(options: { refresh?: boolean } = {}): Promise<Contract> {
+    if (options.refresh || !this.contracts.identityStorage) {
       this.contracts.identityStorage = await this.resolveContract('IdentityStorage');
     }
     return this.contracts.identityStorage;
@@ -3178,13 +3207,13 @@ export class EVMChainAdapterBase {
    *      See the `randomSamplingPairCache` field comment for the
    *      coupling invariants this path preserves.
    *
-   *   2. Lazy bindings with dependent caches, currently `IdentityStorage`,
-   *      clear their lazy slot and dependent cache, then use the same rotation
-   *      finalization as boot-bound bindings.
+   *   2. Names in `HUB_BINDING_INVALIDATORS` may clear a lazy slot and
+   *      dependent cache through `invalidateOnRotation`, then use the same
+   *      rotation finalization as boot-bound bindings.
    *
-   *   3. Any name in `BOOT_BOUND_CONTRACT_INVALIDATORS` -> leave the existing
-   *      `this.contracts.X` field intact but flip `this.initialized` back to
-   *      `false` so the next `await
+   *   3. Any name in `HUB_BINDING_INVALIDATORS` without a rotation invalidator
+   *      leaves the existing `this.contracts.X` field intact but flips
+   *      `this.initialized` back to `false` so the next `await
    *      this.init()` re-resolves every binding fresh from Hub. Keeping
    *      the old handle until the next init pass avoids a race where an
    *      in-flight public method already passed `init()` and then trips
@@ -3235,15 +3264,10 @@ export class EVMChainAdapterBase {
       this.invalidateRandomSamplingPair();
       return;
     }
-    const lazyInvalidator = LAZY_BINDING_INVALIDATORS.get(name);
-    if (lazyInvalidator) {
-      lazyInvalidator(this);
-      this.finalizeKnownHubRotation();
-      return;
-    }
-    if (BOOT_BOUND_CONTRACT_INVALIDATORS.has(name)) {
-      this.finalizeKnownHubRotation();
-    }
+    const policy = HUB_BINDING_INVALIDATORS.get(name);
+    if (!policy) return;
+    policy.invalidateOnRotation?.(this);
+    this.finalizeKnownHubRotation();
   }
 
   protected finalizeKnownHubRotation(): void {
@@ -3272,11 +3296,8 @@ export class EVMChainAdapterBase {
    * (in-flight probe, ready flag) that `init()` alone won't reset.
    */
   protected invalidateAllBoundContracts(): void {
-    for (const invalidator of BOOT_BOUND_CONTRACT_INVALIDATORS.values()) {
-      invalidator(this);
-    }
-    for (const invalidator of LAZY_BINDING_INVALIDATORS.values()) {
-      invalidator(this);
+    for (const policy of HUB_BINDING_INVALIDATORS.values()) {
+      policy.invalidate(this);
     }
     this.invalidatePublishPreflightCache();
     this.invalidateRandomSamplingPair();

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -14,7 +14,7 @@
 import { JsonRpcProvider, Wallet, Contract, ethers } from 'ethers';
 import { createFilterErrorSilencer, installFilterNotFoundConsoleSuppressor, formatProviderError } from './filter-error-silencer.js';
 import type { FilterErrorSilencer } from './filter-error-silencer.js';
-import { DEFAULT_APPROVAL_POLICY } from './chain-adapter.js';
+import { DEFAULT_APPROVAL_POLICY, buildEvmDeploymentId } from './chain-adapter.js';
 import type {
   ApprovalPolicy,
   V10PublishParams,
@@ -36,6 +36,7 @@ import { formatProviderContext } from './evm-adapter-types.js';
 import { ReadThroughTtlCache } from './keyed-ttl-single-flight-cache.js';
 import { PcaReadCache } from './pca-read-cache.js';
 import { HubRotationPoller } from './hub-rotation-poller.js';
+import { ContextGraphRegistryScanCursor } from './context-graph-registry-scan-cursor.js';
 import type { ContractCache, EVMAdapterConfig } from './evm-adapter-types.js';
 import { RPC_READ_STALL_TIMEOUT_MS, DEFAULT_RANDOM_SAMPLING_HUB_REFRESH_MS, RPC_RECEIPT_TIMEOUT_MS, RPC_RECEIPT_POLL_INTERVAL_MS, RPC_ENDPOINT_SET_RETRIES, RPC_ENDPOINT_SET_RETRY_BACKOFF_MS, ADMIN_KEY_PURPOSE, OPERATIONAL_KEY_PURPOSE, PUBLISHER_FUNDING_CACHE_TTL_MS } from './evm-adapter-constants.js';
 
@@ -378,7 +379,7 @@ async function contractAddress(contract: Contract): Promise<string> {
 export class EVMChainAdapterBase {
   /** See `ChainAdapter.deploymentId`. */
   get deploymentId(): string {
-    return `${this.chainId}:hub=${this.hubAddress.toLowerCase()}`;
+    return buildEvmDeploymentId({ chainId: this.chainId, hubAddress: this.hubAddress });
   }
 
   readonly chainType = 'evm' as const;
@@ -623,11 +624,7 @@ export class EVMChainAdapterBase {
    */
   protected readonly cachedContractDeployBlocks: Map<string, number> = new Map();
 
-  /**
-   * Next unbuffered block for ContextGraphNameRegistry scans, keyed by lowercase
-   * registry address. Read with a reorg buffer; duplicate delivery is harmless.
-   */
-  protected readonly contextGraphRegistryScanWatermarks: Map<string, number> = new Map();
+  protected readonly contextGraphRegistryScanCursor: ContextGraphRegistryScanCursor;
 
   /**
    * eth_getLogs block-window for the pre-10.0.4 getMaxKaNumberForAuthor fallback
@@ -652,7 +649,7 @@ export class EVMChainAdapterBase {
     this.cachedKav10Address = undefined;
     this.cachedMinRequiredSignatures = undefined;
     this.cachedContractDeployBlocks.clear();
-    this.contextGraphRegistryScanWatermarks.clear();
+    this.contextGraphRegistryScanCursor.clearMemoryCache();
   }
 
   protected clearIdentityIdForAddress(address: string): void {
@@ -861,6 +858,11 @@ export class EVMChainAdapterBase {
     }
     this.tokenAddress = config.tokenAddress ? ethers.getAddress(config.tokenAddress) : undefined;
     this.chainId = config.chainId ?? 'evm:31337';
+    this.contextGraphRegistryScanCursor = new ContextGraphRegistryScanCursor({
+      chainId: this.chainId,
+      deploymentId: this.deploymentId,
+      store: config.contextGraphRegistryScanCursorStore,
+    });
     this.approvalPolicy = config.approvalPolicy ?? DEFAULT_APPROVAL_POLICY;
     this.minPublisherNativeWei = config.minPublisherNativeWei ?? 0n;
     this.minPublisherTracWei = config.minPublisherTracWei ?? 0n;

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -2650,18 +2650,22 @@ export class EVMChainAdapterBase {
 
     let validation = this.configuredStaticChainIdValidationsByProvider.get(provider);
     if (!validation) {
-      validation = (async () => {
-        const raw = await provider.send('eth_chainId', []);
-        const live = BigInt(raw);
-        if (live !== this.configuredStaticChainId) {
-          throw new Error(
-            `Configured chainId ${this.configuredStaticChainId} does not match RPC chainId ${live}`,
-          );
-        }
-        this.configuredStaticChainIdsByProvider.set(provider, { value: live, cachedAt: Date.now() });
-        this.cachedChainId = { value: live, cachedAt: Date.now() };
-        return live;
-      })().finally(() => {
+      validation = withTimeout(
+        (async () => {
+          const raw = await provider.send('eth_chainId', []);
+          const live = BigInt(raw);
+          if (live !== this.configuredStaticChainId) {
+            throw new Error(
+              `Configured chainId ${this.configuredStaticChainId} does not match RPC chainId ${live}`,
+            );
+          }
+          this.configuredStaticChainIdsByProvider.set(provider, { value: live, cachedAt: Date.now() });
+          this.cachedChainId = { value: live, cachedAt: Date.now() };
+          return live;
+        })(),
+        RPC_READ_STALL_TIMEOUT_MS,
+        'configured chainId validation',
+      ).finally(() => {
         this.configuredStaticChainIdValidationsByProvider.delete(provider);
       });
       this.configuredStaticChainIdValidationsByProvider.set(provider, validation);

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -3133,7 +3133,10 @@ export class EVMChainAdapterBase {
   protected async startHubRotationListener(): Promise<void> {
     if (this.hubRotationListenerStarted) return;
     try {
-      await this.hubRotationPoller.start(this.contracts.hub);
+      await this.hubRotationPoller.start(
+        this.contracts.hub,
+        await contractAddress(this.contracts.hub),
+      );
       this.hubRotationListenerStarted = this.hubRotationPoller.isStarted;
     } catch {
       /* provider doesn't support log polling — TTL refresh (RS)
@@ -3144,7 +3147,7 @@ export class EVMChainAdapterBase {
   protected async pollHubRotationEvents(): Promise<void> {
     const hub = this.contracts.hub;
     if (!hub) return;
-    await this.hubRotationPoller.poll(hub);
+    await this.hubRotationPoller.poll(hub, await contractAddress(hub));
   }
 
   protected applyHubRotationEventName(name: string): void {

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -41,7 +41,7 @@ import type { ContractCache, EVMAdapterConfig } from './evm-adapter-types.js';
 import { RPC_READ_STALL_TIMEOUT_MS, DEFAULT_RANDOM_SAMPLING_HUB_REFRESH_MS, RPC_RECEIPT_TIMEOUT_MS, RPC_RECEIPT_POLL_INTERVAL_MS, RPC_ENDPOINT_SET_RETRIES, RPC_ENDPOINT_SET_RETRY_BACKOFF_MS, ADMIN_KEY_PURPOSE, OPERATIONAL_KEY_PURPOSE, PUBLISHER_FUNDING_CACHE_TTL_MS } from './evm-adapter-constants.js';
 
 /**
- * Maps a Hub-registered contract name to the function that invalidates
+ * Maps a Hub-registered contract name to the policy that invalidates
  * the corresponding boot-bound field on `EVMChainAdapter.contracts`.
  *
  * Used by:
@@ -63,27 +63,92 @@ import { RPC_READ_STALL_TIMEOUT_MS, DEFAULT_RANDOM_SAMPLING_HUB_REFRESH_MS, RPC_
  * `Hub.getContractAddress(name)` / `Hub.getAssetStorageAddress(name)`
  * — keep these in sync when adding/removing bindings in `init()`.
  */
-const BOUND_CONTRACT_INVALIDATORS = new Map<string, (adapter: EVMChainAdapterBase) => void>([
-  ['Identity',                   (a) => { (a as any).contracts.identity = undefined; }],
-  ['IdentityStorage',            (a) => { (a as any).invalidateIdentityStorageBinding(); }],
-  ['Profile',                    (a) => { (a as any).contracts.profile = undefined; }],
-  ['ProfileStorage',             (a) => { (a as any).contracts.profileStorage = undefined; }],
-  ['ParametersStorage',          (a) => { (a as any).contracts.parametersStorage = undefined; }],
-  ['Staking',                    (a) => { (a as any).contracts.staking = undefined; }],
-  ['Token',                      (a) => { (a as any).contracts.token = undefined; }],
-  ['AskStorage',                 (a) => { (a as any).contracts.askStorage = undefined; }],
-  ['KnowledgeAssets',            (a) => { (a as any).contracts.knowledgeAssets = undefined; }],
-  ['KnowledgeAssetsStorage',     (a) => { (a as any).contracts.knowledgeAssetsStorage = undefined; }],
-  ['KnowledgeAssetsLifecycle',   (a) => { (a as any).contracts.knowledgeAssetsLifecycle = undefined; }],
-  ['DKGKnowledgeAssets',         (a) => { (a as any).contracts.knowledgeAssetStorage = undefined; }],
-  ['ContextGraphNameRegistry',   (a) => { (a as any).contracts.contextGraphNameRegistry = undefined; }],
-  ['ContextGraphs',              (a) => { (a as any).contracts.contextGraphs = undefined; }],
-  ['ContextGraphStorage',        (a) => { (a as any).contracts.contextGraphStorage = undefined; }],
-  ['DKGPublishingConvictionNFT', (a) => { (a as any).contracts.dkgPublishingConvictionNFT = undefined; }],
-  ['Chronos',                    (a) => { (a as any).contracts.chronos = undefined; }],
+type BoundContractInvalidationPolicy = {
+  invalidate: (adapter: EVMChainAdapterBase) => void;
+  onRotation?: (adapter: EVMChainAdapterBase) => void;
+};
+
+const BOUND_CONTRACT_INVALIDATORS = new Map<string, BoundContractInvalidationPolicy>([
+  ['Identity',                   { invalidate: (a) => { (a as any).contracts.identity = undefined; } }],
+  ['IdentityStorage',            {
+    invalidate: (a) => { (a as any).invalidateIdentityStorageBinding(); },
+    onRotation: (a) => {
+      (a as any).invalidateIdentityStorageBinding();
+      (a as any).initialized = false;
+    },
+  }],
+  ['Profile',                    { invalidate: (a) => { (a as any).contracts.profile = undefined; } }],
+  ['ProfileStorage',             { invalidate: (a) => { (a as any).contracts.profileStorage = undefined; } }],
+  ['ParametersStorage',          { invalidate: (a) => { (a as any).contracts.parametersStorage = undefined; } }],
+  ['Staking',                    { invalidate: (a) => { (a as any).contracts.staking = undefined; } }],
+  ['Token',                      { invalidate: (a) => { (a as any).contracts.token = undefined; } }],
+  ['AskStorage',                 { invalidate: (a) => { (a as any).contracts.askStorage = undefined; } }],
+  ['KnowledgeAssets',            { invalidate: (a) => { (a as any).contracts.knowledgeAssets = undefined; } }],
+  ['KnowledgeAssetsStorage',     { invalidate: (a) => { (a as any).contracts.knowledgeAssetsStorage = undefined; } }],
+  ['KnowledgeAssetsLifecycle',   { invalidate: (a) => { (a as any).contracts.knowledgeAssetsLifecycle = undefined; } }],
+  ['DKGKnowledgeAssets',         { invalidate: (a) => { (a as any).contracts.knowledgeAssetStorage = undefined; } }],
+  ['ContextGraphNameRegistry',   { invalidate: (a) => { (a as any).contracts.contextGraphNameRegistry = undefined; } }],
+  ['ContextGraphs',              { invalidate: (a) => { (a as any).contracts.contextGraphs = undefined; } }],
+  ['ContextGraphStorage',        { invalidate: (a) => { (a as any).contracts.contextGraphStorage = undefined; } }],
+  ['DKGPublishingConvictionNFT', { invalidate: (a) => { (a as any).contracts.dkgPublishingConvictionNFT = undefined; } }],
+  ['Chronos',                    { invalidate: (a) => { (a as any).contracts.chronos = undefined; } }],
 ]);
 
 const KA_HIGH_WATER_VIEW_SIGNATURE = 'getMaxKaNumberForAuthor(address)';
+
+type IdentityIdCacheEntry = {
+  identityId: bigint;
+  ttlMs: number;
+};
+
+class IdentityIdCache {
+  private readonly values = new ReadThroughTtlCache<string, IdentityIdCacheEntry>({
+    ttlMs: (entry) => entry.ttlMs,
+  });
+
+  constructor(
+    private readonly signerCacheKey: string,
+    private readonly positiveTtlMs: number,
+    private readonly signerZeroTtlMs: number,
+  ) {}
+
+  async getOrLoad(
+    address: string,
+    load: (checksumAddress: string) => Promise<bigint>,
+  ): Promise<bigint> {
+    if (!ethers.isAddress(address)) return 0n;
+    const checksum = ethers.getAddress(address);
+    const cacheKey = checksum.toLowerCase();
+    const entry = await this.values.getOrLoad(cacheKey, cacheKey, async () => {
+      const identityId = await load(checksum);
+      return this.entry(cacheKey, identityId);
+    });
+    return entry.identityId;
+  }
+
+  seed(address: string, identityId: bigint): void {
+    const cacheKey = ethers.getAddress(address).toLowerCase();
+    this.values.seed(cacheKey, this.entry(cacheKey, identityId));
+  }
+
+  invalidate(address: string): void {
+    const cacheKey = ethers.getAddress(address).toLowerCase();
+    this.values.invalidate(cacheKey);
+  }
+
+  invalidateAll(): void {
+    this.values.invalidateAll();
+  }
+
+  private entry(cacheKey: string, identityId: bigint): IdentityIdCacheEntry {
+    const ttlMs = identityId > 0n
+      ? this.positiveTtlMs
+      : cacheKey === this.signerCacheKey
+        ? this.signerZeroTtlMs
+        : 0;
+    return { identityId, ttlMs };
+  }
+}
 
 /**
  * Upper bound on the pre-10.0.4 KnowledgeAssetCreated fallback scan, in
@@ -512,38 +577,16 @@ export class EVMChainAdapterBase {
 
   protected static readonly IDENTITY_ID_POSITIVE_TTL_MS = 5 * 60 * 1000;
 
-  protected static readonly IDENTITY_ID_NEGATIVE_TTL_MS = 0;
-
   protected static readonly SIGNER_IDENTITY_ID_ZERO_TTL_MS = 15 * 1000;
 
-  protected static readonly SIGNER_IDENTITY_ID_CACHE_KEY = 'signer';
-
   /**
-   * OT-RFC-39 — per-process cache for `getIdentityIdForAddress`.
-   * Positive hits are memoised with a bounded TTL; negative hits are only
-   * single-flighted so a later external registration is visible immediately.
-   * Local mutations seed/invalidate through the cache so stale in-flight reads
-   * cannot win.
+   * OT-RFC-39 — per-process identity-id cache. Positive hits are memoised with
+   * a bounded TTL; arbitrary-address negative hits are only single-flighted so
+   * later external registration is visible immediately. The signer address has
+   * a short zero TTL so fresh edge-node startup sync does not repeat the same
+   * self `0n` lookup per page.
    */
-  protected readonly identityIdByAddressCache = new ReadThroughTtlCache<string, bigint>({
-    ttlMs: (value) => value > 0n
-      ? EVMChainAdapterBase.IDENTITY_ID_POSITIVE_TTL_MS
-      : EVMChainAdapterBase.IDENTITY_ID_NEGATIVE_TTL_MS,
-  });
-
-  /**
-   * Signer-only identity cache for `getIdentityId()`.
-   *
-   * Edge nodes commonly have no node-operator identity (`0n`) and fall back to
-   * agent-key signing. A short zero TTL prevents startup sync from repeating the
-   * same self lookup per page while keeping arbitrary-address negative lookups
-   * live and bounding external profile-creation visibility delay.
-   */
-  protected readonly signerIdentityIdCache = new ReadThroughTtlCache<string, bigint>({
-    ttlMs: (value) => value > 0n
-      ? EVMChainAdapterBase.IDENTITY_ID_POSITIVE_TTL_MS
-      : EVMChainAdapterBase.SIGNER_IDENTITY_ID_ZERO_TTL_MS,
-  });
+  protected identityIdCache!: IdentityIdCache;
 
   protected readonly pcaReadCache = new PcaReadCache();
 
@@ -672,25 +715,16 @@ export class EVMChainAdapterBase {
   }
 
   protected clearIdentityIdForAddress(address: string): void {
-    const cacheKey = ethers.getAddress(address).toLowerCase();
-    this.identityIdByAddressCache.invalidate(cacheKey);
-    if (cacheKey === this.signer.address.toLowerCase()) {
-      this.signerIdentityIdCache.invalidate(EVMChainAdapterBase.SIGNER_IDENTITY_ID_CACHE_KEY);
-    }
+    this.identityIdCache.invalidate(address);
   }
 
   protected seedIdentityIdForAddress(address: string, identityId: bigint): void {
-    const cacheKey = ethers.getAddress(address).toLowerCase();
-    this.identityIdByAddressCache.seed(cacheKey, identityId);
-    if (cacheKey === this.signer.address.toLowerCase()) {
-      this.signerIdentityIdCache.seed(EVMChainAdapterBase.SIGNER_IDENTITY_ID_CACHE_KEY, identityId);
-    }
+    this.identityIdCache.seed(address, identityId);
   }
 
   protected invalidateIdentityStorageBinding(): void {
     this.contracts.identityStorage = undefined;
-    this.identityIdByAddressCache.invalidateAll();
-    this.signerIdentityIdCache.invalidateAll();
+    this.identityIdCache.invalidateAll();
   }
 
   protected async readIdentityIdFromStorage(address: string): Promise<bigint> {
@@ -705,16 +739,7 @@ export class EVMChainAdapterBase {
   }
 
   protected async readIdentityIdForAddress(address: string): Promise<bigint> {
-    if (!ethers.isAddress(address)) return 0n;
-    const checksum = ethers.getAddress(address);
-    const cacheKey = checksum.toLowerCase();
-    return this.identityIdByAddressCache.getOrLoad(cacheKey, cacheKey, async () => {
-      const identityId = await this.readIdentityIdFromStorage(checksum);
-      if (identityId > 0n && cacheKey === this.signer.address.toLowerCase()) {
-        this.signerIdentityIdCache.seed(EVMChainAdapterBase.SIGNER_IDENTITY_ID_CACHE_KEY, identityId);
-      }
-      return identityId;
-    });
+    return this.identityIdCache.getOrLoad(address, (checksum) => this.readIdentityIdFromStorage(checksum));
   }
 
   protected static preflightCacheFresh(
@@ -907,6 +932,11 @@ export class EVMChainAdapterBase {
         throw new Error('EVM adminPrivateKey must be distinct from operational keys');
       }
     }
+    this.identityIdCache = new IdentityIdCache(
+      this.signer.address.toLowerCase(),
+      EVMChainAdapterBase.IDENTITY_ID_POSITIVE_TTL_MS,
+      EVMChainAdapterBase.SIGNER_IDENTITY_ID_ZERO_TTL_MS,
+    );
     this.hubAddress = config.hubAddress;
     if (config.tokenAddress && !ethers.isAddress(config.tokenAddress)) {
       throw new Error(`Invalid tokenAddress: ${config.tokenAddress}`);
@@ -2027,11 +2057,7 @@ export class EVMChainAdapterBase {
   // =====================================================================
 
   async getIdentityId(): Promise<bigint> {
-    return this.signerIdentityIdCache.getOrLoad(
-      EVMChainAdapterBase.SIGNER_IDENTITY_ID_CACHE_KEY,
-      EVMChainAdapterBase.SIGNER_IDENTITY_ID_CACHE_KEY,
-      () => this.readIdentityIdForAddress(this.signer.address),
-    );
+    return this.readIdentityIdForAddress(this.signer.address);
   }
 
   // =====================================================================
@@ -3159,11 +3185,11 @@ export class EVMChainAdapterBase {
    *      See the `randomSamplingPairCache` field comment for the
    *      coupling invariants this path preserves.
    *
-   *   2. `IdentityStorage` -> clear the lazy storage binding and the
-   *      dependent identity caches, then force the next public-method
-   *      entry through `init()`.
+   *   2. Any name in `BOUND_CONTRACT_INVALIDATORS` with an explicit
+   *      rotation policy -> run that policy. `IdentityStorage` uses this
+   *      to clear its lazy storage binding and dependent identity cache.
    *
-   *   3. Any other name in `BOUND_CONTRACT_INVALIDATORS` → leave the
+   *   3. Any other name in `BOUND_CONTRACT_INVALIDATORS` -> leave the
    *      existing `this.contracts.X` field intact but flip
    *      `this.initialized` back to `false` so the next `await
    *      this.init()` re-resolves every binding fresh from Hub. Keeping
@@ -3216,12 +3242,12 @@ export class EVMChainAdapterBase {
       this.invalidateRandomSamplingPair();
       return;
     }
-    if (name === 'IdentityStorage') {
-      this.invalidateIdentityStorageBinding();
-      this.initialized = false;
+    const policy = BOUND_CONTRACT_INVALIDATORS.get(name);
+    if (policy?.onRotation) {
+      policy.onRotation(this);
       return;
     }
-    if (BOUND_CONTRACT_INVALIDATORS.has(name)) {
+    if (policy) {
       this.invalidatePublishPreflightCache();
       // Force the next public-method entry through `init()` so it re-resolves
       // every binding. Do not clear the current handle here: the callback can
@@ -3247,8 +3273,8 @@ export class EVMChainAdapterBase {
    * (in-flight probe, ready flag) that `init()` alone won't reset.
    */
   protected invalidateAllBoundContracts(): void {
-    for (const invalidator of BOUND_CONTRACT_INVALIDATORS.values()) {
-      invalidator(this);
+    for (const policy of BOUND_CONTRACT_INVALIDATORS.values()) {
+      policy.invalidate(this);
     }
     this.invalidatePublishPreflightCache();
     this.invalidateRandomSamplingPair();

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -65,6 +65,7 @@ import { RPC_READ_STALL_TIMEOUT_MS, DEFAULT_RANDOM_SAMPLING_HUB_REFRESH_MS, RPC_
  */
 const BOUND_CONTRACT_INVALIDATORS = new Map<string, (adapter: EVMChainAdapterBase) => void>([
   ['Identity',                   (a) => { (a as any).contracts.identity = undefined; }],
+  ['IdentityStorage',            (a) => { (a as any).invalidateIdentityStorageBinding(); }],
   ['Profile',                    (a) => { (a as any).contracts.profile = undefined; }],
   ['ProfileStorage',             (a) => { (a as any).contracts.profileStorage = undefined; }],
   ['ParametersStorage',          (a) => { (a as any).contracts.parametersStorage = undefined; }],
@@ -513,6 +514,10 @@ export class EVMChainAdapterBase {
 
   protected static readonly IDENTITY_ID_NEGATIVE_TTL_MS = 0;
 
+  protected static readonly SIGNER_IDENTITY_ID_ZERO_TTL_MS = 15 * 1000;
+
+  protected static readonly SIGNER_IDENTITY_ID_CACHE_KEY = 'signer';
+
   /**
    * OT-RFC-39 — per-process cache for `getIdentityIdForAddress`.
    * Positive hits are memoised with a bounded TTL; negative hits are only
@@ -524,6 +529,20 @@ export class EVMChainAdapterBase {
     ttlMs: (value) => value > 0n
       ? EVMChainAdapterBase.IDENTITY_ID_POSITIVE_TTL_MS
       : EVMChainAdapterBase.IDENTITY_ID_NEGATIVE_TTL_MS,
+  });
+
+  /**
+   * Signer-only identity cache for `getIdentityId()`.
+   *
+   * Edge nodes commonly have no node-operator identity (`0n`) and fall back to
+   * agent-key signing. A short zero TTL prevents startup sync from repeating the
+   * same self lookup per page while keeping arbitrary-address negative lookups
+   * live and bounding external profile-creation visibility delay.
+   */
+  protected readonly signerIdentityIdCache = new ReadThroughTtlCache<string, bigint>({
+    ttlMs: (value) => value > 0n
+      ? EVMChainAdapterBase.IDENTITY_ID_POSITIVE_TTL_MS
+      : EVMChainAdapterBase.SIGNER_IDENTITY_ID_ZERO_TTL_MS,
   });
 
   protected readonly pcaReadCache = new PcaReadCache();
@@ -655,11 +674,47 @@ export class EVMChainAdapterBase {
   protected clearIdentityIdForAddress(address: string): void {
     const cacheKey = ethers.getAddress(address).toLowerCase();
     this.identityIdByAddressCache.invalidate(cacheKey);
+    if (cacheKey === this.signer.address.toLowerCase()) {
+      this.signerIdentityIdCache.invalidate(EVMChainAdapterBase.SIGNER_IDENTITY_ID_CACHE_KEY);
+    }
   }
 
   protected seedIdentityIdForAddress(address: string, identityId: bigint): void {
     const cacheKey = ethers.getAddress(address).toLowerCase();
     this.identityIdByAddressCache.seed(cacheKey, identityId);
+    if (cacheKey === this.signer.address.toLowerCase()) {
+      this.signerIdentityIdCache.seed(EVMChainAdapterBase.SIGNER_IDENTITY_ID_CACHE_KEY, identityId);
+    }
+  }
+
+  protected invalidateIdentityStorageBinding(): void {
+    this.contracts.identityStorage = undefined;
+    this.identityIdByAddressCache.invalidateAll();
+    this.signerIdentityIdCache.invalidateAll();
+  }
+
+  protected async readIdentityIdFromStorage(address: string): Promise<bigint> {
+    if (!ethers.isAddress(address)) return 0n;
+    const checksum = ethers.getAddress(address);
+    await this.init();
+    const identityStorage = await this.resolveContract('IdentityStorage');
+    const id: bigint = await this.readContract(
+      identityStorage, 'identityStorage.getIdentityId', 'getIdentityId', checksum,
+    );
+    return BigInt(id);
+  }
+
+  protected async readIdentityIdForAddress(address: string): Promise<bigint> {
+    if (!ethers.isAddress(address)) return 0n;
+    const checksum = ethers.getAddress(address);
+    const cacheKey = checksum.toLowerCase();
+    return this.identityIdByAddressCache.getOrLoad(cacheKey, cacheKey, async () => {
+      const identityId = await this.readIdentityIdFromStorage(checksum);
+      if (identityId > 0n && cacheKey === this.signer.address.toLowerCase()) {
+        this.signerIdentityIdCache.seed(EVMChainAdapterBase.SIGNER_IDENTITY_ID_CACHE_KEY, identityId);
+      }
+      return identityId;
+    });
   }
 
   protected static preflightCacheFresh(
@@ -1972,12 +2027,11 @@ export class EVMChainAdapterBase {
   // =====================================================================
 
   async getIdentityId(): Promise<bigint> {
-    await this.init();
-    const identityStorage = await this.getIdentityStorage();
-    const id: bigint = await this.readContract(
-      identityStorage, 'identityStorage.getIdentityId', 'getIdentityId', this.signer.address,
+    return this.signerIdentityIdCache.getOrLoad(
+      EVMChainAdapterBase.SIGNER_IDENTITY_ID_CACHE_KEY,
+      EVMChainAdapterBase.SIGNER_IDENTITY_ID_CACHE_KEY,
+      () => this.readIdentityIdForAddress(this.signer.address),
     );
-    return id;
   }
 
   // =====================================================================
@@ -3105,7 +3159,11 @@ export class EVMChainAdapterBase {
    *      See the `randomSamplingPairCache` field comment for the
    *      coupling invariants this path preserves.
    *
-   *   2. Any other name in `BOUND_CONTRACT_INVALIDATORS` → leave the
+   *   2. `IdentityStorage` -> clear the lazy storage binding and the
+   *      dependent identity caches, then force the next public-method
+   *      entry through `init()`.
+   *
+   *   3. Any other name in `BOUND_CONTRACT_INVALIDATORS` → leave the
    *      existing `this.contracts.X` field intact but flip
    *      `this.initialized` back to `false` so the next `await
    *      this.init()` re-resolves every binding fresh from Hub. Keeping
@@ -3118,7 +3176,7 @@ export class EVMChainAdapterBase {
    *      operators were silently stuck on the pre-rotation address
    *      until a daemon restart.
    *
-   *   3. Unknown name → ignored. We deliberately allowlist rather
+   *   4. Unknown name → ignored. We deliberately allowlist rather
    *      than reflexively re-init on any rotation: third-party
    *      deployments may register names we don't bind, and we don't
    *      want a benign rotation of an unrelated contract to thrash
@@ -3156,6 +3214,11 @@ export class EVMChainAdapterBase {
   protected applyHubRotationEventName(name: string): void {
     if (name === 'RandomSampling' || name === 'RandomSamplingStorage') {
       this.invalidateRandomSamplingPair();
+      return;
+    }
+    if (name === 'IdentityStorage') {
+      this.invalidateIdentityStorageBinding();
+      this.initialized = false;
       return;
     }
     if (BOUND_CONTRACT_INVALIDATORS.has(name)) {

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -41,15 +41,14 @@ import type { ContractCache, EVMAdapterConfig } from './evm-adapter-types.js';
 import { RPC_READ_STALL_TIMEOUT_MS, DEFAULT_RANDOM_SAMPLING_HUB_REFRESH_MS, RPC_RECEIPT_TIMEOUT_MS, RPC_RECEIPT_POLL_INTERVAL_MS, RPC_ENDPOINT_SET_RETRIES, RPC_ENDPOINT_SET_RETRY_BACKOFF_MS, ADMIN_KEY_PURPOSE, OPERATIONAL_KEY_PURPOSE, PUBLISHER_FUNDING_CACHE_TTL_MS } from './evm-adapter-constants.js';
 
 /**
- * Maps a Hub-registered contract name to the policy that invalidates
+ * Maps a Hub-registered contract name to the function that invalidates
  * the corresponding boot-bound field on `EVMChainAdapter.contracts`.
  *
  * Used by:
  *   1. `startHubRotationListener` — when the Hub rotation poller sees
- *      `name`, it checks this allowlist, marks the
- *      adapter uninitialised, and leaves the existing handle intact so
- *      in-flight calls that already passed `init()` don't observe a
- *      transient `undefined`.
+ *      `name`, it checks this allowlist, marks the adapter uninitialised,
+ *      and leaves the existing handle intact so in-flight calls that already
+ *      passed `init()` don't observe a transient `undefined`.
  *   2. `invalidateAllBoundContracts` — bulk drop, called by the
  *      write-side self-heal path (`withHubStaleRetry`) when a stale
  *      address surfaces `UnauthorizedAccess(Only Contracts in Hub)`.
@@ -59,39 +58,33 @@ import { RPC_READ_STALL_TIMEOUT_MS, DEFAULT_RANDOM_SAMPLING_HUB_REFRESH_MS, RPC_
  * which owns side-channel state (in-flight probe, ready flag) that
  * a simple field reset wouldn't touch.
  *
- * Names listed here MUST match what `init()` resolves via
+ * Names listed here MUST match boot-bound contracts that `init()` resolves via
  * `Hub.getContractAddress(name)` / `Hub.getAssetStorageAddress(name)`
  * — keep these in sync when adding/removing bindings in `init()`.
  */
-type BoundContractInvalidationPolicy = {
-  invalidate: (adapter: EVMChainAdapterBase) => void;
-  onRotation?: (adapter: EVMChainAdapterBase) => void;
-};
+type ContractInvalidator = (adapter: EVMChainAdapterBase) => void;
 
-const BOUND_CONTRACT_INVALIDATORS = new Map<string, BoundContractInvalidationPolicy>([
-  ['Identity',                   { invalidate: (a) => { (a as any).contracts.identity = undefined; } }],
-  ['IdentityStorage',            {
-    invalidate: (a) => { (a as any).invalidateIdentityStorageBinding(); },
-    onRotation: (a) => {
-      (a as any).invalidateIdentityStorageBinding();
-      (a as any).initialized = false;
-    },
-  }],
-  ['Profile',                    { invalidate: (a) => { (a as any).contracts.profile = undefined; } }],
-  ['ProfileStorage',             { invalidate: (a) => { (a as any).contracts.profileStorage = undefined; } }],
-  ['ParametersStorage',          { invalidate: (a) => { (a as any).contracts.parametersStorage = undefined; } }],
-  ['Staking',                    { invalidate: (a) => { (a as any).contracts.staking = undefined; } }],
-  ['Token',                      { invalidate: (a) => { (a as any).contracts.token = undefined; } }],
-  ['AskStorage',                 { invalidate: (a) => { (a as any).contracts.askStorage = undefined; } }],
-  ['KnowledgeAssets',            { invalidate: (a) => { (a as any).contracts.knowledgeAssets = undefined; } }],
-  ['KnowledgeAssetsStorage',     { invalidate: (a) => { (a as any).contracts.knowledgeAssetsStorage = undefined; } }],
-  ['KnowledgeAssetsLifecycle',   { invalidate: (a) => { (a as any).contracts.knowledgeAssetsLifecycle = undefined; } }],
-  ['DKGKnowledgeAssets',         { invalidate: (a) => { (a as any).contracts.knowledgeAssetStorage = undefined; } }],
-  ['ContextGraphNameRegistry',   { invalidate: (a) => { (a as any).contracts.contextGraphNameRegistry = undefined; } }],
-  ['ContextGraphs',              { invalidate: (a) => { (a as any).contracts.contextGraphs = undefined; } }],
-  ['ContextGraphStorage',        { invalidate: (a) => { (a as any).contracts.contextGraphStorage = undefined; } }],
-  ['DKGPublishingConvictionNFT', { invalidate: (a) => { (a as any).contracts.dkgPublishingConvictionNFT = undefined; } }],
-  ['Chronos',                    { invalidate: (a) => { (a as any).contracts.chronos = undefined; } }],
+const BOOT_BOUND_CONTRACT_INVALIDATORS = new Map<string, ContractInvalidator>([
+  ['Identity',                   (a) => { (a as any).contracts.identity = undefined; }],
+  ['Profile',                    (a) => { (a as any).contracts.profile = undefined; }],
+  ['ProfileStorage',             (a) => { (a as any).contracts.profileStorage = undefined; }],
+  ['ParametersStorage',          (a) => { (a as any).contracts.parametersStorage = undefined; }],
+  ['Staking',                    (a) => { (a as any).contracts.staking = undefined; }],
+  ['Token',                      (a) => { (a as any).contracts.token = undefined; }],
+  ['AskStorage',                 (a) => { (a as any).contracts.askStorage = undefined; }],
+  ['KnowledgeAssets',            (a) => { (a as any).contracts.knowledgeAssets = undefined; }],
+  ['KnowledgeAssetsStorage',     (a) => { (a as any).contracts.knowledgeAssetsStorage = undefined; }],
+  ['KnowledgeAssetsLifecycle',   (a) => { (a as any).contracts.knowledgeAssetsLifecycle = undefined; }],
+  ['DKGKnowledgeAssets',         (a) => { (a as any).contracts.knowledgeAssetStorage = undefined; }],
+  ['ContextGraphNameRegistry',   (a) => { (a as any).contracts.contextGraphNameRegistry = undefined; }],
+  ['ContextGraphs',              (a) => { (a as any).contracts.contextGraphs = undefined; }],
+  ['ContextGraphStorage',        (a) => { (a as any).contracts.contextGraphStorage = undefined; }],
+  ['DKGPublishingConvictionNFT', (a) => { (a as any).contracts.dkgPublishingConvictionNFT = undefined; }],
+  ['Chronos',                    (a) => { (a as any).contracts.chronos = undefined; }],
+]);
+
+const LAZY_BINDING_INVALIDATORS = new Map<string, ContractInvalidator>([
+  ['IdentityStorage',            (a) => { (a as any).invalidateIdentityStorageBinding(); }],
 ]);
 
 const KA_HIGH_WATER_VIEW_SIGNATURE = 'getMaxKaNumberForAuthor(address)';
@@ -731,7 +724,7 @@ export class EVMChainAdapterBase {
     if (!ethers.isAddress(address)) return 0n;
     const checksum = ethers.getAddress(address);
     await this.init();
-    const identityStorage = await this.resolveContract('IdentityStorage');
+    const identityStorage = await this.getIdentityStorage();
     const id: bigint = await this.readContract(
       identityStorage, 'identityStorage.getIdentityId', 'getIdentityId', checksum,
     );
@@ -3185,13 +3178,13 @@ export class EVMChainAdapterBase {
    *      See the `randomSamplingPairCache` field comment for the
    *      coupling invariants this path preserves.
    *
-   *   2. Any name in `BOUND_CONTRACT_INVALIDATORS` with an explicit
-   *      rotation policy -> run that policy. `IdentityStorage` uses this
-   *      to clear its lazy storage binding and dependent identity cache.
+   *   2. Lazy bindings with dependent caches, currently `IdentityStorage`,
+   *      clear their lazy slot and dependent cache, then use the same rotation
+   *      finalization as boot-bound bindings.
    *
-   *   3. Any other name in `BOUND_CONTRACT_INVALIDATORS` -> leave the
-   *      existing `this.contracts.X` field intact but flip
-   *      `this.initialized` back to `false` so the next `await
+   *   3. Any name in `BOOT_BOUND_CONTRACT_INVALIDATORS` -> leave the existing
+   *      `this.contracts.X` field intact but flip `this.initialized` back to
+   *      `false` so the next `await
    *      this.init()` re-resolves every binding fresh from Hub. Keeping
    *      the old handle until the next init pass avoids a race where an
    *      in-flight public method already passed `init()` and then trips
@@ -3242,23 +3235,29 @@ export class EVMChainAdapterBase {
       this.invalidateRandomSamplingPair();
       return;
     }
-    const policy = BOUND_CONTRACT_INVALIDATORS.get(name);
-    if (policy?.onRotation) {
-      policy.onRotation(this);
+    const lazyInvalidator = LAZY_BINDING_INVALIDATORS.get(name);
+    if (lazyInvalidator) {
+      lazyInvalidator(this);
+      this.finalizeKnownHubRotation();
       return;
     }
-    if (policy) {
-      this.invalidatePublishPreflightCache();
-      // Force the next public-method entry through `init()` so it re-resolves
-      // every binding. Do not clear the current handle here: the callback can
-      // fire between a public method's `await init()` and its first
-      // `this.contracts.X` read.
-      this.initialized = false;
+    if (BOOT_BOUND_CONTRACT_INVALIDATORS.has(name)) {
+      this.finalizeKnownHubRotation();
     }
   }
 
+  protected finalizeKnownHubRotation(): void {
+    this.invalidatePublishPreflightCache();
+    // Force the next public-method entry through `init()` so it re-resolves
+    // every binding. Do not clear boot-bound handles here: the callback can
+    // fire between a public method's `await init()` and its first
+    // `this.contracts.X` read.
+    this.initialized = false;
+  }
+
   /**
-   * Drop every boot-bound contract handle and re-arm `init()`.
+   * Drop every boot-bound contract handle, lazy binding, and dependent cache,
+   * then re-arm `init()`.
    *
    * Used by `withHubStaleRetry` on the write-side self-heal path when
    * a Hub-rotated contract surfaces `UnauthorizedAccess(Only Contracts
@@ -3273,8 +3272,11 @@ export class EVMChainAdapterBase {
    * (in-flight probe, ready flag) that `init()` alone won't reset.
    */
   protected invalidateAllBoundContracts(): void {
-    for (const policy of BOUND_CONTRACT_INVALIDATORS.values()) {
-      policy.invalidate(this);
+    for (const invalidator of BOOT_BOUND_CONTRACT_INVALIDATORS.values()) {
+      invalidator(this);
+    }
+    for (const invalidator of LAZY_BINDING_INVALIDATORS.values()) {
+      invalidator(this);
     }
     this.invalidatePublishPreflightCache();
     this.invalidateRandomSamplingPair();

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -119,7 +119,9 @@ export const CG_REGISTRY_MAX_SCAN_PAGES = Math.ceil(
 
 export const CG_REGISTRY_REORG_BUFFER_BLOCKS = 50;
 
-const HUB_ROTATION_POLL_INTERVAL_MS = DEFAULT_RANDOM_SAMPLING_HUB_REFRESH_MS;
+// Keep generic Hub binding invalidation responsive for read paths while still
+// replacing four hidden ethers subscription pollers with one owned log poller.
+const HUB_ROTATION_POLL_INTERVAL_MS = 30 * 1000;
 const HUB_ROTATION_REORG_BUFFER_BLOCKS = 50;
 
 /**

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -44,8 +44,8 @@ import { RPC_READ_STALL_TIMEOUT_MS, DEFAULT_RANDOM_SAMPLING_HUB_REFRESH_MS, RPC_
  * the corresponding boot-bound field on `EVMChainAdapter.contracts`.
  *
  * Used by:
- *   1. `startHubRotationListener` — when a Hub rotation event fires
- *      for `name`, the listener checks this allowlist, marks the
+ *   1. `startHubRotationListener` — when the Hub rotation poller sees
+ *      `name`, it checks this allowlist, marks the
  *      adapter uninitialised, and leaves the existing handle intact so
  *      in-flight calls that already passed `init()` don't observe a
  *      transient `undefined`.
@@ -498,8 +498,8 @@ export class EVMChainAdapterBase {
    * has a defensive guard against. Resolving both names atomically
    * inside one cache eliminates that race.
    *
-   * See `HubResolutionCache` for the semantics; the listener
-   * installed in `init()` invalidates this cache on
+   * See `HubResolutionCache` for the semantics; the poller
+   * started in `init()` invalidates this cache on
    * `Hub.ContractChanged` / `Hub.NewContract` for **either** name,
    * and `withHubStaleRetry()` invalidates it when a write surfaces
    * `UnauthorizedAccess(Only Contracts in Hub)`.
@@ -2009,7 +2009,7 @@ export class EVMChainAdapterBase {
    * address fails loudly instead of reconciling from empty logs.
    */
   async getMaxKaNumberForAuthor(author: string): Promise<bigint> {
-    // Re-resolve contract handles first. The Hub-rotation listener flips
+    // Re-resolve contract handles first. The Hub rotation poller flips
     // `initialized` to false but leaves the old bindings in place, so without
     // this a long-lived adapter keeps querying the PRE-rotation
     // DKGKnowledgeAssets after the 10.0.4 redeploy this getter exists for.
@@ -3029,9 +3029,8 @@ export class EVMChainAdapterBase {
    * Used at write-side call sites that touch any of the redeployable
    * V10 contracts (PCA NFT, ContextGraphs, KnowledgeCollection, etc.)
    * so the FIRST write after a Hub rotation self-heals even when the
-   * event listener never fired (HTTP-only RPC endpoints, dropped
-   * subscriptions, rate-limited filter installs — all of which we
-   * see in the wild on public Base Sepolia / Gnosis Chain RPCs).
+   * low-cadence Hub poller has not observed the rotation yet, or when
+   * the RPC endpoint cannot serve log scans.
    *
    * Idempotency note: the wrapped closure MUST be safe to call twice.
    * That holds for our write paths because the on-chain side either
@@ -3085,7 +3084,7 @@ export class EVMChainAdapterBase {
   }
 
   /**
-   * Subscribe to Hub rotation events and invalidate the local cache for any
+   * Poll Hub rotation events and invalidate the local cache for any
    * Hub-rotated contract.
    *
    * Two invalidation paths, dispatched by name:
@@ -3144,12 +3143,6 @@ export class EVMChainAdapterBase {
     }
   }
 
-  protected async pollHubRotationEvents(): Promise<void> {
-    const hub = this.contracts.hub;
-    if (!hub) return;
-    await this.hubRotationPoller.poll(hub, await contractAddress(hub));
-  }
-
   protected applyHubRotationEventName(name: string): void {
     if (name === 'RandomSampling' || name === 'RandomSamplingStorage') {
       this.invalidateRandomSamplingPair();
@@ -3170,8 +3163,8 @@ export class EVMChainAdapterBase {
    *
    * Used by `withHubStaleRetry` on the write-side self-heal path when
    * a Hub-rotated contract surfaces `UnauthorizedAccess(Only Contracts
-   * in Hub)`: the listener may have missed the rotation event (HTTP-only
-   * RPC, dropped subscription, etc.) so the failing operation can't tell
+   * in Hub)`: the poller may not have observed the rotation yet (HTTP-only
+   * RPC, log-scan failure, etc.) so the failing operation can't tell
    * which specific name was rotated. Resetting everything is the safest
    * fallback — the next `await this.init()` re-resolves all 15+ bindings
    * in a single pass (still under a second on a healthy RPC) and the

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -951,7 +951,9 @@ export class EVMChainAdapterBase {
     method: string,
     ...args: unknown[]
   ): Promise<T> {
-    return this.rpcFailover.readContract(label, contract, (c) => c[method](...args));
+    return this.rpcFailover.readContract(label, contract, (c) => c[method](...args), {
+      rpcUsageConsumer: label,
+    });
   }
 
   /**
@@ -966,7 +968,10 @@ export class EVMChainAdapterBase {
     fn: (c: Contract) => Promise<T>,
     opts?: ReadOpts,
   ): Promise<T> {
-    return this.rpcFailover.readContract(label, contract, fn, opts);
+    return this.rpcFailover.readContract(label, contract, fn, {
+      ...opts,
+      rpcUsageConsumer: opts?.rpcUsageConsumer ?? label,
+    });
   }
 
   /**
@@ -981,7 +986,10 @@ export class EVMChainAdapterBase {
     fn: (provider: JsonRpcProvider) => Promise<T>,
     opts?: ReadOpts,
   ): Promise<T> {
-    return this.rpcFailover.read(label, fn, opts);
+    return this.rpcFailover.read(label, fn, {
+      ...opts,
+      rpcUsageConsumer: opts?.rpcUsageConsumer ?? label,
+    });
   }
 
   /**

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -61,33 +61,39 @@ import { RPC_READ_STALL_TIMEOUT_MS, DEFAULT_RANDOM_SAMPLING_HUB_REFRESH_MS, RPC_
  * `Hub.getContractAddress(name)` / `Hub.getAssetStorageAddress(name)`. Lazy
  * names listed here MUST match helpers such as `getIdentityStorage()`.
  */
-type HubBindingInvalidationPolicy = {
-  invalidate: (adapter: EVMChainAdapterBase) => void;
-  invalidateOnRotation?: (adapter: EVMChainAdapterBase) => void;
-};
+type ResettableContractCacheKey = {
+  [K in keyof ContractCache]: undefined extends ContractCache[K] ? K : never
+}[keyof ContractCache];
 
-const HUB_BINDING_INVALIDATORS = new Map<string, HubBindingInvalidationPolicy>([
-  ['Identity',                   { invalidate: (a) => { (a as any).contracts.identity = undefined; } }],
-  ['IdentityStorage',            {
-    invalidate: (a) => { (a as any).invalidateIdentityStorageBinding(); },
-    invalidateOnRotation: (a) => { (a as any).invalidateIdentityStorageBinding(); },
-  }],
-  ['Profile',                    { invalidate: (a) => { (a as any).contracts.profile = undefined; } }],
-  ['ProfileStorage',             { invalidate: (a) => { (a as any).contracts.profileStorage = undefined; } }],
-  ['ParametersStorage',          { invalidate: (a) => { (a as any).contracts.parametersStorage = undefined; } }],
-  ['Staking',                    { invalidate: (a) => { (a as any).contracts.staking = undefined; } }],
-  ['Token',                      { invalidate: (a) => { (a as any).contracts.token = undefined; } }],
-  ['AskStorage',                 { invalidate: (a) => { (a as any).contracts.askStorage = undefined; } }],
-  ['KnowledgeAssets',            { invalidate: (a) => { (a as any).contracts.knowledgeAssets = undefined; } }],
-  ['KnowledgeAssetsStorage',     { invalidate: (a) => { (a as any).contracts.knowledgeAssetsStorage = undefined; } }],
-  ['KnowledgeAssetsLifecycle',   { invalidate: (a) => { (a as any).contracts.knowledgeAssetsLifecycle = undefined; } }],
-  ['DKGKnowledgeAssets',         { invalidate: (a) => { (a as any).contracts.knowledgeAssetStorage = undefined; } }],
-  ['ContextGraphNameRegistry',   { invalidate: (a) => { (a as any).contracts.contextGraphNameRegistry = undefined; } }],
-  ['ContextGraphs',              { invalidate: (a) => { (a as any).contracts.contextGraphs = undefined; } }],
-  ['ContextGraphStorage',        { invalidate: (a) => { (a as any).contracts.contextGraphStorage = undefined; } }],
-  ['DKGPublishingConvictionNFT', { invalidate: (a) => { (a as any).contracts.dkgPublishingConvictionNFT = undefined; } }],
-  ['Chronos',                    { invalidate: (a) => { (a as any).contracts.chronos = undefined; } }],
-]);
+type HubContractCacheKey = Exclude<ResettableContractCacheKey, undefined>;
+
+type HubBindingInvalidationPolicy =
+  | { contractKey: HubContractCacheKey; invalidateOnRotation?: false }
+  | { special: 'identityStorage'; invalidateOnRotation: true };
+
+const HUB_BINDING_INVALIDATOR_ENTRIES = [
+  ['Identity',                   { contractKey: 'identity' }],
+  ['IdentityStorage',            { special: 'identityStorage', invalidateOnRotation: true }],
+  ['Profile',                    { contractKey: 'profile' }],
+  ['ProfileStorage',             { contractKey: 'profileStorage' }],
+  ['ParametersStorage',          { contractKey: 'parametersStorage' }],
+  ['Staking',                    { contractKey: 'staking' }],
+  ['Token',                      { contractKey: 'token' }],
+  ['AskStorage',                 { contractKey: 'askStorage' }],
+  ['KnowledgeAssets',            { contractKey: 'knowledgeAssets' }],
+  ['KnowledgeAssetsStorage',     { contractKey: 'knowledgeAssetsStorage' }],
+  ['KnowledgeAssetsLifecycle',   { contractKey: 'knowledgeAssetsLifecycle' }],
+  ['DKGKnowledgeAssets',         { contractKey: 'knowledgeAssetStorage' }],
+  ['ContextGraphNameRegistry',   { contractKey: 'contextGraphNameRegistry' }],
+  ['ContextGraphs',              { contractKey: 'contextGraphs' }],
+  ['ContextGraphStorage',        { contractKey: 'contextGraphStorage' }],
+  ['DKGPublishingConvictionNFT', { contractKey: 'dkgPublishingConvictionNFT' }],
+  ['Chronos',                    { contractKey: 'chronos' }],
+] as const satisfies ReadonlyArray<readonly [string, HubBindingInvalidationPolicy]>;
+
+const HUB_BINDING_INVALIDATORS = new Map<string, HubBindingInvalidationPolicy>(
+  HUB_BINDING_INVALIDATOR_ENTRIES,
+);
 
 const KA_HIGH_WATER_VIEW_SIGNATURE = 'getMaxKaNumberForAuthor(address)';
 
@@ -3266,8 +3272,20 @@ export class EVMChainAdapterBase {
     }
     const policy = HUB_BINDING_INVALIDATORS.get(name);
     if (!policy) return;
-    policy.invalidateOnRotation?.(this);
+    this.invalidateHubBindingOnRotation(policy);
     this.finalizeKnownHubRotation();
+  }
+
+  protected invalidateHubBindingOnRotation(policy: HubBindingInvalidationPolicy): void {
+    if (policy.invalidateOnRotation) this.invalidateHubBinding(policy);
+  }
+
+  protected invalidateHubBinding(policy: HubBindingInvalidationPolicy): void {
+    if ('contractKey' in policy) {
+      this.contracts[policy.contractKey] = undefined;
+      return;
+    }
+    if (policy.special === 'identityStorage') this.invalidateIdentityStorageBinding();
   }
 
   protected finalizeKnownHubRotation(): void {
@@ -3297,7 +3315,7 @@ export class EVMChainAdapterBase {
    */
   protected invalidateAllBoundContracts(): void {
     for (const policy of HUB_BINDING_INVALIDATORS.values()) {
-      policy.invalidate(this);
+      this.invalidateHubBinding(policy);
     }
     this.invalidatePublishPreflightCache();
     this.invalidateRandomSamplingPair();

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -35,6 +35,7 @@ import { computeApprovalAction, effectivePublishAllowance, V10_PUBLISH_ONCHAIN_M
 import { formatProviderContext } from './evm-adapter-types.js';
 import { ReadThroughTtlCache } from './keyed-ttl-single-flight-cache.js';
 import { PcaReadCache } from './pca-read-cache.js';
+import { HubRotationPoller } from './hub-rotation-poller.js';
 import type { ContractCache, EVMAdapterConfig } from './evm-adapter-types.js';
 import { RPC_READ_STALL_TIMEOUT_MS, DEFAULT_RANDOM_SAMPLING_HUB_REFRESH_MS, RPC_RECEIPT_TIMEOUT_MS, RPC_RECEIPT_POLL_INTERVAL_MS, RPC_ENDPOINT_SET_RETRIES, RPC_ENDPOINT_SET_RETRY_BACKOFF_MS, ADMIN_KEY_PURPOSE, OPERATIONAL_KEY_PURPOSE, PUBLISHER_FUNDING_CACHE_TTL_MS } from './evm-adapter-constants.js';
 
@@ -117,8 +118,6 @@ export const CG_REGISTRY_MAX_SCAN_PAGES = Math.ceil(
 );
 
 export const CG_REGISTRY_REORG_BUFFER_BLOCKS = 50;
-
-export const CG_REGISTRY_LIVE_TAIL_LOOKBACK_BLOCKS = 9_000;
 
 const HUB_ROTATION_POLL_INTERVAL_MS = DEFAULT_RANDOM_SAMPLING_HUB_REFRESH_MS;
 const HUB_ROTATION_REORG_BUFFER_BLOCKS = 50;
@@ -528,11 +527,7 @@ export class EVMChainAdapterBase {
 
   protected hubRotationListenerStarted = false;
 
-  protected hubRotationPollTimer: ReturnType<typeof setInterval> | null = null;
-
-  protected hubRotationPollInFlight: Promise<void> | null = null;
-
-  protected hubRotationLastScannedBlock: number | undefined;
+  protected readonly hubRotationPoller: HubRotationPoller;
 
   /**
    * Single-flight guard for the best-effort
@@ -796,6 +791,12 @@ export class EVMChainAdapterBase {
       () => this.chainId,
       async (endpoint) => { await this.ensureConfiguredStaticChainIdValidated(endpoint.provider); },
     );
+    this.hubRotationPoller = new HubRotationPoller({
+      readProvider: (label, fn, opts) => this.readProvider(label, fn, opts),
+      intervalMs: HUB_ROTATION_POLL_INTERVAL_MS,
+      reorgBufferBlocks: HUB_ROTATION_REORG_BUFFER_BLOCKS,
+      onContractName: (name) => this.applyHubRotationEventName(name),
+    });
     const providerContext = formatProviderContext(config);
     // PR-8: install the filter-not-found silencer. Without this, RPC
     // nodes that GC filters faster than ethers' polling cadence
@@ -3132,15 +3133,8 @@ export class EVMChainAdapterBase {
   protected async startHubRotationListener(): Promise<void> {
     if (this.hubRotationListenerStarted) return;
     try {
-      await this.pollHubRotationEvents();
-      this.hubRotationPollTimer = setInterval(() => {
-        if (this.hubRotationPollInFlight) return;
-        this.hubRotationPollInFlight = this.pollHubRotationEvents()
-          .catch(() => { /* optional listener path */ })
-          .finally(() => { this.hubRotationPollInFlight = null; });
-      }, HUB_ROTATION_POLL_INTERVAL_MS);
-      if (this.hubRotationPollTimer.unref) this.hubRotationPollTimer.unref();
-      this.hubRotationListenerStarted = true;
+      await this.hubRotationPoller.start(this.contracts.hub);
+      this.hubRotationListenerStarted = this.hubRotationPoller.isStarted;
     } catch {
       /* provider doesn't support log polling — TTL refresh (RS)
        * and `withHubStaleRetry` (writes) are the fallbacks */
@@ -3150,62 +3144,7 @@ export class EVMChainAdapterBase {
   protected async pollHubRotationEvents(): Promise<void> {
     const hub = this.contracts.hub;
     if (!hub) return;
-
-    const topics = this.hubRotationEventTopics(hub);
-    if (topics.length === 0) return;
-
-    const head = await this.readProvider(
-      'Hub rotation poll getBlockNumber',
-      (provider) => provider.getBlockNumber(),
-    );
-    const candidateFromBlock = this.hubRotationLastScannedBlock == null
-      ? head - HUB_ROTATION_REORG_BUFFER_BLOCKS
-      : this.hubRotationLastScannedBlock + 1 - HUB_ROTATION_REORG_BUFFER_BLOCKS;
-    const recentFromBlock = head - HUB_ROTATION_REORG_BUFFER_BLOCKS;
-    const fromBlock = Math.max(
-      0,
-      Math.min(candidateFromBlock, recentFromBlock),
-    );
-    const hubAddress = await this.hubContractAddress(hub);
-    const logs = await this.readProvider<ethers.Log[]>(
-      'Hub rotation poll getLogs',
-      (provider) => provider.getLogs({
-        address: hubAddress,
-        fromBlock,
-        toBlock: head,
-        topics: [topics],
-      }),
-      { policy: 'wideLogScan' },
-    );
-
-    for (const log of logs) {
-      try {
-        const parsed = hub.interface.parseLog({ topics: [...log.topics], data: log.data });
-        if (!parsed) continue;
-        this.applyHubRotationEventName(parsed.args?.contractName ?? parsed.args?.[0]);
-      } catch {
-        // Ignore malformed/unexpected Hub logs. The topic filter should already
-        // constrain these, but a parse miss must not wedge the poll cursor.
-      }
-    }
-    this.hubRotationLastScannedBlock = head;
-  }
-
-  protected hubRotationEventTopics(hub: Contract): string[] {
-    return [
-      'ContractChanged',
-      'NewContract',
-      'AssetStorageChanged',
-      'NewAssetStorage',
-    ].flatMap((eventName) => {
-      const event = hub.interface.getEvent(eventName);
-      return event?.topicHash ? [event.topicHash] : [];
-    });
-  }
-
-  protected async hubContractAddress(hub: Contract): Promise<string> {
-    const target = (hub as unknown as { target?: unknown }).target;
-    return typeof target === 'string' ? target : hub.getAddress();
+    await this.hubRotationPoller.poll(hub);
   }
 
   protected applyHubRotationEventName(name: unknown): void {
@@ -3278,10 +3217,7 @@ export class EVMChainAdapterBase {
    * so destroying once flushes everything).
    */
   destroy(): void {
-    if (this.hubRotationPollTimer) {
-      clearInterval(this.hubRotationPollTimer);
-      this.hubRotationPollTimer = null;
-    }
+    this.hubRotationPoller.stop();
     this.hubRotationListenerStarted = false;
     for (const provider of this.providers) {
       try { provider.destroy(); } catch { /* already destroyed / not destroyable */ }

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -527,8 +527,6 @@ export class EVMChainAdapterBase {
 
   protected readonly pcaReadCache = new PcaReadCache();
 
-  protected hubRotationListenerStarted = false;
-
   protected readonly hubRotationPoller: HubRotationPoller;
 
   /**
@@ -3132,13 +3130,12 @@ export class EVMChainAdapterBase {
    * rotation detection without four hidden idle log streams.
    */
   protected async startHubRotationListener(): Promise<void> {
-    if (this.hubRotationListenerStarted) return;
+    if (this.hubRotationPoller.isStarted) return;
     try {
       await this.hubRotationPoller.start(
         this.contracts.hub,
         await contractAddress(this.contracts.hub),
       );
-      this.hubRotationListenerStarted = this.hubRotationPoller.isStarted;
     } catch {
       /* provider doesn't support log polling — TTL refresh (RS)
        * and `withHubStaleRetry` (writes) are the fallbacks */
@@ -3215,7 +3212,6 @@ export class EVMChainAdapterBase {
    */
   destroy(): void {
     this.hubRotationPoller.stop();
-    this.hubRotationListenerStarted = false;
     for (const provider of this.providers) {
       try { provider.destroy(); } catch { /* already destroyed / not destroyable */ }
     }

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -3136,9 +3136,10 @@ export class EVMChainAdapterBase {
         this.contracts.hub,
         await contractAddress(this.contracts.hub),
       );
-    } catch {
-      /* provider doesn't support log polling — TTL refresh (RS)
-       * and `withHubStaleRetry` (writes) are the fallbacks */
+    } catch (err) {
+      console.warn(
+        `[chain] Hub rotation poller setup disabled: ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
   }
 

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -3147,8 +3147,7 @@ export class EVMChainAdapterBase {
     await this.hubRotationPoller.poll(hub);
   }
 
-  protected applyHubRotationEventName(name: unknown): void {
-    if (typeof name !== 'string') return;
+  protected applyHubRotationEventName(name: string): void {
     if (name === 'RandomSampling' || name === 'RandomSamplingStorage') {
       this.invalidateRandomSamplingPair();
       return;

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -9,11 +9,23 @@
  * via applyMixins(); see evm-adapter.ts for the assembly.
  */
 
-import { EVMChainAdapterBase, CG_REGISTRY_MAX_SCAN_PAGES, CG_REGISTRY_REORG_BUFFER_BLOCKS } from './evm-adapter-base.js';
+import {
+  EVMChainAdapterBase,
+  CG_REGISTRY_LIVE_TAIL_LOOKBACK_BLOCKS,
+  CG_REGISTRY_MAX_SCAN_PAGES,
+  CG_REGISTRY_REORG_BUFFER_BLOCKS,
+} from './evm-adapter-base.js';
 import { isTooLowAllowanceError } from './evm-adapter-errors.js';
 import { ethers, Contract, type JsonRpcProvider } from 'ethers';
 import { ContextGraphChainScanPartialError, type CreateContextGraphParams, type TxResult, type ContextGraphOnChain, type ContextGraphChainScanOptions, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type VerifyParams, type PublishToContextGraphParams, type OnChainPublishResult } from './chain-adapter.js';
 import { buildAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1 } from '@origintrail-official/dkg-core';
+
+function normalizeLiveTailLookbackBlocks(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return CG_REGISTRY_LIVE_TAIL_LOOKBACK_BLOCKS;
+  }
+  return Math.max(0, Math.floor(value));
+}
 
 export class ContextGraphMethods extends EVMChainAdapterBase {
   /**
@@ -123,14 +135,16 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     const eventFilter = registry.filters.NameClaimed();
     const registryAddress = (await registry.getAddress()).toLowerCase();
     const incremental = options?.incremental === true && fromBlock === undefined;
+    const liveTailOnly = options?.liveTailOnly === true && fromBlock === undefined && !incremental;
     const seedIncrementalWatermark =
       options?.seedIncrementalWatermark === true && !incremental && fromBlock === undefined;
+    const liveTailLookback = normalizeLiveTailLookbackBlocks(options?.liveTailLookbackBlocks);
     const watermark = incremental
       ? this.contextGraphRegistryScanWatermarks.get(registryAddress)
       : undefined;
     const scan =
       fromBlock === undefined
-        ? incremental && watermark !== undefined
+        ? liveTailOnly || (incremental && watermark !== undefined)
           ? { fromBlock: 0, ...(await this.resolveLogScanHead('listContextGraphsFromChain')) }
           : await this.resolveContractDeployBlock(
               registryAddress,
@@ -140,7 +154,9 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
         : { fromBlock, ...(await this.resolveLogScanHead('listContextGraphsFromChain')) };
     const { fromBlock: deployBlock, head, scanProviders, degradedFromGenesis = false } = scan;
     const start = fromBlock ?? (
-      incremental && watermark !== undefined
+      liveTailOnly
+        ? liveTailLookback <= 0 ? head + 1 : Math.max(0, head - liveTailLookback + 1)
+        : incremental && watermark !== undefined
         ? Math.max(0, watermark - CG_REGISTRY_REORG_BUFFER_BLOCKS)
         : deployBlock
     );
@@ -154,9 +170,10 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     const pageSize = this.cgRegistryScanPageSize;
     const pages = Math.ceil((head - start + 1) / pageSize);
     const blockBudget = CG_REGISTRY_MAX_SCAN_PAGES * pageSize;
-    if (incremental && !degradedFromGenesis && pages > CG_REGISTRY_MAX_SCAN_PAGES) {
+    if ((incremental || liveTailOnly) && !degradedFromGenesis && pages > CG_REGISTRY_MAX_SCAN_PAGES) {
+      const scanKind = liveTailOnly ? 'live-tail' : 'incremental';
       throw new Error(
-        `listContextGraphsFromChain: incremental ContextGraphNameRegistry scan would need ` +
+        `listContextGraphsFromChain: ${scanKind} ContextGraphNameRegistry scan would need ` +
           `${pages} eth_getLogs calls over blocks [${start}, ${head}] at a ` +
           `${pageSize}-block window (budget ${CG_REGISTRY_MAX_SCAN_PAGES} pages / ` +
           `${blockBudget} blocks). ` +
@@ -171,8 +188,8 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     let preferred: JsonRpcProvider | undefined;
     let scannedAnyPage = false;
 
-    // Incremental daemon scans can resume from the scanned prefix after a later
-    // page failure. Public list-all calls should remain all-or-error.
+    // Daemon scans can surface scanned-prefix results after a later page
+    // failure. Public list-all calls should remain all-or-error.
     for (let lo = start; lo <= head; lo += pageSize) {
       const hi = Math.min(lo + pageSize - 1, head);
       try {
@@ -205,7 +222,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
           this.contextGraphRegistryScanWatermarks.set(registryAddress, hi + 1);
         }
       } catch (err) {
-        if (incremental && scannedAnyPage) {
+        if ((incremental || liveTailOnly) && scannedAnyPage) {
           const message = err instanceof Error ? err.message : String(err);
           throw new ContextGraphChainScanPartialError(
             `listContextGraphsFromChain: partial ContextGraphNameRegistry scan ` +

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -472,7 +472,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
 
     // Unreachable below (kept for type-completeness until the mirror is removed);
     // the unsupported-mirror guard above throws before any on-chain side effect.
-    const v10ChainId = (await this.readProvider('getNetwork (chainId)', (p) => p.getNetwork())).chainId;
+    const v10ChainId = await this.getEvmChainId();
     const v10KavAddress = await this.contracts.knowledgeAssetsLifecycle!.getAddress();
     const authorTypedData = buildAuthorAttestationTypedData({
       chainId: v10ChainId,

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -11,7 +11,6 @@
 
 import {
   EVMChainAdapterBase,
-  CG_REGISTRY_LIVE_TAIL_LOOKBACK_BLOCKS,
   CG_REGISTRY_MAX_SCAN_PAGES,
   CG_REGISTRY_REORG_BUFFER_BLOCKS,
 } from './evm-adapter-base.js';
@@ -19,13 +18,6 @@ import { isTooLowAllowanceError } from './evm-adapter-errors.js';
 import { ethers, Contract, type JsonRpcProvider } from 'ethers';
 import { ContextGraphChainScanPartialError, type CreateContextGraphParams, type TxResult, type ContextGraphOnChain, type ContextGraphChainScanOptions, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type VerifyParams, type PublishToContextGraphParams, type OnChainPublishResult } from './chain-adapter.js';
 import { buildAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1 } from '@origintrail-official/dkg-core';
-
-function normalizeLiveTailLookbackBlocks(value: unknown): number {
-  if (typeof value !== 'number' || !Number.isFinite(value)) {
-    return CG_REGISTRY_LIVE_TAIL_LOOKBACK_BLOCKS;
-  }
-  return Math.max(0, Math.floor(value));
-}
 
 export class ContextGraphMethods extends EVMChainAdapterBase {
   /**
@@ -135,16 +127,14 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     const eventFilter = registry.filters.NameClaimed();
     const registryAddress = (await registry.getAddress()).toLowerCase();
     const incremental = options?.incremental === true && fromBlock === undefined;
-    const liveTailOnly = options?.liveTailOnly === true && fromBlock === undefined && !incremental;
     const seedIncrementalWatermark =
       options?.seedIncrementalWatermark === true && !incremental && fromBlock === undefined;
-    const liveTailLookback = normalizeLiveTailLookbackBlocks(options?.liveTailLookbackBlocks);
     const watermark = incremental
       ? this.contextGraphRegistryScanWatermarks.get(registryAddress)
       : undefined;
     const scan =
       fromBlock === undefined
-        ? liveTailOnly || (incremental && watermark !== undefined)
+        ? incremental && watermark !== undefined
           ? { fromBlock: 0, ...(await this.resolveLogScanHead('listContextGraphsFromChain')) }
           : await this.resolveContractDeployBlock(
               registryAddress,
@@ -154,9 +144,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
         : { fromBlock, ...(await this.resolveLogScanHead('listContextGraphsFromChain')) };
     const { fromBlock: deployBlock, head, scanProviders, degradedFromGenesis = false } = scan;
     const start = fromBlock ?? (
-      liveTailOnly
-        ? liveTailLookback <= 0 ? head + 1 : Math.max(0, head - liveTailLookback + 1)
-        : incremental && watermark !== undefined
+      incremental && watermark !== undefined
         ? Math.max(0, watermark - CG_REGISTRY_REORG_BUFFER_BLOCKS)
         : deployBlock
     );
@@ -170,10 +158,9 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     const pageSize = this.cgRegistryScanPageSize;
     const pages = Math.ceil((head - start + 1) / pageSize);
     const blockBudget = CG_REGISTRY_MAX_SCAN_PAGES * pageSize;
-    if ((incremental || liveTailOnly) && !degradedFromGenesis && pages > CG_REGISTRY_MAX_SCAN_PAGES) {
-      const scanKind = liveTailOnly ? 'live-tail' : 'incremental';
+    if (incremental && !degradedFromGenesis && pages > CG_REGISTRY_MAX_SCAN_PAGES) {
       throw new Error(
-        `listContextGraphsFromChain: ${scanKind} ContextGraphNameRegistry scan would need ` +
+        `listContextGraphsFromChain: incremental ContextGraphNameRegistry scan would need ` +
           `${pages} eth_getLogs calls over blocks [${start}, ${head}] at a ` +
           `${pageSize}-block window (budget ${CG_REGISTRY_MAX_SCAN_PAGES} pages / ` +
           `${blockBudget} blocks). ` +
@@ -188,8 +175,8 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     let preferred: JsonRpcProvider | undefined;
     let scannedAnyPage = false;
 
-    // Daemon scans can surface scanned-prefix results after a later page
-    // failure. Public list-all calls should remain all-or-error.
+    // Incremental daemon scans can resume from the scanned prefix after a later
+    // page failure. Public list-all calls should remain all-or-error.
     for (let lo = start; lo <= head; lo += pageSize) {
       const hi = Math.min(lo + pageSize - 1, head);
       try {
@@ -222,7 +209,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
           this.contextGraphRegistryScanWatermarks.set(registryAddress, hi + 1);
         }
       } catch (err) {
-        if ((incremental || liveTailOnly) && scannedAnyPage) {
+        if (incremental && scannedAnyPage) {
           const message = err instanceof Error ? err.message : String(err);
           throw new ContextGraphChainScanPartialError(
             `listContextGraphsFromChain: partial ContextGraphNameRegistry scan ` +

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -16,8 +16,157 @@ import {
 } from './evm-adapter-base.js';
 import { isTooLowAllowanceError } from './evm-adapter-errors.js';
 import { ethers, Contract, type JsonRpcProvider } from 'ethers';
-import { ContextGraphChainScanPartialError, type CreateContextGraphParams, type TxResult, type ContextGraphOnChain, type ContextGraphChainScanOptions, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type VerifyParams, type PublishToContextGraphParams, type OnChainPublishResult } from './chain-adapter.js';
+import { ContextGraphChainScanPartialError, type CreateContextGraphParams, type TxResult, type ContextGraphOnChain, type ContextGraphChainScanOptions, type ContextGraphRegistryScanOptions, type ContextGraphRegistryScanPage, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type VerifyParams, type PublishToContextGraphParams, type OnChainPublishResult } from './chain-adapter.js';
 import { buildAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1 } from '@origintrail-official/dkg-core';
+
+type ContextGraphRegistryScanPlan =
+  | {
+      mode: 'explicitFromBlock' | 'listAll';
+      resumeFromWatermark: false;
+      persistProgress: false;
+      allowPartialFailure: false;
+      seedAtEnd: false;
+      pageBudget?: undefined;
+    }
+  | {
+      mode: 'incremental';
+      resumeFromWatermark: true;
+      persistProgress: true;
+      allowPartialFailure: true;
+      seedAtEnd: false;
+      pageBudget?: number;
+    }
+  | {
+      mode: 'seedFull';
+      resumeFromWatermark: false;
+      persistProgress: true;
+      allowPartialFailure: true;
+      seedAtEnd: true;
+      pageBudget?: undefined;
+    }
+  | {
+      mode: 'seedFromCursor';
+      resumeFromWatermark: true;
+      persistProgress: true;
+      allowPartialFailure: true;
+      seedAtEnd: true;
+      pageBudget?: number;
+    };
+
+function normalizePageBudget(value: number | undefined): number | undefined {
+  return Number.isFinite(value) && (value ?? 0) >= 1
+    ? Math.floor(value ?? 0)
+    : undefined;
+}
+
+function buildPublicContextGraphRegistryScanPlan(
+  fromBlock: number | undefined,
+  options: ContextGraphChainScanOptions | undefined,
+): ContextGraphRegistryScanPlan {
+  const runtimeOptions = options as
+    | (ContextGraphChainScanOptions & { mode?: string })
+    | undefined;
+  const mode = runtimeOptions?.mode;
+
+  if (fromBlock !== undefined) {
+    return {
+      mode: 'explicitFromBlock',
+      resumeFromWatermark: false,
+      persistProgress: false,
+      allowPartialFailure: false,
+      seedAtEnd: false,
+    };
+  }
+
+  if (runtimeOptions && 'incremental' in runtimeOptions && runtimeOptions.incremental === true) {
+    return {
+      mode: 'incremental',
+      resumeFromWatermark: true,
+      persistProgress: true,
+      allowPartialFailure: true,
+      seedAtEnd: false,
+      pageBudget: normalizePageBudget(runtimeOptions.pageBudget),
+    };
+  }
+
+  if (
+    runtimeOptions &&
+    'seedIncrementalWatermark' in runtimeOptions &&
+    runtimeOptions.seedIncrementalWatermark === true
+  ) {
+    if (runtimeOptions.resumeFromCursor === true) {
+      return {
+        mode: 'seedFromCursor',
+        resumeFromWatermark: true,
+        persistProgress: true,
+        allowPartialFailure: true,
+        seedAtEnd: true,
+        pageBudget: normalizePageBudget(runtimeOptions.pageBudget),
+      };
+    }
+    return {
+      mode: 'seedFull',
+      resumeFromWatermark: false,
+      persistProgress: true,
+      allowPartialFailure: true,
+      seedAtEnd: true,
+    };
+  }
+
+  if (mode !== undefined && mode !== 'listAll') {
+    throw new Error(
+      'listContextGraphsFromChain accepts only listAll or legacy boolean scan options; ' +
+      'use scanContextGraphRegistryPages for cursor-backed daemon scans.',
+    );
+  }
+
+  return {
+    mode: 'listAll',
+    resumeFromWatermark: false,
+    persistProgress: false,
+    allowPartialFailure: false,
+    seedAtEnd: false,
+  };
+}
+
+function buildCursorContextGraphRegistryScanPlan(
+  options: ContextGraphRegistryScanOptions,
+): ContextGraphRegistryScanPlan {
+  if (options.mode === 'incremental') {
+    return {
+      mode: 'incremental',
+      resumeFromWatermark: true,
+      persistProgress: true,
+      allowPartialFailure: true,
+      seedAtEnd: false,
+      pageBudget: normalizePageBudget(options.pageBudget),
+    };
+  }
+
+  if (options?.mode === 'seedFull') {
+    return {
+      mode: 'seedFull',
+      resumeFromWatermark: false,
+      persistProgress: true,
+      allowPartialFailure: true,
+      seedAtEnd: true,
+    };
+  }
+
+  if (options?.mode === 'seedFromCursor') {
+    return {
+      mode: 'seedFromCursor',
+      resumeFromWatermark: true,
+      persistProgress: true,
+      allowPartialFailure: true,
+      seedAtEnd: true,
+      pageBudget: normalizePageBudget(options.pageBudget),
+    };
+  }
+
+  const exhaustive: never = options;
+  throw new Error(`Unsupported ContextGraphNameRegistry scan mode: ${JSON.stringify(exhaustive)}`);
+}
 
 export class ContextGraphMethods extends EVMChainAdapterBase {
   /**
@@ -114,7 +263,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     const registry = this.contracts.contextGraphNameRegistry;
     if (!registry) return false;
     const registryAddress = (await registry.getAddress()).toLowerCase();
-    return this.contextGraphRegistryScanWatermarks.has(registryAddress);
+    return (await this.contextGraphRegistryScanCursor.loadWatermark(registryAddress)) != null;
   }
 
   async listContextGraphsFromChain(
@@ -124,17 +273,55 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     await this.init();
     const registry = this.contracts.contextGraphNameRegistry;
     if (!registry) return [];
-    const eventFilter = registry.filters.NameClaimed();
     const registryAddress = (await registry.getAddress()).toLowerCase();
-    const incremental = options?.incremental === true && fromBlock === undefined;
-    const seedIncrementalWatermark =
-      options?.seedIncrementalWatermark === true && !incremental && fromBlock === undefined;
-    const watermark = incremental
-      ? this.contextGraphRegistryScanWatermarks.get(registryAddress)
+    const scanPlan = buildPublicContextGraphRegistryScanPlan(fromBlock, options);
+    return this._collectContextGraphRegistryScan(registry, registryAddress, fromBlock, scanPlan);
+  }
+
+  async *scanContextGraphRegistryPages(
+    options: ContextGraphRegistryScanOptions,
+  ): AsyncIterable<ContextGraphRegistryScanPage> {
+    await this.init();
+    const registry = this.contracts.contextGraphNameRegistry;
+    if (!registry) return;
+    const registryAddress = (await registry.getAddress()).toLowerCase();
+    const scanPlan = buildCursorContextGraphRegistryScanPlan(options);
+    yield* this._iterateContextGraphRegistryScanPages(registry, registryAddress, undefined, scanPlan);
+  }
+
+  async _collectContextGraphRegistryScan(
+    registry: Contract,
+    registryAddress: string,
+    fromBlock: number | undefined,
+    scanPlan: ContextGraphRegistryScanPlan,
+  ): Promise<ContextGraphOnChain[]> {
+    const results: ContextGraphOnChain[] = [];
+    for await (const page of this._iterateContextGraphRegistryScanPages(
+      registry,
+      registryAddress,
+      fromBlock,
+      scanPlan,
+    )) {
+      results.push(...page.contextGraphs);
+      await page.ack();
+    }
+    return results;
+  }
+
+  async *_iterateContextGraphRegistryScanPages(
+    registry: Contract,
+    registryAddress: string,
+    fromBlock: number | undefined,
+    scanPlan: ContextGraphRegistryScanPlan,
+  ): AsyncGenerator<ContextGraphRegistryScanPage, void, unknown> {
+    const eventFilter = registry.filters.NameClaimed();
+    const persistedWatermark = (scanPlan.resumeFromWatermark || scanPlan.seedAtEnd)
+      ? await this.contextGraphRegistryScanCursor.loadWatermark(registryAddress)
       : undefined;
+    const canResumeFromWatermark = scanPlan.resumeFromWatermark && persistedWatermark !== undefined;
     const scan =
       fromBlock === undefined
-        ? incremental && watermark !== undefined
+        ? canResumeFromWatermark
           ? { fromBlock: 0, ...(await this.resolveLogScanHead('listContextGraphsFromChain')) }
           : await this.resolveContractDeployBlock(
               registryAddress,
@@ -144,21 +331,21 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
         : { fromBlock, ...(await this.resolveLogScanHead('listContextGraphsFromChain')) };
     const { fromBlock: deployBlock, head, scanProviders, degradedFromGenesis = false } = scan;
     const start = fromBlock ?? (
-      incremental && watermark !== undefined
-        ? Math.max(0, watermark - CG_REGISTRY_REORG_BUFFER_BLOCKS)
+      canResumeFromWatermark
+        ? Math.max(0, persistedWatermark - CG_REGISTRY_REORG_BUFFER_BLOCKS)
         : deployBlock
     );
     if (start > head) {
-      if (seedIncrementalWatermark) {
-        this.contextGraphRegistryScanWatermarks.set(registryAddress, head + 1);
+      if (scanPlan.seedAtEnd) {
+        await this.contextGraphRegistryScanCursor.saveWatermark(registryAddress, head + 1);
       }
-      return [];
+      return;
     }
 
     const pageSize = this.cgRegistryScanPageSize;
     const pages = Math.ceil((head - start + 1) / pageSize);
     const blockBudget = CG_REGISTRY_MAX_SCAN_PAGES * pageSize;
-    if (incremental && !degradedFromGenesis && pages > CG_REGISTRY_MAX_SCAN_PAGES) {
+    if (scanPlan.mode === 'incremental' && scanPlan.pageBudget === undefined && !degradedFromGenesis && pages > CG_REGISTRY_MAX_SCAN_PAGES) {
       throw new Error(
         `listContextGraphsFromChain: incremental ContextGraphNameRegistry scan would need ` +
           `${pages} eth_getLogs calls over blocks [${start}, ${head}] at a ` +
@@ -175,10 +362,11 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     let preferred: JsonRpcProvider | undefined;
     let scannedAnyPage = false;
 
-    // Incremental daemon scans can resume from the scanned prefix after a later
-    // page failure. Public list-all calls should remain all-or-error.
+    // Daemon scans can resume from the scanned prefix after a later page
+    // failure. Public list-all calls should remain all-or-error.
     for (let lo = start; lo <= head; lo += pageSize) {
       const hi = Math.min(lo + pageSize - 1, head);
+      let pageResults: ContextGraphOnChain[];
       try {
         const page = await this.queryEventLogsPage(
           registry,
@@ -191,7 +379,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
           preferred,
         );
         preferred = page.provider;
-        const pageResults: ContextGraphOnChain[] = [];
+        pageResults = [];
         for (const log of page.logs) {
           const parsed = registry.interface.parseLog({ topics: [...log.topics], data: log.data });
           if (!parsed || parsed.name !== 'NameClaimed') continue;
@@ -203,13 +391,8 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
             metadataRevealed: false,
           });
         }
-        results.push(...pageResults);
-        scannedAnyPage = true;
-        if (incremental) {
-          this.contextGraphRegistryScanWatermarks.set(registryAddress, hi + 1);
-        }
       } catch (err) {
-        if (incremental && scannedAnyPage) {
+        if (scanPlan.allowPartialFailure && scannedAnyPage) {
           const message = err instanceof Error ? err.message : String(err);
           throw new ContextGraphChainScanPartialError(
             `listContextGraphsFromChain: partial ContextGraphNameRegistry scan ` +
@@ -225,13 +408,19 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
         }
         throw err;
       }
+      results.push(...pageResults);
+      scannedAnyPage = true;
+      yield {
+        contextGraphs: pageResults,
+        ack: scanPlan.persistProgress
+          ? async () => {
+              await this.contextGraphRegistryScanCursor.saveWatermark(registryAddress, hi + 1);
+            }
+          : async () => {},
+      };
+      const scannedPages = Math.floor((hi - start) / pageSize) + 1;
+      if (scanPlan.pageBudget !== undefined && scannedPages >= scanPlan.pageBudget && hi < head) return;
     }
-
-    if (seedIncrementalWatermark) {
-      this.contextGraphRegistryScanWatermarks.set(registryAddress, head + 1);
-    }
-
-    return results;
   }
 
   // =====================================================================

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -289,7 +289,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     yield* this._iterateContextGraphRegistryScanPages(registry, registryAddress, undefined, scanPlan);
   }
 
-  async _collectContextGraphRegistryScan(
+  private async _collectContextGraphRegistryScan(
     registry: Contract,
     registryAddress: string,
     fromBlock: number | undefined,
@@ -308,7 +308,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     return results;
   }
 
-  async *_iterateContextGraphRegistryScanPages(
+  private async *_iterateContextGraphRegistryScanPages(
     registry: Contract,
     registryAddress: string,
     fromBlock: number | undefined,

--- a/packages/chain/src/evm-adapter-conviction.ts
+++ b/packages/chain/src/evm-adapter-conviction.ts
@@ -23,6 +23,7 @@ import type {
 } from './chain-adapter.js';
 import { PcaUnavailableError } from './pca-errors.js';
 import { enrichEvmError, getPcaLogicInterface } from './evm-adapter-errors.js';
+import type { PcaMutationInvalidation } from './pca-read-cache.js';
 
 export interface RawShardingTableNode extends ArrayLike<unknown> {
   nodeId?: unknown;
@@ -41,6 +42,15 @@ export function toShardingTableNode(raw: RawShardingTableNode): ShardingTableNod
 }
 
 export class ConvictionMethods extends EVMChainAdapterBase implements ConvictionReader {
+  protected async pcaWriteAndInvalidate<T>(
+    invalidation: PcaMutationInvalidation<T>,
+    op: () => Promise<T>,
+  ): Promise<T> {
+    const result = await this.pcaWrite(op);
+    this.pcaReadCache.invalidateMutation(invalidation, result);
+    return result;
+  }
+
   // =====================================================================
   // Staking + Publishing Conviction Account legacy surface — ARCHIVED
   /**
@@ -64,7 +74,8 @@ export class ConvictionMethods extends EVMChainAdapterBase implements Conviction
     opts?: { strict?: boolean },
   ): Promise<bigint> {
     await this.init();
-    if (!this.contracts.dkgPublishingConvictionNFT) {
+    const convictionNft = this.contracts.dkgPublishingConvictionNFT;
+    if (!convictionNft) {
       // Selector fail-safe: "no PCA contract on this chain" → "no PCA path"
       // (0n), so publishing stays on direct-spend. The discovery path (strict)
       // surfaces it instead, so the daemon answers 503 rather than letting a UI
@@ -73,21 +84,24 @@ export class ConvictionMethods extends EVMChainAdapterBase implements Conviction
       return 0n;
     }
     if (!ethers.isAddress(agent)) return 0n;
-    try {
-      const id: bigint = await this.readContract(
-        this.contracts.dkgPublishingConvictionNFT, 'pcaNFT.agentToAccountId', 'agentToAccountId', agent,
-      );
-      return BigInt(id);
-    } catch (err: any) {
-      // `agentToAccountId` is a plain mapping getter — it returns 0 (NOT a
-      // revert) for an unregistered address, so a CALL_EXCEPTION here is a real
-      // read failure, never a normal "unregistered". The selector fail-safe
-      // masks it as 0n (publish at full price, safe); the discovery path
-      // (strict) rethrows so a transient blip stays inconclusive instead of
-      // flipping a covered wallet to a confirmed "registered nowhere".
-      if (err?.code === 'CALL_EXCEPTION' && !opts?.strict) return 0n;
-      throw err;
-    }
+    const strict = !!opts?.strict;
+    return this.pcaReadCache.getAgentAccountId(agent, strict, async (normalized) => {
+      try {
+        const id: bigint = await this.readContract(
+          convictionNft, 'pcaNFT.agentToAccountId', 'agentToAccountId', normalized,
+        );
+        return BigInt(id);
+      } catch (err: any) {
+        // `agentToAccountId` is a plain mapping getter — it returns 0 (NOT a
+        // revert) for an unregistered address, so a CALL_EXCEPTION here is a real
+        // read failure, never a normal "unregistered". The selector fail-safe
+        // masks it as 0n (publish at full price, safe); the discovery path
+        // (strict) rethrows so a transient blip stays inconclusive instead of
+        // flipping a covered wallet to a confirmed "registered nowhere".
+        if (err?.code === 'CALL_EXCEPTION' && !strict) return 0n;
+        throw err;
+      }
+    });
   }
 
   async getConvictionAccountLockDurationEpochs(accountId: bigint): Promise<number> {
@@ -251,7 +265,7 @@ export class ConvictionMethods extends EVMChainAdapterBase implements Conviction
     primaryNode: bigint = 0n,
   ): Promise<{ accountId: bigint } & TxResult> {
     await this.init();
-    return this.pcaWrite(async () => {
+    return this.pcaWriteAndInvalidate({ kind: 'account-created', accountIdFromResult: (result) => result.accountId }, async () => {
       const nft = this.requireConvictionNFT();
       const nftAddress = await nft.getAddress();
 
@@ -317,63 +331,68 @@ export class ConvictionMethods extends EVMChainAdapterBase implements Conviction
     await this.init();
     // Undeployed NFT → capability error (503). null is reserved below
     // for a genuine account-missing revert so the route can disambiguate.
-    if (!this.contracts.dkgPublishingConvictionNFT) throw new PcaUnavailableError();
-    try {
-      const t = await this.readContract(
-        this.contracts.dkgPublishingConvictionNFT, 'pcaNFT.getAccountInfo', 'getAccountInfo', accountId,
-      );
-      const info: V10PublishingConvictionAccountInfo = {
-        owner: ethers.getAddress(t[0]),
-        committedTRAC: BigInt(t[1]),
-        baseEpochAllowance: BigInt(t[2]),
-        createdAtEpoch: Number(t[3]),
-        expiresAtEpoch: Number(t[4]),
-        createdAtTimestamp: Number(t[5]),
-        expiresAtTimestamp: Number(t[6]),
-        discountBps: Number(t[7]),
-        topUpBuffer: BigInt(t[8]),
-        agentCount: Number(t[9]),
-        lastSettledWindow: Number(t[10]),
-        fullySwept: Boolean(t[11]),
-      };
-      // GAP-4/5 (opt-in; the S3 budget widget passes `extended`). The default
-      // path (incl. the `convictionAccountCanCover` publish hot path) skips
-      // this entirely — zero extra reads. FAIL-SOFT: an extended-read error
-      // must NOT null the account (core getAccountInfo already succeeded); the
-      // fields are simply left undefined so the UI shows them as unknown
-      // (distinct from primaryNode '0' = "no designated node"). primaryNode /
-      // lastPrimaryNodeChangeEpoch are `accounts()` [9]/[10] (RFC-51, not in
-      // getAccountInfo); remainingAllowance is the current epoch's headroom.
-      if (opts?.extended) {
-        try {
-          const acct = await this.readContract(
-            this.contracts.dkgPublishingConvictionNFT, 'pcaNFT.accounts', 'accounts', accountId,
-          );
-          info.primaryNode = BigInt(acct[9]);
-          info.lastPrimaryNodeChangeEpoch = Number(acct[10]);
-          if (!this.contracts.chronos) {
-            this.contracts.chronos = await this.resolveContract('Chronos');
-          }
-          const currentEpoch: bigint = BigInt(await this.readContract(
-            this.contracts.chronos, 'chronos.getCurrentEpoch', 'getCurrentEpoch',
-          ));
-          info.currentEpoch = Number(currentEpoch);
-          info.remainingAllowance = BigInt(await this.readContract(
-            this.contracts.dkgPublishingConvictionNFT, 'pcaNFT.getRemainingAllowance',
-            'getRemainingAllowance', accountId, currentEpoch,
-          ));
-        } catch { /* extended enrichment is best-effort; leave fields undefined */ }
+    const convictionNft = this.contracts.dkgPublishingConvictionNFT;
+    if (!convictionNft) throw new PcaUnavailableError();
+    return this.pcaReadCache.getAccountInfo(accountId, !!opts?.extended, async () => {
+      try {
+        const t = await this.readContract(
+          convictionNft, 'pcaNFT.getAccountInfo', 'getAccountInfo', accountId,
+        );
+        const info: V10PublishingConvictionAccountInfo = {
+          owner: ethers.getAddress(t[0]),
+          committedTRAC: BigInt(t[1]),
+          baseEpochAllowance: BigInt(t[2]),
+          createdAtEpoch: Number(t[3]),
+          expiresAtEpoch: Number(t[4]),
+          createdAtTimestamp: Number(t[5]),
+          expiresAtTimestamp: Number(t[6]),
+          discountBps: Number(t[7]),
+          topUpBuffer: BigInt(t[8]),
+          agentCount: Number(t[9]),
+          lastSettledWindow: Number(t[10]),
+          fullySwept: Boolean(t[11]),
+        };
+        // GAP-4/5 (opt-in; the S3 budget widget passes `extended`). The default
+        // path (incl. the `convictionAccountCanCover` publish hot path) skips
+        // this entirely — zero extra reads. FAIL-SOFT: an extended-read error
+        // must NOT null the account (core getAccountInfo already succeeded); the
+        // fields are simply left undefined so the UI shows them as unknown
+        // (distinct from primaryNode '0' = "no designated node"). primaryNode /
+        // lastPrimaryNodeChangeEpoch are `accounts()` [9]/[10] (RFC-51, not in
+        // getAccountInfo); remainingAllowance is the current epoch's headroom.
+        if (opts?.extended) {
+          try {
+            const acct = await this.readContract(
+              convictionNft, 'pcaNFT.accounts', 'accounts', accountId,
+            );
+            info.primaryNode = BigInt(acct[9]);
+            info.lastPrimaryNodeChangeEpoch = Number(acct[10]);
+            if (!this.contracts.chronos) {
+              this.contracts.chronos = await this.resolveContract('Chronos');
+            }
+            const currentEpoch: bigint = BigInt(await this.readContract(
+              this.contracts.chronos, 'chronos.getCurrentEpoch', 'getCurrentEpoch',
+            ));
+            info.currentEpoch = Number(currentEpoch);
+            info.remainingAllowance = BigInt(await this.readContract(
+              convictionNft, 'pcaNFT.getRemainingAllowance',
+              'getRemainingAllowance', accountId, currentEpoch,
+            ));
+          } catch { /* extended enrichment is best-effort; leave fields undefined */ }
+        }
+        return info;
+      } catch (err: any) {
+        if (err?.code === 'CALL_EXCEPTION') {
+          return null;
+        }
+        throw err;
       }
-      return info;
-    } catch (err: any) {
-      if (err?.code === 'CALL_EXCEPTION') return null;
-      throw err;
-    }
+    });
   }
 
   async topUpPublishingConvictionAccount(accountId: bigint, amount: bigint): Promise<TxResult> {
     await this.init();
-    return this.pcaWrite(async () => {
+    return this.pcaWriteAndInvalidate({ kind: 'account-changed', accountId }, async () => {
       const nft = this.requireConvictionNFT();
       const nftAddress = await nft.getAddress();
       if (this.contracts.token) {
@@ -403,7 +422,7 @@ export class ConvictionMethods extends EVMChainAdapterBase implements Conviction
 
   async settlePublishingConvictionAccount(accountId: bigint): Promise<TxResult> {
     await this.init();
-    return this.pcaWrite(async () => {
+    return this.pcaWriteAndInvalidate({ kind: 'account-changed', accountId }, async () => {
       const nft = this.requireConvictionNFT();
       const receipt = await this.sendContractTransaction(
         nft,
@@ -418,7 +437,7 @@ export class ConvictionMethods extends EVMChainAdapterBase implements Conviction
 
   async registerPublishingConvictionAgent(accountId: bigint, agent: string): Promise<TxResult> {
     await this.init();
-    return this.pcaWrite(async () => {
+    return this.pcaWriteAndInvalidate({ kind: 'agents-changed', accountId, agents: [agent] }, async () => {
       const nft = this.requireConvictionNFT();
       const receipt = await this.sendContractTransaction(
         nft,
@@ -433,7 +452,7 @@ export class ConvictionMethods extends EVMChainAdapterBase implements Conviction
 
   async deregisterPublishingConvictionAgent(accountId: bigint, agent: string): Promise<TxResult> {
     await this.init();
-    return this.pcaWrite(async () => {
+    return this.pcaWriteAndInvalidate({ kind: 'agents-changed', accountId, agents: [agent] }, async () => {
       const nft = this.requireConvictionNFT();
       const receipt = await this.sendContractTransaction(
         nft,
@@ -456,7 +475,7 @@ export class ConvictionMethods extends EVMChainAdapterBase implements Conviction
    */
   async clearPublishingConvictionAgents(accountId: bigint): Promise<TxResult> {
     await this.init();
-    return this.pcaWrite(async () => {
+    return this.pcaWriteAndInvalidate({ kind: 'all-agents-cleared', accountId }, async () => {
       const logic = await this.resolveContract('PublishingConviction');
       const receipt = await this.sendContractTransaction(
         logic,
@@ -477,7 +496,7 @@ export class ConvictionMethods extends EVMChainAdapterBase implements Conviction
    */
   async registerPublishingConvictionAgents(accountId: bigint, agents: string[]): Promise<TxResult> {
     await this.init();
-    return this.pcaWrite(async () => {
+    return this.pcaWriteAndInvalidate({ kind: 'agents-changed', accountId, agents }, async () => {
       const logic = await this.resolveContract('PublishingConviction');
       const receipt = await this.sendContractTransaction(
         logic,
@@ -625,7 +644,7 @@ export class ConvictionMethods extends EVMChainAdapterBase implements Conviction
    */
   async setPublishingConvictionPrimaryNode(accountId: bigint, primaryNode: bigint): Promise<TxResult> {
     await this.init();
-    return this.pcaWrite(async () => {
+    return this.pcaWriteAndInvalidate({ kind: 'account-changed', accountId }, async () => {
       const nft = this.requireConvictionNFT();
       const receipt = await this.sendContractTransaction(
         nft,

--- a/packages/chain/src/evm-adapter-identity.ts
+++ b/packages/chain/src/evm-adapter-identity.ts
@@ -268,17 +268,7 @@ export class IdentityMethods extends EVMChainAdapterBase {
    * not rely on TTL expiry.
    */
   async getIdentityIdForAddress(address: string): Promise<bigint> {
-    if (!ethers.isAddress(address)) return 0n;
-    const checksum = ethers.getAddress(address);
-    const cacheKey = checksum.toLowerCase();
-    return this.identityIdByAddressCache.getOrLoad(cacheKey, cacheKey, async () => {
-      await this.init();
-      const identityStorage = await this.resolveContract('IdentityStorage');
-      const id: bigint = await this.readContract(
-        identityStorage, 'identityStorage.getIdentityId', 'getIdentityId', checksum,
-      );
-      return BigInt(id);
-    });
+    return this.readIdentityIdForAddress(address);
   }
 
   async ensureProfile(options?: { nodeName?: string; stakeAmount?: bigint; lockTier?: number }): Promise<bigint> {
@@ -320,6 +310,7 @@ export class IdentityMethods extends EVMChainAdapterBase {
       if (identityId === 0n) {
         throw new Error('Profile created but no IdentityCreated event found');
       }
+      this.seedIdentityIdForAddress(this.signer.address, identityId);
     }
 
     // Step 2: Stake via V10 path (separate try/catch so profile isn't lost).
@@ -401,7 +392,9 @@ export class IdentityMethods extends EVMChainAdapterBase {
           data: log.data,
         });
         if (parsed?.name === 'IdentityCreated') {
-          return BigInt(parsed.args.identityId);
+          const identityId = BigInt(parsed.args.identityId);
+          this.seedIdentityIdForAddress(this.signer.address, identityId);
+          return identityId;
         }
       } catch { /* not this contract */ }
     }
@@ -413,7 +406,9 @@ export class IdentityMethods extends EVMChainAdapterBase {
           data: log.data,
         });
         if (parsed?.name === 'ProfileCreated') {
-          return BigInt(parsed.args.identityId);
+          const identityId = BigInt(parsed.args.identityId);
+          this.seedIdentityIdForAddress(this.signer.address, identityId);
+          return identityId;
         }
       } catch { /* not this contract */ }
     }

--- a/packages/chain/src/evm-adapter-identity.ts
+++ b/packages/chain/src/evm-adapter-identity.ts
@@ -88,6 +88,7 @@ export class IdentityMethods extends EVMChainAdapterBase {
     for (const address of missing) {
       if (await this.hasOperationalPurpose(identityStorage, identityId, address)) {
         result.registered.push(address);
+        this.seedIdentityIdForAddress(address, identityId);
       }
     }
 
@@ -130,6 +131,7 @@ export class IdentityMethods extends EVMChainAdapterBase {
       this.adminSigner,
       'addOperationalWallet',
     );
+    this.seedIdentityIdForAddress(wallet, identityId);
     return {
       hash: receipt.hash,
       blockNumber: receipt.blockNumber,
@@ -208,6 +210,7 @@ export class IdentityMethods extends EVMChainAdapterBase {
       this.adminSigner,
       'removeOperationalWallet',
     );
+    this.clearIdentityIdForAddress(wallet);
     return {
       hash: receipt.hash,
       blockNumber: receipt.blockNumber,
@@ -257,29 +260,25 @@ export class IdentityMethods extends EVMChainAdapterBase {
   }
 
   /**
-   * OT-RFC-39 — view-only address → identityId lookup. Returns 0n
-   * when the address is not registered as a node operator. Caches
-   * results per-process: `IdentityStorage.identities` is append-only
-   * (operator key rotation goes through a separate slot), so a
-   * memoised hit is safe.
+   * OT-RFC-39 view-only address to identityId lookup.
+   *
+   * Positive results are cached briefly; negative results are only coalesced
+   * while in flight so a later external registration is visible immediately.
+   * Local wallet mutations seed or clear the cache so operator-key changes do
+   * not rely on TTL expiry.
    */
   async getIdentityIdForAddress(address: string): Promise<bigint> {
     if (!ethers.isAddress(address)) return 0n;
     const checksum = ethers.getAddress(address);
-    const cached = this.identityIdByAddressCache.get(checksum.toLowerCase());
-    if (cached !== undefined) return cached;
-    await this.init();
-    const identityStorage = await this.resolveContract('IdentityStorage');
-    const id: bigint = await this.readContract(
-      identityStorage, 'identityStorage.getIdentityId', 'getIdentityId', checksum,
-    );
-    if (id > 0n) {
-      // Only memoise positive hits — a 0n result may flip to non-zero
-      // once the operator registers, and we don't want to lock the
-      // negative answer in for the process lifetime.
-      this.identityIdByAddressCache.set(checksum.toLowerCase(), id);
-    }
-    return id;
+    const cacheKey = checksum.toLowerCase();
+    return this.identityIdByAddressCache.getOrLoad(cacheKey, cacheKey, async () => {
+      await this.init();
+      const identityStorage = await this.resolveContract('IdentityStorage');
+      const id: bigint = await this.readContract(
+        identityStorage, 'identityStorage.getIdentityId', 'getIdentityId', checksum,
+      );
+      return BigInt(id);
+    });
   }
 
   async ensureProfile(options?: { nodeName?: string; stakeAmount?: bigint; lockTier?: number }): Promise<bigint> {

--- a/packages/chain/src/evm-adapter-identity.ts
+++ b/packages/chain/src/evm-adapter-identity.ts
@@ -275,6 +275,9 @@ export class IdentityMethods extends EVMChainAdapterBase {
     await this.init();
 
     let identityId = await this.getIdentityId();
+    if (identityId === 0n) {
+      identityId = await this.refreshIdentityIdForAddress(this.signer.address);
+    }
 
     // Step 1: Create profile if none exists
     if (identityId === 0n) {

--- a/packages/chain/src/evm-adapter-publish.ts
+++ b/packages/chain/src/evm-adapter-publish.ts
@@ -521,7 +521,7 @@ export class PublishMethods extends EVMChainAdapterBase {
 
     const kas = this.contracts.knowledgeAssetStorage;
     const kav10Address = await this.contracts.knowledgeAssetsLifecycle.getAddress();
-    const evmChainId = BigInt((await this.readProvider('getNetwork (chainId)', (p) => p.getNetwork())).chainId);
+    const evmChainId = await this.getEvmChainId();
 
     const currentTokenAmount = await this.resolveCurrentTokenAmount(params.kaId);
 
@@ -684,7 +684,7 @@ export class PublishMethods extends EVMChainAdapterBase {
     const ka = this.contracts.knowledgeAssetsLifecycle.connect(signer) as Contract;
 
     const kav10Address = await this.contracts.knowledgeAssetsLifecycle.getAddress();
-    const evmChainId = (await this.readProvider('getNetwork (chainId)', (p) => p.getNetwork())).chainId;
+    const evmChainId = await this.getEvmChainId();
 
     const identityId = params.publisherNodeIdentityId ?? await this.getIdentityId();
 

--- a/packages/chain/src/evm-adapter-random-sampling.ts
+++ b/packages/chain/src/evm-adapter-random-sampling.ts
@@ -74,10 +74,7 @@ export class RandomSamplingMethods extends EVMChainAdapterBase {
   async createChallenge(): Promise<CreateChallengeResult> {
     await this.init();
 
-    const identityStorage = await this.getIdentityStorage();
-    const identityId: bigint = await this.readContract(
-      identityStorage, 'identityStorage.getIdentityId', 'getIdentityId', this.signer.address,
-    );
+    const identityId = await this.getIdentityId();
 
     return this.withHubStaleRetry(async () => {
       const { rs, rss } = await this.getRandomSampling();
@@ -108,11 +105,13 @@ export class RandomSamplingMethods extends EVMChainAdapterBase {
       // off the Challenge struct fetched below, so everything stays
       // consistent if the storage layout shifts.
       let contextGraphId = 0n;
+      let challengeIdentityId = identityId;
       const rsIface = rs.interface;
       for (const log of receipt.logs) {
         try {
           const parsed = rsIface.parseLog({ topics: [...log.topics], data: log.data });
           if (parsed?.name === 'ChallengeGenerated') {
+            challengeIdentityId = BigInt(parsed.args.identityId ?? parsed.args[0]);
             contextGraphId = BigInt(parsed.args.contextGraphId);
             break;
           }
@@ -129,12 +128,12 @@ export class RandomSamplingMethods extends EVMChainAdapterBase {
       }
 
       const challengeRaw = await this.readContract(
-        rss, 'rss.getNodeChallenge', 'getNodeChallenge', identityId,
+        rss, 'rss.getNodeChallenge', 'getNodeChallenge', challengeIdentityId,
       );
       const challenge = this.toNodeChallenge(challengeRaw);
       if (!challenge) {
         throw new Error(
-          `createChallenge succeeded but RandomSamplingStorage.getNodeChallenge(${identityId}) ` +
+          `createChallenge succeeded but RandomSamplingStorage.getNodeChallenge(${challengeIdentityId}) ` +
           'returned an empty struct. This indicates a state inconsistency between ' +
           'RandomSampling and RandomSamplingStorage.',
         );

--- a/packages/chain/src/evm-adapter-random-sampling.ts
+++ b/packages/chain/src/evm-adapter-random-sampling.ts
@@ -74,8 +74,6 @@ export class RandomSamplingMethods extends EVMChainAdapterBase {
   async createChallenge(): Promise<CreateChallengeResult> {
     await this.init();
 
-    const identityId = await this.getIdentityId();
-
     return this.withHubStaleRetry(async () => {
       const { rs, rss } = await this.getRandomSampling();
 
@@ -105,7 +103,7 @@ export class RandomSamplingMethods extends EVMChainAdapterBase {
       // off the Challenge struct fetched below, so everything stays
       // consistent if the storage layout shifts.
       let contextGraphId = 0n;
-      let challengeIdentityId = identityId;
+      let challengeIdentityId: bigint | undefined;
       const rsIface = rs.interface;
       for (const log of receipt.logs) {
         try {
@@ -117,13 +115,13 @@ export class RandomSamplingMethods extends EVMChainAdapterBase {
           }
         } catch { /* not this contract */ }
       }
-      if (contextGraphId === 0n) {
+      if (contextGraphId === 0n || challengeIdentityId == null) {
         // The picker only emits the event when it actually lands on a CG,
         // so a missing event is a bug — fail loud rather than fall back
         // to "lookup by KC" which V10 doesn't support natively.
         throw new Error(
           'createChallenge succeeded on-chain but no ChallengeGenerated event was found in the receipt; ' +
-          'cannot route proof builder without contextGraphId.',
+          'cannot route proof builder without identityId and contextGraphId.',
         );
       }
 

--- a/packages/chain/src/evm-adapter-types.ts
+++ b/packages/chain/src/evm-adapter-types.ts
@@ -26,6 +26,13 @@ export interface EVMAdapterBaseConfig {
   tokenAddress?: string;
   chainId?: string;
   /**
+   * When true (default), a configured numeric chainId such as `evm:31337`
+   * is passed to ethers as a static network to avoid steady `eth_chainId`
+   * detection calls. Set to false only when a test or caller intentionally
+   * wants dynamic provider network detection.
+   */
+  staticNetwork?: boolean;
+  /**
    * TTL (ms) for re-resolving `RandomSampling` / `RandomSamplingStorage`
    * addresses from the Hub. Defaults to 5 minutes. Values `<= 0` are
    * treated as "use default" and intentionally NOT supported as a

--- a/packages/chain/src/evm-adapter-types.ts
+++ b/packages/chain/src/evm-adapter-types.ts
@@ -6,7 +6,7 @@
  * evm-adapter.ts. Bodies are a 1:1 move from the original module.
  */
 import { Contract } from 'ethers';
-import type { ApprovalPolicy } from './chain-adapter.js';
+import type { ApprovalPolicy, ContextGraphRegistryScanCursorStore } from './chain-adapter.js';
 
 export interface EVMAdapterBaseConfig {
   rpcUrl: string;
@@ -75,6 +75,13 @@ export interface EVMAdapterBaseConfig {
    * non-finite or `< 1` value falls back to the default.
    */
   cgRegistryScanPageSize?: number;
+  /**
+   * Optional durable cursor for daemon ContextGraphNameRegistry discovery scans.
+   * The adapter still keeps an in-memory mirror; this store lets process
+   * restarts resume from the last successfully covered prefix instead of
+   * repeating a historical `eth_getLogs` walk.
+   */
+  contextGraphRegistryScanCursorStore?: ContextGraphRegistryScanCursorStore;
   /**
    * Funding-aware publish wallet selection: minimum NATIVE gas balance (wei) an
    * operational wallet must hold to be PREFERRED when selecting the publish

--- a/packages/chain/src/evm-adapter-types.ts
+++ b/packages/chain/src/evm-adapter-types.ts
@@ -36,7 +36,7 @@ export interface EVMAdapterBaseConfig {
    * TTL (ms) for re-resolving `RandomSampling` / `RandomSamplingStorage`
    * addresses from the Hub. Defaults to 5 minutes. Values `<= 0` are
    * treated as "use default" and intentionally NOT supported as a
-   * "disable periodic refresh" mode: even with the Hub event listener
+   * "disable periodic refresh" mode: even with the Hub rotation poller
    * and the `Only Contracts in Hub` retry wrapper, a missed event on
    * a read-only path (e.g. `getActiveProofPeriodStatus`,
    * `getNodeChallenge`) would leave the adapter pinned to a stale

--- a/packages/chain/src/hub-resolution-cache.ts
+++ b/packages/chain/src/hub-resolution-cache.ts
@@ -3,8 +3,8 @@
  * given Hub-registered contract name). Re-resolves lazily when:
  *   - cache is empty (first call),
  *   - TTL expired (when `ttlMs > 0`), OR
- *   - `invalidate()` was called explicitly (e.g. from a Hub
- *     `ContractChanged` / `NewContract` event listener, or after a
+ *   - `invalidate()` was called explicitly (e.g. from the Hub rotation
+ *     poller observing `ContractChanged` / `NewContract`, or after a
  *     write surfaced `UnauthorizedAccess(Only Contracts in Hub)`).
  *
  * This is the structural fix for the post-rotation stale-address bug:

--- a/packages/chain/src/hub-rotation-poller.ts
+++ b/packages/chain/src/hub-rotation-poller.ts
@@ -27,8 +27,6 @@ type HubRotationLogWithIdentity = ethers.Log & {
   logIndex?: unknown;
 };
 
-type HubRotationScanMode = 'probe' | 'dispatch';
-
 export class HubRotationPoller {
   private readonly readProvider: HubRotationReadProvider;
   private readonly intervalMs: number;
@@ -40,7 +38,6 @@ export class HubRotationPoller {
   private binding: HubRotationBinding | undefined;
   private readonly seenLogIds = new Map<string, number>();
   private started = false;
-  private startInFlight: Promise<void> | null = null;
   private generation = 0;
 
   constructor(config: HubRotationPollerConfig) {
@@ -56,19 +53,10 @@ export class HubRotationPoller {
 
   async start(hub: Contract, hubAddress: string): Promise<void> {
     if (this.started) return;
-    if (this.startInFlight) return this.startInFlight;
 
     this.bind(hub, hubAddress);
     const generation = ++this.generation;
     this.started = true;
-    const startPromise = this.seed(generation)
-      .catch(() => { /* optional bootstrap path */ })
-      .finally(() => {
-        if (this.startInFlight === startPromise) this.startInFlight = null;
-        if (this.inFlight === startPromise) this.inFlight = null;
-      });
-    this.startInFlight = startPromise;
-    this.inFlight = startPromise;
 
     this.timer = setInterval(() => {
       if (this.inFlight) return;
@@ -84,7 +72,6 @@ export class HubRotationPoller {
 
   stop(): void {
     this.generation++;
-    this.startInFlight = null;
     this.inFlight = null;
     if (this.timer) {
       clearInterval(this.timer);
@@ -102,27 +89,18 @@ export class HubRotationPoller {
   }
 
   async pollOnce(generation = this.generation): Promise<void> {
-    await this.scan(generation, 'dispatch');
-  }
-
-  private async seed(generation: number): Promise<void> {
-    await this.scan(generation, 'probe');
-  }
-
-  private async scan(generation: number, mode: HubRotationScanMode): Promise<void> {
     const binding = this.binding;
-    if (!binding || binding.topics.length === 0 || generation !== this.generation) return;
+    if (!this.started || !binding || binding.topics.length === 0 || generation !== this.generation) return;
 
-    const label = mode === 'probe' ? 'Hub rotation seed' : 'Hub rotation poll';
     const previousLastScannedBlock = this.lastScannedBlock;
     const head = await this.readProvider(
-      `${label} getBlockNumber`,
+      'Hub rotation poll getBlockNumber',
       (provider) => provider.getBlockNumber(),
     );
-    if (generation !== this.generation) return;
-    const fromBlock = this.scanFromBlock(mode, previousLastScannedBlock, head);
+    if (!this.started || generation !== this.generation) return;
+    const fromBlock = this.scanFromBlock(previousLastScannedBlock, head);
     const logs = await this.readProvider<ethers.Log[]>(
-      `${label} getLogs`,
+      'Hub rotation poll getLogs',
       (provider) => provider.getLogs({
         address: binding.hubAddress,
         fromBlock,
@@ -131,23 +109,17 @@ export class HubRotationPoller {
       }),
       { policy: 'wideLogScan' },
     );
-    if (generation !== this.generation) return;
+    if (!this.started || generation !== this.generation) return;
 
-    // Probe mode intentionally does not mark logs as seen; the first buffered
-    // dispatch must still process rotations that landed during adapter init.
-    if (mode === 'dispatch') this.dispatchLogs(binding.hub, logs);
+    this.dispatchLogs(binding.hub, logs);
     this.lastScannedBlock = previousLastScannedBlock == null
       ? head
       : Math.max(previousLastScannedBlock, head);
     this.pruneSeenLogs(head);
   }
 
-  private scanFromBlock(
-    mode: HubRotationScanMode,
-    previousLastScannedBlock: number | undefined,
-    head: number,
-  ): number {
-    if (mode === 'probe' || previousLastScannedBlock == null) {
+  private scanFromBlock(previousLastScannedBlock: number | undefined, head: number): number {
+    if (previousLastScannedBlock == null) {
       return Math.max(0, head - this.reorgBufferBlocks);
     }
     const candidateFromBlock = previousLastScannedBlock + 1 - this.reorgBufferBlocks;

--- a/packages/chain/src/hub-rotation-poller.ts
+++ b/packages/chain/src/hub-rotation-poller.ts
@@ -31,6 +31,7 @@ export class HubRotationPoller {
   private binding: HubRotationBinding | undefined;
   private readonly seenLogIds = new Map<string, number>();
   private started = false;
+  private startInFlight: Promise<void> | null = null;
 
   constructor(config: HubRotationPollerConfig) {
     this.readProvider = config.readProvider;
@@ -45,17 +46,15 @@ export class HubRotationPoller {
 
   async start(hub: Contract, hubAddress: string): Promise<void> {
     if (this.started) return;
+    if (this.startInFlight) return this.startInFlight;
 
-    this.bind(hub, hubAddress);
-    await this.seed();
-    this.timer = setInterval(() => {
-      if (this.inFlight) return;
-      this.inFlight = this.pollOnce()
-        .catch(() => { /* optional poller path */ })
-        .finally(() => { this.inFlight = null; });
-    }, this.intervalMs);
-    if (this.timer.unref) this.timer.unref();
-    this.started = true;
+    let startPromise!: Promise<void>;
+    startPromise = this.startOnce(hub, hubAddress)
+      .finally(() => {
+        if (this.startInFlight === startPromise) this.startInFlight = null;
+      });
+    this.startInFlight = startPromise;
+    return startPromise;
   }
 
   stop(): void {
@@ -72,6 +71,21 @@ export class HubRotationPoller {
       hubAddress: ethers.getAddress(hubAddress),
       topics: this.eventTopics(hub),
     };
+  }
+
+  private async startOnce(hub: Contract, hubAddress: string): Promise<void> {
+    if (this.started) return;
+
+    this.bind(hub, hubAddress);
+    await this.seed();
+    this.timer = setInterval(() => {
+      if (this.inFlight) return;
+      this.inFlight = this.pollOnce()
+        .catch(() => { /* optional poller path */ })
+        .finally(() => { this.inFlight = null; });
+    }, this.intervalMs);
+    if (this.timer.unref) this.timer.unref();
+    this.started = true;
   }
 
   async pollOnce(): Promise<void> {

--- a/packages/chain/src/hub-rotation-poller.ts
+++ b/packages/chain/src/hub-rotation-poller.ts
@@ -155,9 +155,12 @@ export class HubRotationPoller {
       'NewContract',
       'AssetStorageChanged',
       'NewAssetStorage',
-    ].flatMap((eventName) => {
+    ].map((eventName) => {
       const event = hub.interface.getEvent(eventName);
-      return event?.topicHash ? [event.topicHash] : [];
+      if (!event?.topicHash) {
+        throw new Error(`Hub ABI is missing required rotation event ${eventName}`);
+      }
+      return event.topicHash;
     });
   }
 

--- a/packages/chain/src/hub-rotation-poller.ts
+++ b/packages/chain/src/hub-rotation-poller.ts
@@ -51,7 +51,7 @@ export class HubRotationPoller {
     return this.started;
   }
 
-  async start(hub: Contract, hubAddress: string): Promise<void> {
+  start(hub: Contract, hubAddress: string): void {
     if (this.started) return;
 
     this.bind(hub, hubAddress);
@@ -62,6 +62,8 @@ export class HubRotationPoller {
       this.runExclusive(() => this.pollOnce(generation));
     }, this.intervalMs);
     if (this.timer.unref) this.timer.unref();
+    // Best-effort baseline: keep startup non-blocking while preventing the
+    // first scheduled poll from replaying historical rotation logs.
     this.runExclusive(() => this.recordInitialHead(generation));
   }
 

--- a/packages/chain/src/hub-rotation-poller.ts
+++ b/packages/chain/src/hub-rotation-poller.ts
@@ -1,5 +1,7 @@
 import { Contract, ethers, type JsonRpcProvider } from 'ethers';
 import type { ReadOpts } from './rpc-failover-client.js';
+import { withTimeout } from './evm-adapter-rpc.js';
+import { RPC_LOG_SCAN_TIMEOUT_MS, RPC_READ_STALL_TIMEOUT_MS } from './evm-adapter-constants.js';
 
 export type HubRotationReadProvider = <T>(
   label: string,
@@ -93,13 +95,14 @@ export class HubRotationPoller {
     if (!this.started || !binding || binding.topics.length === 0 || generation !== this.generation) return;
 
     const previousLastScannedBlock = this.lastScannedBlock;
-    const head = await this.readProvider(
+    const head = await this.readWithTimeout(
       'Hub rotation poll getBlockNumber',
       (provider) => provider.getBlockNumber(),
+      RPC_READ_STALL_TIMEOUT_MS,
     );
     if (!this.started || generation !== this.generation) return;
     const fromBlock = this.scanFromBlock(previousLastScannedBlock, head);
-    const logs = await this.readProvider<ethers.Log[]>(
+    const logs = await this.readWithTimeout<ethers.Log[]>(
       'Hub rotation poll getLogs',
       (provider) => provider.getLogs({
         address: binding.hubAddress,
@@ -107,6 +110,7 @@ export class HubRotationPoller {
         toBlock: head,
         topics: [binding.topics],
       }),
+      RPC_LOG_SCAN_TIMEOUT_MS,
       { policy: 'wideLogScan' },
     );
     if (!this.started || generation !== this.generation) return;
@@ -116,6 +120,15 @@ export class HubRotationPoller {
       ? head
       : Math.max(previousLastScannedBlock, head);
     this.pruneSeenLogs(head);
+  }
+
+  private readWithTimeout<T>(
+    label: string,
+    fn: (provider: JsonRpcProvider) => Promise<T>,
+    timeoutMs: number,
+    opts?: ReadOpts,
+  ): Promise<T> {
+    return withTimeout(this.readProvider(label, fn, opts), timeoutMs, label);
   }
 
   private scanFromBlock(previousLastScannedBlock: number | undefined, head: number): number {

--- a/packages/chain/src/hub-rotation-poller.ts
+++ b/packages/chain/src/hub-rotation-poller.ts
@@ -1,7 +1,5 @@
 import { Contract, ethers, type JsonRpcProvider } from 'ethers';
 import type { ReadOpts } from './rpc-failover-client.js';
-import { withTimeout } from './evm-adapter-rpc.js';
-import { RPC_LOG_SCAN_TIMEOUT_MS, RPC_READ_STALL_TIMEOUT_MS } from './evm-adapter-constants.js';
 
 export type HubRotationReadProvider = <T>(
   label: string,
@@ -95,14 +93,14 @@ export class HubRotationPoller {
     if (!this.started || !binding || binding.topics.length === 0 || generation !== this.generation) return;
 
     const previousLastScannedBlock = this.lastScannedBlock;
-    const head = await this.readWithTimeout(
+    const head = await this.readProvider(
       'Hub rotation poll getBlockNumber',
       (provider) => provider.getBlockNumber(),
-      RPC_READ_STALL_TIMEOUT_MS,
+      { capSingleProvider: true },
     );
     if (!this.started || generation !== this.generation) return;
     const fromBlock = this.scanFromBlock(previousLastScannedBlock, head);
-    const logs = await this.readWithTimeout<ethers.Log[]>(
+    const logs = await this.readProvider<ethers.Log[]>(
       'Hub rotation poll getLogs',
       (provider) => provider.getLogs({
         address: binding.hubAddress,
@@ -110,8 +108,7 @@ export class HubRotationPoller {
         toBlock: head,
         topics: [binding.topics],
       }),
-      RPC_LOG_SCAN_TIMEOUT_MS,
-      { policy: 'wideLogScan' },
+      { policy: 'wideLogScan', capSingleProvider: true },
     );
     if (!this.started || generation !== this.generation) return;
 
@@ -120,15 +117,6 @@ export class HubRotationPoller {
       ? head
       : Math.max(previousLastScannedBlock, head);
     this.pruneSeenLogs(head);
-  }
-
-  private readWithTimeout<T>(
-    label: string,
-    fn: (provider: JsonRpcProvider) => Promise<T>,
-    timeoutMs: number,
-    opts?: ReadOpts,
-  ): Promise<T> {
-    return withTimeout(this.readProvider(label, fn, opts), timeoutMs, label);
   }
 
   private scanFromBlock(previousLastScannedBlock: number | undefined, head: number): number {

--- a/packages/chain/src/hub-rotation-poller.ts
+++ b/packages/chain/src/hub-rotation-poller.ts
@@ -96,7 +96,7 @@ export class HubRotationPoller {
     const head = await this.readProvider(
       'Hub rotation poll getBlockNumber',
       (provider) => provider.getBlockNumber(),
-      { capSingleProvider: true },
+      { policy: 'watchdogPointRead' },
     );
     if (!this.started || generation !== this.generation) return;
     const fromBlock = this.scanFromBlock(previousLastScannedBlock, head);
@@ -108,7 +108,7 @@ export class HubRotationPoller {
         toBlock: head,
         topics: [binding.topics],
       }),
-      { policy: 'wideLogScan', capSingleProvider: true },
+      { policy: 'watchdogWideLogScan' },
     );
     if (!this.started || generation !== this.generation) return;
 

--- a/packages/chain/src/hub-rotation-poller.ts
+++ b/packages/chain/src/hub-rotation-poller.ts
@@ -14,6 +14,12 @@ export interface HubRotationPollerConfig {
   onContractName: (name: string) => void;
 }
 
+interface HubRotationBinding {
+  hub: Contract;
+  hubAddress: string;
+  topics: string[];
+}
+
 export class HubRotationPoller {
   private readonly readProvider: HubRotationReadProvider;
   private readonly intervalMs: number;
@@ -22,6 +28,8 @@ export class HubRotationPoller {
   private timer: ReturnType<typeof setInterval> | null = null;
   private inFlight: Promise<void> | null = null;
   private lastScannedBlock: number | undefined;
+  private binding: HubRotationBinding | undefined;
+  private readonly seenLogIds = new Map<string, number>();
   private started = false;
 
   constructor(config: HubRotationPollerConfig) {
@@ -38,11 +46,12 @@ export class HubRotationPoller {
   async start(hub: Contract, hubAddress: string): Promise<void> {
     if (this.started) return;
 
-    await this.seed(hub);
+    this.bind(hub, hubAddress);
+    await this.seed();
     this.timer = setInterval(() => {
       if (this.inFlight) return;
-      this.inFlight = this.poll(hub, hubAddress)
-        .catch(() => { /* optional listener path */ })
+      this.inFlight = this.pollOnce()
+        .catch(() => { /* optional poller path */ })
         .finally(() => { this.inFlight = null; });
     }, this.intervalMs);
     if (this.timer.unref) this.timer.unref();
@@ -57,9 +66,17 @@ export class HubRotationPoller {
     this.started = false;
   }
 
-  async poll(hub: Contract, hubAddress: string): Promise<void> {
-    const topics = this.eventTopics(hub);
-    if (topics.length === 0) return;
+  private bind(hub: Contract, hubAddress: string): void {
+    this.binding = {
+      hub,
+      hubAddress: ethers.getAddress(hubAddress),
+      topics: this.eventTopics(hub),
+    };
+  }
+
+  async pollOnce(): Promise<void> {
+    const binding = this.binding;
+    if (!binding || binding.topics.length === 0) return;
 
     const previousLastScannedBlock = this.lastScannedBlock;
     const head = await this.readProvider(
@@ -74,31 +91,48 @@ export class HubRotationPoller {
     const logs = await this.readProvider<ethers.Log[]>(
       'Hub rotation poll getLogs',
       (provider) => provider.getLogs({
-        address: hubAddress,
+        address: binding.hubAddress,
         fromBlock,
         toBlock: head,
-        topics: [topics],
+        topics: [binding.topics],
       }),
       { policy: 'wideLogScan' },
     );
 
     for (const log of logs) {
-      if (previousLastScannedBlock != null && log.blockNumber <= previousLastScannedBlock) continue;
-      const contractName = this.contractNameFromLog(hub, log);
+      const identity = this.logIdentity(log);
+      if (this.seenLogIds.has(identity)) continue;
+      this.rememberLog(identity, log);
+      const contractName = this.contractNameFromLog(binding.hub, log);
       if (contractName) this.onContractName(contractName);
     }
     this.lastScannedBlock = previousLastScannedBlock == null
       ? head
       : Math.max(previousLastScannedBlock, head);
+    this.pruneSeenLogs(head);
   }
 
-  private async seed(hub: Contract): Promise<void> {
-    const topics = this.eventTopics(hub);
-    if (topics.length === 0) return;
-    this.lastScannedBlock = await this.readProvider(
+  private async seed(): Promise<void> {
+    const binding = this.binding;
+    if (!binding || binding.topics.length === 0) return;
+    const head = await this.readProvider(
       'Hub rotation seed getBlockNumber',
       (provider) => provider.getBlockNumber(),
     );
+    const fromBlock = Math.max(0, head - this.reorgBufferBlocks);
+    const logs = await this.readProvider<ethers.Log[]>(
+      'Hub rotation seed getLogs',
+      (provider) => provider.getLogs({
+        address: binding.hubAddress,
+        fromBlock,
+        toBlock: head,
+        topics: [binding.topics],
+      }),
+      { policy: 'wideLogScan' },
+    );
+    for (const log of logs) this.rememberLog(this.logIdentity(log), log);
+    this.lastScannedBlock = head;
+    this.pruneSeenLogs(head);
   }
 
   private contractNameFromLog(hub: Contract, log: ethers.Log): string | undefined {
@@ -123,5 +157,41 @@ export class HubRotationPoller {
       const event = hub.interface.getEvent(eventName);
       return event?.topicHash ? [event.topicHash] : [];
     });
+  }
+
+  private logIdentity(log: ethers.Log): string {
+    const maybe = log as ethers.Log & {
+      blockHash?: unknown;
+      transactionHash?: unknown;
+      index?: unknown;
+      logIndex?: unknown;
+    };
+    const blockHash = typeof maybe.blockHash === 'string' ? maybe.blockHash : undefined;
+    const transactionHash = typeof maybe.transactionHash === 'string' ? maybe.transactionHash : undefined;
+    const index = typeof maybe.index === 'number'
+      ? maybe.index
+      : typeof maybe.logIndex === 'number'
+        ? maybe.logIndex
+        : undefined;
+    if (blockHash && transactionHash && index != null) {
+      return `${blockHash}:${transactionHash}:${index}`;
+    }
+    return [
+      log.blockNumber,
+      index ?? 'unknown',
+      log.topics.join(','),
+      log.data,
+    ].join(':');
+  }
+
+  private rememberLog(identity: string, log: ethers.Log): void {
+    this.seenLogIds.set(identity, log.blockNumber);
+  }
+
+  private pruneSeenLogs(head: number): void {
+    const earliestBufferedBlock = Math.max(0, head - this.reorgBufferBlocks);
+    for (const [identity, blockNumber] of this.seenLogIds) {
+      if (blockNumber < earliestBufferedBlock) this.seenLogIds.delete(identity);
+    }
   }
 }

--- a/packages/chain/src/hub-rotation-poller.ts
+++ b/packages/chain/src/hub-rotation-poller.ts
@@ -120,7 +120,10 @@ export class HubRotationPoller {
       (provider) => provider.getBlockNumber(),
     );
     const fromBlock = Math.max(0, head - this.reorgBufferBlocks);
-    const logs = await this.readProvider<ethers.Log[]>(
+    // Probe log-scan support and position the high-water mark, but do not mark
+    // returned logs as seen. They must remain eligible for the first buffered
+    // post-start poll in case a real rotation landed during adapter init.
+    await this.readProvider<ethers.Log[]>(
       'Hub rotation seed getLogs',
       (provider) => provider.getLogs({
         address: binding.hubAddress,
@@ -130,7 +133,6 @@ export class HubRotationPoller {
       }),
       { policy: 'wideLogScan' },
     );
-    for (const log of logs) this.rememberLog(this.logIdentity(log), log);
     this.lastScannedBlock = head;
     this.pruneSeenLogs(head);
   }

--- a/packages/chain/src/hub-rotation-poller.ts
+++ b/packages/chain/src/hub-rotation-poller.ts
@@ -59,15 +59,10 @@ export class HubRotationPoller {
     this.started = true;
 
     this.timer = setInterval(() => {
-      if (this.inFlight) return;
-      const pollPromise = this.pollOnce(generation)
-        .catch(() => { /* optional poller path */ })
-        .finally(() => {
-          if (this.inFlight === pollPromise) this.inFlight = null;
-        });
-      this.inFlight = pollPromise;
+      this.runExclusive(() => this.pollOnce(generation));
     }, this.intervalMs);
     if (this.timer.unref) this.timer.unref();
+    this.runExclusive(() => this.recordInitialHead(generation));
   }
 
   stop(): void {
@@ -78,6 +73,16 @@ export class HubRotationPoller {
       this.timer = null;
     }
     this.started = false;
+  }
+
+  private runExclusive(work: () => Promise<void>): void {
+    if (this.inFlight) return;
+    const pollPromise = work()
+      .catch(() => { /* optional poller path */ })
+      .finally(() => {
+        if (this.inFlight === pollPromise) this.inFlight = null;
+      });
+    this.inFlight = pollPromise;
   }
 
   private bind(hub: Contract, hubAddress: string): void {
@@ -117,6 +122,19 @@ export class HubRotationPoller {
       ? head
       : Math.max(previousLastScannedBlock, head);
     this.pruneSeenLogs(head);
+  }
+
+  private async recordInitialHead(generation: number): Promise<void> {
+    if (!this.started || generation !== this.generation) return;
+    const head = await this.readProvider(
+      'Hub rotation poll initial getBlockNumber',
+      (provider) => provider.getBlockNumber(),
+      { policy: 'watchdogPointRead' },
+    );
+    if (!this.started || generation !== this.generation) return;
+    this.lastScannedBlock = this.lastScannedBlock == null
+      ? head
+      : Math.max(this.lastScannedBlock, head);
   }
 
   private scanFromBlock(previousLastScannedBlock: number | undefined, head: number): number {

--- a/packages/chain/src/hub-rotation-poller.ts
+++ b/packages/chain/src/hub-rotation-poller.ts
@@ -1,0 +1,114 @@
+import { Contract, ethers, type JsonRpcProvider } from 'ethers';
+import type { ReadOpts } from './rpc-failover-client.js';
+
+export type HubRotationReadProvider = <T>(
+  label: string,
+  fn: (provider: JsonRpcProvider) => Promise<T>,
+  opts?: ReadOpts,
+) => Promise<T>;
+
+export interface HubRotationPollerConfig {
+  readProvider: HubRotationReadProvider;
+  intervalMs: number;
+  reorgBufferBlocks: number;
+  onContractName: (name: unknown) => void;
+}
+
+export class HubRotationPoller {
+  private readonly readProvider: HubRotationReadProvider;
+  private readonly intervalMs: number;
+  private readonly reorgBufferBlocks: number;
+  private readonly onContractName: (name: unknown) => void;
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private inFlight: Promise<void> | null = null;
+  private lastScannedBlock: number | undefined;
+  private started = false;
+
+  constructor(config: HubRotationPollerConfig) {
+    this.readProvider = config.readProvider;
+    this.intervalMs = config.intervalMs;
+    this.reorgBufferBlocks = config.reorgBufferBlocks;
+    this.onContractName = config.onContractName;
+  }
+
+  get isStarted(): boolean {
+    return this.started;
+  }
+
+  async start(hub: Contract): Promise<void> {
+    if (this.started) return;
+
+    await this.poll(hub);
+    this.timer = setInterval(() => {
+      if (this.inFlight) return;
+      this.inFlight = this.poll(hub)
+        .catch(() => { /* optional listener path */ })
+        .finally(() => { this.inFlight = null; });
+    }, this.intervalMs);
+    if (this.timer.unref) this.timer.unref();
+    this.started = true;
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    this.started = false;
+  }
+
+  async poll(hub: Contract): Promise<void> {
+    const topics = this.eventTopics(hub);
+    if (topics.length === 0) return;
+
+    const head = await this.readProvider(
+      'Hub rotation poll getBlockNumber',
+      (provider) => provider.getBlockNumber(),
+    );
+    const candidateFromBlock = this.lastScannedBlock == null
+      ? head - this.reorgBufferBlocks
+      : this.lastScannedBlock + 1 - this.reorgBufferBlocks;
+    const recentFromBlock = head - this.reorgBufferBlocks;
+    const fromBlock = Math.max(0, Math.min(candidateFromBlock, recentFromBlock));
+    const hubAddress = await this.contractAddress(hub);
+    const logs = await this.readProvider<ethers.Log[]>(
+      'Hub rotation poll getLogs',
+      (provider) => provider.getLogs({
+        address: hubAddress,
+        fromBlock,
+        toBlock: head,
+        topics: [topics],
+      }),
+      { policy: 'wideLogScan' },
+    );
+
+    for (const log of logs) {
+      try {
+        const parsed = hub.interface.parseLog({ topics: [...log.topics], data: log.data });
+        if (!parsed) continue;
+        this.onContractName(parsed.args?.contractName ?? parsed.args?.[0]);
+      } catch {
+        // Ignore malformed/unexpected Hub logs. The topic filter should already
+        // constrain these, but a parse miss must not wedge the poll cursor.
+      }
+    }
+    this.lastScannedBlock = head;
+  }
+
+  private eventTopics(hub: Contract): string[] {
+    return [
+      'ContractChanged',
+      'NewContract',
+      'AssetStorageChanged',
+      'NewAssetStorage',
+    ].flatMap((eventName) => {
+      const event = hub.interface.getEvent(eventName);
+      return event?.topicHash ? [event.topicHash] : [];
+    });
+  }
+
+  private async contractAddress(hub: Contract): Promise<string> {
+    const target = (hub as unknown as { target?: unknown }).target;
+    return typeof target === 'string' ? target : hub.getAddress();
+  }
+}

--- a/packages/chain/src/hub-rotation-poller.ts
+++ b/packages/chain/src/hub-rotation-poller.ts
@@ -35,13 +35,13 @@ export class HubRotationPoller {
     return this.started;
   }
 
-  async start(hub: Contract): Promise<void> {
+  async start(hub: Contract, hubAddress: string): Promise<void> {
     if (this.started) return;
 
     await this.seed(hub);
     this.timer = setInterval(() => {
       if (this.inFlight) return;
-      this.inFlight = this.poll(hub)
+      this.inFlight = this.poll(hub, hubAddress)
         .catch(() => { /* optional listener path */ })
         .finally(() => { this.inFlight = null; });
     }, this.intervalMs);
@@ -57,7 +57,7 @@ export class HubRotationPoller {
     this.started = false;
   }
 
-  async poll(hub: Contract): Promise<void> {
+  async poll(hub: Contract, hubAddress: string): Promise<void> {
     const topics = this.eventTopics(hub);
     if (topics.length === 0) return;
 
@@ -71,7 +71,6 @@ export class HubRotationPoller {
       : previousLastScannedBlock + 1 - this.reorgBufferBlocks;
     const recentFromBlock = head - this.reorgBufferBlocks;
     const fromBlock = Math.max(0, Math.min(candidateFromBlock, recentFromBlock));
-    const hubAddress = await this.contractAddress(hub);
     const logs = await this.readProvider<ethers.Log[]>(
       'Hub rotation poll getLogs',
       (provider) => provider.getLogs({
@@ -124,10 +123,5 @@ export class HubRotationPoller {
       const event = hub.interface.getEvent(eventName);
       return event?.topicHash ? [event.topicHash] : [];
     });
-  }
-
-  private async contractAddress(hub: Contract): Promise<string> {
-    const target = (hub as unknown as { target?: unknown }).target;
-    return typeof target === 'string' ? target : hub.getAddress();
   }
 }

--- a/packages/chain/src/hub-rotation-poller.ts
+++ b/packages/chain/src/hub-rotation-poller.ts
@@ -11,14 +11,14 @@ export interface HubRotationPollerConfig {
   readProvider: HubRotationReadProvider;
   intervalMs: number;
   reorgBufferBlocks: number;
-  onContractName: (name: unknown) => void;
+  onContractName: (name: string) => void;
 }
 
 export class HubRotationPoller {
   private readonly readProvider: HubRotationReadProvider;
   private readonly intervalMs: number;
   private readonly reorgBufferBlocks: number;
-  private readonly onContractName: (name: unknown) => void;
+  private readonly onContractName: (name: string) => void;
   private timer: ReturnType<typeof setInterval> | null = null;
   private inFlight: Promise<void> | null = null;
   private lastScannedBlock: number | undefined;
@@ -38,7 +38,7 @@ export class HubRotationPoller {
   async start(hub: Contract): Promise<void> {
     if (this.started) return;
 
-    await this.poll(hub);
+    await this.seed(hub);
     this.timer = setInterval(() => {
       if (this.inFlight) return;
       this.inFlight = this.poll(hub)
@@ -61,13 +61,14 @@ export class HubRotationPoller {
     const topics = this.eventTopics(hub);
     if (topics.length === 0) return;
 
+    const previousLastScannedBlock = this.lastScannedBlock;
     const head = await this.readProvider(
       'Hub rotation poll getBlockNumber',
       (provider) => provider.getBlockNumber(),
     );
-    const candidateFromBlock = this.lastScannedBlock == null
+    const candidateFromBlock = previousLastScannedBlock == null
       ? head - this.reorgBufferBlocks
-      : this.lastScannedBlock + 1 - this.reorgBufferBlocks;
+      : previousLastScannedBlock + 1 - this.reorgBufferBlocks;
     const recentFromBlock = head - this.reorgBufferBlocks;
     const fromBlock = Math.max(0, Math.min(candidateFromBlock, recentFromBlock));
     const hubAddress = await this.contractAddress(hub);
@@ -83,16 +84,34 @@ export class HubRotationPoller {
     );
 
     for (const log of logs) {
-      try {
-        const parsed = hub.interface.parseLog({ topics: [...log.topics], data: log.data });
-        if (!parsed) continue;
-        this.onContractName(parsed.args?.contractName ?? parsed.args?.[0]);
-      } catch {
-        // Ignore malformed/unexpected Hub logs. The topic filter should already
-        // constrain these, but a parse miss must not wedge the poll cursor.
-      }
+      if (previousLastScannedBlock != null && log.blockNumber <= previousLastScannedBlock) continue;
+      const contractName = this.contractNameFromLog(hub, log);
+      if (contractName) this.onContractName(contractName);
     }
-    this.lastScannedBlock = head;
+    this.lastScannedBlock = previousLastScannedBlock == null
+      ? head
+      : Math.max(previousLastScannedBlock, head);
+  }
+
+  private async seed(hub: Contract): Promise<void> {
+    const topics = this.eventTopics(hub);
+    if (topics.length === 0) return;
+    this.lastScannedBlock = await this.readProvider(
+      'Hub rotation seed getBlockNumber',
+      (provider) => provider.getBlockNumber(),
+    );
+  }
+
+  private contractNameFromLog(hub: Contract, log: ethers.Log): string | undefined {
+    try {
+      const parsed = hub.interface.parseLog({ topics: [...log.topics], data: log.data });
+      const contractName = parsed?.args?.contractName ?? parsed?.args?.[0];
+      return typeof contractName === 'string' ? contractName : undefined;
+    } catch {
+      // Ignore malformed/unexpected Hub logs. The topic filter should already
+      // constrain these, but a parse miss must not wedge the poll cursor.
+      return undefined;
+    }
   }
 
   private eventTopics(hub: Contract): string[] {

--- a/packages/chain/src/hub-rotation-poller.ts
+++ b/packages/chain/src/hub-rotation-poller.ts
@@ -20,6 +20,15 @@ interface HubRotationBinding {
   topics: string[];
 }
 
+type HubRotationLogWithIdentity = ethers.Log & {
+  blockHash?: unknown;
+  transactionHash?: unknown;
+  index?: unknown;
+  logIndex?: unknown;
+};
+
+type HubRotationScanMode = 'probe' | 'dispatch';
+
 export class HubRotationPoller {
   private readonly readProvider: HubRotationReadProvider;
   private readonly intervalMs: number;
@@ -32,6 +41,7 @@ export class HubRotationPoller {
   private readonly seenLogIds = new Map<string, number>();
   private started = false;
   private startInFlight: Promise<void> | null = null;
+  private generation = 0;
 
   constructor(config: HubRotationPollerConfig) {
     this.readProvider = config.readProvider;
@@ -48,16 +58,34 @@ export class HubRotationPoller {
     if (this.started) return;
     if (this.startInFlight) return this.startInFlight;
 
-    let startPromise!: Promise<void>;
-    startPromise = this.startOnce(hub, hubAddress)
+    this.bind(hub, hubAddress);
+    const generation = ++this.generation;
+    this.started = true;
+    const startPromise = this.seed(generation)
+      .catch(() => { /* optional bootstrap path */ })
       .finally(() => {
         if (this.startInFlight === startPromise) this.startInFlight = null;
+        if (this.inFlight === startPromise) this.inFlight = null;
       });
     this.startInFlight = startPromise;
-    return startPromise;
+    this.inFlight = startPromise;
+
+    this.timer = setInterval(() => {
+      if (this.inFlight) return;
+      const pollPromise = this.pollOnce(generation)
+        .catch(() => { /* optional poller path */ })
+        .finally(() => {
+          if (this.inFlight === pollPromise) this.inFlight = null;
+        });
+      this.inFlight = pollPromise;
+    }, this.intervalMs);
+    if (this.timer.unref) this.timer.unref();
   }
 
   stop(): void {
+    this.generation++;
+    this.startInFlight = null;
+    this.inFlight = null;
     if (this.timer) {
       clearInterval(this.timer);
       this.timer = null;
@@ -73,37 +101,28 @@ export class HubRotationPoller {
     };
   }
 
-  private async startOnce(hub: Contract, hubAddress: string): Promise<void> {
-    if (this.started) return;
-
-    this.bind(hub, hubAddress);
-    await this.seed();
-    this.timer = setInterval(() => {
-      if (this.inFlight) return;
-      this.inFlight = this.pollOnce()
-        .catch(() => { /* optional poller path */ })
-        .finally(() => { this.inFlight = null; });
-    }, this.intervalMs);
-    if (this.timer.unref) this.timer.unref();
-    this.started = true;
+  async pollOnce(generation = this.generation): Promise<void> {
+    await this.scan(generation, 'dispatch');
   }
 
-  async pollOnce(): Promise<void> {
-    const binding = this.binding;
-    if (!binding || binding.topics.length === 0) return;
+  private async seed(generation: number): Promise<void> {
+    await this.scan(generation, 'probe');
+  }
 
+  private async scan(generation: number, mode: HubRotationScanMode): Promise<void> {
+    const binding = this.binding;
+    if (!binding || binding.topics.length === 0 || generation !== this.generation) return;
+
+    const label = mode === 'probe' ? 'Hub rotation seed' : 'Hub rotation poll';
     const previousLastScannedBlock = this.lastScannedBlock;
     const head = await this.readProvider(
-      'Hub rotation poll getBlockNumber',
+      `${label} getBlockNumber`,
       (provider) => provider.getBlockNumber(),
     );
-    const candidateFromBlock = previousLastScannedBlock == null
-      ? head - this.reorgBufferBlocks
-      : previousLastScannedBlock + 1 - this.reorgBufferBlocks;
-    const recentFromBlock = head - this.reorgBufferBlocks;
-    const fromBlock = Math.max(0, Math.min(candidateFromBlock, recentFromBlock));
+    if (generation !== this.generation) return;
+    const fromBlock = this.scanFromBlock(mode, previousLastScannedBlock, head);
     const logs = await this.readProvider<ethers.Log[]>(
-      'Hub rotation poll getLogs',
+      `${label} getLogs`,
       (provider) => provider.getLogs({
         address: binding.hubAddress,
         fromBlock,
@@ -112,43 +131,38 @@ export class HubRotationPoller {
       }),
       { policy: 'wideLogScan' },
     );
+    if (generation !== this.generation) return;
 
-    for (const log of logs) {
-      const identity = this.logIdentity(log);
-      if (this.seenLogIds.has(identity)) continue;
-      this.rememberLog(identity, log);
-      const contractName = this.contractNameFromLog(binding.hub, log);
-      if (contractName) this.onContractName(contractName);
-    }
+    // Probe mode intentionally does not mark logs as seen; the first buffered
+    // dispatch must still process rotations that landed during adapter init.
+    if (mode === 'dispatch') this.dispatchLogs(binding.hub, logs);
     this.lastScannedBlock = previousLastScannedBlock == null
       ? head
       : Math.max(previousLastScannedBlock, head);
     this.pruneSeenLogs(head);
   }
 
-  private async seed(): Promise<void> {
-    const binding = this.binding;
-    if (!binding || binding.topics.length === 0) return;
-    const head = await this.readProvider(
-      'Hub rotation seed getBlockNumber',
-      (provider) => provider.getBlockNumber(),
-    );
-    const fromBlock = Math.max(0, head - this.reorgBufferBlocks);
-    // Probe log-scan support and position the high-water mark, but do not mark
-    // returned logs as seen. They must remain eligible for the first buffered
-    // post-start poll in case a real rotation landed during adapter init.
-    await this.readProvider<ethers.Log[]>(
-      'Hub rotation seed getLogs',
-      (provider) => provider.getLogs({
-        address: binding.hubAddress,
-        fromBlock,
-        toBlock: head,
-        topics: [binding.topics],
-      }),
-      { policy: 'wideLogScan' },
-    );
-    this.lastScannedBlock = head;
-    this.pruneSeenLogs(head);
+  private scanFromBlock(
+    mode: HubRotationScanMode,
+    previousLastScannedBlock: number | undefined,
+    head: number,
+  ): number {
+    if (mode === 'probe' || previousLastScannedBlock == null) {
+      return Math.max(0, head - this.reorgBufferBlocks);
+    }
+    const candidateFromBlock = previousLastScannedBlock + 1 - this.reorgBufferBlocks;
+    const recentFromBlock = head - this.reorgBufferBlocks;
+    return Math.max(0, Math.min(candidateFromBlock, recentFromBlock));
+  }
+
+  private dispatchLogs(hub: Contract, logs: ethers.Log[]): void {
+    for (const log of logs) {
+      const identity = this.logIdentity(log);
+      if (this.seenLogIds.has(identity)) continue;
+      this.rememberLog(identity, log);
+      const contractName = this.contractNameFromLog(hub, log);
+      if (contractName) this.onContractName(contractName);
+    }
   }
 
   private contractNameFromLog(hub: Contract, log: ethers.Log): string | undefined {
@@ -179,12 +193,7 @@ export class HubRotationPoller {
   }
 
   private logIdentity(log: ethers.Log): string {
-    const maybe = log as ethers.Log & {
-      blockHash?: unknown;
-      transactionHash?: unknown;
-      index?: unknown;
-      logIndex?: unknown;
-    };
+    const maybe = log as HubRotationLogWithIdentity;
     const blockHash = typeof maybe.blockHash === 'string' ? maybe.blockHash : undefined;
     const transactionHash = typeof maybe.transactionHash === 'string' ? maybe.transactionHash : undefined;
     const index = typeof maybe.index === 'number'

--- a/packages/chain/src/index.ts
+++ b/packages/chain/src/index.ts
@@ -4,7 +4,15 @@ export * from './chain-adapter.js';
 // daemon's rpc_usage log emission). The parsing/label-bounding helpers stay
 // package-internal (imported via ./rpc-usage.js) so the transport accounting
 // implementation can change without a public-API break.
-export { emptyRpcUsageWindow, mergeRpcUsageWindows, rpcUsageWindowTotal, type RpcUsageDrainable, type RpcUsageWindow } from './rpc-usage.js';
+export {
+  emptyRpcUsageWindow,
+  mergeRpcUsageWindows,
+  normalizeRpcUsageWindow,
+  rpcUsageWindowTotal,
+  type NormalizedRpcUsageWindow,
+  type RpcUsageDrainable,
+  type RpcUsageWindow,
+} from './rpc-usage.js';
 export { MockChainAdapter, MOCK_DEFAULT_SIGNER } from './mock-adapter.js';
 export {
   EVMChainAdapter,

--- a/packages/chain/src/keyed-ttl-single-flight-cache.ts
+++ b/packages/chain/src/keyed-ttl-single-flight-cache.ts
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export interface TtlValueCacheOptions<V> {
+  ttlMs: number | ((value: CacheValue<V>) => number);
+  now?: () => number;
+}
+
+export type CacheValue<V> = undefined extends V ? never : V;
+
+/**
+ * Small process-local TTL value cache.
+ *
+ * `undefined` is intentionally excluded from stored values so `get()` can use
+ * it as the miss sentinel. A non-positive TTL means "do not retain".
+ */
+export class TtlValueCache<K, V> {
+  private readonly values = new Map<K, { value: CacheValue<V>; cachedAt: number }>();
+
+  private readonly ttlMs: number | ((value: CacheValue<V>) => number);
+
+  private readonly now: () => number;
+
+  constructor(options: TtlValueCacheOptions<V>) {
+    this.ttlMs = options.ttlMs;
+    this.now = options.now ?? (() => Date.now());
+  }
+
+  get(key: K, now = this.now()): CacheValue<V> | undefined {
+    const entry = this.values.get(key);
+    if (!entry) return undefined;
+    const ttl = this.ttlFor(entry.value);
+    if (now - entry.cachedAt < ttl) return entry.value;
+    this.values.delete(key);
+    return undefined;
+  }
+
+  has(key: K, now = this.now()): boolean {
+    return this.get(key, now) !== undefined;
+  }
+
+  set(key: K, value: CacheValue<V>): boolean {
+    if (this.ttlFor(value) <= 0) {
+      this.values.delete(key);
+      return false;
+    }
+    this.values.set(key, { value, cachedAt: this.now() });
+    return true;
+  }
+
+  delete(key: K): void {
+    this.values.delete(key);
+  }
+
+  clear(): void {
+    this.values.clear();
+  }
+
+  private ttlFor(value: CacheValue<V>): number {
+    return typeof this.ttlMs === 'function' ? this.ttlMs(value) : this.ttlMs;
+  }
+}
+
+/**
+ * Per-key promise coalescer with invalidation epochs.
+ *
+ * Invalidation clears known in-flight variants for the value key and bumps an
+ * epoch. A pre-invalidation promise can still resolve to its original caller,
+ * but its `onSuccess` hook is suppressed so it cannot repopulate stale state.
+ */
+export class KeyedSingleFlight<K, I = K> {
+  private readonly inflightByKey = new Map<K, Map<I, Promise<unknown>>>();
+
+  private readonly keyEpochs = new Map<K, number>();
+
+  private globalEpoch = 0;
+
+  async run<V>(
+    key: K,
+    inflightKey: I,
+    load: () => Promise<V>,
+    onSuccess?: (value: V) => void,
+  ): Promise<V> {
+    const keys = this.inflightKeysFor(key);
+    const existing = keys.get(inflightKey) as Promise<V> | undefined;
+    if (existing) return existing;
+
+    const epoch = this.epoch(key);
+    const lookup = (async () => {
+      const value = await load();
+      if (onSuccess && this.epochUnchanged(key, epoch)) onSuccess(value);
+      return value;
+    })();
+
+    keys.set(inflightKey, lookup);
+    try {
+      return await lookup;
+    } finally {
+      this.removeInflightKeyFor(key, inflightKey, lookup);
+    }
+  }
+
+  invalidate(key: K): void {
+    this.clearInflightForKey(key);
+    this.bumpKeyEpoch(key);
+  }
+
+  invalidateAll(): void {
+    this.inflightByKey.clear();
+    this.globalEpoch++;
+  }
+
+  private clearInflightForKey(key: K): void {
+    this.inflightByKey.delete(key);
+  }
+
+  private inflightKeysFor(key: K): Map<I, Promise<unknown>> {
+    let keys = this.inflightByKey.get(key);
+    if (!keys) {
+      keys = new Map<I, Promise<unknown>>();
+      this.inflightByKey.set(key, keys);
+    }
+    return keys;
+  }
+
+  private removeInflightKeyFor(key: K, inflightKey: I, promise: Promise<unknown>): void {
+    const keys = this.inflightByKey.get(key);
+    if (!keys) return;
+    if (keys.get(inflightKey) !== promise) return;
+    keys.delete(inflightKey);
+    if (keys.size === 0) this.inflightByKey.delete(key);
+  }
+
+  private bumpKeyEpoch(key: K): void {
+    this.keyEpochs.set(key, (this.keyEpochs.get(key) ?? 0) + 1);
+  }
+
+  private epoch(key: K): { global: number; key: number } {
+    return {
+      global: this.globalEpoch,
+      key: this.keyEpochs.get(key) ?? 0,
+    };
+  }
+
+  private epochUnchanged(key: K, epoch: { global: number; key: number }): boolean {
+    return this.globalEpoch === epoch.global && (this.keyEpochs.get(key) ?? 0) === epoch.key;
+  }
+}
+
+/**
+ * Read-through TTL cache that owns the cache/single-flight/invalidation
+ * protocol for callers.
+ */
+export class ReadThroughTtlCache<K, V, I = K> {
+  private readonly values: TtlValueCache<K, V>;
+
+  private readonly singleFlight = new KeyedSingleFlight<K, I>();
+
+  constructor(options: TtlValueCacheOptions<V>) {
+    this.values = new TtlValueCache<K, V>(options);
+  }
+
+  async getOrLoad(
+    key: K,
+    inflightKey: I,
+    load: () => Promise<CacheValue<V>>,
+  ): Promise<CacheValue<V>> {
+    const cached = this.values.get(key);
+    if (cached !== undefined) return cached;
+    return this.singleFlight.run(key, inflightKey, load, (value) => {
+      this.values.set(key, value);
+    });
+  }
+
+  seed(key: K, value: CacheValue<V>): void {
+    this.singleFlight.invalidate(key);
+    this.values.set(key, value);
+  }
+
+  invalidate(key: K): void {
+    this.values.delete(key);
+    this.singleFlight.invalidate(key);
+  }
+
+  invalidateAll(): void {
+    this.values.clear();
+    this.singleFlight.invalidateAll();
+  }
+}

--- a/packages/chain/src/mock-adapter.ts
+++ b/packages/chain/src/mock-adapter.ts
@@ -132,7 +132,7 @@ export class MockChainAdapter implements ChainAdapter {
 
   /** RPC-usage capability: the mock has no RPC transport → always-empty window. */
   drainRpcUsage(): RpcUsageWindow {
-    return { byMethod: {}, lifetimeTotal: 0 };
+    return { byMethod: {}, ethCallByConsumer: {}, lifetimeTotal: 0 };
   }
 
   async ensureProfile(_options?: { nodeName?: string; stakeAmount?: bigint; lockTier?: number }): Promise<bigint> {

--- a/packages/chain/src/mock-adapter.ts
+++ b/packages/chain/src/mock-adapter.ts
@@ -481,6 +481,12 @@ export class MockChainAdapter implements ChainAdapter {
     return [];
   }
 
+  async *scanContextGraphRegistryPages(
+    _options: import('./chain-adapter.js').ContextGraphRegistryScanOptions,
+  ): AsyncIterable<import('./chain-adapter.js').ContextGraphRegistryScanPage> {
+    return;
+  }
+
   async hasContextGraphRegistryScanWatermark(): Promise<boolean> {
     return false;
   }

--- a/packages/chain/src/pca-read-cache.ts
+++ b/packages/chain/src/pca-read-cache.ts
@@ -16,7 +16,7 @@ export class PcaReadCache {
   });
 
   private readonly accountInfoCache = new ReadThroughTtlCache<string, V10PublishingConvictionAccountInfo | null>({
-    ttlMs: PcaReadCache.READ_TTL_MS,
+    ttlMs: (value) => (value === null ? 0 : PcaReadCache.READ_TTL_MS),
   });
 
   async getAgentAccountId(

--- a/packages/chain/src/pca-read-cache.ts
+++ b/packages/chain/src/pca-read-cache.ts
@@ -1,0 +1,100 @@
+import { ethers } from 'ethers';
+import type { V10PublishingConvictionAccountInfo } from './chain-adapter.js';
+import { ReadThroughTtlCache } from './keyed-ttl-single-flight-cache.js';
+
+export type PcaMutationInvalidation<T> =
+  | { kind: 'account-created'; accountIdFromResult: (result: T) => bigint | undefined }
+  | { kind: 'account-changed'; accountId: bigint }
+  | { kind: 'agents-changed'; accountId: bigint; agents: readonly string[] }
+  | { kind: 'all-agents-cleared'; accountId: bigint };
+
+export class PcaReadCache {
+  private static readonly READ_TTL_MS = 15 * 1000;
+
+  private readonly agentAccountIdCache = new ReadThroughTtlCache<string, bigint, string>({
+    ttlMs: 0,
+  });
+
+  private readonly accountInfoCache = new ReadThroughTtlCache<string, V10PublishingConvictionAccountInfo | null>({
+    ttlMs: PcaReadCache.READ_TTL_MS,
+  });
+
+  async getAgentAccountId(
+    agent: string,
+    strict: boolean,
+    load: (normalizedAgent: string) => Promise<bigint>,
+  ): Promise<bigint> {
+    const normalized = this.normalizeAgent(agent);
+    if (!normalized) return 0n;
+    return this.agentAccountIdCache.getOrLoad(
+      normalized.cacheKey,
+      `${normalized.cacheKey}:${strict ? 'strict' : 'soft'}`,
+      () => load(normalized.address),
+    );
+  }
+
+  async getAccountInfo(
+    accountId: bigint,
+    extended: boolean,
+    load: () => Promise<V10PublishingConvictionAccountInfo | null>,
+  ): Promise<V10PublishingConvictionAccountInfo | null> {
+    const key = this.accountInfoCacheKey(accountId, extended);
+    return this.accountInfoCache.getOrLoad(key, key, load);
+  }
+
+  invalidateMutation<T>(invalidation: PcaMutationInvalidation<T>, result: T): void {
+    switch (invalidation.kind) {
+      case 'account-created':
+        this.invalidatePcaAccountInfo(invalidation.accountIdFromResult(result));
+        return;
+      case 'account-changed':
+        this.invalidatePcaAccountInfo(invalidation.accountId);
+        return;
+      case 'agents-changed':
+        this.invalidatePcaAccountInfo(invalidation.accountId);
+        for (const agent of invalidation.agents) this.invalidatePcaAgent(agent);
+        return;
+      case 'all-agents-cleared':
+        this.invalidatePcaAccountInfo(invalidation.accountId);
+        this.invalidatePcaAgentsForAccount(invalidation.accountId);
+        return;
+    }
+  }
+
+  private invalidatePcaAccountInfo(accountId?: bigint): void {
+    if (accountId == null || accountId <= 0n) return;
+    for (const key of [
+      this.accountInfoCacheKey(accountId, false),
+      this.accountInfoCacheKey(accountId, true),
+    ]) {
+      this.accountInfoCache.invalidate(key);
+    }
+  }
+
+  private invalidatePcaAgent(agent: string): void {
+    const normalized = this.normalizeAgent(agent);
+    if (!normalized) return;
+    this.agentAccountIdCache.invalidate(normalized.cacheKey);
+  }
+
+  private invalidateAllPcaAgents(): void {
+    this.agentAccountIdCache.invalidateAll();
+  }
+
+  private invalidatePcaAgentsForAccount(accountId?: bigint): void {
+    if (accountId == null || accountId <= 0n) return;
+    // The chain exposes no cheap reverse index from account -> agents here.
+    // A broad flush is safer than retaining a stale allow-list after clearAgents().
+    this.invalidateAllPcaAgents();
+  }
+
+  private accountInfoCacheKey(accountId: bigint, extended: boolean): string {
+    return `${accountId.toString()}:${extended ? 'extended' : 'base'}`;
+  }
+
+  private normalizeAgent(agent: string): { address: string; cacheKey: string } | undefined {
+    if (!ethers.isAddress(agent)) return undefined;
+    const address = ethers.getAddress(agent);
+    return { address, cacheKey: address.toLowerCase() };
+  }
+}

--- a/packages/chain/src/rpc-failover-client.ts
+++ b/packages/chain/src/rpc-failover-client.ts
@@ -62,18 +62,25 @@ export interface RpcEndpoint {
  * {@link resolveCapMs}.
  *   - `pointRead`           — a single `eth_call` / point provider read.
  *   - `wideLogScan`         — a multi-thousand-block `eth_getLogs` scan.
+ *   - `watchdogPointRead`   — a background point read that must not wedge a
+ *     one-RPC node.
+ *   - `watchdogWideLogScan` — a background log scan that must not wedge a
+ *     one-RPC node.
  *   - `failOpenFundingRead` — a fail-open funding/allowance read that must never
  *     stall selection (capped on EVERY attempt, including single-RPC).
  */
-export type ReadPolicy = 'pointRead' | 'wideLogScan' | 'failOpenFundingRead';
+export type ReadPolicy =
+  | 'pointRead'
+  | 'wideLogScan'
+  | 'watchdogPointRead'
+  | 'watchdogWideLogScan'
+  | 'failOpenFundingRead';
 
 /** Per-read options: a named timeout policy + an optional failover classifier
  *  override (a read whose error shape carries domain meaning). */
 export interface ReadOpts {
   policy?: ReadPolicy;
   isRetryable?: (err: unknown) => boolean;
-  /** Opt-in watchdog for background reads that must not wedge even with one RPC endpoint. */
-  capSingleProvider?: boolean;
 }
 
 /**
@@ -106,24 +113,25 @@ export function isContractViewRetryable(err: unknown): boolean {
 /**
  * The timeout-policy matrix — the per-attempt cap each named policy yields:
  *
- *   | policy              | multi-RPC cap            | single-RPC default      | capSingleProvider |
- *   |---------------------|--------------------------|-------------------------|-------------------|
- *   | pointRead           | RPC_READ_STALL (4s)      | uncapped (#894)         | RPC_READ_STALL    |
- *   | wideLogScan         | RPC_LOG_SCAN (30s)       | uncapped (#894)         | RPC_LOG_SCAN      |
- *   | failOpenFundingRead | RPC_READ_STALL (4s)      | RPC_READ_STALL (4s)     | RPC_READ_STALL    |
+ *   | policy              | multi-RPC cap            | single-RPC cap          |
+ *   |---------------------|--------------------------|-------------------------|
+ *   | pointRead           | RPC_READ_STALL (4s)      | uncapped (#894)         |
+ *   | wideLogScan         | RPC_LOG_SCAN (30s)       | uncapped (#894)         |
+ *   | watchdogPointRead   | RPC_READ_STALL (4s)      | RPC_READ_STALL (4s)    |
+ *   | watchdogWideLogScan | RPC_LOG_SCAN (30s)       | RPC_LOG_SCAN (30s)     |
+ *   | failOpenFundingRead | RPC_READ_STALL (4s)      | RPC_READ_STALL (4s)    |
  *
  * `pointRead` / `wideLogScan` leave single-RPC uncapped (nothing to fail over
- * to; #894) by default. `capSingleProvider` lets background watcher reads opt
- * into the same per-policy cap for a one-endpoint node without imposing a
- * poll-level deadline over the multi-RPC failover sequence.
+ * to; #894). The watchdog policies are for background reads that must clear
+ * their scheduler gate even on one-RPC nodes, without imposing a poll-level
+ * deadline over a multi-RPC failover sequence.
  */
-export function resolveCapMs(
-  policy: ReadPolicy,
-  providerCount: number,
-  capSingleProvider = false,
-): number | undefined {
-  if (policy === 'failOpenFundingRead') return RPC_READ_STALL_TIMEOUT_MS;
-  if (providerCount <= 1 && !capSingleProvider) return undefined;
+export function resolveCapMs(policy: ReadPolicy, providerCount: number): number | undefined {
+  if (policy === 'failOpenFundingRead' || policy === 'watchdogPointRead') {
+    return RPC_READ_STALL_TIMEOUT_MS;
+  }
+  if (policy === 'watchdogWideLogScan') return RPC_LOG_SCAN_TIMEOUT_MS;
+  if (providerCount <= 1) return undefined;
   return policy === 'wideLogScan' ? RPC_LOG_SCAN_TIMEOUT_MS : RPC_READ_STALL_TIMEOUT_MS;
 }
 
@@ -193,7 +201,6 @@ export class RpcFailoverClient {
       fn,
       opts?.isRetryable ?? isRetryableRpcError,
       opts?.policy ?? 'pointRead',
-      opts?.capSingleProvider ?? false,
     );
   }
 
@@ -228,7 +235,6 @@ export class RpcFailoverClient {
             (p) => fn(this.rebindContract(contract, p)),
             opts?.isRetryable ?? isContractViewRetryable,
             opts?.policy ?? 'pointRead',
-            opts?.capSingleProvider ?? false,
           );
           this.recordRpcOutcome('eth_call', 'ok');
           return out;
@@ -509,8 +515,8 @@ export class RpcFailoverClient {
    * `readContract`. The per-attempt `withTimeout` is a hard deadline that ABORTS
    * and fails over a hung backend; the cap comes from the named `policy` via
    * {@link resolveCapMs} (multi-RPC caps each attempt; single-RPC is uncapped for
-   * `pointRead`/`wideLogScan` by default — #894, nothing to fail over to — unless
-   * the caller opts into `capSingleProvider` or uses `failOpenFundingRead`). The
+   * `pointRead`/`wideLogScan` — #894, nothing to fail over to — while watchdog
+   * policies and `failOpenFundingRead` cap even single-RPC attempts). The
    * `endpoints` are read LIVE from the injected thunk so a mid-flight reassignment
    * of the pool is observed.
    */
@@ -519,10 +525,9 @@ export class RpcFailoverClient {
     fn: (provider: JsonRpcProvider) => Promise<T>,
     isRetryable: (err: unknown) => boolean,
     policy: ReadPolicy,
-    capSingleProvider: boolean,
   ): Promise<T> {
     const endpoints = this.getEndpoints();
-    const capMs = resolveCapMs(policy, endpoints.length, capSingleProvider);
+    const capMs = resolveCapMs(policy, endpoints.length);
     let lastRetryable: unknown;
     for (let i = 0; i < endpoints.length; i += 1) {
       const endpoint = endpoints[i];

--- a/packages/chain/src/rpc-failover-client.ts
+++ b/packages/chain/src/rpc-failover-client.ts
@@ -72,6 +72,8 @@ export type ReadPolicy = 'pointRead' | 'wideLogScan' | 'failOpenFundingRead';
 export interface ReadOpts {
   policy?: ReadPolicy;
   isRetryable?: (err: unknown) => boolean;
+  /** Opt-in watchdog for background reads that must not wedge even with one RPC endpoint. */
+  capSingleProvider?: boolean;
 }
 
 /**
@@ -104,19 +106,24 @@ export function isContractViewRetryable(err: unknown): boolean {
 /**
  * The timeout-policy matrix — the per-attempt cap each named policy yields:
  *
- *   | policy              | multi-RPC cap            | single-RPC cap          |
- *   |---------------------|--------------------------|-------------------------|
- *   | pointRead           | RPC_READ_STALL (4s)      | uncapped (#894)         |
- *   | wideLogScan         | RPC_LOG_SCAN (30s)       | uncapped (#894)         |
- *   | failOpenFundingRead | RPC_READ_STALL (4s)      | RPC_READ_STALL (4s)     |
+ *   | policy              | multi-RPC cap            | single-RPC default      | capSingleProvider |
+ *   |---------------------|--------------------------|-------------------------|-------------------|
+ *   | pointRead           | RPC_READ_STALL (4s)      | uncapped (#894)         | RPC_READ_STALL    |
+ *   | wideLogScan         | RPC_LOG_SCAN (30s)       | uncapped (#894)         | RPC_LOG_SCAN      |
+ *   | failOpenFundingRead | RPC_READ_STALL (4s)      | RPC_READ_STALL (4s)     | RPC_READ_STALL    |
  *
  * `pointRead` / `wideLogScan` leave single-RPC uncapped (nothing to fail over
- * to; #894); `failOpenFundingRead` caps EVERY attempt incl. single so a fail-open
- * funding read can never stall publish-signer selection.
+ * to; #894) by default. `capSingleProvider` lets background watcher reads opt
+ * into the same per-policy cap for a one-endpoint node without imposing a
+ * poll-level deadline over the multi-RPC failover sequence.
  */
-export function resolveCapMs(policy: ReadPolicy, providerCount: number): number | undefined {
+export function resolveCapMs(
+  policy: ReadPolicy,
+  providerCount: number,
+  capSingleProvider = false,
+): number | undefined {
   if (policy === 'failOpenFundingRead') return RPC_READ_STALL_TIMEOUT_MS;
-  if (providerCount <= 1) return undefined;
+  if (providerCount <= 1 && !capSingleProvider) return undefined;
   return policy === 'wideLogScan' ? RPC_LOG_SCAN_TIMEOUT_MS : RPC_READ_STALL_TIMEOUT_MS;
 }
 
@@ -186,6 +193,7 @@ export class RpcFailoverClient {
       fn,
       opts?.isRetryable ?? isRetryableRpcError,
       opts?.policy ?? 'pointRead',
+      opts?.capSingleProvider ?? false,
     );
   }
 
@@ -220,6 +228,7 @@ export class RpcFailoverClient {
             (p) => fn(this.rebindContract(contract, p)),
             opts?.isRetryable ?? isContractViewRetryable,
             opts?.policy ?? 'pointRead',
+            opts?.capSingleProvider ?? false,
           );
           this.recordRpcOutcome('eth_call', 'ok');
           return out;
@@ -499,20 +508,21 @@ export class RpcFailoverClient {
    * The shared read-family core: one per-endpoint loop backing both `read` and
    * `readContract`. The per-attempt `withTimeout` is a hard deadline that ABORTS
    * and fails over a hung backend; the cap comes from the named `policy` via
-   * {@link resolveCapMs} (multi-RPC caps the attempt; single-RPC is uncapped for
-   * `pointRead`/`wideLogScan` — #894, nothing to fail over to — UNLESS
-   * `failOpenFundingRead`, which caps every attempt). The `endpoints` are read
-   * LIVE from the injected thunk so a mid-flight reassignment of the pool is
-   * observed.
+   * {@link resolveCapMs} (multi-RPC caps each attempt; single-RPC is uncapped for
+   * `pointRead`/`wideLogScan` by default — #894, nothing to fail over to — unless
+   * the caller opts into `capSingleProvider` or uses `failOpenFundingRead`). The
+   * `endpoints` are read LIVE from the injected thunk so a mid-flight reassignment
+   * of the pool is observed.
    */
   private async runAcrossProviders<T>(
     label: string,
     fn: (provider: JsonRpcProvider) => Promise<T>,
     isRetryable: (err: unknown) => boolean,
     policy: ReadPolicy,
+    capSingleProvider: boolean,
   ): Promise<T> {
     const endpoints = this.getEndpoints();
-    const capMs = resolveCapMs(policy, endpoints.length);
+    const capMs = resolveCapMs(policy, endpoints.length, capSingleProvider);
     let lastRetryable: unknown;
     for (let i = 0; i < endpoints.length; i += 1) {
       const endpoint = endpoints[i];

--- a/packages/chain/src/rpc-failover-client.ts
+++ b/packages/chain/src/rpc-failover-client.ts
@@ -9,7 +9,8 @@
  * SAFETY BOUNDARY: this module holds NO transaction-safety state — no WAL, no
  * per-wallet serializer, no approval latch. The adapter's tx-orchestration owns
  * all of that and calls into this surface. The module never references the
- * adapter; it is constructed with exactly two capabilities:
+ * adapter; it is constructed with two required capabilities and one optional
+ * per-endpoint transport preflight:
  *   1. `getEndpoints()` — a LIVE thunk over the RPC endpoints, each a
  *      `{ provider, rpcUrl }` pair. One object per endpoint keeps the
  *      `provider ↔ rpcUrl` pairing explicit inside every failover loop (not an
@@ -83,6 +84,9 @@ export type SignPopulatedFn = (
   populated: ethers.TransactionRequest,
 ) => Promise<{ signedTx: string; txHash: string }>;
 
+/** Optional per-endpoint transport preflight, e.g. static-network chain-id validation. */
+export type ValidateEndpointFn = (endpoint: RpcEndpoint) => Promise<void>;
+
 /**
  * Failover classifier for CONTRACT VIEW reads (`readContract`'s default): the
  * generic `isRetryableRpcError` transient set MINUS `BAD_DATA`. A view `BAD_DATA`
@@ -125,6 +129,7 @@ export class RpcFailoverClient {
     // construct this client BEFORE its own `chainId` field is assigned and still
     // have the label resolve correctly at metric-record time.
     private readonly chainId: () => string,
+    private readonly validateEndpoint?: ValidateEndpointFn,
   ) {}
 
   /**
@@ -259,8 +264,14 @@ export class RpcFailoverClient {
     const endpoints = this.getEndpoints();
     let lastRetryable: unknown;
     for (let i = 0; i < endpoints.length; i += 1) {
-      const rpcSigner = this.rebindSigner(signer, endpoints[i].provider);
+      const endpoint = endpoints[i];
       try {
+        await this.validateEndpointForAttempt(
+          endpoint,
+          RPC_TRANSACTION_POPULATION_ATTEMPT_TIMEOUT_MS,
+          `${label} chainId validation via RPC #${i + 1}`,
+        );
+        const rpcSigner = this.rebindSigner(signer, endpoint.provider);
         const connected = this.rebindContract(contract, rpcSigner) as any;
         const populated = await withTimeout<ethers.TransactionRequest>(
           connected[method].populateTransaction(...args) as Promise<ethers.TransactionRequest>,
@@ -349,9 +360,15 @@ export class RpcFailoverClient {
           const endpoints = this.getEndpoints();
           let lastRetryable: unknown;
           for (let i = 0; i < endpoints.length; i += 1) {
-            const provider = endpoints[i].provider;
+            const endpoint = endpoints[i];
+            const provider = endpoint.provider;
             span.addEvent('broadcast.attempt', { attempt: i + 1 });
             try {
+              await this.validateEndpointForAttempt(
+                endpoint,
+                RPC_BROADCAST_ATTEMPT_TIMEOUT_MS,
+                `${label} chainId validation via RPC #${i + 1}`,
+              );
               await withTimeout(
                 provider.broadcastTransaction(signedTx),
                 RPC_BROADCAST_ATTEMPT_TIMEOUT_MS,
@@ -421,9 +438,15 @@ export class RpcFailoverClient {
           let lastRetryable: unknown;
           let sawNonErrorResponse = false;
           for (let i = 0; i < endpoints.length; i += 1) {
-            const provider = endpoints[i].provider;
+            const endpoint = endpoints[i];
+            const provider = endpoint.provider;
             span.addEvent('receipt.attempt', { attempt: i + 1 });
             try {
+              await this.validateEndpointForAttempt(
+                endpoint,
+                RPC_RECEIPT_ATTEMPT_TIMEOUT_MS,
+                `receipt lookup chainId validation via RPC #${i + 1}`,
+              );
               const receipt = await withTimeout(
                 provider.getTransactionReceipt(txHash),
                 RPC_RECEIPT_ATTEMPT_TIMEOUT_MS,
@@ -492,9 +515,17 @@ export class RpcFailoverClient {
     const capMs = resolveCapMs(policy, endpoints.length);
     let lastRetryable: unknown;
     for (let i = 0; i < endpoints.length; i += 1) {
+      const endpoint = endpoints[i];
       const isLast = i === endpoints.length - 1;
       try {
-        const attempt = fn(endpoints[i].provider);
+        const attempt = (async () => {
+          await this.validateEndpointForAttempt(
+            endpoint,
+            capMs,
+            `${label} chainId validation via RPC #${i + 1}`,
+          );
+          return fn(endpoint.provider);
+        })();
         return await (capMs == null
           ? attempt
           : withTimeout(attempt, capMs, `${label} via RPC #${i + 1}`));
@@ -532,6 +563,20 @@ export class RpcFailoverClient {
    */
   private rebindContract(contract: Contract, runner: JsonRpcProvider | Wallet): Contract {
     return contract.connect(runner) as Contract;
+  }
+
+  private async validateEndpointForAttempt(
+    endpoint: RpcEndpoint,
+    timeoutMs: number | undefined,
+    timeoutLabel: string,
+  ): Promise<void> {
+    if (!this.validateEndpoint) return;
+    const validation = this.validateEndpoint(endpoint);
+    if (timeoutMs == null) {
+      await validation;
+      return;
+    }
+    await withTimeout(validation, timeoutMs, timeoutLabel);
   }
 
   /** Rebind a SIGNER to `provider` for one per-endpoint populate+sign attempt. */

--- a/packages/chain/src/rpc-failover-client.ts
+++ b/packages/chain/src/rpc-failover-client.ts
@@ -36,6 +36,7 @@ import { withTimeout, isRetryableRpcError, isKnownTransactionError } from './evm
 import { errorCode, errorMessage } from './evm-adapter-errors.js';
 import { noteRpcFailover, noteRpcExhaustion, rpcHost } from './rpc-failover-log.js';
 import { ChainRpcTransportError } from './chain-rpc-transport-error.js';
+import { withRpcUsageConsumer } from './rpc-usage.js';
 import {
   RPC_READ_STALL_TIMEOUT_MS,
   RPC_LOG_SCAN_TIMEOUT_MS,
@@ -76,11 +77,13 @@ export type ReadPolicy =
   | 'watchdogWideLogScan'
   | 'failOpenFundingRead';
 
-/** Per-read options: a named timeout policy + an optional failover classifier
- *  override (a read whose error shape carries domain meaning). */
+/** Per-read options: timeout/failover behavior plus an explicit low-cardinality
+ *  telemetry consumer key for `eth_call` attribution. `label` remains a human
+ *  failover/span label and is not implicitly part of the daemon log contract. */
 export interface ReadOpts {
   policy?: ReadPolicy;
   isRetryable?: (err: unknown) => boolean;
+  rpcUsageConsumer?: string;
 }
 
 /**
@@ -196,12 +199,13 @@ export class RpcFailoverClient {
     fn: (provider: JsonRpcProvider) => Promise<T>,
     opts?: ReadOpts,
   ): Promise<T> {
-    return this.runAcrossProviders(
+    const run = () => this.runAcrossProviders(
       label,
       fn,
       opts?.isRetryable ?? isRetryableRpcError,
       opts?.policy ?? 'pointRead',
     );
+    return opts?.rpcUsageConsumer ? withRpcUsageConsumer(opts.rpcUsageConsumer, run) : run();
   }
 
   /**
@@ -224,7 +228,7 @@ export class RpcFailoverClient {
     // `chain.eth_call` span + RPC metric spanning the whole failover sequence.
     // `dkg.read=label` (e.g. 'token.allowance') rides the SPAN only — kept OFF
     // the metric so its label set stays low-cardinality.
-    return withSpan(
+    const run = () => withSpan(
       'chain.eth_call',
       async () => {
         const metrics = getMetrics();
@@ -249,6 +253,7 @@ export class RpcFailoverClient {
       },
       { attributes: { 'rpc.method': 'eth_call', 'dkg.chain_id': chainId, 'dkg.read': label } },
     );
+    return opts?.rpcUsageConsumer ? withRpcUsageConsumer(opts.rpcUsageConsumer, run) : run();
   }
 
   // --- write transport (called by the adapter's tx-orchestration; this layer

--- a/packages/chain/src/rpc-usage.ts
+++ b/packages/chain/src/rpc-usage.ts
@@ -258,6 +258,7 @@ export function createCountingJsonRpcProvider(
   maxRetries: number | undefined,
   tracker: RpcUsageTracker,
   options: JsonRpcApiProviderOptions,
+  network?: Networkish,
 ): CountingJsonRpcProvider {
   // boundedRetryFetchRequest stays PURE retry policy; the accounting
   // composition lives HERE, with the rest of the accounting. Ethers' throttle
@@ -276,5 +277,15 @@ export function createCountingJsonRpcProvider(
     }
     return retry;
   };
-  return new CountingJsonRpcProvider(fetchRequest, undefined, options, (method) => tracker.record(method));
+  const providerOptions = network == null
+    ? options
+    : {
+        ...options,
+        // `network` is supplied from static node config. Passing it here tells
+        // ethers not to re-detect the same chain with eth_chainId on every
+        // internal network check, while malformed/absent config keeps the old
+        // dynamic detection behavior.
+        staticNetwork: network as JsonRpcApiProviderOptions['staticNetwork'],
+      };
+  return new CountingJsonRpcProvider(fetchRequest, network, providerOptions, (method) => tracker.record(method));
 }

--- a/packages/chain/src/rpc-usage.ts
+++ b/packages/chain/src/rpc-usage.ts
@@ -21,6 +21,7 @@
  *    per method TODAY, with exact sums (deltas, not cumulative gauges).
  */
 
+import { AsyncLocalStorage } from 'node:async_hooks';
 import { JsonRpcProvider } from 'ethers';
 import type {
   FetchRequest,
@@ -88,8 +89,17 @@ export function jsonRpcMethodsFromBody(body: Uint8Array | null | undefined): str
 }
 
 /** A fresh all-zero window — the identity element for merging and the value of "nothing to report". */
-export function emptyRpcUsageWindow(): RpcUsageWindow {
-  return { byMethod: {}, lifetimeTotal: 0 };
+export function emptyRpcUsageWindow(): NormalizedRpcUsageWindow {
+  return { byMethod: {}, ethCallByConsumer: {}, lifetimeTotal: 0 };
+}
+
+/** Normalize a public drain-window input into the concrete telemetry model. */
+export function normalizeRpcUsageWindow(window: RpcUsageWindow): NormalizedRpcUsageWindow {
+  return {
+    byMethod: window.byMethod,
+    ethCallByConsumer: window.ethCallByConsumer ?? {},
+    lifetimeTotal: window.lifetimeTotal,
+  };
 }
 
 /**
@@ -116,16 +126,21 @@ export interface RpcUsageDrainable {
  */
 export function mergeRpcUsageWindows(
   ...windows: Array<RpcUsageWindow | undefined>
-): RpcUsageWindow {
+): NormalizedRpcUsageWindow {
   const defined = windows.filter((w): w is RpcUsageWindow => w !== undefined);
   if (defined.length === 0) return emptyRpcUsageWindow();
   const byMethod: Record<string, number> = {};
+  const ethCallByConsumer: Record<string, number> = {};
   let lifetimeTotal = 0;
-  for (const w of defined) {
+  for (const input of defined) {
+    const w = normalizeRpcUsageWindow(input);
     for (const [m, c] of Object.entries(w.byMethod)) byMethod[m] = (byMethod[m] ?? 0) + c;
+    for (const [consumer, c] of Object.entries(w.ethCallByConsumer)) {
+      ethCallByConsumer[consumer] = (ethCallByConsumer[consumer] ?? 0) + c;
+    }
     lifetimeTotal += w.lifetimeTotal;
   }
-  return { byMethod, lifetimeTotal };
+  return { byMethod, ethCallByConsumer, lifetimeTotal };
 }
 
 export interface RpcUsageWindow {
@@ -137,8 +152,25 @@ export interface RpcUsageWindow {
    * must sanitize keys for their own sink (the cli logfmt formatter does).
    */
   byMethod: Record<string, number>;
+  /**
+   * Raw `eth_call` attribution by bounded code-owned consumer label.
+   * This is a companion diagnostic dimension only: `byMethod.eth_call` remains
+   * the billing-exact aggregate count and existing dashboards should continue
+   * to use it. The consumer map is emitted as separate daemon log lines so it
+   * cannot double-count aggregate `rpc_usage` queries. Empty map means no
+   * attributed `eth_call`s in the current drain window. Optional only to
+   * preserve source compatibility for external drain sources that still return
+   * the pre-attribution aggregate window. Package-owned producers return the
+   * concrete {@link NormalizedRpcUsageWindow} shape.
+   */
+  ethCallByConsumer?: Record<string, number>;
   /** Raw requests since process start (monotonic; NOT reset by drain). */
   lifetimeTotal: number;
+}
+
+/** Concrete package-owned telemetry window after legacy inputs are normalized. */
+export interface NormalizedRpcUsageWindow extends RpcUsageWindow {
+  ethCallByConsumer: Record<string, number>;
 }
 
 /**
@@ -146,10 +178,40 @@ export interface RpcUsageWindow {
  * window model deliberately stores no separate total, so an inconsistent
  * {byMethod, total} pair is unrepresentable.
  */
-export function rpcUsageWindowTotal(window: RpcUsageWindow): number {
+export function rpcUsageWindowTotal(window: Pick<RpcUsageWindow, 'byMethod'>): number {
   let total = 0;
   for (const count of Object.values(window.byMethod)) total += count;
   return total;
+}
+
+const rpcUsageConsumerContext = new AsyncLocalStorage<string>();
+
+/**
+ * Bound code-owned read labels for logfmt-safe consumer attribution. Labels are
+ * intentionally not derived from calldata, addresses, request ids, or peer ids.
+ */
+export function normalizeRpcUsageConsumer(consumer: string | undefined): string | undefined {
+  if (typeof consumer !== 'string') return undefined;
+  const normalized = consumer
+    .trim()
+    .replace(/[^A-Za-z0-9_.:-]+/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/^_+|_+$/g, '');
+  if (normalized.length === 0) return undefined;
+  if (normalized.length > 64) return 'other';
+  return normalized;
+}
+
+/** Run a provider read under a bounded diagnostic consumer label. */
+export function withRpcUsageConsumer<T>(consumer: string, fn: () => T): T {
+  const normalized = normalizeRpcUsageConsumer(consumer);
+  if (!normalized) return fn();
+  return rpcUsageConsumerContext.run(normalized, fn);
+}
+
+/** Current diagnostic consumer label, if a caller established one. */
+function activeRpcUsageConsumer(): string | undefined {
+  return rpcUsageConsumerContext.getStore();
 }
 
 /**
@@ -159,6 +221,7 @@ export function rpcUsageWindowTotal(window: RpcUsageWindow): number {
  */
 export class RpcUsageTracker {
   private window = new Map<string, number>();
+  private ethCallConsumers = new Map<string, number>();
   private lifetime = 0;
 
   constructor(
@@ -180,6 +243,7 @@ export class RpcUsageTracker {
    * one rpc_usage log line per fabricated name every minute.
    */
   static readonly MAX_WINDOW_METHODS = 64;
+  static readonly MAX_WINDOW_CONSUMERS = 128;
 
   record(method: string): void {
     // Authoritative window/lifetime state first, OUTSIDE any try — pure map
@@ -188,6 +252,16 @@ export class RpcUsageTracker {
     const raw = typeof method === 'string' && method.length > 0 && method.length <= 128 ? method : 'other';
     const key = this.window.has(raw) || this.window.size < RpcUsageTracker.MAX_WINDOW_METHODS ? raw : 'other';
     this.window.set(key, (this.window.get(key) ?? 0) + 1);
+    if (raw === 'eth_call') {
+      const normalizedConsumer = activeRpcUsageConsumer();
+      if (normalizedConsumer) {
+        const consumerKey = this.ethCallConsumers.has(normalizedConsumer) ||
+          this.ethCallConsumers.size < RpcUsageTracker.MAX_WINDOW_CONSUMERS
+          ? normalizedConsumer
+          : 'other';
+        this.ethCallConsumers.set(consumerKey, (this.ethCallConsumers.get(consumerKey) ?? 0) + 1);
+      }
+    }
     this.lifetime += 1;
     // Best-effort applies ONLY to the OTel side effect (and the chainId
     // thunk it evaluates) — a throwing metrics backend must not break the
@@ -207,11 +281,14 @@ export class RpcUsageTracker {
    * cumulative totals) are what the daemon logs, so `sum_over_time` in Grafana
    * yields exact request counts over any range.
    */
-  drainWindow(): RpcUsageWindow {
+  drainWindow(): NormalizedRpcUsageWindow {
     const byMethod: Record<string, number> = {};
     for (const [method, count] of this.window) byMethod[method] = count;
     this.window.clear();
-    return { byMethod, lifetimeTotal: this.lifetime };
+    const ethCallByConsumer: Record<string, number> = {};
+    for (const [consumer, count] of this.ethCallConsumers) ethCallByConsumer[consumer] = count;
+    this.ethCallConsumers.clear();
+    return { byMethod, ethCallByConsumer, lifetimeTotal: this.lifetime };
   }
 }
 
@@ -287,5 +364,10 @@ export function createCountingJsonRpcProvider(
         // dynamic detection behavior.
         staticNetwork: network as JsonRpcApiProviderOptions['staticNetwork'],
       };
-  return new CountingJsonRpcProvider(fetchRequest, network, providerOptions, (method) => tracker.record(method));
+  return new CountingJsonRpcProvider(
+    fetchRequest,
+    network,
+    providerOptions,
+    (method) => tracker.record(method),
+  );
 }

--- a/packages/chain/test/chain-rpc-telemetry.unit.test.ts
+++ b/packages/chain/test/chain-rpc-telemetry.unit.test.ts
@@ -33,6 +33,7 @@ function minimalConfig(overrides: Partial<EVMAdapterConfig> = {}): EVMAdapterCon
     hubAddress: HUB,
     chainId: 'evm:31337',
     allowNoAdminSigner: true,
+    staticNetwork: false,
     ...overrides,
   };
 }

--- a/packages/chain/test/context-graph-registry-scan.unit.test.ts
+++ b/packages/chain/test/context-graph-registry-scan.unit.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from 'vitest';
 import { EVMChainAdapter, type EVMAdapterConfig } from '../src/evm-adapter.js';
 import { ContextGraphChainScanPartialError } from '../src/chain-adapter.js';
 import {
-  CG_REGISTRY_LIVE_TAIL_LOOKBACK_BLOCKS,
   CG_REGISTRY_MAX_SCAN_PAGES,
   CG_REGISTRY_REORG_BUFFER_BLOCKS,
 } from '../src/evm-adapter-base.js';
@@ -232,15 +231,23 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
   });
 
   it('can seed the incremental watermark from an explicit successful full scan', async () => {
-    const registry = makeRegistry();
-    const { adapter, provider } = makeAdapter(registry, 4_000);
-    registry.queryFilter.setImpl(async () => []);
+    const historicalGraphBlock = 10_000;
+    const head = 20_000;
+    const registry = makeRegistry({
+      queryFilter: seam(async (_filter: unknown, lo: number, hi: number) =>
+        lo <= historicalGraphBlock && historicalGraphBlock <= hi
+          ? [{ topics: [], data: '0x01', blockNumber: historicalGraphBlock }]
+          : [],
+      ),
+    });
+    const { adapter, provider } = makeAdapter(registry, head);
 
     await expect(adapter.hasContextGraphRegistryScanWatermark()).resolves.toBe(false);
 
-    await adapter.listContextGraphsFromChain(undefined, { seedIncrementalWatermark: true });
+    const seeded = await adapter.listContextGraphsFromChain(undefined, { seedIncrementalWatermark: true });
 
-    expect((adapter as any).contextGraphRegistryScanWatermarks.get(REGISTRY.toLowerCase())).toBe(4_001);
+    expect(seeded.map((cg) => cg.blockNumber)).toEqual([historicalGraphBlock]);
+    expect((adapter as any).contextGraphRegistryScanWatermarks.get(REGISTRY.toLowerCase())).toBe(head + 1);
     await expect(adapter.hasContextGraphRegistryScanWatermark()).resolves.toBe(true);
 
     provider.getCode = seam(async () => {
@@ -252,34 +259,8 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
 
     expect(provider.getCode.calls).toEqual([]);
     expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
-      [4_001 - CG_REGISTRY_REORG_BUFFER_BLOCKS, 4_000],
+      [head + 1 - CG_REGISTRY_REORG_BUFFER_BLOCKS, head],
     ]);
-  });
-
-  it('can seed the incremental watermark from a bounded live-tail scan without deploy-block probing', async () => {
-    const registry = makeRegistry();
-    const head = 20_000;
-    const { adapter, provider } = makeAdapter(registry, head);
-    provider.getCode = seam(async () => {
-      throw new Error('eth_getCode should not be called for daemon live-tail seeding');
-    });
-    registry.queryFilter.setImpl(async () => []);
-
-    await adapter.listContextGraphsFromChain(undefined, {
-      liveTailOnly: true,
-      liveTailLookbackBlocks: CG_REGISTRY_LIVE_TAIL_LOOKBACK_BLOCKS,
-      seedIncrementalWatermark: true,
-    });
-
-    expect(provider.getCode.calls).toEqual([]);
-    expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
-      [11_001, 13_000],
-      [13_001, 15_000],
-      [15_001, 17_000],
-      [17_001, 19_000],
-      [19_001, 20_000],
-    ]);
-    expect((adapter as any).contextGraphRegistryScanWatermarks.get(REGISTRY.toLowerCase())).toBe(head + 1);
   });
 
   it('reports no registry scan watermark after preflight cache invalidation', async () => {

--- a/packages/chain/test/context-graph-registry-scan.unit.test.ts
+++ b/packages/chain/test/context-graph-registry-scan.unit.test.ts
@@ -64,6 +64,7 @@ function minimalConfig(overrides: Partial<EVMAdapterConfig> = {}): EVMAdapterCon
     adminPrivateKey: ADMIN_PK,
     hubAddress: '0x0000000000000000000000000000000000000001',
     chainId: 'evm:31337',
+    staticNetwork: false,
     ...overrides,
   };
 }

--- a/packages/chain/test/context-graph-registry-scan.unit.test.ts
+++ b/packages/chain/test/context-graph-registry-scan.unit.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { EVMChainAdapter, type EVMAdapterConfig } from '../src/evm-adapter.js';
-import { ContextGraphChainScanPartialError, type ContextGraphOnChain, type ContextGraphRegistryScanOptions } from '../src/chain-adapter.js';
+import { ContextGraphChainScanPartialError, type ContextGraphChainScanOptions, type ContextGraphOnChain, type ContextGraphRegistryScanOptions } from '../src/chain-adapter.js';
 import {
   CG_REGISTRY_MAX_SCAN_PAGES,
   CG_REGISTRY_REORG_BUFFER_BLOCKS,
@@ -328,6 +328,36 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
       [1_000 - CG_REGISTRY_REORG_BUFFER_BLOCKS, 1_949],
     ]);
     expect(store.saves.map((s) => s.nextBlock)).toEqual([1_000, 1_950]);
+  });
+
+  it('keeps false and computed legacy public options source-compatible as list-all scans', async () => {
+    const registry = makeRegistry();
+    const { adapter } = makeAdapter(registry, 2_100, {
+      cgRegistryScanPageSize: 1_000,
+    });
+    registry.queryFilter.setImpl(async () => []);
+    const incrementalOptions = (incremental: boolean): ContextGraphChainScanOptions => ({
+      incremental,
+      pageBudget: 1,
+    });
+    const seedOptions = (seedIncrementalWatermark: boolean): ContextGraphChainScanOptions => ({
+      seedIncrementalWatermark,
+      resumeFromCursor: true,
+      pageBudget: 1,
+    });
+
+    await adapter.listContextGraphsFromChain(undefined, incrementalOptions(false));
+    await adapter.listContextGraphsFromChain(undefined, seedOptions(false));
+
+    expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
+      [0, 999],
+      [1_000, 1_999],
+      [2_000, 2_100],
+      [0, 999],
+      [1_000, 1_999],
+      [2_000, 2_100],
+    ]);
+    expect((adapter as any).contextGraphRegistryScanCursor.getCachedWatermark(REGISTRY)).toBeUndefined();
   });
 
   it('keeps legacy public seed option as a full-scan watermark compatibility wrapper', async () => {

--- a/packages/chain/test/context-graph-registry-scan.unit.test.ts
+++ b/packages/chain/test/context-graph-registry-scan.unit.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { EVMChainAdapter, type EVMAdapterConfig } from '../src/evm-adapter.js';
 import { ContextGraphChainScanPartialError } from '../src/chain-adapter.js';
-import { CG_REGISTRY_MAX_SCAN_PAGES, CG_REGISTRY_REORG_BUFFER_BLOCKS } from '../src/evm-adapter-base.js';
+import {
+  CG_REGISTRY_LIVE_TAIL_LOOKBACK_BLOCKS,
+  CG_REGISTRY_MAX_SCAN_PAGES,
+  CG_REGISTRY_REORG_BUFFER_BLOCKS,
+} from '../src/evm-adapter-base.js';
 
 function recorder<A extends unknown[], R>(impl: (...args: A) => R) {
   const calls: A[] = [];
@@ -250,6 +254,32 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
       [4_001 - CG_REGISTRY_REORG_BUFFER_BLOCKS, 4_000],
     ]);
+  });
+
+  it('can seed the incremental watermark from a bounded live-tail scan without deploy-block probing', async () => {
+    const registry = makeRegistry();
+    const head = 20_000;
+    const { adapter, provider } = makeAdapter(registry, head);
+    provider.getCode = seam(async () => {
+      throw new Error('eth_getCode should not be called for daemon live-tail seeding');
+    });
+    registry.queryFilter.setImpl(async () => []);
+
+    await adapter.listContextGraphsFromChain(undefined, {
+      liveTailOnly: true,
+      liveTailLookbackBlocks: CG_REGISTRY_LIVE_TAIL_LOOKBACK_BLOCKS,
+      seedIncrementalWatermark: true,
+    });
+
+    expect(provider.getCode.calls).toEqual([]);
+    expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
+      [11_001, 13_000],
+      [13_001, 15_000],
+      [15_001, 17_000],
+      [17_001, 19_000],
+      [19_001, 20_000],
+    ]);
+    expect((adapter as any).contextGraphRegistryScanWatermarks.get(REGISTRY.toLowerCase())).toBe(head + 1);
   });
 
   it('reports no registry scan watermark after preflight cache invalidation', async () => {

--- a/packages/chain/test/context-graph-registry-scan.unit.test.ts
+++ b/packages/chain/test/context-graph-registry-scan.unit.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { EVMChainAdapter, type EVMAdapterConfig } from '../src/evm-adapter.js';
-import { ContextGraphChainScanPartialError } from '../src/chain-adapter.js';
+import { ContextGraphChainScanPartialError, type ContextGraphOnChain, type ContextGraphRegistryScanOptions } from '../src/chain-adapter.js';
 import {
   CG_REGISTRY_MAX_SCAN_PAGES,
   CG_REGISTRY_REORG_BUFFER_BLOCKS,
@@ -60,6 +60,28 @@ const DEPLOYER_PK = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf
 const ADMIN_PK = '0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a';
 const REGISTRY = '0x3333333333333333333333333333333333333333';
 
+class MemoryRegistryScanCursorStore {
+  readonly values = new Map<string, number>();
+  readonly loads: string[] = [];
+  readonly saves: Array<{ key: string; nextBlock: number }> = [];
+
+  async load(key: { chainId: string; deploymentId: string; registryAddress: string }): Promise<number | undefined> {
+    const encoded = this.key(key);
+    this.loads.push(encoded);
+    return this.values.get(encoded);
+  }
+
+  async save(key: { chainId: string; deploymentId: string; registryAddress: string }, nextBlock: number): Promise<void> {
+    const encoded = this.key(key);
+    this.saves.push({ key: encoded, nextBlock });
+    this.values.set(encoded, nextBlock);
+  }
+
+  private key(key: { chainId: string; deploymentId: string; registryAddress: string }): string {
+    return `${key.chainId}|${key.deploymentId}|${key.registryAddress.toLowerCase()}`;
+  }
+}
+
 function minimalConfig(overrides: Partial<EVMAdapterConfig> = {}): EVMAdapterConfig {
   return {
     rpcUrl: 'http://127.0.0.1:59998',
@@ -113,6 +135,18 @@ function makeAdapter(registry: any, head = 0, config: Partial<EVMAdapterConfig> 
   return { adapter, provider };
 }
 
+async function collectRegistryScan(
+  adapter: EVMChainAdapter,
+  options: ContextGraphRegistryScanOptions,
+): Promise<ContextGraphOnChain[]> {
+  const results: ContextGraphOnChain[] = [];
+  for await (const page of adapter.scanContextGraphRegistryPages(options)) {
+    results.push(...page.contextGraphs);
+    await page.ack();
+  }
+  return results;
+}
+
 describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
   it('anchors at the registry deploy block and paginates with the 2,000-block default', async () => {
     const deployBlock = 1_500;
@@ -158,21 +192,49 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     });
     registry.queryFilter.queueOnce({ type: 'throw', error: new Error('range too wide') });
 
-    const partial = await adapter.listContextGraphsFromChain(undefined, { incremental: true }).catch((err) => err);
+    const partial = await collectRegistryScan(adapter, {
+      mode: 'incremental',
+    }).catch((err) => err);
 
     expect(partial).toBeInstanceOf(ContextGraphChainScanPartialError);
     expect(partial.partialResults).toHaveLength(1);
     expect(partial.scannedToBlock).toBe(1_999);
     expect(partial.failedFromBlock).toBe(2_000);
     expect(partial.failedToBlock).toBe(3_999);
-    expect((adapter as any).contextGraphRegistryScanWatermarks.get(REGISTRY.toLowerCase())).toBe(2_000);
+    expect((adapter as any).contextGraphRegistryScanCursor.getCachedWatermark(REGISTRY)).toBe(2_000);
 
     registry.queryFilter.reset();
     registry.queryFilter.setImpl(async () => []);
-    await adapter.listContextGraphsFromChain(undefined, { incremental: true });
+    await collectRegistryScan(adapter, {
+      mode: 'incremental',
+    });
 
     expect(registry.queryFilter.calls[0][1]).toBe(1_950);
     expect(registry.queryFilter.calls[0][2]).toBe(2_100);
+  });
+
+  it('surfaces partial-prefix results for failing seeded daemon scans', async () => {
+    const store = new MemoryRegistryScanCursorStore();
+    const registry = makeRegistry();
+    const { adapter } = makeAdapter(registry, 4_999, {
+      contextGraphRegistryScanCursorStore: store,
+    });
+    registry.queryFilter.queueOnce({
+      type: 'return',
+      value: Promise.resolve([{ topics: [], data: '0x01', blockNumber: 10 }]),
+    });
+    registry.queryFilter.queueOnce({ type: 'throw', error: new Error('range too wide') });
+
+    const partial = await collectRegistryScan(adapter, {
+      mode: 'seedFull',
+    }).catch((err) => err);
+
+    expect(partial).toBeInstanceOf(ContextGraphChainScanPartialError);
+    expect(partial.partialResults.map((cg: { blockNumber: number }) => cg.blockNumber)).toEqual([10]);
+    expect(partial.scannedToBlock).toBe(1_999);
+    expect(partial.failedFromBlock).toBe(2_000);
+    expect(partial.failedToBlock).toBe(3_999);
+    expect(store.saves.map((s) => s.nextBlock)).toEqual([2_000]);
   });
 
   it('does not advance the incremental watermark when parsing a later page fails', async () => {
@@ -202,13 +264,15 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
       value: Promise.resolve([{ topics: [], data: '0xbad', blockNumber: 2_000 }]),
     });
 
-    const partial = await adapter.listContextGraphsFromChain(undefined, { incremental: true }).catch((err) => err);
+    const partial = await collectRegistryScan(adapter, {
+      mode: 'incremental',
+    }).catch((err) => err);
 
     expect(partial).toBeInstanceOf(ContextGraphChainScanPartialError);
     expect(partial.partialResults).toHaveLength(1);
     expect(partial.failedFromBlock).toBe(2_000);
     expect(partial.failedToBlock).toBe(2_100);
-    expect((adapter as any).contextGraphRegistryScanWatermarks.get(REGISTRY.toLowerCase())).toBe(2_000);
+    expect((adapter as any).contextGraphRegistryScanCursor.getCachedWatermark(REGISTRY)).toBe(2_000);
   });
 
   it('preserves public list-all semantics unless the caller opts into incremental scans', async () => {
@@ -227,7 +291,106 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
       [0, 1_999],
       [2_000, 2_100],
     ]);
-    expect((adapter as any).contextGraphRegistryScanWatermarks.get(REGISTRY.toLowerCase())).toBeUndefined();
+    expect((adapter as any).contextGraphRegistryScanCursor.getCachedWatermark(REGISTRY)).toBeUndefined();
+  });
+
+  it('keeps legacy public incremental option as a cursor-backed compatibility wrapper', async () => {
+    const store = new MemoryRegistryScanCursorStore();
+    const registry = makeRegistry();
+    const { adapter, provider } = makeAdapter(registry, 2_100, {
+      cgRegistryScanPageSize: 1_000,
+      contextGraphRegistryScanCursorStore: store,
+    });
+    registry.queryFilter.setImpl(async () => []);
+
+    await adapter.listContextGraphsFromChain(undefined, {
+      incremental: true,
+      pageBudget: 1,
+    });
+
+    expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
+      [0, 999],
+    ]);
+    expect(store.saves.map((s) => s.nextBlock)).toEqual([1_000]);
+
+    provider.getCode = seam(async () => {
+      throw new Error('deploy block probing should not run with the legacy incremental cursor');
+    });
+    registry.queryFilter.clear();
+
+    await adapter.listContextGraphsFromChain(undefined, {
+      incremental: true,
+      pageBudget: 1,
+    });
+
+    expect(provider.getCode.calls).toEqual([]);
+    expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
+      [1_000 - CG_REGISTRY_REORG_BUFFER_BLOCKS, 1_949],
+    ]);
+    expect(store.saves.map((s) => s.nextBlock)).toEqual([1_000, 1_950]);
+  });
+
+  it('keeps legacy public seed option as a full-scan watermark compatibility wrapper', async () => {
+    const store = new MemoryRegistryScanCursorStore();
+    const historicalGraphBlock = 10;
+    const registry = makeRegistry({
+      queryFilter: seam(async (_filter: unknown, lo: number, hi: number) =>
+        lo <= historicalGraphBlock && historicalGraphBlock <= hi
+          ? [{ topics: [], data: '0x01', blockNumber: historicalGraphBlock }]
+          : [],
+      ),
+    });
+    const { adapter } = makeAdapter(registry, 2_100, {
+      cgRegistryScanPageSize: 1_000,
+      contextGraphRegistryScanCursorStore: store,
+    });
+
+    const seeded = await adapter.listContextGraphsFromChain(undefined, {
+      seedIncrementalWatermark: true,
+    });
+
+    expect(seeded.map((cg) => cg.blockNumber)).toEqual([historicalGraphBlock]);
+    expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
+      [0, 999],
+      [1_000, 1_999],
+      [2_000, 2_100],
+    ]);
+    expect(store.saves.map((s) => s.nextBlock)).toEqual([1_000, 2_000, 2_101]);
+    expect((adapter as any).contextGraphRegistryScanCursor.getCachedWatermark(REGISTRY)).toBe(2_101);
+  });
+
+  it('rejects explicit daemon scan modes on the public list method', async () => {
+    const registry = makeRegistry();
+    const { adapter } = makeAdapter(registry, 2_100);
+
+    await expect(adapter.listContextGraphsFromChain(undefined, {
+      mode: 'incremental',
+    } as any)).rejects.toThrow('scanContextGraphRegistryPages');
+    expect(registry.queryFilter.calls).toEqual([]);
+  });
+
+  it('does not emit a synthetic empty terminal page for seed scans', async () => {
+    const registry = makeRegistry();
+    const { adapter } = makeAdapter(registry, 2_100, {
+      cgRegistryScanPageSize: 1_000,
+    });
+    registry.queryFilter.setImpl(async () => []);
+
+    const pageSizes: number[] = [];
+    for await (const page of adapter.scanContextGraphRegistryPages({
+      mode: 'seedFull',
+    })) {
+      pageSizes.push(page.contextGraphs.length);
+      await page.ack();
+    }
+
+    expect(pageSizes).toEqual([0, 0, 0]);
+    expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
+      [0, 999],
+      [1_000, 1_999],
+      [2_000, 2_100],
+    ]);
+    expect((adapter as any).contextGraphRegistryScanCursor.getCachedWatermark(REGISTRY)).toBe(2_101);
   });
 
   it('can seed the incremental watermark from an explicit successful full scan', async () => {
@@ -244,10 +407,12 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
 
     await expect(adapter.hasContextGraphRegistryScanWatermark()).resolves.toBe(false);
 
-    const seeded = await adapter.listContextGraphsFromChain(undefined, { seedIncrementalWatermark: true });
+    const seeded = await collectRegistryScan(adapter, {
+      mode: 'seedFull',
+    });
 
     expect(seeded.map((cg) => cg.blockNumber)).toEqual([historicalGraphBlock]);
-    expect((adapter as any).contextGraphRegistryScanWatermarks.get(REGISTRY.toLowerCase())).toBe(head + 1);
+    expect((adapter as any).contextGraphRegistryScanCursor.getCachedWatermark(REGISTRY)).toBe(head + 1);
     await expect(adapter.hasContextGraphRegistryScanWatermark()).resolves.toBe(true);
 
     provider.getCode = seam(async () => {
@@ -255,7 +420,9 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     });
     registry.queryFilter.clear();
 
-    await adapter.listContextGraphsFromChain(undefined, { incremental: true });
+    await collectRegistryScan(adapter, {
+      mode: 'incremental',
+    });
 
     expect(provider.getCode.calls).toEqual([]);
     expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
@@ -263,17 +430,278 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     ]);
   });
 
-  it('reports no registry scan watermark after preflight cache invalidation', async () => {
+  it('persists daemon scan progress and resumes after restart with the reorg buffer', async () => {
+    const store = new MemoryRegistryScanCursorStore();
+    const registry = makeRegistry();
+    const { adapter } = makeAdapter(registry, 5_000, {
+      cgRegistryScanPageSize: 1_000,
+      contextGraphRegistryScanCursorStore: store,
+    });
+    registry.queryFilter.setImpl(async () => []);
+
+    await collectRegistryScan(adapter, {
+      mode: 'seedFromCursor',
+      pageBudget: 2,
+    });
+
+    expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
+      [0, 999],
+      [1_000, 1_999],
+    ]);
+    expect(store.saves.map((s) => s.nextBlock)).toEqual([1_000, 2_000]);
+
+    const restartedRegistry = makeRegistry();
+    const { adapter: restarted, provider } = makeAdapter(restartedRegistry, 5_000, {
+      cgRegistryScanPageSize: 1_000,
+      contextGraphRegistryScanCursorStore: store,
+    });
+    provider.getCode = seam(async () => {
+      throw new Error('deploy block probing should not run with persisted cursor');
+    });
+    restartedRegistry.queryFilter.setImpl(async () => []);
+
+    await expect(restarted.hasContextGraphRegistryScanWatermark()).resolves.toBe(true);
+    await collectRegistryScan(restarted, {
+      mode: 'incremental',
+      pageBudget: 1,
+    });
+
+    expect(provider.getCode.calls).toEqual([]);
+    expect(restartedRegistry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
+      [2_000 - CG_REGISTRY_REORG_BUFFER_BLOCKS, 2_949],
+    ]);
+    expect(store.saves.map((s) => s.nextBlock)).toEqual([1_000, 2_000, 2_950]);
+  });
+
+  it('does not advance durable registry cursor until page discoveries are committed', async () => {
+    const store = new MemoryRegistryScanCursorStore();
+    const registry = makeRegistry({
+      queryFilter: seam(async () => [{ topics: [], data: '0x01', blockNumber: 10 }]),
+    });
+    const { adapter } = makeAdapter(registry, 2_100, {
+      cgRegistryScanPageSize: 1_000,
+      contextGraphRegistryScanCursorStore: store,
+    });
+
+    const iterator = adapter.scanContextGraphRegistryPages({
+      mode: 'seedFromCursor',
+      pageBudget: 1,
+    })[Symbol.asyncIterator]();
+    const first = await iterator.next();
+    expect(first.done).toBe(false);
+    expect(first.value.contextGraphs).toHaveLength(1);
+    expect(store.saves).toEqual([]);
+    expect((adapter as any).contextGraphRegistryScanCursor.getCachedWatermark(REGISTRY)).toBeUndefined();
+    await iterator.return?.();
+
+    const restartedRegistry = makeRegistry();
+    const { adapter: restarted } = makeAdapter(restartedRegistry, 2_100, {
+      cgRegistryScanPageSize: 1_000,
+      contextGraphRegistryScanCursorStore: store,
+    });
+    restartedRegistry.queryFilter.setImpl(async () => []);
+
+    await collectRegistryScan(restarted, {
+      mode: 'seedFromCursor',
+      pageBudget: 1,
+    });
+
+    expect(restartedRegistry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
+      [0, 999],
+    ]);
+    expect(store.saves.map((s) => s.nextBlock)).toEqual([1_000]);
+  });
+
+  it('falls back to deploy-block scanning when durable cursor load fails', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const store = {
+      load: vi.fn(async () => {
+        throw new Error('cursor load failed');
+      }),
+      save: vi.fn(async () => {}),
+    };
+    try {
+      const registry = makeRegistry();
+      const { adapter } = makeAdapter(registry, 2_100, {
+        contextGraphRegistryScanCursorStore: store,
+      });
+      registry.queryFilter.setImpl(async () => []);
+
+      await collectRegistryScan(adapter, {
+        mode: 'seedFromCursor',
+        pageBudget: 1,
+      });
+
+      expect(store.load).toHaveBeenCalledTimes(1);
+      expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
+        [0, 1_999],
+      ]);
+      expect(store.save).toHaveBeenCalledWith(expect.any(Object), 2_000);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('keeps save failures non-fatal and advances the process-local registry cursor', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const store = {
+      load: vi.fn(async () => undefined),
+      save: vi.fn(async () => {
+        throw new Error('cursor save failed');
+      }),
+    };
+    try {
+      const registry = makeRegistry();
+      const { adapter, provider } = makeAdapter(registry, 2_100, {
+        contextGraphRegistryScanCursorStore: store,
+      });
+      registry.queryFilter.setImpl(async () => []);
+
+      await collectRegistryScan(adapter, {
+        mode: 'seedFull',
+      });
+
+      expect((adapter as any).contextGraphRegistryScanCursor.getCachedWatermark(REGISTRY)).toBe(2_101);
+      provider.getCode = seam(async () => {
+        throw new Error('deploy block probing should not run with process-local cursor');
+      });
+      registry.queryFilter.clear();
+
+      await collectRegistryScan(adapter, {
+        mode: 'incremental',
+      });
+
+      expect(provider.getCode.calls).toEqual([]);
+      expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
+        [2_101 - CG_REGISTRY_REORG_BUFFER_BLOCKS, 2_100],
+      ]);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('continues cursor-resumed daemon catch-up scans from the persisted cursor', async () => {
+    const store = new MemoryRegistryScanCursorStore();
+    await store.save({
+      chainId: 'evm:31337',
+      deploymentId: 'evm:31337:hub=0x0000000000000000000000000000000000000001',
+      registryAddress: REGISTRY,
+    }, 3_000);
+
+    const registry = makeRegistry();
+    const { adapter, provider } = makeAdapter(registry, 5_000, {
+      cgRegistryScanPageSize: 1_000,
+      contextGraphRegistryScanCursorStore: store,
+    });
+    provider.getCode = seam(async () => {
+      throw new Error('deploy block probing should not run with persisted cursor');
+    });
+    registry.queryFilter.setImpl(async () => []);
+
+    await collectRegistryScan(adapter, {
+      mode: 'seedFromCursor',
+      pageBudget: 1,
+    });
+
+    expect(provider.getCode.calls).toEqual([]);
+    expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
+      [3_000 - CG_REGISTRY_REORG_BUFFER_BLOCKS, 3_949],
+    ]);
+    expect(store.saves.map((s) => s.nextBlock)).toEqual([3_000, 3_950]);
+  });
+
+  it('keeps periodic full-recovery seeded scans full even when a daemon cursor is persisted', async () => {
+    const store = new MemoryRegistryScanCursorStore();
+    await store.save({
+      chainId: 'evm:31337',
+      deploymentId: 'evm:31337:hub=0x0000000000000000000000000000000000000001',
+      registryAddress: REGISTRY,
+    }, 3_000);
+    const registry = makeRegistry({
+      queryFilter: seam(async (_filter: unknown, lo: number, hi: number) =>
+        lo <= 10 && 10 <= hi
+          ? [{ topics: [], data: '0x01', blockNumber: 10 }]
+          : [],
+      ),
+    });
+    const { adapter } = makeAdapter(registry, 3_500, {
+      cgRegistryScanPageSize: 1_000,
+      contextGraphRegistryScanCursorStore: store,
+    });
+
+    const results = await collectRegistryScan(adapter, {
+      mode: 'seedFull',
+    });
+
+    expect(results.map((cg) => cg.blockNumber)).toEqual([10]);
+    expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
+      [0, 999],
+      [1_000, 1_999],
+      [2_000, 2_999],
+      [3_000, 3_500],
+    ]);
+    expect(store.saves.map((s) => s.nextBlock)).toEqual([3_000, 3_501]);
+  });
+
+  it('keeps public list-all scans complete even when a daemon cursor is persisted', async () => {
+    const store = new MemoryRegistryScanCursorStore();
+    const seedRegistry = makeRegistry();
+    const { adapter: seedAdapter } = makeAdapter(seedRegistry, 2_100, {
+      contextGraphRegistryScanCursorStore: store,
+    });
+    seedRegistry.queryFilter.setImpl(async () => []);
+
+    await collectRegistryScan(seedAdapter, {
+      mode: 'seedFromCursor',
+      pageBudget: 1,
+    });
+
+    const publicRegistry = makeRegistry();
+    const { adapter: publicAdapter } = makeAdapter(publicRegistry, 2_100, {
+      contextGraphRegistryScanCursorStore: store,
+    });
+    publicRegistry.queryFilter.setImpl(async () => []);
+
+    await publicAdapter.listContextGraphsFromChain();
+
+    expect(publicRegistry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
+      [0, 1_999],
+      [2_000, 2_100],
+    ]);
+  });
+
+  it('reports no registry scan watermark after preflight cache invalidation without a durable store', async () => {
     const registry = makeRegistry();
     const { adapter } = makeAdapter(registry, 4_000);
     registry.queryFilter.setImpl(async () => []);
 
-    await adapter.listContextGraphsFromChain(undefined, { seedIncrementalWatermark: true });
+    await collectRegistryScan(adapter, {
+      mode: 'seedFull',
+    });
     await expect(adapter.hasContextGraphRegistryScanWatermark()).resolves.toBe(true);
 
     adapter.invalidatePublishPreflightCache();
 
     await expect(adapter.hasContextGraphRegistryScanWatermark()).resolves.toBe(false);
+  });
+
+  it('preflight cache invalidation clears only the in-memory registry cursor cache', async () => {
+    const store = new MemoryRegistryScanCursorStore();
+    const registry = makeRegistry();
+    const { adapter } = makeAdapter(registry, 4_000, {
+      contextGraphRegistryScanCursorStore: store,
+    });
+    registry.queryFilter.setImpl(async () => []);
+
+    await collectRegistryScan(adapter, {
+      mode: 'seedFull',
+    });
+    await expect(adapter.hasContextGraphRegistryScanWatermark()).resolves.toBe(true);
+
+    adapter.invalidatePublishPreflightCache();
+
+    expect((adapter as any).contextGraphRegistryScanCursor.getCachedWatermark(REGISTRY)).toBeUndefined();
+    await expect(adapter.hasContextGraphRegistryScanWatermark()).resolves.toBe(true);
   });
 
   it('rethrows later page failures for public list-all scans', async () => {
@@ -284,7 +712,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     registry.queryFilter.queueOnce({ type: 'throw', error: new Error('range too wide') });
 
     await expect(adapter.listContextGraphsFromChain()).rejects.toThrow('range too wide');
-    expect((adapter as any).contextGraphRegistryScanWatermarks.get(REGISTRY.toLowerCase())).toBeUndefined();
+    expect((adapter as any).contextGraphRegistryScanCursor.getCachedWatermark(REGISTRY)).toBeUndefined();
   });
 
   it('does not require deploy-block probing when fromBlock is explicit', async () => {
@@ -310,9 +738,11 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
       throw new Error('eth_getCode should not be called');
     });
     registry.queryFilter.setImpl(async () => []);
-    (adapter as any).contextGraphRegistryScanWatermarks.set(REGISTRY.toLowerCase(), 2_050);
+    await (adapter as any).contextGraphRegistryScanCursor.saveWatermark(REGISTRY, 2_050);
 
-    await adapter.listContextGraphsFromChain(undefined, { incremental: true });
+    await collectRegistryScan(adapter, {
+      mode: 'incremental',
+    });
 
     expect(provider.getCode.calls).toEqual([]);
     expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
@@ -360,7 +790,9 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     const defaultBlockBudget = CG_REGISTRY_MAX_SCAN_PAGES * defaultPageSize;
     const { adapter } = makeAdapter(registry, defaultBlockBudget);
 
-    await expect(adapter.listContextGraphsFromChain(undefined, { incremental: true })).rejects.toThrow(
+    await expect(collectRegistryScan(adapter, {
+      mode: 'incremental',
+    })).rejects.toThrow(
       new RegExp(`incremental ContextGraphNameRegistry scan would need.*budget ${CG_REGISTRY_MAX_SCAN_PAGES} pages`),
     );
     expect(registry.queryFilter.calls).toEqual([]);

--- a/packages/chain/test/evm-adapter-hub-rotation.e2e.test.ts
+++ b/packages/chain/test/evm-adapter-hub-rotation.e2e.test.ts
@@ -5,7 +5,7 @@
  * stale-address bug that bricked `RandomSampling` writes from running
  * daemons whenever the Hub rotated to a new RS deployment. The fix
  * lives in `evm-adapter.ts` (`HubResolutionCache` for RS+RSS, plus a
- * Hub event listener and a `withHubStaleRetry` wrapper); the unit
+ * low-cadence Hub rotation poller and a `withHubStaleRetry` wrapper); the unit
  * tests in `hub-resolution-cache.unit.test.ts` cover the cache
  * primitive in isolation. Here we drive a **real** Hardhat node with
  * a **real** `Hub.setContractAddress(...)` rotation and assert the
@@ -14,9 +14,8 @@
  *
  *   1. TTL refresh    — cached address is replaced after `ttlMs` elapses
  *                       and the next adapter call re-resolves from Hub.
- *   2. Event listener — adapter's Hub contract/storage rotation
- *                       subscriptions invalidate the cache as soon as
- *                       the rotation is mined.
+ *   2. Hub poller     — adapter's Hub contract/storage rotation scan
+ *                       invalidates the cache after the rotation is mined.
  *   3. Self-heal      — `withHubStaleRetry()` catches the exact revert
  *                       wording the prover sees in the wild
  *                       (`UnauthorizedAccess(Only Contracts in Hub)`),
@@ -136,22 +135,27 @@ async function waitFor(
   return false;
 }
 
+/** Drive the adapter's bound Hub rotation poller once. */
+async function pollHubRotations(adapter: EVMChainAdapter): Promise<void> {
+  await (adapter as any).hubRotationPoller.pollOnce();
+}
+
 /**
- * Let the adapter's Hub rotation listener consume any historical
+ * Let the adapter's Hub rotation poller consume any historical
  * `ContractChanged` / `NewContract` events that a previous test in
  * the same Hardhat session may have left behind. ethers v6 subscribes
  * its polling filter with fromBlock=latest, but in practice the
  * computed `latest` can include the most-recent rotation tx — so a
- * brand-new adapter can fire its first listener callback against an
+ * brand-new adapter can fire its first poller callback against an
  * event it never directly caused.
  *
  * This mirrors production behaviour: a daemon that boots immediately
- * after a Hub rotation will catch the rotation it didn't subscribe
+ * after a Hub rotation will catch the rotation it didn't observe
  * to. The "drain" step here just ensures the test snapshots are
  * taken AFTER that catch-up, so steady-state assertions hold.
  */
 async function drainHistoricalRotationEvents(adapter: EVMChainAdapter): Promise<void> {
-  await new Promise((r) => setTimeout(r, 1_000));
+  await pollHubRotations(adapter);
   if (!(adapter as any).initialized) {
     await (adapter as any).init();
   }
@@ -182,9 +186,8 @@ describe('EVMChainAdapter — Hub rotation self-refresh (E2E)', () => {
       expect(cachedBefore).not.toBeNull();
       const addrA: string = await cachedBefore!.rs.getAddress();
 
-      // Isolate the TTL path from the event-listener path so this test
-      // doesn't trivially pass via event-driven invalidation.
-      (adapter as any).contracts.hub.removeAllListeners();
+      // Isolate the TTL path from the Hub poller path by not driving the
+      // poller during this test; production cadence is far longer than 300 ms.
 
       const deployer = new Wallet(HARDHAT_KEYS.DEPLOYER, ctx.provider);
       const replacementAddr = freshAddress();
@@ -192,7 +195,7 @@ describe('EVMChainAdapter — Hub rotation self-refresh (E2E)', () => {
       try {
         await rotateHubContract(ctx.hubAddress, deployer, 'RandomSampling', replacementAddr);
 
-        // Sanity: with the listener removed, immediate inspection still
+        // Sanity: without driving the Hub poller, immediate inspection still
         // shows the stale cached address — TTL hasn't fired yet.
         const peeked = (adapter as any).randomSamplingPairCache.peek() as
           | { rs: Contract; rss: Contract }
@@ -216,10 +219,10 @@ describe('EVMChainAdapter — Hub rotation self-refresh (E2E)', () => {
   );
 
   it(
-    'Hub event listener: rotating RandomSamplingStorage ALSO invalidates the pair cache (coupled refresh)',
+    'Hub rotation poller: rotating RandomSamplingStorage ALSO invalidates the pair cache (coupled refresh)',
     async () => {
       // RS and RSS are deliberately treated as a coupled unit because
-      // RS.initialize() snapshots its RSS address. If the listener
+      // RS.initialize() snapshots its RSS address. If the poller
       // only invalidated on a name match, a single-side rotation
       // (rare but possible) could leave the adapter holding a mixed
       // pair — the exact bug Codex flagged on round 1. This test
@@ -238,12 +241,8 @@ describe('EVMChainAdapter — Hub rotation self-refresh (E2E)', () => {
       try {
         await rotateHubContract(ctx.hubAddress, deployer, 'RandomSamplingStorage', replacementAddr);
 
-        const invalidated = await waitFor(
-          () => (adapter as any).randomSamplingPairCache.peek() === null,
-          15_000,
-          100,
-        );
-        expect(invalidated).toBe(true);
+        await pollHubRotations(adapter);
+        expect((adapter as any).randomSamplingPairCache.peek()).toBeNull();
       } finally {
         await rotateHubContract(ctx.hubAddress, deployer, 'RandomSamplingStorage', realRssAddr);
       }
@@ -252,7 +251,7 @@ describe('EVMChainAdapter — Hub rotation self-refresh (E2E)', () => {
   );
 
   it(
-    'Hub event listener: invalidation also flips isRandomSamplingReady() to false until next getRandomSampling()',
+    'Hub rotation poller: invalidation also flips isRandomSamplingReady() to false until next getRandomSampling()',
     async () => {
       // Codex N15 — invalidating only the pair cache without dropping
       // the side-channel `this.contracts.randomSampling[Storage]` handles
@@ -275,12 +274,8 @@ describe('EVMChainAdapter — Hub rotation self-refresh (E2E)', () => {
       try {
         await rotateHubContract(ctx.hubAddress, deployer, 'RandomSampling', replacementAddr);
 
-        const becameNotReady = await waitFor(
-          () => adapter.isRandomSamplingReady() === false,
-          15_000,
-          100,
-        );
-        expect(becameNotReady).toBe(true);
+        await pollHubRotations(adapter);
+        expect(adapter.isRandomSamplingReady()).toBe(false);
 
         await (adapter as any).getRandomSampling();
         expect(adapter.isRandomSamplingReady()).toBe(true);
@@ -292,15 +287,15 @@ describe('EVMChainAdapter — Hub rotation self-refresh (E2E)', () => {
   );
 
   it(
-    'Hub event listener: ContractChanged invalidates the RandomSampling cache',
+    'Hub rotation poller: ContractChanged invalidates the RandomSampling cache',
     async () => {
       // High TTL (10 min) far exceeds the test's lifetime, so the only
       // path that can plausibly re-resolve within this test window is
-      // the event listener installed in init().
+      // the Hub rotation poller driven by the test.
       const adapter = makeAdapter(ctx.rpcUrl, ctx.hubAddress, 600_000);
 
-      // Drop the JsonRpcProvider polling interval (default 4 s) before
-      // the listener is attached so this test resolves quickly.
+      // Keep the adapter provider fast for direct reads; Hub invalidation is
+      // driven explicitly through the adapter-owned poller.
       (adapter as any).provider.pollingInterval = 250;
 
       await adapter.getActiveProofPeriodStatus!();
@@ -315,14 +310,8 @@ describe('EVMChainAdapter — Hub rotation self-refresh (E2E)', () => {
       try {
         await rotateHubContract(ctx.hubAddress, deployer, 'RandomSampling', replacementAddr);
 
-        // The listener should observe `ContractChanged('RandomSampling', ...)`
-        // within a few polling cycles and call `cache.invalidate()`.
-        const invalidated = await waitFor(
-          () => (adapter as any).randomSamplingPairCache.peek() === null,
-          15_000,
-          100,
-        );
-        expect(invalidated).toBe(true);
+        await pollHubRotations(adapter);
+        expect((adapter as any).randomSamplingPairCache.peek()).toBeNull();
 
         // Next get() resolves from the live Hub and reflects the new addr.
         const { rs } = await (adapter as any).getRandomSampling();
@@ -426,12 +415,8 @@ describe('EVMChainAdapter — Hub rotation self-refresh (E2E)', () => {
       const tempAddr = freshAddress();
       await rotateHubContract(ctx.hubAddress, deployer, 'RandomSampling', tempAddr);
 
-      // Wait for invalidation (event listener path; TTL also covers it).
-      const invalidatedFirst = await waitFor(
-        () => (adapter as any).randomSamplingPairCache.peek() === null,
-        15_000,
-      );
-      expect(invalidatedFirst).toBe(true);
+      await pollHubRotations(adapter);
+      expect((adapter as any).randomSamplingPairCache.peek()).toBeNull();
 
       // Restore the real RS and let the adapter rediscover it.
       await rotateHubContract(ctx.hubAddress, deployer, 'RandomSampling', realRsAddr);
@@ -470,16 +455,16 @@ describe('EVMChainAdapter — Hub rotation self-refresh (E2E)', () => {
   // that backs `pcaWrite` and any future write-side caller. The
   // contract under test is `Identity` — it's always deployed, always
   // boot-bound, and listed in `BOUND_CONTRACT_INVALIDATORS`; the
-  // listener should treat it identically to any other entry in the
+  // poller should treat it identically to any other entry in the
   // map.
   // ===================================================================
 
   it(
-    'event listener (generic): rotating Identity preserves live handle and re-arms init()',
+    'Hub rotation poller (generic): rotating Identity preserves live handle and re-arms init()',
     async () => {
-      // High TTL — only the event listener can flip the field within
+      // High TTL — only the Hub rotation poller can flip the field within
       // the test window. (RS cache has its own TTL; the generic path
-      // doesn't use one — only event/listener + write-side retry.)
+      // doesn't use one — only poller + write-side retry.)
       const adapter = makeAdapter(ctx.rpcUrl, ctx.hubAddress, 600_000);
       (adapter as any).provider.pollingInterval = 250;
 
@@ -494,16 +479,9 @@ describe('EVMChainAdapter — Hub rotation self-refresh (E2E)', () => {
       try {
         await rotateHubContract(ctx.hubAddress, deployer, 'Identity', replacementAddr);
 
-        // Listener keeps the field usable for in-flight calls and flips
-        // `initialized` so the next public entry re-resolves from Hub.
-        const observed = await waitFor(
-          () =>
-            (adapter as any).contracts.identity === identityBefore &&
-            (adapter as any).initialized === false,
-          15_000,
-          100,
-        );
-        expect(observed).toBe(true);
+        await pollHubRotations(adapter);
+        expect((adapter as any).contracts.identity).toBe(identityBefore);
+        expect((adapter as any).initialized).toBe(false);
 
         // Next init() re-resolves from the live Hub and binds the new address.
         await (adapter as any).init();
@@ -520,7 +498,7 @@ describe('EVMChainAdapter — Hub rotation self-refresh (E2E)', () => {
   );
 
   it(
-    'event listener (generic): boot-bound rotation clears publish preflight cache before TTL',
+    'Hub rotation poller (generic): boot-bound rotation clears publish preflight cache before TTL',
     async () => {
       const adapter = makeAdapter(ctx.rpcUrl, ctx.hubAddress, 600_000);
       (adapter as any).provider.pollingInterval = 250;
@@ -543,16 +521,11 @@ describe('EVMChainAdapter — Hub rotation self-refresh (E2E)', () => {
         // is what getKnowledgeAssetsLifecycleAddress() resolves. Rotate that key.
         await rotateHubContract(ctx.hubAddress, deployer, 'KnowledgeAssetsLifecycle', replacementAddr);
 
-        const observed = await waitFor(
-          () =>
-            (adapter as any).contracts.knowledgeAssetsLifecycle === kav10HandleBefore &&
-            (adapter as any).cachedKav10Address === undefined &&
-            (adapter as any).cachedMinRequiredSignatures === undefined &&
-            (adapter as any).initialized === false,
-          15_000,
-          100,
-        );
-        expect(observed).toBe(true);
+        await pollHubRotations(adapter);
+        expect((adapter as any).contracts.knowledgeAssetsLifecycle).toBe(kav10HandleBefore);
+        expect((adapter as any).cachedKav10Address).toBeUndefined();
+        expect((adapter as any).cachedMinRequiredSignatures).toBeUndefined();
+        expect((adapter as any).initialized).toBe(false);
 
         const kav10After = await adapter.getKnowledgeAssetsLifecycleAddress();
         expect(kav10After.toLowerCase()).toBe(replacementAddr.toLowerCase());
@@ -564,7 +537,7 @@ describe('EVMChainAdapter — Hub rotation self-refresh (E2E)', () => {
   );
 
   it(
-    'event listener (asset storage): rotating ContextGraphStorage preserves live handle and re-arms init()',
+    'Hub rotation poller (asset storage): rotating ContextGraphStorage preserves live handle and re-arms init()',
     async () => {
       const adapter = makeAdapter(ctx.rpcUrl, ctx.hubAddress, 600_000);
       (adapter as any).provider.pollingInterval = 250;
@@ -593,14 +566,9 @@ describe('EVMChainAdapter — Hub rotation self-refresh (E2E)', () => {
           replacementAddr,
         );
 
-        const observed = await waitFor(
-          () =>
-            (adapter as any).contracts.contextGraphStorage === storageBefore &&
-            (adapter as any).initialized === false,
-          15_000,
-          100,
-        );
-        expect(observed).toBe(true);
+        await pollHubRotations(adapter);
+        expect((adapter as any).contracts.contextGraphStorage).toBe(storageBefore);
+        expect((adapter as any).initialized).toBe(false);
 
         await (adapter as any).init();
         const storageAfter: Contract = (adapter as any).contracts.contextGraphStorage;
@@ -621,7 +589,7 @@ describe('EVMChainAdapter — Hub rotation self-refresh (E2E)', () => {
   );
 
   it(
-    'event listener (generic): rotating an unknown contract name is ignored — no fields touched',
+    'Hub rotation poller (generic): rotating an unknown contract name is ignored — no fields touched',
     async () => {
       const adapter = makeAdapter(ctx.rpcUrl, ctx.hubAddress, 600_000);
       (adapter as any).provider.pollingInterval = 250;
@@ -636,13 +604,12 @@ describe('EVMChainAdapter — Hub rotation self-refresh (E2E)', () => {
       const deployer = new Wallet(HARDHAT_KEYS.DEPLOYER, ctx.provider);
       // Use a name NOT in BOUND_CONTRACT_INVALIDATORS. Hub.setContractAddress
       // accepts arbitrary strings and emits `NewContract` for first
-      // registrations — exactly the noise we need to confirm the listener
+      // registrations — exactly the noise we need to confirm the poller
       // safely allowlists.
       const unknownName = `RC12TestUnknown-${Date.now()}`;
       await rotateHubContract(ctx.hubAddress, deployer, unknownName, freshAddress());
 
-      // Give the listener multiple polling cycles to mis-fire if it would.
-      await new Promise((r) => setTimeout(r, 1_500));
+      await pollHubRotations(adapter);
 
       expect((adapter as any).contracts.identity).toBe(identityBefore);
       expect((adapter as any).initialized).toBe(true);

--- a/packages/chain/test/evm-adapter-op-wallet.unit.test.ts
+++ b/packages/chain/test/evm-adapter-op-wallet.unit.test.ts
@@ -28,11 +28,35 @@ function minimalConfig(overrides: Partial<EVMAdapterConfig> = {}): EVMAdapterCon
   };
 }
 
-function makeAdapter(opts: { admin?: boolean; identityId?: bigint; adminPurposeWallets?: string[]; operationalPurposeWallets?: string[] } = {}) {
+function recorder<A extends unknown[], R>(impl: (...args: A) => R) {
+  const calls: A[] = [];
+  const fn = (...args: A): R => { calls.push(args); return impl(...args); };
+  return Object.assign(fn, { calls });
+}
+
+function makeAdapter(opts: {
+  admin?: boolean;
+  identityId?: bigint;
+  adminPurposeWallets?: string[];
+  operationalPurposeWallets?: string[];
+  identityLookupValues?: bigint[];
+} = {}) {
   const cfg = minimalConfig(opts.admin === false ? {} : { adminPrivateKey: ADMIN_PK });
   const a = new EVMChainAdapter(cfg);
   (a as any).init = async () => undefined;
   (a as any).getIdentityStorage = async () => ({ __isIdentityStorage: true });
+  (a as any).resolveContract = async (name: string) => ({ __name: name });
+  let identityLookupIndex = 0;
+  const readContract = recorder(async (_contract: any, _label: string, method: string) => {
+    if (method === 'getIdentityId') {
+      const values = opts.identityLookupValues ?? [0n];
+      const value = values[Math.min(identityLookupIndex, values.length - 1)];
+      identityLookupIndex++;
+      return value;
+    }
+    return 0n;
+  });
+  (a as any).readContract = readContract;
   // Purpose-aware: the configured admin key (plus any extras the test marks)
   // reads back as an on-chain ADMIN_KEY; everything else does not. The default
   // lets removing an ordinary external op wallet proceed while still exercising
@@ -60,7 +84,7 @@ function makeAdapter(opts: { admin?: boolean; identityId?: bigint; adminPurposeW
   };
   (a as any).contracts.profile = { __name: 'profile', getAddress: async () => '0xprofile' };
   (a as any).contracts.identity = { __name: 'identity', getAddress: async () => '0xidentity' };
-  return { a, calls };
+  return { a, calls, readContract };
 }
 
 describe('EVMChainAdapter.addOperationalWallet', () => {
@@ -76,6 +100,18 @@ describe('EVMChainAdapter.addOperationalWallet', () => {
     // MUST be signed by the admin key (onlyAdmin), not the primary op signer.
     expect(calls[0].signer).toBe(new ethers.Wallet(ADMIN_PK).address);
     expect(calls[0].signer).not.toBe((a as any).signer.address);
+  });
+
+  it('seeds the identity lookup cache after a successful public add', async () => {
+    const { a, readContract } = makeAdapter({ identityId: 5n, identityLookupValues: [0n, 99n] });
+
+    await expect(a.getIdentityIdForAddress(EXTERNAL)).resolves.toBe(0n);
+    expect(readContract.calls).toHaveLength(1);
+
+    await a.addOperationalWallet(EXTERNAL);
+
+    await expect(a.getIdentityIdForAddress(EXTERNAL)).resolves.toBe(5n);
+    expect(readContract.calls).toHaveLength(1);
   });
 
   it('throws when no admin key is configured', async () => {
@@ -106,6 +142,18 @@ describe('EVMChainAdapter.removeOperationalWallet', () => {
     const expectedHash = ethers.keccak256(ethers.solidityPacked(['address'], [ethers.getAddress(EXTERNAL)]));
     expect(calls[0].args[1]).toBe(expectedHash);
     expect(calls[0].signer).toBe(new ethers.Wallet(ADMIN_PK).address);
+  });
+
+  it('clears the identity lookup cache after a successful public removal', async () => {
+    const { a, readContract } = makeAdapter({ identityId: 5n, identityLookupValues: [5n, 0n] });
+
+    await expect(a.getIdentityIdForAddress(EXTERNAL)).resolves.toBe(5n);
+    expect(readContract.calls).toHaveLength(1);
+
+    await a.removeOperationalWallet(EXTERNAL);
+
+    await expect(a.getIdentityIdForAddress(EXTERNAL)).resolves.toBe(0n);
+    expect(readContract.calls).toHaveLength(2);
   });
 
   it('REFUSES to remove the bound primary operational wallet, before any tx', async () => {

--- a/packages/chain/test/evm-adapter-pca-enrich.test.ts
+++ b/packages/chain/test/evm-adapter-pca-enrich.test.ts
@@ -30,6 +30,7 @@ function minimalConfig(overrides: Partial<EVMAdapterConfig> = {}): EVMAdapterCon
     privateKey: DEPLOYER_PK,
     hubAddress: '0x0000000000000000000000000000000000000001',
     chainId: 'evm:31337',
+    staticNetwork: false,
     ...overrides,
   };
 }

--- a/packages/chain/test/evm-adapter-pca-rpc.unit.test.ts
+++ b/packages/chain/test/evm-adapter-pca-rpc.unit.test.ts
@@ -1,15 +1,28 @@
-import { beforeEach, afterEach, describe, expect, it } from 'vitest';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 import { EVMChainAdapter, type EVMAdapterConfig } from '../src/evm-adapter.js';
 import { isChainRpcTransportError } from '../src/chain-rpc-transport-error.js';
 import { _resetRpcFailoverStatsForTest } from '../src/rpc-failover-log.js';
+import { getPcaLogicInterface } from '../src/evm-adapter-errors.js';
 
 const PK = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
 const HUB = '0x0000000000000000000000000000000000000001';
+const AGENT = '0x00000000000000000000000000000000000000a1';
+const OWNER = '0x00000000000000000000000000000000000000b1';
 
 function recorder<A extends unknown[], R>(impl: (...args: A) => R) {
   const calls: A[] = [];
   const fn = (...args: A): R => { calls.push(args); return impl(...args); };
   return Object.assign(fn, { calls });
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
 }
 
 function minimalConfig(overrides: Partial<EVMAdapterConfig> = {}): EVMAdapterConfig {
@@ -34,11 +47,80 @@ type SendProvider = {
 };
 
 function pcaRpcAdapter(providers: SendProvider[], rpcUrls: string[]): EVMChainAdapter {
-  const adapter = new EVMChainAdapter(minimalConfig({ rpcUrl: rpcUrls[0], rpcUrls: rpcUrls.slice(1) }));
+  const adapter = new EVMChainAdapter(minimalConfig({
+    rpcUrl: rpcUrls[0],
+    rpcUrls: rpcUrls.slice(1),
+    staticNetwork: false,
+  }));
   (adapter as unknown as { init: () => Promise<void> }).init = async () => undefined;
   (adapter as unknown as { providers: SendProvider[] }).providers = providers;
   (adapter as unknown as { rpcUrls: string[] }).rpcUrls = rpcUrls;
   return adapter;
+}
+
+function pcaReadCacheAdapter(values: unknown[]): EVMChainAdapter {
+  const adapter = new EVMChainAdapter(minimalConfig());
+  const a = adapter as unknown as {
+    init: () => Promise<void>;
+    contracts: { dkgPublishingConvictionNFT?: unknown };
+    readContract: ReturnType<typeof recorder<[unknown, string, string, ...unknown[]], Promise<unknown>>>;
+  };
+  let i = 0;
+  a.init = async () => undefined;
+  a.contracts.dkgPublishingConvictionNFT = { getAddress: async () => '0x' + '33'.repeat(20) };
+  a.readContract = recorder(async () => {
+    const value = values[Math.min(i, values.length - 1)];
+    i++;
+    return value;
+  });
+  return adapter;
+}
+
+function installPcaWriteStubs(adapter: EVMChainAdapter) {
+  const calls: Array<{ method: string; args: readonly unknown[]; label: string }> = [];
+  (adapter as any).sendContractTransaction = recorder(async (_contract: unknown, method: string, args: readonly unknown[], _signer: unknown, label: string) => {
+    calls.push({ method, args, label });
+    return { hash: '0xtx', blockNumber: 1, index: 0, status: 1, logs: [] };
+  });
+  (adapter as any).resolveContract = async (name: string) => ({ __name: name });
+  return calls;
+}
+
+function accountInfoTuple(
+  owner: string,
+  committed = 100n,
+  topUpBuffer = 0n,
+  agentCount = 0n,
+  lastSettledWindow = 0n,
+): unknown[] {
+  return [
+    owner,
+    committed,
+    10n,
+    1n,
+    24n,
+    1000n,
+    2000n,
+    2500n,
+    topUpBuffer,
+    agentCount,
+    lastSettledWindow,
+    false,
+  ];
+}
+
+function accountTuple(primaryNode: bigint, lastPrimaryNodeChangeEpoch = 0n): unknown[] {
+  const tuple = new Array(11).fill(0n);
+  tuple[9] = primaryNode;
+  tuple[10] = lastPrimaryNodeChangeEpoch;
+  return tuple;
+}
+
+function accountCreatedLog(accountId: bigint) {
+  const iface = getPcaLogicInterface();
+  const event = iface.getEvent('AccountCreated');
+  if (!event) throw new Error('AccountCreated event missing');
+  return iface.encodeEventLog(event, [accountId, OWNER, 100n, 2500, 1, 24]);
 }
 
 describe('EVMChainAdapter PCA RPC bridge', () => {
@@ -114,5 +196,384 @@ describe('EVMChainAdapter PCA RPC bridge', () => {
     expect(contracts.walletRpcUrls).toEqual(['https://wallet-rpc.example/base-sepolia']);
     expect(JSON.stringify(contracts)).not.toContain('SECRETKEY');
     expect(JSON.stringify(contracts)).not.toContain('private-rpc.example');
+  });
+});
+
+describe('EVMChainAdapter PCA read cache', () => {
+  beforeEach(() => { _resetRpcFailoverStatsForTest(); });
+  afterEach(() => {
+    vi.useRealTimers();
+    _resetRpcFailoverStatsForTest();
+  });
+
+  it('coalesces concurrent agentToAccountId reads without retaining externally mutable mappings', async () => {
+    vi.useFakeTimers({ now: 0 });
+    const adapter = pcaReadCacheAdapter([7n, 8n]) as any;
+
+    const results = await Promise.all(
+      Array.from({ length: 20 }, () => adapter.getConvictionAgentAccountId(AGENT)),
+    );
+    expect(results.every((value) => value === 7n)).toBe(true);
+    expect(adapter.readContract.calls).toHaveLength(1);
+
+    await expect(adapter.getConvictionAgentAccountId(AGENT)).resolves.toBe(8n);
+    expect(adapter.readContract.calls).toHaveLength(2);
+  });
+
+  it('does not reuse a cached positive agent lookup after an external deregistration', async () => {
+    const adapter = pcaReadCacheAdapter([7n, 0n]) as any;
+
+    await expect(adapter.getConvictionAgentAccountId(AGENT)).resolves.toBe(7n);
+    await expect(adapter.getConvictionAgentAccountId(AGENT)).resolves.toBe(0n);
+    expect(adapter.readContract.calls).toHaveLength(2);
+  });
+
+  it('public agent deregistration clears older in-flight reverse-agent lookups', async () => {
+    const first = deferred<bigint>();
+    const second = deferred<bigint>();
+    const adapter = pcaReadCacheAdapter([]) as any;
+    installPcaWriteStubs(adapter);
+    const reads = [first.promise, second.promise];
+    adapter.readContract = recorder(async () => reads.shift()!);
+
+    const firstLookup = adapter.getConvictionAgentAccountId(AGENT);
+    await Promise.resolve();
+    expect(adapter.readContract.calls).toHaveLength(1);
+
+    await adapter.deregisterPublishingConvictionAgent(7n, AGENT);
+    first.resolve(7n);
+    await expect(firstLookup).resolves.toBe(7n);
+
+    const secondLookup = adapter.getConvictionAgentAccountId(AGENT);
+    await Promise.resolve();
+    expect(adapter.readContract.calls).toHaveLength(2);
+    second.resolve(0n);
+    await expect(secondLookup).resolves.toBe(0n);
+  });
+
+  it('broadly clears agent mappings when a PCA allow-list is cleared', async () => {
+    const adapter = pcaReadCacheAdapter([7n, 0n]) as any;
+    installPcaWriteStubs(adapter);
+
+    await expect(adapter.getConvictionAgentAccountId(AGENT)).resolves.toBe(7n);
+
+    await adapter.clearPublishingConvictionAgents(7n);
+
+    await expect(adapter.getConvictionAgentAccountId(AGENT)).resolves.toBe(0n);
+    expect(adapter.readContract.calls).toHaveLength(2);
+  });
+
+  it('clear-all invalidation does not reuse older in-flight reverse-agent lookups', async () => {
+    const first = deferred<bigint>();
+    const second = deferred<bigint>();
+    const adapter = pcaReadCacheAdapter([]) as any;
+    installPcaWriteStubs(adapter);
+    const reads = [first.promise, second.promise];
+    adapter.readContract = recorder(async () => reads.shift()!);
+
+    const staleLookup = adapter.getConvictionAgentAccountId(AGENT);
+    await Promise.resolve();
+    expect(adapter.readContract.calls).toHaveLength(1);
+
+    await adapter.clearPublishingConvictionAgents(7n);
+
+    const freshLookup = adapter.getConvictionAgentAccountId(AGENT);
+    await Promise.resolve();
+    expect(adapter.readContract.calls).toHaveLength(2);
+
+    first.resolve(7n);
+    second.resolve(0n);
+    await expect(staleLookup).resolves.toBe(7n);
+    await expect(freshLookup).resolves.toBe(0n);
+  });
+
+  it('does not cache a negative agent lookup across an external registration', async () => {
+    const adapter = pcaReadCacheAdapter([0n, 7n]) as any;
+
+    await expect(adapter.getConvictionAgentAccountId(AGENT)).resolves.toBe(0n);
+    await expect(adapter.getConvictionAgentAccountId(AGENT)).resolves.toBe(7n);
+    expect(adapter.readContract.calls).toHaveLength(2);
+  });
+
+  it('does not cache fail-soft CALL_EXCEPTION agent lookups as negative answers', async () => {
+    const adapter = pcaReadCacheAdapter([]) as any;
+    let calls = 0;
+    adapter.readContract = recorder(async () => {
+      calls++;
+      if (calls === 1) {
+        const err = new Error('missing revert data');
+        (err as { code?: string }).code = 'CALL_EXCEPTION';
+        throw err;
+      }
+      return 7n;
+    });
+
+    await expect(adapter.getConvictionAgentAccountId(AGENT)).resolves.toBe(0n);
+    await expect(adapter.getConvictionAgentAccountId(AGENT)).resolves.toBe(7n);
+    expect(adapter.readContract.calls).toHaveLength(2);
+  });
+
+  it('keeps strict agent lookups isolated from soft fail-safe single-flight results', async () => {
+    const adapter = pcaReadCacheAdapter([]) as any;
+    adapter.readContract = recorder(async () => {
+      const err = new Error('missing revert data');
+      (err as { code?: string }).code = 'CALL_EXCEPTION';
+      throw err;
+    });
+
+    const soft = adapter.getConvictionAgentAccountId(AGENT);
+    const strict = adapter.getConvictionAgentAccountId(AGENT, { strict: true });
+
+    await expect(soft).resolves.toBe(0n);
+    await expect(strict).rejects.toMatchObject({ code: 'CALL_EXCEPTION' });
+    expect(adapter.readContract.calls).toHaveLength(2);
+  });
+
+  it('public agent registration clears older in-flight reverse-agent lookups', async () => {
+    const first = deferred<bigint>();
+    const second = deferred<bigint>();
+    const adapter = pcaReadCacheAdapter([]) as any;
+    installPcaWriteStubs(adapter);
+    const reads = [first.promise, second.promise];
+    adapter.readContract = recorder(async () => reads.shift()!);
+
+    const staleLookup = adapter.getConvictionAgentAccountId(AGENT);
+    await Promise.resolve();
+    expect(adapter.readContract.calls).toHaveLength(1);
+
+    await adapter.registerPublishingConvictionAgent(7n, AGENT);
+
+    const freshLookup = adapter.getConvictionAgentAccountId(AGENT);
+    await Promise.resolve();
+    expect(adapter.readContract.calls).toHaveLength(2);
+
+    first.resolve(0n);
+    second.resolve(7n);
+    await expect(staleLookup).resolves.toBe(0n);
+    await expect(freshLookup).resolves.toBe(7n);
+  });
+
+  it('coalesces and briefly caches getAccountInfo reads per account id', async () => {
+    vi.useFakeTimers({ now: 0 });
+    const adapter = pcaReadCacheAdapter([
+      accountInfoTuple(OWNER, 100n),
+      accountInfoTuple(OWNER, 200n),
+    ]) as any;
+
+    const results = await Promise.all(
+      Array.from({ length: 10 }, () => adapter.getPublishingConvictionAccountInfo(9n)),
+    );
+    expect(results.every((info) => info?.committedTRAC === 100n)).toBe(true);
+    expect(adapter.readContract.calls).toHaveLength(1);
+
+    await expect(adapter.getPublishingConvictionAccountInfo(9n))
+      .resolves.toMatchObject({ committedTRAC: 100n });
+    expect(adapter.readContract.calls).toHaveLength(1);
+
+    vi.setSystemTime(16_000);
+    await expect(adapter.getPublishingConvictionAccountInfo(9n))
+      .resolves.toMatchObject({ committedTRAC: 200n });
+    expect(adapter.readContract.calls).toHaveLength(2);
+  });
+
+  it('cached account-info cannot make an expired PCA look coverable', async () => {
+    const expiringInfo = accountInfoTuple(OWNER, 100n);
+    expiringInfo[6] = 100n;
+    const adapter = pcaReadCacheAdapter([expiringInfo]) as any;
+    adapter.readProvider = recorder(async (_label: string, fn: (provider: unknown) => Promise<unknown>) => fn({
+      getBlock: async () => ({ timestamp: 101 }),
+    }));
+
+    await expect(adapter.getPublishingConvictionAccountInfo(9n))
+      .resolves.toMatchObject({ expiresAtTimestamp: 100 });
+    expect(adapter.readContract.calls).toHaveLength(1);
+
+    await expect(adapter.convictionAccountCanCover(9n, 1n)).resolves.toBe(false);
+    expect(adapter.readProvider.calls).toHaveLength(1);
+    expect(adapter.readContract.calls).toHaveLength(1);
+  });
+
+  it('public top-up refreshes warmed account-info cache immediately', async () => {
+    const adapter = pcaReadCacheAdapter([
+      accountInfoTuple(OWNER, 100n, 0n),
+      accountInfoTuple(OWNER, 100n, 50n),
+    ]) as any;
+    const calls = installPcaWriteStubs(adapter);
+
+    await expect(adapter.getPublishingConvictionAccountInfo(9n))
+      .resolves.toMatchObject({ topUpBuffer: 0n });
+    expect(adapter.readContract.calls).toHaveLength(1);
+
+    await adapter.topUpPublishingConvictionAccount(9n, 50n);
+    expect(calls).toMatchObject([{ method: 'topUp', args: [9n, 50n] }]);
+
+    await expect(adapter.getPublishingConvictionAccountInfo(9n))
+      .resolves.toMatchObject({ topUpBuffer: 50n });
+    expect(adapter.readContract.calls).toHaveLength(2);
+  });
+
+  it('public top-up prevents older in-flight account-info reads from repopulating stale cache', async () => {
+    const first = deferred<unknown[]>();
+    const second = deferred<unknown[]>();
+    const adapter = pcaReadCacheAdapter([]) as any;
+    installPcaWriteStubs(adapter);
+    const reads = [first.promise, second.promise];
+    adapter.readContract = recorder(async () => reads.shift()!);
+
+    const staleLookup = adapter.getPublishingConvictionAccountInfo(9n);
+    await Promise.resolve();
+    expect(adapter.readContract.calls).toHaveLength(1);
+
+    await adapter.topUpPublishingConvictionAccount(9n, 50n);
+
+    const freshLookup = adapter.getPublishingConvictionAccountInfo(9n);
+    await Promise.resolve();
+    expect(adapter.readContract.calls).toHaveLength(2);
+
+    second.resolve(accountInfoTuple(OWNER, 100n, 50n));
+    await expect(freshLookup).resolves.toMatchObject({ topUpBuffer: 50n });
+
+    first.resolve(accountInfoTuple(OWNER, 100n, 0n));
+    await expect(staleLookup).resolves.toMatchObject({ topUpBuffer: 0n });
+
+    await expect(adapter.getPublishingConvictionAccountInfo(9n))
+      .resolves.toMatchObject({ topUpBuffer: 50n });
+    expect(adapter.readContract.calls).toHaveLength(2);
+  });
+
+  it('account creation clears a cached missing account-info result', async () => {
+    const adapter = pcaReadCacheAdapter([]) as any;
+    let calls = 0;
+    adapter.readContract = recorder(async () => {
+      calls++;
+      if (calls === 1) {
+        const err = new Error('missing account');
+        (err as { code?: string }).code = 'CALL_EXCEPTION';
+        throw err;
+      }
+      return accountInfoTuple(OWNER, 100n, 0n, 0n);
+    });
+    (adapter as any).sendContractTransaction = recorder(async (_contract: unknown, method: string) => {
+      if (method !== 'createAccount') throw new Error(`unexpected method ${method}`);
+      return {
+        hash: '0xcreate',
+        blockNumber: 1,
+        index: 0,
+        status: 1,
+        logs: [accountCreatedLog(9n)],
+      };
+    });
+
+    await expect(adapter.getPublishingConvictionAccountInfo(9n)).resolves.toBeNull();
+    expect(adapter.readContract.calls).toHaveLength(1);
+
+    await expect(adapter.createPublishingConvictionAccount(100n)).resolves.toMatchObject({ accountId: 9n });
+
+    await expect(adapter.getPublishingConvictionAccountInfo(9n))
+      .resolves.toMatchObject({ committedTRAC: 100n });
+    expect(adapter.readContract.calls).toHaveLength(2);
+  });
+
+  it('public agent registration refreshes warmed account-info cache immediately', async () => {
+    const adapter = pcaReadCacheAdapter([
+      accountInfoTuple(OWNER, 100n, 0n, 0n),
+      accountInfoTuple(OWNER, 100n, 0n, 1n),
+    ]) as any;
+    installPcaWriteStubs(adapter);
+
+    await expect(adapter.getPublishingConvictionAccountInfo(9n))
+      .resolves.toMatchObject({ agentCount: 0 });
+    expect(adapter.readContract.calls).toHaveLength(1);
+
+    await adapter.registerPublishingConvictionAgent(9n, AGENT);
+
+    await expect(adapter.getPublishingConvictionAccountInfo(9n))
+      .resolves.toMatchObject({ agentCount: 1 });
+    expect(adapter.readContract.calls).toHaveLength(2);
+  });
+
+  it('public primary-node update refreshes warmed extended account-info cache immediately', async () => {
+    const adapter = pcaReadCacheAdapter([
+      accountInfoTuple(OWNER, 100n, 0n, 0n),
+      accountTuple(11n, 1n),
+      5n,
+      500n,
+      accountInfoTuple(OWNER, 100n, 0n, 0n),
+      accountTuple(22n, 2n),
+      6n,
+      600n,
+    ]) as any;
+    installPcaWriteStubs(adapter);
+    adapter.contracts.chronos = {};
+
+    await expect(adapter.getPublishingConvictionAccountInfo(9n, { extended: true }))
+      .resolves.toMatchObject({ primaryNode: 11n, lastPrimaryNodeChangeEpoch: 1 });
+    expect(adapter.readContract.calls).toHaveLength(4);
+
+    await adapter.setPublishingConvictionPrimaryNode(9n, 22n);
+
+    await expect(adapter.getPublishingConvictionAccountInfo(9n, { extended: true }))
+      .resolves.toMatchObject({ primaryNode: 22n, lastPrimaryNodeChangeEpoch: 2 });
+    expect(adapter.readContract.calls).toHaveLength(8);
+  });
+
+  it('public settlement and agent batch mutations refresh warmed account-info cache immediately', async () => {
+    const cases: Array<{
+      name: string;
+      before: unknown[];
+      after: unknown[];
+      invoke: (adapter: any) => Promise<unknown>;
+      expectedMethod: string;
+      expectedAfter: Record<string, unknown>;
+    }> = [
+      {
+        name: 'settlement',
+        before: accountInfoTuple(OWNER, 100n, 0n, 0n, 0n),
+        after: accountInfoTuple(OWNER, 100n, 0n, 0n, 1n),
+        invoke: (adapter) => adapter.settlePublishingConvictionAccount(9n),
+        expectedMethod: 'settle',
+        expectedAfter: { lastSettledWindow: 1 },
+      },
+      {
+        name: 'agent deregistration',
+        before: accountInfoTuple(OWNER, 100n, 0n, 1n),
+        after: accountInfoTuple(OWNER, 100n, 0n, 0n),
+        invoke: (adapter) => adapter.deregisterPublishingConvictionAgent(9n, AGENT),
+        expectedMethod: 'deregisterAgent',
+        expectedAfter: { agentCount: 0 },
+      },
+      {
+        name: 'batch agent registration',
+        before: accountInfoTuple(OWNER, 100n, 0n, 0n),
+        after: accountInfoTuple(OWNER, 100n, 0n, 2n),
+        invoke: (adapter) => adapter.registerPublishingConvictionAgents(9n, [AGENT, OWNER]),
+        expectedMethod: 'registerAgents',
+        expectedAfter: { agentCount: 2 },
+      },
+      {
+        name: 'clear agents',
+        before: accountInfoTuple(OWNER, 100n, 0n, 3n),
+        after: accountInfoTuple(OWNER, 100n, 0n, 0n),
+        invoke: (adapter) => adapter.clearPublishingConvictionAgents(9n),
+        expectedMethod: 'clearAgents',
+        expectedAfter: { agentCount: 0 },
+      },
+    ];
+
+    for (const scenario of cases) {
+      const adapter = pcaReadCacheAdapter([scenario.before, scenario.after]) as any;
+      const writes = installPcaWriteStubs(adapter);
+
+      await expect(adapter.getPublishingConvictionAccountInfo(9n))
+        .resolves.toMatchObject({ committedTRAC: 100n });
+      expect(adapter.readContract.calls, `${scenario.name}: warm read`).toHaveLength(1);
+
+      await scenario.invoke(adapter);
+      expect(writes.at(-1), `${scenario.name}: write method`).toMatchObject({ method: scenario.expectedMethod });
+
+      await expect(adapter.getPublishingConvictionAccountInfo(9n))
+        .resolves.toMatchObject(scenario.expectedAfter);
+      expect(adapter.readContract.calls, `${scenario.name}: refreshed read`).toHaveLength(2);
+    }
   });
 });

--- a/packages/chain/test/evm-adapter-pca-rpc.unit.test.ts
+++ b/packages/chain/test/evm-adapter-pca-rpc.unit.test.ts
@@ -474,6 +474,35 @@ describe('EVMChainAdapter PCA read cache', () => {
     expect(adapter.readContract.calls).toHaveLength(2);
   });
 
+  it('does not retain missing account-info results across external account creation', async () => {
+    const adapter = pcaReadCacheAdapter([]) as any;
+    let calls = 0;
+    adapter.readContract = recorder(async () => {
+      calls++;
+      if (calls === 1) {
+        const err = new Error('missing account');
+        (err as { code?: string }).code = 'CALL_EXCEPTION';
+        throw err;
+      }
+      return accountInfoTuple(OWNER, 100n, 0n, 0n);
+    });
+
+    const missingReads = await Promise.all([
+      adapter.getPublishingConvictionAccountInfo(9n),
+      adapter.getPublishingConvictionAccountInfo(9n),
+    ]);
+    expect(missingReads).toEqual([null, null]);
+    expect(adapter.readContract.calls).toHaveLength(1);
+
+    await expect(adapter.getPublishingConvictionAccountInfo(9n))
+      .resolves.toMatchObject({ committedTRAC: 100n });
+    expect(adapter.readContract.calls).toHaveLength(2);
+
+    await expect(adapter.getPublishingConvictionAccountInfo(9n))
+      .resolves.toMatchObject({ committedTRAC: 100n });
+    expect(adapter.readContract.calls).toHaveLength(2);
+  });
+
   it('public agent registration refreshes warmed account-info cache immediately', async () => {
     const adapter = pcaReadCacheAdapter([
       accountInfoTuple(OWNER, 100n, 0n, 0n),

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -27,6 +27,7 @@ import {
 } from '../src/chain-adapter.js';
 import { _resetRpcFailoverStatsForTest } from '../src/rpc-failover-log.js';
 import { isChainRpcTransportError } from '../src/chain-rpc-transport-error.js';
+import { RPC_READ_STALL_TIMEOUT_MS } from '../src/evm-adapter-constants.js';
 import { connectable } from './connectable.js';
 
 // Isolate the process-wide RPC failover stats + dedup window before EVERY test
@@ -2310,6 +2311,32 @@ describe('PR3 / RC11 — publish-preflight TTL cache', () => {
     // Second call should retry — failure was not memoised.
     expect(await a.getEvmChainId()).toBe(31337n);
     expect(getNetwork.calls).toHaveLength(2);
+  });
+
+  it('abandons timed-out static chain-id validations so the next read retries', async () => {
+    vi.useFakeTimers({ now: 0 });
+    const a: any = new EVMChainAdapter(minimalConfig({ staticNetwork: true }));
+    let calls = 0;
+    const provider = {
+      send: vi.fn(async (method: string) => {
+        expect(method).toBe('eth_chainId');
+        calls += 1;
+        if (calls === 1) {
+          return new Promise<never>(() => undefined);
+        }
+        return '0x7a69';
+      }),
+    };
+    a.providers = [provider];
+    a.rpcUrls = ['https://primary.example'];
+
+    const first = a.getEvmChainId();
+    const firstTimeout = expect(first).rejects.toThrow('configured chainId validation timed out');
+    await vi.advanceTimersByTimeAsync(RPC_READ_STALL_TIMEOUT_MS);
+    await firstTimeout;
+
+    await expect(a.getEvmChainId()).resolves.toBe(31337n);
+    expect(provider.send).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -39,6 +39,7 @@ beforeEach(() => {
 
 describe('EVMChainAdapter getIdentityIdForAddress cache', () => {
   const ADDR = '0x00000000000000000000000000000000000000a1';
+  const ADDR2 = '0x00000000000000000000000000000000000000a2';
   const identityInterface = new Interface([
     'event IdentityCreated(uint72 indexed identityId, bytes32 indexed operationalKey, bytes32 indexed adminKey)',
   ]);
@@ -222,6 +223,34 @@ describe('EVMChainAdapter getIdentityIdForAddress cache', () => {
     expect(a.readContract.calls[1][0]).toBe(identityStorage);
   });
 
+  it('identity cache misses refresh IdentityStorage so a missed Hub rotation cannot pin stale zero reads', async () => {
+    const a: any = new EVMChainAdapter(minimalConfig());
+    const oldIdentityStorage = { target: '0x0000000000000000000000000000000000000101' };
+    const newIdentityStorage = { target: '0x0000000000000000000000000000000000000102' };
+    let resolveCount = 0;
+    a.initialized = true;
+    a.init = async () => { a.initialized = true; };
+    a.resolveContract = recorder(async () => {
+      resolveCount += 1;
+      return resolveCount === 1 ? oldIdentityStorage : newIdentityStorage;
+    });
+    a.readContract = recorder(async (contract: unknown) => (
+      contract === oldIdentityStorage ? 0n : 42n
+    ));
+
+    await expect(a.getIdentityIdForAddress(ADDR)).resolves.toBe(0n);
+    expect(a.contracts.identityStorage).toBe(oldIdentityStorage);
+
+    await expect(a.getIdentityIdForAddress(ADDR2)).resolves.toBe(42n);
+    expect(a.contracts.identityStorage).toBe(newIdentityStorage);
+    expect(a.resolveContract.calls).toHaveLength(2);
+    expect(a.readContract.calls).toHaveLength(2);
+
+    await expect(a.getIdentityIdForAddress(ADDR2)).resolves.toBe(42n);
+    expect(a.resolveContract.calls).toHaveLength(2);
+    expect(a.readContract.calls).toHaveLength(2);
+  });
+
   it('IdentityStorage Hub rotation invalidates cached identity ids and the lazy contract binding', async () => {
     const { a, readContract } = makeIdentityLookupAdapter([7n, 9n]);
 
@@ -258,7 +287,7 @@ describe('EVMChainAdapter getIdentityIdForAddress cache', () => {
   });
 
   it('ensureProfile seeds the signer identity cache after IdentityCreated', async () => {
-    const { a, readContract } = makeIdentityLookupAdapter([0n, 99n]);
+    const { a, readContract } = makeIdentityLookupAdapter([0n, 0n]);
     a.contracts.identity = { interface: identityInterface };
     a.contracts.profile = { interface: profileInterface };
     a.sendContractTransaction = recorder(async () => ({
@@ -271,7 +300,20 @@ describe('EVMChainAdapter getIdentityIdForAddress cache', () => {
 
     await expect(a.ensureProfile({ stakeAmount: 0n })).resolves.toBe(77n);
     await expect(a.getIdentityId()).resolves.toBe(77n);
-    expect(readContract.calls).toHaveLength(1);
+    expect(readContract.calls).toHaveLength(2);
+  });
+
+  it('ensureProfile freshly rechecks a cached signer zero before creating a profile', async () => {
+    const { a, readContract } = makeIdentityLookupAdapter([0n, 55n]);
+    a.sendContractTransaction = recorder(async () => {
+      throw new Error('ensureProfile should not create a duplicate profile');
+    });
+
+    await expect(a.getIdentityId()).resolves.toBe(0n);
+    await expect(a.ensureProfile({ stakeAmount: 0n })).resolves.toBe(55n);
+    await expect(a.getIdentityId()).resolves.toBe(55n);
+    expect(readContract.calls).toHaveLength(2);
+    expect(a.sendContractTransaction.calls).toHaveLength(0);
   });
 
   it('registerIdentity seeds the signer identity cache after IdentityCreated', async () => {

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -37,6 +37,73 @@ beforeEach(() => {
   _resetRpcFailoverStatsForTest();
 });
 
+describe('EVMChainAdapter getIdentityIdForAddress cache', () => {
+  const ADDR = '0x00000000000000000000000000000000000000a1';
+
+  function makeIdentityLookupAdapter(values: bigint[]) {
+    const a: any = new EVMChainAdapter(minimalConfig());
+    a.initialized = true;
+    a.resolveContract = recorder(async () => ({}));
+    let i = 0;
+    const readContract = recorder(async () => {
+      const value = values[Math.min(i, values.length - 1)];
+      i++;
+      return value;
+    });
+    a.readContract = readContract;
+    return { a, readContract };
+  }
+
+  it('invalid addresses return 0 without an RPC read', async () => {
+    const { a, readContract } = makeIdentityLookupAdapter([1n]);
+    await expect(a.getIdentityIdForAddress('not-an-address')).resolves.toBe(0n);
+    expect(readContract.calls).toHaveLength(0);
+  });
+
+  it('coalesces concurrent negative lookups but does not cache the negative result', async () => {
+    const { a, readContract } = makeIdentityLookupAdapter([0n, 42n]);
+
+    const results = await Promise.all(
+      Array.from({ length: 20 }, () => a.getIdentityIdForAddress(ADDR)),
+    );
+    expect(results.every((value) => value === 0n)).toBe(true);
+    expect(readContract.calls).toHaveLength(1);
+
+    await expect(a.getIdentityIdForAddress(ADDR)).resolves.toBe(42n);
+    expect(readContract.calls).toHaveLength(2);
+  });
+
+  it('refreshes positive lookups after the positive TTL', async () => {
+    vi.useFakeTimers({ now: 0 });
+    const { a, readContract } = makeIdentityLookupAdapter([7n, 9n]);
+
+    try {
+      await expect(a.getIdentityIdForAddress(ADDR)).resolves.toBe(7n);
+      await expect(a.getIdentityIdForAddress(ADDR)).resolves.toBe(7n);
+      expect(readContract.calls).toHaveLength(1);
+
+      vi.setSystemTime(5 * 60_000 + 1);
+
+      await expect(a.getIdentityIdForAddress(ADDR)).resolves.toBe(9n);
+      expect(readContract.calls).toHaveLength(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('local registration and removal update the bounded positive cache', async () => {
+    const { a, readContract } = makeIdentityLookupAdapter([0n]);
+
+    a.seedIdentityIdForAddress(ADDR, 7n);
+    await expect(a.getIdentityIdForAddress(ADDR)).resolves.toBe(7n);
+    expect(readContract.calls).toHaveLength(0);
+
+    a.clearIdentityIdForAddress(ADDR);
+    await expect(a.getIdentityIdForAddress(ADDR)).resolves.toBe(0n);
+    expect(readContract.calls).toHaveLength(1);
+  });
+});
+
 
 const DEPLOYER_PK = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
 const OTHER_PK = '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b63b91100';
@@ -58,6 +125,7 @@ function minimalConfig(overrides: Partial<EVMAdapterConfig> = {}): EVMAdapterCon
     adminPrivateKey: ADMIN_PK,
     hubAddress: '0x0000000000000000000000000000000000000001',
     chainId: 'evm:31337',
+    staticNetwork: false,
     ...overrides,
   };
 }
@@ -1076,6 +1144,48 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     }
   });
 
+  it('startHubRotationListener skips optional listener setup when primary static validation fails but backup reads still work', async () => {
+    const a: any = new EVMChainAdapter(minimalConfig({
+      rpcUrl: 'https://primary.example',
+      rpcUrls: ['https://backup.example'],
+      staticNetwork: true,
+    }));
+    const primaryError = new Error('429 too many requests');
+    (primaryError as any).status = 429;
+    const primaryProvider = {
+      send: recorder(async () => { throw primaryError; }),
+      getBlockNumber: recorder(async () => {
+        throw new Error('primary read should fail before blockNumber');
+      }),
+    };
+    const backupProvider = {
+      send: recorder(async (method: string) => {
+        expect(method).toBe('eth_chainId');
+        return '0x7a69';
+      }),
+      getBlockNumber: recorder(async () => 123),
+    };
+    const on = recorder(async () => {
+      throw new Error('listener subscription should be skipped');
+    });
+
+    a.primaryProvider = primaryProvider;
+    a.provider = primaryProvider;
+    a.providers = [primaryProvider, backupProvider];
+    a.rpcUrls = ['https://primary.example', 'https://backup.example'];
+    a.contracts.hub = { on };
+    a.hubRotationListenerStarted = false;
+
+    await expect(a.startHubRotationListener()).resolves.toBeUndefined();
+    expect(on.calls).toEqual([]);
+    expect(a.hubRotationListenerStarted).toBe(false);
+
+    await expect(a.readProvider('getBlockNumber', (p: any) => p.getBlockNumber()))
+      .resolves.toBe(123);
+    expect(primaryProvider.getBlockNumber.calls).toEqual([]);
+    expect(backupProvider.getBlockNumber.calls).toEqual([[]]);
+  });
+
   it('invalidateRandomSamplingPair drops both the cache AND the side-channel contract handles (Codex N15)', () => {
     const a = new EVMChainAdapter(minimalConfig());
     (a as any).contracts.randomSampling = { dummy: 'rs' };
@@ -1624,7 +1734,7 @@ describe('PR3 / RC11 — publish-preflight TTL cache', () => {
   });
 
   it('getEvmChainId issues exactly one provider.getNetwork call across repeat reads', async () => {
-    const a = new EVMChainAdapter(minimalConfig());
+    const a = new EVMChainAdapter(minimalConfig({ staticNetwork: false }));
     const getNetwork = recorder(async () => ({ chainId: 31337n }));
     // R1/#1336: getEvmChainId now reads via readProvider (this.rpcFailover.read)
     // over this.providers[] (was this.provider.getNetwork). Mock this.providers[0];
@@ -1671,7 +1781,7 @@ describe('PR3 / RC11 — publish-preflight TTL cache', () => {
 
   it('refreshes after the 1h TTL expires', async () => {
     vi.useFakeTimers({ now: 0 });
-    const a = new EVMChainAdapter(minimalConfig());
+    const a = new EVMChainAdapter(minimalConfig({ staticNetwork: false }));
     let returned = 31337n;
     const getNetwork = recorder(async () => ({ chainId: returned }));
     // R1/#1336: getEvmChainId now reads via readProvider (this.rpcFailover.read)
@@ -1696,7 +1806,7 @@ describe('PR3 / RC11 — publish-preflight TTL cache', () => {
   });
 
   it('invalidatePublishPreflightCache forces a fresh read on next call', async () => {
-    const a = new EVMChainAdapter(minimalConfig());
+    const a = new EVMChainAdapter(minimalConfig({ staticNetwork: false }));
     const getNetwork = recorder(async () => ({ chainId: 31337n }));
     // R1/#1336: getEvmChainId now reads via readProvider (this.rpcFailover.read)
     // over this.providers[] (was this.provider.getNetwork). Mock this.providers[0];
@@ -1715,7 +1825,7 @@ describe('PR3 / RC11 — publish-preflight TTL cache', () => {
   });
 
   it('does NOT cache failures (next call retries the underlying read)', async () => {
-    const a = new EVMChainAdapter(minimalConfig());
+    const a = new EVMChainAdapter(minimalConfig({ staticNetwork: false }));
     let attempts = 0;
     const getNetwork = recorder(async () => {
       attempts += 1;
@@ -2585,6 +2695,10 @@ describe('createKnowledgeAssets / updateKnowledgeCollectionV10 — approval sign
     const tracByAddr = funding?.trac ?? new Map<string, bigint>();
     (a as any).provider.getBalance = recorder(async (addr: string) =>
       nativeByAddr.get(String(addr).toLowerCase()) ?? ABUNDANT_WEI);
+    (a as any).provider.send = recorder(async (method: string) => {
+      if (method === 'eth_chainId') return '0x7a69';
+      throw new Error(`unexpected RPC method ${method}`);
+    });
 
     // R1/#1336: readTracBalance now reads via readContractWith (failOpenFundingRead
     // policy) → rebindContract does `token.connect(p).balanceOf(addr)`, so the
@@ -2772,12 +2886,10 @@ describe('createKnowledgeAssets / updateKnowledgeCollectionV10 — approval sign
     (a as any).resolveCurrentTokenAmount = recorder(async () => 0n);
     (a as any).computeUpdateNewTokenAmount = recorder(async () => 0n);
     (a as any).getIdentityId = recorder(async () => 0n);
-    // `provider.getNetwork()` is called for chainId; stub it so the update path
-    // doesn't hit the placeholder RPC. R1/#1336: getEvmChainId reads via
-    // readProvider over this.providers[0] (=== this.provider), so MUTATE
-    // getNetwork on the shared object — REPLACING this.provider would orphan
-    // this.providers[0] (and the helper's getBalance mock) and the read would
-    // dial the dead RPC instead.
+    // `getEvmChainId()` validates chainId through this.providers[0]
+    // (=== this.provider), so mutate the shared object — replacing
+    // this.provider would orphan this.providers[0] and the read would dial the
+    // dead placeholder RPC instead.
     (a as any).provider.getNetwork = recorder(async () => ({ chainId: 31337n }));
 
     const updateParams: any = {
@@ -2827,6 +2939,48 @@ describe('createKnowledgeAssets / updateKnowledgeCollectionV10 — approval sign
     // Assert the signer ADDRESS, not object identity (#870 "publish signed by
     // walletB, no mid-flight rotation" invariant is preserved).
     expect((signSpy.calls[0][0] as ethers.Wallet).address).toBe(walletB.address);
+  });
+
+  it('update path: validates live chain id before approval/signing on static-network providers', async () => {
+    const allowanceByOwner = makeAllowanceByOwner();
+    const { a, walletB, sendSpy, signSpy, tokenWithSigner } =
+      makeMultiWalletV10Adapter(allowanceByOwner, undefined, [], { staticNetwork: true });
+
+    const kaId = 42n;
+    (a as any).contracts.knowledgeAssetStorage = connectable({
+      getLatestMerkleRootPublisher: recorder(async () => walletB.address),
+      getMerkleRoots: recorder(async () => []),
+    });
+    (a as any).provider.getNetwork = recorder(async () => ({ chainId: 31337n }));
+    (a as any).provider.send = recorder(async (method: string) => {
+      if (method === 'eth_chainId') return '0x14a34';
+      throw new Error(`unexpected RPC method ${method}`);
+    });
+
+    const updateParams: any = {
+      kaId,
+      newMerkleRoot: ethers.getBytes(ethers.keccak256(ethers.toUtf8Bytes('umr'))),
+      newByteSize: 100,
+      newMerkleLeafCount: 1,
+      newTokenAmount: 0n,
+      authorAddress: walletB.address,
+      authorR: new Uint8Array(32),
+      authorVS: new Uint8Array(32),
+      authorSchemeVersion: 1,
+      ackSignatures: [{
+        identityId: 1n,
+        r: new Uint8Array(32),
+        vs: new Uint8Array(32),
+      }],
+    };
+
+    await expect(
+      a.updateKnowledgeCollectionV10(updateParams),
+    ).rejects.toThrow(/Configured chainId 31337 does not match RPC chainId 84532/);
+
+    expect(tokenWithSigner.allowance.calls).toHaveLength(0);
+    expect(sendSpy.calls).toHaveLength(0);
+    expect(signSpy.calls).toHaveLength(0);
   });
 
 // -----------------------------------------------------------------------------

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -1212,7 +1212,11 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     a.rpcUrls = ['https://primary.example'];
     a.primaryProvider = provider;
     a.provider = provider;
-    a.contracts.hub = { interface: iface, target: '0x0000000000000000000000000000000000000001', on };
+    a.contracts.hub = {
+      interface: iface,
+      getAddress: async () => '0x0000000000000000000000000000000000000001',
+      on,
+    };
     a.contracts.contextGraphs = { stale: true };
     a.cachedKav10Address = { value: '0x00000000000000000000000000000000000000aa', cachedAt: 1 };
     a.hubRotationListenerStarted = false;
@@ -1273,7 +1277,11 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     a.rpcUrls = ['https://primary.example'];
     a.primaryProvider = provider;
     a.provider = provider;
-    a.contracts.hub = { interface: iface, target: '0x0000000000000000000000000000000000000001', on };
+    a.contracts.hub = {
+      interface: iface,
+      getAddress: async () => '0x0000000000000000000000000000000000000001',
+      on,
+    };
     a.contracts.contextGraphs = { fresh: true };
     a.contracts.randomSampling = { fresh: 'rs' };
     a.contracts.randomSamplingStorage = { fresh: 'rss' };
@@ -1326,7 +1334,10 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     a.rpcUrls = ['https://primary.example'];
     a.primaryProvider = provider;
     a.provider = provider;
-    a.contracts.hub = { interface: iface, target: '0x0000000000000000000000000000000000000001' };
+    a.contracts.hub = {
+      interface: iface,
+      getAddress: async () => '0x0000000000000000000000000000000000000001',
+    };
     a.hubRotationListenerStarted = false;
 
     try {
@@ -1364,7 +1375,10 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     a.rpcUrls = ['https://lagging.example'];
     a.primaryProvider = provider;
     a.provider = provider;
-    a.contracts.hub = { interface: iface, target: '0x0000000000000000000000000000000000000001' };
+    a.contracts.hub = {
+      interface: iface,
+      getAddress: async () => '0x0000000000000000000000000000000000000001',
+    };
     a.hubRotationPoller.lastScannedBlock = 1_000;
 
     await expect(a.pollHubRotationEvents()).resolves.toBeUndefined();

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -54,6 +54,14 @@ describe('EVMChainAdapter getIdentityIdForAddress cache', () => {
     return { topics: encoded.topics, data: encoded.data };
   }
 
+  function profileCreatedLog(identityId: bigint) {
+    const encoded = profileInterface.encodeEventLog(
+      profileInterface.getEvent('ProfileCreated')!,
+      [identityId],
+    );
+    return { topics: encoded.topics, data: encoded.data };
+  }
+
   function makeIdentityLookupAdapter(values: bigint[]) {
     const a: any = new EVMChainAdapter(minimalConfig());
     a.initialized = true;
@@ -166,14 +174,23 @@ describe('EVMChainAdapter getIdentityIdForAddress cache', () => {
     }
   });
 
-  it('repairs a cached self zero when a live signer-address lookup observes a positive identity', async () => {
+  it('shares the short signer zero cache between getIdentityId and getIdentityIdForAddress', async () => {
+    vi.useFakeTimers({ now: 0 });
     const { a, readContract } = makeIdentityLookupAdapter([0n, 42n]);
 
-    await expect(a.getIdentityId()).resolves.toBe(0n);
-    await expect(a.getIdentityIdForAddress((a as any).signer.address)).resolves.toBe(42n);
-    await expect(a.getIdentityId()).resolves.toBe(42n);
+    try {
+      await expect(a.getIdentityId()).resolves.toBe(0n);
+      await expect(a.getIdentityIdForAddress((a as any).signer.address)).resolves.toBe(0n);
+      expect(readContract.calls).toHaveLength(1);
 
-    expect(readContract.calls).toHaveLength(2);
+      vi.setSystemTime(15_001);
+
+      await expect(a.getIdentityIdForAddress((a as any).signer.address)).resolves.toBe(42n);
+      await expect(a.getIdentityId()).resolves.toBe(42n);
+      expect(readContract.calls).toHaveLength(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('shares cache entries between getIdentityId and getIdentityIdForAddress for the signer', async () => {
@@ -251,10 +268,28 @@ describe('EVMChainAdapter getIdentityIdForAddress cache', () => {
     await expect(a.getIdentityId()).resolves.toBe(88n);
     expect(readContract.calls).toHaveLength(0);
   });
+
+  it('registerIdentity seeds the signer identity cache after ProfileCreated fallback', async () => {
+    const { a, readContract } = makeIdentityLookupAdapter([0n, 99n]);
+    a.contracts.identity = { interface: identityInterface };
+    a.contracts.profile = { interface: profileInterface };
+    a.sendContractTransaction = recorder(async () => ({
+      logs: [profileCreatedLog(89n)],
+      hash: '0x' + '56'.repeat(32),
+      blockNumber: 1,
+      index: 0,
+      status: 1,
+    }));
+
+    await expect(a.getIdentityId()).resolves.toBe(0n);
+    await expect(a.registerIdentity({ publicKey: new Uint8Array([1]), signature: new Uint8Array() })).resolves.toBe(89n);
+    await expect(a.getIdentityId()).resolves.toBe(89n);
+    expect(readContract.calls).toHaveLength(1);
+  });
 });
 
 describe('EVMChainAdapter random sampling identity lookup', () => {
-  it('createChallenge uses the cached self identity path and reads back by the emitted identity', async () => {
+  it('createChallenge reads back by the emitted identity without pre-reading signer identity', async () => {
     const a: any = new EVMChainAdapter(minimalConfig());
     const challengeIdentityId = 99n;
     const cachedIdentityId = 42n;
@@ -286,19 +321,18 @@ describe('EVMChainAdapter random sampling identity lookup', () => {
     };
     const rss = { __rss: true };
     const rs = { interface: rsInterface };
-    const getIdentityId = recorder(async () => cachedIdentityId);
     const readContract = recorder(async () => challengeRaw);
     const sendContractTransaction = recorder(async () => receipt as any);
 
     a.init = async () => undefined;
-    a.getIdentityId = getIdentityId;
+    a.getIdentityId = recorder(async () => cachedIdentityId);
     a.getRandomSampling = async () => ({ rs, rss });
     a.readContract = readContract;
     a.sendContractTransaction = sendContractTransaction;
 
     const result = await a.createChallenge();
 
-    expect(getIdentityId.calls).toHaveLength(1);
+    expect(a.getIdentityId.calls).toHaveLength(0);
     expect(sendContractTransaction.calls[0][1]).toBe('createChallenge');
     expect(readContract.calls).toHaveLength(1);
     expect(readContract.calls[0][0]).toBe(rss);

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -1239,6 +1239,59 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     expect(a.hubRotationListenerStarted).toBe(false);
   });
 
+  it('startHubRotationListener processes Hub rotations from the recurring poll timer', async () => {
+    vi.useFakeTimers({ now: 0 });
+    const a: any = new EVMChainAdapter(minimalConfig());
+    const iface = new ethers.Interface([
+      'event NewContract(string contractName, address newContractAddress)',
+      'event ContractChanged(string contractName, address newContractAddress)',
+      'event NewAssetStorage(string contractName, address newContractAddress)',
+      'event AssetStorageChanged(string contractName, address newContractAddress)',
+    ]);
+    const changed = iface.encodeEventLog(iface.getEvent('NewContract')!, [
+      'ContextGraphs',
+      '0x00000000000000000000000000000000000000c1',
+    ]);
+    let poll = 0;
+    const provider = {
+      getBlockNumber: recorder(async () => 1_000 + poll),
+      getLogs: recorder(async (_filter: any) => {
+        poll++;
+        return poll === 1
+          ? []
+          : [{ topics: changed.topics, data: changed.data }];
+      }),
+      destroy: recorder(() => undefined),
+    };
+    const on = recorder(async () => {
+      throw new Error('ethers subscription should not be installed');
+    });
+    a.providers = [provider];
+    a.rpcUrls = ['https://primary.example'];
+    a.primaryProvider = provider;
+    a.provider = provider;
+    a.contracts.hub = { interface: iface, target: '0x0000000000000000000000000000000000000001', on };
+    a.cachedKav10Address = { value: '0x00000000000000000000000000000000000000aa', cachedAt: 1 };
+    a.hubRotationListenerStarted = false;
+    a.initialized = true;
+
+    try {
+      await expect(a.startHubRotationListener()).resolves.toBeUndefined();
+      expect(on.calls).toEqual([]);
+      expect(provider.getLogs.calls).toHaveLength(1);
+      expect(a.initialized).toBe(true);
+
+      await vi.advanceTimersByTimeAsync(5 * 60_000);
+
+      expect(provider.getLogs.calls).toHaveLength(2);
+      expect(a.cachedKav10Address).toBeUndefined();
+      expect(a.initialized).toBe(false);
+    } finally {
+      a.destroy();
+      vi.useRealTimers();
+    }
+  });
+
   it('pollHubRotationEvents clamps the range when failover observes a lower head', async () => {
     const a: any = new EVMChainAdapter(minimalConfig());
     const iface = new ethers.Interface([
@@ -1257,7 +1310,7 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     a.primaryProvider = provider;
     a.provider = provider;
     a.contracts.hub = { interface: iface, target: '0x0000000000000000000000000000000000000001' };
-    a.hubRotationLastScannedBlock = 1_000;
+    a.hubRotationPoller.lastScannedBlock = 1_000;
 
     await expect(a.pollHubRotationEvents()).resolves.toBeUndefined();
 
@@ -1266,7 +1319,7 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
       fromBlock: 850,
       toBlock: 900,
     });
-    expect(a.hubRotationLastScannedBlock).toBe(900);
+    expect(a.hubRotationPoller.lastScannedBlock).toBe(900);
   });
 
   it('invalidateRandomSamplingPair drops both the cache AND the side-channel contract handles (Codex N15)', () => {

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -1427,7 +1427,7 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     expect(a.chainType).toBe('evm');
   });
 
-  it('startHubRotationListener validates Hub binding without touching RPC logs', async () => {
+  it('startHubRotationListener validates Hub binding with a startup head baseline but without RPC logs', async () => {
     const a: any = new EVMChainAdapter(minimalConfig());
     const iface = new ethers.Interface([
       'event NewContract(string contractName, address newContractAddress)',
@@ -1436,9 +1436,7 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
       'event AssetStorageChanged(string contractName, address newContractAddress)',
     ]);
     const provider = {
-      getBlockNumber: recorder(async () => {
-        throw new Error('startup should not read block number');
-      }),
+      getBlockNumber: recorder(async () => 1_000),
       getLogs: recorder(async () => {
         throw new Error('startup should not read logs');
       }),
@@ -1453,7 +1451,7 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     };
     await expect(a.startHubRotationListener()).resolves.toBeUndefined();
 
-    expect(provider.getBlockNumber.calls).toEqual([]);
+    expect(provider.getBlockNumber.calls).toEqual([[]]);
     expect(provider.getLogs.calls).toEqual([]);
     expect(a.hubRotationPoller.isStarted).toBe(true);
   });
@@ -1493,7 +1491,7 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     expect(a.hubRotationPoller.isStarted).toBe(false);
   });
 
-  it('startHubRotationListener does not consume RPC budget while backup reads still work', async () => {
+  it('startHubRotationListener uses one startup head baseline while backup reads still work', async () => {
     const a: any = new EVMChainAdapter(minimalConfig({
       rpcUrl: 'https://primary.example',
       rpcUrls: ['https://backup.example'],
@@ -1535,7 +1533,7 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     await expect(a.readProvider('getBlockNumber', (p: any) => p.getBlockNumber()))
       .resolves.toBe(123);
     expect(primaryProvider.getBlockNumber.calls).toEqual([]);
-    expect(backupProvider.getBlockNumber.calls).toHaveLength(1);
+    expect(backupProvider.getBlockNumber.calls).toHaveLength(2);
   });
 
   it('startHubRotationListener wires Hub rotation names into adapter invalidation without subscriptions', async () => {
@@ -1638,13 +1636,13 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     try {
       await expect(a.startHubRotationListener()).resolves.toBeUndefined();
       await flushAsyncWork();
-      expect(provider.getBlockNumber.calls).toHaveLength(0);
+      expect(provider.getBlockNumber.calls).toHaveLength(1);
       expect(provider.getLogs.calls).toHaveLength(0);
 
       a.destroy();
       await vi.advanceTimersByTimeAsync(30_000);
 
-      expect(provider.getBlockNumber.calls).toHaveLength(0);
+      expect(provider.getBlockNumber.calls).toHaveLength(1);
       expect(provider.getLogs.calls).toHaveLength(0);
       expect(provider.destroy.calls).toHaveLength(1);
       expect(a.hubRotationPoller.isStarted).toBe(false);

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -1186,6 +1186,63 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     expect(a.hubRotationListenerStarted).toBe(false);
   });
 
+  it('startHubRotationListener coalesces concurrent poller starts', async () => {
+    vi.useFakeTimers({ now: 0 });
+    const a: any = new EVMChainAdapter(minimalConfig());
+    const iface = new ethers.Interface([
+      'event NewContract(string contractName, address newContractAddress)',
+      'event ContractChanged(string contractName, address newContractAddress)',
+      'event NewAssetStorage(string contractName, address newContractAddress)',
+      'event AssetStorageChanged(string contractName, address newContractAddress)',
+    ]);
+    let seedEntered!: () => void;
+    const seedEnteredPromise = new Promise<void>((resolve) => { seedEntered = resolve; });
+    let releaseSeed!: () => void;
+    const seedGate = new Promise<void>((resolve) => { releaseSeed = resolve; });
+    let getLogsCalls = 0;
+    const provider = {
+      getBlockNumber: recorder(async () => 1_000),
+      getLogs: recorder(async () => {
+        getLogsCalls++;
+        if (getLogsCalls === 1) {
+          seedEntered();
+          await seedGate;
+        }
+        return [];
+      }),
+      destroy: recorder(() => undefined),
+    };
+    a.providers = [provider];
+    a.rpcUrls = ['https://primary.example'];
+    a.primaryProvider = provider;
+    a.provider = provider;
+    a.contracts.hub = {
+      interface: iface,
+      getAddress: async () => '0x0000000000000000000000000000000000000001',
+    };
+    a.hubRotationListenerStarted = false;
+
+    try {
+      const firstStart = a.startHubRotationListener();
+      await seedEnteredPromise;
+      expect(provider.getLogs.calls).toHaveLength(1);
+
+      const secondStart = a.startHubRotationListener();
+      releaseSeed();
+      await expect(Promise.all([firstStart, secondStart])).resolves.toBeDefined();
+
+      expect(provider.getBlockNumber.calls).toHaveLength(1);
+      expect(provider.getLogs.calls).toHaveLength(1);
+
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(provider.getBlockNumber.calls).toHaveLength(2);
+      expect(provider.getLogs.calls).toHaveLength(2);
+    } finally {
+      a.destroy();
+      vi.useRealTimers();
+    }
+  });
+
   it('startHubRotationListener skips optional poller setup when primary static validation fails but backup reads still work', async () => {
     const a: any = new EVMChainAdapter(minimalConfig({
       rpcUrl: 'https://primary.example',

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -39,10 +39,25 @@ beforeEach(() => {
 
 describe('EVMChainAdapter getIdentityIdForAddress cache', () => {
   const ADDR = '0x00000000000000000000000000000000000000a1';
+  const identityInterface = new Interface([
+    'event IdentityCreated(uint72 indexed identityId, bytes32 indexed operationalKey, bytes32 indexed adminKey)',
+  ]);
+  const profileInterface = new Interface([
+    'event ProfileCreated(uint72 indexed identityId)',
+  ]);
+
+  function identityCreatedLog(identityId: bigint) {
+    const encoded = identityInterface.encodeEventLog(
+      identityInterface.getEvent('IdentityCreated')!,
+      [identityId, ethers.ZeroHash, ethers.ZeroHash],
+    );
+    return { topics: encoded.topics, data: encoded.data };
+  }
 
   function makeIdentityLookupAdapter(values: bigint[]) {
     const a: any = new EVMChainAdapter(minimalConfig());
     a.initialized = true;
+    a.init = async () => { a.initialized = true; };
     a.resolveContract = recorder(async () => ({}));
     let i = 0;
     const readContract = recorder(async () => {
@@ -101,6 +116,196 @@ describe('EVMChainAdapter getIdentityIdForAddress cache', () => {
     a.clearIdentityIdForAddress(ADDR);
     await expect(a.getIdentityIdForAddress(ADDR)).resolves.toBe(0n);
     expect(readContract.calls).toHaveLength(1);
+  });
+
+  it('coalesces concurrent self getIdentityId reads through the address cache', async () => {
+    const { a, readContract } = makeIdentityLookupAdapter([42n]);
+
+    const results = await Promise.all(
+      Array.from({ length: 20 }, () => a.getIdentityId()),
+    );
+
+    expect(results.every((value) => value === 42n)).toBe(true);
+    expect(readContract.calls).toHaveLength(1);
+    expect(readContract.calls[0][3]).toBe((a as any).signer.address);
+  });
+
+  it('caches positive self getIdentityId results and refreshes them after the positive TTL', async () => {
+    vi.useFakeTimers({ now: 0 });
+    const { a, readContract } = makeIdentityLookupAdapter([7n, 9n]);
+
+    try {
+      await expect(a.getIdentityId()).resolves.toBe(7n);
+      await expect(a.getIdentityId()).resolves.toBe(7n);
+      expect(readContract.calls).toHaveLength(1);
+
+      vi.setSystemTime(5 * 60_000 + 1);
+
+      await expect(a.getIdentityId()).resolves.toBe(9n);
+      expect(readContract.calls).toHaveLength(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('caches a zero self getIdentityId result only for the short signer TTL', async () => {
+    vi.useFakeTimers({ now: 0 });
+    const { a, readContract } = makeIdentityLookupAdapter([0n, 42n]);
+
+    try {
+      await expect(a.getIdentityId()).resolves.toBe(0n);
+      await expect(a.getIdentityId()).resolves.toBe(0n);
+      expect(readContract.calls).toHaveLength(1);
+
+      vi.setSystemTime(15_001);
+
+      await expect(a.getIdentityId()).resolves.toBe(42n);
+      expect(readContract.calls).toHaveLength(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('repairs a cached self zero when a live signer-address lookup observes a positive identity', async () => {
+    const { a, readContract } = makeIdentityLookupAdapter([0n, 42n]);
+
+    await expect(a.getIdentityId()).resolves.toBe(0n);
+    await expect(a.getIdentityIdForAddress((a as any).signer.address)).resolves.toBe(42n);
+    await expect(a.getIdentityId()).resolves.toBe(42n);
+
+    expect(readContract.calls).toHaveLength(2);
+  });
+
+  it('shares cache entries between getIdentityId and getIdentityIdForAddress for the signer', async () => {
+    const { a, readContract } = makeIdentityLookupAdapter([42n]);
+
+    await expect(a.getIdentityId()).resolves.toBe(42n);
+    await expect(a.getIdentityIdForAddress((a as any).signer.address)).resolves.toBe(42n);
+
+    expect(readContract.calls).toHaveLength(1);
+  });
+
+  it('IdentityStorage Hub rotation invalidates cached identity ids and the lazy contract binding', async () => {
+    const { a, readContract } = makeIdentityLookupAdapter([7n, 9n]);
+
+    await expect(a.getIdentityId()).resolves.toBe(7n);
+    await expect(a.getIdentityId()).resolves.toBe(7n);
+    expect(readContract.calls).toHaveLength(1);
+
+    (a as any).contracts.identityStorage = { stale: true };
+    (a as any).applyHubRotationEventName('IdentityStorage');
+
+    expect((a as any).contracts.identityStorage).toBeUndefined();
+    await expect(a.getIdentityId()).resolves.toBe(9n);
+    expect(readContract.calls).toHaveLength(2);
+  });
+
+  it('bulk bound-contract invalidation clears signer identity cache and IdentityStorage binding', async () => {
+    const { a, readContract } = makeIdentityLookupAdapter([7n, 9n]);
+
+    await expect(a.getIdentityId()).resolves.toBe(7n);
+    await expect(a.getIdentityId()).resolves.toBe(7n);
+    expect(readContract.calls).toHaveLength(1);
+
+    (a as any).contracts.identityStorage = { stale: true };
+    (a as any).invalidateAllBoundContracts();
+
+    expect((a as any).contracts.identityStorage).toBeUndefined();
+    await expect(a.getIdentityId()).resolves.toBe(9n);
+    expect(readContract.calls).toHaveLength(2);
+  });
+
+  it('ensureProfile seeds the signer identity cache after IdentityCreated', async () => {
+    const { a, readContract } = makeIdentityLookupAdapter([0n, 99n]);
+    a.contracts.identity = { interface: identityInterface };
+    a.contracts.profile = { interface: profileInterface };
+    a.sendContractTransaction = recorder(async () => ({
+      logs: [identityCreatedLog(77n)],
+      hash: '0x' + '12'.repeat(32),
+      blockNumber: 1,
+      index: 0,
+      status: 1,
+    }));
+
+    await expect(a.ensureProfile({ stakeAmount: 0n })).resolves.toBe(77n);
+    await expect(a.getIdentityId()).resolves.toBe(77n);
+    expect(readContract.calls).toHaveLength(1);
+  });
+
+  it('registerIdentity seeds the signer identity cache after IdentityCreated', async () => {
+    const a: any = new EVMChainAdapter(minimalConfig());
+    const readContract = recorder(async () => 99n);
+    a.init = async () => undefined;
+    a.contracts.identity = { interface: identityInterface };
+    a.contracts.profile = { interface: profileInterface };
+    a.readContract = readContract;
+    a.sendContractTransaction = recorder(async () => ({
+      logs: [identityCreatedLog(88n)],
+      hash: '0x' + '34'.repeat(32),
+      blockNumber: 1,
+      index: 0,
+      status: 1,
+    }));
+
+    await expect(a.registerIdentity({ publicKey: new Uint8Array([1]), signature: new Uint8Array() })).resolves.toBe(88n);
+    await expect(a.getIdentityId()).resolves.toBe(88n);
+    expect(readContract.calls).toHaveLength(0);
+  });
+});
+
+describe('EVMChainAdapter random sampling identity lookup', () => {
+  it('createChallenge uses the cached self identity path and reads back by the emitted identity', async () => {
+    const a: any = new EVMChainAdapter(minimalConfig());
+    const challengeIdentityId = 99n;
+    const cachedIdentityId = 42n;
+    const contextGraphId = 3n;
+    const rsInterface = new Interface([
+      'event ChallengeGenerated(uint72 indexed identityId,uint256 indexed contextGraphId,uint256 knowledgeAssetId,uint256 chunkId,uint256 epoch,uint256 activeProofPeriodStartBlock)',
+    ]);
+    const encoded = rsInterface.encodeEventLog(
+      rsInterface.getEvent('ChallengeGenerated')!,
+      [challengeIdentityId, contextGraphId, 11n, 2n, 3n, 4n],
+    );
+    const receipt = {
+      hash: '0x' + '11'.repeat(32),
+      blockNumber: 123,
+      index: 4,
+      logs: [{ topics: encoded.topics, data: encoded.data }],
+    };
+    const challengeRaw = {
+      knowledgeAssetId: 11n,
+      knowledgeAssetStorageContract: ethers.ZeroAddress,
+      chunkId: 2n,
+      epoch: 3n,
+      activeProofPeriodStartBlock: 4n,
+      proofingPeriodDurationInBlocks: 5n,
+      solved: false,
+      isCurated: false,
+      challengeLeafCount: 1n,
+      challengeRoot: ethers.ZeroHash,
+    };
+    const rss = { __rss: true };
+    const rs = { interface: rsInterface };
+    const getIdentityId = recorder(async () => cachedIdentityId);
+    const readContract = recorder(async () => challengeRaw);
+    const sendContractTransaction = recorder(async () => receipt as any);
+
+    a.init = async () => undefined;
+    a.getIdentityId = getIdentityId;
+    a.getRandomSampling = async () => ({ rs, rss });
+    a.readContract = readContract;
+    a.sendContractTransaction = sendContractTransaction;
+
+    const result = await a.createChallenge();
+
+    expect(getIdentityId.calls).toHaveLength(1);
+    expect(sendContractTransaction.calls[0][1]).toBe('createChallenge');
+    expect(readContract.calls).toHaveLength(1);
+    expect(readContract.calls[0][0]).toBe(rss);
+    expect(readContract.calls[0][1]).toBe('rss.getNodeChallenge');
+    expect(readContract.calls[0][3]).toBe(challengeIdentityId);
+    expect(result.contextGraphId).toBe(contextGraphId);
+    expect(result.challenge.knowledgeAssetId).toBe(11n);
   });
 });
 

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -118,6 +118,10 @@ function recorder<A extends unknown[], R>(impl: (...args: A) => R) {
   return Object.assign(fn, { calls });
 }
 
+async function flushAsyncWork(turns = 8): Promise<void> {
+  for (let i = 0; i < turns; i++) await Promise.resolve();
+}
+
 function minimalConfig(overrides: Partial<EVMAdapterConfig> = {}): EVMAdapterConfig {
   return {
     rpcUrl: 'http://127.0.0.1:59998',
@@ -1142,7 +1146,6 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
       interface: iface,
       getAddress: async () => '0x0000000000000000000000000000000000000001',
     };
-    a.hubRotationListenerStarted = false;
     let unhandled: unknown = null;
     const onRejection = (reason: unknown) => { unhandled = reason; };
     process.on('unhandledRejection', onRejection);
@@ -1152,7 +1155,7 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
       expect(unhandled).toBeNull();
       expect(provider.getBlockNumber.calls).toHaveLength(1);
       expect(provider.getLogs.calls).toHaveLength(1);
-      expect(a.hubRotationListenerStarted).toBe(false);
+      expect(a.hubRotationPoller.isStarted).toBe(true);
     } finally {
       process.off('unhandledRejection', onRejection);
     }
@@ -1177,70 +1180,12 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
       interface: iface,
       getAddress: async () => '0x0000000000000000000000000000000000000001',
     };
-    a.hubRotationListenerStarted = false;
 
     await expect(a.startHubRotationListener()).resolves.toBeUndefined();
 
     expect(provider.getBlockNumber.calls).toEqual([]);
     expect(provider.getLogs.calls).toEqual([]);
-    expect(a.hubRotationListenerStarted).toBe(false);
-  });
-
-  it('startHubRotationListener coalesces concurrent poller starts', async () => {
-    vi.useFakeTimers({ now: 0 });
-    const a: any = new EVMChainAdapter(minimalConfig());
-    const iface = new ethers.Interface([
-      'event NewContract(string contractName, address newContractAddress)',
-      'event ContractChanged(string contractName, address newContractAddress)',
-      'event NewAssetStorage(string contractName, address newContractAddress)',
-      'event AssetStorageChanged(string contractName, address newContractAddress)',
-    ]);
-    let seedEntered!: () => void;
-    const seedEnteredPromise = new Promise<void>((resolve) => { seedEntered = resolve; });
-    let releaseSeed!: () => void;
-    const seedGate = new Promise<void>((resolve) => { releaseSeed = resolve; });
-    let getLogsCalls = 0;
-    const provider = {
-      getBlockNumber: recorder(async () => 1_000),
-      getLogs: recorder(async () => {
-        getLogsCalls++;
-        if (getLogsCalls === 1) {
-          seedEntered();
-          await seedGate;
-        }
-        return [];
-      }),
-      destroy: recorder(() => undefined),
-    };
-    a.providers = [provider];
-    a.rpcUrls = ['https://primary.example'];
-    a.primaryProvider = provider;
-    a.provider = provider;
-    a.contracts.hub = {
-      interface: iface,
-      getAddress: async () => '0x0000000000000000000000000000000000000001',
-    };
-    a.hubRotationListenerStarted = false;
-
-    try {
-      const firstStart = a.startHubRotationListener();
-      await seedEnteredPromise;
-      expect(provider.getLogs.calls).toHaveLength(1);
-
-      const secondStart = a.startHubRotationListener();
-      releaseSeed();
-      await expect(Promise.all([firstStart, secondStart])).resolves.toBeDefined();
-
-      expect(provider.getBlockNumber.calls).toHaveLength(1);
-      expect(provider.getLogs.calls).toHaveLength(1);
-
-      await vi.advanceTimersByTimeAsync(30_000);
-      expect(provider.getBlockNumber.calls).toHaveLength(2);
-      expect(provider.getLogs.calls).toHaveLength(2);
-    } finally {
-      a.destroy();
-      vi.useRealTimers();
-    }
+    expect(a.hubRotationPoller.isStarted).toBe(false);
   });
 
   it('startHubRotationListener skips optional poller setup when primary static validation fails but backup reads still work', async () => {
@@ -1264,28 +1209,32 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
       }),
       getBlockNumber: recorder(async () => 123),
     };
-    const on = recorder(async () => {
-      throw new Error('poller setup should be skipped');
-    });
-
     a.primaryProvider = primaryProvider;
     a.provider = primaryProvider;
     a.providers = [primaryProvider, backupProvider];
     a.rpcUrls = ['https://primary.example', 'https://backup.example'];
-    a.contracts.hub = { on };
-    a.hubRotationListenerStarted = false;
+    a.contracts.hub = {
+      interface: new ethers.Interface([
+        'event NewContract(string contractName, address newContractAddress)',
+        'event ContractChanged(string contractName, address newContractAddress)',
+        'event NewAssetStorage(string contractName, address newContractAddress)',
+        'event AssetStorageChanged(string contractName, address newContractAddress)',
+      ]),
+      getAddress: async () => '0x0000000000000000000000000000000000000001',
+    };
 
     await expect(a.startHubRotationListener()).resolves.toBeUndefined();
-    expect(on.calls).toEqual([]);
-    expect(a.hubRotationListenerStarted).toBe(false);
+    await flushAsyncWork();
+    expect(a.hubRotationPoller.isStarted).toBe(true);
 
     await expect(a.readProvider('getBlockNumber', (p: any) => p.getBlockNumber()))
       .resolves.toBe(123);
     expect(primaryProvider.getBlockNumber.calls).toEqual([]);
-    expect(backupProvider.getBlockNumber.calls).toEqual([[]]);
+    expect(backupProvider.getBlockNumber.calls).toHaveLength(2);
   });
 
-  it('HubRotationPoller pollOnce scans Hub rotation topics without ethers subscriptions', async () => {
+  it('startHubRotationListener wires Hub rotation names into adapter invalidation without subscriptions', async () => {
+    vi.useFakeTimers({ now: 0 });
     const a: any = new EVMChainAdapter(minimalConfig());
     const iface = new ethers.Interface([
       'event NewContract(string contractName, address newContractAddress)',
@@ -1325,256 +1274,37 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     };
     a.contracts.contextGraphs = { stale: true };
     a.cachedKav10Address = { value: '0x00000000000000000000000000000000000000aa', cachedAt: 1 };
-    a.hubRotationListenerStarted = false;
-    a.initialized = true;
-
-    await expect(a.startHubRotationListener()).resolves.toBeUndefined();
-    includeRotationLog = true;
-    head = 1_001;
-    await expect(a.hubRotationPoller.pollOnce()).resolves.toBeUndefined();
-    a.destroy();
-
-    expect(on.calls).toEqual([]);
-    expect(provider.getLogs.calls).toHaveLength(2);
-    expect(provider.getLogs.calls[1][0]).toMatchObject({
-      address: '0x0000000000000000000000000000000000000001',
-      fromBlock: 951,
-      toBlock: 1_001,
-    });
-    expect(provider.getLogs.calls[1][0].topics[0]).toEqual([
-      iface.getEvent('ContractChanged')!.topicHash,
-      iface.getEvent('NewContract')!.topicHash,
-      iface.getEvent('AssetStorageChanged')!.topicHash,
-      iface.getEvent('NewAssetStorage')!.topicHash,
-    ]);
-    expect(a.contracts.contextGraphs).toEqual({ stale: true });
-    expect(a.cachedKav10Address).toBeUndefined();
-    expect(a.initialized).toBe(false);
-    expect(a.hubRotationListenerStarted).toBe(false);
-  });
-
-  it('startHubRotationListener defers seed logs until the first post-start buffered poll', async () => {
-    vi.useFakeTimers({ now: 0 });
-    const a: any = new EVMChainAdapter(minimalConfig());
-    const iface = new ethers.Interface([
-      'event NewContract(string contractName, address newContractAddress)',
-      'event ContractChanged(string contractName, address newContractAddress)',
-      'event NewAssetStorage(string contractName, address newContractAddress)',
-      'event AssetStorageChanged(string contractName, address newContractAddress)',
-    ]);
-    const oldRandomSampling = iface.encodeEventLog(iface.getEvent('NewContract')!, [
-      'RandomSampling',
-      '0x00000000000000000000000000000000000000b1',
-    ]);
-    const changed = iface.encodeEventLog(iface.getEvent('NewContract')!, [
-      'ContextGraphs',
-      '0x00000000000000000000000000000000000000c1',
-    ]);
-    let head = 1_000;
-    const historicalLogs = [
-      {
-        blockNumber: 1_000,
-        blockHash: '0x' + '10'.repeat(32),
-        transactionHash: '0x' + '11'.repeat(32),
-        index: 0,
-        topics: oldRandomSampling.topics,
-        data: oldRandomSampling.data,
-      },
-      {
-        blockNumber: 1_001,
-        blockHash: '0x' + '12'.repeat(32),
-        transactionHash: '0x' + '13'.repeat(32),
-        index: 0,
-        topics: changed.topics,
-        data: changed.data,
-      },
-    ];
-    const provider = {
-      getBlockNumber: recorder(async () => head),
-      getLogs: recorder(async (filter: any) =>
-        historicalLogs.filter((log) => log.blockNumber >= filter.fromBlock && log.blockNumber <= filter.toBlock)),
-      destroy: recorder(() => undefined),
-    };
-    const on = recorder(async () => {
-      throw new Error('ethers subscription should not be installed');
-    });
-    a.providers = [provider];
-    a.rpcUrls = ['https://primary.example'];
-    a.primaryProvider = provider;
-    a.provider = provider;
-    a.contracts.hub = {
-      interface: iface,
-      getAddress: async () => '0x0000000000000000000000000000000000000001',
-      on,
-    };
-    a.contracts.contextGraphs = { fresh: true };
-    a.contracts.randomSampling = { fresh: 'rs' };
-    a.contracts.randomSamplingStorage = { fresh: 'rss' };
-    a.cachedKav10Address = { value: '0x00000000000000000000000000000000000000aa', cachedAt: 1 };
-    a.hubRotationListenerStarted = false;
     a.initialized = true;
 
     try {
       await expect(a.startHubRotationListener()).resolves.toBeUndefined();
-      expect(on.calls).toEqual([]);
-      expect(provider.getBlockNumber.calls).toHaveLength(1);
-      expect(provider.getLogs.calls).toHaveLength(1);
-      expect(provider.getLogs.calls[0][0]).toMatchObject({
-        fromBlock: 950,
-        toBlock: 1_000,
-      });
-      expect(a.contracts.contextGraphs).toEqual({ fresh: true });
-      expect(a.contracts.randomSampling).toEqual({ fresh: 'rs' });
-      expect(a.initialized).toBe(true);
-
+      await flushAsyncWork();
+      includeRotationLog = true;
       head = 1_001;
       await vi.advanceTimersByTimeAsync(30_000);
+      a.destroy();
 
+      expect(on.calls).toEqual([]);
       expect(provider.getLogs.calls).toHaveLength(2);
       expect(provider.getLogs.calls[1][0]).toMatchObject({
+        address: '0x0000000000000000000000000000000000000001',
         fromBlock: 951,
         toBlock: 1_001,
       });
-      expect(a.contracts.contextGraphs).toEqual({ fresh: true });
-      expect(a.contracts.randomSampling).toBeUndefined();
+      expect(provider.getLogs.calls[1][0].topics[0]).toEqual([
+        iface.getEvent('ContractChanged')!.topicHash,
+        iface.getEvent('NewContract')!.topicHash,
+        iface.getEvent('AssetStorageChanged')!.topicHash,
+        iface.getEvent('NewAssetStorage')!.topicHash,
+      ]);
+      expect(a.contracts.contextGraphs).toEqual({ stale: true });
       expect(a.cachedKav10Address).toBeUndefined();
       expect(a.initialized).toBe(false);
+      expect(a.hubRotationPoller.isStarted).toBe(false);
     } finally {
       a.destroy();
       vi.useRealTimers();
     }
-  });
-
-  it('HubRotationPoller applies replacement logs inside the reorg buffer', async () => {
-    const a: any = new EVMChainAdapter(minimalConfig());
-    const iface = new ethers.Interface([
-      'event NewContract(string contractName, address newContractAddress)',
-      'event ContractChanged(string contractName, address newContractAddress)',
-      'event NewAssetStorage(string contractName, address newContractAddress)',
-      'event AssetStorageChanged(string contractName, address newContractAddress)',
-    ]);
-    const oldRotation = iface.encodeEventLog(iface.getEvent('ContractChanged')!, [
-      'UntrackedAtStartup',
-      '0x00000000000000000000000000000000000000b1',
-    ]);
-    const replacement = iface.encodeEventLog(iface.getEvent('ContractChanged')!, [
-      'ContextGraphs',
-      '0x00000000000000000000000000000000000000c1',
-    ]);
-    let head = 1_000;
-    const logs = [
-      {
-        blockNumber: 1_000,
-        blockHash: '0x' + '20'.repeat(32),
-        transactionHash: '0x' + '21'.repeat(32),
-        index: 0,
-        topics: oldRotation.topics,
-        data: oldRotation.data,
-      },
-    ];
-    const provider = {
-      getBlockNumber: recorder(async () => head),
-      getLogs: recorder(async (filter: any) =>
-        logs.filter((log) => log.blockNumber >= filter.fromBlock && log.blockNumber <= filter.toBlock)),
-      destroy: recorder(() => undefined),
-    };
-    a.providers = [provider];
-    a.rpcUrls = ['https://primary.example'];
-    a.primaryProvider = provider;
-    a.provider = provider;
-    a.contracts.hub = {
-      interface: iface,
-      getAddress: async () => '0x0000000000000000000000000000000000000001',
-    };
-    a.contracts.contextGraphs = { fresh: true };
-    a.cachedKav10Address = { value: '0x00000000000000000000000000000000000000aa', cachedAt: 1 };
-    a.initialized = true;
-
-    await expect(a.startHubRotationListener()).resolves.toBeUndefined();
-    expect(a.cachedKav10Address).toBeDefined();
-    expect(a.initialized).toBe(true);
-
-    logs.splice(0, logs.length, {
-      blockNumber: 1_000,
-      blockHash: '0x' + '22'.repeat(32),
-      transactionHash: '0x' + '23'.repeat(32),
-      index: 0,
-      topics: replacement.topics,
-      data: replacement.data,
-    });
-    head = 1_001;
-    await expect(a.hubRotationPoller.pollOnce()).resolves.toBeUndefined();
-    a.destroy();
-
-    expect(provider.getLogs.calls).toHaveLength(2);
-    expect(provider.getLogs.calls[1][0]).toMatchObject({
-      fromBlock: 951,
-      toBlock: 1_001,
-    });
-    expect(a.contracts.contextGraphs).toEqual({ fresh: true });
-    expect(a.cachedKav10Address).toBeUndefined();
-    expect(a.initialized).toBe(false);
-  });
-
-  it('HubRotationPoller processes a new rotation log at the previous cursor block', async () => {
-    const a: any = new EVMChainAdapter(minimalConfig());
-    const iface = new ethers.Interface([
-      'event NewContract(string contractName, address newContractAddress)',
-      'event ContractChanged(string contractName, address newContractAddress)',
-      'event NewAssetStorage(string contractName, address newContractAddress)',
-      'event AssetStorageChanged(string contractName, address newContractAddress)',
-    ]);
-    const rotation = iface.encodeEventLog(iface.getEvent('ContractChanged')!, [
-      'ContextGraphs',
-      '0x00000000000000000000000000000000000000c1',
-    ]);
-    let head = 1_000;
-    let exposeReorgLog = false;
-    const provider = {
-      getBlockNumber: recorder(async () => head),
-      getLogs: recorder(async (filter: any) => {
-        const log = {
-          blockNumber: 1_000,
-          blockHash: '0x' + '40'.repeat(32),
-          transactionHash: '0x' + '41'.repeat(32),
-          index: 0,
-          topics: rotation.topics,
-          data: rotation.data,
-        };
-        return exposeReorgLog && log.blockNumber >= filter.fromBlock && log.blockNumber <= filter.toBlock
-          ? [log]
-          : [];
-      }),
-      destroy: recorder(() => undefined),
-    };
-    a.providers = [provider];
-    a.rpcUrls = ['https://primary.example'];
-    a.primaryProvider = provider;
-    a.provider = provider;
-    a.contracts.hub = {
-      interface: iface,
-      getAddress: async () => '0x0000000000000000000000000000000000000001',
-    };
-    a.contracts.contextGraphs = { fresh: true };
-    a.cachedKav10Address = { value: '0x00000000000000000000000000000000000000aa', cachedAt: 1 };
-    a.initialized = true;
-
-    await expect(a.startHubRotationListener()).resolves.toBeUndefined();
-    expect(a.cachedKav10Address).toBeDefined();
-
-    exposeReorgLog = true;
-    head = 1_001;
-    await expect(a.hubRotationPoller.pollOnce()).resolves.toBeUndefined();
-    a.destroy();
-
-    expect(provider.getLogs.calls).toHaveLength(2);
-    expect(provider.getLogs.calls[1][0]).toMatchObject({
-      fromBlock: 951,
-      toBlock: 1_001,
-    });
-    expect(a.contracts.contextGraphs).toEqual({ fresh: true });
-    expect(a.cachedKav10Address).toBeUndefined();
-    expect(a.initialized).toBe(false);
   });
 
   it('destroy clears the Hub rotation poll interval', async () => {
@@ -1599,10 +1329,10 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
       interface: iface,
       getAddress: async () => '0x0000000000000000000000000000000000000001',
     };
-    a.hubRotationListenerStarted = false;
 
     try {
       await expect(a.startHubRotationListener()).resolves.toBeUndefined();
+      await flushAsyncWork();
       expect(provider.getBlockNumber.calls).toHaveLength(1);
       expect(provider.getLogs.calls).toHaveLength(1);
 
@@ -1612,47 +1342,11 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
       expect(provider.getBlockNumber.calls).toHaveLength(1);
       expect(provider.getLogs.calls).toHaveLength(1);
       expect(provider.destroy.calls).toHaveLength(1);
-      expect(a.hubRotationListenerStarted).toBe(false);
+      expect(a.hubRotationPoller.isStarted).toBe(false);
     } finally {
       a.destroy();
       vi.useRealTimers();
     }
-  });
-
-  it('HubRotationPoller pollOnce clamps the range when failover observes a lower head', async () => {
-    const a: any = new EVMChainAdapter(minimalConfig());
-    const iface = new ethers.Interface([
-      'event NewContract(string contractName, address newContractAddress)',
-      'event ContractChanged(string contractName, address newContractAddress)',
-      'event NewAssetStorage(string contractName, address newContractAddress)',
-      'event AssetStorageChanged(string contractName, address newContractAddress)',
-    ]);
-    let head = 1_000;
-    const provider = {
-      getBlockNumber: recorder(async () => head),
-      getLogs: recorder(async (_filter: any) => []),
-      destroy: recorder(() => undefined),
-    };
-    a.providers = [provider];
-    a.rpcUrls = ['https://lagging.example'];
-    a.primaryProvider = provider;
-    a.provider = provider;
-    a.contracts.hub = {
-      interface: iface,
-      getAddress: async () => '0x0000000000000000000000000000000000000001',
-    };
-    await expect(a.startHubRotationListener()).resolves.toBeUndefined();
-    head = 900;
-
-    await expect(a.hubRotationPoller.pollOnce()).resolves.toBeUndefined();
-    a.destroy();
-
-    expect(provider.getLogs.calls).toHaveLength(2);
-    expect(provider.getLogs.calls[1][0]).toMatchObject({
-      fromBlock: 850,
-      toBlock: 900,
-    });
-    expect(a.hubRotationPoller.lastScannedBlock).toBe(1_000);
   });
 
   it('invalidateRandomSamplingPair drops both the cache AND the side-channel contract handles (Codex N15)', () => {

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -1117,16 +1117,14 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     expect(a.chainType).toBe('evm');
   });
 
-  it('startHubRotationListener swallows async provider rejections without unhandled-rejection or throw (Codex N15)', async () => {
-    // ethers v6 `Contract.on(...)` is async — providers that reject
-    // filter installation (e.g. HTTP-only endpoints, mocked providers)
-    // must NOT bubble as unhandled rejections, and the listener-started
-    // flag must NOT be flipped if subscription failed (so a future
-    // retry remains possible).
+  it('startHubRotationListener swallows optional poll setup failures without unhandled-rejection or throw', async () => {
+    // Hub rotation detection is best-effort. A mocked or unsupported Hub poll
+    // surface must not bubble as an unhandled rejection, and the listener-started
+    // flag must not flip if setup failed so a future retry remains possible.
     const a = new EVMChainAdapter(minimalConfig());
     const fakeHub = {
       on: async (_event: string, _cb: (...args: unknown[]) => void) => {
-        throw new Error('provider does not support filter subscriptions');
+        throw new Error('legacy subscription seam should not be reached');
       },
     };
     (a as any).contracts.hub = fakeHub;
@@ -1184,6 +1182,91 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
       .resolves.toBe(123);
     expect(primaryProvider.getBlockNumber.calls).toEqual([]);
     expect(backupProvider.getBlockNumber.calls).toEqual([[]]);
+  });
+
+  it('startHubRotationListener polls Hub rotation topics without ethers subscriptions', async () => {
+    const a: any = new EVMChainAdapter(minimalConfig());
+    const iface = new ethers.Interface([
+      'event NewContract(string contractName, address newContractAddress)',
+      'event ContractChanged(string contractName, address newContractAddress)',
+      'event NewAssetStorage(string contractName, address newContractAddress)',
+      'event AssetStorageChanged(string contractName, address newContractAddress)',
+    ]);
+    const changed = iface.encodeEventLog(iface.getEvent('ContractChanged')!, [
+      'ContextGraphs',
+      '0x00000000000000000000000000000000000000c1',
+    ]);
+    const provider = {
+      getBlockNumber: recorder(async () => 1_000),
+      getLogs: recorder(async (_filter: any) => [{
+        topics: changed.topics,
+        data: changed.data,
+      }]),
+      destroy: recorder(() => undefined),
+    };
+    const on = recorder(async () => {
+      throw new Error('ethers subscription should not be installed');
+    });
+    a.providers = [provider];
+    a.rpcUrls = ['https://primary.example'];
+    a.primaryProvider = provider;
+    a.provider = provider;
+    a.contracts.hub = { interface: iface, target: '0x0000000000000000000000000000000000000001', on };
+    a.contracts.contextGraphs = { stale: true };
+    a.cachedKav10Address = { value: '0x00000000000000000000000000000000000000aa', cachedAt: 1 };
+    a.hubRotationListenerStarted = false;
+    a.initialized = true;
+
+    await expect(a.startHubRotationListener()).resolves.toBeUndefined();
+    a.destroy();
+
+    expect(on.calls).toEqual([]);
+    expect(provider.getLogs.calls).toHaveLength(1);
+    expect(provider.getLogs.calls[0][0]).toMatchObject({
+      address: '0x0000000000000000000000000000000000000001',
+      fromBlock: 950,
+      toBlock: 1_000,
+    });
+    expect(provider.getLogs.calls[0][0].topics[0]).toEqual([
+      iface.getEvent('ContractChanged')!.topicHash,
+      iface.getEvent('NewContract')!.topicHash,
+      iface.getEvent('AssetStorageChanged')!.topicHash,
+      iface.getEvent('NewAssetStorage')!.topicHash,
+    ]);
+    expect(a.contracts.contextGraphs).toEqual({ stale: true });
+    expect(a.cachedKav10Address).toBeUndefined();
+    expect(a.initialized).toBe(false);
+    expect(a.hubRotationListenerStarted).toBe(false);
+  });
+
+  it('pollHubRotationEvents clamps the range when failover observes a lower head', async () => {
+    const a: any = new EVMChainAdapter(minimalConfig());
+    const iface = new ethers.Interface([
+      'event NewContract(string contractName, address newContractAddress)',
+      'event ContractChanged(string contractName, address newContractAddress)',
+      'event NewAssetStorage(string contractName, address newContractAddress)',
+      'event AssetStorageChanged(string contractName, address newContractAddress)',
+    ]);
+    const provider = {
+      getBlockNumber: recorder(async () => 900),
+      getLogs: recorder(async (_filter: any) => []),
+      destroy: recorder(() => undefined),
+    };
+    a.providers = [provider];
+    a.rpcUrls = ['https://lagging.example'];
+    a.primaryProvider = provider;
+    a.provider = provider;
+    a.contracts.hub = { interface: iface, target: '0x0000000000000000000000000000000000000001' };
+    a.hubRotationLastScannedBlock = 1_000;
+
+    await expect(a.pollHubRotationEvents()).resolves.toBeUndefined();
+
+    expect(provider.getLogs.calls).toHaveLength(1);
+    expect(provider.getLogs.calls[0][0]).toMatchObject({
+      fromBlock: 850,
+      toBlock: 900,
+    });
+    expect(a.hubRotationLastScannedBlock).toBe(900);
   });
 
   it('invalidateRandomSamplingPair drops both the cache AND the side-channel contract handles (Codex N15)', () => {

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -1158,6 +1158,34 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     }
   });
 
+  it('startHubRotationListener refuses partial Hub rotation event ABI', async () => {
+    const a: any = new EVMChainAdapter(minimalConfig());
+    const iface = new ethers.Interface([
+      'event NewContract(string contractName, address newContractAddress)',
+      'event ContractChanged(string contractName, address newContractAddress)',
+      'event NewAssetStorage(string contractName, address newContractAddress)',
+    ]);
+    const provider = {
+      getBlockNumber: recorder(async () => 1_000),
+      getLogs: recorder(async () => []),
+    };
+    a.providers = [provider];
+    a.rpcUrls = ['https://primary.example'];
+    a.primaryProvider = provider;
+    a.provider = provider;
+    a.contracts.hub = {
+      interface: iface,
+      getAddress: async () => '0x0000000000000000000000000000000000000001',
+    };
+    a.hubRotationListenerStarted = false;
+
+    await expect(a.startHubRotationListener()).resolves.toBeUndefined();
+
+    expect(provider.getBlockNumber.calls).toEqual([]);
+    expect(provider.getLogs.calls).toEqual([]);
+    expect(a.hubRotationListenerStarted).toBe(false);
+  });
+
   it('startHubRotationListener skips optional poller setup when primary static validation fails but backup reads still work', async () => {
     const a: any = new EVMChainAdapter(minimalConfig({
       rpcUrl: 'https://primary.example',

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -202,6 +202,26 @@ describe('EVMChainAdapter getIdentityIdForAddress cache', () => {
     expect(readContract.calls).toHaveLength(1);
   });
 
+  it('identity id reads populate the canonical IdentityStorage lazy binding', async () => {
+    const a: any = new EVMChainAdapter(minimalConfig());
+    const identityStorage = { identityStorage: true };
+    a.initialized = true;
+    a.init = async () => { a.initialized = true; };
+    a.resolveContract = recorder(async () => identityStorage);
+    a.readContract = recorder(async (_contract: unknown, _label: string, method: string) => (
+      method === 'getIdentityId' ? 42n : true
+    ));
+
+    await expect(a.getIdentityId()).resolves.toBe(42n);
+    expect(a.contracts.identityStorage).toBe(identityStorage);
+
+    await expect(a.isOperationalWalletRegistered(42n, ADDR)).resolves.toBe(true);
+    expect(a.resolveContract.calls).toHaveLength(1);
+    expect(a.readContract.calls).toHaveLength(2);
+    expect(a.readContract.calls[0][0]).toBe(identityStorage);
+    expect(a.readContract.calls[1][0]).toBe(identityStorage);
+  });
+
   it('IdentityStorage Hub rotation invalidates cached identity ids and the lazy contract binding', async () => {
     const { a, readContract } = makeIdentityLookupAdapter([7n, 9n]);
 
@@ -210,10 +230,15 @@ describe('EVMChainAdapter getIdentityIdForAddress cache', () => {
     expect(readContract.calls).toHaveLength(1);
 
     (a as any).contracts.identityStorage = { stale: true };
+    const init = recorder(async () => { (a as any).initialized = true; });
+    (a as any).init = init;
     (a as any).applyHubRotationEventName('IdentityStorage');
 
     expect((a as any).contracts.identityStorage).toBeUndefined();
+    expect((a as any).initialized).toBe(false);
     await expect(a.getIdentityId()).resolves.toBe(9n);
+    expect(init.calls).toHaveLength(1);
+    expect((a as any).initialized).toBe(true);
     expect(readContract.calls).toHaveLength(2);
   });
 

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -1415,6 +1415,67 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     expect(a.initialized).toBe(false);
   });
 
+  it('HubRotationPoller processes a new rotation log at the previous cursor block', async () => {
+    const a: any = new EVMChainAdapter(minimalConfig());
+    const iface = new ethers.Interface([
+      'event NewContract(string contractName, address newContractAddress)',
+      'event ContractChanged(string contractName, address newContractAddress)',
+      'event NewAssetStorage(string contractName, address newContractAddress)',
+      'event AssetStorageChanged(string contractName, address newContractAddress)',
+    ]);
+    const rotation = iface.encodeEventLog(iface.getEvent('ContractChanged')!, [
+      'ContextGraphs',
+      '0x00000000000000000000000000000000000000c1',
+    ]);
+    let head = 1_000;
+    let exposeReorgLog = false;
+    const provider = {
+      getBlockNumber: recorder(async () => head),
+      getLogs: recorder(async (filter: any) => {
+        const log = {
+          blockNumber: 1_000,
+          blockHash: '0x' + '40'.repeat(32),
+          transactionHash: '0x' + '41'.repeat(32),
+          index: 0,
+          topics: rotation.topics,
+          data: rotation.data,
+        };
+        return exposeReorgLog && log.blockNumber >= filter.fromBlock && log.blockNumber <= filter.toBlock
+          ? [log]
+          : [];
+      }),
+      destroy: recorder(() => undefined),
+    };
+    a.providers = [provider];
+    a.rpcUrls = ['https://primary.example'];
+    a.primaryProvider = provider;
+    a.provider = provider;
+    a.contracts.hub = {
+      interface: iface,
+      getAddress: async () => '0x0000000000000000000000000000000000000001',
+    };
+    a.contracts.contextGraphs = { fresh: true };
+    a.cachedKav10Address = { value: '0x00000000000000000000000000000000000000aa', cachedAt: 1 };
+    a.initialized = true;
+
+    await expect(a.startHubRotationListener()).resolves.toBeUndefined();
+    expect(a.cachedKav10Address).toBeDefined();
+
+    exposeReorgLog = true;
+    head = 1_001;
+    await expect(a.hubRotationPoller.pollOnce()).resolves.toBeUndefined();
+    a.destroy();
+
+    expect(provider.getLogs.calls).toHaveLength(2);
+    expect(provider.getLogs.calls[1][0]).toMatchObject({
+      fromBlock: 951,
+      toBlock: 1_001,
+    });
+    expect(a.contracts.contextGraphs).toEqual({ fresh: true });
+    expect(a.cachedKav10Address).toBeUndefined();
+    expect(a.initialized).toBe(false);
+  });
+
   it('destroy clears the Hub rotation poll interval', async () => {
     vi.useFakeTimers({ now: 0 });
     const a: any = new EVMChainAdapter(minimalConfig());

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -1142,7 +1142,7 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     }
   });
 
-  it('startHubRotationListener skips optional listener setup when primary static validation fails but backup reads still work', async () => {
+  it('startHubRotationListener skips optional poller setup when primary static validation fails but backup reads still work', async () => {
     const a: any = new EVMChainAdapter(minimalConfig({
       rpcUrl: 'https://primary.example',
       rpcUrls: ['https://backup.example'],
@@ -1164,7 +1164,7 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
       getBlockNumber: recorder(async () => 123),
     };
     const on = recorder(async () => {
-      throw new Error('listener subscription should be skipped');
+      throw new Error('poller setup should be skipped');
     });
 
     a.primaryProvider = primaryProvider;
@@ -1184,7 +1184,7 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     expect(backupProvider.getBlockNumber.calls).toEqual([[]]);
   });
 
-  it('pollHubRotationEvents scans Hub rotation topics without ethers subscriptions', async () => {
+  it('HubRotationPoller pollOnce scans Hub rotation topics without ethers subscriptions', async () => {
     const a: any = new EVMChainAdapter(minimalConfig());
     const iface = new ethers.Interface([
       'event NewContract(string contractName, address newContractAddress)',
@@ -1196,13 +1196,18 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
       'ContextGraphs',
       '0x00000000000000000000000000000000000000c1',
     ]);
+    let head = 1_000;
+    let includeRotationLog = false;
     const provider = {
-      getBlockNumber: recorder(async () => 1_000),
-      getLogs: recorder(async (_filter: any) => [{
-        blockNumber: 1_000,
+      getBlockNumber: recorder(async () => head),
+      getLogs: recorder(async (_filter: any) => includeRotationLog ? [{
+        blockNumber: 1_001,
+        blockHash: '0x' + '30'.repeat(32),
+        transactionHash: '0x' + '31'.repeat(32),
+        index: 0,
         topics: changed.topics,
         data: changed.data,
-      }]),
+      }] : []),
       destroy: recorder(() => undefined),
     };
     const on = recorder(async () => {
@@ -1222,17 +1227,20 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     a.hubRotationListenerStarted = false;
     a.initialized = true;
 
-    await expect(a.pollHubRotationEvents()).resolves.toBeUndefined();
+    await expect(a.startHubRotationListener()).resolves.toBeUndefined();
+    includeRotationLog = true;
+    head = 1_001;
+    await expect(a.hubRotationPoller.pollOnce()).resolves.toBeUndefined();
     a.destroy();
 
     expect(on.calls).toEqual([]);
-    expect(provider.getLogs.calls).toHaveLength(1);
-    expect(provider.getLogs.calls[0][0]).toMatchObject({
+    expect(provider.getLogs.calls).toHaveLength(2);
+    expect(provider.getLogs.calls[1][0]).toMatchObject({
       address: '0x0000000000000000000000000000000000000001',
-      fromBlock: 950,
-      toBlock: 1_000,
+      fromBlock: 951,
+      toBlock: 1_001,
     });
-    expect(provider.getLogs.calls[0][0].topics[0]).toEqual([
+    expect(provider.getLogs.calls[1][0].topics[0]).toEqual([
       iface.getEvent('ContractChanged')!.topicHash,
       iface.getEvent('NewContract')!.topicHash,
       iface.getEvent('AssetStorageChanged')!.topicHash,
@@ -1262,12 +1270,28 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
       '0x00000000000000000000000000000000000000c1',
     ]);
     let head = 1_000;
+    const historicalLogs = [
+      {
+        blockNumber: 1_000,
+        blockHash: '0x' + '10'.repeat(32),
+        transactionHash: '0x' + '11'.repeat(32),
+        index: 0,
+        topics: oldRandomSampling.topics,
+        data: oldRandomSampling.data,
+      },
+      {
+        blockNumber: 1_001,
+        blockHash: '0x' + '12'.repeat(32),
+        transactionHash: '0x' + '13'.repeat(32),
+        index: 0,
+        topics: changed.topics,
+        data: changed.data,
+      },
+    ];
     const provider = {
       getBlockNumber: recorder(async () => head),
-      getLogs: recorder(async (_filter: any) => [
-        { blockNumber: 1_000, topics: oldRandomSampling.topics, data: oldRandomSampling.data },
-        { blockNumber: 1_001, topics: changed.topics, data: changed.data },
-      ]),
+      getLogs: recorder(async (filter: any) =>
+        historicalLogs.filter((log) => log.blockNumber >= filter.fromBlock && log.blockNumber <= filter.toBlock)),
       destroy: recorder(() => undefined),
     };
     const on = recorder(async () => {
@@ -1293,7 +1317,11 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
       await expect(a.startHubRotationListener()).resolves.toBeUndefined();
       expect(on.calls).toEqual([]);
       expect(provider.getBlockNumber.calls).toHaveLength(1);
-      expect(provider.getLogs.calls).toHaveLength(0);
+      expect(provider.getLogs.calls).toHaveLength(1);
+      expect(provider.getLogs.calls[0][0]).toMatchObject({
+        fromBlock: 950,
+        toBlock: 1_000,
+      });
       expect(a.contracts.contextGraphs).toEqual({ fresh: true });
       expect(a.contracts.randomSampling).toEqual({ fresh: 'rs' });
       expect(a.initialized).toBe(true);
@@ -1301,8 +1329,8 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
       head = 1_001;
       await vi.advanceTimersByTimeAsync(5 * 60_000);
 
-      expect(provider.getLogs.calls).toHaveLength(1);
-      expect(provider.getLogs.calls[0][0]).toMatchObject({
+      expect(provider.getLogs.calls).toHaveLength(2);
+      expect(provider.getLogs.calls[1][0]).toMatchObject({
         fromBlock: 951,
         toBlock: 1_001,
       });
@@ -1314,6 +1342,77 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
       a.destroy();
       vi.useRealTimers();
     }
+  });
+
+  it('HubRotationPoller applies replacement logs inside the reorg buffer', async () => {
+    const a: any = new EVMChainAdapter(minimalConfig());
+    const iface = new ethers.Interface([
+      'event NewContract(string contractName, address newContractAddress)',
+      'event ContractChanged(string contractName, address newContractAddress)',
+      'event NewAssetStorage(string contractName, address newContractAddress)',
+      'event AssetStorageChanged(string contractName, address newContractAddress)',
+    ]);
+    const oldRotation = iface.encodeEventLog(iface.getEvent('ContractChanged')!, [
+      'UntrackedAtStartup',
+      '0x00000000000000000000000000000000000000b1',
+    ]);
+    const replacement = iface.encodeEventLog(iface.getEvent('ContractChanged')!, [
+      'ContextGraphs',
+      '0x00000000000000000000000000000000000000c1',
+    ]);
+    let head = 1_000;
+    const logs = [
+      {
+        blockNumber: 1_000,
+        blockHash: '0x' + '20'.repeat(32),
+        transactionHash: '0x' + '21'.repeat(32),
+        index: 0,
+        topics: oldRotation.topics,
+        data: oldRotation.data,
+      },
+    ];
+    const provider = {
+      getBlockNumber: recorder(async () => head),
+      getLogs: recorder(async (filter: any) =>
+        logs.filter((log) => log.blockNumber >= filter.fromBlock && log.blockNumber <= filter.toBlock)),
+      destroy: recorder(() => undefined),
+    };
+    a.providers = [provider];
+    a.rpcUrls = ['https://primary.example'];
+    a.primaryProvider = provider;
+    a.provider = provider;
+    a.contracts.hub = {
+      interface: iface,
+      getAddress: async () => '0x0000000000000000000000000000000000000001',
+    };
+    a.contracts.contextGraphs = { fresh: true };
+    a.cachedKav10Address = { value: '0x00000000000000000000000000000000000000aa', cachedAt: 1 };
+    a.initialized = true;
+
+    await expect(a.startHubRotationListener()).resolves.toBeUndefined();
+    expect(a.cachedKav10Address).toBeDefined();
+    expect(a.initialized).toBe(true);
+
+    logs.splice(0, logs.length, {
+      blockNumber: 1_000,
+      blockHash: '0x' + '22'.repeat(32),
+      transactionHash: '0x' + '23'.repeat(32),
+      index: 0,
+      topics: replacement.topics,
+      data: replacement.data,
+    });
+    head = 1_001;
+    await expect(a.hubRotationPoller.pollOnce()).resolves.toBeUndefined();
+    a.destroy();
+
+    expect(provider.getLogs.calls).toHaveLength(2);
+    expect(provider.getLogs.calls[1][0]).toMatchObject({
+      fromBlock: 951,
+      toBlock: 1_001,
+    });
+    expect(a.contracts.contextGraphs).toEqual({ fresh: true });
+    expect(a.cachedKav10Address).toBeUndefined();
+    expect(a.initialized).toBe(false);
   });
 
   it('destroy clears the Hub rotation poll interval', async () => {
@@ -1343,13 +1442,13 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     try {
       await expect(a.startHubRotationListener()).resolves.toBeUndefined();
       expect(provider.getBlockNumber.calls).toHaveLength(1);
-      expect(provider.getLogs.calls).toHaveLength(0);
+      expect(provider.getLogs.calls).toHaveLength(1);
 
       a.destroy();
       await vi.advanceTimersByTimeAsync(5 * 60_000);
 
       expect(provider.getBlockNumber.calls).toHaveLength(1);
-      expect(provider.getLogs.calls).toHaveLength(0);
+      expect(provider.getLogs.calls).toHaveLength(1);
       expect(provider.destroy.calls).toHaveLength(1);
       expect(a.hubRotationListenerStarted).toBe(false);
     } finally {
@@ -1358,7 +1457,7 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     }
   });
 
-  it('pollHubRotationEvents clamps the range when failover observes a lower head', async () => {
+  it('HubRotationPoller pollOnce clamps the range when failover observes a lower head', async () => {
     const a: any = new EVMChainAdapter(minimalConfig());
     const iface = new ethers.Interface([
       'event NewContract(string contractName, address newContractAddress)',
@@ -1366,8 +1465,9 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
       'event NewAssetStorage(string contractName, address newContractAddress)',
       'event AssetStorageChanged(string contractName, address newContractAddress)',
     ]);
+    let head = 1_000;
     const provider = {
-      getBlockNumber: recorder(async () => 900),
+      getBlockNumber: recorder(async () => head),
       getLogs: recorder(async (_filter: any) => []),
       destroy: recorder(() => undefined),
     };
@@ -1379,12 +1479,14 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
       interface: iface,
       getAddress: async () => '0x0000000000000000000000000000000000000001',
     };
-    a.hubRotationPoller.lastScannedBlock = 1_000;
+    await expect(a.startHubRotationListener()).resolves.toBeUndefined();
+    head = 900;
 
-    await expect(a.pollHubRotationEvents()).resolves.toBeUndefined();
+    await expect(a.hubRotationPoller.pollOnce()).resolves.toBeUndefined();
+    a.destroy();
 
-    expect(provider.getLogs.calls).toHaveLength(1);
-    expect(provider.getLogs.calls[0][0]).toMatchObject({
+    expect(provider.getLogs.calls).toHaveLength(2);
+    expect(provider.getLogs.calls[1][0]).toMatchObject({
       fromBlock: 850,
       toBlock: 900,
     });

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -1184,7 +1184,7 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     expect(backupProvider.getBlockNumber.calls).toEqual([[]]);
   });
 
-  it('startHubRotationListener polls Hub rotation topics without ethers subscriptions', async () => {
+  it('pollHubRotationEvents scans Hub rotation topics without ethers subscriptions', async () => {
     const a: any = new EVMChainAdapter(minimalConfig());
     const iface = new ethers.Interface([
       'event NewContract(string contractName, address newContractAddress)',
@@ -1199,6 +1199,7 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     const provider = {
       getBlockNumber: recorder(async () => 1_000),
       getLogs: recorder(async (_filter: any) => [{
+        blockNumber: 1_000,
         topics: changed.topics,
         data: changed.data,
       }]),
@@ -1217,7 +1218,7 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     a.hubRotationListenerStarted = false;
     a.initialized = true;
 
-    await expect(a.startHubRotationListener()).resolves.toBeUndefined();
+    await expect(a.pollHubRotationEvents()).resolves.toBeUndefined();
     a.destroy();
 
     expect(on.calls).toEqual([]);
@@ -1239,7 +1240,7 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     expect(a.hubRotationListenerStarted).toBe(false);
   });
 
-  it('startHubRotationListener processes Hub rotations from the recurring poll timer', async () => {
+  it('startHubRotationListener ignores replayed startup logs and processes post-start timer rotations', async () => {
     vi.useFakeTimers({ now: 0 });
     const a: any = new EVMChainAdapter(minimalConfig());
     const iface = new ethers.Interface([
@@ -1248,19 +1249,21 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
       'event NewAssetStorage(string contractName, address newContractAddress)',
       'event AssetStorageChanged(string contractName, address newContractAddress)',
     ]);
+    const oldRandomSampling = iface.encodeEventLog(iface.getEvent('NewContract')!, [
+      'RandomSampling',
+      '0x00000000000000000000000000000000000000b1',
+    ]);
     const changed = iface.encodeEventLog(iface.getEvent('NewContract')!, [
       'ContextGraphs',
       '0x00000000000000000000000000000000000000c1',
     ]);
-    let poll = 0;
+    let head = 1_000;
     const provider = {
-      getBlockNumber: recorder(async () => 1_000 + poll),
-      getLogs: recorder(async (_filter: any) => {
-        poll++;
-        return poll === 1
-          ? []
-          : [{ topics: changed.topics, data: changed.data }];
-      }),
+      getBlockNumber: recorder(async () => head),
+      getLogs: recorder(async (_filter: any) => [
+        { blockNumber: 1_000, topics: oldRandomSampling.topics, data: oldRandomSampling.data },
+        { blockNumber: 1_001, topics: changed.topics, data: changed.data },
+      ]),
       destroy: recorder(() => undefined),
     };
     const on = recorder(async () => {
@@ -1271,6 +1274,9 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     a.primaryProvider = provider;
     a.provider = provider;
     a.contracts.hub = { interface: iface, target: '0x0000000000000000000000000000000000000001', on };
+    a.contracts.contextGraphs = { fresh: true };
+    a.contracts.randomSampling = { fresh: 'rs' };
+    a.contracts.randomSamplingStorage = { fresh: 'rss' };
     a.cachedKav10Address = { value: '0x00000000000000000000000000000000000000aa', cachedAt: 1 };
     a.hubRotationListenerStarted = false;
     a.initialized = true;
@@ -1278,14 +1284,63 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     try {
       await expect(a.startHubRotationListener()).resolves.toBeUndefined();
       expect(on.calls).toEqual([]);
-      expect(provider.getLogs.calls).toHaveLength(1);
+      expect(provider.getBlockNumber.calls).toHaveLength(1);
+      expect(provider.getLogs.calls).toHaveLength(0);
+      expect(a.contracts.contextGraphs).toEqual({ fresh: true });
+      expect(a.contracts.randomSampling).toEqual({ fresh: 'rs' });
       expect(a.initialized).toBe(true);
 
+      head = 1_001;
       await vi.advanceTimersByTimeAsync(5 * 60_000);
 
-      expect(provider.getLogs.calls).toHaveLength(2);
+      expect(provider.getLogs.calls).toHaveLength(1);
+      expect(provider.getLogs.calls[0][0]).toMatchObject({
+        fromBlock: 951,
+        toBlock: 1_001,
+      });
+      expect(a.contracts.contextGraphs).toEqual({ fresh: true });
+      expect(a.contracts.randomSampling).toEqual({ fresh: 'rs' });
       expect(a.cachedKav10Address).toBeUndefined();
       expect(a.initialized).toBe(false);
+    } finally {
+      a.destroy();
+      vi.useRealTimers();
+    }
+  });
+
+  it('destroy clears the Hub rotation poll interval', async () => {
+    vi.useFakeTimers({ now: 0 });
+    const a: any = new EVMChainAdapter(minimalConfig());
+    const iface = new ethers.Interface([
+      'event NewContract(string contractName, address newContractAddress)',
+      'event ContractChanged(string contractName, address newContractAddress)',
+      'event NewAssetStorage(string contractName, address newContractAddress)',
+      'event AssetStorageChanged(string contractName, address newContractAddress)',
+    ]);
+    const provider = {
+      getBlockNumber: recorder(async () => 1_000),
+      getLogs: recorder(async (_filter: any) => []),
+      destroy: recorder(() => undefined),
+    };
+    a.providers = [provider];
+    a.rpcUrls = ['https://primary.example'];
+    a.primaryProvider = provider;
+    a.provider = provider;
+    a.contracts.hub = { interface: iface, target: '0x0000000000000000000000000000000000000001' };
+    a.hubRotationListenerStarted = false;
+
+    try {
+      await expect(a.startHubRotationListener()).resolves.toBeUndefined();
+      expect(provider.getBlockNumber.calls).toHaveLength(1);
+      expect(provider.getLogs.calls).toHaveLength(0);
+
+      a.destroy();
+      await vi.advanceTimersByTimeAsync(5 * 60_000);
+
+      expect(provider.getBlockNumber.calls).toHaveLength(1);
+      expect(provider.getLogs.calls).toHaveLength(0);
+      expect(provider.destroy.calls).toHaveLength(1);
+      expect(a.hubRotationListenerStarted).toBe(false);
     } finally {
       a.destroy();
       vi.useRealTimers();
@@ -1319,7 +1374,7 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
       fromBlock: 850,
       toBlock: 900,
     });
-    expect(a.hubRotationPoller.lastScannedBlock).toBe(900);
+    expect(a.hubRotationPoller.lastScannedBlock).toBe(1_000);
   });
 
   it('invalidateRandomSamplingPair drops both the cache AND the side-channel contract handles (Codex N15)', () => {

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -1121,10 +1121,7 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     expect(a.chainType).toBe('evm');
   });
 
-  it('startHubRotationListener swallows optional poll setup failures without unhandled-rejection or throw', async () => {
-    // Hub rotation detection is best-effort. A mocked or unsupported Hub poll
-    // surface must not bubble as an unhandled rejection, and the listener-started
-    // flag must not flip if setup failed so a future retry remains possible.
+  it('startHubRotationListener validates Hub binding without touching RPC logs', async () => {
     const a: any = new EVMChainAdapter(minimalConfig());
     const iface = new ethers.Interface([
       'event NewContract(string contractName, address newContractAddress)',
@@ -1133,9 +1130,11 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
       'event AssetStorageChanged(string contractName, address newContractAddress)',
     ]);
     const provider = {
-      getBlockNumber: recorder(async () => 1_000),
+      getBlockNumber: recorder(async () => {
+        throw new Error('startup should not read block number');
+      }),
       getLogs: recorder(async () => {
-        throw new Error('eth_getLogs unsupported');
+        throw new Error('startup should not read logs');
       }),
     };
     a.providers = [provider];
@@ -1146,19 +1145,11 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
       interface: iface,
       getAddress: async () => '0x0000000000000000000000000000000000000001',
     };
-    let unhandled: unknown = null;
-    const onRejection = (reason: unknown) => { unhandled = reason; };
-    process.on('unhandledRejection', onRejection);
-    try {
-      await expect(a.startHubRotationListener()).resolves.toBeUndefined();
-      await new Promise((resolve) => setTimeout(resolve, 50));
-      expect(unhandled).toBeNull();
-      expect(provider.getBlockNumber.calls).toHaveLength(1);
-      expect(provider.getLogs.calls).toHaveLength(1);
-      expect(a.hubRotationPoller.isStarted).toBe(true);
-    } finally {
-      process.off('unhandledRejection', onRejection);
-    }
+    await expect(a.startHubRotationListener()).resolves.toBeUndefined();
+
+    expect(provider.getBlockNumber.calls).toEqual([]);
+    expect(provider.getLogs.calls).toEqual([]);
+    expect(a.hubRotationPoller.isStarted).toBe(true);
   });
 
   it('startHubRotationListener refuses partial Hub rotation event ABI', async () => {
@@ -1181,14 +1172,22 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
       getAddress: async () => '0x0000000000000000000000000000000000000001',
     };
 
-    await expect(a.startHubRotationListener()).resolves.toBeUndefined();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      await expect(a.startHubRotationListener()).resolves.toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining(
+        'Hub rotation poller setup disabled: Hub ABI is missing required rotation event AssetStorageChanged',
+      ));
+    } finally {
+      warnSpy.mockRestore();
+    }
 
     expect(provider.getBlockNumber.calls).toEqual([]);
     expect(provider.getLogs.calls).toEqual([]);
     expect(a.hubRotationPoller.isStarted).toBe(false);
   });
 
-  it('startHubRotationListener skips optional poller setup when primary static validation fails but backup reads still work', async () => {
+  it('startHubRotationListener does not consume RPC budget while backup reads still work', async () => {
     const a: any = new EVMChainAdapter(minimalConfig({
       rpcUrl: 'https://primary.example',
       rpcUrls: ['https://backup.example'],
@@ -1230,7 +1229,7 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     await expect(a.readProvider('getBlockNumber', (p: any) => p.getBlockNumber()))
       .resolves.toBe(123);
     expect(primaryProvider.getBlockNumber.calls).toEqual([]);
-    expect(backupProvider.getBlockNumber.calls).toHaveLength(2);
+    expect(backupProvider.getBlockNumber.calls).toHaveLength(1);
   });
 
   it('startHubRotationListener wires Hub rotation names into adapter invalidation without subscriptions', async () => {
@@ -1285,13 +1284,13 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
       a.destroy();
 
       expect(on.calls).toEqual([]);
-      expect(provider.getLogs.calls).toHaveLength(2);
-      expect(provider.getLogs.calls[1][0]).toMatchObject({
+      expect(provider.getLogs.calls).toHaveLength(1);
+      expect(provider.getLogs.calls[0][0]).toMatchObject({
         address: '0x0000000000000000000000000000000000000001',
         fromBlock: 951,
         toBlock: 1_001,
       });
-      expect(provider.getLogs.calls[1][0].topics[0]).toEqual([
+      expect(provider.getLogs.calls[0][0].topics[0]).toEqual([
         iface.getEvent('ContractChanged')!.topicHash,
         iface.getEvent('NewContract')!.topicHash,
         iface.getEvent('AssetStorageChanged')!.topicHash,
@@ -1333,14 +1332,14 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     try {
       await expect(a.startHubRotationListener()).resolves.toBeUndefined();
       await flushAsyncWork();
-      expect(provider.getBlockNumber.calls).toHaveLength(1);
-      expect(provider.getLogs.calls).toHaveLength(1);
+      expect(provider.getBlockNumber.calls).toHaveLength(0);
+      expect(provider.getLogs.calls).toHaveLength(0);
 
       a.destroy();
       await vi.advanceTimersByTimeAsync(30_000);
 
-      expect(provider.getBlockNumber.calls).toHaveLength(1);
-      expect(provider.getLogs.calls).toHaveLength(1);
+      expect(provider.getBlockNumber.calls).toHaveLength(0);
+      expect(provider.getLogs.calls).toHaveLength(0);
       expect(provider.destroy.calls).toHaveLength(1);
       expect(a.hubRotationPoller.isStarted).toBe(false);
     } finally {

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -1121,22 +1121,38 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     // Hub rotation detection is best-effort. A mocked or unsupported Hub poll
     // surface must not bubble as an unhandled rejection, and the listener-started
     // flag must not flip if setup failed so a future retry remains possible.
-    const a = new EVMChainAdapter(minimalConfig());
-    const fakeHub = {
-      on: async (_event: string, _cb: (...args: unknown[]) => void) => {
-        throw new Error('legacy subscription seam should not be reached');
-      },
+    const a: any = new EVMChainAdapter(minimalConfig());
+    const iface = new ethers.Interface([
+      'event NewContract(string contractName, address newContractAddress)',
+      'event ContractChanged(string contractName, address newContractAddress)',
+      'event NewAssetStorage(string contractName, address newContractAddress)',
+      'event AssetStorageChanged(string contractName, address newContractAddress)',
+    ]);
+    const provider = {
+      getBlockNumber: recorder(async () => 1_000),
+      getLogs: recorder(async () => {
+        throw new Error('eth_getLogs unsupported');
+      }),
     };
-    (a as any).contracts.hub = fakeHub;
-    (a as any).hubRotationListenerStarted = false;
+    a.providers = [provider];
+    a.rpcUrls = ['https://primary.example'];
+    a.primaryProvider = provider;
+    a.provider = provider;
+    a.contracts.hub = {
+      interface: iface,
+      getAddress: async () => '0x0000000000000000000000000000000000000001',
+    };
+    a.hubRotationListenerStarted = false;
     let unhandled: unknown = null;
     const onRejection = (reason: unknown) => { unhandled = reason; };
     process.on('unhandledRejection', onRejection);
     try {
-      await expect((a as any).startHubRotationListener()).resolves.toBeUndefined();
+      await expect(a.startHubRotationListener()).resolves.toBeUndefined();
       await new Promise((resolve) => setTimeout(resolve, 50));
       expect(unhandled).toBeNull();
-      expect((a as any).hubRotationListenerStarted).toBe(false);
+      expect(provider.getBlockNumber.calls).toHaveLength(1);
+      expect(provider.getLogs.calls).toHaveLength(1);
+      expect(a.hubRotationListenerStarted).toBe(false);
     } finally {
       process.off('unhandledRejection', onRejection);
     }
@@ -1327,7 +1343,7 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
       expect(a.initialized).toBe(true);
 
       head = 1_001;
-      await vi.advanceTimersByTimeAsync(5 * 60_000);
+      await vi.advanceTimersByTimeAsync(30_000);
 
       expect(provider.getLogs.calls).toHaveLength(2);
       expect(provider.getLogs.calls[1][0]).toMatchObject({
@@ -1506,7 +1522,7 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
       expect(provider.getLogs.calls).toHaveLength(1);
 
       a.destroy();
-      await vi.advanceTimersByTimeAsync(5 * 60_000);
+      await vi.advanceTimersByTimeAsync(30_000);
 
       expect(provider.getBlockNumber.calls).toHaveLength(1);
       expect(provider.getLogs.calls).toHaveLength(1);

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -1268,7 +1268,7 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     expect(a.hubRotationListenerStarted).toBe(false);
   });
 
-  it('startHubRotationListener ignores replayed startup logs and processes post-start timer rotations', async () => {
+  it('startHubRotationListener defers seed logs until the first post-start buffered poll', async () => {
     vi.useFakeTimers({ now: 0 });
     const a: any = new EVMChainAdapter(minimalConfig());
     const iface = new ethers.Interface([
@@ -1351,7 +1351,7 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
         toBlock: 1_001,
       });
       expect(a.contracts.contextGraphs).toEqual({ fresh: true });
-      expect(a.contracts.randomSampling).toEqual({ fresh: 'rs' });
+      expect(a.contracts.randomSampling).toBeUndefined();
       expect(a.cachedKav10Address).toBeUndefined();
       expect(a.initialized).toBe(false);
     } finally {

--- a/packages/chain/test/getmaxkanumberforauthor.unit.test.ts
+++ b/packages/chain/test/getmaxkanumberforauthor.unit.test.ts
@@ -42,6 +42,7 @@ function minimalConfig(overrides: Partial<EVMAdapterConfig> = {}): EVMAdapterCon
     adminPrivateKey: ADMIN_PK,
     hubAddress: '0x0000000000000000000000000000000000000001',
     chainId: 'evm:31337',
+    staticNetwork: false,
     ...overrides,
   };
 }

--- a/packages/chain/test/getmaxkanumberforauthor.unit.test.ts
+++ b/packages/chain/test/getmaxkanumberforauthor.unit.test.ts
@@ -218,7 +218,7 @@ describe('EVMChainAdapter.getMaxKaNumberForAuthor — view + bounded fallback (#
   });
 
   it('re-resolves the DKGKnowledgeAssets handle after a Hub rotation rather than querying the stale pre-rotation contract (#1082 review)', async () => {
-    // Long-lived adapter after the 10.0.4 redeploy: the rotation listener has
+    // Long-lived adapter after the 10.0.4 redeploy: the rotation poller has
     // set `initialized = false` but the cached binding still points at the OLD
     // contract. The getter must `await this.init()` to re-resolve before
     // reading, or it answers from the pre-rotation DKGKnowledgeAssets.

--- a/packages/chain/test/hub-resolution-cache.unit.test.ts
+++ b/packages/chain/test/hub-resolution-cache.unit.test.ts
@@ -3,7 +3,7 @@
  * matter for the live-rotation bug:
  *   - first call resolves and caches,
  *   - TTL expiry forces a re-resolve,
- *   - explicit `invalidate()` (used by the Hub event listener and the
+ *   - explicit `invalidate()` (used by the Hub rotation poller and the
  *     `UnauthorizedAccess(Only Contracts in Hub)` self-invalidation
  *     in the EVM adapter) forces a re-resolve.
  *
@@ -139,7 +139,7 @@ describe('HubResolutionCache', () => {
   it('invalidate() during an in-flight resolve discards the result so it cannot write back the stale value', async () => {
     // Simulates the race the Codex review flagged:
     //   1. tick T0 calls get() — resolver starts, awaiting RPC
-    //   2. Hub rotates RandomSampling; listener calls invalidate()
+    //   2. Hub rotates RandomSampling; poller calls invalidate()
     //   3. tick T0's resolver finally returns the PRE-rotation address
     //   4. without the generation guard, that pre-rotation value
     //      would land in `cached` and the very next get() would
@@ -160,7 +160,7 @@ describe('HubResolutionCache', () => {
     expect(calls).toBe(1);
     expect(cache.peek()).toBeNull();
 
-    // Hub-event-listener equivalent fires while the first resolve is
+    // Hub-rotation-poller equivalent fires while the first resolve is
     // still suspended.
     cache.invalidate();
     expect(cache.peek()).toBeNull();

--- a/packages/chain/test/hub-rotation-poller.unit.test.ts
+++ b/packages/chain/test/hub-rotation-poller.unit.test.ts
@@ -79,7 +79,7 @@ describe('HubRotationPoller', () => {
     });
 
     try {
-      await expect(poller.start(hubContract(), HUB_ADDRESS)).resolves.toBeUndefined();
+      poller.start(hubContract(), HUB_ADDRESS);
       expect(poller.isStarted).toBe(true);
       expect(provider.getBlockNumber).toHaveBeenCalledTimes(1);
       expect(provider.getLogs).not.toHaveBeenCalled();
@@ -628,8 +628,8 @@ describe('HubRotationPoller', () => {
       onContractName: vi.fn(),
     });
 
-    await expect(poller.start(hubContract(iface), HUB_ADDRESS))
-      .rejects.toThrow('Hub ABI is missing required rotation event AssetStorageChanged');
+    expect(() => poller.start(hubContract(iface), HUB_ADDRESS))
+      .toThrow('Hub ABI is missing required rotation event AssetStorageChanged');
 
     expect(provider.getBlockNumber).not.toHaveBeenCalled();
     expect(provider.getLogs).not.toHaveBeenCalled();

--- a/packages/chain/test/hub-rotation-poller.unit.test.ts
+++ b/packages/chain/test/hub-rotation-poller.unit.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
 import { Contract, ethers } from 'ethers';
 import { HubRotationPoller } from '../src/hub-rotation-poller.js';
-import { RPC_LOG_SCAN_TIMEOUT_MS } from '../src/evm-adapter-constants.js';
+import { RPC_LOG_SCAN_TIMEOUT_MS, RPC_READ_STALL_TIMEOUT_MS } from '../src/evm-adapter-constants.js';
+import { RpcFailoverClient } from '../src/rpc-failover-client.js';
 
 const HUB_ADDRESS = '0x0000000000000000000000000000000000000001';
 
@@ -48,6 +49,18 @@ function logsInRange(logs: ethers.Log[], filter: { fromBlock: number; toBlock: n
 
 async function flushAsyncWork(turns = 8): Promise<void> {
   for (let i = 0; i < turns; i++) await Promise.resolve();
+}
+
+function failoverReadProvider(providers: unknown[]) {
+  const client = new RpcFailoverClient(
+    () => providers.map((provider, index) => ({
+      provider: provider as any,
+      rpcUrl: `https://rpc-${index}.example`,
+    })),
+    async () => { throw new Error('Hub rotation tests must not sign transactions'); },
+    () => 'evm:31337',
+  );
+  return client.read.bind(client);
 }
 
 describe('HubRotationPoller', () => {
@@ -194,7 +207,7 @@ describe('HubRotationPoller', () => {
     };
     const onContractName = vi.fn();
     const poller = new HubRotationPoller({
-      readProvider: async (_label, fn) => fn(provider as any),
+      readProvider: failoverReadProvider([provider]),
       intervalMs: 1_000,
       reorgBufferBlocks: 50,
       onContractName,
@@ -222,6 +235,95 @@ describe('HubRotationPoller', () => {
         fromBlock: 951,
         toBlock: 1_001,
       });
+      expect(onContractName).toHaveBeenCalledWith('ContextGraphs');
+    } finally {
+      poller.stop();
+      vi.useRealTimers();
+    }
+  });
+
+  it('times out a stalled scheduled head read and retries without scanning logs', async () => {
+    vi.useFakeTimers({ now: 0 });
+    const iface = hubInterface();
+    const rotation = rotationLog(iface, 'ContractChanged', 'ContextGraphs', 1_001, '82');
+    let headCalls = 0;
+    const provider = {
+      getBlockNumber: vi.fn(async () => {
+        headCalls++;
+        if (headCalls === 1) return new Promise<number>(() => { /* hung RPC */ });
+        return 1_001;
+      }),
+      getLogs: vi.fn(async (filter: any) => logsInRange([rotation], filter)),
+    };
+    const onContractName = vi.fn();
+    const poller = new HubRotationPoller({
+      readProvider: failoverReadProvider([provider]),
+      intervalMs: 1_000,
+      reorgBufferBlocks: 50,
+      onContractName,
+    });
+
+    try {
+      await poller.start(hubContract(iface), HUB_ADDRESS);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(provider.getBlockNumber).toHaveBeenCalledTimes(1);
+      expect(provider.getLogs).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(RPC_READ_STALL_TIMEOUT_MS - 1);
+      expect(provider.getBlockNumber).toHaveBeenCalledTimes(1);
+      expect(provider.getLogs).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      await flushAsyncWork();
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      await flushAsyncWork();
+
+      expect(provider.getBlockNumber).toHaveBeenCalledTimes(2);
+      expect(provider.getLogs).toHaveBeenCalledTimes(1);
+      expect(provider.getLogs.mock.calls[0][0]).toMatchObject({
+        fromBlock: 951,
+        toBlock: 1_001,
+      });
+      expect(onContractName).toHaveBeenCalledWith('ContextGraphs');
+    } finally {
+      poller.stop();
+      vi.useRealTimers();
+    }
+  });
+
+  it('lets read-provider failover reach a healthy backup after a stalled primary log scan', async () => {
+    vi.useFakeTimers({ now: 0 });
+    const iface = hubInterface();
+    const rotation = rotationLog(iface, 'ContractChanged', 'ContextGraphs', 1_001, '84');
+    const primary = {
+      getBlockNumber: vi.fn(async () => 1_001),
+      getLogs: vi.fn(async () => new Promise<ethers.Log[]>(() => { /* hung primary */ })),
+    };
+    const backup = {
+      getBlockNumber: vi.fn(async () => 1_001),
+      getLogs: vi.fn(async (filter: any) => logsInRange([rotation], filter)),
+    };
+    const onContractName = vi.fn();
+    const poller = new HubRotationPoller({
+      readProvider: failoverReadProvider([primary, backup]),
+      intervalMs: 1_000,
+      reorgBufferBlocks: 50,
+      onContractName,
+    });
+
+    try {
+      await poller.start(hubContract(iface), HUB_ADDRESS);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(primary.getLogs).toHaveBeenCalledTimes(1);
+      expect(backup.getLogs).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(RPC_LOG_SCAN_TIMEOUT_MS + 1);
+      await flushAsyncWork();
+
+      expect(backup.getLogs).toHaveBeenCalledTimes(1);
       expect(onContractName).toHaveBeenCalledWith('ContextGraphs');
     } finally {
       poller.stop();
@@ -307,8 +409,10 @@ describe('HubRotationPoller', () => {
         iface.getEvent('AssetStorageChanged')!.topicHash,
         iface.getEvent('NewAssetStorage')!.topicHash,
       ]);
+      expect(readCalls.find((call) => call.label === 'Hub rotation poll getBlockNumber')?.opts)
+        .toEqual({ capSingleProvider: true });
       expect(readCalls.find((call) => call.label === 'Hub rotation poll getLogs')?.opts)
-        .toEqual({ policy: 'wideLogScan' });
+        .toEqual({ policy: 'wideLogScan', capSingleProvider: true });
       expect(onContractName.mock.calls.map((call) => call[0])).toEqual([
         'RandomSampling',
         'ContextGraphs',

--- a/packages/chain/test/hub-rotation-poller.unit.test.ts
+++ b/packages/chain/test/hub-rotation-poller.unit.test.ts
@@ -410,9 +410,9 @@ describe('HubRotationPoller', () => {
         iface.getEvent('NewAssetStorage')!.topicHash,
       ]);
       expect(readCalls.find((call) => call.label === 'Hub rotation poll getBlockNumber')?.opts)
-        .toEqual({ capSingleProvider: true });
+        .toEqual({ policy: 'watchdogPointRead' });
       expect(readCalls.find((call) => call.label === 'Hub rotation poll getLogs')?.opts)
-        .toEqual({ policy: 'wideLogScan', capSingleProvider: true });
+        .toEqual({ policy: 'watchdogWideLogScan' });
       expect(onContractName.mock.calls.map((call) => call[0])).toEqual([
         'RandomSampling',
         'ContextGraphs',

--- a/packages/chain/test/hub-rotation-poller.unit.test.ts
+++ b/packages/chain/test/hub-rotation-poller.unit.test.ts
@@ -64,7 +64,7 @@ function failoverReadProvider(providers: unknown[]) {
 }
 
 describe('HubRotationPoller', () => {
-  it('does not touch RPC during startup and stop cancels the scheduled poll', async () => {
+  it('records startup head without log reads and stop cancels the scheduled poll', async () => {
     vi.useFakeTimers({ now: 0 });
     const provider = {
       getBlockNumber: vi.fn(async () => 1_000),
@@ -81,13 +81,13 @@ describe('HubRotationPoller', () => {
     try {
       await expect(poller.start(hubContract(), HUB_ADDRESS)).resolves.toBeUndefined();
       expect(poller.isStarted).toBe(true);
-      expect(provider.getBlockNumber).not.toHaveBeenCalled();
+      expect(provider.getBlockNumber).toHaveBeenCalledTimes(1);
       expect(provider.getLogs).not.toHaveBeenCalled();
 
       poller.stop();
       await vi.advanceTimersByTimeAsync(30_000);
 
-      expect(provider.getBlockNumber).not.toHaveBeenCalled();
+      expect(provider.getBlockNumber).toHaveBeenCalledTimes(1);
       expect(provider.getLogs).not.toHaveBeenCalled();
       expect(onContractName).not.toHaveBeenCalled();
       expect(poller.isStarted).toBe(false);
@@ -129,7 +129,7 @@ describe('HubRotationPoller', () => {
       releasePoll();
       await pendingPoll;
 
-      expect(provider.getBlockNumber).toHaveBeenCalledTimes(1);
+      expect(provider.getBlockNumber.mock.calls.length).toBeGreaterThanOrEqual(2);
       expect(provider.getLogs).toHaveBeenCalledTimes(1);
       expect(onContractName).not.toHaveBeenCalled();
       expect(poller.isStarted).toBe(false);
@@ -280,8 +280,8 @@ describe('HubRotationPoller', () => {
       await vi.advanceTimersByTimeAsync(1_000);
       await flushAsyncWork();
 
-      expect(provider.getBlockNumber).toHaveBeenCalledTimes(2);
-      expect(provider.getLogs).toHaveBeenCalledTimes(1);
+      expect(provider.getBlockNumber.mock.calls.length).toBeGreaterThanOrEqual(2);
+      expect(provider.getLogs.mock.calls.length).toBeGreaterThanOrEqual(1);
       expect(provider.getLogs.mock.calls[0][0]).toMatchObject({
         fromBlock: 951,
         toBlock: 1_001,
@@ -350,11 +350,11 @@ describe('HubRotationPoller', () => {
 
       await Promise.all([firstStart, secondStart]);
 
-      expect(provider.getBlockNumber).not.toHaveBeenCalled();
+      expect(provider.getBlockNumber).toHaveBeenCalledTimes(1);
       expect(provider.getLogs).not.toHaveBeenCalled();
 
       await vi.advanceTimersByTimeAsync(30_000);
-      expect(provider.getBlockNumber).toHaveBeenCalledTimes(1);
+      expect(provider.getBlockNumber.mock.calls.length).toBeGreaterThanOrEqual(2);
       expect(provider.getLogs).toHaveBeenCalledTimes(1);
     } finally {
       poller.stop();
@@ -391,12 +391,13 @@ describe('HubRotationPoller', () => {
       await flushAsyncWork();
 
       expect(onContractName).not.toHaveBeenCalled();
-      expect(provider.getBlockNumber).not.toHaveBeenCalled();
+      expect(provider.getBlockNumber).toHaveBeenCalledTimes(1);
       expect(provider.getLogs).not.toHaveBeenCalled();
 
       head = 1_001;
       await vi.advanceTimersByTimeAsync(30_000);
 
+      expect(provider.getBlockNumber.mock.calls.length).toBeGreaterThanOrEqual(2);
       expect(provider.getLogs).toHaveBeenCalledTimes(1);
       expect(provider.getLogs.mock.calls[0][0]).toMatchObject({
         address: HUB_ADDRESS,
@@ -417,6 +418,44 @@ describe('HubRotationPoller', () => {
         'RandomSampling',
         'ContextGraphs',
       ]);
+    } finally {
+      poller.stop();
+      vi.useRealTimers();
+    }
+  });
+
+  it('keeps post-start rotations visible when the first interval fires after the reorg buffer', async () => {
+    vi.useFakeTimers({ now: 0 });
+    const iface = hubInterface();
+    let head = 1_000;
+    const rotation = rotationLog(iface, 'ContractChanged', 'KnowledgeAssetsLifecycle', 1_001, '18');
+    const provider = {
+      getBlockNumber: vi.fn(async () => head),
+      getLogs: vi.fn(async (filter: any) => logsInRange([rotation], filter)),
+    };
+    const onContractName = vi.fn();
+    const poller = new HubRotationPoller({
+      readProvider: async (_label, fn) => fn(provider as any),
+      intervalMs: 30_000,
+      reorgBufferBlocks: 50,
+      onContractName,
+    });
+
+    try {
+      await poller.start(hubContract(iface), HUB_ADDRESS);
+      await flushAsyncWork();
+      expect(provider.getBlockNumber).toHaveBeenCalledTimes(1);
+      expect(provider.getLogs).not.toHaveBeenCalled();
+
+      head = 1_052;
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      expect(provider.getLogs).toHaveBeenCalledTimes(1);
+      expect(provider.getLogs.mock.calls[0][0]).toMatchObject({
+        fromBlock: 951,
+        toBlock: 1_052,
+      });
+      expect(onContractName).toHaveBeenCalledWith('KnowledgeAssetsLifecycle');
     } finally {
       poller.stop();
       vi.useRealTimers();

--- a/packages/chain/test/hub-rotation-poller.unit.test.ts
+++ b/packages/chain/test/hub-rotation-poller.unit.test.ts
@@ -1,0 +1,420 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Contract, ethers } from 'ethers';
+import { HubRotationPoller } from '../src/hub-rotation-poller.js';
+
+const HUB_ADDRESS = '0x0000000000000000000000000000000000000001';
+
+const ROTATION_EVENTS = [
+  'event NewContract(string contractName, address newContractAddress)',
+  'event ContractChanged(string contractName, address newContractAddress)',
+  'event NewAssetStorage(string contractName, address newContractAddress)',
+  'event AssetStorageChanged(string contractName, address newContractAddress)',
+];
+
+function hubInterface(events = ROTATION_EVENTS): ethers.Interface {
+  return new ethers.Interface(events);
+}
+
+function hubContract(iface = hubInterface()): Contract {
+  return { interface: iface } as unknown as Contract;
+}
+
+function rotationLog(
+  iface: ethers.Interface,
+  eventName: string,
+  contractName: string,
+  blockNumber: number,
+  marker: string,
+  index = 0,
+): ethers.Log {
+  const encoded = iface.encodeEventLog(iface.getEvent(eventName)!, [
+    contractName,
+    '0x00000000000000000000000000000000000000c1',
+  ]);
+  return {
+    blockNumber,
+    blockHash: `0x${marker.repeat(32)}`,
+    transactionHash: `0x${(Number.parseInt(marker, 16) + 1).toString(16).padStart(2, '0').repeat(32)}`,
+    index,
+    topics: encoded.topics,
+    data: encoded.data,
+  } as ethers.Log;
+}
+
+function logsInRange(logs: ethers.Log[], filter: { fromBlock: number; toBlock: number }): ethers.Log[] {
+  return logs.filter((log) => log.blockNumber >= filter.fromBlock && log.blockNumber <= filter.toBlock);
+}
+
+async function flushAsyncWork(turns = 8): Promise<void> {
+  for (let i = 0; i < turns; i++) await Promise.resolve();
+}
+
+describe('HubRotationPoller', () => {
+  it('does not block startup on bootstrap log IO and stop cancels the late bootstrap', async () => {
+    vi.useFakeTimers({ now: 0 });
+    let releaseSeed!: () => void;
+    let seedEntered!: () => void;
+    const seedGate = new Promise<void>((resolve) => { releaseSeed = resolve; });
+    const seedEnteredPromise = new Promise<void>((resolve) => { seedEntered = resolve; });
+    const provider = {
+      getBlockNumber: vi.fn(async () => 1_000),
+      getLogs: vi.fn(async () => {
+        seedEntered();
+        await seedGate;
+        return [];
+      }),
+    };
+    const poller = new HubRotationPoller({
+      readProvider: async (_label, fn) => fn(provider as any),
+      intervalMs: 30_000,
+      reorgBufferBlocks: 50,
+      onContractName: vi.fn(),
+    });
+
+    try {
+      await expect(poller.start(hubContract(), HUB_ADDRESS)).resolves.toBeUndefined();
+      expect(poller.isStarted).toBe(true);
+
+      await seedEnteredPromise;
+      poller.stop();
+      releaseSeed();
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      expect(provider.getBlockNumber).toHaveBeenCalledTimes(1);
+      expect(provider.getLogs).toHaveBeenCalledTimes(1);
+      expect(poller.isStarted).toBe(false);
+    } finally {
+      poller.stop();
+      vi.useRealTimers();
+    }
+  });
+
+  it('recovers after a failed periodic poll', async () => {
+    vi.useFakeTimers({ now: 0 });
+    const hub = hubContract();
+    const rotation = hub.interface.encodeEventLog(hub.interface.getEvent('ContractChanged')!, [
+      'ContextGraphs',
+      '0x00000000000000000000000000000000000000c1',
+    ]);
+    let head = 1_000;
+    let getLogsCalls = 0;
+    const provider = {
+      getBlockNumber: vi.fn(async () => head),
+      getLogs: vi.fn(async () => {
+        getLogsCalls++;
+        if (getLogsCalls === 2) throw new Error('temporary getLogs failure');
+        if (getLogsCalls === 3) {
+          return [{
+            blockNumber: 1_001,
+            blockHash: '0x' + '51'.repeat(32),
+            transactionHash: '0x' + '52'.repeat(32),
+            index: 0,
+            topics: rotation.topics,
+            data: rotation.data,
+          }];
+        }
+        return [];
+      }),
+    };
+    const onContractName = vi.fn();
+    const poller = new HubRotationPoller({
+      readProvider: async (_label, fn) => fn(provider as any),
+      intervalMs: 30_000,
+      reorgBufferBlocks: 50,
+      onContractName,
+    });
+
+    try {
+      await poller.start(hub, HUB_ADDRESS);
+      await Promise.resolve();
+
+      head = 1_001;
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(onContractName).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(onContractName).toHaveBeenCalledWith('ContextGraphs');
+      expect(provider.getLogs).toHaveBeenCalledTimes(3);
+    } finally {
+      poller.stop();
+      vi.useRealTimers();
+    }
+  });
+
+  it('coalesces concurrent starts while bootstrap is still in flight', async () => {
+    vi.useFakeTimers({ now: 0 });
+    let releaseSeed!: () => void;
+    let seedEntered!: () => void;
+    const seedGate = new Promise<void>((resolve) => { releaseSeed = resolve; });
+    const seedEnteredPromise = new Promise<void>((resolve) => { seedEntered = resolve; });
+    let getLogsCalls = 0;
+    const provider = {
+      getBlockNumber: vi.fn(async () => 1_000),
+      getLogs: vi.fn(async () => {
+        getLogsCalls++;
+        if (getLogsCalls === 1) {
+          seedEntered();
+          await seedGate;
+        }
+        return [];
+      }),
+    };
+    const poller = new HubRotationPoller({
+      readProvider: async (_label, fn) => fn(provider as any),
+      intervalMs: 30_000,
+      reorgBufferBlocks: 50,
+      onContractName: vi.fn(),
+    });
+
+    try {
+      const firstStart = poller.start(hubContract(), HUB_ADDRESS);
+      await seedEnteredPromise;
+      const secondStart = poller.start(hubContract(), HUB_ADDRESS);
+
+      releaseSeed();
+      await Promise.all([firstStart, secondStart]);
+      await flushAsyncWork();
+
+      expect(provider.getBlockNumber).toHaveBeenCalledTimes(1);
+      expect(provider.getLogs).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(provider.getBlockNumber).toHaveBeenCalledTimes(2);
+      expect(provider.getLogs).toHaveBeenCalledTimes(2);
+    } finally {
+      poller.stop();
+      vi.useRealTimers();
+    }
+  });
+
+  it('probes startup logs without dispatching and dispatches the first buffered poll', async () => {
+    vi.useFakeTimers({ now: 0 });
+    const iface = hubInterface();
+    let head = 1_000;
+    const logs = [
+      rotationLog(iface, 'NewContract', 'RandomSampling', 1_000, '10'),
+      rotationLog(iface, 'ContractChanged', 'ContextGraphs', 1_001, '12'),
+    ];
+    const provider = {
+      getBlockNumber: vi.fn(async () => head),
+      getLogs: vi.fn(async (filter: any) => logsInRange(logs, filter)),
+    };
+    const onContractName = vi.fn();
+    const poller = new HubRotationPoller({
+      readProvider: async (_label, fn) => fn(provider as any),
+      intervalMs: 30_000,
+      reorgBufferBlocks: 50,
+      onContractName,
+    });
+
+    try {
+      await poller.start(hubContract(iface), HUB_ADDRESS);
+      await flushAsyncWork();
+
+      expect(onContractName).not.toHaveBeenCalled();
+      expect(provider.getLogs.mock.calls[0][0]).toMatchObject({
+        address: HUB_ADDRESS,
+        fromBlock: 950,
+        toBlock: 1_000,
+      });
+      expect(provider.getLogs.mock.calls[0][0].topics[0]).toEqual([
+        iface.getEvent('ContractChanged')!.topicHash,
+        iface.getEvent('NewContract')!.topicHash,
+        iface.getEvent('AssetStorageChanged')!.topicHash,
+        iface.getEvent('NewAssetStorage')!.topicHash,
+      ]);
+
+      head = 1_001;
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      expect(provider.getLogs).toHaveBeenCalledTimes(2);
+      expect(provider.getLogs.mock.calls[1][0]).toMatchObject({
+        fromBlock: 951,
+        toBlock: 1_001,
+      });
+      expect(onContractName.mock.calls.map((call) => call[0])).toEqual([
+        'RandomSampling',
+        'ContextGraphs',
+      ]);
+    } finally {
+      poller.stop();
+      vi.useRealTimers();
+    }
+  });
+
+  it('applies replacement logs inside the reorg buffer', async () => {
+    const iface = hubInterface();
+    let head = 1_000;
+    const logs = [
+      rotationLog(iface, 'ContractChanged', 'UntrackedAtStartup', 1_000, '20'),
+    ];
+    const provider = {
+      getBlockNumber: vi.fn(async () => head),
+      getLogs: vi.fn(async (filter: any) => logsInRange(logs, filter)),
+    };
+    const onContractName = vi.fn();
+    const poller = new HubRotationPoller({
+      readProvider: async (_label, fn) => fn(provider as any),
+      intervalMs: 30_000,
+      reorgBufferBlocks: 50,
+      onContractName,
+    });
+
+    try {
+      await poller.start(hubContract(iface), HUB_ADDRESS);
+      await flushAsyncWork();
+      expect(onContractName).not.toHaveBeenCalled();
+
+      logs.splice(0, logs.length, rotationLog(iface, 'ContractChanged', 'ContextGraphs', 1_000, '22'));
+      head = 1_001;
+      await poller.pollOnce();
+
+      expect(provider.getLogs).toHaveBeenCalledTimes(2);
+      expect(provider.getLogs.mock.calls[1][0]).toMatchObject({
+        fromBlock: 951,
+        toBlock: 1_001,
+      });
+      expect(onContractName).toHaveBeenCalledTimes(1);
+      expect(onContractName).toHaveBeenCalledWith('ContextGraphs');
+    } finally {
+      poller.stop();
+    }
+  });
+
+  it('processes a new rotation log at the previous cursor block', async () => {
+    const iface = hubInterface();
+    let head = 1_000;
+    let exposeReorgLog = false;
+    const log = rotationLog(iface, 'ContractChanged', 'ContextGraphs', 1_000, '40');
+    const provider = {
+      getBlockNumber: vi.fn(async () => head),
+      getLogs: vi.fn(async (filter: any) => (
+        exposeReorgLog ? logsInRange([log], filter) : []
+      )),
+    };
+    const onContractName = vi.fn();
+    const poller = new HubRotationPoller({
+      readProvider: async (_label, fn) => fn(provider as any),
+      intervalMs: 30_000,
+      reorgBufferBlocks: 50,
+      onContractName,
+    });
+
+    try {
+      await poller.start(hubContract(iface), HUB_ADDRESS);
+      await flushAsyncWork();
+
+      exposeReorgLog = true;
+      head = 1_001;
+      await poller.pollOnce();
+
+      expect(provider.getLogs).toHaveBeenCalledTimes(2);
+      expect(provider.getLogs.mock.calls[1][0]).toMatchObject({
+        fromBlock: 951,
+        toBlock: 1_001,
+      });
+      expect(onContractName).toHaveBeenCalledWith('ContextGraphs');
+    } finally {
+      poller.stop();
+    }
+  });
+
+  it('deduplicates logs across overlapping buffered polls', async () => {
+    const iface = hubInterface();
+    let head = 1_000;
+    let logs: ethers.Log[] = [];
+    const repeatedLog = rotationLog(iface, 'ContractChanged', 'ContextGraphs', 1_001, '60');
+    const provider = {
+      getBlockNumber: vi.fn(async () => head),
+      getLogs: vi.fn(async (filter: any) => logsInRange(logs, filter)),
+    };
+    const onContractName = vi.fn();
+    const poller = new HubRotationPoller({
+      readProvider: async (_label, fn) => fn(provider as any),
+      intervalMs: 30_000,
+      reorgBufferBlocks: 50,
+      onContractName,
+    });
+
+    try {
+      await poller.start(hubContract(iface), HUB_ADDRESS);
+      await flushAsyncWork();
+
+      logs = [repeatedLog];
+      head = 1_001;
+      await poller.pollOnce();
+
+      head = 1_002;
+      await poller.pollOnce();
+
+      expect(onContractName).toHaveBeenCalledTimes(1);
+      expect(onContractName).toHaveBeenCalledWith('ContextGraphs');
+    } finally {
+      poller.stop();
+    }
+  });
+
+  it('does not move the high-water mark backwards when the next head is lower', async () => {
+    const iface = hubInterface();
+    let head = 1_000;
+    const provider = {
+      getBlockNumber: vi.fn(async () => head),
+      getLogs: vi.fn(async (_filter: any) => []),
+    };
+    const poller = new HubRotationPoller({
+      readProvider: async (_label, fn) => fn(provider as any),
+      intervalMs: 30_000,
+      reorgBufferBlocks: 50,
+      onContractName: vi.fn(),
+    });
+
+    try {
+      await poller.start(hubContract(iface), HUB_ADDRESS);
+      await flushAsyncWork();
+
+      head = 900;
+      await poller.pollOnce();
+
+      head = 1_001;
+      await poller.pollOnce();
+
+      expect(provider.getLogs).toHaveBeenCalledTimes(3);
+      expect(provider.getLogs.mock.calls[1][0]).toMatchObject({
+        fromBlock: 850,
+        toBlock: 900,
+      });
+      expect(provider.getLogs.mock.calls[2][0]).toMatchObject({
+        fromBlock: 951,
+        toBlock: 1_001,
+      });
+    } finally {
+      poller.stop();
+    }
+  });
+
+  it('refuses a partial Hub rotation event ABI before scheduling reads', async () => {
+    const iface = hubInterface([
+      'event NewContract(string contractName, address newContractAddress)',
+      'event ContractChanged(string contractName, address newContractAddress)',
+      'event NewAssetStorage(string contractName, address newContractAddress)',
+    ]);
+    const provider = {
+      getBlockNumber: vi.fn(async () => 1_000),
+      getLogs: vi.fn(async () => []),
+    };
+    const poller = new HubRotationPoller({
+      readProvider: async (_label, fn) => fn(provider as any),
+      intervalMs: 30_000,
+      reorgBufferBlocks: 50,
+      onContractName: vi.fn(),
+    });
+
+    await expect(poller.start(hubContract(iface), HUB_ADDRESS))
+      .rejects.toThrow('Hub ABI is missing required rotation event AssetStorageChanged');
+
+    expect(provider.getBlockNumber).not.toHaveBeenCalled();
+    expect(provider.getLogs).not.toHaveBeenCalled();
+    expect(poller.isStarted).toBe(false);
+  });
+});

--- a/packages/chain/test/hub-rotation-poller.unit.test.ts
+++ b/packages/chain/test/hub-rotation-poller.unit.test.ts
@@ -50,43 +50,77 @@ async function flushAsyncWork(turns = 8): Promise<void> {
 }
 
 describe('HubRotationPoller', () => {
-  it('does not block startup on bootstrap log IO and stop cancels the late bootstrap', async () => {
+  it('does not touch RPC during startup and stop cancels the scheduled poll', async () => {
     vi.useFakeTimers({ now: 0 });
-    let releaseSeed!: () => void;
-    let seedEntered!: () => void;
-    const seedGate = new Promise<void>((resolve) => { releaseSeed = resolve; });
-    const seedEnteredPromise = new Promise<void>((resolve) => { seedEntered = resolve; });
     const provider = {
       getBlockNumber: vi.fn(async () => 1_000),
-      getLogs: vi.fn(async () => {
-        seedEntered();
-        await seedGate;
-        return [];
-      }),
+      getLogs: vi.fn(async () => []),
     };
+    const onContractName = vi.fn();
     const poller = new HubRotationPoller({
       readProvider: async (_label, fn) => fn(provider as any),
       intervalMs: 30_000,
       reorgBufferBlocks: 50,
-      onContractName: vi.fn(),
+      onContractName,
     });
 
     try {
       await expect(poller.start(hubContract(), HUB_ADDRESS)).resolves.toBeUndefined();
       expect(poller.isStarted).toBe(true);
+      expect(provider.getBlockNumber).not.toHaveBeenCalled();
+      expect(provider.getLogs).not.toHaveBeenCalled();
 
-      await seedEnteredPromise;
       poller.stop();
-      releaseSeed();
-      await Promise.resolve();
       await vi.advanceTimersByTimeAsync(30_000);
 
-      expect(provider.getBlockNumber).toHaveBeenCalledTimes(1);
-      expect(provider.getLogs).toHaveBeenCalledTimes(1);
+      expect(provider.getBlockNumber).not.toHaveBeenCalled();
+      expect(provider.getLogs).not.toHaveBeenCalled();
+      expect(onContractName).not.toHaveBeenCalled();
       expect(poller.isStarted).toBe(false);
     } finally {
       poller.stop();
       vi.useRealTimers();
+    }
+  });
+
+  it('ignores a delayed in-flight poll result after stop', async () => {
+    const iface = hubInterface();
+    const delayedLog = rotationLog(iface, 'ContractChanged', 'ContextGraphs', 1_000, '70');
+    let releasePoll!: () => void;
+    let pollEntered!: () => void;
+    const pollGate = new Promise<void>((resolve) => { releasePoll = resolve; });
+    const pollEnteredPromise = new Promise<void>((resolve) => { pollEntered = resolve; });
+    const provider = {
+      getBlockNumber: vi.fn(async () => 1_000),
+      getLogs: vi.fn(async () => {
+        pollEntered();
+        await pollGate;
+        return [delayedLog];
+      }),
+    };
+    const onContractName = vi.fn();
+    const poller = new HubRotationPoller({
+      readProvider: async (_label, fn) => fn(provider as any),
+      intervalMs: 30_000,
+      reorgBufferBlocks: 50,
+      onContractName,
+    });
+
+    try {
+      await poller.start(hubContract(iface), HUB_ADDRESS);
+      const pendingPoll = poller.pollOnce();
+      await pollEnteredPromise;
+
+      poller.stop();
+      releasePoll();
+      await pendingPoll;
+
+      expect(provider.getBlockNumber).toHaveBeenCalledTimes(1);
+      expect(provider.getLogs).toHaveBeenCalledTimes(1);
+      expect(onContractName).not.toHaveBeenCalled();
+      expect(poller.isStarted).toBe(false);
+    } finally {
+      poller.stop();
     }
   });
 
@@ -103,8 +137,8 @@ describe('HubRotationPoller', () => {
       getBlockNumber: vi.fn(async () => head),
       getLogs: vi.fn(async () => {
         getLogsCalls++;
-        if (getLogsCalls === 2) throw new Error('temporary getLogs failure');
-        if (getLogsCalls === 3) {
+        if (getLogsCalls === 1) throw new Error('temporary getLogs failure');
+        if (getLogsCalls === 2) {
           return [{
             blockNumber: 1_001,
             blockHash: '0x' + '51'.repeat(32),
@@ -135,30 +169,18 @@ describe('HubRotationPoller', () => {
 
       await vi.advanceTimersByTimeAsync(30_000);
       expect(onContractName).toHaveBeenCalledWith('ContextGraphs');
-      expect(provider.getLogs).toHaveBeenCalledTimes(3);
+      expect(provider.getLogs).toHaveBeenCalledTimes(2);
     } finally {
       poller.stop();
       vi.useRealTimers();
     }
   });
 
-  it('coalesces concurrent starts while bootstrap is still in flight', async () => {
+  it('coalesces concurrent starts into a single scheduled poller', async () => {
     vi.useFakeTimers({ now: 0 });
-    let releaseSeed!: () => void;
-    let seedEntered!: () => void;
-    const seedGate = new Promise<void>((resolve) => { releaseSeed = resolve; });
-    const seedEnteredPromise = new Promise<void>((resolve) => { seedEntered = resolve; });
-    let getLogsCalls = 0;
     const provider = {
       getBlockNumber: vi.fn(async () => 1_000),
-      getLogs: vi.fn(async () => {
-        getLogsCalls++;
-        if (getLogsCalls === 1) {
-          seedEntered();
-          await seedGate;
-        }
-        return [];
-      }),
+      getLogs: vi.fn(async () => []),
     };
     const poller = new HubRotationPoller({
       readProvider: async (_label, fn) => fn(provider as any),
@@ -169,26 +191,23 @@ describe('HubRotationPoller', () => {
 
     try {
       const firstStart = poller.start(hubContract(), HUB_ADDRESS);
-      await seedEnteredPromise;
       const secondStart = poller.start(hubContract(), HUB_ADDRESS);
 
-      releaseSeed();
       await Promise.all([firstStart, secondStart]);
-      await flushAsyncWork();
 
-      expect(provider.getBlockNumber).toHaveBeenCalledTimes(1);
-      expect(provider.getLogs).toHaveBeenCalledTimes(1);
+      expect(provider.getBlockNumber).not.toHaveBeenCalled();
+      expect(provider.getLogs).not.toHaveBeenCalled();
 
       await vi.advanceTimersByTimeAsync(30_000);
-      expect(provider.getBlockNumber).toHaveBeenCalledTimes(2);
-      expect(provider.getLogs).toHaveBeenCalledTimes(2);
+      expect(provider.getBlockNumber).toHaveBeenCalledTimes(1);
+      expect(provider.getLogs).toHaveBeenCalledTimes(1);
     } finally {
       poller.stop();
       vi.useRealTimers();
     }
   });
 
-  it('probes startup logs without dispatching and dispatches the first buffered poll', async () => {
+  it('defers startup log reads to the first buffered poll', async () => {
     vi.useFakeTimers({ now: 0 });
     const iface = hubInterface();
     let head = 1_000;
@@ -213,10 +232,17 @@ describe('HubRotationPoller', () => {
       await flushAsyncWork();
 
       expect(onContractName).not.toHaveBeenCalled();
+      expect(provider.getBlockNumber).not.toHaveBeenCalled();
+      expect(provider.getLogs).not.toHaveBeenCalled();
+
+      head = 1_001;
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      expect(provider.getLogs).toHaveBeenCalledTimes(1);
       expect(provider.getLogs.mock.calls[0][0]).toMatchObject({
         address: HUB_ADDRESS,
-        fromBlock: 950,
-        toBlock: 1_000,
+        fromBlock: 951,
+        toBlock: 1_001,
       });
       expect(provider.getLogs.mock.calls[0][0].topics[0]).toEqual([
         iface.getEvent('ContractChanged')!.topicHash,
@@ -224,15 +250,6 @@ describe('HubRotationPoller', () => {
         iface.getEvent('AssetStorageChanged')!.topicHash,
         iface.getEvent('NewAssetStorage')!.topicHash,
       ]);
-
-      head = 1_001;
-      await vi.advanceTimersByTimeAsync(30_000);
-
-      expect(provider.getLogs).toHaveBeenCalledTimes(2);
-      expect(provider.getLogs.mock.calls[1][0]).toMatchObject({
-        fromBlock: 951,
-        toBlock: 1_001,
-      });
       expect(onContractName.mock.calls.map((call) => call[0])).toEqual([
         'RandomSampling',
         'ContextGraphs',
@@ -263,8 +280,8 @@ describe('HubRotationPoller', () => {
 
     try {
       await poller.start(hubContract(iface), HUB_ADDRESS);
-      await flushAsyncWork();
-      expect(onContractName).not.toHaveBeenCalled();
+      await poller.pollOnce();
+      expect(onContractName).toHaveBeenCalledWith('UntrackedAtStartup');
 
       logs.splice(0, logs.length, rotationLog(iface, 'ContractChanged', 'ContextGraphs', 1_000, '22'));
       head = 1_001;
@@ -275,7 +292,7 @@ describe('HubRotationPoller', () => {
         fromBlock: 951,
         toBlock: 1_001,
       });
-      expect(onContractName).toHaveBeenCalledTimes(1);
+      expect(onContractName).toHaveBeenCalledTimes(2);
       expect(onContractName).toHaveBeenCalledWith('ContextGraphs');
     } finally {
       poller.stop();
@@ -303,7 +320,7 @@ describe('HubRotationPoller', () => {
 
     try {
       await poller.start(hubContract(iface), HUB_ADDRESS);
-      await flushAsyncWork();
+      await poller.pollOnce();
 
       exposeReorgLog = true;
       head = 1_001;
@@ -339,7 +356,6 @@ describe('HubRotationPoller', () => {
 
     try {
       await poller.start(hubContract(iface), HUB_ADDRESS);
-      await flushAsyncWork();
 
       logs = [repeatedLog];
       head = 1_001;
@@ -371,7 +387,7 @@ describe('HubRotationPoller', () => {
 
     try {
       await poller.start(hubContract(iface), HUB_ADDRESS);
-      await flushAsyncWork();
+      await poller.pollOnce();
 
       head = 900;
       await poller.pollOnce();

--- a/packages/chain/test/hub-rotation-poller.unit.test.ts
+++ b/packages/chain/test/hub-rotation-poller.unit.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { Contract, ethers } from 'ethers';
 import { HubRotationPoller } from '../src/hub-rotation-poller.js';
+import { RPC_LOG_SCAN_TIMEOUT_MS } from '../src/evm-adapter-constants.js';
 
 const HUB_ADDRESS = '0x0000000000000000000000000000000000000001';
 
@@ -176,6 +177,58 @@ describe('HubRotationPoller', () => {
     }
   });
 
+  it('times out a stalled scheduled log scan and retries the same cursor range', async () => {
+    vi.useFakeTimers({ now: 0 });
+    const iface = hubInterface();
+    const hub = hubContract(iface);
+    const rotation = rotationLog(iface, 'ContractChanged', 'ContextGraphs', 1_001, '80');
+    let head = 1_000;
+    let getLogsCalls = 0;
+    const provider = {
+      getBlockNumber: vi.fn(async () => head),
+      getLogs: vi.fn(async (filter: any) => {
+        getLogsCalls++;
+        if (getLogsCalls === 1) return new Promise<ethers.Log[]>(() => { /* hung RPC */ });
+        return logsInRange([rotation], filter);
+      }),
+    };
+    const onContractName = vi.fn();
+    const poller = new HubRotationPoller({
+      readProvider: async (_label, fn) => fn(provider as any),
+      intervalMs: 1_000,
+      reorgBufferBlocks: 50,
+      onContractName,
+    });
+
+    try {
+      await poller.start(hub, HUB_ADDRESS);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(provider.getLogs).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(RPC_LOG_SCAN_TIMEOUT_MS - 1);
+      expect(provider.getLogs).toHaveBeenCalledTimes(1);
+      expect(onContractName).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      await flushAsyncWork();
+
+      head = 1_001;
+      await vi.advanceTimersByTimeAsync(1_000);
+      await flushAsyncWork();
+
+      expect(provider.getLogs).toHaveBeenCalledTimes(2);
+      expect(provider.getLogs.mock.calls[1][0]).toMatchObject({
+        fromBlock: 951,
+        toBlock: 1_001,
+      });
+      expect(onContractName).toHaveBeenCalledWith('ContextGraphs');
+    } finally {
+      poller.stop();
+      vi.useRealTimers();
+    }
+  });
+
   it('coalesces concurrent starts into a single scheduled poller', async () => {
     vi.useFakeTimers({ now: 0 });
     const provider = {
@@ -215,13 +268,17 @@ describe('HubRotationPoller', () => {
       rotationLog(iface, 'NewContract', 'RandomSampling', 1_000, '10'),
       rotationLog(iface, 'ContractChanged', 'ContextGraphs', 1_001, '12'),
     ];
+    const readCalls: Array<{ label: string; opts: unknown }> = [];
     const provider = {
       getBlockNumber: vi.fn(async () => head),
       getLogs: vi.fn(async (filter: any) => logsInRange(logs, filter)),
     };
     const onContractName = vi.fn();
     const poller = new HubRotationPoller({
-      readProvider: async (_label, fn) => fn(provider as any),
+      readProvider: async (label, fn, opts) => {
+        readCalls.push({ label, opts });
+        return fn(provider as any);
+      },
       intervalMs: 30_000,
       reorgBufferBlocks: 50,
       onContractName,
@@ -250,6 +307,8 @@ describe('HubRotationPoller', () => {
         iface.getEvent('AssetStorageChanged')!.topicHash,
         iface.getEvent('NewAssetStorage')!.topicHash,
       ]);
+      expect(readCalls.find((call) => call.label === 'Hub rotation poll getLogs')?.opts)
+        .toEqual({ policy: 'wideLogScan' });
       expect(onContractName.mock.calls.map((call) => call[0])).toEqual([
         'RandomSampling',
         'ContextGraphs',

--- a/packages/chain/test/keyed-ttl-single-flight-cache.unit.test.ts
+++ b/packages/chain/test/keyed-ttl-single-flight-cache.unit.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it, vi } from 'vitest';
+import { KeyedSingleFlight, ReadThroughTtlCache, TtlValueCache } from '../src/keyed-ttl-single-flight-cache.js';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => { resolve = res; });
+  return { promise, resolve };
+}
+
+describe('TtlValueCache', () => {
+  it('returns cached values until TTL expiry', () => {
+    vi.useFakeTimers({ now: 0 });
+    try {
+      const cache = new TtlValueCache<string, number>({ ttlMs: 1000 });
+
+      expect(cache.set('a', 1)).toBe(true);
+      expect(cache.get('a')).toBe(1);
+
+      vi.setSystemTime(1001);
+      expect(cache.get('a')).toBeUndefined();
+      expect(cache.has('a')).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('caches null as a real value without treating it as a miss', () => {
+    const cache = new TtlValueCache<string, null>({ ttlMs: 1000 });
+
+    expect(cache.set('missing', null)).toBe(true);
+    expect(cache.get('missing')).toBeNull();
+    expect(cache.has('missing')).toBe(true);
+  });
+
+  it('does not store values whose computed TTL is zero', () => {
+    const cache = new TtlValueCache<string, number>({
+      ttlMs: (value) => value > 0 ? 1000 : 0,
+    });
+
+    expect(cache.set('missing', 0)).toBe(false);
+    expect(cache.has('missing')).toBe(false);
+    expect((cache as unknown as { values: Map<string, number> }).values.size).toBe(0);
+
+    expect(cache.set('present', 5)).toBe(true);
+    expect(cache.get('present')).toBe(5);
+  });
+});
+
+describe('KeyedSingleFlight', () => {
+  it('coalesces concurrent loads for the same in-flight key', async () => {
+    let calls = 0;
+    const singleFlight = new KeyedSingleFlight<string>();
+
+    const results = await Promise.all([
+      singleFlight.run('a', 'a', async () => ++calls),
+      singleFlight.run('a', 'a', async () => ++calls),
+    ]);
+
+    expect(results).toEqual([1, 1]);
+    expect(calls).toBe(1);
+  });
+
+  it('invalidates all observed in-flight variants and blocks stale success hooks', async () => {
+    const soft = deferred<number>();
+    const strict = deferred<number>();
+    const freshValue = deferred<number>();
+    const values = new TtlValueCache<string, number>({ ttlMs: 1000 });
+    const singleFlight = new KeyedSingleFlight<string, string>();
+
+    const staleSoft = singleFlight.run('agent', 'agent:soft', async () => soft.promise, (value) => values.set('agent', value));
+    const staleStrict = singleFlight.run('agent', 'agent:strict', async () => strict.promise, (value) => values.set('agent', value));
+    singleFlight.invalidate('agent');
+    values.delete('agent');
+
+    soft.resolve(7);
+    strict.resolve(8);
+    await expect(staleSoft).resolves.toBe(7);
+    await expect(staleStrict).resolves.toBe(8);
+    expect(values.has('agent')).toBe(false);
+
+    const fresh = singleFlight.run('agent', 'agent:strict', async () => freshValue.promise, (value) => values.set('agent', value));
+    freshValue.resolve(9);
+    await expect(fresh).resolves.toBe(9);
+    expect(values.get('agent')).toBe(9);
+  });
+
+  it('does not let an older invalidated read remove a newer in-flight variant', async () => {
+    const stale = deferred<number>();
+    const newer = deferred<number>();
+    const fresh = deferred<number>();
+    const values = new TtlValueCache<string, number>({ ttlMs: 1000 });
+    const singleFlight = new KeyedSingleFlight<string>();
+
+    const staleLookup = singleFlight.run('account', 'account', async () => stale.promise, (value) => values.set('account', value));
+    singleFlight.invalidate('account');
+
+    const newerLookup = singleFlight.run('account', 'account', async () => newer.promise, (value) => values.set('account', value));
+    stale.resolve(1);
+    await expect(staleLookup).resolves.toBe(1);
+
+    singleFlight.invalidate('account');
+    const freshLookup = singleFlight.run('account', 'account', async () => fresh.promise, (value) => values.set('account', value));
+
+    newer.resolve(2);
+    fresh.resolve(3);
+    await expect(newerLookup).resolves.toBe(2);
+    await expect(freshLookup).resolves.toBe(3);
+    expect(values.get('account')).toBe(3);
+  });
+
+  it('scopes identical in-flight keys by value key', async () => {
+    let calls = 0;
+    const singleFlight = new KeyedSingleFlight<string, string>();
+
+    const results = await Promise.all([
+      singleFlight.run('left', 'shared', async () => ++calls),
+      singleFlight.run('right', 'shared', async () => ++calls),
+    ]);
+
+    expect(results).toEqual([1, 2]);
+    expect(calls).toBe(2);
+  });
+});
+
+describe('ReadThroughTtlCache', () => {
+  it('coalesces getOrLoad calls and caches retained values', async () => {
+    vi.useFakeTimers({ now: 0 });
+    try {
+      let calls = 0;
+      const cache = new ReadThroughTtlCache<string, number>({ ttlMs: 1000 });
+      const read = () => cache.getOrLoad('wallet', 'wallet', async () => ++calls);
+
+      await expect(Promise.all([read(), read()])).resolves.toEqual([1, 1]);
+      expect(calls).toBe(1);
+      await expect(read()).resolves.toBe(1);
+
+      vi.setSystemTime(1001);
+      await expect(read()).resolves.toBe(2);
+      expect(calls).toBe(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('caches null as a retained read-through value', async () => {
+    let calls = 0;
+    const cache = new ReadThroughTtlCache<string, number | null>({ ttlMs: 1000 });
+
+    await expect(cache.getOrLoad('missing', 'missing', async () => {
+      calls++;
+      return null;
+    })).resolves.toBeNull();
+    await expect(cache.getOrLoad('missing', 'missing', async () => {
+      calls++;
+      return 5;
+    })).resolves.toBeNull();
+    expect(calls).toBe(1);
+  });
+
+  it('does not retain zero-TTL values', async () => {
+    let calls = 0;
+    const cache = new ReadThroughTtlCache<string, number>({
+      ttlMs: (value) => value > 0 ? 1000 : 0,
+    });
+
+    await expect(cache.getOrLoad('account', 'account', async () => calls++)).resolves.toBe(0);
+    await expect(cache.getOrLoad('account', 'account', async () => calls++)).resolves.toBe(1);
+    expect(calls).toBe(2);
+  });
+
+  it('seeds, invalidates, and broadly invalidates cached values', async () => {
+    let calls = 0;
+    const cache = new ReadThroughTtlCache<string, number>({ ttlMs: 1000 });
+
+    cache.seed('a', 7);
+    await expect(cache.getOrLoad('a', 'a', async () => ++calls)).resolves.toBe(7);
+
+    cache.invalidate('a');
+    await expect(cache.getOrLoad('a', 'a', async () => ++calls)).resolves.toBe(1);
+
+    cache.seed('b', 9);
+    cache.invalidateAll();
+    await expect(cache.getOrLoad('b', 'b', async () => ++calls)).resolves.toBe(2);
+  });
+
+  it('suppresses stale in-flight success after invalidation', async () => {
+    const stale = deferred<number>();
+    const fresh = deferred<number>();
+    const cache = new ReadThroughTtlCache<string, number>({ ttlMs: 1000 });
+
+    const staleLookup = cache.getOrLoad('account', 'account', async () => stale.promise);
+    cache.invalidate('account');
+    const freshLookup = cache.getOrLoad('account', 'account', async () => fresh.promise);
+
+    stale.resolve(1);
+    fresh.resolve(2);
+
+    await expect(staleLookup).resolves.toBe(1);
+    await expect(freshLookup).resolves.toBe(2);
+    await expect(cache.getOrLoad('account', 'account', async () => 3)).resolves.toBe(2);
+  });
+});

--- a/packages/chain/test/mock-adapter-parity.test.ts
+++ b/packages/chain/test/mock-adapter-parity.test.ts
@@ -172,6 +172,7 @@ const MOCK_EXEMPT_FROM_EVM = new Set<string>([
   'withHubStaleRetryAny',
   'invalidateAllBoundContracts',
   'startHubRotationListener',
+  'applyHubRotationEventName',
   'invalidateRandomSamplingPair',
   'resolveAndAssignRandomSamplingPair',
   'isContractMissingRevert',

--- a/packages/chain/test/mock-adapter-parity.test.ts
+++ b/packages/chain/test/mock-adapter-parity.test.ts
@@ -173,6 +173,9 @@ const MOCK_EXEMPT_FROM_EVM = new Set<string>([
   'invalidateAllBoundContracts',
   'startHubRotationListener',
   'applyHubRotationEventName',
+  'invalidateHubBindingOnRotation',
+  'invalidateHubBinding',
+  'finalizeKnownHubRotation',
   'invalidateRandomSamplingPair',
   'resolveAndAssignRandomSamplingPair',
   'isContractMissingRevert',
@@ -189,6 +192,11 @@ const MOCK_EXEMPT_FROM_EVM = new Set<string>([
   'pcaWriteAndInvalidate',
   // Identity read-cache helpers are EVM-only: the mock's identity registry is
   // in-memory and its writes are already immediately visible.
+  'invalidateIdentityStorageBinding',
+  'identityStorageAddressChanged',
+  'readIdentityIdFromStorage',
+  'readIdentityIdForAddress',
+  'refreshIdentityIdForAddress',
   'clearIdentityIdForAddress',
   'seedIdentityIdForAddress',
   // The seven V10 Publishing Conviction NFT methods (issue #519 /

--- a/packages/chain/test/mock-adapter-parity.test.ts
+++ b/packages/chain/test/mock-adapter-parity.test.ts
@@ -185,6 +185,11 @@ const MOCK_EXEMPT_FROM_EVM = new Set<string>([
   // (no mock equivalent — mock raises typed reverts directly).
   'requireConvictionNFT',
   'pcaWrite',
+  'pcaWriteAndInvalidate',
+  // Identity read-cache helpers are EVM-only: the mock's identity registry is
+  // in-memory and its writes are already immediately visible.
+  'clearIdentityIdForAddress',
+  'seedIdentityIdForAddress',
   // The seven V10 Publishing Conviction NFT methods (issue #519 /
   // TB-0002) are now mirrored on MockChainAdapter (in-memory account
   // map + agent reverse map + owner gating) — no longer exempt.
@@ -193,6 +198,7 @@ const MOCK_EXEMPT_FROM_EVM = new Set<string>([
   // round-trips to cache in the first place; a no-op shim would just
   // pad parity for no behavioural reason.
   'invalidatePublishPreflightCache',
+  'ensureConfiguredStaticChainIdValidated',
   // #820 (RFC-39 ciphertext/immutable ACK binding): EVM-only surfaces.
   //  - `computeV10UpdateAckDigest` mirrors the on-chain
   //    `KnowledgeAssetsLifecycle._executeUpdateCore` ACK-digest packing for

--- a/packages/chain/test/readwithfailover-loop.unit.test.ts
+++ b/packages/chain/test/readwithfailover-loop.unit.test.ts
@@ -49,6 +49,7 @@ function minimalConfig(overrides: Partial<EVMAdapterConfig> = {}): EVMAdapterCon
     hubAddress: HUB,
     chainId: 'evm:31337',
     allowNoAdminSigner: true,
+    staticNetwork: false,
     ...overrides,
   };
 }

--- a/packages/chain/test/readwithfailover-loop.unit.test.ts
+++ b/packages/chain/test/readwithfailover-loop.unit.test.ts
@@ -174,8 +174,9 @@ describe('RpcFailoverClient.read — read-failover loop logic (bare-mock, #1336)
 // poller ranges legitimately >4s) → threw RPC_ENDPOINTS_EXHAUSTED before the
 // publisher poller advanced its cursor → permanent stall. Fix: the named
 // `wideLogScan` policy (RPC_LOG_SCAN_TIMEOUT_MS = 30s) caps MULTI-RPC attempts
-// only by default; SINGLE-RPC stays uncapped (#894 — nothing to fail over to)
-// unless a background watcher opts into `capSingleProvider`. The raw
+// only; SINGLE-RPC stays uncapped (#894 — nothing to fail over to). Background
+// watchers that must clear a one-RPC scheduler gate use explicit watchdog
+// policies rather than changing the default read intent. The raw
 // `attemptTimeoutMs` / `multiAttemptTimeoutMs` knobs are gone — callers pick a
 // named ReadPolicy and the module owns the matrix (resolveCapMs). Fake timers
 // throughout — no real 5s/30s sleeps.

--- a/packages/chain/test/readwithfailover-loop.unit.test.ts
+++ b/packages/chain/test/readwithfailover-loop.unit.test.ts
@@ -174,7 +174,8 @@ describe('RpcFailoverClient.read — read-failover loop logic (bare-mock, #1336)
 // poller ranges legitimately >4s) → threw RPC_ENDPOINTS_EXHAUSTED before the
 // publisher poller advanced its cursor → permanent stall. Fix: the named
 // `wideLogScan` policy (RPC_LOG_SCAN_TIMEOUT_MS = 30s) caps MULTI-RPC attempts
-// only; SINGLE-RPC stays uncapped (#894 — nothing to fail over to). The raw
+// only by default; SINGLE-RPC stays uncapped (#894 — nothing to fail over to)
+// unless a background watcher opts into `capSingleProvider`. The raw
 // `attemptTimeoutMs` / `multiAttemptTimeoutMs` knobs are gone — callers pick a
 // named ReadPolicy and the module owns the matrix (resolveCapMs). Fake timers
 // throughout — no real 5s/30s sleeps.

--- a/packages/chain/test/rpc-failover-client.unit.test.ts
+++ b/packages/chain/test/rpc-failover-client.unit.test.ts
@@ -93,13 +93,18 @@ describe('resolveCapMs — the named timeout-policy matrix (PLAN §3.2)', () => 
     expect(resolveCapMs('pointRead', 2)).toBe(RPC_READ_STALL_TIMEOUT_MS);
     expect(resolveCapMs('pointRead', 4)).toBe(RPC_READ_STALL_TIMEOUT_MS);
     expect(resolveCapMs('pointRead', 1)).toBeUndefined();
-    expect(resolveCapMs('pointRead', 1, true)).toBe(RPC_READ_STALL_TIMEOUT_MS);
   });
 
   it('wideLogScan: multi-RPC caps at RPC_LOG_SCAN_TIMEOUT_MS, single-RPC is uncapped (#894)', () => {
     expect(resolveCapMs('wideLogScan', 2)).toBe(RPC_LOG_SCAN_TIMEOUT_MS);
     expect(resolveCapMs('wideLogScan', 1)).toBeUndefined();
-    expect(resolveCapMs('wideLogScan', 1, true)).toBe(RPC_LOG_SCAN_TIMEOUT_MS);
+  });
+
+  it('watchdog policies cap single-RPC attempts with the matching point/log deadline', () => {
+    expect(resolveCapMs('watchdogPointRead', 1)).toBe(RPC_READ_STALL_TIMEOUT_MS);
+    expect(resolveCapMs('watchdogPointRead', 2)).toBe(RPC_READ_STALL_TIMEOUT_MS);
+    expect(resolveCapMs('watchdogWideLogScan', 1)).toBe(RPC_LOG_SCAN_TIMEOUT_MS);
+    expect(resolveCapMs('watchdogWideLogScan', 2)).toBe(RPC_LOG_SCAN_TIMEOUT_MS);
   });
 
   it('failOpenFundingRead: caps EVERY attempt incl. single-RPC at RPC_READ_STALL_TIMEOUT_MS', () => {
@@ -137,18 +142,37 @@ describe('RpcFailoverClient.read / readContract — policy matrix applied + view
     expect(slowView.calls).toHaveLength(1);
   });
 
-  it('read SINGLE-RPC pointRead can opt into the per-policy cap for background watchers', async () => {
+  it('read SINGLE-RPC watchdogPointRead caps background watcher reads', async () => {
     vi.useFakeTimers();
     const slow = recorder(() => new Promise<string>((r) => { setTimeout(() => r('ONLY'), 5_000); }));
     const client = makeClient([{ read: slow }], ['https://only.example']);
 
-    const settled = client.read('watcher point read', (pr: any) => pr.read(), { capSingleProvider: true })
+    const settled = client.read('watcher point read', (pr: any) => pr.read(), { policy: 'watchdogPointRead' })
       .then((r: unknown) => r, (e: unknown) => e);
     await vi.advanceTimersByTimeAsync(RPC_READ_STALL_TIMEOUT_MS + 1_500);
 
     const outcome: any = await settled;
     expect(outcome.code).toBe('RPC_ENDPOINTS_EXHAUSTED');
     expect(slow.calls).toHaveLength(1);
+  });
+
+  it('readContract SINGLE-RPC watchdogPointRead caps background watcher views', async () => {
+    vi.useFakeTimers();
+    const slowView = recorder(() => new Promise<string>((r) => { setTimeout(() => r('ONLY'), 5_000); }));
+    const contract = { connect: () => ({ view: slowView }) } as any;
+    const client = makeClient([{}], ['https://only.example']);
+
+    const settled = client.readContract(
+      'watcher view',
+      contract,
+      (c: any) => c.view(),
+      { policy: 'watchdogPointRead' },
+    ).then((r: unknown) => r, (e: unknown) => e);
+    await vi.advanceTimersByTimeAsync(RPC_READ_STALL_TIMEOUT_MS + 1_500);
+
+    const outcome: any = await settled;
+    expect(outcome.code).toBe('RPC_ENDPOINTS_EXHAUSTED');
+    expect(slowView.calls).toHaveLength(1);
   });
 
   it('readContract MULTI-RPC wideLogScan: a 5s read COMPLETES (the 30s cap, not the 4s point cap)', async () => {

--- a/packages/chain/test/rpc-failover-client.unit.test.ts
+++ b/packages/chain/test/rpc-failover-client.unit.test.ts
@@ -93,11 +93,13 @@ describe('resolveCapMs — the named timeout-policy matrix (PLAN §3.2)', () => 
     expect(resolveCapMs('pointRead', 2)).toBe(RPC_READ_STALL_TIMEOUT_MS);
     expect(resolveCapMs('pointRead', 4)).toBe(RPC_READ_STALL_TIMEOUT_MS);
     expect(resolveCapMs('pointRead', 1)).toBeUndefined();
+    expect(resolveCapMs('pointRead', 1, true)).toBe(RPC_READ_STALL_TIMEOUT_MS);
   });
 
   it('wideLogScan: multi-RPC caps at RPC_LOG_SCAN_TIMEOUT_MS, single-RPC is uncapped (#894)', () => {
     expect(resolveCapMs('wideLogScan', 2)).toBe(RPC_LOG_SCAN_TIMEOUT_MS);
     expect(resolveCapMs('wideLogScan', 1)).toBeUndefined();
+    expect(resolveCapMs('wideLogScan', 1, true)).toBe(RPC_LOG_SCAN_TIMEOUT_MS);
   });
 
   it('failOpenFundingRead: caps EVERY attempt incl. single-RPC at RPC_READ_STALL_TIMEOUT_MS', () => {
@@ -133,6 +135,20 @@ describe('RpcFailoverClient.read / readContract — policy matrix applied + view
     await vi.advanceTimersByTimeAsync(6_500);
     expect(await p).toBe('ONLY');
     expect(slowView.calls).toHaveLength(1);
+  });
+
+  it('read SINGLE-RPC pointRead can opt into the per-policy cap for background watchers', async () => {
+    vi.useFakeTimers();
+    const slow = recorder(() => new Promise<string>((r) => { setTimeout(() => r('ONLY'), 5_000); }));
+    const client = makeClient([{ read: slow }], ['https://only.example']);
+
+    const settled = client.read('watcher point read', (pr: any) => pr.read(), { capSingleProvider: true })
+      .then((r: unknown) => r, (e: unknown) => e);
+    await vi.advanceTimersByTimeAsync(RPC_READ_STALL_TIMEOUT_MS + 1_500);
+
+    const outcome: any = await settled;
+    expect(outcome.code).toBe('RPC_ENDPOINTS_EXHAUSTED');
+    expect(slow.calls).toHaveLength(1);
   });
 
   it('readContract MULTI-RPC wideLogScan: a 5s read COMPLETES (the 30s cap, not the 4s point cap)', async () => {

--- a/packages/chain/test/rpc-usage.unit.test.ts
+++ b/packages/chain/test/rpc-usage.unit.test.ts
@@ -9,6 +9,7 @@
  * chain_id} labels, drain-resets-window semantics, and label bounding.
  */
 import { describe, it, expect, afterEach } from 'vitest';
+import { Contract } from 'ethers';
 import { metrics } from '@opentelemetry/api';
 import {
   MeterProvider,
@@ -18,7 +19,17 @@ import {
 } from '@opentelemetry/sdk-metrics';
 import { rebuildMetrics } from '@origintrail-official/dkg-core';
 import { EVMChainAdapter, type EVMAdapterConfig } from '../src/evm-adapter.js';
-import { boundedRpcMethodLabel, mergeRpcUsageWindows, rpcUsageWindowTotal, RpcUsageTracker } from '../src/rpc-usage.js';
+import {
+  boundedRpcMethodLabel,
+  mergeRpcUsageWindows,
+  normalizeRpcUsageWindow,
+  normalizeRpcUsageConsumer,
+  rpcUsageWindowTotal,
+  RpcUsageTracker,
+  type RpcUsageDrainable,
+  withRpcUsageConsumer,
+} from '../src/rpc-usage.js';
+import type { ChainAdapter } from '../src/chain-adapter.js';
 import { startLoopbackRpc, type LoopbackRpc } from './loopback-rpc-harness.js';
 
 const DEPLOYER_PK = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
@@ -332,21 +343,56 @@ describe('RPC usage accounting — raw request counts EQUAL the server-received 
 
   it('mergeRpcUsageWindows sums per-method and lifetime across trackers', () => {
     const merged = mergeRpcUsageWindows(
-      { byMethod: { eth_call: 5, eth_estimateGas: 2 }, lifetimeTotal: 100 },
-      { byMethod: { eth_call: 3, eth_sendRawTransaction: 4 }, lifetimeTotal: 50 },
+      {
+        byMethod: { eth_call: 5, eth_estimateGas: 2 },
+        ethCallByConsumer: { 'pcaNFT.getAccountInfo': 2 },
+        lifetimeTotal: 100,
+      },
+      {
+        byMethod: { eth_call: 3, eth_sendRawTransaction: 4 },
+        ethCallByConsumer: { 'pcaNFT.getAccountInfo': 1, 'token.balanceOf': 2 },
+        lifetimeTotal: 50,
+      },
     );
     expect(merged).toEqual({
       byMethod: { eth_call: 8, eth_estimateGas: 2, eth_sendRawTransaction: 4 },
+      ethCallByConsumer: { 'pcaNFT.getAccountInfo': 3, 'token.balanceOf': 2 },
       lifetimeTotal: 150,
     });
   });
 
   it('mergeRpcUsageWindows skips undefined inputs; nothing to merge yields a concrete EMPTY window', () => {
-    const w = { byMethod: { eth_call: 1 }, lifetimeTotal: 1 };
-    const empty = { byMethod: {}, lifetimeTotal: 0 };
+    const w = { byMethod: { eth_call: 1 }, ethCallByConsumer: {}, lifetimeTotal: 1 };
+    const legacy = { byMethod: { eth_call: 2 }, lifetimeTotal: 2 };
+    const empty = { byMethod: {}, ethCallByConsumer: {}, lifetimeTotal: 0 };
     expect(mergeRpcUsageWindows(undefined, w, undefined)).toEqual(w);
+    expect(mergeRpcUsageWindows(legacy)).toEqual({
+      byMethod: { eth_call: 2 },
+      ethCallByConsumer: {},
+      lifetimeTotal: 2,
+    });
+    expect(normalizeRpcUsageWindow(legacy)).toEqual({
+      byMethod: { eth_call: 2 },
+      ethCallByConsumer: {},
+      lifetimeTotal: 2,
+    });
     expect(mergeRpcUsageWindows(undefined, undefined)).toEqual(empty);
     expect(mergeRpcUsageWindows()).toEqual(empty);
+  });
+
+  it('keeps legacy aggregate-only drain sources source-compatible at public boundaries', () => {
+    const drainable: RpcUsageDrainable = {
+      drainRpcUsage: () => ({ byMethod: { eth_call: 1 }, lifetimeTotal: 1 }),
+    };
+    const adapter = {
+      drainRpcUsage: () => ({ byMethod: { eth_getLogs: 2 }, lifetimeTotal: 2 }),
+    } satisfies Pick<ChainAdapter, 'drainRpcUsage'>;
+
+    expect(mergeRpcUsageWindows(drainable.drainRpcUsage(), adapter.drainRpcUsage?.())).toEqual({
+      byMethod: { eth_call: 1, eth_getLogs: 2 },
+      ethCallByConsumer: {},
+      lifetimeTotal: 3,
+    });
   });
 
   it('tracker.record never throws; window keys stay RAW (log token-safety is the formatter concern)', () => {
@@ -361,4 +407,202 @@ describe('RPC usage accounting — raw request counts EQUAL the server-received 
     expect(w.byMethod['debug_traceTransaction']).toBe(1); // NOT sanitized to 'other'
     expect(w.byMethod['other']).toBe(2);
   });
+
+  it('attributes eth_call to the current bounded consumer without changing aggregate totals', () => {
+    const t = new RpcUsageTracker(() => 'evm:31337');
+    withRpcUsageConsumer('pcaNFT.getAccountInfo', () => {
+      t.record('eth_call');
+      t.record('eth_call');
+      t.record('eth_getLogs');
+    });
+    t.record('eth_call');
+
+    const w = t.drainWindow();
+    expect(w.byMethod).toEqual({ eth_call: 3, eth_getLogs: 1 });
+    expect(w.ethCallByConsumer).toEqual({ 'pcaNFT.getAccountInfo': 2 });
+    expect(rpcUsageWindowTotal(w)).toBe(4);
+  });
+
+  it('drains eth_call consumer attribution as a per-window delta', () => {
+    const t = new RpcUsageTracker(() => 'evm:31337');
+    withRpcUsageConsumer('pcaNFT.getAccountInfo', () => t.record('eth_call'));
+
+    const first = t.drainWindow();
+    expect(first.byMethod).toEqual({ eth_call: 1 });
+    expect(first.ethCallByConsumer).toEqual({ 'pcaNFT.getAccountInfo': 1 });
+    expect(first.lifetimeTotal).toBe(1);
+
+    t.record('eth_getLogs');
+    const second = t.drainWindow();
+    expect(second.byMethod).toEqual({ eth_getLogs: 1 });
+    expect(second.ethCallByConsumer).toEqual({});
+    expect(second.lifetimeTotal).toBe(2);
+
+    const third = t.drainWindow();
+    expect(third.byMethod).toEqual({});
+    expect(third.ethCallByConsumer).toEqual({});
+    expect(third.lifetimeTotal).toBe(2);
+  });
+
+  it('keeps overlapping async consumer scopes isolated', async () => {
+    const t = new RpcUsageTracker(() => 'evm:31337');
+    await Promise.all([
+      withRpcUsageConsumer('cgStorage.getContextGraph', async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        t.record('eth_call');
+      }),
+      withRpcUsageConsumer('pcaNFT.getAccountInfo', async () => {
+        t.record('eth_call');
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        t.record('eth_call');
+      }),
+    ]);
+
+    const w = t.drainWindow();
+    expect(w.byMethod).toEqual({ eth_call: 3 });
+    expect(w.ethCallByConsumer).toEqual({
+      'cgStorage.getContextGraph': 1,
+      'pcaNFT.getAccountInfo': 2,
+    });
+  });
+
+  it('normalizes and bounds consumer labels', () => {
+    expect(normalizeRpcUsageConsumer(' Hub.getContractAddress(Token) ')).toBe('Hub.getContractAddress_Token');
+    expect(normalizeRpcUsageConsumer('bad label/with=spaces')).toBe('bad_label_with_spaces');
+    expect(normalizeRpcUsageConsumer('')).toBeUndefined();
+    expect(normalizeRpcUsageConsumer('x'.repeat(65))).toBe('other');
+  });
+
+  it('caps distinct eth_call consumer keys and overflows to other', () => {
+    const t = new RpcUsageTracker(() => 'evm:31337');
+    const max = RpcUsageTracker.MAX_WINDOW_CONSUMERS;
+    for (let i = 0; i < max + 4; i++) {
+      withRpcUsageConsumer(`consumer.${i}`, () => t.record('eth_call'));
+    }
+    withRpcUsageConsumer('consumer.0', () => t.record('eth_call'));
+
+    const w = t.drainWindow();
+    expect(Object.keys(w.ethCallByConsumer)).toHaveLength(max + 1);
+    expect(w.ethCallByConsumer['consumer.0']).toBe(2);
+    expect(w.ethCallByConsumer.other).toBe(4);
+    expect(w.byMethod.eth_call).toBe(max + 5);
+  });
+
+  it('attributes failover eth_call attempts to the readProvider label', async () => {
+    installMeter();
+    const primary = await startLoopbackRpc({ throttle: ['eth_call'] });
+    const backup = await startLoopbackRpc();
+    servers.push(primary, backup);
+    const a: any = new EVMChainAdapter(minimalConfig({
+      rpcUrl: primary.url,
+      rpcUrls: [primary.url, backup.url],
+      chainId: 'evm:31337',
+    }));
+    adapters.push(a);
+
+    await expect(
+      a.readProvider('unit.eth_call', (p: any) => p.send('eth_call', [{ to: HUB, data: '0x' }, 'latest'])),
+    ).resolves.toBeDefined();
+
+    const usage = a.drainRpcUsage();
+    const rawEthCallHits = primary.hits('eth_call') + backup.hits('eth_call');
+    expect(rawEthCallHits).toBeGreaterThanOrEqual(2);
+    expect(usage.byMethod.eth_call).toBe(rawEthCallHits);
+    expect(usage.ethCallByConsumer['unit.eth_call']).toBe(rawEthCallHits);
+  }, 30_000);
+
+  it('uses an explicit rpcUsageConsumer key independent of the human read label', async () => {
+    installMeter();
+    const primary = await startLoopbackRpc({ throttle: ['eth_call'] });
+    const backup = await startLoopbackRpc();
+    servers.push(primary, backup);
+    const a: any = new EVMChainAdapter(minimalConfig({
+      rpcUrl: primary.url,
+      rpcUrls: [primary.url, backup.url],
+      chainId: 'evm:31337',
+    }));
+    adapters.push(a);
+
+    await expect(
+      a.readProvider(
+        'human label with spaces can change',
+        (p: any) => p.send('eth_call', [{ to: HUB, data: '0x' }, 'latest']),
+        { rpcUsageConsumer: 'unit.eth_call.stable' },
+      ),
+    ).resolves.toBeDefined();
+
+    const usage = a.drainRpcUsage();
+    const rawEthCallHits = primary.hits('eth_call') + backup.hits('eth_call');
+    expect(rawEthCallHits).toBeGreaterThanOrEqual(2);
+    expect(usage.byMethod.eth_call).toBe(rawEthCallHits);
+    expect(usage.ethCallByConsumer['unit.eth_call.stable']).toBe(rawEthCallHits);
+    expect(usage.ethCallByConsumer.human_label_with_spaces_can_change).toBeUndefined();
+  }, 30_000);
+
+  it('attributes same-endpoint eth_call retry attempts to the readProvider label', async () => {
+    installMeter();
+    const rpc = await startLoopbackRpc({ throttle: ['eth_call'] });
+    servers.push(rpc);
+    const a: any = new EVMChainAdapter(minimalConfig({
+      rpcUrl: rpc.url,
+      chainId: 'evm:31337',
+    }));
+    adapters.push(a);
+
+    await expect(
+      a.readProvider('unit.eth_call.retry', (p: any) => p.send('eth_call', [{ to: HUB, data: '0x' }, 'latest'])),
+    ).rejects.toBeTruthy();
+
+    const usage = a.drainRpcUsage();
+    const rawEthCallHits = rpc.hits('eth_call');
+    expect(rawEthCallHits).toBeGreaterThanOrEqual(2);
+    expect(usage.byMethod.eth_call).toBe(rawEthCallHits);
+    expect(usage.ethCallByConsumer['unit.eth_call.retry']).toBe(rawEthCallHits);
+  }, 30_000);
+
+  it('attributes failover contract-view eth_call attempts to the readContract label', async () => {
+    installMeter();
+    const primary = await startLoopbackRpc({ throttle: ['eth_call'] });
+    const backup = await startLoopbackRpc();
+    servers.push(primary, backup);
+    const a: any = new EVMChainAdapter(minimalConfig({
+      rpcUrl: primary.url,
+      rpcUrls: [backup.url],
+      chainId: 'evm:31337',
+    }));
+    adapters.push(a);
+    const contract = new Contract(HUB, ['function value() view returns (uint256)']);
+
+    await expect(a.readContract(contract, 'unit.contract.value', 'value')).resolves.toBe(0n);
+
+    const usage = a.drainRpcUsage();
+    const rawEthCallHits = primary.hits('eth_call') + backup.hits('eth_call');
+    expect(rawEthCallHits).toBeGreaterThanOrEqual(2);
+    expect(usage.byMethod.eth_call).toBe(rawEthCallHits);
+    expect(usage.ethCallByConsumer['unit.contract.value']).toBe(rawEthCallHits);
+  }, 30_000);
+
+  it('attributes readContractWith eth_call attempts through the real transport path', async () => {
+    installMeter();
+    const primary = await startLoopbackRpc({ throttle: ['eth_call'] });
+    const backup = await startLoopbackRpc();
+    servers.push(primary, backup);
+    const a: any = new EVMChainAdapter(minimalConfig({
+      rpcUrl: primary.url,
+      rpcUrls: [backup.url],
+      chainId: 'evm:31337',
+    }));
+    adapters.push(a);
+    const contract = new Contract(HUB, ['function value() view returns (uint256)']);
+
+    await expect(
+      a.readContractWith(contract, 'unit.contract.with', (c: any) => c.value()),
+    ).resolves.toBe(0n);
+
+    const usage = a.drainRpcUsage();
+    const rawEthCallHits = primary.hits('eth_call') + backup.hits('eth_call');
+    expect(rawEthCallHits).toBeGreaterThanOrEqual(2);
+    expect(usage.byMethod.eth_call).toBe(rawEthCallHits);
+    expect(usage.ethCallByConsumer['unit.contract.with']).toBe(rawEthCallHits);
+  }, 30_000);
 });

--- a/packages/chain/test/rpc-usage.unit.test.ts
+++ b/packages/chain/test/rpc-usage.unit.test.ts
@@ -74,8 +74,8 @@ describe('RPC usage accounting — raw request counts EQUAL the server-received 
     const a: any = new EVMChainAdapter(minimalConfig({ rpcUrl: rpc.url }));
     adapters.push(a);
 
-    await expect(a.getEvmChainId()).resolves.toBe(31337n);
-    await expect(a.getEvmChainId()).resolves.toBe(31337n);
+    await expect(a.getBlockNumber()).resolves.toBe(16);
+    await expect(a.getBlockNumber()).resolves.toBe(16);
 
     // Source of truth: the server's own per-method request log. The tracker's
     // window must EQUAL it — no over- or under-counting.
@@ -87,19 +87,185 @@ describe('RPC usage accounting — raw request counts EQUAL the server-received 
     }
     // ...and per-method the other way: every server-observed method was counted.
     // (The harness has no method-list accessor, so probe the ones this read issues.)
-    expect(usage.byMethod['eth_chainId'] ?? 0).toBe(rpc.hits('eth_chainId'));
+    expect(usage.byMethod['eth_blockNumber'] ?? 0).toBe(rpc.hits('eth_blockNumber'));
 
     // OTel counter: bounded labels only.
     const pts = await requestPoints();
     expect(pts.length).toBeGreaterThanOrEqual(1);
     const keys = new Set(pts.flatMap((p) => Object.keys(p)));
     expect([...keys].sort()).toEqual(['chain_id', 'rpc_method']);
-    expect(pts.some((p) => p.rpc_method === 'eth_chainId' && p.chain_id === 'evm:31337')).toBe(true);
+    expect(pts.some((p) => p.rpc_method === 'eth_blockNumber' && p.chain_id === 'evm:31337')).toBe(true);
 
     // Drain semantics: deltas, not cumulative; lifetime monotonic.
     const drained = a.drainRpcUsage();
     expect(rpcUsageWindowTotal(drained)).toBe(0);
     expect(drained.lifetimeTotal).toBe(usage.lifetimeTotal);
+  });
+
+  it('STATIC NETWORK: getEvmChainId validates configured chain id once, then caches it', async () => {
+    installMeter();
+    const rpc = await startLoopbackRpc();
+    servers.push(rpc);
+    const a: any = new EVMChainAdapter(minimalConfig({ rpcUrl: rpc.url }));
+    adapters.push(a);
+
+    await expect(a.getEvmChainId()).resolves.toBe(31337n);
+    await expect(a.getEvmChainId()).resolves.toBe(31337n);
+
+    const usage = a.drainRpcUsage();
+    expect(rpc.hits('eth_chainId')).toBe(1);
+    expect(usage.byMethod['eth_chainId']).toBe(1);
+    expect(rpcUsageWindowTotal(usage)).toBe(1);
+  });
+
+  it('STATIC NETWORK: ordinary reads validate configured chain id once, then avoid steady eth_chainId calls', async () => {
+    installMeter();
+    const rpc = await startLoopbackRpc();
+    servers.push(rpc);
+    const a: any = new EVMChainAdapter(minimalConfig({ rpcUrl: rpc.url, chainId: 'evm:31337' }));
+    adapters.push(a);
+
+    await expect(a.getBlockNumber()).resolves.toBe(16);
+    await expect(a.getBlockNumber()).resolves.toBe(16);
+
+    const usage = a.drainRpcUsage();
+    expect(rpc.hits('eth_chainId')).toBe(1);
+    expect(usage.byMethod['eth_chainId']).toBe(1);
+    expect(usage.byMethod['eth_blockNumber']).toBe(rpc.hits('eth_blockNumber'));
+    expect(rpcUsageWindowTotal(usage)).toBe(rpc.totalHits());
+  });
+
+  it('STATIC NETWORK: ordinary reads fail closed on configured/live chain-id mismatch', async () => {
+    installMeter();
+    const rpc = await startLoopbackRpc({ results: { eth_chainId: '0x14a34' } });
+    servers.push(rpc);
+    const a: any = new EVMChainAdapter(minimalConfig({ rpcUrl: rpc.url, chainId: 'evm:31337' }));
+    adapters.push(a);
+
+    await expect(a.getBlockNumber()).rejects.toThrow(/Configured chainId 31337 does not match RPC chainId 84532/);
+
+    const usage = a.drainRpcUsage();
+    expect(rpc.hits('eth_chainId')).toBe(1);
+    expect(rpc.hits('eth_blockNumber')).toBe(0);
+    expect(usage.byMethod['eth_chainId']).toBe(1);
+    expect(usage.byMethod['eth_blockNumber'] ?? 0).toBe(0);
+  });
+
+  it('STATIC NETWORK: event log scans fail closed before probing mismatched providers', async () => {
+    installMeter();
+    const rpc = await startLoopbackRpc({ results: { eth_chainId: '0x14a34' } });
+    servers.push(rpc);
+    const a: any = new EVMChainAdapter(minimalConfig({ rpcUrl: rpc.url, chainId: 'evm:31337' }));
+    adapters.push(a);
+
+    await expect(a.resolveLogScanHead('unit log scan'))
+      .rejects.toThrow(/Configured chainId 31337 does not match RPC chainId 84532/);
+
+    const usage = a.drainRpcUsage();
+    expect(rpc.hits('eth_chainId')).toBe(1);
+    expect(rpc.hits('eth_blockNumber')).toBe(0);
+    expect(usage.byMethod['eth_chainId']).toBe(1);
+    expect(usage.byMethod['eth_blockNumber'] ?? 0).toBe(0);
+  });
+
+  it('STATIC NETWORK: failover validates a backup endpoint before it can serve reads', async () => {
+    installMeter();
+    const primary = await startLoopbackRpc({ throttle: ['eth_blockNumber'] });
+    const backup = await startLoopbackRpc({ results: { eth_chainId: '0x14a34', eth_blockNumber: '0x20' } });
+    servers.push(primary, backup);
+    const a: any = new EVMChainAdapter(minimalConfig({
+      rpcUrl: primary.url,
+      rpcUrls: [backup.url],
+      chainId: 'evm:31337',
+    }));
+    adapters.push(a);
+
+    await expect(a.getBlockNumber()).rejects.toThrow(/Configured chainId 31337 does not match RPC chainId 84532/);
+
+    const usage = a.drainRpcUsage();
+    expect(primary.hits('eth_chainId')).toBe(1);
+    expect(primary.hits('eth_blockNumber')).toBe(1);
+    expect(backup.hits('eth_chainId')).toBe(1);
+    expect(backup.hits('eth_blockNumber')).toBe(0);
+    expect(usage.byMethod['eth_chainId']).toBe(2);
+    expect(usage.byMethod['eth_blockNumber']).toBe(1);
+    expect(rpcUsageWindowTotal(usage)).toBe(primary.totalHits() + backup.totalHits());
+  });
+
+  it('STATIC NETWORK: configured chain ids stay bigint-only above JS safe-integer range', async () => {
+    installMeter();
+    const rpc = await startLoopbackRpc({ results: { eth_chainId: '0x20000000000001' } });
+    servers.push(rpc);
+    const a: any = new EVMChainAdapter(minimalConfig({
+      rpcUrl: rpc.url,
+      chainId: 'evm:9007199254740993',
+    }));
+    adapters.push(a);
+
+    await expect(a.getBlockNumber()).resolves.toBe(16);
+
+    const usage = a.drainRpcUsage();
+    expect(rpc.hits('eth_chainId')).toBe(1);
+    expect(usage.byMethod['eth_chainId']).toBe(1);
+    expect(usage.byMethod['eth_blockNumber']).toBe(rpc.hits('eth_blockNumber'));
+  });
+
+  it('STATIC NETWORK: getEvmChainId preserves configured bigint chain ids above JS safe-integer range', async () => {
+    installMeter();
+    const rpc = await startLoopbackRpc({ results: { eth_chainId: '0x20000000000001' } });
+    servers.push(rpc);
+    const a: any = new EVMChainAdapter(minimalConfig({
+      rpcUrl: rpc.url,
+      chainId: 'evm:9007199254740993',
+    }));
+    adapters.push(a);
+
+    await expect(a.getEvmChainId()).resolves.toBe(9007199254740993n);
+
+    const usage = a.drainRpcUsage();
+    expect(rpc.hits('eth_chainId')).toBe(1);
+    expect(usage.byMethod['eth_chainId']).toBe(1);
+  });
+
+  it('STATIC NETWORK: non-numeric chain labels fall back to dynamic detection for compatibility', async () => {
+    const rpc = await startLoopbackRpc();
+    servers.push(rpc);
+    const a: any = new EVMChainAdapter(minimalConfig({
+      rpcUrl: rpc.url,
+      chainId: 'dynamic-test',
+    }));
+    adapters.push(a);
+
+    await expect(a.getEvmChainId()).resolves.toBe(31337n);
+    expect(rpc.hits('eth_chainId')).toBeGreaterThan(0);
+  });
+
+  it('STATIC NETWORK: getEvmChainId fails when configured chain id does not match the RPC', async () => {
+    installMeter();
+    const rpc = await startLoopbackRpc({ results: { eth_chainId: '0x14a34' } });
+    servers.push(rpc);
+    const a: any = new EVMChainAdapter(minimalConfig({ rpcUrl: rpc.url, chainId: 'evm:31337' }));
+    adapters.push(a);
+
+    await expect(a.getEvmChainId()).rejects.toThrow(/Configured chainId 31337 does not match RPC chainId 84532/);
+
+    const usage = a.drainRpcUsage();
+    expect(usage.byMethod['eth_chainId']).toBe(rpc.hits('eth_chainId'));
+    expect(rpcUsageWindowTotal(usage)).toBe(rpc.totalHits());
+  });
+
+  it('STATIC NETWORK: getEvmChainId still surfaces endpoint exhaustion during validation', async () => {
+    installMeter();
+    const rpc = await startLoopbackRpc({ throttle: ['eth_chainId'] });
+    servers.push(rpc);
+    const a: any = new EVMChainAdapter(minimalConfig({ rpcUrl: rpc.url, chainId: 'evm:31337' }));
+    adapters.push(a);
+
+    await expect(a.getEvmChainId()).rejects.toMatchObject({ code: 'RPC_ENDPOINTS_EXHAUSTED' });
+
+    const usage = a.drainRpcUsage();
+    expect(usage.byMethod['eth_chainId'] ?? 0).toBe(rpc.hits('eth_chainId'));
+    expect(rpcUsageWindowTotal(usage)).toBe(rpc.totalHits());
   });
 
   it('RETRIES BILL: ethers 429-retry attempts below _send are counted (tracker == server hits)', async () => {
@@ -111,7 +277,7 @@ describe('RPC usage accounting — raw request counts EQUAL the server-received 
     // must match exactly (this is the undercount the review flagged).
     const rpc = await startLoopbackRpc({ throttle: ['eth_chainId'] });
     servers.push(rpc);
-    const a: any = new EVMChainAdapter(minimalConfig({ rpcUrl: rpc.url }));
+    const a: any = new EVMChainAdapter(minimalConfig({ rpcUrl: rpc.url, staticNetwork: false }));
     adapters.push(a);
 
     await expect(a.getEvmChainId()).rejects.toBeTruthy(); // perpetual 429 → bounded failure
@@ -140,7 +306,7 @@ describe('RPC usage accounting — raw request counts EQUAL the server-received 
     const rpcA = await startLoopbackRpc({ throttle: ['eth_chainId'] });
     const rpcB = await startLoopbackRpc();
     servers.push(rpcA, rpcB);
-    const a: any = new EVMChainAdapter(minimalConfig({ rpcUrl: rpcA.url, rpcUrls: [rpcA.url, rpcB.url] }));
+    const a: any = new EVMChainAdapter(minimalConfig({ rpcUrl: rpcA.url, rpcUrls: [rpcA.url, rpcB.url], staticNetwork: false }));
     adapters.push(a);
 
     await expect(a.getEvmChainId()).resolves.toBe(31337n); // failover succeeds via B

--- a/packages/chain/test/v10-update-ack-digest-parity.unit.test.ts
+++ b/packages/chain/test/v10-update-ack-digest-parity.unit.test.ts
@@ -50,7 +50,13 @@ function makeStubbedAdapter(opts: {
   // R1/#1336: getEvmChainId reads chainId via readProvider (this.rpcFailover.read)
   // over this.providers[0] (=== this.provider in prod). Set the mock on BOTH so the
   // digest's chainId read resolves to the stub instead of dialling the placeholder RPC.
-  const provider = { getNetwork: async () => ({ chainId: TEST_CHAIN_ID }) };
+  const provider = {
+    getNetwork: async () => ({ chainId: TEST_CHAIN_ID }),
+    send: async (method: string) => {
+      if (method === 'eth_chainId') return `0x${TEST_CHAIN_ID.toString(16)}`;
+      throw new Error(`unexpected RPC method ${method}`);
+    },
+  };
   (a as any).provider = provider;
   (a as any).providers = [provider];
   // The contract view reads go through readContract (this.rpcFailover.readContract)
@@ -136,6 +142,35 @@ describe('V10 UPDATE ACK digest parity (off-chain == adapter)', () => {
 
     expect(Buffer.from(offChainDigest).equals(Buffer.from(adapterDigest))).toBe(true);
     expect(offChainDigest.length).toBe(32);
+  });
+
+  it('validates live chain id before computing an update ACK digest on static-network providers', async () => {
+    const a = makeStubbedAdapter({
+      contextGraphId,
+      preUpdateMerkleRootCount,
+      currentTokenAmount,
+      currentByteSize: newByteSize,
+    });
+    const wrongLiveProvider = {
+      // Static-network getNetwork would return the configured id; the digest
+      // path must still validate the live endpoint via eth_chainId.
+      getNetwork: async () => ({ chainId: TEST_CHAIN_ID }),
+      send: async (method: string) => {
+        if (method === 'eth_chainId') return '0x14a34';
+        throw new Error(`unexpected RPC method ${method}`);
+      },
+    };
+    (a as any).provider = wrongLiveProvider;
+    (a as any).providers = [wrongLiveProvider];
+
+    await expect(a.computeV10UpdateAckDigest({
+      kaId,
+      newMerkleRoot,
+      newByteSize,
+      newMerkleLeafCount,
+      mintAmount,
+      burnTokenIds,
+    })).rejects.toThrow(/Configured chainId 31337 does not match RPC chainId 84532/);
   });
 
   it('with explicit user newTokenAmount: bound value flows into both digest paths', async () => {

--- a/packages/chain/test/write-tx-safety-invariants.unit.test.ts
+++ b/packages/chain/test/write-tx-safety-invariants.unit.test.ts
@@ -44,6 +44,7 @@ function minimalConfig(overrides: Partial<EVMAdapterConfig> = {}): EVMAdapterCon
     hubAddress: HUB,
     chainId: 'evm:31337',
     allowNoAdminSigner: true,
+    staticNetwork: false,
     ...overrides,
   };
 }

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -64,6 +64,7 @@ const daemonRequire = createRequire(import.meta.url);
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
 import {
+  buildEvmDeploymentId,
   MockChainAdapter,
   mergeRpcUsageWindows,
   type ApprovalPolicy,
@@ -93,6 +94,8 @@ import {
   SqliteMessageIdempotencyStore,
   SqliteProtocolOutboxStore,
   SqliteSyncCheckpointStore,
+  SqliteChainEventCursorStore,
+  SqliteContextGraphRegistryScanCursorStore,
   SqliteKaNumberStore,
   type MetricsSource,
 } from "@origintrail-official/dkg-node-ui";
@@ -673,14 +676,17 @@ export function shouldUseIncrementalChainDiscoveryScan(input: {
 }
 
 export const CHAIN_FULL_SCAN_EVERY = 48; // about once per day at the 30-minute cadence
+export const CHAIN_DISCOVERY_SCAN_PAGE_BUDGET = 30;
 
 export function chainDiscoveryScanOptions(input: {
   watermarkSeeded: boolean;
   run?: number;
   fullScanEvery?: number;
+  pageBudget?: number;
 }):
-  | { incremental: true }
-  | { seedIncrementalWatermark: true; throwOnChainScanFailure: true } {
+  | { mode: 'incremental'; pageBudget: number }
+  | { mode: 'seedFromCursor'; throwOnChainScanFailure: true; pageBudget: number }
+  | { mode: 'seedFull'; throwOnChainScanFailure: true } {
   const configuredFullScanEvery = input.fullScanEvery;
   let fullScanEvery = CHAIN_FULL_SCAN_EVERY;
   if (
@@ -690,11 +696,59 @@ export function chainDiscoveryScanOptions(input: {
   ) {
     fullScanEvery = Math.floor(configuredFullScanEvery);
   }
+  const configuredPageBudget = input.pageBudget;
+  const pageBudget = (
+    typeof configuredPageBudget === 'number' &&
+    Number.isFinite(configuredPageBudget) &&
+    configuredPageBudget >= 1
+  )
+    ? Math.floor(configuredPageBudget)
+    : CHAIN_DISCOVERY_SCAN_PAGE_BUDGET;
   const run = input.run ?? 0;
   const periodicFullResync = input.watermarkSeeded && run > 0 && run % fullScanEvery === 0;
+  if (periodicFullResync) {
+    return { mode: 'seedFull', throwOnChainScanFailure: true };
+  }
   return input.watermarkSeeded && !periodicFullResync
-    ? { incremental: true }
-    : { seedIncrementalWatermark: true, throwOnChainScanFailure: true };
+    ? { mode: 'incremental', pageBudget }
+    : { mode: 'seedFromCursor', throwOnChainScanFailure: true, pageBudget };
+}
+
+export function createChainDiscoveryScanRunner(input: {
+  agent: {
+    hasContextGraphRegistryScanWatermark(): Promise<boolean>;
+    discoverContextGraphsFromChain(
+      options: ReturnType<typeof chainDiscoveryScanOptions>,
+    ): Promise<number>;
+  };
+  log: (msg: string) => void;
+  pageBudget?: number;
+  fullScanEvery?: number;
+}): () => Promise<void> {
+  let runs = 0;
+  let inFlight = false;
+  return async () => {
+    if (inFlight) return;
+    inFlight = true;
+    try {
+      const run = runs++;
+      const found = await input.agent.discoverContextGraphsFromChain(
+        chainDiscoveryScanOptions({
+          run,
+          watermarkSeeded: await input.agent.hasContextGraphRegistryScanWatermark(),
+          pageBudget: input.pageBudget,
+          fullScanEvery: input.fullScanEvery,
+        }),
+      );
+      if (found > 0) {
+        input.log(`Chain scan: discovered ${found} new context graph(s)`);
+      }
+    } catch {
+      /* non-critical */
+    } finally {
+      inFlight = false;
+    }
+  };
 }
 
 export interface PromoteWorkerDaemonLifecycle {
@@ -1397,6 +1451,16 @@ export async function runDaemonInner(
     : undefined;
 
   const dashDb = new DashboardDB({ dataDir: dkgDir() });
+  const chainCursorScope = chainBase?.type === 'mock'
+    ? (chainBase.chainId ?? 'mock:31337')
+    : chainBase?.hubAddress
+      ? buildEvmDeploymentId({
+          chainId: chainBase.chainId ?? 'evm:31337',
+          hubAddress: chainBase.hubAddress,
+        })
+      : chainBase?.chainId
+        ? `${chainBase.chainId}:hub=none`
+        : 'none:hub=none';
 
   if (role === 'core' && config.core?.allowDegradedRelay === false) {
     const hostInterfaces = Object.values(osModule.networkInterfaces())
@@ -1446,6 +1510,8 @@ export async function runDaemonInner(
     },
   });
   const syncCheckpointStore = new SqliteSyncCheckpointStore(dashDb);
+  const chainEventCursorStore = new SqliteChainEventCursorStore(dashDb, { scope: chainCursorScope });
+  const contextGraphRegistryScanCursorStore = new SqliteContextGraphRegistryScanCursorStore(dashDb);
 
   // OT-RFC-43 Option-1 deterministic KA identity (B2 allocator core).
   // Durable per-author KA-number sequence backing the off-chain
@@ -1528,6 +1594,8 @@ export async function runDaemonInner(
     randomSamplingTickIntervalMs: config.randomSampling?.tickIntervalMs,
     randomSamplingUseWorkerThread: config.randomSampling?.useWorkerThread,
     syncCheckpointStore,
+    chainEventCursorStore,
+    contextGraphRegistryScanCursorStore,
     contextGraphSubscriptionStore: {
       loadAll: async () => dashDb.listContextGraphSubscriptions().map((row) => ({
         id: row.context_graph_id,
@@ -2024,22 +2092,11 @@ export async function runDaemonInner(
   // Run an initial chain scan for context graphs we might not know about,
   // then repeat every 30 minutes as a fallback discovery mechanism.
   const CHAIN_SCAN_INTERVAL_MS = 30 * 60 * 1000;
-  let chainScanRuns = 0;
-  const runChainDiscoveryScan = async () => {
-    try {
-      const run = chainScanRuns++;
-      const found = await agent.discoverContextGraphsFromChain(
-        chainDiscoveryScanOptions({
-          run,
-          watermarkSeeded: await agent.hasContextGraphRegistryScanWatermark(),
-        }),
-      );
-      if (found > 0)
-        log(`Chain scan: discovered ${found} new context graph(s)`);
-    } catch {
-      /* non-critical */
-    }
-  };
+  const runChainDiscoveryScan = createChainDiscoveryScanRunner({
+    agent,
+    log,
+    pageBudget: CHAIN_DISCOVERY_SCAN_PAGE_BUDGET,
+  });
   setTimeout(runChainDiscoveryScan, 15_000);
   const chainScanTimer = setInterval(runChainDiscoveryScan, CHAIN_SCAN_INTERVAL_MS);
   if (chainScanTimer.unref) chainScanTimer.unref();

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -672,24 +672,12 @@ export function shouldUseIncrementalChainDiscoveryScan(input: {
   return input.watermarkSeeded;
 }
 
-export const CHAIN_DISCOVERY_LIVE_TAIL_LOOKBACK_BLOCKS = 9_000;
-
 export function chainDiscoveryScanOptions(incremental: boolean):
   | { incremental: true }
-  | {
-      liveTailOnly: true;
-      liveTailLookbackBlocks: number;
-      seedIncrementalWatermark: true;
-      throwOnChainScanFailure: true;
-    } {
+  | { seedIncrementalWatermark: true; throwOnChainScanFailure: true } {
   return incremental
     ? { incremental: true }
-    : {
-        liveTailOnly: true,
-        liveTailLookbackBlocks: CHAIN_DISCOVERY_LIVE_TAIL_LOOKBACK_BLOCKS,
-        seedIncrementalWatermark: true,
-        throwOnChainScanFailure: true,
-      };
+    : { seedIncrementalWatermark: true, throwOnChainScanFailure: true };
 }
 
 export interface PromoteWorkerDaemonLifecycle {

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -699,8 +699,9 @@ export function chainDiscoveryScanOptions(input: {
     ? Math.floor(configuredPageBudget)
     : CHAIN_DISCOVERY_SCAN_PAGE_BUDGET;
   const run = input.run ?? 0;
+  const startupRecoveryScan = input.watermarkSeeded && run === 0;
   const periodicFullResync = input.watermarkSeeded && run > 0 && run % fullScanEvery === 0;
-  if (periodicFullResync) {
+  if (startupRecoveryScan || periodicFullResync) {
     return { mode: 'seedFull', throwOnChainScanFailure: true };
   }
   return input.watermarkSeeded && !periodicFullResync

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -672,10 +672,10 @@ export function shouldUseIncrementalChainDiscoveryScan(input: {
   return input.watermarkSeeded;
 }
 
-export function chainDiscoveryScanOptions(incremental: boolean):
+export function chainDiscoveryScanOptions(input: { watermarkSeeded: boolean }):
   | { incremental: true }
   | { seedIncrementalWatermark: true; throwOnChainScanFailure: true } {
-  return incremental
+  return input.watermarkSeeded
     ? { incremental: true }
     : { seedIncrementalWatermark: true, throwOnChainScanFailure: true };
 }
@@ -2009,11 +2009,10 @@ export async function runDaemonInner(
   const CHAIN_SCAN_INTERVAL_MS = 30 * 60 * 1000;
   const runChainDiscoveryScan = async () => {
     try {
-      const incremental = shouldUseIncrementalChainDiscoveryScan({
-        watermarkSeeded: await agent.hasContextGraphRegistryScanWatermark(),
-      });
       const found = await agent.discoverContextGraphsFromChain(
-        chainDiscoveryScanOptions(incremental),
+        chainDiscoveryScanOptions({
+          watermarkSeeded: await agent.hasContextGraphRegistryScanWatermark(),
+        }),
       );
       if (found > 0)
         log(`Chain scan: discovered ${found} new context graph(s)`);

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -686,7 +686,7 @@ export function chainDiscoveryScanOptions(input: {
   if (
     typeof configuredFullScanEvery === 'number' &&
     Number.isFinite(configuredFullScanEvery) &&
-    configuredFullScanEvery > 0
+    configuredFullScanEvery >= 1
   ) {
     fullScanEvery = Math.floor(configuredFullScanEvery);
   }

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -667,23 +667,29 @@ export function orderACKCandidatePeerIds(input: {
 }
 
 export function shouldUseIncrementalChainDiscoveryScan(input: {
-  run: number;
   watermarkSeeded: boolean;
-  fullScanEvery: number;
 }): boolean {
-  return (
-    input.watermarkSeeded &&
-    input.run !== 0 &&
-    input.run % input.fullScanEvery !== 0
-  );
+  return input.watermarkSeeded;
 }
+
+export const CHAIN_DISCOVERY_LIVE_TAIL_LOOKBACK_BLOCKS = 9_000;
 
 export function chainDiscoveryScanOptions(incremental: boolean):
   | { incremental: true }
-  | { seedIncrementalWatermark: true; throwOnChainScanFailure: true } {
+  | {
+      liveTailOnly: true;
+      liveTailLookbackBlocks: number;
+      seedIncrementalWatermark: true;
+      throwOnChainScanFailure: true;
+    } {
   return incremental
     ? { incremental: true }
-    : { seedIncrementalWatermark: true, throwOnChainScanFailure: true };
+    : {
+        liveTailOnly: true,
+        liveTailLookbackBlocks: CHAIN_DISCOVERY_LIVE_TAIL_LOOKBACK_BLOCKS,
+        seedIncrementalWatermark: true,
+        throwOnChainScanFailure: true,
+      };
 }
 
 export interface PromoteWorkerDaemonLifecycle {
@@ -2013,15 +2019,10 @@ export async function runDaemonInner(
   // Run an initial chain scan for context graphs we might not know about,
   // then repeat every 30 minutes as a fallback discovery mechanism.
   const CHAIN_SCAN_INTERVAL_MS = 30 * 60 * 1000;
-  const CHAIN_FULL_SCAN_EVERY = 48; // about once per day at the 30-minute cadence
-  let chainScanRuns = 0;
   const runChainDiscoveryScan = async () => {
     try {
-      const run = chainScanRuns++;
       const incremental = shouldUseIncrementalChainDiscoveryScan({
-        run,
         watermarkSeeded: await agent.hasContextGraphRegistryScanWatermark(),
-        fullScanEvery: CHAIN_FULL_SCAN_EVERY,
       });
       const found = await agent.discoverContextGraphsFromChain(
         chainDiscoveryScanOptions(incremental),

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -669,12 +669,6 @@ export function orderACKCandidatePeerIds(input: {
   return connected;
 }
 
-export function shouldUseIncrementalChainDiscoveryScan(input: {
-  watermarkSeeded: boolean;
-}): boolean {
-  return input.watermarkSeeded;
-}
-
 export const CHAIN_FULL_SCAN_EVERY = 48; // about once per day at the 30-minute cadence
 export const CHAIN_DISCOVERY_SCAN_PAGE_BUDGET = 30;
 

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -672,10 +672,27 @@ export function shouldUseIncrementalChainDiscoveryScan(input: {
   return input.watermarkSeeded;
 }
 
-export function chainDiscoveryScanOptions(input: { watermarkSeeded: boolean }):
+export const CHAIN_FULL_SCAN_EVERY = 48; // about once per day at the 30-minute cadence
+
+export function chainDiscoveryScanOptions(input: {
+  watermarkSeeded: boolean;
+  run?: number;
+  fullScanEvery?: number;
+}):
   | { incremental: true }
   | { seedIncrementalWatermark: true; throwOnChainScanFailure: true } {
-  return input.watermarkSeeded
+  const configuredFullScanEvery = input.fullScanEvery;
+  let fullScanEvery = CHAIN_FULL_SCAN_EVERY;
+  if (
+    typeof configuredFullScanEvery === 'number' &&
+    Number.isFinite(configuredFullScanEvery) &&
+    configuredFullScanEvery > 0
+  ) {
+    fullScanEvery = Math.floor(configuredFullScanEvery);
+  }
+  const run = input.run ?? 0;
+  const periodicFullResync = input.watermarkSeeded && run > 0 && run % fullScanEvery === 0;
+  return input.watermarkSeeded && !periodicFullResync
     ? { incremental: true }
     : { seedIncrementalWatermark: true, throwOnChainScanFailure: true };
 }
@@ -2007,10 +2024,13 @@ export async function runDaemonInner(
   // Run an initial chain scan for context graphs we might not know about,
   // then repeat every 30 minutes as a fallback discovery mechanism.
   const CHAIN_SCAN_INTERVAL_MS = 30 * 60 * 1000;
+  let chainScanRuns = 0;
   const runChainDiscoveryScan = async () => {
     try {
+      const run = chainScanRuns++;
       const found = await agent.discoverContextGraphsFromChain(
         chainDiscoveryScanOptions({
+          run,
           watermarkSeeded: await agent.hasContextGraphRegistryScanWatermark(),
         }),
       );

--- a/packages/cli/src/daemon/rpc-usage-log.ts
+++ b/packages/cli/src/daemon/rpc-usage-log.ts
@@ -7,9 +7,17 @@
  *
  * Line shape (parsed in LogQL with `| logfmt` on the log body):
  *   rpc_usage method=eth_call count=42 window_s=60 chain=base:8453
+ *
+ * Companion diagnostic line shape for `eth_call` attribution:
+ *   rpc_usage_by_consumer method=eth_call consumer=pcaNFT.getAccountInfo count=7 window_s=60 chain=base:8453
  */
 
-import { rpcUsageWindowTotal, type RpcUsageDrainable, type RpcUsageWindow } from '@origintrail-official/dkg-chain';
+import {
+  normalizeRpcUsageWindow,
+  rpcUsageWindowTotal,
+  type RpcUsageDrainable,
+  type RpcUsageWindow,
+} from '@origintrail-official/dkg-chain';
 
 /** logfmt-token safety: methods/chain ids are self-generated, but never emit a token that could break parsing. */
 function safeToken(value: string, fallback: string): string {
@@ -26,12 +34,21 @@ export function formatRpcUsageLines(
   windowSeconds: number,
   chainId?: string,
 ): string[] {
-  if (!usage || rpcUsageWindowTotal(usage) <= 0) return [];
+  if (!usage) return [];
+  const normalized = normalizeRpcUsageWindow(usage);
+  if (rpcUsageWindowTotal(normalized) <= 0) return [];
   const chain = chainId ? ` chain=${safeToken(chainId, 'unknown')}` : '';
   const lines: string[] = [];
-  for (const [method, count] of Object.entries(usage.byMethod)) {
+  for (const [method, count] of Object.entries(normalized.byMethod)) {
     if (!Number.isFinite(count) || count <= 0) continue;
     lines.push(`rpc_usage method=${safeToken(method, 'other')} count=${Math.floor(count)} window_s=${windowSeconds}${chain}`);
+  }
+  for (const [consumer, count] of Object.entries(normalized.ethCallByConsumer)) {
+    if (!Number.isFinite(count) || count <= 0) continue;
+    lines.push(
+      `rpc_usage_by_consumer method=eth_call consumer=${safeToken(consumer, 'other')} ` +
+      `count=${Math.floor(count)} window_s=${windowSeconds}${chain}`,
+    );
   }
   return lines;
 }
@@ -54,7 +71,7 @@ export function emitRpcUsage(
 ): number {
   try {
     const usage = source?.drainRpcUsage?.();
-    if (!usage || rpcUsageWindowTotal(usage) <= 0) return 0;
+    if (!usage) return 0;
     const lines = formatRpcUsageLines(usage, windowSeconds, chainId);
     for (const line of lines) emit(line);
     return lines.length;

--- a/packages/cli/test/chain-discovery-scan-mode.test.ts
+++ b/packages/cli/test/chain-discovery-scan-mode.test.ts
@@ -1,12 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import {
-  CHAIN_DISCOVERY_LIVE_TAIL_LOOKBACK_BLOCKS,
   chainDiscoveryScanOptions,
   shouldUseIncrementalChainDiscoveryScan,
 } from '../src/daemon/lifecycle.js';
 
 describe('shouldUseIncrementalChainDiscoveryScan', () => {
-  it('uses bounded live-tail seeding before any watermark seed exists', () => {
+  it('uses historical watermark seeding before any watermark seed exists', () => {
     expect(
       shouldUseIncrementalChainDiscoveryScan({
         watermarkSeeded: false,
@@ -14,7 +13,7 @@ describe('shouldUseIncrementalChainDiscoveryScan', () => {
     ).toBe(false);
   });
 
-  it('keeps bounded live-tail seeding until a watermark seed succeeds', () => {
+  it('keeps historical seeding until a watermark seed succeeds', () => {
     expect(
       shouldUseIncrementalChainDiscoveryScan({
         watermarkSeeded: false,
@@ -40,10 +39,8 @@ describe('shouldUseIncrementalChainDiscoveryScan', () => {
 });
 
 describe('chainDiscoveryScanOptions', () => {
-  it('uses failure-throwing bounded live-tail watermark seeding before incremental scans', () => {
+  it('uses failure-throwing full-history watermark seeding before incremental scans', () => {
     expect(chainDiscoveryScanOptions(false)).toEqual({
-      liveTailOnly: true,
-      liveTailLookbackBlocks: CHAIN_DISCOVERY_LIVE_TAIL_LOOKBACK_BLOCKS,
       seedIncrementalWatermark: true,
       throwOnChainScanFailure: true,
     });

--- a/packages/cli/test/chain-discovery-scan-mode.test.ts
+++ b/packages/cli/test/chain-discovery-scan-mode.test.ts
@@ -10,14 +10,17 @@ describe('chainDiscoveryScanOptions', () => {
     });
   });
 
-  it('keeps steady-state daemon scans incremental-only', () => {
-    expect(chainDiscoveryScanOptions({ watermarkSeeded: true })).toEqual({ mode: 'incremental', pageBudget: 30 });
+  it('uses a startup recovery scan even when the registry watermark already exists', () => {
+    expect(chainDiscoveryScanOptions({ watermarkSeeded: true })).toEqual({
+      mode: 'seedFull',
+      throwOnChainScanFailure: true,
+    });
   });
 
-  it('keeps the first daemon scan incremental when the watermark is already seeded', () => {
+  it('keeps steady-state daemon scans incremental after startup recovery', () => {
     expect(chainDiscoveryScanOptions({
       watermarkSeeded: true,
-      run: 0,
+      run: 1,
       fullScanEvery: 48,
     })).toEqual({ mode: 'incremental', pageBudget: 30 });
   });
@@ -52,6 +55,7 @@ describe('chainDiscoveryScanOptions', () => {
   it('honors a valid custom page budget', () => {
     expect(chainDiscoveryScanOptions({
       watermarkSeeded: true,
+      run: 1,
       pageBudget: 7.9,
     })).toEqual({ mode: 'incremental', pageBudget: 7 });
   });

--- a/packages/cli/test/chain-discovery-scan-mode.test.ts
+++ b/packages/cli/test/chain-discovery-scan-mode.test.ts
@@ -1,26 +1,23 @@
 import { describe, expect, it } from 'vitest';
 import {
+  CHAIN_DISCOVERY_LIVE_TAIL_LOOKBACK_BLOCKS,
   chainDiscoveryScanOptions,
   shouldUseIncrementalChainDiscoveryScan,
 } from '../src/daemon/lifecycle.js';
 
 describe('shouldUseIncrementalChainDiscoveryScan', () => {
-  it('starts with a full scan before any watermark seed exists', () => {
+  it('uses bounded live-tail seeding before any watermark seed exists', () => {
     expect(
       shouldUseIncrementalChainDiscoveryScan({
-        run: 0,
         watermarkSeeded: false,
-        fullScanEvery: 48,
       }),
     ).toBe(false);
   });
 
-  it('keeps retrying full scans until a watermark seed succeeds', () => {
+  it('keeps bounded live-tail seeding until a watermark seed succeeds', () => {
     expect(
       shouldUseIncrementalChainDiscoveryScan({
-        run: 1,
         watermarkSeeded: false,
-        fullScanEvery: 48,
       }),
     ).toBe(false);
   });
@@ -28,27 +25,25 @@ describe('shouldUseIncrementalChainDiscoveryScan', () => {
   it('uses incremental scans after a successful watermark seed', () => {
     expect(
       shouldUseIncrementalChainDiscoveryScan({
-        run: 1,
         watermarkSeeded: true,
-        fullScanEvery: 48,
       }),
     ).toBe(true);
   });
 
-  it('keeps the scheduled full-resync cadence after a watermark seed', () => {
+  it('does not schedule automatic full-resync scans after a watermark seed', () => {
     expect(
       shouldUseIncrementalChainDiscoveryScan({
-        run: 48,
         watermarkSeeded: true,
-        fullScanEvery: 48,
       }),
-    ).toBe(false);
+    ).toBe(true);
   });
 });
 
 describe('chainDiscoveryScanOptions', () => {
-  it('uses failure-throwing watermark seeding for full daemon scans', () => {
+  it('uses failure-throwing bounded live-tail watermark seeding before incremental scans', () => {
     expect(chainDiscoveryScanOptions(false)).toEqual({
+      liveTailOnly: true,
+      liveTailLookbackBlocks: CHAIN_DISCOVERY_LIVE_TAIL_LOOKBACK_BLOCKS,
       seedIncrementalWatermark: true,
       throwOnChainScanFailure: true,
     });

--- a/packages/cli/test/chain-discovery-scan-mode.test.ts
+++ b/packages/cli/test/chain-discovery-scan-mode.test.ts
@@ -1,16 +1,17 @@
-import { describe, expect, it } from 'vitest';
-import { chainDiscoveryScanOptions } from '../src/daemon/lifecycle.js';
+import { describe, expect, it, vi } from 'vitest';
+import { chainDiscoveryScanOptions, createChainDiscoveryScanRunner } from '../src/daemon/lifecycle.js';
 
 describe('chainDiscoveryScanOptions', () => {
-  it('uses failure-throwing full-history watermark seeding before a seed exists', () => {
+  it('uses bounded cursor-resumable watermark seeding before a seed exists', () => {
     expect(chainDiscoveryScanOptions({ watermarkSeeded: false })).toEqual({
-      seedIncrementalWatermark: true,
+      mode: 'seedFromCursor',
       throwOnChainScanFailure: true,
+      pageBudget: 30,
     });
   });
 
   it('keeps steady-state daemon scans incremental-only', () => {
-    expect(chainDiscoveryScanOptions({ watermarkSeeded: true })).toEqual({ incremental: true });
+    expect(chainDiscoveryScanOptions({ watermarkSeeded: true })).toEqual({ mode: 'incremental', pageBudget: 30 });
   });
 
   it('keeps the first daemon scan incremental when the watermark is already seeded', () => {
@@ -18,7 +19,7 @@ describe('chainDiscoveryScanOptions', () => {
       watermarkSeeded: true,
       run: 0,
       fullScanEvery: 48,
-    })).toEqual({ incremental: true });
+    })).toEqual({ mode: 'incremental', pageBudget: 30 });
   });
 
   it('keeps a periodic full-history recovery path after the watermark is seeded', () => {
@@ -27,7 +28,7 @@ describe('chainDiscoveryScanOptions', () => {
       run: 48,
       fullScanEvery: 48,
     })).toEqual({
-      seedIncrementalWatermark: true,
+      mode: 'seedFull',
       throwOnChainScanFailure: true,
     });
   });
@@ -37,7 +38,7 @@ describe('chainDiscoveryScanOptions', () => {
       watermarkSeeded: true,
       run: 47,
       fullScanEvery: 48,
-    })).toEqual({ incremental: true });
+    })).toEqual({ mode: 'incremental', pageBudget: 30 });
   });
 
   it('ignores fractional full-scan cadence overrides below one', () => {
@@ -45,6 +46,45 @@ describe('chainDiscoveryScanOptions', () => {
       watermarkSeeded: true,
       run: 1,
       fullScanEvery: 0.5,
-    })).toEqual({ incremental: true });
+    })).toEqual({ mode: 'incremental', pageBudget: 30 });
+  });
+
+  it('honors a valid custom page budget', () => {
+    expect(chainDiscoveryScanOptions({
+      watermarkSeeded: true,
+      pageBudget: 7.9,
+    })).toEqual({ mode: 'incremental', pageBudget: 7 });
+  });
+
+  it('serializes overlapping scheduled chain scans and resets after settle', async () => {
+    let resolveFirstScan: ((value: number) => void) | undefined;
+    const firstScan = new Promise<number>((resolve) => {
+      resolveFirstScan = resolve;
+    });
+    const agent = {
+      hasContextGraphRegistryScanWatermark: vi.fn(async () => true),
+      discoverContextGraphsFromChain: vi.fn(async () => firstScan),
+    };
+    const runner = createChainDiscoveryScanRunner({
+      agent,
+      log: vi.fn(),
+    });
+
+    const first = runner();
+    const overlapping = runner();
+    await Promise.resolve();
+
+    expect(agent.hasContextGraphRegistryScanWatermark).toHaveBeenCalledTimes(1);
+    expect(agent.discoverContextGraphsFromChain).toHaveBeenCalledTimes(1);
+    await overlapping;
+
+    resolveFirstScan?.(0);
+    await first;
+
+    agent.discoverContextGraphsFromChain.mockResolvedValue(0);
+    await runner();
+
+    expect(agent.hasContextGraphRegistryScanWatermark).toHaveBeenCalledTimes(2);
+    expect(agent.discoverContextGraphsFromChain).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/cli/test/chain-discovery-scan-mode.test.ts
+++ b/packages/cli/test/chain-discovery-scan-mode.test.ts
@@ -12,4 +12,31 @@ describe('chainDiscoveryScanOptions', () => {
   it('keeps steady-state daemon scans incremental-only', () => {
     expect(chainDiscoveryScanOptions({ watermarkSeeded: true })).toEqual({ incremental: true });
   });
+
+  it('keeps the first daemon scan incremental when the watermark is already seeded', () => {
+    expect(chainDiscoveryScanOptions({
+      watermarkSeeded: true,
+      run: 0,
+      fullScanEvery: 48,
+    })).toEqual({ incremental: true });
+  });
+
+  it('keeps a periodic full-history recovery path after the watermark is seeded', () => {
+    expect(chainDiscoveryScanOptions({
+      watermarkSeeded: true,
+      run: 48,
+      fullScanEvery: 48,
+    })).toEqual({
+      seedIncrementalWatermark: true,
+      throwOnChainScanFailure: true,
+    });
+  });
+
+  it('does not force a full scan before the configured recovery cadence', () => {
+    expect(chainDiscoveryScanOptions({
+      watermarkSeeded: true,
+      run: 47,
+      fullScanEvery: 48,
+    })).toEqual({ incremental: true });
+  });
 });

--- a/packages/cli/test/chain-discovery-scan-mode.test.ts
+++ b/packages/cli/test/chain-discovery-scan-mode.test.ts
@@ -1,52 +1,15 @@
 import { describe, expect, it } from 'vitest';
-import {
-  chainDiscoveryScanOptions,
-  shouldUseIncrementalChainDiscoveryScan,
-} from '../src/daemon/lifecycle.js';
-
-describe('shouldUseIncrementalChainDiscoveryScan', () => {
-  it('uses historical watermark seeding before any watermark seed exists', () => {
-    expect(
-      shouldUseIncrementalChainDiscoveryScan({
-        watermarkSeeded: false,
-      }),
-    ).toBe(false);
-  });
-
-  it('keeps historical seeding until a watermark seed succeeds', () => {
-    expect(
-      shouldUseIncrementalChainDiscoveryScan({
-        watermarkSeeded: false,
-      }),
-    ).toBe(false);
-  });
-
-  it('uses incremental scans after a successful watermark seed', () => {
-    expect(
-      shouldUseIncrementalChainDiscoveryScan({
-        watermarkSeeded: true,
-      }),
-    ).toBe(true);
-  });
-
-  it('does not schedule automatic full-resync scans after a watermark seed', () => {
-    expect(
-      shouldUseIncrementalChainDiscoveryScan({
-        watermarkSeeded: true,
-      }),
-    ).toBe(true);
-  });
-});
+import { chainDiscoveryScanOptions } from '../src/daemon/lifecycle.js';
 
 describe('chainDiscoveryScanOptions', () => {
-  it('uses failure-throwing full-history watermark seeding before incremental scans', () => {
-    expect(chainDiscoveryScanOptions(false)).toEqual({
+  it('uses failure-throwing full-history watermark seeding before a seed exists', () => {
+    expect(chainDiscoveryScanOptions({ watermarkSeeded: false })).toEqual({
       seedIncrementalWatermark: true,
       throwOnChainScanFailure: true,
     });
   });
 
   it('keeps steady-state daemon scans incremental-only', () => {
-    expect(chainDiscoveryScanOptions(true)).toEqual({ incremental: true });
+    expect(chainDiscoveryScanOptions({ watermarkSeeded: true })).toEqual({ incremental: true });
   });
 });

--- a/packages/cli/test/chain-discovery-scan-mode.test.ts
+++ b/packages/cli/test/chain-discovery-scan-mode.test.ts
@@ -39,4 +39,12 @@ describe('chainDiscoveryScanOptions', () => {
       fullScanEvery: 48,
     })).toEqual({ incremental: true });
   });
+
+  it('ignores fractional full-scan cadence overrides below one', () => {
+    expect(chainDiscoveryScanOptions({
+      watermarkSeeded: true,
+      run: 1,
+      fullScanEvery: 0.5,
+    })).toEqual({ incremental: true });
+  });
 });

--- a/packages/cli/test/daemon-startup-validation.test.ts
+++ b/packages/cli/test/daemon-startup-validation.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { computeNetworkId } from '../../core/src/genesis.js';
+import { buildEvmDeploymentId } from '@origintrail-official/dkg-chain';
 
 const mocks = vi.hoisted(() => ({
   agentCreate: vi.fn(),
@@ -29,6 +30,13 @@ vi.mock('../src/config.js', async importOriginal => {
 });
 
 const { runDaemonInner } = await import('../src/daemon/lifecycle.js');
+
+function closeDashboardDbFromAgentCreateArg(createArg: any): void {
+  const db =
+    createArg?.chainEventCursorStore?.cursors?.db ??
+    createArg?.contextGraphRegistryScanCursorStore?.cursors?.db;
+  db?.close?.();
+}
 
 describe('daemon startup network validation', () => {
   let tempHome: string | undefined;
@@ -160,12 +168,73 @@ describe('daemon startup network validation', () => {
       networkConfig: 'mainnet-gnosis',
       listenPort: 0,
       nodeRole: 'edge',
+      chain: {
+        type: 'evm',
+        rpcUrl: 'https://private-rpc.example',
+        hubAddress: '0x1234567890123456789012345678901234567890',
+        chainId: 'evm:100',
+      },
     } as any, Date.now())).rejects.toThrow('after-agent-create');
 
     expect(mocks.loadNetworkConfig).toHaveBeenCalledWith('mainnet-gnosis');
     expect(mocks.agentCreate).toHaveBeenCalledTimes(1);
-    expect(mocks.agentCreate.mock.calls[0]?.[0]).toMatchObject({
+    const createArg = mocks.agentCreate.mock.calls[0]?.[0] as any;
+    expect(createArg).toMatchObject({
       genesisId: 'gnosis-mainnet',
+      chainEventCursorStore: {
+        loadLane: expect.any(Function),
+        saveLane: expect.any(Function),
+      },
+      contextGraphRegistryScanCursorStore: {
+        load: expect.any(Function),
+        save: expect.any(Function),
+      },
     });
+    expect((createArg.chainEventCursorStore as any).scope).toBe(buildEvmDeploymentId({
+      chainId: 'evm:100',
+      hubAddress: '0x1234567890123456789012345678901234567890',
+    }));
+    closeDashboardDbFromAgentCreateArg(createArg);
+  });
+
+  it('scopes chain event cursors with the EVM default chain id when chainId is omitted', async () => {
+    tempHome = await mkdtemp(join(tmpdir(), 'dkg-omitted-chainid-startup-'));
+    originalDkgHome = process.env.DKG_HOME;
+    process.env.DKG_HOME = tempHome;
+    stdoutWrite = process.stdout.write;
+    stderrWrite = process.stderr.write;
+    uncaughtExceptionListeners = process.listeners('uncaughtException') as NodeJS.UncaughtExceptionListener[];
+    unhandledRejectionListeners = process.listeners('unhandledRejection') as NodeJS.UnhandledRejectionListener[];
+
+    mocks.loadNetworkConfig.mockResolvedValue({
+      networkName: 'Local EVM',
+      genesisId: 'gnosis-mainnet',
+      genesisVersion: 1,
+      relays: [],
+      defaultNodeRole: 'edge',
+    });
+    mocks.loadOpWallets.mockResolvedValue({ adminWallet: undefined, wallets: [] });
+    mocks.agentCreate.mockRejectedValue(new Error('after-agent-create'));
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    await expect(runDaemonInner(true, {
+      name: 'omitted-chainid-startup-test',
+      networkConfig: 'local-evm',
+      listenPort: 0,
+      nodeRole: 'edge',
+      chain: {
+        type: 'evm',
+        rpcUrl: 'https://private-rpc.example',
+        hubAddress: '0x2234567890123456789012345678901234567890',
+      },
+    } as any, Date.now())).rejects.toThrow('after-agent-create');
+
+    expect(mocks.agentCreate).toHaveBeenCalledTimes(1);
+    const createArg = mocks.agentCreate.mock.calls[0]?.[0] as any;
+    expect((createArg.chainEventCursorStore as any).scope).toBe(buildEvmDeploymentId({
+      chainId: 'evm:31337',
+      hubAddress: '0x2234567890123456789012345678901234567890',
+    }));
+    closeDashboardDbFromAgentCreateArg(createArg);
   });
 });

--- a/packages/cli/test/rpc-usage-log.test.ts
+++ b/packages/cli/test/rpc-usage-log.test.ts
@@ -10,7 +10,7 @@ import { formatRpcUsageLines, emitRpcUsage, startRpcUsageTelemetry } from '../sr
 describe('formatRpcUsageLines — the Grafana-facing rpc_usage contract', () => {
   it('emits one logfmt line per method with count/window/chain', () => {
     const lines = formatRpcUsageLines(
-      { byMethod: { eth_call: 42, eth_getLogs: 7 }, lifetimeTotal: 49 },
+      { byMethod: { eth_call: 42, eth_getLogs: 7 }, ethCallByConsumer: {}, lifetimeTotal: 49 },
       60,
       'base:8453',
     );
@@ -22,12 +22,18 @@ describe('formatRpcUsageLines — the Grafana-facing rpc_usage contract', () => 
   });
 
   it('returns [] for an empty window (idle node logs nothing, not zeros)', () => {
-    expect(formatRpcUsageLines({ byMethod: {}, lifetimeTotal: 123 }, 60, 'base:8453')).toEqual([]);
+    expect(formatRpcUsageLines({ byMethod: {}, ethCallByConsumer: {}, lifetimeTotal: 123 }, 60, 'base:8453')).toEqual([]);
+  });
+
+  it('preserves aggregate lines for legacy windows without consumer attribution', () => {
+    expect(formatRpcUsageLines({ byMethod: { eth_call: 2 }, lifetimeTotal: 2 }, 60, 'base:8453')).toEqual([
+      'rpc_usage method=eth_call count=2 window_s=60 chain=base:8453',
+    ]);
   });
 
   it('omits chain when unset and skips zero/negative/NaN counts', () => {
     const lines = formatRpcUsageLines(
-      { byMethod: { eth_call: 3, eth_getLogs: 0, eth_gasPrice: NaN as unknown as number }, lifetimeTotal: 3 },
+      { byMethod: { eth_call: 3, eth_getLogs: 0, eth_gasPrice: NaN as unknown as number }, ethCallByConsumer: {}, lifetimeTotal: 3 },
       60,
     );
     expect(lines).toEqual(['rpc_usage method=eth_call count=3 window_s=60']);
@@ -35,11 +41,53 @@ describe('formatRpcUsageLines — the Grafana-facing rpc_usage contract', () => 
 
   it('sanitizes non-token-safe method/chain values (defensive logfmt safety)', () => {
     const lines = formatRpcUsageLines(
-      { byMethod: { 'bad method "x"': 5 }, lifetimeTotal: 5 },
+      { byMethod: { 'bad method "x"': 5 }, ethCallByConsumer: {}, lifetimeTotal: 5 },
       60,
       'weird chain id',
     );
     expect(lines).toEqual(['rpc_usage method=other count=5 window_s=60 chain=unknown']);
+  });
+
+  it('emits companion eth_call consumer attribution lines without changing aggregate lines', () => {
+    const lines = formatRpcUsageLines(
+      {
+        byMethod: { eth_call: 42, eth_getLogs: 7 },
+        ethCallByConsumer: {
+          'pcaNFT.getAccountInfo': 30,
+          'Hub.getContractAddress_Token': 12,
+          unsafe_consumer: 0,
+        },
+        lifetimeTotal: 49,
+      },
+      60,
+      'base:8453',
+    );
+
+    expect(lines).toContain('rpc_usage method=eth_call count=42 window_s=60 chain=base:8453');
+    expect(lines).toContain('rpc_usage method=eth_getLogs count=7 window_s=60 chain=base:8453');
+    expect(lines).toContain(
+      'rpc_usage_by_consumer method=eth_call consumer=pcaNFT.getAccountInfo count=30 window_s=60 chain=base:8453',
+    );
+    expect(lines).toContain(
+      'rpc_usage_by_consumer method=eth_call consumer=Hub.getContractAddress_Token count=12 window_s=60 chain=base:8453',
+    );
+    expect(lines.some((l) => l.includes('unsafe_consumer'))).toBe(false);
+    for (const l of lines) expect(l).toMatch(/^rpc_usage(_by_consumer)?( [a-z_]+=[A-Za-z0-9_.:-]+)+$/);
+  });
+
+  it('sanitizes unsafe consumer values in attribution lines', () => {
+    const lines = formatRpcUsageLines(
+      {
+        byMethod: { eth_call: 2 },
+        ethCallByConsumer: { 'bad consumer=value': 2 },
+        lifetimeTotal: 2,
+      },
+      60,
+    );
+    expect(lines).toEqual([
+      'rpc_usage method=eth_call count=2 window_s=60',
+      'rpc_usage_by_consumer method=eth_call consumer=other count=2 window_s=60',
+    ]);
   });
 });
 
@@ -50,8 +98,15 @@ describe('composite daemon source — agent + publisher-runtime windows merged a
     // publish-transaction methods MUST appear in the emitted lines — this is
     // the undercount the review flagged (per-wallet publisher adapters were
     // never drained).
-    let runtime: { drainRpcUsage: () => { byMethod: Record<string, number>; total: number; lifetimeTotal: number } | undefined } | null = null;
-    const agentLike = { drainRpcUsage: () => ({ byMethod: { eth_call: 2 }, lifetimeTotal: 2 }) };
+    let runtime: {
+      drainRpcUsage: () => {
+        byMethod: Record<string, number>;
+        ethCallByConsumer: Record<string, number>;
+        total?: number;
+        lifetimeTotal: number;
+      } | undefined;
+    } | null = null;
+    const agentLike = { drainRpcUsage: () => ({ byMethod: { eth_call: 2 }, ethCallByConsumer: {}, lifetimeTotal: 2 }) };
     const source = { drainRpcUsage: () => mergeRpcUsageWindows(agentLike.drainRpcUsage(), runtime?.drainRpcUsage()) };
 
     const before: string[] = [];
@@ -60,7 +115,7 @@ describe('composite daemon source — agent + publisher-runtime windows merged a
 
     // runtime boots later (the daemon assigns the live variable) — its
     // per-wallet adapter traffic must now be merged in.
-    runtime = { drainRpcUsage: () => ({ byMethod: { eth_sendRawTransaction: 3, eth_call: 1 }, lifetimeTotal: 4 }) };
+    runtime = { drainRpcUsage: () => ({ byMethod: { eth_sendRawTransaction: 3, eth_call: 1 }, ethCallByConsumer: {}, lifetimeTotal: 4 }) };
     const after: string[] = [];
     emitRpcUsage(source, (l) => after.push(l), 60, 'base:8453');
     expect(after).toContain('rpc_usage method=eth_call count=3 window_s=60 chain=base:8453');
@@ -72,7 +127,7 @@ describe('emitRpcUsage — the complete daemon emission step (drain → format �
   it('drains the agent source and emits one line per method', () => {
     const emitted: string[] = [];
     const agentLike = {
-      drainRpcUsage: () => ({ byMethod: { eth_call: 12, eth_getLogs: 3 }, lifetimeTotal: 15 }),
+      drainRpcUsage: () => ({ byMethod: { eth_call: 12, eth_getLogs: 3 }, ethCallByConsumer: {}, lifetimeTotal: 15 }),
     };
     const n = emitRpcUsage(agentLike, (l) => emitted.push(l), 60, 'base:8453');
     expect(n).toBe(2);
@@ -82,7 +137,7 @@ describe('emitRpcUsage — the complete daemon emission step (drain → format �
 
   it('emits nothing for an empty window, a missing capability, or no source', () => {
     const emitted: string[] = [];
-    expect(emitRpcUsage({ drainRpcUsage: () => ({ byMethod: {}, lifetimeTotal: 9 }) }, (l) => emitted.push(l), 60)).toBe(0);
+    expect(emitRpcUsage({ drainRpcUsage: () => ({ byMethod: {}, ethCallByConsumer: {}, lifetimeTotal: 9 }) }, (l) => emitted.push(l), 60)).toBe(0);
     expect(emitRpcUsage({ drainRpcUsage: () => undefined } as never, (l) => emitted.push(l), 60)).toBe(0); // rogue undefined still tolerated at runtime
     expect(emitRpcUsage({}, (l) => emitted.push(l), 60)).toBe(0); // adapter without the capability
     expect(emitRpcUsage(undefined, (l) => emitted.push(l), 60)).toBe(0);
@@ -93,7 +148,7 @@ describe('emitRpcUsage — the complete daemon emission step (drain → format �
     expect(emitRpcUsage({ drainRpcUsage: () => { throw new Error('boom'); } }, () => {}, 60)).toBe(0);
     expect(
       emitRpcUsage(
-        { drainRpcUsage: () => ({ byMethod: { eth_call: 1 }, lifetimeTotal: 1 }) },
+        { drainRpcUsage: () => ({ byMethod: { eth_call: 1 }, ethCallByConsumer: {}, lifetimeTotal: 1 }) },
         () => { throw new Error('sink down'); },
         60,
       ),
@@ -110,7 +165,7 @@ describe('emitRpcUsage ← DKGAgent.drainRpcUsage — the REAL daemon boundary e
     // gap where chain-side and formatter tests both pass but the daemon signal
     // is silently dead.
     const { DKGAgent } = await import('@origintrail-official/dkg-agent');
-    const chain = { drainRpcUsage: () => ({ byMethod: { eth_call: 11 }, lifetimeTotal: 11 }) };
+    const chain = { drainRpcUsage: () => ({ byMethod: { eth_call: 11 }, ethCallByConsumer: {}, lifetimeTotal: 11 }) };
     const agentLike = { drainRpcUsage: () => DKGAgent.prototype.drainRpcUsage.call({ chain } as never) };
     const emitted: string[] = [];
     const n = emitRpcUsage(agentLike, (l) => emitted.push(l), 60, 'base:8453');
@@ -125,7 +180,7 @@ describe('startRpcUsageTelemetry — the full scheduling lifecycle (timer + shut
   it('ticks every window, emits the drained lines, and stop() drains the partial window then halts', () => {
     vi.useFakeTimers();
     const emitted: string[] = [];
-    let next = { byMethod: { eth_call: 5 }, lifetimeTotal: 5 };
+    let next = { byMethod: { eth_call: 5 }, ethCallByConsumer: {}, lifetimeTotal: 5 };
     const handle = startRpcUsageTelemetry({
       source: { drainRpcUsage: () => next },
       emit: (l) => emitted.push(l),
@@ -138,13 +193,13 @@ describe('startRpcUsageTelemetry — the full scheduling lifecycle (timer + shut
     expect(emitted).toEqual(['rpc_usage method=eth_call count=5 window_s=60 chain=base:8453']);
 
     // Partial window accumulated after the last tick → stop() must drain it.
-    next = { byMethod: { eth_getLogs: 2 }, lifetimeTotal: 7 };
+    next = { byMethod: { eth_getLogs: 2 }, ethCallByConsumer: {}, lifetimeTotal: 7 };
     handle.stop();
     expect(emitted).toContain('rpc_usage method=eth_getLogs count=2 window_s=60 chain=base:8453');
 
     // ...and the timer is really gone: no further emissions after stop().
     const after = emitted.length;
-    next = { byMethod: { eth_call: 9 }, lifetimeTotal: 16 };
+    next = { byMethod: { eth_call: 9 }, ethCallByConsumer: {}, lifetimeTotal: 16 };
     vi.advanceTimersByTime(300_000);
     expect(emitted.length).toBe(after);
   });
@@ -153,7 +208,7 @@ describe('startRpcUsageTelemetry — the full scheduling lifecycle (timer + shut
     vi.useFakeTimers();
     const emitted: string[] = [];
     const handle = startRpcUsageTelemetry({
-      source: { drainRpcUsage: () => ({ byMethod: {}, lifetimeTotal: 3 }) },
+      source: { drainRpcUsage: () => ({ byMethod: {}, ethCallByConsumer: {}, lifetimeTotal: 3 }) },
       emit: (l) => emitted.push(l),
       windowSeconds: 60,
     });

--- a/packages/cli/vitest.unit.config.ts
+++ b/packages/cli/vitest.unit.config.ts
@@ -53,6 +53,7 @@ export default defineConfig({
           'test/skill-endpoint.test.ts',
           // R6-B — metric COUNT getter TTL memo. Pure logic, no hardhat.
           'test/metrics-queries.test.ts',
+          'test/rpc-usage-log.test.ts',
           // RFC 120 / plan PR 1 + 2 — Blazegraph support. Pure logic
           // (mocked fetch + in-memory config); cheap to keep in the
           // fast unit lane.

--- a/packages/node-ui/src/chain-cursor-stores.ts
+++ b/packages/node-ui/src/chain-cursor-stores.ts
@@ -1,0 +1,125 @@
+import Database from 'better-sqlite3';
+import type { DashboardDB } from './db.js';
+
+function parsePositiveSafeInteger(value: number | string | undefined): number | undefined {
+  if (value == null) return undefined;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+class SettingsPositiveIntegerCursorStore {
+  constructor(private readonly db: Database.Database) {}
+
+  load(key: string): number | undefined {
+    const row = this.db.prepare(
+      `SELECT value FROM settings WHERE key = ?`,
+    ).get(key) as { value: string } | undefined;
+    return parsePositiveSafeInteger(row?.value);
+  }
+
+  save(key: string, value: number): void {
+    if (!Number.isSafeInteger(value) || value <= 0) return;
+    this.db.prepare(
+      `INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)`,
+    ).run(key, String(value));
+  }
+}
+
+class RuntimePositiveIntegerCursorStore {
+  constructor(
+    private readonly db: Database.Database,
+    private readonly namespace: string,
+  ) {}
+
+  load(scope: string, key: string): number | undefined {
+    const row = this.db.prepare(
+      `SELECT value FROM runtime_cursors WHERE namespace = ? AND scope = ? AND key = ?`,
+    ).get(this.namespace, scope, key) as { value: number } | undefined;
+    return parsePositiveSafeInteger(row?.value);
+  }
+
+  save(scope: string, key: string, value: number): void {
+    if (!Number.isSafeInteger(value) || value <= 0) return;
+    this.db.prepare(`
+      INSERT INTO runtime_cursors (namespace, scope, key, value, updated_at)
+      VALUES (?, ?, ?, ?, ?)
+      ON CONFLICT(namespace, scope, key) DO UPDATE SET
+        value = excluded.value,
+        updated_at = excluded.updated_at
+    `).run(this.namespace, scope, key, value, Date.now());
+  }
+}
+
+/**
+ * SQLite-backed lane cursor store for `ChainEventPoller`.
+ *
+ * `scope` should include the effective chain/deployment identity so a node-home
+ * reused across networks never applies an old lane cursor to a different chain.
+ */
+export class SqliteChainEventCursorStore {
+  private readonly cursors: RuntimePositiveIntegerCursorStore;
+  private readonly legacyCursors: SettingsPositiveIntegerCursorStore;
+  private readonly scope: string;
+
+  constructor(dashboard: DashboardDB, options: { scope?: string } = {}) {
+    this.cursors = new RuntimePositiveIntegerCursorStore(dashboard.db, 'chainEventPoller.cursor');
+    this.legacyCursors = new SettingsPositiveIntegerCursorStore(dashboard.db);
+    this.scope = options.scope ?? 'default';
+  }
+
+  async loadLane(lane: string): Promise<number | undefined> {
+    return this.cursors.load(this.scope, lane) ?? this.legacyCursors.load(this.legacyKey(lane));
+  }
+
+  async saveLane(lane: string, blockNumber: number): Promise<void> {
+    this.cursors.save(this.scope, lane, blockNumber);
+  }
+
+  private legacyKey(lane: string): string {
+    return `chainEventPoller.cursor:${this.scope}:${lane}`;
+  }
+}
+
+/**
+ * SQLite-backed ContextGraphNameRegistry scan cursor.
+ *
+ * The value is the next unbuffered block after a successfully scanned
+ * contiguous prefix. It is keyed by chain/deployment/registry address; corrupt
+ * values are ignored by returning `undefined`, which fails closed to the
+ * historical scan path.
+ */
+export class SqliteContextGraphRegistryScanCursorStore {
+  private readonly cursors: RuntimePositiveIntegerCursorStore;
+  private readonly legacyCursors: SettingsPositiveIntegerCursorStore;
+
+  constructor(dashboard: DashboardDB) {
+    this.cursors = new RuntimePositiveIntegerCursorStore(dashboard.db, 'contextGraphRegistryScan.cursor');
+    this.legacyCursors = new SettingsPositiveIntegerCursorStore(dashboard.db);
+  }
+
+  async load(key: { chainId: string; deploymentId: string; registryAddress: string }): Promise<number | undefined> {
+    return this.cursors.load(this.scope(key), this.registryKey(key))
+      ?? this.legacyCursors.load(this.legacyKey(key));
+  }
+
+  async save(key: { chainId: string; deploymentId: string; registryAddress: string }, nextBlock: number): Promise<void> {
+    this.cursors.save(this.scope(key), this.registryKey(key), nextBlock);
+  }
+
+  private scope(key: { chainId: string; deploymentId: string }): string {
+    return `${key.chainId}:${key.deploymentId}`;
+  }
+
+  private registryKey(key: { registryAddress: string }): string {
+    return key.registryAddress.toLowerCase();
+  }
+
+  private legacyKey(key: { chainId: string; deploymentId: string; registryAddress: string }): string {
+    return [
+      'contextGraphRegistryScan.cursor',
+      key.chainId,
+      key.deploymentId,
+      key.registryAddress.toLowerCase(),
+    ].join(':');
+  }
+}

--- a/packages/node-ui/src/db.ts
+++ b/packages/node-ui/src/db.ts
@@ -10,7 +10,12 @@ import {
   type ProtocolOutboxStore,
 } from '@origintrail-official/dkg-core';
 
-const SCHEMA_VERSION = 21;
+export {
+  SqliteChainEventCursorStore,
+  SqliteContextGraphRegistryScanCursorStore,
+} from './chain-cursor-stores.js';
+
+const SCHEMA_VERSION = 22;
 // Default operator retention. Lowered from 90 → 14 days on V15 (2026-05) after
 // a production incident in which the `logs` table + its FTS5 shadow tables
 // grew to ~9 GB on a 12-day-old node and corrupted the SQLite page (header
@@ -790,6 +795,23 @@ export class DashboardDB {
         );
         CREATE INDEX IF NOT EXISTS idx_sync_checkpoints_expires_at
           ON sync_checkpoints(expires_at);
+      `);
+    }
+
+    if (version < 22) {
+      this.db.exec(`
+        CREATE TABLE IF NOT EXISTS runtime_cursors (
+          namespace TEXT NOT NULL,
+          scope TEXT NOT NULL,
+          key TEXT NOT NULL,
+          value INTEGER NOT NULL CHECK (value > 0),
+          updated_at INTEGER NOT NULL,
+          PRIMARY KEY (namespace, scope, key)
+        );
+      `);
+      this.db.exec(`
+        CREATE INDEX IF NOT EXISTS idx_runtime_cursors_namespace_scope
+          ON runtime_cursors(namespace, scope);
       `);
     }
 

--- a/packages/node-ui/src/index.ts
+++ b/packages/node-ui/src/index.ts
@@ -12,6 +12,10 @@ export {
   buildActivityDigestKey,
   parseActivityDigestKey,
 } from './db.js';
+export {
+  SqliteChainEventCursorStore,
+  SqliteContextGraphRegistryScanCursorStore,
+} from './chain-cursor-stores.js';
 export type {
   DashboardDBOptions,
   MetricSnapshotRow,

--- a/packages/node-ui/src/ui/views/project/components/entities.tsx
+++ b/packages/node-ui/src/ui/views/project/components/entities.tsx
@@ -580,10 +580,24 @@ export function AssertionsList({ contextGraphId, layer, onComplete, scrollKey }:
           {busy === '__all__' ? '...' : actionAllLabel}
         </button>
       </div>
-      {result && <div style={{ padding: '6px 16px', fontSize: 11, color: 'var(--text-success)' }}>✓ {result}</div>}
-      {error && <div style={{ padding: '6px 16px', fontSize: 11, color: 'var(--text-danger)' }}>✕ {error}</div>}
+      {result && (
+        <div
+          data-testid={layer === 'wm' ? 'assertion-promote-result' : 'assertion-publish-result'}
+          style={{ padding: '6px 16px', fontSize: 11, color: 'var(--text-success)' }}
+        >
+          ✓ {result}
+        </div>
+      )}
+      {error && (
+        <div
+          data-testid={layer === 'wm' ? 'assertion-promote-result' : 'assertion-publish-result'}
+          style={{ padding: '6px 16px', fontSize: 11, color: 'var(--text-danger)' }}
+        >
+          ✕ {error}
+        </div>
+      )}
       {assertions.map(a => (
-        <div key={a.graphUri} className="v10-item-row">
+        <div key={a.graphUri} className="v10-item-row" data-testid="assertion-list-row">
           <span className="v10-item-icon">▤</span>
           <div className="v10-item-info">
             <div className="v10-item-name" style={{ fontFamily: 'var(--font-mono)', fontSize: 11 }}>{a.name}</div>
@@ -609,6 +623,7 @@ export function AssertionsList({ contextGraphId, layer, onComplete, scrollKey }:
             </div>
           </div>
           <button
+            data-testid="assertion-row-action"
             className={`v10-layer-expand-footer-btn ${layer === 'wm' ? 'promote' : 'publish'}`}
             disabled={busy !== null}
             onClick={ev => { ev.stopPropagation(); handlePromote(a); }}

--- a/packages/node-ui/test/db.test.ts
+++ b/packages/node-ui/test/db.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import Database from 'better-sqlite3';
-import { DashboardDB, SqliteKaNumberStore, SqliteSyncCheckpointStore, buildActivityDigestKey, ACTIVITY_DIGEST_WINDOW_MS, ASSERTION_ACTIVITY_TYPE } from '../src/db.js';
+import { DashboardDB, SqliteChainEventCursorStore, SqliteContextGraphRegistryScanCursorStore, SqliteKaNumberStore, SqliteSyncCheckpointStore, buildActivityDigestKey, ACTIVITY_DIGEST_WINDOW_MS, ASSERTION_ACTIVITY_TYPE } from '../src/db.js';
 
 let db: DashboardDB;
 let dir: string;
@@ -86,7 +86,7 @@ describe('DashboardDB — metric snapshots', () => {
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(21);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(22);
 
     const cols = (db.db.prepare('PRAGMA table_info(metric_snapshots)').all() as Array<{ name: string }>)
       .map((c) => c.name);
@@ -142,7 +142,7 @@ describe('DashboardDB — metric snapshots', () => {
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(21);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(22);
 
     const newSnapshotCols = (db.db.prepare('PRAGMA table_info(metric_snapshots)').all() as { name: string }[])
       .map(c => c.name);
@@ -545,7 +545,7 @@ describe('DashboardDB — V15 migration: drop FTS5 logs index', () => {
 
     const upgraded = new DashboardDB({ dataDir: upgradeDir });
     try {
-      expect(upgraded.db.pragma('user_version', { simple: true })).toBe(21);
+      expect(upgraded.db.pragma('user_version', { simple: true })).toBe(22);
 
       const ftsTables = upgraded.db.prepare(
         `SELECT name FROM sqlite_master WHERE type IN ('table','view') AND name LIKE 'logs_fts%'`,
@@ -785,7 +785,7 @@ describe('DashboardDB — V17 subscription columns migration (Phase B)', () => {
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(21);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(22);
 
     const cols = (db.db.prepare('PRAGMA table_info(context_graph_subscriptions)').all() as Array<{ name: string }>)
       .map((c) => c.name);
@@ -806,7 +806,7 @@ describe('DashboardDB — V17 subscription columns migration (Phase B)', () => {
       .map((c) => c.name);
     expect(cols).toContain('on_chain_hash');
     expect(cols).toContain('last_reconciled_ordinal');
-    expect(db.db.pragma('user_version', { simple: true })).toBe(21);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(22);
   });
 });
 
@@ -890,7 +890,7 @@ describe('DashboardDB — V19 core_hosted column migration (Phase D)', () => {
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(21);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(22);
 
     const cols = (db.db.prepare('PRAGMA table_info(context_graph_subscriptions)').all() as Array<{ name: string }>)
       .map((c) => c.name);
@@ -919,7 +919,7 @@ describe('DashboardDB — V20 ka_numbers table migration (B2 KA-number allocator
   });
 
   it('fresh install lands at the current schema and already carries the ka_numbers table', () => {
-    expect(db.db.pragma('user_version', { simple: true })).toBe(21);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(22);
 
     const table = db.db.prepare(
       "SELECT name FROM sqlite_master WHERE type='table' AND name='ka_numbers'",
@@ -956,7 +956,7 @@ describe('DashboardDB — V20 ka_numbers table migration (B2 KA-number allocator
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(21);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(22);
 
     const table = db.db.prepare(
       "SELECT name FROM sqlite_master WHERE type='table' AND name='ka_numbers'",
@@ -1049,7 +1049,7 @@ describe('DashboardDB — V21 sync_checkpoints table (A3 sync resume)', () => {
   });
 
   it('fresh install carries the sync_checkpoints table and expiry index', () => {
-    expect(db.db.pragma('user_version', { simple: true })).toBe(21);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(22);
     const tables = db.db.prepare(
       `SELECT name FROM sqlite_master WHERE type='table' AND name='sync_checkpoints'`,
     ).all();
@@ -1115,10 +1115,98 @@ describe('DashboardDB — V21 sync_checkpoints table (A3 sync resume)', () => {
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(21);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(22);
     expect(db.db.prepare(
       `SELECT name FROM sqlite_master WHERE type='table' AND name='sync_checkpoints'`,
     ).all()).toHaveLength(1);
+    expect(db.db.prepare(
+      `SELECT name FROM sqlite_master WHERE type='table' AND name='runtime_cursors'`,
+    ).all()).toHaveLength(1);
+  });
+});
+
+describe('DashboardDB — chain RPC cursor stores', () => {
+  it('persists chain-event lane cursors by scope across reopen', async () => {
+    const store = new SqliteChainEventCursorStore(db, { scope: 'evm:1:hub=0xabc' });
+
+    await store.saveLane('contextGraphDiscovery', 1234);
+    await store.saveLane('vmReconcile', 5678);
+    expect(await store.loadLane('contextGraphDiscovery')).toBe(1234);
+    expect(await store.loadLane('vmReconcile')).toBe(5678);
+    expect(db.db.prepare(
+      `SELECT value FROM runtime_cursors
+       WHERE namespace = 'chainEventPoller.cursor'
+         AND scope = 'evm:1:hub=0xabc'
+         AND key = 'contextGraphDiscovery'`,
+    ).get()).toEqual({ value: 1234 });
+    expect(await new SqliteChainEventCursorStore(db, { scope: 'evm:2:hub=0xabc' }).loadLane('contextGraphDiscovery')).toBeUndefined();
+
+    await store.saveLane('contextGraphDiscovery', 0);
+    await store.saveLane('contextGraphDiscovery', -1);
+    await store.saveLane('contextGraphDiscovery', 1.5);
+    await store.saveLane('contextGraphDiscovery', Number.MAX_SAFE_INTEGER + 1);
+    expect(await store.loadLane('contextGraphDiscovery')).toBe(1234);
+
+    db.db.prepare(
+      `INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)`,
+    ).run('chainEventPoller.cursor:evm:1:hub=0xabc:badLane', '0');
+    expect(await store.loadLane('badLane')).toBeUndefined();
+    db.db.prepare(
+      `INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)`,
+    ).run('chainEventPoller.cursor:evm:1:hub=0xabc:legacyLane', '2468');
+    expect(await store.loadLane('legacyLane')).toBe(2468);
+
+    db.close();
+    db = new DashboardDB({ dataDir: dir });
+    const reopened = new SqliteChainEventCursorStore(db, { scope: 'evm:1:hub=0xabc' });
+    expect(await reopened.loadLane('contextGraphDiscovery')).toBe(1234);
+    expect(await reopened.loadLane('vmReconcile')).toBe(5678);
+    expect(await reopened.loadLane('legacyLane')).toBe(2468);
+  });
+
+  it('persists registry scan cursors by deployment key and ignores corrupt values', async () => {
+    const store = new SqliteContextGraphRegistryScanCursorStore(db);
+    const key = {
+      chainId: 'evm:1',
+      deploymentId: 'evm:1:hub=0xabc',
+      registryAddress: '0x3333333333333333333333333333333333333333',
+    };
+
+    await store.save(key, 5000);
+    expect(await store.load(key)).toBe(5000);
+    expect(db.db.prepare(
+      `SELECT value FROM runtime_cursors
+       WHERE namespace = 'contextGraphRegistryScan.cursor'
+         AND scope = ?
+         AND key = ?`,
+    ).get(`${key.chainId}:${key.deploymentId}`, key.registryAddress.toLowerCase())).toEqual({ value: 5000 });
+    await store.save(key, 0);
+    await store.save(key, -1);
+    await store.save(key, 1.5);
+    await store.save(key, Number.MAX_SAFE_INTEGER + 1);
+    expect(await store.load(key)).toBe(5000);
+    expect(await store.load({ ...key, registryAddress: '0x4444444444444444444444444444444444444444' })).toBeUndefined();
+
+    db.db.prepare(
+      `INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)`,
+    ).run(
+      `contextGraphRegistryScan.cursor:${key.chainId}:${key.deploymentId}:0x5555555555555555555555555555555555555555`,
+      'not-a-number',
+    );
+    expect(await store.load({ ...key, registryAddress: '0x5555555555555555555555555555555555555555' })).toBeUndefined();
+    db.db.prepare(
+      `INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)`,
+    ).run(
+      `contextGraphRegistryScan.cursor:${key.chainId}:${key.deploymentId}:0x6666666666666666666666666666666666666666`,
+      '6000',
+    );
+    expect(await store.load({ ...key, registryAddress: '0x6666666666666666666666666666666666666666' })).toBe(6000);
+
+    db.close();
+    db = new DashboardDB({ dataDir: dir });
+    const reopened = new SqliteContextGraphRegistryScanCursorStore(db);
+    expect(await reopened.load(key)).toBe(5000);
+    expect(await reopened.load({ ...key, registryAddress: '0x6666666666666666666666666666666666666666' })).toBe(6000);
   });
 });
 
@@ -1476,7 +1564,7 @@ describe('DashboardDB — V11→V13 chat schema migration chain', () => {
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(21);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(22);
 
     const cols = (db.db.prepare('PRAGMA table_info(chat_messages)').all() as Array<{ name: string }>)
       .map((c) => c.name);
@@ -1542,7 +1630,7 @@ describe('DashboardDB — V16 notifications.context_graph_id migration (A1)', ()
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(21);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(22);
 
     const cols = (db.db.prepare('PRAGMA table_info(notifications)').all() as Array<{ name: string }>)
       .map((c) => c.name);
@@ -1571,7 +1659,7 @@ describe('DashboardDB — V16 notifications.context_graph_id migration (A1)', ()
     const cols = (db.db.prepare('PRAGMA table_info(notifications)').all() as Array<{ name: string }>)
       .map((c) => c.name);
     expect(cols).toContain('context_graph_id');
-    expect(db.db.pragma('user_version', { simple: true })).toBe(21);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(22);
   });
 
   it('insertNotification writes context_graph_id to the column; omitted → NULL', () => {
@@ -1814,7 +1902,7 @@ describe('DashboardDB — replication telemetry (Phase F)', () => {
     raw.pragma('user_version = 17');
     raw.close();
     const upgraded = new DashboardDB({ dataDir: dir });
-    expect(upgraded.db.pragma('user_version', { simple: true })).toBe(21);
+    expect(upgraded.db.pragma('user_version', { simple: true })).toBe(22);
     // insert works → table exists
     upgraded.insertReplicationEvent({ ts: now, context_graph_id: 'cg', action: 'promote' });
     expect(upgraded.getReplicationSummary(60_000).promotes).toBe(1);

--- a/packages/node-ui/test/messenger-stores.test.ts
+++ b/packages/node-ui/test/messenger-stores.test.ts
@@ -45,9 +45,9 @@ describe('V12 migration', () => {
     // `message_idempotency` table. Both bumps are tested at the
     // DB layer in `db.test.ts`; this assertion just pins that
     // the substrate store fixtures are created against the
-    // current SCHEMA_VERSION (now 21 after A3 added durable
-    // `sync_checkpoints` at migration V21).
-    expect(db.db.pragma('user_version', { simple: true })).toBe(21);
+    // current SCHEMA_VERSION (now 22 after runtime cursors moved to a
+    // dedicated table).
+    expect(db.db.pragma('user_version', { simple: true })).toBe(22);
   });
 });
 

--- a/packages/publisher/src/chain-event-lane-cursor-store.ts
+++ b/packages/publisher/src/chain-event-lane-cursor-store.ts
@@ -1,0 +1,56 @@
+import type { ChainEventPollerLane } from './chain-event-lane-runner.js';
+
+/** Legacy aggregate cursor persistence for saving/loading one shared cursor. */
+export interface LegacyCursorPersistence {
+  load(): Promise<number | undefined>;
+  save(blockNumber: number): Promise<void>;
+}
+
+/** Lane-aware cursor persistence for saving/loading independent lane cursors. */
+export interface LaneCursorPersistence {
+  loadLane(lane: ChainEventPollerLane): Promise<number | undefined>;
+  saveLane(lane: ChainEventPollerLane, blockNumber: number): Promise<void>;
+}
+
+export type CursorPersistence = LegacyCursorPersistence | LaneCursorPersistence;
+
+export type LaneCursorStore =
+  | {
+      kind: 'lane';
+      loadLane(lane: ChainEventPollerLane): Promise<number | undefined>;
+      saveLane(lane: ChainEventPollerLane, blockNumber: number): Promise<void>;
+    }
+  | {
+      kind: 'legacy';
+      loadLegacyAggregate(): Promise<number | undefined>;
+      saveLegacyAggregate(blockNumber: number): Promise<void>;
+    };
+
+export function createLaneCursorStore(cursorPersistence?: CursorPersistence): LaneCursorStore | undefined {
+  if (!cursorPersistence) return undefined;
+  const maybeLane = cursorPersistence as Partial<LaneCursorPersistence>;
+  const hasLoadLane = typeof maybeLane.loadLane === 'function';
+  const hasSaveLane = typeof maybeLane.saveLane === 'function';
+  if (hasLoadLane || hasSaveLane) {
+    if (!hasLoadLane || !hasSaveLane) {
+      throw new Error('ChainEventPoller cursorPersistence must provide both loadLane and saveLane, or neither.');
+    }
+    const laneStore = cursorPersistence as LaneCursorPersistence;
+    return {
+      kind: 'lane',
+      loadLane: (lane) => laneStore.loadLane(lane),
+      saveLane: (lane, blockNumber) => laneStore.saveLane(lane, blockNumber),
+    };
+  }
+
+  const legacyStore = cursorPersistence as LegacyCursorPersistence;
+  let loaded: Promise<number | undefined> | undefined;
+  return {
+    kind: 'legacy',
+    loadLegacyAggregate: async () => {
+      loaded ??= legacyStore.load();
+      return loaded;
+    },
+    saveLegacyAggregate: (blockNumber) => legacyStore.save(blockNumber),
+  };
+}

--- a/packages/publisher/src/chain-event-lane-runner.ts
+++ b/packages/publisher/src/chain-event-lane-runner.ts
@@ -20,9 +20,13 @@ interface ChainEventPollerLaneState {
   headKnown: boolean;
   requiresFullHistory?: boolean;
   lastRunAt?: number;
+  failureBackoffMs?: number;
+  retryAfterMs?: number;
 }
 
 const DEFAULT_LIVE_SEED_LOOKBACK_BLOCKS = 500;
+const FAILURE_BACKOFF_INITIAL_MS = 60_000;
+const FAILURE_BACKOFF_MAX_MS = 5 * 60_000;
 
 export interface ChainEventPollerLaneSpec {
   name: ChainEventPollerLane;
@@ -177,6 +181,8 @@ export class ChainEventLaneRunner {
   }
 
   private laneDue(lane: ChainEventPollerLaneRuntime, now: number): boolean {
+    const retryAfterMs = lane.state.retryAfterMs;
+    if (retryAfterMs != null && now < retryAfterMs) return false;
     const lastRunAt = lane.state.lastRunAt;
     return lastRunAt == null || now - lastRunAt >= lane.spec.cadenceMs;
   }
@@ -266,13 +272,25 @@ export class ChainEventLaneRunner {
       }
 
       state.lastBlock = upperBound;
+      state.failureBackoffMs = undefined;
+      state.retryAfterMs = undefined;
       advanced = true;
     } catch (err) {
       this.log.error(ctx, `Poll lane ${lane.spec.name} failed: ${err instanceof Error ? err.message : String(err)}`);
+      this.backoffFailedLane(lane, now);
     } finally {
       state.lastRunAt = advanced && caughtUp ? now : undefined;
     }
     return { lane, blockNumber: state.lastBlock, advanced };
+  }
+
+  private backoffFailedLane(lane: ChainEventPollerLaneRuntime, now: number): void {
+    const previous = lane.state.failureBackoffMs;
+    const next = previous == null
+      ? Math.max(FAILURE_BACKOFF_INITIAL_MS, lane.spec.cadenceMs)
+      : Math.min(previous * 2, FAILURE_BACKOFF_MAX_MS);
+    lane.state.failureBackoffMs = next;
+    lane.state.retryAfterMs = now + next;
   }
 
   private applyHistoryModeTransition(

--- a/packages/publisher/src/chain-event-lane-runner.ts
+++ b/packages/publisher/src/chain-event-lane-runner.ts
@@ -27,6 +27,11 @@ const DEFAULT_LIVE_SEED_LOOKBACK_BLOCKS = 500;
 const FAILURE_BACKOFF_INITIAL_MS = 60_000;
 const FAILURE_BACKOFF_MAX_MS = 5 * 60_000;
 
+export interface ChainEventPollerFailureBackoffPolicy {
+  initialMs?: number;
+  maxMs?: number;
+}
+
 export interface ChainEventPollerLaneSpec {
   name: ChainEventPollerLane;
   enabled(): boolean;
@@ -34,9 +39,15 @@ export interface ChainEventPollerLaneSpec {
   requiresFullHistory(): boolean;
   canUseLegacyAggregateCursor?(): boolean;
   liveSeedLookbackBlocks?: number;
+  failureBackoff?: ChainEventPollerFailureBackoffPolicy;
   cadenceMs: number;
   dispatch(event: ChainEvent, ctx: OperationContext): Promise<void>;
   onBackfillFromGenesis?(ctx: OperationContext): void;
+}
+
+interface NormalizedFailureBackoffPolicy {
+  initialMs: number;
+  maxMs: number;
 }
 
 interface ChainEventPollerLaneRuntime {
@@ -46,6 +57,7 @@ interface ChainEventPollerLaneRuntime {
   requiresFullHistory: boolean;
   canUseLegacyAggregateCursor: boolean;
   liveSeedLookbackBlocks: number;
+  failureBackoff: NormalizedFailureBackoffPolicy;
 }
 
 interface ChainEventPollerLaneScanResult {
@@ -53,6 +65,11 @@ interface ChainEventPollerLaneScanResult {
   blockNumber: number;
   advanced: boolean;
 }
+
+type ChainEventLaneScheduleOutcome =
+  | { kind: 'noWork'; now: number }
+  | { kind: 'success'; now: number; caughtUp: boolean }
+  | { kind: 'failure'; now: number };
 
 export interface ChainEventLaneRunnerConfig {
   chain: ChainAdapter;
@@ -126,6 +143,7 @@ export class ChainEventLaneRunner {
         requiresFullHistory,
         canUseLegacyAggregateCursor: spec.canUseLegacyAggregateCursor?.() ?? !requiresFullHistory,
         liveSeedLookbackBlocks: this.liveSeedLookbackBlocks(spec),
+        failureBackoff: this.failureBackoffPolicy(spec),
       }];
     });
   }
@@ -135,6 +153,24 @@ export class ChainEventLaneRunner {
     return Number.isFinite(lookback) && lookback >= 0
       ? Math.floor(lookback)
       : DEFAULT_LIVE_SEED_LOOKBACK_BLOCKS;
+  }
+
+  private failureBackoffPolicy(spec: ChainEventPollerLaneSpec): NormalizedFailureBackoffPolicy {
+    const initialMs = this.scheduleDelayMs(
+      spec.failureBackoff?.initialMs,
+      Math.max(FAILURE_BACKOFF_INITIAL_MS, spec.cadenceMs),
+    );
+    const maxMs = Math.max(
+      initialMs,
+      this.scheduleDelayMs(spec.failureBackoff?.maxMs, FAILURE_BACKOFF_MAX_MS),
+    );
+    return { initialMs, maxMs };
+  }
+
+  private scheduleDelayMs(value: number | undefined, fallback: number): number {
+    return Number.isFinite(value) && value! >= 0
+      ? Math.floor(value!)
+      : fallback;
   }
 
   private stateFor(lane: ChainEventPollerLane): ChainEventPollerLaneState {
@@ -251,7 +287,7 @@ export class ChainEventLaneRunner {
       : fromBlock + this.maxRange - 1;
 
     if (fromBlock > upperBound) {
-      state.nextRunAtMs = now + lane.spec.cadenceMs;
+      this.applyLaneSchedule(lane, { kind: 'noWork', now });
       return { lane, blockNumber: state.lastBlock, advanced: false };
     }
 
@@ -269,26 +305,33 @@ export class ChainEventLaneRunner {
       }
 
       state.lastBlock = upperBound;
-      state.failureBackoffMs = undefined;
       advanced = true;
+      this.applyLaneSchedule(lane, { kind: 'success', now, caughtUp });
     } catch (err) {
       this.log.error(ctx, `Poll lane ${lane.spec.name} failed: ${err instanceof Error ? err.message : String(err)}`);
-      this.backoffFailedLane(lane, now);
-    } finally {
-      if (advanced) {
-        state.nextRunAtMs = caughtUp ? now + lane.spec.cadenceMs : undefined;
-      }
+      this.applyLaneSchedule(lane, { kind: 'failure', now });
     }
     return { lane, blockNumber: state.lastBlock, advanced };
   }
 
-  private backoffFailedLane(lane: ChainEventPollerLaneRuntime, now: number): void {
-    const previous = lane.state.failureBackoffMs;
+  private applyLaneSchedule(lane: ChainEventPollerLaneRuntime, outcome: ChainEventLaneScheduleOutcome): void {
+    const state = lane.state;
+    if (outcome.kind === 'noWork') {
+      state.nextRunAtMs = outcome.now + lane.spec.cadenceMs;
+      return;
+    }
+    if (outcome.kind === 'success') {
+      state.failureBackoffMs = undefined;
+      state.nextRunAtMs = outcome.caughtUp ? outcome.now + lane.spec.cadenceMs : undefined;
+      return;
+    }
+
+    const previous = state.failureBackoffMs;
     const next = previous == null
-      ? Math.max(FAILURE_BACKOFF_INITIAL_MS, lane.spec.cadenceMs)
-      : Math.min(previous * 2, FAILURE_BACKOFF_MAX_MS);
-    lane.state.failureBackoffMs = next;
-    lane.state.nextRunAtMs = now + next;
+      ? lane.failureBackoff.initialMs
+      : Math.min(previous * 2, lane.failureBackoff.maxMs);
+    state.failureBackoffMs = next;
+    state.nextRunAtMs = outcome.now + next;
   }
 
   private applyHistoryModeTransition(

--- a/packages/publisher/src/chain-event-lane-runner.ts
+++ b/packages/publisher/src/chain-event-lane-runner.ts
@@ -27,11 +27,6 @@ const DEFAULT_LIVE_SEED_LOOKBACK_BLOCKS = 500;
 const FAILURE_BACKOFF_INITIAL_MS = 60_000;
 const FAILURE_BACKOFF_MAX_MS = 5 * 60_000;
 
-export interface ChainEventPollerFailureBackoffPolicy {
-  initialMs?: number;
-  maxMs?: number;
-}
-
 export interface ChainEventPollerLaneSpec {
   name: ChainEventPollerLane;
   enabled(): boolean;
@@ -39,15 +34,9 @@ export interface ChainEventPollerLaneSpec {
   requiresFullHistory(): boolean;
   canUseLegacyAggregateCursor?(): boolean;
   liveSeedLookbackBlocks?: number;
-  failureBackoff?: ChainEventPollerFailureBackoffPolicy;
   cadenceMs: number;
   dispatch(event: ChainEvent, ctx: OperationContext): Promise<void>;
   onBackfillFromGenesis?(ctx: OperationContext): void;
-}
-
-interface NormalizedFailureBackoffPolicy {
-  initialMs: number;
-  maxMs: number;
 }
 
 interface ChainEventPollerLaneRuntime {
@@ -57,7 +46,6 @@ interface ChainEventPollerLaneRuntime {
   requiresFullHistory: boolean;
   canUseLegacyAggregateCursor: boolean;
   liveSeedLookbackBlocks: number;
-  failureBackoff: NormalizedFailureBackoffPolicy;
 }
 
 interface ChainEventPollerLaneScanResult {
@@ -143,7 +131,6 @@ export class ChainEventLaneRunner {
         requiresFullHistory,
         canUseLegacyAggregateCursor: spec.canUseLegacyAggregateCursor?.() ?? !requiresFullHistory,
         liveSeedLookbackBlocks: this.liveSeedLookbackBlocks(spec),
-        failureBackoff: this.failureBackoffPolicy(spec),
       }];
     });
   }
@@ -153,18 +140,6 @@ export class ChainEventLaneRunner {
     return Number.isFinite(lookback) && lookback >= 0
       ? Math.floor(lookback)
       : DEFAULT_LIVE_SEED_LOOKBACK_BLOCKS;
-  }
-
-  private failureBackoffPolicy(spec: ChainEventPollerLaneSpec): NormalizedFailureBackoffPolicy {
-    const initialMs = this.scheduleDelayMs(
-      spec.failureBackoff?.initialMs,
-      Math.max(FAILURE_BACKOFF_INITIAL_MS, spec.cadenceMs),
-    );
-    const maxMs = Math.max(
-      initialMs,
-      this.scheduleDelayMs(spec.failureBackoff?.maxMs, FAILURE_BACKOFF_MAX_MS),
-    );
-    return { initialMs, maxMs };
   }
 
   private scheduleDelayMs(value: number | undefined, fallback: number): number {
@@ -328,8 +303,8 @@ export class ChainEventLaneRunner {
 
     const previous = state.failureBackoffMs;
     const next = previous == null
-      ? lane.failureBackoff.initialMs
-      : Math.min(previous * 2, lane.failureBackoff.maxMs);
+      ? Math.max(FAILURE_BACKOFF_INITIAL_MS, lane.spec.cadenceMs)
+      : Math.min(previous * 2, FAILURE_BACKOFF_MAX_MS);
     state.failureBackoffMs = next;
     state.nextRunAtMs = outcome.now + next;
   }

--- a/packages/publisher/src/chain-event-lane-runner.ts
+++ b/packages/publisher/src/chain-event-lane-runner.ts
@@ -19,9 +19,8 @@ interface ChainEventPollerLaneState {
   lastBlock: number;
   headKnown: boolean;
   requiresFullHistory?: boolean;
-  lastRunAt?: number;
+  nextRunAtMs?: number;
   failureBackoffMs?: number;
-  retryAfterMs?: number;
 }
 
 const DEFAULT_LIVE_SEED_LOOKBACK_BLOCKS = 500;
@@ -181,10 +180,8 @@ export class ChainEventLaneRunner {
   }
 
   private laneDue(lane: ChainEventPollerLaneRuntime, now: number): boolean {
-    const retryAfterMs = lane.state.retryAfterMs;
-    if (retryAfterMs != null && now < retryAfterMs) return false;
-    const lastRunAt = lane.state.lastRunAt;
-    return lastRunAt == null || now - lastRunAt >= lane.spec.cadenceMs;
+    const nextRunAtMs = lane.state.nextRunAtMs;
+    return nextRunAtMs == null || now >= nextRunAtMs;
   }
 
   private async persistScanResults(
@@ -254,7 +251,7 @@ export class ChainEventLaneRunner {
       : fromBlock + this.maxRange - 1;
 
     if (fromBlock > upperBound) {
-      state.lastRunAt = now;
+      state.nextRunAtMs = now + lane.spec.cadenceMs;
       return { lane, blockNumber: state.lastBlock, advanced: false };
     }
 
@@ -273,13 +270,14 @@ export class ChainEventLaneRunner {
 
       state.lastBlock = upperBound;
       state.failureBackoffMs = undefined;
-      state.retryAfterMs = undefined;
       advanced = true;
     } catch (err) {
       this.log.error(ctx, `Poll lane ${lane.spec.name} failed: ${err instanceof Error ? err.message : String(err)}`);
       this.backoffFailedLane(lane, now);
     } finally {
-      state.lastRunAt = advanced && caughtUp ? now : undefined;
+      if (advanced) {
+        state.nextRunAtMs = caughtUp ? now + lane.spec.cadenceMs : undefined;
+      }
     }
     return { lane, blockNumber: state.lastBlock, advanced };
   }
@@ -290,7 +288,7 @@ export class ChainEventLaneRunner {
       ? Math.max(FAILURE_BACKOFF_INITIAL_MS, lane.spec.cadenceMs)
       : Math.min(previous * 2, FAILURE_BACKOFF_MAX_MS);
     lane.state.failureBackoffMs = next;
-    lane.state.retryAfterMs = now + next;
+    lane.state.nextRunAtMs = now + next;
   }
 
   private applyHistoryModeTransition(

--- a/packages/publisher/src/chain-event-lane-runner.ts
+++ b/packages/publisher/src/chain-event-lane-runner.ts
@@ -142,12 +142,6 @@ export class ChainEventLaneRunner {
       : DEFAULT_LIVE_SEED_LOOKBACK_BLOCKS;
   }
 
-  private scheduleDelayMs(value: number | undefined, fallback: number): number {
-    return Number.isFinite(value) && value! >= 0
-      ? Math.floor(value!)
-      : fallback;
-  }
-
   private stateFor(lane: ChainEventPollerLane): ChainEventPollerLaneState {
     let state = this.laneState.get(lane);
     if (!state) {

--- a/packages/publisher/src/chain-event-lane-runner.ts
+++ b/packages/publisher/src/chain-event-lane-runner.ts
@@ -1,0 +1,298 @@
+import type { ChainAdapter, ChainEvent, EventFilter } from '@origintrail-official/dkg-chain';
+import { createOperationContext, type Logger, type OperationContext } from '@origintrail-official/dkg-core';
+import {
+  createLaneCursorStore,
+  type CursorPersistence,
+  type LaneCursorStore,
+} from './chain-event-lane-cursor-store.js';
+
+export type ChainEventPollerLane =
+  | 'publish'
+  | 'allocatorReconcile'
+  | 'contextGraphDiscovery'
+  | 'vmReconcile'
+  | 'collectionUpdates'
+  | 'allowListUpdates'
+  | 'profileEvents';
+
+interface ChainEventPollerLaneState {
+  lastBlock: number;
+  headKnown: boolean;
+  requiresFullHistory?: boolean;
+  lastRunAt?: number;
+}
+
+const DEFAULT_LIVE_SEED_LOOKBACK_BLOCKS = 500;
+
+export interface ChainEventPollerLaneSpec {
+  name: ChainEventPollerLane;
+  enabled(): boolean;
+  eventTypes(): readonly string[];
+  requiresFullHistory(): boolean;
+  canUseLegacyAggregateCursor?(): boolean;
+  liveSeedLookbackBlocks?: number;
+  cadenceMs: number;
+  dispatch(event: ChainEvent, ctx: OperationContext): Promise<void>;
+  onBackfillFromGenesis?(ctx: OperationContext): void;
+}
+
+interface ChainEventPollerLaneRuntime {
+  spec: ChainEventPollerLaneSpec;
+  state: ChainEventPollerLaneState;
+  eventTypes: string[];
+  requiresFullHistory: boolean;
+  canUseLegacyAggregateCursor: boolean;
+  liveSeedLookbackBlocks: number;
+}
+
+interface ChainEventPollerLaneScanResult {
+  lane: ChainEventPollerLaneRuntime;
+  blockNumber: number;
+  advanced: boolean;
+}
+
+export interface ChainEventLaneRunnerConfig {
+  chain: ChainAdapter;
+  lanes: readonly ChainEventPollerLaneSpec[];
+  maxRange: number;
+  clock: () => number;
+  log: Logger;
+  cursorPersistence?: CursorPersistence;
+}
+
+/**
+ * Owns the lane scheduler, cursor migration/restoration, head seeding, and
+ * block-window scanning for `ChainEventPoller`.
+ */
+export class ChainEventLaneRunner {
+  private readonly chain: ChainAdapter;
+  private readonly lanes: readonly ChainEventPollerLaneSpec[];
+  private readonly maxRange: number;
+  private readonly clock: () => number;
+  private readonly log: Logger;
+  private readonly cursorStore?: LaneCursorStore;
+  private readonly laneState = new Map<ChainEventPollerLane, ChainEventPollerLaneState>();
+  private readonly restoredLanes = new Set<ChainEventPollerLane>();
+
+  constructor(config: ChainEventLaneRunnerConfig) {
+    this.chain = config.chain;
+    this.lanes = config.lanes;
+    this.maxRange = config.maxRange;
+    this.clock = config.clock;
+    this.log = config.log;
+    this.cursorStore = createLaneCursorStore(config.cursorPersistence);
+  }
+
+  async restoreCurrentlyActive(ctx: OperationContext): Promise<void> {
+    await this.restoreLaneCursors(this.activeLaneSpecs(), ctx);
+  }
+
+  async poll(): Promise<void> {
+    const ctx = createOperationContext('publish');
+    const activeLanes = this.activeLaneSpecs();
+    if (activeLanes.length === 0) return;
+
+    await this.restoreLaneCursors(activeLanes, ctx);
+
+    const now = this.clock();
+    const dueLanes = activeLanes.filter((lane) => this.laneDue(lane, now));
+    if (dueLanes.length === 0) return;
+
+    let head: number | undefined;
+    if (this.chain.getBlockNumber) {
+      try { head = await this.chain.getBlockNumber(); } catch { /* unavailable */ }
+    }
+
+    const scanResults: ChainEventPollerLaneScanResult[] = [];
+    for (const lane of dueLanes) {
+      scanResults.push(await this.scanLane(lane, head, now, ctx));
+    }
+    await this.persistScanResults(scanResults, activeLanes);
+  }
+
+  private activeLaneSpecs(): ChainEventPollerLaneRuntime[] {
+    return this.lanes.flatMap((spec) => {
+      if (!spec.enabled()) return [];
+      const eventTypes = [...spec.eventTypes()];
+      if (eventTypes.length === 0) return [];
+      const requiresFullHistory = spec.requiresFullHistory();
+      return [{
+        spec,
+        state: this.stateFor(spec.name),
+        eventTypes,
+        requiresFullHistory,
+        canUseLegacyAggregateCursor: spec.canUseLegacyAggregateCursor?.() ?? !requiresFullHistory,
+        liveSeedLookbackBlocks: this.liveSeedLookbackBlocks(spec),
+      }];
+    });
+  }
+
+  private liveSeedLookbackBlocks(spec: ChainEventPollerLaneSpec): number {
+    const lookback = spec.liveSeedLookbackBlocks ?? DEFAULT_LIVE_SEED_LOOKBACK_BLOCKS;
+    return Number.isFinite(lookback) && lookback >= 0
+      ? Math.floor(lookback)
+      : DEFAULT_LIVE_SEED_LOOKBACK_BLOCKS;
+  }
+
+  private stateFor(lane: ChainEventPollerLane): ChainEventPollerLaneState {
+    let state = this.laneState.get(lane);
+    if (!state) {
+      state = { lastBlock: 0, headKnown: false };
+      this.laneState.set(lane, state);
+    }
+    return state;
+  }
+
+  private async restoreLaneCursors(
+    activeLanes: readonly ChainEventPollerLaneRuntime[],
+    ctx: OperationContext,
+  ): Promise<void> {
+    if (!this.cursorStore) return;
+    for (const lane of activeLanes) {
+      if (this.restoredLanes.has(lane.spec.name)) continue;
+      await this.restoreLaneCursor(lane, ctx);
+    }
+  }
+
+  private async restoreLaneCursor(lane: ChainEventPollerLaneRuntime, ctx: OperationContext): Promise<void> {
+    if (!this.cursorStore) return;
+    try {
+      const saved = await this.loadPersistedLaneCursor(lane);
+      if (saved != null && saved > 0) {
+        lane.state.lastBlock = saved;
+        this.log.info(ctx, `Restored poller cursor from persistence: lane=${lane.spec.name} block ${saved}`);
+      }
+    } catch (err) {
+      this.log.warn(ctx, `Failed to load persisted cursor: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      this.restoredLanes.add(lane.spec.name);
+    }
+  }
+
+  private async loadPersistedLaneCursor(lane: ChainEventPollerLaneRuntime): Promise<number | undefined> {
+    if (!this.cursorStore) return undefined;
+    if (this.cursorStore.kind === 'lane') return this.cursorStore.loadLane(lane.spec.name);
+    if (lane.canUseLegacyAggregateCursor) return this.cursorStore.loadLegacyAggregate();
+    return undefined;
+  }
+
+  private laneDue(lane: ChainEventPollerLaneRuntime, now: number): boolean {
+    const lastRunAt = lane.state.lastRunAt;
+    return lastRunAt == null || now - lastRunAt >= lane.spec.cadenceMs;
+  }
+
+  private async persistScanResults(
+    scanResults: readonly ChainEventPollerLaneScanResult[],
+    activeLanes: readonly ChainEventPollerLaneRuntime[],
+  ): Promise<void> {
+    if (!this.cursorStore) return;
+    const advancedResults = scanResults.filter((result) => result.advanced && result.blockNumber > 0);
+    if (advancedResults.length === 0) return;
+
+    if (this.cursorStore.kind === 'lane') {
+      for (const result of advancedResults) {
+        try {
+          await this.cursorStore.saveLane(result.lane.spec.name, result.blockNumber);
+        } catch {
+          // Non-fatal - this lane will be re-scanned on restart.
+        }
+      }
+      return;
+    }
+
+    const legacySafeCursor = this.legacyAggregateCursorToSave(activeLanes);
+    if (legacySafeCursor > 0) {
+      try {
+        await this.cursorStore.saveLegacyAggregate(legacySafeCursor);
+      } catch {
+        // Non-fatal - legacy aggregate callers will re-scan on restart.
+      }
+    }
+  }
+
+  private legacyAggregateCursorToSave(activeLanes: readonly ChainEventPollerLaneRuntime[]): number {
+    if (activeLanes.length === 0) return 0;
+    if (!activeLanes.every((lane) => lane.canUseLegacyAggregateCursor)) return 0;
+
+    let min = Number.POSITIVE_INFINITY;
+    for (const lane of activeLanes) {
+      if (lane.state.lastBlock <= 0) return 0;
+      min = Math.min(min, lane.state.lastBlock);
+    }
+    return Number.isFinite(min) ? min : 0;
+  }
+
+  private async scanLane(
+    lane: ChainEventPollerLaneRuntime,
+    head: number | undefined,
+    now: number,
+    ctx: OperationContext,
+  ): Promise<ChainEventPollerLaneScanResult> {
+    const state = lane.state;
+
+    this.applyHistoryModeTransition(lane, head, ctx);
+
+    if (head != null && !state.headKnown) {
+      state.headKnown = true;
+      if (state.lastBlock === 0 && !lane.requiresFullHistory) {
+        state.lastBlock = Math.max(0, head - lane.liveSeedLookbackBlocks);
+        this.log.info(ctx, `Seeded poller cursor near chain head: lane=${lane.spec.name} head=${head} scanning from ${state.lastBlock}`);
+      } else if (state.lastBlock === 0 && lane.spec.onBackfillFromGenesis) {
+        lane.spec.onBackfillFromGenesis(ctx);
+      }
+    }
+
+    const fromBlock = state.lastBlock + 1;
+    const upperBound = head != null
+      ? Math.min(fromBlock + this.maxRange - 1, head)
+      : fromBlock + this.maxRange - 1;
+
+    if (fromBlock > upperBound) {
+      state.lastRunAt = now;
+      return { lane, blockNumber: state.lastBlock, advanced: false };
+    }
+
+    const filter: EventFilter = {
+      eventTypes: lane.eventTypes,
+      fromBlock,
+      toBlock: upperBound,
+    };
+    const caughtUp = head != null && upperBound >= head;
+    let advanced = false;
+
+    try {
+      for await (const event of this.chain.listenForEvents(filter)) {
+        await lane.spec.dispatch(event, ctx);
+      }
+
+      state.lastBlock = upperBound;
+      advanced = true;
+    } catch (err) {
+      this.log.error(ctx, `Poll lane ${lane.spec.name} failed: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      state.lastRunAt = advanced && caughtUp ? now : undefined;
+    }
+    return { lane, blockNumber: state.lastBlock, advanced };
+  }
+
+  private applyHistoryModeTransition(
+    lane: ChainEventPollerLaneRuntime,
+    head: number | undefined,
+    ctx: OperationContext,
+  ): void {
+    const state = lane.state;
+    const previousRequiresFullHistory = state.requiresFullHistory;
+    state.requiresFullHistory = lane.requiresFullHistory;
+
+    if (previousRequiresFullHistory !== true || lane.requiresFullHistory || head == null) return;
+
+    const liveSeedBlock = Math.max(0, head - lane.liveSeedLookbackBlocks);
+    if (state.lastBlock >= liveSeedBlock) return;
+
+    state.lastBlock = liveSeedBlock;
+    this.log.info(
+      ctx,
+      `Re-seeded poller cursor after full-history lane cleared: lane=${lane.spec.name} head=${head} scanning from ${state.lastBlock}`,
+    );
+  }
+}

--- a/packages/publisher/src/chain-event-poller.ts
+++ b/packages/publisher/src/chain-event-poller.ts
@@ -274,8 +274,7 @@ export class ChainEventPoller {
         eventTypes: () => ['NameClaimed', 'ContextGraphCreated'],
         // This poller is the low-latency live tail for new context graphs.
         // Historical recovery is handled by the daemon's
-        // discoverContextGraphsFromChain scan, which has its own bounded
-        // incremental watermark.
+        // discoverContextGraphsFromChain scan and incremental watermark.
         requiresFullHistory: () => false,
         canUseLegacyAggregateCursor: () => true,
         cadenceMs: this.intervalMs,

--- a/packages/publisher/src/chain-event-poller.ts
+++ b/packages/publisher/src/chain-event-poller.ts
@@ -1,7 +1,19 @@
-import type { ChainAdapter, EventFilter, ChainEvent } from '@origintrail-official/dkg-chain';
+import type { ChainAdapter, ChainEvent } from '@origintrail-official/dkg-chain';
 import { Logger, createOperationContext, type OperationContext } from '@origintrail-official/dkg-core';
 import type { PublishHandler } from './publish-handler.js';
 import { ethers } from 'ethers';
+import {
+  ChainEventLaneRunner,
+  type ChainEventPollerLaneSpec,
+} from './chain-event-lane-runner.js';
+import type { CursorPersistence as RunnerCursorPersistence } from './chain-event-lane-cursor-store.js';
+
+export type { ChainEventPollerLane } from './chain-event-lane-runner.js';
+export type {
+  CursorPersistence,
+  LaneCursorPersistence,
+  LegacyCursorPersistence,
+} from './chain-event-lane-cursor-store.js';
 
 /** Callback invoked when a ContextGraphCreated event is detected. */
 export type OnContextGraphCreated = (info: {
@@ -66,17 +78,13 @@ export type OnKARegisteredToContextGraph = (info: {
  */
 export type OnKnowledgeAssetCreated = (e: { kaId: bigint; author: string; number: bigint; txHash: string; txIndex: number; blockNumber: number }) => void | Promise<void>;
 
-/** Persistence interface for saving/loading the last processed block. */
-export interface CursorPersistence {
-  load(): Promise<number | undefined>;
-  save(blockNumber: number): Promise<void>;
-}
-
 export interface ChainEventPollerConfig {
   chain: ChainAdapter;
   publishHandler: PublishHandler;
   /** Polling interval in ms. Default: 12000 (roughly 1 L2 block). */
   intervalMs?: number;
+  /** Test seam for deterministic lane-cadence assertions. */
+  clock?: () => number;
   /** Called when a ContextGraphCreated event is detected on-chain. */
   onContextGraphCreated?: OnContextGraphCreated;
   /** Called when a KnowledgeAssetUpdated event is detected. */
@@ -90,7 +98,7 @@ export interface ChainEventPollerConfig {
   /** Called when a KnowledgeAssetCreated event is detected (OT-RFC-43 Option-1 allocator reconciliation). */
   onKnowledgeAssetCreated?: OnKnowledgeAssetCreated;
   /** Persistent cursor for surviving restarts. */
-  cursorPersistence?: CursorPersistence;
+  cursorPersistence?: RunnerCursorPersistence;
 }
 
 /**
@@ -114,16 +122,15 @@ export class ChainEventPoller {
   private readonly chain: ChainAdapter;
   private readonly publishHandler: PublishHandler;
   private readonly intervalMs: number;
+  private readonly clock: () => number;
   private readonly onContextGraphCreated?: OnContextGraphCreated;
   private readonly onCollectionUpdated?: OnCollectionUpdated;
   private readonly onAllowListUpdated?: OnAllowListUpdated;
   private readonly onProfileEvent?: OnProfileEvent;
   private readonly onKARegisteredToContextGraph?: OnKARegisteredToContextGraph;
   private readonly onKnowledgeAssetCreated?: OnKnowledgeAssetCreated;
-  private readonly cursorPersistence?: CursorPersistence;
+  private readonly laneRunner: ChainEventLaneRunner;
   private readonly log = new Logger('ChainEventPoller');
-  private lastBlock = 0;
-  private headKnown = false;
   private timer: ReturnType<typeof setInterval> | null = null;
   private running = false;
   /**
@@ -145,13 +152,21 @@ export class ChainEventPoller {
     this.chain = config.chain;
     this.publishHandler = config.publishHandler;
     this.intervalMs = config.intervalMs ?? 12_000;
+    this.clock = config.clock ?? (() => Date.now());
     this.onContextGraphCreated = config.onContextGraphCreated;
     this.onCollectionUpdated = config.onCollectionUpdated;
     this.onAllowListUpdated = config.onAllowListUpdated;
     this.onProfileEvent = config.onProfileEvent;
     this.onKARegisteredToContextGraph = config.onKARegisteredToContextGraph;
     this.onKnowledgeAssetCreated = config.onKnowledgeAssetCreated;
-    this.cursorPersistence = config.cursorPersistence;
+    this.laneRunner = new ChainEventLaneRunner({
+      chain: this.chain,
+      lanes: this.laneSpecs(),
+      maxRange: ChainEventPoller.MAX_RANGE,
+      clock: this.clock,
+      log: this.log,
+      cursorPersistence: config.cursorPersistence,
+    });
   }
 
   async start(): Promise<void> {
@@ -161,17 +176,8 @@ export class ChainEventPoller {
     const ctx = createOperationContext('system');
 
     // Restore cursor from persistent storage (spec §5.1: scan from last processed block)
-    if (this.cursorPersistence) {
-      try {
-        const saved = await this.cursorPersistence.load();
-        if (saved != null && saved > 0) {
-          this.lastBlock = saved;
-          this.log.info(ctx, `Restored poller cursor from persistence: block ${saved}`);
-        }
-      } catch (err) {
-        this.log.warn(ctx, `Failed to load persisted cursor: ${err instanceof Error ? err.message : String(err)}`);
-      }
-    }
+    await this.laneRunner.restoreCurrentlyActive(ctx);
+    if (!this.running) return;
 
     this.log.info(ctx, `Starting chain event poller (interval=${this.intervalMs}ms)`);
 
@@ -234,141 +240,84 @@ export class ChainEventPoller {
     this.log.info(ctx, 'Chain event poller stopped');
   }
 
+  private laneSpecs(): ChainEventPollerLaneSpec[] {
+    return [
+      {
+        name: 'publish',
+        enabled: () => this.publishHandler.hasPendingPublishes,
+        eventTypes: () => ['KCCreated'],
+        requiresFullHistory: () => this.publishHandler.hasRestoredPendingPublishes,
+        canUseLegacyAggregateCursor: () => this.publishHandler.hasRestoredPendingPublishes,
+        // A live publish can be activated after its KCCreated event is already
+        // beyond the generic live-tail window on fast chains. Scan one full RPC
+        // page on activation without falling back to a genesis backfill.
+        liveSeedLookbackBlocks: ChainEventPoller.MAX_RANGE,
+        cadenceMs: this.intervalMs,
+        dispatch: (event, ctx) => this.handleBatchCreated(event, ctx),
+      },
+      {
+        name: 'allocatorReconcile',
+        enabled: () => !!this.onKnowledgeAssetCreated,
+        eventTypes: () => ['KCCreated'],
+        requiresFullHistory: () => true,
+        canUseLegacyAggregateCursor: () => false,
+        cadenceMs: this.intervalMs,
+        dispatch: (event, ctx) => this.handleKACreated(event, ctx),
+        onBackfillFromGenesis: (ctx) => {
+          if (!this.onKnowledgeAssetCreated) return;
+          this.log.info(ctx, 'Allocator-reconciliation watcher wired and no persisted cursor - scanning from block 0 (codex PR #976 F9 backfill)');
+        },
+      },
+      {
+        name: 'contextGraphDiscovery',
+        enabled: () => !!this.onContextGraphCreated,
+        eventTypes: () => ['NameClaimed', 'ContextGraphCreated'],
+        // This poller is the low-latency live tail for new context graphs.
+        // Historical recovery is handled by the daemon's
+        // discoverContextGraphsFromChain scan, which has its own bounded
+        // incremental watermark.
+        requiresFullHistory: () => false,
+        canUseLegacyAggregateCursor: () => true,
+        cadenceMs: this.intervalMs,
+        dispatch: (event, ctx) => this.handleContextGraphCreated(event, ctx),
+      },
+      {
+        name: 'vmReconcile',
+        enabled: () => !!this.onKARegisteredToContextGraph,
+        eventTypes: () => ['KnowledgeAssetRegisteredToContextGraph'],
+        requiresFullHistory: () => false,
+        cadenceMs: this.intervalMs,
+        dispatch: (event, ctx) => this.handleKARegistered(event, ctx),
+      },
+      {
+        name: 'collectionUpdates',
+        enabled: () => !!this.onCollectionUpdated,
+        eventTypes: () => ['KnowledgeAssetUpdated'],
+        requiresFullHistory: () => false,
+        cadenceMs: this.intervalMs,
+        dispatch: (event, ctx) => this.handleCollectionUpdated(event, ctx),
+      },
+      {
+        name: 'allowListUpdates',
+        enabled: () => !!this.onAllowListUpdated,
+        eventTypes: () => ['AllowListUpdated'],
+        requiresFullHistory: () => false,
+        cadenceMs: this.intervalMs,
+        dispatch: (event, ctx) => this.handleAllowListUpdated(event, ctx),
+      },
+      {
+        name: 'profileEvents',
+        enabled: () => !!this.onProfileEvent,
+        eventTypes: () => ['ProfileCreated', 'ProfileUpdated'],
+        requiresFullHistory: () => false,
+        cadenceMs: this.intervalMs,
+        dispatch: (event, ctx) => this.handleProfileEvent(event, ctx),
+      },
+    ];
+  }
+
   private async poll(): Promise<void> {
-    const hasPending = this.publishHandler.hasPendingPublishes;
-    const watchContextGraphs = !!this.onContextGraphCreated;
-    const watchUpdates = !!this.onCollectionUpdated;
-    const watchAllowList = !!this.onAllowListUpdated;
-    const watchProfiles = !!this.onProfileEvent;
-    const watchKARegistered = !!this.onKARegisteredToContextGraph;
-    const watchKACreated = !!this.onKnowledgeAssetCreated;
-    if (!hasPending && !watchContextGraphs && !watchUpdates && !watchAllowList && !watchProfiles && !watchKARegistered && !watchKACreated) return;
-
-    const ctx = createOperationContext('publish');
-
-    // Resolve the actual chain head so we can bound the scan precisely.
-    // Without a known head we cannot safely advance the cursor.
-    let head: number | undefined;
-    if (this.chain.getBlockNumber) {
-      try { head = await this.chain.getBlockNumber(); } catch { /* unavailable */ }
-    }
-
-    // On first successful head fetch, seed cursor near the tip — but only
-    // when no subscriber depends on full chain history. The head-seed is
-    // a latency optimisation for the "watch for our own pending tx
-    // confirmation" use case: confirmations land at the tip, so scanning
-    // from `head - 500` is sufficient and avoids re-walking the chain on
-    // every cold start.
-    //
-    // Full-history context graph discovery is handled separately by
-    // `discoverContextGraphsFromChain()`.
-    //
-    // The OT-RFC-43 Option-1 allocator-reconciliation watcher
-    // (`onKnowledgeAssetCreated`) MUST observe every historical
-    // `KCCreated` event (codex PR #976 F9) — otherwise a fresh daemon
-    // would miss every author whose last mint was >500 blocks ago, the
-    // per-author floor would stay at 0, and a downstream
-    // `markReconciled()` would be unsound (the allocator would happily
-    // re-issue a number already minted on-chain). Treat this watcher
-    // exactly like `hasPending`: when wired AND there is no persisted
-    // cursor, refuse to seed near head and scan from block 0.
-    //
-    // Once a `cursorPersistence` round-trip lands (so `lastBlock > 0` on
-    // restart) the watcher resumes incrementally from that cursor like
-    // every other subscription — there is no extra cost beyond the
-    // first cold start.
-    if (head != null && !this.headKnown) {
-      this.headKnown = true;
-      const requiresFullHistory = hasPending || watchKACreated;
-      if (this.lastBlock === 0 && !requiresFullHistory) {
-        this.lastBlock = Math.max(0, head - 500);
-        this.log.info(ctx, `Seeded poller cursor near chain head: ${head} → scanning from ${this.lastBlock}`);
-      } else if (this.lastBlock === 0 && watchKACreated) {
-        this.log.info(ctx, `Allocator-reconciliation watcher wired and no persisted cursor → scanning from block 0 (codex PR #976 F9 backfill)`);
-      }
-    }
-
-    // V10-only event subscription. The archived V9 batch-created event is
-    // intentionally absent — see the file-level docblock and CHANGELOG.
-    const eventTypes: string[] = ['KCCreated'];
-    if (watchContextGraphs) {
-      eventTypes.push('NameClaimed');
-      eventTypes.push('ContextGraphCreated');
-    }
-    if (this.onCollectionUpdated) eventTypes.push('KnowledgeAssetUpdated');
-    if (this.onAllowListUpdated) eventTypes.push('AllowListUpdated');
-    if (this.onProfileEvent) {
-      eventTypes.push('ProfileCreated');
-      eventTypes.push('ProfileUpdated');
-    }
-    if (watchKARegistered) eventTypes.push('KnowledgeAssetRegisteredToContextGraph');
-    // OT-RFC-43 Option-1 allocator reconciliation (codex PR #976 F5):
-    // The chain adapter's `listenForEvents()` decodes both the V10 greenfield
-    // `KnowledgeAssetCreated` event and the legacy V8/V9 batch-create event
-    // into a SINGLE normalized `{ type: 'KCCreated', data: { kaId, author, ... } }`
-    // surface (see packages/chain/src/evm-adapter-events.ts ~L119 and L193).
-    // A redundant `KnowledgeAssetCreated` subscription used to live here, but
-    // the adapter never yielded events with that type, so the dead branch
-    // below this loop never fired and allocator reconciliation never ran.
-    // Subscribe to `KCCreated` always (already implicit at the top of the
-    // list) and fan out to both `handleBatchCreated` AND `handleKACreated`
-    // inline below. When `onKnowledgeAssetCreated` is the ONLY subscriber
-    // wired (i.e. no PublishHandler pending state), still enter the poll
-    // loop — `watchKACreated` covers that case in the gating check above.
-
-    const fromBlock = this.lastBlock + 1;
-    const upperBound = head != null
-      ? Math.min(fromBlock + ChainEventPoller.MAX_RANGE - 1, head)
-      : fromBlock + ChainEventPoller.MAX_RANGE - 1;
-
-    if (fromBlock > upperBound) return;
-
-    const filter: EventFilter = {
-      eventTypes,
-      fromBlock,
-      toBlock: upperBound,
-    };
-
-    let maxEventBlock = this.lastBlock;
-    for await (const event of this.chain.listenForEvents(filter)) {
-      if (event.blockNumber > maxEventBlock) maxEventBlock = event.blockNumber;
-      if (event.type === 'KCCreated') {
-        await this.handleBatchCreated(event, ctx);
-        // OT-RFC-43 Option-1 allocator reconciliation (codex PR #976 F5).
-        // The adapter normalizes the greenfield `KnowledgeAssetCreated` event
-        // to `type: 'KCCreated'`, so there is no separate dispatch branch —
-        // we fan out off the same event here. `handleKACreated` is a no-op
-        // when `onKnowledgeAssetCreated` is not wired, when `kaId` is missing
-        // (legacy batch-create paths), or when `kaId` is zero (sentinel for
-        // `getKnowledgeAssetId`'s "not part of any KA" return — never minted).
-        await this.handleKACreated(event, ctx);
-      } else if (event.type === 'NameClaimed' || event.type === 'ContextGraphCreated') {
-        await this.handleContextGraphCreated(event, ctx);
-      } else if (event.type === 'KnowledgeAssetUpdated') {
-        await this.handleCollectionUpdated(event, ctx);
-      } else if (event.type === 'AllowListUpdated') {
-        await this.handleAllowListUpdated(event, ctx);
-      } else if (event.type === 'ProfileCreated' || event.type === 'ProfileUpdated') {
-        await this.handleProfileEvent(event, ctx);
-      } else if (event.type === 'KnowledgeAssetRegisteredToContextGraph') {
-        await this.handleKARegistered(event, ctx);
-      }
-    }
-
-    // Always advance cursor to upperBound. When head is known, upperBound
-    // is capped to it. When head is unknown, upperBound is an estimate — but
-    // the RPC successfully returned results (or empty) for this range, so
-    // those blocks have been scanned and we must progress past them.
-    this.lastBlock = upperBound;
-
-    // Persist cursor for restart recovery (spec §5.1)
-    if (this.cursorPersistence && this.lastBlock > 0) {
-      try {
-        await this.cursorPersistence.save(this.lastBlock);
-      } catch {
-        // Non-fatal — cursor will be re-seeded on restart
-      }
-    }
+    await this.laneRunner.poll();
   }
 
   private async handleBatchCreated(event: ChainEvent, ctx: OperationContext): Promise<void> {

--- a/packages/publisher/src/index.ts
+++ b/packages/publisher/src/index.ts
@@ -265,7 +265,7 @@ export {
   type WorkspacePublicSnapshotStore,
 } from './workspace-snapshot-store.js';
 export { UpdateHandler } from './update-handler.js';
-export { ChainEventPoller, type ChainEventPollerConfig, type OnContextGraphCreated } from './chain-event-poller.js';
+export { ChainEventPoller, type ChainEventPollerConfig, type CursorPersistence, type OnContextGraphCreated } from './chain-event-poller.js';
 export { AccessHandler, type AccessPolicy } from './access-handler.js';
 export { AccessClient, type AccessResult } from './access-client.js';
 export * from './share-batching.js';

--- a/packages/publisher/src/publish-handler.ts
+++ b/packages/publisher/src/publish-handler.ts
@@ -37,6 +37,7 @@ interface PendingPublish {
   expectedChainId: string;
   rootEntities: string[];
   createdAt: number;
+  restoredFromJournal: boolean;
 }
 
 /**
@@ -85,6 +86,13 @@ export class PublishHandler {
 
   get hasPendingPublishes(): boolean {
     return this.pendingPublishes.size > 0;
+  }
+
+  get hasRestoredPendingPublishes(): boolean {
+    for (const pending of this.pendingPublishes.values()) {
+      if (pending.restoredFromJournal) return true;
+    }
+    return false;
   }
 
   /**
@@ -328,6 +336,7 @@ export class PublishHandler {
         expectedChainId: request.chainId ?? '',
         rootEntities: manifest.map(m => m.rootEntity),
         createdAt: Date.now(),
+        restoredFromJournal: false,
       });
       this.persistJournal();
 
@@ -509,6 +518,7 @@ export class PublishHandler {
         expectedChainId: entry.expectedChainId,
         rootEntities: entry.rootEntities ?? [],
         createdAt: entry.createdAt,
+        restoredFromJournal: true,
       });
       restored++;
     }

--- a/packages/publisher/test/chain-event-lane-runner.unit.test.ts
+++ b/packages/publisher/test/chain-event-lane-runner.unit.test.ts
@@ -294,6 +294,7 @@ describe('ChainEventPoller lane runner and cursors', () => {
       async save(n: number) { this.saved.push(n); },
     };
     let failContextLane = true;
+    let now = 0;
     const adapter = {
       chainId: 'mock:0',
       getBlockNumber: async () => 100,
@@ -309,7 +310,7 @@ describe('ChainEventPoller lane runner and cursors', () => {
       publishHandler: makeHandler(),
       intervalMs: 20,
       cursorPersistence: cursor,
-      clock: () => 0,
+      clock: () => now,
       onContextGraphCreated: async () => { /* sink */ },
       onKARegisteredToContextGraph: async () => { /* sink */ },
     });
@@ -327,6 +328,7 @@ describe('ChainEventPoller lane runner and cursors', () => {
     expect(cursor.saved).toEqual([]);
 
     failContextLane = false;
+    now = 60_000;
     await (poller as unknown as { poll(): Promise<void> }).poll();
 
     expect(filters[2].eventTypes).toEqual(['NameClaimed', 'ContextGraphCreated']);
@@ -820,10 +822,11 @@ describe('ChainEventPoller lane runner and cursors', () => {
     expect(filters[3].toBlock).toBe(1100);
   });
 
-  it('retries a failed context graph discovery lane on the next tick', async () => {
+  it('backs off a failed context graph discovery lane and retries the same range later', async () => {
     const filters: EventFilter[] = [];
     const saveCalls: Array<{ lane: ChainEventPollerLane; block: number }> = [];
     let calls = 0;
+    let now = 0;
     const adapter = {
       chainId: 'mock:0',
       getBlockNumber: async () => 100,
@@ -842,15 +845,17 @@ describe('ChainEventPoller lane runner and cursors', () => {
       publishHandler: makeHandler(),
       intervalMs: 20,
       cursorPersistence: cursor,
-      clock: () => 0,
+      clock: () => now,
       onContextGraphCreated: async () => { /* sink */ },
     });
 
-    await poller.start();
-    await new Promise((r) => setTimeout(r, 80));
-    await poller.stop();
+    await (poller as unknown as { poll(): Promise<void> }).poll();
+    now = 20;
+    await (poller as unknown as { poll(): Promise<void> }).poll();
+    now = 60_000;
+    await (poller as unknown as { poll(): Promise<void> }).poll();
 
-    expect(filters.length).toBeGreaterThanOrEqual(2);
+    expect(filters).toHaveLength(2);
     expect(filters[0].eventTypes).toEqual(['NameClaimed', 'ContextGraphCreated']);
     expect(filters[1].eventTypes).toEqual(['NameClaimed', 'ContextGraphCreated']);
     expect(filters[0].fromBlock).toBe(1);

--- a/packages/publisher/test/chain-event-lane-runner.unit.test.ts
+++ b/packages/publisher/test/chain-event-lane-runner.unit.test.ts
@@ -853,6 +853,8 @@ describe('ChainEventPoller lane runner and cursors', () => {
     await (poller as unknown as { poll(): Promise<void> }).poll();
     now = 20;
     await (poller as unknown as { poll(): Promise<void> }).poll();
+    expect(filters).toHaveLength(1);
+
     now = 60_000;
     await (poller as unknown as { poll(): Promise<void> }).poll();
 
@@ -930,7 +932,7 @@ describe('ChainEventPoller lane runner and cursors', () => {
     ]);
   });
 
-  it('uses an explicit lane failure-backoff policy and caps repeated failures', async () => {
+  it('caps repeated lane failures at the internal max backoff', async () => {
     const filters: EventFilter[] = [];
     let calls = 0;
     let now = 0;
@@ -940,7 +942,7 @@ describe('ChainEventPoller lane runner and cursors', () => {
       listenForEvents: async function* (f: EventFilter): AsyncIterable<ChainEvent> {
         filters.push(f);
         calls++;
-        if (calls <= 3) throw new Error('rpc down');
+        if (calls <= 5) throw new Error('rpc down');
       },
     } as unknown as ChainAdapter;
     const lane: ChainEventPollerLaneSpec = {
@@ -949,7 +951,6 @@ describe('ChainEventPoller lane runner and cursors', () => {
       eventTypes: () => ['ContextGraphCreated'],
       requiresFullHistory: () => false,
       cadenceMs: 20,
-      failureBackoff: { initialMs: 10, maxMs: 25 },
       dispatch: async () => { /* sink */ },
     };
     const runner = new ChainEventLaneRunner({
@@ -961,20 +962,30 @@ describe('ChainEventPoller lane runner and cursors', () => {
     });
 
     await runner.poll();
-    now = 9;
+    now = 59_999;
     await runner.poll();
-    now = 10;
+    now = 60_000;
     await runner.poll();
-    now = 29;
+    now = 179_999;
     await runner.poll();
-    now = 30;
+    now = 180_000;
     await runner.poll();
-    now = 54;
+    now = 419_999;
     await runner.poll();
-    now = 55;
+    now = 420_000;
+    await runner.poll();
+    now = 719_999;
+    await runner.poll();
+    now = 720_000;
+    await runner.poll();
+    now = 1_019_999;
+    await runner.poll();
+    now = 1_020_000;
     await runner.poll();
 
     expect(filters.map((f) => [f.fromBlock, f.toBlock])).toEqual([
+      [1, 100],
+      [1, 100],
       [1, 100],
       [1, 100],
       [1, 100],

--- a/packages/publisher/test/chain-event-lane-runner.unit.test.ts
+++ b/packages/publisher/test/chain-event-lane-runner.unit.test.ts
@@ -865,6 +865,70 @@ describe('ChainEventPoller lane runner and cursors', () => {
     expect(saveCalls).toEqual([{ lane: 'contextGraphDiscovery', block: 100 }]);
   });
 
+  it('exponentially backs off repeated lane failures and resets after success', async () => {
+    const filters: EventFilter[] = [];
+    const saveCalls: Array<{ lane: ChainEventPollerLane; block: number }> = [];
+    let calls = 0;
+    let head = 100;
+    let now = 0;
+    const adapter = {
+      chainId: 'mock:0',
+      getBlockNumber: async () => head,
+      listenForEvents: async function* (f: EventFilter): AsyncIterable<ChainEvent> {
+        filters.push(f);
+        calls++;
+        if (calls === 1 || calls === 2 || calls === 4) throw new Error('rpc down');
+      },
+    } as unknown as ChainAdapter;
+    const cursor: LaneCursorPersistence = {
+      async loadLane() { return undefined; },
+      async saveLane(lane, block) { saveCalls.push({ lane, block }); },
+    };
+    const poller = new ChainEventPoller({
+      chain: adapter,
+      publishHandler: makeHandler(),
+      intervalMs: 20,
+      cursorPersistence: cursor,
+      clock: () => now,
+      onContextGraphCreated: async () => { /* sink */ },
+    });
+
+    await (poller as unknown as { poll(): Promise<void> }).poll();
+    now = 60_000;
+    await (poller as unknown as { poll(): Promise<void> }).poll();
+    now = 120_000;
+    await (poller as unknown as { poll(): Promise<void> }).poll();
+    now = 180_000;
+    await (poller as unknown as { poll(): Promise<void> }).poll();
+
+    expect(filters.map((f) => [f.fromBlock, f.toBlock])).toEqual([
+      [1, 100],
+      [1, 100],
+      [1, 100],
+    ]);
+    expect(saveCalls).toEqual([{ lane: 'contextGraphDiscovery', block: 100 }]);
+
+    head = 200;
+    now = 180_020;
+    await (poller as unknown as { poll(): Promise<void> }).poll();
+    now = 240_019;
+    await (poller as unknown as { poll(): Promise<void> }).poll();
+    now = 240_020;
+    await (poller as unknown as { poll(): Promise<void> }).poll();
+
+    expect(filters.map((f) => [f.fromBlock, f.toBlock])).toEqual([
+      [1, 100],
+      [1, 100],
+      [1, 100],
+      [101, 200],
+      [101, 200],
+    ]);
+    expect(saveCalls).toEqual([
+      { lane: 'contextGraphDiscovery', block: 100 },
+      { lane: 'contextGraphDiscovery', block: 200 },
+    ]);
+  });
+
   it('keeps headless scans due until a known head proves the lane is caught up', async () => {
     const filters: EventFilter[] = [];
     const adapter = {

--- a/packages/publisher/test/chain-event-lane-runner.unit.test.ts
+++ b/packages/publisher/test/chain-event-lane-runner.unit.test.ts
@@ -1,0 +1,890 @@
+import { describe, expect, it } from 'vitest';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import { TypedEventBus } from '@origintrail-official/dkg-core';
+import type { ChainAdapter, ChainEvent, EventFilter } from '@origintrail-official/dkg-chain';
+import { ChainEventPoller, type ChainEventPollerLane, type LaneCursorPersistence } from '../src/chain-event-poller.js';
+import { PublishHandler } from '../src/publish-handler.js';
+import type { JournalEntry } from '../src/publish-journal.js';
+
+function makeChain(head: number, events: ChainEvent[]): {
+  adapter: ChainAdapter;
+  filters: EventFilter[];
+} {
+  const filters: EventFilter[] = [];
+  const adapter = {
+    chainId: 'mock:0',
+    getBlockNumber: async () => head,
+    listenForEvents: async function* (f: EventFilter): AsyncIterable<ChainEvent> {
+      filters.push(f);
+      const fromBlock = f.fromBlock ?? 0;
+      const toBlock = f.toBlock ?? Number.MAX_SAFE_INTEGER;
+      for (const evt of events) {
+        if (f.eventTypes.includes(evt.type) && evt.blockNumber >= fromBlock && evt.blockNumber <= toBlock) {
+          yield evt;
+        }
+      }
+    },
+  } as unknown as ChainAdapter;
+  return { adapter, filters };
+}
+
+function makeHandler(): PublishHandler {
+  return new PublishHandler(new OxigraphStore(), new TypedEventBus());
+}
+
+function markPending(handler: PublishHandler, restoredFromJournal: boolean): void {
+  (handler as unknown as { pendingPublishes: Map<string, unknown> }).pendingPublishes.set(
+    restoredFromJournal ? 'restored' : 'live',
+    { expectedMerkleRoot: new Uint8Array(32), restoredFromJournal },
+  );
+}
+
+function journalEntry(overrides: Partial<JournalEntry> = {}): JournalEntry {
+  return {
+    ual: 'did:dkg:mock:0/0xa1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1/1',
+    contextGraphId: 'contextGraph-1',
+    expectedPublisherAddress: '0x' + 'a1'.repeat(20),
+    expectedMerkleRoot: '0x' + '55'.repeat(32),
+    expectedStartKAId: '1',
+    expectedEndKAId: '1',
+    expectedChainId: 'mock:0',
+    rootEntities: [],
+    createdAt: Date.now(),
+    ...overrides,
+  };
+}
+
+describe('ChainEventPoller lane runner and cursors', () => {
+  it('does not install a timer or initial poll when stopped during async startup restore', async () => {
+    const { adapter, filters } = makeChain(100, []);
+    const handler = makeHandler();
+    markPending(handler, true);
+    let releaseRestore: () => void = () => {};
+    let restoreStarted: () => void = () => {};
+    const restoreStartedPromise = new Promise<void>((resolve) => { restoreStarted = resolve; });
+    const restoreReleasePromise = new Promise<void>((resolve) => { releaseRestore = resolve; });
+    const cursor: LaneCursorPersistence = {
+      async loadLane(lane) {
+        if (lane === 'publish') {
+          restoreStarted();
+          await restoreReleasePromise;
+        }
+        return undefined;
+      },
+      async saveLane() { /* not reached */ },
+    };
+    const poller = new ChainEventPoller({
+      chain: adapter,
+      publishHandler: handler,
+      intervalMs: 10,
+      cursorPersistence: cursor,
+    });
+
+    const startPromise = poller.start();
+    await restoreStartedPromise;
+    await poller.stop();
+    releaseRestore();
+    await startPromise;
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    const state = poller as unknown as {
+      timer: ReturnType<typeof setInterval> | null;
+      inFlightPoll: Promise<void> | null;
+    };
+    expect(state.timer).toBeNull();
+    expect(state.inFlightPoll).toBeNull();
+    expect(filters).toEqual([]);
+  });
+
+  it('cold-starts a restored pending publish lane from block 0 without allocator callbacks', async () => {
+    const merkleRoot = '0x' + '55'.repeat(32);
+    const oldCreate: ChainEvent = {
+      type: 'KCCreated',
+      blockNumber: 1,
+      data: {
+        kaId: '1',
+        author: '0x' + 'a1'.repeat(20),
+        merkleRoot,
+        publisherAddress: '0x' + 'a1'.repeat(20),
+        startKAId: '1',
+        endKAId: '1',
+        txHash: '0xabc',
+        txIndex: 0,
+      },
+    };
+    const { adapter, filters } = makeChain(10_000, [oldCreate]);
+    const handler = makeHandler();
+    markPending(handler, true);
+    const confirmed: unknown[] = [];
+    (handler as unknown as { confirmByMerkleRoot: (...args: unknown[]) => Promise<boolean> }).confirmByMerkleRoot = async (...args) => {
+      confirmed.push(args);
+      return true;
+    };
+
+    const poller = new ChainEventPoller({ chain: adapter, publishHandler: handler, intervalMs: 60_000 });
+
+    await poller.start();
+    await new Promise((r) => setTimeout(r, 50));
+    await poller.stop();
+
+    expect(filters).toHaveLength(1);
+    expect(filters[0].eventTypes).toEqual(['KCCreated']);
+    expect(filters[0].fromBlock).toBe(1);
+    expect(filters[0].toBlock).toBe(9000);
+    expect(confirmed).toHaveLength(1);
+  });
+
+  it('uses the journal restore path to mark restored publishes for backfill', async () => {
+    const merkleRoot = '0x' + '55'.repeat(32);
+    const oldCreate: ChainEvent = {
+      type: 'KCCreated',
+      blockNumber: 1,
+      data: {
+        kaId: '1',
+        author: '0x' + 'a1'.repeat(20),
+        merkleRoot,
+        publisherAddress: '0x' + 'a1'.repeat(20),
+        startKAId: '1',
+        endKAId: '1',
+        txHash: '0xabc',
+        txIndex: 0,
+      },
+    };
+    const { adapter, filters } = makeChain(10_000, [oldCreate]);
+    const journal = {
+      load: async () => [journalEntry({ expectedMerkleRoot: merkleRoot })],
+      save: async () => { /* sink */ },
+    };
+    const handler = new PublishHandler(new OxigraphStore(), new TypedEventBus(), { journal: journal as any });
+    const confirmed: unknown[] = [];
+    (handler as unknown as { confirmByMerkleRoot: (...args: unknown[]) => Promise<boolean> }).confirmByMerkleRoot = async (...args) => {
+      confirmed.push(args);
+      return true;
+    };
+
+    expect(await handler.restorePendingPublishes()).toBe(1);
+    expect(handler.hasRestoredPendingPublishes).toBe(true);
+
+    const poller = new ChainEventPoller({ chain: adapter, publishHandler: handler, intervalMs: 60_000 });
+    try {
+      await poller.start();
+      await new Promise((r) => setTimeout(r, 50));
+      await poller.stop();
+    } finally {
+      const pending = (handler as unknown as {
+        pendingPublishes: Map<string, { timeout: ReturnType<typeof setTimeout> }>;
+      }).pendingPublishes;
+      for (const entry of pending.values()) clearTimeout(entry.timeout);
+      pending.clear();
+    }
+
+    expect(filters).toHaveLength(1);
+    expect(filters[0].eventTypes).toEqual(['KCCreated']);
+    expect(filters[0].fromBlock).toBe(1);
+    expect(filters[0].toBlock).toBe(9000);
+    expect(confirmed).toHaveLength(1);
+  });
+
+  it('live-tails context graph discovery near the current head on cold start', async () => {
+    const { adapter, filters } = makeChain(10_000, []);
+    const poller = new ChainEventPoller({
+      chain: adapter,
+      publishHandler: makeHandler(),
+      intervalMs: 60_000,
+      onContextGraphCreated: async () => { /* sink */ },
+    });
+
+    await poller.start();
+    await new Promise((r) => setTimeout(r, 50));
+    await poller.stop();
+
+    expect(filters.length).toBeGreaterThanOrEqual(1);
+    expect(filters[0].eventTypes).toEqual(['NameClaimed', 'ContextGraphCreated']);
+    expect(filters[0].fromBlock).toBe(9501);
+    expect(filters[0].toBlock).toBe(10_000);
+  });
+
+  it('dispatches a near-head context graph event on the first poll', async () => {
+    const event: ChainEvent = {
+      type: 'ContextGraphCreated',
+      blockNumber: 19_999_990,
+      data: {
+        contextGraphId: '42',
+        creator: '0x' + 'a1'.repeat(20),
+        accessPolicy: 0,
+        publishPolicy: 1,
+        nameHash: '0x' + 'ab'.repeat(32),
+      },
+    };
+    const { adapter, filters } = makeChain(20_000_000, [event]);
+    const seen: Array<{ contextGraphId: string; blockNumber: number }> = [];
+    const poller = new ChainEventPoller({
+      chain: adapter,
+      publishHandler: makeHandler(),
+      intervalMs: 60_000,
+      onContextGraphCreated: async (info) => { seen.push(info); },
+    });
+
+    await poller.start();
+    await new Promise((r) => setTimeout(r, 50));
+    await poller.stop();
+
+    expect(filters[0].eventTypes).toEqual(['NameClaimed', 'ContextGraphCreated']);
+    expect(filters[0].fromBlock).toBe(19_999_501);
+    expect(filters[0].toBlock).toBe(20_000_000);
+    expect(seen).toMatchObject([{ contextGraphId: '42', blockNumber: 19_999_990 }]);
+  });
+
+  it('saves and restores a legacy aggregate cursor when active lanes can safely share it', async () => {
+    const cursor = {
+      loaded: undefined as number | undefined,
+      saved: [] as number[],
+      async load() { return this.loaded; },
+      async save(n: number) {
+        this.saved.push(n);
+        this.loaded = n;
+      },
+    };
+    const first = makeChain(10_000, []);
+    const handler = makeHandler();
+    const firstPoller = new ChainEventPoller({
+      chain: first.adapter,
+      publishHandler: handler,
+      intervalMs: 60_000,
+      cursorPersistence: cursor,
+      onContextGraphCreated: async () => { /* sink */ },
+      onKARegisteredToContextGraph: async () => { /* sink */ },
+    });
+
+    await firstPoller.start();
+    await new Promise((r) => setTimeout(r, 50));
+    await firstPoller.stop();
+
+    expect(first.filters.map((f) => f.eventTypes)).toEqual([
+      ['NameClaimed', 'ContextGraphCreated'],
+      ['KnowledgeAssetRegisteredToContextGraph'],
+    ]);
+    expect(first.filters[0].fromBlock).toBe(9501);
+    expect(first.filters[0].toBlock).toBe(10_000);
+    expect(first.filters[1].fromBlock).toBe(9501);
+    expect(first.filters[1].toBlock).toBe(10_000);
+    expect(cursor.saved).toEqual([10_000]);
+
+    const restart = makeChain(10_000, []);
+    const restartPoller = new ChainEventPoller({
+      chain: restart.adapter,
+      publishHandler: handler,
+      intervalMs: 60_000,
+      cursorPersistence: cursor,
+      onContextGraphCreated: async () => { /* sink */ },
+    });
+
+    await restartPoller.start();
+    await new Promise((r) => setTimeout(r, 50));
+    await restartPoller.stop();
+
+    expect(restart.filters).toHaveLength(0);
+  });
+
+  it('does not advance a legacy aggregate cursor past a failed active lane', async () => {
+    const filters: EventFilter[] = [];
+    const cursor = {
+      saved: [] as number[],
+      async load() { return undefined; },
+      async save(n: number) { this.saved.push(n); },
+    };
+    let failContextLane = true;
+    const adapter = {
+      chainId: 'mock:0',
+      getBlockNumber: async () => 100,
+      listenForEvents: async function* (f: EventFilter): AsyncIterable<ChainEvent> {
+        filters.push(f);
+        if (f.eventTypes.includes('ContextGraphCreated') && failContextLane) {
+          throw new Error('context lane unavailable');
+        }
+      },
+    } as unknown as ChainAdapter;
+    const poller = new ChainEventPoller({
+      chain: adapter,
+      publishHandler: makeHandler(),
+      intervalMs: 20,
+      cursorPersistence: cursor,
+      clock: () => 0,
+      onContextGraphCreated: async () => { /* sink */ },
+      onKARegisteredToContextGraph: async () => { /* sink */ },
+    });
+
+    await (poller as unknown as { poll(): Promise<void> }).poll();
+
+    expect(filters.map((f) => f.eventTypes)).toEqual([
+      ['NameClaimed', 'ContextGraphCreated'],
+      ['KnowledgeAssetRegisteredToContextGraph'],
+    ]);
+    expect(filters[0].fromBlock).toBe(1);
+    expect(filters[0].toBlock).toBe(100);
+    expect(filters[1].fromBlock).toBe(1);
+    expect(filters[1].toBlock).toBe(100);
+    expect(cursor.saved).toEqual([]);
+
+    failContextLane = false;
+    await (poller as unknown as { poll(): Promise<void> }).poll();
+
+    expect(filters[2].eventTypes).toEqual(['NameClaimed', 'ContextGraphCreated']);
+    expect(filters[2].fromBlock).toBe(1);
+    expect(filters[2].toBlock).toBe(100);
+    expect(cursor.saved).toEqual([100]);
+  });
+
+  it('does not let a legacy context-only cursor skip a later full-history allocator lane', async () => {
+    const cursor = {
+      loaded: 10_000 as number | undefined,
+      saved: [] as number[],
+      async load() { return this.loaded; },
+      async save(n: number) {
+        this.saved.push(n);
+        this.loaded = n;
+      },
+    };
+    const oldCreate: ChainEvent = {
+      type: 'KCCreated',
+      blockNumber: 5000,
+      data: {
+        kaId: '1',
+        author: '0x' + 'a1'.repeat(20),
+        merkleRoot: '0x' + '11'.repeat(32),
+        publisherAddress: '0x' + 'a1'.repeat(20),
+        startKAId: '1',
+        endKAId: '1',
+        txHash: '0xabc',
+        txIndex: 0,
+      },
+    };
+    const { adapter, filters } = makeChain(12_000, [oldCreate]);
+    const seen: bigint[] = [];
+    const poller = new ChainEventPoller({
+      chain: adapter,
+      publishHandler: makeHandler(),
+      intervalMs: 60_000,
+      cursorPersistence: cursor,
+      onKnowledgeAssetCreated: async (event) => { seen.push(event.kaId); },
+    });
+
+    await poller.start();
+    await new Promise((r) => setTimeout(r, 50));
+    await poller.stop();
+
+    expect(filters[0].eventTypes).toContain('KCCreated');
+    expect(filters[0].fromBlock).toBe(1);
+    expect(filters[0].toBlock).toBe(9000);
+    expect(seen).toEqual([1n]);
+    expect(cursor.saved).toEqual([]);
+  });
+
+  it('restores a legacy pending-publish cursor without applying it to allocator backfill', async () => {
+    const cursor = {
+      loaded: 1_200_000 as number | undefined,
+      saved: [] as number[],
+      async load() { return this.loaded; },
+      async save(n: number) {
+        this.saved.push(n);
+        this.loaded = n;
+      },
+    };
+    const { adapter, filters } = makeChain(1_210_000, []);
+    const handler = makeHandler();
+    markPending(handler, true);
+    const poller = new ChainEventPoller({
+      chain: adapter,
+      publishHandler: handler,
+      intervalMs: 60_000,
+      cursorPersistence: cursor,
+      onKnowledgeAssetCreated: async () => { /* sink */ },
+    });
+
+    await poller.start();
+    await new Promise((r) => setTimeout(r, 50));
+    await poller.stop();
+
+    expect(filters.map((f) => f.eventTypes)).toEqual([
+      ['KCCreated'],
+      ['KCCreated'],
+    ]);
+    expect(filters[0].fromBlock).toBe(1_200_001);
+    expect(filters[0].toBlock).toBe(1_209_000);
+    expect(filters[1].fromBlock).toBe(1);
+    expect(filters[1].toBlock).toBe(9000);
+    expect(cursor.saved).toEqual([]);
+  });
+
+  it('does not let a saved publish cursor skip later allocator reconciliation backfill', async () => {
+    const saved = new Map<ChainEventPollerLane, number>([['publish', 10_000]]);
+    const loadCalls: ChainEventPollerLane[] = [];
+    const saveCalls: Array<{ lane: ChainEventPollerLane; block: number }> = [];
+    const cursor: LaneCursorPersistence = {
+      async loadLane(lane) {
+        loadCalls.push(lane);
+        return saved.get(lane);
+      },
+      async saveLane(lane, block) {
+        saveCalls.push({ lane, block });
+        saved.set(lane, block);
+      },
+    };
+    const oldCreate: ChainEvent = {
+      type: 'KCCreated',
+      blockNumber: 5000,
+      data: {
+        kaId: '1',
+        author: '0x' + 'a1'.repeat(20),
+        merkleRoot: '0x' + '11'.repeat(32),
+        publisherAddress: '0x' + 'a1'.repeat(20),
+        startKAId: '1',
+        endKAId: '1',
+        txHash: '0xabc',
+        txIndex: 0,
+      },
+    };
+    const { adapter, filters } = makeChain(12_000, [oldCreate]);
+    const seen: bigint[] = [];
+    const poller = new ChainEventPoller({
+      chain: adapter,
+      publishHandler: makeHandler(),
+      intervalMs: 60_000,
+      cursorPersistence: cursor,
+      onKnowledgeAssetCreated: async (event) => { seen.push(event.kaId); },
+    });
+
+    await poller.start();
+    await new Promise((r) => setTimeout(r, 50));
+    await poller.stop();
+
+    expect(loadCalls).toEqual(['allocatorReconcile']);
+    expect(filters[0].eventTypes).toEqual(['KCCreated']);
+    expect(filters[0].fromBlock).toBe(1);
+    expect(filters[0].toBlock).toBe(9000);
+    expect(seen).toEqual([1n]);
+    expect(saveCalls).toEqual([{ lane: 'allocatorReconcile', block: 9000 }]);
+  });
+
+  it('saves and restores a legacy aggregate cursor for non-full-history lanes', async () => {
+    const cursor = {
+      loaded: undefined as number | undefined,
+      saved: [] as number[],
+      async load() { return this.loaded; },
+      async save(n: number) {
+        this.saved.push(n);
+        this.loaded = n;
+      },
+    };
+    const first = makeChain(100, []);
+    const handler = makeHandler();
+    const firstPoller = new ChainEventPoller({
+      chain: first.adapter,
+      publishHandler: handler,
+      intervalMs: 60_000,
+      cursorPersistence: cursor,
+      onKARegisteredToContextGraph: async () => { /* sink */ },
+    });
+
+    await firstPoller.start();
+    await new Promise((r) => setTimeout(r, 50));
+    await firstPoller.stop();
+
+    expect(first.filters[0].eventTypes).toEqual(['KnowledgeAssetRegisteredToContextGraph']);
+    expect(first.filters[0].fromBlock).toBe(1);
+    expect(first.filters[0].toBlock).toBe(100);
+    expect(cursor.saved).toEqual([100]);
+
+    const restart = makeChain(150, []);
+    const restartPoller = new ChainEventPoller({
+      chain: restart.adapter,
+      publishHandler: handler,
+      intervalMs: 60_000,
+      cursorPersistence: cursor,
+      onKARegisteredToContextGraph: async () => { /* sink */ },
+    });
+
+    await restartPoller.start();
+    await new Promise((r) => setTimeout(r, 50));
+    await restartPoller.stop();
+
+    expect(restart.filters[0].eventTypes).toEqual(['KnowledgeAssetRegisteredToContextGraph']);
+    expect(restart.filters[0].fromBlock).toBe(101);
+    expect(restart.filters[0].toBlock).toBe(150);
+    expect(cursor.saved).toEqual([100, 150]);
+  });
+
+  it('restores and saves independent lane cursors when lane persistence is available', async () => {
+    const saved = new Map<ChainEventPollerLane, number>([
+      ['contextGraphDiscovery', 10],
+      ['vmReconcile', 9500],
+    ]);
+    const loadCalls: ChainEventPollerLane[] = [];
+    const saveCalls: Array<{ lane: ChainEventPollerLane; block: number }> = [];
+    const cursor: LaneCursorPersistence = {
+      async loadLane(lane) {
+        loadCalls.push(lane);
+        return saved.get(lane);
+      },
+      async saveLane(lane, block) {
+        saveCalls.push({ lane, block });
+        saved.set(lane, block);
+      },
+    };
+    const { adapter, filters } = makeChain(10_000, []);
+    const poller = new ChainEventPoller({
+      chain: adapter,
+      publishHandler: makeHandler(),
+      intervalMs: 60_000,
+      cursorPersistence: cursor,
+      onContextGraphCreated: async () => { /* sink */ },
+      onKARegisteredToContextGraph: async () => { /* sink */ },
+    });
+
+    await poller.start();
+    await new Promise((r) => setTimeout(r, 50));
+    await poller.stop();
+
+    expect(loadCalls).toEqual(['contextGraphDiscovery', 'vmReconcile']);
+    expect(filters.map((f) => f.eventTypes)).toEqual([
+      ['NameClaimed', 'ContextGraphCreated'],
+      ['KnowledgeAssetRegisteredToContextGraph'],
+    ]);
+    expect(filters[0].fromBlock).toBe(11);
+    expect(filters[0].toBlock).toBe(9010);
+    expect(filters[1].fromBlock).toBe(9501);
+    expect(filters[1].toBlock).toBe(10_000);
+    expect(saveCalls).toEqual([
+      { lane: 'contextGraphDiscovery', block: 9010 },
+      { lane: 'vmReconcile', block: 10_000 },
+    ]);
+  });
+
+  it('lazy-restores a lane cursor when the lane becomes active after startup', async () => {
+    const saved = new Map<ChainEventPollerLane, number>([
+      ['publish', 12_000],
+      ['contextGraphDiscovery', 50],
+    ]);
+    const loadCalls: ChainEventPollerLane[] = [];
+    const cursor: LaneCursorPersistence = {
+      async loadLane(lane) {
+        loadCalls.push(lane);
+        return saved.get(lane);
+      },
+      async saveLane(lane, block) {
+        saved.set(lane, block);
+      },
+    };
+    const { adapter, filters } = makeChain(13_000, []);
+    const handler = makeHandler();
+    const poller = new ChainEventPoller({
+      chain: adapter,
+      publishHandler: handler,
+      intervalMs: 20,
+      cursorPersistence: cursor,
+      onContextGraphCreated: async () => { /* initially active lane */ },
+    });
+
+    await poller.start();
+    await new Promise((r) => setTimeout(r, 50));
+    markPending(handler, true);
+    await new Promise((r) => setTimeout(r, 80));
+    await poller.stop();
+
+    expect(loadCalls).toContain('contextGraphDiscovery');
+    expect(loadCalls).toContain('publish');
+    const publishFilter = filters.find((f) => f.eventTypes.includes('KCCreated'));
+    expect(publishFilter).toBeDefined();
+    expect(publishFilter!.fromBlock).toBe(12_001);
+  });
+
+  it('seeds a newly-active live publish lane near the current head after idle', async () => {
+    const filters: EventFilter[] = [];
+    let head = 20_000_000;
+    const adapter = {
+      chainId: 'mock:0',
+      getBlockNumber: async () => head,
+      listenForEvents: async function* (f: EventFilter): AsyncIterable<ChainEvent> {
+        filters.push(f);
+      },
+    } as unknown as ChainAdapter;
+    const handler = makeHandler();
+    const poller = new ChainEventPoller({
+      chain: adapter,
+      publishHandler: handler,
+      intervalMs: 20,
+      onContextGraphCreated: async () => { /* idle always-on lane */ },
+    });
+
+    await (poller as unknown as { poll(): Promise<void> }).poll();
+    expect(filters.map((f) => f.eventTypes)).toEqual([
+      ['NameClaimed', 'ContextGraphCreated'],
+    ]);
+
+    head = 20_000_050;
+    markPending(handler, false);
+    await (poller as unknown as { poll(): Promise<void> }).poll();
+
+    const publishFilter = filters.find((f) => f.eventTypes.includes('KCCreated'));
+    expect(publishFilter).toBeDefined();
+    expect(publishFilter!.fromBlock).toBe(19_991_051);
+    expect(publishFilter!.toBlock).toBe(20_000_050);
+  });
+
+  it('scans a full page behind head for newly-active live publish confirmations', async () => {
+    const merkleRoot = '0x' + '00'.repeat(32);
+    const oldCreate: ChainEvent = {
+      type: 'KCCreated',
+      blockNumber: 9000,
+      data: {
+        kaId: '1',
+        author: '0x' + 'a1'.repeat(20),
+        merkleRoot,
+        publisherAddress: '0x' + 'a1'.repeat(20),
+        startKAId: '1',
+        endKAId: '1',
+        txHash: '0xabc',
+        txIndex: 0,
+      },
+    };
+    const { adapter, filters } = makeChain(10_000, [oldCreate]);
+    const handler = makeHandler();
+    markPending(handler, false);
+    const confirmed: unknown[] = [];
+    (handler as unknown as { confirmByMerkleRoot: (...args: unknown[]) => Promise<boolean> }).confirmByMerkleRoot = async (...args) => {
+      confirmed.push(args);
+      return true;
+    };
+    const poller = new ChainEventPoller({
+      chain: adapter,
+      publishHandler: handler,
+      intervalMs: 60_000,
+    });
+
+    await (poller as unknown as { poll(): Promise<void> }).poll();
+
+    expect(filters).toHaveLength(1);
+    expect(filters[0].eventTypes).toEqual(['KCCreated']);
+    expect(filters[0].fromBlock).toBe(1001);
+    expect(filters[0].toBlock).toBe(10_000);
+    expect(confirmed).toHaveLength(1);
+  });
+
+  it('re-seeds live publish confirmations near head after restored publish backfill clears', async () => {
+    const restoredMerkleRoot = '0x' + '11'.repeat(32);
+    const liveMerkleRoot = '0x' + '22'.repeat(32);
+    const events: ChainEvent[] = [
+      {
+        type: 'KCCreated',
+        blockNumber: 1,
+        data: {
+          kaId: '1',
+          author: '0x' + 'a1'.repeat(20),
+          merkleRoot: restoredMerkleRoot,
+          publisherAddress: '0x' + 'a1'.repeat(20),
+          startKAId: '1',
+          endKAId: '1',
+          txHash: '0xrestored',
+          txIndex: 0,
+        },
+      },
+      {
+        type: 'KCCreated',
+        blockNumber: 1_999_950,
+        data: {
+          kaId: '2',
+          author: '0x' + 'b2'.repeat(20),
+          merkleRoot: liveMerkleRoot,
+          publisherAddress: '0x' + 'b2'.repeat(20),
+          startKAId: '2',
+          endKAId: '2',
+          txHash: '0xlive',
+          txIndex: 0,
+        },
+      },
+    ];
+    const { adapter, filters } = makeChain(2_000_000, events);
+    const handler = makeHandler();
+    markPending(handler, true);
+    markPending(handler, false);
+    const pending = (handler as unknown as {
+      pendingPublishes: Map<string, { restoredFromJournal: boolean }>;
+    }).pendingPublishes;
+    const confirmed: number[] = [];
+    (handler as unknown as { confirmByMerkleRoot: (...args: unknown[]) => Promise<boolean> }).confirmByMerkleRoot = async (merkleRoot) => {
+      const root = merkleRoot as Uint8Array;
+      confirmed.push(root[0]);
+      if (root[0] === 0x11) pending.delete('restored');
+      if (root[0] === 0x22) pending.delete('live');
+      return true;
+    };
+    const poller = new ChainEventPoller({
+      chain: adapter,
+      publishHandler: handler,
+      intervalMs: 60_000,
+    });
+
+    await (poller as unknown as { poll(): Promise<void> }).poll();
+    await (poller as unknown as { poll(): Promise<void> }).poll();
+
+    expect(filters).toHaveLength(2);
+    expect(filters[0].eventTypes).toEqual(['KCCreated']);
+    expect(filters[0].fromBlock).toBe(1);
+    expect(filters[0].toBlock).toBe(9000);
+    expect(filters[1].eventTypes).toEqual(['KCCreated']);
+    expect(filters[1].fromBlock).toBe(1_991_001);
+    expect(filters[1].toBlock).toBe(2_000_000);
+    expect(confirmed).toEqual([0x11, 0x22]);
+  });
+
+  it('dispatches collection update events and advances the collectionUpdates cursor', async () => {
+    const event: ChainEvent = {
+      type: 'KnowledgeAssetUpdated',
+      blockNumber: 50,
+      data: {
+        merkleRoot: '0x' + '44'.repeat(32),
+        batchId: '42',
+      },
+    };
+    const { adapter, filters } = makeChain(100, [event]);
+    const saveCalls: Array<{ lane: ChainEventPollerLane; block: number }> = [];
+    const cursor: LaneCursorPersistence = {
+      async loadLane() { return undefined; },
+      async saveLane(lane, block) { saveCalls.push({ lane, block }); },
+    };
+    const seen: Array<{ merkleRoot: Uint8Array; batchId: bigint; blockNumber: number }> = [];
+    const poller = new ChainEventPoller({
+      chain: adapter,
+      publishHandler: makeHandler(),
+      intervalMs: 60_000,
+      cursorPersistence: cursor,
+      onCollectionUpdated: async (info) => { seen.push(info); },
+    });
+
+    await poller.start();
+    await new Promise((r) => setTimeout(r, 50));
+    await poller.stop();
+
+    expect(filters[0].eventTypes).toEqual(['KnowledgeAssetUpdated']);
+    expect(seen).toHaveLength(1);
+    expect(Buffer.from(seen[0].merkleRoot).toString('hex')).toBe('44'.repeat(32));
+    expect(seen[0].batchId).toBe(42n);
+    expect(seen[0].blockNumber).toBe(50);
+    expect(saveCalls).toEqual([{ lane: 'collectionUpdates', block: 100 }]);
+  });
+
+  it('tails context graph discovery on the normal poll cadence', async () => {
+    const filters: EventFilter[] = [];
+    let now = 0;
+    let head = 1000;
+    let blockNumberCalls = 0;
+    const adapter = {
+      chainId: 'mock:0',
+      getBlockNumber: async () => {
+        blockNumberCalls++;
+        return head;
+      },
+      listenForEvents: async function* (f: EventFilter): AsyncIterable<ChainEvent> {
+        filters.push(f);
+      },
+    } as unknown as ChainAdapter;
+    const poller = new ChainEventPoller({
+      chain: adapter,
+      publishHandler: makeHandler(),
+      intervalMs: 20,
+      clock: () => now,
+      onContextGraphCreated: async () => { /* sink */ },
+      onKARegisteredToContextGraph: async () => { /* normal-cadence lane */ },
+    });
+
+    await (poller as unknown as { poll(): Promise<void> }).poll();
+    expect(filters.map((f) => f.eventTypes)).toEqual([
+      ['NameClaimed', 'ContextGraphCreated'],
+      ['KnowledgeAssetRegisteredToContextGraph'],
+    ]);
+
+    now = 25;
+    head = 1100;
+    await (poller as unknown as { poll(): Promise<void> }).poll();
+
+    expect(blockNumberCalls).toBe(2);
+    expect(filters.map((f) => f.eventTypes)).toEqual([
+      ['NameClaimed', 'ContextGraphCreated'],
+      ['KnowledgeAssetRegisteredToContextGraph'],
+      ['NameClaimed', 'ContextGraphCreated'],
+      ['KnowledgeAssetRegisteredToContextGraph'],
+    ]);
+    expect(filters[2].fromBlock).toBe(1001);
+    expect(filters[2].toBlock).toBe(1100);
+    expect(filters[3].fromBlock).toBe(1001);
+    expect(filters[3].toBlock).toBe(1100);
+  });
+
+  it('retries a failed context graph discovery lane on the next tick', async () => {
+    const filters: EventFilter[] = [];
+    const saveCalls: Array<{ lane: ChainEventPollerLane; block: number }> = [];
+    let calls = 0;
+    const adapter = {
+      chainId: 'mock:0',
+      getBlockNumber: async () => 100,
+      listenForEvents: async function* (f: EventFilter): AsyncIterable<ChainEvent> {
+        filters.push(f);
+        calls++;
+        if (calls === 1) throw new Error('rpc down');
+      },
+    } as unknown as ChainAdapter;
+    const cursor: LaneCursorPersistence = {
+      async loadLane() { return undefined; },
+      async saveLane(lane, block) { saveCalls.push({ lane, block }); },
+    };
+    const poller = new ChainEventPoller({
+      chain: adapter,
+      publishHandler: makeHandler(),
+      intervalMs: 20,
+      cursorPersistence: cursor,
+      clock: () => 0,
+      onContextGraphCreated: async () => { /* sink */ },
+    });
+
+    await poller.start();
+    await new Promise((r) => setTimeout(r, 80));
+    await poller.stop();
+
+    expect(filters.length).toBeGreaterThanOrEqual(2);
+    expect(filters[0].eventTypes).toEqual(['NameClaimed', 'ContextGraphCreated']);
+    expect(filters[1].eventTypes).toEqual(['NameClaimed', 'ContextGraphCreated']);
+    expect(filters[0].fromBlock).toBe(1);
+    expect(filters[0].toBlock).toBe(100);
+    expect(filters[1].fromBlock).toBe(1);
+    expect(filters[1].toBlock).toBe(100);
+    expect(saveCalls).toEqual([{ lane: 'contextGraphDiscovery', block: 100 }]);
+  });
+
+  it('keeps headless scans due until a known head proves the lane is caught up', async () => {
+    const filters: EventFilter[] = [];
+    const adapter = {
+      chainId: 'mock:0',
+      getBlockNumber: async () => { throw new Error('head unavailable'); },
+      listenForEvents: async function* (f: EventFilter): AsyncIterable<ChainEvent> {
+        filters.push(f);
+      },
+    } as unknown as ChainAdapter;
+    const poller = new ChainEventPoller({
+      chain: adapter,
+      publishHandler: makeHandler(),
+      intervalMs: 20,
+      clock: () => 0,
+      onContextGraphCreated: async () => { /* sink */ },
+    });
+
+    await poller.start();
+    await new Promise((r) => setTimeout(r, 90));
+    await poller.stop();
+
+    expect(filters.length).toBeGreaterThanOrEqual(2);
+    expect(filters[0].fromBlock).toBe(1);
+    expect(filters[0].toBlock).toBe(9000);
+    expect(filters[1].fromBlock).toBe(9001);
+    expect(filters[1].toBlock).toBe(18_000);
+  });
+});

--- a/packages/publisher/test/chain-event-lane-runner.unit.test.ts
+++ b/packages/publisher/test/chain-event-lane-runner.unit.test.ts
@@ -930,7 +930,7 @@ describe('ChainEventPoller lane runner and cursors', () => {
     ]);
   });
 
-  it('uses an explicit lane failure-backoff policy', async () => {
+  it('uses an explicit lane failure-backoff policy and caps repeated failures', async () => {
     const filters: EventFilter[] = [];
     let calls = 0;
     let now = 0;
@@ -940,7 +940,7 @@ describe('ChainEventPoller lane runner and cursors', () => {
       listenForEvents: async function* (f: EventFilter): AsyncIterable<ChainEvent> {
         filters.push(f);
         calls++;
-        if (calls <= 2) throw new Error('rpc down');
+        if (calls <= 3) throw new Error('rpc down');
       },
     } as unknown as ChainAdapter;
     const lane: ChainEventPollerLaneSpec = {
@@ -969,8 +969,13 @@ describe('ChainEventPoller lane runner and cursors', () => {
     await runner.poll();
     now = 30;
     await runner.poll();
+    now = 54;
+    await runner.poll();
+    now = 55;
+    await runner.poll();
 
     expect(filters.map((f) => [f.fromBlock, f.toBlock])).toEqual([
+      [1, 100],
       [1, 100],
       [1, 100],
       [1, 100],

--- a/packages/publisher/test/chain-event-lane-runner.unit.test.ts
+++ b/packages/publisher/test/chain-event-lane-runner.unit.test.ts
@@ -3,6 +3,7 @@ import { OxigraphStore } from '@origintrail-official/dkg-storage';
 import { TypedEventBus } from '@origintrail-official/dkg-core';
 import type { ChainAdapter, ChainEvent, EventFilter } from '@origintrail-official/dkg-chain';
 import { ChainEventPoller, type ChainEventPollerLane, type LaneCursorPersistence } from '../src/chain-event-poller.js';
+import { ChainEventLaneRunner, type ChainEventPollerLaneSpec } from '../src/chain-event-lane-runner.js';
 import { PublishHandler } from '../src/publish-handler.js';
 import type { JournalEntry } from '../src/publish-journal.js';
 
@@ -926,6 +927,53 @@ describe('ChainEventPoller lane runner and cursors', () => {
     expect(saveCalls).toEqual([
       { lane: 'contextGraphDiscovery', block: 100 },
       { lane: 'contextGraphDiscovery', block: 200 },
+    ]);
+  });
+
+  it('uses an explicit lane failure-backoff policy', async () => {
+    const filters: EventFilter[] = [];
+    let calls = 0;
+    let now = 0;
+    const adapter = {
+      chainId: 'mock:0',
+      getBlockNumber: async () => 100,
+      listenForEvents: async function* (f: EventFilter): AsyncIterable<ChainEvent> {
+        filters.push(f);
+        calls++;
+        if (calls <= 2) throw new Error('rpc down');
+      },
+    } as unknown as ChainAdapter;
+    const lane: ChainEventPollerLaneSpec = {
+      name: 'contextGraphDiscovery',
+      enabled: () => true,
+      eventTypes: () => ['ContextGraphCreated'],
+      requiresFullHistory: () => false,
+      cadenceMs: 20,
+      failureBackoff: { initialMs: 10, maxMs: 25 },
+      dispatch: async () => { /* sink */ },
+    };
+    const runner = new ChainEventLaneRunner({
+      chain: adapter,
+      lanes: [lane],
+      maxRange: 1000,
+      clock: () => now,
+      log: { info() {}, warn() {}, error() {} } as any,
+    });
+
+    await runner.poll();
+    now = 9;
+    await runner.poll();
+    now = 10;
+    await runner.poll();
+    now = 29;
+    await runner.poll();
+    now = 30;
+    await runner.poll();
+
+    expect(filters.map((f) => [f.fromBlock, f.toBlock])).toEqual([
+      [1, 100],
+      [1, 100],
+      [1, 100],
     ]);
   });
 

--- a/packages/publisher/test/chain-event-poller-extra.test.ts
+++ b/packages/publisher/test/chain-event-poller-extra.test.ts
@@ -20,10 +20,9 @@
  * This file covers:
  *   - cursor persistence across restart (load + advance)
  *   - load() errors are non-fatal
- *   - head-seed skip for old events when no pending publishes
- *   - early-block events NOT skipped when hasPendingPublishes (scan
- *     must cover the full history — losing them is a durability bug)
- *   - MAX_RANGE (9000-block) capping → multiple polls needed for large gaps
+ *   - live context graph tail starts near the chain head
+ *   - pending publishes do not force unrelated context graph backfill
+ *   - historical context graph recovery is left to the daemon chain scan
  *   - callback failures must NOT abort the poll (fault isolation)
  *   - double-start() is a no-op (no duplicate timers)
  *   - stop() is idempotent and clears the interval
@@ -54,7 +53,13 @@ import {
   HARDHAT_KEYS,
 } from '../../chain/test/evm-test-context.js';
 import { mintTokens } from '../../chain/test/hardhat-harness.js';
-import { ChainEventPoller, type CursorPersistence } from '../src/chain-event-poller.js';
+import {
+  ChainEventPoller,
+  type ChainEventPollerLane,
+  type CursorPersistence,
+  type LaneCursorPersistence,
+  type LegacyCursorPersistence,
+} from '../src/chain-event-poller.js';
 import { PublishHandler } from '../src/publish-handler.js';
 
 // Track adapters across the file so afterEach can release their HTTP
@@ -80,11 +85,21 @@ afterEach(() => {
   }
 });
 
-class InMemoryCursor implements CursorPersistence {
+class InMemoryCursor implements LegacyCursorPersistence {
   public saved: number[] = [];
   constructor(public loaded?: number) {}
   async load(): Promise<number | undefined> { return this.loaded; }
   async save(n: number): Promise<void> { this.saved.push(n); }
+}
+
+class InMemoryLaneCursor implements LaneCursorPersistence {
+  public saved: Array<{ lane: ChainEventPollerLane; block: number }> = [];
+  constructor(private readonly loaded = new Map<ChainEventPollerLane, number>()) {}
+  async loadLane(lane: ChainEventPollerLane): Promise<number | undefined> { return this.loaded.get(lane); }
+  async saveLane(lane: ChainEventPollerLane, block: number): Promise<void> {
+    this.saved.push({ lane, block });
+    this.loaded.set(lane, block);
+  }
 }
 
 async function pollOnce(_poller: ChainEventPoller, timeoutMs = 300): Promise<void> {
@@ -151,7 +166,7 @@ describe('ChainEventPoller — cursor persistence', () => {
     // observable: the first poll must start at `eventBlock` and pick up
     // the ContextGraphCreated that would otherwise be missed if the cursor
     // reset to 0 (slow / redundant) or to head (skips the event).
-    const cursor = new InMemoryCursor(eventBlock - 1);
+    const cursor = new InMemoryLaneCursor(new Map([['contextGraphDiscovery', eventBlock - 1]]));
     const received: Array<{ id: string; blockNumber: number }> = [];
 
     const poller = new ChainEventPoller({
@@ -174,16 +189,19 @@ describe('ChainEventPoller — cursor persistence', () => {
     expect(mine, `expected ContextGraphCreated at block ${eventBlock}; received=${JSON.stringify(received)}`).toBeDefined();
 
     // Cursor must have advanced past the event block (not regressed).
-    expect(cursor.saved.length).toBeGreaterThan(0);
-    expect(cursor.saved.at(-1)).toBeGreaterThanOrEqual(eventBlock);
+    const savedBlocks = cursor.saved
+      .filter((entry) => entry.lane === 'contextGraphDiscovery')
+      .map((entry) => entry.block);
+    expect(savedBlocks.length).toBeGreaterThan(0);
+    expect(savedBlocks.at(-1)).toBeGreaterThanOrEqual(eventBlock);
     const head = await provider.getBlockNumber();
-    expect(cursor.saved.at(-1)).toBeLessThanOrEqual(head);
+    expect(savedBlocks.at(-1)).toBeLessThanOrEqual(head);
   }, 30_000);
 
   it('persists advancing cursor to survive restart', async () => {
     const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
     const handler = new PublishHandler(new OxigraphStore(), new TypedEventBus());
-    const cursor = new InMemoryCursor();
+    const cursor = new InMemoryLaneCursor();
 
     // Take a snapshot of current head, then emit an event.
     const result = await createV10Cg(chain);
@@ -201,9 +219,12 @@ describe('ChainEventPoller — cursor persistence', () => {
     await pollOnce(poller);
     await poller.stop();
 
-    expect(cursor.saved.length).toBeGreaterThan(0);
+    const savedBlocks = cursor.saved
+      .filter((entry) => entry.lane === 'contextGraphDiscovery')
+      .map((entry) => entry.block);
+    expect(savedBlocks.length).toBeGreaterThan(0);
     // Final cursor must cover the block we emitted at.
-    expect(cursor.saved.at(-1)).toBeGreaterThanOrEqual(eventBlock);
+    expect(savedBlocks.at(-1)).toBeGreaterThanOrEqual(eventBlock);
   }, 30_000);
 
   it('load() errors are non-fatal (poller still starts)', async () => {
@@ -227,8 +248,8 @@ describe('ChainEventPoller — cursor persistence', () => {
   }, 15_000);
 });
 
-describe('ChainEventPoller — head seeding & range capping', () => {
-  it('seeds cursor near head (head - 500) when no pending publishes and no cursor persistence', async () => {
+describe('ChainEventPoller — context graph live tail', () => {
+  it('does not replay old context graph events outside the live tail window', async () => {
     const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
     const provider = createProvider();
     const handler = new PublishHandler(new OxigraphStore(), new TypedEventBus());
@@ -249,26 +270,26 @@ describe('ChainEventPoller — head seeding & range capping', () => {
       onContextGraphCreated: async (e) => { received.push(e.blockNumber); },
     });
 
-    // No cursor persistence + no pendings → poller seeds at head-500.
-    // Our old event (block oldEventBlock) is > 500 blocks behind head,
-    // so it MUST NOT be received on the first (seeded) poll.
+    // Context graph event polling is the live tail. Historical recovery runs
+    // through DKGAgent.discoverContextGraphsFromChain, not this event lane.
     await poller.start();
     await pollOnce(poller);
     await poller.stop();
 
-    expect(received.includes(oldEventBlock), `expected block ${oldEventBlock} to be skipped (head=${head}, seed=${head - 500}); received=${received.join(',')}`).toBe(false);
+    expect(received.includes(oldEventBlock), `old block ${oldEventBlock} should be left to chain discovery (head=${head}); received=${received.join(',')}`).toBe(false);
   }, 45_000);
 
-  it('does NOT skip early-block events when hasPendingPublishes (cursor is not seeded near head)', async () => {
+  it('does not let live pending publishes force context graph backfill from genesis', async () => {
     const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
     const provider = createProvider();
     const handler = new PublishHandler(new OxigraphStore(), new TypedEventBus());
 
-    // Plant a pending publish sentinel so `hasPendingPublishes === true` and
-    // the poller is FORCED to start scanning from lastBlock=0 (full history).
+    // Plant a live pending publish sentinel. The publish lane may become
+    // active, but it must not change the context graph lane into a historical
+    // backfill lane.
     (handler as unknown as { pendingPublishes: Map<string, unknown> }).pendingPublishes.set(
       'sentinel',
-      { expectedMerkleRoot: new Uint8Array(32) } as never,
+      { expectedMerkleRoot: new Uint8Array(32), restoredFromJournal: false } as never,
     );
     expect(handler.hasPendingPublishes).toBe(true);
 
@@ -277,8 +298,8 @@ describe('ChainEventPoller — head seeding & range capping', () => {
     const earlyBlock = result.blockNumber;
     expect(earlyBlock).toBeGreaterThan(beforeHead);
 
-    // Mine far past the early block — head would trigger head-500 seeding
-    // if hasPendingPublishes were false. This assertion proves it isn't.
+    // Mine far past the early block so it is outside the context live-tail
+    // window.
     await mineBlocks(2000);
 
     const received: number[] = [];
@@ -293,28 +314,26 @@ describe('ChainEventPoller — head seeding & range capping', () => {
     await pollOnce(poller, 500);
     await poller.stop();
 
-    // Early event must be picked up in the first poll. Scan range is
-    // [1, min(9000, head)]; earlyBlock < 9000 for a fresh Hardhat, so the
-    // event is reachable on the first poll even though head is far beyond.
-    expect(received.includes(earlyBlock), `expected block ${earlyBlock} to be picked up; received=${received.join(',')}`).toBe(true);
+    expect(received.includes(earlyBlock), `context graph block ${earlyBlock} should be left to chain discovery; received=${received.join(',')}`).toBe(false);
   }, 45_000);
 
-  it('caps scan range at MAX_RANGE (9000 blocks) — multiple polls needed to cover large gaps', async () => {
+  it('delivers near-head context graph events without walking the historical gap first', async () => {
     const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
     const provider = createProvider();
     const handler = new PublishHandler(new OxigraphStore(), new TypedEventBus());
 
-    // Pending publish forces full-history scan.
+    // Live pending publishes must not force unrelated context graph backfill.
     (handler as unknown as { pendingPublishes: Map<string, unknown> }).pendingPublishes.set(
       'sentinel',
-      { expectedMerkleRoot: new Uint8Array(32) } as never,
+      { expectedMerkleRoot: new Uint8Array(32), restoredFromJournal: false } as never,
     );
 
     // Emit an early event (current head + 1 after this tx).
     const earlyResult = await createV10Cg(chain);
     const earlyBlock = earlyResult.blockNumber;
 
-    // Mine past MAX_RANGE so cursor cannot cover the gap in one poll.
+    // Mine far enough that a genesis backfill would need multiple MAX_RANGE
+    // pages before it could reach the fresh event.
     await mineBlocks(10_000);
 
     // Emit a late event near current head — two events straddle the cap.
@@ -333,14 +352,13 @@ describe('ChainEventPoller — head seeding & range capping', () => {
     });
 
     await poller.start();
-    // Wait long enough for multiple polls (intervalMs=50, head-early > 9000
-    // means at least 2 polls are required to close the gap).
+    // Wait long enough for the live tail to catch the near-head event.
     await pollOnce(poller, 1500);
     await poller.stop();
 
-    // Both events are observed, but NOT in a single poll — the cursor
-    // had to advance through the MAX_RANGE boundary first.
-    expect(received.includes(earlyBlock), `earlyBlock ${earlyBlock} missing; received=${received.join(',')}`).toBe(true);
+    // The old event is left to chain discovery; the near-head event is
+    // observed promptly.
+    expect(received.includes(earlyBlock), `earlyBlock ${earlyBlock} should be left to chain discovery; received=${received.join(',')}`).toBe(false);
     expect(received.includes(lateBlock),  `lateBlock  ${lateBlock}  missing; received=${received.join(',')}`).toBe(true);
   }, 60_000);
 });
@@ -414,6 +432,7 @@ describe('ChainEventPoller — fault isolation & lifecycle', () => {
     // real node runtimes. Here we also check the `running` flag flipped
     // exactly once and that the second start() was a no-op.
     const pollCalls: number[] = [];
+    const cursor = new InMemoryLaneCursor(new Map([['contextGraphDiscovery', ourBlock - 1]]));
     const poller = new ChainEventPoller({
       chain,
       publishHandler: handler,
@@ -426,11 +445,8 @@ describe('ChainEventPoller — fault isolation & lifecycle', () => {
           pollCalls.push(e.blockNumber);
         }
       },
+      cursorPersistence: cursor,
     });
-
-    // Seed cursor right before our event so the first poll is guaranteed to
-    // reach it in the initial synchronous poll triggered by start().
-    (poller as unknown as { lastBlock: number }).lastBlock = ourBlock - 1;
 
     await poller.start();
     // Capture timer + running snapshot before the second start() call.

--- a/packages/publisher/test/chain-event-poller-ka-created.test.ts
+++ b/packages/publisher/test/chain-event-poller-ka-created.test.ts
@@ -1,29 +1,7 @@
-/**
- * OT-RFC-43 Option-1 — ChainEventPoller surfaces `KnowledgeAssetCreated`
- * (codex PR #976 F5 regression).
- *
- * The chain adapter's `listenForEvents()` decodes both the V10 greenfield
- * `KnowledgeAssetCreated` Solidity event AND the legacy V8/V9 batch-create
- * event into a SINGLE normalized `{ type: 'KCCreated', data: { kaId, author,
- * txHash, txIndex, ... } }` surface (see `packages/chain/src/evm-adapter-
- * events.ts` ~L119 and L193). A prior wiring iteration of the poller
- * subscribed to a distinct `KnowledgeAssetCreated` event type and dispatched
- * to `onKnowledgeAssetCreated` on a `event.type === 'KnowledgeAssetCreated'`
- * branch — but the adapter never yielded events with that type, so the
- * branch never fired and allocator reconciliation (`reconcileFloor`) never
- * ran. Cold-start refusal in `KaNumberAllocator` therefore never lifted on
- * a fresh daemon coming up against an existing chain.
- *
- * This test pins the corrected wiring: a `KCCreated` event (the only
- * create-event type the adapter ever emits) carrying `kaId` / `author` /
- * `txHash` / `txIndex` MUST dispatch to `onKnowledgeAssetCreated` with the
- * unpacked `(author, number)` pair, in addition to whatever publish-handler
- * fan-out the same event triggers.
- */
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { OxigraphStore } from '@origintrail-official/dkg-storage';
 import { TypedEventBus } from '@origintrail-official/dkg-core';
-import type { ChainAdapter, EventFilter, ChainEvent } from '@origintrail-official/dkg-chain';
+import type { ChainAdapter, ChainEvent, EventFilter } from '@origintrail-official/dkg-chain';
 import { ChainEventPoller } from '../src/chain-event-poller.js';
 import { PublishHandler } from '../src/publish-handler.js';
 
@@ -35,39 +13,31 @@ function makeChain(head: number, events: ChainEvent[]): {
   const adapter = {
     chainId: 'mock:0',
     getBlockNumber: async () => head,
-    // eslint-disable-next-line @typescript-eslint/require-await
     listenForEvents: async function* (f: EventFilter): AsyncIterable<ChainEvent> {
       filters.push(f);
+      const fromBlock = f.fromBlock ?? 0;
+      const toBlock = f.toBlock ?? Number.MAX_SAFE_INTEGER;
       for (const evt of events) {
-        if (f.eventTypes.includes(evt.type)) yield evt;
+        if (f.eventTypes.includes(evt.type) && evt.blockNumber >= fromBlock && evt.blockNumber <= toBlock) {
+          yield evt;
+        }
       }
     },
   } as unknown as ChainAdapter;
   return { adapter, filters };
 }
 
-describe('ChainEventPoller — KnowledgeAssetCreated (allocator reconciliation)', () => {
+describe('ChainEventPoller - KnowledgeAssetCreated allocator reconciliation', () => {
   it('dispatches onKnowledgeAssetCreated off the adapter-normalized KCCreated event', async () => {
-    // Pack a representative author-namespaced kaId:
-    //   kaId = (uint160(author) << 96) | number
-    // The poller reverses this and passes the per-author `number` to the
-    // allocator's reconcileFloor.
-    const author = '0x' + 'a1'.repeat(20);                       // checksum-irrelevant
+    const author = '0x' + 'a1'.repeat(20);
     const number = 7n;
     const packedKaId = (BigInt(author) << 96n) | number;
-
-    // The adapter ALWAYS yields create-events with `type: 'KCCreated'`,
-    // regardless of whether the underlying Solidity event was the V10
-    // greenfield `KnowledgeAssetCreated` or the legacy batch-create. This
-    // is the surface the poller must consume.
     const event: ChainEvent = {
       type: 'KCCreated',
       blockNumber: 901,
       data: {
         kaId: packedKaId.toString(),
         author,
-        // Fields the publish-handler fan-out consumes; the allocator
-        // reconciliation only needs kaId/author/txHash/txIndex.
         merkleRoot: '0x' + '11'.repeat(32),
         byteSize: '1024',
         publisherAddress: author,
@@ -77,10 +47,8 @@ describe('ChainEventPoller — KnowledgeAssetCreated (allocator reconciliation)'
         txIndex: 2,
       },
     };
-
     const { adapter, filters } = makeChain(1000, [event]);
     const handler = new PublishHandler(new OxigraphStore(), new TypedEventBus());
-
     const seen: Array<{
       kaId: bigint;
       author: string;
@@ -110,17 +78,11 @@ describe('ChainEventPoller — KnowledgeAssetCreated (allocator reconciliation)'
     await new Promise((r) => setTimeout(r, 50));
     await poller.stop();
 
-    // (1) The poller subscribes to the real adapter surface (`KCCreated`),
-    //     not a phantom `KnowledgeAssetCreated` filter type that the adapter
-    //     does not emit. This is the wiring regression — the bot's F5.
     expect(filters.length).toBeGreaterThanOrEqual(1);
     for (const f of filters) {
       expect(f.eventTypes).toContain('KCCreated');
       expect(f.eventTypes).not.toContain('KnowledgeAssetCreated');
     }
-
-    // (2) The callback receives the unpacked (author, number) plus tx
-    //     coordinates needed for the allocator's reconcileFloor + dedup.
     expect(seen).toHaveLength(1);
     expect(seen[0].kaId).toBe(packedKaId);
     expect(seen[0].author).toBe(author.toLowerCase());
@@ -131,46 +93,8 @@ describe('ChainEventPoller — KnowledgeAssetCreated (allocator reconciliation)'
   });
 
   it('enters the poll loop when onKnowledgeAssetCreated is the only subscriber wired', async () => {
-    // No pending publishes, no other callbacks — the only reason to scan is
-    // allocator reconciliation. The gating check must include `watchKACreated`.
     const { adapter, filters } = makeChain(1000, []);
     const handler = new PublishHandler(new OxigraphStore(), new TypedEventBus());
-
-    const poller = new ChainEventPoller({
-      chain: adapter,
-      publishHandler: handler,
-      intervalMs: 60_000,
-      onKnowledgeAssetCreated: async () => {
-        // intentionally empty — we only care that the poll fires
-      },
-    });
-
-    await poller.start();
-    await new Promise((r) => setTimeout(r, 50));
-    await poller.stop();
-
-    expect(filters.length).toBeGreaterThanOrEqual(1);
-    // KCCreated is always subscribed (it's the V10 publish-flow surface),
-    // independent of whether allocator reconciliation is also wired.
-    expect(filters[0].eventTypes).toContain('KCCreated');
-  });
-
-  // codex PR #976 F9: when `onKnowledgeAssetCreated` is wired and there
-  // is no persisted cursor, the poller MUST backfill from block 0.
-  // Without this, a fresh daemon would skip every `KCCreated` event
-  // older than ~500 blocks (the "seed near head" optimisation that
-  // applies to the pending-publish watcher) and the per-author floor
-  // for older authors would stay at 0. A subsequent `markReconciled()`
-  // would then be unsound — the allocator could re-issue a number
-  // already minted on-chain.
-  it('cold-starts from block 0 when onKnowledgeAssetCreated is wired (F9 backfill)', async () => {
-    // Chain head is 10_000 — well past the 500-block head-seed window.
-    // If the F9 backfill is missing, the poller would seed `lastBlock`
-    // at 9500 and the first filter would have fromBlock=9501, which
-    // would miss every historical `KCCreated` at e.g. block 1.
-    const { adapter, filters } = makeChain(10_000, []);
-    const handler = new PublishHandler(new OxigraphStore(), new TypedEventBus());
-
     const poller = new ChainEventPoller({
       chain: adapter,
       publishHandler: handler,
@@ -183,28 +107,17 @@ describe('ChainEventPoller — KnowledgeAssetCreated (allocator reconciliation)'
     await poller.stop();
 
     expect(filters.length).toBeGreaterThanOrEqual(1);
-    // First poll scans from block 1 (fromBlock = lastBlock + 1, and
-    // lastBlock stays at 0 because the F9 backfill suppressed the
-    // head-seed). Pre-fix this would have been 9501.
-    expect(filters[0].fromBlock).toBe(1);
-    // toBlock is capped by MAX_RANGE (9000) not the chain head, but it
-    // MUST cover historical territory (block 1) not just the tip.
-    expect(filters[0].toBlock).toBeLessThanOrEqual(10_000);
-    expect(filters[0].toBlock).toBeGreaterThanOrEqual(1);
+    expect(filters[0].eventTypes).toContain('KCCreated');
   });
 
-  // Sanity inverse: with NO allocator watcher and no pending publishes,
-  // the head-seed optimisation still kicks in. We're not regressing
-  // the existing behaviour for the "watch context graphs only" path.
-  it('still seeds near head when onKnowledgeAssetCreated is NOT wired', async () => {
+  it('cold-starts from block 0 when onKnowledgeAssetCreated is wired', async () => {
     const { adapter, filters } = makeChain(10_000, []);
     const handler = new PublishHandler(new OxigraphStore(), new TypedEventBus());
-
     const poller = new ChainEventPoller({
       chain: adapter,
       publishHandler: handler,
       intervalMs: 60_000,
-      onContextGraphCreated: async () => { /* sink */ },
+      onKnowledgeAssetCreated: async () => { /* sink */ },
     });
 
     await poller.start();
@@ -212,7 +125,8 @@ describe('ChainEventPoller — KnowledgeAssetCreated (allocator reconciliation)'
     await poller.stop();
 
     expect(filters.length).toBeGreaterThanOrEqual(1);
-    // head-seed: lastBlock = head - 500 = 9500, so fromBlock = 9501.
-    expect(filters[0].fromBlock).toBe(9_501);
+    expect(filters[0].fromBlock).toBe(1);
+    expect(filters[0].toBlock).toBeLessThanOrEqual(10_000);
+    expect(filters[0].toBlock).toBeGreaterThanOrEqual(1);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -298,6 +298,12 @@ importers:
         specifier: ^4.0.18
         version: 4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.19.11)(happy-dom@20.8.9(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
+  devnet/rpc-quiet-window:
+    devDependencies:
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.19.11)(happy-dom@20.8.9(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
+
   devnet/v10-core-flows:
     dependencies:
       ethers:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,6 +14,7 @@ packages:
   - "devnet/edge-update-flow"
   - "devnet/greenfield-10min"
   - "devnet/rich-scenario"
+  - "devnet/rpc-quiet-window"
   - "devnet/v10-rs-prune"
   - "devnet/_bootstrap"
   - "devnet/pr1386-term-canon"


### PR DESCRIPTION
## Summary

This PR now contains the full DKG-node RPC reduction stack, including the merged chained PRs #1461, #1481, #1487, and #1491. It reduces RPC pressure across steady-state polling, startup catch-up, and the previously dominant `identityStorage.getIdentityId` `eth_call` path, while preserving the covered node workflows.

At a high level, the PR:

- Eliminates repeated steady-state `eth_chainId` detection by validating configured RPC endpoints once and then using counted static-network providers.
- Reduces hot `eth_call` traffic with bounded positive TTL caches, keyed single-flight coalescing, stale-write guards, PCA account-info caching, reverse-agent lookup coalescing, explicit PCA write invalidation, and targeted signer identity caching.
- Replaces hidden ethers Hub subscriptions with an owned Hub rotation poller that explicitly polls, deduplicates logs, handles reorg windows, bounds reads, and keeps lifecycle cancellation visible.
- Splits publisher chain-event polling into independently scheduled lanes with durable cursors, lazy restoration, legacy cursor compatibility, and failed-lane backoff.
- Drastically reduces `eth_getLogs` by using lane-specific polling, bounded scans, owned Hub polling, and context-graph registry cursors instead of repeated broad catch-up scans.
- Adds startup catch-up / persisted-cursor optimization so a fresh or restarted node does not replay the expensive context-graph registry scan burst once safe cursor state exists.
- Adds `eth_call` consumer attribution while preserving aggregate `rpc_usage` logs, then uses that attribution to collapse repeated `identityStorage.getIdentityId` calls.
- Adds regression coverage plus a registered `devnet/rpc-quiet-window` suite for idle RPC budget validation.

The latest live Base Sepolia benchmark after #1491 shows a large reduction versus `origin/main`: `93.8%` lower total RPC in idle, `93.2%` lower during the activity matrix, and `92.9%` lower post-activity idle. Compared with the PR #1440 branch after the startup-catchup work (#1481 benchmark), the identity-cache PR reduces total RPC another `46.0%` in idle, `61.5%` during activity, and `50.4%` post-idle.

The previous attribution run found `identityStorage.getIdentityId` as the dominant `eth_call` spender at `431` calls. After #1491, the same fresh-start window saw `8` calls in the first startup minute and `10` across the first three startup windows, a `97.7%` reduction against the prior attributed identity-spend total. Covered functionality remained intact across the benchmark and the follow-up lifecycle run: runtime build, node start/stop, public status and RPC health, wallet, publisher, context graph, KA create/write/finalize/share/query/pull, PCA read/write cleanup, served node UI dashboard/PCA rendering, and async share jobs all passed.

## Latest benchmark results

The latest benchmark reused the same Windows testnet shape as the earlier PR #1440/#1461/#1481 reports: 2-minute warmup, 5-minute idle baseline, the same CLI/API/KA/publisher activity matrix, and 5-minute post-activity idle with an isolated `DKG_HOME` from the funded testnet config bundle.

References:

- Main baseline: `origin/main` at `397f50b414a45930cd803440331e0136b8e4f756` from run `20260705-201200`.
- Post-startup-catchup reference: PR #1481 head `cff3a60c230ba7c65760e23873a5fdf998e1eedc`, included in this PR via merge commit `fa6c76b97b8eac70c53457ffbad5166a31fd0fba`.
- `eth_call` attribution reference: PR #1487 at `a47b3179f70d308cf8f43a17f6fbf4d9f31b7922`, report `testnet-pr1487-20260706-224126`.
- Identity-cache validation: PR #1491 head `3c5ad4c6b10a260ce31a4aaa6211872da65896c1`, included in this PR via merge commit `a5feeaa646627d1d1bcc0afa0c330fee8434f3ad`, report `testnet-pr1491-identity-rpc-benchmark-pr1491-20260707-015417`.
- Full lifecycle validation: PR #1491 head `3c5ad4c6b10a260ce31a4aaa6211872da65896c1`, report `testnet-pr1491-cg-ka-pca-lifecycle-cg-ka-pca-20260707-023824`.

### Total RPC calls

| Phase | Main calls/min | #1481 base calls/min | Current PR calls/min | Reduction vs main | Reduction vs #1481 |
| --- | ---: | ---: | ---: | ---: | ---: |
| Idle baseline | 609.4 | 70.0 | 37.8 | 93.8% | 46.0% |
| Activity | 607.25 | 107.23 | 41.25 | 93.2% | 61.5% |
| Post-activity idle | 554.0 | 79.2 | 39.25 | 92.9% | 50.4% |

### `eth_call`

| Phase | Main `eth_call`/min | #1481 base `eth_call`/min | Current PR `eth_call`/min | Reduction vs main | Reduction vs #1481 |
| --- | ---: | ---: | ---: | ---: | ---: |
| Idle baseline | 62.8 | 37.2 | 1.8 | 97.1% | 95.2% |
| Activity | 88.5 | 75.48 | 5.0 | 94.4% | 93.4% |
| Post-activity idle | 59.4 | 44.8 | 3.25 | 94.5% | 92.7% |

### `eth_getLogs`

| Phase | Main `eth_getLogs`/min | Current PR `eth_getLogs`/min | Reduction |
| --- | ---: | ---: | ---: |
| Idle baseline | 349.8 | 22.4 | 93.6% |
| Activity | 314.25 | 23.25 | 92.6% |
| Post-activity idle | 316.2 | 23.0 | 92.7% |

### Other major methods

| Phase | Method | Main calls/min | Current PR calls/min | Reduction |
| --- | --- | ---: | ---: | ---: |
| Idle baseline | `eth_chainId` | 137.4 | 0.2 | 99.9% |
| Activity | `eth_chainId` | 140.25 | 0.0 | 100.0% |
| Post-activity idle | `eth_chainId` | 114.0 | 0.0 | 100.0% |
| Idle baseline | `eth_blockNumber` | 59.4 | 13.4 | 77.4% |
| Activity | `eth_blockNumber` | 64.25 | 13.0 | 79.8% |
| Post-activity idle | `eth_blockNumber` | 64.4 | 13.0 | 79.8% |

### Startup catch-up improvement

The #1461 benchmark had already reduced steady-state `eth_getLogs`, but fresh-home idle still had a startup catch-up burst. PR #1481 removed that burst.

| Comparison | Idle `eth_getLogs`/min | Result |
| --- | ---: | --- |
| Captured post-`eth_getLogs` base (#1461) | 170.0 | Startup catch-up still front-loaded the idle phase |
| Current PR | 22.4 | 86.8% lower than the captured base |

The per-window idle pattern changed from `294, 280, 299, 231, 23` calls/min in the captured base run to a steady low-20s/min profile after the cursor and polling changes. The remaining steady floor is now mostly lane polling plus block-number cadence, not the prior broad startup scan burst.

### `eth_call` attribution and identity reduction

PR #1487 added consumer attribution without changing `eth_call` volume. That validation attributed `532 / 535` captured `eth_call`s and identified `identityStorage.getIdentityId` as the largest spender at `431` calls (`~80.6%` of captured `eth_call`). PR #1491 targeted that spender directly.

| Metric | PR #1487 attribution run | Current PR after #1491 | Reduction |
| --- | ---: | ---: | ---: |
| First startup window `identityStorage.getIdentityId` | ~431 dominant identity calls | 8 | ~98.1% |
| First three startup windows `identityStorage.getIdentityId` | 431 | 10 | 97.7% |
| First three startup windows aggregate `eth_call` | 535 | 92 | 82.8% |

Identity consumer totals in the latest run:

| Phase | `identityStorage.getIdentityId` total | Identity calls/min |
| --- | ---: | ---: |
| Warmup | 10 | 5.0 |
| Idle baseline | 4 | 0.8 |
| Activity | 9 | 2.25 |
| Post-activity idle | 6 | 1.5 |

Interpretation: the former dominant `eth_call` spender is no longer a startup/read-path source of quota burn. Further RPC reduction should now focus on the remaining steady `eth_getLogs` and `eth_blockNumber` floor.

### Functional validation and caveats

Passed in the latest live testnet benchmark and lifecycle validation:

- Runtime build and native `better-sqlite3` database-open check.
- Daemon startup, API readiness, and isolated cleanup.
- `/api/status` and `/api/chain/rpc-health` returned HTTP 200.
- Public status reported connected peers, relay connectivity, `admission.rejectedTotal=0`, and `chain.rpcExhaustions=0`.
- Wallet, publisher wallet/stats/jobs, context graph commands, KA create/share/history/query/pull, and async share job success.
- Context graph create, on-chain register with PCA policy, subgraph create, KA write/finalize/seal/share to SWM/pull/query, PCA discovery/read/write cleanup, and served node UI dashboard/CG/PCA rendering.
- Critical log scans found no fatal, uncaught, unhandled, type, syntax, reference, EADDRINUSE, or managed Oxigraph startup failures.

Interpreted caveats:

- The full lifecycle validation used the prepared bundle's default `oxigraph-server` backend and passed. The earlier RPC benchmark report recorded `oxigraph-worker` in its isolated home; the chain RPC reduction target is independent of the local RDF store backend, but future benchmark runs should preserve `oxigraph-server` unless explicitly testing worker behavior.
- VM finality in the lifecycle run reached the known public-testnet `storage_ack_insufficient` boundary. The async VM job was accepted, claimed, and validated, then failed at broadcast with retryable external-infrastructure failure.
- Protected raw API probes returned HTTP 401 in the benchmark harness, while public status/RPC-health and CLI paths passed.
- One benchmark `ka publish-async` path rejected an unsealed SWM share, matching prior workload/state caveats rather than an RPC regression.

## Implementation highlights

- Static-network counted providers validate numeric EVM RPC configs once per endpoint, preventing repeated chain-id checks while still rejecting wrong-chain or unavailable RPCs.
- `TtlValueCache`, `KeyedSingleFlight`, `HubResolutionCache`, and PCA read caches centralize bounded caching/coalescing behavior.
- `HubRotationPoller` replaces hidden subscription behavior with explicit, cancellable, bounded polling and log identity dedupe.
- `ChainEventLaneRunner` owns event-lane cadence, cursors, lazy restoration, failed-lane backoff, and legacy cursor compatibility.
- Context graph registry scanning now has explicit scan modes, paged scan/ack behavior, durable cursor handling, legacy adapter compatibility, and safe partial-failure behavior.
- Daemon/node-ui cursor stores persist runtime cursor state outside generic settings, with migration/fallback coverage.
- Agent and CLI boundaries pass explicit context-graph discovery scan policy without accidentally triggering broad full-history scans.

## Scope note

This PR does not intentionally change random-sampling-specific code or the random sampling prover/bind implementation. Random sampling may indirectly benefit from shared chain-adapter provider behavior, but its core challenge/proof flow and random-sampling RPC logic are not part of this change.

## Related

- Includes merged chained PR #1461: reduce remaining `eth_getLogs` pressure.
- Includes merged chained PR #1481: reduce startup context-graph catch-up RPCs.
- Includes merged chained PR #1487: attribute `eth_call` RPC usage by consumer.
- Includes merged chained PR #1491: reduce repeated `identityStorage.getIdentityId` reads.
- Follow-ups filed during review: #1448, #1449, #1452, #1454, #1455, #1456, #1457, #1466, #1467, #1484, #1485, #1486, #1490.

## Files changed

| File | What |
|------|------|
| `packages/chain/src/rpc-usage.ts`, `packages/chain/src/evm-adapter-base.ts` | Counted static-network provider setup, one-time endpoint validation, adapter cache ownership, and RPC failover integration. |
| `packages/chain/src/rpc-failover-client.ts`, `packages/cli/src/daemon/rpc-usage-log.ts`, `packages/agent/test/rpc-usage-boundary.test.ts` | `eth_call` consumer attribution, explicit `ReadOpts.rpcUsageConsumer`, aggregate-log compatibility, and boundary coverage. |
| `packages/chain/src/keyed-ttl-single-flight-cache.ts`, `packages/chain/src/hub-resolution-cache.ts`, `packages/chain/src/pca-read-cache.ts` | Shared bounded cache and single-flight primitives for hot chain reads. |
| `packages/chain/src/hub-rotation-poller.ts` | Owned Hub rotation polling with bounded reads, dedupe, reorg tolerance, lifecycle cancellation, and failover-aware reads. |
| `packages/chain/src/evm-adapter-identity.ts`, `packages/chain/src/evm-adapter-conviction.ts`, `packages/chain/src/evm-adapter-publish.ts` | Identity/PCA/publish read caching, write invalidation, and read-path coalescing. |
| `packages/chain/src/evm-adapter-context-graph.ts`, `packages/chain/src/context-graph-registry-scan-cursor.ts`, `packages/chain/src/chain-adapter.ts`, `packages/chain/src/mock-adapter.ts` | Context-graph registry scan modes, cursor persistence, page ack semantics, and adapter compatibility. |
| `packages/publisher/src/chain-event-lane-runner.ts`, `packages/publisher/src/chain-event-poller.ts`, `packages/publisher/src/chain-event-lane-cursor-store.ts` | Event-lane scheduling, durable cursors, backoff, dispatch policy, and cursor store wiring. |
| `packages/cli/src/daemon/lifecycle.ts`, `packages/cli/test/chain-discovery-scan-mode.test.ts` | Daemon startup/recovery scan policy and CLI regression coverage. |
| `packages/agent/src/dkg-agent*.ts`, `packages/agent/test/*` | Agent context-graph discovery scan options, legacy adapter fallback, and scan/cursor wiring coverage. |
| `packages/node-ui/src/chain-cursor-stores.ts`, `packages/node-ui/src/db.ts`, `packages/node-ui/test/*` | Runtime cursor persistence, settings fallback/migration behavior, and node-ui store coverage. |
| `packages/chain/test/*`, `packages/publisher/test/*`, `packages/cli/test/*`, `packages/agent/test/*` | Static-network, cache, PCA, Hub poller, context-graph scan, failover, lifecycle, lane, cursor, and backoff regression tests. |
| `devnet/rpc-quiet-window/*`, `devnet/suites.json`, `package.json`, `pnpm-*` | Registered idle RPC quiet-window devnet suite and workspace metadata. |

Note: investigation/planning artifacts and live benchmark reports were kept local to the Codex run and are intentionally not part of the repository diff.

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg-core --filter @origintrail-official/dkg-storage --filter @origintrail-official/dkg-chain --filter @origintrail-official/dkg-publisher run build`
- [x] `pnpm --dir packages/chain exec vitest run --config vitest.unit.config.ts test/keyed-ttl-single-flight-cache.unit.test.ts test/rpc-usage.unit.test.ts test/evm-adapter.unit.test.ts test/evm-adapter-pca-rpc.unit.test.ts test/evm-adapter-op-wallet.unit.test.ts --reporter dot`
- [x] `pnpm --dir packages/publisher exec vitest run test/chain-event-poller-v10-only.test.ts test/chain-event-poller-ka-registered.test.ts test/chain-event-poller-ka-created.test.ts test/chain-event-poller-extra.test.ts --reporter dot`
- [x] `pnpm test:devnet:manifest -- --reporter dot`
- [x] `pnpm exec vitest run --config devnet/rpc-quiet-window/vitest.config.ts -t "parses the committed" --reporter dot`
- [x] PR #1461 focused verification across review rounds: CLI scan-policy tests, chain Hub rotation/context-graph/unit/e2e slices, publisher lane-runner tests, agent context-graph discovery tests, and CLI/chain/publisher/agent builds.
- [x] PR #1481 focused verification across review rounds: context-graph registry scan tests, chain cursor tests, node-ui cursor-store tests, agent discovery tests, CLI scan-mode tests, package builds, and diff hygiene.
- [x] Live Windows testnet benchmark after #1461: `83.2%` post-idle total RPC reduction and `93.1%` post-idle `eth_getLogs` reduction versus `origin/main`.
- [x] Live Windows testnet benchmark after #1481: `88.5%` idle total RPC reduction, `82.3%` activity total RPC reduction, `85.7%` post-idle total RPC reduction, and `94.1%` idle `eth_getLogs` reduction versus `origin/main`; covered node workflows passed.
- [x] PR #1487 focused verification: chain RPC attribution/failover tests (4 files, 77 tests), CLI RPC formatter tests (1 file, 14 tests), agent RPC boundary tests (1 file, 4 tests), chain/CLI builds, and native `better-sqlite3` runtime check.
- [x] Live Windows testnet attribution validation after #1487: daemon startup, CLI/API status/wallet/peer/PCA read smoke, post-telemetry responsiveness, preserved aggregate `rpc_usage`, 33 `rpc_usage_by_consumer method=eth_call` lines, 532/535 `eth_call`s attributed, 0 bad labels.
- [x] PR #1491 focused verification: `evm-adapter.unit.test.ts` through 195 tests, `packages/chain` build, `tsc --noEmit`, `git diff --check`, thread-aware PR review sweep with 0 unresolved active threads, and merge into PR #1440 via `a5feeaa646627d1d1bcc0afa0c330fee8434f3ad`.
- [x] Live Windows testnet benchmark after #1491: `93.8%` idle total RPC reduction, `93.2%` activity total RPC reduction, `92.9%` post-idle total RPC reduction versus `origin/main`; `97.7%` reduction in first-three-window `identityStorage.getIdentityId` calls versus #1487 attribution; covered node workflows passed.
- [x] Live Windows testnet CG/KA/PCA lifecycle validation after #1491: default `oxigraph-server`, CG create/register, KA write/finalize/seal/share/pull/query, PCA read/write cleanup, served UI dashboard/PCA validation, async VM queue path accepted/validated until known public-testnet `storage_ack_insufficient` broadcast boundary.
- [x] PR #1440 GitHub check sweep after merging #1487: head `77cdd495773faf718cf8968fcf225131ca1f6982`; visible CodeQL checks passed and the Dependabot advisory-gate jobs were skipped as before.
