### PR TITLE
fix(storage): enumerate named graphs via the graph index, not an O(store) scan

### DIFF
--- a/packages/storage/src/adapters/graph-enumeration-query.ts
+++ b/packages/storage/src/adapters/graph-enumeration-query.ts
@@ -1,0 +1,33 @@
+/**
+ * SPARQL that enumerates named graphs currently holding at least one quad,
+ * by reading the store's named-graph index instead of scanning quads.
+ *
+ * Single source of truth for this query, shared by the Oxigraph adapters
+ * (`OxigraphStore` in-process and `SparqlHttpStore` over the oxigraph-server
+ * HTTP endpoint) so the two paths cannot silently diverge.
+ *
+ * WHY THIS SHAPE:
+ *   - `GRAPH ?g {}` matches each REGISTERED named graph exactly once. On
+ *     oxigraph (RocksDB-backed server and in-process alike) this reads the
+ *     graph index → O(#graphs), flat. Benchmarked on the pinned 0.5.8 RocksDB
+ *     binary: ~5–14 ms regardless of store size.
+ *   - The legacy `SELECT DISTINCT ?g WHERE { GRAPH ?g { ?s ?p ?o } }` forces an
+ *     O(#quads) scan + DISTINCT: 12 ms → 947 ms across 25k → 1M quads (super-
+ *     linear). On a large core store it exceeds the request timeout, the
+ *     graph-set index never seeds, and the sync responder re-runs the doomed
+ *     scan on every request — the 2026-07-10 beacon-OOM livelock (dkg #1597).
+ *
+ * WHY `FILTER EXISTS` (not bare `GRAPH ?g {}`):
+ *   A graph emptied by DELETE (not DROP) stays REGISTERED in oxigraph, so bare
+ *   `GRAPH ?g {}` over-lists it (confirmed on RocksDB: bare = 1001 vs
+ *   FILTER-EXISTS = 1000 == the legacy query). `FILTER EXISTS` reproduces the
+ *   historical non-empty-only contract exactly (see
+ *   graph-set-index-store.ts — "only graphs containing at least one quad are
+ *   listed").
+ *
+ * This is standard SPARQL 1.1 — correct on any endpoint, index-optimized on
+ * oxigraph (the sparql-http adapter's DKG backend). The Blazegraph adapter
+ * deliberately keeps the legacy scan form (mainnet cores; out of scope here).
+ */
+export const NON_EMPTY_NAMED_GRAPH_ENUMERATION_QUERY =
+  'SELECT ?g WHERE { GRAPH ?g {} FILTER EXISTS { GRAPH ?g { ?s ?p ?o } } }';

--- a/packages/storage/src/adapters/oxigraph.ts
+++ b/packages/storage/src/adapters/oxigraph.ts
@@ -1,4 +1,5 @@
 import oxigraph from 'oxigraph';
+import { NON_EMPTY_NAMED_GRAPH_ENUMERATION_QUERY } from './graph-enumeration-query.js';
 import { existsSync, readFileSync, renameSync } from 'node:fs';
 import { mkdir, open, rename } from 'node:fs/promises';
 import { dirname } from 'node:path';
@@ -300,13 +301,9 @@ export class OxigraphStore implements TripleStore {
 
   async listGraphs(options?: TripleStoreQueryOptions): Promise<string[]> {
     throwIfAborted(options?.signal);
-    // Read the graph index instead of scanning quads. See the detailed rationale
-    // in SparqlHttpStore.listGraphsDirect: `GRAPH ?g { ?s ?p ?o }` is O(#quads);
-    // `GRAPH ?g {}` reads the graph index (flat), and FILTER EXISTS preserves the
-    // non-empty-only contract (emptied-but-not-dropped graphs stay registered).
-    const result = this.store.query(
-      'SELECT ?g WHERE { GRAPH ?g {} FILTER EXISTS { GRAPH ?g { ?s ?p ?o } } }',
-    );
+    // Index-read enumeration shared with SparqlHttpStore — see the rationale on
+    // NON_EMPTY_NAMED_GRAPH_ENUMERATION_QUERY.
+    const result = this.store.query(NON_EMPTY_NAMED_GRAPH_ENUMERATION_QUERY);
     throwIfAborted(options?.signal);
     if (typeof result === 'boolean' || typeof result === 'string') return [];
     if (!Array.isArray(result)) return [];

--- a/packages/storage/src/adapters/oxigraph.ts
+++ b/packages/storage/src/adapters/oxigraph.ts
@@ -300,8 +300,12 @@ export class OxigraphStore implements TripleStore {
 
   async listGraphs(options?: TripleStoreQueryOptions): Promise<string[]> {
     throwIfAborted(options?.signal);
+    // Read the graph index instead of scanning quads. See the detailed rationale
+    // in SparqlHttpStore.listGraphsDirect: `GRAPH ?g { ?s ?p ?o }` is O(#quads);
+    // `GRAPH ?g {}` reads the graph index (flat), and FILTER EXISTS preserves the
+    // non-empty-only contract (emptied-but-not-dropped graphs stay registered).
     const result = this.store.query(
-      'SELECT DISTINCT ?g WHERE { GRAPH ?g { ?s ?p ?o } }',
+      'SELECT ?g WHERE { GRAPH ?g {} FILTER EXISTS { GRAPH ?g { ?s ?p ?o } } }',
     );
     throwIfAborted(options?.signal);
     if (typeof result === 'boolean' || typeof result === 'string') return [];

--- a/packages/storage/src/adapters/sparql-http.ts
+++ b/packages/storage/src/adapters/sparql-http.ts
@@ -483,8 +483,20 @@ export class SparqlHttpStore implements TripleStore {
 
   private async listGraphsDirect(options?: QueryOptions): Promise<string[]> {
     throwIfAborted(options?.signal);
+    // Enumerate named graphs from oxigraph's graph index, NOT via a quad scan.
+    // `GRAPH ?g { ?s ?p ?o }` forces oxigraph to iterate EVERY quad and DISTINCT
+    // the graph column — O(#quads). Benchmarked on the pinned 0.5.8 RocksDB
+    // backend: 12ms -> 947ms as the store grows 25k -> 1M quads (super-linear),
+    // so on a large core store it exceeds the request timeout, the graph-set
+    // index never seeds, and the sync responder re-runs the doomed scan on every
+    // request (the observed 30s `sync.responder.listGraphs` livelock).
+    // `GRAPH ?g {}` reads the graph index directly (flat, single-digit ms). The
+    // `FILTER EXISTS` keeps the existing non-empty-only contract: a graph emptied
+    // by DELETE (but not DROP) stays registered, so bare `GRAPH ?g {}` would
+    // over-list it and break graph-set-index-store's invariant — confirmed on the
+    // 0.5.8 RocksDB backend (bare=1001 vs FILTER-EXISTS=1000 == the old query).
     const r = await this.query(
-      'SELECT DISTINCT ?g WHERE { GRAPH ?g { ?s ?p ?o } }',
+      'SELECT ?g WHERE { GRAPH ?g {} FILTER EXISTS { GRAPH ?g { ?s ?p ?o } } }',
       { ...options, source: options?.source ?? 'sparql-http.listGraphs' },
     );
     return r.type === 'bindings' ? r.bindings.map((b) => b.g).filter(Boolean) : [];

--- a/packages/storage/src/adapters/sparql-http.ts
+++ b/packages/storage/src/adapters/sparql-http.ts
@@ -34,6 +34,7 @@ import type {
 } from '../triple-store.js';
 import { registerTripleStoreAdapter } from '../triple-store.js';
 import { externalStorePriorityScheduler } from '../store-priority-scheduler.js';
+import { NON_EMPTY_NAMED_GRAPH_ENUMERATION_QUERY } from './graph-enumeration-query.js';
 import { assertQuadLiteralsMutf8Safe, JAVA_WRITE_UTF_MAX_BYTES } from '@origintrail-official/dkg-core';
 import { createHash } from 'node:crypto';
 import { performance } from 'node:perf_hooks';
@@ -483,20 +484,11 @@ export class SparqlHttpStore implements TripleStore {
 
   private async listGraphsDirect(options?: QueryOptions): Promise<string[]> {
     throwIfAborted(options?.signal);
-    // Enumerate named graphs from oxigraph's graph index, NOT via a quad scan.
-    // `GRAPH ?g { ?s ?p ?o }` forces oxigraph to iterate EVERY quad and DISTINCT
-    // the graph column — O(#quads). Benchmarked on the pinned 0.5.8 RocksDB
-    // backend: 12ms -> 947ms as the store grows 25k -> 1M quads (super-linear),
-    // so on a large core store it exceeds the request timeout, the graph-set
-    // index never seeds, and the sync responder re-runs the doomed scan on every
-    // request (the observed 30s `sync.responder.listGraphs` livelock).
-    // `GRAPH ?g {}` reads the graph index directly (flat, single-digit ms). The
-    // `FILTER EXISTS` keeps the existing non-empty-only contract: a graph emptied
-    // by DELETE (but not DROP) stays registered, so bare `GRAPH ?g {}` would
-    // over-list it and break graph-set-index-store's invariant — confirmed on the
-    // 0.5.8 RocksDB backend (bare=1001 vs FILTER-EXISTS=1000 == the old query).
+    // Index-read enumeration shared with OxigraphStore — see the rationale on
+    // NON_EMPTY_NAMED_GRAPH_ENUMERATION_QUERY (O(#graphs) vs the legacy O(#quads)
+    // scan; FILTER EXISTS preserves the non-empty-only contract).
     const r = await this.query(
-      'SELECT ?g WHERE { GRAPH ?g {} FILTER EXISTS { GRAPH ?g { ?s ?p ?o } } }',
+      NON_EMPTY_NAMED_GRAPH_ENUMERATION_QUERY,
       { ...options, source: options?.source ?? 'sparql-http.listGraphs' },
     );
     return r.type === 'bindings' ? r.bindings.map((b) => b.g).filter(Boolean) : [];

--- a/packages/storage/test/listgraphs-nonempty-contract.test.ts
+++ b/packages/storage/test/listgraphs-nonempty-contract.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { OxigraphStore } from '../src/adapters/oxigraph.js';
+
+/**
+ * Regression for the sync-responder O(store) fix (listGraphs enumeration).
+ *
+ * listGraphs() now enumerates via oxigraph's graph index —
+ *   `SELECT ?g WHERE { GRAPH ?g {} FILTER EXISTS { GRAPH ?g { ?s ?p ?o } } }`
+ * — instead of the O(#quads) scan `SELECT DISTINCT ?g WHERE { GRAPH ?g { ?s ?p ?o } }`.
+ *
+ * The FILTER EXISTS is load-bearing: a graph emptied by DELETE (not DROP) stays
+ * REGISTERED in oxigraph, so a bare `GRAPH ?g {}` would over-list it and break
+ * graph-set-index-store's non-empty-only contract (graph-set-index-store.ts:48-53).
+ * This test fails if the query regresses to bare `GRAPH ?g {}`, and asserts the
+ * enumeration still matches the historical non-empty-only semantics.
+ */
+describe('OxigraphStore.listGraphs — non-empty-only contract (O(store) fix)', () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'oxigraph-listgraphs-')); });
+  afterEach(() => { try { rmSync(dir, { recursive: true, force: true }); } catch { /* */ } });
+
+  it('lists only graphs that currently hold quads; excludes emptied-but-registered graphs', async () => {
+    const store = new OxigraphStore(join(dir, 'store.nq'));
+    try {
+      await store.update(
+        'INSERT DATA { '
+        + 'GRAPH <urn:g:keep> { <urn:s1> <urn:p> <urn:o1> } '
+        + 'GRAPH <urn:g:emptied> { <urn:s2> <urn:p> <urn:o2> } }',
+      );
+      expect((await store.listGraphs()).sort()).toEqual(['urn:g:emptied', 'urn:g:keep']);
+
+      // Empty one graph via DELETE (NOT dropGraph) — oxigraph keeps it registered.
+      await store.update('DELETE WHERE { GRAPH <urn:g:emptied> { ?s ?p ?o } }');
+
+      // The emptied graph must be gone from the listing (non-empty-only contract).
+      // Bare `GRAPH ?g {}` would still return it here → this assertion guards that.
+      expect(await store.listGraphs()).toEqual(['urn:g:keep']);
+    } finally {
+      await store.close();
+    }
+  });
+});

--- a/packages/storage/test/listgraphs-nonempty-contract.test.ts
+++ b/packages/storage/test/listgraphs-nonempty-contract.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { OxigraphStore } from '../src/adapters/oxigraph.js';
+import { NON_EMPTY_NAMED_GRAPH_ENUMERATION_QUERY } from '../src/adapters/graph-enumeration-query.js';
 
 /**
  * Regression for the sync-responder O(store) fix (listGraphs enumeration).
@@ -41,5 +42,21 @@ describe('OxigraphStore.listGraphs — non-empty-only contract (O(store) fix)', 
     } finally {
       await store.close();
     }
+  });
+});
+
+/**
+ * Query-SHAPE guard (dkg #1597 review). Both Oxigraph adapters (in-process and
+ * sparql-http) enumerate via NON_EMPTY_NAMED_GRAPH_ENUMERATION_QUERY, so this
+ * single assertion fails if the shared query is reverted to the O(#quads)
+ * `SELECT DISTINCT ?g` scan (the livelock) OR relaxed to bare `GRAPH ?g {}`
+ * (which over-lists emptied-but-registered graphs).
+ */
+describe('non-empty named-graph enumeration query — shape guard', () => {
+  it('reads the graph index (GRAPH ?g {}), is non-empty-guarded (FILTER EXISTS), and is not the O(#quads) scan', () => {
+    const q = NON_EMPTY_NAMED_GRAPH_ENUMERATION_QUERY;
+    expect(q).toContain('GRAPH ?g {}');        // index read, not a quad scan
+    expect(q).toMatch(/FILTER\s+EXISTS/i);      // non-empty-only contract (not bare)
+    expect(q).not.toMatch(/DISTINCT/i);         // not the legacy O(#quads) scan
   });
 });

--- a/packages/storage/test/sparql-http.test.ts
+++ b/packages/storage/test/sparql-http.test.ts
@@ -12,7 +12,7 @@ let server: Server;
 let queryUrl: string;
 let updateUrl: string;
 const insertedQuads: string[] = [];
-/** How many times the server received the `SELECT DISTINCT ?g` listGraphs scan. */
+/** How many times the server received a listGraphs enumeration query (old `SELECT DISTINCT ?g` scan or the new index-read `GRAPH ?g {} FILTER EXISTS`). */
 let listGraphsHits = 0;
 
 function respondSelect(res: ServerResponse): void {
@@ -73,7 +73,7 @@ function startTestServer(): Promise<void> {
             }));
             return;
           }
-          if (decoded.includes('DISTINCT') && decoded.includes('?g')) {
+          if (decoded.includes('?g') && (decoded.includes('DISTINCT') || decoded.includes('GRAPH ?g {}'))) {
             listGraphsHits++;
             respondListGraphs(res);
             return;
@@ -181,7 +181,7 @@ describe('SparqlHttpStore (test server)', () => {
             respondSelect(res);
             return;
           }
-          if (decoded.includes('DISTINCT') && decoded.includes('?g')) {
+          if (decoded.includes('?g') && (decoded.includes('DISTINCT') || decoded.includes('GRAPH ?g {}'))) {
             arrivals.push('listGraphs');
             listGraphRequests++;
             if (listGraphRequests <= backgroundSlots) {
@@ -429,7 +429,7 @@ describe('SparqlHttpStore (test server)', () => {
     expect(has).toBe(true);
   });
 
-  it('listGraphs returns graph URIs from SELECT DISTINCT ?g', async () => {
+  it('listGraphs returns graph URIs from the graph-index enumeration query', async () => {
     const graphs = await store.listGraphs();
     expect(graphs).toContain('http://ex.org/g1');
   });

--- a/packages/storage/test/sparql-http.test.ts
+++ b/packages/storage/test/sparql-http.test.ts
@@ -14,6 +14,8 @@ let updateUrl: string;
 const insertedQuads: string[] = [];
 /** How many times the server received a listGraphs enumeration query (old `SELECT DISTINCT ?g` scan or the new index-read `GRAPH ?g {} FILTER EXISTS`). */
 let listGraphsHits = 0;
+/** The most recent listGraphs enumeration query the server received — asserted on to guard the query SHAPE (index-read, not the O(#quads) scan; dkg #1597). */
+let lastListGraphsQuery = '';
 
 function respondSelect(res: ServerResponse): void {
   if (res.writableEnded) return;
@@ -75,6 +77,7 @@ function startTestServer(): Promise<void> {
           }
           if (decoded.includes('?g') && (decoded.includes('DISTINCT') || decoded.includes('GRAPH ?g {}'))) {
             listGraphsHits++;
+            lastListGraphsQuery = decoded;
             respondListGraphs(res);
             return;
           }
@@ -430,8 +433,15 @@ describe('SparqlHttpStore (test server)', () => {
   });
 
   it('listGraphs returns graph URIs from the graph-index enumeration query', async () => {
+    lastListGraphsQuery = '';
     const graphs = await store.listGraphs();
     expect(graphs).toContain('http://ex.org/g1');
+    // Query SHAPE guard (dkg #1597 review): the adapter MUST issue the index-read
+    // form, not the O(#quads) scan and not bare `GRAPH ?g {}` (which over-lists
+    // emptied graphs). Fails if listGraphsDirect is reverted to the legacy query.
+    expect(lastListGraphsQuery).toContain('GRAPH ?g {}');
+    expect(lastListGraphsQuery).toMatch(/FILTER\s+EXISTS/i);
+    expect(lastListGraphsQuery).not.toMatch(/DISTINCT/i);
   });
 
   it('dropGraph sends DROP SILENT GRAPH to update endpoint', async () => {


### PR DESCRIPTION
## Problem — the beacon OOM livelock (2026-07-10)

`sync.responder.listGraphs` enumerates named graphs with:
```sparql
SELECT DISTINCT ?g WHERE { GRAPH ?g { ?s ?p ?o } }
```
The `{ ?s ?p ?o }` BGP forces oxigraph to iterate **every quad** to produce the graph names — **O(#quads)** work for an O(#graphs) answer. On a large core store this exceeds the sparql-http 30 s timeout, so `GraphSetIndexStore` never seeds (its refresh throws → clears the index), and the sync responder re-issues the doomed scan on **every** request. That is the fleet-wide `sync.responder.listGraphs elapsedMs=30005` livelock that saturated oxigraph and drove the beacon OOM incident.

## Fix

Switch both oxigraph adapters (in-process `oxigraph.ts` + `sparql-http.ts`) to read oxigraph's **named-graph index** directly:
```sparql
SELECT ?g WHERE { GRAPH ?g {} FILTER EXISTS { GRAPH ?g { ?s ?p ?o } } }
```

### Evidence — benchmarked on the pinned **oxigraph 0.5.8 RocksDB** binary (`~/dev/oxbench`)
| quads (1000 graphs) | old `DISTINCT ?g` | new `GRAPH ?g {} FILTER EXISTS` |
|---:|---:|---:|
| 25,000 | 12.2 ms | 5.7 ms |
| 100,000 | 37.6 ms | 9.5 ms |
| 400,000 | 206 ms | 13.7 ms |
| 1,000,000 | **947 ms** | **7.7 ms** |

Old is super-linear (78× over a 40× data increase) → crosses 30 s at beacon scale. New is **flat** (reads the graph index).

### Why `FILTER EXISTS`, not bare `GRAPH ?g {}`
A graph emptied by `DELETE` (not `DROP`) stays **registered** in oxigraph, so bare `GRAPH ?g {}` over-lists it — **confirmed on RocksDB: bare = 1001 vs FILTER-EXISTS = 1000 == the old query.** That would break `graph-set-index-store`'s non-empty-only contract. `FILTER EXISTS` reproduces the old row set exactly.

## Scope
- **Fix 1a** of the sync-responder O(store) plan (`~/dev/DKG-SYNC-RESPONDER-OSTORE-FIX-PLAN.md`). This alone breaks the livelock: the seed query now completes, so the index warms and stops re-scanning.
- **Deliberately not touched:** `blazegraph.ts` (mainnet cores — separate track).
- **Follow-ups (separate PRs):** 1b — event/generation-based memo invalidation (now a smaller optimization, since the query is cheap); Fix 3 — a persistent graph catalog so enumeration is O(#graphs) forever even as graph counts grow (`FILTER EXISTS` is O(#graphs)).

## Testing
- New regression test `listgraphs-nonempty-contract.test.ts` — asserts emptied-but-registered graphs are excluded (fails if anyone regresses to bare `GRAPH ?g {}`).
- Updated the `sparql-http` mock fixtures for the new query shape.
- `packages/storage` builds (`tsc` clean); affected suites green (graph-set-index 30, sparql-http 25, new test 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)