### PR TITLE
feat(sync): OT-RFC-59 responder delta-serve core (readChangelogDeltaPage)

### DIFF
--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -6,10 +6,11 @@ import {
   validateSubGraphName,
   contextGraphCatalogUri,
 } from '@origintrail-official/dkg-core';
-import type { QueryOptions, TripleStore } from '@origintrail-official/dkg-storage';
+import type { QueryOptions, TripleStore, ChangelogReader, ChangeOp } from '@origintrail-official/dkg-storage';
 import { isSharedMemoryBucketDescendantDataGraph } from '../shared-memory-graphs.js';
 import type { SyncRow, SyncRowListMemo } from './snapshot-cache.js';
 import { SyncRowSnapshotBudgetError } from './snapshot-budget.js';
+import type { ChangelogSyncResponse, ChangelogDeltaRecord } from '../changelog/wire.js';
 
 export {
   createResponderSyncRowListMemo,
@@ -308,6 +309,141 @@ export async function readDurableMetaPage(params: {
   );
 }
 
+/** Response byte budget for one changelog delta page — keeps a page under the
+ * transport read cap (the requester loops for more). A single graph larger than
+ * this is still emitted alone rather than split across pages. */
+const DEFAULT_CHANGELOG_PAGE_BYTES = 4 * 1024 * 1024;
+
+/**
+ * The per-CG admission boundary shared by the durable-data phase and the
+ * changelog delta lane: the candidate-graph exclusions (wrong CG / top `_meta` /
+ * `/_shared_memory*` / `/_private`) and the RFC-49 `isAdmitted` gate
+ * (assertion-graph membership + child-CG descendant rejection). `assertionGraphs`
+ * is memoised per invocation, matching the original inline closure.
+ */
+function createAdmissionContext(store: TripleStore, contextGraphId: string): {
+  cgPrefix: string;
+  topMetaGraph: string;
+  isCandidateGraph: (graph: string) => boolean;
+  isAdmitted: (signal?: AbortSignal) => (graph: string) => Promise<boolean>;
+} {
+  const cgPrefix = contextGraphDataGraphUri(contextGraphId);
+  const topMetaGraph = contextGraphMetaGraphUri(contextGraphId);
+  const isCandidateGraph = (graph: string): boolean => {
+    if (graph !== cgPrefix && !graph.startsWith(`${cgPrefix}/`)) return false;
+    if (graph === topMetaGraph) return false;
+    // SWM graphs are the dedicated SWM phase's exclusive domain; `/_private` is
+    // never durable-served (see readDurableDataPage's original inline note).
+    if (graph.includes('/_shared_memory')) return false;
+    return !graph.includes('/_private');
+  };
+  let assertionGraphs: Set<string> | null = null;
+  const isAdmitted = (signal?: AbortSignal) => async (graph: string): Promise<boolean> => {
+    if (graph.includes('/assertion/')) {
+      assertionGraphs ??= await readAdmittedAssertionGraphs(store, contextGraphId, signal);
+      const assertionGraph = graph.endsWith('/_meta') ? graph.slice(0, -'/_meta'.length) : graph;
+      if (!assertionGraphs.has(assertionGraph)) return false;
+    }
+    return !(await isDescendantOfKnownChildContextGraph(store, cgPrefix, graph, signal));
+  };
+  return { cgPrefix, topMetaGraph, isCandidateGraph, isAdmitted };
+}
+
+/**
+ * OT-RFC-59 changelog delta lane (PROTOCOL_SYNC_CHANGELOG). Answers "what changed
+ * in this CG since (era, sinceSeq)?" from the append-only log instead of scanning
+ * the store. Reuses the SAME candidate exclusions + RFC-49 `isAdmitted` boundary
+ * as the durable-data phase, applied to BOTH upsert and drop records, so a graph
+ * — or its very existence — the requester may not host never leaks.
+ *
+ * Returns a `resync` directive on era mismatch / rollback / first contact (the
+ * requester then runs the existing bootstrap lane), else a byte-bounded `delta`
+ * page. Progress is `nextSeq` (scanned-through), never the record count, because
+ * `readChanges` is node-global and a CG-scoped page can be validly empty.
+ */
+export async function readChangelogDeltaPage(params: {
+  reader: ChangelogReader;
+  store: TripleStore;
+  contextGraphId: string;
+  sinceSeq: number;
+  requesterEra: string | null;
+  limit: number;
+  maxResponseBytes?: number;
+  signal?: AbortSignal;
+}): Promise<ChangelogSyncResponse> {
+  const head = await params.reader.changelogHead(
+    syncResponderStoreOptions(params.signal, 'sync.responder.changelogHead'),
+  );
+
+  // (1) First contact / era rotation (wipe, restore) / rollback ⇒ full resync.
+  if (
+    params.requesterEra == null ||
+    params.requesterEra !== head.era ||
+    head.seq < params.sinceSeq
+  ) {
+    return { kind: 'resync', era: head.era, headSeq: head.seq };
+  }
+
+  // (2) Node-global raw scan of the log since the requester's cursor.
+  const raw = await params.reader.readChanges(
+    params.sinceSeq,
+    params.limit,
+    syncResponderStoreOptions(params.signal, 'sync.responder.readChanges'),
+  );
+
+  // (3) Re-apply the candidate exclusions (readChanges bypassed every phase
+  // filter) and collapse to the latest op per graph (ascending seq ⇒ last wins).
+  const { isCandidateGraph, isAdmitted } = createAdmissionContext(params.store, params.contextGraphId);
+  const lastOp = new Map<string, { seq: number; op: ChangeOp }>();
+  for (const r of raw) {
+    if (!isCandidateGraph(r.graph)) continue; // wrong-CG / topMeta / SWM / private — hides other/private-CG URIs
+    lastOp.set(r.graph, { seq: r.seq, op: r.op });
+  }
+
+  // (4) Admit + serialise in SEQ order under a byte budget. Emitting ascending by
+  // seq makes `nextSeq = last-emitted seq` safe on a partial page: every graph
+  // with a smaller last-op seq is already emitted, so re-requesting from nextSeq
+  // never skips an un-emitted change.
+  const admit = isAdmitted(params.signal);
+  const ordered = [...lastOp.entries()]
+    .map(([graph, v]) => ({ graph, seq: v.seq, op: v.op }))
+    .sort((a, b) => a.seq - b.seq);
+  const budget = params.maxResponseBytes ?? DEFAULT_CHANGELOG_PAGE_BYTES;
+
+  const records: ChangelogDeltaRecord[] = [];
+  let bytes = 0;
+  let budgetStopped = false;
+  for (const { graph, seq, op } of ordered) {
+    if (!(await admit(graph))) continue; // unadmitted ⇒ omit URI + op entirely
+    if (op === 'drop') {
+      records.push({ seq, graph, op: 'drop' });
+      continue;
+    }
+    const quads = serializeResponderRows(
+      await readRowsAcrossGraphs(params.store, [graph], params.signal),
+    );
+    // Always include at least one record; otherwise stop before exceeding the
+    // budget (a single graph over budget is emitted alone, never split).
+    if (records.length > 0 && bytes + quads.length > budget) {
+      budgetStopped = true;
+      break;
+    }
+    bytes += quads.length;
+    records.push({ seq, graph, op: 'upsert', quads });
+  }
+
+  // (5) nextSeq: on a budget-truncated page, the last emitted record's seq; else
+  // the scanned-through high-water — head.seq if the scan drained the log,
+  // otherwise the max raw seq scanned (more remains beyond this window).
+  const scannedTo = raw.length > 0 ? raw[raw.length - 1].seq : head.seq;
+  const drained = raw.length < params.limit;
+  const nextSeq = budgetStopped
+    ? records[records.length - 1].seq
+    : drained ? head.seq : scannedTo;
+
+  return { kind: 'delta', era: head.era, headSeq: head.seq, nextSeq, records };
+}
+
 export async function readDurableDataPage(params: {
   store: TripleStore;
   graphList: readonly string[];
@@ -320,32 +456,12 @@ export async function readDurableDataPage(params: {
   rowListCacheScope?: string;
   refreshRowList?: boolean;
 }): Promise<SyncRow[]> {
-  const cgPrefix = contextGraphDataGraphUri(params.contextGraphId);
-  const topMetaGraph = contextGraphMetaGraphUri(params.contextGraphId);
-  const candidateGraphs = params.graphList.filter((graph) => {
-    if (graph !== cgPrefix && !graph.startsWith(`${cgPrefix}/`)) return false;
-    if (graph === topMetaGraph) return false;
-    // Shared-memory graphs (`/_shared_memory`, `/_shared_memory_meta`, including
-    // per-sub-graph buckets) are the EXCLUSIVE domain of the dedicated SWM phase
-    // (readSwmDataPage), which applies per-(graph,subject) REPLACE + the
-    // curator-skip. Serving them in the durable DATA phase makes the requester
-    // blind-UNION them, which (a) corrupts single-valued SWM into {v1,v2}, and
-    // (b) lets a curator reverse-sync its OWN CG's SWM from a member, polluting
-    // itself (devnet curator-converge Gate A) — and it leaks gated SWM to durable
-    // requesters. SWM is never served through the durable data phase.
-    if (graph.includes('/_shared_memory')) return false;
-    return !graph.includes('/_private');
-  }).sort(compareCodePoint);
-
-  let assertionGraphs: Set<string> | null = null;
-  const isAdmitted = (signal?: AbortSignal) => async (graph: string): Promise<boolean> => {
-    if (graph.includes('/assertion/')) {
-      assertionGraphs ??= await readAdmittedAssertionGraphs(params.store, params.contextGraphId, signal);
-      const assertionGraph = graph.endsWith('/_meta') ? graph.slice(0, -'/_meta'.length) : graph;
-      if (!assertionGraphs.has(assertionGraph)) return false;
-    }
-    return !(await isDescendantOfKnownChildContextGraph(params.store, cgPrefix, graph, signal));
-  };
+  // Admission context (candidate exclusions + RFC-49 `isAdmitted`) — extracted to
+  // a module factory so `readChangelogDeltaPage` reuses it verbatim. Behaviour
+  // here is byte-identical to the previous inline closures.
+  const { cgPrefix, topMetaGraph, isCandidateGraph, isAdmitted } =
+    createAdmissionContext(params.store, params.contextGraphId);
+  const candidateGraphs = params.graphList.filter(isCandidateGraph).sort(compareCodePoint);
 
   if (params.sinceBatchId == null) {
     return readPagedRowsAcrossGraphs(

--- a/packages/agent/test/changelog-delta-page.test.ts
+++ b/packages/agent/test/changelog-delta-page.test.ts
@@ -1,0 +1,162 @@
+/**
+ * OT-RFC-59 SC3 — readChangelogDeltaPage responder logic.
+ * Uses a real Oxigraph store (for content serving + the RFC-49 admission
+ * primitives) plus a fake ChangelogReader (to drive head/readChanges precisely).
+ */
+import { describe, it, expect } from 'vitest';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import type { ChangelogReader, ChangeRecord, ChangeOp } from '@origintrail-official/dkg-storage';
+import { contextGraphDataUri } from '@origintrail-official/dkg-core';
+import { readChangelogDeltaPage } from '../src/sync/responder/graph-plan.js';
+
+const CG = 'delta-test';
+const cgPrefix = contextGraphDataUri(CG);           // did:dkg:context-graph:delta-test
+const G1 = `${cgPrefix}/1`;
+const G2 = `${cgPrefix}/2`;
+
+class FakeReader implements ChangelogReader {
+  constructor(
+    private readonly headV: { era: string; seq: number },
+    private readonly changes: ChangeRecord[],
+  ) {}
+  async changelogHead() { return this.headV; }
+  async readChanges(sinceSeq: number, limit: number) {
+    return this.changes.filter((c) => c.seq > sinceSeq).slice(0, limit);
+  }
+}
+
+function rec(seq: number, graph: string, op: ChangeOp): ChangeRecord {
+  return { seq, graph, op };
+}
+
+async function storeWith(quads: Array<[string, string, string, string]>) {
+  const store = new OxigraphStore();
+  await store.insert(quads.map(([s, p, o, g]) => ({ subject: s, predicate: p, object: o, graph: g })));
+  return store;
+}
+
+describe('readChangelogDeltaPage — resync directives', () => {
+  it('resyncs on era mismatch', async () => {
+    const store = new OxigraphStore();
+    const resp = await readChangelogDeltaPage({
+      reader: new FakeReader({ era: 'E2', seq: 10 }, []),
+      store, contextGraphId: CG, sinceSeq: 4, requesterEra: 'E1', limit: 100,
+    });
+    expect(resp).toEqual({ kind: 'resync', era: 'E2', headSeq: 10 });
+    await store.close();
+  });
+
+  it('resyncs on first contact (era null)', async () => {
+    const store = new OxigraphStore();
+    const resp = await readChangelogDeltaPage({
+      reader: new FakeReader({ era: 'E1', seq: 10 }, []),
+      store, contextGraphId: CG, sinceSeq: 0, requesterEra: null, limit: 100,
+    });
+    expect(resp.kind).toBe('resync');
+    await store.close();
+  });
+
+  it('resyncs on rollback (head.seq < sinceSeq)', async () => {
+    const store = new OxigraphStore();
+    const resp = await readChangelogDeltaPage({
+      reader: new FakeReader({ era: 'E1', seq: 5 }, []),
+      store, contextGraphId: CG, sinceSeq: 8, requesterEra: 'E1', limit: 100,
+    });
+    expect(resp.kind).toBe('resync');
+    await store.close();
+  });
+});
+
+describe('readChangelogDeltaPage — delta serving', () => {
+  it('serves admitted upsert content + drop records, collapses per graph, nextSeq=head when drained', async () => {
+    const store = await storeWith([
+      ['urn:s1', 'urn:p', '"a"', G2],
+      ['urn:s2', 'urn:p', '"b"', G2],
+    ]);
+    // G1 upsert@1 then drop@3; G2 upsert@2. Collapse: G1→drop(3), G2→upsert(2).
+    const resp = await readChangelogDeltaPage({
+      reader: new FakeReader({ era: 'E1', seq: 3 }, [
+        rec(1, G1, 'upsert'), rec(2, G2, 'upsert'), rec(3, G1, 'drop'),
+      ]),
+      store, contextGraphId: CG, sinceSeq: 0, requesterEra: 'E1', limit: 100,
+    });
+    expect(resp.kind).toBe('delta');
+    if (resp.kind !== 'delta') return;
+    expect(resp.era).toBe('E1');
+    expect(resp.headSeq).toBe(3);
+    expect(resp.nextSeq).toBe(3);              // drained (3 < limit) ⇒ caught up to head
+    // Ascending by seq: G2 upsert (2) then G1 drop (3).
+    expect(resp.records.map((r) => [r.seq, r.op])).toEqual([[2, 'upsert'], [3, 'drop']]);
+    const g2 = resp.records.find((r) => r.graph === G2)!;
+    expect(g2.quads).toContain('urn:s1');
+    expect(g2.quads).toContain('urn:s2');
+    const g1 = resp.records.find((r) => r.graph === G1)!;
+    expect(g1.quads).toBeUndefined();          // drop carries no content
+    await store.close();
+  });
+
+  it('excludes wrong-CG / private / shared-memory graphs (no existence leak)', async () => {
+    const store = await storeWith([['urn:s', 'urn:p', '"v"', G1]]);
+    const other = `${contextGraphDataUri('other-cg')}/9`;
+    const priv = `${cgPrefix}/_private`;
+    const swm = `${cgPrefix}/_shared_memory`;
+    const resp = await readChangelogDeltaPage({
+      reader: new FakeReader({ era: 'E1', seq: 4 }, [
+        rec(1, G1, 'upsert'), rec(2, other, 'upsert'), rec(3, priv, 'upsert'), rec(4, swm, 'upsert'),
+      ]),
+      store, contextGraphId: CG, sinceSeq: 0, requesterEra: 'E1', limit: 100,
+    });
+    expect(resp.kind).toBe('delta');
+    if (resp.kind !== 'delta') return;
+    expect(resp.records.map((r) => r.graph)).toEqual([G1]); // only the in-CG data graph
+    expect(resp.nextSeq).toBe(4);              // still advances past the filtered window
+    await store.close();
+  });
+
+  it('nextSeq is the scanned high-water (not head) when the scan window is full', async () => {
+    const store = await storeWith([['urn:s', 'urn:p', '"v"', G1], ['urn:s2', 'urn:p', '"v"', G2]]);
+    // limit 1 ⇒ readChanges returns only seq 1; head is 2 ⇒ not drained.
+    const resp = await readChangelogDeltaPage({
+      reader: new FakeReader({ era: 'E1', seq: 2 }, [rec(1, G1, 'upsert'), rec(2, G2, 'upsert')]),
+      store, contextGraphId: CG, sinceSeq: 0, requesterEra: 'E1', limit: 1,
+    });
+    expect(resp.kind).toBe('delta');
+    if (resp.kind !== 'delta') return;
+    expect(resp.records.map((r) => r.seq)).toEqual([1]);
+    expect(resp.nextSeq).toBe(1);              // scanned-through, < headSeq(2) ⇒ requester loops
+    expect(resp.headSeq).toBe(2);
+    await store.close();
+  });
+
+  it('byte-bounds a page: a tiny budget emits one graph and stops at its seq', async () => {
+    const big = '"' + 'x'.repeat(500) + '"';
+    const store = await storeWith([
+      ['urn:a', 'urn:p', big, G1],
+      ['urn:b', 'urn:p', big, G2],
+    ]);
+    const resp = await readChangelogDeltaPage({
+      reader: new FakeReader({ era: 'E1', seq: 2 }, [rec(1, G1, 'upsert'), rec(2, G2, 'upsert')]),
+      store, contextGraphId: CG, sinceSeq: 0, requesterEra: 'E1', limit: 100,
+      maxResponseBytes: 100,                    // smaller than one graph's serialized quads
+    });
+    expect(resp.kind).toBe('delta');
+    if (resp.kind !== 'delta') return;
+    expect(resp.records).toHaveLength(1);       // first graph emitted alone (never split)
+    expect(resp.records[0].seq).toBe(1);
+    expect(resp.nextSeq).toBe(1);               // budget-truncated ⇒ last emitted seq
+    await store.close();
+  });
+
+  it('empty in-CG delta still advances nextSeq to head when drained', async () => {
+    const store = new OxigraphStore();
+    const resp = await readChangelogDeltaPage({
+      reader: new FakeReader({ era: 'E1', seq: 7 }, [rec(6, `${contextGraphDataUri('x')}/1`, 'upsert')]),
+      store, contextGraphId: CG, sinceSeq: 5, requesterEra: 'E1', limit: 100,
+    });
+    expect(resp.kind).toBe('delta');
+    if (resp.kind !== 'delta') return;
+    expect(resp.records).toHaveLength(0);
+    expect(resp.nextSeq).toBe(7);
+    await store.close();
+  });
+});


### PR DESCRIPTION
Part of the **OT-RFC-59 sync changelog** series. Stacked on `feat/rfc59-changelog-restore-guard` (→ #1604 → #1603 → #1602 → #1601). **First commit of the responder serve-side**; the flag-gated handler + registration (SC4) will be pushed to this same branch.

## What
`readChangelogDeltaPage` — the responder's changelog delta core — reusing the durable-data phase's RFC-49 admission boundary. Behaviour-preserving refactor + one new exported function; **no caller yet** (dormant until SC4 registers the handler).

- Extract the per-CG admission boundary (candidate-graph exclusions + the `isAdmitted` gate: assertion-graph membership + child-CG descendant rejection) from a `readDurableDataPage`-local closure into a module-scope `createAdmissionContext`. **Byte-identical** — all 50 existing responder tests pass.
- `readChangelogDeltaPage`: era-mismatch / rollback / first-contact ⇒ `resync`; else read the log since the cursor, re-apply the candidate exclusions (`readChanges` bypasses every phase filter), collapse to last-op-per-graph, and serve each admitted graph — reusing `isAdmitted` for **both upsert and drop** so a graph the requester may not host never leaks (existence or content). Reserved `urn:dkg:changelog` never appears.

## Adversarial-review fixes baked in
- **Byte-bounded** page (a graph over budget is emitted alone, never split).
- Progress is the scanned-through **`nextSeq`** (head when the scan drained, else the max raw seq) — never the record count, since `readChanges` is node-global.
- Emitting **ascending by seq** makes a truncated page's `nextSeq` safe: no un-emitted change is skipped on the next request.

## Tests
+8 (resync directives; collapse + admitted-content serving; wrong-CG / private / shared-memory existence-leak exclusion; scanned-high-water nextSeq; byte-bounding; empty-in-CG advance) + 50 existing responder tests (refactor is behaviour-preserving).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
