### PR TITLE
fix(sync): progress-aware phase deadline — end the durable-sync storm behind the mainnet publish outage

### DIFF
--- a/packages/agent/src/sync/requester/page-fetch.ts
+++ b/packages/agent/src/sync/requester/page-fetch.ts
@@ -10,6 +10,22 @@ import {
   DURABLE_DATA_SYNC_SESSION_TTL_MS,
 } from '../durable-session.js';
 
+// Progress-aware deadline (10.0.3 mainnet sync-storm fix). The per-graph
+// budget is SYNC_TOTAL_TIMEOUT_MS / remaining-graphs floored at
+// SYNC_MIN_GRAPH_BUDGET_MS (~10s once a node subscribes to many discovered
+// on-chain CGs). Large system graphs ("agents" is 20k+ triples on mainnet)
+// cannot finish inside that floor, so every attempt hard-aborted at the
+// absolute deadline MID-PROGRESS, retried from a (often superseded)
+// checkpoint, and re-transferred the same pages forever — saturating every
+// responder so badly their StorageACK handlers stopped answering publishers
+// (the v10.0.3 publish outage). A sync that is actively receiving pages must
+// be allowed to finish: each page that lands extends the effective deadline
+// by the grace window below. A STALLED sync (no page inside the grace
+// window past its budget) still times out exactly as before, and the hard
+// cap bounds the total time any single phase can hold its on-connect slot.
+export const SYNC_PROGRESS_GRACE_MS = 15_000;
+export const SYNC_PHASE_HARD_CAP_MS = 600_000;
+
 const MAX_UNFINISHED_SYNC_RESPONDER_SESSIONS = 4096;
 type UnfinishedSyncResponderSession = {
   syncSessionId: string;
@@ -221,15 +237,32 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
     }
     : undefined;
 
+  // Progress extends the effective deadline (see SYNC_PROGRESS_GRACE_MS):
+  // a phase past its share-based budget but still receiving pages keeps
+  // going until it stalls for a full grace window or hits the scaled hard
+  // cap (8x the phase's own budget, ceilinged by SYNC_PHASE_HARD_CAP_MS).
+  // `lastProgressAt` starts at -Infinity so a phase that never received a
+  // page keeps the EXACT pre-fix budget — the grace only rewards real
+  // progress. The `max(deadline, …)` shape means the extension can only
+  // ever LENGTHEN the caller's window, never shorten it: recovery paths
+  // that pass a far-future deadline are untouched.
+  const budgetMs = Math.max(0, deadline - sessionStartedAt);
+  const hardCapMs = Math.min(SYNC_PHASE_HARD_CAP_MS, 8 * budgetMs);
+  let lastProgressAt = Number.NEGATIVE_INFINITY;
+  const effectiveDeadline = () => Math.max(
+    deadline,
+    Math.min(lastProgressAt + SYNC_PROGRESS_GRACE_MS, sessionStartedAt + hardCapMs),
+  );
+
   try {
     while (true) {
       throwIfAborted(signal);
-      if (Date.now() > deadline) {
+      if (Date.now() > effectiveDeadline()) {
         timedOut = true;
         break;
       }
 
-      const remainingMs = Math.max(0, deadline - Date.now());
+      const remainingMs = Math.max(0, effectiveDeadline() - Date.now());
       const timeoutMs = Math.min(
         syncPageTimeoutMs,
         Math.max(2000, Math.floor(remainingMs / syncRouterAttempts)),
@@ -313,6 +346,8 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
 
       allQuads.push(...parsed.quads);
       offset += parsed.totalQuads;
+      // A page landed — this sync is alive; extend the effective deadline.
+      lastProgressAt = Date.now();
 
       if (debugSyncProgress) {
         logInfo(

--- a/packages/agent/test/sync-progress-deadline.test.ts
+++ b/packages/agent/test/sync-progress-deadline.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { fetchSyncPages, type SyncPageResult } from '../src/sync/requester/page-fetch.js';
+import type { OperationContext } from '@origintrail-official/dkg-core';
+
+/**
+ * Regression tests for the v10.0.3 durable-sync timeout storm.
+ *
+ * Symptom on mainnet cores: the durable-data phase of a large SYSTEM context
+ * graph ("agents"/"ontology" are 20k+ triples) timed out mid-stream — logging
+ * "…(20000 triples received so far)…" — because the phase deadline
+ * (`createContextGraphSyncDeadline` → `Date.now() + budgetMs`) is a FIXED
+ * wall-clock window that cannot drain the whole graph while the responder is
+ * under load. Each timeout retried, the responder-session supersede path wiped
+ * the checkpoint, and the next attempt restarted from offset 0
+ * ("…(0 triples received…)"): a non-converging retry storm that saturated the
+ * node and starved its StorageACK handler (publish quorum failed network-wide).
+ *
+ * The fix (page-fetch.ts) makes the phase budget progress-aware: it is re-armed
+ * after every page that makes forward progress, so a healthy-but-large transfer
+ * completes in ONE session, while an absolute cap still bounds a peer that only
+ * ever trickles a row per page.
+ *
+ * Time is driven through a `Date`-only fake clock advanced from inside the
+ * `send` stub, so each page "costs" wall-clock time deterministically without a
+ * real sleep. `send` resolves immediately (no retries), so `sendSyncRequest`'s
+ * real `withRetry` timers never fire — leaving them un-faked is safe.
+ */
+
+const REMOTE_PEER_ID = '12D3KooWSmU3owJvB9sFw8uApDgKrv2VBMecsGGvgAc4Gq6hB57M';
+const CG_ID = 'did:dkg:context-graph:agents';
+const GRAPH_URI = `${CG_ID}/graph`;
+const PROTOCOL_ID = '/dkg/10.0.2/sync';
+const PAGE_SIZE = 500;
+const BASE_MS = 1_700_000_000_000;
+const BUDGET_MS = 10_000; // the floored/divided per-phase budget
+
+function noopLog(): void {}
+function makeCtx(): OperationContext {
+  return { kind: 'system', id: 'test', startedAt: Date.now() } as never;
+}
+
+const nullCheckpointStore = {
+  get: () => undefined,
+  set: () => {},
+  delete: () => {},
+};
+
+/**
+ * Runs one durable-data phase against a peer that serves `fullPages` full pages
+ * — each advancing the fake clock by `stepMs` — and then, if `terminate` is set,
+ * an empty page that ends the phase cleanly. Returns the page result plus the
+ * final fake-clock value so tests can assert elapsed wall-clock time.
+ */
+async function runPhase(opts: {
+  fullPages: number;
+  stepMs: number;
+  terminate: boolean;
+}): Promise<{ result: SyncPageResult; elapsedMs: number }> {
+  let pagesSent = 0;
+  const result = await fetchSyncPages({
+    ctx: makeCtx(),
+    remotePeerId: REMOTE_PEER_ID,
+    contextGraphId: CG_ID,
+    includeSharedMemory: false,
+    phase: 'data',
+    graphUri: GRAPH_URI,
+    deadline: Date.now() + BUDGET_MS,
+    syncPageTimeoutMs: 45_000,
+    syncRouterAttempts: 3,
+    syncPageRetryAttempts: 1,
+    syncPageSize: PAGE_SIZE,
+    syncDeniedResponse: '#DENIED',
+    debugSyncProgress: false,
+    protocolSync: PROTOCOL_ID,
+    checkpointStore: nullCheckpointStore,
+    buildSyncRequest: async () => new TextEncoder().encode('request'),
+    parseAndFilter: async (nquadsText: string) => (
+      nquadsText ? { quads: [], totalQuads: PAGE_SIZE } : { quads: [], totalQuads: 0 }
+    ),
+    send: async () => {
+      // Each page "costs" `stepMs` of wall-clock time.
+      vi.setSystemTime(Date.now() + opts.stepMs);
+      pagesSent += 1;
+      if (pagesSent > opts.fullPages) {
+        // Empty body ⇒ end-of-stream; the phase completes cleanly.
+        return opts.terminate ? new Uint8Array() : new TextEncoder().encode('page');
+      }
+      return new TextEncoder().encode('page');
+    },
+    logWarn: noopLog,
+    logInfo: noopLog,
+    logDebug: noopLog,
+  });
+  return { result, elapsedMs: Date.now() - BASE_MS };
+}
+
+describe('durable-sync progress-aware phase deadline (v10.0.3 storm fix)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(BASE_MS);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('drains a large-but-healthy phase to completion even after the initial budget elapses', async () => {
+    // 5 pages, 6s each = 30s of wall-clock, THREE TIMES the fixed 10s budget.
+    // Pre-fix, the phase would have timed out after ~2 pages (~1000 triples,
+    // the "20000 triples received so far" symptom at scale); the checkpoint
+    // then thrashed and the next round restarted from 0.
+    const { result, elapsedMs } = await runPhase({ fullPages: 5, stepMs: 6_000, terminate: true });
+
+    expect(result.completed).toBe(true);
+    expect(result.timedOut).toBe(false);
+    expect(result.nextOffset).toBe(5 * PAGE_SIZE);
+    // Proves the phase kept running well past the fixed initial budget.
+    expect(elapsedMs).toBeGreaterThan(BUDGET_MS);
+  });
+
+  it('still times out (with an intact, resumable checkpoint) when a peer only trickles rows forever', async () => {
+    // Every page makes progress but costs 30s — far slower than the phase can
+    // ever finish. The absolute cap (8 × 10s = 80s) must bound it so it cannot
+    // pin the responder slot indefinitely.
+    const { result, elapsedMs } = await runPhase({ fullPages: 1_000, stepMs: 30_000, terminate: false });
+
+    expect(result.timedOut).toBe(true);
+    expect(result.completed).toBe(false);
+    // Progress made before the cap is preserved — the next round resumes from
+    // this offset instead of restarting from 0.
+    expect(result.nextOffset).toBeGreaterThan(0);
+    // Bounded by the absolute cap, not left running forever.
+    expect(elapsedMs).toBeLessThanOrEqual(8 * BUDGET_MS + 30_000);
+    expect(elapsedMs).toBeGreaterThan(BUDGET_MS);
+  });
+
+  it('completes a small phase within the initial budget unchanged (no regression)', async () => {
+    // Two fast pages that finish comfortably inside the 10s budget behave
+    // exactly as before the fix.
+    const { result, elapsedMs } = await runPhase({ fullPages: 2, stepMs: 500, terminate: true });
+
+    expect(result.completed).toBe(true);
+    expect(result.timedOut).toBe(false);
+    expect(result.nextOffset).toBe(2 * PAGE_SIZE);
+    expect(elapsedMs).toBeLessThan(BUDGET_MS);
+  });
+});

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -31,6 +31,7 @@ export default defineConfig({
       "test/ensure-registered-for-publish.test.ts",
       "test/sync-verify-collapsed.test.ts",
       "test/durable-sync-since-threading.test.ts",
+      "test/sync-progress-deadline.test.ts",
       "test/sync-responder-concurrent-interleaving.test.ts",
       "test/sync-fetch-coalescing.test.ts",
       "test/sync-on-connect-churn.test.ts",


### PR DESCRIPTION
## Summary

**Single fix: progress-aware durable-sync phase deadline** — the convergence fix for the mainnet publish outage (2026-07-07 →). Rebased onto latest main; the ACK relay-cap half of the original PR was dropped as superseded by #1501 / `0dd2b4e2c`.

## The problem this fixes

The per-graph sync budget is `max(10s, 120s / remaining CGs)`, enforced as a hard **mid-progress abort** (`page-fetch.ts`). The `agents` system CG grew ~10x (30–57k triples) — a full scan (durable sync is full-scan-only; the `sinceBatchIdFor` delta hook is never wired) can no longer complete inside one window. Checkpoints/sessions are in-memory with a 10-min TTL, so aborted attempts restart at offset 0. The synchronized 10.0.3 fleet restart wiped all checkpoints at once → every core full-rescanning everything from everyone → store saturation → deadline blowouts → offset-0 retries: a **self-sustaining congestion loop**. Publish ACKs (`persistStaging`) queue behind that flood in the single-threaded store worker → `storage_ack_insufficient` / (10.0.4) `CORE_TEMPORARILY_UNAVAILABLE (ack handler deadline exceeded)` network-wide. 10.0.4's C-1/C-2/#1510 bound the damage but don't make big syncs complete — the fleet re-entered the storm on release day.

## The fix

Each page that lands extends the effective deadline by a 15s grace, bounded by a hard cap scaling with the phase budget (8×, ceilinged at 10 min): a phase actively receiving pages completes; a stalled phase times out exactly as before (zero-progress keeps the exact pre-fix budget; far-future recovery deadlines are never shortened); a trickling peer still times out with a resumable checkpoint.

## Production A/B/A evidence (same mainnet Gnosis edge node)

| build | sync timeouts |
|---|---|
| stock 10.0.3 | ~49/h sustained |
| **this fix** | **decays to ~1/h** |
| stock 10.0.4 | 22→61/h and rising |

## Tests

`test/sync-progress-deadline.test.ts`: large-but-healthy phase drains to completion past the budget; trickle-forever still bounded with progress preserved; small phase unchanged. Green together with main's `sync-fetch-coalescing` + `sync-requester-bailout` suites (12/12).

## Rollout note

Deploy with **staggered** restarts — a simultaneous fleet restart wipes all in-memory checkpoints and re-seeds the storm the fix then has to drain. Follow-ups tracked separately: persist checkpoints across restarts; wire the delta-sync hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
