### PR TITLE
fix(agent): bound sync responder page logs

### DIFF
--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -421,10 +421,14 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
     const nquads: string[] = [];
     // A durable/SWM snapshot can span thousands of page requests. Emitting the
     // same successful timing record for every page turned routine catch-up into
-    // millions of SQLite dashboard rows on mainnet. Keep one representative
-    // diagnostic per phase/session; slow total responses are still logged below
-    // regardless of offset.
-    const logPageDetail = offset === 0;
+    // millions of SQLite dashboard rows on mainnet. Keep the policy at one lazy
+    // logging boundary so every phase gets one representative diagnostic per
+    // session without constructing strings for skipped pages. Slow total
+    // responses are still logged below regardless of offset.
+    const logFirstPageDetail = (message: () => string): void => {
+      if (offset !== 0) return;
+      logDebug(createOperationContext('sync'), message());
+    };
 
     return limiter.run(peerId, signal, async () => {
       throwIfAborted(signal);
@@ -436,9 +440,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
       if (phase === 'catalog') {
         const rows = await raceAgainstAbort(readCatalogPage({ store, contextGraphId, offset, limit }), signal);
         const serialized = serializeResponderRows(rows);
-        if (logPageDetail) {
-          logDebug(createOperationContext('sync'), `Sync responder catalog facet for "${contextGraphId}": rows=${rows.length}`);
-        }
+        logFirstPageDetail(() => `Sync responder catalog facet for "${contextGraphId}": rows=${rows.length}`);
         return new TextEncoder().encode(serialized ?? '');
       }
 
@@ -474,9 +476,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
             return new TextEncoder().encode('');
           }
           nquads.push(serializeWorkspacePublicSnapshotQuads(page).trimEnd());
-          if (logPageDetail) {
-            logDebug(createOperationContext('sync'), `Sync responder SWM snapshot for "${contextGraphId}" ref=${snapshotRef}: auth=${authDurationMs}ms quads=${page.length}`);
-          }
+          logFirstPageDetail(() => `Sync responder SWM snapshot for "${contextGraphId}" ref=${snapshotRef}: auth=${authDurationMs}ms quads=${page.length}`);
         } else if (phase === 'meta') {
           const queryStartedAt = Date.now();
           const session = prepareResponderSession(
@@ -506,9 +506,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
           const serialized = serializeResponderRows(rows);
           if (serialized) nquads.push(serialized);
           const serializeDurationMs = Date.now() - serializeStartedAt;
-          if (logPageDetail) {
-            logDebug(createOperationContext('sync'), `Sync responder SWM meta for "${contextGraphId}": auth=${authDurationMs}ms query=${queryDurationMs}ms serialize=${serializeDurationMs}ms`);
-          }
+          logFirstPageDetail(() => `Sync responder SWM meta for "${contextGraphId}": auth=${authDurationMs}ms query=${queryDurationMs}ms serialize=${serializeDurationMs}ms`);
         } else {
           const queryStartedAt = Date.now();
           const session = prepareResponderSession(
@@ -538,9 +536,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
           const serialized = serializeResponderRows(rows);
           if (serialized) nquads.push(serialized);
           const serializeDurationMs = Date.now() - serializeStartedAt;
-          if (logPageDetail) {
-            logDebug(createOperationContext('sync'), `Sync responder SWM data for "${contextGraphId}": auth=${authDurationMs}ms query=${queryDurationMs}ms serialize=${serializeDurationMs}ms`);
-          }
+          logFirstPageDetail(() => `Sync responder SWM data for "${contextGraphId}": auth=${authDurationMs}ms query=${queryDurationMs}ms serialize=${serializeDurationMs}ms`);
         }
 
         if (nquads.length === 0) return new TextEncoder().encode('');
@@ -589,9 +585,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
           const serialized = serializeResponderRows(rows);
           if (serialized) nquads.push(serialized);
           const serializeDurationMs = Date.now() - serializeStartedAt;
-          if (logPageDetail) {
-            logDebug(createOperationContext('sync'), `Sync responder durable meta for "${contextGraphId}": auth=${authDurationMs}ms query=${queryDurationMs}ms serialize=${serializeDurationMs}ms`);
-          }
+          logFirstPageDetail(() => `Sync responder durable meta for "${contextGraphId}": auth=${authDurationMs}ms query=${queryDurationMs}ms serialize=${serializeDurationMs}ms`);
         }
       } else {
         const queryStartedAt = Date.now();
@@ -618,9 +612,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
         const serialized = serializeResponderRows(rows);
         if (serialized) nquads.push(serialized);
         const serializeDurationMs = Date.now() - serializeStartedAt;
-        if (logPageDetail) {
-          logDebug(createOperationContext('sync'), `Sync responder durable data for "${contextGraphId}": auth=${authDurationMs}ms query=${queryDurationMs}ms serialize=${serializeDurationMs}ms`);
-        }
+        logFirstPageDetail(() => `Sync responder durable data for "${contextGraphId}": auth=${authDurationMs}ms query=${queryDurationMs}ms serialize=${serializeDurationMs}ms`);
       }
 
       const totalDurationMs = Date.now() - handlerStartedAt;

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -419,6 +419,12 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
       }
     }
     const nquads: string[] = [];
+    // A durable/SWM snapshot can span thousands of page requests. Emitting the
+    // same successful timing record for every page turned routine catch-up into
+    // millions of SQLite dashboard rows on mainnet. Keep one representative
+    // diagnostic per phase/session; slow total responses are still logged below
+    // regardless of offset.
+    const logPageDetail = offset === 0;
 
     return limiter.run(peerId, signal, async () => {
       throwIfAborted(signal);
@@ -430,7 +436,9 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
       if (phase === 'catalog') {
         const rows = await raceAgainstAbort(readCatalogPage({ store, contextGraphId, offset, limit }), signal);
         const serialized = serializeResponderRows(rows);
-        logDebug(createOperationContext('sync'), `Sync responder catalog facet for "${contextGraphId}": rows=${rows.length}`);
+        if (logPageDetail) {
+          logDebug(createOperationContext('sync'), `Sync responder catalog facet for "${contextGraphId}": rows=${rows.length}`);
+        }
         return new TextEncoder().encode(serialized ?? '');
       }
 
@@ -466,7 +474,9 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
             return new TextEncoder().encode('');
           }
           nquads.push(serializeWorkspacePublicSnapshotQuads(page).trimEnd());
-          logDebug(createOperationContext('sync'), `Sync responder SWM snapshot for "${contextGraphId}" ref=${snapshotRef}: auth=${authDurationMs}ms quads=${page.length}`);
+          if (logPageDetail) {
+            logDebug(createOperationContext('sync'), `Sync responder SWM snapshot for "${contextGraphId}" ref=${snapshotRef}: auth=${authDurationMs}ms quads=${page.length}`);
+          }
         } else if (phase === 'meta') {
           const queryStartedAt = Date.now();
           const session = prepareResponderSession(
@@ -496,7 +506,9 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
           const serialized = serializeResponderRows(rows);
           if (serialized) nquads.push(serialized);
           const serializeDurationMs = Date.now() - serializeStartedAt;
-          logDebug(createOperationContext('sync'), `Sync responder SWM meta for "${contextGraphId}": auth=${authDurationMs}ms query=${queryDurationMs}ms serialize=${serializeDurationMs}ms`);
+          if (logPageDetail) {
+            logDebug(createOperationContext('sync'), `Sync responder SWM meta for "${contextGraphId}": auth=${authDurationMs}ms query=${queryDurationMs}ms serialize=${serializeDurationMs}ms`);
+          }
         } else {
           const queryStartedAt = Date.now();
           const session = prepareResponderSession(
@@ -526,7 +538,9 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
           const serialized = serializeResponderRows(rows);
           if (serialized) nquads.push(serialized);
           const serializeDurationMs = Date.now() - serializeStartedAt;
-          logDebug(createOperationContext('sync'), `Sync responder SWM data for "${contextGraphId}": auth=${authDurationMs}ms query=${queryDurationMs}ms serialize=${serializeDurationMs}ms`);
+          if (logPageDetail) {
+            logDebug(createOperationContext('sync'), `Sync responder SWM data for "${contextGraphId}": auth=${authDurationMs}ms query=${queryDurationMs}ms serialize=${serializeDurationMs}ms`);
+          }
         }
 
         if (nquads.length === 0) return new TextEncoder().encode('');
@@ -575,7 +589,9 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
           const serialized = serializeResponderRows(rows);
           if (serialized) nquads.push(serialized);
           const serializeDurationMs = Date.now() - serializeStartedAt;
-          logDebug(createOperationContext('sync'), `Sync responder durable meta for "${contextGraphId}": auth=${authDurationMs}ms query=${queryDurationMs}ms serialize=${serializeDurationMs}ms`);
+          if (logPageDetail) {
+            logDebug(createOperationContext('sync'), `Sync responder durable meta for "${contextGraphId}": auth=${authDurationMs}ms query=${queryDurationMs}ms serialize=${serializeDurationMs}ms`);
+          }
         }
       } else {
         const queryStartedAt = Date.now();
@@ -602,7 +618,9 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
         const serialized = serializeResponderRows(rows);
         if (serialized) nquads.push(serialized);
         const serializeDurationMs = Date.now() - serializeStartedAt;
-        logDebug(createOperationContext('sync'), `Sync responder durable data for "${contextGraphId}": auth=${authDurationMs}ms query=${queryDurationMs}ms serialize=${serializeDurationMs}ms`);
+        if (logPageDetail) {
+          logDebug(createOperationContext('sync'), `Sync responder durable data for "${contextGraphId}": auth=${authDurationMs}ms query=${queryDurationMs}ms serialize=${serializeDurationMs}ms`);
+        }
       }
 
       const totalDurationMs = Date.now() - handlerStartedAt;

--- a/packages/agent/test/_helpers/sync-responder.ts
+++ b/packages/agent/test/_helpers/sync-responder.ts
@@ -43,6 +43,7 @@ export function registerTestSyncHandler(
     syncPageSize?: number;
     snapshotBudget?: SyncResponderSnapshotBudgetOptions;
     authorize?: (request: SyncRequestEnvelope, remotePeerId: string) => Promise<boolean>;
+    logDebug?: (ctx: OperationContext, message: string) => void;
   } = {},
 ): CapturedSyncHandler {
   const cap = captureSyncHandler();
@@ -57,7 +58,7 @@ export function registerTestSyncHandler(
     parseSyncRequest: (data) => JSON.parse(new TextDecoder().decode(data)) as SyncRequestEnvelope,
     authorizeSyncRequest: options.authorize ?? (async () => true),
     logWarn: noopLog,
-    logDebug: noopLog,
+    logDebug: options.logDebug ?? noopLog,
     snapshotBudget: options.snapshotBudget,
   });
   return cap;

--- a/packages/agent/test/_helpers/sync-responder.ts
+++ b/packages/agent/test/_helpers/sync-responder.ts
@@ -1,5 +1,6 @@
 import type { OperationContext } from '@origintrail-official/dkg-core';
 import type { TripleStore } from '@origintrail-official/dkg-storage';
+import type { WorkspacePublicSnapshotStore } from '@origintrail-official/dkg-publisher';
 import { registerSyncHandler } from '../../src/sync/responder/sync-handler.js';
 import type { SyncResponderSnapshotBudgetOptions } from '../../src/sync/responder/snapshot-budget.js';
 import type { SyncRequestEnvelope } from '../../src/sync/auth/request-build.js';
@@ -44,6 +45,7 @@ export function registerTestSyncHandler(
     snapshotBudget?: SyncResponderSnapshotBudgetOptions;
     authorize?: (request: SyncRequestEnvelope, remotePeerId: string) => Promise<boolean>;
     logDebug?: (ctx: OperationContext, message: string) => void;
+    publicSnapshotStore?: WorkspacePublicSnapshotStore;
   } = {},
 ): CapturedSyncHandler {
   const cap = captureSyncHandler();
@@ -54,6 +56,7 @@ export function registerTestSyncHandler(
     syncPageSize: options.syncPageSize ?? 5000,
     sharedMemoryTtlMs: options.sharedMemoryTtlMs ?? 0,
     store,
+    publicSnapshotStore: options.publicSnapshotStore,
     peerId: 'self-peer',
     parseSyncRequest: (data) => JSON.parse(new TextDecoder().decode(data)) as SyncRequestEnvelope,
     authorizeSyncRequest: options.authorize ?? (async () => true),

--- a/packages/agent/test/sync-responder-log-volume.test.ts
+++ b/packages/agent/test/sync-responder-log-volume.test.ts
@@ -16,7 +16,10 @@ describe('sync responder page diagnostics', () => {
     const durableMeta = `${prefix}/_meta`;
     const swmData = `${prefix}/_shared_memory`;
     const swmMeta = `${prefix}/_shared_memory_meta`;
+    const catalog = `${prefix}/_catalog`;
     await store.insert([
+      { graph: catalog, subject: prefix, predicate: 'urn:catalog:value', object: '"one"' },
+      { graph: catalog, subject: prefix, predicate: 'urn:catalog:label', object: '"two"' },
       { graph: durableData, subject: 'urn:durable:1', predicate: 'urn:test:value', object: '"one"' },
       { graph: durableData, subject: 'urn:durable:2', predicate: 'urn:test:value', object: '"two"' },
       { graph: durableMeta, subject: prefix, predicate: `${DKG_NS}createdAt`, object: '"2026-07-01T00:00:00Z"' },
@@ -48,6 +51,11 @@ describe('sync responder page diagnostics', () => {
     });
 
     const cases = [
+      {
+        name: 'catalog',
+        prefix: `Sync responder catalog facet for "${contextGraphId}"`,
+        request: { includeSharedMemory: false, phase: 'catalog' as const },
+      },
       {
         name: 'durable data',
         prefix: `Sync responder durable data for "${contextGraphId}"`,

--- a/packages/agent/test/sync-responder-log-volume.test.ts
+++ b/packages/agent/test/sync-responder-log-volume.test.ts
@@ -1,37 +1,100 @@
 import { describe, expect, it } from 'vitest';
 import { OxigraphStore } from '@origintrail-official/dkg-storage';
-import { registerTestSyncHandler } from './_helpers/sync-responder.js';
+import type { WorkspacePublicSnapshotStore } from '@origintrail-official/dkg-publisher';
+import {
+  DKG_NS,
+  registerTestSyncHandler,
+  workspaceOpQuads,
+} from './_helpers/sync-responder.js';
 
 describe('sync responder page diagnostics', () => {
-  it('logs successful page timing once per phase/session instead of once per page', async () => {
+  it('logs every successful responder phase once per session instead of once per page', async () => {
     const store = new OxigraphStore();
     const contextGraphId = 'log-volume';
-    const graph = `did:dkg:context-graph:${contextGraphId}/context/1`;
+    const prefix = `did:dkg:context-graph:${contextGraphId}`;
+    const durableData = `${prefix}/context/1`;
+    const durableMeta = `${prefix}/_meta`;
+    const swmData = `${prefix}/_shared_memory`;
+    const swmMeta = `${prefix}/_shared_memory_meta`;
     await store.insert([
-      { graph, subject: 'urn:log-volume:1', predicate: 'urn:test:value', object: '"one"' },
-      { graph, subject: 'urn:log-volume:2', predicate: 'urn:test:value', object: '"two"' },
+      { graph: durableData, subject: 'urn:durable:1', predicate: 'urn:test:value', object: '"one"' },
+      { graph: durableData, subject: 'urn:durable:2', predicate: 'urn:test:value', object: '"two"' },
+      { graph: durableMeta, subject: prefix, predicate: `${DKG_NS}createdAt`, object: '"2026-07-01T00:00:00Z"' },
+      { graph: durableMeta, subject: prefix, predicate: `${DKG_NS}updatedAt`, object: '"2026-07-02T00:00:00Z"' },
+      { graph: swmData, subject: 'urn:swm:1', predicate: 'urn:test:value', object: '"one"' },
+      { graph: swmData, subject: 'urn:swm:2', predicate: 'urn:test:value', object: '"two"' },
+      ...workspaceOpQuads(
+        contextGraphId,
+        'share-1',
+        'urn:swm:1',
+        swmMeta,
+        '2026-07-01T00:00:00.000Z',
+      ),
     ]);
 
+    const snapshotQuads = [
+      { graph: '', subject: 'urn:snapshot:1', predicate: 'urn:test:value', object: '"one"' },
+      { graph: '', subject: 'urn:snapshot:2', predicate: 'urn:test:value', object: '"two"' },
+    ];
+    const publicSnapshotStore: WorkspacePublicSnapshotStore = {
+      putSnapshot: async () => ({ ref: 'snapshot-ref', byteLength: 0 }),
+      getSnapshot: async () => snapshotQuads,
+    };
     const debugMessages: string[] = [];
     const handler = registerTestSyncHandler(store, {
       syncPageSize: 1,
       logDebug: (_ctx, message) => debugMessages.push(message),
+      publicSnapshotStore,
     });
-    const request = {
-      contextGraphId,
-      includeSharedMemory: false,
-      phase: 'data' as const,
-      limit: 1,
-      syncSessionId: 'log-volume-session',
-    };
 
-    await handler.invoke({ ...request, offset: 0 });
-    await handler.invoke({ ...request, offset: 1 });
+    const cases = [
+      {
+        name: 'durable data',
+        prefix: `Sync responder durable data for "${contextGraphId}"`,
+        request: { includeSharedMemory: false, phase: 'data' as const },
+      },
+      {
+        name: 'durable meta',
+        prefix: `Sync responder durable meta for "${contextGraphId}"`,
+        request: { includeSharedMemory: false, phase: 'meta' as const },
+      },
+      {
+        name: 'SWM snapshot',
+        prefix: `Sync responder SWM snapshot for "${contextGraphId}"`,
+        request: {
+          includeSharedMemory: true,
+          phase: 'snapshot' as const,
+          snapshotRef: 'snapshot-ref',
+        },
+      },
+      {
+        name: 'SWM meta',
+        prefix: `Sync responder SWM meta for "${contextGraphId}"`,
+        request: { includeSharedMemory: true, phase: 'meta' as const },
+      },
+      {
+        name: 'SWM data',
+        prefix: `Sync responder SWM data for "${contextGraphId}"`,
+        request: { includeSharedMemory: true, phase: 'data' as const },
+      },
+    ];
 
-    expect(
-      debugMessages.filter((message) =>
-        message.startsWith(`Sync responder durable data for "${contextGraphId}"`),
-      ),
-    ).toHaveLength(1);
+    for (const testCase of cases) {
+      const request = {
+        contextGraphId,
+        limit: 1,
+        syncSessionId: `log-volume-${testCase.name}`,
+        ...testCase.request,
+      };
+      const first = await handler.invoke({ ...request, offset: 0 });
+      const second = await handler.invoke({ ...request, offset: 1 });
+
+      expect(first, `${testCase.name} first page`).not.toBe('');
+      expect(second, `${testCase.name} second page`).not.toBe('');
+      expect(
+        debugMessages.filter((message) => message.startsWith(testCase.prefix)),
+        `${testCase.name} diagnostic count`,
+      ).toHaveLength(1);
+    }
   });
 });

--- a/packages/agent/test/sync-responder-log-volume.test.ts
+++ b/packages/agent/test/sync-responder-log-volume.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import { registerTestSyncHandler } from './_helpers/sync-responder.js';
+
+describe('sync responder page diagnostics', () => {
+  it('logs successful page timing once per phase/session instead of once per page', async () => {
+    const store = new OxigraphStore();
+    const contextGraphId = 'log-volume';
+    const graph = `did:dkg:context-graph:${contextGraphId}/context/1`;
+    await store.insert([
+      { graph, subject: 'urn:log-volume:1', predicate: 'urn:test:value', object: '"one"' },
+      { graph, subject: 'urn:log-volume:2', predicate: 'urn:test:value', object: '"two"' },
+    ]);
+
+    const debugMessages: string[] = [];
+    const handler = registerTestSyncHandler(store, {
+      syncPageSize: 1,
+      logDebug: (_ctx, message) => debugMessages.push(message),
+    });
+    const request = {
+      contextGraphId,
+      includeSharedMemory: false,
+      phase: 'data' as const,
+      limit: 1,
+      syncSessionId: 'log-volume-session',
+    };
+
+    await handler.invoke({ ...request, offset: 0 });
+    await handler.invoke({ ...request, offset: 1 });
+
+    expect(
+      debugMessages.filter((message) =>
+        message.startsWith(`Sync responder durable data for "${contextGraphId}"`),
+      ),
+    ).toHaveLength(1);
+  });
+});

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -34,6 +34,7 @@ export default defineConfig({
       "test/oversize-filter.test.ts",
       "test/cg-registration-oversize-guard.test.ts",
       "test/sync-responder-concurrent-interleaving.test.ts",
+      "test/sync-responder-log-volume.test.ts",
       "test/sync-responder-snapshot-cache.test.ts",
       "test/sync-responder-oversized-fallback.test.ts",
       "test/sync-responder-large-graph-stack-overflow.test.ts",

--- a/packages/cli/src/daemon/dashboard-log-volume-pruner.ts
+++ b/packages/cli/src/daemon/dashboard-log-volume-pruner.ts
@@ -1,0 +1,95 @@
+import type {
+  DashboardDB,
+  LogVolumePruneResult,
+} from '@origintrail-official/dkg-node-ui';
+
+export interface DashboardLogVolumePrunerIntervals {
+  initialDelayMs: number;
+  catchupIntervalMs: number;
+  reclaimRetryMs: number;
+  steadyIntervalMs: number;
+}
+
+export const DEFAULT_DASHBOARD_LOG_VOLUME_PRUNER_INTERVALS: DashboardLogVolumePrunerIntervals = {
+  initialDelayMs: 60_000,
+  catchupIntervalMs: 15_000,
+  reclaimRetryMs: 10 * 60_000,
+  steadyIntervalMs: 6 * 60 * 60_000,
+};
+
+export interface DashboardLogVolumePrunerHandle {
+  stop(): void;
+}
+
+/**
+ * Own the incremental dashboard-log cleanup lifecycle outside the daemon
+ * bootstrap. The database decides what one bounded maintenance step did; this
+ * helper decides when the next step runs, aggregates deletion telemetry, and
+ * guarantees shutdown clears the recursive timeout.
+ */
+export function startDashboardLogVolumePruner(opts: {
+  dashDb: Pick<DashboardDB, 'pruneLogVolumeBatch'>;
+  log: (message: string) => void;
+  intervals?: Partial<DashboardLogVolumePrunerIntervals>;
+}): DashboardLogVolumePrunerHandle {
+  const intervals = {
+    ...DEFAULT_DASHBOARD_LOG_VOLUME_PRUNER_INTERVALS,
+    ...opts.intervals,
+  };
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let stopped = false;
+  let rowsDeleted = 0;
+
+  const schedule = (delayMs: number): void => {
+    if (stopped) return;
+    timer = setTimeout(run, delayMs);
+    timer.unref?.();
+  };
+
+  const nextDelayFor = (result: LogVolumePruneResult): number => {
+    switch (result.status) {
+      case 'more':
+        return intervals.catchupIntervalMs;
+      case 'reclaim-pending':
+        return intervals.reclaimRetryMs;
+      case 'done':
+      case 'done-compacted':
+        return intervals.steadyIntervalMs;
+    }
+  };
+
+  const run = (): void => {
+    timer = null;
+    if (stopped) return;
+    try {
+      const result = opts.dashDb.pruneLogVolumeBatch();
+      rowsDeleted += result.deleted;
+      if (result.status === 'done' || result.status === 'done-compacted') {
+        if (rowsDeleted > 0 || result.status === 'done-compacted') {
+          opts.log(
+            `Dashboard log-volume cleanup removed ${rowsDeleted} old routine row(s)` +
+              (result.status === 'done-compacted' ? ' and compacted node-ui.db' : ''),
+          );
+        }
+        rowsDeleted = 0;
+      }
+      schedule(nextDelayFor(result));
+    } catch (error) {
+      opts.log(
+        `Dashboard log-volume cleanup deferred: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      schedule(intervals.reclaimRetryMs);
+    }
+  };
+
+  schedule(intervals.initialDelayMs);
+
+  return {
+    stop() {
+      if (stopped) return;
+      stopped = true;
+      if (timer) clearTimeout(timer);
+      timer = null;
+    },
+  };
+}

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -2599,6 +2599,47 @@ export async function runDaemonInner(
   }, PRUNE_INTERVAL_MS);
   pruneTimer.unref();
 
+  // A time window cannot bound a same-day log storm. Trim an oversized
+  // dashboard DB incrementally after startup so upgrading a multi-GB node does
+  // not block its boot on one huge DELETE/VACUUM. Small batches smooth event-
+  // loop impact; after the cap is reached DashboardDB performs one compaction
+  // that returns the free pages to the OS. Steady-state probes share the normal
+  // six-hour prune cadence.
+  const LOG_VOLUME_PRUNE_INITIAL_DELAY_MS = 60_000;
+  const LOG_VOLUME_PRUNE_CATCHUP_INTERVAL_MS = 15_000;
+  const LOG_VOLUME_RECLAIM_RETRY_MS = 10 * 60_000;
+  let logVolumePruneTimer: ReturnType<typeof setTimeout> | null = null;
+  let logVolumeRowsDeleted = 0;
+  const scheduleLogVolumePrune = (delayMs: number): void => {
+    logVolumePruneTimer = setTimeout(() => {
+      try {
+        const result = dashDb.pruneLogVolumeBatch();
+        logVolumeRowsDeleted += result.deleted;
+        if (!result.hasMore && !result.reclaimPending && (logVolumeRowsDeleted > 0 || result.compacted)) {
+          log(
+            `Dashboard log-volume cleanup removed ${logVolumeRowsDeleted} old routine row(s)` +
+              (result.compacted ? ' and compacted node-ui.db' : ''),
+          );
+          logVolumeRowsDeleted = 0;
+        }
+        scheduleLogVolumePrune(
+          result.hasMore
+            ? LOG_VOLUME_PRUNE_CATCHUP_INTERVAL_MS
+            : result.reclaimPending
+              ? LOG_VOLUME_RECLAIM_RETRY_MS
+              : PRUNE_INTERVAL_MS,
+        );
+      } catch (err) {
+        log(
+          `Dashboard log-volume cleanup deferred: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        scheduleLogVolumePrune(LOG_VOLUME_RECLAIM_RETRY_MS);
+      }
+    }, delayMs);
+    logVolumePruneTimer.unref();
+  };
+  scheduleLogVolumePrune(LOG_VOLUME_PRUNE_INITIAL_DELAY_MS);
+
   // RPC usage telemetry — the "RPC credit burn" signal (incident: a node spent
   // ~$200 of RPC credits in a day with nothing measuring it). The whole
   // Wiring only (scheduling/format live in rpc-usage-log.ts, unit-tested).
@@ -3454,6 +3495,7 @@ export async function runDaemonInner(
         clearInterval(chainScanTimer);
         clearInterval(pingTimer);
         clearInterval(pruneTimer);
+        if (logVolumePruneTimer) clearTimeout(logVolumePruneTimer);
         // Clears the timer AND performs the final best-effort drain (BEFORE
         // telemetry stops), so a partial window still reaches Loki — keeps
         // log-derived request totals exact across process lifecycles.

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -146,6 +146,7 @@ import { projectRuntimeEvmChainConfig } from '../runtime-chain-config.js';
 import { resolveOtelSignals, resolveLogExporterMode, isUnknownLogExporter } from '../telemetry-config.js';
 import { createDaemonLogSink } from './log-sink.js';
 import { startRpcUsageTelemetry } from './rpc-usage-log.js';
+import { startDashboardLogVolumePruner } from './dashboard-log-volume-pruner.js';
 import { createInitialPublisherState, createPublicSnapshotStore, createPublisherControlFromStore, startPublisherRuntimeWithOutcome, type PublisherState } from '../publisher-runner.js';
 import { createCatchupRunner, type CatchupJobResult, type CatchupRunner } from '../catchup-runner.js';
 import { loadTokens, httpAuthGuard } from '../auth.js';
@@ -2599,46 +2600,14 @@ export async function runDaemonInner(
   }, PRUNE_INTERVAL_MS);
   pruneTimer.unref();
 
-  // A time window cannot bound a same-day log storm. Trim an oversized
-  // dashboard DB incrementally after startup so upgrading a multi-GB node does
-  // not block its boot on one huge DELETE/VACUUM. Small batches smooth event-
-  // loop impact; after the cap is reached DashboardDB performs one compaction
-  // that returns the free pages to the OS. Steady-state probes share the normal
-  // six-hour prune cadence.
-  const LOG_VOLUME_PRUNE_INITIAL_DELAY_MS = 60_000;
-  const LOG_VOLUME_PRUNE_CATCHUP_INTERVAL_MS = 15_000;
-  const LOG_VOLUME_RECLAIM_RETRY_MS = 10 * 60_000;
-  let logVolumePruneTimer: ReturnType<typeof setTimeout> | null = null;
-  let logVolumeRowsDeleted = 0;
-  const scheduleLogVolumePrune = (delayMs: number): void => {
-    logVolumePruneTimer = setTimeout(() => {
-      try {
-        const result = dashDb.pruneLogVolumeBatch();
-        logVolumeRowsDeleted += result.deleted;
-        if (!result.hasMore && !result.reclaimPending && (logVolumeRowsDeleted > 0 || result.compacted)) {
-          log(
-            `Dashboard log-volume cleanup removed ${logVolumeRowsDeleted} old routine row(s)` +
-              (result.compacted ? ' and compacted node-ui.db' : ''),
-          );
-          logVolumeRowsDeleted = 0;
-        }
-        scheduleLogVolumePrune(
-          result.hasMore
-            ? LOG_VOLUME_PRUNE_CATCHUP_INTERVAL_MS
-            : result.reclaimPending
-              ? LOG_VOLUME_RECLAIM_RETRY_MS
-              : PRUNE_INTERVAL_MS,
-        );
-      } catch (err) {
-        log(
-          `Dashboard log-volume cleanup deferred: ${err instanceof Error ? err.message : String(err)}`,
-        );
-        scheduleLogVolumePrune(LOG_VOLUME_RECLAIM_RETRY_MS);
-      }
-    }, delayMs);
-    logVolumePruneTimer.unref();
-  };
-  scheduleLogVolumePrune(LOG_VOLUME_PRUNE_INITIAL_DELAY_MS);
+  // A time window cannot bound a same-day log storm. The focused maintenance
+  // helper owns bounded catch-up batches, compaction retries, and timer cleanup;
+  // daemon lifecycle only starts and stops it.
+  const logVolumePruner = startDashboardLogVolumePruner({
+    dashDb,
+    log,
+    intervals: { steadyIntervalMs: PRUNE_INTERVAL_MS },
+  });
 
   // RPC usage telemetry — the "RPC credit burn" signal (incident: a node spent
   // ~$200 of RPC credits in a day with nothing measuring it). The whole
@@ -3495,7 +3464,7 @@ export async function runDaemonInner(
         clearInterval(chainScanTimer);
         clearInterval(pingTimer);
         clearInterval(pruneTimer);
-        if (logVolumePruneTimer) clearTimeout(logVolumePruneTimer);
+        logVolumePruner.stop();
         // Clears the timer AND performs the final best-effort drain (BEFORE
         // telemetry stops), so a partial window still reaches Loki — keeps
         // log-derived request totals exact across process lifecycles.

--- a/packages/cli/test/dashboard-log-volume-pruner.test.ts
+++ b/packages/cli/test/dashboard-log-volume-pruner.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { LogVolumePruneResult } from '@origintrail-official/dkg-node-ui';
+import { startDashboardLogVolumePruner } from '../src/daemon/dashboard-log-volume-pruner.js';
+
+describe('startDashboardLogVolumePruner', () => {
+  afterEach(() => vi.useRealTimers());
+
+  it('starts after the boot delay, catches up quickly, logs compaction, and stops cleanly', () => {
+    vi.useFakeTimers();
+    const results: LogVolumePruneResult[] = [
+      { deleted: 25_000, status: 'more' },
+      { deleted: 0, status: 'done-compacted' },
+    ];
+    const calls: number[] = [];
+    const logs: string[] = [];
+    const handle = startDashboardLogVolumePruner({
+      dashDb: {
+        pruneLogVolumeBatch: () => {
+          calls.push(Date.now());
+          return results.shift() ?? { deleted: 0, status: 'done' };
+        },
+      },
+      log: (message) => logs.push(message),
+      intervals: {
+        initialDelayMs: 100,
+        catchupIntervalMs: 20,
+        reclaimRetryMs: 50,
+        steadyIntervalMs: 1_000,
+      },
+    });
+
+    vi.advanceTimersByTime(99);
+    expect(calls).toHaveLength(0);
+    vi.advanceTimersByTime(1);
+    expect(calls).toHaveLength(1);
+    vi.advanceTimersByTime(19);
+    expect(calls).toHaveLength(1);
+    vi.advanceTimersByTime(1);
+    expect(calls).toHaveLength(2);
+    expect(logs).toEqual([
+      'Dashboard log-volume cleanup removed 25000 old routine row(s) and compacted node-ui.db',
+    ]);
+
+    handle.stop();
+    vi.advanceTimersByTime(5_000);
+    expect(calls).toHaveLength(2);
+  });
+
+  it('retries reclaim-pending and thrown maintenance steps on the retry cadence', () => {
+    vi.useFakeTimers();
+    const steps: Array<LogVolumePruneResult | Error> = [
+      { deleted: 12, status: 'reclaim-pending' },
+      new Error('database is locked'),
+      { deleted: 0, status: 'done-compacted' },
+    ];
+    const logs: string[] = [];
+    let calls = 0;
+    const handle = startDashboardLogVolumePruner({
+      dashDb: {
+        pruneLogVolumeBatch: () => {
+          calls += 1;
+          const step = steps.shift() ?? { deleted: 0, status: 'done' as const };
+          if (step instanceof Error) throw step;
+          return step;
+        },
+      },
+      log: (message) => logs.push(message),
+      intervals: { initialDelayMs: 10, reclaimRetryMs: 30 },
+    });
+
+    vi.advanceTimersByTime(10);
+    expect(calls).toBe(1);
+    vi.advanceTimersByTime(30);
+    expect(calls).toBe(2);
+    vi.advanceTimersByTime(30);
+    expect(calls).toBe(3);
+    expect(logs).toEqual([
+      'Dashboard log-volume cleanup deferred: database is locked',
+      'Dashboard log-volume cleanup removed 12 old routine row(s) and compacted node-ui.db',
+    ]);
+    handle.stop();
+  });
+});

--- a/packages/cli/vitest.unit.config.ts
+++ b/packages/cli/vitest.unit.config.ts
@@ -63,6 +63,7 @@ export default defineConfig({
           // #1066 Item 1 — metrics presence gate. Pure logic (injected clock).
           'test/metrics-presence.test.ts',
           'test/rpc-usage-log.test.ts',
+          'test/dashboard-log-volume-pruner.test.ts',
           // RFC 120 / plan PR 1 + 2 — Blazegraph support. Pure logic
           // (mocked fetch + in-memory config); cheap to keep in the
           // fast unit lane.

--- a/packages/node-ui/src/db.ts
+++ b/packages/node-ui/src/db.ts
@@ -21,13 +21,17 @@ const SCHEMA_VERSION = 24;
 // grew to ~9 GB on a 12-day-old node and corrupted the SQLite page (header
 // hash mismatch on boot). 90 days had been chosen for "metrics history",
 // but logs were the dominant grower (~1M rows/12d) and pruning was a no-op
-// on any DB younger than 90 days. 14 days is still long enough for any
-// realistic operator-driven post-mortem while bounding worst-case growth
-// of the (now FTS5-less) logs table to ~150 MB. Operators who want longer
+// on any DB younger than 90 days. 14 days is still long enough for a useful
+// operator-driven post-mortem, but the mainnet sync storm proved that time
+// retention alone cannot bound worst-case growth. Operators who want longer
 // retention can override via `setRetentionDays()`; the setting is persisted
-// in the `settings` table and re-read on next boot.
+// in the `settings` table and re-read on next boot. Time alone is not a hard
+// size bound during a log storm, so routine info/debug rows also have a count
+// ceiling. Warning/error rows keep the full operator-selected time window.
 const DEFAULT_RETENTION_DAYS = 14;
 const LEGACY_IMPLICIT_RETENTION_DAYS = 90;
+const DEFAULT_ROUTINE_LOG_ROW_CAP = 1_000_000;
+const DEFAULT_LOG_VOLUME_PRUNE_BATCH_ROWS = 25_000;
 const LOGS_VACUUM_DELETE_THRESHOLD = 10_000;
 // SQLite reports reusable-but-not-yet-reclaimed pages via freelist_count.
 // With the default 4 KiB page size this is roughly 4 MiB, large enough
@@ -106,6 +110,17 @@ export interface DashboardDBOptions {
    * `DKG_DASHBOARD_CACHE_TTL_MS` env var, then a 2000ms default.
    */
   cacheTtlMs?: number;
+  /** Maximum retained info/debug/unknown log rows. Warning/error rows are time-bound only. */
+  routineLogRowCap?: number;
+  /** Maximum oldest routine rows removed by one bounded catch-up tick. */
+  logVolumePruneBatchRows?: number;
+}
+
+export interface LogVolumePruneResult {
+  deleted: number;
+  hasMore: boolean;
+  compacted: boolean;
+  reclaimPending: boolean;
 }
 
 /**
@@ -135,11 +150,21 @@ export class DashboardDB {
   readonly dataDir: string;
   private retentionDays: number;
   private readonly explicitRetentionDays: boolean;
+  private readonly routineLogRowCap: number;
+  private readonly logVolumePruneBatchRows: number;
 
   constructor(opts: DashboardDBOptions) {
     this.dataDir = opts.dataDir;
     this.explicitRetentionDays = opts.retentionDays !== undefined;
     this.retentionDays = opts.retentionDays ?? DEFAULT_RETENTION_DAYS;
+    this.routineLogRowCap = Math.max(
+      0,
+      Math.floor(opts.routineLogRowCap ?? DEFAULT_ROUTINE_LOG_ROW_CAP),
+    );
+    this.logVolumePruneBatchRows = Math.max(
+      1,
+      Math.floor(opts.logVolumePruneBatchRows ?? DEFAULT_LOG_VOLUME_PRUNE_BATCH_ROWS),
+    );
     this._memoTtlMs = resolveCacheTtlMs(opts.cacheTtlMs);
     const dbPath = join(opts.dataDir, 'node-ui.db');
     this.db = new Database(dbPath);
@@ -891,19 +916,12 @@ export class DashboardDB {
     const messengerCutoff = Date.now() - 24 * 60 * 60 * 1000;
     this.db.exec(`DELETE FROM message_idempotency WHERE ts < ${messengerCutoff}`);
 
-    // Reclaim free pages from the file. Without this, the SQLite file
-    // size only ever grows — DELETE / DROP just marks pages reusable,
-    // it does not return them to the OS. Vacuum when prune removed a
-    // meaningful number of log rows, or when a previous migration/drop
-    // left a large freelist behind without deleting any retained logs.
-    const freePages = Number(this.db.pragma('freelist_count', { simple: true }) ?? 0);
-    if (logsDeleted > LOGS_VACUUM_DELETE_THRESHOLD || freePages > VACUUM_FREE_PAGE_THRESHOLD) {
-      try {
-        this.db.exec(`VACUUM`);
-      } catch {
-        // VACUUM requires an exclusive lock. If another connection is
-        // holding the DB open we skip and retry on the next prune.
-      }
+    // Avoid rebuilding an oversized DB at startup while millions of routine
+    // rows are still live. The daemon trims that backlog in bounded batches;
+    // the final batch performs one compacting VACUUM. Databases already under
+    // the cap retain the established time-prune reclamation behaviour.
+    if (!this.hasRoutineLogOverflow()) {
+      this.reclaimFreePagesIfNeeded(logsDeleted > LOGS_VACUUM_DELETE_THRESHOLD);
     }
 
     // Return the WAL file itself to the OS. journal_size_limit bounds it
@@ -912,6 +930,97 @@ export class DashboardDB {
     // which rewrites the whole DB through the WAL and momentarily grows
     // it. Runs unconditionally — independent of the VACUUM gate — because
     // an idle node still wants its -wal reclaimed.
+    this.truncateWal('prune');
+  }
+
+  /**
+   * Remove one bounded batch of the oldest routine (non-warning/error) logs.
+   * A count cap complements time retention: a high-rate sync storm can create
+   * millions of rows inside a single day, long before a 14-day cutoff applies.
+   *
+   * Deletion is deliberately incremental so an upgrade does not block node
+   * startup on a multi-GB transaction. Once the backlog reaches the cap, one
+   * VACUUM returns the accumulated free pages to the OS and the file shrinks.
+   */
+  pruneLogVolumeBatch(): LogVolumePruneResult {
+    const overflowCutoff = this.routineLogOverflowCutoff();
+    if (overflowCutoff === null) {
+      const reclaim = this.reclaimFreePagesIfNeeded(false);
+      if (!reclaim.reclaimPending) this.truncateWal('log-volume prune');
+      return {
+        deleted: 0,
+        hasMore: false,
+        compacted: reclaim.compacted,
+        reclaimPending: reclaim.reclaimPending,
+      };
+    }
+
+    const deleted = this.db.prepare(`
+      DELETE FROM logs
+      WHERE id IN (
+        SELECT id
+        FROM logs
+        WHERE id <= @cutoff
+          AND level NOT IN ('warn', 'error')
+        ORDER BY id ASC
+        LIMIT @batchRows
+      )
+    `).run({
+      cutoff: overflowCutoff,
+      batchRows: this.logVolumePruneBatchRows,
+    }).changes;
+
+    // If the batch filled, conservatively schedule another tick. An exact-size
+    // final batch costs one extra cheap probe before compaction, which is safer
+    // than running a second million-row count after every deletion.
+    const hasMore = deleted === this.logVolumePruneBatchRows;
+    const reclaim = hasMore
+      ? { compacted: false, reclaimPending: false }
+      : this.reclaimFreePagesIfNeeded(deleted > LOGS_VACUUM_DELETE_THRESHOLD);
+    if (!hasMore && !reclaim.reclaimPending) this.truncateWal('log-volume prune');
+    return {
+      deleted,
+      hasMore,
+      compacted: reclaim.compacted,
+      reclaimPending: reclaim.reclaimPending,
+    };
+  }
+
+  private routineLogOverflowCutoff(): number | null {
+    const row = this.db.prepare(`
+      SELECT id
+      FROM logs
+      WHERE level NOT IN ('warn', 'error')
+      ORDER BY id DESC
+      LIMIT 1 OFFSET ?
+    `).get(this.routineLogRowCap) as { id: number } | undefined;
+    return row?.id ?? null;
+  }
+
+  private hasRoutineLogOverflow(): boolean {
+    return this.routineLogOverflowCutoff() !== null;
+  }
+
+  private reclaimFreePagesIfNeeded(force: boolean): {
+    compacted: boolean;
+    reclaimPending: boolean;
+  } {
+    // DELETE / DROP only marks pages reusable; VACUUM is what returns them to
+    // the OS. A failed exclusive-lock/disk attempt remains pending for a later
+    // background retry and never prevents the node from running.
+    const freePages = Number(this.db.pragma('freelist_count', { simple: true }) ?? 0);
+    if (!force && freePages <= VACUUM_FREE_PAGE_THRESHOLD) {
+      return { compacted: false, reclaimPending: false };
+    }
+    try {
+      this.db.exec(`VACUUM`);
+      return { compacted: true, reclaimPending: false };
+    } catch {
+      return { compacted: false, reclaimPending: true };
+    }
+  }
+
+  private truncateWal(reason: string): void {
     try {
       // wal_checkpoint signals reader contention through its result row
       // (`busy = 1`), NOT by throwing — so a busy checkpoint leaves the
@@ -926,7 +1035,7 @@ export class DashboardDB {
       }>;
       if (checkpoint?.busy) {
         console.warn(
-          `[DashboardDB] wal_checkpoint(TRUNCATE) busy — WAL not reclaimed this prune ` +
+          `[DashboardDB] wal_checkpoint(TRUNCATE) busy — WAL not reclaimed during ${reason} ` +
             `(log=${checkpoint.log}, checkpointed=${checkpoint.checkpointed}); retried next prune`,
         );
       }
@@ -938,7 +1047,7 @@ export class DashboardDB {
       // stalled WAL reclaim is visible in the daemon log instead of only
       // showing up later as unexplained disk growth. Never block prune.
       console.warn(
-        `[DashboardDB] wal_checkpoint(TRUNCATE) failed — WAL not reclaimed this prune: ` +
+        `[DashboardDB] wal_checkpoint(TRUNCATE) failed — WAL not reclaimed during ${reason}: ` +
           `${err instanceof Error ? err.message : String(err)}`,
       );
     }

--- a/packages/node-ui/src/db.ts
+++ b/packages/node-ui/src/db.ts
@@ -118,9 +118,7 @@ export interface DashboardDBOptions {
 
 export interface LogVolumePruneResult {
   deleted: number;
-  hasMore: boolean;
-  compacted: boolean;
-  reclaimPending: boolean;
+  status: 'more' | 'reclaim-pending' | 'done' | 'done-compacted';
 }
 
 /**
@@ -949,9 +947,11 @@ export class DashboardDB {
       if (!reclaim.reclaimPending) this.truncateWal('log-volume prune');
       return {
         deleted: 0,
-        hasMore: false,
-        compacted: reclaim.compacted,
-        reclaimPending: reclaim.reclaimPending,
+        status: reclaim.reclaimPending
+          ? 'reclaim-pending'
+          : reclaim.compacted
+            ? 'done-compacted'
+            : 'done',
       };
     }
 
@@ -980,9 +980,13 @@ export class DashboardDB {
     if (!hasMore && !reclaim.reclaimPending) this.truncateWal('log-volume prune');
     return {
       deleted,
-      hasMore,
-      compacted: reclaim.compacted,
-      reclaimPending: reclaim.reclaimPending,
+      status: hasMore
+        ? 'more'
+        : reclaim.reclaimPending
+          ? 'reclaim-pending'
+          : reclaim.compacted
+            ? 'done-compacted'
+            : 'done',
     };
   }
 

--- a/packages/node-ui/src/index.ts
+++ b/packages/node-ui/src/index.ts
@@ -20,6 +20,7 @@ export {
 } from './chain-cursor-stores.js';
 export type {
   DashboardDBOptions,
+  LogVolumePruneResult,
   MetricSnapshotRow,
   OperationRow,
   OperationPhaseRow,

--- a/packages/node-ui/src/ui/pages/Settings.tsx
+++ b/packages/node-ui/src/ui/pages/Settings.tsx
@@ -354,7 +354,8 @@ function LocalDataRetentionSection() {
         )}
         {pendingRetention == null && (
           <div style={{ fontSize: 10, color: 'var(--text-dim)', marginTop: 4 }}>
-            Operations, logs, and metric snapshots older than this are pruned automatically.
+            Operations and metric snapshots older than this are pruned automatically. Warning and error logs
+            keep this window; high-volume routine logs also have a size safety cap.
           </div>
         )}
         <div aria-live="polite">

--- a/packages/node-ui/test/db.test.ts
+++ b/packages/node-ui/test/db.test.ts
@@ -390,11 +390,11 @@ describe('DashboardDB — retention', () => {
       volumeDb.insertLog({ ts: 2_000, level: 'warn', module: 'sync', message: 'keep-warn' });
       volumeDb.insertLog({ ts: 2_001, level: 'error', module: 'sync', message: 'keep-error' });
 
-      expect(volumeDb.pruneLogVolumeBatch()).toMatchObject({ deleted: 2, hasMore: true });
+      expect(volumeDb.pruneLogVolumeBatch()).toEqual({ deleted: 2, status: 'more' });
       // The second batch exactly reaches the cap. The API conservatively asks
       // for one final probe, avoiding a second large count on every batch.
-      expect(volumeDb.pruneLogVolumeBatch()).toMatchObject({ deleted: 2, hasMore: true });
-      expect(volumeDb.pruneLogVolumeBatch()).toMatchObject({ deleted: 0, hasMore: false });
+      expect(volumeDb.pruneLogVolumeBatch()).toEqual({ deleted: 2, status: 'more' });
+      expect(volumeDb.pruneLogVolumeBatch()).toEqual({ deleted: 0, status: 'done' });
 
       const rows = volumeDb.db.prepare(
         `SELECT level, message FROM logs ORDER BY id ASC`,
@@ -439,8 +439,8 @@ describe('DashboardDB — retention', () => {
       let compacted = false;
       for (let i = 0; i < 10; i += 1) {
         const result = volumeDb.pruneLogVolumeBatch();
-        compacted ||= result.compacted;
-        if (!result.hasMore && !result.reclaimPending) break;
+        compacted ||= result.status === 'done-compacted';
+        if (result.status === 'done' || result.status === 'done-compacted') break;
       }
 
       const afterBytes = statSync(dbPath).size;

--- a/packages/node-ui/test/db.test.ts
+++ b/packages/node-ui/test/db.test.ts
@@ -369,6 +369,93 @@ describe('DashboardDB — retention', () => {
 
     db2.close();
   });
+
+  it('caps routine logs incrementally while preserving warning and error history', () => {
+    const volumeDir = mkdtempSync(join(tmpdir(), 'dkg-db-log-volume-'));
+    const volumeDb = new DashboardDB({
+      dataDir: volumeDir,
+      retentionDays: 365,
+      routineLogRowCap: 3,
+      logVolumePruneBatchRows: 2,
+    });
+    try {
+      for (let i = 0; i < 7; i += 1) {
+        volumeDb.insertLog({
+          ts: 1_000 + i,
+          level: i % 2 === 0 ? 'debug' : 'info',
+          module: 'sync',
+          message: `routine-${i}`,
+        });
+      }
+      volumeDb.insertLog({ ts: 2_000, level: 'warn', module: 'sync', message: 'keep-warn' });
+      volumeDb.insertLog({ ts: 2_001, level: 'error', module: 'sync', message: 'keep-error' });
+
+      expect(volumeDb.pruneLogVolumeBatch()).toMatchObject({ deleted: 2, hasMore: true });
+      // The second batch exactly reaches the cap. The API conservatively asks
+      // for one final probe, avoiding a second large count on every batch.
+      expect(volumeDb.pruneLogVolumeBatch()).toMatchObject({ deleted: 2, hasMore: true });
+      expect(volumeDb.pruneLogVolumeBatch()).toMatchObject({ deleted: 0, hasMore: false });
+
+      const rows = volumeDb.db.prepare(
+        `SELECT level, message FROM logs ORDER BY id ASC`,
+      ).all() as Array<{ level: string; message: string }>;
+      expect(rows.filter((row) => row.level === 'debug' || row.level === 'info'))
+        .toEqual([
+          { level: 'debug', message: 'routine-4' },
+          { level: 'info', message: 'routine-5' },
+          { level: 'debug', message: 'routine-6' },
+        ]);
+      expect(rows).toContainEqual({ level: 'warn', message: 'keep-warn' });
+      expect(rows).toContainEqual({ level: 'error', message: 'keep-error' });
+    } finally {
+      volumeDb.close();
+      rmSync(volumeDir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns multi-megabyte free pages to the OS after the final volume batch', () => {
+    const volumeDir = mkdtempSync(join(tmpdir(), 'dkg-db-log-compact-'));
+    const dbPath = join(volumeDir, 'node-ui.db');
+    const volumeDb = new DashboardDB({
+      dataDir: volumeDir,
+      retentionDays: 365,
+      routineLogRowCap: 2,
+      logVolumePruneBatchRows: 10,
+    });
+    try {
+      const payload = 'x'.repeat(256 * 1024);
+      for (let i = 0; i < 30; i += 1) {
+        volumeDb.insertLog({
+          ts: 1_000 + i,
+          level: 'debug',
+          module: 'sync',
+          message: `${i}:${payload}`,
+        });
+      }
+      volumeDb.insertLog({ ts: 2_000, level: 'warn', module: 'sync', message: 'keep-warn' });
+      volumeDb.db.pragma('wal_checkpoint(TRUNCATE)');
+      const beforeBytes = statSync(dbPath).size;
+
+      let compacted = false;
+      for (let i = 0; i < 10; i += 1) {
+        const result = volumeDb.pruneLogVolumeBatch();
+        compacted ||= result.compacted;
+        if (!result.hasMore && !result.reclaimPending) break;
+      }
+
+      const afterBytes = statSync(dbPath).size;
+      const levels = volumeDb.db.prepare(
+        `SELECT level, COUNT(*) AS count FROM logs GROUP BY level`,
+      ).all() as Array<{ level: string; count: number }>;
+      expect(compacted).toBe(true);
+      expect(afterBytes).toBeLessThan(beforeBytes / 2);
+      expect(levels).toContainEqual({ level: 'debug', count: 2 });
+      expect(levels).toContainEqual({ level: 'warn', count: 1 });
+    } finally {
+      volumeDb.close();
+      rmSync(volumeDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('DashboardDB — operation phases', () => {

--- a/packages/node-ui/test/settings-page.dom.test.ts
+++ b/packages/node-ui/test/settings-page.dom.test.ts
@@ -139,6 +139,7 @@ describe('SettingsPage (cleanup) — rendering, removals, a11y', () => {
     // size-rotated, independent of the retention window).
     expect(c.textContent ?? '').not.toMatch(/daemon\.log/i);
     expect(c.textContent ?? '').toMatch(/pruned automatically/i);
+    expect(c.textContent ?? '').toMatch(/routine logs also have a size safety cap/i);
   });
 
   it('reducing retention shows the reduce-confirm group, focuses Prune & Save, and Escape-free Cancel dismisses it', async () => {


### PR DESCRIPTION
## Summary

- emit successful sync-responder page timing details only for offset 0 of each phase/session
- keep slow-response diagnostics for every page, along with all warning/error paths and metrics
- add a regression test proving a two-page response produces one routine timing record

## Mainnet evidence

The 10.0.6 fleet is persisting one debug row for every successfully served sync page. On two inspected core nodes:

- Anacreon: 11.17M log rows / 2.84 GB `node-ui.db`; 9.06M rows are debug
- SBB: 7.15M log rows / 1.81 GB `node-ui.db`; 4.93M rows are debug

The dominant messages are routine 0-10 ms `Sync responder durable data/meta` page timings for `agents`, `foodie-network`, and `sports`. Large snapshots can span thousands of pages, so the existing 14-day retention window does not bound DB growth under catch-up traffic.

This change preserves one representative timing record per transfer while avoiding redundant per-page SQLite writes. It does not alter sync responses, subscriptions, or triple-store data.

## Verification

- `pnpm --filter @origintrail-official/dkg-agent exec vitest run --config vitest.unit.config.ts test/sync-responder-log-volume.test.ts`
- `pnpm --filter @origintrail-official/dkg-agent exec tsc --noEmit`
- `pnpm --filter @origintrail-official/dkg-agent test:unit`
