### PR TITLE
fix(cli): infer legacy network overlay from chain ID

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -25,7 +25,7 @@ import {
   loadConfig, saveConfig, configExists, configPath,
   readPid, readApiPort, isProcessRunning, dkgDir, logPath, ensureDkgDir, removeApiPort,
   apiPortPath,
-  loadNetworkConfig, loadProjectConfig, resolveAutoUpdateConfig, resolveAutoUpdateSource, resolveChainConfig, validateNetworkConfigReadiness,
+  loadNetworkConfig, loadProjectConfig, resolveAutoUpdateConfig, resolveAutoUpdateSource, resolveChainConfig, resolveNetworkConfigName, validateNetworkConfigReadiness,
   releasesDir, activeSlot, swapSlot,
   slotEntryPoint, isStandaloneInstall, repoDir, isDkgMonorepo, classifyMonorepoInit, sharedHomeInitGate,
   resolveContextGraphs, resolveNetworkDefaultContextGraphs,
@@ -104,11 +104,10 @@ import {
 
 /**
  * Decide whether `dkg init` is SWITCHING an existing node to a different
- * network (vs a fresh install or a same-network re-init). Only an EXPLICIT
- * prior `networkConfig` that differs from the selection counts as a switch:
+ * network (vs a fresh install or a same-network re-init). A known prior
+ * effective network that differs from the selection counts as a switch:
  *   - fresh node (no networkConfig)               → not a switch (no chain to lose)
- *   - legacy node (no networkConfig, custom chain) → not a switch (preserve the
- *     operator's chain/RPC override — its true network is unknown)
+ *   - legacy node with a known chain              → compare its inferred network
  *   - node with networkConfig === selected        → not a switch (preserve overrides)
  *   - node with networkConfig !== selected        → SWITCH (drop the stale chain)
  *
@@ -118,10 +117,10 @@ import {
  * Pure + exported so the decision is unit-testable.
  */
 export function isInitNetworkSwitch(
-  existingNetworkConfig: string | undefined,
+  existingNetwork: string | undefined,
   selectedNetwork: string,
 ): boolean {
-  const prior = existingNetworkConfig?.trim();
+  const prior = existingNetwork?.trim();
   return !!prior && selectedNetwork !== prior;
 }
 
@@ -294,8 +293,9 @@ program
     await ensureDkgDir();
     const existing = await loadConfig();
     // Distinguish a genuinely fresh install (→ default mainnet) from a
-    // legacy node whose config predates `networkConfig` (→ testnet,
-    // preserved). `loadConfig` merges over defaults, so it can't tell us —
+    // legacy node whose config predates `networkConfig` (→ infer from a
+    // known chain, else preserve the testnet fallback). `loadConfig` merges
+    // over defaults, so it can't tell us —
     // probe the home directly (both json + yaml, like the daemon does).
     const configExisted = existsSync(join(dkgDir(), 'config.json'))
       || existsSync(join(dkgDir(), 'config.yaml'));
@@ -311,11 +311,14 @@ program
     // chosen network drives every downstream default (role, relay, context
     // graphs, auto-update, and the blockchain-config prompts below). Default:
     // mainnet-gnosis for a fresh node, the existing network on re-init, and
-    // testnet for a legacy config that never set one. `--network` (or `-y`)
-    // skips the prompt.
+    // the chain-inferred network (or testnet fallback) for a legacy config.
+    // `--network` (or `-y`) skips the prompt.
     const explicitNetwork = typeof opts.network === 'string' ? opts.network.trim() : '';
+    const existingNetwork = configExisted
+      ? resolveNetworkConfigName(existing)
+      : undefined;
     const networkDefault = resolveSetupNetworkName({
-      existingNetworkConfig: existing.networkConfig,
+      existingNetworkConfig: existingNetwork,
       configExisted,
     });
     let selectedNetwork: string;
@@ -467,14 +470,14 @@ program
     // network defaults so an operator who's only customised RPC keeps that
     // override even after `dkg init` re-prompts.
     //
-    // EXCEPT on a network SWITCH (an existing node with an explicit
-    // networkConfig that differs from the selection): the existing `chain`
+    // EXCEPT on a network SWITCH (an existing node whose effective explicit
+    // or chain-inferred network differs from the selection): the existing `chain`
     // block belongs to the OLD network (e.g. Base-mainnet hub/RPC/chainId) and
     // must NOT pre-fill or persist — otherwise the node would run the new
     // network's relays/genesis against the old chain (the Frankenstein config).
-    // See isInitNetworkSwitch — a fresh/legacy node is NOT a switch, so its
-    // chain field-merge (incl. operator RPC overrides) is preserved.
-    const isNetworkSwitch = isInitNetworkSwitch(existing.networkConfig, selectedNetwork);
+    // See isInitNetworkSwitch — a same-network legacy node preserves its
+    // chain field-merge (including operator RPC overrides).
+    const isNetworkSwitch = isInitNetworkSwitch(existingNetwork, selectedNetwork);
     const chainDefaults = resolveChainConfig(isNetworkSwitch ? undefined : existing, network);
     const defaultRpcUrl = chainDefaults?.rpcUrl;
     const defaultRpcUrls = chainDefaults?.rpcUrls?.join(', ') ?? '';

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -25,7 +25,7 @@ import {
   loadConfig, saveConfig, configExists, configPath,
   readPid, readApiPort, isProcessRunning, dkgDir, logPath, ensureDkgDir, removeApiPort,
   apiPortPath,
-  loadNetworkConfig, loadProjectConfig, resolveAutoUpdateConfig, resolveAutoUpdateSource, resolveChainConfig, resolveNetworkConfigName, validateNetworkConfigReadiness,
+  loadNetworkConfig, loadProjectConfig, resolveAutoUpdateConfig, resolveAutoUpdateSource, resolveChainConfig, resolveKnownNetworkConfigName, resolveNetworkConfigName, validateNetworkConfigReadiness,
   releasesDir, activeSlot, swapSlot,
   slotEntryPoint, isStandaloneInstall, repoDir, isDkgMonorepo, classifyMonorepoInit, sharedHomeInitGate,
   resolveContextGraphs, resolveNetworkDefaultContextGraphs,
@@ -314,8 +314,16 @@ program
     // the chain-inferred network (or testnet fallback) for a legacy config.
     // `--network` (or `-y`) skips the prompt.
     const explicitNetwork = typeof opts.network === 'string' ? opts.network.trim() : '';
+    // Keep the setup default and switch evidence separate. An unknown legacy
+    // chain still defaults to the project network for the prompt, but that
+    // fallback is not proof that the existing node actually belonged to it.
+    // Only explicit or uniquely chain-inferred state may cause us to discard
+    // operator RPC/hub overrides as a real network switch.
+    const knownExistingNetwork = configExisted
+      ? resolveKnownNetworkConfigName(existing)
+      : undefined;
     const existingNetwork = configExisted
-      ? resolveNetworkConfigName(existing)
+      ? knownExistingNetwork ?? resolveNetworkConfigName(existing)
       : undefined;
     const networkDefault = resolveSetupNetworkName({
       existingNetworkConfig: existingNetwork,
@@ -477,7 +485,7 @@ program
     // network's relays/genesis against the old chain (the Frankenstein config).
     // See isInitNetworkSwitch — a same-network legacy node preserves its
     // chain field-merge (including operator RPC overrides).
-    const isNetworkSwitch = isInitNetworkSwitch(existingNetwork, selectedNetwork);
+    const isNetworkSwitch = isInitNetworkSwitch(knownExistingNetwork, selectedNetwork);
     const chainDefaults = resolveChainConfig(isNetworkSwitch ? undefined : existing, network);
     const defaultRpcUrl = chainDefaults?.rpcUrl;
     const defaultRpcUrls = chainDefaults?.rpcUrls?.join(', ') ?? '';

--- a/packages/cli/src/commands/maintenance.ts
+++ b/packages/cli/src/commands/maintenance.ts
@@ -22,7 +22,7 @@ import {
   loadConfig, saveConfig, configExists, configPath,
   readPid, readApiPort, isProcessRunning, dkgDir, logPath, ensureDkgDir, removeApiPort,
   apiPortPath,
-  loadNetworkConfig, loadProjectConfig, resolveNetworkConfigName, resolveAutoUpdateConfig, resolveAutoUpdateSource, resolveChainConfig,
+  loadNetworkConfig, loadResolvedNetworkConfig, loadProjectConfig, resolveAutoUpdateConfig, resolveAutoUpdateSource, resolveChainConfig,
   releasesDir, activeSlot, swapSlot,
   slotEntryPoint, isStandaloneInstall, repoDir, isDkgMonorepo,
   resolveContextGraphs, resolveNetworkDefaultContextGraphs,
@@ -118,7 +118,7 @@ program
   .option('--no-verify-tag', 'Skip signed-tag verification for version/tag updates')
   .action(async (versionOrRef: string | undefined, opts: ActionOpts) => {
     const config = await loadConfig();
-    const net = await loadNetworkConfig(resolveNetworkConfigName(config));
+    const { network: net } = await loadResolvedNetworkConfig(config, loadNetworkConfig);
     // Resolve field-by-field across local/network/project so defaults flow
     // through even when the local config omits repo/branch.
     const au = resolveAutoUpdateConfig(config, net) ?? (() => {

--- a/packages/cli/src/commands/maintenance.ts
+++ b/packages/cli/src/commands/maintenance.ts
@@ -22,7 +22,7 @@ import {
   loadConfig, saveConfig, configExists, configPath,
   readPid, readApiPort, isProcessRunning, dkgDir, logPath, ensureDkgDir, removeApiPort,
   apiPortPath,
-  loadNetworkConfig, loadProjectConfig, resolveAutoUpdateConfig, resolveAutoUpdateSource, resolveChainConfig,
+  loadNetworkConfig, loadProjectConfig, resolveNetworkConfigName, resolveAutoUpdateConfig, resolveAutoUpdateSource, resolveChainConfig,
   releasesDir, activeSlot, swapSlot,
   slotEntryPoint, isStandaloneInstall, repoDir, isDkgMonorepo,
   resolveContextGraphs, resolveNetworkDefaultContextGraphs,
@@ -118,7 +118,7 @@ program
   .option('--no-verify-tag', 'Skip signed-tag verification for version/tag updates')
   .action(async (versionOrRef: string | undefined, opts: ActionOpts) => {
     const config = await loadConfig();
-    const net = await loadNetworkConfig(config.networkConfig);
+    const net = await loadNetworkConfig(resolveNetworkConfigName(config));
     // Resolve field-by-field across local/network/project so defaults flow
     // through even when the local config omits repo/branch.
     const au = resolveAutoUpdateConfig(config, net) ?? (() => {

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -19,7 +19,7 @@ import {
   loadConfig, saveConfig, configExists, configPath,
   readPid, readApiPort, isProcessRunning, dkgDir, logPath, ensureDkgDir, removeApiPort,
   apiPortPath,
-  loadNetworkConfig, loadProjectConfig, resolveAutoUpdateConfig, resolveAutoUpdateSource, resolveChainConfig,
+  listBundledNetworkConfigNames, loadNetworkConfig, loadProjectConfig, resolveAutoUpdateConfig, resolveAutoUpdateSource, resolveChainConfig,
   releasesDir, activeSlot, swapSlot,
   slotEntryPoint, isStandaloneInstall, repoDir, isDkgMonorepo,
   resolveContextGraphs, resolveNetworkDefaultContextGraphs,
@@ -187,7 +187,7 @@ mcpCmd
     try {
       await mcpSetupAction(opts, {
         loadNetworkConfig: openclawSetupExports.loadNetworkConfig,
-        networkConfigNames: coreExports.SELECTABLE_SETUP_NETWORKS,
+        networkConfigNames: listBundledNetworkConfigNames(),
         ensureDkgNodeConfig: coreExports.ensureDkgNodeConfig,
         startDaemon: openclawSetupExports.startDaemon,
         // Lazy + best-effort (parity with openclaw/hermes): dkg-agent is

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -187,6 +187,7 @@ mcpCmd
     try {
       await mcpSetupAction(opts, {
         loadNetworkConfig: openclawSetupExports.loadNetworkConfig,
+        networkConfigNames: coreExports.SELECTABLE_SETUP_NETWORKS,
         ensureDkgNodeConfig: coreExports.ensureDkgNodeConfig,
         startDaemon: openclawSetupExports.startDaemon,
         // Lazy + best-effort (parity with openclaw/hermes): dkg-agent is

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -19,7 +19,8 @@ import {
   loadConfig, saveConfig, configExists, configPath,
   readPid, readApiPort, isProcessRunning, dkgDir, logPath, ensureDkgDir, removeApiPort,
   apiPortPath,
-  listBundledNetworkConfigNames, loadNetworkConfig, loadProjectConfig, resolveAutoUpdateConfig, resolveAutoUpdateSource, resolveChainConfig,
+  loadNetworkConfig, loadProjectConfig, resolveAutoUpdateConfig, resolveAutoUpdateSource, resolveChainConfig,
+  resolveKnownNetworkConfigName,
   releasesDir, activeSlot, swapSlot,
   slotEntryPoint, isStandaloneInstall, repoDir, isDkgMonorepo,
   resolveContextGraphs, resolveNetworkDefaultContextGraphs,
@@ -187,7 +188,7 @@ mcpCmd
     try {
       await mcpSetupAction(opts, {
         loadNetworkConfig: openclawSetupExports.loadNetworkConfig,
-        networkConfigNames: listBundledNetworkConfigNames(),
+        resolveKnownNetworkConfigName,
         ensureDkgNodeConfig: coreExports.ensureDkgNodeConfig,
         startDaemon: openclawSetupExports.startDaemon,
         // Lazy + best-effort (parity with openclaw/hermes): dkg-agent is

--- a/packages/cli/src/commands/node-ops.ts
+++ b/packages/cli/src/commands/node-ops.ts
@@ -22,7 +22,7 @@ import {
   loadConfig, saveConfig, configExists, configPath,
   readPid, readApiPort, isProcessRunning, dkgDir, logPath, ensureDkgDir, removeApiPort,
   apiPortPath,
-  loadNetworkConfig, loadProjectConfig, resolveAutoUpdateConfig, resolveAutoUpdateSource, resolveChainConfig, resolveReadyChainConfig,
+  loadNetworkConfig, loadProjectConfig, resolveNetworkConfigName, resolveAutoUpdateConfig, resolveAutoUpdateSource, resolveChainConfig, resolveReadyChainConfig,
   releasesDir, activeSlot, swapSlot,
   slotEntryPoint, isStandaloneInstall, repoDir, isDkgMonorepo,
   resolveContextGraphs, resolveNetworkDefaultContextGraphs,
@@ -127,7 +127,7 @@ program
   .action(async () => {
     try {
       const config = await loadConfig();
-      const network = await loadNetworkConfig(config.networkConfig);
+      const network = await loadNetworkConfig(resolveNetworkConfigName(config));
       const { loadOpWallets } = await import('@origintrail-official/dkg-agent');
       const opWallets = await loadOpWallets(dkgDir());
 
@@ -222,7 +222,7 @@ program
   .action(async (amount: string, opts: ActionOpts) => {
     try {
       const config = await loadConfig();
-      const network = await loadNetworkConfig(config.networkConfig);
+      const network = await loadNetworkConfig(resolveNetworkConfigName(config));
       const { loadOpWallets } = await import('@origintrail-official/dkg-agent');
       const opWallets = await loadOpWallets(dkgDir());
 

--- a/packages/cli/src/commands/node-ops.ts
+++ b/packages/cli/src/commands/node-ops.ts
@@ -22,7 +22,7 @@ import {
   loadConfig, saveConfig, configExists, configPath,
   readPid, readApiPort, isProcessRunning, dkgDir, logPath, ensureDkgDir, removeApiPort,
   apiPortPath,
-  loadNetworkConfig, loadProjectConfig, resolveNetworkConfigName, resolveAutoUpdateConfig, resolveAutoUpdateSource, resolveChainConfig, resolveReadyChainConfig,
+  loadNetworkConfig, loadResolvedNetworkConfig, loadProjectConfig, resolveAutoUpdateConfig, resolveAutoUpdateSource, resolveChainConfig, resolveReadyChainConfig,
   releasesDir, activeSlot, swapSlot,
   slotEntryPoint, isStandaloneInstall, repoDir, isDkgMonorepo,
   resolveContextGraphs, resolveNetworkDefaultContextGraphs,
@@ -127,7 +127,7 @@ program
   .action(async () => {
     try {
       const config = await loadConfig();
-      const network = await loadNetworkConfig(resolveNetworkConfigName(config));
+      const { network } = await loadResolvedNetworkConfig(config, loadNetworkConfig);
       const { loadOpWallets } = await import('@origintrail-official/dkg-agent');
       const opWallets = await loadOpWallets(dkgDir());
 
@@ -222,7 +222,7 @@ program
   .action(async (amount: string, opts: ActionOpts) => {
     try {
       const config = await loadConfig();
-      const network = await loadNetworkConfig(resolveNetworkConfigName(config));
+      const { network } = await loadResolvedNetworkConfig(config, loadNetworkConfig);
       const { loadOpWallets } = await import('@origintrail-official/dkg-agent');
       const opWallets = await loadOpWallets(dkgDir());
 

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1103,13 +1103,9 @@ export function parseWeiFloor(
   return parsed;
 }
 
-let _networkConfig: NetworkConfig | null = null;
-let _networkConfigName: string | null = null;
 let _bundledNetworkRegistry: Readonly<Record<string, NetworkConfig>> | null = null;
 
 export function _resetNetworkConfigCache(): void {
-  _networkConfig = null;
-  _networkConfigName = null;
   _bundledNetworkRegistry = null;
 }
 
@@ -1536,6 +1532,20 @@ export function inferNetworkConfigNameFromChainId(
 }
 
 /**
+ * Resolve only network identities that are actually known from persisted
+ * state. Unlike {@link resolveNetworkConfigName}, this does not collapse an
+ * unknown legacy chain into the project default. Setup uses the distinction
+ * when deciding whether it is safe to discard operator chain overrides.
+ */
+export function resolveKnownNetworkConfigName(
+  config?: Pick<DkgConfig, 'networkConfig' | 'chain'> | null,
+): string | undefined {
+  const explicitNetwork = config?.networkConfig?.trim();
+  if (explicitNetwork) return explicitNetwork;
+  return inferNetworkConfigNameFromChainId(config?.chain?.chainId);
+}
+
+/**
  * Resolve the bundled network overlay for both current and legacy configs.
  *
  * Older homes predate `networkConfig` and only persisted the selected chain.
@@ -1546,16 +1556,7 @@ export function inferNetworkConfigNameFromChainId(
 export function resolveNetworkConfigName(
   config?: Pick<DkgConfig, 'networkConfig' | 'chain'> | null,
 ): string {
-  const explicitNetwork = config?.networkConfig?.trim();
-  if (explicitNetwork) return explicitNetwork;
-
-  const chainId = config?.chain?.chainId?.trim().toLowerCase();
-  if (chainId) {
-    const inferredNetwork = inferNetworkConfigNameFromChainId(chainId);
-    if (inferredNetwork) return inferredNetwork;
-  }
-
-  return loadProjectConfig().defaultNetwork;
+  return resolveKnownNetworkConfigName(config) ?? loadProjectConfig().defaultNetwork;
 }
 
 /**

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1103,9 +1103,13 @@ export function parseWeiFloor(
   return parsed;
 }
 
+let _networkConfig: NetworkConfig | null = null;
+let _networkConfigName: string | null = null;
 let _bundledNetworkRegistry: Readonly<Record<string, NetworkConfig>> | null = null;
 
 export function _resetNetworkConfigCache(): void {
+  _networkConfig = null;
+  _networkConfigName = null;
   _bundledNetworkRegistry = null;
 }
 
@@ -1486,7 +1490,7 @@ export async function loadNetworkConfig(network?: string): Promise<NetworkConfig
 function loadBundledNetworkRegistry(): Readonly<Record<string, NetworkConfig>> {
   if (_bundledNetworkRegistry) return _bundledNetworkRegistry;
 
-  _bundledNetworkRegistry = loadNetworkRegistryFromRoots(candidateRoots());
+  _bundledNetworkRegistry = loadNetworkRegistryFromRoots(runtimeAssetRoots());
   return _bundledNetworkRegistry;
 }
 

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -482,7 +482,9 @@ export interface DkgConfig {
   name: string;
   /**
    * Selects which bundled network/<name>.json overlay this node should use.
-   * When omitted, runtime falls back to project.json#defaultNetwork.
+   * When omitted, legacy configs infer the overlay from chain.chainId when it
+   * matches a bundled network; otherwise runtime falls back to
+   * project.json#defaultNetwork.
    */
   networkConfig?: string;
   relay?: string;
@@ -1483,8 +1485,34 @@ export async function loadNetworkConfig(network?: string): Promise<NetworkConfig
   }
 }
 
-export function resolveNetworkConfigName(config?: Pick<DkgConfig, 'networkConfig'> | null): string {
-  return config?.networkConfig?.trim() || loadProjectConfig().defaultNetwork;
+const LEGACY_NETWORK_BY_CHAIN_ID: Readonly<Record<string, string>> = {
+  'base:84532': 'testnet',
+  'base:8453': 'mainnet-base',
+  'gnosis:100': 'mainnet-gnosis',
+  'neuroweb:2043': 'mainnet-neuroweb',
+};
+
+/**
+ * Resolve the bundled network overlay for both current and legacy configs.
+ *
+ * Older homes predate `networkConfig` and only persisted the selected chain.
+ * Falling straight through to project.json#defaultNetwork can silently place
+ * one of those homes on the wrong p2p overlay. Infer known bundled networks
+ * from chainId; explicit operator selection always takes precedence.
+ */
+export function resolveNetworkConfigName(
+  config?: Pick<DkgConfig, 'networkConfig' | 'chain'> | null,
+): string {
+  const explicitNetwork = config?.networkConfig?.trim();
+  if (explicitNetwork) return explicitNetwork;
+
+  const chainId = config?.chain?.chainId?.trim().toLowerCase();
+  if (chainId) {
+    const inferredNetwork = LEGACY_NETWORK_BY_CHAIN_ID[chainId];
+    if (inferredNetwork) return inferredNetwork;
+  }
+
+  return loadProjectConfig().defaultNetwork;
 }
 
 /**

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1486,26 +1486,43 @@ export async function loadNetworkConfig(network?: string): Promise<NetworkConfig
 function loadBundledNetworkRegistry(): Readonly<Record<string, NetworkConfig>> {
   if (_bundledNetworkRegistry) return _bundledNetworkRegistry;
 
-  for (const root of candidateRoots()) {
+  _bundledNetworkRegistry = loadNetworkRegistryFromRoots(candidateRoots());
+  return _bundledNetworkRegistry;
+}
+
+/**
+ * Build the bundled registry entry-by-entry in root priority order.
+ *
+ * A malformed optional/experimental overlay must not make every known network
+ * unavailable. If a higher-priority root contains a bad copy of one entry, a
+ * valid package-local fallback for that same entry can still supply it.
+ */
+export function loadNetworkRegistryFromRoots(
+  roots: readonly string[],
+): Readonly<Record<string, NetworkConfig>> {
+  const registry: Record<string, NetworkConfig> = {};
+
+  for (const root of roots) {
     const networkDir = join(root, 'network');
+    let entries;
     try {
-      const registry: Record<string, NetworkConfig> = {};
-      for (const entry of readdirSync(networkDir, { withFileTypes: true })) {
-        if (!entry.isFile() || !entry.name.endsWith('.json')) continue;
-        const name = entry.name.slice(0, -'.json'.length);
+      entries = readdirSync(networkDir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith('.json')) continue;
+      const name = entry.name.slice(0, -'.json'.length);
+      if (registry[name] !== undefined) continue;
+      try {
         registry[name] = JSON.parse(
           readFileSync(join(networkDir, entry.name), 'utf-8'),
         ) as NetworkConfig;
-      }
-      if (Object.keys(registry).length > 0) {
-        _bundledNetworkRegistry = registry;
-        return registry;
-      }
-    } catch { /* try the next monorepo/package root */ }
+      } catch { /* isolate a malformed entry and continue */ }
+    }
   }
 
-  _bundledNetworkRegistry = {};
-  return _bundledNetworkRegistry;
+  return registry;
 }
 
 /**

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,6 +1,6 @@
 import { readFile, writeFile, mkdir, symlink, rename, unlink, readlink } from 'node:fs/promises';
 import { join, dirname, basename } from 'node:path';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import yaml from 'js-yaml';
 import type { DKGAgentConfig } from '@origintrail-official/dkg-agent';
@@ -1105,10 +1105,12 @@ export function parseWeiFloor(
 
 let _networkConfig: NetworkConfig | null = null;
 let _networkConfigName: string | null = null;
+let _bundledNetworkRegistry: Readonly<Record<string, NetworkConfig>> | null = null;
 
 export function _resetNetworkConfigCache(): void {
   _networkConfig = null;
   _networkConfigName = null;
+  _bundledNetworkRegistry = null;
 }
 
 export interface ProjectConfig {
@@ -1485,12 +1487,53 @@ export async function loadNetworkConfig(network?: string): Promise<NetworkConfig
   }
 }
 
-const LEGACY_NETWORK_BY_CHAIN_ID: Readonly<Record<string, string>> = {
-  'base:84532': 'testnet',
-  'base:8453': 'mainnet-base',
-  'gnosis:100': 'mainnet-gnosis',
-  'neuroweb:2043': 'mainnet-neuroweb',
-};
+function loadBundledNetworkRegistry(): Readonly<Record<string, NetworkConfig>> {
+  if (_bundledNetworkRegistry) return _bundledNetworkRegistry;
+
+  for (const root of candidateRoots()) {
+    const networkDir = join(root, 'network');
+    try {
+      const registry: Record<string, NetworkConfig> = {};
+      for (const entry of readdirSync(networkDir, { withFileTypes: true })) {
+        if (!entry.isFile() || !entry.name.endsWith('.json')) continue;
+        const name = entry.name.slice(0, -'.json'.length);
+        registry[name] = JSON.parse(
+          readFileSync(join(networkDir, entry.name), 'utf-8'),
+        ) as NetworkConfig;
+      }
+      if (Object.keys(registry).length > 0) {
+        _bundledNetworkRegistry = registry;
+        return registry;
+      }
+    } catch { /* try the next monorepo/package root */ }
+  }
+
+  _bundledNetworkRegistry = {};
+  return _bundledNetworkRegistry;
+}
+
+/**
+ * Infer an overlay from its canonical bundled network config's chain ID.
+ * Production reads network/*.json, so adding a network needs no second table.
+ * Tests and embedders may supply a registry explicitly.
+ */
+export function inferNetworkConfigNameFromChainId(
+  chainId: string | null | undefined,
+  registry: Readonly<Record<string, Pick<NetworkConfig, 'chain'>>> = loadBundledNetworkRegistry(),
+): string | undefined {
+  const normalized = chainId?.trim().toLowerCase();
+  if (!normalized) return undefined;
+
+  let matchedName: string | undefined;
+  for (const [name, network] of Object.entries(registry)) {
+    if (network.chain?.chainId?.trim().toLowerCase() !== normalized) continue;
+    // Ambiguous chain ownership is not safe to infer. Require an explicit
+    // networkConfig until the bundled registry is unique again.
+    if (matchedName && matchedName !== name) return undefined;
+    matchedName = name;
+  }
+  return matchedName;
+}
 
 /**
  * Resolve the bundled network overlay for both current and legacy configs.
@@ -1508,7 +1551,7 @@ export function resolveNetworkConfigName(
 
   const chainId = config?.chain?.chainId?.trim().toLowerCase();
   if (chainId) {
-    const inferredNetwork = LEGACY_NETWORK_BY_CHAIN_ID[chainId];
+    const inferredNetwork = inferNetworkConfigNameFromChainId(chainId);
     if (inferredNetwork) return inferredNetwork;
   }
 

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1490,6 +1490,13 @@ function loadBundledNetworkRegistry(): Readonly<Record<string, NetworkConfig>> {
   return _bundledNetworkRegistry;
 }
 
+/** Every valid network overlay bundled with this CLI, including entries that
+ * are intentionally omitted from the interactive setup menu. Persisted-config
+ * inference must use this registry rather than UI curation. */
+export function listBundledNetworkConfigNames(): readonly string[] {
+  return Object.keys(loadBundledNetworkRegistry()).sort();
+}
+
 /**
  * Build the bundled registry entry-by-entry in root priority order.
  *
@@ -1530,9 +1537,13 @@ export function loadNetworkRegistryFromRoots(
  * Production reads network/*.json, so adding a network needs no second table.
  * Tests and embedders may supply a registry explicitly.
  */
+export interface NetworkChainIdentity {
+  chain?: { chainId?: string | null };
+}
+
 export function inferNetworkConfigNameFromChainId(
   chainId: string | null | undefined,
-  registry: Readonly<Record<string, Pick<NetworkConfig, 'chain'>>> = loadBundledNetworkRegistry(),
+  registry: Readonly<Record<string, NetworkChainIdentity>> = loadBundledNetworkRegistry(),
 ): string | undefined {
   const normalized = chainId?.trim().toLowerCase();
   if (!normalized) return undefined;
@@ -1556,10 +1567,11 @@ export function inferNetworkConfigNameFromChainId(
  */
 export function resolveKnownNetworkConfigName(
   config?: Pick<DkgConfig, 'networkConfig' | 'chain'> | null,
+  registry: Readonly<Record<string, NetworkChainIdentity>> = loadBundledNetworkRegistry(),
 ): string | undefined {
   const explicitNetwork = config?.networkConfig?.trim();
   if (explicitNetwork) return explicitNetwork;
-  return inferNetworkConfigNameFromChainId(config?.chain?.chainId);
+  return inferNetworkConfigNameFromChainId(config?.chain?.chainId, registry);
 }
 
 /**
@@ -1574,6 +1586,24 @@ export function resolveNetworkConfigName(
   config?: Pick<DkgConfig, 'networkConfig' | 'chain'> | null,
 ): string {
   return resolveKnownNetworkConfigName(config) ?? loadProjectConfig().defaultNetwork;
+}
+
+export interface LoadedResolvedNetworkConfig {
+  name: string;
+  network: NetworkConfig | null;
+}
+
+/**
+ * Resolve legacy chain-only homes and load their effective overlay at one
+ * boundary. Callers that need network metadata should use this instead of
+ * manually composing resolveNetworkConfigName() and loadNetworkConfig().
+ */
+export async function loadResolvedNetworkConfig(
+  config?: Pick<DkgConfig, 'networkConfig' | 'chain'> | null,
+  loader: (name: string) => Promise<NetworkConfig | null> = loadNetworkConfig,
+): Promise<LoadedResolvedNetworkConfig> {
+  const name = resolveNetworkConfigName(config);
+  return { name, network: await loader(name) };
 }
 
 /**

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1118,9 +1118,9 @@ export async function runDaemonInner(
   }
 
   const storageAckTiming = resolveStorageAckTiming(config.storageAck);
-  const selectedNetworkConfig = config.networkConfig?.trim();
+  const selectedNetworkConfig = resolveNetworkConfigName(config);
   const network = await loadNetworkConfig(selectedNetworkConfig);
-  if (selectedNetworkConfig && !network) {
+  if (!network) {
     log(`FATAL: network config "${selectedNetworkConfig}" was not found (expected network/${selectedNetworkConfig}.json).`);
     process.exit(1);
   }

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -104,6 +104,7 @@ import {
   loadConfig,
   saveConfig,
   loadNetworkConfig,
+  loadResolvedNetworkConfig,
   resolveAutoUpdateConfig,
   resolveChainConfig,
   dkgDir,
@@ -125,7 +126,6 @@ import {
   type LocalAgentIntegrationTransport,
   resolveContextGraphs,
   resolveNetworkDefaultContextGraphs,
-  resolveNetworkConfigName,
   resolveSharedMemoryTtlMs,
   resolveStorageAckTiming,
   repoDir,
@@ -1118,8 +1118,10 @@ export async function runDaemonInner(
   }
 
   const storageAckTiming = resolveStorageAckTiming(config.storageAck);
-  const selectedNetworkConfig = resolveNetworkConfigName(config);
-  const network = await loadNetworkConfig(selectedNetworkConfig);
+  const { name: selectedNetworkConfig, network } = await loadResolvedNetworkConfig(
+    config,
+    loadNetworkConfig,
+  );
   if (!network) {
     log(`FATAL: network config "${selectedNetworkConfig}" was not found (expected network/${selectedNetworkConfig}.json).`);
     process.exit(1);
@@ -1169,7 +1171,7 @@ export async function runDaemonInner(
   // 'testnet' fallback and never spuriously trips on a normal restart.
   const networkSwitch = detectNetworkSwitch({
     dataDir: dkgDir(),
-    currentNetworkConfig: resolveNetworkConfigName(config),
+    currentNetworkConfig: selectedNetworkConfig,
     acceptNetworkSwitch: process.env.DKG_ACCEPT_NETWORK_SWITCH === '1',
     log,
   });
@@ -1542,7 +1544,7 @@ export async function runDaemonInner(
       genesisId: network?.genesisId,
       networkId,
       chainId: chainBase?.chainId,
-      networkConfigName: resolveNetworkConfigName(config),
+      networkConfigName: selectedNetworkConfig,
     },
     framework: "DKG",
     listenPort: config.listenPort,

--- a/packages/cli/src/mcp-setup.ts
+++ b/packages/cli/src/mcp-setup.ts
@@ -75,7 +75,6 @@ import TOML from '@iarna/toml';
 import { resolveSetupNetworkName } from '@origintrail-official/dkg-core';
 import {
   assertSelectableNetwork,
-  resolveKnownNetworkConfigName,
   type DkgConfig,
 } from './config.js';
 
@@ -158,6 +157,8 @@ export interface PlannedItem {
  */
 export interface McpSetupActionDeps {
   loadNetworkConfig: typeof import('@origintrail-official/dkg-adapter-openclaw').loadNetworkConfig;
+  /** Candidate names resolved through the same injected loader above. */
+  networkConfigNames: readonly string[];
   /**
    * Codex Round-23 Fix 30: agent-agnostic config-write helper from
    * `dkg-core`. Pre-fix this dep was `adapter-openclaw`'s
@@ -220,6 +221,33 @@ export interface McpSetupActionDeps {
     planned: readonly PlannedItem[],
     opts: { yes: boolean },
   ) => Promise<PlannedItem[]>;
+}
+
+function resolveKnownNetworkConfigNameFromLoader(
+  config: Pick<DkgConfig, 'networkConfig' | 'chain'> | undefined,
+  networkConfigNames: readonly string[],
+  loadNetworkConfig: (
+    name: string,
+  ) => ReturnType<McpSetupActionDeps['loadNetworkConfig']>,
+): string | undefined {
+  const explicit = config?.networkConfig?.trim();
+  if (explicit) return explicit;
+
+  const chainId = config?.chain?.chainId?.trim().toLowerCase();
+  if (!chainId) return undefined;
+
+  let matchedName: string | undefined;
+  for (const name of networkConfigNames) {
+    try {
+      const network = loadNetworkConfig(name);
+      if (network.chain?.chainId?.trim().toLowerCase() !== chainId) continue;
+      if (matchedName && matchedName !== name) return undefined;
+      matchedName = name;
+    } catch {
+      // One unavailable candidate must not prevent inference from the rest.
+    }
+  }
+  return matchedName;
 }
 
 /**
@@ -1796,10 +1824,24 @@ export async function mcpSetupAction(
   // and reuse it for both the config write and the faucet gate, so the
   // persisted selector, the loaded network slice, and the faucet decision
   // (mainnet has no faucet) all agree.
+  type LoadedNetworkConfig = ReturnType<McpSetupActionDeps['loadNetworkConfig']>;
+  const loadedNetworks = new Map<string, LoadedNetworkConfig>();
+  const loadSetupNetworkConfig = (name: string): LoadedNetworkConfig => {
+    const cached = loadedNetworks.get(name);
+    if (cached !== undefined) return cached;
+    const network = deps.loadNetworkConfig(name);
+    loadedNetworks.set(name, network);
+    return network;
+  };
+
   const persistedNodeConfig = readPersistedConfig(dkgDirPath) as
     | Pick<DkgConfig, 'networkConfig' | 'chain'>
     | undefined;
-  const existingNetworkConfig = resolveKnownNetworkConfigName(persistedNodeConfig);
+  const existingNetworkConfig = resolveKnownNetworkConfigNameFromLoader(
+    persistedNodeConfig,
+    deps.networkConfigNames,
+    loadSetupNetworkConfig,
+  );
   // `--network` is honored only for a FRESH node (existing nodes keep their
   // current network; switch via `dkg init --network`). Dropping it on an
   // existing node keeps the faucet decision aligned with the booted network
@@ -1878,7 +1920,7 @@ export async function mcpSetupAction(
     console.log(`[setup] [dry-run] Would write ${tildify(jsonPath)} (port ${effectivePort}, name "${effectiveAgentName}")`);
   } else {
     try {
-      const network = deps.loadNetworkConfig(setupNetworkConfigName);
+      const network = loadSetupNetworkConfig(setupNetworkConfigName);
       // Codex Round-23 Fix 30: call the agent-agnostic
       // ensureDkgNodeConfig directly. The caller-loads-existing
       // contract means we pre-read the persisted config (yaml or
@@ -1959,7 +2001,7 @@ export async function mcpSetupAction(
     console.log('[setup] [dry-run] Would attempt wallet funding');
   } else {
     try {
-      const network = deps.loadNetworkConfig(setupNetworkConfigName);
+      const network = loadSetupNetworkConfig(setupNetworkConfigName);
       await deps.fundWalletsBestEffort({
         network,
         idempotencySeed: effectiveAgentName,

--- a/packages/cli/src/mcp-setup.ts
+++ b/packages/cli/src/mcp-setup.ts
@@ -75,7 +75,9 @@ import TOML from '@iarna/toml';
 import { resolveSetupNetworkName } from '@origintrail-official/dkg-core';
 import {
   assertSelectableNetwork,
+  resolveKnownNetworkConfigName,
   type DkgConfig,
+  type NetworkChainIdentity,
 } from './config.js';
 
 export interface McpSetupCliOptions {
@@ -157,7 +159,7 @@ export interface PlannedItem {
  */
 export interface McpSetupActionDeps {
   loadNetworkConfig: typeof import('@origintrail-official/dkg-adapter-openclaw').loadNetworkConfig;
-  /** Candidate names resolved through the same injected loader above. */
+  /** All bundled candidate names, including networks omitted from setup UI. */
   networkConfigNames: readonly string[];
   /**
    * Codex Round-23 Fix 30: agent-agnostic config-write helper from
@@ -230,24 +232,16 @@ function resolveKnownNetworkConfigNameFromLoader(
     name: string,
   ) => ReturnType<McpSetupActionDeps['loadNetworkConfig']>,
 ): string | undefined {
-  const explicit = config?.networkConfig?.trim();
-  if (explicit) return explicit;
-
-  const chainId = config?.chain?.chainId?.trim().toLowerCase();
-  if (!chainId) return undefined;
-
-  let matchedName: string | undefined;
+  const registry: Record<string, NetworkChainIdentity> = {};
   for (const name of networkConfigNames) {
     try {
       const network = loadNetworkConfig(name);
-      if (network.chain?.chainId?.trim().toLowerCase() !== chainId) continue;
-      if (matchedName && matchedName !== name) return undefined;
-      matchedName = name;
+      registry[name] = { chain: network.chain };
     } catch {
       // One unavailable candidate must not prevent inference from the rest.
     }
   }
-  return matchedName;
+  return resolveKnownNetworkConfigName(config, registry);
 }
 
 /**

--- a/packages/cli/src/mcp-setup.ts
+++ b/packages/cli/src/mcp-setup.ts
@@ -73,7 +73,11 @@ import { execSync } from 'node:child_process';
 import yaml from 'js-yaml';
 import TOML from '@iarna/toml';
 import { resolveSetupNetworkName } from '@origintrail-official/dkg-core';
-import { assertSelectableNetwork } from './config.js';
+import {
+  assertSelectableNetwork,
+  resolveKnownNetworkConfigName,
+  type DkgConfig,
+} from './config.js';
 
 export interface McpSetupCliOptions {
   /** Refresh every detected client regardless of current registration state. */
@@ -1792,10 +1796,10 @@ export async function mcpSetupAction(
   // and reuse it for both the config write and the faucet gate, so the
   // persisted selector, the loaded network slice, and the faucet decision
   // (mainnet has no faucet) all agree.
-  const existingNetworkConfig = ((): string | undefined => {
-    const nc = readPersistedConfig(dkgDirPath)?.networkConfig;
-    return typeof nc === 'string' ? nc : undefined;
-  })();
+  const persistedNodeConfig = readPersistedConfig(dkgDirPath) as
+    | Pick<DkgConfig, 'networkConfig' | 'chain'>
+    | undefined;
+  const existingNetworkConfig = resolveKnownNetworkConfigName(persistedNodeConfig);
   // `--network` is honored only for a FRESH node (existing nodes keep their
   // current network; switch via `dkg init --network`). Dropping it on an
   // existing node keeps the faucet decision aligned with the booted network

--- a/packages/cli/src/mcp-setup.ts
+++ b/packages/cli/src/mcp-setup.ts
@@ -77,7 +77,6 @@ import {
   assertSelectableNetwork,
   resolveKnownNetworkConfigName,
   type DkgConfig,
-  type NetworkChainIdentity,
 } from './config.js';
 
 export interface McpSetupCliOptions {
@@ -159,8 +158,8 @@ export interface PlannedItem {
  */
 export interface McpSetupActionDeps {
   loadNetworkConfig: typeof import('@origintrail-official/dkg-adapter-openclaw').loadNetworkConfig;
-  /** All bundled candidate names, including networks omitted from setup UI. */
-  networkConfigNames: readonly string[];
+  /** Canonical persisted-config network resolver, injectable for tests. */
+  resolveKnownNetworkConfigName: typeof resolveKnownNetworkConfigName;
   /**
    * Codex Round-23 Fix 30: agent-agnostic config-write helper from
    * `dkg-core`. Pre-fix this dep was `adapter-openclaw`'s
@@ -223,25 +222,6 @@ export interface McpSetupActionDeps {
     planned: readonly PlannedItem[],
     opts: { yes: boolean },
   ) => Promise<PlannedItem[]>;
-}
-
-function resolveKnownNetworkConfigNameFromLoader(
-  config: Pick<DkgConfig, 'networkConfig' | 'chain'> | undefined,
-  networkConfigNames: readonly string[],
-  loadNetworkConfig: (
-    name: string,
-  ) => ReturnType<McpSetupActionDeps['loadNetworkConfig']>,
-): string | undefined {
-  const registry: Record<string, NetworkChainIdentity> = {};
-  for (const name of networkConfigNames) {
-    try {
-      const network = loadNetworkConfig(name);
-      registry[name] = { chain: network.chain };
-    } catch {
-      // One unavailable candidate must not prevent inference from the rest.
-    }
-  }
-  return resolveKnownNetworkConfigName(config, registry);
 }
 
 /**
@@ -1831,11 +1811,7 @@ export async function mcpSetupAction(
   const persistedNodeConfig = readPersistedConfig(dkgDirPath) as
     | Pick<DkgConfig, 'networkConfig' | 'chain'>
     | undefined;
-  const existingNetworkConfig = resolveKnownNetworkConfigNameFromLoader(
-    persistedNodeConfig,
-    deps.networkConfigNames,
-    loadSetupNetworkConfig,
-  );
+  const existingNetworkConfig = deps.resolveKnownNetworkConfigName(persistedNodeConfig);
   // `--network` is honored only for a FRESH node (existing nodes keep their
   // current network; switch via `dkg init --network`). Dropping it on an
   // existing node keeps the faucet decision aligned with the booted network

--- a/packages/cli/src/migration.ts
+++ b/packages/cli/src/migration.ts
@@ -2,7 +2,7 @@ import { existsSync, lstatSync, readFileSync } from 'node:fs';
 import { mkdir, rm, readFile, readlink, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { execSync, execFileSync } from 'node:child_process';
-import { releasesDir, repoDir, swapSlot, loadConfig, loadNetworkConfig, loadProjectConfig, gitCommandEnv, gitCommandArgs, slotReady, activeSlot, dkgDir } from './config.js';
+import { releasesDir, repoDir, swapSlot, loadConfig, loadNetworkConfig, loadProjectConfig, resolveNetworkConfigName, gitCommandEnv, gitCommandArgs, slotReady, activeSlot, dkgDir } from './config.js';
 import {
   FULL_BUILD_COMMAND,
   isNodeUiGitLayoutSlot,
@@ -102,7 +102,7 @@ export async function migrateToBlueGreen(
   }
 
   const config = await loadConfig().catch(() => ({} as any));
-  const network = await loadNetworkConfig(config?.networkConfig).catch(() => undefined);
+  const network = await loadNetworkConfig(resolveNetworkConfigName(config)).catch(() => undefined);
   const gitEnv = gitCommandEnv(config?.autoUpdate ?? network?.autoUpdate);
   const localRepo = repoDir();
   const hasLocalRepo = Boolean(localRepo && existsSync(join(localRepo, '.git')));

--- a/packages/cli/src/migration.ts
+++ b/packages/cli/src/migration.ts
@@ -2,7 +2,7 @@ import { existsSync, lstatSync, readFileSync } from 'node:fs';
 import { mkdir, rm, readFile, readlink, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { execSync, execFileSync } from 'node:child_process';
-import { releasesDir, repoDir, swapSlot, loadConfig, loadNetworkConfig, loadProjectConfig, resolveNetworkConfigName, gitCommandEnv, gitCommandArgs, slotReady, activeSlot, dkgDir } from './config.js';
+import { releasesDir, repoDir, swapSlot, loadConfig, loadNetworkConfig, loadProjectConfig, loadResolvedNetworkConfig, gitCommandEnv, gitCommandArgs, slotReady, activeSlot, dkgDir } from './config.js';
 import {
   FULL_BUILD_COMMAND,
   isNodeUiGitLayoutSlot,
@@ -102,7 +102,9 @@ export async function migrateToBlueGreen(
   }
 
   const config = await loadConfig().catch(() => ({} as any));
-  const network = await loadNetworkConfig(resolveNetworkConfigName(config)).catch(() => undefined);
+  const network = await loadResolvedNetworkConfig(config, loadNetworkConfig)
+    .then((resolved) => resolved.network)
+    .catch(() => undefined);
   const gitEnv = gitCommandEnv(config?.autoUpdate ?? network?.autoUpdate);
   const localRepo = repoDir();
   const hasLocalRepo = Boolean(localRepo && existsSync(join(localRepo, '.git')));

--- a/packages/cli/src/publisher-runner.ts
+++ b/packages/cli/src/publisher-runner.ts
@@ -4,7 +4,7 @@ import { EVMChainAdapter, NoChainAdapter, mergeRpcUsageWindows, type ChainAdapte
 import { TypedEventBus, type Ed25519Keypair } from '@origintrail-official/dkg-core';
 import { ACKCollector, AsyncLiftRunner, DKGPublisher, FileWorkspacePublicSnapshotStore, TripleStoreAsyncLiftPublisher, wrapAsRpcPreconditionIfApplicable, type ACKTransport, type ACKTransportFactory, type AsyncLiftPublishExecutionInput, type AsyncLiftPublisher, type AsyncLiftPublisherConfig, type AsyncLiftPublisherRecoveryResult, type LiftJobBroadcast, type LiftJobIncluded, type PublishOptions, type V10ACKProviderParams, type WorkspacePublicSnapshotStore } from '@origintrail-official/dkg-publisher';
 import { createTripleStore, type TripleStore } from '@origintrail-official/dkg-storage';
-import { loadNetworkConfig, resolveNetworkConfigName, resolveReadyChainConfig, type DkgConfig } from './config.js';
+import { loadNetworkConfig, loadResolvedNetworkConfig, resolveReadyChainConfig, type DkgConfig } from './config.js';
 import {
   projectRuntimeEvmChainConfig,
   type RuntimeEvmChainConfig,
@@ -288,7 +288,7 @@ export async function createPublisherRuntime(args: {
     throw new Error('No publisher wallets configured. Use `dkg publisher wallet add <privateKey>` first.');
   }
 
-  const network = await loadNetworkConfig(resolveNetworkConfigName(args.config));
+  const { network } = await loadResolvedNetworkConfig(args.config, loadNetworkConfig);
   const keypair = await loadOrCreateAgentWallet(args.dataDir);
   const store = await createPublisherStore(args.dataDir, args.config);
   const publicSnapshotStore = createPublicSnapshotStore(args.dataDir, args.config);

--- a/packages/cli/src/publisher-runner.ts
+++ b/packages/cli/src/publisher-runner.ts
@@ -4,7 +4,7 @@ import { EVMChainAdapter, NoChainAdapter, mergeRpcUsageWindows, type ChainAdapte
 import { TypedEventBus, type Ed25519Keypair } from '@origintrail-official/dkg-core';
 import { ACKCollector, AsyncLiftRunner, DKGPublisher, FileWorkspacePublicSnapshotStore, TripleStoreAsyncLiftPublisher, wrapAsRpcPreconditionIfApplicable, type ACKTransport, type ACKTransportFactory, type AsyncLiftPublishExecutionInput, type AsyncLiftPublisher, type AsyncLiftPublisherConfig, type AsyncLiftPublisherRecoveryResult, type LiftJobBroadcast, type LiftJobIncluded, type PublishOptions, type V10ACKProviderParams, type WorkspacePublicSnapshotStore } from '@origintrail-official/dkg-publisher';
 import { createTripleStore, type TripleStore } from '@origintrail-official/dkg-storage';
-import { loadNetworkConfig, resolveReadyChainConfig, type DkgConfig } from './config.js';
+import { loadNetworkConfig, resolveNetworkConfigName, resolveReadyChainConfig, type DkgConfig } from './config.js';
 import {
   projectRuntimeEvmChainConfig,
   type RuntimeEvmChainConfig,
@@ -288,7 +288,7 @@ export async function createPublisherRuntime(args: {
     throw new Error('No publisher wallets configured. Use `dkg publisher wallet add <privateKey>` first.');
   }
 
-  const network = await loadNetworkConfig(args.config.networkConfig);
+  const network = await loadNetworkConfig(resolveNetworkConfigName(args.config));
   const keypair = await loadOrCreateAgentWallet(args.dataDir);
   const store = await createPublisherStore(args.dataDir, args.config);
   const publicSnapshotStore = createPublicSnapshotStore(args.dataDir, args.config);

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -25,6 +25,7 @@ import {
   sharedHomeInitGate,
   repoDir,
   inferNetworkConfigNameFromChainId,
+  loadNetworkRegistryFromRoots,
   resolveKnownNetworkConfigName,
   resolveNetworkConfigName,
   resolveAutoUpdateConfig,
@@ -149,6 +150,25 @@ describe('removePid / removeApiPort (catch path)', () => {
 });
 
 describe('loadNetworkConfig', () => {
+  it('keeps a valid requested network available when an unrelated overlay is malformed', async () => {
+    const root = join(tmpdir(), `dkg-network-registry-${randomBytes(8).toString('hex')}`);
+    await mkdir(join(root, 'network'), { recursive: true });
+    try {
+      await writeFile(join(root, 'network', 'testnet.json'), JSON.stringify({
+        networkName: 'Fixture Testnet',
+        relays: [],
+        defaultNodeRole: 'edge',
+      }));
+      await writeFile(join(root, 'network', 'experimental.json'), '{not-json');
+
+      const registry = loadNetworkRegistryFromRoots([root]);
+      expect(registry.testnet?.networkName).toBe('Fixture Testnet');
+      expect(registry.experimental).toBeUndefined();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it('loads network/testnet.json with correct shape when run from repo', async () => {
     const config = await loadNetworkConfig();
     if (!config) {

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -25,6 +25,8 @@ import {
   sharedHomeInitGate,
   repoDir,
   inferNetworkConfigNameFromChainId,
+  listBundledNetworkConfigNames,
+  loadResolvedNetworkConfig,
   loadNetworkRegistryFromRoots,
   resolveKnownNetworkConfigName,
   resolveNetworkConfigName,
@@ -560,6 +562,22 @@ describe('localAgentIntegrations config round-trip', () => {
       expect(network).not.toBeNull();
       expect(inferNetworkConfigNameFromChainId(network?.chain?.chainId)).toBe(name);
     }
+  });
+
+  it('lists every bundled overlay, including networks omitted from setup menus', () => {
+    expect(listBundledNetworkConfigNames()).toEqual([
+      'mainnet-base',
+      'mainnet-gnosis',
+      'mainnet-neuroweb',
+      'testnet',
+    ]);
+  });
+
+  it('loads a legacy chain-only config through one resolved-network boundary', async () => {
+    const resolved = await loadResolvedNetworkConfig({ chain: { chainId: 'neuroweb:2043' } });
+
+    expect(resolved.name).toBe('mainnet-neuroweb');
+    expect(resolved.network?.chain?.chainId).toBe('neuroweb:2043');
   });
 
   it('refuses to infer an ambiguous chain shared by two overlays', () => {

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -25,6 +25,7 @@ import {
   sharedHomeInitGate,
   repoDir,
   inferNetworkConfigNameFromChainId,
+  resolveKnownNetworkConfigName,
   resolveNetworkConfigName,
   resolveAutoUpdateConfig,
   resolveAutoUpdateSource,
@@ -533,6 +534,14 @@ describe('localAgentIntegrations config round-trip', () => {
     })).toBe('fixture-network');
   });
 
+  it('uses the same bundled registry for load-by-name and chain inference', async () => {
+    for (const name of ['testnet', 'mainnet-base', 'mainnet-gnosis'] as const) {
+      const network = await loadNetworkConfig(name);
+      expect(network).not.toBeNull();
+      expect(inferNetworkConfigNameFromChainId(network?.chain?.chainId)).toBe(name);
+    }
+  });
+
   it('refuses to infer an ambiguous chain shared by two overlays', () => {
     const chain = {
       type: 'evm' as const,
@@ -564,6 +573,12 @@ describe('localAgentIntegrations config round-trip', () => {
     expect(resolveNetworkConfigName({})).toBe('testnet');
     expect(resolveNetworkConfigName({ networkConfig: '   ' })).toBe('testnet');
     expect(resolveNetworkConfigName({ chain: { chainId: 'evm:31337' } })).toBe('testnet');
+  });
+
+  it('keeps unknown legacy chains distinguishable from the project fallback', () => {
+    expect(resolveKnownNetworkConfigName({})).toBeUndefined();
+    expect(resolveKnownNetworkConfigName({ chain: { chainId: 'evm:31337' } })).toBeUndefined();
+    expect(resolveKnownNetworkConfigName({ chain: { chainId: 'gnosis:100' } })).toBe('mainnet-gnosis');
   });
 
   it('round-trips relayServerCapacity through saveConfig/loadConfig (operator override)', async () => {

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -24,6 +24,7 @@ import {
   classifyMonorepoInit,
   sharedHomeInitGate,
   repoDir,
+  inferNetworkConfigNameFromChainId,
   resolveNetworkConfigName,
   resolveAutoUpdateConfig,
   resolveAutoUpdateSource,
@@ -517,6 +518,32 @@ describe('localAgentIntegrations config round-trip', () => {
     expect(resolveNetworkConfigName({ chain: { chainId: ' BASE:8453 ' } })).toBe('mainnet-base');
     expect(resolveNetworkConfigName({ chain: { chainId: 'gnosis:100' } })).toBe('mainnet-gnosis');
     expect(resolveNetworkConfigName({ chain: { chainId: 'neuroweb:2043' } })).toBe('mainnet-neuroweb');
+  });
+
+  it('derives legacy inference from the supplied bundled-network registry', () => {
+    expect(inferNetworkConfigNameFromChainId('fixture:42', {
+      'fixture-network': {
+        chain: {
+          type: 'evm',
+          chainId: 'fixture:42',
+          rpcUrl: 'https://fixture.invalid',
+          hubAddress: '0x0000000000000000000000000000000000000042',
+        },
+      },
+    })).toBe('fixture-network');
+  });
+
+  it('refuses to infer an ambiguous chain shared by two overlays', () => {
+    const chain = {
+      type: 'evm' as const,
+      chainId: 'fixture:42',
+      rpcUrl: 'https://fixture.invalid',
+      hubAddress: '0x0000000000000000000000000000000000000042',
+    };
+    expect(inferNetworkConfigNameFromChainId('fixture:42', {
+      first: { chain },
+      second: { chain },
+    })).toBeUndefined();
   });
 
   it('keeps explicit networkConfig authoritative over chain inference', () => {

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -512,9 +512,31 @@ describe('localAgentIntegrations config round-trip', () => {
     expect(resolveNetworkConfigName(loaded)).toBe('mainnet-base');
   });
 
-  it('falls back to project default network when networkConfig is unset or blank', () => {
+  it('infers legacy network selection from a known chainId', () => {
+    expect(resolveNetworkConfigName({ chain: { chainId: 'base:84532' } })).toBe('testnet');
+    expect(resolveNetworkConfigName({ chain: { chainId: ' BASE:8453 ' } })).toBe('mainnet-base');
+    expect(resolveNetworkConfigName({ chain: { chainId: 'gnosis:100' } })).toBe('mainnet-gnosis');
+    expect(resolveNetworkConfigName({ chain: { chainId: 'neuroweb:2043' } })).toBe('mainnet-neuroweb');
+  });
+
+  it('keeps explicit networkConfig authoritative over chain inference', () => {
+    expect(resolveNetworkConfigName({
+      networkConfig: 'mainnet-base',
+      chain: { chainId: 'gnosis:100' },
+    })).toBe('mainnet-base');
+  });
+
+  it('infers from chain when networkConfig is blank', () => {
+    expect(resolveNetworkConfigName({
+      networkConfig: '   ',
+      chain: { chainId: 'gnosis:100' },
+    })).toBe('mainnet-gnosis');
+  });
+
+  it('falls back to project default network without a known legacy chain', () => {
     expect(resolveNetworkConfigName({})).toBe('testnet');
     expect(resolveNetworkConfigName({ networkConfig: '   ' })).toBe('testnet');
+    expect(resolveNetworkConfigName({ chain: { chainId: 'evm:31337' } })).toBe('testnet');
   });
 
   it('round-trips relayServerCapacity through saveConfig/loadConfig (operator override)', async () => {

--- a/packages/cli/test/daemon-startup-validation.test.ts
+++ b/packages/cli/test/daemon-startup-validation.test.ts
@@ -201,7 +201,7 @@ describe('daemon startup network validation', () => {
     );
   });
 
-  it('passes the selected network genesis id into agent creation', async () => {
+  it('infers a legacy network from chainId and passes its genesis id into agent creation', async () => {
     tempHome = await mkdtemp(join(tmpdir(), 'dkg-genesis-startup-'));
     originalDkgHome = process.env.DKG_HOME;
     process.env.DKG_HOME = tempHome;
@@ -223,14 +223,13 @@ describe('daemon startup network validation', () => {
 
     await expect(runDaemonInner(true, {
       name: 'genesis-startup-test',
-      networkConfig: 'mainnet-gnosis',
       listenPort: 0,
       nodeRole: 'edge',
       chain: {
         type: 'evm',
         rpcUrl: 'https://private-rpc.example',
         hubAddress: '0x1234567890123456789012345678901234567890',
-        chainId: 'evm:100',
+        chainId: 'gnosis:100',
       },
     } as any, Date.now())).rejects.toThrow('after-agent-create');
 
@@ -249,7 +248,7 @@ describe('daemon startup network validation', () => {
       },
     });
     expect((createArg.chainEventCursorStore as any).scope).toBe(buildEvmDeploymentId({
-      chainId: 'evm:100',
+      chainId: 'gnosis:100',
       hubAddress: '0x1234567890123456789012345678901234567890',
     }));
     closeDashboardDbFromAgentCreateArg(createArg);

--- a/packages/cli/test/init.test.ts
+++ b/packages/cli/test/init.test.ts
@@ -4,6 +4,7 @@ import { buildInitAutoUpdate, isInitNetworkSwitch } from '../src/commands/init.j
 import {
   loadNetworkConfig,
   resolveChainConfig,
+  resolveKnownNetworkConfigName,
   resolveNetworkConfigName,
 } from '../src/config.js';
 
@@ -28,8 +29,26 @@ describe('isInitNetworkSwitch', () => {
     expect(isInitNetworkSwitch('testnet', 'mainnet-gnosis')).toBe(true);
   });
 
-  it('a legacy node with no recognizable chain remains on the testnet fallback', () => {
-    expect(isInitNetworkSwitch('testnet', 'testnet')).toBe(false);
+  it('does not treat the fallback as switch evidence for an unknown legacy chain', async () => {
+    const existing = {
+      chain: {
+        type: 'evm' as const,
+        chainId: 'evm:100',
+        rpcUrl: 'https://operator-rpc.invalid',
+        hubAddress: '0x0000000000000000000000000000000000000042',
+      },
+    };
+    const knownExistingNetwork = resolveKnownNetworkConfigName(existing);
+    const selectedNetwork = 'mainnet-gnosis';
+    const network = await loadNetworkConfig(selectedNetwork);
+    const switching = isInitNetworkSwitch(knownExistingNetwork, selectedNetwork);
+    const persistedChain = resolveChainConfig(switching ? undefined : existing, network);
+
+    expect(knownExistingNetwork).toBeUndefined();
+    expect(switching).toBe(false);
+    expect(persistedChain?.chainId).toBe('evm:100');
+    expect(persistedChain?.rpcUrl).toBe('https://operator-rpc.invalid');
+    expect(persistedChain?.hubAddress).toBe('0x0000000000000000000000000000000000000042');
   });
 
   it('keeps legacy Base/Gnosis setup defaults and persisted chain fields consistent', async () => {

--- a/packages/cli/test/init.test.ts
+++ b/packages/cli/test/init.test.ts
@@ -1,10 +1,16 @@
 import { describe, it, expect } from 'vitest';
+import { resolveSetupNetworkName } from '@origintrail-official/dkg-core';
 import { buildInitAutoUpdate, isInitNetworkSwitch } from '../src/commands/init.js';
+import {
+  loadNetworkConfig,
+  resolveChainConfig,
+  resolveNetworkConfigName,
+} from '../src/config.js';
 
 // Guards the network-SWITCH decision that drives whether `dkg init` discards
 // the existing chain block (new-network/old-chain Frankenstein prevention) or
-// preserves it (operator RPC override). Only an EXPLICIT prior networkConfig
-// that differs counts as a switch.
+// preserves it (operator RPC override). The prior effective network may be
+// explicit or inferred from a legacy chain ID.
 describe('isInitNetworkSwitch', () => {
   it('is NOT a switch for a fresh node (no networkConfig)', () => {
     expect(isInitNetworkSwitch(undefined, 'mainnet-gnosis')).toBe(false);
@@ -17,15 +23,46 @@ describe('isInitNetworkSwitch', () => {
     expect(isInitNetworkSwitch('  mainnet-base  ', 'mainnet-base')).toBe(false);
   });
 
-  it('IS a switch when an explicit prior networkConfig differs from the selection', () => {
+  it('IS a switch when the effective prior network differs from the selection', () => {
     expect(isInitNetworkSwitch('mainnet-base', 'testnet')).toBe(true);
     expect(isInitNetworkSwitch('testnet', 'mainnet-gnosis')).toBe(true);
   });
 
-  it('a legacy node (no networkConfig) re-inited to a real network is NOT a switch — its chain override is preserved', () => {
-    // The legacy node never persisted networkConfig, so its true network is
-    // unknown; treat as same-network so resolveChainConfig keeps existing.chain.
-    expect(isInitNetworkSwitch(undefined, 'mainnet-gnosis')).toBe(false);
+  it('a legacy node with no recognizable chain remains on the testnet fallback', () => {
+    expect(isInitNetworkSwitch('testnet', 'testnet')).toBe(false);
+  });
+
+  it('keeps legacy Base/Gnosis setup defaults and persisted chain fields consistent', async () => {
+    for (const [chainId, expectedNetwork] of [
+      ['base:8453', 'mainnet-base'],
+      ['gnosis:100', 'mainnet-gnosis'],
+    ] as const) {
+      const existing = {
+        chain: {
+          type: 'evm' as const,
+          chainId,
+          rpcUrl: `https://operator-${expectedNetwork}.invalid`,
+          hubAddress: '0x0000000000000000000000000000000000000042',
+        },
+      };
+      const existingNetwork = resolveNetworkConfigName(existing);
+      const selectedNetwork = resolveSetupNetworkName({
+        existingNetworkConfig: existingNetwork,
+        configExisted: true,
+      });
+      const network = await loadNetworkConfig(selectedNetwork);
+      const switching = isInitNetworkSwitch(existingNetwork, selectedNetwork);
+      const persisted = {
+        ...existing,
+        networkConfig: selectedNetwork,
+        chain: resolveChainConfig(switching ? undefined : existing, network),
+      };
+
+      expect(persisted.networkConfig).toBe(expectedNetwork);
+      expect(persisted.chain?.chainId).toBe(chainId);
+      expect(persisted.chain?.rpcUrl).toBe(`https://operator-${expectedNetwork}.invalid`);
+      expect(switching).toBe(false);
+    }
   });
 });
 

--- a/packages/cli/test/mcp-setup.test.ts
+++ b/packages/cli/test/mcp-setup.test.ts
@@ -177,6 +177,7 @@ describe('mcpSetupAction — bundled init + daemon-start + register flow', () =>
     const ensureDkgNodeConfig = recorder((opts: {
       agentName: string;
       network: any;
+      networkConfigName: string;
       apiPort: number;
       existing: Record<string, any>;
       overrides?: { nameExplicit?: boolean; portExplicit?: boolean };
@@ -191,6 +192,7 @@ describe('mcpSetupAction — bundled init + daemon-start + register flow', () =>
         ...opts.existing,
         name: opts.overrides?.nameExplicit ? opts.agentName : (opts.existing?.name ?? opts.agentName),
         apiPort: opts.overrides?.portExplicit ? opts.apiPort : (opts.existing?.apiPort ?? opts.apiPort),
+        networkConfig: opts.networkConfigName,
         nodeRole: opts.existing?.nodeRole ?? 'edge',
       };
       writeFileSync(
@@ -198,12 +200,20 @@ describe('mcpSetupAction — bundled init + daemon-start + register flow', () =>
         JSON.stringify(merged, null, 2),
       );
     });
-    const loadNetworkConfig = recorder(() => ({
-      networkName: 'test-net',
+    const loadNetworkConfig = recorder((networkName = 'testnet') => ({
+      networkName,
       relays: [],
       defaultContextGraphs: ['agent-context'],
       defaultNodeRole: 'edge',
       faucet: { url: 'http://faucet.test', mode: 'testnet' },
+      chain: {
+        chainId: ({
+          testnet: 'base:84532',
+          'mainnet-base': 'base:8453',
+          'mainnet-gnosis': 'gnosis:100',
+          'mainnet-neuroweb': 'neuroweb:2043',
+        } as Record<string, string>)[networkName],
+      },
     }) as any);
     // Eager wallet creation (issue #1306). Idempotent generate-if-absent;
     // mcpSetupAction ignores the return value (the faucet re-reads from disk),
@@ -249,6 +259,7 @@ describe('mcpSetupAction — bundled init + daemon-start + register flow', () =>
     );
     return {
       loadNetworkConfig,
+      networkConfigNames: ['testnet', 'mainnet-base', 'mainnet-gnosis', 'mainnet-neuroweb'],
       ensureDkgNodeConfig,
       startDaemon,
       loadOpWallets,
@@ -377,8 +388,61 @@ describe('mcpSetupAction — bundled init + daemon-start + register flow', () =>
     const deps = makeDeps();
     await mcpSetupAction({ port: '9300', start: false, verify: false, fund: false }, deps);
 
-    expect((deps.loadNetworkConfig as any).calls[0][0]).toBe('mainnet-gnosis');
+    expect((deps.loadNetworkConfig as any).calls.map((call: any[]) => call[0])).toContain('mainnet-gnosis');
     expect((deps.ensureDkgNodeConfig as any).calls).toHaveLength(1);
+    const writeArgs = (deps.ensureDkgNodeConfig as any).calls[0][0];
+    expect(writeArgs.networkConfigName).toBe('mainnet-gnosis');
+    const rewritten = JSON.parse(readFileSync(join(dkgDir, 'config.json'), 'utf-8'));
+    expect(rewritten).toMatchObject({
+      networkConfig: 'mainnet-gnosis',
+      chain: {
+        chainId: 'gnosis:100',
+        rpcUrl: 'https://operator-rpc.invalid',
+        hubAddress: '0x0000000000000000000000000000000000000042',
+      },
+    });
+  });
+
+  it('infers a legacy chain exclusively through injected network metadata', async () => {
+    const dkgDir = join(tmpHome, '.dkg');
+    mkdirSync(dkgDir, { recursive: true });
+    writeFileSync(join(dkgDir, 'config.json'), JSON.stringify({
+      name: 'fixture-legacy',
+      apiPort: 9200,
+      chain: {
+        type: 'evm',
+        chainId: 'fixture:42',
+        rpcUrl: 'https://fixture-rpc.invalid',
+        hubAddress: '0x0000000000000000000000000000000000000042',
+      },
+    }, null, 2));
+    mkdirSync(join(tmpHome, '.cursor'), { recursive: true });
+    const injectedLoader = recorder((name: string) => {
+      if (name !== 'fixture-mainnet') throw new Error(`unexpected network ${name}`);
+      return {
+        networkName: 'Fixture Mainnet',
+        relays: [],
+        defaultContextGraphs: [],
+        defaultNodeRole: 'edge',
+        chain: { chainId: 'fixture:42' },
+      } as any;
+    });
+    const deps = makeDeps({
+      loadNetworkConfig: injectedLoader as any,
+      networkConfigNames: ['fixture-mainnet'],
+    });
+
+    await mcpSetupAction({ port: '9300', start: false, verify: false, fund: false }, deps);
+
+    const writeArgs = (deps.ensureDkgNodeConfig as any).calls[0][0];
+    expect(writeArgs.networkConfigName).toBe('fixture-mainnet');
+    expect(JSON.parse(readFileSync(join(dkgDir, 'config.json'), 'utf-8'))).toMatchObject({
+      networkConfig: 'fixture-mainnet',
+      chain: {
+        chainId: 'fixture:42',
+        rpcUrl: 'https://fixture-rpc.invalid',
+      },
+    });
   });
 
   it('funds wallets via the shared fundWalletsBestEffort orchestrator (network, seed, didStartDaemon)', async () => {

--- a/packages/cli/test/mcp-setup.test.ts
+++ b/packages/cli/test/mcp-setup.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path';
 import TOML from '@iarna/toml';
 import { SELECTABLE_SETUP_NETWORKS } from '@origintrail-official/dkg-core';
 import { mcpSetupAction, type McpSetupActionDeps } from '../src/mcp-setup.js';
-import { listBundledNetworkConfigNames } from '../src/config.js';
+import { listBundledNetworkConfigNames, resolveKnownNetworkConfigName } from '../src/config.js';
 
 /**
  * NO MOCKS. `dkg mcp setup` is a pure CLI ORCHESTRATOR over (a) a real
@@ -261,7 +261,7 @@ describe('mcpSetupAction — bundled init + daemon-start + register flow', () =>
     );
     return {
       loadNetworkConfig,
-      networkConfigNames: listBundledNetworkConfigNames(),
+      resolveKnownNetworkConfigName,
       ensureDkgNodeConfig,
       startDaemon,
       loadOpWallets,
@@ -390,7 +390,7 @@ describe('mcpSetupAction — bundled init + daemon-start + register flow', () =>
     const deps = makeDeps();
     await mcpSetupAction({ port: '9300', start: false, verify: false, fund: false }, deps);
 
-    expect((deps.loadNetworkConfig as any).calls.map((call: any[]) => call[0])).toContain('mainnet-gnosis');
+    expect((deps.loadNetworkConfig as any).calls.map((call: any[]) => call[0])).toEqual(['mainnet-gnosis']);
     expect((deps.ensureDkgNodeConfig as any).calls).toHaveLength(1);
     const writeArgs = (deps.ensureDkgNodeConfig as any).calls[0][0];
     expect(writeArgs.networkConfigName).toBe('mainnet-gnosis');
@@ -431,7 +431,9 @@ describe('mcpSetupAction — bundled init + daemon-start + register flow', () =>
     });
     const deps = makeDeps({
       loadNetworkConfig: injectedLoader as any,
-      networkConfigNames: ['fixture-mainnet'],
+      resolveKnownNetworkConfigName: (config) => resolveKnownNetworkConfigName(config, {
+        'fixture-mainnet': { chain: { chainId: 'fixture:42' } },
+      }),
     });
 
     await mcpSetupAction({ port: '9300', start: false, verify: false, fund: false }, deps);

--- a/packages/cli/test/mcp-setup.test.ts
+++ b/packages/cli/test/mcp-setup.test.ts
@@ -356,6 +356,31 @@ describe('mcpSetupAction — bundled init + daemon-start + register flow', () =>
     expect((deps.startDaemon as any).calls).toEqual([]);
   });
 
+  it('keeps a legacy mainnet chain on its inferred overlay when an override rewrites config', async () => {
+    const dkgDir = join(tmpHome, '.dkg');
+    mkdirSync(dkgDir, { recursive: true });
+    writeFileSync(
+      join(dkgDir, 'config.json'),
+      JSON.stringify({
+        name: 'legacy-mainnet',
+        apiPort: 9200,
+        chain: {
+          type: 'evm',
+          chainId: 'gnosis:100',
+          rpcUrl: 'https://operator-rpc.invalid',
+          hubAddress: '0x0000000000000000000000000000000000000042',
+        },
+      }, null, 2),
+    );
+    mkdirSync(join(tmpHome, '.cursor'), { recursive: true });
+
+    const deps = makeDeps();
+    await mcpSetupAction({ port: '9300', start: false, verify: false, fund: false }, deps);
+
+    expect((deps.loadNetworkConfig as any).calls[0][0]).toBe('mainnet-gnosis');
+    expect((deps.ensureDkgNodeConfig as any).calls).toHaveLength(1);
+  });
+
   it('funds wallets via the shared fundWalletsBestEffort orchestrator (network, seed, didStartDaemon)', async () => {
     // Wallet funding delegates to the SAME orchestrator openclaw/hermes use
     // (no bespoke /api/status probe). On a normal setup it fires with the

--- a/packages/cli/test/mcp-setup.test.ts
+++ b/packages/cli/test/mcp-setup.test.ts
@@ -3,7 +3,9 @@ import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync, readFileSync
 import { tmpdir, homedir, platform } from 'node:os';
 import { join } from 'node:path';
 import TOML from '@iarna/toml';
+import { SELECTABLE_SETUP_NETWORKS } from '@origintrail-official/dkg-core';
 import { mcpSetupAction, type McpSetupActionDeps } from '../src/mcp-setup.js';
+import { listBundledNetworkConfigNames } from '../src/config.js';
 
 /**
  * NO MOCKS. `dkg mcp setup` is a pure CLI ORCHESTRATOR over (a) a real
@@ -259,7 +261,7 @@ describe('mcpSetupAction — bundled init + daemon-start + register flow', () =>
     );
     return {
       loadNetworkConfig,
-      networkConfigNames: ['testnet', 'mainnet-base', 'mainnet-gnosis', 'mainnet-neuroweb'],
+      networkConfigNames: listBundledNetworkConfigNames(),
       ensureDkgNodeConfig,
       startDaemon,
       loadOpWallets,
@@ -441,6 +443,38 @@ describe('mcpSetupAction — bundled init + daemon-start + register flow', () =>
       chain: {
         chainId: 'fixture:42',
         rpcUrl: 'https://fixture-rpc.invalid',
+      },
+    });
+  });
+
+  it('uses bundled registry candidates that are intentionally absent from the setup menu', async () => {
+    expect(SELECTABLE_SETUP_NETWORKS).not.toContain('mainnet-neuroweb');
+    expect(listBundledNetworkConfigNames()).toContain('mainnet-neuroweb');
+
+    const dkgDir = join(tmpHome, '.dkg');
+    mkdirSync(dkgDir, { recursive: true });
+    writeFileSync(join(dkgDir, 'config.json'), JSON.stringify({
+      name: 'legacy-neuroweb',
+      apiPort: 9200,
+      chain: {
+        type: 'evm',
+        chainId: 'neuroweb:2043',
+        rpcUrl: 'https://operator-neuroweb.invalid',
+        hubAddress: '0x0000000000000000000000000000000000000042',
+      },
+    }, null, 2));
+    mkdirSync(join(tmpHome, '.cursor'), { recursive: true });
+    const deps = makeDeps();
+
+    await mcpSetupAction({ port: '9300', start: false, verify: false, fund: false }, deps);
+
+    expect((deps.ensureDkgNodeConfig as any).calls[0][0].networkConfigName)
+      .toBe('mainnet-neuroweb');
+    expect(JSON.parse(readFileSync(join(dkgDir, 'config.json'), 'utf-8'))).toMatchObject({
+      networkConfig: 'mainnet-neuroweb',
+      chain: {
+        chainId: 'neuroweb:2043',
+        rpcUrl: 'https://operator-neuroweb.invalid',
       },
     });
   });

--- a/packages/cli/test/migration.test.ts
+++ b/packages/cli/test/migration.test.ts
@@ -208,6 +208,38 @@ describe('migrateToBlueGreen', () => {
     expect(selectedNetwork).toBe('mainnet-base');
   });
 
+  it('uses inferred network update defaults for a legacy chain-only config', async () => {
+    let selectedNetwork: string | undefined;
+    _migrationIo.repoDir = () => null;
+    _migrationIo.loadConfig = async () => ({
+      chain: { type: 'evm', chainId: 'gnosis:100' },
+    });
+    _migrationIo.loadNetworkConfig = async (network?: string) => {
+      selectedNetwork = network;
+      if (network !== 'mainnet-gnosis') return undefined;
+      return {
+        autoUpdate: {
+          enabled: true,
+          repo: 'fixture/gnosis-runtime',
+          branch: 'gnosis-release',
+        },
+      };
+    };
+    execFileSyncCalls = [];
+
+    const log = makeLog();
+    await migrateToBlueGreen(log.fn, { allowRemoteBootstrap: true });
+
+    expect(selectedNetwork).toBe('mainnet-gnosis');
+    const cloneCall = execFileSyncCalls.find(
+      c => c.binary === 'git' && c.args.includes('clone'),
+    );
+    expect(cloneCall).toBeTruthy();
+    expect(cloneCall?.args).toContain('--branch');
+    expect(cloneCall?.args).toContain('gnosis-release');
+    expect(cloneCall?.args).toContain('https://github.com/fixture/gnosis-runtime.git');
+  });
+
   it('logs migration progress', async () => {
     const log = makeLog();
     await migrateToBlueGreen(log.fn);

--- a/packages/cli/test/node-ops-receipt-timeout.test.ts
+++ b/packages/cli/test/node-ops-receipt-timeout.test.ts
@@ -146,4 +146,16 @@ describe('node-ops set-ask receipt deadline wiring', () => {
       '0xhash',
     );
   });
+
+  it('loads the inferred Gnosis overlay for a legacy config before sending set-ask', async () => {
+    mocks.loadConfig.mockResolvedValue({ chain: { chainId: 'gnosis:100' } });
+    const program = new Command();
+    program.exitOverride();
+    registerNodeOpsCommands(program);
+
+    await program.parseAsync(['set-ask', '2'], { from: 'user' });
+
+    expect(mocks.loadNetworkConfig).toHaveBeenCalledWith('mainnet-gnosis');
+    expect(mocks.sendCliRawTransactionWithFailover).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/cli/test/publisher-wallets.test.ts
+++ b/packages/cli/test/publisher-wallets.test.ts
@@ -177,6 +177,27 @@ describe('publisher wallets', () => {
     ).rejects.toThrow(/DKG V10 NeuroWeb Mainnet is marked pre-deployment/);
   });
 
+  it('resolves publisher network readiness from a legacy chain-only config', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'dkg-publisher-runtime-'));
+    const wallet = ethers.Wallet.createRandom();
+    await addPublisherWallet(dataDir, wallet.privateKey);
+
+    await expect(
+      createPublisherRuntime({
+        dataDir,
+        config: {
+          name: 'legacy-neuroweb-publisher',
+          apiPort: 9200,
+          listenPort: 0,
+          nodeRole: 'edge',
+          contextGraphs: [],
+          store: { backend: 'oxigraph' },
+          chain: { chainId: 'neuroweb:2043' },
+        },
+      }),
+    ).rejects.toThrow(/DKG V10 NeuroWeb Mainnet is marked pre-deployment/);
+  });
+
   it('bootstraps publisher runtime from an existing agent store', async () => {
     const dataDir = await mkdtemp(join(tmpdir(), 'dkg-publisher-runtime-'));
     const wallet = ethers.Wallet.createRandom();

--- a/packages/core/src/setup-network.ts
+++ b/packages/core/src/setup-network.ts
@@ -13,9 +13,10 @@
  * below encodes that split:
  *
  *   - a genuinely fresh node    → {@link DEFAULT_SETUP_NETWORK} (mainnet-gnosis)
- *   - a legacy node (config on
- *     disk but no networkConfig) → {@link LEGACY_FALLBACK_NETWORK} (testnet),
- *     preserving its current behaviour — no flip to a real-money chain
+ *   - a legacy node whose caller can infer a bundled network from its chain
+ *     → keep that inferred network via `existingNetworkConfig`
+ *   - any other legacy node (config on disk but no networkConfig)
+ *     → {@link LEGACY_FALLBACK_NETWORK} (testnet)
  *   - a node that already chose  → keep its choice
  *   - an explicit `--network` /
  *     interactive answer         → wins outright
@@ -50,7 +51,10 @@ export interface ResolveSetupNetworkNameOptions {
    * interactive answer. When non-empty it wins over everything else.
    */
   explicit?: string | null;
-  /** The `networkConfig` already present in the existing config, if any. */
+  /**
+   * The existing effective network, if known. Callers with access to bundled
+   * network metadata should pass a chain-inferred name for legacy configs.
+   */
   existingNetworkConfig?: string | null;
   /**
    * Whether a config file already existed on disk before this setup run.


### PR DESCRIPTION
## Summary

- infer a bundled network overlay from `chain.chainId` for legacy configs that predate `networkConfig`
- keep an explicit `networkConfig` authoritative
- use the resolved overlay consistently for daemon startup, updates, wallet/node operations, publisher startup, and blue-green migration
- preserve the existing network-switch and triple-store genesis guards

## Incident context

Two mainnet relay homes had `chain.chainId=gnosis:100` but no `networkConfig`. The old fallback selected the project default (`testnet`), so version-current processes silently joined the Base testnet p2p overlay. Their stores also contain the testnet genesis marker, which the existing guard correctly blocks from being switched in place.

This change makes the chain/overlay mismatch fail safely: known legacy chain IDs resolve to their corresponding bundled network first, after which the existing switch/genesis guards require an explicit accepted migration instead of silently selecting testnet.

Known mappings:

- `base:84532` -> `testnet`
- `base:8453` -> `mainnet-base`
- `gnosis:100` -> `mainnet-gnosis`
- `neuroweb:2043` -> `mainnet-neuroweb`

Unknown/mock chain IDs retain the project-default fallback.

## Verification

- `pnpm --filter @origintrail-official/dkg... run build`
- focused Vitest suite: 5 files, 166 tests passed
  - `config.test.ts`
  - `daemon-startup-validation.test.ts`
  - `migration.test.ts`
  - `publisher-wallets.test.ts`
  - `node-ops-receipt-timeout.test.ts`
- `git diff --check`

## Operational note

This PR does not mutate or reset any existing store. The two affected relays were explicitly pinned to `networkConfig: testnet` after discovery so this fix will not auto-switch them on rollout; they need a separately planned clean-home or supported data migration.