### PR TITLE
fix(storage): keep the graph-set index warm at source + off the ack lane (#1549)

### DIFF
--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -2731,7 +2731,16 @@ export class SwmHostModeMethods extends DKGAgentBase {
       // backend can't do SPARQL UPDATE we bail rather than risk a lossy JS round-trip.
       const storeUpdate = this.store.update;
       if (typeof storeUpdate !== 'function') return;
-      const update = (sparql: string): Promise<void> => storeUpdate.call(this.store, sparql);
+      // #1549: declare the graph(s) each server-side INSERT touches so the
+      // graph-set index maintains itself incrementally (a bounded `hasGraph`)
+      // instead of marking the whole index dirty and forcing a full store scan on
+      // the next enumeration. RS-heal is one of only two recurring server-side
+      // UPDATE sources that dirtied the index, and its target graphs are known here.
+      const update = (sparql: string, touchedGraphs?: string[]): Promise<void> =>
+        storeUpdate.call(this.store, sparql, {
+          source: 'agent.swm.rsHeal.materialize',
+          ...(touchedGraphs ? { touchedGraphs } : {}),
+        });
 
       const DKG = 'http://dkg.io/ontology/';
       const legacyMeta = contextGraphMetaUri(localCgId);
@@ -2873,6 +2882,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
                      }
                    }
                  }`,
+                [scopedData],
               );
             }
 
@@ -2886,6 +2896,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
                    FILTER(?s = <${ual}> || STRSTARTS(STR(?s), "${ual}/"))
                  }
                }`,
+              [scopedMeta],
             );
 
             // Stamp so a later stale writer can't clobber.

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -2731,16 +2731,14 @@ export class SwmHostModeMethods extends DKGAgentBase {
       // backend can't do SPARQL UPDATE we bail rather than risk a lossy JS round-trip.
       const storeUpdate = this.store.update;
       if (typeof storeUpdate !== 'function') return;
-      // #1549: declare the graph(s) each server-side INSERT touches so the
-      // graph-set index maintains itself incrementally (a bounded `hasGraph`)
-      // instead of marking the whole index dirty and forcing a full store scan on
-      // the next enumeration. RS-heal is one of only two recurring server-side
-      // UPDATE sources that dirtied the index, and its target graphs are known here.
-      const update = (sparql: string, touchedGraphs?: string[]): Promise<void> =>
-        storeUpdate.call(this.store, sparql, {
-          source: 'agent.swm.rsHeal.materialize',
-          ...(touchedGraphs ? { touchedGraphs } : {}),
-        });
+      // #1549: every server-side INSERT in this RS-heal path has a statically-known
+      // target graph, so `touchedGraphs` is REQUIRED — the index then maintains
+      // itself incrementally (a bounded `hasGraph`) instead of marking the whole
+      // index dirty and forcing a full store scan on the next enumeration. Requiring
+      // it (not optional) closes the escape hatch: a future `update(sparql)` here that
+      // forgot to declare its graph would silently fall back to dirtying the index.
+      const update = (sparql: string, touchedGraphs: readonly string[]): Promise<void> =>
+        storeUpdate.call(this.store, sparql, { source: 'agent.swm.rsHeal.materialize', touchedGraphs });
 
       const DKG = 'http://dkg.io/ontology/';
       const legacyMeta = contextGraphMetaUri(localCgId);

--- a/packages/agent/test/rs-heal-stranded-kc-decorated.test.ts
+++ b/packages/agent/test/rs-heal-stranded-kc-decorated.test.ts
@@ -141,6 +141,41 @@ describe('healStrandedScopedKCs — through the production store decorator stack
     expect(legacyStill.type === 'boolean' && legacyStill.value).toBe(true);
   });
 
+  it('(#1549) RS-heal INSERTs declare touchedGraphs through the decorator stack', async () => {
+    // Guard the #1549 warm-index behaviour at the call site: a regression reverting
+    // either INSERT to a plain `store.update(sparql)` would still relocate the KC
+    // (the graphsAfter/merkle assertions above stay green) but would re-dirty the
+    // graph-set index and force a full rebuild scan. Capture the update() options the
+    // heal sends through the top of the production stack and assert each INSERT
+    // declares its scoped target graph + source tag.
+    const updateCalls: Array<{ sparql: string; options?: { source?: string; touchedGraphs?: readonly string[] } }> = [];
+    const capturing = new Proxy(store, {
+      get(target, prop, receiver) {
+        if (prop === 'update') {
+          const orig = Reflect.get(target, prop, receiver) as NonNullable<TripleStore['update']>;
+          return (sparql: string, options?: { source?: string; touchedGraphs?: readonly string[] }) => {
+            updateCalls.push({ sparql, options });
+            return orig.call(target, sparql, options);
+          };
+        }
+        return Reflect.get(target, prop, receiver);
+      },
+    }) as TripleStore;
+
+    await SwmHostModeMethods.prototype.healStrandedScopedKCs.call(
+      { store: capturing, log: { info: () => undefined, warn: () => undefined, error: () => undefined } } as never,
+      TEST_CG,
+      { subscribed: true, synced: true, onChainId: TEST_ONCHAIN } as never,
+    );
+
+    const scopedData = contextGraphDataUri(TEST_CG, TEST_ONCHAIN);
+    const scopedMeta = contextGraphMetaUri(TEST_CG, TEST_ONCHAIN);
+    const dataInsert = updateCalls.find((c) => /INSERT/i.test(c.sparql) && c.sparql.includes(scopedData));
+    const metaInsert = updateCalls.find((c) => /INSERT/i.test(c.sparql) && c.sparql.includes(scopedMeta));
+    expect(dataInsert?.options).toMatchObject({ source: 'agent.swm.rsHeal.materialize', touchedGraphs: [scopedData] });
+    expect(metaInsert?.options).toMatchObject({ source: 'agent.swm.rsHeal.materialize', touchedGraphs: [scopedMeta] });
+  });
+
   it('relocates a VM-graph-only one-shot strand through the full stack (read-both)', async () => {
     // The publisher's own one-shot publish() lands public data in the per-KA VM
     // graph, not legacy root data. The read-both heal must recover it through the

--- a/packages/publisher/src/agent-registry-meta-retention.ts
+++ b/packages/publisher/src/agent-registry-meta-retention.ts
@@ -327,5 +327,13 @@ WHERE { GRAPH <${metaGraph}> {
   ?s ?p ?o .
   FILTER(?s = ?record || STRSTARTS(STR(?s), CONCAT(STR(?record), "/")))
 } }`;
-  await storeUpdate.call(store, sparql);
+  // #1549: the prune's DELETE only touches `metaGraph`, so declare it — the
+  // graph-set index then maintains itself incrementally (one `hasGraph`) instead
+  // of marking the whole index dirty and forcing a full store scan on the next
+  // enumeration. The agents-meta prune is one of only two recurring server-side
+  // UPDATE sources that dirtied the index on managed cores.
+  await storeUpdate.call(store, sparql, {
+    touchedGraphs: [metaGraph],
+    source: 'agent-registry-meta.prune',
+  });
 }

--- a/packages/publisher/test/agents-meta-bound.test.ts
+++ b/packages/publisher/test/agents-meta-bound.test.ts
@@ -245,6 +245,40 @@ describe('agents/_meta bound at the residual load-bearing write sites (#1233)', 
     expect(await base.countQuads(metaOf(AGENTS)), 'the prior record was deleted by the UPDATE').toBe(0);
   });
 
+  it('(#1549) the prune declares touchedGraphs=[metaGraph] on its server-side update (index stays warm)', async () => {
+    // Call-site guard: a regression reverting to `store.update(sparql)` (dropping the
+    // hint) would still delete the record and pass the count-free test above, but it
+    // would mark the graph-set index dirty and force a full rebuild scan on the next
+    // enumeration — exactly what #1549 avoids. Assert the hint is sent.
+    const base = new OxigraphStore();
+    const agent = agentDid(0xa1);
+    await base.insert(metaQuadsFor(AGENTS, agent, mkUal('prior')));
+    const updateCalls: Array<{ sparql: string; options?: { touchedGraphs?: readonly string[] } }> = [];
+    const capturing = new Proxy(base, {
+      get(t, p, r) {
+        if (p === 'update') {
+          return (sparql: string, options?: { touchedGraphs?: readonly string[] }) => {
+            updateCalls.push({ sparql, options });
+            return base.update(sparql, options);
+          };
+        }
+        return Reflect.get(t, p, r);
+      },
+    }) as unknown as OxigraphStore;
+
+    await pruneSupersededAgentRegistryMeta({
+      store: capturing,
+      contextGraphId: AGENTS,
+      metaGraph: metaOf(AGENTS),
+      rootEntities: [agent],
+      keepUal: mkUal('prior'),
+    });
+
+    const deleteUpdate = updateCalls.find((c) => /DELETE/i.test(c.sparql));
+    expect(deleteUpdate, 'the prune issues a server-side DELETE update').toBeDefined();
+    expect(deleteUpdate?.options?.touchedGraphs).toEqual([metaOf(AGENTS)]);
+  });
+
   it('(B) evicts the WHOLE record for legacy/multi-root shape (member on <ual>/n with dkg:partOf)', async () => {
     // Legacy / multi-root shape: the member entity sits on the `<ual>/1` TOKEN
     // subject (carrying `dkg:partOf <ual>`), while the KC-level rows (status,

--- a/packages/storage/src/adapters/blazegraph.ts
+++ b/packages/storage/src/adapters/blazegraph.ts
@@ -2,6 +2,7 @@ import type {
   TripleStore,
   Quad as DKGQuad,
   QueryOptions,
+  UpdateOptions,
   StorePressureSnapshot,
   TripleStoreQueryOptions,
   QueryResult,
@@ -146,7 +147,7 @@ export class BlazegraphStore implements TripleStore {
    * delete with two full-graph `countQuads` scans (see above), which is
    * prohibitive on a CPU-pegged core.
    */
-  async update(sparql: string, options?: QueryOptions): Promise<void> {
+  async update(sparql: string, options?: UpdateOptions): Promise<void> {
     await this.sparqlUpdate(
       sparql,
       { ...options, source: options?.source ?? 'blazegraph.update' },

--- a/packages/storage/src/adapters/oxigraph-worker.ts
+++ b/packages/storage/src/adapters/oxigraph-worker.ts
@@ -2,7 +2,7 @@ import { Worker } from 'node:worker_threads';
 import { existsSync } from 'node:fs';
 import { sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import type { TripleStore, Quad, TripleStoreQueryOptions, QueryResult } from '../triple-store.js';
+import type { TripleStore, Quad, TripleStoreQueryOptions, QueryResult, UpdateOptions } from '../triple-store.js';
 import { registerTripleStoreAdapter } from '../triple-store.js';
 
 /**
@@ -628,7 +628,8 @@ export class OxigraphWorkerStore implements TripleStore {
   async deleteByPattern(pattern: Partial<Quad>): Promise<number> { return this.call('deleteByPattern', pattern); }
   // Server-side SPARQL UPDATE forwarded to the worker's OxigraphStore (which
   // implements `update`); same atomic single-message contract as `insert`.
-  async update(sparql: string): Promise<void> { return this.call('update', sparql); }
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async update(sparql: string, _options?: UpdateOptions): Promise<void> { return this.call('update', sparql); }
   async query(sparql: string, options?: TripleStoreQueryOptions): Promise<QueryResult> {
     return this.callWithTimeout<QueryResult>(this.operationTimeoutMs, options?.signal, 'query', sparql);
   }

--- a/packages/storage/src/adapters/oxigraph.ts
+++ b/packages/storage/src/adapters/oxigraph.ts
@@ -10,6 +10,7 @@ import type {
   ConstructResult,
   AskResult,
   TripleStoreQueryOptions,
+  UpdateOptions,
 } from '../triple-store.js';
 import { registerTripleStoreAdapter } from '../triple-store.js';
 import { assertQuadLiteralsMutf8Safe, JAVA_WRITE_UTF_MAX_BYTES } from '@origintrail-official/dkg-core';
@@ -332,7 +333,11 @@ export class OxigraphStore implements TripleStore {
    * graph-to-graph `INSERT…WHERE` copies keep terms byte-identical (no JS
    * termToString→parseTerm round-trip). See {@link TripleStore.update}.
    */
-  async update(sparql: string): Promise<void> {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async update(sparql: string, _options?: UpdateOptions): Promise<void> {
+    // In-process oxigraph is never wrapped by a graph-set index, so the
+    // `touchedGraphs` hint is inapplicable here — accepted for a uniform
+    // update contract, ignored.
     this.store.update(sparql);
     this.scheduleFlush();
   }

--- a/packages/storage/src/adapters/sparql-http.ts
+++ b/packages/storage/src/adapters/sparql-http.ts
@@ -25,6 +25,7 @@ import type {
   TripleStore,
   Quad as DKGQuad,
   QueryOptions,
+  UpdateOptions,
   QueryResult,
   SelectResult,
   ConstructResult,
@@ -365,7 +366,7 @@ export class SparqlHttpStore implements TripleStore {
    * (oxigraph-server) executes graph-to-graph `INSERT…WHERE` copies internally,
    * so terms stay byte-identical (no JS round-trip). See {@link TripleStore.update}.
    */
-  async update(sparql: string, options?: QueryOptions): Promise<void> {
+  async update(sparql: string, options?: UpdateOptions): Promise<void> {
     const res = await this.postUpdate(sparql, {
       ...options,
       source: options?.source ?? 'sparql-http.update',

--- a/packages/storage/src/graph-set-index-store.ts
+++ b/packages/storage/src/graph-set-index-store.ts
@@ -1,5 +1,5 @@
 import { performance } from 'node:perf_hooks';
-import type { Quad, QueryOptions, QueryResult, StorePressureSnapshot, TripleStore } from './triple-store.js';
+import type { Quad, QueryOptions, QueryResult, StorePressureSnapshot, TripleStore, UpdateOptions } from './triple-store.js';
 
 export const DEFAULT_GRAPH_SET_REVALIDATE_MS = 30_000;
 
@@ -131,24 +131,17 @@ export class GraphSetIndexStore implements TripleStore {
     }
     const result = await this.inner.query(sparql, options);
     if (isSparqlUpdate(sparql)) {
-      // A SPARQL UPDATE may create/drop named graphs. When the caller declares
-      // the touched graphs, maintain the index incrementally (bounded per-graph
-      // `hasGraph`) instead of forcing a full rebuild on the next read (#1549 —
-      // keeps the index warm under the UPDATE stream). Opaque updates (no
-      // `touchedGraphs`) fall back to the lazy full rebuild.
-      if (options?.touchedGraphs && options.touchedGraphs.length > 0) {
-        this.bumpMutation();
-        await this.maintainIndex(() =>
-          this.refreshTouchedGraphs([...options.touchedGraphs!], 'query', options),
-        );
-      } else {
-        this.scheduleFullRefresh('query');
-      }
+      // A SPARQL UPDATE through query() may create/drop named graphs we can't
+      // derive incrementally — query() is the READ-path type and carries no
+      // index-maintenance hint (that lives on `update(…, UpdateOptions.touchedGraphs)`).
+      // Mark dirty for a single lazy rebuild on the next read instead of re-scanning
+      // the whole store now (the eager per-UPDATE scan thrashed large stores).
+      this.scheduleFullRefresh('query');
     }
     return result;
   }
 
-  async update(sparql: string, options?: QueryOptions): Promise<void> {
+  async update(sparql: string, options?: UpdateOptions): Promise<void> {
     if (typeof this.inner.update !== 'function') {
       throw new Error('GraphSetIndexStore: inner store does not support update()');
     }
@@ -278,19 +271,22 @@ export class GraphSetIndexStore implements TripleStore {
 
   private async refreshIndexLoop(source: GraphSetRefreshSource, options?: QueryOptions): Promise<Set<string>> {
     for (;;) {
+      const isDirtyRebuild = this.pendingFullRefresh != null;
       const sourceForScan = this.pendingFullRefresh ?? source;
       const generation = this.mutationGeneration;
-      // #1549: the rebuild is a bulk full-store `SELECT DISTINCT ?g` scan. Force it
-      // onto the BACKGROUND lane and tag it, so a rebuild triggered by an
-      // `ack`-priority read (whose `options` would otherwise flow straight through)
-      // never consumes the scarce reserved ACK slot. The triggering read still
-      // awaits this rebuild (forced-fresh — never a stale/empty serve), it just no
-      // longer runs the scan on the ACK lane. Cancellation (`signal`) is preserved.
-      const next = new Set((await this.inner.listGraphs({
-        ...options,
-        priority: 'background',
-        source: 'graph-set-index.rebuild',
-      })).filter(Boolean));
+      // #1549: force the bulk full-store `SELECT DISTINCT ?g` rebuild onto the
+      // BACKGROUND lane ONLY when it is a DIRTY rebuild (an opaque server-side UPDATE
+      // marked the index dirty). Such a rebuild would otherwise inherit an
+      // `ack`-priority reader's `options` and run the full scan on the scarce reserved
+      // ACK slot, head-of-line-blocking other ACK work. A SEED (cold start) or
+      // REVALIDATE refresh is genuinely part of serving the caller — an `ack` read's
+      // seed scan SHOULD use the reserved ACK lane — so it keeps the caller's
+      // priority/source. Cancellation (`signal`) is preserved either way. (With L1
+      // keeping the index warm at source, dirty rebuilds are rare.)
+      const scanOptions: QueryOptions | undefined = isDirtyRebuild
+        ? { ...options, priority: 'background', source: 'graph-set-index.rebuild' }
+        : options;
+      const next = new Set((await this.inner.listGraphs(scanOptions)).filter(Boolean));
       if (generation !== this.mutationGeneration) continue;
       // This scan reflects every mutation up to `generation` (synchronous from
       // here — no await — so a concurrent write can't slip between the check and

--- a/packages/storage/src/graph-set-index-store.ts
+++ b/packages/storage/src/graph-set-index-store.ts
@@ -11,7 +11,8 @@ export type GraphSetMutationSource =
   | 'deleteByPattern'
   | 'deleteBySubjectPrefix'
   | 'dropGraph'
-  | 'query';
+  | 'query'
+  | 'update';
 
 type GraphSetRefreshSource = 'seed' | 'revalidate' | 'deleteByPattern' | 'query' | 'update';
 type PendingFullRefreshSource = 'deleteByPattern' | 'query' | 'update';
@@ -130,11 +131,19 @@ export class GraphSetIndexStore implements TripleStore {
     }
     const result = await this.inner.query(sparql, options);
     if (isSparqlUpdate(sparql)) {
-      // A SPARQL UPDATE may create/drop named graphs we can't derive
-      // incrementally. Mark dirty for a single lazy rebuild on the next read
-      // instead of re-scanning the whole store now — the eager per-UPDATE scan
-      // thrashed large stores under the RS-heal/sync UPDATE stream.
-      this.scheduleFullRefresh('query');
+      // A SPARQL UPDATE may create/drop named graphs. When the caller declares
+      // the touched graphs, maintain the index incrementally (bounded per-graph
+      // `hasGraph`) instead of forcing a full rebuild on the next read (#1549 —
+      // keeps the index warm under the UPDATE stream). Opaque updates (no
+      // `touchedGraphs`) fall back to the lazy full rebuild.
+      if (options?.touchedGraphs && options.touchedGraphs.length > 0) {
+        this.bumpMutation();
+        await this.maintainIndex(() =>
+          this.refreshTouchedGraphs([...options.touchedGraphs!], 'query', options),
+        );
+      } else {
+        this.scheduleFullRefresh('query');
+      }
     }
     return result;
   }
@@ -148,10 +157,22 @@ export class GraphSetIndexStore implements TripleStore {
       return;
     }
     await this.inner.update(sparql, options);
-    // A server-side SPARQL UPDATE (e.g. the RS heal's INSERT…WHERE) can create
-    // or drop named graphs the index must learn about. Rather than re-scan the
-    // whole store on every UPDATE (the thrash), mark dirty: the next read does a
-    // single rebuild and the freshly-created/dropped graph is reflected then.
+    // A server-side SPARQL UPDATE (e.g. the RS heal's INSERT…WHERE) can create or
+    // drop named graphs the index must learn about. When the caller declares the
+    // touched graphs (#1549: RS-heal + agents-meta prune write statically-known
+    // URIs), maintain the index INCREMENTALLY — a bounded per-graph `hasGraph`
+    // (which correctly handles an ASK-guarded INSERT that matched zero rows) —
+    // instead of marking the whole index dirty. That keeps the index warm so
+    // graph enumeration stays O(1) rather than forcing a full store scan on the
+    // next read. Only opaque updates (no `touchedGraphs`) fall back to the lazy
+    // full rebuild.
+    if (this.enabled && options?.touchedGraphs && options.touchedGraphs.length > 0) {
+      this.bumpMutation();
+      await this.maintainIndex(() =>
+        this.refreshTouchedGraphs([...options.touchedGraphs!], 'update', options),
+      );
+      return;
+    }
     this.scheduleFullRefresh('update');
   }
 
@@ -259,7 +280,17 @@ export class GraphSetIndexStore implements TripleStore {
     for (;;) {
       const sourceForScan = this.pendingFullRefresh ?? source;
       const generation = this.mutationGeneration;
-      const next = new Set((await this.inner.listGraphs(options)).filter(Boolean));
+      // #1549: the rebuild is a bulk full-store `SELECT DISTINCT ?g` scan. Force it
+      // onto the BACKGROUND lane and tag it, so a rebuild triggered by an
+      // `ack`-priority read (whose `options` would otherwise flow straight through)
+      // never consumes the scarce reserved ACK slot. The triggering read still
+      // awaits this rebuild (forced-fresh — never a stale/empty serve), it just no
+      // longer runs the scan on the ACK lane. Cancellation (`signal`) is preserved.
+      const next = new Set((await this.inner.listGraphs({
+        ...options,
+        priority: 'background',
+        source: 'graph-set-index.rebuild',
+      })).filter(Boolean));
       if (generation !== this.mutationGeneration) continue;
       // This scan reflects every mutation up to `generation` (synchronous from
       // here — no await — so a concurrent write can't slip between the check and

--- a/packages/storage/src/graph-set-index-store.ts
+++ b/packages/storage/src/graph-set-index-store.ts
@@ -159,11 +159,14 @@ export class GraphSetIndexStore implements TripleStore {
     // graph enumeration stays O(1) rather than forcing a full store scan on the
     // next read. Only opaque updates (no `touchedGraphs`) fall back to the lazy
     // full rebuild.
-    if (this.enabled && options?.touchedGraphs && options.touchedGraphs.length > 0) {
+    if (options?.touchedGraphs && options.touchedGraphs.length > 0) {
+      // Strip the update-only `touchedGraphs` hint before the maintenance READS
+      // (`hasGraph`) — it is meaningless on the read path and must not be smuggled
+      // through the `QueryOptions` boundary into read-path wrappers/diagnostics.
+      const touched = [...options.touchedGraphs];
+      const readOptions = queryOptionsFromUpdateOptions(options);
       this.bumpMutation();
-      await this.maintainIndex(() =>
-        this.refreshTouchedGraphs([...options.touchedGraphs!], 'update', options),
-      );
+      await this.maintainIndex(() => this.refreshTouchedGraphs(touched, 'update', readOptions));
       return;
     }
     this.scheduleFullRefresh('update');
@@ -376,6 +379,16 @@ export class GraphSetIndexStore implements TripleStore {
 
 function namedGraphsFromQuads(quads: Quad[]): string[] {
   return [...new Set(quads.map((quad) => quad.graph).filter(Boolean))];
+}
+
+/**
+ * Drop the update-only `touchedGraphs` hint, yielding the read-path `QueryOptions`
+ * (source/priority/signal) to forward to index-maintenance reads (`hasGraph`) — so
+ * the update-only field never crosses into a read call via structural assignability.
+ */
+function queryOptionsFromUpdateOptions(options: UpdateOptions): QueryOptions {
+  const { touchedGraphs: _touchedGraphs, ...readOptions } = options;
+  return readOptions;
 }
 
 function isSparqlUpdate(sparql: string): boolean {

--- a/packages/storage/src/graph-set-index-store.ts
+++ b/packages/storage/src/graph-set-index-store.ts
@@ -159,15 +159,20 @@ export class GraphSetIndexStore implements TripleStore {
     // graph enumeration stays O(1) rather than forcing a full store scan on the
     // next read. Only opaque updates (no `touchedGraphs`) fall back to the lazy
     // full rebuild.
-    if (options?.touchedGraphs && options.touchedGraphs.length > 0) {
-      // Strip the update-only `touchedGraphs` hint before the maintenance READS
-      // (`hasGraph`) — it is meaningless on the read path and must not be smuggled
-      // through the `QueryOptions` boundary into read-path wrappers/diagnostics.
-      const touched = [...options.touchedGraphs];
-      const readOptions = queryOptionsFromUpdateOptions(options);
-      this.bumpMutation();
-      await this.maintainIndex(() => this.refreshTouchedGraphs(touched, 'update', readOptions));
-      return;
+    if (options?.touchedGraphs) {
+      // Normalize the caller-supplied hint once at the boundary (filter falsy +
+      // de-dupe), matching the `namedGraphsFromQuads` pattern — keeps the incremental
+      // path predictable and avoids repeated `hasGraph` calls on duplicates.
+      const touched = normalizeGraphUris(options.touchedGraphs);
+      if (touched.length > 0) {
+        // Strip the update-only `touchedGraphs` hint before the maintenance READS
+        // (`hasGraph`) — it is meaningless on the read path and must not be smuggled
+        // through the `QueryOptions` boundary into read-path wrappers/diagnostics.
+        const readOptions = queryOptionsFromUpdateOptions(options);
+        this.bumpMutation();
+        await this.maintainIndex(() => this.refreshTouchedGraphs(touched, 'update', readOptions));
+        return;
+      }
     }
     this.scheduleFullRefresh('update');
   }
@@ -379,6 +384,11 @@ export class GraphSetIndexStore implements TripleStore {
 
 function namedGraphsFromQuads(quads: Quad[]): string[] {
   return [...new Set(quads.map((quad) => quad.graph).filter(Boolean))];
+}
+
+/** Filter falsy entries and de-duplicate a caller-supplied graph-URI hint list. */
+function normalizeGraphUris(graphs: readonly string[]): string[] {
+  return [...new Set(graphs.filter(Boolean))];
 }
 
 /**

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -11,6 +11,7 @@ export {
   type TripleStoreConfig,
   type TripleStoreBackend,
   type TripleStoreQueryOptions,
+  type UpdateOptions,
   type LargeLiteralStorageConfig,
   registerTripleStoreAdapter,
   createTripleStore,

--- a/packages/storage/src/shared-memory-literal-blob-store.ts
+++ b/packages/storage/src/shared-memory-literal-blob-store.ts
@@ -5,6 +5,7 @@ import type {
   ConstructResult,
   Quad,
   QueryOptions,
+  UpdateOptions,
   QueryResult,
   SelectResult,
   StorePressureSnapshot,
@@ -83,7 +84,7 @@ export class SharedMemoryLiteralBlobStore implements TripleStore {
     return removed;
   }
 
-  async update(sparql: string, options?: QueryOptions): Promise<void> {
+  async update(sparql: string, options?: UpdateOptions): Promise<void> {
     if (typeof this.inner.update !== 'function') {
       throw new Error('SharedMemoryLiteralBlobStore: inner store does not support update()');
     }

--- a/packages/storage/src/triple-store.ts
+++ b/packages/storage/src/triple-store.ts
@@ -66,19 +66,26 @@ export interface QueryOptions {
    * dispatching or after returning from their blocking native call.
    */
   signal?: AbortSignal;
-  /**
-   * Statically-known named graphs a server-side `update()`/`query(<UPDATE>)`
-   * creates or drops. When supplied, a graph-set index maintains itself
-   * INCREMENTALLY (a bounded `hasGraph` per graph) instead of marking the whole
-   * index dirty and forcing a full `SELECT DISTINCT ?g` rebuild on the next read
-   * — the fix for #1549's perpetually-dirty index under the RS-heal / agents-meta
-   * UPDATE stream. Omit it for opaque updates whose touched graphs are not
-   * derivable at the call site (those still fall back to a lazy full rebuild).
-   */
-  touchedGraphs?: readonly string[];
 }
 
 export type TripleStoreQueryOptions = QueryOptions;
+
+/**
+ * Options for a server-side `update()`. A superset of {@link QueryOptions} with an
+ * index-maintenance hint — kept OFF the read-path `QueryOptions` so it can't be set
+ * on `listGraphs`/`query` reads where it is meaningless.
+ */
+export interface UpdateOptions extends QueryOptions {
+  /**
+   * Statically-known named graphs this UPDATE creates or drops. When supplied, a
+   * graph-set index maintains itself INCREMENTALLY (a bounded `hasGraph` per graph)
+   * instead of marking the whole index dirty and forcing a full `SELECT DISTINCT ?g`
+   * rebuild on the next read — the fix for #1549's perpetually-dirty index under the
+   * RS-heal / agents-meta UPDATE stream. Omit it for opaque updates whose touched
+   * graphs are not derivable at the call site (those fall back to a lazy full rebuild).
+   */
+  touchedGraphs?: readonly string[];
+}
 
 export interface TripleStore {
   /**
@@ -120,7 +127,7 @@ export interface TripleStore {
    * callers needing a byte-stable copy MUST guard on its presence and never
    * fall back to `insert(quads)` for already-stored terms.
    */
-  update?(sparql: string, options?: QueryOptions): Promise<void>;
+  update?(sparql: string, options?: UpdateOptions): Promise<void>;
 
   countQuads(graphUri?: string, options?: QueryOptions): Promise<number>;
 

--- a/packages/storage/src/triple-store.ts
+++ b/packages/storage/src/triple-store.ts
@@ -77,12 +77,12 @@ export type TripleStoreQueryOptions = QueryOptions;
  */
 export interface UpdateOptions extends QueryOptions {
   /**
-   * Statically-known named graphs this UPDATE creates or drops. When supplied, a
-   * graph-set index maintains itself INCREMENTALLY (a bounded `hasGraph` per graph)
-   * instead of marking the whole index dirty and forcing a full `SELECT DISTINCT ?g`
-   * rebuild on the next read — the fix for #1549's perpetually-dirty index under the
-   * RS-heal / agents-meta UPDATE stream. Omit it for opaque updates whose touched
-   * graphs are not derivable at the call site (those fall back to a lazy full rebuild).
+   * The named graphs whose membership (existence) this UPDATE may change — the graphs
+   * it creates, or empties/drops. When supplied, a graph-set index can maintain itself
+   * INCREMENTALLY (a bounded `hasGraph` per graph) instead of marking the whole index
+   * dirty and forcing a full `SELECT DISTINCT ?g` rebuild on the next read. Omit it for
+   * opaque updates whose affected graphs are not derivable at the call site (those fall
+   * back to a lazy full rebuild).
    */
   touchedGraphs?: readonly string[];
 }

--- a/packages/storage/src/triple-store.ts
+++ b/packages/storage/src/triple-store.ts
@@ -66,6 +66,16 @@ export interface QueryOptions {
    * dispatching or after returning from their blocking native call.
    */
   signal?: AbortSignal;
+  /**
+   * Statically-known named graphs a server-side `update()`/`query(<UPDATE>)`
+   * creates or drops. When supplied, a graph-set index maintains itself
+   * INCREMENTALLY (a bounded `hasGraph` per graph) instead of marking the whole
+   * index dirty and forcing a full `SELECT DISTINCT ?g` rebuild on the next read
+   * — the fix for #1549's perpetually-dirty index under the RS-heal / agents-meta
+   * UPDATE stream. Omit it for opaque updates whose touched graphs are not
+   * derivable at the call site (those still fall back to a lazy full rebuild).
+   */
+  touchedGraphs?: readonly string[];
 }
 
 export type TripleStoreQueryOptions = QueryOptions;

--- a/packages/storage/test/graph-set-index-store.test.ts
+++ b/packages/storage/test/graph-set-index-store.test.ts
@@ -526,6 +526,46 @@ describe('GraphSetIndexStore', () => {
     expect(rebuildScan?.priority).not.toBe('ack');
   });
 
+  it('#1549: a cold/seed ack-priority read KEEPS the ACK lane (only the dirty rebuild is demoted)', async () => {
+    const inner = new OxigraphStore();
+    await inner.insert([q('did:dkg:context-graph:seedme')]);
+    const counting = new CountingStore(inner);
+    const store = new GraphSetIndexStore(counting);
+
+    // Cold index (graphs === null). An inbound StorageACK read must SEED on the ACK
+    // lane — demoting the seed to background would make the first ACK after restart
+    // wait behind saturated sync scans and miss its deadline.
+    await expect(
+      store.listGraphsByPrefix('did:dkg:', { priority: 'ack', source: 'test.ack.cold' }),
+    ).resolves.toEqual(['did:dkg:context-graph:seedme']);
+    expect(counting.listGraphsCalls).toBe(1);
+    expect(counting.listGraphsOptions.at(-1)).toMatchObject({ priority: 'ack', source: 'test.ack.cold' });
+  });
+
+  it('#1549: update() with touchedGraphs REMOVES a graph emptied by a DELETE — no full rebuild scan', async () => {
+    const graph = 'did:dkg:context-graph:prune-me';
+    const counting = new MutationHookStore(new OxigraphStore(), {
+      onUpdate: async ({ inner }) => { await inner.deleteByPattern({ graph }); },
+    });
+    const events: GraphSetMutationEvent[] = [];
+    const store = new GraphSetIndexStore(counting, {
+      revalidateMs: 100_000, now: () => 1_000, onMutation: (e) => events.push(e),
+    });
+    await store.insert([q(graph)]);
+    await expect(store.listGraphs()).resolves.toEqual([graph]);
+    expect(counting.listGraphsCalls).toBe(1);
+
+    // A server-side DELETE that empties the graph, with the touched graph declared
+    // (mirrors the agents-meta prune). The index REMOVES it via a bounded hasGraph,
+    // never a full rebuild scan.
+    await store.update(`DELETE WHERE { GRAPH <${graph}> { ?s ?p ?o } }`, { touchedGraphs: [graph] });
+
+    expect(counting.listGraphsCalls).toBe(1); // incremental hasGraph, NOT a full scan
+    await expect(store.listGraphs()).resolves.toEqual([]);
+    expect(counting.listGraphsCalls).toBe(1); // still warm — no rebuild triggered
+    expect(events).toContainEqual({ type: 'graph-removed', graph, source: 'update' });
+  });
+
   it('removes stale graph names after a deferred SPARQL query removal', async () => {
     const graph = 'did:dkg:context-graph:old-query';
     const counting = new MutationHookStore(new OxigraphStore(), {

--- a/packages/storage/test/graph-set-index-store.test.ts
+++ b/packages/storage/test/graph-set-index-store.test.ts
@@ -474,6 +474,58 @@ describe('GraphSetIndexStore', () => {
     });
   });
 
+  it('#1549: update() with declared touchedGraphs maintains the index INCREMENTALLY — no full rebuild scan', async () => {
+    const healed = 'did:dkg:context-graph:heal';
+    const counting = new MutationHookStore(new OxigraphStore(), {
+      onUpdate: async ({ inner }) => { await inner.insert([q(healed)]); },
+    });
+    const events: GraphSetMutationEvent[] = [];
+    const store = new GraphSetIndexStore(counting, {
+      revalidateMs: 100_000, now: () => 1_000, onMutation: (e) => events.push(e),
+    });
+    await store.insert([q('did:dkg:context-graph:seed')]);
+    await expect(store.listGraphs()).resolves.toEqual(['did:dkg:context-graph:seed']);
+    expect(counting.listGraphsCalls).toBe(1);
+
+    // A server-side UPDATE that creates a new graph, with the touched graph DECLARED.
+    // Contrast with the "defers update()" test above (no touchedGraphs → a full
+    // rebuild scan on the next read); here the index stays warm with zero scans.
+    await store.update(
+      'INSERT DATA { GRAPH <did:dkg:context-graph:heal> { <urn:s> <urn:p> "v" } }',
+      { touchedGraphs: [healed] },
+    );
+
+    expect(counting.listGraphsCalls).toBe(1); // incremental hasGraph, NOT a full scan
+    await expect(store.listGraphs()).resolves.toEqual(
+      expect.arrayContaining([healed, 'did:dkg:context-graph:seed']),
+    );
+    expect(counting.listGraphsCalls).toBe(1); // still warm — no rebuild triggered
+    expect(events).toContainEqual({ type: 'graph-added', graph: healed, source: 'update' });
+  });
+
+  it('#1549: a rebuild triggered by an ack-priority read runs the full scan on the BACKGROUND lane, not ack', async () => {
+    const counting = new MutationHookStore(new OxigraphStore(), {
+      onUpdate: async ({ inner }) => { await inner.insert([q('did:dkg:context-graph:y')]); },
+    });
+    const store = new GraphSetIndexStore(counting, { revalidateMs: 100_000, now: () => 1_000 });
+    await store.insert([q('did:dkg:context-graph:x')]);
+    await store.listGraphs(); // seed (listGraphsCalls = 1)
+    expect(counting.listGraphsCalls).toBe(1);
+
+    // Opaque update (NO touchedGraphs) marks the index dirty → next read rebuilds.
+    await store.update('INSERT DATA { GRAPH <did:dkg:context-graph:y> { <urn:s> <urn:p> "v" } }');
+
+    // An ACK-priority read on the dirty index forces the rebuild. The rebuild's full
+    // SELECT DISTINCT ?g scan must NOT run on the ack lane (it would consume the
+    // scarce reserved ACK slot); it is forced onto background + tagged.
+    await store.listGraphsByPrefix('did:dkg:', { priority: 'ack', source: 'test.ack.read' });
+    expect(counting.listGraphsCalls).toBe(2);
+
+    const rebuildScan = counting.listGraphsOptions.at(-1);
+    expect(rebuildScan).toMatchObject({ priority: 'background', source: 'graph-set-index.rebuild' });
+    expect(rebuildScan?.priority).not.toBe('ack');
+  });
+
   it('removes stale graph names after a deferred SPARQL query removal', async () => {
     const graph = 'did:dkg:context-graph:old-query';
     const counting = new MutationHookStore(new OxigraphStore(), {


### PR DESCRIPTION
## Summary

Managed-Oxigraph cores saturate (Oxigraph RSS ~5.4G, CPU ~213%, SPARQL 12–30s, occasional SIGKILL) under sync/finalization pressure. This fixes the **dominant** driver: the repeated full `SELECT DISTINCT ?g WHERE { GRAPH ?g { ?s ?p ?o } }` graph scan.

**Root cause (evidence-verified):** the managed store wraps `SparqlHttpStore` in `GraphSetIndexStore`, and the inner adapter's own list-graphs cache is disabled (`managedByDkg:false`), so the index is the *sole* graph-enumeration authority. The index is meant to answer enumeration from an in-memory `Set` (O(1)), scanning only on rebuild — but **every server-side UPDATE called `scheduleFullRefresh`**, and `ensureGraphSet` then forces a full scan on the *next* read regardless of the 30s window. Under a steady UPDATE stream the index is **perpetually dirty**, so every `listGraphs`/`listGraphsByPrefix` (sync responder, finalization slice, ACK SWM read) pays a fresh 12–30s scan — frequency tracks UPDATE bursts, not reads. A 4-reader research pass + adversarial plan review established the **only two recurring server-side-UPDATE sources are RS-heal and the agents-meta prune, both writing statically-known graph URIs**.

Two fixes, both correctness-preserving (no freshness relaxation, no single-writer dependency):

- **L1 — keep the index warm at source.** New optional `QueryOptions.touchedGraphs`. When a server-side `update()`/`query(<UPDATE>)` declares the graphs it creates/drops, the index maintains itself **incrementally** via the existing `refreshTouchedGraphs` (a bounded, `hasGraph`-checked per-graph update — correctly handles an ASK-guarded INSERT that matched zero rows) instead of marking the whole index dirty. Wired the two known sources (RS-heal `[scopedData]`/`[scopedMeta]`; agents-meta prune `[metaGraph]`). Opaque updates still fall back to the lazy full rebuild → so nothing regresses for callers that can't derive their touched graphs.
- **L2 — never rebuild on the ack lane.** The rebuild's full scan previously inherited the *first* caller's `options`, so a rebuild triggered by an `ack`-priority read (the StorageACK SWM read) ran the full scan **on the reserved ACK lane**, consuming its slot. The rebuild scan is now forced onto `background` and tagged `graph-set-index.rebuild`. The triggering read still **awaits** it (forced-fresh — never a stale/empty serve; merkle-gated ACK/finalization paths stay fail-safe), it just no longer runs on the ACK lane.

## Related
- Part of #1502 (mainnet sync/ACK storm); Tier-2 Chunk 6 of the agents/_meta sync-storm plan.
- Follows the merged Tier-1 (#1526/#1533/#1534) + store-priority-scheduler (#1528).
- **Deferred fast-follows** (in the plan; intentionally out of this PR): L9 sanitized cardinality observability; L4/L5 finalization slice → background lane + cancellation + promote-cleanup `listGraphs()` fix; D2-gated serve-stale-on-responder; SWM-slice `CONSTRUCT` chunking (adversarial review found it **efficacy-negative** today — no memory reduction + (K−1)× extra scans — so it waits on telemetry).

## Files changed

| File | What |
|------|------|
| `packages/storage/src/triple-store.ts` | New optional `QueryOptions.touchedGraphs` (declared created/dropped graphs for incremental index maintenance). |
| `packages/storage/src/graph-set-index-store.ts` | `update()`/`query(<UPDATE>)` use `refreshTouchedGraphs` when `touchedGraphs` is supplied (else lazy rebuild); `refreshIndexLoop` forces the rebuild scan onto `background` + tags it (off the ack lane). |
| `packages/storage/test/graph-set-index-store.test.ts` | Two #1549 tests: `touchedGraphs` warm-index (zero scans); ack-triggered rebuild runs on background, not ack. |
| `packages/agent/src/dkg-agent-swm-host.ts` | RS-heal materialization declares its touched graphs (`[scopedData]`/`[scopedMeta]`). |
| `packages/publisher/src/agent-registry-meta-retention.ts` | agents-meta prune declares its touched graph (`[metaGraph]`). |

## Test plan
- [x] `pnpm --filter @origintrail-official/dkg-storage exec vitest run test/graph-set-index-store.test.ts` → **26/26** (incl. the two #1549 cases).
- [x] `pnpm --filter @origintrail-official/dkg-publisher exec vitest run test/agents-meta-bound.test.ts` (prune caller) → **17/17**.
- [x] `storage → publisher → agent → cli` typecheck clean.
- [ ] Canary a managed-Oxigraph core: confirm `sync.responder.listGraphs`/`sparql-http.listGraphs` slow-query (>10s) count drops sharply, **no `SELECT DISTINCT ?g` runs on the ack lane**, and Oxigraph CPU trends down under the same load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)