### PR TITLE
fix(chain): retry reads after full-pool throttling (#1561)

### DIFF
--- a/packages/chain/src/chain-rpc-transport-error.ts
+++ b/packages/chain/src/chain-rpc-transport-error.ts
@@ -50,6 +50,7 @@ export interface ChainRpcTransportErrorLike {
   message?: string;
   rpcUrls?: readonly string[];
   txHash?: string;
+  allEndpointsThrottled?: boolean;
 }
 
 export class ChainRpcTransportError extends Error {
@@ -61,17 +62,19 @@ export class ChainRpcTransportError extends Error {
   readonly rpcUrls?: readonly string[];
 
   readonly txHash?: string;
+  readonly allEndpointsThrottled?: boolean;
 
   constructor(
     code: ChainRpcTransportCode,
     message: string,
-    opts?: { cause?: unknown; rpcUrls?: readonly string[]; txHash?: string },
+    opts?: { cause?: unknown; rpcUrls?: readonly string[]; txHash?: string; allEndpointsThrottled?: boolean },
   ) {
     super(message, opts?.cause !== undefined ? { cause: opts.cause } : undefined);
     this.name = 'ChainRpcTransportError';
     this.code = code;
     if (opts?.rpcUrls) this.rpcUrls = Object.freeze([...opts.rpcUrls]);
     if (opts?.txHash) this.txHash = opts.txHash;
+    if (opts?.allEndpointsThrottled !== undefined) this.allEndpointsThrottled = opts.allEndpointsThrottled;
   }
 }
 

--- a/packages/chain/src/chain-rpc-transport-error.ts
+++ b/packages/chain/src/chain-rpc-transport-error.ts
@@ -50,7 +50,6 @@ export interface ChainRpcTransportErrorLike {
   message?: string;
   rpcUrls?: readonly string[];
   txHash?: string;
-  allEndpointsThrottled?: boolean;
 }
 
 export class ChainRpcTransportError extends Error {
@@ -62,19 +61,16 @@ export class ChainRpcTransportError extends Error {
   readonly rpcUrls?: readonly string[];
 
   readonly txHash?: string;
-  readonly allEndpointsThrottled?: boolean;
-
   constructor(
     code: ChainRpcTransportCode,
     message: string,
-    opts?: { cause?: unknown; rpcUrls?: readonly string[]; txHash?: string; allEndpointsThrottled?: boolean },
+    opts?: { cause?: unknown; rpcUrls?: readonly string[]; txHash?: string },
   ) {
     super(message, opts?.cause !== undefined ? { cause: opts.cause } : undefined);
     this.name = 'ChainRpcTransportError';
     this.code = code;
     if (opts?.rpcUrls) this.rpcUrls = Object.freeze([...opts.rpcUrls]);
     if (opts?.txHash) this.txHash = opts.txHash;
-    if (opts?.allEndpointsThrottled !== undefined) this.allEndpointsThrottled = opts.allEndpointsThrottled;
   }
 }
 

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -2591,10 +2591,14 @@ export class EVMChainAdapterBase {
     // endpoint that has it; best-effort `0` only when EVERY endpoint lacks it and
     // no transport error occurred. Non-retryable / transport-exhaustion errors
     // propagate (never masked as a bogus `0`). Order-independent — see the helper.
-    const block = await this.rpcFailover.readReceiptBlock(
+    const block = await this.rpcFailover.read(
       'getBlock',
       (p) => p.getBlock(blockNumber),
-      { rpcUsageConsumer: 'getBlock', isEmptyResult: (value) => value == null },
+      {
+        rpcUsageConsumer: 'getBlock',
+        isEmptyResult: (value) => value == null,
+        endpointSetRetry: 'all-throttled',
+      },
     );
     return block?.timestamp != null ? Number(block.timestamp) : 0;
   }

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -2591,9 +2591,11 @@ export class EVMChainAdapterBase {
     // endpoint that has it; best-effort `0` only when EVERY endpoint lacks it and
     // no transport error occurred. Non-retryable / transport-exhaustion errors
     // propagate (never masked as a bogus `0`). Order-independent — see the helper.
-    const block = await this.readProviderRetryingNull('getBlock', (p) => p.getBlock(blockNumber), {
-      retryOnThrottleExhaustion: true,
-    });
+    const block = await this.rpcFailover.readReceiptBlock(
+      'getBlock',
+      (p) => p.getBlock(blockNumber),
+      { rpcUsageConsumer: 'getBlock', isEmptyResult: (value) => value == null },
+    );
     return block?.timestamp != null ? Number(block.timestamp) : 0;
   }
 

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -2591,7 +2591,9 @@ export class EVMChainAdapterBase {
     // endpoint that has it; best-effort `0` only when EVERY endpoint lacks it and
     // no transport error occurred. Non-retryable / transport-exhaustion errors
     // propagate (never masked as a bogus `0`). Order-independent — see the helper.
-    const block = await this.readProviderRetryingNull('getBlock', (p) => p.getBlock(blockNumber));
+    const block = await this.readProviderRetryingNull('getBlock', (p) => p.getBlock(blockNumber), {
+      retryOnThrottleExhaustion: true,
+    });
     return block?.timestamp != null ? Number(block.timestamp) : 0;
   }
 

--- a/packages/chain/src/evm-adapter-rpc.ts
+++ b/packages/chain/src/evm-adapter-rpc.ts
@@ -153,6 +153,14 @@ export function isRetryableRpcError(err: unknown): boolean {
     .test(msg);
 }
 
+/** Canonical classifier for provider throttling, shared by failover policy. */
+export function isThrottleRpcError(err: unknown): boolean {
+  if (err instanceof Error) enrichEvmError(err);
+  const status = errorStatus(err);
+  const message = errorMessage(err).toLowerCase();
+  return status === 429 || /\b429\b|too many requests|rate[ -]?limit|throttl/.test(message);
+}
+
 export function assertSuccessfulReceipt(receipt: ethers.TransactionReceipt, label: string): void {
   if (receipt.status !== 0) return;
   const err = new Error(`${label} tx ${receipt.hash} was mined but reverted (status=0)`);

--- a/packages/chain/src/rpc-failover-client.ts
+++ b/packages/chain/src/rpc-failover-client.ts
@@ -41,8 +41,8 @@
 
 import { JsonRpcProvider, Wallet, Contract, ethers } from 'ethers';
 import { withSpan, getMetrics } from '@origintrail-official/dkg-core';
-import { withTimeout, isRetryableRpcError, isKnownTransactionError, sleep } from './evm-adapter-rpc.js';
-import { errorCode, errorMessage, errorStatus } from './evm-adapter-errors.js';
+import { withTimeout, isRetryableRpcError, isThrottleRpcError, isKnownTransactionError, sleep } from './evm-adapter-rpc.js';
+import { errorCode, errorMessage } from './evm-adapter-errors.js';
 import { noteRpcFailover, noteRpcExhaustion, notePreferredEndpoint, noteRpcServed, rpcHost } from './rpc-failover-log.js';
 import { EndpointStickiness, type StickinessIntent } from './endpoint-stickiness.js';
 import { ChainRpcTransportError } from './chain-rpc-transport-error.js';
@@ -95,13 +95,6 @@ export interface ReadOpts {
   policy?: ReadPolicy;
   isRetryable?: (err: unknown) => boolean;
   rpcUsageConsumer?: string;
-  /**
-   * Retry the entire endpoint pool when every endpoint was exhausted by an RPC
-   * throttle. This is deliberately opt-in: ordinary reads retain the established
-   * one-pass failover contract, while publish-critical receipt-block reads can
-   * absorb a short provider-wide rate-limit burst before failing the operation.
-   */
-  retryOnThrottleExhaustion?: boolean;
   /**
    * Opt this read OUT of endpoint stickiness — it always uses the canonical
    * (configured) endpoint order AND never mutates the preferred pointer
@@ -302,7 +295,7 @@ export class RpcFailoverClient {
     fn: (provider: JsonRpcProvider) => Promise<T>,
     opts?: ReadOpts,
   ): Promise<T> {
-    const readOnce = () => this.runAcrossProviders(
+    const run = () => this.runAcrossProviders(
       label,
       fn,
       opts?.isRetryable ?? isRetryableRpcError,
@@ -310,9 +303,26 @@ export class RpcFailoverClient {
       opts?.skipPreferred ?? false,
       opts?.isEmptyResult,
     );
-    const run = () => opts?.retryOnThrottleExhaustion
-      ? this.withThrottleRetries(readOnce)
-      : readOnce();
+    return opts?.rpcUsageConsumer ? withRpcUsageConsumer(opts.rpcUsageConsumer, run) : run();
+  }
+
+  /**
+   * Narrow publish-critical receipt-block read. Unlike generic reads, it retries
+   * a full pool pass only when every endpoint in that pass was throttled.
+   */
+  readReceiptBlock<T>(
+    label: string,
+    fn: (provider: JsonRpcProvider) => Promise<T>,
+    opts?: ReadOpts,
+  ): Promise<T> {
+    const run = () => this.withThrottleRetries(() => this.runAcrossProviders(
+      label,
+      fn,
+      opts?.isRetryable ?? isRetryableRpcError,
+      opts?.policy ?? 'pointRead',
+      opts?.skipPreferred ?? false,
+      opts?.isEmptyResult,
+    ));
     return opts?.rpcUsageConsumer ? withRpcUsageConsumer(opts.rpcUsageConsumer, run) : run();
   }
 
@@ -342,7 +352,7 @@ export class RpcFailoverClient {
         const metrics = getMetrics();
         const startedAt = Date.now();
         try {
-          const readOnce = () => this.runAcrossProviders(
+          const out = await this.runAcrossProviders(
             label,
             (p) => fn(this.rebindContract(contract, p)),
             opts?.isRetryable ?? isContractViewRetryable,
@@ -350,9 +360,6 @@ export class RpcFailoverClient {
             opts?.skipPreferred ?? false,
             opts?.isEmptyResult,
           );
-          const out = await (opts?.retryOnThrottleExhaustion
-            ? this.withThrottleRetries(readOnce)
-            : readOnce());
           this.recordRpcOutcome('eth_call', 'ok');
           return out;
         } catch (err) {
@@ -686,6 +693,7 @@ export class RpcFailoverClient {
     const attempts = this.stickiness.attempts(canonical, intent);
     const capMs = resolveCapMs(policy, canonical.length);
     let lastRetryable: unknown;
+    let allEndpointsThrottled = true;
     let sawEmpty = false;
     let lastEmpty: T | undefined;
     for (let i = 0; i < attempts.length; i += 1) {
@@ -711,6 +719,7 @@ export class RpcFailoverClient {
           // telemetry. Try the next endpoint; if EVERY endpoint is empty (and none
           // errored) the empty value itself is the honest answer.
           sawEmpty = true;
+          allEndpointsThrottled = false;
           lastEmpty = out;
           continue;
         }
@@ -720,6 +729,7 @@ export class RpcFailoverClient {
       } catch (err) {
         if (!isRetryable(err)) throw err;
         lastRetryable = err;
+        if (!isThrottleRpcError(err)) allEndpointsThrottled = false;
         attempt.recordFailure(); // de-prefer a failed backend
         if (!isLast) {
           noteRpcFailover(label, endpoint.rpcUrl, err, attempts[i + 1].endpoint.rpcUrl);
@@ -748,6 +758,7 @@ export class RpcFailoverClient {
       throw new ChainRpcTransportError('RPC_ENDPOINTS_EXHAUSTED', message, {
         cause: lastRetryable,
         rpcUrls: canonical.map((e) => e.rpcUrl),
+        allEndpointsThrottled,
       });
     }
     // Every endpoint returned an empty result and none errored → the empty value
@@ -772,11 +783,9 @@ export class RpcFailoverClient {
         // its no-failover/no-retry contract. Only retry a typed FULL-POOL
         // exhaustion produced by runAcrossProviders.
         if (errorCode(error) !== 'RPC_ENDPOINTS_EXHAUSTED') throw error;
-        const cause = error instanceof Error ? error.cause : undefined;
-        const status = errorStatus(cause ?? error);
-        const message = errorMessage(cause ?? error).toLowerCase();
-        const throttled = status === 429 || /\b429\b|too many requests|rate[ -]?limit|throttl/.test(message);
-        if (!throttled || retry >= this.readThrottleRetries) throw error;
+        const allThrottled = error instanceof ChainRpcTransportError
+          && error.allEndpointsThrottled === true;
+        if (!allThrottled || retry >= this.readThrottleRetries) throw error;
         await sleep(this.readThrottleBackoffMs * (2 ** retry));
       }
     }

--- a/packages/chain/src/rpc-failover-client.ts
+++ b/packages/chain/src/rpc-failover-client.ts
@@ -41,8 +41,8 @@
 
 import { JsonRpcProvider, Wallet, Contract, ethers } from 'ethers';
 import { withSpan, getMetrics } from '@origintrail-official/dkg-core';
-import { withTimeout, isRetryableRpcError, isKnownTransactionError } from './evm-adapter-rpc.js';
-import { errorCode, errorMessage } from './evm-adapter-errors.js';
+import { withTimeout, isRetryableRpcError, isKnownTransactionError, sleep } from './evm-adapter-rpc.js';
+import { errorCode, errorMessage, errorStatus } from './evm-adapter-errors.js';
 import { noteRpcFailover, noteRpcExhaustion, notePreferredEndpoint, noteRpcServed, rpcHost } from './rpc-failover-log.js';
 import { EndpointStickiness, type StickinessIntent } from './endpoint-stickiness.js';
 import { ChainRpcTransportError } from './chain-rpc-transport-error.js';
@@ -142,6 +142,9 @@ export interface RpcFailoverClientOptions {
   validateEndpoint?: ValidateEndpointFn;
   /** Endpoint-stickiness configuration (Mechanism B). */
   stickiness?: StickinessOptions;
+  /** Full-pool retries after every endpoint reports a transient throttle. */
+  readThrottleRetries?: number;
+  readThrottleBackoffMs?: number;
 }
 
 export interface StickinessOptions {
@@ -205,6 +208,8 @@ export class RpcFailoverClient {
   private readonly stickiness: EndpointStickiness;
   /** Optional per-endpoint transport preflight (from `options.validateEndpoint`). */
   private readonly validateEndpoint?: ValidateEndpointFn;
+  private readonly readThrottleRetries: number;
+  private readonly readThrottleBackoffMs: number;
 
   constructor(
     private readonly getEndpoints: () => RpcEndpoint[],
@@ -219,6 +224,8 @@ export class RpcFailoverClient {
     options?: RpcFailoverClientOptions,
   ) {
     this.validateEndpoint = options?.validateEndpoint;
+    this.readThrottleRetries = options?.readThrottleRetries ?? 2;
+    this.readThrottleBackoffMs = options?.readThrottleBackoffMs ?? 250;
     const stickiness = options?.stickiness;
     const isEnabled = stickiness?.isEnabled
       ?? (stickiness?.enabled !== undefined ? () => stickiness.enabled as boolean : () => true);
@@ -288,14 +295,14 @@ export class RpcFailoverClient {
     fn: (provider: JsonRpcProvider) => Promise<T>,
     opts?: ReadOpts,
   ): Promise<T> {
-    const run = () => this.runAcrossProviders(
+    const run = () => this.withThrottleRetries(() => this.runAcrossProviders(
       label,
       fn,
       opts?.isRetryable ?? isRetryableRpcError,
       opts?.policy ?? 'pointRead',
       opts?.skipPreferred ?? false,
       opts?.isEmptyResult,
-    );
+    ));
     return opts?.rpcUsageConsumer ? withRpcUsageConsumer(opts.rpcUsageConsumer, run) : run();
   }
 
@@ -325,14 +332,14 @@ export class RpcFailoverClient {
         const metrics = getMetrics();
         const startedAt = Date.now();
         try {
-          const out = await this.runAcrossProviders(
+          const out = await this.withThrottleRetries(() => this.runAcrossProviders(
             label,
             (p) => fn(this.rebindContract(contract, p)),
             opts?.isRetryable ?? isContractViewRetryable,
             opts?.policy ?? 'pointRead',
             opts?.skipPreferred ?? false,
             opts?.isEmptyResult,
-          );
+          ));
           this.recordRpcOutcome('eth_call', 'ok');
           return out;
         } catch (err) {
@@ -741,6 +748,21 @@ export class RpcFailoverClient {
       `${label} read failed: no configured RPC endpoints`,
       { rpcUrls: [] },
     );
+  }
+
+  private async withThrottleRetries<T>(run: () => Promise<T>): Promise<T> {
+    for (let retry = 0; ; retry += 1) {
+      try {
+        return await run();
+      } catch (error) {
+        const cause = error instanceof Error ? error.cause : undefined;
+        const status = errorStatus(cause ?? error);
+        const message = errorMessage(cause ?? error).toLowerCase();
+        const throttled = status === 429 || /\b429\b|too many requests|rate[ -]?limit|throttl/.test(message);
+        if (!throttled || retry >= this.readThrottleRetries) throw error;
+        await sleep(this.readThrottleBackoffMs * (2 ** retry));
+      }
+    }
   }
 
   /**

--- a/packages/chain/src/rpc-failover-client.ts
+++ b/packages/chain/src/rpc-failover-client.ts
@@ -117,6 +117,21 @@ export interface ReadOpts {
    * sentinel polluting stickiness or telemetry.
    */
   isEmptyResult?: (value: unknown) => boolean;
+  /** Retry a complete endpoint pass only when every failure was a throttle. */
+  endpointSetRetry?: 'all-throttled';
+}
+
+type ProviderSetExhaustionKind = 'all-throttled' | 'mixed';
+
+/** Internal exhaustion detail used only while deciding whether to retry a pass. */
+class ProviderSetExhaustedError extends ChainRpcTransportError {
+  constructor(
+    message: string,
+    readonly exhaustionKind: ProviderSetExhaustionKind,
+    opts: { cause: unknown; rpcUrls: readonly string[] },
+  ) {
+    super('RPC_ENDPOINTS_EXHAUSTED', message, opts);
+  }
 }
 
 /**
@@ -295,7 +310,7 @@ export class RpcFailoverClient {
     fn: (provider: JsonRpcProvider) => Promise<T>,
     opts?: ReadOpts,
   ): Promise<T> {
-    const run = () => this.runAcrossProviders(
+    const runPass = () => this.runAcrossProviders(
       label,
       fn,
       opts?.isRetryable ?? isRetryableRpcError,
@@ -303,26 +318,9 @@ export class RpcFailoverClient {
       opts?.skipPreferred ?? false,
       opts?.isEmptyResult,
     );
-    return opts?.rpcUsageConsumer ? withRpcUsageConsumer(opts.rpcUsageConsumer, run) : run();
-  }
-
-  /**
-   * Narrow publish-critical receipt-block read. Unlike generic reads, it retries
-   * a full pool pass only when every endpoint in that pass was throttled.
-   */
-  readReceiptBlock<T>(
-    label: string,
-    fn: (provider: JsonRpcProvider) => Promise<T>,
-    opts?: ReadOpts,
-  ): Promise<T> {
-    const run = () => this.withThrottleRetries(() => this.runAcrossProviders(
-      label,
-      fn,
-      opts?.isRetryable ?? isRetryableRpcError,
-      opts?.policy ?? 'pointRead',
-      opts?.skipPreferred ?? false,
-      opts?.isEmptyResult,
-    ));
+    const run = opts?.endpointSetRetry === 'all-throttled'
+      ? () => this.withThrottleRetries(runPass)
+      : runPass;
     return opts?.rpcUsageConsumer ? withRpcUsageConsumer(opts.rpcUsageConsumer, run) : run();
   }
 
@@ -755,10 +753,9 @@ export class RpcFailoverClient {
         ? errorMessage(lastRetryable)
         : `${label} read failed on all configured RPC endpoints ` +
           `(${canonical.map((e) => rpcHost(e.rpcUrl)).join(', ')}): ${errorMessage(lastRetryable)}`;
-      throw new ChainRpcTransportError('RPC_ENDPOINTS_EXHAUSTED', message, {
+      throw new ProviderSetExhaustedError(message, allEndpointsThrottled ? 'all-throttled' : 'mixed', {
         cause: lastRetryable,
         rpcUrls: canonical.map((e) => e.rpcUrl),
-        allEndpointsThrottled,
       });
     }
     // Every endpoint returned an empty result and none errored → the empty value
@@ -782,10 +779,9 @@ export class RpcFailoverClient {
         // A raw 429 from a caller-supplied non-retryable classifier must retain
         // its no-failover/no-retry contract. Only retry a typed FULL-POOL
         // exhaustion produced by runAcrossProviders.
-        if (errorCode(error) !== 'RPC_ENDPOINTS_EXHAUSTED') throw error;
-        const allThrottled = error instanceof ChainRpcTransportError
-          && error.allEndpointsThrottled === true;
-        if (!allThrottled || retry >= this.readThrottleRetries) throw error;
+        if (!(error instanceof ProviderSetExhaustedError)
+          || error.exhaustionKind !== 'all-throttled'
+          || retry >= this.readThrottleRetries) throw error;
         await sleep(this.readThrottleBackoffMs * (2 ** retry));
       }
     }

--- a/packages/chain/src/rpc-failover-client.ts
+++ b/packages/chain/src/rpc-failover-client.ts
@@ -96,6 +96,13 @@ export interface ReadOpts {
   isRetryable?: (err: unknown) => boolean;
   rpcUsageConsumer?: string;
   /**
+   * Retry the entire endpoint pool when every endpoint was exhausted by an RPC
+   * throttle. This is deliberately opt-in: ordinary reads retain the established
+   * one-pass failover contract, while publish-critical receipt-block reads can
+   * absorb a short provider-wide rate-limit burst before failing the operation.
+   */
+  retryOnThrottleExhaustion?: boolean;
+  /**
    * Opt this read OUT of endpoint stickiness — it always uses the canonical
    * (configured) endpoint order AND never mutates the preferred pointer
    * (fully preference-transparent). Set on TIP-SENSITIVE reads (current head /
@@ -295,14 +302,17 @@ export class RpcFailoverClient {
     fn: (provider: JsonRpcProvider) => Promise<T>,
     opts?: ReadOpts,
   ): Promise<T> {
-    const run = () => this.withThrottleRetries(() => this.runAcrossProviders(
+    const readOnce = () => this.runAcrossProviders(
       label,
       fn,
       opts?.isRetryable ?? isRetryableRpcError,
       opts?.policy ?? 'pointRead',
       opts?.skipPreferred ?? false,
       opts?.isEmptyResult,
-    ));
+    );
+    const run = () => opts?.retryOnThrottleExhaustion
+      ? this.withThrottleRetries(readOnce)
+      : readOnce();
     return opts?.rpcUsageConsumer ? withRpcUsageConsumer(opts.rpcUsageConsumer, run) : run();
   }
 
@@ -332,14 +342,17 @@ export class RpcFailoverClient {
         const metrics = getMetrics();
         const startedAt = Date.now();
         try {
-          const out = await this.withThrottleRetries(() => this.runAcrossProviders(
+          const readOnce = () => this.runAcrossProviders(
             label,
             (p) => fn(this.rebindContract(contract, p)),
             opts?.isRetryable ?? isContractViewRetryable,
             opts?.policy ?? 'pointRead',
             opts?.skipPreferred ?? false,
             opts?.isEmptyResult,
-          ));
+          );
+          const out = await (opts?.retryOnThrottleExhaustion
+            ? this.withThrottleRetries(readOnce)
+            : readOnce());
           this.recordRpcOutcome('eth_call', 'ok');
           return out;
         } catch (err) {
@@ -755,6 +768,10 @@ export class RpcFailoverClient {
       try {
         return await run();
       } catch (error) {
+        // A raw 429 from a caller-supplied non-retryable classifier must retain
+        // its no-failover/no-retry contract. Only retry a typed FULL-POOL
+        // exhaustion produced by runAcrossProviders.
+        if (errorCode(error) !== 'RPC_ENDPOINTS_EXHAUSTED') throw error;
         const cause = error instanceof Error ? error.cause : undefined;
         const status = errorStatus(cause ?? error);
         const message = errorMessage(cause ?? error).toLowerCase();

--- a/packages/chain/test/evm-adapter-tip-read-carveouts.unit.test.ts
+++ b/packages/chain/test/evm-adapter-tip-read-carveouts.unit.test.ts
@@ -181,6 +181,22 @@ describe('getBlockTimestamp: a null (unimported) receipt block fails over instea
     await expect(a.getBlockTimestamp(123n)).rejects.toMatchObject({ code: 'RPC_ENDPOINTS_EXHAUSTED' });
   });
 
+  it('retries an all-429 receipt-block pass and returns the recovered timestamp', async () => {
+    const retryable429 = () => { const e: any = new Error('429 too many requests'); e.status = 429; return e; };
+    const primary = recorder(async () => { throw retryable429(); });
+    let backupAttempt = 0;
+    const backup = recorder(async () => {
+      backupAttempt += 1;
+      if (backupAttempt === 1) throw retryable429();
+      return { timestamp: 42 };
+    });
+    const a = makeTwoEndpointAdapter({ getBlock: primary }, { getBlock: backup });
+
+    await expect(a.getBlockTimestamp(123n)).resolves.toBe(42);
+    expect(primary.calls).toHaveLength(2);
+    expect(backup.calls).toHaveLength(2);
+  });
+
   it('MIXED null + transport error PROPAGATES regardless of endpoint order (order-independent, round-6 🔴)', async () => {
     const retryable429 = () => { const e: any = new Error('429 too many requests'); e.status = 429; return e; };
     // Order A: primary transport error, backup null. A transport failure occurred,

--- a/packages/chain/test/readwithfailover-loop.unit.test.ts
+++ b/packages/chain/test/readwithfailover-loop.unit.test.ts
@@ -133,7 +133,9 @@ describe('RpcFailoverClient.read — read-failover loop logic (bare-mock, #1336)
       readThrottleBackoffMs: 1,
     });
 
-    await expect(client.readReceiptBlock('getBlock', (provider: any) => provider.read()))
+    await expect(client.read('getBlock', (provider: any) => provider.read(), {
+      endpointSetRetry: 'all-throttled',
+    }))
       .resolves.toBe('recovered');
     expect(primary.read.calls).toHaveLength(2);
     expect(backup.read.calls).toHaveLength(2);
@@ -147,8 +149,9 @@ describe('RpcFailoverClient.read — read-failover loop logic (bare-mock, #1336)
       readThrottleBackoffMs: 1,
     });
 
-    await expect(client.readReceiptBlock('getBlock', (provider: any) => provider.read()))
-      .rejects.toMatchObject({ code: 'RPC_ENDPOINTS_EXHAUSTED', allEndpointsThrottled: false });
+    await expect(client.read('getBlock', (provider: any) => provider.read(), {
+      endpointSetRetry: 'all-throttled',
+    })).rejects.toMatchObject({ code: 'RPC_ENDPOINTS_EXHAUSTED' });
     expect(primary.read.calls).toHaveLength(1);
     expect(backup.read.calls).toHaveLength(1);
   });

--- a/packages/chain/test/readwithfailover-loop.unit.test.ts
+++ b/packages/chain/test/readwithfailover-loop.unit.test.ts
@@ -28,7 +28,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { EVMChainAdapter, type EVMAdapterConfig } from '../src/evm-adapter.js';
-import { RpcFailoverClient, type SignPopulatedFn } from '../src/rpc-failover-client.js';
+import { RpcFailoverClient, type RpcFailoverClientOptions, type SignPopulatedFn } from '../src/rpc-failover-client.js';
 import { isChainRpcTransportError } from '../src/chain-rpc-transport-error.js';
 import { getRpcFailoverStats, _resetRpcFailoverStatsForTest } from '../src/rpc-failover-log.js';
 import { RPC_READ_STALL_TIMEOUT_MS } from '../src/evm-adapter-constants.js';
@@ -79,11 +79,12 @@ const NEVER_SIGN: SignPopulatedFn = async () => {
  * is the exact shape the adapter constructs it with, minus the adapter — so a
  * read failover regression is caught without a god-object back-reference.
  */
-function makeClient(providers: unknown[], rpcUrls: string[], signPopulated: SignPopulatedFn = NEVER_SIGN): RpcFailoverClient {
+function makeClient(providers: unknown[], rpcUrls: string[], signPopulated: SignPopulatedFn = NEVER_SIGN, options?: RpcFailoverClientOptions): RpcFailoverClient {
   return new RpcFailoverClient(
     () => providers.map((p, i) => ({ provider: p as any, rpcUrl: rpcUrls[i] })),
     signPopulated,
     () => 'evm:31337',
+    options,
   );
 }
 
@@ -104,7 +105,9 @@ describe('RpcFailoverClient.read — read-failover loop logic (bare-mock, #1336)
   it('exhausts ALL endpoints → ChainRpcTransportError RPC_ENDPOINTS_EXHAUSTED, one attempt each', async () => {
     const primary = { read: recorder(async () => { throw retryable429(); }) };
     const backup = { read: recorder(async () => { throw retryable429(); }) };
-    const client = makeClient([primary, backup], ['https://primary.example', 'https://backup.example']);
+    const client = makeClient([primary, backup], ['https://primary.example', 'https://backup.example'], NEVER_SIGN, {
+      readThrottleRetries: 0,
+    });
 
     let thrown: any;
     try { await client.read('unit read', (p: any) => p.read()); } catch (e) { thrown = e; }
@@ -115,6 +118,24 @@ describe('RpcFailoverClient.read — read-failover loop logic (bare-mock, #1336)
     expect(thrown.message).not.toContain('https://');
     expect(primary.read.calls).toHaveLength(1);
     expect(backup.read.calls).toHaveLength(1);
+  });
+
+  it('backs off and retries the full pool when every endpoint returns 429', async () => {
+    let round = 0;
+    const primary = { read: recorder(async () => { throw retryable429(); }) };
+    const backup = { read: recorder(async () => {
+      round += 1;
+      if (round === 1) throw retryable429();
+      return 'recovered';
+    }) };
+    const client = makeClient([primary, backup], ['https://primary.example', 'https://backup.example'], NEVER_SIGN, {
+      readThrottleRetries: 2,
+      readThrottleBackoffMs: 1,
+    });
+
+    await expect(client.read('getBlock', (provider: any) => provider.read())).resolves.toBe('recovered');
+    expect(primary.read.calls).toHaveLength(2);
+    expect(backup.read.calls).toHaveLength(2);
   });
 
   it('single-RPC: a retryable failure still stamps RPC_ENDPOINTS_EXHAUSTED but keeps the original message verbatim', async () => {

--- a/packages/chain/test/readwithfailover-loop.unit.test.ts
+++ b/packages/chain/test/readwithfailover-loop.unit.test.ts
@@ -133,11 +133,24 @@ describe('RpcFailoverClient.read — read-failover loop logic (bare-mock, #1336)
       readThrottleBackoffMs: 1,
     });
 
-    await expect(client.read('getBlock', (provider: any) => provider.read(), {
-      retryOnThrottleExhaustion: true,
-    })).resolves.toBe('recovered');
+    await expect(client.readReceiptBlock('getBlock', (provider: any) => provider.read()))
+      .resolves.toBe('recovered');
     expect(primary.read.calls).toHaveLength(2);
     expect(backup.read.calls).toHaveLength(2);
+  });
+
+  it('does not retry a mixed timeout plus 429 endpoint exhaustion', async () => {
+    const primary = { read: recorder(async () => { const error: any = new Error('timed out'); error.code = 'TIMEOUT'; throw error; }) };
+    const backup = { read: recorder(async () => { throw retryable429(); }) };
+    const client = makeClient([primary, backup], ['https://primary.example', 'https://backup.example'], NEVER_SIGN, {
+      readThrottleRetries: 2,
+      readThrottleBackoffMs: 1,
+    });
+
+    await expect(client.readReceiptBlock('getBlock', (provider: any) => provider.read()))
+      .rejects.toMatchObject({ code: 'RPC_ENDPOINTS_EXHAUSTED', allEndpointsThrottled: false });
+    expect(primary.read.calls).toHaveLength(1);
+    expect(backup.read.calls).toHaveLength(1);
   });
 
   it('single-RPC: a retryable failure still stamps RPC_ENDPOINTS_EXHAUSTED but keeps the original message verbatim', async () => {

--- a/packages/chain/test/readwithfailover-loop.unit.test.ts
+++ b/packages/chain/test/readwithfailover-loop.unit.test.ts
@@ -133,7 +133,9 @@ describe('RpcFailoverClient.read — read-failover loop logic (bare-mock, #1336)
       readThrottleBackoffMs: 1,
     });
 
-    await expect(client.read('getBlock', (provider: any) => provider.read())).resolves.toBe('recovered');
+    await expect(client.read('getBlock', (provider: any) => provider.read(), {
+      retryOnThrottleExhaustion: true,
+    })).resolves.toBe('recovered');
     expect(primary.read.calls).toHaveLength(2);
     expect(backup.read.calls).toHaveLength(2);
   });

--- a/scripts/devnet-test-issue-1561-rpc-throttle-retry.sh
+++ b/scripts/devnet-test-issue-1561-rpc-throttle-retry.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Live-devnet regression for #1561. A temporary node uses two logical RPC
+# endpoints behind a fault proxy. The first eth_getBlockByNumber on each endpoint
+# returns 429 (one complete throttled pool); the next pool pass forwards and the
+# publish must confirm.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DEVNET_DIR="${DEVNET_DIR:-$ROOT/.devnet}"
+API_PORT_BASE="${API_PORT_BASE:-9201}"
+UPSTREAM="${DEVNET_RPC:-http://127.0.0.1:8545}"
+PROXY_PORT="${THROTTLE_PROXY_PORT:-18561}"
+NODE="${THROTTLE_TEST_NODE:-7}"
+NODE_DIR="$DEVNET_DIR/node$NODE"
+CG="${DEVNET_CONTEXT_GRAPH:-devnet-test}"
+proxy_pid=''
+
+fail() { echo "[#1561] FAIL: $*" >&2; exit 1; }
+cleanup() {
+  "$ROOT/scripts/devnet.sh" stop-node "$NODE" >/dev/null 2>&1 || true
+  rm -rf "$NODE_DIR"
+  [[ -n "$proxy_pid" ]] && kill "$proxy_pid" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT INT TERM
+[[ ! -d "$NODE_DIR" ]] || fail "$NODE_DIR already exists"
+
+UPSTREAM="$UPSTREAM" PROXY_PORT="$PROXY_PORT" node --input-type=module <<'NODE' &
+import http from 'node:http';
+const counts = new Map();
+http.createServer(async (req, res) => {
+  if (req.method === 'GET' && req.url === '/stats') {
+    res.setHeader('content-type', 'application/json');
+    return res.end(JSON.stringify(Object.fromEntries(counts)));
+  }
+  const chunks = [];
+  for await (const chunk of req) chunks.push(chunk);
+  const body = Buffer.concat(chunks);
+  let method = '';
+  try { method = JSON.parse(body.toString()).method; } catch {}
+  const key = `${req.url}:${method}`;
+  const count = counts.get(key) ?? 0;
+  counts.set(key, count + 1);
+  if (method === 'eth_getBlockByNumber' && count === 0) {
+    res.statusCode = 429;
+    res.setHeader('content-type', 'application/json');
+    return res.end(JSON.stringify({ error: 'Too Many Requests' }));
+  }
+  const upstream = await fetch(process.env.UPSTREAM, {
+    method: 'POST', headers: { 'content-type': 'application/json' }, body,
+  });
+  res.statusCode = upstream.status;
+  res.end(Buffer.from(await upstream.arrayBuffer()));
+}).listen(Number(process.env.PROXY_PORT), '127.0.0.1');
+NODE
+proxy_pid=$!
+sleep 1
+curl -fsS "http://127.0.0.1:$PROXY_PORT/stats" >/dev/null || fail "fault proxy did not start"
+
+"$ROOT/scripts/devnet.sh" addnode "$NODE" edge >/dev/null
+"$ROOT/scripts/devnet.sh" stop-node "$NODE" >/dev/null
+NODE_DIR="$NODE_DIR" PROXY_PORT="$PROXY_PORT" node --input-type=module <<'NODE'
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+const path = join(process.env.NODE_DIR, 'config.json');
+const config = JSON.parse(readFileSync(path, 'utf8'));
+const base = `http://127.0.0.1:${process.env.PROXY_PORT}`;
+config.chain.rpcUrl = `${base}/a`;
+config.chain.rpcUrls = [`${base}/a`, `${base}/b`];
+writeFileSync(path, JSON.stringify(config, null, 2));
+NODE
+"$ROOT/scripts/devnet.sh" restart-node "$NODE" >/dev/null
+
+. "$ROOT/scripts/devnet-lib.sh"
+for _ in $(seq 1 90); do
+  [[ "$(code_of "$(api "$NODE" GET /api/status)")" == 200 ]] && break
+  sleep 1
+done
+[[ "$(code_of "$(api "$NODE" GET /api/status)")" == 200 ]] || fail "temporary node not ready"
+api "$NODE" POST /api/identity/ensure '{}' >/dev/null || true
+
+name="issue-1561-$(date +%s)-$$"; subject="urn:issue:1561:$name"
+api "$NODE" POST /api/knowledge-assets "{\"contextGraphId\":\"$CG\",\"name\":\"$name\"}" >/dev/null
+api "$NODE" POST "/api/knowledge-assets/$name/wm/write" \
+  "{\"contextGraphId\":\"$CG\",\"quads\":[{\"subject\":\"$subject\",\"predicate\":\"http://schema.org/name\",\"object\":\"\\\"429 recovery probe\\\"\",\"graph\":\"\"}]}" >/dev/null
+api "$NODE" POST "/api/knowledge-assets/$name/wm/finalize" "{\"contextGraphId\":\"$CG\"}" >/dev/null
+api "$NODE" POST "/api/knowledge-assets/$name/swm/share" "{\"contextGraphId\":\"$CG\"}" >/dev/null
+result="$(api "$NODE" POST "/api/knowledge-assets/$name/vm/publish" "{\"contextGraphId\":\"$CG\"}")"
+[[ "$(code_of "$result")" == 200 ]] || fail "publish failed: $(body_of "$result")"
+[[ "$(field "$(body_of "$result")" status)" == confirmed ]] || fail "publish not confirmed"
+
+stats="$(curl -fsS "http://127.0.0.1:$PROXY_PORT/stats")"
+STATS="$stats" node -e 'const s=JSON.parse(process.env.STATS); for (const p of ["/a","/b"]) { const n=s[`${p}:eth_getBlockByNumber`]||0; if(n<2) throw new Error(`${p} getBlock calls=${n}, expected throttle plus recovery`); }' \
+  || fail "proxy did not observe a full throttled pass plus recovery: $stats"
+echo "[#1561] PASS: publish recovered after both RPC endpoints returned 429"


### PR DESCRIPTION
## Summary

- detect the specific case where every configured read endpoint exhausts on HTTP 429/rate limiting
- retry the full endpoint pool twice with bounded exponential backoff
- retain immediate failover within each round and preserve deterministic-error behavior
- expose retry/backoff knobs for deterministic transport tests

Closes #1561

## Verification

- `pnpm --filter @origintrail-official/dkg-chain run build`
- added direct `RpcFailoverClient` regression: both endpoints throttle in round one, backup recovers in round two
