### PR TITLE
Reduce startup context-graph catch-up RPCs

### DIFF
--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -1444,6 +1444,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       this.chainPoller = new ChainEventPoller({
         chain: this.chain,
         publishHandler,
+        cursorPersistence: this.config.chainEventCursorStore,
         onContextGraphCreated: async ({ contextGraphId, creator, accessPolicy, publishPolicy, nameHash, blockNumber }) => {
           this.log.info(ctx, `Discovered on-chain context graph ${contextGraphId.slice(0, 16)}… (block ${blockNumber}, creator ${creator.slice(0, 10)}…, policy ${accessPolicy}, publishPolicy ${publishPolicy ?? '?'}, nameHash ${nameHash ? nameHash.slice(0, 10) + '…' : '(opt-out)'})`);
 

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -33,8 +33,9 @@ import type {
   LiftTransitionType,
   LiftAuthorityProof,
   SharedMemoryPublicSnapshotStorageConfig,
+  CursorPersistence as ChainEventCursorPersistence,
 } from '@origintrail-official/dkg-publisher';
-import type { ApprovalPolicy, ChainAdapter } from '@origintrail-official/dkg-chain';
+import type { ApprovalPolicy, ChainAdapter, ContextGraphRegistryScanCursorStore } from '@origintrail-official/dkg-chain';
 import type { QueryAccessConfig } from '@origintrail-official/dkg-query';
 import type { SkillHandler } from './messaging.js';
 import type { CclFactResolutionMode } from './ccl-fact-resolution.js';
@@ -1134,6 +1135,10 @@ export interface DKGAgentConfig {
   contextGraphSubscriptionStore?: ContextGraphSubscriptionStore;
   /** Durable local store for paged sync checkpoints. Defaults to in-memory. */
   syncCheckpointStore?: SyncCheckpointStore;
+  /** Durable lane cursor store for the chain event poller. Defaults to in-memory. */
+  chainEventCursorStore?: ChainEventCursorPersistence;
+  /** Durable ContextGraphNameRegistry discovery cursor store. Defaults to in-memory adapter state. */
+  contextGraphRegistryScanCursorStore?: ContextGraphRegistryScanCursorStore;
   /**
    * Intentional cap on how many persisted context-graph subscriptions are
    * *activated* (gossip-subscribed + sync-tracked) when rehydrating at startup.

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -459,13 +459,15 @@ export interface AssertionHistoryDescriptor extends AssertionDescriptor {
   publishedUal?: string;
 }
 
-export interface DiscoverContextGraphsFromChainOptions {
-  incremental?: boolean;
-  seedIncrementalWatermark?: boolean;
-  resumeFromCursor?: boolean;
+export type DiscoverContextGraphsFromChainOptions = {
   throwOnChainScanFailure?: boolean;
   pageBudget?: number;
-}
+} & (
+  | { mode?: 'listAll' }
+  | { mode: 'incremental' }
+  | { mode: 'seedFull' }
+  | { mode: 'seedFromCursor' }
+);
 
 /**
  * High-level facade that ties together all DKG agent capabilities:
@@ -1104,49 +1106,9 @@ export class DKGAgent extends DKGAgentBase {
       return 0;
     }
 
-    let onChainContextGraphs;
+    let onChainContextGraphs: ContextGraphOnChain[] = [];
     let partialChainScan = false;
     let partialChainScanError: unknown;
-    try {
-      const scanOptions = options.incremental
-          ? {
-              incremental: true as const,
-              ...(options.pageBudget !== undefined ? { pageBudget: options.pageBudget } : {}),
-            }
-        : options.seedIncrementalWatermark
-          ? {
-              seedIncrementalWatermark: true as const,
-              ...(options.resumeFromCursor ? { resumeFromCursor: true as const } : {}),
-              ...(options.pageBudget !== undefined ? { pageBudget: options.pageBudget } : {}),
-            }
-          : undefined;
-      onChainContextGraphs = await this.chain.listContextGraphsFromChain(undefined, scanOptions);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      const signature = message
-        .replace(/stopped after block \d+/g, 'stopped after block N')
-        .replace(/\[\d+,\s*\d+\]/g, '[range]')
-        .replace(/\b\d+\s+eth_getLogs calls/g, 'N eth_getLogs calls');
-      if (this.chainContextGraphScanFailure?.signature !== signature) {
-        this.log.warn(ctx, `Chain context graph scan failed: ${message}`);
-        this.chainContextGraphScanFailure = { signature, count: 1 };
-      } else {
-        this.chainContextGraphScanFailure.count += 1;
-      }
-      const partialError = isContextGraphChainScanPartialError(err);
-      if (options.throwOnChainScanFailure && !partialError) throw err;
-      if (!partialError) return 0;
-      partialChainScan = true;
-      partialChainScanError = err;
-      onChainContextGraphs = err.partialResults;
-    }
-    if (!partialChainScan && this.chainContextGraphScanFailure) {
-      this.log.info(
-        ctx,
-        `Chain context graph scan recovered after ${this.chainContextGraphScanFailure.count} failed attempt(s)`,
-      );
-      this.chainContextGraphScanFailure = undefined;
-    }
 
     // Build a set of all known on-chain IDs (stored and computed) for fast dedup
     const knownOnChainIds = new Set<string>();
@@ -1157,7 +1119,9 @@ export class DKGAgent extends DKGAgentBase {
     }
 
     let discovered = 0;
-    for (const p of onChainContextGraphs) {
+    let committedByScanPage = false;
+    const applyDiscoveredContextGraphs = async (contextGraphs: ContextGraphOnChain[]): Promise<void> => {
+      for (const p of contextGraphs) {
       if (knownOnChainIds.has(p.contextGraphId)) continue;
 
       if (!p.name) {
@@ -1216,6 +1180,64 @@ export class DKGAgent extends DKGAgentBase {
       this.contextGraphMetaProjection.markDirty(p.name);
       this.log.info(ctx, `Discovered on-chain context graph "${p.name}" (${p.contextGraphId.slice(0, 16)}…) — auto-subscribed (synced=false)`);
       discovered++;
+    }
+
+    };
+
+    try {
+      const mode = options.mode ?? 'listAll';
+      const commitPage = async (page: ContextGraphOnChain[]): Promise<void> => {
+        committedByScanPage = true;
+        await applyDiscoveredContextGraphs(page);
+      };
+      const scanOptions = mode === 'incremental'
+        ? {
+            mode,
+            commitPage,
+            ...(options.pageBudget !== undefined ? { pageBudget: options.pageBudget } : {}),
+          }
+        : mode === 'seedFull'
+          ? {
+              mode,
+              commitPage,
+            }
+          : mode === 'seedFromCursor'
+            ? {
+                mode,
+                commitPage,
+                ...(options.pageBudget !== undefined ? { pageBudget: options.pageBudget } : {}),
+              }
+            : undefined;
+      onChainContextGraphs = await this.chain.listContextGraphsFromChain(undefined, scanOptions);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const signature = message
+        .replace(/stopped after block \d+/g, 'stopped after block N')
+        .replace(/\[\d+,\s*\d+\]/g, '[range]')
+        .replace(/\b\d+\s+eth_getLogs calls/g, 'N eth_getLogs calls');
+      if (this.chainContextGraphScanFailure?.signature !== signature) {
+        this.log.warn(ctx, `Chain context graph scan failed: ${message}`);
+        this.chainContextGraphScanFailure = { signature, count: 1 };
+      } else {
+        this.chainContextGraphScanFailure.count += 1;
+      }
+      const partialError = isContextGraphChainScanPartialError(err);
+      if (options.throwOnChainScanFailure && !partialError) throw err;
+      if (!partialError) return 0;
+      partialChainScan = true;
+      partialChainScanError = err;
+      onChainContextGraphs = committedByScanPage ? [] : err.partialResults;
+    }
+    if (!partialChainScan && this.chainContextGraphScanFailure) {
+      this.log.info(
+        ctx,
+        `Chain context graph scan recovered after ${this.chainContextGraphScanFailure.count} failed attempt(s)`,
+      );
+      this.chainContextGraphScanFailure = undefined;
+    }
+
+    if (!committedByScanPage) {
+      await applyDiscoveredContextGraphs(onChainContextGraphs);
     }
 
     if (discovered > 0) {

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -463,6 +463,7 @@ export interface DiscoverContextGraphsFromChainOptions {
   incremental?: boolean;
   seedIncrementalWatermark?: boolean;
   throwOnChainScanFailure?: boolean;
+  pageBudget?: number;
 }
 
 /**
@@ -535,6 +536,7 @@ export class DKGAgent extends DKGAgentBase {
         chainId: config.chainConfig.chainId,
         approvalPolicy: config.chainConfig.approvalPolicy,
         cgRegistryScanPageSize: config.chainConfig.cgRegistryScanPageSize,
+        contextGraphRegistryScanCursorStore: config.contextGraphRegistryScanCursorStore,
       };
       if (config.chainConfig.adminPrivateKey) {
         chain = new EVMChainAdapter({ ...evmConfigBase, adminPrivateKey: config.chainConfig.adminPrivateKey });
@@ -1088,7 +1090,7 @@ export class DKGAgent extends DKGAgentBase {
    *
    * Defaults to a full scan so SDK callers can rebuild missing local state.
    * Background daemon loops may opt into incremental scans to reuse the
-   * in-memory chain adapter watermark.
+   * chain adapter watermark.
    *
    * Returns the number of newly discovered context graphs.
    */
@@ -1106,12 +1108,14 @@ export class DKGAgent extends DKGAgentBase {
     let partialChainScanError: unknown;
     try {
       const scanOptions = options.incremental
-        ? {
-            incremental: true as const,
-          }
+          ? {
+              incremental: true as const,
+              ...(options.pageBudget !== undefined ? { pageBudget: options.pageBudget } : {}),
+            }
         : options.seedIncrementalWatermark
           ? {
               seedIncrementalWatermark: true as const,
+              ...(options.pageBudget !== undefined ? { pageBudget: options.pageBudget } : {}),
             }
           : undefined;
       onChainContextGraphs = await this.chain.listContextGraphsFromChain(undefined, scanOptions);

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -462,6 +462,7 @@ export interface AssertionHistoryDescriptor extends AssertionDescriptor {
 export interface DiscoverContextGraphsFromChainOptions {
   incremental?: boolean;
   seedIncrementalWatermark?: boolean;
+  resumeFromCursor?: boolean;
   throwOnChainScanFailure?: boolean;
   pageBudget?: number;
 }
@@ -1115,6 +1116,7 @@ export class DKGAgent extends DKGAgentBase {
         : options.seedIncrementalWatermark
           ? {
               seedIncrementalWatermark: true as const,
+              ...(options.resumeFromCursor ? { resumeFromCursor: true as const } : {}),
               ...(options.pageBudget !== undefined ? { pageBudget: options.pageBudget } : {}),
             }
           : undefined;

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -462,12 +462,58 @@ export interface AssertionHistoryDescriptor extends AssertionDescriptor {
 export type DiscoverContextGraphsFromChainOptions = {
   throwOnChainScanFailure?: boolean;
   pageBudget?: number;
-} & (
-  | { mode?: 'listAll' }
-  | { mode: 'incremental' }
+  mode?: 'listAll' | 'incremental' | 'seedFull' | 'seedFromCursor';
+  incremental?: boolean;
+  seedIncrementalWatermark?: boolean;
+  resumeFromCursor?: boolean;
+};
+
+type NormalizedContextGraphDiscoveryScan =
+  | { mode: 'listAll' }
+  | { mode: 'incremental'; pageBudget?: number }
   | { mode: 'seedFull' }
-  | { mode: 'seedFromCursor' }
-);
+  | { mode: 'seedFromCursor'; pageBudget?: number };
+
+function normalizeContextGraphDiscoveryScan(
+  options: DiscoverContextGraphsFromChainOptions,
+): NormalizedContextGraphDiscoveryScan {
+  if (options.mode !== undefined) {
+    if (options.mode === 'incremental') {
+      return {
+        mode: 'incremental',
+        ...(options.pageBudget !== undefined ? { pageBudget: options.pageBudget } : {}),
+      };
+    }
+    if (options.mode === 'seedFull') return { mode: 'seedFull' };
+    if (options.mode === 'seedFromCursor') {
+      return {
+        mode: 'seedFromCursor',
+        ...(options.pageBudget !== undefined ? { pageBudget: options.pageBudget } : {}),
+      };
+    }
+    if (options.mode === 'listAll') return { mode: 'listAll' };
+    throw new Error(`Unsupported context graph chain discovery scan mode: ${String(options.mode)}`);
+  }
+
+  if (options.incremental === true) {
+    return {
+      mode: 'incremental',
+      ...(options.pageBudget !== undefined ? { pageBudget: options.pageBudget } : {}),
+    };
+  }
+
+  if (options.seedIncrementalWatermark === true) {
+    if (options.resumeFromCursor === true) {
+      return {
+        mode: 'seedFromCursor',
+        ...(options.pageBudget !== undefined ? { pageBudget: options.pageBudget } : {}),
+      };
+    }
+    return { mode: 'seedFull' };
+  }
+
+  return { mode: 'listAll' };
+}
 
 /**
  * High-level facade that ties together all DKG agent capabilities:
@@ -1101,115 +1147,20 @@ export class DKGAgent extends DKGAgentBase {
     options: DiscoverContextGraphsFromChainOptions = {},
   ): Promise<number> {
     const ctx = createOperationContext('system');
-    if (!this.chain.listContextGraphsFromChain) {
+    const scanMode = normalizeContextGraphDiscoveryScan(options);
+    if (scanMode.mode === 'listAll' && !this.chain.listContextGraphsFromChain) {
       this.log.info(ctx, 'Chain adapter does not support listContextGraphsFromChain — skipping');
+      return 0;
+    }
+    if (scanMode.mode !== 'listAll' && !this.chain.scanContextGraphRegistryPages) {
+      this.log.info(ctx, 'Chain adapter does not support scanContextGraphRegistryPages — skipping');
       return 0;
     }
 
     let onChainContextGraphs: ContextGraphOnChain[] = [];
     let partialChainScan = false;
     let partialChainScanError: unknown;
-
-    // Build a set of all known on-chain IDs (stored and computed) for fast dedup
-    const knownOnChainIds = new Set<string>();
-    for (const [localId, sub] of this.subscribedContextGraphs) {
-      if (sub.onChainId) knownOnChainIds.add(sub.onChainId);
-      // Also compute expected hash for locally-known context graph IDs
-      knownOnChainIds.add(ethers.keccak256(ethers.toUtf8Bytes(localId)));
-    }
-
-    let discovered = 0;
-    let committedByScanPage = false;
-    const applyDiscoveredContextGraphs = async (contextGraphs: ContextGraphOnChain[]): Promise<void> => {
-      for (const p of contextGraphs) {
-      if (knownOnChainIds.has(p.contextGraphId)) continue;
-
-      if (!p.name) {
-        // Hash-only entry (metadata not revealed) — record for dedup but don't
-        // subscribe to gossip topics since hash-keyed topics are unusable.
-        this.log.info(ctx, `Noted unresolved on-chain context graph ${p.contextGraphId.slice(0, 16)}… (no metadata)`);
-        knownOnChainIds.add(p.contextGraphId);
-        continue;
-      }
-
-      // Curated CGs (accessPolicy=1) must not silently land in non-participants' lists.
-      // We can't query the V10 ContextGraphs participant set from a NameRegistry event alone,
-      // so apply the strict default: only auto-subscribe when this node's wallet matches
-      // `creator` (the address that called claimName). Real participants will have the CG
-      // surfaced through manual subscribe / catch-up triggered by their curator.
-      if (Number(p.accessPolicy) === 1) {
-        const isCurator = !!this.defaultAgentAddress
-          && typeof p.creator === 'string'
-          && p.creator.toLowerCase() === this.defaultAgentAddress.toLowerCase();
-        if (!isCurator) {
-          this.log.info(ctx, `Skipping auto-subscribe to curated chain entry "${p.name}" (${p.contextGraphId.slice(0, 16)}…) — not curator`);
-          knownOnChainIds.add(p.contextGraphId);
-          continue;
-        }
-      }
-
-      this.setContextGraphSubscription(p.name, {
-        name: p.name,
-        subscribed: true,
-        synced: false,
-        metaSynced: false,
-        onChainId: p.contextGraphId,
-      });
-      this.subscribeToContextGraph(p.name, { trackSyncScope: false });
-
-      // Persist the on-chain ID to the ontology graph so the publisher's
-      // VM registration guard can find it via RDF (it has no access to
-      // the in-memory subscribedContextGraphs map).
-      const cgUri = contextGraphDataGraphUri(p.name);
-      const ontoGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
-      // Single-valued binding guard (RS heal): on-chain id is immutable; clear
-      // any prior value so the cgId resolver / heal never read a multi-valued
-      // (LIMIT-1-nondeterministic) binding.
-      await this.store.deleteByPattern({
-        graph: ontoGraph,
-        subject: cgUri,
-        predicate: `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`,
-      });
-      await this.store.insert([{
-        subject: cgUri,
-        predicate: `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`,
-        object: `"${p.contextGraphId}"`,
-        graph: ontoGraph,
-      }]);
-
-      this.contextGraphMetaProjection.markDirty(p.name);
-      this.log.info(ctx, `Discovered on-chain context graph "${p.name}" (${p.contextGraphId.slice(0, 16)}…) — auto-subscribed (synced=false)`);
-      discovered++;
-    }
-
-    };
-
-    try {
-      const mode = options.mode ?? 'listAll';
-      const commitPage = async (page: ContextGraphOnChain[]): Promise<void> => {
-        committedByScanPage = true;
-        await applyDiscoveredContextGraphs(page);
-      };
-      const scanOptions = mode === 'incremental'
-        ? {
-            mode,
-            commitPage,
-            ...(options.pageBudget !== undefined ? { pageBudget: options.pageBudget } : {}),
-          }
-        : mode === 'seedFull'
-          ? {
-              mode,
-              commitPage,
-            }
-          : mode === 'seedFromCursor'
-            ? {
-                mode,
-                commitPage,
-                ...(options.pageBudget !== undefined ? { pageBudget: options.pageBudget } : {}),
-              }
-            : undefined;
-      onChainContextGraphs = await this.chain.listContextGraphsFromChain(undefined, scanOptions);
-    } catch (err) {
+    const handleChainScanFailure = (err: unknown): ContextGraphOnChain[] | undefined => {
       const message = err instanceof Error ? err.message : String(err);
       const signature = message
         .replace(/stopped after block \d+/g, 'stopped after block N')
@@ -1223,10 +1174,113 @@ export class DKGAgent extends DKGAgentBase {
       }
       const partialError = isContextGraphChainScanPartialError(err);
       if (options.throwOnChainScanFailure && !partialError) throw err;
-      if (!partialError) return 0;
+      if (!partialError) return undefined;
       partialChainScan = true;
       partialChainScanError = err;
-      onChainContextGraphs = committedByScanPage ? [] : err.partialResults;
+      return err.partialResults;
+    };
+
+    // Build a set of all known on-chain IDs (stored and computed) for fast dedup
+    const knownOnChainIds = new Set<string>();
+    for (const [localId, sub] of this.subscribedContextGraphs) {
+      if (sub.onChainId) knownOnChainIds.add(sub.onChainId);
+      // Also compute expected hash for locally-known context graph IDs
+      knownOnChainIds.add(ethers.keccak256(ethers.toUtf8Bytes(localId)));
+    }
+
+    let discovered = 0;
+    const applyDiscoveredContextGraphs = async (contextGraphs: ContextGraphOnChain[]): Promise<void> => {
+      for (const p of contextGraphs) {
+        if (knownOnChainIds.has(p.contextGraphId)) continue;
+
+        if (!p.name) {
+          // Hash-only entry (metadata not revealed) — record for dedup but don't
+          // subscribe to gossip topics since hash-keyed topics are unusable.
+          this.log.info(ctx, `Noted unresolved on-chain context graph ${p.contextGraphId.slice(0, 16)}… (no metadata)`);
+          knownOnChainIds.add(p.contextGraphId);
+          continue;
+        }
+
+        // Curated CGs (accessPolicy=1) must not silently land in non-participants' lists.
+        // We can't query the V10 ContextGraphs participant set from a NameRegistry event alone,
+        // so apply the strict default: only auto-subscribe when this node's wallet matches
+        // `creator` (the address that called claimName). Real participants will have the CG
+        // surfaced through manual subscribe / catch-up triggered by their curator.
+        if (Number(p.accessPolicy) === 1) {
+          const isCurator = !!this.defaultAgentAddress
+            && typeof p.creator === 'string'
+            && p.creator.toLowerCase() === this.defaultAgentAddress.toLowerCase();
+          if (!isCurator) {
+            this.log.info(ctx, `Skipping auto-subscribe to curated chain entry "${p.name}" (${p.contextGraphId.slice(0, 16)}…) — not curator`);
+            knownOnChainIds.add(p.contextGraphId);
+            continue;
+          }
+        }
+
+        this.setContextGraphSubscription(p.name, {
+          name: p.name,
+          subscribed: true,
+          synced: false,
+          metaSynced: false,
+          onChainId: p.contextGraphId,
+        });
+        this.subscribeToContextGraph(p.name, { trackSyncScope: false });
+
+        // Persist the on-chain ID to the ontology graph so the publisher's
+        // VM registration guard can find it via RDF (it has no access to
+        // the in-memory subscribedContextGraphs map).
+        const cgUri = contextGraphDataGraphUri(p.name);
+        const ontoGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+        // Single-valued binding guard (RS heal): on-chain id is immutable; clear
+        // any prior value so the cgId resolver / heal never read a multi-valued
+        // (LIMIT-1-nondeterministic) binding.
+        await this.store.deleteByPattern({
+          graph: ontoGraph,
+          subject: cgUri,
+          predicate: `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`,
+        });
+        await this.store.insert([{
+          subject: cgUri,
+          predicate: `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`,
+          object: `"${p.contextGraphId}"`,
+          graph: ontoGraph,
+        }]);
+
+        this.contextGraphMetaProjection.markDirty(p.name);
+        this.log.info(ctx, `Discovered on-chain context graph "${p.name}" (${p.contextGraphId.slice(0, 16)}…) — auto-subscribed (synced=false)`);
+        knownOnChainIds.add(p.contextGraphId);
+        discovered++;
+      }
+    };
+
+    if (scanMode.mode === 'listAll') {
+      try {
+        onChainContextGraphs = await this.chain.listContextGraphsFromChain!();
+      } catch (err) {
+        const partialResults = handleChainScanFailure(err);
+        if (!partialResults) return 0;
+        onChainContextGraphs = partialResults;
+      }
+      await applyDiscoveredContextGraphs(onChainContextGraphs);
+    } else {
+      const iterator = this.chain.scanContextGraphRegistryPages!(scanMode)[Symbol.asyncIterator]();
+      try {
+        while (true) {
+          let next: Awaited<ReturnType<typeof iterator.next>>;
+          try {
+            next = await iterator.next();
+          } catch (err) {
+            const partialResults = handleChainScanFailure(err);
+            if (!partialResults) return 0;
+            break;
+          }
+          if (next.done) break;
+          await applyDiscoveredContextGraphs(next.value.contextGraphs);
+          await next.value.ack();
+        }
+      } finally {
+        await iterator.return?.();
+      }
     }
     if (!partialChainScan && this.chainContextGraphScanFailure) {
       this.log.info(
@@ -1234,10 +1288,6 @@ export class DKGAgent extends DKGAgentBase {
         `Chain context graph scan recovered after ${this.chainContextGraphScanFailure.count} failed attempt(s)`,
       );
       this.chainContextGraphScanFailure = undefined;
-    }
-
-    if (!committedByScanPage) {
-      await applyDiscoveredContextGraphs(onChainContextGraphs);
     }
 
     if (discovered > 0) {

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -85,7 +85,7 @@ import {
   ENTITY_PRED_ALT,
 } from '@origintrail-official/dkg-core';
 import { GraphManager, PrivateContentStore, createTripleStore, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig } from '@origintrail-official/dkg-storage';
-import { EVMChainAdapter, NoChainAdapter, enrichEvmError, buildKnowledgeAssetUal, isContextGraphChainScanPartialError, type EVMAdapterConfig, type ChainAdapter, type ContextGraphOnChain, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo } from '@origintrail-official/dkg-chain';
+import { EVMChainAdapter, NoChainAdapter, enrichEvmError, buildKnowledgeAssetUal, isContextGraphChainScanPartialError, type EVMAdapterConfig, type ChainAdapter, type ContextGraphOnChain, type ContextGraphChainScanOptions, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo } from '@origintrail-official/dkg-chain';
 import {
   DKGPublisher, PublishHandler, SharedMemoryHandler, UpdateHandler, ChainEventPoller, AccessHandler, AccessClient,
   PublishJournal, StaleWriteError,
@@ -513,6 +513,26 @@ function normalizeContextGraphDiscoveryScan(
   }
 
   return { mode: 'listAll' };
+}
+
+function legacyChainListScanOptions(
+  options: DiscoverContextGraphsFromChainOptions,
+): ContextGraphChainScanOptions | undefined {
+  if (options.mode !== undefined) return undefined;
+  if (options.incremental === true) {
+    return {
+      incremental: true,
+      ...(options.pageBudget !== undefined ? { pageBudget: options.pageBudget } : {}),
+    };
+  }
+  if (options.seedIncrementalWatermark === true) {
+    return {
+      seedIncrementalWatermark: true,
+      ...(options.resumeFromCursor !== undefined ? { resumeFromCursor: options.resumeFromCursor } : {}),
+      ...(options.pageBudget !== undefined ? { pageBudget: options.pageBudget } : {}),
+    };
+  }
+  return undefined;
 }
 
 /**
@@ -1148,11 +1168,17 @@ export class DKGAgent extends DKGAgentBase {
   ): Promise<number> {
     const ctx = createOperationContext('system');
     const scanMode = normalizeContextGraphDiscoveryScan(options);
+    const legacyListOptions = legacyChainListScanOptions(options);
+    const useLegacyListFallback =
+      scanMode.mode !== 'listAll' &&
+      legacyListOptions !== undefined &&
+      !this.chain.scanContextGraphRegistryPages &&
+      !!this.chain.listContextGraphsFromChain;
     if (scanMode.mode === 'listAll' && !this.chain.listContextGraphsFromChain) {
       this.log.info(ctx, 'Chain adapter does not support listContextGraphsFromChain — skipping');
       return 0;
     }
-    if (scanMode.mode !== 'listAll' && !this.chain.scanContextGraphRegistryPages) {
+    if (scanMode.mode !== 'listAll' && !this.chain.scanContextGraphRegistryPages && !useLegacyListFallback) {
       this.log.info(ctx, 'Chain adapter does not support scanContextGraphRegistryPages — skipping');
       return 0;
     }
@@ -1253,9 +1279,12 @@ export class DKGAgent extends DKGAgentBase {
       }
     };
 
-    if (scanMode.mode === 'listAll') {
+    if (scanMode.mode === 'listAll' || useLegacyListFallback) {
       try {
-        onChainContextGraphs = await this.chain.listContextGraphsFromChain!();
+        onChainContextGraphs = await this.chain.listContextGraphsFromChain!(
+          undefined,
+          useLegacyListFallback ? legacyListOptions : undefined,
+        );
       } catch (err) {
         const partialResults = handleChainScanFailure(err);
         if (!partialResults) return 0;

--- a/packages/agent/test/chain-cursor-wiring.test.ts
+++ b/packages/agent/test/chain-cursor-wiring.test.ts
@@ -31,7 +31,7 @@ describe('DKGAgent chain cursor wiring', () => {
       contextGraphRegistryScanCursorStore: registryCursorStore,
     });
 
-    expect((agent as any).chain.contextGraphRegistryScanCursorStore).toBe(registryCursorStore);
+    expect((agent as any).chain.contextGraphRegistryScanCursor?.input?.store).toBe(registryCursorStore);
   });
 
   it('passes the chain-event lane cursor store into the poller on start', async () => {

--- a/packages/agent/test/chain-cursor-wiring.test.ts
+++ b/packages/agent/test/chain-cursor-wiring.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { MockChainAdapter } from '@origintrail-official/dkg-chain';
+import { DKGAgent } from '../src/index.js';
+
+const OPERATIONAL_KEY =
+  '0x59c6995e998f97a5a0044966f0945388c9e82d88a3fdf0e0c7b33e0d2d2d8b2f';
+
+describe('DKGAgent chain cursor wiring', () => {
+  let agent: DKGAgent | undefined;
+
+  afterEach(async () => {
+    await agent?.stop().catch(() => {});
+    agent = undefined;
+  });
+
+  it('passes the registry scan cursor store into an EVM adapter built from chainConfig', async () => {
+    const registryCursorStore = {
+      load: vi.fn(async () => undefined),
+      save: vi.fn(async () => {}),
+    };
+
+    agent = await DKGAgent.create({
+      name: 'RegistryCursorWiring',
+      listenPort: 0,
+      chainConfig: {
+        rpcUrl: 'http://127.0.0.1:59998',
+        hubAddress: '0x0000000000000000000000000000000000000001',
+        operationalKeys: [OPERATIONAL_KEY],
+        chainId: 'evm:31337',
+      },
+      contextGraphRegistryScanCursorStore: registryCursorStore,
+    });
+
+    expect((agent as any).chain.contextGraphRegistryScanCursorStore).toBe(registryCursorStore);
+  });
+
+  it('passes the chain-event lane cursor store into the poller on start', async () => {
+    const chainEventCursorStore = {
+      loadLane: vi.fn(async () => undefined),
+      saveLane: vi.fn(async () => {}),
+    };
+
+    agent = await DKGAgent.create({
+      name: 'LaneCursorWiring',
+      listenPort: 0,
+      chainAdapter: new MockChainAdapter('mock:31337'),
+      chainEventCursorStore,
+    });
+    await agent.start();
+
+    expect(chainEventCursorStore.loadLane).toHaveBeenCalled();
+    expect(chainEventCursorStore.loadLane.mock.calls.map(([lane]) => lane)).toContain('contextGraphDiscovery');
+  });
+});

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -2341,10 +2341,14 @@ describe('discoverContextGraphsFromChain', () => {
 
   it('keeps full chain discovery as the default and makes incremental opt-in', async () => {
     const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
-    const calls: unknown[] = [];
+    const listCalls: unknown[] = [];
+    const scanCalls: unknown[] = [];
     (chain as any).listContextGraphsFromChain = async (_fromBlock?: number, options?: unknown) => {
-      calls.push(options);
+      listCalls.push(options);
       return [];
+    };
+    (chain as any).scanContextGraphRegistryPages = async function* (options: unknown) {
+      scanCalls.push(options);
     };
 
     const result = await createTestAgent({ chainAdapter: chain });
@@ -2360,13 +2364,142 @@ describe('discoverContextGraphsFromChain', () => {
       pageBudget: 11,
     })).toBe(0);
 
-    expect(calls).toEqual([
+    expect(listCalls).toEqual([
       undefined,
-      { mode: 'incremental', commitPage: expect.any(Function) },
-      { mode: 'incremental', commitPage: expect.any(Function), pageBudget: 7 },
-      { mode: 'seedFull', commitPage: expect.any(Function) },
-      { mode: 'seedFromCursor', commitPage: expect.any(Function), pageBudget: 11 },
     ]);
+    expect(scanCalls).toEqual([
+      { mode: 'incremental' },
+      { mode: 'incremental', pageBudget: 7 },
+      { mode: 'seedFull' },
+      { mode: 'seedFromCursor', pageBudget: 11 },
+    ]);
+  }, 15000);
+
+  it('keeps legacy chain discovery scan options as explicit cursor-mode aliases', async () => {
+    const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
+    const scanCalls: unknown[] = [];
+    (chain as any).listContextGraphsFromChain = async () => [];
+    (chain as any).scanContextGraphRegistryPages = async function* (options: unknown) {
+      scanCalls.push(options);
+    };
+
+    const result = await createTestAgent({ chainAdapter: chain });
+    agent = result.agent;
+    await agent.start();
+
+    expect(await agent.discoverContextGraphsFromChain({ incremental: true })).toBe(0);
+    expect(await agent.discoverContextGraphsFromChain({ incremental: true, pageBudget: 5 })).toBe(0);
+    expect(await agent.discoverContextGraphsFromChain({ seedIncrementalWatermark: true })).toBe(0);
+    expect(await agent.discoverContextGraphsFromChain({
+      seedIncrementalWatermark: true,
+      resumeFromCursor: true,
+      pageBudget: 6,
+    })).toBe(0);
+
+    expect(scanCalls).toEqual([
+      { mode: 'incremental' },
+      { mode: 'incremental', pageBudget: 5 },
+      { mode: 'seedFull' },
+      { mode: 'seedFromCursor', pageBudget: 6 },
+    ]);
+  }, 15000);
+
+  it('applies cursor scan pages once and acknowledges after local discovery work', async () => {
+    const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
+    const contextGraphId = '0xfeed000000000000000000000000000000000000000000000000000000000001';
+    const revealed: ContextGraphOnChain = {
+      contextGraphId,
+      name: 'paged-revealed',
+      creator: '0x1234',
+      accessPolicy: 0,
+      blockNumber: 100,
+      metadataRevealed: true,
+    };
+    const scanCalls: unknown[] = [];
+    const ackedCounts: number[] = [];
+    (chain as any).listContextGraphsFromChain = async () => [];
+    (chain as any).scanContextGraphRegistryPages = async function* (options: unknown) {
+      scanCalls.push(options);
+      yield {
+        contextGraphs: [revealed],
+        ack: async () => {
+          ackedCounts.push(1);
+        },
+      };
+      yield {
+        contextGraphs: [revealed],
+        ack: async () => {
+          ackedCounts.push(2);
+        },
+      };
+    };
+
+    const result = await createTestAgent({ chainAdapter: chain });
+    agent = result.agent;
+    await agent.start();
+
+    const discovered = await agent.discoverContextGraphsFromChain({
+      mode: 'seedFromCursor',
+      pageBudget: 1,
+    });
+
+    expect(discovered).toBe(1);
+    expect(scanCalls).toEqual([{ mode: 'seedFromCursor', pageBudget: 1 }]);
+    expect(ackedCounts).toEqual([1, 2]);
+    const entry = agent.getSubscribedContextGraphs().get('paged-revealed');
+    expect(entry).toBeDefined();
+    expect(entry!.onChainId).toBe(contextGraphId);
+    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+    const contextGraphUri = contextGraphDataGraphUri('paged-revealed');
+    const onChainIdBinding = await result.store.query(`
+      ASK WHERE {
+        GRAPH <${ontologyGraph}> {
+          <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId> "${contextGraphId}" .
+        }
+      }
+    `);
+    expect(onChainIdBinding.type).toBe('boolean');
+    if (onChainIdBinding.type === 'boolean') {
+      expect(onChainIdBinding.value).toBe(true);
+    }
+  }, 15000);
+
+  it('propagates cursor scan page apply failures without acknowledging progress', async () => {
+    const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
+    const revealed: ContextGraphOnChain = {
+      contextGraphId: '0xfeed000000000000000000000000000000000000000000000000000000000002',
+      name: 'apply-failure-revealed',
+      creator: '0x1234',
+      accessPolicy: 0,
+      blockNumber: 100,
+      metadataRevealed: true,
+    };
+    let acked = 0;
+    (chain as any).listContextGraphsFromChain = async () => [];
+    (chain as any).scanContextGraphRegistryPages = async function* () {
+      yield {
+        contextGraphs: [revealed],
+        ack: async () => {
+          acked += 1;
+        },
+      };
+    };
+
+    const result = await createTestAgent({ chainAdapter: chain });
+    agent = result.agent;
+    await agent.start();
+    const originalInsert = result.store.insert.bind(result.store);
+    (result.store as any).insert = async (quads: Parameters<typeof originalInsert>[0]) => {
+      if (quads.some((quad) => quad.predicate === `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`)) {
+        throw new Error('local on-chain id insert failed');
+      }
+      return originalInsert(quads);
+    };
+
+    await expect(agent.discoverContextGraphsFromChain({ mode: 'incremental' }))
+      .rejects.toThrow('local on-chain id insert failed');
+    expect(acked).toBe(0);
+    expect((agent as any).chainContextGraphScanFailure).toBeUndefined();
   }, 15000);
 
   it('warns once for repeated chain scan failures and logs recovery', async () => {
@@ -2406,6 +2539,9 @@ describe('discoverContextGraphsFromChain', () => {
     (chain as any).listContextGraphsFromChain = async () => {
       throw failure;
     };
+    (chain as any).scanContextGraphRegistryPages = async function* () {
+      throw failure;
+    };
 
     const result = await createTestAgent({ chainAdapter: chain });
     agent = result.agent;
@@ -2423,7 +2559,8 @@ describe('discoverContextGraphsFromChain', () => {
   it('processes partial chain scan prefixes without marking the scan recovered', async () => {
     const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
     let calls = 0;
-    (chain as any).listContextGraphsFromChain = async () => {
+    (chain as any).listContextGraphsFromChain = async () => [];
+    (chain as any).scanContextGraphRegistryPages = async function* () {
       calls += 1;
       const stopped = calls === 1 ? 1_999 : 3_999;
       const failedFrom = calls === 1 ? 2_000 : 4_000;
@@ -2451,6 +2588,10 @@ describe('discoverContextGraphsFromChain', () => {
       err.scannedToBlock = stopped;
       err.failedFromBlock = failedFrom;
       err.failedToBlock = failedTo;
+      yield {
+        contextGraphs: err.partialResults,
+        ack: async () => {},
+      };
       throw err;
     };
     const entries: Array<{ level: string; message: string }> = [];

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -2353,12 +2353,19 @@ describe('discoverContextGraphsFromChain', () => {
 
     expect(await agent.discoverContextGraphsFromChain()).toBe(0);
     expect(await agent.discoverContextGraphsFromChain({ incremental: true })).toBe(0);
+    expect(await agent.discoverContextGraphsFromChain({ incremental: true, pageBudget: 7 })).toBe(0);
     expect(await agent.discoverContextGraphsFromChain({ seedIncrementalWatermark: true })).toBe(0);
+    expect(await agent.discoverContextGraphsFromChain({
+      seedIncrementalWatermark: true,
+      pageBudget: 11,
+    })).toBe(0);
 
     expect(calls).toEqual([
       undefined,
       { incremental: true },
+      { incremental: true, pageBudget: 7 },
       { seedIncrementalWatermark: true },
+      { seedIncrementalWatermark: true, pageBudget: 11 },
     ]);
   }, 15000);
 

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -2404,6 +2404,53 @@ describe('discoverContextGraphsFromChain', () => {
     ]);
   }, 15000);
 
+  it('falls back to legacy list scan options for adapters without the paged scanner', async () => {
+    const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
+    const listCalls: unknown[] = [];
+    const entries: ContextGraphOnChain[] = [
+      {
+        contextGraphId: '0xfeed000000000000000000000000000000000000000000000000000000000010',
+        name: 'legacy-list-incremental',
+        creator: '0x1234',
+        accessPolicy: 0,
+        blockNumber: 100,
+        metadataRevealed: true,
+      },
+      {
+        contextGraphId: '0xfeed000000000000000000000000000000000000000000000000000000000011',
+        name: 'legacy-list-seed',
+        creator: '0x1234',
+        accessPolicy: 0,
+        blockNumber: 200,
+        metadataRevealed: true,
+      },
+    ];
+    (chain as any).listContextGraphsFromChain = async (_fromBlock?: number, options?: unknown) => {
+      listCalls.push(options);
+      return [entries[listCalls.length - 1]];
+    };
+    (chain as any).scanContextGraphRegistryPages = undefined;
+
+    const result = await createTestAgent({ chainAdapter: chain });
+    agent = result.agent;
+    await agent.start();
+
+    expect(await agent.discoverContextGraphsFromChain({
+      incremental: true,
+      pageBudget: 5,
+    })).toBe(1);
+    expect(await agent.discoverContextGraphsFromChain({
+      seedIncrementalWatermark: true,
+    })).toBe(1);
+
+    expect(listCalls).toEqual([
+      { incremental: true, pageBudget: 5 },
+      { seedIncrementalWatermark: true },
+    ]);
+    expect(agent.getSubscribedContextGraphs().has('legacy-list-incremental')).toBe(true);
+    expect(agent.getSubscribedContextGraphs().has('legacy-list-seed')).toBe(true);
+  }, 15000);
+
   it('applies cursor scan pages once and acknowledges after local discovery work', async () => {
     const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
     const contextGraphId = '0xfeed000000000000000000000000000000000000000000000000000000000001';
@@ -2602,7 +2649,7 @@ describe('discoverContextGraphsFromChain', () => {
       await agent.start();
 
       await expect(agent.discoverContextGraphsFromChain({
-        mode: 'incremental',
+        mode: 'seedFull',
         throwOnChainScanFailure: true,
       })).rejects.toThrow('partial ContextGraphNameRegistry scan');
       expect(await agent.discoverContextGraphsFromChain({ mode: 'incremental' })).toBe(0);

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -2352,21 +2352,20 @@ describe('discoverContextGraphsFromChain', () => {
     await agent.start();
 
     expect(await agent.discoverContextGraphsFromChain()).toBe(0);
-    expect(await agent.discoverContextGraphsFromChain({ incremental: true })).toBe(0);
-    expect(await agent.discoverContextGraphsFromChain({ incremental: true, pageBudget: 7 })).toBe(0);
-    expect(await agent.discoverContextGraphsFromChain({ seedIncrementalWatermark: true })).toBe(0);
+    expect(await agent.discoverContextGraphsFromChain({ mode: 'incremental' })).toBe(0);
+    expect(await agent.discoverContextGraphsFromChain({ mode: 'incremental', pageBudget: 7 })).toBe(0);
+    expect(await agent.discoverContextGraphsFromChain({ mode: 'seedFull' })).toBe(0);
     expect(await agent.discoverContextGraphsFromChain({
-      seedIncrementalWatermark: true,
-      resumeFromCursor: true,
+      mode: 'seedFromCursor',
       pageBudget: 11,
     })).toBe(0);
 
     expect(calls).toEqual([
       undefined,
-      { incremental: true },
-      { incremental: true, pageBudget: 7 },
-      { seedIncrementalWatermark: true },
-      { seedIncrementalWatermark: true, resumeFromCursor: true, pageBudget: 11 },
+      { mode: 'incremental', commitPage: expect.any(Function) },
+      { mode: 'incremental', commitPage: expect.any(Function), pageBudget: 7 },
+      { mode: 'seedFull', commitPage: expect.any(Function) },
+      { mode: 'seedFromCursor', commitPage: expect.any(Function), pageBudget: 11 },
     ]);
   }, 15000);
 
@@ -2415,7 +2414,7 @@ describe('discoverContextGraphsFromChain', () => {
     expect(await agent.discoverContextGraphsFromChain()).toBe(0);
     await expect(
       agent.discoverContextGraphsFromChain({
-        seedIncrementalWatermark: true,
+        mode: 'seedFull',
         throwOnChainScanFailure: true,
       }),
     ).rejects.toThrow('seed scan failed');
@@ -2462,10 +2461,10 @@ describe('discoverContextGraphsFromChain', () => {
       await agent.start();
 
       await expect(agent.discoverContextGraphsFromChain({
-        incremental: true,
+        mode: 'incremental',
         throwOnChainScanFailure: true,
       })).rejects.toThrow('partial ContextGraphNameRegistry scan');
-      expect(await agent.discoverContextGraphsFromChain({ incremental: true })).toBe(0);
+      expect(await agent.discoverContextGraphsFromChain({ mode: 'incremental' })).toBe(0);
     } finally {
       Logger.setSink(null);
     }

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -2357,6 +2357,7 @@ describe('discoverContextGraphsFromChain', () => {
     expect(await agent.discoverContextGraphsFromChain({ seedIncrementalWatermark: true })).toBe(0);
     expect(await agent.discoverContextGraphsFromChain({
       seedIncrementalWatermark: true,
+      resumeFromCursor: true,
       pageBudget: 11,
     })).toBe(0);
 
@@ -2365,7 +2366,7 @@ describe('discoverContextGraphsFromChain', () => {
       { incremental: true },
       { incremental: true, pageBudget: 7 },
       { seedIncrementalWatermark: true },
-      { seedIncrementalWatermark: true, pageBudget: 11 },
+      { seedIncrementalWatermark: true, resumeFromCursor: true, pageBudget: 11 },
     ]);
   }, 15000);
 

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -38,6 +38,7 @@ export default defineConfig({
       "test/swm-fanout-peer-selection.test.ts",
       "test/publish-literal-size.test.ts",
       "test/verify-batch.test.ts",
+      "test/chain-cursor-wiring.test.ts",
     ],
     testTimeout: 60_000,
     maxWorkers: 1,

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -358,34 +358,54 @@ export function isContextGraphChainScanPartialError(
   );
 }
 
-export type ContextGraphChainScanPageCommit = (
-  contextGraphs: ContextGraphOnChain[],
-) => void | Promise<void>;
-
 /**
  * ContextGraphNameRegistry scan mode.
  *
  * Public/default calls use `listAll` semantics and never mutate daemon
- * watermarks. Cursor-backed daemon modes require a per-page commit callback so
- * the adapter can advance durable progress only after the consumer has applied
- * the discoveries from that page.
+ * watermarks. Cursor-backed daemon scans are exposed through
+ * `scanContextGraphRegistryPages`, where callers explicitly acknowledge a page
+ * after local apply succeeds.
  */
 export type ContextGraphChainScanOptions =
   | { mode?: 'listAll' }
   | {
       mode: 'incremental';
-      commitPage: ContextGraphChainScanPageCommit;
       pageBudget?: number;
     }
   | {
       mode: 'seedFull';
-      commitPage: ContextGraphChainScanPageCommit;
     }
   | {
       mode: 'seedFromCursor';
-      commitPage: ContextGraphChainScanPageCommit;
+      pageBudget?: number;
+    }
+  | {
+      incremental: true;
+      pageBudget?: number;
+    }
+  | {
+      seedIncrementalWatermark: true;
+      resumeFromCursor?: boolean;
       pageBudget?: number;
     };
+
+export type ContextGraphRegistryScanOptions =
+  | {
+      mode: 'incremental';
+      pageBudget?: number;
+    }
+  | {
+      mode: 'seedFull';
+    }
+  | {
+      mode: 'seedFromCursor';
+      pageBudget?: number;
+    };
+
+export interface ContextGraphRegistryScanPage {
+  contextGraphs: ContextGraphOnChain[];
+  ack(): Promise<void>;
+}
 
 export function buildEvmDeploymentId(input: { chainId: string; hubAddress: string }): string {
   return `${input.chainId}:hub=${input.hubAddress.toLowerCase()}`;
@@ -956,13 +976,19 @@ export interface ChainAdapter {
 
   // Context Graphs (name-hash commitment via ContextGraphNameRegistry)
   createContextGraph(params: CreateContextGraphParams): Promise<TxResult>;
-  submitToContextGraph(kaId: string, contextGraphId: string): Promise<TxResult>;
-  /** Reveal cleartext name+description on-chain for a context graph you created. Optional. */
-  revealContextGraphMetadata?(contextGraphId: string, name: string, description: string): Promise<TxResult>;
-  /** List context graphs from chain via `NameClaimed` events. Optional; not supported on no-chain/mock. */
-  listContextGraphsFromChain?(fromBlock?: number, options?: ContextGraphChainScanOptions): Promise<ContextGraphOnChain[]>;
-  /** True when the adapter has a registry scan watermark for its currently bound ContextGraphNameRegistry. */
-  hasContextGraphRegistryScanWatermark?(): Promise<boolean>;
+    submitToContextGraph(kaId: string, contextGraphId: string): Promise<TxResult>;
+    /** Reveal cleartext name+description on-chain for a context graph you created. Optional. */
+    revealContextGraphMetadata?(contextGraphId: string, name: string, description: string): Promise<TxResult>;
+    /** List context graphs from chain via `NameClaimed` events. Optional; not supported on no-chain/mock. */
+    listContextGraphsFromChain?(fromBlock?: number, options?: ContextGraphChainScanOptions): Promise<ContextGraphOnChain[]>;
+    /**
+     * Daemon cursor-backed ContextGraphNameRegistry scan. Each yielded page must
+     * be acknowledged after the caller has applied it locally; only then may the
+     * adapter advance durable scan progress.
+     */
+    scanContextGraphRegistryPages?(options: ContextGraphRegistryScanOptions): AsyncIterable<ContextGraphRegistryScanPage>;
+    /** True when the adapter has a registry scan watermark for its currently bound ContextGraphNameRegistry. */
+    hasContextGraphRegistryScanWatermark?(): Promise<boolean>;
 
   /**
    * Live owner lookup for a PCA NFT — wraps `DKGPublishingConvictionNFT.ownerOf(accountId)`.

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -358,34 +358,34 @@ export function isContextGraphChainScanPartialError(
   );
 }
 
-export interface ContextGraphChainScanOptions {
-  /**
-   * When true and `fromBlock` is omitted, adapters may resume from a
-   * scan watermark with a reorg buffer. The default preserves public
-   * list-all semantics for SDK callers.
-   */
-  incremental?: boolean;
-  /**
-   * When true on a successful full scan, adapters may seed the
-   * incremental watermark for later daemon background scans. This is opt-in so
-   * public SDK list-all calls remain side-effect free by default.
-   */
-  seedIncrementalWatermark?: boolean;
-  /**
-   * Explicitly allow a seeded daemon/background scan to resume from the
-   * existing scan watermark. `seedIncrementalWatermark` without this flag keeps
-   * full scan semantics and starts at the registry deploy block.
-   */
-  resumeFromCursor?: boolean;
-  /**
-   * Optional daemon/background scan budget. When set, adapters may stop after
-   * this many successful log pages and return the scanned prefix while keeping
-   * any durable cursor advanced only through covered pages. Public SDK callers
-   * should leave this unset to preserve complete list-all semantics. The budget
-   * is honored only for incremental scans or explicit cursor-resumed seed scans.
-   */
-  pageBudget?: number;
-}
+export type ContextGraphChainScanPageCommit = (
+  contextGraphs: ContextGraphOnChain[],
+) => void | Promise<void>;
+
+/**
+ * ContextGraphNameRegistry scan mode.
+ *
+ * Public/default calls use `listAll` semantics and never mutate daemon
+ * watermarks. Cursor-backed daemon modes require a per-page commit callback so
+ * the adapter can advance durable progress only after the consumer has applied
+ * the discoveries from that page.
+ */
+export type ContextGraphChainScanOptions =
+  | { mode?: 'listAll' }
+  | {
+      mode: 'incremental';
+      commitPage: ContextGraphChainScanPageCommit;
+      pageBudget?: number;
+    }
+  | {
+      mode: 'seedFull';
+      commitPage: ContextGraphChainScanPageCommit;
+    }
+  | {
+      mode: 'seedFromCursor';
+      commitPage: ContextGraphChainScanPageCommit;
+      pageBudget?: number;
+    };
 
 export function buildEvmDeploymentId(input: { chainId: string; hubAddress: string }): string {
   return `${input.chainId}:hub=${input.hubAddress.toLowerCase()}`;

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -359,26 +359,16 @@ export function isContextGraphChainScanPartialError(
 }
 
 /**
- * ContextGraphNameRegistry scan mode.
+ * Public ContextGraphNameRegistry list options.
  *
- * Public/default calls use `listAll` semantics and never mutate daemon
- * watermarks. Cursor-backed daemon scans are exposed through
+ * Default calls use `listAll` semantics and never mutate daemon watermarks.
+ * The two boolean shapes are retained as legacy compatibility wrappers around
+ * the paged cursor scanner. New cursor-backed daemon scans should use
  * `scanContextGraphRegistryPages`, where callers explicitly acknowledge a page
  * after local apply succeeds.
  */
-export type ContextGraphChainScanOptions =
-  | { mode?: 'listAll' }
-  | {
-      mode: 'incremental';
-      pageBudget?: number;
-    }
-  | {
-      mode: 'seedFull';
-    }
-  | {
-      mode: 'seedFromCursor';
-      pageBudget?: number;
-    }
+export type ContextGraphChainListOptions = { mode?: 'listAll' };
+export type ContextGraphLegacyIncrementalScanOptions =
   | {
       incremental: true;
       pageBudget?: number;
@@ -388,7 +378,11 @@ export type ContextGraphChainScanOptions =
       resumeFromCursor?: boolean;
       pageBudget?: number;
     };
+export type ContextGraphChainScanOptions =
+  | ContextGraphChainListOptions
+  | ContextGraphLegacyIncrementalScanOptions;
 
+/** Cursor-backed daemon ContextGraphNameRegistry scan modes. */
 export type ContextGraphRegistryScanOptions =
   | {
       mode: 'incremental';

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -360,17 +360,35 @@ export function isContextGraphChainScanPartialError(
 
 export interface ContextGraphChainScanOptions {
   /**
-   * When true and `fromBlock` is omitted, adapters may resume from an
-   * in-memory watermark with a reorg buffer. The default preserves public
+   * When true and `fromBlock` is omitted, adapters may resume from a
+   * scan watermark with a reorg buffer. The default preserves public
    * list-all semantics for SDK callers.
    */
   incremental?: boolean;
   /**
-   * When true on a successful full scan, adapters may seed the in-memory
+   * When true on a successful full scan, adapters may seed the
    * incremental watermark for later daemon background scans. This is opt-in so
    * public SDK list-all calls remain side-effect free by default.
    */
   seedIncrementalWatermark?: boolean;
+  /**
+   * Optional daemon/background scan budget. When set, adapters may stop after
+   * this many successful log pages and return the scanned prefix while keeping
+   * any durable cursor advanced only through covered pages. Public SDK callers
+   * should leave this unset to preserve complete list-all semantics.
+   */
+  pageBudget?: number;
+}
+
+export interface ContextGraphRegistryScanCursorKey {
+  chainId: string;
+  deploymentId: string;
+  registryAddress: string;
+}
+
+export interface ContextGraphRegistryScanCursorStore {
+  load(key: ContextGraphRegistryScanCursorKey): Promise<number | undefined>;
+  save(key: ContextGraphRegistryScanCursorKey, nextBlock: number): Promise<void>;
 }
 
 // ----- On-Chain Context Graph types (ContextGraphs contract) -----

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -372,12 +372,23 @@ export interface ContextGraphChainScanOptions {
    */
   seedIncrementalWatermark?: boolean;
   /**
+   * Explicitly allow a seeded daemon/background scan to resume from the
+   * existing scan watermark. `seedIncrementalWatermark` without this flag keeps
+   * full scan semantics and starts at the registry deploy block.
+   */
+  resumeFromCursor?: boolean;
+  /**
    * Optional daemon/background scan budget. When set, adapters may stop after
    * this many successful log pages and return the scanned prefix while keeping
    * any durable cursor advanced only through covered pages. Public SDK callers
-   * should leave this unset to preserve complete list-all semantics.
+   * should leave this unset to preserve complete list-all semantics. The budget
+   * is honored only for incremental scans or explicit cursor-resumed seed scans.
    */
   pageBudget?: number;
+}
+
+export function buildEvmDeploymentId(input: { chainId: string; hubAddress: string }): string {
+  return `${input.chainId}:hub=${input.hubAddress.toLowerCase()}`;
 }
 
 export interface ContextGraphRegistryScanCursorKey {

--- a/packages/chain/src/context-graph-registry-scan-cursor.ts
+++ b/packages/chain/src/context-graph-registry-scan-cursor.ts
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import type {
+  ContextGraphRegistryScanCursorKey,
+  ContextGraphRegistryScanCursorStore,
+} from './chain-adapter.js';
+
+/**
+ * Durable cursor policy for ContextGraphNameRegistry scans.
+ *
+ * The cursor is feature-owned rather than generic EVM plumbing: it is scoped by
+ * chain, deployment, and registry address, and it intentionally tolerates store
+ * failures by falling back to process-local state.
+ */
+export class ContextGraphRegistryScanCursor {
+  private readonly watermarks: Map<string, number> = new Map();
+
+  constructor(
+    private readonly input: {
+      chainId: string;
+      deploymentId: string;
+      store?: ContextGraphRegistryScanCursorStore;
+    },
+  ) {}
+
+  clear(): void {
+    this.watermarks.clear();
+  }
+
+  getCachedWatermark(registryAddress: string): number | undefined {
+    return this.normalize(this.watermarks.get(this.cacheKey(registryAddress)));
+  }
+
+  async loadWatermark(registryAddress: string): Promise<number | undefined> {
+    const cacheKey = this.cacheKey(registryAddress);
+    const cached = this.normalize(this.watermarks.get(cacheKey));
+    if (cached != null) return cached;
+
+    if (!this.input.store) return undefined;
+    try {
+      const persisted = await this.input.store.load(this.cursorKey(cacheKey));
+      const normalized = this.normalize(persisted);
+      if (normalized != null) {
+        this.watermarks.set(cacheKey, normalized);
+      }
+      return normalized;
+    } catch (err) {
+      console.warn(
+        `[chain] ContextGraphNameRegistry scan cursor load failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return undefined;
+    }
+  }
+
+  async saveWatermark(registryAddress: string, nextBlock: number): Promise<void> {
+    const normalized = this.normalize(nextBlock);
+    if (normalized == null) return;
+
+    const cacheKey = this.cacheKey(registryAddress);
+    const existing = this.normalize(this.watermarks.get(cacheKey));
+    if (existing != null && existing >= normalized) return;
+
+    this.watermarks.set(cacheKey, normalized);
+    if (!this.input.store) return;
+    try {
+      await this.input.store.save(this.cursorKey(cacheKey), normalized);
+    } catch (err) {
+      console.warn(
+        `[chain] ContextGraphNameRegistry scan cursor save failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  private cacheKey(registryAddress: string): string {
+    return registryAddress.toLowerCase();
+  }
+
+  private cursorKey(registryAddress: string): ContextGraphRegistryScanCursorKey {
+    return {
+      chainId: this.input.chainId,
+      deploymentId: this.input.deploymentId,
+      registryAddress,
+    };
+  }
+
+  private normalize(value: number | undefined): number | undefined {
+    if (value == null) return undefined;
+    if (!Number.isSafeInteger(value) || value <= 0) return undefined;
+    return value;
+  }
+}

--- a/packages/chain/src/context-graph-registry-scan-cursor.ts
+++ b/packages/chain/src/context-graph-registry-scan-cursor.ts
@@ -23,7 +23,7 @@ export class ContextGraphRegistryScanCursor {
     },
   ) {}
 
-  clear(): void {
+  clearMemoryCache(): void {
     this.watermarks.clear();
   }
 

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -17,6 +17,8 @@ import type { FilterErrorSilencer } from './filter-error-silencer.js';
 import { DEFAULT_APPROVAL_POLICY } from './chain-adapter.js';
 import type {
   ApprovalPolicy,
+  ContextGraphRegistryScanCursorKey,
+  ContextGraphRegistryScanCursorStore,
   V10PublishParams,
   OnChainPublishResult,
   ConvictionReader,
@@ -638,6 +640,8 @@ export class EVMChainAdapterBase {
 
   protected readonly cgRegistryScanPageSize: number;
 
+  protected readonly contextGraphRegistryScanCursorStore?: ContextGraphRegistryScanCursorStore;
+
   /**
    * Reset the PR3 publish-preflight cache. Public so daemon code that
    * knows about an external chain reconfiguration (e.g. a hot-reload
@@ -653,6 +657,69 @@ export class EVMChainAdapterBase {
     this.cachedMinRequiredSignatures = undefined;
     this.cachedContractDeployBlocks.clear();
     this.contextGraphRegistryScanWatermarks.clear();
+  }
+
+  protected contextGraphRegistryScanCursorKey(registryAddress: string): ContextGraphRegistryScanCursorKey {
+    return {
+      chainId: this.chainId,
+      deploymentId: this.deploymentId,
+      registryAddress: registryAddress.toLowerCase(),
+    };
+  }
+
+  protected normalizeContextGraphRegistryScanCursor(value: number | undefined): number | undefined {
+    if (value == null) return undefined;
+    if (!Number.isSafeInteger(value) || value <= 0) return undefined;
+    return value;
+  }
+
+  protected async loadContextGraphRegistryScanWatermark(
+    registryAddress: string,
+  ): Promise<number | undefined> {
+    const cacheKey = registryAddress.toLowerCase();
+    const cached = this.normalizeContextGraphRegistryScanCursor(
+      this.contextGraphRegistryScanWatermarks.get(cacheKey),
+    );
+    if (cached != null) return cached;
+
+    if (!this.contextGraphRegistryScanCursorStore) return undefined;
+    try {
+      const persisted = await this.contextGraphRegistryScanCursorStore.load(
+        this.contextGraphRegistryScanCursorKey(cacheKey),
+      );
+      const normalized = this.normalizeContextGraphRegistryScanCursor(persisted);
+      if (normalized != null) {
+        this.contextGraphRegistryScanWatermarks.set(cacheKey, normalized);
+      }
+      return normalized;
+    } catch (err) {
+      console.warn(
+        `[chain] ContextGraphNameRegistry scan cursor load failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return undefined;
+    }
+  }
+
+  protected async saveContextGraphRegistryScanWatermark(
+    registryAddress: string,
+    nextBlock: number,
+  ): Promise<void> {
+    const normalized = this.normalizeContextGraphRegistryScanCursor(nextBlock);
+    if (normalized == null) return;
+
+    const cacheKey = registryAddress.toLowerCase();
+    this.contextGraphRegistryScanWatermarks.set(cacheKey, normalized);
+    if (!this.contextGraphRegistryScanCursorStore) return;
+    try {
+      await this.contextGraphRegistryScanCursorStore.save(
+        this.contextGraphRegistryScanCursorKey(cacheKey),
+        normalized,
+      );
+    } catch (err) {
+      console.warn(
+        `[chain] ContextGraphNameRegistry scan cursor save failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 
   protected clearIdentityIdForAddress(address: string): void {
@@ -691,6 +758,7 @@ export class EVMChainAdapterBase {
       config.cgRegistryScanPageSize,
       CG_REGISTRY_DEFAULT_PAGE_SIZE,
     );
+    this.contextGraphRegistryScanCursorStore = config.contextGraphRegistryScanCursorStore;
     // BUG-022 root-cause fix: force ethers' `PollingEventSubscriber`
     // (eth_getLogs over a sliding block window) instead of the default
     // `FilterIdEventSubscriber` (eth_newFilter + eth_getFilterChanges).

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -649,7 +649,7 @@ export class EVMChainAdapterBase {
     this.cachedKav10Address = undefined;
     this.cachedMinRequiredSignatures = undefined;
     this.cachedContractDeployBlocks.clear();
-    this.contextGraphRegistryScanCursor.clear();
+    this.contextGraphRegistryScanCursor.clearMemoryCache();
   }
 
   protected clearIdentityIdForAddress(address: string): void {

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -17,8 +17,6 @@ import type { FilterErrorSilencer } from './filter-error-silencer.js';
 import { DEFAULT_APPROVAL_POLICY, buildEvmDeploymentId } from './chain-adapter.js';
 import type {
   ApprovalPolicy,
-  ContextGraphRegistryScanCursorKey,
-  ContextGraphRegistryScanCursorStore,
   V10PublishParams,
   OnChainPublishResult,
   ConvictionReader,
@@ -38,6 +36,7 @@ import { formatProviderContext } from './evm-adapter-types.js';
 import { ReadThroughTtlCache } from './keyed-ttl-single-flight-cache.js';
 import { PcaReadCache } from './pca-read-cache.js';
 import { HubRotationPoller } from './hub-rotation-poller.js';
+import { ContextGraphRegistryScanCursor } from './context-graph-registry-scan-cursor.js';
 import type { ContractCache, EVMAdapterConfig } from './evm-adapter-types.js';
 import { RPC_READ_STALL_TIMEOUT_MS, DEFAULT_RANDOM_SAMPLING_HUB_REFRESH_MS, RPC_RECEIPT_TIMEOUT_MS, RPC_RECEIPT_POLL_INTERVAL_MS, RPC_ENDPOINT_SET_RETRIES, RPC_ENDPOINT_SET_RETRY_BACKOFF_MS, ADMIN_KEY_PURPOSE, OPERATIONAL_KEY_PURPOSE, PUBLISHER_FUNDING_CACHE_TTL_MS } from './evm-adapter-constants.js';
 
@@ -625,11 +624,7 @@ export class EVMChainAdapterBase {
    */
   protected readonly cachedContractDeployBlocks: Map<string, number> = new Map();
 
-  /**
-   * Next unbuffered block for ContextGraphNameRegistry scans, keyed by lowercase
-   * registry address. Read with a reorg buffer; duplicate delivery is harmless.
-   */
-  protected readonly contextGraphRegistryScanWatermarks: Map<string, number> = new Map();
+  protected readonly contextGraphRegistryScanCursor: ContextGraphRegistryScanCursor;
 
   /**
    * eth_getLogs block-window for the pre-10.0.4 getMaxKaNumberForAuthor fallback
@@ -639,8 +634,6 @@ export class EVMChainAdapterBase {
   protected readonly kaHighWaterScanPageSize: number;
 
   protected readonly cgRegistryScanPageSize: number;
-
-  protected readonly contextGraphRegistryScanCursorStore?: ContextGraphRegistryScanCursorStore;
 
   /**
    * Reset the PR3 publish-preflight cache. Public so daemon code that
@@ -656,70 +649,7 @@ export class EVMChainAdapterBase {
     this.cachedKav10Address = undefined;
     this.cachedMinRequiredSignatures = undefined;
     this.cachedContractDeployBlocks.clear();
-    this.contextGraphRegistryScanWatermarks.clear();
-  }
-
-  protected contextGraphRegistryScanCursorKey(registryAddress: string): ContextGraphRegistryScanCursorKey {
-    return {
-      chainId: this.chainId,
-      deploymentId: this.deploymentId,
-      registryAddress: registryAddress.toLowerCase(),
-    };
-  }
-
-  protected normalizeContextGraphRegistryScanCursor(value: number | undefined): number | undefined {
-    if (value == null) return undefined;
-    if (!Number.isSafeInteger(value) || value <= 0) return undefined;
-    return value;
-  }
-
-  protected async loadContextGraphRegistryScanWatermark(
-    registryAddress: string,
-  ): Promise<number | undefined> {
-    const cacheKey = registryAddress.toLowerCase();
-    const cached = this.normalizeContextGraphRegistryScanCursor(
-      this.contextGraphRegistryScanWatermarks.get(cacheKey),
-    );
-    if (cached != null) return cached;
-
-    if (!this.contextGraphRegistryScanCursorStore) return undefined;
-    try {
-      const persisted = await this.contextGraphRegistryScanCursorStore.load(
-        this.contextGraphRegistryScanCursorKey(cacheKey),
-      );
-      const normalized = this.normalizeContextGraphRegistryScanCursor(persisted);
-      if (normalized != null) {
-        this.contextGraphRegistryScanWatermarks.set(cacheKey, normalized);
-      }
-      return normalized;
-    } catch (err) {
-      console.warn(
-        `[chain] ContextGraphNameRegistry scan cursor load failed: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      return undefined;
-    }
-  }
-
-  protected async saveContextGraphRegistryScanWatermark(
-    registryAddress: string,
-    nextBlock: number,
-  ): Promise<void> {
-    const normalized = this.normalizeContextGraphRegistryScanCursor(nextBlock);
-    if (normalized == null) return;
-
-    const cacheKey = registryAddress.toLowerCase();
-    this.contextGraphRegistryScanWatermarks.set(cacheKey, normalized);
-    if (!this.contextGraphRegistryScanCursorStore) return;
-    try {
-      await this.contextGraphRegistryScanCursorStore.save(
-        this.contextGraphRegistryScanCursorKey(cacheKey),
-        normalized,
-      );
-    } catch (err) {
-      console.warn(
-        `[chain] ContextGraphNameRegistry scan cursor save failed: ${err instanceof Error ? err.message : String(err)}`,
-      );
-    }
+    this.contextGraphRegistryScanCursor.clear();
   }
 
   protected clearIdentityIdForAddress(address: string): void {
@@ -758,7 +688,6 @@ export class EVMChainAdapterBase {
       config.cgRegistryScanPageSize,
       CG_REGISTRY_DEFAULT_PAGE_SIZE,
     );
-    this.contextGraphRegistryScanCursorStore = config.contextGraphRegistryScanCursorStore;
     // BUG-022 root-cause fix: force ethers' `PollingEventSubscriber`
     // (eth_getLogs over a sliding block window) instead of the default
     // `FilterIdEventSubscriber` (eth_newFilter + eth_getFilterChanges).
@@ -929,6 +858,11 @@ export class EVMChainAdapterBase {
     }
     this.tokenAddress = config.tokenAddress ? ethers.getAddress(config.tokenAddress) : undefined;
     this.chainId = config.chainId ?? 'evm:31337';
+    this.contextGraphRegistryScanCursor = new ContextGraphRegistryScanCursor({
+      chainId: this.chainId,
+      deploymentId: this.deploymentId,
+      store: config.contextGraphRegistryScanCursorStore,
+    });
     this.approvalPolicy = config.approvalPolicy ?? DEFAULT_APPROVAL_POLICY;
     this.minPublisherNativeWei = config.minPublisherNativeWei ?? 0n;
     this.minPublisherTracWei = config.minPublisherTracWei ?? 0n;

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -14,7 +14,7 @@
 import { JsonRpcProvider, Wallet, Contract, ethers } from 'ethers';
 import { createFilterErrorSilencer, installFilterNotFoundConsoleSuppressor, formatProviderError } from './filter-error-silencer.js';
 import type { FilterErrorSilencer } from './filter-error-silencer.js';
-import { DEFAULT_APPROVAL_POLICY } from './chain-adapter.js';
+import { DEFAULT_APPROVAL_POLICY, buildEvmDeploymentId } from './chain-adapter.js';
 import type {
   ApprovalPolicy,
   ContextGraphRegistryScanCursorKey,
@@ -380,7 +380,7 @@ async function contractAddress(contract: Contract): Promise<string> {
 export class EVMChainAdapterBase {
   /** See `ChainAdapter.deploymentId`. */
   get deploymentId(): string {
-    return `${this.chainId}:hub=${this.hubAddress.toLowerCase()}`;
+    return buildEvmDeploymentId({ chainId: this.chainId, hubAddress: this.hubAddress });
   }
 
   readonly chainType = 'evm' as const;

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -16,7 +16,7 @@ import {
 } from './evm-adapter-base.js';
 import { isTooLowAllowanceError } from './evm-adapter-errors.js';
 import { ethers, Contract, type JsonRpcProvider } from 'ethers';
-import { ContextGraphChainScanPartialError, type CreateContextGraphParams, type TxResult, type ContextGraphOnChain, type ContextGraphChainScanOptions, type ContextGraphChainScanPageCommit, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type VerifyParams, type PublishToContextGraphParams, type OnChainPublishResult } from './chain-adapter.js';
+import { ContextGraphChainScanPartialError, type CreateContextGraphParams, type TxResult, type ContextGraphOnChain, type ContextGraphChainScanOptions, type ContextGraphRegistryScanOptions, type ContextGraphRegistryScanPage, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type VerifyParams, type PublishToContextGraphParams, type OnChainPublishResult } from './chain-adapter.js';
 import { buildAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1 } from '@origintrail-official/dkg-core';
 
 type ContextGraphRegistryScanPlan =
@@ -26,7 +26,6 @@ type ContextGraphRegistryScanPlan =
       persistProgress: false;
       allowPartialFailure: false;
       seedAtEnd: false;
-      commitPage?: undefined;
       pageBudget?: undefined;
     }
   | {
@@ -35,7 +34,6 @@ type ContextGraphRegistryScanPlan =
       persistProgress: true;
       allowPartialFailure: true;
       seedAtEnd: false;
-      commitPage: ContextGraphChainScanPageCommit;
       pageBudget?: number;
     }
   | {
@@ -44,7 +42,6 @@ type ContextGraphRegistryScanPlan =
       persistProgress: true;
       allowPartialFailure: true;
       seedAtEnd: true;
-      commitPage: ContextGraphChainScanPageCommit;
       pageBudget?: undefined;
     }
   | {
@@ -53,7 +50,6 @@ type ContextGraphRegistryScanPlan =
       persistProgress: true;
       allowPartialFailure: true;
       seedAtEnd: true;
-      commitPage: ContextGraphChainScanPageCommit;
       pageBudget?: number;
     };
 
@@ -63,10 +59,24 @@ function normalizePageBudget(value: number | undefined): number | undefined {
     : undefined;
 }
 
-function buildContextGraphRegistryScanPlan(
+function buildPublicContextGraphRegistryScanPlan(
   fromBlock: number | undefined,
   options: ContextGraphChainScanOptions | undefined,
 ): ContextGraphRegistryScanPlan {
+  const mode = options && 'mode' in options ? options.mode : undefined;
+  if (options && (
+    ('incremental' in options && options.incremental === true) ||
+    ('seedIncrementalWatermark' in options && options.seedIncrementalWatermark === true) ||
+    mode === 'incremental' ||
+    mode === 'seedFull' ||
+    mode === 'seedFromCursor'
+  )) {
+    throw new Error(
+      'listContextGraphsFromChain cursor scan options are no longer accepted; ' +
+      'use scanContextGraphRegistryPages for cursor-backed daemon scans.',
+    );
+  }
+
   if (fromBlock !== undefined) {
     return {
       mode: 'explicitFromBlock',
@@ -77,14 +87,25 @@ function buildContextGraphRegistryScanPlan(
     };
   }
 
-  if (options?.mode === 'incremental') {
+  return {
+    mode: 'listAll',
+    resumeFromWatermark: false,
+    persistProgress: false,
+    allowPartialFailure: false,
+    seedAtEnd: false,
+  };
+}
+
+function buildCursorContextGraphRegistryScanPlan(
+  options: ContextGraphRegistryScanOptions,
+): ContextGraphRegistryScanPlan {
+  if (options.mode === 'incremental') {
     return {
       mode: 'incremental',
       resumeFromWatermark: true,
       persistProgress: true,
       allowPartialFailure: true,
       seedAtEnd: false,
-      commitPage: options.commitPage,
       pageBudget: normalizePageBudget(options.pageBudget),
     };
   }
@@ -96,7 +117,6 @@ function buildContextGraphRegistryScanPlan(
       persistProgress: true,
       allowPartialFailure: true,
       seedAtEnd: true,
-      commitPage: options.commitPage,
     };
   }
 
@@ -107,18 +127,12 @@ function buildContextGraphRegistryScanPlan(
       persistProgress: true,
       allowPartialFailure: true,
       seedAtEnd: true,
-      commitPage: options.commitPage,
       pageBudget: normalizePageBudget(options.pageBudget),
     };
   }
 
-  return {
-    mode: 'listAll',
-    resumeFromWatermark: false,
-    persistProgress: false,
-    allowPartialFailure: false,
-    seedAtEnd: false,
-  };
+  const exhaustive: never = options;
+  throw new Error(`Unsupported ContextGraphNameRegistry scan mode: ${JSON.stringify(exhaustive)}`);
 }
 
 export class ContextGraphMethods extends EVMChainAdapterBase {
@@ -226,9 +240,48 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     await this.init();
     const registry = this.contracts.contextGraphNameRegistry;
     if (!registry) return [];
-    const eventFilter = registry.filters.NameClaimed();
     const registryAddress = (await registry.getAddress()).toLowerCase();
-    const scanPlan = buildContextGraphRegistryScanPlan(fromBlock, options);
+    const scanPlan = buildPublicContextGraphRegistryScanPlan(fromBlock, options);
+    return this._collectContextGraphRegistryScan(registry, registryAddress, fromBlock, scanPlan);
+  }
+
+  async *scanContextGraphRegistryPages(
+    options: ContextGraphRegistryScanOptions,
+  ): AsyncIterable<ContextGraphRegistryScanPage> {
+    await this.init();
+    const registry = this.contracts.contextGraphNameRegistry;
+    if (!registry) return;
+    const registryAddress = (await registry.getAddress()).toLowerCase();
+    const scanPlan = buildCursorContextGraphRegistryScanPlan(options);
+    yield* this._iterateContextGraphRegistryScanPages(registry, registryAddress, undefined, scanPlan);
+  }
+
+  async _collectContextGraphRegistryScan(
+    registry: Contract,
+    registryAddress: string,
+    fromBlock: number | undefined,
+    scanPlan: ContextGraphRegistryScanPlan,
+  ): Promise<ContextGraphOnChain[]> {
+    const results: ContextGraphOnChain[] = [];
+    for await (const page of this._iterateContextGraphRegistryScanPages(
+      registry,
+      registryAddress,
+      fromBlock,
+      scanPlan,
+    )) {
+      results.push(...page.contextGraphs);
+      await page.ack();
+    }
+    return results;
+  }
+
+  async *_iterateContextGraphRegistryScanPages(
+    registry: Contract,
+    registryAddress: string,
+    fromBlock: number | undefined,
+    scanPlan: ContextGraphRegistryScanPlan,
+  ): AsyncGenerator<ContextGraphRegistryScanPage, void, unknown> {
+    const eventFilter = registry.filters.NameClaimed();
     const persistedWatermark = (scanPlan.resumeFromWatermark || scanPlan.seedAtEnd)
       ? await this.contextGraphRegistryScanCursor.loadWatermark(registryAddress)
       : undefined;
@@ -251,10 +304,14 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     );
     if (start > head) {
       if (scanPlan.seedAtEnd) {
-        await scanPlan.commitPage([]);
-        await this.contextGraphRegistryScanCursor.saveWatermark(registryAddress, head + 1);
+        yield {
+          contextGraphs: [],
+          ack: async () => {
+            await this.contextGraphRegistryScanCursor.saveWatermark(registryAddress, head + 1);
+          },
+        };
       }
-      return [];
+      return;
     }
 
     const pageSize = this.cgRegistryScanPageSize;
@@ -323,23 +380,28 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
         }
         throw err;
       }
-      if (scanPlan.persistProgress) {
-        await scanPlan.commitPage(pageResults);
-      }
       results.push(...pageResults);
       scannedAnyPage = true;
-      if (scanPlan.persistProgress) {
-        await this.contextGraphRegistryScanCursor.saveWatermark(registryAddress, hi + 1);
-      }
+      yield {
+        contextGraphs: pageResults,
+        ack: scanPlan.persistProgress
+          ? async () => {
+              await this.contextGraphRegistryScanCursor.saveWatermark(registryAddress, hi + 1);
+            }
+          : async () => {},
+      };
       const scannedPages = Math.floor((hi - start) / pageSize) + 1;
-      if (scanPlan.pageBudget !== undefined && scannedPages >= scanPlan.pageBudget && hi < head) return results;
+      if (scanPlan.pageBudget !== undefined && scannedPages >= scanPlan.pageBudget && hi < head) return;
     }
 
     if (scanPlan.seedAtEnd) {
-      await this.contextGraphRegistryScanCursor.saveWatermark(registryAddress, head + 1);
+      yield {
+        contextGraphs: [],
+        ack: async () => {
+          await this.contextGraphRegistryScanCursor.saveWatermark(registryAddress, head + 1);
+        },
+      };
     }
-
-    return results;
   }
 
   // =====================================================================

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -19,6 +19,100 @@ import { ethers, Contract, type JsonRpcProvider } from 'ethers';
 import { ContextGraphChainScanPartialError, type CreateContextGraphParams, type TxResult, type ContextGraphOnChain, type ContextGraphChainScanOptions, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type VerifyParams, type PublishToContextGraphParams, type OnChainPublishResult } from './chain-adapter.js';
 import { buildAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1 } from '@origintrail-official/dkg-core';
 
+type ContextGraphRegistryScanPlan =
+  | {
+      mode: 'explicitFromBlock' | 'listAll';
+      resumeFromWatermark: false;
+      persistProgress: false;
+      allowPartialFailure: false;
+      seedAtEnd: false;
+      pageBudget?: undefined;
+    }
+  | {
+      mode: 'incremental';
+      resumeFromWatermark: true;
+      persistProgress: true;
+      allowPartialFailure: true;
+      seedAtEnd: false;
+      pageBudget?: number;
+    }
+  | {
+      mode: 'seedFull';
+      resumeFromWatermark: false;
+      persistProgress: true;
+      allowPartialFailure: true;
+      seedAtEnd: true;
+      pageBudget?: undefined;
+    }
+  | {
+      mode: 'seedFromCursor';
+      resumeFromWatermark: true;
+      persistProgress: true;
+      allowPartialFailure: true;
+      seedAtEnd: true;
+      pageBudget?: number;
+    };
+
+function normalizePageBudget(value: number | undefined): number | undefined {
+  return Number.isFinite(value) && (value ?? 0) >= 1
+    ? Math.floor(value ?? 0)
+    : undefined;
+}
+
+function buildContextGraphRegistryScanPlan(
+  fromBlock: number | undefined,
+  options: ContextGraphChainScanOptions | undefined,
+): ContextGraphRegistryScanPlan {
+  if (fromBlock !== undefined) {
+    return {
+      mode: 'explicitFromBlock',
+      resumeFromWatermark: false,
+      persistProgress: false,
+      allowPartialFailure: false,
+      seedAtEnd: false,
+    };
+  }
+
+  if (options?.incremental === true) {
+    return {
+      mode: 'incremental',
+      resumeFromWatermark: true,
+      persistProgress: true,
+      allowPartialFailure: true,
+      seedAtEnd: false,
+      pageBudget: normalizePageBudget(options.pageBudget),
+    };
+  }
+
+  if (options?.seedIncrementalWatermark === true) {
+    const cursorResumedSeed = options.resumeFromCursor === true;
+    return cursorResumedSeed
+      ? {
+          mode: 'seedFromCursor',
+          resumeFromWatermark: true,
+          persistProgress: true,
+          allowPartialFailure: true,
+          seedAtEnd: true,
+          pageBudget: normalizePageBudget(options.pageBudget),
+        }
+      : {
+          mode: 'seedFull',
+          resumeFromWatermark: false,
+          persistProgress: true,
+          allowPartialFailure: true,
+          seedAtEnd: true,
+        };
+  }
+
+  return {
+    mode: 'listAll',
+    resumeFromWatermark: false,
+    persistProgress: false,
+    allowPartialFailure: false,
+    seedAtEnd: false,
+  };
+}
+
 export class ContextGraphMethods extends EVMChainAdapterBase {
   /**
    * Reserve the next authorized signer and return its address. The publisher
@@ -126,22 +220,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     if (!registry) return [];
     const eventFilter = registry.filters.NameClaimed();
     const registryAddress = (await registry.getAddress()).toLowerCase();
-    const incremental = options?.incremental === true && fromBlock === undefined;
-    const seedIncrementalWatermark =
-      options?.seedIncrementalWatermark === true && !incremental && fromBlock === undefined;
-    const cursorResumedSeed =
-      seedIncrementalWatermark && options?.resumeFromCursor === true;
-    const scanPlan = {
-      resumeFromWatermark: incremental || cursorResumedSeed,
-      persistProgress: incremental || seedIncrementalWatermark,
-      allowPartialFailure: incremental || seedIncrementalWatermark,
-      seedAtEnd: seedIncrementalWatermark,
-      pageBudget: (incremental || cursorResumedSeed) &&
-        Number.isFinite(options?.pageBudget) &&
-        (options?.pageBudget ?? 0) >= 1
-          ? Math.floor(options?.pageBudget ?? 0)
-          : undefined,
-    };
+    const scanPlan = buildContextGraphRegistryScanPlan(fromBlock, options);
     const persistedWatermark = (scanPlan.resumeFromWatermark || scanPlan.seedAtEnd)
       ? await this.contextGraphRegistryScanCursor.loadWatermark(registryAddress)
       : undefined;
@@ -172,7 +251,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     const pageSize = this.cgRegistryScanPageSize;
     const pages = Math.ceil((head - start + 1) / pageSize);
     const blockBudget = CG_REGISTRY_MAX_SCAN_PAGES * pageSize;
-    if (incremental && scanPlan.pageBudget === undefined && !degradedFromGenesis && pages > CG_REGISTRY_MAX_SCAN_PAGES) {
+    if (scanPlan.mode === 'incremental' && scanPlan.pageBudget === undefined && !degradedFromGenesis && pages > CG_REGISTRY_MAX_SCAN_PAGES) {
       throw new Error(
         `listContextGraphsFromChain: incremental ContextGraphNameRegistry scan would need ` +
           `${pages} eth_getLogs calls over blocks [${start}, ${head}] at a ` +

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -16,7 +16,7 @@ import {
 } from './evm-adapter-base.js';
 import { isTooLowAllowanceError } from './evm-adapter-errors.js';
 import { ethers, Contract, type JsonRpcProvider } from 'ethers';
-import { ContextGraphChainScanPartialError, type CreateContextGraphParams, type TxResult, type ContextGraphOnChain, type ContextGraphChainScanOptions, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type VerifyParams, type PublishToContextGraphParams, type OnChainPublishResult } from './chain-adapter.js';
+import { ContextGraphChainScanPartialError, type CreateContextGraphParams, type TxResult, type ContextGraphOnChain, type ContextGraphChainScanOptions, type ContextGraphChainScanPageCommit, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type VerifyParams, type PublishToContextGraphParams, type OnChainPublishResult } from './chain-adapter.js';
 import { buildAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1 } from '@origintrail-official/dkg-core';
 
 type ContextGraphRegistryScanPlan =
@@ -26,6 +26,7 @@ type ContextGraphRegistryScanPlan =
       persistProgress: false;
       allowPartialFailure: false;
       seedAtEnd: false;
+      commitPage?: undefined;
       pageBudget?: undefined;
     }
   | {
@@ -34,6 +35,7 @@ type ContextGraphRegistryScanPlan =
       persistProgress: true;
       allowPartialFailure: true;
       seedAtEnd: false;
+      commitPage: ContextGraphChainScanPageCommit;
       pageBudget?: number;
     }
   | {
@@ -42,6 +44,7 @@ type ContextGraphRegistryScanPlan =
       persistProgress: true;
       allowPartialFailure: true;
       seedAtEnd: true;
+      commitPage: ContextGraphChainScanPageCommit;
       pageBudget?: undefined;
     }
   | {
@@ -50,6 +53,7 @@ type ContextGraphRegistryScanPlan =
       persistProgress: true;
       allowPartialFailure: true;
       seedAtEnd: true;
+      commitPage: ContextGraphChainScanPageCommit;
       pageBudget?: number;
     };
 
@@ -73,35 +77,39 @@ function buildContextGraphRegistryScanPlan(
     };
   }
 
-  if (options?.incremental === true) {
+  if (options?.mode === 'incremental') {
     return {
       mode: 'incremental',
       resumeFromWatermark: true,
       persistProgress: true,
       allowPartialFailure: true,
       seedAtEnd: false,
+      commitPage: options.commitPage,
       pageBudget: normalizePageBudget(options.pageBudget),
     };
   }
 
-  if (options?.seedIncrementalWatermark === true) {
-    const cursorResumedSeed = options.resumeFromCursor === true;
-    return cursorResumedSeed
-      ? {
-          mode: 'seedFromCursor',
-          resumeFromWatermark: true,
-          persistProgress: true,
-          allowPartialFailure: true,
-          seedAtEnd: true,
-          pageBudget: normalizePageBudget(options.pageBudget),
-        }
-      : {
-          mode: 'seedFull',
-          resumeFromWatermark: false,
-          persistProgress: true,
-          allowPartialFailure: true,
-          seedAtEnd: true,
-        };
+  if (options?.mode === 'seedFull') {
+    return {
+      mode: 'seedFull',
+      resumeFromWatermark: false,
+      persistProgress: true,
+      allowPartialFailure: true,
+      seedAtEnd: true,
+      commitPage: options.commitPage,
+    };
+  }
+
+  if (options?.mode === 'seedFromCursor') {
+    return {
+      mode: 'seedFromCursor',
+      resumeFromWatermark: true,
+      persistProgress: true,
+      allowPartialFailure: true,
+      seedAtEnd: true,
+      commitPage: options.commitPage,
+      pageBudget: normalizePageBudget(options.pageBudget),
+    };
   }
 
   return {
@@ -243,6 +251,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     );
     if (start > head) {
       if (scanPlan.seedAtEnd) {
+        await scanPlan.commitPage([]);
         await this.contextGraphRegistryScanCursor.saveWatermark(registryAddress, head + 1);
       }
       return [];
@@ -272,6 +281,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     // failure. Public list-all calls should remain all-or-error.
     for (let lo = start; lo <= head; lo += pageSize) {
       const hi = Math.min(lo + pageSize - 1, head);
+      let pageResults: ContextGraphOnChain[];
       try {
         const page = await this.queryEventLogsPage(
           registry,
@@ -284,7 +294,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
           preferred,
         );
         preferred = page.provider;
-        const pageResults: ContextGraphOnChain[] = [];
+        pageResults = [];
         for (const log of page.logs) {
           const parsed = registry.interface.parseLog({ topics: [...log.topics], data: log.data });
           if (!parsed || parsed.name !== 'NameClaimed') continue;
@@ -296,13 +306,6 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
             metadataRevealed: false,
           });
         }
-        results.push(...pageResults);
-        scannedAnyPage = true;
-        if (scanPlan.persistProgress) {
-          await this.contextGraphRegistryScanCursor.saveWatermark(registryAddress, hi + 1);
-        }
-        const scannedPages = Math.floor((hi - start) / pageSize) + 1;
-        if (scanPlan.pageBudget !== undefined && scannedPages >= scanPlan.pageBudget && hi < head) return results;
       } catch (err) {
         if (scanPlan.allowPartialFailure && scannedAnyPage) {
           const message = err instanceof Error ? err.message : String(err);
@@ -320,6 +323,16 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
         }
         throw err;
       }
+      if (scanPlan.persistProgress) {
+        await scanPlan.commitPage(pageResults);
+      }
+      results.push(...pageResults);
+      scannedAnyPage = true;
+      if (scanPlan.persistProgress) {
+        await this.contextGraphRegistryScanCursor.saveWatermark(registryAddress, hi + 1);
+      }
+      const scannedPages = Math.floor((hi - start) / pageSize) + 1;
+      if (scanPlan.pageBudget !== undefined && scannedPages >= scanPlan.pageBudget && hi < head) return results;
     }
 
     if (scanPlan.seedAtEnd) {

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -114,7 +114,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     const registry = this.contracts.contextGraphNameRegistry;
     if (!registry) return false;
     const registryAddress = (await registry.getAddress()).toLowerCase();
-    return this.contextGraphRegistryScanWatermarks.has(registryAddress);
+    return (await this.loadContextGraphRegistryScanWatermark(registryAddress)) != null;
   }
 
   async listContextGraphsFromChain(
@@ -129,12 +129,17 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     const incremental = options?.incremental === true && fromBlock === undefined;
     const seedIncrementalWatermark =
       options?.seedIncrementalWatermark === true && !incremental && fromBlock === undefined;
-    const watermark = incremental
-      ? this.contextGraphRegistryScanWatermarks.get(registryAddress)
+    const watermarkEligible = fromBlock === undefined && (incremental || seedIncrementalWatermark);
+    const pageBudget = watermarkEligible && Number.isFinite(options?.pageBudget) && (options?.pageBudget ?? 0) >= 1
+      ? Math.floor(options?.pageBudget ?? 0)
       : undefined;
+    const persistedWatermark = watermarkEligible
+      ? await this.loadContextGraphRegistryScanWatermark(registryAddress)
+      : undefined;
+    const canResumeFromWatermark = watermarkEligible && persistedWatermark !== undefined;
     const scan =
       fromBlock === undefined
-        ? incremental && watermark !== undefined
+        ? canResumeFromWatermark
           ? { fromBlock: 0, ...(await this.resolveLogScanHead('listContextGraphsFromChain')) }
           : await this.resolveContractDeployBlock(
               registryAddress,
@@ -144,13 +149,13 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
         : { fromBlock, ...(await this.resolveLogScanHead('listContextGraphsFromChain')) };
     const { fromBlock: deployBlock, head, scanProviders, degradedFromGenesis = false } = scan;
     const start = fromBlock ?? (
-      incremental && watermark !== undefined
-        ? Math.max(0, watermark - CG_REGISTRY_REORG_BUFFER_BLOCKS)
+      canResumeFromWatermark
+        ? Math.max(0, persistedWatermark - CG_REGISTRY_REORG_BUFFER_BLOCKS)
         : deployBlock
     );
     if (start > head) {
       if (seedIncrementalWatermark) {
-        this.contextGraphRegistryScanWatermarks.set(registryAddress, head + 1);
+        await this.saveContextGraphRegistryScanWatermark(registryAddress, head + 1);
       }
       return [];
     }
@@ -158,7 +163,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     const pageSize = this.cgRegistryScanPageSize;
     const pages = Math.ceil((head - start + 1) / pageSize);
     const blockBudget = CG_REGISTRY_MAX_SCAN_PAGES * pageSize;
-    if (incremental && !degradedFromGenesis && pages > CG_REGISTRY_MAX_SCAN_PAGES) {
+    if (incremental && pageBudget === undefined && !degradedFromGenesis && pages > CG_REGISTRY_MAX_SCAN_PAGES) {
       throw new Error(
         `listContextGraphsFromChain: incremental ContextGraphNameRegistry scan would need ` +
           `${pages} eth_getLogs calls over blocks [${start}, ${head}] at a ` +
@@ -175,8 +180,8 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     let preferred: JsonRpcProvider | undefined;
     let scannedAnyPage = false;
 
-    // Incremental daemon scans can resume from the scanned prefix after a later
-    // page failure. Public list-all calls should remain all-or-error.
+    // Daemon scans can resume from the scanned prefix after a later page
+    // failure. Public list-all calls should remain all-or-error.
     for (let lo = start; lo <= head; lo += pageSize) {
       const hi = Math.min(lo + pageSize - 1, head);
       try {
@@ -205,11 +210,13 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
         }
         results.push(...pageResults);
         scannedAnyPage = true;
-        if (incremental) {
-          this.contextGraphRegistryScanWatermarks.set(registryAddress, hi + 1);
+        if (incremental || seedIncrementalWatermark) {
+          await this.saveContextGraphRegistryScanWatermark(registryAddress, hi + 1);
         }
+        const scannedPages = Math.floor((hi - start) / pageSize) + 1;
+        if (pageBudget !== undefined && scannedPages >= pageBudget && hi < head) return results;
       } catch (err) {
-        if (incremental && scannedAnyPage) {
+        if ((incremental || seedIncrementalWatermark) && scannedAnyPage) {
           const message = err instanceof Error ? err.message : String(err);
           throw new ContextGraphChainScanPartialError(
             `listContextGraphsFromChain: partial ContextGraphNameRegistry scan ` +
@@ -228,7 +235,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     }
 
     if (seedIncrementalWatermark) {
-      this.contextGraphRegistryScanWatermarks.set(registryAddress, head + 1);
+      await this.saveContextGraphRegistryScanWatermark(registryAddress, head + 1);
     }
 
     return results;

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -129,14 +129,23 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     const incremental = options?.incremental === true && fromBlock === undefined;
     const seedIncrementalWatermark =
       options?.seedIncrementalWatermark === true && !incremental && fromBlock === undefined;
-    const watermarkEligible = fromBlock === undefined && (incremental || seedIncrementalWatermark);
-    const pageBudget = watermarkEligible && Number.isFinite(options?.pageBudget) && (options?.pageBudget ?? 0) >= 1
-      ? Math.floor(options?.pageBudget ?? 0)
-      : undefined;
-    const persistedWatermark = watermarkEligible
+    const cursorResumedSeed =
+      seedIncrementalWatermark && options?.resumeFromCursor === true;
+    const scanPlan = {
+      resumeFromWatermark: incremental || cursorResumedSeed,
+      persistProgress: incremental || seedIncrementalWatermark,
+      allowPartialFailure: incremental || seedIncrementalWatermark,
+      seedAtEnd: seedIncrementalWatermark,
+      pageBudget: (incremental || cursorResumedSeed) &&
+        Number.isFinite(options?.pageBudget) &&
+        (options?.pageBudget ?? 0) >= 1
+          ? Math.floor(options?.pageBudget ?? 0)
+          : undefined,
+    };
+    const persistedWatermark = scanPlan.resumeFromWatermark
       ? await this.loadContextGraphRegistryScanWatermark(registryAddress)
       : undefined;
-    const canResumeFromWatermark = watermarkEligible && persistedWatermark !== undefined;
+    const canResumeFromWatermark = scanPlan.resumeFromWatermark && persistedWatermark !== undefined;
     const scan =
       fromBlock === undefined
         ? canResumeFromWatermark
@@ -154,7 +163,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
         : deployBlock
     );
     if (start > head) {
-      if (seedIncrementalWatermark) {
+      if (scanPlan.seedAtEnd) {
         await this.saveContextGraphRegistryScanWatermark(registryAddress, head + 1);
       }
       return [];
@@ -163,7 +172,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     const pageSize = this.cgRegistryScanPageSize;
     const pages = Math.ceil((head - start + 1) / pageSize);
     const blockBudget = CG_REGISTRY_MAX_SCAN_PAGES * pageSize;
-    if (incremental && pageBudget === undefined && !degradedFromGenesis && pages > CG_REGISTRY_MAX_SCAN_PAGES) {
+    if (incremental && scanPlan.pageBudget === undefined && !degradedFromGenesis && pages > CG_REGISTRY_MAX_SCAN_PAGES) {
       throw new Error(
         `listContextGraphsFromChain: incremental ContextGraphNameRegistry scan would need ` +
           `${pages} eth_getLogs calls over blocks [${start}, ${head}] at a ` +
@@ -210,13 +219,13 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
         }
         results.push(...pageResults);
         scannedAnyPage = true;
-        if (incremental || seedIncrementalWatermark) {
+        if (scanPlan.persistProgress) {
           await this.saveContextGraphRegistryScanWatermark(registryAddress, hi + 1);
         }
         const scannedPages = Math.floor((hi - start) / pageSize) + 1;
-        if (pageBudget !== undefined && scannedPages >= pageBudget && hi < head) return results;
+        if (scanPlan.pageBudget !== undefined && scannedPages >= scanPlan.pageBudget && hi < head) return results;
       } catch (err) {
-        if ((incremental || seedIncrementalWatermark) && scannedAnyPage) {
+        if (scanPlan.allowPartialFailure && scannedAnyPage) {
           const message = err instanceof Error ? err.message : String(err);
           throw new ContextGraphChainScanPartialError(
             `listContextGraphsFromChain: partial ContextGraphNameRegistry scan ` +
@@ -234,7 +243,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
       }
     }
 
-    if (seedIncrementalWatermark) {
+    if (scanPlan.seedAtEnd) {
       await this.saveContextGraphRegistryScanWatermark(registryAddress, head + 1);
     }
 

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -63,19 +63,10 @@ function buildPublicContextGraphRegistryScanPlan(
   fromBlock: number | undefined,
   options: ContextGraphChainScanOptions | undefined,
 ): ContextGraphRegistryScanPlan {
-  const mode = options && 'mode' in options ? options.mode : undefined;
-  if (options && (
-    ('incremental' in options && options.incremental === true) ||
-    ('seedIncrementalWatermark' in options && options.seedIncrementalWatermark === true) ||
-    mode === 'incremental' ||
-    mode === 'seedFull' ||
-    mode === 'seedFromCursor'
-  )) {
-    throw new Error(
-      'listContextGraphsFromChain cursor scan options are no longer accepted; ' +
-      'use scanContextGraphRegistryPages for cursor-backed daemon scans.',
-    );
-  }
+  const runtimeOptions = options as
+    | (ContextGraphChainScanOptions & { mode?: string })
+    | undefined;
+  const mode = runtimeOptions?.mode;
 
   if (fromBlock !== undefined) {
     return {
@@ -85,6 +76,48 @@ function buildPublicContextGraphRegistryScanPlan(
       allowPartialFailure: false,
       seedAtEnd: false,
     };
+  }
+
+  if (runtimeOptions && 'incremental' in runtimeOptions && runtimeOptions.incremental === true) {
+    return {
+      mode: 'incremental',
+      resumeFromWatermark: true,
+      persistProgress: true,
+      allowPartialFailure: true,
+      seedAtEnd: false,
+      pageBudget: normalizePageBudget(runtimeOptions.pageBudget),
+    };
+  }
+
+  if (
+    runtimeOptions &&
+    'seedIncrementalWatermark' in runtimeOptions &&
+    runtimeOptions.seedIncrementalWatermark === true
+  ) {
+    if (runtimeOptions.resumeFromCursor === true) {
+      return {
+        mode: 'seedFromCursor',
+        resumeFromWatermark: true,
+        persistProgress: true,
+        allowPartialFailure: true,
+        seedAtEnd: true,
+        pageBudget: normalizePageBudget(runtimeOptions.pageBudget),
+      };
+    }
+    return {
+      mode: 'seedFull',
+      resumeFromWatermark: false,
+      persistProgress: true,
+      allowPartialFailure: true,
+      seedAtEnd: true,
+    };
+  }
+
+  if (mode !== undefined && mode !== 'listAll') {
+    throw new Error(
+      'listContextGraphsFromChain accepts only listAll or legacy boolean scan options; ' +
+      'use scanContextGraphRegistryPages for cursor-backed daemon scans.',
+    );
   }
 
   return {
@@ -304,12 +337,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     );
     if (start > head) {
       if (scanPlan.seedAtEnd) {
-        yield {
-          contextGraphs: [],
-          ack: async () => {
-            await this.contextGraphRegistryScanCursor.saveWatermark(registryAddress, head + 1);
-          },
-        };
+        await this.contextGraphRegistryScanCursor.saveWatermark(registryAddress, head + 1);
       }
       return;
     }
@@ -392,15 +420,6 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
       };
       const scannedPages = Math.floor((hi - start) / pageSize) + 1;
       if (scanPlan.pageBudget !== undefined && scannedPages >= scanPlan.pageBudget && hi < head) return;
-    }
-
-    if (scanPlan.seedAtEnd) {
-      yield {
-        contextGraphs: [],
-        ack: async () => {
-          await this.contextGraphRegistryScanCursor.saveWatermark(registryAddress, head + 1);
-        },
-      };
     }
   }
 

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -114,7 +114,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     const registry = this.contracts.contextGraphNameRegistry;
     if (!registry) return false;
     const registryAddress = (await registry.getAddress()).toLowerCase();
-    return (await this.loadContextGraphRegistryScanWatermark(registryAddress)) != null;
+    return (await this.contextGraphRegistryScanCursor.loadWatermark(registryAddress)) != null;
   }
 
   async listContextGraphsFromChain(
@@ -142,8 +142,8 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
           ? Math.floor(options?.pageBudget ?? 0)
           : undefined,
     };
-    const persistedWatermark = scanPlan.resumeFromWatermark
-      ? await this.loadContextGraphRegistryScanWatermark(registryAddress)
+    const persistedWatermark = (scanPlan.resumeFromWatermark || scanPlan.seedAtEnd)
+      ? await this.contextGraphRegistryScanCursor.loadWatermark(registryAddress)
       : undefined;
     const canResumeFromWatermark = scanPlan.resumeFromWatermark && persistedWatermark !== undefined;
     const scan =
@@ -164,7 +164,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     );
     if (start > head) {
       if (scanPlan.seedAtEnd) {
-        await this.saveContextGraphRegistryScanWatermark(registryAddress, head + 1);
+        await this.contextGraphRegistryScanCursor.saveWatermark(registryAddress, head + 1);
       }
       return [];
     }
@@ -220,7 +220,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
         results.push(...pageResults);
         scannedAnyPage = true;
         if (scanPlan.persistProgress) {
-          await this.saveContextGraphRegistryScanWatermark(registryAddress, hi + 1);
+          await this.contextGraphRegistryScanCursor.saveWatermark(registryAddress, hi + 1);
         }
         const scannedPages = Math.floor((hi - start) / pageSize) + 1;
         if (scanPlan.pageBudget !== undefined && scannedPages >= scanPlan.pageBudget && hi < head) return results;
@@ -244,7 +244,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     }
 
     if (scanPlan.seedAtEnd) {
-      await this.saveContextGraphRegistryScanWatermark(registryAddress, head + 1);
+      await this.contextGraphRegistryScanCursor.saveWatermark(registryAddress, head + 1);
     }
 
     return results;

--- a/packages/chain/src/evm-adapter-types.ts
+++ b/packages/chain/src/evm-adapter-types.ts
@@ -6,7 +6,7 @@
  * evm-adapter.ts. Bodies are a 1:1 move from the original module.
  */
 import { Contract } from 'ethers';
-import type { ApprovalPolicy } from './chain-adapter.js';
+import type { ApprovalPolicy, ContextGraphRegistryScanCursorStore } from './chain-adapter.js';
 
 export interface EVMAdapterBaseConfig {
   rpcUrl: string;
@@ -75,6 +75,13 @@ export interface EVMAdapterBaseConfig {
    * non-finite or `< 1` value falls back to the default.
    */
   cgRegistryScanPageSize?: number;
+  /**
+   * Optional durable cursor for daemon ContextGraphNameRegistry discovery scans.
+   * The adapter still keeps an in-memory mirror; this store lets process
+   * restarts resume from the last successfully covered prefix instead of
+   * repeating a historical `eth_getLogs` walk.
+   */
+  contextGraphRegistryScanCursorStore?: ContextGraphRegistryScanCursorStore;
   /**
    * Funding-aware publish wallet selection: minimum NATIVE gas balance (wei) an
    * operational wallet must hold to be PREFERRED when selecting the publish

--- a/packages/chain/src/mock-adapter.ts
+++ b/packages/chain/src/mock-adapter.ts
@@ -481,6 +481,12 @@ export class MockChainAdapter implements ChainAdapter {
     return [];
   }
 
+  async *scanContextGraphRegistryPages(
+    _options: import('./chain-adapter.js').ContextGraphRegistryScanOptions,
+  ): AsyncIterable<import('./chain-adapter.js').ContextGraphRegistryScanPage> {
+    return;
+  }
+
   async hasContextGraphRegistryScanWatermark(): Promise<boolean> {
     return false;
   }

--- a/packages/chain/test/context-graph-registry-scan.unit.test.ts
+++ b/packages/chain/test/context-graph-registry-scan.unit.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { EVMChainAdapter, type EVMAdapterConfig } from '../src/evm-adapter.js';
-import { ContextGraphChainScanPartialError } from '../src/chain-adapter.js';
+import { ContextGraphChainScanPartialError, type ContextGraphOnChain, type ContextGraphRegistryScanOptions } from '../src/chain-adapter.js';
 import {
   CG_REGISTRY_MAX_SCAN_PAGES,
   CG_REGISTRY_REORG_BUFFER_BLOCKS,
@@ -59,7 +59,6 @@ function seam<A extends unknown[], R>(initialImpl: (...args: A) => R) {
 const DEPLOYER_PK = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
 const ADMIN_PK = '0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a';
 const REGISTRY = '0x3333333333333333333333333333333333333333';
-const commitRegistryScanPage = async () => {};
 
 class MemoryRegistryScanCursorStore {
   readonly values = new Map<string, number>();
@@ -136,6 +135,18 @@ function makeAdapter(registry: any, head = 0, config: Partial<EVMAdapterConfig> 
   return { adapter, provider };
 }
 
+async function collectRegistryScan(
+  adapter: EVMChainAdapter,
+  options: ContextGraphRegistryScanOptions,
+): Promise<ContextGraphOnChain[]> {
+  const results: ContextGraphOnChain[] = [];
+  for await (const page of adapter.scanContextGraphRegistryPages(options)) {
+    results.push(...page.contextGraphs);
+    await page.ack();
+  }
+  return results;
+}
+
 describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
   it('anchors at the registry deploy block and paginates with the 2,000-block default', async () => {
     const deployBlock = 1_500;
@@ -181,9 +192,8 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     });
     registry.queryFilter.queueOnce({ type: 'throw', error: new Error('range too wide') });
 
-    const partial = await adapter.listContextGraphsFromChain(undefined, {
+    const partial = await collectRegistryScan(adapter, {
       mode: 'incremental',
-      commitPage: commitRegistryScanPage,
     }).catch((err) => err);
 
     expect(partial).toBeInstanceOf(ContextGraphChainScanPartialError);
@@ -195,9 +205,8 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
 
     registry.queryFilter.reset();
     registry.queryFilter.setImpl(async () => []);
-    await adapter.listContextGraphsFromChain(undefined, {
+    await collectRegistryScan(adapter, {
       mode: 'incremental',
-      commitPage: commitRegistryScanPage,
     });
 
     expect(registry.queryFilter.calls[0][1]).toBe(1_950);
@@ -216,9 +225,8 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     });
     registry.queryFilter.queueOnce({ type: 'throw', error: new Error('range too wide') });
 
-    const partial = await adapter.listContextGraphsFromChain(undefined, {
+    const partial = await collectRegistryScan(adapter, {
       mode: 'seedFull',
-      commitPage: commitRegistryScanPage,
     }).catch((err) => err);
 
     expect(partial).toBeInstanceOf(ContextGraphChainScanPartialError);
@@ -256,9 +264,8 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
       value: Promise.resolve([{ topics: [], data: '0xbad', blockNumber: 2_000 }]),
     });
 
-    const partial = await adapter.listContextGraphsFromChain(undefined, {
+    const partial = await collectRegistryScan(adapter, {
       mode: 'incremental',
-      commitPage: commitRegistryScanPage,
     }).catch((err) => err);
 
     expect(partial).toBeInstanceOf(ContextGraphChainScanPartialError);
@@ -287,6 +294,19 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     expect((adapter as any).contextGraphRegistryScanCursor.getCachedWatermark(REGISTRY)).toBeUndefined();
   });
 
+  it('rejects cursor scan options on the public list method instead of silently list-scanning', async () => {
+    const registry = makeRegistry();
+    const { adapter } = makeAdapter(registry, 2_100);
+
+    await expect(adapter.listContextGraphsFromChain(undefined, {
+      incremental: true,
+    })).rejects.toThrow('scanContextGraphRegistryPages');
+    await expect(adapter.listContextGraphsFromChain(undefined, {
+      mode: 'incremental',
+    })).rejects.toThrow('scanContextGraphRegistryPages');
+    expect(registry.queryFilter.calls).toEqual([]);
+  });
+
   it('can seed the incremental watermark from an explicit successful full scan', async () => {
     const historicalGraphBlock = 10_000;
     const head = 20_000;
@@ -301,9 +321,8 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
 
     await expect(adapter.hasContextGraphRegistryScanWatermark()).resolves.toBe(false);
 
-    const seeded = await adapter.listContextGraphsFromChain(undefined, {
+    const seeded = await collectRegistryScan(adapter, {
       mode: 'seedFull',
-      commitPage: commitRegistryScanPage,
     });
 
     expect(seeded.map((cg) => cg.blockNumber)).toEqual([historicalGraphBlock]);
@@ -315,9 +334,8 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     });
     registry.queryFilter.clear();
 
-    await adapter.listContextGraphsFromChain(undefined, {
+    await collectRegistryScan(adapter, {
       mode: 'incremental',
-      commitPage: commitRegistryScanPage,
     });
 
     expect(provider.getCode.calls).toEqual([]);
@@ -335,9 +353,8 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     });
     registry.queryFilter.setImpl(async () => []);
 
-    await adapter.listContextGraphsFromChain(undefined, {
+    await collectRegistryScan(adapter, {
       mode: 'seedFromCursor',
-      commitPage: commitRegistryScanPage,
       pageBudget: 2,
     });
 
@@ -358,9 +375,8 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     restartedRegistry.queryFilter.setImpl(async () => []);
 
     await expect(restarted.hasContextGraphRegistryScanWatermark()).resolves.toBe(true);
-    await restarted.listContextGraphsFromChain(undefined, {
+    await collectRegistryScan(restarted, {
       mode: 'incremental',
-      commitPage: commitRegistryScanPage,
       pageBudget: 1,
     });
 
@@ -381,15 +397,16 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
       contextGraphRegistryScanCursorStore: store,
     });
 
-    await expect(adapter.listContextGraphsFromChain(undefined, {
+    const iterator = adapter.scanContextGraphRegistryPages({
       mode: 'seedFromCursor',
-      commitPage: async () => {
-        throw new Error('commit failed');
-      },
       pageBudget: 1,
-    })).rejects.toThrow('commit failed');
+    })[Symbol.asyncIterator]();
+    const first = await iterator.next();
+    expect(first.done).toBe(false);
+    expect(first.value.contextGraphs).toHaveLength(1);
     expect(store.saves).toEqual([]);
     expect((adapter as any).contextGraphRegistryScanCursor.getCachedWatermark(REGISTRY)).toBeUndefined();
+    await iterator.return?.();
 
     const restartedRegistry = makeRegistry();
     const { adapter: restarted } = makeAdapter(restartedRegistry, 2_100, {
@@ -398,9 +415,8 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     });
     restartedRegistry.queryFilter.setImpl(async () => []);
 
-    await restarted.listContextGraphsFromChain(undefined, {
+    await collectRegistryScan(restarted, {
       mode: 'seedFromCursor',
-      commitPage: commitRegistryScanPage,
       pageBudget: 1,
     });
 
@@ -425,9 +441,8 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
       });
       registry.queryFilter.setImpl(async () => []);
 
-      await adapter.listContextGraphsFromChain(undefined, {
+      await collectRegistryScan(adapter, {
         mode: 'seedFromCursor',
-        commitPage: commitRegistryScanPage,
         pageBudget: 1,
       });
 
@@ -456,9 +471,8 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
       });
       registry.queryFilter.setImpl(async () => []);
 
-      await adapter.listContextGraphsFromChain(undefined, {
+      await collectRegistryScan(adapter, {
         mode: 'seedFull',
-        commitPage: commitRegistryScanPage,
       });
 
       expect((adapter as any).contextGraphRegistryScanCursor.getCachedWatermark(REGISTRY)).toBe(2_101);
@@ -467,9 +481,8 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
       });
       registry.queryFilter.clear();
 
-      await adapter.listContextGraphsFromChain(undefined, {
+      await collectRegistryScan(adapter, {
         mode: 'incremental',
-        commitPage: commitRegistryScanPage,
       });
 
       expect(provider.getCode.calls).toEqual([]);
@@ -499,9 +512,8 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     });
     registry.queryFilter.setImpl(async () => []);
 
-    await adapter.listContextGraphsFromChain(undefined, {
+    await collectRegistryScan(adapter, {
       mode: 'seedFromCursor',
-      commitPage: commitRegistryScanPage,
       pageBudget: 1,
     });
 
@@ -531,9 +543,8 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
       contextGraphRegistryScanCursorStore: store,
     });
 
-    const results = await adapter.listContextGraphsFromChain(undefined, {
+    const results = await collectRegistryScan(adapter, {
       mode: 'seedFull',
-      commitPage: commitRegistryScanPage,
     });
 
     expect(results.map((cg) => cg.blockNumber)).toEqual([10]);
@@ -554,9 +565,8 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     });
     seedRegistry.queryFilter.setImpl(async () => []);
 
-    await seedAdapter.listContextGraphsFromChain(undefined, {
+    await collectRegistryScan(seedAdapter, {
       mode: 'seedFromCursor',
-      commitPage: commitRegistryScanPage,
       pageBudget: 1,
     });
 
@@ -579,9 +589,8 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     const { adapter } = makeAdapter(registry, 4_000);
     registry.queryFilter.setImpl(async () => []);
 
-    await adapter.listContextGraphsFromChain(undefined, {
+    await collectRegistryScan(adapter, {
       mode: 'seedFull',
-      commitPage: commitRegistryScanPage,
     });
     await expect(adapter.hasContextGraphRegistryScanWatermark()).resolves.toBe(true);
 
@@ -598,9 +607,8 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     });
     registry.queryFilter.setImpl(async () => []);
 
-    await adapter.listContextGraphsFromChain(undefined, {
+    await collectRegistryScan(adapter, {
       mode: 'seedFull',
-      commitPage: commitRegistryScanPage,
     });
     await expect(adapter.hasContextGraphRegistryScanWatermark()).resolves.toBe(true);
 
@@ -646,9 +654,8 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     registry.queryFilter.setImpl(async () => []);
     await (adapter as any).contextGraphRegistryScanCursor.saveWatermark(REGISTRY, 2_050);
 
-    await adapter.listContextGraphsFromChain(undefined, {
+    await collectRegistryScan(adapter, {
       mode: 'incremental',
-      commitPage: commitRegistryScanPage,
     });
 
     expect(provider.getCode.calls).toEqual([]);
@@ -697,9 +704,8 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     const defaultBlockBudget = CG_REGISTRY_MAX_SCAN_PAGES * defaultPageSize;
     const { adapter } = makeAdapter(registry, defaultBlockBudget);
 
-    await expect(adapter.listContextGraphsFromChain(undefined, {
+    await expect(collectRegistryScan(adapter, {
       mode: 'incremental',
-      commitPage: commitRegistryScanPage,
     })).rejects.toThrow(
       new RegExp(`incremental ContextGraphNameRegistry scan would need.*budget ${CG_REGISTRY_MAX_SCAN_PAGES} pages`),
     );

--- a/packages/chain/test/context-graph-registry-scan.unit.test.ts
+++ b/packages/chain/test/context-graph-registry-scan.unit.test.ts
@@ -294,17 +294,103 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     expect((adapter as any).contextGraphRegistryScanCursor.getCachedWatermark(REGISTRY)).toBeUndefined();
   });
 
-  it('rejects cursor scan options on the public list method instead of silently list-scanning', async () => {
+  it('keeps legacy public incremental option as a cursor-backed compatibility wrapper', async () => {
+    const store = new MemoryRegistryScanCursorStore();
+    const registry = makeRegistry();
+    const { adapter, provider } = makeAdapter(registry, 2_100, {
+      cgRegistryScanPageSize: 1_000,
+      contextGraphRegistryScanCursorStore: store,
+    });
+    registry.queryFilter.setImpl(async () => []);
+
+    await adapter.listContextGraphsFromChain(undefined, {
+      incremental: true,
+      pageBudget: 1,
+    });
+
+    expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
+      [0, 999],
+    ]);
+    expect(store.saves.map((s) => s.nextBlock)).toEqual([1_000]);
+
+    provider.getCode = seam(async () => {
+      throw new Error('deploy block probing should not run with the legacy incremental cursor');
+    });
+    registry.queryFilter.clear();
+
+    await adapter.listContextGraphsFromChain(undefined, {
+      incremental: true,
+      pageBudget: 1,
+    });
+
+    expect(provider.getCode.calls).toEqual([]);
+    expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
+      [1_000 - CG_REGISTRY_REORG_BUFFER_BLOCKS, 1_949],
+    ]);
+    expect(store.saves.map((s) => s.nextBlock)).toEqual([1_000, 1_950]);
+  });
+
+  it('keeps legacy public seed option as a full-scan watermark compatibility wrapper', async () => {
+    const store = new MemoryRegistryScanCursorStore();
+    const historicalGraphBlock = 10;
+    const registry = makeRegistry({
+      queryFilter: seam(async (_filter: unknown, lo: number, hi: number) =>
+        lo <= historicalGraphBlock && historicalGraphBlock <= hi
+          ? [{ topics: [], data: '0x01', blockNumber: historicalGraphBlock }]
+          : [],
+      ),
+    });
+    const { adapter } = makeAdapter(registry, 2_100, {
+      cgRegistryScanPageSize: 1_000,
+      contextGraphRegistryScanCursorStore: store,
+    });
+
+    const seeded = await adapter.listContextGraphsFromChain(undefined, {
+      seedIncrementalWatermark: true,
+    });
+
+    expect(seeded.map((cg) => cg.blockNumber)).toEqual([historicalGraphBlock]);
+    expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
+      [0, 999],
+      [1_000, 1_999],
+      [2_000, 2_100],
+    ]);
+    expect(store.saves.map((s) => s.nextBlock)).toEqual([1_000, 2_000, 2_101]);
+    expect((adapter as any).contextGraphRegistryScanCursor.getCachedWatermark(REGISTRY)).toBe(2_101);
+  });
+
+  it('rejects explicit daemon scan modes on the public list method', async () => {
     const registry = makeRegistry();
     const { adapter } = makeAdapter(registry, 2_100);
 
     await expect(adapter.listContextGraphsFromChain(undefined, {
-      incremental: true,
-    })).rejects.toThrow('scanContextGraphRegistryPages');
-    await expect(adapter.listContextGraphsFromChain(undefined, {
       mode: 'incremental',
-    })).rejects.toThrow('scanContextGraphRegistryPages');
+    } as any)).rejects.toThrow('scanContextGraphRegistryPages');
     expect(registry.queryFilter.calls).toEqual([]);
+  });
+
+  it('does not emit a synthetic empty terminal page for seed scans', async () => {
+    const registry = makeRegistry();
+    const { adapter } = makeAdapter(registry, 2_100, {
+      cgRegistryScanPageSize: 1_000,
+    });
+    registry.queryFilter.setImpl(async () => []);
+
+    const pageSizes: number[] = [];
+    for await (const page of adapter.scanContextGraphRegistryPages({
+      mode: 'seedFull',
+    })) {
+      pageSizes.push(page.contextGraphs.length);
+      await page.ack();
+    }
+
+    expect(pageSizes).toEqual([0, 0, 0]);
+    expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
+      [0, 999],
+      [1_000, 1_999],
+      [2_000, 2_100],
+    ]);
+    expect((adapter as any).contextGraphRegistryScanCursor.getCachedWatermark(REGISTRY)).toBe(2_101);
   });
 
   it('can seed the incremental watermark from an explicit successful full scan', async () => {

--- a/packages/chain/test/context-graph-registry-scan.unit.test.ts
+++ b/packages/chain/test/context-graph-registry-scan.unit.test.ts
@@ -60,6 +60,28 @@ const DEPLOYER_PK = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf
 const ADMIN_PK = '0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a';
 const REGISTRY = '0x3333333333333333333333333333333333333333';
 
+class MemoryRegistryScanCursorStore {
+  readonly values = new Map<string, number>();
+  readonly loads: string[] = [];
+  readonly saves: Array<{ key: string; nextBlock: number }> = [];
+
+  async load(key: { chainId: string; deploymentId: string; registryAddress: string }): Promise<number | undefined> {
+    const encoded = this.key(key);
+    this.loads.push(encoded);
+    return this.values.get(encoded);
+  }
+
+  async save(key: { chainId: string; deploymentId: string; registryAddress: string }, nextBlock: number): Promise<void> {
+    const encoded = this.key(key);
+    this.saves.push({ key: encoded, nextBlock });
+    this.values.set(encoded, nextBlock);
+  }
+
+  private key(key: { chainId: string; deploymentId: string; registryAddress: string }): string {
+    return `${key.chainId}|${key.deploymentId}|${key.registryAddress.toLowerCase()}`;
+  }
+}
+
 function minimalConfig(overrides: Partial<EVMAdapterConfig> = {}): EVMAdapterConfig {
   return {
     rpcUrl: 'http://127.0.0.1:59998',
@@ -175,6 +197,30 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     expect(registry.queryFilter.calls[0][2]).toBe(2_100);
   });
 
+  it('surfaces partial-prefix results for failing seeded daemon scans', async () => {
+    const store = new MemoryRegistryScanCursorStore();
+    const registry = makeRegistry();
+    const { adapter } = makeAdapter(registry, 4_999, {
+      contextGraphRegistryScanCursorStore: store,
+    });
+    registry.queryFilter.queueOnce({
+      type: 'return',
+      value: Promise.resolve([{ topics: [], data: '0x01', blockNumber: 10 }]),
+    });
+    registry.queryFilter.queueOnce({ type: 'throw', error: new Error('range too wide') });
+
+    const partial = await adapter.listContextGraphsFromChain(undefined, {
+      seedIncrementalWatermark: true,
+    }).catch((err) => err);
+
+    expect(partial).toBeInstanceOf(ContextGraphChainScanPartialError);
+    expect(partial.partialResults.map((cg: { blockNumber: number }) => cg.blockNumber)).toEqual([10]);
+    expect(partial.scannedToBlock).toBe(1_999);
+    expect(partial.failedFromBlock).toBe(2_000);
+    expect(partial.failedToBlock).toBe(3_999);
+    expect(store.saves.map((s) => s.nextBlock)).toEqual([2_000]);
+  });
+
   it('does not advance the incremental watermark when parsing a later page fails', async () => {
     const registry = makeRegistry({
       interface: {
@@ -260,6 +306,106 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     expect(provider.getCode.calls).toEqual([]);
     expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
       [head + 1 - CG_REGISTRY_REORG_BUFFER_BLOCKS, head],
+    ]);
+  });
+
+  it('persists daemon scan progress and resumes after restart with the reorg buffer', async () => {
+    const store = new MemoryRegistryScanCursorStore();
+    const registry = makeRegistry();
+    const { adapter } = makeAdapter(registry, 5_000, {
+      cgRegistryScanPageSize: 1_000,
+      contextGraphRegistryScanCursorStore: store,
+    });
+    registry.queryFilter.setImpl(async () => []);
+
+    await adapter.listContextGraphsFromChain(undefined, {
+      seedIncrementalWatermark: true,
+      pageBudget: 2,
+    });
+
+    expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
+      [0, 999],
+      [1_000, 1_999],
+    ]);
+    expect(store.saves.map((s) => s.nextBlock)).toEqual([1_000, 2_000]);
+
+    const restartedRegistry = makeRegistry();
+    const { adapter: restarted, provider } = makeAdapter(restartedRegistry, 5_000, {
+      cgRegistryScanPageSize: 1_000,
+      contextGraphRegistryScanCursorStore: store,
+    });
+    provider.getCode = seam(async () => {
+      throw new Error('deploy block probing should not run with persisted cursor');
+    });
+    restartedRegistry.queryFilter.setImpl(async () => []);
+
+    await expect(restarted.hasContextGraphRegistryScanWatermark()).resolves.toBe(true);
+    await restarted.listContextGraphsFromChain(undefined, {
+      incremental: true,
+      pageBudget: 1,
+    });
+
+    expect(provider.getCode.calls).toEqual([]);
+    expect(restartedRegistry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
+      [2_000 - CG_REGISTRY_REORG_BUFFER_BLOCKS, 2_949],
+    ]);
+    expect(store.saves.map((s) => s.nextBlock)).toEqual([1_000, 2_000, 2_950]);
+  });
+
+  it('continues periodic seeded daemon scans from the persisted cursor instead of restarting at deploy', async () => {
+    const store = new MemoryRegistryScanCursorStore();
+    await store.save({
+      chainId: 'evm:31337',
+      deploymentId: 'evm:31337:hub=0x0000000000000000000000000000000000000001',
+      registryAddress: REGISTRY,
+    }, 3_000);
+
+    const registry = makeRegistry();
+    const { adapter, provider } = makeAdapter(registry, 5_000, {
+      cgRegistryScanPageSize: 1_000,
+      contextGraphRegistryScanCursorStore: store,
+    });
+    provider.getCode = seam(async () => {
+      throw new Error('deploy block probing should not run with persisted cursor');
+    });
+    registry.queryFilter.setImpl(async () => []);
+
+    await adapter.listContextGraphsFromChain(undefined, {
+      seedIncrementalWatermark: true,
+      pageBudget: 1,
+    });
+
+    expect(provider.getCode.calls).toEqual([]);
+    expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
+      [3_000 - CG_REGISTRY_REORG_BUFFER_BLOCKS, 3_949],
+    ]);
+    expect(store.saves.map((s) => s.nextBlock)).toEqual([3_000, 3_950]);
+  });
+
+  it('keeps public list-all scans complete even when a daemon cursor is persisted', async () => {
+    const store = new MemoryRegistryScanCursorStore();
+    const seedRegistry = makeRegistry();
+    const { adapter: seedAdapter } = makeAdapter(seedRegistry, 2_100, {
+      contextGraphRegistryScanCursorStore: store,
+    });
+    seedRegistry.queryFilter.setImpl(async () => []);
+
+    await seedAdapter.listContextGraphsFromChain(undefined, {
+      seedIncrementalWatermark: true,
+      pageBudget: 1,
+    });
+
+    const publicRegistry = makeRegistry();
+    const { adapter: publicAdapter } = makeAdapter(publicRegistry, 2_100, {
+      contextGraphRegistryScanCursorStore: store,
+    });
+    publicRegistry.queryFilter.setImpl(async () => []);
+
+    await publicAdapter.listContextGraphsFromChain();
+
+    expect(publicRegistry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
+      [0, 1_999],
+      [2_000, 2_100],
     ]);
   });
 

--- a/packages/chain/test/context-graph-registry-scan.unit.test.ts
+++ b/packages/chain/test/context-graph-registry-scan.unit.test.ts
@@ -320,6 +320,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
 
     await adapter.listContextGraphsFromChain(undefined, {
       seedIncrementalWatermark: true,
+      resumeFromCursor: true,
       pageBudget: 2,
     });
 
@@ -372,6 +373,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
 
     await adapter.listContextGraphsFromChain(undefined, {
       seedIncrementalWatermark: true,
+      resumeFromCursor: true,
       pageBudget: 1,
     });
 
@@ -380,6 +382,38 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
       [3_000 - CG_REGISTRY_REORG_BUFFER_BLOCKS, 3_949],
     ]);
     expect(store.saves.map((s) => s.nextBlock)).toEqual([3_000, 3_950]);
+  });
+
+  it('keeps plain seeded scans full even when a daemon cursor is persisted', async () => {
+    const store = new MemoryRegistryScanCursorStore();
+    await store.save({
+      chainId: 'evm:31337',
+      deploymentId: 'evm:31337:hub=0x0000000000000000000000000000000000000001',
+      registryAddress: REGISTRY,
+    }, 3_000);
+    const registry = makeRegistry({
+      queryFilter: seam(async (_filter: unknown, lo: number, hi: number) =>
+        lo <= 10 && 10 <= hi
+          ? [{ topics: [], data: '0x01', blockNumber: 10 }]
+          : [],
+      ),
+    });
+    const { adapter } = makeAdapter(registry, 3_500, {
+      cgRegistryScanPageSize: 1_000,
+      contextGraphRegistryScanCursorStore: store,
+    });
+
+    const results = await adapter.listContextGraphsFromChain(undefined, {
+      seedIncrementalWatermark: true,
+    });
+
+    expect(results.map((cg) => cg.blockNumber)).toEqual([10]);
+    expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
+      [0, 999],
+      [1_000, 1_999],
+      [2_000, 2_999],
+      [3_000, 3_500],
+    ]);
   });
 
   it('keeps public list-all scans complete even when a daemon cursor is persisted', async () => {
@@ -392,6 +426,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
 
     await seedAdapter.listContextGraphsFromChain(undefined, {
       seedIncrementalWatermark: true,
+      resumeFromCursor: true,
       pageBudget: 1,
     });
 

--- a/packages/chain/test/context-graph-registry-scan.unit.test.ts
+++ b/packages/chain/test/context-graph-registry-scan.unit.test.ts
@@ -187,7 +187,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     expect(partial.scannedToBlock).toBe(1_999);
     expect(partial.failedFromBlock).toBe(2_000);
     expect(partial.failedToBlock).toBe(3_999);
-    expect((adapter as any).contextGraphRegistryScanWatermarks.get(REGISTRY.toLowerCase())).toBe(2_000);
+    expect((adapter as any).contextGraphRegistryScanCursor.getCachedWatermark(REGISTRY)).toBe(2_000);
 
     registry.queryFilter.reset();
     registry.queryFilter.setImpl(async () => []);
@@ -254,7 +254,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     expect(partial.partialResults).toHaveLength(1);
     expect(partial.failedFromBlock).toBe(2_000);
     expect(partial.failedToBlock).toBe(2_100);
-    expect((adapter as any).contextGraphRegistryScanWatermarks.get(REGISTRY.toLowerCase())).toBe(2_000);
+    expect((adapter as any).contextGraphRegistryScanCursor.getCachedWatermark(REGISTRY)).toBe(2_000);
   });
 
   it('preserves public list-all semantics unless the caller opts into incremental scans', async () => {
@@ -273,7 +273,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
       [0, 1_999],
       [2_000, 2_100],
     ]);
-    expect((adapter as any).contextGraphRegistryScanWatermarks.get(REGISTRY.toLowerCase())).toBeUndefined();
+    expect((adapter as any).contextGraphRegistryScanCursor.getCachedWatermark(REGISTRY)).toBeUndefined();
   });
 
   it('can seed the incremental watermark from an explicit successful full scan', async () => {
@@ -293,7 +293,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     const seeded = await adapter.listContextGraphsFromChain(undefined, { seedIncrementalWatermark: true });
 
     expect(seeded.map((cg) => cg.blockNumber)).toEqual([historicalGraphBlock]);
-    expect((adapter as any).contextGraphRegistryScanWatermarks.get(REGISTRY.toLowerCase())).toBe(head + 1);
+    expect((adapter as any).contextGraphRegistryScanCursor.getCachedWatermark(REGISTRY)).toBe(head + 1);
     await expect(adapter.hasContextGraphRegistryScanWatermark()).resolves.toBe(true);
 
     provider.getCode = seam(async () => {
@@ -353,7 +353,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     expect(store.saves.map((s) => s.nextBlock)).toEqual([1_000, 2_000, 2_950]);
   });
 
-  it('continues periodic seeded daemon scans from the persisted cursor instead of restarting at deploy', async () => {
+  it('continues cursor-resumed daemon catch-up scans from the persisted cursor', async () => {
     const store = new MemoryRegistryScanCursorStore();
     await store.save({
       chainId: 'evm:31337',
@@ -384,7 +384,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     expect(store.saves.map((s) => s.nextBlock)).toEqual([3_000, 3_950]);
   });
 
-  it('keeps plain seeded scans full even when a daemon cursor is persisted', async () => {
+  it('keeps periodic full-recovery seeded scans full even when a daemon cursor is persisted', async () => {
     const store = new MemoryRegistryScanCursorStore();
     await store.save({
       chainId: 'evm:31337',
@@ -414,6 +414,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
       [2_000, 2_999],
       [3_000, 3_500],
     ]);
+    expect(store.saves.map((s) => s.nextBlock)).toEqual([3_000, 3_501]);
   });
 
   it('keeps public list-all scans complete even when a daemon cursor is persisted', async () => {
@@ -465,7 +466,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     registry.queryFilter.queueOnce({ type: 'throw', error: new Error('range too wide') });
 
     await expect(adapter.listContextGraphsFromChain()).rejects.toThrow('range too wide');
-    expect((adapter as any).contextGraphRegistryScanWatermarks.get(REGISTRY.toLowerCase())).toBeUndefined();
+    expect((adapter as any).contextGraphRegistryScanCursor.getCachedWatermark(REGISTRY)).toBeUndefined();
   });
 
   it('does not require deploy-block probing when fromBlock is explicit', async () => {
@@ -491,7 +492,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
       throw new Error('eth_getCode should not be called');
     });
     registry.queryFilter.setImpl(async () => []);
-    (adapter as any).contextGraphRegistryScanWatermarks.set(REGISTRY.toLowerCase(), 2_050);
+    await (adapter as any).contextGraphRegistryScanCursor.saveWatermark(REGISTRY, 2_050);
 
     await adapter.listContextGraphsFromChain(undefined, { incremental: true });
 

--- a/packages/chain/test/context-graph-registry-scan.unit.test.ts
+++ b/packages/chain/test/context-graph-registry-scan.unit.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { EVMChainAdapter, type EVMAdapterConfig } from '../src/evm-adapter.js';
 import { ContextGraphChainScanPartialError } from '../src/chain-adapter.js';
 import {
@@ -59,6 +59,7 @@ function seam<A extends unknown[], R>(initialImpl: (...args: A) => R) {
 const DEPLOYER_PK = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
 const ADMIN_PK = '0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a';
 const REGISTRY = '0x3333333333333333333333333333333333333333';
+const commitRegistryScanPage = async () => {};
 
 class MemoryRegistryScanCursorStore {
   readonly values = new Map<string, number>();
@@ -180,7 +181,10 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     });
     registry.queryFilter.queueOnce({ type: 'throw', error: new Error('range too wide') });
 
-    const partial = await adapter.listContextGraphsFromChain(undefined, { incremental: true }).catch((err) => err);
+    const partial = await adapter.listContextGraphsFromChain(undefined, {
+      mode: 'incremental',
+      commitPage: commitRegistryScanPage,
+    }).catch((err) => err);
 
     expect(partial).toBeInstanceOf(ContextGraphChainScanPartialError);
     expect(partial.partialResults).toHaveLength(1);
@@ -191,7 +195,10 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
 
     registry.queryFilter.reset();
     registry.queryFilter.setImpl(async () => []);
-    await adapter.listContextGraphsFromChain(undefined, { incremental: true });
+    await adapter.listContextGraphsFromChain(undefined, {
+      mode: 'incremental',
+      commitPage: commitRegistryScanPage,
+    });
 
     expect(registry.queryFilter.calls[0][1]).toBe(1_950);
     expect(registry.queryFilter.calls[0][2]).toBe(2_100);
@@ -210,7 +217,8 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     registry.queryFilter.queueOnce({ type: 'throw', error: new Error('range too wide') });
 
     const partial = await adapter.listContextGraphsFromChain(undefined, {
-      seedIncrementalWatermark: true,
+      mode: 'seedFull',
+      commitPage: commitRegistryScanPage,
     }).catch((err) => err);
 
     expect(partial).toBeInstanceOf(ContextGraphChainScanPartialError);
@@ -248,7 +256,10 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
       value: Promise.resolve([{ topics: [], data: '0xbad', blockNumber: 2_000 }]),
     });
 
-    const partial = await adapter.listContextGraphsFromChain(undefined, { incremental: true }).catch((err) => err);
+    const partial = await adapter.listContextGraphsFromChain(undefined, {
+      mode: 'incremental',
+      commitPage: commitRegistryScanPage,
+    }).catch((err) => err);
 
     expect(partial).toBeInstanceOf(ContextGraphChainScanPartialError);
     expect(partial.partialResults).toHaveLength(1);
@@ -290,7 +301,10 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
 
     await expect(adapter.hasContextGraphRegistryScanWatermark()).resolves.toBe(false);
 
-    const seeded = await adapter.listContextGraphsFromChain(undefined, { seedIncrementalWatermark: true });
+    const seeded = await adapter.listContextGraphsFromChain(undefined, {
+      mode: 'seedFull',
+      commitPage: commitRegistryScanPage,
+    });
 
     expect(seeded.map((cg) => cg.blockNumber)).toEqual([historicalGraphBlock]);
     expect((adapter as any).contextGraphRegistryScanCursor.getCachedWatermark(REGISTRY)).toBe(head + 1);
@@ -301,7 +315,10 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     });
     registry.queryFilter.clear();
 
-    await adapter.listContextGraphsFromChain(undefined, { incremental: true });
+    await adapter.listContextGraphsFromChain(undefined, {
+      mode: 'incremental',
+      commitPage: commitRegistryScanPage,
+    });
 
     expect(provider.getCode.calls).toEqual([]);
     expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
@@ -319,8 +336,8 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     registry.queryFilter.setImpl(async () => []);
 
     await adapter.listContextGraphsFromChain(undefined, {
-      seedIncrementalWatermark: true,
-      resumeFromCursor: true,
+      mode: 'seedFromCursor',
+      commitPage: commitRegistryScanPage,
       pageBudget: 2,
     });
 
@@ -342,7 +359,8 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
 
     await expect(restarted.hasContextGraphRegistryScanWatermark()).resolves.toBe(true);
     await restarted.listContextGraphsFromChain(undefined, {
-      incremental: true,
+      mode: 'incremental',
+      commitPage: commitRegistryScanPage,
       pageBudget: 1,
     });
 
@@ -351,6 +369,116 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
       [2_000 - CG_REGISTRY_REORG_BUFFER_BLOCKS, 2_949],
     ]);
     expect(store.saves.map((s) => s.nextBlock)).toEqual([1_000, 2_000, 2_950]);
+  });
+
+  it('does not advance durable registry cursor until page discoveries are committed', async () => {
+    const store = new MemoryRegistryScanCursorStore();
+    const registry = makeRegistry({
+      queryFilter: seam(async () => [{ topics: [], data: '0x01', blockNumber: 10 }]),
+    });
+    const { adapter } = makeAdapter(registry, 2_100, {
+      cgRegistryScanPageSize: 1_000,
+      contextGraphRegistryScanCursorStore: store,
+    });
+
+    await expect(adapter.listContextGraphsFromChain(undefined, {
+      mode: 'seedFromCursor',
+      commitPage: async () => {
+        throw new Error('commit failed');
+      },
+      pageBudget: 1,
+    })).rejects.toThrow('commit failed');
+    expect(store.saves).toEqual([]);
+    expect((adapter as any).contextGraphRegistryScanCursor.getCachedWatermark(REGISTRY)).toBeUndefined();
+
+    const restartedRegistry = makeRegistry();
+    const { adapter: restarted } = makeAdapter(restartedRegistry, 2_100, {
+      cgRegistryScanPageSize: 1_000,
+      contextGraphRegistryScanCursorStore: store,
+    });
+    restartedRegistry.queryFilter.setImpl(async () => []);
+
+    await restarted.listContextGraphsFromChain(undefined, {
+      mode: 'seedFromCursor',
+      commitPage: commitRegistryScanPage,
+      pageBudget: 1,
+    });
+
+    expect(restartedRegistry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
+      [0, 999],
+    ]);
+    expect(store.saves.map((s) => s.nextBlock)).toEqual([1_000]);
+  });
+
+  it('falls back to deploy-block scanning when durable cursor load fails', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const store = {
+      load: vi.fn(async () => {
+        throw new Error('cursor load failed');
+      }),
+      save: vi.fn(async () => {}),
+    };
+    try {
+      const registry = makeRegistry();
+      const { adapter } = makeAdapter(registry, 2_100, {
+        contextGraphRegistryScanCursorStore: store,
+      });
+      registry.queryFilter.setImpl(async () => []);
+
+      await adapter.listContextGraphsFromChain(undefined, {
+        mode: 'seedFromCursor',
+        commitPage: commitRegistryScanPage,
+        pageBudget: 1,
+      });
+
+      expect(store.load).toHaveBeenCalledTimes(1);
+      expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
+        [0, 1_999],
+      ]);
+      expect(store.save).toHaveBeenCalledWith(expect.any(Object), 2_000);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('keeps save failures non-fatal and advances the process-local registry cursor', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const store = {
+      load: vi.fn(async () => undefined),
+      save: vi.fn(async () => {
+        throw new Error('cursor save failed');
+      }),
+    };
+    try {
+      const registry = makeRegistry();
+      const { adapter, provider } = makeAdapter(registry, 2_100, {
+        contextGraphRegistryScanCursorStore: store,
+      });
+      registry.queryFilter.setImpl(async () => []);
+
+      await adapter.listContextGraphsFromChain(undefined, {
+        mode: 'seedFull',
+        commitPage: commitRegistryScanPage,
+      });
+
+      expect((adapter as any).contextGraphRegistryScanCursor.getCachedWatermark(REGISTRY)).toBe(2_101);
+      provider.getCode = seam(async () => {
+        throw new Error('deploy block probing should not run with process-local cursor');
+      });
+      registry.queryFilter.clear();
+
+      await adapter.listContextGraphsFromChain(undefined, {
+        mode: 'incremental',
+        commitPage: commitRegistryScanPage,
+      });
+
+      expect(provider.getCode.calls).toEqual([]);
+      expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
+        [2_101 - CG_REGISTRY_REORG_BUFFER_BLOCKS, 2_100],
+      ]);
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it('continues cursor-resumed daemon catch-up scans from the persisted cursor', async () => {
@@ -372,8 +500,8 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     registry.queryFilter.setImpl(async () => []);
 
     await adapter.listContextGraphsFromChain(undefined, {
-      seedIncrementalWatermark: true,
-      resumeFromCursor: true,
+      mode: 'seedFromCursor',
+      commitPage: commitRegistryScanPage,
       pageBudget: 1,
     });
 
@@ -404,7 +532,8 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     });
 
     const results = await adapter.listContextGraphsFromChain(undefined, {
-      seedIncrementalWatermark: true,
+      mode: 'seedFull',
+      commitPage: commitRegistryScanPage,
     });
 
     expect(results.map((cg) => cg.blockNumber)).toEqual([10]);
@@ -426,8 +555,8 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     seedRegistry.queryFilter.setImpl(async () => []);
 
     await seedAdapter.listContextGraphsFromChain(undefined, {
-      seedIncrementalWatermark: true,
-      resumeFromCursor: true,
+      mode: 'seedFromCursor',
+      commitPage: commitRegistryScanPage,
       pageBudget: 1,
     });
 
@@ -445,17 +574,40 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     ]);
   });
 
-  it('reports no registry scan watermark after preflight cache invalidation', async () => {
+  it('reports no registry scan watermark after preflight cache invalidation without a durable store', async () => {
     const registry = makeRegistry();
     const { adapter } = makeAdapter(registry, 4_000);
     registry.queryFilter.setImpl(async () => []);
 
-    await adapter.listContextGraphsFromChain(undefined, { seedIncrementalWatermark: true });
+    await adapter.listContextGraphsFromChain(undefined, {
+      mode: 'seedFull',
+      commitPage: commitRegistryScanPage,
+    });
     await expect(adapter.hasContextGraphRegistryScanWatermark()).resolves.toBe(true);
 
     adapter.invalidatePublishPreflightCache();
 
     await expect(adapter.hasContextGraphRegistryScanWatermark()).resolves.toBe(false);
+  });
+
+  it('preflight cache invalidation clears only the in-memory registry cursor cache', async () => {
+    const store = new MemoryRegistryScanCursorStore();
+    const registry = makeRegistry();
+    const { adapter } = makeAdapter(registry, 4_000, {
+      contextGraphRegistryScanCursorStore: store,
+    });
+    registry.queryFilter.setImpl(async () => []);
+
+    await adapter.listContextGraphsFromChain(undefined, {
+      mode: 'seedFull',
+      commitPage: commitRegistryScanPage,
+    });
+    await expect(adapter.hasContextGraphRegistryScanWatermark()).resolves.toBe(true);
+
+    adapter.invalidatePublishPreflightCache();
+
+    expect((adapter as any).contextGraphRegistryScanCursor.getCachedWatermark(REGISTRY)).toBeUndefined();
+    await expect(adapter.hasContextGraphRegistryScanWatermark()).resolves.toBe(true);
   });
 
   it('rethrows later page failures for public list-all scans', async () => {
@@ -494,7 +646,10 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     registry.queryFilter.setImpl(async () => []);
     await (adapter as any).contextGraphRegistryScanCursor.saveWatermark(REGISTRY, 2_050);
 
-    await adapter.listContextGraphsFromChain(undefined, { incremental: true });
+    await adapter.listContextGraphsFromChain(undefined, {
+      mode: 'incremental',
+      commitPage: commitRegistryScanPage,
+    });
 
     expect(provider.getCode.calls).toEqual([]);
     expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
@@ -542,7 +697,10 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     const defaultBlockBudget = CG_REGISTRY_MAX_SCAN_PAGES * defaultPageSize;
     const { adapter } = makeAdapter(registry, defaultBlockBudget);
 
-    await expect(adapter.listContextGraphsFromChain(undefined, { incremental: true })).rejects.toThrow(
+    await expect(adapter.listContextGraphsFromChain(undefined, {
+      mode: 'incremental',
+      commitPage: commitRegistryScanPage,
+    })).rejects.toThrow(
       new RegExp(`incremental ContextGraphNameRegistry scan would need.*budget ${CG_REGISTRY_MAX_SCAN_PAGES} pages`),
     );
     expect(registry.queryFilter.calls).toEqual([]);

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1362,9 +1362,16 @@ export async function runDaemonInner(
     : undefined;
 
   const dashDb = new DashboardDB({ dataDir: dkgDir() });
-  const chainCursorScope = chainBase?.chainId && chainBase?.hubAddress
-    ? buildEvmDeploymentId({ chainId: chainBase.chainId, hubAddress: chainBase.hubAddress })
-    : 'none:hub=none';
+  const chainCursorScope = chainBase?.type === 'mock'
+    ? (chainBase.chainId ?? 'mock:31337')
+    : chainBase?.hubAddress
+      ? buildEvmDeploymentId({
+          chainId: chainBase.chainId ?? 'evm:31337',
+          hubAddress: chainBase.hubAddress,
+        })
+      : chainBase?.chainId
+        ? `${chainBase.chainId}:hub=none`
+        : 'none:hub=none';
 
   if (role === 'core' && config.core?.allowDegradedRelay === false) {
     const hostInterfaces = Object.values(osModule.networkInterfaces())

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -91,6 +91,8 @@ import {
   SqliteMessageIdempotencyStore,
   SqliteProtocolOutboxStore,
   SqliteSyncCheckpointStore,
+  SqliteChainEventCursorStore,
+  SqliteContextGraphRegistryScanCursorStore,
   SqliteKaNumberStore,
   type MetricsSource,
 } from "@origintrail-official/dkg-node-ui";
@@ -600,14 +602,16 @@ export function mergePreferredRelays(input: {
 }
 
 export const CHAIN_FULL_SCAN_EVERY = 48; // about once per day at the 30-minute cadence
+export const CHAIN_DISCOVERY_SCAN_PAGE_BUDGET = 30;
 
 export function chainDiscoveryScanOptions(input: {
   watermarkSeeded: boolean;
   run?: number;
   fullScanEvery?: number;
+  pageBudget?: number;
 }):
-  | { incremental: true }
-  | { seedIncrementalWatermark: true; throwOnChainScanFailure: true } {
+  | { incremental: true; pageBudget: number }
+  | { seedIncrementalWatermark: true; throwOnChainScanFailure: true; pageBudget: number } {
   const configuredFullScanEvery = input.fullScanEvery;
   let fullScanEvery = CHAIN_FULL_SCAN_EVERY;
   if (
@@ -617,11 +621,19 @@ export function chainDiscoveryScanOptions(input: {
   ) {
     fullScanEvery = Math.floor(configuredFullScanEvery);
   }
+  const configuredPageBudget = input.pageBudget;
+  const pageBudget = (
+    typeof configuredPageBudget === 'number' &&
+    Number.isFinite(configuredPageBudget) &&
+    configuredPageBudget >= 1
+  )
+    ? Math.floor(configuredPageBudget)
+    : CHAIN_DISCOVERY_SCAN_PAGE_BUDGET;
   const run = input.run ?? 0;
   const periodicFullResync = input.watermarkSeeded && run > 0 && run % fullScanEvery === 0;
   return input.watermarkSeeded && !periodicFullResync
-    ? { incremental: true }
-    : { seedIncrementalWatermark: true, throwOnChainScanFailure: true };
+    ? { incremental: true, pageBudget }
+    : { seedIncrementalWatermark: true, throwOnChainScanFailure: true, pageBudget };
 }
 
 export interface PromoteWorkerDaemonLifecycle {
@@ -1308,6 +1320,7 @@ export async function runDaemonInner(
     : undefined;
 
   const dashDb = new DashboardDB({ dataDir: dkgDir() });
+  const chainCursorScope = `${chainBase?.chainId ?? 'none'}:hub=${(chainBase?.hubAddress ?? 'none').toLowerCase()}`;
 
   if (role === 'core' && config.core?.allowDegradedRelay === false) {
     const hostInterfaces = Object.values(osModule.networkInterfaces())
@@ -1357,6 +1370,8 @@ export async function runDaemonInner(
     },
   });
   const syncCheckpointStore = new SqliteSyncCheckpointStore(dashDb);
+  const chainEventCursorStore = new SqliteChainEventCursorStore(dashDb, { scope: chainCursorScope });
+  const contextGraphRegistryScanCursorStore = new SqliteContextGraphRegistryScanCursorStore(dashDb);
 
   // OT-RFC-43 Option-1 deterministic KA identity (B2 allocator core).
   // Durable per-author KA-number sequence backing the off-chain
@@ -1438,6 +1453,8 @@ export async function runDaemonInner(
     randomSamplingTickIntervalMs: config.randomSampling?.tickIntervalMs,
     randomSamplingUseWorkerThread: config.randomSampling?.useWorkerThread,
     syncCheckpointStore,
+    chainEventCursorStore,
+    contextGraphRegistryScanCursorStore,
     contextGraphSubscriptionStore: {
       loadAll: async () => dashDb.listContextGraphSubscriptions().map((row) => ({
         id: row.context_graph_id,
@@ -1929,19 +1946,25 @@ export async function runDaemonInner(
   // then repeat every 30 minutes as a fallback discovery mechanism.
   const CHAIN_SCAN_INTERVAL_MS = 30 * 60 * 1000;
   let chainScanRuns = 0;
+  let chainScanInFlight = false;
   const runChainDiscoveryScan = async () => {
+    if (chainScanInFlight) return;
+    chainScanInFlight = true;
     try {
       const run = chainScanRuns++;
       const found = await agent.discoverContextGraphsFromChain(
         chainDiscoveryScanOptions({
           run,
           watermarkSeeded: await agent.hasContextGraphRegistryScanWatermark(),
+          pageBudget: CHAIN_DISCOVERY_SCAN_PAGE_BUDGET,
         }),
       );
       if (found > 0)
         log(`Chain scan: discovered ${found} new context graph(s)`);
     } catch {
       /* non-critical */
+    } finally {
+      chainScanInFlight = false;
     }
   };
   setTimeout(runChainDiscoveryScan, 15_000);

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -64,6 +64,7 @@ const daemonRequire = createRequire(import.meta.url);
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
 import {
+  buildEvmDeploymentId,
   MockChainAdapter,
   mergeRpcUsageWindows,
   type ApprovalPolicy,
@@ -611,7 +612,7 @@ export function chainDiscoveryScanOptions(input: {
   pageBudget?: number;
 }):
   | { incremental: true; pageBudget: number }
-  | { seedIncrementalWatermark: true; throwOnChainScanFailure: true; pageBudget: number } {
+  | { seedIncrementalWatermark: true; resumeFromCursor: true; throwOnChainScanFailure: true; pageBudget: number } {
   const configuredFullScanEvery = input.fullScanEvery;
   let fullScanEvery = CHAIN_FULL_SCAN_EVERY;
   if (
@@ -633,7 +634,7 @@ export function chainDiscoveryScanOptions(input: {
   const periodicFullResync = input.watermarkSeeded && run > 0 && run % fullScanEvery === 0;
   return input.watermarkSeeded && !periodicFullResync
     ? { incremental: true, pageBudget }
-    : { seedIncrementalWatermark: true, throwOnChainScanFailure: true, pageBudget };
+    : { seedIncrementalWatermark: true, resumeFromCursor: true, throwOnChainScanFailure: true, pageBudget };
 }
 
 export interface PromoteWorkerDaemonLifecycle {
@@ -1320,7 +1321,9 @@ export async function runDaemonInner(
     : undefined;
 
   const dashDb = new DashboardDB({ dataDir: dkgDir() });
-  const chainCursorScope = `${chainBase?.chainId ?? 'none'}:hub=${(chainBase?.hubAddress ?? 'none').toLowerCase()}`;
+  const chainCursorScope = chainBase?.chainId && chainBase?.hubAddress
+    ? buildEvmDeploymentId({ chainId: chainBase.chainId, hubAddress: chainBase.hubAddress })
+    : 'none:hub=none';
 
   if (role === 'core' && config.core?.allowDegradedRelay === false) {
     const hostInterfaces = Object.values(osModule.networkInterfaces())

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -612,7 +612,8 @@ export function chainDiscoveryScanOptions(input: {
   pageBudget?: number;
 }):
   | { incremental: true; pageBudget: number }
-  | { seedIncrementalWatermark: true; resumeFromCursor: true; throwOnChainScanFailure: true; pageBudget: number } {
+  | { seedIncrementalWatermark: true; resumeFromCursor: true; throwOnChainScanFailure: true; pageBudget: number }
+  | { seedIncrementalWatermark: true; throwOnChainScanFailure: true } {
   const configuredFullScanEvery = input.fullScanEvery;
   let fullScanEvery = CHAIN_FULL_SCAN_EVERY;
   if (
@@ -632,9 +633,49 @@ export function chainDiscoveryScanOptions(input: {
     : CHAIN_DISCOVERY_SCAN_PAGE_BUDGET;
   const run = input.run ?? 0;
   const periodicFullResync = input.watermarkSeeded && run > 0 && run % fullScanEvery === 0;
+  if (periodicFullResync) {
+    return { seedIncrementalWatermark: true, throwOnChainScanFailure: true };
+  }
   return input.watermarkSeeded && !periodicFullResync
     ? { incremental: true, pageBudget }
     : { seedIncrementalWatermark: true, resumeFromCursor: true, throwOnChainScanFailure: true, pageBudget };
+}
+
+export function createChainDiscoveryScanRunner(input: {
+  agent: {
+    hasContextGraphRegistryScanWatermark(): Promise<boolean>;
+    discoverContextGraphsFromChain(
+      options: ReturnType<typeof chainDiscoveryScanOptions>,
+    ): Promise<number>;
+  };
+  log: (msg: string) => void;
+  pageBudget?: number;
+  fullScanEvery?: number;
+}): () => Promise<void> {
+  let runs = 0;
+  let inFlight = false;
+  return async () => {
+    if (inFlight) return;
+    inFlight = true;
+    try {
+      const run = runs++;
+      const found = await input.agent.discoverContextGraphsFromChain(
+        chainDiscoveryScanOptions({
+          run,
+          watermarkSeeded: await input.agent.hasContextGraphRegistryScanWatermark(),
+          pageBudget: input.pageBudget,
+          fullScanEvery: input.fullScanEvery,
+        }),
+      );
+      if (found > 0) {
+        input.log(`Chain scan: discovered ${found} new context graph(s)`);
+      }
+    } catch {
+      /* non-critical */
+    } finally {
+      inFlight = false;
+    }
+  };
 }
 
 export interface PromoteWorkerDaemonLifecycle {
@@ -1948,28 +1989,11 @@ export async function runDaemonInner(
   // Run an initial chain scan for context graphs we might not know about,
   // then repeat every 30 minutes as a fallback discovery mechanism.
   const CHAIN_SCAN_INTERVAL_MS = 30 * 60 * 1000;
-  let chainScanRuns = 0;
-  let chainScanInFlight = false;
-  const runChainDiscoveryScan = async () => {
-    if (chainScanInFlight) return;
-    chainScanInFlight = true;
-    try {
-      const run = chainScanRuns++;
-      const found = await agent.discoverContextGraphsFromChain(
-        chainDiscoveryScanOptions({
-          run,
-          watermarkSeeded: await agent.hasContextGraphRegistryScanWatermark(),
-          pageBudget: CHAIN_DISCOVERY_SCAN_PAGE_BUDGET,
-        }),
-      );
-      if (found > 0)
-        log(`Chain scan: discovered ${found} new context graph(s)`);
-    } catch {
-      /* non-critical */
-    } finally {
-      chainScanInFlight = false;
-    }
-  };
+  const runChainDiscoveryScan = createChainDiscoveryScanRunner({
+    agent,
+    log,
+    pageBudget: CHAIN_DISCOVERY_SCAN_PAGE_BUDGET,
+  });
   setTimeout(runChainDiscoveryScan, 15_000);
   const chainScanTimer = setInterval(runChainDiscoveryScan, CHAIN_SCAN_INTERVAL_MS);
   if (chainScanTimer.unref) chainScanTimer.unref();

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -611,9 +611,9 @@ export function chainDiscoveryScanOptions(input: {
   fullScanEvery?: number;
   pageBudget?: number;
 }):
-  | { incremental: true; pageBudget: number }
-  | { seedIncrementalWatermark: true; resumeFromCursor: true; throwOnChainScanFailure: true; pageBudget: number }
-  | { seedIncrementalWatermark: true; throwOnChainScanFailure: true } {
+  | { mode: 'incremental'; pageBudget: number }
+  | { mode: 'seedFromCursor'; throwOnChainScanFailure: true; pageBudget: number }
+  | { mode: 'seedFull'; throwOnChainScanFailure: true } {
   const configuredFullScanEvery = input.fullScanEvery;
   let fullScanEvery = CHAIN_FULL_SCAN_EVERY;
   if (
@@ -634,11 +634,11 @@ export function chainDiscoveryScanOptions(input: {
   const run = input.run ?? 0;
   const periodicFullResync = input.watermarkSeeded && run > 0 && run % fullScanEvery === 0;
   if (periodicFullResync) {
-    return { seedIncrementalWatermark: true, throwOnChainScanFailure: true };
+    return { mode: 'seedFull', throwOnChainScanFailure: true };
   }
   return input.watermarkSeeded && !periodicFullResync
-    ? { incremental: true, pageBudget }
-    : { seedIncrementalWatermark: true, resumeFromCursor: true, throwOnChainScanFailure: true, pageBudget };
+    ? { mode: 'incremental', pageBudget }
+    : { mode: 'seedFromCursor', throwOnChainScanFailure: true, pageBudget };
 }
 
 export function createChainDiscoveryScanRunner(input: {

--- a/packages/cli/test/chain-discovery-scan-mode.test.ts
+++ b/packages/cli/test/chain-discovery-scan-mode.test.ts
@@ -1,8 +1,8 @@
-import { describe, expect, it } from 'vitest';
-import { chainDiscoveryScanOptions } from '../src/daemon/lifecycle.js';
+import { describe, expect, it, vi } from 'vitest';
+import { chainDiscoveryScanOptions, createChainDiscoveryScanRunner } from '../src/daemon/lifecycle.js';
 
 describe('chainDiscoveryScanOptions', () => {
-  it('uses failure-throwing full-history watermark seeding before a seed exists', () => {
+  it('uses bounded cursor-resumable watermark seeding before a seed exists', () => {
     expect(chainDiscoveryScanOptions({ watermarkSeeded: false })).toEqual({
       seedIncrementalWatermark: true,
       resumeFromCursor: true,
@@ -23,16 +23,14 @@ describe('chainDiscoveryScanOptions', () => {
     })).toEqual({ incremental: true, pageBudget: 30 });
   });
 
-  it('keeps a periodic bounded recovery path after the watermark is seeded', () => {
+  it('keeps a periodic full-history recovery path after the watermark is seeded', () => {
     expect(chainDiscoveryScanOptions({
       watermarkSeeded: true,
       run: 48,
       fullScanEvery: 48,
     })).toEqual({
       seedIncrementalWatermark: true,
-      resumeFromCursor: true,
       throwOnChainScanFailure: true,
-      pageBudget: 30,
     });
   });
 
@@ -57,5 +55,37 @@ describe('chainDiscoveryScanOptions', () => {
       watermarkSeeded: true,
       pageBudget: 7.9,
     })).toEqual({ incremental: true, pageBudget: 7 });
+  });
+
+  it('serializes overlapping scheduled chain scans and resets after settle', async () => {
+    let resolveFirstScan: ((value: number) => void) | undefined;
+    const firstScan = new Promise<number>((resolve) => {
+      resolveFirstScan = resolve;
+    });
+    const agent = {
+      hasContextGraphRegistryScanWatermark: vi.fn(async () => true),
+      discoverContextGraphsFromChain: vi.fn(async () => firstScan),
+    };
+    const runner = createChainDiscoveryScanRunner({
+      agent,
+      log: vi.fn(),
+    });
+
+    const first = runner();
+    const overlapping = runner();
+    await Promise.resolve();
+
+    expect(agent.hasContextGraphRegistryScanWatermark).toHaveBeenCalledTimes(1);
+    expect(agent.discoverContextGraphsFromChain).toHaveBeenCalledTimes(1);
+    await overlapping;
+
+    resolveFirstScan?.(0);
+    await first;
+
+    agent.discoverContextGraphsFromChain.mockResolvedValue(0);
+    await runner();
+
+    expect(agent.hasContextGraphRegistryScanWatermark).toHaveBeenCalledTimes(2);
+    expect(agent.discoverContextGraphsFromChain).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/cli/test/chain-discovery-scan-mode.test.ts
+++ b/packages/cli/test/chain-discovery-scan-mode.test.ts
@@ -6,11 +6,12 @@ describe('chainDiscoveryScanOptions', () => {
     expect(chainDiscoveryScanOptions({ watermarkSeeded: false })).toEqual({
       seedIncrementalWatermark: true,
       throwOnChainScanFailure: true,
+      pageBudget: 30,
     });
   });
 
   it('keeps steady-state daemon scans incremental-only', () => {
-    expect(chainDiscoveryScanOptions({ watermarkSeeded: true })).toEqual({ incremental: true });
+    expect(chainDiscoveryScanOptions({ watermarkSeeded: true })).toEqual({ incremental: true, pageBudget: 30 });
   });
 
   it('keeps the first daemon scan incremental when the watermark is already seeded', () => {
@@ -18,10 +19,10 @@ describe('chainDiscoveryScanOptions', () => {
       watermarkSeeded: true,
       run: 0,
       fullScanEvery: 48,
-    })).toEqual({ incremental: true });
+    })).toEqual({ incremental: true, pageBudget: 30 });
   });
 
-  it('keeps a periodic full-history recovery path after the watermark is seeded', () => {
+  it('keeps a periodic bounded recovery path after the watermark is seeded', () => {
     expect(chainDiscoveryScanOptions({
       watermarkSeeded: true,
       run: 48,
@@ -29,6 +30,7 @@ describe('chainDiscoveryScanOptions', () => {
     })).toEqual({
       seedIncrementalWatermark: true,
       throwOnChainScanFailure: true,
+      pageBudget: 30,
     });
   });
 
@@ -37,7 +39,7 @@ describe('chainDiscoveryScanOptions', () => {
       watermarkSeeded: true,
       run: 47,
       fullScanEvery: 48,
-    })).toEqual({ incremental: true });
+    })).toEqual({ incremental: true, pageBudget: 30 });
   });
 
   it('ignores fractional full-scan cadence overrides below one', () => {
@@ -45,6 +47,13 @@ describe('chainDiscoveryScanOptions', () => {
       watermarkSeeded: true,
       run: 1,
       fullScanEvery: 0.5,
-    })).toEqual({ incremental: true });
+    })).toEqual({ incremental: true, pageBudget: 30 });
+  });
+
+  it('honors a valid custom page budget', () => {
+    expect(chainDiscoveryScanOptions({
+      watermarkSeeded: true,
+      pageBudget: 7.9,
+    })).toEqual({ incremental: true, pageBudget: 7 });
   });
 });

--- a/packages/cli/test/chain-discovery-scan-mode.test.ts
+++ b/packages/cli/test/chain-discovery-scan-mode.test.ts
@@ -4,15 +4,14 @@ import { chainDiscoveryScanOptions, createChainDiscoveryScanRunner } from '../sr
 describe('chainDiscoveryScanOptions', () => {
   it('uses bounded cursor-resumable watermark seeding before a seed exists', () => {
     expect(chainDiscoveryScanOptions({ watermarkSeeded: false })).toEqual({
-      seedIncrementalWatermark: true,
-      resumeFromCursor: true,
+      mode: 'seedFromCursor',
       throwOnChainScanFailure: true,
       pageBudget: 30,
     });
   });
 
   it('keeps steady-state daemon scans incremental-only', () => {
-    expect(chainDiscoveryScanOptions({ watermarkSeeded: true })).toEqual({ incremental: true, pageBudget: 30 });
+    expect(chainDiscoveryScanOptions({ watermarkSeeded: true })).toEqual({ mode: 'incremental', pageBudget: 30 });
   });
 
   it('keeps the first daemon scan incremental when the watermark is already seeded', () => {
@@ -20,7 +19,7 @@ describe('chainDiscoveryScanOptions', () => {
       watermarkSeeded: true,
       run: 0,
       fullScanEvery: 48,
-    })).toEqual({ incremental: true, pageBudget: 30 });
+    })).toEqual({ mode: 'incremental', pageBudget: 30 });
   });
 
   it('keeps a periodic full-history recovery path after the watermark is seeded', () => {
@@ -29,7 +28,7 @@ describe('chainDiscoveryScanOptions', () => {
       run: 48,
       fullScanEvery: 48,
     })).toEqual({
-      seedIncrementalWatermark: true,
+      mode: 'seedFull',
       throwOnChainScanFailure: true,
     });
   });
@@ -39,7 +38,7 @@ describe('chainDiscoveryScanOptions', () => {
       watermarkSeeded: true,
       run: 47,
       fullScanEvery: 48,
-    })).toEqual({ incremental: true, pageBudget: 30 });
+    })).toEqual({ mode: 'incremental', pageBudget: 30 });
   });
 
   it('ignores fractional full-scan cadence overrides below one', () => {
@@ -47,14 +46,14 @@ describe('chainDiscoveryScanOptions', () => {
       watermarkSeeded: true,
       run: 1,
       fullScanEvery: 0.5,
-    })).toEqual({ incremental: true, pageBudget: 30 });
+    })).toEqual({ mode: 'incremental', pageBudget: 30 });
   });
 
   it('honors a valid custom page budget', () => {
     expect(chainDiscoveryScanOptions({
       watermarkSeeded: true,
       pageBudget: 7.9,
-    })).toEqual({ incremental: true, pageBudget: 7 });
+    })).toEqual({ mode: 'incremental', pageBudget: 7 });
   });
 
   it('serializes overlapping scheduled chain scans and resets after settle', async () => {

--- a/packages/cli/test/chain-discovery-scan-mode.test.ts
+++ b/packages/cli/test/chain-discovery-scan-mode.test.ts
@@ -5,6 +5,7 @@ describe('chainDiscoveryScanOptions', () => {
   it('uses failure-throwing full-history watermark seeding before a seed exists', () => {
     expect(chainDiscoveryScanOptions({ watermarkSeeded: false })).toEqual({
       seedIncrementalWatermark: true,
+      resumeFromCursor: true,
       throwOnChainScanFailure: true,
       pageBudget: 30,
     });
@@ -29,6 +30,7 @@ describe('chainDiscoveryScanOptions', () => {
       fullScanEvery: 48,
     })).toEqual({
       seedIncrementalWatermark: true,
+      resumeFromCursor: true,
       throwOnChainScanFailure: true,
       pageBudget: 30,
     });

--- a/packages/cli/test/daemon-startup-validation.test.ts
+++ b/packages/cli/test/daemon-startup-validation.test.ts
@@ -164,8 +164,18 @@ describe('daemon startup network validation', () => {
 
     expect(mocks.loadNetworkConfig).toHaveBeenCalledWith('mainnet-gnosis');
     expect(mocks.agentCreate).toHaveBeenCalledTimes(1);
-    expect(mocks.agentCreate.mock.calls[0]?.[0]).toMatchObject({
+    const createArg = mocks.agentCreate.mock.calls[0]?.[0] as any;
+    expect(createArg).toMatchObject({
       genesisId: 'gnosis-mainnet',
+      chainEventCursorStore: {
+        loadLane: expect.any(Function),
+        saveLane: expect.any(Function),
+      },
+      contextGraphRegistryScanCursorStore: {
+        load: expect.any(Function),
+        save: expect.any(Function),
+      },
     });
+    createArg.chainEventCursorStore?.db?.close?.();
   });
 });

--- a/packages/cli/test/daemon-startup-validation.test.ts
+++ b/packages/cli/test/daemon-startup-validation.test.ts
@@ -31,6 +31,13 @@ vi.mock('../src/config.js', async importOriginal => {
 
 const { runDaemonInner } = await import('../src/daemon/lifecycle.js');
 
+function closeDashboardDbFromAgentCreateArg(createArg: any): void {
+  const db =
+    createArg?.chainEventCursorStore?.cursors?.db ??
+    createArg?.contextGraphRegistryScanCursorStore?.cursors?.db;
+  db?.close?.();
+}
+
 describe('daemon startup network validation', () => {
   let tempHome: string | undefined;
   let originalDkgHome: string | undefined;
@@ -187,6 +194,47 @@ describe('daemon startup network validation', () => {
       chainId: 'evm:100',
       hubAddress: '0x1234567890123456789012345678901234567890',
     }));
-    createArg.chainEventCursorStore?.db?.close?.();
+    closeDashboardDbFromAgentCreateArg(createArg);
+  });
+
+  it('scopes chain event cursors with the EVM default chain id when chainId is omitted', async () => {
+    tempHome = await mkdtemp(join(tmpdir(), 'dkg-omitted-chainid-startup-'));
+    originalDkgHome = process.env.DKG_HOME;
+    process.env.DKG_HOME = tempHome;
+    stdoutWrite = process.stdout.write;
+    stderrWrite = process.stderr.write;
+    uncaughtExceptionListeners = process.listeners('uncaughtException') as NodeJS.UncaughtExceptionListener[];
+    unhandledRejectionListeners = process.listeners('unhandledRejection') as NodeJS.UnhandledRejectionListener[];
+
+    mocks.loadNetworkConfig.mockResolvedValue({
+      networkName: 'Local EVM',
+      genesisId: 'gnosis-mainnet',
+      genesisVersion: 1,
+      relays: [],
+      defaultNodeRole: 'edge',
+    });
+    mocks.loadOpWallets.mockResolvedValue({ adminWallet: undefined, wallets: [] });
+    mocks.agentCreate.mockRejectedValue(new Error('after-agent-create'));
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    await expect(runDaemonInner(true, {
+      name: 'omitted-chainid-startup-test',
+      networkConfig: 'local-evm',
+      listenPort: 0,
+      nodeRole: 'edge',
+      chain: {
+        type: 'evm',
+        rpcUrl: 'https://private-rpc.example',
+        hubAddress: '0x2234567890123456789012345678901234567890',
+      },
+    } as any, Date.now())).rejects.toThrow('after-agent-create');
+
+    expect(mocks.agentCreate).toHaveBeenCalledTimes(1);
+    const createArg = mocks.agentCreate.mock.calls[0]?.[0] as any;
+    expect((createArg.chainEventCursorStore as any).scope).toBe(buildEvmDeploymentId({
+      chainId: 'evm:31337',
+      hubAddress: '0x2234567890123456789012345678901234567890',
+    }));
+    closeDashboardDbFromAgentCreateArg(createArg);
   });
 });

--- a/packages/cli/test/daemon-startup-validation.test.ts
+++ b/packages/cli/test/daemon-startup-validation.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { computeNetworkId } from '../../core/src/genesis.js';
+import { buildEvmDeploymentId } from '@origintrail-official/dkg-chain';
 
 const mocks = vi.hoisted(() => ({
   agentCreate: vi.fn(),
@@ -160,6 +161,12 @@ describe('daemon startup network validation', () => {
       networkConfig: 'mainnet-gnosis',
       listenPort: 0,
       nodeRole: 'edge',
+      chain: {
+        type: 'evm',
+        rpcUrl: 'https://private-rpc.example',
+        hubAddress: '0x1234567890123456789012345678901234567890',
+        chainId: 'evm:100',
+      },
     } as any, Date.now())).rejects.toThrow('after-agent-create');
 
     expect(mocks.loadNetworkConfig).toHaveBeenCalledWith('mainnet-gnosis');
@@ -176,6 +183,10 @@ describe('daemon startup network validation', () => {
         save: expect.any(Function),
       },
     });
+    expect((createArg.chainEventCursorStore as any).scope).toBe(buildEvmDeploymentId({
+      chainId: 'evm:100',
+      hubAddress: '0x1234567890123456789012345678901234567890',
+    }));
     createArg.chainEventCursorStore?.db?.close?.();
   });
 });

--- a/packages/node-ui/src/chain-cursor-stores.ts
+++ b/packages/node-ui/src/chain-cursor-stores.ts
@@ -1,7 +1,7 @@
 import Database from 'better-sqlite3';
 import type { DashboardDB } from './db.js';
 
-function parsePositiveSafeIntegerSetting(value: string | undefined): number | undefined {
+function parsePositiveSafeInteger(value: number | string | undefined): number | undefined {
   if (value == null) return undefined;
   const parsed = Number(value);
   return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
@@ -14,7 +14,7 @@ class SettingsPositiveIntegerCursorStore {
     const row = this.db.prepare(
       `SELECT value FROM settings WHERE key = ?`,
     ).get(key) as { value: string } | undefined;
-    return parsePositiveSafeIntegerSetting(row?.value);
+    return parsePositiveSafeInteger(row?.value);
   }
 
   save(key: string, value: number): void {
@@ -25,32 +25,57 @@ class SettingsPositiveIntegerCursorStore {
   }
 }
 
+class RuntimePositiveIntegerCursorStore {
+  constructor(
+    private readonly db: Database.Database,
+    private readonly namespace: string,
+  ) {}
+
+  load(scope: string, key: string): number | undefined {
+    const row = this.db.prepare(
+      `SELECT value FROM runtime_cursors WHERE namespace = ? AND scope = ? AND key = ?`,
+    ).get(this.namespace, scope, key) as { value: number } | undefined;
+    return parsePositiveSafeInteger(row?.value);
+  }
+
+  save(scope: string, key: string, value: number): void {
+    if (!Number.isSafeInteger(value) || value <= 0) return;
+    this.db.prepare(`
+      INSERT INTO runtime_cursors (namespace, scope, key, value, updated_at)
+      VALUES (?, ?, ?, ?, ?)
+      ON CONFLICT(namespace, scope, key) DO UPDATE SET
+        value = excluded.value,
+        updated_at = excluded.updated_at
+    `).run(this.namespace, scope, key, value, Date.now());
+  }
+}
+
 /**
  * SQLite-backed lane cursor store for `ChainEventPoller`.
  *
- * The store is intentionally implemented against the generic settings table:
- * cursor rows are tiny, durable, and should not be pruned. `scope` should
- * include the effective chain/deployment identity so a node-home reused across
- * networks never applies an old lane cursor to a different chain.
+ * `scope` should include the effective chain/deployment identity so a node-home
+ * reused across networks never applies an old lane cursor to a different chain.
  */
 export class SqliteChainEventCursorStore {
-  private readonly cursors: SettingsPositiveIntegerCursorStore;
+  private readonly cursors: RuntimePositiveIntegerCursorStore;
+  private readonly legacyCursors: SettingsPositiveIntegerCursorStore;
   private readonly scope: string;
 
   constructor(dashboard: DashboardDB, options: { scope?: string } = {}) {
-    this.cursors = new SettingsPositiveIntegerCursorStore(dashboard.db);
+    this.cursors = new RuntimePositiveIntegerCursorStore(dashboard.db, 'chainEventPoller.cursor');
+    this.legacyCursors = new SettingsPositiveIntegerCursorStore(dashboard.db);
     this.scope = options.scope ?? 'default';
   }
 
   async loadLane(lane: string): Promise<number | undefined> {
-    return this.cursors.load(this.key(lane));
+    return this.cursors.load(this.scope, lane) ?? this.legacyCursors.load(this.legacyKey(lane));
   }
 
   async saveLane(lane: string, blockNumber: number): Promise<void> {
-    this.cursors.save(this.key(lane), blockNumber);
+    this.cursors.save(this.scope, lane, blockNumber);
   }
 
-  private key(lane: string): string {
+  private legacyKey(lane: string): string {
     return `chainEventPoller.cursor:${this.scope}:${lane}`;
   }
 }
@@ -64,21 +89,32 @@ export class SqliteChainEventCursorStore {
  * historical scan path.
  */
 export class SqliteContextGraphRegistryScanCursorStore {
-  private readonly cursors: SettingsPositiveIntegerCursorStore;
+  private readonly cursors: RuntimePositiveIntegerCursorStore;
+  private readonly legacyCursors: SettingsPositiveIntegerCursorStore;
 
   constructor(dashboard: DashboardDB) {
-    this.cursors = new SettingsPositiveIntegerCursorStore(dashboard.db);
+    this.cursors = new RuntimePositiveIntegerCursorStore(dashboard.db, 'contextGraphRegistryScan.cursor');
+    this.legacyCursors = new SettingsPositiveIntegerCursorStore(dashboard.db);
   }
 
   async load(key: { chainId: string; deploymentId: string; registryAddress: string }): Promise<number | undefined> {
-    return this.cursors.load(this.key(key));
+    return this.cursors.load(this.scope(key), this.registryKey(key))
+      ?? this.legacyCursors.load(this.legacyKey(key));
   }
 
   async save(key: { chainId: string; deploymentId: string; registryAddress: string }, nextBlock: number): Promise<void> {
-    this.cursors.save(this.key(key), nextBlock);
+    this.cursors.save(this.scope(key), this.registryKey(key), nextBlock);
   }
 
-  private key(key: { chainId: string; deploymentId: string; registryAddress: string }): string {
+  private scope(key: { chainId: string; deploymentId: string }): string {
+    return `${key.chainId}:${key.deploymentId}`;
+  }
+
+  private registryKey(key: { registryAddress: string }): string {
+    return key.registryAddress.toLowerCase();
+  }
+
+  private legacyKey(key: { chainId: string; deploymentId: string; registryAddress: string }): string {
     return [
       'contextGraphRegistryScan.cursor',
       key.chainId,

--- a/packages/node-ui/src/chain-cursor-stores.ts
+++ b/packages/node-ui/src/chain-cursor-stores.ts
@@ -1,0 +1,89 @@
+import Database from 'better-sqlite3';
+import type { DashboardDB } from './db.js';
+
+function parsePositiveSafeIntegerSetting(value: string | undefined): number | undefined {
+  if (value == null) return undefined;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+class SettingsPositiveIntegerCursorStore {
+  constructor(private readonly db: Database.Database) {}
+
+  load(key: string): number | undefined {
+    const row = this.db.prepare(
+      `SELECT value FROM settings WHERE key = ?`,
+    ).get(key) as { value: string } | undefined;
+    return parsePositiveSafeIntegerSetting(row?.value);
+  }
+
+  save(key: string, value: number): void {
+    if (!Number.isSafeInteger(value) || value <= 0) return;
+    this.db.prepare(
+      `INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)`,
+    ).run(key, String(value));
+  }
+}
+
+/**
+ * SQLite-backed lane cursor store for `ChainEventPoller`.
+ *
+ * The store is intentionally implemented against the generic settings table:
+ * cursor rows are tiny, durable, and should not be pruned. `scope` should
+ * include the effective chain/deployment identity so a node-home reused across
+ * networks never applies an old lane cursor to a different chain.
+ */
+export class SqliteChainEventCursorStore {
+  private readonly cursors: SettingsPositiveIntegerCursorStore;
+  private readonly scope: string;
+
+  constructor(dashboard: DashboardDB, options: { scope?: string } = {}) {
+    this.cursors = new SettingsPositiveIntegerCursorStore(dashboard.db);
+    this.scope = options.scope ?? 'default';
+  }
+
+  async loadLane(lane: string): Promise<number | undefined> {
+    return this.cursors.load(this.key(lane));
+  }
+
+  async saveLane(lane: string, blockNumber: number): Promise<void> {
+    this.cursors.save(this.key(lane), blockNumber);
+  }
+
+  private key(lane: string): string {
+    return `chainEventPoller.cursor:${this.scope}:${lane}`;
+  }
+}
+
+/**
+ * SQLite-backed ContextGraphNameRegistry scan cursor.
+ *
+ * The value is the next unbuffered block after a successfully scanned
+ * contiguous prefix. It is keyed by chain/deployment/registry address; corrupt
+ * values are ignored by returning `undefined`, which fails closed to the
+ * historical scan path.
+ */
+export class SqliteContextGraphRegistryScanCursorStore {
+  private readonly cursors: SettingsPositiveIntegerCursorStore;
+
+  constructor(dashboard: DashboardDB) {
+    this.cursors = new SettingsPositiveIntegerCursorStore(dashboard.db);
+  }
+
+  async load(key: { chainId: string; deploymentId: string; registryAddress: string }): Promise<number | undefined> {
+    return this.cursors.load(this.key(key));
+  }
+
+  async save(key: { chainId: string; deploymentId: string; registryAddress: string }, nextBlock: number): Promise<void> {
+    this.cursors.save(this.key(key), nextBlock);
+  }
+
+  private key(key: { chainId: string; deploymentId: string; registryAddress: string }): string {
+    return [
+      'contextGraphRegistryScan.cursor',
+      key.chainId,
+      key.deploymentId,
+      key.registryAddress.toLowerCase(),
+    ].join(':');
+  }
+}

--- a/packages/node-ui/src/db.ts
+++ b/packages/node-ui/src/db.ts
@@ -15,7 +15,7 @@ export {
   SqliteContextGraphRegistryScanCursorStore,
 } from './chain-cursor-stores.js';
 
-const SCHEMA_VERSION = 21;
+const SCHEMA_VERSION = 22;
 // Default operator retention. Lowered from 90 → 14 days on V15 (2026-05) after
 // a production incident in which the `logs` table + its FTS5 shadow tables
 // grew to ~9 GB on a 12-day-old node and corrupted the SQLite page (header
@@ -795,6 +795,23 @@ export class DashboardDB {
         );
         CREATE INDEX IF NOT EXISTS idx_sync_checkpoints_expires_at
           ON sync_checkpoints(expires_at);
+      `);
+    }
+
+    if (version < 22) {
+      this.db.exec(`
+        CREATE TABLE IF NOT EXISTS runtime_cursors (
+          namespace TEXT NOT NULL,
+          scope TEXT NOT NULL,
+          key TEXT NOT NULL,
+          value INTEGER NOT NULL CHECK (value > 0),
+          updated_at INTEGER NOT NULL,
+          PRIMARY KEY (namespace, scope, key)
+        );
+      `);
+      this.db.exec(`
+        CREATE INDEX IF NOT EXISTS idx_runtime_cursors_namespace_scope
+          ON runtime_cursors(namespace, scope);
       `);
     }
 

--- a/packages/node-ui/src/db.ts
+++ b/packages/node-ui/src/db.ts
@@ -10,6 +10,11 @@ import {
   type ProtocolOutboxStore,
 } from '@origintrail-official/dkg-core';
 
+export {
+  SqliteChainEventCursorStore,
+  SqliteContextGraphRegistryScanCursorStore,
+} from './chain-cursor-stores.js';
+
 const SCHEMA_VERSION = 21;
 // Default operator retention. Lowered from 90 → 14 days on V15 (2026-05) after
 // a production incident in which the `logs` table + its FTS5 shadow tables
@@ -2397,97 +2402,6 @@ export class SqliteSyncCheckpointStore {
 
   pruneExpired(nowMs = this.clock()): number {
     return this.db.prepare(`DELETE FROM sync_checkpoints WHERE expires_at < ?`).run(nowMs).changes;
-  }
-}
-
-// --- Chain/RPC cursor stores ---
-
-function parsePositiveSafeIntegerSetting(value: string | undefined): number | undefined {
-  if (value == null) return undefined;
-  const parsed = Number(value);
-  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
-}
-
-class SettingsPositiveIntegerCursorStore {
-  constructor(private readonly db: Database.Database) {}
-
-  load(key: string): number | undefined {
-    const row = this.db.prepare(
-      `SELECT value FROM settings WHERE key = ?`,
-    ).get(key) as { value: string } | undefined;
-    return parsePositiveSafeIntegerSetting(row?.value);
-  }
-
-  save(key: string, value: number): void {
-    if (!Number.isSafeInteger(value) || value <= 0) return;
-    this.db.prepare(
-      `INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)`,
-    ).run(key, String(value));
-  }
-}
-
-/**
- * SQLite-backed lane cursor store for `ChainEventPoller`.
- *
- * The store is intentionally implemented against the generic settings table:
- * cursor rows are tiny, durable, and should not be pruned. `scope` should
- * include the effective chain/deployment identity so a node-home reused across
- * networks never applies an old lane cursor to a different chain.
- */
-export class SqliteChainEventCursorStore {
-  private readonly db: Database.Database;
-  private readonly cursors: SettingsPositiveIntegerCursorStore;
-  private readonly scope: string;
-
-  constructor(dashboard: DashboardDB, options: { scope?: string } = {}) {
-    this.db = dashboard.db;
-    this.cursors = new SettingsPositiveIntegerCursorStore(this.db);
-    this.scope = options.scope ?? 'default';
-  }
-
-  async loadLane(lane: string): Promise<number | undefined> {
-    return this.cursors.load(this.key(lane));
-  }
-
-  async saveLane(lane: string, blockNumber: number): Promise<void> {
-    this.cursors.save(this.key(lane), blockNumber);
-  }
-
-  private key(lane: string): string {
-    return `chainEventPoller.cursor:${this.scope}:${lane}`;
-  }
-}
-
-/**
- * SQLite-backed ContextGraphNameRegistry scan cursor.
- *
- * The value is the next unbuffered block after a successfully scanned
- * contiguous prefix. It is keyed by chain/deployment/registry address; corrupt
- * values are ignored by returning `undefined`, which fails closed to the
- * historical scan path.
- */
-export class SqliteContextGraphRegistryScanCursorStore {
-  private readonly cursors: SettingsPositiveIntegerCursorStore;
-
-  constructor(dashboard: DashboardDB) {
-    this.cursors = new SettingsPositiveIntegerCursorStore(dashboard.db);
-  }
-
-  async load(key: { chainId: string; deploymentId: string; registryAddress: string }): Promise<number | undefined> {
-    return this.cursors.load(this.key(key));
-  }
-
-  async save(key: { chainId: string; deploymentId: string; registryAddress: string }, nextBlock: number): Promise<void> {
-    this.cursors.save(this.key(key), nextBlock);
-  }
-
-  private key(key: { chainId: string; deploymentId: string; registryAddress: string }): string {
-    return [
-      'contextGraphRegistryScan.cursor',
-      key.chainId,
-      key.deploymentId,
-      key.registryAddress.toLowerCase(),
-    ].join(':');
   }
 }
 

--- a/packages/node-ui/src/db.ts
+++ b/packages/node-ui/src/db.ts
@@ -2408,6 +2408,24 @@ function parsePositiveSafeIntegerSetting(value: string | undefined): number | un
   return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
 }
 
+class SettingsPositiveIntegerCursorStore {
+  constructor(private readonly db: Database.Database) {}
+
+  load(key: string): number | undefined {
+    const row = this.db.prepare(
+      `SELECT value FROM settings WHERE key = ?`,
+    ).get(key) as { value: string } | undefined;
+    return parsePositiveSafeIntegerSetting(row?.value);
+  }
+
+  save(key: string, value: number): void {
+    if (!Number.isSafeInteger(value) || value <= 0) return;
+    this.db.prepare(
+      `INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)`,
+    ).run(key, String(value));
+  }
+}
+
 /**
  * SQLite-backed lane cursor store for `ChainEventPoller`.
  *
@@ -2418,25 +2436,21 @@ function parsePositiveSafeIntegerSetting(value: string | undefined): number | un
  */
 export class SqliteChainEventCursorStore {
   private readonly db: Database.Database;
+  private readonly cursors: SettingsPositiveIntegerCursorStore;
   private readonly scope: string;
 
   constructor(dashboard: DashboardDB, options: { scope?: string } = {}) {
     this.db = dashboard.db;
+    this.cursors = new SettingsPositiveIntegerCursorStore(this.db);
     this.scope = options.scope ?? 'default';
   }
 
   async loadLane(lane: string): Promise<number | undefined> {
-    const row = this.db.prepare(
-      `SELECT value FROM settings WHERE key = ?`,
-    ).get(this.key(lane)) as { value: string } | undefined;
-    return parsePositiveSafeIntegerSetting(row?.value);
+    return this.cursors.load(this.key(lane));
   }
 
   async saveLane(lane: string, blockNumber: number): Promise<void> {
-    if (!Number.isSafeInteger(blockNumber) || blockNumber <= 0) return;
-    this.db.prepare(
-      `INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)`,
-    ).run(this.key(lane), String(blockNumber));
+    this.cursors.save(this.key(lane), blockNumber);
   }
 
   private key(lane: string): string {
@@ -2453,24 +2467,18 @@ export class SqliteChainEventCursorStore {
  * historical scan path.
  */
 export class SqliteContextGraphRegistryScanCursorStore {
-  private readonly db: Database.Database;
+  private readonly cursors: SettingsPositiveIntegerCursorStore;
 
   constructor(dashboard: DashboardDB) {
-    this.db = dashboard.db;
+    this.cursors = new SettingsPositiveIntegerCursorStore(dashboard.db);
   }
 
   async load(key: { chainId: string; deploymentId: string; registryAddress: string }): Promise<number | undefined> {
-    const row = this.db.prepare(
-      `SELECT value FROM settings WHERE key = ?`,
-    ).get(this.key(key)) as { value: string } | undefined;
-    return parsePositiveSafeIntegerSetting(row?.value);
+    return this.cursors.load(this.key(key));
   }
 
   async save(key: { chainId: string; deploymentId: string; registryAddress: string }, nextBlock: number): Promise<void> {
-    if (!Number.isSafeInteger(nextBlock) || nextBlock <= 0) return;
-    this.db.prepare(
-      `INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)`,
-    ).run(this.key(key), String(nextBlock));
+    this.cursors.save(this.key(key), nextBlock);
   }
 
   private key(key: { chainId: string; deploymentId: string; registryAddress: string }): string {

--- a/packages/node-ui/src/db.ts
+++ b/packages/node-ui/src/db.ts
@@ -2400,6 +2400,89 @@ export class SqliteSyncCheckpointStore {
   }
 }
 
+// --- Chain/RPC cursor stores ---
+
+function parsePositiveSafeIntegerSetting(value: string | undefined): number | undefined {
+  if (value == null) return undefined;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+/**
+ * SQLite-backed lane cursor store for `ChainEventPoller`.
+ *
+ * The store is intentionally implemented against the generic settings table:
+ * cursor rows are tiny, durable, and should not be pruned. `scope` should
+ * include the effective chain/deployment identity so a node-home reused across
+ * networks never applies an old lane cursor to a different chain.
+ */
+export class SqliteChainEventCursorStore {
+  private readonly db: Database.Database;
+  private readonly scope: string;
+
+  constructor(dashboard: DashboardDB, options: { scope?: string } = {}) {
+    this.db = dashboard.db;
+    this.scope = options.scope ?? 'default';
+  }
+
+  async loadLane(lane: string): Promise<number | undefined> {
+    const row = this.db.prepare(
+      `SELECT value FROM settings WHERE key = ?`,
+    ).get(this.key(lane)) as { value: string } | undefined;
+    return parsePositiveSafeIntegerSetting(row?.value);
+  }
+
+  async saveLane(lane: string, blockNumber: number): Promise<void> {
+    if (!Number.isSafeInteger(blockNumber) || blockNumber <= 0) return;
+    this.db.prepare(
+      `INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)`,
+    ).run(this.key(lane), String(blockNumber));
+  }
+
+  private key(lane: string): string {
+    return `chainEventPoller.cursor:${this.scope}:${lane}`;
+  }
+}
+
+/**
+ * SQLite-backed ContextGraphNameRegistry scan cursor.
+ *
+ * The value is the next unbuffered block after a successfully scanned
+ * contiguous prefix. It is keyed by chain/deployment/registry address; corrupt
+ * values are ignored by returning `undefined`, which fails closed to the
+ * historical scan path.
+ */
+export class SqliteContextGraphRegistryScanCursorStore {
+  private readonly db: Database.Database;
+
+  constructor(dashboard: DashboardDB) {
+    this.db = dashboard.db;
+  }
+
+  async load(key: { chainId: string; deploymentId: string; registryAddress: string }): Promise<number | undefined> {
+    const row = this.db.prepare(
+      `SELECT value FROM settings WHERE key = ?`,
+    ).get(this.key(key)) as { value: string } | undefined;
+    return parsePositiveSafeIntegerSetting(row?.value);
+  }
+
+  async save(key: { chainId: string; deploymentId: string; registryAddress: string }, nextBlock: number): Promise<void> {
+    if (!Number.isSafeInteger(nextBlock) || nextBlock <= 0) return;
+    this.db.prepare(
+      `INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)`,
+    ).run(this.key(key), String(nextBlock));
+  }
+
+  private key(key: { chainId: string; deploymentId: string; registryAddress: string }): string {
+    return [
+      'contextGraphRegistryScan.cursor',
+      key.chainId,
+      key.deploymentId,
+      key.registryAddress.toLowerCase(),
+    ].join(':');
+  }
+}
+
 // --- Universal Messenger substrate stores (rc.9 plan PR-1) ---
 
 /**

--- a/packages/node-ui/src/index.ts
+++ b/packages/node-ui/src/index.ts
@@ -4,6 +4,8 @@ export {
   SqliteProtocolOutboxStore,
   type SqliteProtocolOutboxStoreOptions,
   SqliteSyncCheckpointStore,
+  SqliteChainEventCursorStore,
+  SqliteContextGraphRegistryScanCursorStore,
   SqliteKaNumberStore,
   // Notifications-pane redesign (V16): activity-digest primitives shared
   // with the daemon's `assertion_activity` emitters + scoped read path.

--- a/packages/node-ui/src/index.ts
+++ b/packages/node-ui/src/index.ts
@@ -4,8 +4,6 @@ export {
   SqliteProtocolOutboxStore,
   type SqliteProtocolOutboxStoreOptions,
   SqliteSyncCheckpointStore,
-  SqliteChainEventCursorStore,
-  SqliteContextGraphRegistryScanCursorStore,
   SqliteKaNumberStore,
   // Notifications-pane redesign (V16): activity-digest primitives shared
   // with the daemon's `assertion_activity` emitters + scoped read path.
@@ -14,6 +12,10 @@ export {
   buildActivityDigestKey,
   parseActivityDigestKey,
 } from './db.js';
+export {
+  SqliteChainEventCursorStore,
+  SqliteContextGraphRegistryScanCursorStore,
+} from './chain-cursor-stores.js';
 export type {
   DashboardDBOptions,
   MetricSnapshotRow,

--- a/packages/node-ui/test/db.test.ts
+++ b/packages/node-ui/test/db.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import Database from 'better-sqlite3';
-import { DashboardDB, SqliteKaNumberStore, SqliteSyncCheckpointStore, buildActivityDigestKey, ACTIVITY_DIGEST_WINDOW_MS, ASSERTION_ACTIVITY_TYPE } from '../src/db.js';
+import { DashboardDB, SqliteChainEventCursorStore, SqliteContextGraphRegistryScanCursorStore, SqliteKaNumberStore, SqliteSyncCheckpointStore, buildActivityDigestKey, ACTIVITY_DIGEST_WINDOW_MS, ASSERTION_ACTIVITY_TYPE } from '../src/db.js';
 
 let db: DashboardDB;
 let dir: string;
@@ -1119,6 +1119,61 @@ describe('DashboardDB — V21 sync_checkpoints table (A3 sync resume)', () => {
     expect(db.db.prepare(
       `SELECT name FROM sqlite_master WHERE type='table' AND name='sync_checkpoints'`,
     ).all()).toHaveLength(1);
+  });
+});
+
+describe('DashboardDB — chain RPC cursor stores', () => {
+  it('persists chain-event lane cursors by scope across reopen', async () => {
+    const store = new SqliteChainEventCursorStore(db, { scope: 'evm:1:hub=0xabc' });
+
+    await store.saveLane('contextGraphDiscovery', 1234);
+    await store.saveLane('vmReconcile', 5678);
+    expect(await store.loadLane('contextGraphDiscovery')).toBe(1234);
+    expect(await store.loadLane('vmReconcile')).toBe(5678);
+    expect(await new SqliteChainEventCursorStore(db, { scope: 'evm:2:hub=0xabc' }).loadLane('contextGraphDiscovery')).toBeUndefined();
+
+    await store.saveLane('contextGraphDiscovery', 0);
+    await store.saveLane('contextGraphDiscovery', -1);
+    await store.saveLane('contextGraphDiscovery', 1.5);
+    await store.saveLane('contextGraphDiscovery', Number.MAX_SAFE_INTEGER + 1);
+    expect(await store.loadLane('contextGraphDiscovery')).toBe(1234);
+
+    db.db.prepare(
+      `INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)`,
+    ).run('chainEventPoller.cursor:evm:1:hub=0xabc:badLane', '0');
+    expect(await store.loadLane('badLane')).toBeUndefined();
+
+    db.close();
+    db = new DashboardDB({ dataDir: dir });
+    const reopened = new SqliteChainEventCursorStore(db, { scope: 'evm:1:hub=0xabc' });
+    expect(await reopened.loadLane('contextGraphDiscovery')).toBe(1234);
+    expect(await reopened.loadLane('vmReconcile')).toBe(5678);
+  });
+
+  it('persists registry scan cursors by deployment key and ignores corrupt values', async () => {
+    const store = new SqliteContextGraphRegistryScanCursorStore(db);
+    const key = {
+      chainId: 'evm:1',
+      deploymentId: 'evm:1:hub=0xabc',
+      registryAddress: '0x3333333333333333333333333333333333333333',
+    };
+
+    await store.save(key, 5000);
+    expect(await store.load(key)).toBe(5000);
+    await store.save(key, 0);
+    await store.save(key, -1);
+    await store.save(key, 1.5);
+    await store.save(key, Number.MAX_SAFE_INTEGER + 1);
+    expect(await store.load(key)).toBe(5000);
+    expect(await store.load({ ...key, registryAddress: '0x4444444444444444444444444444444444444444' })).toBeUndefined();
+
+    db.db.prepare(
+      `INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)`,
+    ).run(
+      `contextGraphRegistryScan.cursor:${key.chainId}:${key.deploymentId}:0x5555555555555555555555555555555555555555`,
+      'not-a-number',
+    );
+    expect(await store.load({ ...key, registryAddress: '0x5555555555555555555555555555555555555555' })).toBeUndefined();
   });
 });
 

--- a/packages/node-ui/test/db.test.ts
+++ b/packages/node-ui/test/db.test.ts
@@ -1174,6 +1174,11 @@ describe('DashboardDB — chain RPC cursor stores', () => {
       'not-a-number',
     );
     expect(await store.load({ ...key, registryAddress: '0x5555555555555555555555555555555555555555' })).toBeUndefined();
+
+    db.close();
+    db = new DashboardDB({ dataDir: dir });
+    const reopened = new SqliteContextGraphRegistryScanCursorStore(db);
+    expect(await reopened.load(key)).toBe(5000);
   });
 });
 

--- a/packages/node-ui/test/db.test.ts
+++ b/packages/node-ui/test/db.test.ts
@@ -86,7 +86,7 @@ describe('DashboardDB — metric snapshots', () => {
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(21);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(22);
 
     const cols = (db.db.prepare('PRAGMA table_info(metric_snapshots)').all() as Array<{ name: string }>)
       .map((c) => c.name);
@@ -142,7 +142,7 @@ describe('DashboardDB — metric snapshots', () => {
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(21);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(22);
 
     const newSnapshotCols = (db.db.prepare('PRAGMA table_info(metric_snapshots)').all() as { name: string }[])
       .map(c => c.name);
@@ -545,7 +545,7 @@ describe('DashboardDB — V15 migration: drop FTS5 logs index', () => {
 
     const upgraded = new DashboardDB({ dataDir: upgradeDir });
     try {
-      expect(upgraded.db.pragma('user_version', { simple: true })).toBe(21);
+      expect(upgraded.db.pragma('user_version', { simple: true })).toBe(22);
 
       const ftsTables = upgraded.db.prepare(
         `SELECT name FROM sqlite_master WHERE type IN ('table','view') AND name LIKE 'logs_fts%'`,
@@ -785,7 +785,7 @@ describe('DashboardDB — V17 subscription columns migration (Phase B)', () => {
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(21);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(22);
 
     const cols = (db.db.prepare('PRAGMA table_info(context_graph_subscriptions)').all() as Array<{ name: string }>)
       .map((c) => c.name);
@@ -806,7 +806,7 @@ describe('DashboardDB — V17 subscription columns migration (Phase B)', () => {
       .map((c) => c.name);
     expect(cols).toContain('on_chain_hash');
     expect(cols).toContain('last_reconciled_ordinal');
-    expect(db.db.pragma('user_version', { simple: true })).toBe(21);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(22);
   });
 });
 
@@ -890,7 +890,7 @@ describe('DashboardDB — V19 core_hosted column migration (Phase D)', () => {
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(21);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(22);
 
     const cols = (db.db.prepare('PRAGMA table_info(context_graph_subscriptions)').all() as Array<{ name: string }>)
       .map((c) => c.name);
@@ -919,7 +919,7 @@ describe('DashboardDB — V20 ka_numbers table migration (B2 KA-number allocator
   });
 
   it('fresh install lands at the current schema and already carries the ka_numbers table', () => {
-    expect(db.db.pragma('user_version', { simple: true })).toBe(21);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(22);
 
     const table = db.db.prepare(
       "SELECT name FROM sqlite_master WHERE type='table' AND name='ka_numbers'",
@@ -956,7 +956,7 @@ describe('DashboardDB — V20 ka_numbers table migration (B2 KA-number allocator
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(21);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(22);
 
     const table = db.db.prepare(
       "SELECT name FROM sqlite_master WHERE type='table' AND name='ka_numbers'",
@@ -1049,7 +1049,7 @@ describe('DashboardDB — V21 sync_checkpoints table (A3 sync resume)', () => {
   });
 
   it('fresh install carries the sync_checkpoints table and expiry index', () => {
-    expect(db.db.pragma('user_version', { simple: true })).toBe(21);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(22);
     const tables = db.db.prepare(
       `SELECT name FROM sqlite_master WHERE type='table' AND name='sync_checkpoints'`,
     ).all();
@@ -1115,9 +1115,12 @@ describe('DashboardDB — V21 sync_checkpoints table (A3 sync resume)', () => {
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(21);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(22);
     expect(db.db.prepare(
       `SELECT name FROM sqlite_master WHERE type='table' AND name='sync_checkpoints'`,
+    ).all()).toHaveLength(1);
+    expect(db.db.prepare(
+      `SELECT name FROM sqlite_master WHERE type='table' AND name='runtime_cursors'`,
     ).all()).toHaveLength(1);
   });
 });
@@ -1130,6 +1133,12 @@ describe('DashboardDB — chain RPC cursor stores', () => {
     await store.saveLane('vmReconcile', 5678);
     expect(await store.loadLane('contextGraphDiscovery')).toBe(1234);
     expect(await store.loadLane('vmReconcile')).toBe(5678);
+    expect(db.db.prepare(
+      `SELECT value FROM runtime_cursors
+       WHERE namespace = 'chainEventPoller.cursor'
+         AND scope = 'evm:1:hub=0xabc'
+         AND key = 'contextGraphDiscovery'`,
+    ).get()).toEqual({ value: 1234 });
     expect(await new SqliteChainEventCursorStore(db, { scope: 'evm:2:hub=0xabc' }).loadLane('contextGraphDiscovery')).toBeUndefined();
 
     await store.saveLane('contextGraphDiscovery', 0);
@@ -1142,12 +1151,17 @@ describe('DashboardDB — chain RPC cursor stores', () => {
       `INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)`,
     ).run('chainEventPoller.cursor:evm:1:hub=0xabc:badLane', '0');
     expect(await store.loadLane('badLane')).toBeUndefined();
+    db.db.prepare(
+      `INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)`,
+    ).run('chainEventPoller.cursor:evm:1:hub=0xabc:legacyLane', '2468');
+    expect(await store.loadLane('legacyLane')).toBe(2468);
 
     db.close();
     db = new DashboardDB({ dataDir: dir });
     const reopened = new SqliteChainEventCursorStore(db, { scope: 'evm:1:hub=0xabc' });
     expect(await reopened.loadLane('contextGraphDiscovery')).toBe(1234);
     expect(await reopened.loadLane('vmReconcile')).toBe(5678);
+    expect(await reopened.loadLane('legacyLane')).toBe(2468);
   });
 
   it('persists registry scan cursors by deployment key and ignores corrupt values', async () => {
@@ -1160,6 +1174,12 @@ describe('DashboardDB — chain RPC cursor stores', () => {
 
     await store.save(key, 5000);
     expect(await store.load(key)).toBe(5000);
+    expect(db.db.prepare(
+      `SELECT value FROM runtime_cursors
+       WHERE namespace = 'contextGraphRegistryScan.cursor'
+         AND scope = ?
+         AND key = ?`,
+    ).get(`${key.chainId}:${key.deploymentId}`, key.registryAddress.toLowerCase())).toEqual({ value: 5000 });
     await store.save(key, 0);
     await store.save(key, -1);
     await store.save(key, 1.5);
@@ -1174,11 +1194,19 @@ describe('DashboardDB — chain RPC cursor stores', () => {
       'not-a-number',
     );
     expect(await store.load({ ...key, registryAddress: '0x5555555555555555555555555555555555555555' })).toBeUndefined();
+    db.db.prepare(
+      `INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)`,
+    ).run(
+      `contextGraphRegistryScan.cursor:${key.chainId}:${key.deploymentId}:0x6666666666666666666666666666666666666666`,
+      '6000',
+    );
+    expect(await store.load({ ...key, registryAddress: '0x6666666666666666666666666666666666666666' })).toBe(6000);
 
     db.close();
     db = new DashboardDB({ dataDir: dir });
     const reopened = new SqliteContextGraphRegistryScanCursorStore(db);
     expect(await reopened.load(key)).toBe(5000);
+    expect(await reopened.load({ ...key, registryAddress: '0x6666666666666666666666666666666666666666' })).toBe(6000);
   });
 });
 
@@ -1536,7 +1564,7 @@ describe('DashboardDB — V11→V13 chat schema migration chain', () => {
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(21);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(22);
 
     const cols = (db.db.prepare('PRAGMA table_info(chat_messages)').all() as Array<{ name: string }>)
       .map((c) => c.name);
@@ -1602,7 +1630,7 @@ describe('DashboardDB — V16 notifications.context_graph_id migration (A1)', ()
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(21);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(22);
 
     const cols = (db.db.prepare('PRAGMA table_info(notifications)').all() as Array<{ name: string }>)
       .map((c) => c.name);
@@ -1631,7 +1659,7 @@ describe('DashboardDB — V16 notifications.context_graph_id migration (A1)', ()
     const cols = (db.db.prepare('PRAGMA table_info(notifications)').all() as Array<{ name: string }>)
       .map((c) => c.name);
     expect(cols).toContain('context_graph_id');
-    expect(db.db.pragma('user_version', { simple: true })).toBe(21);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(22);
   });
 
   it('insertNotification writes context_graph_id to the column; omitted → NULL', () => {
@@ -1874,7 +1902,7 @@ describe('DashboardDB — replication telemetry (Phase F)', () => {
     raw.pragma('user_version = 17');
     raw.close();
     const upgraded = new DashboardDB({ dataDir: dir });
-    expect(upgraded.db.pragma('user_version', { simple: true })).toBe(21);
+    expect(upgraded.db.pragma('user_version', { simple: true })).toBe(22);
     // insert works → table exists
     upgraded.insertReplicationEvent({ ts: now, context_graph_id: 'cg', action: 'promote' });
     expect(upgraded.getReplicationSummary(60_000).promotes).toBe(1);

--- a/packages/node-ui/test/messenger-stores.test.ts
+++ b/packages/node-ui/test/messenger-stores.test.ts
@@ -45,9 +45,9 @@ describe('V12 migration', () => {
     // `message_idempotency` table. Both bumps are tested at the
     // DB layer in `db.test.ts`; this assertion just pins that
     // the substrate store fixtures are created against the
-    // current SCHEMA_VERSION (now 21 after A3 added durable
-    // `sync_checkpoints` at migration V21).
-    expect(db.db.pragma('user_version', { simple: true })).toBe(21);
+    // current SCHEMA_VERSION (now 22 after runtime cursors moved to a
+    // dedicated table).
+    expect(db.db.pragma('user_version', { simple: true })).toBe(22);
   });
 });
 

--- a/packages/publisher/src/index.ts
+++ b/packages/publisher/src/index.ts
@@ -260,7 +260,7 @@ export {
   type WorkspacePublicSnapshotStore,
 } from './workspace-snapshot-store.js';
 export { UpdateHandler } from './update-handler.js';
-export { ChainEventPoller, type ChainEventPollerConfig, type OnContextGraphCreated } from './chain-event-poller.js';
+export { ChainEventPoller, type ChainEventPollerConfig, type CursorPersistence, type OnContextGraphCreated } from './chain-event-poller.js';
 export { AccessHandler, type AccessPolicy } from './access-handler.js';
 export { AccessClient, type AccessResult } from './access-client.js';
 export * from './share-batching.js';


### PR DESCRIPTION
## Summary

- Persist ContextGraphNameRegistry historical catch-up progress as a covered-prefix cursor keyed by chain id, deployment id, and registry address.
- Pace daemon startup/fresh-home context-graph catch-up with a bounded page budget while keeping public list-all scans complete by default.
- Wire production SQLite cursor stores into `DKGAgent` and `ChainEventPoller` so daemon restarts reuse lane and registry progress instead of repeating startup scans.
- Preserve correctness on failures: seeded and incremental daemon scans surface partial-prefix results after later-page failures so the agent can process successful pages before the saved cursor is trusted.

## Related

- Chained into PR #1440 (`codex/rpc-call-reduction`).
- Follow-up to the remaining startup catch-up opportunity identified after PR #1461 RPC benchmarking.

## Files changed

| File | What |
|------|------|
| `packages/chain/src/chain-adapter.ts` | Adds registry scan cursor store types and page-budget scan option. |
| `packages/chain/src/evm-adapter-base.ts` | Adds durable registry cursor load/save helpers keyed by deployment and registry. |
| `packages/chain/src/evm-adapter-context-graph.ts` | Resumes daemon scans from durable cursors, applies page budgets, and returns partial-prefix errors on later-page failures. |
| `packages/node-ui/src/db.ts` | Adds SQLite-backed chain-event and registry scan cursor stores using the existing settings table. |
| `packages/cli/src/daemon/lifecycle.ts` | Wires cursor stores into daemon agent creation, adds the startup catch-up page budget, and prevents overlapping chain discovery scans. |
| `packages/agent/src/*` | Forwards registry cursor storage and page-budget scan options; passes lane cursor persistence into `ChainEventPoller`. |
| `packages/*/test/*` | Adds regression coverage for bounded catch-up, durable resume, partial seeded failures, forwarding, wiring, and invalid cursor handling. |

## Test plan

- [x] `pnpm --dir packages/chain exec vitest run --config vitest.unit.config.ts test/context-graph-registry-scan.unit.test.ts --reporter dot`
- [x] `pnpm --dir packages/node-ui exec vitest run test/db.test.ts -t "chain RPC cursor stores" --reporter dot`
- [x] `pnpm --dir packages/cli exec vitest run --config vitest.unit.config.ts ./test/chain-discovery-scan-mode.test.ts --reporter dot`
- [x] `pnpm --dir packages/cli exec vitest run ./test/daemon-startup-validation.test.ts --reporter dot`
- [x] `pnpm --dir packages/agent exec vitest run ./test/context-graph-discovery.test.ts -t "keeps full chain discovery" --reporter dot`
- [x] `pnpm --filter @origintrail-official/dkg-chain build`
- [x] `pnpm --filter @origintrail-official/dkg-publisher build`
- [x] `pnpm --filter @origintrail-official/dkg-node-ui build`
- [x] `pnpm --filter @origintrail-official/dkg-agent build`
- [x] `pnpm --filter @origintrail-official/dkg build`
- [x] `pnpm test:devnet:manifest -- --reporter dot`
- [x] `pnpm exec vitest run --config devnet/rpc-quiet-window/vitest.config.ts -t "parses the committed|reports nodes|fails preflight" --reporter dot`

Live validation after review should include fresh-home startup, same-home restart startup, activity, and post-activity idle windows; the same-home restart first telemetry window is the key startup-catch-up signal.
