### PR TITLE
Fix active-network peer isolation across DKG networks

### DIFF
--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -149,6 +149,7 @@ import { bindRandomSampling, type RandomSamplingHandle, type RandomSamplingStatu
 import { connectToMultiaddr, ensurePeerConnected as ensurePeerConnectedAtom, primeCatchupConnections as primeCatchupConnectionsAtom } from './p2p/peer-connect.js';
 import { Messenger, type SloProtocolStats } from './p2p/messenger.js';
 import { NetworkAdmissionService } from './p2p/network-admission.js';
+import { NetworkAdmissionCoordinator } from './p2p/network-admission-coordinator.js';
 import {
   createCGMemberEnumerator,
   type CGMemberEnumerator,
@@ -535,6 +536,7 @@ export class DKGAgentBase {
   router!: ProtocolRouter;
   messenger!: Messenger;
   networkAdmission: NetworkAdmissionService = new NetworkAdmissionService();
+  networkAdmissionCoordinator!: NetworkAdmissionCoordinator;
   /** Single in-process peer-address resolver (RFC 07 §3). Used by Messenger
    * today; ProtocolRouter / /api/connect migrate in PR-3 / PR-4. */
   peerResolver!: PeerResolver;
@@ -1435,6 +1437,16 @@ export class DKGAgentBase {
     this.kaNumberAllocator = config.kaNumberAllocator;
     this.discovery = new DiscoveryClient(queryEngine);
     this.profileManager = new ProfileManager(publisher, store);
+    this.networkAdmissionCoordinator = new NetworkAdmissionCoordinator({
+      admission: this.networkAdmission,
+      selfPeerId: '',
+      sign: (payload) => wallet.sign(payload),
+      sendIdentityProbe: async () => {
+        throw new Error('network admission coordinator is not started');
+      },
+      getConnections: () => [],
+      deletePeerFromPeerStore: async () => {},
+    });
     this.publisher.setWorkspaceAgentRecipientResolver((input) => (this as unknown as DKGAgent).resolveWorkspaceRecipientsGated(input));
     this.publisher.setWorkspaceSenderKeyEncryptor((input) => (this as unknown as DKGAgent).encryptWorkspacePayloadWithSenderKey(input));
     this.syncCheckpoints = config.syncCheckpointStore ?? this.syncCheckpoints;

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -148,6 +148,7 @@ import { SyncVerifyWorker } from './sync-verify-worker.js';
 import { bindRandomSampling, type RandomSamplingHandle, type RandomSamplingStatus } from './random-sampling-bind.js';
 import { connectToMultiaddr, ensurePeerConnected as ensurePeerConnectedAtom, primeCatchupConnections as primeCatchupConnectionsAtom } from './p2p/peer-connect.js';
 import { Messenger, type SloProtocolStats } from './p2p/messenger.js';
+import { NetworkAdmissionService } from './p2p/network-admission.js';
 import {
   createCGMemberEnumerator,
   type CGMemberEnumerator,
@@ -533,6 +534,7 @@ export class DKGAgentBase {
   gossip!: GossipSubManager;
   router!: ProtocolRouter;
   messenger!: Messenger;
+  networkAdmission: NetworkAdmissionService = new NetworkAdmissionService();
   /** Single in-process peer-address resolver (RFC 07 §3). Used by Messenger
    * today; ProtocolRouter / /api/connect migrate in PR-3 / PR-4. */
   peerResolver!: PeerResolver;

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -73,6 +73,7 @@ import {
   ratchetSwmSenderChainKey,
   uint64ForProto,
   SWM_SENDER_KEY_SKIPPED_MESSAGE_CACHE_LIMIT,
+  type AdmissionCheckOptions,
   type DKGNodeConfig, type OperationContext, type GetView, type AssertionDescriptor, type AssertionEvent, type AssertionState,
   type SwmSenderKeyMessageMsg,
   type SwmSenderKeyPackageAckReasonCode,
@@ -149,7 +150,7 @@ import { bindRandomSampling, type RandomSamplingHandle, type RandomSamplingStatu
 import { connectToMultiaddr, ensurePeerConnected as ensurePeerConnectedAtom, primeCatchupConnections as primeCatchupConnectionsAtom } from './p2p/peer-connect.js';
 import { Messenger, type SloProtocolStats } from './p2p/messenger.js';
 import { NetworkAdmissionService } from './p2p/network-admission.js';
-import { NetworkAdmissionCoordinator } from './p2p/network-admission-coordinator.js';
+import { NetworkAdmissionCoordinator, NetworkAdmissionRejectedError } from './p2p/network-admission-coordinator.js';
 import {
   createCGMemberEnumerator,
   type CGMemberEnumerator,
@@ -742,10 +743,16 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     });
     this.router = new ProtocolRouter(this.node, {
       peerResolver,
-      isPeerAccepted: (peerId, _protocolId, _direction) =>
+      isPeerAccepted: (
+        peerId: string,
+        _protocolId: string,
+        _direction: 'inbound' | 'outbound',
+        options?: AdmissionCheckOptions,
+      ) =>
         this.networkAdmissionCoordinator.ensureAdmitted(
           peerId,
           createOperationContext('connect'),
+          options,
         ),
       admissionExemptProtocols: [PROTOCOL_NETWORK_IDENTITY],
     });
@@ -2914,6 +2921,23 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     return plan.eligibleContextGraphIds;
   }
 
+  async ensurePeerAdmittedForRecovery(
+    this: DKGAgent,
+    peerId: string,
+    ctx: OperationContext,
+    label: string,
+  ): Promise<boolean> {
+    if (this.networkAdmissionCoordinator.isAcceptedPeer(peerId)) return true;
+    if (this.networkAdmissionCoordinator.isRejectedPeer(peerId)) return false;
+    try {
+      return await this.networkAdmissionCoordinator.ensureAdmitted(peerId, ctx);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.log.warn(ctx, `${label} admission probe failed for ${peerId.slice(-8)}: ${message}`);
+      return false;
+    }
+  }
+
   /**
    * Event-driven retry path for the libp2p identify race that otherwise
    * leaves a peer permanently in `skippedNoSyncPeers`. libp2p emits
@@ -2930,7 +2954,6 @@ export class LifecycleSyncMethods extends DKGAgentBase {
    */
   handlePeerUpdateForSyncRetry(this: DKGAgent, peerId: string, protocols: readonly string[]): void {
     if (peerId === this.node.libp2p.peerId.toString()) return;
-    if (!this.networkAdmissionCoordinator.isAcceptedPeer(peerId)) return;
     // #1093: keep the confirmed-core set fresh from `peer:update` too.
     // `runSyncOnConnect` reads the protocol list exactly once, racing
     // identify — a core peer whose identify completed late was never
@@ -2953,16 +2976,21 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     if (!this.skippedNoSyncPeers.has(peerId)) return;
     if (!syncOnConnectEnabled(this.config)) return;
     if (!protocols.includes(PROTOCOL_SYNC)) return;
-    this.skippedNoSyncPeers.delete(peerId);
     const ctx = createOperationContext('sync');
     const shortPeer = peerId.slice(-8);
-    this.log.info(ctx, `Peer ${shortPeer} now advertises sync protocol — retrying sync-on-connect`);
-    setTimeout(() => {
-      this.trySyncFromPeer(peerId).catch((err: unknown) => {
-        const message = err instanceof Error ? err.message : String(err);
-        this.log.warn(ctx, `Sync retry after peer:update failed for ${shortPeer}: ${message}`);
-      });
-    }, 0);
+    void (async () => {
+      const admitted = await this.ensurePeerAdmittedForRecovery(peerId, ctx, 'Peer:update sync retry');
+      if (!admitted) return;
+      if (!this.skippedNoSyncPeers.has(peerId)) return;
+      this.skippedNoSyncPeers.delete(peerId);
+      this.log.info(ctx, `Peer ${shortPeer} now advertises sync protocol — retrying sync-on-connect`);
+      setTimeout(() => {
+        this.trySyncFromPeer(peerId).catch((err: unknown) => {
+          const message = err instanceof Error ? err.message : String(err);
+          this.log.warn(ctx, `Sync retry after peer:update failed for ${shortPeer}: ${message}`);
+        });
+      }, 0);
+    })();
   }
 
   /**
@@ -2988,7 +3016,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     this.pruneSyncReconcilerState(now);
     for (const pid of this.node.libp2p.getPeers()) {
       const peerId = pid.toString();
-      if (!this.networkAdmissionCoordinator.isAcceptedPeer(peerId)) continue;
+      if (this.networkAdmissionCoordinator.isRejectedPeer(peerId)) continue;
       if (this.syncingPeers.has(peerId)) continue;
       const lastOk = this.lastSuccessfulSyncAt.get(peerId);
       const lastDisconnected = this.syncOnConnectDisconnectBoundary(peerId, now);
@@ -3013,6 +3041,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         }
         this.syncReconcilerBackoff.delete(peerId);
       }
+      if (!(await this.ensurePeerAdmittedForRecovery(peerId, ctx, 'Sync reconciler'))) continue;
       const shortPeer = peerId.slice(-8);
       this.log.info(ctx, `Sync reconciler retrying ${shortPeer} (last success: ${lastOk == null ? 'never' : `${Math.round((now - lastOk) / 1000)}s ago`}${backoff ? `, prior failures: ${backoff.failures}` : ''})`);
       this.attemptSyncFromPeerWithReconcilerAccounting(peerId, probe)
@@ -3267,7 +3296,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
   async maybeDialGossipSender(this: DKGAgent, peerIdStr: string): Promise<void> {
     const selfPeerId = this.node.libp2p.peerId.toString();
     if (peerIdStr === selfPeerId) return;
-    if (!this.networkAdmissionCoordinator.isAcceptedPeer(peerIdStr)) return;
+    if (this.networkAdmissionCoordinator.isRejectedPeer(peerIdStr)) return;
 
     // Already connected → nothing to do.
     const connected = this.node.libp2p.getPeers().some(p => p.toString() === peerIdStr);
@@ -3944,12 +3973,17 @@ export class LifecycleSyncMethods extends DKGAgentBase {
 
     await this.primeCatchupConnections();
 
+    const connectedPeers = [...new Map(
+      this.node.libp2p.getConnections().map((conn) => [conn.remotePeer.toString(), conn.remotePeer]),
+    ).values()];
+    const admittedConnectedPeers: Array<{ toString(): string }> = [];
+    for (const peer of connectedPeers) {
+      if (await this.ensurePeerAdmittedForRecovery(peer.toString(), ctx, 'Connected catchup peer')) {
+        admittedConnectedPeers.push(peer);
+      }
+    }
     const orderedPeers = this.selectCatchupPeers(
-      [...new Map(
-        this.node.libp2p.getConnections().map((conn) => [conn.remotePeer.toString(), conn.remotePeer]),
-      ).values()].filter((peer) =>
-        this.networkAdmissionCoordinator.isAcceptedPeer(peer.toString()),
-      ),
+      admittedConnectedPeers,
       preferredPeerId,
       isPrivateContextGraph,
     );
@@ -4453,9 +4487,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
   async ensurePeerConnected(this: DKGAgent, peerId: string): Promise<void> {
     await ensurePeerConnectedAtom(this.node.libp2p as any, this.discovery, peerId);
     if (await this.networkAdmissionCoordinator.ensureAdmitted(peerId, createOperationContext('connect'))) return;
-    const error = new Error(`Peer ${peerId} is not admitted for the active DKG network`);
-    (error as any).code = 'NETWORK_ADMISSION_REJECTED';
-    throw error;
+    throw new NetworkAdmissionRejectedError(peerId);
   }
 
   async waitForSyncProtocol(this: DKGAgent, pid: { toString(): string }): Promise<boolean> {

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -2222,7 +2222,14 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       // `connection:open` emitter is synchronous and we don't
       // want to slow down other listeners.
       void (async () => {
-        const admitted = await this.networkAdmissionCoordinator.ensureAdmitted(remotePeer, ctx);
+        let admitted = false;
+        try {
+          admitted = await this.networkAdmissionCoordinator.ensureAdmitted(remotePeer, ctx);
+        } catch (err: unknown) {
+          const message = err instanceof Error ? err.message : String(err);
+          this.log.warn(ctx, `Network admission probe failed for ${remotePeer.slice(-8)} on connect: ${message}`);
+          return;
+        }
         if (!admitted) return;
         try {
           await this.enrichPeerStoreFromInboundCircuit(evt.detail);
@@ -3922,8 +3929,17 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     this.trackSyncContextGraph(contextGraphId);
 
     const preferredPeerId = await this.resolvePreferredSyncPeerId(contextGraphId);
-    if (preferredPeerId && await this.networkAdmissionCoordinator.ensureAdmitted(preferredPeerId, ctx)) {
-      await this.ensurePeerConnected(preferredPeerId);
+    if (preferredPeerId) {
+      let preferredPeerAdmitted = false;
+      try {
+        preferredPeerAdmitted = await this.networkAdmissionCoordinator.ensureAdmitted(preferredPeerId, ctx);
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        this.log.warn(ctx, `Preferred catchup peer ${preferredPeerId.slice(-8)} admission probe failed: ${message}`);
+      }
+      if (preferredPeerAdmitted) {
+        await this.ensurePeerConnected(preferredPeerId);
+      }
     }
 
     await this.primeCatchupConnections();

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -771,7 +771,6 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       // remains the step-2 DHT lookup inside resolve(), so we don't
       // lose any pre-existing recovery path.
       resolvePeer: async (peerId, { signal }) => {
-        if (!this.networkAdmission.isAcceptedPeer(peerId)) return;
         await peerResolver.resolve(peerId, { signal }).catch(() => undefined);
       },
     });
@@ -4416,7 +4415,9 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       this.node.libp2p as any,
       this.discovery,
       this.peerId,
-      (peerId) => this.verifyPeerNetworkAdmission(peerId, ctx),
+      async (peerId) => {
+        await this.verifyPeerNetworkAdmission(peerId, ctx);
+      },
     );
   }
 

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -737,8 +737,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     });
     this.router = new ProtocolRouter(this.node, {
       peerResolver,
-      isPeerAccepted: (peerId, protocolId, direction) =>
-        this.networkAdmission.isPeerAccepted(peerId, protocolId, direction),
+      isPeerAccepted: (peerId) => this.networkAdmission.isAcceptedPeer(peerId),
       admissionExemptProtocols: [PROTOCOL_NETWORK_IDENTITY],
     });
     // Default to in-memory substrate stores when no durable stores
@@ -772,15 +771,14 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       // remains the step-2 DHT lookup inside resolve(), so we don't
       // lose any pre-existing recovery path.
       resolvePeer: async (peerId, { signal }) => {
-        if (!this.networkAdmission.isPeerAccepted(peerId, 'peer-resolver', 'outbound')) return;
+        if (!this.networkAdmission.isAcceptedPeer(peerId)) return;
         await peerResolver.resolve(peerId, { signal }).catch(() => undefined);
       },
     });
     this.gossip = new GossipSubManager(this.node, this.eventBus, {
       networkId: this.config.networkIdentity?.networkId,
       chainId: this.config.networkIdentity?.chainId,
-      isPeerAccepted: (peerId, topic) =>
-        this.networkAdmission.isPeerAccepted(peerId, topic, 'gossip'),
+      isPeerAccepted: (peerId) => this.networkAdmission.isAcceptedPeer(peerId),
     });
     await this.loadSwmSenderKeyState();
     await this.initializeSwmHostModeStore();
@@ -2605,7 +2603,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
   ): Promise<boolean> {
     const identity = this.config.networkIdentity;
     if (!identity?.networkId) return true;
-    if (this.networkAdmission.isPeerAccepted(remotePeer, 'network-admission', 'outbound')) {
+    if (this.networkAdmission.isAcceptedPeer(remotePeer)) {
       return true;
     }
 
@@ -2712,7 +2710,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     if (!syncOnConnectEnabled(this.config)) {
       return false;
     }
-    if (!this.networkAdmission.isPeerAccepted(remotePeer, 'sync-on-connect', 'outbound')) {
+    if (!this.networkAdmission.isAcceptedPeer(remotePeer)) {
       return false;
     }
     const now = Date.now();
@@ -2816,7 +2814,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     if (!syncOnConnectEnabled(this.config)) {
       return 'not-started';
     }
-    if (!this.networkAdmission.isPeerAccepted(remotePeer, 'sync-on-connect', 'outbound')) {
+    if (!this.networkAdmission.isAcceptedPeer(remotePeer)) {
       return 'not-started';
     }
     const sharedMemorySyncPlans = new Map<string, Promise<SharedMemorySyncContextGraphPlan>>();
@@ -3022,7 +3020,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
    */
   handlePeerUpdateForSyncRetry(this: DKGAgent, peerId: string, protocols: readonly string[]): void {
     if (peerId === this.node.libp2p.peerId.toString()) return;
-    if (!this.networkAdmission.isPeerAccepted(peerId, 'peer:update', 'inbound')) return;
+    if (!this.networkAdmission.isAcceptedPeer(peerId)) return;
     // #1093: keep the confirmed-core set fresh from `peer:update` too.
     // `runSyncOnConnect` reads the protocol list exactly once, racing
     // identify — a core peer whose identify completed late was never
@@ -3080,7 +3078,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     this.pruneSyncReconcilerState(now);
     for (const pid of this.node.libp2p.getPeers()) {
       const peerId = pid.toString();
-      if (!this.networkAdmission.isPeerAccepted(peerId, 'sync-reconciler', 'outbound')) continue;
+      if (!this.networkAdmission.isAcceptedPeer(peerId)) continue;
       if (this.syncingPeers.has(peerId)) continue;
       const lastOk = this.lastSuccessfulSyncAt.get(peerId);
       const lastDisconnected = this.syncOnConnectDisconnectBoundary(peerId, now);
@@ -3359,7 +3357,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
   async maybeDialGossipSender(this: DKGAgent, peerIdStr: string): Promise<void> {
     const selfPeerId = this.node.libp2p.peerId.toString();
     if (peerIdStr === selfPeerId) return;
-    if (!this.networkAdmission.isPeerAccepted(peerIdStr, 'gossip-redial', 'outbound')) return;
+    if (!this.networkAdmission.isAcceptedPeer(peerIdStr)) return;
 
     // Already connected → nothing to do.
     const connected = this.node.libp2p.getPeers().some(p => p.toString() === peerIdStr);
@@ -4031,7 +4029,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       [...new Map(
         this.node.libp2p.getConnections().map((conn) => [conn.remotePeer.toString(), conn.remotePeer]),
       ).values()].filter((peer) =>
-        this.networkAdmission.isPeerAccepted(peer.toString(), 'catchup', 'outbound'),
+        this.networkAdmission.isAcceptedPeer(peer.toString()),
       ),
       preferredPeerId,
       isPrivateContextGraph,
@@ -4532,7 +4530,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
   }
 
   async ensurePeerConnected(this: DKGAgent, peerId: string): Promise<void> {
-    if (!this.networkAdmission.isPeerAccepted(peerId, 'ensure-peer-connected', 'outbound')) return;
+    if (!this.networkAdmission.isAcceptedPeer(peerId)) return;
     await ensurePeerConnectedAtom(this.node.libp2p as any, this.discovery, peerId);
   }
 

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -8,7 +8,7 @@
  * `this: DKGAgent` so cross-calls resolve against the composed class.
  */
 
-import { createHash, randomUUID } from 'node:crypto';
+import { createHash } from 'node:crypto';
 import {
   DKGNode, ProtocolRouter, GossipSubManager, TypedEventBus, DKGEvent,
   LibP2PNetwork, PeerResolver, StubNetworkStateRegistry,
@@ -148,13 +148,8 @@ import { SyncVerifyWorker } from './sync-verify-worker.js';
 import { bindRandomSampling, type RandomSamplingHandle, type RandomSamplingStatus } from './random-sampling-bind.js';
 import { connectToMultiaddr, ensurePeerConnected as ensurePeerConnectedAtom, primeCatchupConnections as primeCatchupConnectionsAtom } from './p2p/peer-connect.js';
 import { Messenger, type SloProtocolStats } from './p2p/messenger.js';
-import { NetworkAdmissionService, peerIdsFromMultiaddrs } from './p2p/network-admission.js';
-import {
-  makeNetworkIdentityRequest,
-  parseNetworkIdentityRequest,
-  signNetworkIdentityResponse,
-  verifyNetworkIdentityResponse,
-} from './p2p/network-identity-proof.js';
+import { NetworkAdmissionService } from './p2p/network-admission.js';
+import { NetworkAdmissionCoordinator } from './p2p/network-admission-coordinator.js';
 import {
   createCGMemberEnumerator,
   type CGMemberEnumerator,
@@ -726,18 +721,32 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       // Codex review of PR #698 round 2 caught this.
     });
     this.peerResolver = peerResolver;
-    const trustedNetworkPeerIds = new Set<string>([
-      ...peerIdsFromMultiaddrs(this.config.relayPeers),
-      ...peerIdsFromMultiaddrs(this.config.bootstrapPeers),
-    ]);
     this.networkAdmission = new NetworkAdmissionService({
       networkId: this.config.networkIdentity?.networkId,
       selfPeerId: this.node.peerId.toString(),
-      trustedPeerIds: trustedNetworkPeerIds,
+    });
+    this.networkAdmissionCoordinator = new NetworkAdmissionCoordinator({
+      admission: this.networkAdmission,
+      identity: this.config.networkIdentity,
+      selfPeerId: this.node.peerId.toString(),
+      sign: (payload) => this.wallet.sign(payload),
+      sendIdentityProbe: (peerId, data, options) =>
+        this.router.send(peerId, PROTOCOL_NETWORK_IDENTITY, data, options),
+      getConnections: () => this.node.libp2p.getConnections() as any,
+      deletePeerFromPeerStore: async (peerId) => {
+        const { peerIdFromString } = await import('@libp2p/peer-id');
+        await this.node.libp2p.peerStore.delete(peerIdFromString(peerId));
+      },
+      cleanupRejectedPeerState: (peerId) => this.clearNetworkRejectedPeerState(peerId),
+      log: this.log,
     });
     this.router = new ProtocolRouter(this.node, {
       peerResolver,
-      isPeerAccepted: (peerId) => this.networkAdmission.isAcceptedPeer(peerId),
+      isPeerAccepted: (peerId, _protocolId, _direction) =>
+        this.networkAdmissionCoordinator.ensureAdmitted(
+          peerId,
+          createOperationContext('connect'),
+        ),
       admissionExemptProtocols: [PROTOCOL_NETWORK_IDENTITY],
     });
     // Default to in-memory substrate stores when no durable stores
@@ -777,26 +786,13 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     this.gossip = new GossipSubManager(this.node, this.eventBus, {
       networkId: this.config.networkIdentity?.networkId,
       chainId: this.config.networkIdentity?.chainId,
-      isPeerAccepted: (peerId) => this.networkAdmission.isAcceptedPeer(peerId),
+      isPeerAccepted: (peerId) => this.networkAdmissionCoordinator.isAcceptedPeer(peerId),
     });
     await this.loadSwmSenderKeyState();
     await this.initializeSwmHostModeStore();
     await this.rehydrateContextGraphSubscriptions();
 
-    this.router.register(PROTOCOL_NETWORK_IDENTITY, async (data) => {
-      const identity = this.config.networkIdentity;
-      if (!identity?.networkId) {
-        throw new Error('network identity is not configured');
-      }
-      const request = parseNetworkIdentityRequest(data);
-      const response = await signNetworkIdentityResponse({
-        request,
-        identity,
-        responderPeerId: this.node.peerId.toString(),
-        sign: (payload) => this.wallet.sign(payload),
-      });
-      return new TextEncoder().encode(JSON.stringify(response));
-    });
+    this.networkAdmissionCoordinator.registerIdentityProtocol(this.router);
 
     // Register protocol handlers. PROTOCOL_ACCESS migrated onto the
     // Universal Messenger substrate in rc.9 PR-8 — handler is
@@ -2226,7 +2222,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       // `connection:open` emitter is synchronous and we don't
       // want to slow down other listeners.
       void (async () => {
-        const admitted = await this.verifyPeerNetworkAdmission(remotePeer, ctx);
+        const admitted = await this.networkAdmissionCoordinator.ensureAdmitted(remotePeer, ctx);
         if (!admitted) return;
         try {
           await this.enrichPeerStoreFromInboundCircuit(evt.detail);
@@ -2316,7 +2312,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     const alreadyConnected = this.node.libp2p.getPeers();
     for (const pid of alreadyConnected) {
       const remotePeer = pid.toString();
-      void this.verifyPeerNetworkAdmission(remotePeer, ctx)
+      void this.networkAdmissionCoordinator.ensureAdmitted(remotePeer, ctx)
         .then((admitted) => {
           if (admitted) this.queueSyncFromPeerOnConnect(remotePeer, handleSyncError);
         })
@@ -2595,68 +2591,6 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     return now - lastDisconnected >= SYNC_RECONNECT_FLAP_GRACE_MS ? lastDisconnected : 0;
   }
 
-  async verifyPeerNetworkAdmission(
-    this: DKGAgent,
-    remotePeer: string,
-    ctx: OperationContext = createOperationContext('connect'),
-  ): Promise<boolean> {
-    const identity = this.config.networkIdentity;
-    if (!identity?.networkId) return true;
-    if (this.networkAdmission.isAcceptedPeer(remotePeer)) {
-      return true;
-    }
-
-    try {
-      const nonce = randomUUID();
-      const request = makeNetworkIdentityRequest({
-        nonce,
-        requesterPeerId: this.node.peerId.toString(),
-        identity,
-      });
-      const response = await this.router.send(
-        remotePeer,
-        PROTOCOL_NETWORK_IDENTITY,
-        new TextEncoder().encode(JSON.stringify(request)),
-        { timeoutMs: 3_000 },
-      );
-      const raw = new TextDecoder().decode(response);
-      const claimed = JSON.parse(raw) as unknown;
-      const verdict = await verifyNetworkIdentityResponse({
-        response: claimed,
-        remotePeerId: remotePeer,
-        localIdentity: identity,
-        nonce,
-        requesterPeerId: this.node.peerId.toString(),
-      });
-      if (verdict.ok) {
-        this.networkAdmission.markVerifiedSameNetwork(remotePeer);
-        return true;
-      }
-      await this.rejectPeerNetworkAdmission(
-        remotePeer,
-        ctx,
-        `network identity proof rejected: ${verdict.reason ?? 'unknown reason'}`,
-      );
-      return false;
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      await this.rejectPeerNetworkAdmission(remotePeer, ctx, `network identity probe failed: ${message}`);
-      return false;
-    }
-  }
-
-  async rejectPeerNetworkAdmission(
-    this: DKGAgent,
-    remotePeer: string,
-    ctx: OperationContext,
-    reason: string,
-  ): Promise<void> {
-    this.networkAdmission.quarantinePeer(remotePeer);
-    this.clearNetworkRejectedPeerState(remotePeer);
-    await this.disconnectAndForgetNetworkRejectedPeer(remotePeer, ctx);
-    this.log.warn(ctx, `Rejected peer ${remotePeer.slice(-8)}: ${reason}`);
-  }
-
   clearNetworkRejectedPeerState(this: DKGAgent, remotePeer: string): void {
     this.knownCorePeerIds.delete(remotePeer);
     this.knownCorePeerIdsV2.delete(remotePeer);
@@ -2670,36 +2604,6 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     this.warmCoreFailedUnpins.delete(remotePeer);
   }
 
-  async disconnectAndForgetNetworkRejectedPeer(
-    this: DKGAgent,
-    remotePeer: string,
-    ctx: OperationContext,
-  ): Promise<void> {
-    const shortPeer = remotePeer.slice(-8);
-    const connections = this.node.libp2p
-      .getConnections()
-      .filter((conn) => conn.remotePeer.toString() === remotePeer);
-    await Promise.all(connections.map(async (conn) => {
-      try {
-        await conn.close();
-      } catch (err) {
-        try {
-          conn.abort(err instanceof Error ? err : new Error(String(err)));
-        } catch {
-          // Best-effort cleanup only; the admission registry already blocks app work.
-        }
-      }
-    }));
-
-    try {
-      const { peerIdFromString } = await import('@libp2p/peer-id');
-      await this.node.libp2p.peerStore.delete(peerIdFromString(remotePeer));
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      this.log.info(ctx, `Rejected peer ${shortPeer}: peerstore cleanup skipped/failed: ${message}`);
-    }
-  }
-
   queueSyncFromPeerOnConnect(
     this: DKGAgent,
     remotePeer: string,
@@ -2709,7 +2613,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     if (!syncOnConnectEnabled(this.config)) {
       return false;
     }
-    if (!this.networkAdmission.isAcceptedPeer(remotePeer)) {
+    if (!this.networkAdmissionCoordinator.isAcceptedPeer(remotePeer)) {
       return false;
     }
     const now = Date.now();
@@ -2813,7 +2717,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     if (!syncOnConnectEnabled(this.config)) {
       return 'not-started';
     }
-    if (!this.networkAdmission.isAcceptedPeer(remotePeer)) {
+    if (!this.networkAdmissionCoordinator.isAcceptedPeer(remotePeer)) {
       return 'not-started';
     }
     const sharedMemorySyncPlans = new Map<string, Promise<SharedMemorySyncContextGraphPlan>>();
@@ -3019,7 +2923,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
    */
   handlePeerUpdateForSyncRetry(this: DKGAgent, peerId: string, protocols: readonly string[]): void {
     if (peerId === this.node.libp2p.peerId.toString()) return;
-    if (!this.networkAdmission.isAcceptedPeer(peerId)) return;
+    if (!this.networkAdmissionCoordinator.isAcceptedPeer(peerId)) return;
     // #1093: keep the confirmed-core set fresh from `peer:update` too.
     // `runSyncOnConnect` reads the protocol list exactly once, racing
     // identify — a core peer whose identify completed late was never
@@ -3077,7 +2981,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     this.pruneSyncReconcilerState(now);
     for (const pid of this.node.libp2p.getPeers()) {
       const peerId = pid.toString();
-      if (!this.networkAdmission.isAcceptedPeer(peerId)) continue;
+      if (!this.networkAdmissionCoordinator.isAcceptedPeer(peerId)) continue;
       if (this.syncingPeers.has(peerId)) continue;
       const lastOk = this.lastSuccessfulSyncAt.get(peerId);
       const lastDisconnected = this.syncOnConnectDisconnectBoundary(peerId, now);
@@ -3356,7 +3260,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
   async maybeDialGossipSender(this: DKGAgent, peerIdStr: string): Promise<void> {
     const selfPeerId = this.node.libp2p.peerId.toString();
     if (peerIdStr === selfPeerId) return;
-    if (!this.networkAdmission.isAcceptedPeer(peerIdStr)) return;
+    if (!this.networkAdmissionCoordinator.isAcceptedPeer(peerIdStr)) return;
 
     // Already connected → nothing to do.
     const connected = this.node.libp2p.getPeers().some(p => p.toString() === peerIdStr);
@@ -4018,7 +3922,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     this.trackSyncContextGraph(contextGraphId);
 
     const preferredPeerId = await this.resolvePreferredSyncPeerId(contextGraphId);
-    if (preferredPeerId && await this.verifyPeerNetworkAdmission(preferredPeerId, ctx)) {
+    if (preferredPeerId && await this.networkAdmissionCoordinator.ensureAdmitted(preferredPeerId, ctx)) {
       await this.ensurePeerConnected(preferredPeerId);
     }
 
@@ -4028,7 +3932,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       [...new Map(
         this.node.libp2p.getConnections().map((conn) => [conn.remotePeer.toString(), conn.remotePeer]),
       ).values()].filter((peer) =>
-        this.networkAdmission.isAcceptedPeer(peer.toString()),
+        this.networkAdmissionCoordinator.isAcceptedPeer(peer.toString()),
       ),
       preferredPeerId,
       isPrivateContextGraph,
@@ -4416,7 +4320,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       this.discovery,
       this.peerId,
       async (peerId) => {
-        await this.verifyPeerNetworkAdmission(peerId, ctx);
+        await this.networkAdmissionCoordinator.ensureAdmitted(peerId, ctx);
       },
     );
   }
@@ -4461,7 +4365,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     // broadcast in a single try/catch reintroduces the silent-stall
     // bug this method exists to fix (Lex review on PR #517 + Codex).
     try {
-      if (!(await this.verifyPeerNetworkAdmission(curatorPeerId, ctx))) {
+      if (!(await this.networkAdmissionCoordinator.ensureAdmitted(curatorPeerId, ctx))) {
         this.log.warn(
           ctx,
           `Post-approval sync for "${contextGraphId}": curator ${curatorShort} failed network admission; falling back to broadcast catchup`,
@@ -4531,8 +4435,11 @@ export class LifecycleSyncMethods extends DKGAgentBase {
   }
 
   async ensurePeerConnected(this: DKGAgent, peerId: string): Promise<void> {
-    if (!this.networkAdmission.isAcceptedPeer(peerId)) return;
     await ensurePeerConnectedAtom(this.node.libp2p as any, this.discovery, peerId);
+    if (await this.networkAdmissionCoordinator.ensureAdmitted(peerId, createOperationContext('connect'))) return;
+    const error = new Error(`Peer ${peerId} is not admitted for the active DKG network`);
+    (error as any).code = 'NETWORK_ADMISSION_REJECTED';
+    throw error;
   }
 
   async waitForSyncProtocol(this: DKGAgent, pid: { toString(): string }): Promise<boolean> {

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -13,6 +13,7 @@ import {
   DKGNode, ProtocolRouter, GossipSubManager, TypedEventBus, DKGEvent,
   LibP2PNetwork, PeerResolver, StubNetworkStateRegistry,
   PROTOCOL_ACCESS, PROTOCOL_PUBLISH, PROTOCOL_SYNC, PROTOCOL_QUERY_REMOTE, PROTOCOL_STORAGE_ACK, PROTOCOL_STORAGE_ACK_V2, PROTOCOL_STORAGE_UPDATE_ACK, PROTOCOL_GET_CIPHERTEXT_CHUNK, PROTOCOL_VERIFY_PROPOSAL, PROTOCOL_JOIN_REQUEST,
+  PROTOCOL_NETWORK_IDENTITY,
   PROTOCOL_SWM_SENDER_KEY, PROTOCOL_SWM_UPDATE, PROTOCOL_SWM_SHARE_ACK, PROTOCOL_SWM_HOST_CATCHUP, PROTOCOL_MESSAGE,
   contextGraphPublishTopic, contextGraphWorkspaceTopic, contextGraphAppTopic, contextGraphUpdateTopic, contextGraphFinalizationTopic,
   contextGraphDataGraphUri, contextGraphMetaGraphUri, contextGraphWorkspaceGraphUri, contextGraphWorkspaceMetaGraphUri,
@@ -147,6 +148,13 @@ import { SyncVerifyWorker } from './sync-verify-worker.js';
 import { bindRandomSampling, type RandomSamplingHandle, type RandomSamplingStatus } from './random-sampling-bind.js';
 import { connectToMultiaddr, ensurePeerConnected as ensurePeerConnectedAtom, primeCatchupConnections as primeCatchupConnectionsAtom } from './p2p/peer-connect.js';
 import { Messenger, type SloProtocolStats } from './p2p/messenger.js';
+import { NetworkAdmissionService, peerIdsFromMultiaddrs } from './p2p/network-admission.js';
+import {
+  makeNetworkIdentityRequest,
+  parseNetworkIdentityRequest,
+  signNetworkIdentityResponse,
+  verifyNetworkIdentityResponse,
+} from './p2p/network-identity-proof.js';
 import {
   createCGMemberEnumerator,
   type CGMemberEnumerator,
@@ -718,7 +726,21 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       // Codex review of PR #698 round 2 caught this.
     });
     this.peerResolver = peerResolver;
-    this.router = new ProtocolRouter(this.node, { peerResolver });
+    const trustedNetworkPeerIds = new Set<string>([
+      ...peerIdsFromMultiaddrs(this.config.relayPeers),
+      ...peerIdsFromMultiaddrs(this.config.bootstrapPeers),
+    ]);
+    this.networkAdmission = new NetworkAdmissionService({
+      networkId: this.config.networkIdentity?.networkId,
+      selfPeerId: this.node.peerId.toString(),
+      trustedPeerIds: trustedNetworkPeerIds,
+    });
+    this.router = new ProtocolRouter(this.node, {
+      peerResolver,
+      isPeerAccepted: (peerId, protocolId, direction) =>
+        this.networkAdmission.isPeerAccepted(peerId, protocolId, direction),
+      admissionExemptProtocols: [PROTOCOL_NETWORK_IDENTITY],
+    });
     // Default to in-memory substrate stores when no durable stores
     // are supplied. The production daemon (`cli/src/daemon/
     // lifecycle.ts`) always wires SQLite-backed stores against the
@@ -750,13 +772,34 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       // remains the step-2 DHT lookup inside resolve(), so we don't
       // lose any pre-existing recovery path.
       resolvePeer: async (peerId, { signal }) => {
+        if (!this.networkAdmission.isPeerAccepted(peerId, 'peer-resolver', 'outbound')) return;
         await peerResolver.resolve(peerId, { signal }).catch(() => undefined);
       },
     });
-    this.gossip = new GossipSubManager(this.node, this.eventBus);
+    this.gossip = new GossipSubManager(this.node, this.eventBus, {
+      networkId: this.config.networkIdentity?.networkId,
+      chainId: this.config.networkIdentity?.chainId,
+      isPeerAccepted: (peerId, topic) =>
+        this.networkAdmission.isPeerAccepted(peerId, topic, 'gossip'),
+    });
     await this.loadSwmSenderKeyState();
     await this.initializeSwmHostModeStore();
     await this.rehydrateContextGraphSubscriptions();
+
+    this.router.register(PROTOCOL_NETWORK_IDENTITY, async (data) => {
+      const identity = this.config.networkIdentity;
+      if (!identity?.networkId) {
+        throw new Error('network identity is not configured');
+      }
+      const request = parseNetworkIdentityRequest(data);
+      const response = await signNetworkIdentityResponse({
+        request,
+        identity,
+        responderPeerId: this.node.peerId.toString(),
+        sign: (payload) => this.wallet.sign(payload),
+      });
+      return new TextEncoder().encode(JSON.stringify(response));
+    });
 
     // Register protocol handlers. PROTOCOL_ACCESS migrated onto the
     // Universal Messenger substrate in rc.9 PR-8 — handler is
@@ -2186,6 +2229,8 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       // `connection:open` emitter is synchronous and we don't
       // want to slow down other listeners.
       void (async () => {
+        const admitted = await this.verifyPeerNetworkAdmission(remotePeer, ctx);
+        if (!admitted) return;
         try {
           await this.enrichPeerStoreFromInboundCircuit(evt.detail);
         } catch (err: unknown) {
@@ -2216,9 +2261,8 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           const message = err instanceof Error ? err.message : String(err);
           this.log.warn(ctx, `Pending SWM sender-key drain on connect failed for ${remotePeer}: ${message}`);
         }
+        this.queueSyncFromPeerOnConnect(remotePeer, handleSyncError);
       })();
-
-      this.queueSyncFromPeerOnConnect(remotePeer, handleSyncError);
     });
 
     // Remember when the last live connection to a peer is gone. A3 keeps
@@ -2275,7 +2319,14 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     const alreadyConnected = this.node.libp2p.getPeers();
     for (const pid of alreadyConnected) {
       const remotePeer = pid.toString();
-      this.queueSyncFromPeerOnConnect(remotePeer, handleSyncError);
+      void this.verifyPeerNetworkAdmission(remotePeer, ctx)
+        .then((admitted) => {
+          if (admitted) this.queueSyncFromPeerOnConnect(remotePeer, handleSyncError);
+        })
+        .catch((err: unknown) => {
+          const message = err instanceof Error ? err.message : String(err);
+          this.log.warn(ctx, `Startup network admission check failed for ${remotePeer.slice(-8)}: ${message}`);
+        });
     }
 
     // Start periodic shared memory cleanup
@@ -2547,6 +2598,111 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     return now - lastDisconnected >= SYNC_RECONNECT_FLAP_GRACE_MS ? lastDisconnected : 0;
   }
 
+  async verifyPeerNetworkAdmission(
+    this: DKGAgent,
+    remotePeer: string,
+    ctx: OperationContext = createOperationContext('connect'),
+  ): Promise<boolean> {
+    const identity = this.config.networkIdentity;
+    if (!identity?.networkId) return true;
+    if (this.networkAdmission.isPeerAccepted(remotePeer, 'network-admission', 'outbound')) {
+      return true;
+    }
+
+    try {
+      const nonce = randomUUID();
+      const request = makeNetworkIdentityRequest({
+        nonce,
+        requesterPeerId: this.node.peerId.toString(),
+        identity,
+      });
+      const response = await this.router.send(
+        remotePeer,
+        PROTOCOL_NETWORK_IDENTITY,
+        new TextEncoder().encode(JSON.stringify(request)),
+        { timeoutMs: 3_000 },
+      );
+      const raw = new TextDecoder().decode(response);
+      const claimed = JSON.parse(raw) as unknown;
+      const verdict = await verifyNetworkIdentityResponse({
+        response: claimed,
+        remotePeerId: remotePeer,
+        localIdentity: identity,
+        nonce,
+        requesterPeerId: this.node.peerId.toString(),
+      });
+      if (verdict.ok) {
+        this.networkAdmission.markVerifiedSameNetwork(remotePeer);
+        return true;
+      }
+      await this.rejectPeerNetworkAdmission(
+        remotePeer,
+        ctx,
+        `network identity proof rejected: ${verdict.reason ?? 'unknown reason'}`,
+      );
+      return false;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      await this.rejectPeerNetworkAdmission(remotePeer, ctx, `network identity probe failed: ${message}`);
+      return false;
+    }
+  }
+
+  async rejectPeerNetworkAdmission(
+    this: DKGAgent,
+    remotePeer: string,
+    ctx: OperationContext,
+    reason: string,
+  ): Promise<void> {
+    this.networkAdmission.quarantinePeer(remotePeer);
+    this.clearNetworkRejectedPeerState(remotePeer);
+    await this.disconnectAndForgetNetworkRejectedPeer(remotePeer, ctx);
+    this.log.warn(ctx, `Rejected peer ${remotePeer.slice(-8)}: ${reason}`);
+  }
+
+  clearNetworkRejectedPeerState(this: DKGAgent, remotePeer: string): void {
+    this.knownCorePeerIds.delete(remotePeer);
+    this.knownCorePeerIdsV2.delete(remotePeer);
+    this.skippedNoSyncPeers.delete(remotePeer);
+    this.catchupOnConnectAt.delete(remotePeer);
+    this.lastSyncDisconnectedAt.delete(remotePeer);
+    this.lastSuccessfulSyncAt.delete(remotePeer);
+    this.lastSyncProgressAt.delete(remotePeer);
+    this.syncReconcilerBackoff.delete(remotePeer);
+    this.warmedCores.delete(remotePeer);
+    this.warmCoreFailedUnpins.delete(remotePeer);
+  }
+
+  async disconnectAndForgetNetworkRejectedPeer(
+    this: DKGAgent,
+    remotePeer: string,
+    ctx: OperationContext,
+  ): Promise<void> {
+    const shortPeer = remotePeer.slice(-8);
+    const connections = this.node.libp2p
+      .getConnections()
+      .filter((conn) => conn.remotePeer.toString() === remotePeer);
+    await Promise.all(connections.map(async (conn) => {
+      try {
+        await conn.close();
+      } catch (err) {
+        try {
+          conn.abort(err instanceof Error ? err : new Error(String(err)));
+        } catch {
+          // Best-effort cleanup only; the admission registry already blocks app work.
+        }
+      }
+    }));
+
+    try {
+      const { peerIdFromString } = await import('@libp2p/peer-id');
+      await this.node.libp2p.peerStore.delete(peerIdFromString(remotePeer));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.log.info(ctx, `Rejected peer ${shortPeer}: peerstore cleanup skipped/failed: ${message}`);
+    }
+  }
+
   queueSyncFromPeerOnConnect(
     this: DKGAgent,
     remotePeer: string,
@@ -2554,6 +2710,9 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     delayMs = 3000,
   ): boolean {
     if (!syncOnConnectEnabled(this.config)) {
+      return false;
+    }
+    if (!this.networkAdmission.isPeerAccepted(remotePeer, 'sync-on-connect', 'outbound')) {
       return false;
     }
     const now = Date.now();
@@ -2655,6 +2814,9 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       return 'not-started';
     }
     if (!syncOnConnectEnabled(this.config)) {
+      return 'not-started';
+    }
+    if (!this.networkAdmission.isPeerAccepted(remotePeer, 'sync-on-connect', 'outbound')) {
       return 'not-started';
     }
     const sharedMemorySyncPlans = new Map<string, Promise<SharedMemorySyncContextGraphPlan>>();
@@ -2860,6 +3022,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
    */
   handlePeerUpdateForSyncRetry(this: DKGAgent, peerId: string, protocols: readonly string[]): void {
     if (peerId === this.node.libp2p.peerId.toString()) return;
+    if (!this.networkAdmission.isPeerAccepted(peerId, 'peer:update', 'inbound')) return;
     // #1093: keep the confirmed-core set fresh from `peer:update` too.
     // `runSyncOnConnect` reads the protocol list exactly once, racing
     // identify — a core peer whose identify completed late was never
@@ -2917,6 +3080,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     this.pruneSyncReconcilerState(now);
     for (const pid of this.node.libp2p.getPeers()) {
       const peerId = pid.toString();
+      if (!this.networkAdmission.isPeerAccepted(peerId, 'sync-reconciler', 'outbound')) continue;
       if (this.syncingPeers.has(peerId)) continue;
       const lastOk = this.lastSuccessfulSyncAt.get(peerId);
       const lastDisconnected = this.syncOnConnectDisconnectBoundary(peerId, now);
@@ -3195,6 +3359,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
   async maybeDialGossipSender(this: DKGAgent, peerIdStr: string): Promise<void> {
     const selfPeerId = this.node.libp2p.peerId.toString();
     if (peerIdStr === selfPeerId) return;
+    if (!this.networkAdmission.isPeerAccepted(peerIdStr, 'gossip-redial', 'outbound')) return;
 
     // Already connected → nothing to do.
     const connected = this.node.libp2p.getPeers().some(p => p.toString() === peerIdStr);
@@ -3856,7 +4021,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     this.trackSyncContextGraph(contextGraphId);
 
     const preferredPeerId = await this.resolvePreferredSyncPeerId(contextGraphId);
-    if (preferredPeerId) {
+    if (preferredPeerId && this.networkAdmission.isPeerAccepted(preferredPeerId, 'catchup-preferred', 'outbound')) {
       await this.ensurePeerConnected(preferredPeerId);
     }
 
@@ -3865,7 +4030,9 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     const orderedPeers = this.selectCatchupPeers(
       [...new Map(
         this.node.libp2p.getConnections().map((conn) => [conn.remotePeer.toString(), conn.remotePeer]),
-      ).values()],
+      ).values()].filter((peer) =>
+        this.networkAdmission.isPeerAccepted(peer.toString(), 'catchup', 'outbound'),
+      ),
       preferredPeerId,
       isPrivateContextGraph,
     );
@@ -4246,7 +4413,12 @@ export class LifecycleSyncMethods extends DKGAgentBase {
   }
 
   async primeCatchupConnections(this: DKGAgent): Promise<void> {
-    await primeCatchupConnectionsAtom(this.node.libp2p as any, this.discovery, this.peerId);
+    await primeCatchupConnectionsAtom(
+      this.node.libp2p as any,
+      this.discovery,
+      this.peerId,
+      (peerId) => this.networkAdmission.isPeerAccepted(peerId, 'catchup-prime', 'outbound'),
+    );
   }
 
   /**
@@ -4289,29 +4461,36 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     // broadcast in a single try/catch reintroduces the silent-stall
     // bug this method exists to fix (Lex review on PR #517 + Codex).
     try {
-      await this.ensurePeerConnected(curatorPeerId);
-      const curatorRemote = this.node.libp2p
-        .getConnections()
-        .find((conn) => conn.remotePeer.toString() === curatorPeerId)?.remotePeer;
-      if (curatorRemote) {
-        const result = await this.runCatchupOverPeers(contextGraphId, true, [curatorRemote]);
-        if (result.peersSucceeded > 0) {
-          this.log.info(
-            ctx,
-            `Post-approval sync for "${contextGraphId}" from curator ${curatorShort} fetched ${result.dataSynced} data + ${result.sharedMemorySynced} SWM triples`,
-          );
-          curatorTargetSucceeded = true;
+      if (!(await this.verifyPeerNetworkAdmission(curatorPeerId, ctx))) {
+        this.log.warn(
+          ctx,
+          `Post-approval sync for "${contextGraphId}": curator ${curatorShort} failed network admission; falling back to broadcast catchup`,
+        );
+      } else {
+        await this.ensurePeerConnected(curatorPeerId);
+        const curatorRemote = this.node.libp2p
+          .getConnections()
+          .find((conn) => conn.remotePeer.toString() === curatorPeerId)?.remotePeer;
+        if (curatorRemote) {
+          const result = await this.runCatchupOverPeers(contextGraphId, true, [curatorRemote]);
+          if (result.peersSucceeded > 0) {
+            this.log.info(
+              ctx,
+              `Post-approval sync for "${contextGraphId}" from curator ${curatorShort} fetched ${result.dataSynced} data + ${result.sharedMemorySynced} SWM triples`,
+            );
+            curatorTargetSucceeded = true;
+          } else {
+            this.log.warn(
+              ctx,
+              `Post-approval sync for "${contextGraphId}" from curator ${curatorShort} produced no successful peer (denied=${result.denied}); falling back to broadcast catchup`,
+            );
+          }
         } else {
           this.log.warn(
             ctx,
-            `Post-approval sync for "${contextGraphId}" from curator ${curatorShort} produced no successful peer (denied=${result.denied}); falling back to broadcast catchup`,
+            `Post-approval sync for "${contextGraphId}": curator ${curatorShort} not in connected peers after ensurePeerConnected; falling back to broadcast catchup`,
           );
         }
-      } else {
-        this.log.warn(
-          ctx,
-          `Post-approval sync for "${contextGraphId}": curator ${curatorShort} not in connected peers after ensurePeerConnected; falling back to broadcast catchup`,
-        );
       }
     } catch (err) {
       this.log.warn(
@@ -4352,6 +4531,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
   }
 
   async ensurePeerConnected(this: DKGAgent, peerId: string): Promise<void> {
+    if (!this.networkAdmission.isPeerAccepted(peerId, 'ensure-peer-connected', 'outbound')) return;
     await ensurePeerConnectedAtom(this.node.libp2p as any, this.discovery, peerId);
   }
 

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -4021,7 +4021,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     this.trackSyncContextGraph(contextGraphId);
 
     const preferredPeerId = await this.resolvePreferredSyncPeerId(contextGraphId);
-    if (preferredPeerId && this.networkAdmission.isPeerAccepted(preferredPeerId, 'catchup-preferred', 'outbound')) {
+    if (preferredPeerId && await this.verifyPeerNetworkAdmission(preferredPeerId, ctx)) {
       await this.ensurePeerConnected(preferredPeerId);
     }
 
@@ -4413,11 +4413,12 @@ export class LifecycleSyncMethods extends DKGAgentBase {
   }
 
   async primeCatchupConnections(this: DKGAgent): Promise<void> {
+    const ctx = createOperationContext('sync');
     await primeCatchupConnectionsAtom(
       this.node.libp2p as any,
       this.discovery,
       this.peerId,
-      (peerId) => this.networkAdmission.isPeerAccepted(peerId, 'catchup-prime', 'outbound'),
+      (peerId) => this.verifyPeerNetworkAdmission(peerId, ctx),
     );
   }
 

--- a/packages/agent/src/dkg-agent-registry.ts
+++ b/packages/agent/src/dkg-agent-registry.ts
@@ -146,6 +146,7 @@ import {
 import { SyncVerifyWorker } from './sync-verify-worker.js';
 import { bindRandomSampling, type RandomSamplingHandle, type RandomSamplingStatus } from './random-sampling-bind.js';
 import { connectToMultiaddr, ensurePeerConnected as ensurePeerConnectedAtom, primeCatchupConnections as primeCatchupConnectionsAtom } from './p2p/peer-connect.js';
+import { NetworkAdmissionRejectedError, type NetworkAdmissionAttemptOptions } from './p2p/network-admission-coordinator.js';
 import { Messenger, type SloProtocolStats } from './p2p/messenger.js';
 import { targetPeerIdFromMultiaddr } from './p2p/network-admission.js';
 import {
@@ -1814,11 +1815,14 @@ export class AgentRegistryMethods extends DKGAgentBase {
     });
   }
 
-  async assertPeerAdmittedForExplicitConnect(this: DKGAgent, peerId: string, ctx: OperationContext): Promise<void> {
-    if (await this.networkAdmissionCoordinator.ensureAdmitted(peerId, ctx)) return;
-    const error = new Error(`Peer ${peerId} is not admitted for the active DKG network`);
-    (error as any).code = 'NETWORK_ADMISSION_REJECTED';
-    throw error;
+  async assertPeerAdmittedForExplicitConnect(
+    this: DKGAgent,
+    peerId: string,
+    ctx: OperationContext,
+    options?: NetworkAdmissionAttemptOptions,
+  ): Promise<void> {
+    if (await this.networkAdmissionCoordinator.ensureAdmitted(peerId, ctx, options)) return;
+    throw new NetworkAdmissionRejectedError(peerId);
   }
 
   async connectTo(this: DKGAgent, multiaddress: string): Promise<void> {
@@ -1905,13 +1909,20 @@ export class AgentRegistryMethods extends DKGAgentBase {
       throw error;
     }
 
+    const startedAt = Date.now();
+    const signal = AbortSignal.timeout(timeoutMs);
+    const remainingTimeoutMs = () => Math.max(0, timeoutMs - (Date.now() - startedAt));
+
     // Fast-path: already connected (e.g. via gossipsub mesh / mDNS / a
     // prior invite). Resolver step 1 would also short-circuit on this,
     // but the early return preserves the existing log message and skips
     // the rest of the resolution machinery entirely.
     const existing = this.node.libp2p.getConnections(peerId);
     if (existing.length > 0) {
-      await this.assertPeerAdmittedForExplicitConnect(peerIdStr, ctx);
+      await this.assertPeerAdmittedForExplicitConnect(peerIdStr, ctx, {
+        signal,
+        timeoutMs: remainingTimeoutMs(),
+      });
       this.log.info(ctx, `Already connected to ${peerIdStr}`);
       return;
     }
@@ -1922,9 +1933,6 @@ export class AgentRegistryMethods extends DKGAgentBase {
     // final dial, so a slow DHT walk plus a slow dial could exceed the
     // caller's deadline by a wide margin. Using one signal threads the
     // remaining budget through both phases.
-    const startedAt = Date.now();
-    const signal = AbortSignal.timeout(timeoutMs);
-
     this.log.info(ctx, `Resolving ${peerIdStr} via PeerResolver...`);
     const addrs = await this.peerResolver.resolve(peerIdStr, {
       signal,
@@ -1989,7 +1997,10 @@ export class AgentRegistryMethods extends DKGAgentBase {
       (error as any).code = 'DIAL_FAILED';
       throw error;
     }
-    await this.assertPeerAdmittedForExplicitConnect(peerIdStr, ctx);
+    await this.assertPeerAdmittedForExplicitConnect(peerIdStr, ctx, {
+      signal,
+      timeoutMs: remainingTimeoutMs(),
+    });
     this.log.info(ctx, `Connected to ${peerIdStr}`);
   }
 

--- a/packages/agent/src/dkg-agent-registry.ts
+++ b/packages/agent/src/dkg-agent-registry.ts
@@ -147,6 +147,7 @@ import { SyncVerifyWorker } from './sync-verify-worker.js';
 import { bindRandomSampling, type RandomSamplingHandle, type RandomSamplingStatus } from './random-sampling-bind.js';
 import { connectToMultiaddr, ensurePeerConnected as ensurePeerConnectedAtom, primeCatchupConnections as primeCatchupConnectionsAtom } from './p2p/peer-connect.js';
 import { Messenger, type SloProtocolStats } from './p2p/messenger.js';
+import { peerIdsFromMultiaddrs } from './p2p/network-admission.js';
 import {
   createCGMemberEnumerator,
   type CGMemberEnumerator,
@@ -1813,13 +1814,30 @@ export class AgentRegistryMethods extends DKGAgentBase {
     });
   }
 
+  async assertPeerAdmittedForExplicitConnect(this: DKGAgent, peerId: string, ctx: OperationContext): Promise<void> {
+    if (await this.verifyPeerNetworkAdmission(peerId, ctx)) return;
+    const error = new Error(`Peer ${peerId} is not admitted for the active DKG network`);
+    (error as any).code = 'NETWORK_ADMISSION_REJECTED';
+    throw error;
+  }
+
   async connectTo(this: DKGAgent, multiaddress: string): Promise<void> {
     const ctx = createOperationContext('connect');
+    const peerIds = [...peerIdsFromMultiaddrs([multiaddress])];
+    const targetPeerId = peerIds[peerIds.length - 1];
+    if (this.networkAdmission.enabled && !targetPeerId) {
+      const error = new Error('Connect multiaddr must include a target /p2p/<peerId> for network admission');
+      (error as any).code = 'INVALID_PEER_ID';
+      throw error;
+    }
     await connectToMultiaddr(
       this.node.libp2p as any,
       multiaddress,
       (message) => this.log.info(ctx, message),
     );
+    if (targetPeerId) {
+      await this.assertPeerAdmittedForExplicitConnect(targetPeerId, ctx);
+    }
   }
 
   /**
@@ -1894,6 +1912,7 @@ export class AgentRegistryMethods extends DKGAgentBase {
     // the rest of the resolution machinery entirely.
     const existing = this.node.libp2p.getConnections(peerId);
     if (existing.length > 0) {
+      await this.assertPeerAdmittedForExplicitConnect(peerIdStr, ctx);
       this.log.info(ctx, `Already connected to ${peerIdStr}`);
       return;
     }
@@ -1941,7 +1960,6 @@ export class AgentRegistryMethods extends DKGAgentBase {
     // budget is honoured end-to-end.
     try {
       await this.node.libp2p.dial(peerId, { signal });
-      this.log.info(ctx, `Connected to ${peerIdStr}`);
     } catch (err: any) {
       // Codex PR #499 round 5 (dkg-agent.ts:4096): the shared signal
       // covers BOTH resolution and dial. If most of the budget went
@@ -1972,6 +1990,8 @@ export class AgentRegistryMethods extends DKGAgentBase {
       (error as any).code = 'DIAL_FAILED';
       throw error;
     }
+    await this.assertPeerAdmittedForExplicitConnect(peerIdStr, ctx);
+    this.log.info(ctx, `Connected to ${peerIdStr}`);
   }
 
 }

--- a/packages/agent/src/dkg-agent-registry.ts
+++ b/packages/agent/src/dkg-agent-registry.ts
@@ -1815,7 +1815,7 @@ export class AgentRegistryMethods extends DKGAgentBase {
   }
 
   async assertPeerAdmittedForExplicitConnect(this: DKGAgent, peerId: string, ctx: OperationContext): Promise<void> {
-    if (await this.verifyPeerNetworkAdmission(peerId, ctx)) return;
+    if (await this.networkAdmissionCoordinator.ensureAdmitted(peerId, ctx)) return;
     const error = new Error(`Peer ${peerId} is not admitted for the active DKG network`);
     (error as any).code = 'NETWORK_ADMISSION_REJECTED';
     throw error;
@@ -1824,7 +1824,7 @@ export class AgentRegistryMethods extends DKGAgentBase {
   async connectTo(this: DKGAgent, multiaddress: string): Promise<void> {
     const ctx = createOperationContext('connect');
     const targetPeerId = targetPeerIdFromMultiaddr(multiaddress);
-    if (this.networkAdmission.enabled && !targetPeerId) {
+    if (this.networkAdmissionCoordinator.enabled && !targetPeerId) {
       const error = new Error('Connect multiaddr must include a target /p2p/<peerId> for network admission');
       (error as any).code = 'INVALID_PEER_ID';
       throw error;

--- a/packages/agent/src/dkg-agent-registry.ts
+++ b/packages/agent/src/dkg-agent-registry.ts
@@ -147,7 +147,7 @@ import { SyncVerifyWorker } from './sync-verify-worker.js';
 import { bindRandomSampling, type RandomSamplingHandle, type RandomSamplingStatus } from './random-sampling-bind.js';
 import { connectToMultiaddr, ensurePeerConnected as ensurePeerConnectedAtom, primeCatchupConnections as primeCatchupConnectionsAtom } from './p2p/peer-connect.js';
 import { Messenger, type SloProtocolStats } from './p2p/messenger.js';
-import { peerIdsFromMultiaddrs } from './p2p/network-admission.js';
+import { targetPeerIdFromMultiaddr } from './p2p/network-admission.js';
 import {
   createCGMemberEnumerator,
   type CGMemberEnumerator,
@@ -1823,8 +1823,7 @@ export class AgentRegistryMethods extends DKGAgentBase {
 
   async connectTo(this: DKGAgent, multiaddress: string): Promise<void> {
     const ctx = createOperationContext('connect');
-    const peerIds = [...peerIdsFromMultiaddrs([multiaddress])];
-    const targetPeerId = peerIds[peerIds.length - 1];
+    const targetPeerId = targetPeerIdFromMultiaddr(multiaddress);
     if (this.networkAdmission.enabled && !targetPeerId) {
       const error = new Error('Connect multiaddr must include a target /p2p/<peerId> for network admission');
       (error as any).code = 'INVALID_PEER_ID';

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -24,6 +24,7 @@ import type {
 import type {
   OperationContext,
   AuthorAttestationTypedData,
+  DkgNetworkIdentity,
   MessageIdempotencyStore,
   ProtocolOutboxStore,
   SwmSenderKeyPackageAckReasonCode,
@@ -864,6 +865,8 @@ export interface DKGAgentConfig {
   name: string;
   /** Selected genesis document. Defaults to the compatibility Base testnet genesis. */
   genesisId?: string;
+  /** Active network identity used to isolate libp2p and app workflow boundaries. */
+  networkIdentity?: DkgNetworkIdentity;
   /**
    * public-projection enable flag. When set, a private CG's confirmed VM
    * publishes emit/refresh a verifiable public projection (the floor: existence,

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -735,6 +735,11 @@ export class DKGAgent extends DKGAgentBase {
 
     // Load genesis knowledge into the store (idempotent)
     await DKGAgent.loadGenesis(store, genesisId);
+    const networkIdentity = config.networkIdentity ?? {
+      genesisId,
+      networkId: await computeNetworkId(genesisId),
+      chainId: chain.chainId !== 'none' ? chain.chainId : undefined,
+    };
 
     const port = config.listenPort ?? 0;
     const host = config.listenHost ?? '0.0.0.0';
@@ -749,6 +754,7 @@ export class DKGAgent extends DKGAgentBase {
       relayServerCapacity: config.relayServerCapacity,
       relayReservationCount: config.relayReservationCount,
       nodeVersion: config.nodeVersion,
+      networkIdentity,
       ...pickNetworkTunables(config),
     };
 
@@ -1709,6 +1715,9 @@ export class DKGAgent extends DKGAgentBase {
       selfPeerId: this.peerId,
       ackCandidatePeerIds: this.config.ackCandidatePeerIds,
       preferredACKPeerIds: this.config.preferredACKPeerIds,
+      verifiedSameNetworkPeerIds: this.networkAdmission.enabled
+        ? this.networkAdmission.verifiedSameNetworkPeerIds()
+        : undefined,
       knownCorePeerIds: this.knownCorePeerIds,
       knownCorePeerIdsV2: this.knownCorePeerIdsV2,
       requiredACKs,
@@ -1749,10 +1758,16 @@ export class DKGAgent extends DKGAgentBase {
   private createACKSendP2P(
     timeoutMs = this.config.storageAckTiming.sendTimeoutMs,
   ): ACKCollectorDeps['sendP2P'] {
-    return createACKSendP2P({
+    const send = createACKSendP2P({
       messenger: this.messenger,
       timeoutMs,
     });
+    return async (peerId: string, protocol: string, data: Uint8Array) => {
+      if (!this.networkAdmission.isPeerAccepted(peerId, protocol, 'outbound')) {
+        throw new Error(`peer ${peerId.slice(-8)} is not admitted for active-network ACK collection`);
+      }
+      return send(peerId, protocol, data);
+    };
   }
 
   /**

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -740,6 +740,7 @@ export class DKGAgent extends DKGAgentBase {
       networkId: await computeNetworkId(genesisId),
       chainId: chain.chainId !== 'none' ? chain.chainId : undefined,
     };
+    const resolvedConfig: DKGAgentConfig = { ...config, networkIdentity };
 
     const port = config.listenPort ?? 0;
     const host = config.listenHost ?? '0.0.0.0';
@@ -840,7 +841,7 @@ export class DKGAgent extends DKGAgentBase {
     const queryEngine = new DKGQueryEngine(agentStore);
 
     const agent = new DKGAgent(
-      config, wallet, node, agentStore, publisher, queryEngine, eventBus, chain,
+      resolvedConfig, wallet, node, agentStore, publisher, queryEngine, eventBus, chain,
       workspaceOwnedEntities, writeLocks, publicSnapshotStore,
     );
     agentRef = agent;

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1764,7 +1764,7 @@ export class DKGAgent extends DKGAgentBase {
       timeoutMs,
     });
     return async (peerId: string, protocol: string, data: Uint8Array) => {
-      if (!this.networkAdmission.isPeerAccepted(peerId, protocol, 'outbound')) {
+      if (!this.networkAdmission.isAcceptedPeer(peerId)) {
         throw new Error(`peer ${peerId.slice(-8)} is not admitted for active-network ACK collection`);
       }
       return send(peerId, protocol, data);

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -22,7 +22,7 @@ import {
   decodeGossipEnvelope, type GossipEnvelopeMsg,
   decodeEncryptedWorkspacePayload, ENCRYPTED_WORKSPACE_ENVELOPE_TYPE,
   decodeSwmSenderKeyMessage, SWM_SENDER_KEY_MESSAGE_TYPE,
-  getGenesisQuads, computeNetworkId, SYSTEM_CONTEXT_GRAPHS, DKG_ONTOLOGY,
+  DEFAULT_GENESIS_ID, getGenesisQuads, computeNetworkId, SYSTEM_CONTEXT_GRAPHS, DKG_ONTOLOGY,
   Logger, createOperationContext, sparqlString, escapeSparqlLiteral, isSafeIri, assertSafeIri,
   TrustLevel,
   TRUST_LEVEL_PREDICATE,
@@ -731,7 +731,7 @@ export class DKGAgent extends DKGAgentBase {
     const eventBus = new TypedEventBus();
     const keypair = wallet.keypair;
 
-    const genesisId = config.genesisId;
+    const genesisId = config.genesisId ?? DEFAULT_GENESIS_ID;
 
     // Load genesis knowledge into the store (idempotent)
     await DKGAgent.loadGenesis(store, genesisId);
@@ -740,7 +740,7 @@ export class DKGAgent extends DKGAgentBase {
       networkId: await computeNetworkId(genesisId),
       chainId: chain.chainId !== 'none' ? chain.chainId : undefined,
     };
-    const resolvedConfig: DKGAgentConfig = { ...config, networkIdentity };
+    const resolvedConfig: ResolvedDKGAgentConfig = { ...config, genesisId, networkIdentity };
 
     const port = config.listenPort ?? 0;
     const host = config.listenHost ?? '0.0.0.0';
@@ -1716,8 +1716,8 @@ export class DKGAgent extends DKGAgentBase {
       selfPeerId: this.peerId,
       ackCandidatePeerIds: this.config.ackCandidatePeerIds,
       preferredACKPeerIds: this.config.preferredACKPeerIds,
-      verifiedSameNetworkPeerIds: this.networkAdmission.enabled
-        ? this.networkAdmission.verifiedSameNetworkPeerIds()
+      verifiedSameNetworkPeerIds: this.networkAdmissionCoordinator.enabled
+        ? this.networkAdmissionCoordinator.verifiedSameNetworkPeerIds()
         : undefined,
       knownCorePeerIds: this.knownCorePeerIds,
       knownCorePeerIdsV2: this.knownCorePeerIdsV2,
@@ -1764,7 +1764,7 @@ export class DKGAgent extends DKGAgentBase {
       timeoutMs,
     });
     return async (peerId: string, protocol: string, data: Uint8Array) => {
-      if (!this.networkAdmission.isAcceptedPeer(peerId)) {
+      if (!this.networkAdmissionCoordinator.isAcceptedPeer(peerId)) {
         throw new Error(`peer ${peerId.slice(-8)} is not admitted for active-network ACK collection`);
       }
       return send(peerId, protocol, data);

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -731,14 +731,35 @@ export class DKGAgent extends DKGAgentBase {
     const eventBus = new TypedEventBus();
     const keypair = wallet.keypair;
 
-    const genesisId = config.genesisId ?? DEFAULT_GENESIS_ID;
+    const genesisId = config.genesisId ?? config.networkIdentity?.genesisId ?? DEFAULT_GENESIS_ID;
 
     // Load genesis knowledge into the store (idempotent)
     await DKGAgent.loadGenesis(store, genesisId);
-    const networkIdentity = config.networkIdentity ?? {
+    const computedNetworkId = await computeNetworkId(genesisId);
+    if (config.networkIdentity?.genesisId && config.networkIdentity.genesisId !== genesisId) {
+      throw new Error(
+        `DKGAgentConfig.networkIdentity.genesisId (${config.networkIdentity.genesisId}) ` +
+        `must match the selected genesisId (${genesisId})`,
+      );
+    }
+    if (config.networkIdentity?.networkId && config.networkIdentity.networkId !== computedNetworkId) {
+      throw new Error(
+        `DKGAgentConfig.networkIdentity.networkId (${config.networkIdentity.networkId}) ` +
+        `must match computeNetworkId(${genesisId}) (${computedNetworkId})`,
+      );
+    }
+    const adapterChainId = chain.chainId !== 'none' ? chain.chainId : undefined;
+    if (config.networkIdentity?.chainId && adapterChainId && config.networkIdentity.chainId !== adapterChainId) {
+      throw new Error(
+        `DKGAgentConfig.networkIdentity.chainId (${config.networkIdentity.chainId}) ` +
+        `must match the chain adapter id (${adapterChainId})`,
+      );
+    }
+    const networkIdentity = {
+      ...config.networkIdentity,
       genesisId,
-      networkId: await computeNetworkId(genesisId),
-      chainId: chain.chainId !== 'none' ? chain.chainId : undefined,
+      networkId: computedNetworkId,
+      chainId: adapterChainId ?? config.networkIdentity?.chainId,
     };
     const resolvedConfig: ResolvedDKGAgentConfig = { ...config, genesisId, networkIdentity };
 

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -36,6 +36,13 @@ export {
 } from './auth/agent-delegation.js';
 export { encrypt, decrypt, ed25519ToX25519Private, ed25519ToX25519Public, x25519SharedSecret } from './encryption.js';
 export { MessageHandler, type SkillRequest, type SkillResponse, type SkillHandler, type ChatHandler, type ChatAclCheck } from './messaging.js';
+export {
+  NetworkAdmissionService,
+  peerIdsFromMultiaddrs,
+  type NetworkAdmissionDirection,
+  type NetworkAdmissionOptions,
+  type NetworkAdmissionSnapshot,
+} from './p2p/network-admission.js';
 export { GossipPublishHandler, type GossipPublishHandlerCallbacks } from './gossip-publish-handler.js';
 export { FinalizationHandler } from './finalization-handler.js';
 export { buildEndorsementQuads, DKG_ENDORSES, DKG_ENDORSED_AT } from './endorse.js';

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -38,8 +38,9 @@ export { encrypt, decrypt, ed25519ToX25519Private, ed25519ToX25519Public, x25519
 export { MessageHandler, type SkillRequest, type SkillResponse, type SkillHandler, type ChatHandler, type ChatAclCheck } from './messaging.js';
 export {
   NetworkAdmissionService,
+  peerIdsFromMultiaddr,
   peerIdsFromMultiaddrs,
-  type NetworkAdmissionDirection,
+  targetPeerIdFromMultiaddr,
   type NetworkAdmissionOptions,
   type NetworkAdmissionSnapshot,
 } from './p2p/network-admission.js';

--- a/packages/agent/src/p2p/network-admission-coordinator.ts
+++ b/packages/agent/src/p2p/network-admission-coordinator.ts
@@ -1,0 +1,190 @@
+import { randomUUID } from 'node:crypto';
+import {
+  PROTOCOL_NETWORK_IDENTITY,
+  type DkgNetworkIdentity,
+  type OperationContext,
+} from '@origintrail-official/dkg-core';
+import { NetworkAdmissionService } from './network-admission.js';
+import {
+  makeNetworkIdentityRequest,
+  parseNetworkIdentityRequest,
+  signNetworkIdentityResponse,
+  verifyNetworkIdentityResponse,
+} from './network-identity-proof.js';
+
+export interface NetworkAdmissionConnection {
+  remotePeer: { toString(): string };
+  close(): Promise<void> | void;
+  abort(error?: Error): void;
+}
+
+export interface NetworkAdmissionCoordinatorOptions {
+  admission: NetworkAdmissionService;
+  identity?: DkgNetworkIdentity;
+  selfPeerId: string;
+  sign: (payload: Uint8Array) => Promise<Uint8Array>;
+  sendIdentityProbe: (
+    peerId: string,
+    data: Uint8Array,
+    options: { timeoutMs: number },
+  ) => Promise<Uint8Array>;
+  getConnections: () => Iterable<NetworkAdmissionConnection>;
+  deletePeerFromPeerStore: (peerId: string) => Promise<void>;
+  cleanupRejectedPeerState?: (peerId: string) => void;
+  log?: {
+    info(ctx: OperationContext, message: string): void;
+    warn(ctx: OperationContext, message: string): void;
+  };
+  probeTimeoutMs?: number;
+}
+
+export interface NetworkIdentityProtocolRegistrar {
+  register(protocolId: string, handler: (data: Uint8Array) => Promise<Uint8Array>): void;
+}
+
+export class NetworkAdmissionCoordinator {
+  private readonly admission: NetworkAdmissionService;
+  private readonly identity?: DkgNetworkIdentity;
+  private readonly selfPeerId: string;
+  private readonly sign: (payload: Uint8Array) => Promise<Uint8Array>;
+  private readonly sendIdentityProbe: NetworkAdmissionCoordinatorOptions['sendIdentityProbe'];
+  private readonly getConnections: () => Iterable<NetworkAdmissionConnection>;
+  private readonly deletePeerFromPeerStore: (peerId: string) => Promise<void>;
+  private readonly cleanupRejectedPeerState?: (peerId: string) => void;
+  private readonly log?: NetworkAdmissionCoordinatorOptions['log'];
+  private readonly probeTimeoutMs: number;
+  private readonly inFlight = new Map<string, Promise<boolean>>();
+
+  constructor(options: NetworkAdmissionCoordinatorOptions) {
+    this.admission = options.admission;
+    this.identity = options.identity;
+    this.selfPeerId = options.selfPeerId;
+    this.sign = options.sign;
+    this.sendIdentityProbe = options.sendIdentityProbe;
+    this.getConnections = options.getConnections;
+    this.deletePeerFromPeerStore = options.deletePeerFromPeerStore;
+    this.cleanupRejectedPeerState = options.cleanupRejectedPeerState;
+    this.log = options.log;
+    this.probeTimeoutMs = options.probeTimeoutMs ?? 3_000;
+  }
+
+  get enabled(): boolean {
+    return Boolean(this.identity?.networkId);
+  }
+
+  isAcceptedPeer(peerId: string): boolean {
+    return this.admission.isAcceptedPeer(peerId);
+  }
+
+  verifiedSameNetworkPeerIds(): ReadonlySet<string> {
+    return this.admission.verifiedSameNetworkPeerIds();
+  }
+
+  filterAcceptedPeerIds(peerIds: Iterable<string>): string[] {
+    return [...peerIds].filter((peerId) => this.isAcceptedPeer(peerId));
+  }
+
+  filterAcceptedPeers<T extends { toString(): string }>(peers: Iterable<T>): T[] {
+    return [...peers].filter((peer) => this.isAcceptedPeer(peer.toString()));
+  }
+
+  registerIdentityProtocol(router: NetworkIdentityProtocolRegistrar): void {
+    router.register(PROTOCOL_NETWORK_IDENTITY, async (data) => {
+      if (!this.identity?.networkId) {
+        throw new Error('network identity is not configured');
+      }
+      const request = parseNetworkIdentityRequest(data);
+      const response = await signNetworkIdentityResponse({
+        request,
+        identity: this.identity,
+        responderPeerId: this.selfPeerId,
+        sign: this.sign,
+      });
+      return new TextEncoder().encode(JSON.stringify(response));
+    });
+  }
+
+  async ensureAdmitted(remotePeer: string, ctx: OperationContext): Promise<boolean> {
+    if (!this.identity?.networkId) return true;
+    if (this.admission.isAcceptedPeer(remotePeer)) return true;
+
+    const existing = this.inFlight.get(remotePeer);
+    if (existing) return existing;
+
+    const promise = this.probePeer(remotePeer, ctx)
+      .finally(() => {
+        this.inFlight.delete(remotePeer);
+      });
+    this.inFlight.set(remotePeer, promise);
+    return promise;
+  }
+
+  private async probePeer(remotePeer: string, ctx: OperationContext): Promise<boolean> {
+    const identity = this.identity;
+    if (!identity?.networkId) return true;
+
+    try {
+      const nonce = randomUUID();
+      const request = makeNetworkIdentityRequest({
+        nonce,
+        requesterPeerId: this.selfPeerId,
+        identity,
+      });
+      const response = await this.sendIdentityProbe(
+        remotePeer,
+        new TextEncoder().encode(JSON.stringify(request)),
+        { timeoutMs: this.probeTimeoutMs },
+      );
+      const raw = new TextDecoder().decode(response);
+      const claimed = JSON.parse(raw) as unknown;
+      const verdict = await verifyNetworkIdentityResponse({
+        response: claimed,
+        remotePeerId: remotePeer,
+        localIdentity: identity,
+        nonce,
+        requesterPeerId: this.selfPeerId,
+      });
+      if (verdict.ok) {
+        this.admission.markVerifiedSameNetwork(remotePeer);
+        return true;
+      }
+      await this.rejectPeer(remotePeer, ctx, `network identity proof rejected: ${verdict.reason ?? 'unknown reason'}`);
+      return false;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      await this.rejectPeer(remotePeer, ctx, `network identity probe failed: ${message}`);
+      return false;
+    }
+  }
+
+  private async rejectPeer(remotePeer: string, ctx: OperationContext, reason: string): Promise<void> {
+    this.admission.quarantinePeer(remotePeer);
+    this.cleanupRejectedPeerState?.(remotePeer);
+    await this.disconnectAndForgetPeer(remotePeer, ctx);
+    this.log?.warn(ctx, `Rejected peer ${remotePeer.slice(-8)}: ${reason}`);
+  }
+
+  private async disconnectAndForgetPeer(remotePeer: string, ctx: OperationContext): Promise<void> {
+    const shortPeer = remotePeer.slice(-8);
+    const connections = [...this.getConnections()]
+      .filter((conn) => conn.remotePeer.toString() === remotePeer);
+    await Promise.all(connections.map(async (conn) => {
+      try {
+        await conn.close();
+      } catch (err) {
+        try {
+          conn.abort(err instanceof Error ? err : new Error(String(err)));
+        } catch {
+          // Best-effort cleanup only; the admission registry already blocks app work.
+        }
+      }
+    }));
+
+    try {
+      await this.deletePeerFromPeerStore(remotePeer);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.log?.info(ctx, `Rejected peer ${shortPeer}: peerstore cleanup skipped/failed: ${message}`);
+    }
+  }
+}

--- a/packages/agent/src/p2p/network-admission-coordinator.ts
+++ b/packages/agent/src/p2p/network-admission-coordinator.ts
@@ -42,6 +42,15 @@ export interface NetworkIdentityProtocolRegistrar {
   register(protocolId: string, handler: (data: Uint8Array) => Promise<Uint8Array>): void;
 }
 
+export class NetworkAdmissionProbeError extends Error {
+  readonly code = 'NETWORK_ADMISSION_PROBE_FAILED';
+
+  constructor(peerId: string, reason: string) {
+    super(`Network identity probe failed for ${peerId}: ${reason}`);
+    this.name = 'NetworkAdmissionProbeError';
+  }
+}
+
 export class NetworkAdmissionCoordinator {
   private readonly admission: NetworkAdmissionService;
   private readonly identity?: DkgNetworkIdentity;
@@ -123,38 +132,48 @@ export class NetworkAdmissionCoordinator {
     const identity = this.identity;
     if (!identity?.networkId) return true;
 
+    const nonce = randomUUID();
+    const request = makeNetworkIdentityRequest({
+      nonce,
+      requesterPeerId: this.selfPeerId,
+      identity,
+    });
+
+    let response: Uint8Array;
     try {
-      const nonce = randomUUID();
-      const request = makeNetworkIdentityRequest({
-        nonce,
-        requesterPeerId: this.selfPeerId,
-        identity,
-      });
-      const response = await this.sendIdentityProbe(
+      response = await this.sendIdentityProbe(
         remotePeer,
         new TextEncoder().encode(JSON.stringify(request)),
         { timeoutMs: this.probeTimeoutMs },
       );
-      const raw = new TextDecoder().decode(response);
-      const claimed = JSON.parse(raw) as unknown;
-      const verdict = await verifyNetworkIdentityResponse({
-        response: claimed,
-        remotePeerId: remotePeer,
-        localIdentity: identity,
-        nonce,
-        requesterPeerId: this.selfPeerId,
-      });
-      if (verdict.ok) {
-        this.admission.markVerifiedSameNetwork(remotePeer);
-        return true;
-      }
-      await this.rejectPeer(remotePeer, ctx, `network identity proof rejected: ${verdict.reason ?? 'unknown reason'}`);
-      return false;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      await this.rejectPeer(remotePeer, ctx, `network identity probe failed: ${message}`);
-      return false;
+      this.log?.warn(ctx, `Network identity probe for ${remotePeer.slice(-8)} failed retryably: ${message}`);
+      throw new NetworkAdmissionProbeError(remotePeer, message);
     }
+
+    let claimed: unknown;
+    try {
+      claimed = JSON.parse(new TextDecoder().decode(response)) as unknown;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.log?.warn(ctx, `Network identity probe for ${remotePeer.slice(-8)} returned unreadable response: ${message}`);
+      throw new NetworkAdmissionProbeError(remotePeer, message);
+    }
+
+    const verdict = await verifyNetworkIdentityResponse({
+      response: claimed,
+      remotePeerId: remotePeer,
+      localIdentity: identity,
+      nonce,
+      requesterPeerId: this.selfPeerId,
+    });
+    if (verdict.ok) {
+      this.admission.markVerifiedSameNetwork(remotePeer);
+      return true;
+    }
+    await this.rejectPeer(remotePeer, ctx, `network identity proof rejected: ${verdict.reason ?? 'unknown reason'}`);
+    return false;
   }
 
   private async rejectPeer(remotePeer: string, ctx: OperationContext, reason: string): Promise<void> {

--- a/packages/agent/src/p2p/network-admission-coordinator.ts
+++ b/packages/agent/src/p2p/network-admission-coordinator.ts
@@ -26,7 +26,7 @@ export interface NetworkAdmissionCoordinatorOptions {
   sendIdentityProbe: (
     peerId: string,
     data: Uint8Array,
-    options: { timeoutMs: number },
+    options: { timeoutMs: number; signal?: AbortSignal },
   ) => Promise<Uint8Array>;
   getConnections: () => Iterable<NetworkAdmissionConnection>;
   deletePeerFromPeerStore: (peerId: string) => Promise<void>;
@@ -36,6 +36,11 @@ export interface NetworkAdmissionCoordinatorOptions {
     warn(ctx: OperationContext, message: string): void;
   };
   probeTimeoutMs?: number;
+}
+
+export interface NetworkAdmissionAttemptOptions {
+  signal?: AbortSignal;
+  timeoutMs?: number;
 }
 
 export interface NetworkIdentityProtocolRegistrar {
@@ -48,6 +53,15 @@ export class NetworkAdmissionProbeError extends Error {
   constructor(peerId: string, reason: string) {
     super(`Network identity probe failed for ${peerId}: ${reason}`);
     this.name = 'NetworkAdmissionProbeError';
+  }
+}
+
+export class NetworkAdmissionRejectedError extends Error {
+  readonly code = 'NETWORK_ADMISSION_REJECTED';
+
+  constructor(peerId: string) {
+    super(`Peer ${peerId} is not admitted for the active DKG network`);
+    this.name = 'NetworkAdmissionRejectedError';
   }
 }
 
@@ -82,7 +96,13 @@ export class NetworkAdmissionCoordinator {
   }
 
   isAcceptedPeer(peerId: string): boolean {
+    if (!this.identity?.networkId) return true;
     return this.admission.isAcceptedPeer(peerId);
+  }
+
+  isRejectedPeer(peerId: string): boolean {
+    if (!this.identity?.networkId) return false;
+    return this.admission.isRejectedPeer(peerId);
   }
 
   verifiedSameNetworkPeerIds(): ReadonlySet<string> {
@@ -113,22 +133,30 @@ export class NetworkAdmissionCoordinator {
     });
   }
 
-  async ensureAdmitted(remotePeer: string, ctx: OperationContext): Promise<boolean> {
+  async ensureAdmitted(
+    remotePeer: string,
+    ctx: OperationContext,
+    options: NetworkAdmissionAttemptOptions = {},
+  ): Promise<boolean> {
     if (!this.identity?.networkId) return true;
     if (this.admission.isAcceptedPeer(remotePeer)) return true;
 
     const existing = this.inFlight.get(remotePeer);
-    if (existing) return existing;
+    if (existing) return this.raceAdmissionSignal(existing, options.signal);
 
-    const promise = this.probePeer(remotePeer, ctx)
+    const promise = this.probePeer(remotePeer, ctx, options)
       .finally(() => {
         this.inFlight.delete(remotePeer);
       });
     this.inFlight.set(remotePeer, promise);
-    return promise;
+    return this.raceAdmissionSignal(promise, options.signal);
   }
 
-  private async probePeer(remotePeer: string, ctx: OperationContext): Promise<boolean> {
+  private async probePeer(
+    remotePeer: string,
+    ctx: OperationContext,
+    options: NetworkAdmissionAttemptOptions,
+  ): Promise<boolean> {
     const identity = this.identity;
     if (!identity?.networkId) return true;
 
@@ -140,11 +168,15 @@ export class NetworkAdmissionCoordinator {
     });
 
     let response: Uint8Array;
+    const timeoutMs = Math.min(this.probeTimeoutMs, options.timeoutMs ?? this.probeTimeoutMs);
+    if (options.signal?.aborted) {
+      throw abortErrorFromSignal(options.signal.reason);
+    }
     try {
       response = await this.sendIdentityProbe(
         remotePeer,
         new TextEncoder().encode(JSON.stringify(request)),
-        { timeoutMs: this.probeTimeoutMs },
+        { timeoutMs, signal: options.signal },
       );
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
@@ -174,6 +206,30 @@ export class NetworkAdmissionCoordinator {
     }
     await this.rejectPeer(remotePeer, ctx, `network identity proof rejected: ${verdict.reason ?? 'unknown reason'}`);
     return false;
+  }
+
+  private raceAdmissionSignal<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+    if (!signal) return promise;
+    if (signal.aborted) return Promise.reject(abortErrorFromSignal(signal.reason));
+
+    return new Promise<T>((resolve, reject) => {
+      const cleanup = () => signal.removeEventListener('abort', onAbort);
+      const onAbort = () => {
+        cleanup();
+        reject(abortErrorFromSignal(signal.reason));
+      };
+      signal.addEventListener('abort', onAbort, { once: true });
+      promise.then(
+        (value) => {
+          cleanup();
+          resolve(value);
+        },
+        (err) => {
+          cleanup();
+          reject(err);
+        },
+      );
+    });
   }
 
   private async rejectPeer(remotePeer: string, ctx: OperationContext, reason: string): Promise<void> {
@@ -206,4 +262,11 @@ export class NetworkAdmissionCoordinator {
       this.log?.info(ctx, `Rejected peer ${shortPeer}: peerstore cleanup skipped/failed: ${message}`);
     }
   }
+}
+
+function abortErrorFromSignal(reason: unknown): Error {
+  if (reason instanceof Error) return reason;
+  const error = new Error('Network admission aborted');
+  error.name = 'AbortError';
+  return error;
 }

--- a/packages/agent/src/p2p/network-admission.ts
+++ b/packages/agent/src/p2p/network-admission.ts
@@ -1,5 +1,3 @@
-export type NetworkAdmissionDirection = 'inbound' | 'outbound' | 'gossip';
-
 export interface NetworkAdmissionOptions {
   networkId?: string;
   selfPeerId?: string;
@@ -85,11 +83,7 @@ export class NetworkAdmissionService {
     this.verifiedPeerIds.delete(normalized);
   }
 
-  isPeerAccepted(
-    peerId: string,
-    _protocolOrTopic: string,
-    _direction: NetworkAdmissionDirection,
-  ): boolean {
+  isAcceptedPeer(peerId: string): boolean {
     if (!this.enabled) return true;
     const normalized = normalizePeerId(peerId);
     if (!normalized) return false;

--- a/packages/agent/src/p2p/network-admission.ts
+++ b/packages/agent/src/p2p/network-admission.ts
@@ -1,12 +1,10 @@
 export interface NetworkAdmissionOptions {
   networkId?: string;
   selfPeerId?: string;
-  trustedPeerIds?: Iterable<string>;
 }
 
 export interface NetworkAdmissionSnapshot {
   enabled: boolean;
-  trustedPeerIds: string[];
   verifiedPeerIds: string[];
   quarantinedPeerIds: string[];
 }
@@ -47,26 +45,16 @@ export function peerIdsFromMultiaddrs(addrs: readonly string[] | undefined): Set
 export class NetworkAdmissionService {
   private readonly networkId?: string;
   private readonly selfPeerId?: string;
-  private readonly trustedPeerIds = new Set<string>();
   private readonly verifiedPeerIds = new Set<string>();
   private readonly quarantinedPeerIds = new Set<string>();
 
   constructor(options: NetworkAdmissionOptions = {}) {
     this.networkId = options.networkId;
     this.selfPeerId = options.selfPeerId;
-    for (const peerId of options.trustedPeerIds ?? []) {
-      this.trustPeer(peerId);
-    }
   }
 
   get enabled(): boolean {
     return Boolean(this.networkId);
-  }
-
-  trustPeer(peerId: string): void {
-    const normalized = normalizePeerId(peerId);
-    if (!normalized) return;
-    this.trustedPeerIds.add(normalized);
   }
 
   markVerifiedSameNetwork(peerId: string): void {
@@ -103,7 +91,6 @@ export class NetworkAdmissionService {
   snapshot(): NetworkAdmissionSnapshot {
     return {
       enabled: this.enabled,
-      trustedPeerIds: [...this.trustedPeerIds].sort(),
       verifiedPeerIds: [...this.verifiedPeerIds].sort(),
       quarantinedPeerIds: [...this.quarantinedPeerIds].sort(),
     };

--- a/packages/agent/src/p2p/network-admission.ts
+++ b/packages/agent/src/p2p/network-admission.ts
@@ -13,14 +13,24 @@ export interface NetworkAdmissionSnapshot {
   quarantinedPeerIds: string[];
 }
 
+export function peerIdsFromMultiaddr(addr: string): string[] {
+  const peerIds: string[] = [];
+  const matches = addr.matchAll(/\/p2p\/([^/]+)/g);
+  for (const match of matches) {
+    const peerId = match[1]?.trim();
+    if (peerId) peerIds.push(peerId);
+  }
+  return peerIds;
+}
+
+export function targetPeerIdFromMultiaddr(addr: string): string | undefined {
+  return peerIdsFromMultiaddr(addr).at(-1);
+}
+
 export function peerIdsFromMultiaddrs(addrs: readonly string[] | undefined): Set<string> {
   const peerIds = new Set<string>();
   for (const addr of addrs ?? []) {
-    const matches = addr.matchAll(/\/p2p\/([^/]+)/g);
-    for (const match of matches) {
-      const peerId = match[1]?.trim();
-      if (peerId) peerIds.add(peerId);
-    }
+    for (const peerId of peerIdsFromMultiaddr(addr)) peerIds.add(peerId);
   }
   return peerIds;
 }

--- a/packages/agent/src/p2p/network-admission.ts
+++ b/packages/agent/src/p2p/network-admission.ts
@@ -80,6 +80,13 @@ export class NetworkAdmissionService {
     return this.verifiedPeerIds.has(normalized);
   }
 
+  isRejectedPeer(peerId: string): boolean {
+    if (!this.enabled) return false;
+    const normalized = normalizePeerId(peerId);
+    if (!normalized) return true;
+    return this.quarantinedPeerIds.has(normalized);
+  }
+
   verifiedSameNetworkPeerIds(): ReadonlySet<string> {
     if (!this.enabled) return new Set();
     return new Set(

--- a/packages/agent/src/p2p/network-admission.ts
+++ b/packages/agent/src/p2p/network-admission.ts
@@ -1,0 +1,112 @@
+export type NetworkAdmissionDirection = 'inbound' | 'outbound' | 'gossip';
+
+export interface NetworkAdmissionOptions {
+  networkId?: string;
+  selfPeerId?: string;
+  trustedPeerIds?: Iterable<string>;
+}
+
+export interface NetworkAdmissionSnapshot {
+  enabled: boolean;
+  trustedPeerIds: string[];
+  verifiedPeerIds: string[];
+  quarantinedPeerIds: string[];
+}
+
+export function peerIdsFromMultiaddrs(addrs: readonly string[] | undefined): Set<string> {
+  const peerIds = new Set<string>();
+  for (const addr of addrs ?? []) {
+    const matches = addr.matchAll(/\/p2p\/([^/]+)/g);
+    for (const match of matches) {
+      const peerId = match[1]?.trim();
+      if (peerId) peerIds.add(peerId);
+    }
+  }
+  return peerIds;
+}
+
+/**
+ * Process-local admission registry for active-network peers.
+ *
+ * The core overlay isolation keeps accidental cross-network peers out of the
+ * normal DHT/GossipSub path. This registry is the application boundary: it
+ * admits only peers promoted by the signed same-network verifier and self.
+ * Configured relays/bootstrap peers are retained as transport/probe seeds, but
+ * do not become app/ACK eligible until verification succeeds. Unknown peers
+ * fail closed when `networkId` is known; legacy/in-process tests without
+ * network identity keep the previous allow-all behavior.
+ */
+export class NetworkAdmissionService {
+  private readonly networkId?: string;
+  private readonly selfPeerId?: string;
+  private readonly trustedPeerIds = new Set<string>();
+  private readonly verifiedPeerIds = new Set<string>();
+  private readonly quarantinedPeerIds = new Set<string>();
+
+  constructor(options: NetworkAdmissionOptions = {}) {
+    this.networkId = options.networkId;
+    this.selfPeerId = options.selfPeerId;
+    for (const peerId of options.trustedPeerIds ?? []) {
+      this.trustPeer(peerId);
+    }
+  }
+
+  get enabled(): boolean {
+    return Boolean(this.networkId);
+  }
+
+  trustPeer(peerId: string): void {
+    const normalized = normalizePeerId(peerId);
+    if (!normalized) return;
+    this.trustedPeerIds.add(normalized);
+  }
+
+  markVerifiedSameNetwork(peerId: string): void {
+    const normalized = normalizePeerId(peerId);
+    if (!normalized) return;
+    this.verifiedPeerIds.add(normalized);
+    this.quarantinedPeerIds.delete(normalized);
+  }
+
+  quarantinePeer(peerId: string): void {
+    const normalized = normalizePeerId(peerId);
+    if (!normalized) return;
+    this.quarantinedPeerIds.add(normalized);
+    this.verifiedPeerIds.delete(normalized);
+  }
+
+  isPeerAccepted(
+    peerId: string,
+    _protocolOrTopic: string,
+    _direction: NetworkAdmissionDirection,
+  ): boolean {
+    if (!this.enabled) return true;
+    const normalized = normalizePeerId(peerId);
+    if (!normalized) return false;
+    if (normalized === this.selfPeerId) return true;
+    if (this.quarantinedPeerIds.has(normalized)) return false;
+    return this.verifiedPeerIds.has(normalized);
+  }
+
+  verifiedSameNetworkPeerIds(): ReadonlySet<string> {
+    if (!this.enabled) return new Set();
+    return new Set(
+      [...this.verifiedPeerIds]
+        .filter((peerId) => !this.quarantinedPeerIds.has(peerId)),
+    );
+  }
+
+  snapshot(): NetworkAdmissionSnapshot {
+    return {
+      enabled: this.enabled,
+      trustedPeerIds: [...this.trustedPeerIds].sort(),
+      verifiedPeerIds: [...this.verifiedPeerIds].sort(),
+      quarantinedPeerIds: [...this.quarantinedPeerIds].sort(),
+    };
+  }
+}
+
+function normalizePeerId(peerId: string): string | null {
+  const normalized = peerId.trim();
+  return normalized.length > 0 ? normalized : null;
+}

--- a/packages/agent/src/p2p/network-identity-proof.ts
+++ b/packages/agent/src/p2p/network-identity-proof.ts
@@ -121,11 +121,34 @@ export function parseNetworkIdentityRequest(data: Uint8Array): NetworkIdentityRe
   };
 }
 
+export function parseNetworkIdentityResponse(value: unknown): NetworkIdentityResponse {
+  const response = value as Partial<NetworkIdentityResponse>;
+  if (response.version !== NETWORK_IDENTITY_PROOF_VERSION) throw new Error('unsupported proof version');
+  if (!isNonEmptyString(response.peerId)) throw new Error('missing peer id');
+  if (!isNonEmptyString(response.networkId)) throw new Error('missing network id');
+  if (response.proofKind !== NETWORK_IDENTITY_PROOF_KIND) throw new Error('unsupported proof kind');
+  if (!isNonEmptyString(response.signature)) throw new Error('missing signature');
+  return {
+    version: NETWORK_IDENTITY_PROOF_VERSION,
+    peerId: response.peerId,
+    networkId: response.networkId,
+    genesisId: isNonEmptyString(response.genesisId) ? response.genesisId : undefined,
+    chainId: isNonEmptyString(response.chainId) ? response.chainId : undefined,
+    networkConfigName: isNonEmptyString(response.networkConfigName) ? response.networkConfigName : undefined,
+    proofKind: NETWORK_IDENTITY_PROOF_KIND,
+    signature: response.signature,
+  };
+}
+
 export async function verifyNetworkIdentityResponse(
   input: VerifyNetworkIdentityResponseInput,
 ): Promise<VerifyNetworkIdentityResponseResult> {
-  const response = input.response as Partial<NetworkIdentityResponse>;
-  if (response.version !== NETWORK_IDENTITY_PROOF_VERSION) return { ok: false, reason: 'unsupported proof version' };
+  let response: NetworkIdentityResponse;
+  try {
+    response = parseNetworkIdentityResponse(input.response);
+  } catch (err) {
+    return { ok: false, reason: err instanceof Error ? err.message : String(err) };
+  }
   if (response.peerId !== input.remotePeerId) return { ok: false, reason: 'peer id mismatch' };
   if (response.networkId !== input.localIdentity.networkId) return { ok: false, reason: 'network id mismatch' };
   if (input.localIdentity.genesisId && response.genesisId !== input.localIdentity.genesisId) {
@@ -134,9 +157,6 @@ export async function verifyNetworkIdentityResponse(
   if (input.localIdentity.chainId && response.chainId !== input.localIdentity.chainId) {
     return { ok: false, reason: 'chain id mismatch' };
   }
-  if (response.proofKind !== NETWORK_IDENTITY_PROOF_KIND) return { ok: false, reason: 'unsupported proof kind' };
-  if (!isNonEmptyString(response.signature)) return { ok: false, reason: 'missing signature' };
-
   let publicKey: Uint8Array | undefined;
   try {
     const peerId = peerIdFromString(input.remotePeerId);

--- a/packages/agent/src/p2p/network-identity-proof.ts
+++ b/packages/agent/src/p2p/network-identity-proof.ts
@@ -1,0 +1,164 @@
+import { peerIdFromString } from '@libp2p/peer-id';
+import {
+  ed25519Verify,
+  PROTOCOL_NETWORK_IDENTITY,
+  type DkgNetworkIdentity,
+} from '@origintrail-official/dkg-core';
+
+export const NETWORK_IDENTITY_PROOF_VERSION = 1;
+export const NETWORK_IDENTITY_PROOF_KIND = 'ed25519-peer-id';
+
+export interface NetworkIdentityRequest {
+  version: typeof NETWORK_IDENTITY_PROOF_VERSION;
+  nonce: string;
+  requesterPeerId: string;
+  networkId: string;
+  genesisId?: string;
+  chainId?: string;
+}
+
+export interface NetworkIdentityResponse {
+  version: typeof NETWORK_IDENTITY_PROOF_VERSION;
+  peerId: string;
+  networkId: string;
+  genesisId?: string;
+  chainId?: string;
+  networkConfigName?: string;
+  proofKind: typeof NETWORK_IDENTITY_PROOF_KIND;
+  signature: string;
+}
+
+export interface VerifyNetworkIdentityResponseInput {
+  response: unknown;
+  remotePeerId: string;
+  localIdentity: DkgNetworkIdentity;
+  nonce: string;
+  requesterPeerId: string;
+}
+
+export interface VerifyNetworkIdentityResponseResult {
+  ok: boolean;
+  reason?: string;
+}
+
+export function makeNetworkIdentityRequest(input: {
+  nonce: string;
+  requesterPeerId: string;
+  identity: DkgNetworkIdentity;
+}): NetworkIdentityRequest {
+  return {
+    version: NETWORK_IDENTITY_PROOF_VERSION,
+    nonce: input.nonce,
+    requesterPeerId: input.requesterPeerId,
+    networkId: input.identity.networkId,
+    genesisId: input.identity.genesisId,
+    chainId: input.identity.chainId,
+  };
+}
+
+export function networkIdentityProofPayload(input: {
+  nonce: string;
+  requesterPeerId: string;
+  responderPeerId: string;
+  networkId: string;
+  genesisId?: string;
+  chainId?: string;
+}): Uint8Array {
+  return new TextEncoder().encode(JSON.stringify({
+    version: NETWORK_IDENTITY_PROOF_VERSION,
+    protocol: PROTOCOL_NETWORK_IDENTITY,
+    nonce: input.nonce,
+    requesterPeerId: input.requesterPeerId,
+    responderPeerId: input.responderPeerId,
+    networkId: input.networkId,
+    genesisId: input.genesisId ?? null,
+    chainId: input.chainId ?? null,
+  }));
+}
+
+export async function signNetworkIdentityResponse(input: {
+  request: NetworkIdentityRequest;
+  identity: DkgNetworkIdentity;
+  responderPeerId: string;
+  sign: (payload: Uint8Array) => Promise<Uint8Array>;
+}): Promise<NetworkIdentityResponse> {
+  const payload = networkIdentityProofPayload({
+    nonce: input.request.nonce,
+    requesterPeerId: input.request.requesterPeerId,
+    responderPeerId: input.responderPeerId,
+    networkId: input.identity.networkId,
+    genesisId: input.identity.genesisId,
+    chainId: input.identity.chainId,
+  });
+  const signature = await input.sign(payload);
+  return {
+    version: NETWORK_IDENTITY_PROOF_VERSION,
+    peerId: input.responderPeerId,
+    networkId: input.identity.networkId,
+    genesisId: input.identity.genesisId,
+    chainId: input.identity.chainId,
+    networkConfigName: input.identity.networkConfigName,
+    proofKind: NETWORK_IDENTITY_PROOF_KIND,
+    signature: Buffer.from(signature).toString('base64'),
+  };
+}
+
+export function parseNetworkIdentityRequest(data: Uint8Array): NetworkIdentityRequest {
+  const value = JSON.parse(new TextDecoder().decode(data)) as Partial<NetworkIdentityRequest>;
+  if (value.version !== NETWORK_IDENTITY_PROOF_VERSION) {
+    throw new Error('unsupported network identity request version');
+  }
+  if (!isNonEmptyString(value.nonce)) throw new Error('missing network identity nonce');
+  if (!isNonEmptyString(value.requesterPeerId)) throw new Error('missing network identity requester peer id');
+  if (!isNonEmptyString(value.networkId)) throw new Error('missing network identity network id');
+  return {
+    version: NETWORK_IDENTITY_PROOF_VERSION,
+    nonce: value.nonce,
+    requesterPeerId: value.requesterPeerId,
+    networkId: value.networkId,
+    genesisId: isNonEmptyString(value.genesisId) ? value.genesisId : undefined,
+    chainId: isNonEmptyString(value.chainId) ? value.chainId : undefined,
+  };
+}
+
+export async function verifyNetworkIdentityResponse(
+  input: VerifyNetworkIdentityResponseInput,
+): Promise<VerifyNetworkIdentityResponseResult> {
+  const response = input.response as Partial<NetworkIdentityResponse>;
+  if (response.version !== NETWORK_IDENTITY_PROOF_VERSION) return { ok: false, reason: 'unsupported proof version' };
+  if (response.peerId !== input.remotePeerId) return { ok: false, reason: 'peer id mismatch' };
+  if (response.networkId !== input.localIdentity.networkId) return { ok: false, reason: 'network id mismatch' };
+  if (input.localIdentity.genesisId && response.genesisId !== input.localIdentity.genesisId) {
+    return { ok: false, reason: 'genesis id mismatch' };
+  }
+  if (input.localIdentity.chainId && response.chainId !== input.localIdentity.chainId) {
+    return { ok: false, reason: 'chain id mismatch' };
+  }
+  if (response.proofKind !== NETWORK_IDENTITY_PROOF_KIND) return { ok: false, reason: 'unsupported proof kind' };
+  if (!isNonEmptyString(response.signature)) return { ok: false, reason: 'missing signature' };
+
+  let publicKey: Uint8Array | undefined;
+  try {
+    const peerId = peerIdFromString(input.remotePeerId);
+    publicKey = peerId.publicKey?.raw;
+  } catch (err) {
+    return { ok: false, reason: `invalid remote peer id: ${err instanceof Error ? err.message : String(err)}` };
+  }
+  if (!publicKey) return { ok: false, reason: 'remote peer id has no embedded public key' };
+
+  const payload = networkIdentityProofPayload({
+    nonce: input.nonce,
+    requesterPeerId: input.requesterPeerId,
+    responderPeerId: input.remotePeerId,
+    networkId: input.localIdentity.networkId,
+    genesisId: input.localIdentity.genesisId,
+    chainId: input.localIdentity.chainId,
+  });
+  const signature = Buffer.from(response.signature, 'base64');
+  const valid = await ed25519Verify(signature, payload, publicKey);
+  return valid ? { ok: true } : { ok: false, reason: 'invalid signature' };
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}

--- a/packages/agent/src/p2p/network-identity-proof.ts
+++ b/packages/agent/src/p2p/network-identity-proof.ts
@@ -170,9 +170,9 @@ export async function verifyNetworkIdentityResponse(
     nonce: input.nonce,
     requesterPeerId: input.requesterPeerId,
     responderPeerId: input.remotePeerId,
-    networkId: input.localIdentity.networkId,
-    genesisId: input.localIdentity.genesisId,
-    chainId: input.localIdentity.chainId,
+    networkId: response.networkId,
+    genesisId: response.genesisId,
+    chainId: response.chainId,
   });
   const signature = Buffer.from(response.signature, 'base64');
   const valid = await ed25519Verify(signature, payload, publicKey);

--- a/packages/agent/src/p2p/peer-connect.ts
+++ b/packages/agent/src/p2p/peer-connect.ts
@@ -106,7 +106,7 @@ export async function primeCatchupConnections(
   libp2p: Libp2pLike,
   discovery: DiscoveryClient,
   selfPeerId: string,
-  verifyPeerAdmission: (peerId: string) => boolean | Promise<boolean> = () => true,
+  afterDialAdmissionProbe: (peerId: string) => void | Promise<void> = () => undefined,
 ): Promise<void> {
   try {
     const agents = await discovery.findAgents();
@@ -124,7 +124,7 @@ export async function primeCatchupConnections(
         const pid = peerIdFromString(agent.peerId);
         await libp2p.peerStore.merge(pid, { multiaddrs: [circuitAddr] });
         await libp2p.dial(pid);
-        await verifyPeerAdmission(agent.peerId);
+        await afterDialAdmissionProbe(agent.peerId);
       } catch {
         // Non-fatal — peer may be unreachable.
       }

--- a/packages/agent/src/p2p/peer-connect.ts
+++ b/packages/agent/src/p2p/peer-connect.ts
@@ -106,6 +106,7 @@ export async function primeCatchupConnections(
   libp2p: Libp2pLike,
   discovery: DiscoveryClient,
   selfPeerId: string,
+  isPeerEligible: (peerId: string) => boolean = () => true,
 ): Promise<void> {
   try {
     const agents = await discovery.findAgents();
@@ -113,6 +114,7 @@ export async function primeCatchupConnections(
     const { multiaddr } = await import('@multiformats/multiaddr');
     for (const agent of agents) {
       if (agent.peerId === selfPeerId) continue;
+      if (!isPeerEligible(agent.peerId)) continue;
       const existingConns = libp2p.getConnections()
         .filter((conn) => conn.remotePeer.toString() === agent.peerId);
       if (existingConns.length > 0) continue;

--- a/packages/agent/src/p2p/peer-connect.ts
+++ b/packages/agent/src/p2p/peer-connect.ts
@@ -106,7 +106,7 @@ export async function primeCatchupConnections(
   libp2p: Libp2pLike,
   discovery: DiscoveryClient,
   selfPeerId: string,
-  isPeerEligible: (peerId: string) => boolean = () => true,
+  verifyPeerAdmission: (peerId: string) => boolean | Promise<boolean> = () => true,
 ): Promise<void> {
   try {
     const agents = await discovery.findAgents();
@@ -114,7 +114,6 @@ export async function primeCatchupConnections(
     const { multiaddr } = await import('@multiformats/multiaddr');
     for (const agent of agents) {
       if (agent.peerId === selfPeerId) continue;
-      if (!isPeerEligible(agent.peerId)) continue;
       const existingConns = libp2p.getConnections()
         .filter((conn) => conn.remotePeer.toString() === agent.peerId);
       if (existingConns.length > 0) continue;
@@ -125,6 +124,7 @@ export async function primeCatchupConnections(
         const pid = peerIdFromString(agent.peerId);
         await libp2p.peerStore.merge(pid, { multiaddrs: [circuitAddr] });
         await libp2p.dial(pid);
+        await verifyPeerAdmission(agent.peerId);
       } catch {
         // Non-fatal — peer may be unreachable.
       }

--- a/packages/agent/test/ack-candidate-pool.test.ts
+++ b/packages/agent/test/ack-candidate-pool.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect } from 'vitest';
 import { PROTOCOL_STORAGE_ACK, PROTOCOL_STORAGE_ACK_V2 } from '@origintrail-official/dkg-core';
 import { DKGAgent, MockChainAdapter, OxigraphStore } from './agent.shared';
+import { NetworkAdmissionService } from '../src/p2p/network-admission.js';
 
 type AgentInternals = {
   node: {
@@ -19,6 +20,7 @@ type AgentInternals = {
   config: { ackCandidatePeerIds?: string[]; preferredACKPeerIds?: string[] };
   knownCorePeerIds: Set<string>;
   knownCorePeerIdsV2: Set<string>;
+  networkAdmission: NetworkAdmissionService;
   lastKnownRequiredACKs?: number;
   getACKCandidatePeers: (protocol?: string) => string[];
   handlePeerUpdateForSyncRetry: (peerId: string, protocols: readonly string[]) => void;
@@ -139,7 +141,27 @@ describe('getACKCandidatePeers — confirmed peers first with stale-metadata fal
     expect(out.length).toBeGreaterThanOrEqual(3);
   });
 
-  it('V2 folded-private rounds prefer protocol-capable peers, listed peers first within the V2 tier', async () => {
+  it('filters ACK candidates to active-network admitted peers when admission is enabled', async () => {
+    const foreign = ['foreign-core-1', 'foreign-core-2'];
+    const sameNetwork = ['same-network-core', 'trusted-relay'];
+    const a = await buildAgent({
+      confirmedCores: [...foreign, ...sameNetwork],
+      connected: [...foreign, ...sameNetwork],
+      preferredACKPeerIds: ['trusted-relay', foreign[0]],
+    });
+    a.networkAdmission = new NetworkAdmissionService({
+      networkId: 'active-network',
+      trustedPeerIds: ['trusted-relay'],
+    });
+    a.networkAdmission.markVerifiedSameNetwork('same-network-core');
+
+    expect(a.getACKCandidatePeers()).toEqual(['same-network-core']);
+
+    a.networkAdmission.markVerifiedSameNetwork('trusted-relay');
+    expect(a.getACKCandidatePeers()).toEqual(['trusted-relay', 'same-network-core']);
+  });
+
+  it('V2 folded-private rounds keep unlisted V2-advertising cores dialable, listed peers first within each tier', async () => {
     const relays = ['relay-1', 'relay-2'];
     const upgraded = ['staked-core-5', 'staked-core-6', 'staked-core-7'];
     const a = await buildAgent({

--- a/packages/agent/test/ack-candidate-pool.test.ts
+++ b/packages/agent/test/ack-candidate-pool.test.ts
@@ -21,6 +21,11 @@ type AgentInternals = {
   knownCorePeerIds: Set<string>;
   knownCorePeerIdsV2: Set<string>;
   networkAdmission: NetworkAdmissionService;
+  networkAdmissionCoordinator: {
+    enabled: boolean;
+    isAcceptedPeer(peerId: string): boolean;
+    verifiedSameNetworkPeerIds(): ReadonlySet<string>;
+  };
   lastKnownRequiredACKs?: number;
   getACKCandidatePeers: (protocol?: string) => string[];
   handlePeerUpdateForSyncRetry: (peerId: string, protocols: readonly string[]) => void;
@@ -53,6 +58,17 @@ async function buildAgent(opts: {
   for (const id of opts.confirmedCores) internals.knownCorePeerIds.add(id);
   internals.lastKnownRequiredACKs = opts.lastKnownRequiredACKs;
   return internals;
+}
+
+function installAdmission(agent: AgentInternals, admission: NetworkAdmissionService): void {
+  agent.networkAdmission = admission;
+  agent.networkAdmissionCoordinator = {
+    get enabled() {
+      return admission.enabled;
+    },
+    isAcceptedPeer: (peerId) => admission.isAcceptedPeer(peerId),
+    verifiedSameNetworkPeerIds: () => admission.verifiedSameNetworkPeerIds(),
+  };
 }
 
 describe('getACKCandidatePeers — confirmed peers first with stale-metadata fallback (#1093 / #1482)', () => {
@@ -149,15 +165,15 @@ describe('getACKCandidatePeers — confirmed peers first with stale-metadata fal
       connected: [...foreign, ...sameNetwork],
       preferredACKPeerIds: ['trusted-relay', foreign[0]],
     });
-    a.networkAdmission = new NetworkAdmissionService({
+    const admission = new NetworkAdmissionService({
       networkId: 'active-network',
-      trustedPeerIds: ['trusted-relay'],
     });
-    a.networkAdmission.markVerifiedSameNetwork('same-network-core');
+    installAdmission(a, admission);
+    admission.markVerifiedSameNetwork('same-network-core');
 
     expect(a.getACKCandidatePeers()).toEqual(['same-network-core']);
 
-    a.networkAdmission.markVerifiedSameNetwork('trusted-relay');
+    admission.markVerifiedSameNetwork('trusted-relay');
     expect(a.getACKCandidatePeers()).toEqual(['trusted-relay', 'same-network-core']);
   });
 

--- a/packages/agent/test/agent.part-16.test.ts
+++ b/packages/agent/test/agent.part-16.test.ts
@@ -6,6 +6,13 @@ function recorder<A extends unknown[], R>(impl: (...args: A) => R) {
   return Object.assign(fn, { calls });
 }
 
+function allowAllNetworkAdmission(agent: DKGAgent): void {
+  const coordinator = (agent as any).networkAdmissionCoordinator;
+  coordinator.isAcceptedPeer = () => true;
+  coordinator.isRejectedPeer = () => false;
+  coordinator.ensureAdmitted = async () => true;
+}
+
 // #1236 🔵: clean (all-zero, no-backoff, made-no-progress) detailed
 // sync summaries shaped to match the production `DurableSyncResult` /
 // `SharedMemorySyncResult` returns of `syncFromPeerDetailed` /
@@ -94,6 +101,7 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
 
       try {
         await agent.start();
+        allowAllNetworkAdmission(agent);
         agent.subscribeToContextGraph('runtime-contextGraph');
 
         const remotePeer = agent.node.peerId;
@@ -181,6 +189,7 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
 
       try {
         await agent.start();
+        allowAllNetworkAdmission(agent);
         agent.subscribeToContextGraph('runtime-contextGraph');
 
         const remotePeer = agent.node.peerId;
@@ -316,6 +325,7 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
 
       try {
         await agent.start();
+        allowAllNetworkAdmission(agent);
         agent.subscribeToContextGraph('runtime-contextGraph');
 
         const deniedPeer = { toString: () => 'peer-denied' };
@@ -391,6 +401,7 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
 
       try {
         await agent.start();
+        allowAllNetworkAdmission(agent);
         agent.subscribeToContextGraph('runtime-contextGraph');
 
         const deniedPeer = { toString: () => 'peer-denied-empty' };
@@ -444,6 +455,7 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
 
       try {
         await agent.start();
+        allowAllNetworkAdmission(agent);
         agent.subscribeToContextGraph('runtime-contextGraph');
 
         const remotePeer = { toString: () => 'peer-meta-only' };
@@ -516,6 +528,7 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
 
       try {
         await agent.start();
+        allowAllNetworkAdmission(agent);
         agent.subscribeToContextGraph('runtime-contextGraph');
 
         const remotePeer = { toString: () => 'peer-meta-only-clean' };
@@ -589,6 +602,7 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
 
       try {
         await agent.start();
+        allowAllNetworkAdmission(agent);
         const remotePeer = agent.node.peerId.toString();
         const seenCalls: string[][] = [];
 
@@ -655,6 +669,7 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
 
       try {
         await agent.start();
+        allowAllNetworkAdmission(agent);
         agent.subscribeToContextGraph('runtime-contextGraph');
 
         const remotePeer = agent.node.peerId;
@@ -686,6 +701,7 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
 
       try {
         await agent.start();
+        allowAllNetworkAdmission(agent);
         agent.subscribeToContextGraph('runtime-contextGraph');
         (agent as any).preferredSyncPeers.set('runtime-contextGraph', 'peer-preferred');
 
@@ -738,6 +754,7 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
 
       try {
         await agent.start();
+        allowAllNetworkAdmission(agent);
         agent.subscribeToContextGraph('runtime-contextGraph');
         (agent as any).preferredSyncPeers.set('runtime-contextGraph', 'peer-preferred');
         (agent as any).knownCorePeerIds.add('peer-core');
@@ -807,6 +824,7 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
 
       try {
         await agent.start();
+        allowAllNetworkAdmission(agent);
         agent.subscribeToContextGraph('runtime-contextGraph');
 
         const peerNoProtocol = { toString: () => 'peer-no-protocol' };
@@ -926,6 +944,7 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
 
       try {
         await agent.start();
+        allowAllNetworkAdmission(agent);
         agent.subscribeToContextGraph('runtime-contextGraph');
 
         const peerEdgeA = { toString: () => 'peer-edge-a' };
@@ -998,6 +1017,7 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
 
       try {
         await agent.start();
+        allowAllNetworkAdmission(agent);
         (agent as any).subscribedContextGraphs.set('runtime-contextGraph', {
           name: 'Runtime ContextGraph',
           subscribed: true,
@@ -1053,6 +1073,7 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
 
       try {
         await agent.start();
+        allowAllNetworkAdmission(agent);
         (agent as any).subscribedContextGraphs.set('runtime-contextGraph', {
           name: 'Runtime ContextGraph',
           subscribed: true,
@@ -1108,6 +1129,7 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
       });
       try {
         await agent.start();
+        allowAllNetworkAdmission(agent);
 
         const remotePeer = agent.node.peerId;
         let releaseSync: (() => void) | undefined;
@@ -1191,6 +1213,7 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
       });
       try {
         await agent.start();
+        allowAllNetworkAdmission(agent);
         (agent as any).subscribedContextGraphs.set('private-cg', {
           name: 'private-cg',
           subscribed: false,
@@ -1234,6 +1257,7 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
       });
       try {
         await agent.start();
+        allowAllNetworkAdmission(agent);
         (agent as any).subscribedContextGraphs.set('private-cg', {
           name: 'private-cg',
           subscribed: false,
@@ -1280,6 +1304,7 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
       });
       try {
         await agent.start();
+        allowAllNetworkAdmission(agent);
         await chain.ensureProfile();
         (agent as any).subscribedContextGraphs.set('private-cg', {
           name: 'private-cg',

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -2886,6 +2886,7 @@ describe('runImmediatePostApprovalSync', () => {
   const CURATOR_PEER = '12D3KooWFakeCuratorPeerForRunImmediatePostApprovalSyncTest';
 
   function installStubs(a: DKGAgent, opts: {
+    ensureAdmitted?: (pid: string) => boolean | Promise<boolean>;
     ensurePeerConnected?: (pid: string) => Promise<void>;
     connectedPeers?: string[];
     runCatchupResult?: {
@@ -2898,9 +2899,14 @@ describe('runImmediatePostApprovalSync', () => {
     broadcastThrows?: Error;
   }) {
     const calls = {
+      ensureAdmittedCalls: [] as string[],
       ensurePeerConnectedCalls: [] as string[],
       runCatchupCalls: [] as Array<{ cg: string; includeSwm: boolean; peers: string[] }>,
       broadcastCalls: [] as Array<{ cg: string; includeSwm: boolean }>,
+    };
+    (a as any).networkAdmissionCoordinator.ensureAdmitted = async (pid: string) => {
+      calls.ensureAdmittedCalls.push(pid);
+      return opts.ensureAdmitted ? opts.ensureAdmitted(pid) : true;
     };
     (a as any).ensurePeerConnected = async (pid: string) => {
       calls.ensurePeerConnectedCalls.push(pid);
@@ -2954,6 +2960,7 @@ describe('runImmediatePostApprovalSync', () => {
 
     await (agent as any).runImmediatePostApprovalSync('test-cg-success', CURATOR_PEER);
 
+    expect(calls.ensureAdmittedCalls).toEqual([CURATOR_PEER]);
     expect(calls.ensurePeerConnectedCalls).toEqual([CURATOR_PEER]);
     expect(calls.runCatchupCalls).toHaveLength(1);
     expect(calls.runCatchupCalls[0]).toMatchObject({
@@ -2975,6 +2982,7 @@ describe('runImmediatePostApprovalSync', () => {
 
     await (agent as any).runImmediatePostApprovalSync('test-cg-missing-peer', CURATOR_PEER);
 
+    expect(calls.ensureAdmittedCalls).toEqual([CURATOR_PEER]);
     expect(calls.ensurePeerConnectedCalls).toEqual([CURATOR_PEER]);
     expect(calls.runCatchupCalls).toHaveLength(0);
     expect(calls.broadcastCalls).toHaveLength(1);
@@ -3018,6 +3026,29 @@ describe('runImmediatePostApprovalSync', () => {
   // the broadcast fallback MUST still run — wrapping curator-direct
   // and broadcast in a single try/catch reintroduces the silent-stall
   // bug this method was added to close.
+  it('falls back to broadcast when curator fails network admission', async () => {
+    const result = await createTestAgent();
+    agent = result.agent;
+    await agent.start();
+
+    const calls = installStubs(agent, {
+      ensureAdmitted: async () => false,
+      connectedPeers: [CURATOR_PEER],
+      runCatchupResult: { peersSucceeded: 1, dataSynced: 7, sharedMemorySynced: 11, denied: false },
+    });
+
+    await (agent as any).runImmediatePostApprovalSync('test-cg-admission-denied', CURATOR_PEER);
+
+    expect(calls.ensureAdmittedCalls).toEqual([CURATOR_PEER]);
+    expect(calls.ensurePeerConnectedCalls).toHaveLength(0);
+    expect(calls.runCatchupCalls).toHaveLength(0);
+    expect(calls.broadcastCalls).toHaveLength(1);
+    expect(calls.broadcastCalls[0]).toMatchObject({
+      cg: 'test-cg-admission-denied',
+      includeSwm: true,
+    });
+  }, 15000);
+
   it('falls back to broadcast when ensurePeerConnected throws (regression for catch-block bug)', async () => {
     const result = await createTestAgent();
     agent = result.agent;
@@ -3032,6 +3063,7 @@ describe('runImmediatePostApprovalSync', () => {
 
     await (agent as any).runImmediatePostApprovalSync('test-cg-throw', CURATOR_PEER);
 
+    expect(calls.ensureAdmittedCalls).toEqual([CURATOR_PEER]);
     expect(calls.ensurePeerConnectedCalls).toEqual([CURATOR_PEER]);
     expect(calls.runCatchupCalls).toHaveLength(0);
     expect(calls.broadcastCalls).toHaveLength(1);

--- a/packages/agent/test/explicit-connect-admission.test.ts
+++ b/packages/agent/test/explicit-connect-admission.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const peerConnectMocks = vi.hoisted(() => ({
+  connectToMultiaddr: vi.fn(async () => undefined),
+  ensurePeerConnected: vi.fn(async () => undefined),
+  primeCatchupConnections: vi.fn(async () => undefined),
+}));
+
+vi.mock('../src/p2p/peer-connect.js', () => peerConnectMocks);
+
+import { AgentRegistryMethods } from '../src/dkg-agent-registry.js';
+
+const PEER_ID = '12D3KooWQz2bQbQueABKRSjV9koF8VYsXk5TdCsUmPf5zAEZg3q6';
+const DIRECT_MULTIADDR = `/ip4/127.0.0.1/tcp/9090/p2p/${PEER_ID}`;
+
+function makeAgent(overrides: Record<string, unknown> = {}): any {
+  const agent: any = {
+    node: {
+      peerId: '12D3KooWLocalExplicitConnectAdmissionTest11111111111',
+      libp2p: {
+        getConnections: vi.fn(() => []),
+        dial: vi.fn(async () => undefined),
+      },
+    },
+    peerResolver: {
+      resolve: vi.fn(async () => [DIRECT_MULTIADDR]),
+    },
+    networkAdmission: { enabled: true },
+    log: { info: vi.fn() },
+    verifyPeerNetworkAdmission: vi.fn(async () => false),
+    ...overrides,
+  };
+  agent.assertPeerAdmittedForExplicitConnect =
+    AgentRegistryMethods.prototype.assertPeerAdmittedForExplicitConnect;
+  return agent;
+}
+
+describe('explicit connect network admission', () => {
+  beforeEach(() => {
+    peerConnectMocks.connectToMultiaddr.mockClear();
+    peerConnectMocks.ensurePeerConnected.mockClear();
+    peerConnectMocks.primeCatchupConnections.mockClear();
+  });
+
+  it('rejects a multiaddr connect when the target peer fails network admission', async () => {
+    const agent = makeAgent();
+
+    await expect(
+      AgentRegistryMethods.prototype.connectTo.call(agent, DIRECT_MULTIADDR),
+    ).rejects.toMatchObject({ code: 'NETWORK_ADMISSION_REJECTED' });
+
+    expect(peerConnectMocks.connectToMultiaddr).toHaveBeenCalledOnce();
+    expect(agent.verifyPeerNetworkAdmission).toHaveBeenCalledWith(
+      PEER_ID,
+      expect.objectContaining({ operationName: 'connect' }),
+    );
+  });
+
+  it('rejects network-scoped multiaddrs without a target peer id before dialing', async () => {
+    const agent = makeAgent();
+
+    await expect(
+      AgentRegistryMethods.prototype.connectTo.call(agent, '/ip4/127.0.0.1/tcp/9090'),
+    ).rejects.toMatchObject({ code: 'INVALID_PEER_ID' });
+
+    expect(peerConnectMocks.connectToMultiaddr).not.toHaveBeenCalled();
+  });
+
+  it('rejects a peer-id connect when the dial succeeds but admission fails', async () => {
+    const agent = makeAgent();
+
+    await expect(
+      AgentRegistryMethods.prototype.connectToPeerId.call(agent, PEER_ID, { timeoutMs: 5_000 }),
+    ).rejects.toMatchObject({ code: 'NETWORK_ADMISSION_REJECTED' });
+
+    expect(agent.peerResolver.resolve).toHaveBeenCalledWith(
+      PEER_ID,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(agent.node.libp2p.dial).toHaveBeenCalledOnce();
+    expect(agent.verifyPeerNetworkAdmission).toHaveBeenCalledWith(
+      PEER_ID,
+      expect.objectContaining({ operationName: 'connect' }),
+    );
+  });
+});

--- a/packages/agent/test/explicit-connect-admission.test.ts
+++ b/packages/agent/test/explicit-connect-admission.test.ts
@@ -55,6 +55,7 @@ describe('explicit connect network admission', () => {
     expect(agent.networkAdmissionCoordinator.ensureAdmitted).toHaveBeenCalledWith(
       PEER_ID,
       expect.objectContaining({ operationName: 'connect' }),
+      undefined,
     );
   });
 
@@ -83,6 +84,35 @@ describe('explicit connect network admission', () => {
     expect(agent.networkAdmissionCoordinator.ensureAdmitted).toHaveBeenCalledWith(
       PEER_ID,
       expect.objectContaining({ operationName: 'connect' }),
+      expect.objectContaining({ signal: expect.any(AbortSignal), timeoutMs: expect.any(Number) }),
+    );
+  });
+
+  it('rejects an already-connected peer-id connect when admission fails before success', async () => {
+    const agent = makeAgent({
+      node: {
+        peerId: '12D3KooWLocalExplicitConnectAdmissionTest11111111111',
+        libp2p: {
+          getConnections: vi.fn(() => [{ remotePeer: { toString: () => PEER_ID } }]),
+          dial: vi.fn(async () => undefined),
+        },
+      },
+    });
+
+    await expect(
+      AgentRegistryMethods.prototype.connectToPeerId.call(agent, PEER_ID, { timeoutMs: 5_000 }),
+    ).rejects.toMatchObject({ code: 'NETWORK_ADMISSION_REJECTED' });
+
+    expect(agent.networkAdmissionCoordinator.ensureAdmitted).toHaveBeenCalledWith(
+      PEER_ID,
+      expect.objectContaining({ operationName: 'connect' }),
+      expect.objectContaining({ signal: expect.any(AbortSignal), timeoutMs: expect.any(Number) }),
+    );
+    expect(agent.peerResolver.resolve).not.toHaveBeenCalled();
+    expect(agent.node.libp2p.dial).not.toHaveBeenCalled();
+    expect(agent.log.info).not.toHaveBeenCalledWith(
+      expect.objectContaining({ operationName: 'connect' }),
+      expect.stringContaining('Already connected'),
     );
   });
 });

--- a/packages/agent/test/explicit-connect-admission.test.ts
+++ b/packages/agent/test/explicit-connect-admission.test.ts
@@ -25,9 +25,11 @@ function makeAgent(overrides: Record<string, unknown> = {}): any {
     peerResolver: {
       resolve: vi.fn(async () => [DIRECT_MULTIADDR]),
     },
-    networkAdmission: { enabled: true },
+    networkAdmissionCoordinator: {
+      enabled: true,
+      ensureAdmitted: vi.fn(async () => false),
+    },
     log: { info: vi.fn() },
-    verifyPeerNetworkAdmission: vi.fn(async () => false),
     ...overrides,
   };
   agent.assertPeerAdmittedForExplicitConnect =
@@ -50,7 +52,7 @@ describe('explicit connect network admission', () => {
     ).rejects.toMatchObject({ code: 'NETWORK_ADMISSION_REJECTED' });
 
     expect(peerConnectMocks.connectToMultiaddr).toHaveBeenCalledOnce();
-    expect(agent.verifyPeerNetworkAdmission).toHaveBeenCalledWith(
+    expect(agent.networkAdmissionCoordinator.ensureAdmitted).toHaveBeenCalledWith(
       PEER_ID,
       expect.objectContaining({ operationName: 'connect' }),
     );
@@ -78,7 +80,7 @@ describe('explicit connect network admission', () => {
       expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
     expect(agent.node.libp2p.dial).toHaveBeenCalledOnce();
-    expect(agent.verifyPeerNetworkAdmission).toHaveBeenCalledWith(
+    expect(agent.networkAdmissionCoordinator.ensureAdmitted).toHaveBeenCalledWith(
       PEER_ID,
       expect.objectContaining({ operationName: 'connect' }),
     );

--- a/packages/agent/test/network-admission-coordinator.test.ts
+++ b/packages/agent/test/network-admission-coordinator.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createOperationContext } from '@origintrail-official/dkg-core';
+import { NetworkAdmissionCoordinator } from '../src/p2p/network-admission-coordinator.js';
+import { NetworkAdmissionService } from '../src/p2p/network-admission.js';
+
+const REMOTE_PEER_ID = '12D3KooWPvHB21rJUKQuPb7sZDCyveJmtsL3PryNN3y99n6hqRNh';
+const SELF_PEER_ID = '12D3KooWDCuLesNUYHGEUY5ksEsfJGbShbZ9ep2Pu7uqCNGvgwnb';
+const identity = {
+  networkId: 'network-a',
+  genesisId: 'base-testnet',
+};
+
+function buildCoordinator(input: {
+  sendIdentityProbe: () => Promise<Uint8Array>;
+}) {
+  const admission = new NetworkAdmissionService({
+    networkId: identity.networkId,
+    selfPeerId: SELF_PEER_ID,
+  });
+  const close = vi.fn();
+  const abort = vi.fn();
+  const deletePeerFromPeerStore = vi.fn();
+  const cleanupRejectedPeerState = vi.fn();
+  const coordinator = new NetworkAdmissionCoordinator({
+    admission,
+    identity,
+    selfPeerId: SELF_PEER_ID,
+    sign: async () => new Uint8Array(),
+    sendIdentityProbe: input.sendIdentityProbe,
+    getConnections: () => [{
+      remotePeer: { toString: () => REMOTE_PEER_ID },
+      close,
+      abort,
+    }],
+    deletePeerFromPeerStore,
+    cleanupRejectedPeerState,
+  });
+
+  return {
+    admission,
+    coordinator,
+    close,
+    abort,
+    deletePeerFromPeerStore,
+    cleanupRejectedPeerState,
+  };
+}
+
+describe('NetworkAdmissionCoordinator', () => {
+  it('keeps transport probe failures retryable instead of quarantining the peer', async () => {
+    const fixture = buildCoordinator({
+      sendIdentityProbe: async () => {
+        throw new Error('stream timeout');
+      },
+    });
+
+    await expect(
+      fixture.coordinator.ensureAdmitted(REMOTE_PEER_ID, createOperationContext('connect')),
+    ).rejects.toMatchObject({ code: 'NETWORK_ADMISSION_PROBE_FAILED' });
+
+    expect(fixture.admission.snapshot().quarantinedPeerIds).toEqual([]);
+    expect(fixture.admission.snapshot().verifiedPeerIds).toEqual([]);
+    expect(fixture.cleanupRejectedPeerState).not.toHaveBeenCalled();
+    expect(fixture.close).not.toHaveBeenCalled();
+    expect(fixture.abort).not.toHaveBeenCalled();
+    expect(fixture.deletePeerFromPeerStore).not.toHaveBeenCalled();
+  });
+
+  it('keeps unreadable probe responses retryable instead of quarantining the peer', async () => {
+    const fixture = buildCoordinator({
+      sendIdentityProbe: async () => new TextEncoder().encode('{not json'),
+    });
+
+    await expect(
+      fixture.coordinator.ensureAdmitted(REMOTE_PEER_ID, createOperationContext('connect')),
+    ).rejects.toMatchObject({ code: 'NETWORK_ADMISSION_PROBE_FAILED' });
+
+    expect(fixture.admission.snapshot().quarantinedPeerIds).toEqual([]);
+    expect(fixture.cleanupRejectedPeerState).not.toHaveBeenCalled();
+    expect(fixture.deletePeerFromPeerStore).not.toHaveBeenCalled();
+  });
+
+  it('quarantines peers with a parsed but mismatched network identity proof', async () => {
+    const fixture = buildCoordinator({
+      sendIdentityProbe: async () => new TextEncoder().encode(JSON.stringify({
+        version: 1,
+        peerId: REMOTE_PEER_ID,
+        networkId: 'network-b',
+        genesisId: identity.genesisId,
+        proofKind: 'ed25519-peer-id',
+        signature: 'invalid-signature',
+      })),
+    });
+
+    await expect(
+      fixture.coordinator.ensureAdmitted(REMOTE_PEER_ID, createOperationContext('connect')),
+    ).resolves.toBe(false);
+
+    expect(fixture.admission.snapshot().quarantinedPeerIds).toEqual([REMOTE_PEER_ID]);
+    expect(fixture.cleanupRejectedPeerState).toHaveBeenCalledWith(REMOTE_PEER_ID);
+    expect(fixture.close).toHaveBeenCalledTimes(1);
+    expect(fixture.deletePeerFromPeerStore).toHaveBeenCalledWith(REMOTE_PEER_ID);
+  });
+});

--- a/packages/agent/test/network-admission-coordinator.test.ts
+++ b/packages/agent/test/network-admission-coordinator.test.ts
@@ -11,10 +11,12 @@ const identity = {
 };
 
 function buildCoordinator(input: {
-  sendIdentityProbe: () => Promise<Uint8Array>;
+  sendIdentityProbe: (...args: any[]) => Promise<Uint8Array>;
+  identity?: typeof identity;
+  probeTimeoutMs?: number;
 }) {
   const admission = new NetworkAdmissionService({
-    networkId: identity.networkId,
+    networkId: input.identity?.networkId ?? identity.networkId,
     selfPeerId: SELF_PEER_ID,
   });
   const close = vi.fn();
@@ -23,7 +25,7 @@ function buildCoordinator(input: {
   const cleanupRejectedPeerState = vi.fn();
   const coordinator = new NetworkAdmissionCoordinator({
     admission,
-    identity,
+    identity: input.identity,
     selfPeerId: SELF_PEER_ID,
     sign: async () => new Uint8Array(),
     sendIdentityProbe: input.sendIdentityProbe,
@@ -34,6 +36,7 @@ function buildCoordinator(input: {
     }],
     deletePeerFromPeerStore,
     cleanupRejectedPeerState,
+    ...(input.probeTimeoutMs !== undefined ? { probeTimeoutMs: input.probeTimeoutMs } : {}),
   });
 
   return {
@@ -47,8 +50,22 @@ function buildCoordinator(input: {
 }
 
 describe('NetworkAdmissionCoordinator', () => {
+  it('accepts every peer synchronously when network identity is disabled', () => {
+    const fixture = buildCoordinator({
+      identity: undefined,
+      sendIdentityProbe: async () => {
+        throw new Error('probe should not run');
+      },
+    });
+
+    expect(fixture.coordinator.enabled).toBe(false);
+    expect(fixture.coordinator.isAcceptedPeer(REMOTE_PEER_ID)).toBe(true);
+    expect(fixture.coordinator.filterAcceptedPeerIds([REMOTE_PEER_ID])).toEqual([REMOTE_PEER_ID]);
+  });
+
   it('keeps transport probe failures retryable instead of quarantining the peer', async () => {
     const fixture = buildCoordinator({
+      identity,
       sendIdentityProbe: async () => {
         throw new Error('stream timeout');
       },
@@ -58,6 +75,8 @@ describe('NetworkAdmissionCoordinator', () => {
       fixture.coordinator.ensureAdmitted(REMOTE_PEER_ID, createOperationContext('connect')),
     ).rejects.toMatchObject({ code: 'NETWORK_ADMISSION_PROBE_FAILED' });
 
+    expect(fixture.coordinator.isAcceptedPeer(REMOTE_PEER_ID)).toBe(false);
+    expect(fixture.coordinator.isRejectedPeer(REMOTE_PEER_ID)).toBe(false);
     expect(fixture.admission.snapshot().quarantinedPeerIds).toEqual([]);
     expect(fixture.admission.snapshot().verifiedPeerIds).toEqual([]);
     expect(fixture.cleanupRejectedPeerState).not.toHaveBeenCalled();
@@ -68,6 +87,7 @@ describe('NetworkAdmissionCoordinator', () => {
 
   it('keeps unreadable probe responses retryable instead of quarantining the peer', async () => {
     const fixture = buildCoordinator({
+      identity,
       sendIdentityProbe: async () => new TextEncoder().encode('{not json'),
     });
 
@@ -80,8 +100,33 @@ describe('NetworkAdmissionCoordinator', () => {
     expect(fixture.deletePeerFromPeerStore).not.toHaveBeenCalled();
   });
 
+  it('passes caller cancellation and remaining timeout into identity probes', async () => {
+    const callerSignal = AbortSignal.timeout(5_000);
+    let seenOptions: { timeoutMs: number; signal?: AbortSignal } | undefined;
+    const fixture = buildCoordinator({
+      identity,
+      probeTimeoutMs: 3_000,
+      sendIdentityProbe: async (_peerId, _data, options) => {
+        seenOptions = options;
+        return new TextEncoder().encode('{not json');
+      },
+    });
+
+    await expect(
+      fixture.coordinator.ensureAdmitted(
+        REMOTE_PEER_ID,
+        createOperationContext('connect'),
+        { signal: callerSignal, timeoutMs: 100 },
+      ),
+    ).rejects.toMatchObject({ code: 'NETWORK_ADMISSION_PROBE_FAILED' });
+
+    expect(seenOptions).toMatchObject({ timeoutMs: 100 });
+    expect(seenOptions?.signal).toBe(callerSignal);
+  });
+
   it('quarantines peers with a parsed but mismatched network identity proof', async () => {
     const fixture = buildCoordinator({
+      identity,
       sendIdentityProbe: async () => new TextEncoder().encode(JSON.stringify({
         version: 1,
         peerId: REMOTE_PEER_ID,
@@ -97,6 +142,7 @@ describe('NetworkAdmissionCoordinator', () => {
     ).resolves.toBe(false);
 
     expect(fixture.admission.snapshot().quarantinedPeerIds).toEqual([REMOTE_PEER_ID]);
+    expect(fixture.coordinator.isRejectedPeer(REMOTE_PEER_ID)).toBe(true);
     expect(fixture.cleanupRejectedPeerState).toHaveBeenCalledWith(REMOTE_PEER_ID);
     expect(fixture.close).toHaveBeenCalledTimes(1);
     expect(fixture.deletePeerFromPeerStore).toHaveBeenCalledWith(REMOTE_PEER_ID);

--- a/packages/agent/test/network-admission-integration.test.ts
+++ b/packages/agent/test/network-admission-integration.test.ts
@@ -3,6 +3,42 @@ import { OxigraphStore } from '@origintrail-official/dkg-storage';
 import { DKGAgent } from '../src/dkg-agent.js';
 
 describe('network admission integration', () => {
+  it('admits a real explicit connect to a peer on the same network identity', async () => {
+    const local = await DKGAgent.create({
+      name: 'AdmissionIntegrationSameLocal',
+      listenPort: 0,
+      store: new OxigraphStore(),
+      networkIdentity: {
+        genesisId: 'v9-testnet',
+        networkId: 'network-a',
+        chainId: 'chain:1',
+      },
+    });
+    const remote = await DKGAgent.create({
+      name: 'AdmissionIntegrationSameRemote',
+      listenPort: 0,
+      store: new OxigraphStore(),
+      networkIdentity: {
+        genesisId: 'v9-testnet',
+        networkId: 'network-a',
+        chainId: 'chain:1',
+      },
+    });
+
+    try {
+      await local.start();
+      await remote.start();
+      const remoteAddr = remote.multiaddrs.find((addr) => addr.includes('/tcp/') && !addr.includes('/p2p-circuit'));
+      expect(remoteAddr).toBeDefined();
+
+      await expect(local.connectTo(remoteAddr!)).resolves.toBeUndefined();
+      expect(local.networkAdmission.snapshot().verifiedPeerIds).toContain(remote.peerId);
+    } finally {
+      await local.stop().catch(() => {});
+      await remote.stop().catch(() => {});
+    }
+  }, 15000);
+
   it('rejects a real explicit connect to a peer on a different network identity', async () => {
     const local = await DKGAgent.create({
       name: 'AdmissionIntegrationLocal',

--- a/packages/agent/test/network-admission-integration.test.ts
+++ b/packages/agent/test/network-admission-integration.test.ts
@@ -1,16 +1,18 @@
 import { describe, expect, it } from 'vitest';
+import { DEFAULT_GENESIS_ID, computeNetworkId } from '@origintrail-official/dkg-core';
 import { OxigraphStore } from '@origintrail-official/dkg-storage';
 import { DKGAgent } from '../src/dkg-agent.js';
 
 describe('network admission integration', () => {
   it('admits a real explicit connect to a peer on the same network identity', async () => {
+    const networkId = await computeNetworkId(DEFAULT_GENESIS_ID);
     const local = await DKGAgent.create({
       name: 'AdmissionIntegrationSameLocal',
       listenPort: 0,
       store: new OxigraphStore(),
       networkIdentity: {
-        genesisId: 'v9-testnet',
-        networkId: 'network-a',
+        genesisId: DEFAULT_GENESIS_ID,
+        networkId,
         chainId: 'chain:1',
       },
     });
@@ -19,8 +21,8 @@ describe('network admission integration', () => {
       listenPort: 0,
       store: new OxigraphStore(),
       networkIdentity: {
-        genesisId: 'v9-testnet',
-        networkId: 'network-a',
+        genesisId: DEFAULT_GENESIS_ID,
+        networkId,
         chainId: 'chain:1',
       },
     });
@@ -40,13 +42,15 @@ describe('network admission integration', () => {
   }, 15000);
 
   it('rejects a real explicit connect to a peer on a different network identity', async () => {
+    const localNetworkId = await computeNetworkId(DEFAULT_GENESIS_ID);
+    const foreignNetworkId = await computeNetworkId('gnosis-mainnet');
     const local = await DKGAgent.create({
       name: 'AdmissionIntegrationLocal',
       listenPort: 0,
       store: new OxigraphStore(),
       networkIdentity: {
-        genesisId: 'v9-testnet',
-        networkId: 'network-a',
+        genesisId: DEFAULT_GENESIS_ID,
+        networkId: localNetworkId,
         chainId: 'chain:1',
       },
     });
@@ -55,8 +59,8 @@ describe('network admission integration', () => {
       listenPort: 0,
       store: new OxigraphStore(),
       networkIdentity: {
-        genesisId: 'v9-testnet',
-        networkId: 'network-b',
+        genesisId: 'gnosis-mainnet',
+        networkId: foreignNetworkId,
         chainId: 'chain:1',
       },
     });

--- a/packages/agent/test/network-admission-integration.test.ts
+++ b/packages/agent/test/network-admission-integration.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import { DKGAgent } from '../src/dkg-agent.js';
+
+describe('network admission integration', () => {
+  it('rejects a real explicit connect to a peer on a different network identity', async () => {
+    const local = await DKGAgent.create({
+      name: 'AdmissionIntegrationLocal',
+      listenPort: 0,
+      store: new OxigraphStore(),
+      networkIdentity: {
+        genesisId: 'v9-testnet',
+        networkId: 'network-a',
+        chainId: 'chain:1',
+      },
+    });
+    const foreign = await DKGAgent.create({
+      name: 'AdmissionIntegrationForeign',
+      listenPort: 0,
+      store: new OxigraphStore(),
+      networkIdentity: {
+        genesisId: 'v9-testnet',
+        networkId: 'network-b',
+        chainId: 'chain:1',
+      },
+    });
+
+    try {
+      await local.start();
+      await foreign.start();
+      const foreignAddr = foreign.multiaddrs.find((addr) => addr.includes('/tcp/') && !addr.includes('/p2p-circuit'));
+      expect(foreignAddr).toBeDefined();
+
+      await expect(local.connectTo(foreignAddr!))
+        .rejects.toMatchObject({ code: 'NETWORK_ADMISSION_REJECTED' });
+      expect(local.networkAdmission.snapshot().verifiedPeerIds).not.toContain(foreign.peerId);
+      expect(local.networkAdmission.snapshot().quarantinedPeerIds).toContain(foreign.peerId);
+    } finally {
+      await local.stop().catch(() => {});
+      await foreign.stop().catch(() => {});
+    }
+  }, 15000);
+});

--- a/packages/agent/test/network-admission.test.ts
+++ b/packages/agent/test/network-admission.test.ts
@@ -13,30 +13,25 @@ describe('NetworkAdmissionService', () => {
     expect(admission.snapshot().enabled).toBe(false);
   });
 
-  it('fails unknown and configured seed peers closed when network identity is configured', () => {
+  it('fails unknown peers closed when network identity is configured', () => {
     const admission = new NetworkAdmissionService({
       networkId: 'network-a',
       selfPeerId: 'self-peer',
-      trustedPeerIds: ['trusted-peer'],
     });
 
     expect(admission.isAcceptedPeer('self-peer')).toBe(true);
-    expect(admission.isAcceptedPeer('trusted-peer')).toBe(false);
     expect(admission.isAcceptedPeer('unknown-peer')).toBe(false);
   });
 
   it('promotes verified same-network peers and excludes quarantined peers', () => {
     const admission = new NetworkAdmissionService({
       networkId: 'network-a',
-      trustedPeerIds: ['trusted-peer'],
     });
 
     admission.markVerifiedSameNetwork('verified-peer');
     expect([...admission.verifiedSameNetworkPeerIds()].sort()).toEqual(['verified-peer']);
 
-    admission.quarantinePeer('trusted-peer');
     admission.quarantinePeer('verified-peer');
-    expect(admission.isAcceptedPeer('trusted-peer')).toBe(false);
     expect(admission.isAcceptedPeer('verified-peer')).toBe(false);
     expect([...admission.verifiedSameNetworkPeerIds()]).toEqual([]);
   });

--- a/packages/agent/test/network-admission.test.ts
+++ b/packages/agent/test/network-admission.test.ts
@@ -21,6 +21,7 @@ describe('NetworkAdmissionService', () => {
 
     expect(admission.isAcceptedPeer('self-peer')).toBe(true);
     expect(admission.isAcceptedPeer('unknown-peer')).toBe(false);
+    expect(admission.isRejectedPeer('unknown-peer')).toBe(false);
   });
 
   it('promotes verified same-network peers and excludes quarantined peers', () => {
@@ -33,6 +34,7 @@ describe('NetworkAdmissionService', () => {
 
     admission.quarantinePeer('verified-peer');
     expect(admission.isAcceptedPeer('verified-peer')).toBe(false);
+    expect(admission.isRejectedPeer('verified-peer')).toBe(true);
     expect([...admission.verifiedSameNetworkPeerIds()]).toEqual([]);
   });
 

--- a/packages/agent/test/network-admission.test.ts
+++ b/packages/agent/test/network-admission.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import {
+  NetworkAdmissionService,
+  peerIdsFromMultiaddrs,
+} from '../src/p2p/network-admission.js';
+
+describe('NetworkAdmissionService', () => {
+  it('allows all peers when no active network identity is configured', () => {
+    const admission = new NetworkAdmissionService();
+
+    expect(admission.isPeerAccepted('peer-a', '/dkg/test', 'outbound')).toBe(true);
+    expect(admission.snapshot().enabled).toBe(false);
+  });
+
+  it('fails unknown and configured seed peers closed when network identity is configured', () => {
+    const admission = new NetworkAdmissionService({
+      networkId: 'network-a',
+      selfPeerId: 'self-peer',
+      trustedPeerIds: ['trusted-peer'],
+    });
+
+    expect(admission.isPeerAccepted('self-peer', '/dkg/test', 'outbound')).toBe(true);
+    expect(admission.isPeerAccepted('trusted-peer', '/dkg/test', 'inbound')).toBe(false);
+    expect(admission.isPeerAccepted('unknown-peer', '/dkg/test', 'gossip')).toBe(false);
+  });
+
+  it('promotes verified same-network peers and excludes quarantined peers', () => {
+    const admission = new NetworkAdmissionService({
+      networkId: 'network-a',
+      trustedPeerIds: ['trusted-peer'],
+    });
+
+    admission.markVerifiedSameNetwork('verified-peer');
+    expect([...admission.verifiedSameNetworkPeerIds()].sort()).toEqual(['verified-peer']);
+
+    admission.quarantinePeer('trusted-peer');
+    admission.quarantinePeer('verified-peer');
+    expect(admission.isPeerAccepted('trusted-peer', '/dkg/test', 'outbound')).toBe(false);
+    expect(admission.isPeerAccepted('verified-peer', '/dkg/test', 'outbound')).toBe(false);
+    expect([...admission.verifiedSameNetworkPeerIds()]).toEqual([]);
+  });
+
+  it('extracts peer ids from configured relay and bootstrap multiaddrs', () => {
+    expect([...peerIdsFromMultiaddrs([
+      '/ip4/127.0.0.1/tcp/4001/p2p/relay-peer',
+      '/dns4/bootstrap.example/tcp/4001/p2p/bootstrap-peer',
+    ])].sort()).toEqual(['bootstrap-peer', 'relay-peer']);
+  });
+});

--- a/packages/agent/test/network-admission.test.ts
+++ b/packages/agent/test/network-admission.test.ts
@@ -9,7 +9,7 @@ describe('NetworkAdmissionService', () => {
   it('allows all peers when no active network identity is configured', () => {
     const admission = new NetworkAdmissionService();
 
-    expect(admission.isPeerAccepted('peer-a', '/dkg/test', 'outbound')).toBe(true);
+    expect(admission.isAcceptedPeer('peer-a')).toBe(true);
     expect(admission.snapshot().enabled).toBe(false);
   });
 
@@ -20,9 +20,9 @@ describe('NetworkAdmissionService', () => {
       trustedPeerIds: ['trusted-peer'],
     });
 
-    expect(admission.isPeerAccepted('self-peer', '/dkg/test', 'outbound')).toBe(true);
-    expect(admission.isPeerAccepted('trusted-peer', '/dkg/test', 'inbound')).toBe(false);
-    expect(admission.isPeerAccepted('unknown-peer', '/dkg/test', 'gossip')).toBe(false);
+    expect(admission.isAcceptedPeer('self-peer')).toBe(true);
+    expect(admission.isAcceptedPeer('trusted-peer')).toBe(false);
+    expect(admission.isAcceptedPeer('unknown-peer')).toBe(false);
   });
 
   it('promotes verified same-network peers and excludes quarantined peers', () => {
@@ -36,8 +36,8 @@ describe('NetworkAdmissionService', () => {
 
     admission.quarantinePeer('trusted-peer');
     admission.quarantinePeer('verified-peer');
-    expect(admission.isPeerAccepted('trusted-peer', '/dkg/test', 'outbound')).toBe(false);
-    expect(admission.isPeerAccepted('verified-peer', '/dkg/test', 'outbound')).toBe(false);
+    expect(admission.isAcceptedPeer('trusted-peer')).toBe(false);
+    expect(admission.isAcceptedPeer('verified-peer')).toBe(false);
     expect([...admission.verifiedSameNetworkPeerIds()]).toEqual([]);
   });
 

--- a/packages/agent/test/network-admission.test.ts
+++ b/packages/agent/test/network-admission.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   NetworkAdmissionService,
   peerIdsFromMultiaddrs,
+  targetPeerIdFromMultiaddr,
 } from '../src/p2p/network-admission.js';
 
 describe('NetworkAdmissionService', () => {
@@ -45,5 +46,12 @@ describe('NetworkAdmissionService', () => {
       '/ip4/127.0.0.1/tcp/4001/p2p/relay-peer',
       '/dns4/bootstrap.example/tcp/4001/p2p/bootstrap-peer',
     ])].sort()).toEqual(['bootstrap-peer', 'relay-peer']);
+  });
+
+  it('separates relay seed peers from the explicit target peer in relayed multiaddrs', () => {
+    const addr = '/ip4/127.0.0.1/tcp/4001/p2p/relay-peer/p2p-circuit/p2p/target-peer';
+
+    expect([...peerIdsFromMultiaddrs([addr])]).toEqual(['relay-peer', 'target-peer']);
+    expect(targetPeerIdFromMultiaddr(addr)).toBe('target-peer');
   });
 });

--- a/packages/agent/test/network-identity-config.test.ts
+++ b/packages/agent/test/network-identity-config.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { computeNetworkId } from '@origintrail-official/dkg-core';
+import { DEFAULT_GENESIS_ID, computeNetworkId } from '@origintrail-official/dkg-core';
 import { OxigraphStore } from '@origintrail-official/dkg-storage';
 import { DKGAgent } from '../src/dkg-agent.js';
 
 describe('DKGAgent network identity config', () => {
-  it('stores the computed default network identity on the agent config', async () => {
+  it('stores the computed network identity on the agent and node configs', async () => {
     const agent = await DKGAgent.create({
       name: 'NetworkIdentityConfigTest',
       genesisId: 'gnosis-mainnet',
@@ -16,7 +16,37 @@ describe('DKGAgent network identity config', () => {
       genesisId: 'gnosis-mainnet',
       networkId: expectedNetworkId,
     });
+    expect((agent.node as any).config.networkIdentity).toMatchObject({
+      genesisId: 'gnosis-mainnet',
+      networkId: expectedNetworkId,
+    });
 
     await agent.stop().catch(() => {});
+  });
+
+  it('normalizes omitted genesisId to the default genesis identity', async () => {
+    const omitted = await DKGAgent.create({
+      name: 'NetworkIdentityConfigOmittedDefault',
+      store: new OxigraphStore(),
+    });
+    const explicit = await DKGAgent.create({
+      name: 'NetworkIdentityConfigExplicitDefault',
+      genesisId: DEFAULT_GENESIS_ID,
+      store: new OxigraphStore(),
+    });
+
+    try {
+      const expectedNetworkId = await computeNetworkId(DEFAULT_GENESIS_ID);
+      expect((omitted as any).config.genesisId).toBe(DEFAULT_GENESIS_ID);
+      expect((omitted as any).config.networkIdentity).toEqual((explicit as any).config.networkIdentity);
+      expect((omitted as any).config.networkIdentity).toMatchObject({
+        genesisId: DEFAULT_GENESIS_ID,
+        networkId: expectedNetworkId,
+      });
+      expect((omitted.node as any).config.networkIdentity).toEqual((omitted as any).config.networkIdentity);
+    } finally {
+      await omitted.stop().catch(() => {});
+      await explicit.stop().catch(() => {});
+    }
   });
 });

--- a/packages/agent/test/network-identity-config.test.ts
+++ b/packages/agent/test/network-identity-config.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { computeNetworkId } from '@origintrail-official/dkg-core';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import { DKGAgent } from '../src/dkg-agent.js';
+
+describe('DKGAgent network identity config', () => {
+  it('stores the computed default network identity on the agent config', async () => {
+    const agent = await DKGAgent.create({
+      name: 'NetworkIdentityConfigTest',
+      genesisId: 'gnosis-mainnet',
+      store: new OxigraphStore(),
+    });
+
+    const expectedNetworkId = await computeNetworkId('gnosis-mainnet');
+    expect((agent as any).config.networkIdentity).toMatchObject({
+      genesisId: 'gnosis-mainnet',
+      networkId: expectedNetworkId,
+    });
+
+    await agent.stop().catch(() => {});
+  });
+});

--- a/packages/agent/test/network-identity-config.test.ts
+++ b/packages/agent/test/network-identity-config.test.ts
@@ -49,4 +49,51 @@ describe('DKGAgent network identity config', () => {
       await explicit.stop().catch(() => {});
     }
   });
+
+  it('uses networkIdentity.genesisId as the selected genesis when genesisId is omitted', async () => {
+    const networkId = await computeNetworkId('gnosis-mainnet');
+    const agent = await DKGAgent.create({
+      name: 'NetworkIdentityConfigDerivedGenesis',
+      networkIdentity: {
+        genesisId: 'gnosis-mainnet',
+        networkId,
+      },
+      store: new OxigraphStore(),
+    });
+
+    try {
+      expect((agent as any).config.genesisId).toBe('gnosis-mainnet');
+      expect((agent as any).config.networkIdentity).toMatchObject({
+        genesisId: 'gnosis-mainnet',
+        networkId,
+      });
+      expect((agent.node as any).config.networkIdentity).toEqual((agent as any).config.networkIdentity);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+
+  it('rejects networkIdentity values that diverge from the selected genesis', async () => {
+    const defaultNetworkId = await computeNetworkId(DEFAULT_GENESIS_ID);
+
+    await expect(DKGAgent.create({
+      name: 'NetworkIdentityConfigGenesisMismatch',
+      genesisId: DEFAULT_GENESIS_ID,
+      networkIdentity: {
+        genesisId: 'gnosis-mainnet',
+        networkId: await computeNetworkId('gnosis-mainnet'),
+      },
+      store: new OxigraphStore(),
+    })).rejects.toThrow(/networkIdentity\.genesisId/);
+
+    await expect(DKGAgent.create({
+      name: 'NetworkIdentityConfigNetworkIdMismatch',
+      genesisId: DEFAULT_GENESIS_ID,
+      networkIdentity: {
+        genesisId: DEFAULT_GENESIS_ID,
+        networkId: `${defaultNetworkId}-wrong`,
+      },
+      store: new OxigraphStore(),
+    })).rejects.toThrow(/networkIdentity\.networkId/);
+  });
 });

--- a/packages/agent/test/network-identity-proof.test.ts
+++ b/packages/agent/test/network-identity-proof.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import { ed25519Sign } from '@origintrail-official/dkg-core';
+import {
+  makeNetworkIdentityRequest,
+  signNetworkIdentityResponse,
+  verifyNetworkIdentityResponse,
+} from '../src/p2p/network-identity-proof.js';
+
+const REMOTE_PEER_ID = '12D3KooWPvHB21rJUKQuPb7sZDCyveJmtsL3PryNN3y99n6hqRNh';
+const REMOTE_PRIVATE_KEY_SEED = Buffer
+  .from('vHxcSg3ecwP9UfJWdmlnWQeJe83jD2yKtOJlWuLpIrTRh3QiB5sL6iRhAidCZ3bHQLaE0RwBfHBNEmV7ylcjqg==', 'base64')
+  .slice(0, 32);
+
+const localIdentity = {
+  networkId: 'network-a',
+  genesisId: 'base-testnet',
+  chainId: 'base:84532',
+};
+
+async function signedResponse(identity = localIdentity, nonce = 'nonce-1') {
+  const request = makeNetworkIdentityRequest({
+    nonce,
+    requesterPeerId: 'requester-peer',
+    identity: localIdentity,
+  });
+  return signNetworkIdentityResponse({
+    request,
+    identity,
+    responderPeerId: REMOTE_PEER_ID,
+    sign: (payload) => ed25519Sign(payload, REMOTE_PRIVATE_KEY_SEED),
+  });
+}
+
+describe('network identity proof', () => {
+  it('accepts a complete same-network response signed by the remote peer id key', async () => {
+    const response = await signedResponse();
+
+    await expect(verifyNetworkIdentityResponse({
+      response,
+      remotePeerId: REMOTE_PEER_ID,
+      localIdentity,
+      nonce: 'nonce-1',
+      requesterPeerId: 'requester-peer',
+    })).resolves.toEqual({ ok: true });
+  });
+
+  it('rejects peers that omit required local chain or genesis identity fields', async () => {
+    const response = await signedResponse();
+    const missingChain = { ...response, chainId: undefined };
+    const missingGenesis = { ...response, genesisId: undefined };
+
+    await expect(verifyNetworkIdentityResponse({
+      response: missingChain,
+      remotePeerId: REMOTE_PEER_ID,
+      localIdentity,
+      nonce: 'nonce-1',
+      requesterPeerId: 'requester-peer',
+    })).resolves.toMatchObject({ ok: false, reason: 'chain id mismatch' });
+
+    await expect(verifyNetworkIdentityResponse({
+      response: missingGenesis,
+      remotePeerId: REMOTE_PEER_ID,
+      localIdentity,
+      nonce: 'nonce-1',
+      requesterPeerId: 'requester-peer',
+    })).resolves.toMatchObject({ ok: false, reason: 'genesis id mismatch' });
+  });
+
+  it('rejects cross-network claims even when the response shape is otherwise valid', async () => {
+    const response = await signedResponse({ ...localIdentity, chainId: 'base:8453' });
+
+    await expect(verifyNetworkIdentityResponse({
+      response,
+      remotePeerId: REMOTE_PEER_ID,
+      localIdentity,
+      nonce: 'nonce-1',
+      requesterPeerId: 'requester-peer',
+    })).resolves.toMatchObject({ ok: false, reason: 'chain id mismatch' });
+  });
+
+  it('rejects replayed or self-asserted claims without a valid peer-id-bound signature', async () => {
+    const response = await signedResponse();
+
+    await expect(verifyNetworkIdentityResponse({
+      response,
+      remotePeerId: REMOTE_PEER_ID,
+      localIdentity,
+      nonce: 'different-nonce',
+      requesterPeerId: 'requester-peer',
+    })).resolves.toMatchObject({ ok: false, reason: 'invalid signature' });
+
+    await expect(verifyNetworkIdentityResponse({
+      response: { ...response, signature: Buffer.from(new Uint8Array(64)).toString('base64') },
+      remotePeerId: REMOTE_PEER_ID,
+      localIdentity,
+      nonce: 'nonce-1',
+      requesterPeerId: 'requester-peer',
+    })).resolves.toMatchObject({ ok: false, reason: 'invalid signature' });
+  });
+});

--- a/packages/agent/test/network-identity-proof.test.ts
+++ b/packages/agent/test/network-identity-proof.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { ed25519Sign } from '@origintrail-official/dkg-core';
 import {
   makeNetworkIdentityRequest,
+  parseNetworkIdentityResponse,
   signNetworkIdentityResponse,
   verifyNetworkIdentityResponse,
 } from '../src/p2p/network-identity-proof.js';
@@ -96,5 +97,18 @@ describe('network identity proof', () => {
       nonce: 'nonce-1',
       requesterPeerId: 'requester-peer',
     })).resolves.toMatchObject({ ok: false, reason: 'invalid signature' });
+  });
+
+  it('validates response shape before proof verification', async () => {
+    expect(() => parseNetworkIdentityResponse({ version: 1, networkId: 'network-a' }))
+      .toThrow('missing peer id');
+
+    await expect(verifyNetworkIdentityResponse({
+      response: { version: 1, peerId: REMOTE_PEER_ID, networkId: localIdentity.networkId, proofKind: 'ed25519-peer-id' },
+      remotePeerId: REMOTE_PEER_ID,
+      localIdentity,
+      nonce: 'nonce-1',
+      requesterPeerId: 'requester-peer',
+    })).resolves.toMatchObject({ ok: false, reason: 'missing signature' });
   });
 });

--- a/packages/agent/test/network-identity-proof.test.ts
+++ b/packages/agent/test/network-identity-proof.test.ts
@@ -79,6 +79,18 @@ describe('network identity proof', () => {
     })).resolves.toMatchObject({ ok: false, reason: 'chain id mismatch' });
   });
 
+  it('verifies signatures over optional identity fields claimed by the responder', async () => {
+    const response = await signedResponse(localIdentity);
+
+    await expect(verifyNetworkIdentityResponse({
+      response,
+      remotePeerId: REMOTE_PEER_ID,
+      localIdentity: { networkId: localIdentity.networkId },
+      nonce: 'nonce-1',
+      requesterPeerId: 'requester-peer',
+    })).resolves.toEqual({ ok: true });
+  });
+
   it('rejects replayed or self-asserted claims without a valid peer-id-bound signature', async () => {
     const response = await signedResponse();
 

--- a/packages/agent/test/p2p-peer-connect.test.ts
+++ b/packages/agent/test/p2p-peer-connect.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { connectToMultiaddr } from '../src/p2p/peer-connect.js';
+import { connectToMultiaddr, primeCatchupConnections } from '../src/p2p/peer-connect.js';
 
 function recorder<A extends unknown[], R>(impl: (...args: A) => R) {
   const calls: A[] = [];
@@ -49,5 +49,29 @@ describe('connectToMultiaddr', () => {
       dial,
       peerStore: { merge },
     }, multiaddress)).rejects.toThrow('Circuit target peer 12D3KooWQz2bQbQueABKRSjV9koF8VYsXk5TdCsUmPf5zAEZg3q6 not observed before timeout');
+  });
+});
+
+describe('primeCatchupConnections', () => {
+  it('dials only catchup peers accepted by the caller admission gate', async () => {
+    const dial = recorder(async () => undefined);
+    const merge = recorder(async () => undefined);
+    const relayAddress = '/ip4/178.104.54.178/tcp/9090/p2p/12D3KooWSmU3owJvB9sFw8uApDgKrv2VBMecsGGvgAc4Gq6hB57M';
+    const eligiblePeer = '12D3KooWQz2bQbQueABKRSjV9koF8VYsXk5TdCsUmPf5zAEZg3q6';
+    const foreignPeer = '12D3KooWForeignCatchupPeer111111111111111111111111';
+
+    await primeCatchupConnections({
+      getConnections: () => [],
+      dial,
+      peerStore: { merge },
+    }, {
+      findAgents: async () => [
+        { peerId: foreignPeer, relayAddress },
+        { peerId: eligiblePeer, relayAddress },
+      ],
+    } as any, 'self-peer', (peerId) => peerId === eligiblePeer);
+
+    expect(merge.calls).toHaveLength(1);
+    expect(dial.calls).toHaveLength(1);
   });
 });

--- a/packages/agent/test/p2p-peer-connect.test.ts
+++ b/packages/agent/test/p2p-peer-connect.test.ts
@@ -53,12 +53,13 @@ describe('connectToMultiaddr', () => {
 });
 
 describe('primeCatchupConnections', () => {
-  it('dials only catchup peers accepted by the caller admission gate', async () => {
+  it('dials discovered peers before running the caller admission proof', async () => {
     const dial = recorder(async () => undefined);
     const merge = recorder(async () => undefined);
     const relayAddress = '/ip4/178.104.54.178/tcp/9090/p2p/12D3KooWSmU3owJvB9sFw8uApDgKrv2VBMecsGGvgAc4Gq6hB57M';
     const eligiblePeer = '12D3KooWQz2bQbQueABKRSjV9koF8VYsXk5TdCsUmPf5zAEZg3q6';
-    const foreignPeer = '12D3KooWForeignCatchupPeer111111111111111111111111';
+    const foreignPeer = '12D3KooWR5C8ajtPigVGnBwDGTZ4XAtCepRs2WCgfPuBPrgGqcNK';
+    const admissionCalls: string[] = [];
 
     await primeCatchupConnections({
       getConnections: () => [],
@@ -69,9 +70,13 @@ describe('primeCatchupConnections', () => {
         { peerId: foreignPeer, relayAddress },
         { peerId: eligiblePeer, relayAddress },
       ],
-    } as any, 'self-peer', (peerId) => peerId === eligiblePeer);
+    } as any, 'self-peer', async (peerId) => {
+      admissionCalls.push(peerId);
+      return peerId === eligiblePeer;
+    });
 
-    expect(merge.calls).toHaveLength(1);
-    expect(dial.calls).toHaveLength(1);
+    expect(merge.calls).toHaveLength(2);
+    expect(dial.calls).toHaveLength(2);
+    expect(admissionCalls).toEqual([foreignPeer, eligiblePeer]);
   });
 });

--- a/packages/agent/test/p2p-peer-connect.test.ts
+++ b/packages/agent/test/p2p-peer-connect.test.ts
@@ -72,7 +72,6 @@ describe('primeCatchupConnections', () => {
       ],
     } as any, 'self-peer', async (peerId) => {
       admissionCalls.push(peerId);
-      return peerId === eligiblePeer;
     });
 
     expect(merge.calls).toHaveLength(2);

--- a/packages/agent/test/p2p-resilience.test.ts
+++ b/packages/agent/test/p2p-resilience.test.ts
@@ -43,6 +43,13 @@ function relayAddrFor(peerId: string): string {
   return `/ip4/127.0.0.1/tcp/4001/p2p/${peerId}`;
 }
 
+function allowAllNetworkAdmission(agent: DKGAgent): void {
+  const coordinator = (agent as any).networkAdmissionCoordinator;
+  coordinator.isAcceptedPeer = () => true;
+  coordinator.isRejectedPeer = () => false;
+  coordinator.ensureAdmitted = async () => true;
+}
+
 describe('p2p resilience hooks', () => {
   describe('reconnect-on-gossip', () => {
     it('dials the sender of a gossip message via a connected relay circuit', async () => {
@@ -53,6 +60,7 @@ describe('p2p resilience hooks', () => {
       });
       try {
         await agent.start();
+        allowAllNetworkAdmission(agent);
 
         const dialSpy = recorder(async (..._args: any[]) => ({} as any));
         agent.node.libp2p.dial = dialSpy as any;
@@ -92,6 +100,7 @@ describe('p2p resilience hooks', () => {
       });
       try {
         await agent.start();
+        allowAllNetworkAdmission(agent);
 
         const dialSpy = recorder(async (..._args: any[]) => ({} as any));
         agent.node.libp2p.dial = dialSpy as any;
@@ -120,6 +129,7 @@ describe('p2p resilience hooks', () => {
       });
       try {
         await agent.start();
+        allowAllNetworkAdmission(agent);
 
         const dialSpy = recorder(async (..._args: any[]) => ({} as any));
         agent.node.libp2p.dial = dialSpy as any;
@@ -154,6 +164,7 @@ describe('p2p resilience hooks', () => {
       });
       try {
         await agent.start();
+        allowAllNetworkAdmission(agent);
 
         const dialSpy = recorder(async (..._args: any[]) => ({} as any));
         agent.node.libp2p.dial = dialSpy as any;
@@ -179,6 +190,7 @@ describe('p2p resilience hooks', () => {
       });
       try {
         await agent.start();
+        allowAllNetworkAdmission(agent);
 
         // Stubbed dial always rejects so no real path is created; we only
         // care about how many times maybeDialGossipSender *attempted* it.
@@ -225,6 +237,7 @@ describe('p2p resilience hooks', () => {
       });
       try {
         await agent.start();
+        allowAllNetworkAdmission(agent);
 
         const calls: string[] = [];
         (agent as any).trySyncFromPeer = async (peerId: string) => {
@@ -260,6 +273,7 @@ describe('p2p resilience hooks', () => {
       });
       try {
         await agent.start();
+        allowAllNetworkAdmission(agent);
 
         const calls: string[] = [];
         (agent as any).trySyncFromPeer = async (peerId: string) => {
@@ -301,6 +315,7 @@ describe('p2p resilience hooks', () => {
       });
       try {
         await agent.start();
+        allowAllNetworkAdmission(agent);
 
         const calls: string[] = [];
         (agent as any).trySyncFromPeer = async (peerId: string) => {
@@ -345,6 +360,7 @@ describe('p2p resilience hooks', () => {
       });
       try {
         await agent.start();
+        allowAllNetworkAdmission(agent);
 
         const events: string[] = [];
         let enrichResolve: (() => void) | null = null;

--- a/packages/agent/test/sync-on-connect-retry.test.ts
+++ b/packages/agent/test/sync-on-connect-retry.test.ts
@@ -40,6 +40,13 @@ async function flushMicrotasks(): Promise<void> {
   await Promise.resolve();
 }
 
+function allowAllNetworkAdmission(agent: DKGAgent): void {
+  const coordinator = (agent as any).networkAdmissionCoordinator;
+  coordinator.isAcceptedPeer = () => true;
+  coordinator.isRejectedPeer = () => false;
+  coordinator.ensureAdmitted = async () => true;
+}
+
 describe('runSyncOnConnect callbacks', () => {
   it('accepts omitted knownCorePeerIdsV2 for backwards-compatible call sites', async () => {
     const remotePeer = freshPeerIdString();
@@ -703,6 +710,15 @@ describe('DKGAgent sync retry — event-driven via peer:update', () => {
       await agent.start();
 
       const remotePeer = freshPeerIdString();
+      let admitted = false;
+      const ensureAdmitted = recorder(async (peerId: string) => {
+        admitted = true;
+        return peerId === remotePeer;
+      });
+      const coordinator = (agent as any).networkAdmissionCoordinator;
+      coordinator.isAcceptedPeer = () => admitted;
+      coordinator.isRejectedPeer = () => false;
+      coordinator.ensureAdmitted = ensureAdmitted;
       // Pretend sync-on-connect ran earlier and skipped this peer because
       // identify hadn't completed (the libp2p race we're fixing).
       (agent as any).skippedNoSyncPeers.add(remotePeer);
@@ -730,6 +746,7 @@ describe('DKGAgent sync retry — event-driven via peer:update', () => {
       }
 
       expect(calls).toEqual([remotePeer]);
+      expect(ensureAdmitted.calls.map(([peerId]) => peerId)).toEqual([remotePeer]);
       expect((agent as any).skippedNoSyncPeers.has(remotePeer)).toBe(false);
     } finally {
       await agent.stop().catch(() => {});
@@ -744,6 +761,7 @@ describe('DKGAgent sync retry — event-driven via peer:update', () => {
     });
     try {
       await agent.start();
+      allowAllNetworkAdmission(agent);
 
       const remotePeer = freshPeerIdString();
       (agent as any).skippedNoSyncPeers.add(remotePeer);
@@ -781,6 +799,7 @@ describe('DKGAgent sync retry — event-driven via peer:update', () => {
     });
     try {
       await agent.start();
+      allowAllNetworkAdmission(agent);
 
       const remotePeer = freshPeerIdString();
 
@@ -819,6 +838,7 @@ describe('DKGAgent sync retry — periodic reconciler', () => {
     });
     try {
       await agent.start();
+      allowAllNetworkAdmission(agent);
 
       const peerA = freshPeerIdString();
       const peerB = freshPeerIdString();
@@ -851,6 +871,7 @@ describe('DKGAgent sync retry — periodic reconciler', () => {
     });
     try {
       await agent.start();
+      allowAllNetworkAdmission(agent);
 
       const freshPeer = freshPeerIdString();
       const stalePeer = freshPeerIdString();
@@ -887,6 +908,7 @@ describe('DKGAgent sync retry — periodic reconciler', () => {
     });
     try {
       await agent.start();
+      allowAllNetworkAdmission(agent);
 
       const remotePeer = freshPeerIdString();
       const origGetPeers = agent.node.libp2p.getPeers.bind(agent.node.libp2p);
@@ -920,6 +942,7 @@ describe('DKGAgent sync retry — periodic reconciler', () => {
     });
     try {
       await agent.start();
+      allowAllNetworkAdmission(agent);
 
       const peerA = freshPeerIdString();
 
@@ -953,6 +976,7 @@ describe('DKGAgent sync retry — periodic reconciler', () => {
     });
     try {
       await agent.start();
+      allowAllNetworkAdmission(agent);
 
       const peerA = freshPeerIdString();
       const origGetPeers = agent.node.libp2p.getPeers.bind(agent.node.libp2p);
@@ -1015,6 +1039,7 @@ describe('DKGAgent sync retry — periodic reconciler', () => {
     });
     try {
       await agent.start();
+      allowAllNetworkAdmission(agent);
 
       const peerA = freshPeerIdString();
       const origGetPeers = agent.node.libp2p.getPeers.bind(agent.node.libp2p);
@@ -1055,6 +1080,7 @@ describe('DKGAgent sync retry — periodic reconciler', () => {
     });
     try {
       await agent.start();
+      allowAllNetworkAdmission(agent);
 
       const peerA = freshPeerIdString();
       const origGetPeers = agent.node.libp2p.getPeers.bind(agent.node.libp2p);
@@ -1094,6 +1120,7 @@ describe('DKGAgent sync retry — periodic reconciler', () => {
     });
     try {
       await agent.start();
+      allowAllNetworkAdmission(agent);
 
       const peerA = freshPeerIdString();
       const origGetPeers = agent.node.libp2p.getPeers.bind(agent.node.libp2p);
@@ -1120,6 +1147,7 @@ describe('DKGAgent sync retry — periodic reconciler', () => {
     });
     try {
       await agent.start();
+      allowAllNetworkAdmission(agent);
 
       const peerA = freshPeerIdString();
       const origGetPeers = agent.node.libp2p.getPeers.bind(agent.node.libp2p);
@@ -1148,6 +1176,7 @@ describe('DKGAgent sync retry — periodic reconciler', () => {
     });
     try {
       await agent.start();
+      allowAllNetworkAdmission(agent);
 
       const peerA = freshPeerIdString();
       const origGetPeers = agent.node.libp2p.getPeers.bind(agent.node.libp2p);
@@ -1178,6 +1207,7 @@ describe('DKGAgent sync retry — periodic reconciler', () => {
     });
     try {
       await agent.start();
+      allowAllNetworkAdmission(agent);
 
       const peerA = freshPeerIdString();
       let connectedPeers = [peerIdFromString(peerA)];
@@ -1219,6 +1249,7 @@ describe('DKGAgent sync state lifecycle', () => {
     });
     try {
       await agent.start();
+      allowAllNetworkAdmission(agent);
 
       const remotePeer = freshPeerIdString();
       (agent as any).skippedNoSyncPeers.add(remotePeer);
@@ -1254,6 +1285,7 @@ describe('DKGAgent sync state lifecycle', () => {
     });
     try {
       await agent.start();
+      allowAllNetworkAdmission(agent);
 
       const remotePeer = freshPeerIdString();
       (agent as any).lastSuccessfulSyncAt.set(remotePeer, Date.now() - 30_000);
@@ -1287,6 +1319,7 @@ describe('DKGAgent sync state lifecycle', () => {
     });
     try {
       await agent.start();
+      allowAllNetworkAdmission(agent);
 
       const remotePeer = freshPeerIdString();
       const sameTickBoundary = Date.now() - 30_000;
@@ -1307,7 +1340,7 @@ describe('DKGAgent sync state lifecycle', () => {
         },
       } as any));
 
-      expect((agent as any).catchupOnConnectAt.get(remotePeer)).toBeGreaterThan(sameTickBoundary);
+      expect((agent as any).catchupOnConnectAt.get(remotePeer)).toBeGreaterThanOrEqual(sameTickBoundary);
       await new Promise(r => setTimeout(r, 3100));
       expect(calls).toEqual([remotePeer]);
     } finally {
@@ -1323,6 +1356,7 @@ describe('DKGAgent sync state lifecycle', () => {
     });
     try {
       await agent.start();
+      allowAllNetworkAdmission(agent);
 
       const remotePeer = freshPeerIdString();
       const now = Date.now();
@@ -1356,6 +1390,7 @@ describe('DKGAgent sync state lifecycle', () => {
     });
     try {
       await agent.start();
+      allowAllNetworkAdmission(agent);
 
       const remotePeer = freshPeerIdString();
       (agent.node.libp2p as any).getPeers = recorder(() => [peerIdFromString(remotePeer)]);
@@ -1437,6 +1472,7 @@ describe('DKGAgent sync state lifecycle', () => {
     });
     try {
       await agent.start();
+      allowAllNetworkAdmission(agent);
 
       const peerA = freshPeerIdString();
       const origGetPeers = agent.node.libp2p.getPeers.bind(agent.node.libp2p);
@@ -1480,6 +1516,7 @@ describe('DKGAgent sync transport — off the messenger substrate (node-ui.db bl
     });
     try {
       await agent.start();
+      allowAllNetworkAdmission(agent);
 
       const messengerHandlers = (agent as any).messenger.handlers as Map<string, unknown>;
       const routerHandlers = (agent as any).router.handlers as Map<string, unknown>;

--- a/packages/cli/src/daemon/http-utils.ts
+++ b/packages/cli/src/daemon/http-utils.ts
@@ -1821,6 +1821,7 @@ export function classifyClientError(
   msg: string,
 ):
   | { status: 404; sanitized: string }
+  | { status: 403; sanitized: string }
   | { status: 400; sanitized: string }
   | { status: 504; sanitized: string }
   | null {
@@ -1872,6 +1873,17 @@ export function classifyClientError(
   // start returning 500 on what's plainly a malformed-input 400.
   if (/ERR_INVALID_(PEER|MULTIHASH|MULTIADDR|CID|BASE)/.test(msg)) {
     return { status: 400, sanitized };
+  }
+  if (
+    /\b(not admitted|network identity proof rejected|NETWORK_ADMISSION_REJECTED)\b/i.test(msg)
+  ) {
+    return { status: 403, sanitized };
+  }
+  if (
+    /\b(network identity probe failed|network admission probe failed|NETWORK_ADMISSION_PROBE_FAILED|protocol selection failed|could not negotiate)\b/i.test(msg) ||
+    /not synchronously deliverable \(queued\)/i.test(msg)
+  ) {
+    return { status: 504, sanitized };
   }
   return null;
 }

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1969,8 +1969,6 @@ export async function runDaemonInner(
             chainBase: publisherChainBase,
             ackTransportFactory: agent.createACKTransportFactory({
               sendTimeoutMs: storageAckTiming.sendTimeoutMs,
-              // to the prior `agent.router.send` path — `/dkg/10.0.0/*`
-              // through) → `ProtocolRouter.send`. The wiring matters at
               log,
             }),
             publishEncryptionFactory: (publishOptions) => resolveDaemonPublishEncryption(agent, publishOptions),

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -647,12 +647,14 @@ export function orderACKCandidatePeerIds(input: {
   selfPeerId: string;
   knownCorePeerIds?: ReadonlySet<string>;
   preferredACKPeerIds?: readonly string[];
+  verifiedSameNetworkPeerIds?: ReadonlySet<string>;
 }): string[] {
   return selectACKCandidatePeers({
     connectedPeers: input.connectedPeerIds,
     selfPeerId: input.selfPeerId,
     knownCorePeerIds: input.knownCorePeerIds,
     preferredACKPeerIds: input.preferredACKPeerIds,
+    verifiedSameNetworkPeerIds: input.verifiedSameNetworkPeerIds,
     requiredACKs: Number.MAX_SAFE_INTEGER,
   });
 }
@@ -1528,6 +1530,12 @@ export async function runDaemonInner(
     kaNumberAllocator,
     name: config.name,
     genesisId: network?.genesisId,
+    networkIdentity: {
+      genesisId: network?.genesisId,
+      networkId,
+      chainId: chainBase?.chainId,
+      networkConfigName: resolveNetworkConfigName(config),
+    },
     framework: "DKG",
     listenPort: config.listenPort,
     dataDir: dkgDir(),
@@ -1961,6 +1969,8 @@ export async function runDaemonInner(
             chainBase: publisherChainBase,
             ackTransportFactory: agent.createACKTransportFactory({
               sendTimeoutMs: storageAckTiming.sendTimeoutMs,
+              // to the prior `agent.router.send` path — `/dkg/10.0.0/*`
+              // through) → `ProtocolRouter.send`. The wiring matters at
               log,
             }),
             publishEncryptionFactory: (publishOptions) => resolveDaemonPublishEncryption(agent, publishOptions),

--- a/packages/cli/src/daemon/routes/agent-chat.ts
+++ b/packages/cli/src/daemon/routes/agent-chat.ts
@@ -979,6 +979,9 @@ export async function handleAgentChatRoutes(ctx: RequestContext): Promise<void> 
         case 'DIAL_FAILED':
           status = 502; // retriable: addrs known but transport failed
           break;
+        case 'NETWORK_ADMISSION_REJECTED':
+          status = 403; // reachable peer, but not part of this active DKG network
+          break;
         default:
           status = 400;
       }

--- a/packages/cli/test/http-admission-control.test.ts
+++ b/packages/cli/test/http-admission-control.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import type { ServerResponse } from 'node:http';
-import { InFlightLimiter, admitRequest, resolveIntSetting, applyServerLimits } from '../src/daemon/http-utils.js';
+import {
+  InFlightLimiter,
+  admitRequest,
+  resolveIntSetting,
+  applyServerLimits,
+  classifyClientError,
+} from '../src/daemon/http-utils.js';
 
 /**
  * Minimal ServerResponse stand-in capturing writeHead/end and supporting the
@@ -78,6 +84,17 @@ describe('InFlightLimiter — concurrency admission control', () => {
     limiter.release();
     expect(limiter.tryAcquire()).toBe(true); // admitted again — still 2
     expect(limiter.rejectedTotal).toBe(2);
+  });
+});
+
+describe('classifyClientError', () => {
+  it('maps active-network admission failures to bounded HTTP statuses', () => {
+    expect(classifyClientError(
+      'peer abcdefgh is not admitted for outbound protocol /dkg/10.0.1/query',
+    )).toMatchObject({ status: 403 });
+    expect(classifyClientError(
+      'Network identity probe failed for abcdefgh: Protocol selection failed - could not negotiate /dkg/10.0.1/network-identity',
+    )).toMatchObject({ status: 504 });
   });
 });
 

--- a/packages/cli/test/preferred-relays.test.ts
+++ b/packages/cli/test/preferred-relays.test.ts
@@ -239,4 +239,17 @@ describe('orderACKCandidatePeerIds', () => {
       knownCorePeerIds: new Set(),
     })).toEqual(['edge-1', 'edge-2']);
   });
+
+  it('filters daemon async ACK candidates to active-network admitted peers when provided', () => {
+    const base = ['base-core-1', 'base-core-2'];
+    const testnet = ['testnet-core-1', 'testnet-core-2'];
+
+    expect(orderACKCandidatePeerIds({
+      connectedPeerIds: ['self', testnet[0], base[0], testnet[1], base[1]],
+      selfPeerId: 'self',
+      knownCorePeerIds: new Set([...base, ...testnet]),
+      preferredACKPeerIds: [testnet[0], base[0]],
+      verifiedSameNetworkPeerIds: new Set(base),
+    })).toEqual(base);
+  });
 });

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -157,8 +157,49 @@ export const PROTOCOL_STORAGE_UPDATE_ACK = '/dkg/10.0.1/storage-update-ack';
  * signed JSON wire format and per-pull authorization gate.
  */
 export const PROTOCOL_GET_CIPHERTEXT_CHUNK = '/dkg/10.0.2/get-ciphertext-chunk';
+export const PROTOCOL_NETWORK_IDENTITY = '/dkg/10.0.1/network-identity';
 
 export const DHT_PROTOCOL = '/dkg/kad/1.0.0';
+
+const NETWORK_TOPIC_PREFIX = 'dkg/network';
+const NON_DKG_TOPIC_PREFIX = 'topic';
+
+export function networkNamespaceSegment(networkId: string, chainId?: string): string {
+  const parts = [networkId, chainId]
+    .map((part) => part?.trim())
+    .filter((part): part is string => Boolean(part));
+  for (const part of parts) {
+    if (!/^[A-Za-z0-9._:-]+$/.test(part)) {
+      throw new Error(`Invalid DKG network namespace: ${part}`);
+    }
+  }
+  return parts.join('.');
+}
+
+export function dhtProtocolForNetwork(networkId?: string, chainId?: string): string {
+  if (!networkId) return DHT_PROTOCOL;
+  return `/dkg/${networkNamespaceSegment(networkId, chainId)}/kad/1.0.0`;
+}
+
+export function wireTopicForNetwork(networkId: string | undefined, logicalTopic: string, chainId?: string): string {
+  if (!networkId) return logicalTopic;
+  const segment = networkNamespaceSegment(networkId, chainId);
+  const suffix = logicalTopic.startsWith('dkg/')
+    ? logicalTopic.slice('dkg/'.length)
+    : `${NON_DKG_TOPIC_PREFIX}/${logicalTopic}`;
+  return `${NETWORK_TOPIC_PREFIX}/${segment}/${suffix}`;
+}
+
+export function logicalTopicFromWireTopic(networkId: string | undefined, wireTopic: string, chainId?: string): string | null {
+  if (!networkId) return wireTopic;
+  const prefix = `${NETWORK_TOPIC_PREFIX}/${networkNamespaceSegment(networkId, chainId)}/`;
+  if (!wireTopic.startsWith(prefix)) return null;
+  const suffix = wireTopic.slice(prefix.length);
+  if (suffix.startsWith(`${NON_DKG_TOPIC_PREFIX}/`)) {
+    return suffix.slice(NON_DKG_TOPIC_PREFIX.length + 1);
+  }
+  return `dkg/${suffix}`;
+}
 
 /** Maximum application payload size allowed for one DKG GossipSub message (10 MB). */
 export const DKG_GOSSIP_MAX_MESSAGE_BYTES = 10 * 1024 * 1024;

--- a/packages/core/src/genesis.ts
+++ b/packages/core/src/genesis.ts
@@ -8,7 +8,7 @@
 
 const GENESIS_AGENTS_GRAPH = 'did:dkg:context-graph:agents';
 const GENESIS_ONTOLOGY_GRAPH = 'did:dkg:context-graph:ontology';
-const DEFAULT_GENESIS_ID = 'base-testnet';
+export const DEFAULT_GENESIS_ID = 'base-testnet';
 
 interface GenesisNetworkDefinition {
   subject: string;

--- a/packages/core/src/gossipsub-manager.ts
+++ b/packages/core/src/gossipsub-manager.ts
@@ -2,6 +2,7 @@ import type { DKGNode } from './node.js';
 import type { EventBus } from './types.js';
 import { DKGEvent } from './event-bus.js';
 import { withRetry } from './retry.js';
+import { logicalTopicFromWireTopic, wireTopicForNetwork } from './constants.js';
 
 export type GossipMessageHandler = (
   topic: string,
@@ -9,25 +10,47 @@ export type GossipMessageHandler = (
   from: string,
 ) => void;
 
+export interface GossipSubManagerOptions {
+  networkId?: string;
+  chainId?: string;
+  isPeerAccepted?: (peerId: string, topic: string) => boolean;
+}
+
 export class GossipSubManager {
   private readonly node: DKGNode;
   private readonly eventBus: EventBus;
+  private readonly networkId?: string;
+  private readonly chainId?: string;
+  private readonly isPeerAccepted?: (peerId: string, topic: string) => boolean;
   private topicHandlers = new Map<string, Set<GossipMessageHandler>>();
 
-  constructor(node: DKGNode, eventBus: EventBus) {
+  constructor(node: DKGNode, eventBus: EventBus, options: GossipSubManagerOptions = {}) {
     this.node = node;
     this.eventBus = eventBus;
+    this.networkId = options.networkId;
+    this.chainId = options.chainId;
+    this.isPeerAccepted = options.isPeerAccepted;
     this.setupListener();
+  }
+
+  private toWireTopic(logicalTopic: string): string {
+    return wireTopicForNetwork(this.networkId, logicalTopic, this.chainId);
+  }
+
+  private toLogicalTopic(wireTopic: string): string | null {
+    return logicalTopicFromWireTopic(this.networkId, wireTopic, this.chainId);
   }
 
   private setupListener(): void {
     const pubsub = this.node.libp2p.services.pubsub;
     pubsub.addEventListener('message', (evt) => {
       const msg = evt.detail;
-      const topic = msg.topic;
+      const topic = this.toLogicalTopic(msg.topic);
+      if (topic == null) return;
       const data =
         msg.data instanceof Uint8Array ? msg.data : new Uint8Array(0);
       const from = 'from' in msg ? String(msg.from) : 'unknown';
+      if (this.isPeerAccepted && !this.isPeerAccepted(from, topic)) return;
 
       this.eventBus.emit(DKGEvent.GOSSIP_MESSAGE, { topic, data, from });
 
@@ -45,17 +68,18 @@ export class GossipSubManager {
   }
 
   subscribe(topic: string): void {
-    this.node.libp2p.services.pubsub.subscribe(topic);
+    this.node.libp2p.services.pubsub.subscribe(this.toWireTopic(topic));
   }
 
   unsubscribe(topic: string): void {
-    this.node.libp2p.services.pubsub.unsubscribe(topic);
+    this.node.libp2p.services.pubsub.unsubscribe(this.toWireTopic(topic));
     this.topicHandlers.delete(topic);
   }
 
   async publish(topic: string, data: Uint8Array): Promise<void> {
+    const wireTopic = this.toWireTopic(topic);
     await withRetry(
-      () => this.node.libp2p.services.pubsub.publish(topic, data),
+      () => this.node.libp2p.services.pubsub.publish(wireTopic, data),
       {
         maxAttempts: 3,
         baseDelayMs: 500,
@@ -83,7 +107,9 @@ export class GossipSubManager {
   }
 
   get subscribedTopics(): string[] {
-    return this.node.libp2p.services.pubsub.getTopics();
+    return this.node.libp2p.services.pubsub.getTopics()
+      .map((topic) => this.toLogicalTopic(topic))
+      .filter((topic): topic is string => topic != null);
   }
 
   /**
@@ -105,6 +131,6 @@ export class GossipSubManager {
   getSubscribers(topic: string): string[] {
     const pubsub = this.node.libp2p.services.pubsub as { getSubscribers?: (t: string) => Array<{ toString(): string }> };
     if (typeof pubsub.getSubscribers !== 'function') return [];
-    return pubsub.getSubscribers(topic).map(p => p.toString());
+    return pubsub.getSubscribers(this.toWireTopic(topic)).map(p => p.toString());
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -111,6 +111,7 @@ export {
 export {
   ProtocolRouter,
   QuietRetryableHandlerError,
+  type AdmissionCheckOptions,
   type ProtocolRouterOptions,
   type SendOptions,
   DEFAULT_MAX_READ_BYTES,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -142,6 +142,7 @@ export {
 export { GossipSubManager, type GossipMessageHandler } from './gossipsub-manager.js';
 export { PeerDiscoveryManager } from './discovery.js';
 export {
+  DEFAULT_GENESIS_ID,
   getGenesisQuads,
   computeNetworkId,
   getGenesisRaw,

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -21,7 +21,9 @@ import type { ConnectionTransport, DKGNodeConfig } from './types.js';
 import { DKG_GOSSIP_MAX_RPC_BYTES, dhtProtocolForNetwork } from './constants.js';
 import { RelayMetricsAdapter, RELAY_V2_STOP_CODEC } from './libp2p-metrics-adapter.js';
 import { readRelayReservations, readConnectionStreams } from './relay-internal-shapes.js';
-import { RelayFlapGuard, parseCircuitRelayPeerIds, buildRelayFlapConnectionGater, buildActiveRelayDiscoveryFilter } from './relay-flap-guard.js';
+import { RelayFlapGuard, buildRelayFlapConnectionGater } from './relay-flap-guard.js';
+import { buildActiveRelayNetworkPolicy } from './relay-network-policy.js';
+import { parseCircuitRelayPeerIds, type RelayedConnectionGater } from './relay-path.js';
 
 export interface DKGServices extends Record<string, unknown> {
   dht: KadDHT;
@@ -874,7 +876,11 @@ export class DKGNode {
     const activeNetworkRelayPeerIds = this.config.networkIdentity
       ? new Set(usableRelayCandidates.map(({ peerId }) => peerId.toString()))
       : undefined;
-    const activeRelayDiscoveryFilter = buildActiveRelayDiscoveryFilter(activeNetworkRelayPeerIds);
+    const activeRelayNetworkPolicy = buildActiveRelayNetworkPolicy(
+      activeNetworkRelayPeerIds,
+      (message) => console.warn(`[${new Date().toISOString()}] ${message}`),
+    );
+    const activeRelayDiscoveryFilter = activeRelayNetworkPolicy?.discoveryFilter;
 
     // TCP keepAlive helps prevent idle relay connections from being dropped by
     // middleboxes or remote timeouts (common cause of ECONNRESET).
@@ -1111,7 +1117,7 @@ export class DKGNode {
       streamMuxers: [yamux()],
       peerDiscovery,
       services,
-      connectionGater: this.createRelayFlapConnectionGater(activeNetworkRelayPeerIds),
+      connectionGater: this.createRelayConnectionGater(activeRelayNetworkPolicy?.connectionGater),
       connectionManager: {
         minConnections: 0,
         // Core Nodes scale this with relayServerCapacity (default
@@ -1472,16 +1478,23 @@ export class DKGNode {
     }
   }
 
-  private createRelayFlapConnectionGater(activeNetworkRelayPeerIds?: ReadonlySet<string>): ConnectionGater {
+  private createRelayConnectionGater(activeRelayGater?: RelayedConnectionGater): ConnectionGater {
     const ts = () => new Date().toISOString();
     // The gater hooks live in a pure builder (relay-flap-guard.ts) so the wiring
     // is unit-tested (relay-flap-guard.test.ts) — a hook arg-shape or plumbing
     // regression fails a test instead of silently leaving the guard inert.
-    return buildRelayFlapConnectionGater(
+    const flapGater = buildRelayFlapConnectionGater(
       this.relayFlapGuard,
       (message) => console.warn(`[${ts()}] ${message}`),
-      { activeRelayPeerIds: activeNetworkRelayPeerIds },
-    ) as ConnectionGater;
+    );
+    return {
+      denyInboundRelayedConnection: (relay, remotePeer) =>
+        activeRelayGater?.denyInboundRelayedConnection(relay, remotePeer) ||
+        flapGater.denyInboundRelayedConnection(relay, remotePeer),
+      denyDialMultiaddr: (multiaddr) =>
+        activeRelayGater?.denyDialMultiaddr(multiaddr) ||
+        flapGater.denyDialMultiaddr(multiaddr),
+    } as ConnectionGater;
   }
 
   /**

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -18,10 +18,10 @@ import { generateKeyPair, privateKeyFromRaw } from '@libp2p/crypto/keys';
 import { peerIdFromString, peerIdFromPrivateKey } from '@libp2p/peer-id';
 import { ed25519GetPublicKey } from './crypto/ed25519.js';
 import type { ConnectionTransport, DKGNodeConfig } from './types.js';
-import { DHT_PROTOCOL, DKG_GOSSIP_MAX_RPC_BYTES } from './constants.js';
+import { DKG_GOSSIP_MAX_RPC_BYTES, dhtProtocolForNetwork } from './constants.js';
 import { RelayMetricsAdapter, RELAY_V2_STOP_CODEC } from './libp2p-metrics-adapter.js';
 import { readRelayReservations, readConnectionStreams } from './relay-internal-shapes.js';
-import { RelayFlapGuard, parseCircuitRelayPeerIds, buildRelayFlapConnectionGater } from './relay-flap-guard.js';
+import { RelayFlapGuard, parseCircuitRelayPeerIds, buildRelayFlapConnectionGater, buildActiveRelayDiscoveryFilter } from './relay-flap-guard.js';
 
 export interface DKGServices extends Record<string, unknown> {
   dht: KadDHT;
@@ -871,6 +871,11 @@ export class DKGNode {
       );
     }
 
+    const activeNetworkRelayPeerIds = this.config.networkIdentity
+      ? new Set(usableRelayCandidates.map(({ peerId }) => peerId.toString()))
+      : undefined;
+    const activeRelayDiscoveryFilter = buildActiveRelayDiscoveryFilter(activeNetworkRelayPeerIds);
+
     // TCP keepAlive helps prevent idle relay connections from being dropped by
     // middleboxes or remote timeouts (common cause of ECONNRESET).
     const transports: any[] = [
@@ -894,12 +899,16 @@ export class DKGNode {
           ? {
               maxInboundStopStreams: relayCaps.maxInboundStopStreams,
               maxOutboundStopStreams: relayCaps.maxOutboundStopStreams,
+              ...(activeRelayDiscoveryFilter ? { discoveryFilter: activeRelayDiscoveryFilter } : {}),
               ...(isEdgeWithRelays
                 ? { reservationConcurrency: relayReservationCount }
                 : {}),
             }
           : isEdgeWithRelays
-            ? { reservationConcurrency: relayReservationCount }
+            ? {
+                reservationConcurrency: relayReservationCount,
+                ...(activeRelayDiscoveryFilter ? { discoveryFilter: activeRelayDiscoveryFilter } : {}),
+              }
             : undefined,
       ),
     ];
@@ -921,7 +930,13 @@ export class DKGNode {
     const services: Record<string, any> = {
       identify: identify(),
       ping: ping(),
-      dht: kadDHT(buildKadDHTOptions(this.config, DHT_PROTOCOL)),
+      dht: kadDHT(buildKadDHTOptions(
+        this.config,
+        dhtProtocolForNetwork(
+          this.config.networkIdentity?.networkId,
+          this.config.networkIdentity?.chainId,
+        ),
+      )),
       pubsub: gossipsub({
         emitSelf: false,
         allowPublishToZeroTopicPeers: true,
@@ -1096,7 +1111,7 @@ export class DKGNode {
       streamMuxers: [yamux()],
       peerDiscovery,
       services,
-      connectionGater: this.createRelayFlapConnectionGater(),
+      connectionGater: this.createRelayFlapConnectionGater(activeNetworkRelayPeerIds),
       connectionManager: {
         minConnections: 0,
         // Core Nodes scale this with relayServerCapacity (default
@@ -1457,7 +1472,7 @@ export class DKGNode {
     }
   }
 
-  private createRelayFlapConnectionGater(): ConnectionGater {
+  private createRelayFlapConnectionGater(activeNetworkRelayPeerIds?: ReadonlySet<string>): ConnectionGater {
     const ts = () => new Date().toISOString();
     // The gater hooks live in a pure builder (relay-flap-guard.ts) so the wiring
     // is unit-tested (relay-flap-guard.test.ts) — a hook arg-shape or plumbing
@@ -1465,6 +1480,7 @@ export class DKGNode {
     return buildRelayFlapConnectionGater(
       this.relayFlapGuard,
       (message) => console.warn(`[${ts()}] ${message}`),
+      { activeRelayPeerIds: activeNetworkRelayPeerIds },
     ) as ConnectionGater;
   }
 

--- a/packages/core/src/protocol-router.ts
+++ b/packages/core/src/protocol-router.ts
@@ -128,9 +128,9 @@ export interface ProtocolRouterOptions {
    * before inbound application handler dispatch, including pooled handlers.
    *
    * Use `admissionExemptProtocols` for narrow pre-admission protocols such as
-   * a network-identity probe. The hook should be side-effect-free and fast; it
-   * may return a Promise when the caller fronts it with an async admission
-   * registry.
+   * a network-identity probe. The hook may be async: production admission can
+   * distinguish an unknown peer from a rejected peer by running an exempt proof
+   * before the app protocol is failed.
    */
   isPeerAccepted?: (
     peerId: string,
@@ -429,8 +429,8 @@ export class ProtocolRouter {
       const handlerSignal = handlerSignalScope.signal;
       try {
         const remotePeer = connection.remotePeer.toString();
-        await this.requirePeerAccepted(remotePeer, protocolId, 'inbound');
         const requestData = await readAllWithSignal(stream, limit, handlerSignal);
+        await this.requirePeerAccepted(remotePeer, protocolId, 'inbound');
         const peerId = {
           toString: () => remotePeer,
           toBytes: () => connection.remotePeer.toMultihash().bytes,

--- a/packages/core/src/protocol-router.ts
+++ b/packages/core/src/protocol-router.ts
@@ -96,6 +96,13 @@ export interface SendOptions {
   signal?: AbortSignal;
 }
 
+export interface AdmissionCheckOptions {
+  /** Shared operation cancellation signal; admission must not outlive the caller. */
+  signal?: AbortSignal;
+  /** Remaining operation timeout for admission probes that need their own timer. */
+  timeoutMs?: number;
+}
+
 export interface ProtocolRouterOptions {
   maxReadBytes?: number;
   /**
@@ -136,6 +143,7 @@ export interface ProtocolRouterOptions {
     peerId: string,
     protocolId: string,
     direction: 'inbound' | 'outbound',
+    options?: AdmissionCheckOptions,
   ) => boolean | Promise<boolean>;
   admissionExemptProtocols?: Iterable<string>;
 }
@@ -204,9 +212,10 @@ export class ProtocolRouter {
     peerId: string,
     protocolId: string,
     direction: 'inbound' | 'outbound',
+    options?: AdmissionCheckOptions,
   ): Promise<void> {
     if (!this.isPeerAccepted || this.admissionExemptProtocols.has(protocolId)) return;
-    const accepted = await this.isPeerAccepted(peerId, protocolId, direction);
+    const accepted = await this.isPeerAccepted(peerId, protocolId, direction, options);
     if (accepted) return;
     throw new Error(
       `peer ${peerId.slice(-8)} is not admitted for ${direction} protocol ${protocolId}`,
@@ -354,7 +363,9 @@ export class ProtocolRouter {
       const handlerSignal = handlerSignalScope.signal;
       try {
         if (handlerSignal?.aborted) throw asAbortError(handlerSignal.reason);
-        await this.requirePeerAccepted(remote.toString(), logicalProtocolId, 'inbound');
+        await this.requirePeerAccepted(remote.toString(), logicalProtocolId, 'inbound', {
+          signal: handlerSignal,
+        });
         const responseData = await handler(requestData, wrappedPeerId, { signal: handlerSignal });
         if (handlerSignal?.aborted) throw asAbortError(handlerSignal.reason);
         return responseData;
@@ -430,7 +441,9 @@ export class ProtocolRouter {
       try {
         const remotePeer = connection.remotePeer.toString();
         const requestData = await readAllWithSignal(stream, limit, handlerSignal);
-        await this.requirePeerAccepted(remotePeer, protocolId, 'inbound');
+        await this.requirePeerAccepted(remotePeer, protocolId, 'inbound', {
+          signal: handlerSignal,
+        });
         const peerId = {
           toString: () => remotePeer,
           toBytes: () => connection.remotePeer.toMultihash().bytes,
@@ -561,7 +574,16 @@ export class ProtocolRouter {
       typeof timeoutMsOrOpts === 'number' ? { timeoutMs: timeoutMsOrOpts } : timeoutMsOrOpts;
     const timeoutMs = opts.timeoutMs ?? DEFAULT_SEND_TIMEOUT_MS;
     const parallelPaths = Math.max(1, Math.floor(opts.parallelPaths ?? 1));
-    await this.requirePeerAccepted(peerIdStr, protocolId, 'outbound');
+    const overallStartedAt = Date.now();
+    const overallDeadline = AbortSignal.timeout(timeoutMs);
+    const stopSignal = this.node.stopSignal;
+    const budgetSignal = composeAbortSignals(overallDeadline, opts.signal) ?? overallDeadline;
+    const overallSignal = composeAbortSignals(budgetSignal, stopSignal) ?? budgetSignal;
+    if (overallSignal.aborted) throw asAbortError(overallSignal.reason);
+    await this.requirePeerAccepted(peerIdStr, protocolId, 'outbound', {
+      signal: overallSignal,
+      timeoutMs,
+    });
 
     // Pooled overlay short-circuit. When `enablePooling(protocolId)`
     // has been called for this logical protocol AND the peer hasn't
@@ -586,13 +608,6 @@ export class ProtocolRouter {
     // fallback honors. The shared signal aborts BOTH the pool
     // attempt and any one-shot retry as soon as the overall budget
     // is exhausted.
-    const overallStartedAt = Date.now();
-    const overallDeadline = AbortSignal.timeout(timeoutMs);
-    const stopSignal = this.node.stopSignal;
-    const budgetSignal = composeAbortSignals(overallDeadline, opts.signal) ?? overallDeadline;
-    const overallSignal = composeAbortSignals(budgetSignal, stopSignal) ?? budgetSignal;
-    if (overallSignal.aborted) throw asAbortError(overallSignal.reason);
-
     const overlay = this.pooledByLogical.get(protocolId);
     const memoizedVariant = this.peerWireVariantFor(peerIdStr, protocolId);
     if (overlay && memoizedVariant !== 'one-shot') {

--- a/packages/core/src/protocol-router.ts
+++ b/packages/core/src/protocol-router.ts
@@ -122,6 +122,22 @@ export interface ProtocolRouterOptions {
    * call-time surface.
    */
   peerResolver?: PeerResolver;
+  /**
+   * Optional app-protocol admission gate. When present, every DKG
+   * request/response protocol is checked before outbound dial/reuse and
+   * before inbound application handler dispatch, including pooled handlers.
+   *
+   * Use `admissionExemptProtocols` for narrow pre-admission protocols such as
+   * a network-identity probe. The hook should be side-effect-free and fast; it
+   * may return a Promise when the caller fronts it with an async admission
+   * registry.
+   */
+  isPeerAccepted?: (
+    peerId: string,
+    protocolId: string,
+    direction: 'inbound' | 'outbound',
+  ) => boolean | Promise<boolean>;
+  admissionExemptProtocols?: Iterable<string>;
 }
 
 export class QuietRetryableHandlerError extends Error {
@@ -134,6 +150,8 @@ export class QuietRetryableHandlerError extends Error {
 export class ProtocolRouter {
   private readonly node: DKGNode;
   private readonly peerResolver?: PeerResolver;
+  private readonly isPeerAccepted?: ProtocolRouterOptions['isPeerAccepted'];
+  private readonly admissionExemptProtocols: ReadonlySet<string>;
   private handlers = new Map<string, DKGStreamHandler>();
   /**
    * One-shot guard: we warn the first time `send()` runs without a
@@ -177,7 +195,22 @@ export class ProtocolRouter {
   constructor(node: DKGNode, options?: ProtocolRouterOptions) {
     this.node = node;
     this.peerResolver = options?.peerResolver;
+    this.isPeerAccepted = options?.isPeerAccepted;
+    this.admissionExemptProtocols = new Set(options?.admissionExemptProtocols ?? []);
     this.maxReadBytes = options?.maxReadBytes ?? DEFAULT_MAX_READ_BYTES;
+  }
+
+  private async requirePeerAccepted(
+    peerId: string,
+    protocolId: string,
+    direction: 'inbound' | 'outbound',
+  ): Promise<void> {
+    if (!this.isPeerAccepted || this.admissionExemptProtocols.has(protocolId)) return;
+    const accepted = await this.isPeerAccepted(peerId, protocolId, direction);
+    if (accepted) return;
+    throw new Error(
+      `peer ${peerId.slice(-8)} is not admitted for ${direction} protocol ${protocolId}`,
+    );
   }
 
   /**
@@ -321,6 +354,7 @@ export class ProtocolRouter {
       const handlerSignal = handlerSignalScope.signal;
       try {
         if (handlerSignal?.aborted) throw asAbortError(handlerSignal.reason);
+        await this.requirePeerAccepted(remote.toString(), logicalProtocolId, 'inbound');
         const responseData = await handler(requestData, wrappedPeerId, { signal: handlerSignal });
         if (handlerSignal?.aborted) throw asAbortError(handlerSignal.reason);
         return responseData;
@@ -394,9 +428,11 @@ export class ProtocolRouter {
       const handlerSignalScope = composeAbortSignalsScoped(streamController.signal, stopSignal);
       const handlerSignal = handlerSignalScope.signal;
       try {
+        const remotePeer = connection.remotePeer.toString();
+        await this.requirePeerAccepted(remotePeer, protocolId, 'inbound');
         const requestData = await readAllWithSignal(stream, limit, handlerSignal);
         const peerId = {
-          toString: () => connection.remotePeer.toString(),
+          toString: () => remotePeer,
           toBytes: () => connection.remotePeer.toMultihash().bytes,
         };
         if (handlerSignal?.aborted) throw asAbortError(handlerSignal.reason);
@@ -525,6 +561,7 @@ export class ProtocolRouter {
       typeof timeoutMsOrOpts === 'number' ? { timeoutMs: timeoutMsOrOpts } : timeoutMsOrOpts;
     const timeoutMs = opts.timeoutMs ?? DEFAULT_SEND_TIMEOUT_MS;
     const parallelPaths = Math.max(1, Math.floor(opts.parallelPaths ?? 1));
+    await this.requirePeerAccepted(peerIdStr, protocolId, 'outbound');
 
     // Pooled overlay short-circuit. When `enablePooling(protocolId)`
     // has been called for this logical protocol AND the peer hasn't

--- a/packages/core/src/relay-flap-guard.ts
+++ b/packages/core/src/relay-flap-guard.ts
@@ -1,3 +1,8 @@
+import { parseCircuitRelayPeerIds, type RelayedConnectionGater } from './relay-path.js';
+
+export { parseCircuitRelayPeerIds } from './relay-path.js';
+export type { RelayPathPeerIds } from './relay-path.js';
+
 export const RELAY_FLAP_SHORT_CLOSE_MS = 1_000;
 export const RELAY_FLAP_WINDOW_MS = 60_000;
 export const RELAY_FLAP_THRESHOLD = 5;
@@ -7,11 +12,6 @@ export const RELAY_FLAP_STABLE_CLOSE_MS = 10_000;
 export const RELAY_FLAP_DENY_LOG_INTERVAL_MS = 30_000;
 
 const KEY_SEPARATOR = '\u001f';
-
-export interface RelayPathPeerIds {
-  relayPeerId: string;
-  remotePeerId?: string;
-}
 
 export interface RelayFlapGuardOptions {
   shortCloseMs?: number;
@@ -76,31 +76,6 @@ function clampPositiveInteger(value: number, fallback: number): number {
   return Number.isFinite(value) && Number.isInteger(value) && value > 0
     ? value
     : fallback;
-}
-
-export function parseCircuitRelayPeerIds(addr: string): RelayPathPeerIds | null {
-  const parts = addr.split('/').filter(Boolean);
-  const circuitIndex = parts.indexOf('p2p-circuit');
-  if (circuitIndex === -1) return null;
-
-  let relayPeerId: string | undefined;
-  for (let i = circuitIndex - 1; i >= 0; i--) {
-    if (parts[i] === 'p2p' && i + 1 < circuitIndex) {
-      relayPeerId = parts[i + 1];
-      break;
-    }
-  }
-  if (!relayPeerId) return null;
-
-  let remotePeerId: string | undefined;
-  for (let i = circuitIndex + 1; i < parts.length - 1; i++) {
-    if (parts[i] === 'p2p') {
-      remotePeerId = parts[i + 1];
-      break;
-    }
-  }
-
-  return { relayPeerId, remotePeerId };
 }
 
 export class RelayFlapGuard {
@@ -291,51 +266,6 @@ export class RelayFlapGuard {
 }
 
 /**
- * Minimal structural shape of the libp2p ConnectionGater hooks this guard
- * implements. Kept structural (`{ toString(): string }`) so the gater can be
- * unit-tested without importing libp2p's PeerId/Multiaddr types — the module
- * stays a dependency-free, pure state machine.
- */
-export interface RelayFlapConnectionGater {
-  denyInboundRelayedConnection(relay: { toString(): string }, remotePeer: { toString(): string }): boolean;
-  denyDialMultiaddr(multiaddr: { toString(): string }): boolean;
-}
-
-export interface RelayConnectionGaterOptions {
-  /**
-   * When set, only these relay peer ids may be used for circuit-relay paths.
-   * `undefined` preserves the legacy open relay-path behavior.
-   */
-  activeRelayPeerIds?: ReadonlySet<string>;
-}
-
-export interface RelayDiscoveryFilter {
-  has(peerId: { toString(): string }): boolean;
-  add(peerId: { toString(): string }): void;
-  remove(peerId: { toString(): string }): void;
-}
-
-export function buildActiveRelayDiscoveryFilter(
-  activeRelayPeerIds: ReadonlySet<string> | undefined,
-): RelayDiscoveryFilter | undefined {
-  if (activeRelayPeerIds == null) return undefined;
-  const seen = new Set<string>();
-  return {
-    has(peerId) {
-      const id = peerId.toString();
-      return !activeRelayPeerIds.has(id) || seen.has(id);
-    },
-    add(peerId) {
-      const id = peerId.toString();
-      if (activeRelayPeerIds.has(id)) seen.add(id);
-    },
-    remove(peerId) {
-      seen.delete(peerId.toString());
-    },
-  };
-}
-
-/**
  * Build the libp2p connection-gater hooks that enforce a `RelayFlapGuard`.
  * Extracted as a pure function so the WIRING (not just the guard) is testable:
  * a regression in the hook arg-shapes or guard plumbing fails a unit test
@@ -350,25 +280,8 @@ export function buildActiveRelayDiscoveryFilter(
 export function buildRelayFlapConnectionGater(
   guard: RelayFlapGuard,
   log: (message: string) => void = () => {},
-  options: RelayConnectionGaterOptions = {},
-): RelayFlapConnectionGater {
+): RelayedConnectionGater {
   const short = (id: string): string => id.slice(-8);
-  const denyInactiveRelayPath = (
-    direction: 'inbound' | 'outbound',
-    relayPeerId: string,
-    remotePeerId?: string,
-    addr?: string,
-  ): boolean => {
-    if (options.activeRelayPeerIds == null || options.activeRelayPeerIds.has(relayPeerId)) {
-      return false;
-    }
-    log(
-      `Network isolation: denying ${direction} relayed connection ` +
-      `relay=${short(relayPeerId)}${remotePeerId ? ` remote=${short(remotePeerId)}` : ''}` +
-      `${addr ? ` addr=${addr}` : ''}`,
-    );
-    return true;
-  };
   const denyRelayedPath = (
     direction: 'inbound' | 'outbound',
     relayPeerId: string,
@@ -389,13 +302,11 @@ export function buildRelayFlapConnectionGater(
   };
   return {
     denyInboundRelayedConnection: (relay, remotePeer) =>
-      denyInactiveRelayPath('inbound', relay.toString(), remotePeer.toString()) ||
       denyRelayedPath('inbound', relay.toString(), remotePeer.toString()),
     denyDialMultiaddr: (multiaddr) => {
       const addr = multiaddr.toString();
       const parsed = parseCircuitRelayPeerIds(addr);
       if (!parsed) return false;
-      if (denyInactiveRelayPath('outbound', parsed.relayPeerId, parsed.remotePeerId, addr)) return true;
       if (!parsed.remotePeerId) return false;
       return denyRelayedPath('outbound', parsed.relayPeerId, parsed.remotePeerId, addr);
     },

--- a/packages/core/src/relay-flap-guard.ts
+++ b/packages/core/src/relay-flap-guard.ts
@@ -301,6 +301,40 @@ export interface RelayFlapConnectionGater {
   denyDialMultiaddr(multiaddr: { toString(): string }): boolean;
 }
 
+export interface RelayConnectionGaterOptions {
+  /**
+   * When set, only these relay peer ids may be used for circuit-relay paths.
+   * `undefined` preserves the legacy open relay-path behavior.
+   */
+  activeRelayPeerIds?: ReadonlySet<string>;
+}
+
+export interface RelayDiscoveryFilter {
+  has(peerId: { toString(): string }): boolean;
+  add(peerId: { toString(): string }): void;
+  remove(peerId: { toString(): string }): void;
+}
+
+export function buildActiveRelayDiscoveryFilter(
+  activeRelayPeerIds: ReadonlySet<string> | undefined,
+): RelayDiscoveryFilter | undefined {
+  if (activeRelayPeerIds == null) return undefined;
+  const seen = new Set<string>();
+  return {
+    has(peerId) {
+      const id = peerId.toString();
+      return !activeRelayPeerIds.has(id) || seen.has(id);
+    },
+    add(peerId) {
+      const id = peerId.toString();
+      if (activeRelayPeerIds.has(id)) seen.add(id);
+    },
+    remove(peerId) {
+      seen.delete(peerId.toString());
+    },
+  };
+}
+
 /**
  * Build the libp2p connection-gater hooks that enforce a `RelayFlapGuard`.
  * Extracted as a pure function so the WIRING (not just the guard) is testable:
@@ -316,8 +350,25 @@ export interface RelayFlapConnectionGater {
 export function buildRelayFlapConnectionGater(
   guard: RelayFlapGuard,
   log: (message: string) => void = () => {},
+  options: RelayConnectionGaterOptions = {},
 ): RelayFlapConnectionGater {
   const short = (id: string): string => id.slice(-8);
+  const denyInactiveRelayPath = (
+    direction: 'inbound' | 'outbound',
+    relayPeerId: string,
+    remotePeerId?: string,
+    addr?: string,
+  ): boolean => {
+    if (options.activeRelayPeerIds == null || options.activeRelayPeerIds.has(relayPeerId)) {
+      return false;
+    }
+    log(
+      `Network isolation: denying ${direction} relayed connection ` +
+      `relay=${short(relayPeerId)}${remotePeerId ? ` remote=${short(remotePeerId)}` : ''}` +
+      `${addr ? ` addr=${addr}` : ''}`,
+    );
+    return true;
+  };
   const denyRelayedPath = (
     direction: 'inbound' | 'outbound',
     relayPeerId: string,
@@ -338,11 +389,14 @@ export function buildRelayFlapConnectionGater(
   };
   return {
     denyInboundRelayedConnection: (relay, remotePeer) =>
+      denyInactiveRelayPath('inbound', relay.toString(), remotePeer.toString()) ||
       denyRelayedPath('inbound', relay.toString(), remotePeer.toString()),
     denyDialMultiaddr: (multiaddr) => {
       const addr = multiaddr.toString();
       const parsed = parseCircuitRelayPeerIds(addr);
-      if (!parsed?.remotePeerId) return false;
+      if (!parsed) return false;
+      if (denyInactiveRelayPath('outbound', parsed.relayPeerId, parsed.remotePeerId, addr)) return true;
+      if (!parsed.remotePeerId) return false;
       return denyRelayedPath('outbound', parsed.relayPeerId, parsed.remotePeerId, addr);
     },
   };

--- a/packages/core/src/relay-network-policy.ts
+++ b/packages/core/src/relay-network-policy.ts
@@ -1,0 +1,97 @@
+import { parseCircuitRelayPeerIds, type RelayedConnectionGater } from './relay-path.js';
+
+export type RelayPathDirection = 'inbound' | 'outbound';
+
+export interface RelayPathGateInput {
+  direction: RelayPathDirection;
+  relayPeerId: string;
+  remotePeerId?: string;
+  addr?: string;
+}
+
+export type RelayPathGate = (input: RelayPathGateInput) => boolean;
+
+export interface RelayDiscoveryFilter {
+  has(peerId: { toString(): string }): boolean;
+  add(peerId: { toString(): string }): void;
+  remove(peerId: { toString(): string }): void;
+}
+
+export interface RelayNetworkPolicy {
+  discoveryFilter: RelayDiscoveryFilter;
+  relayPathGate: RelayPathGate;
+  connectionGater: RelayedConnectionGater;
+}
+
+export function buildActiveRelayNetworkPolicy(
+  activeRelayPeerIds: ReadonlySet<string> | undefined,
+  log: (message: string) => void = () => {},
+): RelayNetworkPolicy | undefined {
+  if (activeRelayPeerIds == null) return undefined;
+  return {
+    discoveryFilter: buildActiveRelayDiscoveryFilter(activeRelayPeerIds),
+    relayPathGate: buildActiveRelayPathGate(activeRelayPeerIds, log),
+    connectionGater: buildActiveRelayConnectionGater(activeRelayPeerIds, log),
+  };
+}
+
+export function buildActiveRelayDiscoveryFilter(
+  activeRelayPeerIds: ReadonlySet<string>,
+): RelayDiscoveryFilter {
+  const seen = new Set<string>();
+  return {
+    has(peerId) {
+      const id = peerId.toString();
+      return !activeRelayPeerIds.has(id) || seen.has(id);
+    },
+    add(peerId) {
+      const id = peerId.toString();
+      if (activeRelayPeerIds.has(id)) seen.add(id);
+    },
+    remove(peerId) {
+      seen.delete(peerId.toString());
+    },
+  };
+}
+
+export function buildActiveRelayPathGate(
+  activeRelayPeerIds: ReadonlySet<string>,
+  log: (message: string) => void = () => {},
+): RelayPathGate {
+  const short = (id: string): string => id.slice(-8);
+  return ({ direction, relayPeerId, remotePeerId, addr }) => {
+    if (activeRelayPeerIds.has(relayPeerId)) return false;
+    log(
+      `Network isolation: denying ${direction} relayed connection ` +
+      `relay=${short(relayPeerId)}${remotePeerId ? ` remote=${short(remotePeerId)}` : ''}` +
+      `${addr ? ` addr=${addr}` : ''}`,
+    );
+    return true;
+  };
+}
+
+export function buildActiveRelayConnectionGater(
+  activeRelayPeerIds: ReadonlySet<string>,
+  log: (message: string) => void = () => {},
+): RelayedConnectionGater {
+  const relayPathGate = buildActiveRelayPathGate(activeRelayPeerIds, log);
+  return {
+    denyInboundRelayedConnection: (relay, remotePeer) =>
+      relayPathGate({
+        direction: 'inbound',
+        relayPeerId: relay.toString(),
+        remotePeerId: remotePeer.toString(),
+      }),
+    denyDialMultiaddr: (multiaddr) => {
+      const addr = multiaddr.toString();
+      const parsed = parseCircuitRelayPeerIds(addr);
+      if (!parsed) return false;
+      return relayPathGate({
+        direction: 'outbound',
+        relayPeerId: parsed.relayPeerId,
+        remotePeerId: parsed.remotePeerId,
+        addr,
+      });
+    },
+  };
+}

--- a/packages/core/src/relay-path.ts
+++ b/packages/core/src/relay-path.ts
@@ -1,0 +1,34 @@
+export interface RelayPathPeerIds {
+  relayPeerId: string;
+  remotePeerId?: string;
+}
+
+export interface RelayedConnectionGater {
+  denyInboundRelayedConnection(relay: { toString(): string }, remotePeer: { toString(): string }): boolean;
+  denyDialMultiaddr(multiaddr: { toString(): string }): boolean;
+}
+
+export function parseCircuitRelayPeerIds(addr: string): RelayPathPeerIds | null {
+  const parts = addr.split('/').filter(Boolean);
+  const circuitIndex = parts.indexOf('p2p-circuit');
+  if (circuitIndex === -1) return null;
+
+  let relayPeerId: string | undefined;
+  for (let i = circuitIndex - 1; i >= 0; i--) {
+    if (parts[i] === 'p2p' && i + 1 < circuitIndex) {
+      relayPeerId = parts[i + 1];
+      break;
+    }
+  }
+  if (!relayPeerId) return null;
+
+  let remotePeerId: string | undefined;
+  for (let i = circuitIndex + 1; i < parts.length - 1; i++) {
+    if (parts[i] === 'p2p') {
+      remotePeerId = parts[i + 1];
+      break;
+    }
+  }
+
+  return { relayPeerId, remotePeerId };
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -14,6 +14,17 @@ export interface EventBus {
   off(event: string, handler: (data: unknown) => void): void;
 }
 
+export interface DkgNetworkIdentity {
+  /** Canonical genesis identifier from the selected network config. */
+  genesisId?: string;
+  /** Canonical hash/identifier for the active DKG network. */
+  networkId: string;
+  /** Effective chain id after network config and operator overrides resolve. */
+  chainId?: string;
+  /** Selected network config name, when known by the caller. */
+  networkConfigName?: string;
+}
+
 export interface DKGNodeConfig {
   /** Multiaddr strings to listen on. Defaults to TCP + WS on random ports. */
   listenAddresses?: string[];
@@ -31,6 +42,8 @@ export interface DKGNodeConfig {
   dataDir?: string;
   /** Multiaddrs of relay nodes to connect to for NAT traversal. */
   relayPeers?: string[];
+  /** Active network identity used to isolate DHT, GossipSub, and relay wire paths. */
+  networkIdentity?: DkgNetworkIdentity;
   /** Enable circuit relay server on this node (for nodes with public IPs). */
   enableRelayServer?: boolean;
   /**

--- a/packages/core/test/constants.test.ts
+++ b/packages/core/test/constants.test.ts
@@ -7,10 +7,15 @@ import {
   contextGraphSessionsTopic,
   contextGraphPublishTopic,
   contextGraphWorkspaceTopic,
+  DHT_PROTOCOL,
   validateContextGraphId,
   validateSubGraphName,
   validateAssertionName,
   deriveCuratorDidFromCgId,
+  dhtProtocolForNetwork,
+  logicalTopicFromWireTopic,
+  networkNamespaceSegment,
+  wireTopicForNetwork,
 } from '../src/constants.js';
 import { createOperationContext } from '../src/logger.js';
 
@@ -59,6 +64,53 @@ describe('context graph topic helpers (V10)', () => {
     expect(contextGraphPublishTopic('my-contextGraph')).toBe(contextGraphFinalizationTopic('my-contextGraph'));
     expect(contextGraphPublishTopic('')).toBe(contextGraphFinalizationTopic(''));
     expect(contextGraphPublishTopic('a/b')).toBe(contextGraphFinalizationTopic('a/b'));
+  });
+});
+
+describe('network namespace helpers', () => {
+  it('keeps the legacy DHT protocol when no network identity is supplied', () => {
+    expect(dhtProtocolForNetwork()).toBe(DHT_PROTOCOL);
+  });
+
+  it('derives distinct DHT protocols for distinct networks', () => {
+    expect(dhtProtocolForNetwork('base-testnet')).toBe('/dkg/base-testnet/kad/1.0.0');
+    expect(dhtProtocolForNetwork('base-mainnet')).toBe('/dkg/base-mainnet/kad/1.0.0');
+  });
+
+  it('derives distinct DHT protocols for the same network id on different chains', () => {
+    expect(dhtProtocolForNetwork('shared-genesis', 'base:84532')).toBe('/dkg/shared-genesis.base:84532/kad/1.0.0');
+    expect(dhtProtocolForNetwork('shared-genesis', 'base:8453')).toBe('/dkg/shared-genesis.base:8453/kad/1.0.0');
+  });
+
+  it('maps logical DKG topics into and out of network-scoped wire topics', () => {
+    const logical = contextGraphFinalizationTopic('agents');
+    const wire = wireTopicForNetwork('base-testnet', logical);
+    expect(wire).toBe('dkg/network/base-testnet/context-graph/agents/finalization');
+    expect(logicalTopicFromWireTopic('base-testnet', wire)).toBe(logical);
+    expect(logicalTopicFromWireTopic('base-mainnet', wire)).toBeNull();
+  });
+
+  it('maps logical DKG topics into chain-scoped wire topics', () => {
+    const logical = contextGraphFinalizationTopic('agents');
+    const baseSepoliaWire = wireTopicForNetwork('shared-genesis', logical, 'base:84532');
+    const baseMainnetWire = wireTopicForNetwork('shared-genesis', logical, 'base:8453');
+
+    expect(baseSepoliaWire).toBe('dkg/network/shared-genesis.base:84532/context-graph/agents/finalization');
+    expect(baseMainnetWire).toBe('dkg/network/shared-genesis.base:8453/context-graph/agents/finalization');
+    expect(logicalTopicFromWireTopic('shared-genesis', baseSepoliaWire, 'base:84532')).toBe(logical);
+    expect(logicalTopicFromWireTopic('shared-genesis', baseSepoliaWire, 'base:8453')).toBeNull();
+  });
+
+  it('round-trips non-DKG topics without colliding with DKG topic suffixes', () => {
+    const wire = wireTopicForNetwork('network-a', 'custom/topic');
+    expect(wire).toBe('dkg/network/network-a/topic/custom/topic');
+    expect(logicalTopicFromWireTopic('network-a', wire)).toBe('custom/topic');
+  });
+
+  it('rejects unsafe network namespace segments', () => {
+    expect(() => networkNamespaceSegment('base/testnet')).toThrow(/Invalid DKG network namespace/);
+    expect(() => networkNamespaceSegment('base-testnet', 'bad chain')).toThrow(/Invalid DKG network namespace/);
+    expect(() => dhtProtocolForNetwork('base testnet')).toThrow(/Invalid DKG network namespace/);
   });
 });
 

--- a/packages/core/test/networking.test.ts
+++ b/packages/core/test/networking.test.ts
@@ -309,7 +309,15 @@ describe('GossipSubManager', () => {
     };
     const node = { libp2p: { services: { pubsub } } } as unknown as DKGNode;
     const bus = new TypedEventBus();
-    const manager = new GossipSubManager(node, bus, { networkId: 'base-testnet', chainId: 'base:84532' });
+    const admissionChecks: Array<{ peerId: string; topic: string }> = [];
+    const manager = new GossipSubManager(node, bus, {
+      networkId: 'base-testnet',
+      chainId: 'base:84532',
+      isPeerAccepted: (peerId, topic) => {
+        admissionChecks.push({ peerId, topic });
+        return peerId === 'peer-a';
+      },
+    });
     const logicalTopic = 'dkg/context-graph/test/finalization';
     const wireTopic = 'dkg/network/base-testnet.base:84532/context-graph/test/finalization';
 
@@ -331,6 +339,13 @@ describe('GossipSubManager', () => {
     });
     handlers[0]({
       detail: {
+        topic: wireTopic,
+        from: 'peer-b',
+        data: new TextEncoder().encode('rejected-wire'),
+      },
+    });
+    handlers[0]({
+      detail: {
         topic: 'dkg/network/base-mainnet/context-graph/test/finalization',
         from: 'peer-b',
         data: new TextEncoder().encode('foreign-wire'),
@@ -343,5 +358,9 @@ describe('GossipSubManager', () => {
     expect(manager.getSubscribers(logicalTopic)).toEqual(['peer-a']);
     expect(events).toEqual([{ topic: logicalTopic, from: 'peer-a', data: new TextEncoder().encode('from-wire') }]);
     expect(received).toEqual([{ topic: logicalTopic, from: 'peer-a', data: 'from-wire' }]);
+    expect(admissionChecks).toEqual([
+      { peerId: 'peer-a', topic: logicalTopic },
+      { peerId: 'peer-b', topic: logicalTopic },
+    ]);
   });
 });

--- a/packages/core/test/networking.test.ts
+++ b/packages/core/test/networking.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach } from 'vitest';
 import { DKGNode } from '../src/node.js';
 import { ProtocolRouter, DEFAULT_MAX_READ_BYTES } from '../src/protocol-router.js';
 import { GossipSubManager } from '../src/gossipsub-manager.js';
-import { TypedEventBus } from '../src/event-bus.js';
+import { DKGEvent, TypedEventBus } from '../src/event-bus.js';
 import { PeerDiscoveryManager } from '../src/discovery.js';
 import { multiaddr } from '@multiformats/multiaddr';
 
@@ -282,4 +282,66 @@ describe('GossipSubManager', () => {
     expect(received.length).toBe(1);
     expect(new TextDecoder().decode(received[0])).toBe('test-msg');
   }, 20000);
+
+  it('uses network-scoped wire topics while exposing logical topics', async () => {
+    const subscribed: string[] = [];
+    const published: Array<{ topic: string; data: Uint8Array }> = [];
+    const handlers: Array<(evt: { detail: { topic: string; data: Uint8Array; from: string } }) => void> = [];
+    const topics = new Set<string>();
+    const pubsub = {
+      addEventListener: (_event: string, handler: (evt: { detail: { topic: string; data: Uint8Array; from: string } }) => void) => {
+        handlers.push(handler);
+      },
+      subscribe: (topic: string) => {
+        subscribed.push(topic);
+        topics.add(topic);
+      },
+      unsubscribe: (topic: string) => {
+        topics.delete(topic);
+      },
+      publish: async (topic: string, data: Uint8Array) => {
+        published.push({ topic, data });
+      },
+      getTopics: () => [...topics],
+      getSubscribers: (topic: string) => topic.endsWith('/context-graph/test/finalization')
+        ? [{ toString: () => 'peer-a' }]
+        : [],
+    };
+    const node = { libp2p: { services: { pubsub } } } as unknown as DKGNode;
+    const bus = new TypedEventBus();
+    const manager = new GossipSubManager(node, bus, { networkId: 'base-testnet', chainId: 'base:84532' });
+    const logicalTopic = 'dkg/context-graph/test/finalization';
+    const wireTopic = 'dkg/network/base-testnet.base:84532/context-graph/test/finalization';
+
+    const events: unknown[] = [];
+    bus.on(DKGEvent.GOSSIP_MESSAGE, (evt) => events.push(evt));
+    const received: Array<{ topic: string; from: string; data: string }> = [];
+    manager.onMessage(logicalTopic, (topic, data, from) => {
+      received.push({ topic, from, data: new TextDecoder().decode(data) });
+    });
+
+    manager.subscribe(logicalTopic);
+    await manager.publish(logicalTopic, new TextEncoder().encode('hello'));
+    handlers[0]({
+      detail: {
+        topic: wireTopic,
+        from: 'peer-a',
+        data: new TextEncoder().encode('from-wire'),
+      },
+    });
+    handlers[0]({
+      detail: {
+        topic: 'dkg/network/base-mainnet/context-graph/test/finalization',
+        from: 'peer-b',
+        data: new TextEncoder().encode('foreign-wire'),
+      },
+    });
+
+    expect(subscribed).toEqual([wireTopic]);
+    expect(published.map((entry) => entry.topic)).toEqual([wireTopic]);
+    expect(manager.subscribedTopics).toEqual([logicalTopic]);
+    expect(manager.getSubscribers(logicalTopic)).toEqual(['peer-a']);
+    expect(events).toEqual([{ topic: logicalTopic, from: 'peer-a', data: new TextEncoder().encode('from-wire') }]);
+    expect(received).toEqual([{ topic: logicalTopic, from: 'peer-a', data: 'from-wire' }]);
+  });
 });

--- a/packages/core/test/node-dht-wiring.test.ts
+++ b/packages/core/test/node-dht-wiring.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { dhtProtocolForNetwork } from '../src/constants.js';
+
+const mocks = vi.hoisted(() => ({
+  kadOptions: [] as any[],
+  createLibp2p: vi.fn(async (options: any) => ({
+    peerId: { toString: () => 'mock-peer' },
+    peerStore: { merge: vi.fn() },
+    services: options.services,
+    getConnections: vi.fn(() => []),
+    getMultiaddrs: vi.fn(() => []),
+    getPeers: vi.fn(() => []),
+    addEventListener: vi.fn(),
+    stop: vi.fn(),
+    dial: vi.fn(),
+  })),
+}));
+
+vi.mock('@libp2p/kad-dht', () => ({
+  kadDHT: vi.fn((options: any) => {
+    mocks.kadOptions.push(options);
+    return { mockService: 'dht' };
+  }),
+}));
+
+vi.mock('libp2p', () => ({
+  createLibp2p: mocks.createLibp2p,
+}));
+
+describe('DKGNode DHT network identity wiring', () => {
+  afterEach(() => {
+    mocks.kadOptions.length = 0;
+    mocks.createLibp2p.mockClear();
+  });
+
+  it('passes the network-scoped DHT protocol into kadDHT during start', async () => {
+    const { DKGNode } = await import('../src/node.js');
+    const node = new DKGNode({
+      listenAddresses: ['/ip4/127.0.0.1/tcp/0'],
+      enableMdns: false,
+      networkIdentity: {
+        networkId: 'shared-genesis',
+        genesisId: 'base-testnet',
+        chainId: 'base:84532',
+      },
+    });
+
+    await node.start();
+
+    expect(mocks.kadOptions).toHaveLength(1);
+    expect(mocks.kadOptions[0]).toMatchObject({
+      protocol: dhtProtocolForNetwork('shared-genesis', 'base:84532'),
+    });
+
+    await node.stop();
+  });
+});

--- a/packages/core/test/node-dht-wiring.test.ts
+++ b/packages/core/test/node-dht-wiring.test.ts
@@ -27,6 +27,10 @@ vi.mock('libp2p', () => ({
   createLibp2p: mocks.createLibp2p,
 }));
 
+const ACTIVE_RELAY_PEER = '12D3KooWSmU3owJvB9sFw8uApDgKrv2VBMecsGGvgAc4Gq6hB57M';
+const FOREIGN_RELAY_PEER = '12D3KooWAbLiM6Xy2TfXtFpUrXqttnTSuctW8Lo1mkauaijsNrWw';
+const REMOTE_PEER = '12D3KooWQz2bQbQueABKRSjV9koF8VYsXk5TdCsUmPf5zAEZg3q6';
+
 describe('DKGNode DHT network identity wiring', () => {
   afterEach(() => {
     mocks.kadOptions.length = 0;
@@ -51,6 +55,36 @@ describe('DKGNode DHT network identity wiring', () => {
     expect(mocks.kadOptions[0]).toMatchObject({
       protocol: dhtProtocolForNetwork('shared-genesis', 'base:84532'),
     });
+
+    await node.stop();
+  });
+
+  it('passes the active relay network gater into libp2p during start', async () => {
+    const { DKGNode } = await import('../src/node.js');
+    const node = new DKGNode({
+      listenAddresses: ['/ip4/127.0.0.1/tcp/0'],
+      enableMdns: false,
+      enableRelayServer: false,
+      relayPeers: [`/ip4/1.2.3.4/tcp/9090/p2p/${ACTIVE_RELAY_PEER}`],
+      networkIdentity: {
+        networkId: 'shared-genesis',
+        genesisId: 'base-testnet',
+        chainId: 'base:84532',
+      },
+    });
+
+    await node.start();
+
+    expect(mocks.createLibp2p).toHaveBeenCalledOnce();
+    const options = mocks.createLibp2p.mock.calls[0][0];
+    const denyDialMultiaddr = options.connectionGater?.denyDialMultiaddr;
+    expect(denyDialMultiaddr).toEqual(expect.any(Function));
+    expect(
+      denyDialMultiaddr(`/ip4/1.2.3.4/tcp/9090/p2p/${ACTIVE_RELAY_PEER}/p2p-circuit/p2p/${REMOTE_PEER}`),
+    ).toBe(false);
+    expect(
+      denyDialMultiaddr(`/ip4/1.2.3.4/tcp/9090/p2p/${FOREIGN_RELAY_PEER}/p2p-circuit/p2p/${REMOTE_PEER}`),
+    ).toBe(true);
 
     await node.stop();
   });

--- a/packages/core/test/protocol-router-pool.test.ts
+++ b/packages/core/test/protocol-router-pool.test.ts
@@ -680,6 +680,78 @@ describe('ProtocolRouter pooled inbound handler', () => {
     await router.closePooling();
   });
 
+  it('rejects pooled inbound application dispatch for non-admitted peers', async () => {
+    type HandlerFn = (
+      stream: import('@libp2p/interface').Stream,
+      connection: { remotePeer: { toString: () => string; toMultihash: () => { bytes: Uint8Array } } },
+    ) => void | Promise<void>;
+    let inboundHandler: HandlerFn | null = null;
+    let handlerCalls = 0;
+    const admittedCalls: Array<[string, string, 'inbound' | 'outbound']> = [];
+    const node = {
+      libp2p: {
+        dialProtocol: async () => {
+          throw new Error('not used');
+        },
+        handle: (_protocolId: string, handler: HandlerFn) => {
+          if (_protocolId === POOLED_MESSAGE_PROTOCOL) {
+            inboundHandler = handler;
+          }
+        },
+        unhandle: () => undefined,
+        getConnections: () => [],
+        peerStore: { get: async () => ({ addresses: [] }) },
+      },
+    } as unknown as DKGNode;
+
+    const router = new ProtocolRouter(node, {
+      isPeerAccepted: (peerId, protocolId, direction) => {
+        admittedCalls.push([peerId, protocolId, direction]);
+        return false;
+      },
+    });
+    router.enablePooling('/dkg/10.0.1/message', {
+      keepaliveIntervalMs: 0,
+      idleTimeoutMs: 0,
+      peerIdFromString: (s) => ({ toString: () => s }) as unknown,
+    });
+    router.register('/dkg/10.0.1/message', async () => {
+      handlerCalls += 1;
+      return new TextEncoder().encode('should-not-run');
+    });
+
+    expect(inboundHandler).toBeDefined();
+    const inboundStream = new FakeStream();
+    const inboundRun = inboundHandler!(inboundStream as unknown as import('@libp2p/interface').Stream, {
+      remotePeer: {
+        toString: () => PEER_NEW,
+        toMultihash: () => ({ bytes: new Uint8Array() }),
+      },
+    });
+    await flush();
+    inboundStream.feed(encodeFrame(FrameType.REQUEST, new TextEncoder().encode('hi')));
+    await flush();
+
+    expect(admittedCalls).toEqual([[PEER_NEW, '/dkg/10.0.1/message', 'inbound']]);
+    expect(handlerCalls).toBe(0);
+    expect(inboundStream.sent.length).toBeGreaterThanOrEqual(1);
+
+    const parsed: { type: FrameType; payload: Uint8Array }[] = [];
+    for await (const f of decodeFrames(
+      (async function* () {
+        for (const c of inboundStream.sent) yield c;
+      })(),
+    )) {
+      parsed.push(f);
+    }
+    expect(parsed[0].type).toBe(FrameType.ERROR);
+    expect(new TextDecoder().decode(parsed[0].payload)).toMatch(/not admitted/);
+
+    inboundStream.endRemote();
+    await inboundRun;
+    await router.closePooling();
+  });
+
   it('removes the node stop listener after successful pooled inbound handling', async () => {
     type HandlerFn = (
       stream: import('@libp2p/interface').Stream,

--- a/packages/core/test/protocol-router.test.ts
+++ b/packages/core/test/protocol-router.test.ts
@@ -84,6 +84,7 @@ describe('ProtocolRouter', () => {
       sent: Uint8Array | null = null;
       aborted: Error | null = null;
       closedWithSignal: AbortSignal | undefined;
+      reads = 0;
 
       constructor(
         private readonly chunks: Uint8Array[],
@@ -109,6 +110,7 @@ describe('ProtocolRouter', () => {
         let completed = false;
         return {
           next: async () => {
+            this.reads += 1;
             if (index < this.chunks.length) {
               return { value: this.chunks[index++], done: false };
             }
@@ -129,6 +131,77 @@ describe('ProtocolRouter', () => {
         };
       }
     }
+
+    it('rejects non-admitted inbound peers before reading request bytes', async () => {
+      let inbound: ((stream: FakeInboundStream, connection: unknown) => Promise<void>) | null = null;
+      let handlerCalls = 0;
+      const admittedCalls: Array<[string, string, 'inbound' | 'outbound']> = [];
+      const node = {
+        libp2p: {
+          handle: (_protocol: string, handler: (stream: FakeInboundStream, connection: unknown) => Promise<void>) => {
+            inbound = handler;
+          },
+          unhandle: () => undefined,
+        },
+      } as unknown as DKGNode;
+      const router = new ProtocolRouter(node, {
+        isPeerAccepted: (peerId, protocolId, direction) => {
+          admittedCalls.push([peerId, protocolId, direction]);
+          return false;
+        },
+      });
+      router.register(PROTOCOL, async () => {
+        handlerCalls += 1;
+        return new Uint8Array([0xaa]);
+      });
+
+      const stream = new FakeInboundStream([new Uint8Array([0x01])]);
+      await inbound!(stream, {
+        remotePeer: {
+          toString: () => REMOTE_PEER,
+          toMultihash: () => ({ bytes: new Uint8Array([1, 2, 3]) }),
+        },
+      });
+
+      expect(admittedCalls).toEqual([[REMOTE_PEER, PROTOCOL, 'inbound']]);
+      expect(handlerCalls).toBe(0);
+      expect(stream.reads).toBe(0);
+      expect(stream.sent).toBeNull();
+      expect(stream.aborted?.message).toMatch(/handler error/);
+    });
+
+    it('allows exempt inbound protocols before admission', async () => {
+      let inbound: ((stream: FakeInboundStream, connection: unknown) => Promise<void>) | null = null;
+      let handlerCalls = 0;
+      const node = {
+        libp2p: {
+          handle: (_protocol: string, handler: (stream: FakeInboundStream, connection: unknown) => Promise<void>) => {
+            inbound = handler;
+          },
+          unhandle: () => undefined,
+        },
+      } as unknown as DKGNode;
+      const router = new ProtocolRouter(node, {
+        isPeerAccepted: () => false,
+        admissionExemptProtocols: [PROTOCOL],
+      });
+      router.register(PROTOCOL, async () => {
+        handlerCalls += 1;
+        return new Uint8Array([0xaa]);
+      });
+
+      const stream = new FakeInboundStream([new Uint8Array([0x01])]);
+      await inbound!(stream, {
+        remotePeer: {
+          toString: () => REMOTE_PEER,
+          toMultihash: () => ({ bytes: new Uint8Array([1, 2, 3]) }),
+        },
+      });
+
+      expect(handlerCalls).toBe(1);
+      expect(stream.sent).toEqual(new Uint8Array([0xaa]));
+      expect(stream.aborted).toBeNull();
+    });
 
     function makeInboundFixture(stopSignal?: AbortSignal) {
       let inbound: ((stream: FakeInboundStream, connection: unknown) => Promise<void>) | null = null;
@@ -321,6 +394,40 @@ describe('ProtocolRouter', () => {
       } finally {
         console.error = originalError;
       }
+    });
+  });
+
+  describe('send() network admission', () => {
+    it('rejects non-admitted outbound peers before peer parsing or dialing', async () => {
+      let dialCalls = 0;
+      const admittedCalls: Array<[string, string, 'inbound' | 'outbound']> = [];
+      const node = {
+        libp2p: {
+          getConnections: () => {
+            throw new Error('getConnections should not be reached');
+          },
+          dialProtocol: async () => {
+            dialCalls += 1;
+            throw new Error('dialProtocol should not be reached');
+          },
+          handle: () => undefined,
+          unhandle: () => undefined,
+          peerStore: { get: async () => { throw new Error('NotFound'); } },
+        },
+      } as unknown as DKGNode;
+      const router = new ProtocolRouter(node, {
+        isPeerAccepted: (peerId, protocolId, direction) => {
+          admittedCalls.push([peerId, protocolId, direction]);
+          return false;
+        },
+      });
+
+      await expect(
+        router.send('not-a-libp2p-peer-id', '/dkg/test/1.0.0', new Uint8Array([1])),
+      ).rejects.toThrow(/not admitted/);
+
+      expect(admittedCalls).toEqual([['not-a-libp2p-peer-id', '/dkg/test/1.0.0', 'outbound']]);
+      expect(dialCalls).toBe(0);
     });
   });
 

--- a/packages/core/test/protocol-router.test.ts
+++ b/packages/core/test/protocol-router.test.ts
@@ -469,6 +469,52 @@ describe('ProtocolRouter', () => {
       expect(admittedCalls).toEqual([['not-a-libp2p-peer-id', '/dkg/test/1.0.0', 'outbound']]);
       expect(dialCalls).toBe(0);
     });
+
+    it('bounds outbound admission with the caller send timeout before dialing', async () => {
+      let dialCalls = 0;
+      let admissionOptions: { signal?: AbortSignal; timeoutMs?: number } | undefined;
+      const node = {
+        libp2p: {
+          getConnections: () => {
+            throw new Error('getConnections should not be reached');
+          },
+          dialProtocol: async () => {
+            dialCalls += 1;
+            throw new Error('dialProtocol should not be reached');
+          },
+          handle: () => undefined,
+          unhandle: () => undefined,
+          peerStore: { get: async () => { throw new Error('NotFound'); } },
+        },
+      } as unknown as DKGNode;
+      const router = new ProtocolRouter(node, {
+        isPeerAccepted: async (_peerId, _protocolId, _direction, options) => {
+          admissionOptions = options;
+          const signal = options?.signal;
+          if (!signal) throw new Error('missing admission signal');
+          await new Promise((_resolve, reject) => {
+            signal.addEventListener(
+              'abort',
+              () => reject(signal.reason instanceof Error ? signal.reason : new Error('admission aborted')),
+              { once: true },
+            );
+          });
+          return true;
+        },
+      });
+
+      const startedAt = Date.now();
+      await expect(
+        router.send('not-a-libp2p-peer-id', '/dkg/test/1.0.0', new Uint8Array([1]), {
+          timeoutMs: 50,
+        }),
+      ).rejects.toThrow(/aborted|timeout|operation/i);
+
+      expect(Date.now() - startedAt).toBeLessThan(1_000);
+      expect(admissionOptions?.signal).toBeDefined();
+      expect(admissionOptions?.timeoutMs).toBe(50);
+      expect(dialCalls).toBe(0);
+    });
   });
 
   describe('send() node stop abort propagation', () => {

--- a/packages/core/test/protocol-router.test.ts
+++ b/packages/core/test/protocol-router.test.ts
@@ -132,7 +132,7 @@ describe('ProtocolRouter', () => {
       }
     }
 
-    it('rejects non-admitted inbound peers before reading request bytes', async () => {
+    it('rejects non-admitted inbound peers after reading bounded request bytes but before handler dispatch', async () => {
       let inbound: ((stream: FakeInboundStream, connection: unknown) => Promise<void>) | null = null;
       let handlerCalls = 0;
       const admittedCalls: Array<[string, string, 'inbound' | 'outbound']> = [];
@@ -165,9 +165,49 @@ describe('ProtocolRouter', () => {
 
       expect(admittedCalls).toEqual([[REMOTE_PEER, PROTOCOL, 'inbound']]);
       expect(handlerCalls).toBe(0);
-      expect(stream.reads).toBe(0);
+      expect(stream.reads).toBe(2);
       expect(stream.sent).toBeNull();
       expect(stream.aborted?.message).toMatch(/handler error/);
+    });
+
+    it('awaits async inbound admission before dispatching the handler', async () => {
+      let inbound: ((stream: FakeInboundStream, connection: unknown) => Promise<void>) | null = null;
+      let admitted = false;
+      let handlerCalls = 0;
+      const node = {
+        libp2p: {
+          handle: (_protocol: string, handler: (stream: FakeInboundStream, connection: unknown) => Promise<void>) => {
+            inbound = handler;
+          },
+          unhandle: () => undefined,
+        },
+      } as unknown as DKGNode;
+      const router = new ProtocolRouter(node, {
+        isPeerAccepted: async () => {
+          await Promise.resolve();
+          admitted = true;
+          return true;
+        },
+      });
+      router.register(PROTOCOL, async (data) => {
+        expect(admitted).toBe(true);
+        handlerCalls += 1;
+        return data;
+      });
+
+      const request = new Uint8Array([0x42]);
+      const stream = new FakeInboundStream([request]);
+      await inbound!(stream, {
+        remotePeer: {
+          toString: () => REMOTE_PEER,
+          toMultihash: () => ({ bytes: new Uint8Array([1, 2, 3]) }),
+        },
+      });
+
+      expect(handlerCalls).toBe(1);
+      expect(stream.reads).toBe(2);
+      expect(stream.sent).toEqual(request);
+      expect(stream.aborted).toBeNull();
     });
 
     it('allows exempt inbound protocols before admission', async () => {

--- a/packages/core/test/relay-flap-guard.test.ts
+++ b/packages/core/test/relay-flap-guard.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { RelayFlapGuard, buildRelayFlapConnectionGater, parseCircuitRelayPeerIds } from '../src/relay-flap-guard.js';
+import { RelayFlapGuard, buildActiveRelayDiscoveryFilter, buildRelayFlapConnectionGater, parseCircuitRelayPeerIds } from '../src/relay-flap-guard.js';
 
 const RELAY_A = '12D3KooWRelayA';
 const RELAY_B = '12D3KooWRelayB';
@@ -170,5 +170,37 @@ describe('buildRelayFlapConnectionGater (libp2p wiring)', () => {
     // The inbound hook (relay, remotePeer) also denies the quarantined pair.
     expect(gater.denyInboundRelayedConnection({ toString: () => RELAY_A }, { toString: () => REMOTE_A })).toBe(true);
     expect(gater.denyInboundRelayedConnection({ toString: () => RELAY_B }, { toString: () => REMOTE_B })).toBe(false);
+  });
+
+  it('denies circuit-relay paths through relays outside the active network allowlist', () => {
+    const gater = buildRelayFlapConnectionGater(
+      guard(),
+      () => {},
+      { activeRelayPeerIds: new Set([RELAY_A]) },
+    );
+
+    expect(gater.denyDialMultiaddr(`/ip4/1.2.3.4/tcp/9090/p2p/${RELAY_A}/p2p-circuit/p2p/${REMOTE_A}`)).toBe(false);
+    expect(gater.denyDialMultiaddr(`/ip4/1.2.3.4/tcp/9090/p2p/${RELAY_B}/p2p-circuit/p2p/${REMOTE_A}`)).toBe(true);
+    expect(gater.denyDialMultiaddr(`/ip4/1.2.3.4/tcp/9090/p2p/${RELAY_B}/p2p-circuit`)).toBe(true);
+    expect(gater.denyDialMultiaddr(`/ip4/1.2.3.4/tcp/9090/p2p/${REMOTE_A}`)).toBe(false);
+
+    expect(gater.denyInboundRelayedConnection({ toString: () => RELAY_A }, { toString: () => REMOTE_A })).toBe(false);
+    expect(gater.denyInboundRelayedConnection({ toString: () => RELAY_B }, { toString: () => REMOTE_A })).toBe(true);
+  });
+});
+
+describe('buildActiveRelayDiscoveryFilter', () => {
+  it('suppresses non-active relay discoveries and still de-duplicates active relays', () => {
+    const filter = buildActiveRelayDiscoveryFilter(new Set([RELAY_A]));
+    expect(filter).toBeDefined();
+    const active = { toString: () => RELAY_A };
+    const foreign = { toString: () => RELAY_B };
+
+    expect(filter!.has(foreign)).toBe(true);
+    expect(filter!.has(active)).toBe(false);
+    filter!.add(active);
+    expect(filter!.has(active)).toBe(true);
+    filter!.remove(active);
+    expect(filter!.has(active)).toBe(false);
   });
 });

--- a/packages/core/test/relay-flap-guard.test.ts
+++ b/packages/core/test/relay-flap-guard.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { RelayFlapGuard, buildActiveRelayDiscoveryFilter, buildRelayFlapConnectionGater, parseCircuitRelayPeerIds } from '../src/relay-flap-guard.js';
+import { RelayFlapGuard, buildRelayFlapConnectionGater } from '../src/relay-flap-guard.js';
 
 const RELAY_A = '12D3KooWRelayA';
 const RELAY_B = '12D3KooWRelayB';
@@ -23,24 +23,6 @@ function recordShortBurst(g: RelayFlapGuard, relayPeerId = RELAY_A, remotePeerId
   expect(g.recordRelayedClose({ relayPeerId, remotePeerId, durationMs: 50, now: 10 }).enteredQuarantine).toBe(false);
   expect(g.recordRelayedClose({ relayPeerId, remotePeerId, durationMs: 50, now: 20 }).enteredQuarantine).toBe(true);
 }
-
-describe('parseCircuitRelayPeerIds', () => {
-  it('extracts relay and remote peer ids from a circuit address', () => {
-    expect(
-      parseCircuitRelayPeerIds(`/ip4/1.2.3.4/tcp/9090/p2p/${RELAY_A}/p2p-circuit/p2p/${REMOTE_A}`),
-    ).toEqual({ relayPeerId: RELAY_A, remotePeerId: REMOTE_A });
-  });
-
-  it('extracts only the relay peer id from reservation-style circuit addresses', () => {
-    expect(
-      parseCircuitRelayPeerIds(`/ip4/1.2.3.4/tcp/9090/p2p/${RELAY_A}/p2p-circuit`),
-    ).toEqual({ relayPeerId: RELAY_A, remotePeerId: undefined });
-  });
-
-  it('does not classify direct addresses as relayed paths', () => {
-    expect(parseCircuitRelayPeerIds(`/ip4/1.2.3.4/tcp/9090/p2p/${REMOTE_A}`)).toBeNull();
-  });
-});
 
 describe('RelayFlapGuard', () => {
   it('quarantines the exact relay/remote pair after repeated short relayed closes', () => {
@@ -172,35 +154,4 @@ describe('buildRelayFlapConnectionGater (libp2p wiring)', () => {
     expect(gater.denyInboundRelayedConnection({ toString: () => RELAY_B }, { toString: () => REMOTE_B })).toBe(false);
   });
 
-  it('denies circuit-relay paths through relays outside the active network allowlist', () => {
-    const gater = buildRelayFlapConnectionGater(
-      guard(),
-      () => {},
-      { activeRelayPeerIds: new Set([RELAY_A]) },
-    );
-
-    expect(gater.denyDialMultiaddr(`/ip4/1.2.3.4/tcp/9090/p2p/${RELAY_A}/p2p-circuit/p2p/${REMOTE_A}`)).toBe(false);
-    expect(gater.denyDialMultiaddr(`/ip4/1.2.3.4/tcp/9090/p2p/${RELAY_B}/p2p-circuit/p2p/${REMOTE_A}`)).toBe(true);
-    expect(gater.denyDialMultiaddr(`/ip4/1.2.3.4/tcp/9090/p2p/${RELAY_B}/p2p-circuit`)).toBe(true);
-    expect(gater.denyDialMultiaddr(`/ip4/1.2.3.4/tcp/9090/p2p/${REMOTE_A}`)).toBe(false);
-
-    expect(gater.denyInboundRelayedConnection({ toString: () => RELAY_A }, { toString: () => REMOTE_A })).toBe(false);
-    expect(gater.denyInboundRelayedConnection({ toString: () => RELAY_B }, { toString: () => REMOTE_A })).toBe(true);
-  });
-});
-
-describe('buildActiveRelayDiscoveryFilter', () => {
-  it('suppresses non-active relay discoveries and still de-duplicates active relays', () => {
-    const filter = buildActiveRelayDiscoveryFilter(new Set([RELAY_A]));
-    expect(filter).toBeDefined();
-    const active = { toString: () => RELAY_A };
-    const foreign = { toString: () => RELAY_B };
-
-    expect(filter!.has(foreign)).toBe(true);
-    expect(filter!.has(active)).toBe(false);
-    filter!.add(active);
-    expect(filter!.has(active)).toBe(true);
-    filter!.remove(active);
-    expect(filter!.has(active)).toBe(false);
-  });
 });

--- a/packages/core/test/relay-network-policy.test.ts
+++ b/packages/core/test/relay-network-policy.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildActiveRelayConnectionGater,
+  buildActiveRelayDiscoveryFilter,
+  buildActiveRelayNetworkPolicy,
+} from '../src/relay-network-policy.js';
+
+const RELAY_A = '12D3KooWRelayA';
+const RELAY_B = '12D3KooWRelayB';
+const REMOTE_A = '12D3KooWRemoteA';
+
+describe('buildActiveRelayNetworkPolicy', () => {
+  it('is disabled when no active relay set is supplied', () => {
+    expect(buildActiveRelayNetworkPolicy(undefined)).toBeUndefined();
+  });
+
+  it('builds coupled discovery and connection-gater policy for active relays', () => {
+    const policy = buildActiveRelayNetworkPolicy(new Set([RELAY_A]));
+    expect(policy).toBeDefined();
+    expect(policy!.discoveryFilter.has({ toString: () => RELAY_B })).toBe(true);
+    expect(
+      policy!.connectionGater.denyDialMultiaddr(`/ip4/1.2.3.4/tcp/9090/p2p/${RELAY_B}/p2p-circuit`),
+    ).toBe(true);
+  });
+});
+
+describe('buildActiveRelayConnectionGater', () => {
+  it('denies circuit-relay paths through relays outside the active network allowlist', () => {
+    const gater = buildActiveRelayConnectionGater(new Set([RELAY_A]));
+
+    expect(gater.denyDialMultiaddr(`/ip4/1.2.3.4/tcp/9090/p2p/${RELAY_A}/p2p-circuit/p2p/${REMOTE_A}`)).toBe(false);
+    expect(gater.denyDialMultiaddr(`/ip4/1.2.3.4/tcp/9090/p2p/${RELAY_B}/p2p-circuit/p2p/${REMOTE_A}`)).toBe(true);
+    expect(gater.denyDialMultiaddr(`/ip4/1.2.3.4/tcp/9090/p2p/${RELAY_B}/p2p-circuit`)).toBe(true);
+    expect(gater.denyDialMultiaddr(`/ip4/1.2.3.4/tcp/9090/p2p/${REMOTE_A}`)).toBe(false);
+
+    expect(gater.denyInboundRelayedConnection({ toString: () => RELAY_A }, { toString: () => REMOTE_A })).toBe(false);
+    expect(gater.denyInboundRelayedConnection({ toString: () => RELAY_B }, { toString: () => REMOTE_A })).toBe(true);
+  });
+});
+
+describe('buildActiveRelayDiscoveryFilter', () => {
+  it('suppresses non-active relay discoveries and still de-duplicates active relays', () => {
+    const filter = buildActiveRelayDiscoveryFilter(new Set([RELAY_A]));
+    const active = { toString: () => RELAY_A };
+    const foreign = { toString: () => RELAY_B };
+
+    expect(filter.has(foreign)).toBe(true);
+    expect(filter.has(active)).toBe(false);
+    filter.add(active);
+    expect(filter.has(active)).toBe(true);
+    filter.remove(active);
+    expect(filter.has(active)).toBe(false);
+  });
+});

--- a/packages/core/test/relay-path.test.ts
+++ b/packages/core/test/relay-path.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { parseCircuitRelayPeerIds } from '../src/relay-path.js';
+
+const RELAY_A = '12D3KooWRelayA';
+const REMOTE_A = '12D3KooWRemoteA';
+
+describe('parseCircuitRelayPeerIds', () => {
+  it('extracts relay and remote peer ids from a circuit address', () => {
+    expect(
+      parseCircuitRelayPeerIds(`/ip4/1.2.3.4/tcp/9090/p2p/${RELAY_A}/p2p-circuit/p2p/${REMOTE_A}`),
+    ).toEqual({ relayPeerId: RELAY_A, remotePeerId: REMOTE_A });
+  });
+
+  it('extracts only the relay peer id from reservation-style circuit addresses', () => {
+    expect(
+      parseCircuitRelayPeerIds(`/ip4/1.2.3.4/tcp/9090/p2p/${RELAY_A}/p2p-circuit`),
+    ).toEqual({ relayPeerId: RELAY_A, remotePeerId: undefined });
+  });
+
+  it('does not classify direct addresses as relayed paths', () => {
+    expect(parseCircuitRelayPeerIds(`/ip4/1.2.3.4/tcp/9090/p2p/${REMOTE_A}`)).toBeNull();
+  });
+});

--- a/packages/publisher/src/ack-peer-selection.ts
+++ b/packages/publisher/src/ack-peer-selection.ts
@@ -6,6 +6,8 @@ export interface ACKCandidatePeerSelectionInput {
   ackCandidatePeerIds?: readonly string[];
   /** Preference-only ranking list. Listed peers are ordered first within each tier but never gate eligibility. */
   preferredACKPeerIds?: readonly string[];
+  /** Active-network admission filter. When set, peers outside this set are not ACK candidates. */
+  verifiedSameNetworkPeerIds?: ReadonlySet<string>;
   knownCorePeerIds?: ReadonlySet<string>;
   knownCorePeerIdsV2?: ReadonlySet<string>;
   requiredACKs: number;
@@ -127,9 +129,12 @@ export function selectACKCandidatePeersWithDiagnostics(
   const allowlistedACKPeers = normalizePeerIdSet(input.ackCandidatePeerIds);
   const preferredACKPeers = normalizePeerIdSet(input.preferredACKPeerIds);
   const allowlistEnabled = allowlistedACKPeers.size > 0;
-  const eligible = allowlistEnabled
+  const allowlisted = allowlistEnabled
     ? connected.filter((id) => allowlistedACKPeers.has(id))
     : connected;
+  const eligible = input.verifiedSameNetworkPeerIds
+    ? allowlisted.filter((id) => input.verifiedSameNetworkPeerIds!.has(id))
+    : allowlisted;
   const tiers = buildCandidateTiers({
     connected: eligible,
     knownCorePeerIds: input.knownCorePeerIds,
@@ -146,7 +151,9 @@ export function selectACKCandidatePeersWithDiagnostics(
     selected,
     tier: tierMap.get(peerId) ?? 'rest',
     preferred: preferredACKPeers,
-    allowlisted: !allowlistEnabled || allowlistedACKPeers.has(peerId),
+    allowlisted:
+      (!allowlistEnabled || allowlistedACKPeers.has(peerId)) &&
+      (!input.verifiedSameNetworkPeerIds || input.verifiedSameNetworkPeerIds.has(peerId)),
     protocol: input.protocol,
     knownCorePeerIds: input.knownCorePeerIds,
     knownCorePeerIdsV2: input.knownCorePeerIdsV2,

--- a/packages/publisher/test/ack-peer-selection.test.ts
+++ b/packages/publisher/test/ack-peer-selection.test.ts
@@ -22,6 +22,41 @@ describe('selectACKCandidatePeers — allowlist vs preference-only ranking', () 
     expect(out).toEqual(['trusted-core']);
   });
 
+  it('excludes peers that are not verified for the active network even when preferred or core', () => {
+    const foreign = ['foreign-core-1', 'foreign-core-2'];
+    const sameNetwork = ['same-network-core', RELAYS[0]];
+    const out = selectACKCandidatePeers({
+      connectedPeers: [...foreign, ...sameNetwork],
+      preferredACKPeerIds: [...foreign, RELAYS[0]],
+      verifiedSameNetworkPeerIds: new Set(sameNetwork),
+      knownCorePeerIds: new Set([...foreign, ...sameNetwork]),
+      requiredACKs: 3,
+    });
+    expect(out).toEqual([RELAYS[0], 'same-network-core']);
+  });
+
+  it('keeps same-network non-relay cores eligible while filtering foreign relays', () => {
+    const out = selectACKCandidatePeers({
+      connectedPeers: ['foreign-relay', STAKED[0], STAKED[1]],
+      preferredACKPeerIds: ['foreign-relay'],
+      verifiedSameNetworkPeerIds: new Set([STAKED[0], STAKED[1]]),
+      knownCorePeerIds: new Set(['foreign-relay', STAKED[0], STAKED[1]]),
+      requiredACKs: 3,
+    });
+    expect(out).toEqual([STAKED[0], STAKED[1]]);
+  });
+
+  it('composes the legacy ACK allowlist with active-network eligibility', () => {
+    const out = selectACKCandidatePeers({
+      connectedPeers: ['same-network-core', 'foreign-core'],
+      ackCandidatePeerIds: ['same-network-core', 'foreign-core'],
+      verifiedSameNetworkPeerIds: new Set(['same-network-core']),
+      knownCorePeerIds: new Set(['same-network-core', 'foreign-core']),
+      requiredACKs: 3,
+    });
+    expect(out).toEqual(['same-network-core']);
+  });
+
   it('keeps unlisted staked cores in the pool when listed relays cannot reach quorum (incident shape)', () => {
     // Base mainnet 2026-07-07: 4-relay preference list, only 2 connected
     // and healthy; 3 upgraded non-relay cores connected. Old behavior

--- a/packages/publisher/vitest.unit.config.ts
+++ b/packages/publisher/vitest.unit.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     include: [
       'test/ack-peer-selection.test.ts',
       'test/trust-metadata.test.ts',
+      'test/ack-peer-selection.test.ts',
       'test/dkg-publisher-compat.test.ts',
       'test/shared-memory-publish-boundary.test.ts',
       'test/storage-ack-roster-and-verify-mofn-extra.test.ts',

--- a/packages/publisher/vitest.unit.config.ts
+++ b/packages/publisher/vitest.unit.config.ts
@@ -5,7 +5,6 @@ export default defineConfig({
     include: [
       'test/ack-peer-selection.test.ts',
       'test/trust-metadata.test.ts',
-      'test/ack-peer-selection.test.ts',
       'test/dkg-publisher-compat.test.ts',
       'test/shared-memory-publish-boundary.test.ts',
       'test/storage-ack-roster-and-verify-mofn-extra.test.ts',


### PR DESCRIPTION
## Summary

- Fixes generic DKG cross-network contamination, using Base Sepolia/Base mainnet as the regression fixture rather than a hardcoded special case.
- Scopes libp2p DHT protocols and GossipSub wire topics by active `networkId` plus `chainId` when present, while preserving logical application topic names.
- Adds signed, peer-id-bound network admission through the p2p admission coordinator, with quarantine cleanup and app-boundary gates for ProtocolRouter, GossipSub, sync/catchup, explicit `/api/connect`, and ACK flows.
- Keeps relay flap handling separate from active-network relay policy while preserving active relay discovery/path filtering.
- Preserves broad same-network ACK candidate pools while filtering foreign-network peers before ACK selection/send.
- Rebased onto `upstream/main` at `f9cf428e6` and preserved upstream StorageACK priority/CLI auto-update changes.
- Follow-up review fixes keep transient admission probe failures retryable, reconcile custom `networkIdentity` with loaded genesis, bind admission probes to caller send/connect deadlines, add DKGNode DHT/relay wiring coverage, and map query-remote admission-boundary failures away from accidental 500s.

## Related

- Fixes #1543

## Files changed

| File | What |
|------|------|
| `packages/core/src/constants.ts`, `types.ts`, `genesis.ts`, `node.ts`, `gossipsub-manager.ts`, `protocol-router.ts` | Add network identity types, canonical default genesis identity, chain-aware DHT/topic namespaces, and central protocol/gossip admission gates. |
| `packages/core/src/relay-path.ts`, `relay-network-policy.ts`, `relay-flap-guard.ts` | Split relay path parsing and active-network relay policy out of flap mitigation, then compose both gates in `DKGNode`. |
| `packages/core/test/node-dht-wiring.test.ts` | Add DKGNode-level coverage for network-scoped DHT protocol and active relay gater wiring. |
| `packages/agent/src/p2p/network-admission.ts`, `network-admission-coordinator.ts`, `network-identity-proof.ts` | Add process-local admission registry, coordinator-owned proof/quarantine/cleanup flow, retryable probe failures, and nonce/signed peer-id-bound network identity proof helpers. |
| `packages/agent/src/dkg-agent*.ts`, `p2p/peer-connect.ts` | Thread identity/admission through agent startup, sync/catchup, explicit connects, peer cleanup, custom network identity validation, and ACK provider paths. |
| `packages/publisher/src/ack-peer-selection.ts`, `packages/publisher/vitest.unit.config.ts` | Filter ACK candidates by verified same-network peers without turning preferred relays into a hard allowlist, and keep pure ACK selector tests in unit config. |
| `packages/cli/src/daemon/lifecycle.ts`, `routes/agent-chat.ts`, `http-utils.ts` | Pass active network identity into the agent, gate daemon ACK/connect flows on network admission, and classify query-remote admission/probe failures as bounded HTTP responses. |
| `packages/**/test/*.test.ts` | Add regression coverage for namespacing, admission gates, relay filtering, default/custom identity wiring, explicit connect admission, post-approval sync admission, and ACK peer eligibility. |

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg-core build`
- [x] `pnpm --filter @origintrail-official/dkg-storage build`
- [x] `pnpm --filter @origintrail-official/dkg-publisher build`
- [x] `pnpm --filter @origintrail-official/dkg-agent build`
- [x] `pnpm --filter @origintrail-official/dkg build`, including CLI adapter/MCP/OKF prebuilds
- [x] `pnpm --filter @origintrail-official/dkg-agent test -- test/network-admission-coordinator.test.ts test/network-identity-config.test.ts test/context-graph-discovery.test.ts -t "NetworkAdmissionCoordinator|DKGAgent network identity config|runImmediatePostApprovalSync"`
- [x] `pnpm --filter @origintrail-official/dkg-agent test -- test/network-admission-integration.test.ts test/network-admission.test.ts test/network-admission-coordinator.test.ts test/network-identity-proof.test.ts test/network-identity-config.test.ts test/explicit-connect-admission.test.ts test/p2p-peer-connect.test.ts test/ack-candidate-pool.test.ts`
- [x] `pnpm --filter @origintrail-official/dkg-agent test -- test/e2e-agents.test.ts -t "Relay E2E"`
- [x] `pnpm --filter @origintrail-official/dkg-core test -- test/node-dht-wiring.test.ts test/relay-path.test.ts test/relay-network-policy.test.ts test/relay-flap-guard.test.ts test/protocol-router.test.ts test/networking.test.ts test/constants.test.ts test/genesis.test.ts`
- [x] `pnpm --filter @origintrail-official/dkg-publisher test:unit -- test/ack-peer-selection.test.ts`
- [x] `pnpm --filter @origintrail-official/dkg test -- test/preferred-relays.test.ts`
- [x] `pnpm --filter @origintrail-official/dkg test -- test/http-admission-control.test.ts`
- [x] `pnpm --filter @origintrail-official/dkg-core test -- test/protocol-router.test.ts test/node-dht-wiring.test.ts`
- [x] `pnpm exec vitest run --root . --config ../core/vitest.config.ts test/explicit-connect-admission.test.ts test/network-admission.test.ts test/network-admission-coordinator.test.ts test/p2p-resilience.test.ts test/sync-on-connect-retry.test.ts`
- [x] `pnpm --filter @origintrail-official/dkg-agent test -- test/agent.part-16.test.ts`
- [x] `git diff --check` and `git diff --cached --check`
- [ ] Not run locally: live WSL two-network/devnet validation and mixed-version rollout validation. These remain release gates for this high-risk networking change.
