### PR TITLE
Codex/base mainnet ack candidate filter

### DIFF
--- a/devnet/ack-candidate-isolation/README.md
+++ b/devnet/ack-candidate-isolation/README.md
@@ -1,0 +1,22 @@
+# ack-candidate-isolation - devnet regression
+
+Read-only live devnet coverage for ACK candidate isolation.
+
+## What it proves
+
+An edge node can have a live transport peer set that includes stale relay peers,
+but ACK candidate ordering must still be bounded to the active network's core
+peer IDs. The test uses node5's generated local-devnet core bootstrap peers as
+the active ACK set, injects the known public Base testnet relay IDs as stale
+connected peers, and verifies the candidate ordering returns only the four
+active devnet cores.
+
+## Run
+
+```bash
+pnpm run build
+./scripts/devnet.sh clean && ./scripts/devnet.sh start 6
+pnpm test:devnet:ack-candidate-isolation
+```
+
+The suite does not publish, restart nodes, or mutate chain state.

--- a/devnet/ack-candidate-isolation/automated.test.ts
+++ b/devnet/ack-candidate-isolation/automated.test.ts
@@ -1,0 +1,144 @@
+/**
+ * ACK candidate isolation - devnet regression.
+ *
+ * Preconditions:
+ *   pnpm run build
+ *   ./scripts/devnet.sh clean && ./scripts/devnet.sh start 6
+ *
+ * This suite is intentionally read-only. It uses the running local devnet's
+ * generated edge-node config to get the active core peer IDs, then injects the
+ * known public Base testnet relay IDs as stale connected peers. That pins the
+ * exact 4 active cores + 3 stale testnet peers pollution shape seen on Base
+ * mainnet without mutating the shared devnet.
+ */
+import { beforeAll, describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  DEVNET_DIR,
+  REPO_ROOT,
+  detectDevnet,
+  fetchRetry,
+  type DevnetNode,
+  type DevnetState,
+} from '../_bootstrap/harness.js';
+import {
+  extractPeerIdsFromMultiaddrs,
+  orderACKCandidatePeerIds,
+} from '../../packages/cli/src/daemon/lifecycle.js';
+
+interface RuntimeConfig {
+  nodeRole?: string;
+  relay?: unknown;
+  bootstrapPeers?: unknown;
+}
+
+interface StatusResponse {
+  peerId?: string;
+  nodeRole?: string;
+  networkId?: string;
+  genesisId?: string;
+}
+
+const UNEXPECTED_TESTNET_SUFFIXES = ['aijsNrWw', 'nWcpzsge', 'Ce8Q82bZ'];
+
+let state: DevnetState;
+let edge: DevnetNode;
+let edgeStatus: StatusResponse;
+let edgeConfig: RuntimeConfig;
+
+function readJson<T>(path: string): T {
+  return JSON.parse(readFileSync(path, 'utf8')) as T;
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((v): v is string => typeof v === 'string') : [];
+}
+
+function loadPublicTestnetPeerIds(): string[] {
+  const cfg = readJson<{ relays?: string[] }>(join(REPO_ROOT, 'network/testnet.json'));
+  return extractPeerIdsFromMultiaddrs(cfg.relays);
+}
+
+function activeDevnetCoreIds(): string[] {
+  const ids = extractPeerIdsFromMultiaddrs(stringArray(edgeConfig.bootstrapPeers));
+  expect(ids, 'node5 bootstrapPeers should be the four local devnet cores').toHaveLength(4);
+  return ids;
+}
+
+async function fetchNodeStatus(node: DevnetNode): Promise<StatusResponse> {
+  const res = await fetchRetry(`http://127.0.0.1:${node.apiPort}/api/status`);
+  if (!res.ok) throw new Error(`node${node.num} /api/status failed: ${res.status}`);
+  return (await res.json()) as StatusResponse;
+}
+
+beforeAll(async () => {
+  const detected = await detectDevnet(6);
+  if (!detected) {
+    throw new Error('Live 6-node devnet not detected. Run ./scripts/devnet.sh start 6 first.');
+  }
+
+  state = detected;
+  edge = state.nodes[5]!;
+  edgeConfig = readJson<RuntimeConfig>(join(DEVNET_DIR, 'node5', 'config.json'));
+  edgeStatus = await fetchNodeStatus(edge);
+}, 60_000);
+
+describe('ACK candidate isolation on devnet', () => {
+  it('devnet edge bootstraps to local cores, not public testnet relay IDs', () => {
+    const bootstrapIds = activeDevnetCoreIds();
+    const publicTestnetIds = loadPublicTestnetPeerIds();
+    const peerBearingConfiguredAddrs = [
+      ...(typeof edgeConfig.relay === 'string' && edgeConfig.relay !== 'none' ? [edgeConfig.relay] : []),
+      ...stringArray(edgeConfig.bootstrapPeers),
+    ];
+    const configuredPeerIds = extractPeerIdsFromMultiaddrs(peerBearingConfiguredAddrs);
+
+    expect(edgeConfig.nodeRole).toBe('edge');
+    expect(edgeStatus.nodeRole).toBe('edge');
+    expect(edgeStatus.peerId, 'node5 status must expose a peerId').toEqual(expect.any(String));
+    expect(bootstrapIds).not.toContain(edgeStatus.peerId);
+    expect(configuredPeerIds.filter((id) => publicTestnetIds.includes(id))).toEqual([]);
+  });
+
+  it('filters the 4 devnet cores + 3 stale testnet peers ACK fallback back to devnet cores', () => {
+    const devnetCoreIds = activeDevnetCoreIds();
+    const publicTestnetIds = loadPublicTestnetPeerIds();
+    const staleTestnetIds = UNEXPECTED_TESTNET_SUFFIXES.map((suffix) => {
+      const peerId = publicTestnetIds.find((id) => id.endsWith(suffix));
+      expect(peerId, `network/testnet.json should still contain ${suffix}`).toBeTruthy();
+      return peerId!;
+    });
+    const selfPeerId = edgeStatus.peerId!;
+
+    const connectedPeerIds = [
+      selfPeerId,
+      devnetCoreIds[2]!,
+      staleTestnetIds[0]!,
+      staleTestnetIds[1]!,
+      devnetCoreIds[0]!,
+      staleTestnetIds[2]!,
+      devnetCoreIds[1]!,
+      devnetCoreIds[3]!,
+    ];
+
+    const nonSelfConnectedPeers = connectedPeerIds.filter((id) => id !== selfPeerId);
+    expect(nonSelfConnectedPeers).toHaveLength(7);
+    expect(nonSelfConnectedPeers.filter((id) => staleTestnetIds.includes(id))).toHaveLength(3);
+
+    const filtered = orderACKCandidatePeerIds({
+      connectedPeerIds,
+      selfPeerId,
+      knownCorePeerIds: new Set([devnetCoreIds[2]!, staleTestnetIds[0]!]),
+      ackCandidatePeerIds: devnetCoreIds,
+    });
+
+    expect(filtered).toEqual([
+      devnetCoreIds[2],
+      devnetCoreIds[0],
+      devnetCoreIds[1],
+      devnetCoreIds[3],
+    ]);
+    expect(filtered.filter((id) => staleTestnetIds.includes(id))).toEqual([]);
+  });
+});

--- a/devnet/ack-candidate-isolation/automated.test.ts
+++ b/devnet/ack-candidate-isolation/automated.test.ts
@@ -12,7 +12,7 @@
  * mainnet without mutating the shared devnet.
  */
 import { beforeAll, describe, expect, it } from 'vitest';
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import {
   DEVNET_DIR,
@@ -99,6 +99,27 @@ describe('ACK candidate isolation on devnet', () => {
     expect(edgeStatus.peerId, 'node5 status must expose a peerId').toEqual(expect.any(String));
     expect(bootstrapIds).not.toContain(edgeStatus.peerId);
     expect(configuredPeerIds.filter((id) => publicTestnetIds.includes(id))).toEqual([]);
+  });
+
+  it('does not install the default public testnet ACK allowlist in the local devnet relay topology', () => {
+    const node1LogPath = join(DEVNET_DIR, 'node1', 'daemon.log');
+    const node5LogPath = join(DEVNET_DIR, 'node5', 'daemon.log');
+    const node1Config = readJson<RuntimeConfig>(join(DEVNET_DIR, 'node1', 'config.json'));
+    expect(existsSync(node1LogPath), 'node1 daemon.log should exist').toBe(true);
+    expect(existsSync(node5LogPath), 'node5 daemon.log should exist').toBe(true);
+    const node1Log = readFileSync(node1LogPath, 'utf8');
+    const node5Log = readFileSync(node5LogPath, 'utf8');
+
+    expect(node1Config.relay).toBe('none');
+    expect(typeof edgeConfig.relay).toBe('string');
+    expect(edgeConfig.relay).toMatch(/^\/ip4\/127\.0\.0\.1\/tcp\//);
+    expect(node1Log).toContain('Relay disabled (config.relay = "none")');
+    for (const log of [node1Log, node5Log]) {
+      expect(log).not.toMatch(/ACK candidate peer allowlist: .*network config/);
+      for (const suffix of UNEXPECTED_TESTNET_SUFFIXES) {
+        expect(log).not.toContain(suffix);
+      }
+    }
   });
 
   it('filters the 4 devnet cores + 3 stale testnet peers ACK fallback back to devnet cores', () => {

--- a/devnet/ack-candidate-isolation/package.json
+++ b/devnet/ack-candidate-isolation/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@origintrail-official/dkg-devnet-ack-candidate-isolation",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test:devnet": "vitest run --config vitest.config.ts"
+  },
+  "dependencies": {
+    "ethers": "^6.16.0"
+  },
+  "devDependencies": {
+    "vitest": "^4.0.18"
+  }
+}

--- a/devnet/ack-candidate-isolation/vitest.config.ts
+++ b/devnet/ack-candidate-isolation/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'node:path';
+
+const automatedTest = resolve(import.meta.dirname, 'automated.test.ts').replace(/\\/g, '/');
+
+export default defineConfig({
+  test: {
+    include: [automatedTest],
+    testTimeout: 120_000,
+    hookTimeout: 60_000,
+    pool: 'forks',
+    sequence: { concurrent: false },
+    globals: false,
+  },
+  resolve: {
+    modules: [resolve(import.meta.dirname, '../../node_modules'), 'node_modules'],
+  },
+});

--- a/devnet/suites.json
+++ b/devnet/suites.json
@@ -12,6 +12,7 @@
     "pr1370-admin-op-wallet"
   ],
   "all": [
+    "ack-candidate-isolation",
     "agent-provenance",
     "conviction-lazy-settle",
     "core-peers-features",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "test:devnet:conviction-lazy-settle": "vitest run --config devnet/conviction-lazy-settle/vitest.config.ts",
     "test:devnet:rfc51-publishing-allocation": "vitest run --config devnet/rfc51-publishing-allocation/vitest.config.ts",
     "test:devnet:core-peers-features": "vitest run --config devnet/core-peers-features/vitest.config.ts",
+    "test:devnet:ack-candidate-isolation": "vitest run --config devnet/ack-candidate-isolation/vitest.config.ts",
     "test:devnet:edge-update-flow": "vitest run --config devnet/edge-update-flow/vitest.config.ts",
     "test:devnet:greenfield-10min": "vitest run --config devnet/greenfield-10min/vitest.config.ts",
     "test:devnet:rich-scenario": "vitest run --config devnet/rich-scenario/vitest.config.ts",

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -894,6 +894,15 @@ export interface DKGAgentConfig {
   bootstrapPeers?: string[];
   /** Multiaddrs of relay nodes for NAT traversal. */
   relayPeers?: string[];
+  /**
+   * Peer IDs that are eligible ACK candidates for the selected chain/network.
+   *
+   * When set, ACK collection may still use identify-time `knownCorePeerIds`
+   * as a fast path, but the below-quorum fallback must not widen beyond this
+   * set. This keeps stale bootstrap/preferred-relay connections from other
+   * networks out of the StorageACK candidate pool.
+   */
+  ackCandidatePeerIds?: string[];
   /** Multiaddrs to announce to the network (for VPS/cloud nodes with a public IP not on the interface). */
   announceAddresses?: string[];
   skills?: Array<{

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1432,9 +1432,11 @@ export class DKGAgent extends DKGAgentBase {
    *
    * Fix: only trust the confirmed-core subset when it can actually
    * satisfy the quorum. Below that, return confirmed cores FIRST
-   * followed by every other connected peer — edge nodes fail fast at
-   * protocol negotiation (no handler registered), so over-asking is
-   * cheap, while under-asking is fatal.
+   * followed by the remaining connected ACK-eligible peers. On configured
+   * public networks the daemon supplies `ackCandidatePeerIds` from the
+   * selected network relays, so stale preferred/bootstrap connections from
+   * another network cannot enter the ACK round. Dev/no-network configs keep
+   * the legacy all-connected fallback.
    *
    * Folded-private publishes require `PROTOCOL_STORAGE_ACK_V2` because their
    * PublishIntent carries field 20 (`privateMerkleRoots`). Prefer peers that
@@ -1461,6 +1463,7 @@ export class DKGAgent extends DKGAgentBase {
     return selectACKCandidatePeers({
       connectedPeers: peers.map(p => p.toString()),
       selfPeerId: this.peerId,
+      ackCandidatePeerIds: this.config.ackCandidatePeerIds,
       knownCorePeerIds: this.knownCorePeerIds,
       knownCorePeerIdsV2: this.knownCorePeerIdsV2,
       requiredACKs: this.lastKnownRequiredACKs ?? DEFAULT_REQUIRED_ACKS,

--- a/packages/agent/test/ack-candidate-pool.test.ts
+++ b/packages/agent/test/ack-candidate-pool.test.ts
@@ -18,6 +18,7 @@ type AgentInternals = {
     };
   };
   peerId: string;
+  config: { ackCandidatePeerIds?: string[] };
   knownCorePeerIds: Set<string>;
   knownCorePeerIdsV2: Set<string>;
   lastKnownRequiredACKs?: number;
@@ -32,11 +33,13 @@ async function buildAgent(opts: {
   confirmedCores: string[];
   connected: string[];
   lastKnownRequiredACKs?: number;
+  ackCandidatePeerIds?: string[];
 }): Promise<AgentInternals> {
   const agent = await DKGAgent.create({
     name: 'AckPoolProbe',
     store: new OxigraphStore(),
     chainAdapter: new MockChainAdapter(),
+    ackCandidatePeerIds: opts.ackCandidatePeerIds,
   });
   const internals = agent as unknown as AgentInternals;
   internals.node = {
@@ -86,6 +89,17 @@ describe('getACKCandidatePeers — quorum-aware confirmed-core shortcut (#1093 /
     });
     // 4 confirmed ≥ quorum 4 → trust the confirmed-core subset.
     expect(at.getACKCandidatePeers()).toEqual(CORE);
+  });
+
+  it('with a configured ACK allowlist, below-quorum fallback excludes connected foreign-network peers', async () => {
+    const foreign = ['testnet-core-1', 'testnet-core-2', 'testnet-core-3'];
+    const a = await buildAgent({
+      confirmedCores: [CORE[2]],
+      connected: [CORE[2], ...foreign, CORE[0], CORE[1], CORE[3]],
+      ackCandidatePeerIds: CORE,
+    });
+
+    expect(a.getACKCandidatePeers()).toEqual([CORE[2], CORE[0], CORE[1], CORE[3]]);
   });
 
   it('runtime quorum below default (2): 2 confirmed cores already satisfy it', async () => {

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
   test: {
     include: [
       "test/endorse.test.ts",
+      "test/ack-candidate-pool.test.ts",
       "test/e2e-dht-dial.test.ts",
       "test/generic-sql-source.test.ts",
       "test/imported-artifact.test.ts",

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -606,6 +606,66 @@ export function mergePreferredRelays(input: {
   };
 }
 
+export function extractPeerIdFromMultiaddr(raw: string): string | null {
+  const parts = raw.split('/').filter((part) => part.length > 0);
+  const idx = parts.indexOf('p2p');
+  if (idx < 0) return null;
+  return parts[idx + 1]?.trim() || null;
+}
+
+export function extractPeerIdsFromMultiaddrs(addrs: readonly string[] | undefined): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const raw of addrs ?? []) {
+    const peerId = extractPeerIdFromMultiaddr(raw);
+    if (!peerId || seen.has(peerId)) continue;
+    seen.add(peerId);
+    out.push(peerId);
+  }
+  return out;
+}
+
+export function resolveACKCandidatePeerIds(input: {
+  usingNetworkRelays: boolean;
+  networkRelays: readonly string[] | undefined;
+}): string[] {
+  if (!input.usingNetworkRelays) return [];
+  return extractPeerIdsFromMultiaddrs(input.networkRelays);
+}
+
+export function orderACKCandidatePeerIds(input: {
+  connectedPeerIds: readonly string[];
+  selfPeerId: string;
+  knownCorePeerIds?: ReadonlySet<string>;
+  ackCandidatePeerIds?: readonly string[];
+}): string[] {
+  const connected = input.connectedPeerIds.filter((id) => id !== input.selfPeerId);
+  const allowedACKPeers = new Set(
+    (input.ackCandidatePeerIds ?? []).map((id) => id.trim()).filter((id) => id.length > 0),
+  );
+  const eligible = allowedACKPeers.size > 0
+    ? connected.filter((id) => allowedACKPeers.has(id))
+    : connected;
+  const knownCorePeerIds = input.knownCorePeerIds;
+
+  if (allowedACKPeers.size > 0) {
+    const confirmed = knownCorePeerIds
+      ? eligible.filter((id) => knownCorePeerIds.has(id))
+      : [];
+    const rest = knownCorePeerIds
+      ? eligible.filter((id) => !knownCorePeerIds.has(id))
+      : eligible;
+    return [...confirmed, ...rest];
+  }
+
+  if (knownCorePeerIds && knownCorePeerIds.size > 0) {
+    const filtered = connected.filter((id) => knownCorePeerIds.has(id));
+    if (filtered.length > 0) return filtered;
+  }
+
+  return connected;
+}
+
 export function shouldUseIncrementalChainDiscoveryScan(input: {
   run: number;
   watermarkSeeded: boolean;
@@ -1261,6 +1321,7 @@ export async function runDaemonInner(
   // "none" disables relay entirely (used by devnet relay nodes to prevent
   // cross-network leakage into testnet).
   let relayPeers: string[] | undefined;
+  let usingNetworkRelays = false;
   if (config.relay === "none") {
     relayPeers = undefined;
     log(
@@ -1270,7 +1331,17 @@ export async function runDaemonInner(
     relayPeers = [config.relay];
   } else if (network?.relays?.length) {
     relayPeers = network.relays;
+    usingNetworkRelays = true;
     log(`Using relay(s) from network config (${network.networkName})`);
+  }
+  const ackCandidatePeerIds = resolveACKCandidatePeerIds({
+    usingNetworkRelays,
+    networkRelays: network?.relays,
+  });
+  if (ackCandidatePeerIds.length > 0) {
+    log(
+      `ACK candidate peer allowlist: ${ackCandidatePeerIds.length} peer(s) from network config (${network?.networkName ?? "unknown"})`,
+    );
   }
 
   // rc.9 PR-7 — operator-preferred relays. See `mergePreferredRelays`
@@ -1389,6 +1460,7 @@ export async function runDaemonInner(
     dataDir: dkgDir(),
     bootstrapPeers: config.bootstrapPeers,
     relayPeers,
+    ackCandidatePeerIds: ackCandidatePeerIds.length > 0 ? ackCandidatePeerIds : undefined,
     announceAddresses: config.announceAddresses,
     nodeRole: role,
     relayServerCapacity: config.relayServerCapacity,
@@ -1841,8 +1913,7 @@ export async function runDaemonInner(
               getConnectedCorePeers: (protocol?: string) => {
                 const allPeers = agent.node.libp2p
                   .getPeers()
-                  .map((p) => p.toString())
-                  .filter((id) => id !== agent.peerId);
+                  .map((p) => p.toString());
                 const knownCorePeerIds = (agent as any).knownCorePeerIds as
                   | Set<string>
                   | undefined;
@@ -1851,10 +1922,12 @@ export async function runDaemonInner(
                   | undefined;
                 return selectACKCandidatePeers({
                   connectedPeers: allPeers,
+                  selfPeerId: agent.peerId,
                   knownCorePeerIds,
                   knownCorePeerIdsV2,
                   requiredACKs: (agent as any).lastKnownRequiredACKs ?? DEFAULT_REQUIRED_ACKS,
                   protocol,
+                  ackCandidatePeerIds,
                 });
               },
               log,

--- a/packages/cli/test/preferred-relays.test.ts
+++ b/packages/cli/test/preferred-relays.test.ts
@@ -6,7 +6,13 @@
 // pin the merge contract here.
 
 import { describe, it, expect } from 'vitest';
-import { mergePreferredRelays } from '../src/daemon/lifecycle.js';
+import {
+  extractPeerIdFromMultiaddr,
+  extractPeerIdsFromMultiaddrs,
+  mergePreferredRelays,
+  orderACKCandidatePeerIds,
+  resolveACKCandidatePeerIds,
+} from '../src/daemon/lifecycle.js';
 
 const RELAY_PUB_A = '/ip4/10.0.0.1/tcp/4001/p2p/12D3KooWPubA...';
 const RELAY_PUB_B = '/ip4/10.0.0.2/tcp/4001/p2p/12D3KooWPubB...';
@@ -151,5 +157,78 @@ describe('mergePreferredRelays (rc.9 PR-7)', () => {
     expect(result.relayPeers).toEqual([RELAY_PUB_A]);
     expect(result.configCount).toBe(0);
     expect(result.preferredCount).toBe(0);
+  });
+});
+
+describe('ACK peer-id extraction from network relays', () => {
+  it('extracts and dedupes relay peer IDs in declaration order', () => {
+    expect(extractPeerIdsFromMultiaddrs([
+      '/ip4/10.0.0.1/tcp/4001/p2p/12D3KooWBaseA',
+      '/dns4/relay.example.com/tcp/9090/ws/p2p/12D3KooWBaseB',
+      '/ip4/10.0.0.1/tcp/4001/p2p/12D3KooWBaseA',
+      '/ip4/10.0.0.3/tcp/4001',
+    ])).toEqual(['12D3KooWBaseA', '12D3KooWBaseB']);
+  });
+
+  it('returns the first p2p component for circuit relay addresses', () => {
+    expect(
+      extractPeerIdFromMultiaddr(
+        '/ip4/10.0.0.1/tcp/4001/p2p/12D3KooWRelay/p2p-circuit/p2p/12D3KooWTarget',
+      ),
+    ).toBe('12D3KooWRelay');
+  });
+});
+
+describe('resolveACKCandidatePeerIds', () => {
+  it('uses network relay IDs as ACK allowlist when relays are enabled', () => {
+    expect(resolveACKCandidatePeerIds({
+      usingNetworkRelays: true,
+      networkRelays: [
+        '/ip4/10.0.0.1/tcp/4001/p2p/base-core-1',
+        '/ip4/10.0.0.2/tcp/4001/p2p/base-core-2',
+      ],
+    })).toEqual(['base-core-1', 'base-core-2']);
+  });
+
+  it('does not inherit public network relays when config.relay disables relays', () => {
+    expect(resolveACKCandidatePeerIds({
+      usingNetworkRelays: false,
+      networkRelays: [
+        '/ip4/157.180.37.169/tcp/9090/p2p/12D3KooWAbLiM6Xy2TfXtFpUrXqttnTSuctW8Lo1mkauaijsNrWw',
+        '/ip4/178.156.252.147/tcp/9090/p2p/12D3KooWPyTpqBBtU1AvzSsd5rWXCQzFcGtG44qDmeYenWcpzsge',
+        '/ip4/49.12.4.64/tcp/9090/p2p/12D3KooWJqhnnfouiNRUyJBEREpuKtV4A448LUbS6JiVCe8Q82bZ',
+      ],
+    })).toEqual([]);
+  });
+
+  it('does not inherit public network relays when config.relay is an explicit local relay', () => {
+    expect(resolveACKCandidatePeerIds({
+      usingNetworkRelays: false,
+      networkRelays: [
+        '/ip4/157.180.37.169/tcp/9090/p2p/12D3KooWAbLiM6Xy2TfXtFpUrXqttnTSuctW8Lo1mkauaijsNrWw',
+      ],
+    })).toEqual([]);
+  });
+});
+
+describe('orderACKCandidatePeerIds', () => {
+  it('filters daemon async ACK fallback to active-network candidates when an allowlist is configured', () => {
+    const base = ['base-core-1', 'base-core-2', 'base-core-3', 'base-core-4'];
+    const testnet = ['testnet-core-1', 'testnet-core-2', 'testnet-core-3'];
+
+    expect(orderACKCandidatePeerIds({
+      connectedPeerIds: ['self', base[2], ...testnet, base[0], base[1], base[3]],
+      selfPeerId: 'self',
+      knownCorePeerIds: new Set([base[2], testnet[0]]),
+      ackCandidatePeerIds: base,
+    })).toEqual([base[2], base[0], base[1], base[3]]);
+  });
+
+  it('preserves legacy all-connected fallback when no ACK allowlist is configured', () => {
+    expect(orderACKCandidatePeerIds({
+      connectedPeerIds: ['self', 'edge-1', 'edge-2'],
+      selfPeerId: 'self',
+      knownCorePeerIds: new Set(),
+    })).toEqual(['edge-1', 'edge-2']);
   });
 });

--- a/packages/cli/vitest.unit.config.ts
+++ b/packages/cli/vitest.unit.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
       ? ['test/daemon-http-behavior-extra.test.ts']
       : [
           'test/api-client.test.ts',
+          'test/preferred-relays.test.ts',
           'test/reconcile-503-mapping.test.ts',
           'test/config.test.ts',
           'test/status-route-rpc.test.ts',

--- a/packages/publisher/src/ack-peer-selection.ts
+++ b/packages/publisher/src/ack-peer-selection.ts
@@ -2,6 +2,7 @@ import { PROTOCOL_STORAGE_ACK_V2 } from '@origintrail-official/dkg-core';
 
 export interface ACKCandidatePeerSelectionInput {
   connectedPeers: readonly string[];
+  ackCandidatePeerIds?: readonly string[];
   knownCorePeerIds?: ReadonlySet<string>;
   knownCorePeerIdsV2?: ReadonlySet<string>;
   requiredACKs: number;
@@ -11,24 +12,30 @@ export interface ACKCandidatePeerSelectionInput {
 
 export function selectACKCandidatePeers(input: ACKCandidatePeerSelectionInput): string[] {
   const connected = input.connectedPeers.filter((id) => id !== input.selfPeerId);
+  const allowedACKPeers = new Set(
+    (input.ackCandidatePeerIds ?? []).map((id) => id.trim()).filter((id) => id.length > 0),
+  );
+  const eligible = allowedACKPeers.size > 0
+    ? connected.filter((id) => allowedACKPeers.has(id))
+    : connected;
   const confirmedCore = input.knownCorePeerIds
-    ? connected.filter((id) => input.knownCorePeerIds!.has(id))
+    ? eligible.filter((id) => input.knownCorePeerIds!.has(id))
     : [];
 
   if (input.protocol === PROTOCOL_STORAGE_ACK_V2) {
     const v2Advertised = input.knownCorePeerIdsV2
-      ? connected.filter((id) => input.knownCorePeerIdsV2!.has(id))
+      ? eligible.filter((id) => input.knownCorePeerIdsV2!.has(id))
       : [];
     const v2Set = new Set(v2Advertised);
     const remainingConfirmedCore = confirmedCore.filter((id) => !v2Set.has(id));
     const seen = new Set([...v2Advertised, ...remainingConfirmedCore]);
-    const rest = connected.filter((id) => !seen.has(id));
+    const rest = eligible.filter((id) => !seen.has(id));
     // Identify metadata can be stale. Prefer advertised V2 peers, but keep
     // fallback candidates so wire negotiation, not cached metadata, is the gate.
     return [...v2Advertised, ...remainingConfirmedCore, ...rest];
   }
 
   if (confirmedCore.length >= input.requiredACKs) return confirmedCore;
-  const rest = connected.filter((id) => !input.knownCorePeerIds?.has(id));
+  const rest = eligible.filter((id) => !input.knownCorePeerIds?.has(id));
   return [...confirmedCore, ...rest];
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,16 @@ importers:
         specifier: ^4.0.18
         version: 4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.19.11)(happy-dom@20.8.9(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
+  devnet/ack-candidate-isolation:
+    dependencies:
+      ethers:
+        specifier: ^6.16.0
+        version: 6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+    devDependencies:
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.19.11)(happy-dom@20.8.9(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
+
   devnet/agent-provenance:
     dependencies:
       ethers:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ packages:
   - "packages/cli/test-fixtures/sample-kafka-plugin"
   - "packages/cli/test-fixtures/sample-kafka-extension"
   - "demo"
+  - "devnet/ack-candidate-isolation"
   - "devnet/agent-provenance"
   - "devnet/core-peers-features"
   - "devnet/v10-core-flows"


### PR DESCRIPTION
## Summary

Fixes ACK candidate pollution where an edge node on a configured network could request StorageACKs from connected peers outside the active network relay set.

The issue was not “wrong network config loaded.” `mainnet-base` could load correctly, but stale preferred/bootstrap/transport peers could still enter the ACK candidate fallback path when confirmed core discovery was below quorum.

## Changes

- Derive `ackCandidatePeerIds` from the active `network.relays` before preferred relay merging.
- Pass that ACK allowlist into `DKGAgent`.
- Filter `getACKCandidatePeers()` fallback candidates through the allowlist when configured.
- Preserve legacy all-connected fallback only when no ACK allowlist exists.
- Keep async publisher ACK candidate ordering aligned with the same active-network allowlist.
- Add logs for the effective ACK candidate allowlist source/count.
- Add unit coverage for:
  - relay peer ID extraction
  - preferred relay pollution not expanding ACK eligibility
  - agent fallback filtering of foreign/testnet peers
- Add live devnet regression suite:
  - `devnet/ack-candidate-isolation`
  - models the “4 active cores + 3 stale testnet peers” shape
  - verifies ACK ordering returns only active devnet cores

## Test Plan

- `CI=true corepack pnpm test:devnet:manifest`
- `CI=true corepack pnpm --dir packages/agent exec vitest run --config vitest.unit.config.ts test/ack-candidate-pool.test.ts`
- `CI=true corepack pnpm --dir packages/cli exec vitest run --config vitest.unit.config.ts test/preferred-relays.test.ts`
- Live six-node devnet:
  - `CI=true DEVNET_RPC=http://127.0.0.1:23100 corepack pnpm test:devnet:ack-candidate-isolation`