### PR TITLE
refactor(node-ui): consolidate approve signer planning into the owner-access model + close the snapshot-load lock (#1470, #1469)

### DIFF
--- a/packages/node-ui/src/ui/pages/conviction/ApproveWalletsModal.tsx
+++ b/packages/node-ui/src/ui/pages/conviction/ApproveWalletsModal.tsx
@@ -7,6 +7,7 @@ import {
 } from '../../api.js';
 import { useOwnerActionSubmitter, useOwnerActionSubmitterForAccount, resolveSignerKindForAccount } from '../../pca/ownerActions.js';
 import { usePcaOwnerAccess } from '../../pca/usePcaOwnerAccess.js';
+import { mayTargetWritePromptWallet, resolvePrimaryWalletState } from '../../pca/ownerAccess.js';
 import { resolveWalletBinding, planSelfCoverage, signableOwnersFor } from '../../pca/walletBinding.js';
 import {
   approveBatchReducer,
@@ -25,7 +26,7 @@ import {
   SponsorshipHandshake,
   CopyButton,
 } from '../../components/Pca/index.js';
-import { useWalletStore } from '../../stores/wallet.js';
+import { isWrongNetwork, useWalletStore } from '../../stores/wallet.js';
 
 const ADDR_RE = /^0x[0-9a-fA-F]{40}$/;
 
@@ -83,6 +84,7 @@ export function ApproveWalletsModal({
   const nodeWallets = wb?.wallets ?? [];
   const ownerWallet = nodeWallets[0]; // the daemon EOA — what it can deregister-from
   const connectedWallet = useWalletStore((s) => s.address);
+  const walletWrongNetwork = useWalletStore((s) => isWrongNetwork(s));
   // #1375 — the shared owner-access model for THIS account (drives the managed-target display
   // predicate + the signer candidates). The async, per-account cross-account signer classification
   // now lives in `resolveSignerKindForAccount` (a separate re-fetching seam, inv-16 / P4).
@@ -91,7 +93,7 @@ export function ApproveWalletsModal({
   // PCA as external → pin read-only → fail a valid owner approval. Marking it 'loading'/'unreadable'
   // (⇒ mode 'unknown') routes the resolved submitter through the re-fetching path (which self-heals
   // to daemon once wallets[0] is readable).
-  const primaryWalletState: 'loading' | 'unreadable' | 'ready' = wb ? 'ready' : wbError ? 'unreadable' : 'loading';
+  const primaryWalletState = resolvePrimaryWalletState(wb, wbError);
   const access = usePcaOwnerAccess({ owner: snapshot?.owner, primaryWallet: ownerWallet, primaryWalletState });
   // Item 3 (#1375) — resolve THIS account's owner submitter ONCE from `access`, so the batch's
   // registerAgent (ALWAYS on the TARGET) submits directly with no per-write owner/wallet re-fetch.
@@ -176,12 +178,12 @@ export function ApproveWalletsModal({
   const addresses = mode === 'self' ? selfSelected : parsed.valid;
   const overCap = addresses.length > cap;
   // R4 (#1468) + #1469 — arm the batch's device-progress + cancel/dismiss lock whenever the TARGET
-  // write could open a browser-wallet signature. This is now the single `access.mayPromptWallet`
-  // signing-plan flag (owner-access model): the loaded wallet-owned case AND the load window
+  // write could open a browser-wallet signature. `mayTargetWritePromptWallet` is the pure signing-
+  // plan helper OVER the owner-access model: the loaded wallet-owned case AND the load window
   // (mode 'unknown' with a connected wallet whose address is — or may turn out to be — the owner).
   // runApproveBatch sets `walletBatchSigning`/deviceTotal BEFORE the in-flight wallet action, so a
   // wallet-signed approve never runs under the daemon (no-prompt, freely-dismissable) contract.
-  const targetWalletManaged = access.mayPromptWallet;
+  const targetWalletManaged = mayTargetWritePromptWallet(access, snapshot?.owner, connectedWallet);
   const signableOwners = signableOwnersFor(ownerWallet, connectedWallet);
 
   const run = async () => {
@@ -205,7 +207,8 @@ export function ApproveWalletsModal({
         // Pass this node's already-loaded primary wallet (wallets[0]) so the signer-kind planning
         // stays correlated with the OLD inline predicate — no uncorrelated wallets re-fetch that
         // could disarm the R4 lock on a transient blip (gate finding).
-        signerKindForAccount: (id?: string) => resolveSignerKindForAccount(id, ownerWallet),
+        signerKindForAccount: (id?: string) =>
+          resolveSignerKindForAccount({ accountId: id, primaryWallet: ownerWallet, connectedWallet, walletWrongNetwork }),
         probePca: fetchPca,
         describePcaError,
         onApproved,

--- a/packages/node-ui/src/ui/pages/conviction/ApproveWalletsModal.tsx
+++ b/packages/node-ui/src/ui/pages/conviction/ApproveWalletsModal.tsx
@@ -5,7 +5,7 @@ import {
   fetchPca,
   describePcaError,
 } from '../../api.js';
-import { useOwnerActionSubmitter, useOwnerActionSubmitterForAccount, resolveSignerKindForAccount } from '../../pca/ownerActions.js';
+import { usePinnedOwnerActionSubmitter, useResolvingOwnerActionSubmitter, resolveSignerKindForAccount } from '../../pca/ownerActions.js';
 import { usePcaOwnerAccess } from '../../pca/usePcaOwnerAccess.js';
 import { mayTargetWritePromptWallet, resolvePrimaryWalletState } from '../../pca/ownerAccess.js';
 import { resolveWalletBinding, planSelfCoverage, signableOwnersFor } from '../../pca/walletBinding.js';
@@ -80,7 +80,7 @@ export function ApproveWalletsModal({
   // Renew — the OLD account's owner-action submitter (free the wallet there first). Resolved
   // separately, via the async re-fetching path, because the old PCA can have a different
   // owner/signing branch than THIS account.
-  const deregisterOwner = useOwnerActionSubmitterForAccount({ accountId: deregisterFrom });
+  const deregisterOwner = useResolvingOwnerActionSubmitter();
   const nodeWallets = wb?.wallets ?? [];
   const ownerWallet = nodeWallets[0]; // the daemon EOA — what it can deregister-from
   const connectedWallet = useWalletStore((s) => s.address);
@@ -98,13 +98,13 @@ export function ApproveWalletsModal({
   // Item 3 (#1375) — resolve THIS account's owner submitter ONCE from `access`, so the batch's
   // registerAgent (ALWAYS on the TARGET) submits directly with no per-write owner/wallet re-fetch.
   // The wallet branch keeps its per-prompt loadContext / assertStillConnected liveness guards.
-  const owner = useOwnerActionSubmitter({ access });
+  const owner = usePinnedOwnerActionSubmitter({ access });
   // Self-coverage's deregisterSelf frees a wallet from its OWN-bound `prevAccountId`, which VARIES
   // per wallet and can be owned DIFFERENTLY than THIS target (daemon vs connected wallet). So it
   // must resolve the submitter PER-ACCOUNT (the resolving path, keyed on the passed accountId) —
   // the access-path `owner` would misroute it to the target's signer → NotAccountOwner revert. No
   // onWalletProgress: the batch drives its own device prompts.
-  const crossAccountDeregister = useOwnerActionSubmitterForAccount({});
+  const crossAccountDeregister = useResolvingOwnerActionSubmitter();
   const agentCount = snapshot?.agentCount ?? 0;
   const cap = Math.max(0, 100 - agentCount);
 

--- a/packages/node-ui/src/ui/pages/conviction/ApproveWalletsModal.tsx
+++ b/packages/node-ui/src/ui/pages/conviction/ApproveWalletsModal.tsx
@@ -5,7 +5,7 @@ import {
   fetchPca,
   describePcaError,
 } from '../../api.js';
-import { useResolvedOwnerActionSubmitter, useResolvingOwnerActionSubmitter } from '../../pca/ownerActions.js';
+import { useOwnerActionSubmitter, useOwnerActionSubmitterForAccount, resolveSignerKindForAccount } from '../../pca/ownerActions.js';
 import { usePcaOwnerAccess } from '../../pca/usePcaOwnerAccess.js';
 import { resolveWalletBinding, planSelfCoverage, signableOwnersFor } from '../../pca/walletBinding.js';
 import {
@@ -25,8 +25,7 @@ import {
   SponsorshipHandshake,
   CopyButton,
 } from '../../components/Pca/index.js';
-import { isWrongNetwork, useWalletStore } from '../../stores/wallet.js';
-import { eqAddress as sameAddress } from '../../pca/address.js';
+import { useWalletStore } from '../../stores/wallet.js';
 
 const ADDR_RE = /^0x[0-9a-fA-F]{40}$/;
 
@@ -75,35 +74,35 @@ export function ApproveWalletsModal({
    */
   selfCoverage?: boolean;
 }) {
-  const { data: wb } = useFetch(fetchWalletsBalances, [], 0);
+  const { data: wb, error: wbError } = useFetch(fetchWalletsBalances, [], 0);
   const { data: snapshot } = useFetch(() => fetchPca(accountId), [accountId]);
   // Renew — the OLD account's owner-action submitter (free the wallet there first). Resolved
   // separately, via the async re-fetching path, because the old PCA can have a different
   // owner/signing branch than THIS account.
-  const deregisterOwner = useResolvingOwnerActionSubmitter({ accountId: deregisterFrom });
+  const deregisterOwner = useOwnerActionSubmitterForAccount({ accountId: deregisterFrom });
   const nodeWallets = wb?.wallets ?? [];
   const ownerWallet = nodeWallets[0]; // the daemon EOA — what it can deregister-from
   const connectedWallet = useWalletStore((s) => s.address);
-  const walletWrongNetwork = useWalletStore((s) => isWrongNetwork(s));
   // #1375 — the shared owner-access model for THIS account (drives the managed-target display
-  // predicate + the signer candidates). The async, per-account signerKindForAccount below
-  // deliberately stays a separate re-fetching seam (inv-16 / P4).
-  // `walletsUnknown` while the wallet balances are still loading: without it, a snapshot that
-  // loads BEFORE the wallets would see owner + an undefined primaryWallet and misclassify a
-  // daemon-owned PCA as external → pin read-only → fail a valid owner approval. Marking it
-  // unknown routes the resolved submitter through the re-fetching path (which self-heals to
-  // daemon once wallets[0] is readable).
-  const access = usePcaOwnerAccess({ owner: snapshot?.owner, primaryWallet: ownerWallet, walletsUnknown: !wb });
+  // predicate + the signer candidates). The async, per-account cross-account signer classification
+  // now lives in `resolveSignerKindForAccount` (a separate re-fetching seam, inv-16 / P4).
+  // `primaryWalletState` while the wallet balances load/fail: without it, a snapshot that loads
+  // BEFORE the wallets would see owner + an undefined primaryWallet and misclassify a daemon-owned
+  // PCA as external → pin read-only → fail a valid owner approval. Marking it 'loading'/'unreadable'
+  // (⇒ mode 'unknown') routes the resolved submitter through the re-fetching path (which self-heals
+  // to daemon once wallets[0] is readable).
+  const primaryWalletState: 'loading' | 'unreadable' | 'ready' = wb ? 'ready' : wbError ? 'unreadable' : 'loading';
+  const access = usePcaOwnerAccess({ owner: snapshot?.owner, primaryWallet: ownerWallet, primaryWalletState });
   // Item 3 (#1375) — resolve THIS account's owner submitter ONCE from `access`, so the batch's
   // registerAgent (ALWAYS on the TARGET) submits directly with no per-write owner/wallet re-fetch.
   // The wallet branch keeps its per-prompt loadContext / assertStillConnected liveness guards.
-  const owner = useResolvedOwnerActionSubmitter({ access });
+  const owner = useOwnerActionSubmitter({ access });
   // Self-coverage's deregisterSelf frees a wallet from its OWN-bound `prevAccountId`, which VARIES
   // per wallet and can be owned DIFFERENTLY than THIS target (daemon vs connected wallet). So it
   // must resolve the submitter PER-ACCOUNT (the resolving path, keyed on the passed accountId) —
   // the access-path `owner` would misroute it to the target's signer → NotAccountOwner revert. No
   // onWalletProgress: the batch drives its own device prompts.
-  const crossAccountDeregister = useResolvingOwnerActionSubmitter({});
+  const crossAccountDeregister = useOwnerActionSubmitterForAccount({});
   const agentCount = snapshot?.agentCount ?? 0;
   const cap = Math.max(0, 100 - agentCount);
 
@@ -176,28 +175,14 @@ export function ApproveWalletsModal({
   );
   const addresses = mode === 'self' ? selfSelected : parsed.valid;
   const overCap = addresses.length > cap;
-  // R4 (#1468) — arm the batch's device-progress + cancel/dismiss lock whenever the TARGET write
-  // could open a browser-wallet signature. `access.mode === 'wallet'` covers the loaded case, but
-  // during the wallet-balances load window the target access is `unknown` (the walletsUnknown
-  // self-heal above), yet the resolved submitter re-fetches and STILL routes the target write to
-  // the wallet signer when the owner is the connected wallet. Counting it managed here makes
-  // runApproveBatch set `walletBatchSigning`/deviceTotal BEFORE that in-flight wallet action —
-  // never run a wallet-signed approve under the daemon (no-prompt, freely-dismissable) contract.
-  // Daemon-owned targets (owner == wallets[0], normally != the connected wallet) are unaffected;
-  // the rare owner==primary==connected case merely shows a device row that confirms instantly.
-  const targetWalletManaged =
-    (access.mode === 'wallet' && access.writesEnabled) ||
-    (access.mode === 'unknown' && sameAddress(snapshot?.owner, connectedWallet));
+  // R4 (#1468) + #1469 — arm the batch's device-progress + cancel/dismiss lock whenever the TARGET
+  // write could open a browser-wallet signature. This is now the single `access.mayPromptWallet`
+  // signing-plan flag (owner-access model): the loaded wallet-owned case AND the load window
+  // (mode 'unknown' with a connected wallet whose address is — or may turn out to be — the owner).
+  // runApproveBatch sets `walletBatchSigning`/deviceTotal BEFORE the in-flight wallet action, so a
+  // wallet-signed approve never runs under the daemon (no-prompt, freely-dismissable) contract.
+  const targetWalletManaged = access.mayPromptWallet;
   const signableOwners = signableOwnersFor(ownerWallet, connectedWallet);
-
-  const signerKindForAccount = async (id?: string): Promise<'daemon' | 'wallet' | undefined> => {
-    if (!id) return undefined;
-    const oldSnapshot = await fetchPca(id).catch(() => null);
-    if (!oldSnapshot?.owner) return undefined;
-    if (sameAddress(oldSnapshot.owner, ownerWallet)) return 'daemon';
-    if (connectedWallet && !walletWrongNetwork && sameAddress(oldSnapshot.owner, connectedWallet)) return 'wallet';
-    return undefined;
-  };
 
   const run = async () => {
     // U1 — do NOT hard-block on the raw count > cap: already-approved-here addresses
@@ -217,7 +202,10 @@ export function ApproveWalletsModal({
         deregisterSelf: crossAccountDeregister.deregisterAgent,
         resolveWalletBinding,
         planSelfCoverage,
-        signerKindForAccount,
+        // Pass this node's already-loaded primary wallet (wallets[0]) so the signer-kind planning
+        // stays correlated with the OLD inline predicate — no uncorrelated wallets re-fetch that
+        // could disarm the R4 lock on a transient blip (gate finding).
+        signerKindForAccount: (id?: string) => resolveSignerKindForAccount(id, ownerWallet),
         probePca: fetchPca,
         describePcaError,
         onApproved,

--- a/packages/node-ui/src/ui/pages/conviction/ConvictionDetailView.tsx
+++ b/packages/node-ui/src/ui/pages/conviction/ConvictionDetailView.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useFetch } from '../../hooks.js';
 import { fetchPca, fetchWalletsBalances, type PcaSnapshot } from '../../api.js';
-import { useOwnerActionSubmitter } from '../../pca/ownerActions.js';
+import { usePinnedOwnerActionSubmitter } from '../../pca/ownerActions.js';
 import { useWalletTxProgress } from '../../pca/useWalletTxProgress.js';
 import { useWalletBootstrap } from '../../hooks/useWalletBootstrap.js';
 import { detailDeviceFlow, describeDetailWalletError, type DetailDeviceAction } from '../../pca/detailWalletTx.js';
@@ -160,7 +160,7 @@ function DetailBody({
     flow: (v) => detailDeviceFlow(v ?? 'topup'),
     describeActionError: (err, v) => describeDetailWalletError(err, v ?? 'topup'),
   });
-  const owner = useOwnerActionSubmitter({
+  const owner = usePinnedOwnerActionSubmitter({
     // Item 3 (#1375) — resolve the owner submitter ONCE from `access` for THIS account. daemon
     // pins (server-side); a wallet-owned account re-verifies ownership per write (T1). Wallet
     // device progress flows through onWalletProgress; the submitter liveness stays per-prompt.

--- a/packages/node-ui/src/ui/pages/conviction/ConvictionDetailView.tsx
+++ b/packages/node-ui/src/ui/pages/conviction/ConvictionDetailView.tsx
@@ -23,7 +23,7 @@ import { FundingSection } from './FundingSection.js';
 import { PublishingWalletsSection } from './PublishingWalletsSection.js';
 import { LifecycleSection } from './LifecycleSection.js';
 import { eqAddress } from '../../pca/address.js';
-import type { PcaOwnerAccess } from '../../pca/ownerAccess.js';
+import { resolvePrimaryWalletState, type PcaOwnerAccess } from '../../pca/ownerAccess.js';
 import { usePcaOwnerAccess } from '../../pca/usePcaOwnerAccess.js';
 
 function formatExpiryTileValue(expiresAtTimestamp?: number): string {
@@ -51,7 +51,7 @@ export function ConvictionDetailView({ accountId }: { accountId: string }) {
   // "loading" (mode 'unknown'), NOT a read-only/external flash, while the balances fetch is in
   // flight. L3: a balances READ FAILURE (wb null + error) still classifies unknown ('unreadable') —
   // the owner controls read "can't confirm ownership" + Retry, never a definitive non-owner.
-  const primaryWalletState: 'loading' | 'unreadable' | 'ready' = wb ? 'ready' : wbError ? 'unreadable' : 'loading';
+  const primaryWalletState = resolvePrimaryWalletState(wb, wbError);
   // #1375 — the single owner-access model. Called before the early returns (Rules of
   // Hooks); while the snapshot is still loading `owner` is undefined and this render path
   // returns early below, so the resulting access is never consumed on that path.

--- a/packages/node-ui/src/ui/pages/conviction/ConvictionDetailView.tsx
+++ b/packages/node-ui/src/ui/pages/conviction/ConvictionDetailView.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useFetch } from '../../hooks.js';
 import { fetchPca, fetchWalletsBalances, type PcaSnapshot } from '../../api.js';
-import { useResolvedOwnerActionSubmitter } from '../../pca/ownerActions.js';
+import { useOwnerActionSubmitter } from '../../pca/ownerActions.js';
 import { useWalletTxProgress } from '../../pca/useWalletTxProgress.js';
 import { useWalletBootstrap } from '../../hooks/useWalletBootstrap.js';
 import { detailDeviceFlow, describeDetailWalletError, type DetailDeviceAction } from '../../pca/detailWalletTx.js';
@@ -47,14 +47,15 @@ export function ConvictionDetailView({ accountId }: { accountId: string }) {
   const explorer = nodeStatus?.blockExplorerUrl ?? null;
   const connectedWallet = useWalletStore((s) => s.address);
   const wallets = wb?.wallets ?? [];
-  // L3: a transient balances blip (wb null + error) must NOT reclassify
-  // owned→not-owner and flicker the owner controls into a definitive "you're not
-  // the owner" — show "can't confirm" instead and keep the retry.
-  const walletsUnknown = !wb && !!wbError;
+  // The wallet-list load state (#1470): split loading from unreadable so a daemon PCA shows
+  // "loading" (mode 'unknown'), NOT a read-only/external flash, while the balances fetch is in
+  // flight. L3: a balances READ FAILURE (wb null + error) still classifies unknown ('unreadable') —
+  // the owner controls read "can't confirm ownership" + Retry, never a definitive non-owner.
+  const primaryWalletState: 'loading' | 'unreadable' | 'ready' = wb ? 'ready' : wbError ? 'unreadable' : 'loading';
   // #1375 — the single owner-access model. Called before the early returns (Rules of
   // Hooks); while the snapshot is still loading `owner` is undefined and this render path
   // returns early below, so the resulting access is never consumed on that path.
-  const access = usePcaOwnerAccess({ owner: snapshot?.owner, primaryWallet: wallets[0], walletsUnknown });
+  const access = usePcaOwnerAccess({ owner: snapshot?.owner, primaryWallet: wallets[0], primaryWalletState });
 
   useWalletBootstrap();
 
@@ -73,21 +74,30 @@ export function ConvictionDetailView({ accountId }: { accountId: string }) {
   }
 
   const ownerInPool = wallets.some((w) => eqAddress(w, snapshot.owner));
+  // Owner can't be classified because this node's wallet list is loading or unreadable (#1470).
+  // `owner` is present here (past the snapshot early-returns), so this is never the no-snapshot
+  // cause — split the two so a still-LOADING read shows a neutral "confirming ownership" affordance
+  // (no false "Couldn't load", no Retry), while a FAILED read keeps the "can't confirm" + Retry.
+  // Both stay `unknown` (never a definitive read-only/external verdict — the daemon-flash fix).
+  const walletsLoading = access.ownerUnknownCause === 'wallets-loading';
+  const walletsUnreadable = access.ownerUnknownCause === 'wallets-unreadable';
 
   // gateReason stays consumer-built for now (model gateReason deferred to a later step): the
   // exact same branches, re-expressed on access.mode / access.wrongNetwork — identical values
   // to the old ownerMode / walletWrongNetwork now that both come from the one model.
-  const ownerGateReason = walletsUnknown
+  const ownerGateReason = walletsLoading
+    ? `Confirming ownership of PCA #${accountId}…`
+    : walletsUnreadable
     ? `Couldn't load this node's wallets - can't confirm ownership of PCA #${accountId}.`
     : access.mode === 'wallet' && access.wrongNetwork
-      ? `Wrong network - switch the connected wallet to this node's PCA network to manage PCA #${accountId}.`
-      : access.mode === 'wallet'
-        ? `Connected wallet ${snapshot.owner} owns PCA #${accountId}; device-signed owner actions are enabled.`
-        : ownerInPool
-          ? `Owner-only - PCA #${accountId} is owned by ${snapshot.owner}, not this node's primary operational wallet, so node-UI can't sign for it.`
-          : connectedWallet
-            ? `Owner-only - connected as ${connectedWallet}; switch to ${snapshot.owner} to manage PCA #${accountId}.`
-            : `Owner-only - connect ${snapshot.owner} to manage PCA #${accountId}.`;
+    ? `Wrong network - switch the connected wallet to this node's PCA network to manage PCA #${accountId}.`
+    : access.mode === 'wallet'
+    ? `Connected wallet ${snapshot.owner} owns PCA #${accountId}; device-signed owner actions are enabled.`
+    : ownerInPool
+    ? `Owner-only - PCA #${accountId} is owned by ${snapshot.owner}, not this node's primary operational wallet, so node-UI can't sign for it.`
+    : connectedWallet
+    ? `Owner-only - connected as ${connectedWallet}; switch to ${snapshot.owner} to manage PCA #${accountId}.`
+    : `Owner-only - connect ${snapshot.owner} to manage PCA #${accountId}.`;
 
   return (
     <DetailBody
@@ -99,7 +109,8 @@ export function ConvictionDetailView({ accountId }: { accountId: string }) {
       access={access}
       connectedWallet={connectedWallet}
       ownerOnlyReason={ownerGateReason}
-      walletsUnknown={walletsUnknown}
+      walletsLoading={walletsLoading}
+      walletsUnreadable={walletsUnreadable}
       onRetryWallets={refreshWallets}
       refresh={refresh}
     />
@@ -115,7 +126,8 @@ function DetailBody({
   access,
   connectedWallet,
   ownerOnlyReason,
-  walletsUnknown,
+  walletsLoading,
+  walletsUnreadable,
   onRetryWallets,
   refresh,
 }: {
@@ -127,7 +139,10 @@ function DetailBody({
   access: PcaOwnerAccess;
   connectedWallet?: string | null;
   ownerOnlyReason: string;
-  walletsUnknown: boolean;
+  /** Wallet list still loading (owner unconfirmed) → neutral affordance, no Retry. */
+  walletsLoading: boolean;
+  /** Wallet list read FAILED (owner unconfirmable) → "can't confirm" + Retry. */
+  walletsUnreadable: boolean;
   onRetryWallets: () => void;
   refresh: () => void;
 }) {
@@ -145,7 +160,7 @@ function DetailBody({
     flow: (v) => detailDeviceFlow(v ?? 'topup'),
     describeActionError: (err, v) => describeDetailWalletError(err, v ?? 'topup'),
   });
-  const owner = useResolvedOwnerActionSubmitter({
+  const owner = useOwnerActionSubmitter({
     // Item 3 (#1375) — resolve the owner submitter ONCE from `access` for THIS account. daemon
     // pins (server-side); a wallet-owned account re-verifies ownership per write (T1). Wallet
     // device progress flows through onWalletProgress; the submitter liveness stays per-prompt.
@@ -192,14 +207,21 @@ function DetailBody({
       )}
 
       {!access.writesEnabled && (
-        <div className="v10-modal-warning" role="status">
-          ⓘ {ownerOnlyReason}{' '}
-          {walletsUnknown ? (
-            <button type="button" className="v10-pca-card-btn" onClick={onRetryWallets}>Retry</button>
-          ) : (
-            'Wallet probe stays available.'
-          )}
-        </div>
+        // Pure LOADING window (#1470): a neutral "confirming ownership" tip — no false "Couldn't
+        // load", no Retry (the balances are auto-fetching); owner controls stay disabled for the
+        // brief window. FAILED/EXTERNAL/wrong-network keep the warning box (+ Retry when unreadable).
+        walletsLoading ? (
+          <div className="v10-modal-tip" role="status">{ownerOnlyReason}</div>
+        ) : (
+          <div className="v10-modal-warning" role="status">
+            ⓘ {ownerOnlyReason}{' '}
+            {walletsUnreadable ? (
+              <button type="button" className="v10-pca-card-btn" onClick={onRetryWallets}>Retry</button>
+            ) : (
+              'Wallet probe stays available.'
+            )}
+          </div>
+        )
       )}
 
       <StatStrip

--- a/packages/node-ui/src/ui/pages/conviction/CreatePcaModal.tsx
+++ b/packages/node-ui/src/ui/pages/conviction/CreatePcaModal.tsx
@@ -9,7 +9,7 @@ import {
   type CreatePcaResult,
   type PcaSnapshot,
 } from '../../api.js';
-import { useOwnerActionSubmitterForAccount, type OwnerKey } from '../../pca/ownerActions.js';
+import { useResolvingOwnerActionSubmitter, type OwnerKey } from '../../pca/ownerActions.js';
 import { probeWalletBindings, selfCoverageOutlook } from '../../pca/walletBinding.js';
 import { useDesignatableNodes } from '../../hooks/useDesignatableNodes.js';
 import { usePrimaryNodeSelection } from '../../hooks/usePrimaryNodeSelection.js';
@@ -117,7 +117,7 @@ export function CreatePcaModal({
     },
     flow: () => ({ requiresApproval: true, actionLabel: 'Sign Create PCA' }),
   });
-  const owner = useOwnerActionSubmitterForAccount({ ownerKey, onWalletProgress: createProgress.onProgress });
+  const owner = useResolvingOwnerActionSubmitter({ ownerKey, onWalletProgress: createProgress.onProgress });
   const finishCreate = usePcaStore((s) => s.finishCreate);
   const setCreatePending = usePcaStore((s) => s.setCreatePending);
   const clearCreatePending = usePcaStore((s) => s.clearCreatePending);

--- a/packages/node-ui/src/ui/pages/conviction/CreatePcaModal.tsx
+++ b/packages/node-ui/src/ui/pages/conviction/CreatePcaModal.tsx
@@ -9,7 +9,7 @@ import {
   type CreatePcaResult,
   type PcaSnapshot,
 } from '../../api.js';
-import { useResolvingOwnerActionSubmitter, type OwnerKey } from '../../pca/ownerActions.js';
+import { useOwnerActionSubmitterForAccount, type OwnerKey } from '../../pca/ownerActions.js';
 import { probeWalletBindings, selfCoverageOutlook } from '../../pca/walletBinding.js';
 import { useDesignatableNodes } from '../../hooks/useDesignatableNodes.js';
 import { usePrimaryNodeSelection } from '../../hooks/usePrimaryNodeSelection.js';
@@ -117,7 +117,7 @@ export function CreatePcaModal({
     },
     flow: () => ({ requiresApproval: true, actionLabel: 'Sign Create PCA' }),
   });
-  const owner = useResolvingOwnerActionSubmitter({ ownerKey, onWalletProgress: createProgress.onProgress });
+  const owner = useOwnerActionSubmitterForAccount({ ownerKey, onWalletProgress: createProgress.onProgress });
   const finishCreate = usePcaStore((s) => s.finishCreate);
   const setCreatePending = usePcaStore((s) => s.setCreatePending);
   const clearCreatePending = usePcaStore((s) => s.clearCreatePending);

--- a/packages/node-ui/src/ui/pca/ownerAccess.ts
+++ b/packages/node-ui/src/ui/pca/ownerAccess.ts
@@ -33,9 +33,11 @@ export type PcaOwnerMode = 'daemon' | 'wallet' | 'external' | 'unknown';
  * Why the owner couldn't be classified. Kept distinct because the consumers word them
  * differently: `no-snapshot` = the PCA snapshot (owner) isn't loaded (ConvictionOverview's
  * `!owner`); `wallets-unreadable` = the node's own wallet list failed to read, so ownership
- * can't be confirmed (ConvictionDetailView's `walletsUnknown`).
+ * can't be confirmed; `wallets-loading` = the node's wallet list is still loading (the load
+ * window), split out of `wallets-unreadable` so a daemon PCA shows loading (not read-only)
+ * while the balances fetch is in flight.
  */
-export type PcaOwnerUnknownCause = 'no-snapshot' | 'wallets-unreadable';
+export type PcaOwnerUnknownCause = 'no-snapshot' | 'wallets-unreadable' | 'wallets-loading';
 
 export interface PcaOwnerAccessInput {
   /** The on-chain PCA owner. Absent/empty ⇒ `unknown` (`no-snapshot`). */
@@ -46,8 +48,13 @@ export interface PcaOwnerAccessInput {
   connectedWallet?: string | null;
   /** The connected wallet is on a chain other than the node's PCA network (raw fact). */
   walletWrongNetwork?: boolean;
-  /** This node's wallet list failed to read ⇒ `unknown` (`wallets-unreadable`). */
-  walletsUnknown?: boolean;
+  /**
+   * The load state of this node's wallet list (`wallets[0]` = the daemon signer). `'loading'`
+   * ⇒ `unknown` (`wallets-loading`); `'unreadable'` ⇒ `unknown` (`wallets-unreadable`); `'ready'`
+   * (the default when omitted) ⇒ classify the owner normally. Split out of the former
+   * `walletsUnknown` boolean so a daemon PCA shows loading (not read-only) during the fetch.
+   */
+  primaryWalletState?: 'loading' | 'unreadable' | 'ready';
 }
 
 /**
@@ -65,6 +72,15 @@ export interface PcaOwnerAccess {
   writesEnabled: boolean;
   /** Present only when `mode === 'unknown'`; names which read is missing. */
   ownerUnknownCause?: PcaOwnerUnknownCause;
+  /**
+   * The target-write signing plan: could an owner write open a browser-wallet signature? True
+   * when the owner is a loaded wallet on the right network, OR — during a load window (`mode`
+   * still `unknown`) — a wallet is connected and the owner is either not-yet-known (#1469) or
+   * equals the connected wallet (subsumes R4). Safe-direction over-arm; the resolving submitter
+   * refuses read-only / daemon-confirms once the re-fetched owner is known. See
+   * `computeMayPromptWallet`.
+   */
+  mayPromptWallet: boolean;
 }
 
 /**
@@ -78,6 +94,28 @@ export function ownerModeWritesEnabled(mode: PcaOwnerMode, wrongNetwork: boolean
 }
 
 /**
+ * The target-write signing plan — could an owner write open a browser-wallet signature? The
+ * single source `ApproveWalletsModal.targetWalletManaged` reads.
+ *  - Clause 1: a loaded wallet-owned PCA on the right network (`mode === 'wallet' && writesEnabled`).
+ *  - Clause 2: a load window (`mode === 'unknown'` — loading / unreadable / no-snapshot) with a
+ *    connected wallet, when the owner is not-yet-known (`!owner` ⇒ closes #1469) or equals the
+ *    connected wallet (subsumes the R4 fix).
+ * Safe-direction over-arm: NOT gated on wrong-network (render→click network flips are re-checked
+ * call-time by the wallet submitter, inv-16), and the resolving submitter refuses read-only /
+ * daemon-confirms instantly once the re-fetched owner turns out not to be the connected wallet.
+ */
+function computeMayPromptWallet(
+  mode: PcaOwnerMode,
+  owner: string | null | undefined,
+  connectedWallet: string | null | undefined,
+  writesEnabled: boolean,
+): boolean {
+  if (mode === 'wallet' && writesEnabled) return true;
+  if (mode === 'unknown') return !!connectedWallet && (!owner || eqAddress(owner, connectedWallet));
+  return false;
+}
+
+/**
  * The one pure owner-access classifier. Sync, side-effect-free, and the single encoding of
  * inv-17 + the wrong-network gate. Both faces of the model (the sync display hook below and
  * the async re-fetching submitter resolver) reduce to this.
@@ -88,17 +126,39 @@ export function resolvePcaOwnerAccess(input: PcaOwnerAccessInput): PcaOwnerAcces
     primaryWallet,
     connectedWallet,
     walletWrongNetwork = false,
-    walletsUnknown = false,
+    primaryWalletState = 'ready',
   } = input;
 
-  // Unknown carve-outs (OUTSIDE inv-17 precedence), causes kept distinct. `walletsUnknown`
-  // is checked FIRST to mirror the detail view, which gates on "couldn't read this node's
-  // wallets" before it ever classifies the owner.
-  if (walletsUnknown) {
-    return { mode: 'unknown', wrongNetwork: walletWrongNetwork, writesEnabled: false, ownerUnknownCause: 'wallets-unreadable' };
+  // Unknown carve-outs (OUTSIDE inv-17 precedence), causes kept distinct. The wallet-list load
+  // state is checked FIRST to mirror the detail view, which gates on "couldn't read / still
+  // reading this node's wallets" before it ever classifies the owner. `'loading'` is split from
+  // `'unreadable'` so a daemon PCA shows loading (not read-only) while the balances fetch runs.
+  if (primaryWalletState === 'loading') {
+    return {
+      mode: 'unknown',
+      wrongNetwork: walletWrongNetwork,
+      writesEnabled: false,
+      ownerUnknownCause: 'wallets-loading',
+      mayPromptWallet: computeMayPromptWallet('unknown', owner, connectedWallet, false),
+    };
+  }
+  if (primaryWalletState === 'unreadable') {
+    return {
+      mode: 'unknown',
+      wrongNetwork: walletWrongNetwork,
+      writesEnabled: false,
+      ownerUnknownCause: 'wallets-unreadable',
+      mayPromptWallet: computeMayPromptWallet('unknown', owner, connectedWallet, false),
+    };
   }
   if (!owner) {
-    return { mode: 'unknown', wrongNetwork: walletWrongNetwork, writesEnabled: false, ownerUnknownCause: 'no-snapshot' };
+    return {
+      mode: 'unknown',
+      wrongNetwork: walletWrongNetwork,
+      writesEnabled: false,
+      ownerUnknownCause: 'no-snapshot',
+      mayPromptWallet: computeMayPromptWallet('unknown', owner, connectedWallet, false),
+    };
   }
 
   // inv-17 precedence — byte-for-byte from detailOwnerMode / the async classifier
@@ -115,8 +175,9 @@ export function resolvePcaOwnerAccess(input: PcaOwnerAccessInput): PcaOwnerAcces
 
   const wrongNetwork = walletWrongNetwork;
   const writesEnabled = ownerModeWritesEnabled(mode, wrongNetwork);
+  const mayPromptWallet = computeMayPromptWallet(mode, owner, connectedWallet, writesEnabled);
 
-  return { mode, wrongNetwork, writesEnabled };
+  return { mode, wrongNetwork, writesEnabled, mayPromptWallet };
 }
 
 // The sync display hook `usePcaOwnerAccess` lives in `./usePcaOwnerAccess.ts` so THIS module

--- a/packages/node-ui/src/ui/pca/ownerAccess.ts
+++ b/packages/node-ui/src/ui/pca/ownerAccess.ts
@@ -39,6 +39,22 @@ export type PcaOwnerMode = 'daemon' | 'wallet' | 'external' | 'unknown';
  */
 export type PcaOwnerUnknownCause = 'no-snapshot' | 'wallets-unreadable' | 'wallets-loading';
 
+/**
+ * The load state of this node's wallet list (`wallets[0]` = the daemon signer), as consumed by
+ * the owner-access model. `'ready'` classifies the owner normally; `'loading'` / `'unreadable'`
+ * ⇒ `unknown` (cause `wallets-loading` / `wallets-unreadable`).
+ */
+export type PcaPrimaryWalletState = 'loading' | 'unreadable' | 'ready';
+
+/**
+ * Map a `useFetch(fetchWalletsBalances)` `{ data, error }` pair to a `PcaPrimaryWalletState` — the
+ * SINGLE source the modal + detail view derive it from: data ⇒ `'ready'`; error-without-data ⇒
+ * `'unreadable'`; neither ⇒ `'loading'`.
+ */
+export function resolvePrimaryWalletState(data: unknown, error: unknown): PcaPrimaryWalletState {
+  return data ? 'ready' : error ? 'unreadable' : 'loading';
+}
+
 export interface PcaOwnerAccessInput {
   /** The on-chain PCA owner. Absent/empty ⇒ `unknown` (`no-snapshot`). */
   owner?: string | null;
@@ -54,7 +70,7 @@ export interface PcaOwnerAccessInput {
    * (the default when omitted) ⇒ classify the owner normally. Split out of the former
    * `walletsUnknown` boolean so a daemon PCA shows loading (not read-only) during the fetch.
    */
-  primaryWalletState?: 'loading' | 'unreadable' | 'ready';
+  primaryWalletState?: PcaPrimaryWalletState;
 }
 
 /**
@@ -72,15 +88,6 @@ export interface PcaOwnerAccess {
   writesEnabled: boolean;
   /** Present only when `mode === 'unknown'`; names which read is missing. */
   ownerUnknownCause?: PcaOwnerUnknownCause;
-  /**
-   * The target-write signing plan: could an owner write open a browser-wallet signature? True
-   * when the owner is a loaded wallet on the right network, OR — during a load window (`mode`
-   * still `unknown`) — a wallet is connected and the owner is either not-yet-known (#1469) or
-   * equals the connected wallet (subsumes R4). Safe-direction over-arm; the resolving submitter
-   * refuses read-only / daemon-confirms once the re-fetched owner is known. See
-   * `computeMayPromptWallet`.
-   */
-  mayPromptWallet: boolean;
 }
 
 /**
@@ -94,8 +101,9 @@ export function ownerModeWritesEnabled(mode: PcaOwnerMode, wrongNetwork: boolean
 }
 
 /**
- * The target-write signing plan — could an owner write open a browser-wallet signature? The
- * single source `ApproveWalletsModal.targetWalletManaged` reads.
+ * The target-write signing plan — could an owner write open a browser-wallet signature? A pure
+ * helper OVER the owner-access model (deliberately NOT a field on it — keeps the model minimal);
+ * `ApproveWalletsModal.targetWalletManaged` is its single caller.
  *  - Clause 1: a loaded wallet-owned PCA on the right network (`mode === 'wallet' && writesEnabled`).
  *  - Clause 2: a load window (`mode === 'unknown'` — loading / unreadable / no-snapshot) with a
  *    connected wallet, when the owner is not-yet-known (`!owner` ⇒ closes #1469) or equals the
@@ -104,14 +112,13 @@ export function ownerModeWritesEnabled(mode: PcaOwnerMode, wrongNetwork: boolean
  * call-time by the wallet submitter, inv-16), and the resolving submitter refuses read-only /
  * daemon-confirms instantly once the re-fetched owner turns out not to be the connected wallet.
  */
-function computeMayPromptWallet(
-  mode: PcaOwnerMode,
+export function mayTargetWritePromptWallet(
+  access: Pick<PcaOwnerAccess, 'mode' | 'writesEnabled'>,
   owner: string | null | undefined,
   connectedWallet: string | null | undefined,
-  writesEnabled: boolean,
 ): boolean {
-  if (mode === 'wallet' && writesEnabled) return true;
-  if (mode === 'unknown') return !!connectedWallet && (!owner || eqAddress(owner, connectedWallet));
+  if (access.mode === 'wallet' && access.writesEnabled) return true;
+  if (access.mode === 'unknown') return !!connectedWallet && (!owner || eqAddress(owner, connectedWallet));
   return false;
 }
 
@@ -134,31 +141,13 @@ export function resolvePcaOwnerAccess(input: PcaOwnerAccessInput): PcaOwnerAcces
   // reading this node's wallets" before it ever classifies the owner. `'loading'` is split from
   // `'unreadable'` so a daemon PCA shows loading (not read-only) while the balances fetch runs.
   if (primaryWalletState === 'loading') {
-    return {
-      mode: 'unknown',
-      wrongNetwork: walletWrongNetwork,
-      writesEnabled: false,
-      ownerUnknownCause: 'wallets-loading',
-      mayPromptWallet: computeMayPromptWallet('unknown', owner, connectedWallet, false),
-    };
+    return { mode: 'unknown', wrongNetwork: walletWrongNetwork, writesEnabled: false, ownerUnknownCause: 'wallets-loading' };
   }
   if (primaryWalletState === 'unreadable') {
-    return {
-      mode: 'unknown',
-      wrongNetwork: walletWrongNetwork,
-      writesEnabled: false,
-      ownerUnknownCause: 'wallets-unreadable',
-      mayPromptWallet: computeMayPromptWallet('unknown', owner, connectedWallet, false),
-    };
+    return { mode: 'unknown', wrongNetwork: walletWrongNetwork, writesEnabled: false, ownerUnknownCause: 'wallets-unreadable' };
   }
   if (!owner) {
-    return {
-      mode: 'unknown',
-      wrongNetwork: walletWrongNetwork,
-      writesEnabled: false,
-      ownerUnknownCause: 'no-snapshot',
-      mayPromptWallet: computeMayPromptWallet('unknown', owner, connectedWallet, false),
-    };
+    return { mode: 'unknown', wrongNetwork: walletWrongNetwork, writesEnabled: false, ownerUnknownCause: 'no-snapshot' };
   }
 
   // inv-17 precedence — byte-for-byte from detailOwnerMode / the async classifier
@@ -175,9 +164,8 @@ export function resolvePcaOwnerAccess(input: PcaOwnerAccessInput): PcaOwnerAcces
 
   const wrongNetwork = walletWrongNetwork;
   const writesEnabled = ownerModeWritesEnabled(mode, wrongNetwork);
-  const mayPromptWallet = computeMayPromptWallet(mode, owner, connectedWallet, writesEnabled);
 
-  return { mode, wrongNetwork, writesEnabled, mayPromptWallet };
+  return { mode, wrongNetwork, writesEnabled };
 }
 
 // The sync display hook `usePcaOwnerAccess` lives in `./usePcaOwnerAccess.ts` so THIS module

--- a/packages/node-ui/src/ui/pca/ownerActions.ts
+++ b/packages/node-ui/src/ui/pca/ownerActions.ts
@@ -7,7 +7,7 @@ import {
   pcaTopUp,
   pcaSettle,
 } from '../api.js';
-import { isWrongNetwork, useWalletStore } from '../stores/wallet.js';
+import { useWalletStore } from '../stores/wallet.js';
 import {
   walletOwnerActionSubmitter,
   type WalletOwnerActionSubmitterDeps,
@@ -160,15 +160,16 @@ export function resolveOwnerActionSubmitterKind({
  * so the classification math lives in the owner-access layer, not the component (folds the former
  * inline `ApproveWalletsModal.signerKindForAccount`, #1470 item).
  *
- * `primaryWallet` (this node's `wallets[0]`, the daemon signer) is passed BY THE CALLER from its
- * already-loaded wallet list — deliberately NOT re-fetched here. The old inline predicate keyed the
- * daemon branch on the modal's cached `ownerWallet` and the wallet branch on `connectedWallet` only
- * (no wallet-LIST dependency at all), so its only async was `fetchPca(deregisterFrom)`, correlated
- * with the execution path. An internal `fetchWalletsBalances()` would add an UNCORRELATED failure
- * that maps to `undefined` and can disarm the R4 wallet-signing lock (deviceTotal 0 / no
- * `walletBatchSigning`) while the resolving deregister submitter independently re-fetches, succeeds,
- * and opens a browser prompt with the lock off — the exact contract #1468/R4 protects. Keeping the
- * fetch out preserves the old correlation.
+ * ALL classification inputs — `primaryWallet` (this node's `wallets[0]`, the daemon signer),
+ * `connectedWallet`, and `walletWrongNetwork` — are passed EXPLICITLY by the caller; there are NO
+ * ambient wallet-store reads and NO wallet-list refetch, so the only async is `fetchPca(accountId)`.
+ * The old inline predicate keyed the daemon branch on the modal's cached `ownerWallet` and the
+ * wallet branch on `connectedWallet` only (no wallet-LIST dependency at all), so its only async was
+ * `fetchPca(deregisterFrom)`, correlated with the execution path. An internal `fetchWalletsBalances()`
+ * would add an UNCORRELATED failure that maps to `undefined` and can disarm the R4 wallet-signing
+ * lock (deviceTotal 0 / no `walletBatchSigning`) while the resolving deregister submitter
+ * independently re-fetches, succeeds, and opens a browser prompt with the lock off — the exact
+ * contract #1468/R4 protects. Keeping the fetch out preserves the old correlation.
  *
  * `undefined` for a missing id, a read failure, or an owner this node can't sign for
  * (external / wrong-network) — byte-identical to the old inline predicate (the `signerKindRef`
@@ -176,19 +177,21 @@ export function resolveOwnerActionSubmitterKind({
  * connected wallet owns it ON THE RIGHT NETWORK (`writesEnabled`). inv-16: this only PLANS the
  * device count — the actual deregister still re-resolves + re-verifies ownership per prompt.
  */
-export async function resolveSignerKindForAccount(
-  accountId?: string,
-  primaryWallet?: string | null,
-): Promise<'daemon' | 'wallet' | undefined> {
+export async function resolveSignerKindForAccount(opts: {
+  accountId?: string;
+  primaryWallet?: string | null;
+  connectedWallet?: string | null;
+  walletWrongNetwork?: boolean;
+}): Promise<'daemon' | 'wallet' | undefined> {
+  const { accountId, primaryWallet, connectedWallet, walletWrongNetwork } = opts;
   if (!accountId) return undefined;
   const snapshot = await fetchPca(accountId).catch(() => null);
   if (!snapshot?.owner) return undefined;
-  const walletState = useWalletStore.getState();
   const access = resolvePcaOwnerAccess({
     owner: snapshot.owner,
-    primaryWallet,
-    connectedWallet: walletState.address,
-    walletWrongNetwork: isWrongNetwork(walletState),
+    primaryWallet: primaryWallet ?? null,
+    connectedWallet,
+    walletWrongNetwork,
   });
   const kind = submitterKindForOwnerMode(access.mode);
   if (kind === 'daemon') return 'daemon';

--- a/packages/node-ui/src/ui/pca/ownerActions.ts
+++ b/packages/node-ui/src/ui/pca/ownerActions.ts
@@ -7,7 +7,7 @@ import {
   pcaTopUp,
   pcaSettle,
 } from '../api.js';
-import { useWalletStore } from '../stores/wallet.js';
+import { isWrongNetwork, useWalletStore } from '../stores/wallet.js';
 import {
   walletOwnerActionSubmitter,
   type WalletOwnerActionSubmitterDeps,
@@ -89,9 +89,11 @@ export const readOnlyOwnerActionSubmitter: OwnerActionSubmitter = {
 
 export type OwnerKey = 'hot' | 'hardware';
 
-/** Args for the per-call RESOLVING submitter (cross-account deregister, create). */
-export interface ResolvingOwnerActionSubmitterArgs {
-  /** Advisory only — the manage writes resolve per the accountId PASSED to each method. */
+/** Args for `useOwnerActionSubmitterForAccount` — the per-call RESOLVING submitter (cross-account
+ *  deregister, create). */
+export interface OwnerActionSubmitterForAccountArgs {
+  /** ADVISORY only — documents the bound account at the call site; routing resolves per the
+   *  accountId PASSED to each method, not this field. */
   accountId?: string;
   /** Create-time selector: 'hardware' → browser wallet, else daemon. */
   ownerKey?: OwnerKey;
@@ -99,8 +101,9 @@ export interface ResolvingOwnerActionSubmitterArgs {
   onWalletProgress?: WalletOwnerActionSubmitterDeps['onProgress'];
 }
 
-/** Args for the same-account RESOLVED submitter (resolve-once from the display access). */
-export interface ResolvedOwnerActionSubmitterArgs {
+/** Args for `useOwnerActionSubmitter` — the same-account ACCESS-PINNED submitter (resolve-once from
+ *  the display access). */
+export interface OwnerActionSubmitterArgs {
   /** The display-resolved owner access for THIS account. */
   access: PcaOwnerAccess;
   /** Optional UI progress hook for browser-wallet approve/action prompts. */
@@ -148,6 +151,51 @@ export function resolveOwnerActionSubmitterKind({
   connectedWallet?: string | null;
 }): OwnerActionSubmitterKind {
   return submitterKindForOwnerMode(resolvePcaOwnerAccess({ owner, primaryWallet, connectedWallet }).mode);
+}
+
+/**
+ * The signer KIND for a (possibly different) account's OWNER — `'daemon' | 'wallet' | undefined`.
+ * The approve batch calls this to count device prompts for a CROSS-account deregister (renew's
+ * old `deregisterFrom`). It re-fetches that account's owner and reduces via the owner-access model,
+ * so the classification math lives in the owner-access layer, not the component (folds the former
+ * inline `ApproveWalletsModal.signerKindForAccount`, #1470 item).
+ *
+ * `primaryWallet` (this node's `wallets[0]`, the daemon signer) is passed BY THE CALLER from its
+ * already-loaded wallet list — deliberately NOT re-fetched here. The old inline predicate keyed the
+ * daemon branch on the modal's cached `ownerWallet` and the wallet branch on `connectedWallet` only
+ * (no wallet-LIST dependency at all), so its only async was `fetchPca(deregisterFrom)`, correlated
+ * with the execution path. An internal `fetchWalletsBalances()` would add an UNCORRELATED failure
+ * that maps to `undefined` and can disarm the R4 wallet-signing lock (deviceTotal 0 / no
+ * `walletBatchSigning`) while the resolving deregister submitter independently re-fetches, succeeds,
+ * and opens a browser prompt with the lock off — the exact contract #1468/R4 protects. Keeping the
+ * fetch out preserves the old correlation.
+ *
+ * `undefined` for a missing id, a read failure, or an owner this node can't sign for
+ * (external / wrong-network) — byte-identical to the old inline predicate (the `signerKindRef`
+ * oracle pins it): `daemon` when the owner is this node's primary wallet; `wallet` only when the
+ * connected wallet owns it ON THE RIGHT NETWORK (`writesEnabled`). inv-16: this only PLANS the
+ * device count — the actual deregister still re-resolves + re-verifies ownership per prompt.
+ */
+export async function resolveSignerKindForAccount(
+  accountId?: string,
+  primaryWallet?: string | null,
+): Promise<'daemon' | 'wallet' | undefined> {
+  if (!accountId) return undefined;
+  const snapshot = await fetchPca(accountId).catch(() => null);
+  if (!snapshot?.owner) return undefined;
+  const walletState = useWalletStore.getState();
+  const access = resolvePcaOwnerAccess({
+    owner: snapshot.owner,
+    primaryWallet,
+    connectedWallet: walletState.address,
+    walletWrongNetwork: isWrongNetwork(walletState),
+  });
+  const kind = submitterKindForOwnerMode(access.mode);
+  if (kind === 'daemon') return 'daemon';
+  // The wrong-network gate lives in `writesEnabled` (mode stays 'wallet'): a wrong-network wallet
+  // owner is NOT counted as a device prompt, matching the old `!walletWrongNetwork` conjunct.
+  if (kind === 'wallet' && access.writesEnabled) return 'wallet';
+  return undefined;
 }
 
 /**
@@ -205,7 +253,7 @@ export async function resolveOwnerActionSubmitterForAccount(
  * the browser wallet (pre-flight walletUnavailableReason), anything else uses the daemon. Shared
  * by both the resolving and the access-path submitters — create never depends on `access`.
  */
-function resolvingCreate(args: ResolvingOwnerActionSubmitterArgs): OwnerActionSubmitter['create'] {
+function resolvingCreate(args: OwnerActionSubmitterForAccountArgs): OwnerActionSubmitter['create'] {
   return async (createArgs) => {
     if (args.ownerKey !== 'hardware') return daemonOwnerActionSubmitter.create(createArgs);
     const reason = walletUnavailableReason();
@@ -215,8 +263,8 @@ function resolvingCreate(args: ResolvingOwnerActionSubmitterArgs): OwnerActionSu
 }
 
 // Internal (NOT a hook) — the per-call resolving submitter. Exposed to components via
-// `useResolvingOwnerActionSubmitter`, and reused by the resolved submitter's fallback branches.
-function resolvingOwnerActionSubmitter(args: ResolvingOwnerActionSubmitterArgs = {}): OwnerActionSubmitter {
+// `useOwnerActionSubmitterForAccount`, and reused by the pinned submitter's fallback branches.
+function resolvingOwnerActionSubmitter(args: OwnerActionSubmitterForAccountArgs = {}): OwnerActionSubmitter {
   return {
     create: resolvingCreate(args),
     async registerAgent(accountId, address) {
@@ -233,7 +281,7 @@ function resolvingOwnerActionSubmitter(args: ResolvingOwnerActionSubmitterArgs =
 }
 
 // Internal (NOT a hook) — the same-account resolve-ONCE submitter, with the two safety fallbacks.
-function resolvedOwnerActionSubmitter(
+function pinnedOwnerActionSubmitter(
   access: PcaOwnerAccess,
   onWalletProgress?: WalletOwnerActionSubmitterDeps['onProgress'],
 ): OwnerActionSubmitter {
@@ -262,20 +310,23 @@ function resolvedOwnerActionSubmitter(
 }
 
 /**
- * The per-call RESOLVING submitter (T3 / #1468): every manage write re-fetches the PCA owner +
- * re-classifies (via `resolveOwnerActionSubmitterForAccount`, keyed on the accountId PASSED to the
- * method). Use for CROSS-account writes — renew's / self-coverage's deregister from a DIFFERENT
- * account — and for create. This is the security seam; it must NOT be pinned onto React state.
+ * `useOwnerActionSubmitterForAccount` — the per-call RESOLVING strategy (T3 / #1468): every manage
+ * write re-fetches the PCA owner + re-classifies (via `resolveOwnerActionSubmitterForAccount`, keyed
+ * on the accountId PASSED to the method). Use for CROSS-account writes — renew's / self-coverage's
+ * deregister from a DIFFERENT account — and for create. The optional `accountId` arg is ADVISORY
+ * (routing uses the call-time accountId). This is the security seam; it must NOT be pinned onto
+ * React state.
  */
-export function useResolvingOwnerActionSubmitter(args: ResolvingOwnerActionSubmitterArgs = {}): OwnerActionSubmitter {
+export function useOwnerActionSubmitterForAccount(args: OwnerActionSubmitterForAccountArgs = {}): OwnerActionSubmitter {
   return resolvingOwnerActionSubmitter(args);
 }
 
 /**
- * The same-account RESOLVED submitter (T3 / #1468): resolves the signer ONCE from the display
- * `access` for writes on THAT account (the resolve-once win), with the T1 wallet re-verify + the
- * unknown-mode self-heal baked in (see `resolvedOwnerActionSubmitter`). create/settle unchanged.
+ * `useOwnerActionSubmitter` — the same-account ACCESS-PINNED strategy (T3 / #1468): resolves the
+ * signer ONCE from the display `access` for writes on THAT account (the resolve-once win), with the
+ * T1 wallet re-verify + the unknown-mode self-heal baked in (see `pinnedOwnerActionSubmitter`).
+ * create/settle unchanged.
  */
-export function useResolvedOwnerActionSubmitter(args: ResolvedOwnerActionSubmitterArgs): OwnerActionSubmitter {
-  return resolvedOwnerActionSubmitter(args.access, args.onWalletProgress);
+export function useOwnerActionSubmitter(args: OwnerActionSubmitterArgs): OwnerActionSubmitter {
+  return pinnedOwnerActionSubmitter(args.access, args.onWalletProgress);
 }

--- a/packages/node-ui/src/ui/pca/ownerActions.ts
+++ b/packages/node-ui/src/ui/pca/ownerActions.ts
@@ -89,21 +89,18 @@ export const readOnlyOwnerActionSubmitter: OwnerActionSubmitter = {
 
 export type OwnerKey = 'hot' | 'hardware';
 
-/** Args for `useOwnerActionSubmitterForAccount` — the per-call RESOLVING submitter (cross-account
+/** Args for `useResolvingOwnerActionSubmitter` — the per-call RESOLVING submitter (cross-account
  *  deregister, create). */
-export interface OwnerActionSubmitterForAccountArgs {
-  /** ADVISORY only — documents the bound account at the call site; routing resolves per the
-   *  accountId PASSED to each method, not this field. */
-  accountId?: string;
+export interface ResolvingOwnerActionSubmitterArgs {
   /** Create-time selector: 'hardware' → browser wallet, else daemon. */
   ownerKey?: OwnerKey;
   /** Optional UI progress hook for browser-wallet approve/action prompts. */
   onWalletProgress?: WalletOwnerActionSubmitterDeps['onProgress'];
 }
 
-/** Args for `useOwnerActionSubmitter` — the same-account ACCESS-PINNED submitter (resolve-once from
+/** Args for `usePinnedOwnerActionSubmitter` — the same-account ACCESS-PINNED submitter (resolve-once from
  *  the display access). */
-export interface OwnerActionSubmitterArgs {
+export interface PinnedOwnerActionSubmitterArgs {
   /** The display-resolved owner access for THIS account. */
   access: PcaOwnerAccess;
   /** Optional UI progress hook for browser-wallet approve/action prompts. */
@@ -256,7 +253,7 @@ export async function resolveOwnerActionSubmitterForAccount(
  * the browser wallet (pre-flight walletUnavailableReason), anything else uses the daemon. Shared
  * by both the resolving and the access-path submitters — create never depends on `access`.
  */
-function resolvingCreate(args: OwnerActionSubmitterForAccountArgs): OwnerActionSubmitter['create'] {
+function resolvingCreate(args: ResolvingOwnerActionSubmitterArgs): OwnerActionSubmitter['create'] {
   return async (createArgs) => {
     if (args.ownerKey !== 'hardware') return daemonOwnerActionSubmitter.create(createArgs);
     const reason = walletUnavailableReason();
@@ -266,8 +263,8 @@ function resolvingCreate(args: OwnerActionSubmitterForAccountArgs): OwnerActionS
 }
 
 // Internal (NOT a hook) — the per-call resolving submitter. Exposed to components via
-// `useOwnerActionSubmitterForAccount`, and reused by the pinned submitter's fallback branches.
-function resolvingOwnerActionSubmitter(args: OwnerActionSubmitterForAccountArgs = {}): OwnerActionSubmitter {
+// `useResolvingOwnerActionSubmitter`, and reused by the pinned submitter's fallback branches.
+function resolvingOwnerActionSubmitter(args: ResolvingOwnerActionSubmitterArgs = {}): OwnerActionSubmitter {
   return {
     create: resolvingCreate(args),
     async registerAgent(accountId, address) {
@@ -313,23 +310,23 @@ function pinnedOwnerActionSubmitter(
 }
 
 /**
- * `useOwnerActionSubmitterForAccount` — the per-call RESOLVING strategy (T3 / #1468): every manage
+ * `useResolvingOwnerActionSubmitter` — the per-call RESOLVING strategy (T3 / #1468): every manage
  * write re-fetches the PCA owner + re-classifies (via `resolveOwnerActionSubmitterForAccount`, keyed
  * on the accountId PASSED to the method). Use for CROSS-account writes — renew's / self-coverage's
- * deregister from a DIFFERENT account — and for create. The optional `accountId` arg is ADVISORY
- * (routing uses the call-time accountId). This is the security seam; it must NOT be pinned onto
- * React state.
+ * deregister from a DIFFERENT account — and for create. Routing is ENTIRELY per-call (the accountId
+ * each method receives); the hook itself takes no bound account. This is the security seam; it must
+ * NOT be pinned onto React state.
  */
-export function useOwnerActionSubmitterForAccount(args: OwnerActionSubmitterForAccountArgs = {}): OwnerActionSubmitter {
+export function useResolvingOwnerActionSubmitter(args: ResolvingOwnerActionSubmitterArgs = {}): OwnerActionSubmitter {
   return resolvingOwnerActionSubmitter(args);
 }
 
 /**
- * `useOwnerActionSubmitter` — the same-account ACCESS-PINNED strategy (T3 / #1468): resolves the
+ * `usePinnedOwnerActionSubmitter` — the same-account ACCESS-PINNED strategy (T3 / #1468): resolves the
  * signer ONCE from the display `access` for writes on THAT account (the resolve-once win), with the
  * T1 wallet re-verify + the unknown-mode self-heal baked in (see `pinnedOwnerActionSubmitter`).
  * create/settle unchanged.
  */
-export function useOwnerActionSubmitter(args: OwnerActionSubmitterArgs): OwnerActionSubmitter {
+export function usePinnedOwnerActionSubmitter(args: PinnedOwnerActionSubmitterArgs): OwnerActionSubmitter {
   return pinnedOwnerActionSubmitter(args.access, args.onWalletProgress);
 }

--- a/packages/node-ui/src/ui/pca/usePcaOwnerAccess.ts
+++ b/packages/node-ui/src/ui/pca/usePcaOwnerAccess.ts
@@ -11,7 +11,7 @@ import { resolvePcaOwnerAccess, type PcaOwnerAccess } from './ownerAccess.js';
 export function usePcaOwnerAccess(input: {
   owner?: string | null;
   primaryWallet?: string | null;
-  walletsUnknown?: boolean;
+  primaryWalletState?: 'loading' | 'unreadable' | 'ready';
 }): PcaOwnerAccess {
   const connectedWallet = useWalletStore((s) => s.address);
   const walletWrongNetwork = useWalletStore((s) => isWrongNetwork(s));
@@ -20,6 +20,6 @@ export function usePcaOwnerAccess(input: {
     primaryWallet: input.primaryWallet,
     connectedWallet,
     walletWrongNetwork,
-    walletsUnknown: input.walletsUnknown,
+    primaryWalletState: input.primaryWalletState,
   });
 }

--- a/packages/node-ui/src/ui/pca/usePcaOwnerAccess.ts
+++ b/packages/node-ui/src/ui/pca/usePcaOwnerAccess.ts
@@ -6,12 +6,12 @@
 // The async, deliberately re-fetching face stays in
 // `ownerActions.resolveOwnerActionSubmitterForAccount` — do NOT force it onto React state.
 import { isWrongNetwork, useWalletStore } from '../stores/wallet.js';
-import { resolvePcaOwnerAccess, type PcaOwnerAccess } from './ownerAccess.js';
+import { resolvePcaOwnerAccess, type PcaOwnerAccess, type PcaPrimaryWalletState } from './ownerAccess.js';
 
 export function usePcaOwnerAccess(input: {
   owner?: string | null;
   primaryWallet?: string | null;
-  primaryWalletState?: 'loading' | 'unreadable' | 'ready';
+  primaryWalletState?: PcaPrimaryWalletState;
 }): PcaOwnerAccess {
   const connectedWallet = useWalletStore((s) => s.address);
   const walletWrongNetwork = useWalletStore((s) => isWrongNetwork(s));

--- a/packages/node-ui/test/pca-approve-modal.test.ts
+++ b/packages/node-ui/test/pca-approve-modal.test.ts
@@ -513,6 +513,54 @@ describe('ApproveWalletsModal — per-row mapping', () => {
     await unmount();
   });
 
+  // #1469 — the SNAPSHOT-load window (sibling of R4's wallets-load window): when the PCA snapshot
+  // (owner) hasn't loaded at click but the WALLETS have and a wallet is connected, the target access
+  // is `unknown` (no-snapshot) and `mayTargetWritePromptWallet` arms on `!owner`. So a connected-owner
+  // target that resolves to the wallet still runs under the wallet-signing lock, never the daemon's
+  // no-prompt / freely-dismissable contract. RED without the fix (targetWalletManaged =
+  // access.mode==='wallet' && access.writesEnabled): the owner-undefined click never arms the lock →
+  // the wallet write opens a device prompt with the lock off / times out. seedBulk enables immediate
+  // sponsor-mode submit while the snapshot is still pending.
+  it('no-snapshot window (wallets before snapshot): a connected-owner target arms the wallet-signing lock before the snapshot loads, then wallet-signs', async () => {
+    useWalletStore.setState({
+      provider: { request: vi.fn() } as any,
+      providerInfo: null,
+      address: CONNECTED_OWNER as `0x${string}`,
+      chainId: 84532,
+      expectedChainId: 84532,
+      bootstrap: CONTRACTS,
+    });
+    // Wallets resolve normally; the PCA SNAPSHOT (fetchPca) stays PENDING through the click, so at
+    // submit `snapshot` is undefined ⇒ access.mode 'unknown' (no-snapshot) ⇒ the #1469 lock arm.
+    mocks.fetchWalletsBalances.mockResolvedValue({ wallets: [DEFAULT_NODE_WALLET], balances: [], chainId: '84532', rpcUrl: null });
+    let resolveSnapshot!: (value: unknown) => void;
+    const snapshotPromise = new Promise((resolve) => { resolveSnapshot = resolve; });
+    mocks.fetchPca.mockImplementation(() => snapshotPromise as any);
+
+    const onClose = vi.fn();
+    const { container, unmount } = await render(
+      React.createElement(ApproveWalletsModal, {
+        accountId: '8', initialMode: 'sponsor', seedBulk: ADDR_A, onClose,
+      }),
+    );
+    await waitForText(container, 'Wallet address(es)');
+    await click(container.querySelector('[data-testid="pca-approve-submit"]')!);
+    // The lock + device step arm from the render-time targetWalletManaged (owner undefined +
+    // connected wallet ⇒ mayTargetWritePromptWallet), BEFORE the snapshot re-fetch resolves.
+    await waitForText(container, 'Confirm on your device');
+    expect(container.querySelector('button[aria-label="Close disabled while signing"]')).toBeTruthy();
+    expect((container.querySelector('.v10-modal-footer .v10-modal-btn') as HTMLButtonElement).disabled).toBe(true);
+    await act(async () => { window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' })); });
+    expect(onClose).not.toHaveBeenCalled();
+
+    // Resolve the snapshot (owner == connected wallet) → the parked register routes to the WALLET.
+    resolveSnapshot(ownedSnap(CONNECTED_OWNER, { accountId: '8' }));
+    await waitForText(container, 'approved on-chain');
+    expect(mocks.walletRegisterAgent).toHaveBeenCalledWith('8', ADDR_A); // routed to the WALLET signer
+    expect(mocks.pcaAddAgent).not.toHaveBeenCalled(); // never the daemon (no-prompt) path
+    await unmount();
+  });
+
   it('wallet-managed renew progress counts only wallet-signed writes, not daemon deregisters', async () => {
     useWalletStore.setState({
       provider: { request: vi.fn() } as any,

--- a/packages/node-ui/test/pca-detail-view.test.ts
+++ b/packages/node-ui/test/pca-detail-view.test.ts
@@ -213,6 +213,41 @@ describe('ConvictionDetailView §8A owner-gating', () => {
     await unmount();
   });
 
+  // #1470 loading-window flash fix — while the wallet balances LOAD, a daemon-owned PCA must show a
+  // neutral "Confirming ownership…" affordance (unknown/loading): NOT a read-only/external
+  // "Owner-only" flash, and NOT a false "Couldn't load"/Retry (they haven't failed, they're
+  // loading). Owner controls stay gated for the brief window, then enable once balances resolve.
+  // RED without the split: old `walletsUnknown = !wb && !!wbError` was FALSE during loading, so a
+  // wallets[0]-undefined daemon PCA misclassified as external → "Owner-only" + read-only.
+  it('loading-window: a daemon-owned PCA reads "Confirming ownership…" (no error/Retry, not Owner-only) while balances load, then enables once ready', async () => {
+    // Snapshot resolves daemon-owned (owner == W0). Balances stay PENDING → wallet list loading.
+    let resolveBalances!: (value: unknown) => void;
+    mocks.fetchWalletsBalances.mockImplementationOnce(
+      () => new Promise((resolve) => { resolveBalances = resolve; }),
+    );
+    const { container, unmount } = await render(React.createElement(ConvictionDetailView, { accountId: '7' }));
+    // During the balances load: neutral loading affordance, NOT a false error and NOT a definitive
+    // non-owner; writes gated. (Renew needs no amount input, so its disabled state is a clean gate.)
+    await waitForText(container, 'Confirming ownership');
+    expect(container.textContent).not.toContain('Owner-only');
+    expect(container.textContent).not.toContain("Couldn't load this node's wallets"); // no false failure copy
+    expect(container.textContent).not.toContain("can't confirm ownership");
+    expect(container.textContent).not.toContain('isn’t the owner');
+    expect(Array.from(container.querySelectorAll('button')).some((b) => b.textContent === 'Retry')).toBe(false); // no Retry while loading
+    expect(btn(container, '[data-testid="pca-renew-btn"]').disabled).toBe(true);
+    // Balances resolve as this node's wallet (== owner W0) → daemon-owned → owner controls enable.
+    await act(async () => {
+      resolveBalances({ wallets: [W0], balances: [{ address: W0, eth: '1', trac: '5', symbol: 'TRAC' }], chainId: '84532', rpcUrl: null });
+    });
+    const started = Date.now();
+    while (Date.now() - started < 1500 && btn(container, '[data-testid="pca-renew-btn"]')?.disabled) {
+      await act(async () => { await new Promise((r) => setTimeout(r, 5)); });
+    }
+    expect(btn(container, '[data-testid="pca-renew-btn"]').disabled).toBe(false);
+    expect(container.textContent).not.toContain('Confirming ownership');
+    await unmount();
+  });
+
   it('deregister uses a consequence-naming two-step confirm', async () => {
     mocks.fetchWalletsBalances.mockResolvedValue({ wallets: [W0], balances: [], chainId: '84532', rpcUrl: null });
     const { container, unmount } = await render(React.createElement(ConvictionDetailView, { accountId: '7' }));

--- a/packages/node-ui/test/pca-owner-access.test.ts
+++ b/packages/node-ui/test/pca-owner-access.test.ts
@@ -25,7 +25,7 @@ vi.mock('../src/ui/web3/walletOwnerActionSubmitter.js', () => ({
   walletOwnerActionSubmitter: () => ({}),
 }));
 
-const { resolvePcaOwnerAccess } = await import('../src/ui/pca/ownerAccess.js');
+const { resolvePcaOwnerAccess, mayTargetWritePromptWallet, resolvePrimaryWalletState } = await import('../src/ui/pca/ownerAccess.js');
 const { resolveOwnerActionSubmitterKind, submitterKindForOwnerMode } = await import('../src/ui/pca/ownerActions.js');
 
 const HOT = `0x${'11'.repeat(20)}`; // this node's primary operational (daemon) wallet
@@ -148,68 +148,86 @@ describe('resolvePcaOwnerAccess — primaryWalletState load model (#1470)', () =
   });
 });
 
-describe('resolvePcaOwnerAccess — mayPromptWallet truth table (#1469 + R4)', () => {
-  it('(i) loaded wallet-owned, right network ⇒ mayPromptWallet true', () => {
+// `mayTargetWritePromptWallet(access, owner, connectedWallet)` is a pure helper OVER the model
+// (not a field on it). Each case builds `access` then asserts the helper's verdict for the same
+// owner/connectedWallet inputs.
+describe('mayTargetWritePromptWallet — truth table (#1469 + R4)', () => {
+  it('(i) loaded wallet-owned, right network ⇒ true', () => {
     const access = resolvePcaOwnerAccess({ owner: HW, primaryWallet: HOT, connectedWallet: HW });
     expect(access.mode).toBe('wallet');
     expect(access.writesEnabled).toBe(true);
-    expect(access.mayPromptWallet).toBe(true);
+    expect(mayTargetWritePromptWallet(access, HW, HW)).toBe(true);
   });
 
-  it('(ii) loaded wallet-owned, WRONG network ⇒ mayPromptWallet false (mode wallet, writesEnabled false)', () => {
+  it('(ii) loaded wallet-owned, WRONG network ⇒ false (mode wallet, writesEnabled false)', () => {
     const access = resolvePcaOwnerAccess({ owner: HW, primaryWallet: HOT, connectedWallet: HW, walletWrongNetwork: true });
     expect(access.mode).toBe('wallet');
     expect(access.writesEnabled).toBe(false);
-    expect(access.mayPromptWallet).toBe(false);
+    expect(mayTargetWritePromptWallet(access, HW, HW)).toBe(false);
   });
 
-  it('(iii) daemon-owned (owner==primary, owner!=connected) ⇒ mayPromptWallet false', () => {
+  it('(iii) daemon-owned (owner==primary, owner!=connected) ⇒ false', () => {
     const access = resolvePcaOwnerAccess({ owner: HOT, primaryWallet: HOT, connectedWallet: HW });
     expect(access.mode).toBe('daemon');
-    expect(access.mayPromptWallet).toBe(false);
+    expect(mayTargetWritePromptWallet(access, HOT, HW)).toBe(false);
   });
 
-  it('(iv) #1469: primaryWalletState loading, owner undefined, connectedWallet set ⇒ mayPromptWallet true', () => {
+  it('(iv) #1469: primaryWalletState loading, owner undefined, connectedWallet set ⇒ true', () => {
     const access = resolvePcaOwnerAccess({ owner: undefined, primaryWallet: HOT, connectedWallet: HW, primaryWalletState: 'loading' });
     expect(access.mode).toBe('unknown');
     expect(access.ownerUnknownCause).toBe('wallets-loading');
-    expect(access.mayPromptWallet).toBe(true);
+    expect(mayTargetWritePromptWallet(access, undefined, HW)).toBe(true);
   });
 
-  it('(v) R4: mode unknown (loading), owner == connectedWallet ⇒ mayPromptWallet true', () => {
+  it('(v) R4: mode unknown (loading), owner == connectedWallet ⇒ true', () => {
     const access = resolvePcaOwnerAccess({ owner: HW, primaryWallet: HOT, connectedWallet: HW, primaryWalletState: 'loading' });
     expect(access.mode).toBe('unknown');
-    expect(access.mayPromptWallet).toBe(true);
+    expect(mayTargetWritePromptWallet(access, HW, HW)).toBe(true);
   });
 
-  it('(vi) unknown (loading) + NO connected wallet ⇒ mayPromptWallet false', () => {
+  it('(vi) unknown (loading) + NO connected wallet ⇒ false', () => {
     const access = resolvePcaOwnerAccess({ owner: undefined, primaryWallet: HOT, connectedWallet: null, primaryWalletState: 'loading' });
     expect(access.mode).toBe('unknown');
-    expect(access.mayPromptWallet).toBe(false);
+    expect(mayTargetWritePromptWallet(access, undefined, null)).toBe(false);
   });
 
-  it('(vii) unknown (loading) + owner present but != connectedWallet ⇒ mayPromptWallet false', () => {
+  it('(vii) unknown (loading) + owner present but != connectedWallet ⇒ false', () => {
     const access = resolvePcaOwnerAccess({ owner: EXTERNAL, primaryWallet: HOT, connectedWallet: HW, primaryWalletState: 'loading' });
     expect(access.mode).toBe('unknown');
-    expect(access.mayPromptWallet).toBe(false);
+    expect(mayTargetWritePromptWallet(access, EXTERNAL, HW)).toBe(false);
   });
 
-  it("(viii) #1469 wallets-loaded-before-snapshot: owner undefined, primaryWalletState 'ready', connectedWallet set ⇒ no-snapshot + mayPromptWallet true", () => {
+  it("(viii) #1469 wallets-loaded-before-snapshot: owner undefined, primaryWalletState 'ready', connectedWallet set ⇒ no-snapshot + true", () => {
     // Distinct code path from (iv): wallets are READY but the PCA snapshot (owner) isn't loaded
     // yet, so classification falls through to the `!owner` → no-snapshot branch. The lock must
     // still arm for the connected wallet (the resolving submitter confirms the owner call-time).
     const access = resolvePcaOwnerAccess({ owner: undefined, primaryWallet: HOT, connectedWallet: HW, primaryWalletState: 'ready' });
     expect(access.mode).toBe('unknown');
     expect(access.ownerUnknownCause).toBe('no-snapshot');
-    expect(access.mayPromptWallet).toBe(true);
+    expect(mayTargetWritePromptWallet(access, undefined, HW)).toBe(true);
   });
 
-  it('(ix) loaded EXTERNAL-owned (a wallet is connected but is not the owner) ⇒ mayPromptWallet false', () => {
+  it('(ix) loaded EXTERNAL-owned (a wallet is connected but is not the owner) ⇒ false', () => {
     // Locks the `external` branch against a future fall-through: an external owner can never open a
     // wallet prompt (the connected wallet isn't the owner), so the lock must stay disarmed.
     const access = resolvePcaOwnerAccess({ owner: EXTERNAL, primaryWallet: HOT, connectedWallet: HW });
     expect(access.mode).toBe('external');
-    expect(access.mayPromptWallet).toBe(false);
+    expect(mayTargetWritePromptWallet(access, EXTERNAL, HW)).toBe(false);
+  });
+});
+
+describe('resolvePrimaryWalletState', () => {
+  it('data present ⇒ ready (even with a stale error)', () => {
+    expect(resolvePrimaryWalletState({ wallets: [HOT] }, null)).toBe('ready');
+    expect(resolvePrimaryWalletState({ wallets: [] }, new Error('stale'))).toBe('ready');
+  });
+  it('no data + error ⇒ unreadable', () => {
+    expect(resolvePrimaryWalletState(null, new Error('balances down'))).toBe('unreadable');
+    expect(resolvePrimaryWalletState(undefined, 'boom')).toBe('unreadable');
+  });
+  it('no data + no error ⇒ loading', () => {
+    expect(resolvePrimaryWalletState(null, null)).toBe('loading');
+    expect(resolvePrimaryWalletState(undefined, undefined)).toBe('loading');
   });
 });
 

--- a/packages/node-ui/test/pca-owner-access.test.ts
+++ b/packages/node-ui/test/pca-owner-access.test.ts
@@ -92,8 +92,8 @@ describe('resolvePcaOwnerAccess — core classification', () => {
 });
 
 describe('resolvePcaOwnerAccess — the two distinct unknown causes', () => {
-  it('wallets-unreadable: walletsUnknown wins even with an owner present', () => {
-    const access = resolvePcaOwnerAccess({ owner: HOT, primaryWallet: HOT, connectedWallet: HOT, walletsUnknown: true });
+  it("wallets-unreadable: primaryWalletState 'unreadable' wins even with an owner present", () => {
+    const access = resolvePcaOwnerAccess({ owner: HOT, primaryWallet: HOT, connectedWallet: HOT, primaryWalletState: 'unreadable' });
     expect(access.mode).toBe('unknown');
     expect(access.ownerUnknownCause).toBe('wallets-unreadable');
     expect(access.writesEnabled).toBe(false);
@@ -112,10 +112,104 @@ describe('resolvePcaOwnerAccess — the two distinct unknown causes', () => {
     expect(access.ownerUnknownCause).toBe('no-snapshot');
   });
 
-  it('walletsUnknown takes precedence over a missing owner (documented ordering)', () => {
-    const access = resolvePcaOwnerAccess({ owner: undefined, primaryWallet: HOT, connectedWallet: HW, walletsUnknown: true });
+  it("primaryWalletState 'unreadable' takes precedence over a missing owner (documented ordering)", () => {
+    const access = resolvePcaOwnerAccess({ owner: undefined, primaryWallet: HOT, connectedWallet: HW, primaryWalletState: 'unreadable' });
     expect(access.mode).toBe('unknown');
     expect(access.ownerUnknownCause).toBe('wallets-unreadable');
+  });
+});
+
+describe('resolvePcaOwnerAccess — primaryWalletState load model (#1470)', () => {
+  it("'loading' → unknown + cause 'wallets-loading' + writesEnabled false", () => {
+    const access = resolvePcaOwnerAccess({ owner: HOT, primaryWallet: HOT, connectedWallet: HOT, primaryWalletState: 'loading' });
+    expect(access.mode).toBe('unknown');
+    expect(access.ownerUnknownCause).toBe('wallets-loading');
+    expect(access.writesEnabled).toBe(false);
+  });
+
+  it("'unreadable' → unknown + cause 'wallets-unreadable'", () => {
+    const access = resolvePcaOwnerAccess({ owner: HOT, primaryWallet: HOT, connectedWallet: HOT, primaryWalletState: 'unreadable' });
+    expect(access.mode).toBe('unknown');
+    expect(access.ownerUnknownCause).toBe('wallets-unreadable');
+    expect(access.writesEnabled).toBe(false);
+  });
+
+  it("'ready' with a valid owner/primary → classifies normally (daemon), no unknown cause", () => {
+    const access = resolvePcaOwnerAccess({ owner: HOT, primaryWallet: HOT, connectedWallet: HOT, primaryWalletState: 'ready' });
+    expect(access.mode).toBe('daemon');
+    expect(access.ownerUnknownCause).toBeUndefined();
+    expect(access.writesEnabled).toBe(true);
+  });
+
+  it("omitted primaryWalletState behaves as 'ready' (classifies normally)", () => {
+    const access = resolvePcaOwnerAccess({ owner: HW, primaryWallet: HOT, connectedWallet: HW });
+    expect(access.mode).toBe('wallet');
+    expect(access.ownerUnknownCause).toBeUndefined();
+  });
+});
+
+describe('resolvePcaOwnerAccess — mayPromptWallet truth table (#1469 + R4)', () => {
+  it('(i) loaded wallet-owned, right network ⇒ mayPromptWallet true', () => {
+    const access = resolvePcaOwnerAccess({ owner: HW, primaryWallet: HOT, connectedWallet: HW });
+    expect(access.mode).toBe('wallet');
+    expect(access.writesEnabled).toBe(true);
+    expect(access.mayPromptWallet).toBe(true);
+  });
+
+  it('(ii) loaded wallet-owned, WRONG network ⇒ mayPromptWallet false (mode wallet, writesEnabled false)', () => {
+    const access = resolvePcaOwnerAccess({ owner: HW, primaryWallet: HOT, connectedWallet: HW, walletWrongNetwork: true });
+    expect(access.mode).toBe('wallet');
+    expect(access.writesEnabled).toBe(false);
+    expect(access.mayPromptWallet).toBe(false);
+  });
+
+  it('(iii) daemon-owned (owner==primary, owner!=connected) ⇒ mayPromptWallet false', () => {
+    const access = resolvePcaOwnerAccess({ owner: HOT, primaryWallet: HOT, connectedWallet: HW });
+    expect(access.mode).toBe('daemon');
+    expect(access.mayPromptWallet).toBe(false);
+  });
+
+  it('(iv) #1469: primaryWalletState loading, owner undefined, connectedWallet set ⇒ mayPromptWallet true', () => {
+    const access = resolvePcaOwnerAccess({ owner: undefined, primaryWallet: HOT, connectedWallet: HW, primaryWalletState: 'loading' });
+    expect(access.mode).toBe('unknown');
+    expect(access.ownerUnknownCause).toBe('wallets-loading');
+    expect(access.mayPromptWallet).toBe(true);
+  });
+
+  it('(v) R4: mode unknown (loading), owner == connectedWallet ⇒ mayPromptWallet true', () => {
+    const access = resolvePcaOwnerAccess({ owner: HW, primaryWallet: HOT, connectedWallet: HW, primaryWalletState: 'loading' });
+    expect(access.mode).toBe('unknown');
+    expect(access.mayPromptWallet).toBe(true);
+  });
+
+  it('(vi) unknown (loading) + NO connected wallet ⇒ mayPromptWallet false', () => {
+    const access = resolvePcaOwnerAccess({ owner: undefined, primaryWallet: HOT, connectedWallet: null, primaryWalletState: 'loading' });
+    expect(access.mode).toBe('unknown');
+    expect(access.mayPromptWallet).toBe(false);
+  });
+
+  it('(vii) unknown (loading) + owner present but != connectedWallet ⇒ mayPromptWallet false', () => {
+    const access = resolvePcaOwnerAccess({ owner: EXTERNAL, primaryWallet: HOT, connectedWallet: HW, primaryWalletState: 'loading' });
+    expect(access.mode).toBe('unknown');
+    expect(access.mayPromptWallet).toBe(false);
+  });
+
+  it("(viii) #1469 wallets-loaded-before-snapshot: owner undefined, primaryWalletState 'ready', connectedWallet set ⇒ no-snapshot + mayPromptWallet true", () => {
+    // Distinct code path from (iv): wallets are READY but the PCA snapshot (owner) isn't loaded
+    // yet, so classification falls through to the `!owner` → no-snapshot branch. The lock must
+    // still arm for the connected wallet (the resolving submitter confirms the owner call-time).
+    const access = resolvePcaOwnerAccess({ owner: undefined, primaryWallet: HOT, connectedWallet: HW, primaryWalletState: 'ready' });
+    expect(access.mode).toBe('unknown');
+    expect(access.ownerUnknownCause).toBe('no-snapshot');
+    expect(access.mayPromptWallet).toBe(true);
+  });
+
+  it('(ix) loaded EXTERNAL-owned (a wallet is connected but is not the owner) ⇒ mayPromptWallet false', () => {
+    // Locks the `external` branch against a future fall-through: an external owner can never open a
+    // wallet prompt (the connected wallet isn't the owner), so the lock must stay disarmed.
+    const access = resolvePcaOwnerAccess({ owner: EXTERNAL, primaryWallet: HOT, connectedWallet: HW });
+    expect(access.mode).toBe('external');
+    expect(access.mayPromptWallet).toBe(false);
   });
 });
 

--- a/packages/node-ui/test/pca-owner-actions.test.ts
+++ b/packages/node-ui/test/pca-owner-actions.test.ts
@@ -51,8 +51,9 @@ const {
   daemonOwnerActionSubmitter,
   resolveOwnerActionSubmitterKind,
   submitterKindForOwnerMode,
-  useResolvingOwnerActionSubmitter,
-  useResolvedOwnerActionSubmitter,
+  useOwnerActionSubmitterForAccount,
+  useOwnerActionSubmitter,
+  resolveSignerKindForAccount,
 } = await import('../src/ui/pca/ownerActions.js');
 const { useWalletStore } = await import('../src/ui/stores/wallet.js');
 const { resolvePcaOwnerAccess } = await import('../src/ui/pca/ownerAccess.js');
@@ -142,31 +143,31 @@ describe('owner submitter resolver', () => {
     mocks.createPca.mockResolvedValue({ accountId: '1' });
     mocks.walletSubmitter.create.mockResolvedValue({ accountId: '2' });
 
-    await expect(useResolvingOwnerActionSubmitter().create({ tokens: '0.5', primaryNode: '41' }))
+    await expect(useOwnerActionSubmitterForAccount().create({ tokens: '0.5', primaryNode: '41' }))
       .resolves.toEqual({ accountId: '1' });
     expect(mocks.createPca).toHaveBeenCalledWith({ tokens: '0.5', primaryNode: '41' });
 
-    await expect(useResolvingOwnerActionSubmitter({ ownerKey: 'hot' }).create({ tokens: '1', primaryNode: '42' }))
+    await expect(useOwnerActionSubmitterForAccount({ ownerKey: 'hot' }).create({ tokens: '1', primaryNode: '42' }))
       .resolves.toEqual({ accountId: '1' });
     expect(mocks.createPca).toHaveBeenCalledWith({ tokens: '1', primaryNode: '42' });
 
     setConnected(HW);
-    await expect(useResolvingOwnerActionSubmitter({ ownerKey: 'hardware' }).create({ tokens: '2', primaryNode: '43' }))
+    await expect(useOwnerActionSubmitterForAccount({ ownerKey: 'hardware' }).create({ tokens: '2', primaryNode: '43' }))
       .resolves.toEqual({ accountId: '2' });
     expect(mocks.walletOwnerActionSubmitter).toHaveBeenCalled();
     expect(mocks.walletSubmitter.create).toHaveBeenCalledWith({ tokens: '2', primaryNode: '43' });
   });
 
   it('create ownerKey hardware fails unavailable without provider or expected chain before wallet signing', async () => {
-    await expect(useResolvingOwnerActionSubmitter({ ownerKey: 'hardware' }).create({ tokens: '1', primaryNode: '42' }))
+    await expect(useOwnerActionSubmitterForAccount({ ownerKey: 'hardware' }).create({ tokens: '1', primaryNode: '42' }))
       .rejects.toBeInstanceOf(OwnerActionUnavailableError);
 
     setConnected(HW, { chainId: 1, expectedChainId: 84532 });
-    await expect(useResolvingOwnerActionSubmitter({ ownerKey: 'hardware' }).create({ tokens: '1', primaryNode: '42' }))
+    await expect(useOwnerActionSubmitterForAccount({ ownerKey: 'hardware' }).create({ tokens: '1', primaryNode: '42' }))
       .rejects.toBeInstanceOf(OwnerActionUnavailableError);
 
     setConnected(HW, { bootstrap: null });
-    await expect(useResolvingOwnerActionSubmitter({ ownerKey: 'hardware' }).create({ tokens: '1', primaryNode: '42' }))
+    await expect(useOwnerActionSubmitterForAccount({ ownerKey: 'hardware' }).create({ tokens: '1', primaryNode: '42' }))
       .rejects.toBeInstanceOf(OwnerActionUnavailableError);
 
     expect(mocks.walletOwnerActionSubmitter).not.toHaveBeenCalled();
@@ -179,7 +180,7 @@ describe('owner submitter resolver', () => {
     mocks.fetchWalletsBalances.mockResolvedValue({ wallets: [HOT] });
     mocks.pcaAddAgent.mockResolvedValue({ registered: true });
 
-    await expect(useResolvingOwnerActionSubmitter({ accountId: '7' }).registerAgent('7', AGENT))
+    await expect(useOwnerActionSubmitterForAccount({ accountId: '7' }).registerAgent('7', AGENT))
       .resolves.toEqual({ registered: true });
 
     expect(mocks.fetchPca).toHaveBeenCalledWith('7');
@@ -193,7 +194,7 @@ describe('owner submitter resolver', () => {
     mocks.fetchWalletsBalances.mockResolvedValue({ wallets: [HOT] });
     mocks.walletSubmitter.topUp.mockResolvedValue({ addedTokens: '10' });
 
-    await expect(useResolvingOwnerActionSubmitter({ accountId: '7' }).topUp('7', '10'))
+    await expect(useOwnerActionSubmitterForAccount({ accountId: '7' }).topUp('7', '10'))
       .resolves.toEqual({ addedTokens: '10' });
 
     expect(mocks.pcaTopUp).not.toHaveBeenCalled();
@@ -205,7 +206,7 @@ describe('owner submitter resolver', () => {
     mocks.fetchPca.mockResolvedValue({ owner: EXTERNAL });
     mocks.fetchWalletsBalances.mockResolvedValue({ wallets: [HOT] });
 
-    await expect(useResolvingOwnerActionSubmitter({ accountId: '7' }).deregisterAgent('7', AGENT))
+    await expect(useOwnerActionSubmitterForAccount({ accountId: '7' }).deregisterAgent('7', AGENT))
       .rejects.toBeInstanceOf(ReadOnlyOwnerActionError);
 
     expect(mocks.pcaRemoveAgent).not.toHaveBeenCalled();
@@ -216,7 +217,7 @@ describe('owner submitter resolver', () => {
     setConnected(HW);
     mocks.fetchPca.mockRejectedValue(new Error('read failed'));
 
-    await expect(useResolvingOwnerActionSubmitter({ accountId: '7' }).topUp('7', '10'))
+    await expect(useOwnerActionSubmitterForAccount({ accountId: '7' }).topUp('7', '10'))
       .rejects.toBeInstanceOf(OwnerActionUnavailableError);
 
     expect(mocks.pcaTopUp).not.toHaveBeenCalled();
@@ -228,11 +229,11 @@ describe('owner submitter resolver', () => {
     mocks.fetchWalletsBalances.mockResolvedValue({ wallets: [HOT] });
 
     setConnected(HW, { chainId: 1, expectedChainId: 84532 });
-    await expect(useResolvingOwnerActionSubmitter({ accountId: '7' }).registerAgent('7', AGENT))
+    await expect(useOwnerActionSubmitterForAccount({ accountId: '7' }).registerAgent('7', AGENT))
       .rejects.toBeInstanceOf(OwnerActionUnavailableError);
 
     setConnected(HW, { provider: null });
-    await expect(useResolvingOwnerActionSubmitter({ accountId: '7' }).registerAgent('7', AGENT))
+    await expect(useOwnerActionSubmitterForAccount({ accountId: '7' }).registerAgent('7', AGENT))
       .rejects.toBeInstanceOf(OwnerActionUnavailableError);
 
     expect(mocks.walletSubmitter.registerAgent).not.toHaveBeenCalled();
@@ -242,7 +243,7 @@ describe('owner submitter resolver', () => {
     setConnected(HW);
     mocks.pcaSettle.mockResolvedValue({ settled: true });
 
-    await expect(useResolvingOwnerActionSubmitter({ accountId: '7' }).settle('7')).resolves.toEqual({ settled: true });
+    await expect(useOwnerActionSubmitterForAccount({ accountId: '7' }).settle('7')).resolves.toEqual({ settled: true });
 
     expect(mocks.pcaSettle).toHaveBeenCalledWith('7');
     expect(mocks.walletSubmitter.settle).not.toHaveBeenCalled();
@@ -262,16 +263,72 @@ describe('submitterKindForOwnerMode', () => {
   });
 });
 
+// #1470 — the folded cross-account signer-kind planner. Pins byte-fidelity to the old inline
+// `ApproveWalletsModal.signerKindForAccount` + the gate-caught correlation contract: the daemon
+// branch uses the CALLER-PASSED primaryWallet (already-loaded wallets[0]), and the wallet branch
+// depends ONLY on the connected wallet — NEITHER re-fetches the wallet list, so a wallet-list blip
+// can't disarm the R4 lock via a planning/execution desync.
+describe('resolveSignerKindForAccount (folded signerKindForAccount)', () => {
+  it('daemon: owner == passed primaryWallet ⇒ daemon (no fetchWalletsBalances)', async () => {
+    mocks.fetchPca.mockResolvedValue({ owner: HOT });
+    setConnected(HW);
+    expect(await resolveSignerKindForAccount('4', HOT)).toBe('daemon');
+    expect(mocks.fetchWalletsBalances).not.toHaveBeenCalled();
+  });
+
+  it('wallet: owner == connected wallet on the right network ⇒ wallet', async () => {
+    mocks.fetchPca.mockResolvedValue({ owner: HW });
+    setConnected(HW);
+    expect(await resolveSignerKindForAccount('4', HOT)).toBe('wallet');
+    expect(mocks.fetchWalletsBalances).not.toHaveBeenCalled();
+  });
+
+  // THE REGRESSION PIN (gate): the wallet branch keys ONLY on the connected wallet — it must NOT
+  // depend on this node's wallet list. So a wallet-owned old account still classifies 'wallet' even
+  // when the node's primary wallet is unknown (undefined), matching the old inline predicate. A
+  // fresh internal fetchWalletsBalances (removed) would have returned undefined here on a blip and
+  // silently disarmed the renew device prompt / R4 lock.
+  it('wallet branch does NOT depend on the node wallet list: primaryWallet undefined ⇒ still wallet', async () => {
+    mocks.fetchPca.mockResolvedValue({ owner: HW });
+    setConnected(HW);
+    expect(await resolveSignerKindForAccount('4', undefined)).toBe('wallet');
+    expect(mocks.fetchWalletsBalances).not.toHaveBeenCalled();
+  });
+
+  it('wrong network wallet owner ⇒ undefined (not counted as a device prompt)', async () => {
+    mocks.fetchPca.mockResolvedValue({ owner: HW });
+    setConnected(HW, { chainId: 1, expectedChainId: 84532 });
+    expect(await resolveSignerKindForAccount('4', HOT)).toBeUndefined();
+  });
+
+  it('external owner ⇒ undefined', async () => {
+    mocks.fetchPca.mockResolvedValue({ owner: EXTERNAL });
+    setConnected(HW);
+    expect(await resolveSignerKindForAccount('4', HOT)).toBeUndefined();
+  });
+
+  it('fetchPca read failure ⇒ undefined (correlated with the execution path)', async () => {
+    mocks.fetchPca.mockRejectedValue(new Error('read failed'));
+    setConnected(HW);
+    expect(await resolveSignerKindForAccount('4', HOT)).toBeUndefined();
+  });
+
+  it('no accountId ⇒ undefined (no fetch)', async () => {
+    expect(await resolveSignerKindForAccount(undefined, HOT)).toBeUndefined();
+    expect(mocks.fetchPca).not.toHaveBeenCalled();
+  });
+});
+
 // Item 3 (#1375) — when the caller passes the display-resolved `access`, the submitter is
 // selected ONCE up-front and the manage writes submit DIRECTLY, with no per-write owner/wallet
 // re-fetch. (The absent-access path above is unchanged; the wallet submitter's per-prompt
 // liveness guards still run on every write — covered by pca-wallet-owner-actions.)
-describe('useResolvedOwnerActionSubmitter access-path (resolve signer once)', () => {
+describe('useOwnerActionSubmitter access-path (resolve signer once)', () => {
   it('daemon access submits via the daemon EOA WITHOUT re-fetching owner/wallets', async () => {
     mocks.pcaAddAgent.mockResolvedValue({ registered: true });
     const access = resolvePcaOwnerAccess({ owner: HOT, primaryWallet: HOT, connectedWallet: HOT });
 
-    await expect(useResolvedOwnerActionSubmitter({ access }).registerAgent('7', AGENT))
+    await expect(useOwnerActionSubmitter({ access }).registerAgent('7', AGENT))
       .resolves.toEqual({ registered: true });
 
     expect(mocks.pcaAddAgent).toHaveBeenCalledWith('7', AGENT);
@@ -288,7 +345,7 @@ describe('useResolvedOwnerActionSubmitter access-path (resolve signer once)', ()
     const access = resolvePcaOwnerAccess({ owner: HW, primaryWallet: HOT, connectedWallet: HW });
     expect(access.mode).toBe('wallet');
 
-    await expect(useResolvedOwnerActionSubmitter({ access }).topUp('7', '5'))
+    await expect(useOwnerActionSubmitter({ access }).topUp('7', '5'))
       .resolves.toEqual({ addedTokens: '5' });
 
     // T1: it does NOT pin from the render-time access — it re-fetches the PCA owner first...
@@ -305,7 +362,7 @@ describe('useResolvedOwnerActionSubmitter access-path (resolve signer once)', ()
     const access = resolvePcaOwnerAccess({ owner: HW, primaryWallet: HOT, connectedWallet: HW });
     expect(access.mode).toBe('wallet'); // the stale render-time classification
 
-    await expect(useResolvedOwnerActionSubmitter({ access }).topUp('7', '5'))
+    await expect(useOwnerActionSubmitter({ access }).topUp('7', '5'))
       .rejects.toBeInstanceOf(ReadOnlyOwnerActionError);
 
     // The re-fetch caught the stale owner and returned read-only FIRST — the wallet approve/write
@@ -318,7 +375,7 @@ describe('useResolvedOwnerActionSubmitter access-path (resolve signer once)', ()
   it('read-only access throws ReadOnlyOwnerActionError WITHOUT re-fetching or signing', async () => {
     const access = resolvePcaOwnerAccess({ owner: EXTERNAL, primaryWallet: HOT, connectedWallet: HW });
 
-    await expect(useResolvedOwnerActionSubmitter({ access }).deregisterAgent('7', AGENT))
+    await expect(useOwnerActionSubmitter({ access }).deregisterAgent('7', AGENT))
       .rejects.toBeInstanceOf(ReadOnlyOwnerActionError);
 
     expect(mocks.fetchPca).not.toHaveBeenCalled();
@@ -331,7 +388,7 @@ describe('useResolvedOwnerActionSubmitter access-path (resolve signer once)', ()
     mocks.pcaSettle.mockResolvedValue({ settled: true });
     const access = resolvePcaOwnerAccess({ owner: HW, primaryWallet: HOT, connectedWallet: HW });
 
-    await expect(useResolvedOwnerActionSubmitter({ access }).settle('7')).resolves.toEqual({ settled: true });
+    await expect(useOwnerActionSubmitter({ access }).settle('7')).resolves.toEqual({ settled: true });
 
     expect(mocks.pcaSettle).toHaveBeenCalledWith('7');
     expect(mocks.walletSubmitter.settle).not.toHaveBeenCalled();
@@ -347,7 +404,7 @@ describe('useResolvedOwnerActionSubmitter access-path (resolve signer once)', ()
     const access = resolvePcaOwnerAccess({ owner: undefined, primaryWallet: HOT, connectedWallet: HOT });
     expect(access.mode).toBe('unknown');
 
-    await expect(useResolvedOwnerActionSubmitter({ access }).registerAgent('7', AGENT))
+    await expect(useOwnerActionSubmitter({ access }).registerAgent('7', AGENT))
       .resolves.toEqual({ registered: true });
 
     // Fell back to the resolving path: RE-FETCHED the owner and resolved daemon → registered.
@@ -355,18 +412,18 @@ describe('useResolvedOwnerActionSubmitter access-path (resolve signer once)', ()
     expect(mocks.pcaAddAgent).toHaveBeenCalledWith('7', AGENT);
   });
 
-  it('T5: daemon-owned target whose wallets are STILL LOADING (walletsUnknown) is NOT pinned read-only', async () => {
+  it("T5: daemon-owned target whose wallets are STILL LOADING (primaryWalletState 'loading') is NOT pinned read-only", async () => {
     // The approve modal builds access before fetchWalletsBalances resolves — owner known,
-    // primaryWallet undefined. WITHOUT walletsUnknown that would misclassify a daemon-owned PCA
-    // as external → pin read-only → fail a valid owner approval. With walletsUnknown it is
-    // 'unknown', so the write re-fetches wallets and routes daemon; approval succeeds.
+    // primaryWallet undefined. WITHOUT the loading state that would misclassify a daemon-owned PCA
+    // as external → pin read-only → fail a valid owner approval. With primaryWalletState 'loading'
+    // it is 'unknown', so the write re-fetches wallets and routes daemon; approval succeeds.
     mocks.fetchPca.mockResolvedValue({ owner: HOT });
     mocks.fetchWalletsBalances.mockResolvedValue({ wallets: [HOT] });
     mocks.pcaAddAgent.mockResolvedValue({ registered: true });
-    const access = resolvePcaOwnerAccess({ owner: HOT, primaryWallet: undefined, connectedWallet: HW, walletsUnknown: true });
+    const access = resolvePcaOwnerAccess({ owner: HOT, primaryWallet: undefined, connectedWallet: HW, primaryWalletState: 'loading' });
     expect(access.mode).toBe('unknown'); // NOT 'external' — the fix
 
-    await expect(useResolvedOwnerActionSubmitter({ access }).registerAgent('8', AGENT))
+    await expect(useOwnerActionSubmitter({ access }).registerAgent('8', AGENT))
       .resolves.toEqual({ registered: true });
 
     expect(mocks.pcaAddAgent).toHaveBeenCalledWith('8', AGENT); // daemon, via the re-fetch

--- a/packages/node-ui/test/pca-owner-actions.test.ts
+++ b/packages/node-ui/test/pca-owner-actions.test.ts
@@ -51,8 +51,8 @@ const {
   daemonOwnerActionSubmitter,
   resolveOwnerActionSubmitterKind,
   submitterKindForOwnerMode,
-  useOwnerActionSubmitterForAccount,
-  useOwnerActionSubmitter,
+  useResolvingOwnerActionSubmitter,
+  usePinnedOwnerActionSubmitter,
   resolveSignerKindForAccount,
 } = await import('../src/ui/pca/ownerActions.js');
 const { useWalletStore } = await import('../src/ui/stores/wallet.js');
@@ -143,31 +143,31 @@ describe('owner submitter resolver', () => {
     mocks.createPca.mockResolvedValue({ accountId: '1' });
     mocks.walletSubmitter.create.mockResolvedValue({ accountId: '2' });
 
-    await expect(useOwnerActionSubmitterForAccount().create({ tokens: '0.5', primaryNode: '41' }))
+    await expect(useResolvingOwnerActionSubmitter().create({ tokens: '0.5', primaryNode: '41' }))
       .resolves.toEqual({ accountId: '1' });
     expect(mocks.createPca).toHaveBeenCalledWith({ tokens: '0.5', primaryNode: '41' });
 
-    await expect(useOwnerActionSubmitterForAccount({ ownerKey: 'hot' }).create({ tokens: '1', primaryNode: '42' }))
+    await expect(useResolvingOwnerActionSubmitter({ ownerKey: 'hot' }).create({ tokens: '1', primaryNode: '42' }))
       .resolves.toEqual({ accountId: '1' });
     expect(mocks.createPca).toHaveBeenCalledWith({ tokens: '1', primaryNode: '42' });
 
     setConnected(HW);
-    await expect(useOwnerActionSubmitterForAccount({ ownerKey: 'hardware' }).create({ tokens: '2', primaryNode: '43' }))
+    await expect(useResolvingOwnerActionSubmitter({ ownerKey: 'hardware' }).create({ tokens: '2', primaryNode: '43' }))
       .resolves.toEqual({ accountId: '2' });
     expect(mocks.walletOwnerActionSubmitter).toHaveBeenCalled();
     expect(mocks.walletSubmitter.create).toHaveBeenCalledWith({ tokens: '2', primaryNode: '43' });
   });
 
   it('create ownerKey hardware fails unavailable without provider or expected chain before wallet signing', async () => {
-    await expect(useOwnerActionSubmitterForAccount({ ownerKey: 'hardware' }).create({ tokens: '1', primaryNode: '42' }))
+    await expect(useResolvingOwnerActionSubmitter({ ownerKey: 'hardware' }).create({ tokens: '1', primaryNode: '42' }))
       .rejects.toBeInstanceOf(OwnerActionUnavailableError);
 
     setConnected(HW, { chainId: 1, expectedChainId: 84532 });
-    await expect(useOwnerActionSubmitterForAccount({ ownerKey: 'hardware' }).create({ tokens: '1', primaryNode: '42' }))
+    await expect(useResolvingOwnerActionSubmitter({ ownerKey: 'hardware' }).create({ tokens: '1', primaryNode: '42' }))
       .rejects.toBeInstanceOf(OwnerActionUnavailableError);
 
     setConnected(HW, { bootstrap: null });
-    await expect(useOwnerActionSubmitterForAccount({ ownerKey: 'hardware' }).create({ tokens: '1', primaryNode: '42' }))
+    await expect(useResolvingOwnerActionSubmitter({ ownerKey: 'hardware' }).create({ tokens: '1', primaryNode: '42' }))
       .rejects.toBeInstanceOf(OwnerActionUnavailableError);
 
     expect(mocks.walletOwnerActionSubmitter).not.toHaveBeenCalled();
@@ -180,7 +180,7 @@ describe('owner submitter resolver', () => {
     mocks.fetchWalletsBalances.mockResolvedValue({ wallets: [HOT] });
     mocks.pcaAddAgent.mockResolvedValue({ registered: true });
 
-    await expect(useOwnerActionSubmitterForAccount({ accountId: '7' }).registerAgent('7', AGENT))
+    await expect(useResolvingOwnerActionSubmitter().registerAgent('7', AGENT))
       .resolves.toEqual({ registered: true });
 
     expect(mocks.fetchPca).toHaveBeenCalledWith('7');
@@ -194,7 +194,7 @@ describe('owner submitter resolver', () => {
     mocks.fetchWalletsBalances.mockResolvedValue({ wallets: [HOT] });
     mocks.walletSubmitter.topUp.mockResolvedValue({ addedTokens: '10' });
 
-    await expect(useOwnerActionSubmitterForAccount({ accountId: '7' }).topUp('7', '10'))
+    await expect(useResolvingOwnerActionSubmitter().topUp('7', '10'))
       .resolves.toEqual({ addedTokens: '10' });
 
     expect(mocks.pcaTopUp).not.toHaveBeenCalled();
@@ -206,7 +206,7 @@ describe('owner submitter resolver', () => {
     mocks.fetchPca.mockResolvedValue({ owner: EXTERNAL });
     mocks.fetchWalletsBalances.mockResolvedValue({ wallets: [HOT] });
 
-    await expect(useOwnerActionSubmitterForAccount({ accountId: '7' }).deregisterAgent('7', AGENT))
+    await expect(useResolvingOwnerActionSubmitter().deregisterAgent('7', AGENT))
       .rejects.toBeInstanceOf(ReadOnlyOwnerActionError);
 
     expect(mocks.pcaRemoveAgent).not.toHaveBeenCalled();
@@ -217,7 +217,7 @@ describe('owner submitter resolver', () => {
     setConnected(HW);
     mocks.fetchPca.mockRejectedValue(new Error('read failed'));
 
-    await expect(useOwnerActionSubmitterForAccount({ accountId: '7' }).topUp('7', '10'))
+    await expect(useResolvingOwnerActionSubmitter().topUp('7', '10'))
       .rejects.toBeInstanceOf(OwnerActionUnavailableError);
 
     expect(mocks.pcaTopUp).not.toHaveBeenCalled();
@@ -229,11 +229,11 @@ describe('owner submitter resolver', () => {
     mocks.fetchWalletsBalances.mockResolvedValue({ wallets: [HOT] });
 
     setConnected(HW, { chainId: 1, expectedChainId: 84532 });
-    await expect(useOwnerActionSubmitterForAccount({ accountId: '7' }).registerAgent('7', AGENT))
+    await expect(useResolvingOwnerActionSubmitter().registerAgent('7', AGENT))
       .rejects.toBeInstanceOf(OwnerActionUnavailableError);
 
     setConnected(HW, { provider: null });
-    await expect(useOwnerActionSubmitterForAccount({ accountId: '7' }).registerAgent('7', AGENT))
+    await expect(useResolvingOwnerActionSubmitter().registerAgent('7', AGENT))
       .rejects.toBeInstanceOf(OwnerActionUnavailableError);
 
     expect(mocks.walletSubmitter.registerAgent).not.toHaveBeenCalled();
@@ -243,7 +243,7 @@ describe('owner submitter resolver', () => {
     setConnected(HW);
     mocks.pcaSettle.mockResolvedValue({ settled: true });
 
-    await expect(useOwnerActionSubmitterForAccount({ accountId: '7' }).settle('7')).resolves.toEqual({ settled: true });
+    await expect(useResolvingOwnerActionSubmitter().settle('7')).resolves.toEqual({ settled: true });
 
     expect(mocks.pcaSettle).toHaveBeenCalledWith('7');
     expect(mocks.walletSubmitter.settle).not.toHaveBeenCalled();
@@ -317,12 +317,12 @@ describe('resolveSignerKindForAccount (folded signerKindForAccount)', () => {
 // selected ONCE up-front and the manage writes submit DIRECTLY, with no per-write owner/wallet
 // re-fetch. (The absent-access path above is unchanged; the wallet submitter's per-prompt
 // liveness guards still run on every write — covered by pca-wallet-owner-actions.)
-describe('useOwnerActionSubmitter access-path (resolve signer once)', () => {
+describe('usePinnedOwnerActionSubmitter access-path (resolve signer once)', () => {
   it('daemon access submits via the daemon EOA WITHOUT re-fetching owner/wallets', async () => {
     mocks.pcaAddAgent.mockResolvedValue({ registered: true });
     const access = resolvePcaOwnerAccess({ owner: HOT, primaryWallet: HOT, connectedWallet: HOT });
 
-    await expect(useOwnerActionSubmitter({ access }).registerAgent('7', AGENT))
+    await expect(usePinnedOwnerActionSubmitter({ access }).registerAgent('7', AGENT))
       .resolves.toEqual({ registered: true });
 
     expect(mocks.pcaAddAgent).toHaveBeenCalledWith('7', AGENT);
@@ -339,7 +339,7 @@ describe('useOwnerActionSubmitter access-path (resolve signer once)', () => {
     const access = resolvePcaOwnerAccess({ owner: HW, primaryWallet: HOT, connectedWallet: HW });
     expect(access.mode).toBe('wallet');
 
-    await expect(useOwnerActionSubmitter({ access }).topUp('7', '5'))
+    await expect(usePinnedOwnerActionSubmitter({ access }).topUp('7', '5'))
       .resolves.toEqual({ addedTokens: '5' });
 
     // T1: it does NOT pin from the render-time access — it re-fetches the PCA owner first...
@@ -356,7 +356,7 @@ describe('useOwnerActionSubmitter access-path (resolve signer once)', () => {
     const access = resolvePcaOwnerAccess({ owner: HW, primaryWallet: HOT, connectedWallet: HW });
     expect(access.mode).toBe('wallet'); // the stale render-time classification
 
-    await expect(useOwnerActionSubmitter({ access }).topUp('7', '5'))
+    await expect(usePinnedOwnerActionSubmitter({ access }).topUp('7', '5'))
       .rejects.toBeInstanceOf(ReadOnlyOwnerActionError);
 
     // The re-fetch caught the stale owner and returned read-only FIRST — the wallet approve/write
@@ -369,7 +369,7 @@ describe('useOwnerActionSubmitter access-path (resolve signer once)', () => {
   it('read-only access throws ReadOnlyOwnerActionError WITHOUT re-fetching or signing', async () => {
     const access = resolvePcaOwnerAccess({ owner: EXTERNAL, primaryWallet: HOT, connectedWallet: HW });
 
-    await expect(useOwnerActionSubmitter({ access }).deregisterAgent('7', AGENT))
+    await expect(usePinnedOwnerActionSubmitter({ access }).deregisterAgent('7', AGENT))
       .rejects.toBeInstanceOf(ReadOnlyOwnerActionError);
 
     expect(mocks.fetchPca).not.toHaveBeenCalled();
@@ -382,7 +382,7 @@ describe('useOwnerActionSubmitter access-path (resolve signer once)', () => {
     mocks.pcaSettle.mockResolvedValue({ settled: true });
     const access = resolvePcaOwnerAccess({ owner: HW, primaryWallet: HOT, connectedWallet: HW });
 
-    await expect(useOwnerActionSubmitter({ access }).settle('7')).resolves.toEqual({ settled: true });
+    await expect(usePinnedOwnerActionSubmitter({ access }).settle('7')).resolves.toEqual({ settled: true });
 
     expect(mocks.pcaSettle).toHaveBeenCalledWith('7');
     expect(mocks.walletSubmitter.settle).not.toHaveBeenCalled();
@@ -398,7 +398,7 @@ describe('useOwnerActionSubmitter access-path (resolve signer once)', () => {
     const access = resolvePcaOwnerAccess({ owner: undefined, primaryWallet: HOT, connectedWallet: HOT });
     expect(access.mode).toBe('unknown');
 
-    await expect(useOwnerActionSubmitter({ access }).registerAgent('7', AGENT))
+    await expect(usePinnedOwnerActionSubmitter({ access }).registerAgent('7', AGENT))
       .resolves.toEqual({ registered: true });
 
     // Fell back to the resolving path: RE-FETCHED the owner and resolved daemon → registered.
@@ -417,7 +417,7 @@ describe('useOwnerActionSubmitter access-path (resolve signer once)', () => {
     const access = resolvePcaOwnerAccess({ owner: HOT, primaryWallet: undefined, connectedWallet: HW, primaryWalletState: 'loading' });
     expect(access.mode).toBe('unknown'); // NOT 'external' — the fix
 
-    await expect(useOwnerActionSubmitter({ access }).registerAgent('8', AGENT))
+    await expect(usePinnedOwnerActionSubmitter({ access }).registerAgent('8', AGENT))
       .resolves.toEqual({ registered: true });
 
     expect(mocks.pcaAddAgent).toHaveBeenCalledWith('8', AGENT); // daemon, via the re-fetch

--- a/packages/node-ui/test/pca-owner-actions.test.ts
+++ b/packages/node-ui/test/pca-owner-actions.test.ts
@@ -264,22 +264,20 @@ describe('submitterKindForOwnerMode', () => {
 });
 
 // #1470 — the folded cross-account signer-kind planner. Pins byte-fidelity to the old inline
-// `ApproveWalletsModal.signerKindForAccount` + the gate-caught correlation contract: the daemon
-// branch uses the CALLER-PASSED primaryWallet (already-loaded wallets[0]), and the wallet branch
-// depends ONLY on the connected wallet — NEITHER re-fetches the wallet list, so a wallet-list blip
-// can't disarm the R4 lock via a planning/execution desync.
+// `ApproveWalletsModal.signerKindForAccount` + the gate-caught correlation contract: ALL
+// classification inputs (primaryWallet / connectedWallet / walletWrongNetwork) are passed
+// EXPLICITLY — NO ambient wallet-store reads and NO wallet-list refetch — so a wallet-list blip
+// can't disarm the R4 lock via a planning/execution desync, and the only async is `fetchPca`.
 describe('resolveSignerKindForAccount (folded signerKindForAccount)', () => {
   it('daemon: owner == passed primaryWallet ⇒ daemon (no fetchWalletsBalances)', async () => {
     mocks.fetchPca.mockResolvedValue({ owner: HOT });
-    setConnected(HW);
-    expect(await resolveSignerKindForAccount('4', HOT)).toBe('daemon');
+    expect(await resolveSignerKindForAccount({ accountId: '4', primaryWallet: HOT, connectedWallet: HW, walletWrongNetwork: false })).toBe('daemon');
     expect(mocks.fetchWalletsBalances).not.toHaveBeenCalled();
   });
 
   it('wallet: owner == connected wallet on the right network ⇒ wallet', async () => {
     mocks.fetchPca.mockResolvedValue({ owner: HW });
-    setConnected(HW);
-    expect(await resolveSignerKindForAccount('4', HOT)).toBe('wallet');
+    expect(await resolveSignerKindForAccount({ accountId: '4', primaryWallet: HOT, connectedWallet: HW, walletWrongNetwork: false })).toBe('wallet');
     expect(mocks.fetchWalletsBalances).not.toHaveBeenCalled();
   });
 
@@ -290,31 +288,27 @@ describe('resolveSignerKindForAccount (folded signerKindForAccount)', () => {
   // silently disarmed the renew device prompt / R4 lock.
   it('wallet branch does NOT depend on the node wallet list: primaryWallet undefined ⇒ still wallet', async () => {
     mocks.fetchPca.mockResolvedValue({ owner: HW });
-    setConnected(HW);
-    expect(await resolveSignerKindForAccount('4', undefined)).toBe('wallet');
+    expect(await resolveSignerKindForAccount({ accountId: '4', primaryWallet: undefined, connectedWallet: HW, walletWrongNetwork: false })).toBe('wallet');
     expect(mocks.fetchWalletsBalances).not.toHaveBeenCalled();
   });
 
   it('wrong network wallet owner ⇒ undefined (not counted as a device prompt)', async () => {
     mocks.fetchPca.mockResolvedValue({ owner: HW });
-    setConnected(HW, { chainId: 1, expectedChainId: 84532 });
-    expect(await resolveSignerKindForAccount('4', HOT)).toBeUndefined();
+    expect(await resolveSignerKindForAccount({ accountId: '4', primaryWallet: HOT, connectedWallet: HW, walletWrongNetwork: true })).toBeUndefined();
   });
 
   it('external owner ⇒ undefined', async () => {
     mocks.fetchPca.mockResolvedValue({ owner: EXTERNAL });
-    setConnected(HW);
-    expect(await resolveSignerKindForAccount('4', HOT)).toBeUndefined();
+    expect(await resolveSignerKindForAccount({ accountId: '4', primaryWallet: HOT, connectedWallet: HW, walletWrongNetwork: false })).toBeUndefined();
   });
 
   it('fetchPca read failure ⇒ undefined (correlated with the execution path)', async () => {
     mocks.fetchPca.mockRejectedValue(new Error('read failed'));
-    setConnected(HW);
-    expect(await resolveSignerKindForAccount('4', HOT)).toBeUndefined();
+    expect(await resolveSignerKindForAccount({ accountId: '4', primaryWallet: HOT, connectedWallet: HW })).toBeUndefined();
   });
 
   it('no accountId ⇒ undefined (no fetch)', async () => {
-    expect(await resolveSignerKindForAccount(undefined, HOT)).toBeUndefined();
+    expect(await resolveSignerKindForAccount({ accountId: undefined, primaryWallet: HOT, connectedWallet: HW })).toBeUndefined();
     expect(mocks.fetchPca).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## What & why
Consolidates the last of the PCA owner/signer planning into the centralized owner-access model (`#1470`) and closes the snapshot-load-window sibling of the #1468 **R4** wallet-signing lock (`#1469`).

Fixes #1470
Fixes #1469

## Changes
**Model (`pca/ownerAccess.ts`)**
- Replace the overloaded `walletsUnknown` boolean with a typed **`primaryWalletState: 'loading' | 'unreadable' | 'ready'`** (+ a `wallets-loading` unknown cause). The two consumers had *diverged* on the loading signal, so a daemon-owned PCA could flash **read-only** in the detail view during the balances load; the model now unifies them (loading → `unknown`, never a definitive non-owner verdict).
- Add a derived **`mayPromptWallet`** — the single target-write signing plan the approve modal reads. It subsumes the R4 branch and **closes #1469**: the lock now arms in the *snapshot*-load window too (owner not-yet-known + a connected wallet), so a wallet-signed approve can never run under the daemon (no-prompt, freely-dismissable) contract. inv-17 classification is byte-unchanged.

**Consumers**
- `ApproveWalletsModal`: `targetWalletManaged = access.mayPromptWallet`; the async cross-account `signerKindForAccount` is folded behind a shared `resolveSignerKindForAccount`.
- `ConvictionDetailView`: switches to `primaryWalletState`; splits the owner-unknown gate — pure loading shows a neutral **"Confirming ownership…"** (no false "Couldn't load", no Retry); only a genuine read failure keeps the error + Retry.

**Strategy-named submitter factories (#1470 item 2)** — behaviour-preserving rename across all 5 call sites: `useResolvedOwnerActionSubmitter` → `useOwnerActionSubmitter` (same-account, access-pinned), `useResolvingOwnerActionSubmitter` → `useOwnerActionSubmitterForAccount` (per-call resolving).

## Invariants
- **inv-16:** `web3/walletOwnerActionSubmitter.ts` **byte-untouched** (per-prompt liveness guards stay call-time).
- **inv-17:** owner precedence + address-only classification unchanged.

## Verification
- **556** node-UI PCA unit tests green; **tsc zero-delta** (0 errors in touched files).
- **4-lens adversarial gate: GO.** It caught one real MEDIUM — the folded `resolveSignerKindForAccount` initially did an internal `fetchWalletsBalances`, adding an *uncorrelated* failure path that could disarm the R4 lock on a transient blip during a cross-signer renew. **Fixed:** the resolver now takes the caller's already-loaded `primaryWallet`, restoring the old inline predicate's correlation; pinned by new resolver unit tests (incl. "wallet branch does not depend on the node wallet list").
- Spend-free testnet browser smoke to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
