### PR TITLE
perf(publisher): replace ACK catalogs without count scans

### DIFF
--- a/packages/publisher/src/catalog-persistence.ts
+++ b/packages/publisher/src/catalog-persistence.ts
@@ -1,0 +1,63 @@
+import {
+  tryUpdateWithTouchedGraphs,
+  type Quad,
+  type QueryOptions,
+  type TripleStore,
+} from '@origintrail-official/dkg-storage';
+import { sparqlIri } from '@origintrail-official/dkg-core';
+
+function catalogStoreOptions(operation: string, signal?: AbortSignal): QueryOptions {
+  return {
+    priority: 'ack',
+    source: `storage-ack.persistCatalog.${operation}`,
+    ...(signal ? { signal } : {}),
+  };
+}
+
+/**
+ * Replace the touched subjects in a verified public catalog and make the
+ * replacement durable.
+ *
+ * The fast path clears IRI subjects in one server-side UPDATE. Blank-node
+ * labels are scoped to a single RDF operation and therefore cannot safely be
+ * carried into a later UPDATE; catalogs containing one use the legacy
+ * per-subject delete path. Stores with no real UPDATE capability use that same
+ * compatibility path, while genuine UPDATE execution errors still propagate.
+ */
+export async function replaceCatalogQuads(
+  store: TripleStore,
+  catalogGraph: string,
+  parsedCatalog: readonly Quad[],
+  signal?: AbortSignal,
+): Promise<void> {
+  const catalogSubjects = [...new Set(parsedCatalog.map((quad) => quad.subject))];
+  const canUseTargetedUpdate = catalogSubjects.length > 0 &&
+    catalogSubjects.every((subject) => !subject.startsWith('_:'));
+  const usedTargetedUpdate = canUseTargetedUpdate && await tryUpdateWithTouchedGraphs(
+    store,
+    `DELETE { GRAPH ${sparqlIri(catalogGraph)} { ?s ?p ?o } }
+WHERE { GRAPH ${sparqlIri(catalogGraph)} {
+  VALUES ?s { ${catalogSubjects.map((subject) => sparqlIri(subject)).join(' ')} }
+  ?s ?p ?o
+} }`,
+    [catalogGraph],
+    catalogStoreOptions('update', signal),
+  );
+
+  if (!usedTargetedUpdate) {
+    for (const subject of catalogSubjects) {
+      await store.deleteByPattern(
+        { graph: catalogGraph, subject },
+        catalogStoreOptions('deleteByPattern', signal),
+      );
+    }
+  }
+
+  await store.insert(
+    parsedCatalog.map((quad) => ({ ...quad, graph: catalogGraph })),
+    catalogStoreOptions('insert', signal),
+  );
+  // The ACK asserts this data is stored. Force any debounced persistence
+  // boundary before the caller signs it.
+  await store.flush?.(catalogStoreOptions('flush', signal));
+}

--- a/packages/publisher/src/storage-ack-handler.ts
+++ b/packages/publisher/src/storage-ack-handler.ts
@@ -5,7 +5,6 @@ import {
   type Quad,
   type QueryOptions,
   type StorePressureSnapshot,
-  tryUpdateWithTouchedGraphs,
 } from '@origintrail-official/dkg-storage';
 import type {
   EventBus,
@@ -36,13 +35,13 @@ import {
   contextGraphCatalogUri,
   isSwmMerkleExcludedQuad,
   STORAGE_ACK_MAX_STAGING_BYTES,
-  sparqlIri,
 } from '@origintrail-official/dkg-core';
 import {
   computeFlatKCRootV10 as computeFlatKCRoot,
   computeFlatKCMerkleLeafCountV10,
 } from './merkle.js';
 import { parseSimpleNQuads } from './publish-handler.js';
+import { replaceCatalogQuads } from './catalog-persistence.js';
 import { ethers } from 'ethers';
 
 type PeerId = { toString(): string };
@@ -614,17 +613,7 @@ export class StorageACKHandler {
     }
   }
 
-  /**
-   * REPLACE-persist a verified public `_catalog` into `<cg>/_catalog`:
-   * clear each subject then insert the catalog quads under `catalogGraph`.
-   * Production stores support server-side UPDATE, so clear every subject in
-   * one targeted DELETE/WHERE instead of calling deleteByPattern per subject
-   * (the HTTP adapters bracket each such call with two full-graph COUNTs).
-   * Stores without update() retain the existing per-subject fallback.
-   * Used by BOTH the curated publish and curated update paths (identical
-   * store shape). The caller MUST have already run `assertSafeIri(catalogGraph)`
-   * (malformed-request → reset stays outside the store-op wrapper).
-   */
+  /** Persist a verified public catalog under the shared store-error boundary. */
   private async persistCatalogOrDecline(
     cgId: string,
     catalogGraph: string,
@@ -635,42 +624,11 @@ export class StorageACKHandler {
     // the store wrapper so they reset the stream instead of being mislabeled
     // as a transient decline (see assertPersistQuadTermsSafe).
     assertPersistQuadTermsSafe(parsedCatalog);
-    const result = await this.runStoreOpOrDecline(cgId, async () => {
-      const catalogSubjects = new Set(parsedCatalog.map((q) => q.subject));
-      // Blank-node labels cannot be safely used as cross-operation identities
-      // in a SPARQL UPDATE. Catalog subjects are canonical IRIs in production;
-      // preserve the legacy fallback for any non-canonical input rather than
-      // silently changing its deletion semantics.
-      const iriSubjects = [...catalogSubjects].filter((subject) => !subject.startsWith('_:'));
-      const canUseTargetedUpdate = iriSubjects.length === catalogSubjects.size;
-      const usedTargetedUpdate = canUseTargetedUpdate && await tryUpdateWithTouchedGraphs(
-        this.store,
-        `DELETE { GRAPH ${sparqlIri(catalogGraph)} { ?s ?p ?o } }
-WHERE { GRAPH ${sparqlIri(catalogGraph)} {
-  VALUES ?s { ${iriSubjects.map((subject) => sparqlIri(subject)).join(' ')} }
-  ?s ?p ?o
-} }`,
-        [catalogGraph],
-        ackStoreOptions('storage-ack.persistCatalog.update', signal),
-      );
-      if (!usedTargetedUpdate) {
-        for (const subject of catalogSubjects) {
-          await this.store.deleteByPattern(
-            { graph: catalogGraph, subject },
-            ackStoreOptions('storage-ack.persistCatalog.deleteByPattern', signal),
-          );
-        }
-      }
-      await this.store.insert(
-        parsedCatalog.map((q) => ({ ...q, graph: catalogGraph })),
-        ackStoreOptions('storage-ack.persistCatalog.insert', signal),
-      );
-      // Durability boundary: the ACK we are about to sign asserts this data is
-      // stored, and a worker respawn can recover from a snapshot that predates
-      // the debounced flush — so force it durable before signing. A flush
-      // failure stays inside the wrapper → transient decline (never sign).
-      await this.store.flush?.(ackStoreOptions('storage-ack.persistCatalog.flush', signal));
-    }, signal);
+    const result = await this.runStoreOpOrDecline(
+      cgId,
+      () => replaceCatalogQuads(this.store, catalogGraph, parsedCatalog, signal),
+      signal,
+    );
     return result.ok ? { ok: true } : result;
   }
 

--- a/packages/publisher/src/storage-ack-handler.ts
+++ b/packages/publisher/src/storage-ack-handler.ts
@@ -5,6 +5,7 @@ import {
   type Quad,
   type QueryOptions,
   type StorePressureSnapshot,
+  tryUpdateWithTouchedGraphs,
 } from '@origintrail-official/dkg-storage';
 import type {
   EventBus,
@@ -35,6 +36,7 @@ import {
   contextGraphCatalogUri,
   isSwmMerkleExcludedQuad,
   STORAGE_ACK_MAX_STAGING_BYTES,
+  sparqlIri,
 } from '@origintrail-official/dkg-core';
 import {
   computeFlatKCRootV10 as computeFlatKCRoot,
@@ -615,6 +617,10 @@ export class StorageACKHandler {
   /**
    * REPLACE-persist a verified public `_catalog` into `<cg>/_catalog`:
    * clear each subject then insert the catalog quads under `catalogGraph`.
+   * Production stores support server-side UPDATE, so clear every subject in
+   * one targeted DELETE/WHERE instead of calling deleteByPattern per subject
+   * (the HTTP adapters bracket each such call with two full-graph COUNTs).
+   * Stores without update() retain the existing per-subject fallback.
    * Used by BOTH the curated publish and curated update paths (identical
    * store shape). The caller MUST have already run `assertSafeIri(catalogGraph)`
    * (malformed-request → reset stays outside the store-op wrapper).
@@ -631,11 +637,29 @@ export class StorageACKHandler {
     assertPersistQuadTermsSafe(parsedCatalog);
     const result = await this.runStoreOpOrDecline(cgId, async () => {
       const catalogSubjects = new Set(parsedCatalog.map((q) => q.subject));
-      for (const subject of catalogSubjects) {
-        await this.store.deleteByPattern(
-          { graph: catalogGraph, subject },
-          ackStoreOptions('storage-ack.persistCatalog.deleteByPattern', signal),
-        );
+      // Blank-node labels cannot be safely used as cross-operation identities
+      // in a SPARQL UPDATE. Catalog subjects are canonical IRIs in production;
+      // preserve the legacy fallback for any non-canonical input rather than
+      // silently changing its deletion semantics.
+      const iriSubjects = [...catalogSubjects].filter((subject) => !subject.startsWith('_:'));
+      const canUseTargetedUpdate = iriSubjects.length === catalogSubjects.size;
+      const usedTargetedUpdate = canUseTargetedUpdate && await tryUpdateWithTouchedGraphs(
+        this.store,
+        `DELETE { GRAPH ${sparqlIri(catalogGraph)} { ?s ?p ?o } }
+WHERE { GRAPH ${sparqlIri(catalogGraph)} {
+  VALUES ?s { ${iriSubjects.map((subject) => sparqlIri(subject)).join(' ')} }
+  ?s ?p ?o
+} }`,
+        [catalogGraph],
+        ackStoreOptions('storage-ack.persistCatalog.update', signal),
+      );
+      if (!usedTargetedUpdate) {
+        for (const subject of catalogSubjects) {
+          await this.store.deleteByPattern(
+            { graph: catalogGraph, subject },
+            ackStoreOptions('storage-ack.persistCatalog.deleteByPattern', signal),
+          );
+        }
       }
       await this.store.insert(
         parsedCatalog.map((q) => ({ ...q, graph: catalogGraph })),

--- a/packages/publisher/test/storage-ack-handler.test.ts
+++ b/packages/publisher/test/storage-ack-handler.test.ts
@@ -40,12 +40,12 @@ function makeQuad(s: string, p: string, o: string, g = 'urn:test:swm'): Quad {
  * hitting the live store. Mirrors `storeWithFailingOps` in
  * storage-ack-core-unavailable.test.ts — the curated-catalog store-failure
  * regressions below need the SAME real-store-with-armed-failure model so
- * they exercise the actual persist path (parse → verify → deleteByPattern →
+ * they exercise the actual persist path (parse → verify → targeted update →
  * insert) up to the failing store call.
  */
 function storeWithFailingOps(
   base: OxigraphStore,
-  failingOps: readonly ('query' | 'insert' | 'dropGraph' | 'deleteByPattern' | 'flush')[],
+  failingOps: readonly ('query' | 'insert' | 'dropGraph' | 'deleteByPattern' | 'update' | 'flush')[],
 ): TripleStore {
   return new Proxy(base as unknown as TripleStore, {
     get(target, prop, receiver) {
@@ -1004,13 +1004,12 @@ describe('StorageACKHandler', () => {
     // throw the classic 'store is closed' mid-restart error, reusing the
     // curated fixtures above. The catalog is VALID (root/leaf/byteSize all
     // check out) so the handler reaches the `<cg>/_catalog` persist —
-    // deleteByPattern + insert — which is the store-outage catch path this
+    // targeted update + insert — which is the store-outage catch path this
     // regression pins (otReviewAgent #1408:650).
-    async function curatedHandlerWithFailingStore(
-      failingOps: readonly ('deleteByPattern' | 'insert' | 'flush')[],
+    function curatedHandlerWithStore(
+      store: TripleStore,
       configOverrides: Partial<StorageACKHandlerConfig> = {},
     ) {
-      const base = new OxigraphStore();
       const config: StorageACKHandlerConfig = {
         nodeRole: 'core',
         nodeIdentityId: coreIdentityId,
@@ -1022,20 +1021,99 @@ describe('StorageACKHandler', () => {
         isCgCurated: async () => true,
         ...configOverrides,
       };
-      return new StorageACKHandler(
+      return new StorageACKHandler(store as any, config, new TypedEventBus() as any);
+    }
+
+    async function curatedHandlerWithFailingStore(
+      failingOps: readonly ('deleteByPattern' | 'update' | 'insert' | 'flush')[],
+      configOverrides: Partial<StorageACKHandlerConfig> = {},
+    ) {
+      const base = new OxigraphStore();
+      return curatedHandlerWithStore(
         storeWithFailingOps(base, failingOps) as any,
-        config,
-        new TypedEventBus() as any,
+        configOverrides,
       );
     }
 
-    it('curated catalog persist / deleteByPattern throws → CORE_TEMPORARILY_UNAVAILABLE ("store unavailable"), NO signed ACK', async () => {
+    it('uses one targeted update with graph hints, avoids deleteByPattern counts, and preserves unrelated subjects', async () => {
+      const catalogGraph = `${cgDid}/_catalog`;
+      const unrelatedSubject = 'urn:test:unrelated-catalog-subject';
+      const stalePredicate = 'urn:test:stale-catalog-predicate';
+      const base = new OxigraphStore();
+      await base.insert([
+        { subject: cgDid, predicate: stalePredicate, object: '"stale"', graph: catalogGraph },
+        { subject: unrelatedSubject, predicate: 'urn:test:kept', object: '"yes"', graph: catalogGraph },
+      ]);
+      const updates: Array<{ sparql: string; options?: { source?: string; priority?: string; touchedGraphs?: readonly string[] } }> = [];
+      let deleteByPatternCalls = 0;
+      const store = new Proxy(base as unknown as TripleStore, {
+        get(target, prop, receiver) {
+          if (prop === 'update') {
+            return async (sparql: string, options?: { source?: string; priority?: string; touchedGraphs?: readonly string[] }) => {
+              updates.push({ sparql, options });
+              return target.update!.call(target, sparql, options);
+            };
+          }
+          if (prop === 'deleteByPattern') {
+            return async (...args: Parameters<TripleStore['deleteByPattern']>) => {
+              deleteByPatternCalls += 1;
+              return target.deleteByPattern.call(target, ...args);
+            };
+          }
+          const value = Reflect.get(target, prop, receiver);
+          return typeof value === 'function' ? value.bind(target) : value;
+        },
+      });
+      const handler = curatedHandlerWithStore(store);
+
+      const decoded = decodeStorageACK(await handler.handler(curatedIntent(), fakePeerId));
+
+      expect(isStorageACKDecline(decoded)).toBe(false);
+      expect(deleteByPatternCalls).toBe(0);
+      expect(updates).toHaveLength(1);
+      expect(updates[0]?.sparql).toContain(`VALUES ?s { <${cgDid}> }`);
+      expect(updates[0]?.options).toMatchObject({
+        source: 'storage-ack.persistCatalog.update',
+        priority: 'ack',
+        touchedGraphs: [catalogGraph],
+      });
+      const stale = await base.query(`ASK { GRAPH <${catalogGraph}> { <${cgDid}> <${stalePredicate}> ?o } }`);
+      expect(stale).toMatchObject({ type: 'boolean', value: false });
+      const unrelated = await base.query(`ASK { GRAPH <${catalogGraph}> { <${unrelatedSubject}> ?p ?o } }`);
+      expect(unrelated).toMatchObject({ type: 'boolean', value: true });
+    });
+
+    it('falls back to per-subject deleteByPattern when update() is unavailable', async () => {
+      const base = new OxigraphStore();
+      let deleteByPatternCalls = 0;
+      const store = new Proxy(base as unknown as TripleStore, {
+        get(target, prop, receiver) {
+          if (prop === 'update') return undefined;
+          if (prop === 'deleteByPattern') {
+            return async (...args: Parameters<TripleStore['deleteByPattern']>) => {
+              deleteByPatternCalls += 1;
+              return target.deleteByPattern.call(target, ...args);
+            };
+          }
+          const value = Reflect.get(target, prop, receiver);
+          return typeof value === 'function' ? value.bind(target) : value;
+        },
+      });
+      const handler = curatedHandlerWithStore(store);
+
+      const decoded = decodeStorageACK(await handler.handler(curatedIntent(), fakePeerId));
+
+      expect(isStorageACKDecline(decoded)).toBe(false);
+      expect(deleteByPatternCalls).toBe(1);
+    });
+
+    it('curated catalog persist / targeted update throws → CORE_TEMPORARILY_UNAVAILABLE ("store unavailable"), NO signed ACK', async () => {
       // Dead-air regression: a curated encrypted publish with a VALID catalog
-      // root whose `<cg>/_catalog` REPLACE (deleteByPattern) hits a closed
+      // root whose `<cg>/_catalog` targeted DELETE update hits a closed
       // store used to throw out of the handler → stream reset → publisher
       // no_response. It must instead reply with the transient decline.
       const onDecline = vi.fn();
-      const handler = await curatedHandlerWithFailingStore(['deleteByPattern'], { onDecline });
+      const handler = await curatedHandlerWithFailingStore(['update'], { onDecline });
       const decoded = decodeStorageACK(await handler.handler(curatedIntent(), fakePeerId));
 
       expect(isStorageACKDecline(decoded)).toBe(true);

--- a/packages/publisher/test/storage-ack-handler.test.ts
+++ b/packages/publisher/test/storage-ack-handler.test.ts
@@ -11,7 +11,7 @@ import {
   isStorageACKDecline, STORAGE_ACK_DECLINE_CODES, computeCatalogRoot, Logger,
 } from '@origintrail-official/dkg-core';
 import { TypedEventBus, rebuildMetrics } from '@origintrail-official/dkg-core';
-import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import { GraphSetIndexStore, OxigraphStore } from '@origintrail-official/dkg-storage';
 import { ethers } from 'ethers';
 import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
 import { metrics } from '@opentelemetry/api';
@@ -1105,6 +1105,86 @@ describe('StorageACKHandler', () => {
 
       expect(isStorageACKDecline(decoded)).toBe(false);
       expect(deleteByPatternCalls).toBe(1);
+    });
+
+    it('falls back through a decorator whose inner store does not support update()', async () => {
+      const base = new OxigraphStore();
+      let deleteByPatternCalls = 0;
+      const innerWithoutUpdate = new Proxy(base as unknown as TripleStore, {
+        get(target, prop, receiver) {
+          if (prop === 'update') return undefined;
+          if (prop === 'deleteByPattern') {
+            return async (...args: Parameters<TripleStore['deleteByPattern']>) => {
+              deleteByPatternCalls += 1;
+              return target.deleteByPattern.call(target, ...args);
+            };
+          }
+          const value = Reflect.get(target, prop, receiver);
+          return typeof value === 'function' ? value.bind(target) : value;
+        },
+      });
+      const decoratedStore = new GraphSetIndexStore(innerWithoutUpdate);
+      expect(typeof decoratedStore.update).toBe('function');
+      const handler = curatedHandlerWithStore(decoratedStore);
+
+      const decoded = decodeStorageACK(await handler.handler(curatedIntent(), fakePeerId));
+
+      expect(isStorageACKDecline(decoded)).toBe(false);
+      expect(deleteByPatternCalls).toBe(1);
+      await expect(base.countQuads(`${cgDid}/_catalog`)).resolves.toBe(catalogTriples.length);
+    });
+
+    it('skips targeted update and deletes by pattern for a blank-node catalog subject', async () => {
+      const blankCatalogTriples = [{
+        subject: '_:catalog',
+        predicate: 'urn:test:catalog-predicate',
+        object: '"blank-subject"',
+      }];
+      const blankCatalogNquads = '_:catalog <urn:test:catalog-predicate> "blank-subject" .';
+      const blankCatalogBytes = new TextEncoder().encode(blankCatalogNquads);
+      const blankCatalogRoot = computeCatalogRoot(blankCatalogTriples);
+      const base = new OxigraphStore();
+      let updateCalls = 0;
+      const deletedPatterns: Array<Partial<Quad>> = [];
+      const store = new Proxy(base as unknown as TripleStore, {
+        get(target, prop, receiver) {
+          if (prop === 'update') {
+            return async (...args: Parameters<NonNullable<TripleStore['update']>>) => {
+              updateCalls += 1;
+              return target.update!.call(target, ...args);
+            };
+          }
+          if (prop === 'deleteByPattern') {
+            return async (...args: Parameters<TripleStore['deleteByPattern']>) => {
+              deletedPatterns.push(args[0]);
+              // This regression targets the ACK routing policy. Blank-node
+              // labels are operation-local, so the spy records the requested
+              // legacy delete without asking the embedded backend to resolve
+              // that label in a separate operation.
+              if (args[0].subject?.startsWith('_:')) return 0;
+              return target.deleteByPattern.call(target, ...args);
+            };
+          }
+          const value = Reflect.get(target, prop, receiver);
+          return typeof value === 'function' ? value.bind(target) : value;
+        },
+      });
+      const handler = curatedHandlerWithStore(store);
+
+      const decoded = decodeStorageACK(await handler.handler(curatedIntent({
+        stagingQuads: blankCatalogBytes,
+        publicByteSize: blankCatalogBytes.length,
+        catalogRoot: blankCatalogRoot.root,
+        catalogLeafCount: blankCatalogRoot.leafCount,
+      }), fakePeerId));
+
+      expect(isStorageACKDecline(decoded)).toBe(false);
+      expect(updateCalls).toBe(0);
+      expect(deletedPatterns).toEqual([{
+        graph: `${cgDid}/_catalog`,
+        subject: '_:catalog',
+      }]);
+      await expect(base.countQuads(`${cgDid}/_catalog`)).resolves.toBe(1);
     });
 
     it('curated catalog persist / targeted update throws → CORE_TEMPORARILY_UNAVAILABLE ("store unavailable"), NO signed ACK', async () => {

--- a/packages/publisher/test/storage-update-ack.test.ts
+++ b/packages/publisher/test/storage-update-ack.test.ts
@@ -32,11 +32,11 @@ function makeQuad(s: string, p: string, o: string, g = 'urn:test:swm'): Quad {
  * hitting the live store. Mirrors `storeWithFailingOps` in
  * storage-ack-core-unavailable.test.ts — the curated-catalog UPDATE store-
  * failure regression below drives the real persist path (parse → verify →
- * deleteByPattern → insert) up to the armed failure.
+ * targeted update → insert) up to the armed failure.
  */
 function storeWithFailingOps(
   base: OxigraphStore,
-  failingOps: readonly ('query' | 'insert' | 'dropGraph' | 'deleteByPattern')[],
+  failingOps: readonly ('query' | 'insert' | 'dropGraph' | 'deleteByPattern' | 'update')[],
 ): TripleStore {
   return new Proxy(base as unknown as TripleStore, {
     get(target, prop, receiver) {
@@ -245,13 +245,13 @@ describe('V10 UPDATE StorageACK — peer handler + collector quorum', () => {
       expect(isStorageACKDecline(ack)).toBe(false);
     });
 
-    it('curated catalog persist / deleteByPattern throws → CORE_TEMPORARILY_UNAVAILABLE ("store unavailable"), NO signed ACK', async () => {
+    it('curated catalog persist / targeted update throws → CORE_TEMPORARILY_UNAVAILABLE ("store unavailable"), NO signed ACK', async () => {
       // Dead-air regression (otReviewAgent #1408:650): a curated UPDATE with a
-      // VALID rotated catalog root whose `<cg>/_catalog` REPLACE (deleteByPattern)
+      // VALID rotated catalog root whose `<cg>/_catalog` targeted DELETE update
       // hits a closed store used to throw out of the handler → stream reset →
       // publisher no_response. It must instead reply with the transient decline.
       const onDecline = vi.fn();
-      const store = storeWithFailingOps(new OxigraphStore(), ['deleteByPattern']);
+      const store = storeWithFailingOps(new OxigraphStore(), ['update']);
       const handler = new StorageACKHandler(
         store as any,
         makeConfig(ethers.Wallet.createRandom(), 42n, { onDecline }),

--- a/packages/storage/src/changelog-store.ts
+++ b/packages/storage/src/changelog-store.ts
@@ -8,6 +8,7 @@ import type {
   UpdateOptions,
   StorePressureSnapshot,
 } from './triple-store.js';
+import { UnsupportedTripleStoreCapabilityError } from './unsupported-capability-error.js';
 
 /**
  * ChangelogStore — an append-only per-node change log maintained on the write
@@ -325,7 +326,7 @@ export class ChangelogStore implements TripleStore, ChangelogReader {
 
   async update(sparql: string, options?: UpdateOptions): Promise<void> {
     if (typeof this.inner.update !== 'function') {
-      throw new Error('ChangelogStore: inner store does not support update()');
+      throw new UnsupportedTripleStoreCapabilityError('update', 'ChangelogStore');
     }
     if (!this.enabled) return this.inner.update(sparql, options);
     // Reject BEFORE the mutation runs so it never touches the reserved plane.

--- a/packages/storage/src/graph-set-index-store.ts
+++ b/packages/storage/src/graph-set-index-store.ts
@@ -1,6 +1,7 @@
 import { performance } from 'node:perf_hooks';
 import { isSparqlUpdateOperation } from '@origintrail-official/dkg-core';
 import type { Quad, QueryOptions, QueryResult, StorePressureSnapshot, TripleStore, UpdateOptions } from './triple-store.js';
+import { UnsupportedTripleStoreCapabilityError } from './unsupported-capability-error.js';
 
 export const DEFAULT_GRAPH_SET_REVALIDATE_MS = 30_000;
 
@@ -145,7 +146,7 @@ export class GraphSetIndexStore implements TripleStore {
 
   async update(sparql: string, options?: UpdateOptions): Promise<void> {
     if (typeof this.inner.update !== 'function') {
-      throw new Error('GraphSetIndexStore: inner store does not support update()');
+      throw new UnsupportedTripleStoreCapabilityError('update', 'GraphSetIndexStore');
     }
     if (!this.enabled) {
       await this.inner.update(sparql, options);

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -21,6 +21,10 @@ export {
   type SparqlEndpoint,
 } from './triple-store.js';
 export {
+  UnsupportedTripleStoreCapabilityError,
+  type TripleStoreCapability,
+} from './unsupported-capability-error.js';
+export {
   StorePriorityScheduler,
   externalStorePriorityScheduler,
   getExternalStorePrioritySchedulerSnapshot,

--- a/packages/storage/src/shared-memory-literal-blob-store.ts
+++ b/packages/storage/src/shared-memory-literal-blob-store.ts
@@ -11,6 +11,7 @@ import type {
   StorePressureSnapshot,
   TripleStore,
 } from './triple-store.js';
+import { UnsupportedTripleStoreCapabilityError } from './unsupported-capability-error.js';
 
 export const EXTERNAL_LITERAL_REF_DATATYPE = 'http://dkg.io/ontology/externalLiteralRef';
 export const SHARED_MEMORY_GRAPH_SUFFIX = '/_shared_memory';
@@ -86,7 +87,7 @@ export class SharedMemoryLiteralBlobStore implements TripleStore {
 
   async update(sparql: string, options?: UpdateOptions): Promise<void> {
     if (typeof this.inner.update !== 'function') {
-      throw new Error('SharedMemoryLiteralBlobStore: inner store does not support update()');
+      throw new UnsupportedTripleStoreCapabilityError('update', 'SharedMemoryLiteralBlobStore');
     }
     // Forward verbatim. A server-side INSERT…WHERE copies whatever terms are
     // already stored — including any externalized blob-ref placeholders — so

--- a/packages/storage/src/triple-store.ts
+++ b/packages/storage/src/triple-store.ts
@@ -17,6 +17,7 @@ import {
   ChangelogStore,
   type ChangelogStoreOptions,
 } from './changelog-store.js';
+import { UnsupportedTripleStoreCapabilityError } from './unsupported-capability-error.js';
 
 export interface Quad {
   subject: string;
@@ -151,8 +152,10 @@ export interface TripleStore {
 
 /**
  * Run a server-side update whose affected named graphs are known by the caller.
- * Returns `false` when the store does not support `update()` so feature code can
- * apply its own fallback policy without duplicating method binding or hint wiring.
+ * Returns `false` when the store does not support `update()` directly, or when
+ * a decorator reports that its wrapped store lacks the capability. Genuine
+ * update execution errors propagate so feature code cannot mask an outage or
+ * partially executed mutation as a compatibility fallback.
  */
 export async function tryUpdateWithTouchedGraphs(
   store: TripleStore,
@@ -162,8 +165,18 @@ export async function tryUpdateWithTouchedGraphs(
 ): Promise<boolean> {
   const update = store.update;
   if (typeof update !== 'function') return false;
-  await update.call(store, sparql, { ...options, touchedGraphs });
-  return true;
+  try {
+    await update.call(store, sparql, { ...options, touchedGraphs });
+    return true;
+  } catch (error) {
+    if (
+      error instanceof UnsupportedTripleStoreCapabilityError &&
+      error.capability === 'update'
+    ) {
+      return false;
+    }
+    throw error;
+  }
 }
 
 export type TripleStoreBackend = 'oxigraph' | 'oxigraph-persistent' | 'oxigraph-worker' | 'blazegraph' | 'sparql-http' | string;

--- a/packages/storage/src/unsupported-capability-error.ts
+++ b/packages/storage/src/unsupported-capability-error.ts
@@ -1,0 +1,26 @@
+/**
+ * Optional TripleStore operations that a decorator may expose even when its
+ * wrapped backend cannot perform them.
+ */
+export type TripleStoreCapability = 'update';
+
+/**
+ * Typed signal that an optional store capability is unavailable.
+ *
+ * Decorators use this instead of a generic Error when their public method is
+ * present but the wrapped store lacks the corresponding optional operation.
+ * Callers may then choose a compatibility fallback without accidentally
+ * treating a genuine execution failure as "unsupported". Implementations
+ * must raise it before starting the operation so a caller can safely fall back.
+ */
+export class UnsupportedTripleStoreCapabilityError extends Error {
+  readonly capability: TripleStoreCapability;
+  readonly storeName: string;
+
+  constructor(capability: TripleStoreCapability, storeName: string) {
+    super(`${storeName}: inner store does not support ${capability}()`);
+    this.name = 'UnsupportedTripleStoreCapabilityError';
+    this.capability = capability;
+    this.storeName = storeName;
+  }
+}

--- a/packages/storage/test/triple-store-update-capability.test.ts
+++ b/packages/storage/test/triple-store-update-capability.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import {
+  UnsupportedTripleStoreCapabilityError,
+  tryUpdateWithTouchedGraphs,
+  type TripleStore,
+} from '../src/index.js';
+
+describe('tryUpdateWithTouchedGraphs', () => {
+  it('returns false for a typed unsupported-update signal from a decorator', async () => {
+    const store = {
+      update: async () => {
+        throw new UnsupportedTripleStoreCapabilityError('update', 'TestDecorator');
+      },
+    } as unknown as TripleStore;
+
+    await expect(
+      tryUpdateWithTouchedGraphs(store, 'DELETE WHERE { ?s ?p ?o }', ['urn:test:graph']),
+    ).resolves.toBe(false);
+  });
+
+  it('does not mask a genuine update execution failure', async () => {
+    const failure = new Error('store is closed');
+    const store = {
+      update: async () => {
+        throw failure;
+      },
+    } as unknown as TripleStore;
+
+    await expect(
+      tryUpdateWithTouchedGraphs(store, 'DELETE WHERE { ?s ?p ?o }', ['urn:test:graph']),
+    ).rejects.toBe(failure);
+  });
+});


### PR DESCRIPTION
## Summary

- replace per-subject `deleteByPattern` calls during curated storage-ACK catalog persistence with one targeted SPARQL DELETE/WHERE
- bind all incoming IRI catalog subjects through one VALUES clause
- preserve unrelated subjects in the catalog graph
- provide the touched-graph hint so graph-set and changelog decorators remain coherent
- extract catalog replacement policy from the ACK handler into a focused persistence helper
- retain the legacy per-subject path for blank-node subjects and stores whose real UPDATE capability is absent, including decorated stores
- distinguish typed capability absence from genuine UPDATE execution failures

## Why

The HTTP store adapters implement `deleteByPattern` as `COUNT → DELETE → COUNT`. Persisting a verified catalog one subject at a time therefore performs repeated full-graph counts on the ACK hot path. The targeted update performs the same subject replacement server-side without those scans.

Publish and update storage-ACK flows share this persistence helper, so both benefit.

## Validation

- storage and publisher builds
- focused publisher catalog/ACK tests after review: 55 passed
- relevant storage capability/decorator tests: 82 passed
- original full publisher suite: 1,494 passed, 6 skipped
- verifies one targeted update, zero `deleteByPattern` calls on the fast path, touched-graph/priority/source hints, stale incoming-subject removal, unrelated-subject preservation, direct and decorated capability fallback, genuine-error propagation, blank-node routing, and transient decline behavior
