### PR TITLE
fix(cli): bound daemon log rotation memory

### DIFF
--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -30,12 +30,10 @@ import {
   chmod,
   copyFile,
   mkdir,
-  readFile,
   rename,
   rm,
   stat,
   unlink,
-  writeFile,
 } from "node:fs/promises";
 import { execSync, exec, execFile } from "node:child_process";
 import { promisify } from "node:util";
@@ -49,6 +47,7 @@ import { existsSync, readdirSync, readFileSync, openSync, closeSync, writeFileSy
 import * as osModule from 'node:os';
 import type { NetworkInterfaceInfo } from 'node:os';
 import { checkCoreRelayPrereqs } from './core-prereq-check.js';
+import { rotateDaemonLogIfNeeded } from './log-rotation.js';
 const { homedir } = osModule;
 import { fileURLToPath } from 'node:url';
 import { createRequire } from 'node:module';
@@ -989,6 +988,10 @@ export async function runDaemonInner(
 ): Promise<void> {
   configureKaPublishLifecycleDebugLogging(config);
   const logFile = logPath();
+  // Rotate before installing the in-process stdout/stderr tee so startup does
+  // not race the truncation with fresh log appends. Existing logs survive
+  // upgrades/restarts and can already be multi-gigabyte at this point.
+  const startupLogRotation = await rotateDaemonLogIfNeeded(logFile).catch(() => null);
 
   // Tee all stdout/stderr (including structured Logger output) into the log file
   const origStdoutWrite = process.stdout.write.bind(process.stdout);
@@ -1012,6 +1015,13 @@ export async function runDaemonInner(
     const line = `[${new Date().toISOString()}] ${msg}`;
     if (foreground) origStdoutWrite(line + "\n");
     appendFile(logFile, line + "\n").catch(() => {});
+  }
+
+  if (startupLogRotation?.rotated) {
+    log(
+      `Rotated daemon.log during startup ` +
+      `(was ${(startupLogRotation.previousBytes / 1024 / 1024).toFixed(1)} MB)`,
+    );
   }
 
   process.on("uncaughtException", (err) => {
@@ -2568,28 +2578,22 @@ export async function runDaemonInner(
     }
   }
 
-  const MAX_LOG_BYTES = 50 * 1024 * 1024; // 50 MB
   const PRUNE_INTERVAL_MS = 6 * 60 * 60_000; // 6 hours
-  const pruneTimer = setInterval(async () => {
+  const pruneRuntimeState = async (): Promise<void> => {
     try {
       dashDb.prune();
-      const st = await stat(logFile).catch(() => null);
-      if (st && st.size > MAX_LOG_BYTES) {
-        const tail = await readFile(logFile, "utf8");
-        const keepFrom = tail.length - Math.floor(MAX_LOG_BYTES * 0.7);
-        const newlineIdx = tail.indexOf("\n", keepFrom);
-        if (newlineIdx > 0) {
-          await writeFile(logFile, tail.slice(newlineIdx + 1));
-        } else {
-          await writeFile(logFile, tail.slice(keepFrom));
-        }
+      const rotation = await rotateDaemonLogIfNeeded(logFile);
+      if (rotation.rotated) {
         log(
-          `Rotated daemon.log (was ${(st.size / 1024 / 1024).toFixed(1)} MB)`,
+          `Rotated daemon.log (was ${(rotation.previousBytes / 1024 / 1024).toFixed(1)} MB)`,
         );
       }
     } catch {
       /* never crash the daemon */
     }
+  };
+  const pruneTimer = setInterval(() => {
+    void pruneRuntimeState();
   }, PRUNE_INTERVAL_MS);
   pruneTimer.unref();
 

--- a/packages/cli/src/daemon/log-rotation.ts
+++ b/packages/cli/src/daemon/log-rotation.ts
@@ -49,13 +49,16 @@ export async function rotateDaemonLogIfNeeded(
   const handle = await open(logFile, 'r');
   let bytesRead = 0;
   try {
-    const result = await handle.read(
-      buffer,
-      0,
-      bytesToRead,
-      before.size - bytesToRead,
-    );
-    bytesRead = result.bytesRead;
+    while (bytesRead < bytesToRead) {
+      const result = await handle.read(
+        buffer,
+        bytesRead,
+        bytesToRead - bytesRead,
+        before.size - bytesToRead + bytesRead,
+      );
+      if (result.bytesRead === 0) break;
+      bytesRead += result.bytesRead;
+    }
   } finally {
     await handle.close();
   }

--- a/packages/cli/src/daemon/log-rotation.ts
+++ b/packages/cli/src/daemon/log-rotation.ts
@@ -1,0 +1,73 @@
+import { open, stat, writeFile } from 'node:fs/promises';
+
+export const DEFAULT_DAEMON_LOG_MAX_BYTES = 50 * 1024 * 1024;
+export const DEFAULT_DAEMON_LOG_KEEP_BYTES = Math.floor(
+  DEFAULT_DAEMON_LOG_MAX_BYTES * 0.7,
+);
+
+export interface DaemonLogRotationResult {
+  rotated: boolean;
+  previousBytes: number;
+  keptBytes: number;
+}
+
+/**
+ * Trim an oversized daemon log from a bounded tail read.
+ *
+ * The previous implementation used readFile(), so a multi-gigabyte log was
+ * copied wholesale into the daemon heap precisely when rotation was supposed
+ * to protect the node. This reads at most keepBytes and drops the first
+ * partial line before replacing the file.
+ */
+export async function rotateDaemonLogIfNeeded(
+  logFile: string,
+  options: {
+    maxBytes?: number;
+    keepBytes?: number;
+  } = {},
+): Promise<DaemonLogRotationResult> {
+  const maxBytes = options.maxBytes ?? DEFAULT_DAEMON_LOG_MAX_BYTES;
+  const keepBytes = options.keepBytes ?? DEFAULT_DAEMON_LOG_KEEP_BYTES;
+  if (!Number.isSafeInteger(maxBytes) || maxBytes <= 0) {
+    throw new Error('daemon log maxBytes must be a positive safe integer');
+  }
+  if (!Number.isSafeInteger(keepBytes) || keepBytes <= 0 || keepBytes >= maxBytes) {
+    throw new Error('daemon log keepBytes must be a positive safe integer below maxBytes');
+  }
+
+  const before = await stat(logFile).catch(() => null);
+  if (!before || before.size <= maxBytes) {
+    return {
+      rotated: false,
+      previousBytes: before?.size ?? 0,
+      keptBytes: before?.size ?? 0,
+    };
+  }
+
+  const bytesToRead = Math.min(keepBytes, before.size);
+  const buffer = Buffer.allocUnsafe(bytesToRead);
+  const handle = await open(logFile, 'r');
+  let bytesRead = 0;
+  try {
+    const result = await handle.read(
+      buffer,
+      0,
+      bytesToRead,
+      before.size - bytesToRead,
+    );
+    bytesRead = result.bytesRead;
+  } finally {
+    await handle.close();
+  }
+
+  const tail = buffer.subarray(0, bytesRead);
+  const firstNewline = tail.indexOf(0x0a);
+  const retained = firstNewline >= 0 ? tail.subarray(firstNewline + 1) : tail;
+  await writeFile(logFile, retained);
+
+  return {
+    rotated: true,
+    previousBytes: before.size,
+    keptBytes: retained.length,
+  };
+}

--- a/packages/cli/test/daemon-log-rotation-io.test.ts
+++ b/packages/cli/test/daemon-log-rotation-io.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fsMocks = vi.hoisted(() => ({
+  stat: vi.fn(),
+  open: vi.fn(),
+  writeFile: vi.fn(),
+  readFile: vi.fn(),
+  read: vi.fn(),
+  close: vi.fn(),
+}));
+
+vi.mock('node:fs/promises', () => ({
+  stat: fsMocks.stat,
+  open: fsMocks.open,
+  writeFile: fsMocks.writeFile,
+  // Deliberately supplied so a regression to whole-file readFile() is visible.
+  readFile: fsMocks.readFile,
+}));
+
+const { rotateDaemonLogIfNeeded } = await import('../src/daemon/log-rotation.js');
+
+describe('daemon log rotation I/O bound', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fsMocks.stat.mockResolvedValue({ size: 2_000_000_000 });
+    fsMocks.read.mockImplementation(async (
+      buffer: Buffer,
+      offset: number,
+      length: number,
+    ) => {
+      buffer.fill(0x78, offset, offset + length);
+      return { bytesRead: length, buffer };
+    });
+    fsMocks.close.mockResolvedValue(undefined);
+    fsMocks.open.mockResolvedValue({ read: fsMocks.read, close: fsMocks.close });
+    fsMocks.writeFile.mockResolvedValue(undefined);
+  });
+
+  it('reads only keepBytes from a multi-gigabyte log and never uses readFile', async () => {
+    const result = await rotateDaemonLogIfNeeded('/var/lib/dkg/daemon.log', {
+      maxBytes: 100,
+      keepBytes: 60,
+    });
+
+    expect(result).toEqual({
+      rotated: true,
+      previousBytes: 2_000_000_000,
+      keptBytes: 60,
+    });
+    expect(fsMocks.readFile).not.toHaveBeenCalled();
+    expect(fsMocks.read).toHaveBeenCalledTimes(1);
+    expect(fsMocks.read).toHaveBeenCalledWith(
+      expect.any(Buffer),
+      0,
+      60,
+      1_999_999_940,
+    );
+    expect(fsMocks.writeFile).toHaveBeenCalledWith(
+      '/var/lib/dkg/daemon.log',
+      expect.objectContaining({ length: 60 }),
+    );
+  });
+});

--- a/packages/cli/test/daemon-log-rotation.test.ts
+++ b/packages/cli/test/daemon-log-rotation.test.ts
@@ -1,0 +1,67 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { rotateDaemonLogIfNeeded } from '../src/daemon/log-rotation.js';
+
+const tempDirs: string[] = [];
+
+async function tempLog(contents: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'dkg-log-rotation-'));
+  tempDirs.push(dir);
+  const path = join(dir, 'daemon.log');
+  await writeFile(path, contents);
+  return path;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })));
+});
+
+describe('rotateDaemonLogIfNeeded', () => {
+  it('leaves a log at or below the size limit untouched', async () => {
+    const path = await tempLog('one\ntwo\n');
+
+    const result = await rotateDaemonLogIfNeeded(path, { maxBytes: 20, keepBytes: 10 });
+
+    expect(result).toEqual({ rotated: false, previousBytes: 8, keptBytes: 8 });
+    expect(await readFile(path, 'utf-8')).toBe('one\ntwo\n');
+  });
+
+  it('reads only the bounded tail and keeps complete recent log lines', async () => {
+    const path = await tempLog([
+      'old-0000000000',
+      'middle-1111111',
+      'recent-a',
+      'recent-b',
+      'recent-c',
+      '',
+    ].join('\n'));
+
+    const result = await rotateDaemonLogIfNeeded(path, { maxBytes: 40, keepBytes: 30 });
+    const retained = await readFile(path, 'utf-8');
+
+    expect(result.rotated).toBe(true);
+    expect(result.previousBytes).toBeGreaterThan(40);
+    expect(result.keptBytes).toBeLessThanOrEqual(30);
+    expect(retained).toBe('recent-a\nrecent-b\nrecent-c\n');
+  });
+
+  it('handles a single oversized line without allocating beyond keepBytes', async () => {
+    const path = await tempLog('x'.repeat(200));
+
+    const result = await rotateDaemonLogIfNeeded(path, { maxBytes: 100, keepBytes: 60 });
+
+    expect(result).toEqual({ rotated: true, previousBytes: 200, keptBytes: 60 });
+    expect((await readFile(path)).length).toBe(60);
+  });
+
+  it('rejects invalid bounds before touching the file', async () => {
+    const path = await tempLog('unchanged');
+
+    await expect(
+      rotateDaemonLogIfNeeded(path, { maxBytes: 10, keepBytes: 10 }),
+    ).rejects.toThrow(/keepBytes/);
+    expect(await readFile(path, 'utf-8')).toBe('unchanged');
+  });
+});

--- a/packages/cli/test/daemon-startup-validation.test.ts
+++ b/packages/cli/test/daemon-startup-validation.test.ts
@@ -1,9 +1,12 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, open, rm, stat } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { computeNetworkId } from '../../core/src/genesis.js';
 import { buildEvmDeploymentId } from '@origintrail-official/dkg-chain';
+import {
+  DEFAULT_DAEMON_LOG_MAX_BYTES,
+} from '../src/daemon/log-rotation.js';
 
 const mocks = vi.hoisted(() => ({
   agentCreate: vi.fn(),
@@ -36,6 +39,24 @@ function closeDashboardDbFromAgentCreateArg(createArg: any): void {
     createArg?.chainEventCursorStore?.cursors?.db ??
     createArg?.contextGraphRegistryScanCursorStore?.cursors?.db;
   db?.close?.();
+}
+
+async function readFileTail(path: string, maxBytes = 16 * 1024): Promise<string> {
+  const before = await stat(path);
+  const bytesToRead = Math.min(before.size, maxBytes);
+  const buffer = Buffer.alloc(bytesToRead);
+  const handle = await open(path, 'r');
+  try {
+    const { bytesRead } = await handle.read(
+      buffer,
+      0,
+      bytesToRead,
+      before.size - bytesToRead,
+    );
+    return buffer.subarray(0, bytesRead).toString('utf-8');
+  } finally {
+    await handle.close();
+  }
 }
 
 describe('daemon startup network validation', () => {
@@ -108,6 +129,43 @@ describe('daemon startup network validation', () => {
     expect(stdoutSpy.mock.calls.map(call => String(call[0])).join('')).toContain(
       'FATAL: network config DKG V10 Base Mainnet is marked pre-deployment',
     );
+  });
+
+  it('rotates an oversized inherited daemon log during startup before tee appends', async () => {
+    tempHome = await mkdtemp(join(tmpdir(), 'dkg-log-rotation-startup-'));
+    originalDkgHome = process.env.DKG_HOME;
+    process.env.DKG_HOME = tempHome;
+    stdoutWrite = process.stdout.write;
+    stderrWrite = process.stderr.write;
+    uncaughtExceptionListeners = process.listeners('uncaughtException') as NodeJS.UncaughtExceptionListener[];
+    unhandledRejectionListeners = process.listeners('unhandledRejection') as NodeJS.UnhandledRejectionListener[];
+
+    const daemonLog = join(tempHome, 'daemon.log');
+    const logHandle = await open(daemonLog, 'w');
+    await logHandle.truncate(DEFAULT_DAEMON_LOG_MAX_BYTES + 1024);
+    await logHandle.close();
+
+    mocks.loadNetworkConfig.mockResolvedValue(null);
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    vi.spyOn(process, 'exit').mockImplementation(((code?: string | number | null) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+
+    await expect(runDaemonInner(true, {
+      name: 'startup-log-rotation-test',
+      networkConfig: 'missing-mainnet',
+      listenPort: 0,
+      nodeRole: 'edge',
+    } as any, Date.now())).rejects.toThrow('process.exit:1');
+
+    expect((await stat(daemonLog)).size).toBeLessThan(DEFAULT_DAEMON_LOG_MAX_BYTES);
+    let tail = '';
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      tail = await readFileTail(daemonLog);
+      if (tail.includes('Rotated daemon.log during startup')) break;
+      await new Promise(resolve => setTimeout(resolve, 10));
+    }
+    expect(tail).toContain('Rotated daemon.log during startup');
   });
 
   it('exits before agent creation when config.networkConfig does not resolve', async () => {


### PR DESCRIPTION
## Summary

- rotate oversized `daemon.log` files from a bounded 35 MB tail instead of reading the entire file into the Node.js heap
- perform the first rotation before the daemon installs its stdout/stderr tee, so large logs inherited across upgrades are handled immediately and without racing startup appends
- keep the existing 50 MB threshold and six-hour recurring prune behavior
- add focused coverage for small logs, complete-line tail retention, huge single lines, and invalid bounds

## Why

The mainnet fleet audit found a node with an approximately 2 GB `daemon.log`. The current implementation calls `readFile(logFile, "utf8")` when the six-hour prune runs, transiently materializing the whole log in the daemon heap. That makes the safety mechanism itself capable of triggering an OOM, particularly after a restart or upgrade where the existing log survives.

This change makes rotation memory bounded by the retained tail size and also checks once during startup rather than waiting six hours.

## Validation

- `pnpm exec vitest run test/daemon-log-rotation.test.ts test/daemon-startup-validation.test.ts test/daemon-http-behavior-extra.test.ts` (66/66)
- `pnpm run build` in `packages/cli`
- `git diff --check`
