### PR TITLE
Reduce repeated identity getIdentityId RPC calls

### DIFF
--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -41,8 +41,7 @@ import type { ContractCache, EVMAdapterConfig } from './evm-adapter-types.js';
 import { RPC_READ_STALL_TIMEOUT_MS, DEFAULT_RANDOM_SAMPLING_HUB_REFRESH_MS, RPC_RECEIPT_TIMEOUT_MS, RPC_RECEIPT_POLL_INTERVAL_MS, RPC_ENDPOINT_SET_RETRIES, RPC_ENDPOINT_SET_RETRY_BACKOFF_MS, ADMIN_KEY_PURPOSE, OPERATIONAL_KEY_PURPOSE, PUBLISHER_FUNDING_CACHE_TTL_MS } from './evm-adapter-constants.js';
 
 /**
- * Maps a Hub-registered contract name to the function that invalidates
- * the corresponding boot-bound field on `EVMChainAdapter.contracts`.
+ * Maps a Hub-registered contract name to its local binding invalidation policy.
  *
  * Used by:
  *   1. `startHubRotationListener` — when the Hub rotation poller sees
@@ -58,33 +57,36 @@ import { RPC_READ_STALL_TIMEOUT_MS, DEFAULT_RANDOM_SAMPLING_HUB_REFRESH_MS, RPC_
  * which owns side-channel state (in-flight probe, ready flag) that
  * a simple field reset wouldn't touch.
  *
- * Names listed here MUST match boot-bound contracts that `init()` resolves via
- * `Hub.getContractAddress(name)` / `Hub.getAssetStorageAddress(name)`
- * — keep these in sync when adding/removing bindings in `init()`.
+ * Boot-bound names listed here MUST match contracts that `init()` resolves via
+ * `Hub.getContractAddress(name)` / `Hub.getAssetStorageAddress(name)`. Lazy
+ * names listed here MUST match helpers such as `getIdentityStorage()`.
  */
-type ContractInvalidator = (adapter: EVMChainAdapterBase) => void;
+type HubBindingInvalidationPolicy = {
+  invalidate: (adapter: EVMChainAdapterBase) => void;
+  invalidateOnRotation?: (adapter: EVMChainAdapterBase) => void;
+};
 
-const BOOT_BOUND_CONTRACT_INVALIDATORS = new Map<string, ContractInvalidator>([
-  ['Identity',                   (a) => { (a as any).contracts.identity = undefined; }],
-  ['Profile',                    (a) => { (a as any).contracts.profile = undefined; }],
-  ['ProfileStorage',             (a) => { (a as any).contracts.profileStorage = undefined; }],
-  ['ParametersStorage',          (a) => { (a as any).contracts.parametersStorage = undefined; }],
-  ['Staking',                    (a) => { (a as any).contracts.staking = undefined; }],
-  ['Token',                      (a) => { (a as any).contracts.token = undefined; }],
-  ['AskStorage',                 (a) => { (a as any).contracts.askStorage = undefined; }],
-  ['KnowledgeAssets',            (a) => { (a as any).contracts.knowledgeAssets = undefined; }],
-  ['KnowledgeAssetsStorage',     (a) => { (a as any).contracts.knowledgeAssetsStorage = undefined; }],
-  ['KnowledgeAssetsLifecycle',   (a) => { (a as any).contracts.knowledgeAssetsLifecycle = undefined; }],
-  ['DKGKnowledgeAssets',         (a) => { (a as any).contracts.knowledgeAssetStorage = undefined; }],
-  ['ContextGraphNameRegistry',   (a) => { (a as any).contracts.contextGraphNameRegistry = undefined; }],
-  ['ContextGraphs',              (a) => { (a as any).contracts.contextGraphs = undefined; }],
-  ['ContextGraphStorage',        (a) => { (a as any).contracts.contextGraphStorage = undefined; }],
-  ['DKGPublishingConvictionNFT', (a) => { (a as any).contracts.dkgPublishingConvictionNFT = undefined; }],
-  ['Chronos',                    (a) => { (a as any).contracts.chronos = undefined; }],
-]);
-
-const LAZY_BINDING_INVALIDATORS = new Map<string, ContractInvalidator>([
-  ['IdentityStorage',            (a) => { (a as any).invalidateIdentityStorageBinding(); }],
+const HUB_BINDING_INVALIDATORS = new Map<string, HubBindingInvalidationPolicy>([
+  ['Identity',                   { invalidate: (a) => { (a as any).contracts.identity = undefined; } }],
+  ['IdentityStorage',            {
+    invalidate: (a) => { (a as any).invalidateIdentityStorageBinding(); },
+    invalidateOnRotation: (a) => { (a as any).invalidateIdentityStorageBinding(); },
+  }],
+  ['Profile',                    { invalidate: (a) => { (a as any).contracts.profile = undefined; } }],
+  ['ProfileStorage',             { invalidate: (a) => { (a as any).contracts.profileStorage = undefined; } }],
+  ['ParametersStorage',          { invalidate: (a) => { (a as any).contracts.parametersStorage = undefined; } }],
+  ['Staking',                    { invalidate: (a) => { (a as any).contracts.staking = undefined; } }],
+  ['Token',                      { invalidate: (a) => { (a as any).contracts.token = undefined; } }],
+  ['AskStorage',                 { invalidate: (a) => { (a as any).contracts.askStorage = undefined; } }],
+  ['KnowledgeAssets',            { invalidate: (a) => { (a as any).contracts.knowledgeAssets = undefined; } }],
+  ['KnowledgeAssetsStorage',     { invalidate: (a) => { (a as any).contracts.knowledgeAssetsStorage = undefined; } }],
+  ['KnowledgeAssetsLifecycle',   { invalidate: (a) => { (a as any).contracts.knowledgeAssetsLifecycle = undefined; } }],
+  ['DKGKnowledgeAssets',         { invalidate: (a) => { (a as any).contracts.knowledgeAssetStorage = undefined; } }],
+  ['ContextGraphNameRegistry',   { invalidate: (a) => { (a as any).contracts.contextGraphNameRegistry = undefined; } }],
+  ['ContextGraphs',              { invalidate: (a) => { (a as any).contracts.contextGraphs = undefined; } }],
+  ['ContextGraphStorage',        { invalidate: (a) => { (a as any).contracts.contextGraphStorage = undefined; } }],
+  ['DKGPublishingConvictionNFT', { invalidate: (a) => { (a as any).contracts.dkgPublishingConvictionNFT = undefined; } }],
+  ['Chronos',                    { invalidate: (a) => { (a as any).contracts.chronos = undefined; } }],
 ]);
 
 const KA_HIGH_WATER_VIEW_SIGNATURE = 'getMaxKaNumberForAuthor(address)';
@@ -720,19 +722,46 @@ export class EVMChainAdapterBase {
     this.identityIdCache.invalidateAll();
   }
 
+  protected async identityStorageAddressChanged(
+    previous: Contract | undefined,
+    next: Contract,
+  ): Promise<boolean> {
+    if (!previous) return false;
+    if (previous === next) return false;
+    try {
+      return (await contractAddress(previous)).toLowerCase() !== (await contractAddress(next)).toLowerCase();
+    } catch {
+      return true;
+    }
+  }
+
   protected async readIdentityIdFromStorage(address: string): Promise<bigint> {
     if (!ethers.isAddress(address)) return 0n;
     const checksum = ethers.getAddress(address);
     await this.init();
-    const identityStorage = await this.getIdentityStorage();
+    const previousIdentityStorage = this.contracts.identityStorage;
+    const identityStorage = await this.getIdentityStorage({ refresh: true });
+    const identityStorageChanged = await this.identityStorageAddressChanged(previousIdentityStorage, identityStorage);
+    if (identityStorageChanged) this.identityIdCache.invalidateAll();
     const id: bigint = await this.readContract(
       identityStorage, 'identityStorage.getIdentityId', 'getIdentityId', checksum,
     );
-    return BigInt(id);
+    const identityId = BigInt(id);
+    if (identityStorageChanged) this.identityIdCache.seed(checksum, identityId);
+    return identityId;
   }
 
   protected async readIdentityIdForAddress(address: string): Promise<bigint> {
     return this.identityIdCache.getOrLoad(address, (checksum) => this.readIdentityIdFromStorage(checksum));
+  }
+
+  protected async refreshIdentityIdForAddress(address: string): Promise<bigint> {
+    if (!ethers.isAddress(address)) return 0n;
+    const checksum = ethers.getAddress(address);
+    this.identityIdCache.invalidate(checksum);
+    const identityId = await this.readIdentityIdFromStorage(checksum);
+    this.identityIdCache.seed(checksum, identityId);
+    return identityId;
   }
 
   protected static preflightCacheFresh(
@@ -1785,8 +1814,8 @@ export class EVMChainAdapterBase {
     return ethers.keccak256(ethers.solidityPacked(['address'], [ethers.getAddress(address)]));
   }
 
-  protected async getIdentityStorage(): Promise<Contract> {
-    if (!this.contracts.identityStorage) {
+  protected async getIdentityStorage(options: { refresh?: boolean } = {}): Promise<Contract> {
+    if (options.refresh || !this.contracts.identityStorage) {
       this.contracts.identityStorage = await this.resolveContract('IdentityStorage');
     }
     return this.contracts.identityStorage;
@@ -3178,13 +3207,13 @@ export class EVMChainAdapterBase {
    *      See the `randomSamplingPairCache` field comment for the
    *      coupling invariants this path preserves.
    *
-   *   2. Lazy bindings with dependent caches, currently `IdentityStorage`,
-   *      clear their lazy slot and dependent cache, then use the same rotation
-   *      finalization as boot-bound bindings.
+   *   2. Names in `HUB_BINDING_INVALIDATORS` may clear a lazy slot and
+   *      dependent cache through `invalidateOnRotation`, then use the same
+   *      rotation finalization as boot-bound bindings.
    *
-   *   3. Any name in `BOOT_BOUND_CONTRACT_INVALIDATORS` -> leave the existing
-   *      `this.contracts.X` field intact but flip `this.initialized` back to
-   *      `false` so the next `await
+   *   3. Any name in `HUB_BINDING_INVALIDATORS` without a rotation invalidator
+   *      leaves the existing `this.contracts.X` field intact but flips
+   *      `this.initialized` back to `false` so the next `await
    *      this.init()` re-resolves every binding fresh from Hub. Keeping
    *      the old handle until the next init pass avoids a race where an
    *      in-flight public method already passed `init()` and then trips
@@ -3235,15 +3264,10 @@ export class EVMChainAdapterBase {
       this.invalidateRandomSamplingPair();
       return;
     }
-    const lazyInvalidator = LAZY_BINDING_INVALIDATORS.get(name);
-    if (lazyInvalidator) {
-      lazyInvalidator(this);
-      this.finalizeKnownHubRotation();
-      return;
-    }
-    if (BOOT_BOUND_CONTRACT_INVALIDATORS.has(name)) {
-      this.finalizeKnownHubRotation();
-    }
+    const policy = HUB_BINDING_INVALIDATORS.get(name);
+    if (!policy) return;
+    policy.invalidateOnRotation?.(this);
+    this.finalizeKnownHubRotation();
   }
 
   protected finalizeKnownHubRotation(): void {
@@ -3272,11 +3296,8 @@ export class EVMChainAdapterBase {
    * (in-flight probe, ready flag) that `init()` alone won't reset.
    */
   protected invalidateAllBoundContracts(): void {
-    for (const invalidator of BOOT_BOUND_CONTRACT_INVALIDATORS.values()) {
-      invalidator(this);
-    }
-    for (const invalidator of LAZY_BINDING_INVALIDATORS.values()) {
-      invalidator(this);
+    for (const policy of HUB_BINDING_INVALIDATORS.values()) {
+      policy.invalidate(this);
     }
     this.invalidatePublishPreflightCache();
     this.invalidateRandomSamplingPair();

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -41,7 +41,7 @@ import type { ContractCache, EVMAdapterConfig } from './evm-adapter-types.js';
 import { RPC_READ_STALL_TIMEOUT_MS, DEFAULT_RANDOM_SAMPLING_HUB_REFRESH_MS, RPC_RECEIPT_TIMEOUT_MS, RPC_RECEIPT_POLL_INTERVAL_MS, RPC_ENDPOINT_SET_RETRIES, RPC_ENDPOINT_SET_RETRY_BACKOFF_MS, ADMIN_KEY_PURPOSE, OPERATIONAL_KEY_PURPOSE, PUBLISHER_FUNDING_CACHE_TTL_MS } from './evm-adapter-constants.js';
 
 /**
- * Maps a Hub-registered contract name to the function that invalidates
+ * Maps a Hub-registered contract name to the policy that invalidates
  * the corresponding boot-bound field on `EVMChainAdapter.contracts`.
  *
  * Used by:
@@ -63,27 +63,92 @@ import { RPC_READ_STALL_TIMEOUT_MS, DEFAULT_RANDOM_SAMPLING_HUB_REFRESH_MS, RPC_
  * `Hub.getContractAddress(name)` / `Hub.getAssetStorageAddress(name)`
  * — keep these in sync when adding/removing bindings in `init()`.
  */
-const BOUND_CONTRACT_INVALIDATORS = new Map<string, (adapter: EVMChainAdapterBase) => void>([
-  ['Identity',                   (a) => { (a as any).contracts.identity = undefined; }],
-  ['IdentityStorage',            (a) => { (a as any).invalidateIdentityStorageBinding(); }],
-  ['Profile',                    (a) => { (a as any).contracts.profile = undefined; }],
-  ['ProfileStorage',             (a) => { (a as any).contracts.profileStorage = undefined; }],
-  ['ParametersStorage',          (a) => { (a as any).contracts.parametersStorage = undefined; }],
-  ['Staking',                    (a) => { (a as any).contracts.staking = undefined; }],
-  ['Token',                      (a) => { (a as any).contracts.token = undefined; }],
-  ['AskStorage',                 (a) => { (a as any).contracts.askStorage = undefined; }],
-  ['KnowledgeAssets',            (a) => { (a as any).contracts.knowledgeAssets = undefined; }],
-  ['KnowledgeAssetsStorage',     (a) => { (a as any).contracts.knowledgeAssetsStorage = undefined; }],
-  ['KnowledgeAssetsLifecycle',   (a) => { (a as any).contracts.knowledgeAssetsLifecycle = undefined; }],
-  ['DKGKnowledgeAssets',         (a) => { (a as any).contracts.knowledgeAssetStorage = undefined; }],
-  ['ContextGraphNameRegistry',   (a) => { (a as any).contracts.contextGraphNameRegistry = undefined; }],
-  ['ContextGraphs',              (a) => { (a as any).contracts.contextGraphs = undefined; }],
-  ['ContextGraphStorage',        (a) => { (a as any).contracts.contextGraphStorage = undefined; }],
-  ['DKGPublishingConvictionNFT', (a) => { (a as any).contracts.dkgPublishingConvictionNFT = undefined; }],
-  ['Chronos',                    (a) => { (a as any).contracts.chronos = undefined; }],
+type BoundContractInvalidationPolicy = {
+  invalidate: (adapter: EVMChainAdapterBase) => void;
+  onRotation?: (adapter: EVMChainAdapterBase) => void;
+};
+
+const BOUND_CONTRACT_INVALIDATORS = new Map<string, BoundContractInvalidationPolicy>([
+  ['Identity',                   { invalidate: (a) => { (a as any).contracts.identity = undefined; } }],
+  ['IdentityStorage',            {
+    invalidate: (a) => { (a as any).invalidateIdentityStorageBinding(); },
+    onRotation: (a) => {
+      (a as any).invalidateIdentityStorageBinding();
+      (a as any).initialized = false;
+    },
+  }],
+  ['Profile',                    { invalidate: (a) => { (a as any).contracts.profile = undefined; } }],
+  ['ProfileStorage',             { invalidate: (a) => { (a as any).contracts.profileStorage = undefined; } }],
+  ['ParametersStorage',          { invalidate: (a) => { (a as any).contracts.parametersStorage = undefined; } }],
+  ['Staking',                    { invalidate: (a) => { (a as any).contracts.staking = undefined; } }],
+  ['Token',                      { invalidate: (a) => { (a as any).contracts.token = undefined; } }],
+  ['AskStorage',                 { invalidate: (a) => { (a as any).contracts.askStorage = undefined; } }],
+  ['KnowledgeAssets',            { invalidate: (a) => { (a as any).contracts.knowledgeAssets = undefined; } }],
+  ['KnowledgeAssetsStorage',     { invalidate: (a) => { (a as any).contracts.knowledgeAssetsStorage = undefined; } }],
+  ['KnowledgeAssetsLifecycle',   { invalidate: (a) => { (a as any).contracts.knowledgeAssetsLifecycle = undefined; } }],
+  ['DKGKnowledgeAssets',         { invalidate: (a) => { (a as any).contracts.knowledgeAssetStorage = undefined; } }],
+  ['ContextGraphNameRegistry',   { invalidate: (a) => { (a as any).contracts.contextGraphNameRegistry = undefined; } }],
+  ['ContextGraphs',              { invalidate: (a) => { (a as any).contracts.contextGraphs = undefined; } }],
+  ['ContextGraphStorage',        { invalidate: (a) => { (a as any).contracts.contextGraphStorage = undefined; } }],
+  ['DKGPublishingConvictionNFT', { invalidate: (a) => { (a as any).contracts.dkgPublishingConvictionNFT = undefined; } }],
+  ['Chronos',                    { invalidate: (a) => { (a as any).contracts.chronos = undefined; } }],
 ]);
 
 const KA_HIGH_WATER_VIEW_SIGNATURE = 'getMaxKaNumberForAuthor(address)';
+
+type IdentityIdCacheEntry = {
+  identityId: bigint;
+  ttlMs: number;
+};
+
+class IdentityIdCache {
+  private readonly values = new ReadThroughTtlCache<string, IdentityIdCacheEntry>({
+    ttlMs: (entry) => entry.ttlMs,
+  });
+
+  constructor(
+    private readonly signerCacheKey: string,
+    private readonly positiveTtlMs: number,
+    private readonly signerZeroTtlMs: number,
+  ) {}
+
+  async getOrLoad(
+    address: string,
+    load: (checksumAddress: string) => Promise<bigint>,
+  ): Promise<bigint> {
+    if (!ethers.isAddress(address)) return 0n;
+    const checksum = ethers.getAddress(address);
+    const cacheKey = checksum.toLowerCase();
+    const entry = await this.values.getOrLoad(cacheKey, cacheKey, async () => {
+      const identityId = await load(checksum);
+      return this.entry(cacheKey, identityId);
+    });
+    return entry.identityId;
+  }
+
+  seed(address: string, identityId: bigint): void {
+    const cacheKey = ethers.getAddress(address).toLowerCase();
+    this.values.seed(cacheKey, this.entry(cacheKey, identityId));
+  }
+
+  invalidate(address: string): void {
+    const cacheKey = ethers.getAddress(address).toLowerCase();
+    this.values.invalidate(cacheKey);
+  }
+
+  invalidateAll(): void {
+    this.values.invalidateAll();
+  }
+
+  private entry(cacheKey: string, identityId: bigint): IdentityIdCacheEntry {
+    const ttlMs = identityId > 0n
+      ? this.positiveTtlMs
+      : cacheKey === this.signerCacheKey
+        ? this.signerZeroTtlMs
+        : 0;
+    return { identityId, ttlMs };
+  }
+}
 
 /**
  * Upper bound on the pre-10.0.4 KnowledgeAssetCreated fallback scan, in
@@ -512,38 +577,16 @@ export class EVMChainAdapterBase {
 
   protected static readonly IDENTITY_ID_POSITIVE_TTL_MS = 5 * 60 * 1000;
 
-  protected static readonly IDENTITY_ID_NEGATIVE_TTL_MS = 0;
-
   protected static readonly SIGNER_IDENTITY_ID_ZERO_TTL_MS = 15 * 1000;
 
-  protected static readonly SIGNER_IDENTITY_ID_CACHE_KEY = 'signer';
-
   /**
-   * OT-RFC-39 — per-process cache for `getIdentityIdForAddress`.
-   * Positive hits are memoised with a bounded TTL; negative hits are only
-   * single-flighted so a later external registration is visible immediately.
-   * Local mutations seed/invalidate through the cache so stale in-flight reads
-   * cannot win.
+   * OT-RFC-39 — per-process identity-id cache. Positive hits are memoised with
+   * a bounded TTL; arbitrary-address negative hits are only single-flighted so
+   * later external registration is visible immediately. The signer address has
+   * a short zero TTL so fresh edge-node startup sync does not repeat the same
+   * self `0n` lookup per page.
    */
-  protected readonly identityIdByAddressCache = new ReadThroughTtlCache<string, bigint>({
-    ttlMs: (value) => value > 0n
-      ? EVMChainAdapterBase.IDENTITY_ID_POSITIVE_TTL_MS
-      : EVMChainAdapterBase.IDENTITY_ID_NEGATIVE_TTL_MS,
-  });
-
-  /**
-   * Signer-only identity cache for `getIdentityId()`.
-   *
-   * Edge nodes commonly have no node-operator identity (`0n`) and fall back to
-   * agent-key signing. A short zero TTL prevents startup sync from repeating the
-   * same self lookup per page while keeping arbitrary-address negative lookups
-   * live and bounding external profile-creation visibility delay.
-   */
-  protected readonly signerIdentityIdCache = new ReadThroughTtlCache<string, bigint>({
-    ttlMs: (value) => value > 0n
-      ? EVMChainAdapterBase.IDENTITY_ID_POSITIVE_TTL_MS
-      : EVMChainAdapterBase.SIGNER_IDENTITY_ID_ZERO_TTL_MS,
-  });
+  protected identityIdCache!: IdentityIdCache;
 
   protected readonly pcaReadCache = new PcaReadCache();
 
@@ -672,25 +715,16 @@ export class EVMChainAdapterBase {
   }
 
   protected clearIdentityIdForAddress(address: string): void {
-    const cacheKey = ethers.getAddress(address).toLowerCase();
-    this.identityIdByAddressCache.invalidate(cacheKey);
-    if (cacheKey === this.signer.address.toLowerCase()) {
-      this.signerIdentityIdCache.invalidate(EVMChainAdapterBase.SIGNER_IDENTITY_ID_CACHE_KEY);
-    }
+    this.identityIdCache.invalidate(address);
   }
 
   protected seedIdentityIdForAddress(address: string, identityId: bigint): void {
-    const cacheKey = ethers.getAddress(address).toLowerCase();
-    this.identityIdByAddressCache.seed(cacheKey, identityId);
-    if (cacheKey === this.signer.address.toLowerCase()) {
-      this.signerIdentityIdCache.seed(EVMChainAdapterBase.SIGNER_IDENTITY_ID_CACHE_KEY, identityId);
-    }
+    this.identityIdCache.seed(address, identityId);
   }
 
   protected invalidateIdentityStorageBinding(): void {
     this.contracts.identityStorage = undefined;
-    this.identityIdByAddressCache.invalidateAll();
-    this.signerIdentityIdCache.invalidateAll();
+    this.identityIdCache.invalidateAll();
   }
 
   protected async readIdentityIdFromStorage(address: string): Promise<bigint> {
@@ -705,16 +739,7 @@ export class EVMChainAdapterBase {
   }
 
   protected async readIdentityIdForAddress(address: string): Promise<bigint> {
-    if (!ethers.isAddress(address)) return 0n;
-    const checksum = ethers.getAddress(address);
-    const cacheKey = checksum.toLowerCase();
-    return this.identityIdByAddressCache.getOrLoad(cacheKey, cacheKey, async () => {
-      const identityId = await this.readIdentityIdFromStorage(checksum);
-      if (identityId > 0n && cacheKey === this.signer.address.toLowerCase()) {
-        this.signerIdentityIdCache.seed(EVMChainAdapterBase.SIGNER_IDENTITY_ID_CACHE_KEY, identityId);
-      }
-      return identityId;
-    });
+    return this.identityIdCache.getOrLoad(address, (checksum) => this.readIdentityIdFromStorage(checksum));
   }
 
   protected static preflightCacheFresh(
@@ -907,6 +932,11 @@ export class EVMChainAdapterBase {
         throw new Error('EVM adminPrivateKey must be distinct from operational keys');
       }
     }
+    this.identityIdCache = new IdentityIdCache(
+      this.signer.address.toLowerCase(),
+      EVMChainAdapterBase.IDENTITY_ID_POSITIVE_TTL_MS,
+      EVMChainAdapterBase.SIGNER_IDENTITY_ID_ZERO_TTL_MS,
+    );
     this.hubAddress = config.hubAddress;
     if (config.tokenAddress && !ethers.isAddress(config.tokenAddress)) {
       throw new Error(`Invalid tokenAddress: ${config.tokenAddress}`);
@@ -2027,11 +2057,7 @@ export class EVMChainAdapterBase {
   // =====================================================================
 
   async getIdentityId(): Promise<bigint> {
-    return this.signerIdentityIdCache.getOrLoad(
-      EVMChainAdapterBase.SIGNER_IDENTITY_ID_CACHE_KEY,
-      EVMChainAdapterBase.SIGNER_IDENTITY_ID_CACHE_KEY,
-      () => this.readIdentityIdForAddress(this.signer.address),
-    );
+    return this.readIdentityIdForAddress(this.signer.address);
   }
 
   // =====================================================================
@@ -3159,11 +3185,11 @@ export class EVMChainAdapterBase {
    *      See the `randomSamplingPairCache` field comment for the
    *      coupling invariants this path preserves.
    *
-   *   2. `IdentityStorage` -> clear the lazy storage binding and the
-   *      dependent identity caches, then force the next public-method
-   *      entry through `init()`.
+   *   2. Any name in `BOUND_CONTRACT_INVALIDATORS` with an explicit
+   *      rotation policy -> run that policy. `IdentityStorage` uses this
+   *      to clear its lazy storage binding and dependent identity cache.
    *
-   *   3. Any other name in `BOUND_CONTRACT_INVALIDATORS` → leave the
+   *   3. Any other name in `BOUND_CONTRACT_INVALIDATORS` -> leave the
    *      existing `this.contracts.X` field intact but flip
    *      `this.initialized` back to `false` so the next `await
    *      this.init()` re-resolves every binding fresh from Hub. Keeping
@@ -3216,12 +3242,12 @@ export class EVMChainAdapterBase {
       this.invalidateRandomSamplingPair();
       return;
     }
-    if (name === 'IdentityStorage') {
-      this.invalidateIdentityStorageBinding();
-      this.initialized = false;
+    const policy = BOUND_CONTRACT_INVALIDATORS.get(name);
+    if (policy?.onRotation) {
+      policy.onRotation(this);
       return;
     }
-    if (BOUND_CONTRACT_INVALIDATORS.has(name)) {
+    if (policy) {
       this.invalidatePublishPreflightCache();
       // Force the next public-method entry through `init()` so it re-resolves
       // every binding. Do not clear the current handle here: the callback can
@@ -3247,8 +3273,8 @@ export class EVMChainAdapterBase {
    * (in-flight probe, ready flag) that `init()` alone won't reset.
    */
   protected invalidateAllBoundContracts(): void {
-    for (const invalidator of BOUND_CONTRACT_INVALIDATORS.values()) {
-      invalidator(this);
+    for (const policy of BOUND_CONTRACT_INVALIDATORS.values()) {
+      policy.invalidate(this);
     }
     this.invalidatePublishPreflightCache();
     this.invalidateRandomSamplingPair();

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -65,6 +65,7 @@ import { RPC_READ_STALL_TIMEOUT_MS, DEFAULT_RANDOM_SAMPLING_HUB_REFRESH_MS, RPC_
  */
 const BOUND_CONTRACT_INVALIDATORS = new Map<string, (adapter: EVMChainAdapterBase) => void>([
   ['Identity',                   (a) => { (a as any).contracts.identity = undefined; }],
+  ['IdentityStorage',            (a) => { (a as any).invalidateIdentityStorageBinding(); }],
   ['Profile',                    (a) => { (a as any).contracts.profile = undefined; }],
   ['ProfileStorage',             (a) => { (a as any).contracts.profileStorage = undefined; }],
   ['ParametersStorage',          (a) => { (a as any).contracts.parametersStorage = undefined; }],
@@ -513,6 +514,10 @@ export class EVMChainAdapterBase {
 
   protected static readonly IDENTITY_ID_NEGATIVE_TTL_MS = 0;
 
+  protected static readonly SIGNER_IDENTITY_ID_ZERO_TTL_MS = 15 * 1000;
+
+  protected static readonly SIGNER_IDENTITY_ID_CACHE_KEY = 'signer';
+
   /**
    * OT-RFC-39 — per-process cache for `getIdentityIdForAddress`.
    * Positive hits are memoised with a bounded TTL; negative hits are only
@@ -524,6 +529,20 @@ export class EVMChainAdapterBase {
     ttlMs: (value) => value > 0n
       ? EVMChainAdapterBase.IDENTITY_ID_POSITIVE_TTL_MS
       : EVMChainAdapterBase.IDENTITY_ID_NEGATIVE_TTL_MS,
+  });
+
+  /**
+   * Signer-only identity cache for `getIdentityId()`.
+   *
+   * Edge nodes commonly have no node-operator identity (`0n`) and fall back to
+   * agent-key signing. A short zero TTL prevents startup sync from repeating the
+   * same self lookup per page while keeping arbitrary-address negative lookups
+   * live and bounding external profile-creation visibility delay.
+   */
+  protected readonly signerIdentityIdCache = new ReadThroughTtlCache<string, bigint>({
+    ttlMs: (value) => value > 0n
+      ? EVMChainAdapterBase.IDENTITY_ID_POSITIVE_TTL_MS
+      : EVMChainAdapterBase.SIGNER_IDENTITY_ID_ZERO_TTL_MS,
   });
 
   protected readonly pcaReadCache = new PcaReadCache();
@@ -655,11 +674,47 @@ export class EVMChainAdapterBase {
   protected clearIdentityIdForAddress(address: string): void {
     const cacheKey = ethers.getAddress(address).toLowerCase();
     this.identityIdByAddressCache.invalidate(cacheKey);
+    if (cacheKey === this.signer.address.toLowerCase()) {
+      this.signerIdentityIdCache.invalidate(EVMChainAdapterBase.SIGNER_IDENTITY_ID_CACHE_KEY);
+    }
   }
 
   protected seedIdentityIdForAddress(address: string, identityId: bigint): void {
     const cacheKey = ethers.getAddress(address).toLowerCase();
     this.identityIdByAddressCache.seed(cacheKey, identityId);
+    if (cacheKey === this.signer.address.toLowerCase()) {
+      this.signerIdentityIdCache.seed(EVMChainAdapterBase.SIGNER_IDENTITY_ID_CACHE_KEY, identityId);
+    }
+  }
+
+  protected invalidateIdentityStorageBinding(): void {
+    this.contracts.identityStorage = undefined;
+    this.identityIdByAddressCache.invalidateAll();
+    this.signerIdentityIdCache.invalidateAll();
+  }
+
+  protected async readIdentityIdFromStorage(address: string): Promise<bigint> {
+    if (!ethers.isAddress(address)) return 0n;
+    const checksum = ethers.getAddress(address);
+    await this.init();
+    const identityStorage = await this.resolveContract('IdentityStorage');
+    const id: bigint = await this.readContract(
+      identityStorage, 'identityStorage.getIdentityId', 'getIdentityId', checksum,
+    );
+    return BigInt(id);
+  }
+
+  protected async readIdentityIdForAddress(address: string): Promise<bigint> {
+    if (!ethers.isAddress(address)) return 0n;
+    const checksum = ethers.getAddress(address);
+    const cacheKey = checksum.toLowerCase();
+    return this.identityIdByAddressCache.getOrLoad(cacheKey, cacheKey, async () => {
+      const identityId = await this.readIdentityIdFromStorage(checksum);
+      if (identityId > 0n && cacheKey === this.signer.address.toLowerCase()) {
+        this.signerIdentityIdCache.seed(EVMChainAdapterBase.SIGNER_IDENTITY_ID_CACHE_KEY, identityId);
+      }
+      return identityId;
+    });
   }
 
   protected static preflightCacheFresh(
@@ -1972,12 +2027,11 @@ export class EVMChainAdapterBase {
   // =====================================================================
 
   async getIdentityId(): Promise<bigint> {
-    await this.init();
-    const identityStorage = await this.getIdentityStorage();
-    const id: bigint = await this.readContract(
-      identityStorage, 'identityStorage.getIdentityId', 'getIdentityId', this.signer.address,
+    return this.signerIdentityIdCache.getOrLoad(
+      EVMChainAdapterBase.SIGNER_IDENTITY_ID_CACHE_KEY,
+      EVMChainAdapterBase.SIGNER_IDENTITY_ID_CACHE_KEY,
+      () => this.readIdentityIdForAddress(this.signer.address),
     );
-    return id;
   }
 
   // =====================================================================
@@ -3105,7 +3159,11 @@ export class EVMChainAdapterBase {
    *      See the `randomSamplingPairCache` field comment for the
    *      coupling invariants this path preserves.
    *
-   *   2. Any other name in `BOUND_CONTRACT_INVALIDATORS` → leave the
+   *   2. `IdentityStorage` -> clear the lazy storage binding and the
+   *      dependent identity caches, then force the next public-method
+   *      entry through `init()`.
+   *
+   *   3. Any other name in `BOUND_CONTRACT_INVALIDATORS` → leave the
    *      existing `this.contracts.X` field intact but flip
    *      `this.initialized` back to `false` so the next `await
    *      this.init()` re-resolves every binding fresh from Hub. Keeping
@@ -3118,7 +3176,7 @@ export class EVMChainAdapterBase {
    *      operators were silently stuck on the pre-rotation address
    *      until a daemon restart.
    *
-   *   3. Unknown name → ignored. We deliberately allowlist rather
+   *   4. Unknown name → ignored. We deliberately allowlist rather
    *      than reflexively re-init on any rotation: third-party
    *      deployments may register names we don't bind, and we don't
    *      want a benign rotation of an unrelated contract to thrash
@@ -3156,6 +3214,11 @@ export class EVMChainAdapterBase {
   protected applyHubRotationEventName(name: string): void {
     if (name === 'RandomSampling' || name === 'RandomSamplingStorage') {
       this.invalidateRandomSamplingPair();
+      return;
+    }
+    if (name === 'IdentityStorage') {
+      this.invalidateIdentityStorageBinding();
+      this.initialized = false;
       return;
     }
     if (BOUND_CONTRACT_INVALIDATORS.has(name)) {

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -41,15 +41,14 @@ import type { ContractCache, EVMAdapterConfig } from './evm-adapter-types.js';
 import { RPC_READ_STALL_TIMEOUT_MS, DEFAULT_RANDOM_SAMPLING_HUB_REFRESH_MS, RPC_RECEIPT_TIMEOUT_MS, RPC_RECEIPT_POLL_INTERVAL_MS, RPC_ENDPOINT_SET_RETRIES, RPC_ENDPOINT_SET_RETRY_BACKOFF_MS, ADMIN_KEY_PURPOSE, OPERATIONAL_KEY_PURPOSE, PUBLISHER_FUNDING_CACHE_TTL_MS } from './evm-adapter-constants.js';
 
 /**
- * Maps a Hub-registered contract name to the policy that invalidates
+ * Maps a Hub-registered contract name to the function that invalidates
  * the corresponding boot-bound field on `EVMChainAdapter.contracts`.
  *
  * Used by:
  *   1. `startHubRotationListener` — when the Hub rotation poller sees
- *      `name`, it checks this allowlist, marks the
- *      adapter uninitialised, and leaves the existing handle intact so
- *      in-flight calls that already passed `init()` don't observe a
- *      transient `undefined`.
+ *      `name`, it checks this allowlist, marks the adapter uninitialised,
+ *      and leaves the existing handle intact so in-flight calls that already
+ *      passed `init()` don't observe a transient `undefined`.
  *   2. `invalidateAllBoundContracts` — bulk drop, called by the
  *      write-side self-heal path (`withHubStaleRetry`) when a stale
  *      address surfaces `UnauthorizedAccess(Only Contracts in Hub)`.
@@ -59,39 +58,33 @@ import { RPC_READ_STALL_TIMEOUT_MS, DEFAULT_RANDOM_SAMPLING_HUB_REFRESH_MS, RPC_
  * which owns side-channel state (in-flight probe, ready flag) that
  * a simple field reset wouldn't touch.
  *
- * Names listed here MUST match what `init()` resolves via
+ * Names listed here MUST match boot-bound contracts that `init()` resolves via
  * `Hub.getContractAddress(name)` / `Hub.getAssetStorageAddress(name)`
  * — keep these in sync when adding/removing bindings in `init()`.
  */
-type BoundContractInvalidationPolicy = {
-  invalidate: (adapter: EVMChainAdapterBase) => void;
-  onRotation?: (adapter: EVMChainAdapterBase) => void;
-};
+type ContractInvalidator = (adapter: EVMChainAdapterBase) => void;
 
-const BOUND_CONTRACT_INVALIDATORS = new Map<string, BoundContractInvalidationPolicy>([
-  ['Identity',                   { invalidate: (a) => { (a as any).contracts.identity = undefined; } }],
-  ['IdentityStorage',            {
-    invalidate: (a) => { (a as any).invalidateIdentityStorageBinding(); },
-    onRotation: (a) => {
-      (a as any).invalidateIdentityStorageBinding();
-      (a as any).initialized = false;
-    },
-  }],
-  ['Profile',                    { invalidate: (a) => { (a as any).contracts.profile = undefined; } }],
-  ['ProfileStorage',             { invalidate: (a) => { (a as any).contracts.profileStorage = undefined; } }],
-  ['ParametersStorage',          { invalidate: (a) => { (a as any).contracts.parametersStorage = undefined; } }],
-  ['Staking',                    { invalidate: (a) => { (a as any).contracts.staking = undefined; } }],
-  ['Token',                      { invalidate: (a) => { (a as any).contracts.token = undefined; } }],
-  ['AskStorage',                 { invalidate: (a) => { (a as any).contracts.askStorage = undefined; } }],
-  ['KnowledgeAssets',            { invalidate: (a) => { (a as any).contracts.knowledgeAssets = undefined; } }],
-  ['KnowledgeAssetsStorage',     { invalidate: (a) => { (a as any).contracts.knowledgeAssetsStorage = undefined; } }],
-  ['KnowledgeAssetsLifecycle',   { invalidate: (a) => { (a as any).contracts.knowledgeAssetsLifecycle = undefined; } }],
-  ['DKGKnowledgeAssets',         { invalidate: (a) => { (a as any).contracts.knowledgeAssetStorage = undefined; } }],
-  ['ContextGraphNameRegistry',   { invalidate: (a) => { (a as any).contracts.contextGraphNameRegistry = undefined; } }],
-  ['ContextGraphs',              { invalidate: (a) => { (a as any).contracts.contextGraphs = undefined; } }],
-  ['ContextGraphStorage',        { invalidate: (a) => { (a as any).contracts.contextGraphStorage = undefined; } }],
-  ['DKGPublishingConvictionNFT', { invalidate: (a) => { (a as any).contracts.dkgPublishingConvictionNFT = undefined; } }],
-  ['Chronos',                    { invalidate: (a) => { (a as any).contracts.chronos = undefined; } }],
+const BOOT_BOUND_CONTRACT_INVALIDATORS = new Map<string, ContractInvalidator>([
+  ['Identity',                   (a) => { (a as any).contracts.identity = undefined; }],
+  ['Profile',                    (a) => { (a as any).contracts.profile = undefined; }],
+  ['ProfileStorage',             (a) => { (a as any).contracts.profileStorage = undefined; }],
+  ['ParametersStorage',          (a) => { (a as any).contracts.parametersStorage = undefined; }],
+  ['Staking',                    (a) => { (a as any).contracts.staking = undefined; }],
+  ['Token',                      (a) => { (a as any).contracts.token = undefined; }],
+  ['AskStorage',                 (a) => { (a as any).contracts.askStorage = undefined; }],
+  ['KnowledgeAssets',            (a) => { (a as any).contracts.knowledgeAssets = undefined; }],
+  ['KnowledgeAssetsStorage',     (a) => { (a as any).contracts.knowledgeAssetsStorage = undefined; }],
+  ['KnowledgeAssetsLifecycle',   (a) => { (a as any).contracts.knowledgeAssetsLifecycle = undefined; }],
+  ['DKGKnowledgeAssets',         (a) => { (a as any).contracts.knowledgeAssetStorage = undefined; }],
+  ['ContextGraphNameRegistry',   (a) => { (a as any).contracts.contextGraphNameRegistry = undefined; }],
+  ['ContextGraphs',              (a) => { (a as any).contracts.contextGraphs = undefined; }],
+  ['ContextGraphStorage',        (a) => { (a as any).contracts.contextGraphStorage = undefined; }],
+  ['DKGPublishingConvictionNFT', (a) => { (a as any).contracts.dkgPublishingConvictionNFT = undefined; }],
+  ['Chronos',                    (a) => { (a as any).contracts.chronos = undefined; }],
+]);
+
+const LAZY_BINDING_INVALIDATORS = new Map<string, ContractInvalidator>([
+  ['IdentityStorage',            (a) => { (a as any).invalidateIdentityStorageBinding(); }],
 ]);
 
 const KA_HIGH_WATER_VIEW_SIGNATURE = 'getMaxKaNumberForAuthor(address)';
@@ -731,7 +724,7 @@ export class EVMChainAdapterBase {
     if (!ethers.isAddress(address)) return 0n;
     const checksum = ethers.getAddress(address);
     await this.init();
-    const identityStorage = await this.resolveContract('IdentityStorage');
+    const identityStorage = await this.getIdentityStorage();
     const id: bigint = await this.readContract(
       identityStorage, 'identityStorage.getIdentityId', 'getIdentityId', checksum,
     );
@@ -3185,13 +3178,13 @@ export class EVMChainAdapterBase {
    *      See the `randomSamplingPairCache` field comment for the
    *      coupling invariants this path preserves.
    *
-   *   2. Any name in `BOUND_CONTRACT_INVALIDATORS` with an explicit
-   *      rotation policy -> run that policy. `IdentityStorage` uses this
-   *      to clear its lazy storage binding and dependent identity cache.
+   *   2. Lazy bindings with dependent caches, currently `IdentityStorage`,
+   *      clear their lazy slot and dependent cache, then use the same rotation
+   *      finalization as boot-bound bindings.
    *
-   *   3. Any other name in `BOUND_CONTRACT_INVALIDATORS` -> leave the
-   *      existing `this.contracts.X` field intact but flip
-   *      `this.initialized` back to `false` so the next `await
+   *   3. Any name in `BOOT_BOUND_CONTRACT_INVALIDATORS` -> leave the existing
+   *      `this.contracts.X` field intact but flip `this.initialized` back to
+   *      `false` so the next `await
    *      this.init()` re-resolves every binding fresh from Hub. Keeping
    *      the old handle until the next init pass avoids a race where an
    *      in-flight public method already passed `init()` and then trips
@@ -3242,23 +3235,29 @@ export class EVMChainAdapterBase {
       this.invalidateRandomSamplingPair();
       return;
     }
-    const policy = BOUND_CONTRACT_INVALIDATORS.get(name);
-    if (policy?.onRotation) {
-      policy.onRotation(this);
+    const lazyInvalidator = LAZY_BINDING_INVALIDATORS.get(name);
+    if (lazyInvalidator) {
+      lazyInvalidator(this);
+      this.finalizeKnownHubRotation();
       return;
     }
-    if (policy) {
-      this.invalidatePublishPreflightCache();
-      // Force the next public-method entry through `init()` so it re-resolves
-      // every binding. Do not clear the current handle here: the callback can
-      // fire between a public method's `await init()` and its first
-      // `this.contracts.X` read.
-      this.initialized = false;
+    if (BOOT_BOUND_CONTRACT_INVALIDATORS.has(name)) {
+      this.finalizeKnownHubRotation();
     }
   }
 
+  protected finalizeKnownHubRotation(): void {
+    this.invalidatePublishPreflightCache();
+    // Force the next public-method entry through `init()` so it re-resolves
+    // every binding. Do not clear boot-bound handles here: the callback can
+    // fire between a public method's `await init()` and its first
+    // `this.contracts.X` read.
+    this.initialized = false;
+  }
+
   /**
-   * Drop every boot-bound contract handle and re-arm `init()`.
+   * Drop every boot-bound contract handle, lazy binding, and dependent cache,
+   * then re-arm `init()`.
    *
    * Used by `withHubStaleRetry` on the write-side self-heal path when
    * a Hub-rotated contract surfaces `UnauthorizedAccess(Only Contracts
@@ -3273,8 +3272,11 @@ export class EVMChainAdapterBase {
    * (in-flight probe, ready flag) that `init()` alone won't reset.
    */
   protected invalidateAllBoundContracts(): void {
-    for (const policy of BOUND_CONTRACT_INVALIDATORS.values()) {
-      policy.invalidate(this);
+    for (const invalidator of BOOT_BOUND_CONTRACT_INVALIDATORS.values()) {
+      invalidator(this);
+    }
+    for (const invalidator of LAZY_BINDING_INVALIDATORS.values()) {
+      invalidator(this);
     }
     this.invalidatePublishPreflightCache();
     this.invalidateRandomSamplingPair();

--- a/packages/chain/src/evm-adapter-identity.ts
+++ b/packages/chain/src/evm-adapter-identity.ts
@@ -268,17 +268,7 @@ export class IdentityMethods extends EVMChainAdapterBase {
    * not rely on TTL expiry.
    */
   async getIdentityIdForAddress(address: string): Promise<bigint> {
-    if (!ethers.isAddress(address)) return 0n;
-    const checksum = ethers.getAddress(address);
-    const cacheKey = checksum.toLowerCase();
-    return this.identityIdByAddressCache.getOrLoad(cacheKey, cacheKey, async () => {
-      await this.init();
-      const identityStorage = await this.resolveContract('IdentityStorage');
-      const id: bigint = await this.readContract(
-        identityStorage, 'identityStorage.getIdentityId', 'getIdentityId', checksum,
-      );
-      return BigInt(id);
-    });
+    return this.readIdentityIdForAddress(address);
   }
 
   async ensureProfile(options?: { nodeName?: string; stakeAmount?: bigint; lockTier?: number }): Promise<bigint> {
@@ -320,6 +310,7 @@ export class IdentityMethods extends EVMChainAdapterBase {
       if (identityId === 0n) {
         throw new Error('Profile created but no IdentityCreated event found');
       }
+      this.seedIdentityIdForAddress(this.signer.address, identityId);
     }
 
     // Step 2: Stake via V10 path (separate try/catch so profile isn't lost).
@@ -401,7 +392,9 @@ export class IdentityMethods extends EVMChainAdapterBase {
           data: log.data,
         });
         if (parsed?.name === 'IdentityCreated') {
-          return BigInt(parsed.args.identityId);
+          const identityId = BigInt(parsed.args.identityId);
+          this.seedIdentityIdForAddress(this.signer.address, identityId);
+          return identityId;
         }
       } catch { /* not this contract */ }
     }
@@ -413,7 +406,9 @@ export class IdentityMethods extends EVMChainAdapterBase {
           data: log.data,
         });
         if (parsed?.name === 'ProfileCreated') {
-          return BigInt(parsed.args.identityId);
+          const identityId = BigInt(parsed.args.identityId);
+          this.seedIdentityIdForAddress(this.signer.address, identityId);
+          return identityId;
         }
       } catch { /* not this contract */ }
     }

--- a/packages/chain/src/evm-adapter-identity.ts
+++ b/packages/chain/src/evm-adapter-identity.ts
@@ -275,6 +275,9 @@ export class IdentityMethods extends EVMChainAdapterBase {
     await this.init();
 
     let identityId = await this.getIdentityId();
+    if (identityId === 0n) {
+      identityId = await this.refreshIdentityIdForAddress(this.signer.address);
+    }
 
     // Step 1: Create profile if none exists
     if (identityId === 0n) {

--- a/packages/chain/src/evm-adapter-random-sampling.ts
+++ b/packages/chain/src/evm-adapter-random-sampling.ts
@@ -74,10 +74,7 @@ export class RandomSamplingMethods extends EVMChainAdapterBase {
   async createChallenge(): Promise<CreateChallengeResult> {
     await this.init();
 
-    const identityStorage = await this.getIdentityStorage();
-    const identityId: bigint = await this.readContract(
-      identityStorage, 'identityStorage.getIdentityId', 'getIdentityId', this.signer.address,
-    );
+    const identityId = await this.getIdentityId();
 
     return this.withHubStaleRetry(async () => {
       const { rs, rss } = await this.getRandomSampling();
@@ -108,11 +105,13 @@ export class RandomSamplingMethods extends EVMChainAdapterBase {
       // off the Challenge struct fetched below, so everything stays
       // consistent if the storage layout shifts.
       let contextGraphId = 0n;
+      let challengeIdentityId = identityId;
       const rsIface = rs.interface;
       for (const log of receipt.logs) {
         try {
           const parsed = rsIface.parseLog({ topics: [...log.topics], data: log.data });
           if (parsed?.name === 'ChallengeGenerated') {
+            challengeIdentityId = BigInt(parsed.args.identityId ?? parsed.args[0]);
             contextGraphId = BigInt(parsed.args.contextGraphId);
             break;
           }
@@ -129,12 +128,12 @@ export class RandomSamplingMethods extends EVMChainAdapterBase {
       }
 
       const challengeRaw = await this.readContract(
-        rss, 'rss.getNodeChallenge', 'getNodeChallenge', identityId,
+        rss, 'rss.getNodeChallenge', 'getNodeChallenge', challengeIdentityId,
       );
       const challenge = this.toNodeChallenge(challengeRaw);
       if (!challenge) {
         throw new Error(
-          `createChallenge succeeded but RandomSamplingStorage.getNodeChallenge(${identityId}) ` +
+          `createChallenge succeeded but RandomSamplingStorage.getNodeChallenge(${challengeIdentityId}) ` +
           'returned an empty struct. This indicates a state inconsistency between ' +
           'RandomSampling and RandomSamplingStorage.',
         );

--- a/packages/chain/src/evm-adapter-random-sampling.ts
+++ b/packages/chain/src/evm-adapter-random-sampling.ts
@@ -74,8 +74,6 @@ export class RandomSamplingMethods extends EVMChainAdapterBase {
   async createChallenge(): Promise<CreateChallengeResult> {
     await this.init();
 
-    const identityId = await this.getIdentityId();
-
     return this.withHubStaleRetry(async () => {
       const { rs, rss } = await this.getRandomSampling();
 
@@ -105,7 +103,7 @@ export class RandomSamplingMethods extends EVMChainAdapterBase {
       // off the Challenge struct fetched below, so everything stays
       // consistent if the storage layout shifts.
       let contextGraphId = 0n;
-      let challengeIdentityId = identityId;
+      let challengeIdentityId: bigint | undefined;
       const rsIface = rs.interface;
       for (const log of receipt.logs) {
         try {
@@ -117,13 +115,13 @@ export class RandomSamplingMethods extends EVMChainAdapterBase {
           }
         } catch { /* not this contract */ }
       }
-      if (contextGraphId === 0n) {
+      if (contextGraphId === 0n || challengeIdentityId == null) {
         // The picker only emits the event when it actually lands on a CG,
         // so a missing event is a bug — fail loud rather than fall back
         // to "lookup by KC" which V10 doesn't support natively.
         throw new Error(
           'createChallenge succeeded on-chain but no ChallengeGenerated event was found in the receipt; ' +
-          'cannot route proof builder without contextGraphId.',
+          'cannot route proof builder without identityId and contextGraphId.',
         );
       }
 

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -39,6 +39,7 @@ beforeEach(() => {
 
 describe('EVMChainAdapter getIdentityIdForAddress cache', () => {
   const ADDR = '0x00000000000000000000000000000000000000a1';
+  const ADDR2 = '0x00000000000000000000000000000000000000a2';
   const identityInterface = new Interface([
     'event IdentityCreated(uint72 indexed identityId, bytes32 indexed operationalKey, bytes32 indexed adminKey)',
   ]);
@@ -222,6 +223,34 @@ describe('EVMChainAdapter getIdentityIdForAddress cache', () => {
     expect(a.readContract.calls[1][0]).toBe(identityStorage);
   });
 
+  it('identity cache misses refresh IdentityStorage so a missed Hub rotation cannot pin stale zero reads', async () => {
+    const a: any = new EVMChainAdapter(minimalConfig());
+    const oldIdentityStorage = { target: '0x0000000000000000000000000000000000000101' };
+    const newIdentityStorage = { target: '0x0000000000000000000000000000000000000102' };
+    let resolveCount = 0;
+    a.initialized = true;
+    a.init = async () => { a.initialized = true; };
+    a.resolveContract = recorder(async () => {
+      resolveCount += 1;
+      return resolveCount === 1 ? oldIdentityStorage : newIdentityStorage;
+    });
+    a.readContract = recorder(async (contract: unknown) => (
+      contract === oldIdentityStorage ? 0n : 42n
+    ));
+
+    await expect(a.getIdentityIdForAddress(ADDR)).resolves.toBe(0n);
+    expect(a.contracts.identityStorage).toBe(oldIdentityStorage);
+
+    await expect(a.getIdentityIdForAddress(ADDR2)).resolves.toBe(42n);
+    expect(a.contracts.identityStorage).toBe(newIdentityStorage);
+    expect(a.resolveContract.calls).toHaveLength(2);
+    expect(a.readContract.calls).toHaveLength(2);
+
+    await expect(a.getIdentityIdForAddress(ADDR2)).resolves.toBe(42n);
+    expect(a.resolveContract.calls).toHaveLength(2);
+    expect(a.readContract.calls).toHaveLength(2);
+  });
+
   it('IdentityStorage Hub rotation invalidates cached identity ids and the lazy contract binding', async () => {
     const { a, readContract } = makeIdentityLookupAdapter([7n, 9n]);
 
@@ -258,7 +287,7 @@ describe('EVMChainAdapter getIdentityIdForAddress cache', () => {
   });
 
   it('ensureProfile seeds the signer identity cache after IdentityCreated', async () => {
-    const { a, readContract } = makeIdentityLookupAdapter([0n, 99n]);
+    const { a, readContract } = makeIdentityLookupAdapter([0n, 0n]);
     a.contracts.identity = { interface: identityInterface };
     a.contracts.profile = { interface: profileInterface };
     a.sendContractTransaction = recorder(async () => ({
@@ -271,7 +300,20 @@ describe('EVMChainAdapter getIdentityIdForAddress cache', () => {
 
     await expect(a.ensureProfile({ stakeAmount: 0n })).resolves.toBe(77n);
     await expect(a.getIdentityId()).resolves.toBe(77n);
-    expect(readContract.calls).toHaveLength(1);
+    expect(readContract.calls).toHaveLength(2);
+  });
+
+  it('ensureProfile freshly rechecks a cached signer zero before creating a profile', async () => {
+    const { a, readContract } = makeIdentityLookupAdapter([0n, 55n]);
+    a.sendContractTransaction = recorder(async () => {
+      throw new Error('ensureProfile should not create a duplicate profile');
+    });
+
+    await expect(a.getIdentityId()).resolves.toBe(0n);
+    await expect(a.ensureProfile({ stakeAmount: 0n })).resolves.toBe(55n);
+    await expect(a.getIdentityId()).resolves.toBe(55n);
+    expect(readContract.calls).toHaveLength(2);
+    expect(a.sendContractTransaction.calls).toHaveLength(0);
   });
 
   it('registerIdentity seeds the signer identity cache after IdentityCreated', async () => {

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -54,6 +54,14 @@ describe('EVMChainAdapter getIdentityIdForAddress cache', () => {
     return { topics: encoded.topics, data: encoded.data };
   }
 
+  function profileCreatedLog(identityId: bigint) {
+    const encoded = profileInterface.encodeEventLog(
+      profileInterface.getEvent('ProfileCreated')!,
+      [identityId],
+    );
+    return { topics: encoded.topics, data: encoded.data };
+  }
+
   function makeIdentityLookupAdapter(values: bigint[]) {
     const a: any = new EVMChainAdapter(minimalConfig());
     a.initialized = true;
@@ -166,14 +174,23 @@ describe('EVMChainAdapter getIdentityIdForAddress cache', () => {
     }
   });
 
-  it('repairs a cached self zero when a live signer-address lookup observes a positive identity', async () => {
+  it('shares the short signer zero cache between getIdentityId and getIdentityIdForAddress', async () => {
+    vi.useFakeTimers({ now: 0 });
     const { a, readContract } = makeIdentityLookupAdapter([0n, 42n]);
 
-    await expect(a.getIdentityId()).resolves.toBe(0n);
-    await expect(a.getIdentityIdForAddress((a as any).signer.address)).resolves.toBe(42n);
-    await expect(a.getIdentityId()).resolves.toBe(42n);
+    try {
+      await expect(a.getIdentityId()).resolves.toBe(0n);
+      await expect(a.getIdentityIdForAddress((a as any).signer.address)).resolves.toBe(0n);
+      expect(readContract.calls).toHaveLength(1);
 
-    expect(readContract.calls).toHaveLength(2);
+      vi.setSystemTime(15_001);
+
+      await expect(a.getIdentityIdForAddress((a as any).signer.address)).resolves.toBe(42n);
+      await expect(a.getIdentityId()).resolves.toBe(42n);
+      expect(readContract.calls).toHaveLength(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('shares cache entries between getIdentityId and getIdentityIdForAddress for the signer', async () => {
@@ -251,10 +268,28 @@ describe('EVMChainAdapter getIdentityIdForAddress cache', () => {
     await expect(a.getIdentityId()).resolves.toBe(88n);
     expect(readContract.calls).toHaveLength(0);
   });
+
+  it('registerIdentity seeds the signer identity cache after ProfileCreated fallback', async () => {
+    const { a, readContract } = makeIdentityLookupAdapter([0n, 99n]);
+    a.contracts.identity = { interface: identityInterface };
+    a.contracts.profile = { interface: profileInterface };
+    a.sendContractTransaction = recorder(async () => ({
+      logs: [profileCreatedLog(89n)],
+      hash: '0x' + '56'.repeat(32),
+      blockNumber: 1,
+      index: 0,
+      status: 1,
+    }));
+
+    await expect(a.getIdentityId()).resolves.toBe(0n);
+    await expect(a.registerIdentity({ publicKey: new Uint8Array([1]), signature: new Uint8Array() })).resolves.toBe(89n);
+    await expect(a.getIdentityId()).resolves.toBe(89n);
+    expect(readContract.calls).toHaveLength(1);
+  });
 });
 
 describe('EVMChainAdapter random sampling identity lookup', () => {
-  it('createChallenge uses the cached self identity path and reads back by the emitted identity', async () => {
+  it('createChallenge reads back by the emitted identity without pre-reading signer identity', async () => {
     const a: any = new EVMChainAdapter(minimalConfig());
     const challengeIdentityId = 99n;
     const cachedIdentityId = 42n;
@@ -286,19 +321,18 @@ describe('EVMChainAdapter random sampling identity lookup', () => {
     };
     const rss = { __rss: true };
     const rs = { interface: rsInterface };
-    const getIdentityId = recorder(async () => cachedIdentityId);
     const readContract = recorder(async () => challengeRaw);
     const sendContractTransaction = recorder(async () => receipt as any);
 
     a.init = async () => undefined;
-    a.getIdentityId = getIdentityId;
+    a.getIdentityId = recorder(async () => cachedIdentityId);
     a.getRandomSampling = async () => ({ rs, rss });
     a.readContract = readContract;
     a.sendContractTransaction = sendContractTransaction;
 
     const result = await a.createChallenge();
 
-    expect(getIdentityId.calls).toHaveLength(1);
+    expect(a.getIdentityId.calls).toHaveLength(0);
     expect(sendContractTransaction.calls[0][1]).toBe('createChallenge');
     expect(readContract.calls).toHaveLength(1);
     expect(readContract.calls[0][0]).toBe(rss);

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -39,10 +39,25 @@ beforeEach(() => {
 
 describe('EVMChainAdapter getIdentityIdForAddress cache', () => {
   const ADDR = '0x00000000000000000000000000000000000000a1';
+  const identityInterface = new Interface([
+    'event IdentityCreated(uint72 indexed identityId, bytes32 indexed operationalKey, bytes32 indexed adminKey)',
+  ]);
+  const profileInterface = new Interface([
+    'event ProfileCreated(uint72 indexed identityId)',
+  ]);
+
+  function identityCreatedLog(identityId: bigint) {
+    const encoded = identityInterface.encodeEventLog(
+      identityInterface.getEvent('IdentityCreated')!,
+      [identityId, ethers.ZeroHash, ethers.ZeroHash],
+    );
+    return { topics: encoded.topics, data: encoded.data };
+  }
 
   function makeIdentityLookupAdapter(values: bigint[]) {
     const a: any = new EVMChainAdapter(minimalConfig());
     a.initialized = true;
+    a.init = async () => { a.initialized = true; };
     a.resolveContract = recorder(async () => ({}));
     let i = 0;
     const readContract = recorder(async () => {
@@ -101,6 +116,196 @@ describe('EVMChainAdapter getIdentityIdForAddress cache', () => {
     a.clearIdentityIdForAddress(ADDR);
     await expect(a.getIdentityIdForAddress(ADDR)).resolves.toBe(0n);
     expect(readContract.calls).toHaveLength(1);
+  });
+
+  it('coalesces concurrent self getIdentityId reads through the address cache', async () => {
+    const { a, readContract } = makeIdentityLookupAdapter([42n]);
+
+    const results = await Promise.all(
+      Array.from({ length: 20 }, () => a.getIdentityId()),
+    );
+
+    expect(results.every((value) => value === 42n)).toBe(true);
+    expect(readContract.calls).toHaveLength(1);
+    expect(readContract.calls[0][3]).toBe((a as any).signer.address);
+  });
+
+  it('caches positive self getIdentityId results and refreshes them after the positive TTL', async () => {
+    vi.useFakeTimers({ now: 0 });
+    const { a, readContract } = makeIdentityLookupAdapter([7n, 9n]);
+
+    try {
+      await expect(a.getIdentityId()).resolves.toBe(7n);
+      await expect(a.getIdentityId()).resolves.toBe(7n);
+      expect(readContract.calls).toHaveLength(1);
+
+      vi.setSystemTime(5 * 60_000 + 1);
+
+      await expect(a.getIdentityId()).resolves.toBe(9n);
+      expect(readContract.calls).toHaveLength(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('caches a zero self getIdentityId result only for the short signer TTL', async () => {
+    vi.useFakeTimers({ now: 0 });
+    const { a, readContract } = makeIdentityLookupAdapter([0n, 42n]);
+
+    try {
+      await expect(a.getIdentityId()).resolves.toBe(0n);
+      await expect(a.getIdentityId()).resolves.toBe(0n);
+      expect(readContract.calls).toHaveLength(1);
+
+      vi.setSystemTime(15_001);
+
+      await expect(a.getIdentityId()).resolves.toBe(42n);
+      expect(readContract.calls).toHaveLength(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('repairs a cached self zero when a live signer-address lookup observes a positive identity', async () => {
+    const { a, readContract } = makeIdentityLookupAdapter([0n, 42n]);
+
+    await expect(a.getIdentityId()).resolves.toBe(0n);
+    await expect(a.getIdentityIdForAddress((a as any).signer.address)).resolves.toBe(42n);
+    await expect(a.getIdentityId()).resolves.toBe(42n);
+
+    expect(readContract.calls).toHaveLength(2);
+  });
+
+  it('shares cache entries between getIdentityId and getIdentityIdForAddress for the signer', async () => {
+    const { a, readContract } = makeIdentityLookupAdapter([42n]);
+
+    await expect(a.getIdentityId()).resolves.toBe(42n);
+    await expect(a.getIdentityIdForAddress((a as any).signer.address)).resolves.toBe(42n);
+
+    expect(readContract.calls).toHaveLength(1);
+  });
+
+  it('IdentityStorage Hub rotation invalidates cached identity ids and the lazy contract binding', async () => {
+    const { a, readContract } = makeIdentityLookupAdapter([7n, 9n]);
+
+    await expect(a.getIdentityId()).resolves.toBe(7n);
+    await expect(a.getIdentityId()).resolves.toBe(7n);
+    expect(readContract.calls).toHaveLength(1);
+
+    (a as any).contracts.identityStorage = { stale: true };
+    (a as any).applyHubRotationEventName('IdentityStorage');
+
+    expect((a as any).contracts.identityStorage).toBeUndefined();
+    await expect(a.getIdentityId()).resolves.toBe(9n);
+    expect(readContract.calls).toHaveLength(2);
+  });
+
+  it('bulk bound-contract invalidation clears signer identity cache and IdentityStorage binding', async () => {
+    const { a, readContract } = makeIdentityLookupAdapter([7n, 9n]);
+
+    await expect(a.getIdentityId()).resolves.toBe(7n);
+    await expect(a.getIdentityId()).resolves.toBe(7n);
+    expect(readContract.calls).toHaveLength(1);
+
+    (a as any).contracts.identityStorage = { stale: true };
+    (a as any).invalidateAllBoundContracts();
+
+    expect((a as any).contracts.identityStorage).toBeUndefined();
+    await expect(a.getIdentityId()).resolves.toBe(9n);
+    expect(readContract.calls).toHaveLength(2);
+  });
+
+  it('ensureProfile seeds the signer identity cache after IdentityCreated', async () => {
+    const { a, readContract } = makeIdentityLookupAdapter([0n, 99n]);
+    a.contracts.identity = { interface: identityInterface };
+    a.contracts.profile = { interface: profileInterface };
+    a.sendContractTransaction = recorder(async () => ({
+      logs: [identityCreatedLog(77n)],
+      hash: '0x' + '12'.repeat(32),
+      blockNumber: 1,
+      index: 0,
+      status: 1,
+    }));
+
+    await expect(a.ensureProfile({ stakeAmount: 0n })).resolves.toBe(77n);
+    await expect(a.getIdentityId()).resolves.toBe(77n);
+    expect(readContract.calls).toHaveLength(1);
+  });
+
+  it('registerIdentity seeds the signer identity cache after IdentityCreated', async () => {
+    const a: any = new EVMChainAdapter(minimalConfig());
+    const readContract = recorder(async () => 99n);
+    a.init = async () => undefined;
+    a.contracts.identity = { interface: identityInterface };
+    a.contracts.profile = { interface: profileInterface };
+    a.readContract = readContract;
+    a.sendContractTransaction = recorder(async () => ({
+      logs: [identityCreatedLog(88n)],
+      hash: '0x' + '34'.repeat(32),
+      blockNumber: 1,
+      index: 0,
+      status: 1,
+    }));
+
+    await expect(a.registerIdentity({ publicKey: new Uint8Array([1]), signature: new Uint8Array() })).resolves.toBe(88n);
+    await expect(a.getIdentityId()).resolves.toBe(88n);
+    expect(readContract.calls).toHaveLength(0);
+  });
+});
+
+describe('EVMChainAdapter random sampling identity lookup', () => {
+  it('createChallenge uses the cached self identity path and reads back by the emitted identity', async () => {
+    const a: any = new EVMChainAdapter(minimalConfig());
+    const challengeIdentityId = 99n;
+    const cachedIdentityId = 42n;
+    const contextGraphId = 3n;
+    const rsInterface = new Interface([
+      'event ChallengeGenerated(uint72 indexed identityId,uint256 indexed contextGraphId,uint256 knowledgeAssetId,uint256 chunkId,uint256 epoch,uint256 activeProofPeriodStartBlock)',
+    ]);
+    const encoded = rsInterface.encodeEventLog(
+      rsInterface.getEvent('ChallengeGenerated')!,
+      [challengeIdentityId, contextGraphId, 11n, 2n, 3n, 4n],
+    );
+    const receipt = {
+      hash: '0x' + '11'.repeat(32),
+      blockNumber: 123,
+      index: 4,
+      logs: [{ topics: encoded.topics, data: encoded.data }],
+    };
+    const challengeRaw = {
+      knowledgeAssetId: 11n,
+      knowledgeAssetStorageContract: ethers.ZeroAddress,
+      chunkId: 2n,
+      epoch: 3n,
+      activeProofPeriodStartBlock: 4n,
+      proofingPeriodDurationInBlocks: 5n,
+      solved: false,
+      isCurated: false,
+      challengeLeafCount: 1n,
+      challengeRoot: ethers.ZeroHash,
+    };
+    const rss = { __rss: true };
+    const rs = { interface: rsInterface };
+    const getIdentityId = recorder(async () => cachedIdentityId);
+    const readContract = recorder(async () => challengeRaw);
+    const sendContractTransaction = recorder(async () => receipt as any);
+
+    a.init = async () => undefined;
+    a.getIdentityId = getIdentityId;
+    a.getRandomSampling = async () => ({ rs, rss });
+    a.readContract = readContract;
+    a.sendContractTransaction = sendContractTransaction;
+
+    const result = await a.createChallenge();
+
+    expect(getIdentityId.calls).toHaveLength(1);
+    expect(sendContractTransaction.calls[0][1]).toBe('createChallenge');
+    expect(readContract.calls).toHaveLength(1);
+    expect(readContract.calls[0][0]).toBe(rss);
+    expect(readContract.calls[0][1]).toBe('rss.getNodeChallenge');
+    expect(readContract.calls[0][3]).toBe(challengeIdentityId);
+    expect(result.contextGraphId).toBe(contextGraphId);
+    expect(result.challenge.knowledgeAssetId).toBe(11n);
   });
 });
 

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -202,6 +202,26 @@ describe('EVMChainAdapter getIdentityIdForAddress cache', () => {
     expect(readContract.calls).toHaveLength(1);
   });
 
+  it('identity id reads populate the canonical IdentityStorage lazy binding', async () => {
+    const a: any = new EVMChainAdapter(minimalConfig());
+    const identityStorage = { identityStorage: true };
+    a.initialized = true;
+    a.init = async () => { a.initialized = true; };
+    a.resolveContract = recorder(async () => identityStorage);
+    a.readContract = recorder(async (_contract: unknown, _label: string, method: string) => (
+      method === 'getIdentityId' ? 42n : true
+    ));
+
+    await expect(a.getIdentityId()).resolves.toBe(42n);
+    expect(a.contracts.identityStorage).toBe(identityStorage);
+
+    await expect(a.isOperationalWalletRegistered(42n, ADDR)).resolves.toBe(true);
+    expect(a.resolveContract.calls).toHaveLength(1);
+    expect(a.readContract.calls).toHaveLength(2);
+    expect(a.readContract.calls[0][0]).toBe(identityStorage);
+    expect(a.readContract.calls[1][0]).toBe(identityStorage);
+  });
+
   it('IdentityStorage Hub rotation invalidates cached identity ids and the lazy contract binding', async () => {
     const { a, readContract } = makeIdentityLookupAdapter([7n, 9n]);
 
@@ -210,10 +230,15 @@ describe('EVMChainAdapter getIdentityIdForAddress cache', () => {
     expect(readContract.calls).toHaveLength(1);
 
     (a as any).contracts.identityStorage = { stale: true };
+    const init = recorder(async () => { (a as any).initialized = true; });
+    (a as any).init = init;
     (a as any).applyHubRotationEventName('IdentityStorage');
 
     expect((a as any).contracts.identityStorage).toBeUndefined();
+    expect((a as any).initialized).toBe(false);
     await expect(a.getIdentityId()).resolves.toBe(9n);
+    expect(init.calls).toHaveLength(1);
+    expect((a as any).initialized).toBe(true);
     expect(readContract.calls).toHaveLength(2);
   });
 


### PR DESCRIPTION
## Summary

This chained PR reduces the largest remaining `identityStorage.getIdentityId` RPC consumer identified by the eth-call attribution work.

Changes:
- Adds a signer-only `getIdentityId()` cache in the EVM adapter.
  - Positive signer identity IDs use the existing 5-minute TTL.
  - Signer `0n` is cached for only 15 seconds, targeting fresh edge-node startup spam while bounding external profile-creation visibility delay.
- Keeps arbitrary `getIdentityIdForAddress(address)` negative results live: `0n` is still not retained for external addresses.
- Keeps `ensureOperationalWalletsRegistered()` classification live so wallet repair cannot be stale-skipped by a TTL cache.
- Seeds signer/address identity caches after local `ensureProfile()` / `registerIdentity()` success.
- Invalidates identity caches and the lazy `IdentityStorage` binding on direct Hub rotation and bulk stale-Hub recovery.
- Routes random-sampling's direct self-identity read through `getIdentityId()` and reads back challenges by the emitted `ChallengeGenerated.identityId`.

## Expected RPC impact

Before this PR, repeated self identity reads could produce one raw `identityStorage.getIdentityId` `eth_call` per caller invocation. Startup sync can multiply that by peer, context graph, phase, page, and retry.

After this PR:
- Existing/core nodes with a positive signer identity should collapse repeated self lookups to roughly one raw read per 5-minute TTL window per adapter.
- Fresh edge nodes with signer identity `0n` should collapse repeated self lookups to roughly one raw read per 15 seconds per adapter, instead of one per sync request/page.
- Remaining identity-storage calls should mostly be first misses, TTL refreshes, unique external address probes, or intentionally live wallet-repair reads.

The exact reduction still needs live testnet attribution against the existing PR #1440 / #1487 benchmark before we claim achieved production numbers.

## Test plan

- `pnpm install --frozen-lockfile --ignore-scripts`
  - Note: normal install failed on Windows because `@cyfrin/aderyn` postinstall does not support Windows.
- `pnpm --filter @origintrail-official/dkg-core run build`
- `pnpm --dir packages/chain exec vitest run --config vitest.unit.config.ts test/evm-adapter.unit.test.ts --reporter dot`
  - Passed: 191 tests.
- `pnpm --dir packages/chain run build`
- `pnpm --dir packages/chain exec tsc --noEmit`
- `git diff --check`

## Follow-up validation

Before merging this into PR #1440, run the existing dkg testnet Windows attribution plan on a fresh edge-node startup and compare `identityStorage.getIdentityId`, total `eth_call`, 429s, and functional responsiveness against the latest benchmark.