### PR TITLE
fix(agent): bound global sync backpressure

### DIFF
--- a/packages/agent/src/dkg-agent-apply-mixins.ts
+++ b/packages/agent/src/dkg-agent-apply-mixins.ts
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Copies own-prototype methods from each holder class onto a target class,
+ * Copies own prototype keys (including module-private symbol methods) from
+ * each holder class onto a target class,
  * implementing the mixin assembly for the DKGAgent split. Holder classes
  * define cohesive method groups (extending `DKGAgentBase` for shared `this`
  * state); `DKGAgent` merges their declarations via `interface DKGAgent extends ...`
@@ -12,7 +13,7 @@
  */
 export function applyMixins(derivedCtor: { prototype: object }, holders: Array<{ prototype: object }>): void {
   for (const holder of holders) {
-    for (const propName of Object.getOwnPropertyNames(holder.prototype)) {
+    for (const propName of Reflect.ownKeys(holder.prototype)) {
       if (propName === 'constructor') continue;
       const descriptor = Object.getOwnPropertyDescriptor(holder.prototype, propName);
       if (descriptor) {

--- a/packages/agent/src/dkg-agent-apply-mixins.ts
+++ b/packages/agent/src/dkg-agent-apply-mixins.ts
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Copies own prototype keys (including module-private symbol methods) from
- * each holder class onto a target class,
+ * Copies own-prototype methods from each holder class onto a target class,
  * implementing the mixin assembly for the DKGAgent split. Holder classes
  * define cohesive method groups (extending `DKGAgentBase` for shared `this`
  * state); `DKGAgent` merges their declarations via `interface DKGAgent extends ...`
@@ -13,7 +12,7 @@
  */
 export function applyMixins(derivedCtor: { prototype: object }, holders: Array<{ prototype: object }>): void {
   for (const holder of holders) {
-    for (const propName of Reflect.ownKeys(holder.prototype)) {
+    for (const propName of Object.getOwnPropertyNames(holder.prototype)) {
       if (propName === 'constructor') continue;
       const descriptor = Object.getOwnPropertyDescriptor(holder.prototype, propName);
       if (descriptor) {

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -211,7 +211,7 @@ import { waitForPeerProtocol } from './p2p/protocol-readiness.js';
 import { orderCatchupPeers } from './p2p/peer-selection.js';
 import { reconcileWarmCoreConnections, type WarmCoreAgent } from './p2p/warm-core-connections.js';
 import { fetchSyncPages, type SyncPageResult } from './sync/requester/page-fetch.js';
-import { insertWithOversizeGuard } from './sync/oversize-filter.js';
+import { insertWithOversizeGuard, type OversizeGuardHooks } from './sync/oversize-filter.js';
 import { runOversizeSweep } from './sync/oversize-sweep.js';
 import { getSyncCheckpointKey } from './sync/checkpoint/state.js';
 import { runDurableSync } from './sync/requester/durable-sync.js';
@@ -221,10 +221,11 @@ import { recoverContextGraphSwm, type RecoverContextGraphSwmResult } from './syn
 import { buildSyncRequestEnvelope, type SyncPhase } from './sync/auth/request-build.js';
 import { authorizePrivateSyncRequest } from './sync/auth/request-authorize.js';
 import { registerSyncHandler } from './sync/responder/sync-handler.js';
-import { getSyncOnConnectLocalBackpressureError, runSyncOnConnect, SyncOnConnectPostSyncError, type SyncOnConnectOutcome, type SyncOnConnectPeerOutcome } from './sync/on-connect/sync-on-connect.js';
+import { runSyncOnConnect, SyncOnConnectPostSyncError, type SyncOnConnectOutcome, type SyncOnConnectPeerOutcome } from './sync/on-connect/sync-on-connect.js';
 import { mapWithConcurrency, CATCHUP_MAX_CONCURRENT_PEER_SYNCS } from './sync/map-with-concurrency.js';
 import {
   getSyncBackpressureSnapshot,
+  getSyncBackpressureBusyError,
   resolveBooleanSwitch,
   resolveNonNegativeIntegerSwitch,
   resolveSyncGlobalBackpressure,
@@ -609,7 +610,23 @@ type SharedMemorySyncContextGraphPlan = {
   eligibleContextGraphIds: string[];
 };
 
-const recoverContextGraphSwmFromPeerWork = Symbol('recoverContextGraphSwmFromPeerWork');
+type RecoverContextGraphSwmOptions = Parameters<typeof recoverContextGraphSwm>[0];
+
+interface RecoverContextGraphSwmFromPeerDependencies {
+  store: TripleStore;
+  listSubGraphs: (contextGraphId: string) => ReturnType<DKGAgent['listSubGraphs']>;
+  createContextGraphSyncDeadline: (remainingContextGraphs: number) => number;
+  fetchSyncPages: RecoverContextGraphSwmOptions['fetchSyncPages'];
+  processSharedMemoryBatch: RecoverContextGraphSwmOptions['processSharedMemoryBatch'];
+  recordDrops: OversizeGuardHooks['recordDrops'];
+  invalidateListContextGraphsCache: () => void;
+  markMetaProjectionDirty: (quads: Quad[]) => void;
+  setCheckpoint: RecoverContextGraphSwmOptions['setCheckpoint'];
+  deleteCheckpoint: RecoverContextGraphSwmOptions['deleteCheckpoint'];
+  ensureOwnedMap: RecoverContextGraphSwmOptions['ensureOwnedMap'];
+  logInfo: NonNullable<RecoverContextGraphSwmOptions['logInfo']>;
+  logWarn: NonNullable<RecoverContextGraphSwmOptions['logWarn']>;
+}
 
 type SyncReconcilerAttemptOutcome = SyncOnConnectOutcome | 'not-started' | 'deferred-backpressure';
 
@@ -2790,7 +2807,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       }
       return outcome;
     } catch (err: unknown) {
-      const backpressureError = getSyncOnConnectLocalBackpressureError(err);
+      const backpressureError = getSyncBackpressureBusyError(err);
       if (backpressureError) {
         this.log.info(
           createOperationContext('sync'),
@@ -3735,6 +3752,32 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       this.log.warn(ctx, `Skipping shared-memory sync from ${remotePeerId.slice(-8)} (DKG_DURABLE_SYNC_ENABLED=0)`);
       return emptySharedMemorySyncResult();
     }
+    const recoverPrivateContextGraph = (contextGraphId: string) => runRecoverContextGraphSwmFromPeer(
+      {
+        store: this.store,
+        listSubGraphs: (id) => this.listSubGraphs(id),
+        createContextGraphSyncDeadline: (remaining) => this.createContextGraphSyncDeadline(remaining),
+        fetchSyncPages: (ctx2, peerId, cgId, includeSharedMemory, phase, graphUri, deadline) =>
+          this.fetchSyncPages(ctx2, peerId, cgId, includeSharedMemory, phase, graphUri, deadline, undefined, undefined, undefined, true),
+        processSharedMemoryBatch: (data, meta, cgId, registered, excluded) =>
+          this.getOrCreateSyncVerifyWorker().processSharedMemoryBatch(data, meta, cgId, registered, excluded),
+        recordDrops: (drops, seam) => this.oversizeTombstoneLog.record(drops, seam),
+        invalidateListContextGraphsCache: () => this.invalidateListContextGraphsCache(),
+        markMetaProjectionDirty: (quads) => this.contextGraphMetaProjection.markDirtyFromQuads(quads),
+        setCheckpoint: (key, offset) => this.syncCheckpoints.set(key, offset),
+        deleteCheckpoint: (key) => this.syncCheckpoints.delete(key),
+        ensureOwnedMap: (ownershipKey) => {
+          if (!this.workspaceOwnedEntities.has(ownershipKey)) {
+            this.workspaceOwnedEntities.set(ownershipKey, new Map());
+          }
+          return this.workspaceOwnedEntities.get(ownershipKey)!;
+        },
+        logInfo: (opCtx, message) => this.log.info(opCtx, message),
+        logWarn: (opCtx, message) => this.log.warn(opCtx, message),
+      },
+      remotePeerId,
+      contextGraphId,
+    );
     const planned = options?.sharedMemorySyncPlan;
     const plan = planned && sameStringArray(planned.eligibleContextGraphIds, contextGraphIds)
       ? planned
@@ -3821,7 +3864,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       // gated above to be the curator and not self). Reuses the all-or-nothing recovery.
       for (const contextGraphId of privateRecoverFromCurator) {
         try {
-          const r = await this[recoverContextGraphSwmFromPeerWork](remotePeerId, contextGraphId);
+          const r = await recoverPrivateContextGraph(contextGraphId);
           summary.insertedDataTriples += r.insertedDataQuads;
           summary.insertedMetaTriples += r.insertedMetaQuads;
           summary.insertedTriples += r.insertedDataQuads + r.insertedMetaQuads;
@@ -3883,133 +3926,6 @@ export class LifecycleSyncMethods extends DKGAgentBase {
    * detects a full / cross-epoch gap; isolated from `runSharedMemorySync` so the
    * incremental path is untouched.
    */
-  async [recoverContextGraphSwmFromPeerWork](this: DKGAgent,
-    remotePeerId: string,
-    contextGraphId: string,
-  ): Promise<RecoverContextGraphSwmResult> {
-    const ctx = createOperationContext('sync');
-    const admission = await getSharedMemorySubGraphAdmission(
-      this.store, contextGraphId, this.listSubGraphs(contextGraphId),
-    );
-    return recoverContextGraphSwm({
-        ctx,
-        remotePeerId,
-        contextGraphId,
-        deadline: this.createContextGraphSyncDeadline(1),
-      // R9/R10 — pin recovery=true at the lifecycle boundary so swm-recovery's
-      // deps signature stays unchanged. This forks BOTH the checkpoint namespace
-      // (R10: a distinct `|recovery` cursor that never mutates the shared
-      // incremental-sync cursor) AND the request envelope auth mode (R9: the
-      // responder gates via the strict members-only `isMemberRecoveryAuthorized`).
-        fetchSyncPages: (ctx2, remotePeerId2, contextGraphId2, includeSharedMemory2, phase2, graphUri2, deadline2) =>
-          this.fetchSyncPages(ctx2, remotePeerId2, contextGraphId2, includeSharedMemory2, phase2, graphUri2, deadline2, undefined, undefined, undefined, true),
-        processSharedMemoryBatch: (wsDataQuads, wsMetaQuads, cgId, registered, excluded) =>
-          this.getOrCreateSyncVerifyWorker().processSharedMemoryBatch(wsDataQuads, wsMetaQuads, cgId, registered, excluded),
-      // SwmRecoveryStore: invalidate the list cache + mark the meta projection
-      // dirty on insert (parity with runSharedMemorySync's
-      // insertSyncedQuadsAndInvalidateListCache); deletes pass through to the store.
-      store: {
-        insert: async (quads) => {
-          // Oversize guard (OT-RFC-56) — recovered rows are peer data too.
-          const inserted = await insertWithOversizeGuard(
-            (kept) => this.store.insert(kept, {
-              priority: 'background',
-              source: 'agent.swmRecovery.insert',
-            }),
-            quads,
-            { recordDrops: (drops, seam) => this.oversizeTombstoneLog.record(drops, seam) },
-            'swm-recovery',
-          );
-          if (inserted.length > 0) {
-            this.invalidateListContextGraphsCache();
-            this.contextGraphMetaProjection.markDirtyFromQuads(inserted);
-          }
-        },
-        deleteByPattern: (pattern) => this.store.deleteByPattern(pattern, {
-          priority: 'background',
-          source: 'agent.swmRecovery.deleteByPattern',
-        }),
-        deleteBySubjectPrefix: (graph, prefix) => this.store.deleteBySubjectPrefix(graph, prefix, {
-          priority: 'background',
-          source: 'agent.swmRecovery.deleteBySubjectPrefix',
-        }),
-      },
-      // Codex high: REPLACE per-root SWM meta (mirror the publisher's
-      // deleteMetaForRoot). For each recovered root, drop the op→root-entity
-      // links in the curator's fresh-meta graphs, then delete any op left with
-      // no remaining roots — so a stale WorkspaceOperation can't survive to
-      // TTL-delete the just-recovered root. Runs before swm-recovery inserts the
-      // fresh verifiedMeta. Falls back to the base meta graph if none provided.
-      replaceMetaForRoots: async (roots, metaGraphs) => {
-        const graphs = metaGraphs.length > 0
-          ? metaGraphs
-          : [contextGraphWorkspaceMetaGraphUri(contextGraphId)];
-        const entities = [...new Set(roots.map((r) => r.entity))];
-        for (const metaGraph of graphs) {
-          for (const entity of entities) {
-            const ops = await this.store.query(
-              `SELECT DISTINCT ?op WHERE { GRAPH <${metaGraph}> { ?op ${ENTITY_PRED_ALT} <${entity}> } }`,
-              {
-                priority: 'background',
-                source: 'agent.swmRecovery.replaceMetaForRoots.findOps',
-              },
-            );
-            if (ops.type !== 'bindings') continue;
-            for (const row of ops.bindings) {
-              const op = row['op'];
-              if (!op) continue;
-              await this.store.delete(
-                [
-                  { subject: op, predicate: DKG_ROOT_ENTITY_LEGACY, object: entity, graph: metaGraph },
-                  { subject: op, predicate: DKG_ENTITY, object: entity, graph: metaGraph },
-                ],
-                {
-                  priority: 'background',
-                  source: 'agent.swmRecovery.replaceMetaForRoots.deleteLinks',
-                },
-              );
-              const remaining = await this.store.query(
-                `SELECT (COUNT(DISTINCT ?r) AS ?c) WHERE { GRAPH <${metaGraph}> { <${op}> ${ENTITY_PRED_ALT} ?r } }`,
-                {
-                  priority: 'background',
-                  source: 'agent.swmRecovery.replaceMetaForRoots.countRoots',
-                },
-              );
-              const raw = remaining.type === 'bindings' ? remaining.bindings[0]?.['c'] : undefined;
-              const countVal = raw ? parseInt(String(raw).match(/\d+/)?.[0] ?? '0', 10) : 0;
-              if (countVal === 0) {
-                await this.store.deleteByPattern(
-                  { graph: metaGraph, subject: op },
-                  {
-                    priority: 'background',
-                    source: 'agent.swmRecovery.replaceMetaForRoots.deleteOp',
-                  },
-                );
-              }
-            }
-          }
-        }
-      },
-      ensureContextGraph: async (cgId) => {
-        const graphManager = new GraphManager(this.store);
-        await graphManager.ensureContextGraph(cgId);
-      },
-      setCheckpoint: (key, offset) => this.syncCheckpoints.set(key, offset),
-      deleteCheckpoint: (key) => this.syncCheckpoints.delete(key),
-      getRegisteredSubGraphNames: async () => admission.registered,
-      getExcludedSubGraphNames: async () => admission.excluded,
-      // R2 — hydrate the Rule-4 ownership cache (same map runSharedMemorySync uses).
-      ensureOwnedMap: (ownershipKey) => {
-        if (!this.workspaceOwnedEntities.has(ownershipKey)) {
-          this.workspaceOwnedEntities.set(ownershipKey, new Map());
-        }
-        return this.workspaceOwnedEntities.get(ownershipKey)!;
-      },
-        logInfo: (opCtx, message) => this.log.info(opCtx, message),
-        logWarn: (opCtx, message) => this.log.warn(opCtx, message),
-      });
-  }
-
   async recoverContextGraphSwmFromPeer(this: DKGAgent,
     remotePeerId: string,
     contextGraphId: string,
@@ -4026,7 +3942,32 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         label: `swm-recovery:${remotePeerId.slice(-8)}`,
         logInfo: (opCtx, message) => this.log.info(opCtx, message),
       },
-      () => this[recoverContextGraphSwmFromPeerWork](remotePeerId, contextGraphId),
+      () => runRecoverContextGraphSwmFromPeer(
+        {
+          store: this.store,
+          listSubGraphs: (id) => this.listSubGraphs(id),
+          createContextGraphSyncDeadline: (remaining) => this.createContextGraphSyncDeadline(remaining),
+          fetchSyncPages: (ctx2, peerId, cgId, includeSharedMemory, phase, graphUri, deadline) =>
+            this.fetchSyncPages(ctx2, peerId, cgId, includeSharedMemory, phase, graphUri, deadline, undefined, undefined, undefined, true),
+          processSharedMemoryBatch: (data, meta, cgId, registered, excluded) =>
+            this.getOrCreateSyncVerifyWorker().processSharedMemoryBatch(data, meta, cgId, registered, excluded),
+          recordDrops: (drops, seam) => this.oversizeTombstoneLog.record(drops, seam),
+          invalidateListContextGraphsCache: () => this.invalidateListContextGraphsCache(),
+          markMetaProjectionDirty: (quads) => this.contextGraphMetaProjection.markDirtyFromQuads(quads),
+          setCheckpoint: (key, offset) => this.syncCheckpoints.set(key, offset),
+          deleteCheckpoint: (key) => this.syncCheckpoints.delete(key),
+          ensureOwnedMap: (ownershipKey) => {
+            if (!this.workspaceOwnedEntities.has(ownershipKey)) {
+              this.workspaceOwnedEntities.set(ownershipKey, new Map());
+            }
+            return this.workspaceOwnedEntities.get(ownershipKey)!;
+          },
+          logInfo: (opCtx, message) => this.log.info(opCtx, message),
+          logWarn: (opCtx, message) => this.log.warn(opCtx, message),
+        },
+        remotePeerId,
+        contextGraphId,
+      ),
     );
   }
 
@@ -5540,6 +5481,127 @@ async function listGraphsByPrefix(store: TripleStore, prefix: string): Promise<s
   return store.listGraphsByPrefix
     ? store.listGraphsByPrefix(prefix)
     : (await store.listGraphs()).filter((graph) => graph.startsWith(prefix));
+}
+
+async function runRecoverContextGraphSwmFromPeer(
+  dependencies: RecoverContextGraphSwmFromPeerDependencies,
+  remotePeerId: string,
+  contextGraphId: string,
+): Promise<RecoverContextGraphSwmResult> {
+  const ctx = createOperationContext('sync');
+  const admission = await getSharedMemorySubGraphAdmission(
+    dependencies.store, contextGraphId, dependencies.listSubGraphs(contextGraphId),
+  );
+  return recoverContextGraphSwm({
+    ctx,
+    remotePeerId,
+    contextGraphId,
+    deadline: dependencies.createContextGraphSyncDeadline(1),
+    // R9/R10 — pin recovery=true at the lifecycle boundary so swm-recovery's
+    // deps signature stays unchanged. This forks BOTH the checkpoint namespace
+    // (R10: a distinct `|recovery` cursor that never mutates the shared
+    // incremental-sync cursor) AND the request envelope auth mode (R9: the
+    // responder gates via the strict members-only `isMemberRecoveryAuthorized`).
+    fetchSyncPages: dependencies.fetchSyncPages,
+    processSharedMemoryBatch: dependencies.processSharedMemoryBatch,
+    // SwmRecoveryStore: invalidate the list cache + mark the meta projection
+    // dirty on insert (parity with runSharedMemorySync's
+    // insertSyncedQuadsAndInvalidateListCache); deletes pass through to the store.
+    store: {
+      insert: async (quads) => {
+        // Oversize guard (OT-RFC-56) — recovered rows are peer data too.
+        const inserted = await insertWithOversizeGuard(
+          (kept) => dependencies.store.insert(kept, {
+            priority: 'background',
+            source: 'agent.swmRecovery.insert',
+          }),
+          quads,
+          { recordDrops: (drops, seam) => dependencies.recordDrops(drops, seam) },
+          'swm-recovery',
+        );
+        if (inserted.length > 0) {
+          dependencies.invalidateListContextGraphsCache();
+          dependencies.markMetaProjectionDirty(inserted);
+        }
+      },
+      deleteByPattern: (pattern) => dependencies.store.deleteByPattern(pattern, {
+        priority: 'background',
+        source: 'agent.swmRecovery.deleteByPattern',
+      }),
+      deleteBySubjectPrefix: (graph, prefix) => dependencies.store.deleteBySubjectPrefix(graph, prefix, {
+        priority: 'background',
+        source: 'agent.swmRecovery.deleteBySubjectPrefix',
+      }),
+    },
+    // Codex high: REPLACE per-root SWM meta (mirror the publisher's
+    // deleteMetaForRoot). For each recovered root, drop the op→root-entity
+    // links in the curator's fresh-meta graphs, then delete any op left with
+    // no remaining roots — so a stale WorkspaceOperation can't survive to
+    // TTL-delete the just-recovered root. Runs before swm-recovery inserts the
+    // fresh verifiedMeta. Falls back to the base meta graph if none provided.
+    replaceMetaForRoots: async (roots, metaGraphs) => {
+      const graphs = metaGraphs.length > 0
+        ? metaGraphs
+        : [contextGraphWorkspaceMetaGraphUri(contextGraphId)];
+      const entities = [...new Set(roots.map((r) => r.entity))];
+      for (const metaGraph of graphs) {
+        for (const entity of entities) {
+          const ops = await dependencies.store.query(
+            `SELECT DISTINCT ?op WHERE { GRAPH <${metaGraph}> { ?op ${ENTITY_PRED_ALT} <${entity}> } }`,
+            {
+              priority: 'background',
+              source: 'agent.swmRecovery.replaceMetaForRoots.findOps',
+            },
+          );
+          if (ops.type !== 'bindings') continue;
+          for (const row of ops.bindings) {
+            const op = row['op'];
+            if (!op) continue;
+            await dependencies.store.delete(
+              [
+                { subject: op, predicate: DKG_ROOT_ENTITY_LEGACY, object: entity, graph: metaGraph },
+                { subject: op, predicate: DKG_ENTITY, object: entity, graph: metaGraph },
+              ],
+              {
+                priority: 'background',
+                source: 'agent.swmRecovery.replaceMetaForRoots.deleteLinks',
+              },
+            );
+            const remaining = await dependencies.store.query(
+              `SELECT (COUNT(DISTINCT ?r) AS ?c) WHERE { GRAPH <${metaGraph}> { <${op}> ${ENTITY_PRED_ALT} ?r } }`,
+              {
+                priority: 'background',
+                source: 'agent.swmRecovery.replaceMetaForRoots.countRoots',
+              },
+            );
+            const raw = remaining.type === 'bindings' ? remaining.bindings[0]?.['c'] : undefined;
+            const countVal = raw ? parseInt(String(raw).match(/\d+/)?.[0] ?? '0', 10) : 0;
+            if (countVal === 0) {
+              await dependencies.store.deleteByPattern(
+                { graph: metaGraph, subject: op },
+                {
+                  priority: 'background',
+                  source: 'agent.swmRecovery.replaceMetaForRoots.deleteOp',
+                },
+              );
+            }
+          }
+        }
+      }
+    },
+    ensureContextGraph: async (cgId) => {
+      const graphManager = new GraphManager(dependencies.store);
+      await graphManager.ensureContextGraph(cgId);
+    },
+    setCheckpoint: (key, offset) => dependencies.setCheckpoint(key, offset),
+    deleteCheckpoint: (key) => dependencies.deleteCheckpoint(key),
+    getRegisteredSubGraphNames: async () => admission.registered,
+    getExcludedSubGraphNames: async () => admission.excluded,
+    // R2 — hydrate the Rule-4 ownership cache (same map runSharedMemorySync uses).
+    ensureOwnedMap: dependencies.ensureOwnedMap,
+    logInfo: (opCtx, message) => dependencies.logInfo(opCtx, message),
+    logWarn: (opCtx, message) => dependencies.logWarn(opCtx, message),
+  });
 }
 
 async function getSharedMemorySubGraphAdmission(

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -221,14 +221,13 @@ import { recoverContextGraphSwm, type RecoverContextGraphSwmResult } from './syn
 import { buildSyncRequestEnvelope, type SyncPhase } from './sync/auth/request-build.js';
 import { authorizePrivateSyncRequest } from './sync/auth/request-authorize.js';
 import { registerSyncHandler } from './sync/responder/sync-handler.js';
-import { runSyncOnConnect, SyncOnConnectPostSyncError, type SyncOnConnectOutcome, type SyncOnConnectPeerOutcome } from './sync/on-connect/sync-on-connect.js';
+import { getSyncOnConnectLocalBackpressureError, runSyncOnConnect, SyncOnConnectPostSyncError, type SyncOnConnectOutcome, type SyncOnConnectPeerOutcome } from './sync/on-connect/sync-on-connect.js';
 import { mapWithConcurrency, CATCHUP_MAX_CONCURRENT_PEER_SYNCS } from './sync/map-with-concurrency.js';
 import {
   getSyncBackpressureSnapshot,
   resolveBooleanSwitch,
   resolveNonNegativeIntegerSwitch,
   resolveSyncGlobalBackpressure,
-  SyncBackpressureBusyError,
   withGlobalSyncBackpressure,
 } from './sync/backpressure.js';
 import {
@@ -610,6 +609,8 @@ type SharedMemorySyncContextGraphPlan = {
   eligibleContextGraphIds: string[];
 };
 
+const recoverContextGraphSwmFromPeerWork = Symbol('recoverContextGraphSwmFromPeerWork');
+
 type SyncReconcilerAttemptOutcome = SyncOnConnectOutcome | 'not-started' | 'deferred-backpressure';
 
 function sameStringArray(a: readonly string[], b: readonly string[]): boolean {
@@ -626,14 +627,6 @@ function syncOnConnectEnabled(config: DKGAgentConfig): boolean {
 
 function durableSyncEnabled(config: DKGAgentConfig): boolean {
   return resolveBooleanSwitch(config.durableSyncEnabled, 'DKG_DURABLE_SYNC_ENABLED', true);
-}
-
-function asSyncBackpressureBusyError(err: unknown): SyncBackpressureBusyError | undefined {
-  if (err instanceof SyncBackpressureBusyError) return err;
-  if (err instanceof SyncOnConnectPostSyncError && err.originalError instanceof SyncBackpressureBusyError) {
-    return err.originalError;
-  }
-  return undefined;
 }
 
 function emptyDurableSyncResult(): DurableSyncResult {
@@ -2797,7 +2790,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       }
       return outcome;
     } catch (err: unknown) {
-      const backpressureError = asSyncBackpressureBusyError(err);
+      const backpressureError = getSyncOnConnectLocalBackpressureError(err);
       if (backpressureError) {
         this.log.info(
           createOperationContext('sync'),
@@ -3774,14 +3767,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
             resumedPhases: 0, timedOutPhases: 0, completedPhases: 0, checkpointAdvances: 0,
             emptyResponses: 0, droppedDataTriples: 0, failedPeers: 0, failedPhases: 0, deniedPhases: 0,
           }
-        : await withGlobalSyncBackpressure(
-            {
-              policy: resolveSyncGlobalBackpressure(this.config),
-              ctx,
-              label: `shared-memory:${remotePeerId.slice(-8)}`,
-              logInfo: (opCtx, message) => this.log.info(opCtx, message),
-            },
-            () => runSharedMemorySync({
+        : await runSharedMemorySync({
               ctx,
               remotePeerId,
               contextGraphIds: publicContextGraphIds,
@@ -3829,14 +3815,13 @@ export class LifecycleSyncMethods extends DKGAgentBase {
               logInfo: (opCtx, message) => this.log.info(opCtx, message),
               logWarn: (opCtx, message) => this.log.warn(opCtx, message),
               logDebug: (opCtx, message) => this.log.debug(opCtx, message),
-            }),
-          );
+            });
 
       // PRIVATE CGs: REPLACE-recover the current state from the curator (= remotePeerId,
       // gated above to be the curator and not self). Reuses the all-or-nothing recovery.
       for (const contextGraphId of privateRecoverFromCurator) {
         try {
-          const r = await this.recoverContextGraphSwmFromPeer(remotePeerId, contextGraphId);
+          const r = await this[recoverContextGraphSwmFromPeerWork](remotePeerId, contextGraphId);
           summary.insertedDataTriples += r.insertedDataQuads;
           summary.insertedMetaTriples += r.insertedMetaQuads;
           summary.insertedTriples += r.insertedDataQuads + r.insertedMetaQuads;
@@ -3862,7 +3847,6 @@ export class LifecycleSyncMethods extends DKGAgentBase {
             }
           }
         } catch (err) {
-          if (err instanceof SyncBackpressureBusyError) throw err;
           this.log.warn(ctx, `Curator-recovery for private CG "${contextGraphId}" from ${remotePeerId} failed: ${err instanceof Error ? err.message : String(err)}`);
           summary.failedPeers += 1;
           summary.backoffWorthyFailures = (summary.backoffWorthyFailures ?? 0) + 1;
@@ -3876,7 +3860,19 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       return summary;
     };
 
-    return runSyncSingleFlight(this, singleFlightKey, runSync);
+    return runSyncSingleFlight(
+      this,
+      singleFlightKey,
+      () => withGlobalSyncBackpressure(
+        {
+          policy: resolveSyncGlobalBackpressure(this.config),
+          ctx,
+          label: `shared-memory:${remotePeerId.slice(-8)}`,
+          logInfo: (opCtx, message) => this.log.info(opCtx, message),
+        },
+        runSync,
+      ),
+    );
   }
 
   /**
@@ -3887,26 +3883,15 @@ export class LifecycleSyncMethods extends DKGAgentBase {
    * detects a full / cross-epoch gap; isolated from `runSharedMemorySync` so the
    * incremental path is untouched.
    */
-  async recoverContextGraphSwmFromPeer(this: DKGAgent,
+  async [recoverContextGraphSwmFromPeerWork](this: DKGAgent,
     remotePeerId: string,
     contextGraphId: string,
   ): Promise<RecoverContextGraphSwmResult> {
     const ctx = createOperationContext('sync');
-    if (!durableSyncEnabled(this.config)) {
-      this.log.warn(ctx, `Skipping SWM recovery from ${remotePeerId.slice(-8)} (DKG_DURABLE_SYNC_ENABLED=0)`);
-      return emptySwmRecoveryResult();
-    }
     const admission = await getSharedMemorySubGraphAdmission(
       this.store, contextGraphId, this.listSubGraphs(contextGraphId),
     );
-    return withGlobalSyncBackpressure(
-      {
-        policy: resolveSyncGlobalBackpressure(this.config),
-        ctx,
-        label: `swm-recovery:${remotePeerId.slice(-8)}`,
-        logInfo: (opCtx, message) => this.log.info(opCtx, message),
-      },
-      () => recoverContextGraphSwm({
+    return recoverContextGraphSwm({
         ctx,
         remotePeerId,
         contextGraphId,
@@ -4022,7 +4007,26 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       },
         logInfo: (opCtx, message) => this.log.info(opCtx, message),
         logWarn: (opCtx, message) => this.log.warn(opCtx, message),
-      }),
+      });
+  }
+
+  async recoverContextGraphSwmFromPeer(this: DKGAgent,
+    remotePeerId: string,
+    contextGraphId: string,
+  ): Promise<RecoverContextGraphSwmResult> {
+    const ctx = createOperationContext('sync');
+    if (!durableSyncEnabled(this.config)) {
+      this.log.warn(ctx, `Skipping SWM recovery from ${remotePeerId.slice(-8)} (DKG_DURABLE_SYNC_ENABLED=0)`);
+      return emptySwmRecoveryResult();
+    }
+    return withGlobalSyncBackpressure(
+      {
+        policy: resolveSyncGlobalBackpressure(this.config),
+        ctx,
+        label: `swm-recovery:${remotePeerId.slice(-8)}`,
+        logInfo: (opCtx, message) => this.log.info(opCtx, message),
+      },
+      () => this[recoverContextGraphSwmFromPeerWork](remotePeerId, contextGraphId),
     );
   }
 

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -227,8 +227,8 @@ import {
   getSyncBackpressureSnapshot,
   resolveBooleanSwitch,
   resolveNonNegativeIntegerSwitch,
-  resolveSyncGlobalMaxInflight,
-  resolveSyncGlobalQueueLimit,
+  resolveSyncGlobalBackpressure,
+  SyncBackpressureBusyError,
   withGlobalSyncBackpressure,
 } from './sync/backpressure.js';
 import {
@@ -610,6 +610,8 @@ type SharedMemorySyncContextGraphPlan = {
   eligibleContextGraphIds: string[];
 };
 
+type SyncReconcilerAttemptOutcome = SyncOnConnectOutcome | 'not-started' | 'deferred-backpressure';
+
 function sameStringArray(a: readonly string[], b: readonly string[]): boolean {
   return a.length === b.length && a.every((value, index) => value === b[index]);
 }
@@ -626,12 +628,12 @@ function durableSyncEnabled(config: DKGAgentConfig): boolean {
   return resolveBooleanSwitch(config.durableSyncEnabled, 'DKG_DURABLE_SYNC_ENABLED', true);
 }
 
-function syncGlobalLimit(config: DKGAgentConfig): number | undefined {
-  return resolveSyncGlobalMaxInflight(config.syncGlobalMaxInflight, config.syncGlobalLimit);
-}
-
-function syncGlobalQueueLimit(config: DKGAgentConfig): number | undefined {
-  return resolveSyncGlobalQueueLimit(config.syncGlobalQueueLimit, syncGlobalLimit(config));
+function asSyncBackpressureBusyError(err: unknown): SyncBackpressureBusyError | undefined {
+  if (err instanceof SyncBackpressureBusyError) return err;
+  if (err instanceof SyncOnConnectPostSyncError && err.originalError instanceof SyncBackpressureBusyError) {
+    return err.originalError;
+  }
+  return undefined;
 }
 
 function emptyDurableSyncResult(): DurableSyncResult {
@@ -1457,11 +1459,12 @@ export class LifecycleSyncMethods extends DKGAgentBase {
                 );
               },
               onDecline: (details) => {
-                const syncPressure = getSyncBackpressureSnapshot(syncGlobalLimit(this.config));
+                const syncPressure = getSyncBackpressureSnapshot(resolveSyncGlobalBackpressure(this.config));
                 const syncPressureLabel =
                   `syncGlobalInflight=${syncPressure.inflight} ` +
                   `syncGlobalQueued=${syncPressure.queued} ` +
-                  `syncGlobalLimit=${syncPressure.limit ?? 'unbounded'}`;
+                  `syncGlobalLimit=${syncPressure.limit ?? 'unbounded'} ` +
+                  `syncGlobalQueueLimit=${syncPressure.queueLimit ?? 'unbounded'}`;
                 this.log.warn(
                   attemptCtx,
                   `V10 StorageACK declined: code=${details.code} ` +
@@ -2774,7 +2777,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     this: DKGAgent,
     remotePeer: string,
     probe: SyncReconcilerProbe,
-  ): Promise<SyncOnConnectOutcome | 'not-started'> {
+  ): Promise<SyncReconcilerAttemptOutcome> {
     const lastOk = this.lastSuccessfulSyncAt.get(remotePeer);
     const lastProgress = this.lastSyncProgressAt.get(remotePeer);
     let syncAccountingClearedBackoff = false;
@@ -2794,6 +2797,14 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       }
       return outcome;
     } catch (err: unknown) {
+      const backpressureError = asSyncBackpressureBusyError(err);
+      if (backpressureError) {
+        this.log.info(
+          createOperationContext('sync'),
+          `Deferring sync from peer ${remotePeer.slice(-8)} due to local backpressure: ${backpressureError.message}`,
+        );
+        return 'deferred-backpressure';
+      }
       if (err instanceof SyncOnConnectPostSyncError) {
         if (err.backoffEligible) {
           this.recordSyncReconcilerFailure(remotePeer, probe);
@@ -3475,8 +3486,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     const stopOnBackoffWorthyFailure = options?.stopOnBackoffWorthyFailure;
     const runSync = () => withGlobalSyncBackpressure(
       {
-        limit: syncGlobalLimit(this.config),
-        queueLimit: syncGlobalQueueLimit(this.config),
+        policy: resolveSyncGlobalBackpressure(this.config),
         ctx,
         label: `durable:${remotePeerId.slice(-8)}`,
         logInfo: (opCtx, message) => this.log.info(opCtx, message),
@@ -3766,8 +3776,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           }
         : await withGlobalSyncBackpressure(
             {
-              limit: syncGlobalLimit(this.config),
-              queueLimit: syncGlobalQueueLimit(this.config),
+              policy: resolveSyncGlobalBackpressure(this.config),
               ctx,
               label: `shared-memory:${remotePeerId.slice(-8)}`,
               logInfo: (opCtx, message) => this.log.info(opCtx, message),
@@ -3853,6 +3862,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
             }
           }
         } catch (err) {
+          if (err instanceof SyncBackpressureBusyError) throw err;
           this.log.warn(ctx, `Curator-recovery for private CG "${contextGraphId}" from ${remotePeerId} failed: ${err instanceof Error ? err.message : String(err)}`);
           summary.failedPeers += 1;
           summary.backoffWorthyFailures = (summary.backoffWorthyFailures ?? 0) + 1;
@@ -3891,8 +3901,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     );
     return withGlobalSyncBackpressure(
       {
-        limit: syncGlobalLimit(this.config),
-        queueLimit: syncGlobalQueueLimit(this.config),
+        policy: resolveSyncGlobalBackpressure(this.config),
         ctx,
         label: `swm-recovery:${remotePeerId.slice(-8)}`,
         logInfo: (opCtx, message) => this.log.info(opCtx, message),

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -228,6 +228,7 @@ import {
   resolveBooleanSwitch,
   resolveNonNegativeIntegerSwitch,
   resolveSyncGlobalMaxInflight,
+  resolveSyncGlobalQueueLimit,
   withGlobalSyncBackpressure,
 } from './sync/backpressure.js';
 import {
@@ -626,7 +627,11 @@ function durableSyncEnabled(config: DKGAgentConfig): boolean {
 }
 
 function syncGlobalLimit(config: DKGAgentConfig): number | undefined {
-  return resolveSyncGlobalMaxInflight(config.syncGlobalMaxInflight);
+  return resolveSyncGlobalMaxInflight(config.syncGlobalMaxInflight, config.syncGlobalLimit);
+}
+
+function syncGlobalQueueLimit(config: DKGAgentConfig): number | undefined {
+  return resolveSyncGlobalQueueLimit(config.syncGlobalQueueLimit, syncGlobalLimit(config));
 }
 
 function emptyDurableSyncResult(): DurableSyncResult {
@@ -3471,6 +3476,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     const runSync = () => withGlobalSyncBackpressure(
       {
         limit: syncGlobalLimit(this.config),
+        queueLimit: syncGlobalQueueLimit(this.config),
         ctx,
         label: `durable:${remotePeerId.slice(-8)}`,
         logInfo: (opCtx, message) => this.log.info(opCtx, message),
@@ -3761,6 +3767,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         : await withGlobalSyncBackpressure(
             {
               limit: syncGlobalLimit(this.config),
+              queueLimit: syncGlobalQueueLimit(this.config),
               ctx,
               label: `shared-memory:${remotePeerId.slice(-8)}`,
               logInfo: (opCtx, message) => this.log.info(opCtx, message),
@@ -3885,6 +3892,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     return withGlobalSyncBackpressure(
       {
         limit: syncGlobalLimit(this.config),
+        queueLimit: syncGlobalQueueLimit(this.config),
         ctx,
         label: `swm-recovery:${remotePeerId.slice(-8)}`,
         logInfo: (opCtx, message) => this.log.info(opCtx, message),

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -938,8 +938,15 @@ export interface DKGAgentConfig {
   syncOnConnectEnabled?: boolean;
   /** Emergency switch for durable/SWM sync execution. Env DKG_DURABLE_SYNC_ENABLED wins. */
   durableSyncEnabled?: boolean;
-  /** Global cap for concurrent sync jobs. Env DKG_SYNC_GLOBAL_MAX_INFLIGHT wins. */
+  /**
+   * Global cap for concurrent sync jobs. Defaults to 2; set 0 to disable.
+   * Env DKG_SYNC_GLOBAL_MAX_INFLIGHT wins.
+   */
   syncGlobalMaxInflight?: number;
+  /** Backwards-compatible alias for syncGlobalMaxInflight. Env DKG_SYNC_GLOBAL_LIMIT wins. */
+  syncGlobalLimit?: number;
+  /** Max sync jobs waiting behind the global cap. Defaults to 2x the inflight cap. */
+  syncGlobalQueueLimit?: number;
   /** StorageACK handler deadline override in milliseconds. Env DKG_STORAGE_ACK_HANDLER_DEADLINE_MS wins. */
   storageAckHandlerDeadlineMs?: number;
   /**

--- a/packages/agent/src/sync/backpressure.ts
+++ b/packages/agent/src/sync/backpressure.ts
@@ -13,10 +13,12 @@ export interface SyncGlobalBackpressureConfig {
   syncGlobalQueueLimit?: number;
 }
 
-export interface SyncGlobalBackpressurePolicy {
-  limit: number | undefined;
-  queueLimit: number | undefined;
-}
+declare const syncGlobalBackpressurePolicyBrand: unique symbol;
+
+export type SyncGlobalBackpressurePolicy = Readonly<(
+  | { limit: number; queueLimit: number }
+  | { limit: undefined; queueLimit: undefined }
+) & { [syncGlobalBackpressurePolicyBrand]: true }>;
 
 type Release = () => void;
 
@@ -71,7 +73,7 @@ function acquire(
 ): SyncBackpressureAdmission {
   const { limit } = policy;
   const queuedBefore = queue.length;
-  if (typeof limit !== 'number' || !Number.isInteger(limit) || limit <= 0) {
+  if (limit === undefined) {
     lastLimit = null;
     lastQueueLimit = null;
     return {
@@ -93,7 +95,7 @@ function acquire(
       release: Promise.resolve(releaseOnce),
     };
   }
-  if (typeof queueLimit === 'number' && queuedBefore >= queueLimit) {
+  if (queuedBefore >= queueLimit) {
     throw new SyncBackpressureBusyError(
       `Sync backpressure rejected ${label} `
         + `(global inflight=${inflight}/${limit}, queued=${queuedBefore}/${queueLimit})`,
@@ -165,13 +167,20 @@ export function resolveSyncGlobalBackpressure(
     ?? nonNegativeInteger(config.syncGlobalMaxInflight)
     ?? nonNegativeInteger(config.syncGlobalLimit)
     ?? DEFAULT_SYNC_GLOBAL_MAX_INFLIGHT;
-  if (limit === 0) return { limit: undefined, queueLimit: undefined };
+  if (limit === 0) {
+    return Object.freeze({
+      limit: undefined,
+      queueLimit: undefined,
+    }) as SyncGlobalBackpressurePolicy;
+  }
 
-  const queueLimit = resolveNonNegativeIntegerSwitch(
-    config.syncGlobalQueueLimit,
-    'DKG_SYNC_GLOBAL_QUEUE_LIMIT',
-  ) ?? limit * DEFAULT_SYNC_GLOBAL_QUEUE_LIMIT_MULTIPLIER;
-  return { limit, queueLimit };
+  const queueLimit = nonNegativeInteger(parseIntegerEnv('DKG_SYNC_GLOBAL_QUEUE_LIMIT'))
+    ?? nonNegativeInteger(config.syncGlobalQueueLimit)
+    ?? limit * DEFAULT_SYNC_GLOBAL_QUEUE_LIMIT_MULTIPLIER;
+  return Object.freeze({
+    limit,
+    queueLimit,
+  }) as SyncGlobalBackpressurePolicy;
 }
 
 export function getSyncBackpressureSnapshot(
@@ -205,20 +214,20 @@ export async function withGlobalSyncBackpressure<T>(
     throw error;
   }
 
-  if (typeof limit === 'number' && admission.status === 'queued') {
+  if (limit !== undefined && admission.status === 'queued') {
     options.logInfo?.(
       options.ctx,
       `Sync backpressure queued ${options.label} `
-        + `(global inflight=${inflight}/${limit}, queued=${admission.queuedBefore}${typeof queueLimit === 'number' ? `/${queueLimit}` : ''})`,
+        + `(global inflight=${inflight}/${limit}, queued=${admission.queuedBefore}/${queueLimit})`,
     );
   }
   const release = await admission.release;
   try {
-    if (typeof limit === 'number') {
+    if (limit !== undefined) {
       options.logInfo?.(
         options.ctx,
         `Sync backpressure running ${options.label} `
-          + `(global inflight=${inflight}/${limit}, queued=${queue.length}${typeof queueLimit === 'number' ? `/${queueLimit}` : ''})`,
+          + `(global inflight=${inflight}/${limit}, queued=${queue.length}/${queueLimit})`,
       );
     }
     return await work();

--- a/packages/agent/src/sync/backpressure.ts
+++ b/packages/agent/src/sync/backpressure.ts
@@ -4,6 +4,7 @@ export interface SyncBackpressureSnapshot {
   inflight: number;
   queued: number;
   limit: number | null;
+  queueLimit: number | null;
 }
 
 type Release = () => void;
@@ -16,6 +17,17 @@ interface QueueEntry {
 const queue: QueueEntry[] = [];
 let inflight = 0;
 let lastLimit: number | null = null;
+let lastQueueLimit: number | null = null;
+
+export const DEFAULT_SYNC_GLOBAL_MAX_INFLIGHT = 2;
+export const DEFAULT_SYNC_GLOBAL_QUEUE_LIMIT_MULTIPLIER = 2;
+
+export class SyncBackpressureBusyError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SyncBackpressureBusyError';
+  }
+}
 
 function drain(): void {
   for (;;) {
@@ -36,12 +48,18 @@ function releaseOnce(): void {
   drain();
 }
 
-function acquire(limit: number): Promise<Release> {
+function acquire(limit: number, queueLimit: number | undefined): Promise<Release> {
   lastLimit = limit;
+  lastQueueLimit = queueLimit ?? null;
   if (inflight < limit && queue.length === 0) {
     inflight += 1;
     getMetrics().syncGlobalInflight.record(inflight);
     return Promise.resolve(releaseOnce);
+  }
+  if (typeof queueLimit === 'number' && queue.length >= queueLimit) {
+    throw new SyncBackpressureBusyError(
+      `sync backpressure queue full (global inflight=${inflight}/${limit}, queued=${queue.length}/${queueLimit})`,
+    );
   }
   return new Promise((resolve) => {
     queue.push({ limit, resolve });
@@ -73,13 +91,21 @@ function parseIntegerEnv(name: string): number | undefined {
   return Number.isInteger(parsed) ? parsed : undefined;
 }
 
+function positiveInteger(value: number | undefined): number | undefined {
+  return Number.isInteger(value) && typeof value === 'number' && value > 0 ? value : undefined;
+}
+
+function nonNegativeInteger(value: number | undefined): number | undefined {
+  return Number.isInteger(value) && typeof value === 'number' && value >= 0 ? value : undefined;
+}
+
 export function resolvePositiveIntegerSwitch(
   configValue: number | undefined,
   envName: string,
 ): number | undefined {
   const value = parseIntegerEnv(envName) ?? configValue;
   if (value == null) return undefined;
-  return Number.isInteger(value) && value > 0 ? value : undefined;
+  return positiveInteger(value);
 }
 
 export function resolveNonNegativeIntegerSwitch(
@@ -88,24 +114,44 @@ export function resolveNonNegativeIntegerSwitch(
 ): number | undefined {
   const value = parseIntegerEnv(envName) ?? configValue;
   if (value == null) return undefined;
-  return Number.isInteger(value) && value >= 0 ? value : undefined;
+  return nonNegativeInteger(value);
 }
 
-export function resolveSyncGlobalMaxInflight(configValue: number | undefined): number | undefined {
-  return resolvePositiveIntegerSwitch(configValue, 'DKG_SYNC_GLOBAL_MAX_INFLIGHT');
+export function resolveSyncGlobalMaxInflight(
+  configValue: number | undefined,
+  legacyConfigValue?: number,
+): number | undefined {
+  const value = nonNegativeInteger(parseIntegerEnv('DKG_SYNC_GLOBAL_MAX_INFLIGHT'))
+    ?? nonNegativeInteger(parseIntegerEnv('DKG_SYNC_GLOBAL_LIMIT'))
+    ?? nonNegativeInteger(configValue)
+    ?? nonNegativeInteger(legacyConfigValue)
+    ?? DEFAULT_SYNC_GLOBAL_MAX_INFLIGHT;
+  return value > 0 ? value : undefined;
 }
 
-export function getSyncBackpressureSnapshot(limit?: number): SyncBackpressureSnapshot {
+export function resolveSyncGlobalQueueLimit(
+  configValue: number | undefined,
+  limit?: number,
+): number | undefined {
+  const configured = resolveNonNegativeIntegerSwitch(configValue, 'DKG_SYNC_GLOBAL_QUEUE_LIMIT');
+  if (configured != null) return configured;
+  if (typeof limit !== 'number' || !Number.isInteger(limit) || limit <= 0) return undefined;
+  return limit * DEFAULT_SYNC_GLOBAL_QUEUE_LIMIT_MULTIPLIER;
+}
+
+export function getSyncBackpressureSnapshot(limit?: number, queueLimit?: number): SyncBackpressureSnapshot {
   return {
     inflight,
     queued: queue.length,
     limit: limit ?? lastLimit,
+    queueLimit: queueLimit ?? lastQueueLimit,
   };
 }
 
 export async function withGlobalSyncBackpressure<T>(
   options: {
     limit?: number;
+    queueLimit?: number;
     ctx: OperationContext;
     label: string;
     logInfo?: (ctx: OperationContext, message: string) => void;
@@ -116,19 +162,28 @@ export async function withGlobalSyncBackpressure<T>(
   if (typeof limit !== 'number' || !Number.isInteger(limit) || limit <= 0) {
     return work();
   }
+  const queueLimit = options.queueLimit;
 
   const queuedBefore = queue.length;
   if (inflight >= limit) {
+    if (typeof queueLimit === 'number' && queuedBefore >= queueLimit) {
+      const message = `Sync backpressure rejected ${options.label} `
+        + `(global inflight=${inflight}/${limit}, queued=${queuedBefore}/${queueLimit})`;
+      options.logInfo?.(options.ctx, message);
+      throw new SyncBackpressureBusyError(message);
+    }
     options.logInfo?.(
       options.ctx,
-      `Sync backpressure queued ${options.label} (global inflight=${inflight}/${limit}, queued=${queuedBefore})`,
+      `Sync backpressure queued ${options.label} `
+        + `(global inflight=${inflight}/${limit}, queued=${queuedBefore}${typeof queueLimit === 'number' ? `/${queueLimit}` : ''})`,
     );
   }
-  const release = await acquire(limit);
+  const release = await acquire(limit, queueLimit);
   try {
     options.logInfo?.(
       options.ctx,
-      `Sync backpressure running ${options.label} (global inflight=${inflight}/${limit}, queued=${queue.length})`,
+      `Sync backpressure running ${options.label} `
+        + `(global inflight=${inflight}/${limit}, queued=${queue.length}${typeof queueLimit === 'number' ? `/${queueLimit}` : ''})`,
     );
     return await work();
   } finally {

--- a/packages/agent/src/sync/backpressure.ts
+++ b/packages/agent/src/sync/backpressure.ts
@@ -48,15 +48,16 @@ export class SyncBackpressureBusyError extends Error {
   }
 }
 
-/** Return local admission pressure through a direct or wrapped error boundary. */
+/** Return local admission pressure through the standard Error.cause chain. */
 export function getSyncBackpressureBusyError(
   error: unknown,
 ): SyncBackpressureBusyError | undefined {
-  if (error instanceof SyncBackpressureBusyError) return error;
-  if (error && typeof error === 'object' && 'originalError' in error) {
-    return error.originalError instanceof SyncBackpressureBusyError
-      ? error.originalError
-      : undefined;
+  const seen = new Set<Error>();
+  let current = error;
+  while (current instanceof Error && !seen.has(current)) {
+    if (current instanceof SyncBackpressureBusyError) return current;
+    seen.add(current);
+    current = current.cause;
   }
   return undefined;
 }

--- a/packages/agent/src/sync/backpressure.ts
+++ b/packages/agent/src/sync/backpressure.ts
@@ -48,6 +48,19 @@ export class SyncBackpressureBusyError extends Error {
   }
 }
 
+/** Return local admission pressure through a direct or wrapped error boundary. */
+export function getSyncBackpressureBusyError(
+  error: unknown,
+): SyncBackpressureBusyError | undefined {
+  if (error instanceof SyncBackpressureBusyError) return error;
+  if (error && typeof error === 'object' && 'originalError' in error) {
+    return error.originalError instanceof SyncBackpressureBusyError
+      ? error.originalError
+      : undefined;
+  }
+  return undefined;
+}
+
 function drain(): void {
   for (;;) {
     const next = queue[0];

--- a/packages/agent/src/sync/backpressure.ts
+++ b/packages/agent/src/sync/backpressure.ts
@@ -7,11 +7,28 @@ export interface SyncBackpressureSnapshot {
   queueLimit: number | null;
 }
 
+export interface SyncGlobalBackpressureConfig {
+  syncGlobalMaxInflight?: number;
+  syncGlobalLimit?: number;
+  syncGlobalQueueLimit?: number;
+}
+
+export interface SyncGlobalBackpressurePolicy {
+  limit: number | undefined;
+  queueLimit: number | undefined;
+}
+
 type Release = () => void;
 
 interface QueueEntry {
   limit: number;
   resolve: (release: Release) => void;
+}
+
+interface SyncBackpressureAdmission {
+  status: 'running' | 'queued';
+  queuedBefore: number;
+  release: Promise<Release>;
 }
 
 const queue: QueueEntry[] = [];
@@ -48,24 +65,47 @@ function releaseOnce(): void {
   drain();
 }
 
-function acquire(limit: number, queueLimit: number | undefined): Promise<Release> {
+function acquire(
+  policy: SyncGlobalBackpressurePolicy,
+  label: string,
+): SyncBackpressureAdmission {
+  const { limit } = policy;
+  const queuedBefore = queue.length;
+  if (typeof limit !== 'number' || !Number.isInteger(limit) || limit <= 0) {
+    lastLimit = null;
+    lastQueueLimit = null;
+    return {
+      status: 'running',
+      queuedBefore,
+      release: Promise.resolve(() => {}),
+    };
+  }
+
+  const { queueLimit } = policy;
   lastLimit = limit;
   lastQueueLimit = queueLimit ?? null;
-  if (inflight < limit && queue.length === 0) {
+  if (inflight < limit && queuedBefore === 0) {
     inflight += 1;
     getMetrics().syncGlobalInflight.record(inflight);
-    return Promise.resolve(releaseOnce);
+    return {
+      status: 'running',
+      queuedBefore,
+      release: Promise.resolve(releaseOnce),
+    };
   }
-  if (typeof queueLimit === 'number' && queue.length >= queueLimit) {
+  if (typeof queueLimit === 'number' && queuedBefore >= queueLimit) {
     throw new SyncBackpressureBusyError(
-      `sync backpressure queue full (global inflight=${inflight}/${limit}, queued=${queue.length}/${queueLimit})`,
+      `Sync backpressure rejected ${label} `
+        + `(global inflight=${inflight}/${limit}, queued=${queuedBefore}/${queueLimit})`,
     );
   }
-  return new Promise((resolve) => {
+
+  const release = new Promise<Release>((resolve) => {
     queue.push({ limit, resolve });
     getMetrics().syncBackgroundQueueDepth.record(queue.length);
     drain();
   });
+  return { status: 'queued', queuedBefore, release };
 }
 
 export function parseBooleanEnv(name: string): boolean | undefined {
@@ -117,74 +157,70 @@ export function resolveNonNegativeIntegerSwitch(
   return nonNegativeInteger(value);
 }
 
-export function resolveSyncGlobalMaxInflight(
-  configValue: number | undefined,
-  legacyConfigValue?: number,
-): number | undefined {
-  const value = nonNegativeInteger(parseIntegerEnv('DKG_SYNC_GLOBAL_MAX_INFLIGHT'))
+export function resolveSyncGlobalBackpressure(
+  config: SyncGlobalBackpressureConfig,
+): SyncGlobalBackpressurePolicy {
+  const limit = nonNegativeInteger(parseIntegerEnv('DKG_SYNC_GLOBAL_MAX_INFLIGHT'))
     ?? nonNegativeInteger(parseIntegerEnv('DKG_SYNC_GLOBAL_LIMIT'))
-    ?? nonNegativeInteger(configValue)
-    ?? nonNegativeInteger(legacyConfigValue)
+    ?? nonNegativeInteger(config.syncGlobalMaxInflight)
+    ?? nonNegativeInteger(config.syncGlobalLimit)
     ?? DEFAULT_SYNC_GLOBAL_MAX_INFLIGHT;
-  return value > 0 ? value : undefined;
+  if (limit === 0) return { limit: undefined, queueLimit: undefined };
+
+  const queueLimit = resolveNonNegativeIntegerSwitch(
+    config.syncGlobalQueueLimit,
+    'DKG_SYNC_GLOBAL_QUEUE_LIMIT',
+  ) ?? limit * DEFAULT_SYNC_GLOBAL_QUEUE_LIMIT_MULTIPLIER;
+  return { limit, queueLimit };
 }
 
-export function resolveSyncGlobalQueueLimit(
-  configValue: number | undefined,
-  limit?: number,
-): number | undefined {
-  const configured = resolveNonNegativeIntegerSwitch(configValue, 'DKG_SYNC_GLOBAL_QUEUE_LIMIT');
-  if (configured != null) return configured;
-  if (typeof limit !== 'number' || !Number.isInteger(limit) || limit <= 0) return undefined;
-  return limit * DEFAULT_SYNC_GLOBAL_QUEUE_LIMIT_MULTIPLIER;
-}
-
-export function getSyncBackpressureSnapshot(limit?: number, queueLimit?: number): SyncBackpressureSnapshot {
+export function getSyncBackpressureSnapshot(
+  policy?: SyncGlobalBackpressurePolicy,
+): SyncBackpressureSnapshot {
   return {
     inflight,
     queued: queue.length,
-    limit: limit ?? lastLimit,
-    queueLimit: queueLimit ?? lastQueueLimit,
+    limit: policy ? policy.limit ?? null : lastLimit,
+    queueLimit: policy ? policy.queueLimit ?? null : lastQueueLimit,
   };
 }
 
 export async function withGlobalSyncBackpressure<T>(
   options: {
-    limit?: number;
-    queueLimit?: number;
+    policy: SyncGlobalBackpressurePolicy;
     ctx: OperationContext;
     label: string;
     logInfo?: (ctx: OperationContext, message: string) => void;
   },
   work: () => Promise<T>,
 ): Promise<T> {
-  const limit = options.limit;
-  if (typeof limit !== 'number' || !Number.isInteger(limit) || limit <= 0) {
-    return work();
-  }
-  const queueLimit = options.queueLimit;
-
-  const queuedBefore = queue.length;
-  if (inflight >= limit) {
-    if (typeof queueLimit === 'number' && queuedBefore >= queueLimit) {
-      const message = `Sync backpressure rejected ${options.label} `
-        + `(global inflight=${inflight}/${limit}, queued=${queuedBefore}/${queueLimit})`;
-      options.logInfo?.(options.ctx, message);
-      throw new SyncBackpressureBusyError(message);
+  const { limit, queueLimit } = options.policy;
+  let admission: SyncBackpressureAdmission;
+  try {
+    admission = acquire(options.policy, options.label);
+  } catch (error) {
+    if (error instanceof SyncBackpressureBusyError) {
+      options.logInfo?.(options.ctx, error.message);
     }
+    throw error;
+  }
+
+  if (typeof limit === 'number' && admission.status === 'queued') {
     options.logInfo?.(
       options.ctx,
       `Sync backpressure queued ${options.label} `
-        + `(global inflight=${inflight}/${limit}, queued=${queuedBefore}${typeof queueLimit === 'number' ? `/${queueLimit}` : ''})`,
+        + `(global inflight=${inflight}/${limit}, queued=${admission.queuedBefore}${typeof queueLimit === 'number' ? `/${queueLimit}` : ''})`,
     );
   }
-  const release = await acquire(limit, queueLimit);
+  const release = await admission.release;
   try {
-    options.logInfo?.(
-      options.ctx,
-      `Sync backpressure running ${options.label} `
-        + `(global inflight=${inflight}/${limit}, queued=${queue.length}${typeof queueLimit === 'number' ? `/${queueLimit}` : ''})`,
-    );
+    if (typeof limit === 'number') {
+      options.logInfo?.(
+        options.ctx,
+        `Sync backpressure running ${options.label} `
+          + `(global inflight=${inflight}/${limit}, queued=${queue.length}${typeof queueLimit === 'number' ? `/${queueLimit}` : ''})`,
+      );
+    }
     return await work();
   } finally {
     release();

--- a/packages/agent/src/sync/on-connect/sync-on-connect.ts
+++ b/packages/agent/src/sync/on-connect/sync-on-connect.ts
@@ -1,4 +1,5 @@
 import { createOperationContext, PROTOCOL_STORAGE_ACK, PROTOCOL_STORAGE_ACK_V2, PROTOCOL_SYNC, SYSTEM_CONTEXT_GRAPHS, type OperationContext } from '@origintrail-official/dkg-core';
+import { SyncBackpressureBusyError } from '../backpressure.js';
 
 interface SyncProgressSummary {
   insertedTriples: number;
@@ -71,6 +72,24 @@ export class SyncOnConnectPostSyncError extends Error {
     this.originalError = originalError;
     this.backoffEligible = options.backoffEligible;
   }
+}
+
+/**
+ * Local admission pressure is retryable node state, not a remote-peer failure.
+ * Keep direct and post-durable wrapped classification beside the wrapper type so
+ * lifecycle accounting has one canonical deferral decision.
+ */
+export function getSyncOnConnectLocalBackpressureError(
+  error: unknown,
+): SyncBackpressureBusyError | undefined {
+  if (error instanceof SyncBackpressureBusyError) return error;
+  if (
+    error instanceof SyncOnConnectPostSyncError
+    && error.originalError instanceof SyncBackpressureBusyError
+  ) {
+    return error.originalError;
+  }
+  return undefined;
 }
 
 function insertedTriples(result: SyncFromPeerResult): number {

--- a/packages/agent/src/sync/on-connect/sync-on-connect.ts
+++ b/packages/agent/src/sync/on-connect/sync-on-connect.ts
@@ -1,5 +1,4 @@
 import { createOperationContext, PROTOCOL_STORAGE_ACK, PROTOCOL_STORAGE_ACK_V2, PROTOCOL_SYNC, SYSTEM_CONTEXT_GRAPHS, type OperationContext } from '@origintrail-official/dkg-core';
-import { SyncBackpressureBusyError } from '../backpressure.js';
 
 interface SyncProgressSummary {
   insertedTriples: number;
@@ -72,24 +71,6 @@ export class SyncOnConnectPostSyncError extends Error {
     this.originalError = originalError;
     this.backoffEligible = options.backoffEligible;
   }
-}
-
-/**
- * Local admission pressure is retryable node state, not a remote-peer failure.
- * Keep direct and post-durable wrapped classification beside the wrapper type so
- * lifecycle accounting has one canonical deferral decision.
- */
-export function getSyncOnConnectLocalBackpressureError(
-  error: unknown,
-): SyncBackpressureBusyError | undefined {
-  if (error instanceof SyncBackpressureBusyError) return error;
-  if (
-    error instanceof SyncOnConnectPostSyncError
-    && error.originalError instanceof SyncBackpressureBusyError
-  ) {
-    return error.originalError;
-  }
-  return undefined;
 }
 
 function insertedTriples(result: SyncFromPeerResult): number {

--- a/packages/agent/src/sync/on-connect/sync-on-connect.ts
+++ b/packages/agent/src/sync/on-connect/sync-on-connect.ts
@@ -66,7 +66,7 @@ export class SyncOnConnectPostSyncError extends Error {
 
   constructor(remotePeer: string, originalError: unknown, options: { backoffEligible: boolean }) {
     const detail = originalError instanceof Error ? originalError.message : String(originalError);
-    super(`post-sync step failed for peer ${remotePeer.slice(-8)}: ${detail}`);
+    super(`post-sync step failed for peer ${remotePeer.slice(-8)}: ${detail}`, { cause: originalError });
     this.name = 'SyncOnConnectPostSyncError';
     this.originalError = originalError;
     this.backoffEligible = options.backoffEligible;

--- a/packages/agent/test/e2e-publish-protocol.test.ts
+++ b/packages/agent/test/e2e-publish-protocol.test.ts
@@ -87,6 +87,10 @@ describe('E2E: ContextGraph publish with receiver signature collection', () => {
       skills: [],
       chainAdapter: createEVMAdapter(HARDHAT_KEYS.REC1_OP),
       nodeRole: 'core',
+      // This suite owns GossipSub/finalization behavior. Receiver startup
+      // catch-up can add the same logical rows from the per-KA VM graph; the
+      // read-both bag-semantics issue is tracked separately in #1270.
+      syncOnConnectEnabled: false,
     });
     nodeC = await DKGAgent.create({
       kaNumberAllocator: makeTestKaNumberAllocator(),
@@ -95,6 +99,7 @@ describe('E2E: ContextGraph publish with receiver signature collection', () => {
       skills: [],
       chainAdapter: createEVMAdapter(HARDHAT_KEYS.REC2_OP),
       nodeRole: 'core',
+      syncOnConnectEnabled: false,
     });
 
     await nodeA.start();
@@ -237,8 +242,10 @@ describe('E2E: Design B — multi-entity file publishes as one KA, ACKed cross-n
 
   it('bootstraps 3 agents and a context graph', async () => {
     nodeA = await DKGAgent.create({ kaNumberAllocator: makeTestKaNumberAllocator(), name: 'DBMultiA', listenPort: 0, skills: [], chainAdapter: chainA, nodeRole: 'core' });
-    nodeB = await DKGAgent.create({ kaNumberAllocator: makeTestKaNumberAllocator(), name: 'DBMultiB', listenPort: 0, skills: [], chainAdapter: createEVMAdapter(HARDHAT_KEYS.REC1_OP), nodeRole: 'core' });
-    nodeC = await DKGAgent.create({ kaNumberAllocator: makeTestKaNumberAllocator(), name: 'DBMultiC', listenPort: 0, skills: [], chainAdapter: createEVMAdapter(HARDHAT_KEYS.REC2_OP), nodeRole: 'core' });
+    // Keep receiver startup catch-up out of this GossipSub/finalization canary;
+    // duplicate logical rows across VM layouts are tracked separately in #1270.
+    nodeB = await DKGAgent.create({ kaNumberAllocator: makeTestKaNumberAllocator(), name: 'DBMultiB', listenPort: 0, skills: [], chainAdapter: createEVMAdapter(HARDHAT_KEYS.REC1_OP), nodeRole: 'core', syncOnConnectEnabled: false });
+    nodeC = await DKGAgent.create({ kaNumberAllocator: makeTestKaNumberAllocator(), name: 'DBMultiC', listenPort: 0, skills: [], chainAdapter: createEVMAdapter(HARDHAT_KEYS.REC2_OP), nodeRole: 'core', syncOnConnectEnabled: false });
 
     await nodeA.start();
     await nodeB.start();

--- a/packages/agent/test/sync-backpressure.test.ts
+++ b/packages/agent/test/sync-backpressure.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { createOperationContext } from '@origintrail-official/dkg-core';
 import {
+  getSyncBackpressureSnapshot,
   resolveBooleanSwitch,
   resolveNonNegativeIntegerSwitch,
-  resolveSyncGlobalMaxInflight,
-  resolveSyncGlobalQueueLimit,
+  resolveSyncGlobalBackpressure,
   SyncBackpressureBusyError,
   withGlobalSyncBackpressure,
 } from '../src/sync/backpressure.js';
@@ -18,7 +18,7 @@ describe('sync global backpressure', () => {
     let releaseFirst!: () => void;
 
     const first = withGlobalSyncBackpressure(
-      { limit: 1, ctx, label: 'first' },
+      { policy: { limit: 1, queueLimit: 2 }, ctx, label: 'first' },
       async () => {
         events.push('first-start');
         await new Promise<void>((resolve) => {
@@ -30,28 +30,50 @@ describe('sync global backpressure', () => {
     await tick();
 
     const second = withGlobalSyncBackpressure(
-      { limit: 1, queueLimit: 1, ctx, label: 'second' },
+      { policy: { limit: 1, queueLimit: 2 }, ctx, label: 'second' },
       async () => {
         events.push('second-start');
       },
     );
     await tick();
 
+    const third = withGlobalSyncBackpressure(
+      { policy: { limit: 1, queueLimit: 2 }, ctx, label: 'third' },
+      async () => {
+        events.push('third-start');
+      },
+    );
+    await tick();
+
+    expect(getSyncBackpressureSnapshot({ limit: 1, queueLimit: 2 })).toEqual({
+      inflight: 1,
+      queued: 2,
+      limit: 1,
+      queueLimit: 2,
+    });
+
     events.push('storage-ack-work');
     expect(events).toEqual(['first-start', 'storage-ack-work']);
 
     releaseFirst();
-    await Promise.all([first, second]);
-    expect(events).toEqual(['first-start', 'storage-ack-work', 'first-end', 'second-start']);
+    await Promise.all([first, second, third]);
+    expect(events).toEqual([
+      'first-start',
+      'storage-ack-work',
+      'first-end',
+      'second-start',
+      'third-start',
+    ]);
   });
 
   it('rejects excess sync work instead of growing an unbounded queue', async () => {
     const ctx = createOperationContext('sync');
     const events: string[] = [];
+    const logs: string[] = [];
     let releaseFirst!: () => void;
 
     const first = withGlobalSyncBackpressure(
-      { limit: 1, queueLimit: 1, ctx, label: 'first' },
+      { policy: { limit: 1, queueLimit: 1 }, ctx, label: 'first' },
       async () => {
         events.push('first-start');
         await new Promise<void>((resolve) => {
@@ -62,7 +84,7 @@ describe('sync global backpressure', () => {
     await tick();
 
     const second = withGlobalSyncBackpressure(
-      { limit: 1, queueLimit: 1, ctx, label: 'second' },
+      { policy: { limit: 1, queueLimit: 1 }, ctx, label: 'second' },
       async () => {
         events.push('second-start');
       },
@@ -70,19 +92,27 @@ describe('sync global backpressure', () => {
     await tick();
 
     await expect(withGlobalSyncBackpressure(
-      { limit: 1, queueLimit: 1, ctx, label: 'third' },
+      {
+        policy: { limit: 1, queueLimit: 1 },
+        ctx,
+        label: 'third',
+        logInfo: (_opCtx, message) => logs.push(message),
+      },
       async () => {
         events.push('third-start');
       },
     )).rejects.toThrow(SyncBackpressureBusyError);
 
     expect(events).toEqual(['first-start']);
+    expect(logs).toEqual([
+      'Sync backpressure rejected third (global inflight=1/1, queued=1/1)',
+    ]);
     releaseFirst();
     await Promise.all([first, second]);
     expect(events).toEqual(['first-start', 'second-start']);
   });
 
-  it('defaults sync pressure limits on while preserving env/config overrides and disable switches', () => {
+  it('resolves one policy with defaults, config precedence, and legacy aliases', () => {
     const oldMaxInflight = process.env.DKG_SYNC_GLOBAL_MAX_INFLIGHT;
     const oldLegacyLimit = process.env.DKG_SYNC_GLOBAL_LIMIT;
     const oldQueueLimit = process.env.DKG_SYNC_GLOBAL_QUEUE_LIMIT;
@@ -91,20 +121,68 @@ describe('sync global backpressure', () => {
       delete process.env.DKG_SYNC_GLOBAL_LIMIT;
       delete process.env.DKG_SYNC_GLOBAL_QUEUE_LIMIT;
 
-      expect(resolveSyncGlobalMaxInflight(undefined)).toBe(2);
-      expect(resolveSyncGlobalMaxInflight(3)).toBe(3);
-      expect(resolveSyncGlobalMaxInflight(undefined, 4)).toBe(4);
-      expect(resolveSyncGlobalMaxInflight(0)).toBeUndefined();
-      expect(resolveSyncGlobalQueueLimit(undefined, 2)).toBe(4);
+      expect(resolveSyncGlobalBackpressure({})).toEqual({ limit: 2, queueLimit: 4 });
+      expect(resolveSyncGlobalBackpressure({ syncGlobalMaxInflight: 3 })).toEqual({
+        limit: 3,
+        queueLimit: 6,
+      });
+      expect(resolveSyncGlobalBackpressure({
+        syncGlobalMaxInflight: 3,
+        syncGlobalLimit: 4,
+        syncGlobalQueueLimit: 7,
+      })).toEqual({ limit: 3, queueLimit: 7 });
+      expect(resolveSyncGlobalBackpressure({ syncGlobalLimit: 4 })).toEqual({
+        limit: 4,
+        queueLimit: 8,
+      });
 
       process.env.DKG_SYNC_GLOBAL_LIMIT = '5';
-      expect(resolveSyncGlobalMaxInflight(undefined)).toBe(5);
+      expect(resolveSyncGlobalBackpressure({ syncGlobalMaxInflight: 3 })).toEqual({
+        limit: 5,
+        queueLimit: 10,
+      });
 
       process.env.DKG_SYNC_GLOBAL_MAX_INFLIGHT = '6';
-      expect(resolveSyncGlobalMaxInflight(3, 4)).toBe(6);
+      expect(resolveSyncGlobalBackpressure({ syncGlobalMaxInflight: 3, syncGlobalLimit: 4 })).toEqual({
+        limit: 6,
+        queueLimit: 12,
+      });
 
       process.env.DKG_SYNC_GLOBAL_QUEUE_LIMIT = '0';
-      expect(resolveSyncGlobalQueueLimit(8, 2)).toBe(0);
+      expect(resolveSyncGlobalBackpressure({
+        syncGlobalMaxInflight: 3,
+        syncGlobalQueueLimit: 8,
+      })).toEqual({ limit: 6, queueLimit: 0 });
+    } finally {
+      if (oldMaxInflight === undefined) delete process.env.DKG_SYNC_GLOBAL_MAX_INFLIGHT;
+      else process.env.DKG_SYNC_GLOBAL_MAX_INFLIGHT = oldMaxInflight;
+      if (oldLegacyLimit === undefined) delete process.env.DKG_SYNC_GLOBAL_LIMIT;
+      else process.env.DKG_SYNC_GLOBAL_LIMIT = oldLegacyLimit;
+      if (oldQueueLimit === undefined) delete process.env.DKG_SYNC_GLOBAL_QUEUE_LIMIT;
+      else process.env.DKG_SYNC_GLOBAL_QUEUE_LIMIT = oldQueueLimit;
+    }
+  });
+
+  it('disables the complete policy when the inflight limit is zero', () => {
+    const oldMaxInflight = process.env.DKG_SYNC_GLOBAL_MAX_INFLIGHT;
+    const oldLegacyLimit = process.env.DKG_SYNC_GLOBAL_LIMIT;
+    const oldQueueLimit = process.env.DKG_SYNC_GLOBAL_QUEUE_LIMIT;
+    try {
+      delete process.env.DKG_SYNC_GLOBAL_MAX_INFLIGHT;
+      delete process.env.DKG_SYNC_GLOBAL_LIMIT;
+      delete process.env.DKG_SYNC_GLOBAL_QUEUE_LIMIT;
+
+      expect(resolveSyncGlobalBackpressure({
+        syncGlobalMaxInflight: 0,
+        syncGlobalQueueLimit: 8,
+      })).toEqual({ limit: undefined, queueLimit: undefined });
+
+      process.env.DKG_SYNC_GLOBAL_MAX_INFLIGHT = '0';
+      process.env.DKG_SYNC_GLOBAL_QUEUE_LIMIT = '9';
+      expect(resolveSyncGlobalBackpressure({
+        syncGlobalMaxInflight: 3,
+        syncGlobalQueueLimit: 8,
+      })).toEqual({ limit: undefined, queueLimit: undefined });
     } finally {
       if (oldMaxInflight === undefined) delete process.env.DKG_SYNC_GLOBAL_MAX_INFLIGHT;
       else process.env.DKG_SYNC_GLOBAL_MAX_INFLIGHT = oldMaxInflight;

--- a/packages/agent/test/sync-backpressure.test.ts
+++ b/packages/agent/test/sync-backpressure.test.ts
@@ -3,6 +3,9 @@ import { createOperationContext } from '@origintrail-official/dkg-core';
 import {
   resolveBooleanSwitch,
   resolveNonNegativeIntegerSwitch,
+  resolveSyncGlobalMaxInflight,
+  resolveSyncGlobalQueueLimit,
+  SyncBackpressureBusyError,
   withGlobalSyncBackpressure,
 } from '../src/sync/backpressure.js';
 
@@ -27,7 +30,7 @@ describe('sync global backpressure', () => {
     await tick();
 
     const second = withGlobalSyncBackpressure(
-      { limit: 1, ctx, label: 'second' },
+      { limit: 1, queueLimit: 1, ctx, label: 'second' },
       async () => {
         events.push('second-start');
       },
@@ -40,6 +43,76 @@ describe('sync global backpressure', () => {
     releaseFirst();
     await Promise.all([first, second]);
     expect(events).toEqual(['first-start', 'storage-ack-work', 'first-end', 'second-start']);
+  });
+
+  it('rejects excess sync work instead of growing an unbounded queue', async () => {
+    const ctx = createOperationContext('sync');
+    const events: string[] = [];
+    let releaseFirst!: () => void;
+
+    const first = withGlobalSyncBackpressure(
+      { limit: 1, queueLimit: 1, ctx, label: 'first' },
+      async () => {
+        events.push('first-start');
+        await new Promise<void>((resolve) => {
+          releaseFirst = resolve;
+        });
+      },
+    );
+    await tick();
+
+    const second = withGlobalSyncBackpressure(
+      { limit: 1, queueLimit: 1, ctx, label: 'second' },
+      async () => {
+        events.push('second-start');
+      },
+    );
+    await tick();
+
+    await expect(withGlobalSyncBackpressure(
+      { limit: 1, queueLimit: 1, ctx, label: 'third' },
+      async () => {
+        events.push('third-start');
+      },
+    )).rejects.toThrow(SyncBackpressureBusyError);
+
+    expect(events).toEqual(['first-start']);
+    releaseFirst();
+    await Promise.all([first, second]);
+    expect(events).toEqual(['first-start', 'second-start']);
+  });
+
+  it('defaults sync pressure limits on while preserving env/config overrides and disable switches', () => {
+    const oldMaxInflight = process.env.DKG_SYNC_GLOBAL_MAX_INFLIGHT;
+    const oldLegacyLimit = process.env.DKG_SYNC_GLOBAL_LIMIT;
+    const oldQueueLimit = process.env.DKG_SYNC_GLOBAL_QUEUE_LIMIT;
+    try {
+      delete process.env.DKG_SYNC_GLOBAL_MAX_INFLIGHT;
+      delete process.env.DKG_SYNC_GLOBAL_LIMIT;
+      delete process.env.DKG_SYNC_GLOBAL_QUEUE_LIMIT;
+
+      expect(resolveSyncGlobalMaxInflight(undefined)).toBe(2);
+      expect(resolveSyncGlobalMaxInflight(3)).toBe(3);
+      expect(resolveSyncGlobalMaxInflight(undefined, 4)).toBe(4);
+      expect(resolveSyncGlobalMaxInflight(0)).toBeUndefined();
+      expect(resolveSyncGlobalQueueLimit(undefined, 2)).toBe(4);
+
+      process.env.DKG_SYNC_GLOBAL_LIMIT = '5';
+      expect(resolveSyncGlobalMaxInflight(undefined)).toBe(5);
+
+      process.env.DKG_SYNC_GLOBAL_MAX_INFLIGHT = '6';
+      expect(resolveSyncGlobalMaxInflight(3, 4)).toBe(6);
+
+      process.env.DKG_SYNC_GLOBAL_QUEUE_LIMIT = '0';
+      expect(resolveSyncGlobalQueueLimit(8, 2)).toBe(0);
+    } finally {
+      if (oldMaxInflight === undefined) delete process.env.DKG_SYNC_GLOBAL_MAX_INFLIGHT;
+      else process.env.DKG_SYNC_GLOBAL_MAX_INFLIGHT = oldMaxInflight;
+      if (oldLegacyLimit === undefined) delete process.env.DKG_SYNC_GLOBAL_LIMIT;
+      else process.env.DKG_SYNC_GLOBAL_LIMIT = oldLegacyLimit;
+      if (oldQueueLimit === undefined) delete process.env.DKG_SYNC_GLOBAL_QUEUE_LIMIT;
+      else process.env.DKG_SYNC_GLOBAL_QUEUE_LIMIT = oldQueueLimit;
+    }
   });
 
   it('env switches override config values for emergency controls', () => {

--- a/packages/agent/test/sync-backpressure.test.ts
+++ b/packages/agent/test/sync-backpressure.test.ts
@@ -14,11 +14,15 @@ const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
 describe('sync global backpressure', () => {
   it('serializes concurrent sync work when global limit is 1 while non-sync work can proceed', async () => {
     const ctx = createOperationContext('sync');
+    const policy = resolveSyncGlobalBackpressure({
+      syncGlobalMaxInflight: 1,
+      syncGlobalQueueLimit: 2,
+    });
     const events: string[] = [];
     let releaseFirst!: () => void;
 
     const first = withGlobalSyncBackpressure(
-      { policy: { limit: 1, queueLimit: 2 }, ctx, label: 'first' },
+      { policy, ctx, label: 'first' },
       async () => {
         events.push('first-start');
         await new Promise<void>((resolve) => {
@@ -30,7 +34,7 @@ describe('sync global backpressure', () => {
     await tick();
 
     const second = withGlobalSyncBackpressure(
-      { policy: { limit: 1, queueLimit: 2 }, ctx, label: 'second' },
+      { policy, ctx, label: 'second' },
       async () => {
         events.push('second-start');
       },
@@ -38,14 +42,14 @@ describe('sync global backpressure', () => {
     await tick();
 
     const third = withGlobalSyncBackpressure(
-      { policy: { limit: 1, queueLimit: 2 }, ctx, label: 'third' },
+      { policy, ctx, label: 'third' },
       async () => {
         events.push('third-start');
       },
     );
     await tick();
 
-    expect(getSyncBackpressureSnapshot({ limit: 1, queueLimit: 2 })).toEqual({
+    expect(getSyncBackpressureSnapshot(policy)).toEqual({
       inflight: 1,
       queued: 2,
       limit: 1,
@@ -68,12 +72,16 @@ describe('sync global backpressure', () => {
 
   it('rejects excess sync work instead of growing an unbounded queue', async () => {
     const ctx = createOperationContext('sync');
+    const policy = resolveSyncGlobalBackpressure({
+      syncGlobalMaxInflight: 1,
+      syncGlobalQueueLimit: 1,
+    });
     const events: string[] = [];
     const logs: string[] = [];
     let releaseFirst!: () => void;
 
     const first = withGlobalSyncBackpressure(
-      { policy: { limit: 1, queueLimit: 1 }, ctx, label: 'first' },
+      { policy, ctx, label: 'first' },
       async () => {
         events.push('first-start');
         await new Promise<void>((resolve) => {
@@ -84,7 +92,7 @@ describe('sync global backpressure', () => {
     await tick();
 
     const second = withGlobalSyncBackpressure(
-      { policy: { limit: 1, queueLimit: 1 }, ctx, label: 'second' },
+      { policy, ctx, label: 'second' },
       async () => {
         events.push('second-start');
       },
@@ -93,7 +101,7 @@ describe('sync global backpressure', () => {
 
     await expect(withGlobalSyncBackpressure(
       {
-        policy: { limit: 1, queueLimit: 1 },
+        policy,
         ctx,
         label: 'third',
         logInfo: (_opCtx, message) => logs.push(message),
@@ -183,6 +191,43 @@ describe('sync global backpressure', () => {
         syncGlobalMaxInflight: 3,
         syncGlobalQueueLimit: 8,
       })).toEqual({ limit: undefined, queueLimit: undefined });
+    } finally {
+      if (oldMaxInflight === undefined) delete process.env.DKG_SYNC_GLOBAL_MAX_INFLIGHT;
+      else process.env.DKG_SYNC_GLOBAL_MAX_INFLIGHT = oldMaxInflight;
+      if (oldLegacyLimit === undefined) delete process.env.DKG_SYNC_GLOBAL_LIMIT;
+      else process.env.DKG_SYNC_GLOBAL_LIMIT = oldLegacyLimit;
+      if (oldQueueLimit === undefined) delete process.env.DKG_SYNC_GLOBAL_QUEUE_LIMIT;
+      else process.env.DKG_SYNC_GLOBAL_QUEUE_LIMIT = oldQueueLimit;
+    }
+  });
+
+  it('normalizes invalid raw limits before exposing an executable policy', () => {
+    const oldMaxInflight = process.env.DKG_SYNC_GLOBAL_MAX_INFLIGHT;
+    const oldLegacyLimit = process.env.DKG_SYNC_GLOBAL_LIMIT;
+    const oldQueueLimit = process.env.DKG_SYNC_GLOBAL_QUEUE_LIMIT;
+    try {
+      delete process.env.DKG_SYNC_GLOBAL_MAX_INFLIGHT;
+      delete process.env.DKG_SYNC_GLOBAL_LIMIT;
+      delete process.env.DKG_SYNC_GLOBAL_QUEUE_LIMIT;
+
+      expect(resolveSyncGlobalBackpressure({
+        syncGlobalMaxInflight: Number.NaN,
+        syncGlobalLimit: 3,
+        syncGlobalQueueLimit: 1.5,
+      })).toEqual({ limit: 3, queueLimit: 6 });
+      expect(resolveSyncGlobalBackpressure({
+        syncGlobalMaxInflight: -1,
+        syncGlobalLimit: 4,
+        syncGlobalQueueLimit: -2,
+      })).toEqual({ limit: 4, queueLimit: 8 });
+
+      process.env.DKG_SYNC_GLOBAL_MAX_INFLIGHT = '1.5';
+      process.env.DKG_SYNC_GLOBAL_LIMIT = '5';
+      process.env.DKG_SYNC_GLOBAL_QUEUE_LIMIT = '-1';
+      expect(resolveSyncGlobalBackpressure({
+        syncGlobalMaxInflight: 3,
+        syncGlobalQueueLimit: 7,
+      })).toEqual({ limit: 5, queueLimit: 7 });
     } finally {
       if (oldMaxInflight === undefined) delete process.env.DKG_SYNC_GLOBAL_MAX_INFLIGHT;
       else process.env.DKG_SYNC_GLOBAL_MAX_INFLIGHT = oldMaxInflight;

--- a/packages/agent/test/sync-fetch-coalescing.test.ts
+++ b/packages/agent/test/sync-fetch-coalescing.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { createOperationContext, PROTOCOL_SYNC } from '@origintrail-official/dkg-core';
 import { MockChainAdapter } from '@origintrail-official/dkg-chain';
 import { DKGAgent } from '../src/index.js';
+import { resolveSyncGlobalBackpressure, SyncBackpressureBusyError, withGlobalSyncBackpressure } from '../src/sync/backpressure.js';
 import type { SyncPhase } from '../src/sync/auth/request-build.js';
 import type { SyncPageResult } from '../src/sync/requester/page-fetch.js';
 
@@ -102,11 +103,13 @@ function emptySyncPage(phase: string): SyncPageResult {
 
 async function createAgentWithSend(
   sendToPeer: (...args: unknown[]) => Promise<Uint8Array>,
+  backpressure?: { syncGlobalMaxInflight: number; syncGlobalQueueLimit: number },
 ): Promise<DKGAgent> {
   const agent = await DKGAgent.create({
     name: 'SyncFetchCoalescing',
     listenHost: '127.0.0.1',
     chainAdapter: new MockChainAdapter(),
+    ...backpressure,
   });
   (agent as any).messenger = { sendToPeer };
   (agent as any).buildSyncRequest = async () => new Uint8Array([1, 2, 3]);
@@ -292,7 +295,10 @@ describe('DKGAgent sync fetch coalescing', () => {
   it('joins concurrent direct durable syncs and clears the entry after settle', async () => {
     const firstMetaFetch = deferred<SyncPageResult>();
     let fetchCalls = 0;
-    const agent = await createAgentWithSend(async () => new Uint8Array(0));
+    const agent = await createAgentWithSend(
+      async () => new Uint8Array(0),
+      { syncGlobalMaxInflight: 1, syncGlobalQueueLimit: 0 },
+    );
     (agent as any).fetchSyncPages = async (...args: unknown[]) => {
       fetchCalls++;
       const phase = String(args[4]);
@@ -361,7 +367,10 @@ describe('DKGAgent sync fetch coalescing', () => {
   it('joins concurrent direct shared-memory syncs and clears the entry after settle', async () => {
     const firstMetaFetch = deferred<SyncPageResult>();
     let fetchCalls = 0;
-    const agent = await createAgentWithSend(async () => new Uint8Array(0));
+    const agent = await createAgentWithSend(
+      async () => new Uint8Array(0),
+      { syncGlobalMaxInflight: 1, syncGlobalQueueLimit: 0 },
+    );
     const sharedMemorySyncPlan = {
       eligibleContextGraphIds: ['coalesced-cg'],
       publicContextGraphIds: ['coalesced-cg'],
@@ -401,6 +410,86 @@ describe('DKGAgent sync fetch coalescing', () => {
       await expect(third).resolves.toMatchObject({ failedPeers: 0 });
       expect(fetchCalls).toBe(4);
     } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+
+  it.each([
+    {
+      name: 'private-only',
+      eligibleContextGraphIds: ['private-cg'],
+      publicContextGraphIds: [] as string[],
+      privateRecoverFromCurator: ['private-cg'],
+    },
+    {
+      name: 'mixed public/private',
+      eligibleContextGraphIds: ['public-cg', 'private-cg'],
+      publicContextGraphIds: ['public-cg'],
+      privateRecoverFromCurator: ['private-cg'],
+    },
+  ])('uses one global admission for $name shared-memory aggregation', async ({
+    eligibleContextGraphIds,
+    publicContextGraphIds,
+    privateRecoverFromCurator,
+  }) => {
+    const agent = await createAgentWithSend(
+      async () => new Uint8Array(0),
+      { syncGlobalMaxInflight: 1, syncGlobalQueueLimit: 0 },
+    );
+    (agent as any).listSubGraphs = async () => [];
+    (agent as any).fetchSyncPages = async (...args: unknown[]) => emptySyncPage(String(args[4]));
+    (agent as any).getOrCreateSyncVerifyWorker = () => ({
+      processSharedMemoryBatch: async () => ({
+        verifiedData: [],
+        verifiedMeta: [],
+        totalFetchedDataQuads: 0,
+        totalFetchedMetaQuads: 0,
+        droppedDataTriples: 0,
+        emptyResponses: 1,
+        entityCreators: [],
+      }),
+    });
+
+    try {
+      await expect((agent as any).syncSharedMemoryFromPeerDetailed(
+        PEER_A,
+        eligibleContextGraphIds,
+        {
+          sharedMemorySyncPlan: {
+            eligibleContextGraphIds,
+            publicContextGraphIds,
+            privateRecoverFromCurator,
+          },
+        },
+      )).resolves.toMatchObject({ failedPeers: 0 });
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+
+  it('keeps standalone shared-memory recovery behind global admission', async () => {
+    const agent = await createAgentWithSend(
+      async () => new Uint8Array(0),
+      { syncGlobalMaxInflight: 1, syncGlobalQueueLimit: 0 },
+    );
+    const occupied = deferred<void>();
+    const holder = withGlobalSyncBackpressure(
+      {
+        policy: resolveSyncGlobalBackpressure((agent as any).config),
+        ctx: createOperationContext('sync'),
+        label: 'occupied-slot',
+      },
+      () => occupied.promise,
+    );
+    await flushMicrotasks();
+
+    try {
+      await expect(
+        agent.recoverContextGraphSwmFromPeer(PEER_A, 'private-cg'),
+      ).rejects.toThrow(SyncBackpressureBusyError);
+    } finally {
+      occupied.resolve();
+      await holder;
       await agent.stop().catch(() => {});
     }
   });

--- a/packages/agent/test/sync-fetch-coalescing.test.ts
+++ b/packages/agent/test/sync-fetch-coalescing.test.ts
@@ -436,6 +436,10 @@ describe('DKGAgent sync fetch coalescing', () => {
       async () => new Uint8Array(0),
       { syncGlobalMaxInflight: 1, syncGlobalQueueLimit: 0 },
     );
+    const backpressureLogs: string[] = [];
+    (agent as any).log.info = (_ctx: unknown, message: string) => {
+      if (message.startsWith('Sync backpressure ')) backpressureLogs.push(message);
+    };
     (agent as any).listSubGraphs = async () => [];
     (agent as any).fetchSyncPages = async (...args: unknown[]) => emptySyncPage(String(args[4]));
     (agent as any).getOrCreateSyncVerifyWorker = () => ({
@@ -462,6 +466,12 @@ describe('DKGAgent sync fetch coalescing', () => {
           },
         },
       )).resolves.toMatchObject({ failedPeers: 0 });
+      const runningAdmissions = backpressureLogs.filter((message) => (
+        message.startsWith('Sync backpressure running ')
+      ));
+      expect(runningAdmissions).toHaveLength(1);
+      expect(runningAdmissions[0]).toContain('running shared-memory:');
+      expect(runningAdmissions[0]).not.toContain('swm-recovery:');
     } finally {
       await agent.stop().catch(() => {});
     }

--- a/packages/agent/test/sync-on-connect-retry.test.ts
+++ b/packages/agent/test/sync-on-connect-retry.test.ts
@@ -4,6 +4,7 @@ import { MockChainAdapter } from '@origintrail-official/dkg-chain';
 import { createOperationContext, PROTOCOL_SYNC, PROTOCOL_ACCESS, PROTOCOL_STORAGE_ACK, PROTOCOL_STORAGE_ACK_V2 } from '@origintrail-official/dkg-core';
 import { peerIdFromString } from '@libp2p/peer-id';
 import { runSyncOnConnect, SyncOnConnectPostSyncError } from '../src/sync/on-connect/sync-on-connect.js';
+import { SyncBackpressureBusyError, withGlobalSyncBackpressure } from '../src/sync/backpressure.js';
 import type { OperationContext } from '@origintrail-official/dkg-core';
 
 function recorder<A extends unknown[], R>(impl: (...args: A) => R) {
@@ -1133,6 +1134,115 @@ describe('DKGAgent sync retry — periodic reconciler', () => {
       await (agent as any).reconcileSyncFromConnectedPeers();
       await flushMicrotasks();
 
+      expect((agent as any).syncReconcilerBackoff.has(peerA)).toBe(false);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+
+  it('defers a queue-full sync attempt without peer backoff and retries on the next reconciler tick', async () => {
+    const agent = await DKGAgent.create({
+      name: 'ReconcilerLocalBackpressureRetry',
+      listenHost: '127.0.0.1',
+      chainAdapter: new MockChainAdapter(),
+    });
+    let releaseOccupiedSlot: (() => void) | undefined;
+    let occupiedSlot: Promise<void> | undefined;
+    try {
+      await agent.start();
+      allowAllNetworkAdmission(agent);
+
+      const peerA = freshPeerIdString();
+      const origGetPeers = agent.node.libp2p.getPeers.bind(agent.node.libp2p);
+      (agent.node.libp2p as any).getPeers = recorder(
+        () => [...origGetPeers(), peerIdFromString(peerA)],
+      );
+      (agent as any).getPeerProtocols = recorder(async () => [PROTOCOL_SYNC]);
+
+      const policy = { limit: 1, queueLimit: 0 };
+      const ctx = createOperationContext('sync');
+      occupiedSlot = withGlobalSyncBackpressure(
+        { policy, ctx, label: 'occupied-slot' },
+        async () => new Promise<void>((resolve) => {
+          releaseOccupiedSlot = resolve;
+        }),
+      );
+      await flushMicrotasks();
+
+      const trySync = recorder(async (
+        _peerId: string,
+        onSyncAccounting?: (outcome: { fresh: boolean; progress?: boolean }) => void,
+      ) => {
+        await withGlobalSyncBackpressure(
+          { policy, ctx, label: 'sync-on-connect' },
+          async () => {
+            onSyncAccounting?.({ fresh: true, progress: true });
+          },
+        );
+        return 'synced' as const;
+      });
+      (agent as any).trySyncFromPeer = trySync;
+
+      const outcome = await (agent as any).attemptSyncFromPeerWithReconcilerAccounting(peerA, {
+        protocolsKey: PROTOCOL_SYNC,
+        connectionKey: null,
+      });
+      expect(outcome).toBe('deferred-backpressure');
+      expect(trySync.calls).toHaveLength(1);
+      expect((agent as any).syncReconcilerBackoff.has(peerA)).toBe(false);
+
+      releaseOccupiedSlot();
+      await occupiedSlot;
+      releaseOccupiedSlot = undefined;
+
+      await (agent as any).reconcileSyncFromConnectedPeers();
+      await flushMicrotasks();
+
+      expect(trySync.calls).toHaveLength(2);
+      expect((agent as any).syncReconcilerBackoff.has(peerA)).toBe(false);
+    } finally {
+      releaseOccupiedSlot?.();
+      await occupiedSlot?.catch(() => {});
+      await agent.stop().catch(() => {});
+    }
+  });
+
+  it('propagates private-recovery queue pressure through sync-on-connect without peer backoff', async () => {
+    const agent = await DKGAgent.create({
+      name: 'ReconcilerPrivateRecoveryBackpressure',
+      listenHost: '127.0.0.1',
+      chainAdapter: new MockChainAdapter(),
+      syncContextGraphs: ['private-cg'],
+    });
+    try {
+      await agent.start();
+      allowAllNetworkAdmission(agent);
+
+      const peerA = freshPeerIdString();
+      const origGetPeers = agent.node.libp2p.getPeers.bind(agent.node.libp2p);
+      (agent.node.libp2p as any).getPeers = recorder(
+        () => [...origGetPeers(), peerIdFromString(peerA)],
+      );
+      (agent as any).getPeerProtocols = recorder(async () => [PROTOCOL_SYNC]);
+      (agent as any).syncFromPeerDetailed = recorder(async () => 0);
+      (agent as any).refreshMetaSyncedFlags = recorder(async () => undefined);
+      (agent as any).discoverContextGraphsFromStore = recorder(async () => 0);
+      (agent as any).planSharedMemorySyncContextGraphs = recorder(async () => ({
+        publicContextGraphIds: [],
+        privateRecoverFromCurator: ['private-cg'],
+        eligibleContextGraphIds: ['private-cg'],
+      }));
+      const recoverContextGraphSwmFromPeer = recorder(async () => {
+        throw new SyncBackpressureBusyError('private recovery queue full');
+      });
+      (agent as any).recoverContextGraphSwmFromPeer = recoverContextGraphSwmFromPeer;
+
+      const outcome = await (agent as any).attemptSyncFromPeerWithReconcilerAccounting(peerA, {
+        protocolsKey: PROTOCOL_SYNC,
+        connectionKey: null,
+      });
+      expect(outcome).toBe('deferred-backpressure');
+      expect(recoverContextGraphSwmFromPeer.calls).toEqual([[peerA, 'private-cg']]);
       expect((agent as any).syncReconcilerBackoff.has(peerA)).toBe(false);
     } finally {
       await agent.stop().catch(() => {});

--- a/packages/agent/test/sync-on-connect-retry.test.ts
+++ b/packages/agent/test/sync-on-connect-retry.test.ts
@@ -649,6 +649,7 @@ describe('runSyncOnConnect callbacks', () => {
 
     expect(caught).toBeInstanceOf(SyncOnConnectPostSyncError);
     expect((caught as SyncOnConnectPostSyncError).originalError).toBe(laterError);
+    expect((caught as SyncOnConnectPostSyncError).cause).toBe(laterError);
     expect((caught as SyncOnConnectPostSyncError).backoffEligible).toBe(false);
     expect(synced).toEqual([]);
     expect(syncingPeers.has(remotePeer)).toBe(false);

--- a/packages/agent/test/sync-on-connect-retry.test.ts
+++ b/packages/agent/test/sync-on-connect-retry.test.ts
@@ -4,8 +4,9 @@ import { MockChainAdapter } from '@origintrail-official/dkg-chain';
 import { createOperationContext, PROTOCOL_SYNC, PROTOCOL_ACCESS, PROTOCOL_STORAGE_ACK, PROTOCOL_STORAGE_ACK_V2 } from '@origintrail-official/dkg-core';
 import { peerIdFromString } from '@libp2p/peer-id';
 import { runSyncOnConnect, SyncOnConnectPostSyncError } from '../src/sync/on-connect/sync-on-connect.js';
-import { SyncBackpressureBusyError, withGlobalSyncBackpressure } from '../src/sync/backpressure.js';
+import { resolveSyncGlobalBackpressure, withGlobalSyncBackpressure } from '../src/sync/backpressure.js';
 import type { OperationContext } from '@origintrail-official/dkg-core';
+import type { SyncPageResult } from '../src/sync/requester/page-fetch.js';
 
 function recorder<A extends unknown[], R>(impl: (...args: A) => R) {
   const calls: A[] = [];
@@ -39,6 +40,49 @@ async function flushMicrotasks(): Promise<void> {
   await Promise.resolve();
   await Promise.resolve();
   await Promise.resolve();
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+async function waitFor(condition: () => boolean, timeoutMs = 1_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!condition()) {
+    if (Date.now() > deadline) throw new Error('condition was not met before timeout');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+function emptySyncPage(phase: string): SyncPageResult {
+  return {
+    quads: [],
+    bytesReceived: 0,
+    resumedFromOffset: 0,
+    nextOffset: 0,
+    checkpointKey: `checkpoint:${phase}`,
+    completed: true,
+    timedOut: false,
+  };
+}
+
+function stubDurableSyncExternalIo(agent: DKGAgent): void {
+  (agent as any).processDurableBatchInWorker = async () => ({
+    verifiedData: [],
+    verifiedMeta: [],
+    totalFetchedDataQuads: 0,
+    totalFetchedMetaQuads: 0,
+    rejectedKcs: 0,
+    emptyResponses: 1,
+    metaOnlyResponses: 0,
+    dataRejectedMissingMeta: 0,
+  });
 }
 
 function allowAllNetworkAdmission(agent: DKGAgent): void {
@@ -1145,42 +1189,36 @@ describe('DKGAgent sync retry — periodic reconciler', () => {
       name: 'ReconcilerLocalBackpressureRetry',
       listenHost: '127.0.0.1',
       chainAdapter: new MockChainAdapter(),
+      syncGlobalMaxInflight: 1,
+      syncGlobalQueueLimit: 0,
+      syncSharedMemoryOnConnect: false,
     });
-    let releaseOccupiedSlot: (() => void) | undefined;
-    let occupiedSlot: Promise<void> | undefined;
+    const occupiedFetch = deferred<SyncPageResult>();
+    let fetchCalls = 0;
+    let occupiedSlot: Promise<unknown> | undefined;
     try {
       await agent.start();
       allowAllNetworkAdmission(agent);
+      stubDurableSyncExternalIo(agent);
+      (agent as any).fetchSyncPages = async (...args: unknown[]) => {
+        fetchCalls++;
+        if (fetchCalls === 1) return occupiedFetch.promise;
+        return emptySyncPage(String(args[4]));
+      };
 
       const peerA = freshPeerIdString();
+      const occupyingPeer = freshPeerIdString();
       const origGetPeers = agent.node.libp2p.getPeers.bind(agent.node.libp2p);
       (agent.node.libp2p as any).getPeers = recorder(
         () => [...origGetPeers(), peerIdFromString(peerA)],
       );
       (agent as any).getPeerProtocols = recorder(async () => [PROTOCOL_SYNC]);
 
-      const policy = { limit: 1, queueLimit: 0 };
-      const ctx = createOperationContext('sync');
-      occupiedSlot = withGlobalSyncBackpressure(
-        { policy, ctx, label: 'occupied-slot' },
-        async () => new Promise<void>((resolve) => {
-          releaseOccupiedSlot = resolve;
-        }),
-      );
-      await flushMicrotasks();
+      occupiedSlot = (agent as any).syncFromPeerDetailed(occupyingPeer, ['occupied-cg']);
+      await waitFor(() => fetchCalls === 1);
 
-      const trySync = recorder(async (
-        _peerId: string,
-        onSyncAccounting?: (outcome: { fresh: boolean; progress?: boolean }) => void,
-      ) => {
-        await withGlobalSyncBackpressure(
-          { policy, ctx, label: 'sync-on-connect' },
-          async () => {
-            onSyncAccounting?.({ fresh: true, progress: true });
-          },
-        );
-        return 'synced' as const;
-      });
+      const origTrySync = (agent as any).trySyncFromPeer.bind(agent);
+      const trySync = recorder((...args: unknown[]) => origTrySync(...args));
       (agent as any).trySyncFromPeer = trySync;
 
       const outcome = await (agent as any).attemptSyncFromPeerWithReconcilerAccounting(peerA, {
@@ -1191,32 +1229,38 @@ describe('DKGAgent sync retry — periodic reconciler', () => {
       expect(trySync.calls).toHaveLength(1);
       expect((agent as any).syncReconcilerBackoff.has(peerA)).toBe(false);
 
-      releaseOccupiedSlot();
+      occupiedFetch.resolve(emptySyncPage('meta'));
       await occupiedSlot;
-      releaseOccupiedSlot = undefined;
+      occupiedSlot = undefined;
 
       await (agent as any).reconcileSyncFromConnectedPeers();
-      await flushMicrotasks();
+      await waitFor(() => trySync.calls.length === 2);
 
       expect(trySync.calls).toHaveLength(2);
       expect((agent as any).syncReconcilerBackoff.has(peerA)).toBe(false);
     } finally {
-      releaseOccupiedSlot?.();
+      occupiedFetch.resolve(emptySyncPage('meta'));
       await occupiedSlot?.catch(() => {});
       await agent.stop().catch(() => {});
     }
   });
 
-  it('propagates private-recovery queue pressure through sync-on-connect without peer backoff', async () => {
+  it('defers wrapped private shared-memory admission pressure without peer backoff', async () => {
     const agent = await DKGAgent.create({
       name: 'ReconcilerPrivateRecoveryBackpressure',
       listenHost: '127.0.0.1',
       chainAdapter: new MockChainAdapter(),
       syncContextGraphs: ['private-cg'],
+      syncGlobalMaxInflight: 1,
+      syncGlobalQueueLimit: 0,
     });
+    let occupiedSlot: Promise<void> | undefined;
+    let releaseOccupiedSlot: (() => void) | undefined;
     try {
       await agent.start();
       allowAllNetworkAdmission(agent);
+      stubDurableSyncExternalIo(agent);
+      (agent as any).fetchSyncPages = async (...args: unknown[]) => emptySyncPage(String(args[4]));
 
       const peerA = freshPeerIdString();
       const origGetPeers = agent.node.libp2p.getPeers.bind(agent.node.libp2p);
@@ -1224,17 +1268,34 @@ describe('DKGAgent sync retry — periodic reconciler', () => {
         () => [...origGetPeers(), peerIdFromString(peerA)],
       );
       (agent as any).getPeerProtocols = recorder(async () => [PROTOCOL_SYNC]);
-      (agent as any).syncFromPeerDetailed = recorder(async () => 0);
-      (agent as any).refreshMetaSyncedFlags = recorder(async () => undefined);
+      let occupied = false;
+      (agent as any).refreshMetaSyncedFlags = recorder(async () => {
+        if (occupied) return;
+        occupied = true;
+        occupiedSlot = withGlobalSyncBackpressure(
+          {
+            policy: resolveSyncGlobalBackpressure((agent as any).config),
+            ctx: createOperationContext('sync'),
+            label: 'post-durable-occupied-slot',
+          },
+          async () => new Promise<void>((resolve) => {
+            releaseOccupiedSlot = resolve;
+          }),
+        );
+        await waitFor(() => releaseOccupiedSlot !== undefined);
+      });
       (agent as any).discoverContextGraphsFromStore = recorder(async () => 0);
       (agent as any).planSharedMemorySyncContextGraphs = recorder(async () => ({
         publicContextGraphIds: [],
         privateRecoverFromCurator: ['private-cg'],
         eligibleContextGraphIds: ['private-cg'],
       }));
-      const recoverContextGraphSwmFromPeer = recorder(async () => {
-        throw new SyncBackpressureBusyError('private recovery queue full');
-      });
+      const recoverContextGraphSwmFromPeer = recorder(async () => ({
+        insertedDataQuads: 0,
+        insertedMetaQuads: 0,
+        droppedDataTriples: 0,
+        completed: true,
+      }));
       (agent as any).recoverContextGraphSwmFromPeer = recoverContextGraphSwmFromPeer;
 
       const outcome = await (agent as any).attemptSyncFromPeerWithReconcilerAccounting(peerA, {
@@ -1242,9 +1303,11 @@ describe('DKGAgent sync retry — periodic reconciler', () => {
         connectionKey: null,
       });
       expect(outcome).toBe('deferred-backpressure');
-      expect(recoverContextGraphSwmFromPeer.calls).toEqual([[peerA, 'private-cg']]);
+      expect(recoverContextGraphSwmFromPeer.calls).toEqual([]);
       expect((agent as any).syncReconcilerBackoff.has(peerA)).toBe(false);
     } finally {
+      releaseOccupiedSlot?.();
+      await occupiedSlot?.catch(() => {});
       await agent.stop().catch(() => {});
     }
   });

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -35,6 +35,8 @@ export default defineConfig({
       "test/cg-registration-oversize-guard.test.ts",
       "test/sync-responder-concurrent-interleaving.test.ts",
       "test/sync-fetch-coalescing.test.ts",
+      "test/sync-backpressure.test.ts",
+      "test/sync-on-connect-retry.test.ts",
       "test/sync-on-connect-churn.test.ts",
       "test/sync-requester-bailout.test.ts",
       "test/swm-catchup-peer-selection.test.ts",

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -587,8 +587,15 @@ export interface DkgConfig {
   syncOnConnectEnabled?: boolean;
   /** Emergency switch for durable/SWM sync execution. Env DKG_DURABLE_SYNC_ENABLED wins. */
   durableSyncEnabled?: boolean;
-  /** Global cap for concurrent sync jobs. Env DKG_SYNC_GLOBAL_MAX_INFLIGHT wins. */
+  /**
+   * Global cap for concurrent sync jobs. Defaults to 2; set 0 to disable.
+   * Env DKG_SYNC_GLOBAL_MAX_INFLIGHT wins.
+   */
   syncGlobalMaxInflight?: number;
+  /** Backwards-compatible alias for syncGlobalMaxInflight. Env DKG_SYNC_GLOBAL_LIMIT wins. */
+  syncGlobalLimit?: number;
+  /** Max sync jobs waiting behind the global cap. Defaults to 2x the inflight cap. */
+  syncGlobalQueueLimit?: number;
   /** StorageACK handler deadline override in milliseconds. Env DKG_STORAGE_ACK_HANDLER_DEADLINE_MS wins. */
   storageAckHandlerDeadlineMs?: number;
   /**

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1572,6 +1572,8 @@ export async function runDaemonInner(
     syncOnConnectEnabled: config.syncOnConnectEnabled,
     durableSyncEnabled: config.durableSyncEnabled,
     syncGlobalMaxInflight: config.syncGlobalMaxInflight,
+    syncGlobalLimit: config.syncGlobalLimit,
+    syncGlobalQueueLimit: config.syncGlobalQueueLimit,
     storageAckHandlerDeadlineMs: config.storageAckHandlerDeadlineMs,
     swmAwaitCuratorAck: config.swmAwaitCuratorAck,
     syncAgentsMeta: resolveSyncAgentsMeta(config.syncAgentsMeta, process.env.DKG_SYNC_AGENTS_META),

--- a/packages/cli/test/daemon-sync-agents-meta-wiring.test.ts
+++ b/packages/cli/test/daemon-sync-agents-meta-wiring.test.ts
@@ -53,7 +53,7 @@ function closeDashboardDbFromAgentCreateArg(createArg: any): void {
   db?.close?.();
 }
 
-describe('runDaemonInner wires resolved syncAgentsMeta into DKGAgent.create', () => {
+describe('runDaemonInner wires sync options into DKGAgent.create', () => {
   let tempHome: string | undefined;
   let originalDkgHome: string | undefined;
   const originalSyncEnv = process.env.DKG_SYNC_AGENTS_META;
@@ -150,5 +150,15 @@ describe('runDaemonInner wires resolved syncAgentsMeta into DKGAgent.create', ()
     process.env.DKG_SYNC_AGENTS_META = '0';
     const createArg = await captureCreateArg({ syncAgentsMeta: true });
     expect(createArg.syncAgentsMeta).toBe(true);
+  });
+
+  it('passes syncGlobalLimit and syncGlobalQueueLimit through unchanged', async () => {
+    const createArg = await captureCreateArg({
+      syncGlobalLimit: 1,
+      syncGlobalQueueLimit: 0,
+    });
+
+    expect(createArg.syncGlobalLimit).toBe(1);
+    expect(createArg.syncGlobalQueueLimit).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- enable global sync pressure by default at 2 concurrent sync jobs, with 0 as the explicit disable switch
- add a bounded waiting queue for sync backpressure; default queue depth is 2x the inflight cap
- expose `syncGlobalQueueLimit` / `DKG_SYNC_GLOBAL_QUEUE_LIMIT` and accept `syncGlobalLimit` / `DKG_SYNC_GLOBAL_LIMIT` as a backwards-compatible alias

## Mainnet check
- Read-only SSH check of the nine mainnet nodes found all active releases on 10.0.5.
- None of their live `/home/adminuser/dkg-v10/config.json` files set `syncGlobalMaxInflight`, `syncGlobalLimit`, or queue/pressure overrides, so they are currently relying on compiled defaults.
- Before this PR the compiled default was effectively no global sync cap; this makes default configs load-shed instead of growing unbounded local sync work.

## Tests
- `pnpm --filter @origintrail-official/dkg-agent... run build`
- `pnpm --filter @origintrail-official/dkg-agent run build`
- `pnpm --filter @origintrail-official/dkg-agent exec vitest run test/sync-backpressure.test.ts`