### PR TITLE
fix(core): relay watchdog must not churn sibling-core connections on public nodes

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -54,6 +54,7 @@ export {
   // entries from the phonebook).
   isPublicLikeAddress,
   isLocalOrInternalHostname,
+  nodeHasDirectPublicAddress,
 } from './node.js';
 // NOTE: `isFinitePositiveInteger`, `buildPeerStoreOverrides`, and
 // `buildKadDHTOptions` are intentionally NOT re-exported. They are

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -54,7 +54,6 @@ export {
   // entries from the phonebook).
   isPublicLikeAddress,
   isLocalOrInternalHostname,
-  nodeHasDirectPublicAddress,
 } from './node.js';
 // NOTE: `isFinitePositiveInteger`, `buildPeerStoreOverrides`, and
 // `buildKadDHTOptions` are intentionally NOT re-exported. They are
@@ -63,7 +62,11 @@ export {
 // `../src/node.js` directly so the package root stays free of
 // internals that would otherwise commit us to a semver contract
 // for test-only surface. Codex review of PR #698 round 3 flagged
-// the prior leak.
+// the prior leak. Same rule for `nodeHasDirectPublicAddress` (the
+// relay watchdog's public-reachability gate, PR #1508): it has no
+// production consumer outside `node.ts`, and its tests
+// (`core/test/relay-public-reachability.test.ts`, `core/test/relay.test.ts`)
+// deep-import it from `../src/node.js`.
 export {
   type Network,
   type NodeIdentity,

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -479,6 +479,19 @@ export function isPublicLikeAddress(addr: string): boolean {
   return false;
 }
 
+/**
+ * True when the node advertises at least one DIRECT (non-circuit) public
+ * self-address — i.e. peers can dial it without a relay hop. Such a node does
+ * not need client-side circuit reservations, so the relay watchdog must not
+ * `close()` + redial relay-target connections trying to force one it will
+ * never obtain (the 2026-07-07 Gnosis mainnet ACK-stream churn). A `/p2p-circuit`
+ * self-address is proof of the OPPOSITE — reachability THROUGH a relay — so it
+ * is explicitly excluded here.
+ */
+export function nodeHasDirectPublicAddress(selfAddrs: readonly string[]): boolean {
+  return selfAddrs.some((a) => !a.includes('/p2p-circuit') && isPublicLikeAddress(a));
+}
+
 export class DKGNode {
   private node: Libp2p<DKGServices> | null = null;
   private readonly config: DKGNodeConfig;
@@ -1189,6 +1202,24 @@ export class DKGNode {
     // hint stays accurate within a single iteration.
     let circuitSelfAddrs = node.getMultiaddrs().map(ma => ma.toString()).filter(a => a.includes('/p2p-circuit'));
     let haveAnyReservation = circuitSelfAddrs.length > 0;
+    // A publicly-reachable node — one advertising a direct, non-circuit
+    // public self-address (e.g. a Core Node on a public IP) — does not need
+    // client-side circuit reservations at all: peers dial it directly. On
+    // such a node libp2p never forms a `/p2p-circuit` self-addr, so
+    // `haveAnyReservation` stays false forever and the reservation-recovery
+    // branch below would `close()` + redial every relay-target connection on
+    // each grace-window expiry — permanent churn against the very sibling
+    // cores that StorageACK streams run over. (2026-07-07 Gnosis mainnet: the
+    // watchdog dropping 61u7AUrG/Xw8orCA1 aborted in-flight ACK streams →
+    // empty replies the publisher mislabeled as INVALID_SIGNATURE.) When the
+    // node is publicly reachable we treat every relay's reservation gate as
+    // satisfied and skip the forced drop+redial; the benign
+    // reconnect-on-disconnect path below still keeps relay connections alive
+    // for NAT'd peers that reach us over a hop. Snapshotted once per tick —
+    // a node's public-ness doesn't change mid-tick.
+    const nodeIsPubliclyReachable = nodeHasDirectPublicAddress(
+      node.getMultiaddrs().map((ma) => ma.toString()),
+    );
     // Distinct count of CONFIGURED relays that currently hold a
     // reservation. This is the "do we have enough reservations?"
     // signal — not "does every peer hold one?". Recomputed alongside
@@ -1257,6 +1288,7 @@ export class DKGNode {
       // target > current is still detected and recovered) without
       // demanding 100% coverage when target < relayPeers.length.
       const reservationGateSatisfied =
+        nodeIsPubliclyReachable ||
         thisRelayHasReservation ||
         reservedRelayCount >= this.relayReservationCountTarget;
       if (transportUp && reservationGateSatisfied) {

--- a/packages/core/test/relay-public-reachability.test.ts
+++ b/packages/core/test/relay-public-reachability.test.ts
@@ -1,0 +1,59 @@
+// relay-public-reachability.test.ts
+//
+// 2026-07-07 Gnosis mainnet regression: a public Core Node's relay watchdog
+// never obtained a client-side circuit reservation (`0 /p2p-circuit
+// self-addrs`) and so `close()` + redialed its sibling-core connections on
+// every grace-window expiry — churning the exact peers StorageACK streams run
+// over, aborting in-flight ACK responses (empty replies the publisher then
+// mislabeled as INVALID_SIGNATURE). The fix gates the reservation-forcing
+// branch on `nodeHasDirectPublicAddress`: a directly-dialable node needs no
+// client reservation, so it keeps its relay connections instead of thrashing
+// them. This pins that predicate.
+import { describe, it, expect } from 'vitest';
+import { nodeHasDirectPublicAddress } from '../src/node.js';
+
+const CORE = '178.104.101.41'; // oliwav / dHfyz351, a real Gnosis mainnet core
+const PEER = '12D3KooWL9gwurFAVhQguJVs8CpzuSbt2hom9jyNJ5oHdHfyz351';
+
+describe('nodeHasDirectPublicAddress', () => {
+  it('true for a direct public /ip4 self-address (mainnet core shape)', () => {
+    expect(nodeHasDirectPublicAddress([`/ip4/${CORE}/tcp/9090/p2p/${PEER}`])).toBe(true);
+  });
+
+  it('true for a public /dns4 self-address', () => {
+    expect(nodeHasDirectPublicAddress([`/dns4/core.example.org/tcp/9090/p2p/${PEER}`])).toBe(true);
+  });
+
+  it('false for a circuit self-address only (reachable ONLY through a relay = NAT\'d)', () => {
+    // A /p2p-circuit self-addr is proof of the opposite — this node DOES need
+    // its reservation, so the watchdog must keep maintaining it.
+    expect(nodeHasDirectPublicAddress([
+      `/ip4/198.51.100.7/tcp/9090/p2p/RELAY/p2p-circuit/p2p/${PEER}`,
+    ])).toBe(false);
+  });
+
+  it('false for private / loopback / CGNAT-only addresses (a genuinely NAT\'d node)', () => {
+    expect(nodeHasDirectPublicAddress([
+      `/ip4/10.0.0.5/tcp/9090/p2p/${PEER}`,
+      `/ip4/192.168.1.20/tcp/9090/p2p/${PEER}`,
+      `/ip4/172.16.4.4/tcp/9090/p2p/${PEER}`,
+      `/ip4/100.64.0.1/tcp/9090/p2p/${PEER}`,   // CGNAT
+      `/ip4/127.0.0.1/tcp/9090/p2p/${PEER}`,
+    ])).toBe(false);
+  });
+
+  it('true when a public direct address sits alongside circuit + private ones', () => {
+    // Mixed set: the node has a public IP AND holds a circuit reservation and
+    // has private LAN addrs. The public direct addr is decisive — it does not
+    // need the circuit reservation, so the watchdog stops forcing it.
+    expect(nodeHasDirectPublicAddress([
+      `/ip4/10.0.0.5/tcp/9090/p2p/${PEER}`,
+      `/ip4/198.51.100.7/tcp/9090/p2p/RELAY/p2p-circuit/p2p/${PEER}`,
+      `/ip4/${CORE}/tcp/9090/p2p/${PEER}`,
+    ])).toBe(true);
+  });
+
+  it('false for an empty address set (nothing advertised yet — do not assume public)', () => {
+    expect(nodeHasDirectPublicAddress([])).toBe(false);
+  });
+});

--- a/packages/core/test/relay.test.ts
+++ b/packages/core/test/relay.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { DKGNode } from '../src/node.js';
+import { DKGNode, nodeHasDirectPublicAddress } from '../src/node.js';
 import { ProtocolRouter } from '../src/protocol-router.js';
 import { PeerDiscoveryManager } from '../src/discovery.js';
 import { TypedEventBus } from '../src/event-bus.js';
@@ -988,4 +988,156 @@ describe('Circuit Relay', () => {
       expect(finalReservedPids.has(pid as string)).toBe(true);
     }
   }, 25000);
+
+  it('publicly-reachable node keeps relay-target connections despite 0 reservations (PR #1508)', async () => {
+    // 2026-07-07 Gnosis mainnet incident: a public Core Node advertises a
+    // direct public self-address, so libp2p never forms a `/p2p-circuit`
+    // self-addr for it and `haveAnyReservation` stays false forever. The
+    // pre-#1508 watchdog read that as "reservation lost everywhere" and
+    // `close()` + redialed every relay-target connection on each tick past
+    // the grace window — permanent churn against the very sibling cores
+    // that StorageACK streams run over (aborting in-flight ACK replies the
+    // publisher then mislabeled INVALID_SIGNATURE).
+    //
+    // Gate under test: `reservationGateSatisfied` is also satisfied by
+    // `nodeIsPubliclyReachable` (`nodeHasDirectPublicAddress` over the
+    // node's self-addrs). Deleting that gate from `watchdogTick` must make
+    // THIS test fail — the classifier-only tests in
+    // relay-public-reachability.test.ts stay green without it.
+    //
+    // Harness wrinkle: test nodes listen on loopback, which the classifier
+    // rightly treats as non-public. We reproduce the mainnet self-addr
+    // shape via `announceAddresses`: when announce addrs are configured,
+    // libp2p's AddressManager returns ONLY those from `getMultiaddrs()`,
+    // handing the watchdog exactly what the incident node saw — one direct
+    // public self-addr, ZERO /p2p-circuit self-addrs, transport to the
+    // relay target up. The announced addr is RFC 5737 TEST-NET-3
+    // (public-classified, guaranteed unroutable) and is never dialed.
+    const relay = new DKGNode({
+      listenAddresses: ['/ip4/127.0.0.1/tcp/0'],
+      enableMdns: false,
+      enableRelayServer: true,
+    });
+    nodes.push(relay);
+    await relay.start();
+    const relayAddr = relay.multiaddrs.find(a => a.includes('/tcp/'))!;
+
+    const edge = new DKGNode({
+      listenAddresses: ['/ip4/127.0.0.1/tcp/0'],
+      enableMdns: false,
+      relayPeers: [relayAddr],
+      announceAddresses: ['/ip4/203.0.113.7/tcp/9090'],
+    });
+    nodes.push(edge);
+    await edge.start();
+
+    // start() awaits the relay-target dial, but poll briefly anyway so a
+    // slow accept can't flake the precondition.
+    const deadline = Date.now() + 5_000;
+    while (Date.now() < deadline) {
+      if (edge.libp2p.getConnections().some(c => c.remotePeer.toString() === relay.peerId)) break;
+      await new Promise(r => setTimeout(r, 100));
+    }
+
+    // Preconditions: the exact watchdog-observable mainnet state.
+    const selfAddrs = edge.libp2p.getMultiaddrs().map(ma => ma.toString());
+    expect(
+      selfAddrs.filter(a => a.includes('/p2p-circuit')),
+      `expected ZERO /p2p-circuit self-addrs (announce-only address set); got: ${JSON.stringify(selfAddrs)}`,
+    ).toHaveLength(0);
+    expect(nodeHasDirectPublicAddress(selfAddrs)).toBe(true);
+
+    const before = edge.libp2p.getConnections().filter(c => c.remotePeer.toString() === relay.peerId);
+    expect(before.length).toBeGreaterThan(0);
+    const beforeIds = before.map(c => c.id).sort();
+
+    const logSpy = spyConsole('log');
+    try {
+      // The first manual tick is already "past the grace window":
+      // `relayReservationRedialAt` is empty, so nothing suppresses the
+      // forcing branch except the public-reachability gate under test.
+      // Two ticks so a first-tick pass can't mask a second-tick drop.
+      const tick = (edge as unknown as { watchdogTick: () => Promise<void> }).watchdogTick.bind(edge);
+      await tick();
+      await tick();
+
+      const churnLogs = logSpy.calls.filter((call) =>
+        typeof call[0] === 'string'
+        && call[0].includes('Relay watchdog')
+        && (call[0].includes('dropping + redialing') || call[0].includes('to force reserve')),
+      );
+      expect(
+        churnLogs,
+        `public node must NOT force-drop relay-target connections; got: ${JSON.stringify(churnLogs.map(c => c[0]))}`,
+      ).toHaveLength(0);
+    } finally {
+      console.log = ORIG_CONSOLE_LOG;
+    }
+
+    // The very same connections survived — close() was never called on them.
+    const after = edge.libp2p.getConnections().filter(c => c.remotePeer.toString() === relay.peerId);
+    expect(after.map(c => c.id).sort()).toEqual(beforeIds);
+    expect(after.every(c => c.status === 'open')).toBe(true);
+  }, 20000);
+
+  it("NAT'd node (private self-addrs only) still forces reservation recovery (PR #1508 sanity)", async () => {
+    // Counterpart to the public-node test above: the #1508 gate must not
+    // disable reservation recovery for nodes that genuinely depend on it.
+    // Every pre-existing watchdog test asserts the forcing branch's
+    // ABSENCE; this one pins that it still FIRES on the NAT'd path.
+    //
+    // Deterministic "transport up, reservation impossible" state: the
+    // relay target is NOT a relay server, so it never advertises the
+    // circuit-hop protocol and the edge holds a live connection but can
+    // never obtain a reservation. Loopback-only listen addrs make
+    // `nodeHasDirectPublicAddress` false, so the watchdog must take the
+    // drop + redial path on the first tick (empty grace map = past the
+    // grace window).
+    const target = new DKGNode({
+      listenAddresses: ['/ip4/127.0.0.1/tcp/0'],
+      enableMdns: false,
+    });
+    nodes.push(target);
+    await target.start();
+    const targetAddr = target.multiaddrs.find(a => a.includes('/tcp/'))!;
+
+    const edge = new DKGNode({
+      listenAddresses: ['/ip4/127.0.0.1/tcp/0'],
+      enableMdns: false,
+      relayPeers: [targetAddr],
+    });
+    nodes.push(edge);
+    await edge.start();
+
+    const deadline = Date.now() + 5_000;
+    while (Date.now() < deadline) {
+      if (edge.libp2p.getConnections().some(c => c.remotePeer.toString() === target.peerId)) break;
+      await new Promise(r => setTimeout(r, 100));
+    }
+
+    // Preconditions: transport up, no public self-addr, no reservation.
+    const selfAddrs = edge.libp2p.getMultiaddrs().map(ma => ma.toString());
+    expect(nodeHasDirectPublicAddress(selfAddrs)).toBe(false);
+    expect(selfAddrs.filter(a => a.includes('/p2p-circuit'))).toHaveLength(0);
+    expect(
+      edge.libp2p.getConnections().some(c => c.remotePeer.toString() === target.peerId),
+    ).toBe(true);
+
+    const logSpy = spyConsole('log');
+    try {
+      await (edge as unknown as { watchdogTick: () => Promise<void> }).watchdogTick();
+
+      const forcingLog = logSpy.calls.find((call) =>
+        typeof call[0] === 'string'
+        && call[0].includes('Relay watchdog')
+        && call[0].includes('to force reserve'),
+      );
+      expect(
+        forcingLog,
+        `NAT'd node with 0 reservations must still force-redial; got: ${JSON.stringify(logSpy.calls.map(c => c[0]))}`,
+      ).toBeDefined();
+    } finally {
+      console.log = ORIG_CONSOLE_LOG;
+    }
+  }, 20000);
 });


### PR DESCRIPTION
## Summary
A publicly-reachable node (a direct, non-circuit public self-address — every mainnet Core Node) does not need a client-side circuit reservation: peers dial it directly. But libp2p never forms a `/p2p-circuit` self-addr for such a node, so the watchdog's `haveAnyReservation` stayed **false forever**, and its reservation-recovery branch `close()`+redialed **every relay-target connection** on each grace-window expiry.

## Live incident evidence (2026-07-07 Gnosis mainnet)
Those relay targets are the sibling Core Nodes. The watchdog was dropping `61u7AUrG` / `Xw8orCA1` every 20–300s:
```
Relay watchdog: no circuit reservation anywhere (0 /p2p-circuit self-addrs); dropping + redialing 61u7AUrG to force reserve
```
That aborted the in-flight StorageACK streams running over exactly those connections → empty replies the publisher mislabeled `INVALID_SIGNATURE` → publishes stuck at 2/3. It was pure churn: the reservation being chased can never exist on a public node.

## Change
Gate the reservation-**forcing** branch on `nodeHasDirectPublicAddress` (extracted + exported for unit tests). A publicly-reachable node treats every relay's reservation gate as satisfied and keeps its connections. Untouched: the benign reconnect-on-disconnect path (relay connectivity for NAT'd peers), the relay **server** role, and NAT'd nodes (circuit-only / private self-addrs) which still maintain their reservations.

Removes the need for the operational `relay: "none"` workaround on public cores — ships the fix via release instead of per-node config.

## Tests
- `nodeHasDirectPublicAddress`: public /ip4 + /dns4 → true; circuit-only / private / CGNAT / empty → false; mixed public+circuit+private → true (6 cases)
- relay suite (relay + reservation-count + flap-guard): 45/45

🤖 Generated with [Claude Code](https://claude.com/claude-code)