### PR TITLE
fix(publisher): ACK handler deadline → transient decline instead of dead-air

### DIFF
--- a/packages/publisher/src/storage-ack-handler.ts
+++ b/packages/publisher/src/storage-ack-handler.ts
@@ -297,7 +297,27 @@ export interface StorageACKHandlerConfig {
     maxRetries: number;
     delayMs: number;
   };
+  /**
+   * Wall-clock deadline for a single ACK-handler invocation. If the handler's
+   * store work has not produced a reply within this budget, the handler
+   * returns a `CORE_TEMPORARILY_UNAVAILABLE` decline instead of dead-airing
+   * the stream. The publisher's per-send timeout is 20s
+   * (`DEFAULT_SEND_TIMEOUT_MS`), so the default here is deliberately BELOW it
+   * (15s) — a slow store (e.g. under a sync storm) then hands the publisher an
+   * actionable transient decline that engages its retry-with-backoff ladder,
+   * rather than a timeout the publisher can only read as a dead peer
+   * (2026-07-07 Gnosis mainnet: cores whose Blazegraph was saturated dead-aired
+   * past 20s and every round burned as TRANSPORT_ERROR / mislabeled
+   * INVALID_SIGNATURE). Set to 0 to disable the deadline. Tests override it.
+   */
+  ackHandlerDeadlineMs?: number;
 }
+
+/**
+ * Default ACK-handler deadline — below the publisher's 20s per-send timeout so
+ * a slow responder decline reaches the publisher before it gives up.
+ */
+export const DEFAULT_ACK_HANDLER_DEADLINE_MS = 15_000;
 
 /**
  * StorageACKHandler implements the core node side of V10 spec §9.0 Phase 3.
@@ -608,7 +628,7 @@ export class StorageACKHandler {
         // Malformed request — handlePublishIntent will throw + reset below.
       }
       try {
-        const result = await this.handlePublishIntent(data, peerId);
+        const result = await this.runHandlerWithDeadline(data, peerId, cgIdAttr);
         const decoded = decodeStorageACK(result);
         if (isStorageACKDecline(decoded)) {
           const declineCode = decoded.declineCode || 'UNKNOWN';
@@ -640,6 +660,55 @@ export class StorageACKHandler {
         throw err;
       }
     });
+  };
+
+  /**
+   * Run {@link handlePublishIntent} under a wall-clock deadline. If the store
+   * work has not produced a reply within `ackHandlerDeadlineMs` (default 15s,
+   * below the publisher's 20s per-send timeout), resolve with a
+   * `CORE_TEMPORARILY_UNAVAILABLE` decline so the publisher gets an actionable
+   * transient response instead of dead-air. The in-flight work is left to
+   * settle in the background — any staging it has already persisted is
+   * idempotent, and a late resolve/reject is swallowed so it cannot surface as
+   * an unhandled rejection once the deadline reply has been sent.
+   *
+   * A THROWN handler error still propagates (the race rejects) → the outer
+   * handler resets the stream exactly as before; the deadline only converts
+   * the *slow* (non-throwing) case, which previously had no in-band signal.
+   */
+  private runHandlerWithDeadline = async (
+    data: Uint8Array,
+    peerId: PeerId,
+    cgIdForDecline: string | undefined,
+  ): Promise<Uint8Array> => {
+    const deadlineMs = this.config.ackHandlerDeadlineMs ?? DEFAULT_ACK_HANDLER_DEADLINE_MS;
+    const work = this.handlePublishIntent(data, peerId);
+    if (deadlineMs <= 0) return work;
+
+    // Swallow a late rejection from work when the deadline wins (see jsdoc).
+    // When work WINS the race it still rejects through `Promise.race` below,
+    // so real handler errors are unaffected by this no-op handler.
+    void work.catch(() => {});
+
+    let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
+    const deadline = new Promise<Uint8Array>((resolve) => {
+      deadlineTimer = setTimeout(() => {
+        resolve(
+          this.declineTemporarilyUnavailable(
+            cgIdForDecline ?? '',
+            'ack handler deadline exceeded',
+            new Error(`ACK handler exceeded ${deadlineMs}ms (store slow / saturated)`),
+          ),
+        );
+      }, deadlineMs);
+      if (typeof deadlineTimer.unref === 'function') deadlineTimer.unref();
+    });
+
+    try {
+      return await Promise.race([work, deadline]);
+    } finally {
+      if (deadlineTimer) clearTimeout(deadlineTimer);
+    }
   };
 
   /**

--- a/packages/publisher/src/storage-ack-handler.ts
+++ b/packages/publisher/src/storage-ack-handler.ts
@@ -13,6 +13,7 @@ import {
   assertSafeIri,
   assertSafeRdfTerm,
   STORAGE_ACK_DECLINE_CODES,
+  DEFAULT_SEND_TIMEOUT_MS,
   boundedDeclineCodeLabel,
   computeCatalogRoot,
   catalogCommittedLeaves,
@@ -314,10 +315,23 @@ export interface StorageACKHandlerConfig {
 }
 
 /**
- * Default ACK-handler deadline — below the publisher's 20s per-send timeout so
- * a slow responder decline reaches the publisher before it gives up.
+ * Safety margin between the ACK-handler deadline and the publisher's per-send
+ * timeout: the budget left for the decline to be encoded, written to the
+ * stream, and read by the publisher before it gives up on the send. Without
+ * it the deadline decline would race the publisher's own timeout and lose.
  */
-export const DEFAULT_ACK_HANDLER_DEADLINE_MS = 15_000;
+export const ACK_HANDLER_DEADLINE_SAFETY_MARGIN_MS = 5_000;
+
+/**
+ * Default ACK-handler deadline — DERIVED from the publisher's per-send timeout
+ * ({@link DEFAULT_SEND_TIMEOUT_MS}, 20s) minus
+ * {@link ACK_HANDLER_DEADLINE_SAFETY_MARGIN_MS} (5s) = 15s, so the
+ * "decline must reach the publisher before it gives up" invariant is
+ * compile-time coupled to the send timeout instead of restated as a bare
+ * literal that could silently drift.
+ */
+export const DEFAULT_ACK_HANDLER_DEADLINE_MS =
+  DEFAULT_SEND_TIMEOUT_MS - ACK_HANDLER_DEADLINE_SAFETY_MARGIN_MS;
 
 /**
  * StorageACKHandler implements the core node side of V10 spec §9.0 Phase 3.
@@ -628,7 +642,10 @@ export class StorageACKHandler {
         // Malformed request — handlePublishIntent will throw + reset below.
       }
       try {
-        const result = await this.runHandlerWithDeadline(data, peerId, cgIdAttr);
+        const result = await this.runHandlerWithDeadline(
+          this.handlePublishIntent(data, peerId),
+          cgIdAttr,
+        );
         const decoded = decodeStorageACK(result);
         if (isStorageACKDecline(decoded)) {
           const declineCode = decoded.declineCode || 'UNKNOWN';
@@ -663,7 +680,8 @@ export class StorageACKHandler {
   };
 
   /**
-   * Run {@link handlePublishIntent} under a wall-clock deadline. If the store
+   * Run an in-flight ACK body ({@link handlePublishIntent} or
+   * {@link handleUpdateIntent}) under a wall-clock deadline. If the store
    * work has not produced a reply within `ackHandlerDeadlineMs` (default 15s,
    * below the publisher's 20s per-send timeout), resolve with a
    * `CORE_TEMPORARILY_UNAVAILABLE` decline so the publisher gets an actionable
@@ -677,12 +695,10 @@ export class StorageACKHandler {
    * the *slow* (non-throwing) case, which previously had no in-band signal.
    */
   private runHandlerWithDeadline = async (
-    data: Uint8Array,
-    peerId: PeerId,
+    work: Promise<Uint8Array>,
     cgIdForDecline: string | undefined,
   ): Promise<Uint8Array> => {
     const deadlineMs = this.config.ackHandlerDeadlineMs ?? DEFAULT_ACK_HANDLER_DEADLINE_MS;
-    const work = this.handlePublishIntent(data, peerId);
     if (deadlineMs <= 0) return work;
 
     // Swallow a late rejection from work when the deadline wins (see jsdoc).
@@ -1262,9 +1278,34 @@ export class StorageACKHandler {
    * ACKs require exactly one KA before signing.
    *
    * Mirrors the publish `handler` above; only the digest, the request
-   * fields, and the protocol id differ.
+   * fields, and the protocol id differ — including the ACK-handler
+   * deadline: without it a hanging store op (SWM fallback `store.query`,
+   * catalog persist) dead-airs update ACKs past the publisher's 20s
+   * per-send timeout exactly as publish did, and the update collector
+   * rides the same transient-decline retry ladder.
    */
-  updateHandler = async (data: Uint8Array, _peerId: PeerId): Promise<Uint8Array> => {
+  updateHandler = async (data: Uint8Array, peerId: PeerId): Promise<Uint8Array> => {
+    let cgIdForDecline: string | undefined;
+    try {
+      // contextGraphId is cheap to read off the decoded intent for the
+      // deadline decline; handleUpdateIntent re-decodes + validates below.
+      cgIdForDecline = decodeUpdateIntent(data).contextGraphId;
+    } catch {
+      // Malformed request — handleUpdateIntent will throw + reset below.
+    }
+    return this.runHandlerWithDeadline(
+      this.handleUpdateIntent(data, peerId),
+      cgIdForDecline,
+    );
+  };
+
+  /**
+   * Original update-intent handling body. Split out from
+   * {@link updateHandler} so the public entry point runs it under the
+   * shared ACK deadline; the logic here is byte-for-byte the pre-deadline
+   * behaviour.
+   */
+  private handleUpdateIntent = async (data: Uint8Array, _peerId: PeerId): Promise<Uint8Array> => {
     if (this.config.nodeRole !== 'core') {
       throw new Error('Only core nodes can issue StorageACKs');
     }

--- a/packages/publisher/test/storage-ack-handler-deadline.test.ts
+++ b/packages/publisher/test/storage-ack-handler-deadline.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  StorageACKHandler,
+  DEFAULT_ACK_HANDLER_DEADLINE_MS,
+  type StorageACKHandlerConfig,
+} from '../src/storage-ack-handler.js';
+import {
+  computeFlatKCRootV10 as computeFlatKCRoot,
+  computeFlatKCMerkleLeafCountV10,
+} from '../src/merkle.js';
+import {
+  encodePublishIntent,
+  decodeStorageACK,
+  isStorageACKDecline,
+  STORAGE_ACK_DECLINE_CODES,
+  TypedEventBus,
+} from '@origintrail-official/dkg-core';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
+import { ethers } from 'ethers';
+
+// 2026-07-07 Gnosis mainnet dead-air fix, SLOW-store variant. The existing
+// core-unavailable suite covers a store that THROWS; this covers a store that
+// simply does not answer in time (Blazegraph saturated under the sync storm).
+// Without a handler deadline the invocation dead-airs past the publisher's 20s
+// per-send timeout, so the publisher records TRANSPORT_ERROR / mislabels the
+// empty reply as INVALID_SIGNATURE and burns the round. With the deadline the
+// handler returns an actionable transient CORE_TEMPORARILY_UNAVAILABLE decline
+// before the publisher gives up.
+
+const TEST_CHAIN_ID = 31337n;
+const TEST_KAV10_ADDR = '0x000000000000000000000000000000000000c10a';
+const contextGraphId = '42';
+
+function makeQuad(s: string, p: string, o: string, g = 'urn:test:swm'): Quad {
+  return { subject: s, predicate: p, object: o, graph: g };
+}
+
+const swmQuads: Quad[] = [
+  makeQuad('urn:entity:1', 'urn:p', 'urn:o1'),
+  makeQuad('urn:entity:1', 'urn:p', 'urn:o2'),
+];
+const merkleRoot = computeFlatKCRoot(swmQuads, []);
+const swmMerkleLeafCount = computeFlatKCMerkleLeafCountV10(swmQuads, []);
+const coreWallet = ethers.Wallet.createRandom();
+const fakePeerId = { toString: () => 'publisher-peer' } as any;
+
+/** Wrap a real store so `query` never resolves — models a saturated store. */
+function storeWithHangingQuery(base: OxigraphStore): TripleStore {
+  return new Proxy(base as unknown as TripleStore, {
+    get(target, prop, receiver) {
+      if (prop === 'query') {
+        return () => new Promise(() => {}); // never settles
+      }
+      const value = Reflect.get(target, prop, receiver);
+      return typeof value === 'function' ? value.bind(target) : value;
+    },
+  });
+}
+
+async function createHandler(
+  store: TripleStore,
+  configOverrides: Partial<StorageACKHandlerConfig> = {},
+) {
+  const config: StorageACKHandlerConfig = {
+    nodeRole: 'core',
+    nodeIdentityId: 42n,
+    signerWallet: coreWallet,
+    contextGraphSharedMemoryUri: (cgId: string) => `did:dkg:context-graph:${cgId}/_shared_memory`,
+    chainId: TEST_CHAIN_ID,
+    kav10Address: TEST_KAV10_ADDR,
+    isCgCurated: async () => true,
+    ...configOverrides,
+  };
+  return new StorageACKHandler(store as any, config, new TypedEventBus() as any);
+}
+
+function publishIntent(): Uint8Array {
+  return encodePublishIntent({
+    merkleRoot,
+    contextGraphId,
+    publisherPeerId: 'publisher-0',
+    publicByteSize: 300,
+    isPrivate: false,
+    kaCount: 1,
+    rootEntities: ['urn:entity:1'],
+    epochs: 1,
+    tokenAmountStr: '1000',
+    merkleLeafCount: swmMerkleLeafCount,
+  });
+}
+
+describe('StorageACKHandler — ack-handler deadline (slow-store dead-air fix)', () => {
+  it('default deadline is below the publisher 20s per-send timeout', () => {
+    // The decline must reach the publisher BEFORE it gives up, or it is moot.
+    expect(DEFAULT_ACK_HANDLER_DEADLINE_MS).toBeLessThan(20_000);
+  });
+
+  it('a store that never answers yields a CORE_TEMPORARILY_UNAVAILABLE decline, not dead-air', async () => {
+    const onDecline = vi.fn();
+    const handler = await createHandler(
+      storeWithHangingQuery(new OxigraphStore()),
+      { onDecline, ackHandlerDeadlineMs: 50 },
+    );
+
+    const started = Date.now();
+    const response = await handler.handler(publishIntent(), fakePeerId);
+    const elapsed = Date.now() - started;
+    const decoded = decodeStorageACK(response);
+
+    // Resolved via the deadline, not by hanging until the publisher timed out.
+    expect(elapsed).toBeLessThan(5_000);
+    expect(isStorageACKDecline(decoded)).toBe(true);
+    expect(decoded.declineCode).toBe(STORAGE_ACK_DECLINE_CODES.CORE_TEMPORARILY_UNAVAILABLE);
+    expect(decoded.declineMessage).toBe('ack handler deadline exceeded');
+    // Wire message stays generic; the local hook carries the real cause + cgId.
+    expect(onDecline).toHaveBeenCalledOnce();
+    expect(onDecline.mock.calls[0]?.[0]).toMatchObject({
+      code: STORAGE_ACK_DECLINE_CODES.CORE_TEMPORARILY_UNAVAILABLE,
+      contextGraphId,
+    });
+  });
+
+  it('a healthy fast handler is unaffected by the deadline (returns its real reply)', async () => {
+    const base = new OxigraphStore();
+    await base.insert(
+      swmQuads.map((q) => ({ ...q, graph: `did:dkg:context-graph:${contextGraphId}/_shared_memory` })),
+    );
+    // A generous deadline; the real store answers well within it.
+    const handler = await createHandler(base as unknown as TripleStore, { ackHandlerDeadlineMs: 10_000 });
+
+    const response = await handler.handler(publishIntent(), fakePeerId);
+    const decoded = decodeStorageACK(response);
+
+    // Not a deadline decline — either a signed ACK or a domain decline, but
+    // never the CORE_TEMPORARILY_UNAVAILABLE "deadline exceeded" reply.
+    expect(decoded.declineMessage).not.toBe('ack handler deadline exceeded');
+  });
+
+  it('deadline disabled (0) falls through to the raw handler', async () => {
+    const base = new OxigraphStore();
+    await base.insert(
+      swmQuads.map((q) => ({ ...q, graph: `did:dkg:context-graph:${contextGraphId}/_shared_memory` })),
+    );
+    const handler = await createHandler(base as unknown as TripleStore, { ackHandlerDeadlineMs: 0 });
+
+    const response = await handler.handler(publishIntent(), fakePeerId);
+    const decoded = decodeStorageACK(response);
+    expect(decoded.declineMessage).not.toBe('ack handler deadline exceeded');
+  });
+});

--- a/packages/publisher/test/storage-ack-handler-deadline.test.ts
+++ b/packages/publisher/test/storage-ack-handler-deadline.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import {
   StorageACKHandler,
   DEFAULT_ACK_HANDLER_DEADLINE_MS,
+  ACK_HANDLER_DEADLINE_SAFETY_MARGIN_MS,
   type StorageACKHandlerConfig,
 } from '../src/storage-ack-handler.js';
 import {
@@ -10,9 +11,11 @@ import {
 } from '../src/merkle.js';
 import {
   encodePublishIntent,
+  encodeUpdateIntent,
   decodeStorageACK,
   isStorageACKDecline,
   STORAGE_ACK_DECLINE_CODES,
+  DEFAULT_SEND_TIMEOUT_MS,
   TypedEventBus,
 } from '@origintrail-official/dkg-core';
 import { OxigraphStore } from '@origintrail-official/dkg-storage';
@@ -90,10 +93,36 @@ function publishIntent(): Uint8Array {
   });
 }
 
+/**
+ * No `stagingQuads` + not encrypted → the update handler resolves the new
+ * root from SWM (`loadSWMQuads` → `store.query`) — the store-touching path
+ * that hangs when the store is saturated.
+ */
+function updateIntent(): Uint8Array {
+  return encodeUpdateIntent({
+    kaId: '987654321',
+    contextGraphId,
+    preUpdateMerkleRootCount: 1,
+    newMerkleRoot: merkleRoot,
+    newByteSize: 300,
+    newTokenAmount: '1500',
+    mintAmount: 0,
+    burnTokenIds: [],
+    newMerkleLeafCount: swmMerkleLeafCount,
+    publisherPeerId: 'publisher-0',
+  });
+}
+
 describe('StorageACKHandler — ack-handler deadline (slow-store dead-air fix)', () => {
-  it('default deadline is below the publisher 20s per-send timeout', () => {
+  it('default deadline is below the publisher per-send timeout', () => {
     // The decline must reach the publisher BEFORE it gives up, or it is moot.
-    expect(DEFAULT_ACK_HANDLER_DEADLINE_MS).toBeLessThan(20_000);
+    // Asserted against the IMPORTED send timeout (not a restated literal) and
+    // pinned to the derivation so the coupling survives a timeout change.
+    expect(DEFAULT_ACK_HANDLER_DEADLINE_MS).toBeLessThan(DEFAULT_SEND_TIMEOUT_MS);
+    expect(DEFAULT_ACK_HANDLER_DEADLINE_MS).toBe(
+      DEFAULT_SEND_TIMEOUT_MS - ACK_HANDLER_DEADLINE_SAFETY_MARGIN_MS,
+    );
+    expect(ACK_HANDLER_DEADLINE_SAFETY_MARGIN_MS).toBeGreaterThan(0);
   });
 
   it('a store that never answers yields a CORE_TEMPORARILY_UNAVAILABLE decline, not dead-air', async () => {
@@ -145,6 +174,70 @@ describe('StorageACKHandler — ack-handler deadline (slow-store dead-air fix)',
     const handler = await createHandler(base as unknown as TripleStore, { ackHandlerDeadlineMs: 0 });
 
     const response = await handler.handler(publishIntent(), fakePeerId);
+    const decoded = decodeStorageACK(response);
+    expect(decoded.declineMessage).not.toBe('ack handler deadline exceeded');
+  });
+});
+
+// The UPDATE ACK handler ('/dkg/10.0.1/storage-update-ack') shares the store
+// and the failure mode: before the fix it awaited its body directly, so a
+// hanging SWM `store.query` dead-aired update ACKs past the publisher's 20s
+// per-send timeout exactly as publish did. It now runs under the SAME
+// deadline runner, and the update collector rides the same transient-decline
+// retry ladder — these mirror the publish cases above.
+describe('StorageACKHandler — update-ACK handler deadline (slow-store dead-air fix)', () => {
+  it('a store that never answers yields a CORE_TEMPORARILY_UNAVAILABLE decline, not dead-air', async () => {
+    const onDecline = vi.fn();
+    const handler = await createHandler(
+      storeWithHangingQuery(new OxigraphStore()),
+      { onDecline, ackHandlerDeadlineMs: 50 },
+    );
+
+    const started = Date.now();
+    const response = await handler.updateHandler(updateIntent(), fakePeerId);
+    const elapsed = Date.now() - started;
+    const decoded = decodeStorageACK(response);
+
+    // Resolved via the deadline, not by hanging until the publisher timed out.
+    expect(elapsed).toBeLessThan(5_000);
+    expect(isStorageACKDecline(decoded)).toBe(true);
+    expect(decoded.declineCode).toBe(STORAGE_ACK_DECLINE_CODES.CORE_TEMPORARILY_UNAVAILABLE);
+    expect(decoded.declineMessage).toBe('ack handler deadline exceeded');
+    // The decline carries the cgId decoded off the update intent so the
+    // publisher's collector can attribute it; the wire message stays generic
+    // while the local hook carries the real cause.
+    expect(decoded.contextGraphId).toBe(contextGraphId);
+    expect(onDecline).toHaveBeenCalledOnce();
+    expect(onDecline.mock.calls[0]?.[0]).toMatchObject({
+      code: STORAGE_ACK_DECLINE_CODES.CORE_TEMPORARILY_UNAVAILABLE,
+      contextGraphId,
+    });
+  });
+
+  it('a healthy fast update body is unaffected by the deadline (returns its real reply)', async () => {
+    const base = new OxigraphStore();
+    await base.insert(
+      swmQuads.map((q) => ({ ...q, graph: `did:dkg:context-graph:${contextGraphId}/_shared_memory` })),
+    );
+    // A generous deadline; the real store answers well within it.
+    const handler = await createHandler(base as unknown as TripleStore, { ackHandlerDeadlineMs: 10_000 });
+
+    const response = await handler.updateHandler(updateIntent(), fakePeerId);
+    const decoded = decodeStorageACK(response);
+
+    // Not a deadline decline — either a signed ACK or a domain decline, but
+    // never the CORE_TEMPORARILY_UNAVAILABLE "deadline exceeded" reply.
+    expect(decoded.declineMessage).not.toBe('ack handler deadline exceeded');
+  });
+
+  it('deadline disabled (0) falls through to the raw update handler', async () => {
+    const base = new OxigraphStore();
+    await base.insert(
+      swmQuads.map((q) => ({ ...q, graph: `did:dkg:context-graph:${contextGraphId}/_shared_memory` })),
+    );
+    const handler = await createHandler(base as unknown as TripleStore, { ackHandlerDeadlineMs: 0 });
+
+    const response = await handler.updateHandler(updateIntent(), fakePeerId);
     const decoded = decodeStorageACK(response);
     expect(decoded.declineMessage).not.toBe('ack handler deadline exceeded');
   });


### PR DESCRIPTION
## Summary
The dead-air fix (`CORE_TEMPORARILY_UNAVAILABLE`) only fired when a store op **threw**. A store that is merely **slow** — Blazegraph saturated under the sync storm, not closed — made `handlePublishIntent` block past the publisher's 20s per-send timeout, so the publisher recorded `TRANSPORT_ERROR` or mislabeled the empty reply as `INVALID_SIGNATURE` and burned the round (2026-07-07 Gnosis mainnet).

## Change
Run the handler under a wall-clock deadline (default **15s**, below the publisher's 20s `DEFAULT_SEND_TIMEOUT_MS`; configurable, `0` disables). On expiry the handler resolves with a `CORE_TEMPORARILY_UNAVAILABLE` decline so the publisher gets an actionable transient signal that engages its retry-with-backoff ladder instead of a timeout it can only read as a dead peer.

- The in-flight work settles in the background (its staging is idempotent); a late rejection is swallowed so it never becomes an unhandled rejection.
- A **thrown** handler error still propagates and resets the stream exactly as before — only the slow, non-throwing case is converted.

## Tests
- hanging store → bounded deadline decline (not dead-air); healthy fast handler unaffected; `deadline=0` disables; default < 20s
- broader ACK handler suites: 130/130

🤖 Generated with [Claude Code](https://claude.com/claude-code)