### PR TITLE
fix(publisher): unify the SWM merkle-root exclusion filter (publisher ⇄ responder)

### DIFF
--- a/packages/core/src/trust.ts
+++ b/packages/core/src/trust.ts
@@ -25,6 +25,30 @@ export function isTrustLevelQuad(quad: Pick<TrustLevelQuadLike, 'predicate'>): b
   return TRUST_LEVEL_PREDICATES.has(quad.predicate);
 }
 
+/**
+ * Workspace-owner bookkeeping predicate. Stamped onto SWM quads during
+ * ingestion to record which agent owns a shared-memory entry; it is NOT part
+ * of the author's payload.
+ */
+export const WORKSPACE_OWNER_PREDICATE = 'http://dkg.io/ontology/workspaceOwner';
+
+/**
+ * A quad that lives in SWM but MUST be excluded from the KC merkle-root
+ * recompute. Trust-level annotations and workspace-owner bookkeeping are added
+ * by SWM ingestion, not by the author, so hashing them into the root diverges
+ * the publisher's root from the core responder's on the exact same content.
+ *
+ * This is the SINGLE SOURCE OF TRUTH for that exclusion set: the publisher
+ * (`DKGPublisher` SWM read) and the core responder (`StorageACKHandler`
+ * `loadSWMQuads`) both filter on it, so the two recompute paths can never
+ * drift — the drift being the 2026-07-07 `MERKLE_MISMATCH_IN_SWM` incident,
+ * where the responder hashed trust-level/workspace-owner quads the publisher
+ * had filtered out and declined every folded-private ACK.
+ */
+export function isSwmMerkleExcludedQuad(quad: Pick<TrustLevelQuadLike, 'predicate'>): boolean {
+  return isTrustLevelQuad(quad) || quad.predicate === WORKSPACE_OWNER_PREDICATE;
+}
+
 export function isTrustLevel(value: unknown): value is TrustLevel {
   return typeof value === 'number' &&
     Number.isInteger(value) &&

--- a/packages/core/test/trust.test.ts
+++ b/packages/core/test/trust.test.ts
@@ -4,6 +4,8 @@ import {
   TRUST_LEVEL_PREDICATE,
   buildTrustLevelQuads,
   isTrustLevelQuad,
+  isSwmMerkleExcludedQuad,
+  WORKSPACE_OWNER_PREDICATE,
   assertNoUserAuthoredTrustLevelQuads,
   isTrustLevel,
 } from '../src/index.js';
@@ -36,6 +38,22 @@ describe('trust metadata helpers', () => {
     expect(isTrustLevelQuad({ predicate: TRUST_LEVEL_PREDICATE })).toBe(true);
     expect(isTrustLevelQuad({ predicate: 'https://dkg.network/ontology#trustLevel' })).toBe(true);
     expect(isTrustLevelQuad({ predicate: 'http://schema.org/name' })).toBe(false);
+  });
+
+  // 2026-07-07 MERKLE_MISMATCH_IN_SWM regression: the publisher and the core
+  // responder BOTH exclude these bookkeeping quads before recomputing the KC
+  // merkle root over their SWM copies. If the two exclusion sets ever diverge,
+  // folded-private ACKs fail. This pins the single-source predicate they share.
+  it('isSwmMerkleExcludedQuad excludes trust-level AND workspace-owner bookkeeping, nothing else', () => {
+    // trust-level (canonical + legacy) — excluded
+    expect(isSwmMerkleExcludedQuad({ predicate: TRUST_LEVEL_PREDICATE })).toBe(true);
+    expect(isSwmMerkleExcludedQuad({ predicate: 'https://dkg.network/ontology#trustLevel' })).toBe(true);
+    // workspace-owner bookkeeping — excluded
+    expect(WORKSPACE_OWNER_PREDICATE).toBe('http://dkg.io/ontology/workspaceOwner');
+    expect(isSwmMerkleExcludedQuad({ predicate: WORKSPACE_OWNER_PREDICATE })).toBe(true);
+    // ordinary author payload — kept (hashed into the root)
+    expect(isSwmMerkleExcludedQuad({ predicate: 'http://schema.org/name' })).toBe(false);
+    expect(isSwmMerkleExcludedQuad({ predicate: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type' })).toBe(false);
   });
 
   it('validates TrustLevel values at runtime', () => {

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -2,7 +2,7 @@ import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
 import type { ChainAdapter, OnChainPublishResult, AddBatchToContextGraphParams } from '@origintrail-official/dkg-chain';
 import { enrichEvmError } from '@origintrail-official/dkg-chain';
 import type { EventBus, OperationContext } from '@origintrail-official/dkg-core';
-import { DKGEvent, Logger, createOperationContext, sha256, encodeWorkspacePublishRequest, encodeEncryptedWorkspacePayload, encryptWorkspacePayload, contextGraphDataUri, contextGraphDataGraphUri, contextGraphMetaUri, contextGraphAssertionUri, contextGraphLayerUri, MemoryLayer, assertionLifecycleUri, contextGraphSubGraphUri, contextGraphSubGraphMetaUri, SYSTEM_CONTEXT_GRAPHS, validateSubGraphName, isSafeIri, assertSafeIri, assertSafeRdfTerm, assertQuadLiteralsMutf8Safe, DKG_GOSSIP_MAX_MESSAGE_BYTES, SwmGossipPayloadTooLargeError, type Ed25519Keypair, buildAuthorAttestationTypedData, buildUpdateAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1, TrustLevel, TRUST_LEVEL_PREDICATE, assertNoUserAuthoredTrustLevelQuads, buildTrustLevelQuads, isTrustLevelQuad, DKG_ENTITY, DKG_ROOT_ENTITY_LEGACY, ENTITY_PRED_ALT, parseAssertionSealQuads, ASSERTION_SEAL_PREDICATES, sharedMemoryReadBothFilter, DKG_ONTOLOGY } from '@origintrail-official/dkg-core';
+import { DKGEvent, Logger, createOperationContext, sha256, encodeWorkspacePublishRequest, encodeEncryptedWorkspacePayload, encryptWorkspacePayload, contextGraphDataUri, contextGraphDataGraphUri, contextGraphMetaUri, contextGraphAssertionUri, contextGraphLayerUri, MemoryLayer, assertionLifecycleUri, contextGraphSubGraphUri, contextGraphSubGraphMetaUri, SYSTEM_CONTEXT_GRAPHS, validateSubGraphName, isSafeIri, assertSafeIri, assertSafeRdfTerm, assertQuadLiteralsMutf8Safe, DKG_GOSSIP_MAX_MESSAGE_BYTES, SwmGossipPayloadTooLargeError, type Ed25519Keypair, buildAuthorAttestationTypedData, buildUpdateAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1, TrustLevel, TRUST_LEVEL_PREDICATE, assertNoUserAuthoredTrustLevelQuads, buildTrustLevelQuads, isTrustLevelQuad, isSwmMerkleExcludedQuad, WORKSPACE_OWNER_PREDICATE, DKG_ENTITY, DKG_ROOT_ENTITY_LEGACY, ENTITY_PRED_ALT, parseAssertionSealQuads, ASSERTION_SEAL_PREDICATES, sharedMemoryReadBothFilter, DKG_ONTOLOGY } from '@origintrail-official/dkg-core';
 import { GraphManager, PrivateContentStore } from '@origintrail-official/dkg-storage';
 import { DEFAULT_PUBLISH_EPOCHS, MAX_PUBLISH_EPOCHS, type Publisher, type PublishOptions, type PublishResult, type KAManifestEntry, type PhaseCallback, type V10CoreNodeACK, type V10ACKProviderParams, type V10ACKProviderObject, type LegacyV10ACKProvider } from './publisher.js';
 import { skolemizeByEntity } from './auto-partition.js';
@@ -83,8 +83,6 @@ export {
   CuratorRejectedError,
   type CASCondition,
 };
-
-const WORKSPACE_OWNER_PREDICATE = 'http://dkg.io/ontology/workspaceOwner';
 
 // #1116 (review A1) — marker predicate stamped on the lifecycle URN when a KA
 // has been FULLY shared to SWM (entities:"all", all roots landed). It gates
@@ -1628,7 +1626,7 @@ export class DKGPublisher implements Publisher {
 
     const result = await this.store.query(sparql);
     const quads: Quad[] = result.type === 'quads'
-      ? result.quads.filter((q) => !isTrustLevelQuad(q) && q.predicate !== WORKSPACE_OWNER_PREDICATE)
+      ? result.quads.filter((q) => !isSwmMerkleExcludedQuad(q))
       : [];
 
     if (quads.length === 0) {
@@ -5679,7 +5677,7 @@ export class DKGPublisher implements Publisher {
       `CONSTRUCT { ?s ?p ?o } WHERE { ${sourcePattern} }`,
     );
     const gathered = gather.type === 'quads'
-      ? gather.quads.filter((q) => !isTrustLevelQuad(q) && q.predicate !== WORKSPACE_OWNER_PREDICATE)
+      ? gather.quads.filter((q) => !isSwmMerkleExcludedQuad(q))
       : [];
 
     // Validate the source has content BEFORE touching the draft (PR #972/335e8d8:

--- a/packages/publisher/src/storage-ack-handler.ts
+++ b/packages/publisher/src/storage-ack-handler.ts
@@ -18,6 +18,7 @@ import {
   catalogCommittedLeaves,
   contextGraphCatalogUri,
   sharedMemoryReadBothFilter,
+  isSwmMerkleExcludedQuad,
 } from '@origintrail-official/dkg-core';
 import {
   computeFlatKCRootV10 as computeFlatKCRoot,
@@ -1538,12 +1539,20 @@ export class StorageACKHandler {
 
   private async loadSWMQuads(graphUri: string, rootEntities: string[]): Promise<Quad[]> {
     assertSafeIri(graphUri);
+    // The publisher computes the KC merkle root over its SWM read with the
+    // trust-level / workspace-owner bookkeeping quads filtered OUT
+    // (`isSwmMerkleExcludedQuad`). The core responder recomputes the same root
+    // from its OWN SWM copy here, so it MUST apply the identical exclusion —
+    // otherwise any trust-level/workspace-owner quad resident in the core's
+    // store is hashed on one side but not the other and every folded-private
+    // ACK declines MERKLE_MISMATCH_IN_SWM (2026-07-07 Gnosis mainnet). Shared
+    // single-source filter so the two paths can never drift again.
     if (rootEntities.length === 0) {
       // read-both: per-KA …/_shared_memory/{addr}/{number} graphs (promote) + the legacy
       // bucket; exclude the transient /staging/ graphs (they would corrupt the recompute).
       const sparql = `CONSTRUCT { ?s ?p ?o } WHERE { GRAPH ?g { ?s ?p ?o } ${sharedMemoryReadBothFilter(graphUri)} }`;
       const result = await this.queryStoreOrUnavailable(sparql);
-      return result.type === 'quads' ? result.quads : [];
+      return result.type === 'quads' ? result.quads.filter((q) => !isSwmMerkleExcludedQuad(q)) : [];
     }
 
     const allQuads: Quad[] = [];
@@ -1553,7 +1562,9 @@ export class StorageACKHandler {
       const sparql = `CONSTRUCT { ?s ?p ?o } WHERE { GRAPH ?g { ?s ?p ?o . FILTER(?s = <${entity}> || STRSTARTS(STR(?s), "${genidPrefix}")) } ${sharedMemoryReadBothFilter(graphUri)} }`;
       const result = await this.queryStoreOrUnavailable(sparql);
       if (result.type === 'quads') {
-        allQuads.push(...result.quads);
+        for (const q of result.quads) {
+          if (!isSwmMerkleExcludedQuad(q)) allQuads.push(q);
+        }
       }
     }
     return allQuads;


### PR DESCRIPTION
## Summary
`MERKLE_MISMATCH_IN_SWM` regression (2026-07-07 Gnosis mainnet). The publisher computes the KC merkle root over its SWM read with **trust-level** and **workspace-owner** bookkeeping quads filtered out; the core responder's `loadSWMQuads` recomputed the same root from its own SWM copy **without** that filter. Any such quad resident in a core's store was hashed on the responder side but not the publisher side → different folded root → every folded-private ACK declined `MERKLE_MISMATCH_IN_SWM`.

## Change
Introduce `isSwmMerkleExcludedQuad` in `dkg-core` as the **single source of truth** for the exclusion set (trust-level canonical+legacy, plus the newly-promoted `WORKSPACE_OWNER_PREDICATE`) and use it on **both** sides — the two publisher SWM reads (`dkg-publisher.ts`) and the responder's `loadSWMQuads` (`storage-ack-handler.ts`). The drift that caused the incident is now structurally impossible: one predicate, both paths.

No behavior change for publishes whose SWM held no bookkeeping quads; fixes the ones whose store did.

## Tests
- `isSwmMerkleExcludedQuad`: excludes trust-level (canonical+legacy) + workspace-owner, keeps ordinary payload (trust suite 5/5)
- publisher ACK/SWM suites: 77/77

🤖 Generated with [Claude Code](https://claude.com/claude-code)