### PR TITLE
test(agent): verify byte-budget oversized fallback and telemetry values

### DIFF
--- a/packages/agent/test/sync-memory-metrics.test.ts
+++ b/packages/agent/test/sync-memory-metrics.test.ts
@@ -14,6 +14,7 @@ import {
 import { createSyncResponderSnapshotBudget } from '../src/sync/responder/snapshot-budget.js';
 import { MemorySyncCheckpointStore } from '../src/sync/checkpoint/state.js';
 import { fetchSyncPages } from '../src/sync/requester/page-fetch.js';
+import { estimateQuadHeapBytes } from '../src/sync/memory-telemetry.js';
 
 function createMetricsHarness() {
   const exporter = new InMemoryMetricExporter(AggregationTemporality.CUMULATIVE);
@@ -159,6 +160,22 @@ describe('sync memory attribution metrics', () => {
     )[0].value as { buckets: { boundaries: number[] } };
     expect(byteHistogram.buckets.boundaries.at(-1)).toBeGreaterThan(10_000);
     expect(quadHistogram.buckets.boundaries.at(-1)).toBeGreaterThan(10_000);
+
+    // Assert the RECORDED measurements, not just that the series exist: a
+    // regression that finished the phase with 0 quads / 0 pages / 0 bytes would
+    // still produce points with the right labels, so presence alone is not proof.
+    const completedValue = (name: string): { sum: number; count: number } => {
+      const point = metricPoints(harness.exporter, name).find((candidate) =>
+        candidate.attributes.phase === 'durable_data' && candidate.attributes.outcome === 'completed',
+      );
+      return point!.value as { sum: number; count: number };
+    };
+    expect(completedValue('dkg.sync.requester.accumulated_quads').sum).toBe(2);
+    expect(completedValue('dkg.sync.requester.page_count').sum).toBe(2);
+    const expectedBytes =
+      estimateQuadHeapBytes({ subject: 'urn:s:1', predicate: 'urn:p', object: '"one"', graph: 'urn:data' }) +
+      estimateQuadHeapBytes({ subject: 'urn:s:2', predicate: 'urn:p', object: '"two"', graph: 'urn:data' });
+    expect(completedValue('dkg.sync.requester.accumulated_bytes').sum).toBe(expectedBytes);
   });
 
   it('attributes requester phase memory to the error outcome when parsing throws', async () => {

--- a/packages/agent/test/sync-responder-oversized-fallback.test.ts
+++ b/packages/agent/test/sync-responder-oversized-fallback.test.ts
@@ -9,6 +9,7 @@ import {
   workspaceOpQuads,
   type CapturedSyncHandler,
 } from './_helpers/sync-responder.js';
+import { estimateStringRowHeapBytes } from '../src/sync/memory-telemetry.js';
 import type { SyncRequestEnvelope } from '../src/sync/auth/request-build.js';
 
 /**
@@ -256,7 +257,70 @@ describe('oversized responder fallback is store-bounded and set-equivalent', () 
     expect(t2.size).toBe(3);
     expect([...t2].join('\n')).toContain('"row-002"');
   });
+
+  it('falls back to store-bounded paging for a BYTE-oversized durable snapshot', async () => {
+    // Byte limits are a separate production budget from the row cap and fire
+    // first for long RDF terms. Exercise the handler path under a low
+    // maxSnapshotBytesEstimate with a high row cap, so the rejection is
+    // snapshot_bytes (not snapshot_rows), and prove the graph still syncs.
+    const store = new OxigraphStore();
+    const cgId = 'byte-oversized';
+    const dataGraph = `did:dkg:context-graph:${cgId}/context/1`;
+    const rows: Quad[] = [0, 1].map((index) => ({
+      graph: dataGraph,
+      subject: `urn:byte:${index}`,
+      predicate: `${DKG_NS}label`,
+      object: `"${'x'.repeat(600)}-${index}"`,
+    }));
+    await store.insert(rows);
+    const perRowBytes = estimateStringRowHeapBytes(
+      rows[0].subject,
+      rows[0].predicate,
+      rows[0].object,
+      rows[0].graph,
+    );
+
+    const cap = registerTestSyncHandler(store, {
+      syncPageSize: 1,
+      snapshotBudget: {
+        maxRows: 1_000,
+        maxBytesEstimate: Number.MAX_SAFE_INTEGER,
+        maxSnapshotRows: 100, // the row cap does NOT bind (2 rows)
+        maxSnapshotBytesEstimate: perRowBytes + 10, // one row fits; the 2-row snapshot does not
+      },
+    });
+    const boundedQuery = watchBoundedDataPageQuery(store, dataGraph);
+    const collected = await collectAllPages(
+      cap,
+      { contextGraphId: cgId, includeSharedMemory: false, phase: 'data', limit: 1, syncSessionId: 'byte-oversized-session' },
+      1,
+    );
+
+    // Both rows are served through the store-bounded fallback, not a limit error.
+    expect(collected.size).toBe(2);
+    boundedQuery.assertObserved();
+  });
 });
+
+/** Assert the durable-data fallback issued a bounded ORDER BY/OFFSET/LIMIT page query. */
+function watchBoundedDataPageQuery(store: OxigraphStore, graph: string) {
+  const originalQuery = store.query.bind(store);
+  let observed = 0;
+  store.query = (async (sparql: string) => {
+    const normalized = sparql.replace(/\s+/g, ' ').trim();
+    if (
+      /^SELECT \?g \?s \?p \?o WHERE \{/.test(normalized) &&
+      normalized.includes(`<${graph}>`) &&
+      normalized.includes('ORDER BY ?g ?s ?p ?o') &&
+      /OFFSET \d+/.test(normalized) &&
+      /LIMIT \d+/.test(normalized)
+    ) {
+      observed += 1;
+    }
+    return originalQuery(sparql);
+  }) as OxigraphStore['query'];
+  return { assertObserved: () => expect(observed).toBeGreaterThan(0) };
+}
 
 /** Assert the durable-meta fallback issued a bounded, single-graph paged query. */
 function watchBoundedMetaPageQuery(store: OxigraphStore, metaGraph: string) {


### PR DESCRIPTION
Follow-up to #1569 addressing two post-merge review coverage gaps (both 🟡). Test-only; no production code changes.

## What & why

**Byte-budget oversized fallback is now verified end-to-end** (`otReviewAgent` on graph-plan.ts). The oversized→store-bounded fallback was only covered for the per-snapshot **row** cap. The per-snapshot **byte** cap is a separate production limit that fires first for long RDF terms, so a graph with few but large rows takes a different admission path. Added a handler-level test that trips `snapshot_bytes` (low `maxSnapshotBytesEstimate`, high `maxSnapshotRows`, 600-char object literals) and asserts every row is still served through the bounded `ORDER BY/OFFSET/LIMIT` fallback. Without this, dropping `snapshot_bytes` from `isPerSnapshotBudgetError` would silently turn those graphs into a quiet retryable limit and no test would catch it.

**Telemetry tests now assert recorded values, not just presence** (`otReviewAgent` on sync-memory-metrics.test.ts). The requester-accumulation test proved the series existed with bounded labels but not the measurements, so a `finish()` regressed to `retainedQuads = 0` / `pageCount = 0` / `accumulatedBytes = 0` would stay green. It now asserts the completed-phase histogram sums: accumulated quads = 2, page count = 2, accumulated bytes = the estimated bytes of the parsed quads.

## Test plan
- `pnpm --filter @origintrail-official/dkg-agent build` ✓
- `pnpm --dir packages/agent exec vitest run --config vitest.unit.config.ts` → 45 files / 461 tests ✓

## Follow-ups (tracked separately, per the "keep it focused" review feedback)
This is the first of a small series of focused follow-up PRs for the #1569 post-merge feedback. Still to come as their own PRs: split the 1.5k-line responder interleaving test file; collapse the snapshot memo's parallel maps into one state machine; unify the canonical/paged filter twins into one source of truth; and a stable keyset/seek cursor for the oversized fallback (closing the documented OFFSET-under-mutation limitation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)