### PR TITLE
feat(cli): add git auto-update opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,32 @@ dkg update --allow-prerelease   # follow the `next` dist-tag for pre-release bui
 dkg rollback                # revert to the previous version
 ```
 
-Do **not** `git pull` or clone the repository to update — `dkg update` is the canonical verb. If anything looks off (multiple repositories on disk, served UI doesn't match version, version skew between daemon and CLI), run `dkg doctor` for a structured diagnostic of the install state. See [`OT-RFC-41`](https://github.com/OriginTrail/dkgv10-spec/blob/main/rfcs/OT-RFC-41-edge-node-npm-only-install-and-update.md) for the design rationale.
+NPM/dist-tag updates are the recommended production path. Core operators who
+explicitly need build-from-source updates can opt into the advanced git updater
+by writing this block in `~/.dkg/config.json`:
+
+```json
+{
+  "autoUpdate": {
+    "enabled": true,
+    "source": "git",
+    "repo": "https://github.com/OriginTrail/dkg.git",
+    "branch": "main",
+    "checkIntervalMinutes": 3
+  }
+}
+```
+
+Git mode is daemon-polled and experimental. It builds the watched ref in the
+inactive blue-green slot, swaps slots, then exits through the supervised restart
+flow. Rollback differs from npm/dist-tag mode: it can only flip back to an
+already-built slot, not reinstall an arbitrary package version from npm.
+
+Do **not** manually `git pull` a running node tree. If anything looks off
+(multiple repositories on disk, served UI doesn't match version, version skew
+between daemon and CLI), run `dkg doctor` for a structured diagnostic of the
+install state. See [`OT-RFC-41`](https://github.com/OriginTrail/dkgv10-spec/blob/main/rfcs/OT-RFC-41-edge-node-npm-only-install-and-update.md)
+for the npm-first design rationale.
 
 ### Contributors / monorepo development
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -279,10 +279,16 @@ modes auto-renewal can't recover from:
 | `dkg wallet` | Show operational wallet addresses and balances |
 | `dkg set-ask <amount>` | Set the node's on-chain ask (TRAC per KB·epoch) |
 | `dkg openclaw setup` | Install and configure the OpenClaw adapter |
-| `dkg update` | Update the node software (blue-green slots) |
+| `dkg update` | Update the node software from npm (blue-green slots for Core nodes) |
 | `dkg rollback` | Roll back to the previous software slot |
 
 Run `dkg <command> --help` for per-command options.
+
+NPM/dist-tag auto-update is the recommended production path. Advanced Core nodes
+can opt into daemon-polled git updates with `autoUpdate.source: "git"`,
+`repo`, and `branch` or `ref` in `~/.dkg/config.json`; git mode builds from
+source in the inactive blue-green slot and rollback is limited to already-built
+slots.
 
 Async publisher wallets need valid keys and native gas. Register the wallet as a PCA agent or fund TRAC for direct spend before expecting jobs to publish successfully. An on-chain node identity is optional publisher-node attribution; identity `0` is valid no-attribution mode. See [Async Publisher Wallets](../../docs/use-dkg/async-publisher-wallets.md).
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -30,6 +30,7 @@ import {
   slotEntryPoint, isStandaloneInstall, repoDir, isDkgMonorepo, classifyMonorepoInit, sharedHomeInitGate,
   resolveContextGraphs, resolveNetworkDefaultContextGraphs,
   readNodeRoleFromConfigSync,
+  AUTO_UPDATE_GIT_ONLY_FIELDS,
   type AutoUpdateConfig,
 } from '../config.js';
 import { ApiClient } from '../api-client.js';
@@ -129,34 +130,46 @@ export function isInitNetworkSwitch(
   return !!prior && selectedNetwork !== prior;
 }
 
+function pickPreservedAutoUpdateFields(
+  source: NonNullable<AutoUpdateConfig['source']>,
+  existingAutoUpdate: AutoUpdateConfig | undefined,
+): Partial<AutoUpdateConfig> {
+  if (!existingAutoUpdate) return {};
+  const preserved: Partial<AutoUpdateConfig> = {};
+  if (existingAutoUpdate.channel) preserved.channel = existingAutoUpdate.channel;
+  if (source === 'git') {
+    for (const field of AUTO_UPDATE_GIT_ONLY_FIELDS) {
+      const value = existingAutoUpdate[field as keyof AutoUpdateConfig];
+      if (value !== undefined && value !== null && value !== '') {
+        (preserved as Record<string, unknown>)[field] = value;
+      }
+    }
+  }
+  return preserved;
+}
+
 /**
  * Pure builder for the `autoUpdate` block `dkg init` persists. Extracted from
  * the interactive wizard so it is unit-testable — the decline path (must write
  * `{ enabled: false }`, NOT fall through to the enabled network default) and
- * channel/advanced-field preservation across reruns have each regressed before.
- * The wizard gathers `answers` interactively and passes them in.
+ * source-mode field boundaries across reruns have each regressed before. The
+ * wizard gathers `answers` interactively and passes them in.
  */
 export function buildInitAutoUpdate(opts: {
   enableAutoUpdate: boolean;
   existingAutoUpdate: AutoUpdateConfig | undefined;
   networkAutoUpdate?: {
-    repo?: string;
-    branch?: string;
     allowPrerelease?: boolean;
-    sshKeyPath?: string;
     checkIntervalMinutes?: number;
   };
   projRepo: string;
   projDefaultBranch: string;
   answers?: {
-    repo: string;
-    branch: string;
     allowPrerelease: boolean;
-    sshKeyPath: string;
     interval: number;
   };
 }): AutoUpdateConfig {
-  const { enableAutoUpdate, existingAutoUpdate, networkAutoUpdate, projRepo, projDefaultBranch, answers } = opts;
+  const { enableAutoUpdate, existingAutoUpdate, networkAutoUpdate, answers } = opts;
   if (!enableAutoUpdate) {
     // Explicit decline: persist `enabled: false` so resolveAutoUpdateConfig
     // does NOT fall through to the enabled network default. Keep any existing
@@ -165,30 +178,23 @@ export function buildInitAutoUpdate(opts: {
       ? { ...existingAutoUpdate, enabled: false }
       : { enabled: false };
   }
-  const a = answers ?? { repo: '', branch: '', allowPrerelease: true, sshKeyPath: '', interval: NaN };
+  const a = answers ?? { allowPrerelease: true, interval: NaN };
   // Effective upstream defaults — what the node would use with nothing
   // persisted. We persist a field only when it differs, so future changes to
   // the shipped network/project config propagate without a config rewrite.
-  const effectiveRepo = networkAutoUpdate?.repo ?? projRepo;
-  const effectiveBranch = networkAutoUpdate?.branch ?? projDefaultBranch;
   const effectiveAllowPrerelease = networkAutoUpdate?.allowPrerelease ?? true;
-  const effectiveSshKeyPath = networkAutoUpdate?.sshKeyPath ?? '';
   const effectiveInterval = networkAutoUpdate?.checkIntervalMinutes ?? 30;
+  const source = 'npm' as const;
   return {
     enabled: true,
     // OT-RFC-41 Bundle B1d: explicit npm source for fresh installs.
-    source: 'npm' as const,
-    ...(a.repo && a.repo !== effectiveRepo ? { repo: a.repo } : {}),
-    ...(a.branch && a.branch !== effectiveBranch ? { branch: a.branch } : {}),
+    source,
     ...(a.allowPrerelease !== effectiveAllowPrerelease ? { allowPrerelease: a.allowPrerelease } : {}),
-    ...(a.sshKeyPath && a.sshKeyPath !== effectiveSshKeyPath ? { sshKeyPath: a.sshKeyPath } : {}),
     ...(Number.isFinite(a.interval) && a.interval !== effectiveInterval ? { checkIntervalMinutes: a.interval } : {}),
-    // Preserve advanced fields the wizard does not prompt for so a rerun
-    // doesn't silently revert operator tuning: build timeouts, custom SSH
-    // command, and the per-node `channel` cohort pin.
-    ...(existingAutoUpdate?.buildTimeoutMs ? { buildTimeoutMs: existingAutoUpdate.buildTimeoutMs } : {}),
-    ...(existingAutoUpdate?.sshCommand ? { sshCommand: existingAutoUpdate.sshCommand } : {}),
-    ...(existingAutoUpdate?.channel ? { channel: existingAutoUpdate.channel } : {}),
+    // Source mode is the config boundary. The npm wizard preserves only
+    // npm/common fields that it does not prompt for; git-only fields are kept
+    // together only when source remains git.
+    ...pickPreservedAutoUpdateFields(source, existingAutoUpdate),
   } as AutoUpdateConfig;
 }
 
@@ -415,7 +421,7 @@ program
     const contextGraphs = contextGraphsStr ? contextGraphsStr.split(',').map(s => s.trim()).filter(Boolean) : [];
     const apiPort = parseInt(await ask('API port', String(existing.apiPort)), 10);
 
-    // OT-RFC-41 §4.3 Bundle B1d: post-rc.12, auto-update is npm-only.
+    // OT-RFC-41 §4.3 Bundle B1d: default auto-update is npm.
     // The prompt wording is updated; the persisted config carries an
     // explicit `source: 'npm'` so the daemon's resolution is
     // unambiguous (no implicit `isStandaloneInstall()` probe).
@@ -431,31 +437,22 @@ program
     // it is unit-tested. Prompt defaults show existing value, else the upstream
     // (network → project) default.
     let autoUpdateAnswers:
-      | { repo: string; branch: string; allowPrerelease: boolean; sshKeyPath: string; interval: number }
+      | { allowPrerelease: boolean; interval: number }
       | undefined;
     if (enableAutoUpdate) {
-      const effectiveRepo = network?.autoUpdate?.repo ?? proj.repo;
-      const effectiveBranch = network?.autoUpdate?.branch ?? proj.defaultBranch;
       const effectiveAllowPrerelease = network?.autoUpdate?.allowPrerelease ?? true;
-      const effectiveSshKeyPath = network?.autoUpdate?.sshKeyPath ?? '';
       const effectiveInterval = network?.autoUpdate?.checkIntervalMinutes ?? 30;
 
-      const defaultRepo = existing.autoUpdate?.repo ?? effectiveRepo;
-      const defaultBranch = existing.autoUpdate?.branch ?? effectiveBranch;
       const defaultAllowPrerelease = existing.autoUpdate?.allowPrerelease ?? effectiveAllowPrerelease;
-      const defaultSshKeyPath = existing.autoUpdate?.sshKeyPath ?? effectiveSshKeyPath;
       const defaultInterval = existing.autoUpdate?.checkIntervalMinutes ?? effectiveInterval;
 
-      const repo = await ask('Git repo/path (owner/name, URL, or git@host:org/repo.git)', defaultRepo);
-      const branch = await ask('Branch', defaultBranch);
       const allowPrerelease = (await ask(
         'Allow pre-release versions? (y/n)',
         defaultAllowPrerelease ? 'y' : 'n',
       )).toLowerCase() === 'y';
-      const sshKeyPath = (await ask('SSH private key path (optional; blank uses agent/default SSH config)', defaultSshKeyPath)).trim();
       const interval = parseInt(await ask('Check interval (minutes)', String(defaultInterval)), 10);
 
-      autoUpdateAnswers = { repo, branch, allowPrerelease, sshKeyPath, interval };
+      autoUpdateAnswers = { allowPrerelease, interval };
     }
     const autoUpdate = buildInitAutoUpdate({
       enableAutoUpdate,

--- a/packages/cli/src/commands/maintenance.ts
+++ b/packages/cli/src/commands/maintenance.ts
@@ -239,14 +239,12 @@ program
       return;
     }
 
-    // --- Git-based update path: hard refusal under OT-RFC-41 §4.2 / §5 PR 5 ---
+    // --- Manual git update path: hard refusal. Git source updates are daemon-only. ---
     //
-    // Bundle A shipped this branch with a deprecation warning;
-    // Bundle B converts it to a hard refusal. The npm path above
-    // is the canonical update mechanism for both Edge (`npm
-    // install -g`) and Core (`npm install` into a slot). The
-    // git-pull + build-from-source path is no longer reachable
-    // from any user-facing CLI entry point.
+    // The npm path above is the canonical manual update mechanism for both Edge
+    // (`npm install -g`) and Core (`npm install` into a slot). Core nodes that
+    // opt into `autoUpdate.source = "git"` run the build-from-source updater
+    // only from daemon polling, so the supervised restart flow owns activation.
     //
     // For monorepo contributors: the canonical "update" is
     // `git pull && pnpm install && pnpm build` from the repo
@@ -255,16 +253,13 @@ program
     // `npm install -g @origintrail-official/dkg` and let the
     // first-start migration record `~/.dkg/previous-version`.
     //
-    // The dead `_performUpdateInner` / `performUpdate` /
-    // `checkForUpdate` / `checkForNewCommit*` symbols stay in
-    // `daemon/auto-update.ts` for one release so a rollback to
-    // rc.11 still type-checks; a follow-up cleanup PR deletes
-    // them once Bundle B has soaked on devnet.
     console.error(
       '\n' +
-      '[dkg update] ERROR: git-based update is no longer supported.\n' +
+      '[dkg update] ERROR: manual git-based update is not supported.\n' +
       '\n' +
-      '  Per OT-RFC-41, all DKG node updates now flow through the npm registry.\n' +
+      '  Manual `dkg update` flows through the npm registry.\n' +
+      '  Advanced Core nodes may opt into daemon-polled git updates with\n' +
+      '  autoUpdate.source = "git", repo, and branch/ref in config.json.\n' +
       '\n' +
       '  - Monorepo contributors: use `git pull && pnpm install && pnpm build`\n' +
       '    from the repo root. `dkg update` is for npm-installed nodes only.\n' +

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -37,12 +37,28 @@ export interface AutoUpdateBuildTimeouts {
   markitdown?: number;
 }
 
+export const AUTO_UPDATE_GIT_ONLY_FIELDS = [
+  'repo',
+  'branch',
+  'ref',
+  'sshKeyPath',
+  'sshCommand',
+  'buildTimeoutMs',
+  'verifyTagSignature',
+] as const;
+
 export interface AutoUpdateConfig {
   enabled: boolean;
   /** Optional in ~/.dkg/config.json: omit to inherit from network/project config. */
   repo?: string;
   /** Optional in ~/.dkg/config.json: omit to inherit from network/project config. */
   branch?: string;
+  /**
+   * Optional git ref for the advanced git updater. When set, this wins over
+   * `branch`. Bare values are treated as branches (`main` ->
+   * `refs/heads/main`); full refs such as `refs/heads/main` are accepted.
+   */
+  ref?: string;
   /** Allow auto-updating to pre-release versions (e.g. 9.0.5-rc.1). */
   allowPrerelease?: boolean;
   /**
@@ -86,11 +102,12 @@ export interface AutoUpdateConfig {
    *     (`repoDir() === null`). Treated as `'npm'` under rc.12+ via
    *     `resolveStandaloneInstall()`.
    *
-   *   `'git'` (legacy; pre-rc.12): the now-removed git-build update
-   *     path. Treated as `'monorepo'` under rc.12+ (the daemon does
-   *     not auto-update, no git pull/build). User-facing `dkg
-   *     update` from such a config refuses to run — see OT-RFC-41
-   *     §4.2 and `cli.ts dkg update`.
+   *   `'git'`: advanced/experimental Core-node updater. The daemon
+   *     polls `repo` + `ref`/`branch`, builds the target commit from
+   *     source in the inactive blue-green slot, swaps slots, then exits
+   *     through the supervised restart flow. NPM/dist-tag updates remain
+   *     recommended for production because rollback expectations differ:
+   *     git mode can only roll back to an already-built slot.
    *
    * Implementation: read once at boot via `resolveStandaloneInstall(source)`
    * in `daemon/state.ts`, which writes the result into the shared
@@ -110,6 +127,7 @@ export interface AutoUpdateConfig {
 export type ResolvedAutoUpdateConfig = AutoUpdateConfig & {
   repo: string;
   branch: string;
+  ref?: string;
   checkIntervalMinutes: number;
 };
 
@@ -127,6 +145,7 @@ export interface NetworkConfig {
     enabled: boolean;
     repo: string;
     branch: string;
+    ref?: string;
     allowPrerelease?: boolean;
     /** npm dist-tag this network's nodes track — see `AutoUpdateConfig.channel`. */
     channel?: string;
@@ -1165,6 +1184,7 @@ export function resolveAutoUpdateConfig(
   const proj = loadProjectConfig();
   const repo = cfg?.repo ?? net?.repo ?? proj.repo;
   const branch = cfg?.branch ?? net?.branch ?? proj.defaultBranch;
+  const ref = cfg?.ref ?? net?.ref;
   const allowPrerelease = cfg?.allowPrerelease ?? net?.allowPrerelease ?? true;
   const sshKeyPath = cfg?.sshKeyPath ?? net?.sshKeyPath;
   const sshCommand = cfg?.sshCommand ?? net?.sshCommand;
@@ -1190,6 +1210,7 @@ export function resolveAutoUpdateConfig(
     enabled: true,
     repo,
     branch,
+    ...(ref ? { ref } : {}),
     allowPrerelease,
     ...(sshKeyPath ? { sshKeyPath } : {}),
     ...(sshCommand ? { sshCommand } : {}),

--- a/packages/cli/src/daemon/auto-update.ts
+++ b/packages/cli/src/daemon/auto-update.ts
@@ -6,15 +6,12 @@
 //   - `performNpmUpdate`     — Core nodes (blue-green slots, npm install
 //                              into inactive slot + swap).
 //
-// The legacy git-clone + build-from-source path (`performUpdate`,
+// The git-clone + build-from-source path (`performUpdate`,
 // `_performUpdateInner`, `checkForUpdate`, `checkForNewCommit*`,
 // `runBuildStep`, `cleanGeneratedOutputs`, `sweepOrphanBuildProcesses`,
-// `resolveBuildTimeouts`) remains in this file as **dead production
-// code** under Bundle B: no user-facing CLI entry point or daemon
-// polling loop calls into it anymore (see `cli.ts` `dkg update` and
-// `daemon/lifecycle.ts` polling, both updated in OT-RFC-41 §4.2 /
-// §5 PR 5). A follow-up rc.12.x cleanup PR deletes these symbols
-// once Bundle B has soaked on devnet.
+// `resolveBuildTimeouts`) is intentionally retained for advanced Core nodes
+// that opt into `autoUpdate.source = "git"`. NPM/dist-tag updates remain the
+// default and recommended path.
 //
 // Live "last check" state is shared with `handleRequest`'s `/status`
 // endpoint via `daemonState` in `./state.js`.
@@ -90,7 +87,32 @@ export function parseTagName(ref: string): string | null {
 }
 
 export function isValidRef(ref: string): boolean {
-  return /^[\w./+\-]+$/.test(ref) && !ref.startsWith("-");
+  if (!/^[\w./+\-]+$/.test(ref)) return false;
+  if (!ref || ref.startsWith("-") || ref.startsWith("/") || ref.endsWith("/")) return false;
+  if (ref.includes("..") || ref.includes("//") || ref.includes("@{")) return false;
+  if (ref.endsWith(".")) return false;
+  const parts = ref.split("/");
+  return parts.every((part) => {
+    if (!part || part === "." || part === "..") return false;
+    if (part.endsWith(".lock")) return false;
+    return true;
+  });
+}
+
+export function normalizeGitRefInput(ref: string): string {
+  const trimmed = ref.trim() || "main";
+  if (!isValidRef(trimmed)) {
+    throw new Error(`invalid branch/ref "${ref}"`);
+  }
+  if (trimmed.startsWith("refs/")) return trimmed;
+  return `refs/heads/${trimmed}`;
+}
+
+export function resolveAutoUpdateGitRef(
+  au: Pick<ResolvedAutoUpdateConfig, "branch"> & { ref?: string },
+  refOverride?: string,
+): string {
+  return normalizeGitRefInput(refOverride ?? au.ref ?? au.branch);
 }
 
 export function isValidRepoSpec(repo: string): boolean {
@@ -156,7 +178,7 @@ export async function resolveRemoteCommitSha(
   try {
     fetchUrl = repoToFetchUrl(repoSpec);
   } catch (err: any) {
-    log(`Auto-update: ${err?.message ?? "invalid autoUpdate.repo"}`);
+    log(`Auto-update (git): ${err?.message ?? "invalid autoUpdate.repo"}`);
     return null;
   }
   const githubRepo = githubRepoForApi(repoSpec);
@@ -178,16 +200,16 @@ export async function resolveRemoteCommitSha(
     });
     if (!res.ok) {
       if (res.status === 422 && ref.startsWith("refs/tags/")) {
-        log(`Auto-update: tag "${apiRef}" not found in ${githubRepo}`);
+        log(`Auto-update (git): tag "${apiRef}" not found in ${githubRepo}`);
         return null;
       }
       if (res.status === 404) {
         log(
-          `Auto-update: GitHub returned 404 for ${githubRepo} ref "${ref}". ` +
+          `Auto-update (git): GitHub returned 404 for ${githubRepo} ref "${ref}". ` +
             "If the repo is private, set GITHUB_TOKEN. Otherwise check repo/ref in config.",
         );
       } else {
-        log(`Auto-update: GitHub API returned ${res.status} for ${url}`);
+        log(`Auto-update (git): GitHub API returned ${res.status} for ${url}`);
       }
       return null;
     }
@@ -211,7 +233,7 @@ export async function resolveRemoteCommitSha(
       typeof raw === "string" ? raw : String((raw as any)?.stdout ?? "");
     const lines = String(stdout).trim().split("\n").filter(Boolean);
     if (lines.length === 0) {
-      log(`Auto-update: ref "${ref}" not found in ${fetchUrl}`);
+      log(`Auto-update (git): ref "${ref}" not found in ${fetchUrl}`);
       return null;
     }
     const peeledTagRef = `${ref}^{}`;
@@ -248,6 +270,10 @@ export type CommitCheckStatus = {
   status: "available" | "up-to-date" | "error";
   commit?: string;
 };
+
+function shortCommit(commit: string): string {
+  return commit ? commit.slice(0, 12) : "unknown";
+}
 
 export async function readPendingUpdateState(): Promise<PendingUpdateState | null> {
   const { dkgDir, readFile } = _autoUpdateIo;
@@ -713,12 +739,14 @@ export async function checkForNewCommitWithStatus(
     }
   }
 
-  const ref = (refOverride ?? au.branch).trim() || "main";
-  const gitEnv = gitCommandEnv(au);
-  if (!isValidRef(ref)) {
-    log(`Auto-update: invalid branch/ref "${ref}"`);
+  let ref = "";
+  try {
+    ref = resolveAutoUpdateGitRef(au, refOverride);
+  } catch (err: any) {
+    log(`Auto-update (git): ${err?.message ?? "invalid branch/ref"}`);
     return { status: "error" };
   }
+  const gitEnv = gitCommandEnv(au);
 
   try {
     const latestCommit = await resolveRemoteCommitSha(
@@ -728,11 +756,17 @@ export async function checkForNewCommitWithStatus(
       gitEnv,
     );
     if (!latestCommit) return { status: "error" };
-    if (latestCommit === currentCommit) return { status: "up-to-date" };
+    log(
+      `Auto-update (git): current commit ${shortCommit(currentCommit)}, remote commit ${shortCommit(latestCommit)} for ref "${ref}".`,
+    );
+    if (latestCommit === currentCommit) {
+      log("Auto-update (git): update skipped — remote commit matches current.");
+      return { status: "up-to-date", commit: latestCommit };
+    }
     return { status: "available", commit: latestCommit };
   } catch (err: any) {
     log(
-      `Auto-update: failed to check for new commit (${err?.message ?? String(err)})`,
+      `Auto-update (git): failed to check for new commit (${err?.message ?? String(err)})`,
     );
     return { status: "error" };
   }
@@ -1024,6 +1058,8 @@ async function cleanGeneratedOutputs(
  */
 export interface PerformUpdateOptions {
   refOverride?: string;
+  /** Remote commit already resolved by the daemon poller; avoids a duplicate network check. */
+  expectedCommit?: string;
   allowPrerelease?: boolean;
   verifyTagSignature?: boolean;
   /**
@@ -1117,10 +1153,20 @@ async function _performUpdateInner(
         encoding: "utf-8",
         cwd: activeDir,
       });
-      currentCommit = stdout.trim();
-      await writeFileAtomic(commitFile, currentCommit);
-    } catch {
-      return "failed";
+      const derivedCommit = stdout.trim();
+      if (derivedCommit) {
+        currentCommit = derivedCommit;
+        await writeFileAtomic(commitFile, currentCommit);
+      } else {
+        log(
+          "Auto-update (git): active slot git commit is unknown; continuing bootstrap from configured repo/ref.",
+        );
+      }
+    } catch (err: any) {
+      log(
+        `Auto-update (git): active slot git commit is unknown (${err?.message ?? String(err)}); ` +
+          "continuing bootstrap from configured repo/ref.",
+      );
     }
   }
 
@@ -1141,20 +1187,29 @@ async function _performUpdateInner(
     }
   }
 
-  const ref = (opts.refOverride ?? au.branch).trim() || "main";
-  const gitEnv = gitCommandEnv(au);
-
-  if (!isValidRef(ref)) {
-    log(`Auto-update: invalid branch/ref "${ref}"`);
+  let ref = "";
+  try {
+    ref = resolveAutoUpdateGitRef(au, opts.refOverride);
+  } catch (err: any) {
+    log(`Auto-update (git): ${err?.message ?? "invalid branch/ref"}`);
     return "failed";
   }
-  const latestCommit = await resolveRemoteCommitSha(au.repo, ref, log, gitEnv);
-  if (!latestCommit) return "failed";
+  const gitEnv = gitCommandEnv(au);
 
-  if (latestCommit === currentCommit) return "up-to-date";
+  const latestCommit = opts.expectedCommit?.trim()
+    || await resolveRemoteCommitSha(au.repo, ref, log, gitEnv);
+  if (!latestCommit) return "failed";
+  log(
+    `Auto-update (git): current commit ${shortCommit(currentCommit)}, remote commit ${shortCommit(latestCommit)} for ref "${ref}".`,
+  );
+
+  if (latestCommit === currentCommit) {
+    log("Auto-update (git): update skipped — remote commit matches current.");
+    return "up-to-date";
+  }
 
   log(
-    `Auto-update: new commit detected (${latestCommit.slice(0, 8)}) for "${ref}", building in slot ${target}...`,
+    `Auto-update (git): update started — new commit ${latestCommit.slice(0, 8)} for "${ref}", building in slot ${target}...`,
   );
   let checkedOutCommit = latestCommit;
   let fetchUrl = "";
@@ -1162,14 +1217,14 @@ async function _performUpdateInner(
   try {
     fetchUrl = repoToFetchUrl(au.repo);
   } catch (repoErr: any) {
-    log(`Auto-update: ${repoErr?.message ?? "invalid autoUpdate.repo"}`);
+    log(`Auto-update (git): ${repoErr?.message ?? "invalid autoUpdate.repo"}`);
     return "failed";
   }
 
   if (!existsSync(join(targetDir, ".git"))) {
     try {
       log(
-        `Auto-update: slot ${target} missing git metadata; reinitializing slot repo.`,
+        `Auto-update (git): slot ${target} missing git metadata; reinitializing slot repo.`,
       );
       await mkdir(targetDir, { recursive: true });
       await execFileAsync("git", ["init"], {
@@ -1179,7 +1234,7 @@ async function _performUpdateInner(
       });
     } catch (initErr: any) {
       log(
-        `Auto-update: failed to initialize slot ${target} repo — ${initErr?.message ?? String(initErr)}`,
+        `Auto-update (git): failed to initialize slot ${target} repo — ${initErr?.message ?? String(initErr)}`,
       );
       return "failed";
     }
@@ -1190,7 +1245,7 @@ async function _performUpdateInner(
     const fetchRef = maybeTag ? `${ref}:${ref}` : ref;
     const fetchStartedAt = Date.now();
     log(
-      `Auto-update: fetching "${ref}" from ${fetchUrl} into slot ${target}...`,
+      `Auto-update (git): fetching "${ref}" from ${fetchUrl} into slot ${target}...`,
     );
     await execFileAsync(
       "git",
@@ -1253,7 +1308,7 @@ async function _performUpdateInner(
     );
   } catch (fetchErr: any) {
     log(
-      `Auto-update: git fetch/checkout/verify failed in slot ${target} — ${fetchErr.message}`,
+      `Auto-update (git): git fetch/checkout/verify failed in slot ${target} — ${fetchErr.message}`,
     );
     return "failed";
   }
@@ -1465,22 +1520,22 @@ async function _performUpdateInner(
   });
   try {
     const swapStartedAt = Date.now();
-    log(`Auto-update: swapping active slot to ${target}...`);
+    log(`Auto-update (git): swapping active slot to ${target}...`);
     await swapSlot(target);
     await writeFileAtomic(commitFile, checkedOutCommit);
     if (nextVersion) await writeFileAtomic(versionFile, nextVersion);
     await clearPendingUpdateState();
     const swapElapsedMs = Date.now() - swapStartedAt;
     log(
-      `Auto-update: swap complete; active slot is now ${target} (${checkedOutCommit.slice(0, 8)}) in ${swapElapsedMs}ms.`,
+      `Auto-update (git): swap complete; active slot is now ${target} (${checkedOutCommit.slice(0, 8)}) in ${swapElapsedMs}ms.`,
     );
   } catch (swapErr: any) {
     await clearPendingUpdateState();
-    log(`Auto-update: symlink swap failed — ${swapErr.message}`);
+    log(`Auto-update (git): symlink swap failed — ${swapErr.message}`);
     return "failed";
   }
   log(
-    `Auto-update: build succeeded in slot ${target}` +
+    `Auto-update (git): build succeeded in slot ${target}` +
       `${nextVersion ? ` (version ${nextVersion})` : ""}. Swapped symlink. Restarting...`,
   );
   return "updated";

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -188,6 +188,7 @@ import { DkgClient } from '@origintrail-official/dkg-mcp/client';
 import {
   daemonState,
   resolveStandaloneInstall,
+  resolveAutoUpdatePollingMode,
   type CorsAllowlist,
 } from './state.js';
 import {
@@ -291,6 +292,9 @@ import {
   type UpdateStatus,
   acquireUpdateLock,
   releaseUpdateLock,
+  resolveAutoUpdateGitRef,
+  checkForNewCommitWithStatus,
+  performUpdateWithStatus,
   performNpmUpdate,
   performNpmUpdateEdge,
 } from './auto-update.js';
@@ -2106,14 +2110,73 @@ export async function runDaemonInner(
   // omits the field (the common case after `dkg init` with default answers).
   let updateInterval: ReturnType<typeof setInterval> | null = null;
   const au = resolveAutoUpdateConfig(config, network);
-  // OT-RFC-41 §4.2 / §5 PR 5: auto-update polling is npm-only.
-  // `resolveStandaloneInstall` still seeds `daemonState.standaloneCache`
-  // for `/api/status` consumers; monorepo dev daemons (standalone=false)
-  // skip the polling loop entirely — contributors update via
-  // `git pull && pnpm install && pnpm build`.
-  const standalone = resolveStandaloneInstall(au?.source ?? resolveAutoUpdateSource(config, network));
+  const configuredAutoUpdateSource = au?.source ?? resolveAutoUpdateSource(config, network);
+  const standalone = resolveStandaloneInstall(configuredAutoUpdateSource);
+  const pollingMode = resolveAutoUpdatePollingMode(configuredAutoUpdateSource, standalone);
 
-  if (standalone) {
+  if (pollingMode === "git" && au) {
+    const checkIntervalMs = au.checkIntervalMinutes * 60_000;
+    let watchedRef = "";
+    let watchedRepo = "";
+    try {
+      watchedRef = resolveAutoUpdateGitRef(au);
+      watchedRepo = repoToFetchUrl(au.repo);
+    } catch (err: any) {
+      log(
+        `Auto-update (git): invalid config — ${err?.message ?? String(err)}. ` +
+          "Git polling disabled until config is fixed and the daemon is restarted.",
+      );
+    }
+
+    if (watchedRef && watchedRepo) {
+      log(
+        `Auto-update (git): enabled source="git"; watching repo="${watchedRepo}" ref="${watchedRef}" ` +
+          `(every ${au.checkIntervalMinutes}min). NPM/dist-tag updates remain recommended; git mode is advanced/experimental.`,
+      );
+
+      const runCheck = async () => {
+        const gitStatus = await checkForNewCommitWithStatus(au, log);
+        if (gitStatus.status === "error") {
+          log("Auto-update (git): update check failed.");
+          return;
+        }
+
+        daemonState.lastUpdateCheck.checkedAt = Date.now();
+        daemonState.lastUpdateCheck.upToDate = gitStatus.status === "up-to-date";
+        daemonState.lastUpdateCheck.channelTargetMissing = false;
+        daemonState.lastUpdateCheck.latestVersion = "";
+        daemonState.lastUpdateCheck.latestCommit = gitStatus.commit ?? "";
+
+        if (gitStatus.status !== "available" || !gitStatus.commit) return;
+
+        daemonState.isUpdating = true;
+        let updateStatus: UpdateStatus = "failed";
+        try {
+          updateStatus = await performUpdateWithStatus(au, log, {
+            expectedCommit: gitStatus.commit,
+          });
+        } finally {
+          daemonState.isUpdating = false;
+        }
+
+        if (updateStatus === "updated") {
+          log("Auto-update (git): update activated; exiting for supervised restart.");
+          await shutdown(DAEMON_EXIT_CODE_RESTART);
+          return;
+        }
+        if (updateStatus === "up-to-date") {
+          log("Auto-update (git): update skipped — node caught up before apply.");
+          return;
+        }
+        log("Auto-update (git): update failed.");
+      };
+
+      setTimeout(runCheck, 15_000);
+      updateInterval = setInterval(runCheck, checkIntervalMs);
+    }
+  } else if (pollingMode === "git") {
+    log("Auto-update (git): disabled — autoUpdate.enabled is false.");
+  } else if (pollingMode === "npm") {
     const checkIntervalMs = (au?.checkIntervalMinutes ?? 30) * 60_000;
     // Even in version-check-only mode (au is null because auto-apply is
     // disabled) the policy used for the check must reflect the operator's

--- a/packages/cli/src/daemon/state.ts
+++ b/packages/cli/src/daemon/state.ts
@@ -30,7 +30,7 @@ export const DEBUG_SYNC_TRACE =
 export const daemonState: {
   /** Populated in `runDaemonInner` once the DKGAgent is ready. */
   catchupRunner: CatchupRunner | null;
-  /** Set to `true` while a monorepo `git pull` / slot-swap is in flight. */
+  /** Set to `true` while a package or git slot update is in flight. */
   isUpdating: boolean;
   /** Most recent "is this daemon up to date?" result; polled by `/status`. */
   lastUpdateCheck: {
@@ -99,7 +99,8 @@ export const daemonState: {
  * install, honouring the operator's `autoUpdate.source` override if present.
  *
  *   - `source === 'npm'` → return `true` regardless of `.git` presence.
- *   - `source === 'git'` → return `false` regardless of `.git` presence.
+ *   - `source === 'git'` → return `false` regardless of `.git` presence
+ *     because git mode is slot-built from source, not an npm install.
  *   - `source === 'auto'` or omitted → fall through to the filesystem probe
  *     (`isStandaloneInstall()`, i.e. `repoDir() === null`).
  *
@@ -120,14 +121,9 @@ export function resolveStandaloneInstall(
     return true;
   }
   if (source === 'git' || source === 'monorepo') {
-    // OT-RFC-41 §4.3 Bundle B1d: 'monorepo' is the new sentinel for
-    // dev checkouts (set by Bundle B's `dkg init` monorepo guard
-    // when a contributor opts in via DKG_HOME). For the
-    // standalone-vs-git probe it behaves identically to the legacy
-    // 'git' value — auto-update is monorepo-style ("git pull" in
-    // the dev tree) — until the git-build path itself is deleted
-    // in PR 5, at which point monorepo daemons stop auto-updating
-    // entirely.
+    // Both modes are non-npm for install-layout/status purposes.
+    // Lifecycle dispatch distinguishes the advanced git updater from
+    // contributor monorepo mode before deciding whether to poll.
     daemonState.standaloneCache = false;
     return false;
   }
@@ -135,6 +131,17 @@ export function resolveStandaloneInstall(
     daemonState.standaloneCache = isStandaloneInstall();
   }
   return daemonState.standaloneCache;
+}
+
+export type AutoUpdatePollingMode = 'npm' | 'git' | 'monorepo';
+
+export function resolveAutoUpdatePollingMode(
+  source: 'auto' | 'npm' | 'git' | 'monorepo' | undefined,
+  standalone: boolean,
+): AutoUpdatePollingMode {
+  if (source === 'git') return 'git';
+  if (source === 'monorepo') return 'monorepo';
+  return standalone ? 'npm' : 'monorepo';
 }
 
 /**

--- a/packages/cli/src/doctor/checks/config-sanity.ts
+++ b/packages/cli/src/doctor/checks/config-sanity.ts
@@ -15,14 +15,8 @@
  * cost-benefit is documented in OT-RFC-41 §4.7.2.
  */
 import { join } from 'node:path';
+import { AUTO_UPDATE_GIT_ONLY_FIELDS } from '../../config.js';
 import type { DoctorDeps, Finding } from '../types.js';
-
-const DEPRECATED_AUTO_UPDATE_FIELDS = [
-  'repo',
-  'branch',
-  'verifyTagSignature',
-  'buildTimeoutMs',
-] as const;
 
 export async function runConfigSanityCheck(deps: DoctorDeps): Promise<Finding[]> {
   const findings: Finding[] = [];
@@ -100,15 +94,18 @@ export async function runConfigSanityCheck(deps: DoctorDeps): Promise<Finding[]>
   const autoUpdate = parsed.autoUpdate;
   if (autoUpdate && typeof autoUpdate === 'object' && !Array.isArray(autoUpdate)) {
     const au = autoUpdate as Record<string, unknown>;
+    const source = au.source;
+    const gitMode = source === 'git';
 
-    for (const field of DEPRECATED_AUTO_UPDATE_FIELDS) {
+    for (const field of AUTO_UPDATE_GIT_ONLY_FIELDS) {
+      if (gitMode) continue;
       const value = au[field];
       if (value === undefined || value === null || value === '') continue;
       findings.push({
         check: 'config-sanity',
         severity: 'warning',
         message: `Deprecated autoUpdate field is set: autoUpdate.${field}`,
-        advisory: `The '${field}' field is inert post-rc.12 per OT-RFC-41 §4.3. Remove it from ~/.dkg/config.json — the daemon will continue to ignore it, but its presence is misleading to anyone reading the file.`,
+        advisory: `The '${field}' field is inert unless autoUpdate.source is 'git'. Remove it from npm-mode ~/.dkg/config.json — the daemon will continue to ignore it, but its presence is misleading to anyone reading the file.`,
         subject: `autoUpdate.${field}`,
       });
     }
@@ -127,13 +124,12 @@ export async function runConfigSanityCheck(deps: DoctorDeps): Promise<Finding[]>
       }
     }
 
-    const source = au.source;
     if (source !== undefined && source !== 'npm' && source !== 'monorepo' && source !== 'git' && source !== 'auto') {
       findings.push({
         check: 'config-sanity',
         severity: 'warning',
         message: `autoUpdate.source has an unknown value: ${JSON.stringify(source)}`,
-        advisory: "Expected 'npm' (post-rc.12 default) or 'monorepo' (for contributor checkouts). Older values ('git', 'auto') are accepted but deprecated.",
+        advisory: "Expected 'npm' (recommended default), 'git' (advanced Core-node git updater), or 'monorepo' (for contributor checkouts). Older value 'auto' is accepted for compatibility.",
         subject: 'autoUpdate.source',
       });
     }

--- a/packages/cli/src/doctor/checks/install-layout.ts
+++ b/packages/cli/src/doctor/checks/install-layout.ts
@@ -8,7 +8,8 @@
  *   - The inactive slot is empty OR contains a complete prior
  *     release with its own resolvable entry point — partial state
  *     is a warning suggesting `dkg update --retry` or `dkg rollback`.
- *   - No `.git` inside either slot (post-rc.12 invariant).
+ *   - No `.git` inside either slot unless the node explicitly opts into the
+ *     advanced git updater.
  *
  * **Edge (`nodeRole === "edge"`):**
  *   - The daemon's resolved entry point MUST be inside the
@@ -122,17 +123,18 @@ export async function runInstallLayoutCheck(
       }
     }
 
-    // Post-rc.12 invariant: no `.git` inside either slot.
-    for (const slotName of ['a', 'b'] as const) {
-      const dotGit = join(releasesDir, slotName, '.git');
-      if (deps.exists(dotGit)) {
-        findings.push({
-          check: 'install-layout',
-          severity: 'warning',
-          message: `Legacy '.git' directory found inside slot '${slotName}': ${dotGit}`,
-          advisory: "Pre-rc.12 install.sh-era state survived the npm-only migration. The slot is fine to run from, but the '.git' is unused. Safe to delete after confirming with the operator.",
-          subject: dotGit,
-        });
+    if (state.autoUpdate.source !== 'git') {
+      for (const slotName of ['a', 'b'] as const) {
+        const dotGit = join(releasesDir, slotName, '.git');
+        if (deps.exists(dotGit)) {
+          findings.push({
+            check: 'install-layout',
+            severity: 'warning',
+            message: `Legacy '.git' directory found inside slot '${slotName}': ${dotGit}`,
+            advisory: "Pre-rc.12 install.sh-era state survived the npm-only migration. The slot is fine to run from, but the '.git' is unused unless autoUpdate.source is set to 'git'. Safe to delete after confirming with the operator.",
+            subject: dotGit,
+          });
+        }
       }
     }
 

--- a/packages/cli/src/doctor/types.ts
+++ b/packages/cli/src/doctor/types.ts
@@ -109,7 +109,7 @@ export interface StateSummary {
     enabled: boolean;
     checkIntervalMinutes: number;
     allowPrerelease: boolean;
-    /** `config.autoUpdate.source` — should be `npm` or `monorepo` post-rc.12. */
+    /** `config.autoUpdate.source` — npm by default, git for advanced Core opt-in, monorepo for dev checkouts. */
     source: string | null;
     /** ~/.dkg/auto-update/last-check.json#timestamp — `null` if never checked. */
     lastCheck: string | null;

--- a/packages/cli/test/auto-update.test.ts
+++ b/packages/cli/test/auto-update.test.ts
@@ -194,7 +194,14 @@ function restoreIo() {
   Object.assign(_autoUpdateIo, origIo);
 }
 
-import { checkForNewCommitWithStatus, checkForUpdate, performUpdate, performNpmUpdate } from '../src/daemon.js';
+import {
+  checkForNewCommitWithStatus,
+  checkForUpdate,
+  normalizeGitRefInput,
+  performUpdate,
+  performNpmUpdate,
+  resolveAutoUpdateGitRef,
+} from '../src/daemon.js';
 
 const AU: AutoUpdateConfig = {
   enabled: true,
@@ -202,6 +209,31 @@ const AU: AutoUpdateConfig = {
   branch: 'main',
   checkIntervalMinutes: 30,
 };
+
+describe('git auto-update ref normalization', () => {
+  it('normalizes bare branch values to full branch refs', () => {
+    expect(normalizeGitRefInput('main')).toBe('refs/heads/main');
+    expect(normalizeGitRefInput('release/v10')).toBe('refs/heads/release/v10');
+  });
+
+  it('preserves full refs and lets autoUpdate.ref override branch', () => {
+    expect(normalizeGitRefInput('refs/heads/main')).toBe('refs/heads/main');
+    expect(normalizeGitRefInput('refs/tags/v10.0.5')).toBe('refs/tags/v10.0.5');
+    expect(resolveAutoUpdateGitRef({
+      enabled: true,
+      repo: 'owner/repo',
+      branch: 'main',
+      ref: 'refs/heads/canary',
+      checkIntervalMinutes: 30,
+    })).toBe('refs/heads/canary');
+  });
+
+  it('rejects unsafe refs before they reach git', () => {
+    expect(() => normalizeGitRefInput('main; rm -rf /')).toThrow(/invalid branch\/ref/);
+    expect(() => normalizeGitRefInput('--upload-pack=/tmp/pwn')).toThrow(/invalid branch\/ref/);
+    expect(() => normalizeGitRefInput('refs/heads/')).toThrow(/invalid branch\/ref/);
+  });
+});
 
 function normalizePathString(value: unknown): string {
   return String(value).replace(/\\/g, '/');
@@ -349,6 +381,47 @@ describe('blue-green checkForUpdate', () => {
       if (origToken === undefined) delete process.env.GITHUB_TOKEN;
       else process.env.GITHUB_TOKEN = origToken;
     }
+  });
+
+  it('bootstraps from an npm-built active slot with no current git commit metadata', async () => {
+    const latest = 'bbb222';
+    readFileImpl = async (path: any) => {
+      const normalized = normalizePathString(path);
+      if (normalized.endsWith('/.current-commit')) throw new Error('ENOENT');
+      if (normalized.endsWith('/.update-pending.json')) throw new Error('ENOENT');
+      return '';
+    };
+    existsSyncImpl = (path: any) => {
+      const normalized = normalizePathString(path);
+      if (normalized === '/tmp/dkg-test/releases/a') return true;
+      if (normalized.endsWith('/releases/b/.git')) return false;
+      if (normalized.includes('cli.js')) return true;
+      if (normalized.endsWith('/packages/node-ui/dist-ui/index.html')) return true;
+      return true;
+    };
+    execImpl = async (cmd: string, opts?: any) => {
+      if (cmd.includes('git rev-parse HEAD') && normalizePathString(opts?.cwd) === '/tmp/dkg-test/releases/a') {
+        throw new Error('fatal: not a git repository');
+      }
+      return { stdout: '', stderr: '' };
+    };
+    makeFetchOk(latest);
+
+    const logCalls: string[] = [];
+    const result = await performUpdate(AU, (message) => logCalls.push(message));
+
+    expect(result).toBe(true);
+    expect(logCalls.some(m => m.includes('active slot git commit is unknown'))).toBe(true);
+    const allCmds = getExecCalls();
+    const gitCmds = getExecFileCalls();
+    const activeDir = '/tmp/dkg-test/releases/a';
+    const targetDir = '/tmp/dkg-test/releases/b';
+    expect(allCmds.some(c => c.cmd.includes('git rev-parse HEAD') && c.cwd === activeDir)).toBe(true);
+    expect(gitCmds.some(c => c.file === 'git' && c.args.join(' ') === 'init' && c.cwd === targetDir)).toBe(true);
+    expect(gitCmds.some(c => c.file === 'git' && c.args[0] === 'fetch' && c.cwd === targetDir)).toBe(true);
+    expect(allCmds.some(c => c.cmd.includes('pnpm install') && c.cwd === targetDir)).toBe(true);
+    expect(allCmds.some(c => c.cmd.includes('pnpm build') && c.cwd === targetDir)).toBe(true);
+    expect(swapSlotCalls).toContain('b');
   });
 
   it('skips when no new commit', async () => {

--- a/packages/cli/test/dkg-doctor.test.ts
+++ b/packages/cli/test/dkg-doctor.test.ts
@@ -404,13 +404,50 @@ describe('config-sanity check (§4.7.2)', () => {
     const deps = makeDeps({
       fs: {
         '/test/.dkg/config.json': JSON.stringify({
-          autoUpdate: { repo: 'https://github.com/OriginTrail/dkg.git', branch: 'main' },
+          autoUpdate: {
+            source: 'npm',
+            repo: 'https://github.com/OriginTrail/dkg.git',
+            branch: 'main',
+            ref: 'refs/heads/canary',
+            sshKeyPath: '/tmp/git-key',
+            sshCommand: 'ssh -i /tmp/git-key',
+            buildTimeoutMs: { install: 600000 },
+          },
         }),
       },
     });
     const findings = await runConfigSanityCheck(deps);
     expect(findings.find((f) => f.subject === 'autoUpdate.repo')).toBeDefined();
     expect(findings.find((f) => f.subject === 'autoUpdate.branch')).toBeDefined();
+    expect(findings.find((f) => f.subject === 'autoUpdate.ref')).toBeDefined();
+    expect(findings.find((f) => f.subject === 'autoUpdate.sshKeyPath')).toBeDefined();
+    expect(findings.find((f) => f.subject === 'autoUpdate.sshCommand')).toBeDefined();
+    expect(findings.find((f) => f.subject === 'autoUpdate.buildTimeoutMs')).toBeDefined();
+  });
+
+  it('does not warn on git updater fields when autoUpdate.source is git', async () => {
+    const deps = makeDeps({
+      fs: {
+        '/test/.dkg/config.json': JSON.stringify({
+          autoUpdate: {
+            source: 'git',
+            repo: 'https://github.com/OriginTrail/dkg.git',
+            branch: 'main',
+            ref: 'refs/heads/canary',
+            sshKeyPath: '/tmp/git-key',
+            sshCommand: 'ssh -i /tmp/git-key',
+            buildTimeoutMs: { install: 600000 },
+          },
+        }),
+      },
+    });
+    const findings = await runConfigSanityCheck(deps);
+    expect(findings.find((f) => f.subject === 'autoUpdate.repo')).toBeUndefined();
+    expect(findings.find((f) => f.subject === 'autoUpdate.branch')).toBeUndefined();
+    expect(findings.find((f) => f.subject === 'autoUpdate.ref')).toBeUndefined();
+    expect(findings.find((f) => f.subject === 'autoUpdate.sshKeyPath')).toBeUndefined();
+    expect(findings.find((f) => f.subject === 'autoUpdate.sshCommand')).toBeUndefined();
+    expect(findings.find((f) => f.subject === 'autoUpdate.buildTimeoutMs')).toBeUndefined();
   });
 
   it('errors on checkIntervalMinutes < 1', async () => {
@@ -551,6 +588,23 @@ describe('install-layout check (§4.7.3)', () => {
     const state = await collectStateSummary(deps);
     const findings = await runInstallLayoutCheck(deps, state);
     expect(findings.find((f) => f.message.includes("Legacy '.git' directory") && f.severity === 'warning')).toBeDefined();
+  });
+
+  it('Core: allows .git inside slots when git updater mode is configured', async () => {
+    const deps = makeDeps({
+      fs: {
+        '/test/.dkg/config.json': JSON.stringify({
+          nodeRole: 'core',
+          autoUpdate: { enabled: true, source: 'git' },
+        }),
+        '/test/.dkg/releases/current': 'symlink:a',
+        '/test/.dkg/releases/a/packages/cli/dist/cli.js': '// active slot',
+        '/test/.dkg/releases/a/.git/config': '[remote "origin"]',
+      },
+    });
+    const state = await collectStateSummary(deps);
+    const findings = await runInstallLayoutCheck(deps, state);
+    expect(findings.find((f) => f.message.includes("Legacy '.git' directory"))).toBeUndefined();
   });
 });
 

--- a/packages/cli/test/init.test.ts
+++ b/packages/cli/test/init.test.ts
@@ -64,16 +64,33 @@ describe('buildInitAutoUpdate', () => {
     expect(r.checkIntervalMinutes).toBe(10);
   });
 
-  it('enable preserves a local channel pin across the rerun', () => {
+  it('enable preserves npm fields but drops git-only fields when forcing npm mode', () => {
     const r = buildInitAutoUpdate({
       enableAutoUpdate: true,
-      existingAutoUpdate: { enabled: true, channel: 'staging' },
+      existingAutoUpdate: {
+        enabled: true,
+        source: 'git',
+        channel: 'staging',
+        repo: 'https://github.com/OriginTrail/dkg.git',
+        branch: 'canary',
+        ref: 'refs/heads/canary',
+        sshKeyPath: '/tmp/git-key',
+        sshCommand: 'ssh -i /tmp/git-key',
+        buildTimeoutMs: { install: 600_000 },
+      },
       networkAutoUpdate: net,
       ...proj,
-      answers: { repo: '', branch: '', allowPrerelease: true, sshKeyPath: '', interval: 5 },
+      answers: { allowPrerelease: true, interval: 5 },
     });
     expect(r.enabled).toBe(true);
+    expect(r.source).toBe('npm');
     expect(r.channel).toBe('staging');
+    expect(r.repo).toBeUndefined();
+    expect(r.branch).toBeUndefined();
+    expect(r.ref).toBeUndefined();
+    expect(r.sshKeyPath).toBeUndefined();
+    expect(r.sshCommand).toBeUndefined();
+    expect(r.buildTimeoutMs).toBeUndefined();
   });
 
   it('enable persists only fields that differ from the network/project defaults', () => {
@@ -83,7 +100,7 @@ describe('buildInitAutoUpdate', () => {
       networkAutoUpdate: net,
       ...proj,
       // Every answer equals the effective default → nothing extra is pinned.
-      answers: { repo: 'OriginTrail/dkg', branch: 'main', allowPrerelease: true, sshKeyPath: '', interval: 5 },
+      answers: { allowPrerelease: true, interval: 5 },
     });
     expect(r).toEqual({ enabled: true, source: 'npm' });
   });
@@ -94,7 +111,7 @@ describe('buildInitAutoUpdate', () => {
       existingAutoUpdate: undefined,
       networkAutoUpdate: net, // allowPrerelease default = true
       ...proj,
-      answers: { repo: 'OriginTrail/dkg', branch: 'main', allowPrerelease: false, sshKeyPath: '', interval: 5 },
+      answers: { allowPrerelease: false, interval: 5 },
     });
     expect(r).toEqual({ enabled: true, source: 'npm', allowPrerelease: false });
   });

--- a/packages/cli/test/resolve-standalone-install.test.ts
+++ b/packages/cli/test/resolve-standalone-install.test.ts
@@ -3,6 +3,7 @@ import {
   daemonState,
   resolveStandaloneInstall,
   resolveAutoUpdateEnabled,
+  resolveAutoUpdatePollingMode,
 } from '../src/daemon/state.js';
 
 // `resolveStandaloneInstall` mutates `daemonState.standaloneCache` as a side
@@ -45,6 +46,9 @@ describe('resolveStandaloneInstall', () => {
 
   describe("source === 'git' override", () => {
     it('returns false regardless of cache state', () => {
+      // "False" here means "not an npm standalone updater". Lifecycle uses
+      // resolveAutoUpdatePollingMode to distinguish git updater mode from
+      // contributor monorepo mode.
       daemonState.standaloneCache = true;
       expect(resolveStandaloneInstall('git')).toBe(false);
     });
@@ -120,7 +124,7 @@ describe('resolveAutoUpdateEnabled — integrated with the new override', () => 
     expect(daemonState.standaloneCache).toBe(true);
   });
 
-  it("treats node as monorepo when config sets autoUpdate.source = 'git', applying the monorepo default (enabled => false)", () => {
+  it("keeps source='git' disabled by default unless enabled is explicit", () => {
     const config: any = { autoUpdate: { source: 'git' } };
     expect(resolveAutoUpdateEnabled(config)).toBe(false);
     expect(daemonState.standaloneCache).toBe(false);
@@ -133,10 +137,28 @@ describe('resolveAutoUpdateEnabled — integrated with the new override', () => 
     expect(resolveAutoUpdateEnabled(config)).toBe(false);
   });
 
-  it("explicit `enabled: true` works with source='git' even though monorepo default would be false", () => {
-    // Symmetric case: dev wants their cloned monorepo node to actually
-    // auto-update from main. Default would be false; explicit true overrides.
+  it("explicit `enabled: true` works with source='git' even though the default is disabled", () => {
+    // Git mode is an explicit opt-in: source selects the updater family, while
+    // enabled still controls whether daemon polling applies updates.
     const config: any = { autoUpdate: { source: 'git', enabled: true } };
     expect(resolveAutoUpdateEnabled(config)).toBe(true);
+  });
+});
+
+describe('resolveAutoUpdatePollingMode', () => {
+  it("keeps npm as the default polling mode for standalone installs when source is unset or 'npm'", () => {
+    expect(resolveAutoUpdatePollingMode(undefined, true)).toBe('npm');
+    expect(resolveAutoUpdatePollingMode('npm', true)).toBe('npm');
+  });
+
+  it("selects git polling only for explicit source='git'", () => {
+    expect(resolveAutoUpdatePollingMode('git', false)).toBe('git');
+    expect(resolveAutoUpdatePollingMode('git', true)).toBe('git');
+  });
+
+  it('keeps monorepo checkouts out of package polling', () => {
+    expect(resolveAutoUpdatePollingMode(undefined, false)).toBe('monorepo');
+    expect(resolveAutoUpdatePollingMode('auto', false)).toBe('monorepo');
+    expect(resolveAutoUpdatePollingMode('monorepo', false)).toBe('monorepo');
   });
 });

--- a/packages/cli/vitest.unit.config.ts
+++ b/packages/cli/vitest.unit.config.ts
@@ -37,6 +37,9 @@ export default defineConfig({
           // contributors can run it via `pnpm test:unit` in ~2s instead of
           // paying the 2-minute hardhat-boot tax of the default config.
           'test/resolve-standalone-install.test.ts',
+          'test/auto-update.test.ts',
+          'test/dkg-doctor.test.ts',
+          'test/init.test.ts',
           'test/nat-status.test.ts',
           'test/core-prereq-check.test.ts',
           'test/catchup-runner.test.ts',


### PR DESCRIPTION
# Add config-driven git auto-update opt-in

## Description

This PR restores daemon-polled git auto-update support as an explicit advanced opt-in while preserving the existing npm/dist-tag updater as the default path.

## Changes

- Adds `autoUpdate.source: "git"` dispatch in daemon lifecycle.
- Keeps npm updater behavior for unset `source` or `"npm"`.
- Normalizes git refs from `branch`, `ref`, or full `refs/...` input.
- Validates repo/ref inputs before polling/updating.
- Compares local and remote commits before fetching/building.
- Reuses the existing git slot build/swap flow and supervised restart path.
- Adds clearer git-mode logs for source, repo/ref, current commit, remote commit, skipped/started/failed states.
- Updates doctor/init/docs to explain npm recommendation, git experimental status, and rollback differences.
- Adds focused unit coverage for source selection, ref normalization, validation, skipped update, triggered update, and doctor behavior.

## Git Mode Config

```json
{
  "autoUpdate": {
    "enabled": true,
    "source": "git",
    "repo": "https://github.com/OriginTrail/dkg.git",
    "branch": "main",
    "checkIntervalMinutes": 3
  }
}
```

## Verification

```bash
./node_modules/.bin/vitest run --config vitest.unit.config.ts test/auto-update.test.ts test/resolve-standalone-install.test.ts test/init.test.ts test/dkg-doctor.test.ts
```

Result: `4 passed`, `156 tests passed`.

Also ran:

```bash
git diff --check
```

Full CLI package build was attempted but blocked by existing workspace/package-manager state: pnpm dependency-status install prompts and stale workspace declaration errors outside this patch.
