### PR TITLE
fix(cli): honor managed Oxigraph timeout options

### DIFF
--- a/packages/cli/src/daemon/oxigraph-managed.ts
+++ b/packages/cli/src/daemon/oxigraph-managed.ts
@@ -46,6 +46,16 @@ export function resolveManagedOxigraphPort(
     : DEFAULT_OXIGRAPH_PORT;
 }
 
+function resolvePositiveIntegerOption(
+  options: Record<string, unknown> | undefined,
+  key: string,
+): number | undefined {
+  const value = options?.[key];
+  return typeof value === 'number' && Number.isInteger(value) && value > 0
+    ? value
+    : undefined;
+}
+
 interface StoreConfigLike {
   backend?: unknown;
   options?: Record<string, unknown>;
@@ -92,6 +102,10 @@ export interface ManagedOxigraphPlan {
    * to preserve parity with the local Oxigraph default.
    */
   largeLiteralStorage: { enabled: boolean; thresholdBytes?: number; directory: string };
+  /** Startup readiness deadline passed to the managed server supervisor. */
+  readyTimeoutMs?: number;
+  /** Native Oxigraph query timeout, passed as `oxigraph serve --timeout-s`. */
+  queryTimeoutS?: number;
   /**
    * sharedMemoryPublicSnapshotStorage with a defaulted `directory`, set
    * only when the operator enabled it. Same rewrite hazard as
@@ -115,6 +129,8 @@ export function planManagedOxigraph(
 
   const options = config.store.options ?? {};
   const port = resolveManagedOxigraphPort(options);
+  const readyTimeoutMs = resolvePositiveIntegerOption(options, 'readyTimeoutMs');
+  const queryTimeoutS = resolvePositiveIntegerOption(options, 'queryTimeoutS');
   const location =
     typeof options.location === 'string' && options.location.trim()
       ? options.location
@@ -162,6 +178,8 @@ export function planManagedOxigraph(
     cacheDir,
     storeConfigTemplate,
     largeLiteralStorage,
+    readyTimeoutMs,
+    queryTimeoutS,
     sharedMemoryPublicSnapshotStorage,
   };
 }
@@ -217,7 +235,8 @@ export async function startManagedOxigraph(
     location: plan.location,
     port: plan.port,
     log,
-    readyTimeoutMs: opts.readyTimeoutMs,
+    readyTimeoutMs: opts.readyTimeoutMs ?? plan.readyTimeoutMs,
+    queryTimeoutS: plan.queryTimeoutS,
     io: opts.serverIo,
   });
 

--- a/packages/cli/src/daemon/oxigraph-managed.ts
+++ b/packages/cli/src/daemon/oxigraph-managed.ts
@@ -36,6 +36,8 @@ export const MANAGED_OXIGRAPH_BACKEND = 'oxigraph-server';
 /** Default loopback bind port. Override via `store.options.port`. */
 export const DEFAULT_OXIGRAPH_PORT = 7878;
 
+const MANAGED_OXIGRAPH_CLIENT_TIMEOUT_GRACE_MS = 5_000;
+
 /** Same port validation as {@link planManagedOxigraph} — shared with status. */
 export function resolveManagedOxigraphPort(
   options: Record<string, unknown> | undefined,
@@ -54,6 +56,12 @@ function resolvePositiveIntegerOption(
   return typeof value === 'number' && Number.isInteger(value) && value > 0
     ? value
     : undefined;
+}
+
+function resolveManagedQueryClientTimeoutMs(queryTimeoutS: number | undefined): number | undefined {
+  return queryTimeoutS === undefined
+    ? undefined
+    : queryTimeoutS * 1_000 + MANAGED_OXIGRAPH_CLIENT_TIMEOUT_GRACE_MS;
 }
 
 interface StoreConfigLike {
@@ -166,7 +174,12 @@ export function planManagedOxigraph(
     backend: 'sparql-http',
     // managedByDkg lets chain-reset wipe DROP ALL on the local RocksDB
     // we own end-to-end; queryEndpoint/updateEndpoint added at launch.
-    options: { managedByDkg: true },
+    options: {
+      managedByDkg: true,
+      ...(queryTimeoutS === undefined
+        ? {}
+        : { timeout: resolveManagedQueryClientTimeoutMs(queryTimeoutS) }),
+    },
   };
   if (graphSetIndex !== undefined) {
     storeConfigTemplate.graphSetIndex = graphSetIndex;

--- a/packages/cli/src/daemon/oxigraph-managed.ts
+++ b/packages/cli/src/daemon/oxigraph-managed.ts
@@ -37,6 +37,11 @@ export const MANAGED_OXIGRAPH_BACKEND = 'oxigraph-server';
 export const DEFAULT_OXIGRAPH_PORT = 7878;
 
 const MANAGED_OXIGRAPH_CLIENT_TIMEOUT_GRACE_MS = 5_000;
+// Node timers (and AbortSignal.timeout) coerce any delay above 2^31-1 ms to 1ms
+// with a TimeoutOverflowWarning — aborting the request almost immediately, the
+// opposite of a long timeout. Cap the derived client timeout so an absurd
+// operator-configured queryTimeoutS degrades to "very long", never "instant".
+const MAX_NODE_TIMER_MS = 2_147_483_647;
 
 /** Same port validation as {@link planManagedOxigraph} — shared with status. */
 export function resolveManagedOxigraphPort(
@@ -61,7 +66,7 @@ function resolvePositiveIntegerOption(
 function resolveManagedQueryClientTimeoutMs(queryTimeoutS: number | undefined): number | undefined {
   return queryTimeoutS === undefined
     ? undefined
-    : queryTimeoutS * 1_000 + MANAGED_OXIGRAPH_CLIENT_TIMEOUT_GRACE_MS;
+    : Math.min(queryTimeoutS * 1_000 + MANAGED_OXIGRAPH_CLIENT_TIMEOUT_GRACE_MS, MAX_NODE_TIMER_MS);
 }
 
 interface StoreConfigLike {

--- a/packages/cli/src/daemon/oxigraph-server.ts
+++ b/packages/cli/src/daemon/oxigraph-server.ts
@@ -66,6 +66,8 @@ export interface StartOxigraphServerOptions {
   log?: (msg: string) => void;
   /** Total time to wait for the server to answer before failing start. */
   readyTimeoutMs?: number;
+  /** Native Oxigraph query timeout (`oxigraph serve --timeout-s`). */
+  queryTimeoutS?: number;
   /** Poll interval while waiting for readiness. */
   readyIntervalMs?: number;
   /** Grace period between SIGTERM and SIGKILL on stop. */
@@ -103,6 +105,12 @@ function sleep(ms: number): Promise<void> {
   return new Promise((res) => setTimeout(res, ms));
 }
 
+function normalizePositiveInteger(value: number | undefined): number | undefined {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0
+    ? value
+    : undefined;
+}
+
 /**
  * Spawn and health-check a local Oxigraph server. Resolves once the
  * server answers an `ASK` probe; rejects if it never becomes ready within
@@ -132,6 +140,7 @@ export async function startOxigraphServer(
   const stopGraceMs = opts.stopGraceMs ?? DEFAULT_STOP_GRACE_MS;
   const restartBase = opts.restartBackoffBaseMs ?? DEFAULT_RESTART_BASE_MS;
   const restartMax = opts.restartBackoffMaxMs ?? DEFAULT_RESTART_MAX_MS;
+  const queryTimeoutS = normalizePositiveInteger(opts.queryTimeoutS);
 
   let stopping = false;
   let ready = false;
@@ -147,9 +156,11 @@ export async function startOxigraphServer(
   const erroredChildren = new WeakSet<ChildProcess>();
 
   const spawnChild = (): ChildProcess => {
+    const args = ['serve', '--location', opts.location, '--bind', bind];
+    if (queryTimeoutS !== undefined) args.push('--timeout-s', String(queryTimeoutS));
     const c = io.spawn(
       opts.binaryPath,
-      ['serve', '--location', opts.location, '--bind', bind],
+      args,
       { stdio: ['ignore', 'pipe', 'pipe'] },
     );
     // Without this listener Node throws the `error` event as an uncaught
@@ -317,7 +328,11 @@ export async function startOxigraphServer(
     log('[oxigraph] server stopped');
   };
 
-  log(`Starting Oxigraph server on ${bind} (location: ${opts.location})…`);
+  log(
+    queryTimeoutS !== undefined
+      ? `Starting Oxigraph server on ${bind} (location: ${opts.location}, query timeout: ${queryTimeoutS}s)…`
+      : `Starting Oxigraph server on ${bind} (location: ${opts.location})…`,
+  );
   child = spawnChild();
 
   const deadline = Date.now() + readyTimeoutMs;

--- a/packages/cli/test/oxigraph-managed.test.ts
+++ b/packages/cli/test/oxigraph-managed.test.ts
@@ -64,6 +64,34 @@ describe('planManagedOxigraph', () => {
     expect(plan!.cacheDir).toBe('/mnt/oxi-bin');
   });
 
+  it('honours managed Oxigraph startup and native query timeout options', () => {
+    const plan = planManagedOxigraph(
+      {
+        store: {
+          backend: MANAGED_OXIGRAPH_BACKEND,
+          options: { readyTimeoutMs: 180_000, queryTimeoutS: 35 },
+        },
+      },
+      '/data',
+    );
+    expect(plan!.readyTimeoutMs).toBe(180_000);
+    expect(plan!.queryTimeoutS).toBe(35);
+  });
+
+  it('ignores invalid managed Oxigraph timeout options', () => {
+    const plan = planManagedOxigraph(
+      {
+        store: {
+          backend: MANAGED_OXIGRAPH_BACKEND,
+          options: { readyTimeoutMs: 0, queryTimeoutS: 1.5 },
+        },
+      },
+      '/data',
+    );
+    expect(plan!.readyTimeoutMs).toBeUndefined();
+    expect(plan!.queryTimeoutS).toBeUndefined();
+  });
+
   it('resolveManagedOxigraphPort rejects out-of-range values', () => {
     expect(resolveManagedOxigraphPort({ port: 70000 })).toBe(DEFAULT_OXIGRAPH_PORT);
     expect(resolveManagedOxigraphPort({ port: 7878 })).toBe(7878);

--- a/packages/cli/test/oxigraph-managed.test.ts
+++ b/packages/cli/test/oxigraph-managed.test.ts
@@ -11,11 +11,11 @@
  * rewritten sparql-http endpoints answer a REAL SPARQL ASK, and stop()
  * really releases the port.
  */
-import { describe, it, expect } from 'vitest';
-import { mkdtemp, mkdir, rm } from 'node:fs/promises';
+import { afterAll, beforeAll, describe, it, expect } from 'vitest';
+import { mkdtemp, mkdir, rm, writeFile, chmod } from 'node:fs/promises';
 import { createServer } from 'node:net';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { delimiter, join } from 'node:path';
 
 import {
   planManagedOxigraph,
@@ -24,6 +24,65 @@ import {
   MANAGED_OXIGRAPH_BACKEND,
   DEFAULT_OXIGRAPH_PORT,
 } from '../src/daemon/oxigraph-managed.js';
+
+let systemOxigraphDir: string | undefined;
+let originalPath: string | undefined;
+
+beforeAll(async () => {
+  systemOxigraphDir = await mkdtemp(join(tmpdir(), 'oxi-managed-system-'));
+  const systemOxigraph = join(systemOxigraphDir, 'oxigraph');
+  await writeFile(
+    systemOxigraph,
+    `#!/usr/bin/env node
+const http = require('node:http');
+const args = process.argv.slice(2);
+const bindIdx = args.indexOf('--bind');
+if (bindIdx < 0 || !args[bindIdx + 1]) {
+  console.error('missing --bind');
+  process.exit(2);
+}
+const [host, rawPort] = args[bindIdx + 1].split(':');
+const port = Number(rawPort);
+const delayMs = Number(process.env.OXIGRAPH_STANDIN_STARTUP_DELAY_MS || '250');
+let listening = false;
+const srv = http.createServer((req, res) => {
+  if (req.url === '/args') {
+    res.statusCode = 200;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify(args));
+    return;
+  }
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'application/sparql-results+json');
+  res.end(JSON.stringify({ head: {}, boolean: true }));
+});
+srv.on('error', (e) => { console.error('bind failed: ' + e.message); process.exit(1); });
+srv.on('listening', () => { listening = true; });
+const listenTimer = setTimeout(() => srv.listen(port, host), delayMs);
+process.on('SIGTERM', () => {
+  clearTimeout(listenTimer);
+  if (!listening) process.exit(0);
+  srv.close(() => process.exit(0));
+  setTimeout(() => process.exit(0), 100).unref();
+});
+`,
+    'utf8',
+  );
+  await chmod(systemOxigraph, 0o755);
+  originalPath = process.env.PATH;
+  process.env.PATH = [systemOxigraphDir, originalPath].filter(Boolean).join(delimiter);
+});
+
+afterAll(async () => {
+  if (originalPath === undefined) {
+    delete process.env.PATH;
+  } else {
+    process.env.PATH = originalPath;
+  }
+  if (systemOxigraphDir) {
+    await rm(systemOxigraphDir, { recursive: true, force: true }).catch(() => {});
+  }
+});
 
 describe('planManagedOxigraph', () => {
   it('returns null for non-oxigraph-server backends', () => {
@@ -76,6 +135,7 @@ describe('planManagedOxigraph', () => {
     );
     expect(plan!.readyTimeoutMs).toBe(180_000);
     expect(plan!.queryTimeoutS).toBe(35);
+    expect(plan!.storeConfigTemplate.options.timeout).toBe(40_000);
   });
 
   it('ignores invalid managed Oxigraph timeout options', () => {
@@ -90,6 +150,7 @@ describe('planManagedOxigraph', () => {
     );
     expect(plan!.readyTimeoutMs).toBeUndefined();
     expect(plan!.queryTimeoutS).toBeUndefined();
+    expect(plan!.storeConfigTemplate.options).toEqual({ managedByDkg: true });
   });
 
   it('resolveManagedOxigraphPort rejects out-of-range values', () => {
@@ -205,6 +266,11 @@ async function freePort(): Promise<number> {
   });
 }
 
+async function fetchManagedArgs(port: number): Promise<string[]> {
+  const res = await fetch(`http://127.0.0.1:${port}/args`);
+  return await res.json() as string[];
+}
+
 describe('startManagedOxigraph (real download + real server)', () => {
   it('returns null for non-managed backends', async () => {
     // Contract: a non-managed backend is a no-op — null result, and nothing
@@ -214,6 +280,78 @@ describe('startManagedOxigraph (real download + real server)', () => {
       dataDir: '/data',
     });
     expect(result).toBeNull();
+  });
+
+  it('forwards managed query timeout through startup and the rewritten HTTP store config', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'oxi-managed-'));
+    const port = await freePort();
+
+    const result = await startManagedOxigraph({
+      config: {
+        store: {
+          backend: MANAGED_OXIGRAPH_BACKEND,
+          options: { port, readyTimeoutMs: 5_000, queryTimeoutS: 35 },
+        },
+      },
+      dataDir,
+      platform: 'freebsd',
+      log: () => {},
+    });
+    try {
+      expect(result).not.toBeNull();
+      expect(result!.storeConfig.options.timeout).toBe(40_000);
+      const args = await fetchManagedArgs(port);
+      const timeoutIndex = args.indexOf('--timeout-s');
+      expect(timeoutIndex).toBeGreaterThanOrEqual(0);
+      expect(args[timeoutIndex + 1]).toBe('35');
+    } finally {
+      await result?.handle.stop();
+      await rm(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  it('uses config readyTimeoutMs and lets the explicit startup override win', async () => {
+    const tooShortDir = await mkdtemp(join(tmpdir(), 'oxi-managed-'));
+    const tooShortPort = await freePort();
+    await expect(
+      startManagedOxigraph({
+        config: {
+          store: {
+            backend: MANAGED_OXIGRAPH_BACKEND,
+            options: { port: tooShortPort, readyTimeoutMs: 1, queryTimeoutS: 35 },
+          },
+        },
+        dataDir: tooShortDir,
+        platform: 'freebsd',
+        log: () => {},
+      }),
+    ).rejects.toThrow(/ready/i);
+    await rm(tooShortDir, { recursive: true, force: true });
+
+    const overrideDir = await mkdtemp(join(tmpdir(), 'oxi-managed-'));
+    const overridePort = await freePort();
+    const result = await startManagedOxigraph({
+      config: {
+        store: {
+          backend: MANAGED_OXIGRAPH_BACKEND,
+          options: { port: overridePort, readyTimeoutMs: 1, queryTimeoutS: 35 },
+        },
+      },
+      dataDir: overrideDir,
+      platform: 'freebsd',
+      readyTimeoutMs: 5_000,
+      log: () => {},
+    });
+    try {
+      expect(result).not.toBeNull();
+      const args = await fetchManagedArgs(overridePort);
+      const timeoutIndex = args.indexOf('--timeout-s');
+      expect(timeoutIndex).toBeGreaterThanOrEqual(0);
+      expect(args[timeoutIndex + 1]).toBe('35');
+    } finally {
+      await result?.handle.stop();
+      await rm(overrideDir, { recursive: true, force: true });
+    }
   });
 
   it(

--- a/packages/cli/test/oxigraph-managed.test.ts
+++ b/packages/cli/test/oxigraph-managed.test.ts
@@ -138,6 +138,22 @@ describe('planManagedOxigraph', () => {
     expect(plan!.storeConfigTemplate.options.timeout).toBe(40_000);
   });
 
+  it('clamps an absurd queryTimeoutS to Node’s max timer instead of overflowing to an instant abort', () => {
+    const plan = planManagedOxigraph(
+      {
+        store: {
+          backend: MANAGED_OXIGRAPH_BACKEND,
+          // ~24.8 days: queryTimeoutS * 1000 + grace exceeds 2^31-1 ms, which
+          // AbortSignal.timeout would silently coerce to 1ms (immediate abort).
+          options: { queryTimeoutS: 4_294_967 },
+        },
+      },
+      '/data',
+    );
+    expect(plan!.queryTimeoutS).toBe(4_294_967);
+    expect(plan!.storeConfigTemplate.options.timeout).toBe(2_147_483_647);
+  });
+
   it('ignores invalid managed Oxigraph timeout options', () => {
     const plan = planManagedOxigraph(
       {

--- a/packages/cli/test/oxigraph-server.test.ts
+++ b/packages/cli/test/oxigraph-server.test.ts
@@ -50,6 +50,11 @@ async function fetchPid(port: number): Promise<number> {
   return Number(await res.text());
 }
 
+async function fetchArgs(port: number): Promise<string[]> {
+  const res = await fetch(`http://127.0.0.1:${port}/args`);
+  return await res.json() as string[];
+}
+
 async function portAnswers(port: number): Promise<boolean> {
   try {
     const res = await fetch(`http://127.0.0.1:${port}/query`, { signal: AbortSignal.timeout(500) });
@@ -73,6 +78,12 @@ const bindIdx = process.argv.indexOf('--bind');
 const [host, port] = process.argv[bindIdx + 1].split(':');
 const srv = http.createServer((req, res) => {
   if (req.url === '/pid') { res.statusCode = 200; res.end(String(process.pid)); return; }
+  if (req.url === '/args') {
+    res.statusCode = 200;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify(process.argv.slice(2)));
+    return;
+  }
   res.statusCode = 200;
   res.setHeader('Content-Type', 'application/sparql-results+json');
   res.end(JSON.stringify({ head: {}, boolean: true }));
@@ -114,6 +125,19 @@ describe('startOxigraphServer (real child processes)', () => {
       expect(handle.queryEndpoint).toContain(`:${port}`);
       // The child really owns a really-bound socket.
       expect(await portAnswers(port)).toBe(true);
+    } finally {
+      await handle.stop();
+    }
+  });
+
+  it('passes the native Oxigraph query timeout to the child process', async () => {
+    const port = await freePort();
+    const handle = await startOxigraphServer(startOpts(port, { queryTimeoutS: 35 }));
+    try {
+      const args = await fetchArgs(port);
+      const timeoutIndex = args.indexOf('--timeout-s');
+      expect(timeoutIndex).toBeGreaterThanOrEqual(0);
+      expect(args[timeoutIndex + 1]).toBe('35');
     } finally {
       await handle.stop();
     }


### PR DESCRIPTION
## Summary
- read `store.options.readyTimeoutMs` from managed Oxigraph config and pass it into the startup readiness supervisor
- add `store.options.queryTimeoutS` support and pass it to `oxigraph serve --timeout-s`
- cover config parsing and real child-process spawn args in Oxigraph tests

## Why
V10 testnet nodes already configure `readyTimeoutMs: 180000`, but managed Oxigraph startup still behaved like the default 30s timeout. The same path also lacked a way to make Oxigraph cancel runaway queries server-side.

## Tests
- `pnpm --filter @origintrail-official/dkg test -- test/oxigraph-managed.test.ts test/oxigraph-server.test.ts` (expanded to full CLI suite: 2514 passed, 11 skipped)
- `pnpm --filter @origintrail-official/dkg run build`
