### PR TITLE
fix(agent): avoid cloning durable sync results

### DIFF
--- a/packages/agent/src/sync-verify-worker-impl.ts
+++ b/packages/agent/src/sync-verify-worker-impl.ts
@@ -61,8 +61,23 @@ export function verifySyncedData(
   metaQuads: Quad[],
   acceptUnverified = false,
 ): SyncVerifyResult {
+  return verifySyncedDataImpl(dataQuads, metaQuads, acceptUnverified);
+}
+
+type VerifiedSelectionIndexes = {
+  data: number[];
+  meta: number[];
+};
+
+function verifySyncedDataImpl(
+  dataQuads: Quad[],
+  metaQuads: Quad[],
+  acceptUnverified = false,
+  recordSelection?: (indexes: VerifiedSelectionIndexes) => void,
+): SyncVerifyResult {
   const logs: SyncVerifyLogEntry[] = [];
   if (metaQuads.length === 0) {
+    recordSelection?.({ data: allIndexes(dataQuads), meta: [] });
     return { data: dataQuads, meta: metaQuads, rejected: 0, logs };
   }
 
@@ -115,6 +130,7 @@ export function verifySyncedData(
   }
 
   if (kcMerkleRoots.size === 0) {
+    recordSelection?.({ data: allIndexes(dataQuads), meta: allIndexes(metaQuads) });
     return { data: dataQuads, meta: metaQuads, rejected: 0, logs };
   }
 
@@ -194,6 +210,7 @@ export function verifySyncedData(
 
   if (acceptUnverified && rejected > 0 && verifiedKcUals.size < kcMerkleRoots.size) {
     logs.push({ level: 'debug', message: `Accepting ${rejected} unverified KC(s) (system context graph)` });
+    recordSelection?.({ data: allIndexes(dataQuads), meta: allIndexes(metaQuads) });
     return { data: dataQuads, meta: metaQuads, rejected: 0, logs };
   }
 
@@ -209,22 +226,47 @@ export function verifySyncedData(
     for (const rootEntity of entities) allKnownRootEntities.add(rootEntity);
   }
 
-  const verifiedData = dataQuads.filter((q) => {
+  const selectedData = selectQuads(dataQuads, (q) => {
     if (allKnownRootEntities.has(q.subject)) return verifiedRootEntities.has(q.subject);
     for (const rootEntity of verifiedRootEntities) {
       if (q.subject.startsWith(rootEntity)) return true;
     }
     return true;
-  });
+  }, recordSelection !== undefined);
 
-  const verifiedMeta = metaQuads.filter((q) => {
+  const selectedMeta = selectQuads(metaQuads, (q) => {
     if (kcMerkleRoots.has(q.subject)) return verifiedKcUals.has(q.subject);
     const kcUri = kaToKc.get(q.subject);
     if (kcUri) return verifiedKcUals.has(kcUri);
     return true;
+  }, recordSelection !== undefined);
+
+  recordSelection?.({
+    data: selectedData.indexes!,
+    meta: selectedMeta.indexes!,
   });
 
-  return { data: verifiedData, meta: verifiedMeta, rejected, logs };
+  return { data: selectedData.quads, meta: selectedMeta.quads, rejected, logs };
+}
+
+function allIndexes(source: readonly unknown[]): number[] {
+  return Array.from({ length: source.length }, (_, index) => index);
+}
+
+function selectQuads(
+  source: Quad[],
+  include: (quad: Quad) => boolean,
+  captureIndexes: boolean,
+): { quads: Quad[]; indexes?: number[] } {
+  const quads: Quad[] = [];
+  const indexes = captureIndexes ? [] as number[] : undefined;
+  for (let index = 0; index < source.length; index++) {
+    const quad = source[index];
+    if (!include(quad)) continue;
+    quads.push(quad);
+    indexes?.push(index);
+  }
+  return { quads, indexes };
 }
 
 function parseAndFilterNQuads(text: string, graphUri: string, contextGraphId: string): SyncParseResult {
@@ -418,11 +460,16 @@ function combineRegisteredSubGraphNames(
   return [...out];
 }
 
+type DurableBatchSelectionResult = DurableBatchProcessResult & {
+  verifiedDataIndexes: number[];
+  verifiedMetaIndexes: number[];
+};
+
 function processDurableBatch(
   dataQuads: Quad[],
   metaQuads: Quad[],
   acceptUnverified: boolean,
-): DurableBatchProcessResult {
+): DurableBatchSelectionResult {
   const logs: SyncVerifyLogEntry[] = [];
   const totalFetchedDataQuads = dataQuads.length;
   const totalFetchedMetaQuads = metaQuads.length;
@@ -431,6 +478,8 @@ function processDurableBatch(
     return {
       verifiedData: [],
       verifiedMeta: [],
+      verifiedDataIndexes: [],
+      verifiedMetaIndexes: [],
       totalFetchedDataQuads,
       totalFetchedMetaQuads,
       rejectedKcs: 0,
@@ -449,6 +498,8 @@ function processDurableBatch(
     return {
       verifiedData: [],
       verifiedMeta: [],
+      verifiedDataIndexes: [],
+      verifiedMetaIndexes: [],
       totalFetchedDataQuads,
       totalFetchedMetaQuads,
       rejectedKcs: 0,
@@ -467,10 +518,18 @@ function processDurableBatch(
     });
   }
 
-  const verified = verifySyncedData(dataQuads, metaQuads, acceptUnverified);
+  let verifiedIndexes: VerifiedSelectionIndexes = { data: [], meta: [] };
+  const verified = verifySyncedDataImpl(
+    dataQuads,
+    metaQuads,
+    acceptUnverified,
+    (indexes) => { verifiedIndexes = indexes; },
+  );
   return {
     verifiedData: verified.data,
     verifiedMeta: verified.meta,
+    verifiedDataIndexes: verifiedIndexes.data,
+    verifiedMetaIndexes: verifiedIndexes.meta,
     totalFetchedDataQuads,
     totalFetchedMetaQuads,
     rejectedKcs: verified.rejected,
@@ -488,28 +547,29 @@ function processDurableBatchForWire(
 ): DurableBatchProcessWireResult {
   const result = processDurableBatch(dataQuads, metaQuads, acceptUnverified);
   const {
-    verifiedData,
-    verifiedMeta,
-    ...summary
+    verifiedDataIndexes,
+    verifiedMetaIndexes,
+    totalFetchedDataQuads,
+    totalFetchedMetaQuads,
+    rejectedKcs,
+    emptyResponses,
+    metaOnlyResponses,
+    dataRejectedMissingMeta,
+    logs,
   } = result;
+  // Selection indexes are produced by the exact verification/filter pass,
+  // avoiding any hidden dependency on Quad object identity or source order.
   return {
-    ...summary,
-    // The selected arrays contain references from the worker-owned input
-    // arrays. Send their positions instead of cloning the complete Quad object
-    // graphs back into the requester isolate.
-    verifiedDataIndexes: selectedQuadIndexes(dataQuads, verifiedData),
-    verifiedMetaIndexes: selectedQuadIndexes(metaQuads, verifiedMeta),
+    verifiedDataIndexes,
+    verifiedMetaIndexes,
+    totalFetchedDataQuads,
+    totalFetchedMetaQuads,
+    rejectedKcs,
+    emptyResponses,
+    metaOnlyResponses,
+    dataRejectedMissingMeta,
+    logs,
   };
-}
-
-function selectedQuadIndexes(source: Quad[], selected: Quad[]): number[] {
-  if (selected.length === 0) return [];
-  const selectedSet = new Set(selected);
-  const indexes: number[] = [];
-  for (let i = 0; i < source.length; i++) {
-    if (selectedSet.has(source[i])) indexes.push(i);
-  }
-  return indexes;
 }
 
 function processSharedMemoryBatch(

--- a/packages/agent/src/sync-verify-worker-impl.ts
+++ b/packages/agent/src/sync-verify-worker-impl.ts
@@ -540,7 +540,7 @@ function processDurableBatch(
   };
 }
 
-function processDurableBatchForWire(
+export function processDurableBatchForWire(
   dataQuads: Quad[],
   metaQuads: Quad[],
   acceptUnverified: boolean,

--- a/packages/agent/src/sync-verify-worker-impl.ts
+++ b/packages/agent/src/sync-verify-worker-impl.ts
@@ -2,7 +2,7 @@ import { parentPort } from 'node:worker_threads';
 import { validateSubGraphName } from '@origintrail-official/dkg-core';
 import { computeFlatKCRootV10 as computeFlatKCRoot, skolemizeByEntity } from '@origintrail-official/dkg-publisher';
 import type { Quad } from '@origintrail-official/dkg-storage';
-import type { SyncVerifyResult, SyncVerifyLogEntry, SyncParseResult, SharedMemoryProcessResult, DurableBatchProcessResult, SharedMemoryBatchProcessResult } from './sync-verify-worker.js';
+import type { SyncVerifyResult, SyncVerifyLogEntry, SyncParseResult, SharedMemoryProcessResult, DurableBatchProcessResult, DurableBatchProcessWireResult, SharedMemoryBatchProcessResult } from './sync-verify-worker.js';
 import { isSharedMemoryBucketDescendantDataGraph } from './sync/shared-memory-graphs.js';
 import { appendInPlace } from './sync/append-in-place.js';
 
@@ -33,7 +33,7 @@ parentPort?.on('message', async (message: { id: number; method: string; args: un
     }
     if (message.method === 'processDurableBatch') {
       const [dataQuads, metaQuads, acceptUnverified] = message.args as [Quad[], Quad[], boolean];
-      const result = processDurableBatch(dataQuads, metaQuads, acceptUnverified);
+      const result = processDurableBatchForWire(dataQuads, metaQuads, acceptUnverified);
       parentPort!.postMessage({ id: message.id, result });
       return;
     }
@@ -479,6 +479,37 @@ function processDurableBatch(
     dataRejectedMissingMeta: 0,
     logs: [...logs, ...verified.logs],
   };
+}
+
+function processDurableBatchForWire(
+  dataQuads: Quad[],
+  metaQuads: Quad[],
+  acceptUnverified: boolean,
+): DurableBatchProcessWireResult {
+  const result = processDurableBatch(dataQuads, metaQuads, acceptUnverified);
+  const {
+    verifiedData,
+    verifiedMeta,
+    ...summary
+  } = result;
+  return {
+    ...summary,
+    // The selected arrays contain references from the worker-owned input
+    // arrays. Send their positions instead of cloning the complete Quad object
+    // graphs back into the requester isolate.
+    verifiedDataIndexes: selectedQuadIndexes(dataQuads, verifiedData),
+    verifiedMetaIndexes: selectedQuadIndexes(metaQuads, verifiedMeta),
+  };
+}
+
+function selectedQuadIndexes(source: Quad[], selected: Quad[]): number[] {
+  if (selected.length === 0) return [];
+  const selectedSet = new Set(selected);
+  const indexes: number[] = [];
+  for (let i = 0; i < source.length; i++) {
+    if (selectedSet.has(source[i])) indexes.push(i);
+  }
+  return indexes;
 }
 
 function processSharedMemoryBatch(

--- a/packages/agent/src/sync-verify-worker.ts
+++ b/packages/agent/src/sync-verify-worker.ts
@@ -203,15 +203,29 @@ export class SyncVerifyWorker {
     });
   }
 
+  /**
+   * Array membership and order are snapshotted before dispatch. Callers must
+   * keep the Quad objects themselves immutable until the returned promise
+   * settles so the caller-owned references still match the worker snapshot.
+   */
   processDurableBatch(
-    dataQuads: Quad[],
-    metaQuads: Quad[],
+    dataQuads: readonly Quad[],
+    metaQuads: readonly Quad[],
     acceptUnverified: boolean,
   ): Promise<DurableBatchProcessResult> {
+    // Preserve the array membership/order that the worker verifies without
+    // cloning the Quad object graph on the caller side. Callers may resize or
+    // reorder their arrays once this method returns.
+    const stableDataQuads = dataQuads.slice();
+    const stableMetaQuads = metaQuads.slice();
     const id = this.nextId++;
     return new Promise<DurableBatchProcessWireResult>((resolve, reject) => {
       this.pending.set(id, { resolve, reject });
-      this.worker.postMessage({ id, method: 'processDurableBatch', args: [dataQuads, metaQuads, acceptUnverified] });
+      this.worker.postMessage({
+        id,
+        method: 'processDurableBatch',
+        args: [stableDataQuads, stableMetaQuads, acceptUnverified],
+      });
     }).then((wireResult) => {
       const {
         verifiedDataIndexes,
@@ -220,8 +234,8 @@ export class SyncVerifyWorker {
       } = wireResult;
       return {
         ...summary,
-        verifiedData: selectQuadReferences(dataQuads, verifiedDataIndexes, 'data'),
-        verifiedMeta: selectQuadReferences(metaQuads, verifiedMetaIndexes, 'meta'),
+        verifiedData: selectQuadReferences(stableDataQuads, verifiedDataIndexes, 'data'),
+        verifiedMeta: selectQuadReferences(stableMetaQuads, verifiedMetaIndexes, 'meta'),
       };
     });
   }

--- a/packages/agent/src/sync-verify-worker.ts
+++ b/packages/agent/src/sync-verify-worker.ts
@@ -49,6 +49,22 @@ export interface DurableBatchProcessResult {
   logs: SyncVerifyLogEntry[];
 }
 
+/**
+ * Worker-wire form of {@link DurableBatchProcessResult}.
+ *
+ * Returning verified Quad objects through `postMessage()` structured-clones
+ * every accepted quad back into the requester heap. The requester already
+ * retains the original input arrays, so that clone briefly doubles the
+ * complete durable phase immediately before store serialization. Return only
+ * indexes across the worker boundary and rebuild arrays of references to the
+ * caller-owned quads on the main thread.
+ */
+export interface DurableBatchProcessWireResult
+  extends Omit<DurableBatchProcessResult, 'verifiedData' | 'verifiedMeta'> {
+  verifiedDataIndexes: number[];
+  verifiedMetaIndexes: number[];
+}
+
 export class SyncVerifyWorker {
   private readonly worker: Worker;
   private nextId = 0;
@@ -150,7 +166,7 @@ export class SyncVerifyWorker {
     }
 
     this.worker = new Worker(workerPath);
-    this.worker.on('message', (message: { id: number; result?: SyncVerifyResult; error?: string }) => {
+    this.worker.on('message', (message: { id: number; result?: unknown; error?: string }) => {
       const pending = this.pending.get(message.id);
       if (!pending) return;
       this.pending.delete(message.id);
@@ -193,9 +209,20 @@ export class SyncVerifyWorker {
     acceptUnverified: boolean,
   ): Promise<DurableBatchProcessResult> {
     const id = this.nextId++;
-    return new Promise<DurableBatchProcessResult>((resolve, reject) => {
+    return new Promise<DurableBatchProcessWireResult>((resolve, reject) => {
       this.pending.set(id, { resolve, reject });
       this.worker.postMessage({ id, method: 'processDurableBatch', args: [dataQuads, metaQuads, acceptUnverified] });
+    }).then((wireResult) => {
+      const {
+        verifiedDataIndexes,
+        verifiedMetaIndexes,
+        ...summary
+      } = wireResult;
+      return {
+        ...summary,
+        verifiedData: selectQuadReferences(dataQuads, verifiedDataIndexes, 'data'),
+        verifiedMeta: selectQuadReferences(metaQuads, verifiedMetaIndexes, 'meta'),
+      };
     });
   }
 
@@ -220,4 +247,20 @@ export class SyncVerifyWorker {
   async close(): Promise<void> {
     await this.worker.terminate();
   }
+}
+
+function selectQuadReferences(
+  source: Quad[],
+  indexes: readonly number[],
+  phase: 'data' | 'meta',
+): Quad[] {
+  const selected = new Array<Quad>(indexes.length);
+  for (let i = 0; i < indexes.length; i++) {
+    const index = indexes[i];
+    if (!Number.isSafeInteger(index) || index < 0 || index >= source.length) {
+      throw new Error(`Sync verify worker returned an invalid ${phase} quad index: ${index}`);
+    }
+    selected[i] = source[index];
+  }
+  return selected;
 }

--- a/packages/agent/test/sync-durable-worker-wire.test.ts
+++ b/packages/agent/test/sync-durable-worker-wire.test.ts
@@ -32,4 +32,85 @@ describe('durable sync worker result transport', () => {
       await worker.close();
     }
   });
+
+  it('reconstructs from the dispatched array order when callers resize or reorder inputs', async () => {
+    const worker = new SyncVerifyWorker();
+    const first: Quad = {
+      subject: 'urn:entity:first',
+      predicate: 'http://schema.org/name',
+      object: '"first"',
+      graph: 'did:dkg:context-graph:test/context/1',
+    };
+    const second: Quad = {
+      subject: 'urn:entity:second',
+      predicate: 'http://schema.org/name',
+      object: '"second"',
+      graph: 'did:dkg:context-graph:test/context/1',
+    };
+    const dataQuads = [first, second];
+
+    try {
+      const pending = worker.processDurableBatch(dataQuads, [], true);
+      dataQuads.reverse();
+      dataQuads.length = 0;
+
+      const result = await pending;
+      expect(result.verifiedData).toEqual([first, second]);
+      expect(result.verifiedData[0]).toBe(first);
+      expect(result.verifiedData[1]).toBe(second);
+    } finally {
+      await worker.close();
+    }
+  });
+
+  it('returns the exact retained data and meta subsets as caller-owned references', async () => {
+    const worker = new SyncVerifyWorker();
+    const graph = 'did:dkg:context-graph:test/context/1';
+    const rejectedData: Quad = {
+      subject: 'urn:entity:rejected',
+      predicate: 'http://schema.org/name',
+      object: '"rejected"',
+      graph,
+    };
+    const retainedData: Quad = {
+      subject: 'urn:entity:retained',
+      predicate: 'http://schema.org/name',
+      object: '"retained"',
+      graph,
+    };
+    const rejectedMerkle: Quad = {
+      subject: 'urn:ual:rejected',
+      predicate: 'http://dkg.io/ontology/merkleRoot',
+      object: `"${'0'.repeat(64)}"`,
+      graph,
+    };
+    const rejectedRoot: Quad = {
+      subject: 'urn:ual:rejected',
+      predicate: 'http://dkg.io/ontology/rootEntity',
+      object: '"urn:entity:rejected"',
+      graph,
+    };
+    const retainedMeta: Quad = {
+      subject: 'urn:meta:retained',
+      predicate: 'http://schema.org/name',
+      object: '"retained"',
+      graph,
+    };
+
+    try {
+      const result = await worker.processDurableBatch(
+        [rejectedData, retainedData],
+        [rejectedMerkle, rejectedRoot, retainedMeta],
+        false,
+      );
+
+      expect(result.rejectedKcs).toBe(1);
+      expect(result.verifiedData).toEqual([retainedData]);
+      expect(result.verifiedMeta).toEqual([retainedMeta]);
+      expect(result.verifiedData[0]).toBe(retainedData);
+      expect(result.verifiedMeta[0]).toBe(retainedMeta);
+    } finally {
+      await worker.close();
+    }
+  });
 });

--- a/packages/agent/test/sync-durable-worker-wire.test.ts
+++ b/packages/agent/test/sync-durable-worker-wire.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { Quad } from '@origintrail-official/dkg-storage';
 import { SyncVerifyWorker } from '../src/sync-verify-worker.js';
+import { processDurableBatchForWire } from '../src/sync-verify-worker-impl.js';
 
 describe('durable sync worker result transport', () => {
   it('reuses caller-owned quads instead of structured-cloning verified payloads back', async () => {
@@ -112,5 +113,69 @@ describe('durable sync worker result transport', () => {
     } finally {
       await worker.close();
     }
+  });
+
+  it('records every source index when a system graph accepts a Merkle mismatch', async () => {
+    const worker = new SyncVerifyWorker();
+    const graph = 'did:dkg:context-graph:test/context/1';
+    const data: Quad = {
+      subject: 'urn:entity:mismatch',
+      predicate: 'http://schema.org/name',
+      object: '"accepted"',
+      graph,
+    };
+    const merkleRoot: Quad = {
+      subject: 'urn:ual:mismatch',
+      predicate: 'http://dkg.io/ontology/merkleRoot',
+      object: `"${'0'.repeat(64)}"`,
+      graph,
+    };
+    const rootEntity: Quad = {
+      subject: 'urn:ual:mismatch',
+      predicate: 'http://dkg.io/ontology/rootEntity',
+      object: '"urn:entity:mismatch"',
+      graph,
+    };
+    const retainedMeta: Quad = {
+      subject: 'urn:meta:retained',
+      predicate: 'http://schema.org/name',
+      object: '"retained"',
+      graph,
+    };
+
+    try {
+      const result = await worker.processDurableBatch(
+        [data],
+        [merkleRoot, rootEntity, retainedMeta],
+        true,
+      );
+
+      expect(result.rejectedKcs).toBe(0);
+      expect(result.verifiedData).toEqual([data]);
+      expect(result.verifiedMeta).toEqual([merkleRoot, rootEntity, retainedMeta]);
+      expect(result.verifiedData[0]).toBe(data);
+      expect(result.verifiedMeta[0]).toBe(merkleRoot);
+      expect(result.verifiedMeta[1]).toBe(rootEntity);
+      expect(result.verifiedMeta[2]).toBe(retainedMeta);
+      expect(result.logs.some(({ message }) => message.includes('Accepting 1 unverified KC'))).toBe(true);
+    } finally {
+      await worker.close();
+    }
+  });
+
+  it('keeps verified Quad arrays off the raw worker response payload', () => {
+    const data: Quad = {
+      subject: 'urn:entity:wire',
+      predicate: 'http://schema.org/name',
+      object: '"wire"',
+      graph: 'did:dkg:context-graph:test/context/1',
+    };
+
+    const wireResult = processDurableBatchForWire([data], [], true);
+
+    expect(wireResult.verifiedDataIndexes).toEqual([0]);
+    expect(wireResult.verifiedMetaIndexes).toEqual([]);
+    expect(wireResult).not.toHaveProperty('verifiedData');
+    expect(wireResult).not.toHaveProperty('verifiedMeta');
   });
 });

--- a/packages/agent/test/sync-durable-worker-wire.test.ts
+++ b/packages/agent/test/sync-durable-worker-wire.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import type { Quad } from '@origintrail-official/dkg-storage';
+import { SyncVerifyWorker } from '../src/sync-verify-worker.js';
+
+describe('durable sync worker result transport', () => {
+  it('reuses caller-owned quads instead of structured-cloning verified payloads back', async () => {
+    const worker = new SyncVerifyWorker();
+    const dataQuads: Quad[] = [
+      {
+        subject: 'urn:entity:1',
+        predicate: 'http://schema.org/name',
+        object: '"one"',
+        graph: 'did:dkg:context-graph:test/context/1',
+      },
+      {
+        subject: 'urn:entity:2',
+        predicate: 'http://schema.org/name',
+        object: '"two"',
+        graph: 'did:dkg:context-graph:test/context/1',
+      },
+    ];
+
+    try {
+      const result = await worker.processDurableBatch(dataQuads, [], true);
+
+      expect(result.totalFetchedDataQuads).toBe(2);
+      expect(result.verifiedData).toEqual(dataQuads);
+      expect(result.verifiedData[0]).toBe(dataQuads[0]);
+      expect(result.verifiedData[1]).toBe(dataQuads[1]);
+      expect(result.verifiedMeta).toEqual([]);
+    } finally {
+      await worker.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- return verified durable-sync selections from the worker as quad indexes instead of complete `Quad` object graphs
- reconstruct arrays of references to the requester's existing input quads on the main thread
- preserve the current full-phase Merkle verification, filtering, counters, logs, checkpointing, and store-insert behavior
- add a worker regression proving the public result reuses caller-owned quad objects

## Incident

During the v10.0.6 mainnet rollout, SBB and DMaaST hit deterministic V8 heap OOMs immediately after large legacy durable-sync phases. DMaaST reproduced twice:

- 46,500 data + 6,100 meta triples, then OOM at about 2.03 GiB heap
- 35,500 data + 6,100 meta triples, then OOM at about 2.04 GiB heap

The requester already retains the complete parsed data/meta arrays. `processDurableBatch` then structured-cloned those arrays into the worker and structured-cloned every accepted quad back into the requester immediately before oversize filtering and Blazegraph serialization. The return clone temporarily duplicated the complete accepted payload in the already-pressured main isolate.

This PR keeps verification in the worker but returns only integer positions. The main isolate builds small arrays of references to the objects it already owns, removing that complete return-payload clone without changing which quads are accepted.

## Scope

This removes a concrete peak-memory amplifier; it does **not** claim to make a complete sync phase bounded. Incremental/KC-aware parse, verify, and staging remains the durable follow-up identified in #1569. A naive page cap is not used here because it can split a knowledge collection and advance the checkpoint past data rejected by Merkle verification.

## Verification

- `pnpm --filter @origintrail-official/dkg-agent... run build`
- focused Vitest: 5 files, 40/40 tests
  - `sync-durable-worker-wire.test.ts`
  - `sync-requester-progress.test.ts`
  - `sync-memory-metrics.test.ts`
  - `sync-verify-collapsed.test.ts`
  - `durable-sync-since-threading.test.ts`
- `git diff --check`
