### PR TITLE
fix(publisher): empty ACK reply → retryable transport, not INVALID_SIGNATURE

### DIFF
--- a/packages/publisher/src/ack-collector.ts
+++ b/packages/publisher/src/ack-collector.ts
@@ -728,6 +728,25 @@ export class ACKCollector {
             'publisher.ack_peer_request',
             async (span) => {
               const response = await this.deps.sendP2P(peerId, ackProtocolId, intentBytes);
+              // A ZERO-LENGTH reply is not a StorageACK — it is what the
+              // requester reads when the responder aborts the stream
+              // mid-handler (protocol-router stream.abort → clean EOF →
+              // readAll returns empty bytes). decodeStorageACK would turn it
+              // into a default message with empty signature fields, which
+              // recoverACKSigner then rejects as INVALID_SIGNATURE — a
+              // cryptographic verdict on what is really a transport/store
+              // hiccup, permanently deselecting a healthy peer mid-round.
+              // 2026-07-07 mainnet incident: cores under store load returned
+              // CORE_TEMPORARILY_UNAVAILABLE declines whose stream had already
+              // been abandoned by the publisher's send timeout, so every such
+              // round surfaced as "Invalid ACK signature". Treat an empty
+              // reply as a recoverable transport error: it rides the transport
+              // retry budget and, if it persists, terminates as TRANSPORT_ERROR
+              // (the peer's 6-step transient ladder / a re-dial can still land
+              // a real ACK) rather than a terminal signature rejection.
+              if (response.length === 0) {
+                throw new Error('empty ACK reply (stream aborted remotely — responder decline/abort or connection churn)');
+              }
               const decoded: StorageACKMsg = decodeStorageACK(response);
               if (isStorageACKDecline(decoded)) {
                 const declineCode = sanitizeDeclineField(

--- a/packages/publisher/test/ack-collector.test.ts
+++ b/packages/publisher/test/ack-collector.test.ts
@@ -518,6 +518,107 @@ describe('ACKCollector', () => {
     }
   });
 
+  // 2026-07-07 mainnet incident: a core under store load (Blazegraph
+  // `fetch failed`) computed a CORE_TEMPORARILY_UNAVAILABLE decline but the
+  // publisher's send timeout had already aborted the stream, so the reply
+  // read back as ZERO bytes. The old collector fed that empty buffer to
+  // decodeStorageACK → recoverACKSigner → null → terminal INVALID_SIGNATURE,
+  // permanently deselecting a healthy peer on the first blip. An empty reply
+  // is a transport artifact, not a cryptographic verdict.
+  it('treats a zero-length ACK reply as retryable transport, not terminal INVALID_SIGNATURE, and recovers', async () => {
+    const callsByPeer = new Map<string, number>();
+    const EMPTY_BEFORE_ACK = 2; // within the MAX_RETRIES transport budget
+    const deps: ACKCollectorDeps = {
+      gossipPublish: async () => {},
+      sleep: async () => {}, // collapse backoff
+      sendP2P: async (peerId) => {
+        const n = (callsByPeer.get(peerId) ?? 0) + 1;
+        callsByPeer.set(peerId, n);
+        if (n <= EMPTY_BEFORE_ACK) return new Uint8Array(0); // aborted stream
+        const idx = parseInt(peerId.replace('peer-', ''), 10);
+        const { r, vs } = await signACK(coreWallets[idx], testCGId, merkleRoot, 1, 100n);
+        return encodeStorageACK({
+          merkleRoot,
+          coreNodeSignatureR: r,
+          coreNodeSignatureVS: vs,
+          contextGraphId: testCGIdStr,
+          nodeIdentityId: idx + 1,
+        });
+      },
+      getConnectedCorePeers: () => ['peer-0', 'peer-1', 'peer-2'],
+      log: () => {},
+    };
+
+    const collector = new ACKCollector(deps);
+    const result = await collector.collect({
+      merkleRoot,
+      contextGraphId: testCGId,
+      contextGraphIdStr: testCGIdStr,
+      publisherPeerId: 'publisher-0',
+      publicByteSize: 100n,
+      isPrivate: false,
+      kaCount: 1,
+      rootEntities: ['urn:a'],
+      chainId: TEST_CHAIN_ID,
+      kav10Address: TEST_KAV10_ADDR,
+      merkleLeafCount,
+      ackMode: { kind: 'public' },
+    });
+
+    // Every peer recovered on its 3rd send — impossible if the first empty
+    // reply had been treated as terminal INVALID_SIGNATURE.
+    expect(result.acks).toHaveLength(3);
+    for (const peerId of ['peer-0', 'peer-1', 'peer-2']) {
+      expect(callsByPeer.get(peerId)).toBe(EMPTY_BEFORE_ACK + 1);
+    }
+  });
+
+  it('a persistent zero-length reply terminates as bounded TRANSPORT_ERROR, never INVALID_SIGNATURE', async () => {
+    const callsByPeer = new Map<string, number>();
+    const deps: ACKCollectorDeps = {
+      gossipPublish: async () => {},
+      sleep: async () => {},
+      sendP2P: async (peerId) => {
+        callsByPeer.set(peerId, (callsByPeer.get(peerId) ?? 0) + 1);
+        return new Uint8Array(0); // stream aborted on every attempt
+      },
+      getConnectedCorePeers: () => ['peer-0', 'peer-1', 'peer-2'],
+      log: () => {},
+    };
+
+    const collector = new ACKCollector(deps);
+    let caught: Error | undefined;
+    try {
+      await collector.collect({
+        merkleRoot,
+        contextGraphId: testCGId,
+        contextGraphIdStr: testCGIdStr,
+        publisherPeerId: 'publisher-0',
+        publicByteSize: 100n,
+        isPrivate: false,
+        kaCount: 1,
+        rootEntities: ['urn:a'],
+        chainId: TEST_CHAIN_ID,
+        kav10Address: TEST_KAV10_ADDR,
+        merkleLeafCount,
+        ackMode: { kind: 'public' },
+      });
+    } catch (err) {
+      caught = err as Error;
+    }
+
+    expect(caught).toBeDefined();
+    expect(caught!.message).toContain('storage_ack_insufficient');
+    // The failure is classified transport, not signature — this is the whole
+    // point of the fix: a store/stream hiccup must not read as a crypto fault.
+    expect(caught!.message).toContain('TRANSPORT_ERROR');
+    expect(caught!.message).not.toContain('INVALID_SIGNATURE');
+    // Bounded by the transport budget (MAX_RETRIES=3 in the source), no hang.
+    for (const peerId of ['peer-0', 'peer-1', 'peer-2']) {
+      expect(callsByPeer.get(peerId)).toBe(3);
+    }
+  });
+
   // PR #896 review (🟡): the widened #887 transient-decline budget (~31s)
   // must NOT keep a losing peer dialing after quorum has already formed
   // elsewhere. A peer still mid-retry when the last needed ACK lands must


### PR DESCRIPTION
## Summary
An aborted responder stream (protocol-router `stream.abort` → clean EOF) makes `sendP2P` return **zero bytes**. The collector fed that empty buffer to `decodeStorageACK` → `recoverACKSigner` → `null` → terminal **`INVALID_SIGNATURE`**, permanently deselecting a healthy peer on the first blip and mislabeling a transport/store hiccup as a cryptographic fault.

## Live incident evidence (2026-07-07 Gnosis mainnet)
Cores under store load (`store unavailable: fetch failed`) returned typed `CORE_TEMPORARILY_UNAVAILABLE` declines, but the publisher's 20s send timeout had already abandoned the stream, so the reply read back empty → logged as `Invalid ACK signature`. This mislabel sent the incident RCA chasing mixed-version / folded-private theories for three rounds. On a recovering fleet, publishes stuck at **2/3 valid ACKs** with the two failures both `dial=ok, reason=INVALID_SIGNATURE` — i.e. empty replies from churned streams. With this fix those become retries and the round reaches 3/3.

## Change
Detect a zero-length reply immediately after `sendP2P` and throw, so it rides the existing transport-retry budget (`MAX_RETRIES`) and, if it persists, terminates as `TRANSPORT_ERROR` — leaving the peer's transient-decline ladder and a re-dial able to still land a real ACK.

## Tests
- empty reply recovers on retry (peer not deselected)
- persistent empty terminates as bounded `TRANSPORT_ERROR`, never `INVALID_SIGNATURE`
- full `ack-collector` suite: 15/15

🤖 Generated with [Claude Code](https://claude.com/claude-code)