### PR TITLE
fix(agent): skip-backoff for not-actionable reconcile ordinals (#1609)

### DIFF
--- a/packages/agent/src/chain-reconciler.ts
+++ b/packages/agent/src/chain-reconciler.ts
@@ -28,6 +28,9 @@ import {
   recordCompletion,
   absorbConfirmed,
   ordinalsToReconcile,
+  isOrdinalBackedOff,
+  recordOrdinalBackoff,
+  clearOrdinalBackoff,
 } from './reconcile-cursor.js';
 
 /**
@@ -74,6 +77,11 @@ export interface ChainReconcilerDeps {
   /** Confirmation depth (blocks) before a completed ordinal advances the watermark. */
   confirmationDepth: number;
   log: (msg: string) => void;
+  /**
+   * Clock (ms since epoch). Injectable for tests; defaults to `Date.now`. Used
+   * only for the per-ordinal skip-backoff window (#1609).
+   */
+  now?: () => number;
 }
 
 export interface ReconcileResult {
@@ -81,6 +89,11 @@ export interface ReconcileResult {
   watermark: number;
   reconciled: number;
   pending: number;
+  /**
+   * Ordinals skipped this pass because they are inside an active skip-backoff
+   * window (they are still counted in `pending` — they block the watermark).
+   */
+  backedOff: number;
 }
 
 /**
@@ -116,16 +129,27 @@ export async function reconcileContextGraph(
   // new completions this pass. Skipped when the head is unobservable.
   if (headBlock !== undefined) absorbConfirmed(state, headBlock, deps.confirmationDepth);
 
+  const now = deps.now?.() ?? Date.now();
   let reconciled = 0;
   let pending = 0;
+  let backedOff = 0;
   const ordinals = ordinalsToReconcile(state, head);
   if (headUnavailable) {
     pending = ordinals.length;
   } else {
     for (const ordinal of ordinals) {
+      if (isOrdinalBackedOff(state, ordinal, now)) {
+        // Inside an active skip-backoff window: still pending (it blocks the
+        // watermark), but don't re-run the expensive reconcile this pass — a
+        // never-matching ordinal must not be re-probed on every sweep (#1609).
+        pending += 1;
+        backedOff += 1;
+        continue;
+      }
       const outcome = await deps.reconcileOrdinal(localCgId, onChainCgId, ordinal, headBlock);
       if (outcome.status === 'reconciled' || outcome.status === 'already') {
         reconciled += 1;
+        clearOrdinalBackoff(state, ordinal);
         // With a known head, apply the reorg-depth gate; otherwise (no chain
         // head) absorb as soon as contiguous (depth 0) using the registration
         // block as a self-consistent head.
@@ -137,18 +161,22 @@ export async function reconcileContextGraph(
         );
       } else {
         pending += 1;
+        // `pending`/`skip` both mean "not actionable this pass, retry later"
+        // (no local SWM snapshot yet, or a transient chain-read failure) — grow
+        // the backoff so the next sweeps don't immediately re-run the search.
+        recordOrdinalBackoff(state, ordinal, now);
       }
     }
   }
 
   if (state.watermark !== before) {
     deps.persistWatermark(localCgId, state.watermark);
-    deps.log(`reconcile ${localCgId}: watermark ${before} -> ${state.watermark} (head=${head}, reconciled=${reconciled}, pending=${pending})`);
+    deps.log(`reconcile ${localCgId}: watermark ${before} -> ${state.watermark} (head=${head}, reconciled=${reconciled}, pending=${pending}, backedOff=${backedOff})`);
   } else if (reconciled > 0 || pending > 0) {
-    deps.log(`reconcile ${localCgId}: watermark held at ${state.watermark} (head=${head}, reconciled=${reconciled}, pending=${pending}${headUnavailable ? ', headUnavailable' : ''})`);
+    deps.log(`reconcile ${localCgId}: watermark held at ${state.watermark} (head=${head}, reconciled=${reconciled}, pending=${pending}, backedOff=${backedOff}${headUnavailable ? ', headUnavailable' : ''})`);
   }
 
-  return { head, watermark: state.watermark, reconciled, pending };
+  return { head, watermark: state.watermark, reconciled, pending, backedOff };
 }
 
 /**

--- a/packages/agent/src/reconcile-cursor.ts
+++ b/packages/agent/src/reconcile-cursor.ts
@@ -46,6 +46,18 @@ export interface CursorState {
    * sweep re-derives everything from chain + the persisted watermark.
    */
   ahead: Map<number, number>;
+  /**
+   * Per-ordinal skip-backoff: ordinals that keep returning `pending`/`skip`
+   * (no local SWM snapshot yet, or a transient chain-read failure) mapped to
+   * `{ untilMs, attempts }`. Without this, a never-matching ordinal (e.g. a KA
+   * whose SWM this node never received) is re-attempted on EVERY sweep, each
+   * attempt re-running the expensive finalization SWM search — the reconcile
+   * storm in #1609. This is purely an attempt-rate limiter: it NEVER advances or
+   * blocks the watermark, so invariant 1 (no gap permanently skipped) is
+   * untouched — a backed-off ordinal is still `[watermark, head)`, just probed
+   * less often. In-memory only (a restart re-derives it with one extra attempt).
+   */
+  backoff: Map<number, { untilMs: number; attempts: number }>;
 }
 
 /** A reconciled ordinal plus the chain block its registration was observed at. */
@@ -55,7 +67,39 @@ export interface CompletedOrdinal {
 }
 
 export function createCursorState(watermark = 0): CursorState {
-  return { watermark: Math.max(0, watermark), ahead: new Map() };
+  return { watermark: Math.max(0, watermark), ahead: new Map(), backoff: new Map() };
+}
+
+// Exponential, capped skip-backoff schedule. First skip → 30s, then ×2 up to a
+// 15-min ceiling. Early windows stay short so a KA whose SWM merely lags the
+// chain event still materialises within a few minutes; the ceiling is what
+// tames a permanently-never-matching ordinal (probed ~every 15 min instead of
+// every sweep). The reconcile sweep is a backstop — a bounded materialisation
+// delay for a late-synced KA is acceptable (the primary path materialises when
+// the SWM is already present on the first attempt).
+export const RECONCILE_BACKOFF_BASE_MS = 30_000;
+export const RECONCILE_BACKOFF_FACTOR = 2;
+export const RECONCILE_BACKOFF_CAP_MS = 900_000;
+
+/** True if `ordinal` is inside an active backoff window (skip it this pass). */
+export function isOrdinalBackedOff(state: CursorState, ordinal: number, nowMs: number): boolean {
+  const entry = state.backoff.get(ordinal);
+  return entry !== undefined && entry.untilMs > nowMs;
+}
+
+/** Record a not-actionable outcome for `ordinal`, growing its backoff window. */
+export function recordOrdinalBackoff(state: CursorState, ordinal: number, nowMs: number): void {
+  const attempts = (state.backoff.get(ordinal)?.attempts ?? 0) + 1;
+  const delay = Math.min(
+    RECONCILE_BACKOFF_BASE_MS * RECONCILE_BACKOFF_FACTOR ** (attempts - 1),
+    RECONCILE_BACKOFF_CAP_MS,
+  );
+  state.backoff.set(ordinal, { untilMs: nowMs + delay, attempts });
+}
+
+/** Clear an ordinal's backoff (it reconciled — no longer a retry candidate). */
+export function clearOrdinalBackoff(state: CursorState, ordinal: number): void {
+  state.backoff.delete(ordinal);
 }
 
 /**

--- a/packages/agent/test/chain-reconciler.test.ts
+++ b/packages/agent/test/chain-reconciler.test.ts
@@ -55,9 +55,11 @@ describe('reconcileContextGraph — sweep', () => {
   });
 
   it('a pending ordinal holds the watermark; a later sweep fills the gap', async () => {
+    let now = 1_000_000;
     let firstPass = true;
     const { deps, persisted } = makeDeps({
       getKCCount: async () => 3,
+      now: () => now,
       reconcileOrdinal: async (_cg, _onchain, ordinal) => {
         // ordinal 1 is missing SWM on the first pass only.
         if (ordinal === 1 && firstPass) return { status: 'pending' } as OrdinalOutcome;
@@ -72,6 +74,7 @@ describe('reconcileContextGraph — sweep', () => {
     expect(persisted).toEqual([{ cg: 'cg', watermark: 1 }]);
 
     firstPass = false;
+    now += 30_000; // past ordinal 1's skip-backoff window so the later sweep retries it
     const r2 = await reconcileContextGraph(deps, state, 'cg', 1n);
     // 1 now reconciled -> absorbs 1 and the held 2 -> watermark 3.
     expect(r2.watermark).toBe(3);
@@ -84,10 +87,12 @@ describe('reconcileContextGraph — sweep', () => {
   it('does not re-attempt an ordinal already held in the cursor', async () => {
     // ordinal 2 completes out of order on pass 1 (held because 1 is pending),
     // then must NOT be re-attempted on pass 2.
+    let now = 1_000_000;
     let pass = 0;
     const attempts: number[][] = [[], []];
     const { deps } = makeDeps({
       getKCCount: async () => 3,
+      now: () => now,
       reconcileOrdinal: async (_cg, _onchain, ordinal) => {
         attempts[pass].push(ordinal);
         if (ordinal === 1 && pass === 0) return { status: 'pending' };
@@ -97,9 +102,10 @@ describe('reconcileContextGraph — sweep', () => {
     const state = createCursorState(0);
     await reconcileContextGraph(deps, state, 'cg', 1n);
     pass = 1;
+    now += 30_000; // past ordinal 1's skip-backoff window so it retries
     await reconcileContextGraph(deps, state, 'cg', 1n);
     expect(attempts[0]).toEqual([0, 1, 2]);
-    expect(attempts[1]).toEqual([1]); // only the gap, not the held 2
+    expect(attempts[1]).toEqual([1]); // only the gap (1 retried), not the held 2
   });
 
   it('respects the reorg confirmation depth: a shallow ordinal holds, a buried one advances', async () => {
@@ -149,6 +155,76 @@ describe('reconcileContextGraph — sweep', () => {
     expect(r2.watermark).toBe(2);
     expect(attempted).toEqual([0, 1]);
     expect(persisted).toEqual([{ cg: 'cg', watermark: 2 }]);
+  });
+});
+
+describe('reconcileContextGraph — skip-backoff (#1609)', () => {
+  it('does not re-run reconcileOrdinal for an ordinal inside its backoff window', async () => {
+    let now = 1_000_000;
+    const attempts: number[] = [];
+    const { deps } = makeDeps({
+      getKCCount: async () => 1,
+      now: () => now,
+      reconcileOrdinal: async (_cg, _onchain, ordinal) => { attempts.push(ordinal); return { status: 'pending' }; },
+    });
+    const state = createCursorState(0);
+    await reconcileContextGraph(deps, state, 'cg', 1n); // attempt -> pending -> 30s backoff
+    const res = await reconcileContextGraph(deps, state, 'cg', 1n); // immediate re-sweep, still in window
+    expect(attempts).toEqual([0]); // NOT re-attempted — the storm this fixes
+    expect(res).toMatchObject({ pending: 1, backedOff: 1, watermark: 0 });
+  });
+
+  it('retries once the backoff window expires', async () => {
+    let now = 1_000_000;
+    const attempts: number[] = [];
+    const { deps } = makeDeps({
+      getKCCount: async () => 1,
+      now: () => now,
+      reconcileOrdinal: async (_cg, _onchain, ordinal) => { attempts.push(ordinal); return { status: 'pending' }; },
+    });
+    const state = createCursorState(0);
+    await reconcileContextGraph(deps, state, 'cg', 1n); // window until now+30s
+    now += 29_999;
+    await reconcileContextGraph(deps, state, 'cg', 1n); // still inside -> skipped
+    expect(attempts).toEqual([0]);
+    now += 1; // now == untilMs -> retryable
+    await reconcileContextGraph(deps, state, 'cg', 1n); // retried
+    expect(attempts).toEqual([0, 0]);
+  });
+
+  it('a long-backed-off ordinal that finally reconciles clears its backoff and advances the watermark', async () => {
+    let now = 1_000_000;
+    let outcome: OrdinalOutcome = { status: 'pending' };
+    const attempts: number[] = [];
+    const { deps, persisted } = makeDeps({
+      getKCCount: async () => 1,
+      now: () => now,
+      reconcileOrdinal: async (_cg, _onchain, ordinal) => { attempts.push(ordinal); return outcome; },
+    });
+    const state = createCursorState(0);
+    await reconcileContextGraph(deps, state, 'cg', 1n); // pending -> backoff
+    now += 30_000;                                       // window expires
+    outcome = { status: 'reconciled', blockNumber: 0 };  // SWM finally arrived
+    const res = await reconcileContextGraph(deps, state, 'cg', 1n);
+    expect(res.watermark).toBe(1);                       // convergence NOT broken
+    expect(res.backedOff).toBe(0);
+    expect(state.backoff.has(0)).toBe(false);            // backoff cleared on success
+    expect(persisted).toEqual([{ cg: 'cg', watermark: 1 }]);
+    expect(attempts).toEqual([0, 0]);
+  });
+
+  it('backs off a transient skip (chain-read failure) the same way', async () => {
+    let now = 1_000_000;
+    const attempts: number[] = [];
+    const { deps } = makeDeps({
+      getKCCount: async () => 1,
+      now: () => now,
+      reconcileOrdinal: async (_cg, _onchain, ordinal) => { attempts.push(ordinal); return { status: 'skip' }; },
+    });
+    const state = createCursorState(0);
+    await reconcileContextGraph(deps, state, 'cg', 1n);
+    await reconcileContextGraph(deps, state, 'cg', 1n); // within window
+    expect(attempts).toEqual([0]);
   });
 });
 

--- a/packages/agent/test/reconcile-cursor.test.ts
+++ b/packages/agent/test/reconcile-cursor.test.ts
@@ -4,6 +4,10 @@ import {
   recordCompletion,
   absorbConfirmed,
   ordinalsToReconcile,
+  isOrdinalBackedOff,
+  recordOrdinalBackoff,
+  clearOrdinalBackoff,
+  RECONCILE_BACKOFF_CAP_MS,
   type CursorState,
 } from '../src/reconcile-cursor.js';
 
@@ -124,5 +128,39 @@ describe('reconcile-cursor — ordinalsToReconcile (sweep planning)', () => {
     expect(ordinalsToReconcile(s, 45)).toEqual([43]);
     // 43 finally lands → watermark jumps past 44 too.
     expect(recordCompletion(s, { ordinal: 43, blockNumber: 1 }, 1, 0)).toBe(45);
+  });
+});
+
+describe('reconcile-cursor — ordinal skip-backoff (#1609)', () => {
+  it('grows the window exponentially (30s ×2) then caps at 15 min', () => {
+    const s = createCursorState(0);
+    const expectedDelays = [30_000, 60_000, 120_000, 240_000, 480_000, RECONCILE_BACKOFF_CAP_MS, RECONCILE_BACKOFF_CAP_MS];
+    let now = 0;
+    for (const expected of expectedDelays) {
+      recordOrdinalBackoff(s, 0, now);
+      expect(s.backoff.get(0)!.untilMs - now).toBe(expected);
+      now = s.backoff.get(0)!.untilMs; // jump to the window edge for the next attempt
+    }
+    expect(RECONCILE_BACKOFF_CAP_MS).toBe(900_000);
+  });
+
+  it('isOrdinalBackedOff respects the window boundary and unknown ordinals', () => {
+    const s = createCursorState(0);
+    recordOrdinalBackoff(s, 0, 1_000); // window until 31_000
+    expect(isOrdinalBackedOff(s, 0, 30_999)).toBe(true);
+    expect(isOrdinalBackedOff(s, 0, 31_000)).toBe(false); // untilMs > now is false at the boundary
+    expect(isOrdinalBackedOff(s, 0, 40_000)).toBe(false);
+    expect(isOrdinalBackedOff(s, 1, 0)).toBe(false); // no entry
+  });
+
+  it('clearOrdinalBackoff removes the entry; the window never touches the watermark', () => {
+    const s = createCursorState(5);
+    recordOrdinalBackoff(s, 5, 1_000);
+    expect(s.backoff.has(5)).toBe(true);
+    // Backoff is a rate-limiter only: it must NOT advance/block the watermark or ahead.
+    expect(s.watermark).toBe(5);
+    expect(s.ahead.size).toBe(0);
+    clearOrdinalBackoff(s, 5);
+    expect(s.backoff.has(5)).toBe(false);
   });
 });


### PR DESCRIPTION
Addresses the **amplifier** in #1609 (the finalization/VM-reconcile oxigraph load traced on the testnet beacon fleet).

## Problem
`reconcileContextGraph` sweeps every ordinal in `[watermark, head)` that isn't already completed. An ordinal that keeps returning **`pending`** (no local SWM snapshot yet / on-chain verification not confirmed) or **`skip`** (transient chain-read failure) is therefore **re-attempted on every sweep** — and each attempt re-runs the finalization merkle search `findSwmSnapshotForMerkleRoot` → **O(#WorkspaceOperations) × the unbounded SWM-slice CONSTRUCT** (`getSharedMemoryQuadsForRoots`, 30–45 s on a large CG).

On the beacons this showed up as oxigraph pegged at ~2.4 cores / 112 threads with the *same* KAs reconciling ~6×/10 min (`v10-loadtest-*`, `stake-test-*`, …) — KAs whose SWM this node never received (published elsewhere), so they never match and are retried forever.

## Fix
A per-ordinal **exponential skip-backoff** at the sweep layer (`reconcile-cursor.ts` + `chain-reconciler.ts`):
- a not-actionable outcome (`pending`/`skip`) grows the ordinal's backoff window (**30 s ×2, capped 15 min**);
- the sweep **skips re-running** an ordinal while it's inside its window (still counted in `pending` — it keeps blocking the watermark);
- a successful reconcile (`reconciled`/`already`) **clears** the entry.

It is **purely an attempt-rate limiter**. It does not touch the merkle/SWM logic, and — critically — it **never advances or blocks the watermark**, so both cursor invariants hold:
- *no gap is ever permanently skipped* — a backed-off ordinal is still in `[watermark, head)`, just probed less often;
- *reorg safety* — unchanged.

A long-backed-off ordinal that finally reconciles still advances the watermark (explicitly tested).

## Why this is safe for convergence
The reconcile sweep is a **backstop**, nudged by chain events (`KnowledgeAssetRegisteredToContextGraph`) + a periodic timer — **SWM arrival does not nudge it**, and a KA whose SWM is *already present* materialises on the first attempt (no backoff). Only a KA whose SWM **lags** the chain event is delayed, and only up to the cap; early windows stay short (30 s → 1 min) so legitimate lag still materialises within a couple of minutes.

## Tests
`reconcile-cursor.test.ts`: exponential growth + 15-min cap, window boundary, clear, and the invariant that backoff never touches the watermark/ahead. `chain-reconciler.test.ts`: within-window skip (no re-run), post-expiry retry, transient-`skip` backoff, and **a long-backed-off ordinal that reconciles still advances the watermark**. Two existing sweep tests updated to advance the injected clock between passes (their immediate re-sweep now correctly hits the backoff). Reconcile unit suites green (29/29).

## Scope / follow-ups (do NOT auto-close #1609)
This kills the **repeat** no-match reads. It does **not** reduce the cost of a *single* legitimate reconcile — that O(#ops) × unbounded CONSTRUCT is the separate root-cost item on #1609 (bound the read via the existing `.bounded` per-KA path in `loadSharedMemorySliceWithKaBoundFallback`, or stamp each `WorkspaceOperation` with its KC root for an O(1) lookup). Also: backoff is **in-memory**, so it resets on restart (one extra sweep per restart) — it tames steady-state load, not the post-restart bootstrap spike.

🤖 Generated with [Claude Code](https://claude.com/claude-code)