### PR TITLE
fix(cli): verify the Edge daemon restart entry point (#1567 follow-up)

### DIFF
--- a/packages/cli/src/daemon/auto-update.ts
+++ b/packages/cli/src/daemon/auto-update.ts
@@ -1561,6 +1561,7 @@ export async function performNpmUpdateEdge(
   targetVersion: string,
   currentVersion: string | null,
   log: (msg: string) => void,
+  restartCommand: EdgeRestartCommand = currentEdgeRestartCommand(),
 ): Promise<UpdateStatus> {
   if (_updateInProgress) {
     log("Auto-update (npm-edge): another update is already in progress, skipping");
@@ -1573,7 +1574,7 @@ export async function performNpmUpdateEdge(
     return "failed";
   }
   try {
-    return await _performNpmUpdateInnerEdge(targetVersion, currentVersion, log);
+    return await _performNpmUpdateInnerEdge(targetVersion, currentVersion, log, restartCommand);
   } finally {
     await releaseUpdateLock();
     _updateInProgress = false;
@@ -1584,11 +1585,12 @@ async function _performNpmUpdateInnerEdge(
   targetVersion: string,
   currentVersion: string | null,
   log: (msg: string) => void,
+  restartCommand: EdgeRestartCommand,
 ): Promise<UpdateStatus> {
   // Destructure from `_autoUpdateIo` so unit tests can stub each
   // dependency — matches the existing `_performNpmUpdateInner`
   // (Core) pattern.
-  const { writeFile, exec: execAsyncIo, dkgDir } = _autoUpdateIo;
+  const { writeFile, exec: execAsyncIo, execFile: execFileAsyncIo, dkgDir } = _autoUpdateIo;
   const previousVersionPath = join(dkgDir(), "previous-version");
   if (currentVersion && currentVersion.length > 0) {
     try {
@@ -1611,7 +1613,7 @@ async function _performNpmUpdateInnerEdge(
 
   // 5-minute timeout covers slow network + npm registry round-trips on
   // CI / homegrown runners. Any longer is almost certainly a hung process.
-  const installCmd = `npm install -g ${CLI_NPM_PACKAGE}@${targetVersion}`;
+  const installCmd = globalCliInstallCommand(targetVersion);
   log(`Auto-update (npm-edge): running '${installCmd}'…`);
   try {
     const installStart = Date.now();
@@ -1631,24 +1633,15 @@ async function _performNpmUpdateInnerEdge(
     return "failed";
   }
 
-  try {
-    const reported = await verifyGlobalDkgVersion(execAsyncIo, targetVersion, 'self-check');
-    log(`Auto-update (npm-edge): self-check passed (${reported}).`);
-  } catch (verifyErr: any) {
-    log(`Auto-update (npm-edge): post-install self-check failed — ${verifyErr?.message ?? verifyErr}.`);
-    if (!currentVersion) {
-      log('Auto-update (npm-edge): previous version is unknown; automatic rollback is unavailable.');
-      return 'failed';
-    }
-    const rollbackCmd = `npm install -g ${CLI_NPM_PACKAGE}@${currentVersion}`;
-    log(`Auto-update (npm-edge): rolling back with '${rollbackCmd}'…`);
-    try {
-      await installGlobalCliVersion(execAsyncIo, currentVersion);
-      const reported = await verifyGlobalDkgVersion(execAsyncIo, currentVersion, 'rollback');
-      log(`Auto-update (npm-edge): rollback restored ${reported}.`);
-    } catch (rollbackErr: any) {
-      log(`Auto-update (npm-edge): CRITICAL rollback failed — ${rollbackErr?.message ?? rollbackErr}.`);
-    }
+  const verified = await verifyInstalledCliOrRollback({
+    execIo: execAsyncIo,
+    execFileIo: execFileAsyncIo,
+    targetVersion,
+    currentVersion,
+    restartCommand,
+    log,
+  });
+  if (!verified) {
     return 'failed';
   }
 
@@ -1660,9 +1653,37 @@ async function _performNpmUpdateInnerEdge(
 }
 
 type EdgeExec = typeof _autoUpdateIo.exec;
+type EdgeExecFile = typeof _autoUpdateIo.execFile;
+
+/** The exact Node/module command the supervisor will use for the next worker. */
+export interface EdgeRestartCommand {
+  nodeExecutable: string;
+  nodeExecArgv: readonly string[];
+  restartEntryPoint: string;
+}
+
+function currentEdgeRestartCommand(): EdgeRestartCommand {
+  // Edge workers are spawned as `process.execPath + process.execArgv +
+  // resolveDaemonEntryPoint()`. Inside that worker argv[1] is therefore the
+  // concrete module the already-running supervisor will resolve again after
+  // the in-place global install, even when another `dkg` shadows it on PATH.
+  const restartEntryPoint = process.argv[1];
+  if (!restartEntryPoint) {
+    throw new Error('Cannot verify Edge update: current CLI restart entry point is unavailable.');
+  }
+  return {
+    nodeExecutable: process.execPath,
+    nodeExecArgv: process.execArgv,
+    restartEntryPoint,
+  };
+}
+
+function globalCliInstallCommand(version: string): string {
+  return `npm install -g ${CLI_NPM_PACKAGE}@${version}`;
+}
 
 async function installGlobalCliVersion(execIo: EdgeExec, version: string): Promise<void> {
-  await execIo(`npm install -g ${CLI_NPM_PACKAGE}@${version}`, {
+  await execIo(globalCliInstallCommand(version), {
     encoding: 'utf-8',
     timeout: 300_000,
   });
@@ -1673,20 +1694,69 @@ function parseReportedDkgVersion(output: string): string | undefined {
 }
 
 async function verifyGlobalDkgVersion(
-  execIo: EdgeExec,
+  execFileIo: EdgeExecFile,
+  restartCommand: EdgeRestartCommand,
   expectedVersion: string,
   context: 'self-check' | 'rollback',
 ): Promise<string> {
-  const { stdout, stderr } = await execIo('dkg --version', {
-    encoding: 'utf-8',
-    timeout: 30_000,
-  });
+  const { stdout, stderr } = await execFileIo(
+    restartCommand.nodeExecutable,
+    [...restartCommand.nodeExecArgv, restartCommand.restartEntryPoint, '--version'],
+    {
+      encoding: 'utf-8',
+      timeout: 30_000,
+    },
+  );
   const reported = `${stdout ?? ''} ${stderr ?? ''}`.trim();
   const parsed = parseReportedDkgVersion(reported);
   if (parsed !== expectedVersion) {
     throw new Error(`${context} expected ${expectedVersion}, got ${parsed ?? (reported || 'empty version output')}`);
   }
   return reported;
+}
+
+async function verifyInstalledCliOrRollback(options: {
+  execIo: EdgeExec;
+  execFileIo: EdgeExecFile;
+  targetVersion: string;
+  currentVersion: string | null;
+  restartCommand: EdgeRestartCommand;
+  log: (msg: string) => void;
+}): Promise<boolean> {
+  const { execIo, execFileIo, targetVersion, currentVersion, restartCommand, log } = options;
+  try {
+    const reported = await verifyGlobalDkgVersion(
+      execFileIo,
+      restartCommand,
+      targetVersion,
+      'self-check',
+    );
+    log(`Auto-update (npm-edge): self-check passed (${reported}).`);
+    return true;
+  } catch (verifyErr: any) {
+    log(`Auto-update (npm-edge): post-install self-check failed — ${verifyErr?.message ?? verifyErr}.`);
+  }
+
+  if (!currentVersion) {
+    log('Auto-update (npm-edge): previous version is unknown; automatic rollback is unavailable.');
+    return false;
+  }
+
+  const rollbackCmd = globalCliInstallCommand(currentVersion);
+  log(`Auto-update (npm-edge): rolling back with '${rollbackCmd}'…`);
+  try {
+    await installGlobalCliVersion(execIo, currentVersion);
+    const reported = await verifyGlobalDkgVersion(
+      execFileIo,
+      restartCommand,
+      currentVersion,
+      'rollback',
+    );
+    log(`Auto-update (npm-edge): rollback restored ${reported}.`);
+  } catch (rollbackErr: any) {
+    log(`Auto-update (npm-edge): CRITICAL rollback failed — ${rollbackErr?.message ?? rollbackErr}.`);
+  }
+  return false;
 }
 
 export async function checkForUpdate(

--- a/packages/cli/src/daemon/auto-update.ts
+++ b/packages/cli/src/daemon/auto-update.ts
@@ -1561,7 +1561,6 @@ export async function performNpmUpdateEdge(
   targetVersion: string,
   currentVersion: string | null,
   log: (msg: string) => void,
-  restartCommand: EdgeRestartCommand = currentEdgeRestartCommand(),
 ): Promise<UpdateStatus> {
   if (_updateInProgress) {
     log("Auto-update (npm-edge): another update is already in progress, skipping");
@@ -1574,7 +1573,12 @@ export async function performNpmUpdateEdge(
     return "failed";
   }
   try {
-    return await _performNpmUpdateInnerEdge(targetVersion, currentVersion, log, restartCommand);
+    return await _performNpmUpdateInnerEdge(
+      targetVersion,
+      currentVersion,
+      log,
+      _autoUpdateIo.edgeRestartCommand(),
+    );
   } finally {
     await releaseUpdateLock();
     _updateInProgress = false;
@@ -1654,29 +1658,7 @@ async function _performNpmUpdateInnerEdge(
 
 type EdgeExec = typeof _autoUpdateIo.exec;
 type EdgeExecFile = typeof _autoUpdateIo.execFile;
-
-/** The exact Node/module command the supervisor will use for the next worker. */
-export interface EdgeRestartCommand {
-  nodeExecutable: string;
-  nodeExecArgv: readonly string[];
-  restartEntryPoint: string;
-}
-
-function currentEdgeRestartCommand(): EdgeRestartCommand {
-  // Edge workers are spawned as `process.execPath + process.execArgv +
-  // resolveDaemonEntryPoint()`. Inside that worker argv[1] is therefore the
-  // concrete module the already-running supervisor will resolve again after
-  // the in-place global install, even when another `dkg` shadows it on PATH.
-  const restartEntryPoint = process.argv[1];
-  if (!restartEntryPoint) {
-    throw new Error('Cannot verify Edge update: current CLI restart entry point is unavailable.');
-  }
-  return {
-    nodeExecutable: process.execPath,
-    nodeExecArgv: process.execArgv,
-    restartEntryPoint,
-  };
-}
+type EdgeRestartCommand = ReturnType<typeof _autoUpdateIo.edgeRestartCommand>;
 
 function globalCliInstallCommand(version: string): string {
   return `npm install -g ${CLI_NPM_PACKAGE}@${version}`;

--- a/packages/cli/src/daemon/manifest.ts
+++ b/packages/cli/src/daemon/manifest.ts
@@ -552,6 +552,20 @@ export const _autoUpdateIo = {
   exec: execAsync as (...args: any[]) => Promise<any>,
   execFile: execFileAsync as (...args: any[]) => Promise<any>,
   execSync: execSync as (...args: any[]) => any,
+  // Match the supervisor's next worker command exactly. Keeping this resolver
+  // on the existing IO seam lets tests substitute a real fixture entry point
+  // without exposing process argv details through performNpmUpdateEdge.
+  edgeRestartCommand: () => {
+    const restartEntryPoint = process.argv[1];
+    if (!restartEntryPoint) {
+      throw new Error('Cannot verify Edge update: current CLI restart entry point is unavailable.');
+    }
+    return {
+      nodeExecutable: process.execPath,
+      nodeExecArgv: process.execArgv,
+      restartEntryPoint,
+    };
+  },
   dkgDir,
   releasesDir,
   activeSlot: activeSlot as () => Promise<'a' | 'b'>,

--- a/packages/cli/test/edge-auto-update-entrypoint-e2e.test.ts
+++ b/packages/cli/test/edge-auto-update-entrypoint-e2e.test.ts
@@ -1,0 +1,103 @@
+import { execFileSync } from "node:child_process";
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { delimiter, join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { performNpmUpdateEdge } from "../src/daemon/auto-update.js";
+
+describe("Edge auto-update restart-entry self-check (real child processes)", () => {
+  const originalEnv = {
+    DKG_HOME: process.env.DKG_HOME,
+    PATH: process.env.PATH,
+    FAKE_DKG_VERSION_FILE: process.env.FAKE_DKG_VERSION_FILE,
+  };
+  let root: string | undefined;
+
+  afterEach(async () => {
+    for (const [name, value] of Object.entries(originalEnv)) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+    if (root) await rm(root, { recursive: true, force: true });
+    root = undefined;
+  });
+
+  it("rejects the restart entry's wrong version even when PATH's dkg reports the target", async () => {
+    root = await mkdtemp(join(tmpdir(), "dkg-edge-entry-e2e-"));
+    const binDir = join(root, "bin");
+    const dkgHome = join(root, "home");
+    const versionFile = join(root, "restart-entry-version");
+    const restartEntry = join(root, "restart-entry.mjs");
+    await mkdir(binDir, { recursive: true });
+    await mkdir(dkgHome, { recursive: true });
+    await writeFile(versionFile, "10.0.0-rc.0\n");
+
+    const fakeNpm = join(binDir, "npm");
+    await writeFile(
+      fakeNpm,
+      [
+        "#!/bin/sh",
+        'case "$*" in',
+        '  *10.0.0-rc.1*) printf "%s\\n" "10.0.0-rc.12" >"$FAKE_DKG_VERSION_FILE" ;;',
+        '  *10.0.0-rc.0*) printf "%s\\n" "10.0.0-rc.0" >"$FAKE_DKG_VERSION_FILE" ;;',
+        "  *) exit 2 ;;",
+        "esac",
+      ].join("\n"),
+    );
+    const pathDkg = join(binDir, "dkg");
+    await writeFile(pathDkg, '#!/bin/sh\nprintf "%s\\n" "dkg 10.0.0-rc.1"\n');
+    await chmod(fakeNpm, 0o755);
+    await chmod(pathDkg, 0o755);
+    await writeFile(
+      restartEntry,
+      [
+        "import { readFileSync } from 'node:fs';",
+        "const version = readFileSync(process.env.FAKE_DKG_VERSION_FILE, 'utf8').trim();",
+        "process.stdout.write(`dkg ${version}\\n`);",
+      ].join("\n"),
+    );
+
+    process.env.DKG_HOME = dkgHome;
+    process.env.FAKE_DKG_VERSION_FILE = versionFile;
+    process.env.PATH = `${binDir}${delimiter}${originalEnv.PATH ?? ""}`;
+    expect(
+      execFileSync(pathDkg, ["--version"], { encoding: "utf8" }).trim(),
+    ).toBe("dkg 10.0.0-rc.1");
+
+    const logs: string[] = [];
+    const result = await performNpmUpdateEdge(
+      "10.0.0-rc.1",
+      "10.0.0-rc.0",
+      (message) => logs.push(message),
+      {
+        nodeExecutable: process.execPath,
+        nodeExecArgv: [],
+        restartEntryPoint: restartEntry,
+      },
+    );
+
+    expect(result).toBe("failed");
+    expect(await readFile(versionFile, "utf8")).toBe("10.0.0-rc.0\n");
+    expect(await readFile(join(dkgHome, "previous-version"), "utf8")).toBe(
+      "10.0.0-rc.0",
+    );
+    expect(
+      logs.some((message) =>
+        message.includes("expected 10.0.0-rc.1, got 10.0.0-rc.12"),
+      ),
+    ).toBe(true);
+    expect(
+      logs.some((message) =>
+        message.includes("rollback restored dkg 10.0.0-rc.0"),
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/cli/test/edge-auto-update-entrypoint-e2e.test.ts
+++ b/packages/cli/test/edge-auto-update-entrypoint-e2e.test.ts
@@ -12,8 +12,10 @@ import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { performNpmUpdateEdge } from "../src/daemon/auto-update.js";
+import { _autoUpdateIo } from "../src/daemon/manifest.js";
 
 describe("Edge auto-update restart-entry self-check (real child processes)", () => {
+  const originalEdgeRestartCommand = _autoUpdateIo.edgeRestartCommand;
   const originalEnv = {
     DKG_HOME: process.env.DKG_HOME,
     PATH: process.env.PATH,
@@ -22,6 +24,7 @@ describe("Edge auto-update restart-entry self-check (real child processes)", () 
   let root: string | undefined;
 
   afterEach(async () => {
+    _autoUpdateIo.edgeRestartCommand = originalEdgeRestartCommand;
     for (const [name, value] of Object.entries(originalEnv)) {
       if (value === undefined) delete process.env[name];
       else process.env[name] = value;
@@ -71,17 +74,17 @@ describe("Edge auto-update restart-entry self-check (real child processes)", () 
     expect(
       execFileSync(pathDkg, ["--version"], { encoding: "utf8" }).trim(),
     ).toBe("dkg 10.0.0-rc.1");
+    _autoUpdateIo.edgeRestartCommand = () => ({
+      nodeExecutable: process.execPath,
+      nodeExecArgv: [],
+      restartEntryPoint: restartEntry,
+    });
 
     const logs: string[] = [];
     const result = await performNpmUpdateEdge(
       "10.0.0-rc.1",
       "10.0.0-rc.0",
       (message) => logs.push(message),
-      {
-        nodeExecutable: process.execPath,
-        nodeExecArgv: [],
-        restartEntryPoint: restartEntry,
-      },
     );
 
     expect(result).toBe("failed");

--- a/packages/cli/test/rfc-41-bundle-b.test.ts
+++ b/packages/cli/test/rfc-41-bundle-b.test.ts
@@ -234,6 +234,7 @@ describe('performNpmUpdateEdge (Bundle B1b)', () => {
       operations.push(`${file} ${args.join(' ')}`);
       return Promise.resolve({ stdout: 'dkg 10.0.0-rc.12', stderr: '' });
     }) as any;
+    _autoUpdateIo.edgeRestartCommand = () => restartCommand;
   });
 
   afterEach(() => {
@@ -246,7 +247,6 @@ describe('performNpmUpdateEdge (Bundle B1b)', () => {
       '10.0.0-rc.12',
       '10.0.0-rc.11',
       log.fn,
-      restartCommand,
     );
 
     expect(result).toBe('updated');
@@ -269,7 +269,7 @@ describe('performNpmUpdateEdge (Bundle B1b)', () => {
 
   it('warns when current version is unknown but still attempts the install', async () => {
     const log = makeLog();
-    const result = await performNpmUpdateEdge('10.0.0-rc.12', null, log.fn, restartCommand);
+    const result = await performNpmUpdateEdge('10.0.0-rc.12', null, log.fn);
 
     expect(result).toBe('updated');
     expect(existsSync(join(dkgHome, 'previous-version'))).toBe(false);
@@ -285,7 +285,7 @@ describe('performNpmUpdateEdge (Bundle B1b)', () => {
     }) as any;
 
     const log = makeLog();
-    const result = await performNpmUpdateEdge('99.99.99', '10.0.0-rc.11', log.fn, restartCommand);
+    const result = await performNpmUpdateEdge('99.99.99', '10.0.0-rc.11', log.fn);
 
     expect(result).toBe('failed');
     expect(log.calls.some((m) => m.includes('npm install -g failed'))).toBe(true);
@@ -310,7 +310,6 @@ describe('performNpmUpdateEdge (Bundle B1b)', () => {
       '10.0.0-rc.12',
       '10.0.0-rc.11',
       log.fn,
-      restartCommand,
     );
     expect(result).toBe('failed');
     const restartProbe = `${restartCommand.nodeExecutable} ${restartCommand.nodeExecArgv.join(' ')} ${restartCommand.restartEntryPoint} --version`;
@@ -339,7 +338,6 @@ describe('performNpmUpdateEdge (Bundle B1b)', () => {
       '10.0.0-rc.1',
       '10.0.0-rc.0',
       log.fn,
-      restartCommand,
     );
     expect(result).toBe('failed');
     const restartProbe = `${restartCommand.nodeExecutable} ${restartCommand.nodeExecArgv.join(' ')} ${restartCommand.restartEntryPoint} --version`;
@@ -364,12 +362,25 @@ describe('performNpmUpdateEdge (Bundle B1b)', () => {
       '10.0.0-rc.12',
       '10.0.0-rc.11',
       log.fn,
-      restartCommand,
     );
 
     expect(result).toBe('failed');
     expect(log.calls.some((m) => m.includes('EACCES'))).toBe(true);
     expect(log.calls.some((m) => m.includes('npm config set prefix'))).toBe(true);
+  });
+
+  it('derives the default self-check from the current Node process command', async () => {
+    _autoUpdateIo.edgeRestartCommand = origIo.edgeRestartCommand;
+    const log = makeLog();
+
+    const result = await performNpmUpdateEdge('10.0.0-rc.12', '10.0.0-rc.11', log.fn);
+
+    expect(result).toBe('updated');
+    expect(execFileCalls).toEqual([{
+      file: process.execPath,
+      args: [...process.execArgv, process.argv[1], '--version'],
+      opts: { encoding: 'utf-8', timeout: 30_000 },
+    }]);
   });
 
   // Concurrent-update locking is exercised by the existing

--- a/packages/cli/test/rfc-41-bundle-b.test.ts
+++ b/packages/cli/test/rfc-41-bundle-b.test.ts
@@ -207,16 +207,32 @@ describe('performNpmUpdateEdge (Bundle B1b)', () => {
   // a real subprocess. Other IO (readFile, writeFile, mkdir, …) we let
   // the real fs handle against the per-test DKG_HOME.
   const origIo = { ..._autoUpdateIo };
+  const restartCommand = {
+    nodeExecutable: '/usr/local/bin/node',
+    nodeExecArgv: ['--enable-source-maps'],
+    restartEntryPoint: '/npm-global/lib/node_modules/@origintrail-official/dkg/dist/cli.js',
+  } as const;
   let execCalls: { cmd: string; opts?: any }[] = [];
+  let execFileCalls: { file: string; args: string[]; opts?: any }[] = [];
+  let operations: string[] = [];
 
   beforeEach(() => {
     execCalls = [];
+    execFileCalls = [];
+    operations = [];
     _autoUpdateIo.exec = ((cmd: string, opts?: any): Promise<{ stdout: string; stderr: string }> => {
       execCalls.push({ cmd, opts });
-      return Promise.resolve({
-        stdout: cmd === 'dkg --version' ? 'dkg 10.0.0-rc.12' : '',
-        stderr: '',
-      });
+      operations.push(cmd);
+      return Promise.resolve({ stdout: '', stderr: '' });
+    }) as any;
+    _autoUpdateIo.execFile = ((
+      file: string,
+      args: string[],
+      opts?: any,
+    ): Promise<{ stdout: string; stderr: string }> => {
+      execFileCalls.push({ file, args, opts });
+      operations.push(`${file} ${args.join(' ')}`);
+      return Promise.resolve({ stdout: 'dkg 10.0.0-rc.12', stderr: '' });
     }) as any;
   });
 
@@ -226,20 +242,34 @@ describe('performNpmUpdateEdge (Bundle B1b)', () => {
 
   it('records previous-version and runs npm install -g on success', async () => {
     const log = makeLog();
-    const result = await performNpmUpdateEdge('10.0.0-rc.12', '10.0.0-rc.11', log.fn);
+    const result = await performNpmUpdateEdge(
+      '10.0.0-rc.12',
+      '10.0.0-rc.11',
+      log.fn,
+      restartCommand,
+    );
 
     expect(result).toBe('updated');
     expect(readFileSync(join(dkgHome, 'previous-version'), 'utf-8')).toBe('10.0.0-rc.11');
-    expect(execCalls).toHaveLength(2);
+    expect(execCalls).toHaveLength(1);
     expect(execCalls[0].cmd).toBe('npm install -g @origintrail-official/dkg@10.0.0-rc.12');
-    expect(execCalls[1].cmd).toBe('dkg --version');
+    expect(execFileCalls).toEqual([{
+      file: restartCommand.nodeExecutable,
+      args: [
+        ...restartCommand.nodeExecArgv,
+        restartCommand.restartEntryPoint,
+        '--version',
+      ],
+      opts: { encoding: 'utf-8', timeout: 30_000 },
+    }]);
+    expect(execCalls.some(({ cmd }) => cmd === 'dkg --version')).toBe(false);
     expect(log.calls.some((m) => m.includes('10.0.0-rc.11 → ~/.dkg/previous-version'))).toBe(true);
     expect(log.calls.some((m) => m.includes('install completed'))).toBe(true);
   });
 
   it('warns when current version is unknown but still attempts the install', async () => {
     const log = makeLog();
-    const result = await performNpmUpdateEdge('10.0.0-rc.12', null, log.fn);
+    const result = await performNpmUpdateEdge('10.0.0-rc.12', null, log.fn, restartCommand);
 
     expect(result).toBe('updated');
     expect(existsSync(join(dkgHome, 'previous-version'))).toBe(false);
@@ -255,7 +285,7 @@ describe('performNpmUpdateEdge (Bundle B1b)', () => {
     }) as any;
 
     const log = makeLog();
-    const result = await performNpmUpdateEdge('99.99.99', '10.0.0-rc.11', log.fn);
+    const result = await performNpmUpdateEdge('99.99.99', '10.0.0-rc.11', log.fn, restartCommand);
 
     expect(result).toBe('failed');
     expect(log.calls.some((m) => m.includes('npm install -g failed'))).toBe(true);
@@ -267,49 +297,57 @@ describe('performNpmUpdateEdge (Bundle B1b)', () => {
 
   it('rolls back when the installed CLI cannot pass its self-check', async () => {
     let versionChecks = 0;
-    _autoUpdateIo.exec = (async (cmd: string, opts?: any) => {
-      execCalls.push({ cmd, opts });
-      if (cmd === 'dkg --version') {
-        versionChecks += 1;
-        if (versionChecks === 1) throw new Error('dkg: command not found');
-        return { stdout: 'dkg 10.0.0-rc.11', stderr: '' };
-      }
-      return { stdout: '', stderr: '' };
+    _autoUpdateIo.execFile = (async (file: string, args: string[], opts?: any) => {
+      execFileCalls.push({ file, args, opts });
+      operations.push(`${file} ${args.join(' ')}`);
+      versionChecks += 1;
+      if (versionChecks === 1) throw new Error('restart entry point cannot be executed');
+      return { stdout: 'dkg 10.0.0-rc.11', stderr: '' };
     }) as any;
 
     const log = makeLog();
-    const result = await performNpmUpdateEdge('10.0.0-rc.12', '10.0.0-rc.11', log.fn);
+    const result = await performNpmUpdateEdge(
+      '10.0.0-rc.12',
+      '10.0.0-rc.11',
+      log.fn,
+      restartCommand,
+    );
     expect(result).toBe('failed');
-    expect(execCalls.map((call) => call.cmd)).toEqual([
+    const restartProbe = `${restartCommand.nodeExecutable} ${restartCommand.nodeExecArgv.join(' ')} ${restartCommand.restartEntryPoint} --version`;
+    expect(operations).toEqual([
       'npm install -g @origintrail-official/dkg@10.0.0-rc.12',
-      'dkg --version',
+      restartProbe,
       'npm install -g @origintrail-official/dkg@10.0.0-rc.11',
-      'dkg --version',
+      restartProbe,
     ]);
     expect(log.calls.some((message) => message.includes('rollback restored'))).toBe(true);
   });
 
   it('rolls back on an exact-version mismatch, including semver prefix collisions', async () => {
     let versionChecks = 0;
-    _autoUpdateIo.exec = (async (cmd: string, opts?: any) => {
-      execCalls.push({ cmd, opts });
-      if (cmd === 'dkg --version') {
-        versionChecks += 1;
-        return versionChecks === 1
-          ? { stdout: 'dkg 10.0.0-rc.12', stderr: '' }
-          : { stdout: 'dkg 10.0.0-rc.0', stderr: '' };
-      }
-      return { stdout: '', stderr: '' };
+    _autoUpdateIo.execFile = (async (file: string, args: string[], opts?: any) => {
+      execFileCalls.push({ file, args, opts });
+      operations.push(`${file} ${args.join(' ')}`);
+      versionChecks += 1;
+      return versionChecks === 1
+        ? { stdout: 'dkg 10.0.0-rc.12', stderr: '' }
+        : { stdout: 'dkg 10.0.0-rc.0', stderr: '' };
     }) as any;
 
     const log = makeLog();
-    const result = await performNpmUpdateEdge('10.0.0-rc.1', '10.0.0-rc.0', log.fn);
+    const result = await performNpmUpdateEdge(
+      '10.0.0-rc.1',
+      '10.0.0-rc.0',
+      log.fn,
+      restartCommand,
+    );
     expect(result).toBe('failed');
-    expect(execCalls.map((call) => call.cmd)).toEqual([
+    const restartProbe = `${restartCommand.nodeExecutable} ${restartCommand.nodeExecArgv.join(' ')} ${restartCommand.restartEntryPoint} --version`;
+    expect(operations).toEqual([
       'npm install -g @origintrail-official/dkg@10.0.0-rc.1',
-      'dkg --version',
+      restartProbe,
       'npm install -g @origintrail-official/dkg@10.0.0-rc.0',
-      'dkg --version',
+      restartProbe,
     ]);
     expect(log.calls.some((message) => message.includes('expected 10.0.0-rc.1'))).toBe(true);
   });
@@ -322,7 +360,12 @@ describe('performNpmUpdateEdge (Bundle B1b)', () => {
     }) as any;
 
     const log = makeLog();
-    const result = await performNpmUpdateEdge('10.0.0-rc.12', '10.0.0-rc.11', log.fn);
+    const result = await performNpmUpdateEdge(
+      '10.0.0-rc.12',
+      '10.0.0-rc.11',
+      log.fn,
+      restartCommand,
+    );
 
     expect(result).toBe('failed');
     expect(log.calls.some((m) => m.includes('EACCES'))).toBe(true);

--- a/scripts/devnet-test-issue-1567-global-cli-rollback.sh
+++ b/scripts/devnet-test-issue-1567-global-cli-rollback.sh
@@ -32,16 +32,17 @@ result="$(
   FAKE_DKG_RESTART_ENTRY="$tmp/restart-entry.mjs" \
   node --input-type=module <<'NODE'
 import { performNpmUpdateEdge } from './packages/cli/dist/daemon/auto-update.js';
+import { _autoUpdateIo } from './packages/cli/dist/daemon/manifest.js';
+_autoUpdateIo.edgeRestartCommand = () => ({
+  nodeExecutable: process.execPath,
+  nodeExecArgv: [],
+  restartEntryPoint: process.env.FAKE_DKG_RESTART_ENTRY,
+});
 const logs = [];
 const result = await performNpmUpdateEdge(
   '10.0.0-rc.1',
   '10.0.0-rc.0',
   (line) => logs.push(line),
-  {
-    nodeExecutable: process.execPath,
-    nodeExecArgv: [],
-    restartEntryPoint: process.env.FAKE_DKG_RESTART_ENTRY,
-  },
 );
 process.stdout.write(JSON.stringify({ result, logs }));
 NODE

--- a/scripts/devnet-test-issue-1567-global-cli-rollback.sh
+++ b/scripts/devnet-test-issue-1567-global-cli-rollback.sh
@@ -6,6 +6,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
 tmp="$(mktemp -d "${TMPDIR:-/tmp}/dkg-1567.XXXXXX")"
 trap 'rm -rf "$tmp"' EXIT INT TERM
 mkdir -p "$tmp/bin" "$tmp/home"
@@ -19,15 +20,29 @@ printf '%s\n' '#!/bin/sh' \
   '  *) exit 2 ;;' \
   'esac' >"$tmp/bin/npm"
 printf '%s\n' '#!/bin/sh' \
-  'printf "dkg %s\n" "$(cat "$FAKE_DKG_VERSION_FILE")"' >"$tmp/bin/dkg"
+  'printf "%s\n" "dkg 10.0.0-rc.1"' >"$tmp/bin/dkg"
+printf '%s\n' \
+  'import { readFileSync } from "node:fs";' \
+  'const version = readFileSync(process.env.FAKE_DKG_VERSION_FILE, "utf8").trim();' \
+  'process.stdout.write(`dkg ${version}\n`);' >"$tmp/restart-entry.mjs"
 chmod +x "$tmp/bin/npm" "$tmp/bin/dkg"
 
 result="$(
   PATH="$tmp/bin:$PATH" DKG_HOME="$tmp/home" FAKE_DKG_VERSION_FILE="$version_file" \
+  FAKE_DKG_RESTART_ENTRY="$tmp/restart-entry.mjs" \
   node --input-type=module <<'NODE'
 import { performNpmUpdateEdge } from './packages/cli/dist/daemon/auto-update.js';
 const logs = [];
-const result = await performNpmUpdateEdge('10.0.0-rc.1', '10.0.0-rc.0', (line) => logs.push(line));
+const result = await performNpmUpdateEdge(
+  '10.0.0-rc.1',
+  '10.0.0-rc.0',
+  (line) => logs.push(line),
+  {
+    nodeExecutable: process.execPath,
+    nodeExecArgv: [],
+    restartEntryPoint: process.env.FAKE_DKG_RESTART_ENTRY,
+  },
+);
 process.stdout.write(JSON.stringify({ result, logs }));
 NODE
 )"


### PR DESCRIPTION
Follow-up to #1630 addressing the remaining review findings.

The Edge updater now verifies the exact Node/module command that the supervisor will restart, instead of whichever dkg happens to resolve first on PATH. Forward verification and rollback share the same probe, install command construction is centralized, and rollback recovery is isolated from the main update path. The devnet regression also runs correctly outside the repository working directory.

Regression coverage:
- Bundle B unit tests cover exact restart command invocation and rollback ordering.
- A real-child-process e2e makes PATH report the desired target while the restart module reports the wrong version, and proves rollback.
- The host-style devnet script recreates the same prefix collision and verifies restoration.

Validation:
- 17-package CLI dependency build
- 16 focused Bundle B and restart-entry tests
- 109 auto-update and versioned e2e tests
- scripts/devnet-test-issue-1567-global-cli-rollback.sh

Closes the substantive post-merge review feedback on #1630.