### PR TITLE
fix(agent): coalesce duplicate sync fanout work

### DIFF
--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -425,9 +425,7 @@ type InFlightSyncPageFetch = {
 type ContextGraphCatchupResult = Awaited<ReturnType<DKGAgent['runCatchupOverPeers']>>;
 
 const inFlightSyncPageFetchesByAgent = new WeakMap<DKGAgent, Map<string, InFlightSyncPageFetch>>();
-const inFlightDurableSyncsByAgent = new WeakMap<DKGAgent, Map<string, Promise<DurableSyncResult>>>();
-const inFlightSharedMemorySyncsByAgent = new WeakMap<DKGAgent, Map<string, Promise<SharedMemorySyncResult>>>();
-const inFlightContextGraphCatchupsByAgent = new WeakMap<DKGAgent, Map<string, Promise<ContextGraphCatchupResult>>>();
+const inFlightSyncSingleFlightsByAgent = new WeakMap<DKGAgent, Map<string, Promise<unknown>>>();
 
 function syncPageFetchCoalescingKey(params: {
   remotePeerId: string;
@@ -462,16 +460,32 @@ function inFlightSyncPageFetchesFor(agent: DKGAgent): Map<string, InFlightSyncPa
   return inFlight;
 }
 
-function inFlightPromiseMapFor<T>(
-  registry: WeakMap<DKGAgent, Map<string, Promise<T>>>,
+function runSyncSingleFlight<T>(
   agent: DKGAgent,
-): Map<string, Promise<T>> {
-  let inFlight = registry.get(agent);
+  key: string,
+  factory: () => Promise<T>,
+): Promise<T> {
+  let inFlight = inFlightSyncSingleFlightsByAgent.get(agent);
   if (!inFlight) {
     inFlight = new Map();
-    registry.set(agent, inFlight);
+    inFlightSyncSingleFlightsByAgent.set(agent, inFlight);
   }
-  return inFlight;
+  const existing = inFlight.get(key);
+  if (existing) return existing as Promise<T>;
+
+  const promise = Promise.resolve()
+    .then(factory)
+    .finally(() => {
+      if (inFlight.get(key) === promise) {
+        inFlight.delete(key);
+      }
+    });
+  inFlight.set(key, promise);
+  return promise;
+}
+
+function syncSingleFlightKey(scope: string, fields: Record<string, unknown>): string {
+  return JSON.stringify({ scope, ...fields });
 }
 
 function normalizedCatchupMaxPeers(maxPeers: number | undefined): number | null {
@@ -479,48 +493,54 @@ function normalizedCatchupMaxPeers(maxPeers: number | undefined): number | null 
   return maxPeers;
 }
 
-function contextGraphCatchupCoalescingKey(params: {
+function contextGraphCatchupSingleFlightKey(params: {
   contextGraphId: string;
   includeSharedMemory: boolean;
   maxPeers?: number;
   peerRotationKey?: string;
 }): string {
-  return JSON.stringify([
-    params.contextGraphId,
-    params.includeSharedMemory,
-    normalizedCatchupMaxPeers(params.maxPeers),
-    params.peerRotationKey ?? null,
-  ]);
+  return syncSingleFlightKey('context-graph-catchup', {
+    contextGraphId: params.contextGraphId,
+    includeSharedMemory: params.includeSharedMemory,
+    maxPeers: normalizedCatchupMaxPeers(params.maxPeers),
+    peerRotationKey: params.peerRotationKey ?? null,
+  });
 }
 
-function durableSyncCoalescingKey(params: {
+function durableSyncSingleFlightKey(params: {
   remotePeerId: string;
   contextGraphIds: readonly string[];
   stopOnBackoffWorthyFailure?: boolean;
   syncAgentsMeta: boolean;
-}): string {
-  return JSON.stringify([
-    params.remotePeerId,
-    params.contextGraphIds,
-    params.stopOnBackoffWorthyFailure === true,
-    params.syncAgentsMeta,
-  ]);
+  hasPhaseCallback: boolean;
+  hasAccessDeniedCallback: boolean;
+  hasSinceBatchIdResolver: boolean;
+}): string | null {
+  if (params.hasPhaseCallback || params.hasAccessDeniedCallback || params.hasSinceBatchIdResolver) {
+    return null;
+  }
+  return syncSingleFlightKey('durable-sync', {
+    remotePeerId: params.remotePeerId,
+    contextGraphIds: params.contextGraphIds,
+    stopOnBackoffWorthyFailure: params.stopOnBackoffWorthyFailure === true,
+    syncAgentsMeta: params.syncAgentsMeta,
+  });
 }
 
-function sharedMemorySyncCoalescingKey(params: {
+function sharedMemorySyncSingleFlightKey(params: {
   remotePeerId: string;
   contextGraphIds: readonly string[];
   stopOnBackoffWorthyFailure?: boolean;
   publicContextGraphIds: readonly string[];
   privateRecoverFromCurator: readonly string[];
 }): string {
-  return JSON.stringify([
-    params.remotePeerId,
-    params.contextGraphIds,
-    params.stopOnBackoffWorthyFailure === true,
-    params.publicContextGraphIds,
-    params.privateRecoverFromCurator,
-  ]);
+  return syncSingleFlightKey('shared-memory-sync', {
+    remotePeerId: params.remotePeerId,
+    contextGraphIds: params.contextGraphIds,
+    stopOnBackoffWorthyFailure: params.stopOnBackoffWorthyFailure === true,
+    publicContextGraphIds: params.publicContextGraphIds,
+    privateRecoverFromCurator: params.privateRecoverFromCurator,
+  });
 }
 
 function asSyncFetchAbortError(reason: unknown): Error {
@@ -3479,26 +3499,16 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       }),
     );
 
-    if (onPhase || onAccessDenied || sinceBatchIdFor) {
-      return runSync();
-    }
-    const coalescingKey = durableSyncCoalescingKey({
+    const singleFlightKey = durableSyncSingleFlightKey({
       remotePeerId,
       contextGraphIds,
       stopOnBackoffWorthyFailure,
       syncAgentsMeta,
+      hasPhaseCallback: Boolean(onPhase),
+      hasAccessDeniedCallback: Boolean(onAccessDenied),
+      hasSinceBatchIdResolver: Boolean(sinceBatchIdFor),
     });
-    const inFlight = inFlightPromiseMapFor(inFlightDurableSyncsByAgent, this);
-    const existing = inFlight.get(coalescingKey);
-    if (existing) return existing;
-
-    const sync = runSync().finally(() => {
-      if (inFlight.get(coalescingKey) === sync) {
-        inFlight.delete(coalescingKey);
-      }
-    });
-    inFlight.set(coalescingKey, sync);
-    return sync;
+    return singleFlightKey ? runSyncSingleFlight(this, singleFlightKey, runSync) : runSync();
   }
 
   /**
@@ -3722,16 +3732,13 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       : await this.planSharedMemorySyncContextGraphs(remotePeerId, contextGraphIds, ctx);
     const { publicContextGraphIds, privateRecoverFromCurator } = plan;
     const stopOnBackoffWorthyFailure = options?.stopOnBackoffWorthyFailure;
-    const coalescingKey = sharedMemorySyncCoalescingKey({
+    const singleFlightKey = sharedMemorySyncSingleFlightKey({
       remotePeerId,
       contextGraphIds,
       stopOnBackoffWorthyFailure,
       publicContextGraphIds,
       privateRecoverFromCurator,
     });
-    const inFlight = inFlightPromiseMapFor(inFlightSharedMemorySyncsByAgent, this);
-    const existing = inFlight.get(coalescingKey);
-    if (existing) return existing;
 
     const runSync = async (): Promise<SharedMemorySyncResult> => {
       const subGraphAdmissionByContextGraph = new Map<string, Promise<{ registered: string[]; excluded: string[] }>>();
@@ -3852,13 +3859,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       return summary;
     };
 
-    const sync = runSync().finally(() => {
-      if (inFlight.get(coalescingKey) === sync) {
-        inFlight.delete(coalescingKey);
-      }
-    });
-    inFlight.set(coalescingKey, sync);
-    return sync;
+    return runSyncSingleFlight(this, singleFlightKey, runSync);
   }
 
   /**
@@ -4065,17 +4066,14 @@ export class LifecycleSyncMethods extends DKGAgentBase {
 
     this.trackSyncContextGraph(contextGraphId);
 
-    const coalescingKey = contextGraphCatchupCoalescingKey({
+    const singleFlightKey = contextGraphCatchupSingleFlightKey({
       contextGraphId,
       includeSharedMemory,
       maxPeers: options?.maxPeers,
       peerRotationKey: options?.peerRotationKey,
     });
-    const inFlight = inFlightPromiseMapFor(inFlightContextGraphCatchupsByAgent, this);
-    const existing = inFlight.get(coalescingKey);
-    if (existing) return existing;
 
-    const catchup = (async (): Promise<ContextGraphCatchupResult> => {
+    return runSyncSingleFlight(this, singleFlightKey, async (): Promise<ContextGraphCatchupResult> => {
       const isPrivateContextGraph = await this.isPrivateContextGraph(contextGraphId);
 
       const preferredPeerId = await this.resolvePreferredSyncPeerId(contextGraphId);
@@ -4123,13 +4121,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       return this.runCatchupOverPeers(contextGraphId, includeSharedMemory, peers, {
         totalPeers: orderedPeers.length,
       });
-    })().finally(() => {
-      if (inFlight.get(coalescingKey) === catchup) {
-        inFlight.delete(coalescingKey);
-      }
     });
-    inFlight.set(coalescingKey, catchup);
-    return catchup;
   }
 
   selectCatchupPeerWindow(this: DKGAgent,

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -422,8 +422,12 @@ type InFlightSyncPageFetch = {
   controller: AbortController;
   waiters: number;
 };
+type ContextGraphCatchupResult = Awaited<ReturnType<DKGAgent['runCatchupOverPeers']>>;
 
 const inFlightSyncPageFetchesByAgent = new WeakMap<DKGAgent, Map<string, InFlightSyncPageFetch>>();
+const inFlightDurableSyncsByAgent = new WeakMap<DKGAgent, Map<string, Promise<DurableSyncResult>>>();
+const inFlightSharedMemorySyncsByAgent = new WeakMap<DKGAgent, Map<string, Promise<SharedMemorySyncResult>>>();
+const inFlightContextGraphCatchupsByAgent = new WeakMap<DKGAgent, Map<string, Promise<ContextGraphCatchupResult>>>();
 
 function syncPageFetchCoalescingKey(params: {
   remotePeerId: string;
@@ -456,6 +460,67 @@ function inFlightSyncPageFetchesFor(agent: DKGAgent): Map<string, InFlightSyncPa
     inFlightSyncPageFetchesByAgent.set(agent, inFlight);
   }
   return inFlight;
+}
+
+function inFlightPromiseMapFor<T>(
+  registry: WeakMap<DKGAgent, Map<string, Promise<T>>>,
+  agent: DKGAgent,
+): Map<string, Promise<T>> {
+  let inFlight = registry.get(agent);
+  if (!inFlight) {
+    inFlight = new Map();
+    registry.set(agent, inFlight);
+  }
+  return inFlight;
+}
+
+function normalizedCatchupMaxPeers(maxPeers: number | undefined): number | null {
+  if (maxPeers === undefined || !Number.isInteger(maxPeers) || maxPeers <= 0) return null;
+  return maxPeers;
+}
+
+function contextGraphCatchupCoalescingKey(params: {
+  contextGraphId: string;
+  includeSharedMemory: boolean;
+  maxPeers?: number;
+  peerRotationKey?: string;
+}): string {
+  return JSON.stringify([
+    params.contextGraphId,
+    params.includeSharedMemory,
+    normalizedCatchupMaxPeers(params.maxPeers),
+    params.peerRotationKey ?? null,
+  ]);
+}
+
+function durableSyncCoalescingKey(params: {
+  remotePeerId: string;
+  contextGraphIds: readonly string[];
+  stopOnBackoffWorthyFailure?: boolean;
+  syncAgentsMeta: boolean;
+}): string {
+  return JSON.stringify([
+    params.remotePeerId,
+    params.contextGraphIds,
+    params.stopOnBackoffWorthyFailure === true,
+    params.syncAgentsMeta,
+  ]);
+}
+
+function sharedMemorySyncCoalescingKey(params: {
+  remotePeerId: string;
+  contextGraphIds: readonly string[];
+  stopOnBackoffWorthyFailure?: boolean;
+  publicContextGraphIds: readonly string[];
+  privateRecoverFromCurator: readonly string[];
+}): string {
+  return JSON.stringify([
+    params.remotePeerId,
+    params.contextGraphIds,
+    params.stopOnBackoffWorthyFailure === true,
+    params.publicContextGraphIds,
+    params.privateRecoverFromCurator,
+  ]);
 }
 
 function asSyncFetchAbortError(reason: unknown): Error {
@@ -3381,7 +3446,9 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       this.log.warn(ctx, `Skipping durable sync from ${remotePeerId.slice(-8)} (DKG_DURABLE_SYNC_ENABLED=0)`);
       return emptyDurableSyncResult();
     }
-    return withGlobalSyncBackpressure(
+    const syncAgentsMeta = resolveSyncAgentsMeta(this.config.syncAgentsMeta, process.env.DKG_SYNC_AGENTS_META);
+    const stopOnBackoffWorthyFailure = options?.stopOnBackoffWorthyFailure;
+    const runSync = () => withGlobalSyncBackpressure(
       {
         limit: syncGlobalLimit(this.config),
         ctx,
@@ -3394,11 +3461,11 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         contextGraphIds,
         onPhase,
         onAccessDenied,
-        syncAgentsMeta: resolveSyncAgentsMeta(this.config.syncAgentsMeta, process.env.DKG_SYNC_AGENTS_META),
+        syncAgentsMeta,
         createContextGraphSyncDeadline: this.createContextGraphSyncDeadline.bind(this),
         fetchSyncPages: this.fetchSyncPages.bind(this),
         sinceBatchIdFor,
-        stopOnBackoffWorthyFailure: options?.stopOnBackoffWorthyFailure,
+        stopOnBackoffWorthyFailure,
         processDurableBatchInWorker: this.processDurableBatchInWorker.bind(this),
         storeInsert: (quads) => this.insertSyncedQuadsAndInvalidateListCache(quads, {
           priority: 'background',
@@ -3411,6 +3478,27 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         logDebug: (opCtx, message) => this.log.debug(opCtx, message),
       }),
     );
+
+    if (onPhase || onAccessDenied || sinceBatchIdFor) {
+      return runSync();
+    }
+    const coalescingKey = durableSyncCoalescingKey({
+      remotePeerId,
+      contextGraphIds,
+      stopOnBackoffWorthyFailure,
+      syncAgentsMeta,
+    });
+    const inFlight = inFlightPromiseMapFor(inFlightDurableSyncsByAgent, this);
+    const existing = inFlight.get(coalescingKey);
+    if (existing) return existing;
+
+    const sync = runSync().finally(() => {
+      if (inFlight.get(coalescingKey) === sync) {
+        inFlight.delete(coalescingKey);
+      }
+    });
+    inFlight.set(coalescingKey, sync);
+    return sync;
   }
 
   /**
@@ -3633,123 +3721,144 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       ? planned
       : await this.planSharedMemorySyncContextGraphs(remotePeerId, contextGraphIds, ctx);
     const { publicContextGraphIds, privateRecoverFromCurator } = plan;
+    const stopOnBackoffWorthyFailure = options?.stopOnBackoffWorthyFailure;
+    const coalescingKey = sharedMemorySyncCoalescingKey({
+      remotePeerId,
+      contextGraphIds,
+      stopOnBackoffWorthyFailure,
+      publicContextGraphIds,
+      privateRecoverFromCurator,
+    });
+    const inFlight = inFlightPromiseMapFor(inFlightSharedMemorySyncsByAgent, this);
+    const existing = inFlight.get(coalescingKey);
+    if (existing) return existing;
 
-    const subGraphAdmissionByContextGraph = new Map<string, Promise<{ registered: string[]; excluded: string[] }>>();
-    const getSubGraphAdmission = (contextGraphId: string) => {
-      let admission = subGraphAdmissionByContextGraph.get(contextGraphId);
-      if (!admission) {
-        admission = getSharedMemorySubGraphAdmission(this.store, contextGraphId, this.listSubGraphs(contextGraphId));
-        subGraphAdmissionByContextGraph.set(contextGraphId, admission);
-      }
-      return admission;
-    };
-
-    const summary: SharedMemorySyncResult = publicContextGraphIds.length === 0
-      ? {
-          insertedTriples: 0, fetchedMetaTriples: 0, fetchedDataTriples: 0,
-          insertedMetaTriples: 0, insertedDataTriples: 0, bytesReceived: 0,
-          resumedPhases: 0, timedOutPhases: 0, completedPhases: 0, checkpointAdvances: 0,
-          emptyResponses: 0, droppedDataTriples: 0, failedPeers: 0, failedPhases: 0, deniedPhases: 0,
+    const runSync = async (): Promise<SharedMemorySyncResult> => {
+      const subGraphAdmissionByContextGraph = new Map<string, Promise<{ registered: string[]; excluded: string[] }>>();
+      const getSubGraphAdmission = (contextGraphId: string) => {
+        let admission = subGraphAdmissionByContextGraph.get(contextGraphId);
+        if (!admission) {
+          admission = getSharedMemorySubGraphAdmission(this.store, contextGraphId, this.listSubGraphs(contextGraphId));
+          subGraphAdmissionByContextGraph.set(contextGraphId, admission);
         }
-      : await withGlobalSyncBackpressure(
-          {
-            limit: syncGlobalLimit(this.config),
-            ctx,
-            label: `shared-memory:${remotePeerId.slice(-8)}`,
-            logInfo: (opCtx, message) => this.log.info(opCtx, message),
-          },
-          () => runSharedMemorySync({
-            ctx,
-            remotePeerId,
-            contextGraphIds: publicContextGraphIds,
-            createContextGraphSyncDeadline: this.createContextGraphSyncDeadline.bind(this),
-            fetchSyncPages: this.fetchSyncPages.bind(this),
-            processSharedMemoryBatch: (wsDataQuads, wsMetaQuads, contextGraphId, registeredSubGraphNames, excludedSubGraphNames) =>
-              this.getOrCreateSyncVerifyWorker().processSharedMemoryBatch(
-                wsDataQuads,
-                wsMetaQuads,
-                contextGraphId,
-                registeredSubGraphNames,
-                excludedSubGraphNames,
-              ),
-            getRegisteredSubGraphNames: async (contextGraphId) => (await getSubGraphAdmission(contextGraphId)).registered,
-            getExcludedSubGraphNames: async (contextGraphId) => (await getSubGraphAdmission(contextGraphId)).excluded,
-            stopOnBackoffWorthyFailure: options?.stopOnBackoffWorthyFailure,
-            ensureContextGraph: async (contextGraphId) => {
-              const graphManager = new GraphManager(this.store);
-              await graphManager.ensureContextGraph(contextGraphId);
-            },
-            storeInsert: async (quads) => {
-              // Oversize guard (OT-RFC-56): drop+tombstone protocol-violating
-              // literals BEFORE insert so the SWM page cursor advances instead
-              // of the store throwing and the page re-fetching forever.
-              const inserted = await insertWithOversizeGuard(
-                (kept) => this.store.insert(kept, {
-                  priority: 'background',
-                  source: 'agent.sharedMemorySync.storeInsert',
-                }),
-                quads,
-                { recordDrops: (drops, seam) => this.oversizeTombstoneLog.record(drops, seam) },
-                'swm-sync',
-              );
-              this.contextGraphMetaProjection.markDirtyFromQuads(inserted);
-            },
-            publicSnapshotStore: this.publicSnapshotStore,
-            deleteCheckpoint: (key) => this.syncCheckpoints.delete(key),
-            setCheckpoint: (key, offset) => this.syncCheckpoints.set(key, offset),
-            ensureOwnedMap: (contextGraphId) => {
-              if (!this.workspaceOwnedEntities.has(contextGraphId)) {
-                this.workspaceOwnedEntities.set(contextGraphId, new Map());
-              }
-              return this.workspaceOwnedEntities.get(contextGraphId)!;
-            },
-            logInfo: (opCtx, message) => this.log.info(opCtx, message),
-            logWarn: (opCtx, message) => this.log.warn(opCtx, message),
-            logDebug: (opCtx, message) => this.log.debug(opCtx, message),
-          }),
-        );
+        return admission;
+      };
 
-    // PRIVATE CGs: REPLACE-recover the current state from the curator (= remotePeerId,
-    // gated above to be the curator and not self). Reuses the all-or-nothing recovery.
-    for (const contextGraphId of privateRecoverFromCurator) {
-      try {
-        const r = await this.recoverContextGraphSwmFromPeer(remotePeerId, contextGraphId);
-        summary.insertedDataTriples += r.insertedDataQuads;
-        summary.insertedMetaTriples += r.insertedMetaQuads;
-        summary.insertedTriples += r.insertedDataQuads + r.insertedMetaQuads;
-        summary.droppedDataTriples += r.droppedDataTriples;
-        // `recoverContextGraphSwmFromPeer` signals a partial / deadline-bounded
-        // fetch with `completed === false` WITHOUT throwing (all-or-nothing
-        // REPLACE mutates nothing on a partial). The on-connect accounting and
-        // the catch-up runner key success off the phase counters, so an
-        // incomplete recovery that left `failedPhases`/`completedPhases` at 0
-        // would be reported clean — stamping `lastSuccessfulSyncAt` and
-        // suppressing the next retry while the member stays stale. Count an
-        // incomplete recovery as a failed phase (forces a prompt retry); count a
-        // complete one as a completed phase so an idempotent 0-insert REPLACE
-        // still registers as progress.
-        if (r.completed) {
-          summary.completedPhases += 1;
-        } else {
-          summary.failedPhases += 1;
+      const summary: SharedMemorySyncResult = publicContextGraphIds.length === 0
+        ? {
+            insertedTriples: 0, fetchedMetaTriples: 0, fetchedDataTriples: 0,
+            insertedMetaTriples: 0, insertedDataTriples: 0, bytesReceived: 0,
+            resumedPhases: 0, timedOutPhases: 0, completedPhases: 0, checkpointAdvances: 0,
+            emptyResponses: 0, droppedDataTriples: 0, failedPeers: 0, failedPhases: 0, deniedPhases: 0,
+          }
+        : await withGlobalSyncBackpressure(
+            {
+              limit: syncGlobalLimit(this.config),
+              ctx,
+              label: `shared-memory:${remotePeerId.slice(-8)}`,
+              logInfo: (opCtx, message) => this.log.info(opCtx, message),
+            },
+            () => runSharedMemorySync({
+              ctx,
+              remotePeerId,
+              contextGraphIds: publicContextGraphIds,
+              createContextGraphSyncDeadline: this.createContextGraphSyncDeadline.bind(this),
+              fetchSyncPages: this.fetchSyncPages.bind(this),
+              processSharedMemoryBatch: (wsDataQuads, wsMetaQuads, contextGraphId, registeredSubGraphNames, excludedSubGraphNames) =>
+                this.getOrCreateSyncVerifyWorker().processSharedMemoryBatch(
+                  wsDataQuads,
+                  wsMetaQuads,
+                  contextGraphId,
+                  registeredSubGraphNames,
+                  excludedSubGraphNames,
+                ),
+              getRegisteredSubGraphNames: async (contextGraphId) => (await getSubGraphAdmission(contextGraphId)).registered,
+              getExcludedSubGraphNames: async (contextGraphId) => (await getSubGraphAdmission(contextGraphId)).excluded,
+              stopOnBackoffWorthyFailure,
+              ensureContextGraph: async (contextGraphId) => {
+                const graphManager = new GraphManager(this.store);
+                await graphManager.ensureContextGraph(contextGraphId);
+              },
+              storeInsert: async (quads) => {
+                // Oversize guard (OT-RFC-56): drop+tombstone protocol-violating
+                // literals BEFORE insert so the SWM page cursor advances instead
+                // of the store throwing and the page re-fetching forever.
+                const inserted = await insertWithOversizeGuard(
+                  (kept) => this.store.insert(kept, {
+                    priority: 'background',
+                    source: 'agent.sharedMemorySync.storeInsert',
+                  }),
+                  quads,
+                  { recordDrops: (drops, seam) => this.oversizeTombstoneLog.record(drops, seam) },
+                  'swm-sync',
+                );
+                this.contextGraphMetaProjection.markDirtyFromQuads(inserted);
+              },
+              publicSnapshotStore: this.publicSnapshotStore,
+              deleteCheckpoint: (key) => this.syncCheckpoints.delete(key),
+              setCheckpoint: (key, offset) => this.syncCheckpoints.set(key, offset),
+              ensureOwnedMap: (contextGraphId) => {
+                if (!this.workspaceOwnedEntities.has(contextGraphId)) {
+                  this.workspaceOwnedEntities.set(contextGraphId, new Map());
+                }
+                return this.workspaceOwnedEntities.get(contextGraphId)!;
+              },
+              logInfo: (opCtx, message) => this.log.info(opCtx, message),
+              logWarn: (opCtx, message) => this.log.warn(opCtx, message),
+              logDebug: (opCtx, message) => this.log.debug(opCtx, message),
+            }),
+          );
+
+      // PRIVATE CGs: REPLACE-recover the current state from the curator (= remotePeerId,
+      // gated above to be the curator and not self). Reuses the all-or-nothing recovery.
+      for (const contextGraphId of privateRecoverFromCurator) {
+        try {
+          const r = await this.recoverContextGraphSwmFromPeer(remotePeerId, contextGraphId);
+          summary.insertedDataTriples += r.insertedDataQuads;
+          summary.insertedMetaTriples += r.insertedMetaQuads;
+          summary.insertedTriples += r.insertedDataQuads + r.insertedMetaQuads;
+          summary.droppedDataTriples += r.droppedDataTriples;
+          // `recoverContextGraphSwmFromPeer` signals a partial / deadline-bounded
+          // fetch with `completed === false` WITHOUT throwing (all-or-nothing
+          // REPLACE mutates nothing on a partial). The on-connect accounting and
+          // the catch-up runner key success off the phase counters, so an
+          // incomplete recovery that left `failedPhases`/`completedPhases` at 0
+          // would be reported clean — stamping `lastSuccessfulSyncAt` and
+          // suppressing the next retry while the member stays stale. Count an
+          // incomplete recovery as a failed phase (forces a prompt retry); count a
+          // complete one as a completed phase so an idempotent 0-insert REPLACE
+          // still registers as progress.
+          if (r.completed) {
+            summary.completedPhases += 1;
+          } else {
+            summary.failedPhases += 1;
+            summary.backoffWorthyFailures = (summary.backoffWorthyFailures ?? 0) + 1;
+            if (stopOnBackoffWorthyFailure) {
+              this.log.info(ctx, `Stopping SWM curator-recovery fanout for ${remotePeerId} after "${contextGraphId}" (incomplete recovery)`);
+              break;
+            }
+          }
+        } catch (err) {
+          this.log.warn(ctx, `Curator-recovery for private CG "${contextGraphId}" from ${remotePeerId} failed: ${err instanceof Error ? err.message : String(err)}`);
+          summary.failedPeers += 1;
           summary.backoffWorthyFailures = (summary.backoffWorthyFailures ?? 0) + 1;
-          if (options?.stopOnBackoffWorthyFailure) {
-            this.log.info(ctx, `Stopping SWM curator-recovery fanout for ${remotePeerId} after "${contextGraphId}" (incomplete recovery)`);
+          if (stopOnBackoffWorthyFailure) {
+            this.log.info(ctx, `Stopping SWM curator-recovery fanout for ${remotePeerId} after "${contextGraphId}" (backoff-worthy failure)`);
             break;
           }
         }
-      } catch (err) {
-        this.log.warn(ctx, `Curator-recovery for private CG "${contextGraphId}" from ${remotePeerId} failed: ${err instanceof Error ? err.message : String(err)}`);
-        summary.failedPeers += 1;
-        summary.backoffWorthyFailures = (summary.backoffWorthyFailures ?? 0) + 1;
-        if (options?.stopOnBackoffWorthyFailure) {
-          this.log.info(ctx, `Stopping SWM curator-recovery fanout for ${remotePeerId} after "${contextGraphId}" (backoff-worthy failure)`);
-          break;
-        }
       }
-    }
 
-    return summary;
+      return summary;
+    };
+
+    const sync = runSync().finally(() => {
+      if (inFlight.get(coalescingKey) === sync) {
+        inFlight.delete(coalescingKey);
+      }
+    });
+    inFlight.set(coalescingKey, sync);
+    return sync;
   }
 
   /**
@@ -3953,55 +4062,74 @@ export class LifecycleSyncMethods extends DKGAgentBase {
   }> {
     const ctx = createOperationContext('sync');
     const includeSharedMemory = options?.includeSharedMemory ?? false;
-    const isPrivateContextGraph = await this.isPrivateContextGraph(contextGraphId);
 
     this.trackSyncContextGraph(contextGraphId);
 
-    const preferredPeerId = await this.resolvePreferredSyncPeerId(contextGraphId);
-    if (preferredPeerId) {
-      let preferredPeerAdmitted = false;
-      try {
-        preferredPeerAdmitted = await this.networkAdmissionCoordinator.ensureAdmitted(preferredPeerId, ctx);
-      } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : String(err);
-        this.log.warn(ctx, `Preferred catchup peer ${preferredPeerId.slice(-8)} admission probe failed: ${message}`);
-      }
-      if (preferredPeerAdmitted) {
-        await this.ensurePeerConnected(preferredPeerId);
-      }
-    }
-
-    await this.primeCatchupConnections();
-
-    const connectedPeers = [...new Map(
-      this.node.libp2p.getConnections().map((conn) => [conn.remotePeer.toString(), conn.remotePeer]),
-    ).values()];
-    const admittedConnectedPeers: Array<{ toString(): string }> = [];
-    for (const peer of connectedPeers) {
-      if (await this.ensurePeerAdmittedForRecovery(peer.toString(), ctx, 'Connected catchup peer')) {
-        admittedConnectedPeers.push(peer);
-      }
-    }
-    const orderedPeers = this.selectCatchupPeers(
-      admittedConnectedPeers,
-      preferredPeerId,
-      isPrivateContextGraph,
-    );
-    const peerPriorityRanks = new Map<string, number>();
-    for (const peer of orderedPeers) {
-      const peerId = peer.toString();
-      const rank = peerId === preferredPeerId ? 2 : this.knownCorePeerIds.has(peerId) ? 1 : 0;
-      if (rank > 0) peerPriorityRanks.set(peerId, rank);
-    }
-    const peers = this.selectCatchupPeerWindow(orderedPeers, { ...options, peerPriorityRanks });
-    const coreCount = orderedPeers.filter((p) => this.knownCorePeerIds.has(p.toString())).length;
-    this.log.info(
-      ctx,
-      `catchup peer order for "${contextGraphId}": preferred=${preferredPeerId ?? 'none'} cores=${coreCount} total=${orderedPeers.length} selected=${peers.length}`,
-    );
-    return this.runCatchupOverPeers(contextGraphId, includeSharedMemory, peers, {
-      totalPeers: orderedPeers.length,
+    const coalescingKey = contextGraphCatchupCoalescingKey({
+      contextGraphId,
+      includeSharedMemory,
+      maxPeers: options?.maxPeers,
+      peerRotationKey: options?.peerRotationKey,
     });
+    const inFlight = inFlightPromiseMapFor(inFlightContextGraphCatchupsByAgent, this);
+    const existing = inFlight.get(coalescingKey);
+    if (existing) return existing;
+
+    const catchup = (async (): Promise<ContextGraphCatchupResult> => {
+      const isPrivateContextGraph = await this.isPrivateContextGraph(contextGraphId);
+
+      const preferredPeerId = await this.resolvePreferredSyncPeerId(contextGraphId);
+      if (preferredPeerId) {
+        let preferredPeerAdmitted = false;
+        try {
+          preferredPeerAdmitted = await this.networkAdmissionCoordinator.ensureAdmitted(preferredPeerId, ctx);
+        } catch (err: unknown) {
+          const message = err instanceof Error ? err.message : String(err);
+          this.log.warn(ctx, `Preferred catchup peer ${preferredPeerId.slice(-8)} admission probe failed: ${message}`);
+        }
+        if (preferredPeerAdmitted) {
+          await this.ensurePeerConnected(preferredPeerId);
+        }
+      }
+
+      await this.primeCatchupConnections();
+
+      const connectedPeers = [...new Map(
+        this.node.libp2p.getConnections().map((conn) => [conn.remotePeer.toString(), conn.remotePeer]),
+      ).values()];
+      const admittedConnectedPeers: Array<{ toString(): string }> = [];
+      for (const peer of connectedPeers) {
+        if (await this.ensurePeerAdmittedForRecovery(peer.toString(), ctx, 'Connected catchup peer')) {
+          admittedConnectedPeers.push(peer);
+        }
+      }
+      const orderedPeers = this.selectCatchupPeers(
+        admittedConnectedPeers,
+        preferredPeerId,
+        isPrivateContextGraph,
+      );
+      const peerPriorityRanks = new Map<string, number>();
+      for (const peer of orderedPeers) {
+        const peerId = peer.toString();
+        const rank = peerId === preferredPeerId ? 2 : this.knownCorePeerIds.has(peerId) ? 1 : 0;
+        if (rank > 0) peerPriorityRanks.set(peerId, rank);
+      }
+      const peers = this.selectCatchupPeerWindow(orderedPeers, { ...options, peerPriorityRanks });
+      const coreCount = orderedPeers.filter((p) => this.knownCorePeerIds.has(p.toString())).length;
+      this.log.info(
+        ctx,
+        `catchup peer order for "${contextGraphId}": preferred=${preferredPeerId ?? 'none'} cores=${coreCount} total=${orderedPeers.length} selected=${peers.length}`,
+      );
+      return this.runCatchupOverPeers(contextGraphId, includeSharedMemory, peers, {
+        totalPeers: orderedPeers.length,
+      });
+    })().finally(() => {
+      if (inFlight.get(coalescingKey) === catchup) {
+        inFlight.delete(coalescingKey);
+      }
+    });
+    inFlight.set(coalescingKey, catchup);
+    return catchup;
   }
 
   selectCatchupPeerWindow(this: DKGAgent,

--- a/packages/agent/test/sync-fetch-coalescing.test.ts
+++ b/packages/agent/test/sync-fetch-coalescing.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createOperationContext } from '@origintrail-official/dkg-core';
+import { createOperationContext, PROTOCOL_SYNC } from '@origintrail-official/dkg-core';
 import { MockChainAdapter } from '@origintrail-official/dkg-chain';
 import { DKGAgent } from '../src/index.js';
 import type { SyncPhase } from '../src/sync/auth/request-build.js';
@@ -36,6 +36,36 @@ async function flushMicrotasks(): Promise<void> {
   await Promise.resolve();
   await Promise.resolve();
   await Promise.resolve();
+}
+
+async function waitFor(condition: () => boolean, timeoutMs = 1_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!condition()) {
+    if (Date.now() > deadline) throw new Error('condition was not met before timeout');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+function cleanDurableSyncResult() {
+  return {
+    insertedTriples: 0,
+    fetchedMetaTriples: 0,
+    fetchedDataTriples: 0,
+    insertedMetaTriples: 0,
+    insertedDataTriples: 0,
+    bytesReceived: 0,
+    resumedPhases: 0,
+    timedOutPhases: 0,
+    completedPhases: 1,
+    checkpointAdvances: 0,
+    emptyResponses: 0,
+    metaOnlyResponses: 0,
+    dataRejectedMissingMeta: 0,
+    rejectedKcs: 0,
+    failedPeers: 0,
+    failedPhases: 0,
+    deniedPhases: 0,
+  };
 }
 
 async function createAgentWithSend(
@@ -222,6 +252,48 @@ describe('DKGAgent sync fetch coalescing', () => {
       await expect(waiter).rejects.toMatchObject({ name: 'AbortError', message: 'only waiter aborted' });
       await abortObserved.promise;
       expect(sendSignal?.aborted).toBe(true);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+
+  it('joins concurrent catch-up rounds for the same context graph and mode', async () => {
+    let durableResponse = deferred<ReturnType<typeof cleanDurableSyncResult>>();
+    let durableSyncs = 0;
+    const agent = await createAgentWithSend(async () => new Uint8Array(0));
+    const remotePeer = { toString: () => PEER_A };
+
+    try {
+      await agent.start();
+      (agent as any).isPrivateContextGraph = async () => false;
+      (agent as any).resolvePreferredSyncPeerId = async () => undefined;
+      (agent as any).primeCatchupConnections = async () => undefined;
+      (agent as any).ensurePeerAdmittedForRecovery = async () => true;
+      (agent as any).waitForSyncProtocol = async () => true;
+      (agent as any).refreshMetaSyncedFlags = async () => undefined;
+      (agent.node.libp2p as any).getConnections = () => [{ remotePeer }];
+      (agent.node.libp2p.peerStore as any).get = async () => ({ protocols: [PROTOCOL_SYNC] });
+      (agent as any).syncFromPeerDetailed = async () => {
+        durableSyncs++;
+        return durableResponse.promise;
+      };
+
+      const first = agent.syncContextGraphFromConnectedPeers('coalesced-cg');
+      const second = agent.syncContextGraphFromConnectedPeers('coalesced-cg');
+      await waitFor(() => durableSyncs === 1);
+
+      expect(durableSyncs).toBe(1);
+      durableResponse.resolve(cleanDurableSyncResult());
+      const [firstResult, secondResult] = await Promise.all([first, second]);
+      expect(firstResult).toBe(secondResult);
+      expect(firstResult.peersTried).toBe(1);
+
+      durableResponse = deferred<ReturnType<typeof cleanDurableSyncResult>>();
+      const third = agent.syncContextGraphFromConnectedPeers('coalesced-cg');
+      await waitFor(() => durableSyncs === 2);
+      expect(durableSyncs).toBe(2);
+      durableResponse.resolve(cleanDurableSyncResult());
+      await expect(third).resolves.toMatchObject({ peersTried: 1 });
     } finally {
       await agent.stop().catch(() => {});
     }

--- a/packages/agent/test/sync-fetch-coalescing.test.ts
+++ b/packages/agent/test/sync-fetch-coalescing.test.ts
@@ -68,6 +68,38 @@ function cleanDurableSyncResult() {
   };
 }
 
+function cleanSharedMemorySyncResult() {
+  return {
+    insertedTriples: 0,
+    fetchedMetaTriples: 0,
+    fetchedDataTriples: 0,
+    insertedMetaTriples: 0,
+    insertedDataTriples: 0,
+    bytesReceived: 0,
+    resumedPhases: 0,
+    timedOutPhases: 0,
+    completedPhases: 1,
+    checkpointAdvances: 0,
+    emptyResponses: 0,
+    droppedDataTriples: 0,
+    failedPeers: 0,
+    failedPhases: 0,
+    deniedPhases: 0,
+  };
+}
+
+function emptySyncPage(phase: string): SyncPageResult {
+  return {
+    quads: [],
+    bytesReceived: 0,
+    resumedFromOffset: 0,
+    nextOffset: 0,
+    checkpointKey: `checkpoint:${phase}`,
+    completed: true,
+    timedOut: false,
+  };
+}
+
 async function createAgentWithSend(
   sendToPeer: (...args: unknown[]) => Promise<Uint8Array>,
 ): Promise<DKGAgent> {
@@ -257,6 +289,122 @@ describe('DKGAgent sync fetch coalescing', () => {
     }
   });
 
+  it('joins concurrent direct durable syncs and clears the entry after settle', async () => {
+    const firstMetaFetch = deferred<SyncPageResult>();
+    let fetchCalls = 0;
+    const agent = await createAgentWithSend(async () => new Uint8Array(0));
+    (agent as any).fetchSyncPages = async (...args: unknown[]) => {
+      fetchCalls++;
+      const phase = String(args[4]);
+      if (fetchCalls === 1) return firstMetaFetch.promise;
+      return emptySyncPage(phase);
+    };
+    (agent as any).processDurableBatchInWorker = async () => ({
+      verifiedData: [],
+      verifiedMeta: [],
+      totalFetchedDataQuads: 0,
+      totalFetchedMetaQuads: 0,
+      rejectedKcs: 0,
+      emptyResponses: 1,
+      metaOnlyResponses: 0,
+      dataRejectedMissingMeta: 0,
+    });
+
+    try {
+      const first = (agent as any).syncFromPeerDetailed(PEER_A, ['coalesced-cg']);
+      const second = (agent as any).syncFromPeerDetailed(PEER_A, ['coalesced-cg']);
+      await waitFor(() => fetchCalls === 1);
+      expect(fetchCalls).toBe(1);
+
+      firstMetaFetch.resolve(emptySyncPage('meta'));
+      const [firstResult, secondResult] = await Promise.all([first, second]);
+      expect(firstResult).toBe(secondResult);
+      expect(fetchCalls).toBe(2);
+
+      const third = (agent as any).syncFromPeerDetailed(PEER_A, ['coalesced-cg']);
+      await expect(third).resolves.toMatchObject({ failedPeers: 0 });
+      expect(fetchCalls).toBe(4);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+
+  it('does not join direct durable syncs with callback side effects', async () => {
+    let fetchCalls = 0;
+    const agent = await createAgentWithSend(async () => new Uint8Array(0));
+    (agent as any).fetchSyncPages = async (...args: unknown[]) => {
+      fetchCalls++;
+      return emptySyncPage(String(args[4]));
+    };
+    (agent as any).processDurableBatchInWorker = async () => ({
+      verifiedData: [],
+      verifiedMeta: [],
+      totalFetchedDataQuads: 0,
+      totalFetchedMetaQuads: 0,
+      rejectedKcs: 0,
+      emptyResponses: 1,
+      metaOnlyResponses: 0,
+      dataRejectedMissingMeta: 0,
+    });
+
+    try {
+      await Promise.all([
+        (agent as any).syncFromPeerDetailed(PEER_A, ['coalesced-cg'], () => undefined),
+        (agent as any).syncFromPeerDetailed(PEER_A, ['coalesced-cg'], () => undefined),
+      ]);
+      expect(fetchCalls).toBe(4);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+
+  it('joins concurrent direct shared-memory syncs and clears the entry after settle', async () => {
+    const firstMetaFetch = deferred<SyncPageResult>();
+    let fetchCalls = 0;
+    const agent = await createAgentWithSend(async () => new Uint8Array(0));
+    const sharedMemorySyncPlan = {
+      eligibleContextGraphIds: ['coalesced-cg'],
+      publicContextGraphIds: ['coalesced-cg'],
+      privateRecoverFromCurator: [],
+    };
+    (agent as any).listSubGraphs = async () => [];
+    (agent as any).fetchSyncPages = async (...args: unknown[]) => {
+      fetchCalls++;
+      const phase = String(args[4]);
+      if (fetchCalls === 1) return firstMetaFetch.promise;
+      return emptySyncPage(phase);
+    };
+    (agent as any).getOrCreateSyncVerifyWorker = () => ({
+      processSharedMemoryBatch: async () => ({
+        verifiedData: [],
+        verifiedMeta: [],
+        totalFetchedDataQuads: 0,
+        totalFetchedMetaQuads: 0,
+        droppedDataTriples: 0,
+        emptyResponses: 1,
+        entityCreators: [],
+      }),
+    });
+
+    try {
+      const first = (agent as any).syncSharedMemoryFromPeerDetailed(PEER_A, ['coalesced-cg'], { sharedMemorySyncPlan });
+      const second = (agent as any).syncSharedMemoryFromPeerDetailed(PEER_A, ['coalesced-cg'], { sharedMemorySyncPlan });
+      await waitFor(() => fetchCalls === 1);
+      expect(fetchCalls).toBe(1);
+
+      firstMetaFetch.resolve(emptySyncPage('meta'));
+      const [firstResult, secondResult] = await Promise.all([first, second]);
+      expect(firstResult).toBe(secondResult);
+      expect(fetchCalls).toBe(2);
+
+      const third = (agent as any).syncSharedMemoryFromPeerDetailed(PEER_A, ['coalesced-cg'], { sharedMemorySyncPlan });
+      await expect(third).resolves.toMatchObject({ failedPeers: 0 });
+      expect(fetchCalls).toBe(4);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+
   it('joins concurrent catch-up rounds for the same context graph and mode', async () => {
     let durableResponse = deferred<ReturnType<typeof cleanDurableSyncResult>>();
     let durableSyncs = 0;
@@ -296,6 +444,49 @@ describe('DKGAgent sync fetch coalescing', () => {
       await expect(third).resolves.toMatchObject({ peersTried: 1 });
     } finally {
       await agent.stop().catch(() => {});
+    }
+  });
+
+  it('does not join catch-up rounds with different shareable identity fields', async () => {
+    const cases: Array<{
+      name: string;
+      firstOptions?: { includeSharedMemory?: boolean; maxPeers?: number; peerRotationKey?: string };
+      secondOptions?: { includeSharedMemory?: boolean; maxPeers?: number; peerRotationKey?: string };
+    }> = [
+      { name: 'includeSharedMemory', firstOptions: {}, secondOptions: { includeSharedMemory: true } },
+      { name: 'maxPeers', firstOptions: { maxPeers: 1 }, secondOptions: { maxPeers: 2 } },
+      { name: 'peerRotationKey', firstOptions: { peerRotationKey: 'a' }, secondOptions: { peerRotationKey: 'b' } },
+    ];
+
+    for (const testCase of cases) {
+      let durableSyncs = 0;
+      const agent = await createAgentWithSend(async () => new Uint8Array(0));
+      const remotePeer = { toString: () => PEER_A };
+
+      try {
+        await agent.start();
+        (agent as any).isPrivateContextGraph = async () => false;
+        (agent as any).resolvePreferredSyncPeerId = async () => undefined;
+        (agent as any).primeCatchupConnections = async () => undefined;
+        (agent as any).ensurePeerAdmittedForRecovery = async () => true;
+        (agent as any).waitForSyncProtocol = async () => true;
+        (agent as any).refreshMetaSyncedFlags = async () => undefined;
+        (agent.node.libp2p as any).getConnections = () => [{ remotePeer }];
+        (agent.node.libp2p.peerStore as any).get = async () => ({ protocols: [PROTOCOL_SYNC] });
+        (agent as any).syncFromPeerDetailed = async () => {
+          durableSyncs++;
+          return cleanDurableSyncResult();
+        };
+        (agent as any).syncSharedMemoryFromPeerDetailed = async () => cleanSharedMemorySyncResult();
+
+        await Promise.all([
+          agent.syncContextGraphFromConnectedPeers('coalesced-cg', testCase.firstOptions),
+          agent.syncContextGraphFromConnectedPeers('coalesced-cg', testCase.secondOptions),
+        ]);
+        expect(durableSyncs, testCase.name).toBe(2);
+      } finally {
+        await agent.stop().catch(() => {});
+      }
     }
   });
 });


### PR DESCRIPTION
## Summary
- coalesce duplicate in-flight durable peer/context-graph syncs before they consume separate global backpressure slots
- coalesce duplicate shared-memory peer/context-graph syncs after resolving the effective SWM plan
- coalesce identical in-flight `syncContextGraphFromConnectedPeers` catch-up rounds by CG, SWM mode, and peer-window options

## Tests
- pnpm --filter @origintrail-official/dkg-agent... run build
- pnpm --filter @origintrail-official/dkg-agent run build
- pnpm --filter @origintrail-official/dkg-agent exec vitest run --dir . test/sync-fetch-coalescing.test.ts