### PR TITLE
fix(agent): bound catch-up fan-out concurrency (sync-storm mitigation C-1)

### DIFF
--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -215,6 +215,7 @@ import { buildSyncRequestEnvelope, type SyncPhase } from './sync/auth/request-bu
 import { authorizePrivateSyncRequest } from './sync/auth/request-authorize.js';
 import { registerSyncHandler } from './sync/responder/sync-handler.js';
 import { runSyncOnConnect, SyncOnConnectPostSyncError, type SyncOnConnectOutcome, type SyncOnConnectPeerOutcome } from './sync/on-connect/sync-on-connect.js';
+import { mapWithConcurrency, CATCHUP_MAX_CONCURRENT_PEER_SYNCS } from './sync/map-with-concurrency.js';
 import {
   generateCustodialAgent, registerSelfSovereignAgent, agentFromPrivateKey,
   ensureWorkspaceEncryptionKey,
@@ -3888,16 +3889,28 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       failedPhases: 0,
       deniedPhases: 0,
     });
-    const results = await Promise.all(syncCapable.map(async (remotePeerId) => {
-      const durable = await this.syncFromPeerDetailed(
-        remotePeerId,
-        [contextGraphId],
-      ).catch(emptyDurable);
-      const shared = includeSharedMemory
-        ? await this.syncSharedMemoryFromPeerDetailed(remotePeerId, [contextGraphId]).catch(emptyShared)
-        : null;
-      return { durable, shared };
-    }));
+    // Bounded fan-out: at most CATCHUP_MAX_CONCURRENT_PEER_SYNCS peer syncs run
+    // at once. The pre-cap unbounded `Promise.all` over every sync-capable peer
+    // was the top amplifier of the 2026-07-07 mainnet sync storm — one
+    // subscribe/reconcile round on a high-degree node launched N concurrent
+    // full-CG durable+SWM pulls that saturated the triple store (StorageACK
+    // reads then dead-aired behind them). Every selected peer is still synced
+    // and the result array is unchanged (input order, one entry per peer) — the
+    // load is just staggered into waves.
+    const results = await mapWithConcurrency(
+      syncCapable,
+      CATCHUP_MAX_CONCURRENT_PEER_SYNCS,
+      async (remotePeerId) => {
+        const durable = await this.syncFromPeerDetailed(
+          remotePeerId,
+          [contextGraphId],
+        ).catch(emptyDurable);
+        const shared = includeSharedMemory
+          ? await this.syncSharedMemoryFromPeerDetailed(remotePeerId, [contextGraphId]).catch(emptyShared)
+          : null;
+        return { durable, shared };
+      },
+    );
     let accessDeniedPeers = 0;
     let peersSucceeded = 0;
     for (const r of results) {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -211,3 +211,10 @@ export {
   buildPublicProjection,
   type PublicProjectionInput,
 } from './context-graph-public-projection.js';
+// 2026-07-07 sync-storm mitigation (C-1) — the bounded catch-up fan-out mapper
+// and its shared cap (DKG_CATCHUP_MAX_CONCURRENT_PEERS, default 4). Exported on
+// the public surface because the CLI daemon's Worker-based catch-up runner
+// (`/api/context-graph/subscribe` → `catchup-runner-worker-impl`) runs the same
+// registry-scale per-peer fan-out and must be bounded by the SAME knob, without
+// deep-importing the compiled `dist/` module.
+export { mapWithConcurrency, CATCHUP_MAX_CONCURRENT_PEER_SYNCS } from './sync/map-with-concurrency.js';

--- a/packages/agent/src/sync/map-with-concurrency.ts
+++ b/packages/agent/src/sync/map-with-concurrency.ts
@@ -1,0 +1,57 @@
+// map-with-concurrency.ts
+//
+// Bounded-concurrency ordered map. The catch-up fan-out
+// (`runCatchupOverPeers`) previously fired a full durable+SWM sync at EVERY
+// connected sync-capable peer via one unbounded `Promise.all` — the top
+// amplifier of the 2026-07-07 mainnet "sync storm": one `/api/subscribe` on a
+// large-degree node launched N concurrent full-CG pulls, saturating the triple
+// store and the muxer. This caps the number of peer syncs running AT ONCE
+// without dropping any peer (coverage preserved, just staggered) and without
+// changing the result shape callers aggregate over — the returned array is in
+// input order, one entry per item, exactly like `Promise.all(items.map(fn))`.
+
+/**
+ * Like `Promise.all(items.map(fn))` but with at most `limit` callbacks
+ * in flight at any moment. Results preserve input order. `fn` receives the
+ * item and its original index. A rejecting `fn` rejects the whole call (same
+ * as `Promise.all`) — callers that want per-item isolation must catch inside
+ * `fn`, as the catch-up fan-out already does.
+ *
+ * `limit <= 0` or `limit >= items.length` degrades to a plain `Promise.all`
+ * (no pool overhead, byte-identical behaviour to the pre-cap code).
+ */
+export async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  if (items.length === 0) return [];
+  if (!Number.isInteger(limit) || limit <= 0 || limit >= items.length) {
+    return Promise.all(items.map((item, i) => fn(item, i)));
+  }
+
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+  const worker = async (): Promise<void> => {
+    for (;;) {
+      const i = nextIndex++;
+      if (i >= items.length) return;
+      results[i] = await fn(items[i], i);
+    }
+  };
+  // `limit` workers drain the shared cursor; each awaits its item before
+  // pulling the next, so no more than `limit` `fn` calls are ever in flight.
+  await Promise.all(Array.from({ length: limit }, () => worker()));
+  return results;
+}
+
+/**
+ * Max peer syncs the catch-up fan-out runs concurrently. Kept small so a
+ * high-degree node's subscribe/reconcile round can't flood its own triple
+ * store; every selected peer is still synced, just in bounded waves.
+ * Env-overridable for operators who need to tune throughput vs. store load.
+ */
+export const CATCHUP_MAX_CONCURRENT_PEER_SYNCS: number = (() => {
+  const raw = Number(process.env.DKG_CATCHUP_MAX_CONCURRENT_PEERS);
+  return Number.isInteger(raw) && raw > 0 ? raw : 4;
+})();

--- a/packages/agent/test/map-with-concurrency.test.ts
+++ b/packages/agent/test/map-with-concurrency.test.ts
@@ -1,0 +1,89 @@
+// map-with-concurrency.test.ts
+//
+// Pins the catch-up fan-out cap (2026-07-07 sync-storm mitigation): results
+// stay in input order and one-per-item (so the downstream aggregation is
+// unchanged), and no more than `limit` callbacks are ever in flight (so a
+// high-degree node's subscribe round can't flood its own store).
+import { describe, it, expect } from 'vitest';
+import { mapWithConcurrency, CATCHUP_MAX_CONCURRENT_PEER_SYNCS } from '../src/sync/map-with-concurrency.js';
+
+const tick = () => new Promise<void>((r) => setTimeout(r, 0));
+
+describe('mapWithConcurrency', () => {
+  it('preserves input order and shape regardless of completion order', async () => {
+    const out = await mapWithConcurrency([10, 20, 30, 40], 2, async (n, i) => {
+      // Later items resolve FIRST — output must still be in input order.
+      await new Promise((r) => setTimeout(r, (4 - i) * 5));
+      return n * 2;
+    });
+    expect(out).toEqual([20, 40, 60, 80]);
+  });
+
+  it('never runs more than `limit` callbacks concurrently', async () => {
+    let inFlight = 0;
+    let peak = 0;
+    await mapWithConcurrency(Array.from({ length: 20 }, (_, i) => i), 4, async (n) => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await new Promise((r) => setTimeout(r, 2));
+      inFlight--;
+      return n;
+    });
+    expect(peak).toBeLessThanOrEqual(4);
+    expect(peak).toBeGreaterThan(1); // actually parallel, not accidentally serial
+  });
+
+  it('runs every item exactly once', async () => {
+    const seen = new Set<number>();
+    let calls = 0;
+    const items = Array.from({ length: 50 }, (_, i) => i);
+    await mapWithConcurrency(items, 5, async (n) => {
+      calls++;
+      seen.add(n);
+      await tick();
+      return n;
+    });
+    expect(calls).toBe(50);
+    expect(seen.size).toBe(50);
+  });
+
+  it('degrades to plain Promise.all when limit >= length or <= 0 (unbounded parity)', async () => {
+    let peak = 0;
+    let inFlight = 0;
+    const run = (limit: number) =>
+      mapWithConcurrency([1, 2, 3], limit, async (n) => {
+        inFlight++;
+        peak = Math.max(peak, inFlight);
+        await tick();
+        inFlight--;
+        return n;
+      });
+    peak = 0; inFlight = 0;
+    expect(await run(10)).toEqual([1, 2, 3]);
+    expect(peak).toBe(3); // all at once
+    peak = 0; inFlight = 0;
+    expect(await run(0)).toEqual([1, 2, 3]);
+    expect(peak).toBe(3);
+  });
+
+  it('empty input returns empty array without calling fn', async () => {
+    let called = false;
+    const out = await mapWithConcurrency([], 4, async () => { called = true; return 1; });
+    expect(out).toEqual([]);
+    expect(called).toBe(false);
+  });
+
+  it('propagates a rejection like Promise.all (callers isolate inside fn)', async () => {
+    await expect(
+      mapWithConcurrency([1, 2, 3], 2, async (n) => {
+        if (n === 2) throw new Error('boom');
+        return n;
+      }),
+    ).rejects.toThrow('boom');
+  });
+
+  it('default concurrency is a small positive cap', () => {
+    expect(CATCHUP_MAX_CONCURRENT_PEER_SYNCS).toBeGreaterThan(0);
+    expect(CATCHUP_MAX_CONCURRENT_PEER_SYNCS).toBeLessThanOrEqual(16);
+  });
+});

--- a/packages/cli/src/catchup-runner-worker-impl.ts
+++ b/packages/cli/src/catchup-runner-worker-impl.ts
@@ -1,4 +1,5 @@
 import { parentPort } from 'node:worker_threads';
+import { CATCHUP_MAX_CONCURRENT_PEER_SYNCS, mapWithConcurrency } from '@origintrail-official/dkg-agent';
 import { catchupPeerResponded, catchupPeerSucceeded, type CatchupJobResult, type CatchupRunRequest } from './catchup-runner.js';
 
 type InvokeResultMessage = {
@@ -91,20 +92,27 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
     },
   };
 
-  // Run per-peer syncs in parallel. The sequential version here used to
-  // walk the peer set one at a time, which meant a curated-CG denial
+  // Run per-peer syncs in parallel, but BOUNDED. The sequential version here
+  // used to walk the peer set one at a time, which meant a curated-CG denial
   // from a 10-peer pool took 10 × (syncDurable timeout + syncSharedMemory
-  // timeout) to report back — often minutes. The agent-side
-  // `syncContextGraphFromConnectedPeers` (InlineCatchupRunner) already
-  // uses `Promise.all`, but the daemon subscribe path goes through this
-  // Worker implementation, so Codex N18 pointed out the parallel fix
-  // never reached `/api/context-graph/subscribe`. Mirror the inline path
-  // here so both runners have the same latency characteristics.
-  const checked = await Promise.all(
-    prepared.peerIds.map(async (peerId) => ({
+  // timeout) to report back — often minutes. Codex N18 then parallelised this
+  // Worker path (the daemon `/api/context-graph/subscribe` route) with an
+  // unbounded `Promise.all` — which made it the 2026-07-07 mainnet sync-storm
+  // engine: one subscribe on a high-degree node fired a full durable+SWM pull
+  // at EVERY sync-capable peer at once, saturating the triple store. Mirror
+  // the agent-side `syncContextGraphFromConnectedPeers` fix: run the fan-out
+  // through `mapWithConcurrency` under the shared cap
+  // (CATCHUP_MAX_CONCURRENT_PEER_SYNCS, env DKG_CATCHUP_MAX_CONCURRENT_PEERS)
+  // so both runners have the same latency AND the same load ceiling. The
+  // protocol probe below is lighter but fans out over the full post-prime-dial
+  // peer list, so it gets the same bound.
+  const checked = await mapWithConcurrency(
+    prepared.peerIds,
+    CATCHUP_MAX_CONCURRENT_PEER_SYNCS,
+    async (peerId) => ({
       peerId,
       hasSync: await invoke<boolean>('waitForSyncProtocol', peerId),
-    })),
+    }),
   );
   const syncCapable: string[] = [];
   for (const { peerId, hasSync } of checked) {
@@ -155,14 +163,21 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
     failedPhases: 0,
     deniedPhases: 0,
   });
-  const perPeerResults = await Promise.all(
-    syncCapable.map(async (peerId) => {
+  // Bounded fan-out (sync-storm mitigation C-1): at most
+  // CATCHUP_MAX_CONCURRENT_PEER_SYNCS full per-peer sync rounds in flight.
+  // Every sync-capable peer is still synced and the result array is unchanged
+  // (input order, one entry per peer, per-peer failures isolated by the
+  // `.catch`es inside the callback) — the load is just staggered into waves.
+  const perPeerResults = await mapWithConcurrency(
+    syncCapable,
+    CATCHUP_MAX_CONCURRENT_PEER_SYNCS,
+    async (peerId) => {
       const durable = await invoke<any>('syncDurable', peerId, request.contextGraphId).catch(() => emptyDurable());
       const shared = request.includeSharedMemory
         ? await invoke<any>('syncSharedMemory', peerId, request.contextGraphId).catch(() => emptyShared())
         : null;
       return { durable, shared };
-    }),
+    },
   );
   for (const { durable, shared } of perPeerResults) {
     let peerDenied = false;

--- a/packages/cli/test/catchup-runner-worker-impl.test.ts
+++ b/packages/cli/test/catchup-runner-worker-impl.test.ts
@@ -1,0 +1,231 @@
+// catchup-runner-worker-impl.test.ts
+//
+// Drives the daemon-side Worker catch-up implementation — the
+// `/api/context-graph/subscribe` path that fans a full durable+SWM sync out
+// over every sync-capable peer — over a mocked `parentPort`, and pins the
+// 2026-07-07 sync-storm mitigation (C-1) at THIS call site: no more than
+// CATCHUP_MAX_CONCURRENT_PEER_SYNCS per-peer sync rounds (or protocol probes)
+// may ever be in flight, while every peer still gets synced exactly once, the
+// aggregation keeps its one-result-per-peer input-order shape, and one peer's
+// failure stays isolated instead of failing the whole run.
+import { describe, expect, it, vi } from 'vitest';
+import { CATCHUP_MAX_CONCURRENT_PEER_SYNCS } from '@origintrail-official/dkg-agent';
+import type { CatchupJobResult, CatchupRunRequest } from '../src/catchup-runner.js';
+
+// The worker impl wires itself to `parentPort` at module load, so a
+// controllable port has to be in place BEFORE the module is imported.
+// Everything else from node:worker_threads stays real.
+const fakeParentPort = vi.hoisted(() => {
+  const messageListeners: Array<(message: any) => void> = [];
+  const port = {
+    on(event: string, listener: (message: any) => void) {
+      if (event === 'message') messageListeners.push(listener);
+    },
+    /** Set per run by `runWorkerCatchup`; receives what the impl posts back. */
+    onPosted: undefined as ((message: any) => void) | undefined,
+    postMessage(message: any) {
+      port.onPosted?.(message);
+    },
+    emitMessage(message: any) {
+      for (const listener of messageListeners) listener(message);
+    },
+  };
+  return port;
+});
+
+vi.mock('node:worker_threads', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('node:worker_threads')>()),
+  parentPort: fakeParentPort,
+}));
+
+const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+function durableResult() {
+  return {
+    insertedTriples: 1,
+    fetchedMetaTriples: 0,
+    fetchedDataTriples: 1,
+    insertedMetaTriples: 0,
+    insertedDataTriples: 1,
+    bytesReceived: 10,
+    resumedPhases: 0,
+    timedOutPhases: 0,
+    completedPhases: 1,
+    checkpointAdvances: 0,
+    emptyResponses: 0,
+    metaOnlyResponses: 0,
+    dataRejectedMissingMeta: 0,
+    rejectedKcs: 0,
+    failedPeers: 0,
+    failedPhases: 0,
+    deniedPhases: 0,
+  };
+}
+
+function sharedResult() {
+  return {
+    insertedTriples: 1,
+    fetchedMetaTriples: 0,
+    fetchedDataTriples: 1,
+    insertedMetaTriples: 0,
+    insertedDataTriples: 1,
+    bytesReceived: 10,
+    resumedPhases: 0,
+    timedOutPhases: 0,
+    completedPhases: 1,
+    checkpointAdvances: 0,
+    emptyResponses: 0,
+    droppedDataTriples: 0,
+    failedPeers: 0,
+    failedPhases: 0,
+    deniedPhases: 0,
+  };
+}
+
+type InvokeHandler = (method: string, args: unknown[]) => Promise<unknown>;
+
+let nextRunId = 1;
+
+async function runWorkerCatchup(request: CatchupRunRequest, handler: InvokeHandler): Promise<CatchupJobResult> {
+  // The first call loads the module, which registers its message listener on
+  // the mocked parentPort; later calls reuse it (distinct runIds).
+  await import('../src/catchup-runner-worker-impl.js');
+  const runId = nextRunId++;
+  return new Promise<CatchupJobResult>((resolve, reject) => {
+    fakeParentPort.onPosted = (message: any) => {
+      if (message.type === 'invoke') {
+        handler(message.method, message.args).then(
+          (result) => fakeParentPort.emitMessage({ type: 'invoke-result', invokeId: message.invokeId, result }),
+          (error: unknown) => fakeParentPort.emitMessage({
+            type: 'invoke-result',
+            invokeId: message.invokeId,
+            error: error instanceof Error ? error.message : String(error),
+          }),
+        );
+        return;
+      }
+      if (message.type === 'run-result' && message.runId === runId) {
+        if (message.error) reject(new Error(message.error));
+        else resolve(message.result as CatchupJobResult);
+      }
+    };
+    fakeParentPort.emitMessage({ type: 'run', runId, request });
+  });
+}
+
+describe('catchup-runner-worker-impl bounded fan-out (sync-storm mitigation C-1)', () => {
+  it('caps in-flight peer syncs and protocol probes at the shared limit while still syncing every peer in input order', async () => {
+    const peerIds = Array.from({ length: 20 }, (_, i) => `peer-${i}`);
+    // The bound is only observable when the peer set exceeds the cap.
+    expect(CATCHUP_MAX_CONCURRENT_PEER_SYNCS).toBeLessThan(peerIds.length);
+
+    let inFlightProbes = 0;
+    let peakProbes = 0;
+    let inFlightSyncs = 0;
+    let peakSyncs = 0;
+    const durableOrder: string[] = [];
+    const sharedSeen: string[] = [];
+    const finalizeCalls: unknown[][] = [];
+
+    const result = await runWorkerCatchup({ contextGraphId: 'cg-storm', includeSharedMemory: true }, async (method, args) => {
+      switch (method) {
+        case 'prepareCatchup':
+          return { preferredPeerId: undefined, isPrivateContextGraph: false, peerIds, connectedPeers: peerIds.length };
+        case 'waitForSyncProtocol': {
+          inFlightProbes += 1;
+          peakProbes = Math.max(peakProbes, inFlightProbes);
+          await delay(2);
+          inFlightProbes -= 1;
+          return true;
+        }
+        case 'syncDurable': {
+          durableOrder.push(args[0] as string);
+          inFlightSyncs += 1;
+          peakSyncs = Math.max(peakSyncs, inFlightSyncs);
+          await delay(4);
+          inFlightSyncs -= 1;
+          return durableResult();
+        }
+        case 'syncSharedMemory': {
+          sharedSeen.push(args[0] as string);
+          inFlightSyncs += 1;
+          peakSyncs = Math.max(peakSyncs, inFlightSyncs);
+          await delay(2);
+          inFlightSyncs -= 1;
+          return sharedResult();
+        }
+        case 'finalizeCatchup':
+          finalizeCalls.push(args);
+          return null;
+        default:
+          throw new Error(`unexpected invoke: ${method}`);
+      }
+    });
+
+    // The storm guard: neither fan-out phase ever exceeds the cap…
+    expect(peakSyncs).toBeLessThanOrEqual(CATCHUP_MAX_CONCURRENT_PEER_SYNCS);
+    expect(peakProbes).toBeLessThanOrEqual(CATCHUP_MAX_CONCURRENT_PEER_SYNCS);
+    // …but the fan-out is still actually parallel, not accidentally serialised.
+    expect(peakSyncs).toBeGreaterThan(1);
+
+    // Coverage preserved: every peer synced exactly once, started in input
+    // order (the bounded mapper's shared cursor hands out work in order).
+    expect(durableOrder).toEqual(peerIds);
+    expect([...sharedSeen].sort()).toEqual([...peerIds].sort());
+
+    // Aggregation unchanged from the unbounded Promise.all shape.
+    expect(result.selectedPeers).toBe(peerIds.length);
+    expect(result.syncCapablePeers).toBe(peerIds.length);
+    expect(result.peersTried).toBe(peerIds.length);
+    expect(result.peersResponded).toBe(peerIds.length);
+    expect(result.peersSucceeded).toBe(peerIds.length);
+    expect(result.dataSynced).toBe(peerIds.length);
+    expect(result.sharedMemorySynced).toBe(peerIds.length);
+    expect(result.denied).toBe(false);
+    expect(result.diagnostics?.durable.failedPeers).toBe(0);
+    expect(finalizeCalls).toEqual([['cg-storm', peerIds.length, peerIds.length]]);
+  });
+
+  it('keeps per-peer failure isolation and probe filtering under the bounded fan-out', async () => {
+    const peerIds = Array.from({ length: 12 }, (_, i) => `peer-${i}`);
+    const durableCalls: string[] = [];
+    let sharedCalls = 0;
+
+    const result = await runWorkerCatchup({ contextGraphId: 'cg-isolate', includeSharedMemory: false }, async (method, args) => {
+      switch (method) {
+        case 'prepareCatchup':
+          return { preferredPeerId: undefined, isPrivateContextGraph: false, peerIds, connectedPeers: peerIds.length };
+        case 'waitForSyncProtocol':
+          await delay(1);
+          // peer-5 is connected but not sync-capable: it must be filtered out
+          // by the (bounded) probe pass, never handed to syncDurable.
+          return args[0] !== 'peer-5';
+        case 'syncDurable': {
+          durableCalls.push(args[0] as string);
+          await delay(2);
+          if (args[0] === 'peer-3') throw new Error('peer 3 exploded');
+          return durableResult();
+        }
+        case 'syncSharedMemory':
+          sharedCalls += 1;
+          return sharedResult();
+        case 'finalizeCatchup':
+          return null;
+        default:
+          throw new Error(`unexpected invoke: ${method}`);
+      }
+    });
+
+    // One peer's sync failure must not reject the run or drop other peers.
+    expect(durableCalls).toEqual(peerIds.filter((peerId) => peerId !== 'peer-5'));
+    expect(sharedCalls).toBe(0);
+    expect(result.syncCapablePeers).toBe(11);
+    expect(result.peersTried).toBe(11);
+    expect(result.peersResponded).toBe(10);
+    expect(result.peersSucceeded).toBe(10);
+    expect(result.dataSynced).toBe(10);
+    expect(result.sharedMemorySynced).toBe(0);
+    expect(result.diagnostics?.noProtocolPeers).toBe(1);
+    expect(result.diagnostics?.durable.failedPeers).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
`runCatchupOverPeers` fired a full durable+SWM sync at **every** connected sync-capable peer through one **unbounded `Promise.all`**. On a high-degree node a single `/api/subscribe` (the daemon runner passes no `maxPeers`) or the periodic reconciler launched N concurrent full-CG pulls (500-triple pages, 120s budget each) — the top amplifier of the 2026-07-07 mainnet **sync storm** that saturated the triple store, behind which consensus-critical StorageACK reads then dead-aired.

## Change
Run the fan-out through a new `mapWithConcurrency` helper with a small cap — `CATCHUP_MAX_CONCURRENT_PEER_SYNCS` (default **4**, env-overridable via `DKG_CATCHUP_MAX_CONCURRENT_PEERS`). Every selected peer is still synced and the result array is **byte-identical** (input order, one entry per peer) — the store/muxer load is just staggered into bounded waves. The helper degrades to a plain `Promise.all` when the peer set is at/under the cap, so small clusters and existing tests are unaffected.

Mirrors the bound the VM-reconcile active-fetch path already applies (`maxPeers:1` + rotation).

## Scope
This is **C-1** of the storm fix. **C-2** (R1 — making the superseded-session signal survive `stream.abort` so requesters stop 10-minute blind re-pulls) is a separate PR.

## Tests
- order/shape preserved regardless of completion order; peak concurrency ≤ limit; every item run exactly once; degrade-to-`Promise.all` parity; rejection propagation
- agent sync/catch-up suites: 260/263 (3 pre-existing skips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)