### PR TITLE
fix(publisher): warn on silent PCA full-price fall-through (#1411)

### DIFF
--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -2490,6 +2490,11 @@ export class DKGPublisher implements Publisher {
     // of truth so ACK pricing == chain tx pricing. Resolved BEFORE the PCA
     // coercion below so the fundability probe can price the lock-lifetime publish.
     const effectiveByteSize = useEncryptedInline ? stagingByteSize : publicByteSize;
+    // #1411 — remember PCA-agent eligibility (+ lock, for an accurate reason)
+    // so a post-publish check can warn when a registered agent's publish
+    // silently fell through to full-price direct spend (the #1 PCA footgun).
+    let pcaAgentAccountId = 0n;
+    let pcaLockEpochs = 0; // set on the explicit-override probe (drives the reason)
     let publishEpochs = explicitPublishEpochs ?? DEFAULT_PUBLISH_EPOCHS;
     if (
       explicitPublishEpochs === undefined &&
@@ -2500,6 +2505,7 @@ export class DKGPublisher implements Publisher {
     ) {
       try {
         const accountId = await this.chain.getConvictionAgentAccountId(publisherSigner.address);
+        pcaAgentAccountId = accountId; // #1411 — remember eligibility for the post-publish full-price warn
         if (accountId > 0n) {
           const lockEpochs = await this.chain.getConvictionAccountLockDurationEpochs(accountId);
           if (lockEpochs > 0) {
@@ -2569,6 +2575,25 @@ export class DKGPublisher implements Publisher {
           `PCA epochs probe failed — falling back to publishEpochs=${publishEpochs}: ` +
           `${err instanceof Error ? err.message : String(err)}`,
         );
+      }
+    } else if (
+      explicitPublishEpochs !== undefined &&
+      canAttemptOnChainPublish &&
+      publisherSigner !== undefined &&
+      typeof this.chain.getConvictionAgentAccountId === 'function'
+    ) {
+      // #1411 — an explicit lifetime override SKIPS the coercion block above,
+      // so a registered PCA agent can silently lose the discount and pay full
+      // price. Probe eligibility (+ lock, to distinguish an epochs mismatch
+      // from an underfunded/expired account) so the post-publish check can
+      // warn with an accurate reason. Best-effort — never fail the publish.
+      try {
+        pcaAgentAccountId = await this.chain.getConvictionAgentAccountId(publisherSigner.address);
+        if (pcaAgentAccountId > 0n && typeof this.chain.getConvictionAccountLockDurationEpochs === 'function') {
+          pcaLockEpochs = await this.chain.getConvictionAccountLockDurationEpochs(pcaAgentAccountId);
+        }
+      } catch {
+        /* eligibility unknown → no warn; never fail the publish */
       }
     }
     let precomputedTokenAmount = canAttemptOnChainPublish ? BigInt(publishEpochs) : 0n;
@@ -3349,6 +3374,23 @@ export class DKGPublisher implements Publisher {
 
     // Track owned entities and batch→context graph binding on confirmed publishes
     if (status === 'confirmed' && onChainResult) {
+      // #1411 — a registered PCA agent whose publish did NOT draw on the PCA
+      // (no `CostCovered` event → `convictionCostCovered` absent) silently paid
+      // FULL price via direct wallet spend. That silent fall-through is the #1
+      // PCA footgun (`PUBLISHING-CONVICTION-ACCOUNTS.md`); surface it as an
+      // actionable operator warning. Log-only — publish behavior is unchanged.
+      if (pcaAgentAccountId > 0n && !onChainResult.convictionCostCovered) {
+        const reason =
+          explicitPublishEpochs !== undefined && pcaLockEpochs > 0 && publishEpochs !== pcaLockEpochs
+            ? `the explicit publish lifetime (publishEpochs=${publishEpochs}) does not match the account's lock duration (lockDurationEpochs=${pcaLockEpochs}) — the PCA discount requires an exact epoch match`
+            : `the account could not cover this publish's cost (underfunded, expired, or misconfigured lock)`;
+        this.log.warn(
+          ctx,
+          `PCA discount NOT applied: signer ${publisherSigner?.address} is a registered PCA agent ` +
+          `(accountId=${pcaAgentAccountId}) but this publish paid FULL price via direct wallet spend ` +
+          `(no CostCovered event) — ${reason}. Omit the explicit lifetime (or match the lock duration) to use the discount.`,
+        );
+      }
       const confirmOwnershipKey = options.subGraphName ? `${contextGraphId}\0${options.subGraphName}` : contextGraphId;
       if (!this.ownedEntities.has(confirmOwnershipKey)) {
         this.ownedEntities.set(confirmOwnershipKey, new Set());

--- a/packages/publisher/test/pca-fallthrough-warn.test.ts
+++ b/packages/publisher/test/pca-fallthrough-warn.test.ts
@@ -1,0 +1,247 @@
+/**
+ * #1411 — silent PCA full-price fall-through warning.
+ *
+ * The on-chain PCA discount (`KnowledgeAssetsV10.publish`) applies only when
+ * the signer is a registered, non-expired PCA agent AND
+ * `p.epochs == lockDurationEpochs`. Any miss silently falls through to a
+ * FULL-price direct wallet spend with no revert — historically with no signal
+ * at all. `DKGPublisher.publish()` now emits a post-confirmation `log.warn`
+ * whenever a registered PCA agent's publish did NOT draw on the PCA
+ * (`onChainResult.convictionCostCovered` absent). This is LOG-ONLY — no
+ * publish behavior changes.
+ *
+ * These cases pin that warning:
+ *   1. Explicit lifetime ≠ lock → WARN (epochs-mismatch reason).
+ *   2. Default-path underfunded PCA → WARN (generic reason).
+ *   3. Covered publish (`convictionCostCovered` present) → NO warn.
+ *   4. Non-PCA signer on the explicit path → NO warn.
+ *   5. Eligibility probe throws on the explicit path → NO warn, publish succeeds.
+ *
+ * Self-contained harness (mirrors `publisher-no-random-wallet.test.ts`): the
+ * shared seal/ACK ceremony comes from `./_helpers/*`, the chain doubles are
+ * local so this regression file runs standalone in the unit lane
+ * (`vitest.unit.config.ts`).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { DKGPublisher } from '../src/dkg-publisher.js';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import { TypedEventBus, generateEd25519Keypair } from '@origintrail-official/dkg-core';
+import {
+  MockChainAdapter,
+  type OnChainPublishResult,
+  type V10PublishDirectParams,
+} from '@origintrail-official/dkg-chain';
+import { ethers } from 'ethers';
+import { wrapPublisherForTest, mockSealCtx } from './_helpers/seal.js';
+import { mockChainStubACKProvider } from './_helpers/acks.js';
+
+const TEST_KEY = '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d';
+
+// Signs publish/ACK/seal material with `wallet` (mirrors the
+// `AdapterSigningChain` in publisher-no-random-wallet.test.ts).
+class AdapterSigningChain extends MockChainAdapter {
+  constructor(private readonly wallet: ethers.Wallet) {
+    super('mock:31337', wallet.address);
+    this.seedIdentity(wallet.address, 1n);
+    this.minimumRequiredSignatures = 1;
+  }
+
+  override async signMessage(messageHash: Uint8Array): Promise<{ r: Uint8Array; vs: Uint8Array }> {
+    const sig = ethers.Signature.from(await this.wallet.signMessage(messageHash));
+    return {
+      r: ethers.getBytes(sig.r),
+      vs: ethers.getBytes(sig.yParityAndS),
+    };
+  }
+
+  async signTypedData(
+    domain: ethers.TypedDataDomain,
+    types: Record<string, Array<{ name: string; type: string }>>,
+    value: Record<string, unknown>,
+  ): Promise<string> {
+    return this.wallet.signTypedData(domain, types, value);
+  }
+}
+
+// A single conviction double with three test-controlled seams:
+//  - `pcaLockDurationEpochs`  → what the SDK sees as the account lock.
+//  - `injectConvictionCovered` → attach a `CostCovered` result (a discounted
+//    publish) that the real adapter would decode from the receipt (B1 — the
+//    stock mock never emits it).
+//  - `throwOnAgentLookup`     → model an eligibility-probe RPC failure.
+class PcaProbeChain extends AdapterSigningChain {
+  pcaLockDurationEpochs?: number;
+  injectConvictionCovered = false;
+  throwOnAgentLookup = false;
+
+  override async getConvictionAccountLockDurationEpochs(accountId: bigint): Promise<number> {
+    return this.pcaLockDurationEpochs ?? super.getConvictionAccountLockDurationEpochs(accountId);
+  }
+
+  override async getConvictionAgentAccountId(agent: string): Promise<bigint> {
+    if (this.throwOnAgentLookup) throw new Error('mock: conviction eligibility RPC unavailable');
+    return super.getConvictionAgentAccountId(agent);
+  }
+
+  override async createKnowledgeAssets(params: V10PublishDirectParams): Promise<OnChainPublishResult> {
+    const base = await super.createKnowledgeAssets(params);
+    if (!this.injectConvictionCovered) return base;
+    // Shape mirrors `chain-adapter.ts` `OnChainPublishResult.convictionCostCovered`
+    // (the B8 badge signal) — its mere presence means the publish drew on the PCA.
+    return {
+      ...base,
+      convictionCostCovered: {
+        accountId: 1n,
+        epoch: 0,
+        baseCost: 100n,
+        discountedCost: 80n,
+        drawnFromEpoch: 80n,
+        drawnFromTopUp: 0n,
+      },
+    };
+  }
+}
+
+async function makePublisher(chain: PcaProbeChain, wallet: ethers.Wallet): Promise<DKGPublisher> {
+  const keypair = await generateEd25519Keypair();
+  const chainId = await chain.getEvmChainId();
+  const kav10Address = await chain.getKnowledgeAssetsLifecycleAddress();
+  return wrapPublisherForTest(
+    new DKGPublisher({
+      store: new OxigraphStore(),
+      chain,
+      eventBus: new TypedEventBus(),
+      keypair,
+      publisherNodeIdentityId: 1n,
+    }),
+    {
+      author: wallet,
+      ctx: mockSealCtx({ chainId, kav10Address }),
+      v10ACKProvider: mockChainStubACKProvider(),
+    },
+  );
+}
+
+function quads(label: string) {
+  return [{
+    subject: `urn:test:${label}`,
+    predicate: 'http://schema.org/name',
+    object: `"${label}"`,
+    graph: 'did:dkg:context-graph:1',
+  }];
+}
+
+// The publisher logs several unrelated warnings on the publish hot path
+// (RS scoped-promote, token-amount pricing, etc.), so we filter to the
+// specific full-price fall-through warning rather than asserting "no warn".
+function spyPublisherWarn(publisher: DKGPublisher) {
+  return vi.spyOn((publisher as unknown as { log: { warn: (...a: unknown[]) => void } }).log, 'warn');
+}
+function pcaFallthroughWarns(warnSpy: ReturnType<typeof spyPublisherWarn>): string[] {
+  return warnSpy.mock.calls
+    .map((c) => String(c[1]))
+    .filter((m) => m.includes('PCA discount NOT applied'));
+}
+
+describe('DKGPublisher: warns on silent PCA full-price fall-through (#1411)', () => {
+  it('WARNS (epochs-mismatch reason) when an explicit lifetime does not match the PCA lock', async () => {
+    const wallet = new ethers.Wallet(TEST_KEY);
+    const chain = new PcaProbeChain(wallet);
+    chain.pcaLockDurationEpochs = 24;
+    const { accountId } = await chain.createPublishingConvictionAccount(ethers.parseEther('10000'));
+    await chain.registerPublishingConvictionAgent(accountId, wallet.address);
+    const publisher = await makePublisher(chain, wallet);
+    const warnSpy = spyPublisherWarn(publisher);
+
+    const result = await publisher.publish({
+      contextGraphId: '1',
+      quads: quads('pca-explicit-mismatch-warn'),
+      publishEpochs: 5, // ≠ lock (24) → discount silently lost
+    });
+
+    expect(result.status).toBe('confirmed');
+    const warns = pcaFallthroughWarns(warnSpy);
+    expect(warns).toHaveLength(1);
+    expect(warns[0]).toContain('does not match the account');
+    expect(warns[0]).toContain('publishEpochs=5');
+    expect(warns[0]).toContain('lockDurationEpochs=24');
+    expect(warns[0]).toContain(`accountId=${accountId}`);
+  });
+
+  it('WARNS (generic reason) when a default-path publish falls through on an underfunded PCA', async () => {
+    const wallet = new ethers.Wallet(TEST_KEY);
+    const chain = new PcaProbeChain(wallet);
+    chain.pcaLockDurationEpochs = 24;
+    // 1-wei commit → baseEpochAllowance floors to 0 → cannot cover this
+    // publish's cost → no coercion → direct full-price spend on the default path.
+    const { accountId } = await chain.createPublishingConvictionAccount(1n);
+    await chain.registerPublishingConvictionAgent(accountId, wallet.address);
+    expect(await chain.convictionAccountCanCover(accountId, ethers.parseEther('1'))).toBe(false);
+    const publisher = await makePublisher(chain, wallet);
+    const warnSpy = spyPublisherWarn(publisher);
+
+    const result = await publisher.publish({
+      contextGraphId: '1',
+      quads: quads('pca-default-underfunded-warn'), // no explicit epochs
+    });
+
+    expect(result.status).toBe('confirmed');
+    const warns = pcaFallthroughWarns(warnSpy);
+    expect(warns).toHaveLength(1);
+    expect(warns[0]).toContain('could not cover this publish');
+    expect(warns[0]).not.toContain('does not match'); // generic, not epochs-mismatch
+    expect(warns[0]).toContain(`accountId=${accountId}`);
+  });
+
+  it('does NOT warn when the publish actually drew on the PCA (CostCovered present)', async () => {
+    const wallet = new ethers.Wallet(TEST_KEY);
+    const chain = new PcaProbeChain(wallet);
+    chain.pcaLockDurationEpochs = 24;
+    chain.injectConvictionCovered = true; // covered publish → discount applied
+    const { accountId } = await chain.createPublishingConvictionAccount(ethers.parseEther('10000'));
+    await chain.registerPublishingConvictionAgent(accountId, wallet.address);
+    const publisher = await makePublisher(chain, wallet);
+    const warnSpy = spyPublisherWarn(publisher);
+
+    const result = await publisher.publish({
+      contextGraphId: '1',
+      quads: quads('pca-covered-no-warn'), // default lifetime → coerced + covered
+    });
+
+    expect(result.status).toBe('confirmed');
+    expect(pcaFallthroughWarns(warnSpy)).toHaveLength(0);
+  });
+
+  it('does NOT warn when the explicit-path signer is not a PCA agent', async () => {
+    const wallet = new ethers.Wallet(TEST_KEY);
+    const chain = new PcaProbeChain(wallet); // no PCA registered → agent lookup returns 0n
+    const publisher = await makePublisher(chain, wallet);
+    const warnSpy = spyPublisherWarn(publisher);
+
+    const result = await publisher.publish({
+      contextGraphId: '1',
+      quads: quads('non-pca-explicit-no-warn'),
+      publishEpochs: 5,
+    });
+
+    expect(result.status).toBe('confirmed');
+    expect(pcaFallthroughWarns(warnSpy)).toHaveLength(0);
+  });
+
+  it('does NOT warn and still publishes when the eligibility probe throws on the explicit path', async () => {
+    const wallet = new ethers.Wallet(TEST_KEY);
+    const chain = new PcaProbeChain(wallet);
+    chain.throwOnAgentLookup = true; // best-effort probe fails
+    const publisher = await makePublisher(chain, wallet);
+    const warnSpy = spyPublisherWarn(publisher);
+
+    const result = await publisher.publish({
+      contextGraphId: '1',
+      quads: quads('pca-probe-throws-no-warn'),
+      publishEpochs: 5,
+    });
+
+    expect(result.status).toBe('confirmed');
+    expect(pcaFallthroughWarns(warnSpy)).toHaveLength(0);
+  });
+});

--- a/packages/publisher/test/pca-fallthrough-warn.test.ts
+++ b/packages/publisher/test/pca-fallthrough-warn.test.ts
@@ -193,6 +193,33 @@ describe('DKGPublisher: warns on silent PCA full-price fall-through (#1411)', ()
     expect(warns[0]).toContain(`accountId=${accountId}`);
   });
 
+  it('WARNS (generic reason, NOT epochs-mismatch) on the explicit path when the lifetime EQUALS the lock but the PCA cannot cover it', async () => {
+    // Guards the `publishEpochs !== pcaLockEpochs` conjunct in the reason ternary:
+    // an explicit lifetime that matches the lock but misses the discount
+    // (underfunded/expired) must yield the generic reason, never the
+    // self-contradictory "publishEpochs=24 does not match lockDurationEpochs=24".
+    const wallet = new ethers.Wallet(TEST_KEY);
+    const chain = new PcaProbeChain(wallet);
+    chain.pcaLockDurationEpochs = 24;
+    const { accountId } = await chain.createPublishingConvictionAccount(1n); // underfunded
+    await chain.registerPublishingConvictionAgent(accountId, wallet.address);
+    const publisher = await makePublisher(chain, wallet);
+    const warnSpy = spyPublisherWarn(publisher);
+
+    const result = await publisher.publish({
+      contextGraphId: '1',
+      quads: quads('pca-explicit-match-underfunded'),
+      publishEpochs: 24, // == lock (24), yet no CostCovered → generic reason, not epochs-mismatch
+    });
+
+    expect(result.status).toBe('confirmed');
+    const warns = pcaFallthroughWarns(warnSpy);
+    expect(warns).toHaveLength(1);
+    expect(warns[0]).toContain('could not cover this publish');
+    expect(warns[0]).not.toContain('does not match'); // matched epochs → NOT the mismatch branch
+    expect(warns[0]).toContain(`accountId=${accountId}`);
+  });
+
   it('does NOT warn when the publish actually drew on the PCA (CostCovered present)', async () => {
     const wallet = new ethers.Wallet(TEST_KEY);
     const chain = new PcaProbeChain(wallet);

--- a/packages/publisher/vitest.unit.config.ts
+++ b/packages/publisher/vitest.unit.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
       'test/async-promote-queue.test.ts',
       'test/multi-root-token-rows.test.ts',
       'test/promote-step-tag.test.ts',
+      'test/pca-fallthrough-warn.test.ts',
     ],
     testTimeout: 60_000,
     maxWorkers: 1,


### PR DESCRIPTION
## What & why

Fixes the **code half of #1411** — the #1 PCA footgun (`PUBLISHING-CONVICTION-ACCOUNTS.md`): a registered Publishing-Conviction-Account agent's VM publish can silently fall through to **full-price direct wallet spend** with **no signal at all**.

The on-chain discount (`KnowledgeAssetsV10.publish`) applies only when the signer is a registered, non-expired PCA agent **and** `p.epochs == lockDurationEpochs` (all-or-nothing; any miss falls through to direct spend, no revert). The off-chain probe/coerce/log block that snaps `publishEpochs → lockEpochs` is gated on `explicitPublishEpochs === undefined`, so **any explicit lifetime override skips it entirely** — a caller who sets an explicit `publishEpochs` ≠ the PCA's lock silently loses the discount and pays full price, with no probe and no log.

## The fix (log-only)

A **post-publish operator warning** in `DKGPublisher.publish()` — the single method both **sync** (`/vm/publish`) and **async** (`/vm/publish-async` → publisher-runner) paths funnel through, so one warning covers both. It keys on the **authoritative, already-decoded** `onChainResult.convictionCostCovered` signal (the B8 badge event — no new RPC): if the signer is a registered PCA agent but the publish emitted no `CostCovered` event, warn that it paid full price, with an accurate reason:
- explicit lifetime ≠ lock → *"publishEpochs=X does not match lockDurationEpochs=Y — the discount requires an exact epoch match"*
- otherwise → *"the account could not cover this publish's cost (underfunded, expired, or misconfigured lock)"*

**Behavior is unchanged** — this only adds a `log.warn`. RPC cost: **zero** on default/non-PCA publishes (reuses the probe the default path already runs); a best-effort probe (accountId + lock) is added **only** on the rare explicit-override path and never fails the publish.

## Scope / non-goals
- **Declined:** the "relax exact-match to `<=`" contract change in #1411 — needs an on-chain redeploy, out of node-repo scope.
- **Out of scope:** the parallel PCA discount branch on **KA update** has the same silent fall-through; the warn is publish-only. A follow-up can extend it.
- No API/CLI/UI surface change.
- Note: on the default-underfunded path this intentionally logs both the existing `log.info` ("NOT coercing…") and the new actionable `log.warn` (the warn is the operator-facing one).

## Testing
- New `packages/publisher/test/pca-fallthrough-warn.test.ts` (5 cases, in the unit lane `include`): explicit-mismatch→WARN(epochs), default-underfunded→WARN(generic), covered→NO warn (injects `convictionCostCovered`), non-PCA-explicit→NO warn, probe-throws→NO warn + publish succeeds.
- **Guard-verified:** disabling the warn turns exactly the 2 WARN cases red; restoring returns green — proven both directions.
- Full publisher unit lane: **188/188 green** (was 183; +5), `tsc` clean, `git diff --stat` = 3 files only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M3swmeQGT8WGttaZsp1NQJ
