### PR TITLE
chore(release): 10.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to the DKG V9 node are documented here. The format is based 
 
 ## [Unreleased]
 
+## [10.0.3] - 2026-07-07
+
+Stability and node-operator UX release: Node UI PublishingConviction (PCA) owner-access hardening, folded-private ACK anchoring, reduced node RPC load, the WM→SWM promote fix, and a full repair of the devnet regression lane. **No smart-contract changes — no deployment required** (no Solidity source or ABI changes since 10.0.2).
+
+### Added
+
+- **RPC usage metrics** (#1409) and **reduced DKG node RPC load** across startup and steady-state polling (#1440).
+
+### Changed
+
+- **Node UI — PublishingConviction (PCA) owner-access model** refactor: a centralized owner-access + signer-planning model, an approve reducer/runner, and `ConvictionDetailView` decomposition (#1446, #1453, #1468, #1472; from the #1348 / #1350 / #1375 series).
+
+### Fixed
+
+- **Folded-private ACK anchoring** gated on storage-ack v2, with legacy V10 ACK-provider fallbacks (#1369, #1371).
+- **WM→SWM promote migration** isolated on a dedicated context graph (#1464, #1483).
+- **Base mainnet ACK candidate filtering** by active network relays (#1482).
+- **Devnet UI solc / config** (#1403) and **testnet store preflight resilience** (#1408).
+- **Devnet regression lane repaired** against the #1410 KA-publish CLI unification — a shared `runKaPublishLifecycle` helper, the rpc-quiet-window budget, the `daemon.log` double-write, and 3 flaky/blind spots (#1496).
+
+### Deployment
+
+- **No new contract deployment.** No Solidity source or ABI changes since 10.0.2; existing Base / Gnosis / Base-Sepolia registries recorded via #1405 remain the deploy targets.
+
 ### Fixed — `dkg init` on monorepo checkouts + oxigraph-server default for adapter/MCP setups (#960)
 
 - **V10 publish/update allowance recovery now translates raw ethers custom-error data before `TooLowAllowance` classification** (`packages/chain/src/evm-adapter.ts`): the shared populate-and-sign recovery gate decodes raw provider revert data first, so a fresh node can force one re-approval and retry when RPC allowance reads lag behind a mined TRAC approval.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dkg-v10",
-  "version": "10.0.2",
+  "version": "10.0.3",
   "private": true,
   "packageManager": "pnpm@10.28.1",
   "dkgBuild": {

--- a/packages/adapter-elizaos/package.json
+++ b/packages/adapter-elizaos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-elizaos",
-  "version": "10.0.2",
+  "version": "10.0.3",
   "description": "ElizaOS plugin adapter — turns any ElizaOS agent into a DKG V10 node",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapter-hermes/package.json
+++ b/packages/adapter-hermes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-hermes",
-  "version": "10.0.2",
+  "version": "10.0.3",
   "description": "Hermes Agent adapter — connects Hermes AI agents to a DKG V10 node for verifiable shared memory",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapter-openclaw/package.json
+++ b/packages/adapter-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-openclaw",
-  "version": "10.0.2",
+  "version": "10.0.3",
   "description": "OpenClaw plugin adapter for connecting a DKG V10 node and chat bridge to an OpenClaw agent",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-agent",
-  "version": "10.0.2",
+  "version": "10.0.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/chain/package.json
+++ b/packages/chain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-chain",
-  "version": "10.0.2",
+  "version": "10.0.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg",
-  "version": "10.0.2",
+  "version": "10.0.3",
   "type": "module",
   "main": "dist/cli.js",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-core",
-  "version": "10.0.2",
+  "version": "10.0.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/epcis/package.json
+++ b/packages/epcis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-epcis",
-  "version": "10.0.2",
+  "version": "10.0.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/evm-module/package.json
+++ b/packages/evm-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-evm-module",
-  "version": "10.0.2",
+  "version": "10.0.3",
   "description": "DKG V10 smart contracts (forked from V8 dkg-evm-module)",
   "license": "Apache-2.0",
   "private": true,

--- a/packages/graph-viz/package.json
+++ b/packages/graph-viz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-graph-viz",
-  "version": "10.0.2",
+  "version": "10.0.3",
   "description": "RDF Knowledge Graph Visualizer — force-directed graph rendering with hexagonal nodes, declarative view configs, RDF-native data loading, and SPARQL-driven views",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/kafka-plugin/package.json
+++ b/packages/kafka-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/kafka-plugin",
-  "version": "10.0.2",
+  "version": "10.0.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mcp-dkg/package.json
+++ b/packages/mcp-dkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-mcp",
-  "version": "10.0.2",
+  "version": "10.0.3",
   "description": "MCP server that exposes the local DKG daemon (projects, sub-graphs, activity, chat) to Cursor, Claude Code, and any other MCP-aware coding assistant.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/network-sim/package.json
+++ b/packages/network-sim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-network-sim",
-  "version": "10.0.2",
+  "version": "10.0.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/node-ui/package.json
+++ b/packages/node-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-node-ui",
-  "version": "10.0.2",
+  "version": "10.0.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/okf/package.json
+++ b/packages/okf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-okf",
-  "version": "10.0.2",
+  "version": "10.0.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/publisher/package.json
+++ b/packages/publisher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-publisher",
-  "version": "10.0.2",
+  "version": "10.0.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-query",
-  "version": "10.0.2",
+  "version": "10.0.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/random-sampling/package.json
+++ b/packages/random-sampling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-random-sampling",
-  "version": "10.0.2",
+  "version": "10.0.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-storage",
-  "version": "10.0.2",
+  "version": "10.0.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Release 10.0.3

Version bump for the 10.0.3 release cut from `main` (`b0bbb511a`). Patch release — node/UI/devnet stability fixes; **no smart-contract changes, no deployment required** (no Solidity source or ABI changes since 10.0.2).

### What's in it (13 PRs since v10.0.2)
- **Node UI — PCA owner-access model** hardening (#1446, #1453, #1468, #1472; #1348/#1350/#1375 series)
- **Folded-private ACK anchoring** on storage-ack v2 (#1369, #1371)
- **Reduced node RPC load** + usage metrics (#1440, #1409)
- **WM→SWM promote migration** fix (#1464, #1483)
- **Base mainnet ACK candidate filtering** by active relays (#1482)
- **Devnet UI solc/config** (#1403), **testnet store preflight** (#1408)
- **Devnet regression lane repaired** against the #1410 KA-publish CLI unification (#1496)

### This PR
- Lockstep version bump of all 20 workspace `package.json` files `10.0.2` → `10.0.3` (matches the 10.0.1→10.0.2 convention; internal deps are `workspace:*`).
- `CHANGELOG.md` `[10.0.3]` section.
- Lockfile untouched (the only `10.0.2` strings in `pnpm-lock.yaml` are third-party deps), so `pnpm install --frozen-lockfile` stays valid.

### After merge
Tag `v10.0.3` on `main` → `release.yml` builds the GitHub Release + markitdown binaries → **manual** `pnpm -r publish` (OTP) → move `mainnet`/`testnet` dist-tags. See `DKG-RELEASE-10.0.3-RUNBOOK.md`.
