### PR TITLE
chore(release): 10.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to the DKG V10 node are documented here. The format is based
 
 ## [Unreleased]
 
+## [10.0.6] - 2026-07-10
+
+Sync-, storage-, and admission-path hardening on top of 10.0.5, plus the StorageACK priority-lane follow-ups and a set of CLI/RPC fixes. Eliminates the perpetually-dirty graph-set-index full scan that was saturating managed Oxigraph cores, bounds sync-responder memory and coalesces duplicate sync fan-out, makes network admission probing back off and use canonical peer ids, and completes the StorageACK priority-lane hardening (ACK candidate selection, async promote-queue read serialization, and OT-RFC-49 host-mode ciphertext strip-by-curation). **No smart-contract changes — no deployment required** (no Solidity source, ABI, or mainnet/testnet deployment-registry changes since 10.0.5).
+
+### Fixed
+
+- **StorageACK priority-lane follow-up hardening** (#1564): the ACK candidate pool now unions the peer store with active libp2p connections so it is not empty immediately after startup; async promote-queue status/list/stats reads are serialized under the queue mutation lock so readers never observe a transitional `running` row; and OT-RFC-49 host-mode ciphertext stripping is gated by cached curation classification across both the legacy and chunked dispatch paths, so a stripping node never custodies private ciphertext for a curated context graph.
+- **Graph-set index kept warm and off the ACK lane** (#1563; fixes #1549): every server-side SPARQL `UPDATE` was marking the graph-set index dirty, forcing a fresh full `SELECT DISTINCT ?g` scan on the next `listGraphs` (sync responder, finalization slice, ACK SWM read) — 12–30 s under load, the dominant driver of managed-Oxigraph saturation. The index now updates from the statically known touched-graph URIs at the source (RS-heal, agents-`_meta` prune) and stays off the StorageACK read path.
+- **Graph-index SPARQL update maintenance hardened** (#1554): index maintenance now uses the authoritative `touchedGraphs` path with dirty-rebuild-only background scheduling, fails closed for arbitrary SPARQL updates via a shared ReDoS-safe operation analyzer, and centralizes generation-stale recovery so raced maintenance cannot apply obsolete graph membership.
+- **Sync responder snapshot heap bounded** (#1569): the sync responder no longer copies full-snapshot pages, reducing heap amplification under sync load, and adds telemetry to attribute remaining sync memory.
+- **Duplicate sync fan-out coalesced** (#1559): duplicate in-flight durable and shared-memory peer/context-graph syncs — and identical `syncContextGraphFromConnectedPeers` catch-up rounds — are coalesced before they consume separate global backpressure slots.
+- **Canonical peer ids for admission proofs** (#1555): remote, response, and explicit-connect peer ids are canonicalized before network-identity proof comparison, while invalid `/p2p/` targets stay rejected with `INVALID_PEER_ID`.
+- **Failed network admission probes back off** (#1558): failed network-identity probes get a short retryable backoff (longer for unsupported-protocol failures), repeat probes for already-rejected peers are skipped, and backoff clears on a successful verification or rejection.
+- **Configured API host honored for status** (#1570): the status path respects the configured API host instead of assuming a default bind address.
+- **Managed Oxigraph timeout options honored** (#1552): managed-Oxigraph query timeout options are applied as configured.
+- **Git tag signature verification honored in polling** (#1556): the Git auto-update polling path verifies tag signatures rather than trusting the tag ref alone.
+
+### Changed
+
+- **RPC-failover read-intent and stickiness ergonomics** (#1560, follow-up to #1544/#1548): a behavior-preserving refactor of the `packages/chain` transport — tip reads go through a named `readTip` wrapper, and `EndpointStickiness.attempts(canonical, intent)` bundles the per-loop order/record-success/record-failure triple so `(canonical, intent)` cannot drift across the four failover loops. No production-behavior change.
+- **Admission policy follow-ups** (#1582): bounded admission-probe retry history and active suppression are extracted behind `NetworkAdmissionService`, the mode branch is replaced with a private automatic-only suppression gate (shared in-flight coalescing preserved), and the `/api/connect` status/error-envelope policy is extracted into a pure route-local classifier. Behavior-preserving refactor.
+
+### Deployment
+
+- **No contract changes in this release.** No Solidity source, ABI, or mainnet/testnet deployment-registry changes since 10.0.5, so no on-chain deployment is required and nodes need no action to upgrade.
+- **On-chain PublishingConviction surface unchanged from 10.0.5.** Mainnet (Base + Gnosis) remains on 10.0.7; the 10.0.8 deploy and PCA emission-schedule migration remain a separate, coordinated on-chain activity, unaffected by this node release.
+
 ## [10.0.5] - 2026-07-08
 
 Node stability and sync hardening on top of 10.0.4, plus contract updates and post-canary mainnet-readiness fixes. Ends the oversize-literal retry loop that could pin sync CPU, keeps the `agents/_meta` graph off the sync plane (reduces sync fan-out load), gates node-UI metric store-scans on consumer presence, and repairs the 10.0.4 npm tarball, which shipped without its `network/*.json` overlays and `project.json` (npm-installed nodes were falling back to built-in defaults). Also ships updated PublishingConviction 10.0.8 contracts (sources + ABIs); the on-chain deploy is a separate, coordinated activity (see **Deployment**). The stable cut extends the `10.0.5-canary.1` testnet build with ACK-path hardening, RPC failover fixes, graph-indexed hot-path store reads, active-network peer isolation, git auto-update opt-in, and KA publish lifecycle observability.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dkg-v10",
-  "version": "10.0.5",
+  "version": "10.0.6",
   "private": true,
   "packageManager": "pnpm@10.28.1",
   "dkgBuild": {

--- a/packages/adapter-elizaos/package.json
+++ b/packages/adapter-elizaos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-elizaos",
-  "version": "10.0.5",
+  "version": "10.0.6",
   "description": "ElizaOS plugin adapter — turns any ElizaOS agent into a DKG V10 node",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapter-hermes/package.json
+++ b/packages/adapter-hermes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-hermes",
-  "version": "10.0.5",
+  "version": "10.0.6",
   "description": "Hermes Agent adapter — connects Hermes AI agents to a DKG V10 node for verifiable shared memory",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapter-openclaw/package.json
+++ b/packages/adapter-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-openclaw",
-  "version": "10.0.5",
+  "version": "10.0.6",
   "description": "OpenClaw plugin adapter for connecting a DKG V10 node and chat bridge to an OpenClaw agent",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-agent",
-  "version": "10.0.5",
+  "version": "10.0.6",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/chain/package.json
+++ b/packages/chain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-chain",
-  "version": "10.0.5",
+  "version": "10.0.6",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg",
-  "version": "10.0.5",
+  "version": "10.0.6",
   "type": "module",
   "main": "dist/cli.js",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-core",
-  "version": "10.0.5",
+  "version": "10.0.6",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/epcis/package.json
+++ b/packages/epcis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-epcis",
-  "version": "10.0.5",
+  "version": "10.0.6",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/evm-module/package.json
+++ b/packages/evm-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-evm-module",
-  "version": "10.0.5",
+  "version": "10.0.6",
   "description": "DKG V10 smart contracts (forked from V8 dkg-evm-module)",
   "license": "Apache-2.0",
   "private": true,

--- a/packages/graph-viz/package.json
+++ b/packages/graph-viz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-graph-viz",
-  "version": "10.0.5",
+  "version": "10.0.6",
   "description": "RDF Knowledge Graph Visualizer — force-directed graph rendering with hexagonal nodes, declarative view configs, RDF-native data loading, and SPARQL-driven views",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/kafka-plugin/package.json
+++ b/packages/kafka-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/kafka-plugin",
-  "version": "10.0.5",
+  "version": "10.0.6",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mcp-dkg/package.json
+++ b/packages/mcp-dkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-mcp",
-  "version": "10.0.5",
+  "version": "10.0.6",
   "description": "MCP server that exposes the local DKG daemon (projects, sub-graphs, activity, chat) to Cursor, Claude Code, and any other MCP-aware coding assistant.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/network-sim/package.json
+++ b/packages/network-sim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-network-sim",
-  "version": "10.0.5",
+  "version": "10.0.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/node-ui/package.json
+++ b/packages/node-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-node-ui",
-  "version": "10.0.5",
+  "version": "10.0.6",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/okf/package.json
+++ b/packages/okf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-okf",
-  "version": "10.0.5",
+  "version": "10.0.6",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/publisher/package.json
+++ b/packages/publisher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-publisher",
-  "version": "10.0.5",
+  "version": "10.0.6",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-query",
-  "version": "10.0.5",
+  "version": "10.0.6",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/random-sampling/package.json
+++ b/packages/random-sampling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-random-sampling",
-  "version": "10.0.5",
+  "version": "10.0.6",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-storage",
-  "version": "10.0.5",
+  "version": "10.0.6",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## What

Version-bump PR for the **10.0.6** release. Cut from `main` tip (`2b93a544f`) — scope is everything merged on `main` since the `v10.0.5` tag (`539429d4`): 12 PRs of sync/storage/admission-path hardening plus the StorageACK priority-lane follow-ups and CLI/RPC fixes. **No smart-contract changes — no deployment required.**

Single commit:

- **`chore(release): 10.0.6`** — bump all 20 workspace `package.json` from `10.0.5` → `10.0.6` + a new `CHANGELOG.md` `[10.0.6]` section.

## Changelog `[10.0.6]` summary

- **Fixed** — StorageACK priority-lane follow-up hardening (#1564); graph-set index kept warm and off the ACK lane, the dominant managed-Oxigraph saturation driver (#1563 / #1554); sync-responder heap bounded (#1569); duplicate sync fan-out coalesced (#1559); canonical peer ids for admission proofs (#1555); failed admission probes back off (#1558); configured API host honored for status (#1570); managed-Oxigraph timeout options (#1552); git tag signature verification in polling (#1556).
- **Changed** — RPC-failover read-intent + stickiness ergonomics (#1560, behavior-preserving); admission policy follow-ups (#1582, behavior-preserving).
- **Deployment** — no contract changes; the on-chain PublishingConviction surface is unchanged from 10.0.5 (mainnet Base + Gnosis still 10.0.7).

## Verification

- `pnpm release:verify-versions --version 10.0.6` → `Release package version check passed: 20 package.json files at 10.0.6.`
- `pnpm-lock.yaml` unchanged (workspace deps use `workspace:*`).
- Change set is exactly the 20 workspace `package.json` + `CHANGELOG.md` (21 files).

## Notes

- No Solidity source, ABI, or deployment-registry changes in `v10.0.5..main`, so — unlike the 10.0.5 bump (#1536) — there is **no** deploy-record rescue commit; this is a clean node-only release.
- `v10.0.5` (`539429d4`) is the release boundary. Its stable notes (#1557) already documented the post-canary PRs, so nothing in `[10.0.6]` is double-counted.

## Gates still open (for the tag/publish that follows the merge — not review blockers)

- [ ] devnet gate on the **merged** bump commit
- [ ] tag `v10.0.6` + npm publish per the manual release runbook

🤖 Generated with [Claude Code](https://claude.com/claude-code)
