### PR TITLE
fix(agent): bound the finalization SWM-slice read to the KA's graphs (#1549)

### DIFF
--- a/packages/agent/src/finalization-handler.ts
+++ b/packages/agent/src/finalization-handler.ts
@@ -12,7 +12,7 @@ import {
   DKG_ROOT_ENTITY_LEGACY,
   ENTITY_PRED_ALT,
 } from '@origintrail-official/dkg-core';
-import { GraphManager, loadSelectedSharedMemoryQuads, type SwmKaGraphBound, type TripleStore, type Quad } from '@origintrail-official/dkg-storage';
+import { GraphManager, loadSelectedSharedMemoryQuads, loadKaBoundedSharedMemoryQuads, type SwmKaGraphBound, type TripleStore, type Quad } from '@origintrail-official/dkg-storage';
 import { type ChainAdapter, type EventFilter } from '@origintrail-official/dkg-chain';
 import {
   computeFlatKCRootV10 as computeFlatKCRoot, skolemizeByEntity,
@@ -614,15 +614,19 @@ export class FinalizationHandler {
     // fidelity for the merkle recompute, and so the same logical triple
     // present in BOTH the bucket and a per-KA graph collapses to one
     // (a constructed graph is a set).
-    // #1549: when the caller supplies a per-author `kaGraphBound` (derived from
-    // the finalization message's packed `startKAId`/`endKAId`), the resolved
-    // graph set drops sibling per-KA under-graphs outside the range instead of
-    // scanning all ~120–175 of them. The bound is FAIL-OPEN in storage and a
-    // pure accelerator here — the gossip caller widens to the unbounded read on
-    // an empty-or-mismatch result before it defers.
+    // #1549: with a per-author `kaGraphBound` (derived from the finalization
+    // message's packed `startKAId`/`endKAId`), the resolved graph set drops the
+    // sibling per-KA under-graphs outside the range instead of scanning all
+    // ~120–175 of them. `loadKaBoundedSharedMemoryQuads` is UNSAFE alone — only
+    // `loadSwmSliceWithFallback` may call this with a bound, because it owns the
+    // widen to the unbounded read on an empty-or-mismatch result.
+    if (kaGraphBound) {
+      return loadKaBoundedSharedMemoryQuads(
+        this.store, sharedMemoryGraph, { rootEntities: safeRoots }, kaGraphBound, { querySource },
+      );
+    }
     return loadSelectedSharedMemoryQuads(this.store, sharedMemoryGraph, { rootEntities: safeRoots }, {
       querySource,
-      kaGraphBound,
     });
   }
 

--- a/packages/agent/src/finalization-handler.ts
+++ b/packages/agent/src/finalization-handler.ts
@@ -12,7 +12,7 @@ import {
   DKG_ROOT_ENTITY_LEGACY,
   ENTITY_PRED_ALT,
 } from '@origintrail-official/dkg-core';
-import { GraphManager, loadSelectedSharedMemoryQuads, loadKaBoundedSharedMemoryQuads, type SwmKaGraphBound, type TripleStore, type Quad } from '@origintrail-official/dkg-storage';
+import { GraphManager, loadSelectedSharedMemoryQuads, loadSharedMemorySliceWithKaBoundFallback, type SwmKaGraphBound, type TripleStore, type Quad } from '@origintrail-official/dkg-storage';
 import { type ChainAdapter, type EventFilter } from '@origintrail-official/dkg-chain';
 import {
   computeFlatKCRootV10 as computeFlatKCRoot, skolemizeByEntity,
@@ -35,7 +35,7 @@ const SWM_SLICE_SOURCE = 'agent.finalization.sharedMemorySlice';
 const SWM_SLICE_SOURCE_BOUNDED = `${SWM_SLICE_SOURCE}.bounded`;
 const SWM_SLICE_SOURCE_WIDENED = `${SWM_SLICE_SOURCE}.fallbackUnbounded`;
 import { ethers } from 'ethers';
-import { unpackKnowledgeAssetId } from './ka-identity.js';
+import { deriveSwmKaGraphBound } from './swm-ka-bound.js';
 import {
   FinalizationLifecycleLogger,
   finalizationLifecycleDecision,
@@ -86,41 +86,10 @@ function sameBigIntLiteral(left: string | bigint | null | undefined, right: stri
 }
 
 /**
- * Derives the per-author SWM under-graph bound for the finalization gossip read
- * from the message's packed `startKAId`/`endKAId`. Purely an accelerator: the
- * caller widens to the unbounded read on empty-or-mismatch before it defers, so
- * a `undefined` return (unbounded, i.e. today's behavior) is always safe.
- *
- * `startKAId`/`endKAId` are packed `(author << 96) | number` (see
- * `packKnowledgeAssetIdFromIdentity`), whereas the SWM under-graph URI's last
- * segment is only the low-96 per-author number. We therefore unpack both ends
- * and bound on `(agentAddress, [startNumber, endNumber])`. A range whose two
- * ends unpack to DIFFERENT authors is not a contiguous per-author number range
- * — the low-96 numbers wrap independently of the high-160 address — so no single
- * `SwmKaGraphBound` can describe it; we fall through to the unbounded read.
- *
- * Pure: identical inputs always yield an identical result. The ops kill-switch is
- * read by `swmKaBoundDisabled` at the orchestration boundary, not here.
- */
-export function deriveSwmKaGraphBound(startKAId: bigint, endKAId: bigint): SwmKaGraphBound | undefined {
-  if (startKAId <= 0n || endKAId < startKAId) return undefined;
-  const start = unpackKnowledgeAssetId(startKAId);
-  const end = unpackKnowledgeAssetId(endKAId);
-  // Both sides come from `unpack`, which is already lowercase, so a plain compare
-  // suffices here. The graph-URI side is NOT — see the case-insensitive compare in
-  // `resolveSharedMemoryReadGraphs`.
-  if (start.agentAddress !== end.agentAddress) return undefined;
-  return {
-    agentAddress: start.agentAddress,
-    startNumber: start.kaNumber,
-    endNumber: end.kaNumber,
-  };
-}
-
-/**
  * Ops kill-switch for the #1549 bounded SWM read. Set `DKG_DISABLE_SWM_KA_BOUND=1`
- * to fall back to the unbounded read with no redeploy. Read at the orchestration
- * boundary so `deriveSwmKaGraphBound` stays a deterministic identity transform.
+ * to fall back to the unbounded read with no redeploy. Read here at the
+ * orchestration boundary so `deriveSwmKaGraphBound` (in `swm-ka-bound.ts`) stays a
+ * deterministic identity transform.
  */
 function swmKaBoundDisabled(): boolean {
   return process.env.DKG_DISABLE_SWM_KA_BOUND === '1';
@@ -285,8 +254,9 @@ export class FinalizationHandler {
 
       // #1549: read this KA's per-author SWM under-graphs first, widening to today's
       // unbounded read on empty-or-mismatch. All of the bound/widen policy — and the
-      // reasoning for why it is safe — lives in `loadSwmSliceWithFallback`.
-      const { quads: sharedMemoryQuads, merkleMatchedQuads } = await this.loadSwmSliceWithFallback(
+      // reasoning for why it is safe — lives in storage's
+      // `loadSharedMemorySliceWithKaBoundFallback`, which owns the widen.
+      const { quads: sharedMemoryQuads, matched: merkleMatchedQuads } = await this.loadFinalizationSwmSlice(
         contextGraphId,
         msg.rootEntities,
         subGraphName,
@@ -536,108 +506,60 @@ export class FinalizationHandler {
     }
   }
 
+  private finalizationSwmBucketUri(contextGraphId: string, subGraphName?: string): string {
+    return subGraphName
+      ? new GraphManager(this.store).sharedMemoryUri(contextGraphId, subGraphName)
+      : contextGraphWorkspaceGraphUri(contextGraphId);
+  }
+
   /**
    * Read the finalization SWM slice, preferring this KA's per-author under-graphs
-   * and widening to the unbounded read on empty-or-mismatch (#1549).
+   * and widening to the complete read on empty-or-mismatch (#1549). The widen — and
+   * the reasoning for why the bound is a safe pure accelerator (INV-1 is refuted
+   * under root recurrence, so the bounded read may miss and must widen before the
+   * caller records anything) — lives in storage's
+   * `loadSharedMemorySliceWithKaBoundFallback`. This method only resolves the bucket
+   * URI and the accept predicate; it is a thin finalization-specific adapter.
    *
-   * The bound is a PURE ACCELERATOR. INV-1 — "a root's quads live only under its own
-   * KA number" — is REFUTED under root recurrence (`dkg-agent-swm-host.ts`, an updated
-   * entity republished under a new kaId leaves its earlier quads in the older per-KA
-   * graph). So the bound may miss, and the widen is what makes correctness independent
-   * of it: a miss re-reads exactly what the unbounded code reads, BEFORE the caller
-   * records any lifecycle event.
-   *
-   * The outcome relation is asymmetric, not identity:
-   *   • Never accept→defer. The bounded graph set is a subset of the unbounded one.
-   *   • Sometimes defer→accept. Where recurrence lingers quads the PUBLISHER never
-   *     hashed, the unbounded read builds a superset and mismatches, deferring a KA
-   *     that is in fact valid; the bounded read reproduces the committed set.
-   * Acceptance stays gated on reproducing the on-chain merkle root (and `verifyOnChain`
-   * in the caller), so a bounded match cannot accept a set the chain did not commit to.
-   *
-   * `createMatcher` is invoked at most once, and only when there are quads to match, so
-   * the no-data path issues no extra `_meta` reads. The widen fires at most once.
+   * #1098/#1099: replicas store gossiped SWM shares in the PER-KA graphs
+   * `…/_shared_memory/{author}/{number}`, not the bare bucket, so the read must span
+   * bucket + per-KA graphs or a replica reports "no shared memory data" and never
+   * materialises the KA into VM.
    */
-  private async loadSwmSliceWithFallback(
+  private async loadFinalizationSwmSlice(
     contextGraphId: string,
     rootEntities: string[],
     subGraphName: string | undefined,
     kaGraphBound: SwmKaGraphBound | undefined,
-    createMatcher: () => Promise<(quads: Quad[]) => Quad[] | null>,
-  ): Promise<{ quads: Quad[]; merkleMatchedQuads: Quad[] | null }> {
-    const readUnbounded = (): Promise<Quad[]> => this.getSharedMemoryQuadsForRoots(
-      contextGraphId, rootEntities, subGraphName, undefined, SWM_SLICE_SOURCE_WIDENED,
+    createAccept: () => Promise<(quads: Quad[]) => Quad[] | null>,
+  ): Promise<{ quads: Quad[]; matched: Quad[] | null }> {
+    const safeRoots = rootEntities.filter(isSafeIri);
+    if (safeRoots.length === 0) return { quads: [], matched: null };
+    const { quads, accepted } = await loadSharedMemorySliceWithKaBoundFallback(
+      this.store,
+      this.finalizationSwmBucketUri(contextGraphId, subGraphName),
+      { rootEntities: safeRoots },
+      kaGraphBound,
+      { bounded: SWM_SLICE_SOURCE_BOUNDED, widened: SWM_SLICE_SOURCE_WIDENED, unbounded: SWM_SLICE_SOURCE },
+      createAccept,
     );
-
-    let quads = await this.getSharedMemoryQuadsForRoots(
-      contextGraphId, rootEntities, subGraphName, kaGraphBound,
-      kaGraphBound ? SWM_SLICE_SOURCE_BOUNDED : SWM_SLICE_SOURCE,
-    );
-    let widened = false;
-
-    if (kaGraphBound && quads.length === 0) {
-      quads = await readUnbounded();
-      widened = true;
-    }
-    if (quads.length === 0) return { quads, merkleMatchedQuads: null };
-
-    const matchMerkle = await createMatcher();
-    let merkleMatchedQuads = matchMerkle(quads);
-    if (kaGraphBound && !widened && !merkleMatchedQuads) {
-      quads = await readUnbounded();
-      merkleMatchedQuads = matchMerkle(quads);
-    }
-    return { quads, merkleMatchedQuads };
+    return { quads, matched: accepted };
   }
 
+  /** Complete (unbounded) SWM read for the chain-reconcile backstop. */
   private async getSharedMemoryQuadsForRoots(
     contextGraphId: string,
     rootEntities: string[],
     subGraphName?: string,
-    kaGraphBound?: SwmKaGraphBound,
-    querySource: string = SWM_SLICE_SOURCE,
   ): Promise<Quad[]> {
-    const graphManager = new GraphManager(this.store);
-    const sharedMemoryGraph = subGraphName
-      ? graphManager.sharedMemoryUri(contextGraphId, subGraphName)
-      : contextGraphWorkspaceGraphUri(contextGraphId);
     const safeRoots = rootEntities.filter(isSafeIri);
     if (safeRoots.length === 0) return [];
-
-    // #1098/#1099: replicas store gossiped SWM shares in the PER-KA graphs
-    // `…/_shared_memory/{author}/{number}` (workspace-handler.ts ~line 987),
-    // not the bare bucket. Reading only the bucket made every replica report
-    // "no shared memory data … peer missed SWM sharing" on finalization, so
-    // the published KA was never materialized into VM on subscribed peers
-    // (the VM-divergence half of #1098). Read-both: bucket + per-KA graphs.
-    //
-    // A3 (O(store) relief): bind the read to the exact SWM graph set up front
-    // via the fast named-graph index (`resolveSharedMemoryReadGraphs` →
-    // `listGraphsByPrefix`) instead of an unbounded `GRAPH ?g` +
-    // `sharedMemoryReadBothFilter` STRSTARTS filter, which scans EVERY quad in
-    // EVERY graph on RocksDB and starves finalization/ACK under load. The
-    // resolved set is exactly what that filter matched (bucket + `${bucket}/`
-    // minus `${bucket}/staging/`). Merkle-critical but FAIL-SAFE: if the index
-    // ever omitted a graph the recompute would MISMATCH and this KA is rejected
-    // (retried on a later round), never accepted with corrupt data.
-    // CONSTRUCT (not SELECT) so literal terms keep full datatype/lang
-    // fidelity for the merkle recompute, and so the same logical triple
-    // present in BOTH the bucket and a per-KA graph collapses to one
-    // (a constructed graph is a set).
-    // #1549: with a per-author `kaGraphBound` (derived from the finalization
-    // message's packed `startKAId`/`endKAId`), the resolved graph set drops the
-    // sibling per-KA under-graphs outside the range instead of scanning all
-    // ~120–175 of them. `loadKaBoundedSharedMemoryQuads` is UNSAFE alone — only
-    // `loadSwmSliceWithFallback` may call this with a bound, because it owns the
-    // widen to the unbounded read on an empty-or-mismatch result.
-    if (kaGraphBound) {
-      return loadKaBoundedSharedMemoryQuads(
-        this.store, sharedMemoryGraph, { rootEntities: safeRoots }, kaGraphBound, { querySource },
-      );
-    }
-    return loadSelectedSharedMemoryQuads(this.store, sharedMemoryGraph, { rootEntities: safeRoots }, {
-      querySource,
-    });
+    return loadSelectedSharedMemoryQuads(
+      this.store,
+      this.finalizationSwmBucketUri(contextGraphId, subGraphName),
+      { rootEntities: safeRoots },
+      { querySource: SWM_SLICE_SOURCE },
+    );
   }
 
   private verifyMerkleMatch(sharedMemoryQuads: Quad[], privateRoots: Uint8Array[], expectedMerkleRoot: Uint8Array): boolean {

--- a/packages/agent/src/finalization-handler.ts
+++ b/packages/agent/src/finalization-handler.ts
@@ -27,6 +27,13 @@ import {
   type KCMetadata, type KAMetadata, type OnChainProvenance,
 } from '@origintrail-official/dkg-publisher';
 const DKG_NS = 'http://dkg.io/ontology/';
+
+// Slow-query / canary tags for the finalization SWM slice (#1549). A healthy fleet
+// sees `.fallbackUnbounded` at ~0 relative to `.bounded`; a spike means the bound is
+// mis-derived or recurrence is common, and `DKG_DISABLE_SWM_KA_BOUND=1` is the lever.
+const SWM_SLICE_SOURCE = 'agent.finalization.sharedMemorySlice';
+const SWM_SLICE_SOURCE_BOUNDED = `${SWM_SLICE_SOURCE}.bounded`;
+const SWM_SLICE_SOURCE_WIDENED = `${SWM_SLICE_SOURCE}.fallbackUnbounded`;
 import { ethers } from 'ethers';
 import { unpackKnowledgeAssetId } from './ka-identity.js';
 import {
@@ -266,72 +273,28 @@ export class FinalizationHandler {
         return;
       }
 
-      // #1549: bound the SWM-slice read to this KA's per-author under-graphs, then
-      // WIDEN to today's unbounded read on any empty-or-mismatch BEFORE deferring.
-      // The bound is a pure accelerator: INV-1 (a root's quads live only under its
-      // own KA number) is REFUTED under root recurrence — dkg-agent-swm-host.ts:2793
-      // — so the bound may miss, and the widen is what makes correctness independent
-      // of it.
-      //
-      // The outcome relation to the unbounded code is asymmetric, not identity:
-      //   • Never accept→defer. The bounded graph set is a subset of the unbounded
-      //     one, so a bounded miss widens to exactly today's read and recomputes.
-      //   • Sometimes defer→accept. When recurrence lingers a root's earlier quads
-      //     in a sibling per-KA graph that the PUBLISHER did not hash, today's
-      //     unbounded read builds a superset and mismatches, deferring a KA that is
-      //     in fact valid. The bounded read reproduces the committed set and accepts.
-      // Acceptance stays gated on reproducing the on-chain merkle root and
-      // `verifyOnChain`, so a bounded match cannot accept a set the chain did not
-      // commit to.
-      const kaGraphBound = deriveSwmKaGraphBound(startKAId, endKAId);
-      let sharedMemoryQuads = await this.getSharedMemoryQuadsForRoots(
-        contextGraphId, msg.rootEntities, subGraphName, kaGraphBound,
-        kaGraphBound ? 'agent.finalization.sharedMemorySlice.bounded' : 'agent.finalization.sharedMemorySlice',
-      );
-      let widenedToUnbounded = false;
-      if (kaGraphBound && sharedMemoryQuads.length === 0) {
-        // Empty bounded read may be a false miss (recurrence lingers the root's
-        // quads in an older per-KA graph the bound excludes). Re-read unbounded;
-        // if that is ALSO empty we fall into today's `finalization_no_data` path
-        // with no extra `_meta` reads (privateRoots/floor stay below the guard).
-        sharedMemoryQuads = await this.getSharedMemoryQuadsForRoots(
-          contextGraphId, msg.rootEntities, subGraphName, undefined,
-          'agent.finalization.sharedMemorySlice.fallbackUnbounded',
-        );
-        widenedToUnbounded = true;
-      }
-
-      if (sharedMemoryQuads.length > 0) {
-        const privateRoots = await this.getPrivateRootsFromMeta(contextGraphId, msg.rootEntities, subGraphName);
-        const allowGeneratedCatalogFloor = await this.allowsGeneratedCatalogFloor(contextGraphId, ctxGraphId);
-        let merkleMatchedQuads = this.sharedMemoryQuadsMatchingMerkle(
-          contextGraphId,
-          sharedMemoryQuads,
-          privateRoots,
-          msg.kcMerkleRoot,
-          allowGeneratedCatalogFloor,
-        );
-
-        // A bounded read that returned data but does NOT match the on-chain merkle
-        // (recurrence spread the committed quads across sibling per-KA graphs the
-        // bound dropped) must widen and RECOMPUTE before recording a mismatch —
-        // otherwise the bound could manufacture a false `finalization_merkle_mismatch`.
-        // privateRoots/floor are quad-set-independent, so they are not recomputed.
-        if (kaGraphBound && !widenedToUnbounded && !merkleMatchedQuads) {
-          sharedMemoryQuads = await this.getSharedMemoryQuadsForRoots(
-            contextGraphId, msg.rootEntities, subGraphName, undefined,
-            'agent.finalization.sharedMemorySlice.fallbackUnbounded',
-          );
-          widenedToUnbounded = true;
-          merkleMatchedQuads = this.sharedMemoryQuadsMatchingMerkle(
+      // #1549: read this KA's per-author SWM under-graphs first, widening to today's
+      // unbounded read on empty-or-mismatch. All of the bound/widen policy — and the
+      // reasoning for why it is safe — lives in `loadSwmSliceWithFallback`.
+      const { quads: sharedMemoryQuads, merkleMatchedQuads } = await this.loadSwmSliceWithFallback(
+        contextGraphId,
+        msg.rootEntities,
+        subGraphName,
+        deriveSwmKaGraphBound(startKAId, endKAId),
+        async () => {
+          const privateRoots = await this.getPrivateRootsFromMeta(contextGraphId, msg.rootEntities, subGraphName);
+          const allowGeneratedCatalogFloor = await this.allowsGeneratedCatalogFloor(contextGraphId, ctxGraphId);
+          return (quads) => this.sharedMemoryQuadsMatchingMerkle(
             contextGraphId,
-            sharedMemoryQuads,
+            quads,
             privateRoots,
             msg.kcMerkleRoot,
             allowGeneratedCatalogFloor,
           );
-        }
+        },
+      );
 
+      if (sharedMemoryQuads.length > 0) {
         if (merkleMatchedQuads) {
           const batchId = protoToBigInt(msg.batchId);
           // PR #845 review #9: derive `txIndex` from the verified receipt
@@ -563,12 +526,66 @@ export class FinalizationHandler {
     }
   }
 
+  /**
+   * Read the finalization SWM slice, preferring this KA's per-author under-graphs
+   * and widening to the unbounded read on empty-or-mismatch (#1549).
+   *
+   * The bound is a PURE ACCELERATOR. INV-1 — "a root's quads live only under its own
+   * KA number" — is REFUTED under root recurrence (`dkg-agent-swm-host.ts`, an updated
+   * entity republished under a new kaId leaves its earlier quads in the older per-KA
+   * graph). So the bound may miss, and the widen is what makes correctness independent
+   * of it: a miss re-reads exactly what the unbounded code reads, BEFORE the caller
+   * records any lifecycle event.
+   *
+   * The outcome relation is asymmetric, not identity:
+   *   • Never accept→defer. The bounded graph set is a subset of the unbounded one.
+   *   • Sometimes defer→accept. Where recurrence lingers quads the PUBLISHER never
+   *     hashed, the unbounded read builds a superset and mismatches, deferring a KA
+   *     that is in fact valid; the bounded read reproduces the committed set.
+   * Acceptance stays gated on reproducing the on-chain merkle root (and `verifyOnChain`
+   * in the caller), so a bounded match cannot accept a set the chain did not commit to.
+   *
+   * `createMatcher` is invoked at most once, and only when there are quads to match, so
+   * the no-data path issues no extra `_meta` reads. The widen fires at most once.
+   */
+  private async loadSwmSliceWithFallback(
+    contextGraphId: string,
+    rootEntities: string[],
+    subGraphName: string | undefined,
+    kaGraphBound: SwmKaGraphBound | undefined,
+    createMatcher: () => Promise<(quads: Quad[]) => Quad[] | null>,
+  ): Promise<{ quads: Quad[]; merkleMatchedQuads: Quad[] | null }> {
+    const readUnbounded = (): Promise<Quad[]> => this.getSharedMemoryQuadsForRoots(
+      contextGraphId, rootEntities, subGraphName, undefined, SWM_SLICE_SOURCE_WIDENED,
+    );
+
+    let quads = await this.getSharedMemoryQuadsForRoots(
+      contextGraphId, rootEntities, subGraphName, kaGraphBound,
+      kaGraphBound ? SWM_SLICE_SOURCE_BOUNDED : SWM_SLICE_SOURCE,
+    );
+    let widened = false;
+
+    if (kaGraphBound && quads.length === 0) {
+      quads = await readUnbounded();
+      widened = true;
+    }
+    if (quads.length === 0) return { quads, merkleMatchedQuads: null };
+
+    const matchMerkle = await createMatcher();
+    let merkleMatchedQuads = matchMerkle(quads);
+    if (kaGraphBound && !widened && !merkleMatchedQuads) {
+      quads = await readUnbounded();
+      merkleMatchedQuads = matchMerkle(quads);
+    }
+    return { quads, merkleMatchedQuads };
+  }
+
   private async getSharedMemoryQuadsForRoots(
     contextGraphId: string,
     rootEntities: string[],
     subGraphName?: string,
     kaGraphBound?: SwmKaGraphBound,
-    querySource: string = 'agent.finalization.sharedMemorySlice',
+    querySource: string = SWM_SLICE_SOURCE,
   ): Promise<Quad[]> {
     const graphManager = new GraphManager(this.store);
     const sharedMemoryGraph = subGraphName

--- a/packages/agent/src/finalization-handler.ts
+++ b/packages/agent/src/finalization-handler.ts
@@ -98,10 +98,11 @@ function sameBigIntLiteral(left: string | bigint | null | undefined, right: stri
  * ends unpack to DIFFERENT authors is not a contiguous per-author number range
  * — the low-96 numbers wrap independently of the high-160 address — so no single
  * `SwmKaGraphBound` can describe it; we fall through to the unbounded read.
+ *
+ * Pure: identical inputs always yield an identical result. The ops kill-switch is
+ * read by `swmKaBoundDisabled` at the orchestration boundary, not here.
  */
 export function deriveSwmKaGraphBound(startKAId: bigint, endKAId: bigint): SwmKaGraphBound | undefined {
-  // Kill-switch: no redeploy needed to fall back to the unbounded read.
-  if (process.env.DKG_DISABLE_SWM_KA_BOUND === '1') return undefined;
   if (startKAId <= 0n || endKAId < startKAId) return undefined;
   const start = unpackKnowledgeAssetId(startKAId);
   const end = unpackKnowledgeAssetId(endKAId);
@@ -114,6 +115,15 @@ export function deriveSwmKaGraphBound(startKAId: bigint, endKAId: bigint): SwmKa
     startNumber: start.kaNumber,
     endNumber: end.kaNumber,
   };
+}
+
+/**
+ * Ops kill-switch for the #1549 bounded SWM read. Set `DKG_DISABLE_SWM_KA_BOUND=1`
+ * to fall back to the unbounded read with no redeploy. Read at the orchestration
+ * boundary so `deriveSwmKaGraphBound` stays a deterministic identity transform.
+ */
+function swmKaBoundDisabled(): boolean {
+  return process.env.DKG_DISABLE_SWM_KA_BOUND === '1';
 }
 
 export class FinalizationHandler {
@@ -280,7 +290,7 @@ export class FinalizationHandler {
         contextGraphId,
         msg.rootEntities,
         subGraphName,
-        deriveSwmKaGraphBound(startKAId, endKAId),
+        swmKaBoundDisabled() ? undefined : deriveSwmKaGraphBound(startKAId, endKAId),
         async () => {
           const privateRoots = await this.getPrivateRootsFromMeta(contextGraphId, msg.rootEntities, subGraphName);
           const allowGeneratedCatalogFloor = await this.allowsGeneratedCatalogFloor(contextGraphId, ctxGraphId);

--- a/packages/agent/src/finalization-handler.ts
+++ b/packages/agent/src/finalization-handler.ts
@@ -12,7 +12,7 @@ import {
   DKG_ROOT_ENTITY_LEGACY,
   ENTITY_PRED_ALT,
 } from '@origintrail-official/dkg-core';
-import { GraphManager, loadSelectedSharedMemoryQuads, type TripleStore, type Quad } from '@origintrail-official/dkg-storage';
+import { GraphManager, loadSelectedSharedMemoryQuads, type SwmKaGraphBound, type TripleStore, type Quad } from '@origintrail-official/dkg-storage';
 import { type ChainAdapter, type EventFilter } from '@origintrail-official/dkg-chain';
 import {
   computeFlatKCRootV10 as computeFlatKCRoot, skolemizeByEntity,
@@ -28,6 +28,7 @@ import {
 } from '@origintrail-official/dkg-publisher';
 const DKG_NS = 'http://dkg.io/ontology/';
 import { ethers } from 'ethers';
+import { unpackKnowledgeAssetId } from './ka-identity.js';
 import {
   FinalizationLifecycleLogger,
   finalizationLifecycleDecision,
@@ -75,6 +76,37 @@ function sameBigIntLiteral(left: string | bigint | null | undefined, right: stri
   } catch {
     return false;
   }
+}
+
+/**
+ * Derives the per-author SWM under-graph bound for the finalization gossip read
+ * from the message's packed `startKAId`/`endKAId`. Purely an accelerator: the
+ * caller widens to the unbounded read on empty-or-mismatch before it defers, so
+ * a `undefined` return (unbounded, i.e. today's behavior) is always safe.
+ *
+ * `startKAId`/`endKAId` are packed `(author << 96) | number` (see
+ * `packKnowledgeAssetIdFromIdentity`), whereas the SWM under-graph URI's last
+ * segment is only the low-96 per-author number. We therefore unpack both ends
+ * and bound on `(agentAddress, [startNumber, endNumber])`. A range whose two
+ * ends unpack to DIFFERENT authors is not a contiguous per-author number range
+ * — the low-96 numbers wrap independently of the high-160 address — so no single
+ * `SwmKaGraphBound` can describe it; we fall through to the unbounded read.
+ */
+export function deriveSwmKaGraphBound(startKAId: bigint, endKAId: bigint): SwmKaGraphBound | undefined {
+  // Kill-switch: no redeploy needed to fall back to the unbounded read.
+  if (process.env.DKG_DISABLE_SWM_KA_BOUND === '1') return undefined;
+  if (startKAId <= 0n || endKAId < startKAId) return undefined;
+  const start = unpackKnowledgeAssetId(startKAId);
+  const end = unpackKnowledgeAssetId(endKAId);
+  // Both sides come from `unpack`, which is already lowercase, so a plain compare
+  // suffices here. The graph-URI side is NOT — see the case-insensitive compare in
+  // `resolveSharedMemoryReadGraphs`.
+  if (start.agentAddress !== end.agentAddress) return undefined;
+  return {
+    agentAddress: start.agentAddress,
+    startNumber: start.kaNumber,
+    endNumber: end.kaNumber,
+  };
 }
 
 export class FinalizationHandler {
@@ -234,18 +266,71 @@ export class FinalizationHandler {
         return;
       }
 
-      const sharedMemoryQuads = await this.getSharedMemoryQuadsForRoots(contextGraphId, msg.rootEntities, subGraphName);
+      // #1549: bound the SWM-slice read to this KA's per-author under-graphs, then
+      // WIDEN to today's unbounded read on any empty-or-mismatch BEFORE deferring.
+      // The bound is a pure accelerator: INV-1 (a root's quads live only under its
+      // own KA number) is REFUTED under root recurrence — dkg-agent-swm-host.ts:2793
+      // — so the bound may miss, and the widen is what makes correctness independent
+      // of it.
+      //
+      // The outcome relation to the unbounded code is asymmetric, not identity:
+      //   • Never accept→defer. The bounded graph set is a subset of the unbounded
+      //     one, so a bounded miss widens to exactly today's read and recomputes.
+      //   • Sometimes defer→accept. When recurrence lingers a root's earlier quads
+      //     in a sibling per-KA graph that the PUBLISHER did not hash, today's
+      //     unbounded read builds a superset and mismatches, deferring a KA that is
+      //     in fact valid. The bounded read reproduces the committed set and accepts.
+      // Acceptance stays gated on reproducing the on-chain merkle root and
+      // `verifyOnChain`, so a bounded match cannot accept a set the chain did not
+      // commit to.
+      const kaGraphBound = deriveSwmKaGraphBound(startKAId, endKAId);
+      let sharedMemoryQuads = await this.getSharedMemoryQuadsForRoots(
+        contextGraphId, msg.rootEntities, subGraphName, kaGraphBound,
+        kaGraphBound ? 'agent.finalization.sharedMemorySlice.bounded' : 'agent.finalization.sharedMemorySlice',
+      );
+      let widenedToUnbounded = false;
+      if (kaGraphBound && sharedMemoryQuads.length === 0) {
+        // Empty bounded read may be a false miss (recurrence lingers the root's
+        // quads in an older per-KA graph the bound excludes). Re-read unbounded;
+        // if that is ALSO empty we fall into today's `finalization_no_data` path
+        // with no extra `_meta` reads (privateRoots/floor stay below the guard).
+        sharedMemoryQuads = await this.getSharedMemoryQuadsForRoots(
+          contextGraphId, msg.rootEntities, subGraphName, undefined,
+          'agent.finalization.sharedMemorySlice.fallbackUnbounded',
+        );
+        widenedToUnbounded = true;
+      }
 
       if (sharedMemoryQuads.length > 0) {
         const privateRoots = await this.getPrivateRootsFromMeta(contextGraphId, msg.rootEntities, subGraphName);
         const allowGeneratedCatalogFloor = await this.allowsGeneratedCatalogFloor(contextGraphId, ctxGraphId);
-        const merkleMatchedQuads = this.sharedMemoryQuadsMatchingMerkle(
+        let merkleMatchedQuads = this.sharedMemoryQuadsMatchingMerkle(
           contextGraphId,
           sharedMemoryQuads,
           privateRoots,
           msg.kcMerkleRoot,
           allowGeneratedCatalogFloor,
         );
+
+        // A bounded read that returned data but does NOT match the on-chain merkle
+        // (recurrence spread the committed quads across sibling per-KA graphs the
+        // bound dropped) must widen and RECOMPUTE before recording a mismatch —
+        // otherwise the bound could manufacture a false `finalization_merkle_mismatch`.
+        // privateRoots/floor are quad-set-independent, so they are not recomputed.
+        if (kaGraphBound && !widenedToUnbounded && !merkleMatchedQuads) {
+          sharedMemoryQuads = await this.getSharedMemoryQuadsForRoots(
+            contextGraphId, msg.rootEntities, subGraphName, undefined,
+            'agent.finalization.sharedMemorySlice.fallbackUnbounded',
+          );
+          widenedToUnbounded = true;
+          merkleMatchedQuads = this.sharedMemoryQuadsMatchingMerkle(
+            contextGraphId,
+            sharedMemoryQuads,
+            privateRoots,
+            msg.kcMerkleRoot,
+            allowGeneratedCatalogFloor,
+          );
+        }
 
         if (merkleMatchedQuads) {
           const batchId = protoToBigInt(msg.batchId);
@@ -478,7 +563,13 @@ export class FinalizationHandler {
     }
   }
 
-  private async getSharedMemoryQuadsForRoots(contextGraphId: string, rootEntities: string[], subGraphName?: string): Promise<Quad[]> {
+  private async getSharedMemoryQuadsForRoots(
+    contextGraphId: string,
+    rootEntities: string[],
+    subGraphName?: string,
+    kaGraphBound?: SwmKaGraphBound,
+    querySource: string = 'agent.finalization.sharedMemorySlice',
+  ): Promise<Quad[]> {
     const graphManager = new GraphManager(this.store);
     const sharedMemoryGraph = subGraphName
       ? graphManager.sharedMemoryUri(contextGraphId, subGraphName)
@@ -506,8 +597,15 @@ export class FinalizationHandler {
     // fidelity for the merkle recompute, and so the same logical triple
     // present in BOTH the bucket and a per-KA graph collapses to one
     // (a constructed graph is a set).
+    // #1549: when the caller supplies a per-author `kaGraphBound` (derived from
+    // the finalization message's packed `startKAId`/`endKAId`), the resolved
+    // graph set drops sibling per-KA under-graphs outside the range instead of
+    // scanning all ~120–175 of them. The bound is FAIL-OPEN in storage and a
+    // pure accelerator here — the gossip caller widens to the unbounded read on
+    // an empty-or-mismatch result before it defers.
     return loadSelectedSharedMemoryQuads(this.store, sharedMemoryGraph, { rootEntities: safeRoots }, {
-      querySource: 'agent.finalization.sharedMemorySlice',
+      querySource,
+      kaGraphBound,
     });
   }
 

--- a/packages/agent/src/ka-identity.ts
+++ b/packages/agent/src/ka-identity.ts
@@ -12,6 +12,21 @@ export function packKnowledgeAssetIdFromIdentity(identity: KnowledgeAssetIdentit
   return (BigInt(ethers.getAddress(identity.agentAddress.toLowerCase())) << 96n) | BigInt(identity.kaNumber);
 }
 
+export interface UnpackedKnowledgeAssetId {
+  agentAddress: string;
+  kaNumber: bigint;
+}
+
+// Exact inverse of packKnowledgeAssetIdFromIdentity: high-160 bits are the agent
+// address, low-96 bits are the per-author KA number. The address is returned
+// lowercase (not checksummed), so callers MUST compare it case-insensitively.
+export function unpackKnowledgeAssetId(packed: bigint): UnpackedKnowledgeAssetId {
+  return {
+    agentAddress: `0x${(packed >> 96n).toString(16).padStart(40, '0')}`,
+    kaNumber: packed & ((1n << 96n) - 1n),
+  };
+}
+
 export async function resolveAssetUalFromKaIdentity(
   chain: AssetUalChain,
   identity: KnowledgeAssetIdentity,

--- a/packages/agent/src/swm-ka-bound.ts
+++ b/packages/agent/src/swm-ka-bound.ts
@@ -1,0 +1,35 @@
+import type { SwmKaGraphBound } from '@origintrail-official/dkg-storage';
+import { unpackKnowledgeAssetId } from './ka-identity.js';
+
+/**
+ * Derive the per-author SWM under-graph bound for the finalization gossip read
+ * from a KA batch's packed `startKAId`/`endKAId` (#1549).
+ *
+ * `startKAId`/`endKAId` are packed `(author << 96) | number` (see
+ * `packKnowledgeAssetIdFromIdentity`), whereas the SWM under-graph URI's last
+ * segment is only the low-96 per-author number. We therefore unpack both ends and
+ * bound on `(agentAddress, [startNumber, endNumber])`. A range whose two ends
+ * unpack to DIFFERENT authors is not a contiguous per-author number range — the
+ * low-96 numbers wrap independently of the high-160 address — so no single
+ * `SwmKaGraphBound` can describe it and we return `undefined` (unbounded).
+ *
+ * PURE: identical inputs always yield an identical result, so this has no home in
+ * the message handler. The ops kill-switch (`DKG_DISABLE_SWM_KA_BOUND`) is applied
+ * by the finalization orchestration before calling this, not here. Returning
+ * `undefined` is always safe: the caller widens to the unbounded read on
+ * empty-or-mismatch before it defers.
+ */
+export function deriveSwmKaGraphBound(startKAId: bigint, endKAId: bigint): SwmKaGraphBound | undefined {
+  if (startKAId <= 0n || endKAId < startKAId) return undefined;
+  const start = unpackKnowledgeAssetId(startKAId);
+  const end = unpackKnowledgeAssetId(endKAId);
+  // Both sides come from `unpack`, which is already lowercase, so a plain compare
+  // suffices here. The graph-URI side is NOT — see the case-insensitive compare in
+  // storage's bounded resolver.
+  if (start.agentAddress !== end.agentAddress) return undefined;
+  return {
+    agentAddress: start.agentAddress,
+    startNumber: start.kaNumber,
+    endNumber: end.kaNumber,
+  };
+}

--- a/packages/agent/test/swm-slice-ka-bound.test.ts
+++ b/packages/agent/test/swm-slice-ka-bound.test.ts
@@ -180,9 +180,15 @@ describe('deriveSwmKaGraphBound (T4)', () => {
     expect(deriveSwmKaGraphBound(packA(9), packA(5))).toBeUndefined();
   });
 
-  it('does NOT bound when the DKG_DISABLE_SWM_KA_BOUND kill-switch is set', () => {
+  it('is PURE — the kill-switch does not change its result', () => {
+    // The switch is read by the orchestration boundary, not the derivation, so the
+    // identity transform stays deterministic for identical inputs.
     process.env.DKG_DISABLE_SWM_KA_BOUND = '1';
-    expect(deriveSwmKaGraphBound(packA(7), packA(7))).toBeUndefined();
+    expect(deriveSwmKaGraphBound(packA(7), packA(7))).toEqual({
+      agentAddress: AUTHOR_A_LOWER,
+      startNumber: 7n,
+      endNumber: 7n,
+    });
   });
 
   it('wires a derived bound through to the SWM read (and no bound leaves it plain)', async () => {
@@ -200,6 +206,12 @@ describe('deriveSwmKaGraphBound (T4)', () => {
     const unbounded = await sliceSourcesFor(makeMsg({ startKAId: 0, endKAId: 0 }));
     expect(unbounded).not.toContain(SLICE_BOUNDED);
     expect(unbounded).toContain(SLICE);
+
+    // Kill-switch is applied at the boundary: a derivable bound is not used.
+    process.env.DKG_DISABLE_SWM_KA_BOUND = '1';
+    const killed = await sliceSourcesFor(makeMsg({ startKAId: packA(7), endKAId: packA(7) }));
+    expect(killed).not.toContain(SLICE_BOUNDED);
+    expect(killed).toContain(SLICE);
   });
 });
 
@@ -603,5 +615,71 @@ describe('same-root recurrence residue: bounded read accepts where unbounded def
     expect(logs.some((m) => m.includes('event=finalization_merkle_mismatch'))).toBe(true);
     expect(logs.some((m) => m.includes('event=finalization_applied'))).toBe(false);
     expect(sources).not.toContain(SLICE_BOUNDED);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// T8 — a real multi-KA batch range, end to end. Every other finalization case
+// uses a degenerate [n,n] bound, so an implementation that admitted only the
+// start endpoint would pass them all. Here the committed quads straddle two
+// per-KA graphs inside the range and same-root residue sits below it.
+// ─────────────────────────────────────────────────────────────────────────
+describe('multi-KA same-author batch promotes from the bounded read (T8)', () => {
+  afterEach(() => Logger.setSink(null));
+
+  it('admits both in-range KA graphs, excludes below-range residue, no widen', async () => {
+    const store = new OxigraphStore();
+    const root = 'urn:test:t8:root';
+    const residualPred = 'http://schema.org/legacyName';
+
+    // Committed content is SPLIT across kaNumbers 5 and 9 — both inside [5,9].
+    const committed: Quad[] = [
+      { subject: root, predicate: 'http://schema.org/name', object: '"Batch"', graph: '' },
+      { subject: root, predicate: 'http://schema.org/version', object: '"9"', graph: '' },
+    ];
+    await store.insert([
+      { ...committed[0], graph: swmGraph(AUTHOR_A, 5) },
+      { ...committed[1], graph: swmGraph(AUTHOR_A, 9) },
+      // Same-root residue from an older publish, BELOW the range — must be pruned.
+      { subject: root, predicate: residualPred, object: '"V0"', graph: swmGraph(AUTHOR_A, 3) },
+    ]);
+
+    const committedRoot = computeFlatKCRootV10(committed, []);
+    const startKAId = packKnowledgeAssetIdFromIdentity({ agentAddress: AUTHOR_A, kaNumber: 5 });
+    const endKAId = packKnowledgeAssetIdFromIdentity({ agentAddress: AUTHOR_A, kaNumber: 9 });
+    const msg = makeMsg({ startKAId, endKAId, kcMerkleRoot: committedRoot, rootEntities: [root] });
+
+    const logs: string[] = [];
+    Logger.setSink((r: LogRecord) => logs.push(r.message));
+    const sources = captureQuerySources(store);
+    const handler = new FinalizationHandler(
+      store,
+      makeVerifyingChain({
+        blockNumber: 100,
+        txHash: msg.txHash,
+        merkleRoot: committedRoot,
+        publisher: AUTHOR_A,
+        startKAId,
+        endKAId,
+      }),
+    );
+
+    await handler.handleFinalizationMessage(encodeFinalizationMessage(msg), CG);
+
+    // The bounded read spanned kaNumbers 5 AND 9: an endpoints-only or
+    // equality-only admission would have missed one, mismatched, and widened.
+    expect(await promotedTo(store, root)).toBe(true);
+    expect(logs.some((m) => m.includes('event=finalization_applied'))).toBe(true);
+    expect(logs.some((m) => m.includes('event=finalization_merkle_mismatch'))).toBe(false);
+
+    const sliceSources = sources.filter((s) => s.startsWith(SLICE));
+    expect(sliceSources).toContain(SLICE_BOUNDED);
+    expect(sliceSources).not.toContain(SLICE_WIDENED);
+
+    // Below-range residue never reaches canonical.
+    const residual = await store.query(
+      `ASK { GRAPH <did:dkg:context-graph:${CG}> { <${root}> <${residualPred}> ?o } }`,
+    );
+    expect(residual.type === 'boolean' && residual.value).toBe(false);
   });
 });

--- a/packages/agent/test/swm-slice-ka-bound.test.ts
+++ b/packages/agent/test/swm-slice-ka-bound.test.ts
@@ -505,3 +505,102 @@ describe('a widen that still mismatches defers exactly as today (T6c)', () => {
     expect(sliceSources.filter((s) => s === SLICE_WIDENED)).toHaveLength(1);
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────
+// T5c — the advertised defer→accept improvement, end to end.
+//
+// The SAME root has residue in an out-of-range per-KA graph (#5) that the
+// publisher never hashed; the on-chain root commits ONLY the in-range graph (#9).
+// Today's unbounded read builds a superset and defers a KA that is in fact valid.
+// The bounded read reproduces the committed set and promotes it. T5's decoy is a
+// DIFFERENT root, which the CONSTRUCT's `?s = ?root` filter drops anyway — so it
+// cannot exercise this. The kill-switch half below IS the counterfactual: it runs
+// the identical fixture on the unbounded path and must defer.
+// ─────────────────────────────────────────────────────────────────────────
+describe('same-root recurrence residue: bounded read accepts where unbounded defers (T5c)', () => {
+  afterEach(() => {
+    Logger.setSink(null);
+    delete process.env.DKG_DISABLE_SWM_KA_BOUND;
+  });
+
+  const ROOT = 'urn:test:t5c:root';
+  const RESIDUAL_PRED = 'http://schema.org/legacyName';
+
+  const committedQuads: Quad[] = [
+    { subject: ROOT, predicate: 'http://schema.org/name', object: '"V2"', graph: '' },
+    { subject: ROOT, predicate: 'http://schema.org/version', object: '"9"', graph: '' },
+  ];
+
+  async function seedRecurrence(store: OxigraphStore): Promise<void> {
+    await store.insert([
+      // Residue from an earlier publish under kaNumber 5 — NOT hashed on-chain.
+      { subject: ROOT, predicate: RESIDUAL_PRED, object: '"V1"', graph: swmGraph(AUTHOR_A, 5) },
+      ...committedQuads.map((q) => ({ ...q, graph: swmGraph(AUTHOR_A, 9) })),
+    ]);
+  }
+
+  async function runFinalization(store: OxigraphStore): Promise<{ logs: string[]; sources: string[] }> {
+    const committedRoot = computeFlatKCRootV10(committedQuads, []);
+    const packed = packKnowledgeAssetIdFromIdentity({ agentAddress: AUTHOR_A, kaNumber: 9 });
+    const msg = makeMsg({
+      startKAId: packed,
+      endKAId: packed,
+      kcMerkleRoot: committedRoot,
+      rootEntities: [ROOT],
+    });
+
+    const logs: string[] = [];
+    Logger.setSink((r: LogRecord) => logs.push(r.message));
+    const sources = captureQuerySources(store);
+    const handler = new FinalizationHandler(
+      store,
+      makeVerifyingChain({
+        blockNumber: 100,
+        txHash: msg.txHash,
+        merkleRoot: committedRoot,
+        publisher: AUTHOR_A,
+        startKAId: packed,
+        endKAId: packed,
+      }),
+    );
+    await handler.handleFinalizationMessage(encodeFinalizationMessage(msg), CG);
+    return { logs, sources: sources.filter((s) => s.startsWith(SLICE)) };
+  }
+
+  const residualPromoted = async (store: OxigraphStore): Promise<boolean> => {
+    const res = await store.query(
+      `ASK { GRAPH <did:dkg:context-graph:${CG}> { <${ROOT}> <${RESIDUAL_PRED}> ?o } }`,
+    );
+    return res.type === 'boolean' && res.value === true;
+  };
+
+  it('bounded: promotes on the first read, no widen, no mismatch, residue excluded', async () => {
+    const store = new OxigraphStore();
+    await seedRecurrence(store);
+
+    const { logs, sources } = await runFinalization(store);
+
+    expect(await promotedTo(store, ROOT)).toBe(true);
+    expect(logs.some((m) => m.includes('event=finalization_applied'))).toBe(true);
+    expect(logs.some((m) => m.includes('event=finalization_merkle_mismatch'))).toBe(false);
+    // The bounded read matched, so the widen must never have fired.
+    expect(sources).toContain(SLICE_BOUNDED);
+    expect(sources).not.toContain(SLICE_WIDENED);
+    // The out-of-range residue must not reach canonical.
+    expect(await residualPromoted(store)).toBe(false);
+  });
+
+  it('unbounded (kill-switch): the identical fixture defers on a merkle mismatch', async () => {
+    process.env.DKG_DISABLE_SWM_KA_BOUND = '1';
+    const store = new OxigraphStore();
+    await seedRecurrence(store);
+
+    const { logs, sources } = await runFinalization(store);
+
+    // This is today's behavior: the superset hashes differently, so a valid KA defers.
+    expect(await promotedTo(store, ROOT)).toBe(false);
+    expect(logs.some((m) => m.includes('event=finalization_merkle_mismatch'))).toBe(true);
+    expect(logs.some((m) => m.includes('event=finalization_applied'))).toBe(false);
+    expect(sources).not.toContain(SLICE_BOUNDED);
+  });
+});

--- a/packages/agent/test/swm-slice-ka-bound.test.ts
+++ b/packages/agent/test/swm-slice-ka-bound.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach } from 'vitest';
 import {
   OxigraphStore,
   loadSelectedSharedMemoryQuads,
-  loadKaBoundedSharedMemoryQuads,
+  loadSharedMemorySliceWithKaBoundFallback,
   type SwmKaGraphBound,
   type Quad,
 } from '@origintrail-official/dkg-storage';
@@ -17,7 +17,8 @@ import {
 } from '@origintrail-official/dkg-core';
 import type { ChainAdapter } from '@origintrail-official/dkg-chain';
 import { computeFlatKCRootV10 } from '@origintrail-official/dkg-publisher';
-import { FinalizationHandler, deriveSwmKaGraphBound } from '../src/finalization-handler.js';
+import { FinalizationHandler } from '../src/finalization-handler.js';
+import { deriveSwmKaGraphBound } from '../src/swm-ka-bound.js';
 import { packKnowledgeAssetIdFromIdentity } from '../src/ka-identity.js';
 import { ethers } from 'ethers';
 
@@ -248,7 +249,14 @@ describe('bounded SWM read is merkle-equivalent to the unbounded read (T5b)', ()
     ]);
 
     const bound: SwmKaGraphBound = { agentAddress: AUTHOR_A_LOWER, startNumber: 7n, endNumber: 7n };
-    const bounded = await loadKaBoundedSharedMemoryQuads(store, bucket, { rootEntities: [root] }, bound);
+    // Identity accept never mismatches, so the fallback returns the bounded read
+    // itself (no widen) — the agent reaches the bounded read only via the safe,
+    // fallback-owning primitive, never the raw unsafe loader.
+    const { quads: bounded } = await loadSharedMemorySliceWithKaBoundFallback(
+      store, bucket, { rootEntities: [root] }, bound,
+      { bounded: 'test.bounded', widened: 'test.widened', unbounded: 'test.unbounded' },
+      async () => (qs) => qs,
+    );
     const unbounded = await loadSelectedSharedMemoryQuads(store, bucket, { rootEntities: [root] });
 
     // Both reads must return exactly r's three quads (proves the bound did NOT

--- a/packages/agent/test/swm-slice-ka-bound.test.ts
+++ b/packages/agent/test/swm-slice-ka-bound.test.ts
@@ -1,0 +1,507 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  OxigraphStore,
+  loadSelectedSharedMemoryQuads,
+  type SwmKaGraphBound,
+  type Quad,
+} from '@origintrail-official/dkg-storage';
+import {
+  encodeFinalizationMessage,
+  contextGraphWorkspaceGraphUri,
+  contextGraphLayerUri,
+  MemoryLayer,
+  Logger,
+  type FinalizationMessageMsg,
+  type LogRecord,
+} from '@origintrail-official/dkg-core';
+import type { ChainAdapter } from '@origintrail-official/dkg-chain';
+import { computeFlatKCRootV10 } from '@origintrail-official/dkg-publisher';
+import { FinalizationHandler, deriveSwmKaGraphBound } from '../src/finalization-handler.js';
+import { packKnowledgeAssetIdFromIdentity } from '../src/ka-identity.js';
+import { ethers } from 'ethers';
+
+// #1549 SWM-slice bound (plan 2026-07-10-swm-slice-ka-bound §6, tests T4/T5/T6).
+//
+// The bound is a PURE ACCELERATOR derived from the finalization message's
+// PACKED `startKAId`/`endKAId`. The trap (§3): those are `(author << 96) |
+// number`, but the SWM under-graph URI's last segment is only the LOW-96
+// per-author number — so a bound must UNPACK before comparing, or every real
+// graph is excluded. The bound must also WIDEN to the unbounded read on
+// empty-or-mismatch before it defers. The widen is what makes correctness
+// independent of INV-1: a bounded miss re-reads exactly what today reads, so
+// nothing that today ACCEPTS can now DEFER. T6 pins the mismatch widen and T6b
+// the empty widen — each fails if its widen is removed — and T6c pins that a
+// widen which still mismatches defers exactly as today, exactly once.
+
+const CG = 'swm-bound-cg';
+// Two distinct, checksummed authors (Hardhat #0 / #1). The SWM URI segment is
+// written CHECKSUM-cased on purpose so the tests exercise the case-insensitive
+// address compare (the bound's `agentAddress` unpacks LOWERcase).
+const AUTHOR_A = ethers.getAddress('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266');
+const AUTHOR_B = ethers.getAddress('0x70997970c51812dc3a010c7d01b50e0d17dc79c8');
+const AUTHOR_A_LOWER = AUTHOR_A.toLowerCase();
+
+const SLICE = 'agent.finalization.sharedMemorySlice';
+const SLICE_BOUNDED = `${SLICE}.bounded`;
+const SLICE_WIDENED = `${SLICE}.fallbackUnbounded`;
+
+const swmGraph = (author: string, kaNumber: number): string =>
+  contextGraphLayerUri(CG, MemoryLayer.SharedWorkingMemory, author, kaNumber);
+
+const tripleKey = (q: Quad): string => `${q.subject}|${q.predicate}|${q.object}`;
+const tripleKeys = (qs: Quad[]): string[] => qs.map(tripleKey).sort();
+
+function makeMsg(overrides: Partial<FinalizationMessageMsg> = {}): FinalizationMessageMsg {
+  return {
+    ual: 'did:dkg:evm:31337/0xABC/1',
+    contextGraphId: CG,
+    kcMerkleRoot: new Uint8Array(32),
+    txHash: '0x' + 'ab'.repeat(32),
+    blockNumber: 100,
+    batchId: 1,
+    startKAId: 1,
+    endKAId: 1,
+    publisherAddress: AUTHOR_A,
+    rootEntities: ['urn:test:root'],
+    timestampMs: Date.now(),
+    operationId: 'op-swm-bound',
+    ...overrides,
+  };
+}
+
+/**
+ * Wrap `store.query` to record the `source` tag on every issued query. The
+ * SWM-slice read tags distinguish the three lanes:
+ *   - `${SLICE}`           — no bound was derived (today's unbounded read),
+ *   - `${SLICE}.bounded`   — a bound WAS derived; first read is narrowed,
+ *   - `${SLICE}.fallbackUnbounded` — the bound widened on empty-or-mismatch.
+ */
+function captureQuerySources(store: OxigraphStore): string[] {
+  const sources: string[] = [];
+  const orig = store.query.bind(store);
+  store.query = (async (sparql: string, opts?: { source?: string }) => {
+    if (opts?.source) sources.push(opts.source);
+    return (orig as (s: string, o?: unknown) => unknown)(sparql, opts);
+  }) as typeof store.query;
+  return sources;
+}
+
+/** A minimal chain whose KCCreated event verifies the given finalization. */
+function makeVerifyingChain(opts: {
+  blockNumber: number;
+  txHash: string;
+  merkleRoot: Uint8Array;
+  publisher: string;
+  startKAId: bigint;
+  endKAId: bigint;
+}): ChainAdapter {
+  return {
+    chainId: 'evm:31337',
+    isV10Ready: () => true,
+    listenForEvents: async function* (filter: { eventTypes: string[] }) {
+      if (
+        !filter.eventTypes.includes('KCCreated') &&
+        !filter.eventTypes.includes('KnowledgeBatchCreated')
+      ) {
+        return;
+      }
+      yield {
+        blockNumber: opts.blockNumber,
+        data: {
+          txHash: opts.txHash,
+          merkleRoot: ethers.hexlify(opts.merkleRoot),
+          publisherAddress: opts.publisher,
+          startKAId: opts.startKAId.toString(),
+          endKAId: opts.endKAId.toString(),
+          author: opts.publisher,
+          txIndex: 0,
+        },
+      };
+    },
+  } as unknown as ChainAdapter;
+}
+
+const promotedTo = async (store: OxigraphStore, root: string): Promise<boolean> => {
+  const res = await store.query(
+    `ASK { GRAPH <did:dkg:context-graph:${CG}> { <${root}> ?p ?o } }`,
+  );
+  return res.type === 'boolean' && res.value === true;
+};
+
+// ─────────────────────────────────────────────────────────────────────────
+// T4 — deriveSwmKaGraphBound, tested directly. Every assertion here is about
+// arithmetic on the PACKED id, so it must not be inferred from a telemetry tag.
+// The one wiring assertion (a derived bound reaches the read as `.bounded`)
+// lives in its own test at the bottom.
+// ─────────────────────────────────────────────────────────────────────────
+describe('deriveSwmKaGraphBound (T4)', () => {
+  afterEach(() => {
+    delete process.env.DKG_DISABLE_SWM_KA_BOUND;
+  });
+
+  const packA = (n: number): bigint =>
+    packKnowledgeAssetIdFromIdentity({ agentAddress: AUTHOR_A, kaNumber: n });
+
+  it('unpacks a single-KA id to a lowercase author and the LOW-96 number', () => {
+    // The trap: `packed` is (author << 96) | 7, a 256-bit value. A bound that
+    // compared the URI's low-96 `kaNumber` against `packed` would match nothing.
+    const packed = packA(7);
+    expect(packed).toBeGreaterThan(2n ** 96n);
+
+    expect(deriveSwmKaGraphBound(packed, packed)).toEqual({
+      agentAddress: AUTHOR_A_LOWER,
+      startNumber: 7n,
+      endNumber: 7n,
+    });
+  });
+
+  it('spans a same-author batch range', () => {
+    expect(deriveSwmKaGraphBound(packA(5), packA(9))).toEqual({
+      agentAddress: AUTHOR_A_LOWER,
+      startNumber: 5n,
+      endNumber: 9n,
+    });
+  });
+
+  it('does NOT bound a cross-author packed range', () => {
+    // start=(B,7) < end=(A,7) numerically, so `start <= end` holds — this
+    // exercises the AUTHOR-inequality reject, not the range reject. The low-96
+    // numbers wrap independently of the high-160 address, so no single bound
+    // can describe this range.
+    const start = packKnowledgeAssetIdFromIdentity({ agentAddress: AUTHOR_B, kaNumber: 7 });
+    const end = packKnowledgeAssetIdFromIdentity({ agentAddress: AUTHOR_A, kaNumber: 7 });
+    expect(start < end).toBe(true);
+    expect(deriveSwmKaGraphBound(start, end)).toBeUndefined();
+  });
+
+  it('does NOT bound a non-positive or inverted range', () => {
+    expect(deriveSwmKaGraphBound(0n, 0n)).toBeUndefined();
+    expect(deriveSwmKaGraphBound(packA(9), packA(5))).toBeUndefined();
+  });
+
+  it('does NOT bound when the DKG_DISABLE_SWM_KA_BOUND kill-switch is set', () => {
+    process.env.DKG_DISABLE_SWM_KA_BOUND = '1';
+    expect(deriveSwmKaGraphBound(packA(7), packA(7))).toBeUndefined();
+  });
+
+  it('wires a derived bound through to the SWM read (and no bound leaves it plain)', async () => {
+    const sliceSourcesFor = async (msg: FinalizationMessageMsg): Promise<string[]> => {
+      const store = new OxigraphStore();
+      const sources = captureQuerySources(store);
+      const handler = new FinalizationHandler(store, undefined);
+      await handler.handleFinalizationMessage(encodeFinalizationMessage(msg), CG);
+      return sources.filter((s) => s.startsWith(SLICE));
+    };
+
+    const bounded = await sliceSourcesFor(makeMsg({ startKAId: packA(7), endKAId: packA(7) }));
+    expect(bounded).toContain(SLICE_BOUNDED);
+
+    const unbounded = await sliceSourcesFor(makeMsg({ startKAId: 0, endKAId: 0 }));
+    expect(unbounded).not.toContain(SLICE_BOUNDED);
+    expect(unbounded).toContain(SLICE);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// T5b — bounded read ≡ unbounded read when INV-1 holds (all of a root's quads
+// live inside the bound). Storage-level: the bound is passed directly, so this
+// pins the graph-admission filter. A mis-derived bound (packed-vs-low96, or an
+// author-blind range) that dropped the in-range graph would make the two reads
+// diverge and fail the equal-key / equal-root assertions.
+// ─────────────────────────────────────────────────────────────────────────
+describe('bounded SWM read is merkle-equivalent to the unbounded read (T5b)', () => {
+  it('returns a key-identical quad set and an equal flat-KC root', async () => {
+    const store = new OxigraphStore();
+    const bucket = contextGraphWorkspaceGraphUri(CG);
+    const root = 'urn:test:t5b:root';
+    const genidChild = `${root}/.well-known/genid/child-1`;
+
+    const inRange = swmGraph(AUTHOR_A, 7);
+    // Decoys the bound must exclude. They carry OTHER subjects so the root
+    // filter alone can't be what excludes them — only the graph-set bound can.
+    const sameAuthorOutOfRange = swmGraph(AUTHOR_A, 12);
+    const otherAuthorInRange = swmGraph(AUTHOR_B, 7);
+    const nonLayer = `${bucket}/not-a-layer`;
+
+    await store.insert([
+      // All of root r's quads live in bucket ∪ inRange(AUTHOR_A/7).
+      { subject: root, predicate: 'http://schema.org/name', object: '"Alice"', graph: bucket },
+      { subject: root, predicate: 'http://schema.org/version', object: '"7"', graph: inRange },
+      { subject: genidChild, predicate: 'http://schema.org/value', object: '"child"', graph: inRange },
+      // Decoy sibling KAs — must appear in NEITHER read.
+      { subject: 'urn:test:t5b:sib-a', predicate: 'http://schema.org/name', object: '"Bob"', graph: sameAuthorOutOfRange },
+      { subject: 'urn:test:t5b:sib-b', predicate: 'http://schema.org/name', object: '"Carol"', graph: otherAuthorInRange },
+      { subject: 'urn:test:t5b:sib-c', predicate: 'http://schema.org/name', object: '"Dave"', graph: nonLayer },
+    ]);
+
+    const bound: SwmKaGraphBound = { agentAddress: AUTHOR_A_LOWER, startNumber: 7n, endNumber: 7n };
+    const bounded = await loadSelectedSharedMemoryQuads(store, bucket, { rootEntities: [root] }, { kaGraphBound: bound });
+    const unbounded = await loadSelectedSharedMemoryQuads(store, bucket, { rootEntities: [root] });
+
+    // Both reads must return exactly r's three quads (proves the bound did NOT
+    // drop the legitimate in-range graph, and DID drop the sibling decoys).
+    expect(new Set(tripleKeys(bounded))).toEqual(
+      new Set([
+        `${genidChild}|http://schema.org/value|"child"`,
+        `${root}|http://schema.org/name|"Alice"`,
+        `${root}|http://schema.org/version|"7"`,
+      ]),
+    );
+    expect(tripleKeys(bounded)).toEqual(tripleKeys(unbounded));
+    expect(ethers.hexlify(computeFlatKCRootV10(bounded, []))).toBe(
+      ethers.hexlify(computeFlatKCRootV10(unbounded, [])),
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// T5 (finalization path) — bounded read alone MATCHES when INV-1 holds, so the
+// KA promotes WITHOUT widening. This is the behavioural kill for the §3 trap on
+// the finalization side: a bound derived from the PACKED number (instead of the
+// low-96) would empty the read of graph #9 and force a `.fallbackUnbounded`
+// widen — which this test forbids.
+// ─────────────────────────────────────────────────────────────────────────
+describe('finalization bounded read alone promotes when INV-1 holds (T5, no widen)', () => {
+  afterEach(() => Logger.setSink(null));
+
+  it('promotes from the bounded read with no fallbackUnbounded', async () => {
+    const store = new OxigraphStore();
+    const kaNumber = 9;
+    const root = 'urn:test:t5fin:root';
+    const inBound = swmGraph(AUTHOR_A, kaNumber);
+    // A sibling decoy that the bound excludes and that is NOT needed for the match.
+    const decoy = swmGraph(AUTHOR_A, 12);
+
+    await store.insert([
+      { subject: root, predicate: 'http://schema.org/name', object: '"Current"', graph: inBound },
+      { subject: root, predicate: 'http://schema.org/version', object: '"9"', graph: inBound },
+      { subject: 'urn:test:t5fin:sib', predicate: 'http://schema.org/name', object: '"Ignore"', graph: decoy },
+    ]);
+
+    const committedRoot = computeFlatKCRootV10(
+      [
+        { subject: root, predicate: 'http://schema.org/name', object: '"Current"', graph: '' },
+        { subject: root, predicate: 'http://schema.org/version', object: '"9"', graph: '' },
+      ],
+      [],
+    );
+
+    const packed = packKnowledgeAssetIdFromIdentity({ agentAddress: AUTHOR_A, kaNumber });
+    const msg = makeMsg({
+      startKAId: packed,
+      endKAId: packed,
+      kcMerkleRoot: committedRoot,
+      rootEntities: [root],
+    });
+
+    const logs: string[] = [];
+    Logger.setSink((r: LogRecord) => logs.push(r.message));
+    const sources = captureQuerySources(store);
+    const handler = new FinalizationHandler(
+      store,
+      makeVerifyingChain({
+        blockNumber: 100,
+        txHash: msg.txHash,
+        merkleRoot: committedRoot,
+        publisher: AUTHOR_A,
+        startKAId: packed,
+        endKAId: packed,
+      }),
+    );
+
+    await handler.handleFinalizationMessage(encodeFinalizationMessage(msg), CG);
+
+    expect(await promotedTo(store, root)).toBe(true);
+    expect(logs.some((m) => m.includes('event=finalization_applied'))).toBe(true);
+    const sliceSources = sources.filter((s) => s.startsWith(SLICE));
+    expect(sliceSources).toContain(SLICE_BOUNDED);
+    // The whole point: the low-96 bound admitted graph #9, so no widen fired.
+    expect(sliceSources).not.toContain(SLICE_WIDENED);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// T6 — recurrence widen / liveness. A root recurs across per-KA graphs: its
+// committed quads span graph #5 (residual, out of bound) AND graph #9 (current,
+// in bound). The on-chain root is over bucket ∪ #5 ∪ #9. Driving finalization
+// for kaId=pack(author,9): the bounded read (#9 only) MISMATCHES, the widen
+// fires, and the KA materialises in the SAME tick with NO merkle-mismatch
+// record. A bound-WITHOUT-widen implementation would record
+// `finalization_merkle_mismatch` and never promote — so both the promoted
+// assertion and the no-mismatch assertion below would fail against it.
+// ─────────────────────────────────────────────────────────────────────────
+describe('finalization widens on recurrence mismatch and stays live (T6)', () => {
+  afterEach(() => Logger.setSink(null));
+
+  it('bounded read mismatches, widen fires, KA materialises with no mismatch record', async () => {
+    const store = new OxigraphStore();
+    const root = 'urn:test:t6:root';
+    const residual = swmGraph(AUTHOR_A, 5); // earlier publish under an older kaId — lingers
+    const current = swmGraph(AUTHOR_A, 9); // this finalization's kaId
+
+    await store.insert([
+      { subject: root, predicate: 'http://schema.org/legacyName', object: '"V1"', graph: residual },
+      { subject: root, predicate: 'http://schema.org/name', object: '"V2"', graph: current },
+      { subject: root, predicate: 'http://schema.org/version', object: '"9"', graph: current },
+    ]);
+
+    // On-chain root is committed over the UNION #5 ∪ #9 (the publisher's read is
+    // unbounded), so a tight [9,9] bounded read is a strict subset → mismatch.
+    const committedRoot = computeFlatKCRootV10(
+      [
+        { subject: root, predicate: 'http://schema.org/legacyName', object: '"V1"', graph: '' },
+        { subject: root, predicate: 'http://schema.org/name', object: '"V2"', graph: '' },
+        { subject: root, predicate: 'http://schema.org/version', object: '"9"', graph: '' },
+      ],
+      [],
+    );
+
+    const packed = packKnowledgeAssetIdFromIdentity({ agentAddress: AUTHOR_A, kaNumber: 9 });
+    const msg = makeMsg({
+      startKAId: packed,
+      endKAId: packed,
+      kcMerkleRoot: committedRoot,
+      rootEntities: [root],
+    });
+
+    const logs: string[] = [];
+    Logger.setSink((r: LogRecord) => logs.push(r.message));
+    const sources = captureQuerySources(store);
+    const handler = new FinalizationHandler(
+      store,
+      makeVerifyingChain({
+        blockNumber: 100,
+        txHash: msg.txHash,
+        merkleRoot: committedRoot,
+        publisher: AUTHOR_A,
+        startKAId: packed,
+        endKAId: packed,
+      }),
+    );
+
+    await handler.handleFinalizationMessage(encodeFinalizationMessage(msg), CG);
+
+    // Liveness: the KA materialised to VM in this same tick.
+    expect(await promotedTo(store, root)).toBe(true);
+    expect(logs.some((m) => m.includes('event=finalization_applied'))).toBe(true);
+    // No false mismatch was recorded (the widen absorbed the recurrence).
+    expect(logs.some((m) => m.includes('event=finalization_merkle_mismatch'))).toBe(false);
+
+    const sliceSources = sources.filter((s) => s.startsWith(SLICE));
+    expect(sliceSources).toContain(SLICE_BOUNDED);
+    expect(sliceSources).toContain(SLICE_WIDENED);
+  });
+});
+
+describe('finalization widens on an empty bounded read and stays live (T6b)', () => {
+  afterEach(() => Logger.setSink(null));
+
+  // The bound is derived from `unpack(kaId).agentAddress`, but the share was
+  // stored under the graph the SENDER chose. When those disagree — a remap, or a
+  // PCA publish where the operational wallet packed into `kaId` is not the graph's
+  // author — the bounded read comes back EMPTY even though the data is resident.
+  // Without the empty widen this records `finalization_no_data` and the KA never
+  // materialises, though an unbounded read would have promoted it.
+  it('empty bounded read widens, finds the out-of-range graph, and promotes', async () => {
+    const store = new OxigraphStore();
+    const root = 'urn:test:t6b:root';
+    const stored = swmGraph(AUTHOR_A, 5); // the share actually landed here
+    const quads: Quad[] = [
+      { subject: root, predicate: 'http://schema.org/name', object: '"only-copy"', graph: stored },
+      { subject: root, predicate: 'http://schema.org/version', object: '"5"', graph: stored },
+    ];
+    await store.insert(quads);
+
+    // The publisher hashed exactly these quads, so the unbounded read MATCHES.
+    const committedRoot = computeFlatKCRootV10(
+      quads.map((q) => ({ ...q, graph: '' })),
+      [],
+    );
+
+    // ...but finalization arrives keyed to kaNumber 9, so the bound is [9,9] and
+    // excludes the only graph holding the root.
+    const packed = packKnowledgeAssetIdFromIdentity({ agentAddress: AUTHOR_A, kaNumber: 9 });
+    const msg = makeMsg({
+      startKAId: packed,
+      endKAId: packed,
+      kcMerkleRoot: committedRoot,
+      rootEntities: [root],
+    });
+
+    const logs: string[] = [];
+    Logger.setSink((r: LogRecord) => logs.push(r.message));
+    const sources = captureQuerySources(store);
+    const handler = new FinalizationHandler(
+      store,
+      makeVerifyingChain({
+        blockNumber: 100,
+        txHash: msg.txHash,
+        merkleRoot: committedRoot,
+        publisher: AUTHOR_A,
+        startKAId: packed,
+        endKAId: packed,
+      }),
+    );
+
+    await handler.handleFinalizationMessage(encodeFinalizationMessage(msg), CG);
+
+    expect(await promotedTo(store, root)).toBe(true);
+    expect(logs.some((m) => m.includes('event=finalization_applied'))).toBe(true);
+    // The empty bounded read must NOT be reported as "no data".
+    expect(logs.some((m) => m.includes('event=finalization_no_data'))).toBe(false);
+
+    const sliceSources = sources.filter((s) => s.startsWith(SLICE));
+    expect(sliceSources).toContain(SLICE_BOUNDED);
+    expect(sliceSources).toContain(SLICE_WIDENED);
+  });
+});
+
+describe('a widen that still mismatches defers exactly as today (T6c)', () => {
+  afterEach(() => Logger.setSink(null));
+
+  // The bound must not change the mismatch outcome, only reach it later. This also
+  // pins that the widen fires at most ONCE: the empty-widen and the mismatch-widen
+  // are mutually exclusive via `widenedToUnbounded`.
+  it('records finalization_merkle_mismatch, does not promote, and widens exactly once', async () => {
+    const store = new OxigraphStore();
+    const root = 'urn:test:t6c:root';
+    await store.insert([
+      { subject: root, predicate: 'http://schema.org/name', object: '"data"', graph: swmGraph(AUTHOR_A, 9) },
+    ]);
+
+    // A root the resident quads cannot hash to, so bounded AND unbounded both miss.
+    const wrongRoot = new Uint8Array(32).fill(7);
+    const packed = packKnowledgeAssetIdFromIdentity({ agentAddress: AUTHOR_A, kaNumber: 9 });
+    const msg = makeMsg({
+      startKAId: packed,
+      endKAId: packed,
+      kcMerkleRoot: wrongRoot,
+      rootEntities: [root],
+    });
+
+    const logs: string[] = [];
+    Logger.setSink((r: LogRecord) => logs.push(r.message));
+    const sources = captureQuerySources(store);
+    const handler = new FinalizationHandler(
+      store,
+      makeVerifyingChain({
+        blockNumber: 100,
+        txHash: msg.txHash,
+        merkleRoot: wrongRoot,
+        publisher: AUTHOR_A,
+        startKAId: packed,
+        endKAId: packed,
+      }),
+    );
+
+    await handler.handleFinalizationMessage(encodeFinalizationMessage(msg), CG);
+
+    expect(await promotedTo(store, root)).toBe(false);
+    expect(logs.some((m) => m.includes('event=finalization_merkle_mismatch'))).toBe(true);
+    expect(logs.some((m) => m.includes('event=finalization_applied'))).toBe(false);
+    // Bounded read, then exactly one widen — never two.
+    const sliceSources = sources.filter((s) => s.startsWith(SLICE));
+    expect(sliceSources).toContain(SLICE_BOUNDED);
+    expect(sliceSources.filter((s) => s === SLICE_WIDENED)).toHaveLength(1);
+  });
+});

--- a/packages/agent/test/swm-slice-ka-bound.test.ts
+++ b/packages/agent/test/swm-slice-ka-bound.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, afterEach } from 'vitest';
 import {
   OxigraphStore,
   loadSelectedSharedMemoryQuads,
+  loadKaBoundedSharedMemoryQuads,
   type SwmKaGraphBound,
   type Quad,
 } from '@origintrail-official/dkg-storage';
@@ -235,7 +236,7 @@ describe('bounded SWM read is merkle-equivalent to the unbounded read (T5b)', ()
     ]);
 
     const bound: SwmKaGraphBound = { agentAddress: AUTHOR_A_LOWER, startNumber: 7n, endNumber: 7n };
-    const bounded = await loadSelectedSharedMemoryQuads(store, bucket, { rootEntities: [root] }, { kaGraphBound: bound });
+    const bounded = await loadKaBoundedSharedMemoryQuads(store, bucket, { rootEntities: [root] }, bound);
     const unbounded = await loadSelectedSharedMemoryQuads(store, bucket, { rootEntities: [root] });
 
     // Both reads must return exactly r's three quads (proves the bound did NOT

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -44,6 +44,7 @@ export default defineConfig({
       "test/chain-cursor-wiring.test.ts",
       "test/chain-reconciler.test.ts",
       "test/finalization-lifecycle-logger.test.ts",
+      "test/swm-slice-ka-bound.test.ts",
       "test/ka-lifecycle-asset-ual-timeout.test.ts",
       "test/storage-ack-lifecycle-identity.test.ts",
       "test/v10-ack-provider-wiring.test.ts",

--- a/packages/publisher/test/swm-slice-ack-unbounded.test.ts
+++ b/packages/publisher/test/swm-slice-ack-unbounded.test.ts
@@ -51,14 +51,25 @@ const SWM_GRAPH_URI = `did:dkg:context-graph:${CONTEXT_GRAPH_ID}/_shared_memory`
 const coreWallet = ethers.Wallet.createRandom();
 const fakePeerId = { toString: () => 'requester-peer' } as any;
 
-const q = (subject: string, predicate: string, object: string): Quad =>
-  ({ subject, predicate, object, graph: SWM_GRAPH_URI });
+// Two DIFFERENT authors, so no single `SwmKaGraphBound` (which pins one author and
+// a kaNumber range) can admit both child graphs.
+const AUTHOR_A = '0xAbCdEf0123456789AbCdEf0123456789AbCdEf01';
+const AUTHOR_B = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const CHILD_A = `${SWM_GRAPH_URI}/${AUTHOR_A}/7`;
+const CHILD_B = `${SWM_GRAPH_URI}/${AUTHOR_B}/9`;
 
-// A small author payload seeded directly into the SWM bucket graph.
+const q = (subject: string, predicate: string, object: string, graph = SWM_GRAPH_URI): Quad =>
+  ({ subject, predicate, object, graph });
+
+// The author payload is deliberately SPREAD across the bucket and two per-KA child
+// graphs under different authors. The bucket is always retained even by a bounded
+// read, so a fixture living only in the bucket could not detect an accidental
+// `kaGraphBound` on the ACK path. With this layout ANY bound prunes at least one
+// child, changes the recomputed root, and turns the ACK into a decline.
 const authorQuads: Quad[] = [
   q('urn:entity:1', 'http://schema.org/name', '"Entity One"'),
-  q('urn:entity:1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://schema.org/Thing'),
-  q('urn:entity:2', 'http://schema.org/name', '"Entity Two"'),
+  q('urn:entity:1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://schema.org/Thing', CHILD_A),
+  q('urn:entity:2', 'http://schema.org/name', '"Entity Two"', CHILD_B),
 ];
 const authorRoot = computeFlatKCRoot(authorQuads, []);
 const authorLeafCount = computeFlatKCMerkleLeafCountV10(authorQuads, []);
@@ -67,6 +78,8 @@ interface SpyHandle {
   handler: StorageACKHandler;
   /** `source` recorded for every `store.query` the handler issues, in order. */
   querySources: (string | undefined)[];
+  /** Full SPARQL text of every `store.query`, in order. */
+  querySparqls: string[];
 }
 
 // Real OxigraphStore (genuine merkle recompute) behind a Proxy that records the
@@ -78,11 +91,13 @@ async function makeHandler(seedQuads: Quad[]): Promise<SpyHandle> {
   if (seedQuads.length > 0) await inner.insert(seedQuads);
 
   const querySources: (string | undefined)[] = [];
+  const querySparqls: string[] = [];
   const store = new Proxy(inner, {
     get(target, prop, receiver) {
       if (prop === 'query') {
         return (sparql: string, options?: QueryOptions): Promise<QueryResult> => {
           querySources.push(options?.source);
+          querySparqls.push(sparql);
           return target.query(sparql, options);
         };
       }
@@ -104,7 +119,22 @@ async function makeHandler(seedQuads: Quad[]): Promise<SpyHandle> {
   return {
     handler: new StorageACKHandler(store as any, config, eventBus as any),
     querySources,
+    querySparqls,
   };
+}
+
+/**
+ * The ACK read must resolve the COMPLETE SWM graph set. Any `kaGraphBound` would
+ * prune at least one of the two per-KA children (they sit under different authors),
+ * so asserting both appear in the CONSTRUCT's `VALUES ?g` pins graph-set breadth
+ * directly, independently of the recomputed root.
+ */
+function expectFullGraphSet(querySparqls: string[]): void {
+  const construct = querySparqls.find((s) => s.includes('CONSTRUCT'));
+  expect(construct, 'no CONSTRUCT was issued').toBeDefined();
+  expect(construct).toContain(`<${CHILD_A}>`);
+  expect(construct).toContain(`<${CHILD_B}>`);
+  expect(construct).toContain(`<${SWM_GRAPH_URI}>`);
 }
 
 // SWM-fallback publish intent: NO stagingQuads → the handler recomputes the root
@@ -142,7 +172,7 @@ function ackRootHex(ack: { merkleRoot: Uint8Array | ArrayLike<number> }): string
 
 describe('T7 — storage-ACK SWM read lane is off the #1549 bound path', () => {
   it('per-root-entity read carries the unbounded storage-ack.loadSWMQuads.constructEntity source', async () => {
-    const { handler, querySources } = await makeHandler(authorQuads);
+    const { handler, querySources, querySparqls } = await makeHandler(authorQuads);
 
     const response = await handler.handler(
       swmFallbackIntent({ rootEntities: ['urn:entity:1', 'urn:entity:2'] }),
@@ -151,17 +181,19 @@ describe('T7 — storage-ACK SWM read lane is off the #1549 bound path', () => {
     const ack = decodeStorageACK(response);
 
     expect(isStorageACKDecline(ack)).toBe(false);
-    // Byte-identical read: the signed root equals the root over the EXACT seeded
-    // quads, i.e. the read returned the whole bucket — no graph-set narrowing.
+    // The signed root equals the root over the EXACT seeded quads, which are spread
+    // across the bucket AND two per-KA children under different authors. Any bound
+    // would prune a child, change this root, and turn the ACK into a decline.
     expect(ackRootHex(ack as any)).toBe(ethers.hexlify(authorRoot));
 
     const swmReads = querySources.filter((s) => s?.startsWith('storage-ack.loadSWMQuads.'));
     expect(swmReads).toEqual(['storage-ack.loadSWMQuads.constructEntity']);
     expectNoBoundLane(querySources);
+    expectFullGraphSet(querySparqls);
   });
 
   it('read-both (empty rootEntities) carries the unbounded storage-ack.loadSWMQuads.constructAll source', async () => {
-    const { handler, querySources } = await makeHandler(authorQuads);
+    const { handler, querySources, querySparqls } = await makeHandler(authorQuads);
 
     const response = await handler.handler(
       swmFallbackIntent({ rootEntities: [] }),

--- a/packages/publisher/test/swm-slice-ack-unbounded.test.ts
+++ b/packages/publisher/test/swm-slice-ack-unbounded.test.ts
@@ -1,0 +1,220 @@
+// T7 (#1549 SWM-slice bound) — the storage-ACK responder read lane is OFF the
+// bound path.
+//
+// The finalization gossip lane (packages/agent) accelerates its SWM slice with a
+// per-KA `SwmKaGraphBound` and, because that narrowing can under-read under root
+// recurrence, tags its reads `agent.finalization.sharedMemorySlice.bounded` /
+// `…​.fallbackUnbounded` so the canary can watch the widen ratio. The ACK
+// responder deliberately does NOT bound: a regular `PublishIntent` carries no
+// kaId, and MERKLE_MISMATCH_IN_SWM here is a lost-ACK decline (a bounded
+// under-read would silently drop a publish-quorum vote). storage-ack-handler.ts
+// is therefore left byte-for-byte unchanged by that work, and its SWM read must
+// keep flowing through `loadSelectedSharedMemoryQuads` with NO `kaGraphBound`
+// and the plain `storage-ack.loadSWMQuads.construct{Entity,All}` source.
+//
+// These tests drive the real responder entry point on the SWM-fallback path (a
+// PublishIntent with no stagingQuads → `loadSWMOrDecline` → `loadSWMQuads`,
+// storage-ack-handler.ts:1214/1795) against a real OxigraphStore wrapped in a
+// query-source spy, and pin: (1) the read source is exactly the unbounded ACK
+// tag — never a `.bounded` / `.fallbackUnbounded` suffix, never the finalization
+// lane; (2) the signed ACK's root equals the root over the exact seeded quads
+// (byte-identical read — the graph-set narrowing never ran); (3) the existing
+// MERKLE_MISMATCH_IN_SWM and NO_DATA_IN_SWM declines are unchanged and still
+// read on the unbounded ACK source.
+
+import { describe, it, expect } from 'vitest';
+import { ethers } from 'ethers';
+import {
+  OxigraphStore,
+  type Quad,
+  type QueryOptions,
+  type QueryResult,
+  type TripleStore,
+} from '@origintrail-official/dkg-storage';
+import {
+  encodePublishIntent,
+  decodeStorageACK,
+  isStorageACKDecline,
+  STORAGE_ACK_DECLINE_CODES,
+} from '@origintrail-official/dkg-core';
+import {
+  computeFlatKCRootV10 as computeFlatKCRoot,
+  computeFlatKCMerkleLeafCountV10,
+} from '../src/merkle.js';
+import { StorageACKHandler, type StorageACKHandlerConfig } from '../src/storage-ack-handler.js';
+
+const TEST_CHAIN_ID = 31337n;
+const TEST_KAV10_ADDR = '0x000000000000000000000000000000000000c10a';
+const CONTEXT_GRAPH_ID = '42';
+const SWM_GRAPH_URI = `did:dkg:context-graph:${CONTEXT_GRAPH_ID}/_shared_memory`;
+
+const coreWallet = ethers.Wallet.createRandom();
+const fakePeerId = { toString: () => 'requester-peer' } as any;
+
+const q = (subject: string, predicate: string, object: string): Quad =>
+  ({ subject, predicate, object, graph: SWM_GRAPH_URI });
+
+// A small author payload seeded directly into the SWM bucket graph.
+const authorQuads: Quad[] = [
+  q('urn:entity:1', 'http://schema.org/name', '"Entity One"'),
+  q('urn:entity:1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://schema.org/Thing'),
+  q('urn:entity:2', 'http://schema.org/name', '"Entity Two"'),
+];
+const authorRoot = computeFlatKCRoot(authorQuads, []);
+const authorLeafCount = computeFlatKCMerkleLeafCountV10(authorQuads, []);
+
+interface SpyHandle {
+  handler: StorageACKHandler;
+  /** `source` recorded for every `store.query` the handler issues, in order. */
+  querySources: (string | undefined)[];
+}
+
+// Real OxigraphStore (genuine merkle recompute) behind a Proxy that records the
+// `source` on every CONSTRUCT read. The SWM graph-set resolution goes through
+// `listGraphs` (OxigraphStore has no `listGraphsByPrefix`), so the ONLY
+// `store.query` on this path is the slice CONSTRUCT — exactly the read we pin.
+async function makeHandler(seedQuads: Quad[]): Promise<SpyHandle> {
+  const inner = new OxigraphStore();
+  if (seedQuads.length > 0) await inner.insert(seedQuads);
+
+  const querySources: (string | undefined)[] = [];
+  const store = new Proxy(inner, {
+    get(target, prop, receiver) {
+      if (prop === 'query') {
+        return (sparql: string, options?: QueryOptions): Promise<QueryResult> => {
+          querySources.push(options?.source);
+          return target.query(sparql, options);
+        };
+      }
+      const value = Reflect.get(target, prop, receiver);
+      return typeof value === 'function' ? value.bind(target) : value;
+    },
+  }) as unknown as TripleStore;
+
+  const config: StorageACKHandlerConfig = {
+    nodeRole: 'core',
+    nodeIdentityId: 42n,
+    signerWallet: coreWallet,
+    contextGraphSharedMemoryUri: (cgId: string) =>
+      `did:dkg:context-graph:${cgId}/_shared_memory`,
+    chainId: TEST_CHAIN_ID,
+    kav10Address: TEST_KAV10_ADDR,
+  };
+  const eventBus = { emit: () => {}, on: () => {}, off: () => {}, once: () => {} };
+  return {
+    handler: new StorageACKHandler(store as any, config, eventBus as any),
+    querySources,
+  };
+}
+
+// SWM-fallback publish intent: NO stagingQuads → the handler recomputes the root
+// from its own SWM copy via `loadSWMQuads` (the read under test).
+function swmFallbackIntent(overrides: Record<string, unknown> = {}): Uint8Array {
+  return encodePublishIntent({
+    merkleRoot: authorRoot,
+    contextGraphId: CONTEXT_GRAPH_ID,
+    publisherPeerId: 'pub-0',
+    publicByteSize: 4096,
+    isPrivate: false,
+    kaCount: 1,
+    rootEntities: ['urn:entity:1', 'urn:entity:2'],
+    merkleLeafCount: authorLeafCount,
+    ...overrides,
+  });
+}
+
+// The bound path is observable ONLY through the read source: the ACK responder
+// must never carry the finalization lane's `.bounded` / `.fallbackUnbounded`
+// suffix, nor borrow the `agent.finalization.*` source at all.
+function expectNoBoundLane(querySources: (string | undefined)[]): void {
+  expect(
+    querySources.some((s) => s?.endsWith('.bounded') || s?.endsWith('.fallbackUnbounded')),
+  ).toBe(false);
+  expect(querySources.some((s) => s?.startsWith('agent.finalization.'))).toBe(false);
+}
+
+function ackRootHex(ack: { merkleRoot: Uint8Array | ArrayLike<number> }): string {
+  const root = ack.merkleRoot instanceof Uint8Array
+    ? ack.merkleRoot
+    : new Uint8Array(ack.merkleRoot);
+  return ethers.hexlify(root);
+}
+
+describe('T7 — storage-ACK SWM read lane is off the #1549 bound path', () => {
+  it('per-root-entity read carries the unbounded storage-ack.loadSWMQuads.constructEntity source', async () => {
+    const { handler, querySources } = await makeHandler(authorQuads);
+
+    const response = await handler.handler(
+      swmFallbackIntent({ rootEntities: ['urn:entity:1', 'urn:entity:2'] }),
+      fakePeerId,
+    );
+    const ack = decodeStorageACK(response);
+
+    expect(isStorageACKDecline(ack)).toBe(false);
+    // Byte-identical read: the signed root equals the root over the EXACT seeded
+    // quads, i.e. the read returned the whole bucket — no graph-set narrowing.
+    expect(ackRootHex(ack as any)).toBe(ethers.hexlify(authorRoot));
+
+    const swmReads = querySources.filter((s) => s?.startsWith('storage-ack.loadSWMQuads.'));
+    expect(swmReads).toEqual(['storage-ack.loadSWMQuads.constructEntity']);
+    expectNoBoundLane(querySources);
+  });
+
+  it('read-both (empty rootEntities) carries the unbounded storage-ack.loadSWMQuads.constructAll source', async () => {
+    const { handler, querySources } = await makeHandler(authorQuads);
+
+    const response = await handler.handler(
+      swmFallbackIntent({ rootEntities: [] }),
+      fakePeerId,
+    );
+    const ack = decodeStorageACK(response);
+
+    expect(isStorageACKDecline(ack)).toBe(false);
+    expect(ackRootHex(ack as any)).toBe(ethers.hexlify(authorRoot));
+
+    const swmReads = querySources.filter((s) => s?.startsWith('storage-ack.loadSWMQuads.'));
+    expect(swmReads).toEqual(['storage-ack.loadSWMQuads.constructAll']);
+    expectNoBoundLane(querySources);
+  });
+
+  it('MERKLE_MISMATCH_IN_SWM decline is unchanged and still reads on the unbounded ACK source', async () => {
+    const { handler, querySources } = await makeHandler(authorQuads);
+
+    // Claim a root the core's SWM copy cannot reproduce (the 2026-07-07 incident
+    // shape) — the recompute over the seeded quads differs → decline.
+    const wrongRoot = computeFlatKCRoot(
+      [q('urn:entity:1', 'http://schema.org/name', '"Different"')],
+      [],
+    );
+    const response = await handler.handler(
+      swmFallbackIntent({ merkleRoot: wrongRoot, rootEntities: ['urn:entity:1', 'urn:entity:2'] }),
+      fakePeerId,
+    );
+    const ack = decodeStorageACK(response);
+
+    expect(isStorageACKDecline(ack)).toBe(true);
+    expect((ack as any).declineCode).toBe(STORAGE_ACK_DECLINE_CODES.MERKLE_MISMATCH_IN_SWM);
+
+    const swmReads = querySources.filter((s) => s?.startsWith('storage-ack.loadSWMQuads.'));
+    expect(swmReads).toEqual(['storage-ack.loadSWMQuads.constructEntity']);
+    expectNoBoundLane(querySources);
+  });
+
+  it('NO_DATA_IN_SWM decline is unchanged and still reads on the unbounded ACK source', async () => {
+    // Empty store — the bucket graph is still resolved and read, returns nothing.
+    const { handler, querySources } = await makeHandler([]);
+
+    const response = await handler.handler(
+      swmFallbackIntent({ rootEntities: ['urn:entity:1'] }),
+      fakePeerId,
+    );
+    const ack = decodeStorageACK(response);
+
+    expect(isStorageACKDecline(ack)).toBe(true);
+    expect((ack as any).declineCode).toBe(STORAGE_ACK_DECLINE_CODES.NO_DATA_IN_SWM);
+
+    const swmReads = querySources.filter((s) => s?.startsWith('storage-ack.loadSWMQuads.'));
+    expect(swmReads).toEqual(['storage-ack.loadSWMQuads.constructEntity']);
+    expectNoBoundLane(querySources);
+  });
+});

--- a/packages/publisher/vitest.unit.config.ts
+++ b/packages/publisher/vitest.unit.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
       'test/ack-collector.test.ts',
       'test/publish-lifecycle-logger.test.ts',
       'test/storage-ack-handler.test.ts',
+      'test/swm-slice-ack-unbounded.test.ts',
     ],
     testTimeout: 60_000,
     maxWorkers: 1,

--- a/packages/storage/src/graph-manager.ts
+++ b/packages/storage/src/graph-manager.ts
@@ -86,7 +86,6 @@ export interface LoadSelectedSharedMemoryQuadsOptions {
   querySource?: QueryOptions['source'];
   queryOptions?: QueryOptions;
   quadFilter?: (quad: Quad) => boolean;
-  kaGraphBound?: SwmKaGraphBound;
   rootEntitiesErrorMessage?: (input: {
     inputCount: number;
     hadInput: boolean;
@@ -150,10 +149,17 @@ async function listGraphsByPrefix(
  *
  * `bound` (optional) narrows the under-graph set to a single author + kaNumber
  * range — see `SwmKaGraphBound`. It is FAIL-OPEN: an under-graph is dropped
- * ONLY when it parses as a per-KA layer URI AND its author/kaNumber falls
- * outside the bound. A graph that does not parse (blob/`_meta`/snapshot or any
- * future shape) is KEPT, so a bound can never silently under-read a graph it
+ * ONLY when it parses as a per-KA child of THIS bucket AND its author/kaNumber
+ * falls outside the bound. A graph that does not parse (blob/`_meta`/snapshot or
+ * any future shape) is KEPT, so a bound can never silently under-read a graph it
  * does not understand. The bucket graph is always part of the read contract.
+ *
+ * Passing a `bound` still yields a STRICT SUBSET of the full read set, and INV-1
+ * is refuted under root recurrence, so a bounded resolution can legitimately omit
+ * graphs the on-chain merkle root commits to. Anything that hashes or declines on
+ * the result must widen to the unbounded resolution first — the same contract
+ * `loadKaBoundedSharedMemoryQuads` documents. Do not reach for this to "just make
+ * the read cheaper" on a merkle-defining or ACK path.
  */
 export async function resolveSharedMemoryReadGraphs(
   store: TripleStore,
@@ -192,12 +198,55 @@ export async function resolveSharedMemoryReadGraphs(
  * `resolveSharedMemoryReadGraphs`. This keeps merkle-sensitive SWM selection
  * policy in one place while allowing call sites to inject their small
  * differences, such as query source tags or post-query bookkeeping filters.
+ *
+ * This function reads the COMPLETE SWM graph set and is safe to use anywhere,
+ * including the merkle-DEFINING publish reads and the StorageACK decline lanes.
+ * There is deliberately no way to prune the graph set from here — see
+ * `loadKaBoundedSharedMemoryQuads` for that, and read its contract first.
  */
 export async function loadSelectedSharedMemoryQuads(
   store: TripleStore,
   bucketGraph: string,
   selection: SharedMemoryReadSelection,
   options: LoadSelectedSharedMemoryQuadsOptions = {},
+): Promise<Quad[]> {
+  return loadSharedMemoryQuadsInternal(store, bucketGraph, selection, options, undefined);
+}
+
+/**
+ * Load the SWM quad slice pruned to ONE author's per-KA under-graphs (#1549).
+ *
+ * UNSAFE ON ITS OWN. The pruned graph set is a strict subset of the set
+ * `loadSelectedSharedMemoryQuads` reads, and INV-1 — "a root's quads live only
+ * under its own KA number" — is REFUTED under root recurrence, so this read can
+ * legitimately miss quads the on-chain merkle root commits to. Every caller MUST
+ * widen to `loadSelectedSharedMemoryQuads` on an empty-or-mismatched result and
+ * recompute BEFORE it declines, defers, or otherwise acts on the miss.
+ *
+ * Never call this from a merkle-DEFINING read (it would change what the chain
+ * commits to) or from a StorageACK decline lane (a miss costs a publish-quorum
+ * vote). Today the only caller is the finalization gossip lane, via
+ * `FinalizationHandler.loadSwmSliceWithFallback`, which owns the widen.
+ *
+ * The bound is a required positional argument, not an option, so that no generic
+ * SWM read can opt into pruning by adding a field to an options object.
+ */
+export async function loadKaBoundedSharedMemoryQuads(
+  store: TripleStore,
+  bucketGraph: string,
+  selection: SharedMemoryReadSelection,
+  kaGraphBound: SwmKaGraphBound,
+  options: LoadSelectedSharedMemoryQuadsOptions = {},
+): Promise<Quad[]> {
+  return loadSharedMemoryQuadsInternal(store, bucketGraph, selection, options, kaGraphBound);
+}
+
+async function loadSharedMemoryQuadsInternal(
+  store: TripleStore,
+  bucketGraph: string,
+  selection: SharedMemoryReadSelection,
+  options: LoadSelectedSharedMemoryQuadsOptions,
+  kaGraphBound: SwmKaGraphBound | undefined,
 ): Promise<Quad[]> {
   let innerGraphPattern: string;
   if (selection === 'all') {
@@ -230,7 +279,7 @@ export async function loadSelectedSharedMemoryQuads(
   }
 
   const queryOptions = mergeQueryOptions(options.queryOptions, options.querySource);
-  const swmGraphs = await resolveSharedMemoryReadGraphs(store, bucketGraph, queryOptions, options.kaGraphBound);
+  const swmGraphs = await resolveSharedMemoryReadGraphs(store, bucketGraph, queryOptions, kaGraphBound);
   const graphValues = swmGraphs.map((g) => `<${g}>`).join(' ');
   const result = await store.query(`CONSTRUCT { ?s ?p ?o } WHERE {
         VALUES ?g { ${graphValues} }

--- a/packages/storage/src/graph-manager.ts
+++ b/packages/storage/src/graph-manager.ts
@@ -236,20 +236,14 @@ export async function loadSelectedSharedMemoryQuads(
 /**
  * Load the SWM quad slice pruned to ONE author's per-KA under-graphs (#1549).
  *
- * UNSAFE ON ITS OWN. The pruned graph set is a strict subset of the set
- * `loadSelectedSharedMemoryQuads` reads, and INV-1 — "a root's quads live only
- * under its own KA number" — is REFUTED under root recurrence, so this read can
- * legitimately miss quads the on-chain merkle root commits to. Every caller MUST
- * widen to `loadSelectedSharedMemoryQuads` on an empty-or-mismatched result and
- * recompute BEFORE it declines, defers, or otherwise acts on the miss.
- *
- * Never call this from a merkle-DEFINING read (it would change what the chain
- * commits to) or from a StorageACK decline lane (a miss costs a publish-quorum
- * vote). Today the only caller is the finalization gossip lane, via
- * `FinalizationHandler.loadSwmSliceWithFallback`, which owns the widen.
- *
- * The bound is a required positional argument, not an option, so that no generic
- * SWM read can opt into pruning by adding a field to an options object.
+ * UNSAFE ON ITS OWN, and deliberately NOT re-exported from `src/index.ts`. The
+ * pruned graph set is a strict subset of the set `loadSelectedSharedMemoryQuads`
+ * reads, and INV-1 — "a root's quads live only under its own KA number" — is
+ * REFUTED under root recurrence, so this read can legitimately miss quads the
+ * on-chain merkle root commits to. The only safe caller is
+ * `loadSharedMemorySliceWithKaBoundFallback`, which owns the widen; this is a
+ * module-internal primitive it builds on, kept exported only so the graph-set
+ * behaviour can be unit-tested directly.
  */
 export async function loadKaBoundedSharedMemoryQuads(
   store: TripleStore,
@@ -259,6 +253,66 @@ export async function loadKaBoundedSharedMemoryQuads(
   options: LoadSelectedSharedMemoryQuadsOptions = {},
 ): Promise<Quad[]> {
   return loadSharedMemoryQuadsInternal(store, bucketGraph, selection, options, kaGraphBound);
+}
+
+/** Query-source tags for the three read lanes a bounded slice can take. */
+export interface SwmSliceSourceTags {
+  /** the initial narrowed read, when a bound is supplied */
+  bounded: QueryOptions['source'];
+  /** an unbounded re-read after an empty or mismatched bounded read */
+  widened: QueryOptions['source'];
+  /** the initial read when no bound is supplied */
+  unbounded: QueryOptions['source'];
+}
+
+/**
+ * The ONLY safe way to read a KA-bounded SWM slice: read bounded first, then WIDEN
+ * to the complete read on an empty-or-mismatched result before returning (#1549).
+ * This owns the two-step protocol that `loadKaBoundedSharedMemoryQuads` requires,
+ * so callers cannot hold a pruned `Quad[]` without the widen.
+ *
+ * `accept` is the caller's completeness predicate — e.g. a merkle recompute — that
+ * returns the accepted quads or `null` on mismatch. It decides both when a bounded
+ * read is "good enough" and what the caller ultimately consumes; storage stays
+ * agnostic to merkle. It is built lazily via `createAccept` and invoked at most
+ * once (only when there are quads), so a genuine no-data read triggers no extra
+ * caller-side work. The widen fires at most once.
+ *
+ * With no bound this is a single complete read (safe by construction). With a
+ * bound the result is exactly what the unbounded read would have produced on any
+ * input — never accept→defer, sometimes defer→accept under recurrence.
+ */
+export async function loadSharedMemorySliceWithKaBoundFallback(
+  store: TripleStore,
+  bucketGraph: string,
+  selection: SharedMemoryReadSelection,
+  kaGraphBound: SwmKaGraphBound | undefined,
+  sources: SwmSliceSourceTags,
+  createAccept: () => Promise<(quads: Quad[]) => Quad[] | null>,
+): Promise<{ quads: Quad[]; accepted: Quad[] | null }> {
+  const readComplete = (source: QueryOptions['source']): Promise<Quad[]> =>
+    loadSelectedSharedMemoryQuads(store, bucketGraph, selection, { querySource: source });
+
+  let quads = kaGraphBound
+    ? await loadKaBoundedSharedMemoryQuads(store, bucketGraph, selection, kaGraphBound, {
+        querySource: sources.bounded,
+      })
+    : await readComplete(sources.unbounded);
+  let widened = false;
+
+  if (kaGraphBound && quads.length === 0) {
+    quads = await readComplete(sources.widened);
+    widened = true;
+  }
+  if (quads.length === 0) return { quads, accepted: null };
+
+  const accept = await createAccept();
+  let accepted = accept(quads);
+  if (kaGraphBound && !widened && !accepted) {
+    quads = await readComplete(sources.widened);
+    accepted = accept(quads);
+  }
+  return { quads, accepted };
 }
 
 async function loadSharedMemoryQuadsInternal(

--- a/packages/storage/src/graph-manager.ts
+++ b/packages/storage/src/graph-manager.ts
@@ -12,8 +12,6 @@ import {
   contextGraphSubGraphMetaUri,
   contextGraphSubGraphPrivateUri,
   contextGraphCatalogUri,
-  parseContextGraphLayerUri,
-  MemoryLayer,
   isSafeIri,
   assertSafeIri,
   sparqlString,
@@ -49,37 +47,37 @@ export interface SwmKaGraphBound {
   endNumber: bigint;
 }
 
+const SWM_CHILD_AGENT_ADDRESS = /^0x[0-9a-fA-F]{40}$/;
+const SWM_CHILD_KA_NUMBER = /^\d+$/;
+
 /**
  * Identify `graph` as a per-KA child of THIS shared-memory `bucketGraph`, or
  * return undefined so the caller keeps it (fail-open).
  *
- * `parseContextGraphLayerUri` alone is too permissive to gate an exclusion on:
- * it recognises every memory layer, and a child such as
- * `…/_shared_memory/_verifiable_memory/{addr}/{n}` parses as a 5-segment
- * VERIFIABLE-memory URI whose `subGraphName` happens to be `_shared_memory`.
- * Gating on the raw parse would let that shape — and any future under-bucket
- * shape that merely resembles a layer URI — be pruned by a bound meant only for
- * `<bucket>/{addr}/{n}`. So require the parsed layer to be shared-memory AND its
- * `(contextGraphId, subGraphName)` to reconstruct to exactly the bucket we are
- * reading. Anything else stays in the read set.
- *
- * The reconstruct check is the load-bearing one: for a graph under `${bucketGraph}/`
- * the layer segment is forced to `_shared_memory` whenever the reconstruction matches
- * (a 4-segment child takes its layer from the bucket's own slug; a 5-segment child
- * takes `_shared_memory` as its subGraphName and so reconstructs elsewhere). The layer
- * comparison is therefore redundant today and no test can isolate it — it is kept as an
- * explicit statement of intent, and as a guard if the URI grammar ever changes.
+ * Deliberately bucket-RELATIVE. The only shape a bound is allowed to prune is
+ * exactly `${bucketGraph}/{0x…40hex}/{decimal}`, so we strip the bucket prefix and
+ * require precisely those two segments. Every other suffix — `_meta`, blob and
+ * snapshot graphs, and deeper descendants such as
+ * `${bucketGraph}/_verifiable_memory/{addr}/{n}` — simply fails to match and stays
+ * in the read set. Using the general `parseContextGraphLayerUri` here instead would
+ * accept unrelated layer shapes and force reconstruction checks to rule them back
+ * out; the relative parser makes the contract the code's shape rather than a
+ * comment's claim. Works unchanged for a sub-graph bucket, since the prefix we
+ * strip is whatever bucket the caller is reading.
  */
-function parseSharedMemoryChildGraph(
+function parseBoundableSwmChildGraph(
   bucketGraph: string,
   graph: string,
 ): { agentAddress: string; kaNumber: bigint } | undefined {
-  const parsed = parseContextGraphLayerUri(graph);
-  if (!parsed || parsed.layer !== MemoryLayer.SharedWorkingMemory) return undefined;
-  if (contextGraphSharedMemoryUri(parsed.contextGraphId, parsed.subGraphName) !== bucketGraph) {
+  const prefix = `${bucketGraph}/`;
+  if (!graph.startsWith(prefix)) return undefined;
+  const segments = graph.slice(prefix.length).split('/');
+  if (segments.length !== 2) return undefined;
+  const [agentAddress, kaNumberRaw] = segments;
+  if (!SWM_CHILD_AGENT_ADDRESS.test(agentAddress) || !SWM_CHILD_KA_NUMBER.test(kaNumberRaw)) {
     return undefined;
   }
-  return { agentAddress: parsed.agentAddress, kaNumber: parsed.kaNumber };
+  return { agentAddress, kaNumber: BigInt(kaNumberRaw) };
 }
 
 export interface LoadSelectedSharedMemoryQuadsOptions {
@@ -147,25 +145,49 @@ async function listGraphsByPrefix(
  * revalidate interval; there an under-read is still FAIL-SAFE on merkle-gated
  * paths (recompute mismatch → reject/retry, never accept-with-wrong-data).
  *
- * `bound` (optional) narrows the under-graph set to a single author + kaNumber
- * range — see `SwmKaGraphBound`. It is FAIL-OPEN: an under-graph is dropped
- * ONLY when it parses as a per-KA child of THIS bucket AND its author/kaNumber
- * falls outside the bound. A graph that does not parse (blob/`_meta`/snapshot or
- * any future shape) is KEPT, so a bound can never silently under-read a graph it
- * does not understand. The bucket graph is always part of the read contract.
- *
- * Passing a `bound` still yields a STRICT SUBSET of the full read set, and INV-1
- * is refuted under root recurrence, so a bounded resolution can legitimately omit
- * graphs the on-chain merkle root commits to. Anything that hashes or declines on
- * the result must widen to the unbounded resolution first — the same contract
- * `loadKaBoundedSharedMemoryQuads` documents. Do not reach for this to "just make
- * the read cheaper" on a merkle-defining or ACK path.
+ * This resolver is COMPLETE and therefore safe everywhere, including the
+ * merkle-defining publish reads and the StorageACK decline lanes. Pruning lives in
+ * `resolveKaBoundedSharedMemoryReadGraphs`, which is not part of the package's
+ * public surface — read its contract before reaching for it.
  */
 export async function resolveSharedMemoryReadGraphs(
   store: TripleStore,
   bucketGraph: string,
   options?: QueryOptions,
-  bound?: SwmKaGraphBound,
+): Promise<NonEmptyGraphList> {
+  return resolveSwmReadGraphs(store, bucketGraph, options, undefined);
+}
+
+/**
+ * Resolve the SWM read set pruned to one author's per-KA under-graphs.
+ *
+ * UNSAFE ON ITS OWN, and deliberately NOT re-exported from `src/index.ts`: the
+ * result is a STRICT SUBSET of the complete read set, and INV-1 is refuted under
+ * root recurrence, so a bounded resolution can omit graphs the on-chain merkle root
+ * commits to. Only `loadKaBoundedSharedMemoryQuads` may call this, and only because
+ * its own caller (`FinalizationHandler.loadSwmSliceWithFallback`) owns the widen.
+ * Never build a `VALUES ?g` from this and hash or decline on the result.
+ *
+ * Pruning is FAIL-OPEN: an under-graph is dropped ONLY when it is positively a
+ * per-KA child of THIS bucket (`parseBoundableSwmChildGraph`) AND its author or
+ * kaNumber falls outside the bound. Any other shape — `_meta`, blob, snapshot,
+ * deeper descendants, anything future — is KEPT, so a bound can never silently
+ * under-read a graph it does not understand. The bucket is always in the set.
+ */
+export async function resolveKaBoundedSharedMemoryReadGraphs(
+  store: TripleStore,
+  bucketGraph: string,
+  bound: SwmKaGraphBound,
+  options?: QueryOptions,
+): Promise<NonEmptyGraphList> {
+  return resolveSwmReadGraphs(store, bucketGraph, options, bound);
+}
+
+async function resolveSwmReadGraphs(
+  store: TripleStore,
+  bucketGraph: string,
+  options: QueryOptions | undefined,
+  bound: SwmKaGraphBound | undefined,
 ): Promise<NonEmptyGraphList> {
   assertSafeIri(bucketGraph);
   const stagingPrefix = `${bucketGraph}/staging/`;
@@ -176,9 +198,7 @@ export async function resolveSharedMemoryReadGraphs(
     if (graph.startsWith(stagingPrefix)) continue;
     if (!isSafeIri(graph)) continue;
     if (bound) {
-      // Fail-open: only a graph we can positively identify as a per-KA child of
-      // THIS bucket is eligible for exclusion; every other shape is always read.
-      const child = parseSharedMemoryChildGraph(bucketGraph, graph);
+      const child = parseBoundableSwmChildGraph(bucketGraph, graph);
       if (
         child &&
         (child.agentAddress.toLowerCase() !== boundAddress ||
@@ -279,7 +299,9 @@ async function loadSharedMemoryQuadsInternal(
   }
 
   const queryOptions = mergeQueryOptions(options.queryOptions, options.querySource);
-  const swmGraphs = await resolveSharedMemoryReadGraphs(store, bucketGraph, queryOptions, kaGraphBound);
+  const swmGraphs = kaGraphBound
+    ? await resolveKaBoundedSharedMemoryReadGraphs(store, bucketGraph, kaGraphBound, queryOptions)
+    : await resolveSharedMemoryReadGraphs(store, bucketGraph, queryOptions);
   const graphValues = swmGraphs.map((g) => `<${g}>`).join(' ');
   const result = await store.query(`CONSTRUCT { ?s ?p ?o } WHERE {
         VALUES ?g { ${graphValues} }

--- a/packages/storage/src/graph-manager.ts
+++ b/packages/storage/src/graph-manager.ts
@@ -12,6 +12,7 @@ import {
   contextGraphSubGraphMetaUri,
   contextGraphSubGraphPrivateUri,
   contextGraphCatalogUri,
+  parseContextGraphLayerUri,
   isSafeIri,
   assertSafeIri,
   sparqlString,
@@ -22,10 +23,36 @@ const CG_PREFIX = 'did:dkg:context-graph:';
 export type NonEmptyGraphList = [string, ...string[]];
 export type SharedMemoryReadSelection = 'all' | { rootEntities: readonly string[] };
 
+/**
+ * Per-KA identity window used to PRUNE the SWM under-graph read set to the
+ * single author + kaNumber range a call site already knows it wants. The
+ * `agentAddress`/`kaNumber` pair is the identifying half of a KA's UAL, so a
+ * bound admits exactly the per-KA under-graphs
+ * `…/_shared_memory/{addr}/{n}` (and the 5-segment sub-graph shape
+ * `…/{sub}/_shared_memory/{addr}/{n}`) with `addr ≡ᵢ agentAddress` and
+ * `startNumber ≤ n ≤ endNumber`.
+ *
+ * Both numbers are the LOW-96 per-author KA number, NOT a packed `kaId`
+ * (`packKnowledgeAssetIdFromIdentity` shifts the address into the high bits) —
+ * callers must unpack before deriving a bound, or every real graph is excluded.
+ *
+ * This is a PURE ACCELERATOR: it narrows a graph SET, never the CONSTRUCT body,
+ * and non-parsing / bucket graphs are always kept (fail-open). Correctness of a
+ * bounded read therefore reduces to "same graph set ⇒ same quads", and any call
+ * site that narrows a merkle-gated read MUST widen to the unbounded read on an
+ * empty-or-mismatch result before it defers.
+ */
+export interface SwmKaGraphBound {
+  agentAddress: string;
+  startNumber: bigint;
+  endNumber: bigint;
+}
+
 export interface LoadSelectedSharedMemoryQuadsOptions {
   querySource?: QueryOptions['source'];
   queryOptions?: QueryOptions;
   quadFilter?: (quad: Quad) => boolean;
+  kaGraphBound?: SwmKaGraphBound;
   rootEntitiesErrorMessage?: (input: {
     inputCount: number;
     hadInput: boolean;
@@ -86,19 +113,42 @@ async function listGraphsByPrefix(
  * written by a DIFFERENT process to a SHARED oxigraph-server within the
  * revalidate interval; there an under-read is still FAIL-SAFE on merkle-gated
  * paths (recompute mismatch → reject/retry, never accept-with-wrong-data).
+ *
+ * `bound` (optional) narrows the under-graph set to a single author + kaNumber
+ * range — see `SwmKaGraphBound`. It is FAIL-OPEN: an under-graph is dropped
+ * ONLY when it parses as a per-KA layer URI AND its author/kaNumber falls
+ * outside the bound. A graph that does not parse (blob/`_meta`/snapshot or any
+ * future shape) is KEPT, so a bound can never silently under-read a graph it
+ * does not understand. The bucket graph is always part of the read contract.
  */
 export async function resolveSharedMemoryReadGraphs(
   store: TripleStore,
   bucketGraph: string,
   options?: QueryOptions,
+  bound?: SwmKaGraphBound,
 ): Promise<NonEmptyGraphList> {
   assertSafeIri(bucketGraph);
   const stagingPrefix = `${bucketGraph}/staging/`;
   const under = await listGraphsByPrefix(store, `${bucketGraph}/`, options);
   const out = new Set<string>([bucketGraph]);
+  const boundAddress = bound?.agentAddress.toLowerCase();
   for (const graph of under) {
     if (graph.startsWith(stagingPrefix)) continue;
-    if (isSafeIri(graph)) out.add(graph);
+    if (!isSafeIri(graph)) continue;
+    if (bound) {
+      // Fail-open: only a graph we can positively identify as a per-KA layer
+      // URI is eligible for exclusion; unparseable shapes are always read.
+      const parsed = parseContextGraphLayerUri(graph);
+      if (
+        parsed &&
+        (parsed.agentAddress.toLowerCase() !== boundAddress ||
+          parsed.kaNumber < bound.startNumber ||
+          parsed.kaNumber > bound.endNumber)
+      ) {
+        continue;
+      }
+    }
+    out.add(graph);
   }
   return [...out] as NonEmptyGraphList;
 }
@@ -146,7 +196,7 @@ export async function loadSelectedSharedMemoryQuads(
   }
 
   const queryOptions = mergeQueryOptions(options.queryOptions, options.querySource);
-  const swmGraphs = await resolveSharedMemoryReadGraphs(store, bucketGraph, queryOptions);
+  const swmGraphs = await resolveSharedMemoryReadGraphs(store, bucketGraph, queryOptions, options.kaGraphBound);
   const graphValues = swmGraphs.map((g) => `<${g}>`).join(' ');
   const result = await store.query(`CONSTRUCT { ?s ?p ?o } WHERE {
         VALUES ?g { ${graphValues} }

--- a/packages/storage/src/graph-manager.ts
+++ b/packages/storage/src/graph-manager.ts
@@ -13,6 +13,7 @@ import {
   contextGraphSubGraphPrivateUri,
   contextGraphCatalogUri,
   parseContextGraphLayerUri,
+  MemoryLayer,
   isSafeIri,
   assertSafeIri,
   sparqlString,
@@ -46,6 +47,39 @@ export interface SwmKaGraphBound {
   agentAddress: string;
   startNumber: bigint;
   endNumber: bigint;
+}
+
+/**
+ * Identify `graph` as a per-KA child of THIS shared-memory `bucketGraph`, or
+ * return undefined so the caller keeps it (fail-open).
+ *
+ * `parseContextGraphLayerUri` alone is too permissive to gate an exclusion on:
+ * it recognises every memory layer, and a child such as
+ * `…/_shared_memory/_verifiable_memory/{addr}/{n}` parses as a 5-segment
+ * VERIFIABLE-memory URI whose `subGraphName` happens to be `_shared_memory`.
+ * Gating on the raw parse would let that shape — and any future under-bucket
+ * shape that merely resembles a layer URI — be pruned by a bound meant only for
+ * `<bucket>/{addr}/{n}`. So require the parsed layer to be shared-memory AND its
+ * `(contextGraphId, subGraphName)` to reconstruct to exactly the bucket we are
+ * reading. Anything else stays in the read set.
+ *
+ * The reconstruct check is the load-bearing one: for a graph under `${bucketGraph}/`
+ * the layer segment is forced to `_shared_memory` whenever the reconstruction matches
+ * (a 4-segment child takes its layer from the bucket's own slug; a 5-segment child
+ * takes `_shared_memory` as its subGraphName and so reconstructs elsewhere). The layer
+ * comparison is therefore redundant today and no test can isolate it — it is kept as an
+ * explicit statement of intent, and as a guard if the URI grammar ever changes.
+ */
+function parseSharedMemoryChildGraph(
+  bucketGraph: string,
+  graph: string,
+): { agentAddress: string; kaNumber: bigint } | undefined {
+  const parsed = parseContextGraphLayerUri(graph);
+  if (!parsed || parsed.layer !== MemoryLayer.SharedWorkingMemory) return undefined;
+  if (contextGraphSharedMemoryUri(parsed.contextGraphId, parsed.subGraphName) !== bucketGraph) {
+    return undefined;
+  }
+  return { agentAddress: parsed.agentAddress, kaNumber: parsed.kaNumber };
 }
 
 export interface LoadSelectedSharedMemoryQuadsOptions {
@@ -136,14 +170,14 @@ export async function resolveSharedMemoryReadGraphs(
     if (graph.startsWith(stagingPrefix)) continue;
     if (!isSafeIri(graph)) continue;
     if (bound) {
-      // Fail-open: only a graph we can positively identify as a per-KA layer
-      // URI is eligible for exclusion; unparseable shapes are always read.
-      const parsed = parseContextGraphLayerUri(graph);
+      // Fail-open: only a graph we can positively identify as a per-KA child of
+      // THIS bucket is eligible for exclusion; every other shape is always read.
+      const child = parseSharedMemoryChildGraph(bucketGraph, graph);
       if (
-        parsed &&
-        (parsed.agentAddress.toLowerCase() !== boundAddress ||
-          parsed.kaNumber < bound.startNumber ||
-          parsed.kaNumber > bound.endNumber)
+        child &&
+        (child.agentAddress.toLowerCase() !== boundAddress ||
+          child.kaNumber < bound.startNumber ||
+          child.kaNumber > bound.endNumber)
       ) {
         continue;
       }

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -54,7 +54,7 @@ export {
   ContextGraphManager,
   GraphManager,
   loadSelectedSharedMemoryQuads,
-  loadKaBoundedSharedMemoryQuads,
+  loadSharedMemorySliceWithKaBoundFallback,
   loadSelectedVerifiableMemoryQuads,
   resolveSharedMemoryReadGraphs,
   resolveVerifiableMemoryReadGraphs,
@@ -63,6 +63,7 @@ export {
   type NonEmptyGraphList,
   type SharedMemoryReadSelection,
   type SwmKaGraphBound,
+  type SwmSliceSourceTags,
 } from './graph-manager.js';
 export { PrivateContentStore } from './private-store.js';
 

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -61,6 +61,7 @@ export {
   type LoadSelectedVerifiableMemoryQuadsOptions,
   type NonEmptyGraphList,
   type SharedMemoryReadSelection,
+  type SwmKaGraphBound,
 } from './graph-manager.js';
 export { PrivateContentStore } from './private-store.js';
 

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -54,6 +54,7 @@ export {
   ContextGraphManager,
   GraphManager,
   loadSelectedSharedMemoryQuads,
+  loadKaBoundedSharedMemoryQuads,
   loadSelectedVerifiableMemoryQuads,
   resolveSharedMemoryReadGraphs,
   resolveVerifiableMemoryReadGraphs,

--- a/packages/storage/test/graph-manager-swm-bound.test.ts
+++ b/packages/storage/test/graph-manager-swm-bound.test.ts
@@ -7,6 +7,10 @@ import {
   type Quad,
   type SwmKaGraphBound,
 } from '../src/index.js';
+// `resolveKaBoundedSharedMemoryReadGraphs` is deliberately NOT re-exported from
+// `src/index.ts` — pruning is not part of the package's public surface. Tests reach
+// into the module directly rather than widening that surface.
+import { resolveKaBoundedSharedMemoryReadGraphs } from '../src/graph-manager.js';
 import { contextGraphSharedMemoryUri } from '@origintrail-official/dkg-core';
 
 // The bound's `agentAddress` arrives LOWERCASE (it is unpacked from a packed
@@ -45,7 +49,7 @@ describe('resolveSharedMemoryReadGraphs — SwmKaGraphBound (fail-open per-KA sl
       await seedGraphs(store, [swm, gAdmit, gRangeOut, gAuthorOut, gNonLayer, gStaging]);
 
       const bound: SwmKaGraphBound = { agentAddress: AUTHOR_A, startNumber: 7n, endNumber: 7n };
-      const resolved = await resolveSharedMemoryReadGraphs(store, swm, undefined, bound);
+      const resolved = await resolveKaBoundedSharedMemoryReadGraphs(store, swm, bound);
 
       // Kills: author-blind range (would admit gAuthorOut), range off-by-one
       // (would admit gRangeOut), fail-CLOSED parse (would drop gNonLayer), and a
@@ -70,7 +74,7 @@ describe('resolveSharedMemoryReadGraphs — SwmKaGraphBound (fail-open per-KA sl
       await seedGraphs(store, [swm, gSub]);
 
       const bound: SwmKaGraphBound = { agentAddress: AUTHOR_A, startNumber: 7n, endNumber: 7n };
-      const resolved = await resolveSharedMemoryReadGraphs(store, swm, undefined, bound);
+      const resolved = await resolveKaBoundedSharedMemoryReadGraphs(store, swm, bound);
 
       expect(resolved).toContain(gSub);
       expect(resolved.slice().sort()).toEqual([swm, gSub].sort());
@@ -79,15 +83,20 @@ describe('resolveSharedMemoryReadGraphs — SwmKaGraphBound (fail-open per-KA sl
     }
   });
 
-  it('T3: absent bound is a no-op — resolve(store, swm) deep-equals resolve(store, swm, undefined, undefined)', async () => {
+  // The public resolver has no bound parameter at all: it is COMPLETE by construction
+  // and therefore safe on the merkle-defining and ACK lanes. Pruning requires the
+  // separately-named `resolveKaBoundedSharedMemoryReadGraphs`.
+  it('T3: the public resolver is complete — every non-staging child, regardless of author or number', async () => {
     const store = await createTripleStore({ backend: 'oxigraph' });
     const swm = contextGraphSharedMemoryUri('bound-t3');
+    const gA = `${swm}/${AUTHOR_A_MIXED}/7`;
+    const gB = `${swm}/${AUTHOR_B}/9`;
     try {
-      await seedGraphs(store, [swm, `${swm}/${AUTHOR_A_MIXED}/7`, `${swm}/${AUTHOR_B}/9`, `${swm}/staging/tmp`]);
+      await seedGraphs(store, [swm, gA, gB, `${swm}/staging/tmp`]);
 
-      const implicit = await resolveSharedMemoryReadGraphs(store, swm);
-      const explicit = await resolveSharedMemoryReadGraphs(store, swm, undefined, undefined);
-      expect(implicit).toEqual(explicit);
+      const resolved = await resolveSharedMemoryReadGraphs(store, swm);
+
+      expect(resolved.slice().sort()).toEqual([swm, gA, gB].sort());
     } finally {
       await store.close();
     }
@@ -166,7 +175,7 @@ describe('resolveSharedMemoryReadGraphs — bound only prunes real SWM children 
       await seedGraphs(store, [swm, gAdmit, gVmLookalike, gWmLookalike]);
 
       const bound: SwmKaGraphBound = { agentAddress: AUTHOR_A, startNumber: 7n, endNumber: 7n };
-      const resolved = await resolveSharedMemoryReadGraphs(store, swm, undefined, bound);
+      const resolved = await resolveKaBoundedSharedMemoryReadGraphs(store, swm, bound);
 
       expect(resolved.slice().sort()).toEqual([swm, gAdmit, gVmLookalike, gWmLookalike].sort());
     } finally {
@@ -179,6 +188,28 @@ describe('resolveSharedMemoryReadGraphs — bound only prunes real SWM children 
   // subGraphName is `_shared_memory`, so it reconstructs to `<cg>/_shared_memory/_shared_memory`
   // — a different bucket, not ours to prune, even though its author and number both
   // fall outside the bound.
+  // A deeper descendant whose FIRST two segments look like `{addr}/{n}` must not be
+  // pruned: it is not a per-KA child (it has a trailing segment). Requires an EXACT
+  // two-segment match, not a >=2 prefix match.
+  it('keeps a deeper descendant even when its leading segments resemble a per-KA child', async () => {
+    const store = await createTripleStore({ backend: 'oxigraph' });
+    const swm = contextGraphSharedMemoryUri('bound-deep');
+    const gAdmit = `${swm}/${AUTHOR_A_MIXED}/7`;
+    // Leading `${AUTHOR_B}/12` would be out-of-bound if this parsed as a per-KA
+    // child, but the trailing `/extra` means it is NOT one.
+    const gDeep = `${swm}/${AUTHOR_B}/12/extra`;
+    try {
+      await seedGraphs(store, [swm, gAdmit, gDeep]);
+
+      const bound: SwmKaGraphBound = { agentAddress: AUTHOR_A, startNumber: 7n, endNumber: 7n };
+      const resolved = await resolveKaBoundedSharedMemoryReadGraphs(store, swm, bound);
+
+      expect(resolved.slice().sort()).toEqual([swm, gAdmit, gDeep].sort());
+    } finally {
+      await store.close();
+    }
+  });
+
   it('keeps a shared-memory child that reconstructs to a DIFFERENT bucket', async () => {
     const store = await createTripleStore({ backend: 'oxigraph' });
     const swm = contextGraphSharedMemoryUri('bound-t2b2');
@@ -188,7 +219,7 @@ describe('resolveSharedMemoryReadGraphs — bound only prunes real SWM children 
       await seedGraphs(store, [swm, gAdmit, gOtherBucketChild]);
 
       const bound: SwmKaGraphBound = { agentAddress: AUTHOR_A, startNumber: 7n, endNumber: 7n };
-      const resolved = await resolveSharedMemoryReadGraphs(store, swm, undefined, bound);
+      const resolved = await resolveKaBoundedSharedMemoryReadGraphs(store, swm, bound);
 
       expect(resolved.slice().sort()).toEqual([swm, gAdmit, gOtherBucketChild].sort());
     } finally {
@@ -249,6 +280,54 @@ describe('the generic SWM loader cannot be pruned (bound is not an option)', () 
       );
 
       expect(quads.map((q) => q.object).sort()).toEqual(['"bucket"', '"in"']);
+    } finally {
+      await store.close();
+    }
+  });
+});
+
+describe('a multi-KA range admits the interior, not just the endpoints (T8)', () => {
+  // Every other bound test uses a degenerate [n,n] range, so an implementation that
+  // admitted only `kaNumber === startNumber` would pass all of them. This drives a
+  // real same-author batch range: below/above are pruned, both endpoints AND the
+  // interior are kept.
+  it('admits [start..end] inclusive and prunes below/above and other authors', async () => {
+    const store = await createTripleStore({ backend: 'oxigraph' });
+    const swm = contextGraphSharedMemoryUri('bound-t8');
+    const below = `${swm}/${AUTHOR_A_MIXED}/3`;
+    const start = `${swm}/${AUTHOR_A_MIXED}/5`;
+    const interior = `${swm}/${AUTHOR_A_MIXED}/7`;
+    const end = `${swm}/${AUTHOR_A_MIXED}/9`;
+    const above = `${swm}/${AUTHOR_A_MIXED}/12`;
+    const otherAuthor = `${swm}/${AUTHOR_B}/7`;
+    try {
+      await seedGraphs(store, [swm, below, start, interior, end, above, otherAuthor]);
+
+      const bound: SwmKaGraphBound = { agentAddress: AUTHOR_A, startNumber: 5n, endNumber: 9n };
+      const resolved = await resolveKaBoundedSharedMemoryReadGraphs(store, swm, bound);
+
+      expect(resolved.slice().sort()).toEqual([swm, start, interior, end].sort());
+      expect(resolved).not.toContain(below);
+      expect(resolved).not.toContain(above);
+      expect(resolved).not.toContain(otherAuthor);
+    } finally {
+      await store.close();
+    }
+  });
+
+  it('kaNumbers compare numerically, not lexicographically', async () => {
+    const store = await createTripleStore({ backend: 'oxigraph' });
+    const swm = contextGraphSharedMemoryUri('bound-t8-lex');
+    // Lexicographically "10" < "9", so a string compare would wrongly prune g10.
+    const g9 = `${swm}/${AUTHOR_A_MIXED}/9`;
+    const g10 = `${swm}/${AUTHOR_A_MIXED}/10`;
+    try {
+      await seedGraphs(store, [swm, g9, g10]);
+
+      const bound: SwmKaGraphBound = { agentAddress: AUTHOR_A, startNumber: 9n, endNumber: 10n };
+      const resolved = await resolveKaBoundedSharedMemoryReadGraphs(store, swm, bound);
+
+      expect(resolved.slice().sort()).toEqual([swm, g9, g10].sort());
     } finally {
       await store.close();
     }

--- a/packages/storage/test/graph-manager-swm-bound.test.ts
+++ b/packages/storage/test/graph-manager-swm-bound.test.ts
@@ -1,16 +1,21 @@
 import { describe, it, expect } from 'vitest';
+import * as storageIndex from '../src/index.js';
 import {
   createTripleStore,
   loadSelectedSharedMemoryQuads,
-  loadKaBoundedSharedMemoryQuads,
+  loadSharedMemorySliceWithKaBoundFallback,
   resolveSharedMemoryReadGraphs,
   type Quad,
   type SwmKaGraphBound,
 } from '../src/index.js';
-// `resolveKaBoundedSharedMemoryReadGraphs` is deliberately NOT re-exported from
-// `src/index.ts` — pruning is not part of the package's public surface. Tests reach
-// into the module directly rather than widening that surface.
-import { resolveKaBoundedSharedMemoryReadGraphs } from '../src/graph-manager.js';
+// The unsafe bounded primitives are deliberately NOT re-exported from `src/index.ts`
+// (pruning is not part of the package's public surface — see the API-surface test at
+// the bottom). Tests that exercise the graph-set behaviour reach into the module
+// directly rather than widening that surface.
+import {
+  loadKaBoundedSharedMemoryQuads,
+  resolveKaBoundedSharedMemoryReadGraphs,
+} from '../src/graph-manager.js';
 import { contextGraphSharedMemoryUri } from '@origintrail-official/dkg-core';
 
 // The bound's `agentAddress` arrives LOWERCASE (it is unpacked from a packed
@@ -280,6 +285,105 @@ describe('the generic SWM loader cannot be pruned (bound is not an option)', () 
       );
 
       expect(quads.map((q) => q.object).sort()).toEqual(['"bucket"', '"in"']);
+    } finally {
+      await store.close();
+    }
+  });
+
+  // The reviewer-requested API-surface regression: a non-finalization lane must not
+  // be able to import the unsafe pruning primitives from the package entrypoint.
+  it('does not publish the unsafe bounded primitives from the package public API', () => {
+    expect(storageIndex).not.toHaveProperty('loadKaBoundedSharedMemoryQuads');
+    expect(storageIndex).not.toHaveProperty('resolveKaBoundedSharedMemoryReadGraphs');
+    // The safe, fallback-owning primitive IS public.
+    expect(typeof storageIndex.loadSharedMemorySliceWithKaBoundFallback).toBe('function');
+  });
+});
+
+describe('loadSharedMemorySliceWithKaBoundFallback — the safe bounded read', () => {
+  const SOURCES = {
+    bounded: 'test.bounded',
+    widened: 'test.widened',
+    unbounded: 'test.unbounded',
+  } as const;
+
+  it('bounded hit: reads the bound and never widens or re-accepts', async () => {
+    const store = await createTripleStore({ backend: 'oxigraph' });
+    const swm = contextGraphSharedMemoryUri('fb-hit');
+    const r = 'urn:fb:hit';
+    try {
+      await store.insert([
+        { subject: r, predicate: 'urn:p', object: '"bucket"', graph: swm },
+        { subject: r, predicate: 'urn:p', object: '"in"', graph: `${swm}/${AUTHOR_A_MIXED}/7` },
+        { subject: r, predicate: 'urn:p', object: '"out"', graph: `${swm}/${AUTHOR_B}/12` },
+      ]);
+
+      let accepts = 0;
+      const { quads, accepted } = await loadSharedMemorySliceWithKaBoundFallback(
+        store, swm, { rootEntities: [r] },
+        { agentAddress: AUTHOR_A, startNumber: 7n, endNumber: 7n },
+        SOURCES,
+        async () => (qs) => { accepts += 1; return qs; },
+      );
+
+      // Bounded read excluded the out-of-range graph, and the accept predicate
+      // approved it, so no widen fired.
+      expect(quads.map((q) => q.object).sort()).toEqual(['"bucket"', '"in"']);
+      expect(accepted?.map((q) => q.object).sort()).toEqual(['"bucket"', '"in"']);
+      expect(accepts).toBe(1);
+    } finally {
+      await store.close();
+    }
+  });
+
+  it('bounded mismatch: widens to the complete read and re-accepts', async () => {
+    const store = await createTripleStore({ backend: 'oxigraph' });
+    const swm = contextGraphSharedMemoryUri('fb-miss');
+    const r = 'urn:fb:miss';
+    const outObj = '"out"';
+    try {
+      await store.insert([
+        { subject: r, predicate: 'urn:p', object: '"in"', graph: `${swm}/${AUTHOR_A_MIXED}/7` },
+        { subject: r, predicate: 'urn:p', object: outObj, graph: `${swm}/${AUTHOR_B}/12` },
+      ]);
+
+      // accept only when the out-of-range object is present ⇒ the bounded read is
+      // rejected and the widen must supply it.
+      const { quads, accepted } = await loadSharedMemorySliceWithKaBoundFallback(
+        store, swm, { rootEntities: [r] },
+        { agentAddress: AUTHOR_A, startNumber: 7n, endNumber: 7n },
+        SOURCES,
+        async () => (qs) => (qs.some((q) => q.object === outObj) ? qs : null),
+      );
+
+      expect(accepted).not.toBeNull();
+      expect(quads.map((q) => q.object).sort()).toEqual(['"in"', '"out"']);
+    } finally {
+      await store.close();
+    }
+  });
+
+  it('no bound: one complete read, accept predicate applied once', async () => {
+    const store = await createTripleStore({ backend: 'oxigraph' });
+    const swm = contextGraphSharedMemoryUri('fb-none');
+    const r = 'urn:fb:none';
+    try {
+      await store.insert([
+        { subject: r, predicate: 'urn:p', object: '"a"', graph: `${swm}/${AUTHOR_A_MIXED}/7` },
+        { subject: r, predicate: 'urn:p', object: '"b"', graph: `${swm}/${AUTHOR_B}/12` },
+      ]);
+
+      let accepts = 0;
+      const { quads } = await loadSharedMemorySliceWithKaBoundFallback(
+        store, swm, { rootEntities: [r] },
+        undefined,
+        SOURCES,
+        async () => (qs) => { accepts += 1; return qs; },
+      );
+
+      // Unbounded ⇒ both authors read; accept applied exactly once.
+      expect(quads.map((q) => q.object).sort()).toEqual(['"a"', '"b"']);
+      expect(accepts).toBe(1);
     } finally {
       await store.close();
     }

--- a/packages/storage/test/graph-manager-swm-bound.test.ts
+++ b/packages/storage/test/graph-manager-swm-bound.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   createTripleStore,
   loadSelectedSharedMemoryQuads,
+  loadKaBoundedSharedMemoryQuads,
   resolveSharedMemoryReadGraphs,
   type Quad,
   type SwmKaGraphBound,
@@ -126,7 +127,7 @@ describe('loadSelectedSharedMemoryQuads — bounded read equivalence', () => {
       ]);
 
       const bound: SwmKaGraphBound = { agentAddress: AUTHOR_A, startNumber: 7n, endNumber: 7n };
-      const bounded = await loadSelectedSharedMemoryQuads(store, swm, { rootEntities: [r] }, { kaGraphBound: bound });
+      const bounded = await loadKaBoundedSharedMemoryQuads(store, swm, { rootEntities: [r] }, bound);
       const unbounded = await loadSelectedSharedMemoryQuads(store, swm, { rootEntities: [r] });
 
       expect(keys(bounded)).toEqual(keys(unbounded));
@@ -190,6 +191,64 @@ describe('resolveSharedMemoryReadGraphs — bound only prunes real SWM children 
       const resolved = await resolveSharedMemoryReadGraphs(store, swm, undefined, bound);
 
       expect(resolved.slice().sort()).toEqual([swm, gAdmit, gOtherBucketChild].sort());
+    } finally {
+      await store.close();
+    }
+  });
+});
+
+describe('the generic SWM loader cannot be pruned (bound is not an option)', () => {
+  // `kaGraphBound` was removed from `LoadSelectedSharedMemoryQuadsOptions`, so the
+  // four production callers — two of them merkle-DEFINING, one the ACK decline lane
+  // — get a compile error if they try to prune. This pins the runtime half: even if
+  // the field is forced through at a type boundary, the read stays unbounded.
+  it('ignores a forced kaGraphBound option and still reads every under-graph', async () => {
+    const store = await createTripleStore({ backend: 'oxigraph' });
+    const swm = contextGraphSharedMemoryUri('bound-nofootgun');
+    const root = 'urn:test:footgun:root';
+    const inBound = `${swm}/${AUTHOR_A_MIXED}/7`;
+    const outOfBound = `${swm}/${AUTHOR_B}/12`;
+    try {
+      await store.insert([
+        { subject: root, predicate: 'urn:p', object: '"bucket"', graph: swm },
+        { subject: root, predicate: 'urn:p', object: '"in"', graph: inBound },
+        { subject: root, predicate: 'urn:p', object: '"out"', graph: outOfBound },
+      ]);
+
+      const forced = {
+        querySource: 'test.forced',
+        kaGraphBound: { agentAddress: AUTHOR_A, startNumber: 7n, endNumber: 7n },
+      } as unknown as Parameters<typeof loadSelectedSharedMemoryQuads>[3];
+
+      const quads = await loadSelectedSharedMemoryQuads(store, swm, { rootEntities: [root] }, forced);
+
+      // All three objects present ⇒ the out-of-bound graph was NOT pruned.
+      expect(quads.map((q) => q.object).sort()).toEqual(['"bucket"', '"in"', '"out"']);
+    } finally {
+      await store.close();
+    }
+  });
+
+  it('loadKaBoundedSharedMemoryQuads DOES prune, and takes the bound positionally', async () => {
+    const store = await createTripleStore({ backend: 'oxigraph' });
+    const swm = contextGraphSharedMemoryUri('bound-explicit');
+    const root = 'urn:test:explicit:root';
+    const inBound = `${swm}/${AUTHOR_A_MIXED}/7`;
+    const outOfBound = `${swm}/${AUTHOR_B}/12`;
+    try {
+      await store.insert([
+        { subject: root, predicate: 'urn:p', object: '"bucket"', graph: swm },
+        { subject: root, predicate: 'urn:p', object: '"in"', graph: inBound },
+        { subject: root, predicate: 'urn:p', object: '"out"', graph: outOfBound },
+      ]);
+
+      const quads = await loadKaBoundedSharedMemoryQuads(
+        store, swm, { rootEntities: [root] },
+        { agentAddress: AUTHOR_A, startNumber: 7n, endNumber: 7n },
+        { querySource: 'test.bounded' },
+      );
+
+      expect(quads.map((q) => q.object).sort()).toEqual(['"bucket"', '"in"']);
     } finally {
       await store.close();
     }

--- a/packages/storage/test/graph-manager-swm-bound.test.ts
+++ b/packages/storage/test/graph-manager-swm-bound.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createTripleStore,
+  loadSelectedSharedMemoryQuads,
+  resolveSharedMemoryReadGraphs,
+  type Quad,
+  type SwmKaGraphBound,
+} from '../src/index.js';
+import { contextGraphSharedMemoryUri } from '@origintrail-official/dkg-core';
+
+// The bound's `agentAddress` arrives LOWERCASE (it is unpacked from a packed
+// kaId), but the URI segment written by the DKG path may be checksum-cased.
+// Every fixture below writes the MIXED-case form into the graph URI and bounds
+// on the lowercase form, so a case-sensitive address compare would wrongly drop
+// the admitted graph and fail the test.
+const AUTHOR_A_MIXED = '0xAbCdEf0123456789AbCdEf0123456789AbCdEf01';
+const AUTHOR_A = AUTHOR_A_MIXED.toLowerCase();
+const AUTHOR_B = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+const key = (quad: Quad) => `${quad.subject}|${quad.predicate}|${quad.object}`;
+const keys = (quads: Quad[]) => quads.map(key).sort();
+
+async function seedGraphs(store: Awaited<ReturnType<typeof createTripleStore>>, graphs: string[]): Promise<void> {
+  await store.insert(
+    graphs.map((graph, i) => ({
+      subject: `urn:seed:${i}`,
+      predicate: 'urn:p',
+      object: '"seed"',
+      graph,
+    })),
+  );
+}
+
+describe('resolveSharedMemoryReadGraphs — SwmKaGraphBound (fail-open per-KA slice)', () => {
+  it('T1: admits bucket + matching per-KA graph + non-parsing graph; excludes off-range, off-author, staging', async () => {
+    const store = await createTripleStore({ backend: 'oxigraph' });
+    const swm = contextGraphSharedMemoryUri('bound-t1');
+    const gAdmit = `${swm}/${AUTHOR_A_MIXED}/7`;
+    const gRangeOut = `${swm}/${AUTHOR_A_MIXED}/12`;
+    const gAuthorOut = `${swm}/${AUTHOR_B}/7`;
+    const gNonLayer = `${swm}/not-a-layer`;
+    const gStaging = `${swm}/staging/tmp`;
+    try {
+      await seedGraphs(store, [swm, gAdmit, gRangeOut, gAuthorOut, gNonLayer, gStaging]);
+
+      const bound: SwmKaGraphBound = { agentAddress: AUTHOR_A, startNumber: 7n, endNumber: 7n };
+      const resolved = await resolveSharedMemoryReadGraphs(store, swm, undefined, bound);
+
+      // Kills: author-blind range (would admit gAuthorOut), range off-by-one
+      // (would admit gRangeOut), fail-CLOSED parse (would drop gNonLayer), and a
+      // dropped bucket seed. The packed-vs-low96 trap lives one layer up in
+      // `deriveSwmKaGraphBound` (the bound arrives here already unpacked); it is
+      // killed by T4 and by the bounded-only finalization case in
+      // packages/agent/test/swm-slice-ka-bound.test.ts.
+      expect(resolved.slice().sort()).toEqual([swm, gAdmit, gNonLayer].sort());
+      expect(resolved).not.toContain(gRangeOut);
+      expect(resolved).not.toContain(gAuthorOut);
+      expect(resolved).not.toContain(gStaging);
+    } finally {
+      await store.close();
+    }
+  });
+
+  it('T2: admits a 5-segment sub-graph per-KA URI', async () => {
+    const store = await createTripleStore({ backend: 'oxigraph' });
+    const swm = contextGraphSharedMemoryUri('bound-t2', 'mysub');
+    const gSub = `${swm}/${AUTHOR_A_MIXED}/7`;
+    try {
+      await seedGraphs(store, [swm, gSub]);
+
+      const bound: SwmKaGraphBound = { agentAddress: AUTHOR_A, startNumber: 7n, endNumber: 7n };
+      const resolved = await resolveSharedMemoryReadGraphs(store, swm, undefined, bound);
+
+      expect(resolved).toContain(gSub);
+      expect(resolved.slice().sort()).toEqual([swm, gSub].sort());
+    } finally {
+      await store.close();
+    }
+  });
+
+  it('T3: absent bound is a no-op — resolve(store, swm) deep-equals resolve(store, swm, undefined, undefined)', async () => {
+    const store = await createTripleStore({ backend: 'oxigraph' });
+    const swm = contextGraphSharedMemoryUri('bound-t3');
+    try {
+      await seedGraphs(store, [swm, `${swm}/${AUTHOR_A_MIXED}/7`, `${swm}/${AUTHOR_B}/9`, `${swm}/staging/tmp`]);
+
+      const implicit = await resolveSharedMemoryReadGraphs(store, swm);
+      const explicit = await resolveSharedMemoryReadGraphs(store, swm, undefined, undefined);
+      expect(implicit).toEqual(explicit);
+    } finally {
+      await store.close();
+    }
+  });
+});
+
+describe('loadSelectedSharedMemoryQuads — bounded read equivalence', () => {
+  it('T5a: a bounded root read returns a quad set key-identical to the unbounded read', async () => {
+    const store = await createTripleStore({ backend: 'oxigraph' });
+    const swm = contextGraphSharedMemoryUri('bound-t5a');
+    const r = 'urn:t5a:root';
+    const c1 = `${r}/.well-known/genid/c1`;
+    const c2 = `${r}/.well-known/genid/c2`;
+    const c3 = `${r}/.well-known/genid/c3`;
+    const other = 'urn:t5a:other';
+    const gKa = `${swm}/${AUTHOR_A_MIXED}/7`;
+    const gRangeOut = `${swm}/${AUTHOR_A_MIXED}/12`;
+    const gAuthorOut = `${swm}/${AUTHOR_B}/7`;
+    const gNonLayer = `${swm}/not-a-layer`;
+    const gStaging = `${swm}/staging/tmp`;
+    try {
+      await store.insert([
+        // All of root r's quads live in bucket ∪ gKa ∪ the fail-open non-layer
+        // graph — the clean single-KA case the bound is meant to accelerate.
+        { subject: r, predicate: 'urn:p', object: '"root-bucket"', graph: swm },
+        { subject: c1, predicate: 'urn:p', object: '"child-bucket"', graph: swm },
+        { subject: r, predicate: 'urn:p', object: '"root-ka"', graph: gKa },
+        { subject: c2, predicate: 'urn:p', object: '"child-ka"', graph: gKa },
+        { subject: c3, predicate: 'urn:p', object: '"child-nonlayer"', graph: gNonLayer },
+        // Decoys the bound skips: off-range / off-author graphs holding only a
+        // DIFFERENT root, so neither read attributes them to r (equivalence
+        // holds) — yet a wrong bound that kept gKa out would lose r's quads.
+        { subject: other, predicate: 'urn:p', object: '"decoy-range"', graph: gRangeOut },
+        { subject: other, predicate: 'urn:p', object: '"decoy-author"', graph: gAuthorOut },
+        // Staging is excluded by BOTH reads even though it carries an r quad.
+        { subject: r, predicate: 'urn:p', object: '"staged"', graph: gStaging },
+      ]);
+
+      const bound: SwmKaGraphBound = { agentAddress: AUTHOR_A, startNumber: 7n, endNumber: 7n };
+      const bounded = await loadSelectedSharedMemoryQuads(store, swm, { rootEntities: [r] }, { kaGraphBound: bound });
+      const unbounded = await loadSelectedSharedMemoryQuads(store, swm, { rootEntities: [r] });
+
+      expect(keys(bounded)).toEqual(keys(unbounded));
+      // Guard against the vacuous both-empty pass: the per-KA graph's quads must
+      // actually be in the bounded slice.
+      expect(keys(bounded)).toEqual(
+        [
+          `${r}|urn:p|"root-bucket"`,
+          `${c1}|urn:p|"child-bucket"`,
+          `${r}|urn:p|"root-ka"`,
+          `${c2}|urn:p|"child-ka"`,
+          `${c3}|urn:p|"child-nonlayer"`,
+        ].sort(),
+      );
+      expect(keys(bounded)).not.toContain(`${r}|urn:p|"staged"`);
+    } finally {
+      await store.close();
+    }
+  });
+});

--- a/packages/storage/test/graph-manager-swm-bound.test.ts
+++ b/packages/storage/test/graph-manager-swm-bound.test.ts
@@ -147,3 +147,51 @@ describe('loadSelectedSharedMemoryQuads — bounded read equivalence', () => {
     }
   });
 });
+
+describe('resolveSharedMemoryReadGraphs — bound only prunes real SWM children (T2b)', () => {
+  // `parseContextGraphLayerUri` recognises every memory layer, so a child like
+  // `<swm>/_verifiable_memory/{addr}/{n}` PARSES — as a 5-segment VM URI whose
+  // subGraphName is `_shared_memory`. Gating exclusion on the raw parse would
+  // prune it. Only a child that reconstructs to exactly this bucket may be cut.
+  it('keeps layer-lookalike children of the bucket that are not per-KA SWM graphs', async () => {
+    const store = await createTripleStore({ backend: 'oxigraph' });
+    const swm = contextGraphSharedMemoryUri('bound-t2b');
+    const gAdmit = `${swm}/${AUTHOR_A_MIXED}/7`;
+    // Parses as layer=VerifiableMemory, subGraphName='_shared_memory'. Its author
+    // and number are BOTH out of the bound, so a raw-parse gate would drop it.
+    const gVmLookalike = `${swm}/_verifiable_memory/${AUTHOR_B}/12`;
+    const gWmLookalike = `${swm}/_working_memory/${AUTHOR_B}/12`;
+    try {
+      await seedGraphs(store, [swm, gAdmit, gVmLookalike, gWmLookalike]);
+
+      const bound: SwmKaGraphBound = { agentAddress: AUTHOR_A, startNumber: 7n, endNumber: 7n };
+      const resolved = await resolveSharedMemoryReadGraphs(store, swm, undefined, bound);
+
+      expect(resolved.slice().sort()).toEqual([swm, gAdmit, gVmLookalike, gWmLookalike].sort());
+    } finally {
+      await store.close();
+    }
+  });
+
+  // Isolates the bucket-RECONSTRUCT check specifically: `<swm>/_shared_memory/{addr}/{n}`
+  // parses as a 5-segment SHARED-memory URI, so the layer check alone passes. Its
+  // subGraphName is `_shared_memory`, so it reconstructs to `<cg>/_shared_memory/_shared_memory`
+  // — a different bucket, not ours to prune, even though its author and number both
+  // fall outside the bound.
+  it('keeps a shared-memory child that reconstructs to a DIFFERENT bucket', async () => {
+    const store = await createTripleStore({ backend: 'oxigraph' });
+    const swm = contextGraphSharedMemoryUri('bound-t2b2');
+    const gAdmit = `${swm}/${AUTHOR_A_MIXED}/7`;
+    const gOtherBucketChild = `${swm}/_shared_memory/${AUTHOR_B}/12`;
+    try {
+      await seedGraphs(store, [swm, gAdmit, gOtherBucketChild]);
+
+      const bound: SwmKaGraphBound = { agentAddress: AUTHOR_A, startNumber: 7n, endNumber: 7n };
+      const resolved = await resolveSharedMemoryReadGraphs(store, swm, undefined, bound);
+
+      expect(resolved.slice().sort()).toEqual([swm, gAdmit, gOtherBucketChild].sort());
+    } finally {
+      await store.close();
+    }
+  });
+});


### PR DESCRIPTION
## Bound the finalization SWM-slice CONSTRUCT (#1549 residual)

### Why

`loadSelectedSharedMemoryQuads` resolves its read set to the SWM bucket **plus every non-staging under-graph**, then runs a CONSTRUCT whose BGP is an unconstrained `?s ?p ?o` behind an `OR` / `STRSTARTS` filter. Neither disjunct can bind the subject from an index, so cost is `O(Σ all graphs)`, not `O(roots)`.

In #1549's slow-query sample, `agent.finalization.sharedMemorySlice` is **8 of the slow CONSTRUCTs** (`queryBytes` 13632 and 19550 ⇒ roughly **M ≈ 120–175 graphs** scanned per call to extract a few roots).

Note `storage-ack.loadSWMQuads.*` never appears in that list: the ACK responder is not itself slow, it is **starved by** these queries. Relieving finalization relieves it indirectly.

### What

On the **finalization gossip lane only**, derive a per-author `SwmKaGraphBound` from the message's `startKAId`/`endKAId` and prune under-graphs to that author + `kaNumber` range.

### The packed-id trap

`startKAId`/`endKAId` are packed `(author << 96) | number` (`packKnowledgeAssetIdFromIdentity`), whereas the graph URI's last segment is only the **low-96** per-author number. Comparing them directly is false for every real address — it would exclude every parseable graph, collapse the read to the bucket, and silently defer. The bound therefore `unpack`s both ends into `(agentAddress, [startNumber, endNumber])`. Ends unpacking to different authors ⇒ no bound (a packed range spanning authors is not a contiguous per-author number range).

### INV-1 is refuted ⇒ bound + widen-on-miss

"A root's quads live only under its own `kaNumber`" is **false** under root recurrence: `dkg-agent-swm-host.ts` documents that a root IRI recurs across per-KA graphs when an entity is republished under a new `kaId`, and the receiver's upsert-delete is graph-scoped, so the earlier quads linger. The publisher's merkle-**defining** read is unbounded, so the on-chain root can commit to quads spanning two graphs.

The bound is therefore a **pure accelerator**: on an empty *or* merkle-mismatched bounded read we widen to the unbounded read and recompute **before recording any lifecycle event**. Correctness never depends on INV-1.

### Outcome relation is asymmetric, not identity

- **Never accept → defer.** The bounded graph set is a subset of the unbounded one, so a bounded miss re-reads exactly today's set. Acceptance stays gated on reproducing the on-chain merkle root plus `verifyOnChain`, so a bounded match cannot accept a set the chain did not commit to.
- **Sometimes defer → accept.** Where recurrence lingered quads the *publisher* never hashed, today's unbounded read builds a superset, mismatches, and defers a valid KA. The bounded read reproduces the committed set and promotes it. **This fixes a latent finalization liveness bug** on replicas holding a residual per-KA graph.

### Deliberately NOT bounded (all byte-unchanged)

| Lane | Why |
|---|---|
| StorageACK, regular publish | the intent carries no `kaId` ⇒ unboundable; an under-read here costs a publish-quorum vote |
| StorageACK, update | reads `selection: 'all'` ⇒ any bound always misses |
| `dkg-publisher.ts` / `dkg-agent-publish.ts` merkle-**defining** reads | bounding them changes consensus |
| finalization chain-reconcile backstop | must stay unbounded so a gossip miss self-heals |

### Fail-open filter

A graph is dropped **only if** it parses as a per-KA layer URI *and* its author or `kaNumber` is out of range. Non-parsing shapes (`_meta`, blob, snapshot, anything future) and the bucket are always read. Address compare is case-insensitive — `unpack` yields lowercase, the URI segment may be checksum-cased.

### Rollout

- **Kill-switch:** `DKG_DISABLE_SWM_KA_BOUND=1` ⇒ no bound ⇒ today's behavior, no redeploy.
- **Canary:** ratio of `agent.finalization.sharedMemorySlice.fallbackUnbounded` to `.bounded`, expected ≈ 0. A spike ⇒ mis-derived bound or common recurrence ⇒ flip the switch. `MERKLE_MISMATCH_IN_SWM` decline rate should stay flat (that lane is off the bound path).

### Tests

- **storage** (`graph-manager-swm-bound.test.ts`): T1 filter selection (multi-author, off-range, non-parsing, staging), T2 five-segment sub-graph URI, T3 absent-bound no-op pin, T5a bounded ≡ unbounded quad set.
- **agent** (`swm-slice-ka-bound.test.ts`, 11 tests): T4 `deriveSwmKaGraphBound` (packed round-trip, batch range, cross-author, non-positive/inverted, kill-switch, wiring), T5/T5b bounded-only promote + equal `computeFlatKCRoot`, T6 mismatch-widen, T6b empty-widen, T6c widen-then-still-mismatch defers exactly as today and widens exactly once.
- **publisher** (`swm-slice-ack-unbounded.test.ts`): T7 pins the ACK lane off the bound path.

**Five safety branches are mutation-verified** — each was disabled and a named test failed:

| Mutation | Caught by |
|---|---|
| widen-on-empty disabled | T6b |
| widen-on-mismatch disabled | T6 |
| filter fail-open → fail-closed | T1, T5a |
| cross-author guard removed | T4 cross-author |
| compare packed id instead of low-96 | T4 ×2 + T5 finalization |

### Not run

devnet finalization e2e on a many-sibling bucket (WSL). Unit + integration cover the logic; a real Oxigraph under load has not been exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
