### PR TITLE
fix(sync,storage): oversize-literal boot sweep + producer guards (OT-RFC-56 Fix 2 & 3 → main)

### DIFF
--- a/packages/agent/src/dkg-agent-cg-registry.ts
+++ b/packages/agent/src/dkg-agent-cg-registry.ts
@@ -93,6 +93,7 @@ import {
   type SubscriptionSource,
   SUBSCRIPTION_SOURCES,
   pickNetworkTunables,
+  assertRdfLiteralMutf8Safe,
 } from '@origintrail-official/dkg-core';
 import { GraphManager, PrivateContentStore, createTripleStore, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig } from '@origintrail-official/dkg-storage';
 import { EVMChainAdapter, NoChainAdapter, enrichEvmError, buildKnowledgeAssetUal, type EVMAdapterConfig, type ChainAdapter, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo } from '@origintrail-official/dkg-chain';
@@ -937,6 +938,20 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
     curated?: boolean;
   }): Promise<void> {
     const ctx = createOperationContext('system');
+
+    // OT-RFC-56 §4.6: this writer inserts the CG registration record RAW into
+    // the network-replicated ONTOLOGY graph, bypassing the guarded publish
+    // routes — the exact producer hole behind the 2026-07-08 mainnet
+    // "skyocean" 177KB-description poison. Enforce the protocol literal
+    // limit BEFORE any write; caller-correctable (CG creation is interactive).
+    assertRdfLiteralMutf8Safe(`"${opts.name}"`, {
+      label: 'contextGraph.name', subject: opts.id, predicate: DKG_ONTOLOGY.SCHEMA_NAME,
+    });
+    if (opts.description) {
+      assertRdfLiteralMutf8Safe(`"${opts.description}"`, {
+        label: 'contextGraph.description', subject: opts.id, predicate: DKG_ONTOLOGY.SCHEMA_DESCRIPTION,
+      });
+    }
 
     const exists = await this.contextGraphExists(opts.id);
     if (exists) {

--- a/packages/agent/src/dkg-agent-context-graph.ts
+++ b/packages/agent/src/dkg-agent-context-graph.ts
@@ -91,6 +91,7 @@ import {
   type SubscriptionSource,
   SUBSCRIPTION_SOURCES,
   pickNetworkTunables,
+  assertRdfLiteralMutf8Safe,
 } from '@origintrail-official/dkg-core';
 import { GraphManager, PrivateContentStore, createTripleStore, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig } from '@origintrail-official/dkg-storage';
 import { EVMChainAdapter, NoChainAdapter, enrichEvmError, buildKnowledgeAssetUal, type EVMAdapterConfig, type ChainAdapter, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo } from '@origintrail-official/dkg-chain';
@@ -416,6 +417,17 @@ export class ContextGraphMethods extends DKGAgentBase {
     callerAgentAddress?: string;
   }): Promise<void> {
     const ctx = createOperationContext('system');
+    // OT-RFC-56 §4.6: name/description land as raw literals in a
+    // network-replicated graph — enforce the protocol limit before ANY
+    // side effect (see ensureContextGraphLocal for the incident context).
+    assertRdfLiteralMutf8Safe(`"${opts.name}"`, {
+      label: 'contextGraph.name', subject: opts.id, predicate: DKG_ONTOLOGY.SCHEMA_NAME,
+    });
+    if (opts.description) {
+      assertRdfLiteralMutf8Safe(`"${opts.description}"`, {
+        label: 'contextGraph.description', subject: opts.id, predicate: DKG_ONTOLOGY.SCHEMA_DESCRIPTION,
+      });
+    }
     const gm = new GraphManager(this.store);
     const contextGraphUri = `did:dkg:context-graph:${opts.id}`;
     const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -208,6 +208,7 @@ import { orderCatchupPeers } from './p2p/peer-selection.js';
 import { reconcileWarmCoreConnections, type WarmCoreAgent } from './p2p/warm-core-connections.js';
 import { fetchSyncPages, type SyncPageResult } from './sync/requester/page-fetch.js';
 import { insertWithOversizeGuard } from './sync/oversize-filter.js';
+import { runOversizeSweep } from './sync/oversize-sweep.js';
 import { getSyncCheckpointKey } from './sync/checkpoint/state.js';
 import { runDurableSync } from './sync/requester/durable-sync.js';
 import { resolveSyncAgentsMeta, shouldWithholdAgentsDurableMeta } from './sync/requester/agents-meta-sync-config.js';
@@ -522,6 +523,18 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     this.coreHostRecordingsClosed = false;
     const ctx = createOperationContext('connect');
     this.log.info(ctx, `Starting DKG node`);
+
+    // One-shot resident-poison sweep (OT-RFC-56 §4.4) — BEFORE networking, so
+    // the local store is clean before this node serves or syncs anything.
+    // Marker-gated (runs once per data dir), never throws, no-op on stores
+    // that never accepted oversized literals (Blazegraph).
+    await runOversizeSweep({
+      store: this.store,
+      dataDir: this.config.dataDir,
+      recordDrops: (drops, seam) => this.oversizeTombstoneLog.record(drops, seam),
+      logInfo: (message) => this.log.info(ctx, message),
+      logWarn: (message) => this.log.warn(ctx, message),
+    });
 
     await this.node.start();
     this.started = true;

--- a/packages/agent/src/sync/oversize-sweep.ts
+++ b/packages/agent/src/sync/oversize-sweep.ts
@@ -1,0 +1,142 @@
+/**
+ * One-shot boot sweep of resident oversized literals (OT-RFC-56 §4.4).
+ *
+ * The ingest guard (oversize-filter.ts) stops NEW poison from entering via
+ * sync — but data already resident from before the guard stays in the local
+ * store and keeps being served to peers. In a decentralized network there is
+ * no fleet delete: the only remediation channel we control is the release
+ * itself, so each upgraded node self-cleans at boot. Once ingest everywhere
+ * refuses re-entry, a local delete finally STICKS.
+ *
+ * Semantics (mirror the ingest filter's graph classes):
+ *  - Only mutable graphs are swept. `_verifiable_memory` graphs are never
+ *    touched (Merkle-committed — a partial delete breaks proof verification),
+ *    and `_shared_memory` graphs are exempt (large SWM literals are
+ *    legitimate there via the blob-store rehydration flow).
+ *  - Candidates are over-selected with a cheap SPARQL `STRLEN` filter
+ *    (chars ≤ MUTF-8 bytes ≤ 3×chars, so every >60,000-byte term has
+ *    >19,000 chars — the filter can miss nothing), then each candidate is
+ *    verified EXACTLY with the protocol's MUTF-8 byte measure before
+ *    deletion. Deletes are precise full-quad `deleteByPattern` calls —
+ *    offenders are rare by construction, so per-quad deletion cost is moot.
+ *  - Gated by a marker file (`<dataDir>/.oversize-sweep-v1.done`), written
+ *    only after a fully successful sweep: a failed/partial sweep logs and
+ *    retries on the next boot. No dataDir ⇒ in-memory store ⇒ nothing
+ *    resident to sweep ⇒ skip.
+ *
+ * On Blazegraph-backed nodes the sweep finds nothing (the adapter never
+ * accepted oversized literals) and just writes the marker — a cheap no-op.
+ */
+
+import { existsSync } from 'node:fs';
+import { writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import {
+  DKG_RDF_LITERAL_SAFE_MUTF8_BYTES,
+  rdfLiteralTermMutf8ByteLength,
+} from '@origintrail-official/dkg-core';
+import type { Quad } from '@origintrail-official/dkg-storage';
+import type { OversizeDrop } from './oversize-filter.js';
+
+const SWEEP_MARKER = '.oversize-sweep-v1.done';
+const SHARED_MEMORY_INFIX = '/_shared_memory';
+const VERIFIABLE_MEMORY_INFIX = '/_verifiable_memory';
+// Over-select threshold in SPARQL characters: MUTF-8 bytes ≤ 3 bytes/char,
+// so any term over the 60,000-byte limit has > (60,000/3) - small overhead
+// characters. 19,000 keeps a wide safety margin.
+const STRLEN_OVERSELECT_CHARS = 19_000;
+
+export interface OversizeSweepStore {
+  listGraphs(): Promise<string[]>;
+  query(sparql: string): Promise<{ type: string; quads?: Quad[] }>;
+  deleteByPattern(pattern: Partial<Quad>): Promise<number>;
+}
+
+export interface OversizeSweepOptions {
+  store: OversizeSweepStore;
+  /** Marker-file directory. Absent ⇒ in-memory store ⇒ skip. */
+  dataDir?: string;
+  recordDrops: (drops: OversizeDrop[], seam: string) => void;
+  logInfo: (message: string) => void;
+  logWarn: (message: string) => void;
+}
+
+export interface OversizeSweepResult {
+  ran: boolean;
+  scannedGraphs: number;
+  sweptQuads: number;
+}
+
+function isExemptGraph(graph: string): boolean {
+  return graph.includes(SHARED_MEMORY_INFIX) || graph.includes(VERIFIABLE_MEMORY_INFIX);
+}
+
+/**
+ * Run the sweep if the marker allows it. Never throws: a sweep failure must
+ * not brick the boot — it logs, leaves the marker unwritten, and retries on
+ * the next start.
+ */
+export async function runOversizeSweep(options: OversizeSweepOptions): Promise<OversizeSweepResult> {
+  const { store, dataDir, recordDrops, logInfo, logWarn } = options;
+  const skipped: OversizeSweepResult = { ran: false, scannedGraphs: 0, sweptQuads: 0 };
+  if (!dataDir) return skipped;
+  const markerPath = join(dataDir, SWEEP_MARKER);
+  try {
+    if (existsSync(markerPath)) return skipped;
+  } catch {
+    return skipped;
+  }
+
+  let scannedGraphs = 0;
+  let sweptQuads = 0;
+  try {
+    const graphs = (await store.listGraphs()).filter((g) => !isExemptGraph(g));
+    const startedAt = Date.now();
+    for (const graph of graphs) {
+      scannedGraphs += 1;
+      // Over-select candidates cheaply in the store, verify exactly below.
+      const result = await store.query(
+        `CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${graph}> { ?s ?p ?o } ` +
+        `FILTER(isLiteral(?o) && STRLEN(STR(?o)) > ${STRLEN_OVERSELECT_CHARS}) }`,
+      );
+      const candidates = result.type === 'quads' && result.quads ? result.quads : [];
+      const offenders: OversizeDrop[] = [];
+      for (const q of candidates) {
+        const bytes = rdfLiteralTermMutf8ByteLength(q.object);
+        if (bytes !== undefined && bytes > DKG_RDF_LITERAL_SAFE_MUTF8_BYTES) {
+          offenders.push({ quad: { ...q, graph }, bytes, kind: 'oversize' });
+        }
+      }
+      for (const offender of offenders) {
+        await store.deleteByPattern({
+          graph,
+          subject: offender.quad.subject,
+          predicate: offender.quad.predicate,
+          object: offender.quad.object,
+        });
+        sweptQuads += 1;
+      }
+      if (offenders.length > 0) {
+        recordDrops(offenders, 'sweep');
+        logWarn(
+          `oversize sweep: removed ${offenders.length} resident oversized literal(s) from ${graph} ` +
+          `(largest ${Math.max(...offenders.map((o) => o.bytes))} bytes). ` +
+          `Ingest now refuses re-entry; see docs/use-dkg/large-content.md.`,
+        );
+      }
+    }
+    await writeFile(markerPath, `${new Date().toISOString()} scanned=${scannedGraphs} swept=${sweptQuads}\n`, 'utf8');
+    logInfo(
+      `oversize sweep complete: ${scannedGraphs} graph(s) scanned, ${sweptQuads} quad(s) removed ` +
+      `in ${Date.now() - startedAt}ms (marker ${SWEEP_MARKER} written)`,
+    );
+    return { ran: true, scannedGraphs, sweptQuads };
+  } catch (err) {
+    // No marker on failure — the sweep retries next boot.
+    logWarn(
+      `oversize sweep failed after ${scannedGraphs} graph(s) / ${sweptQuads} removal(s) — ` +
+      `will retry next boot: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return { ran: true, scannedGraphs, sweptQuads };
+  }
+}

--- a/packages/agent/src/sync/oversize-sweep.ts
+++ b/packages/agent/src/sync/oversize-sweep.ts
@@ -39,12 +39,21 @@ import type { Quad } from '@origintrail-official/dkg-storage';
 import type { OversizeDrop } from './oversize-filter.js';
 
 const SWEEP_MARKER = '.oversize-sweep-v1.done';
-const SHARED_MEMORY_INFIX = '/_shared_memory';
-const VERIFIABLE_MEMORY_INFIX = '/_verifiable_memory';
-// Over-select threshold in SPARQL characters: MUTF-8 bytes ≤ 3 bytes/char,
-// so any term over the 60,000-byte limit has > (60,000/3) - small overhead
-// characters. 19,000 keeps a wide safety margin.
-const STRLEN_OVERSELECT_CHARS = 19_000;
+// Match `_shared_memory` / `_verifiable_memory` as a full path SEGMENT — same
+// predicate as the ingest filter. The bucket + per-KA descendants are exempt
+// (SWM: legit blob-externalized large literals; VM: never partial-delete a
+// Merkle graph), but the sibling `…/_shared_memory_meta` is NOT exempt and IS
+// swept — it can hold resident poison and is not externalized.
+const SHARED_MEMORY_SEGMENT_RE = /\/_shared_memory(\/|$)/;
+const VERIFIABLE_MEMORY_SEGMENT_RE = /\/_verifiable_memory(\/|$)/;
+// Over-select threshold in SPARQL CHARACTERS (STRLEN counts code points). Java
+// MUTF-8 is up to 6 bytes per code point (astral chars = surrogate pair, 3+3),
+// so a >60,000-BYTE literal has > 60,000/6 = 10,000 code points. 9,000 is a
+// safe floor that cannot miss an over-limit literal even when it is entirely
+// astral (emoji / CJK-Ext-B / math alphanumerics — review finding); the exact
+// MUTF-8 byte check in JS re-verifies each candidate, so a lower threshold only
+// costs a few extra verifications, never a missed offender.
+const STRLEN_OVERSELECT_CHARS = 9_000;
 
 export interface OversizeSweepStore {
   listGraphs(): Promise<string[]>;
@@ -68,7 +77,7 @@ export interface OversizeSweepResult {
 }
 
 function isExemptGraph(graph: string): boolean {
-  return graph.includes(SHARED_MEMORY_INFIX) || graph.includes(VERIFIABLE_MEMORY_INFIX);
+  return SHARED_MEMORY_SEGMENT_RE.test(graph) || VERIFIABLE_MEMORY_SEGMENT_RE.test(graph);
 }
 
 /**

--- a/packages/agent/test/cg-registration-oversize-guard.test.ts
+++ b/packages/agent/test/cg-registration-oversize-guard.test.ts
@@ -1,0 +1,54 @@
+/**
+ * CG-registration oversize guard (OT-RFC-56 §4.6).
+ *
+ * `createContextGraph` / `ensureContextGraphLocal` write the CG registration
+ * record (name + description) RAW into the network-replicated ONTOLOGY graph,
+ * bypassing the guarded publish routes — the exact producer hole behind the
+ * 2026-07-08 mainnet "skyocean" 177KB-description poison. The guard rejects an
+ * oversized description BEFORE any store write, with a caller-correctable
+ * `OVERSIZED_RDF_LITERAL` error.
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import { DKGAgent } from '../src/index.js';
+import { NoChainAdapter } from '@origintrail-official/dkg-chain';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+
+describe('createContextGraph oversize-description guard', () => {
+  let agent: DKGAgent | undefined;
+  afterEach(async () => { await agent?.stop().catch(() => {}); agent = undefined; });
+
+  const makeAgent = async (store: OxigraphStore) => DKGAgent.create({
+    name: 'CgGuardNode',
+    listenPort: 0,
+    listenHost: '127.0.0.1',
+    store,
+    chainAdapter: new NoChainAdapter(),
+    nodeRole: 'core',
+    skills: [],
+  });
+
+  it('rejects an oversized description with OVERSIZED_RDF_LITERAL, writing nothing', async () => {
+    const store = new OxigraphStore();
+    agent = await makeAgent(store);
+    await agent.start();
+
+    const oversized = 'D'.repeat(200_000);
+    await expect(
+      agent.createContextGraph({ id: 'skyocean-repro', name: 'Skyocean', description: oversized }),
+    ).rejects.toMatchObject({ code: 'OVERSIZED_RDF_LITERAL' });
+
+    // Fail-before-side-effect: no ontology triples for this CG landed.
+    const r = await store.query(
+      `SELECT ?p WHERE { GRAPH ?g { <did:dkg:context-graph:skyocean-repro> ?p ?o } }`,
+    );
+    expect(r.type === 'bindings' && r.bindings).toHaveLength(0);
+  });
+
+  it('accepts a normal-sized description', async () => {
+    agent = await makeAgent(new OxigraphStore());
+    await agent.start();
+    await expect(
+      agent.createContextGraph({ id: 'normal-cg', name: 'Normal', description: 'a reasonable description' }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/agent/test/oversize-filter.test.ts
+++ b/packages/agent/test/oversize-filter.test.ts
@@ -27,6 +27,7 @@ import {
   type OversizeDrop,
 } from '../src/sync/oversize-filter.js';
 import { OversizeTombstoneLog } from '../src/sync/oversize-tombstones.js';
+import { runOversizeSweep } from '../src/sync/oversize-sweep.js';
 import { isSyncPermanentRejection, isSyncBackoffWorthyError } from '../src/sync/error-tags.js';
 import { runDurableSync } from '../src/sync/requester/durable-sync.js';
 import type { SyncPageResult } from '../src/sync/requester/page-fetch.js';
@@ -310,5 +311,84 @@ describe('production wiring — the real sync-ingest seam calls the guard', () =
     } finally {
       await agent.stop().catch(() => {});
     }
+  });
+});
+
+describe('runOversizeSweep (boot-time resident-poison removal)', () => {
+  const bigTerm = `"${'x'.repeat(120_000)}"`;
+  const overSelectedButLegal = `"${'y'.repeat(25_000)}"`; // >19k chars over-select, but 25,002 bytes < 60,000 → must survive
+  const makeStore = (graphQuads: Record<string, Quad[]>) => {
+    const deletions: Array<Partial<Quad>> = [];
+    return {
+      deletions,
+      store: {
+        listGraphs: async () => Object.keys(graphQuads),
+        query: async (sparql: string) => {
+          const m = /GRAPH <([^>]+)>/.exec(sparql);
+          const quads = (graphQuads[m![1]!] ?? []).filter((q) => {
+            const val = q.object.startsWith('"') ? q.object.slice(1, q.object.lastIndexOf('"')) : '';
+            return val.length > 19_000;
+          });
+          return { type: 'quads', quads };
+        },
+        deleteByPattern: async (pattern: Partial<Quad>) => { deletions.push(pattern); return 1; },
+      },
+    };
+  };
+  const drops: Array<{ seam: string; kind: string }> = [];
+  const hooks = {
+    recordDrops: (ds: OversizeDrop[], seam: string) => ds.forEach((d) => drops.push({ seam, kind: d.kind })),
+    logInfo: () => {},
+    logWarn: () => {},
+  };
+
+  it('removes exact offenders only, skips exempt graphs, writes the marker, and no-ops on the second run', async () => {
+    const { mkdtemp } = await import('node:fs/promises');
+    const { tmpdir } = await import('node:os');
+    const dataDir = await mkdtemp(`${tmpdir()}/oversweep-`);
+    drops.length = 0;
+    const { store, deletions } = makeStore({
+      [DATA_GRAPH]: [quad(bigTerm), quad(overSelectedButLegal, DATA_GRAPH, 'http://ex.org/legal')],
+      [SWM_GRAPH]: [quad(bigTerm, SWM_GRAPH)],
+      [VM_GRAPH]: [quad(bigTerm, VM_GRAPH)],
+    });
+
+    const first = await runOversizeSweep({ store, dataDir, ...hooks });
+    expect(first.ran).toBe(true);
+    expect(first.sweptQuads).toBe(1); // only the true offender in the mutable data graph
+    expect(deletions).toHaveLength(1);
+    expect(deletions[0]).toMatchObject({ graph: DATA_GRAPH, object: bigTerm });
+    expect(first.scannedGraphs).toBe(1); // SWM + VM graphs never scanned
+    expect(drops).toEqual([{ seam: 'sweep', kind: 'oversize' }]);
+
+    const second = await runOversizeSweep({ store, dataDir, ...hooks });
+    expect(second.ran).toBe(false); // marker gates the re-run
+    expect(deletions).toHaveLength(1);
+  });
+
+  it('skips entirely without a dataDir (in-memory store)', async () => {
+    const { store, deletions } = makeStore({ [DATA_GRAPH]: [quad(bigTerm)] });
+    const r = await runOversizeSweep({ store, dataDir: undefined, ...hooks });
+    expect(r.ran).toBe(false);
+    expect(deletions).toEqual([]);
+  });
+
+  it('does NOT write the marker on failure — retries next boot', async () => {
+    const { mkdtemp } = await import('node:fs/promises');
+    const { tmpdir } = await import('node:os');
+    const dataDir = await mkdtemp(`${tmpdir()}/oversweep-fail-`);
+    const failing = {
+      listGraphs: async () => [DATA_GRAPH],
+      query: async () => { throw new Error('store exploded'); },
+      deleteByPattern: async () => 1,
+    };
+    const r1 = await runOversizeSweep({ store: failing, dataDir, ...hooks });
+    expect(r1.ran).toBe(true);
+    expect(r1.sweptQuads).toBe(0);
+    // Marker absent → a healthy second run still executes.
+    const { store, deletions } = makeStore({ [DATA_GRAPH]: [quad(bigTerm)] });
+    const r2 = await runOversizeSweep({ store, dataDir, ...hooks });
+    expect(r2.ran).toBe(true);
+    expect(deletions).toHaveLength(1);
   });
 });

--- a/packages/agent/test/oversize-filter.test.ts
+++ b/packages/agent/test/oversize-filter.test.ts
@@ -316,7 +316,7 @@ describe('production wiring — the real sync-ingest seam calls the guard', () =
 
 describe('runOversizeSweep (boot-time resident-poison removal)', () => {
   const bigTerm = `"${'x'.repeat(120_000)}"`;
-  const overSelectedButLegal = `"${'y'.repeat(25_000)}"`; // >19k chars over-select, but 25,002 bytes < 60,000 → must survive
+  const overSelectedButLegal = `"${'y'.repeat(25_000)}"`; // over-select, but 25,002 bytes < 60,000 → must survive
   const makeStore = (graphQuads: Record<string, Quad[]>) => {
     const deletions: Array<Partial<Quad>> = [];
     return {
@@ -324,10 +324,14 @@ describe('runOversizeSweep (boot-time resident-poison removal)', () => {
       store: {
         listGraphs: async () => Object.keys(graphQuads),
         query: async (sparql: string) => {
-          const m = /GRAPH <([^>]+)>/.exec(sparql);
-          const quads = (graphQuads[m![1]!] ?? []).filter((q) => {
+          const g = /GRAPH <([^>]+)>/.exec(sparql);
+          // Faithful STRLEN simulation: COUNT CODE POINTS (not UTF-16 units)
+          // against the threshold the sweep actually put in the query, so an
+          // astral literal is over-selected exactly as real oxigraph would.
+          const thr = Number(/STRLEN\(STR\(\?o\)\) > (\d+)/.exec(sparql)?.[1] ?? '0');
+          const quads = (graphQuads[g![1]!] ?? []).filter((q) => {
             const val = q.object.startsWith('"') ? q.object.slice(1, q.object.lastIndexOf('"')) : '';
-            return val.length > 19_000;
+            return [...val].length > thr;
           });
           return { type: 'quads', quads };
         },
@@ -364,6 +368,39 @@ describe('runOversizeSweep (boot-time resident-poison removal)', () => {
     const second = await runOversizeSweep({ store, dataDir, ...hooks });
     expect(second.ran).toBe(false); // marker gates the re-run
     expect(deletions).toHaveLength(1);
+  });
+
+  it('catches ASTRAL-only oversized poison the 19k threshold would have missed (review finding)', async () => {
+    const { mkdtemp } = await import('node:fs/promises');
+    const { tmpdir } = await import('node:os');
+    const dataDir = await mkdtemp(`${tmpdir()}/oversweep-astral-`);
+    drops.length = 0;
+    // 11,000 × 😀 = 11,000 code points (STRLEN) but 66,000 MUTF-8 bytes: an
+    // offender that STRLEN>19,000 would skip. The 9,000 threshold over-selects
+    // it, and the exact byte-verify confirms + deletes it.
+    const astral = `"${'😀'.repeat(11_000)}"`;
+    const { store, deletions } = makeStore({ [DATA_GRAPH]: [quad(astral)] });
+    const r = await runOversizeSweep({ store, dataDir, ...hooks });
+    expect(r.sweptQuads).toBe(1);
+    expect(deletions).toHaveLength(1);
+    expect(deletions[0]).toMatchObject({ graph: DATA_GRAPH, object: astral });
+  });
+
+  it('SWEEPS _shared_memory_meta (mutable, not blob-externalized) but skips SWM data + VM', async () => {
+    const { mkdtemp } = await import('node:fs/promises');
+    const { tmpdir } = await import('node:os');
+    const dataDir = await mkdtemp(`${tmpdir()}/oversweep-meta-`);
+    drops.length = 0;
+    const metaGraph = `${CG}/_shared_memory_meta`;
+    const { store, deletions } = makeStore({
+      [metaGraph]: [quad(bigTerm, metaGraph)],
+      [SWM_GRAPH]: [quad(bigTerm, SWM_GRAPH)],
+      [VM_GRAPH]: [quad(bigTerm, VM_GRAPH)],
+    });
+    const r = await runOversizeSweep({ store, dataDir, ...hooks });
+    expect(r.scannedGraphs).toBe(1);   // only _shared_memory_meta scanned
+    expect(r.sweptQuads).toBe(1);
+    expect(deletions[0]).toMatchObject({ graph: metaGraph });
   });
 
   it('skips entirely without a dataDir (in-memory store)', async () => {

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -32,6 +32,7 @@ export default defineConfig({
       "test/sync-verify-collapsed.test.ts",
       "test/durable-sync-since-threading.test.ts",
       "test/oversize-filter.test.ts",
+      "test/cg-registration-oversize-guard.test.ts",
       "test/sync-responder-concurrent-interleaving.test.ts",
       "test/sync-fetch-coalescing.test.ts",
       "test/sync-on-connect-churn.test.ts",

--- a/packages/core/src/rdf-literal-size.ts
+++ b/packages/core/src/rdf-literal-size.ts
@@ -41,7 +41,8 @@ export class OversizedRdfLiteralError extends DKGUserError {
       `RDF literal${location} is ${args.actualBytes} Java MUTF-8 bytes, ` +
       `which exceeds the Blazegraph-compatible safe limit of ${args.maxBytes} bytes. ` +
       `Split large text into ordered chunks below the limit, or store the body externally ` +
-      `and publish only its URI, hash, summary, and metadata.`,
+      `and publish only its URI, hash, summary, and metadata. ` +
+      `See docs/use-dkg/large-content.md for the supported patterns and roadmap.`,
     );
     this.name = 'OversizedRdfLiteralError';
     this.actualBytes = args.actualBytes;

--- a/packages/okf/src/mapping.ts
+++ b/packages/okf/src/mapping.ts
@@ -58,6 +58,23 @@ import type {
 const BARE_URL_RE = /https?:\/\/[^\s)<>"]+/g;
 const INLINE_LINK_RE = /\[[^\]]*\]\(([^)\s]+)\)/g;
 
+/**
+ * Display bound for section names (OT-RFC-56 §4.6). Headings are headings —
+ * anything longer is a markdown-parse artifact (a huge single-line document
+ * surfaces its whole body as one "heading"), and un-truncated it becomes an
+ * oversized RDF literal the DKG's replicated graphs must refuse (the
+ * 2026-07-08 mainnet 177KB `schema:name` poison was exactly this shape).
+ * 2,048 chars ≤ 6,144 MUTF-8 bytes — far below the 60,000-byte protocol
+ * limit. Frontmatter fields are NOT truncated: they are author-controlled
+ * structured data, and the daemon's guarded import routes reject oversized
+ * values there with a caller-correctable error.
+ */
+const SECTION_NAME_MAX_CHARS = 2_048;
+function truncateSectionName(text: string): string {
+  if (text.length <= SECTION_NAME_MAX_CHARS) return text;
+  return `${text.slice(0, SECTION_NAME_MAX_CHARS - 1)}…`;
+}
+
 /** OKF `type` value → an rdf:type object IRI (raw, no angle brackets). */
 function typeToIri(value: unknown): string | null {
   const s = String(value).trim();
@@ -232,7 +249,13 @@ export function mapConcept(
   parsed.headings.forEach((text, i) => {
     const sectionIri = `${iri}${SECTION_GENID_INFIX}okfsec_${sanitizeForBlank(doc.conceptId)}_${i}`;
     quads.push({ subject: iri, predicate: DKG_HAS_SECTION, object: sectionIri });
-    quads.push({ subject: sectionIri, predicate: SCHEMA_NAME, object: literalTerm(text) });
+    // OT-RFC-56 §4.6: a markdown-parse quirk (e.g. a huge single-line
+    // document) can surface an arbitrarily large string as a "heading" —
+    // the exact producer bug behind the 2026-07-08 mainnet 177KB
+    // `schema:name` working-memory poison. Section names are HEADINGS:
+    // truncate to a sane display bound rather than failing the whole
+    // import over a parse artifact.
+    quads.push({ subject: sectionIri, predicate: SCHEMA_NAME, object: literalTerm(truncateSectionName(text)) });
   });
 
   const resolvedLinks: OkfLink[] = [];

--- a/packages/okf/test/mapping.test.ts
+++ b/packages/okf/test/mapping.test.ts
@@ -138,3 +138,35 @@ describe('mapConcept code-span policy', () => {
     ]);
   });
 });
+
+describe('mapConcept section-name truncation (OT-RFC-56 §4.6)', () => {
+  // A markdown-parse quirk can surface a huge string as a "heading" — the
+  // producer shape behind the 2026-07-08 mainnet 177KB schema:name poison.
+  // Section names are truncated to a display bound so the import SUCCEEDS
+  // with a sane name instead of minting an oversized RDF literal (or, post
+  // #1323, failing the whole import at the guarded route).
+  const hugeHeading = 'H'.repeat(180_000);
+  const doc = parseDocument(
+    'briefs/world_cup.md',
+    `---\ntype: T\ntitle: O\n---\n\n# ${hugeHeading}\n\nbody\n`,
+  );
+  const m = mapConcept(doc, 'urn:okf:briefs/world_cup', () => false);
+
+  it('truncates oversized section names to the display bound (never an oversized literal)', () => {
+    const sectionNames = m.quads.filter(
+      (q) => q.subject.includes('okfsec_') && q.predicate.includes('schema.org/name'),
+    );
+    expect(sectionNames.length).toBeGreaterThan(0);
+    for (const q of sectionNames) {
+      expect(q.object.length).toBeLessThanOrEqual(2_048 + 4); // bound + quotes + ellipsis
+      expect(q.object.endsWith('…"')).toBe(true);
+    }
+  });
+
+  it('leaves normal headings untouched', () => {
+    const normal = parseDocument('a/b.md', '---\ntype: T\ntitle: O\n---\n\n# Short heading\n\nbody\n');
+    const mm = mapConcept(normal, 'urn:okf:a/b', () => false);
+    const names = mm.quads.filter((q) => q.subject.includes('okfsec_') && q.predicate.includes('schema.org/name'));
+    expect(names.some((q) => q.object === '"Short heading"')).toBe(true);
+  });
+});

--- a/packages/storage/src/adapters/oxigraph.ts
+++ b/packages/storage/src/adapters/oxigraph.ts
@@ -14,6 +14,10 @@ import type {
 import { registerTripleStoreAdapter } from '../triple-store.js';
 import { assertQuadLiteralsMutf8Safe, JAVA_WRITE_UTF_MAX_BYTES } from '@origintrail-official/dkg-core';
 
+// SWM DATA segment (bucket `…/_shared_memory` + per-KA `…/_shared_memory/{author}/{n}`),
+// NOT the sibling `…/_shared_memory_meta`. Kept in sync with the sync-ingest guard.
+const SHARED_MEMORY_DATA_SEGMENT_RE = /\/_shared_memory(\/|$)/;
+
 type OxStore = InstanceType<typeof oxigraph.Store>;
 type OxTerm = oxigraph.Term;
 type OxQuad = oxigraph.Quad;
@@ -194,11 +198,14 @@ export class OxigraphStore implements TripleStore {
     // accept + re-serve oversized literals that Blazegraph peers can
     // physically never store — the split-brain half of the 2026-07-08
     // mainnet poison incident. Assert at the same Java MUTF-8 hard limit so
-    // no backend silently persists what another must refuse. `_shared_memory`
-    // graphs are exempt: their large literals are legitimately handled by the
+    // no backend silently persists what another must refuse. The
+    // `_shared_memory` DATA segment (bucket + per-KA descendants) is exempt:
+    // its large literals are legitimately handled by the
     // SharedMemoryLiteralBlobStore wrapper (externalize-on-insert,
-    // rehydrate-on-query), whose INNER store is exactly this adapter.
-    const guarded = quads.filter((q) => !q.graph?.includes('/_shared_memory'));
+    // rehydrate-on-query), whose INNER store is exactly this adapter. The match
+    // is a path SEGMENT (parity with the sync guard) so the sibling
+    // `…/_shared_memory_meta` graph is NOT exempted — it is not externalized.
+    const guarded = quads.filter((q) => !(q.graph && SHARED_MEMORY_DATA_SEGMENT_RE.test(q.graph)));
     if (guarded.length > 0) {
       assertQuadLiteralsMutf8Safe(guarded, {
         maxBytes: JAVA_WRITE_UTF_MAX_BYTES,

--- a/packages/storage/src/adapters/oxigraph.ts
+++ b/packages/storage/src/adapters/oxigraph.ts
@@ -407,14 +407,53 @@ function parseTerm(term: string): oxigraph.NamedNode | oxigraph.Literal | oxigra
   if (term.startsWith('"')) {
     const match = term.match(/^"((?:[^"\\]|\\.)*)"(?:@(\S+)|\^\^<([^>]+)>)?$/);
     if (match) {
-      if (match[2]) return oxigraph.literal(match[1], match[2]);
-      if (match[3]) return oxigraph.literal(match[1], oxigraph.namedNode(match[3]));
-      return oxigraph.literal(match[1]);
+      // UNESCAPE the captured lexical form: query results (fromOxQuad →
+      // termToString) hand back N-Quads-ESCAPED literals, and store.load()
+      // (insert) UNescapes on parse — so a literal whose value contains
+      // `"`, `\`, LF, or CR is stored unescaped but arrives here escaped.
+      // Without this reversal, `oxigraph.literal(match[1])` builds a literal
+      // whose value is the ESCAPED form, which never matches the stored term,
+      // so deleteByPattern / delete silently affect ZERO quads. (Empirically
+      // reproduced; this is the OT-RFC-56 boot-sweep no-op blocker.)
+      const value = unescapeNQuadsLiteral(match[1]);
+      if (match[2]) return oxigraph.literal(value, match[2]);
+      if (match[3]) return oxigraph.literal(value, oxigraph.namedNode(match[3]));
+      return oxigraph.literal(value);
     }
     return oxigraph.literal(term.slice(1, -1));
   }
   if (term.startsWith('_:')) return oxigraph.blankNode(term.slice(2));
   return oxigraph.namedNode(term);
+}
+
+/**
+ * Reverse {@link escapeNQuadsLiteral} (and the standard N-Quads/Turtle string
+ * escapes) so a lexical form round-trips exactly through
+ * `termToString → parseTerm`. Single left-to-right pass, so `\\n` (an escaped
+ * backslash then a literal `n`) correctly yields `\n` (backslash + n), not LF.
+ */
+function unescapeNQuadsLiteral(s: string): string {
+  if (!s.includes('\\')) return s;
+  let out = '';
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    if (c !== '\\' || i + 1 >= s.length) { out += c; continue; }
+    const n = s[++i];
+    switch (n) {
+      case 'n': out += '\n'; break;
+      case 'r': out += '\r'; break;
+      case 't': out += '\t'; break;
+      case 'b': out += '\b'; break;
+      case 'f': out += '\f'; break;
+      case '"': out += '"'; break;
+      case "'": out += "'"; break;
+      case '\\': out += '\\'; break;
+      case 'u': out += String.fromCodePoint(parseInt(s.slice(i + 1, i + 5), 16)); i += 4; break;
+      case 'U': out += String.fromCodePoint(parseInt(s.slice(i + 1, i + 9), 16)); i += 8; break;
+      default: out += n; break; // unknown escape: drop the backslash, keep the char
+    }
+  }
+  return out;
 }
 
 function toOxQuad(q: DKGQuad): oxigraph.Quad | null {

--- a/packages/storage/src/adapters/oxigraph.ts
+++ b/packages/storage/src/adapters/oxigraph.ts
@@ -12,6 +12,7 @@ import type {
   TripleStoreQueryOptions,
 } from '../triple-store.js';
 import { registerTripleStoreAdapter } from '../triple-store.js';
+import { assertQuadLiteralsMutf8Safe, JAVA_WRITE_UTF_MAX_BYTES } from '@origintrail-official/dkg-core';
 
 type OxStore = InstanceType<typeof oxigraph.Store>;
 type OxTerm = oxigraph.Term;
@@ -188,6 +189,22 @@ export class OxigraphStore implements TripleStore {
 
   async insert(quads: DKGQuad[]): Promise<void> {
     if (quads.length === 0) return;
+    // Oversize parity with the Blazegraph adapter (OT-RFC-56 §4.6): Oxigraph
+    // itself has no literal-size limit, which made oxigraph-backed nodes
+    // accept + re-serve oversized literals that Blazegraph peers can
+    // physically never store — the split-brain half of the 2026-07-08
+    // mainnet poison incident. Assert at the same Java MUTF-8 hard limit so
+    // no backend silently persists what another must refuse. `_shared_memory`
+    // graphs are exempt: their large literals are legitimately handled by the
+    // SharedMemoryLiteralBlobStore wrapper (externalize-on-insert,
+    // rehydrate-on-query), whose INNER store is exactly this adapter.
+    const guarded = quads.filter((q) => !q.graph?.includes('/_shared_memory'));
+    if (guarded.length > 0) {
+      assertQuadLiteralsMutf8Safe(guarded, {
+        maxBytes: JAVA_WRITE_UTF_MAX_BYTES,
+        label: 'OxigraphStore.insert',
+      });
+    }
     const nquads = quads.map(quadToNQuad).join('\n') + '\n';
     this.store.load(nquads, { format: 'application/n-quads' });
     this.scheduleFlush();

--- a/packages/storage/test/oxigraph-delete-roundtrip.unit.test.ts
+++ b/packages/storage/test/oxigraph-delete-roundtrip.unit.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Adapter literal round-trip on delete (OT-RFC-56 boot-sweep blocker).
+ *
+ * `termToString` (query results) N-Quads-ESCAPES literal values, while
+ * `store.load` (insert) UNescapes them — so a literal containing `"`, `\`, LF,
+ * or CR is stored unescaped but handed back escaped. `parseTerm` (used by
+ * `deleteByPattern` / `delete`) must reverse that, or a caller that deletes a
+ * term it just read back matches ZERO quads. This is the silent no-op that made
+ * the boot sweep write its "done" marker while removing nothing.
+ */
+import { describe, it, expect } from 'vitest';
+import { OxigraphStore } from '../src/adapters/oxigraph.js';
+import type { Quad } from '../src/triple-store.js';
+
+const G = 'http://ex.org/g';
+const S = 'http://ex.org/s';
+const P = 'http://ex.org/p';
+
+// Values that exercise every escape produced by escapeNQuadsLiteral.
+const trickyValues = [
+  'line1\nline2',            // LF
+  'has "double quotes"',     // "
+  'back\\slash',             // \
+  'carriage\rreturn',        // CR
+  'all: "q" \\ \n \r mix',   // combined
+  'literal backslash-n: \\n', // an escaped backslash then n → must NOT become LF
+];
+
+describe('OxigraphStore literal round-trip: read → delete matches', () => {
+  it.each(trickyValues)('deleteByPattern removes a literal containing special chars: %j', async (value) => {
+    const store = new OxigraphStore();
+    // Insert via the escaped N-Quads form the rest of the stack uses.
+    const escaped = value.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n').replace(/\r/g, '\\r');
+    await store.insert([{ subject: S, predicate: P, object: `"${escaped}"`, graph: G } as Quad]);
+
+    // Read it back exactly as the sweep does (CONSTRUCT → adapter object term).
+    const r = await store.query(`CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${G}> { ?s ?p ?o } }`);
+    const quads = r.type === 'quads' ? r.quads : [];
+    expect(quads).toHaveLength(1);
+    const objTerm = quads[0]!.object;
+
+    // Delete by the read-back term — must match and remove it.
+    const deleted = await store.deleteByPattern({ graph: G, subject: S, predicate: P, object: objTerm });
+    expect(deleted).toBe(1);
+
+    const after = await store.query(`SELECT ?o WHERE { GRAPH <${G}> { ?s ?p ?o } }`);
+    expect(after.type === 'bindings' && after.bindings).toHaveLength(0);
+  });
+
+  it('does not over-delete: a same-S/P sibling literal survives', async () => {
+    const store = new OxigraphStore();
+    await store.insert([
+      { subject: S, predicate: P, object: '"has \\"quote\\""', graph: G } as Quad,
+      { subject: S, predicate: P, object: '"plain sibling"', graph: G } as Quad,
+    ]);
+    const r = await store.query(`CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${G}> { ?s ?p ?o } }`);
+    const target = (r.type === 'quads' ? r.quads : []).find((q) => q.object.includes('quote'))!;
+    await store.deleteByPattern({ graph: G, subject: S, predicate: P, object: target.object });
+    const after = await store.query(`SELECT ?o WHERE { GRAPH <${G}> { ?s ?p ?o } }`);
+    const objs = after.type === 'bindings' ? after.bindings.map((b) => b.o) : [];
+    expect(objs).toEqual(['"plain sibling"']); // the sibling remains (SELECT returns the quoted term)
+  });
+});

--- a/packages/storage/test/oxigraph-oversize.unit.test.ts
+++ b/packages/storage/test/oxigraph-oversize.unit.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Oxigraph oversize-literal parity (OT-RFC-56 §4.6).
+ *
+ * Oxigraph itself accepts literals of any size, which made oxigraph-backed
+ * nodes store + re-serve oversized literals that Blazegraph peers can
+ * physically never hold — the split-brain half of the 2026-07-08 mainnet
+ * poison incident. The adapter now asserts the same Java MUTF-8 hard limit
+ * as the Blazegraph adapter, EXCEPT for `_shared_memory` graphs, whose
+ * large literals are legitimately handled by the SharedMemoryLiteralBlobStore
+ * wrapper (externalize-on-insert / rehydrate-on-query) with this adapter as
+ * its inner store.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { OxigraphStore } from '../src/adapters/oxigraph.js';
+import type { Quad } from '../src/triple-store.js';
+
+const oversized = `"${'x'.repeat(70_000)}"`;
+const q = (object: string, graph = 'http://ex.org/g', subject = 'http://ex.org/s'): Quad =>
+  ({ subject, predicate: 'http://ex.org/p', object, graph }) as Quad;
+
+describe('OxigraphStore.insert oversize parity', () => {
+  it('rejects a >65,535-byte literal with OVERSIZED_RDF_LITERAL, storing nothing', async () => {
+    const s = new OxigraphStore();
+    await expect(s.insert([q('"small"'), q(oversized, 'http://ex.org/g', 'http://ex.org/s2')]))
+      .rejects.toMatchObject({ code: 'OVERSIZED_RDF_LITERAL' });
+    const r = await s.query('SELECT ?s WHERE { GRAPH ?g { ?s ?p ?o } }');
+    expect(r.type === 'bindings' && r.bindings).toHaveLength(0); // assert precedes load — nothing partial
+  });
+
+  it('still accepts oversized literals in _shared_memory graphs (blob-store inner-store flow)', async () => {
+    const s = new OxigraphStore();
+    await s.insert([q(oversized, 'http://ex.org/cg/_shared_memory/0xabc')]);
+    const r = await s.query('SELECT ?s WHERE { GRAPH ?g { ?s ?p ?o } }');
+    expect(r.type === 'bindings' && r.bindings).toHaveLength(1);
+  });
+
+  it('accepts large-but-legal literals everywhere (25KB)', async () => {
+    const s = new OxigraphStore();
+    await s.insert([q(`"${'y'.repeat(25_000)}"`)]);
+    const r = await s.query('SELECT ?s WHERE { GRAPH ?g { ?s ?p ?o } }');
+    expect(r.type === 'bindings' && r.bindings).toHaveLength(1);
+  });
+});

--- a/packages/storage/test/oxigraph-oversize.unit.test.ts
+++ b/packages/storage/test/oxigraph-oversize.unit.test.ts
@@ -28,11 +28,20 @@ describe('OxigraphStore.insert oversize parity', () => {
     expect(r.type === 'bindings' && r.bindings).toHaveLength(0); // assert precedes load — nothing partial
   });
 
-  it('still accepts oversized literals in _shared_memory graphs (blob-store inner-store flow)', async () => {
+  it('still accepts oversized literals in _shared_memory DATA graphs (bucket + per-KA — blob-store inner-store flow)', async () => {
     const s = new OxigraphStore();
-    await s.insert([q(oversized, 'http://ex.org/cg/_shared_memory/0xabc')]);
+    await s.insert([
+      q(oversized, 'http://ex.org/cg/_shared_memory'),           // bucket
+      q(oversized, 'http://ex.org/cg/_shared_memory/0xa/7', 'http://ex.org/s3'), // per-KA
+    ]);
     const r = await s.query('SELECT ?s WHERE { GRAPH ?g { ?s ?p ?o } }');
-    expect(r.type === 'bindings' && r.bindings).toHaveLength(1);
+    expect(r.type === 'bindings' && r.bindings).toHaveLength(2);
+  });
+
+  it('REJECTS oversized literals in _shared_memory_meta (sibling segment, not blob-externalized)', async () => {
+    const s = new OxigraphStore();
+    await expect(s.insert([q(oversized, 'http://ex.org/cg/_shared_memory_meta')]))
+      .rejects.toMatchObject({ code: 'OVERSIZED_RDF_LITERAL' });
   });
 
   it('accepts large-but-legal literals everywhere (25KB)', async () => {


### PR DESCRIPTION
Stacked on #1530 (Fix 2). **Defense-in-depth: after Fix 1 (ingest) + Fix 2 (sweep) clean up, close the internal write paths that produced the poison so it can't be re-created.**

#1323 guarded the user-facing publish/import routes. These three paths bypassed them and are the direct origins of the 2026-07-08 mainnet payloads:

## 1. Oxigraph adapter parity (`packages/storage`)
Oxigraph has no literal-size limit — oxigraph-backed nodes stored and re-served oversized literals Blazegraph peers can physically never hold (the split-brain half of the incident). Now asserts the same Java MUTF-8 hard limit as the Blazegraph adapter. **`_shared_memory` exempt** — those large literals are the `SharedMemoryLiteralBlobStore`'s legitimate externalize-on-insert / rehydrate-on-query flow (this adapter is its inner store).

## 2. CG registration (`createContextGraph` + `ensureContextGraphLocal`)
Name + description land **raw** in the network-replicated ONTOLOGY graph — the "skyocean" 177KB-description hole. Assert the protocol limit before any write; caller-correctable (`OVERSIZED_RDF_LITERAL`, CG creation is interactive).

## 3. OKF mapping (`packages/okf`)
A markdown-parse quirk (a huge single-line document) surfaces its whole body as one section **"heading"** → `schema:name` — the "fifa" 177KB working-memory hole. **Truncate section names to 2,048 chars** (headings are headings) rather than failing the whole import over a parse artifact. Frontmatter stays reject-only at the guarded routes (author-controlled structured data).

## Plus
`OversizedRdfLiteralError` now cites `docs/use-dkg/large-content.md` (#1527) so operators hitting any guard get the supported patterns + roadmap.

## Tests
oxigraph parity (reject / SWM-exempt / large-but-legal), OKF truncation (oversized heading truncated, normal untouched), CG-registration guard (oversized description rejected before side effects). **Suites: agent 323, storage 234, core 1142, okf 80 green.**

## Release ordering
Ship Fix 1/2/3 in the **same release**: the oxigraph assert must not meet un-swept resident poison (Fix 2's boot sweep runs first and clears it; the SWM finalize re-canonicalization path would otherwise throw on existing local poison). Stack: #1529 → #1530 → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)