### PR TITLE
chore(release): 10.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,31 @@
 # Changelog
 
-All notable changes to the DKG V9 node are documented here. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+All notable changes to the DKG V10 node are documented here. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [10.0.4] - 2026-07-08
+
+Mainnet ACK and release-ops patch: fixes ACK candidate selection and empty-reply retry handling, scopes relay-watchdog churn to private nodes, adds universal per-wallet EVM transaction serialization for publisher approve/send paths, and lands the manual canary/testnet/mainnet release promotion flow. **No smart-contract changes - no deployment required** (no Solidity source, ABI, or deployment JSON changes since 10.0.3).
+
+### Added
+
+- **Universal per-wallet transaction dispatcher** for EVM sends, including serialized approval sends and regression coverage for different-wallet concurrency plus the approval sender wiring (#1503).
+- **Manual release promotion tooling and docs** for package version verification, build metadata, signed tag checks, npm publish verification, canary/testnet promotion, and mainnet dist-tag promotion (#1498).
+
+### Changed
+
+- **Release CI** now validates the manual release flow and keeps release automation focused on signed release gates instead of the removed disabled npm-publish workflow (#1498).
+
+### Fixed
+
+- **ACK peer selection** now uses ACK candidate rankings only for relay preference, not eligibility; publishing remains chain-truth gated by valid on-chain ACK provider status (#1501).
+- **Zero-length ACK replies** are treated as retryable transport failures instead of `INVALID_SIGNATURE`, preserving fallback to other ACK providers (#1507).
+- **Public relay watchdog** no longer churns sibling-core connections on public nodes, with the gate covered at watchdog and relay levels (#1508).
+
+### Deployment
+
+- **No new contract deployment.** No Solidity source, ABI, or deployment JSON changes since 10.0.3; existing v10 registries remain the deploy targets.
 
 ## [10.0.3] - 2026-07-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,26 +6,31 @@ All notable changes to the DKG V10 node are documented here. The format is based
 
 ## [10.0.4] - 2026-07-08
 
-Mainnet ACK and release-ops patch: fixes ACK candidate selection and empty-reply retry handling, scopes relay-watchdog churn to private nodes, adds universal per-wallet EVM transaction serialization for publisher approve/send paths, and lands the manual canary/testnet/mainnet release promotion flow. **No smart-contract changes - no deployment required** (no Solidity source, ABI, or deployment JSON changes since 10.0.3).
+2026-07-07 mainnet-incident hardening + transaction-dispatcher release. Publisher-side: ACK candidacy ranks-not-gates, empty-reply retry, responder ACK deadlines, SWM merkle-filter parity. Network-side: relay-watchdog churn fix and sync-storm calming (bounded catch-up fan-out, superseded-resume loop kill). Chain-side: the universal per-wallet transaction dispatcher lands end-to-end — every node write serialized per wallet, funding-aware generalized signer selection, and Random Sampling rotating across registered operational wallets instead of pinning wallet #0. Plus the codified manual release flow with signed-tag gates. **No smart-contract changes — no deployment required** (no Solidity source, ABI, or mainnet/testnet deployment-registry changes since 10.0.3).
 
 ### Added
 
-- **Universal per-wallet transaction dispatcher** for EVM sends, including serialized approval sends and regression coverage for different-wallet concurrency plus the approval sender wiring (#1503).
-- **Manual release promotion tooling and docs** for package version verification, build metadata, signed tag checks, npm publish verification, canary/testnet promotion, and mainnet dist-tag promotion (#1498).
+- **Universal transaction dispatcher (Phases 0-4)**: every node write funnels through the per-operational-wallet serializer, closing the cross-type nonce race (#1503); funding floors (`minPublisherNativeWei`/`minPublisherTracWei`) plumbed config→adapter with fail-fast parsing of persisted string/number values, and the generalized `selectSigner(spec)` seam with typed funding modes (#1504 via #1516); **Random Sampling rotates `createChallenge`/`submitProof` across registered operational wallets** — fail-closed registered-set eligibility, per-metric funding cache so RS probes never poison publish TRAC reads, `ProfileDoesntExist` self-heal (#1506 via #1516), and on-chain identity revalidation of the chosen wallet at selection, evicting out-of-band re-registrations (#1519).
+- **Manual release promotion tooling and docs**: `release:verify-versions` / `verify-tag` (annotated+signed structure, tag-on-origin, main ancestry) / `build-info` / `promote` / `verify-published`, with the staged canary→testnet→mainnet promotion flow documented as the release process (#1498; signed-tag canary docs #1518).
+- **Devnet coverage for the incident class**: N-version harness + mixed-version interop suite with strictly-older `prev` resolution (#1513), storage-ACK store-outage suite — a real store paused mid-publish must yield a typed decline, quorum via healthy cores, and clean recovery (#1517), and an RS wallet-rotation suite (#1516).
 
 ### Changed
 
 - **Release CI** now validates the manual release flow and keeps release automation focused on signed release gates instead of the removed disabled npm-publish workflow (#1498).
+- **Catch-up sync fan-out is bounded** (default 4 concurrent peers, `DKG_CATCHUP_MAX_CONCURRENT_PEERS`) on both the agent-internal paths and the daemon subscribe worker — the registry-wide unbounded fan-out was the 2026-07-07 sync-storm engine (#1511).
 
 ### Fixed
 
-- **ACK peer selection** now uses ACK candidate rankings only for relay preference, not eligibility; publishing remains chain-truth gated by valid on-chain ACK provider status (#1501).
-- **Zero-length ACK replies** are treated as retryable transport failures instead of `INVALID_SIGNATURE`, preserving fallback to other ACK providers (#1507).
-- **Public relay watchdog** no longer churns sibling-core connections on public nodes, with the gate covered at watchdog and relay levels (#1508).
+- **ACK peer selection** now uses the bundled relay list only for preference ordering, never eligibility: any connected, chain-valid core can complete quorum (the 2026-07-07 outage cap), while `ackCandidatePeerIds` remains a true allowlist for SDK callers that set it (#1501).
+- **Zero-length ACK replies** are treated as retryable transport failures instead of terminal `INVALID_SIGNATURE`, so a store hiccup or connection churn no longer permanently deselects a healthy peer (#1507).
+- **ACK handlers answer within a deadline** (send-timeout minus a safety margin, publish and update paths): a saturated store now produces a typed `CORE_TEMPORARILY_UNAVAILABLE` decline that rides the transient-retry ladder instead of dead-air the publisher mislabels (#1510).
+- **SWM merkle-root exclusion filter unified** publisher⇄responder via one shared helper, closing the `MERKLE_MISMATCH_IN_SWM` class for bookkeeping quads resident in the data graph (#1509; responder-boundary regression pinned in #1520).
+- **Public relay watchdog** no longer churns sibling-core connections on publicly-reachable nodes chasing a circuit reservation it can never obtain (#1508); a `/dnsaddr`-only announce no longer counts as direct reachability, so NAT'd nodes keep maintaining their reservations (#1518).
+- **Superseded-resume sync loop killed**: an aborted resumed round drops the remembered responder session and checkpoint, so the retry restarts fresh at offset 0 and makes progress instead of blind-retrying a doomed resume for the session TTL (#1512).
 
 ### Deployment
 
-- **No new contract deployment.** No Solidity source, ABI, or deployment JSON changes since 10.0.3; existing v10 registries remain the deploy targets.
+- **No new contract deployment.** No Solidity source, ABI, or mainnet/testnet deployment-registry changes since 10.0.3; existing v10 registries remain the deploy targets (re-verified across the full 10.0.4 merge set).
 
 ## [10.0.3] - 2026-07-07
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dkg-v10",
-  "version": "10.0.3",
+  "version": "10.0.4",
   "private": true,
   "packageManager": "pnpm@10.28.1",
   "dkgBuild": {

--- a/packages/adapter-elizaos/package.json
+++ b/packages/adapter-elizaos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-elizaos",
-  "version": "10.0.3",
+  "version": "10.0.4",
   "description": "ElizaOS plugin adapter — turns any ElizaOS agent into a DKG V10 node",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapter-hermes/package.json
+++ b/packages/adapter-hermes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-hermes",
-  "version": "10.0.3",
+  "version": "10.0.4",
   "description": "Hermes Agent adapter — connects Hermes AI agents to a DKG V10 node for verifiable shared memory",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapter-openclaw/package.json
+++ b/packages/adapter-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-openclaw",
-  "version": "10.0.3",
+  "version": "10.0.4",
   "description": "OpenClaw plugin adapter for connecting a DKG V10 node and chat bridge to an OpenClaw agent",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-agent",
-  "version": "10.0.3",
+  "version": "10.0.4",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/chain/package.json
+++ b/packages/chain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-chain",
-  "version": "10.0.3",
+  "version": "10.0.4",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg",
-  "version": "10.0.3",
+  "version": "10.0.4",
   "type": "module",
   "main": "dist/cli.js",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-core",
-  "version": "10.0.3",
+  "version": "10.0.4",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/epcis/package.json
+++ b/packages/epcis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-epcis",
-  "version": "10.0.3",
+  "version": "10.0.4",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/evm-module/package.json
+++ b/packages/evm-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-evm-module",
-  "version": "10.0.3",
+  "version": "10.0.4",
   "description": "DKG V10 smart contracts (forked from V8 dkg-evm-module)",
   "license": "Apache-2.0",
   "private": true,

--- a/packages/graph-viz/package.json
+++ b/packages/graph-viz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-graph-viz",
-  "version": "10.0.3",
+  "version": "10.0.4",
   "description": "RDF Knowledge Graph Visualizer — force-directed graph rendering with hexagonal nodes, declarative view configs, RDF-native data loading, and SPARQL-driven views",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/kafka-plugin/package.json
+++ b/packages/kafka-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/kafka-plugin",
-  "version": "10.0.3",
+  "version": "10.0.4",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mcp-dkg/package.json
+++ b/packages/mcp-dkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-mcp",
-  "version": "10.0.3",
+  "version": "10.0.4",
   "description": "MCP server that exposes the local DKG daemon (projects, sub-graphs, activity, chat) to Cursor, Claude Code, and any other MCP-aware coding assistant.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/network-sim/package.json
+++ b/packages/network-sim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-network-sim",
-  "version": "10.0.3",
+  "version": "10.0.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/node-ui/package.json
+++ b/packages/node-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-node-ui",
-  "version": "10.0.3",
+  "version": "10.0.4",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/okf/package.json
+++ b/packages/okf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-okf",
-  "version": "10.0.3",
+  "version": "10.0.4",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/publisher/package.json
+++ b/packages/publisher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-publisher",
-  "version": "10.0.3",
+  "version": "10.0.4",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-query",
-  "version": "10.0.3",
+  "version": "10.0.4",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/random-sampling/package.json
+++ b/packages/random-sampling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-random-sampling",
-  "version": "10.0.3",
+  "version": "10.0.4",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-storage",
-  "version": "10.0.3",
+  "version": "10.0.4",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Release 10.0.4

Version bump for the 10.0.4 release cut from `main` (`61e4411da`). Patch release - ACK publishing fixes, per-wallet transaction serialization, and release-process hardening; **no smart-contract changes, no deployment required** (no Solidity source, ABI, or deployment JSON changes since 10.0.3).

### What's in it (5 PRs since v10.0.3)
- **ACK candidate selection** ranks relays but gates eligibility by chain truth (#1501)
- **Zero-length ACK reply handling** treats empty replies as retryable transport failures (#1507)
- **Public relay watchdog** avoids sibling-core churn on public nodes (#1508)
- **Universal per-wallet transaction dispatcher** serializes EVM sends and approval paths (#1503)
- **Manual release promotion flow** adds version/tag/publish verification plus canary/testnet/mainnet promotion docs/tooling (#1498)

### This PR
- Lockstep version bump of all 20 workspace `package.json` files `10.0.3` -> `10.0.4` (same convention as 10.0.3; internal deps are `workspace:*`).
- `CHANGELOG.md` `[10.0.4]` section, plus the top-level changelog header corrected from DKG V9 to DKG V10.
- Lockfile untouched.

### Verification
- `pnpm release:verify-versions -- --version 10.0.4`
- `git diff --check`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @origintrail-official/dkg-core build`
- `pnpm test:scripts`

### After merge
Follow `RELEASE_PROCESS.md`: comprehensive devnet on `main` -> canary/testnet smoke -> promote to mainnet on smoke pass -> mainnet smoke and validation.
