### PR TITLE
fix(core): relay watchdog — stream-aware deferral + forced-redial thrash cap

### DIFF
--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -19,6 +19,7 @@ import { peerIdFromString, peerIdFromPrivateKey } from '@libp2p/peer-id';
 import { ed25519GetPublicKey } from './crypto/ed25519.js';
 import type { ConnectionTransport, DKGNodeConfig } from './types.js';
 import { DKG_GOSSIP_MAX_RPC_BYTES, dhtProtocolForNetwork } from './constants.js';
+import { POOLED_MESSAGE_PROTOCOL } from './message-stream-pool.js';
 import { RelayMetricsAdapter, RELAY_V2_STOP_CODEC } from './libp2p-metrics-adapter.js';
 import { readRelayReservations, readConnectionStreams } from './relay-internal-shapes.js';
 import { RelayFlapGuard, buildRelayFlapConnectionGater } from './relay-flap-guard.js';
@@ -67,24 +68,66 @@ const RELAY_RESERVATION_GRACE_MS = 15_000;
 export const WATCHDOG_BUSY_PROTOCOL_PREFIXES = ['/dkg/'] as const;
 
 /**
- * Distinct busy app protocols across a peer's connections (see
- * WATCHDOG_BUSY_PROTOCOL_PREFIXES). Exported for tests.
+ * `/dkg/`-prefixed protocols that are NOT request/response exchanges and must
+ * not defer the forced redial (adversarial review of this fix, round 1):
+ * - The pooled message wire stream (`/dkg/10.0.2/message`) is deliberately
+ *   immortal — 10s keepalive PINGs re-arm its idle timer — so its existence
+ *   ≠ in-flight work, and severing it is recoverable by design
+ *   (PooledStreamResetError → outbox retry → stream reopens on next send).
+ * - DKG namespaces its Kademlia DHT under `/dkg/[…/]kad/1.0.0`; DHT RPCs are
+ *   ambient infrastructure whose abort the query layer routes around.
  */
-export function connectionsBusyAppProtocols(
-  conns: ReadonlyArray<{ streams?: ReadonlyArray<{ protocol?: string | null }> }>,
-): string[] {
+export function isWatchdogBusyProtocol(protocol: string): boolean {
+  if (!WATCHDOG_BUSY_PROTOCOL_PREFIXES.some((prefix) => protocol.startsWith(prefix))) return false;
+  if (protocol === POOLED_MESSAGE_PROTOCOL) return false;
+  if (protocol.includes('/kad/')) return false;
+  return true;
+}
+
+/**
+ * Distinct busy app protocols across a peer's connections (see
+ * isWatchdogBusyProtocol). Stream access goes through
+ * `readConnectionStreams` — the one place that owns libp2p's
+ * not-quite-public `connection.streams` shape. Exported for tests.
+ */
+export function connectionsBusyAppProtocols(conns: readonly unknown[]): string[] {
   const busy = new Set<string>();
   for (const conn of conns) {
-    for (const stream of conn.streams ?? []) {
+    for (const stream of readConnectionStreams(conn) ?? []) {
       const protocol = stream.protocol;
-      if (!protocol) continue;
-      if (WATCHDOG_BUSY_PROTOCOL_PREFIXES.some((prefix) => protocol.startsWith(prefix))) {
+      if (protocol && isWatchdogBusyProtocol(protocol)) {
         busy.add(protocol);
       }
     }
   }
   return [...busy];
 }
+
+/**
+ * Per-relay forced-redial bookkeeping (one object per relay instead of
+ * parallel maps, so the invariants live in one place): `strikes` counts
+ * consecutive futile forced redials, `cooldownUntil` suppresses the forced
+ * path after the strike cap, `busyDeferralTicks` counts consecutive
+ * busy-stream deferrals toward RELAY_BUSY_DEFERRAL_MAX_TICKS. The whole
+ * entry is dropped the moment the relay's reservation gate is satisfied,
+ * and the whole map is cleared on node stop (state must not leak into a
+ * restarted node's fresh connections).
+ */
+interface RelayForcedRedialState {
+  strikes: number;
+  cooldownUntil: number;
+  busyDeferralTicks: number;
+}
+
+/**
+ * Consecutive busy-deferrals per relay before the forced redial proceeds
+ * anyway. Bounds the liveness cost of the deferral: ANY long-lived or leaked
+ * half-open `/dkg/` stream (current or future) can only DELAY reservation
+ * recovery — never permanently disable it (~30 ticks ≈ 5 min at the base
+ * interval). The teardown that then proceeds also doubles as the reaper for
+ * stuck streams the deferral would otherwise preserve forever.
+ */
+const RELAY_BUSY_DEFERRAL_MAX_TICKS = 30;
 
 /**
  * Consecutive forced reservation-redials against the same relay that failed
@@ -571,10 +614,8 @@ export class DKGNode {
    * the new reservation on the wire.
    */
   private relayReservationRedialAt: Map<string, number> = new Map();
-  /** Consecutive futile forced reservation-redials per relay (see RELAY_FORCED_REDIAL_MAX_STRIKES). */
-  private relayForcedRedialStrikes: Map<string, number> = new Map();
-  /** Per-relay epoch-ms until which the forced reservation-redial path is on cooldown. */
-  private relayForcedRedialCooldownUntil: Map<string, number> = new Map();
+  /** Per-relay forced-redial bookkeeping; see RelayForcedRedialState. */
+  private relayForcedRedialState: Map<string, RelayForcedRedialState> = new Map();
   /**
    * Target number of simultaneous relay reservations for this edge node
    * (1 by default, up to `relayReservationCount` for multi-reservation
@@ -1379,8 +1420,7 @@ export class DKGNode {
         reservedRelayCount >= this.relayReservationCountTarget;
       if (transportUp && reservationGateSatisfied) {
         this.relayReservationRedialAt.delete(relayPidStr);
-        this.relayForcedRedialStrikes.delete(relayPidStr);
-        this.relayForcedRedialCooldownUntil.delete(relayPidStr);
+        this.relayForcedRedialState.delete(relayPidStr);
         continue;
       }
 
@@ -1444,8 +1484,16 @@ export class DKGNode {
         // connection keeps carrying app traffic; only the forced
         // reservation-recovery close is suppressed. Benign wait — no
         // backoff escalation (leave `onlyWaitingOnGraceWindow` alone).
-        const cooldownUntil = this.relayForcedRedialCooldownUntil.get(relayPidStr) ?? 0;
-        if (now < cooldownUntil) {
+        //
+        // Honoured only while we hold at least one reservation SOMEWHERE:
+        // with zero reservations the node is inbound-unreachable, and if
+        // every relay were cooled simultaneously nothing would ever retry
+        // (adversarial review round 1). Urgency wins when nothing works;
+        // the cap's job is protecting working connections from churn, and
+        // the global tick backoff (5-min max) already paces the retries.
+        const redialState = this.relayForcedRedialState.get(relayPidStr)
+          ?? { strikes: 0, cooldownUntil: 0, busyDeferralTicks: 0 };
+        if (now < redialState.cooldownUntil && haveAnyReservation) {
           allHealthy = false;
           continue;
         }
@@ -1454,20 +1502,41 @@ export class DKGNode {
         // in-flight application request streams — an abrupt close aborts
         // the exchange (StorageACK collection, sync). Deferral is benign:
         // the deficit persists to the next tick, which retries once the
-        // request streams have drained. See WATCHDOG_BUSY_PROTOCOL_PREFIXES
-        // for why long-lived infra streams don't count. A continuously
-        // busy publisher can defer reservation recovery indefinitely —
-        // that trade is deliberate: live app traffic outranks inbound
-        // reachability freshness.
-        const busyProtocols = connectionsBusyAppProtocols(conns);
+        // request streams have drained. See isWatchdogBusyProtocol for why
+        // long-lived streams (gossipsub, pooled messages, kad) don't count.
+        //
+        // The scan ALSO covers connections relayed THROUGH this relay
+        // (`…/p2p/<relay>/p2p-circuit/p2p/<peer>`): tearing down the relay
+        // connection severs those circuits and their in-flight exchanges
+        // (adversarial review round 1). Only the scan widens — the
+        // teardown below still closes just the direct connections.
+        //
+        // Capped at RELAY_BUSY_DEFERRAL_MAX_TICKS consecutive deferrals so
+        // a leaked half-open stream (or any future immortal /dkg/ stream)
+        // can only delay recovery, never disable it — after the cap the
+        // teardown proceeds and doubles as the stuck-stream reaper.
+        const relayedConns = node.getConnections().filter((c: { remoteAddr?: { toString(): string } }) =>
+          c.remoteAddr?.toString().includes(`/p2p/${relayPidStr}/p2p-circuit`),
+        );
+        const busyProtocols = connectionsBusyAppProtocols([...conns, ...relayedConns]);
         if (busyProtocols.length > 0) {
-          allHealthy = false;
+          const busyTicks = redialState.busyDeferralTicks + 1;
+          if (busyTicks <= RELAY_BUSY_DEFERRAL_MAX_TICKS) {
+            this.relayForcedRedialState.set(relayPidStr, { ...redialState, busyDeferralTicks: busyTicks });
+            allHealthy = false;
+            console.log(
+              `[${ts()}] Relay watchdog: deferring forced redial of ${short(relayPidStr)} — ` +
+              `in-flight app stream(s): ${busyProtocols.join(', ')} ` +
+              `(deferral ${busyTicks}/${RELAY_BUSY_DEFERRAL_MAX_TICKS})`,
+            );
+            continue;
+          }
           console.log(
-            `[${ts()}] Relay watchdog: deferring forced redial of ${short(relayPidStr)} — ` +
-            `in-flight app stream(s): ${busyProtocols.join(', ')}`,
+            `[${ts()}] Relay watchdog: busy-deferral cap reached for ${short(relayPidStr)} ` +
+            `(streams: ${busyProtocols.join(', ')}); proceeding with forced redial`,
           );
-          continue;
         }
+        redialState.busyDeferralTicks = 0;
 
         allHealthy = false;
         // Actual corrective action below (drop + redial); this is a
@@ -1483,21 +1552,22 @@ export class DKGNode {
         this.relayReservationRedialAt.set(relayPidStr, now);
         // Strike accounting: this forced teardown is only ever reached when
         // the previous ones (if any) failed to yield a reservation — the
-        // happy path above clears the counter the moment one appears.
-        const strikes = (this.relayForcedRedialStrikes.get(relayPidStr) ?? 0) + 1;
+        // happy path above drops the whole state entry the moment one
+        // appears.
+        const strikes = redialState.strikes + 1;
         if (strikes >= RELAY_FORCED_REDIAL_MAX_STRIKES) {
-          this.relayForcedRedialStrikes.delete(relayPidStr);
-          this.relayForcedRedialCooldownUntil.set(
-            relayPidStr,
-            now + RELAY_FORCED_REDIAL_COOLDOWN_MS,
-          );
+          this.relayForcedRedialState.set(relayPidStr, {
+            strikes: 0,
+            cooldownUntil: now + RELAY_FORCED_REDIAL_COOLDOWN_MS,
+            busyDeferralTicks: 0,
+          });
           console.log(
             `[${ts()}] Relay watchdog: ${strikes} consecutive forced redials of ${short(relayPidStr)} ` +
             `yielded no reservation (slots likely exhausted); cooling down forced redials for ` +
             `${Math.round(RELAY_FORCED_REDIAL_COOLDOWN_MS / 60_000)}min (connection left alone)`,
           );
         } else {
-          this.relayForcedRedialStrikes.set(relayPidStr, strikes);
+          this.relayForcedRedialState.set(relayPidStr, { ...redialState, strikes, busyDeferralTicks: 0 });
         }
 
         for (const c of conns) {
@@ -1565,11 +1635,17 @@ export class DKGNode {
     if (allHealthy) {
       this.relayWatchdogConsecutiveFailures = 0;
     } else if (onlyWaitingOnGraceWindow) {
-      // Every unhealthy relay this tick was just the reservation
-      // grace window after a forced redial. Don't inflate the backoff
+      // Every unhealthy relay this tick was just a benign wait (grace
+      // window, busy deferral, or cooldown). Don't inflate the backoff
       // — the next scheduled tick needs to actually arrive while the
       // grace window is still the active state, otherwise a missing
-      // reservation can sit uncorrected for minutes.
+      // reservation can sit uncorrected for minutes. DECAY the counter
+      // instead of freezing it (adversarial review round 1): an
+      // indefinitely-persistent benign state (long cooldown, busy
+      // publisher) previously pinned the shared tick interval at
+      // whatever the prior strike sequence escalated it to — walking it
+      // back restores base-granularity checks while the state is benign.
+      this.relayWatchdogConsecutiveFailures = Math.max(0, this.relayWatchdogConsecutiveFailures - 1);
       const nextDelay = Math.min(
         RELAY_WATCHDOG_BASE_INTERVAL_MS * Math.pow(2, this.relayWatchdogConsecutiveFailures),
         RELAY_WATCHDOG_MAX_INTERVAL_MS,
@@ -1737,6 +1813,12 @@ export class DKGNode {
       this.relayWatchdogTimer = null;
     }
     this.relayTargets = [];
+    // Watchdog bookkeeping must not leak into a restarted node: a stale
+    // cooldown/strike entry from the previous run would suppress
+    // reservation recovery on connections that were recreated from
+    // scratch (otReviewAgent on PR #1613).
+    this.relayForcedRedialState.clear();
+    this.relayReservationRedialAt.clear();
     this.relayWatchdogConsecutiveFailures = 0;
     this.relayReservationRedialAt.clear();
     this.relayedPeers.clear();

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -1818,7 +1818,6 @@ export class DKGNode {
     // reservation recovery on connections that were recreated from
     // scratch (otReviewAgent on PR #1613).
     this.relayForcedRedialState.clear();
-    this.relayReservationRedialAt.clear();
     this.relayWatchdogConsecutiveFailures = 0;
     this.relayReservationRedialAt.clear();
     this.relayedPeers.clear();

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -48,6 +48,57 @@ const RELAY_REDIAL_DELAY_MS = 1_500;
 const RELAY_RESERVATION_GRACE_MS = 15_000;
 
 /**
+ * Protocol prefixes whose in-flight streams mark a relay connection "busy"
+ * for the watchdog's forced reservation-redial: application request/response
+ * exchanges (StorageACK collection, durable sync, verify fan-out, …) that an
+ * abrupt `close()` aborts mid-flight. 2026-07-12 testnet outage: a NAT'd
+ * edge's watchdog severed its relay-target connections every grace-window
+ * expiry while the bootstraps' reservation slots were exhausted — and the
+ * relay targets doubled as the publish quorum's ACK cores, so every burst
+ * publish lost its ACK streams (same failure shape as the 2026-07-07 Gnosis
+ * incident documented on `nodeIsPubliclyReachable` below, but on NAT'd nodes
+ * where that bypass can't apply).
+ *
+ * Long-lived infrastructure streams (gossipsub mesh, identify, ping, dcutr,
+ * circuit hop/stop) are deliberately NOT counted: they sit open on virtually
+ * every connection, so counting them would defer reservation recovery
+ * forever.
+ */
+export const WATCHDOG_BUSY_PROTOCOL_PREFIXES = ['/dkg/'] as const;
+
+/**
+ * Distinct busy app protocols across a peer's connections (see
+ * WATCHDOG_BUSY_PROTOCOL_PREFIXES). Exported for tests.
+ */
+export function connectionsBusyAppProtocols(
+  conns: ReadonlyArray<{ streams?: ReadonlyArray<{ protocol?: string | null }> }>,
+): string[] {
+  const busy = new Set<string>();
+  for (const conn of conns) {
+    for (const stream of conn.streams ?? []) {
+      const protocol = stream.protocol;
+      if (!protocol) continue;
+      if (WATCHDOG_BUSY_PROTOCOL_PREFIXES.some((prefix) => protocol.startsWith(prefix))) {
+        busy.add(protocol);
+      }
+    }
+  }
+  return [...busy];
+}
+
+/**
+ * Consecutive forced reservation-redials against the same relay that failed
+ * to yield a reservation before that relay's forced path is put on cooldown.
+ * Tonight's outage shape: both configured relays' slots were exhausted, so
+ * every forced drop+redial was guaranteed futile — and permanent (measured:
+ * one relay torn down 95× in 2h). Strikes convert "futile forever" into
+ * "5 attempts, then leave the connection alone for the cooldown window".
+ * The regular reconnect-on-disconnect path is unaffected.
+ */
+const RELAY_FORCED_REDIAL_MAX_STRIKES = 5;
+const RELAY_FORCED_REDIAL_COOLDOWN_MS = 10 * 60_000;
+
+/**
  * Default relay server capacity — the number of simultaneous circuit-relay v2
  * reservations a Core Node will hold. All other relay-related caps (HOP/STOP
  * stream limits, connectionManager.maxConnections) derive from this at a 1:2
@@ -520,6 +571,10 @@ export class DKGNode {
    * the new reservation on the wire.
    */
   private relayReservationRedialAt: Map<string, number> = new Map();
+  /** Consecutive futile forced reservation-redials per relay (see RELAY_FORCED_REDIAL_MAX_STRIKES). */
+  private relayForcedRedialStrikes: Map<string, number> = new Map();
+  /** Per-relay epoch-ms until which the forced reservation-redial path is on cooldown. */
+  private relayForcedRedialCooldownUntil: Map<string, number> = new Map();
   /**
    * Target number of simultaneous relay reservations for this edge node
    * (1 by default, up to `relayReservationCount` for multi-reservation
@@ -1324,6 +1379,8 @@ export class DKGNode {
         reservedRelayCount >= this.relayReservationCountTarget;
       if (transportUp && reservationGateSatisfied) {
         this.relayReservationRedialAt.delete(relayPidStr);
+        this.relayForcedRedialStrikes.delete(relayPidStr);
+        this.relayForcedRedialCooldownUntil.delete(relayPidStr);
         continue;
       }
 
@@ -1380,6 +1437,38 @@ export class DKGNode {
           continue;
         }
 
+        // Thrash cap: after RELAY_FORCED_REDIAL_MAX_STRIKES consecutive
+        // futile forced redials (reservation never appeared — e.g. the
+        // relay's slots are exhausted), stop tearing this relay's
+        // connection down for RELAY_FORCED_REDIAL_COOLDOWN_MS. The
+        // connection keeps carrying app traffic; only the forced
+        // reservation-recovery close is suppressed. Benign wait — no
+        // backoff escalation (leave `onlyWaitingOnGraceWindow` alone).
+        const cooldownUntil = this.relayForcedRedialCooldownUntil.get(relayPidStr) ?? 0;
+        if (now < cooldownUntil) {
+          allHealthy = false;
+          continue;
+        }
+
+        // Stream-aware deferral: never sever a connection carrying
+        // in-flight application request streams — an abrupt close aborts
+        // the exchange (StorageACK collection, sync). Deferral is benign:
+        // the deficit persists to the next tick, which retries once the
+        // request streams have drained. See WATCHDOG_BUSY_PROTOCOL_PREFIXES
+        // for why long-lived infra streams don't count. A continuously
+        // busy publisher can defer reservation recovery indefinitely —
+        // that trade is deliberate: live app traffic outranks inbound
+        // reachability freshness.
+        const busyProtocols = connectionsBusyAppProtocols(conns);
+        if (busyProtocols.length > 0) {
+          allHealthy = false;
+          console.log(
+            `[${ts()}] Relay watchdog: deferring forced redial of ${short(relayPidStr)} — ` +
+            `in-flight app stream(s): ${busyProtocols.join(', ')}`,
+          );
+          continue;
+        }
+
         allHealthy = false;
         // Actual corrective action below (drop + redial); this is a
         // real failure the watchdog must back off on.
@@ -1392,6 +1481,24 @@ export class DKGNode {
           `dropping + redialing ${short(relayPidStr)} to force reserve`,
         );
         this.relayReservationRedialAt.set(relayPidStr, now);
+        // Strike accounting: this forced teardown is only ever reached when
+        // the previous ones (if any) failed to yield a reservation — the
+        // happy path above clears the counter the moment one appears.
+        const strikes = (this.relayForcedRedialStrikes.get(relayPidStr) ?? 0) + 1;
+        if (strikes >= RELAY_FORCED_REDIAL_MAX_STRIKES) {
+          this.relayForcedRedialStrikes.delete(relayPidStr);
+          this.relayForcedRedialCooldownUntil.set(
+            relayPidStr,
+            now + RELAY_FORCED_REDIAL_COOLDOWN_MS,
+          );
+          console.log(
+            `[${ts()}] Relay watchdog: ${strikes} consecutive forced redials of ${short(relayPidStr)} ` +
+            `yielded no reservation (slots likely exhausted); cooling down forced redials for ` +
+            `${Math.round(RELAY_FORCED_REDIAL_COOLDOWN_MS / 60_000)}min (connection left alone)`,
+          );
+        } else {
+          this.relayForcedRedialStrikes.set(relayPidStr, strikes);
+        }
 
         for (const c of conns) {
           try {

--- a/packages/core/test/relay.test.ts
+++ b/packages/core/test/relay.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { DKGNode, nodeHasDirectPublicAddress } from '../src/node.js';
+import { DKGNode, nodeHasDirectPublicAddress, connectionsBusyAppProtocols } from '../src/node.js';
 import { ProtocolRouter } from '../src/protocol-router.js';
 import { PeerDiscoveryManager } from '../src/discovery.js';
 import { TypedEventBus } from '../src/event-bus.js';
@@ -1140,4 +1140,168 @@ describe('Circuit Relay', () => {
       console.log = ORIG_CONSOLE_LOG;
     }
   }, 20000);
+});
+
+describe('Relay watchdog: stream-aware deferral + forced-redial thrash cap (2026-07-12 testnet outage)', () => {
+  const nodes: DKGNode[] = [];
+
+  afterEach(async () => {
+    console.warn = ORIG_CONSOLE_WARN;
+    console.log = ORIG_CONSOLE_LOG;
+    for (const n of nodes) {
+      try {
+        await n.stop();
+      } catch (err) {
+        console.warn('Teardown: node.stop() failed', err);
+      }
+    }
+    nodes.length = 0;
+  });
+
+  it('connectionsBusyAppProtocols counts /dkg/ request streams and ignores infra streams', () => {
+    const conn = (streams: Array<{ protocol?: string | null }>) => ({ streams });
+    // /dkg/ streams count, deduped across connections.
+    expect(connectionsBusyAppProtocols([
+      conn([{ protocol: '/dkg/10.0.1/storage-ack' }, { protocol: '/dkg/10.0.2/sync' }]),
+      conn([{ protocol: '/dkg/10.0.1/storage-ack' }]),
+    ]).sort()).toEqual(['/dkg/10.0.1/storage-ack', '/dkg/10.0.2/sync']);
+    // Long-lived infra streams never count (they exist on ~every
+    // connection; counting them would defer reservation recovery forever).
+    expect(connectionsBusyAppProtocols([
+      conn([
+        { protocol: '/meshsub/1.1.0' },
+        { protocol: '/ipfs/id/1.0.0' },
+        { protocol: '/ipfs/ping/1.0.0' },
+        { protocol: '/libp2p/circuit/relay/0.2.0/hop' },
+        { protocol: '/libp2p/circuit/relay/0.2.0/stop' },
+        { protocol: '/libp2p/dcutr' },
+        { protocol: null },
+        {},
+      ]),
+    ])).toEqual([]);
+    // No connections / no streams.
+    expect(connectionsBusyAppProtocols([])).toEqual([]);
+    expect(connectionsBusyAppProtocols([conn([])])).toEqual([]);
+  });
+
+  it('defers the forced reservation-redial while a /dkg/ stream is in flight, and resumes after it drains', async () => {
+    // "Relay" that runs NO relay server: the edge can connect but a
+    // reservation can never form, so every tick enters the
+    // forced-redial branch — the 2026-07-12 outage shape (relay slots
+    // exhausted ⇒ reservation never appears).
+    const relay = new DKGNode({ listenAddresses: ['/ip4/127.0.0.1/tcp/0'], enableMdns: false });
+    nodes.push(relay);
+    await relay.start();
+    const relayAddr = relay.multiaddrs.find(a => a.includes('/tcp/'))!;
+    const BUSY_PROTOCOL = '/dkg/test-busy/1.0.0';
+    // Handler holds the inbound stream open — an in-flight exchange.
+    const held: Array<{ close: () => Promise<void> }> = [];
+    await relay.libp2p.handle(BUSY_PROTOCOL, ({ stream }) => { held.push(stream as never); });
+
+    const edge = new DKGNode({
+      listenAddresses: ['/ip4/127.0.0.1/tcp/0'],
+      enableMdns: false,
+      relayPeers: [relayAddr],
+    });
+    nodes.push(edge);
+    await edge.start();
+    const relayPid = relay.libp2p.peerId.toString();
+    const tick = (edge as unknown as { watchdogTick: () => Promise<void> }).watchdogTick.bind(edge);
+    const redialAt = (edge as unknown as { relayReservationRedialAt: Map<string, number> }).relayReservationRedialAt;
+
+    // Baseline (no busy stream): the forced redial DOES run.
+    const logSpy = spyConsole('log');
+    try {
+      await tick();
+      expect(
+        logSpy.calls.some(c => typeof c[0] === 'string' && c[0].includes('to force reserve')),
+        'baseline tick without app streams should force-redial',
+      ).toBe(true);
+
+      // Open an in-flight /dkg/ stream, expire the grace window, tick:
+      // the watchdog must DEFER (no close, no redial) and say why.
+      const stream = await edge.libp2p.dialProtocol(relay.libp2p.getMultiaddrs(), BUSY_PROTOCOL);
+      redialAt.set(relayPid, Date.now() - 16_000);
+      logSpy.calls.length = 0;
+      await tick();
+      expect(
+        logSpy.calls.some(c => typeof c[0] === 'string' && c[0].includes('deferring forced redial')
+          && c[0].includes(BUSY_PROTOCOL)),
+        `expected deferral log; got: ${JSON.stringify(logSpy.calls.map(c => c[0]))}`,
+      ).toBe(true);
+      expect(
+        logSpy.calls.some(c => typeof c[0] === 'string' && c[0].includes('to force reserve')),
+        'must not force-redial while a /dkg/ stream is in flight',
+      ).toBe(false);
+      expect(edge.libp2p.getConnections(relay.libp2p.peerId).length).toBeGreaterThan(0);
+
+      // Drain the stream — BOTH halves: closing only the dialer side
+      // leaves the half-open stream (protocol still set) in
+      // conn.streams until the responder closes too.
+      await stream.abort(new Error('test-drain'));
+      for (const h of held) { try { await h.close(); } catch { /* drained */ } }
+      const drainDeadline = Date.now() + 5_000;
+      while (Date.now() < drainDeadline
+        && connectionsBusyAppProtocols(edge.libp2p.getConnections(relay.libp2p.peerId)).length > 0) {
+        await new Promise(r => setTimeout(r, 100));
+      }
+      redialAt.set(relayPid, Date.now() - 16_000);
+      logSpy.calls.length = 0;
+      await tick();
+      expect(
+        logSpy.calls.some(c => typeof c[0] === 'string' && c[0].includes('to force reserve')),
+        'forced redial should resume once the app stream has drained',
+      ).toBe(true);
+    } finally {
+      console.log = ORIG_CONSOLE_LOG;
+    }
+  }, 40000);
+
+  it('puts a never-reserving relay on cooldown after repeated futile forced redials', async () => {
+    const relay = new DKGNode({ listenAddresses: ['/ip4/127.0.0.1/tcp/0'], enableMdns: false });
+    nodes.push(relay);
+    await relay.start();
+    const relayAddr = relay.multiaddrs.find(a => a.includes('/tcp/'))!;
+
+    const edge = new DKGNode({
+      listenAddresses: ['/ip4/127.0.0.1/tcp/0'],
+      enableMdns: false,
+      relayPeers: [relayAddr],
+    });
+    nodes.push(edge);
+    await edge.start();
+    const relayPid = relay.libp2p.peerId.toString();
+    const tick = (edge as unknown as { watchdogTick: () => Promise<void> }).watchdogTick.bind(edge);
+    const redialAt = (edge as unknown as { relayReservationRedialAt: Map<string, number> }).relayReservationRedialAt;
+
+    const logSpy = spyConsole('log');
+    try {
+      // Five forced redials (grace window expired manually each round —
+      // in production these are ≥15s apart). None can yield a
+      // reservation (no relay server), so the 5th trips the cooldown.
+      for (let i = 0; i < 5; i++) {
+        if (i > 0) redialAt.set(relayPid, Date.now() - 16_000);
+        await tick();
+      }
+      const forced = logSpy.calls.filter(c => typeof c[0] === 'string' && c[0].includes('to force reserve'));
+      expect(forced.length, 'exactly 5 forced redials before the cap trips').toBe(5);
+      expect(
+        logSpy.calls.some(c => typeof c[0] === 'string' && c[0].includes('cooling down forced redials')),
+        `expected cooldown log after 5 strikes; got: ${JSON.stringify(logSpy.calls.map(c => c[0]).slice(-6))}`,
+      ).toBe(true);
+
+      // On cooldown: even with the grace window expired, no further
+      // teardown — the connection is left alone.
+      redialAt.set(relayPid, Date.now() - 16_000);
+      logSpy.calls.length = 0;
+      await tick();
+      expect(
+        logSpy.calls.some(c => typeof c[0] === 'string' && c[0].includes('to force reserve')),
+        'no forced redial while the relay is on cooldown',
+      ).toBe(false);
+      expect(edge.libp2p.getConnections(relay.libp2p.peerId).length).toBeGreaterThan(0);
+    } finally {
+      console.log = ORIG_CONSOLE_LOG;
+    }
+  }, 60000);
 });

--- a/packages/core/test/relay.test.ts
+++ b/packages/core/test/relay.test.ts
@@ -1448,6 +1448,49 @@ describe('Relay watchdog: review-round-1 hardening', () => {
     }
   }, 30000);
 
+  it('decays the shared backoff counter during a benign busy-deferral wait (does not freeze at an escalated interval)', async () => {
+    // otReviewAgent round 3: benign waits reduce relayWatchdogConsecutiveFailures
+    // so a persistent benign state (busy publisher, cooldown) walks the tick
+    // interval back toward base granularity instead of ratcheting at the 5-min
+    // cap. A regression removing the decay would keep the counter frozen.
+    const relay = new DKGNode({ listenAddresses: ['/ip4/127.0.0.1/tcp/0'], enableMdns: false });
+    nodes.push(relay);
+    await relay.start();
+    const relayAddr = relay.multiaddrs.find(a => a.includes('/tcp/'))!;
+    const BUSY_PROTOCOL = '/dkg/test-decay/1.0.0';
+    await relay.libp2p.handle(BUSY_PROTOCOL, () => { /* hold open */ });
+
+    const edge = new DKGNode({
+      listenAddresses: ['/ip4/127.0.0.1/tcp/0'],
+      enableMdns: false,
+      relayPeers: [relayAddr],
+    });
+    nodes.push(edge);
+    await edge.start();
+    const relayPid = relay.libp2p.peerId.toString();
+    const internals = edge as unknown as {
+      watchdogTick: () => Promise<void>;
+      relayReservationRedialAt: Map<string, number>;
+      relayWatchdogConsecutiveFailures: number;
+    };
+    // In-flight app stream ⇒ every tick is a benign busy-deferral.
+    await edge.libp2p.dialProtocol(relay.libp2p.getMultiaddrs(), BUSY_PROTOCOL);
+    internals.relayReservationRedialAt.set(relayPid, Date.now() - 16_000);
+    // Pretend a prior failure sequence escalated the interval.
+    internals.relayWatchdogConsecutiveFailures = 3;
+
+    const logSpy = spyConsole('log');
+    try {
+      await internals.watchdogTick.call(edge);
+    } finally {
+      console.log = ORIG_CONSOLE_LOG;
+    }
+    expect(
+      internals.relayWatchdogConsecutiveFailures,
+      'benign busy-deferral tick must decay the counter (3 → 2), not freeze it',
+    ).toBe(2);
+  }, 30000);
+
   it('busy-deferral cap: forced redial proceeds once RELAY_BUSY_DEFERRAL_MAX_TICKS is exceeded', async () => {
     const relay = new DKGNode({ listenAddresses: ['/ip4/127.0.0.1/tcp/0'], enableMdns: false });
     nodes.push(relay);

--- a/packages/core/test/relay.test.ts
+++ b/packages/core/test/relay.test.ts
@@ -1402,6 +1402,52 @@ describe('Relay watchdog: review-round-1 hardening', () => {
     ).toBe(false);
   }, 30000);
 
+  it('bypasses an active cooldown when NO reservation exists anywhere (urgency wins)', async () => {
+    // Liveness-critical counterpart of the cooldown test (otReviewAgent
+    // round 2): with zero reservations the node is inbound-unreachable,
+    // so an active cooldown must NOT suppress the forced redial — if
+    // every relay were cooled simultaneously nothing would ever retry.
+    const deadRelay = new DKGNode({ listenAddresses: ['/ip4/127.0.0.1/tcp/0'], enableMdns: false });
+    nodes.push(deadRelay);
+    await deadRelay.start();
+    const deadAddr = deadRelay.multiaddrs.find(a => a.includes('/tcp/'))!;
+
+    const edge = new DKGNode({
+      listenAddresses: ['/ip4/127.0.0.1/tcp/0'],
+      enableMdns: false,
+      relayPeers: [deadAddr],
+    });
+    nodes.push(edge);
+    await edge.start();
+    const deadPid = deadRelay.libp2p.peerId.toString();
+    const internals = edge as unknown as {
+      watchdogTick: () => Promise<void>;
+      relayForcedRedialState: Map<string, { strikes: number; cooldownUntil: number; busyDeferralTicks: number }>;
+    };
+    // Active cooldown, zero reservations (dead relay runs no relay server,
+    // so no /p2p-circuit self-addr can exist).
+    internals.relayForcedRedialState.set(deadPid, {
+      strikes: 0,
+      cooldownUntil: Date.now() + 600_000,
+      busyDeferralTicks: 0,
+    });
+    expect(
+      edge.libp2p.getMultiaddrs().some(ma => ma.toString().includes('/p2p-circuit')),
+      'test setup: edge must hold no reservation',
+    ).toBe(false);
+
+    const logSpy = spyConsole('log');
+    try {
+      await internals.watchdogTick.call(edge);
+      expect(
+        logSpy.calls.some(c => typeof c[0] === 'string' && c[0].includes('to force reserve')),
+        `cooldown must be bypassed with zero reservations; got: ${JSON.stringify(logSpy.calls.map(c => c[0]))}`,
+      ).toBe(true);
+    } finally {
+      console.log = ORIG_CONSOLE_LOG;
+    }
+  }, 30000);
+
   it('busy-deferral cap: forced redial proceeds once RELAY_BUSY_DEFERRAL_MAX_TICKS is exceeded', async () => {
     const relay = new DKGNode({ listenAddresses: ['/ip4/127.0.0.1/tcp/0'], enableMdns: false });
     nodes.push(relay);

--- a/packages/core/test/relay.test.ts
+++ b/packages/core/test/relay.test.ts
@@ -1179,6 +1179,17 @@ describe('Relay watchdog: stream-aware deferral + forced-redial thrash cap (2026
         {},
       ]),
     ])).toEqual([]);
+    // /dkg/-prefixed protocols that are NOT request/response exchanges
+    // (adversarial review round 1): the pooled message wire stream is
+    // deliberately immortal, and DKG's own kad-dht (network-scoped or not)
+    // is ambient infrastructure — neither may defer the forced redial.
+    expect(connectionsBusyAppProtocols([
+      conn([
+        { protocol: '/dkg/10.0.2/message' },
+        { protocol: '/dkg/kad/1.0.0' },
+        { protocol: '/dkg/testnet.base:84532/kad/1.0.0' },
+      ]),
+    ])).toEqual([]);
     // No connections / no streams.
     expect(connectionsBusyAppProtocols([])).toEqual([]);
     expect(connectionsBusyAppProtocols([conn([])])).toEqual([]);
@@ -1221,6 +1232,9 @@ describe('Relay watchdog: stream-aware deferral + forced-redial thrash cap (2026
       // Open an in-flight /dkg/ stream, expire the grace window, tick:
       // the watchdog must DEFER (no close, no redial) and say why.
       const stream = await edge.libp2p.dialProtocol(relay.libp2p.getMultiaddrs(), BUSY_PROTOCOL);
+      const busyConnId = edge.libp2p.getConnections(relay.libp2p.peerId)
+        .find(c => connectionsBusyAppProtocols([c]).includes(BUSY_PROTOCOL))?.id;
+      expect(busyConnId, 'test setup: the busy stream must be visible on a connection').toBeTruthy();
       redialAt.set(relayPid, Date.now() - 16_000);
       logSpy.calls.length = 0;
       await tick();
@@ -1233,7 +1247,17 @@ describe('Relay watchdog: stream-aware deferral + forced-redial thrash cap (2026
         logSpy.calls.some(c => typeof c[0] === 'string' && c[0].includes('to force reserve')),
         'must not force-redial while a /dkg/ stream is in flight',
       ).toBe(false);
-      expect(edge.libp2p.getConnections(relay.libp2p.peerId).length).toBeGreaterThan(0);
+      // Prove the SAME connection object survived (not closed+redialed)
+      // and the in-flight stream is still on it (otReviewAgent on
+      // PR #1613: a regression could log the deferral, still tear down,
+      // and a redial would keep the connection COUNT positive).
+      const connsAfter = edge.libp2p.getConnections(relay.libp2p.peerId);
+      expect(connsAfter.length).toBeGreaterThan(0);
+      expect(connsAfter.map(c => c.id)).toContain(busyConnId);
+      expect(
+        connectionsBusyAppProtocols(connsAfter),
+        'the in-flight stream must still be open on the surviving connection',
+      ).toContain(BUSY_PROTOCOL);
 
       // Drain the stream — BOTH halves: closing only the dialer side
       // leaves the half-open stream (protocol still set) in
@@ -1257,11 +1281,134 @@ describe('Relay watchdog: stream-aware deferral + forced-redial thrash cap (2026
     }
   }, 40000);
 
-  it('puts a never-reserving relay on cooldown after repeated futile forced redials', async () => {
+  it('puts a never-reserving relay on cooldown after repeated futile forced redials (while a reservation exists elsewhere)', async () => {
+    // Cooldown semantics (review round 1): the thrash cap only suppresses
+    // the forced path while the node holds >=1 reservation SOMEWHERE —
+    // with zero reservations, urgency wins and the watchdog keeps trying.
+    // So the fixture needs BOTH: a real relay server (provides the
+    // reservation) and a never-reserving plain peer (accumulates strikes).
+    const realRelay = new DKGNode({ listenAddresses: ['/ip4/127.0.0.1/tcp/0'], enableMdns: false, enableRelayServer: true });
+    const deadRelay = new DKGNode({ listenAddresses: ['/ip4/127.0.0.1/tcp/0'], enableMdns: false });
+    nodes.push(realRelay, deadRelay);
+    await realRelay.start();
+    await deadRelay.start();
+    const realAddr = realRelay.multiaddrs.find(a => a.includes('/tcp/'))!;
+    const deadAddr = deadRelay.multiaddrs.find(a => a.includes('/tcp/'))!;
+
+    const edge = new DKGNode({
+      listenAddresses: ['/ip4/127.0.0.1/tcp/0'],
+      enableMdns: false,
+      relayPeers: [realAddr, deadAddr],
+      relayReservationCount: 2,
+    });
+    nodes.push(edge);
+    await edge.start();
+    // Wait for the real relay's reservation so haveAnyReservation=true.
+    const deadline = Date.now() + 10_000;
+    while (Date.now() < deadline
+      && !edge.libp2p.getMultiaddrs().some(ma => ma.toString().includes('/p2p-circuit'))) {
+      await new Promise(r => setTimeout(r, 250));
+    }
+    const deadPid = deadRelay.libp2p.peerId.toString();
+    const tick = (edge as unknown as { watchdogTick: () => Promise<void> }).watchdogTick.bind(edge);
+    const redialAt = (edge as unknown as { relayReservationRedialAt: Map<string, number> }).relayReservationRedialAt;
+
+    const logSpy = spyConsole('log');
+    try {
+      // Five forced redials of the dead relay (grace window expired
+      // manually each round — in production these are >=15s apart). None
+      // can yield a reservation (no relay server), so the 5th trips the
+      // cooldown. The real relay's gate stays satisfied throughout.
+      for (let i = 0; i < 5; i++) {
+        if (i > 0) redialAt.set(deadPid, Date.now() - 16_000);
+        await tick();
+      }
+      const forced = logSpy.calls.filter(c => typeof c[0] === 'string' && c[0].includes('to force reserve'));
+      expect(forced.length, `exactly 5 forced redials before the cap trips; got: ${JSON.stringify(forced.map(c => c[0]))}`).toBe(5);
+      expect(
+        logSpy.calls.some(c => typeof c[0] === 'string' && c[0].includes('cooling down forced redials')),
+        `expected cooldown log after 5 strikes; got: ${JSON.stringify(logSpy.calls.map(c => c[0]).slice(-6))}`,
+      ).toBe(true);
+
+      // On cooldown (and holding a reservation on the real relay): even
+      // with the grace window expired, no further teardown of the dead
+      // relay — its connection is left alone.
+      redialAt.set(deadPid, Date.now() - 16_000);
+      logSpy.calls.length = 0;
+      await tick();
+      expect(
+        logSpy.calls.some(c => typeof c[0] === 'string' && c[0].includes('to force reserve')),
+        'no forced redial while the relay is on cooldown',
+      ).toBe(false);
+      expect(edge.libp2p.getConnections(deadRelay.libp2p.peerId).length).toBeGreaterThan(0);
+    } finally {
+      console.log = ORIG_CONSOLE_LOG;
+    }
+  }, 60000);
+});
+
+describe('Relay watchdog: review-round-1 hardening', () => {
+  const nodes: DKGNode[] = [];
+
+  afterEach(async () => {
+    console.warn = ORIG_CONSOLE_WARN;
+    console.log = ORIG_CONSOLE_LOG;
+    for (const n of nodes) {
+      try {
+        await n.stop();
+      } catch (err) {
+        console.warn('Teardown: node.stop() failed', err);
+      }
+    }
+    nodes.length = 0;
+  });
+
+  it('clears strikes, cooldown, and busy-deferral state the moment a reservation appears (happy path)', async () => {
+    // Real relay SERVER so a reservation actually forms.
+    const relay = new DKGNode({ listenAddresses: ['/ip4/127.0.0.1/tcp/0'], enableMdns: false, enableRelayServer: true });
+    nodes.push(relay);
+    await relay.start();
+    const relayAddr = relay.multiaddrs.find(a => a.includes('/tcp/'))!;
+    const edge = new DKGNode({
+      listenAddresses: ['/ip4/127.0.0.1/tcp/0'],
+      enableMdns: false,
+      relayPeers: [relayAddr],
+    });
+    nodes.push(edge);
+    await edge.start();
+    // Wait for the circuit reservation.
+    const deadline = Date.now() + 10_000;
+    while (Date.now() < deadline
+      && !edge.libp2p.getMultiaddrs().some(ma => ma.toString().includes('/p2p-circuit'))) {
+      await new Promise(r => setTimeout(r, 250));
+    }
+    const relayPid = relay.libp2p.peerId.toString();
+    const internals = edge as unknown as {
+      watchdogTick: () => Promise<void>;
+      relayForcedRedialState: Map<string, { strikes: number; cooldownUntil: number; busyDeferralTicks: number }>;
+    };
+    // Poison the whole state entry as if a strike sequence had just run.
+    internals.relayForcedRedialState.set(relayPid, {
+      strikes: 4,
+      cooldownUntil: Date.now() + 600_000,
+      busyDeferralTicks: 7,
+    });
+
+    await internals.watchdogTick.call(edge);
+
+    expect(
+      internals.relayForcedRedialState.has(relayPid),
+      'forced-redial state dropped entirely on happy path',
+    ).toBe(false);
+  }, 30000);
+
+  it('busy-deferral cap: forced redial proceeds once RELAY_BUSY_DEFERRAL_MAX_TICKS is exceeded', async () => {
     const relay = new DKGNode({ listenAddresses: ['/ip4/127.0.0.1/tcp/0'], enableMdns: false });
     nodes.push(relay);
     await relay.start();
     const relayAddr = relay.multiaddrs.find(a => a.includes('/tcp/'))!;
+    const BUSY_PROTOCOL = '/dkg/test-busy-cap/1.0.0';
+    await relay.libp2p.handle(BUSY_PROTOCOL, () => { /* hold the stream open */ });
 
     const edge = new DKGNode({
       listenAddresses: ['/ip4/127.0.0.1/tcp/0'],
@@ -1271,37 +1418,37 @@ describe('Relay watchdog: stream-aware deferral + forced-redial thrash cap (2026
     nodes.push(edge);
     await edge.start();
     const relayPid = relay.libp2p.peerId.toString();
-    const tick = (edge as unknown as { watchdogTick: () => Promise<void> }).watchdogTick.bind(edge);
-    const redialAt = (edge as unknown as { relayReservationRedialAt: Map<string, number> }).relayReservationRedialAt;
-
+    const internals = edge as unknown as {
+      watchdogTick: () => Promise<void>;
+      relayReservationRedialAt: Map<string, number>;
+      relayForcedRedialState: Map<string, { strikes: number; cooldownUntil: number; busyDeferralTicks: number }>;
+    };
+    await edge.libp2p.dialProtocol(relay.libp2p.getMultiaddrs(), BUSY_PROTOCOL);
+    internals.relayReservationRedialAt.set(relayPid, Date.now() - 16_000);
+    // One tick below the cap: still deferring.
+    internals.relayForcedRedialState.set(relayPid, { strikes: 0, cooldownUntil: 0, busyDeferralTicks: 29 });
     const logSpy = spyConsole('log');
     try {
-      // Five forced redials (grace window expired manually each round —
-      // in production these are ≥15s apart). None can yield a
-      // reservation (no relay server), so the 5th trips the cooldown.
-      for (let i = 0; i < 5; i++) {
-        if (i > 0) redialAt.set(relayPid, Date.now() - 16_000);
-        await tick();
-      }
-      const forced = logSpy.calls.filter(c => typeof c[0] === 'string' && c[0].includes('to force reserve'));
-      expect(forced.length, 'exactly 5 forced redials before the cap trips').toBe(5);
+      await internals.watchdogTick.call(edge);
       expect(
-        logSpy.calls.some(c => typeof c[0] === 'string' && c[0].includes('cooling down forced redials')),
-        `expected cooldown log after 5 strikes; got: ${JSON.stringify(logSpy.calls.map(c => c[0]).slice(-6))}`,
+        logSpy.calls.some(c => typeof c[0] === 'string' && c[0].includes('deferring forced redial')),
+        'tick 30/30 still defers',
       ).toBe(true);
-
-      // On cooldown: even with the grace window expired, no further
-      // teardown — the connection is left alone.
-      redialAt.set(relayPid, Date.now() - 16_000);
+      // Over the cap: teardown proceeds despite the busy stream.
+      internals.relayReservationRedialAt.set(relayPid, Date.now() - 16_000);
+      internals.relayForcedRedialState.set(relayPid, { strikes: 0, cooldownUntil: 0, busyDeferralTicks: 30 });
       logSpy.calls.length = 0;
-      await tick();
+      await internals.watchdogTick.call(edge);
+      expect(
+        logSpy.calls.some(c => typeof c[0] === 'string' && c[0].includes('busy-deferral cap reached')),
+        `expected cap-reached log; got: ${JSON.stringify(logSpy.calls.map(c => c[0]))}`,
+      ).toBe(true);
       expect(
         logSpy.calls.some(c => typeof c[0] === 'string' && c[0].includes('to force reserve')),
-        'no forced redial while the relay is on cooldown',
-      ).toBe(false);
-      expect(edge.libp2p.getConnections(relay.libp2p.peerId).length).toBeGreaterThan(0);
+        'forced redial proceeds past the cap',
+      ).toBe(true);
     } finally {
       console.log = ORIG_CONSOLE_LOG;
     }
-  }, 60000);
+  }, 40000);
 });


### PR DESCRIPTION
## Problem

The relay watchdog's forced reservation-redial (`dropping + redialing <relay> to force reserve`, node.ts) severs connections carrying **in-flight application streams**. On a NAT'd edge whose relay targets double as its publish quorum's ACK cores — the testnet default, since `network.relays` = the bootstraps = cores — every grace-window expiry aborts live StorageACK/sync exchanges.

**Measured on testnet 2026-07-12:** with both bootstraps' reservation slots exhausted, an edge's connections to its ACK cores lived **7–28 seconds** (one relay torn down **95× in 2h**), and publish success collapsed to 0% with `need 3 ACKs but only 2 core peers connected — quorum impossible`. Same failure shape as the 2026-07-07 Gnosis incident already documented on `nodeIsPubliclyReachable` — but that bypass can't apply to NAT'd nodes.

## Fix (scoped strictly to the forced-redial branch)

1. **Stream-aware deferral** — skip the teardown while the connection carries in-flight `/dkg/*` request streams (`WATCHDOG_BUSY_PROTOCOL_PREFIXES`). Long-lived infra streams (gossipsub mesh, identify, dcutr, hop/stop) deliberately do **not** defer — they sit on virtually every connection, so counting them would block reservation recovery forever. Deferral is benign: the deficit persists to the next tick.
2. **Thrash cap** — 5 consecutive futile forced redials (reservation never appeared, e.g. relay slots exhausted) put that relay's *forced path* on a 10-min cooldown. The connection keeps serving app traffic; the regular reconnect-on-disconnect path is unaffected.

Both counters reset the moment a reservation appears (happy path).

## Tests

3 new tests in `relay.test.ts` (22/22 green locally):
- unit: `connectionsBusyAppProtocols` counts `/dkg/` streams, ignores infra streams
- integration: forced redial defers while a `/dkg/` stream is in flight, resumes after it drains (baseline force-reserve asserted first, so the deferral is provably stream-driven)
- integration: 5 futile forced redials → cooldown; further ticks leave the connection alone

## Relation to the relay-registry direction

This is the P3 kernel of the chain-derived relay registry plan (every core = relay, relay set from chain): regardless of how the candidate set is derived, the watchdog must never sacrifice live app traffic for reservation recovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)