### PR TITLE
feat(sync): OT-RFC-59 SC4 — changelog responder handler + enable-path

### DIFF
--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -216,7 +216,7 @@ import { reconcileWarmCoreConnections, type WarmCoreAgent } from './p2p/warm-cor
 import { fetchSyncPages, type SyncPageResult } from './sync/requester/page-fetch.js';
 import { insertWithOversizeGuard } from './sync/oversize-filter.js';
 import { OversizeTombstoneLog } from './sync/oversize-tombstones.js';
-import { getSyncCheckpointKey, MemorySyncCheckpointStore } from './sync/checkpoint/state.js';
+import { getSyncCheckpointKey, MemorySyncCheckpointStore, MemoryChangelogCursorStore } from './sync/checkpoint/state.js';
 import { runDurableSync } from './sync/requester/durable-sync.js';
 import { runSharedMemorySync } from './sync/requester/shared-memory-sync.js';
 import { buildSyncRequestEnvelope, type SyncPhase } from './sync/auth/request-build.js';
@@ -354,7 +354,7 @@ import {
   type ReplicationEvent,
   type SyncReconcilerBackoff,
 } from './dkg-agent-types.js';
-import type { SyncCheckpointStore } from './sync/checkpoint/state.js';
+import type { SyncCheckpointStore, ChangelogCursorStore } from './sync/checkpoint/state.js';
 import {
   normalizePublishContextGraphId,
   isPublishAsyncQuadEnvelope,
@@ -1367,6 +1367,7 @@ export class DKGAgentBase {
    * by PR #237 (sync-refactor-rebased).
    */
   protected syncCheckpoints: SyncCheckpointStore = new MemorySyncCheckpointStore();
+  protected changelogCursors: ChangelogCursorStore = new MemoryChangelogCursorStore();
   protected syncVerifyWorker?: SyncVerifyWorker;
 
   /** Registered agents on this node: agentAddress → AgentKeyRecord */
@@ -1449,6 +1450,7 @@ export class DKGAgentBase {
     this.publisher.setWorkspaceAgentRecipientResolver((input) => (this as unknown as DKGAgent).resolveWorkspaceRecipientsGated(input));
     this.publisher.setWorkspaceSenderKeyEncryptor((input) => (this as unknown as DKGAgent).encryptWorkspacePayloadWithSenderKey(input));
     this.syncCheckpoints = config.syncCheckpointStore ?? this.syncCheckpoints;
+    this.changelogCursors = config.changelogCursorStore ?? this.changelogCursors;
   }
 
   /**

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -99,6 +99,7 @@ import {
 import { GraphManager, PrivateContentStore, createTripleStore, asChangelogReader, type ChangelogReader, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig } from '@origintrail-official/dkg-storage';
 import { readChangelogDeltaPage } from './sync/responder/graph-plan.js';
 import { decodeChangelogRequest, encodeChangelogResponse } from './sync/changelog/wire.js';
+import { runChangelogSync, planPageApply } from './sync/requester/changelog-sync.js';
 import { EVMChainAdapter, NoChainAdapter, enrichEvmError, buildKnowledgeAssetUal, type EVMAdapterConfig, type ChainAdapter, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo } from '@origintrail-official/dkg-chain';
 import {
   DKGPublisher, PublishHandler, SharedMemoryHandler, UpdateHandler, ChainEventPoller, AccessHandler, AccessClient,
@@ -670,6 +671,30 @@ function emptyDurableSyncResult(): DurableSyncResult {
     failedPeers: 0,
     failedPhases: 0,
     deniedPhases: 0,
+  };
+}
+
+/** Field-wise sum of two DurableSyncResults (OT-RFC-59 changelog lane + legacy lane). */
+function mergeDurableSyncResults(a: DurableSyncResult, b: DurableSyncResult): DurableSyncResult {
+  return {
+    insertedTriples: a.insertedTriples + b.insertedTriples,
+    fetchedMetaTriples: a.fetchedMetaTriples + b.fetchedMetaTriples,
+    fetchedDataTriples: a.fetchedDataTriples + b.fetchedDataTriples,
+    insertedMetaTriples: a.insertedMetaTriples + b.insertedMetaTriples,
+    insertedDataTriples: a.insertedDataTriples + b.insertedDataTriples,
+    bytesReceived: a.bytesReceived + b.bytesReceived,
+    resumedPhases: a.resumedPhases + b.resumedPhases,
+    timedOutPhases: a.timedOutPhases + b.timedOutPhases,
+    completedPhases: a.completedPhases + b.completedPhases,
+    checkpointAdvances: a.checkpointAdvances + b.checkpointAdvances,
+    emptyResponses: a.emptyResponses + b.emptyResponses,
+    metaOnlyResponses: a.metaOnlyResponses + b.metaOnlyResponses,
+    dataRejectedMissingMeta: a.dataRejectedMissingMeta + b.dataRejectedMissingMeta,
+    rejectedKcs: a.rejectedKcs + b.rejectedKcs,
+    failedPeers: a.failedPeers + b.failedPeers,
+    failedPhases: a.failedPhases + b.failedPhases,
+    deniedPhases: a.deniedPhases + b.deniedPhases,
+    backoffWorthyFailures: (a.backoffWorthyFailures ?? 0) + (b.backoffWorthyFailures ?? 0),
   };
 }
 
@@ -3553,6 +3578,50 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       this.log.warn(ctx, `Skipping durable sync from ${remotePeerId.slice(-8)} (DKG_DURABLE_SYNC_ENABLED=0)`);
       return emptyDurableSyncResult();
     }
+    // OT-RFC-59 — peel off the public CGs this peer serves via the O(delta) changelog
+    // lane; the rest fall through to the legacy full-scan lane below. STRICTLY ADDITIVE:
+    // gated on this node's `store.changelog` flag, and ANY failure returns every CG to
+    // the legacy lane, so a broken/disabled changelog lane degrades to exactly today's
+    // behaviour rather than dropping sync.
+    let legacyContextGraphIds = contextGraphIds;
+    let changelogResult: DurableSyncResult | undefined;
+    // Gate = this node's own changelog is enabled (its store is ChangelogStore-wrapped) —
+    // the same flag that makes it a responder. Same signal SC4 uses to advertise the protocol.
+    if (asChangelogReader(this.store) !== null && contextGraphIds.length > 0) {
+      try {
+        const lane = await this.runChangelogLane(ctx, remotePeerId, contextGraphIds, onAccessDenied);
+        changelogResult = lane.result;
+        legacyContextGraphIds = lane.remainingLegacyCgs;
+      } catch (err) {
+        this.log.warn(ctx, `Changelog sync lane failed for ${remotePeerId.slice(-8)}; using legacy sync: ${String(err)}`);
+        legacyContextGraphIds = contextGraphIds;
+        changelogResult = undefined;
+      }
+    }
+    if (legacyContextGraphIds.length === 0) {
+      return changelogResult ?? emptyDurableSyncResult();
+    }
+    const legacyResult = await this.runLegacyDurableSync(
+      ctx, remotePeerId, legacyContextGraphIds, onPhase, onAccessDenied, sinceBatchIdFor, options,
+    );
+    return changelogResult ? mergeDurableSyncResults(changelogResult, legacyResult) : legacyResult;
+  }
+
+  /**
+   * The legacy full-scan durable-sync lane (PROTOCOL_SYNC). Extracted verbatim from
+   * `syncFromPeerDetailed` so the OT-RFC-59 changelog lane can (a) run it for the CGs it
+   * does not handle and (b) fall back to it on `resync` / stall — without re-entering the
+   * changelog branch.
+   */
+  async runLegacyDurableSync(this: DKGAgent,
+    ctx: OperationContext,
+    remotePeerId: string,
+    contextGraphIds: string[],
+    onPhase?: PhaseCallback,
+    onAccessDenied?: (contextGraphId: string) => void,
+    sinceBatchIdFor?: (contextGraphId: string) => string | undefined,
+    options?: { stopOnBackoffWorthyFailure?: boolean },
+  ): Promise<DurableSyncResult> {
     const syncAgentsMeta = resolveSyncAgentsMeta(this.config.syncAgentsMeta, process.env.DKG_SYNC_AGENTS_META);
     const stopOnBackoffWorthyFailure = options?.stopOnBackoffWorthyFailure;
     const runSync = () => withGlobalSyncBackpressure(
@@ -3596,6 +3665,135 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       hasSinceBatchIdResolver: Boolean(sinceBatchIdFor),
     });
     return singleFlightKey ? runSyncSingleFlight(this, singleFlightKey, runSync) : runSync();
+  }
+
+  /**
+   * OT-RFC-59 requester lane. For each PUBLIC context graph the peer advertises the
+   * changelog protocol for, runs the O(delta) verified-apply driver; returns the CGs it
+   * did NOT handle (private, peer lacks the protocol, or per-CG failure) for the legacy
+   * lane. Public CGs need no request signing (the responder's ACL gate returns true), so
+   * they are the safe first lane; private CGs stay legacy until signed requests land.
+   */
+  async runChangelogLane(this: DKGAgent,
+    ctx: OperationContext,
+    remotePeerId: string,
+    contextGraphIds: string[],
+    onAccessDenied?: (contextGraphId: string) => void,
+  ): Promise<{ result: DurableSyncResult; remainingLegacyCgs: string[] }> {
+    const peerProtocols = await this.getPeerProtocols(remotePeerId);
+    if (!peerProtocols.includes(PROTOCOL_SYNC_CHANGELOG)) {
+      return { result: emptyDurableSyncResult(), remainingLegacyCgs: contextGraphIds };
+    }
+    const result = emptyDurableSyncResult();
+    const legacyCgs: string[] = [];
+    for (const cg of contextGraphIds) {
+      if (await this.isPrivateContextGraph(cg)) { legacyCgs.push(cg); continue; }
+      try {
+        const applied = await this.runChangelogSyncForCg(ctx, remotePeerId, cg);
+        result.insertedTriples += applied.insertedDataTriples + applied.insertedMetaTriples;
+        result.insertedDataTriples += applied.insertedDataTriples;
+        result.insertedMetaTriples += applied.insertedMetaTriples;
+        result.completedPhases += 1;
+        if (applied.denied) { result.deniedPhases += 1; onAccessDenied?.(cg); }
+      } catch (err) {
+        this.log.warn(ctx, `Changelog sync failed for CG ${cg} from ${remotePeerId.slice(-8)}; deferring to legacy: ${String(err)}`);
+        legacyCgs.push(cg);
+      }
+    }
+    return { result, remainingLegacyCgs: legacyCgs };
+  }
+
+  /**
+   * Drive the OT-RFC-59 changelog delta lane for ONE public context graph: page from the
+   * durable cursor, verify each page (data merkle-checked against its sibling meta via
+   * {@link processDurableBatchInWorker}), REPLACE only the verified graphs, and advance the
+   * cursor along the verified prefix. `runResync` bootstraps via the legacy lane.
+   */
+  async runChangelogSyncForCg(this: DKGAgent,
+    ctx: OperationContext,
+    remotePeerId: string,
+    contextGraphId: string,
+  ): Promise<{ insertedDataTriples: number; insertedMetaTriples: number; denied: boolean }> {
+    let insertedDataTriples = 0;
+    let insertedMetaTriples = 0;
+    const acceptUnverified = (Object.values(SYSTEM_CONTEXT_GRAPHS) as string[]).includes(contextGraphId);
+    const cgDataUri = contextGraphDataUri(contextGraphId);
+    // In-scope iff the graph is this CG's own public data plane. Rejects the reserved
+    // changelog graph, any other CG, and the private/SWM planes (deferred to legacy).
+    const isForeignGraph = (graph: string): boolean => {
+      const inCg = graph === cgDataUri || graph.startsWith(`${cgDataUri}/`);
+      if (!inCg) return true;
+      return graph.includes('/_private') || graph.includes('/_shared_memory');
+    };
+    const worker = this.getOrCreateSyncVerifyWorker();
+
+    const outcome = await runChangelogSync({
+      contextGraphId,
+      limit: SYNC_PAGE_SIZE,
+      getCursor: () => {
+        const c = this.changelogCursors.get(remotePeerId, contextGraphId);
+        return c ? { era: c.era, seq: c.seq } : undefined;
+      },
+      setCursor: (era, seq) => this.changelogCursors.set(remotePeerId, contextGraphId, era, seq),
+      send: (bytes) => this.messenger.sendToPeer(remotePeerId, PROTOCOL_SYNC_CHANGELOG, bytes, {
+        timeoutMs: SYNC_PAGE_TIMEOUT_MS,
+        signal: this.node.stopSignal ?? undefined,
+      }),
+      // Resync = the legacy verified lane for just this CG (no re-entry into the changelog branch).
+      runResync: async () => { await this.runLegacyDurableSync(ctx, remotePeerId, [contextGraphId]); },
+      logWarn: (m) => this.log.warn(ctx, m),
+      applyPage: async (page) => {
+        // Parse the page's upsert records per plane (parseAndFilter validates + CG-filters).
+        const dataRecs = page.records.filter((r) => r.op === 'upsert' && !r.graph.endsWith('/_meta') && !isForeignGraph(r.graph));
+        const metaRecs = page.records.filter((r) => r.op === 'upsert' && r.graph.endsWith('/_meta') && !isForeignGraph(r.graph));
+        const recordQuadCountByGraph = new Map<string, number>();
+        const metaGraphsInPage = new Set<string>();
+        const dataQuads: Quad[] = [];
+        const metaQuads: Quad[] = [];
+        for (const rec of dataRecs) {
+          const { quads } = await worker.parseAndFilter(rec.quads ?? '', rec.graph, contextGraphId);
+          dataQuads.push(...quads);
+          recordQuadCountByGraph.set(rec.graph, quads.length);
+        }
+        for (const rec of metaRecs) {
+          const { quads } = await worker.parseAndFilter(rec.quads ?? '', rec.graph, contextGraphId);
+          metaQuads.push(...quads);
+          recordQuadCountByGraph.set(rec.graph, quads.length);
+          metaGraphsInPage.add(rec.graph);
+        }
+        // Merkle-verify data against meta (same worker path legacy sync uses).
+        const processed = await this.processDurableBatchInWorker(dataQuads, metaQuads, ctx, acceptUnverified);
+        const verifiedByGraph = new Map<string, Quad[]>();
+        for (const q of [...processed.verifiedData, ...processed.verifiedMeta]) {
+          const arr = verifiedByGraph.get(q.graph);
+          if (arr) arr.push(q); else verifiedByGraph.set(q.graph, [q]);
+        }
+        const plan = planPageApply({
+          records: page.records,
+          nextSeq: page.nextSeq,
+          priorSeq: page.priorSeq,
+          isForeignGraph,
+          verifiedByGraph,
+          recordQuadCountByGraph,
+          metaGraphsInPage,
+        });
+        // Apply REPLACE per graph and COMMIT before the driver persists the cursor
+        // (crash-safe: upsert=drop+insert and drop are idempotent, so a crash between
+        // commit and cursor-persist re-fetches and re-applies harmlessly).
+        for (const op of plan.ops) {
+          await this.store.dropGraph(op.graph);
+          if (op.op === 'upsert' && op.quads.length > 0) {
+            await this.insertSyncedQuadsAndInvalidateListCache(op.quads, {
+              priority: 'background', source: 'agent.changelogSync.apply',
+            });
+            if (op.graph.endsWith('/_meta')) insertedMetaTriples += op.quads.length;
+            else insertedDataTriples += op.quads.length;
+          }
+        }
+        return { advanceTo: plan.advanceTo, applied: plan.applied, deferred: plan.deferred };
+      },
+    });
+    return { insertedDataTriples, insertedMetaTriples, denied: outcome.kind === 'denied' };
   }
 
   /**

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -652,6 +652,10 @@ function durableSyncEnabled(config: DKGAgentConfig): boolean {
   return resolveBooleanSwitch(config.durableSyncEnabled, 'DKG_DURABLE_SYNC_ENABLED', true);
 }
 
+/** OT-RFC-59 responder cap on the peer-controlled raw-scan limit (DoS bound). Honest
+ *  requesters send SYNC_PAGE_SIZE (500); the headroom tolerates larger legitimate pages. */
+const CHANGELOG_MAX_SCAN_LIMIT = 2000;
+
 function emptyDurableSyncResult(): DurableSyncResult {
   return {
     insertedTriples: 0,
@@ -2660,12 +2664,19 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       return encodeChangelogResponse({ kind: 'denied' });
     }
     // Same per-CG gate as PROTOCOL_SYNC: public CGs are open (returns true),
-    // private CGs verify the signed digest the requester rode on the request.
-    const authorized = await this.authorizeSyncRequest(
-      request as unknown as SyncRequestEnvelope,
-      peerId,
-      { signal: options?.signal },
-    );
+    // private CGs verify the signed digest — a bare (unsigned) changelog request
+    // carries no digest, so `authorizePrivateSyncRequest` denies it. Any throw on a
+    // malformed envelope must fail CLOSED (deny), never escape as a handler error.
+    let authorized = false;
+    try {
+      authorized = await this.authorizeSyncRequest(
+        request as unknown as SyncRequestEnvelope,
+        peerId,
+        { signal: options?.signal },
+      );
+    } catch {
+      return encodeChangelogResponse({ kind: 'denied' });
+    }
     if (!authorized) return encodeChangelogResponse({ kind: 'denied' });
     const resp = await readChangelogDeltaPage({
       reader,
@@ -2673,7 +2684,9 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       contextGraphId: request.contextGraphId,
       sinceSeq: request.sinceSeq,
       requesterEra: request.era,
-      limit: request.limit,
+      // Clamp the peer-controlled scan limit: an unbounded value would let a peer
+      // force an O(limit) log scan (DoS). Honest requesters send SYNC_PAGE_SIZE.
+      limit: Math.min(Math.max(1, request.limit), CHANGELOG_MAX_SCAN_LIMIT),
       signal: options?.signal,
     });
     return encodeChangelogResponse(resp);

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -12,7 +12,7 @@ import { createHash } from 'node:crypto';
 import {
   DKGNode, ProtocolRouter, GossipSubManager, TypedEventBus, DKGEvent,
   LibP2PNetwork, PeerResolver, StubNetworkStateRegistry,
-  PROTOCOL_ACCESS, PROTOCOL_PUBLISH, PROTOCOL_SYNC, PROTOCOL_QUERY_REMOTE, PROTOCOL_STORAGE_ACK, PROTOCOL_STORAGE_ACK_V2, PROTOCOL_STORAGE_UPDATE_ACK, PROTOCOL_GET_CIPHERTEXT_CHUNK, PROTOCOL_VERIFY_PROPOSAL, PROTOCOL_JOIN_REQUEST,
+  PROTOCOL_ACCESS, PROTOCOL_PUBLISH, PROTOCOL_SYNC, PROTOCOL_SYNC_CHANGELOG, PROTOCOL_QUERY_REMOTE, PROTOCOL_STORAGE_ACK, PROTOCOL_STORAGE_ACK_V2, PROTOCOL_STORAGE_UPDATE_ACK, PROTOCOL_GET_CIPHERTEXT_CHUNK, PROTOCOL_VERIFY_PROPOSAL, PROTOCOL_JOIN_REQUEST,
   PROTOCOL_NETWORK_IDENTITY,
   PROTOCOL_SWM_SENDER_KEY, PROTOCOL_SWM_UPDATE, PROTOCOL_SWM_SHARE_ACK, PROTOCOL_SWM_HOST_CATCHUP, PROTOCOL_MESSAGE,
   contextGraphPublishTopic, contextGraphWorkspaceTopic, contextGraphAppTopic, contextGraphUpdateTopic, contextGraphFinalizationTopic,
@@ -96,7 +96,9 @@ import {
   SUBSCRIPTION_SOURCES,
   pickNetworkTunables,
 } from '@origintrail-official/dkg-core';
-import { GraphManager, PrivateContentStore, createTripleStore, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig } from '@origintrail-official/dkg-storage';
+import { GraphManager, PrivateContentStore, createTripleStore, asChangelogReader, type ChangelogReader, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig } from '@origintrail-official/dkg-storage';
+import { readChangelogDeltaPage } from './sync/responder/graph-plan.js';
+import { decodeChangelogRequest, encodeChangelogResponse } from './sync/changelog/wire.js';
 import { EVMChainAdapter, NoChainAdapter, enrichEvmError, buildKnowledgeAssetUal, type EVMAdapterConfig, type ChainAdapter, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo } from '@origintrail-official/dkg-chain';
 import {
   DKGPublisher, PublishHandler, SharedMemoryHandler, UpdateHandler, ChainEventPoller, AccessHandler, AccessClient,
@@ -1984,6 +1986,20 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       snapshotBudget: resolveSyncResponderSnapshotBudgetOptions(process.env),
     });
 
+    // OT-RFC-59 changelog delta lane. Registered ONLY when the changelog is
+    // enabled — asChangelogReader resolves the ChangelogStore behind the daemon's
+    // store wrapper, which is non-null only if config.store.changelog is on and
+    // wrapped the store. Default-off: with the flag off the store is not wrapped,
+    // this is null, PROTOCOL_SYNC_CHANGELOG is never advertised (identify omits
+    // it), and every requester cleanly falls back to PROTOCOL_SYNC. Separate raw-
+    // router registration (off-substrate, like PROTOCOL_SYNC) reusing the SAME
+    // per-CG RFC-49 authorization as the legacy lane.
+    const changelogReader = asChangelogReader(this.store);
+    if (changelogReader) {
+      this.router.register(PROTOCOL_SYNC_CHANGELOG, (data, peerIdObj, options) =>
+        this.handleChangelogSync(data, peerIdObj.toString(), options, changelogReader));
+    }
+
     // Join-request protocol: receives signed join requests forwarded by peers.
     // Stores them locally if this node is the curator; ACKs with "ok" or "error".
     // rc.9 PR-10: migrated onto the Universal Messenger substrate
@@ -2595,6 +2611,47 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     if (rsStart === 'retryable') {
       this.scheduleRandomSamplingBindRetry(ctx);
     }
+  }
+
+  /**
+   * OT-RFC-59 changelog delta lane handler (PROTOCOL_SYNC_CHANGELOG). Reuses the
+   * SAME per-CG RFC-49 authorization as the legacy sync lane, then serves a
+   * bounded O(delta) page from the change log via {@link readChangelogDeltaPage}
+   * instead of the O(store) scan. Registered only when the changelog is enabled
+   * (see start()).
+   */
+  private async handleChangelogSync(
+    this: DKGAgent,
+    data: Uint8Array,
+    peerId: string,
+    options: { signal?: AbortSignal } | undefined,
+    reader: ChangelogReader,
+  ): Promise<Uint8Array> {
+    let request;
+    try {
+      request = decodeChangelogRequest(data);
+    } catch {
+      // Malformed peer bytes → deny (mirrors the legacy lane's parse-fail path).
+      return encodeChangelogResponse({ kind: 'denied' });
+    }
+    // Same per-CG gate as PROTOCOL_SYNC: public CGs are open (returns true),
+    // private CGs verify the signed digest the requester rode on the request.
+    const authorized = await this.authorizeSyncRequest(
+      request as unknown as SyncRequestEnvelope,
+      peerId,
+      { signal: options?.signal },
+    );
+    if (!authorized) return encodeChangelogResponse({ kind: 'denied' });
+    const resp = await readChangelogDeltaPage({
+      reader,
+      store: this.store,
+      contextGraphId: request.contextGraphId,
+      sinceSeq: request.sinceSeq,
+      requesterEra: request.era,
+      limit: request.limit,
+      signal: options?.signal,
+    });
+    return encodeChangelogResponse(resp);
   }
 
   randomSamplingLogger(this: DKGAgent, ctx: OperationContext) {

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -3684,17 +3684,14 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     if (!peerProtocols.includes(PROTOCOL_SYNC_CHANGELOG)) {
       return { result: emptyDurableSyncResult(), remainingLegacyCgs: contextGraphIds };
     }
-    const result = emptyDurableSyncResult();
+    let result = emptyDurableSyncResult();
     const legacyCgs: string[] = [];
     for (const cg of contextGraphIds) {
       if (await this.isPrivateContextGraph(cg)) { legacyCgs.push(cg); continue; }
       try {
-        const applied = await this.runChangelogSyncForCg(ctx, remotePeerId, cg);
-        result.insertedTriples += applied.insertedDataTriples + applied.insertedMetaTriples;
-        result.insertedDataTriples += applied.insertedDataTriples;
-        result.insertedMetaTriples += applied.insertedMetaTriples;
-        result.completedPhases += 1;
-        if (applied.denied) { result.deniedPhases += 1; onAccessDenied?.(cg); }
+        const cgResult = await this.runChangelogSyncForCg(ctx, remotePeerId, cg);
+        result = mergeDurableSyncResults(result, cgResult);
+        if (cgResult.deniedPhases > 0) onAccessDenied?.(cg);
       } catch (err) {
         this.log.warn(ctx, `Changelog sync failed for CG ${cg} from ${remotePeerId.slice(-8)}; deferring to legacy: ${String(err)}`);
         legacyCgs.push(cg);
@@ -3707,15 +3704,20 @@ export class LifecycleSyncMethods extends DKGAgentBase {
    * Drive the OT-RFC-59 changelog delta lane for ONE public context graph: page from the
    * durable cursor, verify each page (data merkle-checked against its sibling meta via
    * {@link processDurableBatchInWorker}), REPLACE only the verified graphs, and advance the
-   * cursor along the verified prefix. `runResync` bootstraps via the legacy lane.
+   * cursor along the verified prefix. `runResync` bootstraps via the legacy lane and its
+   * DurableSyncResult (inserts + completeness) is folded into the returned result so a
+   * first-contact/resynced CG still reports its inserts (drives the "synced" flags).
    */
   async runChangelogSyncForCg(this: DKGAgent,
     ctx: OperationContext,
     remotePeerId: string,
     contextGraphId: string,
-  ): Promise<{ insertedDataTriples: number; insertedMetaTriples: number; denied: boolean }> {
+  ): Promise<DurableSyncResult> {
+    // `did:dkg:*` public triples anchor a `dkg:merkleRoot` literal in their meta graph.
+    const MERKLE_ROOT_PREDICATE = 'http://dkg.io/ontology/merkleRoot';
     let insertedDataTriples = 0;
     let insertedMetaTriples = 0;
+    let result = emptyDurableSyncResult(); // folds every resync's legacy DurableSyncResult
     const acceptUnverified = (Object.values(SYSTEM_CONTEXT_GRAPHS) as string[]).includes(contextGraphId);
     const cgDataUri = contextGraphDataUri(contextGraphId);
     // In-scope iff the graph is this CG's own public data plane. Rejects the reserved
@@ -3739,15 +3741,23 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         timeoutMs: SYNC_PAGE_TIMEOUT_MS,
         signal: this.node.stopSignal ?? undefined,
       }),
-      // Resync = the legacy verified lane for just this CG (no re-entry into the changelog branch).
-      runResync: async () => { await this.runLegacyDurableSync(ctx, remotePeerId, [contextGraphId]); },
+      // Resync = the legacy verified lane for just this CG (no re-entry into the changelog
+      // branch). Fold its result in, and report completeness so the driver only advances
+      // the cursor to headSeq when the resync verifiably fetched everything below it.
+      runResync: async () => {
+        const r = await this.runLegacyDurableSync(ctx, remotePeerId, [contextGraphId]);
+        result = mergeDurableSyncResults(result, r);
+        const complete = r.timedOutPhases === 0 && r.failedPhases === 0
+          && r.failedPeers === 0 && r.dataRejectedMissingMeta === 0;
+        return { complete, insertedTriples: r.insertedTriples };
+      },
       logWarn: (m) => this.log.warn(ctx, m),
       applyPage: async (page) => {
         // Parse the page's upsert records per plane (parseAndFilter validates + CG-filters).
         const dataRecs = page.records.filter((r) => r.op === 'upsert' && !r.graph.endsWith('/_meta') && !isForeignGraph(r.graph));
         const metaRecs = page.records.filter((r) => r.op === 'upsert' && r.graph.endsWith('/_meta') && !isForeignGraph(r.graph));
         const recordQuadCountByGraph = new Map<string, number>();
-        const metaGraphsInPage = new Set<string>();
+        const metaGraphsWithRoot = new Set<string>();
         const dataQuads: Quad[] = [];
         const metaQuads: Quad[] = [];
         for (const rec of dataRecs) {
@@ -3759,7 +3769,8 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           const { quads } = await worker.parseAndFilter(rec.quads ?? '', rec.graph, contextGraphId);
           metaQuads.push(...quads);
           recordQuadCountByGraph.set(rec.graph, quads.length);
-          metaGraphsInPage.add(rec.graph);
+          // A meta graph can bind data only if it actually carries a merkle root.
+          if (quads.some((q) => q.predicate === MERKLE_ROOT_PREDICATE)) metaGraphsWithRoot.add(rec.graph);
         }
         // Merkle-verify data against meta (same worker path legacy sync uses).
         const processed = await this.processDurableBatchInWorker(dataQuads, metaQuads, ctx, acceptUnverified);
@@ -3775,14 +3786,18 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           isForeignGraph,
           verifiedByGraph,
           recordQuadCountByGraph,
-          metaGraphsInPage,
+          metaGraphsWithRoot,
+          batchVerifiedCleanly: processed.rejectedKcs === 0 && processed.dataRejectedMissingMeta === 0,
         });
         // Apply REPLACE per graph and COMMIT before the driver persists the cursor
         // (crash-safe: upsert=drop+insert and drop are idempotent, so a crash between
-        // commit and cursor-persist re-fetches and re-applies harmlessly).
+        // commit and cursor-persist re-fetches and re-applies harmlessly). Never dropGraph
+        // for a zero-quad upsert — planPageApply never emits one, but guard defensively so a
+        // future change cannot reintroduce the silent-delete vector.
         for (const op of plan.ops) {
+          if (op.op === 'upsert' && op.quads.length === 0) continue;
           await this.store.dropGraph(op.graph);
-          if (op.op === 'upsert' && op.quads.length > 0) {
+          if (op.op === 'upsert') {
             await this.insertSyncedQuadsAndInvalidateListCache(op.quads, {
               priority: 'background', source: 'agent.changelogSync.apply',
             });
@@ -3793,7 +3808,12 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         return { advanceTo: plan.advanceTo, applied: plan.applied, deferred: plan.deferred };
       },
     });
-    return { insertedDataTriples, insertedMetaTriples, denied: outcome.kind === 'denied' };
+    result.insertedDataTriples += insertedDataTriples;
+    result.insertedMetaTriples += insertedMetaTriples;
+    result.insertedTriples += insertedDataTriples + insertedMetaTriples;
+    result.completedPhases += 1;
+    if (outcome.kind === 'denied') result.deniedPhases += 1;
+    return result;
   }
 
   /**

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -41,7 +41,7 @@ import type { ApprovalPolicy, ChainAdapter, ContextGraphRegistryScanCursorStore 
 import type { QueryAccessConfig } from '@origintrail-official/dkg-query';
 import type { SkillHandler } from './messaging.js';
 import type { CclFactResolutionMode } from './ccl-fact-resolution.js';
-import type { SyncCheckpointStore } from './sync/checkpoint/state.js';
+import type { SyncCheckpointStore, ChangelogCursorStore } from './sync/checkpoint/state.js';
 import type { JsonLdContent } from './dkg-agent-utils.js';
 import type { SwmHostModeStoreLimits } from './swm/host-mode-store.js';
 import type { KaNumberAllocator } from './allocator.js';
@@ -1199,6 +1199,8 @@ export interface DKGAgentConfig {
   contextGraphSubscriptionStore?: ContextGraphSubscriptionStore;
   /** Durable local store for paged sync checkpoints. Defaults to in-memory. */
   syncCheckpointStore?: SyncCheckpointStore;
+  /** OT-RFC-59 durable per-(peer,CG) changelog cursor store. Defaults to in-memory. */
+  changelogCursorStore?: ChangelogCursorStore;
   /** Durable lane cursor store for the chain event poller. Defaults to in-memory. */
   chainEventCursorStore?: ChainEventCursorPersistence;
   /** Durable ContextGraphNameRegistry discovery cursor store. Defaults to in-memory adapter state. */

--- a/packages/agent/src/sync/changelog/wire.ts
+++ b/packages/agent/src/sync/changelog/wire.ts
@@ -100,6 +100,22 @@ export function decodeChangelogResponse(bytes: Uint8Array): ChangelogSyncRespons
     const nextSeq = asNonNegInt(obj.nextSeq, 'nextSeq');
     if (!Array.isArray(obj.records)) throw new Error('ChangelogSyncResponse.delta: records must be an array');
     const records = obj.records.map((r, i) => decodeRecord(r, i));
+    // Cursor invariants — defend against a buggy/malicious responder that could
+    // otherwise wedge or over-advance the requester's cursor: the scan cannot
+    // exceed the head, records ascend strictly and stay within the head, and
+    // nextSeq covers every emitted record.
+    if (nextSeq > headSeq) {
+      throw new Error(`ChangelogSyncResponse.delta: nextSeq ${nextSeq} > headSeq ${headSeq}`);
+    }
+    let prev = 0;
+    for (const rec of records) {
+      if (rec.seq > headSeq) throw new Error(`ChangelogSyncResponse.delta: record seq ${rec.seq} > headSeq ${headSeq}`);
+      if (rec.seq <= prev) throw new Error(`ChangelogSyncResponse.delta: records not strictly ascending (${prev} → ${rec.seq})`);
+      prev = rec.seq;
+    }
+    if (records.length > 0 && records[records.length - 1].seq > nextSeq) {
+      throw new Error(`ChangelogSyncResponse.delta: nextSeq ${nextSeq} < last record seq ${records[records.length - 1].seq}`);
+    }
     return { kind: 'delta', era, headSeq, nextSeq, records };
   }
   throw new Error(`ChangelogSyncResponse: unknown kind ${JSON.stringify(obj.kind)}`);

--- a/packages/agent/src/sync/checkpoint/state.ts
+++ b/packages/agent/src/sync/checkpoint/state.ts
@@ -67,6 +67,52 @@ export class MemorySyncCheckpointStore implements SyncCheckpointStore {
   }
 }
 
+// ── OT-RFC-59 changelog cursor (SC5) ─────────────────────────────────────────
+
+export interface ChangelogCursorEntry {
+  /** Log generation id of the responder this cursor tracks (era mismatch ⇒ resync). */
+  era: string;
+  /** Last seq successfully APPLIED from that responder for this CG. */
+  seq: number;
+  updatedAtMs: number;
+}
+
+/**
+ * Durable per-(peer, contextGraph) OT-RFC-59 changelog cursor. Unlike
+ * {@link SyncCheckpointStore} this is **NEVER TTL-pruned** — the whole point is
+ * O(delta) catch-up across restarts, which a TTL would defeat by forcing a full
+ * rescan. Keyed by (peerId, contextGraphId): `seq` is the responder node's
+ * per-node counter, so a cursor is never shared across peers.
+ */
+export interface ChangelogCursorStore {
+  get(peerId: string, contextGraphId: string): ChangelogCursorEntry | undefined;
+  set(peerId: string, contextGraphId: string, era: string, seq: number, nowMs?: number): void;
+}
+
+export class MemoryChangelogCursorStore implements ChangelogCursorStore {
+  private readonly entries = new Map<string, ChangelogCursorEntry>();
+  private readonly clock: () => number;
+
+  constructor(options: { clock?: () => number } = {}) {
+    this.clock = options.clock ?? (() => Date.now());
+  }
+
+  private static key(peerId: string, contextGraphId: string): string {
+    return `${peerId}\n${contextGraphId}`;
+  }
+
+  get(peerId: string, contextGraphId: string): ChangelogCursorEntry | undefined {
+    return this.entries.get(MemoryChangelogCursorStore.key(peerId, contextGraphId));
+  }
+
+  set(peerId: string, contextGraphId: string, era: string, seq: number, nowMs = this.clock()): void {
+    if (!Number.isSafeInteger(seq) || seq < 0) {
+      throw new Error(`Invalid changelog cursor seq for ${peerId}/${contextGraphId}: ${seq}`);
+    }
+    this.entries.set(MemoryChangelogCursorStore.key(peerId, contextGraphId), { era, seq, updatedAtMs: nowMs });
+  }
+}
+
 export function getSyncCheckpointKey(
   remotePeerId: string,
   contextGraphId: string,

--- a/packages/agent/src/sync/requester/changelog-sync.ts
+++ b/packages/agent/src/sync/requester/changelog-sync.ts
@@ -82,9 +82,17 @@ export function planPageApply(params: {
     if ((params.recordQuadCountByGraph.get(rec.graph) ?? 0) === 0) {
       continue;
     }
-    const isMeta = rec.graph.endsWith('/_meta');
-    const dataGraph = isMeta ? rec.graph.slice(0, -'/_meta'.length) : rec.graph;
-    if (!dataGraphTrusted(dataGraph)) {
+    if (rec.graph.endsWith('/_meta')) {
+      // META graphs are trusted ANCHORS, exactly like legacy sync: the served meta is
+      // applied as-is (rejected-KC rows already dropped from verifiedMeta), and DATA is
+      // what gets merkle-verified against it. This is what lets the top-level `_meta`
+      // graph (whose data sibling is often empty) converge instead of deferring forever.
+      ops.push({ seq: rec.seq, graph: rec.graph, op: 'upsert', quads: params.verifiedByGraph.get(rec.graph) ?? [] });
+      applied += 1;
+      continue;
+    }
+    // DATA graphs apply ONLY if they merkle-verify against their in-page meta.
+    if (!dataGraphTrusted(rec.graph)) {
       deferred = true;
       earliestUnresolvedSeq = Math.min(earliestUnresolvedSeq, rec.seq);
       break; // STOP at the first unresolved record — contiguous-prefix cursor safety.

--- a/packages/agent/src/sync/requester/changelog-sync.ts
+++ b/packages/agent/src/sync/requester/changelog-sync.ts
@@ -1,0 +1,185 @@
+import { encodeChangelogRequest, decodeChangelogResponse, type ChangelogDeltaRecord } from '../changelog/wire.js';
+import type { Quad } from '@origintrail-official/dkg-storage';
+
+/** One resolved apply operation, in ascending-seq order. `quads` = VERIFIED snapshot for an upsert. */
+export interface PageApplyOp {
+  seq: number;
+  graph: string;
+  op: 'upsert' | 'drop';
+  quads: Quad[];
+}
+
+export interface PageApplyPlan {
+  /** The contiguous, fully-verified prefix to apply (drop / drop+insert), ascending by seq. */
+  ops: PageApplyOp[];
+  /** Crash-safe seq the durable cursor may advance to after `ops` commit (<= page.nextSeq). */
+  advanceTo: number;
+  /** True when the page had a record that could not be verified/applied yet (retried next round). */
+  deferred: boolean;
+  /** Count of ops that will be applied. */
+  applied: number;
+}
+
+/**
+ * Pure, crash-safe planner for one decoded delta page (OT-RFC-59 requester, model R).
+ *
+ * Mirrors legacy durable-sync's correctness invariant WITHOUT copying its two-phase
+ * mechanism: a data graph is trusted ONLY when its sibling `/_meta` record is in THIS
+ * page (so its merkle root is available) AND every one of its parsed quads survived
+ * verification (`processDurableBatch` → `verifySyncedData`). This closes the orphan-data
+ * hole — `verifiedData` default-accepts quads whose subject is not a recognised root
+ * entity, so "survived verification" alone is insufficient; pairing with the sibling
+ * meta is what makes the KC actually merkle-checked.
+ *
+ * The cursor advances only along a CONTIGUOUS verified prefix: iteration stops at the
+ * FIRST unresolved (meta-pending / rejected) record, so the durable cursor never passes
+ * a change that was not applied. Store writes commit BEFORE the caller persists the
+ * cursor; upsert=REPLACE and drop are idempotent, so a crash between commit and
+ * cursor-persist re-fetches and re-applies harmlessly.
+ */
+export function planPageApply(params: {
+  records: ChangelogDeltaRecord[]; // ascending by seq (wire decoder guarantees)
+  nextSeq: number;
+  priorSeq: number;
+  isForeignGraph: (graph: string) => boolean;
+  /** graph → VERIFIED quads (processDurableBatch verifiedData+verifiedMeta, grouped by .graph). */
+  verifiedByGraph: Map<string, Quad[]>;
+  /** graph → parsed record quad count (pre-verify) — to detect partial/whole rejection. */
+  recordQuadCountByGraph: Map<string, number>;
+  /** meta-graph URIs present as upsert records in this page (sibling-presence test). */
+  metaGraphsInPage: Set<string>;
+}): PageApplyPlan {
+  const ops: PageApplyOp[] = [];
+  let deferred = false;
+  let earliestUnresolvedSeq = Number.POSITIVE_INFINITY;
+  let applied = 0;
+
+  // A data graph G is trusted iff its sibling meta record is in-page AND ALL of G's
+  // parsed quads survived verification (partial survival ⇒ a rejected KC ⇒ defer whole G).
+  const dataGraphTrusted = (dataGraph: string): boolean => {
+    if (!params.metaGraphsInPage.has(`${dataGraph}/_meta`)) return false;
+    const parsedCount = params.recordQuadCountByGraph.get(dataGraph);
+    if (parsedCount === undefined) return false; // data graph not in this page
+    return (params.verifiedByGraph.get(dataGraph)?.length ?? 0) === parsedCount;
+  };
+
+  for (const rec of params.records) {
+    if (params.isForeignGraph(rec.graph)) {
+      // A well-behaved responder never emits a foreign/reserved graph; if one leaks,
+      // skip it but treat its seq as consumed (resolved) so the cursor cannot wedge.
+      continue;
+    }
+    if (rec.op === 'drop') {
+      ops.push({ seq: rec.seq, graph: rec.graph, op: 'drop', quads: [] });
+      applied += 1;
+      continue;
+    }
+    // upsert — resolve the data graph this record verifies against.
+    const isMeta = rec.graph.endsWith('/_meta');
+    const dataGraph = isMeta ? rec.graph.slice(0, -'/_meta'.length) : rec.graph;
+    if (!dataGraphTrusted(dataGraph)) {
+      deferred = true;
+      earliestUnresolvedSeq = Math.min(earliestUnresolvedSeq, rec.seq);
+      break; // STOP at the first unresolved record — contiguous-prefix cursor safety.
+    }
+    ops.push({ seq: rec.seq, graph: rec.graph, op: 'upsert', quads: params.verifiedByGraph.get(rec.graph) ?? [] });
+    applied += 1;
+  }
+
+  const advanceTo = deferred
+    ? Math.max(params.priorSeq, earliestUnresolvedSeq - 1) // never regress below the cursor
+    : params.nextSeq; // whole page resolved ⇒ cover the filtered other-CG tail
+  return { ops, advanceTo, deferred, applied };
+}
+
+/** Injected dependencies for one (peer, contextGraph) changelog sync loop. */
+export interface ChangelogSyncDeps {
+  contextGraphId: string;
+  /** Max RAW records the responder scans per page. */
+  limit: number;
+  /** Durable (era,seq) cursor for (peer, cg); undefined on first contact. */
+  getCursor(): { era: string; seq: number } | undefined;
+  /** Persist the advanced cursor — the caller (applyPage) commits store writes FIRST. */
+  setCursor(era: string, seq: number): void;
+  /** One request/response round-trip on PROTOCOL_SYNC_CHANGELOG. Returns response bytes. */
+  send(requestBytes: Uint8Array): Promise<Uint8Array>;
+  /**
+   * Verify + selectively REPLACE graphs for one decoded delta page as a batch, and
+   * return the crash-safe seq the cursor may advance to. Durably commits its store
+   * writes before returning. Never throws for a rejected/meta-pending record — it
+   * defers by returning `deferred: true` with `advanceTo` capped before it.
+   */
+  applyPage(page: {
+    era: string; headSeq: number; nextSeq: number; priorSeq: number; records: ChangelogDeltaRecord[];
+  }): Promise<{ advanceTo: number; applied: number; deferred: boolean }>;
+  /** Bootstrap this CG via the legacy full/durable lane (resync fallback + stall backstop). */
+  runResync(): Promise<void>;
+  logWarn?(message: string): void;
+}
+
+export interface ChangelogSyncOutcome {
+  kind: 'delta' | 'resync' | 'denied';
+  applied: number;
+}
+
+/** After this many consecutive no-forward-progress rounds, fall back to a full resync. */
+const RESYNC_AFTER_STALLED_ROUNDS = 3;
+
+/**
+ * OT-RFC-59 requester driver for ONE (peer, contextGraph). Pages the changelog from the
+ * durable cursor, hands each page to {@link ChangelogSyncDeps.applyPage} for verified
+ * apply, and advances the cursor only over the fully-verified prefix. On era-mismatch /
+ * rollback / first-contact the responder returns `resync` and we bootstrap via the legacy
+ * lane. A page whose sibling meta straddled the byte budget defers; re-fetching from the
+ * (unadvanced) cursor pulls the meta into the same window next round. If a record stays
+ * unresolvable for {@link RESYNC_AFTER_STALLED_ROUNDS} rounds (genuinely missing meta, or
+ * an in-lane-unverifiable top-level graph), a resync clears it — correct, occasionally
+ * stalls, never inserts unverified data.
+ */
+export async function runChangelogSync(deps: ChangelogSyncDeps): Promise<ChangelogSyncOutcome> {
+  let applied = 0;
+  let stalledRounds = 0;
+  for (let round = 0; round < 100_000; round++) {
+    const cursor = deps.getCursor();
+    const priorSeq = cursor?.seq ?? 0;
+    const requestBytes = encodeChangelogRequest({
+      contextGraphId: deps.contextGraphId,
+      sinceSeq: priorSeq,
+      era: cursor?.era ?? null,
+      limit: deps.limit,
+    });
+    const resp = decodeChangelogResponse(await deps.send(requestBytes));
+
+    if (resp.kind === 'denied') return { kind: 'denied', applied };
+
+    if (resp.kind === 'resync') {
+      await deps.runResync();
+      deps.setCursor(resp.era, resp.headSeq);
+      return { kind: 'resync', applied };
+    }
+
+    // delta — verified apply of the page (store writes commit inside applyPage).
+    const { advanceTo, applied: n, deferred } = await deps.applyPage({
+      era: resp.era, headSeq: resp.headSeq, nextSeq: resp.nextSeq, priorSeq, records: resp.records,
+    });
+    applied += n;
+
+    if (advanceTo > priorSeq) {
+      deps.setCursor(resp.era, advanceTo);
+      stalledRounds = 0;
+    } else {
+      // No forward progress this round (first record unresolved). Back off to resync
+      // after a few rounds so a genuinely-missing meta or top-level graph can't wedge.
+      if (++stalledRounds >= RESYNC_AFTER_STALLED_ROUNDS) {
+        deps.logWarn?.(`changelog sync stalled ${stalledRounds} rounds at seq ${priorSeq}; resyncing`);
+        await deps.runResync();
+        deps.setCursor(resp.era, resp.headSeq);
+        return { kind: 'resync', applied };
+      }
+    }
+
+    if (!deferred && advanceTo >= resp.headSeq) return { kind: 'delta', applied };
+  }
+  deps.logWarn?.('changelog sync exceeded the round bound; stopping (misbehaving peer?)');
+  return { kind: 'delta', applied };
+}

--- a/packages/agent/src/sync/requester/changelog-sync.ts
+++ b/packages/agent/src/sync/requester/changelog-sync.ts
@@ -23,19 +23,20 @@ export interface PageApplyPlan {
 /**
  * Pure, crash-safe planner for one decoded delta page (OT-RFC-59 requester, model R).
  *
- * Mirrors legacy durable-sync's correctness invariant WITHOUT copying its two-phase
- * mechanism: a data graph is trusted ONLY when its sibling `/_meta` record is in THIS
- * page (so its merkle root is available) AND every one of its parsed quads survived
- * verification (`processDurableBatch` → `verifySyncedData`). This closes the orphan-data
- * hole — `verifiedData` default-accepts quads whose subject is not a recognised root
- * entity, so "survived verification" alone is insufficient; pairing with the sibling
- * meta is what makes the KC actually merkle-checked.
+ * A data graph is trusted ONLY when (a) the whole page verified cleanly, (b) its sibling
+ * `/_meta` record — carrying a real `dkg:merkleRoot` — is in THIS page, and (c) every one
+ * of its parsed quads survived `verifySyncedData`. Gates (a)+(b) close the default-accept
+ * hole: `verifiedData` passes through quads whose subject is not a recognised root entity
+ * and is permissive on empty/rootless meta, so "survived verification" ALONE would let
+ * orphan or unbound data through — the clean-batch + merkle-root-present checks force an
+ * actual merkle bind.
  *
- * The cursor advances only along a CONTIGUOUS verified prefix: iteration stops at the
- * FIRST unresolved (meta-pending / rejected) record, so the durable cursor never passes
- * a change that was not applied. Store writes commit BEFORE the caller persists the
- * cursor; upsert=REPLACE and drop are idempotent, so a crash between commit and
- * cursor-persist re-fetches and re-applies harmlessly.
+ * The cursor advances only along a CONTIGUOUS verified prefix (iteration stops at the FIRST
+ * unresolved record), so the durable cursor never passes a change that was not applied.
+ * An empty-content upsert is a resolved NO-OP — never a REPLACE — so it can never delete a
+ * local graph (genuine deletions arrive only via `drop` records). Store writes commit
+ * BEFORE the caller persists the cursor; upsert=REPLACE and drop are idempotent, so a crash
+ * between commit and cursor-persist re-fetches and re-applies harmlessly.
  */
 export function planPageApply(params: {
   records: ChangelogDeltaRecord[]; // ascending by seq (wire decoder guarantees)
@@ -44,29 +45,30 @@ export function planPageApply(params: {
   isForeignGraph: (graph: string) => boolean;
   /** graph → VERIFIED quads (processDurableBatch verifiedData+verifiedMeta, grouped by .graph). */
   verifiedByGraph: Map<string, Quad[]>;
-  /** graph → parsed record quad count (pre-verify) — to detect partial/whole rejection. */
+  /** graph → parsed record quad count (pre-verify) — to detect partial/whole rejection & empties. */
   recordQuadCountByGraph: Map<string, number>;
-  /** meta-graph URIs present as upsert records in this page (sibling-presence test). */
-  metaGraphsInPage: Set<string>;
+  /** meta-graph URIs present in-page THAT carry a `dkg:merkleRoot` (a rootless meta cannot bind data). */
+  metaGraphsWithRoot: Set<string>;
+  /** processDurableBatch rejected nothing this page (rejectedKcs===0 && dataRejectedMissingMeta===0). */
+  batchVerifiedCleanly: boolean;
 }): PageApplyPlan {
   const ops: PageApplyOp[] = [];
   let deferred = false;
   let earliestUnresolvedSeq = Number.POSITIVE_INFINITY;
   let applied = 0;
 
-  // A data graph G is trusted iff its sibling meta record is in-page AND ALL of G's
-  // parsed quads survived verification (partial survival ⇒ a rejected KC ⇒ defer whole G).
   const dataGraphTrusted = (dataGraph: string): boolean => {
-    if (!params.metaGraphsInPage.has(`${dataGraph}/_meta`)) return false;
+    if (!params.batchVerifiedCleanly) return false; // any KC in the page failed merkle ⇒ trust nothing
+    if (!params.metaGraphsWithRoot.has(`${dataGraph}/_meta`)) return false; // no merkle-root-bearing sibling in-page
     const parsedCount = params.recordQuadCountByGraph.get(dataGraph);
-    if (parsedCount === undefined) return false; // data graph not in this page
-    return (params.verifiedByGraph.get(dataGraph)?.length ?? 0) === parsedCount;
+    if (parsedCount === undefined || parsedCount === 0) return false; // absent/empty ⇒ nothing merkle-checkable
+    return (params.verifiedByGraph.get(dataGraph)?.length ?? 0) === parsedCount; // ALL of G's quads survived
   };
 
   for (const rec of params.records) {
     if (params.isForeignGraph(rec.graph)) {
-      // A well-behaved responder never emits a foreign/reserved graph; if one leaks,
-      // skip it but treat its seq as consumed (resolved) so the cursor cannot wedge.
+      // A well-behaved responder never emits a foreign/reserved graph; if one leaks, skip
+      // it but treat its seq as consumed (resolved) so the cursor cannot wedge.
       continue;
     }
     if (rec.op === 'drop') {
@@ -74,7 +76,12 @@ export function planPageApply(params: {
       applied += 1;
       continue;
     }
-    // upsert — resolve the data graph this record verifies against.
+    // Empty-content upsert (parsed to zero quads) carries nothing to verify or apply — a
+    // resolved NO-OP. It must NEVER become a REPLACE (drop): that would silently delete a
+    // local graph on an empty/malformed page. Deletions arrive only via `drop` records.
+    if ((params.recordQuadCountByGraph.get(rec.graph) ?? 0) === 0) {
+      continue;
+    }
     const isMeta = rec.graph.endsWith('/_meta');
     const dataGraph = isMeta ? rec.graph.slice(0, -'/_meta'.length) : rec.graph;
     if (!dataGraphTrusted(dataGraph)) {
@@ -92,6 +99,15 @@ export function planPageApply(params: {
   return { ops, advanceTo, deferred, applied };
 }
 
+/** Result of a legacy-lane resync bootstrap, surfaced to the driver for cursor + accounting. */
+export interface ResyncOutcome {
+  /** True iff the resync verifiably fetched EVERYTHING < headSeq (no timeout/failure/missing-meta),
+   *  so the cursor may safely jump to headSeq. False ⇒ leave the cursor and retry next cycle. */
+  complete: boolean;
+  /** Triples the resync inserted (folded into the driver's applied count). */
+  insertedTriples: number;
+}
+
 /** Injected dependencies for one (peer, contextGraph) changelog sync loop. */
 export interface ChangelogSyncDeps {
   contextGraphId: string;
@@ -104,16 +120,15 @@ export interface ChangelogSyncDeps {
   /** One request/response round-trip on PROTOCOL_SYNC_CHANGELOG. Returns response bytes. */
   send(requestBytes: Uint8Array): Promise<Uint8Array>;
   /**
-   * Verify + selectively REPLACE graphs for one decoded delta page as a batch, and
-   * return the crash-safe seq the cursor may advance to. Durably commits its store
-   * writes before returning. Never throws for a rejected/meta-pending record — it
-   * defers by returning `deferred: true` with `advanceTo` capped before it.
+   * Verify + selectively REPLACE graphs for one decoded delta page as a batch, and return
+   * the crash-safe seq the cursor may advance to. Durably commits its store writes before
+   * returning. Never throws for a rejected/meta-pending record — it defers.
    */
   applyPage(page: {
     era: string; headSeq: number; nextSeq: number; priorSeq: number; records: ChangelogDeltaRecord[];
   }): Promise<{ advanceTo: number; applied: number; deferred: boolean }>;
   /** Bootstrap this CG via the legacy full/durable lane (resync fallback + stall backstop). */
-  runResync(): Promise<void>;
+  runResync(): Promise<ResyncOutcome>;
   logWarn?(message: string): void;
 }
 
@@ -130,11 +145,11 @@ const RESYNC_AFTER_STALLED_ROUNDS = 3;
  * durable cursor, hands each page to {@link ChangelogSyncDeps.applyPage} for verified
  * apply, and advances the cursor only over the fully-verified prefix. On era-mismatch /
  * rollback / first-contact the responder returns `resync` and we bootstrap via the legacy
- * lane. A page whose sibling meta straddled the byte budget defers; re-fetching from the
+ * lane — advancing the cursor to headSeq ONLY when that resync completed fully (a partial
+ * resync leaves the cursor so the next cycle retries, never leaving a gap below headSeq).
+ * A page whose sibling meta straddled the byte budget defers; re-fetching from the
  * (unadvanced) cursor pulls the meta into the same window next round. If a record stays
- * unresolvable for {@link RESYNC_AFTER_STALLED_ROUNDS} rounds (genuinely missing meta, or
- * an in-lane-unverifiable top-level graph), a resync clears it — correct, occasionally
- * stalls, never inserts unverified data.
+ * unresolvable for {@link RESYNC_AFTER_STALLED_ROUNDS} rounds, a resync clears it.
  */
 export async function runChangelogSync(deps: ChangelogSyncDeps): Promise<ChangelogSyncOutcome> {
   let applied = 0;
@@ -153,8 +168,11 @@ export async function runChangelogSync(deps: ChangelogSyncDeps): Promise<Changel
     if (resp.kind === 'denied') return { kind: 'denied', applied };
 
     if (resp.kind === 'resync') {
-      await deps.runResync();
-      deps.setCursor(resp.era, resp.headSeq);
+      const rr = await deps.runResync();
+      applied += rr.insertedTriples;
+      // Only jump the cursor to headSeq if the resync verifiably fetched everything < headSeq;
+      // otherwise leave it (still first-contact / behind) so the next cycle retries — no gap.
+      if (rr.complete) deps.setCursor(resp.era, resp.headSeq);
       return { kind: 'resync', applied };
     }
 
@@ -168,12 +186,13 @@ export async function runChangelogSync(deps: ChangelogSyncDeps): Promise<Changel
       deps.setCursor(resp.era, advanceTo);
       stalledRounds = 0;
     } else {
-      // No forward progress this round (first record unresolved). Back off to resync
-      // after a few rounds so a genuinely-missing meta or top-level graph can't wedge.
+      // No forward progress this round. Back off to resync after a few rounds so a
+      // genuinely-missing meta (or an in-lane-unverifiable graph) can't wedge the CG.
       if (++stalledRounds >= RESYNC_AFTER_STALLED_ROUNDS) {
         deps.logWarn?.(`changelog sync stalled ${stalledRounds} rounds at seq ${priorSeq}; resyncing`);
-        await deps.runResync();
-        deps.setCursor(resp.era, resp.headSeq);
+        const rr = await deps.runResync();
+        applied += rr.insertedTriples;
+        if (rr.complete) deps.setCursor(resp.era, resp.headSeq);
         return { kind: 'resync', applied };
       }
     }

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -321,7 +321,16 @@ const DEFAULT_CHANGELOG_PAGE_BYTES = 4 * 1024 * 1024;
  * (assertion-graph membership + child-CG descendant rejection). `assertionGraphs`
  * is memoised per invocation, matching the original inline closure.
  */
-function createAdmissionContext(store: TripleStore, contextGraphId: string): {
+function createAdmissionContext(
+  store: TripleStore,
+  contextGraphId: string,
+  // The durable-DATA phase (readDurableDataPage) excludes the top-level `_meta`
+  // graph because the separate durable-META phase serves it. The changelog lane
+  // serves data AND meta in ONE delta stream, so it must INCLUDE topMeta —
+  // otherwise a public CG routed to changelog-only never converges its top-level
+  // metadata (OT-RFC-59 review 🔴 3594). SWM (own phase) and `/_private` stay out.
+  opts: { includeTopMeta?: boolean } = {},
+): {
   cgPrefix: string;
   topMetaGraph: string;
   isCandidateGraph: (graph: string) => boolean;
@@ -331,7 +340,7 @@ function createAdmissionContext(store: TripleStore, contextGraphId: string): {
   const topMetaGraph = contextGraphMetaGraphUri(contextGraphId);
   const isCandidateGraph = (graph: string): boolean => {
     if (graph !== cgPrefix && !graph.startsWith(`${cgPrefix}/`)) return false;
-    if (graph === topMetaGraph) return false;
+    if (!opts.includeTopMeta && graph === topMetaGraph) return false;
     // SWM graphs are the dedicated SWM phase's exclusive domain; `/_private` is
     // never durable-served (see readDurableDataPage's original inline note).
     if (graph.includes('/_shared_memory')) return false;
@@ -393,10 +402,16 @@ export async function readChangelogDeltaPage(params: {
 
   // (3) Re-apply the candidate exclusions (readChanges bypassed every phase
   // filter) and collapse to the latest op per graph (ascending seq ⇒ last wins).
-  const { isCandidateGraph, isAdmitted } = createAdmissionContext(params.store, params.contextGraphId);
+  // The changelog lane serves data AND meta in one stream, so — unlike the durable
+  // DATA phase — it INCLUDES the top-level `_meta` graph (the requester applies meta
+  // as a trusted anchor, legacy-parity), so a changelog-only public CG converges its
+  // top-level metadata rather than silently skipping it.
+  const { isCandidateGraph, isAdmitted } = createAdmissionContext(
+    params.store, params.contextGraphId, { includeTopMeta: true },
+  );
   const lastOp = new Map<string, { seq: number; op: ChangeOp }>();
   for (const r of raw) {
-    if (!isCandidateGraph(r.graph)) continue; // wrong-CG / topMeta / SWM / private — hides other/private-CG URIs
+    if (!isCandidateGraph(r.graph)) continue; // wrong-CG / SWM / private — hides other/private-CG URIs
     lastOp.set(r.graph, { seq: r.seq, op: r.op });
   }
 

--- a/packages/agent/test/agents-meta-sync-wiring.test.ts
+++ b/packages/agent/test/agents-meta-sync-wiring.test.ts
@@ -2,11 +2,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Wiring guard for the sync-storm mitigation (Chunk 1). The pure resolver is
 // unit-tested in `agents-meta-policy.test.ts`, but that alone would stay
-// green if someone reverted the production call site in
-// `dkg-agent-lifecycle.ts::syncFromPeerDetailed` back to `nodeRole==='core'
-// ? true`. This test exercises the REAL call site with a stubbed
-// `runDurableSync` and asserts the `syncAgentsMeta` value it actually passes
-// through, so such a regression fails here.
+// green if someone reverted the production call site back to
+// `nodeRole==='core' ? true`. This test exercises the REAL call site with a
+// stubbed `runDurableSync` and asserts the `syncAgentsMeta` value it actually
+// passes through, so such a regression fails here.
+//
+// OT-RFC-59: `syncFromPeerDetailed` now delegates the legacy lane to
+// `runLegacyDurableSync` (which owns the syncAgentsMeta resolution + the
+// runDurableSync call), so the fake `this` must carry that method too. The
+// changelog branch is skipped because `this.store` is absent (asChangelogReader
+// returns null).
 
 // Replace `runDurableSync` so `syncFromPeerDetailed` never touches the store /
 // network — we only capture the options object it forwards. `importOriginal`
@@ -34,6 +39,10 @@ const mockedRunDurableSync = vi.mocked(runDurableSync);
 function fakeAgent(config: { nodeRole?: 'core' | 'edge'; syncAgentsMeta?: boolean }): any {
   return {
     config,
+    store: undefined, // no ChangelogStore ⇒ asChangelogReader null ⇒ legacy lane runs
+    // The legacy lane the changelog dispatch delegates to; it owns the
+    // syncAgentsMeta resolution + the (stubbed) runDurableSync call.
+    runLegacyDurableSync: LifecycleSyncMethods.prototype.runLegacyDurableSync,
     createContextGraphSyncDeadline: () => Date.now() + 60_000,
     fetchSyncPages: async () => ({}),
     processDurableBatchInWorker: async () => ({}),

--- a/packages/agent/test/changelog-delta-page.test.ts
+++ b/packages/agent/test/changelog-delta-page.test.ts
@@ -113,6 +113,22 @@ describe('readChangelogDeltaPage — delta serving', () => {
     await store.close();
   });
 
+  it('INCLUDES the top-level _meta graph (unlike the durable-data phase) so it converges', async () => {
+    // OT-RFC-59 review 🔴 3594: the changelog lane serves data AND meta in one stream, so
+    // it must emit topMeta — otherwise a changelog-only public CG never syncs its top-level
+    // metadata. The durable-DATA phase still excludes it (its META phase serves it).
+    const topMeta = `${cgPrefix}/_meta`;
+    const store = await storeWith([['urn:s', 'http://dkg.io/ontology/merkleRoot', '"0xabc"', topMeta]]);
+    const resp = await readChangelogDeltaPage({
+      reader: new FakeReader({ era: 'E1', seq: 2 }, [rec(1, topMeta, 'upsert'), rec(2, G1, 'upsert')]),
+      store, contextGraphId: CG, sinceSeq: 0, requesterEra: 'E1', limit: 100,
+    });
+    expect(resp.kind).toBe('delta');
+    if (resp.kind !== 'delta') return;
+    expect(resp.records.map((r) => r.graph)).toContain(topMeta); // topMeta now emitted
+    await store.close();
+  });
+
   it('nextSeq is the scanned high-water (not head) when the scan window is full', async () => {
     const store = await storeWith([['urn:s', 'urn:p', '"v"', G1], ['urn:s2', 'urn:p', '"v"', G2]]);
     // limit 1 ⇒ readChanges returns only seq 1; head is 2 ⇒ not drained.

--- a/packages/agent/test/changelog-requester.test.ts
+++ b/packages/agent/test/changelog-requester.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from 'vitest';
+import type { Quad } from '@origintrail-official/dkg-storage';
+import {
+  runChangelogSync, planPageApply, type ChangelogSyncDeps,
+} from '../src/sync/requester/changelog-sync.js';
+import {
+  encodeChangelogResponse, decodeChangelogRequest, decodeChangelogResponse,
+  type ChangelogDeltaRecord, type ChangelogSyncRequest, type ChangelogSyncResponse,
+} from '../src/sync/changelog/wire.js';
+
+const qd = (graph: string, n: number): Quad => ({ subject: `s${n}`, predicate: 'p', object: `o${n}`, graph });
+
+// ── planPageApply (pure verified-apply planner) ─────────────────────────────
+
+/**
+ * Build records + the verify-result maps planPageApply consumes. Each spec is a graph
+ * with `count` parsed quads of which `verified` survived; a data graph is "paired" iff
+ * its `<graph>/_meta` also appears as a spec in the same page.
+ */
+function buildPage(specs: Array<{ seq: number; graph: string; op?: 'upsert' | 'drop'; count?: number; verified?: number }>) {
+  const records: ChangelogDeltaRecord[] = [];
+  const verifiedByGraph = new Map<string, Quad[]>();
+  const recordQuadCountByGraph = new Map<string, number>();
+  const metaGraphsInPage = new Set<string>();
+  for (const s of specs) {
+    const op = s.op ?? 'upsert';
+    if (op === 'drop') { records.push({ seq: s.seq, graph: s.graph, op }); continue; }
+    const count = s.count ?? 1;
+    const verified = s.verified ?? count;
+    records.push({ seq: s.seq, graph: s.graph, op, quads: `nq:${s.graph}` });
+    recordQuadCountByGraph.set(s.graph, count);
+    verifiedByGraph.set(s.graph, Array.from({ length: verified }, (_, i) => qd(s.graph, i)));
+    if (s.graph.endsWith('/_meta')) metaGraphsInPage.add(s.graph);
+  }
+  return { records, verifiedByGraph, recordQuadCountByGraph, metaGraphsInPage };
+}
+
+const plan = (page: ReturnType<typeof buildPage>, extra: { nextSeq: number; priorSeq?: number; isForeign?: (g: string) => boolean }) =>
+  planPageApply({
+    records: page.records,
+    nextSeq: extra.nextSeq,
+    priorSeq: extra.priorSeq ?? 0,
+    isForeignGraph: extra.isForeign ?? (() => false),
+    verifiedByGraph: page.verifiedByGraph,
+    recordQuadCountByGraph: page.recordQuadCountByGraph,
+    metaGraphsInPage: page.metaGraphsInPage,
+  });
+
+const DATA = 'did:dkg:context-graph:cg/context/1';
+const META = `${DATA}/_meta`;
+
+describe('planPageApply — verified-apply planner', () => {
+  it('applies a paired data+meta page and advances to nextSeq', () => {
+    const page = buildPage([
+      { seq: 2, graph: DATA, count: 3 },   // data (lower seq — written first)
+      { seq: 3, graph: META, count: 1 },   // its sibling meta (verifies the data)
+    ]);
+    const p = plan(page, { nextSeq: 3 });
+    expect(p.deferred).toBe(false);
+    expect(p.advanceTo).toBe(3);
+    expect(p.applied).toBe(2);
+    expect(p.ops.map((o) => o.graph)).toEqual([DATA, META]);
+    expect(p.ops[0].quads).toHaveLength(3); // the VERIFIED snapshot
+  });
+
+  it('DEFERS orphan data (no sibling meta in page) — cursor stays before it', () => {
+    const page = buildPage([{ seq: 5, graph: DATA, count: 3 }]); // data only, meta absent
+    const p = plan(page, { nextSeq: 5, priorSeq: 4 });
+    expect(p.deferred).toBe(true);
+    expect(p.applied).toBe(0);
+    expect(p.ops).toHaveLength(0);
+    expect(p.advanceTo).toBe(4); // earliestUnresolved(5) - 1, clamped to priorSeq
+  });
+
+  it('DEFERS a partially-rejected data graph (not all quads survived verification)', () => {
+    const page = buildPage([
+      { seq: 2, graph: DATA, count: 3, verified: 2 }, // one KC quad rejected
+      { seq: 3, graph: META, count: 1 },
+    ]);
+    const p = plan(page, { nextSeq: 3 });
+    expect(p.deferred).toBe(true);
+    expect(p.advanceTo).toBe(1); // stop before the data record at seq 2
+    expect(p.ops).toHaveLength(0);
+  });
+
+  it('stops at the FIRST unresolved record (contiguous prefix)', () => {
+    const G2 = 'did:dkg:context-graph:cg/context/2';
+    const page = buildPage([
+      { seq: 1, graph: 'did:dkg:context-graph:cg/x', op: 'drop' }, // resolves
+      { seq: 4, graph: G2, count: 1 },                              // orphan (no meta) ⇒ defer here
+      { seq: 6, graph: DATA, count: 1 },                            // paired, but AFTER the unresolved
+      { seq: 7, graph: META, count: 1 },
+    ]);
+    const p = plan(page, { nextSeq: 7 });
+    expect(p.deferred).toBe(true);
+    expect(p.ops.map((o) => o.graph)).toEqual(['did:dkg:context-graph:cg/x']); // only the drop before seq 4
+    expect(p.advanceTo).toBe(3); // 4 - 1
+  });
+
+  it('skips a leaked foreign graph but consumes its seq', () => {
+    const page = buildPage([
+      { seq: 1, graph: 'urn:dkg:changelog', count: 1 },
+      { seq: 2, graph: DATA, count: 1 }, { seq: 3, graph: META, count: 1 },
+    ]);
+    const p = plan(page, { nextSeq: 3, isForeign: (g) => g.startsWith('urn:dkg:changelog') });
+    expect(p.deferred).toBe(false);
+    expect(p.ops.map((o) => o.graph)).toEqual([DATA, META]);
+    expect(p.advanceTo).toBe(3);
+  });
+
+  it('applies drops without pairing', () => {
+    const page = buildPage([{ seq: 9, graph: DATA, op: 'drop' }]);
+    const p = plan(page, { nextSeq: 9 });
+    expect(p.ops).toEqual([{ seq: 9, graph: DATA, op: 'drop', quads: [] }]);
+    expect(p.advanceTo).toBe(9);
+  });
+});
+
+// ── runChangelogSync (transport/cursor loop + resync backstop) ──────────────
+
+function loopHarness(
+  responses: ChangelogSyncResponse[],
+  applyPage: ChangelogSyncDeps['applyPage'],
+) {
+  let cursor: { era: string; seq: number } | undefined;
+  const requests: ChangelogSyncRequest[] = [];
+  let resyncs = 0; let i = 0;
+  const deps: ChangelogSyncDeps = {
+    contextGraphId: 'cg', limit: 100,
+    getCursor: () => cursor,
+    setCursor: (era, seq) => { cursor = { era, seq }; },
+    send: async (bytes) => {
+      requests.push(decodeChangelogRequest(bytes));
+      const r = responses[i++];
+      if (!r) throw new Error(`scripted responses exhausted at request ${i}`);
+      return encodeChangelogResponse(r);
+    },
+    applyPage,
+    runResync: async () => { resyncs += 1; },
+    logWarn: () => {},
+  };
+  return { deps, requests, resyncs: () => resyncs, cursor: () => cursor };
+}
+
+const delta = (headSeq: number, nextSeq: number, records: ChangelogDeltaRecord[] = []): ChangelogSyncResponse =>
+  ({ kind: 'delta', era: 'e1', headSeq, nextSeq, records });
+
+describe('runChangelogSync — driver loop', () => {
+  it('completes when a page resolves through headSeq', async () => {
+    const h = loopHarness([delta(3, 3)], async (p) => ({ advanceTo: p.nextSeq, applied: 2, deferred: false }));
+    const out = await runChangelogSync(h.deps);
+    expect(out).toEqual({ kind: 'delta', applied: 2 });
+    expect(h.cursor()).toEqual({ era: 'e1', seq: 3 });
+    expect(h.requests[0]).toMatchObject({ sinceSeq: 0, era: null });
+  });
+
+  it('loops across pages, threading the cursor via advanceTo', async () => {
+    const h = loopHarness(
+      [delta(4, 2), delta(4, 4)],
+      async (p) => ({ advanceTo: p.nextSeq, applied: 1, deferred: false }),
+    );
+    const out = await runChangelogSync(h.deps);
+    expect(out.applied).toBe(2);
+    expect(h.requests).toHaveLength(2);
+    expect(h.requests[1]).toMatchObject({ sinceSeq: 2 });
+    expect(h.cursor()).toEqual({ era: 'e1', seq: 4 });
+  });
+
+  it('resync bootstraps and pins the cursor to (era, headSeq)', async () => {
+    const h = loopHarness([{ kind: 'resync', era: 'e2', headSeq: 9 }], async () => ({ advanceTo: 0, applied: 0, deferred: false }));
+    const out = await runChangelogSync(h.deps);
+    expect(out.kind).toBe('resync');
+    expect(h.resyncs()).toBe(1);
+    expect(h.cursor()).toEqual({ era: 'e2', seq: 9 });
+  });
+
+  it('stops on denied without advancing', async () => {
+    const h = loopHarness([{ kind: 'denied' }], async () => ({ advanceTo: 5, applied: 1, deferred: false }));
+    const out = await runChangelogSync(h.deps);
+    expect(out.kind).toBe('denied');
+    expect(h.cursor()).toBeUndefined();
+  });
+
+  it('falls back to resync after RESYNC_AFTER_STALLED_ROUNDS no-progress rounds', async () => {
+    // applyPage always defers with no forward progress (advanceTo == priorSeq).
+    const h = loopHarness(
+      [delta(9, 9), delta(9, 9), delta(9, 9), delta(9, 9)],
+      async (p) => ({ advanceTo: p.priorSeq, applied: 0, deferred: true }),
+    );
+    const out = await runChangelogSync(h.deps);
+    expect(out.kind).toBe('resync');
+    expect(h.resyncs()).toBe(1);
+    expect(h.requests.length).toBe(3); // stalls after 3 rounds, then resyncs
+    expect(h.cursor()).toEqual({ era: 'e1', seq: 9 });
+  });
+
+  it('keeps looping (no resync) while a deferred page still makes forward progress', async () => {
+    // Round 1 applies a prefix (advanceTo 2 > prior 0) but defers the rest; round 2 completes.
+    const h = loopHarness(
+      [delta(4, 4), delta(4, 4)],
+      async (p) => p.priorSeq === 0
+        ? ({ advanceTo: 2, applied: 1, deferred: true })
+        : ({ advanceTo: 4, applied: 1, deferred: false }),
+    );
+    const out = await runChangelogSync(h.deps);
+    expect(out.kind).toBe('delta');
+    expect(h.resyncs()).toBe(0);
+    expect(h.requests[1]).toMatchObject({ sinceSeq: 2 });
+    expect(h.cursor()).toEqual({ era: 'e1', seq: 4 });
+  });
+});
+
+// ── decodeChangelogResponse cursor invariants (unchanged wire hardening) ─────
+
+describe('decodeChangelogResponse cursor invariants', () => {
+  const bad = (resp: unknown) => encodeChangelogResponse(resp as ChangelogSyncResponse);
+  it('rejects nextSeq > headSeq', () => {
+    expect(() => decodeChangelogResponse(bad({ kind: 'delta', era: 'e', headSeq: 2, nextSeq: 3, records: [] })))
+      .toThrow(/nextSeq 3 > headSeq 2/);
+  });
+  it('rejects a record seq beyond headSeq', () => {
+    expect(() => decodeChangelogResponse(bad({ kind: 'delta', era: 'e', headSeq: 2, nextSeq: 2,
+      records: [{ seq: 5, graph: 'g', op: 'drop' }] }))).toThrow(/record seq 5 > headSeq 2/);
+  });
+  it('rejects non-ascending record seqs', () => {
+    expect(() => decodeChangelogResponse(bad({ kind: 'delta', era: 'e', headSeq: 9, nextSeq: 9,
+      records: [{ seq: 3, graph: 'a', op: 'drop' }, { seq: 2, graph: 'b', op: 'drop' }] })))
+      .toThrow(/not strictly ascending/);
+  });
+  it('rejects nextSeq below the last emitted record seq', () => {
+    expect(() => decodeChangelogResponse(bad({ kind: 'delta', era: 'e', headSeq: 9, nextSeq: 2,
+      records: [{ seq: 4, graph: 'a', op: 'drop' }] }))).toThrow(/nextSeq 2 < last record seq 4/);
+  });
+});

--- a/packages/agent/test/changelog-requester.test.ts
+++ b/packages/agent/test/changelog-requester.test.ts
@@ -133,6 +133,19 @@ describe('planPageApply — verified-apply planner', () => {
     expect(p.ops).toEqual([{ seq: 9, graph: DATA, op: 'drop', quads: [] }]);
     expect(p.advanceTo).toBe(9);
   });
+
+  it('applies a META-only page as a trusted anchor (top-level metadata convergence, no data sibling)', () => {
+    // Top-level `_meta` (CG config) with no merkle root and no data sibling in-page —
+    // legacy trusts served meta, so the changelog lane must apply it, not defer forever.
+    const TOP_META = 'did:dkg:context-graph:cg/_meta';
+    const page = buildPage([{ seq: 7, graph: TOP_META, count: 2, noRoot: true }]);
+    const p = plan(page, { nextSeq: 7 });
+    expect(p.deferred).toBe(false);
+    expect(p.ops.map((o) => o.graph)).toEqual([TOP_META]);
+    expect(p.ops[0].op).toBe('upsert');
+    expect(p.ops[0].quads).toHaveLength(2);
+    expect(p.advanceTo).toBe(7);
+  });
 });
 
 // ── runChangelogSync (transport/cursor loop + resync backstop) ──────────────

--- a/packages/agent/test/changelog-requester.test.ts
+++ b/packages/agent/test/changelog-requester.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { Quad } from '@origintrail-official/dkg-storage';
 import {
-  runChangelogSync, planPageApply, type ChangelogSyncDeps,
+  runChangelogSync, planPageApply, type ChangelogSyncDeps, type ResyncOutcome,
 } from '../src/sync/requester/changelog-sync.js';
 import {
   encodeChangelogResponse, decodeChangelogRequest, decodeChangelogResponse,
@@ -13,15 +13,15 @@ const qd = (graph: string, n: number): Quad => ({ subject: `s${n}`, predicate: '
 // ── planPageApply (pure verified-apply planner) ─────────────────────────────
 
 /**
- * Build records + the verify-result maps planPageApply consumes. Each spec is a graph
- * with `count` parsed quads of which `verified` survived; a data graph is "paired" iff
- * its `<graph>/_meta` also appears as a spec in the same page.
+ * Build records + the verify maps planPageApply consumes. Each spec is a graph with `count`
+ * parsed quads of which `verified` survived; a meta graph is added to metaGraphsWithRoot
+ * unless `noRoot` (a rootless meta cannot bind data).
  */
-function buildPage(specs: Array<{ seq: number; graph: string; op?: 'upsert' | 'drop'; count?: number; verified?: number }>) {
+function buildPage(specs: Array<{ seq: number; graph: string; op?: 'upsert' | 'drop'; count?: number; verified?: number; noRoot?: boolean }>) {
   const records: ChangelogDeltaRecord[] = [];
   const verifiedByGraph = new Map<string, Quad[]>();
   const recordQuadCountByGraph = new Map<string, number>();
-  const metaGraphsInPage = new Set<string>();
+  const metaGraphsWithRoot = new Set<string>();
   for (const s of specs) {
     const op = s.op ?? 'upsert';
     if (op === 'drop') { records.push({ seq: s.seq, graph: s.graph, op }); continue; }
@@ -30,12 +30,12 @@ function buildPage(specs: Array<{ seq: number; graph: string; op?: 'upsert' | 'd
     records.push({ seq: s.seq, graph: s.graph, op, quads: `nq:${s.graph}` });
     recordQuadCountByGraph.set(s.graph, count);
     verifiedByGraph.set(s.graph, Array.from({ length: verified }, (_, i) => qd(s.graph, i)));
-    if (s.graph.endsWith('/_meta')) metaGraphsInPage.add(s.graph);
+    if (s.graph.endsWith('/_meta') && !s.noRoot) metaGraphsWithRoot.add(s.graph);
   }
-  return { records, verifiedByGraph, recordQuadCountByGraph, metaGraphsInPage };
+  return { records, verifiedByGraph, recordQuadCountByGraph, metaGraphsWithRoot };
 }
 
-const plan = (page: ReturnType<typeof buildPage>, extra: { nextSeq: number; priorSeq?: number; isForeign?: (g: string) => boolean }) =>
+const plan = (page: ReturnType<typeof buildPage>, extra: { nextSeq: number; priorSeq?: number; isForeign?: (g: string) => boolean; batchClean?: boolean }) =>
   planPageApply({
     records: page.records,
     nextSeq: extra.nextSeq,
@@ -43,7 +43,8 @@ const plan = (page: ReturnType<typeof buildPage>, extra: { nextSeq: number; prio
     isForeignGraph: extra.isForeign ?? (() => false),
     verifiedByGraph: page.verifiedByGraph,
     recordQuadCountByGraph: page.recordQuadCountByGraph,
-    metaGraphsInPage: page.metaGraphsInPage,
+    metaGraphsWithRoot: page.metaGraphsWithRoot,
+    batchVerifiedCleanly: extra.batchClean ?? true,
   });
 
 const DATA = 'did:dkg:context-graph:cg/context/1';
@@ -52,49 +53,67 @@ const META = `${DATA}/_meta`;
 describe('planPageApply — verified-apply planner', () => {
   it('applies a paired data+meta page and advances to nextSeq', () => {
     const page = buildPage([
-      { seq: 2, graph: DATA, count: 3 },   // data (lower seq — written first)
-      { seq: 3, graph: META, count: 1 },   // its sibling meta (verifies the data)
+      { seq: 2, graph: DATA, count: 3 },
+      { seq: 3, graph: META, count: 1 },
     ]);
     const p = plan(page, { nextSeq: 3 });
     expect(p.deferred).toBe(false);
     expect(p.advanceTo).toBe(3);
     expect(p.applied).toBe(2);
     expect(p.ops.map((o) => o.graph)).toEqual([DATA, META]);
-    expect(p.ops[0].quads).toHaveLength(3); // the VERIFIED snapshot
+    expect(p.ops[0].quads).toHaveLength(3);
   });
 
-  it('DEFERS orphan data (no sibling meta in page) — cursor stays before it', () => {
-    const page = buildPage([{ seq: 5, graph: DATA, count: 3 }]); // data only, meta absent
+  it('DEFERS orphan data (no sibling meta in page)', () => {
+    const page = buildPage([{ seq: 5, graph: DATA, count: 3 }]);
     const p = plan(page, { nextSeq: 5, priorSeq: 4 });
     expect(p.deferred).toBe(true);
     expect(p.applied).toBe(0);
-    expect(p.ops).toHaveLength(0);
-    expect(p.advanceTo).toBe(4); // earliestUnresolved(5) - 1, clamped to priorSeq
+    expect(p.advanceTo).toBe(4);
   });
 
-  it('DEFERS a partially-rejected data graph (not all quads survived verification)', () => {
-    const page = buildPage([
-      { seq: 2, graph: DATA, count: 3, verified: 2 }, // one KC quad rejected
-      { seq: 3, graph: META, count: 1 },
-    ]);
+  it('DEFERS when the batch did not verify cleanly (a KC was rejected)', () => {
+    const page = buildPage([{ seq: 2, graph: DATA, count: 3 }, { seq: 3, graph: META, count: 1 }]);
+    const p = plan(page, { nextSeq: 3, batchClean: false });
+    expect(p.deferred).toBe(true);
+    expect(p.ops).toHaveLength(0);
+    expect(p.advanceTo).toBe(1);
+  });
+
+  it('DEFERS when the sibling meta carries no merkle root (rootless meta cannot bind data)', () => {
+    const page = buildPage([{ seq: 2, graph: DATA, count: 3 }, { seq: 3, graph: META, count: 1, noRoot: true }]);
     const p = plan(page, { nextSeq: 3 });
     expect(p.deferred).toBe(true);
-    expect(p.advanceTo).toBe(1); // stop before the data record at seq 2
     expect(p.ops).toHaveLength(0);
+  });
+
+  it('DEFERS a partially-rejected data graph (not all quads survived)', () => {
+    const page = buildPage([{ seq: 2, graph: DATA, count: 3, verified: 2 }, { seq: 3, graph: META, count: 1 }]);
+    const p = plan(page, { nextSeq: 3 });
+    expect(p.deferred).toBe(true);
+    expect(p.advanceTo).toBe(1);
+  });
+
+  it('an EMPTY-content upsert is a resolved NO-OP — never a delete (regression: silent hard-delete)', () => {
+    // Data + meta records that both parsed to ZERO quads (empty/malformed page).
+    const page = buildPage([{ seq: 4, graph: DATA, count: 0 }, { seq: 5, graph: META, count: 0 }]);
+    const p = plan(page, { nextSeq: 5 });
+    expect(p.deferred).toBe(false);   // consumed, not stalled
+    expect(p.ops).toHaveLength(0);    // NO dropGraph op emitted → no deletion
+    expect(p.advanceTo).toBe(5);
   });
 
   it('stops at the FIRST unresolved record (contiguous prefix)', () => {
     const G2 = 'did:dkg:context-graph:cg/context/2';
     const page = buildPage([
-      { seq: 1, graph: 'did:dkg:context-graph:cg/x', op: 'drop' }, // resolves
-      { seq: 4, graph: G2, count: 1 },                              // orphan (no meta) ⇒ defer here
-      { seq: 6, graph: DATA, count: 1 },                            // paired, but AFTER the unresolved
-      { seq: 7, graph: META, count: 1 },
+      { seq: 1, graph: 'did:dkg:context-graph:cg/x', op: 'drop' },
+      { seq: 4, graph: G2, count: 1 },          // orphan (no meta) ⇒ defer here
+      { seq: 6, graph: DATA, count: 1 }, { seq: 7, graph: META, count: 1 },
     ]);
     const p = plan(page, { nextSeq: 7 });
     expect(p.deferred).toBe(true);
-    expect(p.ops.map((o) => o.graph)).toEqual(['did:dkg:context-graph:cg/x']); // only the drop before seq 4
-    expect(p.advanceTo).toBe(3); // 4 - 1
+    expect(p.ops.map((o) => o.graph)).toEqual(['did:dkg:context-graph:cg/x']);
+    expect(p.advanceTo).toBe(3);
   });
 
   it('skips a leaked foreign graph but consumes its seq', () => {
@@ -121,6 +140,7 @@ describe('planPageApply — verified-apply planner', () => {
 function loopHarness(
   responses: ChangelogSyncResponse[],
   applyPage: ChangelogSyncDeps['applyPage'],
+  resync: () => Promise<ResyncOutcome> = async () => ({ complete: true, insertedTriples: 0 }),
 ) {
   let cursor: { era: string; seq: number } | undefined;
   const requests: ChangelogSyncRequest[] = [];
@@ -136,7 +156,7 @@ function loopHarness(
       return encodeChangelogResponse(r);
     },
     applyPage,
-    runResync: async () => { resyncs += 1; },
+    runResync: async () => { resyncs += 1; return resync(); },
     logWarn: () => {},
   };
   return { deps, requests, resyncs: () => resyncs, cursor: () => cursor };
@@ -151,27 +171,37 @@ describe('runChangelogSync — driver loop', () => {
     const out = await runChangelogSync(h.deps);
     expect(out).toEqual({ kind: 'delta', applied: 2 });
     expect(h.cursor()).toEqual({ era: 'e1', seq: 3 });
-    expect(h.requests[0]).toMatchObject({ sinceSeq: 0, era: null });
   });
 
   it('loops across pages, threading the cursor via advanceTo', async () => {
-    const h = loopHarness(
-      [delta(4, 2), delta(4, 4)],
-      async (p) => ({ advanceTo: p.nextSeq, applied: 1, deferred: false }),
-    );
+    const h = loopHarness([delta(4, 2), delta(4, 4)], async (p) => ({ advanceTo: p.nextSeq, applied: 1, deferred: false }));
     const out = await runChangelogSync(h.deps);
     expect(out.applied).toBe(2);
-    expect(h.requests).toHaveLength(2);
     expect(h.requests[1]).toMatchObject({ sinceSeq: 2 });
     expect(h.cursor()).toEqual({ era: 'e1', seq: 4 });
   });
 
-  it('resync bootstraps and pins the cursor to (era, headSeq)', async () => {
-    const h = loopHarness([{ kind: 'resync', era: 'e2', headSeq: 9 }], async () => ({ advanceTo: 0, applied: 0, deferred: false }));
+  it('resync: COMPLETE bootstrap advances the cursor to headSeq and folds inserts', async () => {
+    const h = loopHarness(
+      [{ kind: 'resync', era: 'e2', headSeq: 9 }],
+      async () => ({ advanceTo: 0, applied: 0, deferred: false }),
+      async () => ({ complete: true, insertedTriples: 42 }),
+    );
     const out = await runChangelogSync(h.deps);
-    expect(out.kind).toBe('resync');
+    expect(out).toEqual({ kind: 'resync', applied: 42 });
     expect(h.resyncs()).toBe(1);
     expect(h.cursor()).toEqual({ era: 'e2', seq: 9 });
+  });
+
+  it('resync: PARTIAL bootstrap does NOT advance the cursor (no gap below headSeq)', async () => {
+    const h = loopHarness(
+      [{ kind: 'resync', era: 'e2', headSeq: 9 }],
+      async () => ({ advanceTo: 0, applied: 0, deferred: false }),
+      async () => ({ complete: false, insertedTriples: 5 }),
+    );
+    const out = await runChangelogSync(h.deps);
+    expect(out).toEqual({ kind: 'resync', applied: 5 });
+    expect(h.cursor()).toBeUndefined(); // cursor left untouched — next cycle retries the resync
   });
 
   it('stops on denied without advancing', async () => {
@@ -182,20 +212,19 @@ describe('runChangelogSync — driver loop', () => {
   });
 
   it('falls back to resync after RESYNC_AFTER_STALLED_ROUNDS no-progress rounds', async () => {
-    // applyPage always defers with no forward progress (advanceTo == priorSeq).
     const h = loopHarness(
       [delta(9, 9), delta(9, 9), delta(9, 9), delta(9, 9)],
       async (p) => ({ advanceTo: p.priorSeq, applied: 0, deferred: true }),
+      async () => ({ complete: true, insertedTriples: 0 }),
     );
     const out = await runChangelogSync(h.deps);
     expect(out.kind).toBe('resync');
     expect(h.resyncs()).toBe(1);
-    expect(h.requests.length).toBe(3); // stalls after 3 rounds, then resyncs
+    expect(h.requests.length).toBe(3);
     expect(h.cursor()).toEqual({ era: 'e1', seq: 9 });
   });
 
   it('keeps looping (no resync) while a deferred page still makes forward progress', async () => {
-    // Round 1 applies a prefix (advanceTo 2 > prior 0) but defers the rest; round 2 completes.
     const h = loopHarness(
       [delta(4, 4), delta(4, 4)],
       async (p) => p.priorSeq === 0
@@ -205,12 +234,11 @@ describe('runChangelogSync — driver loop', () => {
     const out = await runChangelogSync(h.deps);
     expect(out.kind).toBe('delta');
     expect(h.resyncs()).toBe(0);
-    expect(h.requests[1]).toMatchObject({ sinceSeq: 2 });
     expect(h.cursor()).toEqual({ era: 'e1', seq: 4 });
   });
 });
 
-// ── decodeChangelogResponse cursor invariants (unchanged wire hardening) ─────
+// ── decodeChangelogResponse cursor invariants (wire hardening) ──────────────
 
 describe('decodeChangelogResponse cursor invariants', () => {
   const bad = (resp: unknown) => encodeChangelogResponse(resp as ChangelogSyncResponse);

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -575,7 +575,7 @@ export interface DkgConfig {
   /** Block explorer URL for TX links (default: derived from chainId). */
   blockExplorerUrl?: string;
   /** Triple store backend override (default: oxigraph-worker with file persistence). */
-  store?: { backend: string; options?: Record<string, unknown>; graphSetIndex?: boolean | GraphSetIndexConfig };
+  store?: { backend: string; options?: Record<string, unknown>; graphSetIndex?: boolean | GraphSetIndexConfig; changelog?: boolean };
   /**
    * Intentional cap on how many persisted context-graph subscriptions a node
    * ACTIVATES on boot (gossip + sync). A large stale backlog otherwise fans out

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -96,6 +96,7 @@ import {
   SqliteProtocolOutboxStore,
   SqliteSyncCheckpointStore,
   SqliteChangelogCursorStore,
+  SqliteChangelogEraGuard,
   SqliteChainEventCursorStore,
   SqliteContextGraphRegistryScanCursorStore,
   SqliteKaNumberStore,
@@ -1501,6 +1502,10 @@ export async function runDaemonInner(
   });
   const syncCheckpointStore = new SqliteSyncCheckpointStore(dashDb);
   const changelogCursorStore = new SqliteChangelogCursorStore(dashDb);
+  // OT-RFC-59 §6 P0: the durable era guard MUST back the changelog when enabled —
+  // it lives in node-ui.db (survives a `store.nq` RDF restore) so a restore/rollback
+  // rotates the era and forces peers to full-resync instead of silently skipping.
+  const changelogEraGuard = config.store?.changelog ? new SqliteChangelogEraGuard(dashDb) : undefined;
   const chainEventCursorStore = new SqliteChainEventCursorStore(dashDb, { scope: chainCursorScope });
   const contextGraphRegistryScanCursorStore = new SqliteContextGraphRegistryScanCursorStore(dashDb);
 
@@ -1565,7 +1570,11 @@ export async function runDaemonInner(
       // managed-oxigraph path rebuilds runtimeStore and would drop it. Enabling
       // this wraps the store in ChangelogStore, which is what makes
       // asChangelogReader(store) non-null and registers the responder delta lane.
-      changelog: config.store?.changelog,
+      // Wire the DURABLE era guard (§6 P0) so restore/rollback rotates the era —
+      // enabling the changelog fleet-wide without it is unsafe (silent skips).
+      changelog: config.store?.changelog
+        ? { enabled: true, eraGuard: changelogEraGuard }
+        : undefined,
     } : undefined,
     largeLiteralStorage: runtimeLargeLiteralStorage,
     sharedMemoryPublicSnapshotStorage: runtimeSnapshotStorage,

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1558,6 +1558,12 @@ export async function runDaemonInner(
       backend: runtimeStore.backend,
       options: runtimeStore.options,
       graphSetIndex: runtimeStore.graphSetIndex,
+      // OT-RFC-59: operator opt-in to the append-only change log (default OFF).
+      // Sourced from config.store (operator intent), NOT runtimeStore — the
+      // managed-oxigraph path rebuilds runtimeStore and would drop it. Enabling
+      // this wraps the store in ChangelogStore, which is what makes
+      // asChangelogReader(store) non-null and registers the responder delta lane.
+      changelog: config.store?.changelog,
     } : undefined,
     largeLiteralStorage: runtimeLargeLiteralStorage,
     sharedMemoryPublicSnapshotStorage: runtimeSnapshotStorage,

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -95,6 +95,7 @@ import {
   SqliteMessageIdempotencyStore,
   SqliteProtocolOutboxStore,
   SqliteSyncCheckpointStore,
+  SqliteChangelogCursorStore,
   SqliteChainEventCursorStore,
   SqliteContextGraphRegistryScanCursorStore,
   SqliteKaNumberStore,
@@ -1499,6 +1500,7 @@ export async function runDaemonInner(
     },
   });
   const syncCheckpointStore = new SqliteSyncCheckpointStore(dashDb);
+  const changelogCursorStore = new SqliteChangelogCursorStore(dashDb);
   const chainEventCursorStore = new SqliteChainEventCursorStore(dashDb, { scope: chainCursorScope });
   const contextGraphRegistryScanCursorStore = new SqliteContextGraphRegistryScanCursorStore(dashDb);
 
@@ -1606,6 +1608,7 @@ export async function runDaemonInner(
     randomSamplingUseWorkerThread: config.randomSampling?.useWorkerThread,
     storageAckTiming,
     syncCheckpointStore,
+    changelogCursorStore,
     chainEventCursorStore,
     contextGraphRegistryScanCursorStore,
     contextGraphSubscriptionStore: {

--- a/packages/cli/src/publisher-runner.ts
+++ b/packages/cli/src/publisher-runner.ts
@@ -547,6 +547,12 @@ async function createPublisherStore(dataDir: string, config: DkgConfig): Promise
     const storeConfig = config.store as any;
     return await createTripleStore({
       ...storeConfig,
+      // OT-RFC-59 §5.3: the daemon-down CLI publisher is a SECOND writer against
+      // the same store. It MUST NOT maintain the change log — a second in-memory
+      // seq allocator would fork the log (commit order ≠ seq order across
+      // processes). Only the single-writer daemon owns the changelog; force it
+      // off here regardless of config.store.changelog.
+      changelog: false,
       largeLiteralStorage: config.largeLiteralStorage ?? (
         isLocalOxigraphStoreConfig(storeConfig)
           ? defaultLargeLiteralStorage(dataDir, config)

--- a/packages/node-ui/src/db.ts
+++ b/packages/node-ui/src/db.ts
@@ -15,7 +15,7 @@ export {
   SqliteContextGraphRegistryScanCursorStore,
 } from './chain-cursor-stores.js';
 
-const SCHEMA_VERSION = 22;
+const SCHEMA_VERSION = 23;
 // Default operator retention. Lowered from 90 → 14 days on V15 (2026-05) after
 // a production incident in which the `logs` table + its FTS5 shadow tables
 // grew to ~9 GB on a 12-day-old node and corrupted the SQLite page (header
@@ -812,6 +812,22 @@ export class DashboardDB {
       this.db.exec(`
         CREATE INDEX IF NOT EXISTS idx_runtime_cursors_namespace_scope
           ON runtime_cursors(namespace, scope);
+      `);
+    }
+
+    if (version < 23) {
+      // OT-RFC-59 SC5: durable per-(peer, contextGraph) changelog cursor. NEVER
+      // pruned (see SqliteChangelogCursorStore) — a TTL would defeat the O(delta)
+      // cross-restart catch-up this table exists for.
+      this.db.exec(`
+        CREATE TABLE IF NOT EXISTS changelog_cursors (
+          peer_id TEXT NOT NULL,
+          context_graph_id TEXT NOT NULL,
+          era TEXT NOT NULL,
+          seq INTEGER NOT NULL CHECK (seq >= 0),
+          updated_at INTEGER NOT NULL,
+          PRIMARY KEY (peer_id, context_graph_id)
+        );
       `);
     }
 
@@ -2419,6 +2435,45 @@ export class SqliteSyncCheckpointStore {
 
   pruneExpired(nowMs = this.clock()): number {
     return this.db.prepare(`DELETE FROM sync_checkpoints WHERE expires_at < ?`).run(nowMs).changes;
+  }
+}
+
+/**
+ * OT-RFC-59 SC5 durable changelog cursor store (duck-compatible with the agent's
+ * ChangelogCursorStore). Keyed by (peer_id, context_graph_id); stores the last
+ * APPLIED (era, seq) from that responder. Like `ka_numbers` / `protocol_outbox`
+ * this state is durable: it is NEVER added to `prune()` — a TTL would defeat the
+ * O(delta) cross-restart catch-up the changelog lane exists for.
+ */
+export class SqliteChangelogCursorStore {
+  private readonly db: Database.Database;
+  private readonly clock: () => number;
+
+  constructor(dashboard: DashboardDB, options: { clock?: () => number } = {}) {
+    this.db = dashboard.db;
+    this.clock = options.clock ?? (() => Date.now());
+  }
+
+  get(peerId: string, contextGraphId: string): { era: string; seq: number; updatedAtMs: number } | undefined {
+    const row = this.db.prepare(
+      `SELECT era, seq, updated_at FROM changelog_cursors WHERE peer_id = ? AND context_graph_id = ?`,
+    ).get(peerId, contextGraphId) as { era: string; seq: number; updated_at: number } | undefined;
+    if (!row) return undefined;
+    return { era: row.era, seq: row.seq, updatedAtMs: row.updated_at };
+  }
+
+  set(peerId: string, contextGraphId: string, era: string, seq: number, nowMs = this.clock()): void {
+    if (!Number.isSafeInteger(seq) || seq < 0) {
+      throw new Error(`Invalid changelog cursor seq for ${peerId}/${contextGraphId}: ${seq}`);
+    }
+    this.db.prepare(`
+      INSERT INTO changelog_cursors (peer_id, context_graph_id, era, seq, updated_at)
+      VALUES (?, ?, ?, ?, ?)
+      ON CONFLICT(peer_id, context_graph_id) DO UPDATE SET
+        era = excluded.era,
+        seq = excluded.seq,
+        updated_at = excluded.updated_at
+    `).run(peerId, contextGraphId, era, seq, nowMs);
   }
 }
 

--- a/packages/node-ui/src/db.ts
+++ b/packages/node-ui/src/db.ts
@@ -15,7 +15,7 @@ export {
   SqliteContextGraphRegistryScanCursorStore,
 } from './chain-cursor-stores.js';
 
-const SCHEMA_VERSION = 23;
+const SCHEMA_VERSION = 24;
 // Default operator retention. Lowered from 90 → 14 days on V15 (2026-05) after
 // a production incident in which the `logs` table + its FTS5 shadow tables
 // grew to ~9 GB on a 12-day-old node and corrupted the SQLite page (header
@@ -827,6 +827,22 @@ export class DashboardDB {
           seq INTEGER NOT NULL CHECK (seq >= 0),
           updated_at INTEGER NOT NULL,
           PRIMARY KEY (peer_id, context_graph_id)
+        );
+      `);
+    }
+
+    if (version < 24) {
+      // OT-RFC-59 §6 P0 durable era guard: the write-side ChangelogStore's
+      // restore-detection needs the (era, highSeq) high-water in a store that a
+      // `store.nq` restore does NOT roll back with the RDF store. node-ui.db
+      // survives such a restore, so a rollback under the same era rotates the era
+      // (forcing peers to full-resync instead of silently skipping). Single row.
+      this.db.exec(`
+        CREATE TABLE IF NOT EXISTS changelog_era (
+          id INTEGER PRIMARY KEY CHECK (id = 1),
+          era TEXT NOT NULL,
+          high_seq INTEGER NOT NULL CHECK (high_seq >= 0),
+          updated_at INTEGER NOT NULL
         );
       `);
     }
@@ -2474,6 +2490,46 @@ export class SqliteChangelogCursorStore {
         seq = excluded.seq,
         updated_at = excluded.updated_at
     `).run(peerId, contextGraphId, era, seq, nowMs);
+  }
+}
+
+/**
+ * OT-RFC-59 §6 P0 durable era guard (duck-compatible with storage's
+ * ChangelogEraGuard). Persists the single (era, high_seq) high-water in
+ * node-ui.db — which a `store.nq` RDF-store restore does NOT roll back — so the
+ * write-side ChangelogStore can detect a restore/rollback (seq regressed under
+ * the same era) and rotate the era, forcing peers to full-resync instead of
+ * silently skipping. `save` is called after every committed seq, so it must be a
+ * single fast upsert.
+ */
+export class SqliteChangelogEraGuard {
+  private readonly db: Database.Database;
+  private readonly clock: () => number;
+
+  constructor(dashboard: DashboardDB, options: { clock?: () => number } = {}) {
+    this.db = dashboard.db;
+    this.clock = options.clock ?? (() => Date.now());
+  }
+
+  async load(): Promise<{ era: string; highSeq: number } | null> {
+    const row = this.db.prepare(
+      `SELECT era, high_seq FROM changelog_era WHERE id = 1`,
+    ).get() as { era: string; high_seq: number } | undefined;
+    return row ? { era: row.era, highSeq: row.high_seq } : null;
+  }
+
+  async save(era: string, highSeq: number): Promise<void> {
+    if (!Number.isSafeInteger(highSeq) || highSeq < 0) {
+      throw new Error(`Invalid changelog era high_seq: ${highSeq}`);
+    }
+    this.db.prepare(`
+      INSERT INTO changelog_era (id, era, high_seq, updated_at)
+      VALUES (1, ?, ?, ?)
+      ON CONFLICT(id) DO UPDATE SET
+        era = excluded.era,
+        high_seq = excluded.high_seq,
+        updated_at = excluded.updated_at
+    `).run(era, highSeq, this.clock());
   }
 }
 

--- a/packages/node-ui/src/index.ts
+++ b/packages/node-ui/src/index.ts
@@ -4,6 +4,7 @@ export {
   SqliteProtocolOutboxStore,
   type SqliteProtocolOutboxStoreOptions,
   SqliteSyncCheckpointStore,
+  SqliteChangelogCursorStore,
   SqliteKaNumberStore,
   // Notifications-pane redesign (V16): activity-digest primitives shared
   // with the daemon's `assertion_activity` emitters + scoped read path.

--- a/packages/node-ui/src/index.ts
+++ b/packages/node-ui/src/index.ts
@@ -5,6 +5,7 @@ export {
   type SqliteProtocolOutboxStoreOptions,
   SqliteSyncCheckpointStore,
   SqliteChangelogCursorStore,
+  SqliteChangelogEraGuard,
   SqliteKaNumberStore,
   // Notifications-pane redesign (V16): activity-digest primitives shared
   // with the daemon's `assertion_activity` emitters + scoped read path.

--- a/packages/node-ui/test/db.test.ts
+++ b/packages/node-ui/test/db.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import Database from 'better-sqlite3';
-import { DashboardDB, SqliteChainEventCursorStore, SqliteContextGraphRegistryScanCursorStore, SqliteKaNumberStore, SqliteSyncCheckpointStore, SqliteChangelogCursorStore, buildActivityDigestKey, ACTIVITY_DIGEST_WINDOW_MS, ASSERTION_ACTIVITY_TYPE } from '../src/db.js';
+import { DashboardDB, SqliteChainEventCursorStore, SqliteContextGraphRegistryScanCursorStore, SqliteKaNumberStore, SqliteSyncCheckpointStore, SqliteChangelogCursorStore, SqliteChangelogEraGuard, buildActivityDigestKey, ACTIVITY_DIGEST_WINDOW_MS, ASSERTION_ACTIVITY_TYPE } from '../src/db.js';
 
 let db: DashboardDB;
 let dir: string;
@@ -86,7 +86,7 @@ describe('DashboardDB — metric snapshots', () => {
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(23);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(24);
 
     const cols = (db.db.prepare('PRAGMA table_info(metric_snapshots)').all() as Array<{ name: string }>)
       .map((c) => c.name);
@@ -142,7 +142,7 @@ describe('DashboardDB — metric snapshots', () => {
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(23);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(24);
 
     const newSnapshotCols = (db.db.prepare('PRAGMA table_info(metric_snapshots)').all() as { name: string }[])
       .map(c => c.name);
@@ -545,7 +545,7 @@ describe('DashboardDB — V15 migration: drop FTS5 logs index', () => {
 
     const upgraded = new DashboardDB({ dataDir: upgradeDir });
     try {
-      expect(upgraded.db.pragma('user_version', { simple: true })).toBe(23);
+      expect(upgraded.db.pragma('user_version', { simple: true })).toBe(24);
 
       const ftsTables = upgraded.db.prepare(
         `SELECT name FROM sqlite_master WHERE type IN ('table','view') AND name LIKE 'logs_fts%'`,
@@ -785,7 +785,7 @@ describe('DashboardDB — V17 subscription columns migration (Phase B)', () => {
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(23);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(24);
 
     const cols = (db.db.prepare('PRAGMA table_info(context_graph_subscriptions)').all() as Array<{ name: string }>)
       .map((c) => c.name);
@@ -806,7 +806,7 @@ describe('DashboardDB — V17 subscription columns migration (Phase B)', () => {
       .map((c) => c.name);
     expect(cols).toContain('on_chain_hash');
     expect(cols).toContain('last_reconciled_ordinal');
-    expect(db.db.pragma('user_version', { simple: true })).toBe(23);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(24);
   });
 });
 
@@ -890,7 +890,7 @@ describe('DashboardDB — V19 core_hosted column migration (Phase D)', () => {
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(23);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(24);
 
     const cols = (db.db.prepare('PRAGMA table_info(context_graph_subscriptions)').all() as Array<{ name: string }>)
       .map((c) => c.name);
@@ -919,7 +919,7 @@ describe('DashboardDB — V20 ka_numbers table migration (B2 KA-number allocator
   });
 
   it('fresh install lands at the current schema and already carries the ka_numbers table', () => {
-    expect(db.db.pragma('user_version', { simple: true })).toBe(23);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(24);
 
     const table = db.db.prepare(
       "SELECT name FROM sqlite_master WHERE type='table' AND name='ka_numbers'",
@@ -956,7 +956,7 @@ describe('DashboardDB — V20 ka_numbers table migration (B2 KA-number allocator
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(23);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(24);
 
     const table = db.db.prepare(
       "SELECT name FROM sqlite_master WHERE type='table' AND name='ka_numbers'",
@@ -1049,7 +1049,7 @@ describe('DashboardDB — V21 sync_checkpoints table (A3 sync resume)', () => {
   });
 
   it('fresh install carries the sync_checkpoints table and expiry index', () => {
-    expect(db.db.pragma('user_version', { simple: true })).toBe(23);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(24);
     const tables = db.db.prepare(
       `SELECT name FROM sqlite_master WHERE type='table' AND name='sync_checkpoints'`,
     ).all();
@@ -1115,7 +1115,7 @@ describe('DashboardDB — V21 sync_checkpoints table (A3 sync resume)', () => {
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(23);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(24);
     expect(db.db.prepare(
       `SELECT name FROM sqlite_master WHERE type='table' AND name='sync_checkpoints'`,
     ).all()).toHaveLength(1);
@@ -1564,7 +1564,7 @@ describe('DashboardDB — V11→V13 chat schema migration chain', () => {
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(23);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(24);
 
     const cols = (db.db.prepare('PRAGMA table_info(chat_messages)').all() as Array<{ name: string }>)
       .map((c) => c.name);
@@ -1630,7 +1630,7 @@ describe('DashboardDB — V16 notifications.context_graph_id migration (A1)', ()
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(23);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(24);
 
     const cols = (db.db.prepare('PRAGMA table_info(notifications)').all() as Array<{ name: string }>)
       .map((c) => c.name);
@@ -1659,7 +1659,7 @@ describe('DashboardDB — V16 notifications.context_graph_id migration (A1)', ()
     const cols = (db.db.prepare('PRAGMA table_info(notifications)').all() as Array<{ name: string }>)
       .map((c) => c.name);
     expect(cols).toContain('context_graph_id');
-    expect(db.db.pragma('user_version', { simple: true })).toBe(23);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(24);
   });
 
   it('insertNotification writes context_graph_id to the column; omitted → NULL', () => {
@@ -1902,7 +1902,7 @@ describe('DashboardDB — replication telemetry (Phase F)', () => {
     raw.pragma('user_version = 17');
     raw.close();
     const upgraded = new DashboardDB({ dataDir: dir });
-    expect(upgraded.db.pragma('user_version', { simple: true })).toBe(23);
+    expect(upgraded.db.pragma('user_version', { simple: true })).toBe(24);
     // insert works → table exists
     upgraded.insertReplicationEvent({ ts: now, context_graph_id: 'cg', action: 'promote' });
     expect(upgraded.getReplicationSummary(60_000).promotes).toBe(1);
@@ -1933,5 +1933,30 @@ describe('SqliteChangelogCursorStore — OT-RFC-59 durable (era,seq) cursor (SC5
     const db2 = new DashboardDB({ dataDir: dir });
     const store2 = new SqliteChangelogCursorStore(db2);
     expect(store2.get('peerA', 'cg1')).toMatchObject({ era: 'era-2', seq: 9 });
+  });
+});
+
+describe('SqliteChangelogEraGuard — OT-RFC-59 §6 P0 durable era guard', () => {
+  it('round-trips (era, highSeq) as a singleton, is durable across reopen, validates highSeq', async () => {
+    const guard = new SqliteChangelogEraGuard(db);
+    expect(await guard.load()).toBeNull();
+    await guard.save('era-1', 10);
+    expect(await guard.load()).toEqual({ era: 'era-1', highSeq: 10 });
+    // singleton: a second save REPLACES (not a second row) — this is the node-global high-water
+    await guard.save('era-2', 42);
+    expect(await guard.load()).toEqual({ era: 'era-2', highSeq: 42 });
+    await expect(guard.save('era-2', -1)).rejects.toThrow(/Invalid changelog era high_seq/);
+    // survives a fresh DashboardDB on the same dir (the whole point — outlives a store.nq restore)
+    const guard2 = new SqliteChangelogEraGuard(new DashboardDB({ dataDir: dir }));
+    expect(await guard2.load()).toEqual({ era: 'era-2', highSeq: 42 });
+  });
+
+  it('an existing pre-v24 db upgrades and gains the changelog_era + changelog_cursors tables', () => {
+    // Fresh db is already at current version; assert both OT-RFC-59 tables exist after migration.
+    const tables = (db.db.prepare("SELECT name FROM sqlite_master WHERE type='table'").all() as Array<{ name: string }>)
+      .map((t) => t.name);
+    expect(tables).toContain('changelog_cursors');
+    expect(tables).toContain('changelog_era');
+    expect(db.db.pragma('user_version', { simple: true })).toBe(24);
   });
 });

--- a/packages/node-ui/test/db.test.ts
+++ b/packages/node-ui/test/db.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import Database from 'better-sqlite3';
-import { DashboardDB, SqliteChainEventCursorStore, SqliteContextGraphRegistryScanCursorStore, SqliteKaNumberStore, SqliteSyncCheckpointStore, buildActivityDigestKey, ACTIVITY_DIGEST_WINDOW_MS, ASSERTION_ACTIVITY_TYPE } from '../src/db.js';
+import { DashboardDB, SqliteChainEventCursorStore, SqliteContextGraphRegistryScanCursorStore, SqliteKaNumberStore, SqliteSyncCheckpointStore, SqliteChangelogCursorStore, buildActivityDigestKey, ACTIVITY_DIGEST_WINDOW_MS, ASSERTION_ACTIVITY_TYPE } from '../src/db.js';
 
 let db: DashboardDB;
 let dir: string;
@@ -86,7 +86,7 @@ describe('DashboardDB — metric snapshots', () => {
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(22);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(23);
 
     const cols = (db.db.prepare('PRAGMA table_info(metric_snapshots)').all() as Array<{ name: string }>)
       .map((c) => c.name);
@@ -142,7 +142,7 @@ describe('DashboardDB — metric snapshots', () => {
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(22);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(23);
 
     const newSnapshotCols = (db.db.prepare('PRAGMA table_info(metric_snapshots)').all() as { name: string }[])
       .map(c => c.name);
@@ -545,7 +545,7 @@ describe('DashboardDB — V15 migration: drop FTS5 logs index', () => {
 
     const upgraded = new DashboardDB({ dataDir: upgradeDir });
     try {
-      expect(upgraded.db.pragma('user_version', { simple: true })).toBe(22);
+      expect(upgraded.db.pragma('user_version', { simple: true })).toBe(23);
 
       const ftsTables = upgraded.db.prepare(
         `SELECT name FROM sqlite_master WHERE type IN ('table','view') AND name LIKE 'logs_fts%'`,
@@ -785,7 +785,7 @@ describe('DashboardDB — V17 subscription columns migration (Phase B)', () => {
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(22);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(23);
 
     const cols = (db.db.prepare('PRAGMA table_info(context_graph_subscriptions)').all() as Array<{ name: string }>)
       .map((c) => c.name);
@@ -806,7 +806,7 @@ describe('DashboardDB — V17 subscription columns migration (Phase B)', () => {
       .map((c) => c.name);
     expect(cols).toContain('on_chain_hash');
     expect(cols).toContain('last_reconciled_ordinal');
-    expect(db.db.pragma('user_version', { simple: true })).toBe(22);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(23);
   });
 });
 
@@ -890,7 +890,7 @@ describe('DashboardDB — V19 core_hosted column migration (Phase D)', () => {
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(22);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(23);
 
     const cols = (db.db.prepare('PRAGMA table_info(context_graph_subscriptions)').all() as Array<{ name: string }>)
       .map((c) => c.name);
@@ -919,7 +919,7 @@ describe('DashboardDB — V20 ka_numbers table migration (B2 KA-number allocator
   });
 
   it('fresh install lands at the current schema and already carries the ka_numbers table', () => {
-    expect(db.db.pragma('user_version', { simple: true })).toBe(22);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(23);
 
     const table = db.db.prepare(
       "SELECT name FROM sqlite_master WHERE type='table' AND name='ka_numbers'",
@@ -956,7 +956,7 @@ describe('DashboardDB — V20 ka_numbers table migration (B2 KA-number allocator
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(22);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(23);
 
     const table = db.db.prepare(
       "SELECT name FROM sqlite_master WHERE type='table' AND name='ka_numbers'",
@@ -1049,7 +1049,7 @@ describe('DashboardDB — V21 sync_checkpoints table (A3 sync resume)', () => {
   });
 
   it('fresh install carries the sync_checkpoints table and expiry index', () => {
-    expect(db.db.pragma('user_version', { simple: true })).toBe(22);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(23);
     const tables = db.db.prepare(
       `SELECT name FROM sqlite_master WHERE type='table' AND name='sync_checkpoints'`,
     ).all();
@@ -1115,7 +1115,7 @@ describe('DashboardDB — V21 sync_checkpoints table (A3 sync resume)', () => {
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(22);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(23);
     expect(db.db.prepare(
       `SELECT name FROM sqlite_master WHERE type='table' AND name='sync_checkpoints'`,
     ).all()).toHaveLength(1);
@@ -1564,7 +1564,7 @@ describe('DashboardDB — V11→V13 chat schema migration chain', () => {
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(22);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(23);
 
     const cols = (db.db.prepare('PRAGMA table_info(chat_messages)').all() as Array<{ name: string }>)
       .map((c) => c.name);
@@ -1630,7 +1630,7 @@ describe('DashboardDB — V16 notifications.context_graph_id migration (A1)', ()
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(22);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(23);
 
     const cols = (db.db.prepare('PRAGMA table_info(notifications)').all() as Array<{ name: string }>)
       .map((c) => c.name);
@@ -1659,7 +1659,7 @@ describe('DashboardDB — V16 notifications.context_graph_id migration (A1)', ()
     const cols = (db.db.prepare('PRAGMA table_info(notifications)').all() as Array<{ name: string }>)
       .map((c) => c.name);
     expect(cols).toContain('context_graph_id');
-    expect(db.db.pragma('user_version', { simple: true })).toBe(22);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(23);
   });
 
   it('insertNotification writes context_graph_id to the column; omitted → NULL', () => {
@@ -1902,10 +1902,36 @@ describe('DashboardDB — replication telemetry (Phase F)', () => {
     raw.pragma('user_version = 17');
     raw.close();
     const upgraded = new DashboardDB({ dataDir: dir });
-    expect(upgraded.db.pragma('user_version', { simple: true })).toBe(22);
+    expect(upgraded.db.pragma('user_version', { simple: true })).toBe(23);
     // insert works → table exists
     upgraded.insertReplicationEvent({ ts: now, context_graph_id: 'cg', action: 'promote' });
     expect(upgraded.getReplicationSummary(60_000).promotes).toBe(1);
     upgraded.close();
+  });
+});
+
+describe('SqliteChangelogCursorStore — OT-RFC-59 durable (era,seq) cursor (SC5)', () => {
+  it('upserts per (peer,cg), keeps keys independent, is durable across reopen, validates seq', () => {
+    const store = new SqliteChangelogCursorStore(db);
+    expect(store.get('peerA', 'cg1')).toBeUndefined();
+    store.set('peerA', 'cg1', 'era-1', 5);
+    expect(store.get('peerA', 'cg1')).toMatchObject({ era: 'era-1', seq: 5 });
+    // upsert (same key) replaces era + seq
+    store.set('peerA', 'cg1', 'era-2', 9);
+    expect(store.get('peerA', 'cg1')).toMatchObject({ era: 'era-2', seq: 9 });
+    // distinct (peer,cg) keys are independent (seq is per-responder-node)
+    store.set('peerB', 'cg1', 'era-x', 3);
+    store.set('peerA', 'cg2', 'era-y', 7);
+    expect(store.get('peerB', 'cg1')!.seq).toBe(3);
+    expect(store.get('peerA', 'cg2')!.seq).toBe(7);
+    expect(store.get('peerA', 'cg1')!.seq).toBe(9);
+    // seq 0 is valid (first contact / reseed); negative rejected
+    store.set('peerC', 'cg1', 'era-1', 0);
+    expect(store.get('peerC', 'cg1')!.seq).toBe(0);
+    expect(() => store.set('peerC', 'cg1', 'era-1', -1)).toThrow(/Invalid changelog cursor seq/);
+    // durable across a fresh DashboardDB on the same dir (never TTL-pruned)
+    const db2 = new DashboardDB({ dataDir: dir });
+    const store2 = new SqliteChangelogCursorStore(db2);
+    expect(store2.get('peerA', 'cg1')).toMatchObject({ era: 'era-2', seq: 9 });
   });
 });

--- a/packages/node-ui/test/messenger-stores.test.ts
+++ b/packages/node-ui/test/messenger-stores.test.ts
@@ -45,9 +45,9 @@ describe('V12 migration', () => {
     // `message_idempotency` table. Both bumps are tested at the
     // DB layer in `db.test.ts`; this assertion just pins that
     // the substrate store fixtures are created against the
-    // current SCHEMA_VERSION (now 22 after runtime cursors moved to a
-    // dedicated table).
-    expect(db.db.pragma('user_version', { simple: true })).toBe(22);
+    // current SCHEMA_VERSION (now 23 after the OT-RFC-59 changelog_cursors
+    // table was added).
+    expect(db.db.pragma('user_version', { simple: true })).toBe(23);
   });
 });
 

--- a/packages/node-ui/test/messenger-stores.test.ts
+++ b/packages/node-ui/test/messenger-stores.test.ts
@@ -45,9 +45,9 @@ describe('V12 migration', () => {
     // `message_idempotency` table. Both bumps are tested at the
     // DB layer in `db.test.ts`; this assertion just pins that
     // the substrate store fixtures are created against the
-    // current SCHEMA_VERSION (now 23 after the OT-RFC-59 changelog_cursors
-    // table was added).
-    expect(db.db.pragma('user_version', { simple: true })).toBe(23);
+    // current SCHEMA_VERSION (now 24 after the OT-RFC-59 changelog_cursors
+    // and changelog_era tables were added).
+    expect(db.db.pragma('user_version', { simple: true })).toBe(24);
   });
 });
 


### PR DESCRIPTION
Part of the OT-RFC-59 series (write-side + read-lane core already merged, #1601–#1605). This wires the **responder** delta lane and makes the changelog **enableable** (still default-OFF) — the piece that makes the merged-but-dormant code actually run.

## What
- **Responder handler** `handleChangelogSync`: decodes a `PROTOCOL_SYNC_CHANGELOG` request, applies the **same per-CG RFC-49 gate** as the legacy lane (`authorizeSyncRequest` — public CGs open, private CGs verify the signed digest), serves a bounded **O(delta)** page via `readChangelogDeltaPage`. Registered on the raw router **only when `asChangelogReader(this.store)` is non-null** (i.e. only when the changelog is enabled) ⇒ default-off, mixed-version-safe (requesters fall back to `PROTOCOL_SYNC`).
- **Enable-path**: new `config.store.changelog` (default-off) → `storeConfig.changelog` → `createTripleStore` wraps the store in `ChangelogStore`. Sourced from `config.store` (operator intent), not the managed-runtime path that would drop it.
- **§5.3 safety**: the daemon-down CLI publisher (`createPublisherStore`) is a **second writer** — forced `changelog: false` so it never maintains the log (a second seq allocator would fork commit-order vs seq-order). Only the single-writer daemon owns the log.

## Scope
Still inert until an operator sets `config.store.changelog` **and** the requester lane (SC5–SC6) exists to use the protocol. agent + cli typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)