### PR TITLE
fix(testnet): remove implicit testing context graph

### DIFF
--- a/network/testnet.json
+++ b/network/testnet.json
@@ -9,7 +9,7 @@
     "/ip4/178.156.252.147/tcp/9090/p2p/12D3KooWPyTpqBBtU1AvzSsd5rWXCQzFcGtG44qDmeYenWcpzsge",
     "/ip4/49.12.4.64/tcp/9090/p2p/12D3KooWJqhnnfouiNRUyJBEREpuKtV4A448LUbS6JiVCe8Q82bZ"
   ],
-  "defaultContextGraphs": ["testing"],
+  "defaultContextGraphs": [],
   "defaultNodeRole": "edge",
   "autoUpdate": {
     "enabled": true,

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -192,6 +192,7 @@ describe('loadNetworkConfig', () => {
     expect(config.networkName).toBe('DKG V10 Base Testnet');
     expect((config as any).genesisId).toBe('base-testnet');
     expect(config.networkId).toBe('7449c543ff04a550b2dafa999fe8ee577a00b212023bb4d4244e8d58a4792c7b');
+    expect(config.defaultContextGraphs).toEqual([]);
   });
 
   it('loads mainnet prep configs without activating testnet genesis or relays', async () => {


### PR DESCRIPTION
## Summary

- remove the `testing` context graph from the Base testnet network defaults
- add a regression assertion that the testnet preset has no implicit context-graph subscriptions

## Why

A network-level default makes every new testnet node subscribe to the same long-lived graph without explicit operator or application intent. That creates hidden startup/catch-up work, lets historical data from a shared test fixture affect otherwise clean nodes, and makes load qualification dependent on unrelated graph history.

Testnet nodes can still subscribe to any context graph explicitly through node configuration or the context-graph subscription APIs. This only removes the automatic global subscription.

Archived deployment documents are intentionally left unchanged because they describe the former behavior.

## Verification

- `pnpm --filter @origintrail-official/dkg exec vitest run test/config.test.ts -t "loads a specific network by name"`
- `git diff --check`