### PR TITLE
feat(chain): log which RPC endpoint served a call/tx (success-side attribution)

### DIFF
--- a/packages/chain/src/index.ts
+++ b/packages/chain/src/index.ts
@@ -49,6 +49,7 @@ export {
   noteRpcFailover,
   noteRpcExhaustion,
   notePreferredEndpoint,
+  noteRpcServed,
 } from './rpc-failover-log.js';
 export {
   HubResolutionCache,

--- a/packages/chain/src/index.ts
+++ b/packages/chain/src/index.ts
@@ -40,12 +40,12 @@ export {
 } from './chain-rpc-transport-error.js';
 export {
   // Surfaced for the daemon /api/status counter + the CLI failover loop.
-  // Test-only hooks (_reset*/_set*Clock) and internal helpers
-  // (classifyRpcFailoverError/rpcHost) are intentionally NOT re-exported from
-  // the package barrel — import them directly from rpc-failover-log.js in tests
-  // so process-wide-singleton test hooks don't become public API.
+  // Test-only hook exported so cross-package route tests can reset the exact
+  // package singleton that production code reads. Internal helpers
+  // (classifyRpcFailoverError/rpcHost) stay private.
   getRpcFailoverStats,
   type RpcFailoverStatsSnapshot,
+  _resetRpcFailoverStatsForTest,
   noteRpcFailover,
   noteRpcExhaustion,
   notePreferredEndpoint,

--- a/packages/chain/src/rpc-failover-client.ts
+++ b/packages/chain/src/rpc-failover-client.ts
@@ -239,9 +239,13 @@ export class RpcFailoverClient {
     return errorCode(err) === 'TIMEOUT' ? 'timeout' : 'error';
   }
 
-  private servedKey(phase: string, detail?: string): string {
-    const suffix = detail ? `|${detail}` : '';
-    return `${this.chainId()}|${phase}${suffix}`;
+  private servedWriteKey(phase: 'tx-preparation' | 'tx-broadcast' | 'receipt-lookup'): string {
+    return `${this.chainId()}|write|${phase}`;
+  }
+
+  private servedReadBucketKey(policy: ReadPolicy, skipPreferred: boolean): string {
+    const preference = skipPreferred ? 'transparent' : 'sticky';
+    return `${this.chainId()}|read-bucket|${policy}|${preference}`;
   }
 
   /**
@@ -427,7 +431,7 @@ export class RpcFailoverClient {
         // so it's preferred for the read-your-write ops that follow (the caller's
         // broadcast + receipt + confirming re-reads) AND for subsequent populates.
         attempt.recordSuccess();
-        noteRpcServed(`${label} preparation`, endpoint.rpcUrl, { key: this.servedKey('tx-preparation') });
+        noteRpcServed(`${label} preparation`, endpoint.rpcUrl, { mode: 'read', key: this.servedWriteKey('tx-preparation') });
         return signed;
       } catch (err) {
         if (!isRetryableRpcError(err)) throw err;
@@ -500,7 +504,7 @@ export class RpcFailoverClient {
               span.setAttribute('dkg.tx_hash', txHash);
               this.recordRpcOutcome('eth_sendRawTransaction', 'ok');
               attempt.recordSuccess();
-              noteRpcServed(`${label} broadcast`, endpoint.rpcUrl, { alwaysLog: true, key: this.servedKey('tx-broadcast') });
+              noteRpcServed(`${label} broadcast`, endpoint.rpcUrl, { mode: 'write' });
               return;
             } catch (err) {
               if (isKnownTransactionError(err)) {
@@ -509,7 +513,7 @@ export class RpcFailoverClient {
                 span.addEvent('broadcast.already_known', { attempt: i + 1 });
                 this.recordRpcOutcome('eth_sendRawTransaction', 'ok');
                 attempt.recordSuccess();
-                noteRpcServed(`${label} broadcast`, endpoint.rpcUrl, { alwaysLog: true, key: this.servedKey('tx-broadcast') });
+                noteRpcServed(`${label} broadcast`, endpoint.rpcUrl, { mode: 'write' });
                 return;
               }
               if (!isRetryableRpcError(err)) {
@@ -591,7 +595,7 @@ export class RpcFailoverClient {
                 // (no single winning endpoint), so we only note on a real
                 // receipt — the self-heal still polls every endpoint per tick.
                 attempt.recordSuccess();
-                noteRpcServed('receipt lookup', endpoint.rpcUrl, { key: this.servedKey('receipt-lookup') });
+                noteRpcServed('receipt lookup', endpoint.rpcUrl, { mode: 'read', key: this.servedWriteKey('receipt-lookup') });
                 return receipt;
               }
             } catch (err) {
@@ -691,7 +695,7 @@ export class RpcFailoverClient {
           continue;
         }
         attempt.recordSuccess();
-        noteRpcServed(label, endpoint.rpcUrl, { key: this.servedKey('read', `${policy}|${skipPreferred ? 'transparent' : 'sticky'}`) });
+        noteRpcServed(label, endpoint.rpcUrl, { mode: 'read', key: this.servedReadBucketKey(policy, skipPreferred) });
         return out;
       } catch (err) {
         if (!isRetryable(err)) throw err;

--- a/packages/chain/src/rpc-failover-client.ts
+++ b/packages/chain/src/rpc-failover-client.ts
@@ -239,6 +239,11 @@ export class RpcFailoverClient {
     return errorCode(err) === 'TIMEOUT' ? 'timeout' : 'error';
   }
 
+  private servedKey(phase: string, detail?: string): string {
+    const suffix = detail ? `|${detail}` : '';
+    return `${this.chainId()}|${phase}${suffix}`;
+  }
+
   /**
    * Single chain-RPC outcome boundary: records `dkg.chain.rpc.total` (and the
    * `dkg.chain.rpc.failover.total` exhaustion counter) with ONE identical,
@@ -422,7 +427,7 @@ export class RpcFailoverClient {
         // so it's preferred for the read-your-write ops that follow (the caller's
         // broadcast + receipt + confirming re-reads) AND for subsequent populates.
         attempt.recordSuccess();
-        noteRpcServed(`${label} preparation`, endpoint.rpcUrl);
+        noteRpcServed(`${label} preparation`, endpoint.rpcUrl, { key: this.servedKey('tx-preparation') });
         return signed;
       } catch (err) {
         if (!isRetryableRpcError(err)) throw err;
@@ -495,7 +500,7 @@ export class RpcFailoverClient {
               span.setAttribute('dkg.tx_hash', txHash);
               this.recordRpcOutcome('eth_sendRawTransaction', 'ok');
               attempt.recordSuccess();
-              noteRpcServed(`${label} broadcast`, endpoint.rpcUrl, true);
+              noteRpcServed(`${label} broadcast`, endpoint.rpcUrl, { alwaysLog: true, key: this.servedKey('tx-broadcast') });
               return;
             } catch (err) {
               if (isKnownTransactionError(err)) {
@@ -504,7 +509,7 @@ export class RpcFailoverClient {
                 span.addEvent('broadcast.already_known', { attempt: i + 1 });
                 this.recordRpcOutcome('eth_sendRawTransaction', 'ok');
                 attempt.recordSuccess();
-                noteRpcServed(`${label} broadcast`, endpoint.rpcUrl, true);
+                noteRpcServed(`${label} broadcast`, endpoint.rpcUrl, { alwaysLog: true, key: this.servedKey('tx-broadcast') });
                 return;
               }
               if (!isRetryableRpcError(err)) {
@@ -586,7 +591,7 @@ export class RpcFailoverClient {
                 // (no single winning endpoint), so we only note on a real
                 // receipt — the self-heal still polls every endpoint per tick.
                 attempt.recordSuccess();
-                noteRpcServed('receipt lookup', endpoint.rpcUrl);
+                noteRpcServed('receipt lookup', endpoint.rpcUrl, { key: this.servedKey('receipt-lookup') });
                 return receipt;
               }
             } catch (err) {
@@ -686,7 +691,7 @@ export class RpcFailoverClient {
           continue;
         }
         attempt.recordSuccess();
-        noteRpcServed(label, endpoint.rpcUrl);
+        noteRpcServed(label, endpoint.rpcUrl, { key: this.servedKey('read', `${policy}|${skipPreferred ? 'transparent' : 'sticky'}`) });
         return out;
       } catch (err) {
         if (!isRetryable(err)) throw err;

--- a/packages/chain/src/rpc-failover-client.ts
+++ b/packages/chain/src/rpc-failover-client.ts
@@ -43,7 +43,7 @@ import { JsonRpcProvider, Wallet, Contract, ethers } from 'ethers';
 import { withSpan, getMetrics } from '@origintrail-official/dkg-core';
 import { withTimeout, isRetryableRpcError, isKnownTransactionError } from './evm-adapter-rpc.js';
 import { errorCode, errorMessage } from './evm-adapter-errors.js';
-import { noteRpcFailover, noteRpcExhaustion, notePreferredEndpoint, rpcHost } from './rpc-failover-log.js';
+import { noteRpcFailover, noteRpcExhaustion, notePreferredEndpoint, noteRpcServed, rpcHost } from './rpc-failover-log.js';
 import { EndpointStickiness, type StickinessIntent } from './endpoint-stickiness.js';
 import { ChainRpcTransportError } from './chain-rpc-transport-error.js';
 import { withRpcUsageConsumer } from './rpc-usage.js';
@@ -422,6 +422,7 @@ export class RpcFailoverClient {
         // so it's preferred for the read-your-write ops that follow (the caller's
         // broadcast + receipt + confirming re-reads) AND for subsequent populates.
         attempt.recordSuccess();
+        noteRpcServed(`${label} preparation`, endpoint.rpcUrl);
         return signed;
       } catch (err) {
         if (!isRetryableRpcError(err)) throw err;
@@ -494,6 +495,7 @@ export class RpcFailoverClient {
               span.setAttribute('dkg.tx_hash', txHash);
               this.recordRpcOutcome('eth_sendRawTransaction', 'ok');
               attempt.recordSuccess();
+              noteRpcServed(`${label} broadcast`, endpoint.rpcUrl, true);
               return;
             } catch (err) {
               if (isKnownTransactionError(err)) {
@@ -502,6 +504,7 @@ export class RpcFailoverClient {
                 span.addEvent('broadcast.already_known', { attempt: i + 1 });
                 this.recordRpcOutcome('eth_sendRawTransaction', 'ok');
                 attempt.recordSuccess();
+                noteRpcServed(`${label} broadcast`, endpoint.rpcUrl, true);
                 return;
               }
               if (!isRetryableRpcError(err)) {
@@ -583,6 +586,7 @@ export class RpcFailoverClient {
                 // (no single winning endpoint), so we only note on a real
                 // receipt — the self-heal still polls every endpoint per tick.
                 attempt.recordSuccess();
+                noteRpcServed('receipt lookup', endpoint.rpcUrl);
                 return receipt;
               }
             } catch (err) {
@@ -682,6 +686,7 @@ export class RpcFailoverClient {
           continue;
         }
         attempt.recordSuccess();
+        noteRpcServed(label, endpoint.rpcUrl);
         return out;
       } catch (err) {
         if (!isRetryable(err)) throw err;

--- a/packages/chain/src/rpc-failover-log.ts
+++ b/packages/chain/src/rpc-failover-log.ts
@@ -100,6 +100,10 @@ interface MutableStats {
 const MAX_TRACKED_HOSTS = 64;
 const MAX_DEDUP_KEYS = 256;
 
+export type RpcServedAttribution =
+  | { mode: 'read'; key: string }
+  | { mode: 'write' };
+
 function freshStats(): MutableStats {
   return {
     failovers: 0,
@@ -302,23 +306,24 @@ export function notePreferredEndpoint(label: string, preferredUrl: string): void
  *
  * @param label   human operation label, e.g. `V10 publish broadcast`
  * @param servedUrl the RPC URL that served the call (reduced to host before logging)
- * @param options `alwaysLog` logs every success (writes); `key` is the stable
- *                low-cardinality operation identity used for read shift gating
+ * @param attribution explicit read/write attribution mode. Reads require a
+ *                    stable low-cardinality suppression key; writes log every
+ *                    success for per-transaction attribution.
  */
 export function noteRpcServed(
   label: string,
   servedUrl: string,
-  options: boolean | { alwaysLog?: boolean; key?: string } = false,
+  attribution: RpcServedAttribution,
 ): void {
   try {
-    const alwaysLog = typeof options === 'boolean' ? options : options.alwaysLog === true;
-    const key = typeof options === 'boolean' ? label : (options.key ?? label);
     const host = rpcHost(servedUrl);
     bump(stats.servedByEndpointHost, host, MAX_TRACKED_HOSTS);
-    const prior = lastServedByKey.get(key);
+    const alwaysLog = attribution.mode === 'write';
+    const key = attribution.mode === 'read' ? attribution.key : undefined;
+    const prior = key === undefined ? undefined : lastServedByKey.get(key);
     const changed = prior !== host;
     if (!alwaysLog && !changed) return; // same provider on a read — count only, don't log
-    if (!alwaysLog) {
+    if (key !== undefined) {
       if (lastServedByKey.has(key)) lastServedByKey.delete(key);
       lastServedByKey.set(key, host);
       while (lastServedByKey.size > MAX_TRACKED_HOSTS) {

--- a/packages/chain/src/rpc-failover-log.ts
+++ b/packages/chain/src/rpc-failover-log.ts
@@ -88,6 +88,11 @@ interface MutableStats {
   preferredEstablishments: number;
   byErrorClass: Map<RpcFailoverErrorClass, number>;
   byEndpointHost: Map<string, number>;
+  // Per-host count of successful calls each endpoint SERVED — symmetric with
+  // `byEndpointHost` (which counts failures). This is the operator's "which
+  // provider is actually carrying the traffic" distribution, the success-side
+  // complement to the failover log.
+  servedByEndpointHost: Map<string, number>;
 }
 
 /** Cap the per-host map so a pathological churn of hosts can't grow it
@@ -102,10 +107,16 @@ function freshStats(): MutableStats {
     preferredEstablishments: 0,
     byErrorClass: new Map(),
     byEndpointHost: new Map(),
+    servedByEndpointHost: new Map(),
   };
 }
 
 let stats: MutableStats = freshStats();
+
+// Last host that successfully served each operation label — drives the
+// log-on-change gate for high-volume reads (so we log a provider shift, not
+// every call). Bounded like the host map so a churn of labels can't grow it.
+const lastServedByLabel = new Map<string, string>();
 
 function bump(map: Map<string, number>, key: string, cap: number): void {
   if (!map.has(key) && map.size >= cap) return; // bounded; drop new keys past the cap
@@ -119,6 +130,7 @@ export interface RpcFailoverStatsSnapshot {
   preferredEstablishments: number;
   byErrorClass: Record<string, number>;
   byEndpointHost: Record<string, number>;
+  servedByEndpointHost: Record<string, number>;
 }
 
 export function getRpcFailoverStats(): RpcFailoverStatsSnapshot {
@@ -128,6 +140,7 @@ export function getRpcFailoverStats(): RpcFailoverStatsSnapshot {
     preferredEstablishments: stats.preferredEstablishments,
     byErrorClass: Object.fromEntries(stats.byErrorClass),
     byEndpointHost: Object.fromEntries(stats.byEndpointHost),
+    servedByEndpointHost: Object.fromEntries(stats.servedByEndpointHost),
   };
 }
 
@@ -135,6 +148,7 @@ export function getRpcFailoverStats(): RpcFailoverStatsSnapshot {
 export function _resetRpcFailoverStatsForTest(): void {
   stats = freshStats();
   dedup.clear();
+  lastServedByLabel.clear();
   clockOverride = undefined;
 }
 
@@ -267,5 +281,43 @@ export function notePreferredEndpoint(label: string, preferredUrl: string): void
     }
   } catch {
     // Observability must never break the failover path.
+  }
+}
+
+/**
+ * Record + log which endpoint SERVED a successful call/tx — the success-side
+ * complement to {@link noteRpcFailover}. Host-only, never-throwing, safe on the
+ * hot success path. Answers "which provider is actually carrying the traffic",
+ * which the failure-only failover log cannot.
+ *
+ *  - `alwaysLog` (tx / write broadcasts): logs EVERY success. Broadcasts are
+ *    low-volume and operators want per-tx attribution — "which provider
+ *    broadcast this tx".
+ *  - default (reads): high-volume, so it logs ONLY when the serving host CHANGES
+ *    for this label (a provider shift), never once per call. The full per-host
+ *    distribution is always available via {@link getRpcFailoverStats}
+ *    (`servedByEndpointHost`) and `/api/status`.
+ *
+ * @param label      operation label, e.g. `V10 publish broadcast`
+ * @param servedUrl  the RPC URL that served the call (reduced to host before logging)
+ * @param alwaysLog  log every success (writes); default logs only on host change (reads)
+ */
+export function noteRpcServed(label: string, servedUrl: string, alwaysLog = false): void {
+  try {
+    const host = rpcHost(servedUrl);
+    bump(stats.servedByEndpointHost, host, MAX_TRACKED_HOSTS);
+    const prior = lastServedByLabel.get(label);
+    const changed = prior !== host;
+    if (!alwaysLog && !changed) return; // same provider on a read — count only, don't log
+    if (lastServedByLabel.has(label) || lastServedByLabel.size < MAX_TRACKED_HOSTS) {
+      lastServedByLabel.set(label, host);
+    }
+    // Mark a genuine provider SHIFT (had a prior, different host) — not the first
+    // sighting, and not the always-log tx path.
+    const shift = changed && prior !== undefined && !alwaysLog;
+    // eslint-disable-next-line no-console
+    console.log(`[chain] RPC served: ${label} via ${host}${shift ? ' (provider shift)' : ''}`);
+  } catch {
+    // Observability must never break the call path.
   }
 }

--- a/packages/chain/src/rpc-failover-log.ts
+++ b/packages/chain/src/rpc-failover-log.ts
@@ -113,10 +113,12 @@ function freshStats(): MutableStats {
 
 let stats: MutableStats = freshStats();
 
-// Last host that successfully served each operation label — drives the
+// Last host that successfully served each stable operation key — drives the
 // log-on-change gate for high-volume reads (so we log a provider shift, not
-// every call). Bounded like the host map so a churn of labels can't grow it.
-const lastServedByLabel = new Map<string, string>();
+// every call). This deliberately does NOT key by the human log label: call-site
+// wording is presentation, not process-wide state. Bounded with LRU eviction so
+// overflow labels can still suppress repeated same-host read logs.
+const lastServedByKey = new Map<string, string>();
 
 function bump(map: Map<string, number>, key: string, cap: number): void {
   if (!map.has(key) && map.size >= cap) return; // bounded; drop new keys past the cap
@@ -148,7 +150,7 @@ export function getRpcFailoverStats(): RpcFailoverStatsSnapshot {
 export function _resetRpcFailoverStatsForTest(): void {
   stats = freshStats();
   dedup.clear();
-  lastServedByLabel.clear();
+  lastServedByKey.clear();
   clockOverride = undefined;
 }
 
@@ -298,19 +300,32 @@ export function notePreferredEndpoint(label: string, preferredUrl: string): void
  *    distribution is always available via {@link getRpcFailoverStats}
  *    (`servedByEndpointHost`) and `/api/status`.
  *
- * @param label      operation label, e.g. `V10 publish broadcast`
- * @param servedUrl  the RPC URL that served the call (reduced to host before logging)
- * @param alwaysLog  log every success (writes); default logs only on host change (reads)
+ * @param label   human operation label, e.g. `V10 publish broadcast`
+ * @param servedUrl the RPC URL that served the call (reduced to host before logging)
+ * @param options `alwaysLog` logs every success (writes); `key` is the stable
+ *                low-cardinality operation identity used for read shift gating
  */
-export function noteRpcServed(label: string, servedUrl: string, alwaysLog = false): void {
+export function noteRpcServed(
+  label: string,
+  servedUrl: string,
+  options: boolean | { alwaysLog?: boolean; key?: string } = false,
+): void {
   try {
+    const alwaysLog = typeof options === 'boolean' ? options : options.alwaysLog === true;
+    const key = typeof options === 'boolean' ? label : (options.key ?? label);
     const host = rpcHost(servedUrl);
     bump(stats.servedByEndpointHost, host, MAX_TRACKED_HOSTS);
-    const prior = lastServedByLabel.get(label);
+    const prior = lastServedByKey.get(key);
     const changed = prior !== host;
     if (!alwaysLog && !changed) return; // same provider on a read — count only, don't log
-    if (lastServedByLabel.has(label) || lastServedByLabel.size < MAX_TRACKED_HOSTS) {
-      lastServedByLabel.set(label, host);
+    if (!alwaysLog) {
+      if (lastServedByKey.has(key)) lastServedByKey.delete(key);
+      lastServedByKey.set(key, host);
+      while (lastServedByKey.size > MAX_TRACKED_HOSTS) {
+        const oldest = lastServedByKey.keys().next().value;
+        if (oldest === undefined || oldest === key) break;
+        lastServedByKey.delete(oldest);
+      }
     }
     // Mark a genuine provider SHIFT (had a prior, different host) — not the first
     // sighting, and not the always-log tx path.

--- a/packages/chain/test/rpc-failover-client.unit.test.ts
+++ b/packages/chain/test/rpc-failover-client.unit.test.ts
@@ -97,6 +97,22 @@ describe('RpcFailoverClient.read / readContract — policy matrix applied + view
     expect(getRpcFailoverStats().servedByEndpointHost).toEqual({ 'served.example': 1 });
   });
 
+  it('read success logging is bucketed by chain, read policy, and preference mode', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const primary = { read: recorder(async () => 'PRIMARY') };
+      const client = makeClient([primary], ['https://served.example/key']);
+
+      await client.read('token.allowance', (p: any) => p.read());
+      await client.read('hub.version', (p: any) => p.read());
+
+      expect(logSpy).toHaveBeenCalledTimes(1);
+      expect(getRpcFailoverStats().servedByEndpointHost).toEqual({ 'served.example': 2 });
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
   it('read MULTI-RPC pointRead: an attempt over the 4s cap aborts and fails over', async () => {
     vi.useFakeTimers();
     const slow = recorder(() => new Promise<string>((r) => { setTimeout(() => r('PRIMARY'), 5_000); }));
@@ -323,6 +339,7 @@ describe('RpcFailoverClient.populateAndSign — #870 signer propagation + estima
     const passedSigner: any = signPopulated.calls[0][0];
     expect(passedSigner.address).toBe(SIGNER_ADDR); // signed by the right wallet (no mid-flight rotation)
     expect(passedSigner.boundTo).toBe(providerObj);  // bound to the active provider
+    expect(getRpcFailoverStats().servedByEndpointHost).toEqual({ 'only.example': 1 });
   });
 
   it('a RETRYABLE gas-estimate error rethrows and FAILS OVER when another provider remains (buffer applied on the backup)', async () => {

--- a/packages/chain/test/rpc-failover-client.unit.test.ts
+++ b/packages/chain/test/rpc-failover-client.unit.test.ts
@@ -41,7 +41,7 @@ import {
   RPC_RECEIPT_ATTEMPT_TIMEOUT_MS,
   RPC_TRANSACTION_POPULATION_ATTEMPT_TIMEOUT_MS,
 } from '../src/evm-adapter-constants.js';
-import { _resetRpcFailoverStatsForTest } from '../src/rpc-failover-log.js';
+import { _resetRpcFailoverStatsForTest, getRpcFailoverStats } from '../src/rpc-failover-log.js';
 import { recorder, retryable429, NEVER_SIGN, makeClient } from './rpc-failover-test-helpers.js';
 
 const callExceptionErr = (msg = 'execution reverted: TooLowAllowance') => {
@@ -87,6 +87,15 @@ describe('resolveCapMs — the named timeout-policy matrix (PLAN §3.2)', () => 
 // ── read / readContract — the matrix APPLIED + view classifier ───────────────
 describe('RpcFailoverClient.read / readContract — policy matrix applied + view classifier', () => {
   afterEach(() => { vi.useRealTimers(); });
+
+  it('successful read records the serving endpoint host', async () => {
+    const primary = { read: recorder(async () => 'PRIMARY') };
+    const client = makeClient([primary], ['https://served.example/key']);
+
+    await expect(client.read('human read label', (p: any) => p.read())).resolves.toBe('PRIMARY');
+
+    expect(getRpcFailoverStats().servedByEndpointHost).toEqual({ 'served.example': 1 });
+  });
 
   it('read MULTI-RPC pointRead: an attempt over the 4s cap aborts and fails over', async () => {
     vi.useFakeTimers();
@@ -189,6 +198,15 @@ describe('RpcFailoverClient.read / readContract — policy matrix applied + view
 
 // ── broadcast (write transport) ──────────────────────────────────────────────
 describe('RpcFailoverClient.broadcast — idempotent short-circuit + typed exhaustion', () => {
+  it('successful broadcast records the broadcast endpoint host', async () => {
+    const primary = { broadcastTransaction: recorder(async () => undefined) };
+    const client = makeClient([primary], ['https://broadcast.example/key']);
+
+    await expect(client.broadcast('0xsigned', '0xhash', 'unit write')).resolves.toBeUndefined();
+
+    expect(getRpcFailoverStats().servedByEndpointHost).toEqual({ 'broadcast.example': 1 });
+  });
+
   it('an isKnownTransactionError is treated as SUCCESS (idempotent re-broadcast) — no failover', async () => {
     const primary = { broadcastTransaction: recorder(async () => { throw knownTxError(); }) };
     const backup = { broadcastTransaction: recorder(async () => undefined) };
@@ -196,6 +214,7 @@ describe('RpcFailoverClient.broadcast — idempotent short-circuit + typed exhau
 
     await expect(client.broadcast('0xsigned', '0xhash', 'unit write')).resolves.toBeUndefined();
     expect(primary.broadcastTransaction.calls).toHaveLength(1);
+    expect(getRpcFailoverStats().servedByEndpointHost).toEqual({ 'primary.example': 1 });
     // "already known" = the byte-identical tx is already in the mempool → success.
     // The set-retry MUST NOT fail over to a second endpoint and re-submit.
     expect(backup.broadcastTransaction.calls).toEqual([]);
@@ -237,6 +256,7 @@ describe('RpcFailoverClient.getReceipt — sawNonErrorResponse/null vs RPC_RECEI
 
     await expect(client.getReceipt('0xhash')).resolves.toBe(receipt);
     expect(backup.getTransactionReceipt.calls).toEqual([]); // found on the primary
+    expect(getRpcFailoverStats().servedByEndpointHost).toEqual({ 'primary.example': 1 });
   });
 
   it('a backend that RESPONDS with null (not yet mined) yields null — NOT an exhaustion — even after an earlier error', async () => {
@@ -250,6 +270,7 @@ describe('RpcFailoverClient.getReceipt — sawNonErrorResponse/null vs RPC_RECEI
     await expect(client.getReceipt('0xhash')).resolves.toBeNull();
     expect(primary.getTransactionReceipt.calls).toHaveLength(1);
     expect(backup.getTransactionReceipt.calls).toHaveLength(1);
+    expect(getRpcFailoverStats().servedByEndpointHost).toEqual({});
   });
 
   it('all endpoints ERRORED → RPC_RECEIPT_LOOKUP_FAILED, DISTINCT from RPC_ENDPOINTS_EXHAUSTED', async () => {

--- a/packages/chain/test/rpc-failover-log.test.ts
+++ b/packages/chain/test/rpc-failover-log.test.ts
@@ -126,8 +126,8 @@ describe('rpc-failover-log', () => {
     afterEach(() => { logSpy.mockRestore(); });
 
     it('counts every successful call per host, host-only (no key leak)', () => {
-      noteRpcServed('read cgKaCount', 'https://a.example/secretkey');
-      noteRpcServed('read cgKaCount', 'https://a.example/secretkey');
+      noteRpcServed('read cgKaCount', 'https://a.example/secretkey', { mode: 'read', key: 'read-cg-count' });
+      noteRpcServed('read cgKaCount', 'https://a.example/secretkey', { mode: 'read', key: 'read-cg-count' });
       const snap = getRpcFailoverStats();
       expect(snap.servedByEndpointHost).toEqual({ 'a.example': 2 });
       // never the full URL / key
@@ -136,12 +136,12 @@ describe('rpc-failover-log', () => {
     });
 
     it('reads log only on a provider CHANGE, not per call', () => {
-      noteRpcServed('read x', 'https://a.example');   // first sighting -> logs
-      noteRpcServed('read x', 'https://a.example');   // same host    -> silent
-      noteRpcServed('read x', 'https://a.example');   // same host    -> silent
+      noteRpcServed('read x', 'https://a.example', { mode: 'read', key: 'read-x' });   // first sighting -> logs
+      noteRpcServed('read x', 'https://a.example', { mode: 'read', key: 'read-x' });   // same host    -> silent
+      noteRpcServed('read x', 'https://a.example', { mode: 'read', key: 'read-x' });   // same host    -> silent
       expect(logSpy).toHaveBeenCalledTimes(1);
       expect(String(logSpy.mock.calls[0][0])).toContain('via a.example');
-      noteRpcServed('read x', 'https://b.example');   // shift        -> logs
+      noteRpcServed('read x', 'https://b.example', { mode: 'read', key: 'read-x' });   // shift        -> logs
       expect(logSpy).toHaveBeenCalledTimes(2);
       expect(String(logSpy.mock.calls[1][0])).toContain('via b.example (provider shift)');
       // ...but every call was still counted
@@ -149,8 +149,8 @@ describe('rpc-failover-log', () => {
     });
 
     it('uses a stable key for read suppression, independent from display-label wording', () => {
-      noteRpcServed('read cgKaCount', 'https://a.example', { key: 'evm:31337|read|cg-count' });
-      noteRpcServed('read cgKaCount renamed', 'https://a.example', { key: 'evm:31337|read|cg-count' });
+      noteRpcServed('read cgKaCount', 'https://a.example', { mode: 'read', key: 'evm:31337|read|cg-count' });
+      noteRpcServed('read cgKaCount renamed', 'https://a.example', { mode: 'read', key: 'evm:31337|read|cg-count' });
 
       expect(logSpy).toHaveBeenCalledTimes(1);
       expect(getRpcFailoverStats().servedByEndpointHost).toEqual({ 'a.example': 2 });
@@ -158,27 +158,27 @@ describe('rpc-failover-log', () => {
 
     it('keeps overflow read labels bounded without logging every repeated same-host success', () => {
       for (let i = 0; i < 64; i += 1) {
-        noteRpcServed(`read ${i}`, 'https://seed.example');
+        noteRpcServed(`read ${i}`, 'https://seed.example', { mode: 'read', key: `read-${i}` });
       }
       logSpy.mockClear();
 
-      noteRpcServed('read overflow', 'https://overflow.example');
-      noteRpcServed('read overflow', 'https://overflow.example');
+      noteRpcServed('read overflow', 'https://overflow.example', { mode: 'read', key: 'read-overflow' });
+      noteRpcServed('read overflow', 'https://overflow.example', { mode: 'read', key: 'read-overflow' });
 
       expect(logSpy).toHaveBeenCalledTimes(1);
       expect(getRpcFailoverStats().servedByEndpointHost['overflow.example']).toBe(2);
     });
 
     it('tx broadcasts (alwaysLog) log every success for per-tx attribution', () => {
-      noteRpcServed('V10 publish broadcast', 'https://a.example', true);
-      noteRpcServed('V10 publish broadcast', 'https://a.example', true); // same host, still logs
+      noteRpcServed('V10 publish broadcast', 'https://a.example', { mode: 'write' });
+      noteRpcServed('V10 publish broadcast', 'https://a.example', { mode: 'write' }); // same host, still logs
       expect(logSpy).toHaveBeenCalledTimes(2);
       expect(String(logSpy.mock.calls[0][0])).toBe('[chain] RPC served: V10 publish broadcast via a.example');
     });
 
     it('never throws even if console.log throws — the call path must not abort', () => {
       logSpy.mockImplementation(() => { throw new Error('sink down'); });
-      expect(() => noteRpcServed('read x', 'https://a.example', true)).not.toThrow();
+      expect(() => noteRpcServed('read x', 'https://a.example', { mode: 'write' })).not.toThrow();
       expect(getRpcFailoverStats().servedByEndpointHost['a.example']).toBe(1);
     });
   });

--- a/packages/chain/test/rpc-failover-log.test.ts
+++ b/packages/chain/test/rpc-failover-log.test.ts
@@ -148,6 +148,27 @@ describe('rpc-failover-log', () => {
       expect(getRpcFailoverStats().servedByEndpointHost).toEqual({ 'a.example': 3, 'b.example': 1 });
     });
 
+    it('uses a stable key for read suppression, independent from display-label wording', () => {
+      noteRpcServed('read cgKaCount', 'https://a.example', { key: 'evm:31337|read|cg-count' });
+      noteRpcServed('read cgKaCount renamed', 'https://a.example', { key: 'evm:31337|read|cg-count' });
+
+      expect(logSpy).toHaveBeenCalledTimes(1);
+      expect(getRpcFailoverStats().servedByEndpointHost).toEqual({ 'a.example': 2 });
+    });
+
+    it('keeps overflow read labels bounded without logging every repeated same-host success', () => {
+      for (let i = 0; i < 64; i += 1) {
+        noteRpcServed(`read ${i}`, 'https://seed.example');
+      }
+      logSpy.mockClear();
+
+      noteRpcServed('read overflow', 'https://overflow.example');
+      noteRpcServed('read overflow', 'https://overflow.example');
+
+      expect(logSpy).toHaveBeenCalledTimes(1);
+      expect(getRpcFailoverStats().servedByEndpointHost['overflow.example']).toBe(2);
+    });
+
     it('tx broadcasts (alwaysLog) log every success for per-tx attribution', () => {
       noteRpcServed('V10 publish broadcast', 'https://a.example', true);
       noteRpcServed('V10 publish broadcast', 'https://a.example', true); // same host, still logs

--- a/packages/chain/test/rpc-failover-log.test.ts
+++ b/packages/chain/test/rpc-failover-log.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   noteRpcFailover,
   noteRpcExhaustion,
+  noteRpcServed,
   classifyRpcFailoverError,
   rpcHost,
   getRpcFailoverStats,
@@ -114,7 +115,50 @@ describe('rpc-failover-log', () => {
         preferredEstablishments: 0,
         byErrorClass: { THROTTLE_429: 1 },
         byEndpointHost: { 'a.example': 1 },
+        servedByEndpointHost: {},
       });
+    });
+  });
+
+  describe('noteRpcServed', () => {
+    let logSpy: ReturnType<typeof vi.spyOn>;
+    beforeEach(() => { logSpy = vi.spyOn(console, 'log').mockImplementation(() => {}); });
+    afterEach(() => { logSpy.mockRestore(); });
+
+    it('counts every successful call per host, host-only (no key leak)', () => {
+      noteRpcServed('read cgKaCount', 'https://a.example/secretkey');
+      noteRpcServed('read cgKaCount', 'https://a.example/secretkey');
+      const snap = getRpcFailoverStats();
+      expect(snap.servedByEndpointHost).toEqual({ 'a.example': 2 });
+      // never the full URL / key
+      const logged = logSpy.mock.calls.map((c) => String(c[0])).join('\n');
+      expect(logged).not.toContain('secretkey');
+    });
+
+    it('reads log only on a provider CHANGE, not per call', () => {
+      noteRpcServed('read x', 'https://a.example');   // first sighting -> logs
+      noteRpcServed('read x', 'https://a.example');   // same host    -> silent
+      noteRpcServed('read x', 'https://a.example');   // same host    -> silent
+      expect(logSpy).toHaveBeenCalledTimes(1);
+      expect(String(logSpy.mock.calls[0][0])).toContain('via a.example');
+      noteRpcServed('read x', 'https://b.example');   // shift        -> logs
+      expect(logSpy).toHaveBeenCalledTimes(2);
+      expect(String(logSpy.mock.calls[1][0])).toContain('via b.example (provider shift)');
+      // ...but every call was still counted
+      expect(getRpcFailoverStats().servedByEndpointHost).toEqual({ 'a.example': 3, 'b.example': 1 });
+    });
+
+    it('tx broadcasts (alwaysLog) log every success for per-tx attribution', () => {
+      noteRpcServed('V10 publish broadcast', 'https://a.example', true);
+      noteRpcServed('V10 publish broadcast', 'https://a.example', true); // same host, still logs
+      expect(logSpy).toHaveBeenCalledTimes(2);
+      expect(String(logSpy.mock.calls[0][0])).toBe('[chain] RPC served: V10 publish broadcast via a.example');
+    });
+
+    it('never throws even if console.log throws — the call path must not abort', () => {
+      logSpy.mockImplementation(() => { throw new Error('sink down'); });
+      expect(() => noteRpcServed('read x', 'https://a.example', true)).not.toThrow();
+      expect(getRpcFailoverStats().servedByEndpointHost['a.example']).toBe(1);
     });
   });
 });

--- a/packages/cli/src/daemon/routes/status.ts
+++ b/packages/cli/src/daemon/routes/status.ts
@@ -734,6 +734,11 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
             rpcFailovers: rpcFailoverStats.failovers,
             rpcExhaustions: rpcFailoverStats.exhaustions,
             rpcFailoversByClass: rpcFailoverStats.byErrorClass,
+            // Per-provider distribution (host-only). `served` is the success side
+            // — which endpoint is actually carrying the traffic — and `failed` is
+            // the failover side. Together they show provider health at a glance.
+            rpcServedByEndpointHost: rpcFailoverStats.servedByEndpointHost,
+            rpcFailoversByEndpointHost: rpcFailoverStats.byEndpointHost,
             // Endpoint-stickiness: times the client stuck to a backup after a
             // failover (a rising count = a configured primary is degraded).
             rpcPreferredEstablishments: rpcFailoverStats.preferredEstablishments,

--- a/packages/cli/test/status-route-rpc.test.ts
+++ b/packages/cli/test/status-route-rpc.test.ts
@@ -22,7 +22,15 @@
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { createServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
-import { noteRpcFailover, noteRpcExhaustion, notePreferredEndpoint, getRpcFailoverStats, ChainRpcTransportError } from '@origintrail-official/dkg-chain';
+import {
+  noteRpcFailover,
+  noteRpcExhaustion,
+  notePreferredEndpoint,
+  noteRpcServed,
+  getRpcFailoverStats,
+  ChainRpcTransportError,
+} from '@origintrail-official/dkg-chain';
+import { _resetRpcFailoverStatsForTest } from '../../chain/src/rpc-failover-log.js';
 import { computeNetworkId } from '../../core/src/genesis.js';
 import { getSharedContext } from '../../chain/test/evm-test-context.js';
 import { loadNetworkConfig } from '../src/config.js';
@@ -165,6 +173,7 @@ describe('/api/status selected overlay details', () => {
 
   it('surfaces LIVE multi-RPC failover counters on /api/status (not hardcoded zero)', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     const network = await loadNetworkConfig('mainnet-gnosis');
     try {
       // Seed the process-wide failover counters the status route reads, then
@@ -176,6 +185,7 @@ describe('/api/status selected overlay details', () => {
       noteRpcFailover('status-test publish', 'https://other.example', { status: 503 }, 'https://backup.example');
       noteRpcExhaustion('status-test publish', ['https://primary.example', 'https://backup.example']);
       notePreferredEndpoint('status-test publish', 'https://backup.example');
+      noteRpcServed('status-test read', 'https://served.example/key');
 
       const server = createServer(async (req, res) => {
         const url = new URL(req.url ?? '/', 'http://127.0.0.1');
@@ -218,6 +228,15 @@ describe('/api/status selected overlay details', () => {
         expect(body.chain.rpcExhaustions).toBe(before.exhaustions + 1);
         expect(body.chain.rpcFailoversByClass.THROTTLE_429).toBe((before.byErrorClass.THROTTLE_429 ?? 0) + 1);
         expect(body.chain.rpcFailoversByClass.SERVER_5XX).toBe((before.byErrorClass.SERVER_5XX ?? 0) + 1);
+        expect(body.chain.rpcServedByEndpointHost).toEqual({
+          ...before.servedByEndpointHost,
+          'served.example': (before.servedByEndpointHost['served.example'] ?? 0) + 1,
+        });
+        expect(body.chain.rpcFailoversByEndpointHost).toEqual({
+          ...before.byEndpointHost,
+          'primary.example': (before.byEndpointHost['primary.example'] ?? 0) + 1,
+          'other.example': (before.byEndpointHost['other.example'] ?? 0) + 1,
+        });
         // Endpoint-stickiness establishment counter is wired through /api/status.
         expect(body.chain.rpcPreferredEstablishments).toBe(before.preferredEstablishments + 1);
         // The counter surface stays host-only — never a raw RPC URL.
@@ -227,6 +246,8 @@ describe('/api/status selected overlay details', () => {
       }
     } finally {
       warnSpy.mockRestore();
+      logSpy.mockRestore();
+      _resetRpcFailoverStatsForTest();
     }
   });
 

--- a/packages/cli/test/status-route-rpc.test.ts
+++ b/packages/cli/test/status-route-rpc.test.ts
@@ -23,14 +23,14 @@ import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { createServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import {
+  ChainRpcTransportError,
   noteRpcFailover,
   noteRpcExhaustion,
   notePreferredEndpoint,
   noteRpcServed,
   getRpcFailoverStats,
-  ChainRpcTransportError,
+  _resetRpcFailoverStatsForTest,
 } from '@origintrail-official/dkg-chain';
-import { _resetRpcFailoverStatsForTest } from '../../chain/src/rpc-failover-log.js';
 import { computeNetworkId } from '../../core/src/genesis.js';
 import { getSharedContext } from '../../chain/test/evm-test-context.js';
 import { loadNetworkConfig } from '../src/config.js';
@@ -185,7 +185,7 @@ describe('/api/status selected overlay details', () => {
       noteRpcFailover('status-test publish', 'https://other.example', { status: 503 }, 'https://backup.example');
       noteRpcExhaustion('status-test publish', ['https://primary.example', 'https://backup.example']);
       notePreferredEndpoint('status-test publish', 'https://backup.example');
-      noteRpcServed('status-test read', 'https://served.example/key');
+      noteRpcServed('status-test read', 'https://served.example/key', { mode: 'read', key: 'status-test-read' });
 
       const server = createServer(async (req, res) => {
         const url = new URL(req.url ?? '/', 'http://127.0.0.1');

--- a/packages/cli/test/status-route-rpc.test.ts
+++ b/packages/cli/test/status-route-rpc.test.ts
@@ -73,6 +73,9 @@ describe('/api/status + /api/chain/rpc-health (real daemon, real chain)', () => 
     expect(typeof body.chain.rpcFailovers).toBe('number');
     expect(typeof body.chain.rpcExhaustions).toBe('number');
     expect(body.chain.rpcFailoversByClass).toBeDefined();
+    // Success-side per-provider distribution (which endpoint served) — host-only.
+    expect(body.chain.rpcServedByEndpointHost).toBeDefined();
+    expect(body.chain.rpcFailoversByEndpointHost).toBeDefined();
     expect(JSON.stringify(body.chain)).not.toContain('://');
   });
 


### PR DESCRIPTION
## Why
Our multi-RPC failover already logs **failures** — `[chain] RPC failover: <op> via <host> failed (<class>), trying <next>` — plus a stickiness line and a `byEndpointHost` (failure) counter on `/api/status`. So on a degraded chain (the beacon fleet is currently seeing Base Sepolia rate-limit/timeout across all endpoints) you can see *which provider failed* and *when it switched to a backup*, but **not which provider is actually carrying the successful traffic**. That success-side attribution is the missing signal.

## What
Adds `noteRpcServed(label, url, alwaysLog?)` in `rpc-failover-log.ts`, symmetric with `noteRpcFailover` — **host-only** and **never-throwing** — wired into every success point of the read/write failover loops (`rpc-failover-client.ts`: preparation, broadcast ×2, receipt, read):

- **tx / write broadcasts** log **every** success: `[chain] RPC served: <label> via <host>`. Broadcasts are low-volume, so per-tx attribution ("which provider broadcast this tx") is exactly what you want.
- **reads** log **only when the serving host changes** for a label (a provider shift) — never once per call, so the hot read path never floods: `[chain] RPC served: <label> via <host> (provider shift)`.
- a process-wide **`servedByEndpointHost`** counter, surfaced on **`/api/status`** (`rpcServedByEndpointHost`, plus `rpcFailoversByEndpointHost` for symmetry), gives the full who-is-serving distribution with zero log spam.

### Redaction
Everything goes through the existing `rpcHost()` — **host only, never the full URL** (which can carry API keys). The `/api/status` test already asserts `JSON.stringify(body.chain)` contains no `://`, which now also guards these fields.

## Tests
`rpc-failover-log.test.ts`: counter, per-tx always-log, read on-change gate, host-only redaction, and the never-throw guarantee (throwing `console.log` doesn't abort the call). `status-route-rpc.test.ts`: the new `/api/status` fields are present. Full chain failover suite + status route green locally (49 chain + 5 cli).

## Notes
- Log level is `console.log` (informational) vs the failover lines' `console.warn` (problem signals) — both land in the node journal.
- Targets `main`; the beacons track `testnet-canary`, so this reaches them when canary next syncs from main (or via cherry-pick).

🤖 Generated with [Claude Code](https://claude.com/claude-code)