### PR TITLE
Reduce eth_getLogs background polling

### DIFF
--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -462,8 +462,6 @@ export interface AssertionHistoryDescriptor extends AssertionDescriptor {
 export interface DiscoverContextGraphsFromChainOptions {
   incremental?: boolean;
   seedIncrementalWatermark?: boolean;
-  liveTailOnly?: boolean;
-  liveTailLookbackBlocks?: number;
   throwOnChainScanFailure?: boolean;
 }
 
@@ -1107,16 +1105,15 @@ export class DKGAgent extends DKGAgentBase {
     let partialChainScan = false;
     let partialChainScanError: unknown;
     try {
-      const scanOptions = options.incremental || options.seedIncrementalWatermark || options.liveTailOnly
+      const scanOptions = options.incremental
         ? {
-            ...(options.incremental ? { incremental: true } : {}),
-            ...(options.seedIncrementalWatermark ? { seedIncrementalWatermark: true } : {}),
-            ...(options.liveTailOnly ? { liveTailOnly: true } : {}),
-            ...(options.liveTailLookbackBlocks !== undefined
-              ? { liveTailLookbackBlocks: options.liveTailLookbackBlocks }
-              : {}),
+            incremental: true as const,
           }
-        : undefined;
+        : options.seedIncrementalWatermark
+          ? {
+              seedIncrementalWatermark: true as const,
+            }
+          : undefined;
       onChainContextGraphs = await this.chain.listContextGraphsFromChain(undefined, scanOptions);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -462,6 +462,8 @@ export interface AssertionHistoryDescriptor extends AssertionDescriptor {
 export interface DiscoverContextGraphsFromChainOptions {
   incremental?: boolean;
   seedIncrementalWatermark?: boolean;
+  liveTailOnly?: boolean;
+  liveTailLookbackBlocks?: number;
   throwOnChainScanFailure?: boolean;
 }
 
@@ -1105,11 +1107,16 @@ export class DKGAgent extends DKGAgentBase {
     let partialChainScan = false;
     let partialChainScanError: unknown;
     try {
-      const scanOptions = options.incremental
-        ? { incremental: true }
-        : options.seedIncrementalWatermark
-          ? { seedIncrementalWatermark: true }
-          : undefined;
+      const scanOptions = options.incremental || options.seedIncrementalWatermark || options.liveTailOnly
+        ? {
+            ...(options.incremental ? { incremental: true } : {}),
+            ...(options.seedIncrementalWatermark ? { seedIncrementalWatermark: true } : {}),
+            ...(options.liveTailOnly ? { liveTailOnly: true } : {}),
+            ...(options.liveTailLookbackBlocks !== undefined
+              ? { liveTailLookbackBlocks: options.liveTailLookbackBlocks }
+              : {}),
+          }
+        : undefined;
       onChainContextGraphs = await this.chain.listContextGraphsFromChain(undefined, scanOptions);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -2354,17 +2354,11 @@ describe('discoverContextGraphsFromChain', () => {
     expect(await agent.discoverContextGraphsFromChain()).toBe(0);
     expect(await agent.discoverContextGraphsFromChain({ incremental: true })).toBe(0);
     expect(await agent.discoverContextGraphsFromChain({ seedIncrementalWatermark: true })).toBe(0);
-    expect(await agent.discoverContextGraphsFromChain({
-      liveTailOnly: true,
-      liveTailLookbackBlocks: 123,
-      seedIncrementalWatermark: true,
-    })).toBe(0);
 
     expect(calls).toEqual([
       undefined,
       { incremental: true },
       { seedIncrementalWatermark: true },
-      { seedIncrementalWatermark: true, liveTailOnly: true, liveTailLookbackBlocks: 123 },
     ]);
   }, 15000);
 

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -2354,8 +2354,18 @@ describe('discoverContextGraphsFromChain', () => {
     expect(await agent.discoverContextGraphsFromChain()).toBe(0);
     expect(await agent.discoverContextGraphsFromChain({ incremental: true })).toBe(0);
     expect(await agent.discoverContextGraphsFromChain({ seedIncrementalWatermark: true })).toBe(0);
+    expect(await agent.discoverContextGraphsFromChain({
+      liveTailOnly: true,
+      liveTailLookbackBlocks: 123,
+      seedIncrementalWatermark: true,
+    })).toBe(0);
 
-    expect(calls).toEqual([undefined, { incremental: true }, { seedIncrementalWatermark: true }]);
+    expect(calls).toEqual([
+      undefined,
+      { incremental: true },
+      { seedIncrementalWatermark: true },
+      { seedIncrementalWatermark: true, liveTailOnly: true, liveTailLookbackBlocks: 123 },
+    ]);
   }, 15000);
 
   it('warns once for repeated chain scan failures and logs recovery', async () => {

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -371,6 +371,14 @@ export interface ContextGraphChainScanOptions {
    * public SDK list-all calls remain side-effect free by default.
    */
   seedIncrementalWatermark?: boolean;
+  /**
+   * Daemon-oriented mode: scan only a bounded live-tail window near the current
+   * head when no incremental watermark exists. Public list-all calls should
+   * omit this so they retain full historical semantics.
+   */
+  liveTailOnly?: boolean;
+  /** Number of recent blocks to scan when `liveTailOnly` is set. */
+  liveTailLookbackBlocks?: number;
 }
 
 // ----- On-Chain Context Graph types (ContextGraphs contract) -----

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -371,14 +371,6 @@ export interface ContextGraphChainScanOptions {
    * public SDK list-all calls remain side-effect free by default.
    */
   seedIncrementalWatermark?: boolean;
-  /**
-   * Daemon-oriented mode: scan only a bounded live-tail window near the current
-   * head when no incremental watermark exists. Public list-all calls should
-   * omit this so they retain full historical semantics.
-   */
-  liveTailOnly?: boolean;
-  /** Number of recent blocks to scan when `liveTailOnly` is set. */
-  liveTailLookbackBlocks?: number;
 }
 
 // ----- On-Chain Context Graph types (ContextGraphs contract) -----

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -118,6 +118,11 @@ export const CG_REGISTRY_MAX_SCAN_PAGES = Math.ceil(
 
 export const CG_REGISTRY_REORG_BUFFER_BLOCKS = 50;
 
+export const CG_REGISTRY_LIVE_TAIL_LOOKBACK_BLOCKS = 9_000;
+
+const HUB_ROTATION_POLL_INTERVAL_MS = DEFAULT_RANDOM_SAMPLING_HUB_REFRESH_MS;
+const HUB_ROTATION_REORG_BUFFER_BLOCKS = 50;
+
 /**
  * Per-backend timeout for a single KnowledgeAssetCreated scan page before
  * failing over to the next eligible backend — generous enough for a slow
@@ -522,6 +527,12 @@ export class EVMChainAdapterBase {
   protected readonly pcaReadCache = new PcaReadCache();
 
   protected hubRotationListenerStarted = false;
+
+  protected hubRotationPollTimer: ReturnType<typeof setInterval> | null = null;
+
+  protected hubRotationPollInFlight: Promise<void> | null = null;
+
+  protected hubRotationLastScannedBlock: number | undefined;
 
   /**
    * Single-flight guard for the best-effort
@@ -3108,53 +3119,108 @@ export class EVMChainAdapterBase {
    * on the update path it emits both `ContractChanged` AND
    * `NewContract`. Storage bindings resolved through
    * `getAssetStorageAddress(...)` emit the parallel `AssetStorageChanged`
-   * / `NewAssetStorage` events. We listen to all four events so the cache
+   * / `NewAssetStorage` events. We poll all four event topics so the cache
    * invalidates regardless of which Hub set owns the name, and both the
    * RS-pair invalidation and the generic boot-bound invalidation are
    * idempotent so duplicate notifications are harmless.
    *
-   * `Contract.on(...)` is async in ethers v6: a sync `try/catch` would
-   * miss provider rejections (e.g. HTTP-only endpoints that can't
-   * install filter subscriptions) and leave us with an unhandled
-   * rejection. We `await` every subscription and only set
-   * `hubRotationListenerStarted` after all succeed, so a failed
-   * provider can be retried by a future call site if we ever need to
-   * — and meanwhile the TTL refresh path (for RS) and the
-   * `withHubStaleRetry` write-side fallback (for all boot-bound
-   * contracts) still keep stale bindings recoverable without a
-   * working event subscription.
+   * We deliberately avoid `Contract.on(...)` here. With `polling: true`,
+   * ethers implements each subscription as its own steady `eth_getLogs`
+   * poller. One adapter-owned poller with an OR-topic filter preserves
+   * rotation detection without four hidden idle log streams.
    */
   protected async startHubRotationListener(): Promise<void> {
     if (this.hubRotationListenerStarted) return;
-    const onChange = (name: unknown): void => {
-      if (typeof name !== 'string') return;
-      if (name === 'RandomSampling' || name === 'RandomSamplingStorage') {
-        this.invalidateRandomSamplingPair();
-        return;
-      }
-      if (BOUND_CONTRACT_INVALIDATORS.has(name)) {
-        this.invalidatePublishPreflightCache();
-        // Force the next public-method entry through `init()` so it
-        // re-resolves every binding. Do not clear the current handle
-        // here: the callback can fire between a public method's
-        // `await init()` and its first `this.contracts.X` read.
-        this.initialized = false;
-      }
-    };
     try {
-      await withTimeout(
-        this.ensureConfiguredStaticChainIdValidated(this.primaryProvider),
-        RPC_READ_STALL_TIMEOUT_MS,
-        'Hub rotation listener chainId validation',
-      );
-      await this.contracts.hub.on('ContractChanged', onChange);
-      await this.contracts.hub.on('NewContract', onChange);
-      await this.contracts.hub.on('AssetStorageChanged', onChange);
-      await this.contracts.hub.on('NewAssetStorage', onChange);
+      await this.pollHubRotationEvents();
+      this.hubRotationPollTimer = setInterval(() => {
+        if (this.hubRotationPollInFlight) return;
+        this.hubRotationPollInFlight = this.pollHubRotationEvents()
+          .catch(() => { /* optional listener path */ })
+          .finally(() => { this.hubRotationPollInFlight = null; });
+      }, HUB_ROTATION_POLL_INTERVAL_MS);
+      if (this.hubRotationPollTimer.unref) this.hubRotationPollTimer.unref();
       this.hubRotationListenerStarted = true;
     } catch {
-      /* provider doesn't support filter subscriptions — TTL refresh (RS)
+      /* provider doesn't support log polling — TTL refresh (RS)
        * and `withHubStaleRetry` (writes) are the fallbacks */
+    }
+  }
+
+  protected async pollHubRotationEvents(): Promise<void> {
+    const hub = this.contracts.hub;
+    if (!hub) return;
+
+    const topics = this.hubRotationEventTopics(hub);
+    if (topics.length === 0) return;
+
+    const head = await this.readProvider(
+      'Hub rotation poll getBlockNumber',
+      (provider) => provider.getBlockNumber(),
+    );
+    const candidateFromBlock = this.hubRotationLastScannedBlock == null
+      ? head - HUB_ROTATION_REORG_BUFFER_BLOCKS
+      : this.hubRotationLastScannedBlock + 1 - HUB_ROTATION_REORG_BUFFER_BLOCKS;
+    const recentFromBlock = head - HUB_ROTATION_REORG_BUFFER_BLOCKS;
+    const fromBlock = Math.max(
+      0,
+      Math.min(candidateFromBlock, recentFromBlock),
+    );
+    const hubAddress = await this.hubContractAddress(hub);
+    const logs = await this.readProvider<ethers.Log[]>(
+      'Hub rotation poll getLogs',
+      (provider) => provider.getLogs({
+        address: hubAddress,
+        fromBlock,
+        toBlock: head,
+        topics: [topics],
+      }),
+      { policy: 'wideLogScan' },
+    );
+
+    for (const log of logs) {
+      try {
+        const parsed = hub.interface.parseLog({ topics: [...log.topics], data: log.data });
+        if (!parsed) continue;
+        this.applyHubRotationEventName(parsed.args?.contractName ?? parsed.args?.[0]);
+      } catch {
+        // Ignore malformed/unexpected Hub logs. The topic filter should already
+        // constrain these, but a parse miss must not wedge the poll cursor.
+      }
+    }
+    this.hubRotationLastScannedBlock = head;
+  }
+
+  protected hubRotationEventTopics(hub: Contract): string[] {
+    return [
+      'ContractChanged',
+      'NewContract',
+      'AssetStorageChanged',
+      'NewAssetStorage',
+    ].flatMap((eventName) => {
+      const event = hub.interface.getEvent(eventName);
+      return event?.topicHash ? [event.topicHash] : [];
+    });
+  }
+
+  protected async hubContractAddress(hub: Contract): Promise<string> {
+    const target = (hub as unknown as { target?: unknown }).target;
+    return typeof target === 'string' ? target : hub.getAddress();
+  }
+
+  protected applyHubRotationEventName(name: unknown): void {
+    if (typeof name !== 'string') return;
+    if (name === 'RandomSampling' || name === 'RandomSamplingStorage') {
+      this.invalidateRandomSamplingPair();
+      return;
+    }
+    if (BOUND_CONTRACT_INVALIDATORS.has(name)) {
+      this.invalidatePublishPreflightCache();
+      // Force the next public-method entry through `init()` so it re-resolves
+      // every binding. Do not clear the current handle here: the callback can
+      // fire between a public method's `await init()` and its first
+      // `this.contracts.X` read.
+      this.initialized = false;
     }
   }
 
@@ -3212,6 +3278,11 @@ export class EVMChainAdapterBase {
    * so destroying once flushes everything).
    */
   destroy(): void {
+    if (this.hubRotationPollTimer) {
+      clearInterval(this.hubRotationPollTimer);
+      this.hubRotationPollTimer = null;
+    }
+    this.hubRotationListenerStarted = false;
     for (const provider of this.providers) {
       try { provider.destroy(); } catch { /* already destroyed / not destroyable */ }
     }

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -3133,7 +3133,10 @@ export class EVMChainAdapterBase {
   protected async startHubRotationListener(): Promise<void> {
     if (this.hubRotationListenerStarted) return;
     try {
-      await this.hubRotationPoller.start(this.contracts.hub);
+      await this.hubRotationPoller.start(
+        this.contracts.hub,
+        await contractAddress(this.contracts.hub),
+      );
       this.hubRotationListenerStarted = this.hubRotationPoller.isStarted;
     } catch {
       /* provider doesn't support log polling — TTL refresh (RS)
@@ -3144,7 +3147,7 @@ export class EVMChainAdapterBase {
   protected async pollHubRotationEvents(): Promise<void> {
     const hub = this.contracts.hub;
     if (!hub) return;
-    await this.hubRotationPoller.poll(hub);
+    await this.hubRotationPoller.poll(hub, await contractAddress(hub));
   }
 
   protected applyHubRotationEventName(name: string): void {

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -119,7 +119,9 @@ export const CG_REGISTRY_MAX_SCAN_PAGES = Math.ceil(
 
 export const CG_REGISTRY_REORG_BUFFER_BLOCKS = 50;
 
-const HUB_ROTATION_POLL_INTERVAL_MS = DEFAULT_RANDOM_SAMPLING_HUB_REFRESH_MS;
+// Keep generic Hub binding invalidation responsive for read paths while still
+// replacing four hidden ethers subscription pollers with one owned log poller.
+const HUB_ROTATION_POLL_INTERVAL_MS = 30 * 1000;
 const HUB_ROTATION_REORG_BUFFER_BLOCKS = 50;
 
 /**

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -44,8 +44,8 @@ import { RPC_READ_STALL_TIMEOUT_MS, DEFAULT_RANDOM_SAMPLING_HUB_REFRESH_MS, RPC_
  * the corresponding boot-bound field on `EVMChainAdapter.contracts`.
  *
  * Used by:
- *   1. `startHubRotationListener` — when a Hub rotation event fires
- *      for `name`, the listener checks this allowlist, marks the
+ *   1. `startHubRotationListener` — when the Hub rotation poller sees
+ *      `name`, it checks this allowlist, marks the
  *      adapter uninitialised, and leaves the existing handle intact so
  *      in-flight calls that already passed `init()` don't observe a
  *      transient `undefined`.
@@ -498,8 +498,8 @@ export class EVMChainAdapterBase {
    * has a defensive guard against. Resolving both names atomically
    * inside one cache eliminates that race.
    *
-   * See `HubResolutionCache` for the semantics; the listener
-   * installed in `init()` invalidates this cache on
+   * See `HubResolutionCache` for the semantics; the poller
+   * started in `init()` invalidates this cache on
    * `Hub.ContractChanged` / `Hub.NewContract` for **either** name,
    * and `withHubStaleRetry()` invalidates it when a write surfaces
    * `UnauthorizedAccess(Only Contracts in Hub)`.
@@ -2009,7 +2009,7 @@ export class EVMChainAdapterBase {
    * address fails loudly instead of reconciling from empty logs.
    */
   async getMaxKaNumberForAuthor(author: string): Promise<bigint> {
-    // Re-resolve contract handles first. The Hub-rotation listener flips
+    // Re-resolve contract handles first. The Hub rotation poller flips
     // `initialized` to false but leaves the old bindings in place, so without
     // this a long-lived adapter keeps querying the PRE-rotation
     // DKGKnowledgeAssets after the 10.0.4 redeploy this getter exists for.
@@ -3029,9 +3029,8 @@ export class EVMChainAdapterBase {
    * Used at write-side call sites that touch any of the redeployable
    * V10 contracts (PCA NFT, ContextGraphs, KnowledgeCollection, etc.)
    * so the FIRST write after a Hub rotation self-heals even when the
-   * event listener never fired (HTTP-only RPC endpoints, dropped
-   * subscriptions, rate-limited filter installs — all of which we
-   * see in the wild on public Base Sepolia / Gnosis Chain RPCs).
+   * low-cadence Hub poller has not observed the rotation yet, or when
+   * the RPC endpoint cannot serve log scans.
    *
    * Idempotency note: the wrapped closure MUST be safe to call twice.
    * That holds for our write paths because the on-chain side either
@@ -3085,7 +3084,7 @@ export class EVMChainAdapterBase {
   }
 
   /**
-   * Subscribe to Hub rotation events and invalidate the local cache for any
+   * Poll Hub rotation events and invalidate the local cache for any
    * Hub-rotated contract.
    *
    * Two invalidation paths, dispatched by name:
@@ -3144,12 +3143,6 @@ export class EVMChainAdapterBase {
     }
   }
 
-  protected async pollHubRotationEvents(): Promise<void> {
-    const hub = this.contracts.hub;
-    if (!hub) return;
-    await this.hubRotationPoller.poll(hub, await contractAddress(hub));
-  }
-
   protected applyHubRotationEventName(name: string): void {
     if (name === 'RandomSampling' || name === 'RandomSamplingStorage') {
       this.invalidateRandomSamplingPair();
@@ -3170,8 +3163,8 @@ export class EVMChainAdapterBase {
    *
    * Used by `withHubStaleRetry` on the write-side self-heal path when
    * a Hub-rotated contract surfaces `UnauthorizedAccess(Only Contracts
-   * in Hub)`: the listener may have missed the rotation event (HTTP-only
-   * RPC, dropped subscription, etc.) so the failing operation can't tell
+   * in Hub)`: the poller may not have observed the rotation yet (HTTP-only
+   * RPC, log-scan failure, etc.) so the failing operation can't tell
    * which specific name was rotated. Resetting everything is the safest
    * fallback — the next `await this.init()` re-resolves all 15+ bindings
    * in a single pass (still under a second on a healthy RPC) and the

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -35,6 +35,7 @@ import { computeApprovalAction, effectivePublishAllowance, V10_PUBLISH_ONCHAIN_M
 import { formatProviderContext } from './evm-adapter-types.js';
 import { ReadThroughTtlCache } from './keyed-ttl-single-flight-cache.js';
 import { PcaReadCache } from './pca-read-cache.js';
+import { HubRotationPoller } from './hub-rotation-poller.js';
 import type { ContractCache, EVMAdapterConfig } from './evm-adapter-types.js';
 import { RPC_READ_STALL_TIMEOUT_MS, DEFAULT_RANDOM_SAMPLING_HUB_REFRESH_MS, RPC_RECEIPT_TIMEOUT_MS, RPC_RECEIPT_POLL_INTERVAL_MS, RPC_ENDPOINT_SET_RETRIES, RPC_ENDPOINT_SET_RETRY_BACKOFF_MS, ADMIN_KEY_PURPOSE, OPERATIONAL_KEY_PURPOSE, PUBLISHER_FUNDING_CACHE_TTL_MS } from './evm-adapter-constants.js';
 
@@ -117,8 +118,6 @@ export const CG_REGISTRY_MAX_SCAN_PAGES = Math.ceil(
 );
 
 export const CG_REGISTRY_REORG_BUFFER_BLOCKS = 50;
-
-export const CG_REGISTRY_LIVE_TAIL_LOOKBACK_BLOCKS = 9_000;
 
 const HUB_ROTATION_POLL_INTERVAL_MS = DEFAULT_RANDOM_SAMPLING_HUB_REFRESH_MS;
 const HUB_ROTATION_REORG_BUFFER_BLOCKS = 50;
@@ -528,11 +527,7 @@ export class EVMChainAdapterBase {
 
   protected hubRotationListenerStarted = false;
 
-  protected hubRotationPollTimer: ReturnType<typeof setInterval> | null = null;
-
-  protected hubRotationPollInFlight: Promise<void> | null = null;
-
-  protected hubRotationLastScannedBlock: number | undefined;
+  protected readonly hubRotationPoller: HubRotationPoller;
 
   /**
    * Single-flight guard for the best-effort
@@ -796,6 +791,12 @@ export class EVMChainAdapterBase {
       () => this.chainId,
       async (endpoint) => { await this.ensureConfiguredStaticChainIdValidated(endpoint.provider); },
     );
+    this.hubRotationPoller = new HubRotationPoller({
+      readProvider: (label, fn, opts) => this.readProvider(label, fn, opts),
+      intervalMs: HUB_ROTATION_POLL_INTERVAL_MS,
+      reorgBufferBlocks: HUB_ROTATION_REORG_BUFFER_BLOCKS,
+      onContractName: (name) => this.applyHubRotationEventName(name),
+    });
     const providerContext = formatProviderContext(config);
     // PR-8: install the filter-not-found silencer. Without this, RPC
     // nodes that GC filters faster than ethers' polling cadence
@@ -3132,15 +3133,8 @@ export class EVMChainAdapterBase {
   protected async startHubRotationListener(): Promise<void> {
     if (this.hubRotationListenerStarted) return;
     try {
-      await this.pollHubRotationEvents();
-      this.hubRotationPollTimer = setInterval(() => {
-        if (this.hubRotationPollInFlight) return;
-        this.hubRotationPollInFlight = this.pollHubRotationEvents()
-          .catch(() => { /* optional listener path */ })
-          .finally(() => { this.hubRotationPollInFlight = null; });
-      }, HUB_ROTATION_POLL_INTERVAL_MS);
-      if (this.hubRotationPollTimer.unref) this.hubRotationPollTimer.unref();
-      this.hubRotationListenerStarted = true;
+      await this.hubRotationPoller.start(this.contracts.hub);
+      this.hubRotationListenerStarted = this.hubRotationPoller.isStarted;
     } catch {
       /* provider doesn't support log polling — TTL refresh (RS)
        * and `withHubStaleRetry` (writes) are the fallbacks */
@@ -3150,62 +3144,7 @@ export class EVMChainAdapterBase {
   protected async pollHubRotationEvents(): Promise<void> {
     const hub = this.contracts.hub;
     if (!hub) return;
-
-    const topics = this.hubRotationEventTopics(hub);
-    if (topics.length === 0) return;
-
-    const head = await this.readProvider(
-      'Hub rotation poll getBlockNumber',
-      (provider) => provider.getBlockNumber(),
-    );
-    const candidateFromBlock = this.hubRotationLastScannedBlock == null
-      ? head - HUB_ROTATION_REORG_BUFFER_BLOCKS
-      : this.hubRotationLastScannedBlock + 1 - HUB_ROTATION_REORG_BUFFER_BLOCKS;
-    const recentFromBlock = head - HUB_ROTATION_REORG_BUFFER_BLOCKS;
-    const fromBlock = Math.max(
-      0,
-      Math.min(candidateFromBlock, recentFromBlock),
-    );
-    const hubAddress = await this.hubContractAddress(hub);
-    const logs = await this.readProvider<ethers.Log[]>(
-      'Hub rotation poll getLogs',
-      (provider) => provider.getLogs({
-        address: hubAddress,
-        fromBlock,
-        toBlock: head,
-        topics: [topics],
-      }),
-      { policy: 'wideLogScan' },
-    );
-
-    for (const log of logs) {
-      try {
-        const parsed = hub.interface.parseLog({ topics: [...log.topics], data: log.data });
-        if (!parsed) continue;
-        this.applyHubRotationEventName(parsed.args?.contractName ?? parsed.args?.[0]);
-      } catch {
-        // Ignore malformed/unexpected Hub logs. The topic filter should already
-        // constrain these, but a parse miss must not wedge the poll cursor.
-      }
-    }
-    this.hubRotationLastScannedBlock = head;
-  }
-
-  protected hubRotationEventTopics(hub: Contract): string[] {
-    return [
-      'ContractChanged',
-      'NewContract',
-      'AssetStorageChanged',
-      'NewAssetStorage',
-    ].flatMap((eventName) => {
-      const event = hub.interface.getEvent(eventName);
-      return event?.topicHash ? [event.topicHash] : [];
-    });
-  }
-
-  protected async hubContractAddress(hub: Contract): Promise<string> {
-    const target = (hub as unknown as { target?: unknown }).target;
-    return typeof target === 'string' ? target : hub.getAddress();
+    await this.hubRotationPoller.poll(hub);
   }
 
   protected applyHubRotationEventName(name: unknown): void {
@@ -3278,10 +3217,7 @@ export class EVMChainAdapterBase {
    * so destroying once flushes everything).
    */
   destroy(): void {
-    if (this.hubRotationPollTimer) {
-      clearInterval(this.hubRotationPollTimer);
-      this.hubRotationPollTimer = null;
-    }
+    this.hubRotationPoller.stop();
     this.hubRotationListenerStarted = false;
     for (const provider of this.providers) {
       try { provider.destroy(); } catch { /* already destroyed / not destroyable */ }

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -527,8 +527,6 @@ export class EVMChainAdapterBase {
 
   protected readonly pcaReadCache = new PcaReadCache();
 
-  protected hubRotationListenerStarted = false;
-
   protected readonly hubRotationPoller: HubRotationPoller;
 
   /**
@@ -3132,13 +3130,12 @@ export class EVMChainAdapterBase {
    * rotation detection without four hidden idle log streams.
    */
   protected async startHubRotationListener(): Promise<void> {
-    if (this.hubRotationListenerStarted) return;
+    if (this.hubRotationPoller.isStarted) return;
     try {
       await this.hubRotationPoller.start(
         this.contracts.hub,
         await contractAddress(this.contracts.hub),
       );
-      this.hubRotationListenerStarted = this.hubRotationPoller.isStarted;
     } catch {
       /* provider doesn't support log polling — TTL refresh (RS)
        * and `withHubStaleRetry` (writes) are the fallbacks */
@@ -3215,7 +3212,6 @@ export class EVMChainAdapterBase {
    */
   destroy(): void {
     this.hubRotationPoller.stop();
-    this.hubRotationListenerStarted = false;
     for (const provider of this.providers) {
       try { provider.destroy(); } catch { /* already destroyed / not destroyable */ }
     }

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -3136,9 +3136,10 @@ export class EVMChainAdapterBase {
         this.contracts.hub,
         await contractAddress(this.contracts.hub),
       );
-    } catch {
-      /* provider doesn't support log polling — TTL refresh (RS)
-       * and `withHubStaleRetry` (writes) are the fallbacks */
+    } catch (err) {
+      console.warn(
+        `[chain] Hub rotation poller setup disabled: ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
   }
 

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -3147,8 +3147,7 @@ export class EVMChainAdapterBase {
     await this.hubRotationPoller.poll(hub);
   }
 
-  protected applyHubRotationEventName(name: unknown): void {
-    if (typeof name !== 'string') return;
+  protected applyHubRotationEventName(name: string): void {
     if (name === 'RandomSampling' || name === 'RandomSamplingStorage') {
       this.invalidateRandomSamplingPair();
       return;

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -9,11 +9,23 @@
  * via applyMixins(); see evm-adapter.ts for the assembly.
  */
 
-import { EVMChainAdapterBase, CG_REGISTRY_MAX_SCAN_PAGES, CG_REGISTRY_REORG_BUFFER_BLOCKS } from './evm-adapter-base.js';
+import {
+  EVMChainAdapterBase,
+  CG_REGISTRY_LIVE_TAIL_LOOKBACK_BLOCKS,
+  CG_REGISTRY_MAX_SCAN_PAGES,
+  CG_REGISTRY_REORG_BUFFER_BLOCKS,
+} from './evm-adapter-base.js';
 import { isTooLowAllowanceError } from './evm-adapter-errors.js';
 import { ethers, Contract, type JsonRpcProvider } from 'ethers';
 import { ContextGraphChainScanPartialError, type CreateContextGraphParams, type TxResult, type ContextGraphOnChain, type ContextGraphChainScanOptions, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type VerifyParams, type PublishToContextGraphParams, type OnChainPublishResult } from './chain-adapter.js';
 import { buildAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1 } from '@origintrail-official/dkg-core';
+
+function normalizeLiveTailLookbackBlocks(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return CG_REGISTRY_LIVE_TAIL_LOOKBACK_BLOCKS;
+  }
+  return Math.max(0, Math.floor(value));
+}
 
 export class ContextGraphMethods extends EVMChainAdapterBase {
   /**
@@ -123,14 +135,16 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     const eventFilter = registry.filters.NameClaimed();
     const registryAddress = (await registry.getAddress()).toLowerCase();
     const incremental = options?.incremental === true && fromBlock === undefined;
+    const liveTailOnly = options?.liveTailOnly === true && fromBlock === undefined && !incremental;
     const seedIncrementalWatermark =
       options?.seedIncrementalWatermark === true && !incremental && fromBlock === undefined;
+    const liveTailLookback = normalizeLiveTailLookbackBlocks(options?.liveTailLookbackBlocks);
     const watermark = incremental
       ? this.contextGraphRegistryScanWatermarks.get(registryAddress)
       : undefined;
     const scan =
       fromBlock === undefined
-        ? incremental && watermark !== undefined
+        ? liveTailOnly || (incremental && watermark !== undefined)
           ? { fromBlock: 0, ...(await this.resolveLogScanHead('listContextGraphsFromChain')) }
           : await this.resolveContractDeployBlock(
               registryAddress,
@@ -140,7 +154,9 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
         : { fromBlock, ...(await this.resolveLogScanHead('listContextGraphsFromChain')) };
     const { fromBlock: deployBlock, head, scanProviders, degradedFromGenesis = false } = scan;
     const start = fromBlock ?? (
-      incremental && watermark !== undefined
+      liveTailOnly
+        ? liveTailLookback <= 0 ? head + 1 : Math.max(0, head - liveTailLookback + 1)
+        : incremental && watermark !== undefined
         ? Math.max(0, watermark - CG_REGISTRY_REORG_BUFFER_BLOCKS)
         : deployBlock
     );
@@ -154,9 +170,10 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     const pageSize = this.cgRegistryScanPageSize;
     const pages = Math.ceil((head - start + 1) / pageSize);
     const blockBudget = CG_REGISTRY_MAX_SCAN_PAGES * pageSize;
-    if (incremental && !degradedFromGenesis && pages > CG_REGISTRY_MAX_SCAN_PAGES) {
+    if ((incremental || liveTailOnly) && !degradedFromGenesis && pages > CG_REGISTRY_MAX_SCAN_PAGES) {
+      const scanKind = liveTailOnly ? 'live-tail' : 'incremental';
       throw new Error(
-        `listContextGraphsFromChain: incremental ContextGraphNameRegistry scan would need ` +
+        `listContextGraphsFromChain: ${scanKind} ContextGraphNameRegistry scan would need ` +
           `${pages} eth_getLogs calls over blocks [${start}, ${head}] at a ` +
           `${pageSize}-block window (budget ${CG_REGISTRY_MAX_SCAN_PAGES} pages / ` +
           `${blockBudget} blocks). ` +
@@ -171,8 +188,8 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     let preferred: JsonRpcProvider | undefined;
     let scannedAnyPage = false;
 
-    // Incremental daemon scans can resume from the scanned prefix after a later
-    // page failure. Public list-all calls should remain all-or-error.
+    // Daemon scans can surface scanned-prefix results after a later page
+    // failure. Public list-all calls should remain all-or-error.
     for (let lo = start; lo <= head; lo += pageSize) {
       const hi = Math.min(lo + pageSize - 1, head);
       try {
@@ -205,7 +222,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
           this.contextGraphRegistryScanWatermarks.set(registryAddress, hi + 1);
         }
       } catch (err) {
-        if (incremental && scannedAnyPage) {
+        if ((incremental || liveTailOnly) && scannedAnyPage) {
           const message = err instanceof Error ? err.message : String(err);
           throw new ContextGraphChainScanPartialError(
             `listContextGraphsFromChain: partial ContextGraphNameRegistry scan ` +

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -11,7 +11,6 @@
 
 import {
   EVMChainAdapterBase,
-  CG_REGISTRY_LIVE_TAIL_LOOKBACK_BLOCKS,
   CG_REGISTRY_MAX_SCAN_PAGES,
   CG_REGISTRY_REORG_BUFFER_BLOCKS,
 } from './evm-adapter-base.js';
@@ -19,13 +18,6 @@ import { isTooLowAllowanceError } from './evm-adapter-errors.js';
 import { ethers, Contract, type JsonRpcProvider } from 'ethers';
 import { ContextGraphChainScanPartialError, type CreateContextGraphParams, type TxResult, type ContextGraphOnChain, type ContextGraphChainScanOptions, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type VerifyParams, type PublishToContextGraphParams, type OnChainPublishResult } from './chain-adapter.js';
 import { buildAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1 } from '@origintrail-official/dkg-core';
-
-function normalizeLiveTailLookbackBlocks(value: unknown): number {
-  if (typeof value !== 'number' || !Number.isFinite(value)) {
-    return CG_REGISTRY_LIVE_TAIL_LOOKBACK_BLOCKS;
-  }
-  return Math.max(0, Math.floor(value));
-}
 
 export class ContextGraphMethods extends EVMChainAdapterBase {
   /**
@@ -135,16 +127,14 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     const eventFilter = registry.filters.NameClaimed();
     const registryAddress = (await registry.getAddress()).toLowerCase();
     const incremental = options?.incremental === true && fromBlock === undefined;
-    const liveTailOnly = options?.liveTailOnly === true && fromBlock === undefined && !incremental;
     const seedIncrementalWatermark =
       options?.seedIncrementalWatermark === true && !incremental && fromBlock === undefined;
-    const liveTailLookback = normalizeLiveTailLookbackBlocks(options?.liveTailLookbackBlocks);
     const watermark = incremental
       ? this.contextGraphRegistryScanWatermarks.get(registryAddress)
       : undefined;
     const scan =
       fromBlock === undefined
-        ? liveTailOnly || (incremental && watermark !== undefined)
+        ? incremental && watermark !== undefined
           ? { fromBlock: 0, ...(await this.resolveLogScanHead('listContextGraphsFromChain')) }
           : await this.resolveContractDeployBlock(
               registryAddress,
@@ -154,9 +144,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
         : { fromBlock, ...(await this.resolveLogScanHead('listContextGraphsFromChain')) };
     const { fromBlock: deployBlock, head, scanProviders, degradedFromGenesis = false } = scan;
     const start = fromBlock ?? (
-      liveTailOnly
-        ? liveTailLookback <= 0 ? head + 1 : Math.max(0, head - liveTailLookback + 1)
-        : incremental && watermark !== undefined
+      incremental && watermark !== undefined
         ? Math.max(0, watermark - CG_REGISTRY_REORG_BUFFER_BLOCKS)
         : deployBlock
     );
@@ -170,10 +158,9 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     const pageSize = this.cgRegistryScanPageSize;
     const pages = Math.ceil((head - start + 1) / pageSize);
     const blockBudget = CG_REGISTRY_MAX_SCAN_PAGES * pageSize;
-    if ((incremental || liveTailOnly) && !degradedFromGenesis && pages > CG_REGISTRY_MAX_SCAN_PAGES) {
-      const scanKind = liveTailOnly ? 'live-tail' : 'incremental';
+    if (incremental && !degradedFromGenesis && pages > CG_REGISTRY_MAX_SCAN_PAGES) {
       throw new Error(
-        `listContextGraphsFromChain: ${scanKind} ContextGraphNameRegistry scan would need ` +
+        `listContextGraphsFromChain: incremental ContextGraphNameRegistry scan would need ` +
           `${pages} eth_getLogs calls over blocks [${start}, ${head}] at a ` +
           `${pageSize}-block window (budget ${CG_REGISTRY_MAX_SCAN_PAGES} pages / ` +
           `${blockBudget} blocks). ` +
@@ -188,8 +175,8 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     let preferred: JsonRpcProvider | undefined;
     let scannedAnyPage = false;
 
-    // Daemon scans can surface scanned-prefix results after a later page
-    // failure. Public list-all calls should remain all-or-error.
+    // Incremental daemon scans can resume from the scanned prefix after a later
+    // page failure. Public list-all calls should remain all-or-error.
     for (let lo = start; lo <= head; lo += pageSize) {
       const hi = Math.min(lo + pageSize - 1, head);
       try {
@@ -222,7 +209,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
           this.contextGraphRegistryScanWatermarks.set(registryAddress, hi + 1);
         }
       } catch (err) {
-        if ((incremental || liveTailOnly) && scannedAnyPage) {
+        if (incremental && scannedAnyPage) {
           const message = err instanceof Error ? err.message : String(err);
           throw new ContextGraphChainScanPartialError(
             `listContextGraphsFromChain: partial ContextGraphNameRegistry scan ` +

--- a/packages/chain/src/evm-adapter-types.ts
+++ b/packages/chain/src/evm-adapter-types.ts
@@ -36,7 +36,7 @@ export interface EVMAdapterBaseConfig {
    * TTL (ms) for re-resolving `RandomSampling` / `RandomSamplingStorage`
    * addresses from the Hub. Defaults to 5 minutes. Values `<= 0` are
    * treated as "use default" and intentionally NOT supported as a
-   * "disable periodic refresh" mode: even with the Hub event listener
+   * "disable periodic refresh" mode: even with the Hub rotation poller
    * and the `Only Contracts in Hub` retry wrapper, a missed event on
    * a read-only path (e.g. `getActiveProofPeriodStatus`,
    * `getNodeChallenge`) would leave the adapter pinned to a stale

--- a/packages/chain/src/hub-resolution-cache.ts
+++ b/packages/chain/src/hub-resolution-cache.ts
@@ -3,8 +3,8 @@
  * given Hub-registered contract name). Re-resolves lazily when:
  *   - cache is empty (first call),
  *   - TTL expired (when `ttlMs > 0`), OR
- *   - `invalidate()` was called explicitly (e.g. from a Hub
- *     `ContractChanged` / `NewContract` event listener, or after a
+ *   - `invalidate()` was called explicitly (e.g. from the Hub rotation
+ *     poller observing `ContractChanged` / `NewContract`, or after a
  *     write surfaced `UnauthorizedAccess(Only Contracts in Hub)`).
  *
  * This is the structural fix for the post-rotation stale-address bug:

--- a/packages/chain/src/hub-rotation-poller.ts
+++ b/packages/chain/src/hub-rotation-poller.ts
@@ -27,8 +27,6 @@ type HubRotationLogWithIdentity = ethers.Log & {
   logIndex?: unknown;
 };
 
-type HubRotationScanMode = 'probe' | 'dispatch';
-
 export class HubRotationPoller {
   private readonly readProvider: HubRotationReadProvider;
   private readonly intervalMs: number;
@@ -40,7 +38,6 @@ export class HubRotationPoller {
   private binding: HubRotationBinding | undefined;
   private readonly seenLogIds = new Map<string, number>();
   private started = false;
-  private startInFlight: Promise<void> | null = null;
   private generation = 0;
 
   constructor(config: HubRotationPollerConfig) {
@@ -56,19 +53,10 @@ export class HubRotationPoller {
 
   async start(hub: Contract, hubAddress: string): Promise<void> {
     if (this.started) return;
-    if (this.startInFlight) return this.startInFlight;
 
     this.bind(hub, hubAddress);
     const generation = ++this.generation;
     this.started = true;
-    const startPromise = this.seed(generation)
-      .catch(() => { /* optional bootstrap path */ })
-      .finally(() => {
-        if (this.startInFlight === startPromise) this.startInFlight = null;
-        if (this.inFlight === startPromise) this.inFlight = null;
-      });
-    this.startInFlight = startPromise;
-    this.inFlight = startPromise;
 
     this.timer = setInterval(() => {
       if (this.inFlight) return;
@@ -84,7 +72,6 @@ export class HubRotationPoller {
 
   stop(): void {
     this.generation++;
-    this.startInFlight = null;
     this.inFlight = null;
     if (this.timer) {
       clearInterval(this.timer);
@@ -102,27 +89,18 @@ export class HubRotationPoller {
   }
 
   async pollOnce(generation = this.generation): Promise<void> {
-    await this.scan(generation, 'dispatch');
-  }
-
-  private async seed(generation: number): Promise<void> {
-    await this.scan(generation, 'probe');
-  }
-
-  private async scan(generation: number, mode: HubRotationScanMode): Promise<void> {
     const binding = this.binding;
-    if (!binding || binding.topics.length === 0 || generation !== this.generation) return;
+    if (!this.started || !binding || binding.topics.length === 0 || generation !== this.generation) return;
 
-    const label = mode === 'probe' ? 'Hub rotation seed' : 'Hub rotation poll';
     const previousLastScannedBlock = this.lastScannedBlock;
     const head = await this.readProvider(
-      `${label} getBlockNumber`,
+      'Hub rotation poll getBlockNumber',
       (provider) => provider.getBlockNumber(),
     );
-    if (generation !== this.generation) return;
-    const fromBlock = this.scanFromBlock(mode, previousLastScannedBlock, head);
+    if (!this.started || generation !== this.generation) return;
+    const fromBlock = this.scanFromBlock(previousLastScannedBlock, head);
     const logs = await this.readProvider<ethers.Log[]>(
-      `${label} getLogs`,
+      'Hub rotation poll getLogs',
       (provider) => provider.getLogs({
         address: binding.hubAddress,
         fromBlock,
@@ -131,23 +109,17 @@ export class HubRotationPoller {
       }),
       { policy: 'wideLogScan' },
     );
-    if (generation !== this.generation) return;
+    if (!this.started || generation !== this.generation) return;
 
-    // Probe mode intentionally does not mark logs as seen; the first buffered
-    // dispatch must still process rotations that landed during adapter init.
-    if (mode === 'dispatch') this.dispatchLogs(binding.hub, logs);
+    this.dispatchLogs(binding.hub, logs);
     this.lastScannedBlock = previousLastScannedBlock == null
       ? head
       : Math.max(previousLastScannedBlock, head);
     this.pruneSeenLogs(head);
   }
 
-  private scanFromBlock(
-    mode: HubRotationScanMode,
-    previousLastScannedBlock: number | undefined,
-    head: number,
-  ): number {
-    if (mode === 'probe' || previousLastScannedBlock == null) {
+  private scanFromBlock(previousLastScannedBlock: number | undefined, head: number): number {
+    if (previousLastScannedBlock == null) {
       return Math.max(0, head - this.reorgBufferBlocks);
     }
     const candidateFromBlock = previousLastScannedBlock + 1 - this.reorgBufferBlocks;

--- a/packages/chain/src/hub-rotation-poller.ts
+++ b/packages/chain/src/hub-rotation-poller.ts
@@ -31,6 +31,7 @@ export class HubRotationPoller {
   private binding: HubRotationBinding | undefined;
   private readonly seenLogIds = new Map<string, number>();
   private started = false;
+  private startInFlight: Promise<void> | null = null;
 
   constructor(config: HubRotationPollerConfig) {
     this.readProvider = config.readProvider;
@@ -45,17 +46,15 @@ export class HubRotationPoller {
 
   async start(hub: Contract, hubAddress: string): Promise<void> {
     if (this.started) return;
+    if (this.startInFlight) return this.startInFlight;
 
-    this.bind(hub, hubAddress);
-    await this.seed();
-    this.timer = setInterval(() => {
-      if (this.inFlight) return;
-      this.inFlight = this.pollOnce()
-        .catch(() => { /* optional poller path */ })
-        .finally(() => { this.inFlight = null; });
-    }, this.intervalMs);
-    if (this.timer.unref) this.timer.unref();
-    this.started = true;
+    let startPromise!: Promise<void>;
+    startPromise = this.startOnce(hub, hubAddress)
+      .finally(() => {
+        if (this.startInFlight === startPromise) this.startInFlight = null;
+      });
+    this.startInFlight = startPromise;
+    return startPromise;
   }
 
   stop(): void {
@@ -72,6 +71,21 @@ export class HubRotationPoller {
       hubAddress: ethers.getAddress(hubAddress),
       topics: this.eventTopics(hub),
     };
+  }
+
+  private async startOnce(hub: Contract, hubAddress: string): Promise<void> {
+    if (this.started) return;
+
+    this.bind(hub, hubAddress);
+    await this.seed();
+    this.timer = setInterval(() => {
+      if (this.inFlight) return;
+      this.inFlight = this.pollOnce()
+        .catch(() => { /* optional poller path */ })
+        .finally(() => { this.inFlight = null; });
+    }, this.intervalMs);
+    if (this.timer.unref) this.timer.unref();
+    this.started = true;
   }
 
   async pollOnce(): Promise<void> {

--- a/packages/chain/src/hub-rotation-poller.ts
+++ b/packages/chain/src/hub-rotation-poller.ts
@@ -155,9 +155,12 @@ export class HubRotationPoller {
       'NewContract',
       'AssetStorageChanged',
       'NewAssetStorage',
-    ].flatMap((eventName) => {
+    ].map((eventName) => {
       const event = hub.interface.getEvent(eventName);
-      return event?.topicHash ? [event.topicHash] : [];
+      if (!event?.topicHash) {
+        throw new Error(`Hub ABI is missing required rotation event ${eventName}`);
+      }
+      return event.topicHash;
     });
   }
 

--- a/packages/chain/src/hub-rotation-poller.ts
+++ b/packages/chain/src/hub-rotation-poller.ts
@@ -14,6 +14,12 @@ export interface HubRotationPollerConfig {
   onContractName: (name: string) => void;
 }
 
+interface HubRotationBinding {
+  hub: Contract;
+  hubAddress: string;
+  topics: string[];
+}
+
 export class HubRotationPoller {
   private readonly readProvider: HubRotationReadProvider;
   private readonly intervalMs: number;
@@ -22,6 +28,8 @@ export class HubRotationPoller {
   private timer: ReturnType<typeof setInterval> | null = null;
   private inFlight: Promise<void> | null = null;
   private lastScannedBlock: number | undefined;
+  private binding: HubRotationBinding | undefined;
+  private readonly seenLogIds = new Map<string, number>();
   private started = false;
 
   constructor(config: HubRotationPollerConfig) {
@@ -38,11 +46,12 @@ export class HubRotationPoller {
   async start(hub: Contract, hubAddress: string): Promise<void> {
     if (this.started) return;
 
-    await this.seed(hub);
+    this.bind(hub, hubAddress);
+    await this.seed();
     this.timer = setInterval(() => {
       if (this.inFlight) return;
-      this.inFlight = this.poll(hub, hubAddress)
-        .catch(() => { /* optional listener path */ })
+      this.inFlight = this.pollOnce()
+        .catch(() => { /* optional poller path */ })
         .finally(() => { this.inFlight = null; });
     }, this.intervalMs);
     if (this.timer.unref) this.timer.unref();
@@ -57,9 +66,17 @@ export class HubRotationPoller {
     this.started = false;
   }
 
-  async poll(hub: Contract, hubAddress: string): Promise<void> {
-    const topics = this.eventTopics(hub);
-    if (topics.length === 0) return;
+  private bind(hub: Contract, hubAddress: string): void {
+    this.binding = {
+      hub,
+      hubAddress: ethers.getAddress(hubAddress),
+      topics: this.eventTopics(hub),
+    };
+  }
+
+  async pollOnce(): Promise<void> {
+    const binding = this.binding;
+    if (!binding || binding.topics.length === 0) return;
 
     const previousLastScannedBlock = this.lastScannedBlock;
     const head = await this.readProvider(
@@ -74,31 +91,48 @@ export class HubRotationPoller {
     const logs = await this.readProvider<ethers.Log[]>(
       'Hub rotation poll getLogs',
       (provider) => provider.getLogs({
-        address: hubAddress,
+        address: binding.hubAddress,
         fromBlock,
         toBlock: head,
-        topics: [topics],
+        topics: [binding.topics],
       }),
       { policy: 'wideLogScan' },
     );
 
     for (const log of logs) {
-      if (previousLastScannedBlock != null && log.blockNumber <= previousLastScannedBlock) continue;
-      const contractName = this.contractNameFromLog(hub, log);
+      const identity = this.logIdentity(log);
+      if (this.seenLogIds.has(identity)) continue;
+      this.rememberLog(identity, log);
+      const contractName = this.contractNameFromLog(binding.hub, log);
       if (contractName) this.onContractName(contractName);
     }
     this.lastScannedBlock = previousLastScannedBlock == null
       ? head
       : Math.max(previousLastScannedBlock, head);
+    this.pruneSeenLogs(head);
   }
 
-  private async seed(hub: Contract): Promise<void> {
-    const topics = this.eventTopics(hub);
-    if (topics.length === 0) return;
-    this.lastScannedBlock = await this.readProvider(
+  private async seed(): Promise<void> {
+    const binding = this.binding;
+    if (!binding || binding.topics.length === 0) return;
+    const head = await this.readProvider(
       'Hub rotation seed getBlockNumber',
       (provider) => provider.getBlockNumber(),
     );
+    const fromBlock = Math.max(0, head - this.reorgBufferBlocks);
+    const logs = await this.readProvider<ethers.Log[]>(
+      'Hub rotation seed getLogs',
+      (provider) => provider.getLogs({
+        address: binding.hubAddress,
+        fromBlock,
+        toBlock: head,
+        topics: [binding.topics],
+      }),
+      { policy: 'wideLogScan' },
+    );
+    for (const log of logs) this.rememberLog(this.logIdentity(log), log);
+    this.lastScannedBlock = head;
+    this.pruneSeenLogs(head);
   }
 
   private contractNameFromLog(hub: Contract, log: ethers.Log): string | undefined {
@@ -123,5 +157,41 @@ export class HubRotationPoller {
       const event = hub.interface.getEvent(eventName);
       return event?.topicHash ? [event.topicHash] : [];
     });
+  }
+
+  private logIdentity(log: ethers.Log): string {
+    const maybe = log as ethers.Log & {
+      blockHash?: unknown;
+      transactionHash?: unknown;
+      index?: unknown;
+      logIndex?: unknown;
+    };
+    const blockHash = typeof maybe.blockHash === 'string' ? maybe.blockHash : undefined;
+    const transactionHash = typeof maybe.transactionHash === 'string' ? maybe.transactionHash : undefined;
+    const index = typeof maybe.index === 'number'
+      ? maybe.index
+      : typeof maybe.logIndex === 'number'
+        ? maybe.logIndex
+        : undefined;
+    if (blockHash && transactionHash && index != null) {
+      return `${blockHash}:${transactionHash}:${index}`;
+    }
+    return [
+      log.blockNumber,
+      index ?? 'unknown',
+      log.topics.join(','),
+      log.data,
+    ].join(':');
+  }
+
+  private rememberLog(identity: string, log: ethers.Log): void {
+    this.seenLogIds.set(identity, log.blockNumber);
+  }
+
+  private pruneSeenLogs(head: number): void {
+    const earliestBufferedBlock = Math.max(0, head - this.reorgBufferBlocks);
+    for (const [identity, blockNumber] of this.seenLogIds) {
+      if (blockNumber < earliestBufferedBlock) this.seenLogIds.delete(identity);
+    }
   }
 }

--- a/packages/chain/src/hub-rotation-poller.ts
+++ b/packages/chain/src/hub-rotation-poller.ts
@@ -120,7 +120,10 @@ export class HubRotationPoller {
       (provider) => provider.getBlockNumber(),
     );
     const fromBlock = Math.max(0, head - this.reorgBufferBlocks);
-    const logs = await this.readProvider<ethers.Log[]>(
+    // Probe log-scan support and position the high-water mark, but do not mark
+    // returned logs as seen. They must remain eligible for the first buffered
+    // post-start poll in case a real rotation landed during adapter init.
+    await this.readProvider<ethers.Log[]>(
       'Hub rotation seed getLogs',
       (provider) => provider.getLogs({
         address: binding.hubAddress,
@@ -130,7 +133,6 @@ export class HubRotationPoller {
       }),
       { policy: 'wideLogScan' },
     );
-    for (const log of logs) this.rememberLog(this.logIdentity(log), log);
     this.lastScannedBlock = head;
     this.pruneSeenLogs(head);
   }

--- a/packages/chain/src/hub-rotation-poller.ts
+++ b/packages/chain/src/hub-rotation-poller.ts
@@ -1,0 +1,114 @@
+import { Contract, ethers, type JsonRpcProvider } from 'ethers';
+import type { ReadOpts } from './rpc-failover-client.js';
+
+export type HubRotationReadProvider = <T>(
+  label: string,
+  fn: (provider: JsonRpcProvider) => Promise<T>,
+  opts?: ReadOpts,
+) => Promise<T>;
+
+export interface HubRotationPollerConfig {
+  readProvider: HubRotationReadProvider;
+  intervalMs: number;
+  reorgBufferBlocks: number;
+  onContractName: (name: unknown) => void;
+}
+
+export class HubRotationPoller {
+  private readonly readProvider: HubRotationReadProvider;
+  private readonly intervalMs: number;
+  private readonly reorgBufferBlocks: number;
+  private readonly onContractName: (name: unknown) => void;
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private inFlight: Promise<void> | null = null;
+  private lastScannedBlock: number | undefined;
+  private started = false;
+
+  constructor(config: HubRotationPollerConfig) {
+    this.readProvider = config.readProvider;
+    this.intervalMs = config.intervalMs;
+    this.reorgBufferBlocks = config.reorgBufferBlocks;
+    this.onContractName = config.onContractName;
+  }
+
+  get isStarted(): boolean {
+    return this.started;
+  }
+
+  async start(hub: Contract): Promise<void> {
+    if (this.started) return;
+
+    await this.poll(hub);
+    this.timer = setInterval(() => {
+      if (this.inFlight) return;
+      this.inFlight = this.poll(hub)
+        .catch(() => { /* optional listener path */ })
+        .finally(() => { this.inFlight = null; });
+    }, this.intervalMs);
+    if (this.timer.unref) this.timer.unref();
+    this.started = true;
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    this.started = false;
+  }
+
+  async poll(hub: Contract): Promise<void> {
+    const topics = this.eventTopics(hub);
+    if (topics.length === 0) return;
+
+    const head = await this.readProvider(
+      'Hub rotation poll getBlockNumber',
+      (provider) => provider.getBlockNumber(),
+    );
+    const candidateFromBlock = this.lastScannedBlock == null
+      ? head - this.reorgBufferBlocks
+      : this.lastScannedBlock + 1 - this.reorgBufferBlocks;
+    const recentFromBlock = head - this.reorgBufferBlocks;
+    const fromBlock = Math.max(0, Math.min(candidateFromBlock, recentFromBlock));
+    const hubAddress = await this.contractAddress(hub);
+    const logs = await this.readProvider<ethers.Log[]>(
+      'Hub rotation poll getLogs',
+      (provider) => provider.getLogs({
+        address: hubAddress,
+        fromBlock,
+        toBlock: head,
+        topics: [topics],
+      }),
+      { policy: 'wideLogScan' },
+    );
+
+    for (const log of logs) {
+      try {
+        const parsed = hub.interface.parseLog({ topics: [...log.topics], data: log.data });
+        if (!parsed) continue;
+        this.onContractName(parsed.args?.contractName ?? parsed.args?.[0]);
+      } catch {
+        // Ignore malformed/unexpected Hub logs. The topic filter should already
+        // constrain these, but a parse miss must not wedge the poll cursor.
+      }
+    }
+    this.lastScannedBlock = head;
+  }
+
+  private eventTopics(hub: Contract): string[] {
+    return [
+      'ContractChanged',
+      'NewContract',
+      'AssetStorageChanged',
+      'NewAssetStorage',
+    ].flatMap((eventName) => {
+      const event = hub.interface.getEvent(eventName);
+      return event?.topicHash ? [event.topicHash] : [];
+    });
+  }
+
+  private async contractAddress(hub: Contract): Promise<string> {
+    const target = (hub as unknown as { target?: unknown }).target;
+    return typeof target === 'string' ? target : hub.getAddress();
+  }
+}

--- a/packages/chain/src/hub-rotation-poller.ts
+++ b/packages/chain/src/hub-rotation-poller.ts
@@ -35,13 +35,13 @@ export class HubRotationPoller {
     return this.started;
   }
 
-  async start(hub: Contract): Promise<void> {
+  async start(hub: Contract, hubAddress: string): Promise<void> {
     if (this.started) return;
 
     await this.seed(hub);
     this.timer = setInterval(() => {
       if (this.inFlight) return;
-      this.inFlight = this.poll(hub)
+      this.inFlight = this.poll(hub, hubAddress)
         .catch(() => { /* optional listener path */ })
         .finally(() => { this.inFlight = null; });
     }, this.intervalMs);
@@ -57,7 +57,7 @@ export class HubRotationPoller {
     this.started = false;
   }
 
-  async poll(hub: Contract): Promise<void> {
+  async poll(hub: Contract, hubAddress: string): Promise<void> {
     const topics = this.eventTopics(hub);
     if (topics.length === 0) return;
 
@@ -71,7 +71,6 @@ export class HubRotationPoller {
       : previousLastScannedBlock + 1 - this.reorgBufferBlocks;
     const recentFromBlock = head - this.reorgBufferBlocks;
     const fromBlock = Math.max(0, Math.min(candidateFromBlock, recentFromBlock));
-    const hubAddress = await this.contractAddress(hub);
     const logs = await this.readProvider<ethers.Log[]>(
       'Hub rotation poll getLogs',
       (provider) => provider.getLogs({
@@ -124,10 +123,5 @@ export class HubRotationPoller {
       const event = hub.interface.getEvent(eventName);
       return event?.topicHash ? [event.topicHash] : [];
     });
-  }
-
-  private async contractAddress(hub: Contract): Promise<string> {
-    const target = (hub as unknown as { target?: unknown }).target;
-    return typeof target === 'string' ? target : hub.getAddress();
   }
 }

--- a/packages/chain/src/hub-rotation-poller.ts
+++ b/packages/chain/src/hub-rotation-poller.ts
@@ -11,14 +11,14 @@ export interface HubRotationPollerConfig {
   readProvider: HubRotationReadProvider;
   intervalMs: number;
   reorgBufferBlocks: number;
-  onContractName: (name: unknown) => void;
+  onContractName: (name: string) => void;
 }
 
 export class HubRotationPoller {
   private readonly readProvider: HubRotationReadProvider;
   private readonly intervalMs: number;
   private readonly reorgBufferBlocks: number;
-  private readonly onContractName: (name: unknown) => void;
+  private readonly onContractName: (name: string) => void;
   private timer: ReturnType<typeof setInterval> | null = null;
   private inFlight: Promise<void> | null = null;
   private lastScannedBlock: number | undefined;
@@ -38,7 +38,7 @@ export class HubRotationPoller {
   async start(hub: Contract): Promise<void> {
     if (this.started) return;
 
-    await this.poll(hub);
+    await this.seed(hub);
     this.timer = setInterval(() => {
       if (this.inFlight) return;
       this.inFlight = this.poll(hub)
@@ -61,13 +61,14 @@ export class HubRotationPoller {
     const topics = this.eventTopics(hub);
     if (topics.length === 0) return;
 
+    const previousLastScannedBlock = this.lastScannedBlock;
     const head = await this.readProvider(
       'Hub rotation poll getBlockNumber',
       (provider) => provider.getBlockNumber(),
     );
-    const candidateFromBlock = this.lastScannedBlock == null
+    const candidateFromBlock = previousLastScannedBlock == null
       ? head - this.reorgBufferBlocks
-      : this.lastScannedBlock + 1 - this.reorgBufferBlocks;
+      : previousLastScannedBlock + 1 - this.reorgBufferBlocks;
     const recentFromBlock = head - this.reorgBufferBlocks;
     const fromBlock = Math.max(0, Math.min(candidateFromBlock, recentFromBlock));
     const hubAddress = await this.contractAddress(hub);
@@ -83,16 +84,34 @@ export class HubRotationPoller {
     );
 
     for (const log of logs) {
-      try {
-        const parsed = hub.interface.parseLog({ topics: [...log.topics], data: log.data });
-        if (!parsed) continue;
-        this.onContractName(parsed.args?.contractName ?? parsed.args?.[0]);
-      } catch {
-        // Ignore malformed/unexpected Hub logs. The topic filter should already
-        // constrain these, but a parse miss must not wedge the poll cursor.
-      }
+      if (previousLastScannedBlock != null && log.blockNumber <= previousLastScannedBlock) continue;
+      const contractName = this.contractNameFromLog(hub, log);
+      if (contractName) this.onContractName(contractName);
     }
-    this.lastScannedBlock = head;
+    this.lastScannedBlock = previousLastScannedBlock == null
+      ? head
+      : Math.max(previousLastScannedBlock, head);
+  }
+
+  private async seed(hub: Contract): Promise<void> {
+    const topics = this.eventTopics(hub);
+    if (topics.length === 0) return;
+    this.lastScannedBlock = await this.readProvider(
+      'Hub rotation seed getBlockNumber',
+      (provider) => provider.getBlockNumber(),
+    );
+  }
+
+  private contractNameFromLog(hub: Contract, log: ethers.Log): string | undefined {
+    try {
+      const parsed = hub.interface.parseLog({ topics: [...log.topics], data: log.data });
+      const contractName = parsed?.args?.contractName ?? parsed?.args?.[0];
+      return typeof contractName === 'string' ? contractName : undefined;
+    } catch {
+      // Ignore malformed/unexpected Hub logs. The topic filter should already
+      // constrain these, but a parse miss must not wedge the poll cursor.
+      return undefined;
+    }
   }
 
   private eventTopics(hub: Contract): string[] {

--- a/packages/chain/src/hub-rotation-poller.ts
+++ b/packages/chain/src/hub-rotation-poller.ts
@@ -20,6 +20,15 @@ interface HubRotationBinding {
   topics: string[];
 }
 
+type HubRotationLogWithIdentity = ethers.Log & {
+  blockHash?: unknown;
+  transactionHash?: unknown;
+  index?: unknown;
+  logIndex?: unknown;
+};
+
+type HubRotationScanMode = 'probe' | 'dispatch';
+
 export class HubRotationPoller {
   private readonly readProvider: HubRotationReadProvider;
   private readonly intervalMs: number;
@@ -32,6 +41,7 @@ export class HubRotationPoller {
   private readonly seenLogIds = new Map<string, number>();
   private started = false;
   private startInFlight: Promise<void> | null = null;
+  private generation = 0;
 
   constructor(config: HubRotationPollerConfig) {
     this.readProvider = config.readProvider;
@@ -48,16 +58,34 @@ export class HubRotationPoller {
     if (this.started) return;
     if (this.startInFlight) return this.startInFlight;
 
-    let startPromise!: Promise<void>;
-    startPromise = this.startOnce(hub, hubAddress)
+    this.bind(hub, hubAddress);
+    const generation = ++this.generation;
+    this.started = true;
+    const startPromise = this.seed(generation)
+      .catch(() => { /* optional bootstrap path */ })
       .finally(() => {
         if (this.startInFlight === startPromise) this.startInFlight = null;
+        if (this.inFlight === startPromise) this.inFlight = null;
       });
     this.startInFlight = startPromise;
-    return startPromise;
+    this.inFlight = startPromise;
+
+    this.timer = setInterval(() => {
+      if (this.inFlight) return;
+      const pollPromise = this.pollOnce(generation)
+        .catch(() => { /* optional poller path */ })
+        .finally(() => {
+          if (this.inFlight === pollPromise) this.inFlight = null;
+        });
+      this.inFlight = pollPromise;
+    }, this.intervalMs);
+    if (this.timer.unref) this.timer.unref();
   }
 
   stop(): void {
+    this.generation++;
+    this.startInFlight = null;
+    this.inFlight = null;
     if (this.timer) {
       clearInterval(this.timer);
       this.timer = null;
@@ -73,37 +101,28 @@ export class HubRotationPoller {
     };
   }
 
-  private async startOnce(hub: Contract, hubAddress: string): Promise<void> {
-    if (this.started) return;
-
-    this.bind(hub, hubAddress);
-    await this.seed();
-    this.timer = setInterval(() => {
-      if (this.inFlight) return;
-      this.inFlight = this.pollOnce()
-        .catch(() => { /* optional poller path */ })
-        .finally(() => { this.inFlight = null; });
-    }, this.intervalMs);
-    if (this.timer.unref) this.timer.unref();
-    this.started = true;
+  async pollOnce(generation = this.generation): Promise<void> {
+    await this.scan(generation, 'dispatch');
   }
 
-  async pollOnce(): Promise<void> {
-    const binding = this.binding;
-    if (!binding || binding.topics.length === 0) return;
+  private async seed(generation: number): Promise<void> {
+    await this.scan(generation, 'probe');
+  }
 
+  private async scan(generation: number, mode: HubRotationScanMode): Promise<void> {
+    const binding = this.binding;
+    if (!binding || binding.topics.length === 0 || generation !== this.generation) return;
+
+    const label = mode === 'probe' ? 'Hub rotation seed' : 'Hub rotation poll';
     const previousLastScannedBlock = this.lastScannedBlock;
     const head = await this.readProvider(
-      'Hub rotation poll getBlockNumber',
+      `${label} getBlockNumber`,
       (provider) => provider.getBlockNumber(),
     );
-    const candidateFromBlock = previousLastScannedBlock == null
-      ? head - this.reorgBufferBlocks
-      : previousLastScannedBlock + 1 - this.reorgBufferBlocks;
-    const recentFromBlock = head - this.reorgBufferBlocks;
-    const fromBlock = Math.max(0, Math.min(candidateFromBlock, recentFromBlock));
+    if (generation !== this.generation) return;
+    const fromBlock = this.scanFromBlock(mode, previousLastScannedBlock, head);
     const logs = await this.readProvider<ethers.Log[]>(
-      'Hub rotation poll getLogs',
+      `${label} getLogs`,
       (provider) => provider.getLogs({
         address: binding.hubAddress,
         fromBlock,
@@ -112,43 +131,38 @@ export class HubRotationPoller {
       }),
       { policy: 'wideLogScan' },
     );
+    if (generation !== this.generation) return;
 
-    for (const log of logs) {
-      const identity = this.logIdentity(log);
-      if (this.seenLogIds.has(identity)) continue;
-      this.rememberLog(identity, log);
-      const contractName = this.contractNameFromLog(binding.hub, log);
-      if (contractName) this.onContractName(contractName);
-    }
+    // Probe mode intentionally does not mark logs as seen; the first buffered
+    // dispatch must still process rotations that landed during adapter init.
+    if (mode === 'dispatch') this.dispatchLogs(binding.hub, logs);
     this.lastScannedBlock = previousLastScannedBlock == null
       ? head
       : Math.max(previousLastScannedBlock, head);
     this.pruneSeenLogs(head);
   }
 
-  private async seed(): Promise<void> {
-    const binding = this.binding;
-    if (!binding || binding.topics.length === 0) return;
-    const head = await this.readProvider(
-      'Hub rotation seed getBlockNumber',
-      (provider) => provider.getBlockNumber(),
-    );
-    const fromBlock = Math.max(0, head - this.reorgBufferBlocks);
-    // Probe log-scan support and position the high-water mark, but do not mark
-    // returned logs as seen. They must remain eligible for the first buffered
-    // post-start poll in case a real rotation landed during adapter init.
-    await this.readProvider<ethers.Log[]>(
-      'Hub rotation seed getLogs',
-      (provider) => provider.getLogs({
-        address: binding.hubAddress,
-        fromBlock,
-        toBlock: head,
-        topics: [binding.topics],
-      }),
-      { policy: 'wideLogScan' },
-    );
-    this.lastScannedBlock = head;
-    this.pruneSeenLogs(head);
+  private scanFromBlock(
+    mode: HubRotationScanMode,
+    previousLastScannedBlock: number | undefined,
+    head: number,
+  ): number {
+    if (mode === 'probe' || previousLastScannedBlock == null) {
+      return Math.max(0, head - this.reorgBufferBlocks);
+    }
+    const candidateFromBlock = previousLastScannedBlock + 1 - this.reorgBufferBlocks;
+    const recentFromBlock = head - this.reorgBufferBlocks;
+    return Math.max(0, Math.min(candidateFromBlock, recentFromBlock));
+  }
+
+  private dispatchLogs(hub: Contract, logs: ethers.Log[]): void {
+    for (const log of logs) {
+      const identity = this.logIdentity(log);
+      if (this.seenLogIds.has(identity)) continue;
+      this.rememberLog(identity, log);
+      const contractName = this.contractNameFromLog(hub, log);
+      if (contractName) this.onContractName(contractName);
+    }
   }
 
   private contractNameFromLog(hub: Contract, log: ethers.Log): string | undefined {
@@ -179,12 +193,7 @@ export class HubRotationPoller {
   }
 
   private logIdentity(log: ethers.Log): string {
-    const maybe = log as ethers.Log & {
-      blockHash?: unknown;
-      transactionHash?: unknown;
-      index?: unknown;
-      logIndex?: unknown;
-    };
+    const maybe = log as HubRotationLogWithIdentity;
     const blockHash = typeof maybe.blockHash === 'string' ? maybe.blockHash : undefined;
     const transactionHash = typeof maybe.transactionHash === 'string' ? maybe.transactionHash : undefined;
     const index = typeof maybe.index === 'number'

--- a/packages/chain/test/context-graph-registry-scan.unit.test.ts
+++ b/packages/chain/test/context-graph-registry-scan.unit.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from 'vitest';
 import { EVMChainAdapter, type EVMAdapterConfig } from '../src/evm-adapter.js';
 import { ContextGraphChainScanPartialError } from '../src/chain-adapter.js';
 import {
-  CG_REGISTRY_LIVE_TAIL_LOOKBACK_BLOCKS,
   CG_REGISTRY_MAX_SCAN_PAGES,
   CG_REGISTRY_REORG_BUFFER_BLOCKS,
 } from '../src/evm-adapter-base.js';
@@ -232,15 +231,23 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
   });
 
   it('can seed the incremental watermark from an explicit successful full scan', async () => {
-    const registry = makeRegistry();
-    const { adapter, provider } = makeAdapter(registry, 4_000);
-    registry.queryFilter.setImpl(async () => []);
+    const historicalGraphBlock = 10_000;
+    const head = 20_000;
+    const registry = makeRegistry({
+      queryFilter: seam(async (_filter: unknown, lo: number, hi: number) =>
+        lo <= historicalGraphBlock && historicalGraphBlock <= hi
+          ? [{ topics: [], data: '0x01', blockNumber: historicalGraphBlock }]
+          : [],
+      ),
+    });
+    const { adapter, provider } = makeAdapter(registry, head);
 
     await expect(adapter.hasContextGraphRegistryScanWatermark()).resolves.toBe(false);
 
-    await adapter.listContextGraphsFromChain(undefined, { seedIncrementalWatermark: true });
+    const seeded = await adapter.listContextGraphsFromChain(undefined, { seedIncrementalWatermark: true });
 
-    expect((adapter as any).contextGraphRegistryScanWatermarks.get(REGISTRY.toLowerCase())).toBe(4_001);
+    expect(seeded.map((cg) => cg.blockNumber)).toEqual([historicalGraphBlock]);
+    expect((adapter as any).contextGraphRegistryScanWatermarks.get(REGISTRY.toLowerCase())).toBe(head + 1);
     await expect(adapter.hasContextGraphRegistryScanWatermark()).resolves.toBe(true);
 
     provider.getCode = seam(async () => {
@@ -252,34 +259,8 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
 
     expect(provider.getCode.calls).toEqual([]);
     expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
-      [4_001 - CG_REGISTRY_REORG_BUFFER_BLOCKS, 4_000],
+      [head + 1 - CG_REGISTRY_REORG_BUFFER_BLOCKS, head],
     ]);
-  });
-
-  it('can seed the incremental watermark from a bounded live-tail scan without deploy-block probing', async () => {
-    const registry = makeRegistry();
-    const head = 20_000;
-    const { adapter, provider } = makeAdapter(registry, head);
-    provider.getCode = seam(async () => {
-      throw new Error('eth_getCode should not be called for daemon live-tail seeding');
-    });
-    registry.queryFilter.setImpl(async () => []);
-
-    await adapter.listContextGraphsFromChain(undefined, {
-      liveTailOnly: true,
-      liveTailLookbackBlocks: CG_REGISTRY_LIVE_TAIL_LOOKBACK_BLOCKS,
-      seedIncrementalWatermark: true,
-    });
-
-    expect(provider.getCode.calls).toEqual([]);
-    expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
-      [11_001, 13_000],
-      [13_001, 15_000],
-      [15_001, 17_000],
-      [17_001, 19_000],
-      [19_001, 20_000],
-    ]);
-    expect((adapter as any).contextGraphRegistryScanWatermarks.get(REGISTRY.toLowerCase())).toBe(head + 1);
   });
 
   it('reports no registry scan watermark after preflight cache invalidation', async () => {

--- a/packages/chain/test/context-graph-registry-scan.unit.test.ts
+++ b/packages/chain/test/context-graph-registry-scan.unit.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { EVMChainAdapter, type EVMAdapterConfig } from '../src/evm-adapter.js';
 import { ContextGraphChainScanPartialError } from '../src/chain-adapter.js';
-import { CG_REGISTRY_MAX_SCAN_PAGES, CG_REGISTRY_REORG_BUFFER_BLOCKS } from '../src/evm-adapter-base.js';
+import {
+  CG_REGISTRY_LIVE_TAIL_LOOKBACK_BLOCKS,
+  CG_REGISTRY_MAX_SCAN_PAGES,
+  CG_REGISTRY_REORG_BUFFER_BLOCKS,
+} from '../src/evm-adapter-base.js';
 
 function recorder<A extends unknown[], R>(impl: (...args: A) => R) {
   const calls: A[] = [];
@@ -250,6 +254,32 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
       [4_001 - CG_REGISTRY_REORG_BUFFER_BLOCKS, 4_000],
     ]);
+  });
+
+  it('can seed the incremental watermark from a bounded live-tail scan without deploy-block probing', async () => {
+    const registry = makeRegistry();
+    const head = 20_000;
+    const { adapter, provider } = makeAdapter(registry, head);
+    provider.getCode = seam(async () => {
+      throw new Error('eth_getCode should not be called for daemon live-tail seeding');
+    });
+    registry.queryFilter.setImpl(async () => []);
+
+    await adapter.listContextGraphsFromChain(undefined, {
+      liveTailOnly: true,
+      liveTailLookbackBlocks: CG_REGISTRY_LIVE_TAIL_LOOKBACK_BLOCKS,
+      seedIncrementalWatermark: true,
+    });
+
+    expect(provider.getCode.calls).toEqual([]);
+    expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
+      [11_001, 13_000],
+      [13_001, 15_000],
+      [15_001, 17_000],
+      [17_001, 19_000],
+      [19_001, 20_000],
+    ]);
+    expect((adapter as any).contextGraphRegistryScanWatermarks.get(REGISTRY.toLowerCase())).toBe(head + 1);
   });
 
   it('reports no registry scan watermark after preflight cache invalidation', async () => {

--- a/packages/chain/test/evm-adapter-hub-rotation.e2e.test.ts
+++ b/packages/chain/test/evm-adapter-hub-rotation.e2e.test.ts
@@ -5,7 +5,7 @@
  * stale-address bug that bricked `RandomSampling` writes from running
  * daemons whenever the Hub rotated to a new RS deployment. The fix
  * lives in `evm-adapter.ts` (`HubResolutionCache` for RS+RSS, plus a
- * Hub event listener and a `withHubStaleRetry` wrapper); the unit
+ * low-cadence Hub rotation poller and a `withHubStaleRetry` wrapper); the unit
  * tests in `hub-resolution-cache.unit.test.ts` cover the cache
  * primitive in isolation. Here we drive a **real** Hardhat node with
  * a **real** `Hub.setContractAddress(...)` rotation and assert the
@@ -14,9 +14,8 @@
  *
  *   1. TTL refresh    — cached address is replaced after `ttlMs` elapses
  *                       and the next adapter call re-resolves from Hub.
- *   2. Event listener — adapter's Hub contract/storage rotation
- *                       subscriptions invalidate the cache as soon as
- *                       the rotation is mined.
+ *   2. Hub poller     — adapter's Hub contract/storage rotation scan
+ *                       invalidates the cache after the rotation is mined.
  *   3. Self-heal      — `withHubStaleRetry()` catches the exact revert
  *                       wording the prover sees in the wild
  *                       (`UnauthorizedAccess(Only Contracts in Hub)`),
@@ -136,22 +135,27 @@ async function waitFor(
   return false;
 }
 
+/** Drive the adapter's bound Hub rotation poller once. */
+async function pollHubRotations(adapter: EVMChainAdapter): Promise<void> {
+  await (adapter as any).hubRotationPoller.pollOnce();
+}
+
 /**
- * Let the adapter's Hub rotation listener consume any historical
+ * Let the adapter's Hub rotation poller consume any historical
  * `ContractChanged` / `NewContract` events that a previous test in
  * the same Hardhat session may have left behind. ethers v6 subscribes
  * its polling filter with fromBlock=latest, but in practice the
  * computed `latest` can include the most-recent rotation tx — so a
- * brand-new adapter can fire its first listener callback against an
+ * brand-new adapter can fire its first poller callback against an
  * event it never directly caused.
  *
  * This mirrors production behaviour: a daemon that boots immediately
- * after a Hub rotation will catch the rotation it didn't subscribe
+ * after a Hub rotation will catch the rotation it didn't observe
  * to. The "drain" step here just ensures the test snapshots are
  * taken AFTER that catch-up, so steady-state assertions hold.
  */
 async function drainHistoricalRotationEvents(adapter: EVMChainAdapter): Promise<void> {
-  await new Promise((r) => setTimeout(r, 1_000));
+  await pollHubRotations(adapter);
   if (!(adapter as any).initialized) {
     await (adapter as any).init();
   }
@@ -182,9 +186,8 @@ describe('EVMChainAdapter — Hub rotation self-refresh (E2E)', () => {
       expect(cachedBefore).not.toBeNull();
       const addrA: string = await cachedBefore!.rs.getAddress();
 
-      // Isolate the TTL path from the event-listener path so this test
-      // doesn't trivially pass via event-driven invalidation.
-      (adapter as any).contracts.hub.removeAllListeners();
+      // Isolate the TTL path from the Hub poller path by not driving the
+      // poller during this test; production cadence is far longer than 300 ms.
 
       const deployer = new Wallet(HARDHAT_KEYS.DEPLOYER, ctx.provider);
       const replacementAddr = freshAddress();
@@ -192,7 +195,7 @@ describe('EVMChainAdapter — Hub rotation self-refresh (E2E)', () => {
       try {
         await rotateHubContract(ctx.hubAddress, deployer, 'RandomSampling', replacementAddr);
 
-        // Sanity: with the listener removed, immediate inspection still
+        // Sanity: without driving the Hub poller, immediate inspection still
         // shows the stale cached address — TTL hasn't fired yet.
         const peeked = (adapter as any).randomSamplingPairCache.peek() as
           | { rs: Contract; rss: Contract }
@@ -216,10 +219,10 @@ describe('EVMChainAdapter — Hub rotation self-refresh (E2E)', () => {
   );
 
   it(
-    'Hub event listener: rotating RandomSamplingStorage ALSO invalidates the pair cache (coupled refresh)',
+    'Hub rotation poller: rotating RandomSamplingStorage ALSO invalidates the pair cache (coupled refresh)',
     async () => {
       // RS and RSS are deliberately treated as a coupled unit because
-      // RS.initialize() snapshots its RSS address. If the listener
+      // RS.initialize() snapshots its RSS address. If the poller
       // only invalidated on a name match, a single-side rotation
       // (rare but possible) could leave the adapter holding a mixed
       // pair — the exact bug Codex flagged on round 1. This test
@@ -238,12 +241,8 @@ describe('EVMChainAdapter — Hub rotation self-refresh (E2E)', () => {
       try {
         await rotateHubContract(ctx.hubAddress, deployer, 'RandomSamplingStorage', replacementAddr);
 
-        const invalidated = await waitFor(
-          () => (adapter as any).randomSamplingPairCache.peek() === null,
-          15_000,
-          100,
-        );
-        expect(invalidated).toBe(true);
+        await pollHubRotations(adapter);
+        expect((adapter as any).randomSamplingPairCache.peek()).toBeNull();
       } finally {
         await rotateHubContract(ctx.hubAddress, deployer, 'RandomSamplingStorage', realRssAddr);
       }
@@ -252,7 +251,7 @@ describe('EVMChainAdapter — Hub rotation self-refresh (E2E)', () => {
   );
 
   it(
-    'Hub event listener: invalidation also flips isRandomSamplingReady() to false until next getRandomSampling()',
+    'Hub rotation poller: invalidation also flips isRandomSamplingReady() to false until next getRandomSampling()',
     async () => {
       // Codex N15 — invalidating only the pair cache without dropping
       // the side-channel `this.contracts.randomSampling[Storage]` handles
@@ -275,12 +274,8 @@ describe('EVMChainAdapter — Hub rotation self-refresh (E2E)', () => {
       try {
         await rotateHubContract(ctx.hubAddress, deployer, 'RandomSampling', replacementAddr);
 
-        const becameNotReady = await waitFor(
-          () => adapter.isRandomSamplingReady() === false,
-          15_000,
-          100,
-        );
-        expect(becameNotReady).toBe(true);
+        await pollHubRotations(adapter);
+        expect(adapter.isRandomSamplingReady()).toBe(false);
 
         await (adapter as any).getRandomSampling();
         expect(adapter.isRandomSamplingReady()).toBe(true);
@@ -292,15 +287,15 @@ describe('EVMChainAdapter — Hub rotation self-refresh (E2E)', () => {
   );
 
   it(
-    'Hub event listener: ContractChanged invalidates the RandomSampling cache',
+    'Hub rotation poller: ContractChanged invalidates the RandomSampling cache',
     async () => {
       // High TTL (10 min) far exceeds the test's lifetime, so the only
       // path that can plausibly re-resolve within this test window is
-      // the event listener installed in init().
+      // the Hub rotation poller driven by the test.
       const adapter = makeAdapter(ctx.rpcUrl, ctx.hubAddress, 600_000);
 
-      // Drop the JsonRpcProvider polling interval (default 4 s) before
-      // the listener is attached so this test resolves quickly.
+      // Keep the adapter provider fast for direct reads; Hub invalidation is
+      // driven explicitly through the adapter-owned poller.
       (adapter as any).provider.pollingInterval = 250;
 
       await adapter.getActiveProofPeriodStatus!();
@@ -315,14 +310,8 @@ describe('EVMChainAdapter — Hub rotation self-refresh (E2E)', () => {
       try {
         await rotateHubContract(ctx.hubAddress, deployer, 'RandomSampling', replacementAddr);
 
-        // The listener should observe `ContractChanged('RandomSampling', ...)`
-        // within a few polling cycles and call `cache.invalidate()`.
-        const invalidated = await waitFor(
-          () => (adapter as any).randomSamplingPairCache.peek() === null,
-          15_000,
-          100,
-        );
-        expect(invalidated).toBe(true);
+        await pollHubRotations(adapter);
+        expect((adapter as any).randomSamplingPairCache.peek()).toBeNull();
 
         // Next get() resolves from the live Hub and reflects the new addr.
         const { rs } = await (adapter as any).getRandomSampling();
@@ -426,12 +415,8 @@ describe('EVMChainAdapter — Hub rotation self-refresh (E2E)', () => {
       const tempAddr = freshAddress();
       await rotateHubContract(ctx.hubAddress, deployer, 'RandomSampling', tempAddr);
 
-      // Wait for invalidation (event listener path; TTL also covers it).
-      const invalidatedFirst = await waitFor(
-        () => (adapter as any).randomSamplingPairCache.peek() === null,
-        15_000,
-      );
-      expect(invalidatedFirst).toBe(true);
+      await pollHubRotations(adapter);
+      expect((adapter as any).randomSamplingPairCache.peek()).toBeNull();
 
       // Restore the real RS and let the adapter rediscover it.
       await rotateHubContract(ctx.hubAddress, deployer, 'RandomSampling', realRsAddr);
@@ -470,16 +455,16 @@ describe('EVMChainAdapter — Hub rotation self-refresh (E2E)', () => {
   // that backs `pcaWrite` and any future write-side caller. The
   // contract under test is `Identity` — it's always deployed, always
   // boot-bound, and listed in `BOUND_CONTRACT_INVALIDATORS`; the
-  // listener should treat it identically to any other entry in the
+  // poller should treat it identically to any other entry in the
   // map.
   // ===================================================================
 
   it(
-    'event listener (generic): rotating Identity preserves live handle and re-arms init()',
+    'Hub rotation poller (generic): rotating Identity preserves live handle and re-arms init()',
     async () => {
-      // High TTL — only the event listener can flip the field within
+      // High TTL — only the Hub rotation poller can flip the field within
       // the test window. (RS cache has its own TTL; the generic path
-      // doesn't use one — only event/listener + write-side retry.)
+      // doesn't use one — only poller + write-side retry.)
       const adapter = makeAdapter(ctx.rpcUrl, ctx.hubAddress, 600_000);
       (adapter as any).provider.pollingInterval = 250;
 
@@ -494,16 +479,9 @@ describe('EVMChainAdapter — Hub rotation self-refresh (E2E)', () => {
       try {
         await rotateHubContract(ctx.hubAddress, deployer, 'Identity', replacementAddr);
 
-        // Listener keeps the field usable for in-flight calls and flips
-        // `initialized` so the next public entry re-resolves from Hub.
-        const observed = await waitFor(
-          () =>
-            (adapter as any).contracts.identity === identityBefore &&
-            (adapter as any).initialized === false,
-          15_000,
-          100,
-        );
-        expect(observed).toBe(true);
+        await pollHubRotations(adapter);
+        expect((adapter as any).contracts.identity).toBe(identityBefore);
+        expect((adapter as any).initialized).toBe(false);
 
         // Next init() re-resolves from the live Hub and binds the new address.
         await (adapter as any).init();
@@ -520,7 +498,7 @@ describe('EVMChainAdapter — Hub rotation self-refresh (E2E)', () => {
   );
 
   it(
-    'event listener (generic): boot-bound rotation clears publish preflight cache before TTL',
+    'Hub rotation poller (generic): boot-bound rotation clears publish preflight cache before TTL',
     async () => {
       const adapter = makeAdapter(ctx.rpcUrl, ctx.hubAddress, 600_000);
       (adapter as any).provider.pollingInterval = 250;
@@ -543,16 +521,11 @@ describe('EVMChainAdapter — Hub rotation self-refresh (E2E)', () => {
         // is what getKnowledgeAssetsLifecycleAddress() resolves. Rotate that key.
         await rotateHubContract(ctx.hubAddress, deployer, 'KnowledgeAssetsLifecycle', replacementAddr);
 
-        const observed = await waitFor(
-          () =>
-            (adapter as any).contracts.knowledgeAssetsLifecycle === kav10HandleBefore &&
-            (adapter as any).cachedKav10Address === undefined &&
-            (adapter as any).cachedMinRequiredSignatures === undefined &&
-            (adapter as any).initialized === false,
-          15_000,
-          100,
-        );
-        expect(observed).toBe(true);
+        await pollHubRotations(adapter);
+        expect((adapter as any).contracts.knowledgeAssetsLifecycle).toBe(kav10HandleBefore);
+        expect((adapter as any).cachedKav10Address).toBeUndefined();
+        expect((adapter as any).cachedMinRequiredSignatures).toBeUndefined();
+        expect((adapter as any).initialized).toBe(false);
 
         const kav10After = await adapter.getKnowledgeAssetsLifecycleAddress();
         expect(kav10After.toLowerCase()).toBe(replacementAddr.toLowerCase());
@@ -564,7 +537,7 @@ describe('EVMChainAdapter — Hub rotation self-refresh (E2E)', () => {
   );
 
   it(
-    'event listener (asset storage): rotating ContextGraphStorage preserves live handle and re-arms init()',
+    'Hub rotation poller (asset storage): rotating ContextGraphStorage preserves live handle and re-arms init()',
     async () => {
       const adapter = makeAdapter(ctx.rpcUrl, ctx.hubAddress, 600_000);
       (adapter as any).provider.pollingInterval = 250;
@@ -593,14 +566,9 @@ describe('EVMChainAdapter — Hub rotation self-refresh (E2E)', () => {
           replacementAddr,
         );
 
-        const observed = await waitFor(
-          () =>
-            (adapter as any).contracts.contextGraphStorage === storageBefore &&
-            (adapter as any).initialized === false,
-          15_000,
-          100,
-        );
-        expect(observed).toBe(true);
+        await pollHubRotations(adapter);
+        expect((adapter as any).contracts.contextGraphStorage).toBe(storageBefore);
+        expect((adapter as any).initialized).toBe(false);
 
         await (adapter as any).init();
         const storageAfter: Contract = (adapter as any).contracts.contextGraphStorage;
@@ -621,7 +589,7 @@ describe('EVMChainAdapter — Hub rotation self-refresh (E2E)', () => {
   );
 
   it(
-    'event listener (generic): rotating an unknown contract name is ignored — no fields touched',
+    'Hub rotation poller (generic): rotating an unknown contract name is ignored — no fields touched',
     async () => {
       const adapter = makeAdapter(ctx.rpcUrl, ctx.hubAddress, 600_000);
       (adapter as any).provider.pollingInterval = 250;
@@ -636,13 +604,12 @@ describe('EVMChainAdapter — Hub rotation self-refresh (E2E)', () => {
       const deployer = new Wallet(HARDHAT_KEYS.DEPLOYER, ctx.provider);
       // Use a name NOT in BOUND_CONTRACT_INVALIDATORS. Hub.setContractAddress
       // accepts arbitrary strings and emits `NewContract` for first
-      // registrations — exactly the noise we need to confirm the listener
+      // registrations — exactly the noise we need to confirm the poller
       // safely allowlists.
       const unknownName = `RC12TestUnknown-${Date.now()}`;
       await rotateHubContract(ctx.hubAddress, deployer, unknownName, freshAddress());
 
-      // Give the listener multiple polling cycles to mis-fire if it would.
-      await new Promise((r) => setTimeout(r, 1_500));
+      await pollHubRotations(adapter);
 
       expect((adapter as any).contracts.identity).toBe(identityBefore);
       expect((adapter as any).initialized).toBe(true);

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -1212,7 +1212,11 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     a.rpcUrls = ['https://primary.example'];
     a.primaryProvider = provider;
     a.provider = provider;
-    a.contracts.hub = { interface: iface, target: '0x0000000000000000000000000000000000000001', on };
+    a.contracts.hub = {
+      interface: iface,
+      getAddress: async () => '0x0000000000000000000000000000000000000001',
+      on,
+    };
     a.contracts.contextGraphs = { stale: true };
     a.cachedKav10Address = { value: '0x00000000000000000000000000000000000000aa', cachedAt: 1 };
     a.hubRotationListenerStarted = false;
@@ -1273,7 +1277,11 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     a.rpcUrls = ['https://primary.example'];
     a.primaryProvider = provider;
     a.provider = provider;
-    a.contracts.hub = { interface: iface, target: '0x0000000000000000000000000000000000000001', on };
+    a.contracts.hub = {
+      interface: iface,
+      getAddress: async () => '0x0000000000000000000000000000000000000001',
+      on,
+    };
     a.contracts.contextGraphs = { fresh: true };
     a.contracts.randomSampling = { fresh: 'rs' };
     a.contracts.randomSamplingStorage = { fresh: 'rss' };
@@ -1326,7 +1334,10 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     a.rpcUrls = ['https://primary.example'];
     a.primaryProvider = provider;
     a.provider = provider;
-    a.contracts.hub = { interface: iface, target: '0x0000000000000000000000000000000000000001' };
+    a.contracts.hub = {
+      interface: iface,
+      getAddress: async () => '0x0000000000000000000000000000000000000001',
+    };
     a.hubRotationListenerStarted = false;
 
     try {
@@ -1364,7 +1375,10 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     a.rpcUrls = ['https://lagging.example'];
     a.primaryProvider = provider;
     a.provider = provider;
-    a.contracts.hub = { interface: iface, target: '0x0000000000000000000000000000000000000001' };
+    a.contracts.hub = {
+      interface: iface,
+      getAddress: async () => '0x0000000000000000000000000000000000000001',
+    };
     a.hubRotationPoller.lastScannedBlock = 1_000;
 
     await expect(a.pollHubRotationEvents()).resolves.toBeUndefined();

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -1239,6 +1239,59 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     expect(a.hubRotationListenerStarted).toBe(false);
   });
 
+  it('startHubRotationListener processes Hub rotations from the recurring poll timer', async () => {
+    vi.useFakeTimers({ now: 0 });
+    const a: any = new EVMChainAdapter(minimalConfig());
+    const iface = new ethers.Interface([
+      'event NewContract(string contractName, address newContractAddress)',
+      'event ContractChanged(string contractName, address newContractAddress)',
+      'event NewAssetStorage(string contractName, address newContractAddress)',
+      'event AssetStorageChanged(string contractName, address newContractAddress)',
+    ]);
+    const changed = iface.encodeEventLog(iface.getEvent('NewContract')!, [
+      'ContextGraphs',
+      '0x00000000000000000000000000000000000000c1',
+    ]);
+    let poll = 0;
+    const provider = {
+      getBlockNumber: recorder(async () => 1_000 + poll),
+      getLogs: recorder(async (_filter: any) => {
+        poll++;
+        return poll === 1
+          ? []
+          : [{ topics: changed.topics, data: changed.data }];
+      }),
+      destroy: recorder(() => undefined),
+    };
+    const on = recorder(async () => {
+      throw new Error('ethers subscription should not be installed');
+    });
+    a.providers = [provider];
+    a.rpcUrls = ['https://primary.example'];
+    a.primaryProvider = provider;
+    a.provider = provider;
+    a.contracts.hub = { interface: iface, target: '0x0000000000000000000000000000000000000001', on };
+    a.cachedKav10Address = { value: '0x00000000000000000000000000000000000000aa', cachedAt: 1 };
+    a.hubRotationListenerStarted = false;
+    a.initialized = true;
+
+    try {
+      await expect(a.startHubRotationListener()).resolves.toBeUndefined();
+      expect(on.calls).toEqual([]);
+      expect(provider.getLogs.calls).toHaveLength(1);
+      expect(a.initialized).toBe(true);
+
+      await vi.advanceTimersByTimeAsync(5 * 60_000);
+
+      expect(provider.getLogs.calls).toHaveLength(2);
+      expect(a.cachedKav10Address).toBeUndefined();
+      expect(a.initialized).toBe(false);
+    } finally {
+      a.destroy();
+      vi.useRealTimers();
+    }
+  });
+
   it('pollHubRotationEvents clamps the range when failover observes a lower head', async () => {
     const a: any = new EVMChainAdapter(minimalConfig());
     const iface = new ethers.Interface([
@@ -1257,7 +1310,7 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     a.primaryProvider = provider;
     a.provider = provider;
     a.contracts.hub = { interface: iface, target: '0x0000000000000000000000000000000000000001' };
-    a.hubRotationLastScannedBlock = 1_000;
+    a.hubRotationPoller.lastScannedBlock = 1_000;
 
     await expect(a.pollHubRotationEvents()).resolves.toBeUndefined();
 
@@ -1266,7 +1319,7 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
       fromBlock: 850,
       toBlock: 900,
     });
-    expect(a.hubRotationLastScannedBlock).toBe(900);
+    expect(a.hubRotationPoller.lastScannedBlock).toBe(900);
   });
 
   it('invalidateRandomSamplingPair drops both the cache AND the side-channel contract handles (Codex N15)', () => {

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -1186,6 +1186,63 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     expect(a.hubRotationListenerStarted).toBe(false);
   });
 
+  it('startHubRotationListener coalesces concurrent poller starts', async () => {
+    vi.useFakeTimers({ now: 0 });
+    const a: any = new EVMChainAdapter(minimalConfig());
+    const iface = new ethers.Interface([
+      'event NewContract(string contractName, address newContractAddress)',
+      'event ContractChanged(string contractName, address newContractAddress)',
+      'event NewAssetStorage(string contractName, address newContractAddress)',
+      'event AssetStorageChanged(string contractName, address newContractAddress)',
+    ]);
+    let seedEntered!: () => void;
+    const seedEnteredPromise = new Promise<void>((resolve) => { seedEntered = resolve; });
+    let releaseSeed!: () => void;
+    const seedGate = new Promise<void>((resolve) => { releaseSeed = resolve; });
+    let getLogsCalls = 0;
+    const provider = {
+      getBlockNumber: recorder(async () => 1_000),
+      getLogs: recorder(async () => {
+        getLogsCalls++;
+        if (getLogsCalls === 1) {
+          seedEntered();
+          await seedGate;
+        }
+        return [];
+      }),
+      destroy: recorder(() => undefined),
+    };
+    a.providers = [provider];
+    a.rpcUrls = ['https://primary.example'];
+    a.primaryProvider = provider;
+    a.provider = provider;
+    a.contracts.hub = {
+      interface: iface,
+      getAddress: async () => '0x0000000000000000000000000000000000000001',
+    };
+    a.hubRotationListenerStarted = false;
+
+    try {
+      const firstStart = a.startHubRotationListener();
+      await seedEnteredPromise;
+      expect(provider.getLogs.calls).toHaveLength(1);
+
+      const secondStart = a.startHubRotationListener();
+      releaseSeed();
+      await expect(Promise.all([firstStart, secondStart])).resolves.toBeDefined();
+
+      expect(provider.getBlockNumber.calls).toHaveLength(1);
+      expect(provider.getLogs.calls).toHaveLength(1);
+
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(provider.getBlockNumber.calls).toHaveLength(2);
+      expect(provider.getLogs.calls).toHaveLength(2);
+    } finally {
+      a.destroy();
+      vi.useRealTimers();
+    }
+  });
+
   it('startHubRotationListener skips optional poller setup when primary static validation fails but backup reads still work', async () => {
     const a: any = new EVMChainAdapter(minimalConfig({
       rpcUrl: 'https://primary.example',

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -118,6 +118,10 @@ function recorder<A extends unknown[], R>(impl: (...args: A) => R) {
   return Object.assign(fn, { calls });
 }
 
+async function flushAsyncWork(turns = 8): Promise<void> {
+  for (let i = 0; i < turns; i++) await Promise.resolve();
+}
+
 function minimalConfig(overrides: Partial<EVMAdapterConfig> = {}): EVMAdapterConfig {
   return {
     rpcUrl: 'http://127.0.0.1:59998',
@@ -1142,7 +1146,6 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
       interface: iface,
       getAddress: async () => '0x0000000000000000000000000000000000000001',
     };
-    a.hubRotationListenerStarted = false;
     let unhandled: unknown = null;
     const onRejection = (reason: unknown) => { unhandled = reason; };
     process.on('unhandledRejection', onRejection);
@@ -1152,7 +1155,7 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
       expect(unhandled).toBeNull();
       expect(provider.getBlockNumber.calls).toHaveLength(1);
       expect(provider.getLogs.calls).toHaveLength(1);
-      expect(a.hubRotationListenerStarted).toBe(false);
+      expect(a.hubRotationPoller.isStarted).toBe(true);
     } finally {
       process.off('unhandledRejection', onRejection);
     }
@@ -1177,70 +1180,12 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
       interface: iface,
       getAddress: async () => '0x0000000000000000000000000000000000000001',
     };
-    a.hubRotationListenerStarted = false;
 
     await expect(a.startHubRotationListener()).resolves.toBeUndefined();
 
     expect(provider.getBlockNumber.calls).toEqual([]);
     expect(provider.getLogs.calls).toEqual([]);
-    expect(a.hubRotationListenerStarted).toBe(false);
-  });
-
-  it('startHubRotationListener coalesces concurrent poller starts', async () => {
-    vi.useFakeTimers({ now: 0 });
-    const a: any = new EVMChainAdapter(minimalConfig());
-    const iface = new ethers.Interface([
-      'event NewContract(string contractName, address newContractAddress)',
-      'event ContractChanged(string contractName, address newContractAddress)',
-      'event NewAssetStorage(string contractName, address newContractAddress)',
-      'event AssetStorageChanged(string contractName, address newContractAddress)',
-    ]);
-    let seedEntered!: () => void;
-    const seedEnteredPromise = new Promise<void>((resolve) => { seedEntered = resolve; });
-    let releaseSeed!: () => void;
-    const seedGate = new Promise<void>((resolve) => { releaseSeed = resolve; });
-    let getLogsCalls = 0;
-    const provider = {
-      getBlockNumber: recorder(async () => 1_000),
-      getLogs: recorder(async () => {
-        getLogsCalls++;
-        if (getLogsCalls === 1) {
-          seedEntered();
-          await seedGate;
-        }
-        return [];
-      }),
-      destroy: recorder(() => undefined),
-    };
-    a.providers = [provider];
-    a.rpcUrls = ['https://primary.example'];
-    a.primaryProvider = provider;
-    a.provider = provider;
-    a.contracts.hub = {
-      interface: iface,
-      getAddress: async () => '0x0000000000000000000000000000000000000001',
-    };
-    a.hubRotationListenerStarted = false;
-
-    try {
-      const firstStart = a.startHubRotationListener();
-      await seedEnteredPromise;
-      expect(provider.getLogs.calls).toHaveLength(1);
-
-      const secondStart = a.startHubRotationListener();
-      releaseSeed();
-      await expect(Promise.all([firstStart, secondStart])).resolves.toBeDefined();
-
-      expect(provider.getBlockNumber.calls).toHaveLength(1);
-      expect(provider.getLogs.calls).toHaveLength(1);
-
-      await vi.advanceTimersByTimeAsync(30_000);
-      expect(provider.getBlockNumber.calls).toHaveLength(2);
-      expect(provider.getLogs.calls).toHaveLength(2);
-    } finally {
-      a.destroy();
-      vi.useRealTimers();
-    }
+    expect(a.hubRotationPoller.isStarted).toBe(false);
   });
 
   it('startHubRotationListener skips optional poller setup when primary static validation fails but backup reads still work', async () => {
@@ -1264,28 +1209,32 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
       }),
       getBlockNumber: recorder(async () => 123),
     };
-    const on = recorder(async () => {
-      throw new Error('poller setup should be skipped');
-    });
-
     a.primaryProvider = primaryProvider;
     a.provider = primaryProvider;
     a.providers = [primaryProvider, backupProvider];
     a.rpcUrls = ['https://primary.example', 'https://backup.example'];
-    a.contracts.hub = { on };
-    a.hubRotationListenerStarted = false;
+    a.contracts.hub = {
+      interface: new ethers.Interface([
+        'event NewContract(string contractName, address newContractAddress)',
+        'event ContractChanged(string contractName, address newContractAddress)',
+        'event NewAssetStorage(string contractName, address newContractAddress)',
+        'event AssetStorageChanged(string contractName, address newContractAddress)',
+      ]),
+      getAddress: async () => '0x0000000000000000000000000000000000000001',
+    };
 
     await expect(a.startHubRotationListener()).resolves.toBeUndefined();
-    expect(on.calls).toEqual([]);
-    expect(a.hubRotationListenerStarted).toBe(false);
+    await flushAsyncWork();
+    expect(a.hubRotationPoller.isStarted).toBe(true);
 
     await expect(a.readProvider('getBlockNumber', (p: any) => p.getBlockNumber()))
       .resolves.toBe(123);
     expect(primaryProvider.getBlockNumber.calls).toEqual([]);
-    expect(backupProvider.getBlockNumber.calls).toEqual([[]]);
+    expect(backupProvider.getBlockNumber.calls).toHaveLength(2);
   });
 
-  it('HubRotationPoller pollOnce scans Hub rotation topics without ethers subscriptions', async () => {
+  it('startHubRotationListener wires Hub rotation names into adapter invalidation without subscriptions', async () => {
+    vi.useFakeTimers({ now: 0 });
     const a: any = new EVMChainAdapter(minimalConfig());
     const iface = new ethers.Interface([
       'event NewContract(string contractName, address newContractAddress)',
@@ -1325,256 +1274,37 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     };
     a.contracts.contextGraphs = { stale: true };
     a.cachedKav10Address = { value: '0x00000000000000000000000000000000000000aa', cachedAt: 1 };
-    a.hubRotationListenerStarted = false;
-    a.initialized = true;
-
-    await expect(a.startHubRotationListener()).resolves.toBeUndefined();
-    includeRotationLog = true;
-    head = 1_001;
-    await expect(a.hubRotationPoller.pollOnce()).resolves.toBeUndefined();
-    a.destroy();
-
-    expect(on.calls).toEqual([]);
-    expect(provider.getLogs.calls).toHaveLength(2);
-    expect(provider.getLogs.calls[1][0]).toMatchObject({
-      address: '0x0000000000000000000000000000000000000001',
-      fromBlock: 951,
-      toBlock: 1_001,
-    });
-    expect(provider.getLogs.calls[1][0].topics[0]).toEqual([
-      iface.getEvent('ContractChanged')!.topicHash,
-      iface.getEvent('NewContract')!.topicHash,
-      iface.getEvent('AssetStorageChanged')!.topicHash,
-      iface.getEvent('NewAssetStorage')!.topicHash,
-    ]);
-    expect(a.contracts.contextGraphs).toEqual({ stale: true });
-    expect(a.cachedKav10Address).toBeUndefined();
-    expect(a.initialized).toBe(false);
-    expect(a.hubRotationListenerStarted).toBe(false);
-  });
-
-  it('startHubRotationListener defers seed logs until the first post-start buffered poll', async () => {
-    vi.useFakeTimers({ now: 0 });
-    const a: any = new EVMChainAdapter(minimalConfig());
-    const iface = new ethers.Interface([
-      'event NewContract(string contractName, address newContractAddress)',
-      'event ContractChanged(string contractName, address newContractAddress)',
-      'event NewAssetStorage(string contractName, address newContractAddress)',
-      'event AssetStorageChanged(string contractName, address newContractAddress)',
-    ]);
-    const oldRandomSampling = iface.encodeEventLog(iface.getEvent('NewContract')!, [
-      'RandomSampling',
-      '0x00000000000000000000000000000000000000b1',
-    ]);
-    const changed = iface.encodeEventLog(iface.getEvent('NewContract')!, [
-      'ContextGraphs',
-      '0x00000000000000000000000000000000000000c1',
-    ]);
-    let head = 1_000;
-    const historicalLogs = [
-      {
-        blockNumber: 1_000,
-        blockHash: '0x' + '10'.repeat(32),
-        transactionHash: '0x' + '11'.repeat(32),
-        index: 0,
-        topics: oldRandomSampling.topics,
-        data: oldRandomSampling.data,
-      },
-      {
-        blockNumber: 1_001,
-        blockHash: '0x' + '12'.repeat(32),
-        transactionHash: '0x' + '13'.repeat(32),
-        index: 0,
-        topics: changed.topics,
-        data: changed.data,
-      },
-    ];
-    const provider = {
-      getBlockNumber: recorder(async () => head),
-      getLogs: recorder(async (filter: any) =>
-        historicalLogs.filter((log) => log.blockNumber >= filter.fromBlock && log.blockNumber <= filter.toBlock)),
-      destroy: recorder(() => undefined),
-    };
-    const on = recorder(async () => {
-      throw new Error('ethers subscription should not be installed');
-    });
-    a.providers = [provider];
-    a.rpcUrls = ['https://primary.example'];
-    a.primaryProvider = provider;
-    a.provider = provider;
-    a.contracts.hub = {
-      interface: iface,
-      getAddress: async () => '0x0000000000000000000000000000000000000001',
-      on,
-    };
-    a.contracts.contextGraphs = { fresh: true };
-    a.contracts.randomSampling = { fresh: 'rs' };
-    a.contracts.randomSamplingStorage = { fresh: 'rss' };
-    a.cachedKav10Address = { value: '0x00000000000000000000000000000000000000aa', cachedAt: 1 };
-    a.hubRotationListenerStarted = false;
     a.initialized = true;
 
     try {
       await expect(a.startHubRotationListener()).resolves.toBeUndefined();
-      expect(on.calls).toEqual([]);
-      expect(provider.getBlockNumber.calls).toHaveLength(1);
-      expect(provider.getLogs.calls).toHaveLength(1);
-      expect(provider.getLogs.calls[0][0]).toMatchObject({
-        fromBlock: 950,
-        toBlock: 1_000,
-      });
-      expect(a.contracts.contextGraphs).toEqual({ fresh: true });
-      expect(a.contracts.randomSampling).toEqual({ fresh: 'rs' });
-      expect(a.initialized).toBe(true);
-
+      await flushAsyncWork();
+      includeRotationLog = true;
       head = 1_001;
       await vi.advanceTimersByTimeAsync(30_000);
+      a.destroy();
 
+      expect(on.calls).toEqual([]);
       expect(provider.getLogs.calls).toHaveLength(2);
       expect(provider.getLogs.calls[1][0]).toMatchObject({
+        address: '0x0000000000000000000000000000000000000001',
         fromBlock: 951,
         toBlock: 1_001,
       });
-      expect(a.contracts.contextGraphs).toEqual({ fresh: true });
-      expect(a.contracts.randomSampling).toBeUndefined();
+      expect(provider.getLogs.calls[1][0].topics[0]).toEqual([
+        iface.getEvent('ContractChanged')!.topicHash,
+        iface.getEvent('NewContract')!.topicHash,
+        iface.getEvent('AssetStorageChanged')!.topicHash,
+        iface.getEvent('NewAssetStorage')!.topicHash,
+      ]);
+      expect(a.contracts.contextGraphs).toEqual({ stale: true });
       expect(a.cachedKav10Address).toBeUndefined();
       expect(a.initialized).toBe(false);
+      expect(a.hubRotationPoller.isStarted).toBe(false);
     } finally {
       a.destroy();
       vi.useRealTimers();
     }
-  });
-
-  it('HubRotationPoller applies replacement logs inside the reorg buffer', async () => {
-    const a: any = new EVMChainAdapter(minimalConfig());
-    const iface = new ethers.Interface([
-      'event NewContract(string contractName, address newContractAddress)',
-      'event ContractChanged(string contractName, address newContractAddress)',
-      'event NewAssetStorage(string contractName, address newContractAddress)',
-      'event AssetStorageChanged(string contractName, address newContractAddress)',
-    ]);
-    const oldRotation = iface.encodeEventLog(iface.getEvent('ContractChanged')!, [
-      'UntrackedAtStartup',
-      '0x00000000000000000000000000000000000000b1',
-    ]);
-    const replacement = iface.encodeEventLog(iface.getEvent('ContractChanged')!, [
-      'ContextGraphs',
-      '0x00000000000000000000000000000000000000c1',
-    ]);
-    let head = 1_000;
-    const logs = [
-      {
-        blockNumber: 1_000,
-        blockHash: '0x' + '20'.repeat(32),
-        transactionHash: '0x' + '21'.repeat(32),
-        index: 0,
-        topics: oldRotation.topics,
-        data: oldRotation.data,
-      },
-    ];
-    const provider = {
-      getBlockNumber: recorder(async () => head),
-      getLogs: recorder(async (filter: any) =>
-        logs.filter((log) => log.blockNumber >= filter.fromBlock && log.blockNumber <= filter.toBlock)),
-      destroy: recorder(() => undefined),
-    };
-    a.providers = [provider];
-    a.rpcUrls = ['https://primary.example'];
-    a.primaryProvider = provider;
-    a.provider = provider;
-    a.contracts.hub = {
-      interface: iface,
-      getAddress: async () => '0x0000000000000000000000000000000000000001',
-    };
-    a.contracts.contextGraphs = { fresh: true };
-    a.cachedKav10Address = { value: '0x00000000000000000000000000000000000000aa', cachedAt: 1 };
-    a.initialized = true;
-
-    await expect(a.startHubRotationListener()).resolves.toBeUndefined();
-    expect(a.cachedKav10Address).toBeDefined();
-    expect(a.initialized).toBe(true);
-
-    logs.splice(0, logs.length, {
-      blockNumber: 1_000,
-      blockHash: '0x' + '22'.repeat(32),
-      transactionHash: '0x' + '23'.repeat(32),
-      index: 0,
-      topics: replacement.topics,
-      data: replacement.data,
-    });
-    head = 1_001;
-    await expect(a.hubRotationPoller.pollOnce()).resolves.toBeUndefined();
-    a.destroy();
-
-    expect(provider.getLogs.calls).toHaveLength(2);
-    expect(provider.getLogs.calls[1][0]).toMatchObject({
-      fromBlock: 951,
-      toBlock: 1_001,
-    });
-    expect(a.contracts.contextGraphs).toEqual({ fresh: true });
-    expect(a.cachedKav10Address).toBeUndefined();
-    expect(a.initialized).toBe(false);
-  });
-
-  it('HubRotationPoller processes a new rotation log at the previous cursor block', async () => {
-    const a: any = new EVMChainAdapter(minimalConfig());
-    const iface = new ethers.Interface([
-      'event NewContract(string contractName, address newContractAddress)',
-      'event ContractChanged(string contractName, address newContractAddress)',
-      'event NewAssetStorage(string contractName, address newContractAddress)',
-      'event AssetStorageChanged(string contractName, address newContractAddress)',
-    ]);
-    const rotation = iface.encodeEventLog(iface.getEvent('ContractChanged')!, [
-      'ContextGraphs',
-      '0x00000000000000000000000000000000000000c1',
-    ]);
-    let head = 1_000;
-    let exposeReorgLog = false;
-    const provider = {
-      getBlockNumber: recorder(async () => head),
-      getLogs: recorder(async (filter: any) => {
-        const log = {
-          blockNumber: 1_000,
-          blockHash: '0x' + '40'.repeat(32),
-          transactionHash: '0x' + '41'.repeat(32),
-          index: 0,
-          topics: rotation.topics,
-          data: rotation.data,
-        };
-        return exposeReorgLog && log.blockNumber >= filter.fromBlock && log.blockNumber <= filter.toBlock
-          ? [log]
-          : [];
-      }),
-      destroy: recorder(() => undefined),
-    };
-    a.providers = [provider];
-    a.rpcUrls = ['https://primary.example'];
-    a.primaryProvider = provider;
-    a.provider = provider;
-    a.contracts.hub = {
-      interface: iface,
-      getAddress: async () => '0x0000000000000000000000000000000000000001',
-    };
-    a.contracts.contextGraphs = { fresh: true };
-    a.cachedKav10Address = { value: '0x00000000000000000000000000000000000000aa', cachedAt: 1 };
-    a.initialized = true;
-
-    await expect(a.startHubRotationListener()).resolves.toBeUndefined();
-    expect(a.cachedKav10Address).toBeDefined();
-
-    exposeReorgLog = true;
-    head = 1_001;
-    await expect(a.hubRotationPoller.pollOnce()).resolves.toBeUndefined();
-    a.destroy();
-
-    expect(provider.getLogs.calls).toHaveLength(2);
-    expect(provider.getLogs.calls[1][0]).toMatchObject({
-      fromBlock: 951,
-      toBlock: 1_001,
-    });
-    expect(a.contracts.contextGraphs).toEqual({ fresh: true });
-    expect(a.cachedKav10Address).toBeUndefined();
-    expect(a.initialized).toBe(false);
   });
 
   it('destroy clears the Hub rotation poll interval', async () => {
@@ -1599,10 +1329,10 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
       interface: iface,
       getAddress: async () => '0x0000000000000000000000000000000000000001',
     };
-    a.hubRotationListenerStarted = false;
 
     try {
       await expect(a.startHubRotationListener()).resolves.toBeUndefined();
+      await flushAsyncWork();
       expect(provider.getBlockNumber.calls).toHaveLength(1);
       expect(provider.getLogs.calls).toHaveLength(1);
 
@@ -1612,47 +1342,11 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
       expect(provider.getBlockNumber.calls).toHaveLength(1);
       expect(provider.getLogs.calls).toHaveLength(1);
       expect(provider.destroy.calls).toHaveLength(1);
-      expect(a.hubRotationListenerStarted).toBe(false);
+      expect(a.hubRotationPoller.isStarted).toBe(false);
     } finally {
       a.destroy();
       vi.useRealTimers();
     }
-  });
-
-  it('HubRotationPoller pollOnce clamps the range when failover observes a lower head', async () => {
-    const a: any = new EVMChainAdapter(minimalConfig());
-    const iface = new ethers.Interface([
-      'event NewContract(string contractName, address newContractAddress)',
-      'event ContractChanged(string contractName, address newContractAddress)',
-      'event NewAssetStorage(string contractName, address newContractAddress)',
-      'event AssetStorageChanged(string contractName, address newContractAddress)',
-    ]);
-    let head = 1_000;
-    const provider = {
-      getBlockNumber: recorder(async () => head),
-      getLogs: recorder(async (_filter: any) => []),
-      destroy: recorder(() => undefined),
-    };
-    a.providers = [provider];
-    a.rpcUrls = ['https://lagging.example'];
-    a.primaryProvider = provider;
-    a.provider = provider;
-    a.contracts.hub = {
-      interface: iface,
-      getAddress: async () => '0x0000000000000000000000000000000000000001',
-    };
-    await expect(a.startHubRotationListener()).resolves.toBeUndefined();
-    head = 900;
-
-    await expect(a.hubRotationPoller.pollOnce()).resolves.toBeUndefined();
-    a.destroy();
-
-    expect(provider.getLogs.calls).toHaveLength(2);
-    expect(provider.getLogs.calls[1][0]).toMatchObject({
-      fromBlock: 850,
-      toBlock: 900,
-    });
-    expect(a.hubRotationPoller.lastScannedBlock).toBe(1_000);
   });
 
   it('invalidateRandomSamplingPair drops both the cache AND the side-channel contract handles (Codex N15)', () => {

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -1117,16 +1117,14 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     expect(a.chainType).toBe('evm');
   });
 
-  it('startHubRotationListener swallows async provider rejections without unhandled-rejection or throw (Codex N15)', async () => {
-    // ethers v6 `Contract.on(...)` is async — providers that reject
-    // filter installation (e.g. HTTP-only endpoints, mocked providers)
-    // must NOT bubble as unhandled rejections, and the listener-started
-    // flag must NOT be flipped if subscription failed (so a future
-    // retry remains possible).
+  it('startHubRotationListener swallows optional poll setup failures without unhandled-rejection or throw', async () => {
+    // Hub rotation detection is best-effort. A mocked or unsupported Hub poll
+    // surface must not bubble as an unhandled rejection, and the listener-started
+    // flag must not flip if setup failed so a future retry remains possible.
     const a = new EVMChainAdapter(minimalConfig());
     const fakeHub = {
       on: async (_event: string, _cb: (...args: unknown[]) => void) => {
-        throw new Error('provider does not support filter subscriptions');
+        throw new Error('legacy subscription seam should not be reached');
       },
     };
     (a as any).contracts.hub = fakeHub;
@@ -1184,6 +1182,91 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
       .resolves.toBe(123);
     expect(primaryProvider.getBlockNumber.calls).toEqual([]);
     expect(backupProvider.getBlockNumber.calls).toEqual([[]]);
+  });
+
+  it('startHubRotationListener polls Hub rotation topics without ethers subscriptions', async () => {
+    const a: any = new EVMChainAdapter(minimalConfig());
+    const iface = new ethers.Interface([
+      'event NewContract(string contractName, address newContractAddress)',
+      'event ContractChanged(string contractName, address newContractAddress)',
+      'event NewAssetStorage(string contractName, address newContractAddress)',
+      'event AssetStorageChanged(string contractName, address newContractAddress)',
+    ]);
+    const changed = iface.encodeEventLog(iface.getEvent('ContractChanged')!, [
+      'ContextGraphs',
+      '0x00000000000000000000000000000000000000c1',
+    ]);
+    const provider = {
+      getBlockNumber: recorder(async () => 1_000),
+      getLogs: recorder(async (_filter: any) => [{
+        topics: changed.topics,
+        data: changed.data,
+      }]),
+      destroy: recorder(() => undefined),
+    };
+    const on = recorder(async () => {
+      throw new Error('ethers subscription should not be installed');
+    });
+    a.providers = [provider];
+    a.rpcUrls = ['https://primary.example'];
+    a.primaryProvider = provider;
+    a.provider = provider;
+    a.contracts.hub = { interface: iface, target: '0x0000000000000000000000000000000000000001', on };
+    a.contracts.contextGraphs = { stale: true };
+    a.cachedKav10Address = { value: '0x00000000000000000000000000000000000000aa', cachedAt: 1 };
+    a.hubRotationListenerStarted = false;
+    a.initialized = true;
+
+    await expect(a.startHubRotationListener()).resolves.toBeUndefined();
+    a.destroy();
+
+    expect(on.calls).toEqual([]);
+    expect(provider.getLogs.calls).toHaveLength(1);
+    expect(provider.getLogs.calls[0][0]).toMatchObject({
+      address: '0x0000000000000000000000000000000000000001',
+      fromBlock: 950,
+      toBlock: 1_000,
+    });
+    expect(provider.getLogs.calls[0][0].topics[0]).toEqual([
+      iface.getEvent('ContractChanged')!.topicHash,
+      iface.getEvent('NewContract')!.topicHash,
+      iface.getEvent('AssetStorageChanged')!.topicHash,
+      iface.getEvent('NewAssetStorage')!.topicHash,
+    ]);
+    expect(a.contracts.contextGraphs).toEqual({ stale: true });
+    expect(a.cachedKav10Address).toBeUndefined();
+    expect(a.initialized).toBe(false);
+    expect(a.hubRotationListenerStarted).toBe(false);
+  });
+
+  it('pollHubRotationEvents clamps the range when failover observes a lower head', async () => {
+    const a: any = new EVMChainAdapter(minimalConfig());
+    const iface = new ethers.Interface([
+      'event NewContract(string contractName, address newContractAddress)',
+      'event ContractChanged(string contractName, address newContractAddress)',
+      'event NewAssetStorage(string contractName, address newContractAddress)',
+      'event AssetStorageChanged(string contractName, address newContractAddress)',
+    ]);
+    const provider = {
+      getBlockNumber: recorder(async () => 900),
+      getLogs: recorder(async (_filter: any) => []),
+      destroy: recorder(() => undefined),
+    };
+    a.providers = [provider];
+    a.rpcUrls = ['https://lagging.example'];
+    a.primaryProvider = provider;
+    a.provider = provider;
+    a.contracts.hub = { interface: iface, target: '0x0000000000000000000000000000000000000001' };
+    a.hubRotationLastScannedBlock = 1_000;
+
+    await expect(a.pollHubRotationEvents()).resolves.toBeUndefined();
+
+    expect(provider.getLogs.calls).toHaveLength(1);
+    expect(provider.getLogs.calls[0][0]).toMatchObject({
+      fromBlock: 850,
+      toBlock: 900,
+    });
+    expect(a.hubRotationLastScannedBlock).toBe(900);
   });
 
   it('invalidateRandomSamplingPair drops both the cache AND the side-channel contract handles (Codex N15)', () => {

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -1158,6 +1158,34 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     }
   });
 
+  it('startHubRotationListener refuses partial Hub rotation event ABI', async () => {
+    const a: any = new EVMChainAdapter(minimalConfig());
+    const iface = new ethers.Interface([
+      'event NewContract(string contractName, address newContractAddress)',
+      'event ContractChanged(string contractName, address newContractAddress)',
+      'event NewAssetStorage(string contractName, address newContractAddress)',
+    ]);
+    const provider = {
+      getBlockNumber: recorder(async () => 1_000),
+      getLogs: recorder(async () => []),
+    };
+    a.providers = [provider];
+    a.rpcUrls = ['https://primary.example'];
+    a.primaryProvider = provider;
+    a.provider = provider;
+    a.contracts.hub = {
+      interface: iface,
+      getAddress: async () => '0x0000000000000000000000000000000000000001',
+    };
+    a.hubRotationListenerStarted = false;
+
+    await expect(a.startHubRotationListener()).resolves.toBeUndefined();
+
+    expect(provider.getBlockNumber.calls).toEqual([]);
+    expect(provider.getLogs.calls).toEqual([]);
+    expect(a.hubRotationListenerStarted).toBe(false);
+  });
+
   it('startHubRotationListener skips optional poller setup when primary static validation fails but backup reads still work', async () => {
     const a: any = new EVMChainAdapter(minimalConfig({
       rpcUrl: 'https://primary.example',

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -1415,6 +1415,67 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     expect(a.initialized).toBe(false);
   });
 
+  it('HubRotationPoller processes a new rotation log at the previous cursor block', async () => {
+    const a: any = new EVMChainAdapter(minimalConfig());
+    const iface = new ethers.Interface([
+      'event NewContract(string contractName, address newContractAddress)',
+      'event ContractChanged(string contractName, address newContractAddress)',
+      'event NewAssetStorage(string contractName, address newContractAddress)',
+      'event AssetStorageChanged(string contractName, address newContractAddress)',
+    ]);
+    const rotation = iface.encodeEventLog(iface.getEvent('ContractChanged')!, [
+      'ContextGraphs',
+      '0x00000000000000000000000000000000000000c1',
+    ]);
+    let head = 1_000;
+    let exposeReorgLog = false;
+    const provider = {
+      getBlockNumber: recorder(async () => head),
+      getLogs: recorder(async (filter: any) => {
+        const log = {
+          blockNumber: 1_000,
+          blockHash: '0x' + '40'.repeat(32),
+          transactionHash: '0x' + '41'.repeat(32),
+          index: 0,
+          topics: rotation.topics,
+          data: rotation.data,
+        };
+        return exposeReorgLog && log.blockNumber >= filter.fromBlock && log.blockNumber <= filter.toBlock
+          ? [log]
+          : [];
+      }),
+      destroy: recorder(() => undefined),
+    };
+    a.providers = [provider];
+    a.rpcUrls = ['https://primary.example'];
+    a.primaryProvider = provider;
+    a.provider = provider;
+    a.contracts.hub = {
+      interface: iface,
+      getAddress: async () => '0x0000000000000000000000000000000000000001',
+    };
+    a.contracts.contextGraphs = { fresh: true };
+    a.cachedKav10Address = { value: '0x00000000000000000000000000000000000000aa', cachedAt: 1 };
+    a.initialized = true;
+
+    await expect(a.startHubRotationListener()).resolves.toBeUndefined();
+    expect(a.cachedKav10Address).toBeDefined();
+
+    exposeReorgLog = true;
+    head = 1_001;
+    await expect(a.hubRotationPoller.pollOnce()).resolves.toBeUndefined();
+    a.destroy();
+
+    expect(provider.getLogs.calls).toHaveLength(2);
+    expect(provider.getLogs.calls[1][0]).toMatchObject({
+      fromBlock: 951,
+      toBlock: 1_001,
+    });
+    expect(a.contracts.contextGraphs).toEqual({ fresh: true });
+    expect(a.cachedKav10Address).toBeUndefined();
+    expect(a.initialized).toBe(false);
+  });
+
   it('destroy clears the Hub rotation poll interval', async () => {
     vi.useFakeTimers({ now: 0 });
     const a: any = new EVMChainAdapter(minimalConfig());

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -1142,7 +1142,7 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     }
   });
 
-  it('startHubRotationListener skips optional listener setup when primary static validation fails but backup reads still work', async () => {
+  it('startHubRotationListener skips optional poller setup when primary static validation fails but backup reads still work', async () => {
     const a: any = new EVMChainAdapter(minimalConfig({
       rpcUrl: 'https://primary.example',
       rpcUrls: ['https://backup.example'],
@@ -1164,7 +1164,7 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
       getBlockNumber: recorder(async () => 123),
     };
     const on = recorder(async () => {
-      throw new Error('listener subscription should be skipped');
+      throw new Error('poller setup should be skipped');
     });
 
     a.primaryProvider = primaryProvider;
@@ -1184,7 +1184,7 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     expect(backupProvider.getBlockNumber.calls).toEqual([[]]);
   });
 
-  it('pollHubRotationEvents scans Hub rotation topics without ethers subscriptions', async () => {
+  it('HubRotationPoller pollOnce scans Hub rotation topics without ethers subscriptions', async () => {
     const a: any = new EVMChainAdapter(minimalConfig());
     const iface = new ethers.Interface([
       'event NewContract(string contractName, address newContractAddress)',
@@ -1196,13 +1196,18 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
       'ContextGraphs',
       '0x00000000000000000000000000000000000000c1',
     ]);
+    let head = 1_000;
+    let includeRotationLog = false;
     const provider = {
-      getBlockNumber: recorder(async () => 1_000),
-      getLogs: recorder(async (_filter: any) => [{
-        blockNumber: 1_000,
+      getBlockNumber: recorder(async () => head),
+      getLogs: recorder(async (_filter: any) => includeRotationLog ? [{
+        blockNumber: 1_001,
+        blockHash: '0x' + '30'.repeat(32),
+        transactionHash: '0x' + '31'.repeat(32),
+        index: 0,
         topics: changed.topics,
         data: changed.data,
-      }]),
+      }] : []),
       destroy: recorder(() => undefined),
     };
     const on = recorder(async () => {
@@ -1222,17 +1227,20 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     a.hubRotationListenerStarted = false;
     a.initialized = true;
 
-    await expect(a.pollHubRotationEvents()).resolves.toBeUndefined();
+    await expect(a.startHubRotationListener()).resolves.toBeUndefined();
+    includeRotationLog = true;
+    head = 1_001;
+    await expect(a.hubRotationPoller.pollOnce()).resolves.toBeUndefined();
     a.destroy();
 
     expect(on.calls).toEqual([]);
-    expect(provider.getLogs.calls).toHaveLength(1);
-    expect(provider.getLogs.calls[0][0]).toMatchObject({
+    expect(provider.getLogs.calls).toHaveLength(2);
+    expect(provider.getLogs.calls[1][0]).toMatchObject({
       address: '0x0000000000000000000000000000000000000001',
-      fromBlock: 950,
-      toBlock: 1_000,
+      fromBlock: 951,
+      toBlock: 1_001,
     });
-    expect(provider.getLogs.calls[0][0].topics[0]).toEqual([
+    expect(provider.getLogs.calls[1][0].topics[0]).toEqual([
       iface.getEvent('ContractChanged')!.topicHash,
       iface.getEvent('NewContract')!.topicHash,
       iface.getEvent('AssetStorageChanged')!.topicHash,
@@ -1262,12 +1270,28 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
       '0x00000000000000000000000000000000000000c1',
     ]);
     let head = 1_000;
+    const historicalLogs = [
+      {
+        blockNumber: 1_000,
+        blockHash: '0x' + '10'.repeat(32),
+        transactionHash: '0x' + '11'.repeat(32),
+        index: 0,
+        topics: oldRandomSampling.topics,
+        data: oldRandomSampling.data,
+      },
+      {
+        blockNumber: 1_001,
+        blockHash: '0x' + '12'.repeat(32),
+        transactionHash: '0x' + '13'.repeat(32),
+        index: 0,
+        topics: changed.topics,
+        data: changed.data,
+      },
+    ];
     const provider = {
       getBlockNumber: recorder(async () => head),
-      getLogs: recorder(async (_filter: any) => [
-        { blockNumber: 1_000, topics: oldRandomSampling.topics, data: oldRandomSampling.data },
-        { blockNumber: 1_001, topics: changed.topics, data: changed.data },
-      ]),
+      getLogs: recorder(async (filter: any) =>
+        historicalLogs.filter((log) => log.blockNumber >= filter.fromBlock && log.blockNumber <= filter.toBlock)),
       destroy: recorder(() => undefined),
     };
     const on = recorder(async () => {
@@ -1293,7 +1317,11 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
       await expect(a.startHubRotationListener()).resolves.toBeUndefined();
       expect(on.calls).toEqual([]);
       expect(provider.getBlockNumber.calls).toHaveLength(1);
-      expect(provider.getLogs.calls).toHaveLength(0);
+      expect(provider.getLogs.calls).toHaveLength(1);
+      expect(provider.getLogs.calls[0][0]).toMatchObject({
+        fromBlock: 950,
+        toBlock: 1_000,
+      });
       expect(a.contracts.contextGraphs).toEqual({ fresh: true });
       expect(a.contracts.randomSampling).toEqual({ fresh: 'rs' });
       expect(a.initialized).toBe(true);
@@ -1301,8 +1329,8 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
       head = 1_001;
       await vi.advanceTimersByTimeAsync(5 * 60_000);
 
-      expect(provider.getLogs.calls).toHaveLength(1);
-      expect(provider.getLogs.calls[0][0]).toMatchObject({
+      expect(provider.getLogs.calls).toHaveLength(2);
+      expect(provider.getLogs.calls[1][0]).toMatchObject({
         fromBlock: 951,
         toBlock: 1_001,
       });
@@ -1314,6 +1342,77 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
       a.destroy();
       vi.useRealTimers();
     }
+  });
+
+  it('HubRotationPoller applies replacement logs inside the reorg buffer', async () => {
+    const a: any = new EVMChainAdapter(minimalConfig());
+    const iface = new ethers.Interface([
+      'event NewContract(string contractName, address newContractAddress)',
+      'event ContractChanged(string contractName, address newContractAddress)',
+      'event NewAssetStorage(string contractName, address newContractAddress)',
+      'event AssetStorageChanged(string contractName, address newContractAddress)',
+    ]);
+    const oldRotation = iface.encodeEventLog(iface.getEvent('ContractChanged')!, [
+      'UntrackedAtStartup',
+      '0x00000000000000000000000000000000000000b1',
+    ]);
+    const replacement = iface.encodeEventLog(iface.getEvent('ContractChanged')!, [
+      'ContextGraphs',
+      '0x00000000000000000000000000000000000000c1',
+    ]);
+    let head = 1_000;
+    const logs = [
+      {
+        blockNumber: 1_000,
+        blockHash: '0x' + '20'.repeat(32),
+        transactionHash: '0x' + '21'.repeat(32),
+        index: 0,
+        topics: oldRotation.topics,
+        data: oldRotation.data,
+      },
+    ];
+    const provider = {
+      getBlockNumber: recorder(async () => head),
+      getLogs: recorder(async (filter: any) =>
+        logs.filter((log) => log.blockNumber >= filter.fromBlock && log.blockNumber <= filter.toBlock)),
+      destroy: recorder(() => undefined),
+    };
+    a.providers = [provider];
+    a.rpcUrls = ['https://primary.example'];
+    a.primaryProvider = provider;
+    a.provider = provider;
+    a.contracts.hub = {
+      interface: iface,
+      getAddress: async () => '0x0000000000000000000000000000000000000001',
+    };
+    a.contracts.contextGraphs = { fresh: true };
+    a.cachedKav10Address = { value: '0x00000000000000000000000000000000000000aa', cachedAt: 1 };
+    a.initialized = true;
+
+    await expect(a.startHubRotationListener()).resolves.toBeUndefined();
+    expect(a.cachedKav10Address).toBeDefined();
+    expect(a.initialized).toBe(true);
+
+    logs.splice(0, logs.length, {
+      blockNumber: 1_000,
+      blockHash: '0x' + '22'.repeat(32),
+      transactionHash: '0x' + '23'.repeat(32),
+      index: 0,
+      topics: replacement.topics,
+      data: replacement.data,
+    });
+    head = 1_001;
+    await expect(a.hubRotationPoller.pollOnce()).resolves.toBeUndefined();
+    a.destroy();
+
+    expect(provider.getLogs.calls).toHaveLength(2);
+    expect(provider.getLogs.calls[1][0]).toMatchObject({
+      fromBlock: 951,
+      toBlock: 1_001,
+    });
+    expect(a.contracts.contextGraphs).toEqual({ fresh: true });
+    expect(a.cachedKav10Address).toBeUndefined();
+    expect(a.initialized).toBe(false);
   });
 
   it('destroy clears the Hub rotation poll interval', async () => {
@@ -1343,13 +1442,13 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     try {
       await expect(a.startHubRotationListener()).resolves.toBeUndefined();
       expect(provider.getBlockNumber.calls).toHaveLength(1);
-      expect(provider.getLogs.calls).toHaveLength(0);
+      expect(provider.getLogs.calls).toHaveLength(1);
 
       a.destroy();
       await vi.advanceTimersByTimeAsync(5 * 60_000);
 
       expect(provider.getBlockNumber.calls).toHaveLength(1);
-      expect(provider.getLogs.calls).toHaveLength(0);
+      expect(provider.getLogs.calls).toHaveLength(1);
       expect(provider.destroy.calls).toHaveLength(1);
       expect(a.hubRotationListenerStarted).toBe(false);
     } finally {
@@ -1358,7 +1457,7 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     }
   });
 
-  it('pollHubRotationEvents clamps the range when failover observes a lower head', async () => {
+  it('HubRotationPoller pollOnce clamps the range when failover observes a lower head', async () => {
     const a: any = new EVMChainAdapter(minimalConfig());
     const iface = new ethers.Interface([
       'event NewContract(string contractName, address newContractAddress)',
@@ -1366,8 +1465,9 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
       'event NewAssetStorage(string contractName, address newContractAddress)',
       'event AssetStorageChanged(string contractName, address newContractAddress)',
     ]);
+    let head = 1_000;
     const provider = {
-      getBlockNumber: recorder(async () => 900),
+      getBlockNumber: recorder(async () => head),
       getLogs: recorder(async (_filter: any) => []),
       destroy: recorder(() => undefined),
     };
@@ -1379,12 +1479,14 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
       interface: iface,
       getAddress: async () => '0x0000000000000000000000000000000000000001',
     };
-    a.hubRotationPoller.lastScannedBlock = 1_000;
+    await expect(a.startHubRotationListener()).resolves.toBeUndefined();
+    head = 900;
 
-    await expect(a.pollHubRotationEvents()).resolves.toBeUndefined();
+    await expect(a.hubRotationPoller.pollOnce()).resolves.toBeUndefined();
+    a.destroy();
 
-    expect(provider.getLogs.calls).toHaveLength(1);
-    expect(provider.getLogs.calls[0][0]).toMatchObject({
+    expect(provider.getLogs.calls).toHaveLength(2);
+    expect(provider.getLogs.calls[1][0]).toMatchObject({
       fromBlock: 850,
       toBlock: 900,
     });

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -1184,7 +1184,7 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     expect(backupProvider.getBlockNumber.calls).toEqual([[]]);
   });
 
-  it('startHubRotationListener polls Hub rotation topics without ethers subscriptions', async () => {
+  it('pollHubRotationEvents scans Hub rotation topics without ethers subscriptions', async () => {
     const a: any = new EVMChainAdapter(minimalConfig());
     const iface = new ethers.Interface([
       'event NewContract(string contractName, address newContractAddress)',
@@ -1199,6 +1199,7 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     const provider = {
       getBlockNumber: recorder(async () => 1_000),
       getLogs: recorder(async (_filter: any) => [{
+        blockNumber: 1_000,
         topics: changed.topics,
         data: changed.data,
       }]),
@@ -1217,7 +1218,7 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     a.hubRotationListenerStarted = false;
     a.initialized = true;
 
-    await expect(a.startHubRotationListener()).resolves.toBeUndefined();
+    await expect(a.pollHubRotationEvents()).resolves.toBeUndefined();
     a.destroy();
 
     expect(on.calls).toEqual([]);
@@ -1239,7 +1240,7 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     expect(a.hubRotationListenerStarted).toBe(false);
   });
 
-  it('startHubRotationListener processes Hub rotations from the recurring poll timer', async () => {
+  it('startHubRotationListener ignores replayed startup logs and processes post-start timer rotations', async () => {
     vi.useFakeTimers({ now: 0 });
     const a: any = new EVMChainAdapter(minimalConfig());
     const iface = new ethers.Interface([
@@ -1248,19 +1249,21 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
       'event NewAssetStorage(string contractName, address newContractAddress)',
       'event AssetStorageChanged(string contractName, address newContractAddress)',
     ]);
+    const oldRandomSampling = iface.encodeEventLog(iface.getEvent('NewContract')!, [
+      'RandomSampling',
+      '0x00000000000000000000000000000000000000b1',
+    ]);
     const changed = iface.encodeEventLog(iface.getEvent('NewContract')!, [
       'ContextGraphs',
       '0x00000000000000000000000000000000000000c1',
     ]);
-    let poll = 0;
+    let head = 1_000;
     const provider = {
-      getBlockNumber: recorder(async () => 1_000 + poll),
-      getLogs: recorder(async (_filter: any) => {
-        poll++;
-        return poll === 1
-          ? []
-          : [{ topics: changed.topics, data: changed.data }];
-      }),
+      getBlockNumber: recorder(async () => head),
+      getLogs: recorder(async (_filter: any) => [
+        { blockNumber: 1_000, topics: oldRandomSampling.topics, data: oldRandomSampling.data },
+        { blockNumber: 1_001, topics: changed.topics, data: changed.data },
+      ]),
       destroy: recorder(() => undefined),
     };
     const on = recorder(async () => {
@@ -1271,6 +1274,9 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     a.primaryProvider = provider;
     a.provider = provider;
     a.contracts.hub = { interface: iface, target: '0x0000000000000000000000000000000000000001', on };
+    a.contracts.contextGraphs = { fresh: true };
+    a.contracts.randomSampling = { fresh: 'rs' };
+    a.contracts.randomSamplingStorage = { fresh: 'rss' };
     a.cachedKav10Address = { value: '0x00000000000000000000000000000000000000aa', cachedAt: 1 };
     a.hubRotationListenerStarted = false;
     a.initialized = true;
@@ -1278,14 +1284,63 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     try {
       await expect(a.startHubRotationListener()).resolves.toBeUndefined();
       expect(on.calls).toEqual([]);
-      expect(provider.getLogs.calls).toHaveLength(1);
+      expect(provider.getBlockNumber.calls).toHaveLength(1);
+      expect(provider.getLogs.calls).toHaveLength(0);
+      expect(a.contracts.contextGraphs).toEqual({ fresh: true });
+      expect(a.contracts.randomSampling).toEqual({ fresh: 'rs' });
       expect(a.initialized).toBe(true);
 
+      head = 1_001;
       await vi.advanceTimersByTimeAsync(5 * 60_000);
 
-      expect(provider.getLogs.calls).toHaveLength(2);
+      expect(provider.getLogs.calls).toHaveLength(1);
+      expect(provider.getLogs.calls[0][0]).toMatchObject({
+        fromBlock: 951,
+        toBlock: 1_001,
+      });
+      expect(a.contracts.contextGraphs).toEqual({ fresh: true });
+      expect(a.contracts.randomSampling).toEqual({ fresh: 'rs' });
       expect(a.cachedKav10Address).toBeUndefined();
       expect(a.initialized).toBe(false);
+    } finally {
+      a.destroy();
+      vi.useRealTimers();
+    }
+  });
+
+  it('destroy clears the Hub rotation poll interval', async () => {
+    vi.useFakeTimers({ now: 0 });
+    const a: any = new EVMChainAdapter(minimalConfig());
+    const iface = new ethers.Interface([
+      'event NewContract(string contractName, address newContractAddress)',
+      'event ContractChanged(string contractName, address newContractAddress)',
+      'event NewAssetStorage(string contractName, address newContractAddress)',
+      'event AssetStorageChanged(string contractName, address newContractAddress)',
+    ]);
+    const provider = {
+      getBlockNumber: recorder(async () => 1_000),
+      getLogs: recorder(async (_filter: any) => []),
+      destroy: recorder(() => undefined),
+    };
+    a.providers = [provider];
+    a.rpcUrls = ['https://primary.example'];
+    a.primaryProvider = provider;
+    a.provider = provider;
+    a.contracts.hub = { interface: iface, target: '0x0000000000000000000000000000000000000001' };
+    a.hubRotationListenerStarted = false;
+
+    try {
+      await expect(a.startHubRotationListener()).resolves.toBeUndefined();
+      expect(provider.getBlockNumber.calls).toHaveLength(1);
+      expect(provider.getLogs.calls).toHaveLength(0);
+
+      a.destroy();
+      await vi.advanceTimersByTimeAsync(5 * 60_000);
+
+      expect(provider.getBlockNumber.calls).toHaveLength(1);
+      expect(provider.getLogs.calls).toHaveLength(0);
+      expect(provider.destroy.calls).toHaveLength(1);
+      expect(a.hubRotationListenerStarted).toBe(false);
     } finally {
       a.destroy();
       vi.useRealTimers();
@@ -1319,7 +1374,7 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
       fromBlock: 850,
       toBlock: 900,
     });
-    expect(a.hubRotationPoller.lastScannedBlock).toBe(900);
+    expect(a.hubRotationPoller.lastScannedBlock).toBe(1_000);
   });
 
   it('invalidateRandomSamplingPair drops both the cache AND the side-channel contract handles (Codex N15)', () => {

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -1121,10 +1121,7 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     expect(a.chainType).toBe('evm');
   });
 
-  it('startHubRotationListener swallows optional poll setup failures without unhandled-rejection or throw', async () => {
-    // Hub rotation detection is best-effort. A mocked or unsupported Hub poll
-    // surface must not bubble as an unhandled rejection, and the listener-started
-    // flag must not flip if setup failed so a future retry remains possible.
+  it('startHubRotationListener validates Hub binding without touching RPC logs', async () => {
     const a: any = new EVMChainAdapter(minimalConfig());
     const iface = new ethers.Interface([
       'event NewContract(string contractName, address newContractAddress)',
@@ -1133,9 +1130,11 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
       'event AssetStorageChanged(string contractName, address newContractAddress)',
     ]);
     const provider = {
-      getBlockNumber: recorder(async () => 1_000),
+      getBlockNumber: recorder(async () => {
+        throw new Error('startup should not read block number');
+      }),
       getLogs: recorder(async () => {
-        throw new Error('eth_getLogs unsupported');
+        throw new Error('startup should not read logs');
       }),
     };
     a.providers = [provider];
@@ -1146,19 +1145,11 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
       interface: iface,
       getAddress: async () => '0x0000000000000000000000000000000000000001',
     };
-    let unhandled: unknown = null;
-    const onRejection = (reason: unknown) => { unhandled = reason; };
-    process.on('unhandledRejection', onRejection);
-    try {
-      await expect(a.startHubRotationListener()).resolves.toBeUndefined();
-      await new Promise((resolve) => setTimeout(resolve, 50));
-      expect(unhandled).toBeNull();
-      expect(provider.getBlockNumber.calls).toHaveLength(1);
-      expect(provider.getLogs.calls).toHaveLength(1);
-      expect(a.hubRotationPoller.isStarted).toBe(true);
-    } finally {
-      process.off('unhandledRejection', onRejection);
-    }
+    await expect(a.startHubRotationListener()).resolves.toBeUndefined();
+
+    expect(provider.getBlockNumber.calls).toEqual([]);
+    expect(provider.getLogs.calls).toEqual([]);
+    expect(a.hubRotationPoller.isStarted).toBe(true);
   });
 
   it('startHubRotationListener refuses partial Hub rotation event ABI', async () => {
@@ -1181,14 +1172,22 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
       getAddress: async () => '0x0000000000000000000000000000000000000001',
     };
 
-    await expect(a.startHubRotationListener()).resolves.toBeUndefined();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      await expect(a.startHubRotationListener()).resolves.toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining(
+        'Hub rotation poller setup disabled: Hub ABI is missing required rotation event AssetStorageChanged',
+      ));
+    } finally {
+      warnSpy.mockRestore();
+    }
 
     expect(provider.getBlockNumber.calls).toEqual([]);
     expect(provider.getLogs.calls).toEqual([]);
     expect(a.hubRotationPoller.isStarted).toBe(false);
   });
 
-  it('startHubRotationListener skips optional poller setup when primary static validation fails but backup reads still work', async () => {
+  it('startHubRotationListener does not consume RPC budget while backup reads still work', async () => {
     const a: any = new EVMChainAdapter(minimalConfig({
       rpcUrl: 'https://primary.example',
       rpcUrls: ['https://backup.example'],
@@ -1230,7 +1229,7 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     await expect(a.readProvider('getBlockNumber', (p: any) => p.getBlockNumber()))
       .resolves.toBe(123);
     expect(primaryProvider.getBlockNumber.calls).toEqual([]);
-    expect(backupProvider.getBlockNumber.calls).toHaveLength(2);
+    expect(backupProvider.getBlockNumber.calls).toHaveLength(1);
   });
 
   it('startHubRotationListener wires Hub rotation names into adapter invalidation without subscriptions', async () => {
@@ -1285,13 +1284,13 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
       a.destroy();
 
       expect(on.calls).toEqual([]);
-      expect(provider.getLogs.calls).toHaveLength(2);
-      expect(provider.getLogs.calls[1][0]).toMatchObject({
+      expect(provider.getLogs.calls).toHaveLength(1);
+      expect(provider.getLogs.calls[0][0]).toMatchObject({
         address: '0x0000000000000000000000000000000000000001',
         fromBlock: 951,
         toBlock: 1_001,
       });
-      expect(provider.getLogs.calls[1][0].topics[0]).toEqual([
+      expect(provider.getLogs.calls[0][0].topics[0]).toEqual([
         iface.getEvent('ContractChanged')!.topicHash,
         iface.getEvent('NewContract')!.topicHash,
         iface.getEvent('AssetStorageChanged')!.topicHash,
@@ -1333,14 +1332,14 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     try {
       await expect(a.startHubRotationListener()).resolves.toBeUndefined();
       await flushAsyncWork();
-      expect(provider.getBlockNumber.calls).toHaveLength(1);
-      expect(provider.getLogs.calls).toHaveLength(1);
+      expect(provider.getBlockNumber.calls).toHaveLength(0);
+      expect(provider.getLogs.calls).toHaveLength(0);
 
       a.destroy();
       await vi.advanceTimersByTimeAsync(30_000);
 
-      expect(provider.getBlockNumber.calls).toHaveLength(1);
-      expect(provider.getLogs.calls).toHaveLength(1);
+      expect(provider.getBlockNumber.calls).toHaveLength(0);
+      expect(provider.getLogs.calls).toHaveLength(0);
       expect(provider.destroy.calls).toHaveLength(1);
       expect(a.hubRotationPoller.isStarted).toBe(false);
     } finally {

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -1121,22 +1121,38 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     // Hub rotation detection is best-effort. A mocked or unsupported Hub poll
     // surface must not bubble as an unhandled rejection, and the listener-started
     // flag must not flip if setup failed so a future retry remains possible.
-    const a = new EVMChainAdapter(minimalConfig());
-    const fakeHub = {
-      on: async (_event: string, _cb: (...args: unknown[]) => void) => {
-        throw new Error('legacy subscription seam should not be reached');
-      },
+    const a: any = new EVMChainAdapter(minimalConfig());
+    const iface = new ethers.Interface([
+      'event NewContract(string contractName, address newContractAddress)',
+      'event ContractChanged(string contractName, address newContractAddress)',
+      'event NewAssetStorage(string contractName, address newContractAddress)',
+      'event AssetStorageChanged(string contractName, address newContractAddress)',
+    ]);
+    const provider = {
+      getBlockNumber: recorder(async () => 1_000),
+      getLogs: recorder(async () => {
+        throw new Error('eth_getLogs unsupported');
+      }),
     };
-    (a as any).contracts.hub = fakeHub;
-    (a as any).hubRotationListenerStarted = false;
+    a.providers = [provider];
+    a.rpcUrls = ['https://primary.example'];
+    a.primaryProvider = provider;
+    a.provider = provider;
+    a.contracts.hub = {
+      interface: iface,
+      getAddress: async () => '0x0000000000000000000000000000000000000001',
+    };
+    a.hubRotationListenerStarted = false;
     let unhandled: unknown = null;
     const onRejection = (reason: unknown) => { unhandled = reason; };
     process.on('unhandledRejection', onRejection);
     try {
-      await expect((a as any).startHubRotationListener()).resolves.toBeUndefined();
+      await expect(a.startHubRotationListener()).resolves.toBeUndefined();
       await new Promise((resolve) => setTimeout(resolve, 50));
       expect(unhandled).toBeNull();
-      expect((a as any).hubRotationListenerStarted).toBe(false);
+      expect(provider.getBlockNumber.calls).toHaveLength(1);
+      expect(provider.getLogs.calls).toHaveLength(1);
+      expect(a.hubRotationListenerStarted).toBe(false);
     } finally {
       process.off('unhandledRejection', onRejection);
     }
@@ -1327,7 +1343,7 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
       expect(a.initialized).toBe(true);
 
       head = 1_001;
-      await vi.advanceTimersByTimeAsync(5 * 60_000);
+      await vi.advanceTimersByTimeAsync(30_000);
 
       expect(provider.getLogs.calls).toHaveLength(2);
       expect(provider.getLogs.calls[1][0]).toMatchObject({
@@ -1506,7 +1522,7 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
       expect(provider.getLogs.calls).toHaveLength(1);
 
       a.destroy();
-      await vi.advanceTimersByTimeAsync(5 * 60_000);
+      await vi.advanceTimersByTimeAsync(30_000);
 
       expect(provider.getBlockNumber.calls).toHaveLength(1);
       expect(provider.getLogs.calls).toHaveLength(1);

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -1268,7 +1268,7 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     expect(a.hubRotationListenerStarted).toBe(false);
   });
 
-  it('startHubRotationListener ignores replayed startup logs and processes post-start timer rotations', async () => {
+  it('startHubRotationListener defers seed logs until the first post-start buffered poll', async () => {
     vi.useFakeTimers({ now: 0 });
     const a: any = new EVMChainAdapter(minimalConfig());
     const iface = new ethers.Interface([
@@ -1351,7 +1351,7 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
         toBlock: 1_001,
       });
       expect(a.contracts.contextGraphs).toEqual({ fresh: true });
-      expect(a.contracts.randomSampling).toEqual({ fresh: 'rs' });
+      expect(a.contracts.randomSampling).toBeUndefined();
       expect(a.cachedKav10Address).toBeUndefined();
       expect(a.initialized).toBe(false);
     } finally {

--- a/packages/chain/test/getmaxkanumberforauthor.unit.test.ts
+++ b/packages/chain/test/getmaxkanumberforauthor.unit.test.ts
@@ -218,7 +218,7 @@ describe('EVMChainAdapter.getMaxKaNumberForAuthor — view + bounded fallback (#
   });
 
   it('re-resolves the DKGKnowledgeAssets handle after a Hub rotation rather than querying the stale pre-rotation contract (#1082 review)', async () => {
-    // Long-lived adapter after the 10.0.4 redeploy: the rotation listener has
+    // Long-lived adapter after the 10.0.4 redeploy: the rotation poller has
     // set `initialized = false` but the cached binding still points at the OLD
     // contract. The getter must `await this.init()` to re-resolve before
     // reading, or it answers from the pre-rotation DKGKnowledgeAssets.

--- a/packages/chain/test/hub-resolution-cache.unit.test.ts
+++ b/packages/chain/test/hub-resolution-cache.unit.test.ts
@@ -3,7 +3,7 @@
  * matter for the live-rotation bug:
  *   - first call resolves and caches,
  *   - TTL expiry forces a re-resolve,
- *   - explicit `invalidate()` (used by the Hub event listener and the
+ *   - explicit `invalidate()` (used by the Hub rotation poller and the
  *     `UnauthorizedAccess(Only Contracts in Hub)` self-invalidation
  *     in the EVM adapter) forces a re-resolve.
  *
@@ -139,7 +139,7 @@ describe('HubResolutionCache', () => {
   it('invalidate() during an in-flight resolve discards the result so it cannot write back the stale value', async () => {
     // Simulates the race the Codex review flagged:
     //   1. tick T0 calls get() — resolver starts, awaiting RPC
-    //   2. Hub rotates RandomSampling; listener calls invalidate()
+    //   2. Hub rotates RandomSampling; poller calls invalidate()
     //   3. tick T0's resolver finally returns the PRE-rotation address
     //   4. without the generation guard, that pre-rotation value
     //      would land in `cached` and the very next get() would
@@ -160,7 +160,7 @@ describe('HubResolutionCache', () => {
     expect(calls).toBe(1);
     expect(cache.peek()).toBeNull();
 
-    // Hub-event-listener equivalent fires while the first resolve is
+    // Hub-rotation-poller equivalent fires while the first resolve is
     // still suspended.
     cache.invalidate();
     expect(cache.peek()).toBeNull();

--- a/packages/chain/test/hub-rotation-poller.unit.test.ts
+++ b/packages/chain/test/hub-rotation-poller.unit.test.ts
@@ -1,0 +1,420 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Contract, ethers } from 'ethers';
+import { HubRotationPoller } from '../src/hub-rotation-poller.js';
+
+const HUB_ADDRESS = '0x0000000000000000000000000000000000000001';
+
+const ROTATION_EVENTS = [
+  'event NewContract(string contractName, address newContractAddress)',
+  'event ContractChanged(string contractName, address newContractAddress)',
+  'event NewAssetStorage(string contractName, address newContractAddress)',
+  'event AssetStorageChanged(string contractName, address newContractAddress)',
+];
+
+function hubInterface(events = ROTATION_EVENTS): ethers.Interface {
+  return new ethers.Interface(events);
+}
+
+function hubContract(iface = hubInterface()): Contract {
+  return { interface: iface } as unknown as Contract;
+}
+
+function rotationLog(
+  iface: ethers.Interface,
+  eventName: string,
+  contractName: string,
+  blockNumber: number,
+  marker: string,
+  index = 0,
+): ethers.Log {
+  const encoded = iface.encodeEventLog(iface.getEvent(eventName)!, [
+    contractName,
+    '0x00000000000000000000000000000000000000c1',
+  ]);
+  return {
+    blockNumber,
+    blockHash: `0x${marker.repeat(32)}`,
+    transactionHash: `0x${(Number.parseInt(marker, 16) + 1).toString(16).padStart(2, '0').repeat(32)}`,
+    index,
+    topics: encoded.topics,
+    data: encoded.data,
+  } as ethers.Log;
+}
+
+function logsInRange(logs: ethers.Log[], filter: { fromBlock: number; toBlock: number }): ethers.Log[] {
+  return logs.filter((log) => log.blockNumber >= filter.fromBlock && log.blockNumber <= filter.toBlock);
+}
+
+async function flushAsyncWork(turns = 8): Promise<void> {
+  for (let i = 0; i < turns; i++) await Promise.resolve();
+}
+
+describe('HubRotationPoller', () => {
+  it('does not block startup on bootstrap log IO and stop cancels the late bootstrap', async () => {
+    vi.useFakeTimers({ now: 0 });
+    let releaseSeed!: () => void;
+    let seedEntered!: () => void;
+    const seedGate = new Promise<void>((resolve) => { releaseSeed = resolve; });
+    const seedEnteredPromise = new Promise<void>((resolve) => { seedEntered = resolve; });
+    const provider = {
+      getBlockNumber: vi.fn(async () => 1_000),
+      getLogs: vi.fn(async () => {
+        seedEntered();
+        await seedGate;
+        return [];
+      }),
+    };
+    const poller = new HubRotationPoller({
+      readProvider: async (_label, fn) => fn(provider as any),
+      intervalMs: 30_000,
+      reorgBufferBlocks: 50,
+      onContractName: vi.fn(),
+    });
+
+    try {
+      await expect(poller.start(hubContract(), HUB_ADDRESS)).resolves.toBeUndefined();
+      expect(poller.isStarted).toBe(true);
+
+      await seedEnteredPromise;
+      poller.stop();
+      releaseSeed();
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      expect(provider.getBlockNumber).toHaveBeenCalledTimes(1);
+      expect(provider.getLogs).toHaveBeenCalledTimes(1);
+      expect(poller.isStarted).toBe(false);
+    } finally {
+      poller.stop();
+      vi.useRealTimers();
+    }
+  });
+
+  it('recovers after a failed periodic poll', async () => {
+    vi.useFakeTimers({ now: 0 });
+    const hub = hubContract();
+    const rotation = hub.interface.encodeEventLog(hub.interface.getEvent('ContractChanged')!, [
+      'ContextGraphs',
+      '0x00000000000000000000000000000000000000c1',
+    ]);
+    let head = 1_000;
+    let getLogsCalls = 0;
+    const provider = {
+      getBlockNumber: vi.fn(async () => head),
+      getLogs: vi.fn(async () => {
+        getLogsCalls++;
+        if (getLogsCalls === 2) throw new Error('temporary getLogs failure');
+        if (getLogsCalls === 3) {
+          return [{
+            blockNumber: 1_001,
+            blockHash: '0x' + '51'.repeat(32),
+            transactionHash: '0x' + '52'.repeat(32),
+            index: 0,
+            topics: rotation.topics,
+            data: rotation.data,
+          }];
+        }
+        return [];
+      }),
+    };
+    const onContractName = vi.fn();
+    const poller = new HubRotationPoller({
+      readProvider: async (_label, fn) => fn(provider as any),
+      intervalMs: 30_000,
+      reorgBufferBlocks: 50,
+      onContractName,
+    });
+
+    try {
+      await poller.start(hub, HUB_ADDRESS);
+      await Promise.resolve();
+
+      head = 1_001;
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(onContractName).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(onContractName).toHaveBeenCalledWith('ContextGraphs');
+      expect(provider.getLogs).toHaveBeenCalledTimes(3);
+    } finally {
+      poller.stop();
+      vi.useRealTimers();
+    }
+  });
+
+  it('coalesces concurrent starts while bootstrap is still in flight', async () => {
+    vi.useFakeTimers({ now: 0 });
+    let releaseSeed!: () => void;
+    let seedEntered!: () => void;
+    const seedGate = new Promise<void>((resolve) => { releaseSeed = resolve; });
+    const seedEnteredPromise = new Promise<void>((resolve) => { seedEntered = resolve; });
+    let getLogsCalls = 0;
+    const provider = {
+      getBlockNumber: vi.fn(async () => 1_000),
+      getLogs: vi.fn(async () => {
+        getLogsCalls++;
+        if (getLogsCalls === 1) {
+          seedEntered();
+          await seedGate;
+        }
+        return [];
+      }),
+    };
+    const poller = new HubRotationPoller({
+      readProvider: async (_label, fn) => fn(provider as any),
+      intervalMs: 30_000,
+      reorgBufferBlocks: 50,
+      onContractName: vi.fn(),
+    });
+
+    try {
+      const firstStart = poller.start(hubContract(), HUB_ADDRESS);
+      await seedEnteredPromise;
+      const secondStart = poller.start(hubContract(), HUB_ADDRESS);
+
+      releaseSeed();
+      await Promise.all([firstStart, secondStart]);
+      await flushAsyncWork();
+
+      expect(provider.getBlockNumber).toHaveBeenCalledTimes(1);
+      expect(provider.getLogs).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(provider.getBlockNumber).toHaveBeenCalledTimes(2);
+      expect(provider.getLogs).toHaveBeenCalledTimes(2);
+    } finally {
+      poller.stop();
+      vi.useRealTimers();
+    }
+  });
+
+  it('probes startup logs without dispatching and dispatches the first buffered poll', async () => {
+    vi.useFakeTimers({ now: 0 });
+    const iface = hubInterface();
+    let head = 1_000;
+    const logs = [
+      rotationLog(iface, 'NewContract', 'RandomSampling', 1_000, '10'),
+      rotationLog(iface, 'ContractChanged', 'ContextGraphs', 1_001, '12'),
+    ];
+    const provider = {
+      getBlockNumber: vi.fn(async () => head),
+      getLogs: vi.fn(async (filter: any) => logsInRange(logs, filter)),
+    };
+    const onContractName = vi.fn();
+    const poller = new HubRotationPoller({
+      readProvider: async (_label, fn) => fn(provider as any),
+      intervalMs: 30_000,
+      reorgBufferBlocks: 50,
+      onContractName,
+    });
+
+    try {
+      await poller.start(hubContract(iface), HUB_ADDRESS);
+      await flushAsyncWork();
+
+      expect(onContractName).not.toHaveBeenCalled();
+      expect(provider.getLogs.mock.calls[0][0]).toMatchObject({
+        address: HUB_ADDRESS,
+        fromBlock: 950,
+        toBlock: 1_000,
+      });
+      expect(provider.getLogs.mock.calls[0][0].topics[0]).toEqual([
+        iface.getEvent('ContractChanged')!.topicHash,
+        iface.getEvent('NewContract')!.topicHash,
+        iface.getEvent('AssetStorageChanged')!.topicHash,
+        iface.getEvent('NewAssetStorage')!.topicHash,
+      ]);
+
+      head = 1_001;
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      expect(provider.getLogs).toHaveBeenCalledTimes(2);
+      expect(provider.getLogs.mock.calls[1][0]).toMatchObject({
+        fromBlock: 951,
+        toBlock: 1_001,
+      });
+      expect(onContractName.mock.calls.map((call) => call[0])).toEqual([
+        'RandomSampling',
+        'ContextGraphs',
+      ]);
+    } finally {
+      poller.stop();
+      vi.useRealTimers();
+    }
+  });
+
+  it('applies replacement logs inside the reorg buffer', async () => {
+    const iface = hubInterface();
+    let head = 1_000;
+    const logs = [
+      rotationLog(iface, 'ContractChanged', 'UntrackedAtStartup', 1_000, '20'),
+    ];
+    const provider = {
+      getBlockNumber: vi.fn(async () => head),
+      getLogs: vi.fn(async (filter: any) => logsInRange(logs, filter)),
+    };
+    const onContractName = vi.fn();
+    const poller = new HubRotationPoller({
+      readProvider: async (_label, fn) => fn(provider as any),
+      intervalMs: 30_000,
+      reorgBufferBlocks: 50,
+      onContractName,
+    });
+
+    try {
+      await poller.start(hubContract(iface), HUB_ADDRESS);
+      await flushAsyncWork();
+      expect(onContractName).not.toHaveBeenCalled();
+
+      logs.splice(0, logs.length, rotationLog(iface, 'ContractChanged', 'ContextGraphs', 1_000, '22'));
+      head = 1_001;
+      await poller.pollOnce();
+
+      expect(provider.getLogs).toHaveBeenCalledTimes(2);
+      expect(provider.getLogs.mock.calls[1][0]).toMatchObject({
+        fromBlock: 951,
+        toBlock: 1_001,
+      });
+      expect(onContractName).toHaveBeenCalledTimes(1);
+      expect(onContractName).toHaveBeenCalledWith('ContextGraphs');
+    } finally {
+      poller.stop();
+    }
+  });
+
+  it('processes a new rotation log at the previous cursor block', async () => {
+    const iface = hubInterface();
+    let head = 1_000;
+    let exposeReorgLog = false;
+    const log = rotationLog(iface, 'ContractChanged', 'ContextGraphs', 1_000, '40');
+    const provider = {
+      getBlockNumber: vi.fn(async () => head),
+      getLogs: vi.fn(async (filter: any) => (
+        exposeReorgLog ? logsInRange([log], filter) : []
+      )),
+    };
+    const onContractName = vi.fn();
+    const poller = new HubRotationPoller({
+      readProvider: async (_label, fn) => fn(provider as any),
+      intervalMs: 30_000,
+      reorgBufferBlocks: 50,
+      onContractName,
+    });
+
+    try {
+      await poller.start(hubContract(iface), HUB_ADDRESS);
+      await flushAsyncWork();
+
+      exposeReorgLog = true;
+      head = 1_001;
+      await poller.pollOnce();
+
+      expect(provider.getLogs).toHaveBeenCalledTimes(2);
+      expect(provider.getLogs.mock.calls[1][0]).toMatchObject({
+        fromBlock: 951,
+        toBlock: 1_001,
+      });
+      expect(onContractName).toHaveBeenCalledWith('ContextGraphs');
+    } finally {
+      poller.stop();
+    }
+  });
+
+  it('deduplicates logs across overlapping buffered polls', async () => {
+    const iface = hubInterface();
+    let head = 1_000;
+    let logs: ethers.Log[] = [];
+    const repeatedLog = rotationLog(iface, 'ContractChanged', 'ContextGraphs', 1_001, '60');
+    const provider = {
+      getBlockNumber: vi.fn(async () => head),
+      getLogs: vi.fn(async (filter: any) => logsInRange(logs, filter)),
+    };
+    const onContractName = vi.fn();
+    const poller = new HubRotationPoller({
+      readProvider: async (_label, fn) => fn(provider as any),
+      intervalMs: 30_000,
+      reorgBufferBlocks: 50,
+      onContractName,
+    });
+
+    try {
+      await poller.start(hubContract(iface), HUB_ADDRESS);
+      await flushAsyncWork();
+
+      logs = [repeatedLog];
+      head = 1_001;
+      await poller.pollOnce();
+
+      head = 1_002;
+      await poller.pollOnce();
+
+      expect(onContractName).toHaveBeenCalledTimes(1);
+      expect(onContractName).toHaveBeenCalledWith('ContextGraphs');
+    } finally {
+      poller.stop();
+    }
+  });
+
+  it('does not move the high-water mark backwards when the next head is lower', async () => {
+    const iface = hubInterface();
+    let head = 1_000;
+    const provider = {
+      getBlockNumber: vi.fn(async () => head),
+      getLogs: vi.fn(async (_filter: any) => []),
+    };
+    const poller = new HubRotationPoller({
+      readProvider: async (_label, fn) => fn(provider as any),
+      intervalMs: 30_000,
+      reorgBufferBlocks: 50,
+      onContractName: vi.fn(),
+    });
+
+    try {
+      await poller.start(hubContract(iface), HUB_ADDRESS);
+      await flushAsyncWork();
+
+      head = 900;
+      await poller.pollOnce();
+
+      head = 1_001;
+      await poller.pollOnce();
+
+      expect(provider.getLogs).toHaveBeenCalledTimes(3);
+      expect(provider.getLogs.mock.calls[1][0]).toMatchObject({
+        fromBlock: 850,
+        toBlock: 900,
+      });
+      expect(provider.getLogs.mock.calls[2][0]).toMatchObject({
+        fromBlock: 951,
+        toBlock: 1_001,
+      });
+    } finally {
+      poller.stop();
+    }
+  });
+
+  it('refuses a partial Hub rotation event ABI before scheduling reads', async () => {
+    const iface = hubInterface([
+      'event NewContract(string contractName, address newContractAddress)',
+      'event ContractChanged(string contractName, address newContractAddress)',
+      'event NewAssetStorage(string contractName, address newContractAddress)',
+    ]);
+    const provider = {
+      getBlockNumber: vi.fn(async () => 1_000),
+      getLogs: vi.fn(async () => []),
+    };
+    const poller = new HubRotationPoller({
+      readProvider: async (_label, fn) => fn(provider as any),
+      intervalMs: 30_000,
+      reorgBufferBlocks: 50,
+      onContractName: vi.fn(),
+    });
+
+    await expect(poller.start(hubContract(iface), HUB_ADDRESS))
+      .rejects.toThrow('Hub ABI is missing required rotation event AssetStorageChanged');
+
+    expect(provider.getBlockNumber).not.toHaveBeenCalled();
+    expect(provider.getLogs).not.toHaveBeenCalled();
+    expect(poller.isStarted).toBe(false);
+  });
+});

--- a/packages/chain/test/hub-rotation-poller.unit.test.ts
+++ b/packages/chain/test/hub-rotation-poller.unit.test.ts
@@ -50,43 +50,77 @@ async function flushAsyncWork(turns = 8): Promise<void> {
 }
 
 describe('HubRotationPoller', () => {
-  it('does not block startup on bootstrap log IO and stop cancels the late bootstrap', async () => {
+  it('does not touch RPC during startup and stop cancels the scheduled poll', async () => {
     vi.useFakeTimers({ now: 0 });
-    let releaseSeed!: () => void;
-    let seedEntered!: () => void;
-    const seedGate = new Promise<void>((resolve) => { releaseSeed = resolve; });
-    const seedEnteredPromise = new Promise<void>((resolve) => { seedEntered = resolve; });
     const provider = {
       getBlockNumber: vi.fn(async () => 1_000),
-      getLogs: vi.fn(async () => {
-        seedEntered();
-        await seedGate;
-        return [];
-      }),
+      getLogs: vi.fn(async () => []),
     };
+    const onContractName = vi.fn();
     const poller = new HubRotationPoller({
       readProvider: async (_label, fn) => fn(provider as any),
       intervalMs: 30_000,
       reorgBufferBlocks: 50,
-      onContractName: vi.fn(),
+      onContractName,
     });
 
     try {
       await expect(poller.start(hubContract(), HUB_ADDRESS)).resolves.toBeUndefined();
       expect(poller.isStarted).toBe(true);
+      expect(provider.getBlockNumber).not.toHaveBeenCalled();
+      expect(provider.getLogs).not.toHaveBeenCalled();
 
-      await seedEnteredPromise;
       poller.stop();
-      releaseSeed();
-      await Promise.resolve();
       await vi.advanceTimersByTimeAsync(30_000);
 
-      expect(provider.getBlockNumber).toHaveBeenCalledTimes(1);
-      expect(provider.getLogs).toHaveBeenCalledTimes(1);
+      expect(provider.getBlockNumber).not.toHaveBeenCalled();
+      expect(provider.getLogs).not.toHaveBeenCalled();
+      expect(onContractName).not.toHaveBeenCalled();
       expect(poller.isStarted).toBe(false);
     } finally {
       poller.stop();
       vi.useRealTimers();
+    }
+  });
+
+  it('ignores a delayed in-flight poll result after stop', async () => {
+    const iface = hubInterface();
+    const delayedLog = rotationLog(iface, 'ContractChanged', 'ContextGraphs', 1_000, '70');
+    let releasePoll!: () => void;
+    let pollEntered!: () => void;
+    const pollGate = new Promise<void>((resolve) => { releasePoll = resolve; });
+    const pollEnteredPromise = new Promise<void>((resolve) => { pollEntered = resolve; });
+    const provider = {
+      getBlockNumber: vi.fn(async () => 1_000),
+      getLogs: vi.fn(async () => {
+        pollEntered();
+        await pollGate;
+        return [delayedLog];
+      }),
+    };
+    const onContractName = vi.fn();
+    const poller = new HubRotationPoller({
+      readProvider: async (_label, fn) => fn(provider as any),
+      intervalMs: 30_000,
+      reorgBufferBlocks: 50,
+      onContractName,
+    });
+
+    try {
+      await poller.start(hubContract(iface), HUB_ADDRESS);
+      const pendingPoll = poller.pollOnce();
+      await pollEnteredPromise;
+
+      poller.stop();
+      releasePoll();
+      await pendingPoll;
+
+      expect(provider.getBlockNumber).toHaveBeenCalledTimes(1);
+      expect(provider.getLogs).toHaveBeenCalledTimes(1);
+      expect(onContractName).not.toHaveBeenCalled();
+      expect(poller.isStarted).toBe(false);
+    } finally {
+      poller.stop();
     }
   });
 
@@ -103,8 +137,8 @@ describe('HubRotationPoller', () => {
       getBlockNumber: vi.fn(async () => head),
       getLogs: vi.fn(async () => {
         getLogsCalls++;
-        if (getLogsCalls === 2) throw new Error('temporary getLogs failure');
-        if (getLogsCalls === 3) {
+        if (getLogsCalls === 1) throw new Error('temporary getLogs failure');
+        if (getLogsCalls === 2) {
           return [{
             blockNumber: 1_001,
             blockHash: '0x' + '51'.repeat(32),
@@ -135,30 +169,18 @@ describe('HubRotationPoller', () => {
 
       await vi.advanceTimersByTimeAsync(30_000);
       expect(onContractName).toHaveBeenCalledWith('ContextGraphs');
-      expect(provider.getLogs).toHaveBeenCalledTimes(3);
+      expect(provider.getLogs).toHaveBeenCalledTimes(2);
     } finally {
       poller.stop();
       vi.useRealTimers();
     }
   });
 
-  it('coalesces concurrent starts while bootstrap is still in flight', async () => {
+  it('coalesces concurrent starts into a single scheduled poller', async () => {
     vi.useFakeTimers({ now: 0 });
-    let releaseSeed!: () => void;
-    let seedEntered!: () => void;
-    const seedGate = new Promise<void>((resolve) => { releaseSeed = resolve; });
-    const seedEnteredPromise = new Promise<void>((resolve) => { seedEntered = resolve; });
-    let getLogsCalls = 0;
     const provider = {
       getBlockNumber: vi.fn(async () => 1_000),
-      getLogs: vi.fn(async () => {
-        getLogsCalls++;
-        if (getLogsCalls === 1) {
-          seedEntered();
-          await seedGate;
-        }
-        return [];
-      }),
+      getLogs: vi.fn(async () => []),
     };
     const poller = new HubRotationPoller({
       readProvider: async (_label, fn) => fn(provider as any),
@@ -169,26 +191,23 @@ describe('HubRotationPoller', () => {
 
     try {
       const firstStart = poller.start(hubContract(), HUB_ADDRESS);
-      await seedEnteredPromise;
       const secondStart = poller.start(hubContract(), HUB_ADDRESS);
 
-      releaseSeed();
       await Promise.all([firstStart, secondStart]);
-      await flushAsyncWork();
 
-      expect(provider.getBlockNumber).toHaveBeenCalledTimes(1);
-      expect(provider.getLogs).toHaveBeenCalledTimes(1);
+      expect(provider.getBlockNumber).not.toHaveBeenCalled();
+      expect(provider.getLogs).not.toHaveBeenCalled();
 
       await vi.advanceTimersByTimeAsync(30_000);
-      expect(provider.getBlockNumber).toHaveBeenCalledTimes(2);
-      expect(provider.getLogs).toHaveBeenCalledTimes(2);
+      expect(provider.getBlockNumber).toHaveBeenCalledTimes(1);
+      expect(provider.getLogs).toHaveBeenCalledTimes(1);
     } finally {
       poller.stop();
       vi.useRealTimers();
     }
   });
 
-  it('probes startup logs without dispatching and dispatches the first buffered poll', async () => {
+  it('defers startup log reads to the first buffered poll', async () => {
     vi.useFakeTimers({ now: 0 });
     const iface = hubInterface();
     let head = 1_000;
@@ -213,10 +232,17 @@ describe('HubRotationPoller', () => {
       await flushAsyncWork();
 
       expect(onContractName).not.toHaveBeenCalled();
+      expect(provider.getBlockNumber).not.toHaveBeenCalled();
+      expect(provider.getLogs).not.toHaveBeenCalled();
+
+      head = 1_001;
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      expect(provider.getLogs).toHaveBeenCalledTimes(1);
       expect(provider.getLogs.mock.calls[0][0]).toMatchObject({
         address: HUB_ADDRESS,
-        fromBlock: 950,
-        toBlock: 1_000,
+        fromBlock: 951,
+        toBlock: 1_001,
       });
       expect(provider.getLogs.mock.calls[0][0].topics[0]).toEqual([
         iface.getEvent('ContractChanged')!.topicHash,
@@ -224,15 +250,6 @@ describe('HubRotationPoller', () => {
         iface.getEvent('AssetStorageChanged')!.topicHash,
         iface.getEvent('NewAssetStorage')!.topicHash,
       ]);
-
-      head = 1_001;
-      await vi.advanceTimersByTimeAsync(30_000);
-
-      expect(provider.getLogs).toHaveBeenCalledTimes(2);
-      expect(provider.getLogs.mock.calls[1][0]).toMatchObject({
-        fromBlock: 951,
-        toBlock: 1_001,
-      });
       expect(onContractName.mock.calls.map((call) => call[0])).toEqual([
         'RandomSampling',
         'ContextGraphs',
@@ -263,8 +280,8 @@ describe('HubRotationPoller', () => {
 
     try {
       await poller.start(hubContract(iface), HUB_ADDRESS);
-      await flushAsyncWork();
-      expect(onContractName).not.toHaveBeenCalled();
+      await poller.pollOnce();
+      expect(onContractName).toHaveBeenCalledWith('UntrackedAtStartup');
 
       logs.splice(0, logs.length, rotationLog(iface, 'ContractChanged', 'ContextGraphs', 1_000, '22'));
       head = 1_001;
@@ -275,7 +292,7 @@ describe('HubRotationPoller', () => {
         fromBlock: 951,
         toBlock: 1_001,
       });
-      expect(onContractName).toHaveBeenCalledTimes(1);
+      expect(onContractName).toHaveBeenCalledTimes(2);
       expect(onContractName).toHaveBeenCalledWith('ContextGraphs');
     } finally {
       poller.stop();
@@ -303,7 +320,7 @@ describe('HubRotationPoller', () => {
 
     try {
       await poller.start(hubContract(iface), HUB_ADDRESS);
-      await flushAsyncWork();
+      await poller.pollOnce();
 
       exposeReorgLog = true;
       head = 1_001;
@@ -339,7 +356,6 @@ describe('HubRotationPoller', () => {
 
     try {
       await poller.start(hubContract(iface), HUB_ADDRESS);
-      await flushAsyncWork();
 
       logs = [repeatedLog];
       head = 1_001;
@@ -371,7 +387,7 @@ describe('HubRotationPoller', () => {
 
     try {
       await poller.start(hubContract(iface), HUB_ADDRESS);
-      await flushAsyncWork();
+      await poller.pollOnce();
 
       head = 900;
       await poller.pollOnce();

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -599,10 +599,27 @@ export function mergePreferredRelays(input: {
   };
 }
 
-export function chainDiscoveryScanOptions(input: { watermarkSeeded: boolean }):
+export const CHAIN_FULL_SCAN_EVERY = 48; // about once per day at the 30-minute cadence
+
+export function chainDiscoveryScanOptions(input: {
+  watermarkSeeded: boolean;
+  run?: number;
+  fullScanEvery?: number;
+}):
   | { incremental: true }
   | { seedIncrementalWatermark: true; throwOnChainScanFailure: true } {
-  return input.watermarkSeeded
+  const configuredFullScanEvery = input.fullScanEvery;
+  let fullScanEvery = CHAIN_FULL_SCAN_EVERY;
+  if (
+    typeof configuredFullScanEvery === 'number' &&
+    Number.isFinite(configuredFullScanEvery) &&
+    configuredFullScanEvery > 0
+  ) {
+    fullScanEvery = Math.floor(configuredFullScanEvery);
+  }
+  const run = input.run ?? 0;
+  const periodicFullResync = input.watermarkSeeded && run > 0 && run % fullScanEvery === 0;
+  return input.watermarkSeeded && !periodicFullResync
     ? { incremental: true }
     : { seedIncrementalWatermark: true, throwOnChainScanFailure: true };
 }
@@ -1911,10 +1928,13 @@ export async function runDaemonInner(
   // Run an initial chain scan for context graphs we might not know about,
   // then repeat every 30 minutes as a fallback discovery mechanism.
   const CHAIN_SCAN_INTERVAL_MS = 30 * 60 * 1000;
+  let chainScanRuns = 0;
   const runChainDiscoveryScan = async () => {
     try {
+      const run = chainScanRuns++;
       const found = await agent.discoverContextGraphsFromChain(
         chainDiscoveryScanOptions({
+          run,
           watermarkSeeded: await agent.hasContextGraphRegistryScanWatermark(),
         }),
       );

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -613,7 +613,7 @@ export function chainDiscoveryScanOptions(input: {
   if (
     typeof configuredFullScanEvery === 'number' &&
     Number.isFinite(configuredFullScanEvery) &&
-    configuredFullScanEvery > 0
+    configuredFullScanEvery >= 1
   ) {
     fullScanEvery = Math.floor(configuredFullScanEvery);
   }

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -605,24 +605,12 @@ export function shouldUseIncrementalChainDiscoveryScan(input: {
   return input.watermarkSeeded;
 }
 
-export const CHAIN_DISCOVERY_LIVE_TAIL_LOOKBACK_BLOCKS = 9_000;
-
 export function chainDiscoveryScanOptions(incremental: boolean):
   | { incremental: true }
-  | {
-      liveTailOnly: true;
-      liveTailLookbackBlocks: number;
-      seedIncrementalWatermark: true;
-      throwOnChainScanFailure: true;
-    } {
+  | { seedIncrementalWatermark: true; throwOnChainScanFailure: true } {
   return incremental
     ? { incremental: true }
-    : {
-        liveTailOnly: true,
-        liveTailLookbackBlocks: CHAIN_DISCOVERY_LIVE_TAIL_LOOKBACK_BLOCKS,
-        seedIncrementalWatermark: true,
-        throwOnChainScanFailure: true,
-      };
+    : { seedIncrementalWatermark: true, throwOnChainScanFailure: true };
 }
 
 export interface PromoteWorkerDaemonLifecycle {

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -600,23 +600,29 @@ export function mergePreferredRelays(input: {
 }
 
 export function shouldUseIncrementalChainDiscoveryScan(input: {
-  run: number;
   watermarkSeeded: boolean;
-  fullScanEvery: number;
 }): boolean {
-  return (
-    input.watermarkSeeded &&
-    input.run !== 0 &&
-    input.run % input.fullScanEvery !== 0
-  );
+  return input.watermarkSeeded;
 }
+
+export const CHAIN_DISCOVERY_LIVE_TAIL_LOOKBACK_BLOCKS = 9_000;
 
 export function chainDiscoveryScanOptions(incremental: boolean):
   | { incremental: true }
-  | { seedIncrementalWatermark: true; throwOnChainScanFailure: true } {
+  | {
+      liveTailOnly: true;
+      liveTailLookbackBlocks: number;
+      seedIncrementalWatermark: true;
+      throwOnChainScanFailure: true;
+    } {
   return incremental
     ? { incremental: true }
-    : { seedIncrementalWatermark: true, throwOnChainScanFailure: true };
+    : {
+        liveTailOnly: true,
+        liveTailLookbackBlocks: CHAIN_DISCOVERY_LIVE_TAIL_LOOKBACK_BLOCKS,
+        seedIncrementalWatermark: true,
+        throwOnChainScanFailure: true,
+      };
 }
 
 export interface PromoteWorkerDaemonLifecycle {
@@ -1923,15 +1929,10 @@ export async function runDaemonInner(
   // Run an initial chain scan for context graphs we might not know about,
   // then repeat every 30 minutes as a fallback discovery mechanism.
   const CHAIN_SCAN_INTERVAL_MS = 30 * 60 * 1000;
-  const CHAIN_FULL_SCAN_EVERY = 48; // about once per day at the 30-minute cadence
-  let chainScanRuns = 0;
   const runChainDiscoveryScan = async () => {
     try {
-      const run = chainScanRuns++;
       const incremental = shouldUseIncrementalChainDiscoveryScan({
-        run,
         watermarkSeeded: await agent.hasContextGraphRegistryScanWatermark(),
-        fullScanEvery: CHAIN_FULL_SCAN_EVERY,
       });
       const found = await agent.discoverContextGraphsFromChain(
         chainDiscoveryScanOptions(incremental),

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -599,16 +599,10 @@ export function mergePreferredRelays(input: {
   };
 }
 
-export function shouldUseIncrementalChainDiscoveryScan(input: {
-  watermarkSeeded: boolean;
-}): boolean {
-  return input.watermarkSeeded;
-}
-
-export function chainDiscoveryScanOptions(incremental: boolean):
+export function chainDiscoveryScanOptions(input: { watermarkSeeded: boolean }):
   | { incremental: true }
   | { seedIncrementalWatermark: true; throwOnChainScanFailure: true } {
-  return incremental
+  return input.watermarkSeeded
     ? { incremental: true }
     : { seedIncrementalWatermark: true, throwOnChainScanFailure: true };
 }
@@ -1919,11 +1913,10 @@ export async function runDaemonInner(
   const CHAIN_SCAN_INTERVAL_MS = 30 * 60 * 1000;
   const runChainDiscoveryScan = async () => {
     try {
-      const incremental = shouldUseIncrementalChainDiscoveryScan({
-        watermarkSeeded: await agent.hasContextGraphRegistryScanWatermark(),
-      });
       const found = await agent.discoverContextGraphsFromChain(
-        chainDiscoveryScanOptions(incremental),
+        chainDiscoveryScanOptions({
+          watermarkSeeded: await agent.hasContextGraphRegistryScanWatermark(),
+        }),
       );
       if (found > 0)
         log(`Chain scan: discovered ${found} new context graph(s)`);

--- a/packages/cli/test/chain-discovery-scan-mode.test.ts
+++ b/packages/cli/test/chain-discovery-scan-mode.test.ts
@@ -1,12 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import {
-  CHAIN_DISCOVERY_LIVE_TAIL_LOOKBACK_BLOCKS,
   chainDiscoveryScanOptions,
   shouldUseIncrementalChainDiscoveryScan,
 } from '../src/daemon/lifecycle.js';
 
 describe('shouldUseIncrementalChainDiscoveryScan', () => {
-  it('uses bounded live-tail seeding before any watermark seed exists', () => {
+  it('uses historical watermark seeding before any watermark seed exists', () => {
     expect(
       shouldUseIncrementalChainDiscoveryScan({
         watermarkSeeded: false,
@@ -14,7 +13,7 @@ describe('shouldUseIncrementalChainDiscoveryScan', () => {
     ).toBe(false);
   });
 
-  it('keeps bounded live-tail seeding until a watermark seed succeeds', () => {
+  it('keeps historical seeding until a watermark seed succeeds', () => {
     expect(
       shouldUseIncrementalChainDiscoveryScan({
         watermarkSeeded: false,
@@ -40,10 +39,8 @@ describe('shouldUseIncrementalChainDiscoveryScan', () => {
 });
 
 describe('chainDiscoveryScanOptions', () => {
-  it('uses failure-throwing bounded live-tail watermark seeding before incremental scans', () => {
+  it('uses failure-throwing full-history watermark seeding before incremental scans', () => {
     expect(chainDiscoveryScanOptions(false)).toEqual({
-      liveTailOnly: true,
-      liveTailLookbackBlocks: CHAIN_DISCOVERY_LIVE_TAIL_LOOKBACK_BLOCKS,
       seedIncrementalWatermark: true,
       throwOnChainScanFailure: true,
     });

--- a/packages/cli/test/chain-discovery-scan-mode.test.ts
+++ b/packages/cli/test/chain-discovery-scan-mode.test.ts
@@ -1,26 +1,23 @@
 import { describe, expect, it } from 'vitest';
 import {
+  CHAIN_DISCOVERY_LIVE_TAIL_LOOKBACK_BLOCKS,
   chainDiscoveryScanOptions,
   shouldUseIncrementalChainDiscoveryScan,
 } from '../src/daemon/lifecycle.js';
 
 describe('shouldUseIncrementalChainDiscoveryScan', () => {
-  it('starts with a full scan before any watermark seed exists', () => {
+  it('uses bounded live-tail seeding before any watermark seed exists', () => {
     expect(
       shouldUseIncrementalChainDiscoveryScan({
-        run: 0,
         watermarkSeeded: false,
-        fullScanEvery: 48,
       }),
     ).toBe(false);
   });
 
-  it('keeps retrying full scans until a watermark seed succeeds', () => {
+  it('keeps bounded live-tail seeding until a watermark seed succeeds', () => {
     expect(
       shouldUseIncrementalChainDiscoveryScan({
-        run: 1,
         watermarkSeeded: false,
-        fullScanEvery: 48,
       }),
     ).toBe(false);
   });
@@ -28,27 +25,25 @@ describe('shouldUseIncrementalChainDiscoveryScan', () => {
   it('uses incremental scans after a successful watermark seed', () => {
     expect(
       shouldUseIncrementalChainDiscoveryScan({
-        run: 1,
         watermarkSeeded: true,
-        fullScanEvery: 48,
       }),
     ).toBe(true);
   });
 
-  it('keeps the scheduled full-resync cadence after a watermark seed', () => {
+  it('does not schedule automatic full-resync scans after a watermark seed', () => {
     expect(
       shouldUseIncrementalChainDiscoveryScan({
-        run: 48,
         watermarkSeeded: true,
-        fullScanEvery: 48,
       }),
-    ).toBe(false);
+    ).toBe(true);
   });
 });
 
 describe('chainDiscoveryScanOptions', () => {
-  it('uses failure-throwing watermark seeding for full daemon scans', () => {
+  it('uses failure-throwing bounded live-tail watermark seeding before incremental scans', () => {
     expect(chainDiscoveryScanOptions(false)).toEqual({
+      liveTailOnly: true,
+      liveTailLookbackBlocks: CHAIN_DISCOVERY_LIVE_TAIL_LOOKBACK_BLOCKS,
       seedIncrementalWatermark: true,
       throwOnChainScanFailure: true,
     });

--- a/packages/cli/test/chain-discovery-scan-mode.test.ts
+++ b/packages/cli/test/chain-discovery-scan-mode.test.ts
@@ -12,4 +12,31 @@ describe('chainDiscoveryScanOptions', () => {
   it('keeps steady-state daemon scans incremental-only', () => {
     expect(chainDiscoveryScanOptions({ watermarkSeeded: true })).toEqual({ incremental: true });
   });
+
+  it('keeps the first daemon scan incremental when the watermark is already seeded', () => {
+    expect(chainDiscoveryScanOptions({
+      watermarkSeeded: true,
+      run: 0,
+      fullScanEvery: 48,
+    })).toEqual({ incremental: true });
+  });
+
+  it('keeps a periodic full-history recovery path after the watermark is seeded', () => {
+    expect(chainDiscoveryScanOptions({
+      watermarkSeeded: true,
+      run: 48,
+      fullScanEvery: 48,
+    })).toEqual({
+      seedIncrementalWatermark: true,
+      throwOnChainScanFailure: true,
+    });
+  });
+
+  it('does not force a full scan before the configured recovery cadence', () => {
+    expect(chainDiscoveryScanOptions({
+      watermarkSeeded: true,
+      run: 47,
+      fullScanEvery: 48,
+    })).toEqual({ incremental: true });
+  });
 });

--- a/packages/cli/test/chain-discovery-scan-mode.test.ts
+++ b/packages/cli/test/chain-discovery-scan-mode.test.ts
@@ -1,52 +1,15 @@
 import { describe, expect, it } from 'vitest';
-import {
-  chainDiscoveryScanOptions,
-  shouldUseIncrementalChainDiscoveryScan,
-} from '../src/daemon/lifecycle.js';
-
-describe('shouldUseIncrementalChainDiscoveryScan', () => {
-  it('uses historical watermark seeding before any watermark seed exists', () => {
-    expect(
-      shouldUseIncrementalChainDiscoveryScan({
-        watermarkSeeded: false,
-      }),
-    ).toBe(false);
-  });
-
-  it('keeps historical seeding until a watermark seed succeeds', () => {
-    expect(
-      shouldUseIncrementalChainDiscoveryScan({
-        watermarkSeeded: false,
-      }),
-    ).toBe(false);
-  });
-
-  it('uses incremental scans after a successful watermark seed', () => {
-    expect(
-      shouldUseIncrementalChainDiscoveryScan({
-        watermarkSeeded: true,
-      }),
-    ).toBe(true);
-  });
-
-  it('does not schedule automatic full-resync scans after a watermark seed', () => {
-    expect(
-      shouldUseIncrementalChainDiscoveryScan({
-        watermarkSeeded: true,
-      }),
-    ).toBe(true);
-  });
-});
+import { chainDiscoveryScanOptions } from '../src/daemon/lifecycle.js';
 
 describe('chainDiscoveryScanOptions', () => {
-  it('uses failure-throwing full-history watermark seeding before incremental scans', () => {
-    expect(chainDiscoveryScanOptions(false)).toEqual({
+  it('uses failure-throwing full-history watermark seeding before a seed exists', () => {
+    expect(chainDiscoveryScanOptions({ watermarkSeeded: false })).toEqual({
       seedIncrementalWatermark: true,
       throwOnChainScanFailure: true,
     });
   });
 
   it('keeps steady-state daemon scans incremental-only', () => {
-    expect(chainDiscoveryScanOptions(true)).toEqual({ incremental: true });
+    expect(chainDiscoveryScanOptions({ watermarkSeeded: true })).toEqual({ incremental: true });
   });
 });

--- a/packages/cli/test/chain-discovery-scan-mode.test.ts
+++ b/packages/cli/test/chain-discovery-scan-mode.test.ts
@@ -39,4 +39,12 @@ describe('chainDiscoveryScanOptions', () => {
       fullScanEvery: 48,
     })).toEqual({ incremental: true });
   });
+
+  it('ignores fractional full-scan cadence overrides below one', () => {
+    expect(chainDiscoveryScanOptions({
+      watermarkSeeded: true,
+      run: 1,
+      fullScanEvery: 0.5,
+    })).toEqual({ incremental: true });
+  });
 });

--- a/packages/publisher/src/chain-event-lane-runner.ts
+++ b/packages/publisher/src/chain-event-lane-runner.ts
@@ -20,9 +20,13 @@ interface ChainEventPollerLaneState {
   headKnown: boolean;
   requiresFullHistory?: boolean;
   lastRunAt?: number;
+  failureBackoffMs?: number;
+  retryAfterMs?: number;
 }
 
 const DEFAULT_LIVE_SEED_LOOKBACK_BLOCKS = 500;
+const FAILURE_BACKOFF_INITIAL_MS = 60_000;
+const FAILURE_BACKOFF_MAX_MS = 5 * 60_000;
 
 export interface ChainEventPollerLaneSpec {
   name: ChainEventPollerLane;
@@ -177,6 +181,8 @@ export class ChainEventLaneRunner {
   }
 
   private laneDue(lane: ChainEventPollerLaneRuntime, now: number): boolean {
+    const retryAfterMs = lane.state.retryAfterMs;
+    if (retryAfterMs != null && now < retryAfterMs) return false;
     const lastRunAt = lane.state.lastRunAt;
     return lastRunAt == null || now - lastRunAt >= lane.spec.cadenceMs;
   }
@@ -266,13 +272,25 @@ export class ChainEventLaneRunner {
       }
 
       state.lastBlock = upperBound;
+      state.failureBackoffMs = undefined;
+      state.retryAfterMs = undefined;
       advanced = true;
     } catch (err) {
       this.log.error(ctx, `Poll lane ${lane.spec.name} failed: ${err instanceof Error ? err.message : String(err)}`);
+      this.backoffFailedLane(lane, now);
     } finally {
       state.lastRunAt = advanced && caughtUp ? now : undefined;
     }
     return { lane, blockNumber: state.lastBlock, advanced };
+  }
+
+  private backoffFailedLane(lane: ChainEventPollerLaneRuntime, now: number): void {
+    const previous = lane.state.failureBackoffMs;
+    const next = previous == null
+      ? Math.max(FAILURE_BACKOFF_INITIAL_MS, lane.spec.cadenceMs)
+      : Math.min(previous * 2, FAILURE_BACKOFF_MAX_MS);
+    lane.state.failureBackoffMs = next;
+    lane.state.retryAfterMs = now + next;
   }
 
   private applyHistoryModeTransition(

--- a/packages/publisher/src/chain-event-lane-runner.ts
+++ b/packages/publisher/src/chain-event-lane-runner.ts
@@ -27,6 +27,11 @@ const DEFAULT_LIVE_SEED_LOOKBACK_BLOCKS = 500;
 const FAILURE_BACKOFF_INITIAL_MS = 60_000;
 const FAILURE_BACKOFF_MAX_MS = 5 * 60_000;
 
+export interface ChainEventPollerFailureBackoffPolicy {
+  initialMs?: number;
+  maxMs?: number;
+}
+
 export interface ChainEventPollerLaneSpec {
   name: ChainEventPollerLane;
   enabled(): boolean;
@@ -34,9 +39,15 @@ export interface ChainEventPollerLaneSpec {
   requiresFullHistory(): boolean;
   canUseLegacyAggregateCursor?(): boolean;
   liveSeedLookbackBlocks?: number;
+  failureBackoff?: ChainEventPollerFailureBackoffPolicy;
   cadenceMs: number;
   dispatch(event: ChainEvent, ctx: OperationContext): Promise<void>;
   onBackfillFromGenesis?(ctx: OperationContext): void;
+}
+
+interface NormalizedFailureBackoffPolicy {
+  initialMs: number;
+  maxMs: number;
 }
 
 interface ChainEventPollerLaneRuntime {
@@ -46,6 +57,7 @@ interface ChainEventPollerLaneRuntime {
   requiresFullHistory: boolean;
   canUseLegacyAggregateCursor: boolean;
   liveSeedLookbackBlocks: number;
+  failureBackoff: NormalizedFailureBackoffPolicy;
 }
 
 interface ChainEventPollerLaneScanResult {
@@ -53,6 +65,11 @@ interface ChainEventPollerLaneScanResult {
   blockNumber: number;
   advanced: boolean;
 }
+
+type ChainEventLaneScheduleOutcome =
+  | { kind: 'noWork'; now: number }
+  | { kind: 'success'; now: number; caughtUp: boolean }
+  | { kind: 'failure'; now: number };
 
 export interface ChainEventLaneRunnerConfig {
   chain: ChainAdapter;
@@ -126,6 +143,7 @@ export class ChainEventLaneRunner {
         requiresFullHistory,
         canUseLegacyAggregateCursor: spec.canUseLegacyAggregateCursor?.() ?? !requiresFullHistory,
         liveSeedLookbackBlocks: this.liveSeedLookbackBlocks(spec),
+        failureBackoff: this.failureBackoffPolicy(spec),
       }];
     });
   }
@@ -135,6 +153,24 @@ export class ChainEventLaneRunner {
     return Number.isFinite(lookback) && lookback >= 0
       ? Math.floor(lookback)
       : DEFAULT_LIVE_SEED_LOOKBACK_BLOCKS;
+  }
+
+  private failureBackoffPolicy(spec: ChainEventPollerLaneSpec): NormalizedFailureBackoffPolicy {
+    const initialMs = this.scheduleDelayMs(
+      spec.failureBackoff?.initialMs,
+      Math.max(FAILURE_BACKOFF_INITIAL_MS, spec.cadenceMs),
+    );
+    const maxMs = Math.max(
+      initialMs,
+      this.scheduleDelayMs(spec.failureBackoff?.maxMs, FAILURE_BACKOFF_MAX_MS),
+    );
+    return { initialMs, maxMs };
+  }
+
+  private scheduleDelayMs(value: number | undefined, fallback: number): number {
+    return Number.isFinite(value) && value! >= 0
+      ? Math.floor(value!)
+      : fallback;
   }
 
   private stateFor(lane: ChainEventPollerLane): ChainEventPollerLaneState {
@@ -251,7 +287,7 @@ export class ChainEventLaneRunner {
       : fromBlock + this.maxRange - 1;
 
     if (fromBlock > upperBound) {
-      state.nextRunAtMs = now + lane.spec.cadenceMs;
+      this.applyLaneSchedule(lane, { kind: 'noWork', now });
       return { lane, blockNumber: state.lastBlock, advanced: false };
     }
 
@@ -269,26 +305,33 @@ export class ChainEventLaneRunner {
       }
 
       state.lastBlock = upperBound;
-      state.failureBackoffMs = undefined;
       advanced = true;
+      this.applyLaneSchedule(lane, { kind: 'success', now, caughtUp });
     } catch (err) {
       this.log.error(ctx, `Poll lane ${lane.spec.name} failed: ${err instanceof Error ? err.message : String(err)}`);
-      this.backoffFailedLane(lane, now);
-    } finally {
-      if (advanced) {
-        state.nextRunAtMs = caughtUp ? now + lane.spec.cadenceMs : undefined;
-      }
+      this.applyLaneSchedule(lane, { kind: 'failure', now });
     }
     return { lane, blockNumber: state.lastBlock, advanced };
   }
 
-  private backoffFailedLane(lane: ChainEventPollerLaneRuntime, now: number): void {
-    const previous = lane.state.failureBackoffMs;
+  private applyLaneSchedule(lane: ChainEventPollerLaneRuntime, outcome: ChainEventLaneScheduleOutcome): void {
+    const state = lane.state;
+    if (outcome.kind === 'noWork') {
+      state.nextRunAtMs = outcome.now + lane.spec.cadenceMs;
+      return;
+    }
+    if (outcome.kind === 'success') {
+      state.failureBackoffMs = undefined;
+      state.nextRunAtMs = outcome.caughtUp ? outcome.now + lane.spec.cadenceMs : undefined;
+      return;
+    }
+
+    const previous = state.failureBackoffMs;
     const next = previous == null
-      ? Math.max(FAILURE_BACKOFF_INITIAL_MS, lane.spec.cadenceMs)
-      : Math.min(previous * 2, FAILURE_BACKOFF_MAX_MS);
-    lane.state.failureBackoffMs = next;
-    lane.state.nextRunAtMs = now + next;
+      ? lane.failureBackoff.initialMs
+      : Math.min(previous * 2, lane.failureBackoff.maxMs);
+    state.failureBackoffMs = next;
+    state.nextRunAtMs = outcome.now + next;
   }
 
   private applyHistoryModeTransition(

--- a/packages/publisher/src/chain-event-lane-runner.ts
+++ b/packages/publisher/src/chain-event-lane-runner.ts
@@ -27,11 +27,6 @@ const DEFAULT_LIVE_SEED_LOOKBACK_BLOCKS = 500;
 const FAILURE_BACKOFF_INITIAL_MS = 60_000;
 const FAILURE_BACKOFF_MAX_MS = 5 * 60_000;
 
-export interface ChainEventPollerFailureBackoffPolicy {
-  initialMs?: number;
-  maxMs?: number;
-}
-
 export interface ChainEventPollerLaneSpec {
   name: ChainEventPollerLane;
   enabled(): boolean;
@@ -39,15 +34,9 @@ export interface ChainEventPollerLaneSpec {
   requiresFullHistory(): boolean;
   canUseLegacyAggregateCursor?(): boolean;
   liveSeedLookbackBlocks?: number;
-  failureBackoff?: ChainEventPollerFailureBackoffPolicy;
   cadenceMs: number;
   dispatch(event: ChainEvent, ctx: OperationContext): Promise<void>;
   onBackfillFromGenesis?(ctx: OperationContext): void;
-}
-
-interface NormalizedFailureBackoffPolicy {
-  initialMs: number;
-  maxMs: number;
 }
 
 interface ChainEventPollerLaneRuntime {
@@ -57,7 +46,6 @@ interface ChainEventPollerLaneRuntime {
   requiresFullHistory: boolean;
   canUseLegacyAggregateCursor: boolean;
   liveSeedLookbackBlocks: number;
-  failureBackoff: NormalizedFailureBackoffPolicy;
 }
 
 interface ChainEventPollerLaneScanResult {
@@ -143,7 +131,6 @@ export class ChainEventLaneRunner {
         requiresFullHistory,
         canUseLegacyAggregateCursor: spec.canUseLegacyAggregateCursor?.() ?? !requiresFullHistory,
         liveSeedLookbackBlocks: this.liveSeedLookbackBlocks(spec),
-        failureBackoff: this.failureBackoffPolicy(spec),
       }];
     });
   }
@@ -153,18 +140,6 @@ export class ChainEventLaneRunner {
     return Number.isFinite(lookback) && lookback >= 0
       ? Math.floor(lookback)
       : DEFAULT_LIVE_SEED_LOOKBACK_BLOCKS;
-  }
-
-  private failureBackoffPolicy(spec: ChainEventPollerLaneSpec): NormalizedFailureBackoffPolicy {
-    const initialMs = this.scheduleDelayMs(
-      spec.failureBackoff?.initialMs,
-      Math.max(FAILURE_BACKOFF_INITIAL_MS, spec.cadenceMs),
-    );
-    const maxMs = Math.max(
-      initialMs,
-      this.scheduleDelayMs(spec.failureBackoff?.maxMs, FAILURE_BACKOFF_MAX_MS),
-    );
-    return { initialMs, maxMs };
   }
 
   private scheduleDelayMs(value: number | undefined, fallback: number): number {
@@ -328,8 +303,8 @@ export class ChainEventLaneRunner {
 
     const previous = state.failureBackoffMs;
     const next = previous == null
-      ? lane.failureBackoff.initialMs
-      : Math.min(previous * 2, lane.failureBackoff.maxMs);
+      ? Math.max(FAILURE_BACKOFF_INITIAL_MS, lane.spec.cadenceMs)
+      : Math.min(previous * 2, FAILURE_BACKOFF_MAX_MS);
     state.failureBackoffMs = next;
     state.nextRunAtMs = outcome.now + next;
   }

--- a/packages/publisher/src/chain-event-lane-runner.ts
+++ b/packages/publisher/src/chain-event-lane-runner.ts
@@ -19,9 +19,8 @@ interface ChainEventPollerLaneState {
   lastBlock: number;
   headKnown: boolean;
   requiresFullHistory?: boolean;
-  lastRunAt?: number;
+  nextRunAtMs?: number;
   failureBackoffMs?: number;
-  retryAfterMs?: number;
 }
 
 const DEFAULT_LIVE_SEED_LOOKBACK_BLOCKS = 500;
@@ -181,10 +180,8 @@ export class ChainEventLaneRunner {
   }
 
   private laneDue(lane: ChainEventPollerLaneRuntime, now: number): boolean {
-    const retryAfterMs = lane.state.retryAfterMs;
-    if (retryAfterMs != null && now < retryAfterMs) return false;
-    const lastRunAt = lane.state.lastRunAt;
-    return lastRunAt == null || now - lastRunAt >= lane.spec.cadenceMs;
+    const nextRunAtMs = lane.state.nextRunAtMs;
+    return nextRunAtMs == null || now >= nextRunAtMs;
   }
 
   private async persistScanResults(
@@ -254,7 +251,7 @@ export class ChainEventLaneRunner {
       : fromBlock + this.maxRange - 1;
 
     if (fromBlock > upperBound) {
-      state.lastRunAt = now;
+      state.nextRunAtMs = now + lane.spec.cadenceMs;
       return { lane, blockNumber: state.lastBlock, advanced: false };
     }
 
@@ -273,13 +270,14 @@ export class ChainEventLaneRunner {
 
       state.lastBlock = upperBound;
       state.failureBackoffMs = undefined;
-      state.retryAfterMs = undefined;
       advanced = true;
     } catch (err) {
       this.log.error(ctx, `Poll lane ${lane.spec.name} failed: ${err instanceof Error ? err.message : String(err)}`);
       this.backoffFailedLane(lane, now);
     } finally {
-      state.lastRunAt = advanced && caughtUp ? now : undefined;
+      if (advanced) {
+        state.nextRunAtMs = caughtUp ? now + lane.spec.cadenceMs : undefined;
+      }
     }
     return { lane, blockNumber: state.lastBlock, advanced };
   }
@@ -290,7 +288,7 @@ export class ChainEventLaneRunner {
       ? Math.max(FAILURE_BACKOFF_INITIAL_MS, lane.spec.cadenceMs)
       : Math.min(previous * 2, FAILURE_BACKOFF_MAX_MS);
     lane.state.failureBackoffMs = next;
-    lane.state.retryAfterMs = now + next;
+    lane.state.nextRunAtMs = now + next;
   }
 
   private applyHistoryModeTransition(

--- a/packages/publisher/src/chain-event-poller.ts
+++ b/packages/publisher/src/chain-event-poller.ts
@@ -274,8 +274,7 @@ export class ChainEventPoller {
         eventTypes: () => ['NameClaimed', 'ContextGraphCreated'],
         // This poller is the low-latency live tail for new context graphs.
         // Historical recovery is handled by the daemon's
-        // discoverContextGraphsFromChain scan, which has its own bounded
-        // incremental watermark.
+        // discoverContextGraphsFromChain scan and incremental watermark.
         requiresFullHistory: () => false,
         canUseLegacyAggregateCursor: () => true,
         cadenceMs: this.intervalMs,

--- a/packages/publisher/test/chain-event-lane-runner.unit.test.ts
+++ b/packages/publisher/test/chain-event-lane-runner.unit.test.ts
@@ -294,6 +294,7 @@ describe('ChainEventPoller lane runner and cursors', () => {
       async save(n: number) { this.saved.push(n); },
     };
     let failContextLane = true;
+    let now = 0;
     const adapter = {
       chainId: 'mock:0',
       getBlockNumber: async () => 100,
@@ -309,7 +310,7 @@ describe('ChainEventPoller lane runner and cursors', () => {
       publishHandler: makeHandler(),
       intervalMs: 20,
       cursorPersistence: cursor,
-      clock: () => 0,
+      clock: () => now,
       onContextGraphCreated: async () => { /* sink */ },
       onKARegisteredToContextGraph: async () => { /* sink */ },
     });
@@ -327,6 +328,7 @@ describe('ChainEventPoller lane runner and cursors', () => {
     expect(cursor.saved).toEqual([]);
 
     failContextLane = false;
+    now = 60_000;
     await (poller as unknown as { poll(): Promise<void> }).poll();
 
     expect(filters[2].eventTypes).toEqual(['NameClaimed', 'ContextGraphCreated']);
@@ -820,10 +822,11 @@ describe('ChainEventPoller lane runner and cursors', () => {
     expect(filters[3].toBlock).toBe(1100);
   });
 
-  it('retries a failed context graph discovery lane on the next tick', async () => {
+  it('backs off a failed context graph discovery lane and retries the same range later', async () => {
     const filters: EventFilter[] = [];
     const saveCalls: Array<{ lane: ChainEventPollerLane; block: number }> = [];
     let calls = 0;
+    let now = 0;
     const adapter = {
       chainId: 'mock:0',
       getBlockNumber: async () => 100,
@@ -842,15 +845,17 @@ describe('ChainEventPoller lane runner and cursors', () => {
       publishHandler: makeHandler(),
       intervalMs: 20,
       cursorPersistence: cursor,
-      clock: () => 0,
+      clock: () => now,
       onContextGraphCreated: async () => { /* sink */ },
     });
 
-    await poller.start();
-    await new Promise((r) => setTimeout(r, 80));
-    await poller.stop();
+    await (poller as unknown as { poll(): Promise<void> }).poll();
+    now = 20;
+    await (poller as unknown as { poll(): Promise<void> }).poll();
+    now = 60_000;
+    await (poller as unknown as { poll(): Promise<void> }).poll();
 
-    expect(filters.length).toBeGreaterThanOrEqual(2);
+    expect(filters).toHaveLength(2);
     expect(filters[0].eventTypes).toEqual(['NameClaimed', 'ContextGraphCreated']);
     expect(filters[1].eventTypes).toEqual(['NameClaimed', 'ContextGraphCreated']);
     expect(filters[0].fromBlock).toBe(1);

--- a/packages/publisher/test/chain-event-lane-runner.unit.test.ts
+++ b/packages/publisher/test/chain-event-lane-runner.unit.test.ts
@@ -853,6 +853,8 @@ describe('ChainEventPoller lane runner and cursors', () => {
     await (poller as unknown as { poll(): Promise<void> }).poll();
     now = 20;
     await (poller as unknown as { poll(): Promise<void> }).poll();
+    expect(filters).toHaveLength(1);
+
     now = 60_000;
     await (poller as unknown as { poll(): Promise<void> }).poll();
 
@@ -930,7 +932,7 @@ describe('ChainEventPoller lane runner and cursors', () => {
     ]);
   });
 
-  it('uses an explicit lane failure-backoff policy and caps repeated failures', async () => {
+  it('caps repeated lane failures at the internal max backoff', async () => {
     const filters: EventFilter[] = [];
     let calls = 0;
     let now = 0;
@@ -940,7 +942,7 @@ describe('ChainEventPoller lane runner and cursors', () => {
       listenForEvents: async function* (f: EventFilter): AsyncIterable<ChainEvent> {
         filters.push(f);
         calls++;
-        if (calls <= 3) throw new Error('rpc down');
+        if (calls <= 5) throw new Error('rpc down');
       },
     } as unknown as ChainAdapter;
     const lane: ChainEventPollerLaneSpec = {
@@ -949,7 +951,6 @@ describe('ChainEventPoller lane runner and cursors', () => {
       eventTypes: () => ['ContextGraphCreated'],
       requiresFullHistory: () => false,
       cadenceMs: 20,
-      failureBackoff: { initialMs: 10, maxMs: 25 },
       dispatch: async () => { /* sink */ },
     };
     const runner = new ChainEventLaneRunner({
@@ -961,20 +962,30 @@ describe('ChainEventPoller lane runner and cursors', () => {
     });
 
     await runner.poll();
-    now = 9;
+    now = 59_999;
     await runner.poll();
-    now = 10;
+    now = 60_000;
     await runner.poll();
-    now = 29;
+    now = 179_999;
     await runner.poll();
-    now = 30;
+    now = 180_000;
     await runner.poll();
-    now = 54;
+    now = 419_999;
     await runner.poll();
-    now = 55;
+    now = 420_000;
+    await runner.poll();
+    now = 719_999;
+    await runner.poll();
+    now = 720_000;
+    await runner.poll();
+    now = 1_019_999;
+    await runner.poll();
+    now = 1_020_000;
     await runner.poll();
 
     expect(filters.map((f) => [f.fromBlock, f.toBlock])).toEqual([
+      [1, 100],
+      [1, 100],
       [1, 100],
       [1, 100],
       [1, 100],

--- a/packages/publisher/test/chain-event-lane-runner.unit.test.ts
+++ b/packages/publisher/test/chain-event-lane-runner.unit.test.ts
@@ -865,6 +865,70 @@ describe('ChainEventPoller lane runner and cursors', () => {
     expect(saveCalls).toEqual([{ lane: 'contextGraphDiscovery', block: 100 }]);
   });
 
+  it('exponentially backs off repeated lane failures and resets after success', async () => {
+    const filters: EventFilter[] = [];
+    const saveCalls: Array<{ lane: ChainEventPollerLane; block: number }> = [];
+    let calls = 0;
+    let head = 100;
+    let now = 0;
+    const adapter = {
+      chainId: 'mock:0',
+      getBlockNumber: async () => head,
+      listenForEvents: async function* (f: EventFilter): AsyncIterable<ChainEvent> {
+        filters.push(f);
+        calls++;
+        if (calls === 1 || calls === 2 || calls === 4) throw new Error('rpc down');
+      },
+    } as unknown as ChainAdapter;
+    const cursor: LaneCursorPersistence = {
+      async loadLane() { return undefined; },
+      async saveLane(lane, block) { saveCalls.push({ lane, block }); },
+    };
+    const poller = new ChainEventPoller({
+      chain: adapter,
+      publishHandler: makeHandler(),
+      intervalMs: 20,
+      cursorPersistence: cursor,
+      clock: () => now,
+      onContextGraphCreated: async () => { /* sink */ },
+    });
+
+    await (poller as unknown as { poll(): Promise<void> }).poll();
+    now = 60_000;
+    await (poller as unknown as { poll(): Promise<void> }).poll();
+    now = 120_000;
+    await (poller as unknown as { poll(): Promise<void> }).poll();
+    now = 180_000;
+    await (poller as unknown as { poll(): Promise<void> }).poll();
+
+    expect(filters.map((f) => [f.fromBlock, f.toBlock])).toEqual([
+      [1, 100],
+      [1, 100],
+      [1, 100],
+    ]);
+    expect(saveCalls).toEqual([{ lane: 'contextGraphDiscovery', block: 100 }]);
+
+    head = 200;
+    now = 180_020;
+    await (poller as unknown as { poll(): Promise<void> }).poll();
+    now = 240_019;
+    await (poller as unknown as { poll(): Promise<void> }).poll();
+    now = 240_020;
+    await (poller as unknown as { poll(): Promise<void> }).poll();
+
+    expect(filters.map((f) => [f.fromBlock, f.toBlock])).toEqual([
+      [1, 100],
+      [1, 100],
+      [1, 100],
+      [101, 200],
+      [101, 200],
+    ]);
+    expect(saveCalls).toEqual([
+      { lane: 'contextGraphDiscovery', block: 100 },
+      { lane: 'contextGraphDiscovery', block: 200 },
+    ]);
+  });
+
   it('keeps headless scans due until a known head proves the lane is caught up', async () => {
     const filters: EventFilter[] = [];
     const adapter = {

--- a/packages/publisher/test/chain-event-lane-runner.unit.test.ts
+++ b/packages/publisher/test/chain-event-lane-runner.unit.test.ts
@@ -930,7 +930,7 @@ describe('ChainEventPoller lane runner and cursors', () => {
     ]);
   });
 
-  it('uses an explicit lane failure-backoff policy', async () => {
+  it('uses an explicit lane failure-backoff policy and caps repeated failures', async () => {
     const filters: EventFilter[] = [];
     let calls = 0;
     let now = 0;
@@ -940,7 +940,7 @@ describe('ChainEventPoller lane runner and cursors', () => {
       listenForEvents: async function* (f: EventFilter): AsyncIterable<ChainEvent> {
         filters.push(f);
         calls++;
-        if (calls <= 2) throw new Error('rpc down');
+        if (calls <= 3) throw new Error('rpc down');
       },
     } as unknown as ChainAdapter;
     const lane: ChainEventPollerLaneSpec = {
@@ -969,8 +969,13 @@ describe('ChainEventPoller lane runner and cursors', () => {
     await runner.poll();
     now = 30;
     await runner.poll();
+    now = 54;
+    await runner.poll();
+    now = 55;
+    await runner.poll();
 
     expect(filters.map((f) => [f.fromBlock, f.toBlock])).toEqual([
+      [1, 100],
       [1, 100],
       [1, 100],
       [1, 100],

--- a/packages/publisher/test/chain-event-lane-runner.unit.test.ts
+++ b/packages/publisher/test/chain-event-lane-runner.unit.test.ts
@@ -3,6 +3,7 @@ import { OxigraphStore } from '@origintrail-official/dkg-storage';
 import { TypedEventBus } from '@origintrail-official/dkg-core';
 import type { ChainAdapter, ChainEvent, EventFilter } from '@origintrail-official/dkg-chain';
 import { ChainEventPoller, type ChainEventPollerLane, type LaneCursorPersistence } from '../src/chain-event-poller.js';
+import { ChainEventLaneRunner, type ChainEventPollerLaneSpec } from '../src/chain-event-lane-runner.js';
 import { PublishHandler } from '../src/publish-handler.js';
 import type { JournalEntry } from '../src/publish-journal.js';
 
@@ -926,6 +927,53 @@ describe('ChainEventPoller lane runner and cursors', () => {
     expect(saveCalls).toEqual([
       { lane: 'contextGraphDiscovery', block: 100 },
       { lane: 'contextGraphDiscovery', block: 200 },
+    ]);
+  });
+
+  it('uses an explicit lane failure-backoff policy', async () => {
+    const filters: EventFilter[] = [];
+    let calls = 0;
+    let now = 0;
+    const adapter = {
+      chainId: 'mock:0',
+      getBlockNumber: async () => 100,
+      listenForEvents: async function* (f: EventFilter): AsyncIterable<ChainEvent> {
+        filters.push(f);
+        calls++;
+        if (calls <= 2) throw new Error('rpc down');
+      },
+    } as unknown as ChainAdapter;
+    const lane: ChainEventPollerLaneSpec = {
+      name: 'contextGraphDiscovery',
+      enabled: () => true,
+      eventTypes: () => ['ContextGraphCreated'],
+      requiresFullHistory: () => false,
+      cadenceMs: 20,
+      failureBackoff: { initialMs: 10, maxMs: 25 },
+      dispatch: async () => { /* sink */ },
+    };
+    const runner = new ChainEventLaneRunner({
+      chain: adapter,
+      lanes: [lane],
+      maxRange: 1000,
+      clock: () => now,
+      log: { info() {}, warn() {}, error() {} } as any,
+    });
+
+    await runner.poll();
+    now = 9;
+    await runner.poll();
+    now = 10;
+    await runner.poll();
+    now = 29;
+    await runner.poll();
+    now = 30;
+    await runner.poll();
+
+    expect(filters.map((f) => [f.fromBlock, f.toBlock])).toEqual([
+      [1, 100],
+      [1, 100],
+      [1, 100],
     ]);
   });
 


### PR DESCRIPTION
## Summary

- Cuts the remaining steady idle `eth_getLogs` pressure by replacing ethers Hub event subscriptions with one adapter-owned, five-minute OR-topic Hub rotation poller. This removes four hidden polling subscriptions per adapter while preserving the same cache invalidation behavior for Hub rotations.
- Extracts the Hub rotation polling mechanics into a focused `HubRotationPoller` helper that owns topic construction, log polling, cursor/reorg buffering, in-flight suppression, and timer lifecycle.
- Preserves daemon context-graph historical discovery correctness: the permanent incremental watermark is still seeded only by a full historical registry scan, not by a bounded live-tail window.
- Adds failed-lane backoff in the publisher chain-event runner so a throttled or failing RPC does not retry the same `eth_getLogs` range on every scheduler tick.

## Related

- Chained on top of #1440
- Follow-up to the live testnet benchmark where `eth_getLogs` remained around 400-450/min on the first RPC-reduction PR branch

## Files changed

| File | What |
|------|------|
| `packages/chain/src/hub-rotation-poller.ts` | Adds the owned Hub rotation poller helper. |
| `packages/chain/src/evm-adapter-base.ts` | Wires the Hub poller into adapter lifecycle and keeps adapter-specific invalidation policy in the base. |
| `packages/chain/src/evm-adapter-context-graph.ts` | Keeps historical watermark seeding tied to full scans and incremental scans tied to real watermarks. |
| `packages/chain/src/chain-adapter.ts` | Removes the rejected live-tail scan option flags. |
| `packages/cli/src/daemon/lifecycle.ts` | Restores full-history daemon watermark seed options before incremental scans. |
| `packages/agent/src/dkg-agent.ts` | Simplifies context-graph chain scan option pass-through after removing live-tail mode. |
| `packages/publisher/src/chain-event-lane-runner.ts` | Adds exponential backoff and collapses lane scheduling onto one `nextRunAtMs` due-time gate. |
| `packages/publisher/src/chain-event-poller.ts` | Updates historical-recovery wording after review correction. |
| Tests | Cover historical seed discovery before watermark advancement, recurring Hub timer polling, lagging-head failover clamping, scan-mode selection, agent pass-through, and repeated-failure backoff/reset behavior. |

## Test plan

- [x] `git diff --check`
- [x] `pnpm --dir packages/cli exec vitest run test/chain-discovery-scan-mode.test.ts --reporter dot`
- [x] `pnpm --dir packages/chain exec vitest run --config vitest.unit.config.ts test/context-graph-registry-scan.unit.test.ts test/evm-adapter.unit.test.ts --reporter dot`
- [x] `pnpm --dir packages/chain exec vitest run --config vitest.unit.config.ts test/context-graph-registry-scan.unit.test.ts test/evm-adapter.unit.test.ts -t "ContextGraph|Hub rotation|pollHubRotationEvents|startHubRotationListener" --reporter dot`
- [x] Pure publisher lane-runner temp Vitest config: `21 passed`
- [x] `pnpm --dir packages/agent exec vitest run test/context-graph-discovery.test.ts -t "keeps full chain discovery" --reporter dot`
- [x] `pnpm --filter @origintrail-official/dkg-chain build`
- [x] `pnpm --filter @origintrail-official/dkg-publisher build`
- [x] `pnpm --filter @origintrail-official/dkg-agent build`
- [x] `pnpm --dir packages/cli run build`

## Expected RPC impact

The main steady-state reduction is eliminating hidden ethers `Contract.on(...)` log polling: Hub rotation detection goes from four continuous subscription pollers to one explicit `eth_getLogs` call every five minutes per adapter. Repeated lane failures now back off from 60s up to 5m instead of retrying each scheduler tick.

Daemon context-graph historical seed scans are intentionally preserved for correctness, so startup/reseed windows can still include full registry scan spikes. The expected quiet-window improvement should come primarily from removing hidden Hub subscription polling plus avoiding tight failure loops.
