### PR TITLE
fix(storage): prevent ACK traffic starving publish work

### DIFF
--- a/packages/storage/src/store-priority-scheduler.ts
+++ b/packages/storage/src/store-priority-scheduler.ts
@@ -126,6 +126,7 @@ export class StorePriorityScheduler {
   private normalInflight = 0;
   private backgroundInflight = 0;
   private readonly queueLimits: StorePriorityQueueLimits;
+  private lastStartedPriority: StoreWorkPriority | undefined;
 
   constructor(
     private readonly maxConcurrent = parsePositiveIntegerEnv('DKG_STORE_MAX_CONCURRENT', DEFAULT_MAX_CONCURRENT),
@@ -246,13 +247,26 @@ export class StorePriorityScheduler {
   private canStart(priority: StoreWorkPriority): boolean {
     const totalInflight = this.ackInflight + this.normalInflight + this.backgroundInflight;
     if (totalInflight >= this.maxConcurrent) return false;
-    if (priority === 'ack') return true;
+    if (priority === 'ack') return !this.shouldHoldNonAckFloor();
 
     const nonAckLimit = this.nonAckLimit();
     const nonAckInflight = this.normalInflight + this.backgroundInflight;
     if (nonAckInflight >= nonAckLimit) return false;
     if (priority === 'normal' && this.shouldHoldBackgroundFloor()) return false;
     return true;
+  }
+
+  private shouldHoldNonAckFloor(): boolean {
+    const nonAckInflight = this.normalInflight + this.backgroundInflight;
+    if (nonAckInflight >= this.nonAckLimit()) return false;
+
+    if (this.queues.normal.length > 0 && this.normalInflight === 0) {
+      // A single-slot scheduler cannot preserve ACK capacity and a normal lane
+      // simultaneously. Alternate after an ACK so both lanes still progress.
+      return this.maxConcurrent > 1 || this.lastStartedPriority === 'ack';
+    }
+
+    return this.shouldHoldBackgroundFloor();
   }
 
   private shouldHoldBackgroundFloor(): boolean {
@@ -277,6 +291,7 @@ export class StorePriorityScheduler {
   private start(entry: QueueEntry<unknown>): void {
     this.cleanupQueuedEntry(entry);
     this.increment(entry.priority);
+    this.lastStartedPriority = entry.priority;
     const startedAt = this.now();
     const waitMs = Math.max(0, startedAt - entry.queuedAt);
     this.observeQueueWait(entry, waitMs);

--- a/packages/storage/src/store-priority-scheduler.ts
+++ b/packages/storage/src/store-priority-scheduler.ts
@@ -109,11 +109,11 @@ function metricOperation(operation: string): string {
   return trimmed.replace(/[^\w:./-]/g, '_').slice(0, 80) || 'unknown';
 }
 
-function priorityRank(priority: StoreWorkPriority): number {
-  if (priority === 'ack') return 0;
-  if (priority === 'normal') return 1;
-  return 2;
-}
+const PRIORITY_ORDER = [
+  'ack',
+  'normal',
+  'background',
+] as const satisfies readonly StoreWorkPriority[];
 
 export class StorePriorityScheduler {
   private readonly queues: Record<StoreWorkPriority, Array<QueueEntry<unknown>>> = {
@@ -233,9 +233,15 @@ export class StorePriorityScheduler {
   }
 
   private nextRunnable(): QueueEntry<unknown> | undefined {
-    const priorities: StoreWorkPriority[] = ['ack', 'normal', 'background'];
-    priorities.sort((a, b) => priorityRank(a) - priorityRank(b));
-    for (const priority of priorities) {
+    const totalInflight = this.ackInflight + this.normalInflight + this.backgroundInflight;
+    if (totalInflight >= this.maxConcurrent) return undefined;
+
+    const owedFloor = this.owedFloorPriority();
+    if (owedFloor && this.canStart(owedFloor)) {
+      return this.queues[owedFloor].shift();
+    }
+
+    for (const priority of PRIORITY_ORDER) {
       const queue = this.queues[priority];
       if (queue.length === 0) continue;
       if (!this.canStart(priority)) continue;
@@ -247,33 +253,34 @@ export class StorePriorityScheduler {
   private canStart(priority: StoreWorkPriority): boolean {
     const totalInflight = this.ackInflight + this.normalInflight + this.backgroundInflight;
     if (totalInflight >= this.maxConcurrent) return false;
-    if (priority === 'ack') return !this.shouldHoldNonAckFloor();
+    if (priority === 'ack') return true;
 
     const nonAckLimit = this.nonAckLimit();
     const nonAckInflight = this.normalInflight + this.backgroundInflight;
-    if (nonAckInflight >= nonAckLimit) return false;
-    if (priority === 'normal' && this.shouldHoldBackgroundFloor()) return false;
-    return true;
+    return nonAckInflight < nonAckLimit;
   }
 
-  private shouldHoldNonAckFloor(): boolean {
-    const nonAckInflight = this.normalInflight + this.backgroundInflight;
-    if (nonAckInflight >= this.nonAckLimit()) return false;
-
-    if (this.queues.normal.length > 0 && this.normalInflight === 0) {
-      // A single-slot scheduler cannot preserve ACK capacity and a normal lane
-      // simultaneously. Alternate after an ACK so both lanes still progress.
-      return this.maxConcurrent > 1 || this.lastStartedPriority === 'ack';
-    }
-
-    return this.shouldHoldBackgroundFloor();
-  }
-
-  private shouldHoldBackgroundFloor(): boolean {
+  private owedFloorPriority(): Exclude<StoreWorkPriority, 'ack'> | undefined {
     const backgroundReserve = this.effectiveBackgroundReserve();
-    return backgroundReserve > 0 &&
+    const backgroundFloorOwed =
+      backgroundReserve > 0 &&
       this.queues.background.length > 0 &&
       this.backgroundInflight < backgroundReserve;
+    // Restore the background reserve before the normal floor when both are owed.
+    if (backgroundFloorOwed) return 'background';
+
+    const normalFloorOwed =
+      this.queues.normal.length > 0 &&
+      this.normalInflight === 0;
+    if (!normalFloorOwed) return undefined;
+
+    if (this.maxConcurrent > 1) return 'normal';
+
+    // A single-slot scheduler cannot preserve ACK capacity and a normal lane
+    // simultaneously. Alternate after an ACK so both lanes still progress.
+    if (this.lastStartedPriority === 'ack') return 'normal';
+
+    return undefined;
   }
 
   private effectiveAckReserve(): number {

--- a/packages/storage/test/store-priority-scheduler.test.ts
+++ b/packages/storage/test/store-priority-scheduler.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   StorePriorityScheduler,
   StoreSchedulerBusyError,
+  type StorePrioritySchedulerSnapshot,
 } from '../src/store-priority-scheduler.js';
 import type { StoreWorkPriority } from '../src/triple-store.js';
 
@@ -13,6 +14,66 @@ function deferred(): { promise: Promise<void>; resolve: () => void } {
     resolve = resolvePromise;
   });
   return { promise, resolve };
+}
+
+class SchedulerScenario {
+  private readonly events: string[] = [];
+  private readonly gates: Record<StoreWorkPriority, Array<ReturnType<typeof deferred>>> = {
+    ack: [],
+    normal: [],
+    background: [],
+  };
+  private readonly work: Promise<string>[] = [];
+
+  constructor(private readonly scheduler: StorePriorityScheduler) {}
+
+  enqueueBlocked(
+    priority: StoreWorkPriority,
+    count: number,
+    operationPrefix = priority,
+  ): void {
+    const laneGates = this.gates[priority];
+    const firstIndex = laneGates.length;
+    for (let offset = 0; offset < count; offset += 1) {
+      const index = firstIndex + offset;
+      const gate = deferred();
+      const label = `${priority}-${index}`;
+      const operation = count === 1 ? operationPrefix : `${operationPrefix}.${index}`;
+      laneGates.push(gate);
+      this.work.push(this.scheduler.run(priority, operation, async () => {
+        this.events.push(`${label}:start`);
+        await gate.promise;
+        this.events.push(`${label}:end`);
+        return label;
+      }));
+    }
+  }
+
+  release(priority: StoreWorkPriority, index: number): void {
+    const gate = this.gates[priority][index];
+    if (!gate) throw new Error(`No blocked ${priority} work at index ${index}`);
+    gate.resolve();
+  }
+
+  expectEvents(expected: string[]): void {
+    expect(this.events).toEqual(expected);
+  }
+
+  expectStarted(expected: string[]): void {
+    expect(this.events.filter((event) => event.endsWith(':start')))
+      .toEqual(expected.map((label) => `${label}:start`));
+  }
+
+  expectSnapshot(expected: Partial<StorePrioritySchedulerSnapshot>): void {
+    expect(this.scheduler.snapshot).toMatchObject(expected);
+  }
+
+  async finish(): Promise<string[]> {
+    for (const lane of Object.values(this.gates)) {
+      for (const gate of lane) gate.resolve();
+    }
+    return Promise.all(this.work);
+  }
 }
 
 describe('StorePriorityScheduler', () => {
@@ -228,90 +289,60 @@ describe('StorePriorityScheduler', () => {
 
   it('starts queued normal work while the ACK queue stays saturated', async () => {
     const scheduler = new StorePriorityScheduler(3, 1, undefined, 0);
-    const events: string[] = [];
-    const ackGates = Array.from({ length: 6 }, deferred);
-    const ackWork = ackGates.map((gate, index) => scheduler.run(
-      'ack',
-      `storage-ack.${index}`,
-      async () => {
-        events.push(`ack-${index}:start`);
-        await gate.promise;
-        events.push(`ack-${index}:end`);
-        return `ack-${index}`;
-      },
-    ));
-    const normalGate = deferred();
-    const normal = scheduler.run('normal', 'publish.clearPublishedSwmRoots', async () => {
-      events.push('normal:start');
-      await normalGate.promise;
-      events.push('normal:end');
-      return 'normal';
-    });
+    const scenario = new SchedulerScenario(scheduler);
+    scenario.enqueueBlocked('ack', 6, 'storage-ack');
+    scenario.enqueueBlocked('normal', 1, 'publish.clearPublishedSwmRoots');
     await tick();
 
-    expect(scheduler.snapshot).toMatchObject({
+    scenario.expectSnapshot({
       ackInflight: 3,
       ackQueued: 3,
       normalInflight: 0,
       normalQueued: 1,
     });
 
-    ackGates[0].resolve();
+    scenario.release('ack', 0);
     await tick();
 
-    expect(events).toEqual([
+    scenario.expectEvents([
       'ack-0:start',
       'ack-1:start',
       'ack-2:start',
       'ack-0:end',
-      'normal:start',
+      'normal-0:start',
     ]);
-    expect(scheduler.snapshot).toMatchObject({
+    scenario.expectSnapshot({
       ackInflight: 2,
       ackQueued: 3,
       normalInflight: 1,
       normalQueued: 0,
     });
 
-    normalGate.resolve();
-    for (const gate of ackGates) gate.resolve();
-    await expect(Promise.all([...ackWork, normal])).resolves.toHaveLength(7);
+    await expect(scenario.finish()).resolves.toHaveLength(7);
   });
 
   it('preserves normal and background floors at the default-like concurrency', async () => {
     const scheduler = new StorePriorityScheduler(8, 1, undefined, 1);
-    const events: string[] = [];
-    const ackGates = Array.from({ length: 10 }, deferred);
-    const ackWork = ackGates.map((gate, index) => scheduler.run(
-      'ack',
-      `storage-ack.${index}`,
-      async () => {
-        events.push(`ack-${index}:start`);
-        await gate.promise;
-        events.push(`ack-${index}:end`);
-        return `ack-${index}`;
-      },
-    ));
-    const normalGate = deferred();
-    const normal = scheduler.run('normal', 'publish.lifecycle-tail', async () => {
-      events.push('normal:start');
-      await normalGate.promise;
-      events.push('normal:end');
-      return 'normal';
-    });
-    const backgroundGate = deferred();
-    const background = scheduler.run('background', 'sync.catch-up', async () => {
-      events.push('background:start');
-      await backgroundGate.promise;
-      events.push('background:end');
-      return 'background';
-    });
+    const scenario = new SchedulerScenario(scheduler);
+    scenario.enqueueBlocked('ack', 10, 'storage-ack');
+    scenario.enqueueBlocked('normal', 1, 'publish.lifecycle-tail');
+    scenario.enqueueBlocked('background', 1, 'sync.catch-up');
     await tick();
 
-    ackGates[0].resolve();
+    scenario.release('ack', 0);
     await tick();
-    expect(events.at(-1)).toBe('background:start');
-    expect(scheduler.snapshot).toMatchObject({
+    scenario.expectStarted([
+      'ack-0',
+      'ack-1',
+      'ack-2',
+      'ack-3',
+      'ack-4',
+      'ack-5',
+      'ack-6',
+      'ack-7',
+      'background-0',
+    ]);
+    scenario.expectSnapshot({
       ackInflight: 7,
       ackQueued: 2,
       normalQueued: 1,
@@ -319,10 +350,21 @@ describe('StorePriorityScheduler', () => {
       backgroundReservedSlots: 1,
     });
 
-    ackGates[1].resolve();
+    scenario.release('ack', 1);
     await tick();
-    expect(events.at(-1)).toBe('normal:start');
-    expect(scheduler.snapshot).toMatchObject({
+    scenario.expectStarted([
+      'ack-0',
+      'ack-1',
+      'ack-2',
+      'ack-3',
+      'ack-4',
+      'ack-5',
+      'ack-6',
+      'ack-7',
+      'background-0',
+      'normal-0',
+    ]);
+    scenario.expectSnapshot({
       ackInflight: 6,
       ackQueued: 2,
       normalInflight: 1,
@@ -331,104 +373,60 @@ describe('StorePriorityScheduler', () => {
       backgroundReservedSlots: 1,
     });
 
-    normalGate.resolve();
-    backgroundGate.resolve();
-    for (const gate of ackGates) gate.resolve();
-    await expect(Promise.all([...ackWork, normal, background])).resolves.toHaveLength(12);
+    await expect(scenario.finish()).resolves.toHaveLength(12);
   });
 
   it('keeps the ACK reserve work-conserving when non-ACK capacity is full', async () => {
     const scheduler = new StorePriorityScheduler(3, 1, undefined, 1);
-    const events: string[] = [];
-    const normalGates = [deferred(), deferred()];
-    const normalWork = normalGates.map((gate, index) => scheduler.run(
-      'normal',
-      `query.${index}`,
-      async () => {
-        events.push(`normal-${index}:start`);
-        await gate.promise;
-        return `normal-${index}`;
-      },
-    ));
-    const backgroundGate = deferred();
-    const background = scheduler.run('background', 'sync.catch-up', async () => {
-      events.push('background:start');
-      await backgroundGate.promise;
-      return 'background';
-    });
-    const ackGate = deferred();
-    const ack = scheduler.run('ack', 'storage-ack.persist', async () => {
-      events.push('ack:start');
-      await ackGate.promise;
-      return 'ack';
-    });
+    const scenario = new SchedulerScenario(scheduler);
+    scenario.enqueueBlocked('normal', 2, 'query');
+    scenario.enqueueBlocked('background', 1, 'sync.catch-up');
+    scenario.enqueueBlocked('ack', 1, 'storage-ack.persist');
     await tick();
 
-    expect(events).toEqual(['normal-0:start', 'normal-1:start', 'ack:start']);
-    expect(scheduler.snapshot).toMatchObject({
+    scenario.expectStarted(['normal-0', 'normal-1', 'ack-0']);
+    scenario.expectSnapshot({
       ackInflight: 1,
       normalInflight: 2,
       backgroundInflight: 0,
       backgroundQueued: 1,
     });
 
-    normalGates[0].resolve();
+    scenario.release('normal', 0);
     await tick();
-    expect(events.at(-1)).toBe('background:start');
+    scenario.expectStarted(['normal-0', 'normal-1', 'ack-0', 'background-0']);
 
-    ackGate.resolve();
-    backgroundGate.resolve();
-    for (const gate of normalGates) gate.resolve();
-    await expect(Promise.all([...normalWork, background, ack])).resolves.toHaveLength(4);
+    await expect(scenario.finish()).resolves.toHaveLength(4);
   });
 
   it('alternates ACK and normal progress when only one slot exists', async () => {
     const scheduler = new StorePriorityScheduler(1, 1);
-    const events: string[] = [];
-    const ackGates = [deferred(), deferred()];
-    const normalGates = [deferred(), deferred()];
-    const ackWork = ackGates.map((gate, index) => scheduler.run(
-      'ack',
-      `storage-ack.${index}`,
-      async () => {
-        events.push(`ack-${index}:start`);
-        await gate.promise;
-        return `ack-${index}`;
-      },
-    ));
-    const normalWork = normalGates.map((gate, index) => scheduler.run(
-      'normal',
-      `publish.tail.${index}`,
-      async () => {
-        events.push(`normal-${index}:start`);
-        await gate.promise;
-        return `normal-${index}`;
-      },
-    ));
+    const scenario = new SchedulerScenario(scheduler);
+    scenario.enqueueBlocked('ack', 2, 'storage-ack');
+    scenario.enqueueBlocked('normal', 2, 'publish.tail');
     await tick();
 
-    expect(events).toEqual(['ack-0:start']);
-    expect(scheduler.snapshot).toMatchObject({
+    scenario.expectStarted(['ack-0']);
+    scenario.expectSnapshot({
       ackInflight: 1,
       ackQueued: 1,
       normalQueued: 2,
       ackReservedSlots: 0,
     });
 
-    ackGates[0].resolve();
+    scenario.release('ack', 0);
     await tick();
-    expect(events.at(-1)).toBe('normal-0:start');
+    scenario.expectStarted(['ack-0', 'normal-0']);
 
-    normalGates[0].resolve();
+    scenario.release('normal', 0);
     await tick();
-    expect(events.at(-1)).toBe('ack-1:start');
+    scenario.expectStarted(['ack-0', 'normal-0', 'ack-1']);
 
-    ackGates[1].resolve();
+    scenario.release('ack', 1);
     await tick();
-    expect(events.at(-1)).toBe('normal-1:start');
+    scenario.expectStarted(['ack-0', 'normal-0', 'ack-1', 'normal-1']);
 
-    normalGates[1].resolve();
-    await expect(Promise.all([...ackWork, ...normalWork])).resolves.toHaveLength(4);
+    await expect(scenario.finish()).resolves.toHaveLength(4);
   });
 
   it('reserves a non-ACK slot for queued background work behind normal traffic', async () => {

--- a/packages/storage/test/store-priority-scheduler.test.ts
+++ b/packages/storage/test/store-priority-scheduler.test.ts
@@ -7,6 +7,14 @@ import type { StoreWorkPriority } from '../src/triple-store.js';
 
 const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
 
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
 describe('StorePriorityScheduler', () => {
   for (const priority of ['ack', 'normal', 'background'] as const satisfies readonly StoreWorkPriority[]) {
     it(`bounds the ${priority} queue and returns a typed retryable rejection`, async () => {
@@ -216,6 +224,211 @@ describe('StorePriorityScheduler', () => {
     await expect(
       scheduler.run('ack', 'storage-ack.after-throw', async () => 'ok'),
     ).resolves.toBe('ok');
+  });
+
+  it('starts queued normal work while the ACK queue stays saturated', async () => {
+    const scheduler = new StorePriorityScheduler(3, 1, undefined, 0);
+    const events: string[] = [];
+    const ackGates = Array.from({ length: 6 }, deferred);
+    const ackWork = ackGates.map((gate, index) => scheduler.run(
+      'ack',
+      `storage-ack.${index}`,
+      async () => {
+        events.push(`ack-${index}:start`);
+        await gate.promise;
+        events.push(`ack-${index}:end`);
+        return `ack-${index}`;
+      },
+    ));
+    const normalGate = deferred();
+    const normal = scheduler.run('normal', 'publish.clearPublishedSwmRoots', async () => {
+      events.push('normal:start');
+      await normalGate.promise;
+      events.push('normal:end');
+      return 'normal';
+    });
+    await tick();
+
+    expect(scheduler.snapshot).toMatchObject({
+      ackInflight: 3,
+      ackQueued: 3,
+      normalInflight: 0,
+      normalQueued: 1,
+    });
+
+    ackGates[0].resolve();
+    await tick();
+
+    expect(events).toEqual([
+      'ack-0:start',
+      'ack-1:start',
+      'ack-2:start',
+      'ack-0:end',
+      'normal:start',
+    ]);
+    expect(scheduler.snapshot).toMatchObject({
+      ackInflight: 2,
+      ackQueued: 3,
+      normalInflight: 1,
+      normalQueued: 0,
+    });
+
+    normalGate.resolve();
+    for (const gate of ackGates) gate.resolve();
+    await expect(Promise.all([...ackWork, normal])).resolves.toHaveLength(7);
+  });
+
+  it('preserves normal and background floors at the default-like concurrency', async () => {
+    const scheduler = new StorePriorityScheduler(8, 1, undefined, 1);
+    const events: string[] = [];
+    const ackGates = Array.from({ length: 10 }, deferred);
+    const ackWork = ackGates.map((gate, index) => scheduler.run(
+      'ack',
+      `storage-ack.${index}`,
+      async () => {
+        events.push(`ack-${index}:start`);
+        await gate.promise;
+        events.push(`ack-${index}:end`);
+        return `ack-${index}`;
+      },
+    ));
+    const normalGate = deferred();
+    const normal = scheduler.run('normal', 'publish.lifecycle-tail', async () => {
+      events.push('normal:start');
+      await normalGate.promise;
+      events.push('normal:end');
+      return 'normal';
+    });
+    const backgroundGate = deferred();
+    const background = scheduler.run('background', 'sync.catch-up', async () => {
+      events.push('background:start');
+      await backgroundGate.promise;
+      events.push('background:end');
+      return 'background';
+    });
+    await tick();
+
+    ackGates[0].resolve();
+    await tick();
+    expect(events.at(-1)).toBe('background:start');
+    expect(scheduler.snapshot).toMatchObject({
+      ackInflight: 7,
+      ackQueued: 2,
+      normalQueued: 1,
+      backgroundInflight: 1,
+      backgroundReservedSlots: 1,
+    });
+
+    ackGates[1].resolve();
+    await tick();
+    expect(events.at(-1)).toBe('normal:start');
+    expect(scheduler.snapshot).toMatchObject({
+      ackInflight: 6,
+      ackQueued: 2,
+      normalInflight: 1,
+      backgroundInflight: 1,
+      ackReservedSlots: 1,
+      backgroundReservedSlots: 1,
+    });
+
+    normalGate.resolve();
+    backgroundGate.resolve();
+    for (const gate of ackGates) gate.resolve();
+    await expect(Promise.all([...ackWork, normal, background])).resolves.toHaveLength(12);
+  });
+
+  it('keeps the ACK reserve work-conserving when non-ACK capacity is full', async () => {
+    const scheduler = new StorePriorityScheduler(3, 1, undefined, 1);
+    const events: string[] = [];
+    const normalGates = [deferred(), deferred()];
+    const normalWork = normalGates.map((gate, index) => scheduler.run(
+      'normal',
+      `query.${index}`,
+      async () => {
+        events.push(`normal-${index}:start`);
+        await gate.promise;
+        return `normal-${index}`;
+      },
+    ));
+    const backgroundGate = deferred();
+    const background = scheduler.run('background', 'sync.catch-up', async () => {
+      events.push('background:start');
+      await backgroundGate.promise;
+      return 'background';
+    });
+    const ackGate = deferred();
+    const ack = scheduler.run('ack', 'storage-ack.persist', async () => {
+      events.push('ack:start');
+      await ackGate.promise;
+      return 'ack';
+    });
+    await tick();
+
+    expect(events).toEqual(['normal-0:start', 'normal-1:start', 'ack:start']);
+    expect(scheduler.snapshot).toMatchObject({
+      ackInflight: 1,
+      normalInflight: 2,
+      backgroundInflight: 0,
+      backgroundQueued: 1,
+    });
+
+    normalGates[0].resolve();
+    await tick();
+    expect(events.at(-1)).toBe('background:start');
+
+    ackGate.resolve();
+    backgroundGate.resolve();
+    for (const gate of normalGates) gate.resolve();
+    await expect(Promise.all([...normalWork, background, ack])).resolves.toHaveLength(4);
+  });
+
+  it('alternates ACK and normal progress when only one slot exists', async () => {
+    const scheduler = new StorePriorityScheduler(1, 1);
+    const events: string[] = [];
+    const ackGates = [deferred(), deferred()];
+    const normalGates = [deferred(), deferred()];
+    const ackWork = ackGates.map((gate, index) => scheduler.run(
+      'ack',
+      `storage-ack.${index}`,
+      async () => {
+        events.push(`ack-${index}:start`);
+        await gate.promise;
+        return `ack-${index}`;
+      },
+    ));
+    const normalWork = normalGates.map((gate, index) => scheduler.run(
+      'normal',
+      `publish.tail.${index}`,
+      async () => {
+        events.push(`normal-${index}:start`);
+        await gate.promise;
+        return `normal-${index}`;
+      },
+    ));
+    await tick();
+
+    expect(events).toEqual(['ack-0:start']);
+    expect(scheduler.snapshot).toMatchObject({
+      ackInflight: 1,
+      ackQueued: 1,
+      normalQueued: 2,
+      ackReservedSlots: 0,
+    });
+
+    ackGates[0].resolve();
+    await tick();
+    expect(events.at(-1)).toBe('normal-0:start');
+
+    normalGates[0].resolve();
+    await tick();
+    expect(events.at(-1)).toBe('ack-1:start');
+
+    ackGates[1].resolve();
+    await tick();
+    expect(events.at(-1)).toBe('normal-1:start');
+
+    normalGates[1].resolve();
+    await expect(Promise.all([...ackWork, ...normalWork])).resolves.toHaveLength(4);
   });
 
   it('reserves a non-ACK slot for queued background work behind normal traffic', async () => {


### PR DESCRIPTION
## What changed

- reserve progress for queued normal-priority storage work while ACK traffic is continuously saturated
- preserve the existing ACK reserve, background-work floor, queue limits, wait timeouts, abort cleanup, and rejection metrics from current main
- keep the scheduler work-conserving when no non-ACK work needs the slot
- alternate ACK and normal work when concurrency is configured to one slot

## Root cause

Since v10.0.5, storage ACK work has strict priority. On long-lived mainnet nodes, sustained ACK traffic can keep the queue non-empty indefinitely, so the awaited post-confirmation publish tail may not receive a store slot. The chain transaction and reads can succeed while the HTTP publish response remains blocked until Jenkins times out.

This fixes the starvation invariant without detaching work or returning before authoritative publish cleanup completes.

## Safety

- no Promise.race and no detached server-side mutation
- the publish response still waits for the authoritative cleanup boundary
- normal and background work retain progress floors while ACK work can use every otherwise-idle slot
- the current-main overload controls and metrics remain intact

## Validation

On current main (6613cd403):

- full storage suite: 386 passed; 26 expected integration skips
- scheduler regressions: 17/17 passed
- publisher ACK-priority lane: 3/3 passed
- storage, chain, and publisher TypeScript builds passed
- git diff --check passed

Combined with #1651 on a fresh six-node devnet using Oxigraph worker, Blazegraph, and external Oxigraph backends:

- full workspace build passed
- V10 end-to-end suite: 4/4 passed
- two consecutive Jenkins-shaped two-node runs, 10 KAs per node per run, 50 entities per KA, 12 epochs
- 40/40 confirmed publishes, 40/40 normal queries, 40/40 VM GETs
- zero publish timeouts; remote query intentionally disabled as a separate future gate

## PR relationship

#1650 and #1651 are the two server-side fixes for #1572. #1652 hardens the test/publish harness and makes remote query opt-in. Recommended merge order: #1650, then #1651; #1652 lands independently on test/publish.

This supersedes the scheduler portion of #1590.
