### PR TITLE
test(devnet): N-version harness + mixed-version interop suite

### DIFF
--- a/devnet/mixed-version/automated.test.ts
+++ b/devnet/mixed-version/automated.test.ts
@@ -48,25 +48,32 @@ interface NodeVersion {
   version: string;
 }
 
-function parseSemver(v: string): [number, number, number] {
+/** Parse `MAJOR.MINOR.PATCH`, or null if the string carries no semver — callers
+ *  must handle null explicitly rather than silently comparing a 0.0.0 stand-in
+ *  (otReviewAgent #1513: coercing an unknown version to 0.0.0 hides the very
+ *  invariant the skew assertions depend on). */
+function parseSemver(v: string): [number, number, number] | null {
   const m = /(\d+)\.(\d+)\.(\d+)/.exec(v);
-  return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : [0, 0, 0];
+  return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null;
 }
 
-/** Standard semver compare: <0 if a<b, 0 if equal, >0 if a>b. */
-function cmpSemver(a: string, b: string): number {
-  const A = parseSemver(a);
-  const B = parseSemver(b);
+const KNOWN_ROLES = new Set(['core', 'edge']);
+
+/** Standard semver compare over two ALREADY-PARSED versions. */
+function cmpSemver(a: [number, number, number], b: [number, number, number]): number {
   for (let i = 0; i < 3; i++) {
-    if (A[i] !== B[i]) return A[i] - B[i];
+    if (a[i] !== b[i]) return a[i] - b[i];
   }
   return 0;
 }
 
+/** Raw /api/status — no magic fallbacks. Missing fields surface as empty
+ *  strings so the reachability test can fail loudly on a malformed boundary
+ *  instead of silently mislabeling a node's version/role. */
 async function statusOf(node: DevnetNode): Promise<{ version: string; nodeRole: string }> {
   const res = await fetchRetry(`http://127.0.0.1:${node.apiPort}/api/status`);
   const j = (await res.json()) as { version?: string; nodeRole?: string };
-  return { version: j.version ?? 'unknown', nodeRole: j.nodeRole ?? 'edge' };
+  return { version: j.version ?? '', nodeRole: j.nodeRole ?? '' };
 }
 
 let devnet: DevnetState | null = null;
@@ -96,6 +103,19 @@ describe('mixed-version devnet interop', () => {
       return;
     }
     expect(versions.length).toBeGreaterThan(0);
+    // Fail loudly on a malformed status boundary rather than silently coercing:
+    // the whole suite reasons over versions and core/edge roles, so every node
+    // MUST report a parseable version and a known role (otReviewAgent #1513).
+    const badVersion = versions.filter((v) => parseSemver(v.version) === null);
+    expect(
+      badVersion,
+      `nodes with a missing/unparseable /api/status version: ${badVersion.map((v) => `node${v.num}="${v.version}"`).join(', ')}`,
+    ).toEqual([]);
+    const badRole = versions.filter((v) => !KNOWN_ROLES.has(v.role));
+    expect(
+      badRole,
+      `nodes with an unexpected /api/status nodeRole (want core|edge): ${badRole.map((v) => `node${v.num}="${v.role}"`).join(', ')}`,
+    ).toEqual([]);
   });
 
   it('runs at least two distinct versions (else skips the skew checks with guidance)', () => {
@@ -114,15 +134,26 @@ describe('mixed-version devnet interop', () => {
 
   it('edges are NOT ahead of cores (rollout shape: edges lag the cores)', () => {
     if (!devnet) return;
-    const cores = versions.filter((v) => v.role === 'core').map((v) => v.version);
-    const edges = versions.filter((v) => v.role === 'edge').map((v) => v.version);
+    // Parse up front; the reachability test above already guaranteed every node
+    // has a parseable version, so a null here is a real invariant break, not a
+    // silent 0.0.0.
+    const parsed = (role: string) =>
+      versions
+        .filter((v) => v.role === role)
+        .map((v) => {
+          const p = parseSemver(v.version);
+          if (!p) throw new Error(`node${v.num} has an unparseable version "${v.version}"`);
+          return p;
+        });
+    const cores = parsed('core');
+    const edges = parsed('edge');
     if (cores.length === 0 || edges.length === 0) return;
     const minCore = [...cores].sort(cmpSemver)[0];
     const maxEdge = [...edges].sort(cmpSemver)[edges.length - 1];
     // Every edge <= every core (edges behind, or equal on a single-version lane).
     expect(
       cmpSemver(maxEdge, minCore),
-      `expected max edge version (${maxEdge}) <= min core version (${minCore})`,
+      `expected max edge version (${maxEdge.join('.')}) <= min core version (${minCore.join('.')})`,
     ).toBeLessThanOrEqual(0);
   });
 

--- a/devnet/mixed-version/automated.test.ts
+++ b/devnet/mixed-version/automated.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Mixed-version devnet interop.
+ *
+ * The rollout reality: a cluster runs MULTIPLE releases at once — cores upgraded
+ * first, edges lagging one version "behind". The 2026-07-07 mainnet incident was
+ * first (wrongly) blamed on exactly this, and every devnet lane before now ran a
+ * single build, so cross-version behaviour was untested. This suite exercises
+ * it: an older EDGE publishes through the newer CORES and confirms on-chain, and
+ * a current core reaches quorum in the mixed cluster.
+ *
+ * Start a mixed-version devnet with the version-layout the harness now supports
+ * (see scripts/devnet.sh `DEVNET_VERSION_LAYOUT`):
+ *
+ *   DEVNET_VERSION_LAYOUT="all:current,edges:prev" ./scripts/devnet.sh start 6
+ *
+ * `prev` resolves to the latest release tag — the version immediately preceding
+ * the code under test on main (e.g. v10.0.3 while 10.0.4 is in development).
+ * N-version layouts also work:
+ *
+ *   DEVNET_VERSION_LAYOUT="1-2:current,3-4:v10.0.3,5-6:v10.0.2" ./scripts/devnet.sh start 6
+ *
+ * When run against a SINGLE-version devnet the version-skew checks skip with an
+ * explanatory message (the functional publishes still run), so the suite is
+ * green-and-informative on ordinary lanes and only enforces skew when one is
+ * actually present.
+ *
+ * Run: pnpm test:devnet:mixed-version
+ */
+import { beforeAll, describe, expect, it } from 'vitest';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  detectDevnet,
+  makeNquadsFile,
+  publishViaCli,
+  fetchRetry,
+  CONTEXT_GRAPH,
+  type DevnetNode,
+  type DevnetState,
+} from '../_bootstrap/harness.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const NODE_COUNT = Number(process.env.DEVNET_NODE_COUNT ?? 6);
+
+interface NodeVersion {
+  num: number;
+  role: string;
+  version: string;
+}
+
+function parseSemver(v: string): [number, number, number] {
+  const m = /(\d+)\.(\d+)\.(\d+)/.exec(v);
+  return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : [0, 0, 0];
+}
+
+/** Standard semver compare: <0 if a<b, 0 if equal, >0 if a>b. */
+function cmpSemver(a: string, b: string): number {
+  const A = parseSemver(a);
+  const B = parseSemver(b);
+  for (let i = 0; i < 3; i++) {
+    if (A[i] !== B[i]) return A[i] - B[i];
+  }
+  return 0;
+}
+
+async function statusOf(node: DevnetNode): Promise<{ version: string; nodeRole: string }> {
+  const res = await fetchRetry(`http://127.0.0.1:${node.apiPort}/api/status`);
+  const j = (await res.json()) as { version?: string; nodeRole?: string };
+  return { version: j.version ?? 'unknown', nodeRole: j.nodeRole ?? 'edge' };
+}
+
+let devnet: DevnetState | null = null;
+let versions: NodeVersion[] = [];
+
+describe('mixed-version devnet interop', () => {
+  beforeAll(async () => {
+    devnet = await detectDevnet(NODE_COUNT);
+    if (!devnet) return;
+    const nums = Object.keys(devnet.nodes).map(Number).sort((a, b) => a - b);
+    versions = [];
+    for (const num of nums) {
+      const s = await statusOf(devnet.nodes[num]);
+      versions.push({ num, role: s.nodeRole, version: s.version });
+    }
+    // eslint-disable-next-line no-console
+    console.log(
+      '[mixed-version] cluster: ' +
+        versions.map((v) => `node${v.num}=${v.role}:${v.version}`).join(' '),
+    );
+  }, 60_000);
+
+  it('devnet is reachable (otherwise the suite skips)', () => {
+    if (!devnet) {
+      // eslint-disable-next-line no-console
+      console.warn('[mixed-version] no devnet detected — start one to run this suite');
+      return;
+    }
+    expect(versions.length).toBeGreaterThan(0);
+  });
+
+  it('runs at least two distinct versions (else skips the skew checks with guidance)', () => {
+    if (!devnet) return;
+    const distinct = [...new Set(versions.map((v) => v.version))];
+    if (distinct.length < 2) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[mixed-version] single-version cluster (${distinct.join(', ')}). ` +
+          'Start with DEVNET_VERSION_LAYOUT="all:current,edges:prev" to exercise version skew.',
+      );
+      return;
+    }
+    expect(distinct.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('edges are NOT ahead of cores (rollout shape: edges lag the cores)', () => {
+    if (!devnet) return;
+    const cores = versions.filter((v) => v.role === 'core').map((v) => v.version);
+    const edges = versions.filter((v) => v.role === 'edge').map((v) => v.version);
+    if (cores.length === 0 || edges.length === 0) return;
+    const minCore = [...cores].sort(cmpSemver)[0];
+    const maxEdge = [...edges].sort(cmpSemver)[edges.length - 1];
+    // Every edge <= every core (edges behind, or equal on a single-version lane).
+    expect(
+      cmpSemver(maxEdge, minCore),
+      `expected max edge version (${maxEdge}) <= min core version (${minCore})`,
+    ).toBeLessThanOrEqual(0);
+  });
+
+  it('an EDGE publishes a public KA that confirms through the (newer) cores', async () => {
+    if (!devnet) return;
+    const edge = versions.find((v) => v.role === 'edge');
+    if (!edge) {
+      // eslint-disable-next-line no-console
+      console.warn('[mixed-version] no edge node in the cluster — skipping edge publish');
+      return;
+    }
+    const { path } = makeNquadsFile(HERE, 'mixed-edge-pub', CONTEXT_GRAPH);
+    // publishViaCli asserts a confirmed/finalized status + positive kaId itself.
+    const result = await publishViaCli(devnet.nodes[edge.num], CONTEXT_GRAPH, path);
+    expect(result.kaId).toBeGreaterThan(0n);
+  }, 180_000);
+
+  it('a CORE publishes and reaches ACK quorum in the mixed cluster', async () => {
+    if (!devnet) return;
+    const core = versions.find((v) => v.role === 'core');
+    if (!core) return;
+    const { path } = makeNquadsFile(HERE, 'mixed-core-pub', CONTEXT_GRAPH);
+    const result = await publishViaCli(devnet.nodes[core.num], CONTEXT_GRAPH, path);
+    expect(result.kaId).toBeGreaterThan(0n);
+  }, 180_000);
+});

--- a/devnet/mixed-version/package.json
+++ b/devnet/mixed-version/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@origintrail-official/dkg-devnet-mixed-version",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test:devnet": "vitest run --config vitest.config.ts"
+  },
+  "dependencies": {
+    "ethers": "^6.16.0"
+  },
+  "devDependencies": {
+    "vitest": "^4.0.18"
+  }
+}

--- a/devnet/mixed-version/vitest.config.ts
+++ b/devnet/mixed-version/vitest.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'node:path';
+
+/**
+ * Mixed-version devnet interop suite. Depends on a running devnet — ideally a
+ * mixed-version one started with `DEVNET_VERSION_LAYOUT` (see
+ * scripts/devnet.sh). Not part of the default `pnpm test` fan-out.
+ *
+ * Run via: `pnpm test:devnet:mixed-version`.
+ */
+export default defineConfig({
+  test: {
+    include: [resolve(import.meta.dirname, 'automated.test.ts')],
+    testTimeout: 240_000,
+    hookTimeout: 120_000,
+    pool: 'forks',
+    sequence: { concurrent: false },
+    globals: false,
+  },
+  resolve: {
+    modules: [
+      resolve(import.meta.dirname, '../../node_modules'),
+      'node_modules',
+    ],
+  },
+});

--- a/devnet/suites.json
+++ b/devnet/suites.json
@@ -18,6 +18,7 @@
     "core-peers-features",
     "edge-update-flow",
     "greenfield-10min",
+    "mixed-version",
     "pr1366-pca-deposit-waiver",
     "pr1369-folded-private-ack",
     "pr1370-admin-op-wallet",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "test:devnet:ack-candidate-isolation": "vitest run --config devnet/ack-candidate-isolation/vitest.config.ts",
     "test:devnet:edge-update-flow": "vitest run --config devnet/edge-update-flow/vitest.config.ts",
     "test:devnet:greenfield-10min": "vitest run --config devnet/greenfield-10min/vitest.config.ts",
+    "test:devnet:mixed-version": "vitest run --config devnet/mixed-version/vitest.config.ts",
     "test:devnet:rich-scenario": "vitest run --config devnet/rich-scenario/vitest.config.ts",
     "test:devnet:rpc-quiet-window": "vitest run --config devnet/rpc-quiet-window/vitest.config.ts",
     "test:devnet:v10-rs-prune": "vitest run --config devnet/v10-rs-prune/vitest.config.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,6 +177,16 @@ importers:
         specifier: ^4.0.18
         version: 4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.19.11)(happy-dom@20.8.9(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
+  devnet/mixed-version:
+    dependencies:
+      ethers:
+        specifier: ^6.16.0
+        version: 6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+    devDependencies:
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.19.11)(happy-dom@20.8.9(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
+
   devnet/pr1366-pca-deposit-waiver:
     dependencies:
       ethers:
@@ -12906,7 +12916,7 @@ snapshots:
       lines-and-columns: 1.2.4
       mz: 2.7.0
       pirates: 4.0.7
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       ts-interface-checker: 0.1.13
 
   supports-color@10.2.2: {}
@@ -13418,7 +13428,7 @@ snapshots:
       picomatch: 4.0.4
       postcss: 8.5.15
       rollup: 4.60.4
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 22.19.11
       fsevents: 2.3.3
@@ -13433,7 +13443,7 @@ snapshots:
       picomatch: 4.0.4
       postcss: 8.5.15
       rollup: 4.60.4
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 22.19.11
       fsevents: 2.3.3
@@ -13459,7 +13469,7 @@ snapshots:
       std-env: 3.10.0
       tinybench: 2.9.0
       tinyexec: 1.1.2
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 7.3.2(@types/node@22.19.11)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
@@ -13498,7 +13508,7 @@ snapshots:
       std-env: 3.10.0
       tinybench: 2.9.0
       tinyexec: 1.1.2
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 7.3.2(@types/node@22.19.11)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,6 +13,7 @@ packages:
   - "devnet/rfc51-publishing-allocation"
   - "devnet/edge-update-flow"
   - "devnet/greenfield-10min"
+  - "devnet/mixed-version"
   - "devnet/rich-scenario"
   - "devnet/rpc-quiet-window"
   - "devnet/v10-rs-prune"

--- a/scripts/devnet.sh
+++ b/scripts/devnet.sh
@@ -613,6 +613,143 @@ EOCONF
   log "Node $node_num config: port=$api_port, libp2p=$libp2p_port, role=$node_role, wallets=$((NUM_OP_WALLETS + 1))"
 }
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Multi-version support (mixed-version devnet).
+#
+# By default every node launches from the freshly-built repo ("current"). To run
+# a MIXED-VERSION cluster — e.g. edges lagging the cores during a rollout — set
+# DEVNET_VERSION_LAYOUT to a comma-separated list of SELECTOR:REF entries:
+#
+#   SELECTOR : all | cores | edges | <N> | <A-B>
+#   REF      : current | prev | <git-ref, e.g. v10.0.3>
+#
+# Later entries win, so "edges one release behind the cores" is:
+#
+#   DEVNET_VERSION_LAYOUT="all:current,edges:prev"
+#
+# N-version ready — any number of refs can coexist in one cluster:
+#
+#   DEVNET_VERSION_LAYOUT="1-2:current,3-4:v10.0.3,5-6:v10.0.2"
+#
+# "prev" resolves to DEVNET_PREV_VERSION if set, else the latest release tag —
+# i.e. the version immediately preceding the code under test on main. Non-current
+# refs are checked out as git worktrees under DEVNET_VERSIONS_DIR and built once
+# (cached across runs; DEVNET_VERSION_REBUILD=1 forces a rebuild).
+# ─────────────────────────────────────────────────────────────────────────────
+DEVNET_VERSION_LAYOUT="${DEVNET_VERSION_LAYOUT:-}"
+DEVNET_VERSIONS_DIR="${DEVNET_VERSIONS_DIR:-$REPO_ROOT/.devnet-versions}"
+
+# Latest release tag (vMAJOR.MINOR.PATCH), or DEVNET_PREV_VERSION if set.
+resolve_prev_version() {
+  if [ -n "${DEVNET_PREV_VERSION:-}" ]; then
+    echo "$DEVNET_PREV_VERSION"
+    return 0
+  fi
+  git -C "$REPO_ROOT" tag --sort=-v:refname 2>/dev/null \
+    | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | head -1
+}
+
+# Map a version REF to its cli.js entry point. current/empty -> the repo build.
+version_cli_entry() {
+  local ref="$1"
+  if [ -z "$ref" ] || [ "$ref" = "current" ]; then
+    echo "$REPO_ROOT/packages/cli/dist/cli.js"
+    return 0
+  fi
+  if [ "$ref" = "prev" ]; then
+    ref="$(resolve_prev_version)"
+  fi
+  echo "$DEVNET_VERSIONS_DIR/$ref/packages/cli/dist/cli.js"
+}
+
+# A node's authoritative role from its written config (default edge).
+node_role_of() {
+  local node_num="$1"
+  node -e "try{process.stdout.write(JSON.parse(require('fs').readFileSync(process.argv[1],'utf8')).nodeRole||'edge')}catch(e){process.stdout.write('edge')}" \
+    "$DEVNET_DIR/node${node_num}/config.json" 2>/dev/null || printf edge
+}
+
+# Resolve the version REF node <num> (role <role>) should run, per the layout.
+# Later matching entries override earlier ones.
+node_version_ref() {
+  local node_num="$1" role="$2" ref="current"
+  local oldifs="$IFS"
+  IFS=','
+  local entry
+  for entry in $DEVNET_VERSION_LAYOUT; do
+    if [ -z "$entry" ]; then continue; fi
+    local sel="${entry%%:*}" r="${entry#*:}"
+    case "$sel" in
+      all)   ref="$r" ;;
+      cores) if [ "$role" = "core" ]; then ref="$r"; fi ;;
+      edges) if [ "$role" = "edge" ]; then ref="$r"; fi ;;
+      *-*)   local lo="${sel%-*}" hi="${sel#*-}"
+             if [ "$node_num" -ge "$lo" ] 2>/dev/null && [ "$node_num" -le "$hi" ] 2>/dev/null; then
+               ref="$r"
+             fi ;;
+      *)     if [ "$node_num" = "$sel" ]; then ref="$r"; fi ;;
+    esac
+  done
+  IFS="$oldifs"
+  echo "$ref"
+}
+
+# The cli.js a given node should launch from.
+node_cli_entry() {
+  local node_num="$1"
+  local role
+  role="$(node_role_of "$node_num")"
+  version_cli_entry "$(node_version_ref "$node_num" "$role")"
+}
+
+# Check out <ref> as a worktree under DEVNET_VERSIONS_DIR and build it once.
+prepare_version() {
+  local ref="$1"
+  if [ "$ref" = "prev" ]; then ref="$(resolve_prev_version)"; fi
+  if [ -z "$ref" ]; then
+    echo "[devnet] prepare_version: no ref resolved (set DEVNET_PREV_VERSION, or ensure release tags exist)" >&2
+    return 1
+  fi
+  local dest="$DEVNET_VERSIONS_DIR/$ref"
+  if [ -f "$dest/packages/cli/dist/cli.js" ] && [ "${DEVNET_VERSION_REBUILD:-0}" != "1" ]; then
+    log "Version '$ref' already prepared at $dest"
+    return 0
+  fi
+  mkdir -p "$DEVNET_VERSIONS_DIR"
+  if [ ! -e "$dest/package.json" ]; then
+    log "Checking out version '$ref' as a worktree at $dest ..."
+    git -C "$REPO_ROOT" worktree add --force "$dest" "$ref"
+  fi
+  log "Building version '$ref' (runs once, then cached) ..."
+  ( cd "$dest" && pnpm install --prefer-offline && pnpm run build )
+  log "Version '$ref' prepared at $dest"
+}
+
+# Build every distinct non-current ref referenced by the layout (idempotent).
+prepare_layout_versions() {
+  if [ -z "$DEVNET_VERSION_LAYOUT" ]; then return 0; fi
+  local oldifs="$IFS"
+  IFS=','
+  local entry
+  local built=""
+  for entry in $DEVNET_VERSION_LAYOUT; do
+    if [ -z "$entry" ]; then continue; fi
+    local r="${entry#*:}"
+    if [ "$r" = "current" ] || [ -z "$r" ]; then continue; fi
+    if [ "$r" = "prev" ]; then r="$(resolve_prev_version)"; fi
+    case " $built " in *" $r "*) continue ;; esac
+    built="$built $r"
+    IFS="$oldifs"
+    prepare_version "$r"
+    IFS=','
+  done
+  IFS="$oldifs"
+}
+
+cmd_prepare_version() {
+  prepare_version "${2:-prev}"
+}
+
 start_node() {
   local node_num="$1"
   local node_dir="$DEVNET_DIR/node${node_num}"
@@ -679,8 +816,13 @@ start_node() {
   # byte-replayed duplicate tail segments in daemon.log — and doubled the
   # rpc_usage telemetry counts the rpc-quiet-window suite sums. console.log
   # still captures pre-tee output from an early crash.
+  # Version-layout aware: `node_cli_entry` returns the repo build for `current`
+  # nodes and a prepared alternate-version dist for mixed-version layouts.
+  local cli_entry
+  cli_entry="$(node_cli_entry "$node_num")"
+  log "Node $node_num launching from $cli_entry"
   DKG_HOME="$node_dir" DKG_NO_BLUE_GREEN=1 DKG_WALLETS_NO_MIGRATE=1 \
-    node "$REPO_ROOT/packages/cli/dist/cli.js" start --foreground \
+    node "$cli_entry" start --foreground \
     > "$node_dir/console.log" 2>&1 &
   local node_pid=$!
   echo "$node_pid" > "$pidfile"
@@ -863,9 +1005,16 @@ cmd_ui() {
 
 cmd_start() {
   log "Starting devnet with $NUM_NODES nodes..."
+  if [ -n "$DEVNET_VERSION_LAYOUT" ]; then
+    log "Mixed-version layout: $DEVNET_VERSION_LAYOUT"
+  fi
   mkdir -p "$DEVNET_DIR"
 
   ensure_built
+  # Build any alternate versions the layout references BEFORE starting nodes, so
+  # a mixed-version cluster comes up in one `start`. No-op for the default
+  # (all-current) layout.
+  prepare_layout_versions
   start_hardhat
   deploy_contracts
   start_blazegraph
@@ -1717,9 +1866,10 @@ cmd_restart_node() {
 }
 
 case "${1:-}" in
-  start)        cmd_start ;;
-  addnode)      cmd_addnode "$@" ;;
-  restart-node) cmd_restart_node "$@" ;;
+  start)            cmd_start ;;
+  addnode)          cmd_addnode "$@" ;;
+  restart-node)     cmd_restart_node "$@" ;;
+  prepare-version)  cmd_prepare_version "$@" ;;
   stop)         cmd_stop ;;
   status)       cmd_status ;;
   logs)         cmd_logs "$@" ;;
@@ -1734,6 +1884,9 @@ case "${1:-}" in
     echo "                          on-chain identity/stake/ask. (1 <= num <= 10)"
     echo "  restart-node <num>      Restart a single already-existing devnet node"
     echo "                          (pick up new code without rebuilding state)"
+    echo "  prepare-version [ref]   Check out + build an alternate version (default"
+    echo "                          'prev' = latest release tag) for mixed-version"
+    echo "                          runs. See DEVNET_VERSION_LAYOUT."
     echo "  stop                    Stop all devnet processes (incl. UI)"
     echo "  status                  Show running nodes (incl. UI) and their status"
     echo "  logs [N]                Tail logs for node N (default 1)"

--- a/scripts/devnet.sh
+++ b/scripts/devnet.sh
@@ -639,14 +639,35 @@ EOCONF
 DEVNET_VERSION_LAYOUT="${DEVNET_VERSION_LAYOUT:-}"
 DEVNET_VERSIONS_DIR="${DEVNET_VERSIONS_DIR:-$REPO_ROOT/.devnet-versions}"
 
-# Latest release tag (vMAJOR.MINOR.PATCH), or DEVNET_PREV_VERSION if set.
+# Latest release tag (vMAJOR.MINOR.PATCH) STRICTLY BELOW the current workspace
+# version, or DEVNET_PREV_VERSION if set. 'prev' must never resolve to the
+# CURRENT version: right after a release the newest tag equals the workspace
+# version (v10.0.3 tag while package.json says 10.0.3), and a prev==current
+# layout silently builds a single-version devnet whose mixed-version suite
+# self-skips — a falsely green lane. Echoes nothing when no older tag exists
+# (callers guard on empty and point at DEVNET_PREV_VERSION).
 resolve_prev_version() {
   if [ -n "${DEVNET_PREV_VERSION:-}" ]; then
     echo "$DEVNET_PREV_VERSION"
     return 0
   fi
-  git -C "$REPO_ROOT" tag --sort=-v:refname 2>/dev/null \
-    | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | head -1
+  local current tag bare
+  current="$(node -p "require('$REPO_ROOT/package.json').version" 2>/dev/null || true)"
+  for tag in $(git -C "$REPO_ROOT" tag --sort=-v:refname 2>/dev/null | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' || true); do
+    if [ -z "$current" ]; then
+      # Workspace version unreadable — degrade to the newest tag (legacy behavior).
+      echo "$tag"
+      return 0
+    fi
+    bare="${tag#v}"
+    if [ "$bare" = "$current" ]; then continue; fi
+    if [ "$(printf '%s\n%s\n' "$bare" "$current" | sort -V | head -1)" = "$bare" ]; then
+      echo "$tag" # newest-first scan → first tag strictly below current
+      return 0
+    fi
+  done
+  echo "[devnet] resolve_prev_version: no release tag strictly below current version ${current:-unknown}; set DEVNET_PREV_VERSION explicitly" >&2
+  return 0
 }
 
 # Map a version REF to its cli.js entry point. current/empty -> the repo build.


### PR DESCRIPTION
## Summary
Every devnet lane before this ran a **single build**, so cross-version behaviour was untested — yet the 2026-07-07 mainnet incident was first (wrongly) blamed on version skew. This adds the capability to run a **mixed-version cluster** and a suite that exercises it: edges lagging the cores (the rollout reality), interop-verified.

## Harness (`scripts/devnet.sh`)
- **`DEVNET_VERSION_LAYOUT`** maps nodes → versions via `SELECTOR:REF` entries (`SELECTOR`: `all|cores|edges|<N>|<A-B>`, `REF`: `current|prev|<git-ref>`), later entries winning:
  - `"all:current,edges:prev"` — edges one release behind the cores.
  - `"1-2:current,3-4:v10.0.3,5-6:v10.0.2"` — **N versions at once** (built for the "more than 2 later" requirement from day one).
- **`prev`** resolves to the latest release tag — the version immediately preceding the code under test on main (v10.0.3 once 10.0.4 tags); overridable via `DEVNET_PREV_VERSION`.
- Non-current refs are checked out as **git worktrees** under `.devnet-versions/` and built once (cached; `DEVNET_VERSION_REBUILD=1` forces). `start` auto-prepares them; `devnet.sh prepare-version [ref]` does it standalone.
- `start_node` launches each node from its resolved `cli.js` (`node_cli_entry`).

## Suite (`devnet/mixed-version`)
Asserts the cluster runs ≥2 distinct versions, edges are not ahead of cores (rollout shape), an **older edge publishes a public KA that confirms through the newer cores**, and a core reaches ACK quorum in the mixed cluster. On a single-version lane the skew checks skip with guidance, so it's green-and-informative everywhere.

## Validation
- Version resolver unit-tested (`node3→v10.0.3, node6→v10.0.2` for a 3-version layout).
- `bash -n scripts/devnet.sh` clean.
- Wired into `suites.json` / `pnpm-workspace.yaml` / `package.json` — **manifest drift-guard green (8/8)**.
- Suite compiles + skip-path runs green here (5/5). Full behavioural validation needs a live mixed-version devnet.

## Follow-up
Incident-scenario coverage suites (folded-private merkle parity, candidacy-beyond-relays, store-outage) land in a separate stacked PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)