### PR TITLE
feat(chain): funding-floor plumbing + selectSigner(spec) generalization (dispatcher Phase 2/3)

### DIFF
--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -1072,6 +1072,14 @@ export interface DKGAgentConfig {
     approvalPolicy?: ApprovalPolicy;
     /** Optional ContextGraphNameRegistry `eth_getLogs` block-window tuning. */
     cgRegistryScanPageSize?: number;
+    /**
+     * Funding floors (wei) for funding-aware operational-wallet selection,
+     * threaded straight to `EVMAdapterConfig.minPublisher*Wei`. Both default to
+     * `0n` (only strictly-empty wallets are skipped); a wallet below the floor is
+     * deprioritized, not excluded (best-funded fallback still sends).
+     */
+    minPublisherNativeWei?: bigint;
+    minPublisherTracWei?: bigint;
   };
   /** Cross-agent query access configuration. */
   queryAccess?: QueryAccessConfig;

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -606,6 +606,8 @@ export class DKGAgent extends DKGAgentBase {
         chainId: config.chainConfig.chainId,
         approvalPolicy: config.chainConfig.approvalPolicy,
         cgRegistryScanPageSize: config.chainConfig.cgRegistryScanPageSize,
+        minPublisherNativeWei: config.chainConfig.minPublisherNativeWei,
+        minPublisherTracWei: config.chainConfig.minPublisherTracWei,
         contextGraphRegistryScanCursorStore: config.contextGraphRegistryScanCursorStore,
       };
       if (config.chainConfig.adminPrivateKey) {

--- a/packages/agent/test/chain-cursor-wiring.test.ts
+++ b/packages/agent/test/chain-cursor-wiring.test.ts
@@ -13,7 +13,7 @@ describe('DKGAgent chain cursor wiring', () => {
     agent = undefined;
   });
 
-  it('passes the registry scan cursor store into an EVM adapter built from chainConfig', async () => {
+  it('passes EVM chainConfig fields into the constructed adapter', async () => {
     const registryCursorStore = {
       load: vi.fn(async () => undefined),
       save: vi.fn(async () => {}),
@@ -27,11 +27,15 @@ describe('DKGAgent chain cursor wiring', () => {
         hubAddress: '0x0000000000000000000000000000000000000001',
         operationalKeys: [OPERATIONAL_KEY],
         chainId: 'evm:31337',
+        minPublisherNativeWei: 123n,
+        minPublisherTracWei: 456n,
       },
       contextGraphRegistryScanCursorStore: registryCursorStore,
     });
 
     expect((agent as any).chain.contextGraphRegistryScanCursor?.input?.store).toBe(registryCursorStore);
+    expect((agent as any).chain.minPublisherNativeWei).toBe(123n);
+    expect((agent as any).chain.minPublisherTracWei).toBe(456n);
   });
 
   it('passes the chain-event lane cursor store into the poller on start', async () => {

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -475,23 +475,43 @@ export type FundingMode =
       consultPca: boolean;
     };
 
+export type NativeOnlyFundingMode = Extract<FundingMode, { kind: 'native-only' }>;
+export type NativeAndTracFundingMode = Extract<FundingMode, { kind: 'native+trac' }>;
+
 /**
- * Generalized operational-wallet selection request. Publish routes through the
- * thin `nextAuthorizedSigner` wrapper (`rotatable-policy`); the other classes
- * exist for the funding-aware selection later phases route RS / update through.
+ * Generalized operational-wallet selection request. The discriminant fixes the
+ * eligible-wallet scope and the required funding model together, so invalid
+ * combinations (for example, publish policy selection without a context graph or
+ * with native-only funding) do not compile.
+ *
  * - `rotatable-policy`  → publish: eligible = on-chain authorized publishers
  *                          for `contextGraphId` (whole pool when no ContextGraphs surface).
- * - `rotatable-funded`  → update: eligible = whole pool (no authorized-publisher filter).
+ * - `rotatable-funded`  → update: eligible = whole pool, native+TRAC funding.
  * - `rotatable-free`    → RS / relay / settle: eligible = whole pool, native-only funding.
  */
-export interface SelectSignerSpec {
-  txClass: 'rotatable-policy' | 'rotatable-funded' | 'rotatable-free';
-  funding: FundingMode;
-  /** Required for `rotatable-policy` — the CG whose authorized publishers gate eligibility. */
-  contextGraphId?: bigint;
-  /** Soft, fail-open bias toward a funded wallet whose per-wallet lock is free. Default false. */
-  preferIdle?: boolean;
-}
+export type SelectSignerSpec =
+  | {
+      txClass: 'rotatable-policy';
+      funding: NativeAndTracFundingMode;
+      /** The CG whose authorized publishers gate publish eligibility. */
+      contextGraphId: bigint;
+      /** Soft, fail-open bias toward a funded wallet whose per-wallet lock is free. Default false. */
+      preferIdle?: boolean;
+    }
+  | {
+      txClass: 'rotatable-funded';
+      funding: NativeAndTracFundingMode;
+      contextGraphId?: never;
+      /** Soft, fail-open bias toward a funded wallet whose per-wallet lock is free. Default false. */
+      preferIdle?: boolean;
+    }
+  | {
+      txClass: 'rotatable-free';
+      funding: NativeOnlyFundingMode;
+      contextGraphId?: never;
+      /** Soft, fail-open bias toward a funded wallet whose per-wallet lock is free. Default false. */
+      preferIdle?: boolean;
+    };
 
 export class EVMChainAdapterBase {
   /** See `ChainAdapter.deploymentId`. */
@@ -1643,7 +1663,7 @@ export class EVMChainAdapterBase {
         }
         if (eligible.length === 0) {
           throw new Error(
-            `No authorized publisher wallet found in signer pool for context graph ${spec.contextGraphId?.toString()}. ` +
+            `No authorized publisher wallet found in signer pool for context graph ${spec.contextGraphId.toString()}. ` +
             'Ensure at least one configured wallet is permitted by on-chain publish authority.',
           );
         }

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -456,6 +456,43 @@ async function contractAddress(contract: Contract): Promise<string> {
   throw new Error('DKGKnowledgeAssets address is unavailable from the resolved contract handle.');
 }
 
+/**
+ * Per-tx-type funding requirement for operational-wallet selection. A
+ * discriminated union so "native-only" (RS challenge/proof, relay, settle —
+ * gas only, no TRAC transfer) is UNREPRESENTABLE-AS-TRAC-GATED: applying a
+ * publish TRAC floor to a gas-only tx would wrongly reject a valid,
+ * gas-funded, zero-TRAC wallet. `native+trac` (publish/update) additionally
+ * requires own-TRAC to cover the publish above the operator floor, with an
+ * optional Publishing Conviction Account (PCA) fallback.
+ */
+export type FundingMode =
+  | { kind: 'native-only'; nativeFloorWei: bigint }
+  | {
+      kind: 'native+trac';
+      nativeFloorWei: bigint;
+      tracFloorWei: bigint;
+      requiredTracWei: bigint;
+      consultPca: boolean;
+    };
+
+/**
+ * Generalized operational-wallet selection request. Publish routes through the
+ * thin `nextAuthorizedSigner` wrapper (`rotatable-policy`); the other classes
+ * exist for the funding-aware selection later phases route RS / update through.
+ * - `rotatable-policy`  → publish: eligible = on-chain authorized publishers
+ *                          for `contextGraphId` (whole pool when no ContextGraphs surface).
+ * - `rotatable-funded`  → update: eligible = whole pool (no authorized-publisher filter).
+ * - `rotatable-free`    → RS / relay / settle: eligible = whole pool, native-only funding.
+ */
+export interface SelectSignerSpec {
+  txClass: 'rotatable-policy' | 'rotatable-funded' | 'rotatable-free';
+  funding: FundingMode;
+  /** Required for `rotatable-policy` — the CG whose authorized publishers gate eligibility. */
+  contextGraphId?: bigint;
+  /** Soft, fail-open bias toward a funded wallet whose per-wallet lock is free. Default false. */
+  preferIdle?: boolean;
+}
+
 export class EVMChainAdapterBase {
   /** See `ChainAdapter.deploymentId`. */
   get deploymentId(): string {
@@ -535,10 +572,20 @@ export class EVMChainAdapterBase {
 
   /**
    * Kill-switch (env `DKG_DISABLE_FUNDED_WALLET_SELECTION=1`): when set,
-   * `nextAuthorizedSigner` reverts to the pre-funding-aware behaviour
-   * (first authorized wallet in round-robin order, no balance reads).
+   * `selectSigner` reverts to the pre-funding-aware behaviour
+   * (first eligible wallet in round-robin order, no balance reads).
    */
   protected readonly fundedWalletSelectionDisabled: boolean;
+
+  /**
+   * Independent kill-switch (env `DKG_DISABLE_IDLE_AWARE_SELECTION=1`): when
+   * set, `selectSigner` never applies the idle-aware preference even for specs
+   * that request `preferIdle`. Separate from the funding kill-switch so idle
+   * biasing can be disabled without losing funding-awareness. Idle preference
+   * is a soft, fail-open bias (prefer a funded wallet whose per-wallet lock is
+   * currently free); it is OFF for publish (`preferIdle: false`) until soaked.
+   */
+  protected readonly idleAwareSelectionDisabled: boolean;
 
   /**
    * Short-TTL per-wallet funding cache (lowercased address → native+TRAC wei).
@@ -993,6 +1040,7 @@ export class EVMChainAdapterBase {
     this.minPublisherNativeWei = config.minPublisherNativeWei ?? 0n;
     this.minPublisherTracWei = config.minPublisherTracWei ?? 0n;
     this.fundedWalletSelectionDisabled = process.env.DKG_DISABLE_FUNDED_WALLET_SELECTION === '1';
+    this.idleAwareSelectionDisabled = process.env.DKG_DISABLE_IDLE_AWARE_SELECTION === '1';
 
     this.contracts = {
       hub: new Contract(config.hubAddress, loadAbi('Hub'), this.signer),
@@ -1552,22 +1600,20 @@ export class EVMChainAdapterBase {
   }
 
   /**
-   * Pick the operational wallet that signs the next publish tx. Among the
-   * wallets the on-chain ContextGraphs contract authorizes for this context
-   * graph (round-robin order from `signerIndex`), PREFER one that is funded
-   * (native gas AND TRAC above the configured floors, or a covering PCA agent)
-   * so a publish is never routed to an authorized-but-empty wallet — the
-   * unfunded-wallet publish-failure this selector exists to fix. When the
-   * ContextGraphs auth surface is unavailable, every operational wallet is a
-   * candidate — still funding-aware over the full pool, NOT a plain pick. When
-   * no candidate is fundable, falls back to the best-funded one (the publish
-   * then surfaces an actionable InsufficientPublisherFundsError rather than a
-   * raw revert). The DKG_DISABLE_FUNDED_WALLET_SELECTION kill-switch is the only
-   * path that reverts to a plain round-robin pick (the first authorized wallet).
-   * Selection is serialized via `signerSelectionQueue` so concurrent publishes
-   * advance the `signerIndex` cursor coherently.
+   * Generalized operational-wallet selector. Orders the pool round-robin from
+   * `signerIndex`, narrows to the `spec.txClass` eligibility set, then PREFERS a
+   * funded wallet (per `spec.funding`) — optionally an idle one — so a write is
+   * never routed to an eligible-but-empty wallet. When no candidate is fundable
+   * it falls back to the best-funded one (the caller then surfaces an actionable
+   * error rather than a raw revert). `DKG_DISABLE_FUNDED_WALLET_SELECTION` is the
+   * only path that reverts to a plain round-robin pick (the first eligible
+   * wallet, no balance reads). Serialized via `signerSelectionQueue` so
+   * concurrent selections advance the `signerIndex` cursor coherently.
+   *
+   * `nextAuthorizedSigner` is the thin publish wrapper over this; RS / update /
+   * relay route through it with their own `txClass` + `FundingMode` in later phases.
    */
-  protected async nextAuthorizedSigner(contextGraphId: bigint, requiredTracWei: bigint = 0n): Promise<Wallet> {
+  protected async selectSigner(spec: SelectSignerSpec): Promise<Wallet> {
     const previousSelection = this.signerSelectionQueue;
     let releaseSelection!: () => void;
     this.signerSelectionQueue = new Promise<void>((resolve) => { releaseSelection = resolve; });
@@ -1580,34 +1626,34 @@ export class EVMChainAdapterBase {
         ordered.push(this.signerPool[(start + i) % this.signerPool.length]);
       }
 
-      // Filter to on-chain authorized publishers. With no ContextGraphs
-      // surface, every operational wallet is a candidate (was: a single
-      // round-robin pick; now funding-aware over the whole pool).
-      let authorized: Wallet[];
-      if (!this.contracts.contextGraphs) {
-        authorized = ordered;
-      } else {
-        authorized = [];
+      // Eligibility by class. `rotatable-policy` filters to on-chain authorized
+      // publishers for the CG; with no ContextGraphs surface every operational
+      // wallet is a candidate (funding-aware over the whole pool, NOT a plain
+      // pick). `rotatable-funded`/`rotatable-free` use the whole pool.
+      let eligible: Wallet[];
+      if (spec.txClass === 'rotatable-policy' && this.contracts.contextGraphs) {
+        eligible = [];
         for (const signer of ordered) {
           if (await this.readContract(
             this.contracts.contextGraphs, 'contextGraphs.isAuthorizedPublisher',
-            'isAuthorizedPublisher', contextGraphId, signer.address,
+            'isAuthorizedPublisher', spec.contextGraphId, signer.address,
           )) {
-            authorized.push(signer);
+            eligible.push(signer);
           }
         }
-      }
-
-      if (authorized.length === 0) {
-        throw new Error(
-          `No authorized publisher wallet found in signer pool for context graph ${contextGraphId.toString()}. ` +
-          'Ensure at least one configured wallet is permitted by on-chain publish authority.',
-        );
+        if (eligible.length === 0) {
+          throw new Error(
+            `No authorized publisher wallet found in signer pool for context graph ${spec.contextGraphId?.toString()}. ` +
+            'Ensure at least one configured wallet is permitted by on-chain publish authority.',
+          );
+        }
+      } else {
+        eligible = ordered;
       }
 
       const chosen = this.fundedWalletSelectionDisabled
-        ? authorized[0]
-        : await this.selectFundedSigner(authorized, requiredTracWei);
+        ? eligible[0]
+        : await this.selectFundedSigner(eligible, spec.funding, spec.preferIdle ?? false);
 
       // Advance the cursor just past the chosen wallet so the next selection
       // rotates — preserving cross-wallet nonce concurrency (#953) when more
@@ -1621,59 +1667,121 @@ export class EVMChainAdapterBase {
   }
 
   /**
-   * Among `authorized` wallets (already in round-robin order), return the first
-   * that is fundable (native > floor AND TRAC > floor). Balance reads are
-   * short-TTL cached, run in parallel, and FAIL OPEN (a read error / timeout
-   * counts the wallet as fundable) so a flaky RPC never blocks a publish. When
-   * none is fundable, return the best-funded wallet (max native, then max TRAC)
-   * so the publish still attempts and the contract gives the real verdict.
+   * Thin publish wrapper over {@link selectSigner}: pick the operational wallet
+   * that signs the next publish tx among the CG's on-chain authorized
+   * publishers, funding-aware over native gas AND own-TRAC (or a covering PCA
+   * agent). Idle preference is OFF for publish until soaked. Behaviour is
+   * unchanged from the pre-`selectSigner` implementation.
    */
-  protected async selectFundedSigner(authorized: Wallet[], requiredTracWei: bigint): Promise<Wallet> {
-    const fundings = await Promise.all(authorized.map((s) => this.getWalletFunding(s.address)));
+  protected async nextAuthorizedSigner(contextGraphId: bigint, requiredTracWei: bigint = 0n): Promise<Wallet> {
+    return this.selectSigner({
+      txClass: 'rotatable-policy',
+      contextGraphId,
+      funding: {
+        kind: 'native+trac',
+        nativeFloorWei: this.minPublisherNativeWei,
+        tracFloorWei: this.minPublisherTracWei,
+        requiredTracWei,
+        consultPca: true,
+      },
+      preferIdle: false,
+    });
+  }
+
+  /**
+   * Among `candidates` (already in round-robin order), return the first that is
+   * fundable per `funding` — or, when `preferIdle` and idle-aware selection is
+   * enabled, the first fundable wallet whose per-wallet lock is currently free.
+   * Balance reads are short-TTL cached, run in parallel, and FAIL OPEN (a read
+   * error / timeout counts the wallet as fundable) so a flaky RPC never blocks a
+   * write. When none is fundable, return the best-funded wallet (max native,
+   * then max TRAC) so the write still attempts and the contract gives the real
+   * verdict.
+   */
+  protected async selectFundedSigner(
+    candidates: Wallet[],
+    funding: FundingMode,
+    preferIdle: boolean,
+  ): Promise<Wallet> {
+    const fundings = await Promise.all(candidates.map((s) => this.getWalletFunding(s.address)));
     // Fundability is own-balance first (cheap), with a Publishing Conviction
-    // Account (PCA) fallback: a registered+covering PCA agent wallet pays the
-    // publish from its conviction account, NOT its own TRAC (the contract only
-    // `transferFrom`s the wallet on the direct-spend branch). Such a wallet
-    // legitimately holds gas + zero own-TRAC, so without this fallback the
-    // funding gate would skip it and lose the conviction discount.
+    // Account (PCA) fallback for `native+trac`: a registered+covering PCA agent
+    // wallet pays the publish from its conviction account, NOT its own TRAC, so
+    // it legitimately holds gas + zero own-TRAC (`native-only` specs never
+    // consult the PCA).
     const fundable = await Promise.all(
-      authorized.map((s, i) => this.isWalletPublishFundable(s.address, fundings[i], requiredTracWei)),
+      candidates.map((s, i) => this.isWalletFundable(s.address, fundings[i], funding)),
     );
-    for (let i = 0; i < authorized.length; i += 1) {
-      if (fundable[i]) return authorized[i];
+    const fundableIdx: number[] = [];
+    for (let i = 0; i < candidates.length; i += 1) {
+      if (fundable[i]) fundableIdx.push(i);
+    }
+    if (fundableIdx.length > 0) {
+      // Idle preference is a SOFT, fail-open bias: among funded candidates,
+      // prefer one whose per-wallet send lock is currently free so a
+      // deadline-bound write doesn't queue behind a slow in-flight send. Falls
+      // straight through to the first funded candidate when none is idle or the
+      // preference is off — so it can never EXCLUDE a wallet, only reorder.
+      if (preferIdle && !this.idleAwareSelectionDisabled) {
+        const idle = fundableIdx.find((i) => !this.signerTxSerializer.isActive(candidates[i].address));
+        if (idle !== undefined) return candidates[idle];
+      }
+      return candidates[fundableIdx[0]];
     }
     let bestIdx = 0;
-    for (let i = 1; i < authorized.length; i += 1) {
+    for (let i = 1; i < candidates.length; i += 1) {
       const a = fundings[i];
       const b = fundings[bestIdx];
       const an = a.native ?? -1n;
       const bn = b.native ?? -1n;
       if (an > bn || (an === bn && (a.trac ?? -1n) > (b.trac ?? -1n))) bestIdx = i;
     }
-    return authorized[bestIdx];
+    return candidates[bestIdx];
   }
 
   /**
-   * The single fundability predicate: native gas above the floor AND own-TRAC
-   * covers the publish (above the operator floor AND `>= requiredTracWei`, the
-   * publish cost — `0n` when the cost is unknown, so only the floor applies), OR
-   * the wallet is a registered, covering PCA agent (publish paid from its
-   * conviction account, not its own TRAC). A `null` metric (read failed / no
+   * The single fundability predicate, parameterized by {@link FundingMode}:
+   * native gas above the floor, AND — for `native+trac` — own-TRAC covers the
+   * write (above the operator floor AND `>= requiredTracWei`, the cost — `0n`
+   * when unknown, so only the floor applies), OR the wallet is a registered,
+   * covering PCA agent (when `consultPca`). `native-only` (RS / relay / settle)
+   * gates on gas ALONE — it never applies a TRAC floor, so a valid gas-funded
+   * zero-TRAC wallet is not wrongly rejected. A `null` metric (read failed / no
    * token contract) is treated as satisfied so selection FAILS OPEN. The PCA
    * conviction reads run only when own-TRAC is short, so a normally funded
    * wallet pays no extra RPC.
+   */
+  protected async isWalletFundable(
+    address: string,
+    f: { native: bigint | null; trac: bigint | null },
+    funding: FundingMode,
+  ): Promise<boolean> {
+    const nativeOk = f.native === null || f.native > funding.nativeFloorWei;
+    if (!nativeOk) return false; // even a PCA agent needs gas
+    if (funding.kind === 'native-only') return true;
+    const ownTracOk = f.trac === null
+      || (f.trac > funding.tracFloorWei && f.trac >= funding.requiredTracWei);
+    if (ownTracOk) return true;
+    return funding.consultPca ? this.isConvictionFundedAgent(address, funding.requiredTracWei) : false;
+  }
+
+  /**
+   * Thin publish wrapper over {@link isWalletFundable} preserving the original
+   * `isWalletPublishFundable(address, f, requiredTracWei)` shape used by the
+   * error-enrichment path. Native+TRAC with the operator floors and PCA fallback.
    */
   protected async isWalletPublishFundable(
     address: string,
     f: { native: bigint | null; trac: bigint | null },
     requiredTracWei: bigint,
   ): Promise<boolean> {
-    const nativeOk = f.native === null || f.native > this.minPublisherNativeWei;
-    if (!nativeOk) return false; // even a PCA agent needs gas
-    const ownTracOk = f.trac === null
-      || (f.trac > this.minPublisherTracWei && f.trac >= requiredTracWei);
-    if (ownTracOk) return true;
-    return this.isConvictionFundedAgent(address, requiredTracWei);
+    return this.isWalletFundable(address, f, {
+      kind: 'native+trac',
+      nativeFloorWei: this.minPublisherNativeWei,
+      tracFloorWei: this.minPublisherTracWei,
+      requiredTracWei,
+      consultPca: true,
+    });
   }
 
   /**

--- a/packages/chain/src/keyed-mutex.ts
+++ b/packages/chain/src/keyed-mutex.ts
@@ -41,6 +41,11 @@ export class KeyedSerializer {
     return result;
   }
 
+  /** True while `key` has an in-flight or queued operation. */
+  isActive(key: string): boolean {
+    return this.tails.has(key);
+  }
+
   /** Number of keys with an in-flight or queued operation. */
   get activeKeyCount(): number {
     return this.tails.size;

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -3860,6 +3860,84 @@ describe('createKnowledgeAssets — funding-aware wallet selection', () => {
     expect(coverCalls.length).toBe(1); // only walletA's PCA was probed (walletB fundable via own-TRAC)
     expect(coverCalls[0] > 1n).toBe(true); // priced at the REAL publish cost, not the 1-wei liveness probe
   });
+
+  // ── dispatcher Phase 3: the generalized selectSigner seam (RS/relay/update
+  // route through this later). Publish behaviour above is proven byte-identical
+  // through the nextAuthorizedSigner wrapper; these cover the NEW capabilities.
+  describe('selectSigner — generalized funding modes + idle preference', () => {
+    const nativeOnly = { kind: 'native-only' as const, nativeFloorWei: 0n };
+
+    it('native-only funding gates on GAS ALONE — a gas-funded zero-TRAC wallet stays fundable', async () => {
+      const { a, walletA, nativeByAddr, tracByAddr } = makeMultiWalletV10Adapter(makeAllowanceByOwner());
+      // Head walletA: gas but ZERO own-TRAC. Under publish (native+trac) it would
+      // be skipped; under native-only it is fundable, so the head is chosen.
+      nativeByAddr.set(lc(walletA.address), ONE);
+      tracByAddr.set(lc(walletA.address), 0n);
+      const chosen = await (a as any).selectSigner({ txClass: 'rotatable-free', funding: nativeOnly });
+      expect(chosen.address).toBe(walletA.address);
+    });
+
+    it('native-only still skips a gas-EMPTY wallet', async () => {
+      const { a, walletA, walletB, nativeByAddr } = makeMultiWalletV10Adapter(makeAllowanceByOwner());
+      nativeByAddr.set(lc(walletA.address), 0n); nativeByAddr.set(lc(walletB.address), ONE);
+      const chosen = await (a as any).selectSigner({ txClass: 'rotatable-free', funding: nativeOnly });
+      expect(chosen.address).toBe(walletB.address);
+    });
+
+    it('rotatable-free selects over the WHOLE pool, ignoring the authorized-publisher filter', async () => {
+      const { a, walletA } = makeMultiWalletV10Adapter(makeAllowanceByOwner());
+      // No wallet is an authorized publisher → publish (rotatable-policy) throws…
+      (a as any).contracts.contextGraphs = connectable({ isAuthorizedPublisher: recorder(async () => false) });
+      await expect((a as any).selectSigner({ txClass: 'rotatable-policy', contextGraphId: CG, funding: nativeOnly }))
+        .rejects.toThrow(/No authorized publisher wallet/);
+      // …but rotatable-free ignores that surface and picks from the whole pool.
+      const chosen = await (a as any).selectSigner({ txClass: 'rotatable-free', funding: nativeOnly });
+      expect(chosen.address).toBe(walletA.address);
+    });
+
+    it('preferIdle biases toward a funded wallet whose per-wallet lock is free', async () => {
+      const { a, walletA, walletB } = makeMultiWalletV10Adapter(makeAllowanceByOwner());
+      // Both funded (helper default). Hold walletA (the round-robin head) busy.
+      let release!: () => void;
+      const gate = new Promise<void>((r) => { release = r; });
+      void (a as any).signerTxSerializer.run(walletA.address, () => gate);
+      try {
+        const chosen = await (a as any).selectSigner({ txClass: 'rotatable-free', funding: nativeOnly, preferIdle: true });
+        expect(chosen.address).toBe(walletB.address); // idle wallet preferred over the busy head
+      } finally { release(); }
+    });
+
+    it('preferIdle is fail-open: when NO funded wallet is idle it returns the first funded (never excludes)', async () => {
+      const { a, walletA, walletB } = makeMultiWalletV10Adapter(makeAllowanceByOwner());
+      let releaseA!: () => void; let releaseB!: () => void;
+      const gA = new Promise<void>((r) => { releaseA = r; });
+      const gB = new Promise<void>((r) => { releaseB = r; });
+      void (a as any).signerTxSerializer.run(walletA.address, () => gA);
+      void (a as any).signerTxSerializer.run(walletB.address, () => gB);
+      try {
+        const chosen = await (a as any).selectSigner({ txClass: 'rotatable-free', funding: nativeOnly, preferIdle: true });
+        expect(chosen.address).toBe(walletA.address); // both busy → first funded (head), not excluded
+      } finally { releaseA(); releaseB(); }
+    });
+
+    it('DKG_DISABLE_IDLE_AWARE_SELECTION ignores preferIdle (read in the constructor)', async () => {
+      const prev = process.env.DKG_DISABLE_IDLE_AWARE_SELECTION;
+      process.env.DKG_DISABLE_IDLE_AWARE_SELECTION = '1';
+      try {
+        const { a, walletA } = makeMultiWalletV10Adapter(makeAllowanceByOwner());
+        let release!: () => void;
+        const gate = new Promise<void>((r) => { release = r; });
+        void (a as any).signerTxSerializer.run(walletA.address, () => gate);
+        try {
+          const chosen = await (a as any).selectSigner({ txClass: 'rotatable-free', funding: nativeOnly, preferIdle: true });
+          expect(chosen.address).toBe(walletA.address); // idle bias disabled → busy head still chosen
+        } finally { release(); }
+      } finally {
+        if (prev === undefined) delete process.env.DKG_DISABLE_IDLE_AWARE_SELECTION;
+        else process.env.DKG_DISABLE_IDLE_AWARE_SELECTION = prev;
+      }
+    });
+  });
 });
 });
 

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -3866,6 +3866,13 @@ describe('createKnowledgeAssets — funding-aware wallet selection', () => {
   // through the nextAuthorizedSigner wrapper; these cover the NEW capabilities.
   describe('selectSigner — generalized funding modes + idle preference', () => {
     const nativeOnly = { kind: 'native-only' as const, nativeFloorWei: 0n };
+    const nativeAndTrac = {
+      kind: 'native+trac' as const,
+      nativeFloorWei: 0n,
+      tracFloorWei: 0n,
+      requiredTracWei: 0n,
+      consultPca: true,
+    };
 
     it('native-only funding gates on GAS ALONE — a gas-funded zero-TRAC wallet stays fundable', async () => {
       const { a, walletA, nativeByAddr, tracByAddr } = makeMultiWalletV10Adapter(makeAllowanceByOwner());
@@ -3888,7 +3895,7 @@ describe('createKnowledgeAssets — funding-aware wallet selection', () => {
       const { a, walletA } = makeMultiWalletV10Adapter(makeAllowanceByOwner());
       // No wallet is an authorized publisher → publish (rotatable-policy) throws…
       (a as any).contracts.contextGraphs = connectable({ isAuthorizedPublisher: recorder(async () => false) });
-      await expect((a as any).selectSigner({ txClass: 'rotatable-policy', contextGraphId: CG, funding: nativeOnly }))
+      await expect((a as any).selectSigner({ txClass: 'rotatable-policy', contextGraphId: CG, funding: nativeAndTrac }))
         .rejects.toThrow(/No authorized publisher wallet/);
       // …but rotatable-free ignores that surface and picks from the whole pool.
       const chosen = await (a as any).selectSigner({ txClass: 'rotatable-free', funding: nativeOnly });

--- a/packages/chain/test/keyed-mutex.unit.test.ts
+++ b/packages/chain/test/keyed-mutex.unit.test.ts
@@ -63,6 +63,36 @@ describe('KeyedSerializer', () => {
     expect(s.activeKeyCount).toBe(0);
   });
 
+  it('reports active keys while an operation is in flight', async () => {
+    const s = new KeyedSerializer();
+    let release!: () => void;
+    const gate = new Promise<void>((r) => { release = r; });
+    const p = s.run('w', async () => { await gate; });
+
+    expect(s.isActive('w')).toBe(true);
+    expect(s.isActive('other')).toBe(false);
+
+    release();
+    await p;
+    await tick(0);
+    expect(s.isActive('w')).toBe(false);
+  });
+
+  it('reports active keys while later operations are queued', async () => {
+    const s = new KeyedSerializer();
+    let release!: () => void;
+    const gate = new Promise<void>((r) => { release = r; });
+    const p1 = s.run('w', async () => { await gate; });
+    const p2 = s.run('w', async () => undefined);
+
+    expect(s.isActive('w')).toBe(true);
+
+    release();
+    await Promise.all([p1, p2]);
+    await tick(0);
+    expect(s.isActive('w')).toBe(false);
+  });
+
   it('prevents the publisher nonce race: same-wallet sends get distinct, monotonic nonces', async () => {
     // Model the real bug (OriginTrail/dkg#953): an op-wallet's `pending`
     // nonce only advances AFTER a tx is broadcast, and there's an async gap

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -157,6 +157,9 @@ export interface NetworkConfig {
      * Defaults to the EVM adapter's 2,000-block common provider cap.
      */
     cgRegistryScanPageSize?: number;
+    /** Network-level per-chain funding floors (wei). See `ChainConfig.minPublisher*Wei`. */
+    minPublisherNativeWei?: bigint;
+    minPublisherTracWei?: bigint;
   };
   faucet?: {
     url: string;
@@ -258,6 +261,17 @@ export interface ChainConfig {
    * Defaults to the EVM adapter's 2,000-block common provider cap.
    */
   cgRegistryScanPageSize?: number;
+  /**
+   * Funding floors for funding-aware operational-wallet selection (wei of the
+   * native gas token / TRAC). A wallet is preferred for a publish only when its
+   * native balance > `minPublisherNativeWei` AND its own-TRAC covers the publish
+   * above `minPublisherTracWei`; below the floor it is deprioritized (best-funded
+   * fallback still sends). Both default to `0n` (only strictly-empty wallets are
+   * skipped) — per-chain non-zero native defaults are supplied by the network
+   * overlay. Threaded straight to `EVMAdapterConfig.minPublisher*Wei`.
+   */
+  minPublisherNativeWei?: bigint;
+  minPublisherTracWei?: bigint;
 }
 
 export type ResolvedChainConfig = Partial<Omit<ChainConfig, 'approvalPolicy'>> & {
@@ -1250,6 +1264,12 @@ export function resolveChainConfig(
   if (approvalPolicy !== undefined) merged.approvalPolicy = approvalPolicy;
   const cgRegistryScanPageSize = cfg?.cgRegistryScanPageSize ?? net?.cgRegistryScanPageSize;
   if (cgRegistryScanPageSize !== undefined) merged.cgRegistryScanPageSize = cgRegistryScanPageSize;
+  // Funding floors: local config wins, else the network overlay's per-chain
+  // default (both default 0n downstream in the adapter when unset).
+  const minPublisherNativeWei = cfg?.minPublisherNativeWei ?? net?.minPublisherNativeWei;
+  if (minPublisherNativeWei !== undefined) merged.minPublisherNativeWei = minPublisherNativeWei;
+  const minPublisherTracWei = cfg?.minPublisherTracWei ?? net?.minPublisherTracWei;
+  if (minPublisherTracWei !== undefined) merged.minPublisherTracWei = minPublisherTracWei;
   if (cfg?.mockIdentityId !== undefined) merged.mockIdentityId = cfg.mockIdentityId;
   return merged;
 }

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -157,9 +157,13 @@ export interface NetworkConfig {
      * Defaults to the EVM adapter's 2,000-block common provider cap.
      */
     cgRegistryScanPageSize?: number;
-    /** Network-level per-chain funding floors (wei). See `ChainConfig.minPublisher*Wei`. */
-    minPublisherNativeWei?: bigint;
-    minPublisherTracWei?: bigint;
+    /**
+     * Network-level per-chain funding floors (wei). See
+     * `ChainConfig.minPublisher*Wei`. Overlay JSON can only carry
+     * string/number; both are normalized to bigint in `resolveChainConfig`.
+     */
+    minPublisherNativeWei?: bigint | string | number;
+    minPublisherTracWei?: bigint | string | number;
   };
   faucet?: {
     url: string;
@@ -268,14 +272,25 @@ export interface ChainConfig {
    * above `minPublisherTracWei`; below the floor it is deprioritized (best-funded
    * fallback still sends). Both default to `0n` (only strictly-empty wallets are
    * skipped) — per-chain non-zero native defaults are supplied by the network
-   * overlay. Threaded straight to `EVMAdapterConfig.minPublisher*Wei`.
+   * overlay.
+   *
+   * Persisted config (JSON/YAML) cannot express a bigint: use a decimal wei
+   * **string** (recommended — wei amounts overflow the safe number range) or an
+   * integer number. `resolveChainConfig` normalizes + validates both into the
+   * strict bigint that reaches `EVMAdapterConfig.minPublisher*Wei`, failing
+   * fast at startup on decimals, negatives, or unsafe-precision numbers.
    */
-  minPublisherNativeWei?: bigint;
-  minPublisherTracWei?: bigint;
+  minPublisherNativeWei?: bigint | string | number;
+  minPublisherTracWei?: bigint | string | number;
 }
 
-export type ResolvedChainConfig = Partial<Omit<ChainConfig, 'approvalPolicy'>> & {
+export type ResolvedChainConfig = Partial<
+  Omit<ChainConfig, 'approvalPolicy' | 'minPublisherNativeWei' | 'minPublisherTracWei'>
+> & {
   approvalPolicy?: ApprovalPolicyConfig;
+  /** Normalized funding floors — always bigint past resolution. */
+  minPublisherNativeWei?: bigint;
+  minPublisherTracWei?: bigint;
 };
 
 export interface LargeLiteralStorageConfig {
@@ -944,6 +959,50 @@ export function resolveApprovalPolicy(
   };
 }
 
+/**
+ * Normalize a persisted wei amount (funding floors) into a bigint.
+ *
+ * JSON/YAML configs and the network overlay can only produce strings and
+ * numbers, never bigints — so accept all three and fail fast at startup on
+ * anything that would otherwise silently mis-compare downstream: decimal
+ * strings (`BigInt('0.002')` throws — good), empty strings (`BigInt('')` is
+ * silently `0n` — guarded), non-integer or unsafe-precision numbers (would
+ * lose wei), and negatives (would invert the floor comparison).
+ */
+export function parseWeiFloor(
+  value: bigint | string | number | undefined,
+  label: string,
+): bigint | undefined {
+  if (value === undefined) return undefined;
+  let parsed: bigint;
+  if (typeof value === 'bigint') {
+    parsed = value;
+  } else if (typeof value === 'number') {
+    if (!Number.isSafeInteger(value)) {
+      throw new Error(
+        `${label} must be an integer within Number.MAX_SAFE_INTEGER when given as a number — use a decimal wei string for larger amounts (got: ${value})`,
+      );
+    }
+    parsed = BigInt(value);
+  } else {
+    const trimmed = value.trim();
+    if (trimmed.length === 0) {
+      throw new Error(`${label} must be a decimal wei bigint string (got an empty string)`);
+    }
+    try {
+      parsed = BigInt(trimmed);
+    } catch (err: any) {
+      throw new Error(
+        `${label} must be a decimal wei bigint string (got: ${JSON.stringify(value)}, ${err?.message ?? err})`,
+      );
+    }
+  }
+  if (parsed < 0n) {
+    throw new Error(`${label} must be non-negative (got: ${parsed})`);
+  }
+  return parsed;
+}
+
 let _networkConfig: NetworkConfig | null = null;
 let _networkConfigName: string | null = null;
 
@@ -1265,10 +1324,18 @@ export function resolveChainConfig(
   const cgRegistryScanPageSize = cfg?.cgRegistryScanPageSize ?? net?.cgRegistryScanPageSize;
   if (cgRegistryScanPageSize !== undefined) merged.cgRegistryScanPageSize = cgRegistryScanPageSize;
   // Funding floors: local config wins, else the network overlay's per-chain
-  // default (both default 0n downstream in the adapter when unset).
-  const minPublisherNativeWei = cfg?.minPublisherNativeWei ?? net?.minPublisherNativeWei;
+  // default (both default 0n downstream in the adapter when unset). Persisted
+  // values arrive as string/number — normalize to bigint here, failing fast on
+  // garbage instead of letting it reach the adapter's balance comparisons.
+  const minPublisherNativeWei = parseWeiFloor(
+    cfg?.minPublisherNativeWei ?? net?.minPublisherNativeWei,
+    'chain.minPublisherNativeWei',
+  );
   if (minPublisherNativeWei !== undefined) merged.minPublisherNativeWei = minPublisherNativeWei;
-  const minPublisherTracWei = cfg?.minPublisherTracWei ?? net?.minPublisherTracWei;
+  const minPublisherTracWei = parseWeiFloor(
+    cfg?.minPublisherTracWei ?? net?.minPublisherTracWei,
+    'chain.minPublisherTracWei',
+  );
   if (minPublisherTracWei !== undefined) merged.minPublisherTracWei = minPublisherTracWei;
   if (cfg?.mockIdentityId !== undefined) merged.mockIdentityId = cfg.mockIdentityId;
   return merged;

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1581,6 +1581,8 @@ export async function runDaemonInner(
       chainId: chainBase.chainId,
       approvalPolicy: resolveApprovalPolicy(chainBase.approvalPolicy) as ApprovalPolicy | undefined,
       cgRegistryScanPageSize: chainBase.cgRegistryScanPageSize,
+      minPublisherNativeWei: chainBase.minPublisherNativeWei,
+      minPublisherTracWei: chainBase.minPublisherTracWei,
     } : undefined,
     sharedMemoryTtlMs: resolveSharedMemoryTtlMs(config),
     // RFC ka-metadata-trim P3.3 — lifecycle PROV event writes (default true).

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -875,6 +875,34 @@ describe('resolveChainConfig (field-level merge)', () => {
     expect(overridden?.cgRegistryScanPageSize).toBe(4_000);
   });
 
+  it('merges publisher funding floors with operator precedence', () => {
+    const inherited = resolveChainConfig(
+      {},
+      {
+        chain: {
+          ...fullNetworkChain,
+          minPublisherNativeWei: 123n,
+          minPublisherTracWei: 456n,
+        },
+      },
+    );
+    expect(inherited?.minPublisherNativeWei).toBe(123n);
+    expect(inherited?.minPublisherTracWei).toBe(456n);
+
+    const overridden = resolveChainConfig(
+      { chain: { minPublisherNativeWei: 789n } },
+      {
+        chain: {
+          ...fullNetworkChain,
+          minPublisherNativeWei: 123n,
+          minPublisherTracWei: 456n,
+        },
+      },
+    );
+    expect(overridden?.minPublisherNativeWei).toBe(789n);
+    expect(overridden?.minPublisherTracWei).toBe(456n);
+  });
+
   it('dedupes primary + backups while preserving operator priority', () => {
     const merged = resolveChainConfig(
       {

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -903,6 +903,39 @@ describe('resolveChainConfig (field-level merge)', () => {
     expect(overridden?.minPublisherTracWei).toBe(456n);
   });
 
+  it('normalizes persisted (JSON/YAML) funding-floor strings and numbers to bigint', () => {
+    // What operators and the network overlay can actually produce: JSON.parse /
+    // yaml.load never yield bigints. Strings must survive above 2^53.
+    const merged = resolveChainConfig(
+      { chain: { minPublisherNativeWei: '2000000000000000000' } },
+      { chain: { ...fullNetworkChain, minPublisherTracWei: 456 } },
+    );
+    expect(merged?.minPublisherNativeWei).toBe(2_000_000_000_000_000_000n);
+    expect(merged?.minPublisherTracWei).toBe(456n);
+
+    // Operator string overrides an overlay number.
+    const overridden = resolveChainConfig(
+      { chain: { minPublisherNativeWei: '789' } },
+      { chain: { ...fullNetworkChain, minPublisherNativeWei: 123 } },
+    );
+    expect(overridden?.minPublisherNativeWei).toBe(789n);
+  });
+
+  it('rejects malformed funding-floor values at startup instead of mis-comparing silently', () => {
+    const withFloor = (chain: Record<string, unknown>) =>
+      resolveChainConfig({ chain: chain as never }, { chain: fullNetworkChain });
+    expect(() => withFloor({ minPublisherNativeWei: '0.002' }))
+      .toThrow(/chain\.minPublisherNativeWei must be a decimal wei bigint string/);
+    expect(() => withFloor({ minPublisherNativeWei: '' }))
+      .toThrow(/empty string/);
+    expect(() => withFloor({ minPublisherTracWei: -5 }))
+      .toThrow(/non-negative/);
+    expect(() => withFloor({ minPublisherNativeWei: 1e18 }))
+      .toThrow(/MAX_SAFE_INTEGER/);
+    expect(() => withFloor({ minPublisherTracWei: 1.5 }))
+      .toThrow(/MAX_SAFE_INTEGER/);
+  });
+
   it('dedupes primary + backups while preserving operator priority', () => {
     const merged = resolveChainConfig(
       {


### PR DESCRIPTION
Stacked on #1503 (Phase 0/1). Two commits.

## Phase 2 — plumb `minPublisher{Native,Trac}Wei` floors end-to-end
Makes the funding-aware selection floors settable from node config / network overlay: `ChainConfig` → `ResolvedChainConfig` → `AgentConfig.chainConfig` → `EVMAdapterConfig`, merged in `resolveChainConfig` (local config wins, network-overlay fallback).

**Zero behaviour change** — both floors still default to `0n` in the adapter constructor, so publish selection is unchanged. This only opens the seam. The non-zero per-chain native defaults (Base/Gnosis/NeuroWeb) are supplied later via the network overlay, once RS actually consumes them; `minPublisherTracWei` stays `0n` by default (`requiredTracWei` already sizes TRAC per publish).

## Phase 3 — generalize `nextAuthorizedSigner` → `selectSigner(spec)`
Refactor the publish-only funding-aware selector into a generalized seam that RS / update / relay route through in later phases. `nextAuthorizedSigner`, `selectFundedSigner`, and `isWalletPublishFundable` become **thin wrappers**.

**Publish selection is byte-identical** — the `#870` approval-signer-parity and funding-aware-selection golden blocks (196 tests in `evm-adapter.unit.test.ts`) pass with **assertions unmodified**.

New seams (dormant until a caller routes through them):
- **`FundingMode`** discriminated union — `native-only` (RS/relay/settle: gas only; a TRAC floor is *unrepresentable*, so a valid gas-funded zero-TRAC wallet is never wrongly rejected) vs `native+trac` (publish/update: own-TRAC covers the cost, PCA fallback).
- **`isWalletFundable(address, f, mode)`** — the single predicate; `isWalletPublishFundable` delegates.
- **`SelectSignerSpec.txClass`** eligibility — `rotatable-policy` (authorized-publisher filter) vs `rotatable-funded`/`rotatable-free` (whole pool).
- **`preferIdle`** — soft, fail-open bias toward a funded wallet whose per-wallet lock is free (`KeyedSerializer.isActive`), behind the new `DKG_DISABLE_IDLE_AWARE_SELECTION` kill-switch. **OFF for publish.**

Selection still runs under the same `signerSelectionQueue` + `signerIndex` cursor; RPC stays inside the lock (hoisting deferred to the RS-routing phase).

### Known, intentional: `preferIdle` is *advisory*
`selectSigner` returns a bare wallet and the caller acquires the send lock (`signerTxSerializer.run`) separately, so a wallet judged idle can be busy by send time. This costs only a missed optimization, never correctness — the per-wallet serializer still guarantees nonce safety. The spec's tighter "commit the lock inside selection" coupling is a later refinement. `preferIdle` is unused until RS routing (next phase), and OFF for publish.

## Tests
- 6 new tests: native-only funding, whole-pool eligibility, idle preference incl. the kill-switch.
- Full chain unit suite: **536 passed, 1 skipped.**

## Review
Adversarial review (3 angles — publish byte-identity vs `origin/main` line-by-line, FundingMode/first-fundable equivalence, idle TOCTOU/fail-open/kill-switch, each independently verified): **all hold, zero confirmed issues.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)