### PR TITLE
feat(cli): stagger auto-update rollout with per-node jitter

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -137,6 +137,11 @@ function pickPreservedAutoUpdateFields(
   if (!existingAutoUpdate) return {};
   const preserved: Partial<AutoUpdateConfig> = {};
   if (existingAutoUpdate.channel) preserved.channel = existingAutoUpdate.channel;
+  // Common rollout-jitter override (npm + git). Use `!== undefined` so an
+  // explicit `0` (jitter disabled) survives a rerun rather than being dropped
+  // and silently reverting to the network/interval default.
+  if (existingAutoUpdate.updateJitterMinutes !== undefined)
+    preserved.updateJitterMinutes = existingAutoUpdate.updateJitterMinutes;
   if (source === 'git') {
     for (const field of AUTO_UPDATE_GIT_ONLY_FIELDS) {
       const value = existingAutoUpdate[field as keyof AutoUpdateConfig];

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -90,6 +90,15 @@ export interface AutoUpdateConfig {
    * `resolveAutoUpdateConfig()` falls back to network -> 30 (minutes).
    */
   checkIntervalMinutes?: number;
+  /**
+   * Rollout jitter: on detecting an available update, hold off a per-node random
+   * 0..N-minute delay before building + restarting, so a release never restarts
+   * the whole fleet in one window (the bootstrap-storm trigger behind the
+   * 2026-07 beacon OOM incident). Omit to inherit; `resolveUpdateJitterMs()`
+   * falls back to the poll interval. 0 disables. Per-node env override:
+   * `DKG_UPDATE_JITTER_MINUTES`.
+   */
+  updateJitterMinutes?: number;
   /** Optional per-step build timeout overrides for the git-based update path. */
   buildTimeoutMs?: AutoUpdateBuildTimeouts;
   /** Require signed tag verification when the git updater checks out tag refs. */
@@ -161,6 +170,8 @@ export interface NetworkConfig {
     sshKeyPath?: string;
     sshCommand?: string;
     checkIntervalMinutes: number;
+    /** Network-level default for the auto-update rollout jitter (minutes). */
+    updateJitterMinutes?: number;
     buildTimeoutMs?: AutoUpdateBuildTimeouts;
     /** Network-level default for signed tag verification in git auto-update mode. */
     verifyTagSignature?: boolean;
@@ -1273,6 +1284,7 @@ export function resolveAutoUpdateConfig(
   const sshKeyPath = cfg?.sshKeyPath ?? net?.sshKeyPath;
   const sshCommand = cfg?.sshCommand ?? net?.sshCommand;
   const checkIntervalMinutes = cfg?.checkIntervalMinutes ?? net?.checkIntervalMinutes ?? 30;
+  const updateJitterMinutes = cfg?.updateJitterMinutes ?? net?.updateJitterMinutes;
   const source = cfg?.source ?? net?.source;
   const channel = cfg?.channel ?? net?.channel;
   const cfgHasVerifyTagSignature = !!cfg && Object.prototype.hasOwnProperty.call(cfg, 'verifyTagSignature');
@@ -1305,6 +1317,7 @@ export function resolveAutoUpdateConfig(
     ...(sshKeyPath ? { sshKeyPath } : {}),
     ...(sshCommand ? { sshCommand } : {}),
     checkIntervalMinutes,
+    ...(updateJitterMinutes !== undefined ? { updateJitterMinutes } : {}),
     ...(buildTimeoutMs ? { buildTimeoutMs } : {}),
     ...(source ? { source } : {}),
     ...(channel ? { channel } : {}),

--- a/packages/cli/src/daemon/auto-update-jitter.ts
+++ b/packages/cli/src/daemon/auto-update-jitter.ts
@@ -107,15 +107,8 @@ export async function awaitUpdateHoldoff(deps: AwaitUpdateHoldoffDeps): Promise<
   return deps.isShuttingDown() ? 'abort-shutdown' : 'proceed';
 }
 
-/** Single-flight holder shared across polling ticks (see runWithUpdateHoldoff). */
-export interface UpdatePendingFlag {
-  active: boolean;
-}
-
-export interface RunWithUpdateHoldoffDeps<T> {
-  /** Persists across polling ticks so a hold-off that outlasts the poll
-   *  interval cannot start a second concurrent rollout. */
-  pending: UpdatePendingFlag;
+/** Daemon-wide config for the rollout gate — stable across polling ticks. */
+export interface UpdateHoldoffGateConfig {
   /** Resolved jitter window in ms (from resolveUpdateJitterMs). */
   jitterMs: number;
   /** True once the daemon has begun shutting down. */
@@ -123,6 +116,13 @@ export interface RunWithUpdateHoldoffDeps<T> {
   /** Toggle the daemon's user-visible "is updating" flag. */
   setUpdating: (updating: boolean) => void;
   log: (msg: string) => void;
+  /** Injectable for deterministic tests. */
+  rng?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+/** Per-rollout, mode-specific behaviour injected into a gate run. */
+export interface UpdateHoldoffStep<T> {
   /** Emit the mode-specific "holding Ns before applying" line (detected target). */
   onHold: (holdMs: number) => void;
   /**
@@ -136,55 +136,73 @@ export interface RunWithUpdateHoldoffDeps<T> {
   revalidate: () => Promise<T | null>;
   /** Apply the revalidated target (owns its own post-apply restart/log). */
   apply: (target: T) => Promise<void>;
-  /** Logged when the hold-off is aborted because the daemon is shutting down. */
+  /** Logged when the run is aborted because the daemon is shutting down. */
   shutdownMessage: string;
   /** Logged when revalidate() reports no current target (withdrawn / caught up). */
   supersededMessage: string;
-  /** Injectable for deterministic tests. */
-  rng?: () => number;
-  sleep?: (ms: number) => Promise<void>;
+}
+
+export interface UpdateHoldoffGate {
+  /** Run one rollout attempt for a detected update. Concurrent calls while a
+   *  run is in flight are no-ops (single-flight across polling ticks). */
+  run<T>(step: UpdateHoldoffStep<T>): Promise<void>;
 }
 
 /**
  * The single auto-update rollout gate shared by the git and npm daemon paths.
- * Owns the cross-cutting state machine so it lives in ONE place (and is unit
- * tested directly) instead of being duplicated inside each updater branch:
+ * A factory so it OWNS its single-flight state (the `pending` flag) instead of
+ * making callers allocate and thread a mutable object — create it ONCE, at the
+ * daemon scope, and call `.run(step)` on every polling tick. Each run:
  *
  *   single-flight guard -> hold-off (jitter) -> abort if shutting down
- *     -> REVALIDATE the target -> set isUpdating -> apply -> clear isUpdating
+ *     -> REVALIDATE the target -> abort if shutting down (revalidate is async)
+ *     -> set isUpdating -> apply -> clear isUpdating
  *
- * Mode-specific behaviour (which check, which installer, log wording, post-apply
- * restart) is injected via `revalidate`/`apply`/`onHold`/messages.
+ * The second shutdown check matters: revalidate() is a network call, so SIGTERM
+ * can arrive while it runs; without the re-check the gate would start a
+ * build/install after shutdown cleanup has begun.
  */
-export async function runWithUpdateHoldoff<T>(deps: RunWithUpdateHoldoffDeps<T>): Promise<void> {
-  if (deps.pending.active) return; // one rollout at a time
-  deps.pending.active = true;
-  try {
-    const decision = await awaitUpdateHoldoff({
-      jitterMs: deps.jitterMs,
-      isShuttingDown: deps.isShuttingDown,
-      onHold: deps.onHold,
-      rng: deps.rng,
-      sleep: deps.sleep,
-    });
-    if (decision === 'abort-shutdown') {
-      deps.log(deps.shutdownMessage);
-      return;
-    }
+export function createUpdateHoldoffGate(config: UpdateHoldoffGateConfig): UpdateHoldoffGate {
+  // Owned here so single-flight holds across ticks — do NOT recreate per tick.
+  let pending = false;
+  return {
+    async run<T>(step: UpdateHoldoffStep<T>): Promise<void> {
+      if (pending) return; // one rollout at a time
+      pending = true;
+      try {
+        const decision = await awaitUpdateHoldoff({
+          jitterMs: config.jitterMs,
+          isShuttingDown: config.isShuttingDown,
+          onHold: step.onHold,
+          rng: config.rng,
+          sleep: config.sleep,
+        });
+        if (decision === 'abort-shutdown') {
+          config.log(step.shutdownMessage);
+          return;
+        }
 
-    const target = await deps.revalidate();
-    if (target === null || target === undefined) {
-      deps.log(deps.supersededMessage);
-      return;
-    }
+        const target = await step.revalidate();
+        // revalidate() is async (a network check); shutdown may have started
+        // during it, so re-check before committing to an install/restart.
+        if (config.isShuttingDown()) {
+          config.log(step.shutdownMessage);
+          return;
+        }
+        if (target === null || target === undefined) {
+          config.log(step.supersededMessage);
+          return;
+        }
 
-    deps.setUpdating(true);
-    try {
-      await deps.apply(target);
-    } finally {
-      deps.setUpdating(false);
-    }
-  } finally {
-    deps.pending.active = false;
-  }
+        config.setUpdating(true);
+        try {
+          await step.apply(target);
+        } finally {
+          config.setUpdating(false);
+        }
+      } finally {
+        pending = false;
+      }
+    },
+  };
 }

--- a/packages/cli/src/daemon/auto-update-jitter.ts
+++ b/packages/cli/src/daemon/auto-update-jitter.ts
@@ -1,0 +1,108 @@
+/**
+ * Auto-update rollout jitter.
+ *
+ * A commit landing on the tracked ref is detected by every node within one poll
+ * interval, so without jitter the whole fleet builds + restarts in one narrow
+ * window — a synchronized bootstrap storm (the trigger behind the 2026-07-10
+ * beacon OOM incident, where all 4 cores auto-updated to 10.0.6 within ~6 min
+ * and hit the O(store) sync fallback lane at once).
+ *
+ * Poll-phase jitter does NOT fix this: detection is bounded by the interval
+ * regardless of phase. The effective lever is a per-node random HOLD-OFF
+ * between *detecting* an available update and *applying* it (build + restart) —
+ * a staggered rollout that spreads the fleet's restarts across the jitter
+ * window so only a few nodes bootstrap at any moment.
+ *
+ * Pure + deterministic (rng injectable) so it is unit-tested without the daemon.
+ */
+
+export const UPDATE_JITTER_ENV = 'DKG_UPDATE_JITTER_MINUTES';
+
+/** Upper sanity bound so a fat-fingered config can't stall updates for days. */
+const MAX_JITTER_MINUTES = 12 * 60; // 12h
+
+function parseNonNegativeMinutes(raw: string | undefined): number | undefined {
+  if (raw === undefined) return undefined;
+  const n = Number(String(raw).trim());
+  return Number.isFinite(n) && n >= 0 ? n : undefined;
+}
+
+/**
+ * Resolve the rollout-jitter window in milliseconds.
+ *
+ * Precedence: env `DKG_UPDATE_JITTER_MINUTES` > resolved config
+ * `updateJitterMinutes` > fallback = the poll interval (so the window
+ * self-scales with cadence). `0` disables. Clamped to [0, 12h].
+ */
+export function resolveUpdateJitterMs(
+  configuredMinutes: number | undefined,
+  checkIntervalMinutes: number,
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  const fromEnv = parseNonNegativeMinutes(env[UPDATE_JITTER_ENV]);
+  const fallback = Number.isFinite(checkIntervalMinutes) && checkIntervalMinutes > 0
+    ? checkIntervalMinutes
+    : 0;
+  const chosen = fromEnv
+    ?? (typeof configuredMinutes === 'number' && Number.isFinite(configuredMinutes) && configuredMinutes >= 0
+      ? configuredMinutes
+      : fallback);
+  const clamped = Math.max(0, Math.min(chosen, MAX_JITTER_MINUTES));
+  return Math.round(clamped * 60_000);
+}
+
+/**
+ * A random hold-off in [0, jitterMs). Returns 0 when jitter is disabled or the
+ * window is non-positive. `rng` returns a float in [0, 1) (defaults to
+ * Math.random) and is injectable for deterministic tests.
+ */
+export function pickUpdateHoldoffMs(jitterMs: number, rng: () => number = Math.random): number {
+  if (!(jitterMs > 0)) return 0;
+  const r = rng();
+  const safe = Number.isFinite(r) && r >= 0 && r < 1 ? r : 0;
+  return Math.floor(safe * jitterMs);
+}
+
+/**
+ * A hold-off sleep whose timer is `unref`'d, so a pending rollout hold-off never
+ * keeps the daemon process alive / blocks its exit during shutdown.
+ */
+function unrefSleep(ms: number): Promise<void> {
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve, ms).unref();
+  });
+}
+
+export type UpdateHoldoffDecision = 'proceed' | 'abort-shutdown';
+
+export interface AwaitUpdateHoldoffDeps {
+  /** Resolved jitter window in ms (from `resolveUpdateJitterMs`). */
+  jitterMs: number;
+  /** True once the daemon has begun shutting down. */
+  isShuttingDown: () => boolean;
+  /** Invoked once, with the chosen hold-off ms, when a non-zero wait is about
+   *  to start — lets the caller emit a mode-specific log line. */
+  onHold?: (holdMs: number) => void;
+  /** Injectable for deterministic tests. */
+  rng?: () => number;
+  /** Injectable for deterministic tests (default: an unref'd setTimeout). */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+/**
+ * Wait out the per-node rollout hold-off, then report whether to proceed with
+ * applying the update. Returns `'proceed'` after the (possibly zero) hold-off,
+ * or `'abort-shutdown'` if the daemon began shutting down during the wait — in
+ * which case the caller must NOT apply (the update is re-detected on next boot).
+ *
+ * The ordering (pick → optional log → sleep → re-check shutdown) is the exact
+ * sequence both auto-update paths depend on; extracting it here makes the
+ * shutdown-bail unit-testable rather than only eyeballed in the daemon loop.
+ */
+export async function awaitUpdateHoldoff(deps: AwaitUpdateHoldoffDeps): Promise<UpdateHoldoffDecision> {
+  const holdMs = pickUpdateHoldoffMs(deps.jitterMs, deps.rng ?? Math.random);
+  if (holdMs <= 0) return deps.isShuttingDown() ? 'abort-shutdown' : 'proceed';
+  deps.onHold?.(holdMs);
+  await (deps.sleep ?? unrefSleep)(holdMs);
+  return deps.isShuttingDown() ? 'abort-shutdown' : 'proceed';
+}

--- a/packages/cli/src/daemon/auto-update-jitter.ts
+++ b/packages/cli/src/daemon/auto-update-jitter.ts
@@ -106,3 +106,85 @@ export async function awaitUpdateHoldoff(deps: AwaitUpdateHoldoffDeps): Promise<
   await (deps.sleep ?? unrefSleep)(holdMs);
   return deps.isShuttingDown() ? 'abort-shutdown' : 'proceed';
 }
+
+/** Single-flight holder shared across polling ticks (see runWithUpdateHoldoff). */
+export interface UpdatePendingFlag {
+  active: boolean;
+}
+
+export interface RunWithUpdateHoldoffDeps<T> {
+  /** Persists across polling ticks so a hold-off that outlasts the poll
+   *  interval cannot start a second concurrent rollout. */
+  pending: UpdatePendingFlag;
+  /** Resolved jitter window in ms (from resolveUpdateJitterMs). */
+  jitterMs: number;
+  /** True once the daemon has begun shutting down. */
+  isShuttingDown: () => boolean;
+  /** Toggle the daemon's user-visible "is updating" flag. */
+  setUpdating: (updating: boolean) => void;
+  log: (msg: string) => void;
+  /** Emit the mode-specific "holding Ns before applying" line (detected target). */
+  onHold: (holdMs: number) => void;
+  /**
+   * Re-confirm — AFTER the hold-off — that there is still a target to apply, and
+   * return the CURRENT one. The jitter delay means the target detected before
+   * the wait may have been withdrawn (dist-tag rolled back, ref moved) or the
+   * node may have caught up; returning null skips the apply so a superseded /
+   * withdrawn release is never installed. A refreshed target (e.g. a newer
+   * version published during the wait) is applied in place of the stale one.
+   */
+  revalidate: () => Promise<T | null>;
+  /** Apply the revalidated target (owns its own post-apply restart/log). */
+  apply: (target: T) => Promise<void>;
+  /** Logged when the hold-off is aborted because the daemon is shutting down. */
+  shutdownMessage: string;
+  /** Logged when revalidate() reports no current target (withdrawn / caught up). */
+  supersededMessage: string;
+  /** Injectable for deterministic tests. */
+  rng?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+/**
+ * The single auto-update rollout gate shared by the git and npm daemon paths.
+ * Owns the cross-cutting state machine so it lives in ONE place (and is unit
+ * tested directly) instead of being duplicated inside each updater branch:
+ *
+ *   single-flight guard -> hold-off (jitter) -> abort if shutting down
+ *     -> REVALIDATE the target -> set isUpdating -> apply -> clear isUpdating
+ *
+ * Mode-specific behaviour (which check, which installer, log wording, post-apply
+ * restart) is injected via `revalidate`/`apply`/`onHold`/messages.
+ */
+export async function runWithUpdateHoldoff<T>(deps: RunWithUpdateHoldoffDeps<T>): Promise<void> {
+  if (deps.pending.active) return; // one rollout at a time
+  deps.pending.active = true;
+  try {
+    const decision = await awaitUpdateHoldoff({
+      jitterMs: deps.jitterMs,
+      isShuttingDown: deps.isShuttingDown,
+      onHold: deps.onHold,
+      rng: deps.rng,
+      sleep: deps.sleep,
+    });
+    if (decision === 'abort-shutdown') {
+      deps.log(deps.shutdownMessage);
+      return;
+    }
+
+    const target = await deps.revalidate();
+    if (target === null || target === undefined) {
+      deps.log(deps.supersededMessage);
+      return;
+    }
+
+    deps.setUpdating(true);
+    try {
+      await deps.apply(target);
+    } finally {
+      deps.setUpdating(false);
+    }
+  } finally {
+    deps.pending.active = false;
+  }
+}

--- a/packages/cli/src/daemon/auto-update-runner.ts
+++ b/packages/cli/src/daemon/auto-update-runner.ts
@@ -1,0 +1,161 @@
+/**
+ * Per-mode auto-update polling runners.
+ *
+ * These extract the git and npm `runCheck` bodies out of `runDaemonInner` so the
+ * end-to-end polling path — detect an update, hold off (jitter), RE-VALIDATE the
+ * target after the wait, and apply only the still-current one — is a focused,
+ * testable unit rather than a closure buried in the 3.5k-line lifecycle file.
+ *
+ * The mode differences (which check, which installer, log wording) live here;
+ * the cross-cutting rollout state machine (single-flight, hold-off, shutdown
+ * abort, isUpdating) is owned by the {@link UpdateHoldoffGate}. Lifecycle wires
+ * these into setInterval and provides the gate + a restart callback.
+ */
+import {
+  checkForNpmVersionUpdate,
+  deriveUpdateCheckState,
+  resolveCurrentNpmTarget,
+  performNpmUpdate,
+  performNpmUpdateEdge,
+  getCurrentCliVersion,
+  checkForNewCommitWithStatus,
+  resolveCurrentGitTarget,
+  performUpdateWithStatus,
+} from './auto-update.js';
+import type { UpdateHoldoffGate } from './auto-update-jitter.js';
+import type { ResolvedAutoUpdateConfig } from '../config.js';
+
+/** The mutable `/api/status` update-check state (a view of daemonState). */
+export interface AutoUpdateLastCheck {
+  upToDate: boolean;
+  checkedAt: number;
+  latestCommit: string;
+  latestVersion: string;
+  channelTargetMissing: boolean;
+}
+
+export interface NpmUpdateRunCheckDeps {
+  /** null = version-check-only (auto-apply disabled): detect + record, never apply. */
+  gate: UpdateHoldoffGate | null;
+  log: (msg: string) => void;
+  lastUpdateCheck: AutoUpdateLastCheck;
+  allowPrerelease: boolean;
+  channel?: string;
+  nodeRole: 'edge' | 'core';
+  /** Trigger the supervised restart after a successful install. */
+  onRestart: () => Promise<void>;
+}
+
+/**
+ * Build the npm-mode polling `runCheck`. Always refreshes `lastUpdateCheck` (so
+ * `/api/status` is current even when auto-apply is off); when a gate is present
+ * and an update is available, routes the apply through it — including the
+ * post-hold-off revalidation that skips a version withdrawn during the wait.
+ */
+export function createNpmUpdateRunCheck(deps: NpmUpdateRunCheckDeps): () => Promise<void> {
+  return async () => {
+    const npmStatus = await checkForNpmVersionUpdate(deps.log, deps.allowPrerelease, deps.channel);
+    const derived = deriveUpdateCheckState(npmStatus);
+    if (derived) {
+      deps.lastUpdateCheck.checkedAt = Date.now();
+      deps.lastUpdateCheck.upToDate = derived.upToDate;
+      deps.lastUpdateCheck.channelTargetMissing = derived.channelTargetMissing;
+      // Always write (including '') so a prior "available" version does not
+      // linger after the target disappears or the node catches up.
+      deps.lastUpdateCheck.latestVersion = derived.latestVersion;
+      if (npmStatus.status === 'no-target')
+        deps.log(
+          `Auto-update (npm): WARNING — channel "${npmStatus.channel}" has no acceptable target (tag missing or rejected by allowPrerelease); node will not update until it is published.`,
+        );
+    }
+    if (npmStatus.status !== 'available' || !npmStatus.version) return;
+    if (!deps.gate) return; // version check only — no auto-apply when polling disabled
+    const detectedVersion = npmStatus.version;
+
+    await deps.gate.run<string>({
+      onHold: (holdMs) =>
+        deps.log(
+          `Auto-update (npm): version ${detectedVersion} available; ` +
+            `holding ${Math.round(holdMs / 1000)}s before applying (rollout jitter — spreads fleet restarts).`,
+        ),
+      shutdownMessage:
+        'Auto-update (npm): hold-off aborted — daemon shutting down; deferring to next boot.',
+      supersededMessage:
+        'Auto-update (npm): target superseded during hold-off (version withdrawn or node caught up); skipping — next poll re-evaluates.',
+      // Re-resolve the channel target AFTER the hold-off so a version withdrawn /
+      // rolled back during the wait is not installed; a newer one is applied.
+      revalidate: () => resolveCurrentNpmTarget(deps.log, deps.allowPrerelease, deps.channel),
+      apply: async (version) => {
+        // OT-RFC-41 Bundle B1b: Edge → npm install -g, Core → slot install.
+        const status = deps.nodeRole === 'edge'
+          ? await performNpmUpdateEdge(version, getCurrentCliVersion(), deps.log)
+          : await performNpmUpdate(version, deps.log);
+        if (status === 'updated') {
+          deps.log('Auto-update: update activated; exiting for supervised restart.');
+          await deps.onRestart();
+        }
+      },
+    });
+  };
+}
+
+export interface GitUpdateRunCheckDeps {
+  gate: UpdateHoldoffGate;
+  log: (msg: string) => void;
+  lastUpdateCheck: AutoUpdateLastCheck;
+  au: ResolvedAutoUpdateConfig;
+  onRestart: () => Promise<void>;
+}
+
+/**
+ * Build the git-mode polling `runCheck`. Detects the remote ref tip, refreshes
+ * `lastUpdateCheck`, and on an available commit routes the apply through the
+ * gate — re-resolving the ref AFTER the hold-off so the CURRENT tip is applied,
+ * not the commit captured before the (possibly long) wait.
+ */
+export function createGitUpdateRunCheck(deps: GitUpdateRunCheckDeps): () => Promise<void> {
+  return async () => {
+    const gitStatus = await checkForNewCommitWithStatus(deps.au, deps.log);
+    if (gitStatus.status === 'error') {
+      deps.log('Auto-update (git): update check failed.');
+      return;
+    }
+
+    deps.lastUpdateCheck.checkedAt = Date.now();
+    deps.lastUpdateCheck.upToDate = gitStatus.status === 'up-to-date';
+    deps.lastUpdateCheck.channelTargetMissing = false;
+    deps.lastUpdateCheck.latestVersion = '';
+    deps.lastUpdateCheck.latestCommit = gitStatus.commit ?? '';
+
+    if (gitStatus.status !== 'available' || !gitStatus.commit) return;
+    const detectedCommit = gitStatus.commit;
+
+    await deps.gate.run<string>({
+      onHold: (holdMs) =>
+        deps.log(
+          `Auto-update (git): new commit ${detectedCommit.slice(0, 8)} available; ` +
+            `holding ${Math.round(holdMs / 1000)}s before applying (rollout jitter — spreads fleet restarts).`,
+        ),
+      shutdownMessage:
+        'Auto-update (git): hold-off aborted — daemon shutting down; deferring to next boot.',
+      supersededMessage:
+        'Auto-update (git): target superseded during hold-off (ref moved or node caught up); skipping — next poll re-evaluates.',
+      revalidate: () => resolveCurrentGitTarget(deps.au, deps.log),
+      apply: async (commit) => {
+        const updateStatus = await performUpdateWithStatus(deps.au, deps.log, {
+          expectedCommit: commit,
+        });
+        if (updateStatus === 'updated') {
+          deps.log('Auto-update (git): update activated; exiting for supervised restart.');
+          await deps.onRestart();
+          return;
+        }
+        if (updateStatus === 'up-to-date') {
+          deps.log('Auto-update (git): update skipped — node caught up before apply.');
+          return;
+        }
+        deps.log('Auto-update (git): update failed.');
+      },
+    });
+  };
+}

--- a/packages/cli/src/daemon/auto-update-runner.ts
+++ b/packages/cli/src/daemon/auto-update-runner.ts
@@ -14,31 +14,46 @@
 import {
   checkForNpmVersionUpdate,
   deriveUpdateCheckState,
-  resolveCurrentNpmTarget,
   performNpmUpdate,
   performNpmUpdateEdge,
   getCurrentCliVersion,
   checkForNewCommitWithStatus,
-  resolveCurrentGitTarget,
   performUpdateWithStatus,
 } from './auto-update.js';
 import type { UpdateHoldoffGate } from './auto-update-jitter.js';
+import type { LastUpdateCheck } from './state.js';
 import type { ResolvedAutoUpdateConfig } from '../config.js';
 
-/** The mutable `/api/status` update-check state (a view of daemonState). */
-export interface AutoUpdateLastCheck {
-  upToDate: boolean;
-  checkedAt: number;
-  latestCommit: string;
-  latestVersion: string;
-  channelTargetMissing: boolean;
+/**
+ * Re-resolve the CURRENT npm channel target after the hold-off, mapping to the
+ * version to apply or null when there is nothing to apply now (withdrawn /
+ * rolled back / caught up). Private to the runner — a one-line adapter over the
+ * already-public `checkForNpmVersionUpdate`, not part of the daemon's API.
+ */
+export async function resolveCurrentNpmTarget(
+  log: (msg: string) => void,
+  allowPrerelease: boolean,
+  channel?: string,
+): Promise<string | null> {
+  const status = await checkForNpmVersionUpdate(log, allowPrerelease, channel);
+  return status.status === 'available' && status.version ? status.version : null;
+}
+
+/** Git counterpart to {@link resolveCurrentNpmTarget}: the current ref tip, or
+ *  null when it no longer points ahead of the running commit. Runner-private. */
+export async function resolveCurrentGitTarget(
+  au: ResolvedAutoUpdateConfig,
+  log: (msg: string) => void,
+): Promise<string | null> {
+  const status = await checkForNewCommitWithStatus(au, log);
+  return status.status === 'available' && status.commit ? status.commit : null;
 }
 
 export interface NpmUpdateRunCheckDeps {
   /** null = version-check-only (auto-apply disabled): detect + record, never apply. */
   gate: UpdateHoldoffGate | null;
   log: (msg: string) => void;
-  lastUpdateCheck: AutoUpdateLastCheck;
+  lastUpdateCheck: LastUpdateCheck;
   allowPrerelease: boolean;
   channel?: string;
   nodeRole: 'edge' | 'core';
@@ -102,7 +117,7 @@ export function createNpmUpdateRunCheck(deps: NpmUpdateRunCheckDeps): () => Prom
 export interface GitUpdateRunCheckDeps {
   gate: UpdateHoldoffGate;
   log: (msg: string) => void;
-  lastUpdateCheck: AutoUpdateLastCheck;
+  lastUpdateCheck: LastUpdateCheck;
   au: ResolvedAutoUpdateConfig;
   onRestart: () => Promise<void>;
 }

--- a/packages/cli/src/daemon/auto-update.ts
+++ b/packages/cli/src/daemon/auto-update.ts
@@ -739,37 +739,6 @@ export async function checkForNewCommitWithStatus(
   }
 }
 
-/**
- * Re-resolve the CURRENT npm channel target and map it to the version to apply,
- * or null when there is nothing to apply now. This is the post-hold-off
- * revalidation for the rollout gate: the rollout jitter delays applying a
- * detected update, and during that wait the target can be withdrawn (dist-tag
- * rolled back), rejected (prerelease policy), or caught up. Returning null in
- * those cases keeps a superseded / withdrawn release from being installed, and a
- * newer version published during the wait is applied in place of the stale one.
- */
-export async function resolveCurrentNpmTarget(
-  log: (msg: string) => void,
-  allowPrerelease: boolean,
-  channel?: string,
-): Promise<string | null> {
-  const status = await checkForNpmVersionUpdate(log, allowPrerelease, channel);
-  return status.status === "available" && status.version ? status.version : null;
-}
-
-/**
- * Re-resolve the CURRENT git ref tip and map it to the commit to apply, or null
- * when the ref no longer points ahead of the running commit (moved back / caught
- * up). Post-hold-off revalidation counterpart to {@link resolveCurrentNpmTarget}.
- */
-export async function resolveCurrentGitTarget(
-  au: ResolvedAutoUpdateConfig,
-  log: (msg: string) => void,
-): Promise<string | null> {
-  const status = await checkForNewCommitWithStatus(au, log);
-  return status.status === "available" && status.commit ? status.commit : null;
-}
-
 let _updateInProgress = false;
 let _lockToken: string | null = null;
 export type UpdateStatus = "updated" | "up-to-date" | "failed";

--- a/packages/cli/src/daemon/auto-update.ts
+++ b/packages/cli/src/daemon/auto-update.ts
@@ -739,6 +739,37 @@ export async function checkForNewCommitWithStatus(
   }
 }
 
+/**
+ * Re-resolve the CURRENT npm channel target and map it to the version to apply,
+ * or null when there is nothing to apply now. This is the post-hold-off
+ * revalidation for the rollout gate: the rollout jitter delays applying a
+ * detected update, and during that wait the target can be withdrawn (dist-tag
+ * rolled back), rejected (prerelease policy), or caught up. Returning null in
+ * those cases keeps a superseded / withdrawn release from being installed, and a
+ * newer version published during the wait is applied in place of the stale one.
+ */
+export async function resolveCurrentNpmTarget(
+  log: (msg: string) => void,
+  allowPrerelease: boolean,
+  channel?: string,
+): Promise<string | null> {
+  const status = await checkForNpmVersionUpdate(log, allowPrerelease, channel);
+  return status.status === "available" && status.version ? status.version : null;
+}
+
+/**
+ * Re-resolve the CURRENT git ref tip and map it to the commit to apply, or null
+ * when the ref no longer points ahead of the running commit (moved back / caught
+ * up). Post-hold-off revalidation counterpart to {@link resolveCurrentNpmTarget}.
+ */
+export async function resolveCurrentGitTarget(
+  au: ResolvedAutoUpdateConfig,
+  log: (msg: string) => void,
+): Promise<string | null> {
+  const status = await checkForNewCommitWithStatus(au, log);
+  return status.status === "available" && status.commit ? status.commit : null;
+}
+
 let _updateInProgress = false;
 let _lockToken: string | null = null;
 export type UpdateStatus = "updated" | "up-to-date" | "failed";

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -296,6 +296,7 @@ import {
   performNpmUpdateEdge,
 } from './auto-update.js';
 import { formatAutoUpdateTagVerificationWarning, isValidRef, resolveAutoUpdateGitRefPlan } from '../auto-update-ref.js';
+import { resolveUpdateJitterMs, awaitUpdateHoldoff } from './auto-update-jitter.js';
 import {
   chainResetWipe,
   detectBackendSwitch,
@@ -2113,6 +2114,12 @@ export async function runDaemonInner(
       const verificationWarning = watchedRefPlan ? formatAutoUpdateTagVerificationWarning(watchedRefPlan) : null;
       if (verificationWarning) log(verificationWarning);
 
+      // Rollout jitter: hold off a per-node random delay between detecting an
+      // available commit and applying it, so a release never restarts the whole
+      // fleet in one window (the 2026-07-10 bootstrap-storm trigger).
+      const updateJitterMs = resolveUpdateJitterMs(au.updateJitterMinutes, au.checkIntervalMinutes);
+      let updatePending = false;
+
       const runCheck = async () => {
         const gitStatus = await checkForNewCommitWithStatus(au, log);
         if (gitStatus.status === "error") {
@@ -2127,24 +2134,48 @@ export async function runDaemonInner(
         daemonState.lastUpdateCheck.latestCommit = gitStatus.commit ?? "";
 
         if (gitStatus.status !== "available" || !gitStatus.commit) return;
+        // Capture into a const: the narrowing above does not survive into the
+        // onHold closure passed to awaitUpdateHoldoff (TS re-widens it there).
+        const commit = gitStatus.commit;
+        // One rollout at a time: the hold-off below can outlast the poll
+        // interval, so a later tick must not start a second concurrent apply.
+        if (updatePending) return;
+        updatePending = true;
+        try {
+          const decision = await awaitUpdateHoldoff({
+            jitterMs: updateJitterMs,
+            isShuttingDown: () => shuttingDown,
+            onHold: (holdMs) =>
+              log(
+                `Auto-update (git): new commit ${commit.slice(0, 8)} available; ` +
+                  `holding ${Math.round(holdMs / 1000)}s before applying (rollout jitter — spreads fleet restarts).`,
+              ),
+          });
+          if (decision === "abort-shutdown") {
+            log("Auto-update (git): hold-off aborted — daemon shutting down; deferring to next boot.");
+            return;
+          }
 
-        daemonState.isUpdating = true;
-        const updateStatus = await performUpdateWithStatus(au, log, {
-          expectedCommit: gitStatus.commit,
-        }).finally(() => {
-          daemonState.isUpdating = false;
-        });
+          daemonState.isUpdating = true;
+          const updateStatus = await performUpdateWithStatus(au, log, {
+            expectedCommit: commit,
+          }).finally(() => {
+            daemonState.isUpdating = false;
+          });
 
-        if (updateStatus === "updated") {
-          log("Auto-update (git): update activated; exiting for supervised restart.");
-          await shutdown(DAEMON_EXIT_CODE_RESTART);
-          return;
+          if (updateStatus === "updated") {
+            log("Auto-update (git): update activated; exiting for supervised restart.");
+            await shutdown(DAEMON_EXIT_CODE_RESTART);
+            return;
+          }
+          if (updateStatus === "up-to-date") {
+            log("Auto-update (git): update skipped — node caught up before apply.");
+            return;
+          }
+          log("Auto-update (git): update failed.");
+        } finally {
+          updatePending = false;
         }
-        if (updateStatus === "up-to-date") {
-          log("Auto-update (git): update skipped — node caught up before apply.");
-          return;
-        }
-        log("Auto-update (git): update failed.");
       };
 
       setTimeout(runCheck, 15_000);
@@ -2167,6 +2198,11 @@ export async function runDaemonInner(
       `Auto-update (npm): ${au ? "enabled" : "disabled — version check only"}${channel ? ` channel="${channel}"` : ""} (every ${au?.checkIntervalMinutes ?? 30}min)`,
     );
 
+    // Rollout jitter (same rationale as the git path): stagger the fleet's
+    // restarts by holding off a per-node random delay before applying.
+    const updateJitterMs = au ? resolveUpdateJitterMs(au.updateJitterMinutes, au.checkIntervalMinutes) : 0;
+    let updatePending = false;
+
     const runCheck = async () => {
       const npmStatus = await checkForNpmVersionUpdate(log, allowPre, channel);
       const derived = deriveUpdateCheckState(npmStatus);
@@ -2185,18 +2221,39 @@ export async function runDaemonInner(
       if (npmStatus.status !== "available" || !npmStatus.version) return;
       if (!au) return; // version check only — no auto-apply when polling disabled
 
-      daemonState.isUpdating = true;
-      // OT-RFC-41 Bundle B1b: Edge → npm install -g, Core → slot install.
-      const role = config.nodeRole ?? "edge";
-      const status = role === "edge"
-        ? await performNpmUpdateEdge(npmStatus.version, getCurrentCliVersion(), log)
-        : await performNpmUpdate(npmStatus.version, log);
-      const updated = status === "updated";
-      daemonState.isUpdating = false;
-      if (updated) {
-        log("Auto-update: update activated; exiting for supervised restart.");
-        await shutdown(DAEMON_EXIT_CODE_RESTART);
-        return;
+      // One rollout at a time: the hold-off can outlast the poll interval.
+      if (updatePending) return;
+      updatePending = true;
+      try {
+        const decision = await awaitUpdateHoldoff({
+          jitterMs: updateJitterMs,
+          isShuttingDown: () => shuttingDown,
+          onHold: (holdMs) =>
+            log(
+              `Auto-update (npm): version ${npmStatus.version} available; ` +
+                `holding ${Math.round(holdMs / 1000)}s before applying (rollout jitter — spreads fleet restarts).`,
+            ),
+        });
+        if (decision === "abort-shutdown") {
+          log("Auto-update (npm): hold-off aborted — daemon shutting down; deferring to next boot.");
+          return;
+        }
+
+        daemonState.isUpdating = true;
+        // OT-RFC-41 Bundle B1b: Edge → npm install -g, Core → slot install.
+        const role = config.nodeRole ?? "edge";
+        const status = role === "edge"
+          ? await performNpmUpdateEdge(npmStatus.version, getCurrentCliVersion(), log)
+          : await performNpmUpdate(npmStatus.version, log);
+        const updated = status === "updated";
+        daemonState.isUpdating = false;
+        if (updated) {
+          log("Auto-update: update activated; exiting for supervised restart.");
+          await shutdown(DAEMON_EXIT_CODE_RESTART);
+          return;
+        }
+      } finally {
+        updatePending = false;
       }
     };
 

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -288,6 +288,8 @@ import {
   type NpmVersionStatus,
   checkForNpmVersionUpdate,
   checkForNewCommitWithStatus,
+  resolveCurrentNpmTarget,
+  resolveCurrentGitTarget,
   deriveUpdateCheckState,
   acquireUpdateLock,
   releaseUpdateLock,
@@ -296,7 +298,7 @@ import {
   performNpmUpdateEdge,
 } from './auto-update.js';
 import { formatAutoUpdateTagVerificationWarning, isValidRef, resolveAutoUpdateGitRefPlan } from '../auto-update-ref.js';
-import { resolveUpdateJitterMs, awaitUpdateHoldoff } from './auto-update-jitter.js';
+import { resolveUpdateJitterMs, runWithUpdateHoldoff } from './auto-update-jitter.js';
 import {
   chainResetWipe,
   detectBackendSwitch,
@@ -2118,7 +2120,7 @@ export async function runDaemonInner(
       // available commit and applying it, so a release never restarts the whole
       // fleet in one window (the 2026-07-10 bootstrap-storm trigger).
       const updateJitterMs = resolveUpdateJitterMs(au.updateJitterMinutes, au.checkIntervalMinutes);
-      let updatePending = false;
+      const updatePending = { active: false };
 
       const runCheck = async () => {
         const gitStatus = await checkForNewCommitWithStatus(au, log);
@@ -2135,47 +2137,43 @@ export async function runDaemonInner(
 
         if (gitStatus.status !== "available" || !gitStatus.commit) return;
         // Capture into a const: the narrowing above does not survive into the
-        // onHold closure passed to awaitUpdateHoldoff (TS re-widens it there).
-        const commit = gitStatus.commit;
-        // One rollout at a time: the hold-off below can outlast the poll
-        // interval, so a later tick must not start a second concurrent apply.
-        if (updatePending) return;
-        updatePending = true;
-        try {
-          const decision = await awaitUpdateHoldoff({
-            jitterMs: updateJitterMs,
-            isShuttingDown: () => shuttingDown,
-            onHold: (holdMs) =>
-              log(
-                `Auto-update (git): new commit ${commit.slice(0, 8)} available; ` +
-                  `holding ${Math.round(holdMs / 1000)}s before applying (rollout jitter — spreads fleet restarts).`,
-              ),
-          });
-          if (decision === "abort-shutdown") {
-            log("Auto-update (git): hold-off aborted — daemon shutting down; deferring to next boot.");
-            return;
-          }
+        // onHold closure below (TS re-widens it there).
+        const detectedCommit = gitStatus.commit;
 
-          daemonState.isUpdating = true;
-          const updateStatus = await performUpdateWithStatus(au, log, {
-            expectedCommit: commit,
-          }).finally(() => {
-            daemonState.isUpdating = false;
-          });
-
-          if (updateStatus === "updated") {
-            log("Auto-update (git): update activated; exiting for supervised restart.");
-            await shutdown(DAEMON_EXIT_CODE_RESTART);
-            return;
-          }
-          if (updateStatus === "up-to-date") {
-            log("Auto-update (git): update skipped — node caught up before apply.");
-            return;
-          }
-          log("Auto-update (git): update failed.");
-        } finally {
-          updatePending = false;
-        }
+        await runWithUpdateHoldoff<string>({
+          pending: updatePending,
+          jitterMs: updateJitterMs,
+          isShuttingDown: () => shuttingDown,
+          setUpdating: (updating) => { daemonState.isUpdating = updating; },
+          log,
+          onHold: (holdMs) =>
+            log(
+              `Auto-update (git): new commit ${detectedCommit.slice(0, 8)} available; ` +
+                `holding ${Math.round(holdMs / 1000)}s before applying (rollout jitter — spreads fleet restarts).`,
+            ),
+          shutdownMessage:
+            "Auto-update (git): hold-off aborted — daemon shutting down; deferring to next boot.",
+          supersededMessage:
+            "Auto-update (git): target superseded during hold-off (ref moved or node caught up); skipping — next poll re-evaluates.",
+          // Re-resolve the remote ref AFTER the hold-off: apply the CURRENT tip,
+          // not the commit captured before the (possibly long) wait.
+          revalidate: () => resolveCurrentGitTarget(au, log),
+          apply: async (commit) => {
+            const updateStatus = await performUpdateWithStatus(au, log, {
+              expectedCommit: commit,
+            });
+            if (updateStatus === "updated") {
+              log("Auto-update (git): update activated; exiting for supervised restart.");
+              await shutdown(DAEMON_EXIT_CODE_RESTART);
+              return;
+            }
+            if (updateStatus === "up-to-date") {
+              log("Auto-update (git): update skipped — node caught up before apply.");
+              return;
+            }
+            log("Auto-update (git): update failed.");
+          },
+        });
       };
 
       setTimeout(runCheck, 15_000);
@@ -2201,7 +2199,7 @@ export async function runDaemonInner(
     // Rollout jitter (same rationale as the git path): stagger the fleet's
     // restarts by holding off a per-node random delay before applying.
     const updateJitterMs = au ? resolveUpdateJitterMs(au.updateJitterMinutes, au.checkIntervalMinutes) : 0;
-    let updatePending = false;
+    const updatePending = { active: false };
 
     const runCheck = async () => {
       const npmStatus = await checkForNpmVersionUpdate(log, allowPre, channel);
@@ -2220,41 +2218,39 @@ export async function runDaemonInner(
       }
       if (npmStatus.status !== "available" || !npmStatus.version) return;
       if (!au) return; // version check only — no auto-apply when polling disabled
+      const detectedVersion = npmStatus.version;
 
-      // One rollout at a time: the hold-off can outlast the poll interval.
-      if (updatePending) return;
-      updatePending = true;
-      try {
-        const decision = await awaitUpdateHoldoff({
-          jitterMs: updateJitterMs,
-          isShuttingDown: () => shuttingDown,
-          onHold: (holdMs) =>
-            log(
-              `Auto-update (npm): version ${npmStatus.version} available; ` +
-                `holding ${Math.round(holdMs / 1000)}s before applying (rollout jitter — spreads fleet restarts).`,
-            ),
-        });
-        if (decision === "abort-shutdown") {
-          log("Auto-update (npm): hold-off aborted — daemon shutting down; deferring to next boot.");
-          return;
-        }
-
-        daemonState.isUpdating = true;
-        // OT-RFC-41 Bundle B1b: Edge → npm install -g, Core → slot install.
-        const role = config.nodeRole ?? "edge";
-        const status = role === "edge"
-          ? await performNpmUpdateEdge(npmStatus.version, getCurrentCliVersion(), log)
-          : await performNpmUpdate(npmStatus.version, log);
-        const updated = status === "updated";
-        daemonState.isUpdating = false;
-        if (updated) {
-          log("Auto-update: update activated; exiting for supervised restart.");
-          await shutdown(DAEMON_EXIT_CODE_RESTART);
-          return;
-        }
-      } finally {
-        updatePending = false;
-      }
+      await runWithUpdateHoldoff<string>({
+        pending: updatePending,
+        jitterMs: updateJitterMs,
+        isShuttingDown: () => shuttingDown,
+        setUpdating: (updating) => { daemonState.isUpdating = updating; },
+        log,
+        onHold: (holdMs) =>
+          log(
+            `Auto-update (npm): version ${detectedVersion} available; ` +
+              `holding ${Math.round(holdMs / 1000)}s before applying (rollout jitter — spreads fleet restarts).`,
+          ),
+        shutdownMessage:
+          "Auto-update (npm): hold-off aborted — daemon shutting down; deferring to next boot.",
+        supersededMessage:
+          "Auto-update (npm): target superseded during hold-off (version withdrawn or node caught up); skipping — next poll re-evaluates.",
+        // Re-resolve the channel target AFTER the hold-off so a version that was
+        // withdrawn / rolled back during the wait is not installed; a newer one
+        // published meanwhile is applied in its place.
+        revalidate: () => resolveCurrentNpmTarget(log, allowPre, channel),
+        apply: async (version) => {
+          // OT-RFC-41 Bundle B1b: Edge → npm install -g, Core → slot install.
+          const role = config.nodeRole ?? "edge";
+          const status = role === "edge"
+            ? await performNpmUpdateEdge(version, getCurrentCliVersion(), log)
+            : await performNpmUpdate(version, log);
+          if (status === "updated") {
+            log("Auto-update: update activated; exiting for supervised restart.");
+            await shutdown(DAEMON_EXIT_CODE_RESTART);
+          }
+        },
+      });
     };
 
     setTimeout(runCheck, 15_000);

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -284,21 +284,12 @@ import {
   type NpmVersionResult,
   resolveLatestNpmVersion,
   compareSemver,
-  getCurrentCliVersion,
-  type NpmVersionStatus,
-  checkForNpmVersionUpdate,
-  checkForNewCommitWithStatus,
-  resolveCurrentNpmTarget,
-  resolveCurrentGitTarget,
-  deriveUpdateCheckState,
   acquireUpdateLock,
   releaseUpdateLock,
-  performUpdateWithStatus,
-  performNpmUpdate,
-  performNpmUpdateEdge,
 } from './auto-update.js';
 import { formatAutoUpdateTagVerificationWarning, isValidRef, resolveAutoUpdateGitRefPlan } from '../auto-update-ref.js';
-import { resolveUpdateJitterMs, runWithUpdateHoldoff } from './auto-update-jitter.js';
+import { resolveUpdateJitterMs, createUpdateHoldoffGate } from './auto-update-jitter.js';
+import { createGitUpdateRunCheck, createNpmUpdateRunCheck } from './auto-update-runner.js';
 import {
   chainResetWipe,
   detectBackendSwitch,
@@ -2118,63 +2109,21 @@ export async function runDaemonInner(
 
       // Rollout jitter: hold off a per-node random delay between detecting an
       // available commit and applying it, so a release never restarts the whole
-      // fleet in one window (the 2026-07-10 bootstrap-storm trigger).
-      const updateJitterMs = resolveUpdateJitterMs(au.updateJitterMinutes, au.checkIntervalMinutes);
-      const updatePending = { active: false };
-
-      const runCheck = async () => {
-        const gitStatus = await checkForNewCommitWithStatus(au, log);
-        if (gitStatus.status === "error") {
-          log("Auto-update (git): update check failed.");
-          return;
-        }
-
-        daemonState.lastUpdateCheck.checkedAt = Date.now();
-        daemonState.lastUpdateCheck.upToDate = gitStatus.status === "up-to-date";
-        daemonState.lastUpdateCheck.channelTargetMissing = false;
-        daemonState.lastUpdateCheck.latestVersion = "";
-        daemonState.lastUpdateCheck.latestCommit = gitStatus.commit ?? "";
-
-        if (gitStatus.status !== "available" || !gitStatus.commit) return;
-        // Capture into a const: the narrowing above does not survive into the
-        // onHold closure below (TS re-widens it there).
-        const detectedCommit = gitStatus.commit;
-
-        await runWithUpdateHoldoff<string>({
-          pending: updatePending,
-          jitterMs: updateJitterMs,
-          isShuttingDown: () => shuttingDown,
-          setUpdating: (updating) => { daemonState.isUpdating = updating; },
-          log,
-          onHold: (holdMs) =>
-            log(
-              `Auto-update (git): new commit ${detectedCommit.slice(0, 8)} available; ` +
-                `holding ${Math.round(holdMs / 1000)}s before applying (rollout jitter — spreads fleet restarts).`,
-            ),
-          shutdownMessage:
-            "Auto-update (git): hold-off aborted — daemon shutting down; deferring to next boot.",
-          supersededMessage:
-            "Auto-update (git): target superseded during hold-off (ref moved or node caught up); skipping — next poll re-evaluates.",
-          // Re-resolve the remote ref AFTER the hold-off: apply the CURRENT tip,
-          // not the commit captured before the (possibly long) wait.
-          revalidate: () => resolveCurrentGitTarget(au, log),
-          apply: async (commit) => {
-            const updateStatus = await performUpdateWithStatus(au, log, {
-              expectedCommit: commit,
-            });
-            if (updateStatus === "updated") {
-              log("Auto-update (git): update activated; exiting for supervised restart.");
-              await shutdown(DAEMON_EXIT_CODE_RESTART);
-              return;
-            }
-            if (updateStatus === "up-to-date") {
-              log("Auto-update (git): update skipped — node caught up before apply.");
-              return;
-            }
-            log("Auto-update (git): update failed.");
-          },
-        });
-      };
+      // fleet in one window (the 2026-07-10 bootstrap-storm trigger). The gate is
+      // created ONCE here so its single-flight guard holds across polling ticks.
+      const gate = createUpdateHoldoffGate({
+        jitterMs: resolveUpdateJitterMs(au.updateJitterMinutes, au.checkIntervalMinutes),
+        isShuttingDown: () => shuttingDown,
+        setUpdating: (updating) => { daemonState.isUpdating = updating; },
+        log,
+      });
+      const runCheck = createGitUpdateRunCheck({
+        gate,
+        log,
+        lastUpdateCheck: daemonState.lastUpdateCheck,
+        au,
+        onRestart: () => shutdown(DAEMON_EXIT_CODE_RESTART),
+      });
 
       setTimeout(runCheck, 15_000);
       updateInterval = setInterval(runCheck, checkIntervalMs);
@@ -2197,61 +2146,26 @@ export async function runDaemonInner(
     );
 
     // Rollout jitter (same rationale as the git path): stagger the fleet's
-    // restarts by holding off a per-node random delay before applying.
-    const updateJitterMs = au ? resolveUpdateJitterMs(au.updateJitterMinutes, au.checkIntervalMinutes) : 0;
-    const updatePending = { active: false };
-
-    const runCheck = async () => {
-      const npmStatus = await checkForNpmVersionUpdate(log, allowPre, channel);
-      const derived = deriveUpdateCheckState(npmStatus);
-      if (derived) {
-        daemonState.lastUpdateCheck.checkedAt = Date.now();
-        daemonState.lastUpdateCheck.upToDate = derived.upToDate;
-        daemonState.lastUpdateCheck.channelTargetMissing = derived.channelTargetMissing;
-        // Always write (including '') so a prior "available" version does not
-        // linger after the target disappears or the node catches up.
-        daemonState.lastUpdateCheck.latestVersion = derived.latestVersion;
-        if (npmStatus.status === "no-target")
-          log(
-            `Auto-update (npm): WARNING — channel "${npmStatus.channel}" has no acceptable target (tag missing or rejected by allowPrerelease); node will not update until it is published.`,
-          );
-      }
-      if (npmStatus.status !== "available" || !npmStatus.version) return;
-      if (!au) return; // version check only — no auto-apply when polling disabled
-      const detectedVersion = npmStatus.version;
-
-      await runWithUpdateHoldoff<string>({
-        pending: updatePending,
-        jitterMs: updateJitterMs,
-        isShuttingDown: () => shuttingDown,
-        setUpdating: (updating) => { daemonState.isUpdating = updating; },
-        log,
-        onHold: (holdMs) =>
-          log(
-            `Auto-update (npm): version ${detectedVersion} available; ` +
-              `holding ${Math.round(holdMs / 1000)}s before applying (rollout jitter — spreads fleet restarts).`,
-          ),
-        shutdownMessage:
-          "Auto-update (npm): hold-off aborted — daemon shutting down; deferring to next boot.",
-        supersededMessage:
-          "Auto-update (npm): target superseded during hold-off (version withdrawn or node caught up); skipping — next poll re-evaluates.",
-        // Re-resolve the channel target AFTER the hold-off so a version that was
-        // withdrawn / rolled back during the wait is not installed; a newer one
-        // published meanwhile is applied in its place.
-        revalidate: () => resolveCurrentNpmTarget(log, allowPre, channel),
-        apply: async (version) => {
-          // OT-RFC-41 Bundle B1b: Edge → npm install -g, Core → slot install.
-          const role = config.nodeRole ?? "edge";
-          const status = role === "edge"
-            ? await performNpmUpdateEdge(version, getCurrentCliVersion(), log)
-            : await performNpmUpdate(version, log);
-          if (status === "updated") {
-            log("Auto-update: update activated; exiting for supervised restart.");
-            await shutdown(DAEMON_EXIT_CODE_RESTART);
-          }
-        },
-      });
-    };
+    // restarts by holding off a per-node random delay before applying. The gate
+    // is null in version-check-only mode (au disabled) — detect + record only.
+    // Created ONCE so single-flight holds across polling ticks.
+    const gate = au
+      ? createUpdateHoldoffGate({
+          jitterMs: resolveUpdateJitterMs(au.updateJitterMinutes, au.checkIntervalMinutes),
+          isShuttingDown: () => shuttingDown,
+          setUpdating: (updating) => { daemonState.isUpdating = updating; },
+          log,
+        })
+      : null;
+    const runCheck = createNpmUpdateRunCheck({
+      gate,
+      log,
+      lastUpdateCheck: daemonState.lastUpdateCheck,
+      allowPrerelease: allowPre,
+      channel,
+      nodeRole: config.nodeRole ?? "edge",
+      onRestart: () => shutdown(DAEMON_EXIT_CODE_RESTART),
+    });
 
     setTimeout(runCheck, 15_000);
     updateInterval = setInterval(runCheck, checkIntervalMs);

--- a/packages/cli/src/daemon/state.ts
+++ b/packages/cli/src/daemon/state.ts
@@ -18,6 +18,19 @@ import { isStandaloneInstall } from '../config.js';
 
 export type CorsAllowlist = '*' | string[];
 
+/** Most recent "is this daemon up to date?" result; polled by `/api/status`
+ *  and written by the auto-update polling runners. */
+export interface LastUpdateCheck {
+  upToDate: boolean;
+  checkedAt: number;
+  latestCommit: string;
+  latestVersion: string;
+  /** True when a pinned auto-update channel has no acceptable target
+   *  (tag missing / prerelease rejected / non-semver). Distinct from
+   *  `upToDate` so `/api/status` can show a misconfigured channel. */
+  channelTargetMissing: boolean;
+}
+
 /**
  * Verbose sync-progress tracing. Opt-in via either env var. Referenced
  * from the catch-up job handler (routes/context-graph.ts) plus the
@@ -33,16 +46,7 @@ export const daemonState: {
   /** Set to `true` while a package or git slot update is in flight. */
   isUpdating: boolean;
   /** Most recent "is this daemon up to date?" result; polled by `/status`. */
-  lastUpdateCheck: {
-    upToDate: boolean;
-    checkedAt: number;
-    latestCommit: string;
-    latestVersion: string;
-    /** True when a pinned auto-update channel has no acceptable target
-     *  (tag missing / prerelease rejected / non-semver). Distinct from
-     *  `upToDate` so `/api/status` can show a misconfigured channel. */
-    channelTargetMissing: boolean;
-  };
+  lastUpdateCheck: LastUpdateCheck;
   /** Memoised result of `isStandaloneInstall()` — null = not yet checked. */
   standaloneCache: boolean | null;
   /**

--- a/packages/cli/test/auto-update-jitter.test.ts
+++ b/packages/cli/test/auto-update-jitter.test.ts
@@ -3,6 +3,7 @@ import {
   resolveUpdateJitterMs,
   pickUpdateHoldoffMs,
   awaitUpdateHoldoff,
+  runWithUpdateHoldoff,
   UPDATE_JITTER_ENV,
 } from '../src/daemon/auto-update-jitter.js';
 
@@ -114,5 +115,100 @@ describe('awaitUpdateHoldoff', () => {
     });
     expect(decision).toBe('abort-shutdown');
     expect(sleep).not.toHaveBeenCalled();
+  });
+});
+
+describe('runWithUpdateHoldoff (the shared rollout gate)', () => {
+  function makeDeps(overrides: Record<string, unknown> = {}) {
+    const calls: string[] = [];
+    const log = vi.fn();
+    const setUpdating = vi.fn((v: boolean) => { calls.push(`setUpdating:${v}`); });
+    const sleep = vi.fn(async () => { calls.push('sleep'); });
+    const onHold = vi.fn(() => { calls.push('onHold'); });
+    const revalidate = vi.fn(async () => { calls.push('revalidate'); return 'v-fresh' as string | null; });
+    const apply = vi.fn(async (t: string) => { calls.push(`apply:${t}`); });
+    const deps = {
+      pending: { active: false },
+      jitterMs: 600_000,
+      isShuttingDown: () => false,
+      setUpdating,
+      log,
+      onHold,
+      revalidate,
+      apply,
+      shutdownMessage: 'SHUTDOWN',
+      supersededMessage: 'SUPERSEDED',
+      rng: () => 0.5,
+      sleep,
+      ...overrides,
+    };
+    return { deps, calls, log, setUpdating, sleep, onHold, revalidate, apply };
+  }
+
+  it('runs the gate in order and applies the REVALIDATED target (not the detected one)', async () => {
+    const { deps, calls, apply } = makeDeps();
+    await runWithUpdateHoldoff(deps as never);
+    expect(calls).toEqual([
+      'onHold', 'sleep', 'revalidate', 'setUpdating:true', 'apply:v-fresh', 'setUpdating:false',
+    ]);
+    expect(apply).toHaveBeenCalledWith('v-fresh');
+    expect(deps.pending.active).toBe(false);
+  });
+
+  it('is single-flight: a call while a rollout is pending does nothing and leaves the flag set', async () => {
+    const { deps, revalidate, apply } = makeDeps({ pending: { active: true } });
+    await runWithUpdateHoldoff(deps as never);
+    expect(revalidate).not.toHaveBeenCalled();
+    expect(apply).not.toHaveBeenCalled();
+    expect(deps.pending.active).toBe(true); // the in-flight rollout still owns it
+  });
+
+  it('does NOT apply a target withdrawn during the hold-off (revalidate -> null)', async () => {
+    const apply = vi.fn(async () => {});
+    const setUpdating = vi.fn();
+    const log = vi.fn();
+    const { deps } = makeDeps({
+      revalidate: vi.fn(async () => null),
+      apply, setUpdating, log,
+    });
+    await runWithUpdateHoldoff(deps as never);
+    expect(apply).not.toHaveBeenCalled();
+    expect(setUpdating).not.toHaveBeenCalledWith(true);
+    expect(log).toHaveBeenCalledWith('SUPERSEDED');
+    expect(deps.pending.active).toBe(false);
+  });
+
+  it('aborts before revalidate/apply when shutting down during the hold-off', async () => {
+    let sd = false;
+    const revalidate = vi.fn(async () => 'x');
+    const apply = vi.fn(async () => {});
+    const log = vi.fn();
+    const { deps } = makeDeps({
+      isShuttingDown: () => sd,
+      sleep: vi.fn(async () => { sd = true; }),
+      revalidate, apply, log,
+    });
+    await runWithUpdateHoldoff(deps as never);
+    expect(revalidate).not.toHaveBeenCalled();
+    expect(apply).not.toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith('SHUTDOWN');
+    expect(deps.pending.active).toBe(false);
+  });
+
+  it('clears isUpdating and the pending flag even if apply throws', async () => {
+    const setUpdating = vi.fn();
+    const { deps } = makeDeps({
+      apply: vi.fn(async () => { throw new Error('boom'); }),
+      setUpdating,
+    });
+    await expect(runWithUpdateHoldoff(deps as never)).rejects.toThrow('boom');
+    expect(setUpdating).toHaveBeenLastCalledWith(false);
+    expect(deps.pending.active).toBe(false);
+  });
+
+  it('applies with no hold-off log/sleep when jitter is disabled', async () => {
+    const { deps, calls } = makeDeps({ jitterMs: 0 });
+    await runWithUpdateHoldoff(deps as never);
+    expect(calls).toEqual(['revalidate', 'setUpdating:true', 'apply:v-fresh', 'setUpdating:false']);
   });
 });

--- a/packages/cli/test/auto-update-jitter.test.ts
+++ b/packages/cli/test/auto-update-jitter.test.ts
@@ -3,8 +3,10 @@ import {
   resolveUpdateJitterMs,
   pickUpdateHoldoffMs,
   awaitUpdateHoldoff,
-  runWithUpdateHoldoff,
+  createUpdateHoldoffGate,
   UPDATE_JITTER_ENV,
+  type UpdateHoldoffGateConfig,
+  type UpdateHoldoffStep,
 } from '../src/daemon/auto-update-jitter.js';
 
 describe('resolveUpdateJitterMs', () => {
@@ -118,97 +120,117 @@ describe('awaitUpdateHoldoff', () => {
   });
 });
 
-describe('runWithUpdateHoldoff (the shared rollout gate)', () => {
-  function makeDeps(overrides: Record<string, unknown> = {}) {
+describe('createUpdateHoldoffGate (the shared rollout gate)', () => {
+  // Typed harness — the deps keep the real UpdateHoldoffGateConfig / Step types
+  // so drift between the gate contract and the fixtures is a compile error.
+  function harness(opts: {
+    jitterMs?: number;
+    isShuttingDown?: () => boolean;
+    sleep?: (ms: number) => Promise<void>;
+    revalidate?: () => Promise<string | null>;
+    apply?: (t: string) => Promise<void>;
+  } = {}) {
     const calls: string[] = [];
-    const log = vi.fn();
+    const log = vi.fn((m: string) => { calls.push(`log:${m}`); });
     const setUpdating = vi.fn((v: boolean) => { calls.push(`setUpdating:${v}`); });
-    const sleep = vi.fn(async () => { calls.push('sleep'); });
-    const onHold = vi.fn(() => { calls.push('onHold'); });
-    const revalidate = vi.fn(async () => { calls.push('revalidate'); return 'v-fresh' as string | null; });
-    const apply = vi.fn(async (t: string) => { calls.push(`apply:${t}`); });
-    const deps = {
-      pending: { active: false },
-      jitterMs: 600_000,
-      isShuttingDown: () => false,
+    const sleep = vi.fn(opts.sleep ?? (async () => { calls.push('sleep'); }));
+    const revalidate = vi.fn(opts.revalidate ?? (async () => { calls.push('revalidate'); return 'v-fresh' as string | null; }));
+    const apply = vi.fn(opts.apply ?? (async (t: string) => { calls.push(`apply:${t}`); }));
+    const config: UpdateHoldoffGateConfig = {
+      jitterMs: opts.jitterMs ?? 600_000,
+      isShuttingDown: opts.isShuttingDown ?? (() => false),
       setUpdating,
       log,
-      onHold,
+      rng: () => 0.5,
+      sleep,
+    };
+    const step: UpdateHoldoffStep<string> = {
+      onHold: () => calls.push('onHold'),
       revalidate,
       apply,
       shutdownMessage: 'SHUTDOWN',
       supersededMessage: 'SUPERSEDED',
-      rng: () => 0.5,
-      sleep,
-      ...overrides,
     };
-    return { deps, calls, log, setUpdating, sleep, onHold, revalidate, apply };
+    return { gate: createUpdateHoldoffGate(config), step, calls, log, setUpdating, sleep, revalidate, apply };
   }
 
   it('runs the gate in order and applies the REVALIDATED target (not the detected one)', async () => {
-    const { deps, calls, apply } = makeDeps();
-    await runWithUpdateHoldoff(deps as never);
+    const { gate, step, calls, apply } = harness();
+    await gate.run(step);
     expect(calls).toEqual([
       'onHold', 'sleep', 'revalidate', 'setUpdating:true', 'apply:v-fresh', 'setUpdating:false',
     ]);
     expect(apply).toHaveBeenCalledWith('v-fresh');
-    expect(deps.pending.active).toBe(false);
   });
 
-  it('is single-flight: a call while a rollout is pending does nothing and leaves the flag set', async () => {
-    const { deps, revalidate, apply } = makeDeps({ pending: { active: true } });
-    await runWithUpdateHoldoff(deps as never);
-    expect(revalidate).not.toHaveBeenCalled();
+  it('holds single-flight WHILE a hold-off is in flight — a second tick during the wait is a no-op', async () => {
+    // A hold-off that outlasts the poll interval must still block a second tick.
+    let release!: () => void;
+    const held = new Promise<void>((r) => { release = r; });
+    const revalidate = vi.fn(async () => 'v-fresh' as string | null);
+    const apply = vi.fn(async () => {});
+    const { gate, step } = harness({ sleep: () => held, revalidate, apply });
+
+    const first = gate.run(step); // enters, sets pending, awaits the un-resolved hold-off
+    await Promise.resolve();
+    // Second concurrent tick while the first rollout is mid-hold-off:
+    await gate.run(step);
+    expect(revalidate, 'second tick must not start a second rollout').not.toHaveBeenCalled();
     expect(apply).not.toHaveBeenCalled();
-    expect(deps.pending.active).toBe(true); // the in-flight rollout still owns it
+
+    release(); // let the first hold-off complete
+    await first;
+    expect(revalidate).toHaveBeenCalledTimes(1); // exactly ONE rollout ran
+    expect(apply).toHaveBeenCalledTimes(1);
   });
 
   it('does NOT apply a target withdrawn during the hold-off (revalidate -> null)', async () => {
-    const apply = vi.fn(async () => {});
-    const setUpdating = vi.fn();
-    const log = vi.fn();
-    const { deps } = makeDeps({
-      revalidate: vi.fn(async () => null),
-      apply, setUpdating, log,
-    });
-    await runWithUpdateHoldoff(deps as never);
+    const { gate, step, apply, setUpdating, log } = harness({ revalidate: async () => null });
+    await gate.run(step);
     expect(apply).not.toHaveBeenCalled();
     expect(setUpdating).not.toHaveBeenCalledWith(true);
     expect(log).toHaveBeenCalledWith('SUPERSEDED');
-    expect(deps.pending.active).toBe(false);
   });
 
   it('aborts before revalidate/apply when shutting down during the hold-off', async () => {
     let sd = false;
-    const revalidate = vi.fn(async () => 'x');
-    const apply = vi.fn(async () => {});
-    const log = vi.fn();
-    const { deps } = makeDeps({
+    const { gate, step, revalidate, apply, log } = harness({
       isShuttingDown: () => sd,
-      sleep: vi.fn(async () => { sd = true; }),
-      revalidate, apply, log,
+      sleep: async () => { sd = true; },
     });
-    await runWithUpdateHoldoff(deps as never);
+    await gate.run(step);
     expect(revalidate).not.toHaveBeenCalled();
     expect(apply).not.toHaveBeenCalled();
     expect(log).toHaveBeenCalledWith('SHUTDOWN');
-    expect(deps.pending.active).toBe(false);
   });
 
-  it('clears isUpdating and the pending flag even if apply throws', async () => {
-    const setUpdating = vi.fn();
-    const { deps } = makeDeps({
-      apply: vi.fn(async () => { throw new Error('boom'); }),
-      setUpdating,
+  it('aborts AFTER revalidation if shutdown began during the (async) revalidate call', async () => {
+    // The hold-off completes with shutdown=false, so revalidate runs; shutdown
+    // then flips DURING revalidate. The gate must re-check and NOT apply.
+    let sd = false;
+    const { gate, step, apply, setUpdating, log } = harness({
+      isShuttingDown: () => sd,
+      revalidate: async () => { sd = true; return 'v-fresh'; },
     });
-    await expect(runWithUpdateHoldoff(deps as never)).rejects.toThrow('boom');
+    await gate.run(step);
+    expect(apply).not.toHaveBeenCalled();
+    expect(setUpdating).not.toHaveBeenCalledWith(true);
+    expect(log).toHaveBeenCalledWith('SHUTDOWN');
+  });
+
+  it('clears isUpdating (and recovers single-flight) even if apply throws', async () => {
+    const { gate, step, setUpdating } = harness({ apply: async () => { throw new Error('boom'); } });
+    await expect(gate.run(step)).rejects.toThrow('boom');
     expect(setUpdating).toHaveBeenLastCalledWith(false);
-    expect(deps.pending.active).toBe(false);
+    // pending was cleared in finally, so the gate is usable again:
+    const ok = vi.fn(async () => {});
+    await gate.run({ ...step, apply: ok });
+    expect(ok).toHaveBeenCalledOnce();
   });
 
   it('applies with no hold-off log/sleep when jitter is disabled', async () => {
-    const { deps, calls } = makeDeps({ jitterMs: 0 });
-    await runWithUpdateHoldoff(deps as never);
+    const { gate, step, calls } = harness({ jitterMs: 0 });
+    await gate.run(step);
     expect(calls).toEqual(['revalidate', 'setUpdating:true', 'apply:v-fresh', 'setUpdating:false']);
   });
 });

--- a/packages/cli/test/auto-update-jitter.test.ts
+++ b/packages/cli/test/auto-update-jitter.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  resolveUpdateJitterMs,
+  pickUpdateHoldoffMs,
+  awaitUpdateHoldoff,
+  UPDATE_JITTER_ENV,
+} from '../src/daemon/auto-update-jitter.js';
+
+describe('resolveUpdateJitterMs', () => {
+  it('uses the configured minutes when set', () => {
+    expect(resolveUpdateJitterMs(10, 3, {})).toBe(10 * 60_000);
+  });
+
+  it('falls back to the poll interval when config is undefined (self-scaling)', () => {
+    expect(resolveUpdateJitterMs(undefined, 30, {})).toBe(30 * 60_000);
+  });
+
+  it('env override wins over config and interval', () => {
+    expect(resolveUpdateJitterMs(10, 3, { [UPDATE_JITTER_ENV]: '20' })).toBe(20 * 60_000);
+  });
+
+  it('0 disables via config or env', () => {
+    expect(resolveUpdateJitterMs(0, 30, {})).toBe(0);
+    expect(resolveUpdateJitterMs(10, 3, { [UPDATE_JITTER_ENV]: '0' })).toBe(0);
+  });
+
+  it('ignores an invalid / negative env value (falls back to config)', () => {
+    expect(resolveUpdateJitterMs(5, 3, { [UPDATE_JITTER_ENV]: 'abc' })).toBe(5 * 60_000);
+    expect(resolveUpdateJitterMs(5, 3, { [UPDATE_JITTER_ENV]: '-2' })).toBe(5 * 60_000);
+  });
+
+  it('clamps to a 12h maximum', () => {
+    expect(resolveUpdateJitterMs(100_000, 3, {})).toBe(12 * 60 * 60_000);
+  });
+
+  it('treats a non-positive interval fallback as disabled', () => {
+    expect(resolveUpdateJitterMs(undefined, 0, {})).toBe(0);
+  });
+});
+
+describe('pickUpdateHoldoffMs', () => {
+  it('returns 0 when jitter is disabled / non-positive', () => {
+    expect(pickUpdateHoldoffMs(0)).toBe(0);
+    expect(pickUpdateHoldoffMs(-1)).toBe(0);
+  });
+
+  it('returns a value in [0, jitterMs) for a valid rng', () => {
+    expect(pickUpdateHoldoffMs(600_000, () => 0)).toBe(0);
+    expect(pickUpdateHoldoffMs(600_000, () => 0.5)).toBe(300_000);
+    expect(pickUpdateHoldoffMs(600_000, () => 0.999999)).toBeLessThan(600_000);
+  });
+
+  it('guards against a misbehaving rng (NaN / out-of-range)', () => {
+    expect(pickUpdateHoldoffMs(600_000, () => Number.NaN)).toBe(0);
+    expect(pickUpdateHoldoffMs(600_000, () => 1)).toBe(0);
+    expect(pickUpdateHoldoffMs(600_000, () => -0.5)).toBe(0);
+  });
+});
+
+describe('awaitUpdateHoldoff', () => {
+  it('proceeds immediately without sleeping when jitter is disabled', async () => {
+    const sleep = vi.fn(async () => {});
+    const onHold = vi.fn();
+    const decision = await awaitUpdateHoldoff({
+      jitterMs: 0,
+      isShuttingDown: () => false,
+      onHold,
+      sleep,
+    });
+    expect(decision).toBe('proceed');
+    expect(sleep).not.toHaveBeenCalled();
+    expect(onHold).not.toHaveBeenCalled();
+  });
+
+  it('sleeps the picked hold-off and reports the window via onHold, then proceeds', async () => {
+    const sleep = vi.fn(async () => {});
+    const onHold = vi.fn();
+    const decision = await awaitUpdateHoldoff({
+      jitterMs: 600_000,
+      isShuttingDown: () => false,
+      onHold,
+      sleep,
+      rng: () => 0.5,
+    });
+    expect(decision).toBe('proceed');
+    expect(sleep).toHaveBeenCalledOnce();
+    expect(sleep).toHaveBeenCalledWith(300_000);
+    expect(onHold).toHaveBeenCalledWith(300_000);
+  });
+
+  it('aborts when the daemon began shutting down DURING the hold-off', async () => {
+    let shuttingDown = false;
+    // Flip the flag while the (fake) sleep is "in flight" — the shutdown bail
+    // must be evaluated AFTER the wait, not before.
+    const sleep = vi.fn(async () => {
+      shuttingDown = true;
+    });
+    const decision = await awaitUpdateHoldoff({
+      jitterMs: 600_000,
+      isShuttingDown: () => shuttingDown,
+      sleep,
+      rng: () => 0.5,
+    });
+    expect(sleep).toHaveBeenCalledOnce();
+    expect(decision).toBe('abort-shutdown');
+  });
+
+  it('aborts even with jitter disabled if already shutting down (never applies during shutdown)', async () => {
+    const sleep = vi.fn(async () => {});
+    const decision = await awaitUpdateHoldoff({
+      jitterMs: 0,
+      isShuttingDown: () => true,
+      sleep,
+    });
+    expect(decision).toBe('abort-shutdown');
+    expect(sleep).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/test/auto-update.test.ts
+++ b/packages/cli/test/auto-update.test.ts
@@ -205,7 +205,8 @@ import {
   resolveAutoUpdateGitRefPlan,
 } from '../src/daemon.js';
 import { createUpdateHoldoffGate } from '../src/daemon/auto-update-jitter.js';
-import { createNpmUpdateRunCheck, createGitUpdateRunCheck, type AutoUpdateLastCheck } from '../src/daemon/auto-update-runner.js';
+import { createNpmUpdateRunCheck, createGitUpdateRunCheck } from '../src/daemon/auto-update-runner.js';
+import type { LastUpdateCheck } from '../src/daemon/state.js';
 
 const AU: AutoUpdateConfig = {
   enabled: true,
@@ -2117,14 +2118,14 @@ describe('resolveCurrentNpmTarget (post-hold-off revalidation)', () => {
   afterEach(() => { restoreIo(); });
 
   it('returns the version when the channel target is still available and ahead', async () => {
-    const { resolveCurrentNpmTarget } = await import('../src/daemon.js');
+    const { resolveCurrentNpmTarget } = await import('../src/daemon/auto-update-runner.js');
     currentVersion('9.0.0');
     fetchImpl = async () => makeRegistryResponse({ latest: '9.1.0' });
     expect(await resolveCurrentNpmTarget(() => {}, false)).toBe('9.1.0');
   });
 
   it('returns null when the target was withdrawn / rolled back during the hold-off (now up-to-date)', async () => {
-    const { resolveCurrentNpmTarget } = await import('../src/daemon.js');
+    const { resolveCurrentNpmTarget } = await import('../src/daemon/auto-update-runner.js');
     currentVersion('9.0.0');
     // 9.1.0 pulled; latest rolled back to what the node already runs.
     fetchImpl = async () => makeRegistryResponse({ latest: '9.0.0' });
@@ -2132,7 +2133,7 @@ describe('resolveCurrentNpmTarget (post-hold-off revalidation)', () => {
   });
 
   it('returns null when a pinned channel no longer has an acceptable target', async () => {
-    const { resolveCurrentNpmTarget } = await import('../src/daemon.js');
+    const { resolveCurrentNpmTarget } = await import('../src/daemon/auto-update-runner.js');
     currentVersion('9.0.0');
     // The 'mainnet' dist-tag is absent -> no-target -> nothing to apply.
     fetchImpl = async () => makeRegistryResponse({ latest: '9.1.0' });
@@ -2153,14 +2154,14 @@ describe('resolveCurrentGitTarget (post-hold-off revalidation)', () => {
   afterEach(() => { restoreIo(); });
 
   it('returns the fresh remote commit when the ref is still ahead', async () => {
-    const { resolveCurrentGitTarget } = await import('../src/daemon.js');
+    const { resolveCurrentGitTarget } = await import('../src/daemon/auto-update-runner.js');
     readFileImpl = async () => 'aaa1111'; // current commit
     remoteSha('bbb2222');
     expect(await resolveCurrentGitTarget(gitAu, () => {})).toBe('bbb2222');
   });
 
   it('returns null when the ref moved back to the running commit during the hold-off', async () => {
-    const { resolveCurrentGitTarget } = await import('../src/daemon.js');
+    const { resolveCurrentGitTarget } = await import('../src/daemon/auto-update-runner.js');
     readFileImpl = async () => 'aaa1111';
     remoteSha('aaa1111'); // remote == current -> up-to-date -> nothing to apply
     expect(await resolveCurrentGitTarget(gitAu, () => {})).toBeNull();
@@ -2171,7 +2172,7 @@ describe('resolveCurrentGitTarget (post-hold-off revalidation)', () => {
 // gate and skip a target that was withdrawn during the hold-off — i.e. that the
 // production path uses the post-hold-off revalidation, not the pre-hold-off
 // detected target. (Guards against a `revalidate: () => detectedTarget` regression.)
-function freshLastCheck(): AutoUpdateLastCheck {
+function freshLastCheck(): LastUpdateCheck {
   return { upToDate: false, checkedAt: 0, latestCommit: '', latestVersion: '', channelTargetMissing: false };
 }
 function noJitterGate(log: (m: string) => void) {
@@ -2278,7 +2279,10 @@ describe('createGitUpdateRunCheck (end-to-end polling wiring)', () => {
 
     await runCheck();
 
-    expect(logs.some((m) => m.includes('update started')), 'performUpdateWithStatus must not run').toBe(false);
+    // Direct signal, not a log substring: performUpdateWithStatus's first act is
+    // acquireUpdateLock -> openSync(".update.lock"). Zero openSync calls proves
+    // the updater was never entered (detect/revalidate never openSync).
+    expect(openSyncCalls.length, 'the updater (performUpdateWithStatus) must not be entered').toBe(0);
     expect(onRestart).not.toHaveBeenCalled();
     expect(logs.some((m) => m.includes('superseded'))).toBe(true);
     expect(lastUpdateCheck.latestCommit).toBe('bbb2222'); // detect recorded the then-available tip

--- a/packages/cli/test/auto-update.test.ts
+++ b/packages/cli/test/auto-update.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import type { AutoUpdateConfig } from '../src/config.js';
 import { _autoUpdateIo } from '../src/daemon.js';
 
@@ -204,6 +204,8 @@ import {
   resolveAutoUpdateGitRef,
   resolveAutoUpdateGitRefPlan,
 } from '../src/daemon.js';
+import { createUpdateHoldoffGate } from '../src/daemon/auto-update-jitter.js';
+import { createNpmUpdateRunCheck, createGitUpdateRunCheck, type AutoUpdateLastCheck } from '../src/daemon/auto-update-runner.js';
 
 const AU: AutoUpdateConfig = {
   enabled: true,
@@ -2162,5 +2164,123 @@ describe('resolveCurrentGitTarget (post-hold-off revalidation)', () => {
     readFileImpl = async () => 'aaa1111';
     remoteSha('aaa1111'); // remote == current -> up-to-date -> nothing to apply
     expect(await resolveCurrentGitTarget(gitAu, () => {})).toBeNull();
+  });
+});
+
+// End-to-end polling wiring: prove the REAL npm/git runChecks route through the
+// gate and skip a target that was withdrawn during the hold-off — i.e. that the
+// production path uses the post-hold-off revalidation, not the pre-hold-off
+// detected target. (Guards against a `revalidate: () => detectedTarget` regression.)
+function freshLastCheck(): AutoUpdateLastCheck {
+  return { upToDate: false, checkedAt: 0, latestCommit: '', latestVersion: '', channelTargetMissing: false };
+}
+function noJitterGate(log: (m: string) => void) {
+  return createUpdateHoldoffGate({ jitterMs: 0, isShuttingDown: () => false, setUpdating: () => {}, log });
+}
+
+describe('createNpmUpdateRunCheck (end-to-end polling wiring)', () => {
+  function currentVersion(v: string) {
+    readFileImpl = async (path: any) => {
+      if (String(path).endsWith('.current-version')) return v;
+      throw new Error('ENOENT');
+    };
+  }
+  // Successive fetches return successive dist-tag sets (detect, then revalidate).
+  function registrySequence(...tagSets: Record<string, string>[]) {
+    let i = 0;
+    fetchImpl = async () => {
+      const tags = tagSets[Math.min(i, tagSets.length - 1)];
+      i += 1;
+      return { ok: true, json: async () => ({ 'dist-tags': tags }) } as any;
+    };
+  }
+
+  beforeEach(() => { resetMocks(); installMocks(); });
+  afterEach(() => { restoreIo(); });
+
+  it('does NOT install a version withdrawn during the hold-off (detect ahead, revalidate up-to-date)', async () => {
+    const logs: string[] = [];
+    currentVersion('9.0.0');
+    registrySequence({ latest: '9.1.0' }, { latest: '9.0.0' }); // 9.1.0 detected, then rolled back
+    const lastUpdateCheck = freshLastCheck();
+    const onRestart = vi.fn(async () => {});
+    const runCheck = createNpmUpdateRunCheck({
+      gate: noJitterGate((m) => logs.push(m)),
+      log: (m) => logs.push(m),
+      lastUpdateCheck, allowPrerelease: false, nodeRole: 'core', onRestart,
+    });
+
+    await runCheck();
+
+    expect(mkdirCalls.length, 'the installer (performNpmUpdate) must not run').toBe(0);
+    expect(onRestart).not.toHaveBeenCalled();
+    expect(logs.some((m) => m.includes('superseded'))).toBe(true);
+    expect(lastUpdateCheck.latestVersion).toBe('9.1.0'); // detect recorded the then-available target
+  });
+
+  it('reaches the installer when the target is still available after the hold-off', async () => {
+    currentVersion('9.0.0');
+    registrySequence({ latest: '9.1.0' }); // available on both detect and revalidate
+    const runCheck = createNpmUpdateRunCheck({
+      gate: noJitterGate(() => {}), log: () => {},
+      lastUpdateCheck: freshLastCheck(), allowPrerelease: false, nodeRole: 'core', onRestart: async () => {},
+    });
+
+    // The installer may error under the shallow IO mocks; we only assert it was ENTERED.
+    await runCheck().catch(() => {});
+    expect(mkdirCalls.length, 'installer entered → releases dir created').toBeGreaterThan(0);
+  });
+
+  it('version-check-only mode (no gate) records status but never installs', async () => {
+    currentVersion('9.0.0');
+    registrySequence({ latest: '9.1.0' });
+    const lastUpdateCheck = freshLastCheck();
+    const runCheck = createNpmUpdateRunCheck({
+      gate: null, log: () => {},
+      lastUpdateCheck, allowPrerelease: false, nodeRole: 'core', onRestart: async () => {},
+    });
+
+    await runCheck();
+    expect(mkdirCalls.length).toBe(0);
+    expect(lastUpdateCheck.latestVersion).toBe('9.1.0');
+    expect(lastUpdateCheck.upToDate).toBe(false);
+  });
+});
+
+describe('createGitUpdateRunCheck (end-to-end polling wiring)', () => {
+  const gitAu = { ...AU, repo: 'git@github.com:owner/repo.git', sshKeyPath: '/tmp/key' } as any;
+  function remoteSequence(...shas: string[]) {
+    let i = 0;
+    execFileImpl = async (file: string, args: string[]) => {
+      if (file === 'git' && args[0] === 'ls-remote') {
+        const sha = shas[Math.min(i, shas.length - 1)];
+        i += 1;
+        return { stdout: `${sha}\trefs/heads/main\n`, stderr: '' };
+      }
+      return { stdout: '', stderr: '' };
+    };
+  }
+
+  beforeEach(() => { resetMocks(); installMocks(); });
+  afterEach(() => { restoreIo(); });
+
+  it('does NOT build a commit the ref moved away from during the hold-off', async () => {
+    const logs: string[] = [];
+    readFileImpl = async () => 'aaa1111';   // current commit
+    remoteSequence('bbb2222', 'aaa1111');    // detect ahead, then ref rolled back to current
+    const lastUpdateCheck = freshLastCheck();
+    const onRestart = vi.fn(async () => {});
+    const runCheck = createGitUpdateRunCheck({
+      gate: noJitterGate((m) => logs.push(m)),
+      log: (m) => logs.push(m),
+      lastUpdateCheck, au: gitAu, onRestart,
+    });
+
+    await runCheck();
+
+    expect(logs.some((m) => m.includes('update started')), 'performUpdateWithStatus must not run').toBe(false);
+    expect(onRestart).not.toHaveBeenCalled();
+    expect(logs.some((m) => m.includes('superseded'))).toBe(true);
+    expect(lastUpdateCheck.latestCommit).toBe('bbb2222'); // detect recorded the then-available tip
   });
 });

--- a/packages/cli/test/auto-update.test.ts
+++ b/packages/cli/test/auto-update.test.ts
@@ -2094,3 +2094,73 @@ describe('autoupdater hardening', () => {
   });
 
 });
+
+// Post-hold-off revalidation mappers for the rollout gate. These guard the
+// exact seam behind the 🔴 review finding: after the jitter delay, the target
+// detected earlier must be RE-CONFIRMED so a withdrawn / rolled-back release is
+// never installed. (The gate orchestration itself is covered in
+// auto-update-jitter.test.ts; here we prove the real npm/git mappers.)
+describe('resolveCurrentNpmTarget (post-hold-off revalidation)', () => {
+  function makeRegistryResponse(distTags: Record<string, string>) {
+    return { ok: true, json: async () => ({ 'dist-tags': distTags }) } as any;
+  }
+  function currentVersion(v: string) {
+    readFileImpl = async (path: any) => {
+      if (String(path).endsWith('.current-version')) return v;
+      throw new Error('ENOENT');
+    };
+  }
+
+  beforeEach(() => { resetMocks(); installMocks(); });
+  afterEach(() => { restoreIo(); });
+
+  it('returns the version when the channel target is still available and ahead', async () => {
+    const { resolveCurrentNpmTarget } = await import('../src/daemon.js');
+    currentVersion('9.0.0');
+    fetchImpl = async () => makeRegistryResponse({ latest: '9.1.0' });
+    expect(await resolveCurrentNpmTarget(() => {}, false)).toBe('9.1.0');
+  });
+
+  it('returns null when the target was withdrawn / rolled back during the hold-off (now up-to-date)', async () => {
+    const { resolveCurrentNpmTarget } = await import('../src/daemon.js');
+    currentVersion('9.0.0');
+    // 9.1.0 pulled; latest rolled back to what the node already runs.
+    fetchImpl = async () => makeRegistryResponse({ latest: '9.0.0' });
+    expect(await resolveCurrentNpmTarget(() => {}, false)).toBeNull();
+  });
+
+  it('returns null when a pinned channel no longer has an acceptable target', async () => {
+    const { resolveCurrentNpmTarget } = await import('../src/daemon.js');
+    currentVersion('9.0.0');
+    // The 'mainnet' dist-tag is absent -> no-target -> nothing to apply.
+    fetchImpl = async () => makeRegistryResponse({ latest: '9.1.0' });
+    expect(await resolveCurrentNpmTarget(() => {}, false, 'mainnet')).toBeNull();
+  });
+});
+
+describe('resolveCurrentGitTarget (post-hold-off revalidation)', () => {
+  const gitAu = { ...AU, repo: 'git@github.com:owner/repo.git', sshKeyPath: '/tmp/key' } as any;
+  function remoteSha(sha: string) {
+    execFileImpl = async (file: string, args: string[]) =>
+      file === 'git' && args[0] === 'ls-remote'
+        ? { stdout: `${sha}\trefs/heads/main\n`, stderr: '' }
+        : { stdout: '', stderr: '' };
+  }
+
+  beforeEach(() => { resetMocks(); installMocks(); });
+  afterEach(() => { restoreIo(); });
+
+  it('returns the fresh remote commit when the ref is still ahead', async () => {
+    const { resolveCurrentGitTarget } = await import('../src/daemon.js');
+    readFileImpl = async () => 'aaa1111'; // current commit
+    remoteSha('bbb2222');
+    expect(await resolveCurrentGitTarget(gitAu, () => {})).toBe('bbb2222');
+  });
+
+  it('returns null when the ref moved back to the running commit during the hold-off', async () => {
+    const { resolveCurrentGitTarget } = await import('../src/daemon.js');
+    readFileImpl = async () => 'aaa1111';
+    remoteSha('aaa1111'); // remote == current -> up-to-date -> nothing to apply
+    expect(await resolveCurrentGitTarget(gitAu, () => {})).toBeNull();
+  });
+});

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -693,6 +693,38 @@ describe('resolveAutoUpdateConfig', () => {
     expect(resolved?.verifyTagSignature).toBe(true);
   });
 
+  it('plumbs a local updateJitterMinutes through to the resolved config', () => {
+    const resolved = resolveAutoUpdateConfig(
+      { autoUpdate: { enabled: true, source: 'git', updateJitterMinutes: 10 } },
+      { autoUpdate: { enabled: true, repo: 'owner/repo', branch: 'main', checkIntervalMinutes: 30, source: 'git' } },
+    );
+    expect(resolved?.updateJitterMinutes).toBe(10);
+  });
+
+  it('inherits a network-level updateJitterMinutes default when local is unset', () => {
+    const resolved = resolveAutoUpdateConfig(
+      { autoUpdate: { enabled: true, source: 'git' } },
+      { autoUpdate: { enabled: true, repo: 'owner/repo', branch: 'main', checkIntervalMinutes: 30, updateJitterMinutes: 45, source: 'git' } },
+    );
+    expect(resolved?.updateJitterMinutes).toBe(45);
+  });
+
+  it('prefers the local updateJitterMinutes over the network default (including 0 = disable)', () => {
+    const resolved = resolveAutoUpdateConfig(
+      { autoUpdate: { enabled: true, source: 'git', updateJitterMinutes: 0 } },
+      { autoUpdate: { enabled: true, repo: 'owner/repo', branch: 'main', checkIntervalMinutes: 30, updateJitterMinutes: 45, source: 'git' } },
+    );
+    expect(resolved?.updateJitterMinutes).toBe(0);
+  });
+
+  it('omits updateJitterMinutes from the resolved config when neither layer sets it', () => {
+    const resolved = resolveAutoUpdateConfig(
+      { autoUpdate: { enabled: true, source: 'git' } },
+      { autoUpdate: { enabled: true, repo: 'owner/repo', branch: 'main', checkIntervalMinutes: 30, source: 'git' } },
+    );
+    expect(resolved).not.toHaveProperty('updateJitterMinutes');
+  });
+
   it('preserves a local false tag-signature override over network defaults', () => {
     const resolved = resolveAutoUpdateConfig(
       {

--- a/packages/cli/test/init.test.ts
+++ b/packages/cli/test/init.test.ts
@@ -64,6 +64,18 @@ describe('buildInitAutoUpdate', () => {
     expect(r.checkIntervalMinutes).toBe(10);
   });
 
+  it('enable preserves an explicit updateJitterMinutes override across reruns (incl. 0 = disabled)', () => {
+    const r = buildInitAutoUpdate({
+      enableAutoUpdate: true,
+      // Operator disabled rollout jitter on this node; a rerun must not drop it.
+      existingAutoUpdate: { enabled: true, source: 'npm', updateJitterMinutes: 0 },
+      networkAutoUpdate: net,
+      ...proj,
+      answers: { allowPrerelease: true, interval: 5 },
+    });
+    expect(r.updateJitterMinutes).toBe(0);
+  });
+
   it('enable preserves npm fields but drops git-only fields when forcing npm mode', () => {
     const r = buildInitAutoUpdate({
       enableAutoUpdate: true,


### PR DESCRIPTION
## Why

A commit/release on the tracked ref is picked up by **every node within one poll interval**, so the whole fleet builds + restarts in one narrow window. That synchronized restart is the **bootstrap-storm trigger behind the 2026-07-10 beacon OOM incident**: all 4 testnet cores auto-updated to 10.0.6 within ~6 min and hit the O(store) sync-responder fallback lane at once, driving them OOM.

Poll-phase jitter does **not** fix this — detection is bounded by the interval regardless of phase. The effective lever is a per-node random **hold-off between detecting an available update and applying it** (build + restart), which spreads the fleet's restarts across the jitter window so only a few nodes bootstrap at any moment.

## What

- **New `updateJitterMinutes`** config knob (local `autoUpdate` + network overlay). Resolution precedence: `DKG_UPDATE_JITTER_MINUTES` env > config > **fallback = the poll interval** (so the window self-scales with cadence). `0` disables. Clamped to `[0, 12h]`.
- **Wired into both git- and npm-mode** auto-update `runCheck`s: on a detected update, pick a random hold-off in `[0, window)`, wait, then apply. The timer is **`unref`'d** so a pending hold-off never blocks process exit, and the apply **bails if the daemon began shutting down** during the wait (the update is simply re-detected on next boot). A re-entrancy guard keeps **one rollout at a time** when the hold-off outlasts the poll interval.
- Extracted the `pick → sleep → shutdown-bail` ordering into **`awaitUpdateHoldoff`** so that sequence is unit-tested, not just eyeballed inside the daemon loop.

## Behavior change (default-on)

This defaults **on**: with no config, the jitter window equals the poll interval (default 30 min), so **updates now hold off up to ~30 min before applying**. That is intentional — an opt-in jitter leaves the exact incident condition (synchronized restart) intact for every fleet that doesn't reconfigure. Disable per node with `updateJitterMinutes: 0` or `DKG_UPDATE_JITTER_MINUTES=0`.

**Caveat:** the *first* release carrying this code still rolls out synchronized — nodes don't have the jitter logic until after they've updated to it.

**Ops guidance:** the 30-min default spreads a ~5-node fleet to ~6–7 min spacing, but the incident showed nodes thrashing 40+ min post-restart, so adjacent nodes can still overlap during bootstrap. Beacon/core fleets should set an explicit `updateJitterMinutes` **≥ their bootstrap/resync duration** rather than riding the default.

## Tests

- `test/auto-update-jitter.test.ts` — `resolveUpdateJitterMs` (env/config/interval precedence, disable, clamp, invalid-env), `pickUpdateHoldoffMs` (range, rng-guard), and `awaitUpdateHoldoff` (no-sleep when disabled, sleeps+reports window, **aborts when shutdown flips during the wait**, never applies while shutting down).
- `test/config.test.ts` — `resolveAutoUpdateConfig` plumbing for `updateJitterMinutes` (local, network-inherit, local-over-network incl. `0`, omitted-when-unset).
- Full `auto-update` + `config` suites green (114 + 100).

🤖 Generated with [Claude Code](https://claude.com/claude-code)