### PR TITLE
fix(core): preserve custom outbox stores (#1579 follow-up)

### DIFF
--- a/packages/agent/src/dkg-agent-join.ts
+++ b/packages/agent/src/dkg-agent-join.ts
@@ -709,8 +709,8 @@ export class JoinRequestMethods extends DKGAgentBase {
     // rc.9 PR-10: the substrate outbox already holds the queued send
     // (deliverPrivateJoinNotification → messenger.sendReliable enqueues
     // on failure). All we do here is log the transport failure for
-    // operator visibility — the substrate's periodic tick + on-connect
-    // flush will drive the retry to eventual delivery without our help.
+    // operator visibility. The substrate's periodic tick is the only automatic
+    // retry trigger and will drive delivery once the persisted backoff is due.
     const ctx = createOperationContext('system');
     this.log.warn(
       ctx,

--- a/packages/agent/src/dkg-agent-registry.ts
+++ b/packages/agent/src/dkg-agent-registry.ts
@@ -1751,8 +1751,8 @@ export class AgentRegistryMethods extends DKGAgentBase {
           `(messageId=${messageId.slice(0, 8)}, ` +
           `next attempt at ${new Date(result.nextAttemptAtMs ?? Date.now()).toISOString()}, ` +
           `lastError=${result.error ?? 'unknown'}). ` +
-          `Will retry on the periodic tick (every ${MESSAGE_OUTBOX_TICK_MS / 1000}s) ` +
-          `or opportunistically on the next direct re-connect from the recipient's peer.`,
+          `Will retry only when its persisted backoff is due on the periodic tick ` +
+          `(every ${MESSAGE_OUTBOX_TICK_MS / 1000}s); reconnects do not wake the outbox.`,
       );
       return {
         delivered: false,

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -25,8 +25,8 @@ import type {
   OperationContext,
   AuthorAttestationTypedData,
   DkgNetworkIdentity,
+  CompatibleProtocolOutboxStore,
   MessageIdempotencyStore,
-  ProtocolOutboxStore,
   SwmSenderKeyPackageAckReasonCode,
 } from '@origintrail-official/dkg-core';
 import type {
@@ -1246,7 +1246,7 @@ export interface DKGAgentConfig {
   onReplicationEvent?: ReplicationEventSink;
   messengerStores?: {
     idempotencyStore: MessageIdempotencyStore;
-    outboxStore: ProtocolOutboxStore;
+    outboxStore: CompatibleProtocolOutboxStore;
   };
 }
 

--- a/packages/agent/src/p2p/messenger.ts
+++ b/packages/agent/src/p2p/messenger.ts
@@ -6,8 +6,8 @@ import {
   RESPONSE_GONE_MARKER,
   isRecoverableSendError,
   ProtocolOutbox,
+  type CompatibleProtocolOutboxStore,
   type MessageIdempotencyStore,
-  type ProtocolOutboxStore,
   type ProtocolOutboxEntry,
   type ProtocolRouter,
 } from '@origintrail-official/dkg-core';
@@ -128,7 +128,7 @@ export interface MessengerDeps {
    * `ProtocolOutbox` internally (which owns the backoff ladder +
    * inflight guard).
    */
-  outboxStore?: ProtocolOutboxStore;
+  outboxStore?: CompatibleProtocolOutboxStore;
   /**
    * Override the default backoff ladder (5s → 2h, mirrors rc.8 chat
    * outbox). Caller can pass a tighter / looser ladder per Messenger

--- a/packages/agent/test/messenger-substrate.test.ts
+++ b/packages/agent/test/messenger-substrate.test.ts
@@ -6,8 +6,8 @@ import {
   encodeReliableEnvelope,
   RELIABLE_ENVELOPE_VERSION,
   RESPONSE_GONE_MARKER,
+  type LegacyProtocolOutboxStore,
   type ProtocolRouter,
-  type ProtocolOutboxStore,
   type StreamHandler,
 } from '@origintrail-official/dkg-core';
 import {
@@ -100,7 +100,7 @@ function makeSubstrate(overrides: { router?: RouterDouble } = {}) {
 describe('Messenger.sendReliable (happy path semantics)', () => {
   it('accepts a legacy custom outbox store with pendingFor but no hasPendingFor', async () => {
     const backing = new InMemoryProtocolOutboxStore({ backoffs: [10], maxAgeMs: 60_000 });
-    const legacyStore: ProtocolOutboxStore = {
+    const legacyStore: LegacyProtocolOutboxStore = {
       enqueue: backing.enqueue.bind(backing),
       markDelivered: backing.markDelivered.bind(backing),
       hasEntry: backing.hasEntry.bind(backing),

--- a/packages/agent/test/messenger-substrate.test.ts
+++ b/packages/agent/test/messenger-substrate.test.ts
@@ -7,6 +7,7 @@ import {
   RELIABLE_ENVELOPE_VERSION,
   RESPONSE_GONE_MARKER,
   type ProtocolRouter,
+  type ProtocolOutboxStore,
   type StreamHandler,
 } from '@origintrail-official/dkg-core';
 import {
@@ -97,6 +98,37 @@ function makeSubstrate(overrides: { router?: RouterDouble } = {}) {
 }
 
 describe('Messenger.sendReliable (happy path semantics)', () => {
+  it('accepts a legacy custom outbox store with pendingFor but no hasPendingFor', async () => {
+    const backing = new InMemoryProtocolOutboxStore({ backoffs: [10], maxAgeMs: 60_000 });
+    const legacyStore: ProtocolOutboxStore = {
+      enqueue: backing.enqueue.bind(backing),
+      markDelivered: backing.markDelivered.bind(backing),
+      hasEntry: backing.hasEntry.bind(backing),
+      pendingFor: backing.pendingFor.bind(backing),
+      due: backing.due.bind(backing),
+      dropExpired: backing.dropExpired.bind(backing),
+      size: backing.size.bind(backing),
+      list: backing.list.bind(backing),
+      getEntry: backing.getEntry.bind(backing),
+    };
+    const router = makeRouter(async () => new Uint8Array([0x42]));
+    const messenger = new Messenger({
+      router: router as unknown as ProtocolRouter,
+      idempotencyStore: new InMemoryMessageIdempotencyStore(),
+      outboxStore: legacyStore,
+      backoffs: [10],
+      maxAgeMs: 60_000,
+    });
+
+    const result = await messenger.sendReliable(PEER_A, PROTO, new Uint8Array([1]), {
+      messageId: FIXED_MSG_ID,
+    });
+
+    expect(result.delivered).toBe(true);
+    expect(router.send.calls).toHaveLength(1);
+    expect(legacyStore.pendingFor(PEER_A)).toEqual([]);
+  });
+
   it('envelope-wraps the payload before calling router.send', async () => {
     const { messenger, router } = makeSubstrate();
     const payload = new TextEncoder().encode('hello');

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -175,6 +175,8 @@ export {
   type MessageDirection,
   type IdempotencyCheckResult,
   type ProtocolOutboxStore,
+  type LegacyProtocolOutboxStore,
+  type CompatibleProtocolOutboxStore,
   type ProtocolOutboxEntry,
   type KaNumberStore,
   RESPONSE_CACHE_BYTES,

--- a/packages/core/src/messenger-types.ts
+++ b/packages/core/src/messenger-types.ts
@@ -169,7 +169,7 @@ export interface ProtocolOutboxEntry {
   lastError: string;
 }
 
-export interface ProtocolOutboxStore {
+interface ProtocolOutboxStoreBase {
   /**
    * Insert or update an outbox entry for `(peer, protocol, messageId)`.
    * First failure creates the entry with `attempts = 1`. Subsequent
@@ -204,19 +204,6 @@ export interface ProtocolOutboxStore {
    * generic substrate.
    */
   hasEntry(peer: string, protocol: string, messageId: string): boolean;
-
-  /**
-   * Snapshot every durable row for one peer. This is the pre-#1579 public
-   * contract retained for custom store compatibility and diagnostics/DHT
-   * bookkeeping only. Results are ordered by `firstFailureAt` ascending (with
-   * implementation-defined tie order), matching the legacy contract.
-   * Automatic retries MUST continue to select from `due` or `duePage`; a
-   * connection event must never drain this snapshot.
-   */
-  pendingFor(peer: string): ProtocolOutboxEntry[];
-
-  /** Optional storage-level fast path for peer-presence bookkeeping. */
-  hasPendingFor?(peer: string): boolean;
 
   /**
    * All entries whose `nextAttemptAt <= now`.
@@ -266,6 +253,39 @@ export interface ProtocolOutboxStore {
    */
   getEntry(peer: string, protocol: string, messageId: string): ProtocolOutboxEntry | undefined;
 }
+
+/**
+ * Current sender-side outbox store contract. Peer bookkeeping uses a boolean
+ * fast path; retry selection remains exclusively `due`/`duePage`-driven.
+ *
+ * `pendingFor` is an optional compatibility/diagnostic capability. New stores
+ * do not need to materialize full payload-bearing peer snapshots.
+ */
+export interface ProtocolOutboxStore extends ProtocolOutboxStoreBase {
+  /** Whether this peer still has any durable row (DHT recovery bookkeeping). */
+  hasPendingFor(peer: string): boolean;
+
+  /**
+   * Optional snapshot of one peer's rows, ordered by `firstFailureAt`.
+   * Automatic retries MUST NOT select work from this diagnostic snapshot.
+   */
+  pendingFor?(peer: string): ProtocolOutboxEntry[];
+}
+
+/**
+ * Pre-#1579 custom-store shape retained at the `ProtocolOutbox` boundary.
+ * Legacy stores exposed the full peer snapshot instead of a boolean fast path.
+ */
+export interface LegacyProtocolOutboxStore extends ProtocolOutboxStoreBase {
+  /** Snapshot of one peer's rows, ordered by `firstFailureAt`. */
+  pendingFor(peer: string): ProtocolOutboxEntry[];
+
+  /** Optional forward-compatible peer-presence fast path. */
+  hasPendingFor?(peer: string): boolean;
+}
+
+/** Store input accepted by the compatibility-normalizing outbox wrapper. */
+export type CompatibleProtocolOutboxStore = ProtocolOutboxStore | LegacyProtocolOutboxStore;
 
 
 /**

--- a/packages/core/src/messenger-types.ts
+++ b/packages/core/src/messenger-types.ts
@@ -208,8 +208,10 @@ export interface ProtocolOutboxStore {
   /**
    * Snapshot every durable row for one peer. This is the pre-#1579 public
    * contract retained for custom store compatibility and diagnostics/DHT
-   * bookkeeping only. Automatic retries MUST continue to select from `due` or
-   * `duePage`; a connection event must never drain this snapshot.
+   * bookkeeping only. Results are ordered by `firstFailureAt` ascending (with
+   * implementation-defined tie order), matching the legacy contract.
+   * Automatic retries MUST continue to select from `due` or `duePage`; a
+   * connection event must never drain this snapshot.
    */
   pendingFor(peer: string): ProtocolOutboxEntry[];
 

--- a/packages/core/src/messenger-types.ts
+++ b/packages/core/src/messenger-types.ts
@@ -205,8 +205,16 @@ export interface ProtocolOutboxStore {
    */
   hasEntry(peer: string, protocol: string, messageId: string): boolean;
 
-  /** Whether this peer still has any durable row (DHT recovery bookkeeping). */
-  hasPendingFor(peer: string): boolean;
+  /**
+   * Snapshot every durable row for one peer. This is the pre-#1579 public
+   * contract retained for custom store compatibility and diagnostics/DHT
+   * bookkeeping only. Automatic retries MUST continue to select from `due` or
+   * `duePage`; a connection event must never drain this snapshot.
+   */
+  pendingFor(peer: string): ProtocolOutboxEntry[];
+
+  /** Optional storage-level fast path for peer-presence bookkeeping. */
+  hasPendingFor?(peer: string): boolean;
 
   /**
    * All entries whose `nextAttemptAt <= now`.

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -104,6 +104,40 @@ export function connectionsBusyAppProtocols(conns: readonly unknown[]): string[]
 }
 
 /**
+ * Best-effort reset of busy application streams before the relay watchdog
+ * closes their transport. Stream discovery stays behind
+ * `readConnectionStreams`, because libp2p may temporarily expose a missing
+ * stream array or an incompletely negotiated stream during teardown.
+ * Returns the number of distinct streams whose abort function was invoked.
+ */
+export function abortWatchdogBusyStreams(
+  conns: readonly unknown[],
+  reason: Error,
+): number {
+  const reaped = new Set<unknown>();
+  let aborted = 0;
+  for (const connection of conns) {
+    for (const stream of readConnectionStreams(connection) ?? []) {
+      if (reaped.has(stream)) continue;
+      const { protocol, abort } = stream;
+      if (typeof protocol !== 'string'
+        || !isWatchdogBusyProtocol(protocol)
+        || typeof abort !== 'function') {
+        continue;
+      }
+      reaped.add(stream);
+      try {
+        abort.call(stream, reason);
+        aborted += 1;
+      } catch {
+        // Best-effort; connection teardown remains the final reaper.
+      }
+    }
+  }
+  return aborted;
+}
+
+/**
  * Per-relay forced-redial bookkeeping (one object per relay instead of
  * parallel maps, so the invariants live in one place): `strikes` counts
  * consecutive futile forced redials, `cooldownUntil` suppresses the forced
@@ -1579,18 +1613,10 @@ export class DKGNode {
         // purpose. Aborting first gives the reset a turn to flush before the
         // connection itself is closed.
         if (busyProtocols.length > 0) {
-          const reaped = new Set<unknown>();
-          for (const connection of [...conns, ...relayedConns]) {
-            for (const stream of connection.streams) {
-              if (reaped.has(stream) || !isWatchdogBusyProtocol(stream.protocol)) continue;
-              reaped.add(stream);
-              try {
-                stream.abort(new Error('relay watchdog busy-deferral cap reached'));
-              } catch {
-                // Best-effort; connection teardown below is the final reaper.
-              }
-            }
-          }
+          abortWatchdogBusyStreams(
+            [...conns, ...relayedConns],
+            new Error('relay watchdog busy-deferral cap reached'),
+          );
           await new Promise(r => setTimeout(r, 0));
         }
 

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -1570,6 +1570,30 @@ export class DKGNode {
           this.relayForcedRedialState.set(relayPidStr, { ...redialState, strikes, busyDeferralTicks: 0 });
         }
 
+        // Past the busy-deferral cap, reap the stuck application streams while
+        // the transport is still writable. Letting `Connection.close()` abort
+        // them concurrently with the underlying socket close can make Yamux's
+        // reset frame race the socket teardown (`StreamStateError: Cannot write
+        // to a stream that is closing`). Besides surfacing as an unhandled
+        // rejection, that race defeats the cap's explicit stuck-stream-reaper
+        // purpose. Aborting first gives the reset a turn to flush before the
+        // connection itself is closed.
+        if (busyProtocols.length > 0) {
+          const reaped = new Set<unknown>();
+          for (const connection of [...conns, ...relayedConns]) {
+            for (const stream of connection.streams) {
+              if (reaped.has(stream) || !isWatchdogBusyProtocol(stream.protocol)) continue;
+              reaped.add(stream);
+              try {
+                stream.abort(new Error('relay watchdog busy-deferral cap reached'));
+              } catch {
+                // Best-effort; connection teardown below is the final reaper.
+              }
+            }
+          }
+          await new Promise(r => setTimeout(r, 0));
+        }
+
         for (const c of conns) {
           try {
             await c.close();

--- a/packages/core/src/protocol-outbox.ts
+++ b/packages/core/src/protocol-outbox.ts
@@ -28,6 +28,7 @@
  */
 
 import type {
+  CompatibleProtocolOutboxStore,
   IdempotencyCheckResult,
   MessageDirection,
   MessageIdempotencyStore,
@@ -97,6 +98,12 @@ function compareDueEntries(a: ProtocolOutboxEntry, b: ProtocolOutboxEntry): numb
     || a.messageId.localeCompare(b.messageId);
 }
 
+function comparePendingEntries(a: ProtocolOutboxEntry, b: ProtocolOutboxEntry): number {
+  return a.firstFailureAt - b.firstFailureAt
+    || a.protocol.localeCompare(b.protocol)
+    || a.messageId.localeCompare(b.messageId);
+}
+
 function normalizeDuePageLimit(limit: number | undefined): number | undefined {
   if (limit === undefined || !Number.isFinite(limit)) return undefined;
   return Math.max(0, Math.floor(limit));
@@ -106,12 +113,12 @@ interface ProtocolOutboxStorePolicy extends ProtocolOutboxOptions {
   backoffFor: (attempts: number) => number;
 }
 
-type PolicyAwareProtocolOutboxStore = ProtocolOutboxStore & {
+type PolicyAwareProtocolOutboxStore = CompatibleProtocolOutboxStore & {
   configurePolicy?: (policy: ProtocolOutboxStorePolicy) => void;
 };
 
 export class ProtocolOutbox {
-  private readonly store: ProtocolOutboxStore;
+  private readonly store: CompatibleProtocolOutboxStore;
   private readonly backoffs: readonly number[];
   /**
    * Per-key inflight set to prevent concurrent retry attempts for the
@@ -129,7 +136,7 @@ export class ProtocolOutbox {
    */
   private readonly inflight = new Set<string>();
 
-  constructor(store: ProtocolOutboxStore, options: ProtocolOutboxOptions = {}) {
+  constructor(store: CompatibleProtocolOutboxStore, options: ProtocolOutboxOptions = {}) {
     const backoffs = options.backoffs ?? DEFAULT_PROTOCOL_OUTBOX_BACKOFFS_MS;
     if (backoffs.length === 0) {
       throw new Error('ProtocolOutbox: backoffs must be non-empty');
@@ -228,7 +235,12 @@ export class ProtocolOutbox {
   }
 
   hasPendingFor(peer: string): boolean {
-    return this.store.hasPendingFor?.(peer) ?? this.store.pendingFor(peer).length > 0;
+    const hasPendingFor = this.store.hasPendingFor;
+    if (hasPendingFor) return hasPendingFor.call(this.store, peer);
+    const pendingFor = this.store.pendingFor;
+    return pendingFor
+      ? pendingFor.call(this.store, peer).length > 0
+      : this.store.list().some((entry) => entry.peer === peer);
   }
 
   /**
@@ -236,7 +248,11 @@ export class ProtocolOutbox {
    * retry selection; scheduled drains remain exclusively `duePage`-driven.
    */
   pendingFor(peer: string): ProtocolOutboxEntry[] {
-    return this.store.pendingFor(peer);
+    const pendingFor = this.store.pendingFor;
+    const snapshot = pendingFor
+      ? pendingFor.call(this.store, peer)
+      : this.store.list().filter((entry) => entry.peer === peer);
+    return [...snapshot].sort(comparePendingEntries).map(cloneOutboxEntry);
   }
 
   /** Drop entries older than the store's configured max-age. */

--- a/packages/core/src/protocol-outbox.ts
+++ b/packages/core/src/protocol-outbox.ts
@@ -32,6 +32,7 @@ import type {
   IdempotencyCheckResult,
   MessageDirection,
   MessageIdempotencyStore,
+  LegacyProtocolOutboxStore,
   ProtocolOutboxEntry,
   ProtocolOutboxStore,
 } from './messenger-types.js';
@@ -117,8 +118,33 @@ type PolicyAwareProtocolOutboxStore = CompatibleProtocolOutboxStore & {
   configurePolicy?: (policy: ProtocolOutboxStorePolicy) => void;
 };
 
+/**
+ * Keep compatibility at the constructor boundary. Internally the outbox only
+ * sees the current boolean peer-presence contract, while a legacy snapshot
+ * store is adapted once with all method receivers preserved.
+ */
+function normalizeOutboxStore(store: CompatibleProtocolOutboxStore): ProtocolOutboxStore {
+  if (typeof store.hasPendingFor === 'function') return store as ProtocolOutboxStore;
+
+  const legacy = store as LegacyProtocolOutboxStore;
+  const normalized: ProtocolOutboxStore = {
+    enqueue: legacy.enqueue.bind(legacy),
+    markDelivered: legacy.markDelivered.bind(legacy),
+    hasEntry: legacy.hasEntry.bind(legacy),
+    due: legacy.due.bind(legacy),
+    dropExpired: legacy.dropExpired.bind(legacy),
+    size: legacy.size.bind(legacy),
+    list: legacy.list.bind(legacy),
+    getEntry: legacy.getEntry.bind(legacy),
+    hasPendingFor: (peer) => legacy.pendingFor(peer).length > 0,
+    pendingFor: legacy.pendingFor.bind(legacy),
+  };
+  if (legacy.duePage) normalized.duePage = legacy.duePage.bind(legacy);
+  return normalized;
+}
+
 export class ProtocolOutbox {
-  private readonly store: CompatibleProtocolOutboxStore;
+  private readonly store: ProtocolOutboxStore;
   private readonly backoffs: readonly number[];
   /**
    * Per-key inflight set to prevent concurrent retry attempts for the
@@ -141,13 +167,13 @@ export class ProtocolOutbox {
     if (backoffs.length === 0) {
       throw new Error('ProtocolOutbox: backoffs must be non-empty');
     }
-    this.store = store;
     this.backoffs = backoffs;
-    (this.store as PolicyAwareProtocolOutboxStore).configurePolicy?.({
+    (store as PolicyAwareProtocolOutboxStore).configurePolicy?.({
       backoffs,
       maxAgeMs: options.maxAgeMs ?? DEFAULT_PROTOCOL_OUTBOX_MAX_AGE_MS,
       backoffFor: (attempts) => this.backoffFor(attempts),
     });
+    this.store = normalizeOutboxStore(store);
   }
 
   /**
@@ -235,12 +261,7 @@ export class ProtocolOutbox {
   }
 
   hasPendingFor(peer: string): boolean {
-    const hasPendingFor = this.store.hasPendingFor;
-    if (hasPendingFor) return hasPendingFor.call(this.store, peer);
-    const pendingFor = this.store.pendingFor;
-    return pendingFor
-      ? pendingFor.call(this.store, peer).length > 0
-      : this.store.list().some((entry) => entry.peer === peer);
+    return this.store.hasPendingFor(peer);
   }
 
   /**

--- a/packages/core/src/protocol-outbox.ts
+++ b/packages/core/src/protocol-outbox.ts
@@ -228,7 +228,15 @@ export class ProtocolOutbox {
   }
 
   hasPendingFor(peer: string): boolean {
-    return this.store.hasPendingFor(peer);
+    return this.store.hasPendingFor?.(peer) ?? this.store.pendingFor(peer).length > 0;
+  }
+
+  /**
+   * Compatibility/diagnostic snapshot for a peer. This does not participate in
+   * retry selection; scheduled drains remain exclusively `duePage`-driven.
+   */
+  pendingFor(peer: string): ProtocolOutboxEntry[] {
+    return this.store.pendingFor(peer);
   }
 
   /** Drop entries older than the store's configured max-age. */
@@ -345,6 +353,13 @@ export class InMemoryProtocolOutboxStore implements ProtocolOutboxStore {
 
   hasPendingFor(peer: string): boolean {
     return Array.from(this.entries.values()).some((entry) => entry.peer === peer);
+  }
+
+  pendingFor(peer: string): ProtocolOutboxEntry[] {
+    return Array.from(this.entries.values())
+      .filter((entry) => entry.peer === peer)
+      .sort((a, b) => a.firstFailureAt - b.firstFailureAt)
+      .map(cloneOutboxEntry);
   }
 
   due(now: number): ProtocolOutboxEntry[] {

--- a/packages/core/src/relay-internal-shapes.ts
+++ b/packages/core/src/relay-internal-shapes.ts
@@ -80,6 +80,8 @@ export interface LibP2PStreamShape {
   protocol?: string;
   /** Stream direction relative to this node — `inbound` if the peer initiated, `outbound` if we did. */
   direction?: 'inbound' | 'outbound';
+  /** Best-effort stream reset used by the relay watchdog's bounded reaper. */
+  abort?: (reason: Error) => void;
 }
 
 /**

--- a/packages/core/test/protocol-outbox.test.ts
+++ b/packages/core/test/protocol-outbox.test.ts
@@ -7,6 +7,7 @@ import {
 } from '../src/protocol-outbox.js';
 import {
   RESPONSE_CACHE_BYTES,
+  type LegacyProtocolOutboxStore,
   type ProtocolOutboxEntry,
   type ProtocolOutboxStore,
 } from '../src/messenger-types.js';
@@ -178,7 +179,7 @@ describe('ProtocolOutbox.due / peer presence', () => {
     });
     const newer = entry('a-newer-failure', 20);
     const older = entry('z-older-failure', 10);
-    const legacyStore: ProtocolOutboxStore = {
+    const legacyStore: LegacyProtocolOutboxStore = {
       enqueue: backing.enqueue.bind(backing),
       markDelivered: backing.markDelivered.bind(backing),
       hasEntry: backing.hasEntry.bind(backing),
@@ -197,6 +198,57 @@ describe('ProtocolOutbox.due / peer presence', () => {
       .toEqual(['z-older-failure', 'a-newer-failure']);
     expect(outbox.hasPendingFor(PEER_A)).toBe(true);
     expect(outbox.hasPendingFor(PEER_B)).toBe(false);
+    expect(outbox.pendingFor(PEER_A).map((candidate) => candidate.messageId))
+      .toEqual(['z-older-failure', 'a-newer-failure']);
+  });
+
+  it('keeps current hasPendingFor-only stores compatible without requiring peer snapshots', () => {
+    const backing = new InMemoryProtocolOutboxStore();
+    const entry = (
+      peer: string,
+      messageId: string,
+      firstFailureAt: number,
+    ): ProtocolOutboxEntry => ({
+      peer,
+      protocol: PROTO,
+      messageId,
+      payload: PAYLOAD,
+      attempts: 1,
+      firstFailureAt,
+      lastAttemptAt: firstFailureAt,
+      nextAttemptAt: 100,
+      lastError: 'offline',
+    });
+    const newer = entry(PEER_A, 'a-newer-failure', 20);
+    const older = entry(PEER_A, 'z-older-failure', 10);
+    const otherPeer = entry(PEER_B, 'other-peer', 1);
+    let listCalls = 0;
+    const currentStore: ProtocolOutboxStore = {
+      enqueue: backing.enqueue.bind(backing),
+      markDelivered: backing.markDelivered.bind(backing),
+      hasEntry: backing.hasEntry.bind(backing),
+      hasPendingFor: (peer) => peer === PEER_A,
+      due: backing.due.bind(backing),
+      dropExpired: backing.dropExpired.bind(backing),
+      size: backing.size.bind(backing),
+      list: () => {
+        listCalls += 1;
+        return [newer, otherPeer, older];
+      },
+      getEntry: backing.getEntry.bind(backing),
+    };
+    const outbox = new ProtocolOutbox(currentStore);
+
+    expect(outbox.hasPendingFor(PEER_A)).toBe(true);
+    expect(outbox.hasPendingFor(PEER_B)).toBe(false);
+    expect(listCalls).toBe(0);
+
+    const pending = outbox.pendingFor(PEER_A);
+    expect(pending.map((candidate) => candidate.messageId))
+      .toEqual(['z-older-failure', 'a-newer-failure']);
+    expect(listCalls).toBe(1);
+    pending[0].payload[0] = 99;
+    expect(older.payload[0]).toBe(PAYLOAD[0]);
   });
 
   it('uses firstFailureAt before key ordering when nextAttemptAt ties', () => {

--- a/packages/core/test/protocol-outbox.test.ts
+++ b/packages/core/test/protocol-outbox.test.ts
@@ -98,8 +98,8 @@ describe('ProtocolOutbox.markDelivered + hasEntry', () => {
   });
 
   it('hasEntry is the stale-snapshot guard required by the substrate contract', () => {
-    // Models the rc9 #538 race: two sibling flushes both got the same
-    // entry from `pendingFor`, one completed delivery + markDelivered,
+    // Models the rc9 #538 race: two overlapping scheduled drains both got the
+    // same entry from a due snapshot, one completed delivery + markDelivered,
     // the other races to retry. The second MUST check `hasEntry` after
     // `tryBeginAttempt` returns true, because tryBeginAttempt only
     // guards against TRULY concurrent attempts, not stale-snapshot-
@@ -160,7 +160,7 @@ describe('ProtocolOutbox.due / peer presence', () => {
     expect(outbox.duePage(now, Number.NaN).map((entry) => entry.messageId)).toEqual(['a-first', 'z-last']);
   });
 
-  it('keeps legacy due-only stores compatible and sorts before applying the cap', () => {
+  it('keeps legacy due/pendingFor stores compatible and sorts before applying the cap', () => {
     const backing = new InMemoryProtocolOutboxStore();
     const entry = (
       messageId: string,
@@ -182,7 +182,7 @@ describe('ProtocolOutbox.due / peer presence', () => {
       enqueue: backing.enqueue.bind(backing),
       markDelivered: backing.markDelivered.bind(backing),
       hasEntry: backing.hasEntry.bind(backing),
-      hasPendingFor: backing.hasPendingFor.bind(backing),
+      pendingFor: (peer) => peer === PEER_A ? [newer, older] : [],
       due: () => [newer, older],
       dropExpired: backing.dropExpired.bind(backing),
       size: backing.size.bind(backing),
@@ -195,6 +195,8 @@ describe('ProtocolOutbox.due / peer presence', () => {
       .toEqual(['z-older-failure']);
     expect(outbox.due(100).map((candidate) => candidate.messageId))
       .toEqual(['z-older-failure', 'a-newer-failure']);
+    expect(outbox.hasPendingFor(PEER_A)).toBe(true);
+    expect(outbox.hasPendingFor(PEER_B)).toBe(false);
   });
 
   it('uses firstFailureAt before key ordering when nextAttemptAt ties', () => {
@@ -221,6 +223,11 @@ describe('ProtocolOutbox.due / peer presence', () => {
     expect(outbox.hasPendingFor(PEER_A)).toBe(true);
     expect(outbox.hasPendingFor(PEER_B)).toBe(true);
     expect(outbox.hasPendingFor('peer-c')).toBe(false);
+
+    const pending = outbox.pendingFor(PEER_A);
+    expect(pending.map((entry) => entry.messageId)).toEqual([MSG_1, MSG_2]);
+    pending[0].payload[0] = 99;
+    expect(outbox.pendingFor(PEER_A)[0].payload[0]).toBe(PAYLOAD[0]);
   });
 });
 

--- a/packages/core/test/relay.test.ts
+++ b/packages/core/test/relay.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { DKGNode, nodeHasDirectPublicAddress, connectionsBusyAppProtocols } from '../src/node.js';
+import {
+  DKGNode,
+  abortWatchdogBusyStreams,
+  connectionsBusyAppProtocols,
+  nodeHasDirectPublicAddress,
+} from '../src/node.js';
 import { ProtocolRouter } from '../src/protocol-router.js';
 import { PeerDiscoveryManager } from '../src/discovery.js';
 import { TypedEventBus } from '../src/event-bus.js';
@@ -1195,6 +1200,20 @@ describe('Relay watchdog: stream-aware deferral + forced-redial thrash cap (2026
     expect(connectionsBusyAppProtocols([conn([])])).toEqual([]);
   });
 
+  it('abortWatchdogBusyStreams defensively reaps each abortable busy stream once', () => {
+    const reason = new Error('cap reached');
+    const abort = recorder((_error: Error): void => {});
+    const busy = { protocol: '/dkg/10.0.1/storage-ack', abort };
+
+    expect(abortWatchdogBusyStreams([
+      { streams: [busy, {}, { protocol: undefined }, { protocol: '/dkg/10.0.2/sync' }] },
+      { streams: [busy, { protocol: '/meshsub/1.1.0', abort }] },
+      {},
+      { streams: 'opening' },
+    ], reason)).toBe(1);
+    expect(abort.calls).toEqual([[reason]]);
+  });
+
   it('defers the forced reservation-redial while a /dkg/ stream is in flight, and resumes after it drains', async () => {
     // "Relay" that runs NO relay server: the edge can connect but a
     // reservation can never form, so every tick enters the
@@ -1529,13 +1548,20 @@ describe('Relay watchdog: review-round-1 hardening', () => {
       relayReservationRedialAt: Map<string, number>;
       relayForcedRedialState: Map<string, { strikes: number; cooldownUntil: number; busyDeferralTicks: number }>;
     };
-    await edge.libp2p.dialProtocol(relay.libp2p.getMultiaddrs(), BUSY_PROTOCOL);
+    const busyStream = await edge.libp2p.dialProtocol(relay.libp2p.getMultiaddrs(), BUSY_PROTOCOL);
+    const observedStream = busyStream as unknown as {
+      abort: (reason: Error) => void;
+    };
+    const originalAbort = observedStream.abort.bind(observedStream);
+    const abortSpy = recorder((reason: Error): void => originalAbort(reason));
+    observedStream.abort = abortSpy;
     internals.relayReservationRedialAt.set(relayPid, Date.now() - 16_000);
     // One tick below the cap: still deferring.
     internals.relayForcedRedialState.set(relayPid, { strikes: 0, cooldownUntil: 0, busyDeferralTicks: 29 });
     const logSpy = spyConsole('log');
     try {
       await internals.watchdogTick.call(edge);
+      expect(abortSpy.calls.length, 'a below-cap deferral must leave the busy stream open').toBe(0);
       expect(
         logSpy.calls.some(c => typeof c[0] === 'string' && c[0].includes('deferring forced redial')),
         'tick 30/30 still defers',
@@ -1545,6 +1571,7 @@ describe('Relay watchdog: review-round-1 hardening', () => {
       internals.relayForcedRedialState.set(relayPid, { strikes: 0, cooldownUntil: 0, busyDeferralTicks: 30 });
       logSpy.calls.length = 0;
       await internals.watchdogTick.call(edge);
+      expect(abortSpy.calls.length, 'the busy stream must be reset before connection teardown').toBe(1);
       expect(
         logSpy.calls.some(c => typeof c[0] === 'string' && c[0].includes('busy-deferral cap reached')),
         `expected cap-reached log; got: ${JSON.stringify(logSpy.calls.map(c => c[0]))}`,

--- a/packages/core/test/relay.test.ts
+++ b/packages/core/test/relay.test.ts
@@ -1458,7 +1458,16 @@ describe('Relay watchdog: review-round-1 hardening', () => {
     await relay.start();
     const relayAddr = relay.multiaddrs.find(a => a.includes('/tcp/'))!;
     const BUSY_PROTOCOL = '/dkg/test-decay/1.0.0';
-    await relay.libp2p.handle(BUSY_PROTOCOL, () => { /* hold open */ });
+    await relay.libp2p.handle(BUSY_PROTOCOL, async ({ stream }) => {
+      // Model a real request handler that owns the stream until the peer
+      // closes it. Returning immediately leaves libp2p's incoming-stream
+      // middleware to race a reset against connection teardown.
+      try {
+        for await (const _chunk of stream) { /* hold open */ }
+      } catch {
+        // Forced-redial teardown is the behavior under test.
+      }
+    });
 
     const edge = new DKGNode({
       listenAddresses: ['/ip4/127.0.0.1/tcp/0'],
@@ -1497,7 +1506,15 @@ describe('Relay watchdog: review-round-1 hardening', () => {
     await relay.start();
     const relayAddr = relay.multiaddrs.find(a => a.includes('/tcp/'))!;
     const BUSY_PROTOCOL = '/dkg/test-busy-cap/1.0.0';
-    await relay.libp2p.handle(BUSY_PROTOCOL, () => { /* hold the stream open */ });
+    await relay.libp2p.handle(BUSY_PROTOCOL, async ({ stream }) => {
+      // Keep ownership of the inbound stream through the forced close, as a
+      // production request handler does, and absorb the expected teardown.
+      try {
+        for await (const _chunk of stream) { /* hold open */ }
+      } catch {
+        // The deferral cap deliberately reaps this stream.
+      }
+    });
 
     const edge = new DKGNode({
       listenAddresses: ['/ip4/127.0.0.1/tcp/0'],

--- a/packages/node-ui/src/db.ts
+++ b/packages/node-ui/src/db.ts
@@ -536,12 +536,11 @@ export class DashboardDB {
       //     (i.e. the `ReliableEnvelope` proto output, not the raw
       //     application payload), so retries replay byte-identical
       //     frames without re-encoding.
-      //   - `idx_outbox_next_attempt` indexes the periodic-tick query
-      //     (`SELECT ... WHERE next_attempt_at <= ?`); the
-      //     opportunistic-flush query
-      //     (`SELECT ... WHERE peer_id = ?`) uses an implicit scan
-      //     on the PK prefix, which is fast enough at expected
-      //     queue sizes (~tens of entries per peer).
+      //   - `idx_outbox_next_attempt` indexes the sole automatic retry query
+      //     (`SELECT ... WHERE next_attempt_at <= ?`). The peer-scoped query is
+      //     retained only for diagnostics/DHT bookkeeping and MUST NOT become a
+      //     connection-triggered drain; it uses the PK prefix at expected queue
+      //     sizes (~tens of entries per peer).
       //
       // No data migration: pure additive. The chat-specific
       // `idx_chat_msgid` from V11 stays in place — PR-3 will drop
@@ -2776,6 +2775,27 @@ export class SqliteProtocolOutboxStore implements ProtocolOutboxStore {
 
   hasPendingFor(peer: string): boolean {
     return this.db.prepare('SELECT 1 FROM protocol_outbox WHERE peer_id = ? LIMIT 1').get(peer) !== undefined;
+  }
+
+  pendingFor(peer: string): ProtocolOutboxEntry[] {
+    const rows = this.db
+      .prepare(
+        `SELECT * FROM protocol_outbox
+         WHERE peer_id = ?
+         ORDER BY first_failure_at ASC, protocol ASC, message_id ASC`,
+      )
+      .all(peer) as Array<{
+      peer_id: string;
+      protocol: string;
+      message_id: string;
+      payload: Buffer;
+      attempts: number;
+      first_failure_at: number;
+      last_attempt_at: number;
+      next_attempt_at: number;
+      last_error: string | null;
+    }>;
+    return rows.map(SqliteProtocolOutboxStore.rowToEntry);
   }
 
   due(now: number): ProtocolOutboxEntry[] {

--- a/packages/node-ui/test/messenger-stores.test.ts
+++ b/packages/node-ui/test/messenger-stores.test.ts
@@ -217,6 +217,18 @@ describe('SqliteProtocolOutboxStore', () => {
     expect(store.hasPendingFor('peer-c')).toBe(false);
   });
 
+  it('retains the legacy peer snapshot contract without changing retry eligibility', () => {
+    const store = new SqliteProtocolOutboxStore(db, { backoffFor: () => 60_000 });
+    store.enqueue(PEER_A, PROTO, MSG_2, PAYLOAD, 'e', 2_000);
+    store.enqueue(PEER_A, PROTO, MSG_1, PAYLOAD, 'e', 1_000);
+    store.enqueue(PEER_B, PROTO, MSG_1, PAYLOAD, 'e', 500);
+
+    expect(store.pendingFor(PEER_A).map((entry) => entry.messageId)).toEqual([MSG_1, MSG_2]);
+    expect(store.pendingFor(PEER_B)).toHaveLength(1);
+    expect(store.due(60_499)).toHaveLength(0);
+    expect(store.due(60_500).map((entry) => entry.peer)).toEqual([PEER_B]);
+  });
+
   it('due returns entries with nextAttemptAt <= now', () => {
     const store = new SqliteProtocolOutboxStore(db, { backoffFor: () => 5_000 });
     store.enqueue(PEER_A, PROTO, MSG_1, PAYLOAD, 'e', 1_000_000);

--- a/scripts/devnet-test-issue-1579-outbox-backoff.sh
+++ b/scripts/devnet-test-issue-1579-outbox-backoff.sh
@@ -30,23 +30,36 @@ peer2="$(field "$status2" peerId)"
 [[ -n "$peer2" ]] || fail "node2 peerId unavailable"
 
 DB="$DB" PEER="$peer2" MESSAGE_ID="$MESSAGE_ID" node --input-type=module <<'NODE'
-import Database from 'better-sqlite3';
-import { encodeReliableEnvelope, PROTOCOL_MESSAGE } from './packages/core/dist/index.js';
+import { dirname } from 'node:path';
+import {
+  encodeReliableEnvelope,
+  PROTOCOL_MESSAGE,
+  RELIABLE_ENVELOPE_VERSION,
+} from './packages/core/dist/index.js';
+import {
+  DashboardDB,
+  SqliteProtocolOutboxStore,
+} from './packages/node-ui/dist/index.js';
 const now = Date.now();
 const payload = encodeReliableEnvelope({
   messageId: process.env.MESSAGE_ID,
-  version: 1,
+  version: RELIABLE_ENVELOPE_VERSION,
   tsMs: now,
   payload: new TextEncoder().encode('{"type":"chat","text":"#1579 probe"}'),
 });
-const db = new Database(process.env.DB);
-db.prepare(`INSERT INTO protocol_outbox
-  (peer_id, protocol, message_id, payload, attempts, first_failure_at,
-   last_attempt_at, next_attempt_at, last_error)
-  VALUES (?, ?, ?, ?, 1, ?, ?, ?, ?)`)
-  .run(process.env.PEER, PROTOCOL_MESSAGE, process.env.MESSAGE_ID,
-    Buffer.from(payload), now, now, now + 60 * 60 * 1000, 'devnet probe');
-db.close();
+const dashboard = new DashboardDB({ dataDir: dirname(process.env.DB) });
+const store = new SqliteProtocolOutboxStore(dashboard, {
+  backoffFor: () => 60 * 60 * 1000,
+});
+store.enqueue(
+  process.env.PEER,
+  PROTOCOL_MESSAGE,
+  process.env.MESSAGE_ID,
+  payload,
+  'devnet probe',
+  now,
+);
+dashboard.close();
 NODE
 
 "$ROOT/scripts/devnet.sh" restart-node 2 >/dev/null


### PR DESCRIPTION
Follow-up to #1622 for the remaining compatible-store review finding.

This restores the pre-#1579 pendingFor store contract so existing embedders do not need to implement a new required method. The boolean peer-presence check remains an optional fast path and falls back to the legacy snapshot. Documentation makes the boundary explicit: peer snapshots are diagnostics/DHT bookkeeping only, while duePage remains the sole automatic retry selector and reconnects never wake queued sends.

The stale reconnect wording is removed. The live devnet regression now creates its cooling row through SqliteProtocolOutboxStore and RELIABLE_ENVELOPE_VERSION rather than duplicating the durable row/envelope model.

Regression coverage:
- Core compile/runtime fixture for a pendingFor-only custom store.
- Messenger integration with that legacy custom-store shape.
- SQLite store peer-snapshot and due-time separation.
- Real DKGAgent connection-open lifecycle test remains green and proves reconnect does not send before due.
- Host devnet script syntax and canonical seed path.

Validation:
- 11-package core/node-ui/agent dependency build
- core protocol outbox: 29 passed
- node-ui messenger stores: 25 passed
- messenger substrate + real lifecycle: 55 passed
- devnet script shell syntax

The reconnect-drain request was intentionally not applied because issue #1579 explicitly requires direct, relay, startup, and genuine reconnect events to produce zero outbox retries.