### PR TITLE
refactor(cli): centralize Edge restart verification

### DIFF
--- a/packages/cli/src/cli-helpers.ts
+++ b/packages/cli/src/cli-helpers.ts
@@ -1,9 +1,8 @@
 import { Command } from 'commander';
-import { readFileSync, existsSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import { createInterface } from 'node:readline';
 import { spawn, execSync } from 'node:child_process';
 import { createReadStream } from 'node:fs';
-import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { readFile, writeFile, unlink, appendFile } from 'node:fs/promises';
 import { ethers } from 'ethers';
@@ -23,12 +22,12 @@ import {
   readPid, readApiPort, isProcessRunning, dkgDir, logPath, ensureDkgDir, removeApiPort,
   apiPortPath,
   loadNetworkConfig, loadProjectConfig, resolveAutoUpdateConfig, resolveAutoUpdateSource, resolveChainConfig,
-  releasesDir, activeSlot, swapSlot,
-  slotEntryPoint, isStandaloneInstall, repoDir, isDkgMonorepo,
+  activeSlot, swapSlot,
+  isStandaloneInstall, repoDir, isDkgMonorepo,
   resolveContextGraphs, resolveNetworkDefaultContextGraphs,
-  readNodeRoleFromConfigSync,
   type AutoUpdateConfig,
 } from './config.js';
+import { resolveDaemonEntryPoint } from './daemon-entrypoint.js';
 import { ApiClient } from './api-client.js';
 import { parsePositiveIntegerOption, parsePositiveMsOption } from './cli-option-parsers.js';
 import { promptStoreBackend, applyStoreFlagsToConfig } from './store-wizard.js';
@@ -181,47 +180,6 @@ async function loadQuadsFromInput(
 
   console.error(`Provide --file (${rdfParser.supportedExtensions().join(', ')}), --triples, or --subject/--predicate/--object`);
   process.exit(1);
-}
-
-/**
- * Resolve the daemon entry point passed to spawned worker processes.
- *
- * OT-RFC-41 §4.1 / Bundle B1a: Edge nodes run from the npm-global
- * install (`import.meta.url`). Core nodes keep using blue-green
- * slots (`~/.dkg/releases/current`). The role gate is applied here
- * because the supervisor spawns workers via this entry point on
- * every restart — without the gate, an Edge node that had legacy
- * slots from a pre-rc.12 install would keep running the stale slot
- * forever even after `npm install -g` updated the global.
- */
-/**
- * Absolute path to THIS CLI's own entrypoint module, used to respawn the
- * daemon worker. `resolveDaemonEntryPoint` lives in `cli-helpers`, a sibling
- * of the entry module (`cli.ts` → `cli.js` after `tsc`), so the entry is
- * resolved relative to this file and the extension that actually exists is
- * picked: a built install runs `cli.js`, while running from source (tsx /
- * ts-node) runs `cli.ts`. Hardcoding `.js` would respawn a nonexistent
- * `src/cli.js` under source mode (#962 review). This mirrors the pre-split
- * behavior where the helper lived in `cli.ts` and returned its own
- * `import.meta.url` — i.e. the real current entrypoint in either mode.
- */
-function cliEntryPointPath(): string {
-  const builtEntry = fileURLToPath(new URL('./cli.js', import.meta.url));
-  if (existsSync(builtEntry)) return builtEntry;
-  const sourceEntry = fileURLToPath(new URL('./cli.ts', import.meta.url));
-  if (existsSync(sourceEntry)) return sourceEntry;
-  return builtEntry;
-}
-
-function resolveDaemonEntryPoint(): string {
-  if (process.env.DKG_NO_BLUE_GREEN) return cliEntryPointPath();
-  if (readNodeRoleFromConfigSync() === 'edge') return cliEntryPointPath();
-  const rDir = releasesDir();
-  if (existsSync(rDir)) {
-    const entry = slotEntryPoint(join(rDir, 'current'));
-    if (entry) return entry;
-  }
-  return cliEntryPointPath();
 }
 
 function probeHostForApiHost(apiHost: string | undefined): string {
@@ -442,4 +400,3 @@ export {
   stopDaemonIfRunning,
 };
 export type { ActionOpts, CatchupStatusCommandOptions };
-

--- a/packages/cli/src/cli-supervisor.ts
+++ b/packages/cli/src/cli-supervisor.ts
@@ -11,10 +11,7 @@ import {
 import {
   sleep, withSelectedDkgHome, selectedDkgHomeForEnv, probeHostForApiHost,
 } from './cli-helpers.js';
-import {
-  daemonRestartCommandArgs,
-  resolveDaemonRestartCommand,
-} from './daemon-entrypoint.js';
+import { resolveDaemonNodeCommand } from './daemon-entrypoint.js';
 
 async function appendSupervisorLog(message: string): Promise<void> {
   await ensureDkgDir();
@@ -103,10 +100,10 @@ async function runDaemonSupervisor(): Promise<void> {
         `[supervisor] could not clear stale api.port before spawn: ${err?.message ?? String(err)}`,
       );
     });
-    const restartCommand = resolveDaemonRestartCommand();
+    const daemonCommand = resolveDaemonNodeCommand('daemon-worker');
     const child = spawn(
-      restartCommand.nodeExecutable,
-      daemonRestartCommandArgs(restartCommand, 'daemon-worker'),
+      daemonCommand.executable,
+      daemonCommand.args,
       {
         stdio: ['ignore', 'ignore', 'ignore'],
         env: withSelectedDkgHome(process.env),
@@ -169,10 +166,10 @@ async function runForegroundSupervisor(childEnv: NodeJS.ProcessEnv = process.env
       );
     });
 
-    const restartCommand = resolveDaemonRestartCommand();
+    const daemonCommand = resolveDaemonNodeCommand('daemon-foreground-worker');
     currentChild = spawn(
-      restartCommand.nodeExecutable,
-      daemonRestartCommandArgs(restartCommand, 'daemon-foreground-worker'),
+      daemonCommand.executable,
+      daemonCommand.args,
       {
         stdio: 'inherit',
         env: childEnv,

--- a/packages/cli/src/cli-supervisor.ts
+++ b/packages/cli/src/cli-supervisor.ts
@@ -9,8 +9,12 @@ import {
   isLivenessProbeEnabled, startLivenessWatcher, LIVENESS_CONSECUTIVE_FAILURES_TO_KILL,
 } from './daemon/supervisor-liveness.js';
 import {
-  sleep, resolveDaemonEntryPoint, withSelectedDkgHome, selectedDkgHomeForEnv, probeHostForApiHost,
+  sleep, withSelectedDkgHome, selectedDkgHomeForEnv, probeHostForApiHost,
 } from './cli-helpers.js';
+import {
+  daemonRestartCommandArgs,
+  resolveDaemonRestartCommand,
+} from './daemon-entrypoint.js';
 
 async function appendSupervisorLog(message: string): Promise<void> {
   await ensureDkgDir();
@@ -99,9 +103,10 @@ async function runDaemonSupervisor(): Promise<void> {
         `[supervisor] could not clear stale api.port before spawn: ${err?.message ?? String(err)}`,
       );
     });
+    const restartCommand = resolveDaemonRestartCommand();
     const child = spawn(
-      process.execPath,
-      [...process.execArgv, resolveDaemonEntryPoint(), 'daemon-worker'],
+      restartCommand.nodeExecutable,
+      daemonRestartCommandArgs(restartCommand, 'daemon-worker'),
       {
         stdio: ['ignore', 'ignore', 'ignore'],
         env: withSelectedDkgHome(process.env),
@@ -164,9 +169,10 @@ async function runForegroundSupervisor(childEnv: NodeJS.ProcessEnv = process.env
       );
     });
 
+    const restartCommand = resolveDaemonRestartCommand();
     currentChild = spawn(
-      process.execPath,
-      [...process.execArgv, resolveDaemonEntryPoint(), 'daemon-foreground-worker'],
+      restartCommand.nodeExecutable,
+      daemonRestartCommandArgs(restartCommand, 'daemon-foreground-worker'),
       {
         stdio: 'inherit',
         env: childEnv,
@@ -214,4 +220,3 @@ export {
   runDaemonSupervisor,
   runForegroundSupervisor,
 };
-

--- a/packages/cli/src/commands/lifecycle.ts
+++ b/packages/cli/src/commands/lifecycle.ts
@@ -61,7 +61,6 @@ import {
   parseOptionalVerifyTimeoutOption,
   loadStructuredFile,
   loadQuadsFromInput,
-  resolveDaemonEntryPoint,
   probeHostForApiHost,
   selectedDkgHomeForEnv,
   withSelectedDkgHome,
@@ -102,6 +101,7 @@ import {
   runDaemonSupervisor,
   runForegroundSupervisor,
 } from '../cli-supervisor.js';
+import { resolveDaemonNodeCommand } from '../daemon-entrypoint.js';
 
 export function registerLifecycleCommands(program: Command): void {
 // ─── dkg start ───────────────────────────────────────────────────────
@@ -193,11 +193,12 @@ program
       return;
     }
 
-    // Spawn detached background supervisor via releases/current symlink
-    const entryPoint = resolveDaemonEntryPoint();
+    // Spawn the detached supervisor through the same canonical command
+    // boundary used for worker restarts and update verification.
+    const daemonCommand = resolveDaemonNodeCommand('daemon-supervisor');
     const child = spawn(
-      process.execPath,
-      [...process.execArgv, entryPoint, 'daemon-supervisor'],
+      daemonCommand.executable,
+      daemonCommand.args,
       {
         detached: true,
         stdio: ['ignore', 'ignore', 'ignore'],

--- a/packages/cli/src/daemon-entrypoint.ts
+++ b/packages/cli/src/daemon-entrypoint.ts
@@ -1,0 +1,65 @@
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  readNodeRoleFromConfigSync,
+  releasesDir,
+  slotEntryPoint,
+} from './config.js';
+
+/** Canonical Node command prefix used to start or probe this daemon entrypoint. */
+export interface DaemonRestartCommand {
+  nodeExecutable: string;
+  nodeExecArgv: readonly string[];
+  restartEntryPoint: string;
+}
+
+/**
+ * Absolute path to THIS CLI's own entrypoint module. A built install runs
+ * `cli.js`, while source execution (tsx / ts-node) runs `cli.ts`.
+ */
+function cliEntryPointPath(): string {
+  const builtEntry = fileURLToPath(new URL('./cli.js', import.meta.url));
+  if (existsSync(builtEntry)) return builtEntry;
+  const sourceEntry = fileURLToPath(new URL('./cli.ts', import.meta.url));
+  if (existsSync(sourceEntry)) return sourceEntry;
+  return builtEntry;
+}
+
+/**
+ * Resolve the daemon entrypoint used by the supervisor on its next spawn.
+ * Edge and non-blue-green nodes use this installed CLI; Core may use the
+ * active blue-green slot.
+ */
+export function resolveDaemonEntryPoint(): string {
+  if (process.env.DKG_NO_BLUE_GREEN) return cliEntryPointPath();
+  if (readNodeRoleFromConfigSync() === 'edge') return cliEntryPointPath();
+  const rDir = releasesDir();
+  if (existsSync(rDir)) {
+    const entry = slotEntryPoint(join(rDir, 'current'));
+    if (entry) return entry;
+  }
+  return cliEntryPointPath();
+}
+
+/**
+ * Resolve the complete command prefix shared by supervisor restarts and the
+ * Edge post-install executable probe. Keeping both consumers on this model
+ * prevents the verifier from drifting from the process the supervisor starts.
+ */
+export function resolveDaemonRestartCommand(): DaemonRestartCommand {
+  return {
+    nodeExecutable: process.execPath,
+    nodeExecArgv: [...process.execArgv],
+    restartEntryPoint: resolveDaemonEntryPoint(),
+  };
+}
+
+/** Append daemon/CLI arguments to a canonical restart command. */
+export function daemonRestartCommandArgs(
+  command: DaemonRestartCommand,
+  ...args: string[]
+): string[] {
+  return [...command.nodeExecArgv, command.restartEntryPoint, ...args];
+}

--- a/packages/cli/src/daemon-entrypoint.ts
+++ b/packages/cli/src/daemon-entrypoint.ts
@@ -8,11 +8,11 @@ import {
   slotEntryPoint,
 } from './config.js';
 
-/** Canonical Node command prefix used to start or probe this daemon entrypoint. */
-export interface DaemonRestartCommand {
-  nodeExecutable: string;
-  nodeExecArgv: readonly string[];
-  restartEntryPoint: string;
+/** Fully assembled Node command used to start or probe this daemon entrypoint. */
+export interface DaemonNodeCommand {
+  executable: string;
+  args: readonly string[];
+  entryPoint: string;
 }
 
 /**
@@ -44,22 +44,16 @@ export function resolveDaemonEntryPoint(): string {
 }
 
 /**
- * Resolve the complete command prefix shared by supervisor restarts and the
- * Edge post-install executable probe. Keeping both consumers on this model
- * prevents the verifier from drifting from the process the supervisor starts.
+ * Resolve one complete daemon command. Every launch and executable probe goes
+ * through this boundary so Node executable/exec-argv/entrypoint policy has one
+ * owner. The selected entrypoint is retained for diagnostics and tests only;
+ * callers execute `executable` with `args` without rebuilding the shape.
  */
-export function resolveDaemonRestartCommand(): DaemonRestartCommand {
+export function resolveDaemonNodeCommand(...args: string[]): DaemonNodeCommand {
+  const entryPoint = resolveDaemonEntryPoint();
   return {
-    nodeExecutable: process.execPath,
-    nodeExecArgv: [...process.execArgv],
-    restartEntryPoint: resolveDaemonEntryPoint(),
+    executable: process.execPath,
+    args: [...process.execArgv, entryPoint, ...args],
+    entryPoint,
   };
-}
-
-/** Append daemon/CLI arguments to a canonical restart command. */
-export function daemonRestartCommandArgs(
-  command: DaemonRestartCommand,
-  ...args: string[]
-): string[] {
-  return [...command.nodeExecArgv, command.restartEntryPoint, ...args];
 }

--- a/packages/cli/src/daemon/auto-update.ts
+++ b/packages/cli/src/daemon/auto-update.ts
@@ -46,7 +46,6 @@ import {
 } from '../config.js';
 import {
   daemonRestartCommandArgs,
-  resolveDaemonRestartCommand,
   type DaemonRestartCommand,
 } from '../daemon-entrypoint.js';
 import { resolveAutoUpdateGitRef, resolveAutoUpdateGitRefPlan, type AutoUpdateGitRefPlan } from '../auto-update-ref.js';
@@ -1567,7 +1566,6 @@ export async function performNpmUpdateEdge(
   targetVersion: string,
   currentVersion: string | null,
   log: (msg: string) => void,
-  restartCommand: DaemonRestartCommand = resolveDaemonRestartCommand(),
 ): Promise<UpdateStatus> {
   if (_updateInProgress) {
     log("Auto-update (npm-edge): another update is already in progress, skipping");
@@ -1580,6 +1578,7 @@ export async function performNpmUpdateEdge(
     return "failed";
   }
   try {
+    const restartCommand = _autoUpdateIo.resolveDaemonRestartCommand();
     return await _performNpmUpdateInnerEdge(
       targetVersion,
       currentVersion,

--- a/packages/cli/src/daemon/auto-update.ts
+++ b/packages/cli/src/daemon/auto-update.ts
@@ -44,6 +44,11 @@ import {
   type DkgConfig,
   type ResolvedAutoUpdateConfig,
 } from '../config.js';
+import {
+  daemonRestartCommandArgs,
+  resolveDaemonRestartCommand,
+  type DaemonRestartCommand,
+} from '../daemon-entrypoint.js';
 import { resolveAutoUpdateGitRef, resolveAutoUpdateGitRefPlan, type AutoUpdateGitRefPlan } from '../auto-update-ref.js';
 import {
   _autoUpdateIo,
@@ -1547,20 +1552,22 @@ export async function performNpmUpdate(
  * executable/version self-check. A failed check immediately reinstalls the
  * recorded previous version before the daemon is allowed to restart.
  *
- * The function returns `'updated'` after the npm install completes;
- * the caller is responsible for stopping the running daemon so the
- * supervisor respawns from the new entry point (mirrors how the
- * Core path's swap-slot+restart sequence works).
+ * The function returns `'updated'` after the npm install and self-check
+ * complete; the caller is responsible for stopping the running daemon so
+ * the supervisor respawns from the new entry point (mirrors how the Core
+ * path's swap-slot+restart sequence works).
  *
- * Returns `'failed'` on any npm install failure; the previous-version
- * write is best-effort and a write failure does NOT block the install
- * (the operator can still rollback manually via
+ * Returns `'failed'` when the install or executable/version self-check
+ * fails, including after a rollback attempt. The previous-version write is
+ * best-effort and a write failure does NOT block the install (the operator
+ * can still rollback manually via
  * `npm install -g @origintrail-official/dkg@<known-version>`).
  */
 export async function performNpmUpdateEdge(
   targetVersion: string,
   currentVersion: string | null,
   log: (msg: string) => void,
+  restartCommand: DaemonRestartCommand = resolveDaemonRestartCommand(),
 ): Promise<UpdateStatus> {
   if (_updateInProgress) {
     log("Auto-update (npm-edge): another update is already in progress, skipping");
@@ -1577,7 +1584,7 @@ export async function performNpmUpdateEdge(
       targetVersion,
       currentVersion,
       log,
-      _autoUpdateIo.edgeRestartCommand(),
+      restartCommand,
     );
   } finally {
     await releaseUpdateLock();
@@ -1589,7 +1596,7 @@ async function _performNpmUpdateInnerEdge(
   targetVersion: string,
   currentVersion: string | null,
   log: (msg: string) => void,
-  restartCommand: EdgeRestartCommand,
+  restartCommand: DaemonRestartCommand,
 ): Promise<UpdateStatus> {
   // Destructure from `_autoUpdateIo` so unit tests can stub each
   // dependency — matches the existing `_performNpmUpdateInner`
@@ -1637,7 +1644,7 @@ async function _performNpmUpdateInnerEdge(
     return "failed";
   }
 
-  const verified = await verifyInstalledCliOrRollback({
+  const verificationOutcome = await verifyInstalledCliOrRollback({
     execIo: execAsyncIo,
     execFileIo: execFileAsyncIo,
     targetVersion,
@@ -1645,20 +1652,34 @@ async function _performNpmUpdateInnerEdge(
     restartCommand,
     log,
   });
-  if (!verified) {
-    return 'failed';
+  switch (verificationOutcome.kind) {
+    case 'targetVerified':
+      log(`Auto-update (npm-edge): self-check passed (${verificationOutcome.reported}).`);
+      log(
+        `Auto-update (npm-edge): ${CLI_NPM_PACKAGE}@${targetVersion} installed. ` +
+          "Stop the daemon to restart from the new entry point.",
+      );
+      return "updated";
+    case 'rollbackRestored':
+      log(`Auto-update (npm-edge): rollback restored ${verificationOutcome.reported}.`);
+      return 'failed';
+    case 'rollbackUnavailable':
+      log('Auto-update (npm-edge): previous version is unknown; automatic rollback is unavailable.');
+      return 'failed';
+    case 'rollbackFailed':
+      log(`Auto-update (npm-edge): CRITICAL rollback failed — ${verificationOutcome.error}.`);
+      return 'failed';
   }
-
-  log(
-    `Auto-update (npm-edge): ${CLI_NPM_PACKAGE}@${targetVersion} installed. ` +
-      "Stop the daemon to restart from the new entry point.",
-  );
-  return "updated";
 }
 
 type EdgeExec = typeof _autoUpdateIo.exec;
 type EdgeExecFile = typeof _autoUpdateIo.execFile;
-type EdgeRestartCommand = ReturnType<typeof _autoUpdateIo.edgeRestartCommand>;
+
+type InstalledCliVerificationOutcome =
+  | { kind: 'targetVerified'; reported: string }
+  | { kind: 'rollbackRestored'; reported: string }
+  | { kind: 'rollbackUnavailable' }
+  | { kind: 'rollbackFailed'; error: string };
 
 function globalCliInstallCommand(version: string): string {
   return `npm install -g ${CLI_NPM_PACKAGE}@${version}`;
@@ -1677,13 +1698,13 @@ function parseReportedDkgVersion(output: string): string | undefined {
 
 async function verifyGlobalDkgVersion(
   execFileIo: EdgeExecFile,
-  restartCommand: EdgeRestartCommand,
+  restartCommand: DaemonRestartCommand,
   expectedVersion: string,
   context: 'self-check' | 'rollback',
 ): Promise<string> {
   const { stdout, stderr } = await execFileIo(
     restartCommand.nodeExecutable,
-    [...restartCommand.nodeExecArgv, restartCommand.restartEntryPoint, '--version'],
+    daemonRestartCommandArgs(restartCommand, '--version'),
     {
       encoding: 'utf-8',
       timeout: 30_000,
@@ -1702,9 +1723,9 @@ async function verifyInstalledCliOrRollback(options: {
   execFileIo: EdgeExecFile;
   targetVersion: string;
   currentVersion: string | null;
-  restartCommand: EdgeRestartCommand;
+  restartCommand: DaemonRestartCommand;
   log: (msg: string) => void;
-}): Promise<boolean> {
+}): Promise<InstalledCliVerificationOutcome> {
   const { execIo, execFileIo, targetVersion, currentVersion, restartCommand, log } = options;
   try {
     const reported = await verifyGlobalDkgVersion(
@@ -1713,15 +1734,13 @@ async function verifyInstalledCliOrRollback(options: {
       targetVersion,
       'self-check',
     );
-    log(`Auto-update (npm-edge): self-check passed (${reported}).`);
-    return true;
+    return { kind: 'targetVerified', reported };
   } catch (verifyErr: any) {
     log(`Auto-update (npm-edge): post-install self-check failed — ${verifyErr?.message ?? verifyErr}.`);
   }
 
   if (!currentVersion) {
-    log('Auto-update (npm-edge): previous version is unknown; automatic rollback is unavailable.');
-    return false;
+    return { kind: 'rollbackUnavailable' };
   }
 
   const rollbackCmd = globalCliInstallCommand(currentVersion);
@@ -1734,11 +1753,13 @@ async function verifyInstalledCliOrRollback(options: {
       currentVersion,
       'rollback',
     );
-    log(`Auto-update (npm-edge): rollback restored ${reported}.`);
+    return { kind: 'rollbackRestored', reported };
   } catch (rollbackErr: any) {
-    log(`Auto-update (npm-edge): CRITICAL rollback failed — ${rollbackErr?.message ?? rollbackErr}.`);
+    return {
+      kind: 'rollbackFailed',
+      error: String(rollbackErr?.message ?? rollbackErr ?? 'unknown error'),
+    };
   }
-  return false;
 }
 
 export async function checkForUpdate(

--- a/packages/cli/src/daemon/auto-update.ts
+++ b/packages/cli/src/daemon/auto-update.ts
@@ -44,10 +44,7 @@ import {
   type DkgConfig,
   type ResolvedAutoUpdateConfig,
 } from '../config.js';
-import {
-  daemonRestartCommandArgs,
-  type DaemonRestartCommand,
-} from '../daemon-entrypoint.js';
+import type { DaemonNodeCommand } from '../daemon-entrypoint.js';
 import { resolveAutoUpdateGitRef, resolveAutoUpdateGitRefPlan, type AutoUpdateGitRefPlan } from '../auto-update-ref.js';
 import {
   _autoUpdateIo,
@@ -1578,12 +1575,12 @@ export async function performNpmUpdateEdge(
     return "failed";
   }
   try {
-    const restartCommand = _autoUpdateIo.resolveDaemonRestartCommand();
+    const verificationCommand = _autoUpdateIo.resolveDaemonNodeCommand('--version');
     return await _performNpmUpdateInnerEdge(
       targetVersion,
       currentVersion,
       log,
-      restartCommand,
+      verificationCommand,
     );
   } finally {
     await releaseUpdateLock();
@@ -1595,7 +1592,7 @@ async function _performNpmUpdateInnerEdge(
   targetVersion: string,
   currentVersion: string | null,
   log: (msg: string) => void,
-  restartCommand: DaemonRestartCommand,
+  verificationCommand: DaemonNodeCommand,
 ): Promise<UpdateStatus> {
   // Destructure from `_autoUpdateIo` so unit tests can stub each
   // dependency — matches the existing `_performNpmUpdateInner`
@@ -1648,7 +1645,7 @@ async function _performNpmUpdateInnerEdge(
     execFileIo: execFileAsyncIo,
     targetVersion,
     currentVersion,
-    restartCommand,
+    verificationCommand,
     log,
   });
   switch (verificationOutcome.kind) {
@@ -1697,13 +1694,13 @@ function parseReportedDkgVersion(output: string): string | undefined {
 
 async function verifyGlobalDkgVersion(
   execFileIo: EdgeExecFile,
-  restartCommand: DaemonRestartCommand,
+  verificationCommand: DaemonNodeCommand,
   expectedVersion: string,
   context: 'self-check' | 'rollback',
 ): Promise<string> {
   const { stdout, stderr } = await execFileIo(
-    restartCommand.nodeExecutable,
-    daemonRestartCommandArgs(restartCommand, '--version'),
+    verificationCommand.executable,
+    verificationCommand.args,
     {
       encoding: 'utf-8',
       timeout: 30_000,
@@ -1722,14 +1719,14 @@ async function verifyInstalledCliOrRollback(options: {
   execFileIo: EdgeExecFile;
   targetVersion: string;
   currentVersion: string | null;
-  restartCommand: DaemonRestartCommand;
+  verificationCommand: DaemonNodeCommand;
   log: (msg: string) => void;
 }): Promise<InstalledCliVerificationOutcome> {
-  const { execIo, execFileIo, targetVersion, currentVersion, restartCommand, log } = options;
+  const { execIo, execFileIo, targetVersion, currentVersion, verificationCommand, log } = options;
   try {
     const reported = await verifyGlobalDkgVersion(
       execFileIo,
-      restartCommand,
+      verificationCommand,
       targetVersion,
       'self-check',
     );
@@ -1748,7 +1745,7 @@ async function verifyInstalledCliOrRollback(options: {
     await installGlobalCliVersion(execIo, currentVersion);
     const reported = await verifyGlobalDkgVersion(
       execFileIo,
-      restartCommand,
+      verificationCommand,
       currentVersion,
       'rollback',
     );

--- a/packages/cli/src/daemon/manifest.ts
+++ b/packages/cli/src/daemon/manifest.ts
@@ -31,6 +31,7 @@ import {
   swapSlot,
   type AutoUpdateConfig,
 } from '../config.js';
+import { resolveDaemonRestartCommand } from '../daemon-entrypoint.js';
 import {
   expectedBundledMarkItDownBuildMetadata,
   readCliPackageVersion,
@@ -552,6 +553,8 @@ export const _autoUpdateIo = {
   exec: execAsync as (...args: any[]) => Promise<any>,
   execFile: execFileAsync as (...args: any[]) => Promise<any>,
   execSync: execSync as (...args: any[]) => any,
+  // Dependency reference only; restart policy lives in daemon-entrypoint.ts.
+  resolveDaemonRestartCommand,
   dkgDir,
   releasesDir,
   activeSlot: activeSlot as () => Promise<'a' | 'b'>,

--- a/packages/cli/src/daemon/manifest.ts
+++ b/packages/cli/src/daemon/manifest.ts
@@ -31,7 +31,7 @@ import {
   swapSlot,
   type AutoUpdateConfig,
 } from '../config.js';
-import { resolveDaemonRestartCommand } from '../daemon-entrypoint.js';
+import { resolveDaemonNodeCommand } from '../daemon-entrypoint.js';
 import {
   expectedBundledMarkItDownBuildMetadata,
   readCliPackageVersion,
@@ -553,8 +553,8 @@ export const _autoUpdateIo = {
   exec: execAsync as (...args: any[]) => Promise<any>,
   execFile: execFileAsync as (...args: any[]) => Promise<any>,
   execSync: execSync as (...args: any[]) => any,
-  // Dependency reference only; restart policy lives in daemon-entrypoint.ts.
-  resolveDaemonRestartCommand,
+  // Dependency reference only; daemon command policy lives in daemon-entrypoint.ts.
+  resolveDaemonNodeCommand,
   dkgDir,
   releasesDir,
   activeSlot: activeSlot as () => Promise<'a' | 'b'>,

--- a/packages/cli/src/daemon/manifest.ts
+++ b/packages/cli/src/daemon/manifest.ts
@@ -552,20 +552,6 @@ export const _autoUpdateIo = {
   exec: execAsync as (...args: any[]) => Promise<any>,
   execFile: execFileAsync as (...args: any[]) => Promise<any>,
   execSync: execSync as (...args: any[]) => any,
-  // Match the supervisor's next worker command exactly. Keeping this resolver
-  // on the existing IO seam lets tests substitute a real fixture entry point
-  // without exposing process argv details through performNpmUpdateEdge.
-  edgeRestartCommand: () => {
-    const restartEntryPoint = process.argv[1];
-    if (!restartEntryPoint) {
-      throw new Error('Cannot verify Edge update: current CLI restart entry point is unavailable.');
-    }
-    return {
-      nodeExecutable: process.execPath,
-      nodeExecArgv: process.execArgv,
-      restartEntryPoint,
-    };
-  },
   dkgDir,
   releasesDir,
   activeSlot: activeSlot as () => Promise<'a' | 'b'>,

--- a/packages/cli/test/daemon-entrypoint-resolution.test.ts
+++ b/packages/cli/test/daemon-entrypoint-resolution.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { existsSync } from 'node:fs';
 
-import { resolveDaemonEntryPoint } from '../src/cli-helpers.js';
+import {
+  daemonRestartCommandArgs,
+  resolveDaemonEntryPoint,
+  resolveDaemonRestartCommand,
+} from '../src/daemon-entrypoint.js';
 
 /**
  * Regression guard for #962 (cli.ts split review): `resolveDaemonEntryPoint`
@@ -34,5 +38,27 @@ describe('resolveDaemonEntryPoint (#962)', () => {
 
     expect(entry).toMatch(/cli\.(ts|js)$/);
     expect(existsSync(entry), `daemon entrypoint must exist: ${entry}`).toBe(true);
+  });
+
+  it('builds supervisor and verifier arguments from the same canonical command', () => {
+    process.env.DKG_NO_BLUE_GREEN = '1';
+
+    const command = resolveDaemonRestartCommand();
+
+    expect(command).toEqual({
+      nodeExecutable: process.execPath,
+      nodeExecArgv: process.execArgv,
+      restartEntryPoint: resolveDaemonEntryPoint(),
+    });
+    expect(daemonRestartCommandArgs(command, 'daemon-worker')).toEqual([
+      ...process.execArgv,
+      command.restartEntryPoint,
+      'daemon-worker',
+    ]);
+    expect(daemonRestartCommandArgs(command, '--version')).toEqual([
+      ...process.execArgv,
+      command.restartEntryPoint,
+      '--version',
+    ]);
   });
 });

--- a/packages/cli/test/daemon-entrypoint-resolution.test.ts
+++ b/packages/cli/test/daemon-entrypoint-resolution.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 import {
-  daemonRestartCommandArgs,
   resolveDaemonEntryPoint,
-  resolveDaemonRestartCommand,
+  resolveDaemonNodeCommand,
 } from '../src/daemon-entrypoint.js';
 
 /**
@@ -23,10 +25,16 @@ import {
  */
 describe('resolveDaemonEntryPoint (#962)', () => {
   const prevNoBlueGreen = process.env.DKG_NO_BLUE_GREEN;
+  const prevDkgHome = process.env.DKG_HOME;
+  let tempHome: string | undefined;
 
-  afterEach(() => {
+  afterEach(async () => {
     if (prevNoBlueGreen === undefined) delete process.env.DKG_NO_BLUE_GREEN;
     else process.env.DKG_NO_BLUE_GREEN = prevNoBlueGreen;
+    if (prevDkgHome === undefined) delete process.env.DKG_HOME;
+    else process.env.DKG_HOME = prevDkgHome;
+    if (tempHome) await rm(tempHome, { recursive: true, force: true });
+    tempHome = undefined;
   });
 
   it('returns an existing CLI entrypoint regardless of run mode', () => {
@@ -40,25 +48,51 @@ describe('resolveDaemonEntryPoint (#962)', () => {
     expect(existsSync(entry), `daemon entrypoint must exist: ${entry}`).toBe(true);
   });
 
-  it('builds supervisor and verifier arguments from the same canonical command', () => {
+  it('builds every launch and verifier shape through one canonical command', () => {
     process.env.DKG_NO_BLUE_GREEN = '1';
 
-    const command = resolveDaemonRestartCommand();
-
-    expect(command).toEqual({
-      nodeExecutable: process.execPath,
-      nodeExecArgv: process.execArgv,
-      restartEntryPoint: resolveDaemonEntryPoint(),
-    });
-    expect(daemonRestartCommandArgs(command, 'daemon-worker')).toEqual([
-      ...process.execArgv,
-      command.restartEntryPoint,
+    for (const daemonArg of [
+      'daemon-supervisor',
       'daemon-worker',
-    ]);
-    expect(daemonRestartCommandArgs(command, '--version')).toEqual([
-      ...process.execArgv,
-      command.restartEntryPoint,
+      'daemon-foreground-worker',
       '--version',
-    ]);
+    ]) {
+      const command = resolveDaemonNodeCommand(daemonArg);
+      expect(command).toEqual({
+        executable: process.execPath,
+        args: [...process.execArgv, command.entryPoint, daemonArg],
+        entryPoint: resolveDaemonEntryPoint(),
+      });
+    }
+  });
+
+  async function createLegacySlot(role: 'edge' | 'core'): Promise<string> {
+    tempHome = await mkdtemp(join(tmpdir(), `dkg-${role}-entrypoint-`));
+    process.env.DKG_HOME = tempHome;
+    delete process.env.DKG_NO_BLUE_GREEN;
+    await writeFile(join(tempHome, 'config.json'), JSON.stringify({ nodeRole: role }));
+    const slotEntry = join(tempHome, 'releases', 'current', 'packages', 'cli', 'dist', 'cli.js');
+    await mkdir(join(slotEntry, '..'), { recursive: true });
+    await writeFile(slotEntry, '// stale legacy slot');
+    return slotEntry;
+  }
+
+  it('keeps an Edge --version probe on the installed CLI when legacy slots remain', async () => {
+    const legacySlotEntry = await createLegacySlot('edge');
+
+    const command = resolveDaemonNodeCommand('--version');
+
+    expect(command.entryPoint).not.toBe(legacySlotEntry);
+    expect(command.entryPoint).toMatch(/cli\.(ts|js)$/);
+    expect(command.args).toEqual([...process.execArgv, command.entryPoint, '--version']);
+  });
+
+  it('preserves the active legacy slot for Core daemon commands', async () => {
+    const legacySlotEntry = await createLegacySlot('core');
+
+    const command = resolveDaemonNodeCommand('daemon-worker');
+
+    expect(command.entryPoint).toBe(legacySlotEntry);
+    expect(command.args).toEqual([...process.execArgv, legacySlotEntry, 'daemon-worker']);
   });
 });

--- a/packages/cli/test/edge-auto-update-entrypoint-e2e.test.ts
+++ b/packages/cli/test/edge-auto-update-entrypoint-e2e.test.ts
@@ -15,7 +15,7 @@ import { performNpmUpdateEdge } from "../src/daemon/auto-update.js";
 import { _autoUpdateIo } from "../src/daemon/manifest.js";
 
 describe("Edge auto-update restart-entry self-check (real child processes)", () => {
-  const originalRestartCommandResolver = _autoUpdateIo.resolveDaemonRestartCommand;
+  const originalDaemonCommandResolver = _autoUpdateIo.resolveDaemonNodeCommand;
   const originalEnv = {
     DKG_HOME: process.env.DKG_HOME,
     PATH: process.env.PATH,
@@ -24,7 +24,7 @@ describe("Edge auto-update restart-entry self-check (real child processes)", () 
   let root: string | undefined;
 
   afterEach(async () => {
-    _autoUpdateIo.resolveDaemonRestartCommand = originalRestartCommandResolver;
+    _autoUpdateIo.resolveDaemonNodeCommand = originalDaemonCommandResolver;
     for (const [name, value] of Object.entries(originalEnv)) {
       if (value === undefined) delete process.env[name];
       else process.env[name] = value;
@@ -74,12 +74,12 @@ describe("Edge auto-update restart-entry self-check (real child processes)", () 
     expect(
       execFileSync(pathDkg, ["--version"], { encoding: "utf8" }).trim(),
     ).toBe("dkg 10.0.0-rc.1");
-    const restartCommand = {
-      nodeExecutable: process.execPath,
-      nodeExecArgv: [],
-      restartEntryPoint: restartEntry,
+    const verificationCommand = {
+      executable: process.execPath,
+      args: [restartEntry, '--version'],
+      entryPoint: restartEntry,
     };
-    _autoUpdateIo.resolveDaemonRestartCommand = () => restartCommand;
+    _autoUpdateIo.resolveDaemonNodeCommand = () => verificationCommand;
 
     const logs: string[] = [];
     const result = await performNpmUpdateEdge(

--- a/packages/cli/test/edge-auto-update-entrypoint-e2e.test.ts
+++ b/packages/cli/test/edge-auto-update-entrypoint-e2e.test.ts
@@ -12,10 +12,8 @@ import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { performNpmUpdateEdge } from "../src/daemon/auto-update.js";
-import { _autoUpdateIo } from "../src/daemon/manifest.js";
 
 describe("Edge auto-update restart-entry self-check (real child processes)", () => {
-  const originalEdgeRestartCommand = _autoUpdateIo.edgeRestartCommand;
   const originalEnv = {
     DKG_HOME: process.env.DKG_HOME,
     PATH: process.env.PATH,
@@ -24,7 +22,6 @@ describe("Edge auto-update restart-entry self-check (real child processes)", () 
   let root: string | undefined;
 
   afterEach(async () => {
-    _autoUpdateIo.edgeRestartCommand = originalEdgeRestartCommand;
     for (const [name, value] of Object.entries(originalEnv)) {
       if (value === undefined) delete process.env[name];
       else process.env[name] = value;
@@ -74,17 +71,18 @@ describe("Edge auto-update restart-entry self-check (real child processes)", () 
     expect(
       execFileSync(pathDkg, ["--version"], { encoding: "utf8" }).trim(),
     ).toBe("dkg 10.0.0-rc.1");
-    _autoUpdateIo.edgeRestartCommand = () => ({
+    const restartCommand = {
       nodeExecutable: process.execPath,
       nodeExecArgv: [],
       restartEntryPoint: restartEntry,
-    });
+    };
 
     const logs: string[] = [];
     const result = await performNpmUpdateEdge(
       "10.0.0-rc.1",
       "10.0.0-rc.0",
       (message) => logs.push(message),
+      restartCommand,
     );
 
     expect(result).toBe("failed");

--- a/packages/cli/test/edge-auto-update-entrypoint-e2e.test.ts
+++ b/packages/cli/test/edge-auto-update-entrypoint-e2e.test.ts
@@ -12,8 +12,10 @@ import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { performNpmUpdateEdge } from "../src/daemon/auto-update.js";
+import { _autoUpdateIo } from "../src/daemon/manifest.js";
 
 describe("Edge auto-update restart-entry self-check (real child processes)", () => {
+  const originalRestartCommandResolver = _autoUpdateIo.resolveDaemonRestartCommand;
   const originalEnv = {
     DKG_HOME: process.env.DKG_HOME,
     PATH: process.env.PATH,
@@ -22,6 +24,7 @@ describe("Edge auto-update restart-entry self-check (real child processes)", () 
   let root: string | undefined;
 
   afterEach(async () => {
+    _autoUpdateIo.resolveDaemonRestartCommand = originalRestartCommandResolver;
     for (const [name, value] of Object.entries(originalEnv)) {
       if (value === undefined) delete process.env[name];
       else process.env[name] = value;
@@ -76,13 +79,13 @@ describe("Edge auto-update restart-entry self-check (real child processes)", () 
       nodeExecArgv: [],
       restartEntryPoint: restartEntry,
     };
+    _autoUpdateIo.resolveDaemonRestartCommand = () => restartCommand;
 
     const logs: string[] = [];
     const result = await performNpmUpdateEdge(
       "10.0.0-rc.1",
       "10.0.0-rc.0",
       (message) => logs.push(message),
-      restartCommand,
     );
 
     expect(result).toBe("failed");

--- a/packages/cli/test/foreground-supervisor-command.test.ts
+++ b/packages/cli/test/foreground-supervisor-command.test.ts
@@ -1,0 +1,75 @@
+import { execFile } from 'node:child_process';
+import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+import { describe, expect, it } from 'vitest';
+
+const execFileAsync = promisify(execFile);
+
+describe('foreground supervisor restart command', () => {
+  it('spawns the active entrypoint with Node exec argv and the foreground worker argument', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'dkg-foreground-command-'));
+    try {
+      const dkgHome = join(root, 'home');
+      const releasesDir = join(dkgHome, 'releases');
+      const slotEntry = join(releasesDir, 'a', 'packages', 'cli', 'dist', 'cli.js');
+      const capturePath = join(root, 'spawn.json');
+      const harnessPath = join(root, 'run-supervisor.mjs');
+
+      await mkdir(dirname(slotEntry), { recursive: true });
+      await writeFile(join(dkgHome, 'config.json'), JSON.stringify({ nodeRole: 'core' }));
+      await writeFile(
+        slotEntry,
+        [
+          "const { writeFileSync } = require('node:fs');",
+          'writeFileSync(process.env.FOREGROUND_CAPTURE, JSON.stringify({',
+          '  execPath: process.execPath,',
+          '  execArgv: process.execArgv,',
+          '  argv: process.argv,',
+          '}));',
+        ].join('\n'),
+      );
+      await symlink('a', join(releasesDir, 'current'));
+
+      const supervisorUrl = new URL('../src/cli-supervisor.ts', import.meta.url).href;
+      await writeFile(
+        harnessPath,
+        `import { runForegroundSupervisor } from ${JSON.stringify(supervisorUrl)};\n` +
+          'await runForegroundSupervisor(process.env);\n',
+      );
+
+      const env = { ...process.env };
+      delete env.DKG_NO_BLUE_GREEN;
+      env.DKG_HOME = dkgHome;
+      env.DKG_SUPERVISOR_LIVENESS_PROBE = 'off';
+      env.FOREGROUND_CAPTURE = capturePath;
+
+      await execFileAsync(
+        process.execPath,
+        ['--import', 'tsx', harnessPath],
+        {
+          cwd: fileURLToPath(new URL('..', import.meta.url)),
+          env,
+          timeout: 20_000,
+        },
+      );
+
+      const captured = JSON.parse(await readFile(capturePath, 'utf-8')) as {
+        execPath: string;
+        execArgv: string[];
+        argv: string[];
+      };
+      expect(captured.execPath).toBe(process.execPath);
+      expect(captured.execArgv).toEqual(['--import', 'tsx']);
+      expect(captured.argv.slice(1)).toEqual([
+        join(releasesDir, 'current', 'packages', 'cli', 'dist', 'cli.js'),
+        'daemon-foreground-worker',
+      ]);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/cli/test/rfc-41-bundle-b.test.ts
+++ b/packages/cli/test/rfc-41-bundle-b.test.ts
@@ -25,9 +25,8 @@ import { ensureStablePluginRoot } from '../src/daemon/plugin-loader.js';
 import { performNpmUpdateEdge } from '../src/daemon/auto-update.js';
 import { _autoUpdateIo } from '../src/daemon/manifest.js';
 import {
-  daemonRestartCommandArgs,
-  resolveDaemonRestartCommand,
-  type DaemonRestartCommand,
+  resolveDaemonNodeCommand,
+  type DaemonNodeCommand,
 } from '../src/daemon-entrypoint.js';
 
 let tmpDir: string;
@@ -216,11 +215,15 @@ describe('performNpmUpdateEdge (Bundle B1b)', () => {
   // a real subprocess. Other IO (readFile, writeFile, mkdir, …) we let
   // the real fs handle against the per-test DKG_HOME.
   const origIo = { ..._autoUpdateIo };
-  const restartCommand = {
-    nodeExecutable: '/usr/local/bin/node',
-    nodeExecArgv: ['--enable-source-maps'],
-    restartEntryPoint: '/npm-global/lib/node_modules/@origintrail-official/dkg/dist/cli.js',
-  } satisfies DaemonRestartCommand;
+  const verificationCommand = {
+    executable: '/usr/local/bin/node',
+    args: [
+      '--enable-source-maps',
+      '/npm-global/lib/node_modules/@origintrail-official/dkg/dist/cli.js',
+      '--version',
+    ],
+    entryPoint: '/npm-global/lib/node_modules/@origintrail-official/dkg/dist/cli.js',
+  } satisfies DaemonNodeCommand;
   let execCalls: { cmd: string; opts?: any }[] = [];
   let execFileCalls: { file: string; args: string[]; opts?: any }[] = [];
   let operations: string[] = [];
@@ -243,7 +246,7 @@ describe('performNpmUpdateEdge (Bundle B1b)', () => {
       operations.push(`${file} ${args.join(' ')}`);
       return Promise.resolve({ stdout: 'dkg 10.0.0-rc.12', stderr: '' });
     }) as any;
-    _autoUpdateIo.resolveDaemonRestartCommand = () => restartCommand;
+    _autoUpdateIo.resolveDaemonNodeCommand = () => verificationCommand;
   });
 
   afterEach(() => {
@@ -263,12 +266,8 @@ describe('performNpmUpdateEdge (Bundle B1b)', () => {
     expect(execCalls).toHaveLength(1);
     expect(execCalls[0].cmd).toBe('npm install -g @origintrail-official/dkg@10.0.0-rc.12');
     expect(execFileCalls).toEqual([{
-      file: restartCommand.nodeExecutable,
-      args: [
-        ...restartCommand.nodeExecArgv,
-        restartCommand.restartEntryPoint,
-        '--version',
-      ],
+      file: verificationCommand.executable,
+      args: verificationCommand.args,
       opts: { encoding: 'utf-8', timeout: 30_000 },
     }]);
     expect(execCalls.some(({ cmd }) => cmd === 'dkg --version')).toBe(false);
@@ -329,7 +328,7 @@ describe('performNpmUpdateEdge (Bundle B1b)', () => {
       log.fn,
     );
     expect(result).toBe('failed');
-    const restartProbe = `${restartCommand.nodeExecutable} ${restartCommand.nodeExecArgv.join(' ')} ${restartCommand.restartEntryPoint} --version`;
+    const restartProbe = `${verificationCommand.executable} ${verificationCommand.args.join(' ')}`;
     expect(operations).toEqual([
       'npm install -g @origintrail-official/dkg@10.0.0-rc.12',
       restartProbe,
@@ -352,7 +351,7 @@ describe('performNpmUpdateEdge (Bundle B1b)', () => {
       null,
       log.fn,
     );
-    const restartProbe = `${restartCommand.nodeExecutable} ${restartCommand.nodeExecArgv.join(' ')} ${restartCommand.restartEntryPoint} --version`;
+    const restartProbe = `${verificationCommand.executable} ${verificationCommand.args.join(' ')}`;
 
     expect(result).toBe('failed');
     expect(operations).toEqual([
@@ -381,7 +380,7 @@ describe('performNpmUpdateEdge (Bundle B1b)', () => {
       '10.0.0-rc.11',
       log.fn,
     );
-    const restartProbe = `${restartCommand.nodeExecutable} ${restartCommand.nodeExecArgv.join(' ')} ${restartCommand.restartEntryPoint} --version`;
+    const restartProbe = `${verificationCommand.executable} ${verificationCommand.args.join(' ')}`;
 
     expect(result).toBe('failed');
     expect(operations).toEqual([
@@ -412,7 +411,7 @@ describe('performNpmUpdateEdge (Bundle B1b)', () => {
       log.fn,
     );
     expect(result).toBe('failed');
-    const restartProbe = `${restartCommand.nodeExecutable} ${restartCommand.nodeExecArgv.join(' ')} ${restartCommand.restartEntryPoint} --version`;
+    const restartProbe = `${verificationCommand.executable} ${verificationCommand.args.join(' ')}`;
     expect(operations).toEqual([
       'npm install -g @origintrail-official/dkg@10.0.0-rc.1',
       restartProbe,
@@ -441,18 +440,32 @@ describe('performNpmUpdateEdge (Bundle B1b)', () => {
     expect(log.calls.some((m) => m.includes('npm config set prefix'))).toBe(true);
   });
 
-  it('derives the default self-check from the canonical supervisor command', async () => {
-    process.env.DKG_NO_BLUE_GREEN = '1';
-    _autoUpdateIo.resolveDaemonRestartCommand = origIo.resolveDaemonRestartCommand;
-    const canonicalCommand = resolveDaemonRestartCommand();
+  it('probes the installed Edge CLI even when a legacy current slot remains', async () => {
+    delete process.env.DKG_NO_BLUE_GREEN;
+    await writeFile(join(dkgHome, 'config.json'), JSON.stringify({ nodeRole: 'edge' }));
+    const legacyEntry = join(
+      dkgHome,
+      'releases',
+      'current',
+      'packages',
+      'cli',
+      'dist',
+      'cli.js',
+    );
+    await mkdir(join(legacyEntry, '..'), { recursive: true });
+    await writeFile(legacyEntry, '// stale Core-era slot');
+    _autoUpdateIo.resolveDaemonNodeCommand = origIo.resolveDaemonNodeCommand;
+    const canonicalCommand = resolveDaemonNodeCommand('--version');
+    expect(canonicalCommand.entryPoint).not.toBe(legacyEntry);
+    expect(canonicalCommand.entryPoint).toMatch(/cli\.(ts|js)$/);
     const log = makeLog();
 
     const result = await performNpmUpdateEdge('10.0.0-rc.12', '10.0.0-rc.11', log.fn);
 
     expect(result).toBe('updated');
     expect(execFileCalls).toEqual([{
-      file: canonicalCommand.nodeExecutable,
-      args: daemonRestartCommandArgs(canonicalCommand, '--version'),
+      file: canonicalCommand.executable,
+      args: canonicalCommand.args,
       opts: { encoding: 'utf-8', timeout: 30_000 },
     }]);
   });

--- a/packages/cli/test/rfc-41-bundle-b.test.ts
+++ b/packages/cli/test/rfc-41-bundle-b.test.ts
@@ -243,6 +243,7 @@ describe('performNpmUpdateEdge (Bundle B1b)', () => {
       operations.push(`${file} ${args.join(' ')}`);
       return Promise.resolve({ stdout: 'dkg 10.0.0-rc.12', stderr: '' });
     }) as any;
+    _autoUpdateIo.resolveDaemonRestartCommand = () => restartCommand;
   });
 
   afterEach(() => {
@@ -255,7 +256,6 @@ describe('performNpmUpdateEdge (Bundle B1b)', () => {
       '10.0.0-rc.12',
       '10.0.0-rc.11',
       log.fn,
-      restartCommand,
     );
 
     expect(result).toBe('updated');
@@ -282,7 +282,6 @@ describe('performNpmUpdateEdge (Bundle B1b)', () => {
       '10.0.0-rc.12',
       null,
       log.fn,
-      restartCommand,
     );
 
     expect(result).toBe('updated');
@@ -303,7 +302,6 @@ describe('performNpmUpdateEdge (Bundle B1b)', () => {
       '99.99.99',
       '10.0.0-rc.11',
       log.fn,
-      restartCommand,
     );
 
     expect(result).toBe('failed');
@@ -329,7 +327,6 @@ describe('performNpmUpdateEdge (Bundle B1b)', () => {
       '10.0.0-rc.12',
       '10.0.0-rc.11',
       log.fn,
-      restartCommand,
     );
     expect(result).toBe('failed');
     const restartProbe = `${restartCommand.nodeExecutable} ${restartCommand.nodeExecArgv.join(' ')} ${restartCommand.restartEntryPoint} --version`;
@@ -354,7 +351,6 @@ describe('performNpmUpdateEdge (Bundle B1b)', () => {
       '10.0.0-rc.12',
       null,
       log.fn,
-      restartCommand,
     );
     const restartProbe = `${restartCommand.nodeExecutable} ${restartCommand.nodeExecArgv.join(' ')} ${restartCommand.restartEntryPoint} --version`;
 
@@ -384,7 +380,6 @@ describe('performNpmUpdateEdge (Bundle B1b)', () => {
       '10.0.0-rc.12',
       '10.0.0-rc.11',
       log.fn,
-      restartCommand,
     );
     const restartProbe = `${restartCommand.nodeExecutable} ${restartCommand.nodeExecArgv.join(' ')} ${restartCommand.restartEntryPoint} --version`;
 
@@ -415,7 +410,6 @@ describe('performNpmUpdateEdge (Bundle B1b)', () => {
       '10.0.0-rc.1',
       '10.0.0-rc.0',
       log.fn,
-      restartCommand,
     );
     expect(result).toBe('failed');
     const restartProbe = `${restartCommand.nodeExecutable} ${restartCommand.nodeExecArgv.join(' ')} ${restartCommand.restartEntryPoint} --version`;
@@ -440,7 +434,6 @@ describe('performNpmUpdateEdge (Bundle B1b)', () => {
       '10.0.0-rc.12',
       '10.0.0-rc.11',
       log.fn,
-      restartCommand,
     );
 
     expect(result).toBe('failed');
@@ -450,6 +443,7 @@ describe('performNpmUpdateEdge (Bundle B1b)', () => {
 
   it('derives the default self-check from the canonical supervisor command', async () => {
     process.env.DKG_NO_BLUE_GREEN = '1';
+    _autoUpdateIo.resolveDaemonRestartCommand = origIo.resolveDaemonRestartCommand;
     const canonicalCommand = resolveDaemonRestartCommand();
     const log = makeLog();
 

--- a/packages/cli/test/rfc-41-bundle-b.test.ts
+++ b/packages/cli/test/rfc-41-bundle-b.test.ts
@@ -24,15 +24,22 @@ import { noteEdgeLegacyReleases } from '../src/migration.js';
 import { ensureStablePluginRoot } from '../src/daemon/plugin-loader.js';
 import { performNpmUpdateEdge } from '../src/daemon/auto-update.js';
 import { _autoUpdateIo } from '../src/daemon/manifest.js';
+import {
+  daemonRestartCommandArgs,
+  resolveDaemonRestartCommand,
+  type DaemonRestartCommand,
+} from '../src/daemon-entrypoint.js';
 
 let tmpDir: string;
 let dkgHome: string;
 let origDkgHome: string | undefined;
+let origNoBlueGreen: string | undefined;
 
 beforeEach(async () => {
   tmpDir = await mkdtemp(join(tmpdir(), 'dkg-bundleB-'));
   dkgHome = join(tmpDir, '.dkg');
   origDkgHome = process.env.DKG_HOME;
+  origNoBlueGreen = process.env.DKG_NO_BLUE_GREEN;
   process.env.DKG_HOME = dkgHome;
   await mkdir(dkgHome, { recursive: true });
 });
@@ -40,6 +47,8 @@ beforeEach(async () => {
 afterEach(async () => {
   if (origDkgHome === undefined) delete process.env.DKG_HOME;
   else process.env.DKG_HOME = origDkgHome;
+  if (origNoBlueGreen === undefined) delete process.env.DKG_NO_BLUE_GREEN;
+  else process.env.DKG_NO_BLUE_GREEN = origNoBlueGreen;
   await rm(tmpDir, { recursive: true, force: true });
 });
 
@@ -211,7 +220,7 @@ describe('performNpmUpdateEdge (Bundle B1b)', () => {
     nodeExecutable: '/usr/local/bin/node',
     nodeExecArgv: ['--enable-source-maps'],
     restartEntryPoint: '/npm-global/lib/node_modules/@origintrail-official/dkg/dist/cli.js',
-  } as const;
+  } satisfies DaemonRestartCommand;
   let execCalls: { cmd: string; opts?: any }[] = [];
   let execFileCalls: { file: string; args: string[]; opts?: any }[] = [];
   let operations: string[] = [];
@@ -234,7 +243,6 @@ describe('performNpmUpdateEdge (Bundle B1b)', () => {
       operations.push(`${file} ${args.join(' ')}`);
       return Promise.resolve({ stdout: 'dkg 10.0.0-rc.12', stderr: '' });
     }) as any;
-    _autoUpdateIo.edgeRestartCommand = () => restartCommand;
   });
 
   afterEach(() => {
@@ -247,6 +255,7 @@ describe('performNpmUpdateEdge (Bundle B1b)', () => {
       '10.0.0-rc.12',
       '10.0.0-rc.11',
       log.fn,
+      restartCommand,
     );
 
     expect(result).toBe('updated');
@@ -269,7 +278,12 @@ describe('performNpmUpdateEdge (Bundle B1b)', () => {
 
   it('warns when current version is unknown but still attempts the install', async () => {
     const log = makeLog();
-    const result = await performNpmUpdateEdge('10.0.0-rc.12', null, log.fn);
+    const result = await performNpmUpdateEdge(
+      '10.0.0-rc.12',
+      null,
+      log.fn,
+      restartCommand,
+    );
 
     expect(result).toBe('updated');
     expect(existsSync(join(dkgHome, 'previous-version'))).toBe(false);
@@ -285,7 +299,12 @@ describe('performNpmUpdateEdge (Bundle B1b)', () => {
     }) as any;
 
     const log = makeLog();
-    const result = await performNpmUpdateEdge('99.99.99', '10.0.0-rc.11', log.fn);
+    const result = await performNpmUpdateEdge(
+      '99.99.99',
+      '10.0.0-rc.11',
+      log.fn,
+      restartCommand,
+    );
 
     expect(result).toBe('failed');
     expect(log.calls.some((m) => m.includes('npm install -g failed'))).toBe(true);
@@ -310,6 +329,7 @@ describe('performNpmUpdateEdge (Bundle B1b)', () => {
       '10.0.0-rc.12',
       '10.0.0-rc.11',
       log.fn,
+      restartCommand,
     );
     expect(result).toBe('failed');
     const restartProbe = `${restartCommand.nodeExecutable} ${restartCommand.nodeExecArgv.join(' ')} ${restartCommand.restartEntryPoint} --version`;
@@ -320,6 +340,63 @@ describe('performNpmUpdateEdge (Bundle B1b)', () => {
       restartProbe,
     ]);
     expect(log.calls.some((message) => message.includes('rollback restored'))).toBe(true);
+  });
+
+  it('reports rollbackUnavailable when verification fails without a previous version', async () => {
+    _autoUpdateIo.execFile = (async (file: string, args: string[], opts?: any) => {
+      execFileCalls.push({ file, args, opts });
+      operations.push(`${file} ${args.join(' ')}`);
+      throw new Error('restart entry point cannot be executed');
+    }) as any;
+
+    const log = makeLog();
+    const result = await performNpmUpdateEdge(
+      '10.0.0-rc.12',
+      null,
+      log.fn,
+      restartCommand,
+    );
+    const restartProbe = `${restartCommand.nodeExecutable} ${restartCommand.nodeExecArgv.join(' ')} ${restartCommand.restartEntryPoint} --version`;
+
+    expect(result).toBe('failed');
+    expect(operations).toEqual([
+      'npm install -g @origintrail-official/dkg@10.0.0-rc.12',
+      restartProbe,
+    ]);
+    expect(log.calls.some((message) => message.includes('automatic rollback is unavailable'))).toBe(true);
+  });
+
+  it('reports rollbackFailed when reinstalling the previous version fails', async () => {
+    _autoUpdateIo.execFile = (async (file: string, args: string[], opts?: any) => {
+      execFileCalls.push({ file, args, opts });
+      operations.push(`${file} ${args.join(' ')}`);
+      throw new Error('restart entry point cannot be executed');
+    }) as any;
+    _autoUpdateIo.exec = (async (cmd: string, opts?: any) => {
+      execCalls.push({ cmd, opts });
+      operations.push(cmd);
+      if (cmd.endsWith('@10.0.0-rc.11')) throw new Error('rollback registry unavailable');
+      return { stdout: '', stderr: '' };
+    }) as any;
+
+    const log = makeLog();
+    const result = await performNpmUpdateEdge(
+      '10.0.0-rc.12',
+      '10.0.0-rc.11',
+      log.fn,
+      restartCommand,
+    );
+    const restartProbe = `${restartCommand.nodeExecutable} ${restartCommand.nodeExecArgv.join(' ')} ${restartCommand.restartEntryPoint} --version`;
+
+    expect(result).toBe('failed');
+    expect(operations).toEqual([
+      'npm install -g @origintrail-official/dkg@10.0.0-rc.12',
+      restartProbe,
+      'npm install -g @origintrail-official/dkg@10.0.0-rc.11',
+    ]);
+    expect(log.calls.some((message) => (
+      message.includes('CRITICAL rollback failed') && message.includes('rollback registry unavailable')
+    ))).toBe(true);
   });
 
   it('rolls back on an exact-version mismatch, including semver prefix collisions', async () => {
@@ -338,6 +415,7 @@ describe('performNpmUpdateEdge (Bundle B1b)', () => {
       '10.0.0-rc.1',
       '10.0.0-rc.0',
       log.fn,
+      restartCommand,
     );
     expect(result).toBe('failed');
     const restartProbe = `${restartCommand.nodeExecutable} ${restartCommand.nodeExecArgv.join(' ')} ${restartCommand.restartEntryPoint} --version`;
@@ -362,6 +440,7 @@ describe('performNpmUpdateEdge (Bundle B1b)', () => {
       '10.0.0-rc.12',
       '10.0.0-rc.11',
       log.fn,
+      restartCommand,
     );
 
     expect(result).toBe('failed');
@@ -369,16 +448,17 @@ describe('performNpmUpdateEdge (Bundle B1b)', () => {
     expect(log.calls.some((m) => m.includes('npm config set prefix'))).toBe(true);
   });
 
-  it('derives the default self-check from the current Node process command', async () => {
-    _autoUpdateIo.edgeRestartCommand = origIo.edgeRestartCommand;
+  it('derives the default self-check from the canonical supervisor command', async () => {
+    process.env.DKG_NO_BLUE_GREEN = '1';
+    const canonicalCommand = resolveDaemonRestartCommand();
     const log = makeLog();
 
     const result = await performNpmUpdateEdge('10.0.0-rc.12', '10.0.0-rc.11', log.fn);
 
     expect(result).toBe('updated');
     expect(execFileCalls).toEqual([{
-      file: process.execPath,
-      args: [...process.execArgv, process.argv[1], '--version'],
+      file: canonicalCommand.nodeExecutable,
+      args: daemonRestartCommandArgs(canonicalCommand, '--version'),
       opts: { encoding: 'utf-8', timeout: 30_000 },
     }]);
   });

--- a/scripts/devnet-test-issue-1567-global-cli-rollback.sh
+++ b/scripts/devnet-test-issue-1567-global-cli-rollback.sh
@@ -32,17 +32,17 @@ result="$(
   FAKE_DKG_RESTART_ENTRY="$tmp/restart-entry.mjs" \
   node --input-type=module <<'NODE'
 import { performNpmUpdateEdge } from './packages/cli/dist/daemon/auto-update.js';
-const restartCommand = {
+import { _autoUpdateIo } from './packages/cli/dist/daemon/manifest.js';
+_autoUpdateIo.resolveDaemonRestartCommand = () => ({
   nodeExecutable: process.execPath,
   nodeExecArgv: [],
   restartEntryPoint: process.env.FAKE_DKG_RESTART_ENTRY,
-};
+});
 const logs = [];
 const result = await performNpmUpdateEdge(
   '10.0.0-rc.1',
   '10.0.0-rc.0',
   (line) => logs.push(line),
-  restartCommand,
 );
 process.stdout.write(JSON.stringify({ result, logs }));
 NODE

--- a/scripts/devnet-test-issue-1567-global-cli-rollback.sh
+++ b/scripts/devnet-test-issue-1567-global-cli-rollback.sh
@@ -33,10 +33,10 @@ result="$(
   node --input-type=module <<'NODE'
 import { performNpmUpdateEdge } from './packages/cli/dist/daemon/auto-update.js';
 import { _autoUpdateIo } from './packages/cli/dist/daemon/manifest.js';
-_autoUpdateIo.resolveDaemonRestartCommand = () => ({
-  nodeExecutable: process.execPath,
-  nodeExecArgv: [],
-  restartEntryPoint: process.env.FAKE_DKG_RESTART_ENTRY,
+_autoUpdateIo.resolveDaemonNodeCommand = (...args) => ({
+  executable: process.execPath,
+  args: [process.env.FAKE_DKG_RESTART_ENTRY, ...args],
+  entryPoint: process.env.FAKE_DKG_RESTART_ENTRY,
 });
 const logs = [];
 const result = await performNpmUpdateEdge(

--- a/scripts/devnet-test-issue-1567-global-cli-rollback.sh
+++ b/scripts/devnet-test-issue-1567-global-cli-rollback.sh
@@ -32,17 +32,17 @@ result="$(
   FAKE_DKG_RESTART_ENTRY="$tmp/restart-entry.mjs" \
   node --input-type=module <<'NODE'
 import { performNpmUpdateEdge } from './packages/cli/dist/daemon/auto-update.js';
-import { _autoUpdateIo } from './packages/cli/dist/daemon/manifest.js';
-_autoUpdateIo.edgeRestartCommand = () => ({
+const restartCommand = {
   nodeExecutable: process.execPath,
   nodeExecArgv: [],
   restartEntryPoint: process.env.FAKE_DKG_RESTART_ENTRY,
-});
+};
 const logs = [];
 const result = await performNpmUpdateEdge(
   '10.0.0-rc.1',
   '10.0.0-rc.0',
   (line) => logs.push(line),
+  restartCommand,
 );
 process.stdout.write(JSON.stringify({ result, logs }));
 NODE


### PR DESCRIPTION
## Summary

- move daemon restart command construction into a canonical typed entrypoint helper shared by the supervisor and Edge update verifier
- keep the auto-update manifest seam as a dependency reference, with restart policy owned by daemon-entrypoint.ts
- preserve the exported three-argument performNpmUpdateEdge boundary; tests/devnet override the resolver through the existing IO seam
- replace the boolean verify/rollback result with explicit targetVerified, rollbackRestored, rollbackUnavailable, and rollbackFailed outcomes
- preserve install, verify, rollback, and rollback-verification behavior
- cover the actual foreground supervisor spawn path against a fake active Core slot
- keep the host-level issue-1567 rollback devnet scenario on the same resolver seam

Follow-up to the remaining review feedback on #1648.

## Tests

- pnpm -r --filter @origintrail-official/dkg... run build
- pnpm --dir packages/cli run build
- pnpm --dir packages/cli exec vitest run test/daemon-entrypoint-resolution.test.ts test/foreground-supervisor-command.test.ts test/rfc-41-bundle-b.test.ts test/edge-auto-update-entrypoint-e2e.test.ts (22 passed)
- bash -n scripts/devnet-test-issue-1567-global-cli-rollback.sh
- bash scripts/devnet-test-issue-1567-global-cli-rollback.sh (PASS: exact-version self-check rejected rc.12 and restored rc.0)