### PR TITLE
fix(agent): back off failed VM reconcile sweeps

### DIFF
--- a/packages/agent/src/chain-reconciler.ts
+++ b/packages/agent/src/chain-reconciler.ts
@@ -160,21 +160,45 @@ export async function reconcileContextGraph(
 export class ReconcileCoalescer {
   private readonly inFlight = new Map<string, Promise<void>>();
   private readonly again = new Set<string>();
+  private readonly retryAfter = new Map<string, number>();
+  private readonly failureBackoffMs: number;
+  private readonly now: () => number;
 
-  constructor(private readonly run: (key: string) => Promise<void>) {}
+  constructor(
+    private readonly run: (key: string) => Promise<void>,
+    options: { failureBackoffMs?: number; now?: () => number } = {},
+  ) {
+    this.failureBackoffMs = Math.max(0, options.failureBackoffMs ?? 0);
+    this.now = options.now ?? Date.now;
+  }
 
   trigger(key: string): Promise<void> {
+    const retryAfter = this.retryAfter.get(key);
+    if (retryAfter !== undefined) {
+      if (this.now() < retryAfter) return Promise.resolve();
+      this.retryAfter.delete(key);
+    }
     const existing = this.inFlight.get(key);
     if (existing) {
       // A run is in flight — mark that one more pass is needed after it.
       this.again.add(key);
       return existing;
     }
+    let failed = false;
     const promise = this.run(key)
-      .catch(() => { /* run is responsible for its own logging */ })
+      .catch(() => {
+        // The run is responsible for logging. A configured cooldown keeps live
+        // chain-event nudges from immediately re-running the same expensive
+        // failed sweep; the periodic sweep retries after the window expires.
+        failed = true;
+        if (this.failureBackoffMs > 0) {
+          this.retryAfter.set(key, this.now() + this.failureBackoffMs);
+        }
+      })
       .finally(() => {
         this.inFlight.delete(key);
-        if (this.again.delete(key)) void this.trigger(key);
+        const runAgain = this.again.delete(key);
+        if (runAgain && (!failed || this.failureBackoffMs === 0)) void this.trigger(key);
       });
     this.inFlight.set(key, promise);
     return promise;

--- a/packages/agent/src/chain-reconciler.ts
+++ b/packages/agent/src/chain-reconciler.ts
@@ -152,51 +152,17 @@ export async function reconcileContextGraph(
 }
 
 /**
- * Per-key single-flight coalescer: a burst of triggers for the same key runs
- * the action ONCE, with a single trailing re-run if new triggers arrive while
- * a run is in flight (so events that land mid-sweep aren't lost). Used so N
- * KACG events for one CG cause one sweep (+ at most one trailing sweep), not N.
- */
-export class ReconcileCoalescer {
-  private readonly inFlight = new Map<string, Promise<void>>();
-  private readonly again = new Set<string>();
-
-  constructor(private readonly run: (key: string) => Promise<void>) {}
-
-  trigger(key: string): Promise<void> {
-    const existing = this.inFlight.get(key);
-    if (existing) {
-      // A run is in flight — mark that one more pass is needed after it.
-      this.again.add(key);
-      return existing;
-    }
-    const promise = this.run(key)
-      .catch(() => { /* run is responsible for its own logging */ })
-      .finally(() => {
-        this.inFlight.delete(key);
-        if (this.again.delete(key)) void this.trigger(key);
-      });
-    this.inFlight.set(key, promise);
-    return promise;
-  }
-
-  /** True if a run for `key` is currently in flight. */
-  isInFlight(key: string): boolean {
-    return this.inFlight.has(key);
-  }
-}
-
-/**
- * VM-specific, source-aware single-flight scheduling policy.
+ * Per-CG, source-aware single-flight scheduling policy for VM reconciliation.
  *
  * Live chain events are latency nudges, while the periodic sweep is the
  * reliability path. After a failed VM pass, live nudges for that CG are held so
  * they cannot hot-loop the same expensive store/RPC work. The next periodic
  * sweep explicitly releases the hold and retries. Failure logging also lives at
  * this scheduling boundary; the domain operation remains a normal rejecting
- * async function and the generic coalescer remains policy-free. Pending live
- * and periodic triggers are tracked separately so a periodic reliability pass
- * can never be consumed by the live-failure hold.
+ * async function. Pending live and periodic triggers are tracked separately so
+ * a periodic reliability pass can never be consumed by the live-failure hold.
+ * This is the single owner of per-key coalescing semantics: a burst produces at
+ * most one trailing pass, with periodic work taking priority over live nudges.
  */
 interface VmReconcileScheduleState {
   inFlight?: Promise<void>;

--- a/packages/agent/src/chain-reconciler.ts
+++ b/packages/agent/src/chain-reconciler.ts
@@ -187,52 +187,110 @@ export class ReconcileCoalescer {
 }
 
 /**
- * VM-specific scheduling policy around the generic single-flight coalescer.
+ * VM-specific, source-aware single-flight scheduling policy.
  *
  * Live chain events are latency nudges, while the periodic sweep is the
  * reliability path. After a failed VM pass, live nudges for that CG are held so
  * they cannot hot-loop the same expensive store/RPC work. The next periodic
  * sweep explicitly releases the hold and retries. Failure logging also lives at
  * this scheduling boundary; the domain operation remains a normal rejecting
- * async function and the generic coalescer remains policy-free.
+ * async function and the generic coalescer remains policy-free. Pending live
+ * and periodic triggers are tracked separately so a periodic reliability pass
+ * can never be consumed by the live-failure hold.
  */
+interface VmReconcileScheduleState {
+  inFlight?: Promise<void>;
+  pendingLive: boolean;
+  pendingPeriodic: boolean;
+  liveBlocked: boolean;
+}
+
 export class VmReconcileScheduler {
-  private readonly liveBlocked = new Set<string>();
-  private readonly coalescer: ReconcileCoalescer;
+  private readonly states = new Map<string, VmReconcileScheduleState>();
 
   constructor(
-    run: (key: string) => Promise<void>,
-    onFailure: (key: string, error: unknown) => void,
-  ) {
-    this.coalescer = new ReconcileCoalescer(async (key) => {
-      // A failed in-flight pass may already have a trailing live nudge queued
-      // inside the coalescer. Consume that trailing pass without re-running the
-      // expensive domain operation.
-      if (this.liveBlocked.has(key)) return;
-      try {
-        await run(key);
-        this.liveBlocked.delete(key);
-      } catch (error) {
-        this.liveBlocked.add(key);
-        onFailure(key, error);
-      }
-    });
-  }
+    private readonly run: (key: string) => Promise<void>,
+    private readonly onFailure: (key: string, error: unknown) => void,
+  ) {}
 
   /** Low-latency chain-event nudge; suppressed after failure until a sweep. */
   triggerLive(key: string): Promise<void> {
-    if (this.liveBlocked.has(key)) return Promise.resolve();
-    return this.coalescer.trigger(key);
+    const state = this.stateFor(key);
+    if (state.liveBlocked) return Promise.resolve();
+    if (state.inFlight) {
+      state.pendingLive = true;
+      return state.inFlight;
+    }
+    return this.start(key, state);
   }
 
   /** Reliability path; every periodic sweep gets one retry after a failure. */
   triggerPeriodic(key: string): Promise<void> {
-    this.liveBlocked.delete(key);
-    return this.coalescer.trigger(key);
+    const state = this.stateFor(key);
+    if (state.inFlight) {
+      // Periodic has priority over a queued live nudge if the active pass fails.
+      state.pendingPeriodic = true;
+      return state.inFlight;
+    }
+    state.liveBlocked = false;
+    return this.start(key, state);
   }
 
   isInFlight(key: string): boolean {
-    return this.coalescer.isInFlight(key);
+    return this.states.get(key)?.inFlight !== undefined;
+  }
+
+  private stateFor(key: string): VmReconcileScheduleState {
+    let state = this.states.get(key);
+    if (!state) {
+      state = {
+        pendingLive: false,
+        pendingPeriodic: false,
+        liveBlocked: false,
+      };
+      this.states.set(key, state);
+    }
+    return state;
+  }
+
+  private start(
+    key: string,
+    state: VmReconcileScheduleState,
+  ): Promise<void> {
+    const promise = (async () => {
+      try {
+        await this.run(key);
+        state.liveBlocked = false;
+      } catch (error) {
+        state.liveBlocked = true;
+        try {
+          this.onFailure(key, error);
+        } catch {
+          // Observability must never break scheduling or surface to callers.
+        }
+      }
+    })().finally(() => {
+      state.inFlight = undefined;
+      const runPeriodic = state.pendingPeriodic;
+      const runLive = state.pendingLive;
+      state.pendingPeriodic = false;
+      state.pendingLive = false;
+
+      if (runPeriodic) {
+        state.liveBlocked = false;
+        void this.start(key, state);
+        return;
+      }
+      if (runLive && !state.liveBlocked) {
+        void this.start(key, state);
+        return;
+      }
+      // Keep only failed keys so a later live nudge remains suppressed. A
+      // periodic retry or successful run releases and removes the state.
+      if (!state.liveBlocked) this.states.delete(key);
+    });
+    state.inFlight = promise;
+    return promise;
   }
 }
 

--- a/packages/agent/src/chain-reconciler.ts
+++ b/packages/agent/src/chain-reconciler.ts
@@ -160,45 +160,21 @@ export async function reconcileContextGraph(
 export class ReconcileCoalescer {
   private readonly inFlight = new Map<string, Promise<void>>();
   private readonly again = new Set<string>();
-  private readonly retryAfter = new Map<string, number>();
-  private readonly failureBackoffMs: number;
-  private readonly now: () => number;
 
-  constructor(
-    private readonly run: (key: string) => Promise<void>,
-    options: { failureBackoffMs?: number; now?: () => number } = {},
-  ) {
-    this.failureBackoffMs = Math.max(0, options.failureBackoffMs ?? 0);
-    this.now = options.now ?? Date.now;
-  }
+  constructor(private readonly run: (key: string) => Promise<void>) {}
 
   trigger(key: string): Promise<void> {
-    const retryAfter = this.retryAfter.get(key);
-    if (retryAfter !== undefined) {
-      if (this.now() < retryAfter) return Promise.resolve();
-      this.retryAfter.delete(key);
-    }
     const existing = this.inFlight.get(key);
     if (existing) {
       // A run is in flight — mark that one more pass is needed after it.
       this.again.add(key);
       return existing;
     }
-    let failed = false;
     const promise = this.run(key)
-      .catch(() => {
-        // The run is responsible for logging. A configured cooldown keeps live
-        // chain-event nudges from immediately re-running the same expensive
-        // failed sweep; the periodic sweep retries after the window expires.
-        failed = true;
-        if (this.failureBackoffMs > 0) {
-          this.retryAfter.set(key, this.now() + this.failureBackoffMs);
-        }
-      })
+      .catch(() => { /* run is responsible for its own logging */ })
       .finally(() => {
         this.inFlight.delete(key);
-        const runAgain = this.again.delete(key);
-        if (runAgain && (!failed || this.failureBackoffMs === 0)) void this.trigger(key);
+        if (this.again.delete(key)) void this.trigger(key);
       });
     this.inFlight.set(key, promise);
     return promise;
@@ -207,6 +183,56 @@ export class ReconcileCoalescer {
   /** True if a run for `key` is currently in flight. */
   isInFlight(key: string): boolean {
     return this.inFlight.has(key);
+  }
+}
+
+/**
+ * VM-specific scheduling policy around the generic single-flight coalescer.
+ *
+ * Live chain events are latency nudges, while the periodic sweep is the
+ * reliability path. After a failed VM pass, live nudges for that CG are held so
+ * they cannot hot-loop the same expensive store/RPC work. The next periodic
+ * sweep explicitly releases the hold and retries. Failure logging also lives at
+ * this scheduling boundary; the domain operation remains a normal rejecting
+ * async function and the generic coalescer remains policy-free.
+ */
+export class VmReconcileScheduler {
+  private readonly liveBlocked = new Set<string>();
+  private readonly coalescer: ReconcileCoalescer;
+
+  constructor(
+    run: (key: string) => Promise<void>,
+    onFailure: (key: string, error: unknown) => void,
+  ) {
+    this.coalescer = new ReconcileCoalescer(async (key) => {
+      // A failed in-flight pass may already have a trailing live nudge queued
+      // inside the coalescer. Consume that trailing pass without re-running the
+      // expensive domain operation.
+      if (this.liveBlocked.has(key)) return;
+      try {
+        await run(key);
+        this.liveBlocked.delete(key);
+      } catch (error) {
+        this.liveBlocked.add(key);
+        onFailure(key, error);
+      }
+    });
+  }
+
+  /** Low-latency chain-event nudge; suppressed after failure until a sweep. */
+  triggerLive(key: string): Promise<void> {
+    if (this.liveBlocked.has(key)) return Promise.resolve();
+    return this.coalescer.trigger(key);
+  }
+
+  /** Reliability path; every periodic sweep gets one retry after a failure. */
+  triggerPeriodic(key: string): Promise<void> {
+    this.liveBlocked.delete(key);
+    return this.coalescer.trigger(key);
+  }
+
+  isInFlight(key: string): boolean {
+    return this.coalescer.isInFlight(key);
   }
 }
 

--- a/packages/agent/src/chain-reconciler.ts
+++ b/packages/agent/src/chain-reconciler.ts
@@ -159,16 +159,18 @@ export async function reconcileContextGraph(
  * they cannot hot-loop the same expensive store/RPC work. The next periodic
  * sweep explicitly releases the hold and retries. Failure logging also lives at
  * this scheduling boundary; the domain operation remains a normal rejecting
- * async function. Pending live and periodic triggers are tracked separately so
- * a periodic reliability pass can never be consumed by the live-failure hold.
+ * async function. Each key has one prioritized queued source and an explicit
+ * live-failure hold, so invalid combinations of pending flags are impossible.
  * This is the single owner of per-key coalescing semantics: a burst produces at
  * most one trailing pass, with periodic work taking priority over live nudges.
  */
+type VmReconcileTriggerSource = 'live' | 'periodic';
+type VmReconcileHold = 'ready' | 'live-blocked';
+
 interface VmReconcileScheduleState {
   inFlight?: Promise<void>;
-  pendingLive: boolean;
-  pendingPeriodic: boolean;
-  liveBlocked: boolean;
+  queued: VmReconcileTriggerSource | null;
+  hold: VmReconcileHold;
 }
 
 export class VmReconcileScheduler {
@@ -181,25 +183,12 @@ export class VmReconcileScheduler {
 
   /** Low-latency chain-event nudge; suppressed after failure until a sweep. */
   triggerLive(key: string): Promise<void> {
-    const state = this.stateFor(key);
-    if (state.liveBlocked) return Promise.resolve();
-    if (state.inFlight) {
-      state.pendingLive = true;
-      return state.inFlight;
-    }
-    return this.start(key, state);
+    return this.schedule(key, 'live');
   }
 
   /** Reliability path; every periodic sweep gets one retry after a failure. */
   triggerPeriodic(key: string): Promise<void> {
-    const state = this.stateFor(key);
-    if (state.inFlight) {
-      // Periodic has priority over a queued live nudge if the active pass fails.
-      state.pendingPeriodic = true;
-      return state.inFlight;
-    }
-    state.liveBlocked = false;
-    return this.start(key, state);
+    return this.schedule(key, 'periodic');
   }
 
   isInFlight(key: string): boolean {
@@ -210,13 +199,27 @@ export class VmReconcileScheduler {
     let state = this.states.get(key);
     if (!state) {
       state = {
-        pendingLive: false,
-        pendingPeriodic: false,
-        liveBlocked: false,
+        queued: null,
+        hold: 'ready',
       };
       this.states.set(key, state);
     }
     return state;
+  }
+
+  private schedule(key: string, source: VmReconcileTriggerSource): Promise<void> {
+    const state = this.stateFor(key);
+    if (source === 'live' && state.hold === 'live-blocked') {
+      return Promise.resolve();
+    }
+    if (state.inFlight) {
+      // A periodic reliability pass always replaces a queued live nudge.
+      // Otherwise repeated triggers collapse into the existing queued source.
+      if (state.queued !== 'periodic') state.queued = source;
+      return state.inFlight;
+    }
+    if (source === 'periodic') state.hold = 'ready';
+    return this.start(key, state);
   }
 
   private start(
@@ -226,9 +229,9 @@ export class VmReconcileScheduler {
     const promise = (async () => {
       try {
         await this.run(key);
-        state.liveBlocked = false;
+        state.hold = 'ready';
       } catch (error) {
-        state.liveBlocked = true;
+        state.hold = 'live-blocked';
         try {
           this.onFailure(key, error);
         } catch {
@@ -237,23 +240,15 @@ export class VmReconcileScheduler {
       }
     })().finally(() => {
       state.inFlight = undefined;
-      const runPeriodic = state.pendingPeriodic;
-      const runLive = state.pendingLive;
-      state.pendingPeriodic = false;
-      state.pendingLive = false;
-
-      if (runPeriodic) {
-        state.liveBlocked = false;
-        void this.start(key, state);
-        return;
-      }
-      if (runLive && !state.liveBlocked) {
-        void this.start(key, state);
+      const queued = state.queued;
+      state.queued = null;
+      if (queued) {
+        void this.schedule(key, queued);
         return;
       }
       // Keep only failed keys so a later live nudge remains suppressed. A
       // periodic retry or successful run releases and removes the state.
-      if (!state.liveBlocked) this.states.delete(key);
+      if (state.hold === 'ready') this.states.delete(key);
     });
     state.inFlight = promise;
     return promise;

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -239,7 +239,7 @@ import {
 } from './agent-keystore.js';
 import { GossipPublishHandler } from './gossip-publish-handler.js';
 import { FinalizationHandler, KEEP_ROOT_COPY_PREDICATE } from './finalization-handler.js';
-import { reconcileContextGraph, ReconcileCoalescer, RecentUalSet, type ChainReconcilerDeps, type OrdinalOutcome } from './chain-reconciler.js';
+import { reconcileContextGraph, VmReconcileScheduler, RecentUalSet, type ChainReconcilerDeps, type OrdinalOutcome } from './chain-reconciler.js';
 import { createCursorState, type CursorState } from './reconcile-cursor.js';
 // rc.9 PR-10: JoinApprovalRetryQueue removed — substrate outbox
 // (durable, SQLite-backed) replaces it. We keep a minimal local
@@ -856,8 +856,8 @@ export class DKGAgentBase {
   protected swmCleanupTimer: ReturnType<typeof setInterval> | null = null;
   /** Phase B — periodic chain-driven VM reconciliation sweep timer. */
   protected vmReconcileTimer: ReturnType<typeof setInterval> | null = null;
-  /** Phase B — per-CG single-flight coalescer for reconcile sweeps. */
-  protected reconcileCoalescer?: ReconcileCoalescer;
+  /** Phase B — per-CG scheduler separating live nudges from periodic retries. */
+  protected vmReconcileScheduler?: VmReconcileScheduler;
   /** Phase B — in-memory reconcile cursor per local CG id (watermark + `ahead`). */
   protected readonly reconcileCursors = new Map<string, CursorState>();
   /** Phase B — bounded dedupe of recently-reconciled UALs (live-burst guard). */

--- a/packages/agent/src/dkg-agent-ccl.ts
+++ b/packages/agent/src/dkg-agent-ccl.ts
@@ -229,7 +229,7 @@ import {
 } from './agent-keystore.js';
 import { GossipPublishHandler } from './gossip-publish-handler.js';
 import { FinalizationHandler, KEEP_ROOT_COPY_PREDICATE } from './finalization-handler.js';
-import { reconcileContextGraph, ReconcileCoalescer, RecentUalSet, type ChainReconcilerDeps, type OrdinalOutcome } from './chain-reconciler.js';
+import { reconcileContextGraph, RecentUalSet, type ChainReconcilerDeps, type OrdinalOutcome } from './chain-reconciler.js';
 import { createCursorState, type CursorState } from './reconcile-cursor.js';
 // rc.9 PR-10: JoinApprovalRetryQueue removed — substrate outbox
 // (durable, SQLite-backed) replaces it. We keep a minimal local

--- a/packages/agent/src/dkg-agent-cg-registry.ts
+++ b/packages/agent/src/dkg-agent-cg-registry.ts
@@ -231,7 +231,7 @@ import {
 } from './agent-keystore.js';
 import { GossipPublishHandler } from './gossip-publish-handler.js';
 import { FinalizationHandler, KEEP_ROOT_COPY_PREDICATE } from './finalization-handler.js';
-import { reconcileContextGraph, ReconcileCoalescer, RecentUalSet, type ChainReconcilerDeps, type OrdinalOutcome } from './chain-reconciler.js';
+import { reconcileContextGraph, RecentUalSet, type ChainReconcilerDeps, type OrdinalOutcome } from './chain-reconciler.js';
 import { createCursorState, type CursorState } from './reconcile-cursor.js';
 // rc.9 PR-10: JoinApprovalRetryQueue removed — substrate outbox
 // (durable, SQLite-backed) replaces it. We keep a minimal local

--- a/packages/agent/src/dkg-agent-cg-resolve.ts
+++ b/packages/agent/src/dkg-agent-cg-resolve.ts
@@ -230,7 +230,7 @@ import {
 } from './agent-keystore.js';
 import { GossipPublishHandler } from './gossip-publish-handler.js';
 import { FinalizationHandler, KEEP_ROOT_COPY_PREDICATE } from './finalization-handler.js';
-import { reconcileContextGraph, ReconcileCoalescer, RecentUalSet, type ChainReconcilerDeps, type OrdinalOutcome } from './chain-reconciler.js';
+import { reconcileContextGraph, RecentUalSet, type ChainReconcilerDeps, type OrdinalOutcome } from './chain-reconciler.js';
 import { createCursorState, type CursorState } from './reconcile-cursor.js';
 // rc.9 PR-10: JoinApprovalRetryQueue removed — substrate outbox
 // (durable, SQLite-backed) replaces it. We keep a minimal local

--- a/packages/agent/src/dkg-agent-context-graph.ts
+++ b/packages/agent/src/dkg-agent-context-graph.ts
@@ -229,7 +229,7 @@ import {
 } from './agent-keystore.js';
 import { GossipPublishHandler } from './gossip-publish-handler.js';
 import { FinalizationHandler, KEEP_ROOT_COPY_PREDICATE } from './finalization-handler.js';
-import { reconcileContextGraph, ReconcileCoalescer, RecentUalSet, type ChainReconcilerDeps, type OrdinalOutcome } from './chain-reconciler.js';
+import { reconcileContextGraph, RecentUalSet, type ChainReconcilerDeps, type OrdinalOutcome } from './chain-reconciler.js';
 import { createCursorState, type CursorState } from './reconcile-cursor.js';
 // rc.9 PR-10: JoinApprovalRetryQueue removed — substrate outbox
 // (durable, SQLite-backed) replaces it. We keep a minimal local

--- a/packages/agent/src/dkg-agent-crypto.ts
+++ b/packages/agent/src/dkg-agent-crypto.ts
@@ -233,7 +233,7 @@ import {
 } from './agent-keystore.js';
 import { GossipPublishHandler } from './gossip-publish-handler.js';
 import { FinalizationHandler, KEEP_ROOT_COPY_PREDICATE } from './finalization-handler.js';
-import { reconcileContextGraph, ReconcileCoalescer, RecentUalSet, type ChainReconcilerDeps, type OrdinalOutcome } from './chain-reconciler.js';
+import { reconcileContextGraph, RecentUalSet, type ChainReconcilerDeps, type OrdinalOutcome } from './chain-reconciler.js';
 import { createCursorState, type CursorState } from './reconcile-cursor.js';
 // rc.9 PR-10: JoinApprovalRetryQueue removed — substrate outbox
 // (durable, SQLite-backed) replaces it. We keep a minimal local

--- a/packages/agent/src/dkg-agent-endorse.ts
+++ b/packages/agent/src/dkg-agent-endorse.ts
@@ -228,7 +228,7 @@ import {
 } from './agent-keystore.js';
 import { GossipPublishHandler } from './gossip-publish-handler.js';
 import { FinalizationHandler, KEEP_ROOT_COPY_PREDICATE } from './finalization-handler.js';
-import { reconcileContextGraph, ReconcileCoalescer, RecentUalSet, type ChainReconcilerDeps, type OrdinalOutcome } from './chain-reconciler.js';
+import { reconcileContextGraph, RecentUalSet, type ChainReconcilerDeps, type OrdinalOutcome } from './chain-reconciler.js';
 import { createCursorState, type CursorState } from './reconcile-cursor.js';
 // rc.9 PR-10: JoinApprovalRetryQueue removed — substrate outbox
 // (durable, SQLite-backed) replaces it. We keep a minimal local

--- a/packages/agent/src/dkg-agent-join.ts
+++ b/packages/agent/src/dkg-agent-join.ts
@@ -229,7 +229,7 @@ import {
 } from './agent-keystore.js';
 import { GossipPublishHandler } from './gossip-publish-handler.js';
 import { FinalizationHandler, KEEP_ROOT_COPY_PREDICATE } from './finalization-handler.js';
-import { reconcileContextGraph, ReconcileCoalescer, RecentUalSet, type ChainReconcilerDeps, type OrdinalOutcome } from './chain-reconciler.js';
+import { reconcileContextGraph, RecentUalSet, type ChainReconcilerDeps, type OrdinalOutcome } from './chain-reconciler.js';
 import { createCursorState, type CursorState } from './reconcile-cursor.js';
 // rc.9 PR-10: JoinApprovalRetryQueue removed — substrate outbox
 // (durable, SQLite-backed) replaces it. We keep a minimal local

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -257,7 +257,7 @@ import {
 } from './agent-keystore.js';
 import { GossipPublishHandler } from './gossip-publish-handler.js';
 import { FinalizationHandler, KEEP_ROOT_COPY_PREDICATE } from './finalization-handler.js';
-import { reconcileContextGraph, ReconcileCoalescer, RecentUalSet, type ChainReconcilerDeps, type OrdinalOutcome } from './chain-reconciler.js';
+import { reconcileContextGraph, VmReconcileScheduler, RecentUalSet, type ChainReconcilerDeps, type OrdinalOutcome } from './chain-reconciler.js';
 import { createCursorState, type CursorState } from './reconcile-cursor.js';
 import { resolveStorageAckLifecycleAssetUalFromLocalSwm } from './storage-ack-lifecycle-identity.js';
 // rc.9 PR-10: JoinApprovalRetryQueue removed — substrate outbox
@@ -2483,11 +2483,14 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     // catches up late subscribers (the "Monday Fun Facts" case). Only armed when
     // the chain adapter exposes the per-CG registration-ordinal reads.
     if (this.vmReconcileEnabled()) {
-      this.reconcileCoalescer = new ReconcileCoalescer(
+      this.vmReconcileScheduler = new VmReconcileScheduler(
         (localCgId) => this.runVmReconcileForCg(localCgId),
-        // A failed store/RPC sweep is retried by the periodic safety net. Live
-        // KACG nudges during the interval must not hot-loop the same heavy scan.
-        { failureBackoffMs: DKGAgentBase.VM_RECONCILE_SWEEP_INTERVAL_MS },
+        (localCgId, err) => {
+          this.log.warn(
+            ctx,
+            `VM reconcile for "${localCgId}" failed; retrying on the periodic sweep: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        },
       );
       const runSweep = (): void => {
         this.runVmReconcileSweep().catch((err: unknown) => {

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -2483,7 +2483,12 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     // catches up late subscribers (the "Monday Fun Facts" case). Only armed when
     // the chain adapter exposes the per-CG registration-ordinal reads.
     if (this.vmReconcileEnabled()) {
-      this.reconcileCoalescer = new ReconcileCoalescer((localCgId) => this.runVmReconcileForCg(localCgId));
+      this.reconcileCoalescer = new ReconcileCoalescer(
+        (localCgId) => this.runVmReconcileForCg(localCgId),
+        // A failed store/RPC sweep is retried by the periodic safety net. Live
+        // KACG nudges during the interval must not hot-loop the same heavy scan.
+        { failureBackoffMs: DKGAgentBase.VM_RECONCILE_SWEEP_INTERVAL_MS },
+      );
       const runSweep = (): void => {
         this.runVmReconcileSweep().catch((err: unknown) => {
           this.log.warn(ctx, `VM reconcile sweep failed: ${err instanceof Error ? err.message : String(err)}`);

--- a/packages/agent/src/dkg-agent-ownership.ts
+++ b/packages/agent/src/dkg-agent-ownership.ts
@@ -230,7 +230,7 @@ import {
 } from './agent-keystore.js';
 import { GossipPublishHandler } from './gossip-publish-handler.js';
 import { FinalizationHandler, KEEP_ROOT_COPY_PREDICATE } from './finalization-handler.js';
-import { reconcileContextGraph, ReconcileCoalescer, RecentUalSet, type ChainReconcilerDeps, type OrdinalOutcome } from './chain-reconciler.js';
+import { reconcileContextGraph, RecentUalSet, type ChainReconcilerDeps, type OrdinalOutcome } from './chain-reconciler.js';
 import { createCursorState, type CursorState } from './reconcile-cursor.js';
 // rc.9 PR-10: JoinApprovalRetryQueue removed — substrate outbox
 // (durable, SQLite-backed) replaces it. We keep a minimal local

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -253,7 +253,7 @@ import {
 } from './agent-keystore.js';
 import { GossipPublishHandler } from './gossip-publish-handler.js';
 import { FinalizationHandler, KEEP_ROOT_COPY_PREDICATE } from './finalization-handler.js';
-import { reconcileContextGraph, ReconcileCoalescer, RecentUalSet, type ChainReconcilerDeps, type OrdinalOutcome } from './chain-reconciler.js';
+import { reconcileContextGraph, RecentUalSet, type ChainReconcilerDeps, type OrdinalOutcome } from './chain-reconciler.js';
 import { createCursorState, type CursorState } from './reconcile-cursor.js';
 // rc.9 PR-10: JoinApprovalRetryQueue removed — substrate outbox
 // (durable, SQLite-backed) replaces it. We keep a minimal local

--- a/packages/agent/src/dkg-agent-query.ts
+++ b/packages/agent/src/dkg-agent-query.ts
@@ -228,7 +228,7 @@ import {
 } from './agent-keystore.js';
 import { GossipPublishHandler } from './gossip-publish-handler.js';
 import { FinalizationHandler, KEEP_ROOT_COPY_PREDICATE } from './finalization-handler.js';
-import { reconcileContextGraph, ReconcileCoalescer, RecentUalSet, type ChainReconcilerDeps, type OrdinalOutcome } from './chain-reconciler.js';
+import { reconcileContextGraph, RecentUalSet, type ChainReconcilerDeps, type OrdinalOutcome } from './chain-reconciler.js';
 import { createCursorState, type CursorState } from './reconcile-cursor.js';
 // rc.9 PR-10: JoinApprovalRetryQueue removed — substrate outbox
 // (durable, SQLite-backed) replaces it. We keep a minimal local

--- a/packages/agent/src/dkg-agent-registry.ts
+++ b/packages/agent/src/dkg-agent-registry.ts
@@ -239,7 +239,7 @@ import {
 } from './agent-keystore.js';
 import { GossipPublishHandler } from './gossip-publish-handler.js';
 import { FinalizationHandler, KEEP_ROOT_COPY_PREDICATE } from './finalization-handler.js';
-import { reconcileContextGraph, ReconcileCoalescer, RecentUalSet, type ChainReconcilerDeps, type OrdinalOutcome } from './chain-reconciler.js';
+import { reconcileContextGraph, RecentUalSet, type ChainReconcilerDeps, type OrdinalOutcome } from './chain-reconciler.js';
 import { createCursorState, type CursorState } from './reconcile-cursor.js';
 // rc.9 PR-10: JoinApprovalRetryQueue removed — substrate outbox
 // (durable, SQLite-backed) replaces it. We keep a minimal local

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -2417,7 +2417,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
     );
     // Nudge a reconcile now so the first hosted publish lands promptly; the
     // periodic sweep is the safety net.
-    if (this.reconcileCoalescer) void this.reconcileCoalescer.trigger(localCgId);
+    if (this.vmReconcileScheduler) void this.vmReconcileScheduler.triggerLive(localCgId);
   }
 
   trackCoreHostRecording(this: DKGAgent, start: () => Promise<void>): void {
@@ -2523,11 +2523,11 @@ export class SwmHostModeMethods extends DKGAgentBase {
   /**
    * Trigger a coalesced reconcile sweep for every subscribed CG that has an
    * on-chain id. Used by the periodic timer + the startup prime. Per-CG work is
-   * single-flighted by {@link reconcileCoalescer} so overlapping ticks (or a
+   * single-flighted by {@link vmReconcileScheduler} so overlapping ticks (or a
    * burst of live nudges) collapse into one sweep per CG.
    */
   async runVmReconcileSweep(this: DKGAgent): Promise<void> {
-    if (!this.vmReconcileEnabled() || !this.reconcileCoalescer) return;
+    if (!this.vmReconcileEnabled() || !this.vmReconcileScheduler) return;
     for (const [localCgId, sub] of this.subscribedContextGraphs) {
       // GH #1098 — self-prime onChainId for a pre-subscribed PUBLIC member CG
       // (subscribed BEFORE its first publish, so unbound) before the skip-gate
@@ -2537,7 +2537,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
       }
       // Member subscriptions AND Phase D core-hosted public CGs get swept.
       if ((!sub.subscribed && !sub.coreHosted) || !sub.onChainId) continue;
-      void this.reconcileCoalescer.trigger(localCgId);
+      void this.vmReconcileScheduler.triggerPeriodic(localCgId);
       // RS heal: relocate any legacy-stranded KC into the scoped graphs the
       // prover reads (the sweep is the safety net for a missed live nudge).
       void this.healStrandedScopedKCs(localCgId, sub);
@@ -2622,7 +2622,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
           const bound = await this.selfPrimeSubscriptionOnChainId(lcg, sub, targetOnChain);
           if (bound) {
             this.log.info(ctx, `Phase B: KACG nudge cg=${onChainId} ka=${kaId} -> bound + reconcile pre-subscribed "${lcg}"`);
-            if (this.reconcileCoalescer) void this.reconcileCoalescer.trigger(lcg);
+            if (this.vmReconcileScheduler) void this.vmReconcileScheduler.triggerLive(lcg);
             // RS heal immediately so a live KARegistered doesn't wait ~60s for
             // the periodic sweep to relocate the stranded KC.
             void this.healStrandedScopedKCs(lcg, sub);
@@ -2638,7 +2638,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
     // Core hosts — a hosted Core fills its own gaps too.
     if (!sub?.subscribed && !sub?.coreHosted) return null;
     this.log.info(ctx, `Phase B: KACG nudge cg=${onChainId} ka=${kaId} -> reconcile "${localCgId}"`);
-    if (this.reconcileCoalescer) void this.reconcileCoalescer.trigger(localCgId);
+    if (this.vmReconcileScheduler) void this.vmReconcileScheduler.triggerLive(localCgId);
     // RS heal immediately on the already-bound path too.
     void this.healStrandedScopedKCs(localCgId, sub);
     return localCgId;
@@ -2690,41 +2690,30 @@ export class SwmHostModeMethods extends DKGAgentBase {
       log: (msg) => this.log.info(createOperationContext('system'), msg),
     };
 
-    try {
-      const result = await reconcileContextGraph(deps, cursor, localCgId, onChainCgId);
-      if (result.reconciled > 0 || result.pending > 0) {
-        this.emitReplication({
-          contextGraphId: localCgId,
-          onChainCgId: sub.onChainId,
-          action: 'sweep',
-          head: result.head,
-          toWatermark: result.watermark,
-          reconciled: result.reconciled,
-          pending: result.pending,
-        });
-      }
-      // Phase D — a host-only (non-member) reconcile that actually promoted KAs
-      // is a Core filling its own gap. Distinct telemetry so operators can see
-      // the Core-to-Core fill path working (success-criteria metric).
-      if (result.reconciled > 0 && sub.coreHosted && !sub.subscribed) {
-        this.emitReplication({
-          contextGraphId: localCgId,
-          onChainCgId: sub.onChainId,
-          action: 'core-fill',
-          head: result.head,
-          toWatermark: result.watermark,
-          reconciled: result.reconciled,
-        });
-      }
-    } catch (err) {
-      this.log.warn(
-        createOperationContext('system'),
-        `VM reconcile for "${localCgId}" failed; retrying on the periodic sweep: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      // Let ReconcileCoalescer distinguish a failed pass from a clean one so it
-      // can suppress the immediate trailing/live-nudge retry. The coalescer
-      // still resolves its public trigger promise after recording the cooldown.
-      throw err;
+    const result = await reconcileContextGraph(deps, cursor, localCgId, onChainCgId);
+    if (result.reconciled > 0 || result.pending > 0) {
+      this.emitReplication({
+        contextGraphId: localCgId,
+        onChainCgId: sub.onChainId,
+        action: 'sweep',
+        head: result.head,
+        toWatermark: result.watermark,
+        reconciled: result.reconciled,
+        pending: result.pending,
+      });
+    }
+    // Phase D — a host-only (non-member) reconcile that actually promoted KAs
+    // is a Core filling its own gap. Distinct telemetry so operators can see
+    // the Core-to-Core fill path working (success-criteria metric).
+    if (result.reconciled > 0 && sub.coreHosted && !sub.subscribed) {
+      this.emitReplication({
+        contextGraphId: localCgId,
+        onChainCgId: sub.onChainId,
+        action: 'core-fill',
+        head: result.head,
+        toWatermark: result.watermark,
+        reconciled: result.reconciled,
+      });
     }
   }
 

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -232,7 +232,7 @@ import {
 } from './agent-keystore.js';
 import { GossipPublishHandler } from './gossip-publish-handler.js';
 import { FinalizationHandler, KEEP_ROOT_COPY_PREDICATE } from './finalization-handler.js';
-import { reconcileContextGraph, ReconcileCoalescer, RecentUalSet, type ChainReconcilerDeps, type OrdinalOutcome } from './chain-reconciler.js';
+import { reconcileContextGraph, RecentUalSet, type ChainReconcilerDeps, type OrdinalOutcome } from './chain-reconciler.js';
 import { createCursorState, type CursorState } from './reconcile-cursor.js';
 // rc.9 PR-10: JoinApprovalRetryQueue removed — substrate outbox
 // (durable, SQLite-backed) replaces it. We keep a minimal local

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -2719,8 +2719,12 @@ export class SwmHostModeMethods extends DKGAgentBase {
     } catch (err) {
       this.log.warn(
         createOperationContext('system'),
-        `VM reconcile for "${localCgId}" failed: ${err instanceof Error ? err.message : String(err)}`,
+        `VM reconcile for "${localCgId}" failed; retrying on the periodic sweep: ${err instanceof Error ? err.message : String(err)}`,
       );
+      // Let ReconcileCoalescer distinguish a failed pass from a clean one so it
+      // can suppress the immediate trailing/live-nudge retry. The coalescer
+      // still resolves its public trigger promise after recording the cooldown.
+      throw err;
     }
   }
 

--- a/packages/agent/src/dkg-agent-swm-substrate.ts
+++ b/packages/agent/src/dkg-agent-swm-substrate.ts
@@ -238,7 +238,7 @@ import {
 } from './agent-keystore.js';
 import { GossipPublishHandler } from './gossip-publish-handler.js';
 import { FinalizationHandler, KEEP_ROOT_COPY_PREDICATE } from './finalization-handler.js';
-import { reconcileContextGraph, ReconcileCoalescer, RecentUalSet, type ChainReconcilerDeps, type OrdinalOutcome } from './chain-reconciler.js';
+import { reconcileContextGraph, RecentUalSet, type ChainReconcilerDeps, type OrdinalOutcome } from './chain-reconciler.js';
 import { createCursorState, type CursorState } from './reconcile-cursor.js';
 // rc.9 PR-10: JoinApprovalRetryQueue removed — substrate outbox
 // (durable, SQLite-backed) replaces it. We keep a minimal local

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -230,7 +230,7 @@ import {
 } from './agent-keystore.js';
 import { GossipPublishHandler } from './gossip-publish-handler.js';
 import { FinalizationHandler, KEEP_ROOT_COPY_PREDICATE } from './finalization-handler.js';
-import { reconcileContextGraph, ReconcileCoalescer, RecentUalSet, type ChainReconcilerDeps, type OrdinalOutcome } from './chain-reconciler.js';
+import { reconcileContextGraph, RecentUalSet, type ChainReconcilerDeps, type OrdinalOutcome } from './chain-reconciler.js';
 import { createCursorState, type CursorState } from './reconcile-cursor.js';
 // rc.9 PR-10: JoinApprovalRetryQueue removed — substrate outbox
 // (durable, SQLite-backed) replaces it. We keep a minimal local

--- a/packages/agent/test/chain-reconciler.test.ts
+++ b/packages/agent/test/chain-reconciler.test.ts
@@ -225,6 +225,51 @@ describe('VmReconcileScheduler', () => {
     resolveCurrent();
     await retry;
   });
+
+  it('preserves a periodic retry queued behind a failing live pass', async () => {
+    let runs = 0;
+    let resolveCurrent!: () => void;
+    let rejectCurrent!: (error: Error) => void;
+    const scheduler = new VmReconcileScheduler(
+      async () => {
+        runs += 1;
+        await new Promise<void>((resolve, reject) => {
+          resolveCurrent = resolve;
+          rejectCurrent = reject;
+        });
+      },
+      () => undefined,
+    );
+
+    const first = scheduler.triggerLive('cg');
+    void scheduler.triggerPeriodic('cg');
+    rejectCurrent(new Error('store deadline exceeded'));
+    await first;
+
+    expect(runs).toBe(2); // queued periodic pass starts despite the live failure hold
+    resolveCurrent();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(scheduler.isInFlight('cg')).toBe(false);
+  });
+
+  it('isolates the live failure hold per context graph', async () => {
+    const ran: string[] = [];
+    const failures: string[] = [];
+    const scheduler = new VmReconcileScheduler(
+      async (key) => {
+        ran.push(key);
+        if (key === 'cg-a') throw new Error('cg-a unavailable');
+      },
+      (key) => failures.push(key),
+    );
+
+    await scheduler.triggerLive('cg-a');
+    await scheduler.triggerLive('cg-a'); // held after failure
+    await scheduler.triggerLive('cg-b'); // unrelated CG still runs immediately
+
+    expect(ran).toEqual(['cg-a', 'cg-b']);
+    expect(failures).toEqual(['cg-a']);
+  });
 });
 
 describe('RecentUalSet', () => {

--- a/packages/agent/test/chain-reconciler.test.ts
+++ b/packages/agent/test/chain-reconciler.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   reconcileContextGraph,
   ReconcileCoalescer,
+  VmReconcileScheduler,
   RecentUalSet,
   type ChainReconcilerDeps,
   type OrdinalOutcome,
@@ -188,33 +189,40 @@ describe('ReconcileCoalescer', () => {
     await Promise.all([coalescer.trigger('a'), coalescer.trigger('b')]);
     expect(ran.sort()).toEqual(['a', 'b']);
   });
+});
 
-  it('backs off a failed key and suppresses its queued trailing run', async () => {
-    let now = 1_000;
+describe('VmReconcileScheduler', () => {
+  it('suppresses queued/live retries after failure but retries on the periodic path', async () => {
     let runs = 0;
+    const failures: Array<{ key: string; error: unknown }> = [];
+    let resolveCurrent!: () => void;
     let rejectCurrent!: (error: Error) => void;
-    const coalescer = new ReconcileCoalescer(
+    const scheduler = new VmReconcileScheduler(
       async () => {
         runs += 1;
-        await new Promise<void>((_resolve, reject) => { rejectCurrent = reject; });
+        await new Promise<void>((resolve, reject) => {
+          resolveCurrent = resolve;
+          rejectCurrent = reject;
+        });
       },
-      { failureBackoffMs: 60_000, now: () => now },
+      (key, error) => failures.push({ key, error }),
     );
 
-    const first = coalescer.trigger('cg');
-    void coalescer.trigger('cg'); // asks for a trailing run while the first is active
-    rejectCurrent(new Error('store deadline exceeded'));
+    const failure = new Error('store deadline exceeded');
+    const first = scheduler.triggerLive('cg');
+    void scheduler.triggerLive('cg'); // queues one trailing pass while active
+    rejectCurrent(failure);
     await first;
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(runs).toBe(1); // failed pass does not immediately run the queued pass
+    expect(failures).toEqual([{ key: 'cg', error: failure }]);
 
-    await coalescer.trigger('cg');
-    expect(runs).toBe(1); // live nudge inside the cooldown is ignored
+    await scheduler.triggerLive('cg');
+    expect(runs).toBe(1); // live nudge during the failure hold is ignored
 
-    now += 60_000;
-    const retry = coalescer.trigger('cg');
-    expect(runs).toBe(2); // periodic trigger at the boundary retries normally
-    rejectCurrent(new Error('still unavailable'));
+    const retry = scheduler.triggerPeriodic('cg');
+    expect(runs).toBe(2); // the periodic reliability path retries normally
+    resolveCurrent();
     await retry;
   });
 });

--- a/packages/agent/test/chain-reconciler.test.ts
+++ b/packages/agent/test/chain-reconciler.test.ts
@@ -188,6 +188,35 @@ describe('ReconcileCoalescer', () => {
     await Promise.all([coalescer.trigger('a'), coalescer.trigger('b')]);
     expect(ran.sort()).toEqual(['a', 'b']);
   });
+
+  it('backs off a failed key and suppresses its queued trailing run', async () => {
+    let now = 1_000;
+    let runs = 0;
+    let rejectCurrent!: (error: Error) => void;
+    const coalescer = new ReconcileCoalescer(
+      async () => {
+        runs += 1;
+        await new Promise<void>((_resolve, reject) => { rejectCurrent = reject; });
+      },
+      { failureBackoffMs: 60_000, now: () => now },
+    );
+
+    const first = coalescer.trigger('cg');
+    void coalescer.trigger('cg'); // asks for a trailing run while the first is active
+    rejectCurrent(new Error('store deadline exceeded'));
+    await first;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(runs).toBe(1); // failed pass does not immediately run the queued pass
+
+    await coalescer.trigger('cg');
+    expect(runs).toBe(1); // live nudge inside the cooldown is ignored
+
+    now += 60_000;
+    const retry = coalescer.trigger('cg');
+    expect(runs).toBe(2); // periodic trigger at the boundary retries normally
+    rejectCurrent(new Error('still unavailable'));
+    await retry;
+  });
 });
 
 describe('RecentUalSet', () => {

--- a/packages/agent/test/chain-reconciler.test.ts
+++ b/packages/agent/test/chain-reconciler.test.ts
@@ -153,6 +153,36 @@ describe('reconcileContextGraph — sweep', () => {
 });
 
 describe('VmReconcileScheduler', () => {
+  it('collapses a successful live burst into one run plus one trailing run', async () => {
+    let runs = 0;
+    let resolveCurrent!: () => void;
+    const scheduler = new VmReconcileScheduler(
+      async () => {
+        runs += 1;
+        await new Promise<void>((resolve) => {
+          resolveCurrent = resolve;
+        });
+      },
+      () => undefined,
+    );
+
+    const first = scheduler.triggerLive('cg');
+    void scheduler.triggerLive('cg');
+    void scheduler.triggerLive('cg');
+    void scheduler.triggerLive('cg');
+    expect(runs).toBe(1);
+
+    resolveCurrent();
+    await first;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(runs).toBe(2);
+
+    resolveCurrent();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(runs).toBe(2);
+    expect(scheduler.isInFlight('cg')).toBe(false);
+  });
+
   it('suppresses queued/live retries after failure but retries on the periodic path', async () => {
     let runs = 0;
     const failures: Array<{ key: string; error: unknown }> = [];

--- a/packages/agent/test/chain-reconciler.test.ts
+++ b/packages/agent/test/chain-reconciler.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
   reconcileContextGraph,
-  ReconcileCoalescer,
   VmReconcileScheduler,
   RecentUalSet,
   type ChainReconcilerDeps,
@@ -13,7 +12,7 @@ import { createCursorState } from '../src/reconcile-cursor.js';
  * Phase B — sweep + cursor orchestration (B.2/B.4). The cursor math itself is
  * covered by reconcile-cursor.test.ts; here we pin the sweep driver:
  * gap-fill, watermark-persist-only-on-move, reorg depth, pending-retry, plus
- * the coalescer and UAL dedupe.
+ * the VM scheduler and UAL dedupe.
  */
 
 function makeDeps(overrides: Partial<ChainReconcilerDeps> = {}): {
@@ -153,44 +152,6 @@ describe('reconcileContextGraph — sweep', () => {
   });
 });
 
-describe('ReconcileCoalescer', () => {
-  it('collapses a burst into one run plus a single trailing run', async () => {
-    let runs = 0;
-    let resolveCurrent!: () => void;
-    const coalescer = new ReconcileCoalescer(async () => {
-      runs += 1;
-      await new Promise<void>((r) => { resolveCurrent = r; });
-    });
-
-    // First trigger starts a run (now in flight, awaiting resolveCurrent).
-    void coalescer.trigger('cg');
-    // 4 more triggers while in flight → mark "again", do NOT start new runs.
-    void coalescer.trigger('cg');
-    void coalescer.trigger('cg');
-    void coalescer.trigger('cg');
-    void coalescer.trigger('cg');
-    expect(runs).toBe(1);
-
-    // Finish the first run → exactly one trailing run starts.
-    const r1 = resolveCurrent;
-    r1();
-    await new Promise((r) => setTimeout(r, 0));
-    expect(runs).toBe(2);
-
-    // Finish the trailing run → no further runs (no triggers landed during it).
-    resolveCurrent();
-    await new Promise((r) => setTimeout(r, 0));
-    expect(runs).toBe(2);
-  });
-
-  it('runs independently per key', async () => {
-    const ran: string[] = [];
-    const coalescer = new ReconcileCoalescer(async (key) => { ran.push(key); });
-    await Promise.all([coalescer.trigger('a'), coalescer.trigger('b')]);
-    expect(ran.sort()).toEqual(['a', 'b']);
-  });
-});
-
 describe('VmReconcileScheduler', () => {
   it('suppresses queued/live retries after failure but retries on the periodic path', async () => {
     let runs = 0;
@@ -224,6 +185,11 @@ describe('VmReconcileScheduler', () => {
     expect(runs).toBe(2); // the periodic reliability path retries normally
     resolveCurrent();
     await retry;
+
+    const resumedLive = scheduler.triggerLive('cg');
+    expect(runs).toBe(3); // successful periodic recovery releases the live hold
+    resolveCurrent();
+    await resumedLive;
   });
 
   it('preserves a periodic retry queued behind a failing live pass', async () => {

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -55,7 +55,10 @@ interface AgentInternals {
   runVmReconcileForCg(localCgId: string): Promise<void>;
   runVmReconcileSweep(): Promise<void>;
   subscribedContextGraphs: Map<string, { subscribed: boolean; coreHosted?: boolean; onChainId?: string; lastReconciledOrdinal?: number }>;
-  reconcileCoalescer: { trigger: (cg: string) => void } | null;
+  vmReconcileScheduler: {
+    triggerLive: (cg: string) => void;
+    triggerPeriodic: (cg: string) => void;
+  } | null;
   store: TripleStore;
   chain: MockChainAdapter & {
     getContextGraphAccessPolicy?: (id: bigint) => Promise<number>;
@@ -1635,13 +1638,18 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     internals.subscribedContextGraphs.set('100', { subscribed: false, coreHosted: true, onChainId: '100' });
     internals.subscribedContextGraphs.set('200', { subscribed: false, onChainId: '200' }); // neither subscribed nor hosted
 
-    const triggered: string[] = [];
-    internals.reconcileCoalescer = { trigger: (cg: string) => { triggered.push(cg); } };
+    const liveTriggered: string[] = [];
+    const periodicTriggered: string[] = [];
+    internals.vmReconcileScheduler = {
+      triggerLive: (cg: string) => { liveTriggered.push(cg); },
+      triggerPeriodic: (cg: string) => { periodicTriggered.push(cg); },
+    };
 
     await internals.runVmReconcileSweep();
 
-    expect(triggered).toContain('100');     // hosted → swept
-    expect(triggered).not.toContain('200'); // neither → skipped
+    expect(periodicTriggered).toContain('100');     // hosted → swept
+    expect(periodicTriggered).not.toContain('200'); // neither → skipped
+    expect(liveTriggered).toEqual([]);
   });
 
   it('a host-only reconcile promotes the missed KA to VM and emits core-fill', async () => {
@@ -1685,5 +1693,23 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     expect(coreFill).toBeDefined();
     expect(coreFill?.reconciled).toBe(1);
     expect(coreFill?.contextGraphId).toBe(localCgId);
+  });
+
+  it('surfaces a production chain failure from runVmReconcileForCg to its scheduler', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'CoreFillFailure', chainAdapter: chain });
+    stubNode(agent);
+    const internals = agent as unknown as AgentInternals;
+    const failure = new Error('store deadline exceeded');
+
+    internals.subscribedContextGraphs.set('500', {
+      subscribed: true,
+      onChainId: '500',
+    });
+    chain.getContextGraphKCCount = async () => {
+      throw failure;
+    };
+
+    await expect(internals.runVmReconcileForCg('500')).rejects.toBe(failure);
   });
 });

--- a/packages/agent/test/vm-reconcile-self-prime.test.ts
+++ b/packages/agent/test/vm-reconcile-self-prime.test.ts
@@ -30,7 +30,10 @@ interface AgentInternals {
   ): Promise<string | null>;
   handleKARegisteredNudge(onChainId: string, kaId: bigint, ctx: unknown): Promise<string | null>;
   subscribedContextGraphs: Map<string, { subscribed: boolean; coreHosted?: boolean; onChainId?: string }>;
-  reconcileCoalescer: { trigger: (cg: string) => void } | null;
+  vmReconcileScheduler: {
+    triggerLive: (cg: string) => void;
+    triggerPeriodic: (cg: string) => void;
+  } | null;
   store: TripleStore;
 }
 
@@ -72,7 +75,10 @@ describe('GH #1098 — VM reconcile sweep self-primes onChainId for a pre-subscr
     internals.subscribedContextGraphs.set(LOCAL, { subscribed: true });
 
     const triggered: string[] = [];
-    internals.reconcileCoalescer = { trigger: (cg: string) => { triggered.push(cg); } };
+    internals.vmReconcileScheduler = {
+      triggerLive: (cg: string) => { triggered.push(`live:${cg}`); },
+      triggerPeriodic: (cg: string) => { triggered.push(`periodic:${cg}`); },
+    };
 
     // Precondition: unbound before the sweep (so the assertion below is meaningful).
     expect(internals.subscribedContextGraphs.get(LOCAL)?.onChainId).toBeUndefined();
@@ -82,7 +88,7 @@ describe('GH #1098 — VM reconcile sweep self-primes onChainId for a pre-subscr
     // Post-fix: the sweep self-primed onChainId from the ontology quad and then
     // — no longer skipped by the `!onChainId` guard — triggered its reconcile.
     expect(internals.subscribedContextGraphs.get(LOCAL)?.onChainId).toBe(ONCHAIN);
-    expect(triggered).toContain(LOCAL);
+    expect(triggered).toEqual([`periodic:${LOCAL}`]);
   });
 
   it('KACG nudge targeting: binds ONLY the unbound CG whose on-chain id matches the event, not an unrelated one', async () => {
@@ -147,7 +153,10 @@ describe('GH #1098 — VM reconcile sweep self-primes onChainId for a pre-subscr
     internals.subscribedContextGraphs.set(CG_MISS_B, { subscribed: true });
 
     const triggered: string[] = [];
-    internals.reconcileCoalescer = { trigger: (cg: string) => { triggered.push(cg); } };
+    internals.vmReconcileScheduler = {
+      triggerLive: (cg: string) => { triggered.push(`live:${cg}`); },
+      triggerPeriodic: (cg: string) => { triggered.push(`periodic:${cg}`); },
+    };
 
     // The event names ON_HIT's on-chain id. None is bound yet.
     const reconciled = await internals.handleKARegisteredNudge(ON_HIT, 99n, createOperationContext('system'));
@@ -157,7 +166,7 @@ describe('GH #1098 — VM reconcile sweep self-primes onChainId for a pre-subscr
     // The other two pre-subscribed CGs were NOT bound and NOT reconciled.
     expect(internals.subscribedContextGraphs.get(CG_MISS_A)?.onChainId).toBeUndefined();
     expect(internals.subscribedContextGraphs.get(CG_MISS_B)?.onChainId).toBeUndefined();
-    expect(triggered).toEqual([CG_HIT]);
+    expect(triggered).toEqual([`live:${CG_HIT}`]);
   });
 
   it('live KACG nudge handler: an already-bound CG reconciles directly without a self-prime scan', async () => {
@@ -174,10 +183,13 @@ describe('GH #1098 — VM reconcile sweep self-primes onChainId for a pre-subscr
     internals.subscribedContextGraphs.set(CG_BOUND, { subscribed: true, onChainId: ON_BOUND });
 
     const triggered: string[] = [];
-    internals.reconcileCoalescer = { trigger: (cg: string) => { triggered.push(cg); } };
+    internals.vmReconcileScheduler = {
+      triggerLive: (cg: string) => { triggered.push(`live:${cg}`); },
+      triggerPeriodic: (cg: string) => { triggered.push(`periodic:${cg}`); },
+    };
 
     const reconciled = await internals.handleKARegisteredNudge(ON_BOUND, 1n, createOperationContext('system'));
     expect(reconciled).toBe(CG_BOUND);
-    expect(triggered).toEqual([CG_BOUND]);
+    expect(triggered).toEqual([`live:${CG_BOUND}`]);
   });
 });


### PR DESCRIPTION
## Summary

- let failed VM reconcile passes reach the per-CG coalescer after they are logged
- suppress queued/live-nudge retries for one configured sweep interval after a failure
- retain immediate coalescing and trailing runs for successful reconciliation
- add deterministic coverage for failure cooldown and retry at the boundary

## Mainnet evidence

10.0.6 cores repeatedly report 30-second Blazegraph deadlines while reconciling the same on-chain graphs (`foodie-network` on Gnosis and `sports` on Base). Several nodes produced roughly 15 VM timeout warnings in a 15-minute sample.

`runVmReconcileForCg` currently catches the timeout and resolves normally. The coalescer therefore cannot distinguish failure from success: a KACG event queued during the expensive scan immediately launches the trailing scan, and later live events can keep retriggering it despite the periodic safety net.

After this change, a failed CG is cooled down for `DKG_VM_RECONCILE_INTERVAL_MS` (10 minutes on the inspected mainnet units). The periodic sweep retries when that window expires. Successful live-event reconciliation is unchanged and remains immediate.

This is orchestration-only: it does not delete subscriptions or graph data and does not advance a failed reconciliation cursor.

## Verification

- `pnpm --filter @origintrail-official/dkg-agent exec vitest run --config vitest.unit.config.ts test/chain-reconciler.test.ts`
- `pnpm --filter @origintrail-official/dkg-agent exec tsc --noEmit`
- `pnpm --filter @origintrail-official/dkg-agent test:unit` (52 files, 593 tests)
