### PR TITLE
chore(release): 10.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to the DKG V10 node are documented here. The format is based
 
 ## [Unreleased]
 
+## [10.0.5] - 2026-07-08
+
+Node stability and sync hardening on top of 10.0.4, plus contract updates. Ends the oversize-literal retry loop that could pin sync CPU, keeps the `agents/_meta` graph off the sync plane (reduces sync fan-out load), gates node-UI metric store-scans on consumer presence, and repairs the 10.0.4 npm tarball, which shipped without its `network/*.json` overlays and `project.json` (npm-installed nodes were falling back to built-in defaults). Also ships updated PublishingConviction 10.0.8 contracts (sources + ABIs); the on-chain deploy is a separate, coordinated activity (see **Deployment**). Content is identical to the `10.0.5-canary.1` testnet build (commit `6a91a16d`).
+
+### Added
+
+- **PublishingConviction 10.0.8 contract updates** — updated contract sources and regenerated ABIs (#1524). The runtime contract surface (`packages/evm-module/abi/*.json`) is updated; nodes resolve `PublishingConviction` from the Hub per call and hot-swap the new logic with no restart, so 10.0.4 and 10.0.5 nodes both interoperate with either the 10.0.7 or 10.0.8 contract.
+
+### Fixed
+
+- **Oversize-literal retry loop fixed** (#1529, #1530, #1532; OT-RFC-56 Fixes 2 & 3): an ingest-side guard rejects oversized literals and tombstones the offending assertion instead of re-fetching it repeatedly, a boot-time sweep clears graphs affected before the guard existed, and producer-side guards stop a node from emitting oversized literals in the first place.
+- **`agents/_meta` kept off the sync plane** (#1526, follow-up #1533): the per-agent `_meta` graph is no longer carried on the sync/catch-up path (reduces sync fan-out load), with retention behaviour corrected in the post-merge review follow-up.
+- **Node-UI metric store-scans gated on consumer presence** (#1525): the dashboard metric collector no longer issues store `COUNT` scans when nothing is consuming them, removing idle store load.
+- **npm tarball now ships runtime assets** (#1523): `network/*.json` overlays and `project.json` are guaranteed to be packed into the `@origintrail-official/dkg` tarball. The 10.0.4 tarball omitted them (a turbo-cache prepack regression), so npm-installed nodes silently fell back to built-in network defaults.
+
+### Changed
+
+- **Devnet harness hygiene** (#1521): core-peers restore and the RS-rotation window fixes carried over from the 10.0.4 test run (test infrastructure only).
+
+### Deployment
+
+- **Contract sources/ABIs change in this release** (PublishingConviction 10.0.8, #1524) — this is **not** a "no contract changes" release.
+- **Testnet (Base Sepolia): deployed.** PublishingConviction 10.0.8 at `0x99341dEb6cdfACA94F359591ED3fD20da1901DAf` (deployment block 43880924); the updated deployment registry ships with this release.
+- **Mainnet (Base + Gnosis): pending.** Both chains remain on PublishingConviction 10.0.7 at release-cut time; the 10.0.8 deploy and PCA emission-schedule migration are a separate, coordinated on-chain activity. No node action is required for that deploy — nodes hot-swap the new logic from the Hub.
+
 ## [10.0.4] - 2026-07-08
 
 2026-07-07 mainnet-incident hardening + transaction-dispatcher release. Publisher-side: ACK candidacy ranks-not-gates, empty-reply retry, responder ACK deadlines, SWM merkle-filter parity. Network-side: relay-watchdog churn fix and sync-storm calming (bounded catch-up fan-out, superseded-resume loop kill). Chain-side: the universal per-wallet transaction dispatcher lands end-to-end — every node write serialized per wallet, funding-aware generalized signer selection, and Random Sampling rotating across registered operational wallets instead of pinning wallet #0. Plus the codified manual release flow with signed-tag gates. **No smart-contract changes — no deployment required** (no Solidity source, ABI, or mainnet/testnet deployment-registry changes since 10.0.3).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dkg-v10",
-  "version": "10.0.4",
+  "version": "10.0.5",
   "private": true,
   "packageManager": "pnpm@10.28.1",
   "dkgBuild": {

--- a/packages/adapter-elizaos/package.json
+++ b/packages/adapter-elizaos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-elizaos",
-  "version": "10.0.4",
+  "version": "10.0.5",
   "description": "ElizaOS plugin adapter — turns any ElizaOS agent into a DKG V10 node",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapter-hermes/package.json
+++ b/packages/adapter-hermes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-hermes",
-  "version": "10.0.4",
+  "version": "10.0.5",
   "description": "Hermes Agent adapter — connects Hermes AI agents to a DKG V10 node for verifiable shared memory",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapter-openclaw/package.json
+++ b/packages/adapter-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-openclaw",
-  "version": "10.0.4",
+  "version": "10.0.5",
   "description": "OpenClaw plugin adapter for connecting a DKG V10 node and chat bridge to an OpenClaw agent",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-agent",
-  "version": "10.0.4",
+  "version": "10.0.5",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/chain/package.json
+++ b/packages/chain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-chain",
-  "version": "10.0.4",
+  "version": "10.0.5",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg",
-  "version": "10.0.4",
+  "version": "10.0.5",
   "type": "module",
   "main": "dist/cli.js",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-core",
-  "version": "10.0.4",
+  "version": "10.0.5",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/epcis/package.json
+++ b/packages/epcis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-epcis",
-  "version": "10.0.4",
+  "version": "10.0.5",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/evm-module/deployments/base_sepolia_v10_contracts.json
+++ b/packages/evm-module/deployments/base_sepolia_v10_contracts.json
@@ -235,12 +235,12 @@
             "deployed": true
         },
         "PublishingConviction": {
-            "evmAddress": "0x7bEf1bb2139d186d0888329607762D0833C9EC4a",
-            "version": "10.0.7",
-            "gitBranch": "deploy/10.0.2-mainnet-registries",
-            "gitCommitHash": "f175fd4ab342e90db09eb9a8948b244ae38f66c6",
-            "deploymentBlock": 43583799,
-            "deploymentTimestamp": 1782935888267,
+            "evmAddress": "0x99341dEb6cdfACA94F359591ED3fD20da1901DAf",
+            "version": "10.0.8",
+            "gitBranch": "main",
+            "gitCommitHash": "6a91a16db87db6f5765456c8d7032a6a1031541e",
+            "deploymentBlock": 43880924,
+            "deploymentTimestamp": 1783530138645,
             "deployed": true
         },
         "DKGPublishingConvictionNFT": {

--- a/packages/evm-module/package.json
+++ b/packages/evm-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-evm-module",
-  "version": "10.0.4",
+  "version": "10.0.5",
   "description": "DKG V10 smart contracts (forked from V8 dkg-evm-module)",
   "license": "Apache-2.0",
   "private": true,

--- a/packages/graph-viz/package.json
+++ b/packages/graph-viz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-graph-viz",
-  "version": "10.0.4",
+  "version": "10.0.5",
   "description": "RDF Knowledge Graph Visualizer — force-directed graph rendering with hexagonal nodes, declarative view configs, RDF-native data loading, and SPARQL-driven views",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/kafka-plugin/package.json
+++ b/packages/kafka-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/kafka-plugin",
-  "version": "10.0.4",
+  "version": "10.0.5",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mcp-dkg/package.json
+++ b/packages/mcp-dkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-mcp",
-  "version": "10.0.4",
+  "version": "10.0.5",
   "description": "MCP server that exposes the local DKG daemon (projects, sub-graphs, activity, chat) to Cursor, Claude Code, and any other MCP-aware coding assistant.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/network-sim/package.json
+++ b/packages/network-sim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-network-sim",
-  "version": "10.0.4",
+  "version": "10.0.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/node-ui/package.json
+++ b/packages/node-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-node-ui",
-  "version": "10.0.4",
+  "version": "10.0.5",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/okf/package.json
+++ b/packages/okf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-okf",
-  "version": "10.0.4",
+  "version": "10.0.5",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/publisher/package.json
+++ b/packages/publisher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-publisher",
-  "version": "10.0.4",
+  "version": "10.0.5",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-query",
-  "version": "10.0.4",
+  "version": "10.0.5",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/random-sampling/package.json
+++ b/packages/random-sampling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-random-sampling",
-  "version": "10.0.4",
+  "version": "10.0.5",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-storage",
-  "version": "10.0.4",
+  "version": "10.0.5",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## What

Phase 2 version-bump PR for the **10.0.5** release. Cut from `main` tip (`6a91a16db`) — content is **identical** to the already-published `10.0.5-canary.1` testnet build. No new content merges into this (runbook D1: scope frozen at the canary commit).

Two commits:

1. **`chore(release): 10.0.5`** — bump all 20 workspace `package.json` from `10.0.4` → `10.0.5` (retargeted from the `10.0.5-canary.1` string the canary was published with) + a new `CHANGELOG.md` `[10.0.5]` section.
2. **`chore(evm-module): rescue Base Sepolia 10.0.8 deploy record`** — commits the `base_sepolia_v10_contracts.json` 10.0.8 registry update (PC `0x99341dEb…`, block 43880924) that so far existed **only** in the dirty release worktree used to publish the canary. Mechanics, not content (runbook D1); rides this PR so git holds the sole record of the testnet deploy.

## Changelog `[10.0.5]` summary

- **Added** — PublishingConviction 10.0.8 contract updates (sources + ABIs) (#1524)
- **Fixed** — oversize-literal retry-loop fix (#1529/#1530/#1532); `agents/_meta` kept off the sync plane (#1526, #1533); node-UI metric store-scan gating (#1525); npm tarball runtime-asset fix (#1523)
- **Changed** — devnet harness hygiene (#1521, tests only)
- **Deployment** — testnet Base Sepolia deployed; mainnet Base + Gnosis still on 10.0.7 (10.0.8 deploy is separate/pending)

## Verification

- `pnpm release:verify-versions --version 10.0.5` → 20 files at `10.0.5`
- `pnpm-lock.yaml` unchanged (workspace deps use `workspace:*`)

## Gates still open (for the tag/publish that follows the merge — not review blockers)

- [ ] devnet gate on the **merged** bump commit
- [ ] testnet node canary smoke (D4b): a node confirmed on `10.0.5-canary.1` via `/api/status`
- [ ] if Phase 1 deploys mainnet PC before this merges, fold the mainnet PC addresses into the CHANGELOG **Deployment** section

🤖 Generated with [Claude Code](https://claude.com/claude-code)
