### PR TITLE
fix(#1464): WM→SWM promote e2e flake — dedicated-CG isolation + un-masking

### DIFF
--- a/packages/cli/src/daemon/worker/async-promote-worker.ts
+++ b/packages/cli/src/daemon/worker/async-promote-worker.ts
@@ -144,7 +144,13 @@ export type ClassifiedPromoteError = {
  */
 export function classifyPromoteError(err: unknown): ClassifiedPromoteError {
   const raw = err instanceof Error ? err.message : String(err);
-  const message = (raw ?? '').toLowerCase();
+  // #1464 — strip a leading diagnostic "[promote:<step>] " tag (added by the publisher's
+  // promote step-tagging) BEFORE substring-classifying, so a step LABEL can never inject a
+  // classifier trigger token (e.g. the step "encodeWorkspaceGossipPayload" would otherwise make
+  // every error from it match the "gossip" cap-check). We classify on the ORIGINAL error text;
+  // the tag stays on the operator-facing message. The tag is single (idempotent, innermost wins).
+  const untagged = (raw ?? '').replace(/^\[promote:[^\]]*\]\s*/, '');
+  const message = untagged.toLowerCase();
   const code =
     err && typeof err === 'object' && 'code' in err
       ? String((err as { code?: unknown }).code ?? '').toLowerCase()

--- a/packages/cli/test/async-promote-worker.test.ts
+++ b/packages/cli/test/async-promote-worker.test.ts
@@ -87,6 +87,24 @@ describe('classifyPromoteError', () => {
     });
   });
 
+  // #1464 — the publisher tags a promote error's message with a "[promote:<step>] " prefix so the
+  // failing step is NAMED. The step LABEL must never change the retry classification: the classifier
+  // strips the tag before substring-matching. Regression for the gate-caught collision where the
+  // step label "encodeWorkspaceGossipPayload" injected the "gossip" trigger token, flipping a
+  // transient error to non-retryable cap_exceeded. Fails without the tag-strip.
+  it('#1464 — strips the [promote:<step>] tag before classifying (label tokens do not change the verdict)', () => {
+    // A transient error tagged at the gossip-encode step (label contains "gossip") stays retryable.
+    expect(classifyPromoteError(new Error('[promote:encodeWorkspaceGossipPayload] rate limit exceeded — request timed out')))
+      .toEqual({ classification: 'transient', retryable: true });
+    // Identical to the same error untagged.
+    expect(classifyPromoteError(new Error('rate limit exceeded — request timed out')))
+      .toEqual({ classification: 'transient', retryable: true });
+    // A GENUINE gossip-cap error (token in the ORIGINAL message) still classifies cap_exceeded even
+    // when tagged — stripping removes only the injected prefix, never real tokens.
+    expect(classifyPromoteError(new Error('[promote:assertionScopedQuads] Promoted assertion too large for gossip (limit 10 MB)')))
+      .toEqual({ classification: 'cap_exceeded', retryable: false });
+  });
+
   it('classifies timeout errors as transient', () => {
     expect(classifyPromoteError(new Error('Operation timed out'))).toEqual({
       classification: 'transient',

--- a/packages/node-ui/e2e/specs/devnet/wm-swm-vm-ui-cycle.devnet.spec.ts
+++ b/packages/node-ui/e2e/specs/devnet/wm-swm-vm-ui-cycle.devnet.spec.ts
@@ -80,11 +80,14 @@ test.beforeAll(async () => {
       '(set in scripts/devnet.sh); got a non-SPARQL-over-HTTP backend instead',
   ).toBe('oxigraph-server');
 
-  // `/api/status` answering does NOT mean the seeded primary context graph has
-  // finished registering — on a cold boot `listContextGraphs()` can briefly
-  // return [] and make this spec falsely skip with "No context graphs". Poll for
-  // a bounded window so a still-propagating CG isn't mistaken for an empty
-  // devnet; a genuinely-empty operator devnet still falls through to the skip.
+  // Devnet-HEALTH gate (unchanged intent): a settled CI devnet always has the
+  // seeded primary CG registered by global-setup, so an empty list means a
+  // partitioned mesh / dropped CG — keep failing loudly (CI) / skipping (local).
+  // `/api/status` answering does NOT prove the seed finished, so on a cold boot
+  // `listContextGraphs()` can briefly return []; poll a bounded window before
+  // deciding. NOTE: this spec no longer promotes on the shared seeded CG
+  // (`cgs[0]`); it provisions its OWN dedicated CG below (#1464). The gate stays
+  // purely as a "the devnet booted correctly" health check.
   let cgs = await listContextGraphs(1);
   if (cgs.length === 0) {
     const deadline = Date.now() + 30_000;
@@ -94,8 +97,69 @@ test.beforeAll(async () => {
     }
   }
   requireDevnetPrecondition(test, cgs.length === 0, 'No context graphs on devnet');
-  run.cgId = cgs[0]!.id;
-  run.cgName = cgs[0]!.name;
+
+  // #1464 — provision a DEDICATED, unique-per-run context graph so the UI's
+  // promote-all (`widget-promote-all-btn`) sees ONLY this spec's own clean,
+  // default-graph assertion. On the SHARED seeded CG the bulk promote iterates
+  // EVERY WM assertion in the CG and aborts the whole batch if any one throws
+  // (layer-widgets.tsx); sibling specs leave foreign `_named_graph` WM
+  // assertions there, which the promote guard KA_NAMED_GRAPH_SHARE_UNSUPPORTED
+  // (dkg-publisher.ts) correctly rejects → the fixture's own root failed to
+  // migrate INTERMITTENTLY (depends on test ordering). A private, single-
+  // assertion CG removes that cross-test coupling entirely.
+  //
+  // LOCAL create only (no `register`): WM import + WM→SWM promote are local
+  // operations that need no on-chain registration (only the deferred VM-publish
+  // `fixme` below would). The CG is curated by THIS node's agent — the same
+  // identity that curates the seeded CGs (both go through the shared devnet auth
+  // token) — so it renders under the browser's "My Context Graphs" (curator
+  // match / `callerInvolved`), exactly like `devnet-test`. A plain-slug id
+  // (matching the seeded `devnet-test` shape) keeps the
+  // `did:dkg:context-graph:<id>/...` graph URIs the layer-count helpers build
+  // well-formed.
+  //
+  // `accessPolicy: 0` (OPEN) matches the seeded devnet CGs on purpose: the
+  // daemon's context-graph listing DROPS private/unknown-privacy rows when the
+  // caller has no resolvable wallet (dkg-agent-cg-resolve.ts) — only `public`
+  // rows survive that branch. Creating open makes this CG a faithful clone of
+  // `devnet-test`, so it can't be silently filtered out of either the list the
+  // poll below reads or the one the browser reads, regardless of how the devnet
+  // auth token resolves. (Open vs curated has no effect on the local WM→SWM
+  // promote this spec exercises.)
+  const stamp = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const dedicatedCgId = `wm-swm-ui-cycle-1464-${stamp}`;
+  const dedicatedCgName = `WM-SWM UI Cycle 1464 ${stamp}`;
+  const createRes = await devnetApiFetch('/api/context-graph/create', {
+    method: 'POST',
+    nodeNum: 1,
+    body: JSON.stringify({ id: dedicatedCgId, name: dedicatedCgName, accessPolicy: 0 }),
+  });
+  if (!createRes.ok) {
+    const body = await createRes.text().catch(() => '');
+    throw new Error(`dedicated CG create failed: ${createRes.status} ${body}`);
+  }
+
+  // The daemon lists a CG only once it is persisted AND passes the caller-scoped
+  // visibility filter (curator === this node's agent ⇒ `callerInvolved`). Poll
+  // the SAME listing the browser reads so the first `shell.goto()` can't race
+  // the create; if it never lists, fail HERE with a clear message instead of
+  // surfacing later as a confusing `openProjectTab` timeout.
+  //
+  // CLEANUP: intentionally none. There is no CG-definition delete/drop route
+  // (only `/api/context-graph/subscriptions` DELETE tears down subscriptions),
+  // so an afterAll would have nothing to call. It's safe to leave the CG: it's
+  // unique per run so it can't contaminate the shared seeded CG, and CI tears
+  // the whole devnet down after the run.
+  await expect(async () => {
+    const list = await listContextGraphs(1);
+    expect(
+      list.some((c) => c.id === dedicatedCgId),
+      `dedicated CG ${dedicatedCgId} not yet visible in the node's context-graph list`,
+    ).toBe(true);
+  }).toPass({ timeout: 30_000, intervals: [500, 1000, 2000] });
+
+  run.cgId = dedicatedCgId;
+  run.cgName = dedicatedCgName;
 });
 
 async function openProjectTab(page: Page, name: string) {
@@ -238,19 +302,20 @@ test.describe('WM → SWM → VM via the UI', () => {
   });
 
   // DEFERRED (OriginTrail/dkg#966): the SWM → VM publish step is a browser-
-  // coverage gap, NOT the promote bug this spec proves. Both the project-view
-  // bulk "Publish to Verifiable Memory" control (`widget-publish-vm-btn`) and the
-  // `PublishPanel` in `MemoryLayerView` now publish EVERY selected SWM assertion
-  // as its own on-chain Knowledge Asset via the canonical per-KA /vm/publish
-  // (Design B, any entity count). On the shared seeded devnet CG (~25 SWM roots)
-  // that fires ~25 real on-chain mints — too slow/flaky for a browser e2e, and it
-  // touches roots this spec doesn't own. Neither surface offers a click-path to
-  // publish ONLY this spec's imported root, so there is no clean single-assertion
-  // target. End-to-end on-chain mint is already verified by the API-driven
-  // sibling spec (`wm-swm-vm-lifecycle.devnet.spec`). Kept as `fixme` until this
-  // spec provisions its own dedicated single-assertion CG so the bulk publish
-  // maps 1:1 to our root. The import → promote steps above are the asserting
-  // cycle for the blank-node fix.
+  // coverage gap, NOT the promote bug this spec proves. The project-view bulk
+  // "Publish to Verifiable Memory" control (`widget-publish-vm-btn`) publishes
+  // every selected SWM assertion as its own on-chain Knowledge Asset via the
+  // canonical per-KA /vm/publish. Now that this spec runs on its OWN dedicated,
+  // single-assertion CG (see beforeAll), that bulk publish WOULD map 1:1 to our
+  // one root — but the dedicated CG is created LOCAL-ONLY (unregistered), and a
+  // VM publish requires the CG to be registered on-chain AND ACK quorum from
+  // connected core peers. Registering + funding + a real mint from the browser
+  // is a heavier, slower flow than this promote-focused spec should own, and its
+  // end-to-end on-chain mint is already verified by the API-driven sibling spec
+  // (`wm-swm-vm-lifecycle.devnet.spec`). Kept as `fixme`: un-deferring it means
+  // registering this CG on-chain (e.g. create with `register: true` + a
+  // `waitForConnectedPeers` gate) first. The import → promote steps above are
+  // the asserting cycle for the blank-node fix.
   test.fixme('publishes SWM → VM via the UI and the entity lands in Verifiable Memory', async ({ shell, page }) => {
     test.skip(!run.rootUri, 'Promote step did not run');
     await shell.goto();

--- a/packages/node-ui/e2e/specs/devnet/wm-swm-vm-ui-cycle.devnet.spec.ts
+++ b/packages/node-ui/e2e/specs/devnet/wm-swm-vm-ui-cycle.devnet.spec.ts
@@ -114,34 +114,28 @@ async function openImportModal(page: Page) {
   await importBtn.click();
 }
 
-/** A promote control on whichever layer-view surface renders (testid-agnostic). */
+// #1464 — pruned the dead `.or()` fallbacks: the list-*/mlv-* testids exist nowhere in the
+// codebase; only the widget surface renders. Keeping them made the readers surface-agnostic in
+// name only and muddied WHICH component actually rendered.
 function promoteControl(page: Page) {
-  return page
-    .getByTestId('widget-promote-all-btn')
-    .or(page.getByTestId('list-promote-all-btn'))
-    .or(page.getByTestId('mlv-promote-all-btn'));
+  return page.getByTestId('widget-promote-all-btn');
 }
 
-/** A publish control on whichever layer-view surface renders. */
 function publishControl(page: Page) {
-  return page
-    .getByTestId('widget-publish-vm-btn')
-    .or(page.getByTestId('list-publish-all-btn'))
-    .or(page.getByTestId('mlv-publish-all-btn'));
+  return page.getByTestId('widget-publish-vm-btn');
 }
 
-/** Any rendered promote/publish result container's combined text. */
-async function resultText(page: Page): Promise<string> {
-  const containers = page
-    .getByTestId('layer-action-result')
-    .or(page.getByTestId('list-action-result'))
-    .or(page.getByTestId('mlv-promote-result'));
-  const n = await containers.count();
-  let text = '';
-  for (let i = 0; i < n; i++) {
-    text += (await containers.nth(i).textContent()) ?? '';
-  }
-  return text;
+/** The SUCCESS banner text (empty if none). */
+async function successText(page: Page): Promise<string> {
+  const el = page.getByTestId('layer-action-result');
+  return (await el.count()) ? ((await el.first().textContent()) ?? '') : '';
+}
+
+/** #1464 — the ERROR banner text (empty if none), now on a DISTINCT testid from success so a
+ *  thrown promote can't be read as a successful result. */
+async function errorText(page: Page): Promise<string> {
+  const el = page.getByTestId('layer-action-error');
+  return (await el.count()) ? ((await el.first().textContent()) ?? '') : '';
 }
 
 test.describe('WM → SWM → VM via the UI', () => {
@@ -202,22 +196,38 @@ test.describe('WM → SWM → VM via the UI', () => {
     await expect(promote).toBeVisible({ timeout: 15_000 });
     await promote.click();
 
-    // UI contract: the result must NOT be the misleading "No triples were
-    // promoted" no-op that the blank-node DELETE bug produced. Wait for a
-    // result to render, then assert it isn't the no-op message.
+    // #1464 — POSITIVE success contract. The old guard only rejected the literal
+    // "No triples were promoted" no-op, which an "✕ Promote failed…" error banner PASSED —
+    // so a THROWN promote read as success and the redness surfaced later as a bare count-0,
+    // misdiagnosed as a silent migration gap. Now: wait for a terminal outcome, assert NO error
+    // banner is present (surfacing its now-server-tagged text so the throwing step is NAMED in CI),
+    // then assert the success banner rendered and isn't the no-op.
     await expect(async () => {
-      const text = await resultText(page);
-      expect(text.length, 'a promote result must render').toBeGreaterThan(0);
-      expect(text, 'promote must not report the no-op (the bug symptom)').not.toMatch(
+      const err = await errorText(page);
+      expect(err, `promote FAILED — error banner: "${err}"`).toBe('');
+      const ok = await successText(page);
+      expect(ok.length, 'a promote success banner must render').toBeGreaterThan(0);
+      expect(ok, 'promote must not report the no-op (the bug symptom)').not.toMatch(
         /No triples were promoted/i,
       );
     }).toPass({ timeout: 20_000, intervals: [500, 1000, 2000] });
 
-    // Migration contract (surface-independent): the assertion's content left
-    // WM (blank nodes included), landed in SWM (root + skolemized children),
-    // and the memoryLayer marker flipped to SWM.
+    // Migration contract: the assertion's content left WM (blank nodes included), landed in the
+    // count-visible SWM graph (root + skolemized children), and the marker flipped to SWM.
+    // #1464 — on persistent count-0, DISAMBIGUATE instead of failing on a bare 0: capture the
+    // WM-drain + marker so the failure classifies itself — WM intact/marker=WM ⇒ a pre-insert
+    // throw (root never written); WM drained/marker=SWM but count 0 ⇒ the root committed but is
+    // not enumerated by the count query (graph-set-index staleness or the bare-bucket exclusion).
     await expect(async () => {
-      expect(await countRootInSharedMemory(run.cgId!, run.rootUri!)).toBeGreaterThan(0);
+      const count = await countRootInSharedMemory(run.cgId!, run.rootUri!);
+      if (count > 0) return;
+      const wmBlankNodes = await countBlankNodeTriplesInGraph(run.cgId!, run.dataGraph!);
+      const marker = await readMemoryLayerMarker(run.cgId!, run.markerUri!);
+      expect(
+        count,
+        `root not in count-visible SWM. disambiguation → WM-blank-node-triples=${wmBlankNodes} (0=WM drained), ` +
+        `marker=${marker}: {WM,>0}⇒pre-insert throw (root never landed); {SWM,0}⇒committed-but-unenumerated/bare-bucket (see #1464 plan)`,
+      ).toBeGreaterThan(0);
     }).toPass({ timeout: 20_000, intervals: [500, 1000, 2000] });
 
     expect(

--- a/packages/node-ui/src/ui/views/project/components/layer-widgets.tsx
+++ b/packages/node-ui/src/ui/views/project/components/layer-widgets.tsx
@@ -161,7 +161,9 @@ function LayerActionShell({ title, footnote, context, result, error, extras, chi
     <GenWidget title={title} footnote={footnote}>
       <div className="v10-decision-context" style={{ marginBottom: 10 }}>{context}</div>
       {result && <div data-testid="layer-action-result" style={{ fontSize: 11, color: 'var(--text-success)', marginBottom: 8 }}>✓ {result}</div>}
-      {error && <div data-testid="layer-action-result" style={{ fontSize: 11, color: 'var(--text-danger)', marginBottom: 8 }}>✕ {error}</div>}
+      {/* #1464 — errors render under a DISTINCT testid so a failed action can't be mistaken for a
+          successful result by a testid-agnostic reader (the mask that hid the promote failure). */}
+      {error && <div data-testid="layer-action-error" style={{ fontSize: 11, color: 'var(--text-danger)', marginBottom: 8 }}>✕ {error}</div>}
       {extras}
       <div className="v10-decision-actions">{children}</div>
     </GenWidget>
@@ -354,7 +356,8 @@ export function LayerWidgetStrip({ layer, entities, entityCount, tripleCount, co
   const [lastAction, setLastAction] = useState<{ ok: boolean; text: string } | null>(null);
   const actionResult = lastAction && (
     <div
-      data-testid="layer-action-result"
+      // #1464 — success vs failure must not collide on one testid (see LayerActionShell).
+      data-testid={lastAction.ok ? 'layer-action-result' : 'layer-action-error'}
       style={{ fontSize: 11, color: lastAction.ok ? 'var(--text-success)' : 'var(--text-danger)', marginBottom: 8 }}
     >
       {lastAction.ok ? '✓' : '✕'} {lastAction.text}

--- a/packages/node-ui/test/layer-widgets-publish.test.ts
+++ b/packages/node-ui/test/layer-widgets-publish.test.ts
@@ -111,7 +111,8 @@ describe('PublishVmWidget — B8 confirmed discount badge (#1365 r3)', () => {
     );
     await clickPublish(container);
     await flush();
-    const res = container.querySelector('[data-testid="layer-action-result"]');
+    // #1464 — errors now render under a distinct testid (never the success `layer-action-result`).
+    const res = container.querySelector('[data-testid="layer-action-error"]');
     expect(res?.textContent).toContain('VM publish tx reverted');
     expect(res?.textContent).not.toContain('an assertion');
     await unmount();
@@ -286,6 +287,29 @@ describe('PromoteWidget — promote flow (#1382)', () => {
     expect(apiMocks.knowledgeAssetFinalize).toHaveBeenCalledWith('cg', 'a1', { subGraphName: 'sg1' });
     expect(apiMocks.promoteAssertion).toHaveBeenCalledWith('cg', 'a1', 'all', 'sg1');
     expect(container.querySelector('[data-testid="layer-action-result"]')?.textContent).toContain('Promoted 3 triples to Shared Memory');
+    await unmount();
+  });
+
+  // #1464 — THE MASK: a THROWN promote must render under a DISTINCT `layer-action-error` testid,
+  // never the success `layer-action-result`. Before this split both shared one testid, so the
+  // devnet e2e (which reads `layer-action-result` testid-agnostically and only rejects the literal
+  // "No triples were promoted" no-op string) mistook an "✕ Promote failed…" banner for a
+  // successful promote — then the SWM count stayed 0 and the throw was misdiagnosed as a silent
+  // migration gap (#1464). Deterministic; fails before the testid split (the error was queryable
+  // under layer-action-result), passes after.
+  it('#1464 — a promote FAILURE renders under layer-action-error, never the success layer-action-result', async () => {
+    apiMocks.promoteAssertion.mockRejectedValue(new Error('[promote:resolveKaNumber] devnet SPARQL read timed out'));
+    const { container, unmount } = await render(
+      React.createElement(PromoteWidget, { count: 1, contextGraphId: 'cg' }),
+    );
+    await clickPromote(container);
+    for (let i = 0; i < 30 && !container.querySelector('[data-testid="layer-action-error"]'); i++) await flush();
+    // The error is isolated under its own testid AND carries the (server-tagged) failing step.
+    const err = container.querySelector('[data-testid="layer-action-error"]');
+    expect(err?.textContent).toContain('devnet SPARQL read timed out');
+    expect(err?.textContent).toContain('[promote:resolveKaNumber]');
+    // The success testid must be ABSENT — a testid-agnostic reader can no longer read the error as a result.
+    expect(container.querySelector('[data-testid="layer-action-result"]')).toBeNull();
     await unmount();
   });
 });

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -6,6 +6,7 @@ import { DKGEvent, Logger, createOperationContext, sha256, encodeWorkspacePublis
 import { GraphManager, PrivateContentStore } from '@origintrail-official/dkg-storage';
 import { DEFAULT_PUBLISH_EPOCHS, MAX_PUBLISH_EPOCHS, type Publisher, type PublishOptions, type PublishResult, type KAManifestEntry, type PhaseCallback, type V10CoreNodeACK } from './publisher.js';
 import { skolemizeByEntity } from './auto-partition.js';
+import { tagPromoteStep } from './promote-step-tag.js';
 import { canonicalPublishPayload } from './canonical-publish-payload.js';
 import {
   assertTrustedCatalogTriplesAreGeneratedFloor,
@@ -5691,9 +5692,17 @@ export class DKGPublisher implements Publisher {
       confirmBeforeCommit?: (message: Uint8Array) => Promise<{ applied: boolean; rejected?: boolean }>;
     },
   ): Promise<{ promotedCount: number; gossipMessage?: Uint8Array; promotedAllRoots: boolean; shareOperationId?: string }> {
-    await this.ensureSubGraphRegistered(contextGraphId, opts?.subGraphName);
-    const graphUri = await this.wmGraphUri(contextGraphId, agentAddress, name, opts?.subGraphName);
-    const swmGraphUri = await this.swmGraphUri(contextGraphId, agentAddress, name, opts?.subGraphName);
+    // #1464 (PR1, diagnostic) — every awaited op below runs BEFORE the
+    // `store.insert(swmQuads)` that actually lands the root in SWM. A masked
+    // rejection here (typically a sparql-http read hitting the 30s
+    // `AbortSignal.timeout` under load) is the leading hypothesis for the
+    // intermittent count-0. `tagPromoteStep` re-labels any such throw as
+    // "[promote:<step>] …" so CI/UI names the failing op — it does NOT retry,
+    // swallow, or change control flow, and the `store.insert` write itself is
+    // deliberately left untagged.
+    await tagPromoteStep('ensureSubGraphRegistered', () => this.ensureSubGraphRegistered(contextGraphId, opts?.subGraphName));
+    const graphUri = await tagPromoteStep('wmGraphUri', () => this.wmGraphUri(contextGraphId, agentAddress, name, opts?.subGraphName));
+    const swmGraphUri = await tagPromoteStep('swmGraphUri', () => this.swmGraphUri(contextGraphId, agentAddress, name, opts?.subGraphName));
 
     // #1116 (round 10) — the swmShareComplete marker MUST be maintained on EVERY
     // return path of assertionPromote, not just the success tail. A non-full share
@@ -5724,7 +5733,7 @@ export class DKGPublisher implements Publisher {
       }
     };
 
-    const assertionQuads = await this.assertionScopedQuads(graphUri);
+    const assertionQuads = await tagPromoteStep('assertionScopedQuads', () => this.assertionScopedQuads(graphUri));
     if (assertionQuads.length === 0) {
       // Issue #864 — when the assertion data graph is empty, distinguish two
       // failure modes so the caller (and ultimately the UI) gets an
@@ -5819,12 +5828,12 @@ export class DKGPublisher implements Publisher {
       (q) => !isReservedSubject(q.subject) && !isTrustLevelQuad(q),
     );
 
-    await this.assertTrustedCatalogTriplesAllowed({
+    await tagPromoteStep('assertTrustedCatalogTriplesAllowed', () => this.assertTrustedCatalogTriplesAllowed({
       contextGraphId,
       trustedNonManifestCatalogTriples: opts?.trustedNonManifestCatalogTriples,
       onChainContextGraphId: opts?.onChainContextGraphId,
       allowLocalPrivateContextGraph: true,
-    });
+    }));
     const trustedGeneratedCatalogTriples = trustedCatalogTripleKeySet(
       opts?.trustedNonManifestCatalogTriples,
     );
@@ -5884,12 +5893,12 @@ export class DKGPublisher implements Publisher {
 
     const swmMetaGraph = this.graphManager.sharedMemoryMetaUri(contextGraphId, opts?.subGraphName);
     const ownershipKey = opts?.subGraphName ? `${contextGraphId}\0${opts.subGraphName}` : contextGraphId;
-    const swmOwners = await this.sharedMemoryOwnersForPromotion(
+    const swmOwners = await tagPromoteStep('sharedMemoryOwnersForPromotion', () => this.sharedMemoryOwnersForPromotion(
       contextGraphId,
       opts?.subGraphName,
       ownershipKey,
       rootEntities,
-    );
+    ));
     const swmOwned = this.sharedMemoryOwnedEntities.get(ownershipKey) ?? new Map<string, string>();
 
     // Pre-encode gossip message and enforce size limit BEFORE any destructive
@@ -5910,7 +5919,7 @@ export class DKGPublisher implements Publisher {
         privateTripleCount: 0,
       }));
       const timestampMs = Date.now();
-      const promoteKaNumber = await this.resolveKaNumber(contextGraphId, agentAddress, name, opts?.subGraphName);
+      const promoteKaNumber = await tagPromoteStep('resolveKaNumber', () => this.resolveKaNumber(contextGraphId, agentAddress, name, opts?.subGraphName));
       const encoded = encodeWorkspacePublishRequest({
         contextGraphId: contextGraphId,
         nquads: new TextEncoder().encode(nquadsStr),
@@ -5931,7 +5940,7 @@ export class DKGPublisher implements Publisher {
       // ("Sender Key encrypted workspace payload required for private
       // or agent-gated context graph"). Returns plaintext for public
       // CGs (resolver returns requiresEncryption=false).
-      const wrapped = await this.encodeWorkspaceGossipPayload(
+      const wrapped = await tagPromoteStep('encodeWorkspaceGossipPayload', () => this.encodeWorkspaceGossipPayload(
         contextGraphId,
         encoded,
         {
@@ -5941,9 +5950,12 @@ export class DKGPublisher implements Publisher {
           shareOperationId: operationId,
           timestampMs,
           subGraphName: opts.subGraphName,
-          publisherPeerId: opts.publisherPeerId,
+          // Non-null: guarded by the enclosing `if (opts?.publisherPeerId)`. The
+          // tagPromoteStep thunk runs synchronously in-tick, but TS widens the
+          // narrowing across the closure boundary.
+          publisherPeerId: opts.publisherPeerId!,
         },
-      );
+      ));
 
       if (wrapped.length > DKG_GOSSIP_MAX_MESSAGE_BYTES) {
         const hint = `Promote fewer entities per call.`;

--- a/packages/publisher/src/promote-step-tag.ts
+++ b/packages/publisher/src/promote-step-tag.ts
@@ -1,0 +1,73 @@
+/**
+ * Issue #1464 (PR1, diagnostic) — NAME the WM→SWM promote step that threw.
+ *
+ * The intermittent "root never lands in SWM" failure is masked: a pre-insert
+ * awaited op in `assertionPromote` (a `resolveKaNumber` / `assertionScopedQuads`
+ * SPARQL read, etc.) can reject — e.g. the 30s `AbortSignal.timeout` on the
+ * sparql-http read fires under load — and the raw transport error surfaces in
+ * the UI banner with no hint about WHICH step failed. That makes the recurrence
+ * look like a silent migration gap rather than a named, actionable throw.
+ *
+ * `tagPromoteStep` wraps one awaited op so a rejection is re-surfaced as
+ * `"[promote:<step>] <original message>"`. It is DIAGNOSTIC ONLY: it never
+ * swallows, retries, or alters control flow — it rethrows the SAME failure with
+ * a step label, then lets it propagate exactly as before.
+ *
+ * Identity preservation: the tag is applied by mutating the caught error's
+ * `message` in place, so the original stack, `name`, typed-error class
+ * (`instanceof`), and `code` all survive — the last matters because PR2's
+ * transient-vs-deterministic classification keys on `err.code`/`err.name`.
+ * `DOMException` (what `AbortSignal.timeout` throws) has a read-only `message`;
+ * when the in-place mutation is refused we wrap instead, carrying the `cause`,
+ * `name`, and `code` forward. On that wrap path the original stack + the
+ * `instanceof DOMException` identity survive only via `err.cause` (the new
+ * Error gets its own top-frame stack) — no downstream matcher depends on either.
+ */
+
+const PROMOTE_STEP_TAG_PREFIX = '[promote:';
+
+/**
+ * Return `err` re-labelled with the promote step that produced it. Idempotent:
+ * an error already carrying a `[promote:…]` prefix (the innermost, most specific
+ * step) is returned untouched, so nesting a tagged op inside another tagged op
+ * keeps the deepest label rather than stacking prefixes.
+ */
+export function tagPromoteError(step: string, err: unknown): unknown {
+  const prefix = `[promote:${step}]`;
+  if (err !== null && typeof err === 'object') {
+    const e = err as { message?: unknown; name?: unknown; code?: unknown };
+    if (typeof e.message === 'string') {
+      const original = e.message;
+      // Innermost tag wins — never double-prefix.
+      if (original.startsWith(PROMOTE_STEP_TAG_PREFIX)) return err;
+      const tagged = `${prefix} ${original}`;
+      // Prefer in-place mutation (preserves stack / name / class / code).
+      try {
+        (e as { message: string }).message = tagged;
+      } catch {
+        /* read-only message (e.g. DOMException) — handled by the check below */
+      }
+      // Verify the mutation stuck (a read-only setter may throw in strict mode
+      // OR silently no-op in sloppy mode); wrap only if it did not.
+      if (e.message === tagged) return err;
+      const wrapped = new Error(tagged, { cause: err });
+      if (typeof e.name === 'string') wrapped.name = e.name;
+      if (e.code !== undefined) (wrapped as { code?: unknown }).code = e.code;
+      return wrapped;
+    }
+  }
+  return new Error(`${prefix} ${String(err)}`);
+}
+
+/**
+ * Run one awaited promote op, re-labelling any rejection with `step` via
+ * {@link tagPromoteError}. Resolved values pass through unchanged. The `op` is
+ * a thunk so it is invoked inside the try — a synchronous throw is tagged too.
+ */
+export async function tagPromoteStep<T>(step: string, op: () => Promise<T>): Promise<T> {
+  try {
+    return await op();
+  } catch (err) {
+    throw tagPromoteError(step, err);
+  }
+}

--- a/packages/publisher/test/promote-step-tag.test.ts
+++ b/packages/publisher/test/promote-step-tag.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Issue #1464 (PR1, diagnostic) — the WM→SWM promote pre-insert step tagging.
+ *
+ * Two levels:
+ *   A. `tagPromoteStep` / `tagPromoteError` unit tests — pin the labelling
+ *      semantics (in-place tag, identity/`code`/stack preservation, idempotency,
+ *      read-only-message wrap, non-object wrap).
+ *   B. One integration through the real `assertionPromote`: fault-inject a
+ *      rejection into the first pre-insert store read and assert the caller sees
+ *      a `[promote:<step>]`-tagged error instead of an anonymous transport throw.
+ *
+ * No Hardhat / no HTTP: the integration builds a publisher over an in-memory
+ * store whose `query` is stubbed to reject, so it is deterministic and
+ * Windows-runnable.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import { TypedEventBus, generateEd25519Keypair } from '@origintrail-official/dkg-core';
+import type { ChainAdapter } from '@origintrail-official/dkg-chain';
+import { tagPromoteError, tagPromoteStep } from '../src/promote-step-tag.js';
+import { DKGPublisher } from '../src/dkg-publisher.js';
+
+describe('#1464 promote step tagging — tagPromoteStep / tagPromoteError', () => {
+  it('passes a resolved value through unchanged', async () => {
+    await expect(tagPromoteStep('resolveKaNumber', async () => 42)).resolves.toBe(42);
+  });
+
+  it('tags a rejected plain Error IN PLACE, preserving object identity, code, and stack', async () => {
+    const original = new Error('SPARQL HTTP query failed (500): boom');
+    (original as { code?: unknown }).code = 'RPC_503';
+    const originalStack = original.stack; // materialise before tagging
+
+    let caught: unknown;
+    await tagPromoteStep('resolveKaNumber', async () => {
+      throw original;
+    }).catch((e) => {
+      caught = e;
+    });
+
+    expect(caught).toBe(original); // same object — instanceof / typed class preserved
+    expect((caught as Error).message).toBe(
+      '[promote:resolveKaNumber] SPARQL HTTP query failed (500): boom',
+    );
+    expect((caught as { code?: unknown }).code).toBe('RPC_503'); // PR2 classification signal survives
+    expect((caught as Error).stack).toBe(originalStack); // stack untouched
+  });
+
+  it('never double-prefixes — the innermost promote step wins', () => {
+    const already = new Error('[promote:assertionScopedQuads] deep failure');
+    const tagged = tagPromoteError('wmGraphUri', already);
+    expect(tagged).toBe(already);
+    expect((tagged as Error).message).toBe('[promote:assertionScopedQuads] deep failure');
+  });
+
+  it('handles a read-only-message error (DOMException from AbortSignal.timeout) without throwing', () => {
+    const timeout = new DOMException('The operation timed out.', 'TimeoutError');
+    const tagged = tagPromoteError('assertionScopedQuads', timeout) as Error & {
+      cause?: unknown;
+      code?: unknown;
+    };
+
+    expect(tagged.message).toBe('[promote:assertionScopedQuads] The operation timed out.');
+    expect(tagged.name).toBe('TimeoutError'); // transient signal preserved
+    // Robust to either strategy: mutated-in-place (same object) OR wrapped-with-cause.
+    expect(tagged === timeout || tagged.cause === timeout).toBe(true);
+  });
+
+  it('wraps a non-object throwable (string) in a tagged Error', () => {
+    const tagged = tagPromoteError('wmGraphUri', 'raw string failure') as Error;
+    expect(tagged).toBeInstanceOf(Error);
+    expect(tagged.message).toBe('[promote:wmGraphUri] raw string failure');
+  });
+});
+
+describe('#1464 promote step tagging — assertionPromote integration', () => {
+  it('surfaces a [promote:<step>] tag when a pre-insert store read rejects', async () => {
+    const store = new OxigraphStore();
+    const boom = new Error('SPARQL HTTP query failed (500): oxigraph worker unavailable');
+    (boom as { code?: unknown }).code = 'OXIGRAPH_DOWN';
+    // The first pre-insert awaited op in assertionPromote is
+    // wmGraphUri → resolveKaNumber → store.query. Reject there.
+    store.query = async () => {
+      throw boom;
+    };
+
+    const publisher = new DKGPublisher({
+      store,
+      chain: {} as unknown as ChainAdapter, // unused before the reject point
+      eventBus: new TypedEventBus(),
+      keypair: await generateEd25519Keypair(),
+    });
+
+    await expect(
+      publisher.assertionPromote(
+        'cg-1464',
+        'my-assertion',
+        '0x1234567890abcdef1234567890abcdef12345678',
+      ),
+    ).rejects.toThrow(/^\[promote:wmGraphUri\] SPARQL HTTP query failed \(500\)/);
+
+    // Original error identity + classification code preserved for PR2.
+    expect(boom.message).toContain('[promote:wmGraphUri]');
+    expect((boom as { code?: unknown }).code).toBe('OXIGRAPH_DOWN');
+  });
+});

--- a/packages/publisher/vitest.unit.config.ts
+++ b/packages/publisher/vitest.unit.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
       'test/async-lift-publish-options.test.ts',
       'test/async-promote-queue.test.ts',
       'test/multi-root-token-rows.test.ts',
+      'test/promote-step-tag.test.ts',
     ],
     testTimeout: 60_000,
     maxWorkers: 1,


### PR DESCRIPTION
## What & why

Fixes #1464 — the node-UI devnet e2e (`wm-swm-vm-ui-cycle`) intermittently failed at the **WM→SWM promote** step: the UI reported a promote error and the root "never landed in Shared Working Memory." It read like a product migration gap, so the issue guessed at a storage/timeout flake.

**It wasn't a timeout.** The real cause is **cross-test contamination on a shared devnet context graph**:

- The spec drives the UI's **promote-all** action, which iterates **every** WM assertion currently on the CG.
- Sibling specs share the same context graph (`cgs[0]`) and leave behind assertions that carry **RDF named-graph quads**.
- `assertionPromote` **correctly rejects** those (`KA_NAMED_GRAPH_SHARE_UNSUPPORTED`) — so whenever a foreign assertion was present, promote-all threw.
- Whether the foreign assertion was there depended on **test ordering** → intermittent red.

The failure was hard to diagnose because it was **masked**: success and error both rendered the same `layer-action-result` testid, so a thrown promote could read as success/ambiguous rather than a named throw. We shipped the un-masking + diagnostics **first**; on its first CI run it named the real error (`KA_NAMED_GRAPH_SHARE_UNSUPPORTED`, *not* a timeout), which killed the storage-timeout hypothesis outright.

> This is **not** a test-only PR. Alongside the spec fix it hardens two real product behaviours (UI result/error masking, and operator-facing promote diagnostics). Details below.

## Changes

**The fix (root cause) — test isolation**
- `wm-swm-vm-ui-cycle.devnet.spec.ts`: provision a **dedicated, unique-per-run context graph** in `beforeAll`, so promote-all only ever sees this fixture's own clean assertion. This *structurally* removes the contamination (a fresh unique CG cannot hold a foreign named-graph assertion). Also tightened the spec — positive-success assertion, count-0 disambiguation, pruned dead selectors.

**Product hardening #1 — un-mask the UI result (this is what let the failure hide)**
- `layer-widgets.tsx`: split the result testid so a **failed** layer action renders under `layer-action-error`, never `layer-action-result`. A thrown promote can no longer masquerade as success.
- `layer-widgets-publish.test.ts`: regression test asserting a promote failure surfaces under `layer-action-error`.

**Product hardening #2 — name the failing promote step for operators**
- `promote-step-tag.ts` (new) + `dkg-publisher.ts`: each pre-insert promote read is wrapped so a rejection is re-surfaced as `[promote:<step>] <original message>` — the operator banner now says *which* step failed. Identity-preserving: original stack / `name` / `code` survive, so nothing downstream that keys on those is affected.
- `async-promote-worker.ts`: strips the `[promote:<step>]` tag **before** retry-classification, so the diagnostic label can never change a retry decision. Regression tests on both sides.

## Verification
- Re-ran the node-UI devnet e2e lane **5× on CI → 5/5 green**. Because the fix removes the cause structurally, this is deterministic, not luck.
- Full CI: **36 checks pass** (remaining are skips).
- The devnet e2e lane cannot run on Windows, so CI is the runtime test surface here.

## Not in this PR (reverted)
An earlier revision (PR2) added a per-call SPARQL read timeout to "widen" promote reads, on the assumption a 30s abort was the cause. The diagnostic disproved that, so it was **fully reverted** (preserved as tag `backup/1464-pr2-timeout`). The underlying `O(store-size)` `assertionScopedQuads` enumeration it targeted is a genuine latent perf concern and is tracked as a separate follow-up — it is **not** the cause of this flake.
