### PR TITLE
feat(storage): OT-RFC-59 changelog era foundation + reader capability

### DIFF
--- a/packages/storage/src/changelog-store.ts
+++ b/packages/storage/src/changelog-store.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { isSparqlUpdateOperation } from '@origintrail-official/dkg-core';
 import type {
   Quad,
@@ -91,6 +92,7 @@ const P_SEQ = `${NS}seq`;
 const P_GRAPH = `${NS}graph`;
 const P_OP = `${NS}op`;
 const P_SCHEMA_VERSION = `${NS}schemaVersion`;
+const P_ERA = `${NS}era`;
 const ENTRY_PREFIX = 'urn:dkg:changelog:e:';
 const META_SUBJECT = `${NS}self`;
 
@@ -108,6 +110,19 @@ export interface ChangeRecord {
   op: ChangeOp;
 }
 
+/** Durable head cursor a responder returns so a requester can advance safely. */
+export interface ChangelogHead {
+  /**
+   * Log generation id (a UUID). Immutable while the log lives; a wipe/reseed
+   * mints a fresh one. A requester whose cursor `era` differs MUST full-resync
+   * rather than trust `seq` (the guard against cursor poisoning after a
+   * restore/reseed/chain-reset rolls `seq` back — OT-RFC-59 §6).
+   */
+  era: string;
+  /** Highest seq durably present in the log (0 if empty). */
+  seq: number;
+}
+
 /**
  * The changelog READ capability the sync responder (PR2) consumes. Exposed as an
  * explicit interface + {@link asChangelogReader} type guard so a consumer of a
@@ -116,6 +131,8 @@ export interface ChangeRecord {
  * factory return type.
  */
 export interface ChangelogReader {
+  /** Durable head cursor `(era, seq)` — era mismatch or `seq` rollback ⇒ full resync. */
+  changelogHead(options?: QueryOptions): Promise<ChangelogHead>;
   /** Change records with `seq > sinceSeq`, ascending, at most `limit`. */
   readChanges(sinceSeq: number, limit: number, options?: QueryOptions): Promise<ChangeRecord[]>;
   /** Highest seq durably present in the log (0 if empty). */
@@ -154,6 +171,8 @@ export class ChangelogStore implements TripleStore, ChangelogReader {
 
   /** Last ALLOCATED seq (0 = none). Next seq is `seq + 1`. */
   private seq = 0;
+  /** Log generation id, established (read or minted) on seed. Null until then. */
+  private eraValue: string | null = null;
   private seedPromise: Promise<void> | null = null;
   /** Serializes mutations so commit order === seq order (single writer). */
   private tail: Promise<unknown> = Promise.resolve();
@@ -343,6 +362,17 @@ export class ChangelogStore implements TripleStore, ChangelogReader {
   // Changelog read API (consumed by the sync responder — PR2)
   // ------------------------------------------------------------------
 
+  /**
+   * Durable head cursor `(era, seq)` the sync responder returns so a requester
+   * can advance its cursor and detect a wipe/reseed (era change) or a rollback
+   * (`seq` < the requester's cursor). Establishes the era on first call.
+   */
+  async changelogHead(options?: QueryOptions): Promise<ChangelogHead> {
+    await this.ensureSeeded();
+    const seq = await this.headSeq(options);
+    return { era: this.eraValue as string, seq };
+  }
+
   /** Highest seq durably present in the log (0 if empty). */
   async headSeq(options?: QueryOptions): Promise<number> {
     const res = await this.inner.query(
@@ -441,21 +471,49 @@ export class ChangelogStore implements TripleStore, ChangelogReader {
     return run;
   }
 
-  /** Seed the in-memory counter from the durable log's high-water mark, once. */
+  /**
+   * Seed the in-memory seq counter AND the era from the durable log, once.
+   *
+   * If the log has no era yet — a brand-new log, or a pre-era PR1 log first read
+   * by a PR2 node — mint and persist one. Writes reach here under the write mutex
+   * ({@link runExclusive}); reads (the responder's {@link changelogHead}) share
+   * the memoized `seedPromise`, and a concurrent write awaits the same promise
+   * before allocating, so the mint write runs at most once with no writer racing
+   * it.
+   */
   private ensureSeeded(): Promise<void> {
     if (!this.seedPromise) {
-      this.seedPromise = this.headSeq({ source: 'changelog.seed' })
-        .then((head) => {
-          this.seq = head;
-        })
+      this.seedPromise = this.seedOnce()
         .catch((err) => {
-          // Reset so a transient store error retries seeding on the next write
+          // Reset so a transient store error retries seeding on the next call
           // rather than latching seq=0 (which would collide with existing seqs).
           this.seedPromise = null;
           throw err;
         });
     }
     return this.seedPromise;
+  }
+
+  /** Read the durable head (seq + era), minting+persisting an era if absent. */
+  private async seedOnce(): Promise<void> {
+    const seq = await this.headSeq({ source: 'changelog.seed' });
+    this.seq = seq;
+    const res = await this.inner.query(
+      `SELECT ?era WHERE { GRAPH <${CHANGELOG_GRAPH}> { <${META_SUBJECT}> <${P_ERA}> ?era } } LIMIT 1`,
+      { source: 'changelog.seed.era' },
+    );
+    const era = res.type === 'bindings' && res.bindings.length > 0
+      ? stripLiteral(res.bindings[0].era)
+      : '';
+    if (era) {
+      this.eraValue = era;
+      return;
+    }
+    const minted = randomUUID();
+    await this.inner.insert([{
+      subject: META_SUBJECT, predicate: P_ERA, object: `"${minted}"`, graph: CHANGELOG_GRAPH,
+    }]);
+    this.eraValue = minted;
   }
 
   /** Emit `upsert`/`drop` markers for graphs after a mutation, op by probe. */

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -48,6 +48,7 @@ export {
   asChangelogReader,
   type ChangeOp,
   type ChangeRecord,
+  type ChangelogHead,
   type ChangelogReader,
   type ChangelogStoreOptions,
 } from './changelog-store.js';

--- a/packages/storage/test/changelog-store.test.ts
+++ b/packages/storage/test/changelog-store.test.ts
@@ -64,6 +64,10 @@ describe('ChangelogStore — upsert marker atomicity', () => {
     const spy = new SpyStore(base);
     const log = new ChangelogStore(spy);
 
+    // Seed first so the one-time era-mint insert isn't counted; we are asserting
+    // that a DATA write fuses its marker into a single call, not the seed path.
+    await log.changelogHead();
+    spy.insertCalls.length = 0;
     await log.insert([q('http://ex.org/s1', G1)]);
 
     // Exactly one inner insert() — data + marker together, never two calls.
@@ -282,8 +286,9 @@ describe('ChangelogStore over Blazegraph — single-request atomicity', () => {
   });
 
   it('the data quad and its marker land in ONE n-quads POST', async () => {
-    insertBodies.length = 0;
     const log = new ChangelogStore(new BlazegraphStore(url));
+    await log.changelogHead();   // one-time era-mint POST, not under test here
+    insertBodies.length = 0;
     await log.insert([q('http://ex.org/s1', G1)]);
 
     // Exactly one write request, carrying both the data triple and the marker.
@@ -560,6 +565,68 @@ describe('ChangelogStore — lifecycle drains the write queue', () => {
     // flush() did not latch closing: further writes still succeed.
     await log.insert([q('http://ex.org/s2', G2)]);
     expect((await log.readChanges(0, 100)).map((c) => c.graph)).toEqual([G1, G2]);
+    await base.close();
+  });
+});
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+describe('ChangelogStore — era foundation & reader capability', () => {
+  it('mints a stable era on first changelogHead() and returns the live seq', async () => {
+    const base = new OxigraphStore();
+    const log = new ChangelogStore(base);
+    const h1 = await log.changelogHead();
+    expect(h1.era).toMatch(UUID_RE);
+    expect(h1.seq).toBe(0);
+    await log.insert([q('http://ex.org/a', G1)]);
+    await log.insert([q('http://ex.org/b', G2)]);
+    const h2 = await log.changelogHead();
+    expect(h2.era).toBe(h1.era); // era is immutable while the log lives
+    expect(h2.seq).toBe(2);
+    await base.close();
+  });
+
+  it('reads the existing era rather than re-minting (a fresh store over the same log)', async () => {
+    const base = new OxigraphStore();
+    const minted = (await new ChangelogStore(base).changelogHead()).era;
+    // A second ChangelogStore (e.g. a daemon restart) over the SAME underlying
+    // store must recover the SAME era — re-minting would falsely signal a wipe
+    // to peers and force needless full resyncs.
+    const reread = (await new ChangelogStore(base).changelogHead()).era;
+    expect(reread).toBe(minted);
+    await base.close();
+  });
+
+  it('era + seq are durable across a persistent-store reopen', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'changelog-era-'));
+    try {
+      const path = join(dir, 'store.nq');
+      const first = new OxigraphStore(path);
+      const log1 = new ChangelogStore(first);
+      const era = (await log1.changelogHead()).era;
+      await log1.insert([q('http://ex.org/a', G1)]);
+      await first.flush();
+      await first.close();
+
+      const second = new OxigraphStore(path);
+      const head = await new ChangelogStore(second).changelogHead();
+      expect(head.era).toBe(era);
+      expect(head.seq).toBe(1);
+      await second.close();
+    } finally {
+      try { rmSync(dir, { recursive: true, force: true }); } catch { /* */ }
+    }
+  });
+
+  it('asChangelogReader narrows a ChangelogStore and rejects a plain store', async () => {
+    const base = new OxigraphStore();
+    const log = new ChangelogStore(base);
+    const reader = asChangelogReader(log);
+    expect(reader).not.toBeNull();
+    expect(await reader!.readChanges(0, 10)).toEqual([]);
+    // A plain (non-changelog) store is not a reader → capability probe is false.
+    expect(asChangelogReader(base)).toBeNull();
+    expect(asChangelogReader(null)).toBeNull();
     await base.close();
   });
 });

--- a/packages/storage/test/changelog.integration.test.ts
+++ b/packages/storage/test/changelog.integration.test.ts
@@ -78,6 +78,16 @@ describe.skipIf(!URL)('ChangelogStore integration (live Blazegraph read-path)', 
     expect(tail).toEqual([{ seq: 4, graph: G(2), op: 'upsert' }]);
   });
 
+  it('era is minted once and reseeds from the live log on a fresh store', async () => {
+    // First reader mints+persists an era; a second store (restart) must recover
+    // the SAME era from the live Blazegraph, not mint a new one.
+    const era1 = (await new ChangelogStore(base).changelogHead()).era;
+    expect(era1).toMatch(/^[0-9a-f-]{36}$/i);
+    const head2 = await new ChangelogStore(base).changelogHead();
+    expect(head2.era).toBe(era1);
+    expect(head2.seq).toBeGreaterThanOrEqual(3); // seq survives across the "restart" too
+  });
+
   it('upsert marker and data are both durably present after one insert', async () => {
     const log = new ChangelogStore(base);
     await log.insert([q('urn:cl-int:s5', G(3))]);


### PR DESCRIPTION
Part of the **OT-RFC-59 sync changelog** series. Stacked on #1601 (write-side, "PR 1/4") — base is `feat/rfc59-sync-changelog`; retarget to `main` once #1601 merges.

## What
The read-side **foundation**: the append-only change log's per-log **identity** and the capability surface the sync responder will consume. All dormant (default-off) — nothing registers or reads it yet.

- **era** — a per-log UUID minted-and-persisted (or read) on first seed, in the reserved graph's `#self #era`. `changelogHead()` returns `{era, seq}` — the durable head cursor a responder hands back. A fresh `ChangelogStore` over the same store recovers the **same** era (a restart must not falsely signal a wipe).
- **`ChangelogReader` interface + `asChangelogReader()`** — how the responder narrows a changelog-enabled store vs a plain one, without reaching into concrete types.

## Scope
This is era *foundation* + re-mint on **wipe**. It does **not** by itself defend a backup/restore **rollback** (old era travels in the backup while `seq` rolls back) — that guard is the stacked follow-up (`feat/rfc59-changelog-restore-guard`, OT-RFC-59 §6 P0).

## Tests
+4 unit (mint-stable-and-immutable, read-not-re-mint across a fresh store, era+seq durable across a persistent reopen, `asChangelogReader` narrowing) and +1 **live-Blazegraph** (era persists and reseeds from the live log). Storage suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
