### PR TITLE
feat(storage): OT-RFC-59 write-side change log (ChangelogStore) — PR 1/4

### DIFF
--- a/packages/cli/src/daemon/chain-reset-wipe.ts
+++ b/packages/cli/src/daemon/chain-reset-wipe.ts
@@ -73,7 +73,7 @@ import {
   utimesSync,
 } from 'node:fs';
 import { join } from 'node:path';
-import { isExternalBackend, getSparqlEndpoint } from '@origintrail-official/dkg-storage';
+import { isExternalBackend, getSparqlEndpoint, CHANGELOG_GRAPH } from '@origintrail-official/dkg-storage';
 
 const STATE_FILE = '.network-state.json';
 
@@ -134,10 +134,15 @@ export interface ChainResetWipeStoreConfig {
 const V10_GRAPH_PREFIX = 'did:dkg:context-graph:';
 
 const SPARQL_DROP_ALL = 'DROP ALL';
+// Scoped wipe also clears the OT-RFC-59 changelog graph so a chain reset is a
+// clean reseed (stale markers referencing now-deleted CG graphs must not
+// survive). `DROP ALL` (managed namespaces) already covers it. The changelog
+// graph is a reserved `urn:` graph outside the CG prefix, so it needs an
+// explicit disjunct here.
 const SPARQL_SCOPED_DELETE =
   'DELETE { GRAPH ?g { ?s ?p ?o } } ' +
   'WHERE { GRAPH ?g { ?s ?p ?o } ' +
-  `FILTER(strstarts(str(?g), "${V10_GRAPH_PREFIX}")) }`;
+  `FILTER(strstarts(str(?g), "${V10_GRAPH_PREFIX}") || str(?g) = "${CHANGELOG_GRAPH}") }`;
 
 export interface ChainResetWipeResult {
   /** True when a wipe was performed. */

--- a/packages/cli/test/chain-reset-wipe.test.ts
+++ b/packages/cli/test/chain-reset-wipe.test.ts
@@ -527,6 +527,9 @@ describe('chainResetWipe — external SPARQL wipe', () => {
     expect(update).toContain('DELETE');
     expect(update).toContain('did:dkg:context-graph:');
     expect(update).toContain('strstarts');
+    // OT-RFC-59: the reserved changelog graph is a `urn:` graph outside the CG
+    // prefix, so a scoped wipe must clear it too (clean reseed, no stale markers).
+    expect(update).toContain('urn:dkg:changelog');
     expect(update).not.toBe('DROP ALL');
   });
 

--- a/packages/storage/src/changelog-store.ts
+++ b/packages/storage/src/changelog-store.ts
@@ -27,19 +27,37 @@ import type {
  * ## Crash-consistency (the invariant that matters)
  *
  * OT-RFC-59 §6 / G3: *every committed store change is discoverable through the
- * log* — no committed upsert is ever invisible. This holds because an **upsert
- * marker is appended to the very same `insert(quads)` call as the data**
- * (`inner.insert([...quads, ...markers])`). A single `insert()` is one backend
- * transaction on every adapter — one Oxigraph in-memory apply flushed as a whole
- * snapshot, one Blazegraph N-Quads POST, one `sparql-http` INSERT DATA — so the
- * data and its marker commit or abort together. There is no window where the
- * data is durable but the marker is lost.
+ * log*. The strength of that guarantee differs by path:
  *
- * Drops/deletes are the opposite (benign) direction: a *lost* drop marker means
- * a peer keeps stale data, healed by a later catalog reconcile, never silent
- * data loss. Those markers are therefore written in a second step after the
- * mutation (`op` derived from a `hasGraph` probe), which is acceptable per §6
- * and avoids depending on multi-statement UPDATE atomicity.
+ * - **`insert()` — atomic, no window.** The upsert marker is appended to the
+ *   very same `insert(quads)` call as the data (`inner.insert([...quads,
+ *   ...markers])`). A single `insert()` is one backend transaction on every
+ *   adapter — one Oxigraph in-memory apply flushed as a whole snapshot, one
+ *   Blazegraph N-Quads POST, one `sparql-http` INSERT DATA — so data and marker
+ *   commit or abort together. There is genuinely no window where the data is
+ *   durable but the marker is lost.
+ *
+ * - **`delete()`/`dropGraph()`/`deleteByPattern()`/`deleteBySubjectPrefix()`/
+ *   `update()` — post-mutation marker, benign lost-marker window.** These write
+ *   the marker in a SECOND step after the mutation (`op` derived from a
+ *   `hasGraph` probe), so a crash/store-error between the mutation commit and
+ *   the marker append leaves the data durable with no marker. That is acceptable
+ *   because it is **store-authoritative and reconcile-healable**: a later catalog
+ *   reconcile (PR2) re-derives the missing marker from the store. To bound the
+ *   window we also set {@link needsReconcile} whenever the post-mutation marker
+ *   write itself throws (see {@link markPostMutation}), so the daemon has an
+ *   in-process signal even before PR2 reconcile runs (see {@link appendMarkers}).
+ *
+ *   Note the op is not always `drop`: `update()`/`deleteByPattern` with a
+ *   `touchedGraphs` hint into a graph that still has data emits an **`upsert`**
+ *   marker post-mutation. A *lost* such marker is the one non-benign shape a
+ *   naive set-based (listGraphs-vs-log) reconcile cannot catch — the graph is
+ *   present in both store and log, so a set diff sees no discrepancy while a
+ *   syncing peer keeps an under-complete copy. **PR2 constraint:** the reconcile
+ *   pass must be content-aware for graphs touched by opaque/`update()` writes
+ *   (or such upserts must be fused on the `insert()` path), not merely
+ *   set-difference. Today this is latent: the only `update()`-INSERT caller
+ *   (RS-heal) targets brand-new scoped graphs, which a set reconcile does catch.
  *
  * ## Single-writer sequence allocation (the load-bearing constraint)
  *
@@ -267,6 +285,13 @@ export class ChangelogStore implements TripleStore {
   }
 
   async countQuads(graphUri?: string, options?: QueryOptions): Promise<number> {
+    // Deliberate passthrough: unlike listGraphs()/hasGraph(), counting is NOT
+    // masked, so countQuads() (no arg) and query() include marker quads. The
+    // reserved-plane-invisible contract covers enumeration only. No current
+    // caller counts for accounting that must exclude the reserved plane; the
+    // total-triples telemetry (metrics-queries.ts) will drift by the marker
+    // count when enabled — exclude urn:dkg:changelog there alongside the PR2
+    // enable-path wiring.
     return this.inner.countQuads(graphUri, options);
   }
 
@@ -381,24 +406,39 @@ export class ChangelogStore implements TripleStore {
     await this.appendMarkers(specs, options);
   }
 
-  /** Allocate contiguous seqs and durably append markers (caller holds mutex). */
+  /**
+   * Allocate contiguous seqs and durably append markers (caller holds mutex).
+   *
+   * This is the POST-MUTATION marker sink (drops/deletes/update-upserts): the
+   * data mutation has already committed, so a failure here means a committed
+   * change with no marker. We flag {@link needsReconcile} before propagating so
+   * the gap is signalled even before the PR2 catalog reconcile runs. `seq` is
+   * advanced only after a durable append, so a failure is gapless (the next
+   * write reuses the seq). The atomic `insert()` upsert path does NOT go through
+   * here — it fuses markers into the data transaction and cannot half-commit.
+   */
   private async appendMarkers(
     specs: ReadonlyArray<{ graph: string; op: ChangeOp }>,
     options?: QueryOptions,
   ): Promise<void> {
     if (specs.length === 0) return;
-    await this.ensureSeeded();
-    let candidate = this.seq;
-    const quads: Quad[] = [];
-    const records: ChangeRecord[] = [];
-    for (const spec of specs) {
-      candidate += 1;
-      records.push({ seq: candidate, graph: spec.graph, op: spec.op });
-      quads.push(...markerQuads(candidate, spec.graph, spec.op));
+    try {
+      await this.ensureSeeded();
+      let candidate = this.seq;
+      const quads: Quad[] = [];
+      const records: ChangeRecord[] = [];
+      for (const spec of specs) {
+        candidate += 1;
+        records.push({ seq: candidate, graph: spec.graph, op: spec.op });
+        quads.push(...markerQuads(candidate, spec.graph, spec.op));
+      }
+      await this.inner.insert(quads, options);
+      this.seq = candidate;
+      this.fire(records);
+    } catch (err) {
+      this.flagReconcile('appendMarkers(post-mutation-marker-write-failed)');
+      throw err;
     }
-    await this.inner.insert(quads, options);
-    this.seq = candidate;
-    this.fire(records);
   }
 
   private fire(records: readonly ChangeRecord[]): void {

--- a/packages/storage/src/changelog-store.ts
+++ b/packages/storage/src/changelog-store.ts
@@ -1,3 +1,4 @@
+import { isSparqlUpdateOperation } from '@origintrail-official/dkg-core';
 import type {
   Quad,
   QueryOptions,
@@ -107,6 +108,24 @@ export interface ChangeRecord {
   op: ChangeOp;
 }
 
+/**
+ * The changelog READ capability the sync responder (PR2) consumes. Exposed as an
+ * explicit interface + {@link asChangelogReader} type guard so a consumer of a
+ * `createTripleStore(...)` result can recover it without a cast or knowledge of
+ * decorator order — the changelog is otherwise invisible behind the `TripleStore`
+ * factory return type.
+ */
+export interface ChangelogReader {
+  /** Change records with `seq > sinceSeq`, ascending, at most `limit`. */
+  readChanges(sinceSeq: number, limit: number, options?: QueryOptions): Promise<ChangeRecord[]>;
+  /** Highest seq durably present in the log (0 if empty). */
+  headSeq(options?: QueryOptions): Promise<number>;
+  /** True when an opaque mutation left the log incomplete (reconcile owed). */
+  readonly needsReconcile: boolean;
+  /** Cleared by the reconcile pass (PR2) once it has emitted synthetic markers. */
+  clearReconcileFlag(): void;
+}
+
 export interface ChangelogStoreOptions {
   enabled?: boolean;
   /**
@@ -123,7 +142,7 @@ export interface ChangelogStoreOptions {
  * Write-path append-only change log. See the class-level docstring for the
  * crash-consistency and single-writer arguments.
  */
-export class ChangelogStore implements TripleStore {
+export class ChangelogStore implements TripleStore, ChangelogReader {
   get queryCancellation() {
     return this.inner.queryCancellation;
   }
@@ -138,6 +157,8 @@ export class ChangelogStore implements TripleStore {
   private seedPromise: Promise<void> | null = null;
   /** Serializes mutations so commit order === seq order (single writer). */
   private tail: Promise<unknown> = Promise.resolve();
+  /** Set by close(): the write gate is shut so no new mutation may enqueue. */
+  private closing = false;
   /**
    * Set when a mutation could not be attributed to specific graphs (an opaque
    * `update()`/`query()` UPDATE with no `touchedGraphs` hint). Its changed
@@ -161,10 +182,15 @@ export class ChangelogStore implements TripleStore {
 
   async insert(quads: Quad[], options?: QueryOptions): Promise<void> {
     if (!this.enabled) return this.inner.insert(quads, options);
-    const touched = this.attributableGraphs(quads);
+    // The reserved plane is not writable through the public API: strip any
+    // caller-supplied quads targeting it so a forged marker (e.g. a fake seq to
+    // jump the high-water mark) can never reach the inner store. Only the
+    // decorator's own internal writes (below, via this.inner) touch it.
+    const safe = this.stripReserved(quads);
+    const touched = this.attributableGraphs(safe);
     if (touched.length === 0) {
-      // Nothing the log cares about (default graph, or only reserved graphs).
-      return this.inner.insert(quads, options);
+      // Nothing the log cares about (default graph only).
+      return this.inner.insert(safe, options);
     }
     await this.runExclusive(async () => {
       await this.ensureSeeded();
@@ -177,7 +203,7 @@ export class ChangelogStore implements TripleStore {
         markers.push(...markerQuads(candidate, graph, 'upsert'));
       }
       // Data + markers in ONE insert() → one backend transaction → atomic.
-      await this.inner.insert([...quads, ...markers], options);
+      await this.inner.insert([...safe, ...markers], options);
       this.seq = candidate; // advance only after durable success (gapless)
       this.fire(records);
     });
@@ -185,21 +211,31 @@ export class ChangelogStore implements TripleStore {
 
   async delete(quads: Quad[], options?: QueryOptions): Promise<void> {
     if (!this.enabled) return this.inner.delete(quads, options);
-    const touched = this.attributableGraphs(quads);
+    // Strip reserved-graph quads: callers cannot delete markers out of the log.
+    const safe = this.stripReserved(quads);
+    const touched = this.attributableGraphs(safe);
     await this.runExclusive(async () => {
-      await this.inner.delete(quads, options);
+      await this.inner.delete(safe, options);
       await this.markPostMutation(touched, options);
     });
   }
 
   async deleteByPattern(pattern: Partial<Quad>, options?: QueryOptions): Promise<number> {
     if (!this.enabled) return this.inner.deleteByPattern(pattern, options);
+    if (pattern.graph) {
+      // A graph-scoped delete against the reserved plane would erase the log.
+      this.assertNotReserved(pattern.graph, 'deleteByPattern');
+    } else {
+      // A no-graph delete by a reserved-namespaced subject/predicate would delete
+      // markers cross-graph — the same log-erasure vector, so reject it too.
+      this.assertNoReservedTerm(pattern);
+    }
     return this.runExclusive(async () => {
       const removed = await this.inner.deleteByPattern(pattern, options);
       if (removed > 0) {
-        if (pattern.graph && !this.reserved.has(pattern.graph)) {
+        if (pattern.graph) {
           await this.markPostMutation([pattern.graph], options);
-        } else if (!pattern.graph) {
+        } else {
           // No graph hint → cannot attribute which graphs shrank/emptied.
           this.flagReconcile('deleteByPattern(no-graph)');
         }
@@ -210,9 +246,10 @@ export class ChangelogStore implements TripleStore {
 
   async deleteBySubjectPrefix(graphUri: string, prefix: string, options?: QueryOptions): Promise<number> {
     if (!this.enabled) return this.inner.deleteBySubjectPrefix(graphUri, prefix, options);
+    this.assertNotReserved(graphUri, 'deleteBySubjectPrefix');
     return this.runExclusive(async () => {
       const removed = await this.inner.deleteBySubjectPrefix(graphUri, prefix, options);
-      if (removed > 0 && !this.reserved.has(graphUri)) {
+      if (removed > 0) {
         await this.markPostMutation([graphUri], options);
       }
       return removed;
@@ -221,11 +258,13 @@ export class ChangelogStore implements TripleStore {
 
   async dropGraph(graphUri: string, options?: QueryOptions): Promise<void> {
     if (!this.enabled) return this.inner.dropGraph(graphUri, options);
+    // Dropping the reserved plane through the public API would delete the log
+    // with no trace; only internal maintenance (chain-reset, which bypasses this
+    // decorator) may wipe it.
+    this.assertNotReserved(graphUri, 'dropGraph');
     await this.runExclusive(async () => {
       await this.inner.dropGraph(graphUri, options);
-      if (!this.reserved.has(graphUri)) {
-        await this.appendMarkers([{ graph: graphUri, op: 'drop' }], options);
-      }
+      await this.appendMarkers([{ graph: graphUri, op: 'drop' }], options);
     });
   }
 
@@ -241,11 +280,15 @@ export class ChangelogStore implements TripleStore {
       throw new Error('ChangelogStore: inner store does not support update()');
     }
     if (!this.enabled) return this.inner.update(sparql, options);
+    // Reject BEFORE the mutation runs so it never touches the reserved plane.
+    this.assertNoReservedRef(sparql, 'update');
     await this.runExclusive(async () => {
       await this.inner.update!(sparql, options);
       const hinted = (options?.touchedGraphs ?? []).filter((g) => !this.reserved.has(g));
       if (hinted.length > 0) {
-        await this.markPostMutation(hinted, options);
+        // Strip the update-only touchedGraphs hint before the read-path hasGraph
+        // probes — it is meaningless there and must not leak past this boundary.
+        await this.markPostMutation(hinted, queryOptionsFromUpdateOptions(options));
       } else {
         // Opaque server-side UPDATE (e.g. an RS heal INSERT…WHERE with no hint).
         this.flagReconcile('update(no-touchedGraphs)');
@@ -254,12 +297,13 @@ export class ChangelogStore implements TripleStore {
   }
 
   async query(sparql: string, options?: QueryOptions): Promise<QueryResult> {
-    const result = await this.inner.query(sparql, options);
     // A SPARQL UPDATE smuggled through query() is opaque to us — flag for
-    // reconcile rather than silently dropping its changes from the log.
-    if (this.enabled && isSparqlUpdate(sparql)) {
-      this.flagReconcile('query(update)');
-    }
+    // reconcile rather than silently dropping its changes from the log; and if it
+    // targets the reserved plane, reject it before it executes.
+    const isUpdate = this.enabled && isSparqlUpdateOperation(sparql);
+    if (isUpdate) this.assertNoReservedRef(sparql, 'query()-UPDATE');
+    const result = await this.inner.query(sparql, options);
+    if (isUpdate) this.flagReconcile('query(update)');
     return result;
   }
 
@@ -358,11 +402,26 @@ export class ChangelogStore implements TripleStore {
   }
 
   async flush(options?: QueryOptions): Promise<void> {
+    // Drain queued mutations (data + their markers) before flushing the inner
+    // store, so a durability flush cannot return while a write is still queued.
+    // Does NOT close the write gate — flush() is called periodically, not only
+    // at shutdown.
+    await this.drain();
     await this.inner.flush?.(options);
   }
 
   async close(): Promise<void> {
+    // Shut the gate first (reject new mutations), then drain the queue so a
+    // just-enqueued insert's data AND marker are durable before we close the
+    // inner store — otherwise close() could resolve with a write still pending.
+    this.closing = true;
+    await this.drain();
     await this.inner.close();
+  }
+
+  /** Await the current mutation-queue tail (all writes enqueued so far settle). */
+  private drain(): Promise<void> {
+    return this.tail.then(() => undefined, () => undefined);
   }
 
   // ------------------------------------------------------------------
@@ -371,6 +430,11 @@ export class ChangelogStore implements TripleStore {
 
   /** Serialize a mutation so no two writes interleave their seq allocation. */
   private runExclusive<T>(fn: () => Promise<T>): Promise<T> {
+    // Once close() has shut the gate, refuse new mutations rather than racing
+    // the inner store's close — anything already queued still drains.
+    if (this.closing) {
+      return Promise.reject(new Error('ChangelogStore: store is closing; write rejected'));
+    }
     const run = this.tail.then(() => fn(), () => fn());
     // Keep the chain alive regardless of this op's outcome.
     this.tail = run.then(() => undefined, () => undefined);
@@ -398,11 +462,15 @@ export class ChangelogStore implements TripleStore {
   private async markPostMutation(graphs: readonly string[], options?: QueryOptions): Promise<void> {
     const distinct = [...new Set(graphs.filter((g) => g && !this.reserved.has(g)))];
     if (distinct.length === 0) return;
-    const specs: Array<{ graph: string; op: ChangeOp }> = [];
-    for (const graph of distinct) {
-      const stillThere = await this.inner.hasGraph(graph, options);
-      specs.push({ graph, op: stillThere ? 'upsert' : 'drop' });
-    }
+    // The presence probes are independent — run them concurrently (matching
+    // GraphSetIndexStore) instead of serially inside the held write mutex, then
+    // append markers in the original deterministic (distinct) order.
+    const specs = await Promise.all(
+      distinct.map(async (graph): Promise<{ graph: string; op: ChangeOp }> => ({
+        graph,
+        op: (await this.inner.hasGraph(graph, options)) ? 'upsert' : 'drop',
+      })),
+    );
     await this.appendMarkers(specs, options);
   }
 
@@ -464,6 +532,57 @@ export class ChangelogStore implements TripleStore {
     }
     return [...set];
   }
+
+  /** Drop caller quads that target the reserved plane (marker forgery guard). */
+  private stripReserved(quads: readonly Quad[]): Quad[] {
+    return quads.filter((q) => !(q.graph && this.reserved.has(q.graph)));
+  }
+
+  /** Reject a graph-targeted mutation aimed at the reserved plane. Safe as a
+   *  hard error: reserved graphs are never enumerated (listGraphs filters,
+   *  hasGraph returns false), so no legitimate iterate-and-drop loop can reach
+   *  one — only a hardcoded reserved IRI does. */
+  private assertNotReserved(graphUri: string, op: string): void {
+    if (this.reserved.has(graphUri)) {
+      throw new Error(
+        `ChangelogStore: ${op}(<${graphUri}>) targets the reserved changelog plane, ` +
+          `which is not writable through the public store API.`,
+      );
+    }
+  }
+
+  /**
+   * Reject an opaque SPARQL UPDATE that references a reserved graph IRI. A
+   * best-effort guard against accidental mutation and the obvious hardcoded-IRI
+   * vector — NOT airtight against hostile opaque SPARQL (prefixed forms evade
+   * it). The structured paths (insert/delete/dropGraph) are the real guards; the
+   * reserved plane's integrity ultimately rests on it being reconcile-derived.
+   */
+  private assertNoReservedRef(sparql: string, op: string): void {
+    for (const g of this.reserved) {
+      if (sparql.includes(`<${g}>`)) {
+        throw new Error(
+          `ChangelogStore: ${op} references the reserved changelog graph <${g}>, ` +
+            `which is not writable through the public store API.`,
+        );
+      }
+    }
+  }
+
+  /** Reject a no-graph deleteByPattern whose subject/predicate is namespaced
+   *  under a reserved graph (marker terms like `urn:dkg:changelog#seq`) — that
+   *  would delete markers cross-graph. */
+  private assertNoReservedTerm(pattern: Partial<Quad>): void {
+    const terms = [pattern.subject, pattern.predicate];
+    for (const g of this.reserved) {
+      if (terms.some((t) => t != null && t.startsWith(g))) {
+        throw new Error(
+          `ChangelogStore: deleteByPattern by a term under the reserved graph <${g}> ` +
+            `would mutate the changelog plane, which is not writable through the public store API.`,
+        );
+      }
+    }
+  }
 }
 
 // ====================================================================
@@ -511,11 +630,37 @@ function stripLiteral(term: string | undefined): string {
   return m ? m[1] : term;
 }
 
-/** True if `sparql` is a SPARQL 1.1 UPDATE (mirrors GraphSetIndexStore). */
-function isSparqlUpdate(sparql: string): boolean {
-  const withoutPrologue = sparql
-    .trimStart()
-    .replace(/^(?:(?:#[^\r\n]*(?:\r?\n|$))|(?:PREFIX\s+(?:[A-Za-z][\w-]*)?:\s*<[^>]*>|BASE\s*<[^>]*>)\s*)+/i, '')
-    .trimStart();
-  return /^(?:INSERT|DELETE|WITH|LOAD|CLEAR|CREATE|DROP|COPY|MOVE|ADD)\b/i.test(withoutPrologue);
+/**
+ * Drop the update-only `touchedGraphs` hint, yielding the read-path
+ * `QueryOptions` (source/priority/signal) to forward to the post-mutation
+ * `hasGraph` probes. Intentionally duplicates GraphSetIndexStore's boundary
+ * helper of the same name — a trivial destructure kept local to avoid a
+ * decorator-to-decorator import.
+ */
+function queryOptionsFromUpdateOptions(options?: UpdateOptions): QueryOptions | undefined {
+  if (!options) return undefined;
+  const { touchedGraphs: _touchedGraphs, ...readOptions } = options;
+  return readOptions;
+}
+
+/**
+ * Recover the {@link ChangelogReader} capability from a store (typically a
+ * `createTripleStore(...)` result), or `null` when the changelog is not enabled.
+ * The intended consumer boundary: `asChangelogReader(store)?.readChanges(...)` —
+ * no `instanceof`/cast/decorator-order assumption at the call site.
+ */
+export function asChangelogReader(store: unknown): ChangelogReader | null {
+  if (store instanceof ChangelogStore) return store;
+  // Duck-type so a further wrapper that forwards the API still resolves.
+  const s = store as Partial<ChangelogReader> | null | undefined;
+  if (
+    s &&
+    typeof s.readChanges === 'function' &&
+    typeof s.headSeq === 'function' &&
+    typeof s.clearReconcileFlag === 'function' &&
+    typeof s.needsReconcile === 'boolean'
+  ) {
+    return s as ChangelogReader;
+  }
+  return null;
 }

--- a/packages/storage/src/changelog-store.ts
+++ b/packages/storage/src/changelog-store.ts
@@ -1,0 +1,481 @@
+import type {
+  Quad,
+  QueryOptions,
+  QueryResult,
+  TripleStore,
+  UpdateOptions,
+  StorePressureSnapshot,
+} from './triple-store.js';
+
+/**
+ * ChangelogStore — an append-only per-node change log maintained on the write
+ * path, the write-side half of OT-RFC-59 (O(delta) sync convergence).
+ *
+ * ## What it is
+ *
+ * A `TripleStore` decorator that, for every mutation flowing through it, appends
+ * a small **change marker** into a reserved named graph ({@link CHANGELOG_GRAPH})
+ * recording *(seq, graph, op)* — "at sequence N, this named graph was
+ * upserted / dropped". A sync responder can then answer *"what changed since
+ * seq N?"* by reading the log ({@link ChangelogStore.readChanges}) instead of
+ * enumerating and diffing the whole store (the O(store) scan that OOM-killed
+ * beacons on 2026-07-10). The marker lives **inside the RDF store's own commit
+ * domain**, so it travels with RocksDB backups, is wiped by `DROP ALL`, and is
+ * rebuildable — this is OT-RFC-59 **Option A** (store authoritative, log
+ * derived), not event-sourcing (Option B).
+ *
+ * ## Crash-consistency (the invariant that matters)
+ *
+ * OT-RFC-59 §6 / G3: *every committed store change is discoverable through the
+ * log* — no committed upsert is ever invisible. This holds because an **upsert
+ * marker is appended to the very same `insert(quads)` call as the data**
+ * (`inner.insert([...quads, ...markers])`). A single `insert()` is one backend
+ * transaction on every adapter — one Oxigraph in-memory apply flushed as a whole
+ * snapshot, one Blazegraph N-Quads POST, one `sparql-http` INSERT DATA — so the
+ * data and its marker commit or abort together. There is no window where the
+ * data is durable but the marker is lost.
+ *
+ * Drops/deletes are the opposite (benign) direction: a *lost* drop marker means
+ * a peer keeps stale data, healed by a later catalog reconcile, never silent
+ * data loss. Those markers are therefore written in a second step after the
+ * mutation (`op` derived from a `hasGraph` probe), which is acceptable per §6
+ * and avoids depending on multi-statement UPDATE atomicity.
+ *
+ * ## Single-writer sequence allocation (the load-bearing constraint)
+ *
+ * `seq` is a per-node monotonic counter. For a cursor to be gap-safe the log's
+ * **commit order must equal its seq order** — otherwise a requester that reads
+ * seq 11 (committed first) before seq 10 (allocated first, committed later)
+ * advances its cursor past 10 and never sees it. A shared read-modify-write
+ * counter does NOT prevent this reordering; only a single writer that allocates
+ * and commits *in one serialized step* does. This decorator enforces that with
+ * an in-process write mutex ({@link runExclusive}) and an in-memory counter
+ * seeded from `MAX(seq)` on first use — so within one process commit order is
+ * seq order by construction, and a crash simply loses the in-memory tail (the
+ * counter reseeds from the last durable marker on restart).
+ *
+ * **Scope boundary (PR1):** this guarantee holds for a *single writer process*.
+ * The second-process publisher CLI (`publisher-runner.ts`, its own
+ * `createTripleStore`) is a second writer and is therefore NOT yet covered —
+ * it must funnel writes through the daemon (single-writer invariant) or use
+ * per-writer subsequences before the changelog can be enabled fleet-wide. Until
+ * then callers wrap only the daemon's store and leave the flag default-off.
+ * See OT-RFC-59 §5.3.
+ */
+
+const XSD_INTEGER = 'http://www.w3.org/2001/XMLSchema#integer';
+
+/** Reserved named graph holding the append-only change markers. */
+export const CHANGELOG_GRAPH = 'urn:dkg:changelog';
+const NS = 'urn:dkg:changelog#';
+const P_SEQ = `${NS}seq`;
+const P_GRAPH = `${NS}graph`;
+const P_OP = `${NS}op`;
+const P_SCHEMA_VERSION = `${NS}schemaVersion`;
+const ENTRY_PREFIX = 'urn:dkg:changelog:e:';
+const META_SUBJECT = `${NS}self`;
+
+/** On-disk marker schema version, so a future shape change is detectable. */
+export const CHANGELOG_SCHEMA_VERSION = 1;
+
+export type ChangeOp = 'upsert' | 'drop';
+
+export interface ChangeRecord {
+  /** Per-node monotonic sequence. Strictly increasing in commit order. */
+  seq: number;
+  /** The named graph that changed. */
+  graph: string;
+  /** `upsert` = graph created or its content changed; `drop` = graph gone/emptied. */
+  op: ChangeOp;
+}
+
+export interface ChangelogStoreOptions {
+  enabled?: boolean;
+  /**
+   * Extra reserved graphs (besides {@link CHANGELOG_GRAPH}) to hide from
+   * `listGraphs()` and never emit markers for — e.g. a future in-store catalog
+   * graph. The changelog graph is always reserved.
+   */
+  reservedGraphs?: readonly string[];
+  /** Observability hook fired after each marker is durably appended. */
+  onAppend?: (record: ChangeRecord) => void;
+}
+
+/**
+ * Write-path append-only change log. See the class-level docstring for the
+ * crash-consistency and single-writer arguments.
+ */
+export class ChangelogStore implements TripleStore {
+  get queryCancellation() {
+    return this.inner.queryCancellation;
+  }
+
+  private readonly inner: TripleStore;
+  private readonly enabled: boolean;
+  private readonly reserved: ReadonlySet<string>;
+  private readonly onAppend?: (record: ChangeRecord) => void;
+
+  /** Last ALLOCATED seq (0 = none). Next seq is `seq + 1`. */
+  private seq = 0;
+  private seedPromise: Promise<void> | null = null;
+  /** Serializes mutations so commit order === seq order (single writer). */
+  private tail: Promise<unknown> = Promise.resolve();
+  /**
+   * Set when a mutation could not be attributed to specific graphs (an opaque
+   * `update()`/`query()` UPDATE with no `touchedGraphs` hint). Its changed
+   * graphs are missing from the log until a catalog reconcile (PR2) emits
+   * synthetic markers. Exposed via {@link needsReconcile} so the daemon can act.
+   */
+  private reconcilePending = false;
+
+  constructor(inner: TripleStore, options: ChangelogStoreOptions = {}) {
+    this.inner = inner;
+    this.enabled = options.enabled !== false;
+    const reserved = new Set<string>([CHANGELOG_GRAPH]);
+    for (const g of options.reservedGraphs ?? []) reserved.add(g);
+    this.reserved = reserved;
+    this.onAppend = options.onAppend;
+  }
+
+  // ------------------------------------------------------------------
+  // Mutations (marker-emitting)
+  // ------------------------------------------------------------------
+
+  async insert(quads: Quad[], options?: QueryOptions): Promise<void> {
+    if (!this.enabled) return this.inner.insert(quads, options);
+    const touched = this.attributableGraphs(quads);
+    if (touched.length === 0) {
+      // Nothing the log cares about (default graph, or only reserved graphs).
+      return this.inner.insert(quads, options);
+    }
+    await this.runExclusive(async () => {
+      await this.ensureSeeded();
+      let candidate = this.seq;
+      const markers: Quad[] = [];
+      const records: ChangeRecord[] = [];
+      for (const graph of touched) {
+        candidate += 1;
+        records.push({ seq: candidate, graph, op: 'upsert' });
+        markers.push(...markerQuads(candidate, graph, 'upsert'));
+      }
+      // Data + markers in ONE insert() → one backend transaction → atomic.
+      await this.inner.insert([...quads, ...markers], options);
+      this.seq = candidate; // advance only after durable success (gapless)
+      this.fire(records);
+    });
+  }
+
+  async delete(quads: Quad[], options?: QueryOptions): Promise<void> {
+    if (!this.enabled) return this.inner.delete(quads, options);
+    const touched = this.attributableGraphs(quads);
+    await this.runExclusive(async () => {
+      await this.inner.delete(quads, options);
+      await this.markPostMutation(touched, options);
+    });
+  }
+
+  async deleteByPattern(pattern: Partial<Quad>, options?: QueryOptions): Promise<number> {
+    if (!this.enabled) return this.inner.deleteByPattern(pattern, options);
+    return this.runExclusive(async () => {
+      const removed = await this.inner.deleteByPattern(pattern, options);
+      if (removed > 0) {
+        if (pattern.graph && !this.reserved.has(pattern.graph)) {
+          await this.markPostMutation([pattern.graph], options);
+        } else if (!pattern.graph) {
+          // No graph hint → cannot attribute which graphs shrank/emptied.
+          this.flagReconcile('deleteByPattern(no-graph)');
+        }
+      }
+      return removed;
+    });
+  }
+
+  async deleteBySubjectPrefix(graphUri: string, prefix: string, options?: QueryOptions): Promise<number> {
+    if (!this.enabled) return this.inner.deleteBySubjectPrefix(graphUri, prefix, options);
+    return this.runExclusive(async () => {
+      const removed = await this.inner.deleteBySubjectPrefix(graphUri, prefix, options);
+      if (removed > 0 && !this.reserved.has(graphUri)) {
+        await this.markPostMutation([graphUri], options);
+      }
+      return removed;
+    });
+  }
+
+  async dropGraph(graphUri: string, options?: QueryOptions): Promise<void> {
+    if (!this.enabled) return this.inner.dropGraph(graphUri, options);
+    await this.runExclusive(async () => {
+      await this.inner.dropGraph(graphUri, options);
+      if (!this.reserved.has(graphUri)) {
+        await this.appendMarkers([{ graph: graphUri, op: 'drop' }], options);
+      }
+    });
+  }
+
+  async createGraph(graphUri: string): Promise<void> {
+    // Empty graphs are not listed by this repo's `listGraphs` semantics and
+    // carry no data to converge, so no marker until the first insert. Matches
+    // GraphSetIndexStore.
+    await this.inner.createGraph(graphUri);
+  }
+
+  async update(sparql: string, options?: UpdateOptions): Promise<void> {
+    if (typeof this.inner.update !== 'function') {
+      throw new Error('ChangelogStore: inner store does not support update()');
+    }
+    if (!this.enabled) return this.inner.update(sparql, options);
+    await this.runExclusive(async () => {
+      await this.inner.update!(sparql, options);
+      const hinted = (options?.touchedGraphs ?? []).filter((g) => !this.reserved.has(g));
+      if (hinted.length > 0) {
+        await this.markPostMutation(hinted, options);
+      } else {
+        // Opaque server-side UPDATE (e.g. an RS heal INSERT…WHERE with no hint).
+        this.flagReconcile('update(no-touchedGraphs)');
+      }
+    });
+  }
+
+  async query(sparql: string, options?: QueryOptions): Promise<QueryResult> {
+    const result = await this.inner.query(sparql, options);
+    // A SPARQL UPDATE smuggled through query() is opaque to us — flag for
+    // reconcile rather than silently dropping its changes from the log.
+    if (this.enabled && isSparqlUpdate(sparql)) {
+      this.flagReconcile('query(update)');
+    }
+    return result;
+  }
+
+  // ------------------------------------------------------------------
+  // Reads (reserved-graph aware)
+  // ------------------------------------------------------------------
+
+  async hasGraph(graphUri: string, options?: QueryOptions): Promise<boolean> {
+    if (this.reserved.has(graphUri)) return false; // reserved plane is invisible upward
+    return this.inner.hasGraph(graphUri, options);
+  }
+
+  async listGraphs(options?: QueryOptions): Promise<string[]> {
+    const graphs = await this.inner.listGraphs(options);
+    return this.enabled ? graphs.filter((g) => !this.reserved.has(g)) : graphs;
+  }
+
+  async listGraphsByPrefix(prefix: string, options?: QueryOptions): Promise<string[]> {
+    const graphs = this.inner.listGraphsByPrefix
+      ? await this.inner.listGraphsByPrefix(prefix, options)
+      : (await this.inner.listGraphs(options)).filter((g) => g.startsWith(prefix));
+    return this.enabled ? graphs.filter((g) => !this.reserved.has(g)) : graphs;
+  }
+
+  async countQuads(graphUri?: string, options?: QueryOptions): Promise<number> {
+    return this.inner.countQuads(graphUri, options);
+  }
+
+  // ------------------------------------------------------------------
+  // Changelog read API (consumed by the sync responder — PR2)
+  // ------------------------------------------------------------------
+
+  /** Highest seq durably present in the log (0 if empty). */
+  async headSeq(options?: QueryOptions): Promise<number> {
+    const res = await this.inner.query(
+      `SELECT (MAX(?seq) AS ?m) WHERE { GRAPH <${CHANGELOG_GRAPH}> { ?e <${P_SEQ}> ?seq } }`,
+      { ...options, source: options?.source ?? 'changelog.headSeq' },
+    );
+    if (res.type !== 'bindings' || res.bindings.length === 0) return 0;
+    return parseIntTerm(res.bindings[0].m) ?? 0;
+  }
+
+  /**
+   * Change records with `seq > sinceSeq`, in ascending seq order, at most
+   * `limit`. This is the O(delta) read the whole RFC exists to enable. In PR1
+   * it is a range query over the (small) reserved changelog graph; PR2 serves
+   * it from an ordered SQLite projection for O(log L + delta).
+   */
+  async readChanges(sinceSeq: number, limit: number, options?: QueryOptions): Promise<ChangeRecord[]> {
+    const since = Number.isFinite(sinceSeq) ? Math.max(0, Math.floor(sinceSeq)) : 0;
+    const cap = Number.isFinite(limit) ? Math.max(1, Math.floor(limit)) : 1;
+    const res = await this.inner.query(
+      `SELECT ?seq ?graph ?op WHERE {
+  GRAPH <${CHANGELOG_GRAPH}> {
+    ?e <${P_SEQ}> ?seq ; <${P_GRAPH}> ?graph ; <${P_OP}> ?op .
+    FILTER(?seq > ${since})
+  }
+} ORDER BY ?seq LIMIT ${cap}`,
+      { ...options, source: options?.source ?? 'changelog.readChanges' },
+    );
+    if (res.type !== 'bindings') return [];
+    const out: ChangeRecord[] = [];
+    for (const b of res.bindings) {
+      const seq = parseIntTerm(b.seq);
+      const graph = stripIri(b.graph);
+      const op = stripLiteral(b.op);
+      if (seq == null || !graph || (op !== 'upsert' && op !== 'drop')) continue;
+      out.push({ seq, graph, op });
+    }
+    return out;
+  }
+
+  /** True when an opaque mutation left the log incomplete (reconcile owed). */
+  get needsReconcile(): boolean {
+    return this.reconcilePending;
+  }
+
+  /** Cleared by the reconcile pass (PR2) once it has emitted synthetic markers. */
+  clearReconcileFlag(): void {
+    this.reconcilePending = false;
+  }
+
+  // ------------------------------------------------------------------
+  // Lifecycle / passthrough
+  // ------------------------------------------------------------------
+
+  getPressureSnapshot(): StorePressureSnapshot | undefined {
+    return this.inner.getPressureSnapshot?.();
+  }
+
+  async flush(options?: QueryOptions): Promise<void> {
+    await this.inner.flush?.(options);
+  }
+
+  async close(): Promise<void> {
+    await this.inner.close();
+  }
+
+  // ------------------------------------------------------------------
+  // Internals
+  // ------------------------------------------------------------------
+
+  /** Serialize a mutation so no two writes interleave their seq allocation. */
+  private runExclusive<T>(fn: () => Promise<T>): Promise<T> {
+    const run = this.tail.then(() => fn(), () => fn());
+    // Keep the chain alive regardless of this op's outcome.
+    this.tail = run.then(() => undefined, () => undefined);
+    return run;
+  }
+
+  /** Seed the in-memory counter from the durable log's high-water mark, once. */
+  private ensureSeeded(): Promise<void> {
+    if (!this.seedPromise) {
+      this.seedPromise = this.headSeq({ source: 'changelog.seed' })
+        .then((head) => {
+          this.seq = head;
+        })
+        .catch((err) => {
+          // Reset so a transient store error retries seeding on the next write
+          // rather than latching seq=0 (which would collide with existing seqs).
+          this.seedPromise = null;
+          throw err;
+        });
+    }
+    return this.seedPromise;
+  }
+
+  /** Emit `upsert`/`drop` markers for graphs after a mutation, op by probe. */
+  private async markPostMutation(graphs: readonly string[], options?: QueryOptions): Promise<void> {
+    const distinct = [...new Set(graphs.filter((g) => g && !this.reserved.has(g)))];
+    if (distinct.length === 0) return;
+    const specs: Array<{ graph: string; op: ChangeOp }> = [];
+    for (const graph of distinct) {
+      const stillThere = await this.inner.hasGraph(graph, options);
+      specs.push({ graph, op: stillThere ? 'upsert' : 'drop' });
+    }
+    await this.appendMarkers(specs, options);
+  }
+
+  /** Allocate contiguous seqs and durably append markers (caller holds mutex). */
+  private async appendMarkers(
+    specs: ReadonlyArray<{ graph: string; op: ChangeOp }>,
+    options?: QueryOptions,
+  ): Promise<void> {
+    if (specs.length === 0) return;
+    await this.ensureSeeded();
+    let candidate = this.seq;
+    const quads: Quad[] = [];
+    const records: ChangeRecord[] = [];
+    for (const spec of specs) {
+      candidate += 1;
+      records.push({ seq: candidate, graph: spec.graph, op: spec.op });
+      quads.push(...markerQuads(candidate, spec.graph, spec.op));
+    }
+    await this.inner.insert(quads, options);
+    this.seq = candidate;
+    this.fire(records);
+  }
+
+  private fire(records: readonly ChangeRecord[]): void {
+    if (!this.onAppend) return;
+    for (const record of records) {
+      try {
+        this.onAppend(record);
+      } catch {
+        // Observability must never fail an already-committed write.
+      }
+    }
+  }
+
+  private flagReconcile(_reason: string): void {
+    this.reconcilePending = true;
+  }
+
+  /** Distinct named graphs from `quads`, excluding default and reserved graphs. */
+  private attributableGraphs(quads: readonly Quad[]): string[] {
+    const set = new Set<string>();
+    for (const q of quads) {
+      if (q.graph && !this.reserved.has(q.graph)) set.add(q.graph);
+    }
+    return [...set];
+  }
+}
+
+// ====================================================================
+// Marker (de)serialization helpers
+// ====================================================================
+
+function markerQuads(seq: number, graph: string, op: ChangeOp): Quad[] {
+  const entry = `${ENTRY_PREFIX}${seq}`;
+  return [
+    { subject: entry, predicate: P_SEQ, object: `"${seq}"^^<${XSD_INTEGER}>`, graph: CHANGELOG_GRAPH },
+    { subject: entry, predicate: P_GRAPH, object: graph, graph: CHANGELOG_GRAPH },
+    { subject: entry, predicate: P_OP, object: `"${op}"`, graph: CHANGELOG_GRAPH },
+  ];
+}
+
+/** The one-time schema marker; written lazily is unnecessary, exposed for setup/tests. */
+export function changelogSchemaQuad(): Quad {
+  return {
+    subject: META_SUBJECT,
+    predicate: P_SCHEMA_VERSION,
+    object: `"${CHANGELOG_SCHEMA_VERSION}"^^<${XSD_INTEGER}>`,
+    graph: CHANGELOG_GRAPH,
+  };
+}
+
+/** Extract an integer from a binding term (`"42"^^<…integer>`, `42`, or `"42"`). */
+function parseIntTerm(term: string | undefined): number | null {
+  if (term == null) return null;
+  const m = term.match(/-?\d+/);
+  if (!m) return null;
+  const n = Number.parseInt(m[0], 10);
+  return Number.isFinite(n) ? n : null;
+}
+
+/** Bare IRI from a binding term (strip surrounding angle brackets if present). */
+function stripIri(term: string | undefined): string {
+  if (!term) return '';
+  return term.startsWith('<') && term.endsWith('>') ? term.slice(1, -1) : term;
+}
+
+/** Lexical value from a literal binding term (`"upsert"` → `upsert`). */
+function stripLiteral(term: string | undefined): string {
+  if (!term) return '';
+  const m = term.match(/^"((?:[^"\\]|\\.)*)"/);
+  return m ? m[1] : term;
+}
+
+/** True if `sparql` is a SPARQL 1.1 UPDATE (mirrors GraphSetIndexStore). */
+function isSparqlUpdate(sparql: string): boolean {
+  const withoutPrologue = sparql
+    .trimStart()
+    .replace(/^(?:(?:#[^\r\n]*(?:\r?\n|$))|(?:PREFIX\s+(?:[A-Za-z][\w-]*)?:\s*<[^>]*>|BASE\s*<[^>]*>)\s*)+/i, '')
+    .trimStart();
+  return /^(?:INSERT|DELETE|WITH|LOAD|CLEAR|CREATE|DROP|COPY|MOVE|ADD)\b/i.test(withoutPrologue);
+}

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -40,6 +40,15 @@ export {
   type GraphSetMutationEvent,
   type GraphSetMutationSource,
 } from './graph-set-index-store.js';
+export {
+  CHANGELOG_GRAPH,
+  CHANGELOG_SCHEMA_VERSION,
+  ChangelogStore,
+  changelogSchemaQuad,
+  type ChangeOp,
+  type ChangeRecord,
+  type ChangelogStoreOptions,
+} from './changelog-store.js';
 
 export { OxigraphStore } from './adapters/oxigraph.js';
 export { OxigraphWorkerStore } from './adapters/oxigraph-worker.js';

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -45,8 +45,10 @@ export {
   CHANGELOG_SCHEMA_VERSION,
   ChangelogStore,
   changelogSchemaQuad,
+  asChangelogReader,
   type ChangeOp,
   type ChangeRecord,
+  type ChangelogReader,
   type ChangelogStoreOptions,
 } from './changelog-store.js';
 

--- a/packages/storage/src/triple-store.ts
+++ b/packages/storage/src/triple-store.ts
@@ -13,6 +13,10 @@ import {
   GraphSetIndexStore,
   type GraphSetIndexStoreOptions,
 } from './graph-set-index-store.js';
+import {
+  ChangelogStore,
+  type ChangelogStoreOptions,
+} from './changelog-store.js';
 
 export interface Quad {
   subject: string;
@@ -242,6 +246,14 @@ export interface TripleStoreConfig {
   options?: Record<string, unknown>;
   largeLiteralStorage?: LargeLiteralStorageConfig;
   graphSetIndex?: boolean | GraphSetIndexStoreOptions;
+  /**
+   * OT-RFC-59 append-only change log (write-side). **Default OFF** — opt-in per
+   * store, independent of backend (unlike `graphSetIndex`, which is gated to
+   * local Oxigraph): the changelog must work on Blazegraph too, and its cost is
+   * a few marker quads per write. Enable ONLY on a single-writer (daemon) store;
+   * see the {@link ChangelogStore} single-writer caveat.
+   */
+  changelog?: boolean | ChangelogStoreOptions;
 }
 
 type AdapterFactory = (
@@ -272,7 +284,19 @@ export async function createTripleStore(
   const withLargeLiteralStorage = largeLiteralStorage
     ? new SharedMemoryLiteralBlobStore(store, largeLiteralStorage)
     : store;
-  return wrapGraphSetIndex(withLargeLiteralStorage, config);
+  const withGraphSetIndex = wrapGraphSetIndex(withLargeLiteralStorage, config);
+  // Changelog is the OUTERMOST decorator: it observes logical mutations first,
+  // reuses the graph-set index's fast listGraphs() for reconcile, and hides its
+  // own reserved graph from everything above.
+  return wrapChangelog(withGraphSetIndex, config);
+}
+
+function wrapChangelog(store: TripleStore, config: TripleStoreConfig): TripleStore {
+  const changelog = config.changelog;
+  if (changelog == null || changelog === false) return store; // default OFF
+  if (typeof changelog === 'object' && changelog.enabled === false) return store;
+  const options = typeof changelog === 'object' ? changelog : undefined;
+  return new ChangelogStore(store, options);
 }
 
 function resolveAdapterOptions(config: TripleStoreConfig): Record<string, unknown> | undefined {

--- a/packages/storage/test/changelog-store.test.ts
+++ b/packages/storage/test/changelog-store.test.ts
@@ -296,3 +296,76 @@ describe('ChangelogStore — createTripleStore wiring', () => {
     await store.close();
   });
 });
+
+describe('ChangelogStore — reserved-graph mutation guard', () => {
+  it('does not emit a marker for mutations that TARGET the reserved changelog graph', async () => {
+    const base = new OxigraphStore();
+    const spy = new SpyStore(base);
+    const log = new ChangelogStore(spy);
+    await log.insert([q('http://ex.org/s1', G1)]); // 1 fused insert (data+marker)
+    const callsBefore = spy.insertCalls.length;
+    // A drop/delete aimed at the reserved graph must NOT append a self-referential
+    // marker (which would pollute the log and, in PR2, make the responder try to
+    // reconcile the log graph itself).
+    await log.dropGraph(CHANGELOG_GRAPH);
+    await log.deleteByPattern({ graph: CHANGELOG_GRAPH });
+    expect(spy.insertCalls.length).toBe(callsBefore); // no new marker write
+    // No record ever names the changelog graph as its changed graph.
+    await log.insert([q('http://ex.org/s2', G2)]);
+    const changes = await log.readChanges(0, 100);
+    expect(changes.every((c) => c.graph !== CHANGELOG_GRAPH)).toBe(true);
+    await base.close();
+  });
+});
+
+describe('ChangelogStore — delete-path op attribution & reconcile', () => {
+  let base: OxigraphStore;
+  let log: ChangelogStore;
+  beforeEach(() => { base = new OxigraphStore(); log = new ChangelogStore(base); });
+  afterEach(async () => { await base.close(); });
+
+  it('deleteBySubjectPrefix emits upsert when data remains, drop when it empties the graph', async () => {
+    await log.insert([
+      q('http://ex.org/a/1', G1), q('http://ex.org/a/2', G1), q('http://ex.org/b/1', G1),
+    ]);
+    // Remove the a/* subjects → b/1 remains → graph still there → upsert.
+    expect(await log.deleteBySubjectPrefix(G1, 'http://ex.org/a/')).toBeGreaterThan(0);
+    // Remove the last subject → graph empty → drop.
+    expect(await log.deleteBySubjectPrefix(G1, 'http://ex.org/b/')).toBeGreaterThan(0);
+    expect((await log.readChanges(0, 100)).map((c) => c.op)).toEqual(['upsert', 'upsert', 'drop']);
+  });
+
+  it('deleteByPattern with NO graph hint flags reconcile when it removes quads', async () => {
+    await log.insert([q('http://ex.org/s1', G1)]);
+    expect(log.needsReconcile).toBe(false);
+    const removed = await log.deleteByPattern({ predicate: 'http://ex.org/p' }); // no graph
+    expect(removed).toBeGreaterThan(0);
+    // Cannot attribute which graphs shrank/emptied → reconcile owed.
+    expect(log.needsReconcile).toBe(true);
+  });
+});
+
+describe('ChangelogStore — reserved-graph hiding (prefix) & post-mutation failure', () => {
+  it('hides the reserved changelog graph from listGraphsByPrefix (even a matching prefix)', async () => {
+    const base = new OxigraphStore();
+    const log = new ChangelogStore(base);
+    await log.insert([q('http://ex.org/s1', G1)]);
+    // 'urn:' and the exact IRI both match CHANGELOG_GRAPH in the inner store, but
+    // the decorator must filter it out of prefix enumeration too.
+    expect(await log.listGraphsByPrefix('urn:')).not.toContain(CHANGELOG_GRAPH);
+    expect(await log.listGraphsByPrefix('urn:dkg:changelog')).not.toContain(CHANGELOG_GRAPH);
+    await base.close();
+  });
+
+  it('flags reconcile when a post-mutation (drop) marker write fails after the mutation committed', async () => {
+    const base = new OxigraphStore();
+    const spy = new SpyStore(base);
+    const log = new ChangelogStore(spy);
+    await log.insert([q('http://ex.org/s1', G1)]); // seq 1 (fused, succeeds)
+    spy.failNextInsert = true;                     // the drop's marker insert will throw
+    await expect(log.dropGraph(G1)).rejects.toThrow(/injected/);
+    // The graph is durably dropped but its marker was lost → gap recorded.
+    expect(log.needsReconcile).toBe(true);
+    await base.close();
+  });
+});

--- a/packages/storage/test/changelog-store.test.ts
+++ b/packages/storage/test/changelog-store.test.ts
@@ -1,0 +1,298 @@
+/**
+ * OT-RFC-59 write-side (ChangelogStore) tests.
+ *
+ * The load-bearing properties, and why each matters:
+ *  - Upsert markers ride the SAME inner.insert() call as the data → one backend
+ *    transaction → the fatal "committed data invisible to the log" case is
+ *    impossible. Proven structurally (SpyStore counts insert calls) so it holds
+ *    for EVERY adapter: a single insert() is one txn on Oxigraph (in-memory
+ *    apply + whole-snapshot flush), Blazegraph (one N-Quads POST) and sparql-http
+ *    (one INSERT DATA) alike.
+ *  - seq is monotonic AND contiguous even under concurrent writes → commit order
+ *    equals seq order, so a cursor can never skip a change (the multi-writer
+ *    reordering hole). Enforced by the in-process write mutex.
+ *  - seq reseeds from the durable high-water mark on restart → no reuse/rollback.
+ */
+import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { createServer, type Server } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { OxigraphStore } from '../src/adapters/oxigraph.js';
+import { BlazegraphStore } from '../src/adapters/blazegraph.js';
+import { ChangelogStore, CHANGELOG_GRAPH } from '../src/changelog-store.js';
+import { createTripleStore } from '../src/triple-store.js';
+import type { Quad, QueryOptions, QueryResult, TripleStore, UpdateOptions } from '../src/triple-store.js';
+
+const G1 = 'http://ex.org/g1';
+const G2 = 'http://ex.org/g2';
+const G3 = 'http://ex.org/g3';
+
+function q(subject: string, graph: string, object = '"x"'): Quad {
+  return { subject, predicate: 'http://ex.org/p', object, graph };
+}
+
+/** Delegating TripleStore that records insert() call shapes and can inject failures. */
+class SpyStore implements TripleStore {
+  readonly insertCalls: Quad[][] = [];
+  failNextInsert = false;
+  constructor(private readonly inner: TripleStore) {}
+  async insert(quads: Quad[], options?: QueryOptions): Promise<void> {
+    this.insertCalls.push(quads.map((x) => ({ ...x })));
+    if (this.failNextInsert) {
+      this.failNextInsert = false;
+      throw new Error('injected insert failure');
+    }
+    return this.inner.insert(quads, options);
+  }
+  delete(quads: Quad[], options?: QueryOptions) { return this.inner.delete(quads, options); }
+  deleteByPattern(pattern: Partial<Quad>, options?: QueryOptions) { return this.inner.deleteByPattern(pattern, options); }
+  deleteBySubjectPrefix(g: string, p: string, options?: QueryOptions) { return this.inner.deleteBySubjectPrefix(g, p, options); }
+  query(sparql: string, options?: QueryOptions): Promise<QueryResult> { return this.inner.query(sparql, options); }
+  hasGraph(g: string, options?: QueryOptions) { return this.inner.hasGraph(g, options); }
+  createGraph(g: string) { return this.inner.createGraph(g); }
+  dropGraph(g: string, options?: QueryOptions) { return this.inner.dropGraph(g, options); }
+  listGraphs(options?: QueryOptions) { return this.inner.listGraphs(options); }
+  update(sparql: string, options?: UpdateOptions) { return this.inner.update!(sparql, options); }
+  countQuads(g?: string, options?: QueryOptions) { return this.inner.countQuads(g, options); }
+  close() { return this.inner.close(); }
+}
+
+describe('ChangelogStore — upsert marker atomicity', () => {
+  it('appends the marker in the SAME inner.insert() call as the data (one transaction)', async () => {
+    const base = new OxigraphStore();
+    const spy = new SpyStore(base);
+    const log = new ChangelogStore(spy);
+
+    await log.insert([q('http://ex.org/s1', G1)]);
+
+    // Exactly one inner insert() — data + marker together, never two calls.
+    expect(spy.insertCalls).toHaveLength(1);
+    const call = spy.insertCalls[0];
+    const dataQuads = call.filter((x) => x.graph === G1);
+    const markerQuads = call.filter((x) => x.graph === CHANGELOG_GRAPH);
+    expect(dataQuads).toHaveLength(1);
+    expect(markerQuads.length).toBeGreaterThanOrEqual(1);
+    await base.close();
+  });
+
+  it('a failed insert does NOT advance seq (gapless): the next write reuses it', async () => {
+    const base = new OxigraphStore();
+    const spy = new SpyStore(base);
+    const log = new ChangelogStore(spy);
+
+    spy.failNextInsert = true;
+    await expect(log.insert([q('http://ex.org/s1', G1)])).rejects.toThrow(/injected/);
+
+    // Recover: the next successful write must be seq 1, not seq 2.
+    await log.insert([q('http://ex.org/s2', G1)]);
+    const changes = await log.readChanges(0, 100);
+    expect(changes.map((c) => c.seq)).toEqual([1]);
+    await base.close();
+  });
+});
+
+describe('ChangelogStore — sequence semantics', () => {
+  let base: OxigraphStore;
+  let log: ChangelogStore;
+  beforeEach(() => { base = new OxigraphStore(); log = new ChangelogStore(base); });
+  afterEach(async () => { await base.close(); });
+
+  it('assigns monotonic contiguous seqs across successive writes', async () => {
+    await log.insert([q('http://ex.org/a', G1)]);
+    await log.insert([q('http://ex.org/b', G2)]);
+    const changes = await log.readChanges(0, 100);
+    expect(changes).toEqual([
+      { seq: 1, graph: G1, op: 'upsert' },
+      { seq: 2, graph: G2, op: 'upsert' },
+    ]);
+  });
+
+  it('allocates one contiguous seq per distinct graph within a single insert', async () => {
+    await log.insert([q('http://ex.org/a', G1), q('http://ex.org/b', G2), q('http://ex.org/c', G1)]);
+    const changes = await log.readChanges(0, 100);
+    expect(changes.map((c) => c.seq)).toEqual([1, 2]);
+    expect(new Set(changes.map((c) => c.graph))).toEqual(new Set([G1, G2]));
+  });
+
+  it('readChanges honours sinceSeq and limit and returns ascending order', async () => {
+    for (const g of [G1, G2, G3]) await log.insert([q(`http://ex.org/${g}`, g)]);
+    const tail = await log.readChanges(1, 100);
+    expect(tail.map((c) => c.seq)).toEqual([2, 3]);
+    const capped = await log.readChanges(0, 2);
+    expect(capped.map((c) => c.seq)).toEqual([1, 2]);
+    expect(await log.headSeq()).toBe(3);
+  });
+
+  it('serializes concurrent writes into contiguous non-overlapping seqs (single-writer)', async () => {
+    const graphs = Array.from({ length: 12 }, (_, i) => `http://ex.org/c${i}`);
+    // Fire all writes concurrently — the mutex must still yield 1..12 with no
+    // gaps, no duplicates, one marker per graph (commit order === seq order).
+    await Promise.all(graphs.map((g) => log.insert([q(`${g}/s`, g)])));
+    const changes = await log.readChanges(0, 100);
+    expect(changes.map((c) => c.seq).sort((a, b) => a - b)).toEqual(
+      Array.from({ length: 12 }, (_, i) => i + 1),
+    );
+    expect(new Set(changes.map((c) => c.graph)).size).toBe(12);
+  });
+});
+
+describe('ChangelogStore — drop / delete op attribution', () => {
+  let base: OxigraphStore;
+  let log: ChangelogStore;
+  beforeEach(() => { base = new OxigraphStore(); log = new ChangelogStore(base); });
+  afterEach(async () => { await base.close(); });
+
+  it('dropGraph emits a drop marker', async () => {
+    await log.insert([q('http://ex.org/a', G1)]);
+    await log.dropGraph(G1);
+    const changes = await log.readChanges(0, 100);
+    expect(changes).toEqual([
+      { seq: 1, graph: G1, op: 'upsert' },
+      { seq: 2, graph: G1, op: 'drop' },
+    ]);
+  });
+
+  it('a delete that empties a graph emits drop; one that leaves data emits upsert', async () => {
+    await log.insert([q('http://ex.org/a', G1), q('http://ex.org/b', G1)]);
+    // Remove one of two → graph still exists → upsert.
+    await log.delete([q('http://ex.org/a', G1)]);
+    // Remove the last → graph gone → drop.
+    await log.delete([q('http://ex.org/b', G1)]);
+    const ops = (await log.readChanges(0, 100)).map((c) => c.op);
+    expect(ops).toEqual(['upsert', 'upsert', 'drop']);
+  });
+});
+
+describe('ChangelogStore — restart reseed & reserved-graph hiding', () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'changelog-')); });
+  afterEach(() => { try { rmSync(dir, { recursive: true, force: true }); } catch { /* */ } });
+
+  it('markers are durable and seq reseeds from the high-water mark after reopen', async () => {
+    const path = join(dir, 'store.nq');
+    const first = new OxigraphStore(path);
+    const log1 = new ChangelogStore(first);
+    await log1.insert([q('http://ex.org/a', G1)]);
+    await log1.insert([q('http://ex.org/b', G2)]);
+    await first.flush();
+    await first.close();
+
+    // Reopen: a brand-new ChangelogStore over the hydrated store must continue
+    // at seq 3, not restart at 1 (which would collide with durable markers).
+    const second = new OxigraphStore(path);
+    const log2 = new ChangelogStore(second);
+    expect(await log2.headSeq()).toBe(2);
+    await log2.insert([q('http://ex.org/c', G3)]);
+    const changes = await log2.readChanges(0, 100);
+    expect(changes.map((c) => c.seq)).toEqual([1, 2, 3]);
+    expect(changes[2]).toEqual({ seq: 3, graph: G3, op: 'upsert' });
+    await second.close();
+  });
+
+  it('hides the reserved changelog graph from listGraphs', async () => {
+    const base = new OxigraphStore();
+    const log = new ChangelogStore(base);
+    await log.insert([q('http://ex.org/a', G1)]);
+    const graphs = await log.listGraphs();
+    expect(graphs).toContain(G1);
+    expect(graphs).not.toContain(CHANGELOG_GRAPH);
+    // hasGraph on the reserved plane reads as invisible upward.
+    expect(await log.hasGraph(CHANGELOG_GRAPH)).toBe(false);
+    await base.close();
+  });
+});
+
+describe('ChangelogStore — opaque update handling', () => {
+  it('an update() with touchedGraphs emits markers; without, it flags reconcile', async () => {
+    const base = new OxigraphStore();
+    const log = new ChangelogStore(base);
+    await log.insert([q('http://ex.org/a', G1)]);
+
+    // Hinted update → attributable → marker emitted for G2.
+    await base.insert([q('http://ex.org/seed', G2)]); // pre-create so hasGraph is true
+    await log.update(
+      `INSERT DATA { GRAPH <${G2}> { <http://ex.org/x> <http://ex.org/p> "y" } }`,
+      { touchedGraphs: [G2] },
+    );
+    expect(log.needsReconcile).toBe(false);
+    const g2 = (await log.readChanges(0, 100)).filter((c) => c.graph === G2);
+    expect(g2.length).toBeGreaterThanOrEqual(1);
+
+    // Opaque update (no hint) → reconcile owed.
+    await log.update(`INSERT DATA { GRAPH <${G3}> { <http://ex.org/z> <http://ex.org/p> "w" } }`);
+    expect(log.needsReconcile).toBe(true);
+    await base.close();
+  });
+});
+
+describe('ChangelogStore over Blazegraph — single-request atomicity', () => {
+  let server: Server;
+  let url: string;
+  const insertBodies: string[] = [];
+
+  beforeAll(async () => {
+    await new Promise<void>((resolve) => {
+      server = createServer((req, res) => {
+        let body = '';
+        req.on('data', (c) => { body += c; });
+        req.on('end', () => {
+          const ct = String(req.headers['content-type'] ?? '');
+          if (ct.includes('application/sparql-query')) {
+            // headSeq/seed MAX(?seq) → empty result (log starts at 0).
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ head: { vars: ['m'] }, results: { bindings: [] } }));
+            return;
+          }
+          // n-quads insert (text/x-nquads) — capture the body.
+          insertBodies.push(body);
+          res.writeHead(200);
+          res.end();
+        });
+      });
+      server.listen(0, '127.0.0.1', () => {
+        url = `http://127.0.0.1:${(server.address() as { port: number }).port}/sparql`;
+        resolve();
+      });
+    });
+  });
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) => server.close((e) => (e ? reject(e) : resolve())));
+  });
+
+  it('the data quad and its marker land in ONE n-quads POST', async () => {
+    insertBodies.length = 0;
+    const log = new ChangelogStore(new BlazegraphStore(url));
+    await log.insert([q('http://ex.org/s1', G1)]);
+
+    // Exactly one write request, carrying both the data triple and the marker.
+    expect(insertBodies).toHaveLength(1);
+    const body = insertBodies[0];
+    expect(body).toContain(G1);                 // data graph
+    expect(body).toContain(CHANGELOG_GRAPH);    // marker graph, same POST
+    expect(body).toContain('urn:dkg:changelog#seq');
+  });
+});
+
+describe('ChangelogStore — createTripleStore wiring', () => {
+  it('is OFF by default (no marker graph appears)', async () => {
+    const store = await createTripleStore({ backend: 'oxigraph' });
+    await store.insert([q('http://ex.org/a', G1)]);
+    const graphs = await store.listGraphs();
+    expect(graphs).not.toContain(CHANGELOG_GRAPH);
+    await store.close();
+  });
+
+  it('wraps when changelog:true, independent of backend gating', async () => {
+    const store = await createTripleStore({ backend: 'oxigraph', changelog: true });
+    await store.insert([q('http://ex.org/a', G1)]);
+    // The reserved graph is written but hidden; markers are queryable via a raw query.
+    const res = await store.query(
+      `SELECT (COUNT(*) AS ?c) WHERE { GRAPH <${CHANGELOG_GRAPH}> { ?s ?p ?o } }`,
+    );
+    const count = res.type === 'bindings' ? Number(res.bindings[0].c.match(/\d+/)?.[0] ?? '0') : 0;
+    expect(count).toBeGreaterThan(0);
+    expect(await store.listGraphs()).not.toContain(CHANGELOG_GRAPH);
+    await store.close();
+  });
+});

--- a/packages/storage/test/changelog-store.test.ts
+++ b/packages/storage/test/changelog-store.test.ts
@@ -20,7 +20,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { OxigraphStore } from '../src/adapters/oxigraph.js';
 import { BlazegraphStore } from '../src/adapters/blazegraph.js';
-import { ChangelogStore, CHANGELOG_GRAPH } from '../src/changelog-store.js';
+import { ChangelogStore, CHANGELOG_GRAPH, asChangelogReader } from '../src/changelog-store.js';
 import { createTripleStore } from '../src/triple-store.js';
 import type { Quad, QueryOptions, QueryResult, TripleStore, UpdateOptions } from '../src/triple-store.js';
 
@@ -224,6 +224,27 @@ describe('ChangelogStore — opaque update handling', () => {
     expect(log.needsReconcile).toBe(true);
     await base.close();
   });
+
+  it('a SPARQL UPDATE smuggled through query() (even behind a comment) flags reconcile', async () => {
+    // Some HTTP backends execute UPDATEs sent to the query endpoint; the changelog
+    // cannot observe those, so it must flag reconcile. (Oxigraph's query() rejects
+    // updates outright, so this uses an inner whose query() runs them.)
+    const base = new OxigraphStore();
+    const executed: string[] = [];
+    const inner = new (class extends SpyStore {
+      async query(sparql: string): Promise<QueryResult> {
+        executed.push(sparql);
+        return { type: 'bindings', bindings: [] };
+      }
+    })(base);
+    const log = new ChangelogStore(inner);
+    expect(log.needsReconcile).toBe(false);
+    // Leading comment exercises the canonical prologue-aware classifier.
+    await log.query(`# housekeeping\nINSERT DATA { GRAPH <${G1}> { <http://ex.org/s> <http://ex.org/p> "v" } }`);
+    expect(log.needsReconcile).toBe(true); // update detected behind the comment
+    expect(executed).toHaveLength(1);      // and the inner query ran
+    await base.close();
+  });
 });
 
 describe('ChangelogStore over Blazegraph — single-request atomicity', () => {
@@ -297,24 +318,87 @@ describe('ChangelogStore — createTripleStore wiring', () => {
   });
 });
 
-describe('ChangelogStore — reserved-graph mutation guard', () => {
-  it('does not emit a marker for mutations that TARGET the reserved changelog graph', async () => {
+describe('ChangelogStore — reserved-graph write protection', () => {
+  it('rejects graph-targeted mutations against the reserved changelog plane', async () => {
     const base = new OxigraphStore();
     const spy = new SpyStore(base);
     const log = new ChangelogStore(spy);
     await log.insert([q('http://ex.org/s1', G1)]); // 1 fused insert (data+marker)
     const callsBefore = spy.insertCalls.length;
-    // A drop/delete aimed at the reserved graph must NOT append a self-referential
-    // marker (which would pollute the log and, in PR2, make the responder try to
-    // reconcile the log graph itself).
-    await log.dropGraph(CHANGELOG_GRAPH);
-    await log.deleteByPattern({ graph: CHANGELOG_GRAPH });
-    expect(spy.insertCalls.length).toBe(callsBefore); // no new marker write
-    // No record ever names the changelog graph as its changed graph.
-    await log.insert([q('http://ex.org/s2', G2)]);
+    // The reserved plane is not writable through the public API — a drop/delete
+    // aimed at it would erase or corrupt the log, so it is rejected outright.
+    await expect(log.dropGraph(CHANGELOG_GRAPH)).rejects.toThrow(/reserved/i);
+    await expect(log.deleteByPattern({ graph: CHANGELOG_GRAPH })).rejects.toThrow(/reserved/i);
+    await expect(log.deleteBySubjectPrefix(CHANGELOG_GRAPH, 'x')).rejects.toThrow(/reserved/i);
+    expect(spy.insertCalls.length).toBe(callsBefore); // nothing reached the store
+    await base.close();
+  });
+
+  it('strips forged marker quads from insert() — the high-water mark cannot be jumped', async () => {
+    const base = new OxigraphStore();
+    const log = new ChangelogStore(base);
+    await log.insert([q('http://ex.org/a', G1)]); // seq 1
+    // Forge a marker with a huge seq alongside real data in ONE insert.
+    await log.insert([
+      q('http://ex.org/b', G2),
+      {
+        subject: 'urn:dkg:changelog:e:999999',
+        predicate: 'urn:dkg:changelog#seq',
+        object: '"999999"^^<http://www.w3.org/2001/XMLSchema#integer>',
+        graph: CHANGELOG_GRAPH,
+      },
+    ]);
+    // The real data landed (G2 → seq 2); the forged marker never reached the store.
+    expect(await log.headSeq()).toBe(2);
     const changes = await log.readChanges(0, 100);
+    expect(changes.map((c) => c.seq)).toEqual([1, 2]);
     expect(changes.every((c) => c.graph !== CHANGELOG_GRAPH)).toBe(true);
     await base.close();
+  });
+
+  it('rejects a no-graph deleteByPattern that targets marker terms (cross-graph log erasure)', async () => {
+    const base = new OxigraphStore();
+    const log = new ChangelogStore(base);
+    await log.insert([q('http://ex.org/a', G1)]); // seq 1
+    await expect(log.deleteByPattern({ predicate: 'urn:dkg:changelog#seq' })).rejects.toThrow(/reserved/i);
+    await expect(log.deleteByPattern({ subject: 'urn:dkg:changelog:e:1' })).rejects.toThrow(/reserved/i);
+    expect(await log.headSeq()).toBe(1); // log intact
+    await base.close();
+  });
+
+  it('rejects a SPARQL update()/query()-UPDATE that references the reserved plane, but allows reads', async () => {
+    const base = new OxigraphStore();
+    const log = new ChangelogStore(base);
+    await expect(
+      log.update(`INSERT DATA { GRAPH <${CHANGELOG_GRAPH}> { <urn:x> <urn:p> "9" } }`),
+    ).rejects.toThrow(/reserved/i);
+    await expect(
+      log.query(`INSERT DATA { GRAPH <${CHANGELOG_GRAPH}> { <urn:x> <urn:p> "9" } }`),
+    ).rejects.toThrow(/reserved/i);
+    // A READ referencing the reserved graph is NOT a mutation → allowed.
+    const res = await log.query(
+      `SELECT (COUNT(*) AS ?c) WHERE { GRAPH <${CHANGELOG_GRAPH}> { ?s ?p ?o } }`,
+    );
+    expect(res.type).toBe('bindings');
+    await base.close();
+  });
+});
+
+describe('ChangelogStore — capability boundary (asChangelogReader)', () => {
+  it('recovers the changelog reader from a createTripleStore result without a cast', async () => {
+    const store = await createTripleStore({ backend: 'oxigraph', changelog: true });
+    const reader = asChangelogReader(store);
+    expect(reader).not.toBeNull();
+    await store.insert([q('http://ex.org/a', G1)]);
+    expect(await reader!.headSeq()).toBe(1);
+    expect((await reader!.readChanges(0, 100)).map((c) => c.graph)).toContain(G1);
+    await store.close();
+  });
+
+  it('returns null when the changelog is not enabled', async () => {
+    const store = await createTripleStore({ backend: 'oxigraph' });
+    expect(asChangelogReader(store)).toBeNull();
+    await store.close();
   });
 });
 
@@ -343,6 +427,16 @@ describe('ChangelogStore — delete-path op attribution & reconcile', () => {
     // Cannot attribute which graphs shrank/emptied → reconcile owed.
     expect(log.needsReconcile).toBe(true);
   });
+
+  it('deleteByPattern WITH a graph hint emits a marker: upsert when data remains, drop when it empties', async () => {
+    await log.insert([q('http://ex.org/a', G1), q('http://ex.org/b', G1)]); // seq 1
+    // Remove one subject → G1 still has data → upsert.
+    expect(await log.deleteByPattern({ subject: 'http://ex.org/a', graph: G1 })).toBeGreaterThan(0);
+    // Remove the last subject → G1 empty → drop.
+    expect(await log.deleteByPattern({ subject: 'http://ex.org/b', graph: G1 })).toBeGreaterThan(0);
+    expect((await log.readChanges(0, 100)).map((c) => c.op)).toEqual(['upsert', 'upsert', 'drop']);
+    expect(log.needsReconcile).toBe(false); // graph-hinted path is fully attributed
+  });
 });
 
 describe('ChangelogStore — reserved-graph hiding (prefix) & post-mutation failure', () => {
@@ -366,6 +460,106 @@ describe('ChangelogStore — reserved-graph hiding (prefix) & post-mutation fail
     await expect(log.dropGraph(G1)).rejects.toThrow(/injected/);
     // The graph is durably dropped but its marker was lost → gap recorded.
     expect(log.needsReconcile).toBe(true);
+    await base.close();
+  });
+});
+
+/** Inner store whose insert() can be held mid-flight to prove close()/flush() drain. */
+class GatedStore implements TripleStore {
+  readonly insertCalls: Quad[][] = [];
+  flushed = false;
+  closed = false;
+  private gate: Promise<void> | null = null;
+  private release: (() => void) | null = null;
+  constructor(private readonly inner: TripleStore) {}
+  block() { this.gate = new Promise<void>((r) => { this.release = r; }); }
+  unblock() { this.release?.(); this.gate = null; this.release = null; }
+  async insert(quads: Quad[], options?: QueryOptions): Promise<void> {
+    if (this.gate) await this.gate;
+    this.insertCalls.push(quads.map((x) => ({ ...x })));
+    return this.inner.insert(quads, options);
+  }
+  delete(quads: Quad[], options?: QueryOptions) { return this.inner.delete(quads, options); }
+  deleteByPattern(p: Partial<Quad>, options?: QueryOptions) { return this.inner.deleteByPattern(p, options); }
+  deleteBySubjectPrefix(g: string, p: string, options?: QueryOptions) { return this.inner.deleteBySubjectPrefix(g, p, options); }
+  query(sparql: string, options?: QueryOptions): Promise<QueryResult> { return this.inner.query(sparql, options); }
+  hasGraph(g: string, options?: QueryOptions) { return this.inner.hasGraph(g, options); }
+  createGraph(g: string) { return this.inner.createGraph(g); }
+  dropGraph(g: string, options?: QueryOptions) { return this.inner.dropGraph(g, options); }
+  listGraphs(options?: QueryOptions) { return this.inner.listGraphs(options); }
+  update(sparql: string, options?: UpdateOptions) { return this.inner.update!(sparql, options); }
+  countQuads(g?: string, options?: QueryOptions) { return this.inner.countQuads(g, options); }
+  async flush(options?: QueryOptions) { this.flushed = true; return this.inner.flush?.(options); }
+  async close() { this.closed = true; return this.inner.close(); }
+}
+
+const tick = (ms = 20) => new Promise<void>((r) => setTimeout(r, ms));
+
+describe('ChangelogStore — lifecycle drains the write queue', () => {
+  it('close() does not resolve until a queued insert has appended data + marker', async () => {
+    const base = new OxigraphStore();
+    const gated = new GatedStore(base);
+    const log = new ChangelogStore(gated);
+
+    gated.block();
+    const insertP = log.insert([q('http://ex.org/s1', G1)]); // enqueued, hangs in inner.insert
+    let closed = false;
+    const closeP = log.close().then(() => { closed = true; });
+
+    await tick();
+    expect(closed, 'close() must not resolve while a write is queued').toBe(false);
+    expect(gated.closed, 'inner store must not be closed before the queue drains').toBe(false);
+
+    gated.unblock();
+    await Promise.all([insertP, closeP]);
+
+    expect(closed).toBe(true);
+    expect(gated.closed).toBe(true);
+    // The drained insert carried BOTH the data and its marker (one txn).
+    const fused = gated.insertCalls.at(-1)!;
+    expect(fused.some((x) => x.graph === G1)).toBe(true);
+    expect(fused.some((x) => x.graph === CHANGELOG_GRAPH)).toBe(true);
+  });
+
+  it('rejects new writes once close() has started, but still drains the in-flight one', async () => {
+    const base = new OxigraphStore();
+    const gated = new GatedStore(base);
+    const log = new ChangelogStore(gated);
+
+    gated.block();
+    const inFlight = log.insert([q('http://ex.org/a', G1)]);
+    const closeP = log.close();
+    await tick();
+    // A write attempted after the gate is shut is refused, not silently queued.
+    await expect(log.insert([q('http://ex.org/b', G2)])).rejects.toThrow(/closing/i);
+
+    gated.unblock();
+    await Promise.all([inFlight, closeP]);
+    // Only the in-flight insert drained; the rejected one never reached the store.
+    expect(gated.insertCalls.some((c) => c.some((x) => x.graph === G1))).toBe(true);
+    expect(gated.insertCalls.some((c) => c.some((x) => x.graph === G2))).toBe(false);
+  });
+
+  it('flush() persists queued mutations before returning (and does NOT shut the gate)', async () => {
+    const base = new OxigraphStore();
+    const gated = new GatedStore(base);
+    const log = new ChangelogStore(gated);
+
+    gated.block();
+    const insertP = log.insert([q('http://ex.org/s1', G1)]);
+    let flushed = false;
+    const flushP = log.flush().then(() => { flushed = true; });
+
+    await tick();
+    expect(flushed, 'flush() must wait for the queued write').toBe(false);
+
+    gated.unblock();
+    await Promise.all([insertP, flushP]);
+    expect(flushed).toBe(true);
+    expect(gated.flushed).toBe(true);
+    // flush() did not latch closing: further writes still succeed.
+    await log.insert([q('http://ex.org/s2', G2)]);
+    expect((await log.readChanges(0, 100)).map((c) => c.graph)).toEqual([G1, G2]);
     await base.close();
   });
 });

--- a/packages/storage/test/changelog.integration.test.ts
+++ b/packages/storage/test/changelog.integration.test.ts
@@ -1,0 +1,93 @@
+/**
+ * ChangelogStore INTEGRATION tests — run against a REAL Blazegraph server.
+ *
+ * The unit suite (`changelog-store.test.ts`) proves the decorator's logic on
+ * embedded Oxigraph and proves the blazegraph WRITE shape (marker rides one
+ * POST) with a mock. It does NOT exercise the blazegraph READ path, which is
+ * the one thing OT-RFC-59's "must work on blazegraph too" actually turns on:
+ *   - headSeq()  → SELECT (MAX(?seq) …) over "n"^^xsd:integer markers
+ *   - readChanges → FILTER(?seq > N) ORDER BY ?seq  (typed-integer compare/sort)
+ *   - seed        → reseeding the in-memory counter from a POPULATED log
+ * Typed-integer aggregation/ordering is exactly where SPARQL engines differ, so
+ * this suite pins it on a live Blazegraph.
+ *
+ * Gated on BLAZEGRAPH_TEST_URL so a plain `pnpm test` skips it (no Java/Docker
+ * required); CI's blazegraph job sets it. Example:
+ *   BLAZEGRAPH_TEST_URL=http://127.0.0.1:19999/bigdata/namespace/kb/sparql
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { BlazegraphStore } from '../src/adapters/blazegraph.js';
+import { ChangelogStore, CHANGELOG_GRAPH } from '../src/changelog-store.js';
+import type { Quad } from '../src/triple-store.js';
+
+const URL = process.env.BLAZEGRAPH_TEST_URL;
+const RUN = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+const G = (n: number) => `urn:cl-int:${RUN}:g${n}`;
+
+function q(subject: string, graph: string): Quad {
+  return { subject, predicate: 'urn:cl-int:p', object: '"x"', graph };
+}
+
+describe.skipIf(!URL)('ChangelogStore integration (live Blazegraph read-path)', () => {
+  let base: BlazegraphStore;
+
+  beforeAll(async () => {
+    base = new BlazegraphStore(URL as string);
+    // Clean slate: the changelog graph is a fixed URI shared across runs.
+    await base.dropGraph(CHANGELOG_GRAPH);
+  });
+
+  afterAll(async () => {
+    if (!base) return;
+    await base.dropGraph(CHANGELOG_GRAPH).catch(() => {});
+    for (let i = 0; i < 4; i++) await base.dropGraph(G(i)).catch(() => {});
+  });
+
+  it('upserts → headSeq (MAX) and readChanges (FILTER/ORDER BY) work on typed-integer markers', async () => {
+    const log = new ChangelogStore(base);
+    await log.insert([q('urn:cl-int:s1', G(0))]);
+    await log.insert([q('urn:cl-int:s2', G(1))]);
+
+    // MAX(?seq) over "1"^^xsd:integer / "2"^^xsd:integer must return 2, not "2" lexical noise.
+    expect(await log.headSeq()).toBe(2);
+
+    const all = await log.readChanges(0, 100);
+    expect(all).toEqual([
+      { seq: 1, graph: G(0), op: 'upsert' },
+      { seq: 2, graph: G(1), op: 'upsert' },
+    ]);
+
+    // sinceSeq narrowing via FILTER(?seq > 1) on a real engine.
+    expect((await log.readChanges(1, 100)).map((c) => c.seq)).toEqual([2]);
+  });
+
+  it('dropGraph records a drop marker; seq stays monotonic', async () => {
+    const log = new ChangelogStore(base);
+    await log.dropGraph(G(0));
+    const changes = await log.readChanges(0, 100);
+    expect(changes.at(-1)).toEqual({ seq: 3, graph: G(0), op: 'drop' });
+  });
+
+  it('a fresh ChangelogStore reseeds seq from the POPULATED live log (restart)', async () => {
+    // Simulates a daemon restart against the same Blazegraph namespace: the new
+    // in-memory counter must recover from the durable high-water mark, not 0.
+    const log2 = new ChangelogStore(base);
+    expect(await log2.headSeq()).toBe(3);
+    await log2.insert([q('urn:cl-int:s4', G(2))]);
+    const tail = await log2.readChanges(3, 100);
+    expect(tail).toEqual([{ seq: 4, graph: G(2), op: 'upsert' }]);
+  });
+
+  it('upsert marker and data are both durably present after one insert', async () => {
+    const log = new ChangelogStore(base);
+    await log.insert([q('urn:cl-int:s5', G(3))]);
+    // Data landed.
+    expect(await base.hasGraph(G(3))).toBe(true);
+    // Marker landed in the reserved graph (one transaction, real backend).
+    const res = await base.query(
+      `SELECT (COUNT(*) AS ?c) WHERE { GRAPH <${CHANGELOG_GRAPH}> { ?s <urn:dkg:changelog#graph> <${G(3)}> } }`,
+    );
+    const c = res.type === 'bindings' ? Number(res.bindings[0].c.match(/\d+/)?.[0] ?? '0') : 0;
+    expect(c).toBeGreaterThanOrEqual(1);
+  });
+});


### PR DESCRIPTION
**OT-RFC-59: Sync Changelog — Option A.** First of a stacked series that replaces O(store) sync convergence with an O(delta) append-only change log. This PR is the **write side only, default-OFF** — it changes no sync behavior on its own; it lays the foundation the read side (PR2/PR3) consumes.

### What it does
A `TripleStore` decorator (`ChangelogStore`, outermost) that appends a small marker `(seq, graph, op)` into a reserved graph `urn:dkg:changelog` on every mutation, so a future responder can answer *"what changed since seq N?"* without scanning the store.

- **Upsert atomicity**: markers ride the *same* `insert([...quads, ...markers])` call as the data → one backend transaction on every adapter (Oxigraph apply, Blazegraph N-Quads POST, sparql-http INSERT DATA) → no durable-data/lost-marker window.
- **Drops/deletes/updates**: post-mutation markers (`op` from a `hasGraph` probe), reconcile-healable; a failed marker write flags `needsReconcile`.
- **Single-writer seq**: in-process mutex + counter seeded from `MAX(seq)` → commit order = seq order (gap-safe cursor). Recovers across restart from the durable log.
- **Reserved graph** hidden from `listGraphs()`/`hasGraph()`; chain-reset wipes it (local `rm`, managed `DROP ALL`, and the operator-endpoint scoped DELETE widened to match `urn:dkg:changelog`).
- **Portable to Blazegraph** (external HTTP), not just Oxigraph.

### Validation
- `tsc` clean; **19 unit tests** (Oxigraph + mock Blazegraph); **4 integration tests against a real Blazegraph** (typed-integer `MAX`/`FILTER`/`ORDER BY` read path, restart reseed, one-POST durability); full `packages/storage` suite **312 passed / 0 failed**.

### Scope / deferred to later PRs (not bugs)
- **PR2** — `PROTOCOL_SYNC_CHANGELOG`, era mint, responder `sinceSeq` lane, structured `(era, headSeq)` response.
- **PR3** — requester `(era, seq)` cursor persistence, capability negotiation, legacy `sinceBatchId` fallback.
- **PR4** — lifecycle enable-path (intentionally unwired here: enabling before the publisher-CLI single-writer resolution §5.3 would fork the seq), reserved-plane hiding extended to `query()`/RS-sampling, total-triples metric exclusion.

Spec: OT-RFC-59. This PR was adversarially reviewed (7 minor/nit findings, all addressed; zero blockers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)