### PR TITLE
fix(storage): back off graph index revalidation

### DIFF
--- a/packages/storage/src/changelog-store.ts
+++ b/packages/storage/src/changelog-store.ts
@@ -131,7 +131,12 @@ export interface ChangelogHead {
  * factory return type.
  */
 export interface ChangelogReader {
-  /** Durable head cursor `(era, seq)` — era mismatch or `seq` rollback ⇒ full resync. */
+  /**
+   * Live head cursor `(era, seq)` — era mismatch or `seq` rollback ⇒ full resync.
+   * `signal` is honored at the method boundary. `source` and `priority` are not
+   * forwarded because steady-state reads are served from memory; use
+   * {@link headSeq} for an explicitly durable storage read with query metadata.
+   */
   changelogHead(options?: QueryOptions): Promise<ChangelogHead>;
   /** Change records with `seq > sinceSeq`, ascending, at most `limit`. */
   readChanges(sinceSeq: number, limit: number, options?: QueryOptions): Promise<ChangeRecord[]>;
@@ -392,14 +397,21 @@ export class ChangelogStore implements TripleStore, ChangelogReader {
   // ------------------------------------------------------------------
 
   /**
-   * Durable head cursor `(era, seq)` the sync responder returns so a requester
+   * Live head cursor `(era, seq)` the sync responder returns so a requester
    * can advance its cursor and detect a wipe/reseed (era change) or a rollback
-   * (`seq` < the requester's cursor). Establishes the era on first call.
+   * (`seq` < the requester's cursor). Establishes the durable starting state on
+   * first call, then serves the serialized writer's authoritative head from memory.
+   *
+   * QueryOptions boundary: cancellation is checked before and after the shared
+   * one-time seed. `source` and `priority` are intentionally not forwarded: the
+   * seed uses internal source tags and steady-state calls perform no storage read.
+   * Call {@link headSeq} when a caller needs a durable read carrying those options.
    */
   async changelogHead(options?: QueryOptions): Promise<ChangelogHead> {
-    throwIfAborted(options?.signal);
+    const signal = options?.signal;
+    throwIfAborted(signal);
     await this.ensureSeeded();
-    throwIfAborted(options?.signal);
+    throwIfAborted(signal);
     // All changelog writes pass through the serialized single-writer path and
     // advance `seq` only after their marker transaction commits. Once seeded,
     // this is therefore the authoritative live head; repeating MAX(?seq) for

--- a/packages/storage/src/changelog-store.ts
+++ b/packages/storage/src/changelog-store.ts
@@ -397,7 +397,9 @@ export class ChangelogStore implements TripleStore, ChangelogReader {
    * (`seq` < the requester's cursor). Establishes the era on first call.
    */
   async changelogHead(options?: QueryOptions): Promise<ChangelogHead> {
+    throwIfAborted(options?.signal);
     await this.ensureSeeded();
+    throwIfAborted(options?.signal);
     // All changelog writes pass through the serialized single-writer path and
     // advance `seq` only after their marker transaction commits. Once seeded,
     // this is therefore the authoritative live head; repeating MAX(?seq) for
@@ -784,6 +786,11 @@ function queryOptionsFromUpdateOptions(options?: UpdateOptions): QueryOptions | 
   if (!options) return undefined;
   const { touchedGraphs: _touchedGraphs, ...readOptions } = options;
   return readOptions;
+}
+
+/** Preserve the caller's exact abort reason while keeping query-free reads cancellable. */
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) throw signal.reason;
 }
 
 /**

--- a/packages/storage/src/changelog-store.ts
+++ b/packages/storage/src/changelog-store.ts
@@ -196,7 +196,7 @@ export class ChangelogStore implements TripleStore, ChangelogReader {
   private readonly onAppend?: (record: ChangeRecord) => void;
   private readonly eraGuard?: ChangelogEraGuard;
 
-  /** Last ALLOCATED seq (0 = none). Next seq is `seq + 1`. */
+  /** Last durably committed seq (0 = none). Next seq is `seq + 1`. */
   private seq = 0;
   /** Log generation id, established (read or minted) on seed. Null until then. */
   private eraValue: string | null = null;
@@ -398,11 +398,15 @@ export class ChangelogStore implements TripleStore, ChangelogReader {
    */
   async changelogHead(options?: QueryOptions): Promise<ChangelogHead> {
     await this.ensureSeeded();
-    const seq = await this.headSeq(options);
-    return { era: this.eraValue as string, seq };
+    // All changelog writes pass through the serialized single-writer path and
+    // advance `seq` only after their marker transaction commits. Once seeded,
+    // this is therefore the authoritative live head; repeating MAX(?seq) for
+    // every sync request only adds an expensive store read under contention.
+    // Keep headSeq() below as the explicit durable diagnostic/restart primitive.
+    return { era: this.eraValue as string, seq: this.seq };
   }
 
-  /** Highest seq durably present in the log (0 if empty). */
+  /** Highest seq durably present in the log (0 if empty); always queries storage. */
   async headSeq(options?: QueryOptions): Promise<number> {
     const res = await this.inner.query(
       `SELECT (MAX(?seq) AS ?m) WHERE { GRAPH <${CHANGELOG_GRAPH}> { ?e <${P_SEQ}> ?seq } }`,

--- a/packages/storage/src/graph-set-index-store.ts
+++ b/packages/storage/src/graph-set-index-store.ts
@@ -43,9 +43,15 @@ export interface GraphSetIndexStoreOptions {
   enabled?: boolean;
   /** Revalidate after this interval. Use 0 to revalidate on every read. */
   revalidateMs?: number;
-  /** Initial retry delay after a failed warm periodic revalidation. */
+  /**
+   * Initial retry delay after a failed warm periodic revalidation.
+   * Ignored when revalidateMs is 0.
+   */
   revalidateFailureBackoffMs?: number;
-  /** Maximum exponential retry delay after failed warm periodic revalidations. */
+  /**
+   * Maximum exponential retry delay after failed warm periodic revalidations.
+   * Ignored when revalidateMs is 0.
+   */
   revalidateFailureMaxBackoffMs?: number;
   now?: () => number;
   onMutation?: (event: GraphSetMutationEvent) => void;
@@ -75,9 +81,8 @@ export class GraphSetIndexStore implements TripleStore {
   private readonly onMutation?: (event: GraphSetMutationEvent) => void;
 
   private graphs: Set<string> | null = null;
-  private validatedAt = 0;
+  private nextRevalidateAt = 0;
   private revalidateFailureCount = 0;
-  private revalidateRetryAt = 0;
   private mutationGeneration = 0;
   private refreshInFlight: Promise<Set<string>> | null = null;
   /**
@@ -275,14 +280,13 @@ export class GraphSetIndexStore implements TripleStore {
 
   private async ensureGraphSet(options?: QueryOptions): Promise<Set<string>> {
     throwIfAborted(options?.signal);
-    if (this.graphs && !this.pendingFullRefresh) {
-      const now = this.now();
-      if (
-        (this.revalidateMs > 0 && now - this.validatedAt < this.revalidateMs) ||
-        now < this.revalidateRetryAt
-      ) {
-        return this.graphs;
-      }
+    if (
+      this.graphs &&
+      !this.pendingFullRefresh &&
+      this.revalidateMs > 0 &&
+      this.now() < this.nextRevalidateAt
+    ) {
+      return this.graphs;
     }
     return raceAgainstAbort(
       this.refreshIndex(this.pendingFullRefresh ?? (this.graphs ? 'revalidate' : 'seed'), options),
@@ -376,8 +380,7 @@ export class GraphSetIndexStore implements TripleStore {
 
   private clearIndex(): void {
     this.graphs = null;
-    this.validatedAt = 0;
-    this.resetRevalidationFailures();
+    this.resetRevalidationSchedule();
   }
 
   private replaceGraphSet(next: Set<string>, source: GraphSetRefreshSource): void {
@@ -385,14 +388,20 @@ export class GraphSetIndexStore implements TripleStore {
     const added = [...next].filter((graph) => !previous.has(graph)).sort();
     const removed = [...previous].filter((graph) => !next.has(graph)).sort();
     this.graphs = next;
-    this.validatedAt = this.now();
-    this.resetRevalidationFailures();
+    this.revalidateFailureCount = 0;
+    this.nextRevalidateAt = this.now() + this.revalidateMs;
     if (added.length > 0 || removed.length > 0 || source !== 'seed') {
       this.emit({ type: 'graph-set-revalidated', added, removed, source });
     }
   }
 
   private noteRevalidationFailure(): void {
+    // revalidateMs=0 is the strict-freshness opt-out from both cached reads and
+    // failure backoff: every read must attempt another scan, even after failure.
+    if (this.revalidateMs === 0) {
+      this.resetRevalidationSchedule();
+      return;
+    }
     // Cap the exponent before multiplication as an additional overflow guard;
     // the configured maximum is the externally visible bound.
     const exponent = Math.min(this.revalidateFailureCount, 30);
@@ -401,12 +410,12 @@ export class GraphSetIndexStore implements TripleStore {
       this.revalidateFailureBackoffMs * (2 ** exponent),
     );
     this.revalidateFailureCount++;
-    this.revalidateRetryAt = this.now() + delay;
+    this.nextRevalidateAt = this.now() + delay;
   }
 
-  private resetRevalidationFailures(): void {
+  private resetRevalidationSchedule(): void {
     this.revalidateFailureCount = 0;
-    this.revalidateRetryAt = 0;
+    this.nextRevalidateAt = 0;
   }
 
   private addGraphs(graphs: string[], source: GraphSetMutationSource): void {

--- a/packages/storage/src/graph-set-index-store.ts
+++ b/packages/storage/src/graph-set-index-store.ts
@@ -3,6 +3,8 @@ import { isSparqlUpdateOperation } from '@origintrail-official/dkg-core';
 import type { Quad, QueryOptions, QueryResult, StorePressureSnapshot, TripleStore, UpdateOptions } from './triple-store.js';
 
 export const DEFAULT_GRAPH_SET_REVALIDATE_MS = 30_000;
+export const DEFAULT_GRAPH_SET_REVALIDATE_FAILURE_MAX_BACKOFF_MS = 5 * 60_000;
+const MIN_GRAPH_SET_REVALIDATE_FAILURE_BACKOFF_MS = 1_000;
 
 export type GraphSetMutationSource =
   | 'seed'
@@ -41,6 +43,10 @@ export interface GraphSetIndexStoreOptions {
   enabled?: boolean;
   /** Revalidate after this interval. Use 0 to revalidate on every read. */
   revalidateMs?: number;
+  /** Initial retry delay after a failed warm periodic revalidation. */
+  revalidateFailureBackoffMs?: number;
+  /** Maximum exponential retry delay after failed warm periodic revalidations. */
+  revalidateFailureMaxBackoffMs?: number;
   now?: () => number;
   onMutation?: (event: GraphSetMutationEvent) => void;
 }
@@ -63,11 +69,15 @@ export class GraphSetIndexStore implements TripleStore {
   private readonly inner: TripleStore;
   private readonly enabled: boolean;
   private readonly revalidateMs: number;
+  private readonly revalidateFailureBackoffMs: number;
+  private readonly revalidateFailureMaxBackoffMs: number;
   private readonly now: () => number;
   private readonly onMutation?: (event: GraphSetMutationEvent) => void;
 
   private graphs: Set<string> | null = null;
   private validatedAt = 0;
+  private revalidateFailureCount = 0;
+  private revalidateRetryAt = 0;
   private mutationGeneration = 0;
   private refreshInFlight: Promise<Set<string>> | null = null;
   /**
@@ -81,6 +91,17 @@ export class GraphSetIndexStore implements TripleStore {
     this.inner = inner;
     this.enabled = options.enabled !== false;
     this.revalidateMs = Math.max(0, options.revalidateMs ?? DEFAULT_GRAPH_SET_REVALIDATE_MS);
+    this.revalidateFailureBackoffMs = positiveFiniteMs(
+      options.revalidateFailureBackoffMs,
+      Math.max(MIN_GRAPH_SET_REVALIDATE_FAILURE_BACKOFF_MS, this.revalidateMs),
+    );
+    this.revalidateFailureMaxBackoffMs = Math.max(
+      this.revalidateFailureBackoffMs,
+      positiveFiniteMs(
+        options.revalidateFailureMaxBackoffMs,
+        DEFAULT_GRAPH_SET_REVALIDATE_FAILURE_MAX_BACKOFF_MS,
+      ),
+    );
     this.now = options.now ?? (() => performance.now());
     this.onMutation = options.onMutation;
   }
@@ -254,13 +275,14 @@ export class GraphSetIndexStore implements TripleStore {
 
   private async ensureGraphSet(options?: QueryOptions): Promise<Set<string>> {
     throwIfAborted(options?.signal);
-    if (
-      this.graphs &&
-      !this.pendingFullRefresh &&
-      this.revalidateMs > 0 &&
-      this.now() - this.validatedAt < this.revalidateMs
-    ) {
-      return this.graphs;
+    if (this.graphs && !this.pendingFullRefresh) {
+      const now = this.now();
+      if (
+        (this.revalidateMs > 0 && now - this.validatedAt < this.revalidateMs) ||
+        now < this.revalidateRetryAt
+      ) {
+        return this.graphs;
+      }
     }
     return raceAgainstAbort(
       this.refreshIndex(this.pendingFullRefresh ?? (this.graphs ? 'revalidate' : 'seed'), options),
@@ -270,7 +292,22 @@ export class GraphSetIndexStore implements TripleStore {
 
   private async refreshIndex(source: GraphSetRefreshSource, options?: QueryOptions): Promise<Set<string>> {
     if (this.refreshInFlight) return this.refreshInFlight;
-    const task = this.refreshIndexLoop(source, options);
+    let task = this.refreshIndexLoop(source, options);
+    if (source === 'revalidate') {
+      task = task.catch((error: unknown) => {
+        // Periodic discovery of out-of-contract writers is advisory once the
+        // write-through index is warm. Preserve that last known set and back
+        // off after a store failure instead of making every graph reader repeat
+        // the same expensive scan. Cold seeds and mutation-dirty rebuilds are
+        // correctness paths: if either condition applies by the time the scan
+        // fails, keep the original strict rejection behavior.
+        if (options?.signal?.aborted || !this.graphs || this.pendingFullRefresh) {
+          throw error;
+        }
+        this.noteRevalidationFailure();
+        return this.graphs;
+      });
+    }
     this.refreshInFlight = task;
     try {
       return await task;
@@ -340,6 +377,7 @@ export class GraphSetIndexStore implements TripleStore {
   private clearIndex(): void {
     this.graphs = null;
     this.validatedAt = 0;
+    this.resetRevalidationFailures();
   }
 
   private replaceGraphSet(next: Set<string>, source: GraphSetRefreshSource): void {
@@ -348,9 +386,27 @@ export class GraphSetIndexStore implements TripleStore {
     const removed = [...previous].filter((graph) => !next.has(graph)).sort();
     this.graphs = next;
     this.validatedAt = this.now();
+    this.resetRevalidationFailures();
     if (added.length > 0 || removed.length > 0 || source !== 'seed') {
       this.emit({ type: 'graph-set-revalidated', added, removed, source });
     }
+  }
+
+  private noteRevalidationFailure(): void {
+    // Cap the exponent before multiplication as an additional overflow guard;
+    // the configured maximum is the externally visible bound.
+    const exponent = Math.min(this.revalidateFailureCount, 30);
+    const delay = Math.min(
+      this.revalidateFailureMaxBackoffMs,
+      this.revalidateFailureBackoffMs * (2 ** exponent),
+    );
+    this.revalidateFailureCount++;
+    this.revalidateRetryAt = this.now() + delay;
+  }
+
+  private resetRevalidationFailures(): void {
+    this.revalidateFailureCount = 0;
+    this.revalidateRetryAt = 0;
   }
 
   private addGraphs(graphs: string[], source: GraphSetMutationSource): void {
@@ -423,6 +479,10 @@ function normalizeGraphUris(graphs: readonly string[]): string[] {
 function queryOptionsFromUpdateOptions(options: UpdateOptions): QueryOptions {
   const { touchedGraphs: _touchedGraphs, ...readOptions } = options;
   return readOptions;
+}
+
+function positiveFiniteMs(value: number | undefined, fallback: number): number {
+  return Number.isFinite(value) && (value as number) > 0 ? value as number : fallback;
 }
 
 function throwIfAborted(signal: AbortSignal | undefined): void {

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -35,6 +35,7 @@ export {
 } from './shared-memory-literal-blob-store.js';
 export {
   DEFAULT_GRAPH_SET_REVALIDATE_MS,
+  DEFAULT_GRAPH_SET_REVALIDATE_FAILURE_MAX_BACKOFF_MS,
   GraphSetIndexStore,
   type GraphSetIndexStoreOptions,
   type GraphSetMutationEvent,

--- a/packages/storage/test/changelog-store.test.ts
+++ b/packages/storage/test/changelog-store.test.ts
@@ -35,6 +35,7 @@ function q(subject: string, graph: string, object = '"x"'): Quad {
 /** Delegating TripleStore that records insert() call shapes and can inject failures. */
 class SpyStore implements TripleStore {
   readonly insertCalls: Quad[][] = [];
+  readonly queryCalls: string[] = [];
   failNextInsert = false;
   constructor(private readonly inner: TripleStore) {}
   async insert(quads: Quad[], options?: QueryOptions): Promise<void> {
@@ -48,7 +49,10 @@ class SpyStore implements TripleStore {
   delete(quads: Quad[], options?: QueryOptions) { return this.inner.delete(quads, options); }
   deleteByPattern(pattern: Partial<Quad>, options?: QueryOptions) { return this.inner.deleteByPattern(pattern, options); }
   deleteBySubjectPrefix(g: string, p: string, options?: QueryOptions) { return this.inner.deleteBySubjectPrefix(g, p, options); }
-  query(sparql: string, options?: QueryOptions): Promise<QueryResult> { return this.inner.query(sparql, options); }
+  query(sparql: string, options?: QueryOptions): Promise<QueryResult> {
+    this.queryCalls.push(sparql);
+    return this.inner.query(sparql, options);
+  }
   hasGraph(g: string, options?: QueryOptions) { return this.inner.hasGraph(g, options); }
   createGraph(g: string) { return this.inner.createGraph(g); }
   dropGraph(g: string, options?: QueryOptions) { return this.inner.dropGraph(g, options); }
@@ -583,6 +587,26 @@ describe('ChangelogStore — era foundation & reader capability', () => {
     const h2 = await log.changelogHead();
     expect(h2.era).toBe(h1.era); // era is immutable while the log lives
     expect(h2.seq).toBe(2);
+    await base.close();
+  });
+
+  it('serves the seeded live head from memory while headSeq remains a durable diagnostic', async () => {
+    const base = new OxigraphStore();
+    const spy = new SpyStore(base);
+    const log = new ChangelogStore(spy);
+
+    expect((await log.changelogHead()).seq).toBe(0);
+    const durableHeadQueries = () => spy.queryCalls.filter((query) => query.includes('MAX(?seq)')).length;
+    expect(durableHeadQueries()).toBe(1); // one-time restart seed
+
+    await log.insert([q('http://ex.org/a', G1)]);
+    await log.insert([q('http://ex.org/b', G2)]);
+    expect((await log.changelogHead()).seq).toBe(2);
+    expect((await log.changelogHead()).seq).toBe(2);
+    expect(durableHeadQueries()).toBe(1); // no per-request SPARQL aggregation
+
+    expect(await log.headSeq()).toBe(2);
+    expect(durableHeadQueries()).toBe(2); // explicit diagnostic still reads storage
     await base.close();
   });
 

--- a/packages/storage/test/changelog-store.test.ts
+++ b/packages/storage/test/changelog-store.test.ts
@@ -602,7 +602,7 @@ describe('ChangelogStore — era foundation & reader capability', () => {
     await log.insert([q('http://ex.org/a', G1)]);
     await log.insert([q('http://ex.org/b', G2)]);
     expect((await log.changelogHead()).seq).toBe(2);
-    expect((await log.changelogHead()).seq).toBe(2);
+    expect((await log.changelogHead({ source: 'sync.head', priority: 'ack' })).seq).toBe(2);
     expect(durableHeadQueries()).toBe(1); // no per-request SPARQL aggregation
 
     expect(await log.headSeq()).toBe(2);

--- a/packages/storage/test/changelog-store.test.ts
+++ b/packages/storage/test/changelog-store.test.ts
@@ -610,6 +610,24 @@ describe('ChangelogStore — era foundation & reader capability', () => {
     await base.close();
   });
 
+  it('preserves cancellation on the query-free seeded head path', async () => {
+    const base = new OxigraphStore();
+    const spy = new SpyStore(base);
+    const log = new ChangelogStore(spy);
+
+    await log.changelogHead();
+    const durableHeadQueries = () => spy.queryCalls.filter((query) => query.includes('MAX(?seq)')).length;
+    expect(durableHeadQueries()).toBe(1);
+
+    const controller = new AbortController();
+    const reason = new Error('changelog head cancelled');
+    controller.abort(reason);
+
+    await expect(log.changelogHead({ signal: controller.signal })).rejects.toBe(reason);
+    expect(durableHeadQueries()).toBe(1); // cancellation must not restore the per-request aggregate
+    await base.close();
+  });
+
   it('reads the existing era rather than re-minting (a fresh store over the same log)', async () => {
     const base = new OxigraphStore();
     const minted = (await new ChangelogStore(base).changelogHead()).era;

--- a/packages/storage/test/graph-set-index-store.test.ts
+++ b/packages/storage/test/graph-set-index-store.test.ts
@@ -212,6 +212,78 @@ describe('GraphSetIndexStore', () => {
     expect(counting.listGraphsCalls).toBe(2);
   });
 
+  it('serves a warm index and exponentially backs off failed periodic revalidations', async () => {
+    let now = 1_000;
+    const cached = 'did:dkg:context-graph:cached';
+    const external = 'did:dkg:context-graph:external-after-failure';
+    const inner = new OxigraphStore();
+    await inner.insert([q(cached)]);
+    const counting = new CountingStore(inner);
+    const store = new GraphSetIndexStore(counting, {
+      revalidateMs: 100,
+      revalidateFailureBackoffMs: 10,
+      revalidateFailureMaxBackoffMs: 40,
+      now: () => now,
+    });
+
+    await expect(store.listGraphs()).resolves.toEqual([cached]);
+    await inner.insert([q(external)]);
+    counting.failListGraphs = true;
+
+    // The first expired periodic refresh fails, but the warm write-through set
+    // remains serviceable. Repeated readers do not immediately re-run the scan.
+    now += 100;
+    await expect(store.listGraphs()).resolves.toEqual([cached]);
+    expect(counting.listGraphsCalls).toBe(2);
+    await expect(store.listGraphs()).resolves.toEqual([cached]);
+    now += 9;
+    await expect(store.listGraphs()).resolves.toEqual([cached]);
+    expect(counting.listGraphsCalls).toBe(2);
+
+    // Failure delays grow 10 -> 20 -> 40 ms and are bounded at 40 ms.
+    now += 1;
+    await expect(store.listGraphs()).resolves.toEqual([cached]);
+    expect(counting.listGraphsCalls).toBe(3);
+    now += 19;
+    await expect(store.listGraphs()).resolves.toEqual([cached]);
+    expect(counting.listGraphsCalls).toBe(3);
+    now += 1;
+    await expect(store.listGraphs()).resolves.toEqual([cached]);
+    expect(counting.listGraphsCalls).toBe(4);
+    now += 39;
+    await expect(store.listGraphs()).resolves.toEqual([cached]);
+    expect(counting.listGraphsCalls).toBe(4);
+
+    counting.failListGraphs = false;
+    now += 1;
+    await expect(store.listGraphs()).resolves.toEqual(expect.arrayContaining([cached, external]));
+    expect(counting.listGraphsCalls).toBe(5);
+
+    // A successful refresh resets the exponential sequence to its initial delay.
+    counting.failListGraphs = true;
+    now += 100;
+    await expect(store.listGraphs()).resolves.toEqual(expect.arrayContaining([cached, external]));
+    expect(counting.listGraphsCalls).toBe(6);
+    now += 9;
+    await expect(store.listGraphs()).resolves.toEqual(expect.arrayContaining([cached, external]));
+    expect(counting.listGraphsCalls).toBe(6);
+    now += 1;
+    await expect(store.listGraphs()).resolves.toEqual(expect.arrayContaining([cached, external]));
+    expect(counting.listGraphsCalls).toBe(7);
+  });
+
+  it('keeps a failed cold seed strict instead of serving an empty graph set', async () => {
+    const counting = new CountingStore(new OxigraphStore());
+    counting.failListGraphs = true;
+    const store = new GraphSetIndexStore(counting);
+
+    await expect(store.listGraphs()).rejects.toThrow('listGraphs failed');
+    expect(counting.listGraphsCalls).toBe(1);
+    counting.failListGraphs = false;
+    await expect(store.listGraphs()).resolves.toEqual([]);
+    expect(counting.listGraphsCalls).toBe(2);
+  });
+
   it('treats revalidateMs 0 as always expired', async () => {
     const inner = new OxigraphStore();
     const counting = new CountingStore(inner);

--- a/packages/storage/test/graph-set-index-store.test.ts
+++ b/packages/storage/test/graph-set-index-store.test.ts
@@ -295,6 +295,34 @@ describe('GraphSetIndexStore', () => {
     expect(counting.listGraphsCalls).toBe(2);
   });
 
+  it('retries every read after a warm revalidation failure when revalidateMs is 0', async () => {
+    const now = 1_000;
+    const cached = 'did:dkg:context-graph:cached-zero-revalidate';
+    const recovered = 'did:dkg:context-graph:recovered-zero-revalidate';
+    const inner = new OxigraphStore();
+    await inner.insert([q(cached)]);
+    const counting = new CountingStore(inner);
+    const store = new GraphSetIndexStore(counting, {
+      revalidateMs: 0,
+      revalidateFailureBackoffMs: 10,
+      now: () => now,
+    });
+
+    await expect(store.listGraphs()).resolves.toEqual([cached]);
+    await inner.insert([q(recovered)]);
+    counting.failListGraphs = true;
+
+    // A failed warm scan still serves the last known set for availability.
+    await expect(store.listGraphs()).resolves.toEqual([cached]);
+    expect(counting.listGraphsCalls).toBe(2);
+
+    // Recovery is visible on the very next read at the same timestamp. The
+    // configured failure delay must not override the always-revalidate contract.
+    counting.failListGraphs = false;
+    await expect(store.listGraphs()).resolves.toEqual(expect.arrayContaining([cached, recovered]));
+    expect(counting.listGraphsCalls).toBe(3);
+  });
+
   it('coalesces concurrent refresh callers onto one listGraphs scan', async () => {
     const inner = new OxigraphStore();
     await inner.insert([q('did:dkg:context-graph:coalesced')]);


### PR DESCRIPTION
## Summary

- return the committed in-memory changelog sequence after the one-time durable seed instead of repeating `MAX(?seq)` on every sync request
- keep `headSeq()` as the explicit durable diagnostic and restart seed
- preserve caller cancellation on the now query-free changelog-head path and document its options boundary
- serve the last-good graph set after a failed warm periodic revalidation
- use one next-revalidation schedule for success freshness and exponential failure backoff, capped at five minutes
- preserve `revalidateMs: 0` as a strict scan-on-every-read override
- keep cold seeds, mutation-dirty rebuilds, and aborted callers strict

## Why

A store timeout during periodic graph-index revalidation currently makes every graph reader immediately repeat the same expensive `listGraphs` query. In the observed overload this created a retry storm. The sync responder also queried the changelog graph for its head on every delta request even though the documented single-writer changelog already tracks the last committed sequence in memory.

This change removes the repeat head query and makes only advisory, warm revalidation fail open to the last-known graph set. Correctness-sensitive rebuild paths and explicit strict-freshness configurations continue to behave strictly.

## Validation

- storage build
- focused post-review tests: 72 passed
- full storage suite: 349 passed, 25 integration-gated skips
- coverage for stale serving, exponential/capped retry timing, reset after recovery, `revalidateMs: 0` failure/recovery at the same timestamp, strict cold/dirty failures, committed in-memory changelog head behavior, exact abort-reason preservation, and no reintroduction of the durable aggregate query
