### PR TITLE
fix(agent): recover request-owned ACK routing

### DIFF
--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -916,7 +916,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       // through the full PeerResolver instead of raw DHT findPeer.
       // The dial fast-path (ProtocolRouter) already prefers
       // PeerResolver.resolve() on every attempt, but the outbox
-      // stall-walk (`messenger.maybeScheduleDhtWalk`) was hardcoded
+      // stall-walk (the Messenger peer-recovery scheduler) was hardcoded
       // to a DHT-only path — so an entry that timed out 5x because
       // its addresses were stale couldn't recover by consulting
       // agents-CG. Routing through PeerResolver picks up the

--- a/packages/agent/src/p2p/messenger.ts
+++ b/packages/agent/src/p2p/messenger.ts
@@ -372,9 +372,8 @@ export class Messenger {
    * Per-`(protocol, peer, messageId)` "first sendReliable invocation"
    * timestamp. Used to compute the SLO latency clock per the rc.9
    * plan: "sendReliable invoke → resolved {delivered:true} (includes
-   * queue + retries)". Cleared on delivery + on outbox expiry; on
-   * non-recoverable throw the entry leaks (acceptable — these are
-   * exceptional cases that the plan's overnight soak surfaces).
+   * queue + retries)". Cleared on delivery, outbox expiry, and any
+   * terminal/request-owned failure that has no durable retry owner.
    */
   private readonly firstAttemptAt = new Map<string, number>();
 
@@ -404,6 +403,13 @@ export class Messenger {
    * on still-fresh peerStore data).
    */
   private readonly lastDhtWalkAt = new Map<string, number>();
+
+  /**
+   * Active peer-resolution work by peer. Request-owned sends await this exact
+   * promise before returning failure to their external retry owner; durable
+   * outbox retries keep the historical fire-and-forget behavior.
+   */
+  private readonly dhtWalksInFlight = new Map<string, Promise<void>>();
 
   /**
    * Per-protocol classifier that decides whether a successful wire
@@ -746,10 +752,10 @@ export class Messenger {
         // to the request-scoped retry loop.
         this.firstAttemptAt.delete(sloK);
         // ACKCollector owns the retry schedule, but address refresh still
-        // belongs to Messenger. Trigger it immediately: request-owned retries
-        // commonly use fresh message ids, so no durable attempt counter exists
-        // that could ever reach the outbox stall threshold.
-        this.maybeScheduleDhtWalk(peerId, { kind: 'request-owned' }, errMsg);
+        // belongs to Messenger. Wait for the refresh (or its bounded failure)
+        // before returning control so the collector cannot exhaust its short
+        // retry window against the same stale peerStore state.
+        await this.scheduleDhtWalk(peerId, { kind: 'request-owned' }, errMsg);
         throw err;
       }
       const entry = outbox.enqueueFailure(
@@ -761,7 +767,7 @@ export class Messenger {
         this.clock(),
       );
       this.noteQueuedForSlo(protocolId);
-      this.maybeScheduleDhtWalk(peerId, { kind: 'outbox', attempts: entry.attempts }, errMsg);
+      void this.scheduleDhtWalk(peerId, { kind: 'outbox', attempts: entry.attempts }, errMsg);
       return {
         delivered: false,
         queued: true,
@@ -932,7 +938,7 @@ export class Messenger {
         this.clock(),
       );
       if (isRecoverableMessengerSendError(err, errMsg)) {
-        this.maybeScheduleDhtWalk(
+        void this.scheduleDhtWalk(
           entry.peer,
           { kind: 'outbox', attempts: updated.attempts },
           errMsg,
@@ -947,16 +953,13 @@ export class Messenger {
   }
 
   /**
-   * DHT-walk-on-stall recovery primitive (rc.9 PR-5). Fire a
-   * `resolvePeer` call in the background when an outbox entry hits
-   * `OUTBOX_STALL_THRESHOLD` attempts on an address-resolution
-   * error, subject to per-peer rate-limiting.
+   * DHT-walk-on-stall recovery primitive (rc.9 PR-5). Durable outbox callers
+   * fire it in the background after `OUTBOX_STALL_THRESHOLD`; request-owned
+   * callers await it so their external retry loop observes refreshed routing.
    *
-   * Fire-and-forget: never blocks the caller. The DHT walk's
-   * side-effect (populating `peerStore` for the peer) heals the
-   * next periodic-tick retry, not the
-   * current one. This is intentional — the current retry has
-   * already failed; the walk is for the next attempt.
+   * The current wire attempt has already failed. Resolution only prepares the
+   * next attempt, whether that is a periodic outbox tick or an ACKCollector
+   * retry. Concurrent request-owned callers share and await one per-peer walk.
    *
    * Guards:
    *   1. No-op when `resolvePeer` not wired.
@@ -970,24 +973,34 @@ export class Messenger {
    *   5. Time-bounded (`DHT_WALK_TIMEOUT_MS`) — failures logged,
    *      never bubble.
    */
-  private maybeScheduleDhtWalk(peerId: string, trigger: DhtWalkTrigger, errMsg: string): void {
-    if (!this.resolvePeer) return;
-    if (trigger.kind === 'outbox' && trigger.attempts < OUTBOX_STALL_THRESHOLD) return;
-    if (!shouldTriggerDhtWalk(errMsg)) return;
+  private scheduleDhtWalk(
+    peerId: string,
+    trigger: DhtWalkTrigger,
+    errMsg: string,
+  ): Promise<void> {
+    if (!this.resolvePeer) return Promise.resolve();
+    if (trigger.kind === 'outbox' && trigger.attempts < OUTBOX_STALL_THRESHOLD) {
+      return Promise.resolve();
+    }
+    if (!shouldTriggerDhtWalk(errMsg)) return Promise.resolve();
+
+    const activeWalk = this.dhtWalksInFlight.get(peerId);
+    if (activeWalk) return activeWalk;
+
     const last = this.lastDhtWalkAt.get(peerId);
     const now = this.clock();
-    if (last !== undefined && now - last < DHT_WALK_RATE_LIMIT_MS) return;
+    if (last !== undefined && now - last < DHT_WALK_RATE_LIMIT_MS) {
+      return Promise.resolve();
+    }
 
     this.lastDhtWalkAt.set(peerId, now);
     const signal = AbortSignal.timeout(DHT_WALK_TIMEOUT_MS);
     const reason = trigger.kind === 'outbox'
       ? `after ${trigger.attempts} stalled outbox attempts`
       : 'after a request-owned address failure';
-    // Fire-and-forget; never await. Any error swallowed + logged.
-    // The walk's value is its side-effect (peerStore population),
-    // not its return value, so we don't even need the resolved
-    // multiaddrs here.
-    void this.resolvePeer(peerId, { signal })
+    // Errors are swallowed after logging so a request-owned caller still
+    // receives the original transport failure, not a secondary DHT error.
+    const walk = this.resolvePeer(peerId, { signal })
       .then(() => {
         console.warn(
           `[Messenger] DHT walk completed for ${peerId.slice(-8)} ${reason} — peerStore should now be primed`,
@@ -998,7 +1011,14 @@ export class Messenger {
         console.warn(
           `[Messenger] DHT walk for ${peerId.slice(-8)} failed (${reason}): ${msg}`,
         );
+      })
+      .finally(() => {
+        if (this.dhtWalksInFlight.get(peerId) === walk) {
+          this.dhtWalksInFlight.delete(peerId);
+        }
       });
+    this.dhtWalksInFlight.set(peerId, walk);
+    return walk;
   }
 
   private clearDhtWalkRateLimitIfDrained(peerId: string): void {

--- a/packages/agent/src/p2p/messenger.ts
+++ b/packages/agent/src/p2p/messenger.ts
@@ -273,10 +273,6 @@ export type ThrowingReliableSendResult = Exclude<
 /** Internal ownership policy; public callers use distinct named methods. */
 type FramedFailurePolicy = 'durable-outbox' | 'request-owned';
 
-type DhtWalkTrigger =
-  | { kind: 'outbox'; attempts: number }
-  | { kind: 'request-owned' };
-
 /** Handler signature for `Messenger.register`. */
 export type ReliableHandler = (
   payload: Uint8Array,
@@ -747,35 +743,16 @@ export class Messenger {
         throw err;
       }
       if (failurePolicy === 'request-owned') {
-        // No durable row can later deliver or expire this request, so its SLO
-        // start marker has no future owner. Clear it before returning control
-        // to the request-scoped retry loop.
-        this.firstAttemptAt.delete(sloK);
-        // ACKCollector owns the retry schedule, but address refresh still
-        // belongs to Messenger. Wait for the refresh (or its bounded failure)
-        // before returning control so the collector cannot exhaust its short
-        // retry window against the same stale peerStore state.
-        await this.scheduleDhtWalk(peerId, { kind: 'request-owned' }, errMsg);
+        await this.handleRequestOwnedRecoverableFailure(peerId, errMsg, sloK);
         throw err;
       }
-      const entry = outbox.enqueueFailure(
+      return this.handleDurableRecoverableFailure({
         peerId,
         protocolId,
         messageId,
-        envelope,
+        payload: envelope,
         errMsg,
-        this.clock(),
-      );
-      this.noteQueuedForSlo(protocolId);
-      void this.scheduleDhtWalk(peerId, { kind: 'outbox', attempts: entry.attempts }, errMsg);
-      return {
-        delivered: false,
-        queued: true,
-        attempts: entry.attempts,
-        messageId,
-        error: errMsg,
-        nextAttemptAtMs: entry.nextAttemptAt,
-      };
+      });
     } finally {
       outbox.endAttempt(peerId, protocolId, messageId);
     }
@@ -938,11 +915,7 @@ export class Messenger {
         this.clock(),
       );
       if (isRecoverableMessengerSendError(err, errMsg)) {
-        void this.scheduleDhtWalk(
-          entry.peer,
-          { kind: 'outbox', attempts: updated.attempts },
-          errMsg,
-        );
+        this.scheduleOutboxPeerRecovery(entry.peer, updated.attempts, errMsg);
       }
       // A non-recoverable retry remains visible for operator intervention, but
       // advances on the backoff ladder so it cannot permanently occupy the
@@ -952,37 +925,67 @@ export class Messenger {
     }
   }
 
-  /**
-   * DHT-walk-on-stall recovery primitive (rc.9 PR-5). Durable outbox callers
-   * fire it in the background after `OUTBOX_STALL_THRESHOLD`; request-owned
-   * callers await it so their external retry loop observes refreshed routing.
-   *
-   * The current wire attempt has already failed. Resolution only prepares the
-   * next attempt, whether that is a periodic outbox tick or an ACKCollector
-   * retry. Concurrent request-owned callers share and await one per-peer walk.
-   *
-   * Guards:
-   *   1. No-op when `resolvePeer` not wired.
-   *   2. Durable outbox sends are a no-op below
-   *      `OUTBOX_STALL_THRESHOLD` attempts (don't spend a DHT walk on a
-   *      transient blip). Request-owned sends recover immediately because
-   *      their external retry loop has no durable attempt counter here.
-   *   3. No-op for non-address-resolution errors (DHT walk
-   *      doesn't fix stream resets or NO_RESERVATION-after-handshake).
-   *   4. Per-peer rate limit (`DHT_WALK_RATE_LIMIT_MS`).
-   *   5. Time-bounded (`DHT_WALK_TIMEOUT_MS`) — failures logged,
-   *      never bubble.
-   */
-  private scheduleDhtWalk(
+  /** Request-owned failures never create a durable row or leave an SLO owner. */
+  private async handleRequestOwnedRecoverableFailure(
     peerId: string,
-    trigger: DhtWalkTrigger,
     errMsg: string,
+    sloK: string,
+  ): Promise<void> {
+    this.firstAttemptAt.delete(sloK);
+    if (!shouldTriggerDhtWalk(errMsg)) return;
+    await this.resolvePeerOnce(peerId, 'after a request-owned address failure');
+  }
+
+  /** Durable failures enqueue first, then optionally schedule threshold recovery. */
+  private handleDurableRecoverableFailure(args: {
+    peerId: string;
+    protocolId: string;
+    messageId: string;
+    payload: Uint8Array;
+    errMsg: string;
+  }): Extract<ReliableSendResult, { delivered: false; queued: true }> {
+    const entry = this.outbox!.enqueueFailure(
+      args.peerId,
+      args.protocolId,
+      args.messageId,
+      args.payload,
+      args.errMsg,
+      this.clock(),
+    );
+    this.noteQueuedForSlo(args.protocolId);
+    this.scheduleOutboxPeerRecovery(args.peerId, entry.attempts, args.errMsg);
+    return {
+      delivered: false,
+      queued: true,
+      attempts: entry.attempts,
+      messageId: args.messageId,
+      error: args.errMsg,
+      nextAttemptAtMs: entry.nextAttemptAt,
+    };
+  }
+
+  /** Durable outbox recovery is thresholded and always background-owned. */
+  private scheduleOutboxPeerRecovery(
+    peerId: string,
+    attempts: number,
+    errMsg: string,
+  ): void {
+    if (attempts < OUTBOX_STALL_THRESHOLD || !shouldTriggerDhtWalk(errMsg)) return;
+    void this.resolvePeerOnce(peerId, `after ${attempts} stalled outbox attempts`);
+  }
+
+  /**
+   * One de-duplicated, rate-limited, bounded peer-resolution attempt. Ownership
+   * stays with the named caller: request-owned sends await this promise, while
+   * durable outbox paths deliberately discard it after attaching handlers.
+   * Resolver errors are logged and swallowed so they never replace the original
+   * transport error.
+   */
+  private resolvePeerOnce(
+    peerId: string,
+    reason: string,
   ): Promise<void> {
     if (!this.resolvePeer) return Promise.resolve();
-    if (trigger.kind === 'outbox' && trigger.attempts < OUTBOX_STALL_THRESHOLD) {
-      return Promise.resolve();
-    }
-    if (!shouldTriggerDhtWalk(errMsg)) return Promise.resolve();
 
     const activeWalk = this.dhtWalksInFlight.get(peerId);
     if (activeWalk) return activeWalk;
@@ -995,9 +998,6 @@ export class Messenger {
 
     this.lastDhtWalkAt.set(peerId, now);
     const signal = AbortSignal.timeout(DHT_WALK_TIMEOUT_MS);
-    const reason = trigger.kind === 'outbox'
-      ? `after ${trigger.attempts} stalled outbox attempts`
-      : 'after a request-owned address failure';
     // Errors are swallowed after logging so a request-owned caller still
     // receives the original transport failure, not a secondary DHT error.
     const walk = this.resolvePeer(peerId, { signal })

--- a/packages/agent/src/p2p/messenger.ts
+++ b/packages/agent/src/p2p/messenger.ts
@@ -270,6 +270,13 @@ export type ThrowingReliableSendResult = Exclude<
   { delivered: false; queued: true }
 >;
 
+/** Internal ownership policy; public callers use distinct named methods. */
+type FramedFailurePolicy = 'durable-outbox' | 'request-owned';
+
+type DhtWalkTrigger =
+  | { kind: 'outbox'; attempts: number }
+  | { kind: 'request-owned' };
+
 /** Handler signature for `Messenger.register`. */
 export type ReliableHandler = (
   payload: Uint8Array,
@@ -602,7 +609,7 @@ export class Messenger {
     payload: Uint8Array,
     opts: SendReliableOpts = {},
   ): Promise<ReliableSendResult> {
-    return this.sendFramed(peerId, protocolId, payload, opts, true);
+    return this.sendFramed(peerId, protocolId, payload, opts, 'durable-outbox');
   }
 
   /** Reliable framing/idempotency for bounded request-owned retries; never queues. */
@@ -612,15 +619,31 @@ export class Messenger {
     payload: Uint8Array,
     opts: SendReliableOpts = {},
   ): Promise<ThrowingReliableSendResult> {
-    return this.sendFramed(peerId, protocolId, payload, opts, false) as Promise<ThrowingReliableSendResult>;
+    return this.sendFramed(peerId, protocolId, payload, opts, 'request-owned');
   }
+
+  private sendFramed(
+    peerId: string,
+    protocolId: string,
+    payload: Uint8Array,
+    opts: SendReliableOpts,
+    failurePolicy: 'durable-outbox',
+  ): Promise<ReliableSendResult>;
+
+  private sendFramed(
+    peerId: string,
+    protocolId: string,
+    payload: Uint8Array,
+    opts: SendReliableOpts,
+    failurePolicy: 'request-owned',
+  ): Promise<ThrowingReliableSendResult>;
 
   private async sendFramed(
     peerId: string,
     protocolId: string,
     payload: Uint8Array,
     opts: SendReliableOpts,
-    queueRecoverableFailure: boolean,
+    failurePolicy: FramedFailurePolicy,
   ): Promise<ReliableSendResult> {
     this.requireSubstrate('sendReliable');
 
@@ -714,13 +737,19 @@ export class Messenger {
       // the outbox stays out of it because retrying an encoding
       // bug / unhandled protocol won't help.
       if (!isRecoverableMessengerSendError(err, errMsg)) {
+        this.firstAttemptAt.delete(sloK);
         throw err;
       }
-      if (!queueRecoverableFailure) {
+      if (failurePolicy === 'request-owned') {
         // No durable row can later deliver or expire this request, so its SLO
         // start marker has no future owner. Clear it before returning control
         // to the request-scoped retry loop.
         this.firstAttemptAt.delete(sloK);
+        // ACKCollector owns the retry schedule, but address refresh still
+        // belongs to Messenger. Trigger it immediately: request-owned retries
+        // commonly use fresh message ids, so no durable attempt counter exists
+        // that could ever reach the outbox stall threshold.
+        this.maybeScheduleDhtWalk(peerId, { kind: 'request-owned' }, errMsg);
         throw err;
       }
       const entry = outbox.enqueueFailure(
@@ -732,7 +761,7 @@ export class Messenger {
         this.clock(),
       );
       this.noteQueuedForSlo(protocolId);
-      this.maybeScheduleDhtWalk(peerId, entry.attempts, errMsg);
+      this.maybeScheduleDhtWalk(peerId, { kind: 'outbox', attempts: entry.attempts }, errMsg);
       return {
         delivered: false,
         queued: true,
@@ -903,7 +932,11 @@ export class Messenger {
         this.clock(),
       );
       if (isRecoverableMessengerSendError(err, errMsg)) {
-        this.maybeScheduleDhtWalk(entry.peer, updated.attempts, errMsg);
+        this.maybeScheduleDhtWalk(
+          entry.peer,
+          { kind: 'outbox', attempts: updated.attempts },
+          errMsg,
+        );
       }
       // A non-recoverable retry remains visible for operator intervention, but
       // advances on the backoff ladder so it cannot permanently occupy the
@@ -927,18 +960,19 @@ export class Messenger {
    *
    * Guards:
    *   1. No-op when `resolvePeer` not wired.
-   *   2. No-op below `OUTBOX_STALL_THRESHOLD` attempts (don't
-   *      spend a DHT walk on a transient blip the backoff would
-   *      have healed anyway).
+   *   2. Durable outbox sends are a no-op below
+   *      `OUTBOX_STALL_THRESHOLD` attempts (don't spend a DHT walk on a
+   *      transient blip). Request-owned sends recover immediately because
+   *      their external retry loop has no durable attempt counter here.
    *   3. No-op for non-address-resolution errors (DHT walk
    *      doesn't fix stream resets or NO_RESERVATION-after-handshake).
    *   4. Per-peer rate limit (`DHT_WALK_RATE_LIMIT_MS`).
    *   5. Time-bounded (`DHT_WALK_TIMEOUT_MS`) — failures logged,
    *      never bubble.
    */
-  private maybeScheduleDhtWalk(peerId: string, attempts: number, errMsg: string): void {
+  private maybeScheduleDhtWalk(peerId: string, trigger: DhtWalkTrigger, errMsg: string): void {
     if (!this.resolvePeer) return;
-    if (attempts < OUTBOX_STALL_THRESHOLD) return;
+    if (trigger.kind === 'outbox' && trigger.attempts < OUTBOX_STALL_THRESHOLD) return;
     if (!shouldTriggerDhtWalk(errMsg)) return;
     const last = this.lastDhtWalkAt.get(peerId);
     const now = this.clock();
@@ -946,6 +980,9 @@ export class Messenger {
 
     this.lastDhtWalkAt.set(peerId, now);
     const signal = AbortSignal.timeout(DHT_WALK_TIMEOUT_MS);
+    const reason = trigger.kind === 'outbox'
+      ? `after ${trigger.attempts} stalled outbox attempts`
+      : 'after a request-owned address failure';
     // Fire-and-forget; never await. Any error swallowed + logged.
     // The walk's value is its side-effect (peerStore population),
     // not its return value, so we don't even need the resolved
@@ -953,13 +990,13 @@ export class Messenger {
     void this.resolvePeer(peerId, { signal })
       .then(() => {
         console.warn(
-          `[Messenger] DHT walk completed for ${peerId.slice(-8)} after ${attempts} stalled outbox attempts — peerStore should now be primed`,
+          `[Messenger] DHT walk completed for ${peerId.slice(-8)} ${reason} — peerStore should now be primed`,
         );
       })
       .catch((err: unknown) => {
         const msg = err instanceof Error ? err.message : String(err);
         console.warn(
-          `[Messenger] DHT walk for ${peerId.slice(-8)} failed (attempts=${attempts}): ${msg}`,
+          `[Messenger] DHT walk for ${peerId.slice(-8)} failed (${reason}): ${msg}`,
         );
       });
   }

--- a/packages/agent/test/messenger-substrate.test.ts
+++ b/packages/agent/test/messenger-substrate.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   InMemoryMessageIdempotencyStore,
   InMemoryProtocolOutboxStore,
@@ -180,6 +180,64 @@ describe('Messenger.sendRequestOwned', () => {
     expect(outboxStore.size()).toBe(0);
     expect((messenger as any).firstAttemptAt.size).toBe(0);
     expect(resolvePeer.calls).toHaveLength(1);
+  });
+
+  it('does not return an address failure until slow DHT recovery can affect the next retry', async () => {
+    vi.useFakeTimers();
+    try {
+      let peerResolved = false;
+      const router = makeRouter(async () => {
+        if (!peerResolved) throw new Error('no valid addresses for peer');
+        return new Uint8Array([0x42]);
+      });
+      const resolvePeer = recorder(
+        async (_peerId: string, _opts: { signal: AbortSignal }): Promise<void> => {
+          await new Promise<void>((resolve) => setTimeout(resolve, 5_000));
+          peerResolved = true;
+        },
+      );
+      const { messenger, outboxStore } = makeSubstrate({ router, resolvePeer });
+
+      let firstSettled = false;
+      const firstOutcome = messenger.sendRequestOwned(
+        PEER_A,
+        PROTO,
+        new Uint8Array([1]),
+        { messageId: FIXED_MSG_ID },
+      ).then(
+        (value) => ({ value, error: undefined }),
+        (error: unknown) => ({ value: undefined, error }),
+      ).finally(() => {
+        firstSettled = true;
+      });
+
+      // Longer than ACKCollector's historical ~3s retry window: the send still
+      // owns its failure until peerStore refresh completes, so no retry can run
+      // against the same stale routing state.
+      await vi.advanceTimersByTimeAsync(3_001);
+      expect(firstSettled).toBe(false);
+      expect(router.send.calls).toHaveLength(1);
+      expect(outboxStore.size()).toBe(0);
+
+      await vi.advanceTimersByTimeAsync(1_999);
+      const first = await firstOutcome;
+      expect(first.value).toBeUndefined();
+      expect(first.error).toBeInstanceOf(Error);
+      expect((first.error as Error).message).toBe('no valid addresses for peer');
+      expect(resolvePeer.calls).toHaveLength(1);
+
+      const retried = await messenger.sendRequestOwned(
+        PEER_A,
+        PROTO,
+        new Uint8Array([1]),
+        { messageId: '00000000-0000-4000-8000-000000000002' },
+      );
+      expect(retried.delivered).toBe(true);
+      expect(router.send.calls).toHaveLength(2);
+      expect(outboxStore.size()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/packages/agent/test/messenger-substrate.test.ts
+++ b/packages/agent/test/messenger-substrate.test.ts
@@ -77,7 +77,10 @@ function makeRouter(
   return router;
 }
 
-function makeSubstrate(overrides: { router?: RouterDouble } = {}) {
+function makeSubstrate(overrides: {
+  router?: RouterDouble;
+  resolvePeer?: (peerId: string, opts: { signal: AbortSignal }) => Promise<void>;
+} = {}) {
   const router = overrides.router ?? makeRouter();
   const idempotencyStore = new InMemoryMessageIdempotencyStore();
   const outboxStore = new InMemoryProtocolOutboxStore({
@@ -92,6 +95,7 @@ function makeSubstrate(overrides: { router?: RouterDouble } = {}) {
     backoffs: [10],
     maxAgeMs: 60_000,
     clock,
+    resolvePeer: overrides.resolvePeer,
   });
   return { messenger, router, idempotencyStore, outboxStore, clock };
 }
@@ -154,7 +158,10 @@ describe('Messenger.sendRequestOwned', () => {
     const router = makeRouter(async () => {
       throw new Error('no valid addresses for peer');
     });
-    const { messenger, outboxStore } = makeSubstrate({ router });
+    const resolvePeer = recorder(
+      async (_peerId: string, _opts: { signal: AbortSignal }): Promise<void> => undefined,
+    );
+    const { messenger, outboxStore } = makeSubstrate({ router, resolvePeer });
 
     await expect(messenger.sendRequestOwned(PEER_A, PROTO, new Uint8Array([1]), {
       messageId: FIXED_MSG_ID,
@@ -162,6 +169,17 @@ describe('Messenger.sendRequestOwned', () => {
     expect(outboxStore.size()).toBe(0);
     expect(() => decodeReliableEnvelope(router.send.calls[0][2] as Uint8Array)).not.toThrow();
     expect((messenger as any).firstAttemptAt.size).toBe(0);
+    expect(resolvePeer.calls).toEqual([[PEER_A, { signal: expect.any(AbortSignal) }]]);
+
+    // ACKCollector retries with a fresh message id. Recovery remains
+    // request-owned and rate-limited rather than creating an outbox attempt
+    // counter just to reach the normal durable-send DHT threshold.
+    await expect(messenger.sendRequestOwned(PEER_A, PROTO, new Uint8Array([1]), {
+      messageId: '00000000-0000-4000-8000-000000000002',
+    })).rejects.toThrow('no valid addresses for peer');
+    expect(outboxStore.size()).toBe(0);
+    expect((messenger as any).firstAttemptAt.size).toBe(0);
+    expect(resolvePeer.calls).toHaveLength(1);
   });
 });
 
@@ -245,6 +263,7 @@ describe('Messenger.sendReliable (failure / outbox)', () => {
       }),
     ).rejects.toThrow(/something unexpected/);
     expect(outboxStore.size()).toBe(0);
+    expect((messenger as any).firstAttemptAt.size).toBe(0);
   });
 
   it('releases the inflight slot even when the send rejects', async () => {

--- a/packages/agent/test/messenger-substrate.test.ts
+++ b/packages/agent/test/messenger-substrate.test.ts
@@ -239,6 +239,37 @@ describe('Messenger.sendRequestOwned', () => {
       vi.useRealTimers();
     }
   });
+
+  it('preserves the transport failure when awaited peer recovery also fails', async () => {
+    const transportError = new Error('no valid addresses for peer');
+    const recoveryError = new Error('DHT walk timed out');
+    const router = makeRouter(async () => {
+      throw transportError;
+    });
+    const resolvePeer = recorder(
+      async (_peerId: string, _opts: { signal: AbortSignal }): Promise<void> => {
+        throw recoveryError;
+      },
+    );
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      const { messenger, outboxStore } = makeSubstrate({ router, resolvePeer });
+
+      await expect(messenger.sendRequestOwned(
+        PEER_A,
+        PROTO,
+        new Uint8Array([1]),
+        { messageId: FIXED_MSG_ID },
+      )).rejects.toBe(transportError);
+
+      expect(resolvePeer.calls).toHaveLength(1);
+      expect(outboxStore.size()).toBe(0);
+      expect((messenger as any).firstAttemptAt.size).toBe(0);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('DHT walk timed out'));
+    } finally {
+      warn.mockRestore();
+    }
+  });
 });
 
 describe('Messenger.sendReliable (sender-side idempotency)', () => {

--- a/packages/agent/test/v10-ack-provider-wiring.test.ts
+++ b/packages/agent/test/v10-ack-provider-wiring.test.ts
@@ -291,6 +291,29 @@ describe('DKGAgent.createV10ACKProvider — structured ACK verifier wiring (PR #
     });
   });
 
+  it('returns request-owned address failures to the ACK collector retry loop', async () => {
+    const boot = await bootProviderAgent({ ackSendTimeoutMs: 60_000 });
+    agent = boot.agent;
+    const internals = boot.internals;
+    const payload = new Uint8Array([1, 2, 3]);
+    const sendRequestOwned = vi.fn(async () => {
+      throw new Error('no valid addresses for peer');
+    });
+    internals.messenger = { sendRequestOwned };
+
+    internals.createV10ACKProvider('test-cg');
+    const publishDeps = capturedAckCollectorDeps[0] as ACKCollectorDepsCapture;
+    await expect(
+      publishDeps.sendP2P!('peer-a', '/dkg/test/storage-ack', payload),
+    ).rejects.toThrow('no valid addresses for peer');
+    expect(sendRequestOwned).toHaveBeenCalledWith(
+      'peer-a',
+      '/dkg/test/storage-ack',
+      payload,
+      { timeoutMs: 60_000 },
+    );
+  });
+
   it('normalizes legacy handler-only ACK timing before publish sendP2P wiring', async () => {
     const boot = await bootProviderAgent({ ackHandlerDeadlineMs: 55_000 });
     agent = boot.agent;

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -64,6 +64,7 @@ export default defineConfig({
       "test/network-admission-coordinator.test.ts",
       "test/explicit-connect-admission.test.ts",
       "test/sync-responder-agents-meta-serve-skip.test.ts",
+      "test/messenger-substrate.test.ts",
     ],
     testTimeout: 60_000,
     maxWorkers: 1,

--- a/scripts/devnet-lib.sh
+++ b/scripts/devnet-lib.sh
@@ -37,13 +37,11 @@ body_of() { printf '%s' "$1" | tail -n +2; }
 field() { J="$2" node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>{let j;try{j=JSON.parse(d)}catch(e){process.stdout.write("");return}let v=j;for(const k of process.env.J.split("."))v=(v==null?undefined:v[k]);process.stdout.write(v==null?"":(typeof v==="object"?JSON.stringify(v):String(v)))})' <<<"$1"; }
 
 # Protocol constants ---------------------------------------------------------
-# Resolve a string constant from the canonical core source. Callers may set
-# CORE_CONSTANTS_TS explicitly; otherwise resolve it relative to this library.
+# Resolve a string constant through the built core package API. This is a real
+# module/export boundary: harmless TypeScript formatting changes cannot break
+# devnet scripts that consume canonical wire identifiers.
 protocol_const() {
-  local const_name="$1" constants_file="${CORE_CONSTANTS_TS:-}" lib_dir
-  if [[ -z "$constants_file" ]]; then
-    lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-    constants_file="$lib_dir/../packages/core/src/constants.ts"
-  fi
-  sed -nE "s|^export const ${const_name} = '([^']+)';$|\1|p" "$constants_file" 2>/dev/null | head -n 1
+  local const_name="$1" lib_dir
+  lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  node "$lib_dir/lib/core-constant.mjs" "$const_name"
 }

--- a/scripts/devnet-lib.sh
+++ b/scripts/devnet-lib.sh
@@ -35,3 +35,15 @@ body_of() { printf '%s' "$1" | tail -n +2; }
 
 # JSON: field <json> <dot.path> -> value ("" if missing; objects/arrays JSON'd) -
 field() { J="$2" node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>{let j;try{j=JSON.parse(d)}catch(e){process.stdout.write("");return}let v=j;for(const k of process.env.J.split("."))v=(v==null?undefined:v[k]);process.stdout.write(v==null?"":(typeof v==="object"?JSON.stringify(v):String(v)))})' <<<"$1"; }
+
+# Protocol constants ---------------------------------------------------------
+# Resolve a string constant from the canonical core source. Callers may set
+# CORE_CONSTANTS_TS explicitly; otherwise resolve it relative to this library.
+protocol_const() {
+  local const_name="$1" constants_file="${CORE_CONSTANTS_TS:-}" lib_dir
+  if [[ -z "$constants_file" ]]; then
+    lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    constants_file="$lib_dir/../packages/core/src/constants.ts"
+  fi
+  sed -nE "s|^export const ${const_name} = '([^']+)';$|\1|p" "$constants_file" 2>/dev/null | head -n 1
+}

--- a/scripts/devnet-test-issue-1577-ack-outbox-ownership.sh
+++ b/scripts/devnet-test-issue-1577-ack-outbox-ownership.sh
@@ -33,11 +33,13 @@ done
 [[ -f "$DB" ]] || fail "publisher database missing: $DB"
 
 count_ack_rows() {
-  DB="$DB" \
-    PROTOCOL_STORAGE_ACK="$PROTOCOL_STORAGE_ACK" \
-    PROTOCOL_STORAGE_ACK_V2="$PROTOCOL_STORAGE_ACK_V2" \
-    PROTOCOL_STORAGE_UPDATE_ACK="$PROTOCOL_STORAGE_UPDATE_ACK" \
-    node --input-type=module <<'NODE'
+  (
+    cd "$ROOT/packages/cli"
+    DB="$DB" \
+      PROTOCOL_STORAGE_ACK="$PROTOCOL_STORAGE_ACK" \
+      PROTOCOL_STORAGE_ACK_V2="$PROTOCOL_STORAGE_ACK_V2" \
+      PROTOCOL_STORAGE_UPDATE_ACK="$PROTOCOL_STORAGE_UPDATE_ACK" \
+      node --input-type=module <<'NODE'
 import Database from 'better-sqlite3';
 const db = new Database(process.env.DB, { readonly: true });
 const row = db.prepare(`SELECT COUNT(*) AS n FROM protocol_outbox
@@ -48,6 +50,7 @@ const row = db.prepare(`SELECT COUNT(*) AS n FROM protocol_outbox
   );
 process.stdout.write(String(row.n)); db.close();
 NODE
+  )
 }
 baseline="$(count_ack_rows)"
 

--- a/scripts/devnet-test-issue-1577-ack-outbox-ownership.sh
+++ b/scripts/devnet-test-issue-1577-ack-outbox-ownership.sh
@@ -20,17 +20,69 @@ cleanup() {
 trap cleanup EXIT INT TERM
 . "$ROOT/scripts/devnet-lib.sh"
 
+PROTOCOL_STORAGE_ACK="$(protocol_const PROTOCOL_STORAGE_ACK)"
+PROTOCOL_STORAGE_ACK_V2="$(protocol_const PROTOCOL_STORAGE_ACK_V2)"
+PROTOCOL_STORAGE_UPDATE_ACK="$(protocol_const PROTOCOL_STORAGE_UPDATE_ACK)"
+[[ -n "$PROTOCOL_STORAGE_ACK" ]] || fail "canonical PROTOCOL_STORAGE_ACK is unavailable"
+[[ -n "$PROTOCOL_STORAGE_ACK_V2" ]] || fail "canonical PROTOCOL_STORAGE_ACK_V2 is unavailable"
+[[ -n "$PROTOCOL_STORAGE_UPDATE_ACK" ]] || fail "canonical PROTOCOL_STORAGE_UPDATE_ACK is unavailable"
+
+# Compiled-package integration preflight: a request-owned address failure must
+# trigger routing recovery immediately while keeping durable ownership empty.
+ROOT="$ROOT" node --input-type=module <<'NODE'
+import { pathToFileURL } from 'node:url';
+const root = process.env.ROOT;
+const { Messenger } = await import(pathToFileURL(`${root}/packages/agent/dist/p2p/messenger.js`).href);
+const {
+  InMemoryMessageIdempotencyStore,
+  InMemoryProtocolOutboxStore,
+} = await import(pathToFileURL(`${root}/packages/core/dist/index.js`).href);
+const outboxStore = new InMemoryProtocolOutboxStore({ backoffs: [10], maxAgeMs: 60_000 });
+let resolveCalls = 0;
+const messenger = new Messenger({
+  router: {
+    send: async () => { throw new Error('no valid addresses for peer'); },
+    register: () => undefined,
+  },
+  idempotencyStore: new InMemoryMessageIdempotencyStore(),
+  outboxStore,
+  resolvePeer: async () => { resolveCalls += 1; },
+});
+let failed = false;
+try {
+  await messenger.sendRequestOwned('12D3KooWIssue1577Target', '/dkg/test/storage-ack', new Uint8Array([1]));
+} catch {
+  failed = true;
+}
+await Promise.resolve();
+if (!failed || resolveCalls !== 1 || outboxStore.size() !== 0) {
+  throw new Error(`request-owned recovery invariant failed: failed=${failed} resolveCalls=${resolveCalls} outbox=${outboxStore.size()}`);
+}
+NODE
+if [[ "${ACK_OUTBOX_PREFLIGHT_ONLY:-0}" == 1 ]]; then
+  echo "[#1577] PASS: request-owned address recovery fired with no durable outbox row"
+  exit 0
+fi
+
 for n in 1 2 3 4 5; do
   [[ "$(code_of "$(api "$n" GET /api/status)")" == 200 ]] || fail "node$n is not ready (need 4 cores + edge)"
 done
 [[ -f "$DB" ]] || fail "publisher database missing: $DB"
 
 count_ack_rows() {
-  DB="$DB" node --input-type=module <<'NODE'
+  DB="$DB" \
+    PROTOCOL_STORAGE_ACK="$PROTOCOL_STORAGE_ACK" \
+    PROTOCOL_STORAGE_ACK_V2="$PROTOCOL_STORAGE_ACK_V2" \
+    PROTOCOL_STORAGE_UPDATE_ACK="$PROTOCOL_STORAGE_UPDATE_ACK" \
+    node --input-type=module <<'NODE'
 import Database from 'better-sqlite3';
 const db = new Database(process.env.DB, { readonly: true });
 const row = db.prepare(`SELECT COUNT(*) AS n FROM protocol_outbox
-  WHERE protocol IN ('/dkg/10.0.1/storage-ack','/dkg/10.0.2/storage-ack','/dkg/10.0.1/storage-update-ack')`).get();
+  WHERE protocol IN (?, ?, ?)`).get(
+    process.env.PROTOCOL_STORAGE_ACK,
+    process.env.PROTOCOL_STORAGE_ACK_V2,
+    process.env.PROTOCOL_STORAGE_UPDATE_ACK,
+  );
 process.stdout.write(String(row.n)); db.close();
 NODE
 }

--- a/scripts/devnet-test-issue-1577-ack-outbox-ownership.sh
+++ b/scripts/devnet-test-issue-1577-ack-outbox-ownership.sh
@@ -27,43 +27,6 @@ PROTOCOL_STORAGE_UPDATE_ACK="$(protocol_const PROTOCOL_STORAGE_UPDATE_ACK)"
 [[ -n "$PROTOCOL_STORAGE_ACK_V2" ]] || fail "canonical PROTOCOL_STORAGE_ACK_V2 is unavailable"
 [[ -n "$PROTOCOL_STORAGE_UPDATE_ACK" ]] || fail "canonical PROTOCOL_STORAGE_UPDATE_ACK is unavailable"
 
-# Compiled-package integration preflight: a request-owned address failure must
-# trigger routing recovery immediately while keeping durable ownership empty.
-ROOT="$ROOT" node --input-type=module <<'NODE'
-import { pathToFileURL } from 'node:url';
-const root = process.env.ROOT;
-const { Messenger } = await import(pathToFileURL(`${root}/packages/agent/dist/p2p/messenger.js`).href);
-const {
-  InMemoryMessageIdempotencyStore,
-  InMemoryProtocolOutboxStore,
-} = await import(pathToFileURL(`${root}/packages/core/dist/index.js`).href);
-const outboxStore = new InMemoryProtocolOutboxStore({ backoffs: [10], maxAgeMs: 60_000 });
-let resolveCalls = 0;
-const messenger = new Messenger({
-  router: {
-    send: async () => { throw new Error('no valid addresses for peer'); },
-    register: () => undefined,
-  },
-  idempotencyStore: new InMemoryMessageIdempotencyStore(),
-  outboxStore,
-  resolvePeer: async () => { resolveCalls += 1; },
-});
-let failed = false;
-try {
-  await messenger.sendRequestOwned('12D3KooWIssue1577Target', '/dkg/test/storage-ack', new Uint8Array([1]));
-} catch {
-  failed = true;
-}
-await Promise.resolve();
-if (!failed || resolveCalls !== 1 || outboxStore.size() !== 0) {
-  throw new Error(`request-owned recovery invariant failed: failed=${failed} resolveCalls=${resolveCalls} outbox=${outboxStore.size()}`);
-}
-NODE
-if [[ "${ACK_OUTBOX_PREFLIGHT_ONLY:-0}" == 1 ]]; then
-  echo "[#1577] PASS: request-owned address recovery fired with no durable outbox row"
-  exit 0
-fi
-
 for n in 1 2 3 4 5; do
   [[ "$(code_of "$(api "$n" GET /api/status)")" == 200 ]] || fail "node$n is not ready (need 4 cores + edge)"
 done

--- a/scripts/lib/__tests__/core-constant.test.mjs
+++ b/scripts/lib/__tests__/core-constant.test.mjs
@@ -1,5 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 
 import {
   requireStringExport,
@@ -25,6 +27,19 @@ test('resolveCoreStringConstant imports a real module export', async () => {
       '/dkg/test/storage-ack',
     );
   });
+});
+
+test('default resolver and CLI read the canonical built core export', async () => {
+  const expected = '/dkg/10.0.1/storage-ack';
+  assert.equal(await resolveCoreStringConstant('PROTOCOL_STORAGE_ACK'), expected);
+
+  const scriptPath = fileURLToPath(new URL('../core-constant.mjs', import.meta.url));
+  const result = spawnSync(process.execPath, [scriptPath, 'PROTOCOL_STORAGE_ACK'], {
+    encoding: 'utf8',
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stderr, '');
+  assert.equal(result.stdout, expected);
 });
 
 test('missing and non-string exports fail loudly', () => {

--- a/scripts/lib/__tests__/core-constant.test.mjs
+++ b/scripts/lib/__tests__/core-constant.test.mjs
@@ -1,0 +1,39 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  requireStringExport,
+  resolveCoreStringConstant,
+} from '../core-constant.mjs';
+
+test('requireStringExport reads the module value without depending on source formatting', () => {
+  assert.equal(
+    requireStringExport({ PROTOCOL_STORAGE_ACK: '/dkg/test/storage-ack' }, 'PROTOCOL_STORAGE_ACK'),
+    '/dkg/test/storage-ack',
+  );
+});
+
+test('resolveCoreStringConstant imports a real module export', async () => {
+  const source = `
+    // Deliberately unlike the TypeScript source spelling that the old sed parser required.
+    export const PROTOCOL_STORAGE_ACK = "/dkg/test/storage-ack";
+  `;
+  const moduleUrl = new URL(`data:text/javascript,${encodeURIComponent(source)}`);
+  await assert.doesNotReject(async () => {
+    assert.equal(
+      await resolveCoreStringConstant('PROTOCOL_STORAGE_ACK', moduleUrl),
+      '/dkg/test/storage-ack',
+    );
+  });
+});
+
+test('missing and non-string exports fail loudly', () => {
+  assert.throws(
+    () => requireStringExport({}, 'PROTOCOL_STORAGE_ACK'),
+    /Core export PROTOCOL_STORAGE_ACK is unavailable/,
+  );
+  assert.throws(
+    () => requireStringExport({ PROTOCOL_STORAGE_ACK: 42 }, 'PROTOCOL_STORAGE_ACK'),
+    /must be a non-empty string/,
+  );
+});

--- a/scripts/lib/core-constant.mjs
+++ b/scripts/lib/core-constant.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const DEFAULT_CORE_MODULE_URL = new URL('../../packages/core/dist/index.js', import.meta.url);
+
+export function requireStringExport(moduleNamespace, exportName) {
+  if (!Object.prototype.hasOwnProperty.call(moduleNamespace, exportName)) {
+    throw new Error(`Core export ${exportName} is unavailable`);
+  }
+  const value = moduleNamespace[exportName];
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`Core export ${exportName} must be a non-empty string`);
+  }
+  return value;
+}
+
+export async function resolveCoreStringConstant(
+  exportName,
+  moduleUrl = DEFAULT_CORE_MODULE_URL,
+) {
+  const moduleNamespace = await import(moduleUrl.href);
+  return requireStringExport(moduleNamespace, exportName);
+}
+
+async function main() {
+  const exportName = process.argv[2];
+  if (!exportName) {
+    throw new Error('Usage: core-constant.mjs <export-name>');
+  }
+  process.stdout.write(await resolveCoreStringConstant(exportName));
+}
+
+const invokedPath = process.argv[1]
+  ? pathToFileURL(resolve(process.argv[1])).href
+  : undefined;
+if (invokedPath === import.meta.url) {
+  main().catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`[core-constant] ${message}`);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary

- await the shared, rate-limited per-peer resolution lifecycle before returning request-owned address failures, so ACKCollector retries can observe refreshed routing
- keep durable outbox recovery thresholded and fire-and-forget; request-owned failures still throw, create no outbox row, and clear their SLO marker
- replace the boolean/cast failure-policy path with named typed overloads
- resolve StorageACK IDs through the built core module export boundary instead of parsing TypeScript source
- add unit and ACK wiring regressions plus retain the real live-devnet ownership scenario

Follow-up to #1624 and #1577.

## Verification

- `pnpm --filter @origintrail-official/dkg-agent... run build` — 9 packages passed
- `pnpm --filter @origintrail-official/dkg-agent run test:unit` — 52 files, 582 passed
- focused Messenger substrate suite — 46 passed
- `node --test scripts/lib/__tests__/core-constant.test.mjs` — 3 passed
- built core module exports verified for all three StorageACK protocol IDs
- `bash -n scripts/devnet-lib.sh scripts/devnet-test-issue-1577-ack-outbox-ownership.sh`

The live-devnet script remains focused on the real five-node flow; the compiled in-shell fixture and preflight-only mode were removed.