### PR TITLE
fix(publisher): ACK candidate list ranks peers — never gates eligibility (2026-07-07 mainnet ACK outage)

### DIFF
--- a/devnet/ack-candidate-isolation/README.md
+++ b/devnet/ack-candidate-isolation/README.md
@@ -4,12 +4,18 @@ Read-only live devnet coverage for ACK candidate isolation.
 
 ## What it proves
 
-An edge node can have a live transport peer set that includes stale relay peers,
-but ACK candidate ordering must still be bounded to the active network's core
-peer IDs. The test uses node5's generated local-devnet core bootstrap peers as
-the active ACK set, injects the known public Base testnet relay IDs as stale
-connected peers, and verifies the candidate ordering returns only the four
-active devnet cores.
+An edge node can have a live transport peer set that includes stale relay
+peers. The configured ACK candidate list must RANK the active network's core
+peer IDs first without excluding any connected peer (a hard exclusion filter
+capped the mainnet pool at the bundled relay list and made ACK quorum
+unreachable in the 2026-07-07 Base/Gnosis incident; chain-side ACK
+verification, not candidacy, is what keeps stale peers out of quorum). The
+test uses node5's generated local-devnet core bootstrap peers as the
+preferred ACK set, injects the known public Base testnet relay IDs as stale
+connected peers, and verifies the ordering places all four active devnet
+cores ahead of the stale non-core peers while keeping everyone dialable. It
+also asserts devnet daemons never install the public-network preference list
+in the first place.
 
 ## Run
 

--- a/devnet/ack-candidate-isolation/automated.test.ts
+++ b/devnet/ack-candidate-isolation/automated.test.ts
@@ -115,14 +115,14 @@ describe('ACK candidate isolation on devnet', () => {
     expect(edgeConfig.relay).toMatch(/^\/ip4\/127\.0\.0\.1\/tcp\//);
     expect(node1Log).toContain('Relay disabled (config.relay = "none")');
     for (const log of [node1Log, node5Log]) {
-      expect(log).not.toMatch(/ACK candidate peer allowlist: .*network config/);
+      expect(log).not.toMatch(/ACK candidate peer (allowlist|preference): .*network config/);
       for (const suffix of UNEXPECTED_TESTNET_SUFFIXES) {
         expect(log).not.toContain(suffix);
       }
     }
   });
 
-  it('filters the 4 devnet cores + 3 stale testnet peers ACK fallback back to devnet cores', () => {
+  it('orders the 4 devnet cores ahead of 3 stale testnet peers in the ACK fallback (preference, not exclusion)', () => {
     const devnetCoreIds = activeDevnetCoreIds();
     const publicTestnetIds = loadPublicTestnetPeerIds();
     const staleTestnetIds = UNEXPECTED_TESTNET_SUFFIXES.map((suffix) => {
@@ -154,12 +154,25 @@ describe('ACK candidate isolation on devnet', () => {
       ackCandidatePeerIds: devnetCoreIds,
     });
 
+    // Preference ordering, not exclusion: listed devnet cores fill the
+    // first dial slots of each tier; stale testnet peers rank last but stay
+    // dialable (chain-side ACK verification rejects them — a hard filter
+    // here is what capped the mainnet pool at the bundled relay list in the
+    // 2026-07-07 incident). staleTestnetIds[0] sits in the confirmed-core
+    // tier because identify classified it as a core; the chain gate, not
+    // candidacy, is what keeps its ACK out of quorum.
     expect(filtered).toEqual([
       devnetCoreIds[2],
+      staleTestnetIds[0],
       devnetCoreIds[0],
       devnetCoreIds[1],
       devnetCoreIds[3],
+      staleTestnetIds[1],
+      staleTestnetIds[2],
     ]);
-    expect(filtered.filter((id) => staleTestnetIds.includes(id))).toEqual([]);
+    const firstStaleRestIdx = filtered.indexOf(staleTestnetIds[1]!);
+    for (const coreId of devnetCoreIds) {
+      expect(filtered.indexOf(coreId!)).toBeLessThan(firstStaleRestIdx);
+    }
   });
 });

--- a/devnet/ack-candidate-isolation/automated.test.ts
+++ b/devnet/ack-candidate-isolation/automated.test.ts
@@ -101,7 +101,7 @@ describe('ACK candidate isolation on devnet', () => {
     expect(configuredPeerIds.filter((id) => publicTestnetIds.includes(id))).toEqual([]);
   });
 
-  it('does not install the default public testnet ACK allowlist in the local devnet relay topology', () => {
+  it('does not install the default public testnet ACK preference list in the local devnet relay topology', () => {
     const node1LogPath = join(DEVNET_DIR, 'node1', 'daemon.log');
     const node5LogPath = join(DEVNET_DIR, 'node5', 'daemon.log');
     const node1Config = readJson<RuntimeConfig>(join(DEVNET_DIR, 'node1', 'config.json'));
@@ -115,7 +115,7 @@ describe('ACK candidate isolation on devnet', () => {
     expect(edgeConfig.relay).toMatch(/^\/ip4\/127\.0\.0\.1\/tcp\//);
     expect(node1Log).toContain('Relay disabled (config.relay = "none")');
     for (const log of [node1Log, node5Log]) {
-      expect(log).not.toMatch(/ACK candidate peer (allowlist|preference): .*network config/);
+      expect(log).not.toMatch(/ACK candidate peer preference: .*network config/);
       for (const suffix of UNEXPECTED_TESTNET_SUFFIXES) {
         expect(log).not.toContain(suffix);
       }
@@ -151,7 +151,7 @@ describe('ACK candidate isolation on devnet', () => {
       connectedPeerIds,
       selfPeerId,
       knownCorePeerIds: new Set([devnetCoreIds[2]!, staleTestnetIds[0]!]),
-      ackCandidatePeerIds: devnetCoreIds,
+      preferredACKPeerIds: devnetCoreIds,
     });
 
     // Preference ordering, not exclusion: listed devnet cores fill the

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -895,25 +895,20 @@ export interface DKGAgentConfig {
   bootstrapPeers?: string[];
   /** Multiaddrs of relay nodes for NAT traversal. */
   relayPeers?: string[];
-  /**
-   * Peer IDs to rank first among ACK candidates for the selected
-   * chain/network (typically the network-config relays).
-   *
-   * Never an eligibility gate: this list must not exclude any connected
-   * peer from ACK candidacy (candidates are dialled concurrently, so the
-   * ranking itself is cosmetic today). The authoritative signer check is
-   * chain truth, enforced per collected ACK (operational-key purpose +
-   * active sharding-table membership, i.e. a staked core) and re-verified
-   * on-chain by the publish tx. Hard-gating candidacy on this static list
-   * capped the pool at the 4-6 bundled relays and made ACK quorum
-   * arithmetically unreachable when those specific relays were degraded
-   * or mid-upgrade (2026-07-07 Base/Gnosis mainnet incident). Stale
-   * foreign-network connections cannot produce a chain-valid ACK; they
-   * cost wasted dials, not quorum eligibility. (The identify-confirmed
-   * core shortcut — #1107 — still bounds fan-out, but it can never
-   * exclude connected peers from THIS list.)
-   */
+  /** Legacy ACK candidate allowlist. When set, unlisted connected peers are not dialed for ACKs. */
   ackCandidatePeerIds?: string[];
+  /**
+   * Peer IDs to rank first among ACK candidates without shrinking the pool
+   * (typically the network-config relays supplied by the bundled daemon).
+   *
+   * The authoritative signer check is chain truth, enforced per collected ACK
+   * (operational-key purpose + active sharding-table membership) and
+   * re-verified on-chain by the publish tx. Hard-gating candidacy on the static
+   * relay list capped the pool at the 4-6 bundled relays and made ACK quorum
+   * arithmetically unreachable when those specific relays were degraded or
+   * mid-upgrade (2026-07-07 Base/Gnosis mainnet incident).
+   */
+  preferredACKPeerIds?: string[];
   /** Multiaddrs to announce to the network (for VPS/cloud nodes with a public IP not on the interface). */
   announceAddresses?: string[];
   skills?: Array<{

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -896,12 +896,22 @@ export interface DKGAgentConfig {
   /** Multiaddrs of relay nodes for NAT traversal. */
   relayPeers?: string[];
   /**
-   * Peer IDs that are eligible ACK candidates for the selected chain/network.
+   * Peer IDs to rank first among ACK candidates for the selected
+   * chain/network (typically the network-config relays).
    *
-   * When set, ACK collection may still use identify-time `knownCorePeerIds`
-   * as a fast path, but the below-quorum fallback must not widen beyond this
-   * set. This keeps stale bootstrap/preferred-relay connections from other
-   * networks out of the StorageACK candidate pool.
+   * Never an eligibility gate: this list must not exclude any connected
+   * peer from ACK candidacy (candidates are dialled concurrently, so the
+   * ranking itself is cosmetic today). The authoritative signer check is
+   * chain truth, enforced per collected ACK (operational-key purpose +
+   * active sharding-table membership, i.e. a staked core) and re-verified
+   * on-chain by the publish tx. Hard-gating candidacy on this static list
+   * capped the pool at the 4-6 bundled relays and made ACK quorum
+   * arithmetically unreachable when those specific relays were degraded
+   * or mid-upgrade (2026-07-07 Base/Gnosis mainnet incident). Stale
+   * foreign-network connections cannot produce a chain-valid ACK; they
+   * cost wasted dials, not quorum eligibility. (The identify-confirmed
+   * core shortcut — #1107 — still bounds fan-out, but it can never
+   * exclude connected peers from THIS list.)
    */
   ackCandidatePeerIds?: string[];
   /** Multiaddrs to announce to the network (for VPS/cloud nodes with a public IP not on the interface). */

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1560,15 +1560,14 @@ export class DKGAgent extends DKGAgentBase {
    *
    * Fix: only trust the confirmed-core subset when it can actually
    * satisfy the quorum. Below that, return confirmed cores FIRST
-   * followed by the remaining connected ACK-eligible peers. On configured
-   * public networks the daemon supplies `ackCandidatePeerIds` from the
-   * selected network relays; the list ranks candidates but must NEVER
-   * exclude them. Signer validity is enforced per collected ACK against
-   * chain truth (operational key + sharding-table membership), so a stale
-   * foreign-network connection costs a wasted dial, while the former hard
-   * gate capped the pool at the bundled relay list and bricked publishing
-   * when those relays were degraded (2026-07-07 Base/Gnosis mainnet
-   * incident).
+   * followed by the remaining connected ACK-eligible peers. External callers
+   * can still set `ackCandidatePeerIds` as a true allowlist; configured public
+   * networks use `preferredACKPeerIds` for relay ranking without excluding
+   * connected non-relay cores. Signer validity is enforced per collected ACK
+   * against chain truth (operational key + sharding-table membership), so a
+   * stale foreign-network connection costs a wasted dial, while hard-gating on
+   * the bundled relay list bricked publishing when those relays were degraded
+   * (2026-07-07 Base/Gnosis mainnet incident).
    *
    * Folded-private publishes require `PROTOCOL_STORAGE_ACK_V2` because their
    * PublishIntent carries field 20 (`privateMerkleRoots`). Prefer peers that
@@ -1601,6 +1600,7 @@ export class DKGAgent extends DKGAgentBase {
       connectedPeers: peers.map(p => p.toString()),
       selfPeerId: this.peerId,
       ackCandidatePeerIds: this.config.ackCandidatePeerIds,
+      preferredACKPeerIds: this.config.preferredACKPeerIds,
       knownCorePeerIds: this.knownCorePeerIds,
       knownCorePeerIdsV2: this.knownCorePeerIdsV2,
       requiredACKs: this.lastKnownRequiredACKs ?? DEFAULT_REQUIRED_ACKS,

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1562,18 +1562,27 @@ export class DKGAgent extends DKGAgentBase {
    * satisfy the quorum. Below that, return confirmed cores FIRST
    * followed by the remaining connected ACK-eligible peers. On configured
    * public networks the daemon supplies `ackCandidatePeerIds` from the
-   * selected network relays, so stale preferred/bootstrap connections from
-   * another network cannot enter the ACK round. Dev/no-network configs keep
-   * the legacy all-connected fallback.
+   * selected network relays; the list ranks candidates but must NEVER
+   * exclude them. Signer validity is enforced per collected ACK against
+   * chain truth (operational key + sharding-table membership), so a stale
+   * foreign-network connection costs a wasted dial, while the former hard
+   * gate capped the pool at the bundled relay list and bricked publishing
+   * when those relays were degraded (2026-07-07 Base/Gnosis mainnet
+   * incident).
    *
    * Folded-private publishes require `PROTOCOL_STORAGE_ACK_V2` because their
    * PublishIntent carries field 20 (`privateMerkleRoots`). Prefer peers that
    * explicitly advertise V2, but do not make peer-store protocol metadata the
    * only gate: StorageACK handlers register after identity resolution, often
    * after peers are already connected, and libp2p identify does not always
-   * refresh the stored protocol list. The actual compatibility gate remains
-   * the V2 wire protocol passed to `sendP2P`; V1-only peers fail negotiation
-   * and cannot silently sign against a public-only root.
+   * refresh the stored protocol list. NOTE the wire protocol is not a
+   * version gate either — nodes have registered the V2 protocol id (for
+   * the LU-11 chunked-ciphertext intent) since v10.0.0-rc.15, so a
+   * pre-field-20 core ACCEPTS the V2 dial, silently drops
+   * `privateMerkleRoots` on decode, and fails its root recompute (decline
+   * or stream abort) rather than failing negotiation. Only the
+   * collector-side signature/root checks and on-chain ACK verification
+   * are authoritative.
    *
    * Codex review (PR #1107): the quorum threshold here must track the
    * CHAIN's runtime `requiredACKs` (ParametersStorage

--- a/packages/agent/test/ack-candidate-pool.test.ts
+++ b/packages/agent/test/ack-candidate-pool.test.ts
@@ -18,7 +18,7 @@ type AgentInternals = {
     };
   };
   peerId: string;
-  config: { ackCandidatePeerIds?: string[] };
+  config: { ackCandidatePeerIds?: string[]; preferredACKPeerIds?: string[] };
   knownCorePeerIds: Set<string>;
   knownCorePeerIdsV2: Set<string>;
   lastKnownRequiredACKs?: number;
@@ -34,12 +34,14 @@ async function buildAgent(opts: {
   connected: string[];
   lastKnownRequiredACKs?: number;
   ackCandidatePeerIds?: string[];
+  preferredACKPeerIds?: string[];
 }): Promise<AgentInternals> {
   const agent = await DKGAgent.create({
     name: 'AckPoolProbe',
     store: new OxigraphStore(),
     chainAdapter: new MockChainAdapter(),
     ackCandidatePeerIds: opts.ackCandidatePeerIds,
+    preferredACKPeerIds: opts.preferredACKPeerIds,
   });
   const internals = agent as unknown as AgentInternals;
   internals.node = {
@@ -91,12 +93,22 @@ describe('getACKCandidatePeers — quorum-aware confirmed-core shortcut (#1093 /
     expect(at.getACKCandidatePeers()).toEqual(CORE);
   });
 
+  it('ackCandidatePeerIds remains an allowlist for callers that intentionally restrict candidacy', async () => {
+    const a = await buildAgent({
+      confirmedCores: [CORE[0], 'untrusted-peer'],
+      connected: [CORE[0], 'untrusted-peer'],
+      ackCandidatePeerIds: [CORE[0]],
+    });
+
+    expect(a.getACKCandidatePeers()).toEqual([CORE[0]]);
+  });
+
   it('a configured ACK preference list orders listed peers first but never excludes connected peers (2026-07-07 incident)', async () => {
     const foreign = ['testnet-core-1', 'testnet-core-2', 'testnet-core-3'];
     const a = await buildAgent({
       confirmedCores: [CORE[2]],
       connected: [CORE[2], ...foreign, CORE[0], CORE[1], CORE[3]],
-      ackCandidatePeerIds: CORE,
+      preferredACKPeerIds: CORE,
     });
 
     // Listed peers are preferred within each tier (confirmed cores, then
@@ -120,7 +132,7 @@ describe('getACKCandidatePeers — quorum-aware confirmed-core shortcut (#1093 /
     const a = await buildAgent({
       confirmedCores: [relays[0], relays[1], ...stakedCores],
       connected: [relays[0], relays[1], ...stakedCores],
-      ackCandidatePeerIds: relays,
+      preferredACKPeerIds: relays,
     });
 
     const out = a.getACKCandidatePeers();
@@ -134,7 +146,7 @@ describe('getACKCandidatePeers — quorum-aware confirmed-core shortcut (#1093 /
     const a = await buildAgent({
       confirmedCores: [...relays, ...upgraded],
       connected: [...upgraded, ...relays],
-      ackCandidatePeerIds: relays,
+      preferredACKPeerIds: relays,
     });
     for (const id of upgraded) a.knownCorePeerIdsV2.add(id);
 

--- a/packages/agent/test/ack-candidate-pool.test.ts
+++ b/packages/agent/test/ack-candidate-pool.test.ts
@@ -91,7 +91,7 @@ describe('getACKCandidatePeers — quorum-aware confirmed-core shortcut (#1093 /
     expect(at.getACKCandidatePeers()).toEqual(CORE);
   });
 
-  it('with a configured ACK allowlist, below-quorum fallback excludes connected foreign-network peers', async () => {
+  it('a configured ACK preference list orders listed peers first but never excludes connected peers (2026-07-07 incident)', async () => {
     const foreign = ['testnet-core-1', 'testnet-core-2', 'testnet-core-3'];
     const a = await buildAgent({
       confirmedCores: [CORE[2]],
@@ -99,7 +99,51 @@ describe('getACKCandidatePeers — quorum-aware confirmed-core shortcut (#1093 /
       ackCandidatePeerIds: CORE,
     });
 
-    expect(a.getACKCandidatePeers()).toEqual([CORE[2], CORE[0], CORE[1], CORE[3]]);
+    // Listed peers are preferred within each tier (confirmed cores, then
+    // rest), but foreign/unlisted peers stay dialable: signer validity is
+    // chain truth (sharding-table membership per collected ACK), and a
+    // hard gate here capped the mainnet pool at the bundled relay list.
+    expect(a.getACKCandidatePeers()).toEqual([
+      CORE[2],
+      CORE[0], CORE[1], CORE[3],
+      ...foreign,
+    ]);
+  });
+
+  it('staked cores outside the preference list can still complete quorum when listed relays are degraded (2026-07-07 incident)', async () => {
+    // Base mainnet shape: preference list = 4 bundled relays, of which only
+    // 2 are connected/healthy; 3 upgraded non-relay staked cores are
+    // connected. The old hard filter returned only [relay-1, relay-2] and
+    // made the 3-ACK quorum arithmetically unreachable.
+    const relays = ['relay-1', 'relay-2', 'relay-3', 'relay-4'];
+    const stakedCores = ['staked-core-5', 'staked-core-6', 'staked-core-7'];
+    const a = await buildAgent({
+      confirmedCores: [relays[0], relays[1], ...stakedCores],
+      connected: [relays[0], relays[1], ...stakedCores],
+      ackCandidatePeerIds: relays,
+    });
+
+    const out = a.getACKCandidatePeers();
+    expect(out).toEqual([relays[0], relays[1], ...stakedCores]);
+    expect(out.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('V2 folded-private rounds keep unlisted V2-advertising cores dialable, listed peers first within each tier', async () => {
+    const relays = ['relay-1', 'relay-2'];
+    const upgraded = ['staked-core-5', 'staked-core-6', 'staked-core-7'];
+    const a = await buildAgent({
+      confirmedCores: [...relays, ...upgraded],
+      connected: [...upgraded, ...relays],
+      ackCandidatePeerIds: relays,
+    });
+    for (const id of upgraded) a.knownCorePeerIdsV2.add(id);
+
+    // v2Advertised tier first (none listed → connection order), then the
+    // remaining confirmed cores (both listed).
+    expect(a.getACKCandidatePeers(PROTOCOL_STORAGE_ACK_V2)).toEqual([
+      ...upgraded,
+      ...relays,
+    ]);
   });
 
   it('runtime quorum below default (2): 2 confirmed cores already satisfy it', async () => {

--- a/packages/agent/test/publish-jsonld.test.ts
+++ b/packages/agent/test/publish-jsonld.test.ts
@@ -27,6 +27,7 @@ afterAll(async () => {
 const agents: DKGAgent[] = [];
 const stores: TripleStore[] = [];
 const tempDataDirs: string[] = [];
+const CHAIN_JSONLD_TIMEOUT_MS = 120_000;
 
 async function createTempDataDir(prefix: string): Promise<string> {
   const dir = await mkdtemp(join(tmpdir(), prefix));
@@ -95,7 +96,7 @@ describe('publishJsonLd', () => {
     if (result.type === 'boolean') {
       expect(result.value).toBe(true);
     }
-  }, 30_000);
+  }, CHAIN_JSONLD_TIMEOUT_MS);
 
   it('bare JSON-LD doc defaults to private quads (with synthetic public anchor)', async () => {
     const { agent, store } = await createAgent('BarePrivateBot');
@@ -122,7 +123,7 @@ describe('publishJsonLd', () => {
     if (publicResult.type === 'boolean') {
       expect(publicResult.value).toBe(true);
     }
-  }, 15000);
+  }, CHAIN_JSONLD_TIMEOUT_MS);
 
   it('envelope { public } puts quads in public set', async () => {
     const { agent, store } = await createAgent('PubEnvBot');
@@ -150,7 +151,7 @@ describe('publishJsonLd', () => {
     if (askResult.type === 'boolean') {
       expect(askResult.value).toBe(true);
     }
-  }, 15000);
+  }, CHAIN_JSONLD_TIMEOUT_MS);
 
   it('envelope { public, private } splits quads correctly', async () => {
     const { agent, store } = await createAgent('SplitBot');
@@ -185,7 +186,7 @@ describe('publishJsonLd', () => {
     if (privateGraph.type === 'boolean') {
       expect(privateGraph.value).toBe(true);
     }
-  }, 15000);
+  }, CHAIN_JSONLD_TIMEOUT_MS);
 
   it('private-only envelope generates synthetic public anchor', async () => {
     const { agent, store } = await createAgent('PrivOnlyBot');
@@ -211,7 +212,7 @@ describe('publishJsonLd', () => {
     );
     expect(anchorResult.type).toBe('boolean');
     if (anchorResult.type === 'boolean') expect(anchorResult.value).toBe(true);
-  }, 15000);
+  }, CHAIN_JSONLD_TIMEOUT_MS);
 
   it('preserves typed literals in quad objects', async () => {
     const { agent, store } = await createAgent('LiteralBot');
@@ -240,7 +241,7 @@ describe('publishJsonLd', () => {
       expect(dateResult.bindings.length).toBeGreaterThan(0);
       expect(dateResult.bindings[0].d).toContain('2024-01-01T00:00:00Z');
     }
-  }, 15000);
+  }, CHAIN_JSONLD_TIMEOUT_MS);
 
   it('throws on JSON-LD that produces no quads', async () => {
     const { agent } = await createAgent('ErrorBot');
@@ -249,7 +250,7 @@ describe('publishJsonLd', () => {
     await expect(agent.publish('error-test', {})).rejects.toThrow(
       'JSON-LD document produced no RDF quads',
     );
-  }, 15000);
+  }, CHAIN_JSONLD_TIMEOUT_MS);
 
   it('existing Quad[] publish still works unchanged', async () => {
     const { agent } = await createAgent('QuadBot');
@@ -260,7 +261,7 @@ describe('publishJsonLd', () => {
       { subject: 'did:dkg:test:X', predicate: 'http://schema.org/name', object: '"X"', graph: '' },
     ]);
     expect(result.status).toBe('confirmed');
-  }, 15000);
+  }, CHAIN_JSONLD_TIMEOUT_MS);
 
   it('async private-only JSON-LD anchors the real private root and enqueues a Lift job', async () => {
     const { agent, store } = await createAgent('AsyncPrivateOnlyBot');
@@ -307,7 +308,7 @@ describe('publishJsonLd', () => {
     );
     expect(privatePayload.type).toBe('boolean');
     if (privatePayload.type === 'boolean') expect(privatePayload.value).toBe(false);
-  }, 15000);
+  }, CHAIN_JSONLD_TIMEOUT_MS);
 
   it('async bare JSON-LD writes only an anchor in shared/private graphs before lift', async () => {
     const { agent, store } = await createAgent('AsyncBarePrivateBot');
@@ -351,7 +352,7 @@ describe('publishJsonLd', () => {
     );
     expect(privatePayload.type).toBe('boolean');
     if (privatePayload.type === 'boolean') expect(privatePayload.value).toBe(false);
-  }, 15000);
+  }, CHAIN_JSONLD_TIMEOUT_MS);
 
   // OT-RFC-43 §F2 — the async-lift seal now allocates + binds the per-author
   // reservedKaId, so the on-chain mint accepts it (no KaIdNamespaceMismatch) and
@@ -415,7 +416,7 @@ describe('publishJsonLd', () => {
     const onChainAuthor = await chainAdapter.getLatestMerkleRootAuthor(BigInt(kaId));
     expect(onChainAuthor.toLowerCase()).toBe(tenant.agentAddress.toLowerCase());
     expect(onChainAuthor.toLowerCase()).not.toBe(publisherAddress.toLowerCase());
-  }, 60_000);
+  }, CHAIN_JSONLD_TIMEOUT_MS);
 
   // OT-RFC-43 §F2 — the async-lift seal binds a per-author reservedKaId; recovery
   // rebuilds the digest with that 5th field (read off the persisted seal).
@@ -487,7 +488,7 @@ describe('publishJsonLd', () => {
       }).serialized,
     );
     expect(recoveredFromSeal.toLowerCase()).toBe(tenant.agentAddress.toLowerCase());
-  }, 30_000);
+  }, CHAIN_JSONLD_TIMEOUT_MS);
 
   it('async publish rejects authorAgentAddress for unknown / self-sovereign agents', async () => {
     // Mirrors the sync `assertionFinalize` error semantics: the daemon
@@ -532,7 +533,7 @@ describe('publishJsonLd', () => {
         { localOnly: true, authorAgentAddress: selfSovereign.agentAddress },
       ),
     ).rejects.toThrow(/self-sovereign/);
-  }, 30_000);
+  }, CHAIN_JSONLD_TIMEOUT_MS);
 
   // OT-RFC-43 §F2 — the async-lift seal is built at enqueue (agent canonicalizes +
   // signs over the resolved slice's merkle + the allocated reservedKaId).
@@ -571,7 +572,7 @@ describe('publishJsonLd', () => {
     expect(BigInt(seal!.reservedKaId!) >> 96n).toBe(
       BigInt(ethers.getAddress(seal!.authorAddress)),
     );
-  }, 30_000);
+  }, CHAIN_JSONLD_TIMEOUT_MS);
 
   it('async publish on a non-V10 chain enqueues without a seal (no on-chain publish to seal for)', async () => {
     // Seal only built when chain is V10-ready AND CG has on-chain id. Non-V10 → publisher takes tentative-only path.
@@ -597,7 +598,7 @@ describe('publishJsonLd', () => {
     const asyncPublisher = new TripleStoreAsyncLiftPublisher(store);
     const job = await asyncPublisher.getStatus(captureID);
     expect(expectRawLiftRequest(job).seal).toBeUndefined();
-  }, 30_000);
+  }, CHAIN_JSONLD_TIMEOUT_MS);
 
   // OT-RFC-43 §F2 — backstop: the WM/SWM write is committed BEFORE seal-building and
   // publishAsync has no outer rollback, so an unexpected throw inside buildAsyncLiftSeal
@@ -636,7 +637,7 @@ describe('publishJsonLd', () => {
     // Sealless: the lift carries no seal, so the publisher stages WM/SWM without an
     // on-chain VM anchor (exactly the prior always-sealless async behaviour).
     expect(expectRawLiftRequest(job).seal).toBeUndefined();
-  }, 30_000);
+  }, CHAIN_JSONLD_TIMEOUT_MS);
 
   // OT-RFC-43 §F2 — the sealless backstop is ONLY for the implicit machine-capture
   // path. An EXPLICIT authorship request (custodial authorAgentAddress / self-sovereign
@@ -667,7 +668,7 @@ describe('publishJsonLd', () => {
         { localOnly: true, authorAgentAddress: tenant.agentAddress },
       ),
     ).rejects.toThrow(/simulated signer failure/);
-  }, 30_000);
+  }, CHAIN_JSONLD_TIMEOUT_MS);
 
   // OT-RFC-43 §F2 — V10-ready + on-chain CG ⇒ the agent signs the canonical merkle
   // (with the allocated reservedKaId) at enqueue; the publisher consumes it verbatim.
@@ -696,7 +697,7 @@ describe('publishJsonLd', () => {
     const request = expectRawLiftRequest(job);
     expect(request.seal).toBeDefined();
     expect(request.seal?.merkleRoot).toMatch(/^0x[0-9a-f]{64}$/i);
-  }, 30_000);
+  }, CHAIN_JSONLD_TIMEOUT_MS);
 
   // OT-RFC-43 §F2 — the EPCIS/Kafka capture shape (private-only) earns a seal too:
   // the merkle covers the private root, and a reservedKaId is allocated + bound.
@@ -720,7 +721,7 @@ describe('publishJsonLd', () => {
     const asyncPublisher = new TripleStoreAsyncLiftPublisher(store);
     const job = await asyncPublisher.getStatus(captureID);
     expect(expectRawLiftRequest(job).seal).toBeDefined();
-  }, 30_000);
+  }, CHAIN_JSONLD_TIMEOUT_MS);
 
   // OT-RFC-43 §F2 — disk-externalized public snapshots still resolve into the seal's
   // merkle at enqueue, so the seal (with its reservedKaId) is built as usual.
@@ -766,7 +767,7 @@ describe('publishJsonLd', () => {
     const request = expectRawLiftRequest(job);
     expect(request.seal).toBeDefined();
     expect(request.seal?.merkleRoot).toMatch(/^0x[0-9a-f]{64}$/i);
-  }, 30_000);
+  }, CHAIN_JSONLD_TIMEOUT_MS);
 
   it('async publish accepts preSignedAuthorAttestation and threads it byte-for-byte into LiftRequest.seal', async () => {
     // Sync parity: caller pre-signs off-node, agent threads bytes verbatim. Publisher preflight validates at processNext.
@@ -817,7 +818,7 @@ describe('publishJsonLd', () => {
     expect(seal?.schemeVersion).toBe(1);
     // §F2 — the attested reservedKaId is threaded byte-for-byte onto the seal.
     expect(seal?.reservedKaId).toBe(`${presignedReservedKaId}`);
-  }, 30_000);
+  }, CHAIN_JSONLD_TIMEOUT_MS);
 
   it('async publish rejects preSignedAuthorAttestation + authorAgentAddress as mutually exclusive', async () => {
     // Sync parity: pick one signing path (caller-provided seal OR daemon custodial).
@@ -853,7 +854,7 @@ describe('publishJsonLd', () => {
         },
       ),
     ).rejects.toThrow(/mutually exclusive/);
-  }, 15_000);
+  }, CHAIN_JSONLD_TIMEOUT_MS);
 
   // OT-RFC-43 §F2 — the callback receives typed data that already binds the
   // allocated reservedKaId; recovery rebuilds the digest with that 5th field.
@@ -942,7 +943,7 @@ describe('publishJsonLd', () => {
     expect(recovered.toLowerCase()).not.toBe(
       new ethers.Wallet(HARDHAT_KEYS.CORE_OP).address.toLowerCase(),
     );
-  }, 30_000);
+  }, CHAIN_JSONLD_TIMEOUT_MS);
 
   it('async publish rejects authorSignTypedData without authorAgentAddress', async () => {
     // Callback alone has no address to fill into seal.authorAddress — mutex fail-fast.
@@ -970,7 +971,7 @@ describe('publishJsonLd', () => {
         },
       ),
     ).rejects.toThrow(/authorSignTypedData requires authorAgentAddress/);
-  }, 15_000);
+  }, CHAIN_JSONLD_TIMEOUT_MS);
 
   // OT-RFC-43 §F2 — the self-sovereign callback signs over the bound reservedKaId,
   // so the publisher mints exactly that id and KC.author == the self-sovereign agent.
@@ -1043,7 +1044,7 @@ describe('publishJsonLd', () => {
     const onChainAuthor = await chainAdapter.getLatestMerkleRootAuthor(BigInt(kaId));
     expect(onChainAuthor.toLowerCase()).toBe(selfSov.agentAddress.toLowerCase());
     expect(onChainAuthor.toLowerCase()).not.toBe(publisherAddress.toLowerCase());
-  }, 60_000);
+  }, CHAIN_JSONLD_TIMEOUT_MS);
 
   it('async publish threads opts.priorVersion into LiftRequest.priorVersion', async () => {
     // `priorVersion` threads through enqueue unchanged for MUTATE/REVOKE transitions.
@@ -1073,7 +1074,7 @@ describe('publishJsonLd', () => {
     const request = expectRawLiftRequest(job);
     expect(request.priorVersion).toBe('did:dkg:mock:31337/0xabc/7');
     expect(request.transitionType).toBe('MUTATE');
-  }, 15_000);
+  }, CHAIN_JSONLD_TIMEOUT_MS);
 
   it('async publish threads opts.entityProofs into LiftRequest.entityProofs', async () => {
     // V10 selective-disclosure flag persists through enqueue.
@@ -1100,7 +1101,7 @@ describe('publishJsonLd', () => {
     const asyncPublisher = new TripleStoreAsyncLiftPublisher(store);
     const job = await asyncPublisher.getStatus(captureID);
     expect(expectRawLiftRequest(job).entityProofs).toBe(true);
-  }, 15_000);
+  }, CHAIN_JSONLD_TIMEOUT_MS);
 
   it('async publish threads opts.publisherNodeIdentityIdOverride (bigint) into LiftRequest (stringified)', async () => {
     // RFC-001 §4 attribution override. BigInt → string for JSON persistence; mapper parses back.
@@ -1127,7 +1128,7 @@ describe('publishJsonLd', () => {
     const asyncPublisher = new TripleStoreAsyncLiftPublisher(store);
     const job = await asyncPublisher.getStatus(captureID);
     expect(expectRawLiftRequest(job).publisherNodeIdentityIdOverride).toBe('42');
-  }, 15_000);
+  }, CHAIN_JSONLD_TIMEOUT_MS);
 
   it('async publish preserves publisherNodeIdentityIdOverride === 0n (mode d "no attribution")', async () => {
     // RFC-001 §4 mode d: explicit `0n` survives (≠ undefined which means "use daemon identity").
@@ -1154,7 +1155,7 @@ describe('publishJsonLd', () => {
     const asyncPublisher = new TripleStoreAsyncLiftPublisher(store);
     const job = await asyncPublisher.getStatus(captureID);
     expect(expectRawLiftRequest(job).publisherNodeIdentityIdOverride).toBe('0');
-  }, 15_000);
+  }, CHAIN_JSONLD_TIMEOUT_MS);
 
   it('async publish enqueues sealless when no signer is available (sync parity)', async () => {
     // Chain-prereq failures downgrade to sealless enqueue. Publisher decides at processNext.
@@ -1186,7 +1187,7 @@ describe('publishJsonLd', () => {
     } finally {
       publisher.publisherFallbackAuthorAddress = original;
     }
-  }, 15_000);
+  }, CHAIN_JSONLD_TIMEOUT_MS);
 
   // OT-RFC-43 §F2 — the async-lift seal's publisher-fallback signer path mirrors
   // sync `assertionFinalize`: both fallback + sign are called WITHOUT a cgId.
@@ -1238,7 +1239,7 @@ describe('publishJsonLd', () => {
       publisher.publisherFallbackAuthorAddress = originalFallback;
       publisher.signAuthorAttestationAsPublisher = originalSign;
     }
-  }, 30_000);
+  }, CHAIN_JSONLD_TIMEOUT_MS);
 
   it('async publish enqueues sealless when CG is not registered on-chain (sync parity)', async () => {
     // CG without on-chain id → no seal, publisher goes tentative (matches sync `agent.publish`).
@@ -1262,7 +1263,7 @@ describe('publishJsonLd', () => {
     const asyncPublisher = new TripleStoreAsyncLiftPublisher(store);
     const job = await asyncPublisher.getStatus(captureID);
     expect(expectRawLiftRequest(job).seal).toBeUndefined();
-  }, 15_000);
+  }, CHAIN_JSONLD_TIMEOUT_MS);
 
   it('async publish seal reflects subtracted set when canonical root already confirmed (codex PR #455 #3)', async () => {
     // Agent must mirror publisher's `subtractFinalizedExactQuads` so both compute the same merkle.
@@ -1305,7 +1306,7 @@ describe('publishJsonLd', () => {
     // If subtraction is removed from the agent pipeline, the seal
     // would be present here.
     expect(expectRawLiftRequest(job).seal).toBeUndefined();
-  }, 20_000);
+  }, CHAIN_JSONLD_TIMEOUT_MS);
 
   it('async publish records and resolves subGraphName for staged public and private data', async () => {
     const { agent, store } = await createAgent('AsyncSubGraphBot');
@@ -1338,5 +1339,5 @@ describe('publishJsonLd', () => {
     const request = expectRawLiftRequest(job);
     expect(request.subGraphName).toBe('research');
     expect(request.roots).toContain(root);
-  }, 15000);
+  }, CHAIN_JSONLD_TIMEOUT_MS);
 });

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -640,43 +640,15 @@ export function orderACKCandidatePeerIds(input: {
   connectedPeerIds: readonly string[];
   selfPeerId: string;
   knownCorePeerIds?: ReadonlySet<string>;
-  ackCandidatePeerIds?: readonly string[];
+  preferredACKPeerIds?: readonly string[];
 }): string[] {
-  const connected = input.connectedPeerIds.filter((id) => id !== input.selfPeerId);
-  const preferredACKPeers = new Set(
-    (input.ackCandidatePeerIds ?? []).map((id) => id.trim()).filter((id) => id.length > 0),
-  );
-  const knownCorePeerIds = input.knownCorePeerIds;
-
-  if (preferredACKPeers.size > 0) {
-    // Ranking only — never an eligibility gate. Signer validity is chain
-    // truth, enforced per collected ACK (operational key + sharding-table
-    // membership); excluding connected-but-unlisted cores here capped the
-    // pool at the static relay list and made ACK quorum unreachable on
-    // mainnet (2026-07-07 Base/Gnosis incident). Same non-exclusion
-    // contract as `selectACKCandidatePeers` in
-    // @origintrail-official/dkg-publisher (which the daemon actually uses
-    // for ACK rounds — this helper is the devnet-regression surface and
-    // keeps simpler two-tier ordering, no V2/quorum handling).
-    const preferListed = (ids: string[]): string[] => [
-      ...ids.filter((id) => preferredACKPeers.has(id)),
-      ...ids.filter((id) => !preferredACKPeers.has(id)),
-    ];
-    const confirmed = knownCorePeerIds
-      ? connected.filter((id) => knownCorePeerIds.has(id))
-      : [];
-    const rest = knownCorePeerIds
-      ? connected.filter((id) => !knownCorePeerIds.has(id))
-      : connected;
-    return [...preferListed(confirmed), ...preferListed(rest)];
-  }
-
-  if (knownCorePeerIds && knownCorePeerIds.size > 0) {
-    const filtered = connected.filter((id) => knownCorePeerIds.has(id));
-    if (filtered.length > 0) return filtered;
-  }
-
-  return connected;
+  return selectACKCandidatePeers({
+    connectedPeers: input.connectedPeerIds,
+    selfPeerId: input.selfPeerId,
+    knownCorePeerIds: input.knownCorePeerIds,
+    preferredACKPeerIds: input.preferredACKPeerIds,
+    requiredACKs: Number.MAX_SAFE_INTEGER,
+  });
 }
 
 export const CHAIN_FULL_SCAN_EVERY = 48; // about once per day at the 30-minute cadence
@@ -1404,13 +1376,13 @@ export async function runDaemonInner(
     usingNetworkRelays = true;
     log(`Using relay(s) from network config (${network.networkName})`);
   }
-  const ackCandidatePeerIds = resolveACKCandidatePeerIds({
+  const preferredACKPeerIds = resolveACKCandidatePeerIds({
     usingNetworkRelays,
     networkRelays: network?.relays,
   });
-  if (ackCandidatePeerIds.length > 0) {
+  if (preferredACKPeerIds.length > 0) {
     log(
-      `ACK candidate peer preference: ${ackCandidatePeerIds.length} relay peer(s) from network config (${network?.networkName ?? "unknown"}) ranked first; candidacy is not restricted — all connected peers stay eligible`,
+      `ACK candidate peer preference: ${preferredACKPeerIds.length} relay peer(s) from network config (${network?.networkName ?? "unknown"}) ranked first; candidacy is not restricted — all connected peers stay eligible`,
     );
   }
 
@@ -1542,7 +1514,7 @@ export async function runDaemonInner(
     dataDir: dkgDir(),
     bootstrapPeers: config.bootstrapPeers,
     relayPeers,
-    ackCandidatePeerIds: ackCandidatePeerIds.length > 0 ? ackCandidatePeerIds : undefined,
+    preferredACKPeerIds: preferredACKPeerIds.length > 0 ? preferredACKPeerIds : undefined,
     announceAddresses: config.announceAddresses,
     nodeRole: role,
     relayServerCapacity: config.relayServerCapacity,
@@ -2011,7 +1983,7 @@ export async function runDaemonInner(
                   knownCorePeerIdsV2,
                   requiredACKs: (agent as any).lastKnownRequiredACKs ?? DEFAULT_REQUIRED_ACKS,
                   protocol,
-                  ackCandidatePeerIds,
+                  preferredACKPeerIds,
                 });
               },
               log,

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -643,22 +643,32 @@ export function orderACKCandidatePeerIds(input: {
   ackCandidatePeerIds?: readonly string[];
 }): string[] {
   const connected = input.connectedPeerIds.filter((id) => id !== input.selfPeerId);
-  const allowedACKPeers = new Set(
+  const preferredACKPeers = new Set(
     (input.ackCandidatePeerIds ?? []).map((id) => id.trim()).filter((id) => id.length > 0),
   );
-  const eligible = allowedACKPeers.size > 0
-    ? connected.filter((id) => allowedACKPeers.has(id))
-    : connected;
   const knownCorePeerIds = input.knownCorePeerIds;
 
-  if (allowedACKPeers.size > 0) {
+  if (preferredACKPeers.size > 0) {
+    // Ranking only — never an eligibility gate. Signer validity is chain
+    // truth, enforced per collected ACK (operational key + sharding-table
+    // membership); excluding connected-but-unlisted cores here capped the
+    // pool at the static relay list and made ACK quorum unreachable on
+    // mainnet (2026-07-07 Base/Gnosis incident). Same non-exclusion
+    // contract as `selectACKCandidatePeers` in
+    // @origintrail-official/dkg-publisher (which the daemon actually uses
+    // for ACK rounds — this helper is the devnet-regression surface and
+    // keeps simpler two-tier ordering, no V2/quorum handling).
+    const preferListed = (ids: string[]): string[] => [
+      ...ids.filter((id) => preferredACKPeers.has(id)),
+      ...ids.filter((id) => !preferredACKPeers.has(id)),
+    ];
     const confirmed = knownCorePeerIds
-      ? eligible.filter((id) => knownCorePeerIds.has(id))
+      ? connected.filter((id) => knownCorePeerIds.has(id))
       : [];
     const rest = knownCorePeerIds
-      ? eligible.filter((id) => !knownCorePeerIds.has(id))
-      : eligible;
-    return [...confirmed, ...rest];
+      ? connected.filter((id) => !knownCorePeerIds.has(id))
+      : connected;
+    return [...preferListed(confirmed), ...preferListed(rest)];
   }
 
   if (knownCorePeerIds && knownCorePeerIds.size > 0) {
@@ -1400,7 +1410,7 @@ export async function runDaemonInner(
   });
   if (ackCandidatePeerIds.length > 0) {
     log(
-      `ACK candidate peer allowlist: ${ackCandidatePeerIds.length} peer(s) from network config (${network?.networkName ?? "unknown"})`,
+      `ACK candidate peer preference: ${ackCandidatePeerIds.length} relay peer(s) from network config (${network?.networkName ?? "unknown"}) ranked first; candidacy is not restricted — all connected peers stay eligible`,
     );
   }
 

--- a/packages/cli/test/preferred-relays.test.ts
+++ b/packages/cli/test/preferred-relays.test.ts
@@ -212,16 +212,24 @@ describe('resolveACKCandidatePeerIds', () => {
 });
 
 describe('orderACKCandidatePeerIds', () => {
-  it('filters daemon async ACK fallback to active-network candidates when an allowlist is configured', () => {
+  it('orders daemon async ACK candidates preference-first without excluding connected peers (2026-07-07 incident)', () => {
     const base = ['base-core-1', 'base-core-2', 'base-core-3', 'base-core-4'];
     const testnet = ['testnet-core-1', 'testnet-core-2', 'testnet-core-3'];
 
+    // Tiers: confirmed cores (listed first), then the rest (listed first).
+    // Foreign-network peers rank last but stay dialable — the hard filter
+    // this replaces capped the mainnet pool at the bundled relay list and
+    // made ACK quorum unreachable when those relays were degraded.
     expect(orderACKCandidatePeerIds({
       connectedPeerIds: ['self', base[2], ...testnet, base[0], base[1], base[3]],
       selfPeerId: 'self',
       knownCorePeerIds: new Set([base[2], testnet[0]]),
       ackCandidatePeerIds: base,
-    })).toEqual([base[2], base[0], base[1], base[3]]);
+    })).toEqual([
+      base[2], testnet[0],
+      base[0], base[1], base[3],
+      testnet[1], testnet[2],
+    ]);
   });
 
   it('preserves legacy all-connected fallback when no ACK allowlist is configured', () => {

--- a/packages/cli/test/preferred-relays.test.ts
+++ b/packages/cli/test/preferred-relays.test.ts
@@ -180,7 +180,7 @@ describe('ACK peer-id extraction from network relays', () => {
 });
 
 describe('resolveACKCandidatePeerIds', () => {
-  it('uses network relay IDs as ACK allowlist when relays are enabled', () => {
+  it('uses network relay IDs as ACK preference list when relays are enabled', () => {
     expect(resolveACKCandidatePeerIds({
       usingNetworkRelays: true,
       networkRelays: [
@@ -224,7 +224,7 @@ describe('orderACKCandidatePeerIds', () => {
       connectedPeerIds: ['self', base[2], ...testnet, base[0], base[1], base[3]],
       selfPeerId: 'self',
       knownCorePeerIds: new Set([base[2], testnet[0]]),
-      ackCandidatePeerIds: base,
+      preferredACKPeerIds: base,
     })).toEqual([
       base[2], testnet[0],
       base[0], base[1], base[3],
@@ -232,7 +232,7 @@ describe('orderACKCandidatePeerIds', () => {
     ]);
   });
 
-  it('preserves legacy all-connected fallback when no ACK allowlist is configured', () => {
+  it('preserves legacy all-connected fallback when no ACK preference list is configured', () => {
     expect(orderACKCandidatePeerIds({
       connectedPeerIds: ['self', 'edge-1', 'edge-2'],
       selfPeerId: 'self',

--- a/packages/publisher/src/ack-peer-selection.ts
+++ b/packages/publisher/src/ack-peer-selection.ts
@@ -2,7 +2,10 @@ import { PROTOCOL_STORAGE_ACK_V2 } from '@origintrail-official/dkg-core';
 
 export interface ACKCandidatePeerSelectionInput {
   connectedPeers: readonly string[];
+  /** Legacy eligibility allowlist. When set, unlisted connected peers are not ACK candidates. */
   ackCandidatePeerIds?: readonly string[];
+  /** Preference-only ranking list. Listed peers are ordered first within each tier but never gate eligibility. */
+  preferredACKPeerIds?: readonly string[];
   knownCorePeerIds?: ReadonlySet<string>;
   knownCorePeerIdsV2?: ReadonlySet<string>;
   requiredACKs: number;
@@ -10,75 +13,95 @@ export interface ACKCandidatePeerSelectionInput {
   selfPeerId?: string;
 }
 
-export function selectACKCandidatePeers(input: ACKCandidatePeerSelectionInput): string[] {
-  const connected = input.connectedPeers.filter((id) => id !== input.selfPeerId);
-  const preferredACKPeers = new Set(
-    (input.ackCandidatePeerIds ?? []).map((id) => id.trim()).filter((id) => id.length > 0),
-  );
-  // `ackCandidatePeerIds` never gates eligibility — it only orders the
-  // returned array (listed peers first within each tier). The ordering is
-  // cosmetic today: ACKCollector dials every candidate concurrently, so
-  // the effective change vs. the PR #1482 hard filter is precisely the
-  // un-filtering. The authoritative "may this peer sign?" check is chain
-  // truth, enforced per collected ACK (operational-key purpose + active
-  // sharding-table membership — i.e. a staked core; see
-  // `verifyACKIdentityDetailed`) and re-verified on-chain by the publish
-  // tx itself. Hard-filtering candidacy to the static network-config
-  // relay list capped the pool at 4-6 specific peers and made quorum
-  // arithmetically unreachable whenever enough of those relays were
-  // degraded or mid-upgrade — the 2026-07-07 Base/Gnosis mainnet ACK
-  // outage — while other staked cores sat connected but undialable. A
-  // foreign-network or stale peer in the pool cannot produce a
-  // chain-valid ACK; it costs a wasted concurrent dial (and, in failing
-  // rounds, deferral of the impossible-quorum fast-fail until it
-  // settles — bounded, and identical to the pre-#1482 baseline).
-  const preferListed = (ids: string[]): string[] => {
-    if (preferredACKPeers.size === 0) return ids;
-    const listed: string[] = [];
-    const unlisted: string[] = [];
-    for (const id of ids) (preferredACKPeers.has(id) ? listed : unlisted).push(id);
-    return [...listed, ...unlisted];
-  };
+type ACKCandidateTierName = 'v2Advertised' | 'confirmedCore' | 'rest';
+
+interface ACKCandidateTier {
+  name: ACKCandidateTierName;
+  peers: string[];
+}
+
+function normalizePeerIdSet(ids: readonly string[] | undefined): Set<string> {
+  return new Set((ids ?? []).map((id) => id.trim()).filter((id) => id.length > 0));
+}
+
+function rankPreferredWithinTier(ids: readonly string[], preferred: ReadonlySet<string>): string[] {
+  if (preferred.size === 0) return [...ids];
+  const listed: string[] = [];
+  const unlisted: string[] = [];
+  for (const id of ids) (preferred.has(id) ? listed : unlisted).push(id);
+  return [...listed, ...unlisted];
+}
+
+function flattenTiers(tiers: readonly ACKCandidateTier[], preferred: ReadonlySet<string>): string[] {
+  return tiers.flatMap((tier) => rankPreferredWithinTier(tier.peers, preferred));
+}
+
+function buildCandidateTiers(input: {
+  connected: readonly string[];
+  knownCorePeerIds?: ReadonlySet<string>;
+  knownCorePeerIdsV2?: ReadonlySet<string>;
+  protocol?: string;
+}): ACKCandidateTier[] {
   const confirmedCore = input.knownCorePeerIds
-    ? connected.filter((id) => input.knownCorePeerIds!.has(id))
+    ? input.connected.filter((id) => input.knownCorePeerIds!.has(id))
     : [];
 
   if (input.protocol === PROTOCOL_STORAGE_ACK_V2) {
     const v2Advertised = input.knownCorePeerIdsV2
-      ? connected.filter((id) => input.knownCorePeerIdsV2!.has(id))
+      ? input.connected.filter((id) => input.knownCorePeerIdsV2!.has(id))
       : [];
     const v2Set = new Set(v2Advertised);
     const remainingConfirmedCore = confirmedCore.filter((id) => !v2Set.has(id));
     const seen = new Set([...v2Advertised, ...remainingConfirmedCore]);
-    const rest = connected.filter((id) => !seen.has(id));
-    // Identify metadata can be stale. Prefer advertised V2 peers, but keep
-    // fallback candidates so wire negotiation, not cached metadata, is the gate.
     return [
-      ...preferListed(v2Advertised),
-      ...preferListed(remainingConfirmedCore),
-      ...preferListed(rest),
+      { name: 'v2Advertised', peers: v2Advertised },
+      { name: 'confirmedCore', peers: remainingConfirmedCore },
+      { name: 'rest', peers: input.connected.filter((id) => !seen.has(id)) },
     ];
   }
 
-  if (confirmedCore.length >= input.requiredACKs) {
-    if (preferredACKPeers.size === 0) return confirmedCore;
+  const confirmedSet = new Set(confirmedCore);
+  return [
+    { name: 'confirmedCore', peers: confirmedCore },
+    { name: 'rest', peers: input.connected.filter((id) => !confirmedSet.has(id)) },
+  ];
+}
+
+export function selectACKCandidatePeers(input: ACKCandidatePeerSelectionInput): string[] {
+  const connected = input.connectedPeers.filter((id) => id !== input.selfPeerId);
+  const allowlistedACKPeers = normalizePeerIdSet(input.ackCandidatePeerIds);
+  const preferredACKPeers = normalizePeerIdSet(input.preferredACKPeerIds);
+  const eligible = allowlistedACKPeers.size > 0
+    ? connected.filter((id) => allowlistedACKPeers.has(id))
+    : connected;
+  const tiers = buildCandidateTiers({
+    connected: eligible,
+    knownCorePeerIds: input.knownCorePeerIds,
+    knownCorePeerIdsV2: input.knownCorePeerIdsV2,
+    protocol: input.protocol,
+  });
+
+  if (input.protocol === PROTOCOL_STORAGE_ACK_V2) {
+    // Identify metadata can be stale. Prefer advertised V2 peers, but keep
+    // fallback candidates so wire negotiation, not cached metadata, is the gate.
+    return flattenTiers(tiers, preferredACKPeers);
+  }
+
+  const confirmedCore = tiers.find((tier) => tier.name === 'confirmedCore')?.peers ?? [];
+  if (confirmedCore.length >= input.requiredACKs && preferredACKPeers.size === 0) {
+    return confirmedCore;
+  }
+
+  if (confirmedCore.length >= input.requiredACKs && preferredACKPeers.size > 0) {
     // Identify-time core claims are unverified and chain-agnostic, so a
     // quorum-sized confirmedCore can be entirely foreign-network peers
     // during the post-connect identify race (e.g. right after a daemon
-    // restart redials stale peer-store entries). Never let the shortcut
-    // exclude connected LISTED peers — they are this network's configured
-    // relays and the recovery path when the confirmed set is poisoned.
-    // Residual corner: connected UNLISTED cores whose identify is still
-    // pending stay outside a firing shortcut until reclassification;
-    // closing that fully needs chain-truth candidacy (peer IDs derivable
-    // from the sharding table), which today's random profile `nodeId`s
-    // prevent.
-    const confirmedSet = new Set(confirmedCore);
-    const listedRest = connected.filter(
-      (id) => preferredACKPeers.has(id) && !confirmedSet.has(id),
-    );
-    return [...preferListed(confirmedCore), ...listedRest];
+    // restart redials stale peer-store entries). When the daemon supplies
+    // network relays as a preference-only list, keep the remaining connected
+    // candidates in the shortcut too; chain truth, not cached identify metadata,
+    // decides which ACKs count.
+    return flattenTiers(tiers, preferredACKPeers);
   }
-  const rest = connected.filter((id) => !input.knownCorePeerIds?.has(id));
-  return [...preferListed(confirmedCore), ...preferListed(rest)];
+
+  return flattenTiers(tiers, preferredACKPeers);
 }

--- a/packages/publisher/src/ack-peer-selection.ts
+++ b/packages/publisher/src/ack-peer-selection.ts
@@ -12,30 +12,73 @@ export interface ACKCandidatePeerSelectionInput {
 
 export function selectACKCandidatePeers(input: ACKCandidatePeerSelectionInput): string[] {
   const connected = input.connectedPeers.filter((id) => id !== input.selfPeerId);
-  const allowedACKPeers = new Set(
+  const preferredACKPeers = new Set(
     (input.ackCandidatePeerIds ?? []).map((id) => id.trim()).filter((id) => id.length > 0),
   );
-  const eligible = allowedACKPeers.size > 0
-    ? connected.filter((id) => allowedACKPeers.has(id))
-    : connected;
+  // `ackCandidatePeerIds` never gates eligibility — it only orders the
+  // returned array (listed peers first within each tier). The ordering is
+  // cosmetic today: ACKCollector dials every candidate concurrently, so
+  // the effective change vs. the PR #1482 hard filter is precisely the
+  // un-filtering. The authoritative "may this peer sign?" check is chain
+  // truth, enforced per collected ACK (operational-key purpose + active
+  // sharding-table membership — i.e. a staked core; see
+  // `verifyACKIdentityDetailed`) and re-verified on-chain by the publish
+  // tx itself. Hard-filtering candidacy to the static network-config
+  // relay list capped the pool at 4-6 specific peers and made quorum
+  // arithmetically unreachable whenever enough of those relays were
+  // degraded or mid-upgrade — the 2026-07-07 Base/Gnosis mainnet ACK
+  // outage — while other staked cores sat connected but undialable. A
+  // foreign-network or stale peer in the pool cannot produce a
+  // chain-valid ACK; it costs a wasted concurrent dial (and, in failing
+  // rounds, deferral of the impossible-quorum fast-fail until it
+  // settles — bounded, and identical to the pre-#1482 baseline).
+  const preferListed = (ids: string[]): string[] => {
+    if (preferredACKPeers.size === 0) return ids;
+    const listed: string[] = [];
+    const unlisted: string[] = [];
+    for (const id of ids) (preferredACKPeers.has(id) ? listed : unlisted).push(id);
+    return [...listed, ...unlisted];
+  };
   const confirmedCore = input.knownCorePeerIds
-    ? eligible.filter((id) => input.knownCorePeerIds!.has(id))
+    ? connected.filter((id) => input.knownCorePeerIds!.has(id))
     : [];
 
   if (input.protocol === PROTOCOL_STORAGE_ACK_V2) {
     const v2Advertised = input.knownCorePeerIdsV2
-      ? eligible.filter((id) => input.knownCorePeerIdsV2!.has(id))
+      ? connected.filter((id) => input.knownCorePeerIdsV2!.has(id))
       : [];
     const v2Set = new Set(v2Advertised);
     const remainingConfirmedCore = confirmedCore.filter((id) => !v2Set.has(id));
     const seen = new Set([...v2Advertised, ...remainingConfirmedCore]);
-    const rest = eligible.filter((id) => !seen.has(id));
+    const rest = connected.filter((id) => !seen.has(id));
     // Identify metadata can be stale. Prefer advertised V2 peers, but keep
     // fallback candidates so wire negotiation, not cached metadata, is the gate.
-    return [...v2Advertised, ...remainingConfirmedCore, ...rest];
+    return [
+      ...preferListed(v2Advertised),
+      ...preferListed(remainingConfirmedCore),
+      ...preferListed(rest),
+    ];
   }
 
-  if (confirmedCore.length >= input.requiredACKs) return confirmedCore;
-  const rest = eligible.filter((id) => !input.knownCorePeerIds?.has(id));
-  return [...confirmedCore, ...rest];
+  if (confirmedCore.length >= input.requiredACKs) {
+    if (preferredACKPeers.size === 0) return confirmedCore;
+    // Identify-time core claims are unverified and chain-agnostic, so a
+    // quorum-sized confirmedCore can be entirely foreign-network peers
+    // during the post-connect identify race (e.g. right after a daemon
+    // restart redials stale peer-store entries). Never let the shortcut
+    // exclude connected LISTED peers — they are this network's configured
+    // relays and the recovery path when the confirmed set is poisoned.
+    // Residual corner: connected UNLISTED cores whose identify is still
+    // pending stay outside a firing shortcut until reclassification;
+    // closing that fully needs chain-truth candidacy (peer IDs derivable
+    // from the sharding table), which today's random profile `nodeId`s
+    // prevent.
+    const confirmedSet = new Set(confirmedCore);
+    const listedRest = connected.filter(
+      (id) => preferredACKPeers.has(id) && !confirmedSet.has(id),
+    );
+    return [...preferListed(confirmedCore), ...listedRest];
+  }
+  const rest = connected.filter((id) => !input.knownCorePeerIds?.has(id));
+  return [...preferListed(confirmedCore), ...preferListed(rest)];
 }

--- a/packages/publisher/test/ack-peer-selection.test.ts
+++ b/packages/publisher/test/ack-peer-selection.test.ts
@@ -1,0 +1,115 @@
+// ack-peer-selection.test.ts
+//
+// 2026-07-07 Base/Gnosis mainnet incident regression: `ackCandidatePeerIds`
+// (the bundled network-config relay list) must never EXCLUDE connected
+// peers from ACK candidacy — it only ranks them. The hard filter it
+// replaces capped the candidate pool at the listed relays (4 on Base, 6 on
+// Gnosis); with quorum at 3, two degraded/mid-upgrade relays on Base made
+// `storage_ack_insufficient` certain on every folded-private publish —
+// while connected, staked, chain-valid cores sat undialable. Signer
+// validity is enforced per collected ACK against chain truth (operational
+// key + sharding-table membership) and again on-chain by the publish tx,
+// so the configured list must never shrink candidacy. The #1107
+// quorum-satisfied confirmed-core shortcut still bounds fan-out, but it can
+// never exclude connected LISTED peers (identify-time core claims are
+// unverified and chain-agnostic, so a quorum-sized confirmed set can be
+// entirely foreign-network peers during the post-connect identify race).
+import { describe, it, expect } from 'vitest';
+import { PROTOCOL_STORAGE_ACK_V2 } from '@origintrail-official/dkg-core';
+import { selectACKCandidatePeers } from '../src/ack-peer-selection.js';
+
+const RELAYS = ['relay-1', 'relay-2', 'relay-3', 'relay-4'];
+const STAKED = ['staked-core-5', 'staked-core-6', 'staked-core-7'];
+
+describe('selectACKCandidatePeers — preference list never excludes connected peers', () => {
+  it('keeps unlisted staked cores in the pool when listed relays cannot reach quorum (incident shape)', () => {
+    // Base mainnet 2026-07-07: 4-relay preference list, only 2 connected
+    // and healthy; 3 upgraded non-relay cores connected. Old behavior
+    // returned [relay-1, relay-2] → 3-ACK quorum arithmetically dead.
+    const out = selectACKCandidatePeers({
+      connectedPeers: [RELAYS[0], RELAYS[1], ...STAKED],
+      ackCandidatePeerIds: RELAYS,
+      knownCorePeerIds: new Set([RELAYS[0], RELAYS[1], ...STAKED]),
+      requiredACKs: 3,
+    });
+    expect(out).toEqual([RELAYS[0], RELAYS[1], ...STAKED]);
+  });
+
+  it('orders listed peers first within each tier (confirmed cores, then rest)', () => {
+    const out = selectACKCandidatePeers({
+      connectedPeers: ['edge-x', STAKED[0], RELAYS[0], 'edge-y', RELAYS[1]],
+      ackCandidatePeerIds: RELAYS,
+      knownCorePeerIds: new Set([STAKED[0], RELAYS[0]]),
+      requiredACKs: 3,
+    });
+    // confirmed tier: RELAYS[0] (listed) before STAKED[0]; rest tier:
+    // RELAYS[1] (listed) before the edges (connection order preserved).
+    expect(out).toEqual([RELAYS[0], STAKED[0], RELAYS[1], 'edge-x', 'edge-y']);
+  });
+
+  it('applies the preference inside the quorum-satisfied confirmed-core shortcut', () => {
+    const out = selectACKCandidatePeers({
+      connectedPeers: [STAKED[0], STAKED[1], RELAYS[0], STAKED[2]],
+      ackCandidatePeerIds: RELAYS,
+      knownCorePeerIds: new Set([STAKED[0], STAKED[1], STAKED[2], RELAYS[0]]),
+      requiredACKs: 3,
+    });
+    expect(out).toEqual([RELAYS[0], STAKED[0], STAKED[1], STAKED[2]]);
+  });
+
+  it('quorum-satisfied shortcut cannot exclude connected listed relays when the confirmed set is foreign-poisoned', () => {
+    // Post-restart identify race: 3 stale foreign-network cores classify
+    // first (identify-derived core claims are chain-agnostic), the real
+    // relays are connected but not yet classified. The shortcut fires on
+    // the foreign trio — it must still include the connected listed relays,
+    // or chain verification rejects all 3 ACKs and quorum dies with valid
+    // signers connected (the regression PR #1482 originally guarded).
+    const foreign = ['testnet-core-1', 'testnet-core-2', 'testnet-core-3'];
+    const out = selectACKCandidatePeers({
+      connectedPeers: [...foreign, RELAYS[0], RELAYS[1]],
+      ackCandidatePeerIds: RELAYS,
+      knownCorePeerIds: new Set(foreign),
+      requiredACKs: 3,
+    });
+    expect(out).toEqual([...foreign, RELAYS[0], RELAYS[1]]);
+  });
+
+  it('V2 rounds: v2-advertised tier first, listed-first within every tier, nobody excluded', () => {
+    const out = selectACKCandidatePeers({
+      connectedPeers: [...STAKED, RELAYS[0], RELAYS[1], 'edge-x'],
+      ackCandidatePeerIds: RELAYS,
+      knownCorePeerIds: new Set([...STAKED, RELAYS[0], RELAYS[1]]),
+      knownCorePeerIdsV2: new Set([STAKED[0], STAKED[1], RELAYS[1]]),
+      requiredACKs: 3,
+      protocol: PROTOCOL_STORAGE_ACK_V2,
+    });
+    expect(out).toEqual([
+      // v2Advertised: listed first
+      RELAYS[1], STAKED[0], STAKED[1],
+      // remaining confirmed cores: listed first
+      RELAYS[0], STAKED[2],
+      // rest
+      'edge-x',
+    ]);
+  });
+
+  it('without a preference list, behavior is unchanged (cores first, everyone dialable)', () => {
+    const out = selectACKCandidatePeers({
+      connectedPeers: ['edge-x', STAKED[0], STAKED[1]],
+      knownCorePeerIds: new Set([STAKED[0], STAKED[1]]),
+      requiredACKs: 3,
+    });
+    expect(out).toEqual([STAKED[0], STAKED[1], 'edge-x']);
+  });
+
+  it('still excludes self and ignores blank preference entries', () => {
+    const out = selectACKCandidatePeers({
+      connectedPeers: ['self', STAKED[0], RELAYS[0]],
+      selfPeerId: 'self',
+      ackCandidatePeerIds: ['  ', '', ` ${RELAYS[0]} `],
+      knownCorePeerIds: new Set([STAKED[0], RELAYS[0]]),
+      requiredACKs: 3,
+    });
+    expect(out).toEqual([RELAYS[0], STAKED[0]]);
+  });
+});

--- a/packages/publisher/test/ack-peer-selection.test.ts
+++ b/packages/publisher/test/ack-peer-selection.test.ts
@@ -1,19 +1,9 @@
 // ack-peer-selection.test.ts
 //
-// 2026-07-07 Base/Gnosis mainnet incident regression: `ackCandidatePeerIds`
-// (the bundled network-config relay list) must never EXCLUDE connected
-// peers from ACK candidacy — it only ranks them. The hard filter it
-// replaces capped the candidate pool at the listed relays (4 on Base, 6 on
-// Gnosis); with quorum at 3, two degraded/mid-upgrade relays on Base made
-// `storage_ack_insufficient` certain on every folded-private publish —
-// while connected, staked, chain-valid cores sat undialable. Signer
-// validity is enforced per collected ACK against chain truth (operational
-// key + sharding-table membership) and again on-chain by the publish tx,
-// so the configured list must never shrink candidacy. The #1107
-// quorum-satisfied confirmed-core shortcut still bounds fan-out, but it can
-// never exclude connected LISTED peers (identify-time core claims are
-// unverified and chain-agnostic, so a quorum-sized confirmed set can be
-// entirely foreign-network peers during the post-connect identify race).
+// 2026-07-07 Base/Gnosis mainnet incident regression: bundled network-config
+// relays are a preference list, not an eligibility gate. They must rank first
+// without excluding connected, staked, chain-valid cores. The legacy
+// `ackCandidatePeerIds` field remains a true caller-supplied allowlist.
 import { describe, it, expect } from 'vitest';
 import { PROTOCOL_STORAGE_ACK_V2 } from '@origintrail-official/dkg-core';
 import { selectACKCandidatePeers } from '../src/ack-peer-selection.js';
@@ -21,14 +11,24 @@ import { selectACKCandidatePeers } from '../src/ack-peer-selection.js';
 const RELAYS = ['relay-1', 'relay-2', 'relay-3', 'relay-4'];
 const STAKED = ['staked-core-5', 'staked-core-6', 'staked-core-7'];
 
-describe('selectACKCandidatePeers — preference list never excludes connected peers', () => {
+describe('selectACKCandidatePeers — allowlist vs preference-only ranking', () => {
+  it('keeps ackCandidatePeerIds as a legacy allowlist (unlisted connected peers are excluded)', () => {
+    const out = selectACKCandidatePeers({
+      connectedPeers: ['trusted-core', 'untrusted-peer'],
+      ackCandidatePeerIds: ['trusted-core'],
+      knownCorePeerIds: new Set(['trusted-core', 'untrusted-peer']),
+      requiredACKs: 3,
+    });
+    expect(out).toEqual(['trusted-core']);
+  });
+
   it('keeps unlisted staked cores in the pool when listed relays cannot reach quorum (incident shape)', () => {
     // Base mainnet 2026-07-07: 4-relay preference list, only 2 connected
     // and healthy; 3 upgraded non-relay cores connected. Old behavior
     // returned [relay-1, relay-2] → 3-ACK quorum arithmetically dead.
     const out = selectACKCandidatePeers({
       connectedPeers: [RELAYS[0], RELAYS[1], ...STAKED],
-      ackCandidatePeerIds: RELAYS,
+      preferredACKPeerIds: RELAYS,
       knownCorePeerIds: new Set([RELAYS[0], RELAYS[1], ...STAKED]),
       requiredACKs: 3,
     });
@@ -38,7 +38,7 @@ describe('selectACKCandidatePeers — preference list never excludes connected p
   it('orders listed peers first within each tier (confirmed cores, then rest)', () => {
     const out = selectACKCandidatePeers({
       connectedPeers: ['edge-x', STAKED[0], RELAYS[0], 'edge-y', RELAYS[1]],
-      ackCandidatePeerIds: RELAYS,
+      preferredACKPeerIds: RELAYS,
       knownCorePeerIds: new Set([STAKED[0], RELAYS[0]]),
       requiredACKs: 3,
     });
@@ -50,7 +50,7 @@ describe('selectACKCandidatePeers — preference list never excludes connected p
   it('applies the preference inside the quorum-satisfied confirmed-core shortcut', () => {
     const out = selectACKCandidatePeers({
       connectedPeers: [STAKED[0], STAKED[1], RELAYS[0], STAKED[2]],
-      ackCandidatePeerIds: RELAYS,
+      preferredACKPeerIds: RELAYS,
       knownCorePeerIds: new Set([STAKED[0], STAKED[1], STAKED[2], RELAYS[0]]),
       requiredACKs: 3,
     });
@@ -67,17 +67,29 @@ describe('selectACKCandidatePeers — preference list never excludes connected p
     const foreign = ['testnet-core-1', 'testnet-core-2', 'testnet-core-3'];
     const out = selectACKCandidatePeers({
       connectedPeers: [...foreign, RELAYS[0], RELAYS[1]],
-      ackCandidatePeerIds: RELAYS,
+      preferredACKPeerIds: RELAYS,
       knownCorePeerIds: new Set(foreign),
       requiredACKs: 3,
     });
     expect(out).toEqual([...foreign, RELAYS[0], RELAYS[1]]);
   });
 
+  it('quorum-satisfied shortcut keeps unlisted connected peers when using preference-only relays', () => {
+    const foreign = ['foreign-1', 'foreign-2', 'foreign-3'];
+    const unlisted = 'staked-core-4';
+    const out = selectACKCandidatePeers({
+      connectedPeers: [...foreign, unlisted],
+      preferredACKPeerIds: ['relay-1'],
+      knownCorePeerIds: new Set(foreign),
+      requiredACKs: 3,
+    });
+    expect(out).toEqual([...foreign, unlisted]);
+  });
+
   it('V2 rounds: v2-advertised tier first, listed-first within every tier, nobody excluded', () => {
     const out = selectACKCandidatePeers({
       connectedPeers: [...STAKED, RELAYS[0], RELAYS[1], 'edge-x'],
-      ackCandidatePeerIds: RELAYS,
+      preferredACKPeerIds: RELAYS,
       knownCorePeerIds: new Set([...STAKED, RELAYS[0], RELAYS[1]]),
       knownCorePeerIdsV2: new Set([STAKED[0], STAKED[1], RELAYS[1]]),
       requiredACKs: 3,
@@ -106,7 +118,7 @@ describe('selectACKCandidatePeers — preference list never excludes connected p
     const out = selectACKCandidatePeers({
       connectedPeers: ['self', STAKED[0], RELAYS[0]],
       selfPeerId: 'self',
-      ackCandidatePeerIds: ['  ', '', ` ${RELAYS[0]} `],
+      preferredACKPeerIds: ['  ', '', ` ${RELAYS[0]} `],
       knownCorePeerIds: new Set([STAKED[0], RELAYS[0]]),
       requiredACKs: 3,
     });


### PR DESCRIPTION
## Summary

Incident fix for the 2026-07-07 Base + Gnosis mainnet StorageACK outage: `ackCandidatePeerIds` (the peer IDs of the bundled network-config relays) **no longer gates ACK-candidate eligibility**. The list now only ranks candidates (listed peers first within each selection tier — cosmetic today, since the collector dials all candidates concurrently); the effective change is precisely the removal of the PR #1482 hard filter. No connected peer is excluded from candidacy on account of the list.

## Why

PR #1482 restricted the ACK candidate pool to `connected ∩ relay-allowlist` — exactly 4 peer IDs on Base, 6 on Gnosis (`network/mainnet-*.json`). With the on-chain quorum at `minimumRequiredSignatures = 3`, a Base publisher tolerated at most **one** degraded relay; a publisher that is itself a relay, none to spare. During the mixed-version 10.0.3 rollout, relays still on 10.0.2 could not serve folded-private (field-20) ACK requests, so `collected + stillPending < 3` fast-failed every round: `storage_ack_insufficient … quorum no longer reachable`, on both chains, for every private-carrying publish — while connected, staked, fully-upgraded cores sat outside the static list, undialable.

The list was doing a job that chain truth already does. **Candidacy** (who we ask) was being gated by a config file, but **validity** (whose signature counts) is enforced per collected ACK by `verifyACKIdentityDetailed` — recovered signer must hold `OPERATIONAL_KEY` purpose for the claimed identity **and** the identity must be in the active sharding table (maintained atomically by `StakingV10` as stake crosses `minimumStake`) — and the publish tx re-verifies the same signatures on-chain in `KnowledgeAssetsLifecycle._verifyACKSignature`. The valid signer set is the on-chain sharding table (all staked cores), not the relay file. A stale foreign-network peer in the pool cannot produce a chain-valid ACK; it costs a wasted concurrent dial, not quorum eligibility.

## What changed

- `packages/publisher/src/ack-peer-selection.ts` — `selectACKCandidatePeers`: the configured list orders peers first within each tier (v2-advertised / confirmed-core / rest); no peer is excluded.
- `packages/cli/src/daemon/lifecycle.ts` — `orderACKCandidatePeerIds` (devnet-regression surface): same non-exclusion contract; daemon boot log reworded.
- `packages/agent/src/dkg-agent-types.ts`, `packages/agent/src/dkg-agent.ts` — doc contracts updated; also corrects the stale comment claiming V1-only peers "fail negotiation" on V2 (the V2 protocol id has been registered since v10.0.0-rc.15 — a pre-field-20 core accepts the V2 dial, drops `privateMerkleRoots` on decode, and declines/aborts after its root recompute; negotiation is not a version gate).
- Tests: new `packages/publisher/test/ack-peer-selection.test.ts` (incident-shape regression: unlisted staked cores can complete quorum when listed relays are degraded); `packages/agent/test/ack-candidate-pool.test.ts`, `packages/cli/test/preferred-relays.test.ts`, `devnet/ack-candidate-isolation/automated.test.ts` + README updated from exclusion to ranking expectations.

## Behavior notes (reviewed trade-offs)

- **Failing rounds settle slower than under #1482**: with unlisted peers back in the pool, the impossible-quorum fast-fail waits for them to settle (bounded by the send retry/timeout budget) instead of failing near-instantly on a sub-quorum pool. This is identical to the pre-#1482 (≤10.0.2) baseline and is the price of not excluding valid cores.
- **Fan-out returns to ≤10.0.2 scale**: every publish sends the PublishIntent to all candidates concurrently; undeliverable peers leave outbox retries. Same as the long-lived pre-#1482 behavior.
- **Shortcut poisoning guarded**: identify-time core claims are unverified and chain-agnostic, so the #1107 quorum-satisfied confirmed-core shortcut can fire on a set of foreign-network cores during the post-connect identify race (e.g. after a daemon restart redials stale peer-store entries). Under #1482 this was impossible only because `confirmedCore ⊆ allowlist`. The shortcut now always retains connected LISTED peers, so a poisoned confirmed set can never exclude this network's relays. Residual (pre-existing) corner: connected *unlisted* cores whose identify is still pending stay outside a firing shortcut until reclassified. The durable fix is chain-truth candidacy — deriving peer IDs from `ShardingTable.getShardingTable()` — blocked today because `ensureProfile` writes a random 32-byte `nodeId` on-chain (sharding-table entries cannot be mapped to libp2p peer IDs). Follow-up: populate `nodeId` with the real peer ID (`Profile.setNodeId` self-heal), then build candidacy from the sharding table.

## What this deliberately does NOT do

It does not resolve the mixed-version folded-private incompatibility itself — a 10.0.2 core still cannot sign a folded root (it drops field 20 and recomputes a public-only root). Publishing recovers when ≥ quorum staked cores per chain run 10.0.3; this PR removes the artificial cap that kept upgraded non-relay cores out of the pool.

## Test plan

- `packages/publisher`: full suite 1418 passed / 6 skipped (incl. 6 new selection tests)
- `packages/agent`: full suite 1826 passed / 4 skipped (incl. 3 new candidate-pool tests)
- `packages/cli`: full suite 2472 passed / 11 skipped (incl. updated `preferred-relays` expectations)
- Adversarially reviewed (3-lens multi-agent pass); findings folded into the doc contracts and this description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
