### PR TITLE
test(node-ui): stabilize the flaky WM→SWM promote e2e (60s migration wait)

### DIFF
--- a/packages/node-ui/e2e/specs/devnet/wm-swm-vm-ui-cycle.devnet.spec.ts
+++ b/packages/node-ui/e2e/specs/devnet/wm-swm-vm-ui-cycle.devnet.spec.ts
@@ -216,9 +216,14 @@ test.describe('WM → SWM → VM via the UI', () => {
     // Migration contract (surface-independent): the assertion's content left
     // WM (blank nodes included), landed in SWM (root + skolemized children),
     // and the memoryLayer marker flipped to SWM.
+    // The promote UI reports success as soon as the request is accepted, but the
+    // WM→SWM store migration lands in oxigraph asynchronously; under a loaded CI
+    // devnet it can exceed 20s (Received: 0 / "Timeout 20000ms exceeded"). Poll to
+    // 60s — matching the VM-publish wait below — so this is a real migration
+    // assertion, not a race against store propagation.
     await expect(async () => {
       expect(await countRootInSharedMemory(run.cgId!, run.rootUri!)).toBeGreaterThan(0);
-    }).toPass({ timeout: 20_000, intervals: [500, 1000, 2000] });
+    }).toPass({ timeout: 60_000, intervals: [1000, 2000, 5000] });
 
     expect(
       await countBlankNodeTriplesInGraph(run.cgId!, run.dataGraph!),

--- a/packages/node-ui/e2e/specs/devnet/wm-swm-vm-ui-cycle.devnet.spec.ts
+++ b/packages/node-ui/e2e/specs/devnet/wm-swm-vm-ui-cycle.devnet.spec.ts
@@ -52,6 +52,13 @@ const FIXTURE = join(__dir, '..', '..', 'fixtures', 'single-entity-fixture.md');
 // assertion graph URI contains this substring.
 const FIXTURE_NAME_PART = 'single-entity-fixture';
 
+// Shared "wait for the async store migration to land in oxigraph" policy. Both
+// the WM→SWM promote and the SWM→VM publish accept the request immediately but
+// migrate content into the store asynchronously; under a loaded CI devnet that
+// can exceed a 20s poll, so both propagation assertions poll to 60s.
+// (not `as const` — Playwright's toPass expects a mutable `intervals: number[]`)
+const STORE_PROPAGATION_WAIT = { timeout: 60_000, intervals: [1000, 2000, 5000] };
+
 test.describe.configure({ mode: 'serial' });
 
 const run: {
@@ -217,13 +224,13 @@ test.describe('WM → SWM → VM via the UI', () => {
     // WM (blank nodes included), landed in SWM (root + skolemized children),
     // and the memoryLayer marker flipped to SWM.
     // The promote UI reports success as soon as the request is accepted, but the
-    // WM→SWM store migration lands in oxigraph asynchronously; under a loaded CI
-    // devnet it can exceed 20s (Received: 0 / "Timeout 20000ms exceeded"). Poll to
-    // 60s — matching the VM-publish wait below — so this is a real migration
-    // assertion, not a race against store propagation.
+    // WM→SWM store migration lands in oxigraph asynchronously and can exceed a 20s
+    // poll under a loaded CI devnet (Received: 0 / "Timeout 20000ms exceeded") — so
+    // this is a real migration assertion, not a race against store propagation.
+    // Uses the shared STORE_PROPAGATION_WAIT policy (same as the VM-publish wait).
     await expect(async () => {
       expect(await countRootInSharedMemory(run.cgId!, run.rootUri!)).toBeGreaterThan(0);
-    }).toPass({ timeout: 60_000, intervals: [1000, 2000, 5000] });
+    }).toPass(STORE_PROPAGATION_WAIT);
 
     expect(
       await countBlankNodeTriplesInGraph(run.cgId!, run.dataGraph!),
@@ -264,6 +271,6 @@ test.describe('WM → SWM → VM via the UI', () => {
     // verified by the API-driven sibling spec.
     await expect(async () => {
       expect(await countRootInVmScope(run.cgId!, run.rootUri!)).toBeGreaterThan(0);
-    }).toPass({ timeout: 60_000, intervals: [1000, 2000, 5000] });
+    }).toPass(STORE_PROPAGATION_WAIT);
   });
 });


### PR DESCRIPTION
## Summary

Stabilizes the flaky `wm-swm-vm-ui-cycle › promotes WM → SWM via the UI and the triples actually migrate` real-node devnet e2e test, which currently reddens `Kosava: node-ui e2e (Playwright real-node devnet)` on **main** and every open PR branched from it.

**It's a timing flake, not a code regression:**
- The promote UI genuinely succeeds — the "No triples were promoted" no-op assertion (the blank-node-DELETE bug guard) **passes**. The failure is the *next* step: `countRootInSharedMemory > 0` times out at 20 s with `Received: 0` (all 3 retries).
- The WM→SWM store migration lands in oxigraph **asynchronously** after the promote request is accepted; under a loaded CI devnet (this runs alongside 326 other specs) it can exceed the 20 s poll window, so the assertion races store propagation.
- Identical code passes and fails across runs (green on branch CI, red on the merge commit / re-runs) — the signature of a flake. The commit window that "introduced" it touches only PCA node-UI, nothing in the promote/SWM/SPARQL path.

**Fix:** bump the migration-landing poll `20s → 60s` with `[1000, 2000, 5000]` intervals — matching the VM-publish wait already present in the same file (line ~262). Test-only. It does **not** weaken the assertion: a promote that never migrates still fails (it just gives the async store migration realistic headroom under CI load).

## Related

- Unblocks any PR branched off the current main (e.g. #1453), whose e2e lane inherits this flake.

## Files changed

| File | What |
|------|------|
| `packages/node-ui/e2e/specs/devnet/wm-swm-vm-ui-cycle.devnet.spec.ts` | Migration-landing `toPass` timeout `20s → 60s` (`[1000,2000,5000]` intervals) + comment on the async SWM-propagation cause. |

## Test plan

- [ ] CI `Kosava: node-ui e2e (Playwright real-node devnet)` goes green (the previously-flaky spec passes with the migration allowed to land within 60 s).
- [ ] The rest of the e2e suite (326 specs) stays green — no behavior change, timeout-only.
