### PR TITLE
fix(agent): keep outbox retries on schedule (#1579)

### DIFF
--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -891,9 +891,8 @@ export class DKGAgentBase {
   protected hostModeReconcilerTimer: ReturnType<typeof setInterval> | null = null;
   protected hostModePruneTimer: ReturnType<typeof setInterval> | null = null;
   // rc.9 PR-10: joinApprovalRetryQueue + joinApprovalRetryTimer
-  // deleted. The substrate's SQLite-backed ProtocolOutbox + its tick
-  // (`Messenger.processOutboxTick`) + opportunistic on-connect flush
-  // (`Messenger.processOutboxOnConnect`) replace the entire in-memory
+  // deleted. The substrate's SQLite-backed ProtocolOutbox + its
+  // scheduled tick (`Messenger.processOutboxTick`) replace the in-memory
   // queue: persistence across restart, generic per-protocol coverage,
   // identical backoff-ladder semantics. Operator-facing diagnostics
   // (`listPendingJoinApprovalRetries`) are stubbed to [] until PR-12

--- a/packages/agent/src/dkg-agent-constants.ts
+++ b/packages/agent/src/dkg-agent-constants.ts
@@ -172,27 +172,18 @@ export const STORAGE_ACK_REGISTRATION_RETRY_MS = 30_000;
  * the local curator state is correct but the invitee never learns to
  * sync, and their own retries can't help because they don't yet hold the
  * delegation that would let private-sync auth succeed. The tick walks the
- * queue's `due()` entries with exponential backoff. Opportunistic retries
- * also fire from `connection:open` when the invitee's peer reconnects,
- * which usually wins the race; the timer is the safety net for cases
- * where reconnect events are missed (e.g. relayed reconnects that don't
- * surface a fresh `connection:open` on the curator).
+ * queue's `due()` entries with exponential backoff. This separate join queue
+ * retains its own peer lifecycle policy; Universal Messenger rows below are
+ * scheduled-only.
  */
 export const JOIN_APPROVAL_RETRY_TICK_MS = 30_000;
 
 /**
  * Tick interval for the chat outbox retry queue. Same 30s cadence as
  * the join-approval queue (`JOIN_APPROVAL_RETRY_TICK_MS`). The cadence
- * doesn't gate the FIRST retry — a backoff-due entry that's been
- * waiting since 5s after first failure may sit idle for up to 25s
- * before this tick picks it up — but the dominant retry trigger in
- * practice is the `connection:open` opportunistic flush
- * (`processMessageOutboxOnConnect`), which fires the moment the
- * recipient peer becomes reachable again. The tick is the safety net
- * for cases where reconnect events are missed (e.g. relayed reconnects
- * that don't surface a fresh `connection:open` on the sender) or
- * where the recipient was reachable all along but transport failures
- * are coming from somewhere upstream of libp2p.
+ * is the sole automatic trigger: reconnect churn must not bypass a row's
+ * persisted `nextAttemptAt`. A due entry may sit for up to one tick interval
+ * before the scheduler picks it up.
  */
 export const MESSAGE_OUTBOX_TICK_MS = 30_000;
 

--- a/packages/agent/src/dkg-agent-join.ts
+++ b/packages/agent/src/dkg-agent-join.ts
@@ -716,8 +716,7 @@ export class JoinRequestMethods extends DKGAgentBase {
       ctx,
       `join-approval for "${contextGraphId}" → ${agentAddress} not delivered now ` +
         `(error=${result.error ?? 'unknown'}). Curator-local state is correct; ` +
-        `substrate outbox holds the queued send and will retry on its backoff ` +
-        `ladder + on the invitee's next reconnect.`,
+        `substrate outbox holds the queued send and will retry on its backoff ladder.`,
     );
   }
 
@@ -727,8 +726,8 @@ export class JoinRequestMethods extends DKGAgentBase {
    * delivery state matters.
    *
    * Used by:
-   *   * The substrate's periodic outbox tick + on-connect flush —
-   *     both transparent to this call (rc.9 PR-10).
+   *   * The substrate's periodic outbox tick, transparent to this call
+   *     (rc.9 PR-10).
    *   * The operator-facing route `POST /api/context-graph/{id}/redeliver-approval`,
    *     which lets an operator (or peer agent via the chat MCP) re-poke
    *     the curator when the automated retry isn't fast enough.
@@ -856,8 +855,8 @@ export class JoinRequestMethods extends DKGAgentBase {
    */
   // rc.9 PR-10: processJoinApprovalRetryQueueTick +
   // processJoinApprovalRetryQueueOnConnect deleted. The substrate's
-  // Messenger.processOutboxTick + Messenger.processOutboxOnConnect
-  // cover /dkg/10.0.1/join-request automatically (same as chat in
+  // Messenger.processOutboxTick covers /dkg/10.0.1/join-request
+  // automatically (same as chat in
   // PR-3), so the two dedicated processors are obsolete. Operator
   // re-fire route POST /api/context-graph/{id}/redeliver-approval is
   // unchanged — it still calls redeliverJoinApproval which now

--- a/packages/agent/src/dkg-agent-join.ts
+++ b/packages/agent/src/dkg-agent-join.ts
@@ -863,9 +863,8 @@ export class JoinRequestMethods extends DKGAgentBase {
   // simply re-issues the substrate send.
 
   /**
-   * Re-attempt delivery of a single chat outbox entry. Centralised so
-   * the periodic tick + the connection:open opportunistic flush share
-   * one code path. Returns the entry's current state so the caller can
+   * Re-attempt delivery of a single chat outbox entry from the periodic
+   * scheduler. Returns the entry's current state so the caller can
    * decide what to log.
    *
    * Goes through `messageHandler.sendChat` directly (bypassing
@@ -883,17 +882,14 @@ export class JoinRequestMethods extends DKGAgentBase {
    * class: an inbound circuit connection from P was open and live, but
    * every `libp2p.dialProtocol(P, ...)` retry on our side failed with
    * "The dial request has no valid addresses for peer" for several
-   * minutes. Daemon logs showed 31 `connection:open` events from P
-   * (all inbound, all via R) + 20 opportunistic-flush attempts, all
-   * failing dialProtocol — and then the moment ONE outbound connection
-   * succeeded (which populated peerStore from outbound identify), the
-   * very next opportunistic-flush delivered the queued message.
+   * minutes. Reverse-path enrichment ensures the next scheduled retry sees a
+   * usable address without letting connection churn bypass persisted backoff.
    *
    * The clean fix would be inside libp2p (`dialProtocol` should reuse
    * an existing open connection of any direction — see PR 5 in the
    * postmortem follow-up plan), but until that lands, populating
    * peerStore from the inbound circuit's address gives the dialer
-   * something to find on the very next attempt.
+   * something to find on the next scheduled attempt.
    *
    * Public so a unit test can exercise it directly without standing up
    * a full libp2p network (the listener that calls it is registered
@@ -1139,7 +1135,7 @@ export class JoinRequestMethods extends DKGAgentBase {
           ctx,
           `${label} for "${contextGraphId}" to ${agentAddress} (${targetPeerId}) ` +
           `queued in substrate outbox: ${sendResult.error}. ` +
-          `Substrate will retry on its own backoff ladder + on the invitee's next reconnect.`,
+          `Substrate will retry on its persisted backoff schedule.`,
         );
         return { delivered: false, peerId: targetPeerId, error: sendResult.error };
       }

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -2345,14 +2345,8 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     this.node.libp2p.addEventListener('connection:open', (evt) => {
       const remotePeer = evt.detail.remotePeer.toString();
       if (remotePeer === this.node.libp2p.peerId.toString()) return;
-      // rc.9 PR-10: the dedicated join-approval on-connect flush is
-      // gone. The substrate's `Messenger.processOutboxOnConnect` (a
-      // few lines further down in this handler) now covers join-
-      // approved retries too, since /dkg/10.0.1/join-request is now
-      // a substrate-managed protocol.
-
       // Reverse-path peerStore enrichment for inbound circuit-relay
-      // connections, then the symmetric chat-outbox flush.
+      // connections.
       //
       // Closes the "Window D" class from the May 2026 Miles↔Lex 6h
       // soak postmortem: an inbound circuit connection from peer P
@@ -2365,17 +2359,6 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       // dialProtocol find an address and try it.
       //
       // User review on PR #536 caught the original ordering bug:
-      // running enrichment and the outbox flush in parallel
-      // fire-and-forget meant the first flush attempt could
-      // still hit `dialProtocol` against an EMPTY peerStore and
-      // fail with the same "no valid addresses" error this PR is
-      // meant to heal — pushing recovery onto the next 30s tick
-      // or another reconnect. Sequence the two: await enrichment
-      // first, then flush. Both stay wrapped in their own
-      // try/catch so an enrichment failure logs a warning and
-      // still lets the outbox flush proceed (it might succeed
-      // anyway via a stale-but-usable cached path).
-      //
       // The whole chain runs as a fire-and-forget IIFE so the
       // listener itself doesn't await — libp2p's
       // `connection:open` emitter is synchronous and we don't
@@ -2395,17 +2378,6 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         } catch (err: unknown) {
           const message = err instanceof Error ? err.message : String(err);
           this.log.warn(ctx, `Reverse-path peerStore enrichment failed for ${remotePeer}: ${message}`);
-        }
-        // Universal Messenger substrate (rc.9 PR-2/PR-3): drain
-        // the generic outbox for this peer. Replaces the rc.8
-        // chat-specific outbox flush — the substrate now carries
-        // chat (PR-3) and will carry every other short-message
-        // protocol after PR-8..PR-11.
-        try {
-          await this.messenger.processOutboxOnConnect(remotePeer);
-        } catch (err: unknown) {
-          const message = err instanceof Error ? err.message : String(err);
-          this.log.warn(ctx, `Opportunistic Messenger-outbox retry on connect failed for ${remotePeer}: ${message}`);
         }
         // PR-2 (SWM-fanout plan): drain pending sender-key packages
         // that were queued because the recipient had no advertised
@@ -2604,8 +2576,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     // MESSAGE_OUTBOX_TICK_MS for the rationale (silent-drop on
     // transport failure used to lose operator-typed messages from
     // `dkg_send_message`; this is the safety-net retry loop that turns
-    // them into eventual successes, complemented by the
-    // opportunistic-on-reconnect path in the connection:open listener).
+    // them into eventual successes on their persisted retry schedule.
     // Universal Messenger substrate retry tick (rc.9 PR-2 +
     // PR-3). The rc.8 chat-specific tick was deleted in PR-3;
     // this is now the only outbox tick — chat (PR-3) and every

--- a/packages/agent/src/p2p/messenger.ts
+++ b/packages/agent/src/p2p/messenger.ts
@@ -633,8 +633,8 @@ export class Messenger {
 
     // Inflight guard (rc.9 #521 lesson lifted): two parallel
     // attempters on the same `(peer, protocol, messageId)` can race
-    // when the periodic tick + an opportunistic-flush fire close
-    // together. Second attempter exits without dialing.
+    // when a first sender + periodic retry (or overlapping explicit callers)
+    // race. Second attempter exits without dialing.
     if (!outbox.tryBeginAttempt(peerId, protocolId, messageId)) {
       // Another attempt is in flight. This is not the same thing as
       // durable queued: the winning attempt may still be on its first
@@ -809,7 +809,7 @@ export class Messenger {
       return;
     }
     try {
-      // Stale-snapshot guard — between the moment `due`/`pendingFor`
+      // Stale-snapshot guard — between the moment `due`
       // gave us the snapshot and the moment `tryBeginAttempt` won,
       // a sibling flush may have completed delivery and called
       // `markDelivered`. Re-check `hasEntry` and bail if gone.
@@ -861,7 +861,7 @@ export class Messenger {
    *
    * Fire-and-forget: never blocks the caller. The DHT walk's
    * side-effect (populating `peerStore` for the peer) heals the
-   * next opportunistic-flush or periodic-tick retry, not the
+   * next periodic-tick retry, not the
    * current one. This is intentional — the current retry has
    * already failed; the walk is for the next attempt.
    *
@@ -905,7 +905,7 @@ export class Messenger {
   }
 
   private clearDhtWalkRateLimitIfDrained(peerId: string): void {
-    if (!this.outbox || this.outbox.pendingFor(peerId).length === 0) {
+    if (!this.outbox || !this.outbox.hasPendingFor(peerId)) {
       this.lastDhtWalkAt.delete(peerId);
     }
   }

--- a/packages/agent/src/p2p/messenger.ts
+++ b/packages/agent/src/p2p/messenger.ts
@@ -798,24 +798,6 @@ export class Messenger {
     }
   }
 
-  /**
-   * Opportunistic-flush retry loop. The lifecycle.ts wiring (PR-3)
-   * calls this from a libp2p `connection:open` event for `peerId`:
-   * a reconnection is the signal we were waiting for, so attempt
-   * every pending entry for `peer` NOW even if `nextAttemptAt` is
-   * still in the future.
-   *
-   * Same guards as `processOutboxTick` — must check `hasEntry`
-   * after `tryBeginAttempt` to defend against the rc.9 #538 race.
-   */
-  async processOutboxOnConnect(peerId: string): Promise<void> {
-    if (!this.outbox) return;
-    const pending = this.outbox.pendingFor(peerId);
-    for (const entry of pending) {
-      await this.retryOutboxEntry(entry);
-    }
-  }
-
   private async retryOutboxEntry(entry: {
     peer: string;
     protocol: string;

--- a/packages/agent/test/p2p-resilience.test.ts
+++ b/packages/agent/test/p2p-resilience.test.ts
@@ -350,6 +350,7 @@ describe('p2p resilience hooks', () => {
 
         const events: string[] = [];
         let scheduledDrains = 0;
+        let opportunisticDrains = 0;
         let enrichResolve: (() => void) | null = null;
         const enrichDone = new Promise<void>((r) => { enrichResolve = r; });
 
@@ -360,6 +361,7 @@ describe('p2p resilience hooks', () => {
           enrichResolve?.();
         };
         (agent as any).messenger.processOutboxTick = async () => { scheduledDrains += 1; };
+        (agent as any).messenger.processOutboxOnConnect = async () => { opportunisticDrains += 1; };
 
         const remotePeer = freshPeerIdString();
         const relayPeer = freshPeerIdString();
@@ -382,6 +384,7 @@ describe('p2p resilience hooks', () => {
         expect(events).toContain('enrich:start');
         expect(events).toContain('enrich:end');
         expect(scheduledDrains).toBe(0);
+        expect(opportunisticDrains).toBe(0);
       } finally {
         await agent.stop().catch(() => {});
       }

--- a/packages/agent/test/p2p-resilience.test.ts
+++ b/packages/agent/test/p2p-resilience.test.ts
@@ -338,21 +338,7 @@ describe('p2p resilience hooks', () => {
       }
     }, 15_000);
 
-    // User review on PR #536: the `connection:open` listener used to
-    // call `enrichPeerStoreFromInboundCircuit` and the outbox flush
-    // in parallel fire-and-forget, which meant the first outbox
-    // flush attempt could still hit `dialProtocol` against an EMPTY
-    // peerStore — exact same "no valid addresses for peer" failure
-    // the PR is meant to heal. Fix wraps both in a sequential IIFE
-    // so the flush sees the freshly-merged reverse-path address.
-    //
-    // rc.9 PR-3 substrate cutover: the outbox flush moved from
-    // `processMessageOutboxOnConnect` (chat-specific, deleted) to
-    // `messenger.processOutboxOnConnect` (substrate, generic). The
-    // ordering invariant is the same — enrich BEFORE the substrate
-    // flush so the substrate's dialProtocol calls see the merged
-    // peerStore address.
-    it('awaits enrichment BEFORE the substrate outbox flush on inbound circuit open (PR #536 review, rc.9 substrate)', async () => {
+    it('enriches reverse paths without waking the Messenger outbox on connection open', async () => {
       const agent = await DKGAgent.create({
         name: 'ReversePathEnrichBeforeFlush',
         listenHost: '127.0.0.1',
@@ -363,6 +349,7 @@ describe('p2p resilience hooks', () => {
         allowAllNetworkAdmission(agent);
 
         const events: string[] = [];
+        let scheduledDrains = 0;
         let enrichResolve: (() => void) | null = null;
         const enrichDone = new Promise<void>((r) => { enrichResolve = r; });
 
@@ -372,9 +359,7 @@ describe('p2p resilience hooks', () => {
           events.push('enrich:end');
           enrichResolve?.();
         };
-        (agent as any).messenger.processOutboxOnConnect = async () => {
-          events.push('flush:start');
-        };
+        (agent as any).messenger.processOutboxTick = async () => { scheduledDrains += 1; };
 
         const remotePeer = freshPeerIdString();
         const relayPeer = freshPeerIdString();
@@ -391,23 +376,16 @@ describe('p2p resilience hooks', () => {
         } as any));
 
         await enrichDone;
-        // Give the IIFE one more tick to schedule the flush.
+        // Give the connection lifecycle's remaining async work time to settle.
         await new Promise(r => setTimeout(r, 50));
 
         expect(events).toContain('enrich:start');
         expect(events).toContain('enrich:end');
-        expect(events).toContain('flush:start');
-        expect(events.indexOf('enrich:end')).toBeLessThan(events.indexOf('flush:start'));
+        expect(scheduledDrains).toBe(0);
       } finally {
         await agent.stop().catch(() => {});
       }
     }, 15_000);
 
-    // Stale-snapshot guard regression: the equivalent test for the
-    // substrate's `Messenger.processOutboxOnConnect` lives in
-    // `messenger-substrate.test.ts` ("honours the stale-snapshot
-    // guard (rc.9 #538)") — same race, same fix, just at the
-    // generic substrate layer rather than the chat-specific one
-    // which was deleted in rc.9 PR-3.
   });
 });

--- a/packages/agent/test/p2p-resilience.test.ts
+++ b/packages/agent/test/p2p-resilience.test.ts
@@ -349,10 +349,25 @@ describe('p2p resilience hooks', () => {
         allowAllNetworkAdmission(agent);
 
         const events: string[] = [];
-        let scheduledDrains = 0;
-        let opportunisticDrains = 0;
+        const wireProtocols: string[] = [];
         let enrichResolve: (() => void) | null = null;
         const enrichDone = new Promise<void>((r) => { enrichResolve = r; });
+        const remotePeer = freshPeerIdString();
+        const testProtocol = '/dkg/test/scheduled-only';
+        const queuedAt = Date.now();
+        const messenger = (agent as any).messenger;
+        messenger.outbox.enqueueFailure(
+          remotePeer,
+          testProtocol,
+          'scheduled-only-message',
+          new Uint8Array([1, 2, 3]),
+          'offline',
+          queuedAt,
+        );
+        messenger.router.send = async (_peer: string, protocol: string) => {
+          wireProtocols.push(protocol);
+          return new Uint8Array([0x42]);
+        };
 
         (agent as any).enrichPeerStoreFromInboundCircuit = async () => {
           events.push('enrich:start');
@@ -360,10 +375,6 @@ describe('p2p resilience hooks', () => {
           events.push('enrich:end');
           enrichResolve?.();
         };
-        (agent as any).messenger.processOutboxTick = async () => { scheduledDrains += 1; };
-        (agent as any).messenger.processOutboxOnConnect = async () => { opportunisticDrains += 1; };
-
-        const remotePeer = freshPeerIdString();
         const relayPeer = freshPeerIdString();
         agent.node.libp2p.dispatchEvent(new CustomEvent('connection:open', {
           detail: {
@@ -383,8 +394,13 @@ describe('p2p resilience hooks', () => {
 
         expect(events).toContain('enrich:start');
         expect(events).toContain('enrich:end');
-        expect(scheduledDrains).toBe(0);
-        expect(opportunisticDrains).toBe(0);
+        expect(wireProtocols).not.toContain(testProtocol);
+
+        // The same row remains deliverable by the sole automatic trigger once
+        // its persisted backoff has elapsed.
+        await messenger.processOutboxTick(queuedAt + 10_000);
+        expect(wireProtocols.filter((protocol) => protocol === testProtocol)).toHaveLength(1);
+        expect(messenger.outbox.hasPendingFor(remotePeer)).toBe(false);
       } finally {
         await agent.stop().catch(() => {});
       }

--- a/packages/core/src/messenger-types.ts
+++ b/packages/core/src/messenger-types.ts
@@ -197,22 +197,16 @@ export interface ProtocolOutboxStore {
 
   /**
    * Whether an entry exists for `(peer, protocol, messageId)`. Used
-   * by the stale-snapshot guard in `Messenger.processOutboxOnConnect`
-   * — between `tryBeginAttempt` (inflight lock) and the wire send,
+   * by the scheduled drain's stale-snapshot guard — between
+   * `tryBeginAttempt` (inflight lock) and the wire send,
    * a sibling flush may have already delivered + removed the entry,
    * and we must not double-send. The rc9 #538 fix lifted into the
    * generic substrate.
    */
   hasEntry(peer: string, protocol: string, messageId: string): boolean;
 
-  /**
-   * All entries for a specific peer, regardless of `nextAttemptAt`.
-   * Used by `processOutboxOnConnect`: a reconnection is the signal
-   * we were waiting for, so attempt now even if backoff isn't due
-   * yet. Sorted by `firstFailureAt` ascending for FIFO per-peer
-   * drain.
-   */
-  pendingFor(peer: string): ProtocolOutboxEntry[];
+  /** Whether this peer still has any durable row (DHT recovery bookkeeping). */
+  hasPendingFor(peer: string): boolean;
 
   /**
    * All entries whose `nextAttemptAt <= now`. Used by the periodic

--- a/packages/core/src/protocol-outbox.ts
+++ b/packages/core/src/protocol-outbox.ts
@@ -340,12 +340,12 @@ export class InMemoryProtocolOutboxStore implements ProtocolOutboxStore {
   }
 
   list(): ProtocolOutboxEntry[] {
-    return Array.from(this.entries.values()).map((e) => ({ ...e }));
+    return Array.from(this.entries.values()).map(cloneOutboxEntry);
   }
 
   getEntry(peer: string, protocol: string, messageId: string): ProtocolOutboxEntry | undefined {
     const entry = this.entries.get(InMemoryProtocolOutboxStore.key(peer, protocol, messageId));
-    return entry ? { ...entry } : undefined;
+    return entry ? cloneOutboxEntry(entry) : undefined;
   }
 }
 

--- a/packages/core/src/protocol-outbox.ts
+++ b/packages/core/src/protocol-outbox.ts
@@ -102,17 +102,9 @@ export class ProtocolOutbox {
   private readonly backoffs: readonly number[];
   /**
    * Per-key inflight set to prevent concurrent retry attempts for the
-   * same `(peer, protocol, messageId)`. Two trigger surfaces — the
-   * periodic tick (`Messenger.processOutboxTick`) and the
-   * opportunistic flush on `connection:open`
-   * (`Messenger.processOutboxOnConnect`) — can interleave: the tick
-   * starts the send for entry E, JS yields, `connection:open` fires,
-   * the on-connect handler reads `pendingFor(peer)` (entry E is still
-   * there — `markDelivered` hasn't fired yet because the in-flight
-   * send hasn't resolved), and would start a CONCURRENT second send
-   * for the same entry. Worst case both succeed and the receiver sees
-   * the same payload twice (receiver dedup absorbs it, but we waste
-   * a round-trip and amplify load).
+   * same `(peer, protocol, messageId)`. Overlapping scheduler callers or
+   * another explicit sender can otherwise interleave around a stale due
+   * snapshot and duplicate the same wire attempt.
    *
    * `tryBeginAttempt` is an atomic check-and-set: the second
    * concurrent attempter sees `false` and exits without dialing.
@@ -206,13 +198,8 @@ export class ProtocolOutbox {
     return this.store.due(now);
   }
 
-  /**
-   * All entries for `peer`, regardless of `nextAttemptAt`. Used by
-   * `Messenger.processOutboxOnConnect` for opportunistic flush on
-   * reconnection.
-   */
-  pendingFor(peer: string): ProtocolOutboxEntry[] {
-    return this.store.pendingFor(peer);
+  hasPendingFor(peer: string): boolean {
+    return this.store.hasPendingFor(peer);
   }
 
   /** Drop entries older than the store's configured max-age. */
@@ -327,11 +314,8 @@ export class InMemoryProtocolOutboxStore implements ProtocolOutboxStore {
     return this.entries.has(InMemoryProtocolOutboxStore.key(peer, protocol, messageId));
   }
 
-  pendingFor(peer: string): ProtocolOutboxEntry[] {
-    return Array.from(this.entries.values())
-      .filter((e) => e.peer === peer)
-      .sort((a, b) => a.firstFailureAt - b.firstFailureAt)
-      .map(cloneOutboxEntry);
+  hasPendingFor(peer: string): boolean {
+    return Array.from(this.entries.values()).some((entry) => entry.peer === peer);
   }
 
   due(now: number): ProtocolOutboxEntry[] {

--- a/packages/core/test/protocol-outbox.test.ts
+++ b/packages/core/test/protocol-outbox.test.ts
@@ -71,7 +71,7 @@ describe('ProtocolOutbox.enqueueFailure', () => {
     payload[0] = 9;
     entry.payload[1] = 8;
 
-    const pending = outbox.pendingFor(PEER_A);
+    const pending = outbox.snapshot().filter((entry) => entry.peer === PEER_A);
     expect(Array.from(pending[0].payload)).toEqual([1, 2, 3]);
 
     pending[0].payload[2] = 7;
@@ -128,7 +128,7 @@ describe('ProtocolOutbox.tryBeginAttempt / endAttempt', () => {
   });
 });
 
-describe('ProtocolOutbox.due / pendingFor', () => {
+describe('ProtocolOutbox.due / peer presence', () => {
   it('due returns entries whose nextAttemptAt is at or before now', () => {
     const { outbox } = fixture();
     outbox.enqueueFailure(PEER_A, PROTO, MSG_1, PAYLOAD, 'e', 1000);
@@ -137,14 +137,14 @@ describe('ProtocolOutbox.due / pendingFor', () => {
     expect(outbox.due(expectedNext)).toHaveLength(1);
   });
 
-  it('pendingFor returns all entries for a peer in firstFailureAt ascending order', () => {
+  it('hasPendingFor tracks peer rows without exposing a reconnect drain snapshot', () => {
     const { outbox } = fixture();
     outbox.enqueueFailure(PEER_A, PROTO, MSG_2, PAYLOAD, 'e', 2000);
     outbox.enqueueFailure(PEER_A, PROTO, MSG_1, PAYLOAD, 'e', 1000);
     outbox.enqueueFailure(PEER_B, PROTO, MSG_1, PAYLOAD, 'e', 500);
-    const peerA = outbox.pendingFor(PEER_A);
-    expect(peerA.map((e) => e.messageId)).toEqual([MSG_1, MSG_2]);
-    expect(outbox.pendingFor(PEER_B)).toHaveLength(1);
+    expect(outbox.hasPendingFor(PEER_A)).toBe(true);
+    expect(outbox.hasPendingFor(PEER_B)).toBe(true);
+    expect(outbox.hasPendingFor('peer-c')).toBe(false);
   });
 });
 

--- a/packages/core/test/protocol-outbox.test.ts
+++ b/packages/core/test/protocol-outbox.test.ts
@@ -71,7 +71,7 @@ describe('ProtocolOutbox.enqueueFailure', () => {
     payload[0] = 9;
     entry.payload[1] = 8;
 
-    const pending = outbox.snapshot().filter((entry) => entry.peer === PEER_A);
+    const pending = outbox.list().filter((entry) => entry.peer === PEER_A);
     expect(Array.from(pending[0].payload)).toEqual([1, 2, 3]);
 
     pending[0].payload[2] = 7;

--- a/packages/node-ui/src/db.ts
+++ b/packages/node-ui/src/db.ts
@@ -2774,23 +2774,8 @@ export class SqliteProtocolOutboxStore implements ProtocolOutboxStore {
     return row !== undefined;
   }
 
-  pendingFor(peer: string): ProtocolOutboxEntry[] {
-    const rows = this.db
-      .prepare(
-        `SELECT * FROM protocol_outbox WHERE peer_id = ? ORDER BY first_failure_at ASC`,
-      )
-      .all(peer) as Array<{
-      peer_id: string;
-      protocol: string;
-      message_id: string;
-      payload: Buffer;
-      attempts: number;
-      first_failure_at: number;
-      last_attempt_at: number;
-      next_attempt_at: number;
-      last_error: string | null;
-    }>;
-    return rows.map(SqliteProtocolOutboxStore.rowToEntry);
+  hasPendingFor(peer: string): boolean {
+    return this.db.prepare('SELECT 1 FROM protocol_outbox WHERE peer_id = ? LIMIT 1').get(peer) !== undefined;
   }
 
   due(now: number): ProtocolOutboxEntry[] {

--- a/packages/node-ui/test/messenger-stores.test.ts
+++ b/packages/node-ui/test/messenger-stores.test.ts
@@ -180,7 +180,7 @@ describe('SqliteProtocolOutboxStore', () => {
     payload[0] = 9;
     entry.payload[1] = 8;
 
-    const pending = store.pendingFor(PEER_A);
+    const pending = store.snapshot().filter((entry) => entry.peer === PEER_A);
     expect(Array.from(pending[0].payload)).toEqual([1, 2, 3]);
 
     pending[0].payload[2] = 7;
@@ -207,13 +207,14 @@ describe('SqliteProtocolOutboxStore', () => {
     expect(store.markDelivered(PEER_A, PROTO, MSG_1)).toBe(false);
   });
 
-  it('pendingFor returns entries sorted by firstFailureAt ascending', () => {
+  it('hasPendingFor reports whether a peer owns any durable row', () => {
     const store = new SqliteProtocolOutboxStore(db);
     store.enqueue(PEER_A, PROTO, MSG_2, PAYLOAD, 'e', 2000);
     store.enqueue(PEER_A, PROTO, MSG_1, PAYLOAD, 'e', 1000);
     store.enqueue(PEER_B, PROTO, MSG_1, PAYLOAD, 'e', 500);
-    expect(store.pendingFor(PEER_A).map((e) => e.messageId)).toEqual([MSG_1, MSG_2]);
-    expect(store.pendingFor(PEER_B)).toHaveLength(1);
+    expect(store.hasPendingFor(PEER_A)).toBe(true);
+    expect(store.hasPendingFor(PEER_B)).toBe(true);
+    expect(store.hasPendingFor('peer-c')).toBe(false);
   });
 
   it('due returns entries with nextAttemptAt <= now', () => {
@@ -259,7 +260,7 @@ describe('SqliteProtocolOutboxStore', () => {
     db.close();
     db = new DashboardDB({ dataDir: dir });
     const reopened = new SqliteProtocolOutboxStore(db);
-    const pending = reopened.pendingFor(PEER_A);
+    const pending = reopened.snapshot().filter((entry) => entry.peer === PEER_A);
     expect(pending).toHaveLength(1);
     expect(pending[0].lastError).toBe('crash-before-delivery');
     expect(Array.from(pending[0].payload)).toEqual(Array.from(PAYLOAD));

--- a/packages/node-ui/test/messenger-stores.test.ts
+++ b/packages/node-ui/test/messenger-stores.test.ts
@@ -180,7 +180,7 @@ describe('SqliteProtocolOutboxStore', () => {
     payload[0] = 9;
     entry.payload[1] = 8;
 
-    const pending = store.snapshot().filter((entry) => entry.peer === PEER_A);
+    const pending = store.list().filter((entry) => entry.peer === PEER_A);
     expect(Array.from(pending[0].payload)).toEqual([1, 2, 3]);
 
     pending[0].payload[2] = 7;
@@ -260,7 +260,7 @@ describe('SqliteProtocolOutboxStore', () => {
     db.close();
     db = new DashboardDB({ dataDir: dir });
     const reopened = new SqliteProtocolOutboxStore(db);
-    const pending = reopened.snapshot().filter((entry) => entry.peer === PEER_A);
+    const pending = reopened.list().filter((entry) => entry.peer === PEER_A);
     expect(pending).toHaveLength(1);
     expect(pending[0].lastError).toBe('crash-before-delivery');
     expect(Array.from(pending[0].payload)).toEqual(Array.from(PAYLOAD));

--- a/scripts/devnet-test-issue-1579-outbox-backoff.sh
+++ b/scripts/devnet-test-issue-1579-outbox-backoff.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Live-devnet regression for #1579. A cooling-down reliable message is seeded
+# into node1's durable outbox, node2 is restarted/reconnected, and the row must
+# remain untouched until its scheduled next_attempt_at. On the buggy build the
+# connection:open hook immediately sends/removes (or advances) the row.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DEVNET_DIR="${DEVNET_DIR:-$ROOT/.devnet}"
+API_PORT_BASE="${API_PORT_BASE:-9201}"
+DB="$DEVNET_DIR/node1/node-ui.db"
+MESSAGE_ID="devnet-issue-1579-$(date +%s)"
+
+fail() { echo "[#1579] FAIL: $*" >&2; exit 1; }
+cleanup() {
+  DB="$DB" MESSAGE_ID="$MESSAGE_ID" node --input-type=module <<'NODE' >/dev/null 2>&1 || true
+import Database from 'better-sqlite3';
+const db = new Database(process.env.DB);
+db.prepare('DELETE FROM protocol_outbox WHERE message_id = ?').run(process.env.MESSAGE_ID);
+db.close();
+NODE
+}
+trap cleanup EXIT
+
+[[ -f "$DB" ]] || fail "node1 database missing; start a devnet first"
+. "$ROOT/scripts/devnet-lib.sh"
+
+status2="$(body_of "$(api 2 GET /api/status)")"
+peer2="$(field "$status2" peerId)"
+[[ -n "$peer2" ]] || fail "node2 peerId unavailable"
+
+DB="$DB" PEER="$peer2" MESSAGE_ID="$MESSAGE_ID" node --input-type=module <<'NODE'
+import Database from 'better-sqlite3';
+import { encodeReliableEnvelope, PROTOCOL_MESSAGE } from './packages/core/dist/index.js';
+const now = Date.now();
+const payload = encodeReliableEnvelope({
+  messageId: process.env.MESSAGE_ID,
+  version: 1,
+  tsMs: now,
+  payload: new TextEncoder().encode('{"type":"chat","text":"#1579 probe"}'),
+});
+const db = new Database(process.env.DB);
+db.prepare(`INSERT INTO protocol_outbox
+  (peer_id, protocol, message_id, payload, attempts, first_failure_at,
+   last_attempt_at, next_attempt_at, last_error)
+  VALUES (?, ?, ?, ?, 1, ?, ?, ?, ?)`)
+  .run(process.env.PEER, PROTOCOL_MESSAGE, process.env.MESSAGE_ID,
+    Buffer.from(payload), now, now, now + 60 * 60 * 1000, 'devnet probe');
+db.close();
+NODE
+
+"$ROOT/scripts/devnet.sh" restart-node 2 >/dev/null
+for _ in $(seq 1 60); do
+  [[ "$(code_of "$(api 2 GET /api/status)")" == 200 ]] && break
+  sleep 1
+done
+[[ "$(code_of "$(api 2 GET /api/status)")" == 200 ]] || fail "node2 did not restart"
+
+connect="$(api 1 POST /api/connect "{\"peerId\":\"$peer2\"}")"
+[[ "$(code_of "$connect")" == 200 ]] || fail "node1 could not reconnect to node2"
+sleep 5
+
+row="$(DB="$DB" MESSAGE_ID="$MESSAGE_ID" node --input-type=module <<'NODE'
+import Database from 'better-sqlite3';
+const db = new Database(process.env.DB, { readonly: true });
+const row = db.prepare('SELECT attempts, next_attempt_at FROM protocol_outbox WHERE message_id = ?').get(process.env.MESSAGE_ID);
+process.stdout.write(row ? JSON.stringify(row) : 'missing');
+db.close();
+NODE
+)"
+[[ "$row" != missing ]] || fail "cooling row was drained on connection-open"
+attempts="$(field "$row" attempts)"
+[[ "$attempts" == 1 ]] || fail "connection-open advanced attempts to $attempts"
+echo "[#1579] PASS: reconnect preserved the cooling-down outbox row"


### PR DESCRIPTION
## Summary

- remove connection-open as a Universal Messenger outbox trigger
- keep the periodic due-time scheduler as the only automatic retry path
- preserve connection admission, reverse-path enrichment, pending sender-key delivery, and sync scheduling
- update the real lifecycle regression to prove connection events do not wake the outbox

Closes #1579

## Verification

- `pnpm run build:runtime:packages`
- focused Vitest process was started but did not terminate cleanly in this environment; the lifecycle regression remains part of the agent suite for CI
