### PR TITLE
feat(sync): OT-RFC-59 changelog read-lane protocol id + wire codec

### DIFF
--- a/packages/agent/src/sync/changelog/wire.ts
+++ b/packages/agent/src/sync/changelog/wire.ts
@@ -1,0 +1,150 @@
+/**
+ * OT-RFC-59 changelog read-lane wire format (PROTOCOL_SYNC_CHANGELOG).
+ *
+ * A structured JSON request/response over the raw ProtocolRouter stream —
+ * deliberately SEPARATE from the legacy `/dkg/10.0.2/sync` bare-N-Quads wire and
+ * its `SyncRequestEnvelope`, which are left untouched. The delta round is:
+ *   requester → { contextGraphId, sinceSeq, era } (+ the same signed-digest auth
+ *   fields the legacy lane carries; added by the handler wiring, SC4)
+ *   responder → one of:
+ *     - `resync` : era mismatch / no cursor / rollback → requester full-syncs
+ *     - `delta`  : a bounded page of change records + the changed graphs' content
+ *     - `denied` : RFC-49 authorization failure (reuses the legacy deny sentinel)
+ *
+ * Two red-team-driven shape decisions (see RFC59-RESPONDER-PLAN.md):
+ *  - Each record carries its own `seq`, so a requester that fails to apply one
+ *    record (e.g. a poison/oversized graph) advances its cursor only to the last
+ *    SUCCESSFULLY applied seq — never a permanent gap past an unapplied change.
+ *  - Progress is the scanned-through `nextSeq`, never the record count: because
+ *    `readChanges` is node-global, a page scoped to one CG can be validly empty
+ *    while `headSeq ≫ sinceSeq`. The requester loops while `nextSeq < headSeq`.
+ */
+import { SYNC_ACCESS_DENIED_MARKER } from '../../dkg-agent-constants.js';
+
+export interface ChangelogSyncRequest {
+  /** The context graph this delta round is scoped to. */
+  contextGraphId: string;
+  /** Requester's last-applied seq for (peer, cg); 0 on first contact. */
+  sinceSeq: number;
+  /** Requester's cursor era; null on first contact. Mismatch ⇒ responder resyncs. */
+  era: string | null;
+  /** Max RAW change records the responder scans for this page. */
+  limit: number;
+}
+
+export type ChangeOp = 'upsert' | 'drop';
+
+export interface ChangelogDeltaRecord {
+  /** The record's per-node seq — the unit of cursor advancement. */
+  seq: number;
+  /** Admitted, non-reserved graph URI. */
+  graph: string;
+  op: ChangeOp;
+  /** N-Quads text of the graph's ADMITTED content. Present iff `op === 'upsert'`. */
+  quads?: string;
+}
+
+export type ChangelogSyncResponse =
+  | { kind: 'resync'; era: string; headSeq: number }
+  | {
+      kind: 'delta';
+      era: string;
+      headSeq: number;
+      /** Highest raw seq scanned this page; requester advances toward it. */
+      nextSeq: number;
+      records: ChangelogDeltaRecord[];
+    }
+  | { kind: 'denied' };
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+export function encodeChangelogRequest(req: ChangelogSyncRequest): Uint8Array {
+  return encoder.encode(JSON.stringify(req));
+}
+
+export function decodeChangelogRequest(bytes: Uint8Array): ChangelogSyncRequest {
+  const obj = parseJsonObject(decoder.decode(bytes), 'request');
+  const contextGraphId = obj.contextGraphId;
+  const sinceSeq = obj.sinceSeq;
+  const era = obj.era;
+  const limit = obj.limit;
+  if (typeof contextGraphId !== 'string' || contextGraphId.length === 0) {
+    throw new Error('ChangelogSyncRequest: contextGraphId must be a non-empty string');
+  }
+  if (!isNonNegInt(sinceSeq)) throw new Error('ChangelogSyncRequest: sinceSeq must be a non-negative integer');
+  if (era !== null && typeof era !== 'string') throw new Error('ChangelogSyncRequest: era must be a string or null');
+  if (!isPosInt(limit)) throw new Error('ChangelogSyncRequest: limit must be a positive integer');
+  // Preserve any extra fields (SC4 rides the signed-digest auth here) verbatim.
+  return { ...(obj as Record<string, unknown>), contextGraphId, sinceSeq, era, limit } as ChangelogSyncRequest;
+}
+
+export function encodeChangelogResponse(resp: ChangelogSyncResponse): Uint8Array {
+  // Denial reuses the legacy deny sentinel string so the requester's existing
+  // deny classifier is shared — it is NOT valid JSON, hence the decode-side
+  // sentinel check must run BEFORE JSON.parse.
+  if (resp.kind === 'denied') return encoder.encode(SYNC_ACCESS_DENIED_MARKER);
+  return encoder.encode(JSON.stringify(resp));
+}
+
+export function decodeChangelogResponse(bytes: Uint8Array): ChangelogSyncResponse {
+  const text = decoder.decode(bytes);
+  if (text === SYNC_ACCESS_DENIED_MARKER) return { kind: 'denied' };
+  const obj = parseJsonObject(text, 'response');
+  if (obj.kind === 'resync') {
+    return { kind: 'resync', era: asString(obj.era, 'era'), headSeq: asNonNegInt(obj.headSeq, 'headSeq') };
+  }
+  if (obj.kind === 'delta') {
+    const era = asString(obj.era, 'era');
+    const headSeq = asNonNegInt(obj.headSeq, 'headSeq');
+    const nextSeq = asNonNegInt(obj.nextSeq, 'nextSeq');
+    if (!Array.isArray(obj.records)) throw new Error('ChangelogSyncResponse.delta: records must be an array');
+    const records = obj.records.map((r, i) => decodeRecord(r, i));
+    return { kind: 'delta', era, headSeq, nextSeq, records };
+  }
+  throw new Error(`ChangelogSyncResponse: unknown kind ${JSON.stringify(obj.kind)}`);
+}
+
+function decodeRecord(r: unknown, i: number): ChangelogDeltaRecord {
+  if (r === null || typeof r !== 'object') throw new Error(`ChangelogDeltaRecord[${i}]: not an object`);
+  const o = r as Record<string, unknown>;
+  const seq = o.seq;
+  const graph = o.graph;
+  const op = o.op;
+  if (!isPosInt(seq)) throw new Error(`ChangelogDeltaRecord[${i}]: seq must be a positive integer`);
+  if (typeof graph !== 'string' || graph.length === 0) throw new Error(`ChangelogDeltaRecord[${i}]: graph must be a non-empty string`);
+  if (op !== 'upsert' && op !== 'drop') throw new Error(`ChangelogDeltaRecord[${i}]: op must be 'upsert' | 'drop'`);
+  if (op === 'upsert') {
+    if (typeof o.quads !== 'string') throw new Error(`ChangelogDeltaRecord[${i}]: upsert requires quads text`);
+    return { seq, graph, op, quads: o.quads };
+  }
+  return { seq, graph, op };
+}
+
+function parseJsonObject(text: string, what: string): Record<string, unknown> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw new Error(`Changelog ${what}: not valid JSON`);
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`Changelog ${what}: expected a JSON object`);
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function isNonNegInt(v: unknown): v is number {
+  return typeof v === 'number' && Number.isInteger(v) && v >= 0;
+}
+function isPosInt(v: unknown): v is number {
+  return typeof v === 'number' && Number.isInteger(v) && v > 0;
+}
+function asString(v: unknown, field: string): string {
+  if (typeof v !== 'string' || v.length === 0) throw new Error(`Changelog response: ${field} must be a non-empty string`);
+  return v;
+}
+function asNonNegInt(v: unknown, field: string): number {
+  if (!isNonNegInt(v)) throw new Error(`Changelog response: ${field} must be a non-negative integer`);
+  return v;
+}

--- a/packages/agent/test/changelog-wire.test.ts
+++ b/packages/agent/test/changelog-wire.test.ts
@@ -1,0 +1,91 @@
+/**
+ * OT-RFC-59 changelog read-lane wire codec tests (SC2).
+ * Round-trips + the two red-team-driven guarantees: per-record `seq` survives,
+ * and the deny sentinel is recognised BEFORE JSON.parse (it is not valid JSON).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  encodeChangelogRequest,
+  decodeChangelogRequest,
+  encodeChangelogResponse,
+  decodeChangelogResponse,
+  type ChangelogSyncRequest,
+  type ChangelogSyncResponse,
+} from '../src/sync/changelog/wire.js';
+import { SYNC_ACCESS_DENIED_MARKER } from '../src/dkg-agent-constants.js';
+
+const REQ: ChangelogSyncRequest = {
+  contextGraphId: 'did:dkg:context-graph:0xabc',
+  sinceSeq: 41,
+  era: 'e3b0c442-98fc-1c14-9afb-4c8996fb9242',
+  limit: 500,
+};
+
+describe('changelog wire — request', () => {
+  it('round-trips the core fields', () => {
+    expect(decodeChangelogRequest(encodeChangelogRequest(REQ))).toMatchObject(REQ);
+  });
+
+  it('preserves extra fields verbatim (SC4 rides signed-digest auth on this JSON)', () => {
+    const withAuth = { ...REQ, requesterPeerId: '12D3Koo', requesterSignatureR: '0xdead' };
+    const out = decodeChangelogRequest(encodeChangelogRequest(withAuth as ChangelogSyncRequest));
+    expect((out as Record<string, unknown>).requesterPeerId).toBe('12D3Koo');
+    expect((out as Record<string, unknown>).requesterSignatureR).toBe('0xdead');
+  });
+
+  it('accepts era=null and sinceSeq=0 (first contact)', () => {
+    const first = decodeChangelogRequest(encodeChangelogRequest({ ...REQ, era: null, sinceSeq: 0 }));
+    expect(first.era).toBeNull();
+    expect(first.sinceSeq).toBe(0);
+  });
+
+  it('rejects malformed requests', () => {
+    const enc = (o: unknown) => new TextEncoder().encode(JSON.stringify(o));
+    expect(() => decodeChangelogRequest(enc({ ...REQ, contextGraphId: '' }))).toThrow(/contextGraphId/);
+    expect(() => decodeChangelogRequest(enc({ ...REQ, sinceSeq: -1 }))).toThrow(/sinceSeq/);
+    expect(() => decodeChangelogRequest(enc({ ...REQ, limit: 0 }))).toThrow(/limit/);
+    expect(() => decodeChangelogRequest(enc({ ...REQ, era: 5 }))).toThrow(/era/);
+    expect(() => decodeChangelogRequest(new TextEncoder().encode('not json'))).toThrow(/not valid JSON/);
+  });
+});
+
+describe('changelog wire — response', () => {
+  it('round-trips a resync', () => {
+    const r: ChangelogSyncResponse = { kind: 'resync', era: 'era-1', headSeq: 900 };
+    expect(decodeChangelogResponse(encodeChangelogResponse(r))).toEqual(r);
+  });
+
+  it('round-trips a delta preserving per-record seq, upsert quads, and drop', () => {
+    const r: ChangelogSyncResponse = {
+      kind: 'delta',
+      era: 'era-1',
+      headSeq: 140,
+      nextSeq: 140,
+      records: [
+        { seq: 101, graph: 'did:dkg:context-graph:0xabc/1', op: 'upsert', quads: '<s> <p> "o" <g> .' },
+        { seq: 137, graph: 'did:dkg:context-graph:0xabc/2', op: 'drop' },
+      ],
+    };
+    const out = decodeChangelogResponse(encodeChangelogResponse(r));
+    expect(out).toEqual(r);
+    // seq is the load-bearing field for partial-apply cursor advancement.
+    if (out.kind === 'delta') {
+      expect(out.records.map((x) => x.seq)).toEqual([101, 137]);
+      expect(out.records[1].quads).toBeUndefined();
+    }
+  });
+
+  it('encodes denial to the legacy sentinel and decodes it WITHOUT JSON.parse', () => {
+    const bytes = encodeChangelogResponse({ kind: 'denied' });
+    expect(new TextDecoder().decode(bytes)).toBe(SYNC_ACCESS_DENIED_MARKER); // not JSON
+    expect(decodeChangelogResponse(bytes)).toEqual({ kind: 'denied' });
+  });
+
+  it('rejects malformed responses', () => {
+    const enc = (o: unknown) => new TextEncoder().encode(JSON.stringify(o));
+    expect(() => decodeChangelogResponse(enc({ kind: 'delta', era: 'e', headSeq: 1, nextSeq: 1, records: [{ graph: 'g', op: 'upsert', quads: '' }] }))).toThrow(/seq/);
+    expect(() => decodeChangelogResponse(enc({ kind: 'delta', era: 'e', headSeq: 1, nextSeq: 1, records: [{ seq: 1, graph: 'g', op: 'upsert' }] }))).toThrow(/quads/);
+    expect(() => decodeChangelogResponse(enc({ kind: 'bogus' }))).toThrow(/unknown kind/);
+    expect(() => decodeChangelogResponse(enc({ kind: 'resync', era: '', headSeq: 1 }))).toThrow(/era/);
+  });
+});

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -23,6 +23,15 @@ export const PROTOCOL_DISCOVER = '/dkg/10.0.0/discover';
 // (sync is a self-healing catch-up net, so the brief mixed-version
 // window during auto-update is no-data-loss).
 export const PROTOCOL_SYNC = '/dkg/10.0.2/sync';
+// OT-RFC-59 changelog read-lane — a SEPARATE protocol id, not a field on
+// PROTOCOL_SYNC: the legacy sync response is bare N-Quads with no envelope, so a
+// structured (era, headSeq, nextSeq, records) head cannot ride the existing
+// wire. Same 10.0.2 family; the distinct suffix means legacy peers never dial it
+// and identify simply omits it. Advertised ONLY when config.changelog is on
+// (the responder registers it iff asChangelogReader(store) is non-null), so it
+// is default-off and mixed-version-safe: a changelog-capable requester falls
+// back to PROTOCOL_SYNC when a peer does not advertise this id.
+export const PROTOCOL_SYNC_CHANGELOG = '/dkg/10.0.2/sync-changelog';
 export const PROTOCOL_GET_ASSERTION_ARTIFACT = '/dkg/10.0.2/get-assertion-artifact';
 // Universal Messenger pilot protocol (rc.9 PR-3). Bumped from
 // /dkg/10.0.0/message to /dkg/10.0.1/message to opt into the

--- a/packages/storage/src/changelog-store.ts
+++ b/packages/storage/src/changelog-store.ts
@@ -708,17 +708,24 @@ function queryOptionsFromUpdateOptions(options?: UpdateOptions): QueryOptions | 
  * no `instanceof`/cast/decorator-order assumption at the call site.
  */
 export function asChangelogReader(store: unknown): ChangelogReader | null {
-  if (store instanceof ChangelogStore) return store;
-  // Duck-type so a further wrapper that forwards the API still resolves.
-  const s = store as Partial<ChangelogReader> | null | undefined;
-  if (
-    s &&
-    typeof s.readChanges === 'function' &&
-    typeof s.headSeq === 'function' &&
-    typeof s.clearReconcileFlag === 'function' &&
-    typeof s.needsReconcile === 'boolean'
-  ) {
-    return s as ChangelogReader;
+  // Follow `.innerStore` so a wrapper AROUND the ChangelogStore still resolves.
+  // The daemon's store is `createListContextGraphsCacheInvalidatingStore(...)`
+  // (dkg-agent-base.ts), a hand-rolled forwarder that exposes `.innerStore` but
+  // does NOT forward the changelog API — so a direct check misses it even when
+  // the changelog is enabled. The depth bound guards a pathological/cyclic chain.
+  let s = store as (Partial<ChangelogReader> & { innerStore?: unknown }) | null | undefined;
+  for (let depth = 0; s && depth < 8; depth++) {
+    if (s instanceof ChangelogStore) return s;
+    if (
+      typeof s.changelogHead === 'function' &&
+      typeof s.readChanges === 'function' &&
+      typeof s.headSeq === 'function' &&
+      typeof s.clearReconcileFlag === 'function' &&
+      typeof s.needsReconcile === 'boolean'
+    ) {
+      return s as ChangelogReader;
+    }
+    s = s.innerStore as typeof s;
   }
   return null;
 }

--- a/packages/storage/test/changelog-store.test.ts
+++ b/packages/storage/test/changelog-store.test.ts
@@ -629,4 +629,18 @@ describe('ChangelogStore — era foundation & reader capability', () => {
     expect(asChangelogReader(null)).toBeNull();
     await base.close();
   });
+
+  it('asChangelogReader unwraps a forwarder that exposes .innerStore (the daemon store wrapper)', async () => {
+    const base = new OxigraphStore();
+    const log = new ChangelogStore(base);
+    // Mimic createListContextGraphsCacheInvalidatingStore: a wrapper that exposes
+    // .innerStore but does NOT forward the changelog API.
+    const wrapper = { innerStore: log, insert: () => {}, listGraphs: () => Promise.resolve([]) };
+    const reader = asChangelogReader(wrapper);
+    expect(reader).not.toBeNull();
+    expect(await reader!.changelogHead()).toMatchObject({ seq: 0 });
+    // A wrapper whose inner chain has no ChangelogStore stays null.
+    expect(asChangelogReader({ innerStore: { innerStore: base } })).toBeNull();
+    await base.close();
+  });
 });


### PR DESCRIPTION
Part of the **OT-RFC-59 sync changelog** series. Stacked on `feat/rfc59-changelog-era` (→ #1601). The legacy `/dkg/10.0.2/sync` wire and `SyncRequestEnvelope` are **untouched**.

## What
The read-lane's protocol id + structured wire codec — pure additions, dormant.

- **`PROTOCOL_SYNC_CHANGELOG = '/dkg/10.0.2/sync-changelog'`** — a SEPARATE libp2p id (not a field on `PROTOCOL_SYNC`): the legacy response is bare N-Quads with no envelope, so a structured `(era, headSeq, nextSeq, records)` head can't ride it. Distinct suffix ⇒ legacy peers never dial it; advertised only when the changelog is on ⇒ default-off, mixed-version-safe.
- **`asChangelogReader` follows `.innerStore`** — the responder's store is `createListContextGraphsCacheInvalidatingStore(...)`, a forwarder that exposes `.innerStore` but doesn't forward `changelogHead`/`readChanges`, so a direct probe returned null even when enabled.
- **`sync/changelog/wire.ts`** — `ChangelogSyncRequest` + `ChangelogSyncResponse` (`resync | delta | denied`) codec. Two adversarial-review-driven shape decisions: each record carries its own **`seq`** (a failed apply advances only to the last *successfully* applied seq — no permanent gap, the known poison-literal class); progress is the scanned-through **`nextSeq`**, never record count (`readChanges` is node-global). Denial reuses the legacy `SYNC_ACCESS_DENIED_MARKER` sentinel (not JSON), so decode sentinel-checks before `JSON.parse`.

## Tests
+1 unwrap-through-forwarder (storage) and +8 wire codec (round-trips, extra-field preservation, per-record seq survival, denial-before-parse, malformed rejection). Full agent typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
