### PR TITLE
perf(chain): memoize resolveContract address resolution to cut per-publish RPC read amplification (#1583)

### DIFF
--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -123,18 +123,17 @@ const HUB_BINDING_INVALIDATORS = new Map<string, HubBindingInvalidationPolicy>(
  *     in the 1h memo would shadow that shorter backstop (and is redundant with
  *     the pair cache).
  *
- *   - `PublishingConviction` / `ShardingTable` / `DKGStakingConvictionNFT` —
- *     memoized-then-stale would strand an outdated address for up to
- *     `RESOLVE_CONTRACT_ADDRESS_MEMO_TTL_MS` because these three are resolved
- *     per-call (not lazy-bound), are ABSENT from `HUB_BINDING_INVALIDATORS`, and
- *     sit on paths with no read-side self-heal (PCA UI `version()`/`clearAgentsSupported`
- *     gate at evm-adapter-conviction.ts:610; the `listDesignatableNodes` logic
- *     read; and the one-shot conviction-NFT provisioning write at
- *     evm-adapter-identity.ts:350). Pre-#1583 each did a fresh
- *     `Hub.getContractAddress` that self-healed on the next call; excluding them
- *     restores that (a strict non-regression). They are all COLD paths — not the
- *     publish-burst hot path this memo targets — so exclusion costs ~nothing.
- *     (Review of PR #1615, axis-1 invalidation gap.)
+ *   - `PublishingConviction` / `ShardingTable` / `DKGStakingConvictionNFT` — these
+ *     three are resolved per-call (not lazy-bound) on COLD paths only: the PCA UI
+ *     `version()`/`clearAgentsSupported` gate (evm-adapter-conviction.ts:610), the
+ *     `listDesignatableNodes` logic read (itself behind a 30s cache), and the
+ *     one-shot conviction-NFT provisioning write (evm-adapter-identity.ts:350).
+ *     They are NOT excluded for a correctness reason — the round-2 unconditional
+ *     rotation flush (`applyHubRotationEventName`) would self-heal them on an
+ *     observed rotation exactly like the memoized names — but because memoizing a
+ *     cold path saves ~nothing, keeping them fresh-every-call is a zero-cost strict
+ *     non-regression (identical to pre-#1583). Excluding them also keeps this list
+ *     as documentation of "which names the memo intentionally skips."
  *
  * NOTE on the two ACK-verify-floor contracts, `IdentityStorage` and
  * `ShardingTableStorage`, which ARE memoized (not excluded): both are on the
@@ -145,16 +144,18 @@ const HUB_BINDING_INVALIDATORS = new Map<string, HubBindingInvalidationPolicy>(
  * stay live within a single ACK regardless of this memo. The only thing memoized
  * is the proxy ADDRESS, which changes only on a Hub re-registration of the
  * contract itself (a rare, coordinated migration — NOT a key revocation or a
- * table exit). An OBSERVED such rotation of IdentityStorage flushes immediately
- * (`HUB_BINDING_INVALIDATORS`, `invalidateOnRotation:true`, plus every identity-
- * cache-invalidation site); the only residual — a poller-MISSED contract rotation
- * of either — is bounded to `RESOLVE_CONTRACT_ADDRESS_MEMO_TTL_MS` (30s, the
- * staleness the codebase already accepts for the sibling `listDesignatableNodes`
- * sharding-table read), across a compound edge (rare contract rotation × rare
- * poller miss × ≤30s). Memoizing these two is a deliberate reversal of the first
- * cut's ShardingTableStorage exclusion (review of PR #1615, axis-1): excluding it
- * while memoizing its ACK-path twin IdentityStorage was inconsistent and left
- * ~half of ACK-verify address amplification uncut.
+ * table exit). Any OBSERVED such rotation of EITHER flushes the whole memo
+ * immediately: `applyHubRotationEventName` calls `resolvedContractAddressCache`
+ * `.invalidateAll()` unconditionally on every Hub rotation event (round-2 fix —
+ * this is what covers ShardingTableStorage, which has no lazy binding and so no
+ * `HUB_BINDING_INVALIDATORS` entry). The only residual — a poller-MISSED contract
+ * rotation of either — is bounded to `RESOLVE_CONTRACT_ADDRESS_MEMO_TTL_MS` (30s,
+ * the staleness the codebase already accepts for the sibling `listDesignatableNodes`
+ * read), across a compound edge (rare contract rotation × rare poller miss × ≤30s).
+ * Memoizing these two is a deliberate reversal of the first cut's ShardingTableStorage
+ * exclusion (review of PR #1615): excluding it while memoizing its ACK-path twin
+ * IdentityStorage was inconsistent and left ~half of ACK-verify address
+ * amplification uncut.
  */
 const RESOLVE_CONTRACT_ADDRESS_MEMO_EXCLUDED = new Set<string>([
   'RandomSampling',
@@ -173,10 +174,16 @@ const RESOLVE_CONTRACT_ADDRESS_MEMO_EXCLUDED = new Set<string>([
  * contract-rotation the event poller MISSES → a memoized-stale address, e.g.
  * IdentityStorage behind ACK `keyHasPurpose`) to ≤30s instead of ≤1h, while a
  * publish burst (seconds–minutes) still resolves each contract from ~1 read
- * instead of ~150. Observed rotations still invalidate immediately via the hooks
- * below; contract rotation is itself a rare coordinated migration event.
+ * instead of ~150. Observed rotations still invalidate immediately via the
+ * unconditional flush in `applyHubRotationEventName`; contract rotation is itself
+ * a rare coordinated migration event.
+ *
+ * Exported (not a class member) so the memo unit test can couple its TTL-backstop
+ * assertion to the production value without widening the adapter's protected
+ * surface — the same idiom already used for `decodeConvictionCostCovered` and the
+ * `CG_REGISTRY_*` consts. (Review of PR #1615, round-2.)
  */
-const RESOLVE_CONTRACT_ADDRESS_MEMO_TTL_MS = 30_000;
+export const RESOLVE_CONTRACT_ADDRESS_MEMO_TTL_MS = 30_000;
 
 const KA_HIGH_WATER_VIEW_SIGNATURE = 'getMaxKaNumberForAuthor(address)';
 
@@ -864,10 +871,6 @@ export class EVMChainAdapterBase {
    * with no cross-talk.
    */
   protected static readonly PREFLIGHT_TTL_MS = 60 * 60 * 1000;
-
-  /** Class-visible mirror of the module-level memo TTL (see its doc-comment);
-   *  exposed so tests can couple the TTL-backstop assertion to production. */
-  protected static readonly RESOLVE_CONTRACT_ADDRESS_MEMO_TTL_MS = RESOLVE_CONTRACT_ADDRESS_MEMO_TTL_MS;
 
   protected cachedChainId: { value: bigint; cachedAt: number } | undefined;
 
@@ -2354,8 +2357,13 @@ export class EVMChainAdapterBase {
    * (`readHubContractAddress`) throws on a missing/zero result so the memo only
    * ever holds a successfully-resolved non-zero address (a negative result must
    * not poison the cache — the next call re-tries).
+   *
+   * `private`: the only production caller is `resolveContract` (same class). The
+   * memo is an implementation detail of `resolveContract`, not a subclass
+   * extension point (review of PR #1615, round-2). Unit tests reach it via the
+   * usual `any`-cast on the adapter under test.
    */
-  protected async resolveContractAddress(name: string): Promise<string> {
+  private async resolveContractAddress(name: string): Promise<string> {
     if (RESOLVE_CONTRACT_ADDRESS_MEMO_EXCLUDED.has(name)) {
       return this.readHubContractAddress(name);
     }
@@ -3784,6 +3792,20 @@ export class EVMChainAdapterBase {
   }
 
   protected applyHubRotationEventName(name: string): void {
+    // #1583 (review round-2) — flush the resolved-address memo on EVERY observed
+    // Hub rotation, unconditionally and first. The memo caches the address of
+    // any non-excluded name, including per-call names with no lazy binding and
+    // so no `HUB_BINDING_INVALIDATORS` entry (`ShardingTableStorage`, resolved
+    // fresh per ACK in `verifyACKIdentityDetailed`). The pre-round-2 code only
+    // flushed inside `finalizeKnownHubRotation`, reached solely for names WITH a
+    // policy — so an observed ShardingTableStorage rotation left `nodeExists`
+    // pinned to the retired proxy for up to the 30s TTL. A memoized address is a
+    // pure function of Hub-registry state, so any ContractChanged / NewContract /
+    // AssetStorageChanged / NewAssetStorage event (all delivered here via the one
+    // `onContractName` callback) is exactly the signal that some memoized address
+    // may have moved; flushing all of them is correct and keeps the 30s TTL as a
+    // pure missed-rotation backstop.
+    this.resolvedContractAddressCache.invalidateAll();
     if (name === 'RandomSampling' || name === 'RandomSamplingStorage') {
       this.invalidateRandomSamplingPair();
       return;
@@ -3808,11 +3830,10 @@ export class EVMChainAdapterBase {
 
   protected finalizeKnownHubRotation(): void {
     this.invalidatePublishPreflightCache();
-    // #1583 — every known Hub rotation event (any name in
-    // HUB_BINDING_INVALIDATORS) reaches here, so flush the resolved-address memo
-    // alongside the preflight cache. This is the primary invalidation path for
-    // the memoized contract set; the excluded RS pair / ShardingTableStorage
-    // names are never in the memo.
+    // #1583 — redundant-but-harmless second flush (the unconditional flush at the
+    // top of `applyHubRotationEventName` already cleared the memo for this event).
+    // Kept so the memo stays invalidated if `finalizeKnownHubRotation` ever gains
+    // another caller. `invalidateAll()` is idempotent.
     this.resolvedContractAddressCache.invalidateAll();
     // Force the next public-method entry through `init()` so it re-resolves
     // every binding. Do not clear boot-bound handles here: the callback can

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -115,17 +115,6 @@ const HUB_BINDING_INVALIDATORS = new Map<string, HubBindingInvalidationPolicy>(
  * The memo caches a resolved proxy address to skip that read, but two families
  * MUST always resolve fresh:
  *
- *   - `ShardingTableStorage` — the ACK-verify quorum floor. `verifyACKIdentityDetailed`
- *     runs `nodeExists` against it, so a departed node must NOT count toward
- *     quorum. It has NO Hub-rotation invalidation hook (absent from
- *     `HUB_BINDING_INVALIDATORS`, not a boot binding) AND ack-verify is a READ
- *     path with no write-side self-heal (`withHubStaleRetry` only covers write
- *     reverts), so a stale memoized address after a sharding-table rotation could
- *     pin `nodeExists` to an outdated contract for up to `PREFLIGHT_TTL_MS`.
- *     Resolving it fresh every verify is exactly the pre-memo behaviour — a
- *     strict non-regression for the security floor. (`nodeExists` / `keyHasPurpose`
- *     RESULTS are never cached regardless of this decision.)
- *
  *   - `RandomSampling` / `RandomSamplingStorage` — already owned by
  *     `randomSamplingPairCache`, which uses a deliberately SHORTER TTL
  *     (`randomSamplingHubRefreshMs`) as a missed-rotation backstop for the
@@ -133,12 +122,61 @@ const HUB_BINDING_INVALIDATORS = new Map<string, HubBindingInvalidationPolicy>(
  *     lifecycle. Its loader calls `resolveContract`, so memoizing these addresses
  *     in the 1h memo would shadow that shorter backstop (and is redundant with
  *     the pair cache).
+ *
+ *   - `PublishingConviction` / `ShardingTable` / `DKGStakingConvictionNFT` —
+ *     memoized-then-stale would strand an outdated address for up to
+ *     `RESOLVE_CONTRACT_ADDRESS_MEMO_TTL_MS` because these three are resolved
+ *     per-call (not lazy-bound), are ABSENT from `HUB_BINDING_INVALIDATORS`, and
+ *     sit on paths with no read-side self-heal (PCA UI `version()`/`clearAgentsSupported`
+ *     gate at evm-adapter-conviction.ts:610; the `listDesignatableNodes` logic
+ *     read; and the one-shot conviction-NFT provisioning write at
+ *     evm-adapter-identity.ts:350). Pre-#1583 each did a fresh
+ *     `Hub.getContractAddress` that self-healed on the next call; excluding them
+ *     restores that (a strict non-regression). They are all COLD paths — not the
+ *     publish-burst hot path this memo targets — so exclusion costs ~nothing.
+ *     (Review of PR #1615, axis-1 invalidation gap.)
+ *
+ * NOTE on the two ACK-verify-floor contracts, `IdentityStorage` and
+ * `ShardingTableStorage`, which ARE memoized (not excluded): both are on the
+ * per-ACK hot path (`verifyACKIdentityDetailed` resolves both on every ACK, so a
+ * 100-KA burst re-resolved each ~once per ACK ≈ hundreds of redundant Hub reads),
+ * and both are security-sensitive only in their RESULTS — `keyHasPurpose` (key
+ * revoked) and `nodeExists` (node left the table), which are NEVER cached and so
+ * stay live within a single ACK regardless of this memo. The only thing memoized
+ * is the proxy ADDRESS, which changes only on a Hub re-registration of the
+ * contract itself (a rare, coordinated migration — NOT a key revocation or a
+ * table exit). An OBSERVED such rotation of IdentityStorage flushes immediately
+ * (`HUB_BINDING_INVALIDATORS`, `invalidateOnRotation:true`, plus every identity-
+ * cache-invalidation site); the only residual — a poller-MISSED contract rotation
+ * of either — is bounded to `RESOLVE_CONTRACT_ADDRESS_MEMO_TTL_MS` (30s, the
+ * staleness the codebase already accepts for the sibling `listDesignatableNodes`
+ * sharding-table read), across a compound edge (rare contract rotation × rare
+ * poller miss × ≤30s). Memoizing these two is a deliberate reversal of the first
+ * cut's ShardingTableStorage exclusion (review of PR #1615, axis-1): excluding it
+ * while memoizing its ACK-path twin IdentityStorage was inconsistent and left
+ * ~half of ACK-verify address amplification uncut.
  */
 const RESOLVE_CONTRACT_ADDRESS_MEMO_EXCLUDED = new Set<string>([
-  'ShardingTableStorage',
   'RandomSampling',
   'RandomSamplingStorage',
+  'PublishingConviction',
+  'ShardingTable',
+  'DKGStakingConvictionNFT',
 ]);
+
+/**
+ * TTL for the `resolvedContractAddressCache` address memo. Deliberately SHORT
+ * (30s) rather than the 1h `PREFLIGHT_TTL_MS` (review of PR #1615): it matches
+ * the staleness the codebase ALREADY accepts for the same class of read — the
+ * `listDesignatableNodes` sharding-table cache is 30s (evm-adapter-conviction.ts)
+ * — and it bounds the only residual risk of memoizing a contract address (a Hub
+ * contract-rotation the event poller MISSES → a memoized-stale address, e.g.
+ * IdentityStorage behind ACK `keyHasPurpose`) to ≤30s instead of ≤1h, while a
+ * publish burst (seconds–minutes) still resolves each contract from ~1 read
+ * instead of ~150. Observed rotations still invalidate immediately via the hooks
+ * below; contract rotation is itself a rare coordinated migration event.
+ */
+const RESOLVE_CONTRACT_ADDRESS_MEMO_TTL_MS = 30_000;
 
 const KA_HIGH_WATER_VIEW_SIGNATURE = 'getMaxKaNumberForAuthor(address)';
 
@@ -737,9 +775,12 @@ export class EVMChainAdapterBase {
    * (identity resolution, ACK verification, token-amount) through the chain RPC —
    * on that workload the RPC was ~99% reads, almost all address re-resolution.
    *
-   * Only the ADDRESS is memoized; a fresh `new Contract(address, abi, this.signer)`
-   * is still built per call because the signer can change (do NOT cache Contract
-   * objects). Keyed `${hubAddress}:${chainId}:${name}` — the hub+chain scope is
+   * Only the ADDRESS is memoized; the `Contract` handle is still built fresh per
+   * call (a cheap object build, not an RPC). `this.signer` is a constant readonly
+   * pool[0], so caching the handle would be behaviourally safe — but reads go via
+   * `staticCall` and writes `.connect()` an explicitly-passed signer, so the fresh
+   * build is the simplest correct thing and avoids an ABI-vs-address cache pairing.
+   * Keyed `${hubAddress}:${chainId}:${name}` — the hub+chain scope is
    * constant for an adapter instance but is kept explicit so the key survives any
    * future shared-cache refactor. Proxy addresses are immutable except on a Hub
    * re-registration, so the memo is cleared at the SAME rotation/invalidation
@@ -823,6 +864,10 @@ export class EVMChainAdapterBase {
    * with no cross-talk.
    */
   protected static readonly PREFLIGHT_TTL_MS = 60 * 60 * 1000;
+
+  /** Class-visible mirror of the module-level memo TTL (see its doc-comment);
+   *  exposed so tests can couple the TTL-backstop assertion to production. */
+  protected static readonly RESOLVE_CONTRACT_ADDRESS_MEMO_TTL_MS = RESOLVE_CONTRACT_ADDRESS_MEMO_TTL_MS;
 
   protected cachedChainId: { value: bigint; cachedAt: number } | undefined;
 
@@ -914,17 +959,20 @@ export class EVMChainAdapterBase {
     const checksum = ethers.getAddress(address);
     await this.init();
     const previousIdentityStorage = this.contracts.identityStorage;
-    // #1583 — do NOT force a fresh Hub resolve on every getIdentityId miss.
-    // Pre-#1583 this used `{ refresh: true }`, which re-resolved the
-    // IdentityStorage ADDRESS through the Hub on each cache miss — a major RPC
-    // amplifier during publish bursts. The address is now memoized in
-    // `resolveContractAddress` and dropped by the Hub-rotation invalidation
-    // hooks, so the cached lazy binding is authoritative. The `getIdentityId`
-    // VALUE read below stays fresh/uncached (only the ADDRESS is memoized). The
-    // `identityStorageChanged` guard is preserved as a belt-and-suspenders
-    // safety: if a rotation hook cleared the binding, the re-resolve returns a
-    // new handle and we flush the identity caches AND the address memo.
-    const identityStorage = await this.getIdentityStorage();
+    // #1583 — keep the `{ refresh: true }` re-resolve. Pre-#1583 this re-hit the
+    // Hub on every getIdentityId miss (a major RPC amplifier during publish
+    // bursts); now `resolveContractAddress` memoizes the address, so the
+    // re-resolve is memo-served (no RPC on the hot path) yet still rebinds the
+    // lazy Contract to whatever the memo currently holds. That coupling is the
+    // point: a Hub rotation the event poller MISSES no longer strands this
+    // binding on a dead proxy — the address memo TTL-expires within
+    // RESOLVE_CONTRACT_ADDRESS_MEMO_TTL_MS (30s) and this re-resolve picks up the
+    // new address, bounding the missed-rotation window to ≤30s. (An OBSERVED
+    // rotation clears both binding and memo immediately via
+    // `invalidateIdentityStorageBinding`.) The `getIdentityId` VALUE read below
+    // stays fresh/uncached; `identityStorageChanged` flushes the identity caches
+    // when the re-resolve lands on a new address.
+    const identityStorage = await this.getIdentityStorage({ refresh: true });
     const identityStorageChanged = await this.identityStorageAddressChanged(previousIdentityStorage, identityStorage);
     if (identityStorageChanged) {
       this.identityIdCache.invalidateAll();
@@ -1156,9 +1204,10 @@ export class EVMChainAdapterBase {
       EVMChainAdapterBase.IDENTITY_ID_POSITIVE_TTL_MS,
       EVMChainAdapterBase.SIGNER_IDENTITY_ID_ZERO_TTL_MS,
     );
-    // #1583 — resolved-contract-address memo, 1h TTL backstop (PREFLIGHT_TTL_MS).
+    // #1583 — resolved-contract-address memo, 30s TTL backstop
+    // (RESOLVE_CONTRACT_ADDRESS_MEMO_TTL_MS — bounds a poller-missed rotation).
     this.resolvedContractAddressCache = new ReadThroughTtlCache<string, string>({
-      ttlMs: EVMChainAdapterBase.PREFLIGHT_TTL_MS,
+      ttlMs: RESOLVE_CONTRACT_ADDRESS_MEMO_TTL_MS,
     });
     this.hubAddress = config.hubAddress;
     if (config.tokenAddress && !ethers.isAddress(config.tokenAddress)) {
@@ -2292,9 +2341,9 @@ export class EVMChainAdapterBase {
 
   protected async resolveContract(name: string, abiName?: string): Promise<Contract> {
     const address = await this.resolveContractAddress(name);
-    // Build the handle fresh every call — the signer can change (round-robin
-    // operational-wallet selection), so a cached Contract could carry a stale
-    // signer. Only the ADDRESS is memoized (#1583).
+    // Build the handle fresh every call — a cheap object build (no RPC). Only the
+    // ADDRESS is memoized (#1583); reads use staticCall and writes .connect() an
+    // explicit signer, so no stale-signer risk from the constant readonly signer.
     return new Contract(address, loadAbi(abiName ?? name), this.signer);
   }
 

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -108,6 +108,38 @@ const HUB_BINDING_INVALIDATORS = new Map<string, HubBindingInvalidationPolicy>(
   HUB_BINDING_INVALIDATOR_ENTRIES,
 );
 
+/**
+ * Contract names deliberately EXCLUDED from the `resolvedContractAddressCache`
+ * address memo (#1583 — the 100-KA publish-burst RPC read amplifier that funnels
+ * ~150-250 redundant `Hub.getContractAddress` eth_calls through the chain RPC).
+ * The memo caches a resolved proxy address to skip that read, but two families
+ * MUST always resolve fresh:
+ *
+ *   - `ShardingTableStorage` — the ACK-verify quorum floor. `verifyACKIdentityDetailed`
+ *     runs `nodeExists` against it, so a departed node must NOT count toward
+ *     quorum. It has NO Hub-rotation invalidation hook (absent from
+ *     `HUB_BINDING_INVALIDATORS`, not a boot binding) AND ack-verify is a READ
+ *     path with no write-side self-heal (`withHubStaleRetry` only covers write
+ *     reverts), so a stale memoized address after a sharding-table rotation could
+ *     pin `nodeExists` to an outdated contract for up to `PREFLIGHT_TTL_MS`.
+ *     Resolving it fresh every verify is exactly the pre-memo behaviour — a
+ *     strict non-regression for the security floor. (`nodeExists` / `keyHasPurpose`
+ *     RESULTS are never cached regardless of this decision.)
+ *
+ *   - `RandomSampling` / `RandomSamplingStorage` — already owned by
+ *     `randomSamplingPairCache`, which uses a deliberately SHORTER TTL
+ *     (`randomSamplingHubRefreshMs`) as a missed-rotation backstop for the
+ *     read-only prover paths plus its own `invalidateRandomSamplingPair()`
+ *     lifecycle. Its loader calls `resolveContract`, so memoizing these addresses
+ *     in the 1h memo would shadow that shorter backstop (and is redundant with
+ *     the pair cache).
+ */
+const RESOLVE_CONTRACT_ADDRESS_MEMO_EXCLUDED = new Set<string>([
+  'ShardingTableStorage',
+  'RandomSampling',
+  'RandomSamplingStorage',
+]);
+
 const KA_HIGH_WATER_VIEW_SIGNATURE = 'getMaxKaNumberForAuthor(address)';
 
 type IdentityIdCacheEntry = {
@@ -698,6 +730,27 @@ export class EVMChainAdapterBase {
 
   protected readonly pcaReadCache = new PcaReadCache();
 
+  /**
+   * #1583 — resolved-address memo for `resolveContract`. Caches the Hub-resolved
+   * proxy ADDRESS (string) per contract name so a sustained 100-KA publish burst
+   * stops funnelling ~150-250 redundant `Hub.getContractAddress` eth_calls
+   * (identity resolution, ACK verification, token-amount) through the chain RPC —
+   * on that workload the RPC was ~99% reads, almost all address re-resolution.
+   *
+   * Only the ADDRESS is memoized; a fresh `new Contract(address, abi, this.signer)`
+   * is still built per call because the signer can change (do NOT cache Contract
+   * objects). Keyed `${hubAddress}:${chainId}:${name}` — the hub+chain scope is
+   * constant for an adapter instance but is kept explicit so the key survives any
+   * future shared-cache refactor. Proxy addresses are immutable except on a Hub
+   * re-registration, so the memo is cleared at the SAME rotation/invalidation
+   * hooks as `identityIdCache`, with a `PREFLIGHT_TTL_MS` backstop so a missed
+   * hook cannot strand a stale address forever. A zero/missing result is never
+   * cached (only a successfully-resolved non-zero address). See
+   * `RESOLVE_CONTRACT_ADDRESS_MEMO_EXCLUDED` for names that always resolve fresh.
+   * Assigned in the constructor (TTL sourced from the `PREFLIGHT_TTL_MS` static).
+   */
+  protected readonly resolvedContractAddressCache: ReadThroughTtlCache<string, string>;
+
   protected readonly hubRotationPoller: HubRotationPoller;
 
   /**
@@ -824,6 +877,11 @@ export class EVMChainAdapterBase {
 
   protected clearIdentityIdForAddress(address: string): void {
     this.identityIdCache.invalidate(address);
+    // #1583 — this fires on the identity-management / RS-challenge paths (NOT
+    // the per-KA-publish hot path), so dropping the address memo here is cheap
+    // and keeps the resolved-address cache flushed whenever we suspect an
+    // identity binding shifted.
+    this.resolvedContractAddressCache.invalidateAll();
   }
 
   protected seedIdentityIdForAddress(address: string, identityId: bigint): void {
@@ -833,6 +891,9 @@ export class EVMChainAdapterBase {
   protected invalidateIdentityStorageBinding(): void {
     this.contracts.identityStorage = undefined;
     this.identityIdCache.invalidateAll();
+    // #1583 — an IdentityStorage rotation changes its proxy address; drop the
+    // memoized address so the next resolve re-hits the Hub.
+    this.resolvedContractAddressCache.invalidateAll();
   }
 
   protected async identityStorageAddressChanged(
@@ -853,9 +914,22 @@ export class EVMChainAdapterBase {
     const checksum = ethers.getAddress(address);
     await this.init();
     const previousIdentityStorage = this.contracts.identityStorage;
-    const identityStorage = await this.getIdentityStorage({ refresh: true });
+    // #1583 — do NOT force a fresh Hub resolve on every getIdentityId miss.
+    // Pre-#1583 this used `{ refresh: true }`, which re-resolved the
+    // IdentityStorage ADDRESS through the Hub on each cache miss — a major RPC
+    // amplifier during publish bursts. The address is now memoized in
+    // `resolveContractAddress` and dropped by the Hub-rotation invalidation
+    // hooks, so the cached lazy binding is authoritative. The `getIdentityId`
+    // VALUE read below stays fresh/uncached (only the ADDRESS is memoized). The
+    // `identityStorageChanged` guard is preserved as a belt-and-suspenders
+    // safety: if a rotation hook cleared the binding, the re-resolve returns a
+    // new handle and we flush the identity caches AND the address memo.
+    const identityStorage = await this.getIdentityStorage();
     const identityStorageChanged = await this.identityStorageAddressChanged(previousIdentityStorage, identityStorage);
-    if (identityStorageChanged) this.identityIdCache.invalidateAll();
+    if (identityStorageChanged) {
+      this.identityIdCache.invalidateAll();
+      this.resolvedContractAddressCache.invalidateAll();
+    }
     const id: bigint = await this.readContract(
       identityStorage, 'identityStorage.getIdentityId', 'getIdentityId', checksum,
     );
@@ -1082,6 +1156,10 @@ export class EVMChainAdapterBase {
       EVMChainAdapterBase.IDENTITY_ID_POSITIVE_TTL_MS,
       EVMChainAdapterBase.SIGNER_IDENTITY_ID_ZERO_TTL_MS,
     );
+    // #1583 — resolved-contract-address memo, 1h TTL backstop (PREFLIGHT_TTL_MS).
+    this.resolvedContractAddressCache = new ReadThroughTtlCache<string, string>({
+      ttlMs: EVMChainAdapterBase.PREFLIGHT_TTL_MS,
+    });
     this.hubAddress = config.hubAddress;
     if (config.tokenAddress && !ethers.isAddress(config.tokenAddress)) {
       throw new Error(`Invalid tokenAddress: ${config.tokenAddress}`);
@@ -2213,6 +2291,34 @@ export class EVMChainAdapterBase {
   }
 
   protected async resolveContract(name: string, abiName?: string): Promise<Contract> {
+    const address = await this.resolveContractAddress(name);
+    // Build the handle fresh every call — the signer can change (round-robin
+    // operational-wallet selection), so a cached Contract could carry a stale
+    // signer. Only the ADDRESS is memoized (#1583).
+    return new Contract(address, loadAbi(abiName ?? name), this.signer);
+  }
+
+  /**
+   * #1583 — resolve a Hub-registered contract's proxy address, served from
+   * `resolvedContractAddressCache` when memoizable. Names in
+   * `RESOLVE_CONTRACT_ADDRESS_MEMO_EXCLUDED` always hit the Hub. The loader
+   * (`readHubContractAddress`) throws on a missing/zero result so the memo only
+   * ever holds a successfully-resolved non-zero address (a negative result must
+   * not poison the cache — the next call re-tries).
+   */
+  protected async resolveContractAddress(name: string): Promise<string> {
+    if (RESOLVE_CONTRACT_ADDRESS_MEMO_EXCLUDED.has(name)) {
+      return this.readHubContractAddress(name);
+    }
+    const key = `${this.hubAddress}:${this.chainId}:${name}`;
+    return this.resolvedContractAddressCache.getOrLoad(
+      key,
+      key,
+      () => this.readHubContractAddress(name),
+    );
+  }
+
+  private async readHubContractAddress(name: string): Promise<string> {
     let address: string;
     try {
       address = await this.readContract(
@@ -2230,7 +2336,7 @@ export class EVMChainAdapterBase {
     if (address === ethers.ZeroAddress) {
       throw new Error(`Contract "${name}" not found in Hub at ${this.hubAddress}`);
     }
-    return new Contract(address, loadAbi(abiName ?? name), this.signer);
+    return address;
   }
 
   protected async resolveAssetStorage(name: string, abiName?: string): Promise<Contract> {
@@ -3653,6 +3759,12 @@ export class EVMChainAdapterBase {
 
   protected finalizeKnownHubRotation(): void {
     this.invalidatePublishPreflightCache();
+    // #1583 — every known Hub rotation event (any name in
+    // HUB_BINDING_INVALIDATORS) reaches here, so flush the resolved-address memo
+    // alongside the preflight cache. This is the primary invalidation path for
+    // the memoized contract set; the excluded RS pair / ShardingTableStorage
+    // names are never in the memo.
+    this.resolvedContractAddressCache.invalidateAll();
     // Force the next public-method entry through `init()` so it re-resolves
     // every binding. Do not clear boot-bound handles here: the callback can
     // fire between a public method's `await init()` and its first
@@ -3681,6 +3793,9 @@ export class EVMChainAdapterBase {
       this.invalidateHubBinding(policy);
     }
     this.invalidatePublishPreflightCache();
+    // #1583 — the write-side self-heal cannot tell which name rotated, so drop
+    // the entire resolved-address memo along with every bound handle.
+    this.resolvedContractAddressCache.invalidateAll();
     this.invalidateRandomSamplingPair();
     this.initialized = false;
   }

--- a/packages/chain/test/evm-adapter-resolve-contract-memo.unit.test.ts
+++ b/packages/chain/test/evm-adapter-resolve-contract-memo.unit.test.ts
@@ -16,14 +16,13 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { ethers } from 'ethers';
 import { EVMChainAdapter, type EVMAdapterConfig } from '../src/evm-adapter.js';
+// Import the production TTL const directly (it is exported from the adapter base,
+// same idiom as decodeConvictionCostCovered / CG_REGISTRY_*), so the TTL-backstop
+// test stays coupled to production without a class-surface mirror.
+import { RESOLVE_CONTRACT_ADDRESS_MEMO_TTL_MS as MEMO_TTL_MS } from '../src/evm-adapter-base.js';
 
 const DEPLOYER_PK = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
 const ADMIN_PK = '0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a';
-
-// The memo TTL is a protected static on the adapter base; read it through the
-// class so the TTL-backstop test stays coupled to the production constant.
-const MEMO_TTL_MS = ((EVMChainAdapter as unknown as { RESOLVE_CONTRACT_ADDRESS_MEMO_TTL_MS?: number })
-  .RESOLVE_CONTRACT_ADDRESS_MEMO_TTL_MS) ?? 30_000;
 
 const ADDR_BY_NAME: Record<string, string> = {
   IdentityStorage: '0x00000000000000000000000000000000000000A1',
@@ -133,6 +132,23 @@ describe('resolveContract address memo (#1583)', () => {
     expect(hubReads(rc)).toBe(4);
   });
 
+  it('an OBSERVED rotation of a memoized-but-unmapped name (ShardingTableStorage) flushes the memo (#1615 round-2 🔴)', async () => {
+    // ShardingTableStorage is memoized (per-ACK nodeExists) but has NO
+    // HUB_BINDING_INVALIDATORS entry, so pre-fix applyHubRotationEventName hit
+    // `if (!policy) return` and never flushed — an observed rotation left the ACK
+    // floor pinned to the retired proxy for up to the 30s TTL. The unconditional
+    // top-of-handler flush fixes it: the next resolve must re-hit the Hub.
+    const a = makeAdapter();
+    const rc = spyByName(a);
+    await a.resolveContractAddress('ShardingTableStorage');
+    await a.resolveContractAddress('ShardingTableStorage');
+    expect(hubReads(rc, 'ShardingTableStorage')).toBe(1);
+
+    (a as any).applyHubRotationEventName('ShardingTableStorage');
+    await a.resolveContractAddress('ShardingTableStorage');
+    expect(hubReads(rc, 'ShardingTableStorage')).toBe(2);
+  });
+
   it('the bulk write-side self-heal (invalidateAllBoundContracts) flushes the memo', async () => {
     const a = makeAdapter();
     const rc = spyByName(a);
@@ -227,6 +243,34 @@ describe('resolveContract address memo (#1583)', () => {
         .resolves.toBe(ADDR_BY_NAME.ShardingTableStorage);
     }
     expect(hubReads(rc, 'ShardingTableStorage')).toBe(1);
+  });
+
+  it('concurrent same-name resolves single-flight — ONE Hub read for a 100-wide burst (#1615 axis-2)', async () => {
+    // The motivating workload is a *burst*, not sequential repeats: many ACKs
+    // resolve the same name simultaneously while the first Hub read is still in
+    // flight. A plain TTL map without in-flight coalescing would fan out 100 Hub
+    // reads here; the ReadThroughTtlCache single-flights them. This asserts the
+    // adapter wiring inherits that (a regression to a non-coalescing map fails it).
+    const a = makeAdapter();
+    let releaseHubRead!: (addr: string) => void;
+    const pending = new Promise<string>((res) => { releaseHubRead = res; });
+    const rc = recorder(async () => pending); // every readContract awaits the same gate
+    a.readContract = rc;
+
+    const burst = Promise.all(
+      Array.from({ length: 100 }, () => a.resolveContractAddress('IdentityStorage')),
+    );
+    // Drain microtasks so all 100 calls have entered the cache's getOrLoad and
+    // registered against the single in-flight load before we inspect the count.
+    for (let i = 0; i < 5; i++) await Promise.resolve();
+    expect(hubReads(rc)).toBe(1); // only one read is in flight for all 100 waiters
+
+    releaseHubRead(ADDR_BY_NAME.IdentityStorage);
+    const results = await burst;
+    expect(results).toHaveLength(100);
+    expect(new Set(results).size).toBe(1); // all 100 got the same address
+    expect(results[0]).toBe(ADDR_BY_NAME.IdentityStorage);
+    expect(hubReads(rc)).toBe(1); // ...from a single Hub read, start to finish
   });
 
   // PR #1615 review axis-2: the behaviour callers actually depend on is that

--- a/packages/chain/test/evm-adapter-resolve-contract-memo.unit.test.ts
+++ b/packages/chain/test/evm-adapter-resolve-contract-memo.unit.test.ts
@@ -20,10 +20,10 @@ import { EVMChainAdapter, type EVMAdapterConfig } from '../src/evm-adapter.js';
 const DEPLOYER_PK = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
 const ADMIN_PK = '0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a';
 
-// PREFLIGHT_TTL_MS is a protected static on the adapter base; read it through the
+// The memo TTL is a protected static on the adapter base; read it through the
 // class so the TTL-backstop test stays coupled to the production constant.
-const PREFLIGHT_TTL_MS = ((EVMChainAdapter as unknown as { PREFLIGHT_TTL_MS?: number })
-  .PREFLIGHT_TTL_MS) ?? 60 * 60 * 1000;
+const MEMO_TTL_MS = ((EVMChainAdapter as unknown as { RESOLVE_CONTRACT_ADDRESS_MEMO_TTL_MS?: number })
+  .RESOLVE_CONTRACT_ADDRESS_MEMO_TTL_MS) ?? 30_000;
 
 const ADDR_BY_NAME: Record<string, string> = {
   IdentityStorage: '0x00000000000000000000000000000000000000A1',
@@ -33,6 +33,9 @@ const ADDR_BY_NAME: Record<string, string> = {
   RandomSampling: '0x00000000000000000000000000000000000000A5',
   RandomSamplingStorage: '0x00000000000000000000000000000000000000A6',
   Foo: '0x00000000000000000000000000000000000000A7',
+  PublishingConviction: '0x00000000000000000000000000000000000000A8',
+  ShardingTable: '0x00000000000000000000000000000000000000A9',
+  DKGStakingConvictionNFT: '0x00000000000000000000000000000000000000Aa',
 };
 const RECOVERED = ethers.getAddress('0x00000000000000000000000000000000000000ab');
 
@@ -140,7 +143,7 @@ describe('resolveContract address memo (#1583)', () => {
     expect(hubReads(rc)).toBe(2);
   });
 
-  it('re-resolves after the PREFLIGHT_TTL_MS backstop even with no invalidation hook', async () => {
+  it('re-resolves after the 30s memo-TTL backstop even with no invalidation hook', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(0);
     const a = makeAdapter();
@@ -151,12 +154,13 @@ describe('resolveContract address memo (#1583)', () => {
     expect(hubReads(rc)).toBe(1);
 
     // Just inside the TTL — still served from the memo.
-    vi.setSystemTime(PREFLIGHT_TTL_MS - 1);
+    vi.setSystemTime(MEMO_TTL_MS - 1);
     await a.resolveContractAddress('IdentityStorage');
     expect(hubReads(rc)).toBe(1);
 
-    // Past the TTL — re-resolves.
-    vi.setSystemTime(PREFLIGHT_TTL_MS + 1);
+    // Past the TTL — re-resolves. This backstop is what bounds a poller-missed
+    // Hub rotation to ≤30s (see readIdentityIdFromStorage / the memo TTL const).
+    vi.setSystemTime(MEMO_TTL_MS + 1);
     await a.resolveContractAddress('IdentityStorage');
     expect(hubReads(rc)).toBe(2);
   });
@@ -198,16 +202,56 @@ describe('resolveContract address memo (#1583)', () => {
     expect(hubReads(rc)).toBe(2);
   });
 
-  it('excluded names (ShardingTableStorage, RandomSampling*) ALWAYS resolve fresh', async () => {
+  it('excluded names (RandomSampling*, PCA cold paths) ALWAYS resolve fresh', async () => {
     const a = makeAdapter();
     const rc = spyByName(a);
-    for (const name of ['ShardingTableStorage', 'RandomSampling', 'RandomSamplingStorage']) {
+    for (const name of ['RandomSampling', 'RandomSamplingStorage',
+      // PR #1615 review axis-1: hookless, no-self-heal cold paths — always fresh.
+      'PublishingConviction', 'ShardingTable', 'DKGStakingConvictionNFT']) {
       for (let i = 0; i < 4; i++) {
         await expect(a.resolveContractAddress(name)).resolves.toBe(ADDR_BY_NAME[name]);
       }
       // Every call re-hits the Hub — these are deliberately NOT memoized.
       expect(hubReads(rc, name)).toBe(4);
     }
+  });
+
+  it('ShardingTableStorage — the ACK-verify twin of IdentityStorage — IS memoized (#1615 axis-1 reversal)', async () => {
+    // First cut excluded ShardingTableStorage while memoizing its per-ACK twin
+    // IdentityStorage — inconsistent, and it left ~half of ACK-verify address
+    // amplification uncut. Both are now memoized (30s TTL, RESULTS stay live).
+    const a = makeAdapter();
+    const rc = spyByName(a);
+    for (let i = 0; i < 5; i++) {
+      await expect(a.resolveContractAddress('ShardingTableStorage'))
+        .resolves.toBe(ADDR_BY_NAME.ShardingTableStorage);
+    }
+    expect(hubReads(rc, 'ShardingTableStorage')).toBe(1);
+  });
+
+  // PR #1615 review axis-2: the behaviour callers actually depend on is that
+  // `resolveContract()` (the public path — used by getIdentityStorage, ACK
+  // verification, every hot read) inherits the memo, not just the extracted
+  // `resolveContractAddress` helper. These two exercise the caller path end to
+  // end (real Contract build over `loadAbi`, no stub of resolveContract).
+  it('resolveContract() — the real caller path — serves repeats from the memo (ONE Hub read)', async () => {
+    const a = makeAdapter();
+    const rc = spyByName(a);
+    const handles = [];
+    for (let i = 0; i < 5; i++) handles.push(await a.resolveContract('IdentityStorage'));
+    // One Hub address-resolve for all five; each build is a fresh handle bound to
+    // the memoized address (reads staticCall, writes .connect() a signer).
+    expect(hubReads(rc, 'IdentityStorage')).toBe(1);
+    for (const h of handles) {
+      expect((await h.getAddress()).toLowerCase()).toBe(ADDR_BY_NAME.IdentityStorage.toLowerCase());
+    }
+  });
+
+  it('resolveContract() honours the exclusion set — excluded names re-hit the Hub each call', async () => {
+    const a = makeAdapter();
+    const rc = spyByName(a);
+    for (let i = 0; i < 3; i++) await a.resolveContract('RandomSampling');
+    expect(hubReads(rc, 'RandomSampling')).toBe(3);
   });
 });
 

--- a/packages/chain/test/evm-adapter-resolve-contract-memo.unit.test.ts
+++ b/packages/chain/test/evm-adapter-resolve-contract-memo.unit.test.ts
@@ -1,0 +1,239 @@
+/**
+ * #1583 — resolved-contract-address memo in `resolveContract`.
+ *
+ * A sustained 100-KA publish burst saturated the chain RPC with ~99% reads,
+ * almost all of them redundant `Hub.getContractAddress` calls re-resolving
+ * effectively-constant proxy addresses on every hot read (identity resolution,
+ * ACK verification, token-amount). This suite pins the memo's behaviour: hit /
+ * miss counts, per-name keying, invalidation-hook + TTL-backstop refresh,
+ * negative-result non-poisoning, the deliberate ShardingTableStorage /
+ * RandomSampling exclusions, and that the ACK-verify security floor
+ * (keyHasPurpose / nodeExists RESULTS) stays LIVE.
+ *
+ * Mirrors the `minimalConfig` / `recorder` unit harness used across the chain
+ * adapter suite (no live RPC).
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { ethers } from 'ethers';
+import { EVMChainAdapter, type EVMAdapterConfig } from '../src/evm-adapter.js';
+
+const DEPLOYER_PK = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
+const ADMIN_PK = '0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a';
+
+// PREFLIGHT_TTL_MS is a protected static on the adapter base; read it through the
+// class so the TTL-backstop test stays coupled to the production constant.
+const PREFLIGHT_TTL_MS = ((EVMChainAdapter as unknown as { PREFLIGHT_TTL_MS?: number })
+  .PREFLIGHT_TTL_MS) ?? 60 * 60 * 1000;
+
+const ADDR_BY_NAME: Record<string, string> = {
+  IdentityStorage: '0x00000000000000000000000000000000000000A1',
+  ParametersStorage: '0x00000000000000000000000000000000000000A2',
+  Token: '0x00000000000000000000000000000000000000A3',
+  ShardingTableStorage: '0x00000000000000000000000000000000000000A4',
+  RandomSampling: '0x00000000000000000000000000000000000000A5',
+  RandomSamplingStorage: '0x00000000000000000000000000000000000000A6',
+  Foo: '0x00000000000000000000000000000000000000A7',
+};
+const RECOVERED = ethers.getAddress('0x00000000000000000000000000000000000000ab');
+
+function recorder<A extends unknown[], R>(impl: (...args: A) => R) {
+  const calls: A[] = [];
+  const fn = (...args: A): R => { calls.push(args); return impl(...args); };
+  return Object.assign(fn, { calls });
+}
+
+function minimalConfig(overrides: Partial<EVMAdapterConfig> = {}): EVMAdapterConfig {
+  return {
+    rpcUrl: 'http://127.0.0.1:59998',
+    privateKey: DEPLOYER_PK,
+    adminPrivateKey: ADMIN_PK,
+    hubAddress: '0x0000000000000000000000000000000000000001',
+    chainId: 'evm:31337',
+    staticNetwork: false,
+    ...overrides,
+  };
+}
+
+// Bare adapter with `init()` short-circuited — no live RPC.
+function makeAdapter(): any {
+  const a: any = new EVMChainAdapter(minimalConfig());
+  a.initialized = true;
+  a.init = async () => { a.initialized = true; };
+  return a;
+}
+
+// Count the memo's Hub reads. `readHubContractAddress` calls
+// `readContract(hub, 'Hub.getContractAddress(X)', 'getContractAddress', name)`.
+function hubReads(rc: { calls: unknown[][] }, name?: string): number {
+  return rc.calls.filter(
+    (c) => c[2] === 'getContractAddress' && (name === undefined || c[3] === name),
+  ).length;
+}
+
+// readContract spy returning the fixed per-name address (miss path).
+function spyByName(a: any) {
+  const rc = recorder(async (..._args: unknown[]) => ADDR_BY_NAME[_args[3] as string]);
+  a.readContract = rc;
+  return rc;
+}
+
+describe('resolveContract address memo (#1583)', () => {
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('N sequential resolves of one name issue exactly ONE Hub.getContractAddress', async () => {
+    const a = makeAdapter();
+    const rc = spyByName(a);
+    for (let i = 0; i < 6; i++) {
+      await expect(a.resolveContractAddress('IdentityStorage'))
+        .resolves.toBe(ADDR_BY_NAME.IdentityStorage);
+    }
+    expect(hubReads(rc)).toBe(1);
+  });
+
+  it('distinct contract names are keyed independently — one Hub read each', async () => {
+    const a = makeAdapter();
+    const rc = spyByName(a);
+    for (const name of ['IdentityStorage', 'ParametersStorage', 'Token']) {
+      for (let i = 0; i < 3; i++) {
+        await expect(a.resolveContractAddress(name)).resolves.toBe(ADDR_BY_NAME[name]);
+      }
+    }
+    expect(hubReads(rc)).toBe(3);
+    expect(hubReads(rc, 'IdentityStorage')).toBe(1);
+    expect(hubReads(rc, 'ParametersStorage')).toBe(1);
+    expect(hubReads(rc, 'Token')).toBe(1);
+  });
+
+  it('an IdentityStorage-rotation invalidation hook forces the next resolve to re-hit the Hub', async () => {
+    const a = makeAdapter();
+    const rc = spyByName(a);
+    await a.resolveContractAddress('IdentityStorage');
+    await a.resolveContractAddress('IdentityStorage');
+    expect(hubReads(rc)).toBe(1);
+
+    (a as any).invalidateIdentityStorageBinding();
+    await a.resolveContractAddress('IdentityStorage');
+    expect(hubReads(rc)).toBe(2);
+  });
+
+  it('a generic Hub rotation (finalizeKnownHubRotation) flushes the memo for every name', async () => {
+    const a = makeAdapter();
+    const rc = spyByName(a);
+    await a.resolveContractAddress('Token');
+    await a.resolveContractAddress('ParametersStorage');
+    expect(hubReads(rc)).toBe(2);
+
+    // Any allowlisted rotation event reaches finalizeKnownHubRotation.
+    (a as any).applyHubRotationEventName('Token');
+    await a.resolveContractAddress('Token');
+    await a.resolveContractAddress('ParametersStorage');
+    expect(hubReads(rc)).toBe(4);
+  });
+
+  it('the bulk write-side self-heal (invalidateAllBoundContracts) flushes the memo', async () => {
+    const a = makeAdapter();
+    const rc = spyByName(a);
+    await a.resolveContractAddress('Token');
+    expect(hubReads(rc)).toBe(1);
+    (a as any).invalidateAllBoundContracts();
+    await a.resolveContractAddress('Token');
+    expect(hubReads(rc)).toBe(2);
+  });
+
+  it('re-resolves after the PREFLIGHT_TTL_MS backstop even with no invalidation hook', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const a = makeAdapter();
+    const rc = spyByName(a);
+
+    await a.resolveContractAddress('IdentityStorage');
+    await a.resolveContractAddress('IdentityStorage');
+    expect(hubReads(rc)).toBe(1);
+
+    // Just inside the TTL — still served from the memo.
+    vi.setSystemTime(PREFLIGHT_TTL_MS - 1);
+    await a.resolveContractAddress('IdentityStorage');
+    expect(hubReads(rc)).toBe(1);
+
+    // Past the TTL — re-resolves.
+    vi.setSystemTime(PREFLIGHT_TTL_MS + 1);
+    await a.resolveContractAddress('IdentityStorage');
+    expect(hubReads(rc)).toBe(2);
+  });
+
+  it('a ZeroAddress result is never cached — the next call re-tries and recovers', async () => {
+    const a = makeAdapter();
+    let call = 0;
+    const rc = recorder(async () => {
+      call += 1;
+      return call <= 2 ? ethers.ZeroAddress : ADDR_BY_NAME.IdentityStorage;
+    });
+    a.readContract = rc;
+
+    await expect(a.resolveContractAddress('IdentityStorage')).rejects.toThrow('not found in Hub');
+    await expect(a.resolveContractAddress('IdentityStorage')).rejects.toThrow('not found in Hub');
+    // Both misses re-hit the Hub (no negative poisoning).
+    expect(hubReads(rc)).toBe(2);
+
+    // A subsequent successful resolve caches, so the following call is a hit.
+    await expect(a.resolveContractAddress('IdentityStorage'))
+      .resolves.toBe(ADDR_BY_NAME.IdentityStorage);
+    await expect(a.resolveContractAddress('IdentityStorage'))
+      .resolves.toBe(ADDR_BY_NAME.IdentityStorage);
+    expect(hubReads(rc)).toBe(3);
+  });
+
+  it('a ContractDoesNotExist revert is normalized and not cached', async () => {
+    const a = makeAdapter();
+    let call = 0;
+    const rc = recorder(async () => {
+      call += 1;
+      if (call === 1) throw new Error('execution reverted: ContractDoesNotExist("Foo")');
+      return ADDR_BY_NAME.Foo;
+    });
+    a.readContract = rc;
+
+    await expect(a.resolveContractAddress('Foo')).rejects.toThrow('not found in Hub');
+    await expect(a.resolveContractAddress('Foo')).resolves.toBe(ADDR_BY_NAME.Foo);
+    expect(hubReads(rc)).toBe(2);
+  });
+
+  it('excluded names (ShardingTableStorage, RandomSampling*) ALWAYS resolve fresh', async () => {
+    const a = makeAdapter();
+    const rc = spyByName(a);
+    for (const name of ['ShardingTableStorage', 'RandomSampling', 'RandomSamplingStorage']) {
+      for (let i = 0; i < 4; i++) {
+        await expect(a.resolveContractAddress(name)).resolves.toBe(ADDR_BY_NAME[name]);
+      }
+      // Every call re-hits the Hub — these are deliberately NOT memoized.
+      expect(hubReads(rc, name)).toBe(4);
+    }
+  });
+});
+
+describe('ACK-verify security floor stays live under the address memo (#1583)', () => {
+  it('runs keyHasPurpose + nodeExists on EVERY verify (results never memoized)', async () => {
+    const a = makeAdapter();
+    const identityStorage = { id: 'IdentityStorage' };
+    const shardingTableStorage = { id: 'ShardingTableStorage' };
+    // Route the two ACK-verify resolves to distinct stub handles.
+    a.resolveContract = recorder(async (name: string) => (
+      name === 'IdentityStorage' ? identityStorage : shardingTableStorage
+    ));
+    // keyHasPurpose + nodeExists both pass.
+    const rc = recorder(async () => true);
+    a.readContract = rc;
+
+    await expect(a.verifyACKIdentityDetailed(RECOVERED, 5n)).resolves.toEqual({ valid: true });
+    await expect(a.verifyACKIdentityDetailed(RECOVERED, 5n)).resolves.toEqual({ valid: true });
+
+    const keyHasPurposeCalls = rc.calls.filter((c) => c[2] === 'keyHasPurpose').length;
+    const nodeExistsCalls = rc.calls.filter((c) => c[2] === 'nodeExists').length;
+    // One LIVE read of each per verify — the security floor is never cached.
+    expect(keyHasPurposeCalls).toBe(2);
+    expect(nodeExistsCalls).toBe(2);
+    // The reads target the freshly-resolved contract handles.
+    expect(rc.calls.filter((c) => c[0] === identityStorage && c[2] === 'keyHasPurpose')).toHaveLength(2);
+    expect(rc.calls.filter((c) => c[0] === shardingTableStorage && c[2] === 'nodeExists')).toHaveLength(2);
+  });
+});

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -224,7 +224,12 @@ describe('EVMChainAdapter getIdentityIdForAddress cache', () => {
     expect(a.readContract.calls[1][0]).toBe(identityStorage);
   });
 
-  it('identity cache misses refresh IdentityStorage so a missed Hub rotation cannot pin stale zero reads', async () => {
+  it('identity id misses reuse the cached IdentityStorage binding — no per-miss re-resolve (#1583)', async () => {
+    // Pre-#1583 `readIdentityIdFromStorage` forced `getIdentityStorage({ refresh:
+    // true })`, re-resolving the IdentityStorage ADDRESS through the Hub on EVERY
+    // identity-id miss — a major publish-burst RPC amplifier. It now reuses the
+    // cached lazy binding; rotation safety rests on the invalidation hooks (below
+    // and in the following cases), NOT a per-miss refresh.
     const a: any = new EVMChainAdapter(minimalConfig());
     const oldIdentityStorage = { target: '0x0000000000000000000000000000000000000101' };
     const newIdentityStorage = { target: '0x0000000000000000000000000000000000000102' };
@@ -235,21 +240,29 @@ describe('EVMChainAdapter getIdentityIdForAddress cache', () => {
       resolveCount += 1;
       return resolveCount === 1 ? oldIdentityStorage : newIdentityStorage;
     });
-    a.readContract = recorder(async (contract: unknown) => (
-      contract === oldIdentityStorage ? 0n : 42n
+    // VALUE read keys off the WALLET address (not the contract), so each distinct
+    // address is a fresh/uncached read even though the binding is shared.
+    a.readContract = recorder(async (_c: unknown, _l: string, _m: string, addr: string) => (
+      addr === ethers.getAddress(ADDR) ? 7n : 9n
     ));
 
-    await expect(a.getIdentityIdForAddress(ADDR)).resolves.toBe(0n);
+    // Two distinct-address misses resolve IdentityStorage exactly ONCE; the
+    // `getIdentityId` VALUE read stays fresh/uncached (one readContract each).
+    await expect(a.getIdentityIdForAddress(ADDR)).resolves.toBe(7n);
     expect(a.contracts.identityStorage).toBe(oldIdentityStorage);
+    await expect(a.getIdentityIdForAddress(ADDR2)).resolves.toBe(9n);
+    expect(a.contracts.identityStorage).toBe(oldIdentityStorage);
+    expect(a.resolveContract.calls).toHaveLength(1);
+    expect(a.readContract.calls).toHaveLength(2);
 
-    await expect(a.getIdentityIdForAddress(ADDR2)).resolves.toBe(42n);
+    // A dropped binding (Hub-rotation hook) forces the next miss to re-resolve
+    // fresh, so a rotated IdentityStorage cannot pin stale reads.
+    (a as any).invalidateIdentityStorageBinding();
+    expect(a.contracts.identityStorage).toBeUndefined();
+    await expect(a.getIdentityIdForAddress(ADDR)).resolves.toBe(7n);
     expect(a.contracts.identityStorage).toBe(newIdentityStorage);
     expect(a.resolveContract.calls).toHaveLength(2);
-    expect(a.readContract.calls).toHaveLength(2);
-
-    await expect(a.getIdentityIdForAddress(ADDR2)).resolves.toBe(42n);
-    expect(a.resolveContract.calls).toHaveLength(2);
-    expect(a.readContract.calls).toHaveLength(2);
+    expect(a.readContract.calls).toHaveLength(3);
   });
 
   it('IdentityStorage Hub rotation invalidates cached identity ids and the lazy contract binding', async () => {

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -224,44 +224,46 @@ describe('EVMChainAdapter getIdentityIdForAddress cache', () => {
     expect(a.readContract.calls[1][0]).toBe(identityStorage);
   });
 
-  it('identity id misses reuse the cached IdentityStorage binding — no per-miss re-resolve (#1583)', async () => {
-    // Pre-#1583 `readIdentityIdFromStorage` forced `getIdentityStorage({ refresh:
-    // true })`, re-resolving the IdentityStorage ADDRESS through the Hub on EVERY
-    // identity-id miss — a major publish-burst RPC amplifier. It now reuses the
-    // cached lazy binding; rotation safety rests on the invalidation hooks (below
-    // and in the following cases), NOT a per-miss refresh.
+  it('identity-id misses re-resolve the memo-served binding and auto-heal a rotated address without an explicit hook (#1583)', async () => {
+    // #1583 keeps `getIdentityStorage({ refresh: true })` on every identity-id
+    // miss. The re-resolve is memo-served — the ADDRESS is cached in
+    // `resolveContractAddress`, so no Hub RPC on the hot path — which is what
+    // makes it cheap. What it buys back: a Hub rotation the event poller MISSES
+    // is still picked up when the address memo TTL-expires (≤30s), WITHOUT
+    // relying on an explicit invalidation hook firing. Here `resolveContract` is
+    // stubbed to stand in for the memo: it returns the same handle until the
+    // test rotates it.
+    const ADDR3 = '0x00000000000000000000000000000000000000a3';
     const a: any = new EVMChainAdapter(minimalConfig());
     const oldIdentityStorage = { target: '0x0000000000000000000000000000000000000101' };
     const newIdentityStorage = { target: '0x0000000000000000000000000000000000000102' };
-    let resolveCount = 0;
+    let current = oldIdentityStorage;
     a.initialized = true;
     a.init = async () => { a.initialized = true; };
-    a.resolveContract = recorder(async () => {
-      resolveCount += 1;
-      return resolveCount === 1 ? oldIdentityStorage : newIdentityStorage;
-    });
+    a.resolveContract = recorder(async () => current);
     // VALUE read keys off the WALLET address (not the contract), so each distinct
-    // address is a fresh/uncached read even though the binding is shared.
+    // wallet is a fresh/uncached read even though the binding is shared.
     a.readContract = recorder(async (_c: unknown, _l: string, _m: string, addr: string) => (
       addr === ethers.getAddress(ADDR) ? 7n : 9n
     ));
 
-    // Two distinct-address misses resolve IdentityStorage exactly ONCE; the
-    // `getIdentityId` VALUE read stays fresh/uncached (one readContract each).
+    // Two distinct-wallet misses each re-resolve (refresh: true), but the memo
+    // returns the SAME address, so the binding is stable and no cache is flushed;
+    // the `getIdentityId` VALUE read stays fresh/uncached (one readContract each).
     await expect(a.getIdentityIdForAddress(ADDR)).resolves.toBe(7n);
     expect(a.contracts.identityStorage).toBe(oldIdentityStorage);
     await expect(a.getIdentityIdForAddress(ADDR2)).resolves.toBe(9n);
     expect(a.contracts.identityStorage).toBe(oldIdentityStorage);
-    expect(a.resolveContract.calls).toHaveLength(1);
+    expect(a.resolveContract.calls).toHaveLength(2);
     expect(a.readContract.calls).toHaveLength(2);
 
-    // A dropped binding (Hub-rotation hook) forces the next miss to re-resolve
-    // fresh, so a rotated IdentityStorage cannot pin stale reads.
-    (a as any).invalidateIdentityStorageBinding();
-    expect(a.contracts.identityStorage).toBeUndefined();
-    await expect(a.getIdentityIdForAddress(ADDR)).resolves.toBe(7n);
+    // The memo rotates (TTL expiry surfacing a poller-missed Hub rotation). The
+    // next miss re-resolves to the new address; the address-change guard flushes
+    // the identity caches and rebinds — no explicit invalidation hook required.
+    current = newIdentityStorage;
+    await expect(a.getIdentityIdForAddress(ADDR3)).resolves.toBe(9n);
     expect(a.contracts.identityStorage).toBe(newIdentityStorage);
-    expect(a.resolveContract.calls).toHaveLength(2);
+    expect(a.resolveContract.calls).toHaveLength(3);
     expect(a.readContract.calls).toHaveLength(3);
   });
 

--- a/packages/chain/test/mock-adapter-parity.test.ts
+++ b/packages/chain/test/mock-adapter-parity.test.ts
@@ -117,6 +117,12 @@ const MOCK_EXEMPT_FROM_EVM = new Set<string>([
   'hasOperationalPurpose',
   'resolveContract',
   'resolveAssetStorage',
+  // #1583 resolved-address memo internals: `resolveContract` delegates address
+  // resolution to `resolveContractAddress` (memo lookup) → `readHubContractAddress`
+  // (the raw `Hub.getContractAddress` read). EVM-only Hub plumbing — the mock has
+  // no Hub — same category as `resolveContract` / `resolveAssetStorage` above.
+  'resolveContractAddress',
+  'readHubContractAddress',
   'init',
   'initContracts',          // TS-private: init() body extracted so RPC-exhaustion can be wrapped as RPC_ENDPOINTS_EXHAUSTED
   'requireV9',


### PR DESCRIPTION
## Problem (#1583 — idle/burst RPC read amplification)

`resolveContract(name)` (evm-adapter-base.ts) issued a fresh `Hub.getContractAddress(name)` eth_call on **every** call, for Hub **proxy** addresses that are effectively constant. Every hot read (identity resolution, ACK verification, token amounts) funnels through it. Measured on a sustained ~50-KA publish burst on testnet: ~99% of RPC traffic was reads, dominated by this address resolution (~150–250 redundant `getContractAddress` calls per burst), which saturates the RPC endpoints — publishes then fail at the read stage (`No positive on-chain context graph id` / ACK-verify `pool_below_quorum`) long before the ~5 actual mint writes. A 20-KA burst hit 100% (RPC not yet saturated); 50–100-KA fell to 24–64% as quotas depleted. Core-health was green throughout — this is pure RPC read amplification, not a node defect.

## Fix

- **Address memo** in `resolveContract` → `resolveContractAddress` via a `ReadThroughTtlCache<string,string>` keyed `${hubAddress}:${chainId}:${name}`, reusing the same keyed-ttl-single-flight primitive that backs `identityIdCache`. Only the **address** is cached; a fresh `Contract` is still built per call (a cheap object build, no RPC — reads use `staticCall`, writes `.connect()` an explicit signer). Zero/missing/revert results are **never** cached.
- **TTL = 30s** (`RESOLVE_CONTRACT_ADDRESS_MEMO_TTL_MS`), matching the staleness the codebase already accepts for the sibling `listDesignatableNodes` sharding-table read. Bounds a poller-**missed** contract rotation to ≤30s while still collapsing a whole publish burst (seconds–minutes) to ~1 read per contract.
- **Invalidation:** `invalidateAll()` wired into every existing `identityIdCache`-invalidation / Hub-rotation hook (`clearIdentityIdForAddress`, `invalidateIdentityStorageBinding`, `finalizeKnownHubRotation`, `invalidateAllBoundContracts`) — observed rotations flush immediately; the 30s TTL is the missed-rotation backstop.
- `readIdentityIdFromStorage` keeps `getIdentityStorage({ refresh: true })`: now that the address is memoized the re-resolve is memo-served (no Hub RPC on the hot path) yet still rebinds the lazy Contract to the current memo, so a missed rotation self-heals within 30s instead of stranding the binding.

## The two ACK-verify-floor contracts are memoized (IdentityStorage + ShardingTableStorage)

Both are resolved on **every** ACK in `verifyACKIdentityDetailed`, so they are the dominant hot-path amplifier (a 100-KA burst re-resolved each ~once per ACK ≈ hundreds of redundant Hub reads). Both are security-sensitive only in their **RESULTS** — `keyHasPurpose` (key revoked) and `nodeExists` (node left the table) — which are **never cached** and stay live within a single ACK. Only the proxy **ADDRESS** is memoized, and that changes only on a rare, coordinated Hub re-registration of the contract itself (not a key revocation or a table exit). Observed IdentityStorage rotations flush immediately; the only residual (a poller-missed contract rotation of either) is ≤30s.

**Excluded from the memo** (always resolved fresh): `RandomSampling`/`RandomSamplingStorage` (owned by `randomSamplingPairCache`'s shorter-TTL backstop) and the cold, hookless, no-self-heal paths `PublishingConviction`/`ShardingTable`/`DKGStakingConvictionNFT` (strict pre-#1583 non-regression; not the burst hot path, so exclusion costs ~nothing).

## Tests
Chain unit suite: **618 passed / 1 skipped / 0 failed**. `evm-adapter-resolve-contract-memo.unit.test.ts` (13): N-sequential→1 read; per-name keying; rotation invalidation ×3 hooks; 30s TTL backstop; ZeroAddress + ContractDoesNotExist non-poisoning; excluded-name freshness; **ShardingTableStorage memoized** (ACK-floor twin); **`resolveContract()` caller-path** coverage (memoized + excluded, real wrapper); ACK-verify live-every-verify. `evm-adapter.unit.test.ts` identity-id-miss test rewritten for the `refresh:true` auto-heal semantics (old→new Hub lookup with no explicit invalidation → next miss re-resolves). tsc green.

## Review round-1 (otReviewAgent + adversarial pass) — resolved in this PR
- 🔴 *IdentityStorage misses can stay pinned to a stale handle* → restored `refresh:true` (memo-served, so cheap) + the requested no-hook rotation test.
- 🔴 *Memo tests bypass the changed caller path* → added `resolveContract()` seam tests (memoized + excluded).
- 🟡 *Make memoization opt-in from the binding policy* → shrank the blast radius (TTL 1h→30s) and documented why deriving cacheable names from `HUB_BINDING_INVALIDATORS` doesn't work as-is (ShardingTableStorage is deliberately memoized without a rotation hook; RS/PCA exclusions are heterogeneous). Full inversion to an explicit per-name `{ memoize, invalidatedBy }` policy is deferred to a **fast-follow PR** (touches the RS-pair-cache call sites; deserves its own review).
- Adversarial catch (advisor): first cut excluded `ShardingTableStorage` while memoizing its per-ACK twin IdentityStorage — inconsistent, left ~half of ACK-verify address amplification uncut. Now memoized.

## Review round-2 (otReviewAgent + verified investigation workflow) — resolved in this PR
- 🔴 *ShardingTableStorage memo ignored OBSERVED rotations* → it's memoized but has no `HUB_BINDING_INVALIDATORS` entry, so `applyHubRotationEventName` early-returned without flushing. Fixed: flush the address memo **unconditionally** on every observed Hub rotation (all four event topics reach the one `onContractName` callback, so this heals every memoized name; the 30s TTL is now purely the missed-rotation backstop). Corrected the false-invariant comment that caused it + a rotation-flush test.
- 🟡 *Don't widen the protected surface for tests* → exported `RESOLVE_CONTRACT_ADDRESS_MEMO_TTL_MS` and import it directly (dropped the class-static mirror); made `resolveContractAddress` `private` (only caller is `resolveContract`, same class).
- 🟡 *Tests miss the burst concurrency case* → added a 100-wide `Promise.all` single-flight test (one in-flight Hub read for all 100 waiters).
- Tradeoff to note for review: with the Hub rotation poller **disabled** (the `startHubRotationListener` catch path — HTTP-only RPC / log-scan failure), ShardingTableStorage degrades from always-fresh (pre-#1615) to ≤30s stale on a rotation. That 0→≤30s is the PR's core, bounded tradeoff, and the write-side `withHubStaleRetry` still self-heals write paths; the ACK `nodeExists`/`keyHasPurpose` RESULTS remain uncached so revocation/table-exit are caught within one ACK regardless.
- 🟡 *Make memoization opt-in* (raised twice) → **kept opt-out**, backed by a verified caller enumeration: the hot set is exactly `{IdentityStorage, ShardingTableStorage}` (both static literals; every other name is field-cached/boot-bound → resolves ≤once regardless). Opt-in is perf-identical today, buys zero correctness (the unconditional flush heals every memoized name, not just an allowlist), and silently regresses any FUTURE hot-path `resolveContract` with an un-allowlisted per-ACK Hub read. Full per-name policy inversion tracked as a fast-follow.

## Follow-ups (not this PR)
- Opt-in per-name cache/invalidation policy unifying the address memo + `HUB_BINDING_INVALIDATORS` + RS-pair cache.
- Reconcile-debounce for the ~87 `getContextGraphKaCount` head-polls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
