### PR TITLE
fix(#1596): public-CG subscribe 403 + SWM view query blow-up at scale

### DIFF
--- a/packages/cli/src/daemon/routes/context-graph.ts
+++ b/packages/cli/src/daemon/routes/context-graph.ts
@@ -1496,12 +1496,24 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
     // the sync protocol enforces access on the remote side regardless.
     const localAllowed = await agent.getContextGraphAllowedAgents(contextGraphId).catch(() => [] as string[]);
     if (localAllowed.length > 0) {
-      const callerAddr = requestAgentAddress ?? agent.getDefaultAgentAddress();
-      const isEthAddress = callerAddr && /^0x[0-9a-fA-F]{40}$/.test(callerAddr);
-      if (isEthAddress && !localAllowed.some((a: string) => a.toLowerCase() === callerAddr.toLowerCase())) {
-        return jsonResponse(res, 403, {
-          error: `Your agent (${callerAddr}) is not on the allowlist for this curated project. Ask the curator to invite you first.`,
-        });
+      // Issue #1596 / #865: an explicit `accessPolicy="public"` ALWAYS wins over
+      // the allowlist. On a public CG the allowlist gates PUBLISHERS, not
+      // subscribers/readers, so an allowlist entry must not turn a public CG
+      // into invite-only-to-join. Defer to the resolver's `isPrivateContextGraph`
+      // (the single source of truth) so this route can never re-drift from the
+      // resolver rule. Fail CLOSED on a read error (keep the gate) — the remote
+      // sync protocol is the real enforcement, and a public CG's `_meta` is
+      // already local here (we just read its allowlist from it), so the policy
+      // read is reliable in practice.
+      const isPrivate = await agent.isPrivateContextGraph(contextGraphId).catch(() => true);
+      if (isPrivate) {
+        const callerAddr = requestAgentAddress ?? agent.getDefaultAgentAddress();
+        const isEthAddress = callerAddr && /^0x[0-9a-fA-F]{40}$/.test(callerAddr);
+        if (isEthAddress && !localAllowed.some((a: string) => a.toLowerCase() === callerAddr.toLowerCase())) {
+          return jsonResponse(res, 403, {
+            error: `Your agent (${callerAddr}) is not on the allowlist for this curated project. Ask the curator to invite you first.`,
+          });
+        }
       }
     }
 

--- a/packages/cli/test/daemon-http-behavior-extra.test.ts
+++ b/packages/cli/test/daemon-http-behavior-extra.test.ts
@@ -2157,7 +2157,7 @@ describe('#1596 — subscribe allowlist gate respects explicit public accessPoli
   const OTHER = '0x00000000000000000000000000000000000000ff';
 
   async function subscribeWith(opts: {
-    isPrivate: boolean;
+    isPrivate: boolean | 'throw';
     allowlist: string[];
   }): Promise<{ status: number; subscribeCalled: boolean }> {
     const contextGraphId = 'cg-1596-' + Math.random().toString(36).slice(2, 8);
@@ -2191,7 +2191,10 @@ describe('#1596 — subscribe allowlist gate respects explicit public accessPoli
         const url = new URL(req.url ?? '/', 'http://127.0.0.1');
         const agent = {
           getContextGraphAllowedAgents: async () => opts.allowlist,
-          isPrivateContextGraph: async () => opts.isPrivate,
+          isPrivateContextGraph: async () => {
+            if (opts.isPrivate === 'throw') throw new Error('policy read failed');
+            return opts.isPrivate;
+          },
           getDefaultAgentAddress: () => CALLER,
           getSubscribedContextGraphs: () => new Map(),
           subscribeToContextGraph: () => {
@@ -2274,6 +2277,19 @@ describe('#1596 — subscribe allowlist gate respects explicit public accessPoli
   it('still 403s a non-allowlisted caller on an explicit-private CG', async () => {
     const { status, subscribeCalled } = await subscribeWith({
       isPrivate: true, // accessPolicy="private" / curated
+      allowlist: [OTHER],
+    });
+    expect(status).toBe(403);
+    expect(subscribeCalled).toBe(false);
+  });
+
+  it('keeps the allowlist gate CLOSED (403) when the privacy resolver read fails', async () => {
+    // Fix 1 fails closed: `isPrivateContextGraph(...).catch(() => true)`. A
+    // resolver error must keep the curated gate, never fall open to public —
+    // otherwise a future fail-open regression would silently pass the cases
+    // above while letting a non-allowlisted caller subscribe. (#1599 review.)
+    const { status, subscribeCalled } = await subscribeWith({
+      isPrivate: 'throw',
       allowlist: [OTHER],
     });
     expect(status).toBe(403);

--- a/packages/cli/test/daemon-http-behavior-extra.test.ts
+++ b/packages/cli/test/daemon-http-behavior-extra.test.ts
@@ -2145,3 +2145,138 @@ describe('CLI-13 / CLI-14 — shutdown signal exit codes & timer cleanup', () =>
     expect(dt).toBeLessThan(8_000);
   }, 120_000);
 });
+
+// Issue #1596: POST /api/subscribe must not 403 a caller off the allowlist when
+// the CG's explicit accessPolicy is "public". On a public CG the allowlist gates
+// PUBLISHERS, not subscribers, so an allowlist entry must not turn a public CG
+// into invite-only-to-join. An explicit-private CG must still 403. The route now
+// defers to the resolver's `isPrivateContextGraph` (the #865 single source of
+// truth) instead of gating on "allowlist non-empty" alone.
+describe('#1596 — subscribe allowlist gate respects explicit public accessPolicy', () => {
+  const CALLER = '0x0000000000000000000000000000000000000001';
+  const OTHER = '0x00000000000000000000000000000000000000ff';
+
+  async function subscribeWith(opts: {
+    isPrivate: boolean;
+    allowlist: string[];
+  }): Promise<{ status: number; subscribeCalled: boolean }> {
+    const contextGraphId = 'cg-1596-' + Math.random().toString(36).slice(2, 8);
+    const catchupTracker = {
+      jobs: new Map<string, any>(),
+      latestByContextGraph: new Map<string, string>(),
+    };
+    const previousCatchupRunner = daemonState.catchupRunner;
+    // Benign runner: the queued job runs fire-and-forget after the response and
+    // must not touch the mock agent in a way that throws.
+    daemonState.catchupRunner = {
+      run: async () => ({
+        connectedPeers: 0,
+        syncCapablePeers: 0,
+        peersTried: 0,
+        peersResponded: 0,
+        peersSucceeded: 0,
+        dataSynced: 0,
+        sharedMemorySynced: 0,
+        denied: false,
+        deniedPeers: 0,
+        diagnostics: {},
+      }),
+      close: async () => {},
+    } as any;
+
+    let subscribeCalled = false;
+    let routeServer: Server | null = null;
+    try {
+      routeServer = createServer(async (req, res) => {
+        const url = new URL(req.url ?? '/', 'http://127.0.0.1');
+        const agent = {
+          getContextGraphAllowedAgents: async () => opts.allowlist,
+          isPrivateContextGraph: async () => opts.isPrivate,
+          getDefaultAgentAddress: () => CALLER,
+          getSubscribedContextGraphs: () => new Map(),
+          subscribeToContextGraph: () => {
+            subscribeCalled = true;
+          },
+          contextGraphHasLocalContent: async () => false,
+          markContextGraphSubscriptionState: () => {},
+          resolveAgentByToken: () => undefined,
+        };
+        await handleContextGraphRoutes({
+          req,
+          res,
+          agent,
+          publisherControl: {},
+          publisherRuntime: null,
+          config: {},
+          startedAt: Date.now(),
+          dashDb: {},
+          opWallets: {},
+          network: {},
+          tracker: {},
+          memoryManager: {},
+          bridgeAuthToken: undefined,
+          nodeVersion: 'test',
+          nodeCommit: 'test',
+          catchupTracker,
+          extractionRegistry: {},
+          fileStore: {},
+          extractionStatus: new Map(),
+          assertionImportLocks: new Map(),
+          vectorStore: {},
+          embeddingProvider: null,
+          validTokens: new Set(),
+          apiHost: '127.0.0.1',
+          apiPortRef: { value: 0 },
+          routePlugins: [],
+          url,
+          path: url.pathname,
+          requestToken: undefined,
+          requestAgentAddress: CALLER,
+        } as any);
+        if (!res.writableEnded) {
+          res.statusCode = 404;
+          res.end();
+        }
+      });
+      await new Promise<void>((resolve) => routeServer!.listen(0, '127.0.0.1', resolve));
+      const address = routeServer.address();
+      if (!address || typeof address === 'string') {
+        throw new Error('route test server did not bind to a TCP port');
+      }
+      const response = await fetch(
+        `http://127.0.0.1:${address.port}/api/context-graph/subscribe`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ contextGraphId, includeSharedMemory: false }),
+        },
+      );
+      return { status: response.status, subscribeCalled };
+    } finally {
+      daemonState.catchupRunner = previousCatchupRunner;
+      if (routeServer) {
+        await new Promise<void>((resolve, reject) => {
+          routeServer!.close((err) => (err ? reject(err) : resolve()));
+        });
+      }
+    }
+  }
+
+  it('does NOT 403 a non-allowlisted caller on an explicit-public CG', async () => {
+    const { status, subscribeCalled } = await subscribeWith({
+      isPrivate: false, // accessPolicy="public"
+      allowlist: [OTHER], // caller is NOT in it
+    });
+    expect(status).toBe(200);
+    expect(subscribeCalled).toBe(true);
+  });
+
+  it('still 403s a non-allowlisted caller on an explicit-private CG', async () => {
+    const { status, subscribeCalled } = await subscribeWith({
+      isPrivate: true, // accessPolicy="private" / curated
+      allowlist: [OTHER],
+    });
+    expect(status).toBe(403);
+    expect(subscribeCalled).toBe(false);
+  });
+});

--- a/packages/query/src/dkg-query-engine.ts
+++ b/packages/query/src/dkg-query-engine.ts
@@ -595,8 +595,23 @@ export class DKGQueryEngine implements QueryEngine {
     if (graphs.length === 1) {
       return this.execAndNormalize(wrapWithGraph(sparql, graphs[0]));
     }
-    // Build a single union query so LIMIT/ORDER BY/DISTINCT/aggregates
-    // apply over the full dataset rather than per-graph.
+    // Prefer a single `VALUES ?g { … } GRAPH ?g { … }` query: it scopes the
+    // read to the named-graph set as ONE basic graph pattern iterated over a
+    // table, instead of one `{ GRAPH <g> { … } }` UNION branch per graph. A
+    // per-graph UNION over the ~1.4k SWM graphs of a large public context
+    // graph builds a ~1.4k-branch UnionNode that makes the oxigraph-server
+    // planner blow up and drop the socket ("fetch failed", issue #1596); the
+    // VALUES form plans in constant depth. LIMIT/ORDER BY/DISTINCT/aggregate
+    // semantics are preserved because those modifiers stay in the outer query
+    // around the injected block.
+    const valuesSparql = wrapWithGraphValues(sparql, graphs);
+    if (valuesSparql !== null) {
+      return this.execAndNormalize(valuesSparql);
+    }
+    // Residual shapes `wrapWithGraphValues` declines (an inner top-level
+    // UNION, no locatable WHERE block, or a sentinel-variable collision) keep
+    // the original union / per-graph fallback so the #789 form-aware
+    // cross-graph merge below is preserved unchanged.
     const unionSparql = wrapWithGraphUnion(sparql, graphs);
     if (unionSparql !== null) {
       return this.execAndNormalize(unionSparql);
@@ -2429,6 +2444,133 @@ function wrapWithGraphUnion(sparql: string, graphUris: string[]): string | null 
     .map((g) => `{ GRAPH <${g}> { ${inner} } }`)
     .join(' UNION ');
   return `${before} ${unionBranches} ${after}`;
+}
+
+/** The graph variable `wrapWithGraphValues` injects. Double-underscore + a
+ *  view-specific name so a user query is astronomically unlikely to bind it;
+ *  a collision is nonetheless detected and declined (never silently clamped). */
+const VIEW_GRAPH_SENTINEL = '?__dkgViewGraph';
+
+/**
+ * Wrap a query so it runs over a set of named graphs in ONE execution using a
+ * single `VALUES ?g { <g1> … } GRAPH ?g { inner }` block, instead of one
+ * `{ GRAPH <g> { inner } } UNION …` branch per graph.
+ *
+ * Why this exists (issue #1596): the per-graph UNION form (`wrapWithGraphUnion`)
+ * emits an N-branch UnionNode. At the ~1,424 SWM graphs of a large public
+ * context graph that is a ~257 KB query whose union tree makes the
+ * oxigraph-server query planner blow up and reset the connection ("fetch
+ * failed"). A single VALUES table is one basic graph pattern iterated over the
+ * graph list — constant plan depth — so it scales.
+ *
+ * Semantics are preserved. LIMIT/ORDER BY/DISTINCT/GROUP BY/aggregate all live
+ * in the outer query (the `before`/`after` slices) and reduce over the merged
+ * solution set exactly as the UNION form did. The one hazard is the injected
+ * graph variable leaking into the caller's projection: a bare `SELECT *` would
+ * expose `?__dkgViewGraph` as a mystery column, and cross-graph DISTINCT of an
+ * identical triple would split on the graph. Both are neutralised by scoping
+ * the VALUES+GRAPH block inside a sub-SELECT that projects ONLY the user's own
+ * variables (collected from `inner`), so the sentinel never escapes.
+ *
+ * Returns `null` (caller falls back to `wrapWithGraphUnion` / per-graph
+ * execution) when the WHERE block cannot be located, when `inner` carries a
+ * top-level UNION (kept on the #789 form-aware fallback so its behaviour and
+ * tests are untouched), when the user query already binds the sentinel, or
+ * when the WHERE body binds no user variable at all (a var-less body offers
+ * nowhere to hide the sentinel from a `SELECT *` projection).
+ */
+function wrapWithGraphValues(sparql: string, graphUris: string[]): string | null {
+  if (hasGraphClause(sparql)) return sparql;
+  if (graphUris.length === 0) return sparql;
+
+  const braceStart = findWhereBraceStart(sparql);
+  if (braceStart === -1) return null;
+  const braceEnd = findMatchingCloseBrace(sparql, braceStart);
+  if (braceEnd === -1) return null;
+
+  const before = sparql.slice(0, braceStart + 1);
+  const inner = sparql.slice(braceStart + 1, braceEnd);
+  const after = sparql.slice(braceEnd);
+
+  if (graphUris.length === 1) {
+    return `${before} GRAPH <${assertSafeIri(graphUris[0])}> { ${inner} } ${after}`;
+  }
+
+  // An inner top-level UNION stays on the per-graph fallback (#789): merging
+  // that shape across graphs is form-aware there, and this keeps that path and
+  // its tests unchanged. Same guard `wrapWithGraphUnion` uses.
+  if (/\bUNION\b/i.test(inner)) return null;
+
+  // Never clamp a variable the user actually uses — fall back instead.
+  const sentinelName = VIEW_GRAPH_SENTINEL.slice(1);
+  if (collectQueryVariables(sparql).some((v) => v.slice(1) === sentinelName)) {
+    return null;
+  }
+
+  const innerVars = collectQueryVariables(inner);
+  if (innerVars.length === 0) {
+    // Var-less WHERE body (all-constant triples, e.g. `SELECT * WHERE { <a>
+    // <b> <c> }`). We cannot hide the sentinel here: a sub-SELECT projecting
+    // the empty user-variable set is not legal SPARQL, and the bare form would
+    // let `SELECT *` project the injected `?__dkgViewGraph` (leaking the SWM
+    // graph IRI, which embeds a wallet address). Decline so the caller falls
+    // back to the union / per-graph path, which binds no graph variable. Such
+    // a query over many graphs is not a real view workload, so the fallback's
+    // cost is irrelevant.
+    return null;
+  }
+
+  const values = graphUris.map((g) => `<${assertSafeIri(g)}>`).join(' ');
+  const graphBlock = `VALUES ${VIEW_GRAPH_SENTINEL} { ${values} } GRAPH ${VIEW_GRAPH_SENTINEL} { ${inner} }`;
+  // Hide the sentinel behind a sub-SELECT that re-exposes only the user's
+  // variables, so `SELECT *` and cross-graph DISTINCT behave as they did under
+  // the UNION form.
+  return `${before} { SELECT ${innerVars.join(' ')} WHERE { ${graphBlock} } } ${after}`;
+}
+
+/**
+ * Collect every distinct SPARQL variable (`?x` / `$x`, in first-seen order,
+ * sigil included) in a query fragment, skipping tokens inside line comments,
+ * string literals, and IRI refs. Reuses the same literal/comment/IRI-aware
+ * primitives as `collectGraphVariables` so a `?`/`$` inside a literal or IRI is
+ * never mistaken for a variable.
+ */
+function collectQueryVariables(sparql: string): string[] {
+  const variables: string[] = [];
+  const seen = new Set<string>();
+  const n = sparql.length;
+  let i = 0;
+
+  while (i < n) {
+    const ch = sparql[i];
+    if (ch === '#') {
+      while (i < n && sparql[i] !== '\n') i++;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      i = skipSparqlStringLiteral(sparql, i);
+      continue;
+    }
+    if (ch === '<') {
+      const end = skipSparqlIriRef(sparql, i);
+      i = end ?? i + 1;
+      continue;
+    }
+    if (ch === '?' || ch === '$') {
+      const variable = readSparqlVariable(sparql, i);
+      if (variable) {
+        if (!seen.has(variable)) {
+          seen.add(variable);
+          variables.push(variable);
+        }
+        i += variable.length;
+        continue;
+      }
+    }
+    i++;
+  }
+
+  return variables;
 }
 
 /**

--- a/packages/query/test/query-engine.test.ts
+++ b/packages/query/test/query-engine.test.ts
@@ -347,6 +347,44 @@ describe('DKGQueryEngine', () => {
       // that would project the sentinel.
       expect(multiGraphQuery()).toBeUndefined();
     });
+
+    // #1599 review: the VALUES fast path changed execution for EVERY multi-graph
+    // query form with a locatable WHERE block, but only SELECT was covered above.
+    // CONSTRUCT and ASK are part of the engine contract and have had shape
+    // regressions before (#789), so pin them through the new VALUES path too —
+    // without an inner UNION (which would divert to the per-graph fallback).
+    it('CONSTRUCT over the SWM view uses the VALUES path and keeps the quad shape', async () => {
+      const quads: Quad[] = [];
+      for (let i = 0; i < 4; i++) {
+        quads.push(q(`urn:cq:s${i}`, 'http://ex.org/p', `"v${i}"`, swmGraph('0xcq', i)));
+      }
+      await recStore.insert(quads);
+      recStore.queries.length = 0;
+
+      const result = await swmQuery('CONSTRUCT { ?s <urn:out> ?o } WHERE { ?s <http://ex.org/p> ?o }');
+      // Graph-shaped result preserved (not silently flattened to bindings).
+      expect(result.quads).toBeDefined();
+      expect((result.quads ?? []).map((qd) => qd.subject).sort())
+        .toEqual(['urn:cq:s0', 'urn:cq:s1', 'urn:cq:s2', 'urn:cq:s3']);
+      expect((result.quads ?? []).every((qd) => qd.predicate === 'urn:out')).toBe(true);
+      // ...and it went through the ONE VALUES query, never a per-graph UNION.
+      expect(multiGraphQuery()).toBeDefined();
+      expect(recStore.queries.some((s) => /}\s*UNION\s*{\s*GRAPH\s*</i.test(s))).toBe(false);
+    });
+
+    it('ASK over the SWM view uses the VALUES path and returns the boolean', async () => {
+      await recStore.insert([
+        q('urn:aq:s', 'http://ex.org/p', '"present"', swmGraph('0xaq', 2)),
+      ]);
+      recStore.queries.length = 0;
+
+      const hit = await swmQuery('ASK WHERE { ?s <http://ex.org/p> "present" }');
+      expect(hit.bindings).toEqual([{ result: 'true' }]);
+      expect(multiGraphQuery()).toBeDefined();
+
+      const miss = await swmQuery('ASK WHERE { ?s <http://ex.org/p> "absent" }');
+      expect(miss.bindings).toEqual([{ result: 'false' }]);
+    });
   });
 
   it('queries across all contextGraphs', async () => {

--- a/packages/query/test/query-engine.test.ts
+++ b/packages/query/test/query-engine.test.ts
@@ -230,6 +230,125 @@ describe('DKGQueryEngine', () => {
     });
   });
 
+  // ───────────────────────────────────────────────────────────────────
+  // #1596: the strict `shared-working-memory` view over a large public CG
+  // fans out to ~1,424 named graphs. The previous multi-graph wrapper emitted
+  // one `{ GRAPH <g> { … } } UNION …` branch per graph — a ~1,424-branch union
+  // tree that makes the oxigraph-server planner blow up and drop the socket
+  // ("fetch failed"). The read must now be a SINGLE `VALUES ?g { … } GRAPH ?g
+  // { … }` query, with the injected graph variable hidden behind a sub-SELECT
+  // so `SELECT *` and cross-graph DISTINCT keep their UNION-form semantics.
+  describe('#1596 multi-graph SWM view uses one VALUES block, not per-graph UNION', () => {
+    const SWM_CG = 'swm-1596';
+    const swmGraph = (addr: string, n: number) =>
+      `did:dkg:context-graph:${SWM_CG}/_shared_memory/${addr}/${n}`;
+
+    // A store that records every SPARQL string the engine sends, then delegates.
+    class RecordingStore extends OxigraphStore {
+      queries: string[] = [];
+      async query(sparql: string, options?: Parameters<OxigraphStore['query']>[1]) {
+        this.queries.push(sparql);
+        return super.query(sparql, options);
+      }
+    }
+
+    let recStore: RecordingStore;
+    let recEngine: DKGQueryEngine;
+
+    beforeEach(() => {
+      recStore = new RecordingStore();
+      recEngine = new DKGQueryEngine(recStore);
+    });
+
+    const swmQuery = (sparql: string) =>
+      recEngine.query(sparql, { contextGraphId: SWM_CG, view: 'shared-working-memory' });
+
+    const multiGraphQuery = () =>
+      recStore.queries.find((s) => s.includes('VALUES ?__dkgViewGraph'));
+
+    it('collapses N SWM graphs into one VALUES/GRAPH query and reads every triple', async () => {
+      const quads: Quad[] = [];
+      for (let i = 0; i < 6; i++) {
+        const g = swmGraph('0xowner', i);
+        quads.push(q(`urn:swm:s${i}`, 'http://ex.org/p', `"v${i}"`, g));
+        quads.push(q(`urn:swm:s${i}`, 'http://ex.org/o', `"w${i}"`, g));
+      }
+      await recStore.insert(quads);
+      recStore.queries.length = 0; // ignore any graph-discovery from insert
+
+      const result = await swmQuery('SELECT ?s ?p ?o WHERE { ?s ?p ?o }');
+      expect(result.bindings).toHaveLength(12); // all rows, across all 6 graphs
+
+      // The multi-graph read is ONE VALUES-scoped query, never a per-graph UNION.
+      const multi = multiGraphQuery();
+      expect(multi).toBeDefined();
+      expect(multi).toContain('GRAPH ?__dkgViewGraph {');
+      expect(multi).toContain(swmGraph('0xowner', 0));
+      expect(
+        recStore.queries.some((s) => /}\s*UNION\s*{\s*GRAPH\s*</i.test(s)),
+      ).toBe(false);
+    });
+
+    it('preserves COUNT(*) aggregate semantics over the graph set', async () => {
+      const quads: Quad[] = [];
+      for (let i = 0; i < 5; i++) {
+        quads.push(q(`urn:c:s${i}`, 'http://ex.org/p', `"v${i}"`, swmGraph('0xc', i)));
+      }
+      await recStore.insert(quads);
+
+      const result = await swmQuery('SELECT (COUNT(*) AS ?count) WHERE { ?s ?p ?o }');
+      const count = Number(String(result.bindings[0]['count']).match(/^"?(\d+)"?/)?.[1]);
+      expect(count).toBe(5);
+      expect(multiGraphQuery()).toBeDefined(); // still the VALUES form
+    });
+
+    it('cross-graph DISTINCT dedupes an identical triple present in two graphs', async () => {
+      await recStore.insert([
+        q('urn:dup:s', 'http://ex.org/p', '"same"', swmGraph('0xd', 1)),
+        q('urn:dup:s', 'http://ex.org/p', '"same"', swmGraph('0xd', 2)),
+      ]);
+
+      const all = await swmQuery('SELECT ?s ?p ?o WHERE { ?s ?p ?o }');
+      expect(all.bindings).toHaveLength(2); // once per graph, like the UNION form
+
+      const distinct = await swmQuery('SELECT DISTINCT ?s ?p ?o WHERE { ?s ?p ?o }');
+      expect(distinct.bindings).toHaveLength(1); // deduped across graphs
+    });
+
+    it('SELECT * does not leak the injected graph variable', async () => {
+      await recStore.insert([
+        q('urn:star:s', 'http://ex.org/p', '"v"', swmGraph('0xe', 1)),
+        q('urn:star:s', 'http://ex.org/o', '"w"', swmGraph('0xe', 2)),
+      ]);
+
+      const star = await swmQuery('SELECT * WHERE { ?s ?p ?o }');
+      expect(star.bindings.length).toBeGreaterThanOrEqual(2);
+      for (const b of star.bindings) {
+        expect(Object.keys(b).sort()).toEqual(['o', 'p', 's']);
+        expect(Object.keys(b)).not.toContain('__dkgViewGraph');
+      }
+    });
+
+    it('SELECT * over a var-less (all-constant) body never leaks the sentinel', async () => {
+      // A var-less WHERE body offers nowhere to hide the injected graph
+      // variable, so `wrapWithGraphValues` declines and the read falls back to
+      // the union/per-graph form (which binds no graph variable). The sentinel
+      // must not appear as a result column.
+      await recStore.insert([
+        q('urn:cx', 'urn:cp', 'urn:co', swmGraph('0xf', 1)),
+        q('urn:cx', 'urn:cp', 'urn:co', swmGraph('0xf', 2)),
+      ]);
+
+      const star = await swmQuery('SELECT * WHERE { <urn:cx> <urn:cp> <urn:co> }');
+      for (const b of star.bindings) {
+        expect(Object.keys(b)).not.toContain('__dkgViewGraph');
+      }
+      // The var-less body must NOT have been emitted as the bare VALUES form
+      // that would project the sentinel.
+      expect(multiGraphQuery()).toBeUndefined();
+    });
+  });
+
   it('queries across all contextGraphs', async () => {
     // Add data to another context graph
     await store.insert([


### PR DESCRIPTION
## Summary

Fixes the two root causes in #1596. After joining the public context graph `0x633E…/fifa-world-cup-2026`, the node received SWM/VM data locally but the graph was rejected at subscribe time and the strict SWM view query failed. Investigation (code reading + a multi-agent workflow with adversarial verification) confirmed both defects:

1. **Subscribe 403 on a public CG (root cause 1).** `POST /api/subscribe` gated on the mere presence of an allowlist and never consulted the explicit `accessPolicy`, so a CG marked `accessPolicy="public"` that also carries `dkg:allowedAgent` entries was rejected as "curated / invite-only." This drifted from the #865 resolver rule: explicit `accessPolicy` always wins, and on a public CG the allowlist gates *publishers*, not subscribers/readers.

2. **SWM strict-view query blows up at scale (root cause 2).** The `shared-working-memory` view builds one query that `UNION`s every matching SWM named graph. At 1,424 graphs that is a ~257 KB, 1,424-branch `UNION` whose AST makes the **oxigraph-server** query planner blow up and reset the socket (`fetch failed`). The equivalent VM view (142 graphs) succeeds. The failure is the planner tree, not the request body size — `fetch failed` is a socket-level `TypeError`, not an HTTP status or the client timeout.

## Changes

**Fix 1 — `packages/cli/src/daemon/routes/context-graph.ts`**
Gate the allowlist 403 behind `await agent.isPrivateContextGraph(contextGraphId).catch(() => true)`, kept inside the existing `localAllowed.length > 0` block. This reuses the resolver's single source of truth so the route can never re-drift from #865. Fails **closed** on a read error (keeps the gate). The only observable change: an explicit-public CG (`isPrivate === false`) no longer 403s; explicit-private and null-policy-with-allowlist CGs are unchanged. Fixing the gate also lets the subscribe side effects (mark subscribed, enqueue catch-up) run, which the 403 previously short-circuited.

**Fix 2 — `packages/query/src/dkg-query-engine.ts`**
New `wrapWithGraphValues` + `collectQueryVariables`: `queryMultipleGraphs` now prefers a single
`… { SELECT <innerVars> WHERE { VALUES ?__dkgViewGraph { <g1> … } GRAPH ?__dkgViewGraph { <inner> } } } …`
query — one basic graph pattern iterated over a table instead of an N-branch `UNION` tree. `LIMIT`/`ORDER BY`/`DISTINCT`/`GROUP BY`/aggregate semantics are preserved (those modifiers stay in the outer query); the injected graph variable is hidden inside a sub-SELECT that re-projects only the user's own variables, so `SELECT *` and cross-graph `DISTINCT` behave exactly as under the old `UNION` form. It declines (returns `null` → existing `wrapWithGraphUnion`/per-graph fallback) for an inner top-level `UNION` (so the #789 form-aware fallback and its tests are untouched), no locatable `WHERE`, a sentinel-variable collision, or a var-less (all-constant) body — the last so a `SELECT *` can never project the sentinel. No transport change and no chunking.

## Not included (deliberately deferred)

The issue also notes the FIFA CG did not appear under `dkg_list_context_graphs(scope:"mine")`. That is a **separate** bug — the "mine" filter (`contextGraphBelongsToCaller`) keys off `callerInvolved`/`role`, not `subscribed`. An initial fix that treated `subscribed === true` as "joined" was **dropped after adversarial review**: `subscribed:true` is also set by *gossip auto-discovery* (`gossip-publish-handler.ts:208`, `persist:false`, `synced:false`), not only by explicit joins, so keying on it would flood "mine" with passively-discovered public CGs — the exact noise that filter is designed to hide. A correct fix needs an explicit "user-joined" signal that does not exist as a clean row field today (it would require threading intent through the subscription record → daemon row → filter). Tracked as a follow-up rather than shipping a fix that trades one bug for a regression.

## Files changed

- `packages/cli/src/daemon/routes/context-graph.ts` — subscribe gate defers to `isPrivateContextGraph`.
- `packages/query/src/dkg-query-engine.ts` — `wrapWithGraphValues` + `collectQueryVariables`; `queryMultipleGraphs` prefers the VALUES form.
- Tests: `packages/cli/test/daemon-http-behavior-extra.test.ts`, `packages/query/test/query-engine.test.ts`.

## Test plan

- `packages/query` — full suite **289 pass**, including 5 new #1596 tests (single VALUES block, not per-graph `UNION`; `COUNT(*)` correct across graphs; cross-graph `DISTINCT` dedupes; `SELECT *` does not leak `?__dkgViewGraph`; var-less `SELECT *` never leaks the sentinel) and the existing #789 inner-`UNION` fallback tests still green.
- `packages/cli` — new subscribe-gate tests: explicit-public → **200 + subscribes**, explicit-private → **403** (2 pass).
- `turbo build` typechecks the changed packages + deps clean (16/16).
- Adversarial diff review (3 lenses + per-finding verification) surfaced two real bugs, both handled before this PR: the var-less `SELECT *` sentinel leak (fixed here + regression test) and the "mine"/gossip conflation (Fix 3 dropped, above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
