### PR TITLE
feat(storage): OT-RFC-59 era restore-safety guard (§6 P0)

### DIFF
--- a/packages/storage/src/changelog-store.ts
+++ b/packages/storage/src/changelog-store.ts
@@ -143,6 +143,24 @@ export interface ChangelogReader {
   clearReconcileFlag(): void;
 }
 
+/**
+ * Durable, OUT-OF-STORE high-water record used to detect a backup/restore that
+ * rolls `seq` back **under the same era** — the one case the in-store era +
+ * responder `head.seq < sinceSeq` guards cannot catch (a file restore replaces
+ * the whole store atomically, so nothing inside it can tell it was rolled back;
+ * and once the restored node re-advances past a peer's cursor, `head.seq <
+ * sinceSeq` no longer fires while the seqs now mean different changes — a silent
+ * skip). The guard MUST persist somewhere the RDF-store restore does not roll
+ * back with it (e.g. `node-ui.db`, which survives a `store.nq` restore and works
+ * for external backends too). See OT-RFC-59 §6.
+ */
+export interface ChangelogEraGuard {
+  /** The last persisted `(era, highSeq)`; null if never written. */
+  load(): Promise<{ era: string; highSeq: number } | null>;
+  /** Persist the current high-water. Called at seed and after each committed seq. */
+  save(era: string, highSeq: number): Promise<void>;
+}
+
 export interface ChangelogStoreOptions {
   enabled?: boolean;
   /**
@@ -153,6 +171,14 @@ export interface ChangelogStoreOptions {
   reservedGraphs?: readonly string[];
   /** Observability hook fired after each marker is durably appended. */
   onAppend?: (record: ChangeRecord) => void;
+  /**
+   * Optional restore-detection guard. When provided, a seq rollback under the
+   * same era rotates the era on seed (forcing peers to full-resync instead of
+   * silently skipping). When absent, no restore detection runs — the historical
+   * behavior — which is why enabling the changelog fleet-wide REQUIRES a durable
+   * guard (OT-RFC-59 §6 P0).
+   */
+  eraGuard?: ChangelogEraGuard;
 }
 
 /**
@@ -168,6 +194,7 @@ export class ChangelogStore implements TripleStore, ChangelogReader {
   private readonly enabled: boolean;
   private readonly reserved: ReadonlySet<string>;
   private readonly onAppend?: (record: ChangeRecord) => void;
+  private readonly eraGuard?: ChangelogEraGuard;
 
   /** Last ALLOCATED seq (0 = none). Next seq is `seq + 1`. */
   private seq = 0;
@@ -193,6 +220,7 @@ export class ChangelogStore implements TripleStore, ChangelogReader {
     for (const g of options.reservedGraphs ?? []) reserved.add(g);
     this.reserved = reserved;
     this.onAppend = options.onAppend;
+    this.eraGuard = options.eraGuard;
   }
 
   // ------------------------------------------------------------------
@@ -224,6 +252,7 @@ export class ChangelogStore implements TripleStore, ChangelogReader {
       // Data + markers in ONE insert() → one backend transaction → atomic.
       await this.inner.insert([...safe, ...markers], options);
       this.seq = candidate; // advance only after durable success (gapless)
+      await this.noteHighWater();
       this.fire(records);
     });
   }
@@ -507,13 +536,64 @@ export class ChangelogStore implements TripleStore, ChangelogReader {
       : '';
     if (era) {
       this.eraValue = era;
+    } else {
+      const minted = randomUUID();
+      await this.writeEra(minted);
+      this.eraValue = minted;
+    }
+    await this.applyEraGuard();
+  }
+
+  /**
+   * Restore-detection (OT-RFC-59 §6). With a durable {@link ChangelogEraGuard},
+   * a seq that has rolled BACK under the same era means the store was restored
+   * from an older backup: rotate the era so peers detect it and full-resync
+   * rather than silently skipping the changes above the restored point. Otherwise
+   * advance the durable high-water. No-op without a guard (default-off posture).
+   */
+  private async applyEraGuard(): Promise<void> {
+    if (!this.eraGuard) return;
+    const prior = await this.eraGuard.load();
+    if (prior && prior.era === this.eraValue && this.seq < prior.highSeq) {
+      // Rollback under the same era → rotate.
+      const rotated = randomUUID();
+      await this.writeEra(rotated);
+      this.eraValue = rotated;
+      await this.eraGuard.save(rotated, this.seq);
       return;
     }
-    const minted = randomUUID();
+    // Normal boot / wipe (new era) / forward progress: persist the high-water for
+    // this era. A different prior.era (e.g. after a wipe minted a fresh era)
+    // resets the high-water to the current seq under the new era.
+    const highSeq = prior && prior.era === this.eraValue
+      ? Math.max(this.seq, prior.highSeq)
+      : this.seq;
+    await this.eraGuard.save(this.eraValue as string, highSeq);
+  }
+
+  /** Replace the single `#era` marker in the reserved graph (delete-any + insert). */
+  private async writeEra(era: string): Promise<void> {
+    await this.inner.deleteByPattern({
+      subject: META_SUBJECT, predicate: P_ERA, graph: CHANGELOG_GRAPH,
+    });
     await this.inner.insert([{
-      subject: META_SUBJECT, predicate: P_ERA, object: `"${minted}"`, graph: CHANGELOG_GRAPH,
+      subject: META_SUBJECT, predicate: P_ERA, object: `"${era}"`, graph: CHANGELOG_GRAPH,
     }]);
-    this.eraValue = minted;
+  }
+
+  /**
+   * Best-effort: persist the current seq as the durable high-water after a
+   * committed write, so a later restore below it is detectable. Non-fatal — the
+   * data+marker already committed; a failed guard write just leaves a slightly
+   * stale high-water that the next write re-advances. Runs under the write mutex.
+   */
+  private async noteHighWater(): Promise<void> {
+    if (!this.eraGuard || !this.eraValue) return;
+    try {
+      await this.eraGuard.save(this.eraValue, this.seq);
+    } catch {
+      // A stale high-water only narrows restore detection; never fail a write.
+    }
   }
 
   /** Emit `upsert`/`drop` markers for graphs after a mutation, op by probe. */
@@ -560,6 +640,7 @@ export class ChangelogStore implements TripleStore, ChangelogReader {
       }
       await this.inner.insert(quads, options);
       this.seq = candidate;
+      await this.noteHighWater();
       this.fire(records);
     } catch (err) {
       this.flagReconcile('appendMarkers(post-mutation-marker-write-failed)');

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -48,6 +48,7 @@ export {
   asChangelogReader,
   type ChangeOp,
   type ChangeRecord,
+  type ChangelogEraGuard,
   type ChangelogHead,
   type ChangelogReader,
   type ChangelogStoreOptions,

--- a/packages/storage/test/changelog-store.test.ts
+++ b/packages/storage/test/changelog-store.test.ts
@@ -20,7 +20,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { OxigraphStore } from '../src/adapters/oxigraph.js';
 import { BlazegraphStore } from '../src/adapters/blazegraph.js';
-import { ChangelogStore, CHANGELOG_GRAPH, asChangelogReader } from '../src/changelog-store.js';
+import { ChangelogStore, CHANGELOG_GRAPH, asChangelogReader, type ChangelogEraGuard } from '../src/changelog-store.js';
 import { createTripleStore } from '../src/triple-store.js';
 import type { Quad, QueryOptions, QueryResult, TripleStore, UpdateOptions } from '../src/triple-store.js';
 
@@ -627,6 +627,67 @@ describe('ChangelogStore — era foundation & reader capability', () => {
     // A plain (non-changelog) store is not a reader → capability probe is false.
     expect(asChangelogReader(base)).toBeNull();
     expect(asChangelogReader(null)).toBeNull();
+    await base.close();
+  });
+
+  it('era-restore guard: a seq rollback under the same era rotates the era (P0)', async () => {
+    class MemGuard implements ChangelogEraGuard {
+      state: { era: string; highSeq: number } | null;
+      constructor(initial: { era: string; highSeq: number } | null = null) { this.state = initial; }
+      async load() { return this.state; }
+      async save(era: string, highSeq: number) { this.state = { era, highSeq }; }
+    }
+
+    // A store that reached seq 5 under era E1.
+    const base = new OxigraphStore();
+    const era1 = (await new ChangelogStore(base).changelogHead()).era;
+    for (let i = 0; i < 5; i++) await new ChangelogStore(base).insert([q(`http://ex.org/s${i}`, `${G1}${i}`)]);
+
+    // Simulate a restore: the durable guard says this era once reached seq 10,
+    // but the (restored) store is only at seq 5 → rollback under the same era.
+    const guard = new MemGuard({ era: era1, highSeq: 10 });
+    const head = await new ChangelogStore(base, { eraGuard: guard }).changelogHead();
+    expect(head.seq).toBe(5);
+    expect(head.era).not.toBe(era1);              // era rotated → peers full-resync
+    expect(guard.state).toEqual({ era: head.era, highSeq: 5 });
+    await base.close();
+  });
+
+  it('era-restore guard: normal restart (no rollback) keeps the era and advances the high-water', async () => {
+    class MemGuard implements ChangelogEraGuard {
+      state: { era: string; highSeq: number } | null = null;
+      async load() { return this.state; }
+      async save(era: string, highSeq: number) { this.state = { era, highSeq }; }
+    }
+    const base = new OxigraphStore();
+    const guard = new MemGuard();
+    const log1 = new ChangelogStore(base, { eraGuard: guard });
+    const era1 = (await log1.changelogHead()).era;
+    await log1.insert([q('http://ex.org/a', G1)]);
+    await log1.insert([q('http://ex.org/b', G2)]);
+    expect(guard.state).toEqual({ era: era1, highSeq: 2 }); // high-water tracked per write
+
+    // Fresh store (restart) over the same base + same guard: seq(2) == highSeq(2) ⇒ no rotation.
+    const head = await new ChangelogStore(base, { eraGuard: guard }).changelogHead();
+    expect(head.era).toBe(era1);
+    expect(head.seq).toBe(2);
+    await base.close();
+  });
+
+  it('era-restore guard: a wipe (era absent) mints a fresh era and resets the guard, not a rollback', async () => {
+    class MemGuard implements ChangelogEraGuard {
+      state: { era: string; highSeq: number } | null;
+      constructor(initial: { era: string; highSeq: number } | null) { this.state = initial; }
+      async load() { return this.state; }
+      async save(era: string, highSeq: number) { this.state = { era, highSeq }; }
+    }
+    // Guard remembers a prior era at high seq, but the store was wiped (no era/markers).
+    const base = new OxigraphStore();
+    const guard = new MemGuard({ era: 'old-era-uuid', highSeq: 99 });
+    const head = await new ChangelogStore(base, { eraGuard: guard }).changelogHead();
+    expect(head.seq).toBe(0);
+    expect(head.era).not.toBe('old-era-uuid');    // fresh era, not a rotation of the old one
+    expect(guard.state).toEqual({ era: head.era, highSeq: 0 });
     await base.close();
   });
 


### PR DESCRIPTION
Part of the **OT-RFC-59 sync changelog** series. Stacked on `feat/rfc59-changelog-wire` (→ #1601). Closes the **§6 P0** surfaced by the responder-lane adversarial review.

## The bug
A file-level backup/restore rolls `seq` back **under the same era**. Neither the in-store era match nor the responder's `head.seq < sinceSeq` guard catches this once the restored node re-advances past a peer's cursor — the seqs now mean *different* changes and the peer silently skips the ones above the restore point. This blocks ever enabling the flag safely.

## Fix
An optional, injectable **`ChangelogEraGuard`** persists `(era, highSeq)` in a durable location **outside** the RDF store (so it survives a store restore). On seed, a `seq` that rolled back under the same era ⇒ **rotate the era** (mint new UUID, replace in-store `#era`) so every peer detects the change and full-resyncs. Otherwise the durable high-water advances (refreshed best-effort after each committed write; never fails a write). A wipe (era absent) mints a fresh era and resets the guard — not a rollback.

**Default-off preserved:** no guard injected ⇒ no restore detection (historical behavior). Enabling fleet-wide REQUIRES wiring a durable guard (e.g. `node-ui.db`-backed — survives a `store.nq` restore, works for external backends); that wiring lands with the §5.3 enable-path.

## Tests
+3 (rollback-under-same-era → rotate; normal restart → no rotation + high-water advance; wipe → fresh era). Storage suite 320 passed / 0 failed; live-Blazegraph integration 5 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
