### PR TITLE
fix(cli): reject unclaimable async publish jobs (#1576)

### DIFF
--- a/packages/cli/src/daemon/handle-request.ts
+++ b/packages/cli/src/daemon/handle-request.ts
@@ -99,7 +99,7 @@ import {
   slotEntryPoint,
   CLI_NPM_PACKAGE,
 } from '../config.js';
-import { createPublisherControlFromStore, startPublisherRuntimeIfEnabled, type PublisherRuntime } from '../publisher-runner.js';
+import { createPublisherControlFromStore, startPublisherRuntimeIfEnabled, type AsyncPublisherAvailability, type PublisherRuntime } from '../publisher-runner.js';
 import { createCatchupRunner, type CatchupJobResult, type CatchupRunner } from '../catchup-runner.js';
 import { loadTokens, httpAuthGuard, extractBearerToken } from '../auth.js';
 import { ExtractionPipelineRegistry } from '@origintrail-official/dkg-core';
@@ -365,6 +365,7 @@ export async function handleRequest(
   admission: AdmissionStatsView,
   emitMemoryGraphChanged?: (event: MemoryGraphChangedEvent) => void,
   emitNotification?: (event: NotificationSseEvent) => void,
+  publisherAvailability?: AsyncPublisherAvailability,
 ): Promise<void> {
   const url = new URL(req.url ?? "/", `http://${req.headers.host}`);
   const path = url.pathname;
@@ -381,6 +382,7 @@ export async function handleRequest(
     agent,
     publisherControl,
     publisherRuntime,
+    publisherAvailability,
     config,
     startedAt,
     dashDb,

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -148,7 +148,7 @@ import {
 import { resolveOtelSignals, resolveLogExporterMode, isUnknownLogExporter } from '../telemetry-config.js';
 import { createDaemonLogSink } from './log-sink.js';
 import { startRpcUsageTelemetry } from './rpc-usage-log.js';
-import { createPublicSnapshotStore, createPublisherControlFromStore, startPublisherRuntimeIfEnabled, type PublisherRuntime } from '../publisher-runner.js';
+import { createPublicSnapshotStore, createPublisherControlFromStore, resolveAsyncPublisherAvailability, startPublisherRuntimeIfEnabled, type AsyncPublisherAvailability, type PublisherRuntime } from '../publisher-runner.js';
 import { createCatchupRunner, type CatchupJobResult, type CatchupRunner } from '../catchup-runner.js';
 import { loadTokens, httpAuthGuard } from '../auth.js';
 import { ExtractionPipelineRegistry } from '@origintrail-official/dkg-core';
@@ -1717,6 +1717,11 @@ export async function runDaemonInner(
   });
 
   let publisherRuntime: PublisherRuntime | null = null;
+  let publisherAvailability: AsyncPublisherAvailability = resolveAsyncPublisherAvailability({
+    config,
+    runtime: null,
+    lifecycleReason: config.publisher?.enabled ? 'publisher_starting' : 'publisher_disabled',
+  });
   // Holds the running async-promote worker lifecycle (PR #3 of the
   // async-promote-queue series). Initialised in `startPostApiPublishing`
   // after the API is up so a recoverOnStartup hiccup never blocks boot;
@@ -1988,7 +1993,17 @@ export async function runDaemonInner(
             log,
           });
           publisherRuntime = runtime;
+          publisherAvailability = resolveAsyncPublisherAvailability({
+            config,
+            runtime,
+            ...(runtime ? {} : { lifecycleReason: 'no_publisher_wallets' as const }),
+          });
         } catch (err: any) {
+          publisherAvailability = resolveAsyncPublisherAvailability({
+            config,
+            runtime: null,
+            lifecycleReason: 'publisher_startup_failed',
+          });
           log(`Async publisher startup failed: ${err?.message ?? String(err)}`);
         }
       })();
@@ -3369,6 +3384,7 @@ export async function runDaemonInner(
         admissionStats,
         emitMemoryGraphChanged,
         emitNotification,
+        publisherAvailability,
       );
     } catch (err: any) {
       // Single top-level error→HTTP mapping (in http-utils.ts

--- a/packages/cli/src/daemon/routes/context.ts
+++ b/packages/cli/src/daemon/routes/context.ts
@@ -16,7 +16,7 @@ import type {
   OperationTracker,
 } from '@origintrail-official/dkg-node-ui';
 import type { DkgConfig, loadNetworkConfig } from '../../config.js';
-import type { createPublisherControlFromStore, PublisherRuntime } from '../../publisher-runner.js';
+import type { AsyncPublisherAvailability, createPublisherControlFromStore, PublisherRuntime } from '../../publisher-runner.js';
 import type { ExtractionStatusRecord } from '../../extraction-status.js';
 import type { FileStore } from '../../file-store.js';
 import type { VectorStore, EmbeddingProvider } from '../../vector-store.js';
@@ -60,6 +60,8 @@ export interface RequestContext {
   agent: DKGAgent;
   publisherControl: ReturnType<typeof createPublisherControlFromStore>;
   publisherRuntime: PublisherRuntime | null;
+  /** Lifecycle-owned publisher state; optional for direct route embeddings/tests. */
+  publisherAvailability?: AsyncPublisherAvailability;
   config: DkgConfig;
   startedAt: number;
   dashDb: DashboardDB;

--- a/packages/cli/src/daemon/routes/epcis.ts
+++ b/packages/cli/src/daemon/routes/epcis.ts
@@ -103,7 +103,7 @@ import {
   slotEntryPoint,
   CLI_NPM_PACKAGE,
 } from '../../config.js';
-import { createPublisherControlFromStore, startPublisherRuntimeIfEnabled, type PublisherRuntime } from '../../publisher-runner.js';
+import { createPublisherControlFromStore, resolveAsyncPublisherAvailability, startPublisherRuntimeIfEnabled, type PublisherRuntime } from '../../publisher-runner.js';
 import { createCatchupRunner, type CatchupJobResult, type CatchupRunner } from '../../catchup-runner.js';
 import { loadTokens, httpAuthGuard, extractBearerToken } from '../../auth.js';
 import { ExtractionPipelineRegistry } from '@origintrail-official/dkg-core';
@@ -490,16 +490,24 @@ export async function handleEpcisRoutes(ctx: RequestContext): Promise<void> {
 
   // POST /api/epcis/capture  { contextGraphId?, subGraphName?, epcisDocument, publishOptions? }
   if (req.method === "POST" && path === "/api/epcis/capture") {
-    if (!config.publisher?.enabled) {
+    const publisherAvailability = resolveAsyncPublisherAvailability({
+      config,
+      runtime: publisherRuntime,
+      lifecycleAvailability: ctx.publisherAvailability,
+    });
+    if (!publisherAvailability.available && publisherAvailability.reason === 'publisher_disabled') {
       return jsonResponse(res, 503, {
         error: "PublisherDisabled",
         message: "Async EPCIS capture requires publisher.enabled=true",
       });
     }
-    if (!publisherRuntime || publisherRuntime.walletIds.length === 0) {
+    if (!publisherAvailability.available) {
       return jsonResponse(res, 503, {
         error: "PublisherUnavailable",
         message: "Async EPCIS capture requires the publisher runtime to be running with at least one configured publisher wallet",
+        reason: publisherAvailability.reason,
+        retryable: publisherAvailability.retryable,
+        operatorActionRequired: publisherAvailability.operatorActionRequired,
       });
     }
     const body = await readBody(req);

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -1347,6 +1347,17 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
     // to 400 (parity with the legacy publish path).
     if (layer === "vm" && verb === "publish-async") {
       try {
+        if (!ctx.publisherRuntime || ctx.publisherRuntime.wallets.length === 0) {
+          const reason = !ctx.publisherRuntime
+            ? (ctx.config.publisher?.enabled ? "publisher_startup_failed" : "publisher_disabled")
+            : "no_publisher_wallets";
+          return jsonResponse(res, 503, {
+            code: "async_publisher_unavailable",
+            error: "The asynchronous publisher cannot accept jobs on this node.",
+            reason,
+            retryable: true,
+          });
+        }
         const opts = resolveStandaloneVmPublishOptions(ctx, parsed);
         if (opts === null) return;
         const publishOptions = opts;

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -49,6 +49,7 @@ import {
   SMALL_BODY_BYTES,
 } from "../http-utils.js";
 import { validatePreSignedAuthorAttestation } from "./memory.js";
+import { resolveAsyncPublisherAvailability } from "../../publisher-runner.js";
 import { recordAssertionActivity, recordConvictionCostCovered } from "../activity-notification.js";
 import {
   handleKaImportArtifactResolve,
@@ -1347,16 +1348,18 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
     // to 400 (parity with the legacy publish path).
     if (layer === "vm" && verb === "publish-async") {
       try {
-        if (!ctx.publisherRuntime || ctx.publisherRuntime.wallets.length === 0) {
-          const reason = !ctx.publisherRuntime
-            ? (ctx.config.publisher?.enabled ? "publisher_startup_failed" : "publisher_disabled")
-            : "no_publisher_wallets";
+        const publisherAvailability = resolveAsyncPublisherAvailability({
+          config: ctx.config,
+          runtime: ctx.publisherRuntime,
+          lifecycleAvailability: ctx.publisherAvailability,
+        });
+        if (!publisherAvailability.available) {
           return jsonResponse(res, 503, {
             code: "async_publisher_unavailable",
             error: "The asynchronous publisher cannot accept jobs on this node.",
-            reason,
-            retryable: reason === "publisher_startup_failed",
-            operatorActionRequired: reason !== "publisher_startup_failed",
+            reason: publisherAvailability.reason,
+            retryable: publisherAvailability.retryable,
+            operatorActionRequired: publisherAvailability.operatorActionRequired,
           });
         }
         const opts = resolveStandaloneVmPublishOptions(ctx, parsed);

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -1355,7 +1355,8 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
             code: "async_publisher_unavailable",
             error: "The asynchronous publisher cannot accept jobs on this node.",
             reason,
-            retryable: true,
+            retryable: reason === "publisher_startup_failed",
+            operatorActionRequired: reason !== "publisher_startup_failed",
           });
         }
         const opts = resolveStandaloneVmPublishOptions(ctx, parsed);

--- a/packages/cli/src/publisher-runner.ts
+++ b/packages/cli/src/publisher-runner.ts
@@ -24,6 +24,50 @@ export interface PublisherRuntimeWallet {
   readonly identityId: bigint;
 }
 
+export type AsyncPublisherUnavailableReason =
+  | 'publisher_disabled'
+  | 'publisher_starting'
+  | 'no_publisher_wallets'
+  | 'publisher_startup_failed';
+
+export type AsyncPublisherAvailability =
+  | { available: true }
+  | {
+      available: false;
+      reason: AsyncPublisherUnavailableReason;
+      retryable: boolean;
+      operatorActionRequired: boolean;
+    };
+
+/**
+ * Canonical readiness boundary for every async-ingress route. Lifecycle may
+ * supply an explicit starting/failure state; otherwise the runtime/config
+ * shape is classified consistently for direct route tests and embedded users.
+ */
+export function resolveAsyncPublisherAvailability(args: {
+  config: DkgConfig;
+  runtime: PublisherRuntime | null;
+  lifecycleReason?: AsyncPublisherUnavailableReason;
+  lifecycleAvailability?: AsyncPublisherAvailability;
+}): AsyncPublisherAvailability {
+  if (args.lifecycleAvailability) return args.lifecycleAvailability;
+  if (args.runtime?.wallets.length) return { available: true };
+  const reason = args.lifecycleReason
+    ?? (args.runtime
+      ? 'no_publisher_wallets'
+      : args.config.publisher?.enabled
+        ? 'publisher_startup_failed'
+        : 'publisher_disabled');
+  return {
+    available: false,
+    reason,
+    // Only the in-progress state can recover from the same client retry without
+    // operator/config/daemon intervention.
+    retryable: reason === 'publisher_starting',
+    operatorActionRequired: reason !== 'publisher_starting',
+  };
+}
+
 export interface PublisherInspector {
   readonly publisher: AsyncLiftPublisher;
   readonly stop: () => Promise<void>;

--- a/packages/cli/src/publisher-runner.ts
+++ b/packages/cli/src/publisher-runner.ts
@@ -51,7 +51,7 @@ export function resolveAsyncPublisherAvailability(args: {
   lifecycleAvailability?: AsyncPublisherAvailability;
 }): AsyncPublisherAvailability {
   if (args.lifecycleAvailability) return args.lifecycleAvailability;
-  if (args.runtime?.wallets.length) return { available: true };
+  if (args.runtime?.walletIds.length) return { available: true };
   const reason = args.lifecycleReason
     ?? (args.runtime
       ? 'no_publisher_wallets'

--- a/packages/cli/test/helpers/live-daemon.ts
+++ b/packages/cli/test/helpers/live-daemon.ts
@@ -53,6 +53,8 @@ function uniquePort(base: number): number {
 
 export interface StartDaemonOpts {
   authEnabled?: boolean;
+  /** Enable a real async publisher and seed its wallet file. */
+  publisherEnabled?: boolean;
   /** Extra keys merged into config.json (e.g. preset contextGraphs). */
   extraConfig?: Record<string, unknown>;
   readyTimeoutMs?: number;
@@ -89,6 +91,7 @@ export async function startLiveDaemon(opts: StartDaemonOpts = {}): Promise<LiveD
       auth: { enabled: authEnabled },
       store: { backend: 'oxigraph-worker', options: { path: join(home, 'store.nq') } },
       chain: { type: 'evm', rpcUrl, hubAddress, chainId: 'evm:31337' },
+      ...(opts.publisherEnabled ? { publisher: { enabled: true } } : {}),
       contextGraphs: [],
       ...(opts.extraConfig ?? {}),
     }),
@@ -102,6 +105,13 @@ export async function startLiveDaemon(opts: StartDaemonOpts = {}): Promise<LiveD
     JSON.stringify({ wallets: [{ address: coreOp.address, privateKey: coreOp.privateKey }] }, null, 2) + '\n',
     { mode: 0o600 },
   );
+  if (opts.publisherEnabled) {
+    await writeFile(
+      join(home, 'publisher-wallets.json'),
+      JSON.stringify({ wallets: [{ address: coreOp.address, privateKey: coreOp.privateKey }] }, null, 2) + '\n',
+      { mode: 0o600 },
+    );
+  }
 
   const childEnv: Record<string, string | undefined> = {
     ...process.env,
@@ -149,6 +159,30 @@ export async function startLiveDaemon(opts: StartDaemonOpts = {}): Promise<LiveD
     daemon.token =
       raw.split('\n').map((l) => l.trim()).find((l) => l.length > 0 && !l.startsWith('#')) ?? null;
     if (!daemon.token) throw new Error('auth enabled but no token written');
+  }
+  if (opts.publisherEnabled) {
+    // `/api/status` becomes ready before the zero-delay publisher startup task.
+    // Poll the real async-ingress gate so tests never race `publisher_starting`.
+    for (let i = 0; i < 60; i += 1) {
+      const res = await fetch(
+        `${daemon.base}/api/knowledge-assets/publisher-readiness/wm/probe/vm/publish-async`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            ...(daemon.token ? { Authorization: `Bearer ${daemon.token}` } : {}),
+          },
+          body: '{}',
+        },
+      );
+      const body = await res.json().catch(() => ({})) as { code?: string; reason?: string };
+      if (body.code !== 'async_publisher_unavailable') break;
+      if (body.reason !== 'publisher_starting') {
+        throw new Error(`Async publisher failed readiness: ${body.reason ?? res.status}`);
+      }
+      await sleep(100);
+      if (i === 59) throw new Error('Async publisher did not become ready in time');
+    }
   }
   return daemon;
 }

--- a/packages/cli/test/knowledge-assets-1116-share-errors.test.ts
+++ b/packages/cli/test/knowledge-assets-1116-share-errors.test.ts
@@ -397,9 +397,27 @@ describe('#1116 share/seal route error mapping (fake agent)', () => {
     expect(res.body).toMatchObject({
       code: 'async_publisher_unavailable',
       reason: 'publisher_disabled',
-      retryable: true,
+      retryable: false,
+      operatorActionRequired: true,
     });
     expect(resolved).toBe(0);
+    expect(enqueued).toBe(0);
+  });
+
+  it('vm/publish-async treats an empty-wallet runtime as operator-actionable', async () => {
+    let enqueued = 0;
+    await startWith({}, {}, {}, {
+      enqueueKnowledgeAssetVmPublish: async () => { enqueued += 1; },
+    }, { wallets: [] });
+
+    const res = await post('vm/publish-async', { contextGraphId: CG_ID });
+    expect(res.status).toBe(503);
+    expect(res.body).toMatchObject({
+      code: 'async_publisher_unavailable',
+      reason: 'no_publisher_wallets',
+      retryable: false,
+      operatorActionRequired: true,
+    });
     expect(enqueued).toBe(0);
   });
 

--- a/packages/cli/test/knowledge-assets-1116-share-errors.test.ts
+++ b/packages/cli/test/knowledge-assets-1116-share-errors.test.ts
@@ -62,6 +62,7 @@ describe('#1116 share/seal route error mapping (fake agent)', () => {
     agentOverrides: Record<string, unknown> = {},
     routeOverrides: { requestToken?: string; requestAgentAddress?: string } = {},
     publisherControl: Record<string, unknown> = {},
+    publisherRuntime: unknown = { wallets: [{ address: '0x1111111111111111111111111111111111111111' }] },
   ) {
     const agent = {
       async listContextGraphs() {
@@ -90,7 +91,7 @@ describe('#1116 share/seal route error mapping (fake agent)', () => {
           res,
           agent,
           publisherControl,
-          publisherRuntime: null,
+          publisherRuntime,
           config: {},
           startedAt: Date.now(),
           dashDb: { insertNotification: () => 1 },
@@ -380,6 +381,26 @@ describe('#1116 share/seal route error mapping (fake agent)', () => {
     expect(res.body.code).toBe('PUBLISH_INTENT_STALE');
     expect(String(res.body.error)).toContain('re-share');
     expect(enqueueCalls).toBe(0);
+  });
+
+  it('vm/publish-async rejects before persisting when no runtime can claim jobs', async () => {
+    let resolved = 0;
+    let enqueued = 0;
+    await startWith({}, {
+      resolveFinalizedAssertionVmPublishIntent: async () => { resolved += 1; },
+    }, {}, {
+      enqueueKnowledgeAssetVmPublish: async () => { enqueued += 1; },
+    }, null);
+
+    const res = await post('vm/publish-async', { contextGraphId: CG_ID });
+    expect(res.status).toBe(503);
+    expect(res.body).toMatchObject({
+      code: 'async_publisher_unavailable',
+      reason: 'publisher_disabled',
+      retryable: true,
+    });
+    expect(resolved).toBe(0);
+    expect(enqueued).toBe(0);
   });
 
   it('vm/publish-async rejects a missing real share snapshot before enqueue', async () => {

--- a/packages/cli/test/knowledge-assets-1116-share-errors.test.ts
+++ b/packages/cli/test/knowledge-assets-1116-share-errors.test.ts
@@ -62,7 +62,12 @@ describe('#1116 share/seal route error mapping (fake agent)', () => {
     agentOverrides: Record<string, unknown> = {},
     routeOverrides: { requestToken?: string; requestAgentAddress?: string } = {},
     publisherControl: Record<string, unknown> = {},
-    publisherRuntime: unknown = { wallets: [{ address: '0x1111111111111111111111111111111111111111' }] },
+    publisherRuntime: unknown = {
+      walletIds: ['0x1111111111111111111111111111111111111111'],
+      wallets: [{ address: '0x1111111111111111111111111111111111111111' }],
+    },
+    config: Record<string, unknown> = {},
+    publisherAvailability?: unknown,
   ) {
     const agent = {
       async listContextGraphs() {
@@ -92,7 +97,8 @@ describe('#1116 share/seal route error mapping (fake agent)', () => {
           agent,
           publisherControl,
           publisherRuntime,
-          config: {},
+          config,
+          publisherAvailability,
           startedAt: Date.now(),
           dashDb: { insertNotification: () => 1 },
           opWallets: {},
@@ -408,7 +414,7 @@ describe('#1116 share/seal route error mapping (fake agent)', () => {
     let enqueued = 0;
     await startWith({}, {}, {}, {
       enqueueKnowledgeAssetVmPublish: async () => { enqueued += 1; },
-    }, { wallets: [] });
+    }, { walletIds: [], wallets: [] });
 
     const res = await post('vm/publish-async', { contextGraphId: CG_ID });
     expect(res.status).toBe(503);
@@ -419,6 +425,35 @@ describe('#1116 share/seal route error mapping (fake agent)', () => {
       operatorActionRequired: true,
     });
     expect(enqueued).toBe(0);
+  });
+
+  it('vm/publish-async uses lifecycle no-wallet state when the runtime is null', async () => {
+    let enqueued = 0;
+    await startWith({}, {}, {}, {
+      enqueueKnowledgeAssetVmPublish: async () => { enqueued += 1; },
+    }, null, { publisher: { enabled: true } }, {
+      available: false,
+      reason: 'no_publisher_wallets',
+      retryable: false,
+      operatorActionRequired: true,
+    });
+
+    const res = await post('vm/publish-async', { contextGraphId: CG_ID });
+    expect(res.status).toBe(503);
+    expect(res.body).toMatchObject({
+      reason: 'no_publisher_wallets', retryable: false, operatorActionRequired: true,
+    });
+    expect(enqueued).toBe(0);
+  });
+
+  it('vm/publish-async classifies an unknown startup failure as operator-actionable', async () => {
+    await startWith({}, {}, {}, {}, null, { publisher: { enabled: true } });
+
+    const res = await post('vm/publish-async', { contextGraphId: CG_ID });
+    expect(res.status).toBe(503);
+    expect(res.body).toMatchObject({
+      reason: 'publisher_startup_failed', retryable: false, operatorActionRequired: true,
+    });
   });
 
   it('vm/publish-async rejects a missing real share snapshot before enqueue', async () => {

--- a/packages/cli/test/publisher-availability.test.ts
+++ b/packages/cli/test/publisher-availability.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { resolveAsyncPublisherAvailability, type PublisherRuntime } from '../src/publisher-runner.js';
+
+const runtime = (wallets: unknown[]): PublisherRuntime => ({
+  wallets,
+  walletIds: wallets.map((_, index) => String(index)),
+} as unknown as PublisherRuntime);
+
+describe('resolveAsyncPublisherAvailability', () => {
+  it('classifies permanent configuration states as operator-actionable', () => {
+    expect(resolveAsyncPublisherAvailability({ config: {}, runtime: null })).toMatchObject({
+      available: false, reason: 'publisher_disabled', retryable: false, operatorActionRequired: true,
+    });
+    expect(resolveAsyncPublisherAvailability({
+      config: { publisher: { enabled: true } } as any,
+      runtime: runtime([]),
+    })).toMatchObject({
+      available: false, reason: 'no_publisher_wallets', retryable: false, operatorActionRequired: true,
+    });
+    expect(resolveAsyncPublisherAvailability({
+      config: { publisher: { enabled: true } } as any,
+      runtime: null,
+      lifecycleReason: 'publisher_startup_failed',
+    })).toMatchObject({
+      available: false, reason: 'publisher_startup_failed', retryable: false, operatorActionRequired: true,
+    });
+  });
+
+  it('marks only an in-progress startup as retryable and a funded runtime as ready', () => {
+    expect(resolveAsyncPublisherAvailability({
+      config: { publisher: { enabled: true } } as any,
+      runtime: null,
+      lifecycleReason: 'publisher_starting',
+    })).toMatchObject({
+      available: false, reason: 'publisher_starting', retryable: true, operatorActionRequired: false,
+    });
+    expect(resolveAsyncPublisherAvailability({ config: {}, runtime: runtime([{}]) })).toEqual({ available: true });
+  });
+});

--- a/packages/cli/test/source-worker-daemon-client.test.ts
+++ b/packages/cli/test/source-worker-daemon-client.test.ts
@@ -17,7 +17,7 @@ describe('source worker daemon client (real daemon)', () => {
   let daemon: LiveDaemon;
 
   beforeAll(async () => {
-    daemon = await startLiveDaemon();
+    daemon = await startLiveDaemon({ publisherEnabled: true });
     const created = await postJson(daemon, '/api/context-graph/create', { id: CG, name: CG, accessPolicy: 0 });
     expect(created.status, `CG create failed: ${JSON.stringify(created.body)}`).toBeLessThan(300);
   }, 120_000);

--- a/packages/cli/test/source-worker-runner.test.ts
+++ b/packages/cli/test/source-worker-runner.test.ts
@@ -27,7 +27,7 @@ describe('source worker runner (real daemon)', () => {
 
   beforeAll(async () => {
     console.log = () => undefined;
-    daemon = await startLiveDaemon();
+    daemon = await startLiveDaemon({ publisherEnabled: true });
     const created = await postJson(daemon, '/api/context-graph/create', { id: CG, name: CG, accessPolicy: 0 });
     expect(created.status, `CG create failed: ${JSON.stringify(created.body)}`).toBeLessThan(300);
     const sg = await postJson(daemon, '/api/sub-graph/create', { contextGraphId: CG, subGraphName: 'sg-1' });

--- a/scripts/devnet-test-issue-1576-publisher-readiness.sh
+++ b/scripts/devnet-test-issue-1576-publisher-readiness.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Live-devnet regression for #1576. A temporary edge node is started with
+# publisher.enabled=true but no publisher wallet. publish-async must return 503
+# before persistence, and the durable publisher job count must not change.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DEVNET_DIR="${DEVNET_DIR:-$ROOT/.devnet}"
+API_PORT_BASE="${API_PORT_BASE:-9201}"
+NODE="${PUBLISHER_READINESS_NODE:-7}"
+NODE_DIR="$DEVNET_DIR/node$NODE"
+CG="${DEVNET_CONTEXT_GRAPH:-devnet-test}"
+
+fail() { echo "[#1576] FAIL: $*" >&2; exit 1; }
+cleanup() {
+  "$ROOT/scripts/devnet.sh" stop-node "$NODE" >/dev/null 2>&1 || true
+  rm -rf "$NODE_DIR"
+}
+trap cleanup EXIT INT TERM
+
+[[ -d "$DEVNET_DIR/node1" ]] || fail "start the baseline devnet first"
+[[ ! -d "$NODE_DIR" ]] || fail "$NODE_DIR already exists; choose PUBLISHER_READINESS_NODE"
+"$ROOT/scripts/devnet.sh" addnode "$NODE" edge >/dev/null
+"$ROOT/scripts/devnet.sh" stop-node "$NODE" >/dev/null
+
+NODE_DIR="$NODE_DIR" node --input-type=module <<'NODE'
+import { readFileSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+const path = join(process.env.NODE_DIR, 'config.json');
+const config = JSON.parse(readFileSync(path, 'utf8'));
+config.publisher = { ...(config.publisher ?? {}), enabled: true };
+writeFileSync(path, JSON.stringify(config, null, 2));
+rmSync(join(process.env.NODE_DIR, 'publisher-wallets.json'), { force: true });
+NODE
+"$ROOT/scripts/devnet.sh" restart-node "$NODE" >/dev/null
+
+. "$ROOT/scripts/devnet-lib.sh"
+for _ in $(seq 1 90); do
+  [[ "$(code_of "$(api "$NODE" GET /api/status)")" == 200 ]] && break
+  sleep 1
+done
+[[ "$(code_of "$(api "$NODE" GET /api/status)")" == 200 ]] || fail "temporary node did not become ready"
+api "$NODE" POST /api/identity/ensure '{}' >/dev/null || true
+
+jobs_before_body="$(body_of "$(api "$NODE" GET /api/publisher/jobs)")"
+jobs_before="$(JOBS="$jobs_before_body" node -e 'const j=JSON.parse(process.env.JOBS);process.stdout.write(String((j.jobs||[]).length))')"
+
+name="issue-1576-$(date +%s)-$$"
+subject="urn:issue:1576:$name"
+api "$NODE" POST /api/knowledge-assets "{\"contextGraphId\":\"$CG\",\"name\":\"$name\"}" >/dev/null
+api "$NODE" POST "/api/knowledge-assets/$name/wm/write" \
+  "{\"contextGraphId\":\"$CG\",\"quads\":[{\"subject\":\"$subject\",\"predicate\":\"http://schema.org/name\",\"object\":\"\\\"publisher readiness probe\\\"\",\"graph\":\"\"}]}" >/dev/null
+api "$NODE" POST "/api/knowledge-assets/$name/wm/finalize" "{\"contextGraphId\":\"$CG\"}" >/dev/null
+api "$NODE" POST "/api/knowledge-assets/$name/swm/share" "{\"contextGraphId\":\"$CG\"}" >/dev/null
+
+response="$(api "$NODE" POST "/api/knowledge-assets/$name/vm/publish-async" "{\"contextGraphId\":\"$CG\"}")"
+[[ "$(code_of "$response")" == 503 ]] || fail "expected 503, got $(code_of "$response"): $(body_of "$response")"
+body="$(body_of "$response")"
+[[ "$(field "$body" code)" == async_publisher_unavailable ]] || fail "wrong stable error code: $body"
+[[ "$(field "$body" reason)" == no_publisher_wallets ]] || fail "wrong unavailable reason: $body"
+[[ "$(field "$body" retryable)" == false ]] || fail "no-wallet state was advertised retryable"
+
+jobs_after_body="$(body_of "$(api "$NODE" GET /api/publisher/jobs)")"
+jobs_after="$(JOBS="$jobs_after_body" node -e 'const j=JSON.parse(process.env.JOBS);process.stdout.write(String((j.jobs||[]).length))')"
+[[ "$jobs_after" == "$jobs_before" ]] || fail "job count grew from $jobs_before to $jobs_after"
+echo "[#1576] PASS: unavailable publisher rejected before durable enqueue"


### PR DESCRIPTION
## Summary

- gate `vm/publish-async` on a live publisher runtime with usable wallets
- return HTTP 503 with stable `async_publisher_unavailable` code and reason
- reject before resolving/preflighting an intent or persisting a job
- leave synchronous publishing and queue inspection unchanged

Closes #1576

## Verification

- `pnpm --filter @origintrail-official/dkg run build`
- added route regression proving disabled runtime creates no intent and no durable job (local CLI Vitest process did not terminate cleanly; CI will run it)
