### PR TITLE
fix(chain): RPC-failover endpoint stickiness (#1340 retry residual + #1337)

### DIFF
--- a/packages/chain/src/endpoint-stickiness.ts
+++ b/packages/chain/src/endpoint-stickiness.ts
@@ -94,15 +94,18 @@ export class EndpointStickiness {
     // idx < 0: preferred no longer configured (pool rebind dropped it).
     // idx === 0: preferred IS the primary — canonical already tries it first.
     if (idx <= 0) return canonical;
-    // The TTL re-probe is a READ-recovery mechanism: it periodically re-tries the
-    // configured primary so a recovered primary resumes serving READS. It must NOT
-    // redirect a nonce-critical populate — a primary can be transport-healthy while
-    // still behind the block/txpool state that advanced the signer nonce, so
-    // populating there would sign a stale/duplicate nonce. A `nonceWrite` therefore
-    // keeps its populate-proven backend past the TTL; writes return to the primary
-    // only once a READ re-probe CLEARS the preference on primary recovery (or the
-    // backend fails, see recordFailure).
-    if (intent !== 'nonceWrite' && this.cfg.now() >= pref.primaryProbeDueAt) {
+    // The TTL re-probe is a READ-recovery mechanism (only `stickyRead`): it
+    // periodically re-tries the configured primary so a recovered primary resumes
+    // serving reads. It must NOT redirect ANY write — a primary can be
+    // transport-healthy while still behind the block/txpool state that advanced the
+    // signer nonce, so (a) a `nonceWrite` populate there would sign a stale/duplicate
+    // nonce, and (b) a `write` broadcast/receipt there would split a backup-signed tx
+    // across endpoints and a lagging primary could reject the backup's nonce
+    // terminally before the loop reaches the backup. Writes therefore keep the
+    // write-proven backend past the TTL; they return to the primary only once a READ
+    // re-probe CLEARS the preference on primary recovery (or the backend fails, see
+    // recordFailure).
+    if (intent === 'stickyRead' && this.cfg.now() >= pref.primaryProbeDueAt) {
       // Re-probe the configured primary this op; schedule the next re-probe one TTL
       // out so we don't re-stall on it again until then.
       this.state = { ...pref, primaryProbeDueAt: this.cfg.now() + this.cfg.ttlMs };

--- a/packages/chain/src/endpoint-stickiness.ts
+++ b/packages/chain/src/endpoint-stickiness.ts
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * `EndpointStickiness` — the transport-ordering preference state machine extracted
+ * from `RpcFailoverClient` (Mechanism B, #1340 retry residual + #1337 policy-read
+ * fail-close). It owns the "prefer the last-good backend, re-probe the primary at
+ * most once per TTL" decision as a single, typed, testable unit so the four
+ * per-endpoint failover loops don't each hand-wire the ordering + outcome
+ * bookkeeping.
+ *
+ * It is PURE TRANSPORT-ORDERING state — it never signs, broadcasts, holds a WAL /
+ * serializer / nonce, or gates a return. It only decides which endpoint each loop
+ * TRIES FIRST and remembers where the last op succeeded. Callers pass a
+ * {@link StickinessIntent} describing the operation; the state machine encodes all
+ * the transition rules that were previously scattered boolean parameters:
+ *
+ *   State: `none` | `preferred{ url, source: 'read' | 'write', primaryProbeDueAt }`
+ *     - `source` distinguishes a preference proven by a READ from one proven by a
+ *       nonce-critical POPULATE. A read-established backend may lag the signer's
+ *       pending-nonce state, so a `nonceWrite` (populate) MUST NOT start there —
+ *       it re-derives nonce from canonical (primary-first = authoritative) until a
+ *       populate proves the backend.
+ *
+ *   Intents:
+ *     - `stickyRead`      — a normal read: prefer the last-good backend (either source).
+ *     - `transparentRead` — a TIP-sensitive read (current head / latest block):
+ *       canonical order AND no state mutation (a lagging preferred would make the
+ *       tip non-monotonic; and it must not clear a preference the heavy paths rely on).
+ *     - `nonceWrite`      — `populateAndSign`: prefer ONLY a WRITE-proven backend.
+ *     - `write`           — `broadcast` / `getReceipt`: nonce-free, prefer the
+ *       last-good backend; BUT if the primary takes over a write as a fallback
+ *       (the preferred backend failed the write op), the preferred backend's nonce
+ *       view is now stale, so downgrade `source` write→read.
+ *
+ * All methods are synchronous, so concurrent ops on one instance can only observe
+ * a slightly stale order, never torn state.
+ */
+
+/** Minimal endpoint shape the ordering needs — keyed on `rpcUrl` (survives a live
+ *  provider-pool rebind, unlike a positional index). */
+export interface StickyEndpoint {
+  rpcUrl: string;
+}
+
+export type StickinessIntent = 'stickyRead' | 'transparentRead' | 'nonceWrite' | 'write';
+
+type StickyState =
+  | { kind: 'none' }
+  | { kind: 'preferred'; url: string; source: 'read' | 'write'; primaryProbeDueAt: number };
+
+export interface StickinessConfig {
+  /** Monotonic-ish clock (ms). Injected for deterministic cadence tests. */
+  now: () => number;
+  /** Primary re-probe cadence (ms). */
+  ttlMs: number;
+  /** LIVE kill-switch predicate — resolved at the CONFIG boundary (e.g. the
+   *  adapter reads `DKG_DISABLE_RPC_STICKINESS`), so the transport core has no
+   *  process-global dependency. */
+  isEnabled: () => boolean;
+  /** Optional host-only observability hook fired once per establishment edge. */
+  onEstablished?: (rpcUrl: string) => void;
+}
+
+export class EndpointStickiness {
+  private state: StickyState = { kind: 'none' };
+
+  constructor(private readonly cfg: StickinessConfig) {}
+
+  /** Whether a preference is currently active (test/introspection helper). */
+  hasPreference(): boolean {
+    return this.state.kind === 'preferred';
+  }
+
+  /**
+   * Decide the per-op iteration order over `canonical` (the live configured order,
+   * index 0 = primary). Returns canonical unless a compatible preference is active
+   * and inside the current re-probe window, in which case the preferred endpoint is
+   * MOVED to the front (spliced out + unshifted — never duplicated, so fall-through
+   * still visits every endpoint exactly once). A `transparentRead` always uses
+   * canonical; a `nonceWrite` uses canonical unless the preference is WRITE-proven.
+   * When the re-probe deadline has passed this op probes the primary first AND
+   * re-arms the deadline `+ttlMs` (at most one primary re-stall per TTL).
+   */
+  order<T extends StickyEndpoint>(canonical: T[], intent: StickinessIntent): T[] {
+    if (intent === 'transparentRead' || !this.cfg.isEnabled() || this.state.kind !== 'preferred') {
+      return canonical;
+    }
+    const pref = this.state; // narrowed to the 'preferred' variant
+    // A nonce-critical populate must not START on a backend proven only by a READ
+    // (it may lag the signer's pending nonce → a stale-nonce sign → phantom
+    // `nonce too low` success). Fall back to canonical (authoritative nonce).
+    if (intent === 'nonceWrite' && pref.source !== 'write') return canonical;
+    const idx = canonical.findIndex((e) => e.rpcUrl === pref.url);
+    // idx < 0: preferred no longer configured (pool rebind dropped it).
+    // idx === 0: preferred IS the primary — canonical already tries it first.
+    if (idx <= 0) return canonical;
+    if (this.cfg.now() >= pref.primaryProbeDueAt) {
+      // Re-probe the configured primary this op; schedule the next re-probe one TTL
+      // out so we don't re-stall on it again until then.
+      this.state = { ...pref, primaryProbeDueAt: this.cfg.now() + this.cfg.ttlMs };
+      return canonical;
+    }
+    const reordered = canonical.slice();
+    const [preferred] = reordered.splice(idx, 1);
+    reordered.unshift(preferred);
+    return reordered;
+  }
+
+  /**
+   * Record that `endpoint` served the op (intent) successfully, `triedFirst` = it
+   * was the first endpoint attempted (loop index 0). No-op for `transparentRead`
+   * or when disabled. Encodes every transition:
+   *   - primary succeeded, tried FIRST → CLEAR (a genuine canonical/TTL re-probe
+   *     proved the primary healthy again).
+   *   - primary succeeded as a WRITE fallback → the preferred backend failed the
+   *     write op and the tx moved to the primary, so the backend's nonce view is
+   *     stale → downgrade `source` write→read (keeps the read-preference, but the
+   *     next `nonceWrite` re-derives nonce from canonical). NOT for reads (a read
+   *     reaching the primary as a fallback doesn't advance the nonce, and
+   *     downgrading could break a legitimate read-your-write allowance re-read).
+   *   - a backend succeeded → establish (arm the deadline + fire `onEstablished`)
+   *     or silently re-point; `source` = 'write' for a populate, else 'read'. A
+   *     later populate on the SAME preferred upgrades 'read'→'write'.
+   */
+  recordSuccess<T extends StickyEndpoint>(
+    endpoint: T,
+    canonical: T[],
+    intent: StickinessIntent,
+    triedFirst: boolean,
+  ): void {
+    if (intent === 'transparentRead' || !this.cfg.isEnabled()) return;
+    const primaryUrl = canonical[0]?.rpcUrl;
+    const isPopulate = intent === 'nonceWrite';
+    const isWriteOp = intent === 'nonceWrite' || intent === 'write';
+    if (endpoint.rpcUrl === primaryUrl) {
+      if (triedFirst) {
+        this.state = { kind: 'none' };
+      } else if (isWriteOp && this.state.kind === 'preferred' && this.state.source === 'write') {
+        this.state = { ...this.state, source: 'read' };
+      }
+      return;
+    }
+    if (this.state.kind !== 'preferred') {
+      this.state = {
+        kind: 'preferred',
+        url: endpoint.rpcUrl,
+        source: isPopulate ? 'write' : 'read',
+        primaryProbeDueAt: this.cfg.now() + this.cfg.ttlMs,
+      };
+      this.cfg.onEstablished?.(endpoint.rpcUrl);
+    } else if (this.state.url !== endpoint.rpcUrl) {
+      // Re-point to a different backup (the old one also degraded). Keep the
+      // existing deadline (a hop within an ongoing degradation episode, already
+      // counted at establishment — no new `onEstablished`).
+      this.state = { ...this.state, url: endpoint.rpcUrl, source: isPopulate ? 'write' : 'read' };
+    } else if (isPopulate && this.state.source !== 'write') {
+      // Same preferred backend, now PROVEN nonce-safe by a populate → upgrade.
+      // Never DOWNGRADE on a read (a read hitting the write-proven backend doesn't
+      // un-prove its nonce view).
+      this.state = { ...this.state, source: 'write' };
+    }
+  }
+}

--- a/packages/chain/src/endpoint-stickiness.ts
+++ b/packages/chain/src/endpoint-stickiness.ts
@@ -94,7 +94,15 @@ export class EndpointStickiness {
     // idx < 0: preferred no longer configured (pool rebind dropped it).
     // idx === 0: preferred IS the primary — canonical already tries it first.
     if (idx <= 0) return canonical;
-    if (this.cfg.now() >= pref.primaryProbeDueAt) {
+    // The TTL re-probe is a READ-recovery mechanism: it periodically re-tries the
+    // configured primary so a recovered primary resumes serving READS. It must NOT
+    // redirect a nonce-critical populate — a primary can be transport-healthy while
+    // still behind the block/txpool state that advanced the signer nonce, so
+    // populating there would sign a stale/duplicate nonce. A `nonceWrite` therefore
+    // keeps its populate-proven backend past the TTL; writes return to the primary
+    // only once a READ re-probe CLEARS the preference on primary recovery (or the
+    // backend fails, see recordFailure).
+    if (intent !== 'nonceWrite' && this.cfg.now() >= pref.primaryProbeDueAt) {
       // Re-probe the configured primary this op; schedule the next re-probe one TTL
       // out so we don't re-stall on it again until then.
       this.state = { ...pref, primaryProbeDueAt: this.cfg.now() + this.cfg.ttlMs };
@@ -165,6 +173,27 @@ export class EndpointStickiness {
       // Never DOWNGRADE on a read (a read hitting the write-proven backend doesn't
       // un-prove its nonce view).
       this.state = { ...this.state, source: 'write' };
+    }
+  }
+
+  /**
+   * Record that `endpoint` FAILED the op (errored → triggered failover), so the
+   * failover loop is moving on to the next endpoint. If the failed endpoint is the
+   * current preferred, DE-PREFER it (drop to `none`): a degraded/hanging preferred
+   * backup must not keep being tried first, or every subsequent op re-stalls on it
+   * until the TTL re-probe — reintroducing the very fail-close this cadence exists
+   * to prevent, just with the backup as the staller. A later success re-establishes
+   * the new last-good backend. No-op for `transparentRead` (non-mutating) or when
+   * the failed endpoint isn't the preferred (e.g. a re-probe where the PRIMARY
+   * fails is expected and must not disturb the preference). This is called ONLY on
+   * a real error/failover, NOT on a benign `null` (e.g. getReceipt's not-yet-mined
+   * null continues the loop without a failover), so a healthy-but-empty backup
+   * stays preferred.
+   */
+  recordFailure<T extends StickyEndpoint>(endpoint: T, intent: StickinessIntent): void {
+    if (intent === 'transparentRead' || !this.cfg.isEnabled()) return;
+    if (this.state.kind === 'preferred' && this.state.url === endpoint.rpcUrl) {
+      this.state = { kind: 'none' };
     }
   }
 }

--- a/packages/chain/src/endpoint-stickiness.ts
+++ b/packages/chain/src/endpoint-stickiness.ts
@@ -149,10 +149,17 @@ export class EndpointStickiness {
       };
       this.cfg.onEstablished?.(endpoint.rpcUrl);
     } else if (this.state.url !== endpoint.rpcUrl) {
-      // Re-point to a different backup (the old one also degraded). Keep the
-      // existing deadline (a hop within an ongoing degradation episode, already
-      // counted at establishment — no new `onEstablished`).
-      this.state = { ...this.state, url: endpoint.rpcUrl, source: isPopulate ? 'write' : 'read' };
+      // Re-point to a different backup (the old one also degraded, or was dropped
+      // by a live pool rebind). Keep an in-window deadline (a hop within an ongoing
+      // degradation episode, already counted at establishment — no new
+      // `onEstablished`), BUT if the carried-over deadline has already EXPIRED, arm
+      // a fresh one: otherwise a rebind that swaps in a new backup while the old
+      // deadline is stale would re-probe the primary on EVERY subsequent op (the
+      // collapse-to-index-0 this cadence exists to prevent).
+      const primaryProbeDueAt = this.cfg.now() >= this.state.primaryProbeDueAt
+        ? this.cfg.now() + this.cfg.ttlMs
+        : this.state.primaryProbeDueAt;
+      this.state = { ...this.state, url: endpoint.rpcUrl, source: isPopulate ? 'write' : 'read', primaryProbeDueAt };
     } else if (isPopulate && this.state.source !== 'write') {
       // Same preferred backend, now PROVEN nonce-safe by a populate → upgrade.
       // Never DOWNGRADE on a read (a read hitting the write-proven backend doesn't

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -110,21 +110,6 @@ const HUB_BINDING_INVALIDATORS = new Map<string, HubBindingInvalidationPolicy>(
 
 const KA_HIGH_WATER_VIEW_SIGNATURE = 'getMaxKaNumberForAuthor(address)';
 
-/**
- * Sentinel for a nullable read (`getBlock(n)`, `eth_getTransactionReceipt`, …)
- * whose queried endpoint returned `null` — meaning "this endpoint doesn't have
- * the object (yet)", NOT a definitive answer. Thrown inside the read lambda so
- * `readProviderRetryingNull` treats it as a retryable condition and tries another
- * endpoint (a lagging endpoint must not force a fallback when a healthy backup
- * already has the object).
- */
-class NullReadSentinelError extends Error {
-  constructor(label: string) {
-    super(`${label}: object not present on this endpoint`);
-    this.name = 'NullReadSentinelError';
-  }
-}
-
 type IdentityIdCacheEntry = {
   identityId: bigint;
   ttlMs: number;
@@ -1256,57 +1241,23 @@ export class EVMChainAdapterBase {
 
   /**
    * Raw PROVIDER read whose `null` is a "not on this endpoint (yet)" signal, not a
-   * definitive answer — so a `null` FAILS OVER to the other endpoints (a lagging
-   * endpoint must not hide an object a healthy one has) and never records a sticky
-   * success. Returns the first NON-null result, or `null` ONLY when the failover
-   * loop exhausted with EVERY retryable failure being the null sentinel (no
-   * endpoint had a transport problem that could be masking the object).
-   *
-   * The all-null decision is ORDER-INDEPENDENT: it is made from whether ANY real
-   * transport failure occurred across all attempts (`sawTransportFailure`), NOT
-   * from `ChainRpcTransportError.cause` (which is only the LAST failure and would
-   * flip the result based on sticky/canonical attempt order). A non-retryable
-   * provider error (e.g. `INVALID_ARGUMENT`) or a genuine transport exhaustion
-   * PROPAGATES — it is never masked as a `null`.
+   * definitive answer. A `null` FAILS OVER to the other endpoints (a lagging
+   * endpoint must not hide an object a healthy one has) WITHOUT de-preferring that
+   * endpoint or emitting failover/exhaustion telemetry — because an empty result is
+   * not a transport failure. Returns the first NON-null result, or `null` only when
+   * EVERY endpoint returned `null` and none had a real transport error. A
+   * non-retryable provider error (e.g. `INVALID_ARGUMENT`) or a genuine transport
+   * exhaustion PROPAGATES — never masked as `null`. The empty-vs-error distinction
+   * (and thus the order-independent all-null decision) is handled by the transport
+   * loop via `ReadOpts.isEmptyResult`, so no sentinel exception is tunnelled
+   * through the generic failover/telemetry path.
    */
-  protected async readProviderRetryingNull<T>(
+  protected readProviderRetryingNull<T>(
     label: string,
     fn: (provider: JsonRpcProvider) => Promise<T>,
     opts?: ReadOpts,
   ): Promise<T | null> {
-    const baseIsRetryable = opts?.isRetryable ?? isRetryableRpcError;
-    let sawTransportFailure = false;
-    try {
-      return await this.readProvider<T>(
-        label,
-        async (provider) => {
-          try {
-            const result = await fn(provider);
-            if (result == null) throw new NullReadSentinelError(label);
-            return result;
-          } catch (err) {
-            // A REAL (non-sentinel) retryable failure means this endpoint's null
-            // absence — if any — can't be trusted as "object not here". Record it
-            // so the all-null fallback is only taken when NO transport failure
-            // occurred, independent of attempt order.
-            if (!(err instanceof NullReadSentinelError) && baseIsRetryable(err)) {
-              sawTransportFailure = true;
-            }
-            throw err;
-          }
-        },
-        { ...opts, isRetryable: (err) => err instanceof NullReadSentinelError || baseIsRetryable(err) },
-      );
-    } catch (err) {
-      if (
-        err instanceof ChainRpcTransportError
-        && err.code === 'RPC_ENDPOINTS_EXHAUSTED'
-        && !sawTransportFailure
-      ) {
-        return null; // every endpoint returned the null sentinel → honest "not found"
-      }
-      throw err;
-    }
+    return this.readProvider<T | null>(label, fn, { ...opts, isEmptyResult: (v) => v == null });
   }
 
   /**

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -2372,7 +2372,9 @@ export class EVMChainAdapterBase {
   }
 
   protected async getBlockTimestamp(blockNumber: number): Promise<number> {
-    const block = await this.readProvider('getBlock', (p) => p.getBlock(blockNumber));
+    // TIP-SENSITIVE: a near-tip block can be missing (null) on a lagging sticky
+    // backend that hasn't imported it yet → read canonical + preference-transparent.
+    const block = await this.readProvider('getBlock', (p) => p.getBlock(blockNumber), { skipPreferred: true });
     return block?.timestamp ?? 0;
   }
 
@@ -3318,7 +3320,11 @@ export class EVMChainAdapterBase {
   }
 
   async getBlockNumber(): Promise<number> {
-    return this.readProvider('getBlockNumber', (p) => p.getBlockNumber());
+    // TIP-SENSITIVE: the current head drives the event-lane cursor, proof-
+    // challenge block, and finalization reads. A lagging sticky backend would
+    // make the head non-monotonic across calls (poller moving backwards / re-
+    // scanning), so read canonical-order + preference-transparent.
+    return this.readProvider('getBlockNumber', (p) => p.getBlockNumber(), { skipPreferred: true });
   }
 
   getProvider(): JsonRpcProvider {

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -110,6 +110,20 @@ const HUB_BINDING_INVALIDATORS = new Map<string, HubBindingInvalidationPolicy>(
 
 const KA_HIGH_WATER_VIEW_SIGNATURE = 'getMaxKaNumberForAuthor(address)';
 
+/**
+ * A `getBlock(n)` that returned `null` because the queried endpoint hasn't
+ * imported that (already-mined) block yet. Thrown inside `getBlockTimestamp`'s
+ * read lambda so the failover loop treats it as a retryable condition and tries
+ * another endpoint (a lagging endpoint must not force a bogus `blockTimestamp: 0`
+ * when a healthy backup already has the block).
+ */
+class BlockNotYetImportedError extends Error {
+  constructor(blockNumber: number) {
+    super(`block ${blockNumber} not yet imported on this endpoint`);
+    this.name = 'BlockNotYetImportedError';
+  }
+}
+
 type IdentityIdCacheEntry = {
   identityId: bigint;
   ttlMs: number;
@@ -1002,6 +1016,10 @@ export class EVMChainAdapterBase {
       // than capturing the still-undefined field value here.
       () => this.chainId,
       async (endpoint) => { await this.ensureConfiguredStaticChainIdValidated(endpoint.provider); },
+      // Endpoint-stickiness config. The kill-switch is resolved HERE at the config
+      // boundary (LIVE per-check so flipping the env + restart disables it) so the
+      // transport core stays free of any process-global dependency.
+      { isEnabled: () => process.env.DKG_DISABLE_RPC_STICKINESS !== '1' },
     );
     this.hubRotationPoller = new HubRotationPoller({
       readProvider: (label, fn, opts) => this.readProvider(label, fn, opts),
@@ -2372,10 +2390,29 @@ export class EVMChainAdapterBase {
   }
 
   protected async getBlockTimestamp(blockNumber: number): Promise<number> {
-    // TIP-SENSITIVE: a near-tip block can be missing (null) on a lagging sticky
-    // backend that hasn't imported it yet → read canonical + preference-transparent.
-    const block = await this.readProvider('getBlock', (p) => p.getBlock(blockNumber), { skipPreferred: true });
-    return block?.timestamp ?? 0;
+    // A CONCRETE (already-mined receipt) block — NOT the tip, so it uses normal
+    // endpoint stickiness (the endpoint that produced the receipt is the one most
+    // likely to already have the block). It is NOT a `skipPreferred` tip read:
+    // forcing canonical/primary-first here would instead risk querying a lagging
+    // primary that returns `null` for a block a healthy backup already has, and
+    // `null` isn't a retryable transport error, so it would surface as a bogus
+    // `blockTimestamp: 0`. Treat a `null` block as a FAILOVER condition so another
+    // endpoint that has the block can serve it; only if EVERY endpoint lacks it (or
+    // transport is down) do we fall back to the best-effort `0` callers tolerate.
+    try {
+      const block = await this.readProvider(
+        'getBlock',
+        async (p) => {
+          const b = await p.getBlock(blockNumber);
+          if (!b) throw new BlockNotYetImportedError(blockNumber);
+          return b;
+        },
+        { isRetryable: (e) => e instanceof BlockNotYetImportedError || isRetryableRpcError(e) },
+      );
+      return block.timestamp != null ? Number(block.timestamp) : 0;
+    } catch {
+      return 0;
+    }
   }
 
   // =====================================================================

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -1015,11 +1015,13 @@ export class EVMChainAdapterBase {
       // built), so pass a LIVE thunk — resolved at metric-record time — rather
       // than capturing the still-undefined field value here.
       () => this.chainId,
-      async (endpoint) => { await this.ensureConfiguredStaticChainIdValidated(endpoint.provider); },
-      // Endpoint-stickiness config. The kill-switch is resolved HERE at the config
-      // boundary (LIVE per-check so flipping the env + restart disables it) so the
-      // transport core stays free of any process-global dependency.
-      { isEnabled: () => process.env.DKG_DISABLE_RPC_STICKINESS !== '1' },
+      {
+        validateEndpoint: async (endpoint) => { await this.ensureConfiguredStaticChainIdValidated(endpoint.provider); },
+        // Endpoint-stickiness config. The kill-switch is resolved HERE at the config
+        // boundary (LIVE per-check so flipping the env + restart disables it) so the
+        // transport core stays free of any process-global dependency.
+        stickiness: { isEnabled: () => process.env.DKG_DISABLE_RPC_STICKINESS !== '1' },
+      },
     );
     this.hubRotationPoller = new HubRotationPoller({
       readProvider: (label, fn, opts) => this.readProvider(label, fn, opts),
@@ -1233,6 +1235,22 @@ export class EVMChainAdapterBase {
       ...opts,
       rpcUsageConsumer: opts?.rpcUsageConsumer ?? label,
     });
+  }
+
+  /**
+   * Raw PROVIDER read for a TIP-SENSITIVE value — the current head / `latest`
+   * block / any read that must stay canonical-fresh and preference-transparent
+   * (a lagging endpoint-stickiness backend would make the tip non-monotonic
+   * across calls). This is the POSITIVE freshness intent at the call site, so
+   * callers pick `readTipProvider` by meaning instead of remembering the
+   * transport-internal `skipPreferred` opt-out on a plain `readProvider`.
+   */
+  protected readTipProvider<T>(
+    label: string,
+    fn: (provider: JsonRpcProvider) => Promise<T>,
+    opts?: ReadOpts,
+  ): Promise<T> {
+    return this.readProvider(label, fn, { ...opts, skipPreferred: true });
   }
 
   /**
@@ -2410,8 +2428,17 @@ export class EVMChainAdapterBase {
         { isRetryable: (e) => e instanceof BlockNotYetImportedError || isRetryableRpcError(e) },
       );
       return block.timestamp != null ? Number(block.timestamp) : 0;
-    } catch {
-      return 0;
+    } catch (err) {
+      // Best-effort `0` ONLY for the intended sentinel case: EVERY endpoint
+      // returned `null` for this concrete block (not imported anywhere yet), i.e.
+      // the failover loop exhausted with a `BlockNotYetImportedError` cause. Any
+      // OTHER failure — a non-retryable provider error (e.g. `INVALID_ARGUMENT`)
+      // rethrown at once, or a real transport exhaustion — must PROPAGATE, not be
+      // masked as a bogus `blockTimestamp: 0` that hides the error from callers.
+      if (err instanceof ChainRpcTransportError && err.cause instanceof BlockNotYetImportedError) {
+        return 0;
+      }
+      throw err;
     }
   }
 
@@ -3361,7 +3388,7 @@ export class EVMChainAdapterBase {
     // challenge block, and finalization reads. A lagging sticky backend would
     // make the head non-monotonic across calls (poller moving backwards / re-
     // scanning), so read canonical-order + preference-transparent.
-    return this.readProvider('getBlockNumber', (p) => p.getBlockNumber(), { skipPreferred: true });
+    return this.readTipProvider('getBlockNumber', (p) => p.getBlockNumber());
   }
 
   getProvider(): JsonRpcProvider {

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -111,16 +111,17 @@ const HUB_BINDING_INVALIDATORS = new Map<string, HubBindingInvalidationPolicy>(
 const KA_HIGH_WATER_VIEW_SIGNATURE = 'getMaxKaNumberForAuthor(address)';
 
 /**
- * A `getBlock(n)` that returned `null` because the queried endpoint hasn't
- * imported that (already-mined) block yet. Thrown inside `getBlockTimestamp`'s
- * read lambda so the failover loop treats it as a retryable condition and tries
- * another endpoint (a lagging endpoint must not force a bogus `blockTimestamp: 0`
- * when a healthy backup already has the block).
+ * Sentinel for a nullable read (`getBlock(n)`, `eth_getTransactionReceipt`, …)
+ * whose queried endpoint returned `null` — meaning "this endpoint doesn't have
+ * the object (yet)", NOT a definitive answer. Thrown inside the read lambda so
+ * `readProviderRetryingNull` treats it as a retryable condition and tries another
+ * endpoint (a lagging endpoint must not force a fallback when a healthy backup
+ * already has the object).
  */
-class BlockNotYetImportedError extends Error {
-  constructor(blockNumber: number) {
-    super(`block ${blockNumber} not yet imported on this endpoint`);
-    this.name = 'BlockNotYetImportedError';
+class NullReadSentinelError extends Error {
+  constructor(label: string) {
+    super(`${label}: object not present on this endpoint`);
+    this.name = 'NullReadSentinelError';
   }
 }
 
@@ -1251,6 +1252,61 @@ export class EVMChainAdapterBase {
     opts?: ReadOpts,
   ): Promise<T> {
     return this.readProvider(label, fn, { ...opts, skipPreferred: true });
+  }
+
+  /**
+   * Raw PROVIDER read whose `null` is a "not on this endpoint (yet)" signal, not a
+   * definitive answer — so a `null` FAILS OVER to the other endpoints (a lagging
+   * endpoint must not hide an object a healthy one has) and never records a sticky
+   * success. Returns the first NON-null result, or `null` ONLY when the failover
+   * loop exhausted with EVERY retryable failure being the null sentinel (no
+   * endpoint had a transport problem that could be masking the object).
+   *
+   * The all-null decision is ORDER-INDEPENDENT: it is made from whether ANY real
+   * transport failure occurred across all attempts (`sawTransportFailure`), NOT
+   * from `ChainRpcTransportError.cause` (which is only the LAST failure and would
+   * flip the result based on sticky/canonical attempt order). A non-retryable
+   * provider error (e.g. `INVALID_ARGUMENT`) or a genuine transport exhaustion
+   * PROPAGATES — it is never masked as a `null`.
+   */
+  protected async readProviderRetryingNull<T>(
+    label: string,
+    fn: (provider: JsonRpcProvider) => Promise<T>,
+    opts?: ReadOpts,
+  ): Promise<T | null> {
+    const baseIsRetryable = opts?.isRetryable ?? isRetryableRpcError;
+    let sawTransportFailure = false;
+    try {
+      return await this.readProvider<T>(
+        label,
+        async (provider) => {
+          try {
+            const result = await fn(provider);
+            if (result == null) throw new NullReadSentinelError(label);
+            return result;
+          } catch (err) {
+            // A REAL (non-sentinel) retryable failure means this endpoint's null
+            // absence — if any — can't be trusted as "object not here". Record it
+            // so the all-null fallback is only taken when NO transport failure
+            // occurred, independent of attempt order.
+            if (!(err instanceof NullReadSentinelError) && baseIsRetryable(err)) {
+              sawTransportFailure = true;
+            }
+            throw err;
+          }
+        },
+        { ...opts, isRetryable: (err) => err instanceof NullReadSentinelError || baseIsRetryable(err) },
+      );
+    } catch (err) {
+      if (
+        err instanceof ChainRpcTransportError
+        && err.code === 'RPC_ENDPOINTS_EXHAUSTED'
+        && !sawTransportFailure
+      ) {
+        return null; // every endpoint returned the null sentinel → honest "not found"
+      }
+      throw err;
+    }
   }
 
   /**
@@ -2417,29 +2473,12 @@ export class EVMChainAdapterBase {
     // `blockTimestamp: 0`. Treat a `null` block as a FAILOVER condition so another
     // endpoint that has the block can serve it; only if EVERY endpoint lacks it (or
     // transport is down) do we fall back to the best-effort `0` callers tolerate.
-    try {
-      const block = await this.readProvider(
-        'getBlock',
-        async (p) => {
-          const b = await p.getBlock(blockNumber);
-          if (!b) throw new BlockNotYetImportedError(blockNumber);
-          return b;
-        },
-        { isRetryable: (e) => e instanceof BlockNotYetImportedError || isRetryableRpcError(e) },
-      );
-      return block.timestamp != null ? Number(block.timestamp) : 0;
-    } catch (err) {
-      // Best-effort `0` ONLY for the intended sentinel case: EVERY endpoint
-      // returned `null` for this concrete block (not imported anywhere yet), i.e.
-      // the failover loop exhausted with a `BlockNotYetImportedError` cause. Any
-      // OTHER failure — a non-retryable provider error (e.g. `INVALID_ARGUMENT`)
-      // rethrown at once, or a real transport exhaustion — must PROPAGATE, not be
-      // masked as a bogus `blockTimestamp: 0` that hides the error from callers.
-      if (err instanceof ChainRpcTransportError && err.cause instanceof BlockNotYetImportedError) {
-        return 0;
-      }
-      throw err;
-    }
+    // A `null` block (this endpoint hasn't imported it yet) fails over to another
+    // endpoint that has it; best-effort `0` only when EVERY endpoint lacks it and
+    // no transport error occurred. Non-retryable / transport-exhaustion errors
+    // propagate (never masked as a bogus `0`). Order-independent — see the helper.
+    const block = await this.readProviderRetryingNull('getBlock', (p) => p.getBlock(blockNumber));
+    return block?.timestamp != null ? Number(block.timestamp) : 0;
   }
 
   // =====================================================================

--- a/packages/chain/src/evm-adapter-constants.ts
+++ b/packages/chain/src/evm-adapter-constants.ts
@@ -45,6 +45,23 @@ export const MAX_PROBE_AGE_MS = 30_000;
 export const RPC_READ_STALL_TIMEOUT_MS = 4_000;
 
 /**
+ * TTL (ms) for the `RpcFailoverClient` endpoint-stickiness "primary re-probe"
+ * cadence (Mechanism B, #1340 retry residual + #1337 policy-read fail-close).
+ * Once a read/write has failed over to a backup, the client prefers that
+ * last-good backend for subsequent ops, but re-probes the CONFIGURED PRIMARY at
+ * most once every `STICKY_PREFERRED_TTL_MS` of degraded operation (bounded to one
+ * re-stall per window) so a recovered primary resumes automatically. Chosen at
+ * 30s: comfortably spans #1340's seconds-long CG-register recovery burst and
+ * #1337's back-to-back policy-read burst, while keeping the steady-state
+ * re-probe cost to one extra primary attempt per 30s. Deliberately equal to the
+ * hub-rotation poll cadence — but the poller's head probe is `skipPreferred`
+ * (preference-transparent), so the two never interfere. Overridable per-client
+ * via the constructor stickiness options (used by tests) and killable via
+ * `DKG_DISABLE_RPC_STICKINESS=1`.
+ */
+export const STICKY_PREFERRED_TTL_MS = 30_000;
+
+/**
  * Per-attempt deadline for WIDE `eth_getLogs` reads (the `evm-adapter-events.ts`
  * `queryFilter` scans, which run over `[fromBlock ?? 0, toBlock]` — up to the
  * event poller's 9,000-block window, and the full chain on a cold-start

--- a/packages/chain/src/evm-adapter-conviction.ts
+++ b/packages/chain/src/evm-adapter-conviction.ts
@@ -797,12 +797,18 @@ export class ConvictionMethods extends EVMChainAdapterBase implements Conviction
   async requestPublishingConvictionRpc(method: PcaRpcMethod, params: unknown[] = []): Promise<unknown> {
     await this.init();
     const label = `pca rpc ${method}`;
-    const tag = params[0];
 
-    // TRUE tip read (current head, or a latest-family `eth_getBlockByNumber` tag) →
-    // preference-TRANSPARENT: a lagging sticky backend would give a stale head.
+    // TRUE tip read → preference-TRANSPARENT: a lagging sticky backend would give a
+    // stale head / stale contract state. The tip block-tag position differs by
+    // method: `eth_getBlockByNumber` → params[0] (a concrete block is NOT tip);
+    // `eth_call` → params[1] (params[0] is the call object, and an OMITTED tag
+    // defaults to `latest`, so a no-tag / latest-family eth_call is tip-sensitive
+    // too — it reads current contract state that a lagging backend would stale).
+    const isLatestFamilyTag = (t: unknown): boolean =>
+      typeof t === 'string' && PCA_TIP_BLOCK_TAGS.has(t);
     const isTipRead = method === 'eth_blockNumber'
-      || (method === 'eth_getBlockByNumber' && typeof tag === 'string' && PCA_TIP_BLOCK_TAGS.has(tag));
+      || (method === 'eth_getBlockByNumber' && isLatestFamilyTag(params[0]))
+      || (method === 'eth_call' && (params[1] === undefined || isLatestFamilyTag(params[1])));
     if (isTipRead) {
       return this.readTipProvider(label, (provider) => provider.send(method, params));
     }

--- a/packages/chain/src/evm-adapter-conviction.ts
+++ b/packages/chain/src/evm-adapter-conviction.ts
@@ -175,7 +175,10 @@ export class ConvictionMethods extends EVMChainAdapterBase implements Conviction
       // wall clock first to mirror the contract exactly — otherwise the SDK
       // would coerce, then fall through to full-price direct spend.
       if (info.expiresAtTimestamp > 0) {
-        const latestBlock = await this.readProvider('conviction getBlock', (p) => p.getBlock('latest'));
+        // TIP-SENSITIVE: `latest` timestamp gates the expiry check; a stale
+        // (older) latest from a lagging sticky backend would treat an expired
+        // account as still valid → read canonical + preference-transparent.
+        const latestBlock = await this.readProvider('conviction getBlock', (p) => p.getBlock('latest'), { skipPreferred: true });
         const nowTs = latestBlock ? Number(latestBlock.timestamp) : Math.floor(Date.now() / 1000);
         if (nowTs >= info.expiresAtTimestamp) return false;
       }
@@ -778,6 +781,10 @@ export class ConvictionMethods extends EVMChainAdapterBase implements Conviction
 
   async requestPublishingConvictionRpc(method: PcaRpcMethod, params: unknown[] = []): Promise<unknown> {
     await this.init();
-    return this.readProvider(`pca rpc ${method}`, (provider) => provider.send(method, params));
+    // Generic browser-facing read proxy: the allowlisted methods include the
+    // TIP-SENSITIVE `eth_blockNumber` / `eth_getBlockByNumber`, and this path has
+    // no read-your-write need (the node isn't writing here), so stay canonical +
+    // preference-transparent rather than pin the UI to a possibly-lagging backend.
+    return this.readProvider(`pca rpc ${method}`, (provider) => provider.send(method, params), { skipPreferred: true });
   }
 }

--- a/packages/chain/src/evm-adapter-conviction.ts
+++ b/packages/chain/src/evm-adapter-conviction.ts
@@ -804,26 +804,41 @@ export class ConvictionMethods extends EVMChainAdapterBase implements Conviction
     // `eth_call` → params[1] (params[0] is the call object, and an OMITTED tag
     // defaults to `latest`, so a no-tag / latest-family eth_call is tip-sensitive
     // too — it reads current contract state that a lagging backend would stale).
+    const send = (provider: ethers.JsonRpcProvider) => provider.send(method, params);
     const isLatestFamilyTag = (t: unknown): boolean =>
       typeof t === 'string' && PCA_TIP_BLOCK_TAGS.has(t);
-    const isTipRead = method === 'eth_blockNumber'
-      || (method === 'eth_getBlockByNumber' && isLatestFamilyTag(params[0]))
-      || (method === 'eth_call' && (params[1] === undefined || isLatestFamilyTag(params[1])));
-    if (isTipRead) {
-      return this.readTipProvider(label, (provider) => provider.send(method, params));
+    // The tip block-tag position differs by method: `eth_getBlockByNumber` →
+    // params[0]; `eth_call` → params[1] (params[0] is the call object; an omitted
+    // tag defaults to `latest`). A concrete hex block is NOT tip.
+    const isBlockByNumberTip = method === 'eth_getBlockByNumber' && isLatestFamilyTag(params[0]);
+
+    // NON-nullable tip reads → preference-TRANSPARENT: `eth_blockNumber` (a number,
+    // never null) and a latest-family `eth_call` (reads current contract state a
+    // lagging backend would stale; a null-ish result is itself a valid answer).
+    if (method === 'eth_blockNumber'
+      || (method === 'eth_call' && (params[1] === undefined || isLatestFamilyTag(params[1])))) {
+      return this.readTipProvider(label, send);
     }
 
-    // Nullable reconciliation read (receipt / tx / a concrete block; a tip
-    // eth_getBlockByNumber already returned above) → STICKY (prefer the endpoint
-    // that already observed the tx/block), BUT a `null` means "not here yet", not a
-    // definitive answer, so it must FAIL OVER (a lagging preferred backend can't
-    // hide an object another has) and must NOT reinforce a preference. The shared
-    // helper returns null only once EVERY endpoint lacks it (order-independent).
+    // A latest-family `eth_getBlockByNumber` (finalized / safe / latest) is tip
+    // (canonical-fresh, no stale-tip pin) BUT still NULLABLE — a lagging/partially
+    // synced primary can return null for a block a backup already has — so it is
+    // transparent AND fails over on null before returning null.
+    if (isBlockByNumberTip) {
+      return this.readProviderRetryingNull(label, send, { skipPreferred: true });
+    }
+
+    // Nullable reconciliation read (receipt / tx / a CONCRETE block) → STICKY
+    // (prefer the endpoint that already observed the tx/block), BUT a `null` means
+    // "not here yet", not a definitive answer, so it must FAIL OVER (a lagging
+    // preferred backend can't hide an object another has) and must NOT reinforce a
+    // preference. The shared helper returns null only once EVERY endpoint lacks it.
     if (PCA_NULLABLE_LOOKUP_METHODS.has(method)) {
-      return this.readProviderRetryingNull(label, (provider) => provider.send(method, params));
+      return this.readProviderRetryingNull(label, send);
     }
 
-    // eth_call / eth_chainId — plain sticky (a null-ish result is a valid answer).
-    return this.readProvider(label, (provider) => provider.send(method, params));
+    // eth_call at a concrete block / eth_chainId — plain sticky (a null-ish result
+    // is a valid answer that can't change).
+    return this.readProvider(label, send);
   }
 }

--- a/packages/chain/src/evm-adapter-conviction.ts
+++ b/packages/chain/src/evm-adapter-conviction.ts
@@ -24,8 +24,6 @@ import type {
 import { PcaUnavailableError } from './pca-errors.js';
 import { enrichEvmError, getPcaLogicInterface } from './evm-adapter-errors.js';
 import type { PcaMutationInvalidation } from './pca-read-cache.js';
-import { isRetryableRpcError } from './evm-adapter-rpc.js';
-import { ChainRpcTransportError } from './chain-rpc-transport-error.js';
 
 /** Latest-family `eth_getBlockByNumber` block tags that are TIP reads (must stay
  *  preference-transparent). A concrete hex block number or `earliest` is a fixed
@@ -34,21 +32,13 @@ const PCA_TIP_BLOCK_TAGS = new Set<string>(['latest', 'pending', 'safe', 'finali
 
 /** Allowlisted PCA proxy methods whose `null` means "this endpoint doesn't have
  *  the object (yet)", not a definitive answer — so a `null` must FAIL OVER to
- *  other endpoints rather than terminate the lookup or reinforce a preference. */
+ *  other endpoints (via `readProviderRetryingNull`) rather than terminate the
+ *  lookup or reinforce a preference. */
 const PCA_NULLABLE_LOOKUP_METHODS = new Set<string>([
   'eth_getTransactionReceipt',
   'eth_getTransactionByHash',
   'eth_getBlockByNumber',
 ]);
-
-/** Sentinel: the queried endpoint returned `null` for a nullable PCA lookup — a
- *  retryable "not here" so the failover loop tries the next endpoint. */
-class PcaObjectNotFoundError extends Error {
-  constructor(method: string) {
-    super(`PCA ${method}: object not present on this endpoint`);
-    this.name = 'PcaObjectNotFoundError';
-  }
-}
 
 export interface RawShardingTableNode extends ArrayLike<unknown> {
   nodeId?: unknown;
@@ -817,32 +807,14 @@ export class ConvictionMethods extends EVMChainAdapterBase implements Conviction
       return this.readTipProvider(label, (provider) => provider.send(method, params));
     }
 
-    // Nullable reconciliation read (receipt / tx / a concrete block) → STICKY
-    // (prefer the endpoint that already observed the tx/block), BUT a `null` means
-    // "not here yet", not a definitive answer: it must FAIL OVER to the other
-    // endpoints (so a lagging preferred backend can't hide an object another has)
-    // and must NOT reinforce a preference. Throwing on `null` makes it retryable
-    // AND keeps it off the success/establish path; if EVERY endpoint lacks it, the
-    // honest `null` is returned.
-    const isTipConcreteBlock = method === 'eth_getBlockByNumber'
-      && typeof tag === 'string' && PCA_TIP_BLOCK_TAGS.has(tag);
-    if (PCA_NULLABLE_LOOKUP_METHODS.has(method) && !isTipConcreteBlock) {
-      try {
-        return await this.readProvider(
-          label,
-          async (provider) => {
-            const result = await provider.send(method, params);
-            if (result == null) throw new PcaObjectNotFoundError(method);
-            return result;
-          },
-          { isRetryable: (e) => e instanceof PcaObjectNotFoundError || isRetryableRpcError(e) },
-        );
-      } catch (err) {
-        if (err instanceof ChainRpcTransportError && err.cause instanceof PcaObjectNotFoundError) {
-          return null; // no endpoint has it (yet) — the honest "not found" answer
-        }
-        throw err;
-      }
+    // Nullable reconciliation read (receipt / tx / a concrete block; a tip
+    // eth_getBlockByNumber already returned above) → STICKY (prefer the endpoint
+    // that already observed the tx/block), BUT a `null` means "not here yet", not a
+    // definitive answer, so it must FAIL OVER (a lagging preferred backend can't
+    // hide an object another has) and must NOT reinforce a preference. The shared
+    // helper returns null only once EVERY endpoint lacks it (order-independent).
+    if (PCA_NULLABLE_LOOKUP_METHODS.has(method)) {
+      return this.readProviderRetryingNull(label, (provider) => provider.send(method, params));
     }
 
     // eth_call / eth_chainId — plain sticky (a null-ish result is a valid answer).

--- a/packages/chain/src/evm-adapter-conviction.ts
+++ b/packages/chain/src/evm-adapter-conviction.ts
@@ -25,6 +25,11 @@ import { PcaUnavailableError } from './pca-errors.js';
 import { enrichEvmError, getPcaLogicInterface } from './evm-adapter-errors.js';
 import type { PcaMutationInvalidation } from './pca-read-cache.js';
 
+/** Latest-family `eth_getBlockByNumber` block tags that are TIP reads (must stay
+ *  preference-transparent). A concrete hex block number or `earliest` is a fixed
+ *  block → sticky (prefer the endpoint that already has it). */
+const PCA_TIP_BLOCK_TAGS = new Set<string>(['latest', 'pending', 'safe', 'finalized']);
+
 export interface RawShardingTableNode extends ArrayLike<unknown> {
   nodeId?: unknown;
   identityId?: unknown;
@@ -781,10 +786,20 @@ export class ConvictionMethods extends EVMChainAdapterBase implements Conviction
 
   async requestPublishingConvictionRpc(method: PcaRpcMethod, params: unknown[] = []): Promise<unknown> {
     await this.init();
-    // Generic browser-facing read proxy: the allowlisted methods include the
-    // TIP-SENSITIVE `eth_blockNumber` / `eth_getBlockByNumber`, and this path has
-    // no read-your-write need (the node isn't writing here), so stay canonical +
-    // preference-transparent rather than pin the UI to a possibly-lagging backend.
-    return this.readTipProvider(`pca rpc ${method}`, (provider) => provider.send(method, params));
+    // Classify by method/params. Only a TRUE tip read (current head, or an
+    // `eth_getBlockByNumber` for a latest-family block tag) is preference-
+    // transparent — a lagging sticky backend would give a stale head. Receipt /
+    // tx / exact-block / `eth_call` reconciliation reads stay on the STICKY
+    // failover path: the endpoint that already observed the tx/block is the one to
+    // prefer, and forcing canonical/primary-first would make a lagging primary's
+    // `null` terminal (returned as success) instead of trying the preferred backup
+    // that has the result (#PCA-review).
+    const tag = params[0];
+    const isTipRead = method === 'eth_blockNumber'
+      || (method === 'eth_getBlockByNumber' && typeof tag === 'string' && PCA_TIP_BLOCK_TAGS.has(tag));
+    const read = isTipRead
+      ? this.readTipProvider.bind(this)
+      : this.readProvider.bind(this);
+    return read(`pca rpc ${method}`, (provider) => provider.send(method, params));
   }
 }

--- a/packages/chain/src/evm-adapter-conviction.ts
+++ b/packages/chain/src/evm-adapter-conviction.ts
@@ -178,7 +178,7 @@ export class ConvictionMethods extends EVMChainAdapterBase implements Conviction
         // TIP-SENSITIVE: `latest` timestamp gates the expiry check; a stale
         // (older) latest from a lagging sticky backend would treat an expired
         // account as still valid → read canonical + preference-transparent.
-        const latestBlock = await this.readProvider('conviction getBlock', (p) => p.getBlock('latest'), { skipPreferred: true });
+        const latestBlock = await this.readTipProvider('conviction getBlock', (p) => p.getBlock('latest'));
         const nowTs = latestBlock ? Number(latestBlock.timestamp) : Math.floor(Date.now() / 1000);
         if (nowTs >= info.expiresAtTimestamp) return false;
       }
@@ -785,6 +785,6 @@ export class ConvictionMethods extends EVMChainAdapterBase implements Conviction
     // TIP-SENSITIVE `eth_blockNumber` / `eth_getBlockByNumber`, and this path has
     // no read-your-write need (the node isn't writing here), so stay canonical +
     // preference-transparent rather than pin the UI to a possibly-lagging backend.
-    return this.readProvider(`pca rpc ${method}`, (provider) => provider.send(method, params), { skipPreferred: true });
+    return this.readTipProvider(`pca rpc ${method}`, (provider) => provider.send(method, params));
   }
 }

--- a/packages/chain/src/evm-adapter-conviction.ts
+++ b/packages/chain/src/evm-adapter-conviction.ts
@@ -24,11 +24,31 @@ import type {
 import { PcaUnavailableError } from './pca-errors.js';
 import { enrichEvmError, getPcaLogicInterface } from './evm-adapter-errors.js';
 import type { PcaMutationInvalidation } from './pca-read-cache.js';
+import { isRetryableRpcError } from './evm-adapter-rpc.js';
+import { ChainRpcTransportError } from './chain-rpc-transport-error.js';
 
 /** Latest-family `eth_getBlockByNumber` block tags that are TIP reads (must stay
  *  preference-transparent). A concrete hex block number or `earliest` is a fixed
  *  block → sticky (prefer the endpoint that already has it). */
 const PCA_TIP_BLOCK_TAGS = new Set<string>(['latest', 'pending', 'safe', 'finalized']);
+
+/** Allowlisted PCA proxy methods whose `null` means "this endpoint doesn't have
+ *  the object (yet)", not a definitive answer — so a `null` must FAIL OVER to
+ *  other endpoints rather than terminate the lookup or reinforce a preference. */
+const PCA_NULLABLE_LOOKUP_METHODS = new Set<string>([
+  'eth_getTransactionReceipt',
+  'eth_getTransactionByHash',
+  'eth_getBlockByNumber',
+]);
+
+/** Sentinel: the queried endpoint returned `null` for a nullable PCA lookup — a
+ *  retryable "not here" so the failover loop tries the next endpoint. */
+class PcaObjectNotFoundError extends Error {
+  constructor(method: string) {
+    super(`PCA ${method}: object not present on this endpoint`);
+    this.name = 'PcaObjectNotFoundError';
+  }
+}
 
 export interface RawShardingTableNode extends ArrayLike<unknown> {
   nodeId?: unknown;
@@ -786,20 +806,46 @@ export class ConvictionMethods extends EVMChainAdapterBase implements Conviction
 
   async requestPublishingConvictionRpc(method: PcaRpcMethod, params: unknown[] = []): Promise<unknown> {
     await this.init();
-    // Classify by method/params. Only a TRUE tip read (current head, or an
-    // `eth_getBlockByNumber` for a latest-family block tag) is preference-
-    // transparent — a lagging sticky backend would give a stale head. Receipt /
-    // tx / exact-block / `eth_call` reconciliation reads stay on the STICKY
-    // failover path: the endpoint that already observed the tx/block is the one to
-    // prefer, and forcing canonical/primary-first would make a lagging primary's
-    // `null` terminal (returned as success) instead of trying the preferred backup
-    // that has the result (#PCA-review).
+    const label = `pca rpc ${method}`;
     const tag = params[0];
+
+    // TRUE tip read (current head, or a latest-family `eth_getBlockByNumber` tag) →
+    // preference-TRANSPARENT: a lagging sticky backend would give a stale head.
     const isTipRead = method === 'eth_blockNumber'
       || (method === 'eth_getBlockByNumber' && typeof tag === 'string' && PCA_TIP_BLOCK_TAGS.has(tag));
-    const read = isTipRead
-      ? this.readTipProvider.bind(this)
-      : this.readProvider.bind(this);
-    return read(`pca rpc ${method}`, (provider) => provider.send(method, params));
+    if (isTipRead) {
+      return this.readTipProvider(label, (provider) => provider.send(method, params));
+    }
+
+    // Nullable reconciliation read (receipt / tx / a concrete block) → STICKY
+    // (prefer the endpoint that already observed the tx/block), BUT a `null` means
+    // "not here yet", not a definitive answer: it must FAIL OVER to the other
+    // endpoints (so a lagging preferred backend can't hide an object another has)
+    // and must NOT reinforce a preference. Throwing on `null` makes it retryable
+    // AND keeps it off the success/establish path; if EVERY endpoint lacks it, the
+    // honest `null` is returned.
+    const isTipConcreteBlock = method === 'eth_getBlockByNumber'
+      && typeof tag === 'string' && PCA_TIP_BLOCK_TAGS.has(tag);
+    if (PCA_NULLABLE_LOOKUP_METHODS.has(method) && !isTipConcreteBlock) {
+      try {
+        return await this.readProvider(
+          label,
+          async (provider) => {
+            const result = await provider.send(method, params);
+            if (result == null) throw new PcaObjectNotFoundError(method);
+            return result;
+          },
+          { isRetryable: (e) => e instanceof PcaObjectNotFoundError || isRetryableRpcError(e) },
+        );
+      } catch (err) {
+        if (err instanceof ChainRpcTransportError && err.cause instanceof PcaObjectNotFoundError) {
+          return null; // no endpoint has it (yet) — the honest "not found" answer
+        }
+        throw err;
+      }
+    }
+
+    // eth_call / eth_chainId — plain sticky (a null-ish result is a valid answer).
+    return this.readProvider(label, (provider) => provider.send(method, params));
   }
 }

--- a/packages/chain/src/evm-adapter-events.ts
+++ b/packages/chain/src/evm-adapter-events.ts
@@ -23,6 +23,16 @@ export class EventsMethods extends EVMChainAdapterBase {
    * policy so the wide-log multi-RPC timeout (`RPC_LOG_SCAN_TIMEOUT_MS`, vs the 4s
    * point-read cap; single-RPC stays uncapped, #894) is owned HERE once, not by
    * per-call-site discipline. Used by every `listenForEvents` branch below.
+   *
+   * TIP-SENSITIVE → `skipPreferred: true` (endpoint stickiness carve-out). The
+   * event-lane cursor is advanced against a head read canonical-fresh via
+   * `getBlockNumber()` (also `skipPreferred`); if this `[fromBlock, head]` scan
+   * were pinned to a lagging sticky backup whose tip is BELOW `head`, a provider
+   * that silently clamps `toBlock` to its own tip would return fewer logs, the
+   * runner would still persist `lastBlock = head`, and the events in
+   * `(backendTip, head]` would be skipped forever. Scanning canonical-order keeps
+   * the scan's tip coverage aligned with the head that advances the cursor
+   * (mirrors the hub-rotation poller's `skipPreferred` wide-log carve-out).
    */
   private queryFilterWithFailover(
     contract: ethers.Contract,
@@ -35,7 +45,7 @@ export class EventsMethods extends EVMChainAdapterBase {
       contract,
       label,
       (c) => c.queryFilter(eventFilter, fromBlock, toBlock),
-      { policy: 'wideLogScan' },
+      { policy: 'wideLogScan', skipPreferred: true },
     );
   }
 

--- a/packages/chain/src/hub-rotation-poller.ts
+++ b/packages/chain/src/hub-rotation-poller.ts
@@ -103,7 +103,11 @@ export class HubRotationPoller {
     const head = await this.readProvider(
       'Hub rotation poll getBlockNumber',
       (provider) => provider.getBlockNumber(),
-      { policy: 'watchdogPointRead' },
+      // Background head probe at the ~stickiness-TTL cadence: keep it
+      // preference-transparent so a poll tick never re-probes/clears the
+      // preferred backend the read/write paths rely on, and so `head` stays
+      // canonical-fresh (not a lagging sticky backend's lower tip).
+      { policy: 'watchdogPointRead', skipPreferred: true },
     );
     if (!this.started || generation !== this.generation) return;
     const fromBlock = this.scanFromBlock(previousLastScannedBlock, head);
@@ -115,7 +119,7 @@ export class HubRotationPoller {
         toBlock: head,
         topics: [binding.topics],
       }),
-      { policy: 'watchdogWideLogScan' },
+      { policy: 'watchdogWideLogScan', skipPreferred: true },
     );
     if (!this.started || generation !== this.generation) return;
 
@@ -131,7 +135,9 @@ export class HubRotationPoller {
     const head = await this.readProvider(
       'Hub rotation poll initial getBlockNumber',
       (provider) => provider.getBlockNumber(),
-      { policy: 'watchdogPointRead' },
+      // Preference-transparent (see pollOnce): background head probe must not
+      // disturb the read/write stickiness state.
+      { policy: 'watchdogPointRead', skipPreferred: true },
     );
     if (!this.started || generation !== this.generation) return;
     this.lastScannedBlock = this.lastScannedBlock == null

--- a/packages/chain/src/index.ts
+++ b/packages/chain/src/index.ts
@@ -48,6 +48,7 @@ export {
   type RpcFailoverStatsSnapshot,
   noteRpcFailover,
   noteRpcExhaustion,
+  notePreferredEndpoint,
 } from './rpc-failover-log.js';
 export {
   HubResolutionCache,

--- a/packages/chain/src/rpc-failover-client.ts
+++ b/packages/chain/src/rpc-failover-client.ts
@@ -8,9 +8,15 @@
  *
  * SAFETY BOUNDARY: this module holds NO transaction-safety state — no WAL, no
  * per-wallet serializer, no approval latch. The adapter's tx-orchestration owns
- * all of that and calls into this surface. The module never references the
- * adapter; it is constructed with two required capabilities and one optional
- * per-endpoint transport preflight:
+ * all of that and calls into this surface. The ONLY mutable state it owns is a
+ * TRANSPORT-ORDERING preference (endpoint stickiness — `preferredRpcUrl` +
+ * `primaryProbeDueAt`): a "prefer the last-good backend, re-probe the primary at
+ * most once per TTL" pointer, keyed on `rpcUrl` (survives a live pool rebind).
+ * That is pure ordering — it only decides which endpoint each loop TRIES FIRST;
+ * it never signs, never gates a broadcast, never re-orders the tx-safety
+ * guards, and every loop still falls through to the full endpoint set. The
+ * module never references the adapter; it is constructed with two required
+ * capabilities and one optional per-endpoint transport preflight:
  *   1. `getEndpoints()` — a LIVE thunk over the RPC endpoints, each a
  *      `{ provider, rpcUrl }` pair. One object per endpoint keeps the
  *      `provider ↔ rpcUrl` pairing explicit inside every failover loop (not an
@@ -34,7 +40,7 @@ import { JsonRpcProvider, Wallet, Contract, ethers } from 'ethers';
 import { withSpan, getMetrics } from '@origintrail-official/dkg-core';
 import { withTimeout, isRetryableRpcError, isKnownTransactionError } from './evm-adapter-rpc.js';
 import { errorCode, errorMessage } from './evm-adapter-errors.js';
-import { noteRpcFailover, noteRpcExhaustion, rpcHost } from './rpc-failover-log.js';
+import { noteRpcFailover, noteRpcExhaustion, notePreferredEndpoint, rpcHost } from './rpc-failover-log.js';
 import { ChainRpcTransportError } from './chain-rpc-transport-error.js';
 import { withRpcUsageConsumer } from './rpc-usage.js';
 import {
@@ -43,6 +49,7 @@ import {
   RPC_BROADCAST_ATTEMPT_TIMEOUT_MS,
   RPC_RECEIPT_ATTEMPT_TIMEOUT_MS,
   RPC_TRANSACTION_POPULATION_ATTEMPT_TIMEOUT_MS,
+  STICKY_PREFERRED_TTL_MS,
 } from './evm-adapter-constants.js';
 
 /**
@@ -84,6 +91,16 @@ export interface ReadOpts {
   policy?: ReadPolicy;
   isRetryable?: (err: unknown) => boolean;
   rpcUsageConsumer?: string;
+  /**
+   * Opt this read OUT of endpoint stickiness — it always uses the canonical
+   * (configured) endpoint order AND never mutates the preferred pointer
+   * (fully preference-transparent). Set on TIP-SENSITIVE reads (current head /
+   * latest block) where a lagging preferred backend could return a stale/lower
+   * head and make the tip non-monotonic across calls. A `skipPreferred` read on
+   * a selectively-healthy primary must NOT clear the preference the heavy
+   * read/write paths rely on — hence transparent, not merely canonical-ordered.
+   */
+  skipPreferred?: boolean;
 }
 
 /**
@@ -98,6 +115,23 @@ export type SignPopulatedFn = (
 
 /** Optional per-endpoint transport preflight, e.g. static-network chain-id validation. */
 export type ValidateEndpointFn = (endpoint: RpcEndpoint) => Promise<void>;
+
+/**
+ * Endpoint-stickiness knobs (Mechanism B). All optional with production
+ * defaults; overridden only by tests (injected clock / TTL) or the kill-switch.
+ *   - `enabled` — force stickiness on/off. When omitted, resolved LIVE at
+ *     check-time from `DKG_DISABLE_RPC_STICKINESS` (env kill-switch), so the flag
+ *     takes effect on restart without a code change.
+ *   - `ttlMs`   — the primary re-probe cadence (defaults to
+ *     `STICKY_PREFERRED_TTL_MS`).
+ *   - `now`     — monotonic-ish clock (defaults to `Date.now`); injected by the
+ *     cadence unit test.
+ */
+export interface StickinessOptions {
+  enabled?: boolean;
+  ttlMs?: number;
+  now?: () => number;
+}
 
 /**
  * Failover classifier for CONTRACT VIEW reads (`readContract`'s default): the
@@ -139,6 +173,18 @@ export function resolveCapMs(policy: ReadPolicy, providerCount: number): number 
 }
 
 export class RpcFailoverClient {
+  // --- Endpoint stickiness (transport-ordering state; see SAFETY BOUNDARY) ---
+  /** The last-good NON-primary endpoint URL to try first, or undefined = none
+   *  (canonical order). Keyed on `rpcUrl` so it survives a live pool rebind. */
+  private preferredRpcUrl: string | undefined;
+  /** Wall-clock deadline after which the next ordering re-probes the primary
+   *  (canonical order) and re-arms this deadline `+ttlMs`. Guarantees at most
+   *  one primary re-stall per TTL under a persistently degraded primary. */
+  private primaryProbeDueAt = 0;
+  private readonly stickyNow: () => number;
+  private readonly stickyTtlMs: number;
+  private readonly stickyEnabledOverride: boolean | undefined;
+
   constructor(
     private readonly getEndpoints: () => RpcEndpoint[],
     private readonly signPopulated: SignPopulatedFn,
@@ -148,7 +194,108 @@ export class RpcFailoverClient {
     // have the label resolve correctly at metric-record time.
     private readonly chainId: () => string,
     private readonly validateEndpoint?: ValidateEndpointFn,
-  ) {}
+    stickiness?: StickinessOptions,
+  ) {
+    this.stickyNow = stickiness?.now ?? Date.now;
+    this.stickyTtlMs = stickiness?.ttlMs ?? STICKY_PREFERRED_TTL_MS;
+    this.stickyEnabledOverride = stickiness?.enabled;
+  }
+
+  /**
+   * Whether stickiness is active. A test override wins; otherwise it is LIVE off
+   * the `DKG_DISABLE_RPC_STICKINESS` kill-switch (checked per-call so flipping
+   * the env + restart disables it without a code change). Rollback lever for a
+   * High-risk transport change.
+   */
+  private stickinessOn(): boolean {
+    if (this.stickyEnabledOverride !== undefined) return this.stickyEnabledOverride;
+    return process.env.DKG_DISABLE_RPC_STICKINESS !== '1';
+  }
+
+  /**
+   * Decide the per-op iteration order over `canonical` (the live configured
+   * order, index 0 = primary). Returns canonical UNLESS a preferred backend is
+   * set, stickiness is on, `skipPreferred` is false, and we are inside the
+   * current re-probe window — in which case the preferred is MOVED to the front
+   * (spliced out and unshifted; never duplicated, so fall-through still visits
+   * every endpoint exactly once). When the re-probe deadline has passed this
+   * op probes the primary first (canonical) AND re-arms the deadline `+ttlMs`,
+   * so a persistently degraded primary is re-probed at most once per TTL.
+   */
+  private orderEndpoints(canonical: RpcEndpoint[], skipPreferred: boolean): RpcEndpoint[] {
+    if (skipPreferred || !this.stickinessOn() || this.preferredRpcUrl === undefined) {
+      return canonical;
+    }
+    const idx = canonical.findIndex((e) => e.rpcUrl === this.preferredRpcUrl);
+    // idx < 0: preferred no longer configured (pool rebind dropped it).
+    // idx === 0: preferred IS the primary — canonical already tries it first.
+    if (idx <= 0) return canonical;
+    if (this.stickyNow() >= this.primaryProbeDueAt) {
+      // Re-probe the configured primary this op; schedule the next re-probe one
+      // TTL out so we don't re-stall on it again until then.
+      this.primaryProbeDueAt = this.stickyNow() + this.stickyTtlMs;
+      return canonical;
+    }
+    const reordered = canonical.slice();
+    const [preferred] = reordered.splice(idx, 1);
+    reordered.unshift(preferred);
+    return reordered;
+  }
+
+  /**
+   * Update the preferred pointer after `endpoint` served an op successfully.
+   * `canonical[0]` is the configured primary; `triedFirst` is whether this
+   * endpoint was the FIRST one this op attempted (loop index 0). Fully NO-OP
+   * under `skipPreferred` (tip-sensitive reads stay transparent) or when
+   * stickiness is off. All writes here are synchronous (no `await` between the
+   * two field writes) so concurrent ops can only observe a stale order, never
+   * torn state.
+   *   - primary succeeded, tried FIRST → CLEAR the preference (a genuine
+   *     canonical / TTL re-probe proved the primary healthy again).
+   *   - primary succeeded as a FALLBACK (not first) → KEEP the preference: its
+   *     answering ONE op doesn't prove health for the degraded method, and
+   *     clearing outside the TTL cadence would re-stall the next heavy read.
+   *   - a backend succeeded → SET/keep it as preferred; arm the re-probe deadline
+   *     only on FIRST establishment (undefined→set), NOT on every confirming
+   *     success — otherwise the deadline would be pushed forward forever and the
+   *     primary would never be re-probed (the cadence is governed solely by
+   *     `orderEndpoints` re-arming on a re-probe op). A later re-point to a
+   *     different backup is a SILENT pointer move (no new establishment count).
+   */
+  private notePreferredOutcome(
+    endpoint: RpcEndpoint,
+    canonical: RpcEndpoint[],
+    skipPreferred: boolean,
+    triedFirst: boolean,
+  ): void {
+    if (skipPreferred || !this.stickinessOn()) return;
+    const primaryUrl = canonical[0]?.rpcUrl;
+    if (endpoint.rpcUrl === primaryUrl) {
+      // Clear the preference ONLY when the primary was tried FIRST — a genuine
+      // canonical / TTL re-probe op whose success proves the primary is healthy
+      // again. A primary reached as a FALLBACK (the preferred backup errored or
+      // returned null on THIS op) does NOT prove primary health for the degraded
+      // method (method-selective 429s are common), so keep the preference:
+      // clearing here would reset stickiness OUTSIDE the TTL re-probe cadence and
+      // re-stall the next heavy read on the still-degraded primary.
+      if (triedFirst) this.preferredRpcUrl = undefined;
+      return;
+    }
+    if (this.preferredRpcUrl === undefined) {
+      // First establishment after a failover: prefer this backend, arm the
+      // re-probe deadline, and emit the operator signal (log + counter).
+      this.preferredRpcUrl = endpoint.rpcUrl;
+      this.primaryProbeDueAt = this.stickyNow() + this.stickyTtlMs;
+      notePreferredEndpoint('rpc failover', endpoint.rpcUrl);
+    } else if (this.preferredRpcUrl !== endpoint.rpcUrl) {
+      // Preferred moved to a different backup (the old one also degraded). Keep
+      // the existing re-probe deadline — do NOT re-arm (that is orderEndpoints'
+      // job on a re-probe op). Silent re-point: this is a hop WITHIN an ongoing
+      // degradation episode already counted at establishment, so it does NOT
+      // re-increment `preferredEstablishments` (which counts establishment edges).
+      this.preferredRpcUrl = endpoint.rpcUrl;
+    }
+  }
 
   /**
    * Classify an RPC error for low-cardinality metric labels: `timeout` for the
@@ -204,6 +351,7 @@ export class RpcFailoverClient {
       fn,
       opts?.isRetryable ?? isRetryableRpcError,
       opts?.policy ?? 'pointRead',
+      opts?.skipPreferred ?? false,
     );
     return opts?.rpcUsageConsumer ? withRpcUsageConsumer(opts.rpcUsageConsumer, run) : run();
   }
@@ -239,6 +387,7 @@ export class RpcFailoverClient {
             (p) => fn(this.rebindContract(contract, p)),
             opts?.isRetryable ?? isContractViewRetryable,
             opts?.policy ?? 'pointRead',
+            opts?.skipPreferred ?? false,
           );
           this.recordRpcOutcome('eth_call', 'ok');
           return out;
@@ -281,7 +430,8 @@ export class RpcFailoverClient {
     label: string,
     opts?: { gasLimitBufferBps?: number },
   ): Promise<{ signedTx: string; txHash: string }> {
-    const endpoints = this.getEndpoints();
+    const canonical = this.getEndpoints();
+    const endpoints = this.orderEndpoints(canonical, false);
     let lastRetryable: unknown;
     for (let i = 0; i < endpoints.length; i += 1) {
       const endpoint = endpoints[i];
@@ -324,11 +474,15 @@ export class RpcFailoverClient {
             );
           }
         }
-        return await withTimeout(
+        const signed = await withTimeout(
           this.signPopulated(rpcSigner, populated),
           RPC_TRANSACTION_POPULATION_ATTEMPT_TIMEOUT_MS,
           `${label} transaction signing via RPC #${i + 1}`,
         );
+        // Signed on this endpoint → prefer it for the read-your-write ops that
+        // follow (the caller's broadcast + receipt + confirming re-reads).
+        this.notePreferredOutcome(endpoint, canonical, false, i === 0);
+        return signed;
       } catch (err) {
         if (!isRetryableRpcError(err)) throw err;
         lastRetryable = err;
@@ -337,17 +491,17 @@ export class RpcFailoverClient {
         }
       }
     }
-    if (lastRetryable) noteRpcExhaustion(`${label} preparation`, endpoints.map((e) => e.rpcUrl));
+    if (lastRetryable) noteRpcExhaustion(`${label} preparation`, canonical.map((e) => e.rpcUrl));
     // Single provider → carry the code on a new error but keep the message
     // byte-identical (no second endpoint, so the raw message reads cleaner and
     // any message-inspecting caller keeps seeing it). Multiple providers → the
     // HOST-ONLY aggregate (never full URLs — a configured rpcUrl may carry an API
     // key and this message reaches HTTP clients via response paths that echo
     // err.message, e.g. the create+publish 207 tail).
-    const message = endpoints.length <= 1
+    const message = canonical.length <= 1
       ? errorMessage(lastRetryable)
       : `${label} transaction preparation failed on all configured RPC endpoints ` +
-        `(${endpoints.map((e) => rpcHost(e.rpcUrl)).join(', ')}): ${errorMessage(lastRetryable)}`;
+        `(${canonical.map((e) => rpcHost(e.rpcUrl)).join(', ')}): ${errorMessage(lastRetryable)}`;
     // Populate+sign exhausted every endpoint. This is the PREPARE phase
     // (populateTransaction / eth_estimateGas), NOT the broadcast — label it
     // eth_estimateGas so it doesn't collide with the genuine
@@ -357,7 +511,7 @@ export class RpcFailoverClient {
     });
     throw new ChainRpcTransportError('RPC_ENDPOINTS_EXHAUSTED', message, {
       cause: lastRetryable,
-      rpcUrls: endpoints.map((e) => e.rpcUrl),
+      rpcUrls: canonical.map((e) => e.rpcUrl),
     });
   }
 
@@ -377,7 +531,8 @@ export class RpcFailoverClient {
         const metrics = getMetrics();
         const startedAt = Date.now();
         try {
-          const endpoints = this.getEndpoints();
+          const canonical = this.getEndpoints();
+          const endpoints = this.orderEndpoints(canonical, false);
           let lastRetryable: unknown;
           for (let i = 0; i < endpoints.length; i += 1) {
             const endpoint = endpoints[i];
@@ -396,6 +551,7 @@ export class RpcFailoverClient {
               );
               span.setAttribute('dkg.tx_hash', txHash);
               this.recordRpcOutcome('eth_sendRawTransaction', 'ok');
+              this.notePreferredOutcome(endpoint, canonical, false, i === 0);
               return;
             } catch (err) {
               if (isKnownTransactionError(err)) {
@@ -403,6 +559,7 @@ export class RpcFailoverClient {
                 span.setAttribute('dkg.tx_hash', txHash);
                 span.addEvent('broadcast.already_known', { attempt: i + 1 });
                 this.recordRpcOutcome('eth_sendRawTransaction', 'ok');
+                this.notePreferredOutcome(endpoint, canonical, false, i === 0);
                 return;
               }
               if (!isRetryableRpcError(err)) {
@@ -417,7 +574,7 @@ export class RpcFailoverClient {
           }
           // All configured endpoints exhausted.
           this.recordRpcOutcome('eth_sendRawTransaction', this.rpcOutcome(lastRetryable), { retryable: true, exhausted: true });
-          if (lastRetryable) noteRpcExhaustion(`${label} broadcast`, endpoints.map((e) => e.rpcUrl));
+          if (lastRetryable) noteRpcExhaustion(`${label} broadcast`, canonical.map((e) => e.rpcUrl));
           // Typed transport error (mirroring the preparation loop + CLI path) so a
           // broadcast-time all-endpoints-exhausted failure maps to a retryable 503 at
           // the HTTP boundary, not a generic 500 — an exhaustion after a provider
@@ -425,7 +582,7 @@ export class RpcFailoverClient {
           throw new ChainRpcTransportError(
             'RPC_ENDPOINTS_EXHAUSTED',
             `${label} broadcast failed on all configured RPC endpoints for tx ${txHash}: ${errorMessage(lastRetryable)}`,
-            { cause: lastRetryable, rpcUrls: endpoints.map((e) => e.rpcUrl) },
+            { cause: lastRetryable, rpcUrls: canonical.map((e) => e.rpcUrl) },
           );
         } finally {
           metrics.chainRpcDuration.record(Date.now() - startedAt, {
@@ -454,7 +611,8 @@ export class RpcFailoverClient {
         const metrics = getMetrics();
         const startedAt = Date.now();
         try {
-          const endpoints = this.getEndpoints();
+          const canonical = this.getEndpoints();
+          const endpoints = this.orderEndpoints(canonical, false);
           let lastRetryable: unknown;
           let sawNonErrorResponse = false;
           for (let i = 0; i < endpoints.length; i += 1) {
@@ -476,6 +634,11 @@ export class RpcFailoverClient {
               if (receipt) {
                 span.setAttribute('dkg.tx_hash', txHash);
                 this.recordRpcOutcome('eth_getTransactionReceipt', 'ok');
+                // A DEFINITIVE hit (non-null receipt) on this endpoint → prefer
+                // it. A null "not mined yet" response is NOT a stickiness signal
+                // (no single winning endpoint), so we only note on a real
+                // receipt — the self-heal still polls every endpoint per tick.
+                this.notePreferredOutcome(endpoint, canonical, false, i === 0);
                 return receipt;
               }
             } catch (err) {
@@ -492,7 +655,7 @@ export class RpcFailoverClient {
           if (lastRetryable && !sawNonErrorResponse) {
             // No backend could even answer the lookup → endpoints exhausted.
             this.recordRpcOutcome('eth_getTransactionReceipt', this.rpcOutcome(lastRetryable), { retryable: true, exhausted: true });
-            noteRpcExhaustion('receipt lookup', endpoints.map((e) => e.rpcUrl));
+            noteRpcExhaustion('receipt lookup', canonical.map((e) => e.rpcUrl));
             throw new ChainRpcTransportError(
               'RPC_RECEIPT_LOOKUP_FAILED',
               `Receipt lookup for tx ${txHash} failed on all configured RPC endpoints: ${errorMessage(lastRetryable)}`,
@@ -530,9 +693,16 @@ export class RpcFailoverClient {
     fn: (provider: JsonRpcProvider) => Promise<T>,
     isRetryable: (err: unknown) => boolean,
     policy: ReadPolicy,
+    skipPreferred: boolean,
   ): Promise<T> {
-    const endpoints = this.getEndpoints();
-    const capMs = resolveCapMs(policy, endpoints.length);
+    // `canonical` = the configured order (index 0 = primary), used for the cap,
+    // the exhaustion aggregate, and the "which is the primary" check. `endpoints`
+    // = the per-op iteration order (preferred-first when sticky). Same members,
+    // possibly reordered — so the cap/exhaustion contract stays canonical while
+    // only the try-order changes.
+    const canonical = this.getEndpoints();
+    const endpoints = this.orderEndpoints(canonical, skipPreferred);
+    const capMs = resolveCapMs(policy, canonical.length);
     let lastRetryable: unknown;
     for (let i = 0; i < endpoints.length; i += 1) {
       const endpoint = endpoints[i];
@@ -546,9 +716,11 @@ export class RpcFailoverClient {
           );
           return fn(endpoint.provider);
         })();
-        return await (capMs == null
+        const out = await (capMs == null
           ? attempt
           : withTimeout(attempt, capMs, `${label} via RPC #${i + 1}`));
+        this.notePreferredOutcome(endpoint, canonical, skipPreferred, i === 0);
+        return out;
       } catch (err) {
         if (!isRetryable(err)) throw err;
         lastRetryable = err;
@@ -557,21 +729,23 @@ export class RpcFailoverClient {
         }
       }
     }
-    if (lastRetryable) noteRpcExhaustion(label, endpoints.map((e) => e.rpcUrl));
+    if (lastRetryable) noteRpcExhaustion(label, canonical.map((e) => e.rpcUrl));
     // Single provider → carry the typed code but keep the original message
     // byte-identical (there is no second endpoint, so the raw message reads
     // cleaner and any message-inspecting caller keeps seeing it). Multiple
     // providers → the host-only "all endpoints" aggregate (never full URLs —
     // a configured rpcUrl may carry an API key and this message can reach HTTP
     // clients via response paths that echo err.message). Mirrors the write
-    // preparation loop's single-vs-multi message handling.
-    const message = endpoints.length <= 1
+    // preparation loop's single-vs-multi message handling. Built from CANONICAL
+    // order so the error's `rpcUrls` stays a stable configured-order contract
+    // regardless of the per-op reorder.
+    const message = canonical.length <= 1
       ? errorMessage(lastRetryable)
       : `${label} read failed on all configured RPC endpoints ` +
-        `(${endpoints.map((e) => rpcHost(e.rpcUrl)).join(', ')}): ${errorMessage(lastRetryable)}`;
+        `(${canonical.map((e) => rpcHost(e.rpcUrl)).join(', ')}): ${errorMessage(lastRetryable)}`;
     throw new ChainRpcTransportError('RPC_ENDPOINTS_EXHAUSTED', message, {
       cause: lastRetryable,
-      rpcUrls: endpoints.map((e) => e.rpcUrl),
+      rpcUrls: canonical.map((e) => e.rpcUrl),
     });
   }
 

--- a/packages/chain/src/rpc-failover-client.ts
+++ b/packages/chain/src/rpc-failover-client.ts
@@ -131,6 +131,18 @@ export type ValidateEndpointFn = (endpoint: RpcEndpoint) => Promise<void>;
  *   - `now`     — monotonic-ish clock (defaults to `Date.now`); injected by the
  *     cadence unit test.
  */
+/**
+ * Optional transport hooks + config for `RpcFailoverClient`, grouped in ONE
+ * object so the constructor boundary stays readable as knobs are added (no
+ * positional `undefined` placeholders for unrelated optional concerns).
+ */
+export interface RpcFailoverClientOptions {
+  /** Optional per-endpoint transport preflight, e.g. static-network chain-id validation. */
+  validateEndpoint?: ValidateEndpointFn;
+  /** Endpoint-stickiness configuration (Mechanism B). */
+  stickiness?: StickinessOptions;
+}
+
 export interface StickinessOptions {
   /** Force stickiness on/off (tests). Ignored if `isEnabled` is given. */
   enabled?: boolean;
@@ -185,6 +197,8 @@ export class RpcFailoverClient {
   /** Transport-ordering preference state machine — the ONLY mutable state this
    *  module owns (see SAFETY BOUNDARY + endpoint-stickiness.ts). */
   private readonly stickiness: EndpointStickiness;
+  /** Optional per-endpoint transport preflight (from `options.validateEndpoint`). */
+  private readonly validateEndpoint?: ValidateEndpointFn;
 
   constructor(
     private readonly getEndpoints: () => RpcEndpoint[],
@@ -194,9 +208,12 @@ export class RpcFailoverClient {
     // construct this client BEFORE its own `chainId` field is assigned and still
     // have the label resolve correctly at metric-record time.
     private readonly chainId: () => string,
-    private readonly validateEndpoint?: ValidateEndpointFn,
-    stickiness?: StickinessOptions,
+    // Optional transport hooks/config in ONE object (preflight + stickiness) so
+    // adding a knob never appends another positional `undefined`.
+    options?: RpcFailoverClientOptions,
   ) {
+    this.validateEndpoint = options?.validateEndpoint;
+    const stickiness = options?.stickiness;
     const isEnabled = stickiness?.isEnabled
       ?? (stickiness?.enabled !== undefined ? () => stickiness.enabled as boolean : () => true);
     this.stickiness = new EndpointStickiness({

--- a/packages/chain/src/rpc-failover-client.ts
+++ b/packages/chain/src/rpc-failover-client.ts
@@ -9,11 +9,12 @@
  * SAFETY BOUNDARY: this module holds NO transaction-safety state — no WAL, no
  * per-wallet serializer, no approval latch. The adapter's tx-orchestration owns
  * all of that and calls into this surface. The ONLY mutable state it owns is a
- * TRANSPORT-ORDERING preference (endpoint stickiness — `preferredRpcUrl` +
- * `primaryProbeDueAt` + `preferredFromWrite`): a "prefer the last-good backend,
- * re-probe the primary at most once per TTL" pointer, keyed on `rpcUrl` (survives
- * a live pool rebind), plus a flag gating whether a nonce-critical populate may
- * reuse it (a read-only-established backend must not drive a write's nonce).
+ * TRANSPORT-ORDERING preference (endpoint stickiness), fully delegated to the
+ * `EndpointStickiness` state machine (see endpoint-stickiness.ts): a "prefer the
+ * last-good backend, re-probe the primary at most once per TTL" model, keyed on
+ * `rpcUrl` (survives a live pool rebind), that also tracks whether the preference
+ * is nonce-safe for writes (a read-only-established backend must not drive a
+ * write's nonce). Each loop asks it for an order (by intent) and reports success.
  * That is pure ordering — it only decides which endpoint each loop TRIES FIRST;
  * it never signs, never gates a broadcast, never re-orders the tx-safety
  * guards, and every loop still falls through to the full endpoint set. The
@@ -43,6 +44,7 @@ import { withSpan, getMetrics } from '@origintrail-official/dkg-core';
 import { withTimeout, isRetryableRpcError, isKnownTransactionError } from './evm-adapter-rpc.js';
 import { errorCode, errorMessage } from './evm-adapter-errors.js';
 import { noteRpcFailover, noteRpcExhaustion, notePreferredEndpoint, rpcHost } from './rpc-failover-log.js';
+import { EndpointStickiness, type StickinessIntent } from './endpoint-stickiness.js';
 import { ChainRpcTransportError } from './chain-rpc-transport-error.js';
 import { withRpcUsageConsumer } from './rpc-usage.js';
 import {
@@ -130,7 +132,12 @@ export type ValidateEndpointFn = (endpoint: RpcEndpoint) => Promise<void>;
  *     cadence unit test.
  */
 export interface StickinessOptions {
+  /** Force stickiness on/off (tests). Ignored if `isEnabled` is given. */
   enabled?: boolean;
+  /** LIVE kill-switch predicate — the CONFIG boundary (the adapter) resolves
+   *  `DKG_DISABLE_RPC_STICKINESS` here so the transport core stays free of any
+   *  process-global dependency. Takes precedence over `enabled`. */
+  isEnabled?: () => boolean;
   ttlMs?: number;
   now?: () => number;
 }
@@ -175,28 +182,9 @@ export function resolveCapMs(policy: ReadPolicy, providerCount: number): number 
 }
 
 export class RpcFailoverClient {
-  // --- Endpoint stickiness (transport-ordering state; see SAFETY BOUNDARY) ---
-  /** The last-good NON-primary endpoint URL to try first, or undefined = none
-   *  (canonical order). Keyed on `rpcUrl` so it survives a live pool rebind. */
-  private preferredRpcUrl: string | undefined;
-  /** Wall-clock deadline after which the next ordering re-probes the primary
-   *  (canonical order) and re-arms this deadline `+ttlMs`. Guarantees at most
-   *  one primary re-stall per TTL under a persistently degraded primary. */
-  private primaryProbeDueAt = 0;
-  /** Whether the current `preferredRpcUrl` was PROVEN by a populate+sign success
-   *  (nonce-critical write), not merely by a read. A read-established backend may
-   *  lag the signer's pending-nonce state, so `populateAndSign` MUST NOT populate
-   *  a fresh nonce on it (a stale nonce broadcasts as `nonce too low`, which the
-   *  idempotent-rebroadcast classifier treats as success → a phantom-accepted tx
-   *  that never mines). Writes only reuse a preferred endpoint once a populate has
-   *  succeeded there; reads (and the nonce-free broadcast/receipt hops) reuse it
-   *  regardless. Preserves #1340 (the recovery's approve populate proves the
-   *  backend, so the retry sticks to it) without letting an unrelated read steer a
-   *  write's nonce. */
-  private preferredFromWrite = false;
-  private readonly stickyNow: () => number;
-  private readonly stickyTtlMs: number;
-  private readonly stickyEnabledOverride: boolean | undefined;
+  /** Transport-ordering preference state machine — the ONLY mutable state this
+   *  module owns (see SAFETY BOUNDARY + endpoint-stickiness.ts). */
+  private readonly stickiness: EndpointStickiness;
 
   constructor(
     private readonly getEndpoints: () => RpcEndpoint[],
@@ -209,132 +197,14 @@ export class RpcFailoverClient {
     private readonly validateEndpoint?: ValidateEndpointFn,
     stickiness?: StickinessOptions,
   ) {
-    this.stickyNow = stickiness?.now ?? Date.now;
-    this.stickyTtlMs = stickiness?.ttlMs ?? STICKY_PREFERRED_TTL_MS;
-    this.stickyEnabledOverride = stickiness?.enabled;
-  }
-
-  /**
-   * Whether stickiness is active. A test override wins; otherwise it is LIVE off
-   * the `DKG_DISABLE_RPC_STICKINESS` kill-switch (checked per-call so flipping
-   * the env + restart disables it without a code change). Rollback lever for a
-   * High-risk transport change.
-   */
-  private stickinessOn(): boolean {
-    if (this.stickyEnabledOverride !== undefined) return this.stickyEnabledOverride;
-    return process.env.DKG_DISABLE_RPC_STICKINESS !== '1';
-  }
-
-  /**
-   * Decide the per-op iteration order over `canonical` (the live configured
-   * order, index 0 = primary). Returns canonical UNLESS a preferred backend is
-   * set, stickiness is on, `skipPreferred` is false, and we are inside the
-   * current re-probe window — in which case the preferred is MOVED to the front
-   * (spliced out and unshifted; never duplicated, so fall-through still visits
-   * every endpoint exactly once). When the re-probe deadline has passed this
-   * op probes the primary first (canonical) AND re-arms the deadline `+ttlMs`,
-   * so a persistently degraded primary is re-probed at most once per TTL.
-   */
-  private orderEndpoints(
-    canonical: RpcEndpoint[],
-    skipPreferred: boolean,
-    requirePopulateProven: boolean,
-  ): RpcEndpoint[] {
-    if (skipPreferred || !this.stickinessOn() || this.preferredRpcUrl === undefined) {
-      return canonical;
-    }
-    // A nonce-critical populate must not START on a backend proven only by a
-    // READ (it may lag the signer's pending nonce). Fall back to canonical
-    // (primary-first = the authoritative nonce source); a populate SUCCESS then
-    // marks the winning backend populate-proven, so subsequent writes stick.
-    if (requirePopulateProven && !this.preferredFromWrite) return canonical;
-    const idx = canonical.findIndex((e) => e.rpcUrl === this.preferredRpcUrl);
-    // idx < 0: preferred no longer configured (pool rebind dropped it).
-    // idx === 0: preferred IS the primary — canonical already tries it first.
-    if (idx <= 0) return canonical;
-    if (this.stickyNow() >= this.primaryProbeDueAt) {
-      // Re-probe the configured primary this op; schedule the next re-probe one
-      // TTL out so we don't re-stall on it again until then.
-      this.primaryProbeDueAt = this.stickyNow() + this.stickyTtlMs;
-      return canonical;
-    }
-    const reordered = canonical.slice();
-    const [preferred] = reordered.splice(idx, 1);
-    reordered.unshift(preferred);
-    return reordered;
-  }
-
-  /**
-   * Update the preferred pointer after `endpoint` served an op successfully.
-   * `canonical[0]` is the configured primary; `triedFirst` is whether this
-   * endpoint was the FIRST one this op attempted (loop index 0). Fully NO-OP
-   * under `skipPreferred` (tip-sensitive reads stay transparent) or when
-   * stickiness is off. All writes here are synchronous (no `await` between the
-   * two field writes) so concurrent ops can only observe a stale order, never
-   * torn state.
-   *   - primary succeeded, tried FIRST → CLEAR the preference (a genuine
-   *     canonical / TTL re-probe proved the primary healthy again).
-   *   - primary succeeded as a FALLBACK (not first) → KEEP the preference: its
-   *     answering ONE op doesn't prove health for the degraded method, and
-   *     clearing outside the TTL cadence would re-stall the next heavy read.
-   *   - a backend succeeded → SET/keep it as preferred; arm the re-probe deadline
-   *     only on FIRST establishment (undefined→set), NOT on every confirming
-   *     success — otherwise the deadline would be pushed forward forever and the
-   *     primary would never be re-probed (the cadence is governed solely by
-   *     `orderEndpoints` re-arming on a re-probe op). A later re-point to a
-   *     different backup is a SILENT pointer move (no new establishment count).
-   *
-   * `isPopulate` marks a nonce-critical populate+sign success (only
-   * `populateAndSign` passes true): it flags the backend `preferredFromWrite`
-   * (nonce-proven). A read success sets it false, so a read-established backend
-   * can serve reads but a subsequent write will re-derive nonce from canonical
-   * order rather than trust a possibly-lagging read-preferred backend.
-   */
-  private notePreferredOutcome(
-    endpoint: RpcEndpoint,
-    canonical: RpcEndpoint[],
-    skipPreferred: boolean,
-    triedFirst: boolean,
-    isPopulate: boolean,
-  ): void {
-    if (skipPreferred || !this.stickinessOn()) return;
-    const primaryUrl = canonical[0]?.rpcUrl;
-    if (endpoint.rpcUrl === primaryUrl) {
-      // Clear the preference ONLY when the primary was tried FIRST — a genuine
-      // canonical / TTL re-probe op whose success proves the primary is healthy
-      // again. A primary reached as a FALLBACK (the preferred backup errored or
-      // returned null on THIS op) does NOT prove primary health for the degraded
-      // method (method-selective 429s are common), so keep the preference:
-      // clearing here would reset stickiness OUTSIDE the TTL re-probe cadence and
-      // re-stall the next heavy read on the still-degraded primary.
-      if (triedFirst) {
-        this.preferredRpcUrl = undefined;
-        this.preferredFromWrite = false;
-      }
-      return;
-    }
-    if (this.preferredRpcUrl === undefined) {
-      // First establishment after a failover: prefer this backend, arm the
-      // re-probe deadline, and emit the operator signal (log + counter).
-      this.preferredRpcUrl = endpoint.rpcUrl;
-      this.primaryProbeDueAt = this.stickyNow() + this.stickyTtlMs;
-      this.preferredFromWrite = isPopulate;
-      notePreferredEndpoint('rpc failover', endpoint.rpcUrl);
-    } else if (this.preferredRpcUrl !== endpoint.rpcUrl) {
-      // Preferred moved to a different backup (the old one also degraded). Keep
-      // the existing re-probe deadline — do NOT re-arm (that is orderEndpoints'
-      // job on a re-probe op). Silent re-point: this is a hop WITHIN an ongoing
-      // degradation episode already counted at establishment, so it does NOT
-      // re-increment `preferredEstablishments` (which counts establishment edges).
-      this.preferredRpcUrl = endpoint.rpcUrl;
-      this.preferredFromWrite = isPopulate;
-    } else if (isPopulate) {
-      // Same preferred backend, now PROVEN by a populate success → upgrade it to
-      // nonce-safe so subsequent writes may stick to it (a read had only proven
-      // it read-safe). Never DOWNGRADE on a read success (a read hitting the
-      // write-proven backend doesn't un-prove its nonce view).
-      this.preferredFromWrite = true;
-    }
+    const isEnabled = stickiness?.isEnabled
+      ?? (stickiness?.enabled !== undefined ? () => stickiness.enabled as boolean : () => true);
+    this.stickiness = new EndpointStickiness({
+      now: stickiness?.now ?? Date.now,
+      ttlMs: stickiness?.ttlMs ?? STICKY_PREFERRED_TTL_MS,
+      isEnabled,
+      onEstablished: (url) => notePreferredEndpoint('rpc failover', url),
+    });
   }
 
   /**
@@ -471,9 +341,10 @@ export class RpcFailoverClient {
     opts?: { gasLimitBufferBps?: number },
   ): Promise<{ signedTx: string; txHash: string }> {
     const canonical = this.getEndpoints();
-    // requirePopulateProven=true: do NOT start a fresh-nonce populate on a
-    // read-only-established backend (nonce-staleness guard); see preferredFromWrite.
-    const endpoints = this.orderEndpoints(canonical, false, true);
+    // 'nonceWrite': the state machine starts a fresh-nonce populate on a backend
+    // ONLY if a prior populate proved it (else canonical primary-first = the
+    // authoritative nonce source) — the nonce-staleness guard.
+    const endpoints = this.stickiness.order(canonical, 'nonceWrite');
     let lastRetryable: unknown;
     for (let i = 0; i < endpoints.length; i += 1) {
       const endpoint = endpoints[i];
@@ -521,11 +392,10 @@ export class RpcFailoverClient {
           RPC_TRANSACTION_POPULATION_ATTEMPT_TIMEOUT_MS,
           `${label} transaction signing via RPC #${i + 1}`,
         );
-        // Signed on this endpoint → prefer it for the read-your-write ops that
-        // follow (the caller's broadcast + receipt + confirming re-reads), and
-        // mark it populate-proven (isPopulate=true) so subsequent nonce-critical
-        // writes may stick to it.
-        this.notePreferredOutcome(endpoint, canonical, false, i === 0, true);
+        // Signed on this endpoint → 'nonceWrite' marks it WRITE-proven (nonce-safe)
+        // so it's preferred for the read-your-write ops that follow (the caller's
+        // broadcast + receipt + confirming re-reads) AND for subsequent populates.
+        this.stickiness.recordSuccess(endpoint, canonical, 'nonceWrite', i === 0);
         return signed;
       } catch (err) {
         if (!isRetryableRpcError(err)) throw err;
@@ -576,7 +446,7 @@ export class RpcFailoverClient {
         const startedAt = Date.now();
         try {
           const canonical = this.getEndpoints();
-          const endpoints = this.orderEndpoints(canonical, false, false);
+          const endpoints = this.stickiness.order(canonical, 'write');
           let lastRetryable: unknown;
           for (let i = 0; i < endpoints.length; i += 1) {
             const endpoint = endpoints[i];
@@ -595,7 +465,7 @@ export class RpcFailoverClient {
               );
               span.setAttribute('dkg.tx_hash', txHash);
               this.recordRpcOutcome('eth_sendRawTransaction', 'ok');
-              this.notePreferredOutcome(endpoint, canonical, false, i === 0, false);
+              this.stickiness.recordSuccess(endpoint, canonical, 'write', i === 0);
               return;
             } catch (err) {
               if (isKnownTransactionError(err)) {
@@ -603,7 +473,7 @@ export class RpcFailoverClient {
                 span.setAttribute('dkg.tx_hash', txHash);
                 span.addEvent('broadcast.already_known', { attempt: i + 1 });
                 this.recordRpcOutcome('eth_sendRawTransaction', 'ok');
-                this.notePreferredOutcome(endpoint, canonical, false, i === 0, false);
+                this.stickiness.recordSuccess(endpoint, canonical, 'write', i === 0);
                 return;
               }
               if (!isRetryableRpcError(err)) {
@@ -656,7 +526,7 @@ export class RpcFailoverClient {
         const startedAt = Date.now();
         try {
           const canonical = this.getEndpoints();
-          const endpoints = this.orderEndpoints(canonical, false, false);
+          const endpoints = this.stickiness.order(canonical, 'write');
           let lastRetryable: unknown;
           let sawNonErrorResponse = false;
           for (let i = 0; i < endpoints.length; i += 1) {
@@ -682,7 +552,7 @@ export class RpcFailoverClient {
                 // it. A null "not mined yet" response is NOT a stickiness signal
                 // (no single winning endpoint), so we only note on a real
                 // receipt — the self-heal still polls every endpoint per tick.
-                this.notePreferredOutcome(endpoint, canonical, false, i === 0, false);
+                this.stickiness.recordSuccess(endpoint, canonical, 'write', i === 0);
                 return receipt;
               }
             } catch (err) {
@@ -745,7 +615,10 @@ export class RpcFailoverClient {
     // possibly reordered — so the cap/exhaustion contract stays canonical while
     // only the try-order changes.
     const canonical = this.getEndpoints();
-    const endpoints = this.orderEndpoints(canonical, skipPreferred, false);
+    // A tip-sensitive read (skipPreferred) is 'transparentRead' (canonical order +
+    // no state mutation); a normal read is 'stickyRead'.
+    const intent: StickinessIntent = skipPreferred ? 'transparentRead' : 'stickyRead';
+    const endpoints = this.stickiness.order(canonical, intent);
     const capMs = resolveCapMs(policy, canonical.length);
     let lastRetryable: unknown;
     for (let i = 0; i < endpoints.length; i += 1) {
@@ -763,7 +636,7 @@ export class RpcFailoverClient {
         const out = await (capMs == null
           ? attempt
           : withTimeout(attempt, capMs, `${label} via RPC #${i + 1}`));
-        this.notePreferredOutcome(endpoint, canonical, skipPreferred, i === 0, false);
+        this.stickiness.recordSuccess(endpoint, canonical, intent, i === 0);
         return out;
       } catch (err) {
         if (!isRetryable(err)) throw err;

--- a/packages/chain/src/rpc-failover-client.ts
+++ b/packages/chain/src/rpc-failover-client.ts
@@ -121,17 +121,6 @@ export type SignPopulatedFn = (
 export type ValidateEndpointFn = (endpoint: RpcEndpoint) => Promise<void>;
 
 /**
- * Endpoint-stickiness knobs (Mechanism B). All optional with production
- * defaults; overridden only by tests (injected clock / TTL) or the kill-switch.
- *   - `enabled` — force stickiness on/off. When omitted, resolved LIVE at
- *     check-time from `DKG_DISABLE_RPC_STICKINESS` (env kill-switch), so the flag
- *     takes effect on restart without a code change.
- *   - `ttlMs`   — the primary re-probe cadence (defaults to
- *     `STICKY_PREFERRED_TTL_MS`).
- *   - `now`     — monotonic-ish clock (defaults to `Date.now`); injected by the
- *     cadence unit test.
- */
-/**
  * Optional transport hooks + config for `RpcFailoverClient`, grouped in ONE
  * object so the constructor boundary stays readable as knobs are added (no
  * positional `undefined` placeholders for unrelated optional concerns).

--- a/packages/chain/src/rpc-failover-client.ts
+++ b/packages/chain/src/rpc-failover-client.ts
@@ -105,6 +105,18 @@ export interface ReadOpts {
    * read/write paths rely on — hence transparent, not merely canonical-ordered.
    */
   skipPreferred?: boolean;
+  /**
+   * Marks a read whose result may be a benign "not on this endpoint (yet)" EMPTY
+   * value (e.g. `eth_getTransactionReceipt` / `getBlock` returning `null`) rather
+   * than a definitive answer. When set, an empty result is NOT a transport
+   * failure: the loop tries the next endpoint WITHOUT de-preferring it or emitting
+   * failover/exhaustion telemetry, and if EVERY endpoint returns empty (and none
+   * errored) the empty value itself is returned. A real transport error still
+   * fails over / exhausts / propagates as usual. This keeps nullable reads
+   * (receipt/tx/block lookups) failing over on a lagging endpoint without a thrown
+   * sentinel polluting stickiness or telemetry.
+   */
+  isEmptyResult?: (value: unknown) => boolean;
 }
 
 /**
@@ -273,6 +285,7 @@ export class RpcFailoverClient {
       opts?.isRetryable ?? isRetryableRpcError,
       opts?.policy ?? 'pointRead',
       opts?.skipPreferred ?? false,
+      opts?.isEmptyResult,
     );
     return opts?.rpcUsageConsumer ? withRpcUsageConsumer(opts.rpcUsageConsumer, run) : run();
   }
@@ -309,6 +322,7 @@ export class RpcFailoverClient {
             opts?.isRetryable ?? isContractViewRetryable,
             opts?.policy ?? 'pointRead',
             opts?.skipPreferred ?? false,
+            opts?.isEmptyResult,
           );
           this.recordRpcOutcome('eth_call', 'ok');
           return out;
@@ -622,6 +636,7 @@ export class RpcFailoverClient {
     isRetryable: (err: unknown) => boolean,
     policy: ReadPolicy,
     skipPreferred: boolean,
+    isEmptyResult?: (value: unknown) => boolean,
   ): Promise<T> {
     // `canonical` = the configured order (index 0 = primary), used for the cap,
     // the exhaustion aggregate, and the "which is the primary" check. `endpoints`
@@ -635,6 +650,8 @@ export class RpcFailoverClient {
     const endpoints = this.stickiness.order(canonical, intent);
     const capMs = resolveCapMs(policy, canonical.length);
     let lastRetryable: unknown;
+    let sawEmpty = false;
+    let lastEmpty: T | undefined;
     for (let i = 0; i < endpoints.length; i += 1) {
       const endpoint = endpoints[i];
       const isLast = i === endpoints.length - 1;
@@ -650,6 +667,16 @@ export class RpcFailoverClient {
         const out = await (capMs == null
           ? attempt
           : withTimeout(attempt, capMs, `${label} via RPC #${i + 1}`));
+        if (isEmptyResult?.(out)) {
+          // A BENIGN "no result on this endpoint (yet)" — a nullable read whose
+          // endpoint hasn't imported the tx/block. This is NOT a transport failure:
+          // it must NOT de-prefer the endpoint (recordFailure) or emit failover
+          // telemetry. Try the next endpoint; if EVERY endpoint is empty (and none
+          // errored) the empty value itself is the honest answer.
+          sawEmpty = true;
+          lastEmpty = out;
+          continue;
+        }
         this.stickiness.recordSuccess(endpoint, canonical, intent, i === 0);
         return out;
       } catch (err) {
@@ -661,24 +688,41 @@ export class RpcFailoverClient {
         }
       }
     }
-    if (lastRetryable) noteRpcExhaustion(label, canonical.map((e) => e.rpcUrl));
-    // Single provider → carry the typed code but keep the original message
-    // byte-identical (there is no second endpoint, so the raw message reads
-    // cleaner and any message-inspecting caller keeps seeing it). Multiple
-    // providers → the host-only "all endpoints" aggregate (never full URLs —
-    // a configured rpcUrl may carry an API key and this message can reach HTTP
-    // clients via response paths that echo err.message). Mirrors the write
-    // preparation loop's single-vs-multi message handling. Built from CANONICAL
-    // order so the error's `rpcUrls` stays a stable configured-order contract
-    // regardless of the per-op reorder.
-    const message = canonical.length <= 1
-      ? errorMessage(lastRetryable)
-      : `${label} read failed on all configured RPC endpoints ` +
-        `(${canonical.map((e) => rpcHost(e.rpcUrl)).join(', ')}): ${errorMessage(lastRetryable)}`;
-    throw new ChainRpcTransportError('RPC_ENDPOINTS_EXHAUSTED', message, {
-      cause: lastRetryable,
-      rpcUrls: canonical.map((e) => e.rpcUrl),
-    });
+    // A REAL transport error on ANY endpoint → exhaustion (telemetry + typed
+    // throw). Order-independent: a mix of empty + transport error still throws
+    // (a transport failure occurred, so "every endpoint lacks it" can't be
+    // concluded and the empty value must NOT be returned as definitive).
+    if (lastRetryable) {
+      noteRpcExhaustion(label, canonical.map((e) => e.rpcUrl));
+      // Single provider → carry the typed code but keep the original message
+      // byte-identical (there is no second endpoint, so the raw message reads
+      // cleaner and any message-inspecting caller keeps seeing it). Multiple
+      // providers → the host-only "all endpoints" aggregate (never full URLs —
+      // a configured rpcUrl may carry an API key and this message can reach HTTP
+      // clients via response paths that echo err.message). Mirrors the write
+      // preparation loop's single-vs-multi message handling. Built from CANONICAL
+      // order so the error's `rpcUrls` stays a stable configured-order contract
+      // regardless of the per-op reorder.
+      const message = canonical.length <= 1
+        ? errorMessage(lastRetryable)
+        : `${label} read failed on all configured RPC endpoints ` +
+          `(${canonical.map((e) => rpcHost(e.rpcUrl)).join(', ')}): ${errorMessage(lastRetryable)}`;
+      throw new ChainRpcTransportError('RPC_ENDPOINTS_EXHAUSTED', message, {
+        cause: lastRetryable,
+        rpcUrls: canonical.map((e) => e.rpcUrl),
+      });
+    }
+    // Every endpoint returned an empty result and none errored → the empty value
+    // is the honest "not found anywhere (yet)" answer (only reachable when an
+    // `isEmptyResult` predicate was supplied).
+    if (sawEmpty) return lastEmpty as T;
+    // Unreachable when >=1 endpoint is configured (each iteration returns,
+    // continues on empty, or throws / sets lastRetryable). Guard the 0-endpoint case.
+    throw new ChainRpcTransportError(
+      'RPC_ENDPOINTS_EXHAUSTED',
+      `${label} read failed: no configured RPC endpoints`,
+      { rpcUrls: [] },
+    );
   }
 
   /**

--- a/packages/chain/src/rpc-failover-client.ts
+++ b/packages/chain/src/rpc-failover-client.ts
@@ -10,8 +10,10 @@
  * per-wallet serializer, no approval latch. The adapter's tx-orchestration owns
  * all of that and calls into this surface. The ONLY mutable state it owns is a
  * TRANSPORT-ORDERING preference (endpoint stickiness — `preferredRpcUrl` +
- * `primaryProbeDueAt`): a "prefer the last-good backend, re-probe the primary at
- * most once per TTL" pointer, keyed on `rpcUrl` (survives a live pool rebind).
+ * `primaryProbeDueAt` + `preferredFromWrite`): a "prefer the last-good backend,
+ * re-probe the primary at most once per TTL" pointer, keyed on `rpcUrl` (survives
+ * a live pool rebind), plus a flag gating whether a nonce-critical populate may
+ * reuse it (a read-only-established backend must not drive a write's nonce).
  * That is pure ordering — it only decides which endpoint each loop TRIES FIRST;
  * it never signs, never gates a broadcast, never re-orders the tx-safety
  * guards, and every loop still falls through to the full endpoint set. The
@@ -181,6 +183,17 @@ export class RpcFailoverClient {
    *  (canonical order) and re-arms this deadline `+ttlMs`. Guarantees at most
    *  one primary re-stall per TTL under a persistently degraded primary. */
   private primaryProbeDueAt = 0;
+  /** Whether the current `preferredRpcUrl` was PROVEN by a populate+sign success
+   *  (nonce-critical write), not merely by a read. A read-established backend may
+   *  lag the signer's pending-nonce state, so `populateAndSign` MUST NOT populate
+   *  a fresh nonce on it (a stale nonce broadcasts as `nonce too low`, which the
+   *  idempotent-rebroadcast classifier treats as success → a phantom-accepted tx
+   *  that never mines). Writes only reuse a preferred endpoint once a populate has
+   *  succeeded there; reads (and the nonce-free broadcast/receipt hops) reuse it
+   *  regardless. Preserves #1340 (the recovery's approve populate proves the
+   *  backend, so the retry sticks to it) without letting an unrelated read steer a
+   *  write's nonce. */
+  private preferredFromWrite = false;
   private readonly stickyNow: () => number;
   private readonly stickyTtlMs: number;
   private readonly stickyEnabledOverride: boolean | undefined;
@@ -222,10 +235,19 @@ export class RpcFailoverClient {
    * op probes the primary first (canonical) AND re-arms the deadline `+ttlMs`,
    * so a persistently degraded primary is re-probed at most once per TTL.
    */
-  private orderEndpoints(canonical: RpcEndpoint[], skipPreferred: boolean): RpcEndpoint[] {
+  private orderEndpoints(
+    canonical: RpcEndpoint[],
+    skipPreferred: boolean,
+    requirePopulateProven: boolean,
+  ): RpcEndpoint[] {
     if (skipPreferred || !this.stickinessOn() || this.preferredRpcUrl === undefined) {
       return canonical;
     }
+    // A nonce-critical populate must not START on a backend proven only by a
+    // READ (it may lag the signer's pending nonce). Fall back to canonical
+    // (primary-first = the authoritative nonce source); a populate SUCCESS then
+    // marks the winning backend populate-proven, so subsequent writes stick.
+    if (requirePopulateProven && !this.preferredFromWrite) return canonical;
     const idx = canonical.findIndex((e) => e.rpcUrl === this.preferredRpcUrl);
     // idx < 0: preferred no longer configured (pool rebind dropped it).
     // idx === 0: preferred IS the primary — canonical already tries it first.
@@ -261,12 +283,19 @@ export class RpcFailoverClient {
    *     primary would never be re-probed (the cadence is governed solely by
    *     `orderEndpoints` re-arming on a re-probe op). A later re-point to a
    *     different backup is a SILENT pointer move (no new establishment count).
+   *
+   * `isPopulate` marks a nonce-critical populate+sign success (only
+   * `populateAndSign` passes true): it flags the backend `preferredFromWrite`
+   * (nonce-proven). A read success sets it false, so a read-established backend
+   * can serve reads but a subsequent write will re-derive nonce from canonical
+   * order rather than trust a possibly-lagging read-preferred backend.
    */
   private notePreferredOutcome(
     endpoint: RpcEndpoint,
     canonical: RpcEndpoint[],
     skipPreferred: boolean,
     triedFirst: boolean,
+    isPopulate: boolean,
   ): void {
     if (skipPreferred || !this.stickinessOn()) return;
     const primaryUrl = canonical[0]?.rpcUrl;
@@ -278,7 +307,10 @@ export class RpcFailoverClient {
       // method (method-selective 429s are common), so keep the preference:
       // clearing here would reset stickiness OUTSIDE the TTL re-probe cadence and
       // re-stall the next heavy read on the still-degraded primary.
-      if (triedFirst) this.preferredRpcUrl = undefined;
+      if (triedFirst) {
+        this.preferredRpcUrl = undefined;
+        this.preferredFromWrite = false;
+      }
       return;
     }
     if (this.preferredRpcUrl === undefined) {
@@ -286,6 +318,7 @@ export class RpcFailoverClient {
       // re-probe deadline, and emit the operator signal (log + counter).
       this.preferredRpcUrl = endpoint.rpcUrl;
       this.primaryProbeDueAt = this.stickyNow() + this.stickyTtlMs;
+      this.preferredFromWrite = isPopulate;
       notePreferredEndpoint('rpc failover', endpoint.rpcUrl);
     } else if (this.preferredRpcUrl !== endpoint.rpcUrl) {
       // Preferred moved to a different backup (the old one also degraded). Keep
@@ -294,6 +327,13 @@ export class RpcFailoverClient {
       // degradation episode already counted at establishment, so it does NOT
       // re-increment `preferredEstablishments` (which counts establishment edges).
       this.preferredRpcUrl = endpoint.rpcUrl;
+      this.preferredFromWrite = isPopulate;
+    } else if (isPopulate) {
+      // Same preferred backend, now PROVEN by a populate success → upgrade it to
+      // nonce-safe so subsequent writes may stick to it (a read had only proven
+      // it read-safe). Never DOWNGRADE on a read success (a read hitting the
+      // write-proven backend doesn't un-prove its nonce view).
+      this.preferredFromWrite = true;
     }
   }
 
@@ -431,7 +471,9 @@ export class RpcFailoverClient {
     opts?: { gasLimitBufferBps?: number },
   ): Promise<{ signedTx: string; txHash: string }> {
     const canonical = this.getEndpoints();
-    const endpoints = this.orderEndpoints(canonical, false);
+    // requirePopulateProven=true: do NOT start a fresh-nonce populate on a
+    // read-only-established backend (nonce-staleness guard); see preferredFromWrite.
+    const endpoints = this.orderEndpoints(canonical, false, true);
     let lastRetryable: unknown;
     for (let i = 0; i < endpoints.length; i += 1) {
       const endpoint = endpoints[i];
@@ -480,8 +522,10 @@ export class RpcFailoverClient {
           `${label} transaction signing via RPC #${i + 1}`,
         );
         // Signed on this endpoint → prefer it for the read-your-write ops that
-        // follow (the caller's broadcast + receipt + confirming re-reads).
-        this.notePreferredOutcome(endpoint, canonical, false, i === 0);
+        // follow (the caller's broadcast + receipt + confirming re-reads), and
+        // mark it populate-proven (isPopulate=true) so subsequent nonce-critical
+        // writes may stick to it.
+        this.notePreferredOutcome(endpoint, canonical, false, i === 0, true);
         return signed;
       } catch (err) {
         if (!isRetryableRpcError(err)) throw err;
@@ -532,7 +576,7 @@ export class RpcFailoverClient {
         const startedAt = Date.now();
         try {
           const canonical = this.getEndpoints();
-          const endpoints = this.orderEndpoints(canonical, false);
+          const endpoints = this.orderEndpoints(canonical, false, false);
           let lastRetryable: unknown;
           for (let i = 0; i < endpoints.length; i += 1) {
             const endpoint = endpoints[i];
@@ -551,7 +595,7 @@ export class RpcFailoverClient {
               );
               span.setAttribute('dkg.tx_hash', txHash);
               this.recordRpcOutcome('eth_sendRawTransaction', 'ok');
-              this.notePreferredOutcome(endpoint, canonical, false, i === 0);
+              this.notePreferredOutcome(endpoint, canonical, false, i === 0, false);
               return;
             } catch (err) {
               if (isKnownTransactionError(err)) {
@@ -559,7 +603,7 @@ export class RpcFailoverClient {
                 span.setAttribute('dkg.tx_hash', txHash);
                 span.addEvent('broadcast.already_known', { attempt: i + 1 });
                 this.recordRpcOutcome('eth_sendRawTransaction', 'ok');
-                this.notePreferredOutcome(endpoint, canonical, false, i === 0);
+                this.notePreferredOutcome(endpoint, canonical, false, i === 0, false);
                 return;
               }
               if (!isRetryableRpcError(err)) {
@@ -612,7 +656,7 @@ export class RpcFailoverClient {
         const startedAt = Date.now();
         try {
           const canonical = this.getEndpoints();
-          const endpoints = this.orderEndpoints(canonical, false);
+          const endpoints = this.orderEndpoints(canonical, false, false);
           let lastRetryable: unknown;
           let sawNonErrorResponse = false;
           for (let i = 0; i < endpoints.length; i += 1) {
@@ -638,7 +682,7 @@ export class RpcFailoverClient {
                 // it. A null "not mined yet" response is NOT a stickiness signal
                 // (no single winning endpoint), so we only note on a real
                 // receipt — the self-heal still polls every endpoint per tick.
-                this.notePreferredOutcome(endpoint, canonical, false, i === 0);
+                this.notePreferredOutcome(endpoint, canonical, false, i === 0, false);
                 return receipt;
               }
             } catch (err) {
@@ -701,7 +745,7 @@ export class RpcFailoverClient {
     // possibly reordered — so the cap/exhaustion contract stays canonical while
     // only the try-order changes.
     const canonical = this.getEndpoints();
-    const endpoints = this.orderEndpoints(canonical, skipPreferred);
+    const endpoints = this.orderEndpoints(canonical, skipPreferred, false);
     const capMs = resolveCapMs(policy, canonical.length);
     let lastRetryable: unknown;
     for (let i = 0; i < endpoints.length; i += 1) {
@@ -719,7 +763,7 @@ export class RpcFailoverClient {
         const out = await (capMs == null
           ? attempt
           : withTimeout(attempt, capMs, `${label} via RPC #${i + 1}`));
-        this.notePreferredOutcome(endpoint, canonical, skipPreferred, i === 0);
+        this.notePreferredOutcome(endpoint, canonical, skipPreferred, i === 0, false);
         return out;
       } catch (err) {
         if (!isRetryable(err)) throw err;

--- a/packages/chain/src/rpc-failover-client.ts
+++ b/packages/chain/src/rpc-failover-client.ts
@@ -146,9 +146,14 @@ export interface RpcFailoverClientOptions {
 export interface StickinessOptions {
   /** Force stickiness on/off (tests). Ignored if `isEnabled` is given. */
   enabled?: boolean;
-  /** LIVE kill-switch predicate — the CONFIG boundary (the adapter) resolves
-   *  `DKG_DISABLE_RPC_STICKINESS` here so the transport core stays free of any
-   *  process-global dependency. Takes precedence over `enabled`. */
+  /** Kill-switch predicate, evaluated LIVE per check. OWNERSHIP: the config
+   *  boundary owns env resolution — the production adapter injects
+   *  `() => process.env.DKG_DISABLE_RPC_STICKINESS !== '1'` here, so the transport
+   *  core carries no process-global dependency. Takes precedence over `enabled`.
+   *  When NEITHER `isEnabled` nor `enabled` is supplied, stickiness defaults to
+   *  ENABLED and the env kill-switch is NOT consulted by the core — only the
+   *  adapter-injected predicate honors it (a bare `new RpcFailoverClient(...)` is a
+   *  test/non-production path). */
   isEnabled?: () => boolean;
   ttlMs?: number;
   now?: () => number;

--- a/packages/chain/src/rpc-failover-client.ts
+++ b/packages/chain/src/rpc-failover-client.ts
@@ -411,6 +411,7 @@ export class RpcFailoverClient {
       } catch (err) {
         if (!isRetryableRpcError(err)) throw err;
         lastRetryable = err;
+        this.stickiness.recordFailure(endpoint, 'nonceWrite'); // de-prefer a failed backend
         if (i < endpoints.length - 1) {
           noteRpcFailover(`${label} preparation`, endpoints[i].rpcUrl, err, endpoints[i + 1].rpcUrl);
         }
@@ -492,6 +493,7 @@ export class RpcFailoverClient {
                 throw err;
               }
               lastRetryable = err;
+              this.stickiness.recordFailure(endpoint, 'write'); // de-prefer a failed backend
               if (i < endpoints.length - 1) {
                 noteRpcFailover(`${label} broadcast`, endpoints[i].rpcUrl, err, endpoints[i + 1].rpcUrl);
               }
@@ -572,6 +574,7 @@ export class RpcFailoverClient {
                 throw err;
               }
               lastRetryable = err;
+              this.stickiness.recordFailure(endpoint, 'write'); // de-prefer a failed backend
               if (i < endpoints.length - 1) {
                 noteRpcFailover('receipt lookup', endpoints[i].rpcUrl, err, endpoints[i + 1].rpcUrl);
               }
@@ -652,6 +655,7 @@ export class RpcFailoverClient {
       } catch (err) {
         if (!isRetryable(err)) throw err;
         lastRetryable = err;
+        this.stickiness.recordFailure(endpoint, intent); // de-prefer a failed backend
         if (!isLast) {
           noteRpcFailover(label, endpoints[i].rpcUrl, err, endpoints[i + 1].rpcUrl);
         }

--- a/packages/chain/src/rpc-failover-log.ts
+++ b/packages/chain/src/rpc-failover-log.ts
@@ -77,6 +77,12 @@ export function rpcHost(url: string): string {
 interface MutableStats {
   failovers: number;
   exhaustions: number;
+  // Count of times endpoint-stickiness ESTABLISHED a preferred (last-good)
+  // backend after a failover — i.e. how often the client stuck to a backup
+  // because the primary was degraded. A rising counter is the operator's signal
+  // that a configured primary is unhealthy. Cleared on a primary re-probe
+  // success (not tracked here — the establish edge is the load-bearing signal).
+  preferredEstablishments: number;
   byErrorClass: Map<RpcFailoverErrorClass, number>;
   byEndpointHost: Map<string, number>;
 }
@@ -87,7 +93,13 @@ const MAX_TRACKED_HOSTS = 64;
 const MAX_DEDUP_KEYS = 256;
 
 function freshStats(): MutableStats {
-  return { failovers: 0, exhaustions: 0, byErrorClass: new Map(), byEndpointHost: new Map() };
+  return {
+    failovers: 0,
+    exhaustions: 0,
+    preferredEstablishments: 0,
+    byErrorClass: new Map(),
+    byEndpointHost: new Map(),
+  };
 }
 
 let stats: MutableStats = freshStats();
@@ -101,6 +113,7 @@ function bump(map: Map<string, number>, key: string, cap: number): void {
 export interface RpcFailoverStatsSnapshot {
   failovers: number;
   exhaustions: number;
+  preferredEstablishments: number;
   byErrorClass: Record<string, number>;
   byEndpointHost: Record<string, number>;
 }
@@ -109,6 +122,7 @@ export function getRpcFailoverStats(): RpcFailoverStatsSnapshot {
   return {
     failovers: stats.failovers,
     exhaustions: stats.exhaustions,
+    preferredEstablishments: stats.preferredEstablishments,
     byErrorClass: Object.fromEntries(stats.byErrorClass),
     byEndpointHost: Object.fromEntries(stats.byEndpointHost),
   };
@@ -213,6 +227,37 @@ export function noteRpcExhaustion(label: string, urls: readonly string[]): void 
       const suffix = suppressed > 0 ? ` (${suppressed} similar exhaustions suppressed in the previous window)` : '';
       // eslint-disable-next-line no-console
       console.warn(`[chain] RPC endpoints exhausted: ${label} failed on all ${hosts.length} endpoint(s) [${hosts.join(', ')}]${suffix}`);
+      setDedup(key, now);
+    } else {
+      entry.suppressed += 1;
+    }
+  } catch {
+    // Observability must never break the failover path.
+  }
+}
+
+/**
+ * Record + log that endpoint-stickiness ESTABLISHED a preferred (last-good)
+ * backend after a failover — the `RpcFailoverClient` will now try `preferredUrl`
+ * first (until a TTL'd primary re-probe succeeds). Host-only, dedup-gated, and
+ * never-throwing, symmetric with {@link noteRpcFailover}: it sits on the success
+ * path inside the failover loops and must never alter control flow. Gives
+ * operators a visible "we're leaning on a backup because the primary is
+ * degraded" signal (also counted in {@link getRpcFailoverStats}).
+ */
+export function notePreferredEndpoint(label: string, preferredUrl: string): void {
+  try {
+    stats.preferredEstablishments += 1;
+    const host = rpcHost(preferredUrl);
+    const key = `PREFERRED|${host}`;
+    const now = nowMs();
+    const entry = dedup.get(key);
+    const shouldEmit = !entry || now - entry.lastEmitAt >= DEFAULT_DEDUP_WINDOW_MS;
+    if (shouldEmit) {
+      const suppressed = entry?.suppressed ?? 0;
+      const suffix = suppressed > 0 ? ` (${suppressed} similar re-establishments suppressed in the previous window)` : '';
+      // eslint-disable-next-line no-console
+      console.warn(`[chain] RPC stickiness: ${label} now prefers ${host} (primary degraded)${suffix}`);
       setDedup(key, now);
     } else {
       entry.suppressed += 1;

--- a/packages/chain/src/rpc-failover-log.ts
+++ b/packages/chain/src/rpc-failover-log.ts
@@ -77,11 +77,14 @@ export function rpcHost(url: string): string {
 interface MutableStats {
   failovers: number;
   exhaustions: number;
-  // Count of times endpoint-stickiness ESTABLISHED a preferred (last-good)
-  // backend after a failover — i.e. how often the client stuck to a backup
-  // because the primary was degraded. A rising counter is the operator's signal
-  // that a configured primary is unhealthy. Cleared on a primary re-probe
-  // success (not tracked here — the establish edge is the load-bearing signal).
+  // CUMULATIVE, monotonically-increasing count of establishment edges — each
+  // time endpoint-stickiness newly ESTABLISHED a preferred (last-good) backend
+  // after a failover (the primary was degraded). It is NOT decremented when the
+  // primary recovers and the preference is cleared; only the process-wide test
+  // reset (`_resetRpcFailoverStatsForTest`) zeroes it. A rising rate is the
+  // operator's signal that a configured primary is flapping. It is NOT a gauge of
+  // the current active preference (that state lives on the client instance) — for
+  // "is a preference active right now" a separate gauge would be needed.
   preferredEstablishments: number;
   byErrorClass: Map<RpcFailoverErrorClass, number>;
   byEndpointHost: Map<string, number>;

--- a/packages/chain/test/evm-adapter-cg-policy-read-stickiness.unit.test.ts
+++ b/packages/chain/test/evm-adapter-cg-policy-read-stickiness.unit.test.ts
@@ -1,0 +1,176 @@
+/**
+ * #1337 (via Mechanism B endpoint stickiness): the SWM public-CG gate
+ * (`DKGAgent.isContextGraphPublicOnChain` → `resolveOnChainAccessPolicyState`)
+ * makes up to THREE sequential on-chain policy reads
+ * (`getContextGraphNameHash` → `isContextGraphActiveOnChain` →
+ * `getContextGraphAccessPolicy`), each wrapped in the agent's 2.5s
+ * `raceChainPolicyRead`. Under a DEGRADED primary, on `main` every one of those
+ * reads restarts the failover loop at endpoint[0] and re-stalls on the primary —
+ * so each read blows the 2.5s race and the gate fails closed (SWM wrongly kept
+ * encrypted), even though a healthy backup is configured.
+ *
+ * These drive the REAL `EVMChainAdapter` policy-read methods through the REAL
+ * `RpcFailoverClient` (bare-provider doubles, no Hardhat — sibling of
+ * `evm-adapter-cg-deposit-failover.unit.test.ts`). They prove the transport-level
+ * behavior that resolves #1337: once one read fails over to the backup, endpoint
+ * stickiness makes the NEXT policy read start on that backup, so it finishes well
+ * under the 2.5s race instead of re-stalling on the primary. (The agent's
+ * `raceChainPolicyRead` wrapper + the `isContextGraphPublicOnChain` wiring onto
+ * these methods are covered independently in `packages/agent`'s
+ * `swm-public-cg-plaintext.test.ts`; here we model the 2.5s race inline to make
+ * the #1337 fail-close / pass boundary explicit against the real transport.)
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { EVMChainAdapter, type EVMAdapterConfig } from '../src/evm-adapter.js';
+import { RPC_READ_STALL_TIMEOUT_MS } from '../src/evm-adapter-constants.js';
+import { _resetRpcFailoverStatsForTest } from '../src/rpc-failover-log.js';
+
+const DEPLOYER_PK = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
+const ADMIN_PK = '0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a';
+
+// The agent's per-read policy race (dkg-agent-constants CHAIN_POLICY_READ_TIMEOUT_MS
+// = 2500ms), reproduced here so the #1337 fail-close/pass boundary is explicit.
+// It is deliberately TIGHTER than the 4s transport cap (RPC_READ_STALL_TIMEOUT_MS),
+// so a primary stall fails the race BEFORE the transport fails over.
+const CHAIN_POLICY_RACE_MS = 2_500;
+
+function minimalConfig(overrides: Partial<EVMAdapterConfig> = {}): EVMAdapterConfig {
+  return {
+    rpcUrl: 'http://127.0.0.1:59998',
+    privateKey: DEPLOYER_PK,
+    adminPrivateKey: ADMIN_PK,
+    hubAddress: '0x0000000000000000000000000000000000000001',
+    chainId: 'evm:31337',
+    staticNetwork: false,
+    ...overrides,
+  };
+}
+
+function recorder<A extends unknown[], R>(impl: (...args: A) => R) {
+  const calls: A[] = [];
+  const fn = (...args: A): R => { calls.push(args); return impl(...args); };
+  return Object.assign(fn, { calls });
+}
+
+const retryable429 = () => { const e = new Error('429 too many requests'); (e as any).status = 429; return e; };
+
+interface EndpointViews {
+  isActive: () => Promise<boolean>;
+  getPolicy: () => Promise<bigint>;
+}
+
+// Real EVMChainAdapter, two endpoints, ContextGraphStorage stubbed as a
+// per-endpoint `connect` double so the context-graph policy reads run the REAL
+// `this.readContract` → `rpcFailover` failover (mirrors the #1535 deposit-failover
+// harness). `p0` = primary, `p1` = backup.
+function makePolicyAdapter(views: { primary: EndpointViews; backup: EndpointViews }) {
+  const a: any = new EVMChainAdapter(minimalConfig());
+  a.initialized = true;
+  a.init = async () => { a.initialized = true; };
+  a.ensureConfiguredStaticChainIdValidated = async () => {};
+
+  const p0 = {}; const p1 = {};
+  a.providers = [p0, p1];
+  a.rpcUrls = ['https://primary.example', 'https://backup.example'];
+
+  a.contracts = {
+    contextGraphStorage: {
+      connect: (p: unknown) => {
+        const v = p === p0 ? views.primary : views.backup;
+        return {
+          isContextGraphActive: (_id: bigint) => v.isActive(),
+          getAccessPolicy: (_id: bigint) => v.getPolicy(),
+        };
+      },
+    },
+  };
+  return { a };
+}
+
+describe('#1337: context-graph policy reads reuse the last-good endpoint (Mechanism B stickiness)', () => {
+  afterEach(() => { vi.useRealTimers(); _resetRpcFailoverStatsForTest(); });
+
+  it('a STALLED primary fails the 2.5s policy race, but primes the preferred so the NEXT read passes it', async () => {
+    vi.useFakeTimers();
+    const primaryActive = recorder(() => new Promise<boolean>(() => {})); // hangs forever
+    const backupActive = recorder(async () => true);
+    const { a } = makePolicyAdapter({
+      primary: { isActive: primaryActive, getPolicy: async () => 0n },
+      backup: { isActive: backupActive, getPolicy: async () => 0n },
+    });
+
+    const SENTINEL = Symbol('policy-read-timeout');
+    const race = <T>(p: Promise<T>, ms: number): Promise<T | typeof SENTINEL> => {
+      let t: ReturnType<typeof setTimeout>;
+      const to = new Promise<typeof SENTINEL>((r) => { t = setTimeout(() => r(SENTINEL), ms); });
+      return Promise.race([p.finally(() => clearTimeout(t)), to]);
+    };
+
+    // Read #1: primary hangs. The 2.5s policy race fails closed while the 4s
+    // transport cap keeps the read running underneath.
+    const read1 = a.isContextGraphActiveOnChain(7n);
+    const raced1 = race(read1, CHAIN_POLICY_RACE_MS);
+    await vi.advanceTimersByTimeAsync(CHAIN_POLICY_RACE_MS);
+    expect(await raced1).toBe(SENTINEL); // #1337 symptom: the policy read fails closed at 2.5s
+
+    // The transport cap (4s) then fires → the read fails over to the backup →
+    // establishes preferred = backup (the background completion the review flagged).
+    await vi.advanceTimersByTimeAsync(RPC_READ_STALL_TIMEOUT_MS - CHAIN_POLICY_RACE_MS + 100);
+    expect(await read1).toBe(true); // eventually completed on the backup
+
+    // Read #2: preferred = backup → tries the backup FIRST → resolves fast, well
+    // inside the 2.5s race. On `main` (index-0) it would re-stall on the primary
+    // and fail the race again.
+    const read2 = a.isContextGraphActiveOnChain(7n);
+    const raced2 = race(read2, CHAIN_POLICY_RACE_MS);
+    await vi.advanceTimersByTimeAsync(50);
+    expect(await raced2).toBe(true); // #1337 FIXED: the second policy read passes the race
+    expect(primaryActive.calls).toHaveLength(1); // primary NOT re-probed on read #2 (index-0 → 2)
+    expect(backupActive.calls).toHaveLength(2);  // read #1 failover + read #2 preferred-first
+  });
+
+  it('one failover primes the preferred for a SUBSEQUENT heterogeneous policy read (the 3 sequential reads share it)', async () => {
+    // A degraded (but fast-erroring) primary — the cross-op ordering proof, no
+    // stalls needed. isContextGraphActiveOnChain establishes the preferred; the
+    // DIFFERENT getContextGraphAccessPolicy read then starts on that same backend.
+    const primaryActive = recorder(async () => { throw retryable429(); });
+    const backupActive = recorder(async () => true);
+    const primaryPolicy = recorder(async () => { throw retryable429(); });
+    const backupPolicy = recorder(async () => 0n);
+    const { a } = makePolicyAdapter({
+      primary: { isActive: primaryActive, getPolicy: primaryPolicy },
+      backup: { isActive: backupActive, getPolicy: backupPolicy },
+    });
+
+    // Read #1 (isContextGraphActiveOnChain): primary 429 → fail over → backup ok → preferred := backup
+    expect(await a.isContextGraphActiveOnChain(7n)).toBe(true);
+    expect(primaryActive.calls).toHaveLength(1);
+    expect(backupActive.calls).toHaveLength(1);
+
+    // Read #2 (getContextGraphAccessPolicy): a DIFFERENT method on the same storage
+    // contract → preferred = backup → backup FIRST → the primary is NOT re-probed.
+    expect(await a.getContextGraphAccessPolicy(7n)).toBe(0);
+    expect(backupPolicy.calls).toHaveLength(1);
+    expect(primaryPolicy.calls).toHaveLength(0); // #1337: the 2nd sequential read does not re-stall the primary
+  });
+
+  it('kill-switch (DKG_DISABLE_RPC_STICKINESS=1) reproduces the pre-change re-stall on the 2nd read', async () => {
+    const prev = process.env.DKG_DISABLE_RPC_STICKINESS;
+    process.env.DKG_DISABLE_RPC_STICKINESS = '1';
+    try {
+      const primaryPolicy = recorder(async () => { throw retryable429(); });
+      const backupPolicy = recorder(async () => 0n);
+      const { a } = makePolicyAdapter({
+        primary: { isActive: async () => { throw retryable429(); }, getPolicy: primaryPolicy },
+        backup: { isActive: async () => true, getPolicy: backupPolicy },
+      });
+
+      expect(await a.isContextGraphActiveOnChain(7n)).toBe(true); // establishes nothing (kill-switch)
+      expect(await a.getContextGraphAccessPolicy(7n)).toBe(0);
+      expect(primaryPolicy.calls).toHaveLength(1); // index-0: the 2nd read RE-PROBES the primary (the #1337 bug)
+    } finally {
+      if (prev === undefined) delete process.env.DKG_DISABLE_RPC_STICKINESS;
+      else process.env.DKG_DISABLE_RPC_STICKINESS = prev;
+    }
+  });
+});

--- a/packages/chain/test/evm-adapter-tip-read-carveouts.unit.test.ts
+++ b/packages/chain/test/evm-adapter-tip-read-carveouts.unit.test.ts
@@ -73,11 +73,16 @@ describe('endpoint-stickiness carve-outs: tip-sensitive reads pass skipPreferred
     expect(readProvider.calls.find((c: any[]) => c[0] === 'pca rpc eth_blockNumber')![2])
       .toMatchObject({ skipPreferred: true });
 
-    // eth_getBlockByNumber('latest') → TIP → skipPreferred.
-    await a.requestPublishingConvictionRpc('eth_getBlockByNumber', ['latest', false]);
-    expect(readProvider.calls.find((c: any[]) => c[0] === 'pca rpc eth_getBlockByNumber' && c[2]?.skipPreferred))
-      .toBeDefined();
+    // EVERY latest-family eth_getBlockByNumber tag → TIP → skipPreferred (a
+    // regression dropping any one of them from PCA_TIP_BLOCK_TAGS is caught here).
+    for (const blockTag of ['latest', 'pending', 'safe', 'finalized']) {
+      readProvider.calls.length = 0;
+      await a.requestPublishingConvictionRpc('eth_getBlockByNumber', [blockTag, false]);
+      expect(readProvider.calls.find((c: any[]) => c[0] === 'pca rpc eth_getBlockByNumber')![2])
+        .toMatchObject({ skipPreferred: true });
+    }
 
+    readProvider.calls.length = 0;
     // eth_getTransactionReceipt → NOT a tip read → STICKY (no skipPreferred), so a
     // lagging primary's null doesn't short-circuit the backup that has the receipt.
     await a.requestPublishingConvictionRpc('eth_getTransactionReceipt', ['0xhash']);
@@ -85,6 +90,7 @@ describe('endpoint-stickiness carve-outs: tip-sensitive reads pass skipPreferred
     expect(receiptCall).toBeDefined();
     expect(receiptCall![2]?.skipPreferred).toBeUndefined();
 
+    readProvider.calls.length = 0;
     // eth_getBlockByNumber(concrete block) → NOT tip → STICKY.
     await a.requestPublishingConvictionRpc('eth_getBlockByNumber', ['0x7b', false]);
     const exactBlockCall = readProvider.calls.find((c: any[]) => c[0] === 'pca rpc eth_getBlockByNumber' && !c[2]?.skipPreferred);
@@ -157,5 +163,40 @@ describe('getBlockTimestamp: a null (unimported) receipt block fails over instea
     // Exhaustion whose cause is a transport error (NOT the not-imported sentinel)
     // propagates as RPC_ENDPOINTS_EXHAUSTED, not a bogus 0.
     await expect(a.getBlockTimestamp(123n)).rejects.toMatchObject({ code: 'RPC_ENDPOINTS_EXHAUSTED' });
+  });
+});
+
+// A nullable PCA proxy lookup (receipt/tx/block) whose queried endpoint returns
+// `null` must FAIL OVER (a lagging endpoint's null is "not here yet", not a
+// definitive answer) — otherwise the browser sees a stale null while another
+// endpoint already has the object (round-5 🔴).
+describe('PCA proxy nullable lookups fail over on null instead of returning a lagging stale null', () => {
+  function makePca(p0: any, p1: any) {
+    const a: any = new EVMChainAdapter(minimalConfig());
+    a.initialized = true;
+    a.init = async () => { a.initialized = true; };
+    a.ensureConfiguredStaticChainIdValidated = async () => {};
+    a.providers = [p0, p1];
+    a.rpcUrls = ['https://primary.example', 'https://backup.example'];
+    return a;
+  }
+
+  it('primary returns null for the receipt → fails over to the backup that HAS it', async () => {
+    const receipt = { status: '0x1', transactionHash: '0xhash' };
+    const primarySend = recorder(async () => null);   // lagging: no receipt yet
+    const backupSend = recorder(async () => receipt); // has it
+    const a = makePca({ send: primarySend }, { send: backupSend });
+    expect(await a.requestPublishingConvictionRpc('eth_getTransactionReceipt', ['0xhash'])).toBe(receipt);
+    expect(primarySend.calls).toHaveLength(1);
+    expect(backupSend.calls).toHaveLength(1);
+  });
+
+  it('no endpoint has it yet → returns the honest null (after trying ALL endpoints)', async () => {
+    const primarySend = recorder(async () => null);
+    const backupSend = recorder(async () => null);
+    const a = makePca({ send: primarySend }, { send: backupSend });
+    expect(await a.requestPublishingConvictionRpc('eth_getTransactionReceipt', ['0xhash'])).toBeNull();
+    expect(primarySend.calls).toHaveLength(1); // both endpoints were tried before returning null
+    expect(backupSend.calls).toHaveLength(1);
   });
 });

--- a/packages/chain/test/evm-adapter-tip-read-carveouts.unit.test.ts
+++ b/packages/chain/test/evm-adapter-tip-read-carveouts.unit.test.ts
@@ -118,4 +118,26 @@ describe('getBlockTimestamp: a null (unimported) receipt block fails over instea
     const a = makeTwoEndpointAdapter({ getBlock: recorder(async () => null) }, { getBlock: recorder(async () => null) });
     expect(await a.getBlockTimestamp(123n)).toBe(0);
   });
+
+  it('a NON-RETRYABLE provider error PROPAGATES — it is NOT masked as timestamp 0', async () => {
+    // The `0` fallback is scoped to the "block not imported anywhere" sentinel; a
+    // deterministic provider error (INVALID_ARGUMENT) must surface to the caller.
+    const invalidArg = () => { const e: any = new Error('bad blocktag'); e.code = 'INVALID_ARGUMENT'; return e; };
+    const a = makeTwoEndpointAdapter(
+      { getBlock: recorder(async () => { throw invalidArg(); }) },
+      { getBlock: recorder(async () => ({ timestamp: 42 })) },
+    );
+    await expect(a.getBlockTimestamp(123n)).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('a full transport EXHAUSTION (all endpoints error) PROPAGATES — not masked as timestamp 0', async () => {
+    const retryable429 = () => { const e: any = new Error('429 too many requests'); e.status = 429; return e; };
+    const a = makeTwoEndpointAdapter(
+      { getBlock: recorder(async () => { throw retryable429(); }) },
+      { getBlock: recorder(async () => { throw retryable429(); }) },
+    );
+    // Exhaustion whose cause is a transport error (NOT the not-imported sentinel)
+    // propagates as RPC_ENDPOINTS_EXHAUSTED, not a bogus 0.
+    await expect(a.getBlockTimestamp(123n)).rejects.toMatchObject({ code: 'RPC_ENDPOINTS_EXHAUSTED' });
+  });
 });

--- a/packages/chain/test/evm-adapter-tip-read-carveouts.unit.test.ts
+++ b/packages/chain/test/evm-adapter-tip-read-carveouts.unit.test.ts
@@ -233,6 +233,14 @@ describe('PCA proxy nullable lookups fail over on null instead of returning a la
     expect(backupSend.calls).toHaveLength(1);
   });
 
+  it('a latest-family (finalized/safe/latest) eth_getBlockByNumber fails over on null too (round-8 🔴)', async () => {
+    // A tip block tag is transparent (canonical-fresh) but STILL nullable — a lagging
+    // primary must not hide a finalized block a backup already has.
+    const block = { number: '0x7b', hash: '0xabc' };
+    const a = makePca({ send: recorder(async () => null) }, { send: recorder(async () => block) });
+    expect(await a.requestPublishingConvictionRpc('eth_getBlockByNumber', ['finalized', false])).toBe(block);
+  });
+
   it('eth_getTransactionByHash and a concrete eth_getBlockByNumber ALSO fail over on null (round-6 🟡 coverage)', async () => {
     const tx = { hash: '0xhash', blockNumber: '0x7b' };
     const txAdapter = makePca({ send: recorder(async () => null) }, { send: recorder(async () => tx) });

--- a/packages/chain/test/evm-adapter-tip-read-carveouts.unit.test.ts
+++ b/packages/chain/test/evm-adapter-tip-read-carveouts.unit.test.ts
@@ -164,6 +164,24 @@ describe('getBlockTimestamp: a null (unimported) receipt block fails over instea
     // propagates as RPC_ENDPOINTS_EXHAUSTED, not a bogus 0.
     await expect(a.getBlockTimestamp(123n)).rejects.toMatchObject({ code: 'RPC_ENDPOINTS_EXHAUSTED' });
   });
+
+  it('MIXED null + transport error PROPAGATES regardless of endpoint order (order-independent, round-6 🔴)', async () => {
+    const retryable429 = () => { const e: any = new Error('429 too many requests'); e.status = 429; return e; };
+    // Order A: primary transport error, backup null. A transport failure occurred,
+    // so we canNOT conclude "block not imported anywhere" → propagate (not 0).
+    const orderA = makeTwoEndpointAdapter(
+      { getBlock: recorder(async () => { throw retryable429(); }) },
+      { getBlock: recorder(async () => null) },
+    );
+    await expect(orderA.getBlockTimestamp(123n)).rejects.toMatchObject({ code: 'RPC_ENDPOINTS_EXHAUSTED' });
+    // Order B: primary null, backup transport error — SAME endpoint states, so the
+    // result must be identical (before the fix this returned 0 vs threw by order).
+    const orderB = makeTwoEndpointAdapter(
+      { getBlock: recorder(async () => null) },
+      { getBlock: recorder(async () => { throw retryable429(); }) },
+    );
+    await expect(orderB.getBlockTimestamp(123n)).rejects.toMatchObject({ code: 'RPC_ENDPOINTS_EXHAUSTED' });
+  });
 });
 
 // A nullable PCA proxy lookup (receipt/tx/block) whose queried endpoint returns
@@ -198,5 +216,25 @@ describe('PCA proxy nullable lookups fail over on null instead of returning a la
     expect(await a.requestPublishingConvictionRpc('eth_getTransactionReceipt', ['0xhash'])).toBeNull();
     expect(primarySend.calls).toHaveLength(1); // both endpoints were tried before returning null
     expect(backupSend.calls).toHaveLength(1);
+  });
+
+  it('eth_getTransactionByHash and a concrete eth_getBlockByNumber ALSO fail over on null (round-6 🟡 coverage)', async () => {
+    const tx = { hash: '0xhash', blockNumber: '0x7b' };
+    const txAdapter = makePca({ send: recorder(async () => null) }, { send: recorder(async () => tx) });
+    expect(await txAdapter.requestPublishingConvictionRpc('eth_getTransactionByHash', ['0xhash'])).toBe(tx);
+
+    const block = { number: '0x7b', timestamp: '0x1' };
+    const blockAdapter = makePca({ send: recorder(async () => null) }, { send: recorder(async () => block) });
+    expect(await blockAdapter.requestPublishingConvictionRpc('eth_getBlockByNumber', ['0x7b', false])).toBe(block);
+  });
+
+  it('MIXED null + transport error PROPAGATES regardless of endpoint order (order-independent, round-6 🔴)', async () => {
+    const retryable429 = () => { const e: any = new Error('429 too many requests'); e.status = 429; return e; };
+    const orderA = makePca({ send: recorder(async () => { throw retryable429(); }) }, { send: recorder(async () => null) });
+    await expect(orderA.requestPublishingConvictionRpc('eth_getTransactionReceipt', ['0xhash']))
+      .rejects.toMatchObject({ code: 'RPC_ENDPOINTS_EXHAUSTED' });
+    const orderB = makePca({ send: recorder(async () => null) }, { send: recorder(async () => { throw retryable429(); }) });
+    await expect(orderB.requestPublishingConvictionRpc('eth_getTransactionReceipt', ['0xhash']))
+      .rejects.toMatchObject({ code: 'RPC_ENDPOINTS_EXHAUSTED' });
   });
 });

--- a/packages/chain/test/evm-adapter-tip-read-carveouts.unit.test.ts
+++ b/packages/chain/test/evm-adapter-tip-read-carveouts.unit.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Endpoint-stickiness (Mechanism B) carve-out PINS. The tip-sensitive reads that
+ * advance a cursor or gate an expiry MUST stay canonical-order + preference-
+ * transparent (`skipPreferred: true`) — a lagging sticky backend would make the
+ * head non-monotonic (event-lane cursor rewind / proof-challenge instability) or
+ * return a stale `latest` timestamp. These per-site assertions guard against a
+ * refactor silently dropping the flag (which otherwise passes green — the flag
+ * only changes behavior once a preference is established). Mirrors the poller pin
+ * in hub-rotation-poller.unit.test.ts.
+ */
+import { describe, it, expect } from 'vitest';
+import { EVMChainAdapter, type EVMAdapterConfig } from '../src/evm-adapter.js';
+
+const DEPLOYER_PK = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
+const ADMIN_PK = '0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a';
+
+function minimalConfig(overrides: Partial<EVMAdapterConfig> = {}): EVMAdapterConfig {
+  return {
+    rpcUrl: 'http://127.0.0.1:59998',
+    privateKey: DEPLOYER_PK,
+    adminPrivateKey: ADMIN_PK,
+    hubAddress: '0x0000000000000000000000000000000000000001',
+    chainId: 'evm:31337',
+    staticNetwork: false,
+    ...overrides,
+  };
+}
+
+function recorder<A extends unknown[], R>(impl: (...args: A) => R) {
+  const calls: A[] = [];
+  const fn = (...args: A): R => { calls.push(args); return impl(...args); };
+  return Object.assign(fn, { calls });
+}
+
+function makeAdapter() {
+  const a: any = new EVMChainAdapter(minimalConfig());
+  a.initialized = true;
+  a.init = async () => { a.initialized = true; };
+  return a;
+}
+
+describe('endpoint-stickiness carve-outs: tip-sensitive reads pass skipPreferred:true', () => {
+  it('getBlockNumber() reads canonical + preference-transparent', async () => {
+    const a = makeAdapter();
+    const readProvider = recorder(async () => 100);
+    a.readProvider = readProvider;
+    expect(await a.getBlockNumber()).toBe(100);
+    const call = readProvider.calls.find((c: any[]) => c[0] === 'getBlockNumber');
+    expect(call).toBeDefined();
+    expect(call![2]).toMatchObject({ skipPreferred: true });
+  });
+
+  it('getBlockTimestamp(n) reads canonical + preference-transparent', async () => {
+    const a = makeAdapter();
+    const readProvider = recorder(async () => ({ timestamp: 42 }));
+    a.readProvider = readProvider;
+    expect(await a.getBlockTimestamp(5n)).toBe(42);
+    const call = readProvider.calls.find((c: any[]) => c[0] === 'getBlock');
+    expect(call).toBeDefined();
+    expect(call![2]).toMatchObject({ skipPreferred: true });
+  });
+
+  it("conviction getBlock('latest') reads canonical + preference-transparent", async () => {
+    const a = makeAdapter();
+    a.contracts = { dkgPublishingConvictionNFT: {} };
+    a.getPublishingConvictionAccountInfo = async () => ({ expiresAtTimestamp: 9_999_999_999 });
+    const readProvider = recorder(async () => ({ timestamp: 0 })); // nowTs 0 < expiry → continues past the gate
+    a.readProvider = readProvider;
+    // convictionAccountCanCover reaches the `latest` read inside the expiry gate.
+    await a.convictionAccountCanCover(1n, 100n).catch(() => {});
+    const call = readProvider.calls.find((c: any[]) => c[0] === 'conviction getBlock');
+    expect(call).toBeDefined();
+    expect(call![2]).toMatchObject({ skipPreferred: true });
+  });
+
+  it('the PCA rpc proxy (send) reads canonical + preference-transparent', async () => {
+    const a = makeAdapter();
+    const readProvider = recorder(async () => '0x10');
+    a.readProvider = readProvider;
+    expect(await a.requestPublishingConvictionRpc('eth_blockNumber', [])).toBe('0x10');
+    const call = readProvider.calls.find((c: any[]) => c[0] === 'pca rpc eth_blockNumber');
+    expect(call).toBeDefined();
+    expect(call![2]).toMatchObject({ skipPreferred: true });
+  });
+
+  it('the event-lane wide-log scan (listenForEvents → queryFilter) reads canonical + preference-transparent', async () => {
+    const a = makeAdapter();
+    a.contracts = {
+      knowledgeAssetsStorage: {
+        filters: { KnowledgeBatchCreated: () => ({}) },
+        interface: { parseLog: () => null },
+      },
+    };
+    const readContractWith = recorder(async () => []); // intercept the scan, return no logs
+    a.readContractWith = readContractWith;
+    // Drain the async generator; the KnowledgeBatchCreated branch runs the scan.
+    // eslint-disable-next-line no-empty
+    for await (const _ of a.listenForEvents({ eventTypes: ['KnowledgeBatchCreated'], fromBlock: 0 })) { void _; }
+    expect(readContractWith.calls).toHaveLength(1);
+    expect(readContractWith.calls[0][3]).toMatchObject({ policy: 'wideLogScan', skipPreferred: true });
+  });
+});

--- a/packages/chain/test/evm-adapter-tip-read-carveouts.unit.test.ts
+++ b/packages/chain/test/evm-adapter-tip-read-carveouts.unit.test.ts
@@ -96,9 +96,10 @@ describe('endpoint-stickiness carve-outs: tip-sensitive reads pass skipPreferred
     const exactBlockCall = readProvider.calls.find((c: any[]) => c[0] === 'pca rpc eth_getBlockByNumber' && !c[2]?.skipPreferred);
     expect(exactBlockCall).toBeDefined();
 
-    // eth_call with NO block tag (defaults to latest) OR a latest-family tag → TIP
+    // eth_call with NO block tag (defaults to latest) OR ANY latest-family tag → TIP
     // (reads current contract state a lagging backend would stale) → skipPreferred.
-    for (const callParams of [[{ to: '0xC', data: '0x' }], [{ to: '0xC', data: '0x' }, 'latest']]) {
+    const callObj = { to: '0xC', data: '0x' };
+    for (const callParams of [[callObj], [callObj, 'latest'], [callObj, 'pending'], [callObj, 'safe'], [callObj, 'finalized']]) {
       readProvider.calls.length = 0;
       await a.requestPublishingConvictionRpc('eth_call', callParams);
       expect(readProvider.calls.find((c: any[]) => c[0] === 'pca rpc eth_call')![2])

--- a/packages/chain/test/evm-adapter-tip-read-carveouts.unit.test.ts
+++ b/packages/chain/test/evm-adapter-tip-read-carveouts.unit.test.ts
@@ -63,14 +63,32 @@ describe('endpoint-stickiness carve-outs: tip-sensitive reads pass skipPreferred
     expect(call![2]).toMatchObject({ skipPreferred: true });
   });
 
-  it('the PCA rpc proxy (send) reads canonical + preference-transparent', async () => {
+  it('the PCA rpc proxy: TIP methods are transparent, but receipt/exact-block reads stay sticky', async () => {
     const a = makeAdapter();
     const readProvider = recorder(async () => '0x10');
     a.readProvider = readProvider;
-    expect(await a.requestPublishingConvictionRpc('eth_blockNumber', [])).toBe('0x10');
-    const call = readProvider.calls.find((c: any[]) => c[0] === 'pca rpc eth_blockNumber');
-    expect(call).toBeDefined();
-    expect(call![2]).toMatchObject({ skipPreferred: true });
+
+    // eth_blockNumber → TIP → skipPreferred (transparent).
+    await a.requestPublishingConvictionRpc('eth_blockNumber', []);
+    expect(readProvider.calls.find((c: any[]) => c[0] === 'pca rpc eth_blockNumber')![2])
+      .toMatchObject({ skipPreferred: true });
+
+    // eth_getBlockByNumber('latest') → TIP → skipPreferred.
+    await a.requestPublishingConvictionRpc('eth_getBlockByNumber', ['latest', false]);
+    expect(readProvider.calls.find((c: any[]) => c[0] === 'pca rpc eth_getBlockByNumber' && c[2]?.skipPreferred))
+      .toBeDefined();
+
+    // eth_getTransactionReceipt → NOT a tip read → STICKY (no skipPreferred), so a
+    // lagging primary's null doesn't short-circuit the backup that has the receipt.
+    await a.requestPublishingConvictionRpc('eth_getTransactionReceipt', ['0xhash']);
+    const receiptCall = readProvider.calls.find((c: any[]) => c[0] === 'pca rpc eth_getTransactionReceipt');
+    expect(receiptCall).toBeDefined();
+    expect(receiptCall![2]?.skipPreferred).toBeUndefined();
+
+    // eth_getBlockByNumber(concrete block) → NOT tip → STICKY.
+    await a.requestPublishingConvictionRpc('eth_getBlockByNumber', ['0x7b', false]);
+    const exactBlockCall = readProvider.calls.find((c: any[]) => c[0] === 'pca rpc eth_getBlockByNumber' && !c[2]?.skipPreferred);
+    expect(exactBlockCall).toBeDefined();
   });
 
   it('the event-lane wide-log scan (listenForEvents → queryFilter) reads canonical + preference-transparent', async () => {

--- a/packages/chain/test/evm-adapter-tip-read-carveouts.unit.test.ts
+++ b/packages/chain/test/evm-adapter-tip-read-carveouts.unit.test.ts
@@ -95,6 +95,21 @@ describe('endpoint-stickiness carve-outs: tip-sensitive reads pass skipPreferred
     await a.requestPublishingConvictionRpc('eth_getBlockByNumber', ['0x7b', false]);
     const exactBlockCall = readProvider.calls.find((c: any[]) => c[0] === 'pca rpc eth_getBlockByNumber' && !c[2]?.skipPreferred);
     expect(exactBlockCall).toBeDefined();
+
+    // eth_call with NO block tag (defaults to latest) OR a latest-family tag → TIP
+    // (reads current contract state a lagging backend would stale) → skipPreferred.
+    for (const callParams of [[{ to: '0xC', data: '0x' }], [{ to: '0xC', data: '0x' }, 'latest']]) {
+      readProvider.calls.length = 0;
+      await a.requestPublishingConvictionRpc('eth_call', callParams);
+      expect(readProvider.calls.find((c: any[]) => c[0] === 'pca rpc eth_call')![2])
+        .toMatchObject({ skipPreferred: true });
+    }
+
+    readProvider.calls.length = 0;
+    // eth_call at a CONCRETE historical block → the answer can't change → STICKY.
+    await a.requestPublishingConvictionRpc('eth_call', [{ to: '0xC', data: '0x' }, '0x7b']);
+    const exactCall = readProvider.calls.find((c: any[]) => c[0] === 'pca rpc eth_call');
+    expect(exactCall![2]?.skipPreferred).toBeUndefined();
   });
 
   it('the event-lane wide-log scan (listenForEvents → queryFilter) reads canonical + preference-transparent', async () => {

--- a/packages/chain/test/evm-adapter-tip-read-carveouts.unit.test.ts
+++ b/packages/chain/test/evm-adapter-tip-read-carveouts.unit.test.ts
@@ -50,16 +50,6 @@ describe('endpoint-stickiness carve-outs: tip-sensitive reads pass skipPreferred
     expect(call![2]).toMatchObject({ skipPreferred: true });
   });
 
-  it('getBlockTimestamp(n) reads canonical + preference-transparent', async () => {
-    const a = makeAdapter();
-    const readProvider = recorder(async () => ({ timestamp: 42 }));
-    a.readProvider = readProvider;
-    expect(await a.getBlockTimestamp(5n)).toBe(42);
-    const call = readProvider.calls.find((c: any[]) => c[0] === 'getBlock');
-    expect(call).toBeDefined();
-    expect(call![2]).toMatchObject({ skipPreferred: true });
-  });
-
   it("conviction getBlock('latest') reads canonical + preference-transparent", async () => {
     const a = makeAdapter();
     a.contracts = { dkgPublishingConvictionNFT: {} };
@@ -98,5 +88,34 @@ describe('endpoint-stickiness carve-outs: tip-sensitive reads pass skipPreferred
     for await (const _ of a.listenForEvents({ eventTypes: ['KnowledgeBatchCreated'], fromBlock: 0 })) { void _; }
     expect(readContractWith.calls).toHaveLength(1);
     expect(readContractWith.calls[0][3]).toMatchObject({ policy: 'wideLogScan', skipPreferred: true });
+  });
+});
+
+// getBlockTimestamp is a CONCRETE receipt-block read (NOT the tip), so it is NOT a
+// skipPreferred carve-out; instead a `null` (endpoint hasn't imported the block)
+// must fail over rather than force a bogus `0` (#C, otReviewAgent 🔴).
+describe('getBlockTimestamp: a null (unimported) receipt block fails over instead of returning 0', () => {
+  function makeTwoEndpointAdapter(p0: any, p1: any) {
+    const a: any = new EVMChainAdapter(minimalConfig());
+    a.initialized = true;
+    a.init = async () => { a.initialized = true; };
+    a.ensureConfiguredStaticChainIdValidated = async () => {};
+    a.providers = [p0, p1];
+    a.rpcUrls = ['https://primary.example', 'https://backup.example'];
+    return a;
+  }
+
+  it('primary returns null for the receipt block → fails over to the backup timestamp', async () => {
+    const primaryGetBlock = recorder(async () => null); // lagging: block not imported yet
+    const backupGetBlock = recorder(async () => ({ timestamp: 42 }));
+    const a = makeTwoEndpointAdapter({ getBlock: primaryGetBlock }, { getBlock: backupGetBlock });
+    expect(await a.getBlockTimestamp(123n)).toBe(42); // NOT 0 — the backup served the block
+    expect(primaryGetBlock.calls).toHaveLength(1);
+    expect(backupGetBlock.calls).toHaveLength(1);
+  });
+
+  it('all endpoints lack the block → best-effort 0 (callers tolerate it)', async () => {
+    const a = makeTwoEndpointAdapter({ getBlock: recorder(async () => null) }, { getBlock: recorder(async () => null) });
+    expect(await a.getBlockTimestamp(123n)).toBe(0);
   });
 });

--- a/packages/chain/test/hub-rotation-poller.unit.test.ts
+++ b/packages/chain/test/hub-rotation-poller.unit.test.ts
@@ -417,6 +417,12 @@ describe('HubRotationPoller', () => {
         .toEqual({ policy: 'watchdogPointRead', skipPreferred: true });
       expect(readCalls.find((call) => call.label === 'Hub rotation poll getLogs')?.opts)
         .toEqual({ policy: 'watchdogWideLogScan', skipPreferred: true });
+      // The STARTUP head read (recordInitialHead, fired on poller.start) is a
+      // SEPARATE carve-out site — pin it independently, since a regression that
+      // dropped `skipPreferred` there would not be caught by the periodic-poll
+      // assertion above (different label).
+      expect(readCalls.find((call) => call.label === 'Hub rotation poll initial getBlockNumber')?.opts)
+        .toEqual({ policy: 'watchdogPointRead', skipPreferred: true });
       expect(onContractName.mock.calls.map((call) => call[0])).toEqual([
         'RandomSampling',
         'ContextGraphs',

--- a/packages/chain/test/hub-rotation-poller.unit.test.ts
+++ b/packages/chain/test/hub-rotation-poller.unit.test.ts
@@ -410,10 +410,13 @@ describe('HubRotationPoller', () => {
         iface.getEvent('AssetStorageChanged')!.topicHash,
         iface.getEvent('NewAssetStorage')!.topicHash,
       ]);
+      // `skipPreferred` pins the poller's endpoint-stickiness transparency
+      // (Mechanism B): a background head/log probe at the ~TTL cadence must not
+      // re-probe or clear the preferred backend the read/write paths rely on.
       expect(readCalls.find((call) => call.label === 'Hub rotation poll getBlockNumber')?.opts)
-        .toEqual({ policy: 'watchdogPointRead' });
+        .toEqual({ policy: 'watchdogPointRead', skipPreferred: true });
       expect(readCalls.find((call) => call.label === 'Hub rotation poll getLogs')?.opts)
-        .toEqual({ policy: 'watchdogWideLogScan' });
+        .toEqual({ policy: 'watchdogWideLogScan', skipPreferred: true });
       expect(onContractName.mock.calls.map((call) => call[0])).toEqual([
         'RandomSampling',
         'ContextGraphs',

--- a/packages/chain/test/mock-adapter-parity.test.ts
+++ b/packages/chain/test/mock-adapter-parity.test.ts
@@ -135,6 +135,7 @@ const MOCK_EXEMPT_FROM_EVM = new Set<string>([
   'readContract',
   'readContractWith',
   'readProvider',
+  'readTipProvider',
   'queryFilterWithFailover',
   'rebindContract',
   'populateAndSignAcrossProviders',

--- a/packages/chain/test/mock-adapter-parity.test.ts
+++ b/packages/chain/test/mock-adapter-parity.test.ts
@@ -136,6 +136,7 @@ const MOCK_EXEMPT_FROM_EVM = new Set<string>([
   'readContractWith',
   'readProvider',
   'readTipProvider',
+  'readProviderRetryingNull',
   'queryFilterWithFailover',
   'rebindContract',
   'populateAndSignAcrossProviders',

--- a/packages/chain/test/rpc-failover-client.unit.test.ts
+++ b/packages/chain/test/rpc-failover-client.unit.test.ts
@@ -85,8 +85,7 @@ function makeClient(
     () => providers.map((p, i) => ({ provider: p as any, rpcUrl: rpcUrls[i] })),
     signPopulated,
     () => 'evm:31337',
-    undefined,
-    stickiness,
+    { stickiness },
   );
 }
 
@@ -710,8 +709,7 @@ describe('RpcFailoverClient — endpoint stickiness (Mechanism B)', () => {
       () => providers.map((p, i) => ({ provider: p as any, rpcUrl: urls[i] })),
       NEVER_SIGN,
       () => 'evm:31337',
-      undefined,
-      { enabled: true },
+      { stickiness: { enabled: true } },
     );
     expect(await client.read('r', (p: any) => p.read())).toBe('BACKUP'); // establish preferred = backup.example
 

--- a/packages/chain/test/rpc-failover-client.unit.test.ts
+++ b/packages/chain/test/rpc-failover-client.unit.test.ts
@@ -821,6 +821,33 @@ describe('RpcFailoverClient — endpoint stickiness (Mechanism B)', () => {
     expect(primary.read.calls).toHaveLength(0);
   });
 
+  it('AC-29: past the TTL, a WRITE (broadcast) stays on the write-proven backend — NOT re-probed to the primary (which could reject the backup-signed nonce terminally) (round-11 🔴)', async () => {
+    let clock = 0;
+    const p0: any = {}; const p1: any = {};
+    const populateOrder: string[] = [];
+    const signPopulated = recorder(async () => ({ signedTx: '0xS', txHash: '0xH' }));
+    // populate: primary 429s, backup ok → write-proven backup.
+    const contract = { connect: (s: any) => ({ doWrite: { populateTransaction: () => { const w = s.boundTo === p0 ? 'primary' : 'backup'; populateOrder.push(w); return w === 'primary' ? Promise.reject(retryable429()) : Promise.resolve({ to: '0xTO', data: '0x' }); } } }) } as any;
+    // broadcast: primary throws a NON-RETRYABLE nonce error (would terminate the loop if tried first); backup ok.
+    const nonceTooHigh = () => { const e: any = new Error('nonce too high'); e.code = 'CALL_EXCEPTION'; return e; };
+    p0.broadcastTransaction = recorder(async () => { throw nonceTooHigh(); });
+    p1.broadcastTransaction = recorder(async () => undefined);
+    const client = makeClient([p0, p1], STICKY_URLS, signPopulated as SignPopulatedFn, { enabled: true, ttlMs: 30_000, now: () => clock });
+
+    clock = 0;
+    await client.populateAndSign(contract, 'doWrite', [], makeSigner(), 'w'); // establish write-proven backup
+    expect(populateOrder).toEqual(['primary', 'backup']);
+
+    // Past the TTL, broadcast the backup-signed tx. It must try the BACKUP first
+    // (where the tx was signed / nonce is consistent), NOT re-probe the primary
+    // (which is behind and rejects the nonce with a NON-retryable error the broadcast
+    // loop would treat as terminal, never reaching the backup).
+    clock = 40_000;
+    await client.broadcast('0xS', '0xH', 'w');
+    expect(p1.broadcastTransaction.calls).toHaveLength(1); // backup FIRST, succeeded
+    expect(p0.broadcastTransaction.calls).toHaveLength(0); // primary NOT re-probed. (Bug: primary throws terminally.)
+  });
+
   it('AC-10: a populateAndSign failover primes the preferred for the following read (the 4th loop establishes too)', async () => {
     const p0 = { read: recorder(async () => { throw retryable429(); }) };
     const p1 = { read: recorder(async () => 'BACKUP-READ') };

--- a/packages/chain/test/rpc-failover-client.unit.test.ts
+++ b/packages/chain/test/rpc-failover-client.unit.test.ts
@@ -783,6 +783,44 @@ describe('RpcFailoverClient — endpoint stickiness (Mechanism B)', () => {
     expect(order[0]).toBe('primary');
   });
 
+  it('AC-27: a benign EMPTY result (isEmptyResult) fails over but does NOT de-prefer the endpoint or inflate telemetry (round-9/10 🔴)', async () => {
+    const primary = { read: readSeq((n) => (n === 1 ? retryable429() : 'PRIMARY')) };
+    // backup: ok on op1 (establish), a benign null on op2, ok on op3.
+    const backup = { read: readSeq((n) => (n === 2 ? null : 'BACKUP')) };
+    const client = makeClient([primary, backup], STICKY_URLS, NEVER_SIGN, { enabled: true });
+
+    expect(await client.read('r', (p: any) => p.read())).toBe('BACKUP'); // establish preferred=backup
+    const before = getRpcFailoverStats();
+
+    // op2: the preferred backup returns a BENIGN null → fails over to the primary,
+    // but a null is NOT a failure: the backup is NOT de-preferred, and no
+    // failover/exhaustion telemetry is emitted.
+    expect(await client.read('r', (p: any) => p.read(), { isEmptyResult: (v) => v == null })).toBe('PRIMARY');
+    const after = getRpcFailoverStats();
+    expect(after.failovers).toBe(before.failovers);       // a benign empty is NOT a failover
+    expect(after.exhaustions).toBe(before.exhaustions);   // ...nor an exhaustion
+
+    // op3: the preference SURVIVED the benign null → backup tried FIRST again.
+    expect(await client.read('r', (p: any) => p.read())).toBe('BACKUP');
+    expect(primary.read.calls).toHaveLength(2); // op1 (429) + op2 (fallback). NOT op3 — backup was NOT de-preferred.
+    expect(backup.read.calls).toHaveLength(3);  // op1 + op2 (null) + op3
+  });
+
+  it('AC-28: an already-known broadcast (idempotent success) ESTABLISHES the preference like a normal broadcast (round-9/10 🟡)', async () => {
+    const knownTxError = () => new Error('already known');
+    const primary = { broadcastTransaction: recorder(async () => { throw retryable429(); }), read: recorder(async () => 'PRIMARY') };
+    const backup = { broadcastTransaction: recorder(async () => { throw knownTxError(); }), read: recorder(async () => 'BACKUP') };
+    const client = makeClient([primary, backup], STICKY_URLS, NEVER_SIGN, { enabled: true });
+
+    // primary 429 → backup returns "already known" (idempotent success) → the backup
+    // is where the tx is known → it establishes the preference, same as a real send.
+    await client.broadcast('0xsigned', '0xhash', 'w');
+    expect(getRpcFailoverStats().preferredEstablishments).toBe(1);
+
+    expect(await client.read('r', (p: any) => p.read())).toBe('BACKUP'); // prefers the established backend
+    expect(primary.read.calls).toHaveLength(0);
+  });
+
   it('AC-10: a populateAndSign failover primes the preferred for the following read (the 4th loop establishes too)', async () => {
     const p0 = { read: recorder(async () => { throw retryable429(); }) };
     const p1 = { read: recorder(async () => 'BACKUP-READ') };

--- a/packages/chain/test/rpc-failover-client.unit.test.ts
+++ b/packages/chain/test/rpc-failover-client.unit.test.ts
@@ -826,4 +826,70 @@ describe('RpcFailoverClient — endpoint stickiness (Mechanism B)', () => {
     await client.populateAndSign(contract, 'doWrite', [], makeSigner(), 'w'); // still write-proven → sticks to backup
     expect(populateOrder).toEqual(['backup']); // the read did NOT reset the write-proven source
   });
+
+  it('AC-17: a re-point after a live pool rebind (expired carried-over deadline) arms a FRESH TTL — no per-op primary re-probe (round-4 🔴)', async () => {
+    let clock = 0;
+    let urls = ['https://p.example', 'https://b.example'];
+    let providers: any[] = [{ read: readSeq(() => retryable429()) }, { read: readSeq(() => 'B') }];
+    const client = new RpcFailoverClient(
+      () => providers.map((p, i) => ({ provider: p as any, rpcUrl: urls[i] })),
+      NEVER_SIGN,
+      () => 'evm:31337',
+      { stickiness: { enabled: true, ttlMs: 30_000, now: () => clock } },
+    );
+    clock = 0;
+    expect(await client.read('r', (p: any) => p.read())).toBe('B'); // establish B, due = 30_000
+
+    // Live pool rebind PAST the TTL: B is gone, new pool [C(primary, down), D].
+    clock = 60_000;
+    urls = ['https://c.example', 'https://d.example'];
+    const cRead = readSeq(() => retryable429());
+    const dRead = recorder(async () => 'D');
+    providers = [{ read: cRead }, { read: dRead }];
+    expect(await client.read('r', (p: any) => p.read())).toBe('D'); // preferred B absent → canonical → C fails → D → re-point + FRESH due
+    expect(cRead.calls).toHaveLength(1); // C probed once (the rebind op)
+
+    clock = 60_001;
+    expect(await client.read('r', (p: any) => p.read())).toBe('D'); // within the FRESH window → D preferred first
+    expect(cRead.calls).toHaveLength(1); // primary NOT re-probed (bug: a stale deadline would re-probe every op → 2)
+    expect(dRead.calls).toHaveLength(2);
+  });
+
+  it('AC-19: getReceipt is a first-class ESTABLISHER — a non-null receipt after failover primes the preference (round-4 🟡)', async () => {
+    const receipt = { status: 1, hash: '0xhash' };
+    const primary = { getTransactionReceipt: recorder(async () => { throw retryable429(); }), read: recorder(async () => 'P') };
+    const backup = { getTransactionReceipt: recorder(async () => receipt), read: recorder(async () => 'B') };
+    const client = makeClient([primary, backup], STICKY_URLS, NEVER_SIGN, { enabled: true });
+
+    // getReceipt runs as the FIRST loop: primary 429 → backup returns the receipt →
+    // it (not a prior broadcast) establishes the preferred endpoint.
+    await expect(client.getReceipt('0xhash')).resolves.toBe(receipt);
+    expect(getRpcFailoverStats().preferredEstablishments).toBe(1);
+
+    // A following read prefers the backend getReceipt established.
+    expect(await client.read('r', (p: any) => p.read())).toBe('B');
+    expect(primary.read.calls).toHaveLength(0); // primary NOT tried — the receipt establishment carried over
+  });
+
+  it('AC-18: multi-backup re-point (preferred backup degrades mid-window → next backup) keeps the cadence (round-4 🟡)', async () => {
+    let clock = 0;
+    const pRead = readSeq(() => retryable429());     // primary always down
+    let bN = 0;
+    const bRead = recorder(async () => { bN += 1; if (bN >= 2) throw retryable429(); return 'B'; }); // ok once, then degrades
+    const cRead = recorder(async () => 'C');
+    const client = makeClient(
+      [{ read: pRead }, { read: bRead }, { read: cRead }],
+      ['https://p.example', 'https://b.example', 'https://c.example'],
+      NEVER_SIGN,
+      { enabled: true, ttlMs: 30_000, now: () => clock },
+    );
+    clock = 0;
+    expect(await client.read('r', (p: any) => p.read())).toBe('B'); // establish B
+    clock = 10_000;
+    expect(await client.read('r', (p: any) => p.read())).toBe('C'); // preferred B degrades → fail over B→P→C → re-point to C (in-window)
+    clock = 11_000;
+    const pBefore = pRead.calls.length;
+    expect(await client.read('r', (p: any) => p.read())).toBe('C'); // preferred C tried first
+    expect(pRead.calls.length).toBe(pBefore); // primary NOT re-probed (still within the original TTL window)
+  });
 });

--- a/packages/chain/test/rpc-failover-client.unit.test.ts
+++ b/packages/chain/test/rpc-failover-client.unit.test.ts
@@ -765,6 +765,24 @@ describe('RpcFailoverClient — endpoint stickiness (Mechanism B)', () => {
     expect(populateOrder).toEqual(['primary']);
   });
 
+  it('AC-26: a skipPreferred read that FAILS OVER (primary → backup) does NOT establish a preference — transparent stays non-mutating even on the fallback path (round-8 🟡)', async () => {
+    const order: string[] = [];
+    const primary = { read: recorder(async () => { order.push('primary'); throw retryable429(); }) };
+    const backup = { read: recorder(async () => { order.push('backup'); return 'BACKUP'; }) };
+    const client = makeClient([primary, backup], STICKY_URLS, NEVER_SIGN, { enabled: true });
+
+    // Transparent read from a CLEAN state that fails over primary→backup must NOT
+    // establish a sticky preference (else background tip/poller reads would silently
+    // make a backup preferred despite the preference-transparent contract).
+    expect(await client.read('r', (p: any) => p.read(), { skipPreferred: true })).toBe('BACKUP');
+    expect(getRpcFailoverStats().preferredEstablishments).toBe(0); // transparent success did NOT establish
+
+    // The next NORMAL read is canonical (primary FIRST) — proving no preference leaked.
+    order.length = 0;
+    await client.read('r', (p: any) => p.read()).catch(() => {}); // canonical: primary 429 → backup
+    expect(order[0]).toBe('primary');
+  });
+
   it('AC-10: a populateAndSign failover primes the preferred for the following read (the 4th loop establishes too)', async () => {
     const p0 = { read: recorder(async () => { throw retryable429(); }) };
     const p1 = { read: recorder(async () => 'BACKUP-READ') };

--- a/packages/chain/test/rpc-failover-client.unit.test.ts
+++ b/packages/chain/test/rpc-failover-client.unit.test.ts
@@ -733,6 +733,38 @@ describe('RpcFailoverClient — endpoint stickiness (Mechanism B)', () => {
     expect(populateOrder).toEqual(['backup']);
   });
 
+  it('AC-25: a benign-null getReceipt on a write-proven backend (primary serves) DOWNGRADES source write→read → the next populate goes canonical (round-8 🔴 — exercises the downgrade branch, which recordFailure does NOT)', async () => {
+    const receipt = { status: 1, hash: '0xhash' };
+    const p0: any = { getTransactionReceipt: recorder(async () => receipt) }; // primary HAS the receipt
+    const p1: any = { getTransactionReceipt: recorder(async () => null) };    // write-proven backup: benign null (lagging, NOT a failure)
+    const populateOrder: string[] = [];
+    const signPopulated = recorder(async () => ({ signedTx: '0xS', txHash: '0xH' }));
+    let primaryPopN = 0;
+    const contract = { connect: (s: any) => ({ doWrite: { populateTransaction: () => {
+      const which = s.boundTo === p0 ? 'primary' : 'backup';
+      populateOrder.push(which);
+      if (which === 'primary') { primaryPopN += 1; if (primaryPopN === 1) return Promise.reject(retryable429()); }
+      return Promise.resolve({ to: '0xTO', data: '0x' });
+    } } }) } as any;
+    const client = makeClient([p0, p1], STICKY_URLS, signPopulated as SignPopulatedFn, { enabled: true });
+
+    await client.populateAndSign(contract, 'doWrite', [], makeSigner(), 'w'); // establish WRITE-proven backup (primary 429 → backup)
+    expect(populateOrder).toEqual(['primary', 'backup']);
+
+    // getReceipt: the write-proven backup returns null (benign — NOT a failure, so
+    // recordFailure does NOT fire), the primary serves the receipt as a write
+    // fallback → the backend's nonce view is suspect → DOWNGRADE source write→read.
+    await expect(client.getReceipt('0xhash')).resolves.toBe(receipt);
+    expect(p1.getTransactionReceipt.calls).toHaveLength(1); // backup tried first (null)
+    expect(p0.getTransactionReceipt.calls).toHaveLength(1); // primary served
+
+    populateOrder.length = 0;
+    await client.populateAndSign(contract, 'doWrite', [], makeSigner(), 'w');
+    // Downgraded → nonceWrite re-derives from CANONICAL (primary first). Without the
+    // downgrade branch this would be ['backup'] (still write-proven).
+    expect(populateOrder).toEqual(['primary']);
+  });
+
   it('AC-10: a populateAndSign failover primes the preferred for the following read (the 4th loop establishes too)', async () => {
     const p0 = { read: recorder(async () => { throw retryable429(); }) };
     const p1 = { read: recorder(async () => 'BACKUP-READ') };

--- a/packages/chain/test/rpc-failover-client.unit.test.ts
+++ b/packages/chain/test/rpc-failover-client.unit.test.ts
@@ -892,4 +892,22 @@ describe('RpcFailoverClient — endpoint stickiness (Mechanism B)', () => {
     expect(await client.read('r', (p: any) => p.read())).toBe('C'); // preferred C tried first
     expect(pRead.calls.length).toBe(pBefore); // primary NOT re-probed (still within the original TTL window)
   });
+
+  it('AC-20: readContract honors skipPreferred (transparent) — the REAL contract-read path the event-lane scan relies on (round-5 🔴)', async () => {
+    // Proves skipPreferred survives into RpcFailoverClient.readContract (not just
+    // the adapter opts plumbing): `queryFilterWithFailover` passes it here, so if
+    // readContract dropped `opts.skipPreferred` event scans would silently go sticky.
+    const p0 = {}; const p1 = {};
+    let n0 = 0;
+    const primaryView = recorder(async () => { n0 += 1; if (n0 === 1) throw retryable429(); return 'PRIMARY'; });
+    const backupView = recorder(async () => 'BACKUP');
+    const contract = { connect: (p: unknown) => (p === p0 ? { view: primaryView } : { view: backupView }) } as any;
+    const client = makeClient([p0, p1], STICKY_URLS, NEVER_SIGN, { enabled: true });
+
+    expect(await client.readContract('v', contract, (c: any) => c.view())).toBe('BACKUP'); // op1: primary 429 → backup → preferred=backup
+
+    // op2 with skipPreferred → CANONICAL (primary tried first). If readContract
+    // ignored the flag it would prefer the backup and return 'BACKUP'.
+    expect(await client.readContract('v', contract, (c: any) => c.view(), { skipPreferred: true })).toBe('PRIMARY');
+  });
 });

--- a/packages/chain/test/rpc-failover-client.unit.test.ts
+++ b/packages/chain/test/rpc-failover-client.unit.test.ts
@@ -37,6 +37,7 @@ import {
   RpcFailoverClient,
   resolveCapMs,
   type SignPopulatedFn,
+  type StickinessOptions,
 } from '../src/rpc-failover-client.js';
 import {
   RPC_READ_STALL_TIMEOUT_MS,
@@ -45,7 +46,7 @@ import {
   RPC_RECEIPT_ATTEMPT_TIMEOUT_MS,
   RPC_TRANSACTION_POPULATION_ATTEMPT_TIMEOUT_MS,
 } from '../src/evm-adapter-constants.js';
-import { _resetRpcFailoverStatsForTest } from '../src/rpc-failover-log.js';
+import { _resetRpcFailoverStatsForTest, getRpcFailoverStats } from '../src/rpc-failover-log.js';
 
 function recorder<A extends unknown[], R>(impl: (...args: A) => R) {
   const calls: A[] = [];
@@ -70,16 +71,22 @@ const NEVER_SIGN: SignPopulatedFn = async () => {
   throw new Error('signPopulated must not be reached by this path');
 };
 
-/** Construct the module under test over bare doubles (PLAN §0 D1 thunks). */
+/** Construct the module under test over bare doubles (PLAN §0 D1 thunks).
+ *  `stickiness` (Mechanism B) is optional — omitted, the client uses production
+ *  defaults (stickiness on unless `DKG_DISABLE_RPC_STICKINESS=1`, `Date.now`
+ *  clock, 30s TTL); the stickiness suite injects `{ enabled, now, ttlMs }`. */
 function makeClient(
   providers: unknown[],
   rpcUrls: string[],
   signPopulated: SignPopulatedFn = NEVER_SIGN,
+  stickiness?: StickinessOptions,
 ): RpcFailoverClient {
   return new RpcFailoverClient(
     () => providers.map((p, i) => ({ provider: p as any, rpcUrl: rpcUrls[i] })),
     signPopulated,
     () => 'evm:31337',
+    undefined,
+    stickiness,
   );
 }
 
@@ -491,5 +498,250 @@ describe('RpcFailoverClient — write-path per-attempt timeout (hung provider, f
     await expect(p).resolves.toEqual({ signedTx: '0xS', txHash: '0xH' });
     expect(populateTransaction.calls).toHaveLength(2); // primary hung → timed out → backup populated
     expect(signPopulated.calls).toHaveLength(1); // signed exactly once, on the backup (single-sign invariant holds)
+  });
+});
+
+// ── endpoint stickiness (Mechanism B, #1340 retry residual + #1337 fail-close) ─
+// Prefer the last-good backend after a failover; re-probe the configured primary
+// at most once per TTL; stay fully transparent on `skipPreferred` tip reads;
+// clear on a primary success. The kill-switch (`enabled:false`) reproduces the
+// pre-Mechanism-B index-0 behavior — the RED baseline these assertions are
+// written against (AC-4 pins that equivalence). Deterministic: injected `now`
+// (no fake timers) + bare recorder doubles, so we assert TRY-ORDER via call
+// counts, not wall-clock.
+describe('RpcFailoverClient — endpoint stickiness (Mechanism B)', () => {
+  const STICKY_URLS = ['https://primary.example', 'https://backup.example'];
+
+  // A read double: for call N, `fn(N)` returns a value to resolve, or an Error to throw.
+  const readSeq = (fn: (n: number) => unknown) => {
+    let n = 0;
+    return recorder(async () => {
+      n += 1;
+      const out = fn(n);
+      if (out instanceof Error) throw out;
+      return out;
+    });
+  };
+
+  it('AC-1: after a failover the NEXT read tries the last-good backend FIRST (primary not re-probed)', async () => {
+    const primary = { read: readSeq(() => retryable429()) }; // always 429
+    const backup = { read: readSeq(() => 'BACKUP') };        // always ok
+    const client = makeClient([primary, backup], STICKY_URLS, NEVER_SIGN, { enabled: true });
+
+    expect(await client.read('r', (p: any) => p.read())).toBe('BACKUP'); // op1: fail over → establish preferred=backup
+    expect(primary.read.calls).toHaveLength(1);
+    expect(backup.read.calls).toHaveLength(1);
+
+    expect(await client.read('r', (p: any) => p.read())).toBe('BACKUP'); // op2: backup FIRST
+    expect(primary.read.calls).toHaveLength(1); // NOT re-probed (index-0 would make this 2)
+    expect(backup.read.calls).toHaveLength(2);
+  });
+
+  it('AC-4: kill-switch (enabled:false) reproduces index-0 — op2 re-probes the primary every call', async () => {
+    const primary = { read: readSeq(() => retryable429()) };
+    const backup = { read: readSeq(() => 'BACKUP') };
+    const client = makeClient([primary, backup], STICKY_URLS, NEVER_SIGN, { enabled: false });
+
+    expect(await client.read('r', (p: any) => p.read())).toBe('BACKUP');
+    expect(await client.read('r', (p: any) => p.read())).toBe('BACKUP');
+    expect(primary.read.calls).toHaveLength(2); // index-0: primary re-probed on BOTH ops (the pre-change baseline)
+    expect(backup.read.calls).toHaveLength(2);
+  });
+
+  it('AC-2: a write that fails over primes the preferred → the following receipt lookup targets that backend', async () => {
+    const receipt = { status: 1, hash: '0xhash' };
+    const primary = {
+      broadcastTransaction: recorder(async () => { throw retryable429(); }), // primary 429s
+      getTransactionReceipt: recorder(async () => receipt),                   // primary WOULD answer...
+    };
+    const backup = {
+      broadcastTransaction: recorder(async () => undefined),                  // backup broadcasts ok
+      getTransactionReceipt: recorder(async () => receipt),                   // ...but backup is preferred first
+    };
+    const client = makeClient([primary, backup], STICKY_URLS, NEVER_SIGN, { enabled: true });
+
+    await client.broadcast('0xsigned', '0xhash', 'w'); // primary 429 → backup ok → preferred := backup
+    expect(primary.broadcastTransaction.calls).toHaveLength(1);
+    expect(backup.broadcastTransaction.calls).toHaveLength(1);
+
+    await expect(client.getReceipt('0xhash')).resolves.toBe(receipt);
+    expect(backup.getTransactionReceipt.calls).toHaveLength(1);  // receipt looked up on the backup FIRST
+    expect(primary.getTransactionReceipt.calls).toHaveLength(0); // primary not polled — read-your-write on ONE backend
+  });
+
+  it('AC-3: under a persistently degraded primary, the primary is re-probed at most ONCE per TTL (not every call)', async () => {
+    let clock = 0;
+    const primary = { read: readSeq(() => retryable429()) }; // stays down the whole test
+    const backup = { read: readSeq(() => 'BACKUP') };
+    const client = makeClient([primary, backup], STICKY_URLS, NEVER_SIGN, { enabled: true, ttlMs: 30_000, now: () => clock });
+
+    clock = 0;      await client.read('r', (p: any) => p.read()); // op1: establish, arm due=30_000
+    clock = 10_000; await client.read('r', (p: any) => p.read()); // within TTL → backup first
+    clock = 20_000; await client.read('r', (p: any) => p.read()); // within TTL → backup first
+    expect(primary.read.calls).toHaveLength(1); // only the op1 establish probe so far
+
+    clock = 35_000; await client.read('r', (p: any) => p.read()); // past TTL → RE-PROBE primary, re-arm due=65_000
+    expect(primary.read.calls).toHaveLength(2); // exactly one re-probe
+
+    clock = 40_000; await client.read('r', (p: any) => p.read()); // within the new window → backup first
+    clock = 50_000; await client.read('r', (p: any) => p.read()); // within the new window → backup first
+    expect(primary.read.calls).toHaveLength(2); // STILL 2 — NOT re-probed every call (Finding-1 regression guard)
+
+    clock = 66_000; await client.read('r', (p: any) => p.read()); // past the 2nd window → re-probe again
+    expect(primary.read.calls).toHaveLength(3);
+  });
+
+  it('AC-3b: a primary re-probe that SUCCEEDS clears the preference (primary resumes)', async () => {
+    let clock = 0;
+    // primary: 429 on call 1 (establish), healthy from call 2 (the re-probe onward)
+    const primary = { read: readSeq((n) => (n === 1 ? retryable429() : 'PRIMARY')) };
+    const backup = { read: readSeq(() => 'BACKUP') };
+    const client = makeClient([primary, backup], STICKY_URLS, NEVER_SIGN, { enabled: true, ttlMs: 30_000, now: () => clock });
+
+    clock = 0;      expect(await client.read('r', (p: any) => p.read())).toBe('BACKUP');  // establish preferred=backup
+    clock = 35_000; expect(await client.read('r', (p: any) => p.read())).toBe('PRIMARY'); // re-probe → primary ok → CLEAR
+    clock = 36_000; expect(await client.read('r', (p: any) => p.read())).toBe('PRIMARY'); // preference cleared → canonical
+    expect(primary.read.calls).toHaveLength(3); // op1 429 + re-probe + canonical-after-clear
+    expect(backup.read.calls).toHaveLength(1);  // only the initial failover
+  });
+
+  it('AC-5: a single-RPC client never establishes a preferred (nothing to fail over to)', async () => {
+    const only = { read: readSeq(() => 'ONLY') };
+    const client = makeClient([only], ['https://only.example'], NEVER_SIGN, { enabled: true });
+
+    await client.read('r', (p: any) => p.read());
+    await client.read('r', (p: any) => p.read());
+    expect(only.read.calls).toHaveLength(2);
+    expect(getRpcFailoverStats().preferredEstablishments).toBe(0); // lone endpoint == primary → never sticks
+  });
+
+  it('AC-7: a skipPreferred read uses canonical order AND leaves the preference intact (transparent)', async () => {
+    // primary: 429 on call 1 (establish backup), healthy afterwards
+    const primary = { read: readSeq((n) => (n === 1 ? retryable429() : 'PRIMARY')) };
+    const backup = { read: readSeq(() => 'BACKUP') };
+    const client = makeClient([primary, backup], STICKY_URLS, NEVER_SIGN, { enabled: true });
+
+    expect(await client.read('r', (p: any) => p.read())).toBe('BACKUP'); // op1: establish preferred=backup
+
+    // op2 skipPreferred → canonical (primary first) AND must NOT clear the preference
+    expect(await client.read('r', (p: any) => p.read(), { skipPreferred: true })).toBe('PRIMARY');
+
+    // op3 (normal) → preference SURVIVED op2 → backup first
+    expect(await client.read('r', (p: any) => p.read())).toBe('BACKUP');
+    expect(primary.read.calls).toHaveLength(2); // op1 (429) + op2 (skipPreferred canonical). If op2 had CLEARED, op3 → 3.
+    expect(backup.read.calls).toHaveLength(2);  // op1 + op3
+  });
+
+  it('AC-6: with a primed preferred, the reorder DOES happen yet the exhaustion error still reports rpcUrls in CANONICAL order', async () => {
+    // A shared try-order log proves the reorder actually occurred (so the
+    // canonical-rpcUrls assertion isn't vacuously true against a no-op reorder).
+    const order: string[] = [];
+    const primary = { read: recorder(async () => { order.push('primary'); throw retryable429(); }) };
+    let backupN = 0;
+    const backup = { read: recorder(async () => { order.push('backup'); backupN += 1; if (backupN === 1) return 'BACKUP'; throw retryable429(); }) };
+    const client = makeClient([primary, backup], STICKY_URLS, NEVER_SIGN, { enabled: true });
+
+    expect(await client.read('r', (p: any) => p.read())).toBe('BACKUP'); // op1 canonical: primary 429 → backup ok → preferred=backup
+    expect(order).toEqual(['primary', 'backup']);
+
+    order.length = 0;
+    let thrown: any;
+    try { await client.read('r', (p: any) => p.read()); } catch (e) { thrown = e; }
+    expect(order).toEqual(['backup', 'primary']); // op2 REORDERED: backup tried FIRST (the reorder genuinely happened)
+    expect(thrown.code).toBe('RPC_ENDPOINTS_EXHAUSTED');
+    expect(thrown.rpcUrls).toEqual(STICKY_URLS); // ...yet rpcUrls stays CANONICAL [primary, backup], not [backup, primary]
+  });
+
+  it('AC-9: a primary reached as a FALLBACK (not tried first) does NOT clear the preference (cadence fix)', async () => {
+    // primary: 429 on the op1 establish probe, healthy afterward — but only ever reached as a FALLBACK on op2.
+    const primary = { read: readSeq((n) => (n === 1 ? retryable429() : 'PRIMARY')) };
+    // backup: ok on op1 (establish), FAILS on op2 (forces the op to fall over to the primary), ok again after.
+    const backup = { read: readSeq((n) => (n === 2 ? retryable429() : 'BACKUP')) };
+    const client = makeClient([primary, backup], STICKY_URLS, NEVER_SIGN, { enabled: true });
+
+    expect(await client.read('r', (p: any) => p.read())).toBe('BACKUP');  // op1 canonical: establish preferred=backup
+
+    // op2 preferred-first [backup, primary]: backup 429s → falls over to the primary as a FALLBACK (i=1, not first).
+    // The primary answering ONE op must NOT clear the preference (it doesn't prove primary health).
+    expect(await client.read('r', (p: any) => p.read())).toBe('PRIMARY');
+
+    // op3: preference SURVIVED op2's fallback-primary success → backup tried FIRST again.
+    expect(await client.read('r', (p: any) => p.read())).toBe('BACKUP');
+    expect(primary.read.calls).toHaveLength(2); // op1 establish (429) + op2 fallback. If op2 had CLEARED, op3 canonical → 3.
+    expect(backup.read.calls).toHaveLength(3);  // op1 ok, op2 429, op3 ok
+  });
+
+  it('AC-10: a populateAndSign failover primes the preferred for the following read (the 4th loop establishes too)', async () => {
+    const p0 = { read: recorder(async () => { throw retryable429(); }) };
+    const p1 = { read: recorder(async () => 'BACKUP-READ') };
+    const signPopulated = recorder(async () => ({ signedTx: '0xS', txHash: '0xH' }));
+    const makeSigner = () => ({ address: '0x' + 'ab'.repeat(20), connect: (p: unknown) => ({ address: '0x' + 'ab'.repeat(20), boundTo: p }) }) as any;
+    // populateTransaction 429s when the signer is bound to p0 (primary), succeeds on p1 (backup).
+    const contract = { connect: (s: any) => ({ doWrite: { populateTransaction: () => (s.boundTo === p0 ? Promise.reject(retryable429()) : Promise.resolve({ to: '0xTO', data: '0x' })) } }) } as any;
+    const client = makeClient([p0, p1], STICKY_URLS, signPopulated as SignPopulatedFn, { enabled: true });
+
+    await expect(client.populateAndSign(contract, 'doWrite', [], makeSigner(), 'w'))
+      .resolves.toEqual({ signedTx: '0xS', txHash: '0xH' }); // primary populate 429 → backup populates+signs → preferred=backup
+    expect(getRpcFailoverStats().preferredEstablishments).toBe(1);
+
+    // The subsequent read prefers the backup the write signed on → primary read NOT probed.
+    expect(await client.read('r', (p: any) => p.read())).toBe('BACKUP-READ');
+    expect(p0.read.calls).toHaveLength(0);
+    expect(p1.read.calls).toHaveLength(1);
+  });
+
+  it('AC-11: a null (not-yet-mined) receipt does NOT establish a preference', async () => {
+    const primary = { getTransactionReceipt: recorder(async () => { throw retryable429(); }) };
+    const backup = { getTransactionReceipt: recorder(async () => null) }; // responds, but no receipt yet
+    const client = makeClient([primary, backup], STICKY_URLS, NEVER_SIGN, { enabled: true });
+
+    await expect(client.getReceipt('0xhash')).resolves.toBeNull();
+    // A null tick has no single winning endpoint (both were visited; neither had
+    // the receipt), so notePreferredOutcome must not fire → no preference established.
+    // (A regression hoisting the note above the `if (receipt)` null-check would
+    // establish a preference on whichever backend merely answered "not mined yet".)
+    expect(getRpcFailoverStats().preferredEstablishments).toBe(0);
+  });
+
+  it('AC-12: if a live pool rebind drops the preferred endpoint, ordering falls back to canonical cleanly (idx<0)', async () => {
+    let urls = [...STICKY_URLS];
+    let providers: any[] = [{ read: readSeq(() => retryable429()) }, { read: readSeq(() => 'BACKUP') }];
+    const client = new RpcFailoverClient(
+      () => providers.map((p, i) => ({ provider: p as any, rpcUrl: urls[i] })),
+      NEVER_SIGN,
+      () => 'evm:31337',
+      undefined,
+      { enabled: true },
+    );
+    expect(await client.read('r', (p: any) => p.read())).toBe('BACKUP'); // establish preferred = backup.example
+
+    // Live pool rebind: a completely different endpoint set (the preferred url is gone).
+    urls = ['https://new-primary.example', 'https://new-backup.example'];
+    const np = recorder(async () => 'NEW-PRIMARY');
+    const nb = recorder(async () => 'NEW-BACKUP');
+    providers = [{ read: np }, { read: nb }];
+
+    // preferred no longer present in canonical (idx<0) → clean fall-back to canonical → new-primary first.
+    expect(await client.read('r', (p: any) => p.read())).toBe('NEW-PRIMARY');
+    expect(np.calls).toHaveLength(1);
+    expect(nb.calls).toHaveLength(0);
+  });
+
+  it('AC-8: establishing a preferred emits a host-only stickiness log + increments the counter', async () => {
+    const primary = { read: readSeq(() => retryable429()) };
+    const backup = { read: readSeq(() => 'BACKUP') };
+    const client = makeClient([primary, backup], STICKY_URLS, NEVER_SIGN, { enabled: true });
+
+    const warns: string[] = [];
+    const origWarn = console.warn;
+    console.warn = ((...a: unknown[]) => { warns.push(String(a[0])); }) as typeof console.warn;
+    try {
+      await client.read('r', (p: any) => p.read());
+    } finally {
+      console.warn = origWarn;
+    }
+    expect(getRpcFailoverStats().preferredEstablishments).toBe(1);
+    expect(warns.some((w) => w.includes('stickiness') && w.includes('backup.example'))).toBe(true);
+    expect(warns.every((w) => !w.includes('https://'))).toBe(true); // host-only — never a full URL
   });
 });

--- a/packages/chain/test/rpc-failover-client.unit.test.ts
+++ b/packages/chain/test/rpc-failover-client.unit.test.ts
@@ -744,4 +744,43 @@ describe('RpcFailoverClient — endpoint stickiness (Mechanism B)', () => {
     expect(warns.some((w) => w.includes('stickiness') && w.includes('backup.example'))).toBe(true);
     expect(warns.every((w) => !w.includes('https://'))).toBe(true); // host-only — never a full URL
   });
+
+  // --- nonce-staleness guard: a read-established preference must not steer a
+  // nonce-critical populate to a possibly-lagging backend (otReviewAgent 🔴).
+  const SIGNER_ADDR = '0x' + 'ab'.repeat(20);
+  const makeSigner = () => ({ address: SIGNER_ADDR, connect: (p: unknown) => ({ address: SIGNER_ADDR, boundTo: p }) }) as any;
+
+  it('AC-13: a READ-established preference does NOT steer a write populate (populate stays canonical/primary-first)', async () => {
+    const p0 = { read: readSeq(() => retryable429()) };  // primary read 429s → establishes backup as READ preferred
+    const p1 = { read: readSeq(() => 'BACKUP') };
+    const populateOrder: string[] = [];
+    const signPopulated = recorder(async () => ({ signedTx: '0xS', txHash: '0xH' }));
+    // Both endpoints can populate; record which the signer was bound to.
+    const contract = { connect: (s: any) => ({ doWrite: { populateTransaction: () => { populateOrder.push(s.boundTo === p0 ? 'primary' : 'backup'); return Promise.resolve({ to: '0xTO', data: '0x' }); } } }) } as any;
+    const client = makeClient([p0, p1], STICKY_URLS, signPopulated as SignPopulatedFn, { enabled: true });
+
+    expect(await client.read('r', (pr: any) => pr.read())).toBe('BACKUP'); // READ establishes preferred=backup (NOT populate-proven)
+
+    await client.populateAndSign(contract, 'doWrite', [], makeSigner(), 'w');
+    // The nonce-critical populate STARTED on the canonical primary (the authoritative
+    // nonce source), NOT the read-preferred backup — so a lagging read-preferred
+    // backend can never sign a stale nonce.
+    expect(populateOrder).toEqual(['primary']);
+  });
+
+  it('AC-14: once a populate PROVES a backend (primary down for writes), subsequent writes stick to it (#1340, no per-write primary re-probe)', async () => {
+    const p0 = {}; const p1 = {};
+    const populateOrder: string[] = [];
+    const signPopulated = recorder(async () => ({ signedTx: '0xS', txHash: '0xH' }));
+    // primary populate always 429s (down for writes); backup populates ok.
+    const contract = { connect: (s: any) => ({ doWrite: { populateTransaction: () => { const which = s.boundTo === p0 ? 'primary' : 'backup'; populateOrder.push(which); return which === 'primary' ? Promise.reject(retryable429()) : Promise.resolve({ to: '0xTO', data: '0x' }); } } }) } as any;
+    const client = makeClient([p0, p1], STICKY_URLS, signPopulated as SignPopulatedFn, { enabled: true });
+
+    await client.populateAndSign(contract, 'doWrite', [], makeSigner(), 'w'); // write #1: canonical → primary 429 → backup → populate-proven
+    expect(populateOrder).toEqual(['primary', 'backup']);
+
+    populateOrder.length = 0;
+    await client.populateAndSign(contract, 'doWrite', [], makeSigner(), 'w'); // write #2: populate-proven backend tried FIRST
+    expect(populateOrder).toEqual(['backup']); // primary NOT re-probed — write stickiness preserved for #1340
+  });
 });

--- a/packages/chain/test/rpc-failover-client.unit.test.ts
+++ b/packages/chain/test/rpc-failover-client.unit.test.ts
@@ -651,23 +651,86 @@ describe('RpcFailoverClient — endpoint stickiness (Mechanism B)', () => {
     expect(thrown.rpcUrls).toEqual(STICKY_URLS); // ...yet rpcUrls stays CANONICAL [primary, backup], not [backup, primary]
   });
 
-  it('AC-9: a primary reached as a FALLBACK (not tried first) does NOT clear the preference (cadence fix)', async () => {
-    // primary: 429 on the op1 establish probe, healthy afterward — but only ever reached as a FALLBACK on op2.
-    const primary = { read: readSeq((n) => (n === 1 ? retryable429() : 'PRIMARY')) };
-    // backup: ok on op1 (establish), FAILS on op2 (forces the op to fall over to the primary), ok again after.
-    const backup = { read: readSeq((n) => (n === 2 ? retryable429() : 'BACKUP')) };
+  it('AC-9: a preferred backup that RESPONDS (getReceipt null, no failure) while the primary serves the fallback KEEPS the preference (cadence fix; distinct from a FAILED backup — AC-22)', async () => {
+    const receipt = { status: 1, hash: '0xhash' };
+    // Establish preferred=backup via a read failover.
+    const primary = { read: readSeq((n) => (n === 1 ? retryable429() : 'PRIMARY')), getTransactionReceipt: recorder(async () => receipt) };
+    const backup = { read: readSeq(() => 'BACKUP'), getTransactionReceipt: recorder(async () => null) };
     const client = makeClient([primary, backup], STICKY_URLS, NEVER_SIGN, { enabled: true });
 
-    expect(await client.read('r', (p: any) => p.read())).toBe('BACKUP');  // op1 canonical: establish preferred=backup
+    expect(await client.read('r', (p: any) => p.read())).toBe('BACKUP'); // establish preferred=backup
 
-    // op2 preferred-first [backup, primary]: backup 429s → falls over to the primary as a FALLBACK (i=1, not first).
-    // The primary answering ONE op must NOT clear the preference (it doesn't prove primary health).
+    // getReceipt: [backup, primary]. The backup RESPONDS with null (not-yet-mined) —
+    // NOT a failure — so the loop continues to the primary, which has the receipt.
+    // Because the backup did not FAIL, the preference must NOT be cleared (a benign
+    // "no data here" fallback is not evidence the backup is degraded).
+    await expect(client.getReceipt('0xhash')).resolves.toBe(receipt);
+
+    // Preference SURVIVED → the next read still prefers the backup.
+    expect(await client.read('r', (p: any) => p.read())).toBe('BACKUP');
+    expect(primary.read.calls).toHaveLength(1); // only op1's establish 429 — the primary is NOT re-probed for reads
+  });
+
+  it('AC-22: a preferred backup that FAILS (errors) is DE-PREFERRED (not re-tried first every op, which would re-fail-close) (round-7 🔴)', async () => {
+    // primary: 429 on the op1 establish probe, healthy afterward.
+    const primary = { read: readSeq((n) => (n === 1 ? retryable429() : 'PRIMARY')) };
+    // backup: ok on op1 (establish), then FAILS (429) from op2 on — a hanging/erroring backup.
+    const backup = { read: readSeq((n) => (n === 1 ? 'BACKUP' : retryable429())) };
+    const client = makeClient([primary, backup], STICKY_URLS, NEVER_SIGN, { enabled: true });
+
+    expect(await client.read('r', (p: any) => p.read())).toBe('BACKUP'); // op1: establish preferred=backup
+
+    // op2 [backup, primary]: backup FAILS (429) → recordFailure de-prefers it → primary serves.
     expect(await client.read('r', (p: any) => p.read())).toBe('PRIMARY');
 
-    // op3: preference SURVIVED op2's fallback-primary success → backup tried FIRST again.
-    expect(await client.read('r', (p: any) => p.read())).toBe('BACKUP');
-    expect(primary.read.calls).toHaveLength(2); // op1 establish (429) + op2 fallback. If op2 had CLEARED, op3 canonical → 3.
-    expect(backup.read.calls).toHaveLength(3);  // op1 ok, op2 429, op3 ok
+    // op3: backup was de-preferred → canonical [primary, backup] → primary tried FIRST
+    // (NOT re-stalled on the failed backup, which is the #1337 fail-close this prevents).
+    expect(await client.read('r', (p: any) => p.read())).toBe('PRIMARY');
+    expect(backup.read.calls).toHaveLength(2); // op1 (ok) + op2 (429). NOT op3 — de-preferred. (Bug: 3.)
+    expect(primary.read.calls).toHaveLength(3);
+  });
+
+  it('AC-23: past the TTL a nonce-critical populate STAYS on the write-proven backend (does NOT re-probe a possibly-stale primary) (round-7 🔴)', async () => {
+    let clock = 0;
+    const p0 = {}; const p1 = {};
+    const populateOrder: string[] = [];
+    const signPopulated = recorder(async () => ({ signedTx: '0xS', txHash: '0xH' }));
+    const contract = { connect: (s: any) => ({ doWrite: { populateTransaction: () => { const w = s.boundTo === p0 ? 'primary' : 'backup'; populateOrder.push(w); return w === 'primary' ? Promise.reject(retryable429()) : Promise.resolve({ to: '0xTO', data: '0x' }); } } }) } as any;
+    const client = makeClient([p0, p1], STICKY_URLS, signPopulated as SignPopulatedFn, { enabled: true, ttlMs: 30_000, now: () => clock });
+
+    clock = 0;
+    await client.populateAndSign(contract, 'doWrite', [], makeSigner(), 'w'); // establish write-proven backup
+    expect(populateOrder).toEqual(['primary', 'backup']);
+
+    // Past the TTL: a READ re-probe would go canonical, but a nonce-critical populate
+    // MUST NOT (stale-nonce risk on a just-recovered-but-lagging primary) — it keeps
+    // the write-proven backend.
+    clock = 40_000;
+    populateOrder.length = 0;
+    await client.populateAndSign(contract, 'doWrite', [], makeSigner(), 'w');
+    expect(populateOrder).toEqual(['backup']); // backup tried FIRST — no primary re-probe. (Bug: ['primary','backup'].)
+  });
+
+  it('AC-24: a populate on a READ-established preferred backend UPGRADES it to write-proven, so the next populate sticks (round-7 🟡 coverage)', async () => {
+    const p0 = { read: readSeq(() => retryable429()) };
+    const p1 = { read: readSeq(() => 'BACKUP') };
+    const populateOrder: string[] = [];
+    const signPopulated = recorder(async () => ({ signedTx: '0xS', txHash: '0xH' }));
+    // primary populate 429s, backup populate ok (so a populate proves the backup).
+    const contract = { connect: (s: any) => ({ doWrite: { populateTransaction: () => { const w = s.boundTo === p0 ? 'primary' : 'backup'; populateOrder.push(w); return w === 'primary' ? Promise.reject(retryable429()) : Promise.resolve({ to: '0xTO', data: '0x' }); } } }) } as any;
+    const client = makeClient([p0, p1], STICKY_URLS, signPopulated as SignPopulatedFn, { enabled: true });
+
+    expect(await client.read('r', (p: any) => p.read())).toBe('BACKUP'); // establish preferred=backup, source=READ
+
+    // populate #1: source=read → nonceWrite won't trust a read-only backend's nonce →
+    // canonical → primary 429 → backup populates → UPGRADES the preference read→write.
+    await client.populateAndSign(contract, 'doWrite', [], makeSigner(), 'w');
+    expect(populateOrder).toEqual(['primary', 'backup']);
+
+    // populate #2: now write-proven → sticks to the backup first (proves the upgrade).
+    populateOrder.length = 0;
+    await client.populateAndSign(contract, 'doWrite', [], makeSigner(), 'w');
+    expect(populateOrder).toEqual(['backup']);
   });
 
   it('AC-10: a populateAndSign failover primes the preferred for the following read (the 4th loop establishes too)', async () => {

--- a/packages/chain/test/rpc-failover-client.unit.test.ts
+++ b/packages/chain/test/rpc-failover-client.unit.test.ts
@@ -783,4 +783,49 @@ describe('RpcFailoverClient — endpoint stickiness (Mechanism B)', () => {
     await client.populateAndSign(contract, 'doWrite', [], makeSigner(), 'w'); // write #2: populate-proven backend tried FIRST
     expect(populateOrder).toEqual(['backup']); // primary NOT re-probed — write stickiness preserved for #1340
   });
+
+  it('AC-15: a write-proven backend that FAILS a later broadcast (primary takes over as fallback) is downgraded → the next populate re-derives from canonical (#A)', async () => {
+    // primary broadcast OK, backup broadcast FAILS (so the tx moves to the primary
+    // as a fallback); primary populate 429s, backup populate OK (so populate proves backup).
+    const p0 = { broadcastTransaction: recorder(async () => undefined) };
+    const p1 = { broadcastTransaction: recorder(async () => { throw retryable429(); }) };
+    const populateOrder: string[] = [];
+    const signPopulated = recorder(async () => ({ signedTx: '0xS', txHash: '0xH' }));
+    const contract = { connect: (s: any) => ({ doWrite: { populateTransaction: () => { const w = s.boundTo === p0 ? 'primary' : 'backup'; populateOrder.push(w); return w === 'primary' ? Promise.reject(retryable429()) : Promise.resolve({ to: '0xTO', data: '0x' }); } } }) } as any;
+    const client = makeClient([p0, p1], STICKY_URLS, signPopulated as SignPopulatedFn, { enabled: true });
+
+    await client.populateAndSign(contract, 'doWrite', [], makeSigner(), 'w'); // populate proves backup (source=write)
+    expect(populateOrder).toEqual(['primary', 'backup']);
+
+    // Broadcast tx: preferred=backup → backup FAILS → primary broadcasts as a FALLBACK.
+    await client.broadcast('0xsigned', '0xhash', 'w');
+    expect(p1.broadcastTransaction.calls).toHaveLength(1); // backup tried first, failed
+    expect(p0.broadcastTransaction.calls).toHaveLength(1); // primary took over
+
+    populateOrder.length = 0;
+    await client.populateAndSign(contract, 'doWrite', [], makeSigner(), 'w'); // next populate
+    // The backup's nonce view is now suspect (it failed the write; the tx moved to
+    // the primary), so the write-preference was downgraded → populate re-derives
+    // from canonical (primary-first). Without the #A downgrade this would be ['backup'].
+    expect(populateOrder).toEqual(['primary', 'backup']);
+  });
+
+  it('AC-16: a write-proven backend SURVIVES an intervening read on it — the next populate still sticks to it (#B)', async () => {
+    const p0 = {};
+    const p1 = { read: recorder(async () => 'BACKUP-READ') };
+    const populateOrder: string[] = [];
+    const signPopulated = recorder(async () => ({ signedTx: '0xS', txHash: '0xH' }));
+    const contract = { connect: (s: any) => ({ doWrite: { populateTransaction: () => { const w = s.boundTo === p0 ? 'primary' : 'backup'; populateOrder.push(w); return w === 'primary' ? Promise.reject(retryable429()) : Promise.resolve({ to: '0xTO', data: '0x' }); } } }) } as any;
+    const client = makeClient([p0, p1], STICKY_URLS, signPopulated as SignPopulatedFn, { enabled: true });
+
+    await client.populateAndSign(contract, 'doWrite', [], makeSigner(), 'w'); // populate proves backup (source=write)
+    expect(populateOrder).toEqual(['primary', 'backup']);
+
+    // Intervening READ served by the same preferred backend — must NOT downgrade the write-proven flag.
+    expect(await client.read('r', (p: any) => p.read())).toBe('BACKUP-READ');
+
+    populateOrder.length = 0;
+    await client.populateAndSign(contract, 'doWrite', [], makeSigner(), 'w'); // still write-proven → sticks to backup
+    expect(populateOrder).toEqual(['backup']); // the read did NOT reset the write-proven source
+  });
 });

--- a/packages/chain/test/rpc-failover-log.test.ts
+++ b/packages/chain/test/rpc-failover-log.test.ts
@@ -111,6 +111,7 @@ describe('rpc-failover-log', () => {
       expect(getRpcFailoverStats()).toEqual({
         failovers: 1,
         exhaustions: 0,
+        preferredEstablishments: 0,
         byErrorClass: { THROTTLE_429: 1 },
         byEndpointHost: { 'a.example': 1 },
       });

--- a/packages/cli/src/daemon/routes/status.ts
+++ b/packages/cli/src/daemon/routes/status.ts
@@ -735,6 +735,9 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
             rpcFailovers: rpcFailoverStats.failovers,
             rpcExhaustions: rpcFailoverStats.exhaustions,
             rpcFailoversByClass: rpcFailoverStats.byErrorClass,
+            // Endpoint-stickiness: times the client stuck to a backup after a
+            // failover (a rising count = a configured primary is degraded).
+            rpcPreferredEstablishments: rpcFailoverStats.preferredEstablishments,
           }
         : null,
       updateAvailable:

--- a/packages/cli/test/status-route-rpc.test.ts
+++ b/packages/cli/test/status-route-rpc.test.ts
@@ -22,7 +22,7 @@
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { createServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
-import { noteRpcFailover, noteRpcExhaustion, getRpcFailoverStats, ChainRpcTransportError } from '@origintrail-official/dkg-chain';
+import { noteRpcFailover, noteRpcExhaustion, notePreferredEndpoint, getRpcFailoverStats, ChainRpcTransportError } from '@origintrail-official/dkg-chain';
 import { computeNetworkId } from '../../core/src/genesis.js';
 import { getSharedContext } from '../../chain/test/evm-test-context.js';
 import { loadNetworkConfig } from '../src/config.js';
@@ -172,6 +172,7 @@ describe('/api/status selected overlay details', () => {
       noteRpcFailover('status-test publish', 'https://primary.example', { status: 429 }, 'https://backup.example');
       noteRpcFailover('status-test publish', 'https://other.example', { status: 503 }, 'https://backup.example');
       noteRpcExhaustion('status-test publish', ['https://primary.example', 'https://backup.example']);
+      notePreferredEndpoint('status-test publish', 'https://backup.example');
 
       const server = createServer(async (req, res) => {
         const url = new URL(req.url ?? '/', 'http://127.0.0.1');
@@ -214,6 +215,8 @@ describe('/api/status selected overlay details', () => {
         expect(body.chain.rpcExhaustions).toBe(before.exhaustions + 1);
         expect(body.chain.rpcFailoversByClass.THROTTLE_429).toBe((before.byErrorClass.THROTTLE_429 ?? 0) + 1);
         expect(body.chain.rpcFailoversByClass.SERVER_5XX).toBe((before.byErrorClass.SERVER_5XX ?? 0) + 1);
+        // Endpoint-stickiness establishment counter is wired through /api/status.
+        expect(body.chain.rpcPreferredEstablishments).toBe(before.preferredEstablishments + 1);
         // The counter surface stays host-only — never a raw RPC URL.
         expect(JSON.stringify(body.chain)).not.toContain('://');
       } finally {


### PR DESCRIPTION
## Summary

Adds **endpoint stickiness** to the RPC-failover transport (`RpcFailoverClient`), the shared root-cause fix behind two multi-RPC failover residuals:

- **#1340 retry residual** — after the CG-register `TooLowAllowance` recovery mines the TRAC approve on a backup, the retry `submitCreate` + allowance re-read used to re-select from endpoint index 0 and could land on a lagging/stale backend → `TooLowAllowance` again. They now reuse the endpoint the recovery already succeeded on (read-your-write on one backend).
- **#1337 policy-read fail-close** — `isContextGraphPublicOnChain` makes up to 3 sequential on-chain policy reads, each wrapped in a 2.5s race; under a degraded primary every read restarted at index 0 and re-stalled on the primary, so the SWM public-CG gate failed closed (kept encrypted). After one failover primes the preferred, subsequent reads start on the healthy backup and finish inside the race.

**Mechanism (pure transport-ordering — no tx-safety state):** the client remembers the last-good NON-primary endpoint and tries it first, re-probing the configured primary **at most once per `STICKY_PREFERRED_TTL_MS` (30s)** under sustained degradation, and clearing the preference the moment the primary answers again. Applied across both the read core and all three write loops. Tip-sensitive reads (current head / latest block) are carved out (`skipPreferred`) so they stay canonical-fresh and preference-transparent. Fully reversible via the `DKG_DISABLE_RPC_STICKINESS=1` kill-switch (exact pre-change index-0 behavior).

Builds on #1535 (deposit-read-via-`readContract`), which must be merged first — it is.

## Related

- Fixes the #1340 retry read-after-write residual (Mechanism B; #1535 was Mechanism A)
- Fixes #1337 (policy-read fail-close under a degraded primary) via transport stickiness rather than a timeout bump (the naive bump, PR #1537, was closed for breaking other caller budgets)
- Builds on #1535
- Prior art: #1329 / #1338 (multi-RPC failover), #1454 (validated RPC endpoint abstraction — thematically adjacent)

## Files changed

| File | What |
|------|------|
| `packages/chain/src/rpc-failover-client.ts` | Core: `preferredRpcUrl` + `primaryProbeDueAt` state, `StickinessOptions` ctor param, `orderEndpoints`/`notePreferredOutcome`/`stickinessOn` helpers; all 4 loops order-preferred-first + note-on-success; exhaustion built from canonical order |
| `packages/chain/src/evm-adapter-constants.ts` | `STICKY_PREFERRED_TTL_MS = 30_000` |
| `packages/chain/src/evm-adapter-base.ts` | `skipPreferred` carve-out on `getBlockNumber()` and `getBlockTimestamp`/`getBlock(n)` |
| `packages/chain/src/evm-adapter-conviction.ts` | `skipPreferred` on conviction `getBlock('latest')` and the PCA rpc proxy (allowlist includes `eth_blockNumber`) |
| `packages/chain/src/evm-adapter-events.ts` | `skipPreferred` on the event-lane wide-log scan — keeps the scan's tip coverage aligned with the canonical-fresh head that advances the cursor (else a lagging sticky backup could silently truncate and skip events) |
| `packages/chain/src/hub-rotation-poller.ts` | `skipPreferred` on both poller head reads + the getLogs scan (background probe stays preference-transparent) |
| `packages/chain/src/rpc-failover-log.ts` | `notePreferredEndpoint()` (dedup'd host-only log) + `preferredEstablishments` counter in the snapshot |
| `packages/cli/src/daemon/routes/status.ts` | Surface `rpcPreferredEstablishments` in `/api/status` (additive) |
| `packages/chain/test/rpc-failover-client.unit.test.ts` | 9 stickiness ACs (order, one-re-probe-per-TTL cadence, primary-clears, kill-switch, skipPreferred transparency, single-RPC, canonical exhaustion, observability) |
| `packages/chain/test/evm-adapter-cg-policy-read-stickiness.unit.test.ts` | **new** — 3 #1337 tests over a real adapter + real transport (stall + 2.5s race; cross-method sticky; kill-switch re-stall) |
| `packages/chain/test/evm-adapter-tip-read-carveouts.unit.test.ts` | **new** — per-site pins that every tip-sensitive read (`getBlockNumber`, `getBlockTimestamp`, conviction `latest`, PCA rpc, event-lane scan) passes `skipPreferred:true` |
| `packages/chain/test/hub-rotation-poller.unit.test.ts` | Pin the poller's `skipPreferred` transparency |
| `packages/chain/test/rpc-failover-log.test.ts` | Snapshot now includes `preferredEstablishments` |

## Review

Self-reviewed adversarially with a 5-lens agent sweep (ordering/cadence, tx-safety, blast-radius, concurrency, tests), each finding independently verified against the code. Fixed before opening: (1) the event-lane wide-log scan was left sticky while its head is canonical-fresh → carved it out (silent-event-loss regression); (2) the clear-on-primary now only fires when the primary is tried *first* (a genuine re-probe), not when reached as a fallback (avoids resetting stickiness outside the TTL cadence under method-selective 429s); (3) the `preferredEstablishments` counter no longer double-counts backup→backup re-points; (4) added per-site carve-out pins + a stronger AC-6 (proves the reorder happened) + null-receipt / populateAndSign-establishment / pool-rebind coverage. Tx-safety (single-sign, idempotent re-broadcast, WAL-once, exhaustion, `getReceipt` self-heal) was independently confirmed to survive the reordering.

## Test plan

- [x] `packages/chain` `tsc --noEmit` — clean
- [x] `packages/chain` full unit lane (`vitest.unit.config.ts`) — 575 passed / 1 skipped
- [x] `packages/cli` `tsc --noEmit` — clean
- [x] New RED→GREEN gate: op#2 after a failover prefers the backup (kill-switch tests pin the index-0 pre-change baseline)
- [x] Cadence guard: exactly one primary re-probe per TTL under a persistently degraded primary (injected clock)
- [x] tx-safety invariants (single-sign, idempotency, exhaustion, `getReceipt` self-heal) unchanged
- [ ] Optional live repro: node with a broken primary + healthy backup — CG-register first publish + SWM public-CG gate both succeed (pre-fix: `TooLowAllowance` / fail-closed)

Notes: the `status-route-rpc.test.ts` "real daemon, real chain" case requires a built CLI + a Hardhat context and is not runnable in the unit lane (identical on `main`); the additive status field is verified via `tsc`. Observability is unit-tested at the chain level (log + counter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
