### PR TITLE
fix(chain): revalidate the chosen RS wallet's identity on-chain at selection

### DIFF
--- a/devnet/v10-rs-wallet-rotation/automated.test.ts
+++ b/devnet/v10-rs-wallet-rotation/automated.test.ts
@@ -183,6 +183,12 @@ describe('V10 Random Sampling — operational-wallet rotation (Phase 4)', () => 
       if (create.size >= 1 && submit.size >= 1 && senders.size >= 2) break;
     }
 
+    // The window must contain a FULL create→submit cycle — the header's claim.
+    // Without the per-method assertions, two createChallenges from two wallets
+    // would satisfy the rotation check while submitProof went entirely
+    // unobserved (the false-green shape the devnet-suite review flagged).
+    expect(create.size, 'observed NO createChallenge from the node in the window — lengthen DKG_RS_ROT_WINDOW / warp proof periods').toBeGreaterThan(0);
+    expect(submit.size, 'observed NO submitProof from the node in the window — lengthen DKG_RS_ROT_WINDOW / warp proof periods').toBeGreaterThan(0);
     expect(senders.size, 'observed NO RS txs from the node in the window — lengthen DKG_RS_ROT_WINDOW / warp proof periods').toBeGreaterThan(0);
 
     // FAIL-CLOSED (deterministic, the core safety property): every wallet that

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -1760,11 +1760,44 @@ export class EVMChainAdapterBase {
    * removes). Eligibility fails closed to the primary signer (see selectSigner).
    */
   protected async nextRandomSamplingSigner(): Promise<Wallet> {
-    return this.selectSigner({
-      txClass: 'rotatable-free',
-      funding: { kind: 'native-only', nativeFloorWei: this.minPublisherNativeWei },
-      preferIdle: true,
-    });
+    // Bounded loop: every failed revalidation EVICTS the chosen wallet from
+    // the registered set (strictly shrinking pool) and the primary signer
+    // returns unconditionally, so this cannot spin.
+    for (;;) {
+      const chosen = await this.selectSigner({
+        txClass: 'rotatable-free',
+        funding: { kind: 'native-only', nativeFloorWei: this.minPublisherNativeWei },
+        preferIdle: true,
+      });
+      // The primary signer is the identity anchor (registered at profile
+      // creation); if IT stopped resolving, the node is broken at a level
+      // rotation cannot fix — keep existing behavior.
+      if (chosen.address === this.signer.address) return chosen;
+      // Durable close for the OUT-OF-BAND removal race:
+      // `registeredOperationalAddresses` only observes same-process
+      // add/remove, so a wallet removed from THIS identity (and possibly
+      // re-registered to ANOTHER) by a second node instance or a direct admin
+      // tx stays in the set — and an RS tx it signs would act for the OTHER
+      // identity (`RandomSampling` keys off `getIdentityId(msg.sender)`),
+      // silently burning that identity's proof period. Revalidate only the
+      // CHOSEN wallet on-chain (one fresh read per RS selection). FAIL OPEN on
+      // read errors (an RPC blip must not stall proofs); fail CLOSED on a
+      // definitive mismatch: evict + re-select.
+      let onChainId: bigint | null;
+      try {
+        onChainId = await this.refreshIdentityIdForAddress(chosen.address);
+      } catch {
+        onChainId = null;
+      }
+      if (onChainId === null) return chosen;
+      const ourId = await this.getIdentityId().catch(() => 0n);
+      if (ourId === 0n || onChainId === ourId) return chosen;
+      this.registeredOperationalAddresses.delete(chosen.address.toLowerCase());
+      console.warn(
+        `[chain] RS signer ${chosen.address} no longer resolves to this node's identity ` +
+        `(on-chain identityId=${onChainId}, ours=${ourId}) — evicted from RS rotation; re-selecting.`,
+      );
+    }
   }
 
   /**

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -4094,6 +4094,66 @@ describe('createKnowledgeAssets — funding-aware wallet selection', () => {
       expect(chosen.address).toBe(walletA.address);
     });
 
+    it('nextRandomSamplingSigner requests exactly the RS spec (rotatable-free / native-only / preferIdle)', async () => {
+      // Pins the wrapper itself — every other test stubs it or calls
+      // selectSigner directly, so a wrong txClass/funding/preferIdle here
+      // would otherwise only surface on a live devnet.
+      const { a } = makeMultiWalletV10Adapter(makeAllowanceByOwner());
+      const specs: any[] = [];
+      (a as any).selectSigner = async (spec: any) => { specs.push(spec); return (a as any).signer; };
+      await (a as any).nextRandomSamplingSigner();
+      expect(specs).toEqual([{
+        txClass: 'rotatable-free',
+        funding: { kind: 'native-only', nativeFloorWei: 0n },
+        preferIdle: true,
+      }]);
+    });
+
+    it('RS selection revalidates the chosen wallet on-chain: an out-of-band re-registration is evicted', async () => {
+      // Out-of-band removal race: walletB was removed from THIS identity and
+      // re-registered to ANOTHER (identity 99) by a second node instance — the
+      // same-process set never saw it. The selection must detect the mismatch
+      // on the fresh chain read, evict B, and fall back to the primary.
+      const { a, walletA, walletB, nativeByAddr } = makeMultiWalletV10Adapter(makeAllowanceByOwner());
+      registerPool(a);
+      nativeByAddr.set(lc(walletA.address), 0n); // primary gas-empty → B preferred first
+      nativeByAddr.set(lc(walletB.address), ONE);
+      (a as any).getIdentityId = async () => 5n;
+      const refreshed: string[] = [];
+      (a as any).refreshIdentityIdForAddress = async (addr: string) => {
+        refreshed.push(lc(addr));
+        return lc(addr) === lc(walletB.address) ? 99n : 5n;
+      };
+      const chosen = await (a as any).nextRandomSamplingSigner();
+      expect(refreshed).toContain(lc(walletB.address));
+      expect(chosen.address).toBe(walletA.address); // fell back to the primary anchor
+      expect((a as any).registeredOperationalAddresses.has(lc(walletB.address))).toBe(false); // evicted
+    });
+
+    it('RS revalidation FAILS OPEN on a chain-read error (an RPC blip must not stall proofs)', async () => {
+      const { a, walletA, walletB, nativeByAddr } = makeMultiWalletV10Adapter(makeAllowanceByOwner());
+      registerPool(a);
+      nativeByAddr.set(lc(walletA.address), 0n);
+      nativeByAddr.set(lc(walletB.address), ONE);
+      (a as any).getIdentityId = async () => 5n;
+      (a as any).refreshIdentityIdForAddress = async () => { throw new Error('rpc down'); };
+      const chosen = await (a as any).nextRandomSamplingSigner();
+      expect(chosen.address).toBe(walletB.address); // kept despite the failed read
+      expect((a as any).registeredOperationalAddresses.has(lc(walletB.address))).toBe(true);
+    });
+
+    it('RS revalidation keeps a wallet that still resolves to our identity', async () => {
+      const { a, walletA, walletB, nativeByAddr } = makeMultiWalletV10Adapter(makeAllowanceByOwner());
+      registerPool(a);
+      nativeByAddr.set(lc(walletA.address), 0n);
+      nativeByAddr.set(lc(walletB.address), ONE);
+      (a as any).getIdentityId = async () => 5n;
+      (a as any).refreshIdentityIdForAddress = async () => 5n;
+      const chosen = await (a as any).nextRandomSamplingSigner();
+      expect(chosen.address).toBe(walletB.address);
+      expect((a as any).registeredOperationalAddresses.has(lc(walletB.address))).toBe(true);
+    });
+
     it('DKG_DISABLE_IDLE_AWARE_SELECTION ignores preferIdle (read in the constructor)', async () => {
       const prev = process.env.DKG_DISABLE_IDLE_AWARE_SELECTION;
       process.env.DKG_DISABLE_IDLE_AWARE_SELECTION = '1';


### PR DESCRIPTION
Closes the one substantive **post-disposition** `otReviewAgent` finding on #1506 (the bot's final review round landed after the disposition comment and before merge), which is also the code's own tracked follow-up next to `registeredOperationalAddresses`.

## The race

The registered set only observes **same-process** add/remove. A wallet removed from this identity — and possibly re-registered to **another** live identity — by a second node instance or a direct admin tx stayed RS-eligible; an RS tx it signed would act for the *other* identity (`RandomSampling` keys off `getIdentityId(msg.sender)`), succeed on-chain, and silently burn that identity's proof period. The existing `ProfileDoesntExist` self-heal only covers the removed→identity-0 case (revert), not the re-registered→other-identity case (no revert → no eviction).

## The fix

`nextRandomSamplingSigner` revalidates **only the chosen wallet** with a fresh chain read (one read per RS selection, prover-tick cadence):

- **mismatch** → evict from the set + re-select (bounded loop: the pool strictly shrinks; the primary anchor returns unconditionally),
- **read error** → **fail open** (an RPC blip must not stall proofs),
- the primary signer skips revalidation (identity anchor; if *it* moved, rotation can't help).

## Also in this PR (same review round)

- The devnet rotation suite could pass **without ever observing a `submitProof`** (two creates from two wallets satisfied every assertion) — final assertions now require both a `createChallenge` and a `submitProof` in the window.
- The RS wrapper spec (`rotatable-free` / native-only / `preferIdle`) is pinned by a deterministic unit test — previously every test stubbed the wrapper or called `selectSigner` directly, so a wrong spec in the wrapper only surfaced on a live devnet.

## Validation

chain tsc clean; evm-adapter suite **213/213** (4 new tests: eviction, fail-open, still-ours, wrapper spec).

Depends on the dispatcher re-land (#1516) — already merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)