### PR TITLE
fix(metrics): gate node-UI metric store-scans on consumer presence (#1066)

### DIFF
--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -24,6 +24,7 @@ import {
   parseRdfInt,
   shadowContextGraphIdsFromMetricSubscriptionCandidates,
 } from "./metrics-queries.js";
+import { createMetricsPresence } from "./metrics-presence.js";
 import {
   appendFile,
   chmod,
@@ -2345,10 +2346,26 @@ export async function runDaemonInner(
     },
   };
 
+  // Connected node-UI SSE dashboard clients. Declared here (before the metrics
+  // collector) so the presence gate below can consult it; the /api/events
+  // handler further down populates it.
+  const sseClients = new Set<ServerResponse>();
+
+  // Metrics presence gate (#1066 Item 1): the metric COUNT getters are
+  // full-store scans, so the collector skips them when nothing is consuming
+  // metrics — no open dashboard SSE stream and no recent /api/metrics[/history]
+  // read. Bounds those scans to <=1 per tick under load (instead of one per
+  // request) and to zero when idle. Override with DKG_METRICS_ALWAYS_COLLECT=1.
+  const metricsPresence = createMetricsPresence({
+    sseClientCount: () => sseClients.size,
+    alwaysCollect: process.env.DKG_METRICS_ALWAYS_COLLECT === "1",
+  });
+
   const metricsCollector = new MetricsCollector(
     dashDb,
     metricsSource,
     dkgDir(),
+    () => metricsPresence.hasRecentConsumer(),
   );
   metricsCollector.start();
   log("Metrics collector started (30s interval)");
@@ -2678,8 +2695,9 @@ export async function runDaemonInner(
     } catch { /* never crash */ }
   });
 
-  // SSE (Server-Sent Events) broadcast: real-time push to connected UI clients
-  const sseClients = new Set<ServerResponse>();
+  // SSE (Server-Sent Events) broadcast: real-time push to connected UI clients.
+  // `sseClients` is declared earlier (by the metrics collector) so the metrics
+  // presence gate can consult it.
   function sseBroadcast(event: string, payload: Record<string, unknown>) {
     const data = JSON.stringify(payload);
     const msg = `event: ${event}\ndata: ${data}\n\n`;
@@ -3123,6 +3141,16 @@ export async function runDaemonInner(
   const server = createServer(async (req, res) => {
     try {
       const reqUrl = new URL(req.url ?? "/", `http://${req.headers.host}`);
+
+      // Metrics presence (#1066 Item 1): a read of the metric-serving routes
+      // counts as an active consumer, keeping the collector's store scans warm
+      // for Grafana / health probes as well as the node-UI dashboard.
+      if (
+        reqUrl.pathname === "/api/metrics" ||
+        reqUrl.pathname === "/api/metrics/history"
+      ) {
+        metricsPresence.mark();
+      }
 
       // Resolve CORS origin once per request (request-scoped, not global)
       const reqCorsOrigin = resolveCorsOrigin(req, corsAllowed) ?? null;

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -3142,16 +3142,6 @@ export async function runDaemonInner(
     try {
       const reqUrl = new URL(req.url ?? "/", `http://${req.headers.host}`);
 
-      // Metrics presence (#1066 Item 1): a read of the metric-serving routes
-      // counts as an active consumer, keeping the collector's store scans warm
-      // for Grafana / health probes as well as the node-UI dashboard.
-      if (
-        reqUrl.pathname === "/api/metrics" ||
-        reqUrl.pathname === "/api/metrics/history"
-      ) {
-        metricsPresence.mark();
-      }
-
       // Resolve CORS origin once per request (request-scoped, not global)
       const reqCorsOrigin = resolveCorsOrigin(req, corsAllowed) ?? null;
       (res as any).__corsOrigin = reqCorsOrigin;
@@ -3316,7 +3306,13 @@ export async function runDaemonInner(
       // only path the daemon uses. So role-based gating here matches
       // the actual runtime behaviour.
       const relayStatsProvider = role === 'core' ? () => agent.node.getRelayStats() : undefined;
-      const handled = await handleNodeUIRequest(req, res, reqUrl, dashDb, nodeUiStaticDir, undefined, metricsCollector, authEnabled ? firstToken : undefined, memoryManager, llmSettings, telemetrySettings, resolveCorsOrigin(req, corsAllowed), relayStatsProvider);
+      // Metrics presence (#1066 Item 1): a served read of /api/metrics[/history]
+      // marks a consumer, keeping the collector's store scans warm for Grafana /
+      // health probes as well as the dashboard. Marking happens INSIDE the route
+      // handler (below) so it only fires after rate-limit, admission, and auth
+      // have accepted the request — a rejected/unauthenticated request cannot
+      // open the store-metrics gate.
+      const handled = await handleNodeUIRequest(req, res, reqUrl, dashDb, nodeUiStaticDir, undefined, metricsCollector, authEnabled ? firstToken : undefined, memoryManager, llmSettings, telemetrySettings, resolveCorsOrigin(req, corsAllowed), relayStatsProvider, () => metricsPresence.mark());
       if (handled) return;
 
       await handleRequest(

--- a/packages/cli/src/daemon/metrics-presence.ts
+++ b/packages/cli/src/daemon/metrics-presence.ts
@@ -1,0 +1,61 @@
+/**
+ * Metrics presence gate (#1066 Item 1 / R6-B).
+ *
+ * The node-UI metric getters include full-store SPARQL COUNT scans. Running
+ * them on the periodic collector tick while nothing is consuming metrics wastes
+ * CPU — and on a saturated store those scans land on already-pegged cores. This
+ * helper answers "is anything currently watching metrics?" so the collector can
+ * skip the store scans when the answer is no.
+ *
+ * A consumer is considered present when either:
+ *   - a node-UI dashboard is connected (its `/api/events` SSE stream is open), or
+ *   - the metric-serving HTTP routes were read recently (covers Grafana / node
+ *     health probes that poll `/api/metrics[/history]` without opening the UI).
+ *
+ * Pure and side-effect-free apart from the internal timestamp, with an
+ * injectable clock so it can be unit-tested without real time.
+ */
+export interface MetricsPresenceOptions {
+  /** Current count of connected node-UI SSE dashboard clients. */
+  sseClientCount: () => number;
+  /**
+   * How long after the last metric-route read a consumer still counts as
+   * present. Defaults to 90s (3× the 30s collector tick) so a steady poller
+   * stays "present" across ticks without flapping.
+   */
+  windowMs?: number;
+  /**
+   * Kill-switch: when true the gate always reports a consumer, restoring the
+   * pre-gate "always collect" behaviour (wired to `DKG_METRICS_ALWAYS_COLLECT`).
+   */
+  alwaysCollect?: boolean;
+  /** Injectable clock (defaults to `Date.now`); used for deterministic tests. */
+  now?: () => number;
+}
+
+export interface MetricsPresence {
+  /** Record that a metric consumer was just seen (call from the metric routes). */
+  mark(): void;
+  /** True when a metric consumer is currently present. */
+  hasRecentConsumer(): boolean;
+}
+
+export const DEFAULT_METRICS_PRESENCE_WINDOW_MS = 90_000;
+
+export function createMetricsPresence(
+  opts: MetricsPresenceOptions,
+): MetricsPresence {
+  const windowMs = opts.windowMs ?? DEFAULT_METRICS_PRESENCE_WINDOW_MS;
+  const now = opts.now ?? Date.now;
+  let lastConsumerAt = Number.NEGATIVE_INFINITY;
+  return {
+    mark() {
+      lastConsumerAt = now();
+    },
+    hasRecentConsumer() {
+      if (opts.alwaysCollect === true) return true;
+      if (opts.sseClientCount() > 0) return true;
+      return now() - lastConsumerAt < windowMs;
+    },
+  };
+}

--- a/packages/cli/test/metrics-presence.test.ts
+++ b/packages/cli/test/metrics-presence.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createMetricsPresence,
+  DEFAULT_METRICS_PRESENCE_WINDOW_MS,
+} from '../src/daemon/metrics-presence.js';
+
+describe('createMetricsPresence (#1066 Item 1)', () => {
+  it('reports no consumer before any signal', () => {
+    const p = createMetricsPresence({ sseClientCount: () => 0, now: () => 1000 });
+    expect(p.hasRecentConsumer()).toBe(false);
+  });
+
+  it('reports a consumer while an SSE dashboard client is connected', () => {
+    let clients = 0;
+    const p = createMetricsPresence({ sseClientCount: () => clients, now: () => 1000 });
+    expect(p.hasRecentConsumer()).toBe(false);
+    clients = 1;
+    expect(p.hasRecentConsumer()).toBe(true);
+  });
+
+  it('reports a consumer for windowMs after a mark(), then expires', () => {
+    let t = 10_000;
+    const p = createMetricsPresence({ sseClientCount: () => 0, windowMs: 90_000, now: () => t });
+    p.mark(); // marked at t=10_000
+    expect(p.hasRecentConsumer()).toBe(true);
+    t = 10_000 + 89_999; // just inside the window
+    expect(p.hasRecentConsumer()).toBe(true);
+    t = 10_000 + 90_000; // window edge → expired
+    expect(p.hasRecentConsumer()).toBe(false);
+    t = 10_000 + 200_000; // well past
+    expect(p.hasRecentConsumer()).toBe(false);
+  });
+
+  it('a fresh mark() re-opens the window', () => {
+    let t = 0;
+    const p = createMetricsPresence({ sseClientCount: () => 0, windowMs: 1000, now: () => t });
+    p.mark();
+    t = 2000;
+    expect(p.hasRecentConsumer()).toBe(false);
+    p.mark(); // re-mark at t=2000
+    t = 2500;
+    expect(p.hasRecentConsumer()).toBe(true);
+  });
+
+  it('alwaysCollect overrides everything (kill-switch)', () => {
+    const p = createMetricsPresence({
+      sseClientCount: () => 0,
+      alwaysCollect: true,
+      now: () => 1_000_000,
+    });
+    // no SSE client, never marked — still present.
+    expect(p.hasRecentConsumer()).toBe(true);
+  });
+
+  it('defaults the window to 90s (3× the 30s tick)', () => {
+    expect(DEFAULT_METRICS_PRESENCE_WINDOW_MS).toBe(90_000);
+    let t = 0;
+    const p = createMetricsPresence({ sseClientCount: () => 0, now: () => t });
+    p.mark();
+    t = 89_999;
+    expect(p.hasRecentConsumer()).toBe(true);
+    t = 90_000;
+    expect(p.hasRecentConsumer()).toBe(false);
+  });
+});

--- a/packages/cli/vitest.unit.config.ts
+++ b/packages/cli/vitest.unit.config.ts
@@ -53,6 +53,8 @@ export default defineConfig({
           'test/skill-endpoint.test.ts',
           // R6-B — metric COUNT getter TTL memo. Pure logic, no hardhat.
           'test/metrics-queries.test.ts',
+          // #1066 Item 1 — metrics presence gate. Pure logic (injected clock).
+          'test/metrics-presence.test.ts',
           'test/rpc-usage-log.test.ts',
           // RFC 120 / plan PR 1 + 2 — Blazegraph support. Pure logic
           // (mocked fetch + in-memory config); cheap to keep in the

--- a/packages/node-ui/src/api.ts
+++ b/packages/node-ui/src/api.ts
@@ -98,6 +98,13 @@ export async function handleNodeUIRequest(
   telemetrySettings?: TelemetrySettingsCallbacks,
   corsOrigin?: string | null,
   relayStatsProvider?: RelayStatsProvider,
+  /**
+   * Called when a metric-serving route (/api/metrics[/history]) is actually
+   * served here — i.e. after the daemon's rate-limit/admission/auth gates have
+   * accepted the request. Lets the metrics collector treat the caller as a live
+   * consumer without the daemon duplicating route knowledge. (#1066 Item 1)
+   */
+  markMetricsConsumer?: () => void,
 ): Promise<boolean> {
   (res as any).__corsOrigin = corsOrigin ?? null;
   const path = url.pathname;
@@ -105,6 +112,7 @@ export async function handleNodeUIRequest(
   // --- Metrics ---
 
   if (req.method === 'GET' && path === '/api/metrics') {
+    markMetricsConsumer?.();
     // Serve the latest tick-written snapshot rather than live-collecting.
     // A live collect() re-runs the full-store COUNT scans on every request, so
     // an external poller (Grafana / health probe) could hammer a saturated
@@ -125,6 +133,7 @@ export async function handleNodeUIRequest(
   }
 
   if (req.method === 'GET' && path === '/api/metrics/history') {
+    markMetricsConsumer?.();
     const from = parseInt(url.searchParams.get('from') ?? '0', 10) || (Date.now() - 86_400_000);
     const to = parseInt(url.searchParams.get('to') ?? '0', 10) || Date.now();
     const maxPoints = parseInt(url.searchParams.get('maxPoints') ?? '500', 10);

--- a/packages/node-ui/src/api.ts
+++ b/packages/node-ui/src/api.ts
@@ -105,17 +105,23 @@ export async function handleNodeUIRequest(
   // --- Metrics ---
 
   if (req.method === 'GET' && path === '/api/metrics') {
+    // Serve the latest tick-written snapshot rather than live-collecting.
+    // A live collect() re-runs the full-store COUNT scans on every request, so
+    // an external poller (Grafana / health probe) could hammer a saturated
+    // store. The periodic collector already refreshes the snapshot (effective
+    // 30s TTL) and a store outage still surfaces as null columns rather than
+    // being masked. (#1066 Item 1)
+    const snap = db.getLatestSnapshot();
+    if (snap) return json(res, 200, snap);
+    // Cold start only: no snapshot yet (before the first tick). Fall back to a
+    // single live collect so the first request isn't empty; steady state never
+    // reaches here, so external pollers never trigger a per-request scan.
     if (metricsCollector) {
       try {
-        const live = await metricsCollector.collect();
-        return json(res, 200, live);
-      } catch {
-        const snap = db.getLatestSnapshot();
-        return json(res, 200, snap ?? {});
-      }
+        return json(res, 200, await metricsCollector.collect());
+      } catch { /* fall through to empty */ }
     }
-    const snap = db.getLatestSnapshot();
-    return json(res, 200, snap ?? {});
+    return json(res, 200, {});
   }
 
   if (req.method === 'GET' && path === '/api/metrics/history') {

--- a/packages/node-ui/src/metrics-collector.ts
+++ b/packages/node-ui/src/metrics-collector.ts
@@ -78,6 +78,12 @@ export class MetricsCollector {
     private readonly db: DashboardDB,
     private readonly source: MetricsSource,
     private readonly dataDir?: string,
+    /**
+     * Gate for the expensive store-scan getters (#1066 Item 1). When it returns
+     * false the tick skips the full-store COUNT scans and leaves those columns
+     * null. Defaults to always-collect so existing callers/tests are unchanged.
+     */
+    private readonly shouldCollectStoreMetrics: () => boolean = () => true,
   ) {}
 
   start(): void {
@@ -148,12 +154,20 @@ export class MetricsCollector {
     let tentativeKCs: number | null = null;
     let contextGraphCount: number | null = null;
 
-    try { totalTriples = await this.source.getTotalTriples(); } catch { /* ignore */ }
-    try { totalKCs = await this.source.getTotalKCs(); } catch { /* ignore */ }
-    try { totalKAs = await this.source.getTotalKAs(); } catch { /* ignore */ }
-    try { confirmedKCs = await this.source.getConfirmedKCs(); } catch { /* ignore */ }
-    try { tentativeKCs = await this.source.getTentativeKCs(); } catch { /* ignore */ }
-    try { contextGraphCount = await this.source.getContextGraphCount(); } catch { /* ignore */ }
+    // These six getters are full-store SPARQL scans (COUNT / COUNT(DISTINCT)
+    // across every graph, plus the context-graph inventory) — the expensive
+    // part of a tick. Skip them when nothing is consuming metrics, leaving the
+    // columns null (already nullable; charts render the gap). The cheap
+    // system/network metrics above always collect, so a CPU peg is still
+    // recorded even while no dashboard is open. (#1066 Item 1)
+    if (this.shouldCollectStoreMetrics()) {
+      try { totalTriples = await this.source.getTotalTriples(); } catch { /* ignore */ }
+      try { totalKCs = await this.source.getTotalKCs(); } catch { /* ignore */ }
+      try { totalKAs = await this.source.getTotalKAs(); } catch { /* ignore */ }
+      try { confirmedKCs = await this.source.getConfirmedKCs(); } catch { /* ignore */ }
+      try { tentativeKCs = await this.source.getTentativeKCs(); } catch { /* ignore */ }
+      try { contextGraphCount = await this.source.getContextGraphCount(); } catch { /* ignore */ }
+    }
 
     let relayCapacity: number | null = null;
     let relayReservationCount: number | null = null;

--- a/packages/node-ui/test/api-routes.test.ts
+++ b/packages/node-ui/test/api-routes.test.ts
@@ -596,6 +596,46 @@ describe('handleNodeUIRequest CORS origin handling', () => {
   });
 });
 
+describe('handleNodeUIRequest /api/metrics snapshot-first behaviour (#1066 Item 1)', () => {
+  it('serves the latest snapshot without live-collecting when a snapshot exists', async () => {
+    let collectCalls = 0;
+    const fakeDb = {
+      getMetrics: () => [], getErrorHotspots: () => [],
+      getLatestSnapshot: () => ({ ts: 123, total_triples: 42, peer_count: 3 }),
+    } as any;
+    const fakeCollector = { collect: async () => { collectCalls++; return { ts: 999 }; } } as any;
+    harness.setArgs([
+      fakeDb, '.', undefined, fakeCollector, undefined, undefined, undefined, undefined, undefined,
+    ] as any);
+
+    const res = await fetch(`${baseUrl}/api/metrics`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.total_triples).toBe(42);
+    expect(body.ts).toBe(123);
+    // No per-request full-store scan — the periodic collector is the only scanner.
+    expect(collectCalls).toBe(0);
+  });
+
+  it('cold start: falls back to a single live collect when no snapshot exists yet', async () => {
+    let collectCalls = 0;
+    const fakeDb = {
+      getMetrics: () => [], getErrorHotspots: () => [],
+      getLatestSnapshot: () => undefined,
+    } as any;
+    const fakeCollector = { collect: async () => { collectCalls++; return { ts: 999, total_triples: 7 }; } } as any;
+    harness.setArgs([
+      fakeDb, '.', undefined, fakeCollector, undefined, undefined, undefined, undefined, undefined,
+    ] as any);
+
+    const res = await fetch(`${baseUrl}/api/metrics`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.total_triples).toBe(7);
+    expect(collectCalls).toBe(1);
+  });
+});
+
 describe('handleNodeUIRequest replication routes (Phase F)', () => {
   let db: DashboardDB;
   let dir: string;

--- a/packages/node-ui/test/api-routes.test.ts
+++ b/packages/node-ui/test/api-routes.test.ts
@@ -636,6 +636,55 @@ describe('handleNodeUIRequest /api/metrics snapshot-first behaviour (#1066 Item 
   });
 });
 
+describe('handleNodeUIRequest metrics-consumer presence wiring (#1066 Item 1)', () => {
+  // markMetricsConsumer is the 11th positional arg (after relayStatsProvider).
+  // This proves the runtime wiring: a served metric route marks the presence
+  // object the collector consults; other routes do not. Because the daemon
+  // calls handleNodeUIRequest only after rate-limit/admission/auth accept the
+  // request, marking here is inherently post-auth (a rejected request never
+  // reaches this handler, so it cannot open the store-metrics gate).
+  const fakeDb = () => ({
+    getMetrics: () => [], getErrorHotspots: () => [],
+    getLatestSnapshot: () => ({ ts: 1, total_triples: 1 }),
+    getSnapshotHistory: () => [],
+  } as any);
+
+  it('GET /api/metrics marks a metrics consumer', async () => {
+    let marks = 0;
+    harness.setArgs([
+      fakeDb(), '.', undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined,
+      () => { marks++; },
+    ] as any);
+    const res = await fetch(`${baseUrl}/api/metrics`);
+    expect(res.status).toBe(200);
+    expect(marks).toBe(1);
+  });
+
+  it('GET /api/metrics/history marks a metrics consumer', async () => {
+    let marks = 0;
+    harness.setArgs([
+      fakeDb(), '.', undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined,
+      () => { marks++; },
+    ] as any);
+    const res = await fetch(`${baseUrl}/api/metrics/history`);
+    expect(res.status).toBe(200);
+    expect(marks).toBe(1);
+  });
+
+  it('a non-metrics route does NOT mark a metrics consumer', async () => {
+    let marks = 0;
+    harness.setArgs([
+      fakeDb(), '.', undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined,
+      () => { marks++; },
+    ] as any);
+    // /api/relay/stats is handled here (404 without a relay provider) but is
+    // not a metric route, so it must not open the gate.
+    const res = await fetch(`${baseUrl}/api/relay/stats`);
+    expect(res.status).toBe(404);
+    expect(marks).toBe(0);
+  });
+});
+
 describe('handleNodeUIRequest replication routes (Phase F)', () => {
   let db: DashboardDB;
   let dir: string;

--- a/packages/node-ui/test/metrics-collector.test.ts
+++ b/packages/node-ui/test/metrics-collector.test.ts
@@ -271,3 +271,101 @@ describe('MetricsCollector', () => {
     });
   });
 });
+
+// ─── #1066 Item 1: store-metrics presence gate ──────────────────────
+//
+// The six store getters (total triples + KC/KA/confirmed/tentative +
+// context-graph count) are full-store SPARQL scans. When nothing is
+// consuming metrics the collector skips them, leaving those columns null,
+// while the cheap system/network metrics keep flowing.
+describe('MetricsCollector store-metrics presence gate', () => {
+  function countingSource() {
+    const calls = {
+      getContextGraphCount: 0, getTotalTriples: 0, getTotalKCs: 0,
+      getTotalKAs: 0, getConfirmedKCs: 0, getTentativeKCs: 0,
+      getStoreBytes: 0, getPeerCount: 0,
+    };
+    const source: MetricsSource = {
+      getPeerCount: () => { calls.getPeerCount++; return 5; },
+      getDirectPeerCount: () => 3,
+      getRelayedPeerCount: () => 2,
+      getMeshPeerCount: () => 4,
+      getContextGraphCount: async () => { calls.getContextGraphCount++; return 2; },
+      getTotalTriples: async () => { calls.getTotalTriples++; return 1000; },
+      getTotalKCs: async () => { calls.getTotalKCs++; return 15; },
+      getTotalKAs: async () => { calls.getTotalKAs++; return 30; },
+      getConfirmedKCs: async () => { calls.getConfirmedKCs++; return 12; },
+      getTentativeKCs: async () => { calls.getTentativeKCs++; return 3; },
+      getStoreBytes: async () => { calls.getStoreBytes++; return 65536; },
+      getRpcLatencyMs: async () => 25,
+      isRpcHealthy: async () => true,
+    };
+    return { source, calls };
+  }
+
+  it('closed gate: skips the six store scans and nulls their columns; cheap metrics still collect', async () => {
+    const { source, calls } = countingSource();
+    const collector = new MetricsCollector(db, source, dir, () => false);
+    const snap = await collector.collect();
+
+    // None of the full-store scans ran.
+    expect(calls.getTotalTriples).toBe(0);
+    expect(calls.getTotalKCs).toBe(0);
+    expect(calls.getTotalKAs).toBe(0);
+    expect(calls.getConfirmedKCs).toBe(0);
+    expect(calls.getTentativeKCs).toBe(0);
+    expect(calls.getContextGraphCount).toBe(0);
+
+    // Their columns are null.
+    expect(snap.total_triples).toBeNull();
+    expect(snap.total_kcs).toBeNull();
+    expect(snap.total_kas).toBeNull();
+    expect(snap.confirmed_kcs).toBeNull();
+    expect(snap.tentative_kcs).toBeNull();
+    expect(snap.contextGraph_count).toBeNull();
+
+    // Cheap system/network metrics still collected (a CPU peg is still
+    // recorded even with no dashboard open). getStoreBytes is a cheap stat,
+    // not a SPARQL scan, so it is NOT gated.
+    expect(calls.getPeerCount).toBeGreaterThan(0);
+    expect(snap.peer_count).toBe(5);
+    expect(snap.mem_used_bytes).toBeGreaterThan(0);
+    expect(calls.getStoreBytes).toBe(1);
+    expect(snap.store_bytes).toBe(65536);
+  });
+
+  it('open gate: runs the store getters', async () => {
+    const { source, calls } = countingSource();
+    const collector = new MetricsCollector(db, source, dir, () => true);
+    const snap = await collector.collect();
+
+    expect(calls.getTotalTriples).toBe(1);
+    expect(calls.getContextGraphCount).toBe(1);
+    expect(snap.total_triples).toBe(1000);
+    expect(snap.contextGraph_count).toBe(2);
+  });
+
+  it('no gate supplied: collects store metrics by default (back-compat)', async () => {
+    const { source, calls } = countingSource();
+    const collector = new MetricsCollector(db, source, dir);
+    const snap = await collector.collect();
+
+    expect(calls.getTotalTriples).toBe(1);
+    expect(snap.total_triples).toBe(1000);
+  });
+
+  it('re-evaluates the gate every tick (idle → active resumes store metrics)', async () => {
+    const { source, calls } = countingSource();
+    let watching = false;
+    const collector = new MetricsCollector(db, source, dir, () => watching);
+
+    const idle = await collector.collect();
+    expect(idle.total_triples).toBeNull();
+    expect(calls.getTotalTriples).toBe(0);
+
+    watching = true;
+    const active = await collector.collect();
+    expect(active.total_triples).toBe(1000);
+    expect(calls.getTotalTriples).toBe(1);
+  });
+});


### PR DESCRIPTION
## Problem

The node-UI metric collector runs full-store SPARQL `COUNT` scans (`getTotalTriples` + KC/KA/confirmed/tentative) on a fixed **30 s tick regardless of whether anyone is watching**, and — the part the issue text missed — **`GET /api/metrics` re-ran those scans *live on every request*** (`api.ts`). Under load these land on already-saturated oxigraph cores, and an external poller (Grafana / node health probe) hitting `/api/metrics` triggered **one full-store scan per request** (unbounded). Implements **#1066 Item 1 (R6-B)**.

## Changes

**A — gate the tick's store scans (surgical)** · `packages/node-ui/src/metrics-collector.ts`
Optional `shouldCollectStoreMetrics` gate (defaults to always-on, so existing callers/tests are unchanged). The six full-store getters are skipped when the gate is closed, leaving those columns `null`. Cheap system/network metrics (CPU/mem/peers) still collect every tick, so a CPU peg is still recorded even with no dashboard open.

**B — `/api/metrics` serves the latest snapshot** · `packages/node-ui/src/api.ts`
Returns `getLatestSnapshot()` instead of live-collecting (cold-start fallback to a single live collect before the first tick writes a snapshot). Removes the per-request scan surface; effective TTL is the 30 s tick. A store outage still surfaces as `null` columns rather than being masked.

**C — presence signal** · new `packages/cli/src/daemon/metrics-presence.ts` + `lifecycle.ts`
A consumer is present when a node-UI dashboard SSE stream is open **or** the metric routes were read recently (covers Grafana / health probes). Pure and clock-injectable for tests. Wiring moves the `sseClients` declaration above the collector (avoids a TDZ) and calls `mark()` on `/api/metrics[/history]`. Kill-switch `DKG_METRICS_ALWAYS_COLLECT=1` restores always-collect.

## Net behavior

| State | Cheap metrics | Store COUNT scans |
|---|---|---|
| Idle, nothing watching | every 30 s | **0** |
| Dashboard open (SSE) | every 30 s | ≤1 / 30 s |
| Grafana/health probe polling `/api/metrics` | every 30 s | **≤1 / 30 s** (was: 1 per request) |
| `DKG_METRICS_ALWAYS_COLLECT=1` | every 30 s | ≤1 / 30 s (gate disabled) |

## Scope

Item 1 only. The scan-free `listGraphs` index (Item 5) already shipped in 10.0.4 (`GraphSetIndexStore`), and the CG-count getter already reads from it. The #1221 generic-UPDATE index-refresh scan is a separate storage/sync concern and is out of scope.

## Testing

- New `metrics-presence.test.ts` (6) — window expiry, SSE-open short-circuit, kill-switch, clock injection.
- `metrics-collector.test.ts` +4 gate cases (17/17): closed gate skips the six getters and nulls their columns while cheap metrics still collect; open/default gate collects; per-tick re-evaluation.
- `api-routes.test.ts` +2 snapshot cases (33/33): serves snapshot without calling `collect()`; cold-start fallback.
- `node scripts/build.mjs` → exit 0; `tsc --noEmit` on node-ui + cli → exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
