### PR TITLE
fix(publisher): automatically retry transient ACK quorum failures

### DIFF
--- a/packages/publisher/src/async-lift-publish-result.ts
+++ b/packages/publisher/src/async-lift-publish-result.ts
@@ -1,7 +1,9 @@
 import { NO_FUNDED_PUBLISHER_WALLET_CODE, messageIndicatesNoFundedPublisherWallet } from '@origintrail-official/dkg-core';
 import type { PublishResult } from './publisher.js';
+import { isQuorumUnmetError } from './ack-errors.js';
 import {
   createLiftJobFailureMetadata,
+  isTimeoutLiftJobFailure,
   type LiftJobBroadcastMetadata,
   type LiftJobFailureMetadata,
   type LiftJobFinalizationMetadata,
@@ -140,7 +142,11 @@ export function mapPublishExceptionToLiftJobFailure(
     || messageIndicatesNoFundedPublisherWallet(lower);
   const code = isNoFundedWallet && input.failedFromState === 'broadcast'
     ? 'insufficient_funds'
-    : classifyPublishFailureCode(lower, input.failedFromState);
+    : input.failedFromState === 'broadcast' && (
+      isQuorumUnmetError(input.error) || lower.includes('quorumunmeterror')
+    )
+      ? 'quorum_unmet'
+      : classifyPublishFailureCode(lower, input.failedFromState);
 
   return createLiftJobFailureMetadata({
     failedFromState: input.failedFromState,
@@ -150,7 +156,7 @@ export function mapPublishExceptionToLiftJobFailure(
     stackTraceRef: input.stackTraceRef,
     rpcResponseRef: input.rpcResponseRef,
     revertReasonRef: input.revertReasonRef,
-    timeout: input.timeout,
+    timeout: isTimeoutLiftJobFailure(code) ? input.timeout : undefined,
   });
 }
 

--- a/packages/publisher/src/async-lift-publisher-impl.ts
+++ b/packages/publisher/src/async-lift-publisher-impl.ts
@@ -5,6 +5,7 @@ import {
   LIFT_JOB_STATES,
   assertLiftJobTransition,
   createLiftJobFailureMetadata,
+  getLiftJobFailurePolicy,
   type LiftJob,
   type LiftJobAccepted,
   type LiftJobBroadcast,
@@ -81,10 +82,14 @@ export class TripleStoreAsyncLiftPublisher implements AsyncLiftPublisher {
   private static readonly claimQueues = new Map<string, Promise<void>>();
   private static readonly DEFAULT_RECOVERY_LOOKUP_TIMEOUT_MS = 15 * 60 * 1000;
   private static readonly DEFAULT_MAX_RETRIES = 10;
+  private static readonly DEFAULT_RETRY_BACKOFF_BASE_MS = 5_000;
+  private static readonly DEFAULT_RETRY_BACKOFF_MAX_MS = 60_000;
 
   private readonly graphUri: string;
   private readonly walletLockGraphUri: string;
   private readonly maxRetries: number;
+  private readonly retryBackoffBaseMs: number;
+  private readonly retryBackoffMaxMs: number;
   private readonly recoveryLookupTimeoutMs: number;
   private readonly lockLeaseMs: number;
   private readonly now: () => number;
@@ -126,6 +131,14 @@ export class TripleStoreAsyncLiftPublisher implements AsyncLiftPublisher {
     this.graphUri = config.graphUri ?? DEFAULT_GRAPH_URI;
     this.walletLockGraphUri = DEFAULT_WALLET_LOCK_GRAPH_URI;
     this.maxRetries = config.maxRetries ?? TripleStoreAsyncLiftPublisher.DEFAULT_MAX_RETRIES;
+    this.retryBackoffBaseMs = config.retryBackoffBaseMs ?? TripleStoreAsyncLiftPublisher.DEFAULT_RETRY_BACKOFF_BASE_MS;
+    this.retryBackoffMaxMs = config.retryBackoffMaxMs ?? TripleStoreAsyncLiftPublisher.DEFAULT_RETRY_BACKOFF_MAX_MS;
+    if (!Number.isFinite(this.retryBackoffBaseMs) || this.retryBackoffBaseMs <= 0) {
+      throw new Error('Async lift publisher retryBackoffBaseMs must be greater than zero');
+    }
+    if (!Number.isFinite(this.retryBackoffMaxMs) || this.retryBackoffMaxMs < this.retryBackoffBaseMs) {
+      throw new Error('Async lift publisher retryBackoffMaxMs must be at least retryBackoffBaseMs');
+    }
     this.recoveryLookupTimeoutMs = config.recoveryLookupTimeoutMs ?? TripleStoreAsyncLiftPublisher.DEFAULT_RECOVERY_LOOKUP_TIMEOUT_MS;
     this.lockLeaseMs = 5 * 60 * 1000;
     this.now = config.now ?? (() => Date.now());
@@ -243,6 +256,7 @@ export class TripleStoreAsyncLiftPublisher implements AsyncLiftPublisher {
       if (this.paused) return null;
       if (await this.hasActiveWalletLock(walletId)) return null;
 
+      await this.reacceptDueFailedJobs(this.now());
       const next = (await this.list({ status: 'accepted' })).sort(compareAcceptedJobs)[0];
       if (!next) return null;
 
@@ -597,24 +611,7 @@ export class TripleStoreAsyncLiftPublisher implements AsyncLiftPublisher {
     if (!job.failure.retryable || job.retries.retryCount >= job.retries.maxRetries) {
       throw new Error(`Knowledge asset VM publish job ${job.jobId} is not retryable`);
     }
-    const reset = this.resetFailedJobToAccepted(job);
-    const retriedAt = this.now();
-    const reaccepted: LiftJobAccepted = {
-      ...reset,
-      retries: {
-        ...reset.retries,
-        retryCount: job.retries.retryCount + 1,
-        lastRetryReason: job.failure.code,
-      },
-      timestamps: {
-        ...reset.timestamps,
-        lastRetriedAt: retriedAt,
-        updatedAt: retriedAt,
-      },
-    };
-    await this.releaseWalletLockForJob(job);
-    await this.writeJob(reaccepted);
-    return reaccepted;
+    return this.reacceptFailedJob(job);
   }
 
   private isKnowledgeAssetPublishPreconditionFailure(error: unknown): boolean {
@@ -723,9 +720,9 @@ export class TripleStoreAsyncLiftPublisher implements AsyncLiftPublisher {
     await this.ensureGraph();
     const current = await this.getRequiredJob(jobId);
     await this.assertActiveClaimLock(current);
-    const next = this.mergeJob(current, 'failed', {
+    const next = this.scheduleRetryIfEligible(this.mergeJob(current, 'failed', {
       failure: mapPublishExceptionToLiftJobFailure(failure) as any,
-    });
+    }));
     this.assertJobMatchesStatus(next);
     await this.writeJob(next);
     await this.syncWalletLockForJob(next);
@@ -817,23 +814,7 @@ export class TripleStoreAsyncLiftPublisher implements AsyncLiftPublisher {
       // not retry(), to avoid double-publishing if the original tx eventually lands.
       if (job.failure.resolution === 'retry_recovery') continue;
 
-      const reset = this.resetFailedJobToAccepted(job);
-      const retriedAt = this.now();
-      const retriedJob: LiftJobAccepted = {
-        ...reset,
-        retries: {
-          ...reset.retries,
-          retryCount: job.retries.retryCount + 1,
-          lastRetryReason: job.failure.code,
-        },
-        timestamps: {
-          ...reset.timestamps,
-          lastRetriedAt: retriedAt,
-          updatedAt: retriedAt,
-        },
-      };
-      await this.releaseWalletLockForJob(job);
-      await this.writeJob(retriedJob);
+      await this.reacceptFailedJob(job);
       retried += 1;
     }
     return retried;
@@ -1020,7 +1001,9 @@ export class TripleStoreAsyncLiftPublisher implements AsyncLiftPublisher {
         message,
         errorPayloadRef: `urn:dkg:publisher:error:${jobId}`,
       });
-      const failed = this.mergeJob(current, 'failed', { failure: failure as any });
+      const failed = this.scheduleRetryIfEligible(
+        this.mergeJob(current, 'failed', { failure: failure as any }),
+      );
       this.assertJobMatchesStatus(failed);
       await this.writeJob(failed);
       await this.syncWalletLockForJob(failed);
@@ -1286,6 +1269,62 @@ export class TripleStoreAsyncLiftPublisher implements AsyncLiftPublisher {
         : undefined,
       controlPlane: job.controlPlane,
     };
+  }
+
+  private isAutomaticallyRetryable(job: PersistedFailedJob): boolean {
+    return getLiftJobFailurePolicy(job.failure.code).autoRetry === true
+      && job.failure.retryable
+      && job.failure.resolution === 'reset_to_accepted'
+      && job.retries.retryCount < job.retries.maxRetries;
+  }
+
+  private async reacceptDueFailedJobs(now: number): Promise<number> {
+    let retried = 0;
+    for (const job of (await this.list({ status: 'failed' })).filter(isFailedJob)) {
+      if (job.timestamps.nextRetryAt === undefined || job.timestamps.nextRetryAt > now) continue;
+      if (!this.isAutomaticallyRetryable(job)) continue;
+      await this.reacceptFailedJob(job);
+      retried += 1;
+    }
+    return retried;
+  }
+
+  private scheduleRetryIfEligible(job: LiftJob): LiftJob {
+    if (!isFailedJob(job) || !this.isAutomaticallyRetryable(job)) return job;
+    const delay = Math.min(
+      this.retryBackoffMaxMs,
+      this.retryBackoffBaseMs * 2 ** job.retries.retryCount,
+    );
+    const now = this.now();
+    return {
+      ...job,
+      timestamps: {
+        ...job.timestamps,
+        nextRetryAt: now + delay,
+        updatedAt: now,
+      },
+    };
+  }
+
+  private async reacceptFailedJob(job: PersistedFailedJob): Promise<LiftJobAccepted> {
+    const reset = this.resetFailedJobToAccepted(job);
+    const retriedAt = this.now();
+    const reaccepted: LiftJobAccepted = {
+      ...reset,
+      retries: {
+        ...reset.retries,
+        retryCount: job.retries.retryCount + 1,
+        lastRetryReason: job.failure.code,
+      },
+      timestamps: {
+        ...reset.timestamps,
+        lastRetriedAt: retriedAt,
+        updatedAt: retriedAt,
+      },
+    };
+    await this.releaseWalletLockForJob(job);
+    await this.writeJob(reaccepted);
+    return reaccepted;
   }
 
   private finalizeRecoveredJob(

--- a/packages/publisher/src/async-lift-publisher-types.ts
+++ b/packages/publisher/src/async-lift-publisher-types.ts
@@ -89,6 +89,8 @@ export type AsyncLiftPublisherRecoveryResolver = (
 export interface AsyncLiftPublisherConfig {
   graphUri?: string;
   maxRetries?: number;
+  retryBackoffBaseMs?: number;
+  retryBackoffMaxMs?: number;
   recoveryLookupTimeoutMs?: number;
   now?: () => number;
   idGenerator?: () => string;

--- a/packages/publisher/src/lift-job-failures.ts
+++ b/packages/publisher/src/lift-job-failures.ts
@@ -41,6 +41,7 @@ export const LIFT_JOB_FAILURE_CODES = [
   'validation_timeout',
   'wallet_claim_timeout',
   'wallet_unavailable',
+  'quorum_unmet',
   'rpc_unavailable',
   'tx_submit_timeout',
   'tx_reverted',
@@ -69,6 +70,8 @@ export interface LiftJobFailurePolicy {
   readonly mode: LiftJobFailureMode;
   readonly retryable: boolean;
   readonly resolution: LiftJobFailureResolution;
+  /** Safe to re-submit automatically because failure occurs before any transaction can be accepted. */
+  readonly autoRetry?: boolean;
   readonly timeoutHandling?: LiftJobTimeoutHandling;
 }
 
@@ -97,6 +100,7 @@ export const LIFT_JOB_FAILURE_POLICIES: Record<LiftJobFailureCode, LiftJobFailur
   validation_timeout: { code: 'validation_timeout', phase: 'validation', mode: 'timeout', retryable: true, resolution: 'reset_to_accepted', timeoutHandling: 'reset_to_accepted' },
   wallet_claim_timeout: { code: 'wallet_claim_timeout', phase: 'broadcast', mode: 'timeout', retryable: true, resolution: 'reset_to_accepted', timeoutHandling: 'reset_to_accepted' },
   wallet_unavailable: { code: 'wallet_unavailable', phase: 'broadcast', mode: 'retryable', retryable: true, resolution: 'reset_to_accepted' },
+  quorum_unmet: { code: 'quorum_unmet', phase: 'broadcast', mode: 'retryable', retryable: true, resolution: 'reset_to_accepted', autoRetry: true },
   rpc_unavailable: { code: 'rpc_unavailable', phase: 'broadcast', mode: 'retryable', retryable: true, resolution: 'reset_to_accepted' },
   tx_submit_timeout: { code: 'tx_submit_timeout', phase: 'broadcast', mode: 'timeout', retryable: true, resolution: 'check_chain_then_finalize_or_reset', timeoutHandling: 'check_chain_then_finalize_or_reset' },
   tx_reverted: { code: 'tx_reverted', phase: 'broadcast', mode: 'terminal', retryable: false, resolution: 'fail_job' },
@@ -121,6 +125,7 @@ const LIFT_JOB_FAILURE_ALLOWED_STATES: Record<LiftJobFailureCode, readonly LiftJ
   validation_timeout: ['claimed', 'validated'],
   wallet_claim_timeout: ['accepted', 'claimed'],
   wallet_unavailable: ['claimed', 'broadcast'],
+  quorum_unmet: ['broadcast'],
   rpc_unavailable: ['broadcast'],
   tx_submit_timeout: ['broadcast'],
   tx_reverted: ['broadcast'],

--- a/packages/publisher/test/async-lift-publish-result.test.ts
+++ b/packages/publisher/test/async-lift-publish-result.test.ts
@@ -3,6 +3,7 @@ import {
   mapPublishExceptionToLiftJobFailure,
   mapPublishResultToLiftJobSuccess,
 } from '../src/async-lift-publish-result.js';
+import { QuorumUnmetError } from '../src/ack-errors.js';
 
 describe('async lift publish result mapping', () => {
   it('maps tentative canonical publish into included LiftJob state', () => {
@@ -130,6 +131,52 @@ describe('async lift publish result mapping', () => {
       timeoutAt: 123,
       handling: 'check_chain_then_finalize_or_reset',
     });
+  });
+
+  it('classifies typed ACK quorum failures separately from RPC outages', () => {
+    const failure = mapPublishExceptionToLiftJobFailure({
+      error: new QuorumUnmetError({ collected: 2, required: 3, dialled: 2 }),
+      failedFromState: 'broadcast',
+      errorPayloadRef: 'urn:error:quorum-unmet',
+    });
+
+    expect(failure.code).toBe('quorum_unmet');
+    expect(failure.retryable).toBe(true);
+    expect(failure.resolution).toBe('reset_to_accepted');
+  });
+
+  it('recognizes a rewrapped quorum failure from its legacy message', () => {
+    const failure = mapPublishExceptionToLiftJobFailure({
+      error: new Error('QuorumUnmetError(collected=0/3, dialled=0)'),
+      failedFromState: 'broadcast',
+      errorPayloadRef: 'urn:error:rewrapped-quorum-unmet',
+    });
+
+    expect(failure.code).toBe('quorum_unmet');
+    expect(failure.retryable).toBe(true);
+    expect(failure.resolution).toBe('reset_to_accepted');
+  });
+
+  it('drops submit-timeout metadata from a quorum failure with legacy timeout text', () => {
+    const failure = mapPublishExceptionToLiftJobFailure({
+      error: new QuorumUnmetError({
+        collected: 2,
+        required: 3,
+        dialled: 3,
+        legacyMessage: 'storage_ack_timeout: only 2/3 ACKs received',
+      }),
+      failedFromState: 'broadcast',
+      errorPayloadRef: 'urn:error:quorum-timeout',
+      timeout: {
+        timeoutMs: 30_000,
+        timeoutAt: 123,
+        handling: 'check_chain_then_finalize_or_reset',
+      },
+    });
+
+    expect(failure.code).toBe('quorum_unmet');
+    expect(failure.retryable).toBe(true);
+    expect(failure.timeout).toBeUndefined();
   });
 
   it('classifies a NO_FUNDED_PUBLISHER_WALLET error as a TERMINAL insufficient_funds failure (not retryable)', () => {

--- a/packages/publisher/test/async-lift-publisher.test.ts
+++ b/packages/publisher/test/async-lift-publisher.test.ts
@@ -10,6 +10,7 @@ import { makeTestKaAllocator } from './_helpers/ka-allocator.js';
 import { hardhatACKProvider } from './_helpers/acks.js';
 import {
   DKGPublisher,
+  QuorumUnmetError,
   TripleStoreAsyncLiftPublisher,
   createLiftJobFailureMetadata,
   type AsyncLiftPublisherConfig,
@@ -417,6 +418,7 @@ describe('TripleStoreAsyncLiftPublisher', () => {
     expect(failed.status).toBe('failed');
     if (failed.status !== 'failed') throw new Error('expected failed job');
     expect(failed.failure.retryable).toBe(true);
+    expect(failed.timestamps.nextRetryAt).toBeUndefined();
 
     await expect(publisher.enqueueKnowledgeAssetVmPublish(intent)).resolves.toBe(jobId);
     const reaccepted = await publisher.getStatus(jobId);
@@ -428,6 +430,58 @@ describe('TripleStoreAsyncLiftPublisher', () => {
     const claimedAgain = await publisher.claimNext('wallet-2');
     expect(claimedAgain?.jobId).toBe(jobId);
     expect(claimedAgain?.status).toBe('claimed');
+  });
+
+  it('claims due quorum retries with exponential backoff and a durable max cap', async () => {
+    const publisher = createPublisher({
+      config: {
+        retryBackoffBaseMs: 100,
+        retryBackoffMaxMs: 250,
+      },
+    });
+    const jobId = await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
+    await publisher.claimNext('wallet-1');
+    const validation = {
+      canonicalRoots: ['urn:album:one', 'urn:album:two'],
+      canonicalRootMap: {
+        'urn:album:one': 'urn:album:one',
+        'urn:album:two': 'urn:album:two',
+      },
+      swmQuadCount: 2,
+      authorityProofRef: 'urn:dkg:publish-async:share-op-1',
+      transitionType: 'CREATE' as const,
+    };
+    await publisher.update(jobId, 'validated', { validation });
+
+    const failQuorum = () => publisher.recordPublishFailure(jobId, {
+      error: new QuorumUnmetError({ collected: 2, required: 3, dialled: 2 }),
+      failedFromState: 'broadcast',
+      errorPayloadRef: 'urn:dkg:test:error:quorum-unmet',
+    });
+    const failed = await failQuorum();
+    expect(failed.status).toBe('failed');
+    if (failed.status !== 'failed') throw new Error('expected failed job');
+    expect(failed.failure.code).toBe('quorum_unmet');
+    expect((failed.timestamps.nextRetryAt ?? 0) - failed.timestamps.updatedAt).toBe(100);
+
+    expect(await publisher.claimNext('wallet-2')).toBeNull();
+    now += 100;
+    const firstRetry = await publisher.claimNext('wallet-2');
+    expect(firstRetry?.jobId).toBe(jobId);
+    expect(firstRetry?.retries.retryCount).toBe(1);
+    expect(firstRetry?.retries.lastRetryReason).toBe('quorum_unmet');
+    expect(firstRetry?.timestamps.nextRetryAt).toBeUndefined();
+
+    await publisher.update(jobId, 'validated', { validation });
+    const failedAgain = await failQuorum();
+    expect((failedAgain.timestamps.nextRetryAt ?? 0) - failedAgain.timestamps.updatedAt).toBe(200);
+
+    now += 200;
+    const secondRetry = await publisher.claimNext('wallet-3');
+    expect(secondRetry?.retries.retryCount).toBe(2);
+    await publisher.update(jobId, 'validated', { validation });
+    const failedAtCap = await failQuorum();
+    expect((failedAtCap.timestamps.nextRetryAt ?? 0) - failedAtCap.timestamps.updatedAt).toBe(250);
   });
 
   it('processes knowledge asset VM publish jobs through the lifecycle executor', async () => {

--- a/packages/publisher/test/async-lift-runner.test.ts
+++ b/packages/publisher/test/async-lift-runner.test.ts
@@ -61,6 +61,7 @@ describe('AsyncLiftRunner', () => {
     });
 
     await runner.start();
+    await waitFor(() => expect(order).toContain('process'));
     await runner.stop();
 
     expect(order[0]).toBe('recover');


### PR DESCRIPTION
## Summary

- classify typed and rewrapped `QuorumUnmetError` failures as `quorum_unmet` instead of the generic `rpc_unavailable` bucket
- make automatic retry an explicit failure-policy decision and enable it only for pre-transaction ACK quorum failures
- persist `nextRetryAt` with capped exponential backoff (5s to 60s by default) and the existing per-job retry budget
- reconcile due jobs inside `claimNext()` under the existing claim lock, without extending the public publisher API or adding a runner polling clock
- keep ambiguous broadcast/RPC failures manual-only so an accepted transaction is never blindly submitted twice

## Why

The July 12 DKG testnet run reached the publishing target, but transient ACK-pool drops left jobs terminally failed until an operator reran `dkg ka publish`. Two formal-run failures were `QuorumUnmetError` (`2/3` connected core peers); both published successfully when retried. The queue already recorded these failures as retryable and exposed a manual `publisher retry` operation, but did not automatically consume that state.

This PR closes that lifecycle gap without retrying terminal errors, ambiguous transaction submissions, or the existing failed-job backlog.

## Safety

- only the explicit `quorum_unmet` policy has `autoRetry: true`
- quorum collection fails before any publish transaction is submitted
- retry deadlines/counts are durable and retries stop at `maxRetries`
- historical failures without `nextRetryAt` remain untouched
- tx/recovery failures stay on their existing chain-recovery path
- explicit operator retry remains available for manual-only retryable failures

## Verification

- publisher build passes
- focused async publisher/runner/result suites: 65/65 passing
- full publisher unit suite: 275/275 passing
- tests cover typed and string-fallback quorum classification, RPC manual-only behavior, claim-path retry, exponential delays, and the max cap
- `git diff --check`

## Testnet context

Formal run: 100 KAs (50 public, 50 private), 96 strict one-shot successes, 98 VM-finalized by the harness verdict, and 100/100 eventual successes after retrying the remaining quorum failures. This change targets that scored publish-failure class.
