### PR TITLE
Attribute eth_call RPC usage by consumer

### DIFF
--- a/packages/agent/test/rpc-usage-boundary.test.ts
+++ b/packages/agent/test/rpc-usage-boundary.test.ts
@@ -17,7 +17,11 @@ const drain = DKGAgentBase.prototype.drainRpcUsage;
 
 describe('DKGAgent.drainRpcUsage — the adapter→agent telemetry boundary', () => {
   it('delegates to the adapter and passes the window through VERBATIM', () => {
-    const window = { byMethod: { eth_call: 42, eth_getLogs: 7 }, lifetimeTotal: 49 };
+    const window = {
+      byMethod: { eth_call: 42, eth_getLogs: 7 },
+      ethCallByConsumer: { 'pcaNFT.getAccountInfo': 42 },
+      lifetimeTotal: 49,
+    };
     const out = drain.call({ chain: { drainRpcUsage: () => window } } as never);
     expect(out).toBe(window); // same object — no reshaping/copying in the boundary
   });

--- a/packages/agent/test/rpc-usage-boundary.test.ts
+++ b/packages/agent/test/rpc-usage-boundary.test.ts
@@ -29,19 +29,19 @@ describe('DKGAgent.drainRpcUsage — the adapter→agent telemetry boundary', ()
   it('returns the real MockChainAdapter empty window (capability present, no transport)', () => {
     const chain = new MockChainAdapter();
     const out = drain.call({ chain } as never);
-    expect(out).toEqual({ byMethod: {}, lifetimeTotal: 0 });
+    expect(out).toEqual({ byMethod: {}, ethCallByConsumer: {}, lifetimeTotal: 0 });
   });
 
   it('collapses a missing adapter capability to a concrete EMPTY window (consumers never see undefined)', () => {
     const out = drain.call({ chain: {} } as never);
-    expect(out).toEqual({ byMethod: {}, lifetimeTotal: 0 });
+    expect(out).toEqual({ byMethod: {}, ethCallByConsumer: {}, lifetimeTotal: 0 });
   });
 
   it('is inherited by the composed DKGAgent class (the daemon consumes agent, not the base)', () => {
     // The daemon passes the DKGAgent instance as the telemetry source — the
     // method must exist on the composed class's prototype chain.
     expect(typeof DKGAgent.prototype.drainRpcUsage).toBe('function');
-    const window = { byMethod: { eth_sendRawTransaction: 3 }, lifetimeTotal: 3 };
+    const window = { byMethod: { eth_sendRawTransaction: 3 }, ethCallByConsumer: {}, lifetimeTotal: 3 };
     const out = DKGAgent.prototype.drainRpcUsage.call({ chain: { drainRpcUsage: () => window } } as never);
     expect(out).toBe(window);
   });

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -951,7 +951,9 @@ export class EVMChainAdapterBase {
     method: string,
     ...args: unknown[]
   ): Promise<T> {
-    return this.rpcFailover.readContract(label, contract, (c) => c[method](...args));
+    return this.rpcFailover.readContract(label, contract, (c) => c[method](...args), {
+      rpcUsageConsumer: label,
+    });
   }
 
   /**
@@ -966,7 +968,10 @@ export class EVMChainAdapterBase {
     fn: (c: Contract) => Promise<T>,
     opts?: ReadOpts,
   ): Promise<T> {
-    return this.rpcFailover.readContract(label, contract, fn, opts);
+    return this.rpcFailover.readContract(label, contract, fn, {
+      ...opts,
+      rpcUsageConsumer: opts?.rpcUsageConsumer ?? label,
+    });
   }
 
   /**
@@ -981,7 +986,10 @@ export class EVMChainAdapterBase {
     fn: (provider: JsonRpcProvider) => Promise<T>,
     opts?: ReadOpts,
   ): Promise<T> {
-    return this.rpcFailover.read(label, fn, opts);
+    return this.rpcFailover.read(label, fn, {
+      ...opts,
+      rpcUsageConsumer: opts?.rpcUsageConsumer ?? label,
+    });
   }
 
   /**

--- a/packages/chain/src/index.ts
+++ b/packages/chain/src/index.ts
@@ -7,6 +7,7 @@ export * from './chain-adapter.js';
 export {
   emptyRpcUsageWindow,
   mergeRpcUsageWindows,
+  normalizeRpcUsageWindow,
   rpcUsageWindowTotal,
   type NormalizedRpcUsageWindow,
   type RpcUsageDrainable,

--- a/packages/chain/src/index.ts
+++ b/packages/chain/src/index.ts
@@ -4,7 +4,15 @@ export * from './chain-adapter.js';
 // daemon's rpc_usage log emission). The parsing/label-bounding helpers stay
 // package-internal (imported via ./rpc-usage.js) so the transport accounting
 // implementation can change without a public-API break.
-export { emptyRpcUsageWindow, mergeRpcUsageWindows, rpcUsageWindowTotal, type RpcUsageDrainable, type RpcUsageWindow } from './rpc-usage.js';
+export {
+  emptyRpcUsageWindow,
+  mergeRpcUsageWindows,
+  normalizeRpcUsageWindow,
+  rpcUsageWindowTotal,
+  type RpcUsageDrainable,
+  type RpcUsageWindow,
+  type RpcUsageWindowInput,
+} from './rpc-usage.js';
 export { MockChainAdapter, MOCK_DEFAULT_SIGNER } from './mock-adapter.js';
 export {
   EVMChainAdapter,

--- a/packages/chain/src/index.ts
+++ b/packages/chain/src/index.ts
@@ -7,11 +7,10 @@ export * from './chain-adapter.js';
 export {
   emptyRpcUsageWindow,
   mergeRpcUsageWindows,
-  normalizeRpcUsageWindow,
   rpcUsageWindowTotal,
+  type NormalizedRpcUsageWindow,
   type RpcUsageDrainable,
   type RpcUsageWindow,
-  type RpcUsageWindowInput,
 } from './rpc-usage.js';
 export { MockChainAdapter, MOCK_DEFAULT_SIGNER } from './mock-adapter.js';
 export {

--- a/packages/chain/src/mock-adapter.ts
+++ b/packages/chain/src/mock-adapter.ts
@@ -132,7 +132,7 @@ export class MockChainAdapter implements ChainAdapter {
 
   /** RPC-usage capability: the mock has no RPC transport → always-empty window. */
   drainRpcUsage(): RpcUsageWindow {
-    return { byMethod: {}, lifetimeTotal: 0 };
+    return { byMethod: {}, ethCallByConsumer: {}, lifetimeTotal: 0 };
   }
 
   async ensureProfile(_options?: { nodeName?: string; stakeAmount?: bigint; lockTier?: number }): Promise<bigint> {

--- a/packages/chain/src/rpc-failover-client.ts
+++ b/packages/chain/src/rpc-failover-client.ts
@@ -36,6 +36,7 @@ import { withTimeout, isRetryableRpcError, isKnownTransactionError } from './evm
 import { errorCode, errorMessage } from './evm-adapter-errors.js';
 import { noteRpcFailover, noteRpcExhaustion, rpcHost } from './rpc-failover-log.js';
 import { ChainRpcTransportError } from './chain-rpc-transport-error.js';
+import { withRpcUsageConsumer } from './rpc-usage.js';
 import {
   RPC_READ_STALL_TIMEOUT_MS,
   RPC_LOG_SCAN_TIMEOUT_MS,
@@ -196,11 +197,14 @@ export class RpcFailoverClient {
     fn: (provider: JsonRpcProvider) => Promise<T>,
     opts?: ReadOpts,
   ): Promise<T> {
-    return this.runAcrossProviders(
+    return withRpcUsageConsumer(
       label,
-      fn,
-      opts?.isRetryable ?? isRetryableRpcError,
-      opts?.policy ?? 'pointRead',
+      () => this.runAcrossProviders(
+        label,
+        fn,
+        opts?.isRetryable ?? isRetryableRpcError,
+        opts?.policy ?? 'pointRead',
+      ),
     );
   }
 
@@ -224,30 +228,33 @@ export class RpcFailoverClient {
     // `chain.eth_call` span + RPC metric spanning the whole failover sequence.
     // `dkg.read=label` (e.g. 'token.allowance') rides the SPAN only — kept OFF
     // the metric so its label set stays low-cardinality.
-    return withSpan(
-      'chain.eth_call',
-      async () => {
-        const metrics = getMetrics();
-        const startedAt = Date.now();
-        try {
-          const out = await this.runAcrossProviders(
-            label,
-            (p) => fn(this.rebindContract(contract, p)),
-            opts?.isRetryable ?? isContractViewRetryable,
-            opts?.policy ?? 'pointRead',
-          );
-          this.recordRpcOutcome('eth_call', 'ok');
-          return out;
-        } catch (err) {
-          this.recordRpcOutcome('eth_call', this.rpcOutcome(err), { retryable: isRetryableRpcError(err) });
-          throw err;
-        } finally {
-          metrics.chainRpcDuration.record(Date.now() - startedAt, {
-            rpc_method: 'eth_call', chain_id: chainId,
-          });
-        }
-      },
-      { attributes: { 'rpc.method': 'eth_call', 'dkg.chain_id': chainId, 'dkg.read': label } },
+    return withRpcUsageConsumer(
+      label,
+      () => withSpan(
+        'chain.eth_call',
+        async () => {
+          const metrics = getMetrics();
+          const startedAt = Date.now();
+          try {
+            const out = await this.runAcrossProviders(
+              label,
+              (p) => fn(this.rebindContract(contract, p)),
+              opts?.isRetryable ?? isContractViewRetryable,
+              opts?.policy ?? 'pointRead',
+            );
+            this.recordRpcOutcome('eth_call', 'ok');
+            return out;
+          } catch (err) {
+            this.recordRpcOutcome('eth_call', this.rpcOutcome(err), { retryable: isRetryableRpcError(err) });
+            throw err;
+          } finally {
+            metrics.chainRpcDuration.record(Date.now() - startedAt, {
+              rpc_method: 'eth_call', chain_id: chainId,
+            });
+          }
+        },
+        { attributes: { 'rpc.method': 'eth_call', 'dkg.chain_id': chainId, 'dkg.read': label } },
+      ),
     );
   }
 

--- a/packages/chain/src/rpc-failover-client.ts
+++ b/packages/chain/src/rpc-failover-client.ts
@@ -77,11 +77,13 @@ export type ReadPolicy =
   | 'watchdogWideLogScan'
   | 'failOpenFundingRead';
 
-/** Per-read options: a named timeout policy + an optional failover classifier
- *  override (a read whose error shape carries domain meaning). */
+/** Per-read options: timeout/failover behavior plus an explicit low-cardinality
+ *  telemetry consumer key for `eth_call` attribution. `label` remains a human
+ *  failover/span label and is not implicitly part of the daemon log contract. */
 export interface ReadOpts {
   policy?: ReadPolicy;
   isRetryable?: (err: unknown) => boolean;
+  rpcUsageConsumer?: string;
 }
 
 /**
@@ -197,15 +199,13 @@ export class RpcFailoverClient {
     fn: (provider: JsonRpcProvider) => Promise<T>,
     opts?: ReadOpts,
   ): Promise<T> {
-    return withRpcUsageConsumer(
+    const run = () => this.runAcrossProviders(
       label,
-      () => this.runAcrossProviders(
-        label,
-        fn,
-        opts?.isRetryable ?? isRetryableRpcError,
-        opts?.policy ?? 'pointRead',
-      ),
+      fn,
+      opts?.isRetryable ?? isRetryableRpcError,
+      opts?.policy ?? 'pointRead',
     );
+    return opts?.rpcUsageConsumer ? withRpcUsageConsumer(opts.rpcUsageConsumer, run) : run();
   }
 
   /**
@@ -228,34 +228,32 @@ export class RpcFailoverClient {
     // `chain.eth_call` span + RPC metric spanning the whole failover sequence.
     // `dkg.read=label` (e.g. 'token.allowance') rides the SPAN only — kept OFF
     // the metric so its label set stays low-cardinality.
-    return withRpcUsageConsumer(
-      label,
-      () => withSpan(
-        'chain.eth_call',
-        async () => {
-          const metrics = getMetrics();
-          const startedAt = Date.now();
-          try {
-            const out = await this.runAcrossProviders(
-              label,
-              (p) => fn(this.rebindContract(contract, p)),
-              opts?.isRetryable ?? isContractViewRetryable,
-              opts?.policy ?? 'pointRead',
-            );
-            this.recordRpcOutcome('eth_call', 'ok');
-            return out;
-          } catch (err) {
-            this.recordRpcOutcome('eth_call', this.rpcOutcome(err), { retryable: isRetryableRpcError(err) });
-            throw err;
-          } finally {
-            metrics.chainRpcDuration.record(Date.now() - startedAt, {
-              rpc_method: 'eth_call', chain_id: chainId,
-            });
-          }
-        },
-        { attributes: { 'rpc.method': 'eth_call', 'dkg.chain_id': chainId, 'dkg.read': label } },
-      ),
+    const run = () => withSpan(
+      'chain.eth_call',
+      async () => {
+        const metrics = getMetrics();
+        const startedAt = Date.now();
+        try {
+          const out = await this.runAcrossProviders(
+            label,
+            (p) => fn(this.rebindContract(contract, p)),
+            opts?.isRetryable ?? isContractViewRetryable,
+            opts?.policy ?? 'pointRead',
+          );
+          this.recordRpcOutcome('eth_call', 'ok');
+          return out;
+        } catch (err) {
+          this.recordRpcOutcome('eth_call', this.rpcOutcome(err), { retryable: isRetryableRpcError(err) });
+          throw err;
+        } finally {
+          metrics.chainRpcDuration.record(Date.now() - startedAt, {
+            rpc_method: 'eth_call', chain_id: chainId,
+          });
+        }
+      },
+      { attributes: { 'rpc.method': 'eth_call', 'dkg.chain_id': chainId, 'dkg.read': label } },
     );
+    return opts?.rpcUsageConsumer ? withRpcUsageConsumer(opts.rpcUsageConsumer, run) : run();
   }
 
   // --- write transport (called by the adapter's tx-orchestration; this layer

--- a/packages/chain/src/rpc-usage.ts
+++ b/packages/chain/src/rpc-usage.ts
@@ -193,7 +193,7 @@ export function withRpcUsageConsumer<T>(consumer: string, fn: () => T): T {
 }
 
 /** Current diagnostic consumer label, if a caller established one. */
-export function currentRpcUsageConsumer(): string | undefined {
+function activeRpcUsageConsumer(): string | undefined {
   return rpcUsageConsumerContext.getStore();
 }
 
@@ -228,7 +228,7 @@ export class RpcUsageTracker {
   static readonly MAX_WINDOW_METHODS = 64;
   static readonly MAX_WINDOW_CONSUMERS = 128;
 
-  record(method: string, consumer = currentRpcUsageConsumer()): void {
+  record(method: string): void {
     // Authoritative window/lifetime state first, OUTSIDE any try — pure map
     // arithmetic that cannot realistically throw, and it must never be
     // skipped because an OPTIONAL sink misbehaved.
@@ -236,7 +236,7 @@ export class RpcUsageTracker {
     const key = this.window.has(raw) || this.window.size < RpcUsageTracker.MAX_WINDOW_METHODS ? raw : 'other';
     this.window.set(key, (this.window.get(key) ?? 0) + 1);
     if (raw === 'eth_call') {
-      const normalizedConsumer = normalizeRpcUsageConsumer(consumer);
+      const normalizedConsumer = activeRpcUsageConsumer();
       if (normalizedConsumer) {
         const consumerKey = this.ethCallConsumers.has(normalizedConsumer) ||
           this.ethCallConsumers.size < RpcUsageTracker.MAX_WINDOW_CONSUMERS
@@ -337,7 +337,7 @@ export function createCountingJsonRpcProvider(
     const retry = await pureRetry(attemptReq, response, attempt);
     if (retry) {
       try {
-        for (const method of jsonRpcMethodsFromBody(attemptReq?.body)) tracker.record(method, currentRpcUsageConsumer());
+        for (const method of jsonRpcMethodsFromBody(attemptReq?.body)) tracker.record(method);
       } catch { /* accounting must never break the retry path */ }
     }
     return retry;
@@ -356,6 +356,6 @@ export function createCountingJsonRpcProvider(
     fetchRequest,
     network,
     providerOptions,
-    (method) => tracker.record(method, currentRpcUsageConsumer()),
+    (method) => tracker.record(method),
   );
 }

--- a/packages/chain/src/rpc-usage.ts
+++ b/packages/chain/src/rpc-usage.ts
@@ -94,6 +94,27 @@ export function emptyRpcUsageWindow(): RpcUsageWindow {
 }
 
 /**
+ * Compatibility input accepted at merge/format/drain boundaries. Chain-owned
+ * producers return a concrete {@link RpcUsageWindow}; this loose shape exists
+ * only so pre-attribution drain sources do not break aggregate `rpc_usage`
+ * logging while rolling through a mixed-version process boundary.
+ */
+export type RpcUsageWindowInput = {
+  byMethod: Record<string, number>;
+  ethCallByConsumer?: Record<string, number>;
+  lifetimeTotal: number;
+};
+
+/** Normalize a legacy/loose input into the concrete telemetry model. */
+export function normalizeRpcUsageWindow(window: RpcUsageWindowInput): RpcUsageWindow {
+  return {
+    byMethod: window.byMethod,
+    ethCallByConsumer: window.ethCallByConsumer ?? {},
+    lifetimeTotal: window.lifetimeTotal,
+  };
+}
+
+/**
  * THE drain contract — one name for one concept, wherever a usage window can
  * be drained from: an agent (delegates to its adapter), a publisher runtime
  * (merges its per-wallet adapters), or the daemon's composite source. Deltas
@@ -116,16 +137,17 @@ export interface RpcUsageDrainable {
  * always a concrete window — empty when there is nothing to merge.
  */
 export function mergeRpcUsageWindows(
-  ...windows: Array<RpcUsageWindow | undefined>
+  ...windows: Array<RpcUsageWindowInput | undefined>
 ): RpcUsageWindow {
-  const defined = windows.filter((w): w is RpcUsageWindow => w !== undefined);
+  const defined = windows.filter((w): w is RpcUsageWindowInput => w !== undefined);
   if (defined.length === 0) return emptyRpcUsageWindow();
   const byMethod: Record<string, number> = {};
   const ethCallByConsumer: Record<string, number> = {};
   let lifetimeTotal = 0;
-  for (const w of defined) {
+  for (const input of defined) {
+    const w = normalizeRpcUsageWindow(input);
     for (const [m, c] of Object.entries(w.byMethod)) byMethod[m] = (byMethod[m] ?? 0) + c;
-    for (const [consumer, c] of Object.entries(w.ethCallByConsumer ?? {})) {
+    for (const [consumer, c] of Object.entries(w.ethCallByConsumer)) {
       ethCallByConsumer[consumer] = (ethCallByConsumer[consumer] ?? 0) + c;
     }
     lifetimeTotal += w.lifetimeTotal;
@@ -148,11 +170,10 @@ export interface RpcUsageWindow {
    * the billing-exact aggregate count and existing dashboards should continue
    * to use it. The consumer map is emitted as separate daemon log lines so it
    * cannot double-count aggregate `rpc_usage` queries. Empty map means no
-   * attributed `eth_call`s in the current drain window. Optional at the public
-   * drain boundary for compatibility with pre-attribution drain sources; local
-   * chain helpers return a normalized concrete map.
+   * attributed `eth_call`s in the current drain window. Legacy missing-field
+   * compatibility is isolated in {@link normalizeRpcUsageWindow}.
    */
-  ethCallByConsumer?: Record<string, number>;
+  ethCallByConsumer: Record<string, number>;
   /** Raw requests since process start (monotonic; NOT reset by drain). */
   lifetimeTotal: number;
 }
@@ -162,7 +183,7 @@ export interface RpcUsageWindow {
  * window model deliberately stores no separate total, so an inconsistent
  * {byMethod, total} pair is unrepresentable.
  */
-export function rpcUsageWindowTotal(window: RpcUsageWindow): number {
+export function rpcUsageWindowTotal(window: Pick<RpcUsageWindow, 'byMethod'>): number {
   let total = 0;
   for (const count of Object.values(window.byMethod)) total += count;
   return total;

--- a/packages/chain/src/rpc-usage.ts
+++ b/packages/chain/src/rpc-usage.ts
@@ -90,7 +90,7 @@ export function jsonRpcMethodsFromBody(body: Uint8Array | null | undefined): str
 
 /** A fresh all-zero window — the identity element for merging and the value of "nothing to report". */
 export function emptyRpcUsageWindow(): RpcUsageWindow {
-  return { byMethod: {}, lifetimeTotal: 0 };
+  return { byMethod: {}, ethCallByConsumer: {}, lifetimeTotal: 0 };
 }
 
 /**
@@ -125,14 +125,12 @@ export function mergeRpcUsageWindows(
   let lifetimeTotal = 0;
   for (const w of defined) {
     for (const [m, c] of Object.entries(w.byMethod)) byMethod[m] = (byMethod[m] ?? 0) + c;
-    for (const [consumer, c] of Object.entries(w.ethCallByConsumer ?? {})) {
+    for (const [consumer, c] of Object.entries(w.ethCallByConsumer)) {
       ethCallByConsumer[consumer] = (ethCallByConsumer[consumer] ?? 0) + c;
     }
     lifetimeTotal += w.lifetimeTotal;
   }
-  return Object.keys(ethCallByConsumer).length === 0
-    ? { byMethod, lifetimeTotal }
-    : { byMethod, ethCallByConsumer, lifetimeTotal };
+  return { byMethod, ethCallByConsumer, lifetimeTotal };
 }
 
 export interface RpcUsageWindow {
@@ -145,13 +143,14 @@ export interface RpcUsageWindow {
    */
   byMethod: Record<string, number>;
   /**
-   * Optional raw `eth_call` attribution by bounded code-owned consumer label.
+   * Raw `eth_call` attribution by bounded code-owned consumer label.
    * This is a companion diagnostic dimension only: `byMethod.eth_call` remains
    * the billing-exact aggregate count and existing dashboards should continue
    * to use it. The consumer map is emitted as separate daemon log lines so it
-   * cannot double-count aggregate `rpc_usage` queries.
+   * cannot double-count aggregate `rpc_usage` queries. Empty map means no
+   * attributed `eth_call`s in the current drain window.
    */
-  ethCallByConsumer?: Record<string, number>;
+  ethCallByConsumer: Record<string, number>;
   /** Raw requests since process start (monotonic; NOT reset by drain). */
   lifetimeTotal: number;
 }
@@ -268,15 +267,10 @@ export class RpcUsageTracker {
     const byMethod: Record<string, number> = {};
     for (const [method, count] of this.window) byMethod[method] = count;
     this.window.clear();
-    let ethCallByConsumer: Record<string, number> | undefined;
-    if (this.ethCallConsumers.size > 0) {
-      ethCallByConsumer = {};
-      for (const [consumer, count] of this.ethCallConsumers) ethCallByConsumer[consumer] = count;
-    }
+    const ethCallByConsumer: Record<string, number> = {};
+    for (const [consumer, count] of this.ethCallConsumers) ethCallByConsumer[consumer] = count;
     this.ethCallConsumers.clear();
-    return ethCallByConsumer == null
-      ? { byMethod, lifetimeTotal: this.lifetime }
-      : { byMethod, ethCallByConsumer, lifetimeTotal: this.lifetime };
+    return { byMethod, ethCallByConsumer, lifetimeTotal: this.lifetime };
   }
 }
 

--- a/packages/chain/src/rpc-usage.ts
+++ b/packages/chain/src/rpc-usage.ts
@@ -21,6 +21,7 @@
  *    per method TODAY, with exact sums (deltas, not cumulative gauges).
  */
 
+import { AsyncLocalStorage } from 'node:async_hooks';
 import { JsonRpcProvider } from 'ethers';
 import type {
   FetchRequest,
@@ -120,12 +121,18 @@ export function mergeRpcUsageWindows(
   const defined = windows.filter((w): w is RpcUsageWindow => w !== undefined);
   if (defined.length === 0) return emptyRpcUsageWindow();
   const byMethod: Record<string, number> = {};
+  const ethCallByConsumer: Record<string, number> = {};
   let lifetimeTotal = 0;
   for (const w of defined) {
     for (const [m, c] of Object.entries(w.byMethod)) byMethod[m] = (byMethod[m] ?? 0) + c;
+    for (const [consumer, c] of Object.entries(w.ethCallByConsumer ?? {})) {
+      ethCallByConsumer[consumer] = (ethCallByConsumer[consumer] ?? 0) + c;
+    }
     lifetimeTotal += w.lifetimeTotal;
   }
-  return { byMethod, lifetimeTotal };
+  return Object.keys(ethCallByConsumer).length === 0
+    ? { byMethod, lifetimeTotal }
+    : { byMethod, ethCallByConsumer, lifetimeTotal };
 }
 
 export interface RpcUsageWindow {
@@ -137,6 +144,14 @@ export interface RpcUsageWindow {
    * must sanitize keys for their own sink (the cli logfmt formatter does).
    */
   byMethod: Record<string, number>;
+  /**
+   * Optional raw `eth_call` attribution by bounded code-owned consumer label.
+   * This is a companion diagnostic dimension only: `byMethod.eth_call` remains
+   * the billing-exact aggregate count and existing dashboards should continue
+   * to use it. The consumer map is emitted as separate daemon log lines so it
+   * cannot double-count aggregate `rpc_usage` queries.
+   */
+  ethCallByConsumer?: Record<string, number>;
   /** Raw requests since process start (monotonic; NOT reset by drain). */
   lifetimeTotal: number;
 }
@@ -152,6 +167,36 @@ export function rpcUsageWindowTotal(window: RpcUsageWindow): number {
   return total;
 }
 
+const rpcUsageConsumerContext = new AsyncLocalStorage<string>();
+
+/**
+ * Bound code-owned read labels for logfmt-safe consumer attribution. Labels are
+ * intentionally not derived from calldata, addresses, request ids, or peer ids.
+ */
+export function normalizeRpcUsageConsumer(consumer: string | undefined): string | undefined {
+  if (typeof consumer !== 'string') return undefined;
+  const normalized = consumer
+    .trim()
+    .replace(/[^A-Za-z0-9_.:-]+/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/^_+|_+$/g, '');
+  if (normalized.length === 0) return undefined;
+  if (normalized.length > 64) return 'other';
+  return normalized;
+}
+
+/** Run a provider read under a bounded diagnostic consumer label. */
+export function withRpcUsageConsumer<T>(consumer: string, fn: () => T): T {
+  const normalized = normalizeRpcUsageConsumer(consumer);
+  if (!normalized) return fn();
+  return rpcUsageConsumerContext.run(normalized, fn);
+}
+
+/** Current diagnostic consumer label, if a caller established one. */
+export function currentRpcUsageConsumer(): string | undefined {
+  return rpcUsageConsumerContext.getStore();
+}
+
 /**
  * In-process accumulator for raw JSON-RPC request counts. `record()` is on the
  * hot path of every RPC — it does one map increment and one counter add, never
@@ -159,6 +204,7 @@ export function rpcUsageWindowTotal(window: RpcUsageWindow): number {
  */
 export class RpcUsageTracker {
   private window = new Map<string, number>();
+  private ethCallConsumers = new Map<string, number>();
   private lifetime = 0;
 
   constructor(
@@ -180,14 +226,25 @@ export class RpcUsageTracker {
    * one rpc_usage log line per fabricated name every minute.
    */
   static readonly MAX_WINDOW_METHODS = 64;
+  static readonly MAX_WINDOW_CONSUMERS = 128;
 
-  record(method: string): void {
+  record(method: string, consumer = currentRpcUsageConsumer()): void {
     // Authoritative window/lifetime state first, OUTSIDE any try — pure map
     // arithmetic that cannot realistically throw, and it must never be
     // skipped because an OPTIONAL sink misbehaved.
     const raw = typeof method === 'string' && method.length > 0 && method.length <= 128 ? method : 'other';
     const key = this.window.has(raw) || this.window.size < RpcUsageTracker.MAX_WINDOW_METHODS ? raw : 'other';
     this.window.set(key, (this.window.get(key) ?? 0) + 1);
+    if (raw === 'eth_call') {
+      const normalizedConsumer = normalizeRpcUsageConsumer(consumer);
+      if (normalizedConsumer) {
+        const consumerKey = this.ethCallConsumers.has(normalizedConsumer) ||
+          this.ethCallConsumers.size < RpcUsageTracker.MAX_WINDOW_CONSUMERS
+          ? normalizedConsumer
+          : 'other';
+        this.ethCallConsumers.set(consumerKey, (this.ethCallConsumers.get(consumerKey) ?? 0) + 1);
+      }
+    }
     this.lifetime += 1;
     // Best-effort applies ONLY to the OTel side effect (and the chainId
     // thunk it evaluates) — a throwing metrics backend must not break the
@@ -211,7 +268,15 @@ export class RpcUsageTracker {
     const byMethod: Record<string, number> = {};
     for (const [method, count] of this.window) byMethod[method] = count;
     this.window.clear();
-    return { byMethod, lifetimeTotal: this.lifetime };
+    let ethCallByConsumer: Record<string, number> | undefined;
+    if (this.ethCallConsumers.size > 0) {
+      ethCallByConsumer = {};
+      for (const [consumer, count] of this.ethCallConsumers) ethCallByConsumer[consumer] = count;
+    }
+    this.ethCallConsumers.clear();
+    return ethCallByConsumer == null
+      ? { byMethod, lifetimeTotal: this.lifetime }
+      : { byMethod, ethCallByConsumer, lifetimeTotal: this.lifetime };
   }
 }
 
@@ -272,7 +337,7 @@ export function createCountingJsonRpcProvider(
     const retry = await pureRetry(attemptReq, response, attempt);
     if (retry) {
       try {
-        for (const method of jsonRpcMethodsFromBody(attemptReq?.body)) tracker.record(method);
+        for (const method of jsonRpcMethodsFromBody(attemptReq?.body)) tracker.record(method, currentRpcUsageConsumer());
       } catch { /* accounting must never break the retry path */ }
     }
     return retry;
@@ -287,5 +352,10 @@ export function createCountingJsonRpcProvider(
         // dynamic detection behavior.
         staticNetwork: network as JsonRpcApiProviderOptions['staticNetwork'],
       };
-  return new CountingJsonRpcProvider(fetchRequest, network, providerOptions, (method) => tracker.record(method));
+  return new CountingJsonRpcProvider(
+    fetchRequest,
+    network,
+    providerOptions,
+    (method) => tracker.record(method, currentRpcUsageConsumer()),
+  );
 }

--- a/packages/chain/src/rpc-usage.ts
+++ b/packages/chain/src/rpc-usage.ts
@@ -125,7 +125,7 @@ export function mergeRpcUsageWindows(
   let lifetimeTotal = 0;
   for (const w of defined) {
     for (const [m, c] of Object.entries(w.byMethod)) byMethod[m] = (byMethod[m] ?? 0) + c;
-    for (const [consumer, c] of Object.entries(w.ethCallByConsumer)) {
+    for (const [consumer, c] of Object.entries(w.ethCallByConsumer ?? {})) {
       ethCallByConsumer[consumer] = (ethCallByConsumer[consumer] ?? 0) + c;
     }
     lifetimeTotal += w.lifetimeTotal;
@@ -148,9 +148,11 @@ export interface RpcUsageWindow {
    * the billing-exact aggregate count and existing dashboards should continue
    * to use it. The consumer map is emitted as separate daemon log lines so it
    * cannot double-count aggregate `rpc_usage` queries. Empty map means no
-   * attributed `eth_call`s in the current drain window.
+   * attributed `eth_call`s in the current drain window. Optional at the public
+   * drain boundary for compatibility with pre-attribution drain sources; local
+   * chain helpers return a normalized concrete map.
    */
-  ethCallByConsumer: Record<string, number>;
+  ethCallByConsumer?: Record<string, number>;
   /** Raw requests since process start (monotonic; NOT reset by drain). */
   lifetimeTotal: number;
 }

--- a/packages/chain/src/rpc-usage.ts
+++ b/packages/chain/src/rpc-usage.ts
@@ -89,24 +89,12 @@ export function jsonRpcMethodsFromBody(body: Uint8Array | null | undefined): str
 }
 
 /** A fresh all-zero window — the identity element for merging and the value of "nothing to report". */
-export function emptyRpcUsageWindow(): RpcUsageWindow {
+export function emptyRpcUsageWindow(): NormalizedRpcUsageWindow {
   return { byMethod: {}, ethCallByConsumer: {}, lifetimeTotal: 0 };
 }
 
-/**
- * Compatibility input accepted at merge/format/drain boundaries. Chain-owned
- * producers return a concrete {@link RpcUsageWindow}; this loose shape exists
- * only so pre-attribution drain sources do not break aggregate `rpc_usage`
- * logging while rolling through a mixed-version process boundary.
- */
-export type RpcUsageWindowInput = {
-  byMethod: Record<string, number>;
-  ethCallByConsumer?: Record<string, number>;
-  lifetimeTotal: number;
-};
-
-/** Normalize a legacy/loose input into the concrete telemetry model. */
-export function normalizeRpcUsageWindow(window: RpcUsageWindowInput): RpcUsageWindow {
+/** Normalize a public drain-window input into the concrete telemetry model. */
+export function normalizeRpcUsageWindow(window: RpcUsageWindow): NormalizedRpcUsageWindow {
   return {
     byMethod: window.byMethod,
     ethCallByConsumer: window.ethCallByConsumer ?? {},
@@ -137,9 +125,9 @@ export interface RpcUsageDrainable {
  * always a concrete window — empty when there is nothing to merge.
  */
 export function mergeRpcUsageWindows(
-  ...windows: Array<RpcUsageWindowInput | undefined>
-): RpcUsageWindow {
-  const defined = windows.filter((w): w is RpcUsageWindowInput => w !== undefined);
+  ...windows: Array<RpcUsageWindow | undefined>
+): NormalizedRpcUsageWindow {
+  const defined = windows.filter((w): w is RpcUsageWindow => w !== undefined);
   if (defined.length === 0) return emptyRpcUsageWindow();
   const byMethod: Record<string, number> = {};
   const ethCallByConsumer: Record<string, number> = {};
@@ -170,12 +158,19 @@ export interface RpcUsageWindow {
    * the billing-exact aggregate count and existing dashboards should continue
    * to use it. The consumer map is emitted as separate daemon log lines so it
    * cannot double-count aggregate `rpc_usage` queries. Empty map means no
-   * attributed `eth_call`s in the current drain window. Legacy missing-field
-   * compatibility is isolated in {@link normalizeRpcUsageWindow}.
+   * attributed `eth_call`s in the current drain window. Optional only to
+   * preserve source compatibility for external drain sources that still return
+   * the pre-attribution aggregate window. Package-owned producers return the
+   * concrete {@link NormalizedRpcUsageWindow} shape.
    */
-  ethCallByConsumer: Record<string, number>;
+  ethCallByConsumer?: Record<string, number>;
   /** Raw requests since process start (monotonic; NOT reset by drain). */
   lifetimeTotal: number;
+}
+
+/** Concrete package-owned telemetry window after legacy inputs are normalized. */
+export interface NormalizedRpcUsageWindow extends RpcUsageWindow {
+  ethCallByConsumer: Record<string, number>;
 }
 
 /**
@@ -286,7 +281,7 @@ export class RpcUsageTracker {
    * cumulative totals) are what the daemon logs, so `sum_over_time` in Grafana
    * yields exact request counts over any range.
    */
-  drainWindow(): RpcUsageWindow {
+  drainWindow(): NormalizedRpcUsageWindow {
     const byMethod: Record<string, number> = {};
     for (const [method, count] of this.window) byMethod[method] = count;
     this.window.clear();

--- a/packages/chain/test/rpc-usage.unit.test.ts
+++ b/packages/chain/test/rpc-usage.unit.test.ts
@@ -9,6 +9,7 @@
  * chain_id} labels, drain-resets-window semantics, and label bounding.
  */
 import { describe, it, expect, afterEach } from 'vitest';
+import { Contract } from 'ethers';
 import { metrics } from '@opentelemetry/api';
 import {
   MeterProvider,
@@ -426,9 +427,9 @@ describe('RPC usage accounting — raw request counts EQUAL the server-received 
     const t = new RpcUsageTracker(() => 'evm:31337');
     const max = RpcUsageTracker.MAX_WINDOW_CONSUMERS;
     for (let i = 0; i < max + 4; i++) {
-      t.record('eth_call', `consumer.${i}`);
+      withRpcUsageConsumer(`consumer.${i}`, () => t.record('eth_call'));
     }
-    t.record('eth_call', 'consumer.0');
+    withRpcUsageConsumer('consumer.0', () => t.record('eth_call'));
 
     const w = t.drainWindow();
     expect(Object.keys(w.ethCallByConsumer ?? {})).toHaveLength(max + 1);
@@ -458,5 +459,27 @@ describe('RPC usage accounting — raw request counts EQUAL the server-received 
     expect(rawEthCallHits).toBeGreaterThanOrEqual(2);
     expect(usage.byMethod.eth_call).toBe(rawEthCallHits);
     expect(usage.ethCallByConsumer?.['unit.eth_call']).toBe(rawEthCallHits);
+  }, 30_000);
+
+  it('attributes failover contract-view eth_call attempts to the readContract label', async () => {
+    installMeter();
+    const primary = await startLoopbackRpc({ throttle: ['eth_call'] });
+    const backup = await startLoopbackRpc();
+    servers.push(primary, backup);
+    const a: any = new EVMChainAdapter(minimalConfig({
+      rpcUrl: primary.url,
+      rpcUrls: [backup.url],
+      chainId: 'evm:31337',
+    }));
+    adapters.push(a);
+    const contract = new Contract(HUB, ['function value() view returns (uint256)']);
+
+    await expect(a.readContract(contract, 'unit.contract.value', 'value')).resolves.toBe(0n);
+
+    const usage = a.drainRpcUsage();
+    const rawEthCallHits = primary.hits('eth_call') + backup.hits('eth_call');
+    expect(rawEthCallHits).toBeGreaterThanOrEqual(2);
+    expect(usage.byMethod.eth_call).toBe(rawEthCallHits);
+    expect(usage.ethCallByConsumer?.['unit.contract.value']).toBe(rawEthCallHits);
   }, 30_000);
 });

--- a/packages/chain/test/rpc-usage.unit.test.ts
+++ b/packages/chain/test/rpc-usage.unit.test.ts
@@ -359,8 +359,8 @@ describe('RPC usage accounting — raw request counts EQUAL the server-received 
   });
 
   it('mergeRpcUsageWindows skips undefined inputs; nothing to merge yields a concrete EMPTY window', () => {
-    const w = { byMethod: { eth_call: 1 }, lifetimeTotal: 1 };
-    const empty = { byMethod: {}, lifetimeTotal: 0 };
+    const w = { byMethod: { eth_call: 1 }, ethCallByConsumer: {}, lifetimeTotal: 1 };
+    const empty = { byMethod: {}, ethCallByConsumer: {}, lifetimeTotal: 0 };
     expect(mergeRpcUsageWindows(undefined, w, undefined)).toEqual(w);
     expect(mergeRpcUsageWindows(undefined, undefined)).toEqual(empty);
     expect(mergeRpcUsageWindows()).toEqual(empty);
@@ -432,9 +432,9 @@ describe('RPC usage accounting — raw request counts EQUAL the server-received 
     withRpcUsageConsumer('consumer.0', () => t.record('eth_call'));
 
     const w = t.drainWindow();
-    expect(Object.keys(w.ethCallByConsumer ?? {})).toHaveLength(max + 1);
-    expect(w.ethCallByConsumer?.['consumer.0']).toBe(2);
-    expect(w.ethCallByConsumer?.other).toBe(4);
+    expect(Object.keys(w.ethCallByConsumer)).toHaveLength(max + 1);
+    expect(w.ethCallByConsumer['consumer.0']).toBe(2);
+    expect(w.ethCallByConsumer.other).toBe(4);
     expect(w.byMethod.eth_call).toBe(max + 5);
   });
 
@@ -458,7 +458,28 @@ describe('RPC usage accounting — raw request counts EQUAL the server-received 
     const rawEthCallHits = primary.hits('eth_call') + backup.hits('eth_call');
     expect(rawEthCallHits).toBeGreaterThanOrEqual(2);
     expect(usage.byMethod.eth_call).toBe(rawEthCallHits);
-    expect(usage.ethCallByConsumer?.['unit.eth_call']).toBe(rawEthCallHits);
+    expect(usage.ethCallByConsumer['unit.eth_call']).toBe(rawEthCallHits);
+  }, 30_000);
+
+  it('attributes same-endpoint eth_call retry attempts to the readProvider label', async () => {
+    installMeter();
+    const rpc = await startLoopbackRpc({ throttle: ['eth_call'] });
+    servers.push(rpc);
+    const a: any = new EVMChainAdapter(minimalConfig({
+      rpcUrl: rpc.url,
+      chainId: 'evm:31337',
+    }));
+    adapters.push(a);
+
+    await expect(
+      a.readProvider('unit.eth_call.retry', (p: any) => p.send('eth_call', [{ to: HUB, data: '0x' }, 'latest'])),
+    ).rejects.toBeTruthy();
+
+    const usage = a.drainRpcUsage();
+    const rawEthCallHits = rpc.hits('eth_call');
+    expect(rawEthCallHits).toBeGreaterThanOrEqual(2);
+    expect(usage.byMethod.eth_call).toBe(rawEthCallHits);
+    expect(usage.ethCallByConsumer['unit.eth_call.retry']).toBe(rawEthCallHits);
   }, 30_000);
 
   it('attributes failover contract-view eth_call attempts to the readContract label', async () => {
@@ -480,6 +501,6 @@ describe('RPC usage accounting — raw request counts EQUAL the server-received 
     const rawEthCallHits = primary.hits('eth_call') + backup.hits('eth_call');
     expect(rawEthCallHits).toBeGreaterThanOrEqual(2);
     expect(usage.byMethod.eth_call).toBe(rawEthCallHits);
-    expect(usage.ethCallByConsumer?.['unit.contract.value']).toBe(rawEthCallHits);
+    expect(usage.ethCallByConsumer['unit.contract.value']).toBe(rawEthCallHits);
   }, 30_000);
 });

--- a/packages/chain/test/rpc-usage.unit.test.ts
+++ b/packages/chain/test/rpc-usage.unit.test.ts
@@ -26,8 +26,10 @@ import {
   normalizeRpcUsageConsumer,
   rpcUsageWindowTotal,
   RpcUsageTracker,
+  type RpcUsageDrainable,
   withRpcUsageConsumer,
 } from '../src/rpc-usage.js';
+import type { ChainAdapter } from '../src/chain-adapter.js';
 import { startLoopbackRpc, type LoopbackRpc } from './loopback-rpc-harness.js';
 
 const DEPLOYER_PK = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
@@ -378,6 +380,21 @@ describe('RPC usage accounting — raw request counts EQUAL the server-received 
     expect(mergeRpcUsageWindows()).toEqual(empty);
   });
 
+  it('keeps legacy aggregate-only drain sources source-compatible at public boundaries', () => {
+    const drainable: RpcUsageDrainable = {
+      drainRpcUsage: () => ({ byMethod: { eth_call: 1 }, lifetimeTotal: 1 }),
+    };
+    const adapter = {
+      drainRpcUsage: () => ({ byMethod: { eth_getLogs: 2 }, lifetimeTotal: 2 }),
+    } satisfies Pick<ChainAdapter, 'drainRpcUsage'>;
+
+    expect(mergeRpcUsageWindows(drainable.drainRpcUsage(), adapter.drainRpcUsage?.())).toEqual({
+      byMethod: { eth_call: 1, eth_getLogs: 2 },
+      ethCallByConsumer: {},
+      lifetimeTotal: 3,
+    });
+  });
+
   it('tracker.record never throws; window keys stay RAW (log token-safety is the formatter concern)', () => {
     const t = new RpcUsageTracker(() => 'evm:31337');
     expect(() => t.record('eth_call')).not.toThrow();
@@ -404,6 +421,27 @@ describe('RPC usage accounting — raw request counts EQUAL the server-received 
     expect(w.byMethod).toEqual({ eth_call: 3, eth_getLogs: 1 });
     expect(w.ethCallByConsumer).toEqual({ 'pcaNFT.getAccountInfo': 2 });
     expect(rpcUsageWindowTotal(w)).toBe(4);
+  });
+
+  it('drains eth_call consumer attribution as a per-window delta', () => {
+    const t = new RpcUsageTracker(() => 'evm:31337');
+    withRpcUsageConsumer('pcaNFT.getAccountInfo', () => t.record('eth_call'));
+
+    const first = t.drainWindow();
+    expect(first.byMethod).toEqual({ eth_call: 1 });
+    expect(first.ethCallByConsumer).toEqual({ 'pcaNFT.getAccountInfo': 1 });
+    expect(first.lifetimeTotal).toBe(1);
+
+    t.record('eth_getLogs');
+    const second = t.drainWindow();
+    expect(second.byMethod).toEqual({ eth_getLogs: 1 });
+    expect(second.ethCallByConsumer).toEqual({});
+    expect(second.lifetimeTotal).toBe(2);
+
+    const third = t.drainWindow();
+    expect(third.byMethod).toEqual({});
+    expect(third.ethCallByConsumer).toEqual({});
+    expect(third.lifetimeTotal).toBe(2);
   });
 
   it('keeps overlapping async consumer scopes isolated', async () => {
@@ -542,5 +580,29 @@ describe('RPC usage accounting — raw request counts EQUAL the server-received 
     expect(rawEthCallHits).toBeGreaterThanOrEqual(2);
     expect(usage.byMethod.eth_call).toBe(rawEthCallHits);
     expect(usage.ethCallByConsumer['unit.contract.value']).toBe(rawEthCallHits);
+  }, 30_000);
+
+  it('attributes readContractWith eth_call attempts through the real transport path', async () => {
+    installMeter();
+    const primary = await startLoopbackRpc({ throttle: ['eth_call'] });
+    const backup = await startLoopbackRpc();
+    servers.push(primary, backup);
+    const a: any = new EVMChainAdapter(minimalConfig({
+      rpcUrl: primary.url,
+      rpcUrls: [backup.url],
+      chainId: 'evm:31337',
+    }));
+    adapters.push(a);
+    const contract = new Contract(HUB, ['function value() view returns (uint256)']);
+
+    await expect(
+      a.readContractWith(contract, 'unit.contract.with', (c: any) => c.value()),
+    ).resolves.toBe(0n);
+
+    const usage = a.drainRpcUsage();
+    const rawEthCallHits = primary.hits('eth_call') + backup.hits('eth_call');
+    expect(rawEthCallHits).toBeGreaterThanOrEqual(2);
+    expect(usage.byMethod.eth_call).toBe(rawEthCallHits);
+    expect(usage.ethCallByConsumer['unit.contract.with']).toBe(rawEthCallHits);
   }, 30_000);
 });

--- a/packages/chain/test/rpc-usage.unit.test.ts
+++ b/packages/chain/test/rpc-usage.unit.test.ts
@@ -360,8 +360,14 @@ describe('RPC usage accounting — raw request counts EQUAL the server-received 
 
   it('mergeRpcUsageWindows skips undefined inputs; nothing to merge yields a concrete EMPTY window', () => {
     const w = { byMethod: { eth_call: 1 }, ethCallByConsumer: {}, lifetimeTotal: 1 };
+    const legacy = { byMethod: { eth_call: 2 }, lifetimeTotal: 2 };
     const empty = { byMethod: {}, ethCallByConsumer: {}, lifetimeTotal: 0 };
     expect(mergeRpcUsageWindows(undefined, w, undefined)).toEqual(w);
+    expect(mergeRpcUsageWindows(legacy)).toEqual({
+      byMethod: { eth_call: 2 },
+      ethCallByConsumer: {},
+      lifetimeTotal: 2,
+    });
     expect(mergeRpcUsageWindows(undefined, undefined)).toEqual(empty);
     expect(mergeRpcUsageWindows()).toEqual(empty);
   });

--- a/packages/chain/test/rpc-usage.unit.test.ts
+++ b/packages/chain/test/rpc-usage.unit.test.ts
@@ -18,7 +18,14 @@ import {
 } from '@opentelemetry/sdk-metrics';
 import { rebuildMetrics } from '@origintrail-official/dkg-core';
 import { EVMChainAdapter, type EVMAdapterConfig } from '../src/evm-adapter.js';
-import { boundedRpcMethodLabel, mergeRpcUsageWindows, rpcUsageWindowTotal, RpcUsageTracker } from '../src/rpc-usage.js';
+import {
+  boundedRpcMethodLabel,
+  mergeRpcUsageWindows,
+  normalizeRpcUsageConsumer,
+  rpcUsageWindowTotal,
+  RpcUsageTracker,
+  withRpcUsageConsumer,
+} from '../src/rpc-usage.js';
 import { startLoopbackRpc, type LoopbackRpc } from './loopback-rpc-harness.js';
 
 const DEPLOYER_PK = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
@@ -332,11 +339,20 @@ describe('RPC usage accounting — raw request counts EQUAL the server-received 
 
   it('mergeRpcUsageWindows sums per-method and lifetime across trackers', () => {
     const merged = mergeRpcUsageWindows(
-      { byMethod: { eth_call: 5, eth_estimateGas: 2 }, lifetimeTotal: 100 },
-      { byMethod: { eth_call: 3, eth_sendRawTransaction: 4 }, lifetimeTotal: 50 },
+      {
+        byMethod: { eth_call: 5, eth_estimateGas: 2 },
+        ethCallByConsumer: { 'pcaNFT.getAccountInfo': 2 },
+        lifetimeTotal: 100,
+      },
+      {
+        byMethod: { eth_call: 3, eth_sendRawTransaction: 4 },
+        ethCallByConsumer: { 'pcaNFT.getAccountInfo': 1, 'token.balanceOf': 2 },
+        lifetimeTotal: 50,
+      },
     );
     expect(merged).toEqual({
       byMethod: { eth_call: 8, eth_estimateGas: 2, eth_sendRawTransaction: 4 },
+      ethCallByConsumer: { 'pcaNFT.getAccountInfo': 3, 'token.balanceOf': 2 },
       lifetimeTotal: 150,
     });
   });
@@ -361,4 +377,86 @@ describe('RPC usage accounting — raw request counts EQUAL the server-received 
     expect(w.byMethod['debug_traceTransaction']).toBe(1); // NOT sanitized to 'other'
     expect(w.byMethod['other']).toBe(2);
   });
+
+  it('attributes eth_call to the current bounded consumer without changing aggregate totals', () => {
+    const t = new RpcUsageTracker(() => 'evm:31337');
+    withRpcUsageConsumer('pcaNFT.getAccountInfo', () => {
+      t.record('eth_call');
+      t.record('eth_call');
+      t.record('eth_getLogs');
+    });
+    t.record('eth_call');
+
+    const w = t.drainWindow();
+    expect(w.byMethod).toEqual({ eth_call: 3, eth_getLogs: 1 });
+    expect(w.ethCallByConsumer).toEqual({ 'pcaNFT.getAccountInfo': 2 });
+    expect(rpcUsageWindowTotal(w)).toBe(4);
+  });
+
+  it('keeps overlapping async consumer scopes isolated', async () => {
+    const t = new RpcUsageTracker(() => 'evm:31337');
+    await Promise.all([
+      withRpcUsageConsumer('cgStorage.getContextGraph', async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        t.record('eth_call');
+      }),
+      withRpcUsageConsumer('pcaNFT.getAccountInfo', async () => {
+        t.record('eth_call');
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        t.record('eth_call');
+      }),
+    ]);
+
+    const w = t.drainWindow();
+    expect(w.byMethod).toEqual({ eth_call: 3 });
+    expect(w.ethCallByConsumer).toEqual({
+      'cgStorage.getContextGraph': 1,
+      'pcaNFT.getAccountInfo': 2,
+    });
+  });
+
+  it('normalizes and bounds consumer labels', () => {
+    expect(normalizeRpcUsageConsumer(' Hub.getContractAddress(Token) ')).toBe('Hub.getContractAddress_Token');
+    expect(normalizeRpcUsageConsumer('bad label/with=spaces')).toBe('bad_label_with_spaces');
+    expect(normalizeRpcUsageConsumer('')).toBeUndefined();
+    expect(normalizeRpcUsageConsumer('x'.repeat(65))).toBe('other');
+  });
+
+  it('caps distinct eth_call consumer keys and overflows to other', () => {
+    const t = new RpcUsageTracker(() => 'evm:31337');
+    const max = RpcUsageTracker.MAX_WINDOW_CONSUMERS;
+    for (let i = 0; i < max + 4; i++) {
+      t.record('eth_call', `consumer.${i}`);
+    }
+    t.record('eth_call', 'consumer.0');
+
+    const w = t.drainWindow();
+    expect(Object.keys(w.ethCallByConsumer ?? {})).toHaveLength(max + 1);
+    expect(w.ethCallByConsumer?.['consumer.0']).toBe(2);
+    expect(w.ethCallByConsumer?.other).toBe(4);
+    expect(w.byMethod.eth_call).toBe(max + 5);
+  });
+
+  it('attributes failover eth_call attempts to the readProvider label', async () => {
+    installMeter();
+    const primary = await startLoopbackRpc({ throttle: ['eth_call'] });
+    const backup = await startLoopbackRpc();
+    servers.push(primary, backup);
+    const a: any = new EVMChainAdapter(minimalConfig({
+      rpcUrl: primary.url,
+      rpcUrls: [primary.url, backup.url],
+      chainId: 'evm:31337',
+    }));
+    adapters.push(a);
+
+    await expect(
+      a.readProvider('unit.eth_call', (p: any) => p.send('eth_call', [{ to: HUB, data: '0x' }, 'latest'])),
+    ).resolves.toBeDefined();
+
+    const usage = a.drainRpcUsage();
+    const rawEthCallHits = primary.hits('eth_call') + backup.hits('eth_call');
+    expect(rawEthCallHits).toBeGreaterThanOrEqual(2);
+    expect(usage.byMethod.eth_call).toBe(rawEthCallHits);
+    expect(usage.ethCallByConsumer?.['unit.eth_call']).toBe(rawEthCallHits);
+  }, 30_000);
 });

--- a/packages/chain/test/rpc-usage.unit.test.ts
+++ b/packages/chain/test/rpc-usage.unit.test.ts
@@ -22,6 +22,7 @@ import { EVMChainAdapter, type EVMAdapterConfig } from '../src/evm-adapter.js';
 import {
   boundedRpcMethodLabel,
   mergeRpcUsageWindows,
+  normalizeRpcUsageWindow,
   normalizeRpcUsageConsumer,
   rpcUsageWindowTotal,
   RpcUsageTracker,
@@ -368,6 +369,11 @@ describe('RPC usage accounting — raw request counts EQUAL the server-received 
       ethCallByConsumer: {},
       lifetimeTotal: 2,
     });
+    expect(normalizeRpcUsageWindow(legacy)).toEqual({
+      byMethod: { eth_call: 2 },
+      ethCallByConsumer: {},
+      lifetimeTotal: 2,
+    });
     expect(mergeRpcUsageWindows(undefined, undefined)).toEqual(empty);
     expect(mergeRpcUsageWindows()).toEqual(empty);
   });
@@ -465,6 +471,34 @@ describe('RPC usage accounting — raw request counts EQUAL the server-received 
     expect(rawEthCallHits).toBeGreaterThanOrEqual(2);
     expect(usage.byMethod.eth_call).toBe(rawEthCallHits);
     expect(usage.ethCallByConsumer['unit.eth_call']).toBe(rawEthCallHits);
+  }, 30_000);
+
+  it('uses an explicit rpcUsageConsumer key independent of the human read label', async () => {
+    installMeter();
+    const primary = await startLoopbackRpc({ throttle: ['eth_call'] });
+    const backup = await startLoopbackRpc();
+    servers.push(primary, backup);
+    const a: any = new EVMChainAdapter(minimalConfig({
+      rpcUrl: primary.url,
+      rpcUrls: [primary.url, backup.url],
+      chainId: 'evm:31337',
+    }));
+    adapters.push(a);
+
+    await expect(
+      a.readProvider(
+        'human label with spaces can change',
+        (p: any) => p.send('eth_call', [{ to: HUB, data: '0x' }, 'latest']),
+        { rpcUsageConsumer: 'unit.eth_call.stable' },
+      ),
+    ).resolves.toBeDefined();
+
+    const usage = a.drainRpcUsage();
+    const rawEthCallHits = primary.hits('eth_call') + backup.hits('eth_call');
+    expect(rawEthCallHits).toBeGreaterThanOrEqual(2);
+    expect(usage.byMethod.eth_call).toBe(rawEthCallHits);
+    expect(usage.ethCallByConsumer['unit.eth_call.stable']).toBe(rawEthCallHits);
+    expect(usage.ethCallByConsumer.human_label_with_spaces_can_change).toBeUndefined();
   }, 30_000);
 
   it('attributes same-endpoint eth_call retry attempts to the readProvider label', async () => {

--- a/packages/cli/src/daemon/rpc-usage-log.ts
+++ b/packages/cli/src/daemon/rpc-usage-log.ts
@@ -36,7 +36,7 @@ export function formatRpcUsageLines(
     if (!Number.isFinite(count) || count <= 0) continue;
     lines.push(`rpc_usage method=${safeToken(method, 'other')} count=${Math.floor(count)} window_s=${windowSeconds}${chain}`);
   }
-  for (const [consumer, count] of Object.entries(usage.ethCallByConsumer)) {
+  for (const [consumer, count] of Object.entries(usage.ethCallByConsumer ?? {})) {
     if (!Number.isFinite(count) || count <= 0) continue;
     lines.push(
       `rpc_usage_by_consumer method=eth_call consumer=${safeToken(consumer, 'other')} ` +

--- a/packages/cli/src/daemon/rpc-usage-log.ts
+++ b/packages/cli/src/daemon/rpc-usage-log.ts
@@ -36,7 +36,7 @@ export function formatRpcUsageLines(
     if (!Number.isFinite(count) || count <= 0) continue;
     lines.push(`rpc_usage method=${safeToken(method, 'other')} count=${Math.floor(count)} window_s=${windowSeconds}${chain}`);
   }
-  for (const [consumer, count] of Object.entries(usage.ethCallByConsumer ?? {})) {
+  for (const [consumer, count] of Object.entries(usage.ethCallByConsumer)) {
     if (!Number.isFinite(count) || count <= 0) continue;
     lines.push(
       `rpc_usage_by_consumer method=eth_call consumer=${safeToken(consumer, 'other')} ` +

--- a/packages/cli/src/daemon/rpc-usage-log.ts
+++ b/packages/cli/src/daemon/rpc-usage-log.ts
@@ -12,7 +12,12 @@
  *   rpc_usage_by_consumer method=eth_call consumer=pcaNFT.getAccountInfo count=7 window_s=60 chain=base:8453
  */
 
-import { rpcUsageWindowTotal, type RpcUsageDrainable, type RpcUsageWindow } from '@origintrail-official/dkg-chain';
+import {
+  normalizeRpcUsageWindow,
+  rpcUsageWindowTotal,
+  type RpcUsageDrainable,
+  type RpcUsageWindowInput,
+} from '@origintrail-official/dkg-chain';
 
 /** logfmt-token safety: methods/chain ids are self-generated, but never emit a token that could break parsing. */
 function safeToken(value: string, fallback: string): string {
@@ -25,18 +30,20 @@ function safeToken(value: string, fallback: string): string {
  * nothing rather than a stream of zeros).
  */
 export function formatRpcUsageLines(
-  usage: RpcUsageWindow,
+  usage: RpcUsageWindowInput,
   windowSeconds: number,
   chainId?: string,
 ): string[] {
-  if (!usage || rpcUsageWindowTotal(usage) <= 0) return [];
+  if (!usage) return [];
+  const normalized = normalizeRpcUsageWindow(usage);
+  if (rpcUsageWindowTotal(normalized) <= 0) return [];
   const chain = chainId ? ` chain=${safeToken(chainId, 'unknown')}` : '';
   const lines: string[] = [];
-  for (const [method, count] of Object.entries(usage.byMethod)) {
+  for (const [method, count] of Object.entries(normalized.byMethod)) {
     if (!Number.isFinite(count) || count <= 0) continue;
     lines.push(`rpc_usage method=${safeToken(method, 'other')} count=${Math.floor(count)} window_s=${windowSeconds}${chain}`);
   }
-  for (const [consumer, count] of Object.entries(usage.ethCallByConsumer ?? {})) {
+  for (const [consumer, count] of Object.entries(normalized.ethCallByConsumer)) {
     if (!Number.isFinite(count) || count <= 0) continue;
     lines.push(
       `rpc_usage_by_consumer method=eth_call consumer=${safeToken(consumer, 'other')} ` +
@@ -64,7 +71,7 @@ export function emitRpcUsage(
 ): number {
   try {
     const usage = source?.drainRpcUsage?.();
-    if (!usage || rpcUsageWindowTotal(usage) <= 0) return 0;
+    if (!usage) return 0;
     const lines = formatRpcUsageLines(usage, windowSeconds, chainId);
     for (const line of lines) emit(line);
     return lines.length;

--- a/packages/cli/src/daemon/rpc-usage-log.ts
+++ b/packages/cli/src/daemon/rpc-usage-log.ts
@@ -13,6 +13,7 @@
  */
 
 import {
+  normalizeRpcUsageWindow,
   rpcUsageWindowTotal,
   type RpcUsageDrainable,
   type RpcUsageWindow,
@@ -21,10 +22,6 @@ import {
 /** logfmt-token safety: methods/chain ids are self-generated, but never emit a token that could break parsing. */
 function safeToken(value: string, fallback: string): string {
   return /^[A-Za-z0-9_.:-]{1,64}$/.test(value) ? value : fallback;
-}
-
-function normalizeRpcUsageWindow(usage: RpcUsageWindow): RpcUsageWindow & { ethCallByConsumer: Record<string, number> } {
-  return { ...usage, ethCallByConsumer: usage.ethCallByConsumer ?? {} };
 }
 
 /**

--- a/packages/cli/src/daemon/rpc-usage-log.ts
+++ b/packages/cli/src/daemon/rpc-usage-log.ts
@@ -13,15 +13,18 @@
  */
 
 import {
-  normalizeRpcUsageWindow,
   rpcUsageWindowTotal,
   type RpcUsageDrainable,
-  type RpcUsageWindowInput,
+  type RpcUsageWindow,
 } from '@origintrail-official/dkg-chain';
 
 /** logfmt-token safety: methods/chain ids are self-generated, but never emit a token that could break parsing. */
 function safeToken(value: string, fallback: string): string {
   return /^[A-Za-z0-9_.:-]{1,64}$/.test(value) ? value : fallback;
+}
+
+function normalizeRpcUsageWindow(usage: RpcUsageWindow): RpcUsageWindow & { ethCallByConsumer: Record<string, number> } {
+  return { ...usage, ethCallByConsumer: usage.ethCallByConsumer ?? {} };
 }
 
 /**
@@ -30,7 +33,7 @@ function safeToken(value: string, fallback: string): string {
  * nothing rather than a stream of zeros).
  */
 export function formatRpcUsageLines(
-  usage: RpcUsageWindowInput,
+  usage: RpcUsageWindow,
   windowSeconds: number,
   chainId?: string,
 ): string[] {

--- a/packages/cli/src/daemon/rpc-usage-log.ts
+++ b/packages/cli/src/daemon/rpc-usage-log.ts
@@ -7,6 +7,9 @@
  *
  * Line shape (parsed in LogQL with `| logfmt` on the log body):
  *   rpc_usage method=eth_call count=42 window_s=60 chain=base:8453
+ *
+ * Companion diagnostic line shape for `eth_call` attribution:
+ *   rpc_usage_by_consumer method=eth_call consumer=pcaNFT.getAccountInfo count=7 window_s=60 chain=base:8453
  */
 
 import { rpcUsageWindowTotal, type RpcUsageDrainable, type RpcUsageWindow } from '@origintrail-official/dkg-chain';
@@ -32,6 +35,13 @@ export function formatRpcUsageLines(
   for (const [method, count] of Object.entries(usage.byMethod)) {
     if (!Number.isFinite(count) || count <= 0) continue;
     lines.push(`rpc_usage method=${safeToken(method, 'other')} count=${Math.floor(count)} window_s=${windowSeconds}${chain}`);
+  }
+  for (const [consumer, count] of Object.entries(usage.ethCallByConsumer ?? {})) {
+    if (!Number.isFinite(count) || count <= 0) continue;
+    lines.push(
+      `rpc_usage_by_consumer method=eth_call consumer=${safeToken(consumer, 'other')} ` +
+      `count=${Math.floor(count)} window_s=${windowSeconds}${chain}`,
+    );
   }
   return lines;
 }

--- a/packages/cli/test/rpc-usage-log.test.ts
+++ b/packages/cli/test/rpc-usage-log.test.ts
@@ -41,6 +41,48 @@ describe('formatRpcUsageLines — the Grafana-facing rpc_usage contract', () => 
     );
     expect(lines).toEqual(['rpc_usage method=other count=5 window_s=60 chain=unknown']);
   });
+
+  it('emits companion eth_call consumer attribution lines without changing aggregate lines', () => {
+    const lines = formatRpcUsageLines(
+      {
+        byMethod: { eth_call: 42, eth_getLogs: 7 },
+        ethCallByConsumer: {
+          'pcaNFT.getAccountInfo': 30,
+          'Hub.getContractAddress_Token': 12,
+          unsafe_consumer: 0,
+        },
+        lifetimeTotal: 49,
+      },
+      60,
+      'base:8453',
+    );
+
+    expect(lines).toContain('rpc_usage method=eth_call count=42 window_s=60 chain=base:8453');
+    expect(lines).toContain('rpc_usage method=eth_getLogs count=7 window_s=60 chain=base:8453');
+    expect(lines).toContain(
+      'rpc_usage_by_consumer method=eth_call consumer=pcaNFT.getAccountInfo count=30 window_s=60 chain=base:8453',
+    );
+    expect(lines).toContain(
+      'rpc_usage_by_consumer method=eth_call consumer=Hub.getContractAddress_Token count=12 window_s=60 chain=base:8453',
+    );
+    expect(lines.some((l) => l.includes('unsafe_consumer'))).toBe(false);
+    for (const l of lines) expect(l).toMatch(/^rpc_usage(_by_consumer)?( [a-z_]+=[A-Za-z0-9_.:-]+)+$/);
+  });
+
+  it('sanitizes unsafe consumer values in attribution lines', () => {
+    const lines = formatRpcUsageLines(
+      {
+        byMethod: { eth_call: 2 },
+        ethCallByConsumer: { 'bad consumer=value': 2 },
+        lifetimeTotal: 2,
+      },
+      60,
+    );
+    expect(lines).toEqual([
+      'rpc_usage method=eth_call count=2 window_s=60',
+      'rpc_usage_by_consumer method=eth_call consumer=other count=2 window_s=60',
+    ]);
+  });
 });
 
 describe('composite daemon source — agent + publisher-runtime windows merged at drain time', () => {

--- a/packages/cli/test/rpc-usage-log.test.ts
+++ b/packages/cli/test/rpc-usage-log.test.ts
@@ -10,7 +10,7 @@ import { formatRpcUsageLines, emitRpcUsage, startRpcUsageTelemetry } from '../sr
 describe('formatRpcUsageLines — the Grafana-facing rpc_usage contract', () => {
   it('emits one logfmt line per method with count/window/chain', () => {
     const lines = formatRpcUsageLines(
-      { byMethod: { eth_call: 42, eth_getLogs: 7 }, lifetimeTotal: 49 },
+      { byMethod: { eth_call: 42, eth_getLogs: 7 }, ethCallByConsumer: {}, lifetimeTotal: 49 },
       60,
       'base:8453',
     );
@@ -22,12 +22,12 @@ describe('formatRpcUsageLines — the Grafana-facing rpc_usage contract', () => 
   });
 
   it('returns [] for an empty window (idle node logs nothing, not zeros)', () => {
-    expect(formatRpcUsageLines({ byMethod: {}, lifetimeTotal: 123 }, 60, 'base:8453')).toEqual([]);
+    expect(formatRpcUsageLines({ byMethod: {}, ethCallByConsumer: {}, lifetimeTotal: 123 }, 60, 'base:8453')).toEqual([]);
   });
 
   it('omits chain when unset and skips zero/negative/NaN counts', () => {
     const lines = formatRpcUsageLines(
-      { byMethod: { eth_call: 3, eth_getLogs: 0, eth_gasPrice: NaN as unknown as number }, lifetimeTotal: 3 },
+      { byMethod: { eth_call: 3, eth_getLogs: 0, eth_gasPrice: NaN as unknown as number }, ethCallByConsumer: {}, lifetimeTotal: 3 },
       60,
     );
     expect(lines).toEqual(['rpc_usage method=eth_call count=3 window_s=60']);
@@ -35,7 +35,7 @@ describe('formatRpcUsageLines — the Grafana-facing rpc_usage contract', () => 
 
   it('sanitizes non-token-safe method/chain values (defensive logfmt safety)', () => {
     const lines = formatRpcUsageLines(
-      { byMethod: { 'bad method "x"': 5 }, lifetimeTotal: 5 },
+      { byMethod: { 'bad method "x"': 5 }, ethCallByConsumer: {}, lifetimeTotal: 5 },
       60,
       'weird chain id',
     );
@@ -92,8 +92,15 @@ describe('composite daemon source — agent + publisher-runtime windows merged a
     // publish-transaction methods MUST appear in the emitted lines — this is
     // the undercount the review flagged (per-wallet publisher adapters were
     // never drained).
-    let runtime: { drainRpcUsage: () => { byMethod: Record<string, number>; total: number; lifetimeTotal: number } | undefined } | null = null;
-    const agentLike = { drainRpcUsage: () => ({ byMethod: { eth_call: 2 }, lifetimeTotal: 2 }) };
+    let runtime: {
+      drainRpcUsage: () => {
+        byMethod: Record<string, number>;
+        ethCallByConsumer: Record<string, number>;
+        total?: number;
+        lifetimeTotal: number;
+      } | undefined;
+    } | null = null;
+    const agentLike = { drainRpcUsage: () => ({ byMethod: { eth_call: 2 }, ethCallByConsumer: {}, lifetimeTotal: 2 }) };
     const source = { drainRpcUsage: () => mergeRpcUsageWindows(agentLike.drainRpcUsage(), runtime?.drainRpcUsage()) };
 
     const before: string[] = [];
@@ -102,7 +109,7 @@ describe('composite daemon source — agent + publisher-runtime windows merged a
 
     // runtime boots later (the daemon assigns the live variable) — its
     // per-wallet adapter traffic must now be merged in.
-    runtime = { drainRpcUsage: () => ({ byMethod: { eth_sendRawTransaction: 3, eth_call: 1 }, lifetimeTotal: 4 }) };
+    runtime = { drainRpcUsage: () => ({ byMethod: { eth_sendRawTransaction: 3, eth_call: 1 }, ethCallByConsumer: {}, lifetimeTotal: 4 }) };
     const after: string[] = [];
     emitRpcUsage(source, (l) => after.push(l), 60, 'base:8453');
     expect(after).toContain('rpc_usage method=eth_call count=3 window_s=60 chain=base:8453');
@@ -114,7 +121,7 @@ describe('emitRpcUsage — the complete daemon emission step (drain → format �
   it('drains the agent source and emits one line per method', () => {
     const emitted: string[] = [];
     const agentLike = {
-      drainRpcUsage: () => ({ byMethod: { eth_call: 12, eth_getLogs: 3 }, lifetimeTotal: 15 }),
+      drainRpcUsage: () => ({ byMethod: { eth_call: 12, eth_getLogs: 3 }, ethCallByConsumer: {}, lifetimeTotal: 15 }),
     };
     const n = emitRpcUsage(agentLike, (l) => emitted.push(l), 60, 'base:8453');
     expect(n).toBe(2);
@@ -124,7 +131,7 @@ describe('emitRpcUsage — the complete daemon emission step (drain → format �
 
   it('emits nothing for an empty window, a missing capability, or no source', () => {
     const emitted: string[] = [];
-    expect(emitRpcUsage({ drainRpcUsage: () => ({ byMethod: {}, lifetimeTotal: 9 }) }, (l) => emitted.push(l), 60)).toBe(0);
+    expect(emitRpcUsage({ drainRpcUsage: () => ({ byMethod: {}, ethCallByConsumer: {}, lifetimeTotal: 9 }) }, (l) => emitted.push(l), 60)).toBe(0);
     expect(emitRpcUsage({ drainRpcUsage: () => undefined } as never, (l) => emitted.push(l), 60)).toBe(0); // rogue undefined still tolerated at runtime
     expect(emitRpcUsage({}, (l) => emitted.push(l), 60)).toBe(0); // adapter without the capability
     expect(emitRpcUsage(undefined, (l) => emitted.push(l), 60)).toBe(0);
@@ -135,7 +142,7 @@ describe('emitRpcUsage — the complete daemon emission step (drain → format �
     expect(emitRpcUsage({ drainRpcUsage: () => { throw new Error('boom'); } }, () => {}, 60)).toBe(0);
     expect(
       emitRpcUsage(
-        { drainRpcUsage: () => ({ byMethod: { eth_call: 1 }, lifetimeTotal: 1 }) },
+        { drainRpcUsage: () => ({ byMethod: { eth_call: 1 }, ethCallByConsumer: {}, lifetimeTotal: 1 }) },
         () => { throw new Error('sink down'); },
         60,
       ),
@@ -152,7 +159,7 @@ describe('emitRpcUsage ← DKGAgent.drainRpcUsage — the REAL daemon boundary e
     // gap where chain-side and formatter tests both pass but the daemon signal
     // is silently dead.
     const { DKGAgent } = await import('@origintrail-official/dkg-agent');
-    const chain = { drainRpcUsage: () => ({ byMethod: { eth_call: 11 }, lifetimeTotal: 11 }) };
+    const chain = { drainRpcUsage: () => ({ byMethod: { eth_call: 11 }, ethCallByConsumer: {}, lifetimeTotal: 11 }) };
     const agentLike = { drainRpcUsage: () => DKGAgent.prototype.drainRpcUsage.call({ chain } as never) };
     const emitted: string[] = [];
     const n = emitRpcUsage(agentLike, (l) => emitted.push(l), 60, 'base:8453');
@@ -167,7 +174,7 @@ describe('startRpcUsageTelemetry — the full scheduling lifecycle (timer + shut
   it('ticks every window, emits the drained lines, and stop() drains the partial window then halts', () => {
     vi.useFakeTimers();
     const emitted: string[] = [];
-    let next = { byMethod: { eth_call: 5 }, lifetimeTotal: 5 };
+    let next = { byMethod: { eth_call: 5 }, ethCallByConsumer: {}, lifetimeTotal: 5 };
     const handle = startRpcUsageTelemetry({
       source: { drainRpcUsage: () => next },
       emit: (l) => emitted.push(l),
@@ -180,13 +187,13 @@ describe('startRpcUsageTelemetry — the full scheduling lifecycle (timer + shut
     expect(emitted).toEqual(['rpc_usage method=eth_call count=5 window_s=60 chain=base:8453']);
 
     // Partial window accumulated after the last tick → stop() must drain it.
-    next = { byMethod: { eth_getLogs: 2 }, lifetimeTotal: 7 };
+    next = { byMethod: { eth_getLogs: 2 }, ethCallByConsumer: {}, lifetimeTotal: 7 };
     handle.stop();
     expect(emitted).toContain('rpc_usage method=eth_getLogs count=2 window_s=60 chain=base:8453');
 
     // ...and the timer is really gone: no further emissions after stop().
     const after = emitted.length;
-    next = { byMethod: { eth_call: 9 }, lifetimeTotal: 16 };
+    next = { byMethod: { eth_call: 9 }, ethCallByConsumer: {}, lifetimeTotal: 16 };
     vi.advanceTimersByTime(300_000);
     expect(emitted.length).toBe(after);
   });
@@ -195,7 +202,7 @@ describe('startRpcUsageTelemetry — the full scheduling lifecycle (timer + shut
     vi.useFakeTimers();
     const emitted: string[] = [];
     const handle = startRpcUsageTelemetry({
-      source: { drainRpcUsage: () => ({ byMethod: {}, lifetimeTotal: 3 }) },
+      source: { drainRpcUsage: () => ({ byMethod: {}, ethCallByConsumer: {}, lifetimeTotal: 3 }) },
       emit: (l) => emitted.push(l),
       windowSeconds: 60,
     });

--- a/packages/cli/test/rpc-usage-log.test.ts
+++ b/packages/cli/test/rpc-usage-log.test.ts
@@ -25,6 +25,12 @@ describe('formatRpcUsageLines — the Grafana-facing rpc_usage contract', () => 
     expect(formatRpcUsageLines({ byMethod: {}, ethCallByConsumer: {}, lifetimeTotal: 123 }, 60, 'base:8453')).toEqual([]);
   });
 
+  it('preserves aggregate lines for legacy windows without consumer attribution', () => {
+    expect(formatRpcUsageLines({ byMethod: { eth_call: 2 }, lifetimeTotal: 2 }, 60, 'base:8453')).toEqual([
+      'rpc_usage method=eth_call count=2 window_s=60 chain=base:8453',
+    ]);
+  });
+
   it('omits chain when unset and skips zero/negative/NaN counts', () => {
     const lines = formatRpcUsageLines(
       { byMethod: { eth_call: 3, eth_getLogs: 0, eth_gasPrice: NaN as unknown as number }, ethCallByConsumer: {}, lifetimeTotal: 3 },

--- a/packages/cli/vitest.unit.config.ts
+++ b/packages/cli/vitest.unit.config.ts
@@ -52,6 +52,7 @@ export default defineConfig({
           'test/skill-endpoint.test.ts',
           // R6-B — metric COUNT getter TTL memo. Pure logic, no hardhat.
           'test/metrics-queries.test.ts',
+          'test/rpc-usage-log.test.ts',
           // RFC 120 / plan PR 1 + 2 — Blazegraph support. Pure logic
           // (mocked fetch + in-memory config); cheap to keep in the
           // fast unit lane.


### PR DESCRIPTION
## Summary

This chained follow-up into PR #1440 adds attribution for the remaining `eth_call` startup noise called out in #1480 without changing node behavior.

High-level intent:
- keep the existing aggregate `rpc_usage method=<method>` log contract unchanged;
- propagate stable code-owned read labels through adapter-owned failover reads using async-local context;
- count raw `eth_call` attempts by consumer at the provider billing boundary, including retry/failover attempts;
- emit companion `rpc_usage_by_consumer method=eth_call consumer=<label> ...` daemon log lines so the next mainnet-base startup run can identify the largest consumers before we optimize them.

This is deliberately attribution-first. It does not cache, delay, throttle, or otherwise alter chain reads.

## Related Work

- Follow-up to PR #1440 (`codex/rpc-call-reduction`)
- Related to issue #1480 and the fresh `mainnet-base` feedback showing first-minute `eth_call` around `713/min` after the previous `eth_getLogs` / `eth_chainId` reductions.

## Files Changed

- `packages/chain/src/rpc-usage.ts`: adds bounded consumer labels, async-local scope helpers, optional `ethCallByConsumer` windows, merge support, and raw provider/retry attribution through a single tracker-owned recording boundary.
- `packages/chain/src/rpc-failover-client.ts`: scopes adapter-owned `read` and `readContract` operations with the existing logical read label.
- `packages/cli/src/daemon/rpc-usage-log.ts`: preserves aggregate `rpc_usage` lines and adds companion `rpc_usage_by_consumer` lines for `eth_call`.
- Tests cover tracker behavior, async scope isolation, provider and contract-view failover attribution, formatter output, and the agent telemetry boundary.

## Test Plan

- [x] `pnpm --dir packages/chain exec vitest run --config vitest.unit.config.ts test/rpc-usage.unit.test.ts --reporter dot`
- [x] `pnpm --dir packages/cli exec vitest run --config vitest.unit.config.ts test/rpc-usage-log.test.ts --reporter dot`
- [x] `pnpm --dir packages/agent exec vitest run test/rpc-usage-boundary.test.ts --reporter dot`
- [x] `pnpm --dir packages/chain run build`
- [x] `pnpm --dir packages/chain exec tsc --noEmit`
- [x] `pnpm --dir packages/cli exec tsc --noEmit`
- [x] `pnpm --dir packages/agent exec tsc --noEmit`
- [x] `git diff --check`

## Notes

Local focused chain tests rewrote `packages/evm-module/deployments/localhost_contracts.json`; that generated deployment artifact is intentionally left out of this PR.

