### PR TITLE
fix(sync): oversize-literal ingest guard + tombstones — end the poison retry loop

### DIFF
--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -211,6 +211,8 @@ import { waitForPeerProtocol } from './p2p/protocol-readiness.js';
 import { orderCatchupPeers } from './p2p/peer-selection.js';
 import { reconcileWarmCoreConnections, type WarmCoreAgent } from './p2p/warm-core-connections.js';
 import { fetchSyncPages, type SyncPageResult } from './sync/requester/page-fetch.js';
+import { insertWithOversizeGuard } from './sync/oversize-filter.js';
+import { OversizeTombstoneLog } from './sync/oversize-tombstones.js';
 import { getSyncCheckpointKey, MemorySyncCheckpointStore } from './sync/checkpoint/state.js';
 import { runDurableSync } from './sync/requester/durable-sync.js';
 import { runSharedMemorySync } from './sync/requester/shared-memory-sync.js';
@@ -949,11 +951,40 @@ export class DKGAgentBase {
     this.listContextGraphsInFlight.clear();
   }
 
+  /**
+   * Oversize tombstone log — lazily constructed so every sync-ingest seam
+   * shares one bounded ring + JSONL file (OT-RFC-56 §4.2). See
+   * sync/oversize-filter.ts for the guard this records for.
+   */
+  private oversizeTombstoneLogInstance?: OversizeTombstoneLog;
+  protected get oversizeTombstoneLog(): OversizeTombstoneLog {
+    if (!this.oversizeTombstoneLogInstance) {
+      this.oversizeTombstoneLogInstance = new OversizeTombstoneLog({
+        dataDir: this.config.dataDir,
+        logWarn: (message) => this.log.warn(createOperationContext('sync'), message),
+      });
+    }
+    return this.oversizeTombstoneLogInstance;
+  }
+
+  /**
+   * Sync-ingest store insert (durable sync + registry meta pulls). Guarded by
+   * the oversize filter (OT-RFC-56): quads whose literal exceeds the protocol
+   * size invariant are dropped + tombstoned BEFORE the insert, so the sync
+   * offset cursor advances past pages containing them instead of the store
+   * throwing and the page being re-fetched from every peer forever (the
+   * 2026-07-08 mainnet poison-literal retry storm).
+   */
   protected async insertSyncedQuadsAndInvalidateListCache(quads: Quad[]): Promise<void> {
-    await this.store.insert(quads);
-    if (quads.length > 0) {
+    const inserted = await insertWithOversizeGuard(
+      (kept) => this.store.insert(kept),
+      quads,
+      { recordDrops: (drops, seam) => this.oversizeTombstoneLog.record(drops, seam) },
+      'durable-sync',
+    );
+    if (inserted.length > 0) {
       this.invalidateListContextGraphsCache();
-      this.contextGraphMetaProjection.markDirtyFromQuads(quads);
+      this.contextGraphMetaProjection.markDirtyFromQuads(inserted);
     }
   }
   protected readonly gossipRegistered = new Set<string>();

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -207,6 +207,7 @@ import { waitForPeerProtocol } from './p2p/protocol-readiness.js';
 import { orderCatchupPeers } from './p2p/peer-selection.js';
 import { reconcileWarmCoreConnections, type WarmCoreAgent } from './p2p/warm-core-connections.js';
 import { fetchSyncPages, type SyncPageResult } from './sync/requester/page-fetch.js';
+import { insertWithOversizeGuard } from './sync/oversize-filter.js';
 import { getSyncCheckpointKey } from './sync/checkpoint/state.js';
 import { runDurableSync } from './sync/requester/durable-sync.js';
 import { runSharedMemorySync, sharedMemoryOwnershipKeyFromGraph } from './sync/requester/shared-memory-sync.js';
@@ -3418,8 +3419,16 @@ export class LifecycleSyncMethods extends DKGAgentBase {
             await graphManager.ensureContextGraph(contextGraphId);
           },
           storeInsert: async (quads) => {
-            await this.store.insert(quads);
-            this.contextGraphMetaProjection.markDirtyFromQuads(quads);
+            // Oversize guard (OT-RFC-56): drop+tombstone protocol-violating
+            // literals BEFORE insert so the SWM page cursor advances instead
+            // of the store throwing and the page re-fetching forever.
+            const inserted = await insertWithOversizeGuard(
+              (kept) => this.store.insert(kept),
+              quads,
+              { recordDrops: (drops, seam) => this.oversizeTombstoneLog.record(drops, seam) },
+              'swm-sync',
+            );
+            this.contextGraphMetaProjection.markDirtyFromQuads(inserted);
           },
           publicSnapshotStore: this.publicSnapshotStore,
           deleteCheckpoint: (key) => this.syncCheckpoints.delete(key),
@@ -3513,10 +3522,16 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       // insertSyncedQuadsAndInvalidateListCache); deletes pass through to the store.
       store: {
         insert: async (quads) => {
-          await this.store.insert(quads);
-          if (quads.length > 0) {
+          // Oversize guard (OT-RFC-56) — recovered rows are peer data too.
+          const inserted = await insertWithOversizeGuard(
+            (kept) => this.store.insert(kept),
+            quads,
+            { recordDrops: (drops, seam) => this.oversizeTombstoneLog.record(drops, seam) },
+            'swm-recovery',
+          );
+          if (inserted.length > 0) {
             this.invalidateListContextGraphsCache();
-            this.contextGraphMetaProjection.markDirtyFromQuads(quads);
+            this.contextGraphMetaProjection.markDirtyFromQuads(inserted);
           }
         },
         deleteByPattern: (pattern) => this.store.deleteByPattern(pattern),

--- a/packages/agent/src/sync/error-tags.ts
+++ b/packages/agent/src/sync/error-tags.ts
@@ -1,3 +1,5 @@
+import { isOversizedRdfLiteralError } from '@origintrail-official/dkg-core';
+
 type SyncErrorTag = 'syncPeerResponded' | 'syncTransportFailure';
 
 function markSyncError(error: unknown, tag: SyncErrorTag): void {
@@ -34,6 +36,20 @@ export function didSyncPeerRespond(error: unknown): boolean {
 
 export function isSyncTransportFailure(error: unknown): boolean {
   return Boolean(error && typeof error === 'object' && (error as { syncTransportFailure?: boolean }).syncTransportFailure);
+}
+
+/**
+ * PERMANENT ingest rejection (OT-RFC-56): retrying can never succeed — the
+ * content itself violates a protocol invariant (today: the RDF-literal size
+ * limit; `OversizedRdfLiteralError` from the store adapters). The sync
+ * seams' oversize guard (sync/oversize-filter.ts) should make this
+ * unreachable on the ingest paths; when a runner's catch still sees one, a
+ * seam was missed — log loudly, never count it toward peer backoff, and
+ * expect the same page to fail identically on every retry until the seam is
+ * fixed.
+ */
+export function isSyncPermanentRejection(error: unknown): boolean {
+  return isOversizedRdfLiteralError(error);
 }
 
 export function isSyncBackoffWorthyError(error: unknown): boolean {

--- a/packages/agent/src/sync/oversize-filter.ts
+++ b/packages/agent/src/sync/oversize-filter.ts
@@ -1,0 +1,196 @@
+/**
+ * Sync-ingest oversize-literal guard (OT-RFC-56 §4.1/§4.2 — the 2026-07-08
+ * mainnet poison-literal incident).
+ *
+ * The protocol invariant: no replicated RDF literal may exceed
+ * `DKG_RDF_LITERAL_SAFE_MUTF8_BYTES` (60,000 Java-MUTF-8 bytes). Blazegraph
+ * physically cannot store literals above `JAVA_WRITE_UTF_MAX_BYTES` (65,535):
+ * its adapter throws `OversizedRdfLiteralError` on insert. Before this guard,
+ * a synced page containing one such literal threw inside the per-CG sync
+ * loop BEFORE the offset checkpoint advanced, so the identical page was
+ * re-fetched from every peer forever — the observed retry storm. Oxigraph
+ * has no such limit, so oxigraph-backed nodes stored and re-served the same
+ * quads — a permanent split-brain.
+ *
+ * The fix is FILTER-BEFORE-INSERT at the sync storeInsert seams: conforming
+ * quads store normally, oversized quads are dropped and tombstoned, and —
+ * because sync completeness is an offset page-cursor, not quad-set
+ * reconciliation — the phase then completes normally and the cursor advances
+ * past the page. A deliberate refusal terminates the conversation instead of
+ * looping.
+ *
+ * Graph-class semantics (why not one uniform drop):
+ *  - `_shared_memory` graphs are EXEMPT from the pre-filter: large SWM
+ *    literals are legitimate there — `SharedMemoryLiteralBlobStore` (default
+ *    on local Oxigraph stores) externalizes literal terms above 65,536 bytes
+ *    into content-addressed blobs on insert and re-hydrates them on query, so
+ *    the wire legitimately carries raw large SWM text between blob-capable
+ *    nodes. On a Blazegraph node (no blob wrapper) such an insert still
+ *    throws; the guard's BACKSTOP (below) converts that throw into
+ *    tombstone-and-continue instead of a loop. Serving refs instead of
+ *    hydrated text network-wide is the durable fix — tracked in OT-RFC-56.
+ *  - `_verifiable_memory` graphs must never be PARTIALLY stored (their
+ *    content is Merkle-committed; a missing quad breaks proof verification),
+ *    so an oversized quad there drops that graph's ENTIRE batch contribution
+ *    (quarantine, RFC-56 §4.3) rather than the single quad.
+ *  - `externalLiteralRef`-typed terms always pass (they are ~100-byte
+ *    placeholders by construction).
+ */
+
+import {
+  DKG_RDF_LITERAL_SAFE_MUTF8_BYTES,
+  JAVA_WRITE_UTF_MAX_BYTES,
+  rdfLiteralTermMutf8ByteLength,
+  isOversizedRdfLiteralError,
+} from '@origintrail-official/dkg-core';
+import type { Quad } from '@origintrail-official/dkg-storage';
+import { EXTERNAL_LITERAL_REF_DATATYPE } from '@origintrail-official/dkg-storage';
+
+const SHARED_MEMORY_INFIX = '/_shared_memory';
+const VERIFIABLE_MEMORY_INFIX = '/_verifiable_memory';
+
+export type OversizeDropKind = 'oversize' | 'vm-quarantine' | 'store-reject';
+
+export interface OversizeDrop {
+  quad: Quad;
+  bytes: number;
+  kind: OversizeDropKind;
+}
+
+export interface OversizeFilterResult {
+  kept: Quad[];
+  dropped: OversizeDrop[];
+}
+
+function isSharedMemoryGraph(graph: string | undefined): boolean {
+  return !!graph && graph.includes(SHARED_MEMORY_INFIX);
+}
+
+function isVerifiableMemoryGraph(graph: string | undefined): boolean {
+  return !!graph && graph.includes(VERIFIABLE_MEMORY_INFIX);
+}
+
+function isExternalLiteralRefTerm(object: string): boolean {
+  return object.endsWith(`^^<${EXTERNAL_LITERAL_REF_DATATYPE}>`);
+}
+
+/**
+ * Literal MUTF-8 size of a quad object term, or `undefined` when the term is
+ * not a literal (IRIs/blank nodes always pass) or is an external-literal ref.
+ */
+function literalBytes(object: string): number | undefined {
+  if (isExternalLiteralRefTerm(object)) return undefined;
+  return rdfLiteralTermMutf8ByteLength(object);
+}
+
+/**
+ * Pre-insert filter at the PROTOCOL limit (60,000). Pure. `_shared_memory`
+ * graphs pass through untouched (see module doc); `_verifiable_memory`
+ * graphs are all-or-nothing per graph.
+ */
+export function filterOversizedSyncQuads(quads: readonly Quad[]): OversizeFilterResult {
+  const dropped: OversizeDrop[] = [];
+  // First pass: find VM graphs with at least one oversized quad — those
+  // graphs' entire batch contribution is quarantined (never partial-store a
+  // Merkle-committed graph).
+  const quarantinedVmGraphs = new Set<string>();
+  for (const q of quads) {
+    if (!isVerifiableMemoryGraph(q.graph)) continue;
+    const bytes = literalBytes(q.object);
+    if (bytes !== undefined && bytes > DKG_RDF_LITERAL_SAFE_MUTF8_BYTES) {
+      quarantinedVmGraphs.add(q.graph!);
+    }
+  }
+
+  const kept: Quad[] = [];
+  for (const q of quads) {
+    if (q.graph && quarantinedVmGraphs.has(q.graph)) {
+      dropped.push({ quad: q, bytes: literalBytes(q.object) ?? 0, kind: 'vm-quarantine' });
+      continue;
+    }
+    if (isSharedMemoryGraph(q.graph) || isVerifiableMemoryGraph(q.graph)) {
+      kept.push(q); // exempt from the per-quad pre-filter (see module doc)
+      continue;
+    }
+    const bytes = literalBytes(q.object);
+    if (bytes !== undefined && bytes > DKG_RDF_LITERAL_SAFE_MUTF8_BYTES) {
+      dropped.push({ quad: q, bytes, kind: 'oversize' });
+      continue;
+    }
+    kept.push(q);
+  }
+  return { kept, dropped };
+}
+
+/**
+ * BACKSTOP split at the STORE hard limit (65,535), applied only after a
+ * store insert has already thrown `OversizedRdfLiteralError` — i.e. for
+ * exempted graphs on a non-blob-capable store (Blazegraph), or any seam the
+ * pre-filter missed. VM graphs keep all-or-nothing semantics here too.
+ */
+export function splitStoreRejectedQuads(quads: readonly Quad[]): OversizeFilterResult {
+  const quarantinedVmGraphs = new Set<string>();
+  for (const q of quads) {
+    if (!isVerifiableMemoryGraph(q.graph)) continue;
+    const bytes = literalBytes(q.object);
+    if (bytes !== undefined && bytes > JAVA_WRITE_UTF_MAX_BYTES) {
+      quarantinedVmGraphs.add(q.graph!);
+    }
+  }
+  const kept: Quad[] = [];
+  const dropped: OversizeDrop[] = [];
+  for (const q of quads) {
+    if (q.graph && quarantinedVmGraphs.has(q.graph)) {
+      dropped.push({ quad: q, bytes: literalBytes(q.object) ?? 0, kind: 'vm-quarantine' });
+      continue;
+    }
+    const bytes = literalBytes(q.object);
+    if (bytes !== undefined && bytes > JAVA_WRITE_UTF_MAX_BYTES) {
+      dropped.push({ quad: q, bytes, kind: 'store-reject' });
+      continue;
+    }
+    kept.push(q);
+  }
+  return { kept, dropped };
+}
+
+export interface OversizeGuardHooks {
+  /** Persist/record the dropped quads (tombstones). Must not throw. */
+  recordDrops: (drops: OversizeDrop[], seam: string) => void;
+}
+
+/**
+ * Wrap a sync-ingest insert with the oversize guard: pre-filter at the
+ * protocol limit, insert the conforming quads, and — if the store STILL
+ * rejects with `OversizedRdfLiteralError` (exempted graphs on Blazegraph, or
+ * a missed edge) — split at the store hard limit, tombstone the offenders,
+ * and retry ONCE with the remainder. Any other error, or a second oversize
+ * rejection, propagates unchanged: this guard converts exactly one failure
+ * class (permanent, size-based refusals) into converge-minus-poison; it must
+ * never mask transient store failures.
+ *
+ * Returns the quads actually handed to the store (post-filter), so callers
+ * keep accurate inserted-count accounting.
+ */
+export async function insertWithOversizeGuard(
+  insert: (quads: Quad[]) => Promise<void>,
+  quads: readonly Quad[],
+  hooks: OversizeGuardHooks,
+  seam: string,
+): Promise<Quad[]> {
+  const { kept, dropped } = filterOversizedSyncQuads(quads);
+  if (dropped.length > 0) hooks.recordDrops(dropped, seam);
+  if (kept.length === 0) return kept;
+  try {
+    await insert(kept);
+    return kept;
+  } catch (err) {
+    if (!isOversizedRdfLiteralError(err)) throw err;
+    const backstop = splitStoreRejectedQuads(kept);
+    if (backstop.dropped.length === 0) throw err; // not size-explicable → real error
+    hooks.recordDrops(backstop.dropped, `${seam}:store-reject`);
+    if (backstop.kept.length === 0) return [];
+    await insert(backstop.kept); // second oversize throw here propagates — no loop, loud failure
+    return backstop.kept;
+  }
+}

--- a/packages/agent/src/sync/oversize-filter.ts
+++ b/packages/agent/src/sync/oversize-filter.ts
@@ -33,8 +33,14 @@
  *    content is Merkle-committed; a missing quad breaks proof verification),
  *    so an oversized quad there drops that graph's ENTIRE batch contribution
  *    (quarantine, RFC-56 §4.3) rather than the single quad.
- *  - `externalLiteralRef`-typed terms always pass (they are ~100-byte
- *    placeholders by construction).
+ *    LIMITATION (review): the quarantine is batch-local — if a VM graph's
+ *    quads span multiple sync PAGES and an oversized quad arrives on a later
+ *    page, earlier pages were already stored, leaving a partial VM graph. This
+ *    is not a regression (pre-fix, earlier pages were stored too and the
+ *    oversized page then looped forever), and a partial VM graph simply fails
+ *    Merkle verification (reader-safe). Producer guards make oversized VM
+ *    unpublishable going forward, so this only concerns legacy/foreign data;
+ *    a persistent per-graph-version quarantine marker is a tracked follow-up.
  */
 
 import {
@@ -44,10 +50,16 @@ import {
   isOversizedRdfLiteralError,
 } from '@origintrail-official/dkg-core';
 import type { Quad } from '@origintrail-official/dkg-storage';
-import { EXTERNAL_LITERAL_REF_DATATYPE } from '@origintrail-official/dkg-storage';
 
-const SHARED_MEMORY_INFIX = '/_shared_memory';
-const VERIFIABLE_MEMORY_INFIX = '/_verifiable_memory';
+// Match `_shared_memory` / `_verifiable_memory` as a full path SEGMENT — the
+// bucket graph (`…/_shared_memory`) and its per-KA descendants
+// (`…/_shared_memory/{author}/{n}`), but NOT the sibling `…/_shared_memory_meta`
+// graph. Review caught a `.includes('/_shared_memory')` bug that wrongly
+// exempted the meta graph, which the blob store does NOT externalize — so
+// oversized meta literals slipped past the guard. Meta graphs fall through to
+// the normal per-quad drop (they never legitimately hold large literals).
+const SHARED_MEMORY_SEGMENT_RE = /\/_shared_memory(\/|$)/;
+const VERIFIABLE_MEMORY_SEGMENT_RE = /\/_verifiable_memory(\/|$)/;
 
 export type OversizeDropKind = 'oversize' | 'vm-quarantine' | 'store-reject';
 
@@ -63,23 +75,24 @@ export interface OversizeFilterResult {
 }
 
 function isSharedMemoryGraph(graph: string | undefined): boolean {
-  return !!graph && graph.includes(SHARED_MEMORY_INFIX);
+  return !!graph && SHARED_MEMORY_SEGMENT_RE.test(graph);
 }
 
 function isVerifiableMemoryGraph(graph: string | undefined): boolean {
-  return !!graph && graph.includes(VERIFIABLE_MEMORY_INFIX);
-}
-
-function isExternalLiteralRefTerm(object: string): boolean {
-  return object.endsWith(`^^<${EXTERNAL_LITERAL_REF_DATATYPE}>`);
+  return !!graph && VERIFIABLE_MEMORY_SEGMENT_RE.test(graph);
 }
 
 /**
  * Literal MUTF-8 size of a quad object term, or `undefined` when the term is
- * not a literal (IRIs/blank nodes always pass) or is an external-literal ref.
+ * not a literal (IRIs / blank nodes always pass).
+ *
+ * NOTE: every literal is measured — including `externalLiteralRef` placeholder
+ * terms. A real ref is ~100 bytes so it passes anyway; the earlier
+ * datatype-suffix exemption was a peer-exploitable bypass (a hostile peer could
+ * attach the ref datatype to a 70KB value and evade both the pre-filter and the
+ * backstop, re-arming the retry loop — review finding).
  */
 function literalBytes(object: string): number | undefined {
-  if (isExternalLiteralRefTerm(object)) return undefined;
   return rdfLiteralTermMutf8ByteLength(object);
 }
 
@@ -169,8 +182,11 @@ export interface OversizeGuardHooks {
  * class (permanent, size-based refusals) into converge-minus-poison; it must
  * never mask transient store failures.
  *
- * Returns the quads actually handed to the store (post-filter), so callers
- * keep accurate inserted-count accounting.
+ * Returns the quads actually handed to the store (post-filter) — callers use it
+ * for cache-invalidation / meta-dirty marking. (The runners' inserted-count
+ * SUMMARY metric still keys off pre-filter length, so it can slightly over-count
+ * on an all-oversize page; that is log-only, with no convergence/cursor/backoff
+ * effect — review-confirmed cosmetic, tracked separately.)
  */
 export async function insertWithOversizeGuard(
   insert: (quads: Quad[]) => Promise<void>,

--- a/packages/agent/src/sync/oversize-tombstones.ts
+++ b/packages/agent/src/sync/oversize-tombstones.ts
@@ -1,0 +1,128 @@
+/**
+ * Oversize tombstone log (OT-RFC-56 §4.2) — the operator-facing record of
+ * sync-ingested quads deliberately refused for exceeding the RDF-literal
+ * size invariant.
+ *
+ * Tombstones are OBSERVABILITY, not correctness: the sync cursor advances
+ * because the oversize filter runs BEFORE the store insert (see
+ * oversize-filter.ts), so a re-offered page is simply re-filtered — nothing
+ * here is consulted on the ingest hot path. Poison should be visible, not
+ * silent: every drop is structured-logged (rate-limited per graph), counted
+ * on `dkg.sync.oversize_tombstones.total`, kept in a bounded in-memory ring
+ * for the operator API, and best-effort appended to
+ * `<dataDir>/oversize-tombstones.jsonl` when a data dir exists.
+ *
+ * The ring and file are capped: an attacker paying ≥60 KB of bandwidth per
+ * ~200-byte entry cannot grow either unboundedly (RFC-56 §5), and eviction
+ * is harmless — a re-offered drop just re-records.
+ */
+
+import { appendFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+import { getMetrics } from '@origintrail-official/dkg-core';
+import type { OversizeDrop } from './oversize-filter.js';
+
+export interface OversizeTombstone {
+  ts: string;
+  seam: string;
+  kind: OversizeDrop['kind'];
+  graph?: string;
+  subject: string;
+  predicate: string;
+  bytes: number;
+  /** SHA-256 over `subject|predicate|graph|objectBytes` — stable identity without retaining the payload. */
+  quadKeySha256: string;
+}
+
+const MAX_RING_ENTRIES = 10_000;
+const LOG_RATE_LIMIT_MS = 60_000;
+
+export interface OversizeTombstoneLogOptions {
+  /** When set, entries are best-effort appended to `<dataDir>/oversize-tombstones.jsonl`. */
+  dataDir?: string;
+  logWarn: (message: string) => void;
+}
+
+export class OversizeTombstoneLog {
+  private readonly ring: OversizeTombstone[] = [];
+  private readonly dataDir?: string;
+  private readonly logWarn: (message: string) => void;
+  private readonly lastLoggedPerGraph = new Map<string, number>();
+  private fileChain: Promise<void> = Promise.resolve();
+
+  constructor(options: OversizeTombstoneLogOptions) {
+    this.dataDir = options.dataDir;
+    this.logWarn = options.logWarn;
+  }
+
+  /** Never throws — a tombstone-recording failure must not fail the sync. */
+  record(drops: readonly OversizeDrop[], seam: string): void {
+    if (drops.length === 0) return;
+    const now = new Date().toISOString();
+    const entries: OversizeTombstone[] = drops.map((d) => ({
+      ts: now,
+      seam,
+      kind: d.kind,
+      graph: d.quad.graph,
+      subject: d.quad.subject,
+      predicate: d.quad.predicate,
+      bytes: d.bytes,
+      quadKeySha256: createHash('sha256')
+        .update(`${d.quad.subject}|${d.quad.predicate}|${d.quad.graph ?? ''}|${d.bytes}`)
+        .digest('hex'),
+    }));
+
+    for (const e of entries) {
+      this.ring.push(e);
+      try {
+        getMetrics().oversizeTombstonesTotal.add(1, { kind: e.kind });
+      } catch { /* metrics unavailable in some harnesses — never fail the sync */ }
+    }
+    if (this.ring.length > MAX_RING_ENTRIES) {
+      this.ring.splice(0, this.ring.length - MAX_RING_ENTRIES);
+    }
+
+    // Rate-limited structured warn: one line per graph per minute is enough
+    // to make a poison source visible without letting a hostile peer turn the
+    // log into its own flood.
+    const byGraph = new Map<string, { count: number; sample: OversizeTombstone }>();
+    for (const e of entries) {
+      const g = e.graph ?? '(default)';
+      const cur = byGraph.get(g);
+      if (cur) cur.count += 1;
+      else byGraph.set(g, { count: 1, sample: e });
+    }
+    const nowMs = Date.now();
+    for (const [g, { count, sample }] of byGraph) {
+      const last = this.lastLoggedPerGraph.get(g) ?? 0;
+      if (nowMs - last < LOG_RATE_LIMIT_MS) continue;
+      this.lastLoggedPerGraph.set(g, nowMs);
+      this.logWarn(
+        `oversize tombstone: refused ${count} synced quad(s) in graph ${g} ` +
+        `(kind=${sample.kind} seam=${seam} sample subject=${sample.subject} ` +
+        `predicate=${sample.predicate} bytes=${sample.bytes}). ` +
+        `The graph converges without them; see docs/use-dkg/large-content.md.`,
+      );
+    }
+
+    if (this.dataDir) {
+      const path = join(this.dataDir, 'oversize-tombstones.jsonl');
+      const payload = entries.map((e) => JSON.stringify(e)).join('\n') + '\n';
+      // Serialize appends so concurrent seams can't interleave lines; swallow
+      // failures (disk-full etc. must not fail the sync — the ring still has it).
+      this.fileChain = this.fileChain
+        .then(() => appendFile(path, payload, 'utf8'))
+        .catch(() => undefined);
+    }
+  }
+
+  /** Newest-first snapshot for the operator API. */
+  list(limit = 100): OversizeTombstone[] {
+    return this.ring.slice(-limit).reverse();
+  }
+
+  get size(): number {
+    return this.ring.length;
+  }
+}

--- a/packages/agent/src/sync/requester/durable-sync.ts
+++ b/packages/agent/src/sync/requester/durable-sync.ts
@@ -3,7 +3,7 @@ import { contextGraphDataGraphUri, contextGraphMetaGraphUri } from '@origintrail
 import type { OperationContext } from '@origintrail-official/dkg-core';
 import type { Quad } from '@origintrail-official/dkg-storage';
 import type { PhaseCallback } from '@origintrail-official/dkg-publisher';
-import { didSyncPeerRespond, isSyncBackoffWorthyError, isSyncTransportFailure } from '../error-tags.js';
+import { didSyncPeerRespond, isSyncBackoffWorthyError, isSyncPermanentRejection, isSyncTransportFailure } from '../error-tags.js';
 import { getSyncCheckpointKey } from '../checkpoint/state.js';
 import type { SyncPageResult } from './page-fetch.js';
 
@@ -265,6 +265,13 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
     } catch (pidErr) {
       endPhase();
       logWarn(ctx, `Sync for context graph "${pid}" from ${remotePeerId} failed: ${pidErr instanceof Error ? pidErr.message : String(pidErr)}`);
+      if (isSyncPermanentRejection(pidErr)) {
+        // Missed-seam alarm (OT-RFC-56): the oversize guard should have
+        // filtered this BEFORE the store insert. Reaching here means an
+        // ingest path bypassed the guard — this page will fail identically
+        // on every retry until that seam is wired.
+        logWarn(ctx, `PERMANENT ingest rejection for "${pid}" reached the sync catch — an insert seam is missing the oversize guard (sync/oversize-filter.ts): ${pidErr instanceof Error ? pidErr.message : String(pidErr)}`);
+      }
       const backoffWorthy = isSyncBackoffWorthyError(pidErr);
       if (backoffWorthy) {
         summary.backoffWorthyFailures += 1;

--- a/packages/agent/src/sync/requester/shared-memory-sync.ts
+++ b/packages/agent/src/sync/requester/shared-memory-sync.ts
@@ -3,7 +3,7 @@ import type { OperationContext } from '@origintrail-official/dkg-core';
 import type { Quad } from '@origintrail-official/dkg-storage';
 import { workspacePublicQuadsDigest, type WorkspacePublicSnapshotStore } from '@origintrail-official/dkg-publisher';
 import type { SyncPhase } from '../auth/request-build.js';
-import { didSyncPeerRespond, isSyncBackoffWorthyError, isSyncTransportFailure } from '../error-tags.js';
+import { didSyncPeerRespond, isSyncBackoffWorthyError, isSyncPermanentRejection, isSyncTransportFailure } from '../error-tags.js';
 import { isSharedMemoryBucketDescendantDataGraph } from '../shared-memory-graphs.js';
 import type { SyncPageResult } from './page-fetch.js';
 
@@ -270,6 +270,11 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       }
     } catch (err) {
       logWarn(ctx, `SWM sync for context graph "${pid}" from ${remotePeerId} failed: ${err instanceof Error ? err.message : String(err)}`);
+      if (isSyncPermanentRejection(err)) {
+        // Missed-seam alarm (OT-RFC-56) — see durable-sync.ts: the oversize
+        // guard should have filtered this before the insert.
+        logWarn(ctx, `PERMANENT ingest rejection for "${pid}" reached the SWM sync catch — an insert seam is missing the oversize guard (sync/oversize-filter.ts): ${err instanceof Error ? err.message : String(err)}`);
+      }
       const backoffWorthy = isSyncBackoffWorthyError(err);
       if (backoffWorthy) {
         summary.backoffWorthyFailures += 1;

--- a/packages/agent/test/oversize-filter.test.ts
+++ b/packages/agent/test/oversize-filter.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Sync-ingest oversize-literal guard (OT-RFC-56) — the 2026-07-08 mainnet
+ * poison-literal retry storm.
+ *
+ * The load-bearing property: a synced page containing an oversized literal
+ * must CONVERGE (conforming quads stored, offenders tombstoned, offset
+ * checkpoint advanced/deleted) instead of throwing inside the per-CG sync
+ * loop before the checkpoint moves — which re-fetched the identical page
+ * from every peer forever. The regression test drives the REAL
+ * `runDurableSync` both ways: pre-fix behavior (raw throwing storeInsert →
+ * checkpoint stuck) is asserted as the disease, guard-wired behavior as the
+ * cure.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  createOperationContext,
+  DKG_RDF_LITERAL_SAFE_MUTF8_BYTES,
+  JAVA_WRITE_UTF_MAX_BYTES,
+  OversizedRdfLiteralError,
+  assertQuadLiteralsMutf8Safe,
+} from '@origintrail-official/dkg-core';
+import type { Quad } from '@origintrail-official/dkg-storage';
+import {
+  filterOversizedSyncQuads,
+  splitStoreRejectedQuads,
+  insertWithOversizeGuard,
+  type OversizeDrop,
+} from '../src/sync/oversize-filter.js';
+import { OversizeTombstoneLog } from '../src/sync/oversize-tombstones.js';
+import { isSyncPermanentRejection, isSyncBackoffWorthyError } from '../src/sync/error-tags.js';
+import { runDurableSync } from '../src/sync/requester/durable-sync.js';
+import type { SyncPageResult } from '../src/sync/requester/page-fetch.js';
+
+const CG = 'did:dkg:context-graph:agents';
+const DATA_GRAPH = `${CG}`;
+const SWM_GRAPH = `${CG}/_shared_memory/0xabc`;
+const VM_GRAPH = `${CG}/_verifiable_memory/0xabc/1`;
+
+const lit = (bytes: number) => `"${'x'.repeat(bytes)}"`; // ASCII ⇒ 1 MUTF-8 byte per char
+const quad = (object: string, graph = DATA_GRAPH, subject = 'http://ex.org/s'): Quad =>
+  ({ subject, predicate: 'https://schema.org/description', object, graph }) as Quad;
+
+describe('filterOversizedSyncQuads (protocol limit, 60,000)', () => {
+  it('passes literals at the boundary and drops above it', () => {
+    // rdfLiteralTermMutf8ByteLength measures the FULL serialized term
+    // (including the surrounding quotes) — same semantics as the #1323
+    // producer guards. 59,998 content chars + 2 quotes = exactly 60,000.
+    const atLimit = quad(lit(DKG_RDF_LITERAL_SAFE_MUTF8_BYTES - 2));
+    const over = quad(lit(DKG_RDF_LITERAL_SAFE_MUTF8_BYTES + 1));
+    const r = filterOversizedSyncQuads([atLimit, over]);
+    expect(r.kept).toEqual([atLimit]);
+    expect(r.dropped).toHaveLength(1);
+    expect(r.dropped[0]!.kind).toBe('oversize');
+    expect(r.dropped[0]!.quad).toBe(over);
+    expect(r.dropped[0]!.bytes).toBeGreaterThan(DKG_RDF_LITERAL_SAFE_MUTF8_BYTES);
+  });
+
+  it('never drops IRIs or blank-node objects (only literals are measured)', () => {
+    const iri = quad(`<http://ex.org/${'y'.repeat(70_000)}>`);
+    const r = filterOversizedSyncQuads([iri]);
+    expect(r.kept).toEqual([iri]);
+    expect(r.dropped).toEqual([]);
+  });
+
+  it('passes externalLiteralRef placeholder terms', () => {
+    const ref = quad(`"sha256:${'a'.repeat(64)}"^^<http://dkg.io/ontology/externalLiteralRef>`);
+    const r = filterOversizedSyncQuads([ref]);
+    expect(r.kept).toEqual([ref]);
+    expect(r.dropped).toEqual([]);
+  });
+
+  it('exempts _shared_memory graphs (blob-store rehydration makes large SWM literals legitimate on the wire)', () => {
+    const bigSwm = quad(lit(70_000), SWM_GRAPH);
+    const r = filterOversizedSyncQuads([bigSwm]);
+    expect(r.kept).toEqual([bigSwm]);
+    expect(r.dropped).toEqual([]);
+  });
+
+  it('quarantines a _verifiable_memory graph ALL-OR-NOTHING (never a partial Merkle-committed graph)', () => {
+    const vmBig = quad(lit(70_000), VM_GRAPH, 'http://ex.org/a');
+    const vmSmall = quad(lit(10), VM_GRAPH, 'http://ex.org/b');
+    const other = quad(lit(10), DATA_GRAPH);
+    const r = filterOversizedSyncQuads([vmBig, vmSmall, other]);
+    expect(r.kept).toEqual([other]);
+    expect(r.dropped.map((d) => d.kind)).toEqual(['vm-quarantine', 'vm-quarantine']);
+  });
+
+  it('leaves a clean VM graph untouched', () => {
+    const vmSmall = quad(lit(10), VM_GRAPH);
+    const r = filterOversizedSyncQuads([vmSmall]);
+    expect(r.kept).toEqual([vmSmall]);
+    expect(r.dropped).toEqual([]);
+  });
+});
+
+describe('splitStoreRejectedQuads (store hard limit, 65,535)', () => {
+  it('keeps 60k–65,535 range literals (store can hold them) and drops only above the hard limit', () => {
+    const between = quad(lit(61_000), SWM_GRAPH);
+    const above = quad(lit(JAVA_WRITE_UTF_MAX_BYTES + 100), SWM_GRAPH);
+    const r = splitStoreRejectedQuads([between, above]);
+    expect(r.kept).toEqual([between]);
+    expect(r.dropped).toHaveLength(1);
+    expect(r.dropped[0]!.kind).toBe('store-reject');
+  });
+});
+
+describe('insertWithOversizeGuard', () => {
+  const collect = () => {
+    const drops: Array<{ drop: OversizeDrop; seam: string }> = [];
+    return {
+      drops,
+      hooks: { recordDrops: (ds: OversizeDrop[], seam: string) => ds.forEach((d) => drops.push({ drop: d, seam })) },
+    };
+  };
+
+  it('inserts conforming quads, tombstones the oversized, returns what was inserted', async () => {
+    const { drops, hooks } = collect();
+    const inserted: Quad[][] = [];
+    const good = quad(lit(10));
+    const bad = quad(lit(70_000));
+    const result = await insertWithOversizeGuard(async (q) => { inserted.push(q); }, [good, bad], hooks, 'test');
+    expect(result).toEqual([good]);
+    expect(inserted).toEqual([[good]]);
+    expect(drops).toHaveLength(1);
+    expect(drops[0]!.seam).toBe('test');
+  });
+
+  it('BACKSTOP: a store OversizedRdfLiteralError splits at the hard limit, tombstones, retries once', async () => {
+    // A 70k literal in an EXEMPT (_shared_memory) graph passes the pre-filter,
+    // then a Blazegraph-like store throws. The guard must converge: drop it,
+    // record store-reject, retry with the remainder.
+    const { drops, hooks } = collect();
+    const good = quad(lit(10), SWM_GRAPH);
+    const bad = quad(lit(70_000), SWM_GRAPH);
+    const batches: Quad[][] = [];
+    const blazegraphLike = async (quads: Quad[]) => {
+      batches.push(quads);
+      assertQuadLiteralsMutf8Safe(quads, { maxBytes: JAVA_WRITE_UTF_MAX_BYTES, label: 'test.insert' });
+    };
+    const result = await insertWithOversizeGuard(blazegraphLike, [good, bad], hooks, 'swm-sync');
+    expect(result).toEqual([good]);
+    expect(batches).toHaveLength(2); // first attempt (throws), retry (succeeds)
+    expect(drops).toHaveLength(1);
+    expect(drops[0]!.drop.kind).toBe('store-reject');
+    expect(drops[0]!.seam).toBe('swm-sync:store-reject');
+  });
+
+  it('propagates non-oversize store errors unchanged (never masks transient failures)', async () => {
+    const { hooks } = collect();
+    await expect(
+      insertWithOversizeGuard(async () => { throw new Error('store connection refused'); }, [quad(lit(10))], hooks, 'test'),
+    ).rejects.toThrow('store connection refused');
+  });
+
+  it('rethrows an oversize error the split cannot explain (real store bug, loud failure)', async () => {
+    const { hooks } = collect();
+    const smallButRejected = quad(lit(10));
+    await expect(
+      insertWithOversizeGuard(
+        async () => { throw new OversizedRdfLiteralError({ actualBytes: 99, maxBytes: 1 }); },
+        [smallButRejected],
+        hooks,
+        'test',
+      ),
+    ).rejects.toThrow(OversizedRdfLiteralError);
+  });
+});
+
+describe('error-tags: permanent-rejection classification', () => {
+  it('OversizedRdfLiteralError is permanent, and NOT backoff-worthy', () => {
+    const err = new OversizedRdfLiteralError({ actualBytes: 70_000, maxBytes: 65_535 });
+    expect(isSyncPermanentRejection(err)).toBe(true);
+    expect(isSyncBackoffWorthyError(err)).toBe(false);
+  });
+  it('transient transport errors are not permanent', () => {
+    expect(isSyncPermanentRejection(new Error('stream reset'))).toBe(false);
+  });
+});
+
+describe('runDurableSync — the poison-page retry-loop regression', () => {
+  const bad = quad(lit(120_000)); // the incident shape: a ~118KB agents-graph literal
+  const goodA = quad(lit(10), DATA_GRAPH, 'http://ex.org/a');
+  const goodB = quad(lit(10), DATA_GRAPH, 'http://ex.org/b');
+
+  function makeContext(storeInsert: (quads: Quad[]) => Promise<void>) {
+    const deletedCheckpoints: string[] = [];
+    const setCheckpoints: Array<{ key: string; offset: number }> = [];
+    const page = (phase: 'data' | 'meta'): SyncPageResult => ({
+      quads: phase === 'data' ? [goodA, bad, goodB] : [],
+      bytesReceived: 100,
+      resumedFromOffset: 0,
+      nextOffset: 3,
+      checkpointKey: `cp|${phase}`,
+      completed: true,
+      timedOut: false,
+    });
+    return {
+      deletedCheckpoints,
+      setCheckpoints,
+      context: {
+        ctx: createOperationContext('sync'),
+        remotePeerId: 'peerR',
+        contextGraphIds: ['agents'],
+        createContextGraphSyncDeadline: () => Date.now() + 10_000,
+        fetchSyncPages: async (_c: unknown, _p: string, _cg: string, _swm: boolean, phase: 'data' | 'meta') => page(phase),
+        processDurableBatchInWorker: async (dataQuads: Quad[], metaQuads: Quad[]) => ({
+          verifiedData: dataQuads,
+          verifiedMeta: metaQuads,
+          totalFetchedDataQuads: dataQuads.length,
+          totalFetchedMetaQuads: metaQuads.length,
+          rejectedKcs: 0,
+          emptyResponses: 0,
+          metaOnlyResponses: 0,
+          dataRejectedMissingMeta: 0,
+        }),
+        storeInsert,
+        deleteCheckpoint: (key: string) => { deletedCheckpoints.push(key); },
+        setCheckpoint: (key: string, offset: number) => { setCheckpoints.push({ key, offset }); },
+        logInfo: () => {},
+        logWarn: () => {},
+        logDebug: () => {},
+      },
+    };
+  }
+
+  it('DISEASE (pre-fix): a raw throwing store leaves the checkpoint untouched — the page re-fetches forever', async () => {
+    const throwing = async (quads: Quad[]) =>
+      assertQuadLiteralsMutf8Safe(quads, { maxBytes: JAVA_WRITE_UTF_MAX_BYTES, label: 'blazegraph.insert' });
+    const { context, deletedCheckpoints, setCheckpoints } = makeContext(throwing);
+    const summary = await runDurableSync(context as never);
+    expect(summary.failedPhases).toBe(1);
+    // Neither advanced nor completed: the stuck-cursor loop.
+    expect(deletedCheckpoints).toEqual([]);
+    expect(setCheckpoints).toEqual([]);
+  });
+
+  it('CURE: the guard converges the page — conforming quads stored, offender tombstoned, checkpoints completed', async () => {
+    const stored: Quad[][] = [];
+    const tomb = new OversizeTombstoneLog({ logWarn: () => {} });
+    const guarded = async (quads: Quad[]) => {
+      await insertWithOversizeGuard(
+        async (kept) => {
+          assertQuadLiteralsMutf8Safe(kept, { maxBytes: JAVA_WRITE_UTF_MAX_BYTES, label: 'blazegraph.insert' });
+          stored.push(kept);
+        },
+        quads,
+        { recordDrops: (drops, seam) => tomb.record(drops, seam) },
+        'durable-sync',
+      );
+    };
+    const { context, deletedCheckpoints } = makeContext(guarded);
+    const summary = await runDurableSync(context as never);
+    expect(summary.failedPhases).toBe(0);
+    expect(stored).toEqual([[goodA, goodB]]); // poison excluded, the rest converged
+    expect(deletedCheckpoints).toEqual(expect.arrayContaining(['cp|meta', 'cp|data'])); // page consumed → no re-fetch
+    expect(tomb.size).toBe(1);
+    expect(tomb.list(10)[0]).toMatchObject({
+      kind: 'oversize',
+      seam: 'durable-sync',
+      predicate: 'https://schema.org/description',
+    });
+  });
+});

--- a/packages/agent/test/oversize-filter.test.ts
+++ b/packages/agent/test/oversize-filter.test.ts
@@ -62,18 +62,37 @@ describe('filterOversizedSyncQuads (protocol limit, 60,000)', () => {
     expect(r.dropped).toEqual([]);
   });
 
-  it('passes externalLiteralRef placeholder terms', () => {
+  it('passes a real (small) externalLiteralRef placeholder term', () => {
     const ref = quad(`"sha256:${'a'.repeat(64)}"^^<http://dkg.io/ontology/externalLiteralRef>`);
     const r = filterOversizedSyncQuads([ref]);
     expect(r.kept).toEqual([ref]);
     expect(r.dropped).toEqual([]);
   });
 
-  it('exempts _shared_memory graphs (blob-store rehydration makes large SWM literals legitimate on the wire)', () => {
-    const bigSwm = quad(lit(70_000), SWM_GRAPH);
-    const r = filterOversizedSyncQuads([bigSwm]);
-    expect(r.kept).toEqual([bigSwm]);
+  it('DROPS an oversized ref-datatype term (no datatype-suffix bypass — review finding)', () => {
+    // A hostile peer attaches the ref datatype to a huge value; it must NOT be
+    // exempted just because of the suffix.
+    const fakeRef = quad(`"${'x'.repeat(70_000)}"^^<http://dkg.io/ontology/externalLiteralRef>`);
+    const r = filterOversizedSyncQuads([fakeRef]);
+    expect(r.kept).toEqual([]);
+    expect(r.dropped).toHaveLength(1);
+    expect(r.dropped[0]!.kind).toBe('oversize');
+  });
+
+  it('exempts _shared_memory DATA graphs (bucket + per-KA), where large literals are legitimately blob-externalized', () => {
+    const bucket = quad(lit(70_000), SWM_GRAPH);
+    const perKa = quad(lit(70_000), `${CG}/_shared_memory/0xauthor/7`, 'http://ex.org/ka');
+    const r = filterOversizedSyncQuads([bucket, perKa]);
+    expect(r.kept).toEqual([bucket, perKa]);
     expect(r.dropped).toEqual([]);
+  });
+
+  it('does NOT exempt _shared_memory_meta (sibling segment, not blob-externalized — review finding)', () => {
+    const bigMeta = quad(lit(70_000), `${CG}/_shared_memory_meta`);
+    const r = filterOversizedSyncQuads([bigMeta]);
+    expect(r.kept).toEqual([]);
+    expect(r.dropped).toHaveLength(1);
+    expect(r.dropped[0]!.kind).toBe('oversize');
   });
 
   it('quarantines a _verifiable_memory graph ALL-OR-NOTHING (never a partial Merkle-committed graph)', () => {
@@ -259,5 +278,37 @@ describe('runDurableSync — the poison-page retry-loop regression', () => {
       seam: 'durable-sync',
       predicate: 'https://schema.org/description',
     });
+  });
+});
+
+describe('production wiring — the real sync-ingest seam calls the guard', () => {
+  // Falsification (review): the pure-filter regression above proves the helper
+  // works, not that the production seam uses it. This drives the REAL
+  // insertSyncedQuadsAndInvalidateListCache (durable-sync's storeInsert) on a
+  // live agent + store. On oxigraph (no size limit) a removed guard would store
+  // the oversized quad, so deleting the production call turns this red.
+  it('insertSyncedQuadsAndInvalidateListCache drops+tombstones oversized, stores the rest, does not throw', async () => {
+    const { DKGAgent } = await import('../src/index.js');
+    const { NoChainAdapter } = await import('@origintrail-official/dkg-chain');
+    const { OxigraphStore } = await import('@origintrail-official/dkg-storage');
+    const store = new OxigraphStore();
+    const agent = await DKGAgent.create({
+      name: 'IngestWiringNode', listenPort: 0, listenHost: '127.0.0.1',
+      store, chainAdapter: new NoChainAdapter(), nodeRole: 'core', skills: [],
+    });
+    try {
+      const good = { subject: 'http://ex.org/s', predicate: 'http://ex.org/p', object: '"small"', graph: 'http://ex.org/g' } as Quad;
+      const poison = { subject: 'http://ex.org/s2', predicate: 'http://ex.org/p', object: `"${'x'.repeat(120_000)}"`, graph: 'http://ex.org/g' } as Quad;
+
+      await expect((agent as any).insertSyncedQuadsAndInvalidateListCache([good, poison])).resolves.toBeUndefined();
+
+      const r = await store.query('SELECT ?s WHERE { GRAPH ?g { ?s ?p ?o } }');
+      const subjects = r.type === 'bindings' ? r.bindings.map((b) => b.s) : [];
+      expect(subjects).toContain('http://ex.org/s');       // conforming quad stored
+      expect(subjects).not.toContain('http://ex.org/s2');  // poison NOT stored (guard dropped it pre-insert)
+      expect((agent as any).oversizeTombstoneLog.size).toBeGreaterThan(0);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
   });
 });

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -31,6 +31,7 @@ export default defineConfig({
       "test/ensure-registered-for-publish.test.ts",
       "test/sync-verify-collapsed.test.ts",
       "test/durable-sync-since-threading.test.ts",
+      "test/oversize-filter.test.ts",
       "test/sync-responder-concurrent-interleaving.test.ts",
       "test/sync-fetch-coalescing.test.ts",
       "test/sync-on-connect-churn.test.ts",

--- a/packages/core/src/telemetry-api.ts
+++ b/packages/core/src/telemetry-api.ts
@@ -156,6 +156,9 @@ export interface DkgMetrics {
   protocolSendTotal: Counter;
   /** ms; protocol_id — P2P protocol send duration */
   protocolSendDuration: Histogram;
+  /** kind={oversize|vm-quarantine|store-reject} — synced quads refused for
+   *  exceeding the RDF-literal size invariant (OT-RFC-56; poison visibility). */
+  oversizeTombstonesTotal: Counter;
 }
 
 function buildMetrics(): DkgMetrics {
@@ -180,6 +183,9 @@ function buildMetrics(): DkgMetrics {
     syncRequestTotal: meter.createCounter('dkg.sync.request.total', { description: 'Outbound sync requests' }),
     syncResponseTotal: meter.createCounter('dkg.sync.response.total', { description: 'Inbound sync responses' }),
     protocolSendTotal: meter.createCounter('dkg.protocol_router.send.total', { description: 'Outbound P2P protocol sends' }),
+    oversizeTombstonesTotal: meter.createCounter('dkg.sync.oversize_tombstones.total', {
+      description: 'Synced quads refused for exceeding the RDF-literal size invariant (OT-RFC-56)',
+    }),
     protocolSendDuration: meter.createHistogram('dkg.protocol_router.send.duration', {
       unit: 'ms', description: 'P2P protocol send wall-time', advice: { explicitBucketBoundaries: RPC_DURATION_BUCKETS },
     }),


### PR DESCRIPTION
## TL;DR

**Problem:** The third engine of the mainnet sync storm. A synced page containing an RDF literal above Blazegraph's MUTF-8 hard limit throws `OversizedRdfLiteralError` inside the per-CG sync loop **before** the offset checkpoint advances → the identical page is re-fetched from every peer, forever. Observed 2026-07-08: three 118–177KB literals (`agents`/`ontology`/working-memory graphs) re-fetched **hundreds of times per peer** by every Blazegraph core, while Oxigraph nodes (no size limit) stored and re-served them — a permanent split-brain. #1323's guards are producer-side; the sync-ingest path had no permanent-error classification at all (`isOversizedRdfLiteralError` had zero sync consumers).

**Fix: filter-before-insert.** Because sync completeness is an offset page-cursor (not quad-set reconciliation), dropping the oversized quad *before* `storeInsert` lets the phase complete normally and the cursor advance past the page. Conforming quads converge; offenders are tombstoned; a deliberate refusal terminates the conversation instead of looping.

## What this adds

- **`sync/oversize-filter.ts`** — pre-filter at the protocol limit (60,000 MUTF-8 bytes). Graph-class semantics:
  - `_shared_memory` **exempt**: `SharedMemoryLiteralBlobStore` legitimately re-hydrates large SWM literals on the wire between blob-capable nodes; on Blazegraph the guard's **backstop** (catch `OversizedRdfLiteralError` → split at the 65,535 hard limit → tombstone → retry once) covers them. Any non-oversize error propagates unchanged — the guard never masks transient failures.
  - `_verifiable_memory` **all-or-nothing per graph** (never partially store a Merkle-committed graph).
  - `externalLiteralRef` placeholder terms always pass.
- **`sync/oversize-tombstones.ts`** — bounded ring (10k) + rate-limited structured warn + `dkg.sync.oversize_tombstones.total` counter + best-effort JSONL (`<dataDir>/oversize-tombstones.jsonl`). Observability, not correctness: nothing consults tombstones on the hot path; a re-offered page is just re-filtered.
- **Wired at the ingest seams:** `insertSyncedQuadsAndInvalidateListCache` (durable sync + registry meta pulls), the SWM incremental `storeInsert`, the SWM recovery `store.insert`.
- **Deliberately NOT wrapped:** the finalize/gossip canonical insert — chain-confirmed content must never be partially stored, it has no offset-cursor loop (not a storm engine), and Blazegraph nodes never hold the poison to promote (the SWM seam filters it upstream).
- **`error-tags.ts`** — `isSyncPermanentRejection` + a **missed-seam alarm** in both runner catches: a permanent rejection reaching the catch means an ingest path bypassed the guard (loud log, never counted toward peer backoff).

## Effect on the incident

Every upgraded Blazegraph core stops the retry burn immediately: the three known payloads tombstone once per peer-page and the graphs converge without them. Stale nodes keep offering the quads — each offer is a one-time cheap re-filter, not a loop. Blazegraph and Oxigraph ingest now converge to the same logical view.

## Tests

15 new in `test/oversize-filter.test.ts`: boundary (60,000 exact), IRI/ref passes, SWM exemption, VM quarantine, backstop retry, error-propagation, permanent-vs-backoff classification, and a **disease/cure regression pair** driving the real `runDurableSync`: raw throwing store ⇒ checkpoint stuck (documents the loop); guarded store ⇒ converge-minus-poison, checkpoints completed, tombstone recorded.

Suites: **agent 318/318, core 1142/1142, storage 231** green.

## Relation to in-flight work

Three storm engines, three fixes — all complementary, no file conflicts: #1500 (big-graph mid-progress aborts → offset-0 loops), #1526 (`agents/_meta` dead-bloat propagation), **this PR** (permanent-rejection loops). Part of the OT-RFC-56 remediation; follow-ups: one-shot boot sweep of already-resident poison (uses #1526's new `TripleStore.update()`), producer guards (oxigraph adapter parity, CG-registration description, OKF section mapping), error messages citing the new docs page (#1527).

🤖 Generated with [Claude Code](https://claude.com/claude-code)