### PR TITLE
fix(agent): restore private publish-async catalog parity (#1670)

### DIFF
--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -112,7 +112,7 @@ import {
   canonicalPublishPayload,
   generatedPrivateCatalogTripleKeys,
   appendMissingGeneratedPrivateCatalogFloor,
-  replaceGeneratedPrivateCatalogFloor,
+  replaceCatalogPartitionWithGeneratedPrivateFloor,
   createKnowledgeAssetVmPublishSnapshotMetadata,
   createKnowledgeAssetVmPublishSnapshotRequest,
   resolveLiftWorkspaceSlice,
@@ -441,6 +441,43 @@ export function buildPrivateCatalogDefaultGraphQuads(cgDid: string, assertionUri
   // one); normalize it back to the default assertion graph before writing.
   return buildPublicProjection({ ual: cgDid, accessPolicy: 'private', graph: assertionUri })
     .map((quad) => ({ ...quad, graph: '' }));
+}
+
+function prepareQueuedKnowledgeAssetVmPublishOptions(input: {
+  contextGraphId: string;
+  snapshotQuads: readonly Quad[];
+  onChainContextGraphId?: string;
+  resolvedEncryptInlinePayload: PublishOptions['encryptInlinePayload'];
+  resolvedEncryptInlineChunked: PublishOptions['encryptInlineChunked'];
+  queuedEncryptInlinePayload: PublishOptions['encryptInlinePayload'];
+  queuedEncryptInlineChunked: PublishOptions['encryptInlineChunked'];
+}): Pick<
+  PublishOptions,
+  | 'quads'
+  | 'encryptInlinePayload'
+  | 'encryptInlineChunked'
+  | 'trustedNonManifestCatalogTriples'
+> {
+  const encryptionOptions = {
+    encryptInlinePayload:
+      input.resolvedEncryptInlinePayload ?? input.queuedEncryptInlinePayload,
+    encryptInlineChunked:
+      input.resolvedEncryptInlineChunked ?? input.queuedEncryptInlineChunked,
+  };
+  if (!input.onChainContextGraphId || !input.resolvedEncryptInlinePayload) {
+    return { quads: [...input.snapshotQuads], ...encryptionOptions };
+  }
+
+  const preparedCatalog = appendMissingGeneratedPrivateCatalogFloor(
+    input.contextGraphId,
+    input.snapshotQuads,
+  );
+  return {
+    quads: preparedCatalog.quads,
+    ...encryptionOptions,
+    trustedNonManifestCatalogTriples:
+      preparedCatalog.trustedNonManifestCatalogTriples,
+  };
 }
 
 /**
@@ -1689,7 +1726,7 @@ export class PublishMethods extends DKGAgentBase {
     // fails closed (throws) consistently with publish, where the OLD update path
     // would have proceeded. Fail-closed, never a leak; see PR #1208 notes.
     const preparedUpdateCatalog = isCuratedUpdate && updateOnChainId != null
-      ? replaceGeneratedPrivateCatalogFloor(
+      ? replaceCatalogPartitionWithGeneratedPrivateFloor(
           contextGraphId,
           quads,
           contextGraphDataUri(contextGraphId),
@@ -3951,13 +3988,6 @@ export class PublishMethods extends DKGAgentBase {
         undefined,
         publishBindingOptions,
       );
-      const queuedPublishPolicy = {
-        encryptInlinePayload: resolvedEncryptInlinePayload ?? publishOptions.encryptInlinePayload,
-        encryptInlineChunked: resolvedEncryptInlineChunked ?? publishOptions.encryptInlineChunked,
-        catalogFloor: queuedOnChainContextGraphId && resolvedEncryptInlinePayload
-          ? 'generated-private' as const
-          : 'none' as const,
-      };
       // #1670 — finalized private assertions seal the deterministic public
       // catalog floor, but assertionPromote deliberately keeps that synthetic
       // root out of the per-user-root immutable share snapshot. The synchronous
@@ -3966,20 +3996,25 @@ export class PublishMethods extends DKGAgentBase {
       // publisher has no catalog commitment/staging bytes, so cores fall back to
       // their (intentionally absent) curated SWM copy and decline NO_DATA_IN_SWM.
       //
-      // The explicit queued policy requires both a verified on-chain CG binding
+      // The queued preparation boundary requires both a verified on-chain CG binding
       // and a live curated-policy encryption result. That keeps local-only and
       // public CGs untouched and prevents queued mapper placeholders from
       // manufacturing trusted catalog triples. The shared preparation boundary performs exact-key
       // de-duplication for legacy snapshots and returns the trust allow-list
       // with the quads so queued/update/sync paths cannot drift independently.
-      const preparedQueuedCatalog = queuedPublishPolicy.catalogFloor === 'generated-private'
-        ? appendMissingGeneratedPrivateCatalogFloor(request.contextGraphId, snapshotQuads)
-        : undefined;
-      const queuedPublishQuads = preparedQueuedCatalog?.quads ?? snapshotQuads;
+      const queuedPublishPreparation = prepareQueuedKnowledgeAssetVmPublishOptions({
+        contextGraphId: request.contextGraphId,
+        snapshotQuads,
+        onChainContextGraphId: queuedOnChainContextGraphId,
+        resolvedEncryptInlinePayload,
+        resolvedEncryptInlineChunked,
+        queuedEncryptInlinePayload: publishOptions.encryptInlinePayload,
+        queuedEncryptInlineChunked: publishOptions.encryptInlineChunked,
+      });
       result = await publisher.publish({
         ...publisherPublishOptions,
         contextGraphId: request.contextGraphId,
-        quads: queuedPublishQuads,
+        quads: queuedPublishPreparation.quads,
         privateQuads: snapshotPrivateQuads.length > 0 ? snapshotPrivateQuads : undefined,
         publisherPeerId: publishOptions.publisherPeerId ?? this.peerId,
         subGraphName: request.subGraphName,
@@ -3999,12 +4034,12 @@ export class PublishMethods extends DKGAgentBase {
           reservedKaId: recoveredReservedKaId ?? 0n,
         },
         onChainContextGraphId: queuedOnChainContextGraphId,
-        encryptInlinePayload: queuedPublishPolicy.encryptInlinePayload,
-        encryptInlineChunked: queuedPublishPolicy.encryptInlineChunked,
-        ...(preparedQueuedCatalog
+        encryptInlinePayload: queuedPublishPreparation.encryptInlinePayload,
+        encryptInlineChunked: queuedPublishPreparation.encryptInlineChunked,
+        ...(queuedPublishPreparation.trustedNonManifestCatalogTriples
           ? {
               trustedNonManifestCatalogTriples:
-                preparedQueuedCatalog.trustedNonManifestCatalogTriples,
+                queuedPublishPreparation.trustedNonManifestCatalogTriples,
             }
           : {}),
       });

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -95,7 +95,6 @@ import {
   type SubscriptionSource,
   SUBSCRIPTION_SOURCES,
   pickNetworkTunables,
-  partitionCatalogQuads,
   withSpan,
   getMetrics,
   assertQuadLiteralsMutf8Safe,
@@ -111,9 +110,8 @@ import {
   resolveWorkspaceAgentRecipients,
   computeTripleHashV10 as computeTripleHash, computeFlatKCRootV10 as computeFlatKCRoot, skolemizeByEntity, isReservedSubject,
   canonicalPublishPayload,
-  catalogTripleKey,
-  generatedPrivateCatalogFloorQuads,
   generatedPrivateCatalogTripleKeys,
+  prepareGeneratedPrivateCatalogFloor,
   createKnowledgeAssetVmPublishSnapshotMetadata,
   createKnowledgeAssetVmPublishSnapshotRequest,
   resolveLiftWorkspaceSlice,
@@ -1674,10 +1672,10 @@ export class PublishMethods extends DKGAgentBase {
     // out, commit a non-zero `newCatalogRoot`, and satisfy the on-chain
     // `CuratedCGRequiresCatalogCommitment` gate — even for a metadata-only
     // update (Open Decision #2: every curated update re-commits the floor).
-    // The update analogue of `_ensureCuratedCatalogInSwm` (3606): build the
-    // floor via the SAME `buildPublicProjection({ ual: cgDid, accessPolicy:
-    // 'private' })` so the committed catalog is byte-identical across publish
-    // and update. STRIP-THEN-APPEND: drop any catalog quads the caller's
+    // The update analogue of `_ensureCuratedCatalogInSwm`: route through the
+    // SAME publisher-boundary preparation helper so the generated quads and
+    // exact trust allow-list are byte-identical across publish and update.
+    // STRIP-THEN-APPEND: drop any catalog quads the caller's
     // payload already carries (the from-SWM `publishFromFinalizedAssertion`
     // path at 3213 can re-load a previously-injected floor) so the floor is
     // never duplicated, then append exactly the fresh projection. The graph
@@ -1689,18 +1687,13 @@ export class PublishMethods extends DKGAgentBase {
     // path always has — so under a DEGRADED / stale policy probe a public update
     // fails closed (throws) consistently with publish, where the OLD update path
     // would have proceeded. Fail-closed, never a leak; see PR #1208 notes.
-    const shouldInjectCuratedCatalogFloor = isCuratedUpdate && updateOnChainId != null;
-    let updateQuads = quads;
-    if (shouldInjectCuratedCatalogFloor) {
-      const cgDid = contextGraphDataUri(contextGraphId);
-      const { otherQuads: nonCatalogQuads } = partitionCatalogQuads(quads, cgDid);
-      const catalogFloor = buildPublicProjection({
-        ual: cgDid,
-        accessPolicy: 'private',
-        graph: cgDid,
-      });
-      updateQuads = [...nonCatalogQuads, ...catalogFloor];
-    }
+    const preparedUpdateCatalog = isCuratedUpdate && updateOnChainId != null
+      ? prepareGeneratedPrivateCatalogFloor(contextGraphId, quads, {
+          graph: contextGraphDataUri(contextGraphId),
+          mode: 'replace-generated',
+        })
+      : undefined;
+    const updateQuads = preparedUpdateCatalog?.quads ?? quads;
 
     const publisher = opts?.publisherOverride ?? this.publisher;
     const result = await publisher.update(kaId, {
@@ -1713,9 +1706,8 @@ export class PublishMethods extends DKGAgentBase {
       onPhase,
       subGraphName: opts?.subGraphName,
       precomputedUpdateAttestation: opts?.precomputedUpdateAttestation,
-      trustedNonManifestCatalogTriples: shouldInjectCuratedCatalogFloor
-        ? generatedPrivateCatalogTripleKeys(contextGraphId)
-        : undefined,
+      trustedNonManifestCatalogTriples:
+        preparedUpdateCatalog?.trustedNonManifestCatalogTriples,
       v10UpdateACKProvider,
       // Curated → wire the single-blob AEAD hook so the producer's
       // `useEncryptedInlineUpdate` gate fires (catalog commit). Public →
@@ -3970,21 +3962,13 @@ export class PublishMethods extends DKGAgentBase {
       // Gate this on the live, chain-policy-resolved encryption callback rather
       // than the queued mapper placeholder. That keeps public CGs untouched and
       // prevents caller-supplied policy hints from manufacturing trusted catalog
-      // triples. Exact-key de-duplication also supports legacy snapshots that
-      // already contain some or all of the generated floor.
-      const trustedQueuedCatalogTriples = resolvedEncryptInlinePayload
-        ? generatedPrivateCatalogTripleKeys(request.contextGraphId)
+      // triples. The shared preparation boundary performs exact-key
+      // de-duplication for legacy snapshots and returns the trust allow-list
+      // with the quads so queued/update/sync paths cannot drift independently.
+      const preparedQueuedCatalog = resolvedEncryptInlinePayload
+        ? prepareGeneratedPrivateCatalogFloor(request.contextGraphId, snapshotQuads)
         : undefined;
-      const queuedPublishQuads = trustedQueuedCatalogTriples
-        ? (() => {
-            const present = new Set(snapshotQuads.map(catalogTripleKey));
-            return [
-              ...snapshotQuads,
-              ...generatedPrivateCatalogFloorQuads(request.contextGraphId)
-                .filter((quad) => !present.has(catalogTripleKey(quad))),
-            ];
-          })()
-        : snapshotQuads;
+      const queuedPublishQuads = preparedQueuedCatalog?.quads ?? snapshotQuads;
       result = await publisher.publish({
         ...publisherPublishOptions,
         contextGraphId: request.contextGraphId,
@@ -4010,8 +3994,11 @@ export class PublishMethods extends DKGAgentBase {
         onChainContextGraphId: queuedOnChainContextGraphId,
         encryptInlinePayload,
         encryptInlineChunked,
-        ...(trustedQueuedCatalogTriples
-          ? { trustedNonManifestCatalogTriples: trustedQueuedCatalogTriples }
+        ...(preparedQueuedCatalog
+          ? {
+              trustedNonManifestCatalogTriples:
+                preparedQueuedCatalog.trustedNonManifestCatalogTriples,
+            }
           : {}),
       });
 
@@ -4822,9 +4809,9 @@ export class PublishMethods extends DKGAgentBase {
    *
    * Mirrors the finalize-path injection (`assertionFinalize`): the catalog
    * subject is `contextGraphDataUri(contextGraphId)` — the EXACT subject the
-   * publisher's `partitionCatalogQuads` matches — and the floor quads are built
-   * by the SAME `buildPublicProjection`, so the committed catalog is byte-identical
-   * across both paths.
+   * publisher's `partitionCatalogQuads` matches — and the floor quads come from
+   * the SAME preparation helper as queued publish and update, so the committed
+   * catalog and exact trust allow-list cannot drift across those paths.
    *
     * IDEMPOTENT: repeated insertion dedupes in the store/V10 Merkle path because
     * the floor is deterministic, so `catalogLeafCount` stays stable across
@@ -4848,11 +4835,11 @@ export class PublishMethods extends DKGAgentBase {
     const swmGraph = contextGraphSharedMemoryUri(contextGraphId, subGraphName);
     const catalogTargetGraph = canonicalSharedMemoryScopeWriteGraph(swmGraph, scope);
     const cgDid = contextGraphDataUri(contextGraphId);
-    const catalogQuads = buildPublicProjection({
-      ual: cgDid,
-      accessPolicy: 'private',
-      graph: catalogTargetGraph,
-    });
+    const { quads: catalogQuads } = prepareGeneratedPrivateCatalogFloor(
+      contextGraphId,
+      [],
+      { graph: catalogTargetGraph },
+    );
     await this.store.insert(catalogQuads);
     this.log.info(
       ctx,

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -111,7 +111,8 @@ import {
   computeTripleHashV10 as computeTripleHash, computeFlatKCRootV10 as computeFlatKCRoot, skolemizeByEntity, isReservedSubject,
   canonicalPublishPayload,
   generatedPrivateCatalogTripleKeys,
-  prepareGeneratedPrivateCatalogFloor,
+  appendMissingGeneratedPrivateCatalogFloor,
+  replaceGeneratedPrivateCatalogFloor,
   createKnowledgeAssetVmPublishSnapshotMetadata,
   createKnowledgeAssetVmPublishSnapshotRequest,
   resolveLiftWorkspaceSlice,
@@ -1688,10 +1689,11 @@ export class PublishMethods extends DKGAgentBase {
     // fails closed (throws) consistently with publish, where the OLD update path
     // would have proceeded. Fail-closed, never a leak; see PR #1208 notes.
     const preparedUpdateCatalog = isCuratedUpdate && updateOnChainId != null
-      ? prepareGeneratedPrivateCatalogFloor(contextGraphId, quads, {
-          graph: contextGraphDataUri(contextGraphId),
-          mode: 'replace-generated',
-        })
+      ? replaceGeneratedPrivateCatalogFloor(
+          contextGraphId,
+          quads,
+          contextGraphDataUri(contextGraphId),
+        )
       : undefined;
     const updateQuads = preparedUpdateCatalog?.quads ?? quads;
 
@@ -3949,8 +3951,13 @@ export class PublishMethods extends DKGAgentBase {
         undefined,
         publishBindingOptions,
       );
-      const encryptInlinePayload = resolvedEncryptInlinePayload ?? publishOptions.encryptInlinePayload;
-      const encryptInlineChunked = resolvedEncryptInlineChunked ?? publishOptions.encryptInlineChunked;
+      const queuedPublishPolicy = {
+        encryptInlinePayload: resolvedEncryptInlinePayload ?? publishOptions.encryptInlinePayload,
+        encryptInlineChunked: resolvedEncryptInlineChunked ?? publishOptions.encryptInlineChunked,
+        catalogFloor: queuedOnChainContextGraphId && resolvedEncryptInlinePayload
+          ? 'generated-private' as const
+          : 'none' as const,
+      };
       // #1670 — finalized private assertions seal the deterministic public
       // catalog floor, but assertionPromote deliberately keeps that synthetic
       // root out of the per-user-root immutable share snapshot. The synchronous
@@ -3959,14 +3966,14 @@ export class PublishMethods extends DKGAgentBase {
       // publisher has no catalog commitment/staging bytes, so cores fall back to
       // their (intentionally absent) curated SWM copy and decline NO_DATA_IN_SWM.
       //
-      // Gate this on the live, chain-policy-resolved encryption callback rather
-      // than the queued mapper placeholder. That keeps public CGs untouched and
-      // prevents caller-supplied policy hints from manufacturing trusted catalog
-      // triples. The shared preparation boundary performs exact-key
+      // The explicit queued policy requires both a verified on-chain CG binding
+      // and a live curated-policy encryption result. That keeps local-only and
+      // public CGs untouched and prevents queued mapper placeholders from
+      // manufacturing trusted catalog triples. The shared preparation boundary performs exact-key
       // de-duplication for legacy snapshots and returns the trust allow-list
       // with the quads so queued/update/sync paths cannot drift independently.
-      const preparedQueuedCatalog = resolvedEncryptInlinePayload
-        ? prepareGeneratedPrivateCatalogFloor(request.contextGraphId, snapshotQuads)
+      const preparedQueuedCatalog = queuedPublishPolicy.catalogFloor === 'generated-private'
+        ? appendMissingGeneratedPrivateCatalogFloor(request.contextGraphId, snapshotQuads)
         : undefined;
       const queuedPublishQuads = preparedQueuedCatalog?.quads ?? snapshotQuads;
       result = await publisher.publish({
@@ -3992,8 +3999,8 @@ export class PublishMethods extends DKGAgentBase {
           reservedKaId: recoveredReservedKaId ?? 0n,
         },
         onChainContextGraphId: queuedOnChainContextGraphId,
-        encryptInlinePayload,
-        encryptInlineChunked,
+        encryptInlinePayload: queuedPublishPolicy.encryptInlinePayload,
+        encryptInlineChunked: queuedPublishPolicy.encryptInlineChunked,
         ...(preparedQueuedCatalog
           ? {
               trustedNonManifestCatalogTriples:
@@ -4835,10 +4842,10 @@ export class PublishMethods extends DKGAgentBase {
     const swmGraph = contextGraphSharedMemoryUri(contextGraphId, subGraphName);
     const catalogTargetGraph = canonicalSharedMemoryScopeWriteGraph(swmGraph, scope);
     const cgDid = contextGraphDataUri(contextGraphId);
-    const { quads: catalogQuads } = prepareGeneratedPrivateCatalogFloor(
+    const { quads: catalogQuads } = appendMissingGeneratedPrivateCatalogFloor(
       contextGraphId,
       [],
-      { graph: catalogTargetGraph },
+      catalogTargetGraph,
     );
     await this.store.insert(catalogQuads);
     this.log.info(

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -111,6 +111,8 @@ import {
   resolveWorkspaceAgentRecipients,
   computeTripleHashV10 as computeTripleHash, computeFlatKCRootV10 as computeFlatKCRoot, skolemizeByEntity, isReservedSubject,
   canonicalPublishPayload,
+  catalogTripleKey,
+  generatedPrivateCatalogFloorQuads,
   generatedPrivateCatalogTripleKeys,
   createKnowledgeAssetVmPublishSnapshotMetadata,
   createKnowledgeAssetVmPublishSnapshotRequest,
@@ -3957,10 +3959,36 @@ export class PublishMethods extends DKGAgentBase {
       );
       const encryptInlinePayload = resolvedEncryptInlinePayload ?? publishOptions.encryptInlinePayload;
       const encryptInlineChunked = resolvedEncryptInlineChunked ?? publishOptions.encryptInlineChunked;
+      // #1670 — finalized private assertions seal the deterministic public
+      // catalog floor, but assertionPromote deliberately keeps that synthetic
+      // root out of the per-user-root immutable share snapshot. The synchronous
+      // named-KA path reconstructs the floor in SWM before publishing; queued
+      // execution must do the same from deterministic inputs. Without it the
+      // publisher has no catalog commitment/staging bytes, so cores fall back to
+      // their (intentionally absent) curated SWM copy and decline NO_DATA_IN_SWM.
+      //
+      // Gate this on the live, chain-policy-resolved encryption callback rather
+      // than the queued mapper placeholder. That keeps public CGs untouched and
+      // prevents caller-supplied policy hints from manufacturing trusted catalog
+      // triples. Exact-key de-duplication also supports legacy snapshots that
+      // already contain some or all of the generated floor.
+      const trustedQueuedCatalogTriples = resolvedEncryptInlinePayload
+        ? generatedPrivateCatalogTripleKeys(request.contextGraphId)
+        : undefined;
+      const queuedPublishQuads = trustedQueuedCatalogTriples
+        ? (() => {
+            const present = new Set(snapshotQuads.map(catalogTripleKey));
+            return [
+              ...snapshotQuads,
+              ...generatedPrivateCatalogFloorQuads(request.contextGraphId)
+                .filter((quad) => !present.has(catalogTripleKey(quad))),
+            ];
+          })()
+        : snapshotQuads;
       result = await publisher.publish({
         ...publisherPublishOptions,
         contextGraphId: request.contextGraphId,
-        quads: snapshotQuads,
+        quads: queuedPublishQuads,
         privateQuads: snapshotPrivateQuads.length > 0 ? snapshotPrivateQuads : undefined,
         publisherPeerId: publishOptions.publisherPeerId ?? this.peerId,
         subGraphName: request.subGraphName,
@@ -3982,6 +4010,9 @@ export class PublishMethods extends DKGAgentBase {
         onChainContextGraphId: queuedOnChainContextGraphId,
         encryptInlinePayload,
         encryptInlineChunked,
+        ...(trustedQueuedCatalogTriples
+          ? { trustedNonManifestCatalogTriples: trustedQueuedCatalogTriples }
+          : {}),
       });
 
       if (result.status === 'confirmed' && result.onChainResult) {

--- a/packages/agent/test/encrypt-inline-policy.test.ts
+++ b/packages/agent/test/encrypt-inline-policy.test.ts
@@ -18,7 +18,12 @@ import {
   encodePublishIntent,
   isStorageACKDecline,
 } from '@origintrail-official/dkg-core';
-import { StorageACKHandler, type KnowledgeAssetVmPublishRequest } from '@origintrail-official/dkg-publisher';
+import {
+  StorageACKHandler,
+  generatedPrivateCatalogFloorQuads,
+  generatedPrivateCatalogTripleKeys,
+  type KnowledgeAssetVmPublishRequest,
+} from '@origintrail-official/dkg-publisher';
 import { DKGAgent } from '../src/dkg-agent.js';
 
 // Hand-rolled call recorder (replaces vitest spy factories): wraps an
@@ -697,7 +702,7 @@ describe('DKGAgent.publishFromSharedMemory inline encryption routing', () => {
 });
 
 describe('DKGAgent.publishQueuedKnowledgeAssetVmPublish inline encryption routing', () => {
-  it('lets resolved real encryption callbacks override queued fail-closed placeholders', async () => {
+  it('reconstructs the curated catalog floor and lets real encryption override placeholders', async () => {
     const realInline = recorder(async (plaintext: Uint8Array) => new Uint8Array([...plaintext, 0xaa]));
     const realChunked = recorder(async () => ({
       ciphertextChunksRoot: ethers.getBytes(ethers.id('queued-real-chunk-root')),
@@ -789,6 +794,8 @@ describe('DKGAgent.publishQueuedKnowledgeAssetVmPublish inline encryption routin
     expect(publisherPublish.calls.at(-1)?.[0]).toMatchObject({
       encryptInlinePayload: realInline,
       encryptInlineChunked: realChunked,
+      quads: expect.arrayContaining(generatedPrivateCatalogFloorQuads('private-cg')),
+      trustedNonManifestCatalogTriples: generatedPrivateCatalogTripleKeys('private-cg'),
     });
     expect(publisherPublish.calls.at(-1)?.[0].encryptInlinePayload).not.toBe(failClosedInline);
     expect(publisherPublish.calls.at(-1)?.[0].encryptInlineChunked).not.toBe(failClosedChunked);

--- a/packages/agent/test/encrypt-inline-policy.test.ts
+++ b/packages/agent/test/encrypt-inline-policy.test.ts
@@ -702,6 +702,86 @@ describe('DKGAgent.publishFromSharedMemory inline encryption routing', () => {
   });
 });
 
+const QUEUED_TEST_AUTHOR = '0x1111111111111111111111111111111111111111';
+const QUEUED_TEST_LIFECYCLE = '0x2222222222222222222222222222222222222222';
+
+function makeQueuedAgentHarness(options: {
+  peerId: string;
+  ual: string;
+  chain?: Record<string, unknown>;
+  onChainContextGraphId?: string | null;
+  encryptInlinePayload?: unknown;
+  encryptInlineChunked?: unknown;
+}) {
+  const publisherPublish = recorder(async (_opts: any) => ({
+    status: 'tentative' as const,
+    ual: options.ual,
+  }));
+  const agentLike: any = {
+    peerId: options.peerId,
+    defaultAgentAddress: QUEUED_TEST_AUTHOR,
+    chain: options.chain ?? {},
+    store: {
+      query: recorder(async () => ({ type: 'bindings', bindings: [] })),
+      insert: recorder(async () => undefined),
+      deleteByPattern: recorder(async () => undefined),
+    },
+    log: {
+      info: recorder(() => undefined),
+      warn: recorder(() => undefined),
+      error: recorder(() => undefined),
+      debug: recorder(() => undefined),
+    },
+    publisher: {
+      publish: publisherPublish,
+      clearSwmShareComplete: recorder(async () => undefined),
+    },
+    createV10ACKProvider: recorder(() => undefined),
+    _resolveEncryptInlinePayload: recorder(async () => options.encryptInlinePayload),
+    _resolveEncryptInlineChunked: recorder(async () => options.encryptInlineChunked),
+    _stampPointer: recorder(async () => undefined),
+  };
+  if (options.onChainContextGraphId !== undefined) {
+    agentLike.getContextGraphOnChainId = recorder(
+      async () => options.onChainContextGraphId,
+    );
+  }
+  return { agentLike, publisherPublish };
+}
+
+function makeQueuedPublishRequest(options: {
+  contextGraphId: string;
+  name: string;
+  shareOperationId: string;
+  root: string;
+  intentByte: string;
+  reservedKaId?: `${bigint}`;
+}): KnowledgeAssetVmPublishRequest {
+  return {
+    contextGraphId: options.contextGraphId,
+    name: options.name,
+    shareOperationId: options.shareOperationId,
+    roots: [options.root],
+    seal: {
+      merkleRoot: `0x${'12'.repeat(32)}`,
+      authorAddress: QUEUED_TEST_AUTHOR,
+      signature: {
+        r: `0x${'34'.repeat(32)}`,
+        vs: `0x${'56'.repeat(32)}`,
+      },
+      schemeVersion: 1,
+      ...(options.reservedKaId === undefined
+        ? {}
+        : { reservedKaId: options.reservedKaId }),
+    },
+    sealChainId: '31337',
+    sealKav10Address: QUEUED_TEST_LIFECYCLE,
+    sealFinalizedAtIso: '2026-01-01T00:00:00.000Z',
+    sealMerkleRoot: `0x${'12'.repeat(32)}`,
+    intentKey: `sha256:${options.intentByte.repeat(32)}`,
+  };
+}
+
 describe('DKGAgent.publishQueuedKnowledgeAssetVmPublish inline encryption routing', () => {
   it('reconstructs the curated catalog floor and lets real encryption override placeholders', async () => {
     const realInline = recorder(async (plaintext: Uint8Array) => new Uint8Array([...plaintext, 0xaa]));
@@ -716,62 +796,29 @@ describe('DKGAgent.publishQueuedKnowledgeAssetVmPublish inline encryption routin
     const failClosedChunked = recorder(async () => {
       throw new Error('fail-closed chunk placeholder should not be used');
     });
-    const publisherPublish = recorder(async (_opts: any) => ({
-      status: 'tentative',
-      ual: 'did:dkg:local/queued-encryption',
-    }));
-    const store = {
-      query: recorder(async () => ({ type: 'bindings', bindings: [] })),
-      insert: recorder(async () => undefined),
-      deleteByPattern: recorder(async () => undefined),
-    };
-    const agentLike = {
+    const { agentLike, publisherPublish } = makeQueuedAgentHarness({
       peerId: 'did:dkg:agent:queued-encryption',
-      defaultAgentAddress: '0x1111111111111111111111111111111111111111',
+      ual: 'did:dkg:local/queued-encryption',
       chain: {
         getEvmChainId: recorder(async () => 31337n),
         getKnowledgeAssetsLifecycleAddress: recorder(
-          async () => '0x2222222222222222222222222222222222222222',
+          async () => QUEUED_TEST_LIFECYCLE,
         ),
       },
-      store,
-      log: {
-        info: recorder(() => undefined),
-        warn: recorder(() => undefined),
-        error: recorder(() => undefined),
-        debug: recorder(() => undefined),
-      },
-      publisher: {
-        publish: publisherPublish,
-        clearSwmShareComplete: recorder(async () => undefined),
-      },
-      createV10ACKProvider: recorder(() => undefined),
-      getContextGraphOnChainId: recorder(async () => '7'),
-      _resolveEncryptInlinePayload: recorder(async () => realInline),
-      _resolveEncryptInlineChunked: recorder(async () => realChunked),
-      _stampPointer: recorder(async () => undefined),
-    } as any;
-    const request: KnowledgeAssetVmPublishRequest = {
+      onChainContextGraphId: '7',
+      encryptInlinePayload: realInline,
+      encryptInlineChunked: realChunked,
+    });
+    const request = makeQueuedPublishRequest({
       contextGraphId: 'private-cg',
       name: 'queued-private-ka',
       shareOperationId: 'share-op-1',
-      roots: ['urn:test:queued-private'],
-      seal: {
-        merkleRoot: `0x${'12'.repeat(32)}`,
-        authorAddress: '0x1111111111111111111111111111111111111111',
-        signature: {
-          r: `0x${'34'.repeat(32)}`,
-          vs: `0x${'56'.repeat(32)}`,
-        },
-        schemeVersion: 1,
-        reservedKaId: ((BigInt('0x1111111111111111111111111111111111111111') << 96n) | 1n).toString(),
-      },
-      sealChainId: '31337',
-      sealKav10Address: '0x2222222222222222222222222222222222222222',
-      sealFinalizedAtIso: '2026-01-01T00:00:00.000Z',
-      sealMerkleRoot: `0x${'12'.repeat(32)}`,
-      intentKey: `sha256:${'ab'.repeat(32)}`,
-    };
+      root: 'urn:test:queued-private',
+      intentByte: 'ab',
+      reservedKaId: (
+        (BigInt(QUEUED_TEST_AUTHOR) << 96n) | 1n
+      ).toString() as `${bigint}`,
+    });
     const generatedFloor = generatedPrivateCatalogFloorQuads('private-cg');
     const legacyFloorQuad = { ...generatedFloor[0], graph: 'urn:legacy:catalog' };
 
@@ -821,54 +868,18 @@ describe('DKGAgent.publishQueuedKnowledgeAssetVmPublish inline encryption routin
 
   it('does not trust or append a catalog floor for a private local-only queued publish', async () => {
     const realInline = recorder(async (plaintext: Uint8Array) => plaintext);
-    const publisherPublish = recorder(async (_opts: any) => ({
-      status: 'tentative',
-      ual: 'did:dkg:local/queued-private-local',
-    }));
-    const agentLike = {
+    const { agentLike, publisherPublish } = makeQueuedAgentHarness({
       peerId: 'did:dkg:agent:queued-private-local',
-      defaultAgentAddress: '0x1111111111111111111111111111111111111111',
-      chain: {},
-      store: {
-        query: recorder(async () => ({ type: 'bindings', bindings: [] })),
-        insert: recorder(async () => undefined),
-        deleteByPattern: recorder(async () => undefined),
-      },
-      log: {
-        info: recorder(() => undefined),
-        warn: recorder(() => undefined),
-        error: recorder(() => undefined),
-        debug: recorder(() => undefined),
-      },
-      publisher: {
-        publish: publisherPublish,
-        clearSwmShareComplete: recorder(async () => undefined),
-      },
-      createV10ACKProvider: recorder(() => undefined),
-      _resolveEncryptInlinePayload: recorder(async () => realInline),
-      _resolveEncryptInlineChunked: recorder(async () => undefined),
-      _stampPointer: recorder(async () => undefined),
-    } as any;
-    const request: KnowledgeAssetVmPublishRequest = {
+      ual: 'did:dkg:local/queued-private-local',
+      encryptInlinePayload: realInline,
+    });
+    const request = makeQueuedPublishRequest({
       contextGraphId: 'private-local-cg',
       name: 'queued-private-local-ka',
       shareOperationId: 'share-op-private-local',
-      roots: ['urn:test:queued-private-local'],
-      seal: {
-        merkleRoot: `0x${'12'.repeat(32)}`,
-        authorAddress: '0x1111111111111111111111111111111111111111',
-        signature: {
-          r: `0x${'34'.repeat(32)}`,
-          vs: `0x${'56'.repeat(32)}`,
-        },
-        schemeVersion: 1,
-      },
-      sealChainId: '31337',
-      sealKav10Address: '0x2222222222222222222222222222222222222222',
-      sealFinalizedAtIso: '2026-01-01T00:00:00.000Z',
-      sealMerkleRoot: `0x${'12'.repeat(32)}`,
-      intentKey: `sha256:${'cd'.repeat(32)}`,
-    };
+      root: 'urn:test:queued-private-local',
+      intentByte: 'cd',
+    });
     const originalQuads = [{
       subject: 'urn:test:queued-private-local',
       predicate: 'http://schema.org/name',
@@ -899,54 +910,17 @@ describe('DKGAgent.publishQueuedKnowledgeAssetVmPublish inline encryption routin
     const placeholderChunked = recorder(async () => {
       throw new Error('queued fail-closed chunk placeholder');
     });
-    const publisherPublish = recorder(async (_opts: any) => ({
-      status: 'tentative',
-      ual: 'did:dkg:local/queued-placeholder',
-    }));
-    const agentLike = {
+    const { agentLike, publisherPublish } = makeQueuedAgentHarness({
       peerId: 'did:dkg:agent:queued-placeholder',
-      defaultAgentAddress: '0x1111111111111111111111111111111111111111',
-      chain: {},
-      store: {
-        query: recorder(async () => ({ type: 'bindings', bindings: [] })),
-        insert: recorder(async () => undefined),
-        deleteByPattern: recorder(async () => undefined),
-      },
-      log: {
-        info: recorder(() => undefined),
-        warn: recorder(() => undefined),
-        error: recorder(() => undefined),
-        debug: recorder(() => undefined),
-      },
-      publisher: {
-        publish: publisherPublish,
-        clearSwmShareComplete: recorder(async () => undefined),
-      },
-      createV10ACKProvider: recorder(() => undefined),
-      _resolveEncryptInlinePayload: recorder(async () => undefined),
-      _resolveEncryptInlineChunked: recorder(async () => undefined),
-      _stampPointer: recorder(async () => undefined),
-    } as any;
-    const request: KnowledgeAssetVmPublishRequest = {
+      ual: 'did:dkg:local/queued-placeholder',
+    });
+    const request = makeQueuedPublishRequest({
       contextGraphId: 'public-cg',
       name: 'queued-public-ka',
       shareOperationId: 'share-op-placeholder',
-      roots: ['urn:test:queued-public'],
-      seal: {
-        merkleRoot: `0x${'12'.repeat(32)}`,
-        authorAddress: '0x1111111111111111111111111111111111111111',
-        signature: {
-          r: `0x${'34'.repeat(32)}`,
-          vs: `0x${'56'.repeat(32)}`,
-        },
-        schemeVersion: 1,
-      },
-      sealChainId: '31337',
-      sealKav10Address: '0x2222222222222222222222222222222222222222',
-      sealFinalizedAtIso: '2026-01-01T00:00:00.000Z',
-      sealMerkleRoot: `0x${'12'.repeat(32)}`,
-      intentKey: `sha256:${'ef'.repeat(32)}`,
-    };
+      root: 'urn:test:queued-public',
+      intentByte: 'ef',
+    });
     const originalQuads = [{
       subject: 'urn:test:queued-public',
       predicate: 'http://schema.org/name',
@@ -973,60 +947,23 @@ describe('DKGAgent.publishQueuedKnowledgeAssetVmPublish inline encryption routin
   });
 
   it('uses queued resolved on-chain CG id as binding-only metadata for same-CG publishes', async () => {
-    const publisherPublish = recorder(async (_opts: any) => ({
-      status: 'tentative',
-      ual: 'did:dkg:local/queued-binding',
-    }));
-    const store = {
-      query: recorder(async () => ({ type: 'bindings', bindings: [] })),
-      insert: recorder(async () => undefined),
-      deleteByPattern: recorder(async () => undefined),
-    };
-    const agentLike = {
+    const { agentLike, publisherPublish } = makeQueuedAgentHarness({
       peerId: 'did:dkg:agent:queued-binding',
-      defaultAgentAddress: '0x1111111111111111111111111111111111111111',
+      ual: 'did:dkg:local/queued-binding',
       chain: {
         getEvmChainId: recorder(async () => 31337n),
-        getKnowledgeAssetsLifecycleAddress: recorder(async () => '0x2222222222222222222222222222222222222222'),
+        getKnowledgeAssetsLifecycleAddress: recorder(async () => QUEUED_TEST_LIFECYCLE),
       },
-      getContextGraphOnChainId: recorder(async () => null),
-      store,
-      log: {
-        info: recorder(() => undefined),
-        warn: recorder(() => undefined),
-        error: recorder(() => undefined),
-        debug: recorder(() => undefined),
-      },
-      publisher: {
-        publish: publisherPublish,
-        clearSwmShareComplete: recorder(async () => undefined),
-      },
-      createV10ACKProvider: recorder(() => undefined),
-      _resolveEncryptInlinePayload: recorder(async () => undefined),
-      _resolveEncryptInlineChunked: recorder(async () => undefined),
-      _stampPointer: recorder(async () => undefined),
-    } as any;
-    const request: KnowledgeAssetVmPublishRequest = {
+      onChainContextGraphId: null,
+    });
+    const request = makeQueuedPublishRequest({
       contextGraphId: 'memory-layers-e2e',
       name: 'queued-binding-ka',
       shareOperationId: 'share-op-1',
-      roots: ['urn:test:queued-binding'],
-      seal: {
-        merkleRoot: `0x${'12'.repeat(32)}`,
-        authorAddress: '0x1111111111111111111111111111111111111111',
-        signature: {
-          r: `0x${'34'.repeat(32)}`,
-          vs: `0x${'56'.repeat(32)}`,
-        },
-        schemeVersion: 1,
-        reservedKaId: '1' as `${bigint}`,
-      },
-      sealChainId: '31337',
-      sealKav10Address: '0x2222222222222222222222222222222222222222',
-      sealFinalizedAtIso: '2026-01-01T00:00:00.000Z',
-      sealMerkleRoot: `0x${'12'.repeat(32)}`,
-      intentKey: `sha256:${'cd'.repeat(32)}`,
-    };
+      root: 'urn:test:queued-binding',
+      intentByte: 'cd',
+      reservedKaId: '1',
+    });
 
     await (DKGAgent.prototype as any).publishQueuedKnowledgeAssetVmPublish.call(agentLike, request, {
       contextGraphId: request.contextGraphId,
@@ -1066,59 +1003,23 @@ describe('DKGAgent.publishQueuedKnowledgeAssetVmPublish inline encryption routin
   });
 
   it('fails queued same-CG publishes before publisher execution when the CG is not on chain', async () => {
-    const publisherPublish = recorder(async (_opts: any) => ({
-      status: 'tentative',
-      ual: 'did:dkg:local/should-not-publish',
-    }));
-    const agentLike = {
+    const { agentLike, publisherPublish } = makeQueuedAgentHarness({
       peerId: 'did:dkg:agent:queued-unregistered',
-      defaultAgentAddress: '0x1111111111111111111111111111111111111111',
+      ual: 'did:dkg:local/should-not-publish',
       chain: {
         getEvmChainId: recorder(async () => 31337n),
-        getKnowledgeAssetsLifecycleAddress: recorder(async () => '0x2222222222222222222222222222222222222222'),
+        getKnowledgeAssetsLifecycleAddress: recorder(async () => QUEUED_TEST_LIFECYCLE),
       },
-      getContextGraphOnChainId: recorder(async () => null),
-      store: {
-        query: recorder(async () => ({ type: 'bindings', bindings: [] })),
-        insert: recorder(async () => undefined),
-        deleteByPattern: recorder(async () => undefined),
-      },
-      log: {
-        info: recorder(() => undefined),
-        warn: recorder(() => undefined),
-        error: recorder(() => undefined),
-        debug: recorder(() => undefined),
-      },
-      publisher: {
-        publish: publisherPublish,
-        clearSwmShareComplete: recorder(async () => undefined),
-      },
-      createV10ACKProvider: recorder(() => undefined),
-      _resolveEncryptInlinePayload: recorder(async () => undefined),
-      _resolveEncryptInlineChunked: recorder(async () => undefined),
-      _stampPointer: recorder(async () => undefined),
-    } as any;
-    const request: KnowledgeAssetVmPublishRequest = {
+      onChainContextGraphId: null,
+    });
+    const request = makeQueuedPublishRequest({
       contextGraphId: 'unregistered-product-cg',
       name: 'queued-unregistered-ka',
       shareOperationId: 'share-op-1',
-      roots: ['urn:test:queued-unregistered'],
-      seal: {
-        merkleRoot: `0x${'12'.repeat(32)}`,
-        authorAddress: '0x1111111111111111111111111111111111111111',
-        signature: {
-          r: `0x${'34'.repeat(32)}`,
-          vs: `0x${'56'.repeat(32)}`,
-        },
-        schemeVersion: 1,
-        reservedKaId: '1' as `${bigint}`,
-      },
-      sealChainId: '31337',
-      sealKav10Address: '0x2222222222222222222222222222222222222222',
-      sealFinalizedAtIso: '2026-01-01T00:00:00.000Z',
-      sealMerkleRoot: `0x${'12'.repeat(32)}`,
-      intentKey: `sha256:${'de'.repeat(32)}`,
-    };
+      root: 'urn:test:queued-unregistered',
+      intentByte: 'de',
+      reservedKaId: '1',
+    });
 
     let thrown: any;
     try {

--- a/packages/agent/test/encrypt-inline-policy.test.ts
+++ b/packages/agent/test/encrypt-inline-policy.test.ts
@@ -728,7 +728,12 @@ describe('DKGAgent.publishQueuedKnowledgeAssetVmPublish inline encryption routin
     const agentLike = {
       peerId: 'did:dkg:agent:queued-encryption',
       defaultAgentAddress: '0x1111111111111111111111111111111111111111',
-      chain: {},
+      chain: {
+        getEvmChainId: recorder(async () => 31337n),
+        getKnowledgeAssetsLifecycleAddress: recorder(
+          async () => '0x2222222222222222222222222222222222222222',
+        ),
+      },
       store,
       log: {
         info: recorder(() => undefined),
@@ -741,6 +746,7 @@ describe('DKGAgent.publishQueuedKnowledgeAssetVmPublish inline encryption routin
         clearSwmShareComplete: recorder(async () => undefined),
       },
       createV10ACKProvider: recorder(() => undefined),
+      getContextGraphOnChainId: recorder(async () => '7'),
       _resolveEncryptInlinePayload: recorder(async () => realInline),
       _resolveEncryptInlineChunked: recorder(async () => realChunked),
       _stampPointer: recorder(async () => undefined),
@@ -758,6 +764,7 @@ describe('DKGAgent.publishQueuedKnowledgeAssetVmPublish inline encryption routin
           vs: `0x${'56'.repeat(32)}`,
         },
         schemeVersion: 1,
+        reservedKaId: ((BigInt('0x1111111111111111111111111111111111111111') << 96n) | 1n).toString(),
       },
       sealChainId: '31337',
       sealKav10Address: '0x2222222222222222222222222222222222222222',
@@ -788,18 +795,19 @@ describe('DKGAgent.publishQueuedKnowledgeAssetVmPublish inline encryption routin
       undefined,
       undefined,
       undefined,
-      undefined,
+      { aeadBindingContextGraphId: '7' },
     ]);
     expect(agentLike._resolveEncryptInlineChunked.calls.at(-1)).toEqual([
       'private-cg',
       undefined,
       undefined,
       undefined,
-      undefined,
+      { aeadBindingContextGraphId: '7' },
     ]);
     expect(publisherPublish.calls.at(-1)?.[0]).toMatchObject({
       encryptInlinePayload: realInline,
       encryptInlineChunked: realChunked,
+      onChainContextGraphId: '7',
       trustedNonManifestCatalogTriples: generatedPrivateCatalogTripleKeys('private-cg'),
     });
     const publishedQuads = publisherPublish.calls.at(-1)?.[0].quads;
@@ -809,6 +817,79 @@ describe('DKGAgent.publishQueuedKnowledgeAssetVmPublish inline encryption routin
     }
     expect(publisherPublish.calls.at(-1)?.[0].encryptInlinePayload).not.toBe(failClosedInline);
     expect(publisherPublish.calls.at(-1)?.[0].encryptInlineChunked).not.toBe(failClosedChunked);
+  });
+
+  it('does not trust or append a catalog floor for a private local-only queued publish', async () => {
+    const realInline = recorder(async (plaintext: Uint8Array) => plaintext);
+    const publisherPublish = recorder(async (_opts: any) => ({
+      status: 'tentative',
+      ual: 'did:dkg:local/queued-private-local',
+    }));
+    const agentLike = {
+      peerId: 'did:dkg:agent:queued-private-local',
+      defaultAgentAddress: '0x1111111111111111111111111111111111111111',
+      chain: {},
+      store: {
+        query: recorder(async () => ({ type: 'bindings', bindings: [] })),
+        insert: recorder(async () => undefined),
+        deleteByPattern: recorder(async () => undefined),
+      },
+      log: {
+        info: recorder(() => undefined),
+        warn: recorder(() => undefined),
+        error: recorder(() => undefined),
+        debug: recorder(() => undefined),
+      },
+      publisher: {
+        publish: publisherPublish,
+        clearSwmShareComplete: recorder(async () => undefined),
+      },
+      createV10ACKProvider: recorder(() => undefined),
+      _resolveEncryptInlinePayload: recorder(async () => realInline),
+      _resolveEncryptInlineChunked: recorder(async () => undefined),
+      _stampPointer: recorder(async () => undefined),
+    } as any;
+    const request: KnowledgeAssetVmPublishRequest = {
+      contextGraphId: 'private-local-cg',
+      name: 'queued-private-local-ka',
+      shareOperationId: 'share-op-private-local',
+      roots: ['urn:test:queued-private-local'],
+      seal: {
+        merkleRoot: `0x${'12'.repeat(32)}`,
+        authorAddress: '0x1111111111111111111111111111111111111111',
+        signature: {
+          r: `0x${'34'.repeat(32)}`,
+          vs: `0x${'56'.repeat(32)}`,
+        },
+        schemeVersion: 1,
+      },
+      sealChainId: '31337',
+      sealKav10Address: '0x2222222222222222222222222222222222222222',
+      sealFinalizedAtIso: '2026-01-01T00:00:00.000Z',
+      sealMerkleRoot: `0x${'12'.repeat(32)}`,
+      intentKey: `sha256:${'cd'.repeat(32)}`,
+    };
+    const originalQuads = [{
+      subject: 'urn:test:queued-private-local',
+      predicate: 'http://schema.org/name',
+      object: '"Queued Private Local"',
+      graph: '',
+    }];
+
+    await (DKGAgent.prototype as any).publishQueuedKnowledgeAssetVmPublish.call(
+      agentLike,
+      request,
+      { contextGraphId: request.contextGraphId, quads: originalQuads },
+    );
+
+    expect(publisherPublish.calls.at(-1)?.[0]).toMatchObject({
+      quads: originalQuads,
+      encryptInlinePayload: realInline,
+      onChainContextGraphId: undefined,
+    });
+    expect(publisherPublish.calls.at(-1)?.[0]).not.toHaveProperty(
+      'trustedNonManifestCatalogTriples',
+    );
   });
 
   it('does not trust or append a catalog floor from queued placeholder callbacks', async () => {

--- a/packages/agent/test/encrypt-inline-policy.test.ts
+++ b/packages/agent/test/encrypt-inline-policy.test.ts
@@ -20,6 +20,7 @@ import {
 } from '@origintrail-official/dkg-core';
 import {
   StorageACKHandler,
+  catalogTripleKey,
   generatedPrivateCatalogFloorQuads,
   generatedPrivateCatalogTripleKeys,
   type KnowledgeAssetVmPublishRequest,
@@ -764,15 +765,20 @@ describe('DKGAgent.publishQueuedKnowledgeAssetVmPublish inline encryption routin
       sealMerkleRoot: `0x${'12'.repeat(32)}`,
       intentKey: `sha256:${'ab'.repeat(32)}`,
     };
+    const generatedFloor = generatedPrivateCatalogFloorQuads('private-cg');
+    const legacyFloorQuad = { ...generatedFloor[0], graph: 'urn:legacy:catalog' };
 
     await (DKGAgent.prototype as any).publishQueuedKnowledgeAssetVmPublish.call(agentLike, request, {
       contextGraphId: request.contextGraphId,
-      quads: [{
-        subject: 'urn:test:queued-private',
-        predicate: 'http://schema.org/name',
-        object: '"Queued Private"',
-        graph: '',
-      }],
+      quads: [
+        {
+          subject: 'urn:test:queued-private',
+          predicate: 'http://schema.org/name',
+          object: '"Queued Private"',
+          graph: '',
+        },
+        legacyFloorQuad,
+      ],
       encryptInlinePayload: failClosedInline,
       encryptInlineChunked: failClosedChunked,
     });
@@ -794,11 +800,95 @@ describe('DKGAgent.publishQueuedKnowledgeAssetVmPublish inline encryption routin
     expect(publisherPublish.calls.at(-1)?.[0]).toMatchObject({
       encryptInlinePayload: realInline,
       encryptInlineChunked: realChunked,
-      quads: expect.arrayContaining(generatedPrivateCatalogFloorQuads('private-cg')),
       trustedNonManifestCatalogTriples: generatedPrivateCatalogTripleKeys('private-cg'),
     });
+    const publishedQuads = publisherPublish.calls.at(-1)?.[0].quads;
+    expect(publishedQuads).toContainEqual({ ...legacyFloorQuad, graph: '' });
+    for (const key of generatedPrivateCatalogTripleKeys('private-cg')) {
+      expect(publishedQuads.filter((quad: any) => catalogTripleKey(quad) === key)).toHaveLength(1);
+    }
     expect(publisherPublish.calls.at(-1)?.[0].encryptInlinePayload).not.toBe(failClosedInline);
     expect(publisherPublish.calls.at(-1)?.[0].encryptInlineChunked).not.toBe(failClosedChunked);
+  });
+
+  it('does not trust or append a catalog floor from queued placeholder callbacks', async () => {
+    const placeholderInline = recorder(async () => {
+      throw new Error('queued fail-closed placeholder');
+    });
+    const placeholderChunked = recorder(async () => {
+      throw new Error('queued fail-closed chunk placeholder');
+    });
+    const publisherPublish = recorder(async (_opts: any) => ({
+      status: 'tentative',
+      ual: 'did:dkg:local/queued-placeholder',
+    }));
+    const agentLike = {
+      peerId: 'did:dkg:agent:queued-placeholder',
+      defaultAgentAddress: '0x1111111111111111111111111111111111111111',
+      chain: {},
+      store: {
+        query: recorder(async () => ({ type: 'bindings', bindings: [] })),
+        insert: recorder(async () => undefined),
+        deleteByPattern: recorder(async () => undefined),
+      },
+      log: {
+        info: recorder(() => undefined),
+        warn: recorder(() => undefined),
+        error: recorder(() => undefined),
+        debug: recorder(() => undefined),
+      },
+      publisher: {
+        publish: publisherPublish,
+        clearSwmShareComplete: recorder(async () => undefined),
+      },
+      createV10ACKProvider: recorder(() => undefined),
+      _resolveEncryptInlinePayload: recorder(async () => undefined),
+      _resolveEncryptInlineChunked: recorder(async () => undefined),
+      _stampPointer: recorder(async () => undefined),
+    } as any;
+    const request: KnowledgeAssetVmPublishRequest = {
+      contextGraphId: 'public-cg',
+      name: 'queued-public-ka',
+      shareOperationId: 'share-op-placeholder',
+      roots: ['urn:test:queued-public'],
+      seal: {
+        merkleRoot: `0x${'12'.repeat(32)}`,
+        authorAddress: '0x1111111111111111111111111111111111111111',
+        signature: {
+          r: `0x${'34'.repeat(32)}`,
+          vs: `0x${'56'.repeat(32)}`,
+        },
+        schemeVersion: 1,
+      },
+      sealChainId: '31337',
+      sealKav10Address: '0x2222222222222222222222222222222222222222',
+      sealFinalizedAtIso: '2026-01-01T00:00:00.000Z',
+      sealMerkleRoot: `0x${'12'.repeat(32)}`,
+      intentKey: `sha256:${'ef'.repeat(32)}`,
+    };
+    const originalQuads = [{
+      subject: 'urn:test:queued-public',
+      predicate: 'http://schema.org/name',
+      object: '"Queued Public"',
+      graph: '',
+    }];
+
+    await (DKGAgent.prototype as any).publishQueuedKnowledgeAssetVmPublish.call(
+      agentLike,
+      request,
+      {
+        contextGraphId: request.contextGraphId,
+        quads: originalQuads,
+        encryptInlinePayload: placeholderInline,
+        encryptInlineChunked: placeholderChunked,
+      },
+    );
+
+    const publishCall = publisherPublish.calls.at(-1)?.[0];
+    expect(publishCall.quads).toEqual(originalQuads);
+    expect(publishCall.encryptInlinePayload).toBe(placeholderInline);
+    expect(publishCall.encryptInlineChunked).toBe(placeholderChunked);
+    expect(publishCall).not.toHaveProperty('trustedNonManifestCatalogTriples');
   });
 
   it('uses queued resolved on-chain CG id as binding-only metadata for same-CG publishes', async () => {

--- a/packages/agent/test/rfc49-catalog-parity.e2e.test.ts
+++ b/packages/agent/test/rfc49-catalog-parity.e2e.test.ts
@@ -53,6 +53,7 @@ import {
   autoPartition,
   computeFlatKCRootV10,
   computePrivateRootV10,
+  TripleStoreAsyncLiftPublisher,
 } from '../../publisher/src/index.js';
 import type { Quad } from '@origintrail-official/dkg-storage';
 import { ethers, Wallet } from 'ethers';
@@ -249,6 +250,66 @@ describe('OT-RFC-49 WS-D — catalog producer↔extractor↔chain parity', () =>
       'the rebuilt root must not change when a post-publish stamp lands',
     ).toBe(onChainRootHex);
     expect(rebuiltAfter.leafCount).toBe(onChainLeafCount);
+  }, 180_000);
+
+  it('curated named-KA publish-async reaches the same remote catalog ACK path as sync (#1670)', async () => {
+    const CG = 'rfc49-parity-private-async';
+    await publisher.createContextGraph({
+      id: CG,
+      name: 'RFC49 Parity Private Async',
+      accessPolicy: 1,
+      callerAgentAddress: curator,
+    });
+    await publisher.registerContextGraph(CG, { callerAgentAddress: curator });
+
+    const name = 'shipment-async';
+    const root = 'urn:acme:shipment/SH-ASYNC';
+    await publisher.assertion.create(CG, name);
+    await publisher.assertion.write(CG, name, [
+      { subject: root, predicate: 'urn:acme:product', object: '"P-ASYNC"' },
+    ]);
+    await publisher.assertion.finalize(CG, name);
+    const promoted = await publisher.assertion.promote(CG, name);
+    expect(promoted.publishReady).toBe(true);
+
+    const intent = await publisher.resolveFinalizedAssertionVmPublishIntent(CG, name);
+    let queuedResult: any;
+    const queue = new TripleStoreAsyncLiftPublisher((publisher as any).store, {
+      publicSnapshotStore: (publisher as any).publicSnapshotStore,
+      knowledgeAssetVmPublishPreflight: ({ request }) =>
+        publisher.preflightQueuedKnowledgeAssetVmPublishExecution(request),
+      knowledgeAssetVmPublishExecutor: async ({ request, publishOptions }) => {
+        queuedResult = await publisher.publishQueuedKnowledgeAssetVmPublish(request, publishOptions);
+        return queuedResult;
+      },
+    });
+    const jobId = await queue.enqueueKnowledgeAssetVmPublish(intent);
+    const processed = await queue.processNext('rfc49-async-wallet');
+
+    expect(processed?.jobId).toBe(jobId);
+    if (processed?.status !== 'finalized') {
+      throw new Error(`Expected curated async publish to finalize: ${JSON.stringify((processed as any)?.failure)}`);
+    }
+    expect(queuedResult?.status).toBe('confirmed');
+    expect(queuedResult?.onChainResult).toBeDefined();
+
+    const kaId = BigInt(queuedResult.kaId);
+    const chain: any = (publisher as any).chain;
+    const onChainRoot = ethers.hexlify(await chain.getCatalogRoot(kaId));
+    const onChainLeafCount = await chain.getCatalogLeafCount(kaId);
+    expect(onChainRoot).not.toBe(ethers.ZeroHash);
+    expect(onChainLeafCount).toBeGreaterThan(0);
+
+    // ackCore is not a member of this private CG. Its catalog copy therefore
+    // proves that the queued path shipped the public floor inline instead of
+    // asking the core for private SWM and receiving NO_DATA_IN_SWM.
+    const cgId: bigint = await chain.getKAContextGraphId(kaId);
+    const rebuilt = computeCatalogRoot(await extractCatalogLeavesFromStore({
+      store: (ackCore as any).store,
+      contextGraphId: cgId,
+    }));
+    expect(ethers.hexlify(rebuilt.root)).toBe(onChainRoot);
+    expect(rebuilt.leafCount).toBe(onChainLeafCount);
   }, 180_000);
 
   it('curated UPDATE re-commits the catalog (root non-zero, == publish baseline) and a remote core re-hosts it', async () => {

--- a/packages/publisher/src/catalog-trust.ts
+++ b/packages/publisher/src/catalog-trust.ts
@@ -60,54 +60,20 @@ export function generatedPrivateCatalogTripleKeys(contextGraphId: string): Reado
   return new Set(generatedPrivateCatalogFloorQuads(contextGraphId).map(catalogTripleKey));
 }
 
-export interface PrepareGeneratedPrivateCatalogFloorOptions {
-  /** Graph term applied to newly generated floor quads. */
-  graph?: string;
-  /**
-   * append-missing preserves immutable/legacy snapshots and fills only absent
-   * deterministic triples. replace-generated rebuilds the recognized catalog
-   * partition while retaining ordinary private data on the CG-DID subject.
-   */
-  mode?: 'append-missing' | 'replace-generated';
-}
-
 export interface PreparedGeneratedPrivateCatalogFloor {
   quads: Quad[];
   trustedNonManifestCatalogTriples: ReadonlySet<string>;
 }
 
-/**
- * Single preparation boundary for the deterministic private-CG catalog floor.
- *
- * Callers receive the publish quads and their exact trust allow-list together,
- * so queue, sync, and update paths cannot drift by generating one without the
- * other. This helper does not decide whether a CG is private; that security
- * decision remains with the live chain-policy resolver at each call site.
- */
-export function prepareGeneratedPrivateCatalogFloor(
+export function appendMissingGeneratedPrivateCatalogFloor(
   contextGraphId: string,
   quads: readonly Quad[],
-  options: PrepareGeneratedPrivateCatalogFloorOptions = {},
+  graph = '',
 ): PreparedGeneratedPrivateCatalogFloor {
-  const floor = generatedPrivateCatalogFloorQuads(
-    contextGraphId,
-    options.graph ?? '',
-  );
+  const floor = generatedPrivateCatalogFloorQuads(contextGraphId, graph);
   const trustedNonManifestCatalogTriples = generatedPrivateCatalogTripleKeys(
     contextGraphId,
   );
-
-  if (options.mode === 'replace-generated') {
-    const { otherQuads } = partitionCatalogQuads(
-      quads,
-      contextGraphDataUri(contextGraphId),
-    );
-    return {
-      quads: [...otherQuads, ...floor],
-      trustedNonManifestCatalogTriples,
-    };
-  }
-
   const present = new Set(quads.map(catalogTripleKey));
   return {
     quads: [
@@ -115,6 +81,26 @@ export function prepareGeneratedPrivateCatalogFloor(
       ...floor.filter((quad) => !present.has(catalogTripleKey(quad))),
     ],
     trustedNonManifestCatalogTriples,
+  };
+}
+
+export function replaceGeneratedPrivateCatalogFloor(
+  contextGraphId: string,
+  quads: readonly Quad[],
+  graph = '',
+): PreparedGeneratedPrivateCatalogFloor {
+  const { otherQuads } = partitionCatalogQuads(
+    quads,
+    contextGraphDataUri(contextGraphId),
+  );
+  return {
+    quads: [
+      ...otherQuads,
+      ...generatedPrivateCatalogFloorQuads(contextGraphId, graph),
+    ],
+    trustedNonManifestCatalogTriples: generatedPrivateCatalogTripleKeys(
+      contextGraphId,
+    ),
   };
 }
 

--- a/packages/publisher/src/catalog-trust.ts
+++ b/packages/publisher/src/catalog-trust.ts
@@ -1,5 +1,6 @@
 import {
   DKG_ONTOLOGY,
+  assertSafeIri,
   contextGraphDataUri,
   partitionCatalogQuads,
 } from '@origintrail-official/dkg-core';
@@ -27,7 +28,8 @@ export function generatedPrivateCatalogFloorQuads(
   contextGraphId: string,
   graph = '',
 ): Quad[] {
-  const cgDid = contextGraphDataUri(contextGraphId);
+  const cgDid = assertSafeIri(contextGraphDataUri(contextGraphId));
+  if (graph !== '') assertSafeIri(graph);
   return [
     {
       subject: cgDid,
@@ -76,15 +78,34 @@ export interface PrepareGeneratedPrivateCatalogFloorOptions {
   mode?: 'append-missing' | 'replace-generated';
 }
 
-export function appendMissingGeneratedPrivateCatalogFloor(
+type GeneratedPrivateCatalogFloorOperation =
+  | { kind: 'append-missing'; graph?: string }
+  | { kind: 'replace-catalog-partition'; graph?: string };
+
+function prepareGeneratedPrivateCatalogFloorOperation(
   contextGraphId: string,
   quads: readonly Quad[],
-  graph = '',
+  operation: GeneratedPrivateCatalogFloorOperation,
 ): PreparedGeneratedPrivateCatalogFloor {
-  const floor = generatedPrivateCatalogFloorQuads(contextGraphId, graph);
+  const floor = generatedPrivateCatalogFloorQuads(
+    contextGraphId,
+    operation.graph ?? '',
+  );
   const trustedNonManifestCatalogTriples = generatedPrivateCatalogTripleKeys(
     contextGraphId,
   );
+
+  if (operation.kind === 'replace-catalog-partition') {
+    const { otherQuads } = partitionCatalogQuads(
+      quads,
+      contextGraphDataUri(contextGraphId),
+    );
+    return {
+      quads: [...otherQuads, ...floor],
+      trustedNonManifestCatalogTriples,
+    };
+  }
+
   const present = new Set(quads.map(catalogTripleKey));
   return {
     quads: [
@@ -95,24 +116,46 @@ export function appendMissingGeneratedPrivateCatalogFloor(
   };
 }
 
+export function appendMissingGeneratedPrivateCatalogFloor(
+  contextGraphId: string,
+  quads: readonly Quad[],
+  graph = '',
+): PreparedGeneratedPrivateCatalogFloor {
+  return prepareGeneratedPrivateCatalogFloorOperation(
+    contextGraphId,
+    quads,
+    { kind: 'append-missing', graph },
+  );
+}
+
+/**
+ * Replace the complete recognized catalog partition for this CG DID with the
+ * deterministic private floor. This intentionally removes recommended and
+ * opt-in catalog predicates as well as stale generated floor triples.
+ */
+export function replaceCatalogPartitionWithGeneratedPrivateFloor(
+  contextGraphId: string,
+  quads: readonly Quad[],
+  graph = '',
+): PreparedGeneratedPrivateCatalogFloor {
+  return prepareGeneratedPrivateCatalogFloorOperation(
+    contextGraphId,
+    quads,
+    { kind: 'replace-catalog-partition', graph },
+  );
+}
+
+/** @deprecated Use replaceCatalogPartitionWithGeneratedPrivateFloor. */
 export function replaceGeneratedPrivateCatalogFloor(
   contextGraphId: string,
   quads: readonly Quad[],
   graph = '',
 ): PreparedGeneratedPrivateCatalogFloor {
-  const { otherQuads } = partitionCatalogQuads(
+  return replaceCatalogPartitionWithGeneratedPrivateFloor(
+    contextGraphId,
     quads,
-    contextGraphDataUri(contextGraphId),
+    graph,
   );
-  return {
-    quads: [
-      ...otherQuads,
-      ...generatedPrivateCatalogFloorQuads(contextGraphId, graph),
-    ],
-    trustedNonManifestCatalogTriples: generatedPrivateCatalogTripleKeys(
-      contextGraphId,
-    ),
-  };
 }
 
 /**
@@ -127,17 +170,12 @@ export function prepareGeneratedPrivateCatalogFloor(
   quads: readonly Quad[],
   options: PrepareGeneratedPrivateCatalogFloorOptions = {},
 ): PreparedGeneratedPrivateCatalogFloor {
-  if (options.mode === 'replace-generated') {
-    return replaceGeneratedPrivateCatalogFloor(
-      contextGraphId,
-      quads,
-      options.graph,
-    );
-  }
-  return appendMissingGeneratedPrivateCatalogFloor(
+  return prepareGeneratedPrivateCatalogFloorOperation(
     contextGraphId,
     quads,
-    options.graph,
+    options.mode === 'replace-generated'
+      ? { kind: 'replace-catalog-partition', graph: options.graph }
+      : { kind: 'append-missing', graph: options.graph },
   );
 }
 

--- a/packages/publisher/src/catalog-trust.ts
+++ b/packages/publisher/src/catalog-trust.ts
@@ -1,4 +1,8 @@
-import { DKG_ONTOLOGY, contextGraphDataUri } from '@origintrail-official/dkg-core';
+import {
+  DKG_ONTOLOGY,
+  contextGraphDataUri,
+  partitionCatalogQuads,
+} from '@origintrail-official/dkg-core';
 import type { Quad } from '@origintrail-official/dkg-storage';
 
 export type TrustedCatalogTripleKeys = ReadonlySet<string> | readonly string[] | undefined;
@@ -54,6 +58,64 @@ export function generatedPrivateCatalogFloorQuads(
 
 export function generatedPrivateCatalogTripleKeys(contextGraphId: string): ReadonlySet<string> {
   return new Set(generatedPrivateCatalogFloorQuads(contextGraphId).map(catalogTripleKey));
+}
+
+export interface PrepareGeneratedPrivateCatalogFloorOptions {
+  /** Graph term applied to newly generated floor quads. */
+  graph?: string;
+  /**
+   * append-missing preserves immutable/legacy snapshots and fills only absent
+   * deterministic triples. replace-generated rebuilds the recognized catalog
+   * partition while retaining ordinary private data on the CG-DID subject.
+   */
+  mode?: 'append-missing' | 'replace-generated';
+}
+
+export interface PreparedGeneratedPrivateCatalogFloor {
+  quads: Quad[];
+  trustedNonManifestCatalogTriples: ReadonlySet<string>;
+}
+
+/**
+ * Single preparation boundary for the deterministic private-CG catalog floor.
+ *
+ * Callers receive the publish quads and their exact trust allow-list together,
+ * so queue, sync, and update paths cannot drift by generating one without the
+ * other. This helper does not decide whether a CG is private; that security
+ * decision remains with the live chain-policy resolver at each call site.
+ */
+export function prepareGeneratedPrivateCatalogFloor(
+  contextGraphId: string,
+  quads: readonly Quad[],
+  options: PrepareGeneratedPrivateCatalogFloorOptions = {},
+): PreparedGeneratedPrivateCatalogFloor {
+  const floor = generatedPrivateCatalogFloorQuads(
+    contextGraphId,
+    options.graph ?? '',
+  );
+  const trustedNonManifestCatalogTriples = generatedPrivateCatalogTripleKeys(
+    contextGraphId,
+  );
+
+  if (options.mode === 'replace-generated') {
+    const { otherQuads } = partitionCatalogQuads(
+      quads,
+      contextGraphDataUri(contextGraphId),
+    );
+    return {
+      quads: [...otherQuads, ...floor],
+      trustedNonManifestCatalogTriples,
+    };
+  }
+
+  const present = new Set(quads.map(catalogTripleKey));
+  return {
+    quads: [
+      ...quads,
+      ...floor.filter((quad) => !present.has(catalogTripleKey(quad))),
+    ],
+    trustedNonManifestCatalogTriples,
+  };
 }
 
 export function assertTrustedCatalogTriplesAreGeneratedFloor(

--- a/packages/publisher/src/catalog-trust.ts
+++ b/packages/publisher/src/catalog-trust.ts
@@ -65,6 +65,17 @@ export interface PreparedGeneratedPrivateCatalogFloor {
   trustedNonManifestCatalogTriples: ReadonlySet<string>;
 }
 
+export interface PrepareGeneratedPrivateCatalogFloorOptions {
+  /** Graph term applied to newly generated floor quads. */
+  graph?: string;
+  /**
+   * append-missing preserves immutable/legacy snapshots and fills only absent
+   * deterministic triples. replace-generated rebuilds the recognized catalog
+   * partition while retaining ordinary private data on the CG-DID subject.
+   */
+  mode?: 'append-missing' | 'replace-generated';
+}
+
 export function appendMissingGeneratedPrivateCatalogFloor(
   contextGraphId: string,
   quads: readonly Quad[],
@@ -102,6 +113,32 @@ export function replaceGeneratedPrivateCatalogFloor(
       contextGraphId,
     ),
   };
+}
+
+/**
+ * Backward-compatible public preparation boundary for the deterministic
+ * private-CG catalog floor.
+ *
+ * Keep publish quads and their exact trust allow-list coupled while allowing
+ * callers to select the immutable append path or the update replacement path.
+ */
+export function prepareGeneratedPrivateCatalogFloor(
+  contextGraphId: string,
+  quads: readonly Quad[],
+  options: PrepareGeneratedPrivateCatalogFloorOptions = {},
+): PreparedGeneratedPrivateCatalogFloor {
+  if (options.mode === 'replace-generated') {
+    return replaceGeneratedPrivateCatalogFloor(
+      contextGraphId,
+      quads,
+      options.graph,
+    );
+  }
+  return appendMissingGeneratedPrivateCatalogFloor(
+    contextGraphId,
+    quads,
+    options.graph,
+  );
 }
 
 export function assertTrustedCatalogTriplesAreGeneratedFloor(

--- a/packages/publisher/src/index.ts
+++ b/packages/publisher/src/index.ts
@@ -22,11 +22,13 @@ export {
   generatedPrivateCatalogFloorQuads,
   generatedPrivateCatalogTripleKeys,
   appendMissingGeneratedPrivateCatalogFloor,
+  prepareGeneratedPrivateCatalogFloor,
   replaceGeneratedPrivateCatalogFloor,
   splitTrustedGeneratedCatalogRootMap,
   trustedCatalogTripleKeySet,
   type TrustedCatalogTripleKeys,
   type TrustedCatalogRootSplit,
+  type PrepareGeneratedPrivateCatalogFloorOptions,
   type PreparedGeneratedPrivateCatalogFloor,
 } from './catalog-trust.js';
 export { resolveLiftWorkspaceSlice } from './workspace-resolution.js';

--- a/packages/publisher/src/index.ts
+++ b/packages/publisher/src/index.ts
@@ -21,12 +21,12 @@ export {
   catalogTripleKey,
   generatedPrivateCatalogFloorQuads,
   generatedPrivateCatalogTripleKeys,
-  prepareGeneratedPrivateCatalogFloor,
+  appendMissingGeneratedPrivateCatalogFloor,
+  replaceGeneratedPrivateCatalogFloor,
   splitTrustedGeneratedCatalogRootMap,
   trustedCatalogTripleKeySet,
   type TrustedCatalogTripleKeys,
   type TrustedCatalogRootSplit,
-  type PrepareGeneratedPrivateCatalogFloorOptions,
   type PreparedGeneratedPrivateCatalogFloor,
 } from './catalog-trust.js';
 export { resolveLiftWorkspaceSlice } from './workspace-resolution.js';

--- a/packages/publisher/src/index.ts
+++ b/packages/publisher/src/index.ts
@@ -23,6 +23,7 @@ export {
   generatedPrivateCatalogTripleKeys,
   appendMissingGeneratedPrivateCatalogFloor,
   prepareGeneratedPrivateCatalogFloor,
+  replaceCatalogPartitionWithGeneratedPrivateFloor,
   replaceGeneratedPrivateCatalogFloor,
   splitTrustedGeneratedCatalogRootMap,
   trustedCatalogTripleKeySet,

--- a/packages/publisher/src/index.ts
+++ b/packages/publisher/src/index.ts
@@ -21,10 +21,13 @@ export {
   catalogTripleKey,
   generatedPrivateCatalogFloorQuads,
   generatedPrivateCatalogTripleKeys,
+  prepareGeneratedPrivateCatalogFloor,
   splitTrustedGeneratedCatalogRootMap,
   trustedCatalogTripleKeySet,
   type TrustedCatalogTripleKeys,
   type TrustedCatalogRootSplit,
+  type PrepareGeneratedPrivateCatalogFloorOptions,
+  type PreparedGeneratedPrivateCatalogFloor,
 } from './catalog-trust.js';
 export { resolveLiftWorkspaceSlice } from './workspace-resolution.js';
 export {

--- a/packages/publisher/test/pure-functions.test.ts
+++ b/packages/publisher/test/pure-functions.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { Quad } from '@origintrail-official/dkg-storage';
+import { DKG_ONTOLOGY } from '@origintrail-official/dkg-core';
 import {
   skolemize,
   isBlankNode,
@@ -15,6 +16,7 @@ import {
   generatedPrivateCatalogTripleKeys,
   appendMissingGeneratedPrivateCatalogFloor,
   prepareGeneratedPrivateCatalogFloor,
+  replaceCatalogPartitionWithGeneratedPrivateFloor,
   replaceGeneratedPrivateCatalogFloor,
   catalogTripleKey,
   validatePublishRequest,
@@ -144,6 +146,17 @@ describe('merkle', () => {
 });
 
 describe('generated private catalog preparation', () => {
+  it('rejects unsafe generated subjects and non-empty graph IRIs', () => {
+    expect(() => generatedPrivateCatalogFloorQuads(
+      'bad> <urn:p> <urn:o> . <urn:x',
+    )).toThrow(/Unsafe or empty IRI/);
+    expect(() => appendMissingGeneratedPrivateCatalogFloor(
+      'safe-cg',
+      [],
+      'urn:unsafe> <urn:p>',
+    )).toThrow(/Unsafe or empty IRI/);
+  });
+
   it('preserves the public preparation API for default append and explicit replacement', () => {
     const contextGraphId = 'private-catalog-api-cg';
     const cgDid = `did:dkg:context-graph:${contextGraphId}`;
@@ -194,15 +207,26 @@ describe('generated private catalog preparation', () => {
       .toEqual(generatedPrivateCatalogTripleKeys(contextGraphId));
   });
 
-  it('replaces only recognized catalog triples and preserves private CG-DID data', () => {
+  it('replaces the complete catalog partition and preserves private CG-DID data', () => {
     const contextGraphId = 'private-catalog-cg';
     const cgDid = `did:dkg:context-graph:${contextGraphId}`;
     const privateCgDidQuad = q(cgDid, 'urn:test:private-note', '"keep encrypted"');
+    const recommendedCatalogQuad = q(
+      cgDid,
+      DKG_ONTOLOGY.DCT_PUBLISHER,
+      'urn:test:publisher',
+      'urn:stale',
+    );
     const staleFloor = generatedPrivateCatalogFloorQuads(contextGraphId, 'urn:stale');
 
-    const prepared = replaceGeneratedPrivateCatalogFloor(
+    const prepared = replaceCatalogPartitionWithGeneratedPrivateFloor(
       contextGraphId,
-      [privateCgDidQuad, ...staleFloor],
+      [privateCgDidQuad, recommendedCatalogQuad, ...staleFloor],
+      cgDid,
+    );
+    const deprecatedAlias = replaceGeneratedPrivateCatalogFloor(
+      contextGraphId,
+      [privateCgDidQuad, recommendedCatalogQuad, ...staleFloor],
       cgDid,
     );
 
@@ -210,7 +234,9 @@ describe('generated private catalog preparation', () => {
     expect(prepared.quads.slice(1)).toEqual(
       generatedPrivateCatalogFloorQuads(contextGraphId, cgDid),
     );
+    expect(prepared.quads).not.toContainEqual(recommendedCatalogQuad);
     expect(prepared.quads.filter((quad) => quad.graph === 'urn:stale')).toHaveLength(0);
+    expect(deprecatedAlias).toEqual(prepared);
   });
 });
 

--- a/packages/publisher/test/pure-functions.test.ts
+++ b/packages/publisher/test/pure-functions.test.ts
@@ -14,12 +14,14 @@ import {
   generatedPrivateCatalogFloorQuads,
   generatedPrivateCatalogTripleKeys,
   appendMissingGeneratedPrivateCatalogFloor,
+  prepareGeneratedPrivateCatalogFloor,
   replaceGeneratedPrivateCatalogFloor,
   catalogTripleKey,
   validatePublishRequest,
   assertTrustedCatalogTriplesAreGeneratedFloor,
 } from '../src/index.js';
 import type { ValidationOptions } from '../src/validation.js';
+import type { PrepareGeneratedPrivateCatalogFloorOptions } from '../src/index.js';
 
 const CONTEXT_GRAPH = 'agent-registry';
 const GRAPH = `did:dkg:context-graph:${CONTEXT_GRAPH}`;
@@ -142,6 +144,36 @@ describe('merkle', () => {
 });
 
 describe('generated private catalog preparation', () => {
+  it('preserves the public preparation API for default append and explicit replacement', () => {
+    const contextGraphId = 'private-catalog-api-cg';
+    const cgDid = `did:dkg:context-graph:${contextGraphId}`;
+    const content = q(cgDid, 'urn:test:private-note', '"keep encrypted"');
+    const staleFloor = generatedPrivateCatalogFloorQuads(contextGraphId, 'urn:stale');
+    const defaultOptions: PrepareGeneratedPrivateCatalogFloorOptions = {};
+    const replaceOptions: PrepareGeneratedPrivateCatalogFloorOptions = {
+      graph: cgDid,
+      mode: 'replace-generated',
+    };
+
+    const appended = prepareGeneratedPrivateCatalogFloor(
+      contextGraphId,
+      [content, staleFloor[0]],
+      defaultOptions,
+    );
+    const replaced = prepareGeneratedPrivateCatalogFloor(
+      contextGraphId,
+      [content, ...staleFloor],
+      replaceOptions,
+    );
+
+    expect(appended.quads[0]).toBe(content);
+    expect(appended.quads[1]).toBe(staleFloor[0]);
+    expect(replaced.quads).toEqual([
+      content,
+      ...generatedPrivateCatalogFloorQuads(contextGraphId, cgDid),
+    ]);
+  });
+
   it('fills a partial legacy floor without duplicating existing triples', () => {
     const contextGraphId = 'private-catalog-cg';
     const floor = generatedPrivateCatalogFloorQuads(contextGraphId);

--- a/packages/publisher/test/pure-functions.test.ts
+++ b/packages/publisher/test/pure-functions.test.ts
@@ -13,7 +13,8 @@ import {
   computeKCRootV10 as computeKCRoot,
   generatedPrivateCatalogFloorQuads,
   generatedPrivateCatalogTripleKeys,
-  prepareGeneratedPrivateCatalogFloor,
+  appendMissingGeneratedPrivateCatalogFloor,
+  replaceGeneratedPrivateCatalogFloor,
   catalogTripleKey,
   validatePublishRequest,
   assertTrustedCatalogTriplesAreGeneratedFloor,
@@ -147,7 +148,7 @@ describe('generated private catalog preparation', () => {
     const legacyFloorQuad = { ...floor[0], graph: 'urn:legacy:catalog' };
     const content = q('urn:test:shipment:1', 'http://schema.org/name', '"Shipment 1"');
 
-    const prepared = prepareGeneratedPrivateCatalogFloor(
+    const prepared = appendMissingGeneratedPrivateCatalogFloor(
       contextGraphId,
       [content, legacyFloorQuad],
     );
@@ -167,10 +168,10 @@ describe('generated private catalog preparation', () => {
     const privateCgDidQuad = q(cgDid, 'urn:test:private-note', '"keep encrypted"');
     const staleFloor = generatedPrivateCatalogFloorQuads(contextGraphId, 'urn:stale');
 
-    const prepared = prepareGeneratedPrivateCatalogFloor(
+    const prepared = replaceGeneratedPrivateCatalogFloor(
       contextGraphId,
       [privateCgDidQuad, ...staleFloor],
-      { graph: cgDid, mode: 'replace-generated' },
+      cgDid,
     );
 
     expect(prepared.quads[0]).toBe(privateCgDidQuad);

--- a/packages/publisher/test/pure-functions.test.ts
+++ b/packages/publisher/test/pure-functions.test.ts
@@ -13,6 +13,7 @@ import {
   computeKCRootV10 as computeKCRoot,
   generatedPrivateCatalogFloorQuads,
   generatedPrivateCatalogTripleKeys,
+  prepareGeneratedPrivateCatalogFloor,
   catalogTripleKey,
   validatePublishRequest,
   assertTrustedCatalogTriplesAreGeneratedFloor,
@@ -136,6 +137,47 @@ describe('merkle', () => {
     const r2 = computePublicRoot([q('did:dkg:agent:QmBot2', 'http://ex.org/p', '"b"')])!;
     const kcRoot = computeKCRoot([r1, r2]);
     expect(kcRoot).toHaveLength(32);
+  });
+});
+
+describe('generated private catalog preparation', () => {
+  it('fills a partial legacy floor without duplicating existing triples', () => {
+    const contextGraphId = 'private-catalog-cg';
+    const floor = generatedPrivateCatalogFloorQuads(contextGraphId);
+    const legacyFloorQuad = { ...floor[0], graph: 'urn:legacy:catalog' };
+    const content = q('urn:test:shipment:1', 'http://schema.org/name', '"Shipment 1"');
+
+    const prepared = prepareGeneratedPrivateCatalogFloor(
+      contextGraphId,
+      [content, legacyFloorQuad],
+    );
+
+    expect(prepared.quads[0]).toBe(content);
+    expect(prepared.quads[1]).toBe(legacyFloorQuad);
+    for (const key of generatedPrivateCatalogTripleKeys(contextGraphId)) {
+      expect(prepared.quads.filter((quad) => catalogTripleKey(quad) === key)).toHaveLength(1);
+    }
+    expect(prepared.trustedNonManifestCatalogTriples)
+      .toEqual(generatedPrivateCatalogTripleKeys(contextGraphId));
+  });
+
+  it('replaces only recognized catalog triples and preserves private CG-DID data', () => {
+    const contextGraphId = 'private-catalog-cg';
+    const cgDid = `did:dkg:context-graph:${contextGraphId}`;
+    const privateCgDidQuad = q(cgDid, 'urn:test:private-note', '"keep encrypted"');
+    const staleFloor = generatedPrivateCatalogFloorQuads(contextGraphId, 'urn:stale');
+
+    const prepared = prepareGeneratedPrivateCatalogFloor(
+      contextGraphId,
+      [privateCgDidQuad, ...staleFloor],
+      { graph: cgDid, mode: 'replace-generated' },
+    );
+
+    expect(prepared.quads[0]).toBe(privateCgDidQuad);
+    expect(prepared.quads.slice(1)).toEqual(
+      generatedPrivateCatalogFloorQuads(contextGraphId, cgDid),
+    );
+    expect(prepared.quads.filter((quad) => quad.graph === 'urn:stale')).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
## Summary

- reconstruct the deterministic private-CG catalog floor when executing a queued named-KA publish snapshot
- trust only the exact generated floor, and only after live chain-policy resolution returns the curated encryption callback
- preserve immutable user-root snapshot semantics while giving the publisher the same catalog commitment and inline ACK payload as the synchronous path
- de-duplicate legacy snapshots that already carry any generated floor triples

The root cause was that assertion finalization seals the catalog floor, while promotion intentionally excludes that synthetic root from per-user-root immutable snapshots. The synchronous path reconstructs it before publish; the queued path did not, so cores fell back to private SWM lookup and returned NO_DATA_IN_SWM.

Tracked for 10.0.7 in #1678.

Fixes #1670

## Verification

- regression demonstrated red on unpatched main, then green: encrypt-inline-policy.test.ts — 24/24 passed
- real-chain remote-core gate: private named KA via publish-async confirmed with source=inline, catalogCommitment=present, and ackMode=curated_catalog
- the ACK core is not a private-CG member; its persisted catalog rebuild matches the non-zero on-chain catalog root and leaf count
- pnpm --filter @origintrail-official/dkg-agent build — passed
- dependency build chain — 17/17 packages passed