### PR TITLE
Bound Hub rotation poll reads

### DIFF
--- a/packages/chain/src/hub-rotation-poller.ts
+++ b/packages/chain/src/hub-rotation-poller.ts
@@ -1,5 +1,7 @@
 import { Contract, ethers, type JsonRpcProvider } from 'ethers';
 import type { ReadOpts } from './rpc-failover-client.js';
+import { withTimeout } from './evm-adapter-rpc.js';
+import { RPC_LOG_SCAN_TIMEOUT_MS, RPC_READ_STALL_TIMEOUT_MS } from './evm-adapter-constants.js';
 
 export type HubRotationReadProvider = <T>(
   label: string,
@@ -93,13 +95,14 @@ export class HubRotationPoller {
     if (!this.started || !binding || binding.topics.length === 0 || generation !== this.generation) return;
 
     const previousLastScannedBlock = this.lastScannedBlock;
-    const head = await this.readProvider(
+    const head = await this.readWithTimeout(
       'Hub rotation poll getBlockNumber',
       (provider) => provider.getBlockNumber(),
+      RPC_READ_STALL_TIMEOUT_MS,
     );
     if (!this.started || generation !== this.generation) return;
     const fromBlock = this.scanFromBlock(previousLastScannedBlock, head);
-    const logs = await this.readProvider<ethers.Log[]>(
+    const logs = await this.readWithTimeout<ethers.Log[]>(
       'Hub rotation poll getLogs',
       (provider) => provider.getLogs({
         address: binding.hubAddress,
@@ -107,6 +110,7 @@ export class HubRotationPoller {
         toBlock: head,
         topics: [binding.topics],
       }),
+      RPC_LOG_SCAN_TIMEOUT_MS,
       { policy: 'wideLogScan' },
     );
     if (!this.started || generation !== this.generation) return;
@@ -116,6 +120,15 @@ export class HubRotationPoller {
       ? head
       : Math.max(previousLastScannedBlock, head);
     this.pruneSeenLogs(head);
+  }
+
+  private readWithTimeout<T>(
+    label: string,
+    fn: (provider: JsonRpcProvider) => Promise<T>,
+    timeoutMs: number,
+    opts?: ReadOpts,
+  ): Promise<T> {
+    return withTimeout(this.readProvider(label, fn, opts), timeoutMs, label);
   }
 
   private scanFromBlock(previousLastScannedBlock: number | undefined, head: number): number {

--- a/packages/chain/src/hub-rotation-poller.ts
+++ b/packages/chain/src/hub-rotation-poller.ts
@@ -1,7 +1,5 @@
 import { Contract, ethers, type JsonRpcProvider } from 'ethers';
 import type { ReadOpts } from './rpc-failover-client.js';
-import { withTimeout } from './evm-adapter-rpc.js';
-import { RPC_LOG_SCAN_TIMEOUT_MS, RPC_READ_STALL_TIMEOUT_MS } from './evm-adapter-constants.js';
 
 export type HubRotationReadProvider = <T>(
   label: string,
@@ -95,14 +93,14 @@ export class HubRotationPoller {
     if (!this.started || !binding || binding.topics.length === 0 || generation !== this.generation) return;
 
     const previousLastScannedBlock = this.lastScannedBlock;
-    const head = await this.readWithTimeout(
+    const head = await this.readProvider(
       'Hub rotation poll getBlockNumber',
       (provider) => provider.getBlockNumber(),
-      RPC_READ_STALL_TIMEOUT_MS,
+      { capSingleProvider: true },
     );
     if (!this.started || generation !== this.generation) return;
     const fromBlock = this.scanFromBlock(previousLastScannedBlock, head);
-    const logs = await this.readWithTimeout<ethers.Log[]>(
+    const logs = await this.readProvider<ethers.Log[]>(
       'Hub rotation poll getLogs',
       (provider) => provider.getLogs({
         address: binding.hubAddress,
@@ -110,8 +108,7 @@ export class HubRotationPoller {
         toBlock: head,
         topics: [binding.topics],
       }),
-      RPC_LOG_SCAN_TIMEOUT_MS,
-      { policy: 'wideLogScan' },
+      { policy: 'wideLogScan', capSingleProvider: true },
     );
     if (!this.started || generation !== this.generation) return;
 
@@ -120,15 +117,6 @@ export class HubRotationPoller {
       ? head
       : Math.max(previousLastScannedBlock, head);
     this.pruneSeenLogs(head);
-  }
-
-  private readWithTimeout<T>(
-    label: string,
-    fn: (provider: JsonRpcProvider) => Promise<T>,
-    timeoutMs: number,
-    opts?: ReadOpts,
-  ): Promise<T> {
-    return withTimeout(this.readProvider(label, fn, opts), timeoutMs, label);
   }
 
   private scanFromBlock(previousLastScannedBlock: number | undefined, head: number): number {

--- a/packages/chain/src/hub-rotation-poller.ts
+++ b/packages/chain/src/hub-rotation-poller.ts
@@ -96,7 +96,7 @@ export class HubRotationPoller {
     const head = await this.readProvider(
       'Hub rotation poll getBlockNumber',
       (provider) => provider.getBlockNumber(),
-      { capSingleProvider: true },
+      { policy: 'watchdogPointRead' },
     );
     if (!this.started || generation !== this.generation) return;
     const fromBlock = this.scanFromBlock(previousLastScannedBlock, head);
@@ -108,7 +108,7 @@ export class HubRotationPoller {
         toBlock: head,
         topics: [binding.topics],
       }),
-      { policy: 'wideLogScan', capSingleProvider: true },
+      { policy: 'watchdogWideLogScan' },
     );
     if (!this.started || generation !== this.generation) return;
 

--- a/packages/chain/src/rpc-failover-client.ts
+++ b/packages/chain/src/rpc-failover-client.ts
@@ -62,18 +62,25 @@ export interface RpcEndpoint {
  * {@link resolveCapMs}.
  *   - `pointRead`           — a single `eth_call` / point provider read.
  *   - `wideLogScan`         — a multi-thousand-block `eth_getLogs` scan.
+ *   - `watchdogPointRead`   — a background point read that must not wedge a
+ *     one-RPC node.
+ *   - `watchdogWideLogScan` — a background log scan that must not wedge a
+ *     one-RPC node.
  *   - `failOpenFundingRead` — a fail-open funding/allowance read that must never
  *     stall selection (capped on EVERY attempt, including single-RPC).
  */
-export type ReadPolicy = 'pointRead' | 'wideLogScan' | 'failOpenFundingRead';
+export type ReadPolicy =
+  | 'pointRead'
+  | 'wideLogScan'
+  | 'watchdogPointRead'
+  | 'watchdogWideLogScan'
+  | 'failOpenFundingRead';
 
 /** Per-read options: a named timeout policy + an optional failover classifier
  *  override (a read whose error shape carries domain meaning). */
 export interface ReadOpts {
   policy?: ReadPolicy;
   isRetryable?: (err: unknown) => boolean;
-  /** Opt-in watchdog for background reads that must not wedge even with one RPC endpoint. */
-  capSingleProvider?: boolean;
 }
 
 /**
@@ -106,24 +113,25 @@ export function isContractViewRetryable(err: unknown): boolean {
 /**
  * The timeout-policy matrix — the per-attempt cap each named policy yields:
  *
- *   | policy              | multi-RPC cap            | single-RPC default      | capSingleProvider |
- *   |---------------------|--------------------------|-------------------------|-------------------|
- *   | pointRead           | RPC_READ_STALL (4s)      | uncapped (#894)         | RPC_READ_STALL    |
- *   | wideLogScan         | RPC_LOG_SCAN (30s)       | uncapped (#894)         | RPC_LOG_SCAN      |
- *   | failOpenFundingRead | RPC_READ_STALL (4s)      | RPC_READ_STALL (4s)     | RPC_READ_STALL    |
+ *   | policy              | multi-RPC cap            | single-RPC cap          |
+ *   |---------------------|--------------------------|-------------------------|
+ *   | pointRead           | RPC_READ_STALL (4s)      | uncapped (#894)         |
+ *   | wideLogScan         | RPC_LOG_SCAN (30s)       | uncapped (#894)         |
+ *   | watchdogPointRead   | RPC_READ_STALL (4s)      | RPC_READ_STALL (4s)    |
+ *   | watchdogWideLogScan | RPC_LOG_SCAN (30s)       | RPC_LOG_SCAN (30s)     |
+ *   | failOpenFundingRead | RPC_READ_STALL (4s)      | RPC_READ_STALL (4s)    |
  *
  * `pointRead` / `wideLogScan` leave single-RPC uncapped (nothing to fail over
- * to; #894) by default. `capSingleProvider` lets background watcher reads opt
- * into the same per-policy cap for a one-endpoint node without imposing a
- * poll-level deadline over the multi-RPC failover sequence.
+ * to; #894). The watchdog policies are for background reads that must clear
+ * their scheduler gate even on one-RPC nodes, without imposing a poll-level
+ * deadline over a multi-RPC failover sequence.
  */
-export function resolveCapMs(
-  policy: ReadPolicy,
-  providerCount: number,
-  capSingleProvider = false,
-): number | undefined {
-  if (policy === 'failOpenFundingRead') return RPC_READ_STALL_TIMEOUT_MS;
-  if (providerCount <= 1 && !capSingleProvider) return undefined;
+export function resolveCapMs(policy: ReadPolicy, providerCount: number): number | undefined {
+  if (policy === 'failOpenFundingRead' || policy === 'watchdogPointRead') {
+    return RPC_READ_STALL_TIMEOUT_MS;
+  }
+  if (policy === 'watchdogWideLogScan') return RPC_LOG_SCAN_TIMEOUT_MS;
+  if (providerCount <= 1) return undefined;
   return policy === 'wideLogScan' ? RPC_LOG_SCAN_TIMEOUT_MS : RPC_READ_STALL_TIMEOUT_MS;
 }
 
@@ -193,7 +201,6 @@ export class RpcFailoverClient {
       fn,
       opts?.isRetryable ?? isRetryableRpcError,
       opts?.policy ?? 'pointRead',
-      opts?.capSingleProvider ?? false,
     );
   }
 
@@ -228,7 +235,6 @@ export class RpcFailoverClient {
             (p) => fn(this.rebindContract(contract, p)),
             opts?.isRetryable ?? isContractViewRetryable,
             opts?.policy ?? 'pointRead',
-            opts?.capSingleProvider ?? false,
           );
           this.recordRpcOutcome('eth_call', 'ok');
           return out;
@@ -509,8 +515,8 @@ export class RpcFailoverClient {
    * `readContract`. The per-attempt `withTimeout` is a hard deadline that ABORTS
    * and fails over a hung backend; the cap comes from the named `policy` via
    * {@link resolveCapMs} (multi-RPC caps each attempt; single-RPC is uncapped for
-   * `pointRead`/`wideLogScan` by default — #894, nothing to fail over to — unless
-   * the caller opts into `capSingleProvider` or uses `failOpenFundingRead`). The
+   * `pointRead`/`wideLogScan` — #894, nothing to fail over to — while watchdog
+   * policies and `failOpenFundingRead` cap even single-RPC attempts). The
    * `endpoints` are read LIVE from the injected thunk so a mid-flight reassignment
    * of the pool is observed.
    */
@@ -519,10 +525,9 @@ export class RpcFailoverClient {
     fn: (provider: JsonRpcProvider) => Promise<T>,
     isRetryable: (err: unknown) => boolean,
     policy: ReadPolicy,
-    capSingleProvider: boolean,
   ): Promise<T> {
     const endpoints = this.getEndpoints();
-    const capMs = resolveCapMs(policy, endpoints.length, capSingleProvider);
+    const capMs = resolveCapMs(policy, endpoints.length);
     let lastRetryable: unknown;
     for (let i = 0; i < endpoints.length; i += 1) {
       const endpoint = endpoints[i];

--- a/packages/chain/src/rpc-failover-client.ts
+++ b/packages/chain/src/rpc-failover-client.ts
@@ -72,6 +72,8 @@ export type ReadPolicy = 'pointRead' | 'wideLogScan' | 'failOpenFundingRead';
 export interface ReadOpts {
   policy?: ReadPolicy;
   isRetryable?: (err: unknown) => boolean;
+  /** Opt-in watchdog for background reads that must not wedge even with one RPC endpoint. */
+  capSingleProvider?: boolean;
 }
 
 /**
@@ -104,19 +106,24 @@ export function isContractViewRetryable(err: unknown): boolean {
 /**
  * The timeout-policy matrix — the per-attempt cap each named policy yields:
  *
- *   | policy              | multi-RPC cap            | single-RPC cap          |
- *   |---------------------|--------------------------|-------------------------|
- *   | pointRead           | RPC_READ_STALL (4s)      | uncapped (#894)         |
- *   | wideLogScan         | RPC_LOG_SCAN (30s)       | uncapped (#894)         |
- *   | failOpenFundingRead | RPC_READ_STALL (4s)      | RPC_READ_STALL (4s)     |
+ *   | policy              | multi-RPC cap            | single-RPC default      | capSingleProvider |
+ *   |---------------------|--------------------------|-------------------------|-------------------|
+ *   | pointRead           | RPC_READ_STALL (4s)      | uncapped (#894)         | RPC_READ_STALL    |
+ *   | wideLogScan         | RPC_LOG_SCAN (30s)       | uncapped (#894)         | RPC_LOG_SCAN      |
+ *   | failOpenFundingRead | RPC_READ_STALL (4s)      | RPC_READ_STALL (4s)     | RPC_READ_STALL    |
  *
  * `pointRead` / `wideLogScan` leave single-RPC uncapped (nothing to fail over
- * to; #894); `failOpenFundingRead` caps EVERY attempt incl. single so a fail-open
- * funding read can never stall publish-signer selection.
+ * to; #894) by default. `capSingleProvider` lets background watcher reads opt
+ * into the same per-policy cap for a one-endpoint node without imposing a
+ * poll-level deadline over the multi-RPC failover sequence.
  */
-export function resolveCapMs(policy: ReadPolicy, providerCount: number): number | undefined {
+export function resolveCapMs(
+  policy: ReadPolicy,
+  providerCount: number,
+  capSingleProvider = false,
+): number | undefined {
   if (policy === 'failOpenFundingRead') return RPC_READ_STALL_TIMEOUT_MS;
-  if (providerCount <= 1) return undefined;
+  if (providerCount <= 1 && !capSingleProvider) return undefined;
   return policy === 'wideLogScan' ? RPC_LOG_SCAN_TIMEOUT_MS : RPC_READ_STALL_TIMEOUT_MS;
 }
 
@@ -186,6 +193,7 @@ export class RpcFailoverClient {
       fn,
       opts?.isRetryable ?? isRetryableRpcError,
       opts?.policy ?? 'pointRead',
+      opts?.capSingleProvider ?? false,
     );
   }
 
@@ -220,6 +228,7 @@ export class RpcFailoverClient {
             (p) => fn(this.rebindContract(contract, p)),
             opts?.isRetryable ?? isContractViewRetryable,
             opts?.policy ?? 'pointRead',
+            opts?.capSingleProvider ?? false,
           );
           this.recordRpcOutcome('eth_call', 'ok');
           return out;
@@ -499,20 +508,21 @@ export class RpcFailoverClient {
    * The shared read-family core: one per-endpoint loop backing both `read` and
    * `readContract`. The per-attempt `withTimeout` is a hard deadline that ABORTS
    * and fails over a hung backend; the cap comes from the named `policy` via
-   * {@link resolveCapMs} (multi-RPC caps the attempt; single-RPC is uncapped for
-   * `pointRead`/`wideLogScan` — #894, nothing to fail over to — UNLESS
-   * `failOpenFundingRead`, which caps every attempt). The `endpoints` are read
-   * LIVE from the injected thunk so a mid-flight reassignment of the pool is
-   * observed.
+   * {@link resolveCapMs} (multi-RPC caps each attempt; single-RPC is uncapped for
+   * `pointRead`/`wideLogScan` by default — #894, nothing to fail over to — unless
+   * the caller opts into `capSingleProvider` or uses `failOpenFundingRead`). The
+   * `endpoints` are read LIVE from the injected thunk so a mid-flight reassignment
+   * of the pool is observed.
    */
   private async runAcrossProviders<T>(
     label: string,
     fn: (provider: JsonRpcProvider) => Promise<T>,
     isRetryable: (err: unknown) => boolean,
     policy: ReadPolicy,
+    capSingleProvider: boolean,
   ): Promise<T> {
     const endpoints = this.getEndpoints();
-    const capMs = resolveCapMs(policy, endpoints.length);
+    const capMs = resolveCapMs(policy, endpoints.length, capSingleProvider);
     let lastRetryable: unknown;
     for (let i = 0; i < endpoints.length; i += 1) {
       const endpoint = endpoints[i];

--- a/packages/chain/test/hub-rotation-poller.unit.test.ts
+++ b/packages/chain/test/hub-rotation-poller.unit.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
 import { Contract, ethers } from 'ethers';
 import { HubRotationPoller } from '../src/hub-rotation-poller.js';
-import { RPC_LOG_SCAN_TIMEOUT_MS } from '../src/evm-adapter-constants.js';
+import { RPC_LOG_SCAN_TIMEOUT_MS, RPC_READ_STALL_TIMEOUT_MS } from '../src/evm-adapter-constants.js';
+import { RpcFailoverClient } from '../src/rpc-failover-client.js';
 
 const HUB_ADDRESS = '0x0000000000000000000000000000000000000001';
 
@@ -48,6 +49,18 @@ function logsInRange(logs: ethers.Log[], filter: { fromBlock: number; toBlock: n
 
 async function flushAsyncWork(turns = 8): Promise<void> {
   for (let i = 0; i < turns; i++) await Promise.resolve();
+}
+
+function failoverReadProvider(providers: unknown[]) {
+  const client = new RpcFailoverClient(
+    () => providers.map((provider, index) => ({
+      provider: provider as any,
+      rpcUrl: `https://rpc-${index}.example`,
+    })),
+    async () => { throw new Error('Hub rotation tests must not sign transactions'); },
+    () => 'evm:31337',
+  );
+  return client.read.bind(client);
 }
 
 describe('HubRotationPoller', () => {
@@ -194,7 +207,7 @@ describe('HubRotationPoller', () => {
     };
     const onContractName = vi.fn();
     const poller = new HubRotationPoller({
-      readProvider: async (_label, fn) => fn(provider as any),
+      readProvider: failoverReadProvider([provider]),
       intervalMs: 1_000,
       reorgBufferBlocks: 50,
       onContractName,
@@ -222,6 +235,95 @@ describe('HubRotationPoller', () => {
         fromBlock: 951,
         toBlock: 1_001,
       });
+      expect(onContractName).toHaveBeenCalledWith('ContextGraphs');
+    } finally {
+      poller.stop();
+      vi.useRealTimers();
+    }
+  });
+
+  it('times out a stalled scheduled head read and retries without scanning logs', async () => {
+    vi.useFakeTimers({ now: 0 });
+    const iface = hubInterface();
+    const rotation = rotationLog(iface, 'ContractChanged', 'ContextGraphs', 1_001, '82');
+    let headCalls = 0;
+    const provider = {
+      getBlockNumber: vi.fn(async () => {
+        headCalls++;
+        if (headCalls === 1) return new Promise<number>(() => { /* hung RPC */ });
+        return 1_001;
+      }),
+      getLogs: vi.fn(async (filter: any) => logsInRange([rotation], filter)),
+    };
+    const onContractName = vi.fn();
+    const poller = new HubRotationPoller({
+      readProvider: failoverReadProvider([provider]),
+      intervalMs: 1_000,
+      reorgBufferBlocks: 50,
+      onContractName,
+    });
+
+    try {
+      await poller.start(hubContract(iface), HUB_ADDRESS);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(provider.getBlockNumber).toHaveBeenCalledTimes(1);
+      expect(provider.getLogs).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(RPC_READ_STALL_TIMEOUT_MS - 1);
+      expect(provider.getBlockNumber).toHaveBeenCalledTimes(1);
+      expect(provider.getLogs).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      await flushAsyncWork();
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      await flushAsyncWork();
+
+      expect(provider.getBlockNumber).toHaveBeenCalledTimes(2);
+      expect(provider.getLogs).toHaveBeenCalledTimes(1);
+      expect(provider.getLogs.mock.calls[0][0]).toMatchObject({
+        fromBlock: 951,
+        toBlock: 1_001,
+      });
+      expect(onContractName).toHaveBeenCalledWith('ContextGraphs');
+    } finally {
+      poller.stop();
+      vi.useRealTimers();
+    }
+  });
+
+  it('lets read-provider failover reach a healthy backup after a stalled primary log scan', async () => {
+    vi.useFakeTimers({ now: 0 });
+    const iface = hubInterface();
+    const rotation = rotationLog(iface, 'ContractChanged', 'ContextGraphs', 1_001, '84');
+    const primary = {
+      getBlockNumber: vi.fn(async () => 1_001),
+      getLogs: vi.fn(async () => new Promise<ethers.Log[]>(() => { /* hung primary */ })),
+    };
+    const backup = {
+      getBlockNumber: vi.fn(async () => 1_001),
+      getLogs: vi.fn(async (filter: any) => logsInRange([rotation], filter)),
+    };
+    const onContractName = vi.fn();
+    const poller = new HubRotationPoller({
+      readProvider: failoverReadProvider([primary, backup]),
+      intervalMs: 1_000,
+      reorgBufferBlocks: 50,
+      onContractName,
+    });
+
+    try {
+      await poller.start(hubContract(iface), HUB_ADDRESS);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(primary.getLogs).toHaveBeenCalledTimes(1);
+      expect(backup.getLogs).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(RPC_LOG_SCAN_TIMEOUT_MS + 1);
+      await flushAsyncWork();
+
+      expect(backup.getLogs).toHaveBeenCalledTimes(1);
       expect(onContractName).toHaveBeenCalledWith('ContextGraphs');
     } finally {
       poller.stop();
@@ -307,8 +409,10 @@ describe('HubRotationPoller', () => {
         iface.getEvent('AssetStorageChanged')!.topicHash,
         iface.getEvent('NewAssetStorage')!.topicHash,
       ]);
+      expect(readCalls.find((call) => call.label === 'Hub rotation poll getBlockNumber')?.opts)
+        .toEqual({ capSingleProvider: true });
       expect(readCalls.find((call) => call.label === 'Hub rotation poll getLogs')?.opts)
-        .toEqual({ policy: 'wideLogScan' });
+        .toEqual({ policy: 'wideLogScan', capSingleProvider: true });
       expect(onContractName.mock.calls.map((call) => call[0])).toEqual([
         'RandomSampling',
         'ContextGraphs',

--- a/packages/chain/test/hub-rotation-poller.unit.test.ts
+++ b/packages/chain/test/hub-rotation-poller.unit.test.ts
@@ -410,9 +410,9 @@ describe('HubRotationPoller', () => {
         iface.getEvent('NewAssetStorage')!.topicHash,
       ]);
       expect(readCalls.find((call) => call.label === 'Hub rotation poll getBlockNumber')?.opts)
-        .toEqual({ capSingleProvider: true });
+        .toEqual({ policy: 'watchdogPointRead' });
       expect(readCalls.find((call) => call.label === 'Hub rotation poll getLogs')?.opts)
-        .toEqual({ policy: 'wideLogScan', capSingleProvider: true });
+        .toEqual({ policy: 'watchdogWideLogScan' });
       expect(onContractName.mock.calls.map((call) => call[0])).toEqual([
         'RandomSampling',
         'ContextGraphs',

--- a/packages/chain/test/hub-rotation-poller.unit.test.ts
+++ b/packages/chain/test/hub-rotation-poller.unit.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { Contract, ethers } from 'ethers';
 import { HubRotationPoller } from '../src/hub-rotation-poller.js';
+import { RPC_LOG_SCAN_TIMEOUT_MS } from '../src/evm-adapter-constants.js';
 
 const HUB_ADDRESS = '0x0000000000000000000000000000000000000001';
 
@@ -176,6 +177,58 @@ describe('HubRotationPoller', () => {
     }
   });
 
+  it('times out a stalled scheduled log scan and retries the same cursor range', async () => {
+    vi.useFakeTimers({ now: 0 });
+    const iface = hubInterface();
+    const hub = hubContract(iface);
+    const rotation = rotationLog(iface, 'ContractChanged', 'ContextGraphs', 1_001, '80');
+    let head = 1_000;
+    let getLogsCalls = 0;
+    const provider = {
+      getBlockNumber: vi.fn(async () => head),
+      getLogs: vi.fn(async (filter: any) => {
+        getLogsCalls++;
+        if (getLogsCalls === 1) return new Promise<ethers.Log[]>(() => { /* hung RPC */ });
+        return logsInRange([rotation], filter);
+      }),
+    };
+    const onContractName = vi.fn();
+    const poller = new HubRotationPoller({
+      readProvider: async (_label, fn) => fn(provider as any),
+      intervalMs: 1_000,
+      reorgBufferBlocks: 50,
+      onContractName,
+    });
+
+    try {
+      await poller.start(hub, HUB_ADDRESS);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(provider.getLogs).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(RPC_LOG_SCAN_TIMEOUT_MS - 1);
+      expect(provider.getLogs).toHaveBeenCalledTimes(1);
+      expect(onContractName).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      await flushAsyncWork();
+
+      head = 1_001;
+      await vi.advanceTimersByTimeAsync(1_000);
+      await flushAsyncWork();
+
+      expect(provider.getLogs).toHaveBeenCalledTimes(2);
+      expect(provider.getLogs.mock.calls[1][0]).toMatchObject({
+        fromBlock: 951,
+        toBlock: 1_001,
+      });
+      expect(onContractName).toHaveBeenCalledWith('ContextGraphs');
+    } finally {
+      poller.stop();
+      vi.useRealTimers();
+    }
+  });
+
   it('coalesces concurrent starts into a single scheduled poller', async () => {
     vi.useFakeTimers({ now: 0 });
     const provider = {
@@ -215,13 +268,17 @@ describe('HubRotationPoller', () => {
       rotationLog(iface, 'NewContract', 'RandomSampling', 1_000, '10'),
       rotationLog(iface, 'ContractChanged', 'ContextGraphs', 1_001, '12'),
     ];
+    const readCalls: Array<{ label: string; opts: unknown }> = [];
     const provider = {
       getBlockNumber: vi.fn(async () => head),
       getLogs: vi.fn(async (filter: any) => logsInRange(logs, filter)),
     };
     const onContractName = vi.fn();
     const poller = new HubRotationPoller({
-      readProvider: async (_label, fn) => fn(provider as any),
+      readProvider: async (label, fn, opts) => {
+        readCalls.push({ label, opts });
+        return fn(provider as any);
+      },
       intervalMs: 30_000,
       reorgBufferBlocks: 50,
       onContractName,
@@ -250,6 +307,8 @@ describe('HubRotationPoller', () => {
         iface.getEvent('AssetStorageChanged')!.topicHash,
         iface.getEvent('NewAssetStorage')!.topicHash,
       ]);
+      expect(readCalls.find((call) => call.label === 'Hub rotation poll getLogs')?.opts)
+        .toEqual({ policy: 'wideLogScan' });
       expect(onContractName.mock.calls.map((call) => call[0])).toEqual([
         'RandomSampling',
         'ContextGraphs',

--- a/packages/chain/test/mock-adapter-parity.test.ts
+++ b/packages/chain/test/mock-adapter-parity.test.ts
@@ -172,6 +172,7 @@ const MOCK_EXEMPT_FROM_EVM = new Set<string>([
   'withHubStaleRetryAny',
   'invalidateAllBoundContracts',
   'startHubRotationListener',
+  'applyHubRotationEventName',
   'invalidateRandomSamplingPair',
   'resolveAndAssignRandomSamplingPair',
   'isContractMissingRevert',

--- a/packages/chain/test/readwithfailover-loop.unit.test.ts
+++ b/packages/chain/test/readwithfailover-loop.unit.test.ts
@@ -174,8 +174,9 @@ describe('RpcFailoverClient.read — read-failover loop logic (bare-mock, #1336)
 // poller ranges legitimately >4s) → threw RPC_ENDPOINTS_EXHAUSTED before the
 // publisher poller advanced its cursor → permanent stall. Fix: the named
 // `wideLogScan` policy (RPC_LOG_SCAN_TIMEOUT_MS = 30s) caps MULTI-RPC attempts
-// only by default; SINGLE-RPC stays uncapped (#894 — nothing to fail over to)
-// unless a background watcher opts into `capSingleProvider`. The raw
+// only; SINGLE-RPC stays uncapped (#894 — nothing to fail over to). Background
+// watchers that must clear a one-RPC scheduler gate use explicit watchdog
+// policies rather than changing the default read intent. The raw
 // `attemptTimeoutMs` / `multiAttemptTimeoutMs` knobs are gone — callers pick a
 // named ReadPolicy and the module owns the matrix (resolveCapMs). Fake timers
 // throughout — no real 5s/30s sleeps.

--- a/packages/chain/test/readwithfailover-loop.unit.test.ts
+++ b/packages/chain/test/readwithfailover-loop.unit.test.ts
@@ -174,7 +174,8 @@ describe('RpcFailoverClient.read — read-failover loop logic (bare-mock, #1336)
 // poller ranges legitimately >4s) → threw RPC_ENDPOINTS_EXHAUSTED before the
 // publisher poller advanced its cursor → permanent stall. Fix: the named
 // `wideLogScan` policy (RPC_LOG_SCAN_TIMEOUT_MS = 30s) caps MULTI-RPC attempts
-// only; SINGLE-RPC stays uncapped (#894 — nothing to fail over to). The raw
+// only by default; SINGLE-RPC stays uncapped (#894 — nothing to fail over to)
+// unless a background watcher opts into `capSingleProvider`. The raw
 // `attemptTimeoutMs` / `multiAttemptTimeoutMs` knobs are gone — callers pick a
 // named ReadPolicy and the module owns the matrix (resolveCapMs). Fake timers
 // throughout — no real 5s/30s sleeps.

--- a/packages/chain/test/rpc-failover-client.unit.test.ts
+++ b/packages/chain/test/rpc-failover-client.unit.test.ts
@@ -93,13 +93,18 @@ describe('resolveCapMs — the named timeout-policy matrix (PLAN §3.2)', () => 
     expect(resolveCapMs('pointRead', 2)).toBe(RPC_READ_STALL_TIMEOUT_MS);
     expect(resolveCapMs('pointRead', 4)).toBe(RPC_READ_STALL_TIMEOUT_MS);
     expect(resolveCapMs('pointRead', 1)).toBeUndefined();
-    expect(resolveCapMs('pointRead', 1, true)).toBe(RPC_READ_STALL_TIMEOUT_MS);
   });
 
   it('wideLogScan: multi-RPC caps at RPC_LOG_SCAN_TIMEOUT_MS, single-RPC is uncapped (#894)', () => {
     expect(resolveCapMs('wideLogScan', 2)).toBe(RPC_LOG_SCAN_TIMEOUT_MS);
     expect(resolveCapMs('wideLogScan', 1)).toBeUndefined();
-    expect(resolveCapMs('wideLogScan', 1, true)).toBe(RPC_LOG_SCAN_TIMEOUT_MS);
+  });
+
+  it('watchdog policies cap single-RPC attempts with the matching point/log deadline', () => {
+    expect(resolveCapMs('watchdogPointRead', 1)).toBe(RPC_READ_STALL_TIMEOUT_MS);
+    expect(resolveCapMs('watchdogPointRead', 2)).toBe(RPC_READ_STALL_TIMEOUT_MS);
+    expect(resolveCapMs('watchdogWideLogScan', 1)).toBe(RPC_LOG_SCAN_TIMEOUT_MS);
+    expect(resolveCapMs('watchdogWideLogScan', 2)).toBe(RPC_LOG_SCAN_TIMEOUT_MS);
   });
 
   it('failOpenFundingRead: caps EVERY attempt incl. single-RPC at RPC_READ_STALL_TIMEOUT_MS', () => {
@@ -137,18 +142,37 @@ describe('RpcFailoverClient.read / readContract — policy matrix applied + view
     expect(slowView.calls).toHaveLength(1);
   });
 
-  it('read SINGLE-RPC pointRead can opt into the per-policy cap for background watchers', async () => {
+  it('read SINGLE-RPC watchdogPointRead caps background watcher reads', async () => {
     vi.useFakeTimers();
     const slow = recorder(() => new Promise<string>((r) => { setTimeout(() => r('ONLY'), 5_000); }));
     const client = makeClient([{ read: slow }], ['https://only.example']);
 
-    const settled = client.read('watcher point read', (pr: any) => pr.read(), { capSingleProvider: true })
+    const settled = client.read('watcher point read', (pr: any) => pr.read(), { policy: 'watchdogPointRead' })
       .then((r: unknown) => r, (e: unknown) => e);
     await vi.advanceTimersByTimeAsync(RPC_READ_STALL_TIMEOUT_MS + 1_500);
 
     const outcome: any = await settled;
     expect(outcome.code).toBe('RPC_ENDPOINTS_EXHAUSTED');
     expect(slow.calls).toHaveLength(1);
+  });
+
+  it('readContract SINGLE-RPC watchdogPointRead caps background watcher views', async () => {
+    vi.useFakeTimers();
+    const slowView = recorder(() => new Promise<string>((r) => { setTimeout(() => r('ONLY'), 5_000); }));
+    const contract = { connect: () => ({ view: slowView }) } as any;
+    const client = makeClient([{}], ['https://only.example']);
+
+    const settled = client.readContract(
+      'watcher view',
+      contract,
+      (c: any) => c.view(),
+      { policy: 'watchdogPointRead' },
+    ).then((r: unknown) => r, (e: unknown) => e);
+    await vi.advanceTimersByTimeAsync(RPC_READ_STALL_TIMEOUT_MS + 1_500);
+
+    const outcome: any = await settled;
+    expect(outcome.code).toBe('RPC_ENDPOINTS_EXHAUSTED');
+    expect(slowView.calls).toHaveLength(1);
   });
 
   it('readContract MULTI-RPC wideLogScan: a 5s read COMPLETES (the 30s cap, not the 4s point cap)', async () => {

--- a/packages/chain/test/rpc-failover-client.unit.test.ts
+++ b/packages/chain/test/rpc-failover-client.unit.test.ts
@@ -93,11 +93,13 @@ describe('resolveCapMs — the named timeout-policy matrix (PLAN §3.2)', () => 
     expect(resolveCapMs('pointRead', 2)).toBe(RPC_READ_STALL_TIMEOUT_MS);
     expect(resolveCapMs('pointRead', 4)).toBe(RPC_READ_STALL_TIMEOUT_MS);
     expect(resolveCapMs('pointRead', 1)).toBeUndefined();
+    expect(resolveCapMs('pointRead', 1, true)).toBe(RPC_READ_STALL_TIMEOUT_MS);
   });
 
   it('wideLogScan: multi-RPC caps at RPC_LOG_SCAN_TIMEOUT_MS, single-RPC is uncapped (#894)', () => {
     expect(resolveCapMs('wideLogScan', 2)).toBe(RPC_LOG_SCAN_TIMEOUT_MS);
     expect(resolveCapMs('wideLogScan', 1)).toBeUndefined();
+    expect(resolveCapMs('wideLogScan', 1, true)).toBe(RPC_LOG_SCAN_TIMEOUT_MS);
   });
 
   it('failOpenFundingRead: caps EVERY attempt incl. single-RPC at RPC_READ_STALL_TIMEOUT_MS', () => {
@@ -133,6 +135,20 @@ describe('RpcFailoverClient.read / readContract — policy matrix applied + view
     await vi.advanceTimersByTimeAsync(6_500);
     expect(await p).toBe('ONLY');
     expect(slowView.calls).toHaveLength(1);
+  });
+
+  it('read SINGLE-RPC pointRead can opt into the per-policy cap for background watchers', async () => {
+    vi.useFakeTimers();
+    const slow = recorder(() => new Promise<string>((r) => { setTimeout(() => r('ONLY'), 5_000); }));
+    const client = makeClient([{ read: slow }], ['https://only.example']);
+
+    const settled = client.read('watcher point read', (pr: any) => pr.read(), { capSingleProvider: true })
+      .then((r: unknown) => r, (e: unknown) => e);
+    await vi.advanceTimersByTimeAsync(RPC_READ_STALL_TIMEOUT_MS + 1_500);
+
+    const outcome: any = await settled;
+    expect(outcome.code).toBe('RPC_ENDPOINTS_EXHAUSTED');
+    expect(slow.calls).toHaveLength(1);
   });
 
   it('readContract MULTI-RPC wideLogScan: a 5s read COMPLETES (the 30s cap, not the 4s point cap)', async () => {

--- a/packages/publisher/src/chain-event-lane-runner.ts
+++ b/packages/publisher/src/chain-event-lane-runner.ts
@@ -142,12 +142,6 @@ export class ChainEventLaneRunner {
       : DEFAULT_LIVE_SEED_LOOKBACK_BLOCKS;
   }
 
-  private scheduleDelayMs(value: number | undefined, fallback: number): number {
-    return Number.isFinite(value) && value! >= 0
-      ? Math.floor(value!)
-      : fallback;
-  }
-
   private stateFor(lane: ChainEventPollerLane): ChainEventPollerLaneState {
     let state = this.laneState.get(lane);
     if (!state) {


### PR DESCRIPTION
## Summary

This is a small chained fix into PR #1440 after the final PR #1461 review round.

- Bounds Hub rotation watcher reads through the shared `RpcFailoverClient` policy boundary, not a poller-local timeout wrapper.
- Adds explicit watcher read intents (`watchdogPointRead`, `watchdogWideLogScan`) so Hub background reads can cap one-RPC hangs while default single-RPC `pointRead` / `wideLogScan` behavior remains unchanged.
- Keeps multi-RPC failover intact: a stalled primary watchdog log scan can time out per endpoint and continue to a healthy backup in the same poll.
- Preserves cursor correctness on read failure: failed head/log reads do not advance `lastScannedBlock`, and the next scheduled poll retries the buffered range.
- Pins the Hub rotation read policies to `watchdogPointRead` and `watchdogWideLogScan` in unit coverage.
- Removes the unused publisher lane-runner helper from the final nit comment.
- Fixes the current PR #1440 chain CI failure by documenting `applyHubRotationEventName` as EVM-only Hub rotation plumbing in the mock parity exemption list.

## Review Comments Addressed

- Red bug from the first chained PR round: a stalled single-RPC `eth_getLogs`/`wideLogScan` call could wedge the Hub rotation poller indefinitely by leaving `inFlight` set.
- Red bug from the next round: the first fix used a per-attempt timeout as a whole-failover deadline; this now lives inside `RpcFailoverClient` so endpoint failover still reaches a healthy backup.
- Latest review: timeout intent is now encoded as named `ReadPolicy` variants instead of a cross-cutting boolean.
- Latest review: `readContract` watchdog policy forwarding is covered by a focused single-RPC fake-timer test.
- Test gap: stalled head reads are covered separately from stalled log scans.
- Nit: `ChainEventLaneRunner.scheduleDelayMs` was left unused after the earlier review simplification.
- CI: `MockChainAdapter API parity` failed on PR #1440 because `applyHubRotationEventName` is an EVM-only protected helper that was not listed with the rest of the Hub-rotation exemptions.

## Validation

- `pnpm --dir packages/chain exec vitest run --config vitest.unit.config.ts test/hub-rotation-poller.unit.test.ts test/rpc-failover-client.unit.test.ts test/readwithfailover-loop.unit.test.ts --reporter dot` (`57 passed`)
- `pnpm --dir packages/chain exec vitest run test/mock-adapter-parity.test.ts --reporter dot` (`15 passed`)
- `pnpm --dir packages/publisher exec vitest run --config vitest.lane-temp.config.mjs --reporter dot` (`22 passed`; temp config removed after run)
- `pnpm --filter @origintrail-official/dkg-chain build`
- `pnpm --filter @origintrail-official/dkg-publisher build`
- `git diff --check` (passes; Git reports CRLF conversion warnings only)

## Deferred / Not Changed

- Broader Hub poller lifecycle abstraction remains tracked separately in follow-up issue #1466.
- The lane retry policy explicitness discussion is intentionally not expanded here; the previous simplification kept retry/backoff as private runner policy and no new correctness issue was found.
