### PR TITLE
fix(cli): verify and roll back torn global updates (#1567)

### DIFF
--- a/packages/cli/src/daemon/auto-update.ts
+++ b/packages/cli/src/daemon/auto-update.ts
@@ -1543,11 +1543,9 @@ export async function performNpmUpdate(
  * version to `~/.dkg/previous-version` so `dkg rollback` (Edge
  * branch) has a target to reinstall.
  *
- * Tradeoffs accepted (per RFC §7.2):
- *   - Non-atomic: a mid-install crash leaves the global state
- *     half-updated. Recovery is `npm install -g` re-run.
- *   - Network-dependent rollback: requires the npm registry to
- *     have the previous version available.
+ * The npm mutation itself is not atomic, so completion is followed by an
+ * executable/version self-check. A failed check immediately reinstalls the
+ * recorded previous version before the daemon is allowed to restart.
  *
  * The function returns `'updated'` after the npm install completes;
  * the caller is responsible for stopping the running daemon so the
@@ -1638,6 +1636,41 @@ async function _performNpmUpdateInnerEdge(
       );
     }
     return "failed";
+  }
+
+  try {
+    const { stdout, stderr } = await execAsyncIo('dkg --version', {
+      encoding: 'utf-8',
+      timeout: 30_000,
+    });
+    const reported = `${stdout ?? ''} ${stderr ?? ''}`.trim();
+    if (!reported.includes(targetVersion)) {
+      throw new Error(`expected ${targetVersion}, got ${reported || 'empty version output'}`);
+    }
+    log(`Auto-update (npm-edge): self-check passed (${reported}).`);
+  } catch (verifyErr: any) {
+    log(`Auto-update (npm-edge): post-install self-check failed — ${verifyErr?.message ?? verifyErr}.`);
+    if (!currentVersion) {
+      log('Auto-update (npm-edge): previous version is unknown; automatic rollback is unavailable.');
+      return 'failed';
+    }
+    const rollbackCmd = `npm install -g ${CLI_NPM_PACKAGE}@${currentVersion}`;
+    log(`Auto-update (npm-edge): rolling back with '${rollbackCmd}'…`);
+    try {
+      await execAsyncIo(rollbackCmd, { encoding: 'utf-8', timeout: 300_000 });
+      const { stdout, stderr } = await execAsyncIo('dkg --version', {
+        encoding: 'utf-8',
+        timeout: 30_000,
+      });
+      const reported = `${stdout ?? ''} ${stderr ?? ''}`.trim();
+      if (!reported.includes(currentVersion)) {
+        throw new Error(`rollback expected ${currentVersion}, got ${reported || 'empty version output'}`);
+      }
+      log(`Auto-update (npm-edge): rollback restored ${reported}.`);
+    } catch (rollbackErr: any) {
+      log(`Auto-update (npm-edge): CRITICAL rollback failed — ${rollbackErr?.message ?? rollbackErr}.`);
+    }
+    return 'failed';
   }
 
   log(

--- a/packages/cli/src/daemon/auto-update.ts
+++ b/packages/cli/src/daemon/auto-update.ts
@@ -1615,14 +1615,7 @@ async function _performNpmUpdateInnerEdge(
   log(`Auto-update (npm-edge): running '${installCmd}'…`);
   try {
     const installStart = Date.now();
-    await execAsyncIo(installCmd, {
-      encoding: "utf-8",
-      timeout: 300_000,
-      // Allow npm's progress / warning output to surface in the daemon
-      // log — operators tailing the log get real-time feedback on slow
-      // installs. stderr → stdout merge mirrors how npm itself runs
-      // interactively.
-    });
+    await installGlobalCliVersion(execAsyncIo, targetVersion);
     const installMs = Date.now() - installStart;
     log(`Auto-update (npm-edge): npm install completed in ${installMs}ms.`);
   } catch (installErr: any) {
@@ -1639,14 +1632,7 @@ async function _performNpmUpdateInnerEdge(
   }
 
   try {
-    const { stdout, stderr } = await execAsyncIo('dkg --version', {
-      encoding: 'utf-8',
-      timeout: 30_000,
-    });
-    const reported = `${stdout ?? ''} ${stderr ?? ''}`.trim();
-    if (!reported.includes(targetVersion)) {
-      throw new Error(`expected ${targetVersion}, got ${reported || 'empty version output'}`);
-    }
+    const reported = await verifyGlobalDkgVersion(execAsyncIo, targetVersion, 'self-check');
     log(`Auto-update (npm-edge): self-check passed (${reported}).`);
   } catch (verifyErr: any) {
     log(`Auto-update (npm-edge): post-install self-check failed — ${verifyErr?.message ?? verifyErr}.`);
@@ -1657,15 +1643,8 @@ async function _performNpmUpdateInnerEdge(
     const rollbackCmd = `npm install -g ${CLI_NPM_PACKAGE}@${currentVersion}`;
     log(`Auto-update (npm-edge): rolling back with '${rollbackCmd}'…`);
     try {
-      await execAsyncIo(rollbackCmd, { encoding: 'utf-8', timeout: 300_000 });
-      const { stdout, stderr } = await execAsyncIo('dkg --version', {
-        encoding: 'utf-8',
-        timeout: 30_000,
-      });
-      const reported = `${stdout ?? ''} ${stderr ?? ''}`.trim();
-      if (!reported.includes(currentVersion)) {
-        throw new Error(`rollback expected ${currentVersion}, got ${reported || 'empty version output'}`);
-      }
+      await installGlobalCliVersion(execAsyncIo, currentVersion);
+      const reported = await verifyGlobalDkgVersion(execAsyncIo, currentVersion, 'rollback');
       log(`Auto-update (npm-edge): rollback restored ${reported}.`);
     } catch (rollbackErr: any) {
       log(`Auto-update (npm-edge): CRITICAL rollback failed — ${rollbackErr?.message ?? rollbackErr}.`);
@@ -1678,6 +1657,36 @@ async function _performNpmUpdateInnerEdge(
       "Stop the daemon to restart from the new entry point.",
   );
   return "updated";
+}
+
+type EdgeExec = typeof _autoUpdateIo.exec;
+
+async function installGlobalCliVersion(execIo: EdgeExec, version: string): Promise<void> {
+  await execIo(`npm install -g ${CLI_NPM_PACKAGE}@${version}`, {
+    encoding: 'utf-8',
+    timeout: 300_000,
+  });
+}
+
+function parseReportedDkgVersion(output: string): string | undefined {
+  return output.match(/(?:^|\s)v?(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)(?=\s|$)/)?.[1];
+}
+
+async function verifyGlobalDkgVersion(
+  execIo: EdgeExec,
+  expectedVersion: string,
+  context: 'self-check' | 'rollback',
+): Promise<string> {
+  const { stdout, stderr } = await execIo('dkg --version', {
+    encoding: 'utf-8',
+    timeout: 30_000,
+  });
+  const reported = `${stdout ?? ''} ${stderr ?? ''}`.trim();
+  const parsed = parseReportedDkgVersion(reported);
+  if (parsed !== expectedVersion) {
+    throw new Error(`${context} expected ${expectedVersion}, got ${parsed ?? (reported || 'empty version output')}`);
+  }
+  return reported;
 }
 
 export async function checkForUpdate(

--- a/packages/cli/test/rfc-41-bundle-b.test.ts
+++ b/packages/cli/test/rfc-41-bundle-b.test.ts
@@ -213,7 +213,10 @@ describe('performNpmUpdateEdge (Bundle B1b)', () => {
     execCalls = [];
     _autoUpdateIo.exec = ((cmd: string, opts?: any): Promise<{ stdout: string; stderr: string }> => {
       execCalls.push({ cmd, opts });
-      return Promise.resolve({ stdout: '', stderr: '' });
+      return Promise.resolve({
+        stdout: cmd === 'dkg --version' ? 'dkg 10.0.0-rc.12' : '',
+        stderr: '',
+      });
     }) as any;
   });
 
@@ -227,8 +230,9 @@ describe('performNpmUpdateEdge (Bundle B1b)', () => {
 
     expect(result).toBe('updated');
     expect(readFileSync(join(dkgHome, 'previous-version'), 'utf-8')).toBe('10.0.0-rc.11');
-    expect(execCalls).toHaveLength(1);
+    expect(execCalls).toHaveLength(2);
     expect(execCalls[0].cmd).toBe('npm install -g @origintrail-official/dkg@10.0.0-rc.12');
+    expect(execCalls[1].cmd).toBe('dkg --version');
     expect(log.calls.some((m) => m.includes('10.0.0-rc.11 → ~/.dkg/previous-version'))).toBe(true);
     expect(log.calls.some((m) => m.includes('install completed'))).toBe(true);
   });
@@ -259,6 +263,30 @@ describe('performNpmUpdateEdge (Bundle B1b)', () => {
     // design, so an operator can recover via `npm install -g
     // @origintrail-official/dkg@<previous>` even after a failed update.
     expect(readFileSync(join(dkgHome, 'previous-version'), 'utf-8')).toBe('10.0.0-rc.11');
+  });
+
+  it('rolls back when the installed CLI cannot pass its self-check', async () => {
+    let versionChecks = 0;
+    _autoUpdateIo.exec = (async (cmd: string, opts?: any) => {
+      execCalls.push({ cmd, opts });
+      if (cmd === 'dkg --version') {
+        versionChecks += 1;
+        if (versionChecks === 1) throw new Error('dkg: command not found');
+        return { stdout: 'dkg 10.0.0-rc.11', stderr: '' };
+      }
+      return { stdout: '', stderr: '' };
+    }) as any;
+
+    const log = makeLog();
+    const result = await performNpmUpdateEdge('10.0.0-rc.12', '10.0.0-rc.11', log.fn);
+    expect(result).toBe('failed');
+    expect(execCalls.map((call) => call.cmd)).toEqual([
+      'npm install -g @origintrail-official/dkg@10.0.0-rc.12',
+      'dkg --version',
+      'npm install -g @origintrail-official/dkg@10.0.0-rc.11',
+      'dkg --version',
+    ]);
+    expect(log.calls.some((message) => message.includes('rollback restored'))).toBe(true);
   });
 
   it('surfaces a prefix-configuration advisory on EACCES', async () => {

--- a/packages/cli/test/rfc-41-bundle-b.test.ts
+++ b/packages/cli/test/rfc-41-bundle-b.test.ts
@@ -289,6 +289,31 @@ describe('performNpmUpdateEdge (Bundle B1b)', () => {
     expect(log.calls.some((message) => message.includes('rollback restored'))).toBe(true);
   });
 
+  it('rolls back on an exact-version mismatch, including semver prefix collisions', async () => {
+    let versionChecks = 0;
+    _autoUpdateIo.exec = (async (cmd: string, opts?: any) => {
+      execCalls.push({ cmd, opts });
+      if (cmd === 'dkg --version') {
+        versionChecks += 1;
+        return versionChecks === 1
+          ? { stdout: 'dkg 10.0.0-rc.12', stderr: '' }
+          : { stdout: 'dkg 10.0.0-rc.0', stderr: '' };
+      }
+      return { stdout: '', stderr: '' };
+    }) as any;
+
+    const log = makeLog();
+    const result = await performNpmUpdateEdge('10.0.0-rc.1', '10.0.0-rc.0', log.fn);
+    expect(result).toBe('failed');
+    expect(execCalls.map((call) => call.cmd)).toEqual([
+      'npm install -g @origintrail-official/dkg@10.0.0-rc.1',
+      'dkg --version',
+      'npm install -g @origintrail-official/dkg@10.0.0-rc.0',
+      'dkg --version',
+    ]);
+    expect(log.calls.some((message) => message.includes('expected 10.0.0-rc.1'))).toBe(true);
+  });
+
   it('surfaces a prefix-configuration advisory on EACCES', async () => {
     _autoUpdateIo.exec = (() => {
       const err: any = new Error("EACCES: permission denied, mkdir '/usr/local/lib/node_modules'");

--- a/scripts/devnet-test-issue-1567-global-cli-rollback.sh
+++ b/scripts/devnet-test-issue-1567-global-cli-rollback.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Host-level devnet regression for #1567. It exercises the real edge updater
+# orchestration in an isolated npm prefix/PATH: the target install reports a
+# semver-prefix collision (rc.12 for expected rc.1), so verification must reject
+# it and the previous rc.0 CLI must be restored.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+tmp="$(mktemp -d "${TMPDIR:-/tmp}/dkg-1567.XXXXXX")"
+trap 'rm -rf "$tmp"' EXIT INT TERM
+mkdir -p "$tmp/bin" "$tmp/home"
+version_file="$tmp/version"
+printf '%s\n' '10.0.0-rc.0' >"$version_file"
+
+printf '%s\n' '#!/bin/sh' \
+  'case "$*" in' \
+  '  *10.0.0-rc.1*) printf "%s\n" "10.0.0-rc.12" >"$FAKE_DKG_VERSION_FILE" ;;' \
+  '  *10.0.0-rc.0*) printf "%s\n" "10.0.0-rc.0" >"$FAKE_DKG_VERSION_FILE" ;;' \
+  '  *) exit 2 ;;' \
+  'esac' >"$tmp/bin/npm"
+printf '%s\n' '#!/bin/sh' \
+  'printf "dkg %s\n" "$(cat "$FAKE_DKG_VERSION_FILE")"' >"$tmp/bin/dkg"
+chmod +x "$tmp/bin/npm" "$tmp/bin/dkg"
+
+result="$(
+  PATH="$tmp/bin:$PATH" DKG_HOME="$tmp/home" FAKE_DKG_VERSION_FILE="$version_file" \
+  node --input-type=module <<'NODE'
+import { performNpmUpdateEdge } from './packages/cli/dist/daemon/auto-update.js';
+const logs = [];
+const result = await performNpmUpdateEdge('10.0.0-rc.1', '10.0.0-rc.0', (line) => logs.push(line));
+process.stdout.write(JSON.stringify({ result, logs }));
+NODE
+)"
+
+RESULT="$result" node -e '
+const value = JSON.parse(process.env.RESULT);
+if (value.result !== "failed") throw new Error(`expected failed-with-rollback, got ${value.result}`);
+if (!value.logs.some((line) => line.includes("expected 10.0.0-rc.1"))) throw new Error("exact mismatch was not detected");
+if (!value.logs.some((line) => line.includes("rollback restored"))) throw new Error("rollback was not verified");
+'
+[[ "$(cat "$version_file")" == 10.0.0-rc.0 ]] || { echo "[#1567] FAIL: previous CLI not restored" >&2; exit 1; }
+[[ "$(cat "$tmp/home/previous-version")" == 10.0.0-rc.0 ]] || { echo "[#1567] FAIL: rollback target not recorded" >&2; exit 1; }
+echo "[#1567] PASS: exact-version self-check rejected rc.12 and restored rc.0"


### PR DESCRIPTION
## Summary

- run the newly installed global `dkg --version` before reporting update success
- verify both command resolution and the exact target version
- automatically reinstall and verify the recorded previous version on failure
- refuse daemon restart when verification fails, with critical rollback diagnostics

Closes #1567

## Verification

- `pnpm --filter @origintrail-official/dkg run build`
- added a rollback regression covering a torn install whose `dkg` command is missing
