### PR TITLE
fix(devnet): repair suites broken by #1410 + daemon.log double-write; harden stress/lifecycle blind spots

### DIFF
--- a/devnet/_bootstrap/harness.ts
+++ b/devnet/_bootstrap/harness.ts
@@ -257,6 +257,64 @@ export interface PublishResult {
   raw: string;
 }
 
+export interface KaLifecycleOptions {
+  kaName: string;
+  contextGraphId: string;
+  inputFile: string;
+  /** Extra args appended to `ka create` (e.g. --sub-graph-name). */
+  createArgs?: string[];
+  /** Extra args appended to `ka publish` (e.g. --publish-epochs, --publisher-node-identity-id). */
+  publishArgs?: string[];
+}
+
+/**
+ * The two-step #1410 KA publish lifecycle (`ka create --share` stages WM ->
+ * finalize -> SWM, then `ka publish` lands SWM -> VM on-chain) with its output
+ * parsing, in ONE place. `runCli` abstracts how a suite spawns the CLI — each
+ * suite keeps its own node/env/timeout mechanics — while this helper owns the
+ * argument contract and the stdout contract (`Status:`, `KA ID:`, `Tx hash:`).
+ * Throws on a non-zero exit of either step. Status/kaId ASSERTIONS stay with
+ * callers: accepted statuses differ per scenario (e.g. tentative-tolerant
+ * suites). `status` is returned lowercased; `kaId` is undefined when no
+ * "KA ID:" line was printed.
+ */
+export async function runKaPublishLifecycle(
+  runCli: (args: string[]) => Promise<CliResult>,
+  opts: KaLifecycleOptions,
+): Promise<PublishResult> {
+  const created = await runCli([
+    'ka', 'create', opts.kaName,
+    '--context-graph-id', opts.contextGraphId,
+    '--input-file', opts.inputFile,
+    '--share',
+    ...(opts.createArgs ?? []),
+  ]);
+  if (created.code !== 0) {
+    throw new Error(
+      `ka create --share ${opts.kaName} failed (exit ${created.code})\nstdout: ${created.stdout}\nstderr: ${created.stderr}`,
+    );
+  }
+  const published = await runCli([
+    'ka', 'publish', opts.kaName,
+    '--context-graph-id', opts.contextGraphId,
+    ...(opts.publishArgs ?? []),
+  ]);
+  if (published.code !== 0) {
+    throw new Error(
+      `ka publish ${opts.kaName} failed (exit ${published.code})\nstdout: ${published.stdout}\nstderr: ${published.stderr}`,
+    );
+  }
+  const status = (/Status:\s*(\w+)/i.exec(published.stdout)?.[1] ?? 'unknown').toLowerCase();
+  const kaMatch = /K[AC] ID:\s*(\d+)/i.exec(published.stdout);
+  const txMatch = /Tx hash:\s*(0x[0-9a-fA-F]+)/i.exec(published.stdout);
+  return {
+    status,
+    kaId: kaMatch ? BigInt(kaMatch[1]!) : undefined,
+    txHash: txMatch?.[1],
+    raw: published.stdout,
+  };
+}
+
 const PUBLISH_OK = ['confirmed', 'finalized', 'tentative'];
 let publishSeq = 0;
 
@@ -266,37 +324,23 @@ export async function publishViaCli(
   filePath: string,
   options: { publisherNodeIdentityId?: bigint; extraArgs?: string[] } = {},
 ): Promise<PublishResult> {
-  // #1410 replaced the one-shot `dkg publish <cg> --file` with the KA
-  // lifecycle CLI: `ka create --share` stages the KA (WM -> finalize -> SWM),
-  // then `ka publish` performs the on-chain SWM -> VM publish.
-  const kaName = `harness-pub-${Date.now().toString(36)}-${++publishSeq}`;
-  const created = await runDkgCli(node, ['ka', 'create', kaName, '--context-graph-id', contextGraph, '--input-file', filePath, '--share']);
-  if (created.code !== 0) {
-    throw new Error(
-      `ka create --share failed (exit ${created.code})\nstdout: ${created.stdout}\nstderr: ${created.stderr}`,
-    );
-  }
-  const args = ['ka', 'publish', kaName, '--context-graph-id', contextGraph];
+  const publishArgs: string[] = [];
   if (options.publisherNodeIdentityId !== undefined) {
-    args.push('--publisher-node-identity-id', String(options.publisherNodeIdentityId));
+    publishArgs.push('--publisher-node-identity-id', String(options.publisherNodeIdentityId));
   }
-  if (options.extraArgs) args.push(...options.extraArgs);
-  const result = await runDkgCli(node, args);
-  if (result.code !== 0) {
-    throw new Error(
-      `ka publish failed (exit ${result.code})\nstdout: ${result.stdout}\nstderr: ${result.stderr}`,
-    );
-  }
-  const status = /Status:\s*(\w+)/i.exec(result.stdout)?.[1] ?? 'unknown';
-  const kcMatch = /K[AC] ID:\s*(\d+)/i.exec(result.stdout);
-  const txMatch = /Tx hash:\s*(0x[0-9a-fA-F]+)/i.exec(result.stdout);
-  const kaId = kcMatch ? BigInt(kcMatch[1]!) : undefined;
+  if (options.extraArgs) publishArgs.push(...options.extraArgs);
+  const result = await runKaPublishLifecycle((args) => runDkgCli(node, args), {
+    kaName: `harness-pub-${Date.now().toString(36)}-${++publishSeq}`,
+    contextGraphId: contextGraph,
+    inputFile: filePath,
+    publishArgs,
+  });
   expect(
     PUBLISH_OK,
-    `ka publish status="${status}", expected one of ${PUBLISH_OK.join('/')}\n${result.stdout}`,
-  ).toContain(status.toLowerCase());
-  expect(kaId, `ka publish surfaced no positive "KA ID:" (kaId=${kaId})\n${result.stdout}`).toBeGreaterThan(0n);
-  return { status, kaId, txHash: txMatch ? txMatch[1] : undefined, raw: result.stdout };
+    `ka publish status="${result.status}", expected one of ${PUBLISH_OK.join('/')}\n${result.raw}`,
+  ).toContain(result.status);
+  expect(result.kaId, `ka publish surfaced no positive "KA ID:" (kaId=${result.kaId})\n${result.raw}`).toBeGreaterThan(0n);
+  return result;
 }
 
 // ───────────────────────────── n-quads files ─────────────────────────────

--- a/devnet/_bootstrap/harness.ts
+++ b/devnet/_bootstrap/harness.ts
@@ -258,6 +258,7 @@ export interface PublishResult {
 }
 
 const PUBLISH_OK = ['confirmed', 'finalized', 'tentative'];
+let publishSeq = 0;
 
 export async function publishViaCli(
   node: DevnetNode,
@@ -265,7 +266,17 @@ export async function publishViaCli(
   filePath: string,
   options: { publisherNodeIdentityId?: bigint; extraArgs?: string[] } = {},
 ): Promise<PublishResult> {
-  const args = ['publish', contextGraph, '--file', filePath];
+  // #1410 replaced the one-shot `dkg publish <cg> --file` with the KA
+  // lifecycle CLI: `ka create --share` stages the KA (WM -> finalize -> SWM),
+  // then `ka publish` performs the on-chain SWM -> VM publish.
+  const kaName = `harness-pub-${Date.now().toString(36)}-${++publishSeq}`;
+  const created = await runDkgCli(node, ['ka', 'create', kaName, '--context-graph-id', contextGraph, '--input-file', filePath, '--share']);
+  if (created.code !== 0) {
+    throw new Error(
+      `ka create --share failed (exit ${created.code})\nstdout: ${created.stdout}\nstderr: ${created.stderr}`,
+    );
+  }
+  const args = ['ka', 'publish', kaName, '--context-graph-id', contextGraph];
   if (options.publisherNodeIdentityId !== undefined) {
     args.push('--publisher-node-identity-id', String(options.publisherNodeIdentityId));
   }
@@ -273,18 +284,18 @@ export async function publishViaCli(
   const result = await runDkgCli(node, args);
   if (result.code !== 0) {
     throw new Error(
-      `dkg publish failed (exit ${result.code})\nstdout: ${result.stdout}\nstderr: ${result.stderr}`,
+      `ka publish failed (exit ${result.code})\nstdout: ${result.stdout}\nstderr: ${result.stderr}`,
     );
   }
   const status = /Status:\s*(\w+)/i.exec(result.stdout)?.[1] ?? 'unknown';
-  const kcMatch = /KC ID:\s*(\d+)/i.exec(result.stdout);
-  const txMatch = /TX hash:\s*(0x[0-9a-fA-F]+)/i.exec(result.stdout);
+  const kcMatch = /K[AC] ID:\s*(\d+)/i.exec(result.stdout);
+  const txMatch = /Tx hash:\s*(0x[0-9a-fA-F]+)/i.exec(result.stdout);
   const kaId = kcMatch ? BigInt(kcMatch[1]!) : undefined;
   expect(
     PUBLISH_OK,
-    `dkg publish status="${status}", expected one of ${PUBLISH_OK.join('/')}\n${result.stdout}`,
+    `ka publish status="${status}", expected one of ${PUBLISH_OK.join('/')}\n${result.stdout}`,
   ).toContain(status.toLowerCase());
-  expect(kaId, `dkg publish surfaced no positive "KC ID:" (kaId=${kaId})\n${result.stdout}`).toBeGreaterThan(0n);
+  expect(kaId, `ka publish surfaced no positive "KA ID:" (kaId=${kaId})\n${result.stdout}`).toBeGreaterThan(0n);
   return { status, kaId, txHash: txMatch ? txMatch[1] : undefined, raw: result.stdout };
 }
 

--- a/devnet/agent-provenance/README.md
+++ b/devnet/agent-provenance/README.md
@@ -40,7 +40,7 @@ sequence per mode, including:
 
 - **Setup** — what fixtures (PCAs, `authorizedKeys`, identities) the
   mode requires before any `publish` call.
-- **Action** — the actual `dkg publish` (or HTTP) call.
+- **Action** — the actual `dkg ka` publish (or HTTP) call.
 - **Assertions** — the on-chain reads + log checks that ratify the
   mode succeeded with the right authorship / attribution / payment
   shape.
@@ -269,7 +269,7 @@ option — explicit `0n` proceeds on-chain.
 - `KnowledgeAssetCreated` event has `author = edge.agent`,
   emitted with `publisherNodeIdentityId = 0` (verifiable via the
   `merkleRoots` accessor: the on-chain attribution field is `0`).
-- `dkg publish` returns `Status: confirmed` (not `tentative`).
+- `dkg ka publish` returns `Status: confirmed` (not `tentative`).
 
 ### Negative case: unauthorized PCA fall-through
 
@@ -284,7 +284,7 @@ option — explicit `0n` proceeds on-chain.
 
 # Action — publish from a fresh wallet not on the allowlist.
 # Use `dkg publisher wallet add <pk>` on node5 first to enroll a
-# fresh signing wallet, then drive `dkg publish`. Do NOT pass that
+# fresh signing wallet, then drive `dkg ka publish`. Do NOT pass that
 # fresh wallet through `node1 pca authorize` — that would defeat
 # the purpose. Verify with `node1 pca info 1 --probe-key <addr>`
 # that `authorized: false` BEFORE the publish.

--- a/devnet/agent-provenance/automated.test.ts
+++ b/devnet/agent-provenance/automated.test.ts
@@ -44,6 +44,7 @@ import { spawn } from 'node:child_process';
 import { readFileSync, existsSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { ethers } from 'ethers';
+import { runKaPublishLifecycle } from '../_bootstrap/harness';
 
 const REPO_ROOT = resolve(__dirname, '../..');
 const RPC = 'http://127.0.0.1:8545';
@@ -350,7 +351,8 @@ function runDkgCli(node: DevnetNode, args: string[], timeoutMs = 60_000): Promis
   });
 }
 
-/** Run `dkg ka create --share` + `dkg ka publish` and return the parsed { kaId, status, txHash }. */
+/** Run `dkg ka create --share` + `dkg ka publish` and return the parsed { kaId, status, txHash }
+ *  (status lowercased — every caller here compares via .toLowerCase()). */
 let publishSeq = 0;
 
 async function publishViaCli(
@@ -360,59 +362,36 @@ async function publishViaCli(
   options: { publisherNodeIdentityId?: bigint } = {},
 ): Promise<{ status: string; kaId?: bigint; txHash?: string; raw: string }> {
   // #1410 replaced the one-shot `dkg publish <cg> --file` with the KA
-  // lifecycle CLI: `ka create --share` stages the KA (WM -> finalize -> SWM),
-  // then `ka publish` performs the on-chain SWM -> VM publish.
-  const kaName = `cli-pub-${Date.now().toString(36)}-${++publishSeq}`;
-  const created = await runDkgCli(node, [
-    'ka', 'create', kaName,
-    '--context-graph-id', contextGraph,
-    '--input-file', filePath,
-    '--share',
-  ]);
-  if (created.code !== 0) {
-    throw new Error(
-      `ka create --share failed (exit ${created.code})\n` +
-      `stdout: ${created.stdout}\nstderr: ${created.stderr}`,
-    );
-  }
-  const args = ['ka', 'publish', kaName, '--context-graph-id', contextGraph];
+  // lifecycle CLI (`ka create --share` stages WM -> finalize -> SWM, then
+  // `ka publish` lands SWM -> VM on-chain) — argument arrays + Status:/KA ID:/
+  // Tx hash: stdout parsing live in the shared runKaPublishLifecycle
+  // (../_bootstrap/harness); this suite keeps its own 5-node CLI spawn.
+  const publishArgs: string[] = [];
   if (options.publisherNodeIdentityId !== undefined) {
-    args.push('--publisher-node-identity-id', String(options.publisherNodeIdentityId));
+    publishArgs.push('--publisher-node-identity-id', String(options.publisherNodeIdentityId));
   }
-  const result = await runDkgCli(node, args);
-  if (result.code !== 0) {
-    throw new Error(
-      `ka publish failed (exit ${result.code})\n` +
-      `stdout: ${result.stdout}\nstderr: ${result.stderr}`,
-    );
-  }
-  // Parse the human-readable output. The CLI prints "Status: confirmed",
-  // "KA ID: <n>", "Tx hash: 0x..."  (lines vary slightly across statuses).
-  const status = /Status:\s*(\w+)/i.exec(result.stdout)?.[1] ?? 'unknown';
-  const kcMatch = /K[AC] ID:\s*(\d+)/i.exec(result.stdout);
-  const txMatch = /Tx hash:\s*(0x[0-9a-fA-F]+)/i.exec(result.stdout);
-  const kaId = kcMatch ? BigInt(kcMatch[1]!) : undefined;
+  const result = await runKaPublishLifecycle((args) => runDkgCli(node, args), {
+    kaName: `cli-pub-${Date.now().toString(36)}-${++publishSeq}`,
+    contextGraphId: contextGraph,
+    inputFile: filePath,
+    publishArgs,
+  });
   // Greedy publish-outcome gate (mirrors the devnet shell _devnet_publish_status_ok
   // contract): a CLI exit code of 0 is NOT proof of a real publish. Pin the
   // status to a known success value and require a positive on-chain kaId so an
   // 'unknown'/failed status — or a missing id (e.g. a "KC ID:" → "KA ID:" output
-  // rename that drifts past this regex after the KC→KA transition) — fails
+  // rename that drifts past the helper's regex after the KC→KA transition) — fails
   // loudly here instead of slipping through every caller as a green publish.
   const publishOk = ['confirmed', 'finalized', 'tentative'];
   expect(
     publishOk,
-    `ka publish status="${status}", expected one of ${publishOk.join('/')}\n${result.stdout}`,
-  ).toContain(status.toLowerCase());
+    `ka publish status="${result.status}", expected one of ${publishOk.join('/')}\n${result.raw}`,
+  ).toContain(result.status);
   expect(
-    kaId,
-    `ka publish surfaced no positive "KA ID:" (kaId=${kaId})\n${result.stdout}`,
+    result.kaId,
+    `ka publish surfaced no positive "KA ID:" (kaId=${result.kaId})\n${result.raw}`,
   ).toBeGreaterThan(0n);
-  return {
-    status,
-    kaId,
-    txHash: txMatch ? txMatch[1] : undefined,
-    raw: result.stdout,
-  };
+  return result;
 }
 
 async function loadContractAddresses(provider: ethers.JsonRpcProvider, hubAddress: string) {

--- a/devnet/agent-provenance/automated.test.ts
+++ b/devnet/agent-provenance/automated.test.ts
@@ -36,7 +36,7 @@
  * drives the OLD `PublishingConvictionAccount` contract; V10 publish
  * uses `DKGPublishingConvictionNFT`. There is no CLI surface for the
  * NFT yet. Mode (a) here drives the NFT contract directly via JSON-RPC
- * and uses the CLI only for the actual `dkg publish` call. The CLI
+ * and uses the CLI only for the actual `dkg ka` publish flow. The CLI
  * gap is filed as a follow-up task in the DKG.
  */
 import { describe, it, expect, beforeAll } from 'vitest';
@@ -350,29 +350,47 @@ function runDkgCli(node: DevnetNode, args: string[], timeoutMs = 60_000): Promis
   });
 }
 
-/** Run `dkg publish` and return the parsed { kaId, status, txHash } it printed. */
+/** Run `dkg ka create --share` + `dkg ka publish` and return the parsed { kaId, status, txHash }. */
+let publishSeq = 0;
+
 async function publishViaCli(
   node: DevnetNode,
   contextGraph: string,
   filePath: string,
   options: { publisherNodeIdentityId?: bigint } = {},
 ): Promise<{ status: string; kaId?: bigint; txHash?: string; raw: string }> {
-  const args = ['publish', contextGraph, '--file', filePath];
+  // #1410 replaced the one-shot `dkg publish <cg> --file` with the KA
+  // lifecycle CLI: `ka create --share` stages the KA (WM -> finalize -> SWM),
+  // then `ka publish` performs the on-chain SWM -> VM publish.
+  const kaName = `cli-pub-${Date.now().toString(36)}-${++publishSeq}`;
+  const created = await runDkgCli(node, [
+    'ka', 'create', kaName,
+    '--context-graph-id', contextGraph,
+    '--input-file', filePath,
+    '--share',
+  ]);
+  if (created.code !== 0) {
+    throw new Error(
+      `ka create --share failed (exit ${created.code})\n` +
+      `stdout: ${created.stdout}\nstderr: ${created.stderr}`,
+    );
+  }
+  const args = ['ka', 'publish', kaName, '--context-graph-id', contextGraph];
   if (options.publisherNodeIdentityId !== undefined) {
     args.push('--publisher-node-identity-id', String(options.publisherNodeIdentityId));
   }
   const result = await runDkgCli(node, args);
   if (result.code !== 0) {
     throw new Error(
-      `dkg publish failed (exit ${result.code})\n` +
+      `ka publish failed (exit ${result.code})\n` +
       `stdout: ${result.stdout}\nstderr: ${result.stderr}`,
     );
   }
   // Parse the human-readable output. The CLI prints "Status: confirmed",
-  // "KC ID: <n>", "TX hash: 0x..."  (lines vary slightly across statuses).
+  // "KA ID: <n>", "Tx hash: 0x..."  (lines vary slightly across statuses).
   const status = /Status:\s*(\w+)/i.exec(result.stdout)?.[1] ?? 'unknown';
-  const kcMatch = /KC ID:\s*(\d+)/i.exec(result.stdout);
-  const txMatch = /TX hash:\s*(0x[0-9a-fA-F]+)/i.exec(result.stdout);
+  const kcMatch = /K[AC] ID:\s*(\d+)/i.exec(result.stdout);
+  const txMatch = /Tx hash:\s*(0x[0-9a-fA-F]+)/i.exec(result.stdout);
   const kaId = kcMatch ? BigInt(kcMatch[1]!) : undefined;
   // Greedy publish-outcome gate (mirrors the devnet shell _devnet_publish_status_ok
   // contract): a CLI exit code of 0 is NOT proof of a real publish. Pin the
@@ -383,11 +401,11 @@ async function publishViaCli(
   const publishOk = ['confirmed', 'finalized', 'tentative'];
   expect(
     publishOk,
-    `dkg publish status="${status}", expected one of ${publishOk.join('/')}\n${result.stdout}`,
+    `ka publish status="${status}", expected one of ${publishOk.join('/')}\n${result.stdout}`,
   ).toContain(status.toLowerCase());
   expect(
     kaId,
-    `dkg publish surfaced no positive "KC ID:" (kaId=${kaId})\n${result.stdout}`,
+    `ka publish surfaced no positive "KA ID:" (kaId=${kaId})\n${result.stdout}`,
   ).toBeGreaterThan(0n);
   return {
     status,
@@ -649,7 +667,7 @@ describe('Agent provenance — automated 5-node devnet validation', () => {
   //      `hardhat_setStorageAt`. ETH is untouched — daemon can still
   //      pay gas. After this step `sumOpBalances(edge) == 0n`.
   //
-  // Action: edge runs `dkg publish` naming core1 for attribution. The
+  // Action: edge runs the `dkg ka` publish flow naming core1 for attribution. The
   // daemon will pick one of the now-zero-TRAC op wallets as `msg.sender`
   // for `KAV10.publish()`. The conviction branch fires
   // (`agentToAccountId[msg.sender] != 0`, `epochs == lockDurationEpochs`,

--- a/devnet/agent-provenance/transcript.template.md
+++ b/devnet/agent-provenance/transcript.template.md
@@ -23,15 +23,16 @@ added, etc.):
 ## Action
 
 ```text
-$ NODE_DIR=.devnet/node5 ./scripts/dkg publish <cgId> \
-    --file devnet/agent-provenance/turns/turn-<x>.nq \
+$ NODE_DIR=.devnet/node5 ./scripts/dkg ka create <name> --context-graph-id <cgId> \
+    --input-file devnet/agent-provenance/turns/turn-<x>.nq --share
+$ NODE_DIR=.devnet/node5 ./scripts/dkg ka publish <name> --context-graph-id <cgId> \
     --publisher-node-identity-id <core_id>
 
 <paste full stdout/stderr — should include the daemon log line:
 "On-chain confirmed: UAL=... batchId=N tx=0x...">
 ```
 
-KC ID minted: `<batchId>`
+KA ID minted: `<batchId>`
 TX hash: `<0x...>`
 Block number: `<N>`
 

--- a/devnet/conviction-lazy-settle/automated.test.ts
+++ b/devnet/conviction-lazy-settle/automated.test.ts
@@ -6,7 +6,7 @@
  *
  *   - `createAccount` no longer distributes the committed TRAC upfront. It
  *     sits in escrow against per-billing-window budgets.
- *   - Active sink: `coverPublishingCost` (driven through `dkg publish` via
+ *   - Active sink: `coverPublishingCost` (driven through `dkg ka publish` via
  *     a registered agent) distributes `discountedCost` across the published
  *     KC's chain-epoch range and increments `windowSpent[acct][currentWindow]`.
  *   - Passive sink: after a billing window closes, `settle(accountId)`
@@ -26,7 +26,7 @@
  *   "first publish on window 0" assertions racey. We mint a SECOND PCA with
  *   a fresh agent EOA so the windowSpent[acct][0] === 0 precondition holds.
  *
- * Why use direct ABI calls + `dkg publish` (no new HTTP routes)?
+ * Why use direct ABI calls + `dkg ka publish` (no new HTTP routes)?
  *   The node operator's official surface for PCA discount is "publish via
  *   an agent that's registered on the NFT" — there is no `/api/pca` route
  *   for the V10 NFT yet (the existing one drives the legacy V9 contract).
@@ -255,11 +255,11 @@ function nquadsFile(name: string): string {
   return p;
 }
 
-async function dkgPublish(node: DevnetNode, file: string): Promise<{ kaId: bigint; txHash: string }> {
+function runCliOnce(node: DevnetNode, args: string[]): Promise<{ code: number; stdout: string; stderr: string }> {
   return new Promise((res, rej) => {
     const child = spawn(
       process.execPath,
-      [join(REPO_ROOT, 'packages/cli/dist/cli.js'), 'publish', CONTEXT_GRAPH, '--file', file],
+      [join(REPO_ROOT, 'packages/cli/dist/cli.js'), ...args],
       {
         cwd: REPO_ROOT,
         env: {
@@ -274,40 +274,52 @@ async function dkgPublish(node: DevnetNode, file: string): Promise<{ kaId: bigin
     let stderr = '';
     const timer = setTimeout(() => {
       child.kill('SIGKILL');
-      rej(new Error(`dkg publish timeout (90s)\nstdout: ${stdout}\nstderr: ${stderr}`));
+      rej(new Error(`dkg ${args.join(' ')} timeout (90s)\nstdout: ${stdout}\nstderr: ${stderr}`));
     }, 90_000);
     child.stdout?.on('data', (d) => { stdout += d.toString(); });
     child.stderr?.on('data', (d) => { stderr += d.toString(); });
     child.on('close', (code) => {
       clearTimeout(timer);
-      if (code !== 0) {
-        rej(new Error(`dkg publish exit=${code}\nstdout: ${stdout}\nstderr: ${stderr}`));
-        return;
-      }
-      const status = /Status:\s*(\w+)/i.exec(stdout)?.[1]?.toLowerCase() ?? 'unknown';
-      const kcMatch = /KC ID:\s*(\d+)/i.exec(stdout);
-      const txMatch = /TX hash:\s*(0x[0-9a-fA-F]+)/i.exec(stdout);
-      if (!kcMatch || !txMatch) {
-        rej(new Error(`could not parse publish output\n${stdout}`));
-        return;
-      }
-      // Greedy publish-outcome gate: exit 0 is not proof of a real publish.
-      // Require a known success status and a positive kaId so a failed/tentative
-      // publish (whose receipt could otherwise drive the CostCovered / lazy-settle
-      // assertions against the wrong tx) is rejected here, not silently accepted.
-      const publishOk = ['confirmed', 'finalized', 'tentative'];
-      if (!publishOk.includes(status)) {
-        rej(new Error(`dkg publish status="${status}", expected one of ${publishOk.join('/')}\n${stdout}`));
-        return;
-      }
-      const kaId = BigInt(kcMatch[1]!);
-      if (kaId <= 0n) {
-        rej(new Error(`dkg publish surfaced non-positive kaId=${kaId}\n${stdout}`));
-        return;
-      }
-      res({ kaId, txHash: txMatch[1]! });
+      res({ code: code ?? -1, stdout, stderr });
     });
   });
+}
+
+let publishSeq = 0;
+
+async function dkgPublish(node: DevnetNode, file: string): Promise<{ kaId: bigint; txHash: string }> {
+  // #1410 replaced the one-shot `dkg publish <cg> --file` with the KA
+  // lifecycle CLI: `ka create --share` stages the KA (WM -> finalize -> SWM),
+  // then `ka publish` performs the on-chain SWM -> VM publish.
+  const kaName = `cls-pub-${Date.now().toString(36)}-${++publishSeq}`;
+  const created = await runCliOnce(node, ['ka', 'create', kaName, '--context-graph-id', CONTEXT_GRAPH, '--input-file', file, '--share']);
+  if (created.code !== 0) {
+    throw new Error(`ka create --share exit=${created.code}\nstdout: ${created.stdout}\nstderr: ${created.stderr}`);
+  }
+  const result = await runCliOnce(node, ['ka', 'publish', kaName, '--context-graph-id', CONTEXT_GRAPH]);
+  if (result.code !== 0) {
+    throw new Error(`ka publish exit=${result.code}\nstdout: ${result.stdout}\nstderr: ${result.stderr}`);
+  }
+  const { stdout } = result;
+  const status = /Status:\s*(\w+)/i.exec(stdout)?.[1]?.toLowerCase() ?? 'unknown';
+  const kcMatch = /K[AC] ID:\s*(\d+)/i.exec(stdout);
+  const txMatch = /Tx hash:\s*(0x[0-9a-fA-F]+)/i.exec(stdout);
+  if (!kcMatch || !txMatch) {
+    throw new Error(`could not parse publish output\n${stdout}`);
+  }
+  // Greedy publish-outcome gate: exit 0 is not proof of a real publish.
+  // Require a known success status and a positive kaId so a failed/tentative
+  // publish (whose receipt could otherwise drive the CostCovered / lazy-settle
+  // assertions against the wrong tx) is rejected here, not silently accepted.
+  const publishOk = ['confirmed', 'finalized', 'tentative'];
+  if (!publishOk.includes(status)) {
+    throw new Error(`ka publish status="${status}", expected one of ${publishOk.join('/')}\n${stdout}`);
+  }
+  const kaId = BigInt(kcMatch[1]!);
+  if (kaId <= 0n) {
+    throw new Error(`ka publish surfaced non-positive kaId=${kaId}\n${stdout}`);
+  }
+  return { kaId, txHash: txMatch[1]! };
 }
 
 async function rawTxNonce(provider: ethers.JsonRpcProvider, addr: string): Promise<number> {
@@ -358,7 +370,7 @@ describe('V10 PCA lazy settlement — devnet validation', () => {
   beforeAll(async () => {
     state.s = await loadContracts();
     // Use a CORE node (node 2). Edge nodes don't have an on-chain identity
-    // by default and `dkg publish` short-circuits to status="tentative" with
+    // by default and `dkg ka publish` short-circuits to status="tentative" with
     // kaId=0 — we need an actual on-chain confirmation to assert the active
     // sink (the discounted cost lands in EpochStorage via the conviction
     // path). Node 1 is reserved for RS in the v10-end-to-end run; node 2

--- a/devnet/conviction-lazy-settle/automated.test.ts
+++ b/devnet/conviction-lazy-settle/automated.test.ts
@@ -39,6 +39,7 @@ import { readFileSync, existsSync, writeFileSync, mkdtempSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { ethers } from 'ethers';
+import { runKaPublishLifecycle } from '../_bootstrap/harness.js';
 
 const REPO_ROOT = resolve(__dirname, '../..');
 const RPC = 'http://127.0.0.1:8545';
@@ -289,37 +290,30 @@ let publishSeq = 0;
 
 async function dkgPublish(node: DevnetNode, file: string): Promise<{ kaId: bigint; txHash: string }> {
   // #1410 replaced the one-shot `dkg publish <cg> --file` with the KA
-  // lifecycle CLI: `ka create --share` stages the KA (WM -> finalize -> SWM),
-  // then `ka publish` performs the on-chain SWM -> VM publish.
+  // lifecycle CLI (`ka create --share` then `ka publish`) — the two-step
+  // argument/stdout contract now lives in the shared runKaPublishLifecycle
+  // helper (devnet/_bootstrap/harness.ts); status is returned lowercased.
   const kaName = `cls-pub-${Date.now().toString(36)}-${++publishSeq}`;
-  const created = await runCliOnce(node, ['ka', 'create', kaName, '--context-graph-id', CONTEXT_GRAPH, '--input-file', file, '--share']);
-  if (created.code !== 0) {
-    throw new Error(`ka create --share exit=${created.code}\nstdout: ${created.stdout}\nstderr: ${created.stderr}`);
-  }
-  const result = await runCliOnce(node, ['ka', 'publish', kaName, '--context-graph-id', CONTEXT_GRAPH]);
-  if (result.code !== 0) {
-    throw new Error(`ka publish exit=${result.code}\nstdout: ${result.stdout}\nstderr: ${result.stderr}`);
-  }
-  const { stdout } = result;
-  const status = /Status:\s*(\w+)/i.exec(stdout)?.[1]?.toLowerCase() ?? 'unknown';
-  const kcMatch = /K[AC] ID:\s*(\d+)/i.exec(stdout);
-  const txMatch = /Tx hash:\s*(0x[0-9a-fA-F]+)/i.exec(stdout);
-  if (!kcMatch || !txMatch) {
-    throw new Error(`could not parse publish output\n${stdout}`);
+  const result = await runKaPublishLifecycle((args) => runCliOnce(node, args), {
+    kaName,
+    contextGraphId: CONTEXT_GRAPH,
+    inputFile: file,
+  });
+  if (result.kaId === undefined || !result.txHash) {
+    throw new Error(`could not parse publish output\n${result.raw}`);
   }
   // Greedy publish-outcome gate: exit 0 is not proof of a real publish.
   // Require a known success status and a positive kaId so a failed/tentative
   // publish (whose receipt could otherwise drive the CostCovered / lazy-settle
   // assertions against the wrong tx) is rejected here, not silently accepted.
   const publishOk = ['confirmed', 'finalized', 'tentative'];
-  if (!publishOk.includes(status)) {
-    throw new Error(`ka publish status="${status}", expected one of ${publishOk.join('/')}\n${stdout}`);
+  if (!publishOk.includes(result.status)) {
+    throw new Error(`ka publish status="${result.status}", expected one of ${publishOk.join('/')}\n${result.raw}`);
   }
-  const kaId = BigInt(kcMatch[1]!);
-  if (kaId <= 0n) {
-    throw new Error(`ka publish surfaced non-positive kaId=${kaId}\n${stdout}`);
+  if (result.kaId <= 0n) {
+    throw new Error(`ka publish surfaced non-positive kaId=${result.kaId}\n${result.raw}`);
   }
-  return { kaId, txHash: txMatch[1]! };
+  return { kaId: result.kaId, txHash: result.txHash };
 }
 
 async function rawTxNonce(provider: ethers.JsonRpcProvider, addr: string): Promise<number> {

--- a/devnet/core-peers-features/automated.test.ts
+++ b/devnet/core-peers-features/automated.test.ts
@@ -46,6 +46,7 @@ import { readFileSync, existsSync, writeFileSync, mkdirSync, rmSync } from 'node
 import { join, resolve } from 'node:path';
 import * as http from 'node:http';
 import { ethers } from 'ethers';
+import { runKaPublishLifecycle } from '../_bootstrap/harness';
 
 // ───────────────────────────── constants ─────────────────────────────────
 const REPO_ROOT = resolve(__dirname, '../..');
@@ -266,30 +267,28 @@ let publishSeq = 0;
 async function publishFromCore(node: DevnetNode, name: string): Promise<{ subject: string; literal: string; kaId?: string; status: string }> {
   const witness = makeWitnessFile(name);
   // #1410 replaced the one-shot `dkg publish <cg> --file` with the KA
-  // lifecycle CLI: `ka create --share` stages the KA (WM -> finalize -> SWM),
-  // then `ka publish` performs the on-chain SWM -> VM publish.
-  const kaName = `cpf-pub-${Date.now().toString(36)}-${++publishSeq}`;
-  const created = await runDkgCli(node, ['ka', 'create', kaName, '--context-graph-id', CONTEXT_GRAPH, '--input-file', witness.path, '--share']);
-  if (created.code !== 0) {
-    throw new Error(`ka create --share failed (exit ${created.code}) stdout=${created.stdout} stderr=${created.stderr}`);
-  }
-  const result = await runDkgCli(node, ['ka', 'publish', kaName, '--context-graph-id', CONTEXT_GRAPH]);
-  if (result.code !== 0) {
-    throw new Error(`ka publish failed (exit ${result.code}) stdout=${result.stdout} stderr=${result.stderr}`);
-  }
-  const status = /Status:\s*(\w+)/i.exec(result.stdout)?.[1]?.toLowerCase() ?? 'unknown';
-  const kaId = /K[AC] ID:\s*(\d+)/i.exec(result.stdout)?.[1];
+  // lifecycle CLI (`ka create --share` then `ka publish`) — argument arrays +
+  // Status:/KA ID: stdout parsing live in the shared runKaPublishLifecycle
+  // (../_bootstrap/harness), which returns status lowercased; this suite keeps
+  // its own CLI spawn (120s timeout).
+  const result = await runKaPublishLifecycle((args) => runDkgCli(node, args), {
+    kaName: `cpf-pub-${Date.now().toString(36)}-${++publishSeq}`,
+    contextGraphId: CONTEXT_GRAPH,
+    inputFile: witness.path,
+  });
+  const status = result.status;
+  const kaId = result.kaId !== undefined ? String(result.kaId) : undefined;
   // Greedy publish-outcome gate: exit 0 is not proof of a real publish. Pin a
   // known success status and a positive kaId so a failed/'unknown' status or a
   // missing "KA ID:" line fails here instead of passing as a green publish.
   const publishOk = ['confirmed', 'finalized', 'tentative'];
   expect(
     publishOk,
-    `publish status="${status}", expected one of ${publishOk.join('/')}\n${result.stdout}`,
+    `publish status="${status}", expected one of ${publishOk.join('/')}\n${result.raw}`,
   ).toContain(status);
   expect(
     BigInt(kaId ?? '0'),
-    `publish surfaced no positive "KA ID:" (kaId="${kaId}")\n${result.stdout}`,
+    `publish surfaced no positive "KA ID:" (kaId="${kaId}")\n${result.raw}`,
   ).toBeGreaterThan(0n);
   return { subject: witness.subject, literal: witness.literal, kaId, status };
 }

--- a/devnet/core-peers-features/automated.test.ts
+++ b/devnet/core-peers-features/automated.test.ts
@@ -261,17 +261,27 @@ function makeWitnessFile(name: string): { path: string; subject: string; literal
   return { path, subject, literal };
 }
 
+let publishSeq = 0;
+
 async function publishFromCore(node: DevnetNode, name: string): Promise<{ subject: string; literal: string; kaId?: string; status: string }> {
   const witness = makeWitnessFile(name);
-  const result = await runDkgCli(node, ['publish', CONTEXT_GRAPH, '--file', witness.path]);
+  // #1410 replaced the one-shot `dkg publish <cg> --file` with the KA
+  // lifecycle CLI: `ka create --share` stages the KA (WM -> finalize -> SWM),
+  // then `ka publish` performs the on-chain SWM -> VM publish.
+  const kaName = `cpf-pub-${Date.now().toString(36)}-${++publishSeq}`;
+  const created = await runDkgCli(node, ['ka', 'create', kaName, '--context-graph-id', CONTEXT_GRAPH, '--input-file', witness.path, '--share']);
+  if (created.code !== 0) {
+    throw new Error(`ka create --share failed (exit ${created.code}) stdout=${created.stdout} stderr=${created.stderr}`);
+  }
+  const result = await runDkgCli(node, ['ka', 'publish', kaName, '--context-graph-id', CONTEXT_GRAPH]);
   if (result.code !== 0) {
-    throw new Error(`publish failed (exit ${result.code}) stdout=${result.stdout} stderr=${result.stderr}`);
+    throw new Error(`ka publish failed (exit ${result.code}) stdout=${result.stdout} stderr=${result.stderr}`);
   }
   const status = /Status:\s*(\w+)/i.exec(result.stdout)?.[1]?.toLowerCase() ?? 'unknown';
-  const kaId = /KC ID:\s*(\d+)/i.exec(result.stdout)?.[1];
+  const kaId = /K[AC] ID:\s*(\d+)/i.exec(result.stdout)?.[1];
   // Greedy publish-outcome gate: exit 0 is not proof of a real publish. Pin a
   // known success status and a positive kaId so a failed/'unknown' status or a
-  // missing "KC ID:" line fails here instead of passing as a green publish.
+  // missing "KA ID:" line fails here instead of passing as a green publish.
   const publishOk = ['confirmed', 'finalized', 'tentative'];
   expect(
     publishOk,
@@ -279,7 +289,7 @@ async function publishFromCore(node: DevnetNode, name: string): Promise<{ subjec
   ).toContain(status);
   expect(
     BigInt(kaId ?? '0'),
-    `publish surfaced no positive "KC ID:" (kaId="${kaId}")\n${result.stdout}`,
+    `publish surfaced no positive "KA ID:" (kaId="${kaId}")\n${result.stdout}`,
   ).toBeGreaterThan(0n);
   return { subject: witness.subject, literal: witness.literal, kaId, status };
 }
@@ -513,7 +523,7 @@ describe('Phase D — Cores host public CGs and fill their own gaps', () => {
     //           event for this ka id, or a `chain-promote action=…` daemon.log
     //           line naming it. This rules out a coincidental non-chain path.
     //    `already` is NOT accepted (it means the KA was present pre-restart).
-    expect(pub.kaId, 'gap publish did not report a KC ID — cannot pin chain-path evidence').toBeTruthy();
+    expect(pub.kaId, 'gap publish did not report a KA ID — cannot pin chain-path evidence').toBeTruthy();
     const kaId = pub.kaId!;
     const chainActions = new Set(['fetch', 'promote', 'core-fill']);
     const filled = await waitFor(

--- a/devnet/greenfield-10min/README.md
+++ b/devnet/greenfield-10min/README.md
@@ -32,7 +32,7 @@ RS_TIMEOUT=180 pnpm test:devnet:greenfield-10min
 
 | Phase | What | Budget |
 |-------|------|--------|
-| 1 | `dkg publish` one KA from core1 into `devnet-test` | ~2 min |
+| 1 | `dkg ka create --share` + `dkg ka publish` one KA from core1 into `devnet-test` | ~2 min |
 | 2 | `POST /api/update` with `precomputedUpdateAttestation`; UAL stable, merkle rotates | ~2 min |
 | 3 | `DKGStakingConvictionNFT.createConviction` → `withdraw` | ~4 min |
 | 4 | Poll `/api/random-sampling/status` until proof + `RandomSamplingStorage.solved` | ~2.5 min |

--- a/devnet/greenfield-10min/automated.test.ts
+++ b/devnet/greenfield-10min/automated.test.ts
@@ -186,24 +186,36 @@ function runDkgCli(
   });
 }
 
+let publishSeq = 0;
+
 async function publishViaCli(
   node: DevnetNode,
   filePath: string,
 ): Promise<{ status: string; kaId?: bigint; txHash?: string }> {
-  const result = await runDkgCli(node, [
-    'publish',
-    CONTEXT_GRAPH,
-    '--file',
-    filePath,
+  // #1410 replaced the one-shot `dkg publish <cg> --file` with the KA
+  // lifecycle CLI: `ka create --share` stages the KA (WM -> finalize -> SWM),
+  // then `ka publish` performs the on-chain SWM -> VM publish.
+  const kaName = `gf-pub-${Date.now().toString(36)}-${++publishSeq}`;
+  const created = await runDkgCli(node, [
+    'ka', 'create', kaName,
+    '--context-graph-id', CONTEXT_GRAPH,
+    '--input-file', filePath,
+    '--share',
   ]);
+  if (created.code !== 0) {
+    throw new Error(
+      `ka create --share failed (exit ${created.code})\nstdout: ${created.stdout}\nstderr: ${created.stderr}`,
+    );
+  }
+  const result = await runDkgCli(node, ['ka', 'publish', kaName, '--context-graph-id', CONTEXT_GRAPH]);
   if (result.code !== 0) {
     throw new Error(
-      `dkg publish failed (exit ${result.code})\nstdout: ${result.stdout}\nstderr: ${result.stderr}`,
+      `ka publish failed (exit ${result.code})\nstdout: ${result.stdout}\nstderr: ${result.stderr}`,
     );
   }
   const status = /Status:\s*(\w+)/i.exec(result.stdout)?.[1] ?? 'unknown';
-  const kcMatch = /KC ID:\s*(\d+)/i.exec(result.stdout);
-  const txMatch = /TX hash:\s*(0x[0-9a-fA-F]+)/i.exec(result.stdout);
+  const kcMatch = /K[AC] ID:\s*(\d+)/i.exec(result.stdout);
+  const txMatch = /Tx hash:\s*(0x[0-9a-fA-F]+)/i.exec(result.stdout);
   const kaId = kcMatch ? BigInt(kcMatch[1]!) : undefined;
   // Greedy publish-outcome gate (mirrors the devnet shell _devnet_publish_status_ok
   // contract): a CLI exit code of 0 is NOT proof of a real publish. Pin the
@@ -214,11 +226,11 @@ async function publishViaCli(
   const publishOk = ['confirmed', 'finalized', 'tentative'];
   expect(
     publishOk,
-    `dkg publish status="${status}", expected one of ${publishOk.join('/')}\n${result.stdout}`,
+    `ka publish status="${status}", expected one of ${publishOk.join('/')}\n${result.stdout}`,
   ).toContain(status.toLowerCase());
   expect(
     kaId,
-    `dkg publish surfaced no positive "KC ID:" (kaId=${kaId})\n${result.stdout}`,
+    `ka publish surfaced no positive "KA ID:" (kaId=${kaId})\n${result.stdout}`,
   ).toBeGreaterThan(0n);
   return {
     status,

--- a/devnet/greenfield-10min/automated.test.ts
+++ b/devnet/greenfield-10min/automated.test.ts
@@ -33,6 +33,7 @@ import { join, resolve } from 'node:path';
 import { ethers, Wallet } from 'ethers';
 import { buildKnowledgeAssetUal } from '@origintrail-official/dkg-chain';
 import { buildUpdateSeal } from '../../packages/publisher/test/_helpers/seal.js';
+import { runKaPublishLifecycle } from '../_bootstrap/harness.js';
 
 const REPO_ROOT = resolve(__dirname, '../..');
 const RPC = 'http://127.0.0.1:8545';
@@ -192,51 +193,31 @@ async function publishViaCli(
   node: DevnetNode,
   filePath: string,
 ): Promise<{ status: string; kaId?: bigint; txHash?: string }> {
-  // #1410 replaced the one-shot `dkg publish <cg> --file` with the KA
-  // lifecycle CLI: `ka create --share` stages the KA (WM -> finalize -> SWM),
-  // then `ka publish` performs the on-chain SWM -> VM publish.
-  const kaName = `gf-pub-${Date.now().toString(36)}-${++publishSeq}`;
-  const created = await runDkgCli(node, [
-    'ka', 'create', kaName,
-    '--context-graph-id', CONTEXT_GRAPH,
-    '--input-file', filePath,
-    '--share',
-  ]);
-  if (created.code !== 0) {
-    throw new Error(
-      `ka create --share failed (exit ${created.code})\nstdout: ${created.stdout}\nstderr: ${created.stderr}`,
-    );
-  }
-  const result = await runDkgCli(node, ['ka', 'publish', kaName, '--context-graph-id', CONTEXT_GRAPH]);
-  if (result.code !== 0) {
-    throw new Error(
-      `ka publish failed (exit ${result.code})\nstdout: ${result.stdout}\nstderr: ${result.stderr}`,
-    );
-  }
-  const status = /Status:\s*(\w+)/i.exec(result.stdout)?.[1] ?? 'unknown';
-  const kcMatch = /K[AC] ID:\s*(\d+)/i.exec(result.stdout);
-  const txMatch = /Tx hash:\s*(0x[0-9a-fA-F]+)/i.exec(result.stdout);
-  const kaId = kcMatch ? BigInt(kcMatch[1]!) : undefined;
+  // #1410 replaced the one-shot `dkg publish <cg> --file` with the two-step KA
+  // lifecycle CLI — arg arrays + stdout parsing live in the shared
+  // runKaPublishLifecycle helper (devnet/_bootstrap/harness.ts).
+  const result = await runKaPublishLifecycle((args) => runDkgCli(node, args), {
+    kaName: `gf-pub-${Date.now().toString(36)}-${++publishSeq}`,
+    contextGraphId: CONTEXT_GRAPH,
+    inputFile: filePath,
+  });
   // Greedy publish-outcome gate (mirrors the devnet shell _devnet_publish_status_ok
   // contract): a CLI exit code of 0 is NOT proof of a real publish. Pin the
   // status to a known success value and require a positive on-chain kaId so an
   // 'unknown'/failed status — or a missing id (e.g. a "KC ID:" → "KA ID:" output
   // rename that drifts past this regex after the KC→KA transition) — fails
   // loudly here instead of slipping through every caller as a green publish.
+  // (helper returns `status` already lowercased)
   const publishOk = ['confirmed', 'finalized', 'tentative'];
   expect(
     publishOk,
-    `ka publish status="${status}", expected one of ${publishOk.join('/')}\n${result.stdout}`,
-  ).toContain(status.toLowerCase());
+    `ka publish status="${result.status}", expected one of ${publishOk.join('/')}\n${result.raw}`,
+  ).toContain(result.status);
   expect(
-    kaId,
-    `ka publish surfaced no positive "KA ID:" (kaId=${kaId})\n${result.stdout}`,
+    result.kaId,
+    `ka publish surfaced no positive "KA ID:" (kaId=${result.kaId})\n${result.raw}`,
   ).toBeGreaterThan(0n);
-  return {
-    status,
-    kaId,
-    txHash: txMatch ? txMatch[1] : undefined,
-  };
+  return { status: result.status, kaId: result.kaId, txHash: result.txHash };
 }
 
 function makeNquadsFile(name: string, subject: string, label: string): string {

--- a/devnet/ka-lifecycle-cli/automated.test.ts
+++ b/devnet/ka-lifecycle-cli/automated.test.ts
@@ -21,7 +21,7 @@
  *   pnpm run build
  *   DEVNET_ENABLE_PUBLISHER=1 ./scripts/devnet.sh start 6
  */
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { beforeAll, describe, expect, it } from 'vitest';
 import {
@@ -410,6 +410,29 @@ beforeAll(async () => {
   }
   await ensureAllIdentities(detected, 4);
   const node = detected.nodes[1]!;
+
+  // Fail fast when the devnet was booted WITHOUT the async publisher runtime —
+  // otherwise every VM-publish test enqueues a publisher job that can never
+  // run and burns its full 300s timeout instead of failing with a cause.
+  // devnet.sh writes publisher.enabled=true unconditionally; what actually
+  // gates runtime startup is a non-empty publisher-wallets.json (only written
+  // under DEVNET_ENABLE_PUBLISHER=1 — without it the daemon logs "Publisher
+  // startup skipped: No publisher wallets configured" and boots without a runner).
+  const nodeConfig = JSON.parse(readFileSync(join(node.home, 'config.json'), 'utf8'));
+  let publisherWallets: unknown[] = [];
+  try {
+    publisherWallets = JSON.parse(readFileSync(join(node.home, 'publisher-wallets.json'), 'utf8'))?.wallets ?? [];
+  } catch {
+    // ENOENT / bad JSON → runtime never started
+  }
+  if (nodeConfig?.publisher?.enabled !== true || !Array.isArray(publisherWallets) || publisherWallets.length === 0) {
+    throw new Error(
+      'Devnet publisher runtime is not running (node1 publisher-wallets.json is missing/empty — ' +
+        'the daemon skips publisher startup even though config.json says enabled:true). ' +
+        'The async VM-publish tests cannot finalize. Reboot with: ' +
+        './scripts/devnet.sh clean && DEVNET_ENABLE_PUBLISHER=1 ./scripts/devnet.sh start 6',
+    );
+  }
 
   const slug = unique('ka-lifecycle-cli');
   const created = await runDkgCli(

--- a/devnet/ka-lifecycle-cli/vitest.config.ts
+++ b/devnet/ka-lifecycle-cli/vitest.config.ts
@@ -1,6 +1,22 @@
 import { defineConfig } from 'vitest/config';
 import { resolve } from 'node:path';
 
+/**
+ * KA lifecycle CLI — devnet coverage for the #1410 `dkg ka` commands.
+ *
+ * Preconditions (the async VM-publish tests need the publisher runtime; a
+ * devnet booted without it makes every publisher job queue forever and each
+ * of those tests burns its full 300s timeout):
+ *
+ *   ./scripts/devnet.sh clean
+ *   DEVNET_ENABLE_PUBLISHER=1 ./scripts/devnet.sh start 6
+ *
+ * Run via: `pnpm test:devnet:ka-lifecycle-cli`
+ * The suite also fail-fasts in beforeAll with a pointed message when the
+ * devnet's publisher runtime is not running — detected via node1's
+ * publisher-wallets.json, which devnet.sh only writes under
+ * DEVNET_ENABLE_PUBLISHER=1 (config.json's publisher.enabled is always true).
+ */
 const automatedTest = resolve(import.meta.dirname, 'automated.test.ts').replace(/\\/g, '/');
 
 export default defineConfig({

--- a/devnet/pr1385-subgraph-rs/automated.test.ts
+++ b/devnet/pr1385-subgraph-rs/automated.test.ts
@@ -113,6 +113,7 @@ import {
   detectDevnet,
   ensureAllIdentities,
   runDkgCli,
+  runKaPublishLifecycle,
   writeNquads,
   queryNode,
   postJson,
@@ -270,66 +271,36 @@ describe('PR #1385 — RS extraction reads named sub-graph KAs (live 6-node devn
         `sub-graph register failed (${reg.status}): ${JSON.stringify(reg.json)}`,
       ).toBe(true);
 
-      // ── 2. Stage the KA INTO the sub-graph ───────────────────────────────────
-      // `dkg ka create <name> -c <cg> --input-file <file> --share --sub-graph-name <sg>`
-      // (#1410 KA lifecycle CLI: WM → finalize → SWM). The n-quads file is
-      // labelled with the PARENT CG graph URI — sub-graph routing is the
-      // --sub-graph-name flag, NOT the file's graph label.
+      // ── 2+3. Stage the KA INTO the sub-graph, then publish it on-chain ──────
+      // #1410 KA lifecycle CLI (`ka create --share`: WM → finalize → SWM, then
+      // `ka publish`: SWM → VM/chain) via the shared runKaPublishLifecycle
+      // helper (devnet/_bootstrap/harness.ts), which owns the argument arrays
+      // and the `Status:`/`KA ID:` stdout parsing (status lowercased). We pass
+      // --sub-graph-name on BOTH steps. The n-quads file is labelled with the
+      // PARENT CG graph URI — sub-graph routing is the --sub-graph-name flag,
+      // NOT the file's graph label.
       const g = `did:dkg:context-graph:${CONTEXT_GRAPH}`;
       const file = writeNquads(import.meta.dirname, name, [
         `<${s.subject}> <${PRED}> "${OBJECT_VALUE}" <${g}>`,
         `<${s.subject}> <https://schema.org/name> "${name}" <${g}>`,
       ]);
 
-      const write = await runDkgCli(
-        node,
-        [
-          'ka',
-          'create',
-          name,
-          '--context-graph-id',
-          CONTEXT_GRAPH,
-          '--input-file',
-          file,
-          '--share',
-          '--sub-graph-name',
-          s.subGraphName,
-        ],
-        120_000,
+      const result = await runKaPublishLifecycle(
+        (args) => runDkgCli(node, args, 120_000),
+        {
+          kaName: name,
+          contextGraphId: CONTEXT_GRAPH,
+          inputFile: file,
+          createArgs: ['--sub-graph-name', s.subGraphName],
+          publishArgs: ['--sub-graph-name', s.subGraphName],
+        },
       );
-      expect(
-        write.code,
-        `ka create --share failed (exit ${write.code})\nstdout: ${write.stdout}\nstderr: ${write.stderr}`,
-      ).toBe(0);
-
-      // ── 3. Publish it on-chain ───────────────────────────────────────────────
-      // `dkg ka publish <name> -c <cg> --sub-graph-name <sg>` (SWM → VM/chain).
-      // Prints `Status:` + `KA ID:` we parse — same surface publishViaCli parses.
-      const publish = await runDkgCli(
-        node,
-        [
-          'ka',
-          'publish',
-          name,
-          '--context-graph-id',
-          CONTEXT_GRAPH,
-          '--sub-graph-name',
-          s.subGraphName,
-        ],
-        120_000,
-      );
-      expect(
-        publish.code,
-        `ka publish failed (exit ${publish.code})\nstdout: ${publish.stdout}\nstderr: ${publish.stderr}`,
-      ).toBe(0);
-      const status = (/Status:\s*(\w+)/i.exec(publish.stdout)?.[1] ?? 'unknown').toLowerCase();
       expect(
         ['confirmed', 'finalized', 'tentative'],
-        `sub-graph publish status="${status}"\n${publish.stdout}`,
-      ).toContain(status);
-      const kaIdStr = /K[AC] ID:\s*(\d+)/i.exec(publish.stdout)?.[1];
-      expect(kaIdStr, `sub-graph publish surfaced no "KA ID:"\n${publish.stdout}`).toBeTruthy();
-      s.kaId = BigInt(kaIdStr!);
+        `sub-graph publish status="${result.status}"\n${result.raw}`,
+      ).toContain(result.status);
+      expect(result.kaId, `sub-graph publish surfaced no "KA ID:"\n${result.raw}`).toBeDefined();
+      s.kaId = result.kaId!;
       expect(s.kaId, 'sub-graph KA id must be positive').toBeGreaterThan(0n);
       // eslint-disable-next-line no-console
       console.log(

--- a/devnet/pr1385-subgraph-rs/automated.test.ts
+++ b/devnet/pr1385-subgraph-rs/automated.test.ts
@@ -86,17 +86,14 @@
  *      (packages/cli/src/daemon/routes/context-graph.ts:727; body validated by
  *      validateSubGraphName). Equivalent CLI: `dkg context-graph create-sub-graph
  *      <cg> <sg>` (positional, commands/context-graph.ts:265).
- *   2. Stage the KA into the sub-graph — `dkg shared-memory write <cg> -f <file>
- *      --name <name> --sub-graph-name <sg>` (commands/shared-memory.ts:114-124:
- *      `-f/--file`, `--name`, `--sub-graph-name` are all real options; create →
- *      append batches into the named assertion).
- *   3. Publish it on-chain — `dkg shared-memory publish <cg> --name <name>
- *      --sub-graph-name <sg>` (commands/shared-memory.ts:180-237: finalize →
- *      promote → publishFromFinalizedAssertion, i.e. land on VM/chain). Prints
- *      `Status:` + `KC ID:` we parse for the kaId.
- *   NB the one-shot `dkg publish` does NOT support sub-graphs (no
- *   --sub-graph-name on `publish` in the harness `publishViaCli`), hence the
- *   write→publish lifecycle.
+ *   2. Stage the KA into the sub-graph — `dkg ka create <name> -c <cg>
+ *      --input-file <file> --share --sub-graph-name <sg>` (the #1410 KA
+ *      lifecycle CLI; addSubGraphOption is applied to ka create/publish in
+ *      commands/knowledge-asset.ts, so sub-graph routing rides the same flag).
+ *   3. Publish it on-chain — `dkg ka publish <name> -c <cg> --sub-graph-name
+ *      <sg>` (SWM → VM/chain). Prints `Status:` + `KA ID:` we parse for the
+ *      kaId. (The pre-#1410 `dkg shared-memory write/publish` commands this
+ *      suite originally drove were removed with the rest of the legacy verbs.)
  *
  * ISOLATION (this suite runs against ONE shared 6-node devnet, in sequence with
  * the rest of the 10.0.2 sweep):
@@ -274,11 +271,10 @@ describe('PR #1385 — RS extraction reads named sub-graph KAs (live 6-node devn
       ).toBe(true);
 
       // ── 2. Stage the KA INTO the sub-graph ───────────────────────────────────
-      // `dkg shared-memory write <cg> -f <file> --name <name> --sub-graph-name <sg>`
-      // (commands/shared-memory.ts:114-124). The n-quads file is labelled with the
-      // PARENT CG graph URI — sub-graph routing is the API param, NOT the file's
-      // graph label (write loads quads against the default CG graph + passes
-      // subGraphName separately). makeNquadsFile's contract, mirrored here.
+      // `dkg ka create <name> -c <cg> --input-file <file> --share --sub-graph-name <sg>`
+      // (#1410 KA lifecycle CLI: WM → finalize → SWM). The n-quads file is
+      // labelled with the PARENT CG graph URI — sub-graph routing is the
+      // --sub-graph-name flag, NOT the file's graph label.
       const g = `did:dkg:context-graph:${CONTEXT_GRAPH}`;
       const file = writeNquads(import.meta.dirname, name, [
         `<${s.subject}> <${PRED}> "${OBJECT_VALUE}" <${g}>`,
@@ -288,13 +284,14 @@ describe('PR #1385 — RS extraction reads named sub-graph KAs (live 6-node devn
       const write = await runDkgCli(
         node,
         [
-          'shared-memory',
-          'write',
-          CONTEXT_GRAPH,
-          '-f',
-          file,
-          '--name',
+          'ka',
+          'create',
           name,
+          '--context-graph-id',
+          CONTEXT_GRAPH,
+          '--input-file',
+          file,
+          '--share',
           '--sub-graph-name',
           s.subGraphName,
         ],
@@ -302,51 +299,36 @@ describe('PR #1385 — RS extraction reads named sub-graph KAs (live 6-node devn
       );
       expect(
         write.code,
-        `shared-memory write failed (exit ${write.code})\nstdout: ${write.stdout}\nstderr: ${write.stderr}`,
+        `ka create --share failed (exit ${write.code})\nstdout: ${write.stdout}\nstderr: ${write.stderr}`,
       ).toBe(0);
 
       // ── 3. Publish it on-chain ───────────────────────────────────────────────
-      // `dkg shared-memory publish <cg> --name <name> --sub-graph-name <sg>`
-      // (commands/shared-memory.ts:180; finalize → promote → publish-to-VM). Prints
-      // `Status:` + `KC ID:` we parse — same surface publishViaCli parses.
+      // `dkg ka publish <name> -c <cg> --sub-graph-name <sg>` (SWM → VM/chain).
+      // Prints `Status:` + `KA ID:` we parse — same surface publishViaCli parses.
       const publish = await runDkgCli(
         node,
         [
-          'shared-memory',
+          'ka',
           'publish',
-          CONTEXT_GRAPH,
-          '--name',
           name,
+          '--context-graph-id',
+          CONTEXT_GRAPH,
           '--sub-graph-name',
           s.subGraphName,
         ],
         120_000,
       );
-      // NOTE: `dkg shared-memory publish --sub-graph-name` currently exits 1 on a
-      // cosmetic POST-success error ("Cannot read properties of undefined
-      // (reading 'length')") even though the on-chain publish confirms (Status:
-      // confirmed + KC ID + merkle root are printed, "Promoted: N quads"). We
-      // therefore assert success from stdout, not the exit code, and surface the
-      // anomaly. If stdout shows no confirmation, THEN treat the non-zero exit as
-      // a real failure.
+      expect(
+        publish.code,
+        `ka publish failed (exit ${publish.code})\nstdout: ${publish.stdout}\nstderr: ${publish.stderr}`,
+      ).toBe(0);
       const status = (/Status:\s*(\w+)/i.exec(publish.stdout)?.[1] ?? 'unknown').toLowerCase();
-      if (publish.code !== 0) {
-        // eslint-disable-next-line no-console
-        console.warn(
-          `#1385: sub-graph 'shared-memory publish' exited ${publish.code} despite Status=${status} — ` +
-            `cosmetic CLI post-success error (worth a follow-up). stderr: ${publish.stderr.slice(0, 200)}`,
-        );
-        expect(
-          /Status:\s*(confirmed|finalized|tentative)/i.test(publish.stdout) && /KC ID:\s*\d+/i.test(publish.stdout),
-          `sub-graph publish exited ${publish.code} AND stdout shows no confirmation — real failure\nstdout: ${publish.stdout}\nstderr: ${publish.stderr}`,
-        ).toBe(true);
-      }
       expect(
         ['confirmed', 'finalized', 'tentative'],
         `sub-graph publish status="${status}"\n${publish.stdout}`,
       ).toContain(status);
-      const kaIdStr = /KC ID:\s*(\d+)/i.exec(publish.stdout)?.[1];
-      expect(kaIdStr, `sub-graph publish surfaced no "KC ID:"\n${publish.stdout}`).toBeTruthy();
+      const kaIdStr = /K[AC] ID:\s*(\d+)/i.exec(publish.stdout)?.[1];
+      expect(kaIdStr, `sub-graph publish surfaced no "KA ID:"\n${publish.stdout}`).toBeTruthy();
       s.kaId = BigInt(kaIdStr!);
       expect(s.kaId, 'sub-graph KA id must be positive').toBeGreaterThan(0n);
       // eslint-disable-next-line no-console

--- a/devnet/rpc-quiet-window/automated.test.ts
+++ b/devnet/rpc-quiet-window/automated.test.ts
@@ -113,7 +113,16 @@ function parseRpcUsageWindows(node: string, text: string): UsageWindow[] {
   const windows = new Map<string, UsageWindow>();
   const lineRe = /^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}).*\brpc_usage method=([A-Za-z0-9_.:-]+) count=(\d+) window_s=(\d+)(?: chain=([A-Za-z0-9_.:-]+))?/gm;
 
+  // Every legitimate rpc_usage emission carries a unique operation UUID, so a
+  // byte-identical line can only be a log-replay artifact (e.g. the historical
+  // shell-redirect + in-process-tee double-write of daemon.log). Summing a
+  // replayed line doubles the window and fails the budget with phantom load —
+  // count each distinct line once.
+  const seenLines = new Set<string>();
+
   for (const match of text.matchAll(lineRe)) {
+    if (seenLines.has(match[0])) continue;
+    seenLines.add(match[0]);
     const [, timestamp, method, countRaw, windowSecondsRaw] = match;
     const windowSeconds = Number(windowSecondsRaw);
     const key = `${node}:${timestamp}`;
@@ -183,16 +192,20 @@ describe('devnet RPC quiet-window budget', () => {
       MIN_EVALUATED_WINDOWS * EXPECTED_DEVNET_NODES,
     );
 
+    // Collect every violation across every node/window before asserting, so
+    // one over-budget window cannot mask the rest of the fleet's numbers.
+    const violations: string[] = [];
     for (const window of evaluated) {
       const getLogs = window.byMethod.eth_getLogs ?? 0;
       const chainId = window.byMethod.eth_chainId ?? 0;
       const total = windowTotal(window);
       const label = `${window.node} ${window.timestamp} ${JSON.stringify(window.byMethod)}`;
 
-      expect(getLogs, `${label}: eth_getLogs should be idle except slow context discovery`).toBeLessThanOrEqual(MAX_ETH_GETLOGS);
-      expect(chainId, `${label}: static-network providers should suppress steady eth_chainId`).toBeLessThanOrEqual(MAX_ETH_CHAINID);
-      expect(total, `${label}: total quiet-window RPC volume`).toBeLessThanOrEqual(MAX_TOTAL);
+      if (getLogs > MAX_ETH_GETLOGS) violations.push(`${label}: eth_getLogs=${getLogs} > ${MAX_ETH_GETLOGS} (should be idle except slow context discovery)`);
+      if (chainId > MAX_ETH_CHAINID) violations.push(`${label}: eth_chainId=${chainId} > ${MAX_ETH_CHAINID} (static-network providers should suppress steady eth_chainId)`);
+      if (total > MAX_TOTAL) violations.push(`${label}: total=${total} > ${MAX_TOTAL} (quiet-window RPC volume)`);
     }
+    expect(violations, `lane-aware poller budget violations:\n${violations.join('\n')}`).toEqual([]);
   });
 
   it('parses the committed rpc_usage contract shape used by daemon logs', () => {

--- a/devnet/rpc-quiet-window/automated.test.ts
+++ b/devnet/rpc-quiet-window/automated.test.ts
@@ -109,19 +109,33 @@ function readNewText(path: string, startOffset: number): string {
   return buffer.toString('utf8');
 }
 
-function parseRpcUsageWindows(node: string, text: string): UsageWindow[] {
+function parseRpcUsageWindows(
+  node: string,
+  text: string,
+): { windows: UsageWindow[]; duplicateLines: string[] } {
   const windows = new Map<string, UsageWindow>();
   const lineRe = /^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}).*\brpc_usage method=([A-Za-z0-9_.:-]+) count=(\d+) window_s=(\d+)(?: chain=([A-Za-z0-9_.:-]+))?/gm;
 
-  // Every legitimate rpc_usage emission carries a unique operation UUID, so a
-  // byte-identical line can only be a log-replay artifact (e.g. the historical
-  // shell-redirect + in-process-tee double-write of daemon.log). Summing a
-  // replayed line doubles the window and fails the budget with phantom load —
-  // count each distinct line once.
+  // rpc_usage lines carry NO per-line id — the payload is just
+  // `rpc_usage method=X count=N window_s=S[ chain=C]` behind a second-resolution
+  // timestamp (see packages/cli/src/daemon/rpc-usage-log.ts). Byte-identical
+  // dedupe is still sound because the daemon emits ONE line per method per
+  // drain and drains are >=60s apart (the shutdown final-drain re-drains an
+  // already-emptied window and emits nothing when idle), so a byte-identical
+  // repeat within one node's chunk is provably a replay artifact of the
+  // daemon.log double-write (shell redirect + in-process tee writing the same
+  // file), never legitimate telemetry. Summing a replayed line doubles the
+  // window and fails the budget with phantom load — count each distinct line
+  // once, but RECORD every filtered duplicate so the suite fails loudly on the
+  // double-write regression itself instead of silently compensating for it.
   const seenLines = new Set<string>();
+  const duplicateLines: string[] = [];
 
   for (const match of text.matchAll(lineRe)) {
-    if (seenLines.has(match[0])) continue;
+    if (seenLines.has(match[0])) {
+      duplicateLines.push(match[0]);
+      continue;
+    }
     seenLines.add(match[0]);
     const [, timestamp, method, countRaw, windowSecondsRaw] = match;
     const windowSeconds = Number(windowSecondsRaw);
@@ -136,7 +150,10 @@ function parseRpcUsageWindows(node: string, text: string): UsageWindow[] {
     window.byMethod[method] = (window.byMethod[method] ?? 0) + Number(countRaw);
   }
 
-  return [...windows.values()].sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+  return {
+    windows: [...windows.values()].sort((a, b) => a.timestamp.localeCompare(b.timestamp)),
+    duplicateLines,
+  };
 }
 
 function windowTotal(window: UsageWindow): number {
@@ -156,6 +173,8 @@ describe('devnet RPC quiet-window budget', () => {
     const missingTelemetry: string[] = [];
     const activityHints: string[] = [];
     const windowsByNode = new Map<string, UsageWindow[]>();
+    const duplicateLineReports: string[] = [];
+    const duplicateNodes = new Set<string>();
 
     for (const log of logs) {
       const chunk = readNewText(log.path, offsets.get(log.path) ?? 0);
@@ -163,7 +182,11 @@ describe('devnet RPC quiet-window budget', () => {
         activityHints.push(log.node);
       }
 
-      const windows = parseRpcUsageWindows(log.node, chunk);
+      const { windows, duplicateLines } = parseRpcUsageWindows(log.node, chunk);
+      if (duplicateLines.length > 0) {
+        duplicateNodes.add(log.node);
+        duplicateLineReports.push(...duplicateLines.map((line) => `${log.node}: ${line}`));
+      }
       windowsByNode.set(log.node, windows);
       if (windows.length === 0) {
         missingTelemetry.push(log.node);
@@ -187,6 +210,12 @@ describe('devnet RPC quiet-window budget', () => {
     expect(
       invalidWindowDurations,
       `rpc_usage window_s mismatch: ${invalidWindowDurations.join(', ')}`,
+    ).toEqual([]);
+    expect(
+      duplicateLineReports,
+      `duplicated rpc_usage lines detected in ${[...duplicateNodes].join(', ')} — a daemon.log ` +
+        'double-write regression (shell redirect + in-process tee writing the same file); ' +
+        `see scripts/devnet.sh start_node:\n${duplicateLineReports.join('\n')}`,
     ).toEqual([]);
     expect(evaluated.length, 'not enough post-warmup rpc_usage windows; increase RPC_QUIET_WINDOW_MS').toBeGreaterThanOrEqual(
       MIN_EVALUATED_WINDOWS * EXPECTED_DEVNET_NODES,
@@ -212,7 +241,7 @@ describe('devnet RPC quiet-window budget', () => {
     const sample = readFileSync(resolve(import.meta.dirname, 'package.json'), 'utf8');
     expect(sample).toContain('dkg-devnet-rpc-quiet-window');
 
-    const windows = parseRpcUsageWindows(
+    const { windows } = parseRpcUsageWindows(
       'node1',
       '2026-07-04 10:00:00 system abc [chain-rpc] rpc_usage method=eth_getLogs count=2 window_s=60 chain=hardhat:31337\n' +
       '2026-07-04 10:00:00 system def [chain-rpc] rpc_usage method=eth_chainId count=0 window_s=60 chain=hardhat:31337\n',
@@ -229,7 +258,7 @@ describe('devnet RPC quiet-window budget', () => {
   });
 
   it('reports rpc_usage windows with unexpected durations', () => {
-    const windows = parseRpcUsageWindows(
+    const { windows } = parseRpcUsageWindows(
       'node1',
       '2026-07-04 10:00:00 system abc [chain-rpc] rpc_usage method=eth_getLogs count=2 window_s=10 chain=hardhat:31337\n',
     );
@@ -241,7 +270,7 @@ describe('devnet RPC quiet-window budget', () => {
   });
 
   it('reports mixed rpc_usage durations in the same timestamp bucket', () => {
-    const windows = parseRpcUsageWindows(
+    const { windows } = parseRpcUsageWindows(
       'node1',
       '2026-07-04 10:00:00 system abc [chain-rpc] rpc_usage method=eth_getLogs count=2 window_s=60 chain=hardhat:31337\n' +
       '2026-07-04 10:00:00 system def [chain-rpc] rpc_usage method=eth_chainId count=0 window_s=10 chain=hardhat:31337\n',
@@ -262,12 +291,12 @@ describe('devnet RPC quiet-window budget', () => {
   });
 
   it('reports nodes that lack post-warmup rpc_usage windows', () => {
-    const node1 = parseRpcUsageWindows(
+    const { windows: node1 } = parseRpcUsageWindows(
       'node1',
       '2026-07-04 10:00:00 system abc [chain-rpc] rpc_usage method=eth_getLogs count=2 window_s=60 chain=hardhat:31337\n' +
       '2026-07-04 10:01:00 system abc [chain-rpc] rpc_usage method=eth_getLogs count=1 window_s=60 chain=hardhat:31337\n',
     );
-    const node2 = parseRpcUsageWindows(
+    const { windows: node2 } = parseRpcUsageWindows(
       'node2',
       '2026-07-04 10:00:00 system abc [chain-rpc] rpc_usage method=eth_getLogs count=50 window_s=60 chain=hardhat:31337\n',
     );
@@ -280,5 +309,49 @@ describe('devnet RPC quiet-window budget', () => {
       ['node1', 'node2'],
       1,
     )).toEqual(['node2']);
+  });
+});
+
+describe('rpc_usage parser (deterministic)', () => {
+  it('counts a byte-replayed rpc_usage line once and reports the replay in duplicateLines', () => {
+    const line = '2026-01-01 12:00:00 info: rpc_usage method=eth_call count=4 window_s=60 chain=hardhat:31337';
+    const { windows, duplicateLines } = parseRpcUsageWindows('node1', `${line}\n${line}\n`);
+
+    expect(windows).toHaveLength(1);
+    expect(windows[0].byMethod).toEqual({ eth_call: 4 }); // deduped, NOT 8
+    expect(duplicateLines).toEqual([line]);
+  });
+
+  it('counts two distinct same-second lines fully with no duplicates reported', () => {
+    const differentMethod = parseRpcUsageWindows(
+      'node1',
+      '2026-01-01 12:00:00 info: rpc_usage method=eth_call count=4 window_s=60 chain=hardhat:31337\n' +
+      '2026-01-01 12:00:00 info: rpc_usage method=eth_getLogs count=2 window_s=60 chain=hardhat:31337\n',
+    );
+    expect(differentMethod.windows).toHaveLength(1);
+    expect(differentMethod.windows[0].byMethod).toEqual({ eth_call: 4, eth_getLogs: 2 });
+    expect(differentMethod.duplicateLines).toEqual([]);
+
+    const sameMethodDifferentCount = parseRpcUsageWindows(
+      'node1',
+      '2026-01-01 12:00:00 info: rpc_usage method=eth_call count=4 window_s=60 chain=hardhat:31337\n' +
+      '2026-01-01 12:00:00 info: rpc_usage method=eth_call count=1 window_s=60 chain=hardhat:31337\n',
+    );
+    expect(sameMethodDifferentCount.windows).toHaveLength(1);
+    expect(sameMethodDifferentCount.windows[0].byMethod).toEqual({ eth_call: 5 });
+    expect(sameMethodDifferentCount.duplicateLines).toEqual([]);
+  });
+
+  it('keeps identical method+count repeats across 60s-apart windows as legitimate telemetry', () => {
+    const { windows, duplicateLines } = parseRpcUsageWindows(
+      'node1',
+      '2026-01-01 12:00:00 info: rpc_usage method=eth_call count=4 window_s=60 chain=hardhat:31337\n' +
+      '2026-01-01 12:01:00 info: rpc_usage method=eth_call count=4 window_s=60 chain=hardhat:31337\n',
+    );
+
+    expect(windows).toHaveLength(2);
+    expect(windows[0]).toMatchObject({ timestamp: '2026-01-01 12:00:00', byMethod: { eth_call: 4 } });
+    expect(windows[1]).toMatchObject({ timestamp: '2026-01-01 12:01:00', byMethod: { eth_call: 4 } });
+    expect(duplicateLines).toEqual([]);
   });
 });

--- a/devnet/v10-core-flows/automated.test.ts
+++ b/devnet/v10-core-flows/automated.test.ts
@@ -70,8 +70,18 @@ const DEVNET_DIR = join(REPO_ROOT, '.devnet');
 const CONTEXT_GRAPH = 'devnet-test';
 const FINDINGS_PATH = join(__dirname, 'FINDINGS.local.md');
 
-const NODE1_API = 'http://127.0.0.1:9201';
-const NODE5_API = 'http://127.0.0.1:9205'; // edge
+// Derive node API URLs from each node's devnet config instead of hardcoding
+// the default ports, so the suite honors an API_PORT_BASE-rebased devnet
+// (needed when another local service occupies the 9201.. range).
+function nodeApiUrl(num: number): string {
+  const configPath = join(DEVNET_DIR, `node${num}`, 'config.json');
+  const apiPort = existsSync(configPath)
+    ? (JSON.parse(readFileSync(configPath, 'utf8')).apiPort ?? 9200 + num)
+    : 9200 + num;
+  return `http://127.0.0.1:${apiPort}`;
+}
+const NODE1_API = nodeApiUrl(1);
+const NODE5_API = nodeApiUrl(5); // edge
 
 const HUB_ABI = [
   'function getContractAddress(string) view returns (address)',

--- a/devnet/v10-end-to-end/automated.test.ts
+++ b/devnet/v10-end-to-end/automated.test.ts
@@ -65,6 +65,7 @@ import {
 } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { ethers } from 'ethers';
+import { runKaPublishLifecycle } from '../_bootstrap/harness.js';
 
 const REPO_ROOT = resolve(__dirname, '../..');
 const RPC = 'http://127.0.0.1:8545';
@@ -239,61 +240,39 @@ async function publishViaCli(
   txHash?: string;
   raw: string;
 }> {
-  // #1410 replaced the one-shot `dkg publish <cg> --file` with the KA
-  // lifecycle CLI: `ka create --share` stages the KA (WM -> finalize -> SWM),
-  // then `ka publish` performs the on-chain SWM -> VM publish.
-  const kaName = `cli-pub-${Date.now().toString(36)}-${++publishSeq}`;
-  const created = await runDkgCli(node, [
-    'ka', 'create', kaName,
-    '--context-graph-id', contextGraph,
-    '--input-file', filePath,
-    '--share',
-  ]);
-  if (created.code !== 0) {
-    throw new Error(
-      `ka create --share failed (exit ${created.code})\n` +
-        `stdout: ${created.stdout}\nstderr: ${created.stderr}`,
-    );
-  }
-  const args = ['ka', 'publish', kaName, '--context-graph-id', contextGraph];
+  // #1410 replaced the one-shot `dkg publish <cg> --file` with the two-step KA
+  // lifecycle CLI — arg arrays + stdout parsing live in the shared
+  // runKaPublishLifecycle helper (devnet/_bootstrap/harness.ts).
+  const publishArgs: string[] = [];
   if (options.publisherNodeIdentityId !== undefined) {
-    args.push(
+    publishArgs.push(
       '--publisher-node-identity-id',
       String(options.publisherNodeIdentityId),
     );
   }
-  const result = await runDkgCli(node, args);
-  if (result.code !== 0) {
-    throw new Error(
-      `ka publish failed (exit ${result.code})\n` +
-        `stdout: ${result.stdout}\nstderr: ${result.stderr}`,
-    );
-  }
-  const status = /Status:\s*(\w+)/i.exec(result.stdout)?.[1] ?? 'unknown';
-  const kcMatch = /K[AC] ID:\s*(\d+)/i.exec(result.stdout);
-  const txMatch = /Tx hash:\s*(0x[0-9a-fA-F]+)/i.exec(result.stdout);
-  const kaId = kcMatch ? BigInt(kcMatch[1]!) : undefined;
+  const result = await runKaPublishLifecycle((args) => runDkgCli(node, args), {
+    kaName: `cli-pub-${Date.now().toString(36)}-${++publishSeq}`,
+    contextGraphId: contextGraph,
+    inputFile: filePath,
+    publishArgs,
+  });
   // Greedy publish-outcome gate (mirrors the devnet shell _devnet_publish_status_ok
   // contract): a CLI exit code of 0 is NOT proof of a real publish. Pin the
   // status to a known success value and require a positive on-chain kaId so an
   // 'unknown'/failed status — or a missing id (e.g. a "KC ID:" → "KA ID:" output
   // rename that drifts past this regex after the KC→KA transition) — fails
   // loudly here instead of slipping through every caller as a green publish.
+  // (helper returns `status` already lowercased)
   const publishOk = ['confirmed', 'finalized', 'tentative'];
   expect(
     publishOk,
-    `ka publish status="${status}", expected one of ${publishOk.join('/')}\n${result.stdout}`,
-  ).toContain(status.toLowerCase());
+    `ka publish status="${result.status}", expected one of ${publishOk.join('/')}\n${result.raw}`,
+  ).toContain(result.status);
   expect(
-    kaId,
-    `ka publish surfaced no positive "KA ID:" (kaId=${kaId})\n${result.stdout}`,
+    result.kaId,
+    `ka publish surfaced no positive "KA ID:" (kaId=${result.kaId})\n${result.raw}`,
   ).toBeGreaterThan(0n);
-  return {
-    status,
-    kaId,
-    txHash: txMatch ? txMatch[1] : undefined,
-    raw: result.stdout,
-  };
+  return result;
 }
 
 async function loadContractAddresses(

--- a/devnet/v10-end-to-end/automated.test.ts
+++ b/devnet/v10-end-to-end/automated.test.ts
@@ -226,6 +226,8 @@ function runDkgCli(
   });
 }
 
+let publishSeq = 0;
+
 async function publishViaCli(
   node: DevnetNode,
   contextGraph: string,
@@ -237,7 +239,23 @@ async function publishViaCli(
   txHash?: string;
   raw: string;
 }> {
-  const args = ['publish', contextGraph, '--file', filePath];
+  // #1410 replaced the one-shot `dkg publish <cg> --file` with the KA
+  // lifecycle CLI: `ka create --share` stages the KA (WM -> finalize -> SWM),
+  // then `ka publish` performs the on-chain SWM -> VM publish.
+  const kaName = `cli-pub-${Date.now().toString(36)}-${++publishSeq}`;
+  const created = await runDkgCli(node, [
+    'ka', 'create', kaName,
+    '--context-graph-id', contextGraph,
+    '--input-file', filePath,
+    '--share',
+  ]);
+  if (created.code !== 0) {
+    throw new Error(
+      `ka create --share failed (exit ${created.code})\n` +
+        `stdout: ${created.stdout}\nstderr: ${created.stderr}`,
+    );
+  }
+  const args = ['ka', 'publish', kaName, '--context-graph-id', contextGraph];
   if (options.publisherNodeIdentityId !== undefined) {
     args.push(
       '--publisher-node-identity-id',
@@ -247,13 +265,13 @@ async function publishViaCli(
   const result = await runDkgCli(node, args);
   if (result.code !== 0) {
     throw new Error(
-      `dkg publish failed (exit ${result.code})\n` +
+      `ka publish failed (exit ${result.code})\n` +
         `stdout: ${result.stdout}\nstderr: ${result.stderr}`,
     );
   }
   const status = /Status:\s*(\w+)/i.exec(result.stdout)?.[1] ?? 'unknown';
-  const kcMatch = /KC ID:\s*(\d+)/i.exec(result.stdout);
-  const txMatch = /TX hash:\s*(0x[0-9a-fA-F]+)/i.exec(result.stdout);
+  const kcMatch = /K[AC] ID:\s*(\d+)/i.exec(result.stdout);
+  const txMatch = /Tx hash:\s*(0x[0-9a-fA-F]+)/i.exec(result.stdout);
   const kaId = kcMatch ? BigInt(kcMatch[1]!) : undefined;
   // Greedy publish-outcome gate (mirrors the devnet shell _devnet_publish_status_ok
   // contract): a CLI exit code of 0 is NOT proof of a real publish. Pin the
@@ -264,11 +282,11 @@ async function publishViaCli(
   const publishOk = ['confirmed', 'finalized', 'tentative'];
   expect(
     publishOk,
-    `dkg publish status="${status}", expected one of ${publishOk.join('/')}\n${result.stdout}`,
+    `ka publish status="${status}", expected one of ${publishOk.join('/')}\n${result.stdout}`,
   ).toContain(status.toLowerCase());
   expect(
     kaId,
-    `dkg publish surfaced no positive "KC ID:" (kaId=${kaId})\n${result.stdout}`,
+    `ka publish surfaced no positive "KA ID:" (kaId=${kaId})\n${result.stdout}`,
   ).toBeGreaterThan(0n);
   return {
     status,

--- a/devnet/v10-rs-prune/automated.test.ts
+++ b/devnet/v10-rs-prune/automated.test.ts
@@ -36,6 +36,7 @@ import { spawn } from 'node:child_process';
 import { readFileSync, existsSync, writeFileSync, mkdirSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { ethers } from 'ethers';
+import { runKaPublishLifecycle } from '../_bootstrap/harness.js';
 
 // ───────────────────────────── constants ─────────────────────────────────
 const REPO_ROOT = resolve(__dirname, '../..');
@@ -145,22 +146,20 @@ async function publish(node: DevnetNode, cg: string, name: string, epochs: numbe
       `<${subject}> <https://schema.org/description> "rs-prune devnet scenario" <did:dkg:context-graph:${cg}> .\n`,
   );
   // #1410 replaced the one-shot `dkg publish <cg> --file` with the KA
-  // lifecycle CLI: `ka create --share` stages the KA (WM -> finalize -> SWM),
-  // then `ka publish` performs the on-chain SWM -> VM publish. `name` is
-  // already unique per call (live/flood-N), so it doubles as the KA name.
-  const created = await runDkgCli(node, ['ka', 'create', name, '--context-graph-id', cg, '--input-file', file, '--share']);
-  if (created.code !== 0) {
-    throw new Error(`ka create --share ${name} failed (exit ${created.code})\nstdout: ${created.stdout}\nstderr: ${created.stderr}`);
-  }
-  const r = await runDkgCli(node, ['ka', 'publish', name, '--context-graph-id', cg, '--publish-epochs', String(epochs)]);
-  if (r.code !== 0) {
-    throw new Error(`ka publish ${name} failed (exit ${r.code})\nstdout: ${r.stdout}\nstderr: ${r.stderr}`);
-  }
-  const status = (/Status:\s*(\w+)/i.exec(r.stdout)?.[1] ?? 'unknown').toLowerCase();
-  expect(['confirmed', 'finalized', 'tentative'], `ka publish ${name} status=${status}\n${r.stdout}`).toContain(status);
-  const kaId = /K[AC] ID:\s*(\d+)/i.exec(r.stdout)?.[1];
-  expect(kaId, `ka publish ${name} surfaced no KA ID\n${r.stdout}`).toBeTruthy();
-  return BigInt(kaId!);
+  // lifecycle CLI (`ka create --share` then `ka publish`) — the two-step
+  // argument/stdout contract now lives in the shared runKaPublishLifecycle
+  // helper (devnet/_bootstrap/harness.ts); status is returned lowercased.
+  // `name` is already unique per call (live/flood-N), so it doubles as the
+  // KA name.
+  const r = await runKaPublishLifecycle((args) => runDkgCli(node, args), {
+    kaName: name,
+    contextGraphId: cg,
+    inputFile: file,
+    publishArgs: ['--publish-epochs', String(epochs)],
+  });
+  expect(['confirmed', 'finalized', 'tentative'], `ka publish ${name} status=${r.status}\n${r.raw}`).toContain(r.status);
+  expect(r.kaId, `ka publish ${name} surfaced no KA ID\n${r.raw}`).toBeDefined();
+  return r.kaId!;
 }
 
 async function timeWarpSeconds(provider: ethers.JsonRpcProvider, seconds: number): Promise<void> {

--- a/devnet/v10-rs-prune/automated.test.ts
+++ b/devnet/v10-rs-prune/automated.test.ts
@@ -63,6 +63,7 @@ interface ScenarioState {
   randomSampling: ethers.Contract;
   chronos: ethers.Contract;
   cgName: string;
+  cgCanonicalId: string;
   cgId: bigint;
   liveKaId: bigint;
   floodKaIds: bigint[];
@@ -143,14 +144,22 @@ async function publish(node: DevnetNode, cg: string, name: string, epochs: numbe
     `<${subject}> <https://schema.org/name> "${name}" <did:dkg:context-graph:${cg}> .\n` +
       `<${subject}> <https://schema.org/description> "rs-prune devnet scenario" <did:dkg:context-graph:${cg}> .\n`,
   );
-  const r = await runDkgCli(node, ['publish', cg, '--file', file, '--publish-epochs', String(epochs)]);
+  // #1410 replaced the one-shot `dkg publish <cg> --file` with the KA
+  // lifecycle CLI: `ka create --share` stages the KA (WM -> finalize -> SWM),
+  // then `ka publish` performs the on-chain SWM -> VM publish. `name` is
+  // already unique per call (live/flood-N), so it doubles as the KA name.
+  const created = await runDkgCli(node, ['ka', 'create', name, '--context-graph-id', cg, '--input-file', file, '--share']);
+  if (created.code !== 0) {
+    throw new Error(`ka create --share ${name} failed (exit ${created.code})\nstdout: ${created.stdout}\nstderr: ${created.stderr}`);
+  }
+  const r = await runDkgCli(node, ['ka', 'publish', name, '--context-graph-id', cg, '--publish-epochs', String(epochs)]);
   if (r.code !== 0) {
-    throw new Error(`publish ${name} failed (exit ${r.code})\nstdout: ${r.stdout}\nstderr: ${r.stderr}`);
+    throw new Error(`ka publish ${name} failed (exit ${r.code})\nstdout: ${r.stdout}\nstderr: ${r.stderr}`);
   }
   const status = (/Status:\s*(\w+)/i.exec(r.stdout)?.[1] ?? 'unknown').toLowerCase();
-  expect(['confirmed', 'finalized', 'tentative'], `publish ${name} status=${status}\n${r.stdout}`).toContain(status);
-  const kaId = /KC ID:\s*(\d+)/i.exec(r.stdout)?.[1];
-  expect(kaId, `publish ${name} surfaced no KC ID\n${r.stdout}`).toBeTruthy();
+  expect(['confirmed', 'finalized', 'tentative'], `ka publish ${name} status=${status}\n${r.stdout}`).toContain(status);
+  const kaId = /K[AC] ID:\s*(\d+)/i.exec(r.stdout)?.[1];
+  expect(kaId, `ka publish ${name} surfaced no KA ID\n${r.stdout}`).toBeTruthy();
   return BigInt(kaId!);
 }
 
@@ -167,7 +176,9 @@ describe('V10 RS prune keeper — flood → expire → prune → reconciler-safe
     }
     const provider = new ethers.JsonRpcProvider(RPC, undefined, { staticNetwork: true });
     const contractsPath = join(REPO_ROOT, 'packages/evm-module/deployments/localhost_contracts.json');
-    const hubAddress: string = JSON.parse(readFileSync(contractsPath, 'utf8')).Hub.evmAddress;
+    // The deploy writes { contracts: { Hub: { evmAddress } } } (schema since the
+    // localhost_contracts.json consolidation) — read through the wrapper.
+    const hubAddress: string = JSON.parse(readFileSync(contractsPath, 'utf8')).contracts.Hub.evmAddress;
     const hub = new ethers.Contract(
       hubAddress,
       ['function getContractAddress(string) view returns (address)', 'function getAssetStorageAddress(string) view returns (address)'],
@@ -199,17 +210,39 @@ describe('V10 RS prune keeper — flood → expire → prune → reconciler-safe
     state.floodKaIds = [];
 
     await ensureIdentity(state.node);
-  }, 120_000);
+
+    // The retired one-shot `dkg publish` auto-created its context graph; the
+    // #1410 `ka` lifecycle requires an existing, ON-CHAIN-registered CG (the
+    // flood publishes to VM). Create + register it once up front.
+    const cgCreate = await runDkgCli(state.node, ['context-graph', 'create', state.cgName, '--name', state.cgName]);
+    if (cgCreate.code !== 0) {
+      throw new Error(`context-graph create failed (exit ${cgCreate.code})\nstdout: ${cgCreate.stdout}\nstderr: ${cgCreate.stderr}`);
+    }
+    // A curated CG's canonical id is "<curatorAddress>/<slug>" — register and
+    // publishes must use the canonical form from create's output. Keep cgName
+    // (the slug) for KA names/filenames: the "/" would break both.
+    const canonicalId = /^\s*ID:\s+(.+)$/m.exec(cgCreate.stdout)?.[1]?.trim();
+    if (!canonicalId) {
+      throw new Error(`could not parse context graph ID from:\n${cgCreate.stdout}`);
+    }
+    state.cgCanonicalId = canonicalId;
+    // Inner CLI timeout must stay below the hook budget (420s) or vitest's
+    // opaque hook timeout fires before this call's pointed error can.
+    const cgRegister = await runDkgCli(state.node, ['context-graph', 'register', state.cgCanonicalId], 240_000);
+    if (cgRegister.code !== 0) {
+      throw new Error(`context-graph register failed (exit ${cgRegister.code})\nstdout: ${cgRegister.stdout}\nstderr: ${cgRegister.stderr}`);
+    }
+  }, 420_000);
 
   it('publishes a live KA + a flood of 1-epoch KAs; both per-CG lists mirror on-chain', async () => {
     const s = state as ScenarioState;
     // Live KA first → it lands at sampling index 0 and is never swapped out.
-    s.liveKaId = await publish(s.node, s.cgName, `${s.cgName}-live`, LIVE_EPOCHS);
+    s.liveKaId = await publish(s.node, s.cgCanonicalId, `${s.cgName}-live`, LIVE_EPOCHS);
     s.cgId = await s.contextGraphStorage.kaToContextGraph(s.liveKaId);
     expect(s.cgId, 'live KA has no CG binding').toBeGreaterThan(0n);
 
     for (let i = 0; i < FLOOD; i++) {
-      const ka = await publish(s.node, s.cgName, `${s.cgName}-flood-${i}`, 1);
+      const ka = await publish(s.node, s.cgCanonicalId, `${s.cgName}-flood-${i}`, 1);
       s.floodKaIds.push(ka);
       expect(await s.contextGraphStorage.kaToContextGraph(ka)).to.equal(s.cgId);
     }

--- a/devnet/v10-stress/automated.test.ts
+++ b/devnet/v10-stress/automated.test.ts
@@ -274,13 +274,31 @@ function runDkgCli(
   });
 }
 
+let cliPublishSeq = 0;
+
 async function publishViaCli(
   node: DevnetNode,
   contextGraph: string,
   filePath: string,
   options: { publisherNodeIdentityId?: bigint } = {},
 ): Promise<{ status: string; kaId?: bigint; txHash?: string; raw: string }> {
-  const args = ['publish', contextGraph, '--file', filePath];
+  // #1410 replaced the one-shot `dkg publish <cg> --file` with the KA
+  // lifecycle CLI: `ka create --share` stages the KA (WM -> finalize -> SWM),
+  // then `ka publish` performs the on-chain SWM -> VM publish.
+  const kaName = `stress-pub-${Date.now().toString(36)}-${++cliPublishSeq}`;
+  const created = await runDkgCli(node, [
+    'ka', 'create', kaName,
+    '--context-graph-id', contextGraph,
+    '--input-file', filePath,
+    '--share',
+  ]);
+  if (created.code !== 0) {
+    throw new Error(
+      `ka create --share failed (exit ${created.code})\n` +
+        `stdout: ${created.stdout}\nstderr: ${created.stderr}`,
+    );
+  }
+  const args = ['ka', 'publish', kaName, '--context-graph-id', contextGraph];
   if (options.publisherNodeIdentityId !== undefined) {
     args.push(
       '--publisher-node-identity-id',
@@ -290,13 +308,13 @@ async function publishViaCli(
   const result = await runDkgCli(node, args);
   if (result.code !== 0) {
     throw new Error(
-      `dkg publish failed (exit ${result.code})\n` +
+      `ka publish failed (exit ${result.code})\n` +
         `stdout: ${result.stdout}\nstderr: ${result.stderr}`,
     );
   }
   const status = /Status:\s*(\w+)/i.exec(result.stdout)?.[1] ?? 'unknown';
-  const kcMatch = /KC ID:\s*(\d+)/i.exec(result.stdout);
-  const txMatch = /TX hash:\s*(0x[0-9a-fA-F]+)/i.exec(result.stdout);
+  const kcMatch = /K[AC] ID:\s*(\d+)/i.exec(result.stdout);
+  const txMatch = /Tx hash:\s*(0x[0-9a-fA-F]+)/i.exec(result.stdout);
   const kaId = kcMatch ? BigInt(kcMatch[1]!) : undefined;
   // Greedy publish-outcome gate (mirrors the devnet shell _devnet_publish_status_ok
   // contract): a CLI exit code of 0 is NOT proof of a real publish. Pin the
@@ -307,11 +325,11 @@ async function publishViaCli(
   const publishOk = ['confirmed', 'finalized', 'tentative'];
   expect(
     publishOk,
-    `dkg publish status="${status}", expected one of ${publishOk.join('/')}\n${result.stdout}`,
+    `ka publish status="${status}", expected one of ${publishOk.join('/')}\n${result.stdout}`,
   ).toContain(status.toLowerCase());
   expect(
     kaId,
-    `dkg publish surfaced no positive "KC ID:" (kaId=${kaId})\n${result.stdout}`,
+    `ka publish surfaced no positive "KA ID:" (kaId=${kaId})\n${result.stdout}`,
   ).toBeGreaterThan(0n);
   return {
     status,
@@ -1010,6 +1028,7 @@ describe('V10 chain — stress + scenario validation', () => {
     // chain adapter sees a clean nonce slate before this batch starts.
     await new Promise((r) => setTimeout(r, 2_000));
     let custodialTentativeRetries = 0;
+    let transportQuorumRetries = 0;
     console.log(`phase 2: VM custodial (mode B) batch (${vmCustodial} assertions via core2)...`);
     for (let i = 0; i < vmCustodial; i++) {
       const name = `vm-custodial-${runTag}-${i}`;
@@ -1048,7 +1067,11 @@ describe('V10 chain — stress + scenario validation', () => {
       // FINDINGS.md "publisher nonce race"), retry ONCE after 2s. The
       // publisher's nonce manager re-fetches `pending` on retry and
       // succeeds. Persistent tentative is still a hard failure.
-      const doPublish = async () => {
+      const doPublish = async (attempt = 0): Promise<{
+        kaId?: string;
+        status?: string;
+        txHash?: string;
+      }> => {
         const r = await fetch(
           `http://127.0.0.1:${core2.apiPort}/api/knowledge-assets/${encodeURIComponent(name)}/vm/publish`,
           {
@@ -1072,7 +1095,28 @@ describe('V10 chain — stress + scenario validation', () => {
         } | null;
         const tentative = !!j && (j.status === 'tentative' || j.kaId === '0');
         if (!r.ok && !tentative) {
-          throw new Error(`HTTP ${r.status}: ${j ? JSON.stringify(j) : ''}`);
+          const body = j ? JSON.stringify(j) : '';
+          // Under the 100-publish storm a core peer can transiently drop a
+          // storage-ack stream (protocol negotiation fails / no response
+          // during connection churn) and cost a single publish its quorum.
+          // That is load-induced connection churn, not a publish-path defect —
+          // retry ONCE after a short backoff so one flaky stream doesn't fail
+          // the whole storm; a repeat failure is still a hard failure.
+          // An active decline (STORAGE_ACK_DECLINE) is never churn — a peer
+          // examined the payload and refused it — so a mixed failure with any
+          // decline in it must NOT be retried or a decline regression under
+          // load would pass on the second attempt.
+          const transientQuorum =
+            r.status >= 500 &&
+            /storage_ack_insufficient/.test(body) &&
+            /TRANSPORT_ERROR|no_response/.test(body) &&
+            !/STORAGE_ACK_DECLINE/.test(body);
+          if (transientQuorum && attempt === 0) {
+            transportQuorumRetries++;
+            await new Promise((res) => setTimeout(res, 3_000));
+            return doPublish(1);
+          }
+          throw new Error(`HTTP ${r.status}: ${body}`);
         }
         return j ?? {};
       };
@@ -1251,6 +1295,30 @@ describe('V10 chain — stress + scenario validation', () => {
         `that path requires client-side EIP-712 + V10 merkle root computation ` +
         `and is covered in devnet/agent-provenance/automated.test.ts.`,
     );
+    if (transportQuorumRetries > 0) {
+      console.log(
+        `phase 2: ${transportQuorumRetries} publish(es) retried once after a transient ` +
+          'storage-ack transport failure (connection churn under storm load)',
+      );
+      appendFinding(
+        'WARN — storage-ack transport retries under storm load',
+        `${transportQuorumRetries}/${vmCustodial} VM-custodial (mode B) publishes needed a one-shot ` +
+          `retry after \`500 + storage_ack_insufficient\` with only transport-class peer outcomes ` +
+          `(\`TRANSPORT_ERROR\`/\`no_response\`, zero declines). Sporadic occurrences are connection ` +
+          `churn under the 100-publish storm; a systemic count means first-attempt storage-ack ` +
+          `streams are failing deterministically — a product regression, not churn.`,
+      );
+    }
+    // Genuine churn is sporadic. A deterministic first-attempt storage-ack
+    // failure would push every custodial publish through the retry and pass
+    // silently — cap the absorbed retries so the systemic case still fails.
+    const transportRetryCap = Math.max(3, Math.ceil(vmCustodial * 0.2));
+    expect(
+      transportQuorumRetries,
+      `storage-ack transport retries (${transportQuorumRetries}) exceeded the churn budget ` +
+        `${transportRetryCap} — a systemic first-attempt ACK-transport failure is a product ` +
+        `regression, not connection churn`,
+    ).toBeLessThanOrEqual(transportRetryCap);
     if (custodialTentativeRetries > 0) {
       appendFinding(
         'BUG — publisher nonce race during back-to-back publishes',

--- a/devnet/v10-stress/automated.test.ts
+++ b/devnet/v10-stress/automated.test.ts
@@ -59,6 +59,7 @@ import {
 } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { ethers } from 'ethers';
+import { runKaPublishLifecycle } from '../_bootstrap/harness';
 
 // ───────────────────────────── constants ─────────────────────────────────
 const REPO_ROOT = resolve(__dirname, '../..');
@@ -282,40 +283,25 @@ async function publishViaCli(
   filePath: string,
   options: { publisherNodeIdentityId?: bigint } = {},
 ): Promise<{ status: string; kaId?: bigint; txHash?: string; raw: string }> {
-  // #1410 replaced the one-shot `dkg publish <cg> --file` with the KA
-  // lifecycle CLI: `ka create --share` stages the KA (WM -> finalize -> SWM),
-  // then `ka publish` performs the on-chain SWM -> VM publish.
+  // Thin wrapper over the shared #1410 two-step lifecycle helper (`ka create
+  // --share` stages WM -> finalize -> SWM, then `ka publish` lands SWM -> VM
+  // on-chain). The harness owns the arg arrays + stdout parsing (and returns
+  // `status` lowercased); this suite keeps its own kaName scheme, CLI runner
+  // (with its timeouts) and the greedy publish-outcome gate below.
   const kaName = `stress-pub-${Date.now().toString(36)}-${++cliPublishSeq}`;
-  const created = await runDkgCli(node, [
-    'ka', 'create', kaName,
-    '--context-graph-id', contextGraph,
-    '--input-file', filePath,
-    '--share',
-  ]);
-  if (created.code !== 0) {
-    throw new Error(
-      `ka create --share failed (exit ${created.code})\n` +
-        `stdout: ${created.stdout}\nstderr: ${created.stderr}`,
-    );
-  }
-  const args = ['ka', 'publish', kaName, '--context-graph-id', contextGraph];
+  const publishArgs: string[] = [];
   if (options.publisherNodeIdentityId !== undefined) {
-    args.push(
+    publishArgs.push(
       '--publisher-node-identity-id',
       String(options.publisherNodeIdentityId),
     );
   }
-  const result = await runDkgCli(node, args);
-  if (result.code !== 0) {
-    throw new Error(
-      `ka publish failed (exit ${result.code})\n` +
-        `stdout: ${result.stdout}\nstderr: ${result.stderr}`,
-    );
-  }
-  const status = /Status:\s*(\w+)/i.exec(result.stdout)?.[1] ?? 'unknown';
-  const kcMatch = /K[AC] ID:\s*(\d+)/i.exec(result.stdout);
-  const txMatch = /Tx hash:\s*(0x[0-9a-fA-F]+)/i.exec(result.stdout);
-  const kaId = kcMatch ? BigInt(kcMatch[1]!) : undefined;
+  const result = await runKaPublishLifecycle((args) => runDkgCli(node, args), {
+    kaName,
+    contextGraphId: contextGraph,
+    inputFile: filePath,
+    publishArgs,
+  });
   // Greedy publish-outcome gate (mirrors the devnet shell _devnet_publish_status_ok
   // contract): a CLI exit code of 0 is NOT proof of a real publish. Pin the
   // status to a known success value and require a positive on-chain kaId so an
@@ -325,18 +311,57 @@ async function publishViaCli(
   const publishOk = ['confirmed', 'finalized', 'tentative'];
   expect(
     publishOk,
-    `ka publish status="${status}", expected one of ${publishOk.join('/')}\n${result.stdout}`,
-  ).toContain(status.toLowerCase());
+    `ka publish status="${result.status}", expected one of ${publishOk.join('/')}\n${result.raw}`,
+  ).toContain(result.status);
   expect(
-    kaId,
-    `ka publish surfaced no positive "KA ID:" (kaId=${kaId})\n${result.stdout}`,
+    result.kaId,
+    `ka publish surfaced no positive "KA ID:" (kaId=${result.kaId})\n${result.raw}`,
   ).toBeGreaterThan(0n);
-  return {
-    status,
-    kaId,
-    txHash: txMatch ? txMatch[1] : undefined,
-    raw: result.stdout,
-  };
+  return result;
+}
+
+// ───────────────────────── storm retry policy ─────────────────────────────
+// Phase 2's 100-publish storm absorbs a bounded amount of load-induced
+// flakiness. The classification lives in these module-scope functions (not
+// inline in the publish loop) so the policy is deterministic-testable — see
+// the `storm retry policy (deterministic)` describe at the end of this file.
+
+/**
+ * Transport-only quorum miss under storm load = connection churn, retryable.
+ * Under the 100-publish storm a core peer can transiently drop a storage-ack
+ * stream (protocol negotiation fails / no response during connection churn)
+ * and cost a single publish its quorum. That is load-induced connection
+ * churn, not a publish-path defect. An active decline (STORAGE_ACK_DECLINE)
+ * is never churn — a peer examined the payload and refused it — so a mixed
+ * failure with any decline in it must NOT be retried, or a decline
+ * regression under load would pass on the second attempt.
+ */
+function isTransientQuorumFailure(status: number, body: string): boolean {
+  return (
+    status >= 500 &&
+    /storage_ack_insufficient/.test(body) &&
+    /TRANSPORT_ERROR|no_response/.test(body) &&
+    !/STORAGE_ACK_DECLINE/.test(body)
+  );
+}
+
+/**
+ * Churn budget for the storm's absorbed transport retries. Genuine churn is
+ * sporadic; a deterministic first-attempt storage-ack failure would push
+ * every custodial publish through the one-shot retry and pass silently —
+ * capping the absorbed retries keeps the systemic case a hard failure.
+ */
+function stormTransportRetryCap(publishCount: number): number {
+  return Math.max(3, Math.ceil(publishCount * 0.2));
+}
+
+/**
+ * A publish response is "tentative" when the daemon says so explicitly or
+ * returns the kaId="0" sentinel (publisher nonce race — see FINDINGS.md
+ * "publisher nonce race"). Tentative outcomes get one delayed retry.
+ */
+function isTentativePublish(j: { status?: string; kaId?: string } | null): boolean {
+  return !!j && (j.status === 'tentative' || j.kaId === '0');
 }
 
 async function loadContractAddresses(
@@ -1093,24 +1118,13 @@ describe('V10 chain — stress + scenario validation', () => {
           status?: string;
           txHash?: string;
         } | null;
-        const tentative = !!j && (j.status === 'tentative' || j.kaId === '0');
+        const tentative = isTentativePublish(j);
         if (!r.ok && !tentative) {
           const body = j ? JSON.stringify(j) : '';
-          // Under the 100-publish storm a core peer can transiently drop a
-          // storage-ack stream (protocol negotiation fails / no response
-          // during connection churn) and cost a single publish its quorum.
-          // That is load-induced connection churn, not a publish-path defect —
-          // retry ONCE after a short backoff so one flaky stream doesn't fail
-          // the whole storm; a repeat failure is still a hard failure.
-          // An active decline (STORAGE_ACK_DECLINE) is never churn — a peer
-          // examined the payload and refused it — so a mixed failure with any
-          // decline in it must NOT be retried or a decline regression under
-          // load would pass on the second attempt.
-          const transientQuorum =
-            r.status >= 500 &&
-            /storage_ack_insufficient/.test(body) &&
-            /TRANSPORT_ERROR|no_response/.test(body) &&
-            !/STORAGE_ACK_DECLINE/.test(body);
+          // Retry ONCE after a short backoff so one flaky stream doesn't fail
+          // the whole storm; a repeat failure is still a hard failure. See
+          // isTransientQuorumFailure for what qualifies as retryable churn.
+          const transientQuorum = isTransientQuorumFailure(r.status, body);
           if (transientQuorum && attempt === 0) {
             transportQuorumRetries++;
             await new Promise((res) => setTimeout(res, 3_000));
@@ -1122,7 +1136,7 @@ describe('V10 chain — stress + scenario validation', () => {
       };
 
       let publishJson = await doPublish();
-      if (publishJson.status === 'tentative' || publishJson.kaId === '0') {
+      if (isTentativePublish(publishJson)) {
         custodialTentativeRetries++;
         if (i === 0) {
           console.log(
@@ -1309,10 +1323,9 @@ describe('V10 chain — stress + scenario validation', () => {
           `streams are failing deterministically — a product regression, not churn.`,
       );
     }
-    // Genuine churn is sporadic. A deterministic first-attempt storage-ack
-    // failure would push every custodial publish through the retry and pass
-    // silently — cap the absorbed retries so the systemic case still fails.
-    const transportRetryCap = Math.max(3, Math.ceil(vmCustodial * 0.2));
+    // Cap the absorbed retries so the systemic case still fails — see
+    // stormTransportRetryCap for the churn-budget rationale.
+    const transportRetryCap = stormTransportRetryCap(vmCustodial);
     expect(
       transportQuorumRetries,
       `storage-ack transport retries (${transportQuorumRetries}) exceeded the churn budget ` +
@@ -1964,3 +1977,78 @@ async function ensurePcaAccountForOpWallets(
   }
   return accountId;
 }
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Storm retry policy — deterministic coverage.
+//
+// The phase-2 storm only exercises isTransientQuorumFailure when the live
+// devnet happens to drop a storage-ack stream, so the retry classification is
+// pinned here against representative /vm/publish failure bodies. This block
+// is intentionally OUTSIDE the main describe (whose beforeAll boots the
+// devnet state): the tests are pure functions of their inputs and must pass
+// regardless of devnet availability.
+// ═══════════════════════════════════════════════════════════════════════════
+describe('storm retry policy (deterministic)', () => {
+  /** Representative /vm/publish quorum-failure body carrying per-peer outcomes. */
+  const quorumBody = (peerOutcomes: string[]) =>
+    JSON.stringify({
+      error: 'storage_ack_insufficient',
+      message: `storage ack quorum not reached (peer outcomes: ${peerOutcomes.join(', ')})`,
+      outcomes: peerOutcomes,
+    });
+
+  it('retries a 500 quorum miss whose only peer failures are TRANSPORT_ERROR', () => {
+    expect(isTransientQuorumFailure(500, quorumBody(['TRANSPORT_ERROR']))).toBe(true);
+  });
+
+  it('retries a 500 quorum miss whose only peer failures are no_response', () => {
+    expect(isTransientQuorumFailure(500, quorumBody(['no_response']))).toBe(true);
+  });
+
+  it('never retries a mixed failure containing an active decline', () => {
+    expect(
+      isTransientQuorumFailure(
+        500,
+        quorumBody(['TRANSPORT_ERROR', 'STORAGE_ACK_DECLINE:NO_DATA_IN_SWM']),
+      ),
+    ).toBe(false);
+  });
+
+  it('does not retry a quorum miss without a transport-class marker', () => {
+    expect(
+      isTransientQuorumFailure(
+        500,
+        JSON.stringify({
+          error: 'storage_ack_insufficient',
+          message: 'storage ack quorum not reached',
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it('does not retry a 5xx body that is not a storage-ack quorum failure', () => {
+    expect(
+      isTransientQuorumFailure(
+        502,
+        JSON.stringify({ error: 'bad_gateway', message: 'upstream TRANSPORT_ERROR' }),
+      ),
+    ).toBe(false);
+  });
+
+  it('does not retry below 500 even with transport-only quorum markers', () => {
+    expect(isTransientQuorumFailure(400, quorumBody(['TRANSPORT_ERROR']))).toBe(false);
+  });
+
+  it('stormTransportRetryCap floors at 3 and scales at 20% of the batch', () => {
+    expect(stormTransportRetryCap(1)).toBe(3);
+    expect(stormTransportRetryCap(25)).toBe(5);
+    expect(stormTransportRetryCap(100)).toBe(20);
+  });
+
+  it('isTentativePublish detects explicit tentative and the kaId="0" sentinel', () => {
+    expect(isTentativePublish({ status: 'tentative' })).toBe(true);
+    expect(isTentativePublish({ kaId: '0' })).toBe(true);
+    expect(isTentativePublish({ status: 'confirmed', kaId: '7' })).toBe(false);
+    expect(isTentativePublish(null)).toBe(false);
+  });
+});

--- a/scripts/devnet-soak-rs.sh
+++ b/scripts/devnet-soak-rs.sh
@@ -646,7 +646,7 @@ while true; do
     rm -f "$DEVNET_DIR/node${RESTART_NODE}/daemon.pid"
     DKG_HOME="$DEVNET_DIR/node${RESTART_NODE}" DKG_NO_BLUE_GREEN=1 \
       node "$CLI_JS" start --foreground \
-      >> "$DEVNET_DIR/node${RESTART_NODE}/daemon.log" 2>&1 &
+      >> "$DEVNET_DIR/node${RESTART_NODE}/console.log" 2>&1 &
     new_pid=$!
     echo "$new_pid" > "$pidfile"
     log "  restarted node ${RESTART_NODE} pid=$new_pid; verifying API readiness..."

--- a/scripts/devnet-test-random-sampling.sh
+++ b/scripts/devnet-test-random-sampling.sh
@@ -152,10 +152,20 @@ else
 fi
 
 log "Publishing 1 quad into $CG_NAME (cgId=$CG_NUMERIC_ID) via CLI..."
+# #1410 replaced the one-shot `dkg publish <cg> --file` with the two-step KA
+# lifecycle: `ka create --share` (WM → finalize → SWM) then `ka publish` (→ VM).
+RS_KA_NAME="rs-smoke-$(date +%s)"
 set +e
-DKG_HOME="$NODE_DIR" node "$CLI_JS" publish "$CG_NAME" --file "$TMP_RDF" \
+DKG_HOME="$NODE_DIR" node "$CLI_JS" ka create "$RS_KA_NAME" \
+  --context-graph-id "$CG_NAME" --input-file "$TMP_RDF" --share \
   > /tmp/rs-publish.log 2>&1
 PUBLISH_RC=$?
+if [ $PUBLISH_RC -eq 0 ]; then
+  DKG_HOME="$NODE_DIR" node "$CLI_JS" ka publish "$RS_KA_NAME" \
+    --context-graph-id "$CG_NAME" \
+    >> /tmp/rs-publish.log 2>&1
+  PUBLISH_RC=$?
+fi
 set -e
 if [ $PUBLISH_RC -ne 0 ]; then
   tail -n 30 /tmp/rs-publish.log >&2

--- a/scripts/devnet-test-rfc39-comprehensive.sh
+++ b/scripts/devnet-test-rfc39-comprehensive.sh
@@ -454,7 +454,8 @@ stop_node_inline() {
 }
 
 # Re-spawn a single core node using the same invocation devnet.sh
-# uses (DKG_HOME=<node_dir>, foreground, log → daemon.log). Waits for
+# uses (DKG_HOME=<node_dir>, foreground, shell output → console.log;
+# the daemon tees its own stream into daemon.log in-process). Waits for
 # the API to respond. Returns 0 on ready, non-zero on timeout.
 start_node_inline() {
   local n="$1"
@@ -468,7 +469,7 @@ start_node_inline() {
   log "  Spawning node $n..."
   DKG_HOME="$node_dir" DKG_NO_BLUE_GREEN=1 \
     node "$REPO_ROOT/packages/cli/dist/cli.js" start --foreground \
-    >> "$node_dir/daemon.log" 2>&1 &
+    >> "$node_dir/console.log" 2>&1 &
   local pid=$!
   echo "$pid" > "$pidf"
   local port; port=$(node_port "$n")

--- a/scripts/devnet-test.sh
+++ b/scripts/devnet-test.sh
@@ -2470,7 +2470,7 @@ else
     echo "--- 30c: restart Node1 (fresh libp2p instance, empty peerStore) ---"
     DKG_HOME="$DEVNET_DIR/node1" DKG_NO_BLUE_GREEN=1 \
       node "$CLI_JS" start --foreground \
-      >> "$DEVNET_DIR/node1/daemon.log" 2>&1 &
+      >> "$DEVNET_DIR/node1/console.log" 2>&1 &
     NEW_PID=$!
     echo "$NEW_PID" > "$PIDFILE"
     ok "Node1 restart launched (PID $NEW_PID)"
@@ -3567,7 +3567,7 @@ except Exception:
         # end with the node still down and no failure signal).
         DKG_HOME="$RECIPIENT_DIR" DKG_NO_BLUE_GREEN=1 \
           node "$CLI_JS" start --foreground \
-          >> "$RECIPIENT_DIR/daemon.log" 2>&1 &
+          >> "$RECIPIENT_DIR/console.log" 2>&1 &
         NEW_PID=$!
         echo "$NEW_PID" > "$RECIPIENT_PIDFILE"
         cleanup_ready=0
@@ -3589,7 +3589,7 @@ except Exception:
       echo "--- 37d: restart recipient (substrate should drain on connection re-establishment) ---"
       DKG_HOME="$RECIPIENT_DIR" DKG_NO_BLUE_GREEN=1 \
         node "$CLI_JS" start --foreground \
-        >> "$RECIPIENT_DIR/daemon.log" 2>&1 &
+        >> "$RECIPIENT_DIR/console.log" 2>&1 &
       NEW_PID=$!
       echo "$NEW_PID" > "$RECIPIENT_PIDFILE"
       ok "Recipient restart launched (PID $NEW_PID)"

--- a/scripts/devnet.sh
+++ b/scripts/devnet.sh
@@ -672,9 +672,16 @@ start_node() {
   # RANDOM operational keys and the staking step (cmd_start) re-reads
   # wallets[0].privateKey directly, so the daemon must NOT migrate it to an
   # encrypted keystore (GH #11). Production daemons omit this and auto-migrate.
+  # Redirect console output to console.log, NOT daemon.log: the daemon already
+  # tees its full log stream into $DKG_HOME/daemon.log in-process (lifecycle.ts
+  # stdout/stderr tee). Pointing the shell redirect at the SAME file wrote every
+  # byte through two independent fds (one positional, one append), which left
+  # byte-replayed duplicate tail segments in daemon.log — and doubled the
+  # rpc_usage telemetry counts the rpc-quiet-window suite sums. console.log
+  # still captures pre-tee output from an early crash.
   DKG_HOME="$node_dir" DKG_NO_BLUE_GREEN=1 DKG_WALLETS_NO_MIGRATE=1 \
     node "$REPO_ROOT/packages/cli/dist/cli.js" start --foreground \
-    > "$node_dir/daemon.log" 2>&1 &
+    > "$node_dir/console.log" 2>&1 &
   local node_pid=$!
   echo "$node_pid" > "$pidfile"
 
@@ -708,7 +715,7 @@ start_node() {
   done
 
   if [ "$ready" = false ]; then
-    log "WARNING: Node $node_num not ready after ${max_wait}s (check $node_dir/daemon.log)"
+    log "WARNING: Node $node_num not ready after ${max_wait}s (check $node_dir/daemon.log and $node_dir/console.log)"
   fi
 
   # Save THIS node's multiaddr so (a) node 1 serves as the universal relay and


### PR DESCRIPTION
## What

Fixes the 5 issues found by running the full devnet test sweep on latest main, plus the defects an adversarial multi-agent review of this diff itself confirmed. **Test harness + scripts only — no product code and no CI changes** (devnet suites stay manual-run by design).

### 1. `daemon.log` double-write → phantom RPC "budget overshoot"
The daemon tees its stdout into `daemon.log` in-process (`lifecycle.ts`), and `devnet.sh` **also** shell-redirected the process into the same file. Tail segments got byte-replayed, so every `rpc_usage` count the quiet-window suite summed was **exactly 2× real** — the "22/26 > 20 eth_getLogs" failure was a log artifact, not product RPC load (real numbers: 13/20 and 91/120, comfortably inside budget — **budgets unchanged**).
- `devnet.sh` now redirects the shell stream to `console.log` (daemon.log stays complete, single-written, via the in-process tee).
- Same fix applied to the identical restart-path pattern in `devnet-soak-rs.sh`, `devnet-test-rfc39-comprehensive.sh`, `devnet-test.sh` (these silently double-counted `rs.tick.*` in downstream validation scripts).
- `rpc-quiet-window` also dedupes replayed lines defensively and reports **all** violations at once instead of dying on the first.

### 2. Suites broken by #1410's CLI removal — every caller migrated
`dkg publish <cg> --file` (and `dkg shared-memory write/publish`) no longer exist. Migrated to the two-step `ka create --share` → `ka publish` flow: **v10-end-to-end, agent-provenance, greenfield-10min, core-peers-features, conviction-lazy-settle, v10-stress, v10-rs-prune, the shared `_bootstrap/harness.ts` `publishViaCli`, `devnet-test-random-sampling.sh`, and pr1385-subgraph-rs** (sub-graphs ride `--sub-graph-name` on `ka create/publish`; the old exit-1-despite-success workaround is obsolete — `ka publish` exits 0). Output parsing updated (`KC ID:` → `KA ID:`), stale `dkg publish` text swept from expect messages, comments, READMEs and the provenance transcript template.

### 3. v10-rs-prune: contracts schema + CG registration
- Reads the current `{contracts:{Hub:{evmAddress}}}` schema of `localhost_contracts.json`.
- Creates **and registers** its context graph in `beforeAll` (the retired one-shot auto-created CGs). The curated CG's canonical id (`<curator>/<slug>`) is used for CLI/chain calls while the slug keeps naming KAs/files — the `/` would break both.
- Hook budget raised to 420s so the register call's pointed error can fire before vitest's opaque hook timeout.

### 4. ka-lifecycle-cli: real fail-fast when the publisher runtime is off
A devnet booted without `DEVNET_ENABLE_PUBLISHER=1` used to burn 3×300s timeouts with no cause. The first version of this gate checked `config.json`'s `publisher.enabled` — which `devnet.sh` writes as `true` unconditionally, so the gate was dead code (caught by the adversarial review). It now keys on a **non-empty `publisher-wallets.json`**, the signal that actually gates publisher startup. **Verified live: publisher-off boot fails in 1s with a pointed reboot message.**

### 5. v10-stress: bounded, deliberately-narrow storage-ack retry
One retry for storm-load quorum flakes, only when `500 + storage_ack_insufficient` and **every** missing ACK is transport-class (`TRANSPORT_ERROR`/`no_response`) and **no peer actively declined** (a decline is never churn — review-caught masking hole). Retries are persisted to `FINDINGS.local.md` and capped at `max(3, 20% of custodial publishes)` so a deterministic first-attempt regression still fails the storm.

**Bonus:** v10-core-flows derives node API URLs from `.devnet/nodeN/config.json` instead of hardcoding ports (`API_PORT_BASE`-safe).

## Validation (live devnets, fresh publisher-enabled 6-node boots)

| Suite | Result |
|---|---|
| rpc-quiet-window | ✅ (0 duplicated `rpc_usage` lines across 6 nodes post-fix) |
| v10-end-to-end | ✅ |
| v10-core-flows | ✅ (fresh boot) |
| conviction-lazy-settle | ✅ |
| v10-rs-prune | ✅ |
| ka-lifecycle-cli | ✅ + negative test: publisher-off boot fails fast in 1s |
| v10-stress | ✅ (with tightened retry + churn cap) |
| greenfield-10min | ✅ |
| pr1385-subgraph-rs | ✅ (13s, first green run since the CLI rework) |
| agent-provenance (5-node) | ✅ |

`devnet-test-random-sampling.sh`'s migration is code-reviewed but not live-run (standalone soak-style script); it targets the same bootstrap `devnet-test` CG through the exact flow the green suites use.

## Known issues documented, NOT fixed here

- **core-peers-features kill-a-core phase**: expects publishes to succeed with a deliberately-killed core member, but quorum needs 3/3 member ACKs — a pre-existing expectation mismatch that was invisible while the suite couldn't run at all (#1410 breakage). Needs its own follow-up issue: either the expectation is wrong or degraded-membership publishing is a real product gap.
- **v10-core-flows order-sensitivity**: RS-score timing + a strict staking equality assert that trips on reward dust when run late on a shared devnet. Passes reliably on a fresh boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)