### PR TITLE
fix(agent): widen policy-read timeout to span one RPC failover hop (#1337)

### DIFF
--- a/packages/agent/src/dkg-agent-constants.ts
+++ b/packages/agent/src/dkg-agent-constants.ts
@@ -291,14 +291,24 @@ export const ON_CHAIN_PUBLISH_POLICY_CACHE_TTL_MS = 60_000;
 
 /**
  * #884 review — bound the on-chain liveness / access-policy reads on the
- * share/promote/publish hot path (`isContextGraphPublicOnChain`). Mirrors
- * `CHAIN_RPC_FALLBACK_TIMEOUT_MS` in `DKGAgent.getContextGraphOnChainPolicy`:
- * if the RPC layer HANGS (rather than rejecting), the helper must still
- * resolve so the caller fails closed to "not public / not known" instead of
- * blocking the request indefinitely. 2.5s stays well under the daemon-ready
- * budget while allowing a single slow eth_call hop under normal load.
+ * share/promote/publish hot path (`isContextGraphPublicOnChain`). If the RPC
+ * layer HANGS (rather than rejecting), the helper must still resolve so the
+ * caller fails closed to "not public / not known" instead of blocking the
+ * request indefinitely.
+ *
+ * #1337 — sized to span ONE multi-RPC failover hop. The chain adapter caps
+ * each read attempt at `RPC_READ_STALL_TIMEOUT_MS` (4_000ms in dkg-chain)
+ * before failing over to the next endpoint, so the old 2.5s budget fired
+ * BEFORE a degraded primary could fail over to a healthy backup — the policy
+ * read fail-closed and never benefited from failover. 6.5s = one 4s hop cap +
+ * a ~2.5s healthy backup read, so a stalled primary fails over and resolves
+ * instead of fail-closing. Still well under the ~45s daemon-ready budget, and
+ * a genuinely-hung chain is bounded: fail-closed is the safe direction and the
+ * policy is cached for `ON_CHAIN_PUBLISH_POLICY_CACHE_TTL_MS` (60s), so at most
+ * one slow cold read per CG per minute. Healthy primaries answer well under
+ * 2.5s and are unaffected.
  */
-export const CHAIN_POLICY_READ_TIMEOUT_MS = 2_500;
+export const CHAIN_POLICY_READ_TIMEOUT_MS = 6_500;
 
 // ── SWM sender-key ────────────────────────────────────────────────────
 /** Shared operation context for pending sender-key drain logging. */

--- a/packages/agent/test/swm-public-cg-plaintext.test.ts
+++ b/packages/agent/test/swm-public-cg-plaintext.test.ts
@@ -22,6 +22,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { ethers } from 'ethers';
 import { DKGAgent } from '../src/dkg-agent.js';
+import { CHAIN_POLICY_READ_TIMEOUT_MS } from '../src/dkg-agent-constants.js';
 
 // Hand-rolled call recorder: records every invocation's args and delegates to
 // the real impl, replacing the DI-seam spies on this file's agent-like stub.
@@ -293,7 +294,7 @@ describe('DKGAgent.isContextGraphPublicOnChain', () => {
       // Override with a hung read so the bounded race trips the timeout path.
       agentLike.chain.getContextGraphNameHash = recorder(() => new Promise(() => {}));
       const pending = isPublic(agentLike, cgId);
-      await vi.advanceTimersByTimeAsync(3_000);
+      await vi.advanceTimersByTimeAsync(7_000); // #1337: past the 6.5s policy-read budget (was 3_000 for the old 2.5s)
       await expect(pending).resolves.toBe(false);
       expect((agentLike.chain.getContextGraphAccessPolicy as any).calls).toEqual([]);
     } finally {
@@ -417,7 +418,7 @@ describe('DKGAgent.isContextGraphPublicOnChain', () => {
       // Liveness probe hangs (never resolves / never rejects) instead of failing.
       agentLike.chain.isContextGraphActiveOnChain = recorder(() => new Promise(() => {}));
       const pending = isPublic(agentLike);
-      await vi.advanceTimersByTimeAsync(3_000);
+      await vi.advanceTimersByTimeAsync(7_000); // #1337: past the 6.5s policy-read budget (was 3_000 for the old 2.5s)
       await expect(pending).resolves.toBe(false);
       expect(agentLike.log.warn.calls).toContainEqual([
         expect.anything(),
@@ -437,7 +438,7 @@ describe('DKGAgent.isContextGraphPublicOnChain', () => {
       // Liveness resolves (live), but the policy read hangs.
       agentLike.chain.getContextGraphAccessPolicy = recorder(() => new Promise(() => {}));
       const pending = isPublic(agentLike);
-      await vi.advanceTimersByTimeAsync(3_000);
+      await vi.advanceTimersByTimeAsync(7_000); // #1337: past the 6.5s policy-read budget (was 3_000 for the old 2.5s)
       await expect(pending).resolves.toBe(false);
       expect(agentLike.log.warn.calls).toContainEqual([
         expect.anything(),
@@ -591,5 +592,22 @@ describe('DKGAgent publish-inline gating respects on-chain public policy', () =>
     await expect(resolveInline(agentLike, '42')).rejects.toThrow(/publish access-policy is unknown/);
     expect((agentLike.chain.isContextGraphActiveOnChain as any).calls).toEqual([]);
     expect((agentLike.chain.getContextGraphAccessPolicy as any).calls).toEqual([]);
+  });
+});
+
+// #1337: the isContextGraphPublicOnChain policy-read race must span at least one
+// multi-RPC failover hop, else a degraded primary fail-closes (encrypt) before
+// the chain adapter can fail over to a healthy backup. The adapter caps each
+// read attempt at RPC_READ_STALL_TIMEOUT_MS (4_000ms in dkg-chain) before moving
+// to the next endpoint, so the policy budget must exceed it. Static + non-flaky;
+// red if the constant is reverted to the old 2.5s.
+describe('CHAIN_POLICY_READ_TIMEOUT_MS failover-hop budget (#1337)', () => {
+  // Keep in sync with RPC_READ_STALL_TIMEOUT_MS in
+  // packages/chain/src/evm-adapter-constants.ts (not re-exported from the chain
+  // package index, so mirrored here rather than imported).
+  const RPC_READ_STALL_TIMEOUT_MS = 4_000;
+
+  it('spans at least one RPC failover hop (> the adapter per-attempt cap)', () => {
+    expect(CHAIN_POLICY_READ_TIMEOUT_MS).toBeGreaterThan(RPC_READ_STALL_TIMEOUT_MS);
   });
 });


### PR DESCRIPTION
## Summary

- `isContextGraphPublicOnChain` (the SWM-plaintext gate on the share/promote/publish hot path) races its on-chain policy reads against `CHAIN_POLICY_READ_TIMEOUT_MS` and **fail-closes** (treat CG as NOT public → keep SWM encrypted) on timeout. That budget was **2.5s**, but the chain adapter caps each read attempt at `RPC_READ_STALL_TIMEOUT_MS = 4s` before failing over to the next endpoint — so under a **degraded primary** the 2.5s race fired *before* one failover hop could complete, and the policy read never benefited from multi-RPC failover.
- Widen `CHAIN_POLICY_READ_TIMEOUT_MS` **2500 → 6500** (one 4s failover-hop cap + a ~2.5s healthy backup read), so a stalled primary fails over to a healthy backup and **resolves instead of fail-closing**.
- Bounded impact: fail-closed stays the **safe** direction (SWM stays encrypted, #884, unchanged); the policy is cached 60s (`ON_CHAIN_PUBLISH_POLICY_CACHE_TTL_MS`); healthy primaries answer well under 2.5s and are unaffected; 6.5s is still far under the ~45s daemon-ready budget.

**Scope:** only the `isContextGraphPublicOnChain` hot-path timeout that the issue names. The separate `getContextGraphOnChainPolicy` fallback (`CHAIN_RPC_FALLBACK_TIMEOUT_MS`, on the daemon-ready/registration path) is deliberately kept tight for the readiness budget and is **left unchanged**.

## Related

- Fixes #1337
- Sibling of #1535 (#1340) — both "a read that doesn't benefit from multi-RPC failover" (that one = chain pkg / a hard failure; this one = agent pkg / latency-only). Independent.
- Follow-up (not this PR): Mechanism B — endpoint pinning of the CG-register approve→retry (#1340 residual), overlaps #1454.

## Files changed

| File | What |
|------|------|
| `packages/agent/src/dkg-agent-constants.ts` | `CHAIN_POLICY_READ_TIMEOUT_MS` 2500 → 6500; doc comment rewritten to explain the failover-hop sizing + bounded impact |
| `packages/agent/test/swm-public-cg-plaintext.test.ts` | 3 hung-RPC fail-closed tests advance past the new 6.5s budget; new static invariant test `CHAIN_POLICY_READ_TIMEOUT_MS > RPC_READ_STALL_TIMEOUT_MS` (red if reverted to 2.5s) |

## Test plan

- [x] `cd packages/agent && npx vitest run swm-public-cg-plaintext dkg-agent-on-chain-policy encrypt-inline-policy` → **78 pass** (swm 39 incl. new invariant + updated advances; on-chain-policy 15 unchanged — confirms the separate `CHAIN_RPC_FALLBACK_TIMEOUT_MS` path is untouched; encrypt-inline 24).
- [x] Red-on-revert: invariant test **fails** when the constant is reverted to `2_500`.
- [x] `npx tsc --noEmit` (agent) clean; workspace build exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
