### PR TITLE
fix(core,docs): /dnsaddr is not direct reachability; canary tags must be signed

### DIFF
--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -78,14 +78,7 @@ Keep the generated devnet report with the release notes. If this gate fails, fix
 
 ## 5) Canary tagging workflow
 
-Create and push the canary/prerelease tag from the devnet-validated `main` commit:
-
-```bash
-git tag -a v10.0.0-canary.1 -m "DKG v10.0.0 canary 1"
-git push origin v10.0.0-canary.1
-```
-
-For signed tags (recommended for production-grade verification):
+Create and push the canary/prerelease tag from the devnet-validated `main` commit. Tags **must be signed** (`git tag -s`): the `release:verify-tag` publish preflight in §6a rejects any tag without a PGP/SSH signature block, so an unsigned `git tag -a` tag cannot be published — it fails the release run at the first step.
 
 ```bash
 git tag -s v10.0.0-canary.1 -m "DKG v10.0.0 canary 1"

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -489,7 +489,17 @@ export function isPublicLikeAddress(addr: string): boolean {
  * is explicitly excluded here.
  */
 export function nodeHasDirectPublicAddress(selfAddrs: readonly string[]): boolean {
-  return selfAddrs.some((a) => !a.includes('/p2p-circuit') && isPublicLikeAddress(a));
+  return selfAddrs.some(
+    (a) =>
+      !a.includes('/p2p-circuit') &&
+      // A /dnsaddr is a POINTER, not a transport: its TXT records may resolve
+      // to circuit-only or private addresses, so announcing one is no proof of
+      // direct dialability — treating it as direct would let a NAT'd node skip
+      // reservation recovery and silently lose relay reachability. Concrete
+      // transports (/ip4, /ip6, /dns4, /dns6 + port) remain valid evidence.
+      !a.startsWith('/dnsaddr/') &&
+      isPublicLikeAddress(a),
+  );
 }
 
 export class DKGNode {

--- a/packages/core/test/relay-public-reachability.test.ts
+++ b/packages/core/test/relay-public-reachability.test.ts
@@ -24,6 +24,19 @@ describe('nodeHasDirectPublicAddress', () => {
     expect(nodeHasDirectPublicAddress([`/dns4/core.example.org/tcp/9090/p2p/${PEER}`])).toBe(true);
   });
 
+  it('false for a /dnsaddr-only self-address (a pointer, not proof of direct dialability)', () => {
+    // /dnsaddr TXT records may resolve to circuit-only or private addrs; a
+    // NAT'd node announcing one must still maintain its relay reservations.
+    expect(nodeHasDirectPublicAddress([`/dnsaddr/core.example.org/p2p/${PEER}`])).toBe(false);
+  });
+
+  it('true when a concrete public transport sits alongside a /dnsaddr', () => {
+    expect(nodeHasDirectPublicAddress([
+      `/dnsaddr/core.example.org/p2p/${PEER}`,
+      `/ip4/${CORE}/tcp/9090/p2p/${PEER}`,
+    ])).toBe(true);
+  });
+
   it('false for a circuit self-address only (reachable ONLY through a relay = NAT\'d)', () => {
     // A /p2p-circuit self-addr is proof of the opposite — this node DOES need
     // its reservation, so the watchdog must keep maintaining it.


### PR DESCRIPTION
Two verified leftovers from post-disposition `otReviewAgent` rounds on the merged 10.0.4 set — both on-main content, independent of the #1516 re-land.

## 1. `/dnsaddr` no longer counts as a direct public self-address (`packages/core`)

`nodeHasDirectPublicAddress` (the #1508 watchdog gate) accepted `/dnsaddr/<public-host>/…` as proof of direct dialability. A `/dnsaddr` is a **pointer** — its TXT records may resolve to circuit-only or private addresses — so a NAT'd node announcing only a `/dnsaddr` would satisfy the reservation gate, never force reservation recovery, and **silently lose relay reachability**.

- Concrete transports (`/ip4`, `/ip6`, `/dns4`, `/dns6`) are unchanged → mainnet cores keep the #1508 churn fix.
- A `/dnsaddr`-only node returns to pre-#1508 behavior (keeps maintaining reservations) — the conservative failure direction.
- 2 new predicate tests; relay + reachability suites 27/27.

## 2. RELEASE_PROCESS.md §5 — canary example contradicted the release preflight

The documented default was unsigned `git tag -a`, but §6a's first mandatory command (`pnpm release:verify-tag`) hard-fails any tag without a PGP/SSH signature block — the documented happy path would have blocked the 10.0.4 release run at its first step. Signed `git tag -s` is now the only documented form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)