### PR TITLE
fix(storage): bound external store admission

### DIFF
--- a/packages/core/src/telemetry-api.ts
+++ b/packages/core/src/telemetry-api.ts
@@ -177,6 +177,8 @@ export interface DkgMetrics {
   storageAckInflight: Histogram;
   /** queue_depth sample for background/normal store work competing with ACK */
   syncBackgroundQueueDepth: Histogram;
+  /** priority={ack|normal|background}, reason={queue_full|queue_wait_timeout} */
+  storeSchedulerRejectionsTotal: Counter;
   /** process-local sync inflight sample */
   syncGlobalInflight: Histogram;
   /** currently retained responder snapshots; phase is a bounded enum */
@@ -273,6 +275,9 @@ function buildMetrics(): DkgMetrics {
     }),
     syncBackgroundQueueDepth: meter.createHistogram('dkg.sync.background_queue_depth', {
       description: 'Sampled non-ACK store queue depth',
+    }),
+    storeSchedulerRejectionsTotal: meter.createCounter('dkg.store.scheduler_rejections_total', {
+      description: 'External-store work rejected before dispatch by bounded priority and reason',
     }),
     syncGlobalInflight: meter.createHistogram('dkg.sync.global_inflight', {
       description: 'Sampled process-local sync inflight count',

--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -66,6 +66,41 @@ For heavy / production workloads, prefer an out-of-process SPARQL server
 (`sparql-http` or `blazegraph`), which handles reads and writes concurrently
 and keeps the daemon responsive under load.
 
+## External-store admission and deadlines
+
+All external adapters share a process-wide priority scheduler. Waiting work is
+bounded independently for `ack`, `normal`, and `background` traffic, and an
+operation rejected before dispatch receives `StoreSchedulerBusyError` with
+`code: STORE_SCHEDULER_BUSY`, `retryable: true`, and a reason of either
+`queue_full` or `queue_wait_timeout`. Because this error is only created before
+the operation closure starts, retrying it cannot duplicate a write that might
+already have reached the store.
+
+| Environment variable | Default | Purpose |
+|---|---:|---|
+| `DKG_STORE_MAX_CONCURRENT` | `8` | Maximum external-store operations in flight. |
+| `DKG_STORE_ACK_RESERVED_SLOTS` | `1` | In-flight capacity reserved for ACK work. |
+| `DKG_STORE_BACKGROUND_RESERVED_SLOTS` | `1` | Non-ACK capacity reserved for background progress. |
+| `DKG_STORE_QUEUE_LIMIT` | `64` | Maximum waiting operations in each priority queue. |
+| `DKG_STORE_ACK_QUEUE_LIMIT` | common limit | Optional ACK queue override. |
+| `DKG_STORE_NORMAL_QUEUE_LIMIT` | common limit | Optional normal queue override. |
+| `DKG_STORE_BACKGROUND_QUEUE_LIMIT` | common limit | Optional background queue override. |
+| `DKG_STORE_QUEUE_WAIT_TIMEOUT_MS` | `10000` | Maximum pre-dispatch wait before a retryable busy rejection. |
+| `DKG_BLAZEGRAPH_OPERATION_TIMEOUT_MS` | `30000` | Blazegraph end-to-end operation deadline, including scheduler wait, HTTP, response decoding, and mapping. |
+
+Blazegraph's deadline can also be set per store, which takes precedence over
+the environment default:
+
+```jsonc
+"store": {
+  "backend": "blazegraph",
+  "options": {
+    "url": "http://127.0.0.1:9999/blazegraph/namespace/dkg/sparql",
+    "timeout": 30000
+  }
+}
+```
+
 ## Internal Dependencies
 
 - `@origintrail-official/dkg-core` — configuration types, logging, constants

--- a/packages/storage/src/adapters/blazegraph.ts
+++ b/packages/storage/src/adapters/blazegraph.ts
@@ -26,9 +26,10 @@ export interface BlazegraphStoreOptions {
 }
 
 interface StoreOperationDeadline {
-  signal: AbortSignal;
-  throwIfExpired: () => void;
-  dispose: () => void;
+  readonly signal: AbortSignal;
+  waitFor<T>(work: Promise<T>): Promise<T>;
+  check(): void;
+  dispose(): void;
 }
 
 function parsePositiveIntegerEnv(name: string, fallback: number): number {
@@ -94,16 +95,33 @@ function createStoreOperationDeadline(
     if (typeof timer.unref === 'function') timer.unref();
   }
 
+  const check = () => {
+    if (controller.signal.aborted) throw abortError(controller.signal);
+    if (performance.now() < deadlineAt) return;
+    const error = timeoutError();
+    detachCaller();
+    controller.abort(error);
+    throw error;
+  };
+  const waitFor = async <T>(work: Promise<T>): Promise<T> => {
+    let result: T;
+    try {
+      result = await raceAgainstAbort(work, controller.signal);
+    } catch (error) {
+      // The timer callback may be delayed by synchronous response processing.
+      // Re-check the monotonic deadline before preserving an underlying error
+      // so elapsed operations still surface the deadline's TimeoutError.
+      check();
+      throw error;
+    }
+    check();
+    return result;
+  };
+
   return {
     signal: controller.signal,
-    throwIfExpired: () => {
-      if (controller.signal.aborted) throw abortError(controller.signal);
-      if (performance.now() < deadlineAt) return;
-      const error = timeoutError();
-      detachCaller();
-      controller.abort(error);
-      throw error;
-    },
+    waitFor,
+    check,
     dispose: () => {
       if (timer) {
         clearTimeout(timer);
@@ -168,16 +186,16 @@ export class BlazegraphStore implements TripleStore {
   private runStoreWork<T>(
     operation: string,
     options: QueryOptions | undefined,
-    work: (signal: AbortSignal, throwIfExpired: () => void) => Promise<T>,
+    work: (deadline: StoreOperationDeadline) => Promise<T>,
   ): Promise<T> {
     const deadline = createStoreOperationDeadline(this.operationTimeoutMs, options?.signal);
     const scheduled = externalStorePriorityScheduler.run(
       options?.priority,
       options?.source ?? `blazegraph.${operation}`,
       async () => {
-        deadline.throwIfExpired();
-        const result = await work(deadline.signal, deadline.throwIfExpired);
-        deadline.throwIfExpired();
+        deadline.check();
+        const result = await work(deadline);
+        deadline.check();
         return result;
       },
       deadline.signal,
@@ -198,7 +216,7 @@ export class BlazegraphStore implements TripleStore {
     await this.runStoreWork('insert', {
       ...options,
       source: options?.source ?? 'blazegraph.insert',
-    }, async (signal, throwIfExpired) => {
+    }, async (deadline) => {
       assertQuadLiteralsMutf8Safe(quads, {
         maxBytes: JAVA_WRITE_UTF_MAX_BYTES,
         label: 'BlazegraphStore.insert',
@@ -207,16 +225,15 @@ export class BlazegraphStore implements TripleStore {
       // retains the caller's quad array, not an additional potentially-large
       // N-Quads copy for every waiting insert.
       const nquads = quads.map(quadToBlazegraphNQuad).join('\n') + '\n';
-      throwIfExpired();
-      const res = await raceAgainstAbort(fetch(this.url, {
+      deadline.check();
+      const res = await deadline.waitFor(fetch(this.url, {
         method: 'POST',
         headers: { 'Content-Type': 'text/x-nquads' },
         body: nquads,
-        signal,
-      }), signal);
+        signal: deadline.signal,
+      }));
       if (!res.ok) {
-        const text = await raceAgainstAbort(res.text().catch(() => ''), signal);
-        throwIfExpired();
+        const text = await deadline.waitFor(res.text().catch(() => ''));
         throw new Error(`Blazegraph insert failed (${res.status}): ${text.slice(0, 200)}`);
       }
     });
@@ -306,14 +323,14 @@ export class BlazegraphStore implements TripleStore {
   // -------------------------------------------------------------------
 
   async query(sparql: string, options?: TripleStoreQueryOptions): Promise<QueryResult> {
-    return this.runStoreWork('query', options, async (signal, throwIfExpired) => {
+    return this.runStoreWork('query', options, async (deadline) => {
       const trimmed = sparql.trim();
       const upper = trimmed.toUpperCase();
       const isAsk = upper.startsWith('ASK');
       const isConstruct = upper.startsWith('CONSTRUCT') || upper.startsWith('DESCRIBE');
 
       if (isConstruct) {
-        return this.queryConstruct(trimmed, signal, throwIfExpired);
+        return this.queryConstruct(trimmed, deadline);
       }
 
       // Direct POST (W3C SPARQL 1.1 Protocol): send the query as the raw
@@ -324,26 +341,23 @@ export class BlazegraphStore implements TripleStore {
       // "Unable to parse form content". The direct-POST body is not form
       // parsed, so large queries (e.g. CONSTRUCT/VALUES) are not capped.
       // SPARQL_QUERY_CONTENT_TYPE carries charset=utf-8 (see sparql-content-types.ts).
-      const res = await raceAgainstAbort(fetch(this.url, {
+      const res = await deadline.waitFor(fetch(this.url, {
         method: 'POST',
         headers: {
           'Content-Type': SPARQL_QUERY_CONTENT_TYPE,
           Accept: 'application/sparql-results+json',
         },
         body: trimmed,
-        signal,
-      }), signal);
+        signal: deadline.signal,
+      }));
       if (!res.ok) {
-        const text = await raceAgainstAbort(res.text().catch(() => ''), signal);
-        throwIfExpired();
+        const text = await deadline.waitFor(res.text().catch(() => ''));
         throw new Error(`Blazegraph query failed (${res.status}): ${text.slice(0, 300)}`);
       }
 
-      const json = await raceAgainstAbort(
+      const json = await deadline.waitFor(
         res.json() as Promise<BlazeSelectResponse | BlazeAskResponse>,
-        signal,
       );
-      throwIfExpired();
 
       if (isAsk || 'boolean' in json) {
         return { type: 'boolean', value: (json as BlazeAskResponse).boolean } satisfies AskResult;
@@ -365,26 +379,24 @@ export class BlazegraphStore implements TripleStore {
 
   private async queryConstruct(
     sparql: string,
-    signal: AbortSignal,
-    throwIfExpired: () => void,
+    deadline: StoreOperationDeadline,
   ): Promise<ConstructResult> {
-    const res = await raceAgainstAbort(fetch(this.url, {
+    const res = await deadline.waitFor(fetch(this.url, {
       method: 'POST',
       headers: {
         'Content-Type': SPARQL_QUERY_CONTENT_TYPE,
         Accept: 'text/x-nquads, application/n-quads',
       },
       body: sparql,
-      signal,
-    }), signal);
+      signal: deadline.signal,
+    }));
     if (!res.ok) {
-      const text = await raceAgainstAbort(res.text().catch(() => ''), signal);
-      throwIfExpired();
+      const text = await deadline.waitFor(res.text().catch(() => ''));
       throw new Error(`Blazegraph construct failed (${res.status}): ${text.slice(0, 300)}`);
     }
-    const text = await raceAgainstAbort(res.text(), signal);
+    const text = await deadline.waitFor(res.text());
     const quads = parseNQuadsText(text);
-    throwIfExpired();
+    deadline.check();
     return { type: 'quads', quads };
   }
 
@@ -467,16 +479,15 @@ export class BlazegraphStore implements TripleStore {
     // raw body is not form parsed, so large updates succeed.
     //
     // SPARQL_UPDATE_CONTENT_TYPE carries charset=utf-8 (see sparql-content-types.ts).
-    await this.runStoreWork(operation, options, async (signal, throwIfExpired) => {
-      const res = await raceAgainstAbort(fetch(this.url, {
+    await this.runStoreWork(operation, options, async (deadline) => {
+      const res = await deadline.waitFor(fetch(this.url, {
         method: 'POST',
         headers: { 'Content-Type': SPARQL_UPDATE_CONTENT_TYPE },
         body: update,
-        signal,
-      }), signal);
+        signal: deadline.signal,
+      }));
       if (!res.ok) {
-        const text = await raceAgainstAbort(res.text().catch(() => ''), signal);
-        throwIfExpired();
+        const text = await deadline.waitFor(res.text().catch(() => ''));
         throw new Error(`Blazegraph update failed (${res.status}): ${text.slice(0, 300)}`);
       }
     });

--- a/packages/storage/src/adapters/blazegraph.ts
+++ b/packages/storage/src/adapters/blazegraph.ts
@@ -1,3 +1,4 @@
+import { performance } from 'node:perf_hooks';
 import type {
   TripleStore,
   Quad as DKGQuad,
@@ -17,6 +18,134 @@ import { SPARQL_QUERY_CONTENT_TYPE, SPARQL_UPDATE_CONTENT_TYPE } from './sparql-
 import { assertQuadLiteralsMutf8Safe, JAVA_WRITE_UTF_MAX_BYTES } from '@origintrail-official/dkg-core';
 import { externalStorePriorityScheduler } from '../store-priority-scheduler.js';
 
+export const DEFAULT_BLAZEGRAPH_OPERATION_TIMEOUT_MS = 30_000;
+
+export interface BlazegraphStoreOptions {
+  /** End-to-end timeout including scheduler wait, HTTP work, and response decoding. */
+  timeout?: number;
+}
+
+interface StoreOperationDeadline {
+  signal: AbortSignal;
+  throwIfExpired: () => void;
+  dispose: () => void;
+}
+
+function parsePositiveIntegerEnv(name: string, fallback: number): number {
+  const raw = process.env[name]?.trim();
+  if (!raw) return fallback;
+  const parsed = Number(raw);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function resolveOperationTimeout(configured: number | undefined): number {
+  if (configured === undefined) {
+    return parsePositiveIntegerEnv(
+      'DKG_BLAZEGRAPH_OPERATION_TIMEOUT_MS',
+      DEFAULT_BLAZEGRAPH_OPERATION_TIMEOUT_MS,
+    );
+  }
+  if (!Number.isInteger(configured) || configured <= 0) {
+    throw new Error('BlazegraphStore timeout must be a positive integer in milliseconds');
+  }
+  return configured;
+}
+
+function abortError(signal: AbortSignal): Error {
+  const reason = signal.reason;
+  return reason instanceof Error ? reason : new Error(String(reason ?? 'aborted'));
+}
+
+function createStoreOperationDeadline(
+  timeoutMs: number,
+  callerSignal?: AbortSignal,
+): StoreOperationDeadline {
+  const controller = new AbortController();
+  const deadlineAt = performance.now() + timeoutMs;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let callerAttached = false;
+
+  const timeoutError = () => new DOMException(
+    `Blazegraph operation exceeded its ${timeoutMs}ms deadline`,
+    'TimeoutError',
+  );
+  const detachCaller = () => {
+    if (!callerAttached) return;
+    callerAttached = false;
+    callerSignal?.removeEventListener('abort', onCallerAbort);
+  };
+  const onCallerAbort = () => {
+    detachCaller();
+    controller.abort(callerSignal?.reason);
+  };
+
+  if (callerSignal?.aborted) {
+    controller.abort(callerSignal.reason);
+  } else {
+    if (callerSignal) {
+      callerAttached = true;
+      callerSignal.addEventListener('abort', onCallerAbort, { once: true });
+    }
+    timer = setTimeout(() => {
+      timer = undefined;
+      detachCaller();
+      controller.abort(timeoutError());
+    }, timeoutMs);
+    if (typeof timer.unref === 'function') timer.unref();
+  }
+
+  return {
+    signal: controller.signal,
+    throwIfExpired: () => {
+      if (controller.signal.aborted) throw abortError(controller.signal);
+      if (performance.now() < deadlineAt) return;
+      const error = timeoutError();
+      detachCaller();
+      controller.abort(error);
+      throw error;
+    },
+    dispose: () => {
+      if (timer) {
+        clearTimeout(timer);
+        timer = undefined;
+      }
+      detachCaller();
+    },
+  };
+}
+
+function raceAgainstAbort<T>(work: Promise<T>, signal: AbortSignal): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    let listening = false;
+    const cleanup = () => {
+      if (!listening) return;
+      listening = false;
+      signal.removeEventListener('abort', onAbort);
+    };
+    const onAbort = () => {
+      cleanup();
+      reject(abortError(signal));
+    };
+    work.then(
+      (value) => {
+        cleanup();
+        resolve(value);
+      },
+      (error) => {
+        cleanup();
+        reject(error);
+      },
+    );
+    if (signal.aborted) {
+      onAbort();
+    } else {
+      listening = true;
+      signal.addEventListener('abort', onAbort, { once: true });
+      if (signal.aborted) onAbort();
+    }
+  });
+}
+
 /**
  * BlazegraphStore — TripleStore adapter backed by a remote Blazegraph
  * SPARQL endpoint over HTTP.  Works with any Blazegraph 2.x instance
@@ -29,22 +158,31 @@ export class BlazegraphStore implements TripleStore {
   readonly queryCancellation = 'interruptible' as const;
 
   private readonly url: string;
+  private readonly operationTimeoutMs: number;
 
-  constructor(url: string) {
+  constructor(url: string, options: BlazegraphStoreOptions = {}) {
     this.url = url.replace(/\/$/, '');
+    this.operationTimeoutMs = resolveOperationTimeout(options.timeout);
   }
 
   private runStoreWork<T>(
     operation: string,
     options: QueryOptions | undefined,
-    work: () => Promise<T>,
+    work: (signal: AbortSignal, throwIfExpired: () => void) => Promise<T>,
   ): Promise<T> {
-    return externalStorePriorityScheduler.run(
+    const deadline = createStoreOperationDeadline(this.operationTimeoutMs, options?.signal);
+    const scheduled = externalStorePriorityScheduler.run(
       options?.priority,
       options?.source ?? `blazegraph.${operation}`,
-      work,
-      options?.signal,
+      async () => {
+        deadline.throwIfExpired();
+        const result = await work(deadline.signal, deadline.throwIfExpired);
+        deadline.throwIfExpired();
+        return result;
+      },
+      deadline.signal,
     );
+    return scheduled.finally(deadline.dispose);
   }
 
   getPressureSnapshot(): StorePressureSnapshot {
@@ -57,28 +195,31 @@ export class BlazegraphStore implements TripleStore {
 
   async insert(quads: DKGQuad[], options?: QueryOptions): Promise<void> {
     if (quads.length === 0) return;
-    assertQuadLiteralsMutf8Safe(quads, {
-      maxBytes: JAVA_WRITE_UTF_MAX_BYTES,
-      label: 'BlazegraphStore.insert',
-    });
-    // Blazegraph's bulk-insert wire serializer (ASCII-safe N-Quads). See
-    // quadToBlazegraphNQuad / toBlazegraphAsciiSafeNQuads for why Blazegraph
-    // requires this.
-    const nquads = quads.map(quadToBlazegraphNQuad).join('\n') + '\n';
-    const res = await this.runStoreWork('insert', {
+    await this.runStoreWork('insert', {
       ...options,
       source: options?.source ?? 'blazegraph.insert',
-    }, async () => fetch(this.url, {
+    }, async (signal, throwIfExpired) => {
+      assertQuadLiteralsMutf8Safe(quads, {
+        maxBytes: JAVA_WRITE_UTF_MAX_BYTES,
+        label: 'BlazegraphStore.insert',
+      });
+      // Serialize only after scheduler admission. A blocked store therefore
+      // retains the caller's quad array, not an additional potentially-large
+      // N-Quads copy for every waiting insert.
+      const nquads = quads.map(quadToBlazegraphNQuad).join('\n') + '\n';
+      throwIfExpired();
+      const res = await raceAgainstAbort(fetch(this.url, {
         method: 'POST',
         headers: { 'Content-Type': 'text/x-nquads' },
         body: nquads,
-        signal: options?.signal,
-      }),
-    );
-    if (!res.ok) {
-      const text = await res.text().catch(() => '');
-      throw new Error(`Blazegraph insert failed (${res.status}): ${text.slice(0, 200)}`);
-    }
+        signal,
+      }), signal);
+      if (!res.ok) {
+        const text = await raceAgainstAbort(res.text().catch(() => ''), signal);
+        throwIfExpired();
+        throw new Error(`Blazegraph insert failed (${res.status}): ${text.slice(0, 200)}`);
+      }
+    });
   }
 
   async delete(quads: DKGQuad[], options?: QueryOptions): Promise<void> {
@@ -165,18 +306,14 @@ export class BlazegraphStore implements TripleStore {
   // -------------------------------------------------------------------
 
   async query(sparql: string, options?: TripleStoreQueryOptions): Promise<QueryResult> {
-    return this.runStoreWork('query', options, async () => {
-      if (options?.signal?.aborted) {
-        const reason = options.signal.reason;
-        throw reason instanceof Error ? reason : new Error(String(reason ?? 'aborted'));
-      }
+    return this.runStoreWork('query', options, async (signal, throwIfExpired) => {
       const trimmed = sparql.trim();
       const upper = trimmed.toUpperCase();
       const isAsk = upper.startsWith('ASK');
       const isConstruct = upper.startsWith('CONSTRUCT') || upper.startsWith('DESCRIBE');
 
       if (isConstruct) {
-        return this.queryConstruct(trimmed, options);
+        return this.queryConstruct(trimmed, signal, throwIfExpired);
       }
 
       // Direct POST (W3C SPARQL 1.1 Protocol): send the query as the raw
@@ -187,21 +324,26 @@ export class BlazegraphStore implements TripleStore {
       // "Unable to parse form content". The direct-POST body is not form
       // parsed, so large queries (e.g. CONSTRUCT/VALUES) are not capped.
       // SPARQL_QUERY_CONTENT_TYPE carries charset=utf-8 (see sparql-content-types.ts).
-      const res = await fetch(this.url, {
+      const res = await raceAgainstAbort(fetch(this.url, {
         method: 'POST',
         headers: {
           'Content-Type': SPARQL_QUERY_CONTENT_TYPE,
           Accept: 'application/sparql-results+json',
         },
         body: trimmed,
-        signal: options?.signal,
-      });
+        signal,
+      }), signal);
       if (!res.ok) {
-        const text = await res.text().catch(() => '');
+        const text = await raceAgainstAbort(res.text().catch(() => ''), signal);
+        throwIfExpired();
         throw new Error(`Blazegraph query failed (${res.status}): ${text.slice(0, 300)}`);
       }
 
-      const json = (await res.json()) as BlazeSelectResponse | BlazeAskResponse;
+      const json = await raceAgainstAbort(
+        res.json() as Promise<BlazeSelectResponse | BlazeAskResponse>,
+        signal,
+      );
+      throwIfExpired();
 
       if (isAsk || 'boolean' in json) {
         return { type: 'boolean', value: (json as BlazeAskResponse).boolean } satisfies AskResult;
@@ -221,22 +363,28 @@ export class BlazegraphStore implements TripleStore {
     });
   }
 
-  private async queryConstruct(sparql: string, options?: QueryOptions): Promise<ConstructResult> {
-    const res = await fetch(this.url, {
+  private async queryConstruct(
+    sparql: string,
+    signal: AbortSignal,
+    throwIfExpired: () => void,
+  ): Promise<ConstructResult> {
+    const res = await raceAgainstAbort(fetch(this.url, {
       method: 'POST',
       headers: {
         'Content-Type': SPARQL_QUERY_CONTENT_TYPE,
         Accept: 'text/x-nquads, application/n-quads',
       },
       body: sparql,
-      signal: options?.signal,
-    });
+      signal,
+    }), signal);
     if (!res.ok) {
-      const text = await res.text().catch(() => '');
+      const text = await raceAgainstAbort(res.text().catch(() => ''), signal);
+      throwIfExpired();
       throw new Error(`Blazegraph construct failed (${res.status}): ${text.slice(0, 300)}`);
     }
-    const text = await res.text();
+    const text = await raceAgainstAbort(res.text(), signal);
     const quads = parseNQuadsText(text);
+    throwIfExpired();
     return { type: 'quads', quads };
   }
 
@@ -319,17 +467,19 @@ export class BlazegraphStore implements TripleStore {
     // raw body is not form parsed, so large updates succeed.
     //
     // SPARQL_UPDATE_CONTENT_TYPE carries charset=utf-8 (see sparql-content-types.ts).
-    const res = await this.runStoreWork(operation, options, async () => fetch(this.url, {
+    await this.runStoreWork(operation, options, async (signal, throwIfExpired) => {
+      const res = await raceAgainstAbort(fetch(this.url, {
         method: 'POST',
         headers: { 'Content-Type': SPARQL_UPDATE_CONTENT_TYPE },
         body: update,
-        signal: options?.signal,
-      }),
-    );
-    if (!res.ok) {
-      const text = await res.text().catch(() => '');
-      throw new Error(`Blazegraph update failed (${res.status}): ${text.slice(0, 300)}`);
-    }
+        signal,
+      }), signal);
+      if (!res.ok) {
+        const text = await raceAgainstAbort(res.text().catch(() => ''), signal);
+        throwIfExpired();
+        throw new Error(`Blazegraph update failed (${res.status}): ${text.slice(0, 300)}`);
+      }
+    });
   }
 }
 
@@ -521,5 +671,6 @@ function rejectOversizedLiterals(quads: DKGQuad[], maxBytes: number): DKGQuad[] 
 registerTripleStoreAdapter('blazegraph', async (opts) => {
   const url = opts?.url as string | undefined;
   if (!url) throw new Error('blazegraph adapter requires options.url (SPARQL endpoint)');
-  return new BlazegraphStore(url);
+  const timeout = opts?.timeout as number | undefined;
+  return new BlazegraphStore(url, { timeout });
 });

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -22,9 +22,14 @@ export {
 } from './triple-store.js';
 export {
   StorePriorityScheduler,
+  StoreSchedulerBusyError,
   externalStorePriorityScheduler,
   getExternalStorePrioritySchedulerSnapshot,
+  DEFAULT_STORE_QUEUE_LIMIT,
+  DEFAULT_STORE_QUEUE_WAIT_TIMEOUT_MS,
   type StorePrioritySchedulerSnapshot,
+  type StorePriorityQueueLimits,
+  type StoreSchedulerBusyReason,
 } from './store-priority-scheduler.js';
 export {
   EXTERNAL_LITERAL_REF_DATATYPE,
@@ -61,7 +66,11 @@ export {
 
 export { OxigraphStore } from './adapters/oxigraph.js';
 export { OxigraphWorkerStore } from './adapters/oxigraph-worker.js';
-export { BlazegraphStore } from './adapters/blazegraph.js';
+export {
+  BlazegraphStore,
+  DEFAULT_BLAZEGRAPH_OPERATION_TIMEOUT_MS,
+  type BlazegraphStoreOptions,
+} from './adapters/blazegraph.js';
 export {
   SparqlHttpStore,
   type SparqlHttpStoreOptions,

--- a/packages/storage/src/store-priority-scheduler.ts
+++ b/packages/storage/src/store-priority-scheduler.ts
@@ -12,7 +12,33 @@ export interface StorePrioritySchedulerSnapshot extends StorePressureSnapshot {
   maxConcurrent: number;
   ackReservedSlots: number;
   backgroundReservedSlots: number;
+  ackQueueLimit: number;
+  normalQueueLimit: number;
+  backgroundQueueLimit: number;
+  queueWaitTimeoutMs: number;
 }
+
+export type StoreSchedulerBusyReason = 'queue_full' | 'queue_wait_timeout';
+
+/**
+ * A retry-safe overload rejection emitted only while work is still queued.
+ * Callers may retry because the operation closure has not started.
+ */
+export class StoreSchedulerBusyError extends Error {
+  readonly code = 'STORE_SCHEDULER_BUSY' as const;
+  readonly retryable = true as const;
+
+  constructor(
+    readonly reason: StoreSchedulerBusyReason,
+    readonly priority: StoreWorkPriority,
+    readonly operation: string,
+  ) {
+    super(`Store scheduler ${reason.replaceAll('_', ' ')} (${priority}: ${operation || 'unknown'})`);
+    this.name = 'StoreSchedulerBusyError';
+  }
+}
+
+export type StorePriorityQueueLimits = Record<StoreWorkPriority, number>;
 
 interface QueueEntry<T> {
   priority: StoreWorkPriority;
@@ -23,11 +49,14 @@ interface QueueEntry<T> {
   reject: (reason?: unknown) => void;
   signal?: AbortSignal;
   onAbort?: () => void;
+  waitTimer?: ReturnType<typeof setTimeout>;
 }
 
 const DEFAULT_MAX_CONCURRENT = 8;
 const DEFAULT_ACK_RESERVED_SLOTS = 1;
 const DEFAULT_BACKGROUND_RESERVED_SLOTS = 1;
+export const DEFAULT_STORE_QUEUE_LIMIT = 64;
+export const DEFAULT_STORE_QUEUE_WAIT_TIMEOUT_MS = 10_000;
 
 function parsePositiveIntegerEnv(name: string, fallback: number): number {
   const raw = process.env[name]?.trim();
@@ -41,6 +70,37 @@ function parseNonNegativeIntegerEnv(name: string, fallback: number): number {
   if (!raw) return fallback;
   const parsed = Number(raw);
   return Number.isInteger(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function resolveQueueLimitsFromEnv(): StorePriorityQueueLimits {
+  const common = parsePositiveIntegerEnv('DKG_STORE_QUEUE_LIMIT', DEFAULT_STORE_QUEUE_LIMIT);
+  return {
+    ack: parsePositiveIntegerEnv('DKG_STORE_ACK_QUEUE_LIMIT', common),
+    normal: parsePositiveIntegerEnv('DKG_STORE_NORMAL_QUEUE_LIMIT', common),
+    background: parsePositiveIntegerEnv('DKG_STORE_BACKGROUND_QUEUE_LIMIT', common),
+  };
+}
+
+function normalizeQueueLimits(
+  configured: number | Partial<StorePriorityQueueLimits>,
+): StorePriorityQueueLimits {
+  if (typeof configured === 'number') {
+    const limit = Number.isInteger(configured) && configured > 0
+      ? configured
+      : DEFAULT_STORE_QUEUE_LIMIT;
+    return { ack: limit, normal: limit, background: limit };
+  }
+  return {
+    ack: normalizeQueueLimit(configured.ack),
+    normal: normalizeQueueLimit(configured.normal),
+    background: normalizeQueueLimit(configured.background),
+  };
+}
+
+function normalizeQueueLimit(value: number | undefined): number {
+  return Number.isInteger(value) && (value as number) > 0
+    ? value as number
+    : DEFAULT_STORE_QUEUE_LIMIT;
 }
 
 function metricOperation(operation: string): string {
@@ -65,6 +125,7 @@ export class StorePriorityScheduler {
   private ackInflight = 0;
   private normalInflight = 0;
   private backgroundInflight = 0;
+  private readonly queueLimits: StorePriorityQueueLimits;
 
   constructor(
     private readonly maxConcurrent = parsePositiveIntegerEnv('DKG_STORE_MAX_CONCURRENT', DEFAULT_MAX_CONCURRENT),
@@ -77,7 +138,14 @@ export class StorePriorityScheduler {
       'DKG_STORE_BACKGROUND_RESERVED_SLOTS',
       DEFAULT_BACKGROUND_RESERVED_SLOTS,
     ),
-  ) {}
+    queueLimits: number | Partial<StorePriorityQueueLimits> = resolveQueueLimitsFromEnv(),
+    private readonly queueWaitTimeoutMs = parsePositiveIntegerEnv(
+      'DKG_STORE_QUEUE_WAIT_TIMEOUT_MS',
+      DEFAULT_STORE_QUEUE_WAIT_TIMEOUT_MS,
+    ),
+  ) {
+    this.queueLimits = normalizeQueueLimits(queueLimits);
+  }
 
   get snapshot(): StorePrioritySchedulerSnapshot {
     return {
@@ -90,6 +158,10 @@ export class StorePriorityScheduler {
       maxConcurrent: this.maxConcurrent,
       ackReservedSlots: this.effectiveAckReserve(),
       backgroundReservedSlots: this.effectiveBackgroundReserve(),
+      ackQueueLimit: this.queueLimits.ack,
+      normalQueueLimit: this.queueLimits.normal,
+      backgroundQueueLimit: this.queueLimits.background,
+      queueWaitTimeoutMs: this.queueWaitTimeoutMs,
     };
   }
 
@@ -104,6 +176,11 @@ export class StorePriorityScheduler {
       const reason = signal.reason;
       throw reason instanceof Error ? reason : new Error(String(reason ?? 'aborted'));
     }
+    if (this.queues[normalizedPriority].length >= this.queueLimits[normalizedPriority]) {
+      const error = new StoreSchedulerBusyError('queue_full', normalizedPriority, operation);
+      this.observeRejection(error);
+      throw error;
+    }
     return new Promise<T>((resolve, reject) => {
       const entry: QueueEntry<T> = {
         priority: normalizedPriority,
@@ -116,13 +193,30 @@ export class StorePriorityScheduler {
       };
       const onAbort = () => {
         if (this.removeQueued(entry as QueueEntry<unknown>)) {
+          this.cleanupQueuedEntry(entry as QueueEntry<unknown>);
           const reason = signal?.reason;
           reject(reason instanceof Error ? reason : new Error(String(reason ?? 'aborted')));
           this.observeDepths();
+          this.drain();
         }
       };
       entry.onAbort = onAbort;
       signal?.addEventListener('abort', onAbort, { once: true });
+      entry.waitTimer = setTimeout(() => {
+        entry.waitTimer = undefined;
+        if (!this.removeQueued(entry as QueueEntry<unknown>)) return;
+        this.cleanupQueuedEntry(entry as QueueEntry<unknown>);
+        const error = new StoreSchedulerBusyError(
+          'queue_wait_timeout',
+          normalizedPriority,
+          operation,
+        );
+        this.observeRejection(error);
+        reject(error);
+        this.observeDepths();
+        this.drain();
+      }, this.queueWaitTimeoutMs);
+      if (typeof entry.waitTimer.unref === 'function') entry.waitTimer.unref();
       this.queues[normalizedPriority].push(entry as QueueEntry<unknown>);
       this.observeDepths();
       this.drain();
@@ -181,9 +275,7 @@ export class StorePriorityScheduler {
   }
 
   private start(entry: QueueEntry<unknown>): void {
-    if (entry.signal && entry.onAbort) {
-      entry.signal.removeEventListener('abort', entry.onAbort);
-    }
+    this.cleanupQueuedEntry(entry);
     this.increment(entry.priority);
     const startedAt = this.now();
     const waitMs = Math.max(0, startedAt - entry.queuedAt);
@@ -221,6 +313,17 @@ export class StorePriorityScheduler {
     return true;
   }
 
+  private cleanupQueuedEntry(entry: QueueEntry<unknown>): void {
+    if (entry.signal && entry.onAbort) {
+      entry.signal.removeEventListener('abort', entry.onAbort);
+      entry.onAbort = undefined;
+    }
+    if (entry.waitTimer) {
+      clearTimeout(entry.waitTimer);
+      entry.waitTimer = undefined;
+    }
+  }
+
   private increment(priority: StoreWorkPriority): void {
     if (priority === 'ack') this.ackInflight += 1;
     else if (priority === 'normal') this.normalInflight += 1;
@@ -245,6 +348,13 @@ export class StorePriorityScheduler {
     getMetrics().storageAckStoreOpDurationMs.record(Math.max(0, this.now() - startedAt), {
       operation: metricOperation(entry.operation),
       outcome,
+    });
+  }
+
+  private observeRejection(error: StoreSchedulerBusyError): void {
+    getMetrics().storeSchedulerRejectionsTotal.add(1, {
+      priority: error.priority,
+      reason: error.reason,
     });
   }
 

--- a/packages/storage/test/blazegraph.integration.test.ts
+++ b/packages/storage/test/blazegraph.integration.test.ts
@@ -64,6 +64,21 @@ describe.skipIf(!BLAZEGRAPH_URL)('BlazegraphStore integration (live server)', ()
     if (store) await store.dropGraph(GRAPH).catch(() => {});
   });
 
+  it('runs live requests under the configured deadline and recovers after pre-dispatch cancellation', async () => {
+    const deadlineStore = new BlazegraphStore(BLAZEGRAPH_URL as string, { timeout: 5_000 });
+    const controller = new AbortController();
+    const reason = new Error('cancel live probe');
+    controller.abort(reason);
+
+    await expect(
+      deadlineStore.query('ASK { ?s ?p ?o }', { signal: controller.signal }),
+    ).rejects.toBe(reason);
+
+    const result = await deadlineStore.query('ASK { ?s ?p ?o }');
+    expect(result.type).toBe('boolean');
+    await deadlineStore.close();
+  });
+
   it(
     'large DELETE DATA (publish path) succeeds — the form-content-limit regression',
     async () => {

--- a/packages/storage/test/blazegraph.unit.test.ts
+++ b/packages/storage/test/blazegraph.unit.test.ts
@@ -2,7 +2,7 @@
  * BlazegraphStore unit tests with mocked fetch (03 §16 — graph isolation via GRAPH IRIs;
  * no live Blazegraph required).
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { BlazegraphStore } from '../src/adapters/blazegraph.js';
 import { getExternalStorePrioritySchedulerSnapshot } from '../src/store-priority-scheduler.js';
 
@@ -37,6 +37,23 @@ function blazeListGraphsResponse(): Response {
     }),
     { status: 200, headers: { 'Content-Type': 'application/json' } },
   );
+}
+
+async function outcomeWithin(work: Promise<unknown>, timeoutMs: number): Promise<unknown> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      work.then(
+        () => 'resolved',
+        (error: unknown) => error,
+      ),
+      new Promise<'still-pending'>((resolve) => {
+        timer = setTimeout(() => resolve('still-pending'), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 describe('BlazegraphStore (mocked HTTP)', () => {
@@ -213,6 +230,149 @@ describe('BlazegraphStore (mocked HTTP)', () => {
     expect(String(init?.body)).toMatch(/^CONSTRUCT /);
   });
 
+  it.each([
+    {
+      name: 'SELECT',
+      run: (store: BlazegraphStore) => store.query('SELECT ?s WHERE { ?s ?p ?o }'),
+    },
+    {
+      name: 'CONSTRUCT',
+      run: (store: BlazegraphStore) => store.query('CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }'),
+    },
+    {
+      name: 'UPDATE',
+      run: (store: BlazegraphStore) => store.update('DELETE WHERE { ?s ?p ?o }'),
+    },
+    {
+      name: 'bulk insert',
+      run: (store: BlazegraphStore) => store.insert([
+        { subject: 'http://s', predicate: 'http://p', object: '"o"', graph: 'http://g' },
+      ]),
+    },
+  ])('applies its end-to-end timeout to an in-flight $name fetch', async ({ run }) => {
+    let seenSignal: AbortSignal | undefined;
+    setFetch(async (_url, init) => {
+      seenSignal = init?.signal ?? undefined;
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => reject(init.signal?.reason), { once: true });
+      });
+    });
+    const s = new BlazegraphStore(baseUrl, { timeout: 20 });
+
+    const outcome = await outcomeWithin(run(s), 200);
+    expect(outcome).toMatchObject({ name: 'TimeoutError' });
+    expect(seenSignal?.aborted).toBe(true);
+  });
+
+  it('keeps the SELECT deadline active through response JSON decoding', async () => {
+    let rejectBody!: (reason?: unknown) => void;
+    const body = new Promise<unknown>((_resolve, reject) => {
+      rejectBody = reject;
+    });
+    setFetch(async () => ({
+      ok: true,
+      status: 200,
+      json: () => body,
+    }) as Response);
+    const s = new BlazegraphStore(baseUrl, { timeout: 20 });
+
+    try {
+      const outcome = await outcomeWithin(
+        s.query('SELECT ?s WHERE { ?s ?p ?o }'),
+        200,
+      );
+      expect(outcome).toMatchObject({ name: 'TimeoutError' });
+    } finally {
+      rejectBody(new Error('late JSON failure'));
+    }
+  });
+
+  it('keeps the UPDATE deadline active while reading an error response body', async () => {
+    let rejectBody!: (reason?: unknown) => void;
+    const body = new Promise<string>((_resolve, reject) => {
+      rejectBody = reject;
+    });
+    setFetch(async () => ({
+      ok: false,
+      status: 500,
+      text: () => body,
+    }) as Response);
+    const s = new BlazegraphStore(baseUrl, { timeout: 20 });
+
+    try {
+      const outcome = await outcomeWithin(
+        s.update('DELETE WHERE { ?s ?p ?o }'),
+        200,
+      );
+      expect(outcome).toMatchObject({ name: 'TimeoutError' });
+    } finally {
+      rejectBody(new Error('late body failure'));
+    }
+  });
+
+  it('expires queued work before fetch and never dispatches it later', async () => {
+    const before = getExternalStorePrioritySchedulerSnapshot();
+    const normalSlots = before.maxConcurrent - before.ackReservedSlots;
+    const releases: Array<(response: Response) => void> = [];
+    const blockers: Array<Promise<unknown>> = [];
+    let fetchCount = 0;
+    setFetch(async (_url, init) => {
+      fetchCount++;
+      return new Promise<Response>((resolve, reject) => {
+        releases.push(resolve);
+        init?.signal?.addEventListener('abort', () => reject(init.signal?.reason), { once: true });
+      });
+    });
+
+    try {
+      const blockingStore = new BlazegraphStore(baseUrl, { timeout: 30_000 });
+      for (let i = 0; i < normalSlots; i++) {
+        blockers.push(blockingStore.query(
+          `SELECT ?s WHERE { # queue-blocker-${i}\n?s ?p ?o }`,
+          { priority: 'normal' },
+        ));
+      }
+      await waitForCondition(
+        () => fetchCount === normalSlots,
+        `normal store lanes did not fill; fetchCount=${fetchCount}, slots=${normalSlots}`,
+      );
+
+      const deadlineStore = new BlazegraphStore(baseUrl, { timeout: 20 });
+      const queued = deadlineStore.query(
+        'SELECT ?s WHERE { # must-not-dispatch\n?s ?p ?o }',
+        { priority: 'normal' },
+      );
+      const outcome = await outcomeWithin(queued, 200);
+      expect(outcome).toMatchObject({ name: 'TimeoutError' });
+      expect(fetchCount).toBe(normalSlots);
+
+      for (const release of releases.splice(0)) release(blazeSelectResponse());
+      await Promise.allSettled([...blockers, queued]);
+      expect(fetchCount).toBe(normalSlots);
+    } finally {
+      for (const release of releases.splice(0)) release(blazeSelectResponse());
+      await Promise.allSettled(blockers);
+    }
+  });
+
+  it('detaches the caller abort listener after a completed operation', async () => {
+    setFetch(async () => blazeSelectResponse());
+    const caller = new AbortController();
+    const addListener = vi.spyOn(caller.signal, 'addEventListener');
+    const removeListener = vi.spyOn(caller.signal, 'removeEventListener');
+    const s = new BlazegraphStore(baseUrl);
+
+    await s.query('SELECT ?s WHERE { ?s ?p ?o }', { signal: caller.signal });
+    expect(addListener).toHaveBeenCalledTimes(1);
+    expect(removeListener).toHaveBeenCalledTimes(1);
+    addListener.mockRestore();
+    removeListener.mockRestore();
+  });
+
+  it('rejects invalid explicit operation timeouts', () => {
+    expect(() => new BlazegraphStore(baseUrl, { timeout: 0 })).toThrow(/positive integer/);
+  });
+
   it('routes ack-priority adapter queries ahead of queued background fetch work', async () => {
     const before = getExternalStorePrioritySchedulerSnapshot();
     expect(before.maxConcurrent).toBeGreaterThan(1);
@@ -353,7 +513,8 @@ describe('BlazegraphStore (mocked HTTP)', () => {
     // charset=utf-8 keeps Jetty from ISO-8859-1-decoding non-ASCII literals.
     expect((init?.headers as Record<string, string>)['Content-Type']).toBe('application/sparql-update; charset=utf-8');
     expect(String(init?.body)).toBe(sparql);
-    expect(init?.signal).toBe(controller.signal);
+    expect(init?.signal).toBeInstanceOf(AbortSignal);
+    expect(init?.signal).not.toBe(controller.signal);
     expect(fetchCalls.some((c) => /\bCOUNT\b/i.test(String(c[1]?.body ?? '')))).toBe(false);
     expect(fetchCalls.some((c) => String(c[1]?.body ?? '').startsWith('SELECT'))).toBe(false);
   });

--- a/packages/storage/test/blazegraph.unit.test.ts
+++ b/packages/storage/test/blazegraph.unit.test.ts
@@ -3,6 +3,7 @@
  * no live Blazegraph required).
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { performance } from 'node:perf_hooks';
 import { BlazegraphStore } from '../src/adapters/blazegraph.js';
 import { getExternalStorePrioritySchedulerSnapshot } from '../src/store-priority-scheduler.js';
 
@@ -53,6 +54,14 @@ async function outcomeWithin(work: Promise<unknown>, timeoutMs: number): Promise
     ]);
   } finally {
     if (timer) clearTimeout(timer);
+  }
+}
+
+function blockEventLoopFor(durationMs: number): void {
+  const end = performance.now() + durationMs;
+  while (performance.now() < end) {
+    // Deliberately keep timers from firing so the post-await clock check owns
+    // timeout classification when the awaited work rejects.
   }
 }
 
@@ -262,6 +271,57 @@ describe('BlazegraphStore (mocked HTTP)', () => {
     const outcome = await outcomeWithin(run(s), 200);
     expect(outcome).toMatchObject({ name: 'TimeoutError' });
     expect(seenSignal?.aborted).toBe(true);
+  });
+
+  it('reports TimeoutError when fetch rejects after the deadline clock but before its timer runs', async () => {
+    const lateTransportFailure = new Error('late transport failure');
+    setFetch(async () => {
+      blockEventLoopFor(25);
+      throw lateTransportFailure;
+    });
+    const s = new BlazegraphStore(baseUrl, { timeout: 5 });
+
+    const outcome = await outcomeWithin(
+      s.query('SELECT ?s WHERE { ?s ?p ?o }'),
+      200,
+    );
+    expect(outcome).toMatchObject({ name: 'TimeoutError' });
+    expect(outcome).not.toBe(lateTransportFailure);
+  });
+
+  it('reports TimeoutError when JSON decoding rejects after the deadline clock but before its timer runs', async () => {
+    const lateDecodeFailure = new Error('late JSON failure');
+    setFetch(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => {
+        blockEventLoopFor(25);
+        throw lateDecodeFailure;
+      },
+    }) as Response);
+    const s = new BlazegraphStore(baseUrl, { timeout: 5 });
+
+    const outcome = await outcomeWithin(
+      s.query('SELECT ?s WHERE { ?s ?p ?o }'),
+      200,
+    );
+    expect(outcome).toMatchObject({ name: 'TimeoutError' });
+    expect(outcome).not.toBe(lateDecodeFailure);
+  });
+
+  it('preserves the exact caller abort reason while fetch is in flight', async () => {
+    setFetch(async (_url, init) => new Promise<Response>((_resolve, reject) => {
+      init?.signal?.addEventListener('abort', () => reject(init.signal?.reason), { once: true });
+    }));
+    const controller = new AbortController();
+    const reason = new Error('caller cancelled query');
+    const s = new BlazegraphStore(baseUrl);
+    const query = s.query('SELECT ?s WHERE { ?s ?p ?o }', { signal: controller.signal });
+    await waitForCondition(() => fetchCalls.length === 1, 'query fetch did not start');
+
+    controller.abort(reason);
+
+    await expect(query).rejects.toBe(reason);
   });
 
   it('keeps the SELECT deadline active through response JSON decoding', async () => {
@@ -522,14 +582,15 @@ describe('BlazegraphStore (mocked HTTP)', () => {
   it('update honors pre-aborted options before dispatch', async () => {
     const s = new BlazegraphStore(baseUrl);
     const controller = new AbortController();
-    controller.abort(new Error('cancel update'));
+    const reason = new Error('cancel update');
+    controller.abort(reason);
 
     await expect(
       s.update('DELETE WHERE { GRAPH <http://ex.org/g> { ?s ?p ?o } }', {
         priority: 'ack',
         signal: controller.signal,
       }),
-    ).rejects.toThrow('cancel update');
+    ).rejects.toBe(reason);
     expect(fetchCalls).toHaveLength(0);
   });
 

--- a/packages/storage/test/storage.test.ts
+++ b/packages/storage/test/storage.test.ts
@@ -303,6 +303,13 @@ describe('createTripleStore factory', () => {
     );
   });
 
+  it('passes the Blazegraph operation timeout through store.options', async () => {
+    await expect(createTripleStore({
+      backend: 'blazegraph',
+      options: { url: 'http://blaze.test/sparql', timeout: 0 },
+    })).rejects.toThrow(/timeout must be a positive integer/);
+  });
+
   it('sparql-http adapter is registered and requires queryEndpoint', async () => {
     await expect(createTripleStore({ backend: 'sparql-http' })).rejects.toThrow(
       'queryEndpoint',

--- a/packages/storage/test/store-priority-scheduler.test.ts
+++ b/packages/storage/test/store-priority-scheduler.test.ts
@@ -1,9 +1,155 @@
-import { describe, expect, it } from 'vitest';
-import { StorePriorityScheduler } from '../src/store-priority-scheduler.js';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  StorePriorityScheduler,
+  StoreSchedulerBusyError,
+} from '../src/store-priority-scheduler.js';
+import type { StoreWorkPriority } from '../src/triple-store.js';
 
 const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
 
 describe('StorePriorityScheduler', () => {
+  for (const priority of ['ack', 'normal', 'background'] as const satisfies readonly StoreWorkPriority[]) {
+    it(`bounds the ${priority} queue and returns a typed retryable rejection`, async () => {
+      const scheduler = new StorePriorityScheduler(1, 0, undefined, 0, {
+        ack: 1,
+        normal: 1,
+        background: 1,
+      }, 1_000);
+      let release!: () => void;
+      let queuedStarted = false;
+      let rejectedStarted = false;
+      const blocker = scheduler.run(priority, `${priority}.blocker`, async () => {
+        await new Promise<void>((resolve) => {
+          release = resolve;
+        });
+      });
+      const queued = scheduler.run(priority, `${priority}.queued`, async () => {
+        queuedStarted = true;
+      });
+
+      await expect(scheduler.run(priority, `${priority}.rejected`, async () => {
+        rejectedStarted = true;
+      })).rejects.toMatchObject({
+        name: 'StoreSchedulerBusyError',
+        code: 'STORE_SCHEDULER_BUSY',
+        retryable: true,
+        reason: 'queue_full',
+        priority,
+      });
+      expect(rejectedStarted).toBe(false);
+      expect(scheduler.snapshot[`${priority}Queued`]).toBe(1);
+
+      release();
+      await expect(Promise.all([blocker, queued])).resolves.toEqual([undefined, undefined]);
+      expect(queuedStarted).toBe(true);
+    });
+
+    it(`expires ${priority} work before dispatch and recovers after pressure clears`, async () => {
+      const scheduler = new StorePriorityScheduler(1, 0, undefined, 0, 2, 20);
+      let release!: () => void;
+      let expiredStarted = false;
+      const blocker = scheduler.run(priority, `${priority}.blocker`, async () => {
+        await new Promise<void>((resolve) => {
+          release = resolve;
+        });
+      });
+      const expired = scheduler.run(priority, `${priority}.expired`, async () => {
+        expiredStarted = true;
+      });
+
+      await expect(expired).rejects.toMatchObject({
+        code: 'STORE_SCHEDULER_BUSY',
+        retryable: true,
+        reason: 'queue_wait_timeout',
+        priority,
+      });
+      expect(expiredStarted).toBe(false);
+      expect(scheduler.snapshot[`${priority}Queued`]).toBe(0);
+
+      release();
+      await blocker;
+      await expect(scheduler.run(priority, `${priority}.recovered`, async () => 'ok')).resolves.toBe('ok');
+    });
+  }
+
+  it('removes a cancelled queued entry and releases its abort listener and wait timer', async () => {
+    vi.useFakeTimers();
+    try {
+      const scheduler = new StorePriorityScheduler(1, 0, undefined, 0, 1, 100);
+      let release!: () => void;
+      const blocker = scheduler.run('normal', 'normal.blocker', async () => {
+        await new Promise<void>((resolve) => {
+          release = resolve;
+        });
+      });
+      const controller = new AbortController();
+      const addListener = vi.spyOn(controller.signal, 'addEventListener');
+      const removeListener = vi.spyOn(controller.signal, 'removeEventListener');
+      let cancelledStarted = false;
+      const cancelled = scheduler.run('normal', 'normal.cancelled', async () => {
+        cancelledStarted = true;
+      }, controller.signal);
+      const reason = new Error('caller cancelled');
+
+      controller.abort(reason);
+      await expect(cancelled).rejects.toBe(reason);
+      expect(cancelledStarted).toBe(false);
+      expect(scheduler.snapshot.normalQueued).toBe(0);
+      expect(addListener).toHaveBeenCalledTimes(1);
+      expect(removeListener).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(200);
+      expect(scheduler.snapshot.normalQueued).toBe(0);
+      release();
+      await blocker;
+      addListener.mockRestore();
+      removeListener.mockRestore();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('cleans up admission state when queued work starts normally', async () => {
+    vi.useFakeTimers();
+    try {
+      const scheduler = new StorePriorityScheduler(1, 0, undefined, 0, 1, 100);
+      let release!: () => void;
+      const blocker = scheduler.run('normal', 'normal.blocker', async () => {
+        await new Promise<void>((resolve) => {
+          release = resolve;
+        });
+      });
+      const controller = new AbortController();
+      const addListener = vi.spyOn(controller.signal, 'addEventListener');
+      const removeListener = vi.spyOn(controller.signal, 'removeEventListener');
+      const queued = scheduler.run('normal', 'normal.queued', async () => 'ok', controller.signal);
+
+      release();
+      await blocker;
+      await expect(queued).resolves.toBe('ok');
+      expect(addListener).toHaveBeenCalledTimes(1);
+      expect(removeListener).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(200);
+      expect(scheduler.snapshot).toMatchObject({ normalInflight: 0, normalQueued: 0 });
+      addListener.mockRestore();
+      removeListener.mockRestore();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('exports a distinguishable busy error type for boundary mapping', () => {
+    const error = new StoreSchedulerBusyError('queue_full', 'ack', 'storage-ack.read');
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(StoreSchedulerBusyError);
+    expect(error).toMatchObject({
+      code: 'STORE_SCHEDULER_BUSY',
+      retryable: true,
+      reason: 'queue_full',
+    });
+  });
+
   it('lets ACK work jump ahead of queued background work', async () => {
     const scheduler = new StorePriorityScheduler(2, 1);
     const events: string[] = [];


### PR DESCRIPTION
## Summary

- cap each external-store priority queue independently and reject overflow before dispatch
- expire queued work after a finite pre-dispatch wait with typed, retry-safe `StoreSchedulerBusyError`
- clean up queue entries, timers, and abort listeners on admission, cancellation, and expiry
- add one Blazegraph scheduled-operation deadline covering queue wait, insert serialization, HTTP, response decoding, parsing, and result mapping
- preserve deadline precedence even when the event loop delays the timer, while retaining exact caller abort reasons
- expose bounded rejection telemetry and document queue/deadline configuration

## Why

Concurrency limits alone still allow an unbounded backlog to retain requests and payloads while the external store is overloaded. Individual fetch aborts also do not bound scheduler wait, response decoding, or client-side parsing. The resulting pressure can outlive the caller's useful deadline and amplify a slow store into process-wide overload.

Only pre-dispatch busy errors are marked retryable, so a caller cannot mistake an indeterminate in-flight write for a safe retry.

## Defaults

- 64 waiting operations per priority
- 10 second pre-dispatch wait
- 30 second Blazegraph scheduled-operation deadline

All are configurable through the documented `DKG_STORE_*` and `DKG_BLAZEGRAPH_OPERATION_TIMEOUT_MS` environment variables; Blazegraph `store.options.timeout` takes precedence over its environment default.

Compound helpers such as `deleteByPattern` contain multiple scheduled operations, each with its own deadline; this PR does not add a second whole-method deadline around the compound helper.

## Relationship to #1644

This complements #1644 and deliberately does not modify `sparql-http.ts`. A merge simulation with that PR was conflict-free; the combined storage build and suite passed. The two adapter-local deadline implementations now have aligned timeout-precedence and caller-abort semantics.

Mapping `STORE_SCHEDULER_BUSY` to HTTP 503/Retry-After and structured P2P busy responses remains a protocol-boundary follow-up (#1643).

## Validation

- storage dependency-chain build
- full storage suite after review fix: 366 passed, 26 integration-gated skips
- focused scheduler and Blazegraph tests: 57 passed
- combined with #1644 before the review fix: 371 passed, 26 skipped; merge remains conflict-free
- mocked SELECT, CONSTRUCT, UPDATE, insert, response-decode, event-loop-delayed rejection, queue expiry, cancellation, cleanup, recovery, and no-late-dispatch coverage
- gated live-Blazegraph timeout coverage
