### PR TITLE
fix(agent): kill the superseded-resume sync loop (C-2 / R1)

### DIFF
--- a/packages/agent/src/sync/requester/page-fetch.ts
+++ b/packages/agent/src/sync/requester/page-fetch.ts
@@ -323,13 +323,44 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
       if (parsed.totalQuads < syncPageSize) break;
     }
   } catch (err) {
+    const denied = (err as Error & { syncDenied?: boolean }).syncDenied === true;
     if (usesPageSession && isSyncResponderSessionSupersededError(err)) {
+      // Exact-message match — only fires IN-PROCESS (same-node tests). Over the
+      // wire the responder's "superseded" text is destroyed by the router's
+      // stream.abort (it becomes a generic reset), which is why the
+      // `resumedFromOffset > 0` branch below is the real network-path fix.
       unfinishedSyncResponderSessions.delete(checkpointKey);
       checkpointStore.delete(checkpointKey);
-    } else if (usesPageSession && responderSession && !recovery && !(err as Error & { syncDenied?: boolean }).syncDenied) {
-      // Recovery never persists a responder session to resume (see the timeout
-      // branch below + Codex #1173).
-      rememberUnfinishedSyncResponderSession(checkpointKey, responderSession);
+    } else if (usesPageSession && responderSession && !recovery && !denied) {
+      if (resumedFromOffset > 0) {
+        // R1 fix (2026-07-07 sync storm). This round RESUMED a saved session at
+        // offset>0 and then aborted. The responder supersedes any resume whose
+        // session token it no longer holds (a concurrent flow to the same
+        // peer+CG+phase rotated it), throwing "session superseded" — but that
+        // message never survives the router's stream.abort, so from here a
+        // supersede is indistinguishable from a plain mid-stream transport
+        // drop. Re-saving is a trap in BOTH readings: the retry resumes at
+        // offset>0 with a session id the responder won't honour (offset>0 +
+        // non-active token => it supersedes AGAIN), looping for the full
+        // session TTL (~10 min) while peer backoff compounds. Drop BOTH the
+        // session and the checkpoint (exactly as the in-process superseded
+        // branch above does) so the retry mints a fresh id and sends offset 0
+        // => the responder refreshes its row list and serves from the start —
+        // real progress instead of a stuck loop, and the loop-kill stops the
+        // backoff from compounding. A FRESH round (resumedFromOffset === 0)
+        // that merely advanced then blipped is NOT dropped: its resume is
+        // likely valid, and a supersede there just costs one wasted resume
+        // attempt before this branch catches it next round. Precise
+        // per-supersede handling that never loses resume is the
+        // in-band-sentinel follow-up.
+        unfinishedSyncResponderSessions.delete(checkpointKey);
+        checkpointStore.delete(checkpointKey);
+      } else {
+        // Fresh round (no resume) — keep the session so a retry can resume from
+        // where it got to. Recovery never persists a responder session to
+        // resume (see the timeout branch below + Codex #1173).
+        rememberUnfinishedSyncResponderSession(checkpointKey, responderSession);
+      }
     }
     throw err;
   }

--- a/packages/agent/test/sync-fresh-per-attempt.test.ts
+++ b/packages/agent/test/sync-fresh-per-attempt.test.ts
@@ -785,6 +785,100 @@ describe('fetchSyncPages: fresh envelope + fresh messageId per retry attempt', (
     expect(observedBuilds[observedBuilds.length - 1].syncSessionId).not.toBe(supersededSessionId);
   });
 
+  it('drops a RESUMED session that aborts with a GENERIC transport error (network-path R1 fix)', async () => {
+    // 2026-07-07 sync storm. Over the wire the responder's "superseded" message
+    // is destroyed by the router's stream.abort, so the requester sees a
+    // GENERIC reset — not the text isSyncResponderSessionSupersededError
+    // matches. Before the fix this re-saved the doomed session and the retry
+    // resumed at offset>0 with a token the responder no longer honoured,
+    // looping ~10 min. Now a RESUMED round that aborts drops the session +
+    // checkpoint for a clean offset-0 restart, WITHOUT relying on the (lost)
+    // superseded message.
+    vi.setSystemTime(1_700_100_000_000);
+    const observedBuilds: Array<{ offset: number; syncSessionId: string | undefined }> = [];
+    const checkpointValues = new Map<string, ReturnType<typeof freshCheckpoint>>();
+    const deletedCheckpoints: string[] = [];
+    const checkpointKey = `${REMOTE_PEER_ID}|generic-abort-resume-cg|durable|data`;
+    let sendMode: 'timeout' | 'abort' | 'complete' = 'timeout';
+
+    const checkpointStore = {
+      get: (key: string) => checkpointValues.get(key),
+      set: (key: string, value: number) => { checkpointValues.set(key, freshCheckpoint(value)); },
+      delete: (key: string) => { deletedCheckpoints.push(key); checkpointValues.delete(key); },
+    };
+
+    const runFetch = () => runFetchWithFakeTimers(
+      fetchSyncPages({
+        ctx: makeCtx(),
+        remotePeerId: REMOTE_PEER_ID,
+        contextGraphId: 'generic-abort-resume-cg',
+        includeSharedMemory: false,
+        phase: 'data',
+        graphUri: GRAPH_URI,
+        deadline: Date.now() + 60_000,
+        syncPageTimeoutMs: 5_000,
+        syncRouterAttempts: 1,
+        syncPageRetryAttempts: 1,
+        syncPageSize: 1,
+        syncDeniedResponse: '#DENIED',
+        debugSyncProgress: false,
+        protocolSync: PROTOCOL_ID,
+        checkpointStore,
+        buildSyncRequest: async (
+          _contextGraphId,
+          offset,
+          _limit,
+          _includeSharedMemory,
+          _remotePeerId,
+          _phase,
+          _snapshotRef,
+          _sinceBatchId,
+          syncSessionId,
+        ) => {
+          observedBuilds.push({ offset, syncSessionId });
+          return new TextEncoder().encode(`request-${offset}`);
+        },
+        parseAndFilter: singleQuadParser,
+        send: async () => {
+          if (sendMode === 'timeout') {
+            vi.setSystemTime(1_700_100_060_001);
+            return new TextEncoder().encode('one-quad-line');
+          }
+          if (sendMode === 'abort') {
+            // GENERIC transport error — deliberately NOT the "superseded" text.
+            throw new Error('stream reset');
+          }
+          return new TextEncoder().encode('');
+        },
+        logWarn: noopLog,
+        logInfo: noopLog,
+        logDebug: noopLog,
+      }),
+    );
+
+    // Round 1: partial progress then timeout — persists a resumable session.
+    const first = await runFetch();
+    expect(first.completed).toBe(false);
+    expect(first.nextOffset).toBeGreaterThan(0);
+    checkpointValues.set(checkpointKey, freshCheckpoint(first.nextOffset));
+    const abortedSessionId = observedBuilds[0].syncSessionId;
+
+    // Round 2: RESUME (resumedFromOffset>0), then abort with a generic error.
+    sendMode = 'abort';
+    const before = deletedCheckpoints.length;
+    await expect(runFetch()).rejects.toThrow('stream reset');
+    // The fix: the resumed-then-aborted session's checkpoint is DROPPED even
+    // though no "superseded" message arrived — no 10-minute resume loop.
+    expect(deletedCheckpoints.slice(before)).toContain(checkpointKey);
+
+    // Round 3: clean restart at offset 0 with a FRESH session id.
+    sendMode = 'complete';
+    const resumed = await runFetch();
+    expect(resumed.resumedFromOffset).toBe(0);
+    expect(observedBuilds[observedBuilds.length - 1]).toMatchObject({ offset: 0 });
+    expect(observedBuilds[observedBuilds.length - 1].syncSessionId).not.toBe(abortedSessionId);
+  });
+
   it('restarts durable data checkpoints at offset zero with a stable sync session', async () => {
     const observedBuilds: Array<{
       offset: number;


### PR DESCRIPTION
## Summary
R1 of the 2026-07-07 sync storm. When a resume (offset>0) is **superseded** — a concurrent flow to the same peer+CG+phase rotated the responder's session token — the responder throws `"sync session was superseded before page completion"`. That message **never survives the router's `stream.abort`** (it becomes a generic reset), so the requester's exact-text match (`isSyncResponderSessionSupersededError`) can only fire **in-process, never over the wire**.

On a real network peer the else-branch re-saved the doomed session; the retry resumed at offset>0 with a token the responder no longer honours → superseded **again** → the round **looped for the full session TTL (~10 min)** while peer backoff compounded.

## Change
When a round that **resumed** (`resumedFromOffset > 0`) aborts (and isn't a clean denial), drop **both** the responder session and the checkpoint — exactly as the in-process superseded branch already does — instead of re-saving. The retry then mints a fresh session id and sends **offset 0**, so the responder refreshes its row list and serves from the start: real progress instead of a stuck loop, and killing the loop stops the backoff from compounding.

- A **fresh** round (`resumedFromOffset === 0`) that merely advanced then blipped keeps its resume; a supersede there costs at most one wasted resume attempt before this branch catches it.
- We can't distinguish supersede from a genuine transport drop at the requester (that's the whole R1 problem), so this is the conservative, **no-wire-change** loop-kill.

## Scope
**C-2** of the storm fix. Precise per-supersede handling that never loses resume (an in-band superseded sentinel, reusing the existing `__DKG_SYNC_BUSY__` mechanism) is **Option A**, filed as a follow-up.

## Tests
- new: a RESUMED session aborting with a **generic** `stream reset` (not the superseded text) now drops the checkpoint and restarts clean at offset 0 with a fresh session id
- sync suites: 269/272 (3 pre-existing skips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)