### PR TITLE
perf(agent): write-gen-gated negative memo for the chain-reconcile SWM scan (#1609)

### DIFF
--- a/packages/agent/src/finalization-handler.ts
+++ b/packages/agent/src/finalization-handler.ts
@@ -12,7 +12,7 @@ import {
   DKG_ROOT_ENTITY_LEGACY,
   ENTITY_PRED_ALT,
 } from '@origintrail-official/dkg-core';
-import { GraphManager, loadSelectedSharedMemoryQuads, loadSharedMemorySliceWithKaBoundFallback, type SwmKaGraphBound, type TripleStore, type Quad } from '@origintrail-official/dkg-storage';
+import { GraphManager, loadSelectedSharedMemoryQuads, loadSharedMemorySliceWithKaBoundFallback, asGraphWriteGenSource, type GraphWriteGenSource, type SwmKaGraphBound, type TripleStore, type Quad } from '@origintrail-official/dkg-storage';
 import { type ChainAdapter, type EventFilter } from '@origintrail-official/dkg-chain';
 import {
   computeFlatKCRootV10 as computeFlatKCRoot, skolemizeByEntity,
@@ -131,6 +131,32 @@ function swmKaBoundDisabled(): boolean {
   return process.env.DKG_DISABLE_SWM_KA_BOUND === '1';
 }
 
+/**
+ * TTL cap on the in-memory negative reconcile memo (#1609) — the longest a
+ * "no local SWM snapshot" verdict may be trusted without a fresh scan even
+ * when no write-generation change was observed. Bounds the exposure to any
+ * SWM writer invisible to the adapter's write-generation counter (e.g. a
+ * second process mutating a shared oxigraph-server) to "≤ TTL late", never
+ * "never". Read per call (like `swmKaBoundDisabled`) so ops and tests can
+ * retune it without a redeploy.
+ */
+const VM_RECONCILE_NEGATIVE_TTL_MS_DEFAULT = 600_000;
+function vmReconcileNegativeTtlMs(): number {
+  const raw = Number(process.env['DKG_VM_RECONCILE_NEGATIVE_TTL_MS']);
+  return Number.isFinite(raw) && raw > 0 ? raw : VM_RECONCILE_NEGATIVE_TTL_MS_DEFAULT;
+}
+
+/** LRU cap for the negative reconcile memo — bounds memory across CGs × roots. */
+const VM_RECONCILE_NEGATIVE_MEMO_MAX_ENTRIES = 4096;
+
+type NegativeSnapshotMemoEntry = {
+  /** Write generation for the CG's graph prefix observed BEFORE the scan. */
+  writeGen: number;
+  recordedAt: number;
+  /** Catalog-floor eligibility at scan time — a policy flip changes what can match. */
+  allowGeneratedCatalogFloor: boolean;
+};
+
 export class FinalizationHandler {
   private readonly store: TripleStore;
   private readonly chain: ChainAdapter | undefined;
@@ -145,6 +171,18 @@ export class FinalizationHandler {
   // caching a miss for a KC finalized before its on-chain KA->CG binding lands
   // would pin it to the legacy `/_meta` fallback forever, re-opening the race.
   private readonly chainCgIdByBatchId = new Map<string, string>();
+  // #1609 (2026-07-11/12 testnet incident): the write-generation source backing
+  // the negative reconcile memo below. `null` when the store's adapter doesn't
+  // track write generations — the memo is then DISABLED and every reconcile
+  // scans (fail-open), matching pre-memo behavior.
+  private readonly graphWriteGen: GraphWriteGenSource | null;
+  // Negative memo for `findSwmSnapshotForMerkleRoot`: "this (cg, namespace,
+  // root) had NO matching local SWM snapshot at write generation G". Unlike
+  // `chainCgIdByBatchId` above, caching the negative here is sound BECAUSE it
+  // is generation-gated: the verdict is only replayed while the store proves
+  // no local write has touched the CG since the scan. LRU, in-memory only —
+  // a restart clears it (fail-open).
+  private readonly negativeSnapshotMemo = new Map<string, NegativeSnapshotMemoEntry>();
 
   constructor(
     store: TripleStore,
@@ -155,6 +193,7 @@ export class FinalizationHandler {
     lifecycleLogOptions?: FinalizationLifecycleLogOptions,
   ) {
     this.store = store;
+    this.graphWriteGen = asGraphWriteGenSource(store);
     this.chain = chain;
     this.eventBus = eventBus;
     this.resolveContextGraphOnChainId = resolveContextGraphOnChainId;
@@ -1097,6 +1136,21 @@ export class FinalizationHandler {
    * indexed property (stamped once at op completion) so the fallback disappears
    * entirely. The generated-catalog-floor variant keeps the exhaustive recompute
    * (its match is over quads+floor, not the op's intrinsic stamped root).
+   *
+   * READ memo (#1609, 2026-07-11/12 testnet incident): the #1612 digest memo skips
+   * only the merkle recompute — a never-match KA (a publish this node never shared,
+   * exactly the beacon shape) still paid O(#ops) unbounded SWM CONSTRUCTs on EVERY
+   * sweep tick, forever, stalling the event loop and dropping storage-ACK streams
+   * on big stores. This wrapper adds a write-generation-gated NEGATIVE memo over
+   * the whole scan (floor retry included): a "no match" verdict is replayed
+   * without touching the store while (a) the adapter's write generation for the
+   * CG's graph prefix is unchanged — new SWM only arrives via local writes
+   * (gossip receive, publish share, active fetch), all of which pass the adapter
+   * choke points and bump the generation, so the next call rescans — (b) the
+   * catalog-floor eligibility is unchanged, and (c) the entry is younger than
+   * `vmReconcileNegativeTtlMs()`. A MATCH is never memoized. Stores without the
+   * write-generation capability disable the memo entirely (always scan), and a
+   * restart clears it — every failure mode degrades to a rescan, never a miss.
    */
   private async findSwmSnapshotForMerkleRoot(
     contextGraphId: string,
@@ -1105,6 +1159,65 @@ export class FinalizationHandler {
     onChainCgId?: string,
   ): Promise<{ rootEntities: string[]; sharedMemoryQuads: Quad[]; subGraphName?: string } | null> {
     const allowGeneratedCatalogFloor = await this.allowsGeneratedCatalogFloor(contextGraphId, onChainCgId);
+
+    // Every graph the scan reads — root/sub-graph SWM buckets, their per-KA
+    // under-graphs and `_shared_memory_meta` (op rows, `privateMerkleRoot`,
+    // stamps) — lives under the CG's URI subtree, so one prefix covers all
+    // namespaces of this call. Broader than strictly needed (any CG-local
+    // write invalidates) — that only costs an extra rescan.
+    const memoKey = `${contextGraphId}\0${subGraphName ?? ''}\0${ethers.hexlify(merkleRoot)}`;
+    const swmWritePrefix = `${contextGraphDataUri(contextGraphId)}/`;
+    const preScanGen = this.graphWriteGen?.getWriteGen(swmWritePrefix);
+    if (preScanGen !== undefined) {
+      const memo = this.negativeSnapshotMemo.get(memoKey);
+      if (memo) {
+        if (
+          memo.writeGen === preScanGen &&
+          memo.allowGeneratedCatalogFloor === allowGeneratedCatalogFloor &&
+          Date.now() - memo.recordedAt < vmReconcileNegativeTtlMs()
+        ) {
+          // Refresh LRU recency; recordedAt stays — the TTL runs from the scan.
+          this.negativeSnapshotMemo.delete(memoKey);
+          this.negativeSnapshotMemo.set(memoKey, memo);
+          return null;
+        }
+        this.negativeSnapshotMemo.delete(memoKey);
+      }
+    }
+
+    const hit = await this.scanForSwmSnapshot(
+      contextGraphId,
+      merkleRoot,
+      subGraphName,
+      allowGeneratedCatalogFloor,
+    );
+    if (hit) return hit;
+
+    if (preScanGen !== undefined) {
+      // Record at the PRE-scan generation: any write that raced the scan (or
+      // the scan's own best-effort restamps) flips the gate above, so the next
+      // call rescans rather than replaying a verdict that may predate the write.
+      this.negativeSnapshotMemo.set(memoKey, {
+        writeGen: preScanGen,
+        recordedAt: Date.now(),
+        allowGeneratedCatalogFloor,
+      });
+      while (this.negativeSnapshotMemo.size > VM_RECONCILE_NEGATIVE_MEMO_MAX_ENTRIES) {
+        const oldest = this.negativeSnapshotMemo.keys().next().value;
+        if (oldest === undefined) break;
+        this.negativeSnapshotMemo.delete(oldest);
+      }
+    }
+    return null;
+  }
+
+  /** The authoritative full scan behind {@link findSwmSnapshotForMerkleRoot}. */
+  private async scanForSwmSnapshot(
+    contextGraphId: string,
+    merkleRoot: Uint8Array,
+    subGraphName: string | undefined,
+    allowGeneratedCatalogFloor: boolean,
+  ): Promise<{ rootEntities: string[]; sharedMemoryQuads: Quad[]; subGraphName?: string } | null> {
     // Caller knows the exact namespace → search only that one.
     if (subGraphName) {
       const hit = await this.findSwmSnapshotInNamespace(

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -772,8 +772,13 @@ describe('Phase D - VM reconcile damping', () => {
     connectedPeers = ['peer-empty', 'peer-newly-reachable'];
 
     await expect(internals.reconcileChainOrdinal('54', onChainCgId, 0, undefined)).resolves.toEqual({ status: 'pending' });
+    // The sweep-level cache entry is NOT reused — the fetch re-ran for the new
+    // topology (1 → 3 calls). The scan itself is served by the handler-level
+    // write-generation negative memo (#1609): no local write touched the CG
+    // between passes, so rescanning the unchanged store cannot change the
+    // verdict. Peer topology gates the FETCH, not the scan.
     expect(fetch.calls).toHaveLength(3);
-    expect(expensiveScans).toBeGreaterThan(0);
+    expect(expensiveScans).toBe(0);
   });
 
   it('reuses a negative cache entry when connected peers only reorder', async () => {
@@ -843,8 +848,11 @@ describe('Phase D - VM reconcile damping', () => {
 
     await expect(internals.reconcileChainOrdinal('57', onChainCgId, 0, undefined)).resolves.toEqual({ status: 'pending' });
     expect(primeCalls).toBeGreaterThanOrEqual(1);
+    // Fetch re-ran against the primed topology (sweep entry not reused); the
+    // scan is served by the #1609 write-gen negative memo — see the topology
+    // test above.
     expect(fetch.calls).toHaveLength(3);
-    expect(expensiveScans).toBeGreaterThan(0);
+    expect(expensiveScans).toBe(0);
   });
 
   it('does not reuse a negative cache entry when catchup ranking changes for the same peer set', async () => {
@@ -873,8 +881,11 @@ describe('Phase D - VM reconcile damping', () => {
     (internals as any).knownCorePeerIds.add('peer-reclassified');
 
     await expect(internals.reconcileChainOrdinal('56', onChainCgId, 0, undefined)).resolves.toEqual({ status: 'pending' });
+    // Fetch re-ran for the reclassified peer (sweep entry not reused); the
+    // scan is served by the #1609 write-gen negative memo — see the topology
+    // test above.
     expect(fetch.calls).toHaveLength(2);
-    expect(expensiveScans).toBeGreaterThan(0);
+    expect(expensiveScans).toBe(0);
   });
 
   it('does not reuse a negative cache entry when the same KA has a newer merkle root', async () => {

--- a/packages/agent/test/finalization-reconcile-negative-memo.test.ts
+++ b/packages/agent/test/finalization-reconcile-negative-memo.test.ts
@@ -1,0 +1,274 @@
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import { MockChainAdapter, buildKnowledgeAssetUal } from '@origintrail-official/dkg-chain';
+import { computeFlatKCRootV10, generatedPrivateCatalogFloorQuads } from '@origintrail-official/dkg-publisher';
+import {
+  contextGraphWorkspaceGraphUri,
+  contextGraphWorkspaceMetaGraphUri,
+  createOperationContext,
+} from '@origintrail-official/dkg-core';
+import { ethers } from 'ethers';
+import { FinalizationHandler } from '../src/finalization-handler.js';
+
+/**
+ * #1609 — the write-generation-gated NEGATIVE memo over `findSwmSnapshotForMerkleRoot`
+ * (the layer #1612's digest memo could not provide). During the 2026-07-11/12 testnet
+ * incident, never-match KAs — publishes this node never shared — re-ran O(#ops)
+ * unbounded SWM CONSTRUCT reads on EVERY reconcile sweep tick, stalling the event
+ * loop 30–46s per pass on big stores and dropping storage-ACK streams. These tests
+ * pin the memo's contract: a "no local snapshot" verdict is replayed with ZERO slice
+ * reads while the store's write generation for the CG is unchanged (the win), and
+ * ANY local write under the CG — entity-keyed data changes with identical triple
+ * counts, `privateMerkleRoot` meta arrivals, whole-snapshot arrivals — invalidates
+ * it so the next reconcile rescans and PROMOTES (the false-negative guard, the class
+ * that caught #1612's first cut in core-fills-gap.test.ts). The TTL bounds writers
+ * the adapter counter cannot see.
+ */
+
+const LOCAL_CG = 'fun-facts';
+const ON_CHAIN_CG = 77n;
+const wsGraph = contextGraphWorkspaceGraphUri(LOCAL_CG);
+const wsMetaGraph = contextGraphWorkspaceMetaGraphUri(LOCAL_CG);
+const NAME_PRED = 'http://schema.org/name';
+const PRIVATE_ROOT_PRED = 'http://dkg.io/ontology/privateMerkleRoot';
+
+/** Seed a local SWM snapshot for one KA and return its flat-KC merkle root. */
+async function seedSwmSnapshot(store: OxigraphStore, entity: string, value: string): Promise<Uint8Array> {
+  await store.insert([
+    { subject: entity, predicate: NAME_PRED, object: `"${value}"`, graph: wsGraph },
+    { subject: `urn:dkg:share:${entity}`, predicate: 'http://dkg.io/ontology/rootEntity', object: entity, graph: wsMetaGraph },
+  ]);
+  return rootFor(entity, value);
+}
+
+/** The flat-KC root a snapshot with this (entity,value) would hash to — WITHOUT seeding it. */
+function rootFor(entity: string, value: string, privateRoots: Uint8Array[] = []): Uint8Array {
+  return computeFlatKCRootV10(
+    [{ subject: entity, predicate: NAME_PRED, object: `"${value}"`, graph: '' }],
+    privateRoots,
+  );
+}
+
+/** Drive the FinalizationHandler's chain-reconcile entry directly for one registered kaId. */
+async function reconcileOne(
+  chain: MockChainAdapter,
+  fh: FinalizationHandler,
+  kaId: bigint,
+  onChainCgId: bigint = ON_CHAIN_CG,
+): Promise<string> {
+  const storageAddr = await chain.getDKGKnowledgeAssetsAddress();
+  const ual = buildKnowledgeAssetUal(chain.chainId, storageAddr, kaId);
+  const merkleRoot = await chain.getLatestMerkleRoot(kaId);
+  const publisherAddress = await chain.getLatestMerkleRootPublisher(kaId);
+  return fh.handleChainReconciledKC(
+    { contextGraphId: LOCAL_CG, onChainCgId: onChainCgId.toString(), ual, merkleRoot, publisherAddress, kaId, versionBlock: 0 },
+    createOperationContext('system'),
+  );
+}
+
+async function isInVm(store: OxigraphStore, entity: string, value: string, onChainCgId: bigint = ON_CHAIN_CG): Promise<boolean> {
+  const perCgGraph = `did:dkg:context-graph:${LOCAL_CG}/context/${onChainCgId}`;
+  const res = await store.query(`ASK { GRAPH <${perCgGraph}> { <${entity}> <${NAME_PRED}> "${value}" } }`);
+  return res.type === 'boolean' && res.value;
+}
+
+/**
+ * Drive the never-match reconcile until the negative memo is stable. The first
+ * scan may restamp ops (#1612) — a local write that self-invalidates the memo
+ * recorded at the pre-scan generation — so the second pass scans unchanged
+ * content, performs no writes, and records a stable-generation entry.
+ */
+async function settleNegativeMemo(
+  chain: MockChainAdapter,
+  fh: FinalizationHandler,
+  kaId: bigint,
+  onChainCgId: bigint = ON_CHAIN_CG,
+): Promise<void> {
+  expect(await reconcileOne(chain, fh, kaId, onChainCgId)).toBe('no-swm');
+  expect(await reconcileOne(chain, fh, kaId, onChainCgId)).toBe('no-swm');
+}
+
+type FhSeams = {
+  getSharedMemoryQuadsForRoots: (...a: unknown[]) => Promise<unknown>;
+  computeOpMerkleRoot: (...a: unknown[]) => unknown;
+};
+const readSeam = (fh: FinalizationHandler) =>
+  vi.spyOn(fh as unknown as FhSeams, 'getSharedMemoryQuadsForRoots');
+const recomputeSeam = (fh: FinalizationHandler) =>
+  vi.spyOn(fh as unknown as FhSeams, 'computeOpMerkleRoot');
+
+afterEach(() => {
+  delete process.env.DKG_VM_RECONCILE_NEGATIVE_TTL_MS;
+  vi.restoreAllMocks();
+});
+
+describe('#1609 — write-gen-gated negative memo (chain-reconcile backstop)', () => {
+  it('replays a warm never-match verdict with ZERO slice reads until a local write lands', async () => {
+    const store = new OxigraphStore();
+    const chain = new MockChainAdapter();
+    const fh = new FinalizationHandler(store, chain);
+
+    await seedSwmSnapshot(store, 'urn:fact:a', 'Honey never spoils');
+    await seedSwmSnapshot(store, 'urn:fact:b', 'Octopuses have three hearts');
+    // Warm the #1612 op stamps with one absent-KA pass so the cold pass below
+    // performs no writes of its own (a stamping pass bumps the write generation
+    // and correctly self-invalidates its memo entry).
+    chain.__registerKC({ kaId: 940n, contextGraphId: ON_CHAIN_CG, merkleRootHex: ethers.hexlify(rootFor('urn:fact:w', 'warm-up')), chunks: [] });
+    expect(await reconcileOne(chain, fh, 940n)).toBe('no-swm');
+
+    chain.__registerKC({ kaId: 941n, contextGraphId: ON_CHAIN_CG, merkleRootHex: ethers.hexlify(rootFor('urn:fact:absent', 'published elsewhere')), chunks: [] });
+    const reads = readSeam(fh);
+    const recompute = recomputeSeam(fh);
+
+    // Cold pass for THIS root: the authoritative scan must read ≥1 op slice.
+    expect(await reconcileOne(chain, fh, 941n)).toBe('no-swm');
+    expect(reads.mock.calls.length).toBeGreaterThanOrEqual(1);
+
+    // Warm pass, same root, no writes since: served from the memo — not one
+    // slice read, not one merkle recompute.
+    reads.mockClear();
+    recompute.mockClear();
+    expect(await reconcileOne(chain, fh, 941n)).toBe('no-swm');
+    expect(reads.mock.calls.length).toBe(0);
+    expect(recompute.mock.calls.length).toBe(0);
+  });
+
+  it('promotes after the matching SWM arrives through the real write path (false-negative guard)', async () => {
+    const store = new OxigraphStore();
+    const chain = new MockChainAdapter();
+    const fh = new FinalizationHandler(store, chain);
+
+    // An unrelated op so a real scan is observable on the read seam.
+    await seedSwmSnapshot(store, 'urn:fact:a', 'Honey never spoils');
+    const value = 'A KA that arrives later';
+    chain.__registerKC({ kaId: 950n, contextGraphId: ON_CHAIN_CG, merkleRootHex: ethers.hexlify(rootFor('urn:fact:late', value)), chunks: [] });
+    await settleNegativeMemo(chain, fh, 950n);
+
+    // Memo engaged — the exact moment a stale negative verdict could strand the KA.
+    const reads = readSeam(fh);
+    expect(await reconcileOne(chain, fh, 950n)).toBe('no-swm');
+    expect(reads.mock.calls.length).toBe(0);
+
+    // Arrival: gossip receive / publish share / active fetch all end in adapter
+    // writes under the CG's SWM graphs — the write generation bumps.
+    await seedSwmSnapshot(store, 'urn:fact:late', value);
+
+    reads.mockClear();
+    expect(await reconcileOne(chain, fh, 950n)).toBe('promoted');
+    expect(reads.mock.calls.length).toBeGreaterThanOrEqual(1);
+    expect(await isInVm(store, 'urn:fact:late', value)).toBe(true);
+  });
+
+  it('invalidates on an entity-keyed data change with an identical triple count', async () => {
+    // The class that stranded #1612's first cut (core-fills-gap.test.ts:981): an
+    // op completes incrementally via entity-keyed writes that never rewrite the
+    // op subject and never change the graph's row count.
+    const store = new OxigraphStore();
+    const chain = new MockChainAdapter();
+    const fh = new FinalizationHandler(store, chain);
+
+    await seedSwmSnapshot(store, 'urn:fact:morph', 'incomplete draft');
+    chain.__registerKC({ kaId: 960n, contextGraphId: ON_CHAIN_CG, merkleRootHex: ethers.hexlify(rootFor('urn:fact:morph', 'final content')), chunks: [] });
+    await settleNegativeMemo(chain, fh, 960n);
+
+    const reads = readSeam(fh);
+    expect(await reconcileOne(chain, fh, 960n)).toBe('no-swm');
+    expect(reads.mock.calls.length).toBe(0);
+
+    // Same-count content swap on the entity — op subject untouched.
+    await store.delete([{ subject: 'urn:fact:morph', predicate: NAME_PRED, object: '"incomplete draft"', graph: wsGraph }]);
+    await store.insert([{ subject: 'urn:fact:morph', predicate: NAME_PRED, object: '"final content"', graph: wsGraph }]);
+
+    reads.mockClear();
+    expect(await reconcileOne(chain, fh, 960n)).toBe('promoted');
+    expect(reads.mock.calls.length).toBeGreaterThanOrEqual(1);
+    expect(await isInVm(store, 'urn:fact:morph', 'final content')).toBe(true);
+  });
+
+  it('invalidates on a privateMerkleRoot meta write', async () => {
+    const store = new OxigraphStore();
+    const chain = new MockChainAdapter();
+    const fh = new FinalizationHandler(store, chain);
+
+    const value = 'private-backed content';
+    await seedSwmSnapshot(store, 'urn:fact:priv', value);
+    const privRoot = new Uint8Array(32).fill(7);
+    // The chain root commits to the private root the op does not yet carry.
+    chain.__registerKC({ kaId: 970n, contextGraphId: ON_CHAIN_CG, merkleRootHex: ethers.hexlify(rootFor('urn:fact:priv', value, [privRoot])), chunks: [] });
+    await settleNegativeMemo(chain, fh, 970n);
+
+    const reads = readSeam(fh);
+    expect(await reconcileOne(chain, fh, 970n)).toBe('no-swm');
+    expect(reads.mock.calls.length).toBe(0);
+
+    // The private root replicates in via an entity-keyed SWM meta write.
+    await store.insert([{ subject: 'urn:fact:priv', predicate: PRIVATE_ROOT_PRED, object: `"${ethers.hexlify(privRoot)}"`, graph: wsMetaGraph }]);
+
+    reads.mockClear();
+    expect(await reconcileOne(chain, fh, 970n)).toBe('promoted');
+    expect(reads.mock.calls.length).toBeGreaterThanOrEqual(1);
+    expect(await isInVm(store, 'urn:fact:priv', value)).toBe(true);
+  });
+
+  it('suppresses rescans for a public catalog-floor CG and still promotes a floor-augmented match on arrival', async () => {
+    // Public (catalog-floor) CGs disable the #1612 stamp index entirely — their
+    // match is over quads+floor, not an op's intrinsic root — so this memo is
+    // the ONLY rescan damping they get. The memo caches the whole scan result,
+    // floor retry included.
+    const store = new OxigraphStore();
+    const chain = new MockChainAdapter();
+    const fh = new FinalizationHandler(store, chain);
+    const created = await chain.createOnChainContextGraph({
+      accessPolicy: 1,
+      publishPolicy: 1,
+      nameHash: ethers.keccak256(ethers.toUtf8Bytes(LOCAL_CG)),
+    });
+    const cgId = created.contextGraphId;
+
+    await seedSwmSnapshot(store, 'urn:fact:a', 'Honey never spoils');
+    const value = 'floor-augmented content';
+    const floorRoot = computeFlatKCRootV10(
+      [
+        { subject: 'urn:fact:floor', predicate: NAME_PRED, object: `"${value}"`, graph: '' },
+        ...generatedPrivateCatalogFloorQuads(LOCAL_CG),
+      ],
+      [],
+    );
+    chain.__registerKC({ kaId: 980n, contextGraphId: cgId, merkleRootHex: ethers.hexlify(floorRoot), chunks: [] });
+    await settleNegativeMemo(chain, fh, 980n, cgId);
+
+    const reads = readSeam(fh);
+    expect(await reconcileOne(chain, fh, 980n, cgId)).toBe('no-swm');
+    expect(reads.mock.calls.length).toBe(0);
+
+    await seedSwmSnapshot(store, 'urn:fact:floor', value);
+
+    reads.mockClear();
+    expect(await reconcileOne(chain, fh, 980n, cgId)).toBe('promoted');
+    expect(reads.mock.calls.length).toBeGreaterThanOrEqual(1);
+    expect(await isInVm(store, 'urn:fact:floor', value, cgId)).toBe(true);
+  });
+
+  it('forces a rescan once the TTL expires even with no observed writes', async () => {
+    const store = new OxigraphStore();
+    const chain = new MockChainAdapter();
+    const fh = new FinalizationHandler(store, chain);
+
+    await seedSwmSnapshot(store, 'urn:fact:a', 'Honey never spoils');
+    chain.__registerKC({ kaId: 990n, contextGraphId: ON_CHAIN_CG, merkleRootHex: ethers.hexlify(rootFor('urn:fact:absent', 'published elsewhere')), chunks: [] });
+    await settleNegativeMemo(chain, fh, 990n);
+
+    // Within TTL: memoized.
+    const reads = readSeam(fh);
+    expect(await reconcileOne(chain, fh, 990n)).toBe('no-swm');
+    expect(reads.mock.calls.length).toBe(0);
+
+    // Shrink the TTL below the entry's age: the writer-invisible-to-the-counter
+    // escape hatch must force one authoritative rescan.
+    process.env.DKG_VM_RECONCILE_NEGATIVE_TTL_MS = '1';
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    reads.mockClear();
+    expect(await reconcileOne(chain, fh, 990n)).toBe('no-swm');
+    expect(reads.mock.calls.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/packages/storage/src/adapters/oxigraph-worker.ts
+++ b/packages/storage/src/adapters/oxigraph-worker.ts
@@ -4,6 +4,7 @@ import { sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { TripleStore, Quad, TripleStoreQueryOptions, QueryResult, UpdateOptions } from '../triple-store.js';
 import { registerTripleStoreAdapter } from '../triple-store.js';
+import { GraphWriteGenTracker } from '../graph-write-gen.js';
 
 /**
  * Default per-operation timeout for the embedded worker store. The worker is
@@ -151,6 +152,10 @@ export class OxigraphWorkerStore implements TripleStore {
   private worker!: Worker;
   private nextId = 0;
   private pending = new Map<number, { resolve: (v: any) => void; reject: (e: Error) => void }>();
+  // #1609: per-graph write generations, bumped client-side after each
+  // successful mutation RPC (the worker owns no caller-visible caches).
+  // Feeds the chain-reconcile negative memo via `asGraphWriteGenSource`.
+  private readonly writeGen = new GraphWriteGenTracker();
   private readonly operationTimeoutMs: number;
   /** Resolved path of the compiled worker impl; reused verbatim on respawn. */
   private readonly workerPath: string;
@@ -623,13 +628,29 @@ export class OxigraphWorkerStore implements TripleStore {
   // can't land without the other). Large idempotent bulk imports that want
   // head-of-line fairness should run on an external SPARQL server, not by
   // silently fragmenting this insert into non-atomic chunks.
-  async insert(quads: Quad[]): Promise<void> { return this.call('insert', quads); }
-  async delete(quads: Quad[]): Promise<void> { return this.call('delete', quads); }
-  async deleteByPattern(pattern: Partial<Quad>): Promise<number> { return this.call('deleteByPattern', pattern); }
+  async insert(quads: Quad[]): Promise<void> {
+    await this.call('insert', quads);
+    this.writeGen.recordGraphWrites(new Set(quads.map((q) => q.graph || '')));
+  }
+  async delete(quads: Quad[]): Promise<void> {
+    await this.call('delete', quads);
+    this.writeGen.recordGraphWrites(new Set(quads.map((q) => q.graph || '')));
+  }
+  async deleteByPattern(pattern: Partial<Quad>): Promise<number> {
+    const removed = await this.call<number>('deleteByPattern', pattern);
+    if (pattern.graph) this.writeGen.recordGraphWrites([pattern.graph]);
+    else this.writeGen.recordUnscopedWrite();
+    return removed;
+  }
   // Server-side SPARQL UPDATE forwarded to the worker's OxigraphStore (which
   // implements `update`); same atomic single-message contract as `insert`.
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  async update(sparql: string, _options?: UpdateOptions): Promise<void> { return this.call('update', sparql); }
+  async update(sparql: string, _options?: UpdateOptions): Promise<void> {
+    await this.call('update', sparql);
+    // A raw UPDATE's write scope is not derivable at the call site
+    // (`touchedGraphs` hints only membership changes) — unscoped bump.
+    this.writeGen.recordUnscopedWrite();
+  }
   async query(sparql: string, options?: TripleStoreQueryOptions): Promise<QueryResult> {
     return this.callWithTimeout<QueryResult>(this.operationTimeoutMs, options?.signal, 'query', sparql);
   }
@@ -637,11 +658,23 @@ export class OxigraphWorkerStore implements TripleStore {
     return this.callWithTimeout<boolean>(this.operationTimeoutMs, options?.signal, 'hasGraph', graphUri);
   }
   async createGraph(graphUri: string): Promise<void> { return this.call('createGraph', graphUri); }
-  async dropGraph(graphUri: string): Promise<void> { return this.call('dropGraph', graphUri); }
+  async dropGraph(graphUri: string): Promise<void> {
+    await this.call('dropGraph', graphUri);
+    this.writeGen.recordGraphWrites([graphUri]);
+  }
   async listGraphs(options?: TripleStoreQueryOptions): Promise<string[]> {
     return this.callWithTimeout<string[]>(this.operationTimeoutMs, options?.signal, 'listGraphs');
   }
-  async deleteBySubjectPrefix(graphUri: string, prefix: string): Promise<number> { return this.call('deleteBySubjectPrefix', graphUri, prefix); }
+  async deleteBySubjectPrefix(graphUri: string, prefix: string): Promise<number> {
+    const removed = await this.call<number>('deleteBySubjectPrefix', graphUri, prefix);
+    this.writeGen.recordGraphWrites([graphUri]);
+    return removed;
+  }
+
+  /** {@link GraphWriteGenSource} capability (#1609) — see graph-write-gen.ts. */
+  getWriteGen(graphPrefix: string): number {
+    return this.writeGen.getWriteGen(graphPrefix);
+  }
   async countQuads(graphUri?: string): Promise<number> { return this.call('countQuads', graphUri); }
   async flush(): Promise<void> { return this.call('flush'); }
 

--- a/packages/storage/src/adapters/oxigraph.ts
+++ b/packages/storage/src/adapters/oxigraph.ts
@@ -14,6 +14,7 @@ import type {
   UpdateOptions,
 } from '../triple-store.js';
 import { registerTripleStoreAdapter } from '../triple-store.js';
+import { GraphWriteGenTracker } from '../graph-write-gen.js';
 import { assertQuadLiteralsMutf8Safe, JAVA_WRITE_UTF_MAX_BYTES } from '@origintrail-official/dkg-core';
 
 // SWM DATA segment (bucket `…/_shared_memory` + per-KA `…/_shared_memory/{author}/{n}`),
@@ -29,6 +30,11 @@ export class OxigraphStore implements TripleStore {
 
   private store: OxStore;
   private persistPath: string | undefined;
+  // #1609: per-graph write generations, bumped on every local mutation (the
+  // same choke points the sparql-http adapter pairs with its listGraphs-cache
+  // invalidation). Feeds the chain-reconcile negative memo via
+  // `asGraphWriteGenSource` / `getWriteGen`.
+  private readonly writeGen = new GraphWriteGenTracker();
 
   /**
    * @param persistPath  If provided, the store will dump/load N-Quads
@@ -217,6 +223,7 @@ export class OxigraphStore implements TripleStore {
     const nquads = quads.map(quadToNQuad).join('\n') + '\n';
     this.store.load(nquads, { format: 'application/n-quads' });
     this.scheduleFlush();
+    this.writeGen.recordGraphWrites(new Set(quads.map((q) => q.graph || '')));
   }
 
   async delete(quads: DKGQuad[]): Promise<void> {
@@ -225,6 +232,7 @@ export class OxigraphStore implements TripleStore {
       if (oxQuad) this.store.delete(oxQuad);
     }
     this.scheduleFlush();
+    this.writeGen.recordGraphWrites(new Set(quads.map((q) => q.graph || '')));
   }
 
   async deleteByPattern(pattern: Partial<DKGQuad>): Promise<number> {
@@ -238,6 +246,8 @@ export class OxigraphStore implements TripleStore {
       this.store.delete(q);
     }
     if (matches.length > 0) this.scheduleFlush();
+    if (pattern.graph) this.writeGen.recordGraphWrites([pattern.graph]);
+    else this.writeGen.recordUnscopedWrite();
     return matches.length;
   }
 
@@ -294,9 +304,15 @@ export class OxigraphStore implements TripleStore {
     // Oxigraph creates graphs implicitly on insert — no-op.
   }
 
+  /** {@link GraphWriteGenSource} capability (#1609) — see graph-write-gen.ts. */
+  getWriteGen(graphPrefix: string): number {
+    return this.writeGen.getWriteGen(graphPrefix);
+  }
+
   async dropGraph(graphUri: string): Promise<void> {
     this.store.update(`DROP SILENT GRAPH <${escapeUri(graphUri)}>`);
     this.scheduleFlush();
+    this.writeGen.recordGraphWrites([graphUri]);
   }
 
   async listGraphs(options?: TripleStoreQueryOptions): Promise<string[]> {
@@ -326,6 +342,7 @@ export class OxigraphStore implements TripleStore {
     );
     const removed = before - this.store.size;
     if (removed > 0) this.scheduleFlush();
+    this.writeGen.recordGraphWrites([graphUri]);
     return removed;
   }
 
@@ -341,6 +358,9 @@ export class OxigraphStore implements TripleStore {
     // update contract, ignored.
     this.store.update(sparql);
     this.scheduleFlush();
+    // A raw UPDATE's write scope is not derivable at the call site
+    // (`touchedGraphs` hints only membership changes) — unscoped bump.
+    this.writeGen.recordUnscopedWrite();
   }
 
   async countQuads(graphUri?: string): Promise<number> {

--- a/packages/storage/src/adapters/sparql-http.ts
+++ b/packages/storage/src/adapters/sparql-http.ts
@@ -34,6 +34,7 @@ import type {
 } from '../triple-store.js';
 import { registerTripleStoreAdapter } from '../triple-store.js';
 import { externalStorePriorityScheduler } from '../store-priority-scheduler.js';
+import { GraphWriteGenTracker } from '../graph-write-gen.js';
 import { NON_EMPTY_NAMED_GRAPH_ENUMERATION_QUERY } from './graph-enumeration-query.js';
 import { assertQuadLiteralsMutf8Safe, JAVA_WRITE_UTF_MAX_BYTES } from '@origintrail-official/dkg-core';
 import { createHash } from 'node:crypto';
@@ -166,6 +167,10 @@ export class SparqlHttpStore implements TripleStore {
   private listGraphsCachedAt = 0;
   private listGraphsGeneration = 0;
   private listGraphsInFlight: Promise<string[]> | null = null;
+  // #1609: per-graph write generations, bumped at the same choke points that
+  // invalidate the listGraphs cache (every local mutation). Feeds the chain-
+  // reconcile negative memo via `asGraphWriteGenSource` / `getWriteGen`.
+  private readonly writeGen = new GraphWriteGenTracker();
 
   constructor(options: SparqlHttpStoreOptions) {
     if (!options.queryEndpoint?.trim()) {
@@ -209,6 +214,11 @@ export class SparqlHttpStore implements TripleStore {
 
   getPressureSnapshot(): StorePressureSnapshot {
     return externalStorePriorityScheduler.snapshot;
+  }
+
+  /** {@link GraphWriteGenSource} capability (#1609) — see graph-write-gen.ts. */
+  getWriteGen(graphPrefix: string): number {
+    return this.writeGen.getWriteGen(graphPrefix);
   }
 
   private async postQuery(sparql: string, accept: string, options?: SparqlHttpQueryOptions): Promise<Response> {
@@ -281,6 +291,7 @@ export class SparqlHttpStore implements TripleStore {
       throw new Error(`SPARQL HTTP insert failed (${res.status}): ${text.slice(0, 300)}`);
     }
     this.invalidateListGraphsCache();
+    this.writeGen.recordGraphWrites(byGraph.keys());
   }
 
   async delete(quads: DKGQuad[], options?: QueryOptions): Promise<void> {
@@ -303,6 +314,7 @@ export class SparqlHttpStore implements TripleStore {
       throw new Error(`SPARQL HTTP delete failed (${res.status}): ${text.slice(0, 300)}`);
     }
     this.invalidateListGraphsCache();
+    this.writeGen.recordGraphWrites(new Set(quads.map((q) => q.graph || '')));
   }
 
   async deleteByPattern(pattern: Partial<DKGQuad>, options?: QueryOptions): Promise<number> {
@@ -332,6 +344,8 @@ export class SparqlHttpStore implements TripleStore {
       throw new Error(`SPARQL HTTP deleteByPattern failed (${res.status}): ${text.slice(0, 300)}`);
     }
     this.invalidateListGraphsCache();
+    if (graphUri) this.writeGen.recordGraphWrites([graphUri]);
+    else this.writeGen.recordUnscopedWrite();
     const after = await this.countQuads(graphUri, {
       ...options,
       source: options?.source ?? 'sparql-http.deleteByPattern.countAfter',
@@ -355,6 +369,7 @@ export class SparqlHttpStore implements TripleStore {
       throw new Error(`SPARQL HTTP deleteBySubjectPrefix failed (${res.status}): ${text.slice(0, 300)}`);
     }
     this.invalidateListGraphsCache();
+    this.writeGen.recordGraphWrites([graphUri]);
     const after = await this.countQuads(graphUri, {
       ...options,
       source: options?.source ?? 'sparql-http.deleteBySubjectPrefix.countAfter',
@@ -377,6 +392,9 @@ export class SparqlHttpStore implements TripleStore {
       throw new Error(`SPARQL HTTP update failed (${res.status}): ${text.slice(0, 300)}`);
     }
     this.invalidateListGraphsCache();
+    // `touchedGraphs` hints only membership changes, not every graph whose
+    // CONTENT a raw UPDATE mutates — an unscoped bump is the only sound scope.
+    this.writeGen.recordUnscopedWrite();
   }
 
   async query(sparql: string, options?: SparqlHttpQueryOptions): Promise<QueryResult> {
@@ -462,6 +480,7 @@ export class SparqlHttpStore implements TripleStore {
       throw new Error(`SPARQL HTTP dropGraph failed (${res.status}): ${text.slice(0, 300)}`);
     }
     this.invalidateListGraphsCache();
+    this.writeGen.recordGraphWrites([graphUri]);
   }
 
   async listGraphs(options?: QueryOptions): Promise<string[]> {

--- a/packages/storage/src/graph-write-gen.ts
+++ b/packages/storage/src/graph-write-gen.ts
@@ -1,0 +1,98 @@
+/**
+ * Per-graph write-generation tracking (#1609).
+ *
+ * The chain-reconcile backstop keeps an in-memory negative memo ("this merkle
+ * root has no local SWM snapshot") that may suppress a rescan ONLY while no
+ * local write has touched the context graph's SWM graphs since the memoized
+ * scan — otherwise a KA whose SWM arrives later (gossip receive, publish
+ * share, active fetch) would finalize late or never. Adapters bump this
+ * counter at exactly the choke points that already invalidate the managed
+ * `listGraphs()` cache (every local mutation), so "generation unchanged"
+ * is a proof of "no local write since".
+ *
+ * Consumers recover the capability with {@link asGraphWriteGenSource} (the
+ * `asChangelogReader` pattern — no `instanceof`/decorator-order assumption)
+ * and compare {@link GraphWriteGenSource.getWriteGen} snapshots. Every
+ * imprecision is fail-open: writes whose graph scope is unknowable at the
+ * call site (raw SPARQL UPDATE, pattern deletes without a graph) bump a
+ * global floor that invalidates every prefix, and LRU eviction folds the
+ * evicted generation into that floor — an over-report costs one extra
+ * rescan, never a missed one. Cross-process writers (a second process on a
+ * shared oxigraph-server) are invisible here; the memo's TTL bounds that
+ * hole, and a restart clears the memo entirely (the counter is in-memory).
+ */
+export interface GraphWriteGenSource {
+  /**
+   * Monotonic generation for "any local write that may have touched a graph
+   * whose URI starts with `graphPrefix`". Two equal snapshots bracket a
+   * window with no such write; the value has no meaning beyond equality.
+   */
+  getWriteGen(graphPrefix: string): number;
+}
+
+/**
+ * Cap on individually-tracked graph URIs. Beyond it the least-recently
+ * written graphs fold into the global floor (fail-open — see module doc).
+ */
+const MAX_TRACKED_GRAPHS = 8192;
+
+/** Shared implementation the triple-store adapters embed. */
+export class GraphWriteGenTracker implements GraphWriteGenSource {
+  private counter = 0;
+  /** Floor for writes with unknowable graph scope + LRU-evicted graphs. */
+  private globalFloor = 0;
+  /** graph URI → last write generation; Map insertion order = LRU recency. */
+  private readonly byGraph = new Map<string, number>();
+
+  /** Record a write scoped to known graph URIs (`''` = the default graph). */
+  recordGraphWrites(graphs: Iterable<string>): void {
+    let gen: number | undefined;
+    for (const graph of graphs) {
+      gen ??= ++this.counter;
+      this.byGraph.delete(graph);
+      this.byGraph.set(graph, gen);
+    }
+    while (this.byGraph.size > MAX_TRACKED_GRAPHS) {
+      const oldest = this.byGraph.entries().next().value;
+      if (!oldest) break;
+      this.byGraph.delete(oldest[0]);
+      if (oldest[1] > this.globalFloor) this.globalFloor = oldest[1];
+    }
+  }
+
+  /** Record a write whose affected graphs are not derivable at the call site. */
+  recordUnscopedWrite(): void {
+    this.globalFloor = ++this.counter;
+  }
+
+  getWriteGen(graphPrefix: string): number {
+    let gen = this.globalFloor;
+    for (const [graph, graphGen] of this.byGraph) {
+      if (graphGen > gen && graph.startsWith(graphPrefix)) gen = graphGen;
+    }
+    return gen;
+  }
+}
+
+/**
+ * Recover the {@link GraphWriteGenSource} capability from a store (typically a
+ * `createTripleStore(...)` result behind the daemon's decorator chain), or
+ * `null` when the backing adapter does not track write generations — callers
+ * MUST fail open (always scan) on `null`.
+ */
+export function asGraphWriteGenSource(store: unknown): GraphWriteGenSource | null {
+  // Follow `.innerStore` (hand-rolled forwarders like the daemon's
+  // listContextGraphs-cache invalidator) and `.inner` (ChangelogStore,
+  // GraphSetIndexStore, SharedMemoryLiteralBlobStore) so the capability
+  // resolves through any decorator order — mirrors `asChangelogReader`.
+  // The depth bound guards a pathological/cyclic chain.
+  let s = store as
+    | { getWriteGen?: unknown; innerStore?: unknown; inner?: unknown }
+    | null
+    | undefined;
+  for (let depth = 0; s && depth < 8; depth++) {
+    if (typeof s.getWriteGen === 'function') return s as GraphWriteGenSource;
+    s = (s.innerStore ?? s.inner) as typeof s;
+  }
+  return null;
+}

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -53,6 +53,11 @@ export {
   type ChangelogReader,
   type ChangelogStoreOptions,
 } from './changelog-store.js';
+export {
+  GraphWriteGenTracker,
+  asGraphWriteGenSource,
+  type GraphWriteGenSource,
+} from './graph-write-gen.js';
 
 export { OxigraphStore } from './adapters/oxigraph.js';
 export { OxigraphWorkerStore } from './adapters/oxigraph-worker.js';

--- a/packages/storage/test/graph-write-gen.test.ts
+++ b/packages/storage/test/graph-write-gen.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Per-graph write-generation tracking (#1609) — the storage half of the
+ * chain-reconcile negative memo. The memo suppresses a reconcile rescan ONLY
+ * while `getWriteGen(cgPrefix)` is unchanged, so the contract under test is
+ * fail-open: every write that MAY touch a prefix must be visible to it
+ * (scoped writes to matching graphs, unscoped bumps for raw UPDATEs and
+ * pattern deletes without a graph, LRU-eviction folding), while writes to
+ * unrelated graphs must NOT perturb it (else the memo never holds and #1609's
+ * O(#ops)-per-sweep rescan storm returns).
+ */
+import { describe, it, expect } from 'vitest';
+import { GraphWriteGenTracker, asGraphWriteGenSource } from '../src/graph-write-gen.js';
+import { OxigraphStore } from '../src/adapters/oxigraph.js';
+
+const CG_PREFIX = 'did:dkg:context-graph:fun-facts/';
+const SWM_GRAPH = `${CG_PREFIX}_shared_memory`;
+const SWM_META_GRAPH = `${CG_PREFIX}_shared_memory_meta`;
+const OTHER_GRAPH = 'did:dkg:context-graph:other-cg/_shared_memory';
+
+describe('GraphWriteGenTracker', () => {
+  it('bumps matching prefixes on scoped writes and leaves unrelated prefixes alone', () => {
+    const tracker = new GraphWriteGenTracker();
+    const before = tracker.getWriteGen(CG_PREFIX);
+
+    tracker.recordGraphWrites([OTHER_GRAPH]);
+    expect(tracker.getWriteGen(CG_PREFIX)).toBe(before);
+
+    tracker.recordGraphWrites([SWM_GRAPH]);
+    const after = tracker.getWriteGen(CG_PREFIX);
+    expect(after).toBeGreaterThan(before);
+    // Stable while nothing else is written.
+    expect(tracker.getWriteGen(CG_PREFIX)).toBe(after);
+  });
+
+  it('bumps every prefix on an unscoped write', () => {
+    const tracker = new GraphWriteGenTracker();
+    const cgBefore = tracker.getWriteGen(CG_PREFIX);
+    const otherBefore = tracker.getWriteGen('did:dkg:context-graph:other-cg/');
+
+    tracker.recordUnscopedWrite();
+    expect(tracker.getWriteGen(CG_PREFIX)).toBeGreaterThan(cgBefore);
+    expect(tracker.getWriteGen('did:dkg:context-graph:other-cg/')).toBeGreaterThan(otherBefore);
+  });
+
+  it('keeps default-graph writes invisible to named-graph prefixes', () => {
+    const tracker = new GraphWriteGenTracker();
+    const before = tracker.getWriteGen(CG_PREFIX);
+    tracker.recordGraphWrites(['']);
+    expect(tracker.getWriteGen(CG_PREFIX)).toBe(before);
+    // ...but visible to the match-everything empty prefix.
+    expect(tracker.getWriteGen('')).toBeGreaterThan(0);
+  });
+
+  it('folds LRU-evicted graphs into the global floor (eviction can only force rescans)', () => {
+    const tracker = new GraphWriteGenTracker();
+    tracker.recordGraphWrites([SWM_GRAPH]);
+    const observed = tracker.getWriteGen(CG_PREFIX);
+
+    // Flood with enough distinct graphs to evict SWM_GRAPH from the LRU map.
+    for (let i = 0; i < 8300; i++) {
+      tracker.recordGraphWrites([`urn:flood:${i}`]);
+    }
+    // The evicted graph folded into the global floor: the prefix must NOT
+    // keep reporting the old generation it can no longer prove unchanged —
+    // a memo gated on it then rescans (fail-open) instead of going stale.
+    expect(tracker.getWriteGen(CG_PREFIX)).toBeGreaterThan(observed);
+  });
+});
+
+describe('OxigraphStore write-generation capability', () => {
+  const quad = (graph: string, value = 'v') => ({
+    subject: 'urn:e:1',
+    predicate: 'http://ex.org/p',
+    object: `"${value}"`,
+    graph,
+  });
+
+  it('is recoverable via asGraphWriteGenSource on the bare adapter and through decorator chains', () => {
+    const store = new OxigraphStore();
+    expect(asGraphWriteGenSource(store)).not.toBeNull();
+    // `.innerStore` forwarder (daemon wrapper shape) and `.inner` decorator shape.
+    expect(asGraphWriteGenSource({ innerStore: { inner: store } })).not.toBeNull();
+    expect(asGraphWriteGenSource({})).toBeNull();
+    expect(asGraphWriteGenSource(null)).toBeNull();
+  });
+
+  it('bumps the CG prefix on every mutation kind that can affect an SWM scan', async () => {
+    const store = new OxigraphStore();
+    const gen = () => store.getWriteGen(CG_PREFIX);
+
+    let last = gen();
+    await store.insert([quad(SWM_GRAPH)]);
+    expect(gen()).toBeGreaterThan(last);
+
+    last = gen();
+    await store.delete([quad(SWM_GRAPH)]);
+    expect(gen()).toBeGreaterThan(last);
+
+    last = gen();
+    await store.insert([quad(SWM_META_GRAPH)]);
+    await store.deleteByPattern({ graph: SWM_META_GRAPH, subject: 'urn:e:1' });
+    expect(gen()).toBeGreaterThan(last);
+
+    last = gen();
+    await store.insert([quad(SWM_GRAPH)]);
+    await store.deleteBySubjectPrefix(SWM_GRAPH, 'urn:e:');
+    expect(gen()).toBeGreaterThan(last);
+
+    last = gen();
+    await store.dropGraph(SWM_GRAPH);
+    expect(gen()).toBeGreaterThan(last);
+
+    // Raw UPDATE: write scope unknowable → unscoped bump hits every prefix.
+    last = gen();
+    await store.update(`INSERT DATA { GRAPH <${OTHER_GRAPH}> { <urn:e:2> <http://ex.org/p> "x" } }`);
+    expect(gen()).toBeGreaterThan(last);
+  });
+
+  it('does not bump the CG prefix on scoped writes to other graphs or on reads', async () => {
+    const store = new OxigraphStore();
+    await store.insert([quad(SWM_GRAPH)]);
+    const before = store.getWriteGen(CG_PREFIX);
+
+    await store.insert([quad(OTHER_GRAPH)]);
+    await store.delete([quad(OTHER_GRAPH)]);
+    await store.deleteByPattern({ graph: OTHER_GRAPH });
+    await store.query(`ASK { GRAPH <${SWM_GRAPH}> { ?s ?p ?o } }`);
+    await store.listGraphs();
+    await store.countQuads(SWM_GRAPH);
+
+    expect(store.getWriteGen(CG_PREFIX)).toBe(before);
+  });
+});


### PR DESCRIPTION
## Problem (#1609, second half)

`findSwmSnapshotForMerkleRoot` runs an unbounded O(#ops) SWM `CONSTRUCT` on **every chain-reconcile attempt**. For a KA whose SWM this node will never hold ("never-match" — published elsewhere), the 60s reconcile sweep re-runs that 30–46s read forever on multi-GB stores, stalling the event loop and dropping storage-ACK streams. #1612 memoized the merkle *recompute*; it did **not** touch these reads. Measured on testnet 2026-07-11/12: beacon `agent.finalization.sharedMemorySlice` slow-queries sustained/rising, quorum-ACK cores intermittently unresponsive.

## Fix

A write-generation-gated **negative memo** — the O(1)-per-sweep bridge to OT-RFC-60's write-maintained root stamp:

- **storage**: a monotonic per-graph-prefix write-generation counter bumped at the existing listGraphs-cache-invalidation choke points of all three write adapters (`sparql-http`, `oxigraph`, `oxigraph-worker`), exposed via `getWriteGen()` / `asGraphWriteGenSource()` (follows the `.innerStore` chain like `asChangelogReader`, so every decorator resolves to the one adapter-level tracker).
- **agent**: an LRU (4096) negative memo keyed `(cg, subGraph, merkleRootHex) → pre-scan gen`. A hit returns "no snapshot" without scanning **iff** the CG's SWM-prefix write-gen is unchanged AND the entry is younger than `DKG_VM_RECONCILE_NEGATIVE_TTL_MS` (default 600 000). A MATCH is never memoized.

**Invariant (no false-negative finalization):** new SWM arrives only via a local write to the CG's SWM prefix (gossip receive / share / active fetch) → all pass the adapter choke → gen bumps → next call rescans. Capability absent (e.g. blazegraph) ⇒ memo disabled (fail-open). Restart clears it (in-memory). TTL bounds any writer invisible to the counter to "≤10 min late", never "never".

## Tests
`packages/agent/test/finalization-reconcile-negative-memo.test.ts` (6 design cases: warm never-match zero-read, arrival promotes, entity-keyed change invalidates, meta write invalidates, catalog-floor CG, TTL forced rescan) + `packages/storage/test/graph-write-gen.test.ts` (7). Agent blast-radius 142/142; storage 337 pass / 24 pre-existing skips; both packages `tsc` green. 3 `core-fills-gap.test.ts` cost-model assertions updated (scans now 0 where the memo correctly suppresses; fetch-count assertions still prove sweep-cache non-reuse).

## Known follow-ups (non-blocking, from adversarial self-review)
1. **Adapter test coverage:** the write-gen contract is currently exercised on `OxigraphStore` only; `sparql-http` + `oxigraph-worker` bumps (the incident-shape adapters) are correct but unguarded. Will parameterize the contract test across all three adapters (hermetic sparql endpoint helper already exists).
2. **TTL sizing on multi-GB stores:** each TTL expiry re-runs one full scan; at >~13 pending never-match KAs the 10× rate reduction is insufficient. Recommend raising `DKG_VM_RECONCILE_NEGATIVE_TTL_MS` to 30–60 min on big beacons. The pre-gate chain-RPC path (`verifyChainCgBinding`) is untouched — O(pending)/sweep remains, and OT-RFC-60 is the durable O(1) fix.

## Verified: multi-instance safety
The counter is per-adapter-instance + in-memory. On a **core** (where the stall occurs) all SWM writes are daemon-side through the shared adapter → the memo sees them. The cross-process publisher store is on the *publishing* path, not core reconcile; TTL bounds any residual. Safe on the deploy-critical path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)