### PR TITLE
fix(cli): keep status quad count nonblocking

### DIFF
--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -284,11 +284,14 @@ export interface DaemonStatusResponse {
   } | null;
   // Triple-store backend fields (RFC 120). For local backends only
   // `storeBackend` is meaningful; external backends additionally surface
-  // `storeUrl` and a TTL-cached `storeQuads` count. `null` when local /
-  // unreachable.
+  // `storeUrl` and a TTL-cached `storeQuads` count. `storeQuadsStatus`
+  // distinguishes an initial background refresh from an unreachable store.
+  // Older daemons omit the status; consumers should retain the legacy
+  // `null` = unreachable fallback in that case.
   storeBackend?: string;
   storeUrl?: string | null;
   storeQuads?: number | null;
+  storeQuadsStatus?: 'pending' | 'ready' | 'unreachable';
   // Concurrency admission control (PR #1209 limiter, surfaced by #1230):
   // inFlight = requests currently holding a slot, max = effective cap
   // (0 = disabled), rejectedTotal = cumulative 503-shed count since boot.

--- a/packages/cli/src/commands/lifecycle.ts
+++ b/packages/cli/src/commands/lifecycle.ts
@@ -287,12 +287,16 @@ program
       // bytes are graphed via /api/dashboard); external backends print
       // backend + endpoint + quad count, falling back to a clear
       // "unreachable" signal when the daemon couldn't talk to the
-      // remote store. Quad count = null is rare in practice (cached
-      // every 30 s on the daemon side) so when it shows up the
-      // operator should treat it as an alert, not a no-op.
+      // remote store. A new daemon marks the initial background count
+      // as pending so it renders as CHECKING; absent that marker, null
+      // retains its legacy unreachable meaning for older daemons.
       const backend = s.storeBackend ?? 'oxigraph-worker';
       if (s.storeUrl) {
-        const quads = s.storeQuads == null ? 'UNREACHABLE' : `${s.storeQuads.toLocaleString()} quads`;
+        const quads = s.storeQuadsStatus === 'pending'
+          ? 'CHECKING'
+          : s.storeQuads == null
+            ? 'UNREACHABLE'
+            : `${s.storeQuads.toLocaleString()} quads`;
         console.log(`  Store:     ${backend} (${s.storeUrl}) — ${quads}`);
       } else {
         console.log(`  Store:     ${backend}`);

--- a/packages/cli/src/daemon/routes/status.ts
+++ b/packages/cli/src/daemon/routes/status.ts
@@ -408,11 +408,13 @@ function createRouteEvmProvider(rpcUrl: string, rpcUrls?: string[]): ethers.Json
 // expensive on a large namespace, and the route is polled by the
 // dashboard, telemetry, and `dkg status` operators. 30 s TTL is short
 // enough that a fresh wipe / bulk publish shows up quickly without
-// flooding Blazegraph. Local backends bypass this entirely (file-bytes
-// metric stays on the metrics collector tick).
+// flooding Blazegraph. Cold/stale callers get the current snapshot while
+// one refresh runs in the background, so status never waits on the count.
+// Local backends bypass this entirely (file-bytes metric stays on the
+// metrics collector tick).
 const STORE_QUADS_CACHE_TTL_MS = 30_000;
 let storeQuadsCache: { value: number | null; fetchedAt: number } | null = null;
-let storeQuadsInflight: Promise<number | null> | null = null;
+let storeQuadsInflight: Promise<void> | null = null;
 
 /** Drop cached quad counts (e.g. when the managed Oxigraph child exits). */
 export function invalidateExternalStoreQuadsCache(): void {
@@ -420,40 +422,42 @@ export function invalidateExternalStoreQuadsCache(): void {
   storeQuadsInflight = null;
 }
 
-async function getCachedExternalStoreQuads(
+function getCachedExternalStoreQuads(
   agent: DKGAgent,
   now: number,
-): Promise<number | null> {
+): number | null {
   if (storeQuadsCache && now - storeQuadsCache.fetchedAt < STORE_QUADS_CACHE_TTL_MS) {
     return storeQuadsCache.value;
   }
-  if (storeQuadsInflight) return storeQuadsInflight;
 
-  storeQuadsInflight = (async () => {
-    try {
-      const r = await agent.store.query(
-        'SELECT (COUNT(*) AS ?c) WHERE { GRAPH ?g { ?s ?p ?o } }',
-      );
-      let value: number | null = null;
-      if (r.type === 'bindings' && r.bindings.length > 0) {
-        const cell = r.bindings[0].c ?? '';
-        const digits = cell.match(/\d+/)?.[0];
-        value = digits ? parseInt(digits, 10) : 0;
+  const currentValue = storeQuadsCache?.value ?? null;
+  if (!storeQuadsInflight) {
+    const refresh = (async () => {
+      try {
+        const r = await agent.store.query(
+          'SELECT (COUNT(*) AS ?c) WHERE { GRAPH ?g { ?s ?p ?o } }',
+        );
+        let value: number | null = null;
+        if (r.type === 'bindings' && r.bindings.length > 0) {
+          const cell = r.bindings[0].c ?? '';
+          const digits = cell.match(/\d+/)?.[0];
+          value = digits ? parseInt(digits, 10) : 0;
+        }
+        storeQuadsCache = { value, fetchedAt: Date.now() };
+      } catch {
+        // Surface "unknown" rather than a stale value; operators can
+        // distinguish unreachable from genuinely-empty via storeBackend +
+        // their network logs. Cache the null briefly to avoid hammering
+        // a flapping endpoint.
+        storeQuadsCache = { value: null, fetchedAt: Date.now() };
       }
-      storeQuadsCache = { value, fetchedAt: Date.now() };
-      return value;
-    } catch {
-      // Surface "unknown" rather than a stale value; operators can
-      // distinguish unreachable from genuinely-empty via storeBackend +
-      // their network logs. Cache the null briefly to avoid hammering
-      // a flapping endpoint.
-      storeQuadsCache = { value: null, fetchedAt: Date.now() };
-      return null;
-    } finally {
-      storeQuadsInflight = null;
-    }
-  })();
-  return storeQuadsInflight;
+    })();
+    storeQuadsInflight = refresh;
+    void refresh.finally(() => {
+      if (storeQuadsInflight === refresh) storeQuadsInflight = null;
+    });
+  }
+  return currentValue;
 }
 
 async function getRegistryCacheSnapshot(): Promise<RegistryCacheSnapshot> {
@@ -696,7 +700,7 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
       // (e.g. after a failed revive) instead of it always looking healthy.
       storeQuads:
         isExternalBackend(config.store?.backend) || config.store?.backend === 'oxigraph-server'
-          ? await getCachedExternalStoreQuads(agent, Date.now())
+          ? getCachedExternalStoreQuads(agent, Date.now())
           : null,
       uptimeMs: Date.now() - startedAt,
       // Concurrency admission control (PR #1209): inFlight = requests currently

--- a/packages/cli/src/daemon/routes/status.ts
+++ b/packages/cli/src/daemon/routes/status.ts
@@ -413,7 +413,17 @@ function createRouteEvmProvider(rpcUrl: string, rpcUrls?: string[]): ethers.Json
 // Local backends bypass this entirely (file-bytes metric stays on the
 // metrics collector tick).
 const STORE_QUADS_CACHE_TTL_MS = 30_000;
-let storeQuadsCache: { value: number | null; fetchedAt: number } | null = null;
+type StoreQuadsStatus = 'pending' | 'ready' | 'unreachable';
+interface StoreQuadsSnapshot {
+  value: number | null;
+  status: StoreQuadsStatus;
+}
+
+let storeQuadsCache: {
+  value: number | null;
+  status: Exclude<StoreQuadsStatus, 'pending'>;
+  fetchedAt: number;
+} | null = null;
 let storeQuadsInflight: Promise<void> | null = null;
 
 /** Drop cached quad counts (e.g. when the managed Oxigraph child exits). */
@@ -425,12 +435,14 @@ export function invalidateExternalStoreQuadsCache(): void {
 function getCachedExternalStoreQuads(
   agent: DKGAgent,
   now: number,
-): number | null {
+): StoreQuadsSnapshot {
   if (storeQuadsCache && now - storeQuadsCache.fetchedAt < STORE_QUADS_CACHE_TTL_MS) {
-    return storeQuadsCache.value;
+    return { value: storeQuadsCache.value, status: storeQuadsCache.status };
   }
 
-  const currentValue = storeQuadsCache?.value ?? null;
+  const currentSnapshot: StoreQuadsSnapshot = storeQuadsCache
+    ? { value: storeQuadsCache.value, status: storeQuadsCache.status }
+    : { value: null, status: 'pending' };
   if (!storeQuadsInflight) {
     const refresh = (async () => {
       try {
@@ -443,13 +455,17 @@ function getCachedExternalStoreQuads(
           const digits = cell.match(/\d+/)?.[0];
           value = digits ? parseInt(digits, 10) : 0;
         }
-        storeQuadsCache = { value, fetchedAt: Date.now() };
+        storeQuadsCache = {
+          value,
+          status: value === null ? 'unreachable' : 'ready',
+          fetchedAt: Date.now(),
+        };
       } catch {
         // Surface "unknown" rather than a stale value; operators can
         // distinguish unreachable from genuinely-empty via storeBackend +
         // their network logs. Cache the null briefly to avoid hammering
         // a flapping endpoint.
-        storeQuadsCache = { value: null, fetchedAt: Date.now() };
+        storeQuadsCache = { value: null, status: 'unreachable', fetchedAt: Date.now() };
       }
     })();
     storeQuadsInflight = refresh;
@@ -457,7 +473,7 @@ function getCachedExternalStoreQuads(
       if (storeQuadsInflight === refresh) storeQuadsInflight = null;
     });
   }
-  return currentValue;
+  return currentSnapshot;
 }
 
 async function getRegistryCacheSnapshot(): Promise<RegistryCacheSnapshot> {
@@ -649,6 +665,11 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
       advertisedAddresses: agent.multiaddrs,
       configuredAnnounceAddresses: config.announceAddresses ?? [],
     });
+    const reportsExternalStoreQuads =
+      isExternalBackend(config.store?.backend) || config.store?.backend === 'oxigraph-server';
+    const storeQuadsSnapshot = reportsExternalStoreQuads
+      ? getCachedExternalStoreQuads(agent, Date.now())
+      : null;
     // RFC-41 §4.9 + §4.3: expose build-info + installMode for
     // doctor / agent disambiguation. loadBuildInfo() falls back to
     // the {commit: "uncommitted", distTag: "monorepo", ...}
@@ -672,8 +693,7 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
       networkName: network?.networkName ?? null,
       storeBackend: config.store?.backend ?? "oxigraph-worker",
       // External backend visibility (RFC 120 / plan PR 1 item 3). For
-      // local backends both fields stay null so the response shape is
-      // stable across deployments.
+      // local backends the URL/count stay null and count status is omitted.
       storeUrl: isExternalBackend(config.store?.backend)
         ? (() => {
             const opts = (config.store?.options ?? {}) as Record<string, unknown>;
@@ -698,10 +718,8 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
       // for that backend (getStoreBytes is null, there's no store.nq), and a
       // failed query here is how operators see the managed server is down
       // (e.g. after a failed revive) instead of it always looking healthy.
-      storeQuads:
-        isExternalBackend(config.store?.backend) || config.store?.backend === 'oxigraph-server'
-          ? getCachedExternalStoreQuads(agent, Date.now())
-          : null,
+      storeQuads: storeQuadsSnapshot?.value ?? null,
+      storeQuadsStatus: storeQuadsSnapshot?.status,
       uptimeMs: Date.now() - startedAt,
       // Concurrency admission control (PR #1209): inFlight = requests currently
       // holding a slot, max = the configured cap (0 = disabled), rejectedTotal =

--- a/packages/cli/test/status-command-store.test.ts
+++ b/packages/cli/test/status-command-store.test.ts
@@ -1,0 +1,58 @@
+import { Command } from 'commander';
+import { describe, expect, it, vi } from 'vitest';
+import { ApiClient } from '../src/api-client.js';
+import { registerLifecycleCommands } from '../src/commands/lifecycle.js';
+
+async function renderStatus(store: {
+  storeQuads: number | null;
+  storeQuadsStatus?: 'pending' | 'ready' | 'unreachable';
+}): Promise<string> {
+  const lines: string[] = [];
+  const logSpy = vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+    lines.push(args.map(String).join(' '));
+  });
+  const connectSpy = vi.spyOn(ApiClient, 'connect').mockResolvedValue({
+    controlPlaneWarning: null,
+    status: async () => ({
+      name: 'status-store-test',
+      peerId: 'peer-status-store-test',
+      uptimeMs: 1_000,
+      connectedPeers: 0,
+      relayConnected: false,
+      multiaddrs: [],
+      storeBackend: 'sparql-http',
+      storeUrl: 'http://127.0.0.1:9999/query',
+      ...store,
+    }),
+  } as never);
+
+  try {
+    const program = new Command();
+    program.exitOverride();
+    registerLifecycleCommands(program);
+    await program.parseAsync(['node', 'dkg', 'status']);
+    return lines.join('\n');
+  } finally {
+    connectSpy.mockRestore();
+    logSpy.mockRestore();
+  }
+}
+
+describe('dkg status external-store rendering', () => {
+  it('renders a cold healthy store as checking rather than unreachable', async () => {
+    const output = await renderStatus({
+      storeQuads: null,
+      storeQuadsStatus: 'pending',
+    });
+
+    expect(output).toContain('CHECKING');
+    expect(output).not.toContain('UNREACHABLE');
+  });
+
+  it('keeps null from older daemons as the legacy unreachable signal', async () => {
+    const output = await renderStatus({ storeQuads: null });
+
+    expect(output).toContain('UNREACHABLE');
+    expect(output).not.toContain('CHECKING');
+  });
+});

--- a/packages/cli/test/status-route-store-quads.test.ts
+++ b/packages/cli/test/status-route-store-quads.test.ts
@@ -73,12 +73,18 @@ async function closeServer(server: Server): Promise<void> {
 
 async function fetchStatus(baseUrl: string): Promise<{
   status: number;
-  body: { storeQuads: number | null };
+  body: {
+    storeQuads: number | null;
+    storeQuadsStatus?: 'pending' | 'ready' | 'unreachable';
+  };
 }> {
   const response = await fetch(`${baseUrl}/api/status`);
   return {
     status: response.status,
-    body: await response.json() as { storeQuads: number | null },
+    body: await response.json() as {
+      storeQuads: number | null;
+      storeQuadsStatus?: 'pending' | 'ready' | 'unreachable';
+    },
   };
 }
 
@@ -88,7 +94,7 @@ describe('/api/status external-store quad count', () => {
     vi.restoreAllMocks();
   });
 
-  it('returns an unknown cold count without waiting for the store refresh', async () => {
+  it('returns a pending cold count without waiting for the store refresh', async () => {
     const countResult = deferred<unknown>();
     const queryStarted = deferred<void>();
     let queryCalls = 0;
@@ -101,7 +107,10 @@ describe('/api/status external-store quad count', () => {
     try {
       const responsePromise = fetch(`${baseUrl}/api/status`).then(async (response) => ({
         status: response.status,
-        body: await response.json() as { storeQuads: number | null },
+        body: await response.json() as {
+          storeQuads: number | null;
+          storeQuadsStatus?: 'pending' | 'ready' | 'unreachable';
+        },
       }));
       await queryStarted.promise;
 
@@ -118,7 +127,10 @@ describe('/api/status external-store quad count', () => {
       await responsePromise;
 
       expect(immediate).not.toBe(timeout);
-      expect(immediate).toMatchObject({ status: 200, body: { storeQuads: null } });
+      expect(immediate).toMatchObject({
+        status: 200,
+        body: { storeQuads: null, storeQuadsStatus: 'pending' },
+      });
       expect(queryCalls).toBe(1);
     } finally {
       countResult.resolve({ type: 'bindings', bindings: [] });
@@ -142,6 +154,8 @@ describe('/api/status external-store quad count', () => {
       ]);
       expect(firstCold.body.storeQuads).toBeNull();
       expect(secondCold.body.storeQuads).toBeNull();
+      expect(firstCold.body.storeQuadsStatus).toBe('pending');
+      expect(secondCold.body.storeQuadsStatus).toBe('pending');
       expect(queryCalls).toBe(1);
 
       firstCount.resolve({
@@ -152,6 +166,7 @@ describe('/api/status external-store quad count', () => {
 
       const fresh = await fetchStatus(baseUrl);
       expect(fresh.body.storeQuads).toBe(123);
+      expect(fresh.body.storeQuadsStatus).toBe('ready');
       expect(queryCalls).toBe(1);
 
       const staleNow = Date.now() + 30_001;
@@ -162,6 +177,8 @@ describe('/api/status external-store quad count', () => {
       ]);
       expect(firstStale.body.storeQuads).toBe(123);
       expect(secondStale.body.storeQuads).toBe(123);
+      expect(firstStale.body.storeQuadsStatus).toBe('ready');
+      expect(secondStale.body.storeQuadsStatus).toBe('ready');
       expect(queryCalls).toBe(2);
 
       staleRefresh.reject(new Error('store unavailable'));
@@ -169,6 +186,7 @@ describe('/api/status external-store quad count', () => {
 
       const afterFailure = await fetchStatus(baseUrl);
       expect(afterFailure.body.storeQuads).toBeNull();
+      expect(afterFailure.body.storeQuadsStatus).toBe('unreachable');
       expect(queryCalls).toBe(2);
     } finally {
       firstCount.resolve({ type: 'bindings', bindings: [] });

--- a/packages/cli/test/status-route-store-quads.test.ts
+++ b/packages/cli/test/status-route-store-quads.test.ts
@@ -1,0 +1,179 @@
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  handleStatusRoutes,
+  invalidateExternalStoreQuadsCache,
+} from '../src/daemon/routes/status.js';
+import type { RequestContext } from '../src/daemon/routes/context.js';
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason: unknown) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((done, fail) => {
+    resolve = done;
+    reject = fail;
+  });
+  return { promise, resolve, reject };
+}
+
+async function startStatusServer(query: () => Promise<unknown>): Promise<{
+  server: Server;
+  baseUrl: string;
+}> {
+  const server = createServer(async (req, res) => {
+    const url = new URL(req.url ?? '/', 'http://127.0.0.1');
+    await handleStatusRoutes({
+      req,
+      res,
+      path: url.pathname,
+      url,
+      network: null,
+      config: {
+        name: 'status-store-quads-test',
+        nodeRole: 'edge',
+        chain: { type: 'mock' },
+        store: {
+          backend: 'sparql-http',
+          options: { url: 'http://127.0.0.1:9/query' },
+        },
+      },
+      startedAt: Date.now(),
+      agent: {
+        peerId: 'peer-status-store-quads-test',
+        multiaddrs: [],
+        store: { query },
+        node: {
+          libp2p: { getConnections: () => [] },
+          getRelayStats: () => null,
+        },
+        publisher: { getIdentityId: () => 0n },
+      },
+      nodeVersion: '0.0.0-test',
+      nodeCommit: '',
+      admission: { inFlight: 0, max: 0, rejectedTotal: 0 },
+    } as unknown as RequestContext);
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address() as AddressInfo;
+  return { server, baseUrl: `http://127.0.0.1:${address.port}` };
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve());
+  });
+}
+
+async function fetchStatus(baseUrl: string): Promise<{
+  status: number;
+  body: { storeQuads: number | null };
+}> {
+  const response = await fetch(`${baseUrl}/api/status`);
+  return {
+    status: response.status,
+    body: await response.json() as { storeQuads: number | null },
+  };
+}
+
+describe('/api/status external-store quad count', () => {
+  afterEach(() => {
+    invalidateExternalStoreQuadsCache();
+    vi.restoreAllMocks();
+  });
+
+  it('returns an unknown cold count without waiting for the store refresh', async () => {
+    const countResult = deferred<unknown>();
+    const queryStarted = deferred<void>();
+    let queryCalls = 0;
+    const { server, baseUrl } = await startStatusServer(async () => {
+      queryCalls += 1;
+      queryStarted.resolve();
+      return countResult.promise;
+    });
+
+    try {
+      const responsePromise = fetch(`${baseUrl}/api/status`).then(async (response) => ({
+        status: response.status,
+        body: await response.json() as { storeQuads: number | null },
+      }));
+      await queryStarted.promise;
+
+      const timeout = Symbol('status timed out');
+      const immediate = await Promise.race([
+        responsePromise,
+        new Promise<typeof timeout>((resolve) => setTimeout(() => resolve(timeout), 500)),
+      ]);
+
+      countResult.resolve({
+        type: 'bindings',
+        bindings: [{ c: '"123"^^<http://www.w3.org/2001/XMLSchema#integer>' }],
+      });
+      await responsePromise;
+
+      expect(immediate).not.toBe(timeout);
+      expect(immediate).toMatchObject({ status: 200, body: { storeQuads: null } });
+      expect(queryCalls).toBe(1);
+    } finally {
+      countResult.resolve({ type: 'bindings', bindings: [] });
+      await closeServer(server);
+    }
+  });
+
+  it('returns a stale count while one refresh runs and caches refresh failures as unknown', async () => {
+    const firstCount = deferred<unknown>();
+    const staleRefresh = deferred<unknown>();
+    let queryCalls = 0;
+    const { server, baseUrl } = await startStatusServer(async () => {
+      queryCalls += 1;
+      return queryCalls === 1 ? firstCount.promise : staleRefresh.promise;
+    });
+
+    try {
+      const [firstCold, secondCold] = await Promise.all([
+        fetchStatus(baseUrl),
+        fetchStatus(baseUrl),
+      ]);
+      expect(firstCold.body.storeQuads).toBeNull();
+      expect(secondCold.body.storeQuads).toBeNull();
+      expect(queryCalls).toBe(1);
+
+      firstCount.resolve({
+        type: 'bindings',
+        bindings: [{ c: '"123"^^<http://www.w3.org/2001/XMLSchema#integer>' }],
+      });
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      const fresh = await fetchStatus(baseUrl);
+      expect(fresh.body.storeQuads).toBe(123);
+      expect(queryCalls).toBe(1);
+
+      const staleNow = Date.now() + 30_001;
+      vi.spyOn(Date, 'now').mockReturnValue(staleNow);
+      const [firstStale, secondStale] = await Promise.all([
+        fetchStatus(baseUrl),
+        fetchStatus(baseUrl),
+      ]);
+      expect(firstStale.body.storeQuads).toBe(123);
+      expect(secondStale.body.storeQuads).toBe(123);
+      expect(queryCalls).toBe(2);
+
+      staleRefresh.reject(new Error('store unavailable'));
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      const afterFailure = await fetchStatus(baseUrl);
+      expect(afterFailure.body.storeQuads).toBeNull();
+      expect(queryCalls).toBe(2);
+    } finally {
+      firstCount.resolve({ type: 'bindings', bindings: [] });
+      staleRefresh.resolve({ type: 'bindings', bindings: [] });
+      await closeServer(server);
+    }
+  });
+});

--- a/packages/cli/vitest.unit.config.ts
+++ b/packages/cli/vitest.unit.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
           'test/reconcile-503-mapping.test.ts',
           'test/config.test.ts',
           'test/status-route-rpc.test.ts',
+          'test/status-route-store-quads.test.ts',
           'test/memory-graph-events.test.ts',
           'test/memory-turn-route.test.ts',
           'test/trust-endpoint-validation.test.ts',

--- a/packages/cli/vitest.unit.config.ts
+++ b/packages/cli/vitest.unit.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
           'test/config.test.ts',
           'test/status-route-rpc.test.ts',
           'test/status-route-store-quads.test.ts',
+          'test/status-command-store.test.ts',
           'test/memory-graph-events.test.ts',
           'test/memory-turn-route.test.ts',
           'test/trust-endpoint-validation.test.ts',


### PR DESCRIPTION
## Summary

Keeps `GET /api/status` responsive when an external SPARQL store is slow or saturated. Previously, a cold or stale quad-count cache made the whole status request wait for `COUNT(*)`; now the count refreshes in the background without falsely reporting a healthy cold store as unreachable.

## Changes

- Return a fresh cached count immediately.
- Return the stale count immediately while one refresh runs.
- Return `storeQuads: null` with `storeQuadsStatus: "pending"` on a cold cache.
- Render the pending state as `CHECKING` in `dkg status`.
- Report query failures as `storeQuadsStatus: "unreachable"`.
- Preserve the 30-second TTL, single-flight refreshes, and legacy `null` handling for older daemons.

## Test Plan

- [x] Focused HTTP and CLI status regressions pass (4/4).
- [x] CLI TypeScript build passes.
- [x] Runtime package build passes.
- [ ] Full CLI unit suite: 1,530 tests passed and 48 skipped; five Hardhat-dependent integration suites could not start locally because their shared context file was absent.
- [ ] Manually tested with `dkg start` (not applicable to this isolated route regression).

## Related Issues

None.
