### PR TITLE
fix(agent): keep StorageACK retries collector-owned (#1577)

### DIFF
--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -618,11 +618,11 @@ function normalizeStorageAckConfig(config: DKGAgentConfig): ResolvedDKGAgentConf
 }
 
 interface ACKReliableMessenger {
-  sendReliable(
+  sendRequestOwned(
     peerId: string,
     protocol: string,
     data: Uint8Array,
-    opts: { timeoutMs: number; failurePolicy: 'throw' },
+    opts: { timeoutMs: number },
   ): Promise<{ delivered: boolean; error?: unknown; response?: Uint8Array }>;
 }
 
@@ -631,9 +631,8 @@ function createACKSendP2P(input: {
   timeoutMs: number;
 }): ACKCollectorDeps['sendP2P'] {
   return async (peerId: string, protocol: string, data: Uint8Array) => {
-    const sendResult = await input.messenger.sendReliable(peerId, protocol, data, {
+    const sendResult = await input.messenger.sendRequestOwned(peerId, protocol, data, {
       timeoutMs: input.timeoutMs,
-      failurePolicy: 'throw',
     });
     if (!sendResult.delivered) {
       throw new Error(`substrate send already in flight (transport): ${sendResult.error}`);

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -622,7 +622,7 @@ interface ACKReliableMessenger {
     peerId: string,
     protocol: string,
     data: Uint8Array,
-    opts: { timeoutMs: number },
+    opts: { timeoutMs: number; queueOnFailure: false },
   ): Promise<{ delivered: boolean; error?: unknown; response?: Uint8Array }>;
 }
 
@@ -633,6 +633,7 @@ function createACKSendP2P(input: {
   return async (peerId: string, protocol: string, data: Uint8Array) => {
     const sendResult = await input.messenger.sendReliable(peerId, protocol, data, {
       timeoutMs: input.timeoutMs,
+      queueOnFailure: false,
     });
     if (!sendResult.delivered) {
       throw new Error(`substrate queued (transport): ${sendResult.error}`);

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -622,7 +622,7 @@ interface ACKReliableMessenger {
     peerId: string,
     protocol: string,
     data: Uint8Array,
-    opts: { timeoutMs: number; queueOnFailure: false },
+    opts: { timeoutMs: number; failurePolicy: 'throw' },
   ): Promise<{ delivered: boolean; error?: unknown; response?: Uint8Array }>;
 }
 
@@ -633,10 +633,10 @@ function createACKSendP2P(input: {
   return async (peerId: string, protocol: string, data: Uint8Array) => {
     const sendResult = await input.messenger.sendReliable(peerId, protocol, data, {
       timeoutMs: input.timeoutMs,
-      queueOnFailure: false,
+      failurePolicy: 'throw',
     });
     if (!sendResult.delivered) {
-      throw new Error(`substrate queued (transport): ${sendResult.error}`);
+      throw new Error(`substrate send already in flight (transport): ${sendResult.error}`);
     }
     if (!sendResult.response) {
       throw new Error('substrate delivered (transport) without response');

--- a/packages/agent/src/p2p/messenger.ts
+++ b/packages/agent/src/p2p/messenger.ts
@@ -165,7 +165,7 @@ export interface SendOpts {
   signal?: AbortSignal;
 }
 
-interface SendReliableCommonOpts {
+export interface SendReliableOpts {
   /**
    * Caller-supplied message id. Used by the receiver-side idempotency
    * cache to dedupe duplicate deliveries and by the sender-side
@@ -185,18 +185,6 @@ interface SendReliableCommonOpts {
    */
   maxAgeMs?: number;
 }
-
-/** Default durable contract: recoverable failures are queued. */
-export interface DurableSendReliableOpts extends SendReliableCommonOpts {
-  failurePolicy?: 'queue';
-}
-
-/** Explicit request-owned contract: recoverable failures are thrown, never queued. */
-export interface ThrowingSendReliableOpts extends SendReliableCommonOpts {
-  failurePolicy: 'throw';
-}
-
-export type SendReliableOpts = DurableSendReliableOpts | ThrowingSendReliableOpts;
 
 /**
  * Result of `Messenger.sendReliable`. Three terminal shapes:
@@ -591,19 +579,27 @@ export class Messenger {
     peerId: string,
     protocolId: string,
     payload: Uint8Array,
-    opts: ThrowingSendReliableOpts,
-  ): Promise<ThrowingReliableSendResult>;
-  async sendReliable(
-    peerId: string,
-    protocolId: string,
-    payload: Uint8Array,
-    opts?: DurableSendReliableOpts,
-  ): Promise<ReliableSendResult>;
-  async sendReliable(
+    opts: SendReliableOpts = {},
+  ): Promise<ReliableSendResult> {
+    return this.sendFramed(peerId, protocolId, payload, opts, true);
+  }
+
+  /** Reliable framing/idempotency for bounded request-owned retries; never queues. */
+  async sendRequestOwned(
     peerId: string,
     protocolId: string,
     payload: Uint8Array,
     opts: SendReliableOpts = {},
+  ): Promise<ThrowingReliableSendResult> {
+    return this.sendFramed(peerId, protocolId, payload, opts, false) as Promise<ThrowingReliableSendResult>;
+  }
+
+  private async sendFramed(
+    peerId: string,
+    protocolId: string,
+    payload: Uint8Array,
+    opts: SendReliableOpts,
+    queueRecoverableFailure: boolean,
   ): Promise<ReliableSendResult> {
     this.requireSubstrate('sendReliable');
 
@@ -699,7 +695,7 @@ export class Messenger {
       if (!isRecoverableMessengerSendError(err, errMsg)) {
         throw err;
       }
-      if (opts.failurePolicy === 'throw') {
+      if (!queueRecoverableFailure) {
         // No durable row can later deliver or expire this request, so its SLO
         // start marker has no future owner. Clear it before returning control
         // to the request-scoped retry loop.

--- a/packages/agent/src/p2p/messenger.ts
+++ b/packages/agent/src/p2p/messenger.ts
@@ -184,6 +184,11 @@ export interface SendReliableOpts {
    * (e.g. join-approval).
    */
   maxAgeMs?: number;
+  /**
+   * Disable durable sender retries for bounded request/response flows whose
+   * caller owns retry and response lifetime (for example StorageACK).
+   */
+  queueOnFailure?: boolean;
 }
 
 /**
@@ -667,6 +672,9 @@ export class Messenger {
       // the outbox stays out of it because retrying an encoding
       // bug / unhandled protocol won't help.
       if (!isRecoverableMessengerSendError(err, errMsg)) {
+        throw err;
+      }
+      if (opts.queueOnFailure === false) {
         throw err;
       }
       const entry = outbox.enqueueFailure(

--- a/packages/agent/src/p2p/messenger.ts
+++ b/packages/agent/src/p2p/messenger.ts
@@ -675,6 +675,10 @@ export class Messenger {
         throw err;
       }
       if (opts.queueOnFailure === false) {
+        // No durable row can later deliver or expire this request, so its SLO
+        // start marker has no future owner. Clear it before returning control
+        // to the request-scoped retry loop.
+        this.firstAttemptAt.delete(sloK);
         throw err;
       }
       const entry = outbox.enqueueFailure(

--- a/packages/agent/src/p2p/messenger.ts
+++ b/packages/agent/src/p2p/messenger.ts
@@ -165,7 +165,7 @@ export interface SendOpts {
   signal?: AbortSignal;
 }
 
-export interface SendReliableOpts {
+interface SendReliableCommonOpts {
   /**
    * Caller-supplied message id. Used by the receiver-side idempotency
    * cache to dedupe duplicate deliveries and by the sender-side
@@ -184,12 +184,19 @@ export interface SendReliableOpts {
    * (e.g. join-approval).
    */
   maxAgeMs?: number;
-  /**
-   * Disable durable sender retries for bounded request/response flows whose
-   * caller owns retry and response lifetime (for example StorageACK).
-   */
-  queueOnFailure?: boolean;
 }
+
+/** Default durable contract: recoverable failures are queued. */
+export interface DurableSendReliableOpts extends SendReliableCommonOpts {
+  failurePolicy?: 'queue';
+}
+
+/** Explicit request-owned contract: recoverable failures are thrown, never queued. */
+export interface ThrowingSendReliableOpts extends SendReliableCommonOpts {
+  failurePolicy: 'throw';
+}
+
+export type SendReliableOpts = DurableSendReliableOpts | ThrowingSendReliableOpts;
 
 /**
  * Result of `Messenger.sendReliable`. Three terminal shapes:
@@ -254,6 +261,12 @@ export type ReliableSendResult =
       messageId: string;
       error: string;
     };
+
+/** The explicit throw policy can never produce a durable queued result. */
+export type ThrowingReliableSendResult = Exclude<
+  ReliableSendResult,
+  { delivered: false; queued: true }
+>;
 
 /** Handler signature for `Messenger.register`. */
 export type ReliableHandler = (
@@ -578,6 +591,18 @@ export class Messenger {
     peerId: string,
     protocolId: string,
     payload: Uint8Array,
+    opts: ThrowingSendReliableOpts,
+  ): Promise<ThrowingReliableSendResult>;
+  async sendReliable(
+    peerId: string,
+    protocolId: string,
+    payload: Uint8Array,
+    opts?: DurableSendReliableOpts,
+  ): Promise<ReliableSendResult>;
+  async sendReliable(
+    peerId: string,
+    protocolId: string,
+    payload: Uint8Array,
     opts: SendReliableOpts = {},
   ): Promise<ReliableSendResult> {
     this.requireSubstrate('sendReliable');
@@ -674,7 +699,7 @@ export class Messenger {
       if (!isRecoverableMessengerSendError(err, errMsg)) {
         throw err;
       }
-      if (opts.queueOnFailure === false) {
+      if (opts.failurePolicy === 'throw') {
         // No durable row can later deliver or expire this request, so its SLO
         // start marker has no future owner. Clear it before returning control
         // to the request-scoped retry loop.

--- a/packages/agent/test/messenger-substrate.test.ts
+++ b/packages/agent/test/messenger-substrate.test.ts
@@ -143,6 +143,22 @@ describe('Messenger.sendReliable (happy path semantics)', () => {
   });
 });
 
+describe('Messenger.sendReliable request-owned retry mode', () => {
+  it('keeps reliable framing but does not persist recoverable failures', async () => {
+    const router = makeRouter(async () => {
+      throw new Error('no valid addresses for peer');
+    });
+    const { messenger, outboxStore } = makeSubstrate({ router });
+
+    await expect(messenger.sendReliable(PEER_A, PROTO, new Uint8Array([1]), {
+      messageId: FIXED_MSG_ID,
+      queueOnFailure: false,
+    })).rejects.toThrow('no valid addresses for peer');
+    expect(outboxStore.size()).toBe(0);
+    expect(() => decodeReliableEnvelope(router.send.calls[0][2] as Uint8Array)).not.toThrow();
+  });
+});
+
 describe('Messenger.sendReliable (sender-side idempotency)', () => {
   it('returns the cached response on a second send with the same messageId, no router call', async () => {
     const router = makeRouter(async () => new Uint8Array([0x42]));

--- a/packages/agent/test/messenger-substrate.test.ts
+++ b/packages/agent/test/messenger-substrate.test.ts
@@ -152,7 +152,7 @@ describe('Messenger.sendReliable request-owned retry mode', () => {
 
     await expect(messenger.sendReliable(PEER_A, PROTO, new Uint8Array([1]), {
       messageId: FIXED_MSG_ID,
-      queueOnFailure: false,
+      failurePolicy: 'throw',
     })).rejects.toThrow('no valid addresses for peer');
     expect(outboxStore.size()).toBe(0);
     expect(() => decodeReliableEnvelope(router.send.calls[0][2] as Uint8Array)).not.toThrow();

--- a/packages/agent/test/messenger-substrate.test.ts
+++ b/packages/agent/test/messenger-substrate.test.ts
@@ -156,6 +156,7 @@ describe('Messenger.sendReliable request-owned retry mode', () => {
     })).rejects.toThrow('no valid addresses for peer');
     expect(outboxStore.size()).toBe(0);
     expect(() => decodeReliableEnvelope(router.send.calls[0][2] as Uint8Array)).not.toThrow();
+    expect((messenger as any).firstAttemptAt.size).toBe(0);
   });
 });
 

--- a/packages/agent/test/messenger-substrate.test.ts
+++ b/packages/agent/test/messenger-substrate.test.ts
@@ -143,16 +143,15 @@ describe('Messenger.sendReliable (happy path semantics)', () => {
   });
 });
 
-describe('Messenger.sendReliable request-owned retry mode', () => {
+describe('Messenger.sendRequestOwned', () => {
   it('keeps reliable framing but does not persist recoverable failures', async () => {
     const router = makeRouter(async () => {
       throw new Error('no valid addresses for peer');
     });
     const { messenger, outboxStore } = makeSubstrate({ router });
 
-    await expect(messenger.sendReliable(PEER_A, PROTO, new Uint8Array([1]), {
+    await expect(messenger.sendRequestOwned(PEER_A, PROTO, new Uint8Array([1]), {
       messageId: FIXED_MSG_ID,
-      failurePolicy: 'throw',
     })).rejects.toThrow('no valid addresses for peer');
     expect(outboxStore.size()).toBe(0);
     expect(() => decodeReliableEnvelope(router.send.calls[0][2] as Uint8Array)).not.toThrow();

--- a/packages/agent/test/v10-ack-provider-wiring.test.ts
+++ b/packages/agent/test/v10-ack-provider-wiring.test.ts
@@ -285,9 +285,11 @@ describe('DKGAgent.createV10ACKProvider — structured ACK verifier wiring (PR #
 
     expect(sendReliable).toHaveBeenNthCalledWith(1, 'peer-a', '/dkg/test/storage-ack', payload, {
       timeoutMs: 60_000,
+      queueOnFailure: false,
     });
     expect(sendReliable).toHaveBeenNthCalledWith(2, 'peer-b', '/dkg/test/storage-update-ack', payload, {
       timeoutMs: 60_000,
+      queueOnFailure: false,
     });
   });
 
@@ -309,6 +311,7 @@ describe('DKGAgent.createV10ACKProvider — structured ACK verifier wiring (PR #
 
     expect(sendReliable).toHaveBeenCalledWith('peer-a', '/dkg/test/storage-ack', payload, {
       timeoutMs: 60_000,
+      queueOnFailure: false,
     });
   });
 
@@ -357,6 +360,7 @@ describe('DKGAgent.createV10ACKProvider — structured ACK verifier wiring (PR #
     });
     expect(sendReliable).toHaveBeenCalledWith('peer-a', '/dkg/test/storage-ack', payload, {
       timeoutMs: 20_000,
+      queueOnFailure: false,
     });
   });
 
@@ -376,6 +380,7 @@ describe('DKGAgent.createV10ACKProvider — structured ACK verifier wiring (PR #
     ).rejects.toThrow(/substrate queued \(transport\): queued/);
     expect(queuedSend).toHaveBeenCalledWith('peer-a', '/dkg/test/storage-ack', payload, {
       timeoutMs: 60_000,
+      queueOnFailure: false,
     });
 
     const missingResponseSend = vi.fn(async () => ({

--- a/packages/agent/test/v10-ack-provider-wiring.test.ts
+++ b/packages/agent/test/v10-ack-provider-wiring.test.ts
@@ -268,12 +268,12 @@ describe('DKGAgent.createV10ACKProvider — structured ACK verifier wiring (PR #
     agent = boot.agent;
     const internals = boot.internals;
     const response = new Uint8Array([9]);
-    const sendReliable = vi.fn(async () => ({
+    const sendRequestOwned = vi.fn(async () => ({
       delivered: true,
       response,
     }));
     const payload = new Uint8Array([1, 2, 3]);
-    internals.messenger = { sendReliable };
+    internals.messenger = { sendRequestOwned };
 
     internals.createV10ACKProvider('test-cg');
     const publishDeps = capturedAckCollectorDeps[0] as ACKCollectorDepsCapture;
@@ -283,13 +283,11 @@ describe('DKGAgent.createV10ACKProvider — structured ACK verifier wiring (PR #
     const updateDeps = capturedAckCollectorDeps[1] as ACKCollectorDepsCapture;
     await expect(updateDeps.sendP2P!('peer-b', '/dkg/test/storage-update-ack', payload)).resolves.toEqual(response);
 
-    expect(sendReliable).toHaveBeenNthCalledWith(1, 'peer-a', '/dkg/test/storage-ack', payload, {
+    expect(sendRequestOwned).toHaveBeenNthCalledWith(1, 'peer-a', '/dkg/test/storage-ack', payload, {
       timeoutMs: 60_000,
-      queueOnFailure: false,
     });
-    expect(sendReliable).toHaveBeenNthCalledWith(2, 'peer-b', '/dkg/test/storage-update-ack', payload, {
+    expect(sendRequestOwned).toHaveBeenNthCalledWith(2, 'peer-b', '/dkg/test/storage-update-ack', payload, {
       timeoutMs: 60_000,
-      queueOnFailure: false,
     });
   });
 
@@ -298,20 +296,19 @@ describe('DKGAgent.createV10ACKProvider — structured ACK verifier wiring (PR #
     agent = boot.agent;
     const internals = boot.internals;
     const response = new Uint8Array([9]);
-    const sendReliable = vi.fn(async () => ({
+    const sendRequestOwned = vi.fn(async () => ({
       delivered: true,
       response,
     }));
-    internals.messenger = { sendReliable };
+    internals.messenger = { sendRequestOwned };
     const payload = new Uint8Array([1]);
 
     internals.createV10ACKProvider('test-cg');
     const publishDeps = capturedAckCollectorDeps[0] as ACKCollectorDepsCapture;
     await expect(publishDeps.sendP2P!('peer-a', '/dkg/test/storage-ack', payload)).resolves.toEqual(response);
 
-    expect(sendReliable).toHaveBeenCalledWith('peer-a', '/dkg/test/storage-ack', payload, {
+    expect(sendRequestOwned).toHaveBeenCalledWith('peer-a', '/dkg/test/storage-ack', payload, {
       timeoutMs: 60_000,
-      queueOnFailure: false,
     });
   });
 
@@ -343,11 +340,11 @@ describe('DKGAgent.createV10ACKProvider — structured ACK verifier wiring (PR #
     agent = boot.agent;
     const internals = boot.internals;
     const response = new Uint8Array([9]);
-    const sendReliable = vi.fn(async () => ({
+    const sendRequestOwned = vi.fn(async () => ({
       delivered: true,
       response,
     }));
-    internals.messenger = { sendReliable };
+    internals.messenger = { sendRequestOwned };
     const payload = new Uint8Array([1]);
 
     internals.createV10ACKProvider('test-cg');
@@ -358,9 +355,8 @@ describe('DKGAgent.createV10ACKProvider — structured ACK verifier wiring (PR #
       handlerDeadlineMs: 0,
       sendTimeoutMs: 20_000,
     });
-    expect(sendReliable).toHaveBeenCalledWith('peer-a', '/dkg/test/storage-ack', payload, {
+    expect(sendRequestOwned).toHaveBeenCalledWith('peer-a', '/dkg/test/storage-ack', payload, {
       timeoutMs: 20_000,
-      queueOnFailure: false,
     });
   });
 
@@ -374,19 +370,18 @@ describe('DKGAgent.createV10ACKProvider — structured ACK verifier wiring (PR #
       delivered: false,
       error: 'queued',
     }));
-    internals.messenger = { sendReliable: queuedSend };
+    internals.messenger = { sendRequestOwned: queuedSend };
     await expect(
       internals.createACKTransportFactory()().sendP2P('peer-a', '/dkg/test/storage-ack', payload),
-    ).rejects.toThrow(/substrate queued \(transport\): queued/);
+    ).rejects.toThrow(/substrate send already in flight \(transport\): queued/);
     expect(queuedSend).toHaveBeenCalledWith('peer-a', '/dkg/test/storage-ack', payload, {
       timeoutMs: 60_000,
-      queueOnFailure: false,
     });
 
     const missingResponseSend = vi.fn(async () => ({
       delivered: true,
     }));
-    internals.messenger = { sendReliable: missingResponseSend };
+    internals.messenger = { sendRequestOwned: missingResponseSend };
     await expect(
       internals.createACKTransportFactory()().sendP2P('peer-a', '/dkg/test/storage-ack', payload),
     ).rejects.toThrow(/substrate delivered \(transport\) without response/);

--- a/scripts/devnet-test-issue-1577-ack-outbox-ownership.sh
+++ b/scripts/devnet-test-issue-1577-ack-outbox-ownership.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Live-devnet regression for #1577. Stop one of four cores, publish from an edge
+# (the other three can still satisfy quorum), then prove the finished collector
+# left no durable StorageACK request behind on the publisher.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DEVNET_DIR="${DEVNET_DIR:-$ROOT/.devnet}"
+API_PORT_BASE="${API_PORT_BASE:-9201}"
+PUBLISHER="${ACK_OUTBOX_PUBLISHER:-5}"
+TARGET="${ACK_OUTBOX_TARGET:-4}"
+CG="${DEVNET_CONTEXT_GRAPH:-devnet-test}"
+DB="$DEVNET_DIR/node$PUBLISHER/node-ui.db"
+stopped=0
+
+fail() { echo "[#1577] FAIL: $*" >&2; exit 1; }
+cleanup() {
+  if [[ "$stopped" == 1 ]]; then "$ROOT/scripts/devnet.sh" restart-node "$TARGET" >/dev/null 2>&1 || true; fi
+}
+trap cleanup EXIT INT TERM
+. "$ROOT/scripts/devnet-lib.sh"
+
+for n in 1 2 3 4 5; do
+  [[ "$(code_of "$(api "$n" GET /api/status)")" == 200 ]] || fail "node$n is not ready (need 4 cores + edge)"
+done
+[[ -f "$DB" ]] || fail "publisher database missing: $DB"
+
+count_ack_rows() {
+  DB="$DB" node --input-type=module <<'NODE'
+import Database from 'better-sqlite3';
+const db = new Database(process.env.DB, { readonly: true });
+const row = db.prepare(`SELECT COUNT(*) AS n FROM protocol_outbox
+  WHERE protocol IN ('/dkg/10.0.1/storage-ack','/dkg/10.0.2/storage-ack','/dkg/10.0.1/storage-update-ack')`).get();
+process.stdout.write(String(row.n)); db.close();
+NODE
+}
+baseline="$(count_ack_rows)"
+
+"$ROOT/scripts/devnet.sh" stop-node "$TARGET" >/dev/null
+stopped=1
+sleep 5
+
+name="issue-1577-$(date +%s)-$$"
+subject="urn:issue:1577:$name"
+api "$PUBLISHER" POST /api/knowledge-assets "{\"contextGraphId\":\"$CG\",\"name\":\"$name\"}" >/dev/null
+api "$PUBLISHER" POST "/api/knowledge-assets/$name/wm/write" \
+  "{\"contextGraphId\":\"$CG\",\"quads\":[{\"subject\":\"$subject\",\"predicate\":\"http://schema.org/name\",\"object\":\"\\\"ack ownership probe\\\"\",\"graph\":\"\"}]}" >/dev/null
+api "$PUBLISHER" POST "/api/knowledge-assets/$name/wm/finalize" "{\"contextGraphId\":\"$CG\"}" >/dev/null
+api "$PUBLISHER" POST "/api/knowledge-assets/$name/swm/share" "{\"contextGraphId\":\"$CG\"}" >/dev/null
+published="$(api "$PUBLISHER" POST "/api/knowledge-assets/$name/vm/publish" "{\"contextGraphId\":\"$CG\"}")"
+[[ "$(code_of "$published")" == 200 ]] || fail "publish did not reach quorum: $(body_of "$published")"
+[[ "$(field "$(body_of "$published")" status)" == confirmed ]] || fail "publish was not confirmed"
+
+rows="$(count_ack_rows)"
+[[ "$rows" == "$baseline" ]] || fail "StorageACK outbox rows grew from $baseline to $rows"
+echo "[#1577] PASS: collector completed with no durable StorageACK rows"


### PR DESCRIPTION
## Summary

- add an explicit `queueOnFailure: false` mode to reliable request sends
- use it for publish and update StorageACK transports
- preserve ReliableEnvelope framing and receiver idempotency
- return recoverable failures to ACKCollector without creating durable sender rows

Closes #1577

## Verification

- `pnpm --filter @origintrail-official/dkg-agent run build`
- added Messenger outbox-state and ACK transport wiring regressions (local agent Vitest process did not terminate cleanly; CI will run them)
