### PR TITLE
fix(agent): stop sync responder overflowing the stack on large graphs

### DIFF
--- a/packages/agent/src/dkg-agent-utils.ts
+++ b/packages/agent/src/dkg-agent-utils.ts
@@ -17,6 +17,7 @@
 
 import type { Quad } from '@origintrail-official/dkg-storage';
 import type { Logger, OperationContext } from '@origintrail-official/dkg-core';
+import { appendInPlace } from './sync/append-in-place.js';
 import {
   computeFlatKCRootV10 as computeFlatKCRoot,
   skolemizeByEntity,
@@ -344,7 +345,7 @@ export function verifySyncedData(
       const allQuadsForKC: Quad[] = [];
       for (const re of rootEntities) {
         const quads = partitioned.get(re) ?? [];
-        allQuadsForKC.push(...quads);
+        appendInPlace(allQuadsForKC, quads);
       }
 
       // Collect private merkle roots from KA metadata for this KC

--- a/packages/agent/src/sync-verify-worker-impl.ts
+++ b/packages/agent/src/sync-verify-worker-impl.ts
@@ -4,6 +4,7 @@ import { computeFlatKCRootV10 as computeFlatKCRoot, skolemizeByEntity } from '@o
 import type { Quad } from '@origintrail-official/dkg-storage';
 import type { SyncVerifyResult, SyncVerifyLogEntry, SyncParseResult, SharedMemoryProcessResult, DurableBatchProcessResult, SharedMemoryBatchProcessResult } from './sync-verify-worker.js';
 import { isSharedMemoryBucketDescendantDataGraph } from './sync/shared-memory-graphs.js';
+import { appendInPlace } from './sync/append-in-place.js';
 
 const DKG_NS = 'http://dkg.io/ontology/';
 const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
@@ -152,7 +153,7 @@ export function verifySyncedData(
       const allQuadsForKC: Quad[] = [];
       for (const rootEntity of rootEntities) {
         const quads = partitioned.get(rootEntity) ?? [];
-        allQuadsForKC.push(...quads);
+        appendInPlace(allQuadsForKC, quads);
       }
 
       const privateRoots: Uint8Array[] = [];

--- a/packages/agent/src/sync/append-in-place.ts
+++ b/packages/agent/src/sync/append-in-place.ts
@@ -1,0 +1,24 @@
+/**
+ * Append every element of `source` onto `target`, in place, without the
+ * argument-spread form (`target.push(...source)`).
+ *
+ * `Array.prototype.push(...source)` passes each element of `source` as a
+ * separate function argument. V8 bounds the number of arguments a single call
+ * may spread onto the stack (empirically ~1.25e5 elements on Node 22) and
+ * throws `RangeError: Maximum call stack size exceeded` past that bound. The
+ * sync responder and requester assemble store- and network-sized row/quad
+ * arrays — a single shared-memory data graph routinely holds far more than that
+ * limit — so the spread form crashes the `/dkg/x/sync` handler mid-serve on a
+ * large context graph. The failure surfaces as
+ * `[ProtocolRouter] handler error on /dkg/x/sync from <peer>: Maximum call
+ * stack size exceeded`, the stream is aborted, and the requesting member never
+ * receives the data (it retries and backs off forever).
+ *
+ * A plain index loop appends one element per iteration, is O(n) like the
+ * spread, preserves order, and has no argument-count bound.
+ */
+export function appendInPlace<T>(target: T[], source: readonly T[]): void {
+  for (let i = 0; i < source.length; i += 1) {
+    target.push(source[i]);
+  }
+}

--- a/packages/agent/src/sync/requester/page-fetch.ts
+++ b/packages/agent/src/sync/requester/page-fetch.ts
@@ -2,6 +2,7 @@ import type { OperationContext } from '@origintrail-official/dkg-core';
 import type { Quad } from '@origintrail-official/dkg-storage';
 import { sendSyncRequest } from '../../p2p/sync-transport.js';
 import { markSyncPeerResponded } from '../error-tags.js';
+import { appendInPlace } from '../append-in-place.js';
 import type { SyncPhase } from '../auth/request-build.js';
 import { getSyncCheckpointKey, type SyncCheckpointStore } from '../checkpoint/state.js';
 import {
@@ -316,11 +317,11 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
       }
 
       if (parsed.totalQuads === 0) {
-        if (parsed.quads.length > 0) allQuads.push(...parsed.quads);
+        if (parsed.quads.length > 0) appendInPlace(allQuads, parsed.quads);
         break;
       }
 
-      allQuads.push(...parsed.quads);
+      appendInPlace(allQuads, parsed.quads);
       offset += parsed.totalQuads;
 
       if (debugSyncProgress) {

--- a/packages/agent/src/sync/requester/swm-recovery.ts
+++ b/packages/agent/src/sync/requester/swm-recovery.ts
@@ -7,6 +7,7 @@ import {
 import type { SyncPageResult } from './page-fetch.js';
 import { applySwmRecovery, type SwmRecoveryStore } from './swm-recovery-apply.js';
 import { sharedMemoryOwnershipKeyFromGraph } from './shared-memory-sync.js';
+import { appendInPlace } from '../append-in-place.js';
 
 /**
  * recovery entry point. Recovers a CG's
@@ -122,7 +123,7 @@ async function fetchPhaseFully(
     const page = await deps.fetchSyncPages(
       deps.ctx, deps.remotePeerId, deps.contextGraphId, true, phase, graphUri, deps.deadline,
     );
-    all.push(...page.quads);
+    appendInPlace(all, page.quads);
     lastCheckpointKey = page.checkpointKey;
     if (page.completed) {
       deps.deleteCheckpoint(page.checkpointKey);

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -8,7 +8,6 @@ import {
 } from '@origintrail-official/dkg-core';
 import type { QueryOptions, TripleStore } from '@origintrail-official/dkg-storage';
 import { isSharedMemoryBucketDescendantDataGraph } from '../shared-memory-graphs.js';
-import { appendInPlace } from '../append-in-place.js';
 import type { SyncRow, SyncRowListMemo } from './snapshot-cache.js';
 import { SyncRowSnapshotBudgetError } from './snapshot-budget.js';
 
@@ -859,9 +858,16 @@ async function readFreshSwmDataRows(
     if (roots.size === 0) continue;
     const rootPrefixes = [...roots].map((root) => `${root}/.well-known/genid/`);
     const graphRows = await readRowsAcrossGraphs(store, candidateGraphsFor(graph), signal);
-    appendInPlace(rows, graphRows.filter((row) =>
-      roots.has(row.s) || rootPrefixes.some((prefix) => row.s.startsWith(prefix)),
-    ));
+    // Append only matching rows, one at a time — never `rows.push(...matches)`.
+    // The spread passes every element as a call argument, so a shared-memory
+    // graph with more than V8's argument-count limit (~1.25e5) of matching rows
+    // throws `RangeError: Maximum call stack size exceeded` mid-serve. The loop
+    // also avoids allocating a filtered intermediary before appending.
+    for (const row of graphRows) {
+      if (roots.has(row.s) || rootPrefixes.some((prefix) => row.s.startsWith(prefix))) {
+        rows.push(row);
+      }
+    }
   }
   return rows.sort(compareRows);
 }

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -8,6 +8,7 @@ import {
 } from '@origintrail-official/dkg-core';
 import type { QueryOptions, TripleStore } from '@origintrail-official/dkg-storage';
 import { isSharedMemoryBucketDescendantDataGraph } from '../shared-memory-graphs.js';
+import { appendInPlace } from '../append-in-place.js';
 import type { SyncRow, SyncRowListMemo } from './snapshot-cache.js';
 import { SyncRowSnapshotBudgetError } from './snapshot-budget.js';
 
@@ -858,7 +859,7 @@ async function readFreshSwmDataRows(
     if (roots.size === 0) continue;
     const rootPrefixes = [...roots].map((root) => `${root}/.well-known/genid/`);
     const graphRows = await readRowsAcrossGraphs(store, candidateGraphsFor(graph), signal);
-    rows.push(...graphRows.filter((row) =>
+    appendInPlace(rows, graphRows.filter((row) =>
       roots.has(row.s) || rootPrefixes.some((prefix) => row.s.startsWith(prefix)),
     ));
   }

--- a/packages/agent/test/sync-append-in-place.test.ts
+++ b/packages/agent/test/sync-append-in-place.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { appendInPlace } from '../src/sync/append-in-place.js';
+
+// Safely above V8's argument-spread limit (empirically ~1.25e5 on Node 22), so
+// `target.push(...source)` reliably overflows the stack at this size.
+const OVERFLOW_SIZE = 500_000;
+
+describe('appendInPlace', () => {
+  it('appends a source larger than the argument-spread limit without overflowing the stack', () => {
+    const source = Array.from({ length: OVERFLOW_SIZE }, (_, i) => i);
+    const target: number[] = [];
+    expect(() => appendInPlace(target, source)).not.toThrow();
+    expect(target).toHaveLength(OVERFLOW_SIZE);
+    expect(target[0]).toBe(0);
+    expect(target[OVERFLOW_SIZE - 1]).toBe(OVERFLOW_SIZE - 1);
+  });
+
+  it('documents the crash it guards against: the spread form throws at the same size', () => {
+    const source = Array.from({ length: OVERFLOW_SIZE }, (_, i) => i);
+    const target: number[] = [];
+    // The exact pattern that crashed the sync responder
+    // (`rows.push(...graphRows.filter(...))`): a `RangeError: Maximum call
+    // stack size exceeded`. appendInPlace replaces every such site.
+    expect(() => target.push(...source)).toThrow(RangeError);
+  });
+
+  it('appends onto a non-empty target in order, preserving existing elements', () => {
+    const target = ['a', 'b'];
+    appendInPlace(target, ['c', 'd', 'e']);
+    expect(target).toEqual(['a', 'b', 'c', 'd', 'e']);
+  });
+
+  it('is a no-op for an empty source', () => {
+    const target = [1, 2, 3];
+    appendInPlace(target, []);
+    expect(target).toEqual([1, 2, 3]);
+  });
+});

--- a/packages/agent/test/sync-responder-large-graph-stack-overflow.test.ts
+++ b/packages/agent/test/sync-responder-large-graph-stack-overflow.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import type { TripleStore } from '@origintrail-official/dkg-storage';
+import { readSwmDataPage } from '../src/sync/responder/graph-plan.js';
+import { createResponderSyncRowListMemo } from '../src/sync/responder/snapshot-cache.js';
+
+/**
+ * Regression for the `/dkg/x/sync` responder crash:
+ * `[ProtocolRouter] handler error on /dkg/x/sync from <peer>: Maximum call
+ * stack size exceeded`.
+ *
+ * The TTL-cutoff shared-memory data path (`readFreshSwmDataRows`) materialises
+ * every fresh row of a data graph into one array. When a single shared-memory
+ * graph holds more rows than V8's argument-spread limit (~1.25e5), the former
+ * `rows.push(...graphRows.filter(...))` threw `RangeError: Maximum call stack
+ * size exceeded`, the stream was aborted, and a large member never received the
+ * data (it retried and backed off forever).
+ *
+ * This drives the real `readSwmDataPage` snapshot (cached) path with a store
+ * that returns a single fresh shared-memory graph far larger than that limit
+ * and asserts the responder returns the full row set instead of crashing.
+ */
+describe('sync responder tolerates a shared-memory graph larger than the spread limit', () => {
+  it('serves a >limit fresh SWM-data graph without a stack overflow', async () => {
+    const cg = 'test/overflow-cg';
+    const dataGraph = `did:dkg:context-graph:${cg}/_shared_memory`;
+    const metaGraph = `${dataGraph}_meta`;
+    const root = 'urn:root:overflow';
+    // Safely above V8's ~1.25e5 argument-spread limit — the old
+    // `rows.push(...)` overflowed the stack here; the fix must not.
+    const rowCount = 200_000;
+
+    const bigRows = Array.from({ length: rowCount }, (_, i) => ({
+      g: dataGraph,
+      s: root,
+      p: 'http://schema.org/name',
+      o: `"v${i}"`,
+    }));
+
+    const store = {
+      async query(sparql: string) {
+        // fresh SWM roots (readFreshSwmRoots)
+        if (sparql.includes('WorkspaceOperation')) {
+          return { type: 'bindings' as const, bindings: [{ root }] };
+        }
+        // rows across graphs (readRowsAcrossGraphs)
+        if (sparql.includes('GRAPH ?g') && sparql.includes('?s ?p ?o')) {
+          return { type: 'bindings' as const, bindings: bigRows };
+        }
+        return { type: 'bindings' as const, bindings: [] };
+      },
+    } as unknown as TripleStore;
+
+    // No budget → the snapshot is cached unconditionally, so the request
+    // exercises the in-memory snapshot (spread) path, not the paged fallback.
+    const memo = createResponderSyncRowListMemo(120_000, 32, { phase: 'durable_data' });
+
+    const rows = await readSwmDataPage({
+      store,
+      graphList: [dataGraph, metaGraph],
+      registeredSubGraphNames: [],
+      contextGraphId: cg,
+      cutoffIso: '2020-01-01T00:00:00.000Z',
+      offset: 0,
+      limit: rowCount + 10,
+      rowListMemo: memo,
+      rowListCacheKey: `${cg}:swm-data`,
+      refreshRowList: true,
+    });
+
+    expect(rows).toHaveLength(rowCount);
+    expect(rows.every((r) => r.s === root)).toBe(true);
+  }, 20_000);
+});

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -35,6 +35,8 @@ export default defineConfig({
       "test/cg-registration-oversize-guard.test.ts",
       "test/sync-responder-concurrent-interleaving.test.ts",
       "test/sync-responder-oversized-fallback.test.ts",
+      "test/sync-responder-large-graph-stack-overflow.test.ts",
+      "test/sync-append-in-place.test.ts",
       "test/sync-memory-metrics.test.ts",
       "test/sync-responder-metrics.test.ts",
       "test/sync-fetch-coalescing.test.ts",


### PR DESCRIPTION
## Problem

The shared-memory sync **data** path assembled a graph's rows with an argument spread:

```ts
rows.push(...graphRows.filter((row) => /* fresh-root filter */));
```

`Array.prototype.push(...source)` passes every element as a separate call argument. V8 bounds how many arguments a single call may spread onto the stack (empirically **~1.25e5** elements on Node 22) and throws `RangeError: Maximum call stack size exceeded` past it. `graphRows` is the **full, unpaginated** set of a shared-memory data graph's quads, so on a large context graph it exceeds that bound and the responder crashes **mid-serve**:

```
[ProtocolRouter] handler error on /dkg/x/sync from <peer>: Maximum call stack size exceeded
```

The stream is aborted, the requesting member sees `Remote closed connection during opening` → `Synced 0 data triples` → `Stopping durable sync fanout (backoff-worthy failure)`, and a member syncing a large graph **never receives its data** (it retries and backs off indefinitely). Observed on a mainnet-base 10.0.5 edge node serving a large private CG.

## Why #1569 doesn't already cover this

#1569 bounds responder **heap** (`FATAL ERROR: Reached heap limit … out of memory`). This is a distinct **stack** overflow: it fires *while building* the snapshot inside `readFreshSwmDataRows`, **upstream** of the per-snapshot budget check in `storeCached`, so the budget/oversized-fallback structurally cannot pre-empt it. The `push(...)` spread survives unchanged from 10.0.5 through 10.0.6.

## Fix

Add `appendInPlace(target, source)` — a plain index loop (O(n) like the spread, order-preserving, no argument-count bound) — and use it at every store- or network-sized append in the sync path:

- `sync/responder/graph-plan.ts` — the fresh SWM-data read (**the crash**)
- `sync/requester/page-fetch.ts` — the page accumulator (defensive; page-bounded today)
- `sync/requester/swm-recovery.ts` — SWM recovery accumulator (defensive)
- `sync-verify-worker-impl.ts` — per-KC quad accumulator (defensive)

## Tests

- `sync-append-in-place.test.ts` — asserts the old `push(...source)` spread **throws `RangeError`** and `appendInPlace` does **not**, at 5e5 elements (env-independent).
- `sync-responder-large-graph-stack-overflow.test.ts` — drives the real `readSwmDataPage` cached-snapshot path with a >limit fresh SWM graph. **Verified to throw `RangeError` on the pre-fix spread and pass after the fix.**

Full existing sync responder/requester suite (83 tests) stays green; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
