### PR TITLE
fix(chain): complete full-pool throttle retry contract (#1561)

### DIFF
--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -2591,12 +2591,11 @@ export class EVMChainAdapterBase {
     // endpoint that has it; best-effort `0` only when EVERY endpoint lacks it and
     // no transport error occurred. Non-retryable / transport-exhaustion errors
     // propagate (never masked as a bogus `0`). Order-independent — see the helper.
-    const block = await this.rpcFailover.read(
+    const block = await this.readProviderRetryingNull(
       'getBlock',
       (p) => p.getBlock(blockNumber),
       {
         rpcUsageConsumer: 'getBlock',
-        isEmptyResult: (value) => value == null,
         endpointSetRetry: 'all-throttled',
       },
     );

--- a/packages/chain/src/rpc-failover-client.ts
+++ b/packages/chain/src/rpc-failover-client.ts
@@ -318,9 +318,7 @@ export class RpcFailoverClient {
       opts?.skipPreferred ?? false,
       opts?.isEmptyResult,
     );
-    const run = opts?.endpointSetRetry === 'all-throttled'
-      ? () => this.withThrottleRetries(runPass)
-      : runPass;
+    const run = () => this.runReadPasses(label, runPass, opts?.endpointSetRetry);
     return opts?.rpcUsageConsumer ? withRpcUsageConsumer(opts.rpcUsageConsumer, run) : run();
   }
 
@@ -350,13 +348,17 @@ export class RpcFailoverClient {
         const metrics = getMetrics();
         const startedAt = Date.now();
         try {
-          const out = await this.runAcrossProviders(
+          const out = await this.runReadPasses(
             label,
-            (p) => fn(this.rebindContract(contract, p)),
-            opts?.isRetryable ?? isContractViewRetryable,
-            opts?.policy ?? 'pointRead',
-            opts?.skipPreferred ?? false,
-            opts?.isEmptyResult,
+            () => this.runAcrossProviders(
+              label,
+              (p) => fn(this.rebindContract(contract, p)),
+              opts?.isRetryable ?? isContractViewRetryable,
+              opts?.policy ?? 'pointRead',
+              opts?.skipPreferred ?? false,
+              opts?.isEmptyResult,
+            ),
+            opts?.endpointSetRetry,
           );
           this.recordRpcOutcome('eth_call', 'ok');
           return out;
@@ -739,7 +741,6 @@ export class RpcFailoverClient {
     // (a transport failure occurred, so "every endpoint lacks it" can't be
     // concluded and the empty value must NOT be returned as definitive).
     if (lastRetryable) {
-      noteRpcExhaustion(label, canonical.map((e) => e.rpcUrl));
       // Single provider → carry the typed code but keep the original message
       // byte-identical (there is no second endpoint, so the raw message reads
       // cleaner and any message-inspecting caller keeps seeing it). Multiple
@@ -769,6 +770,28 @@ export class RpcFailoverClient {
       `${label} read failed: no configured RPC endpoints`,
       { rpcUrls: [] },
     );
+  }
+
+  /**
+   * Shared endpoint-set orchestration for provider and contract reads. A
+   * recoverable all-throttled pass stays internal; terminal exhaustion is
+   * reported exactly once only after the retry policy has settled.
+   */
+  private async runReadPasses<T>(
+    label: string,
+    runPass: () => Promise<T>,
+    endpointSetRetry?: ReadOpts['endpointSetRetry'],
+  ): Promise<T> {
+    try {
+      return endpointSetRetry === 'all-throttled'
+        ? await this.withThrottleRetries(runPass)
+        : await runPass();
+    } catch (error) {
+      if (error instanceof ProviderSetExhaustedError) {
+        noteRpcExhaustion(label, error.rpcUrls ?? []);
+      }
+      throw error;
+    }
   }
 
   private async withThrottleRetries<T>(run: () => Promise<T>): Promise<T> {

--- a/packages/chain/test/evm-adapter-tip-read-carveouts.unit.test.ts
+++ b/packages/chain/test/evm-adapter-tip-read-carveouts.unit.test.ts
@@ -201,18 +201,26 @@ describe('getBlockTimestamp: a null (unimported) receipt block fails over instea
     const retryable429 = () => { const e: any = new Error('429 too many requests'); e.status = 429; return e; };
     // Order A: primary transport error, backup null. A transport failure occurred,
     // so we canNOT conclude "block not imported anywhere" → propagate (not 0).
+    const orderAThrottle = recorder(async () => { throw retryable429(); });
+    const orderANull = recorder(async () => null);
     const orderA = makeTwoEndpointAdapter(
-      { getBlock: recorder(async () => { throw retryable429(); }) },
-      { getBlock: recorder(async () => null) },
+      { getBlock: orderAThrottle },
+      { getBlock: orderANull },
     );
     await expect(orderA.getBlockTimestamp(123n)).rejects.toMatchObject({ code: 'RPC_ENDPOINTS_EXHAUSTED' });
+    expect(orderAThrottle.calls).toHaveLength(1);
+    expect(orderANull.calls).toHaveLength(1);
     // Order B: primary null, backup transport error — SAME endpoint states, so the
     // result must be identical (before the fix this returned 0 vs threw by order).
+    const orderBNull = recorder(async () => null);
+    const orderBThrottle = recorder(async () => { throw retryable429(); });
     const orderB = makeTwoEndpointAdapter(
-      { getBlock: recorder(async () => null) },
-      { getBlock: recorder(async () => { throw retryable429(); }) },
+      { getBlock: orderBNull },
+      { getBlock: orderBThrottle },
     );
     await expect(orderB.getBlockTimestamp(123n)).rejects.toMatchObject({ code: 'RPC_ENDPOINTS_EXHAUSTED' });
+    expect(orderBNull.calls).toHaveLength(1);
+    expect(orderBThrottle.calls).toHaveLength(1);
   });
 });
 

--- a/packages/chain/test/readwithfailover-loop.unit.test.ts
+++ b/packages/chain/test/readwithfailover-loop.unit.test.ts
@@ -139,6 +139,44 @@ describe('RpcFailoverClient.read — read-failover loop logic (bare-mock, #1336)
       .resolves.toBe('recovered');
     expect(primary.read.calls).toHaveLength(2);
     expect(backup.read.calls).toHaveLength(2);
+    expect(getRpcFailoverStats().exhaustions).toBe(0);
+  });
+
+  it('recovers from message-only throttles without recording a terminal exhaustion', async () => {
+    let backupAttempt = 0;
+    const primary = { read: recorder(async () => { throw new Error('rate limit exceeded'); }) };
+    const backup = { read: recorder(async () => {
+      backupAttempt += 1;
+      if (backupAttempt === 1) throw new Error('Too Many Requests');
+      return 'recovered-from-message-only-throttle';
+    }) };
+    const client = makeClient([primary, backup], ['https://primary.example', 'https://backup.example'], NEVER_SIGN, {
+      readThrottleRetries: 2,
+      readThrottleBackoffMs: 1,
+    });
+
+    await expect(client.read('message-only throttle', (provider: any) => provider.read(), {
+      endpointSetRetry: 'all-throttled',
+    })).resolves.toBe('recovered-from-message-only-throttle');
+    expect(primary.read.calls).toHaveLength(2);
+    expect(backup.read.calls).toHaveLength(2);
+    expect(getRpcFailoverStats().exhaustions).toBe(0);
+  });
+
+  it('records one terminal exhaustion after all throttle retries are spent', async () => {
+    const primary = { read: recorder(async () => { throw retryable429(); }) };
+    const backup = { read: recorder(async () => { throw retryable429(); }) };
+    const client = makeClient([primary, backup], ['https://primary.example', 'https://backup.example'], NEVER_SIGN, {
+      readThrottleRetries: 2,
+      readThrottleBackoffMs: 1,
+    });
+
+    await expect(client.read('terminal throttle', (provider: any) => provider.read(), {
+      endpointSetRetry: 'all-throttled',
+    })).rejects.toMatchObject({ code: 'RPC_ENDPOINTS_EXHAUSTED' });
+    expect(primary.read.calls).toHaveLength(3);
+    expect(backup.read.calls).toHaveLength(3);
+    expect(getRpcFailoverStats().exhaustions).toBe(1);
   });
 
   it('does not retry a mixed timeout plus 429 endpoint exhaustion', async () => {
@@ -288,6 +326,9 @@ describe('RpcFailoverClient.read — per-attempt cap (named policies, log-scan s
 // over on a post-decode error). So BAD_DATA must surface DIRECTLY (no failover),
 // while a real transient (429) still fails over; opts.isRetryable overrides it.
 describe('RpcFailoverClient.readContract — per-provider rebinding + view classifier (B-2, #2/#3)', () => {
+  beforeEach(() => { _resetRpcFailoverStatsForTest(); });
+  afterEach(() => { _resetRpcFailoverStatsForTest(); });
+
   const badDataError = () => {
     const e: any = new Error('could not decode result data (value="0x", code=BAD_DATA)');
     e.code = 'BAD_DATA';
@@ -326,6 +367,29 @@ describe('RpcFailoverClient.readContract — per-provider rebinding + view class
     // result coming from backupView, and primaryView hit exactly once (not twice).
     expect(primaryView.calls).toHaveLength(1);
     expect(backupView.calls).toHaveLength(1);
+  });
+
+  it('readContract applies all-throttled endpoint-set retry through the shared runner', async () => {
+    const p0 = {}; const p1 = {};
+    const primaryView = recorder(async () => { throw retryable429(); });
+    let backupAttempt = 0;
+    const backupView = recorder(async () => {
+      backupAttempt += 1;
+      if (backupAttempt === 1) throw retryable429();
+      return 'RECOVERED-CONTRACT-RESULT';
+    });
+    const contract = perProviderContract((p) => (p === p0 ? { view: primaryView } : { view: backupView }));
+    const client = makeClient([p0, p1], ['https://primary.example', 'https://backup.example'], NEVER_SIGN, {
+      readThrottleRetries: 2,
+      readThrottleBackoffMs: 1,
+    });
+
+    await expect(client.readContract('someView', contract, (c: any) => c.view(), {
+      endpointSetRetry: 'all-throttled',
+    })).resolves.toBe('RECOVERED-CONTRACT-RESULT');
+    expect(primaryView.calls).toHaveLength(2);
+    expect(backupView.calls).toHaveLength(2);
+    expect(getRpcFailoverStats().exhaustions).toBe(0);
   });
 
   it('an explicit opts.isRetryable OVERRIDES the isContractViewRetryable default (BAD_DATA → rebinds to the BACKUP view)', async () => {

--- a/scripts/devnet-test-issue-1561-rpc-throttle-retry.sh
+++ b/scripts/devnet-test-issue-1561-rpc-throttle-retry.sh
@@ -76,6 +76,9 @@ for _ in $(seq 1 90); do
   sleep 1
 done
 [[ "$(code_of "$(api "$NODE" GET /api/status)")" == 200 ]] || fail "temporary node not ready"
+status_before="$(api "$NODE" GET /api/status)"
+exhaustions_before="$(field "$(body_of "$status_before")" chain.rpcExhaustions)"
+[[ -n "$exhaustions_before" ]] || exhaustions_before=0
 api "$NODE" POST /api/identity/ensure '{}' >/dev/null || true
 
 name="issue-1561-$(date +%s)-$$"; subject="urn:issue:1561:$name"
@@ -87,6 +90,12 @@ api "$NODE" POST "/api/knowledge-assets/$name/swm/share" "{\"contextGraphId\":\"
 result="$(api "$NODE" POST "/api/knowledge-assets/$name/vm/publish" "{\"contextGraphId\":\"$CG\"}")"
 [[ "$(code_of "$result")" == 200 ]] || fail "publish failed: $(body_of "$result")"
 [[ "$(field "$(body_of "$result")" status)" == confirmed ]] || fail "publish not confirmed"
+
+status_after="$(api "$NODE" GET /api/status)"
+exhaustions_after="$(field "$(body_of "$status_after")" chain.rpcExhaustions)"
+[[ -n "$exhaustions_after" ]] || exhaustions_after=0
+[[ "$exhaustions_after" == "$exhaustions_before" ]] \
+  || fail "recovered throttle pass was reported as terminal exhaustion ($exhaustions_before -> $exhaustions_after)"
 
 stats="$(curl -fsS "http://127.0.0.1:$PROXY_PORT/stats")"
 STATS="$stats" node -e 'const s=JSON.parse(process.env.STATS); for (const p of ["/a","/b"]) { const n=s[`${p}:eth_getBlockByNumber`]||0; if(n<2) throw new Error(`${p} getBlock calls=${n}, expected throttle plus recovery`); }' \


### PR DESCRIPTION
Follow-up to #1628 and #1561 after the post-merge review audit.

What changed

- route provider reads and contract views through one endpoint-set retry runner
- honor endpointSetRetry for readContract instead of exposing an ignored option
- defer exhaustion logging/counters until throttle retries are actually terminal
- keep recovered all-throttled passes out of operator-facing exhaustion telemetry
- route getBlockTimestamp through the canonical nullable-read helper
- preserve no-retry behavior for mixed null plus throttle and mixed timeout plus throttle passes
- extend the live devnet proof to reject false exhaustion accounting after recovery

Regression coverage

- message-only rate-limit errors recover through a second endpoint-set pass
- recovered status-429 and message-only passes leave exhaustion count unchanged
- retries-spent exhaustion is counted exactly once
- readContract recovers through the same endpoint-set policy
- mixed null plus 429 performs exactly one call per endpoint in either order
- existing adapter getBlockTimestamp recovery remains covered

Verification

- chain dependency build passed
- focused failover and adapter suites: 36 passed
- broader standalone chain run: 54 files and 999 tests passed, 4 skipped; the only suite unavailable locally was the real-Hardhat relay registry because this fresh worktree had no shared Hardhat context file
- devnet script syntax passed

The updated devnet script remains the live proof against a real node and two logical RPC endpoints.
