### PR TITLE
fix(storage): isolate managed Oxigraph in a finite memory scope

### DIFF
--- a/docs/use-dkg/storage-sparql-http.md
+++ b/docs/use-dkg/storage-sparql-http.md
@@ -72,7 +72,9 @@ Managed Oxigraph accepts optional launch settings under `store.options`:
       "location": "/var/lib/dkg/oxigraph-data",
       "cacheDir": "/var/lib/dkg/oxigraph-bin",
       "readyTimeoutMs": 180000,
-      "queryTimeoutS": 35
+      "queryTimeoutS": 35,
+      "memoryHighMiB": 2048,
+      "memoryMaxMiB": 3072
     }
   }
 }
@@ -81,6 +83,10 @@ Managed Oxigraph accepts optional launch settings under `store.options`:
 `readyTimeoutMs` is the maximum startup readiness wait in milliseconds. It must be a positive integer; invalid values are ignored and the default 30-second timeout is used. Increase it when a large or recovering RocksDB database needs longer to open.
 
 `queryTimeoutS` is the native Oxigraph query timeout in seconds. The rewritten HTTP store timeout includes an additional five-second grace period so Oxigraph can return its timeout response before the client aborts the request.
+
+On Linux hosts using systemd, `memoryMaxMiB` runs managed Oxigraph in a dedicated transient user scope with a finite hard limit and disables swap for that scope, so database pressure cannot spill into host swap and stall the node. Optional `memoryHighMiB` sets its soft reclaim threshold and must not exceed `memoryMaxMiB`. This keeps Oxigraph outside the DKG daemon service's cgroup, so a finite `MemoryMax` on the daemon cannot kill the store or throttle the Node.js control plane as one combined process group. Enable lingering once for the node service account (`sudo loginctl enable-linger <dkg-user>`) so its user manager and bus exist before the system service starts at boot; verify with `systemctl --user is-system-running` as that account. The daemon supplies the required user-bus environment automatically. Startup fails rather than silently dropping configured limits when the scope cannot be created.
+
+Size the daemon service and Oxigraph scope independently, while keeping their combined maxima within host capacity. For example, an 8 GiB node can reserve 3 GiB for managed Oxigraph and place a separate finite 4 GiB cap on the DKG service, leaving roughly 1 GiB for the OS. These options are deliberately opt-in and are not supported on non-systemd platforms.
 
 ### Other stores
 

--- a/packages/cli/src/daemon/oxigraph-launch-strategy.ts
+++ b/packages/cli/src/daemon/oxigraph-launch-strategy.ts
@@ -1,0 +1,137 @@
+import type { ChildProcess } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import type { CgroupOomSnapshot } from './oxigraph-memory.js';
+import { OXIGRAPH_WATCHDOG_OOM_MARKER } from './oxigraph-parent-watchdog.js';
+
+export interface OxigraphMemoryLimits {
+  highMiB?: number;
+  maxMiB: number;
+}
+
+export interface OxigraphSpawnSpec {
+  command: string;
+  args: string[];
+  environment?: NodeJS.ProcessEnv;
+}
+
+export type ListenOwnerResolver = (
+  child: ChildProcess,
+  port: number,
+  host: string,
+  ownership?: 'child-only' | 'process-tree',
+) => Promise<number | null>;
+
+export interface OxigraphLaunchStrategy {
+  readonly mode: 'direct' | 'systemd-scope';
+  nextSpawnSpec(binaryPath: string, binaryArgs: string[]): OxigraphSpawnSpec;
+  resolveListenerPid(
+    child: ChildProcess,
+    port: number,
+    host: string,
+    resolver: ListenOwnerResolver,
+  ): Promise<number | null>;
+  observeStderr(child: ChildProcess, text: string): void;
+  classifyOomExit(input: {
+    child: ChildProcess;
+    code: number | null;
+    signal: NodeJS.Signals | null;
+    snapshot?: CgroupOomSnapshot;
+    readOomKill: (dir: string) => number | null;
+  }): boolean;
+  logSummary(): string | null;
+}
+
+function cgroupEvidenceIncremented(
+  input: Parameters<OxigraphLaunchStrategy['classifyOomExit']>[0],
+): boolean {
+  const sigkillCompatibleExit = input.signal === 'SIGKILL' || input.code === 137;
+  if (!sigkillCompatibleExit || !input.snapshot) return false;
+  const oomKillNow = input.readOomKill(input.snapshot.dir);
+  return typeof oomKillNow === 'number' && oomKillNow > input.snapshot.oomKill;
+}
+
+export function normalizeOxigraphMemoryLimits(input: {
+  highMiB?: unknown;
+  maxMiB?: unknown;
+}): OxigraphMemoryLimits | undefined {
+  if (input.highMiB === undefined && input.maxMiB === undefined) return undefined;
+  if (typeof input.maxMiB !== 'number' || !Number.isInteger(input.maxMiB) || input.maxMiB <= 0) {
+    throw new Error('Managed Oxigraph memoryMaxMiB must be a positive integer');
+  }
+  if (
+    input.highMiB !== undefined &&
+    (typeof input.highMiB !== 'number' || !Number.isInteger(input.highMiB) || input.highMiB <= 0 || input.highMiB > input.maxMiB)
+  ) {
+    throw new Error('Managed Oxigraph memoryHighMiB must be a positive integer no greater than memoryMaxMiB');
+  }
+  return {
+    maxMiB: input.maxMiB,
+    ...(typeof input.highMiB === 'number' ? { highMiB: input.highMiB } : {}),
+  };
+}
+
+export function createOxigraphLaunchStrategy(opts: {
+  memoryLimits?: OxigraphMemoryLimits;
+  platform: NodeJS.Platform;
+  parentPid: number;
+  uid: number;
+  nodeExecutable?: string;
+  watchdogPath?: string;
+}): OxigraphLaunchStrategy {
+  if (!opts.memoryLimits) {
+    return {
+      mode: 'direct',
+      nextSpawnSpec: (binaryPath, binaryArgs) => ({ command: binaryPath, args: binaryArgs }),
+      resolveListenerPid: (child, port, host, resolver) => resolver(child, port, host, 'child-only'),
+      observeStderr: () => {},
+      classifyOomExit: cgroupEvidenceIncremented,
+      logSummary: () => null,
+    };
+  }
+
+  const limits = normalizeOxigraphMemoryLimits(opts.memoryLimits)!;
+  if (opts.platform !== 'linux') {
+    throw new Error('Managed Oxigraph memory limits require Linux with a running systemd user manager');
+  }
+  if (!Number.isInteger(opts.uid) || opts.uid < 0) {
+    throw new Error('Managed Oxigraph memory limits require a numeric service user id');
+  }
+  const runtimeDir = `/run/user/${opts.uid}`;
+  const watchdogPath = opts.watchdogPath ?? fileURLToPath(new URL('./oxigraph-parent-watchdog.js', import.meta.url));
+  const nodeExecutable = opts.nodeExecutable ?? process.execPath;
+  const watchdogOomChildren = new WeakSet<ChildProcess>();
+  let generation = 0;
+
+  return {
+    mode: 'systemd-scope',
+    nextSpawnSpec(binaryPath, binaryArgs) {
+      generation += 1;
+      const unit = `dkg-oxigraph-${opts.parentPid}-${generation}`;
+      return {
+        command: 'systemd-run',
+        args: [
+          '--user', '--scope', '--collect', '--quiet',
+          `--unit=${unit}`,
+          ...(limits.highMiB === undefined ? [] : [`--property=MemoryHigh=${limits.highMiB}M`]),
+          `--property=MemoryMax=${limits.maxMiB}M`,
+          '--property=MemorySwapMax=0',
+          '--', nodeExecutable, watchdogPath, String(opts.parentPid), binaryPath, ...binaryArgs,
+        ],
+        environment: {
+          XDG_RUNTIME_DIR: runtimeDir,
+          DBUS_SESSION_BUS_ADDRESS: `unix:path=${runtimeDir}/bus`,
+        },
+      };
+    },
+    resolveListenerPid: (child, port, host, resolver) => resolver(child, port, host, 'process-tree'),
+    observeStderr(child, text) {
+      if (text.includes(OXIGRAPH_WATCHDOG_OOM_MARKER)) watchdogOomChildren.add(child);
+    },
+    classifyOomExit(input) {
+      return watchdogOomChildren.has(input.child) || cgroupEvidenceIncremented(input);
+    },
+    logSummary: () =>
+      `Starting Oxigraph in an isolated systemd user scope ` +
+      `(MemoryHigh=${limits.highMiB ?? 'unset'}MiB, MemoryMax=${limits.maxMiB}MiB).`,
+  };
+}

--- a/packages/cli/src/daemon/oxigraph-listen-port.ts
+++ b/packages/cli/src/daemon/oxigraph-listen-port.ts
@@ -3,10 +3,13 @@
  *
  * HTTP 200 on loopback alone is not enough — another local SPARQL service
  * can answer while our `oxigraph serve` child died on EADDRINUSE. We try
- * platform-specific probes in order and require a match on `child.pid`.
+ * platform-specific probes in order and require a match on the child process
+ * tree selected by the caller.
  *
  * `lsof` is preferred on Unix but often missing in minimal Linux/container
  * images; Linux fallbacks use `ss`, `fuser`, then `/proc` inode matching.
+ * Managed memory scopes use a tiny parent watchdog, so callers may explicitly
+ * permit a descendant PID while still rejecting unrelated local listeners.
  */
 import { execFile } from 'node:child_process';
 import { readdir, readFile, readlink } from 'node:fs/promises';
@@ -24,23 +27,25 @@ export function procNetLocalPortHex(port: number): string {
   return port.toString(16).toUpperCase().padStart(4, '0');
 }
 
-async function lsofShowsPidListening(pid: number, port: number): Promise<boolean> {
+async function lsofListenOwnerPid(pids: ReadonlySet<number>, port: number): Promise<number | null> {
   try {
     const { stdout } = await execFileAsync(
       'lsof',
       ['-nP', `-iTCP:${port}`, '-sTCP:LISTEN'],
       { timeout: 2_000 },
     );
-    return stdout.split('\n').some((line) => {
+    for (const line of stdout.split('\n')) {
       const parts = line.trim().split(/\s+/);
-      return parts.length >= 2 && Number(parts[1]) === pid;
-    });
+      const pid = Number(parts[1]);
+      if (parts.length >= 2 && pids.has(pid)) return pid;
+    }
+    return null;
   } catch {
-    return false;
+    return null;
   }
 }
 
-async function ssShowsPidListening(pid: number, port: number): Promise<boolean> {
+async function ssListenOwnerPid(pids: ReadonlySet<number>, port: number): Promise<number | null> {
   try {
     // `-p` is required for the `users:(("proc",pid=N,fd=M))` process column;
     // without it `ss` never emits `pid=` and this probe is dead code. Our own
@@ -52,15 +57,16 @@ async function ssShowsPidListening(pid: number, port: number): Promise<boolean> 
     );
     for (const line of stdout.split('\n')) {
       const m = line.match(/pid=(\d+)/);
-      if (m && Number(m[1]) === pid) return true;
+      const pid = Number(m?.[1]);
+      if (m && pids.has(pid)) return pid;
     }
-    return false;
+    return null;
   } catch {
-    return false;
+    return null;
   }
 }
 
-async function fuserShowsPidOnPort(pid: number, port: number): Promise<boolean> {
+async function fuserListenOwnerPid(pids: ReadonlySet<number>, port: number): Promise<number | null> {
   try {
     const { stdout } = await execFileAsync('fuser', [`${port}/tcp`], {
       timeout: 2_000,
@@ -69,13 +75,14 @@ async function fuserShowsPidOnPort(pid: number, port: number): Promise<boolean> 
       .trim()
       .split(/\s+/)
       .filter(Boolean)
-      .some((tok) => Number(tok) === pid);
+      .map(Number)
+      .find((pid) => pids.has(pid)) ?? null;
   } catch {
-    return false;
+    return null;
   }
 }
 
-async function procfsShowsPidListening(pid: number, port: number): Promise<boolean> {
+async function procfsListenOwnerPid(pids: ReadonlySet<number>, port: number): Promise<number | null> {
   try {
     const portHex = procNetLocalPortHex(port);
     const tcp = await readFile('/proc/net/tcp', 'utf8');
@@ -92,26 +99,56 @@ async function procfsShowsPidListening(pid: number, port: number): Promise<boole
         break;
       }
     }
-    if (!listenInode) return false;
+    if (!listenInode) return null;
 
-    const fdDir = `/proc/${pid}/fd`;
-    const fds = await readdir(fdDir);
     const socketNeedle = `socket:[${listenInode}]`;
-    for (const fd of fds) {
+    for (const pid of pids) {
       try {
-        const target = await readlink(`${fdDir}/${fd}`);
-        if (target.includes(socketNeedle)) return true;
+        const fdDir = `/proc/${pid}/fd`;
+        const fds = await readdir(fdDir);
+        for (const fd of fds) {
+          try {
+            const target = await readlink(`${fdDir}/${fd}`);
+            if (target.includes(socketNeedle)) return pid;
+          } catch {
+            continue;
+          }
+        }
       } catch {
         continue;
       }
     }
-    return false;
+    return null;
   } catch {
-    return false;
+    return null;
   }
 }
 
-async function windowsChildOwnsPort(pid: number, port: number): Promise<boolean> {
+async function linuxProcessTree(rootPid: number): Promise<Set<number>> {
+  const pids = new Set<number>([rootPid]);
+  const pending = [rootPid];
+  while (pending.length > 0) {
+    const pid = pending.pop()!;
+    try {
+      const children = (await readFile(`/proc/${pid}/task/${pid}/children`, 'utf8'))
+        .trim()
+        .split(/\s+/)
+        .filter(Boolean)
+        .map(Number)
+        .filter((value) => Number.isInteger(value) && value > 0);
+      for (const childPid of children) {
+        if (pids.has(childPid)) continue;
+        pids.add(childPid);
+        pending.push(childPid);
+      }
+    } catch {
+      continue;
+    }
+  }
+  return pids;
+}
+
+async function windowsListenOwnerPid(pid: number, port: number): Promise<number | null> {
   try {
     const { stdout } = await execFileAsync('netstat', ['-ano'], { timeout: 3_000 });
     const suffix = `:${port}`;
@@ -119,41 +156,59 @@ async function windowsChildOwnsPort(pid: number, port: number): Promise<boolean>
       if (!line.includes('LISTENING') || !line.includes(suffix)) continue;
       const parts = line.trim().split(/\s+/);
       const rowPid = Number(parts[parts.length - 1]);
-      if (rowPid === pid) return true;
+      if (rowPid === pid) return pid;
     }
-    return false;
+    return null;
   } catch {
-    return false;
+    return null;
   }
 }
 
 /**
- * Return true when `child` is alive and owns the TCP listener on `port`.
+ * Return the PID when `child` (or, when explicitly enabled, one of its Linux
+ * descendants) is alive and owns the TCP listener on `port`.
  * For non-loopback hosts we only require the child to be alive (tests).
  */
+export async function findListenOwnerPid(
+  child: ChildProcess,
+  port: number,
+  host: string,
+  ownership: 'child-only' | 'process-tree' = 'child-only',
+): Promise<number | null> {
+  if (!child.pid || child.exitCode !== null || child.signalCode !== null) {
+    return null;
+  }
+  if (host !== '127.0.0.1' && host !== 'localhost') return child.pid;
+
+  const pid = child.pid;
+  const pids = ownership === 'process-tree' && process.platform === 'linux'
+    ? await linuxProcessTree(pid)
+    : new Set([pid]);
+
+  if (process.platform === 'win32') {
+    return windowsListenOwnerPid(pid, port);
+  }
+
+  const lsofOwner = await lsofListenOwnerPid(pids, port);
+  if (lsofOwner !== null) return lsofOwner;
+
+  if (process.platform === 'linux') {
+    const ssOwner = await ssListenOwnerPid(pids, port);
+    if (ssOwner !== null) return ssOwner;
+    const fuserOwner = await fuserListenOwnerPid(pids, port);
+    if (fuserOwner !== null) return fuserOwner;
+    const procfsOwner = await procfsListenOwnerPid(pids, port);
+    if (procfsOwner !== null) return procfsOwner;
+  }
+
+  return null;
+}
+
 export async function childOwnsListenPort(
   child: ChildProcess,
   port: number,
   host: string,
+  ownership: 'child-only' | 'process-tree' = 'child-only',
 ): Promise<boolean> {
-  if (!child.pid || child.exitCode !== null || child.signalCode !== null) {
-    return false;
-  }
-  if (host !== '127.0.0.1' && host !== 'localhost') return true;
-
-  const pid = child.pid;
-
-  if (process.platform === 'win32') {
-    return windowsChildOwnsPort(pid, port);
-  }
-
-  if (await lsofShowsPidListening(pid, port)) return true;
-
-  if (process.platform === 'linux') {
-    if (await ssShowsPidListening(pid, port)) return true;
-    if (await fuserShowsPidOnPort(pid, port)) return true;
-    if (await procfsShowsPidListening(pid, port)) return true;
-  }
-
-  return false;
+  return (await findListenOwnerPid(child, port, host, ownership)) !== null;
 }

--- a/packages/cli/src/daemon/oxigraph-managed.ts
+++ b/packages/cli/src/daemon/oxigraph-managed.ts
@@ -29,6 +29,10 @@ import {
   type OxigraphServerHandle,
   type OxigraphServerIo,
 } from './oxigraph-server.js';
+import {
+  normalizeOxigraphMemoryLimits,
+  type OxigraphMemoryLimits,
+} from './oxigraph-launch-strategy.js';
 
 /** Config value that opts a node into the daemon-managed local server. */
 export const MANAGED_OXIGRAPH_BACKEND = 'oxigraph-server';
@@ -119,6 +123,8 @@ export interface ManagedOxigraphPlan {
   readyTimeoutMs?: number;
   /** Native Oxigraph query timeout, passed as `oxigraph serve --timeout-s`. */
   queryTimeoutS?: number;
+  /** Finite limits applied to an isolated systemd user scope. */
+  memoryLimits?: OxigraphMemoryLimits;
   /**
    * sharedMemoryPublicSnapshotStorage with a defaulted `directory`, set
    * only when the operator enabled it. Same rewrite hazard as
@@ -144,6 +150,10 @@ export function planManagedOxigraph(
   const port = resolveManagedOxigraphPort(options);
   const readyTimeoutMs = resolvePositiveIntegerOption(options, 'readyTimeoutMs');
   const queryTimeoutS = resolvePositiveIntegerOption(options, 'queryTimeoutS');
+  const memoryLimits = normalizeOxigraphMemoryLimits({
+    highMiB: options.memoryHighMiB,
+    maxMiB: options.memoryMaxMiB,
+  });
   const location =
     typeof options.location === 'string' && options.location.trim()
       ? options.location
@@ -198,6 +208,7 @@ export function planManagedOxigraph(
     largeLiteralStorage,
     readyTimeoutMs,
     queryTimeoutS,
+    memoryLimits,
     sharedMemoryPublicSnapshotStorage,
   };
 }
@@ -255,6 +266,8 @@ export async function startManagedOxigraph(
     log,
     readyTimeoutMs: opts.readyTimeoutMs ?? plan.readyTimeoutMs,
     queryTimeoutS: plan.queryTimeoutS,
+    memoryLimits: plan.memoryLimits,
+    platform: opts.platform,
     io: opts.serverIo,
   });
 

--- a/packages/cli/src/daemon/oxigraph-memory.ts
+++ b/packages/cli/src/daemon/oxigraph-memory.ts
@@ -9,8 +9,10 @@ import { readFileSync } from 'node:fs';
  * restart log, never for control flow.
  *
  * The supervisor captures a snapshot (cgroup dir + `oom_kill` count) while the
- * child is alive, then re-reads `oom_kill` from that dir when the child exits
- * (the dir persists after the pid is gone). An increase means the kernel
+ * child is alive, then best-effort re-reads `oom_kill` when the child exits.
+ * A dedicated scope may disappear as soon as its final process exits, so the
+ * scoped watchdog performs the same comparison while it is still resident.
+ * An increase means the kernel
  * cgroup-OOM-killed oxigraph — typically the operator's unit-level `MemoryMax`
  * cap engaging (the 2026-07 beacon remediation), or a host OOM — which the
  * supervisor surfaces so operators can tell it apart from a plain crash without
@@ -18,7 +20,7 @@ import { readFileSync } from 'node:fs';
  */
 
 export interface CgroupOomSnapshot {
-  /** Absolute cgroup dir under /sys/fs/cgroup. Persists after the pid exits. */
+  /** Absolute cgroup dir under /sys/fs/cgroup. */
   dir: string;
   /** `memory.events` oom_kill count at capture time. */
   oomKill: number;
@@ -54,8 +56,8 @@ export function readCgroupOomSnapshot(
 }
 
 /**
- * Exit-time re-read of `oom_kill` from a captured cgroup dir. Used after the
- * pid is gone (the dir outlives it). Returns null on non-Linux / read failure.
+ * Exit-time re-read of `oom_kill` from a captured cgroup dir. Returns null on
+ * non-Linux, read failure, or when systemd already removed an empty scope.
  */
 export function readCgroupOomKill(dir: string, io: MemoryReaderIo = defaultIo): number | null {
   if (io.platform !== 'linux' || !dir) return null;

--- a/packages/cli/src/daemon/oxigraph-parent-watchdog.ts
+++ b/packages/cli/src/daemon/oxigraph-parent-watchdog.ts
@@ -1,0 +1,161 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
+import { constants as osConstants } from 'node:os';
+import {
+  readCgroupOomKill,
+  readCgroupOomSnapshot,
+  type CgroupOomSnapshot,
+} from './oxigraph-memory.js';
+
+export const OXIGRAPH_WATCHDOG_OOM_MARKER =
+  '[oxigraph-watchdog] scoped child OOM-killed by cgroup memory cap (or host OOM)';
+
+export interface OxigraphParentWatchdogOptions {
+  parentPid: number;
+  command: string;
+  args: readonly string[];
+  pollIntervalMs?: number;
+  spawnChild?: typeof spawn;
+  isProcessAlive?: (pid: number) => boolean;
+  readOomSnapshot?: (pid: number) => CgroupOomSnapshot | null;
+  readOomKill?: (dir: string) => number | null;
+}
+
+export interface OxigraphParentWatchdogResult {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  parentLost: boolean;
+  oomKilled: boolean;
+}
+
+export interface OxigraphParentWatchdogHandle {
+  child: ChildProcess;
+  result: Promise<OxigraphParentWatchdogResult>;
+  stop(signal?: NodeJS.Signals): void;
+}
+
+function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Keep Oxigraph tied to the DKG daemon even though systemd places it in a
+ * sibling cgroup. The typed watchdog forwards shutdown signals and terminates
+ * Oxigraph within one poll interval if the original daemon PID disappears.
+ */
+export function startOxigraphParentWatchdog(
+  opts: OxigraphParentWatchdogOptions,
+): OxigraphParentWatchdogHandle {
+  if (!Number.isInteger(opts.parentPid) || opts.parentPid <= 0) {
+    throw new Error('Oxigraph parent watchdog requires a positive parent PID');
+  }
+  if (!opts.command) throw new Error('Oxigraph parent watchdog requires a command');
+
+  const spawnChild = opts.spawnChild ?? spawn;
+  const isProcessAlive = opts.isProcessAlive ?? processIsAlive;
+  const readOomSnapshot = opts.readOomSnapshot ?? readCgroupOomSnapshot;
+  const readOomKill = opts.readOomKill ?? readCgroupOomKill;
+  const pollIntervalMs = opts.pollIntervalMs ?? 1_000;
+  const child = spawnChild(opts.command, [...opts.args], { stdio: 'inherit' });
+  // The watchdog already runs inside the transient scope, so it can retain a
+  // valid baseline and re-read memory.events while the scope still contains
+  // this process. The parent supervisor cannot reliably do that after exit:
+  // systemd may remove the empty cgroup before its ChildProcess callback runs.
+  const oomSnapshot = readOomSnapshot(process.pid);
+  let parentLost = false;
+  let stopping = false;
+
+  const timer = setInterval(() => {
+    if (stopping || isProcessAlive(opts.parentPid)) return;
+    parentLost = true;
+    stopping = true;
+    child.kill('SIGTERM');
+  }, pollIntervalMs);
+  timer.unref?.();
+
+  const result = new Promise<OxigraphParentWatchdogResult>((resolveResult, reject) => {
+    child.once('error', reject);
+    child.once('exit', (code, signal) => {
+      clearInterval(timer);
+      const sigkillCompatibleExit = signal === 'SIGKILL' || code === 137;
+      const oomKillNow = oomSnapshot ? readOomKill(oomSnapshot.dir) : null;
+      const oomKilled = sigkillCompatibleExit
+        && typeof oomKillNow === 'number'
+        && oomKillNow > oomSnapshot!.oomKill;
+      resolveResult({ code, signal, parentLost, oomKilled });
+    });
+  });
+
+  return {
+    child,
+    result,
+    stop(signal: NodeJS.Signals = 'SIGTERM') {
+      if (stopping) return;
+      stopping = true;
+      child.kill(signal);
+    },
+  };
+}
+
+export function parseOxigraphParentWatchdogArgs(argv: readonly string[]): {
+  parentPid: number;
+  command: string;
+  args: string[];
+} {
+  const [rawParentPid, command, ...args] = argv;
+  const parentPid = Number(rawParentPid);
+  if (!Number.isInteger(parentPid) || parentPid <= 0 || !command) {
+    throw new Error('Usage: oxigraph-parent-watchdog <parent-pid> <command> [args...]');
+  }
+  return { parentPid, command, args };
+}
+
+export function conventionalSignalExitCode(signal: NodeJS.Signals): number {
+  const signalNumber = osConstants.signals[signal];
+  return 128 + (typeof signalNumber === 'number' ? signalNumber : 1);
+}
+
+async function main(): Promise<void> {
+  const parsed = parseOxigraphParentWatchdogArgs(process.argv.slice(2));
+  const handle = startOxigraphParentWatchdog(parsed);
+  let forwardedSignal: NodeJS.Signals | null = null;
+  for (const signal of ['SIGTERM', 'SIGINT', 'SIGHUP'] as const) {
+    process.once(signal, () => {
+      forwardedSignal = signal;
+      handle.stop(signal);
+    });
+  }
+
+  const result = await handle.result;
+  if (result.oomKilled) {
+    process.stderr.write(`${OXIGRAPH_WATCHDOG_OOM_MARKER}\n`);
+    process.exitCode = 200;
+    return;
+  }
+  if (forwardedSignal || result.parentLost) {
+    process.exitCode = 0;
+    return;
+  }
+  if (result.signal) {
+    // Re-raising SIGTERM/SIGINT/SIGHUP would hit the forwarding listeners
+    // installed above and could turn an unexpected child death into exit 0.
+    // Preserve signal semantics explicitly without re-entering those handlers.
+    process.exitCode = conventionalSignalExitCode(result.signal);
+    return;
+  }
+  process.exitCode = result.code ?? 1;
+}
+
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : '';
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  void main().catch((error) => {
+    process.stderr.write(`[oxigraph-watchdog] ${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/packages/cli/src/daemon/oxigraph-server.ts
+++ b/packages/cli/src/daemon/oxigraph-server.ts
@@ -37,7 +37,11 @@
  * crash-restart, and shutdown without launching a real binary.
  */
 import { spawn, type ChildProcess } from 'node:child_process';
-import { childOwnsListenPort } from './oxigraph-listen-port.js';
+import { findListenOwnerPid } from './oxigraph-listen-port.js';
+import {
+  createOxigraphLaunchStrategy,
+  type OxigraphMemoryLimits,
+} from './oxigraph-launch-strategy.js';
 import { invalidateExternalStoreQuadsCache } from './routes/status.js';
 import {
   readCgroupOomSnapshot,
@@ -49,14 +53,15 @@ export interface OxigraphServerIo {
   spawn: typeof spawn;
   fetch: typeof globalThis.fetch;
   /**
-   * Verify the spawned child owns the listen socket (not merely that
-   * something on the port returns HTTP 200). Tests inject `async () => true`.
+   * Resolve the child/descendant PID that owns the listen socket (not merely
+   * that something on the port returns HTTP 200).
    */
-  childOwnsListenPort: (
+  findListenOwnerPid: (
     child: ChildProcess,
     port: number,
     host: string,
-  ) => Promise<boolean>;
+    ownership?: 'child-only' | 'process-tree',
+  ) => Promise<number | null>;
   /** Best-effort cgroup OOM snapshot (dir + oom_kill) for a live pid. Injectable for tests. */
   readCgroupOomSnapshot: (pid: number) => CgroupOomSnapshot | null;
   /** Best-effort exit-time re-read of oom_kill from a captured cgroup dir. */
@@ -85,6 +90,10 @@ export interface StartOxigraphServerOptions {
   restartBackoffBaseMs?: number;
   /** Cap for restart backoff. */
   restartBackoffMaxMs?: number;
+  /** Optional finite limits for an isolated systemd user scope (Linux only). */
+  memoryLimits?: OxigraphMemoryLimits;
+  /** Runtime platform. Injectable so command construction is portable in tests. */
+  platform?: NodeJS.Platform;
   io?: Partial<OxigraphServerIo>;
 }
 
@@ -128,11 +137,17 @@ function normalizePositiveInteger(value: number | undefined): number | undefined
 export async function startOxigraphServer(
   opts: StartOxigraphServerOptions,
 ): Promise<OxigraphServerHandle> {
+  const launchStrategy = createOxigraphLaunchStrategy({
+    memoryLimits: opts.memoryLimits,
+    platform: opts.platform ?? process.platform,
+    parentPid: process.pid,
+    uid: typeof process.getuid === 'function' ? process.getuid() : -1,
+  });
   const ioOverrides = opts.io ?? {};
   const io: OxigraphServerIo = {
     spawn: ioOverrides.spawn ?? spawn,
     fetch: ioOverrides.fetch ?? globalThis.fetch,
-    childOwnsListenPort: ioOverrides.childOwnsListenPort ?? childOwnsListenPort,
+    findListenOwnerPid: ioOverrides.findListenOwnerPid ?? findListenOwnerPid,
     readCgroupOomSnapshot: ioOverrides.readCgroupOomSnapshot ?? readCgroupOomSnapshot,
     readCgroupOomKill: ioOverrides.readCgroupOomKill ?? readCgroupOomKill,
   };
@@ -165,21 +180,22 @@ export async function startOxigraphServer(
   // childAlive() wrongly report it alive. Track them so childAlive() and the
   // ready/revive loops treat a spawn error as a dead child.
   const erroredChildren = new WeakSet<ChildProcess>();
+  const oomSnapshots = new WeakMap<ChildProcess, CgroupOomSnapshot>();
 
   const spawnChild = (): ChildProcess => {
     const args = ['serve', '--location', opts.location, '--bind', bind];
     if (queryTimeoutS !== undefined) args.push('--timeout-s', String(queryTimeoutS));
+    const spawnSpec = launchStrategy.nextSpawnSpec(opts.binaryPath, args);
     const c = io.spawn(
-      opts.binaryPath,
-      args,
-      { stdio: ['ignore', 'pipe', 'pipe'] },
+      spawnSpec.command,
+      spawnSpec.args,
+      {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        ...(spawnSpec.environment
+          ? { env: { ...process.env, ...spawnSpec.environment } }
+          : {}),
+      },
     );
-    // Capture THIS child's cgroup OOM baseline while it's alive, closed over by
-    // its own exit handler below — so each child classifies against its own
-    // snapshot with no shared mutable lifecycle state. Best-effort; null
-    // off-Linux / uncapped.
-    const oomSnapshot: CgroupOomSnapshot | null =
-      typeof c.pid === 'number' ? io.readCgroupOomSnapshot(c.pid) : null;
     // Without this listener Node throws the `error` event as an uncaught
     // exception, killing the daemon. Route it through the normal
     // startup/revive failure path instead (the binary couldn't be executed).
@@ -191,6 +207,7 @@ export async function startOxigraphServer(
     c.stderr?.on('data', (b) => {
       const line = b.toString('utf-8').trim();
       if (line) {
+        launchStrategy.observeStderr(c, line);
         lastStderr = `${lastStderr}${line}\n`.slice(-1_000);
         log(`[oxigraph] ${line}`);
       }
@@ -218,11 +235,15 @@ export async function startOxigraphServer(
       // SIGKILL-compatible child death. This catches MemoryMax/host OOM kills
       // without labelling unrelated non-SIGKILL exits as OOM.
       let oomNote = '';
-      if (oomSnapshot && signal === 'SIGKILL') {
-        const oomKillNow = io.readCgroupOomKill(oomSnapshot.dir);
-        if (typeof oomKillNow === 'number' && oomKillNow > oomSnapshot.oomKill) {
-          oomNote = ', OOM-killed by cgroup memory cap (or host OOM)';
-        }
+      const oomSnapshot = oomSnapshots.get(c);
+      if (launchStrategy.classifyOomExit({
+        child: c,
+        code,
+        signal,
+        snapshot: oomSnapshot,
+        readOomKill: io.readCgroupOomKill,
+      })) {
+        oomNote = ', OOM-killed by cgroup memory cap (or host OOM)';
       }
       scheduleRevive(
         `server exited unexpectedly (code=${code ?? 'null'}, signal=${signal ?? 'null'}${oomNote})`,
@@ -237,9 +258,15 @@ export async function startOxigraphServer(
     child.exitCode === null &&
     child.signalCode === null;
 
-  const probeReady = async (): Promise<boolean> => {
+  const captureOomSnapshotForListener = (c: ChildProcess, listenerPid: number): void => {
+    if (oomSnapshots.has(c)) return;
+    const snapshot = io.readCgroupOomSnapshot(listenerPid);
+    if (snapshot) oomSnapshots.set(c, snapshot);
+  };
+
+  const probeReady = async (): Promise<number | null> => {
     const c = child;
-    if (!c || !childAlive()) return false;
+    if (!c || !childAlive()) return null;
     try {
       const res = await io.fetch(queryEndpoint, {
         method: 'POST',
@@ -250,11 +277,16 @@ export async function startOxigraphServer(
         body: 'ASK { ?s ?p ?o }',
         signal: AbortSignal.timeout(readyIntervalMs + 1_000),
       });
-      if (!res.ok) return false;
-      const ownsPort = await io.childOwnsListenPort(c, port, host);
-      return ownsPort && childAlive();
+      if (!res.ok) return null;
+      const listenerPid = await launchStrategy.resolveListenerPid(
+        c,
+        port,
+        host,
+        io.findListenOwnerPid,
+      );
+      return listenerPid !== null && childAlive() ? listenerPid : null;
     } catch {
-      return false;
+      return null;
     }
   };
 
@@ -288,7 +320,9 @@ export async function startOxigraphServer(
       // because `ready` is false). Retry with backoff; never adopt whatever
       // may now be answering on the port.
       if (!childAlive()) break;
-      if ((await probeReady()) && childAlive()) {
+      const listenerPid = await probeReady();
+      if (listenerPid !== null && childAlive()) {
+        captureOomSnapshotForListener(child!, listenerPid);
         ready = true;
         restarts = 0;
         log(`[oxigraph] server restarted and healthy on ${bind}.`);
@@ -357,6 +391,8 @@ export async function startOxigraphServer(
       ? `Starting Oxigraph server on ${bind} (location: ${opts.location}, query timeout: ${queryTimeoutS}s)…`
       : `Starting Oxigraph server on ${bind} (location: ${opts.location})…`,
   );
+  const launchSummary = launchStrategy.logSummary();
+  if (launchSummary) log(launchSummary);
   child = spawnChild();
 
   const deadline = Date.now() + readyTimeoutMs;
@@ -371,11 +407,13 @@ export async function startOxigraphServer(
       childDied = true;
       break;
     }
-    if (await probeReady()) {
+    const listenerPid = await probeReady();
+    if (listenerPid !== null) {
       // Only trust a 200 if the child WE spawned is the one still alive
       // and bound — guards the race where a foreign server answers while
       // our child has just died on EADDRINUSE.
       if (childAlive()) {
+        captureOomSnapshotForListener(child!, listenerPid);
         ready = true;
         log(`Oxigraph server ready on ${bind} after ${attempt} probe(s).`);
         return { host, port, queryEndpoint, updateEndpoint, stop, killSync };

--- a/packages/cli/test/oxigraph-managed.test.ts
+++ b/packages/cli/test/oxigraph-managed.test.ts
@@ -138,6 +138,41 @@ describe('planManagedOxigraph', () => {
     expect(plan!.storeConfigTemplate.options.timeout).toBe(40_000);
   });
 
+  it('plans finite managed Oxigraph memory limits independently of the daemon service', () => {
+    const plan = planManagedOxigraph(
+      {
+        store: {
+          backend: MANAGED_OXIGRAPH_BACKEND,
+          options: { memoryHighMiB: 2048, memoryMaxMiB: 3072 },
+        },
+      },
+      '/data',
+    );
+    expect(plan!.memoryLimits).toEqual({ highMiB: 2048, maxMiB: 3072 });
+  });
+
+  it('rejects unsafe or incomplete managed Oxigraph memory limits', () => {
+    expect(() => planManagedOxigraph(
+      {
+        store: {
+          backend: MANAGED_OXIGRAPH_BACKEND,
+          options: { memoryHighMiB: 2048 },
+        },
+      },
+      '/data',
+    )).toThrow(/memoryMaxMiB/);
+
+    expect(() => planManagedOxigraph(
+      {
+        store: {
+          backend: MANAGED_OXIGRAPH_BACKEND,
+          options: { memoryHighMiB: 4096, memoryMaxMiB: 3072 },
+        },
+      },
+      '/data',
+    )).toThrow(/no greater than memoryMaxMiB/);
+  });
+
   it('clamps an absurd queryTimeoutS to Node’s max timer instead of overflowing to an instant abort', () => {
     const plan = planManagedOxigraph(
       {

--- a/packages/cli/test/oxigraph-parent-watchdog.test.ts
+++ b/packages/cli/test/oxigraph-parent-watchdog.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import {
+  conventionalSignalExitCode,
+  parseOxigraphParentWatchdogArgs,
+  startOxigraphParentWatchdog,
+} from '../src/daemon/oxigraph-parent-watchdog.js';
+
+describe('Oxigraph parent watchdog', () => {
+  it('parses a typed parent/command boundary', () => {
+    expect(parseOxigraphParentWatchdogArgs(['42', '/opt/oxigraph', 'serve']))
+      .toEqual({ parentPid: 42, command: '/opt/oxigraph', args: ['serve'] });
+    expect(() => parseOxigraphParentWatchdogArgs(['nope', '/opt/oxigraph']))
+      .toThrow(/Usage/);
+  });
+
+  it('maps an unforwarded catchable child signal to a non-zero wrapper exit', () => {
+    expect(conventionalSignalExitCode('SIGTERM')).toBe(143);
+    expect(conventionalSignalExitCode('SIGINT')).toBe(130);
+  });
+
+  it('terminates the child when the daemon parent disappears', async () => {
+    const handle = startOxigraphParentWatchdog({
+      parentPid: 42,
+      command: process.execPath,
+      args: ['-e', 'setInterval(() => {}, 1000)'],
+      pollIntervalMs: 5,
+      isProcessAlive: () => false,
+    });
+
+    const result = await handle.result;
+    expect(result.parentLost).toBe(true);
+    expect(result.signal).toBe('SIGTERM');
+    expect(result.oomKilled).toBe(false);
+  });
+
+  it('forwards an explicit shutdown signal to the child', async () => {
+    const handle = startOxigraphParentWatchdog({
+      parentPid: process.pid,
+      command: process.execPath,
+      args: ['-e', 'setInterval(() => {}, 1000)'],
+      pollIntervalMs: 5,
+    });
+    handle.stop('SIGTERM');
+
+    const result = await handle.result;
+    expect(result.parentLost).toBe(false);
+    expect(result.signal).toBe('SIGTERM');
+    expect(result.oomKilled).toBe(false);
+  });
+
+  it('reports an externally SIGTERM-killed child as a non-zero wrapper exit', async () => {
+    const handle = startOxigraphParentWatchdog({
+      parentPid: process.pid,
+      command: process.execPath,
+      args: ['-e', 'setInterval(() => {}, 1000)'],
+      pollIntervalMs: 5,
+    });
+    handle.child.kill('SIGTERM');
+
+    const result = await handle.result;
+    expect(result.parentLost).toBe(false);
+    expect(result.signal).toBe('SIGTERM');
+    expect(conventionalSignalExitCode(result.signal!)).toBe(143);
+  });
+
+  it('captures scoped OOM evidence before the watchdog cgroup can disappear', async () => {
+    const handle = startOxigraphParentWatchdog({
+      parentPid: process.pid,
+      command: process.execPath,
+      args: ['-e', 'setInterval(() => {}, 1000)'],
+      pollIntervalMs: 5,
+      readOomSnapshot: () => ({ dir: '/sys/fs/cgroup/dkg-oxi', oomKill: 4 }),
+      readOomKill: () => 5,
+    });
+    handle.child.kill('SIGKILL');
+
+    const result = await handle.result;
+    expect(result.signal).toBe('SIGKILL');
+    expect(result.oomKilled).toBe(true);
+  });
+});

--- a/packages/cli/test/oxigraph-server.test.ts
+++ b/packages/cli/test/oxigraph-server.test.ts
@@ -21,9 +21,16 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { mkdtemp, rm, writeFile, chmod } from 'node:fs/promises';
 import { createServer, type Server } from 'node:net';
+import { spawn } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { startOxigraphServer } from '../src/daemon/oxigraph-server.js';
+import { createOxigraphLaunchStrategy } from '../src/daemon/oxigraph-launch-strategy.js';
+import { OXIGRAPH_WATCHDOG_OOM_MARKER } from '../src/daemon/oxigraph-parent-watchdog.js';
+import {
+  childOwnsListenPort,
+  findListenOwnerPid,
+} from '../src/daemon/oxigraph-listen-port.js';
 
 const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 
@@ -116,7 +123,132 @@ function startOpts(port: number, extra: Record<string, unknown> = {}) {
   };
 }
 
+describe('buildOxigraphSpawnSpec', () => {
+  it('launches the binary directly when memory isolation is not configured', () => {
+    const strategy = createOxigraphLaunchStrategy({
+      platform: 'linux',
+      parentPid: 42,
+      uid: 1000,
+    });
+    expect(strategy.nextSpawnSpec('/opt/oxigraph', ['serve']))
+      .toEqual({ command: '/opt/oxigraph', args: ['serve'] });
+  });
+
+  it('wraps Oxigraph in a finite systemd user scope', () => {
+    const strategy = createOxigraphLaunchStrategy({
+      memoryLimits: { highMiB: 2048, maxMiB: 3072 },
+      platform: 'linux',
+      parentPid: 42,
+      uid: 1000,
+      nodeExecutable: '/opt/node',
+      watchdogPath: '/opt/oxigraph-watchdog.js',
+    });
+    strategy.nextSpawnSpec('/opt/oxigraph', ['serve']);
+    strategy.nextSpawnSpec('/opt/oxigraph', ['serve']);
+    const spec = strategy.nextSpawnSpec(
+      '/opt/oxigraph',
+      ['serve', '--bind', '127.0.0.1:7878'],
+    );
+
+    expect(spec.command).toBe('systemd-run');
+    expect(spec.environment).toEqual({
+      XDG_RUNTIME_DIR: '/run/user/1000',
+      DBUS_SESSION_BUS_ADDRESS: 'unix:path=/run/user/1000/bus',
+    });
+    expect(spec.args.slice(0, 8)).toEqual([
+      '--user', '--scope', '--collect', '--quiet',
+      '--unit=dkg-oxigraph-42-3',
+      '--property=MemoryHigh=2048M',
+      '--property=MemoryMax=3072M',
+      '--property=MemorySwapMax=0',
+    ]);
+    expect(spec.args.slice(-7)).toEqual([
+      '/opt/node', '/opt/oxigraph-watchdog.js', '42',
+      '/opt/oxigraph', 'serve', '--bind', '127.0.0.1:7878',
+    ]);
+  });
+
+  it('fails closed when finite scope limits cannot be enforced', () => {
+    expect(() => createOxigraphLaunchStrategy({
+      memoryLimits: { maxMiB: 3072 },
+      platform: 'darwin',
+      parentPid: 42,
+      uid: 1000,
+    })).toThrow(/require Linux/);
+  });
+});
+
 describe('startOxigraphServer (real child processes)', () => {
+  it('threads memory limits through systemd launch, descendant readiness, and listener cgroup sampling', async () => {
+    const port = await freePort();
+    let launchedCommand = '';
+    let launchedArgs: readonly string[] = [];
+    let launchedEnv: NodeJS.ProcessEnv | undefined;
+    let ownershipPolicy: 'child-only' | 'process-tree' | undefined;
+    const snapshotPids: number[] = [];
+    const resolvedListenerPid = 424_242;
+
+    const injectedSpawn = ((command: string, args: readonly string[], options: Parameters<typeof spawn>[2]) => {
+      launchedCommand = command;
+      launchedArgs = args;
+      launchedEnv = options?.env;
+      const binaryIndex = args.indexOf(standin);
+      expect(binaryIndex).toBeGreaterThan(0);
+      return spawn(standin, args.slice(binaryIndex + 1), options);
+    }) as typeof spawn;
+
+    const handle = await startOxigraphServer(startOpts(port, {
+      memoryLimits: { highMiB: 128, maxMiB: 256 },
+      platform: 'linux',
+      io: {
+        spawn: injectedSpawn,
+        findListenOwnerPid: async (child: import('node:child_process').ChildProcess, _port: number, _host: string, ownership?: 'child-only' | 'process-tree') => {
+          ownershipPolicy = ownership;
+          expect(child.pid).toBeDefined();
+          return resolvedListenerPid;
+        },
+        readCgroupOomSnapshot: (pid: number) => {
+          snapshotPids.push(pid);
+          return { dir: '/sys/fs/cgroup/dkg-test-oxi', oomKill: 0 };
+        },
+      },
+    }));
+    try {
+      expect(launchedCommand).toBe('systemd-run');
+      expect(launchedArgs).toContain('--property=MemoryHigh=128M');
+      expect(launchedArgs).toContain('--property=MemoryMax=256M');
+      expect(launchedArgs).toContain('--property=MemorySwapMax=0');
+      expect(launchedEnv?.XDG_RUNTIME_DIR).toMatch(/^\/run\/user\/\d+$/);
+      expect(ownershipPolicy).toBe('process-tree');
+      expect(snapshotPids).toEqual([resolvedListenerPid]);
+    } finally {
+      await handle.stop();
+    }
+  });
+
+  it.runIf(process.platform === 'linux')('accepts a descendant process as the verified listener owner', async () => {
+    const port = await freePort();
+    const wrapper = spawn('/bin/sh', [
+      '-c',
+      '"$@" & child=$!; trap \'kill -TERM "$child" 2>/dev/null; wait "$child" 2>/dev/null\' TERM; wait "$child"',
+      'wrapper',
+      standin,
+      'serve',
+      '--location', dir,
+      '--bind', `127.0.0.1:${port}`,
+    ], { stdio: 'ignore' });
+    try {
+      for (let i = 0; i < 50 && !(await portAnswers(port)); i++) await sleep(20);
+      const listenerPid = await fetchPid(port);
+      expect(await childOwnsListenPort(wrapper, port, '127.0.0.1')).toBe(false);
+      expect(await childOwnsListenPort(wrapper, port, '127.0.0.1', 'process-tree')).toBe(true);
+      expect(await findListenOwnerPid(wrapper, port, '127.0.0.1', 'process-tree')).toBe(listenerPid);
+    } finally {
+      wrapper.kill('SIGTERM');
+      await new Promise<void>((resolve) => wrapper.once('exit', () => resolve()));
+    }
+  });
+
   it('spawns the binary and resolves once the real readiness probe answers', async () => {
     const port = await freePort();
     const handle = await startOxigraphServer(startOpts(port));
@@ -236,6 +368,124 @@ describe('startOxigraphServer OOM classification in the restart log', () => {
     }
     return false;
   }
+
+  it('attributes a scoped wrapper SIGKILL using the resolved Oxigraph listener cgroup', async () => {
+    const port = await freePort();
+    const logs: string[] = [];
+    const listenerPid = 777_777;
+    const snapshotPids: number[] = [];
+    let launched: import('node:child_process').ChildProcess | undefined;
+    let oomKillAtExit = 5;
+    const injectedSpawn = ((_command: string, args: readonly string[], options: Parameters<typeof spawn>[2]) => {
+      const binaryIndex = args.indexOf(standin);
+      launched = spawn(standin, args.slice(binaryIndex + 1), options);
+      return launched;
+    }) as typeof spawn;
+
+    const handle = await startOxigraphServer(startOpts(port, {
+      memoryLimits: { maxMiB: 256 },
+      platform: 'linux',
+      log: (message: string) => logs.push(message),
+      io: {
+        spawn: injectedSpawn,
+        findListenOwnerPid: async () => listenerPid,
+        readCgroupOomSnapshot: (pid: number) => {
+          snapshotPids.push(pid);
+          return { dir: '/sys/fs/cgroup/dkg-scoped-oxi', oomKill: 5 };
+        },
+        readCgroupOomKill: () => oomKillAtExit,
+      },
+    }));
+    try {
+      expect(snapshotPids).toEqual([listenerPid]);
+      oomKillAtExit = 6;
+      launched!.kill('SIGKILL');
+      expect(await waitForLog(logs, /OOM-killed by cgroup memory cap/)).toBe(true);
+    } finally {
+      await handle.stop();
+    }
+  });
+
+  it('attributes a scoped command OOM when its wrapper translates SIGKILL to exit 137', async () => {
+    const port = await freePort();
+    const logs: string[] = [];
+    let oomKillAtExit = 9;
+    const wrapperProgram = `
+      const { spawn } = require('node:child_process');
+      const [command, ...args] = process.argv.slice(1);
+      const child = spawn(command, args, { stdio: 'inherit' });
+      process.on('SIGTERM', () => child.kill('SIGTERM'));
+      child.once('exit', () => process.exit(137));
+    `;
+    const injectedSpawn = ((_command: string, args: readonly string[], options: Parameters<typeof spawn>[2]) => {
+      const binaryIndex = args.indexOf(standin);
+      return spawn(
+        process.execPath,
+        ['-e', wrapperProgram, standin, ...args.slice(binaryIndex + 1)],
+        options,
+      );
+    }) as typeof spawn;
+
+    const handle = await startOxigraphServer(startOpts(port, {
+      memoryLimits: { maxMiB: 256 },
+      platform: 'linux',
+      log: (message: string) => logs.push(message),
+      io: {
+        spawn: injectedSpawn,
+        findListenOwnerPid: async () => await fetchPid(port),
+        readCgroupOomSnapshot: () => ({ dir: '/sys/fs/cgroup/dkg-scoped-oxi', oomKill: 9 }),
+        readCgroupOomKill: () => oomKillAtExit,
+      },
+    }));
+    try {
+      oomKillAtExit = 10;
+      process.kill(await fetchPid(port), 'SIGKILL');
+      expect(await waitForLog(logs, /code=137.*OOM-killed by cgroup memory cap/)).toBe(true);
+    } finally {
+      await handle.stop();
+    }
+  });
+
+  it('uses the scoped watchdog marker when systemd removes memory.events before wrapper exit', async () => {
+    const port = await freePort();
+    const logs: string[] = [];
+    const wrapperProgram = `
+      const { spawn } = require('node:child_process');
+      const [command, ...args] = process.argv.slice(1);
+      const child = spawn(command, args, { stdio: 'inherit' });
+      process.on('SIGTERM', () => child.kill('SIGTERM'));
+      child.once('exit', () => {
+        process.stderr.write(${JSON.stringify(OXIGRAPH_WATCHDOG_OOM_MARKER)} + '\\n');
+        process.exit(0);
+      });
+    `;
+    const injectedSpawn = ((_command: string, args: readonly string[], options: Parameters<typeof spawn>[2]) => {
+      const binaryIndex = args.indexOf(standin);
+      return spawn(
+        process.execPath,
+        ['-e', wrapperProgram, standin, ...args.slice(binaryIndex + 1)],
+        options,
+      );
+    }) as typeof spawn;
+
+    const handle = await startOxigraphServer(startOpts(port, {
+      memoryLimits: { maxMiB: 256 },
+      platform: 'linux',
+      log: (message: string) => logs.push(message),
+      io: {
+        spawn: injectedSpawn,
+        findListenOwnerPid: async () => await fetchPid(port),
+        readCgroupOomSnapshot: () => ({ dir: '/sys/fs/cgroup/vanished', oomKill: 12 }),
+        readCgroupOomKill: () => null,
+      },
+    }));
+    try {
+      process.kill(await fetchPid(port), 'SIGKILL');
+      expect(await waitForLog(logs, /code=0.*OOM-killed by cgroup memory cap/)).toBe(true);
+    } finally {
+      await handle.stop();
+    }
+  });
 
   it('labels an OOM-kill when the cgroup oom_kill count increments across the exit', async () => {
     const port = await freePort();


### PR DESCRIPTION
## Summary

- add opt-in `store.options.memoryHighMiB` / `memoryMaxMiB` settings for daemon-managed Oxigraph
- launch configured Oxigraph processes through a stateful systemd-user-scope strategy with independent finite `MemoryHigh` / `MemoryMax` and `MemorySwapMax=0`
- replace the embedded shell watchdog with a typed, tested Node entrypoint that forwards intentional shutdown and terminates Oxigraph if the daemon parent disappears
- resolve the actual descendant listener PID through a strategy-owned process-tree policy and use its cgroup for OOM baselines instead of sampling the `systemd-run` wrapper
- have the in-scope watchdog read final OOM evidence before systemd removes the empty cgroup, then relay a machine-readable marker to the supervisor
- keep readiness probing side-effect free and capture diagnostics explicitly only after a listener is accepted
- preserve unexpected child-signal failures as conventional non-zero wrapper statuses
- centralize memory-limit validation and fail closed on unsupported platforms or invalid limits; behavior is unchanged when limits are absent

## Why

On the DKG testnet beacons, Node.js and managed Oxigraph shared the same service cgroup. `MemoryHigh=4G` throttled the Node control plane when Oxigraph grew, filling the libp2p accept queue; `MemoryMax=5G` then SIGKILLed Oxigraph and destabilized the whole service. The temporary mitigation was `MemoryHigh=6G` with `MemoryMax=infinity`.

This PR lets operators restore a finite daemon limit while bounding Oxigraph separately, preventing one process from consuming or triggering OOM handling for the other's budget. Disabling swap for the Oxigraph scope also prevents memory pressure from turning into host-wide swap latency.

## Configuration

```json
{
  "store": {
    "backend": "oxigraph-server",
    "options": {
      "memoryHighMiB": 2048,
      "memoryMaxMiB": 3072
    }
  }
}
```

Linux/systemd nodes must enable the service user's manager at boot once:

```bash
sudo loginctl enable-linger <dkg-user>
```

The daemon supplies `XDG_RUNTIME_DIR` and the user-bus address to `systemd-run`. Startup fails rather than silently ignoring requested limits when the scope cannot be created.

## Verification

- full CLI build passes
- focused supervisor/watchdog/listener/cgroup suites: 26 passing, one Linux-only local skip
- broader CLI unit run before the final focused changes: 1,520 passing / 48 skipped; five live-chain suites could not start locally because the shared Hardhat context file was absent
- live testnet-beacon probe confirmed the listener entered the dedicated scope with exact finite limits and zero swap
- live probe confirmed both graceful wrapper shutdown and simulated daemon-parent loss remove the listener and stop/collect the scope
- a real cgroup OOM probe confirmed `oom_kill` occurs with swap disabled, the cgroup is removed before the outer exit callback, and the in-scope watchdog reliably emits the OOM marker (wrapper status 200)
- a real scoped signal probe confirmed an unexpected listener `SIGTERM` is preserved as wrapper status 143
- `git diff --check`

## Rollout

This is opt-in. After merge, configure the Oxigraph scope, restore a finite `MemoryMax` on the DKG service sized for Node/worker only, deploy through `main` -> `testnet-canary`, and repeat the mixed public/private 100-KA run before broader rollout.
