### PR TITLE
fix(pca): allow registered agents to register PCA-backed context graphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the DKG V10 node are documented here. The format is based
 
 ## [Unreleased]
 
+### Fixed
+
+- **PCA agents can register PCA-backed Context Graphs:** the agent, CLI/API, and MCP surfaces now match the deployed contract by allowing either the PCA owner or a wallet registered to that exact PCA to register a curated Context Graph. Eligible registrations consume a quota-backed deposit waiver instead of requiring a separate liquid-TRAC deposit; exact-account authorization and Context Graph NFT ownership alignment remain fail-closed.
+
 ## [10.0.6] - 2026-07-13
 
 Mainnet-readiness and high-load hardening on top of 10.0.5. Adds the OT-RFC-59 changelog-backed verified delta-sync lane, eliminates several store and reconciliation full-scan paths, bounds sync, StorageACK, outbox, managed-Oxigraph, and auto-update resource usage, and hardens publish recovery across transient quorum, RPC-throttle, funding, and receipt-timeout failures. Also completes the StorageACK priority-lane follow-ups, makes RDF handling safe for control characters and non-ASCII backends, and preserves the `oxigraph-worker` backend after its proposed retirement was reverted. **No smart-contract changes — no deployment required** (no Solidity source, ABI, or mainnet/testnet deployment-registry changes since 10.0.5).

--- a/docs/how-dkg-works/conviction-and-economics.md
+++ b/docs/how-dkg-works/conviction-and-economics.md
@@ -71,7 +71,9 @@ PCA can be attached to curated Context Graph registration through `pcaAccountId`
 dkg context-graph register <id> --publish-policy 0 --pca-account-id <accountId>
 ```
 
-The daemon preflights ownership so a local curator cannot claim someone else's PCA. `pcaAccountId` is valid only for curated publish policy.
+The daemon preflights authorization so a local curator cannot claim someone else's PCA. `pcaAccountId` is valid only for curated publish policy. The registration signer must own the PCA or be registered as an agent of that exact account, and the local curator must match the signer because the signer receives the Context Graph NFT. The PCA owner remains the graph's live publish authority.
+
+An eligible active PCA can waive the liquid-TRAC Context Graph registration deposit for its owner or registered agents. Each registration consumes one bounded waiver slot (`committedTRAC / registrationDeposit`); it does not debit the PCA commitment. The signer always pays native gas, and the normal liquid-TRAC deposit applies when any waiver condition is not met.
 
 ## Protocol Treasury Fee
 

--- a/docs/use-dkg/publishing-conviction.md
+++ b/docs/use-dkg/publishing-conviction.md
@@ -70,7 +70,11 @@ Attach a PCA to curated Context Graph registration with `--pca-account-id`:
 dkg context-graph register <contextGraphId> --publish-policy 0 --pca-account-id <accountId>
 ```
 
-`pcaAccountId` is valid only for curated publish policy. The daemon checks that the local curator matches the PCA owner before registering the Context Graph with the PCA.
+`pcaAccountId` is valid only for curated publish policy. The registration transaction signer may be either the PCA owner or a wallet currently registered to that exact PCA. The daemon verifies the exact account binding and requires the local curator to match the signer, because that signer receives the Context Graph NFT. The PCA owner remains the live publish authority.
+
+When the PCA is active, meets the governance commitment floor, and still has quota, registration consumes one quota-backed waiver instead of pulling the separate liquid-TRAC registration deposit. The signer still needs native gas. Waiver quota is `committedTRAC / contextGraphRegistrationDeposit`; using a slot does not debit or unlock the PCA's committed TRAC.
+
+The same flow is available through `POST /api/context-graph/register` with `publishPolicy: 0` and `pcaAccountId`, and through MCP with `dkg_context_graph_register`.
 
 ## API Routes
 

--- a/packages/agent/src/dkg-agent-context-graph.ts
+++ b/packages/agent/src/dkg-agent-context-graph.ts
@@ -838,7 +838,9 @@ export class ContextGraphMethods extends DKGAgentBase {
   /**
    * Register an existing context graph on-chain. This is the explicit upgrade
    * step that unlocks Verifiable Memory, chain-based discovery, and economic
-   * participation. Requires a funded wallet with TRAC.
+   * participation. Requires native gas. Direct registration also requires the
+   * configured TRAC deposit; an eligible PCA-backed registration consumes one
+   * quota-backed waiver instead.
    */
   async registerContextGraph(this: DKGAgent, id: string, opts?: {
     /** @deprecated V10 ContextGraphs registration ignores metadata reveal. */
@@ -1226,27 +1228,60 @@ export class ContextGraphMethods extends DKGAgentBase {
       } else {
         publishAuthority = await this.getChainPublishAuthorityAddress(id);
       }
-      // Uniform strict check across EOA and PCA modes:
-      //  - EOA: publishAuthority is the chain signer; local curator
-      //    must equal the chain signer — UNLESS the EOA mismatch
-      //    auto-promotion below relaxes it.
-      //  - PCA: publishAuthority is ownerOf(pcaAccountId); local curator
-      //    must equal the PCA owner. Registered agents are publish-time
-      //    delegates only — publish-time authorization lives on chain in
-      //    `ContextGraphs.isAuthorizedPublisher`.
-      if (publishAuthority && ownerAddress.toLowerCase() !== publishAuthority.toLowerCase()) {
-        if (isPcaCurated) {
-          // PCA mode stays strict: `ContextGraphs.createContextGraph`
-          // mints the governance NFT to msg.sender (= chain signer),
-          // and a mismatch would silently produce a CG whose
-          // on-chain owner is NOT the advertised PCA owner.
-          // Relaxing this would let users create CGs they cannot
-          // govern. The PCA owner must control the chain signer.
+      // PCA registration mirrors the post-#1366 on-chain authorization:
+      // either the PCA owner OR a wallet registered to this exact PCA may
+      // create the CG. Keep the local curator and registration-tx signer
+      // identical in both modes so the local owner and the Context Graph NFT
+      // owner cannot silently diverge:
+      //
+      //   owner mode: local curator == tx signer == PCA owner
+      //   agent mode: local curator == tx signer == registered PCA agent
+      //
+      // The advertised publishAuthority remains the live PCA owner in both
+      // modes, as required by ContextGraphs._validatePCACoherence. In agent
+      // mode the registered agent owns the newly minted CG NFT while the PCA
+      // owner and every registered PCA agent remain authorized publishers.
+      if (isPcaCurated && publishAuthority) {
+        const chainSigner = await this.getRegistrationTxSignerAddress();
+        if (!chainSigner) {
           throw new Error(
-            `Context graph "${id}" cannot be registered as curated by local curator ${ownerAddress} because ` +
-            `PCA account ${publishAuthorityAccountId} is owned by ${publishAuthority}; only the PCA owner can register, registered agents may only publish.`,
+            `Context graph "${id}" cannot be PCA-registered: the chain adapter does not expose its registration-tx signer, so PCA owner/agent authorization cannot be verified. PCA mode requires a chain adapter that surfaces its signer (e.g. via \`signerAddress\` / \`getSignerAddress()\` / \`getOperationalPrivateKey()\`).`,
           );
         }
+
+        const normalizedChainSigner = ethers.getAddress(chainSigner);
+        const signerIsOwner = normalizedChainSigner.toLowerCase() === publishAuthority.toLowerCase();
+        if (ownerAddress.toLowerCase() !== normalizedChainSigner.toLowerCase()) {
+          throw new Error(
+            `Context graph "${id}" cannot be PCA-registered: local curator ${ownerAddress} differs from registration chain signer ${normalizedChainSigner}. The local curator must control the wallet that will own the on-chain Context Graph NFT.`,
+          );
+        }
+
+        if (!signerIsOwner) {
+          if (typeof this.chain.getConvictionAgentAccountId !== 'function') {
+            throw new Error(
+              'PCA curated context graph registration by an agent requires chain adapter PCA agent lookup support.',
+            );
+          }
+          const signerAccountId = await this.chain.getConvictionAgentAccountId(
+            normalizedChainSigner,
+            { strict: true },
+          );
+          if (signerAccountId !== publishAuthorityAccountId) {
+            throw new Error(
+              `Context graph "${id}" cannot be PCA-registered: chain signer ${normalizedChainSigner} is not a registered agent of PCA account ${publishAuthorityAccountId} ` +
+              `(registered account: ${signerAccountId}). The signer must own the PCA or be registered to that exact account.`,
+            );
+          }
+          this.log.info(
+            ctx,
+            `PCA-curated CG "${id}": registered agent ${normalizedChainSigner} will own the Context Graph NFT; ` +
+            `PCA account ${publishAuthorityAccountId} owner ${publishAuthority} remains the live publish authority.`,
+          );
+        }
+      } else if (publishAuthority && ownerAddress.toLowerCase() !== publishAuthority.toLowerCase()) {
+        // EOA mode: publishAuthority is the chain signer; local curator must
+        // equal it unless the explicit auto-promotion path below is allowed.
         if (opts?.strictEoaCuratorMatch) {
           // Opt-in strict mode for callers that explicitly want
           // the legacy "curator agent MUST equal chain signer"
@@ -1332,35 +1367,6 @@ export class ContextGraphMethods extends DKGAgentBase {
         // here on — downstream PCA/signer parity checks compare
         // against this value.
         ownerAddress = publishAuthority;
-      }
-      // PCA-only: the chain signer (= msg.sender for the registration
-      // tx) MUST equal the PCA owner. `ContextGraphs.createContextGraph`
-      // on-chain mints the governance NFT to msg.sender, so any
-      // divergence between the configured chain signer and the PCA
-      // owner would make the chain signer (not the advertised PCA owner)
-      // the actual on-chain context-graph owner — breaking later
-      // `onlyContextGraphOwner` operations (publish-policy/authority
-      // updates, etc.). Per Codex PR #502 round-4/5: keep "advertised
-      // curator == on-chain owner == chain signer == PCA owner" and
-      // FAIL CLOSED when the registration signer cannot be
-      // introspected — a custom adapter that exposes
-      // `getPublishingConvictionAccountOwner()` but not its tx signer
-      // would otherwise sneak past the invariant. Codex PR #502
-      // round-8: use the dedicated `getRegistrationTxSignerAddress`
-      // probe so future readers can't confuse it with a publish-time
-      // delegate principal.
-      if (isPcaCurated && publishAuthority) {
-        const chainSigner = await this.getRegistrationTxSignerAddress();
-        if (!chainSigner) {
-          throw new Error(
-            `Context graph "${id}" cannot be PCA-registered: the chain adapter does not expose its registration-tx signer, so the "chain signer == PCA owner" invariant cannot be verified. PCA mode requires a chain adapter that surfaces its signer (e.g. via \`signerAddress\` / \`getSignerAddress()\` / \`getOperationalPrivateKey()\`) so the on-chain governance NFT is guaranteed to mint to the advertised PCA owner.`,
-          );
-        }
-        if (chainSigner.toLowerCase() !== publishAuthority.toLowerCase()) {
-          throw new Error(
-            `Context graph "${id}" cannot be PCA-registered: chain signer ${chainSigner} differs from PCA owner ${publishAuthority}. The PCA owner must control the chain signer used to submit the registration tx; otherwise the on-chain governance NFT mints to ${chainSigner} rather than the advertised curator.`,
-          );
-        }
       }
       if (
         !publishAuthority

--- a/packages/agent/src/dkg-agent-ownership.ts
+++ b/packages/agent/src/dkg-agent-ownership.ts
@@ -533,9 +533,10 @@ export class OwnershipMethods extends DKGAgentBase {
    *   3. `signerAddress` property (mock adapter and parity tests).
    *   4. `getOperationalPrivateKey()` (legacy adapters).
    *
-   * Returning `undefined` triggers the round-5 "fail closed" branch
-   * in `registerContextGraph`: PCA registration is rejected because
-   * the invariant cannot be verified.
+   * Returning `undefined` triggers the fail-closed branch in
+   * `registerContextGraph`: PCA registration is rejected because neither
+   * owner nor exact-PCA agent authorization can be verified and the local
+   * curator cannot be aligned with the minted CG NFT owner.
    */
   async getRegistrationTxSignerAddress(this: DKGAgent): Promise<string | undefined> {
     const chain = this.chain;

--- a/packages/agent/test/agent.part-11.test.ts
+++ b/packages/agent/test/agent.part-11.test.ts
@@ -393,13 +393,10 @@ decisions: []
     });
 
 
-    // Codex PR #502 round-5: PCA registration must fail-closed when the
-    // chain adapter exposes `getPublishingConvictionAccountOwner()` but
-    // doesn't surface its tx signer in any introspectable way. Without
-    // this guard, a custom adapter could sneak past the
-    // "chain signer == PCA owner" invariant and the registration tx
-    // would still mint the governance NFT to whatever address the
-    // adapter actually signs with.
+    // PCA registration must fail closed when the adapter exposes the PCA
+    // owner but not its tx signer. Without signer introspection the agent
+    // cannot prove either owner mode or exact-PCA registered-agent mode, and
+    // cannot keep local curator ownership aligned with the minted CG NFT.
     it('rejects PCA registration when chain adapter does not expose its tx signer', async () => {
       const pcaOwner = new ethers.Wallet(HARDHAT_KEYS.REC1_OP).address;
       const pcaAccountId = 242n;
@@ -434,20 +431,18 @@ decisions: []
       await expect(agent.registerContextGraph('reject-pca-signerless-adapter', {
         callerAgentAddress: pcaOwner,
         publishAuthorityAccountId: pcaAccountId,
-      })).rejects.toThrow(/does not expose its registration-tx signer|invariant cannot be verified/);
+      })).rejects.toThrow(/does not expose its registration-tx signer|owner\/agent authorization cannot be verified/);
 
       expect(chain.createOnChainContextGraphCalls).toHaveLength(0);
       await agent.stop().catch(() => {});
     });
 
 
-    // Codex PR #502 round-4: rejects PCA registration when the chain
-    // signer (registration-tx msg.sender) doesn't match the PCA owner.
-    // Without this guard, `ContextGraphs.createContextGraph` on-chain
-    // mints the governance NFT to msg.sender while local metadata says
-    // the PCA owner is the curator — phantom-owner bug breaking later
-    // `onlyContextGraphOwner` ops.
-    it('rejects PCA registration when chain signer differs from PCA owner', async () => {
+    // Keep the local curator and registration signer aligned even after
+    // #1366 permits exact-PCA registered agents to create waived CGs. A
+    // different signer would own the on-chain Context Graph NFT while local
+    // metadata names the PCA owner as curator.
+    it('rejects PCA registration when local curator differs from the chain signer', async () => {
       const pcaOwner = new ethers.Wallet(HARDHAT_KEYS.REC1_OP).address;
       const pcaAccountId = 142n;
       // Chain signer is INTENTIONALLY different from the PCA owner —
@@ -476,7 +471,7 @@ decisions: []
       await expect(agent.registerContextGraph('reject-pca-signer-mismatch', {
         callerAgentAddress: pcaOwner,
         publishAuthorityAccountId: pcaAccountId,
-      })).rejects.toThrow(/chain signer .* differs from PCA owner|governance NFT mints to/);
+      })).rejects.toThrow(/local curator .* differs from registration chain signer|wallet that will own the on-chain Context Graph NFT/);
 
       expect(chain.createOnChainContextGraphCalls).toHaveLength(0);
       await agent.stop().catch(() => {});

--- a/packages/agent/test/agent.part-12.test.ts
+++ b/packages/agent/test/agent.part-12.test.ts
@@ -104,33 +104,75 @@ describe('Genesis Knowledge', () => {
     });
 
 
-    it('rejects PCA curated registration when local curator is not the PCA owner', async () => {
+    it('accepts PCA curated registration when local curator/chain signer is an agent of that exact PCA', async () => {
       const pcaOwner = new ethers.Wallet(HARDHAT_KEYS.REC1_OP).address;
-      const nonOwner = new ethers.Wallet(HARDHAT_KEYS.REC2_OP).address;
+      const pcaAgent = new ethers.Wallet(HARDHAT_KEYS.REC2_OP).address;
       const pcaAccountId = 99n;
-      const chain = new PcaCuratedRegistrationChainAdapter(new Map([[pcaAccountId, pcaOwner]]));
+      const chain = new PcaCuratedRegistrationChainAdapter(
+        new Map([[pcaAccountId, pcaOwner]]),
+        pcaAgent,
+        new Map([[pcaAgent.toLowerCase(), pcaAccountId]]),
+      );
       const agent = await DKGAgent.create({
-        name: 'PcaRejectsNonOwnerBot',
+        name: 'PcaAcceptsRegisteredAgentBot',
         store: new OxigraphStore(),
         chainAdapter: chain,
         nodeRole: 'core',
       });
       await agent.start();
 
-      expect(nonOwner.toLowerCase()).not.toBe(pcaOwner.toLowerCase());
+      expect(pcaAgent.toLowerCase()).not.toBe(pcaOwner.toLowerCase());
       await agent.createContextGraph({
-        id: 'reject-pca-non-owner',
-        name: 'Reject PCA non-owner',
+        id: 'accept-pca-agent',
+        name: 'Accept PCA agent',
         accessPolicy: 1,
-        callerAgentAddress: nonOwner,
+        callerAgentAddress: pcaAgent,
       });
 
-      // pcaAccountId at register time (not create) per Codex PR #502
-      // round-3 contract change.
-      await expect(agent.registerContextGraph('reject-pca-non-owner', {
-        callerAgentAddress: nonOwner,
+      await expect(agent.registerContextGraph('accept-pca-agent', {
+        callerAgentAddress: pcaAgent,
         publishAuthorityAccountId: pcaAccountId,
-      })).rejects.toThrow(/PCA account 99|only the PCA owner/i);
+      })).resolves.toMatchObject({ onChainId: expect.any(String) });
+
+      expect(chain.createOnChainContextGraphCalls).toHaveLength(1);
+      expect(chain.createOnChainContextGraphCalls[0]).toMatchObject({
+        publishPolicy: 0,
+        publishAuthority: pcaOwner,
+        publishAuthorityAccountId: pcaAccountId,
+      });
+      await agent.stop().catch(() => {});
+    });
+
+
+    it('rejects PCA curated registration when signer is unregistered or registered to another PCA', async () => {
+      const pcaOwner = new ethers.Wallet(HARDHAT_KEYS.REC1_OP).address;
+      const wrongPcaAgent = new ethers.Wallet(HARDHAT_KEYS.REC2_OP).address;
+      const targetPcaAccountId = 99n;
+      const otherPcaAccountId = 100n;
+      const chain = new PcaCuratedRegistrationChainAdapter(
+        new Map([[targetPcaAccountId, pcaOwner]]),
+        wrongPcaAgent,
+        new Map([[wrongPcaAgent.toLowerCase(), otherPcaAccountId]]),
+      );
+      const agent = await DKGAgent.create({
+        name: 'PcaRejectsWrongAgentBot',
+        store: new OxigraphStore(),
+        chainAdapter: chain,
+        nodeRole: 'core',
+      });
+      await agent.start();
+
+      await agent.createContextGraph({
+        id: 'reject-pca-wrong-agent',
+        name: 'Reject wrong PCA agent',
+        accessPolicy: 1,
+        callerAgentAddress: wrongPcaAgent,
+      });
+
+      await expect(agent.registerContextGraph('reject-pca-wrong-agent', {
+        callerAgentAddress: wrongPcaAgent,
+        publishAuthorityAccountId: targetPcaAccountId,
+      })).rejects.toThrow(/not a registered agent of PCA account 99.*registered account: 100/i);
 
       expect(chain.createOnChainContextGraphCalls).toHaveLength(0);
       await agent.stop().catch(() => {});
@@ -395,8 +437,7 @@ describe('Genesis Knowledge', () => {
     it('treats private:true as a curated signal that dominates accessPolicy=0 for PCA registration', async () => {
       const pcaOwner = new ethers.Wallet(HARDHAT_KEYS.REC1_OP).address;
       const pcaAccountId = 77n;
-      // PCA owner controls the chain signer (Codex PR #502 round-4
-      // contract: chain signer == PCA owner required for PCA mode).
+      // Owner mode: the PCA owner also controls the chain signer.
       const chain = new PcaCuratedRegistrationChainAdapter(
         new Map([[pcaAccountId, pcaOwner]]),
         pcaOwner,

--- a/packages/agent/test/agent.shared.ts
+++ b/packages/agent/test/agent.shared.ts
@@ -108,11 +108,11 @@ class PcaCuratedRegistrationChainAdapter extends AsyncSignerAddressContextGraphC
   constructor(
     private readonly accountOwners: Map<bigint, string>,
     signerAddress?: string,
+    private readonly agentAccounts: Map<string, bigint> = new Map(),
   ) {
-    // Forward an explicit signer to MockChainAdapter so tests can keep
-    // the "chain signer == PCA owner" invariant the agent enforces
-    // (Codex PR #502 round-4: msg.sender for the registration tx mints
-    // the on-chain governance NFT, so the PCA owner must control it).
+    // Forward an explicit signer to MockChainAdapter. PCA registration
+    // supports either an owner signer or a signer registered to the exact
+    // account; in both cases msg.sender owns the minted Context Graph NFT.
     super('mock:31337', signerAddress);
   }
 
@@ -122,6 +122,10 @@ class PcaCuratedRegistrationChainAdapter extends AsyncSignerAddressContextGraphC
       throw new Error(`No mock PCA owner for account ${accountId}`);
     }
     return owner;
+  }
+
+  async getConvictionAgentAccountId(agent: string): Promise<bigint> {
+    return this.agentAccounts.get(agent.toLowerCase()) ?? 0n;
   }
 }
 

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -1010,9 +1010,10 @@ export interface ChainAdapter {
 
   /**
    * Live owner lookup for a PCA NFT — wraps `DKGPublishingConvictionNFT.ownerOf(accountId)`.
-   * Used by the daemon's curated-CG registration preflight to enforce
-   * `local curator == ownerOf(pcaAccountId)` so an agent wallet cannot
-   * impersonate ownership when tying a CG to a PCA.
+   * Used by the daemon's curated-CG registration preflight to populate the
+   * coherence-required publishAuthority. Registration authorization is then
+   * checked separately: the tx signer must be this owner or an agent registered
+   * to the exact PCA.
    */
   getPublishingConvictionAccountOwner?(accountId: bigint): Promise<string>;
 

--- a/packages/chain/src/mock-adapter.ts
+++ b/packages/chain/src/mock-adapter.ts
@@ -828,8 +828,8 @@ export class MockChainAdapter implements ChainAdapter {
   }
 
   /**
-   * Mock owner-lookup for the daemon's curated-CG registration
-   * preflight (`local curator == ownerOf(pcaAccountId)`).
+   * Mock owner lookup for the daemon's curated-CG registration coherence
+   * preflight. Caller authorization (owner or exact-PCA agent) is separate.
    */
   async getPublishingConvictionAccountOwner(accountId: bigint): Promise<string> {
     const acct = this.convictionAccounts.get(accountId);

--- a/packages/cli/src/commands/context-graph.ts
+++ b/packages/cli/src/commands/context-graph.ts
@@ -189,11 +189,11 @@ contextGraphCmd
 
 contextGraphCmd
   .command('register <id>')
-  .description('Register an existing context graph on-chain (unlocks Verifiable Memory, requires TRAC)')
+  .description('Register an existing context graph on-chain (unlocks Verifiable Memory; requires gas and either a TRAC deposit or eligible PCA waiver)')
   .option('--reveal', 'Deprecated: V10 ContextGraphs registration does not reveal cleartext metadata on-chain')
   .option('--access-policy <n>', 'Access policy: 0 = public/discoverable, 1 = private/curated', parseInt)
   .option('--publish-policy <n>', 'Publish policy: 0 = curated, 1 = open', parseInt)
-  .option('--pca-account-id <id>', 'Publishing Conviction Account id for PCA-curated registration')
+  .option('--pca-account-id <id>', 'Publishing Conviction Account id for curated registration by its owner or an exact-account registered agent')
   .action(async (id: string, opts: ActionOpts) => {
     try {
       const client = await ApiClient.connect();

--- a/packages/cli/src/daemon/routes/context-graph.ts
+++ b/packages/cli/src/daemon/routes/context-graph.ts
@@ -55,7 +55,7 @@ const daemonRequire = createRequire(import.meta.url);
 
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
-import { enrichEvmError, MockChainAdapter } from '@origintrail-official/dkg-chain';
+import { enrichEvmError, isPcaUnavailableError, MockChainAdapter } from '@origintrail-official/dkg-chain';
 import { DKGAgent, loadOpWallets } from '@origintrail-official/dkg-agent';
 import { computeNetworkId, createOperationContext, DKGEvent, Logger, PayloadTooLargeError, GET_VIEWS, TrustLevel, validateSubGraphName, validateAssertionName, validateContextGraphId, isSafeIri, assertSafeIri, sparqlIri, contextGraphSharedMemoryUri, contextGraphAssertionUri, contextGraphMetaUri, SYSTEM_CONTEXT_GRAPHS } from '@origintrail-official/dkg-core';
 import { findReservedSubjectPrefix, isSkolemizedUri } from '@origintrail-official/dkg-publisher';
@@ -352,6 +352,9 @@ function classifyRegisterContextGraphError(err: unknown): { status: number; body
     : err && typeof err === 'object' && 'message' in err
       ? String((err as { message?: unknown }).message ?? '')
       : '';
+  if (isPcaUnavailableError(err) || /DKGPublishingConvictionNFT (?:is )?not deployed on this Hub/i.test(msg)) {
+    return { status: 503, body: { error: msg || 'PCA support is unavailable on this network.' } };
+  }
   if (msg.includes('already registered')) return { status: 409, body: { error: msg } };
   if (msg.includes('does not exist')) return { status: 404, body: { error: msg } };
   if (msg.includes('no known creator')) return { status: 503, body: { error: msg, hint: 'Creator not yet synced. Retry after sync completes.' } };
@@ -364,12 +367,19 @@ function classifyRegisterContextGraphError(err: unknown): { status: number; body
   }
   if (msg.includes('PCA account id must be a positive integer')) return { status: 400, body: { error: msg } };
   if (msg.includes('requires chain adapter PCA owner lookup support')) return { status: 501, body: { error: msg } };
+  if (msg.includes('requires chain adapter PCA agent lookup support')) return { status: 501, body: { error: msg } };
   if (/PCA account \d+ does not exist or cannot be looked up/.test(msg)) return { status: 404, body: { error: msg } };
   if (/PCA account \d+ is owned by/.test(msg)) return { status: 403, body: { error: msg } };
-  // PCA chain-signer / signer-introspection invariants (Codex round-4/5/8):
+  // PCA signer authorization and local/on-chain ownership alignment.
+  if (msg.includes('is not a registered agent of PCA account')) return { status: 403, body: { error: msg } };
+  if (msg.includes('local curator') && msg.includes('differs from registration chain signer')) {
+    return { status: 403, body: { error: msg } };
+  }
+  // Compatibility with pre-#1366 owner-only agent errors.
   if (msg.includes('chain signer') && msg.includes('differs from PCA owner')) return { status: 403, body: { error: msg } };
   if (msg.includes('does not expose its registration-tx signer')
-    || msg.includes('invariant cannot be verified')) {
+    || msg.includes('invariant cannot be verified')
+    || msg.includes('owner/agent authorization cannot be verified')) {
     return { status: 501, body: { error: msg } };
   }
   return undefined;

--- a/packages/cli/test/daemon-context-graph-register.test.ts
+++ b/packages/cli/test/daemon-context-graph-register.test.ts
@@ -158,4 +158,51 @@ describe('POST /api/context-graph/register — effective publishPolicy resolutio
       warnSpy.mockRestore();
     }
   });
+
+  it('maps an exact-PCA agent authorization failure to 403', async () => {
+    const { status, json } = await runRegisterRouteCaptureOpts(
+      { id: 'wrong-pca-agent-cg', publishPolicy: 0, pcaAccountId: '8' },
+      {
+        registerContextGraph: async () => {
+          throw new Error(
+            'Context graph "wrong-pca-agent-cg" cannot be PCA-registered: chain signer ' +
+            '0x0000000000000000000000000000000000000002 is not a registered agent of PCA account 8 ' +
+            '(registered account: 9).',
+          );
+        },
+      },
+    );
+    expect(status).toBe(403);
+    expect(json.error).toMatch(/not a registered agent of PCA account 8/);
+  });
+
+  it('maps missing PCA agent lookup support to 501', async () => {
+    const { status, json } = await runRegisterRouteCaptureOpts(
+      { id: 'unsupported-pca-agent-cg', publishPolicy: 0, pcaAccountId: '8' },
+      {
+        registerContextGraph: async () => {
+          throw new Error(
+            'PCA curated context graph registration by an agent requires chain adapter PCA agent lookup support.',
+          );
+        },
+      },
+    );
+    expect(status).toBe(501);
+    expect(json.error).toMatch(/PCA agent lookup support/);
+  });
+
+  it('maps unavailable PCA contract support to 503', async () => {
+    const { status, json } = await runRegisterRouteCaptureOpts(
+      { id: 'unavailable-pca-cg', publishPolicy: 0, pcaAccountId: '8' },
+      {
+        registerContextGraph: async () => {
+          const err = new Error('DKGPublishingConvictionNFT not deployed on this Hub.');
+          Object.assign(err, { code: 'PCA_UNAVAILABLE' });
+          throw err;
+        },
+      },
+    );
+    expect(status).toBe(503);
+    expect(json.error).toMatch(/not deployed on this Hub/);
+  });
 });

--- a/packages/mcp-dkg/README.md
+++ b/packages/mcp-dkg/README.md
@@ -138,7 +138,7 @@ autoShare: true
 
 `.dkg/` is gitignored repo-wide so this file stays local to each operator. The `tokenFile` path is resolved relative to the YAML; default of `~/.dkg/auth.token` matches what `dkg start` writes on first boot.
 
-## Tool surface (29 tools)
+## Tool surface (30 tools)
 
 All tools are available the moment `dkg mcp setup` registers the MCP with your client. They group into seven categories tracking how a session typically uses memory: check health, discover the graph, set it up, drive the knowledge-asset lifecycle (create → write → finalize → share → publish), recall from it, query it, and message other agents.
 
@@ -166,6 +166,7 @@ All tools are available the moment `dkg mcp setup` registers the MCP with your c
 | Tool | What it does |
 |---|---|
 | `dkg_context_graph_create` | Create a context graph (called "projects" in the DKG node UI). The `id` slug is auto-derived from `name` when omitted. Idempotent — pre-existing CGs are returned unchanged. |
+| `dkg_context_graph_register` | Register an existing context graph on-chain. Supports policy overrides and PCA-backed registration by the PCA owner or a wallet registered to that exact PCA. An eligible PCA uses a quota-backed registration-deposit waiver. |
 | `dkg_subscribe` | Subscribe to a context graph so its data syncs locally from peers. Defaults to also syncing Shared Working Memory; pass `includeSharedMemory: false` to skip SWM. |
 | `dkg_sub_graph_create` | Create a named sub-graph inside a context graph (e.g. `code`, `tasks`, `meta`). Idempotent — pre-existing sub-graphs are silently reused. |
 
@@ -289,12 +290,12 @@ Per-turn state is kept in `~/.cache/dkg-mcp/sessions/*.json`; safe to delete at 
 
 | File | Purpose |
 |---|---|
-| `src/index.ts` | Stdio MCP server entrypoint. Boots `McpServer` and registers the 29 tools. |
+| `src/index.ts` | Stdio MCP server entrypoint. Boots `McpServer` and registers the 30 tools. |
 | `src/tools.ts` | Read tools (`dkg_list_context_graphs`, `dkg_sub_graph_list`, `dkg_query`, `dkg_get_entity`, `dkg_get_entity_sources`, `dkg_list_activity`, `dkg_get_agent`). |
 | `src/tools/assertions.ts` | Knowledge-asset lifecycle (`dkg_knowledge_asset_*` × 13: create/write/finalize/share/publish/pull_from/discard/query/history/import_file + import_artifact_resolve/read_markdown + semantic_enrichment_write). |
 | `src/tools/health.ts` | `dkg_status`, `dkg_peer_info`, `dkg_wallet_balances`. |
 | `src/tools/memory-search.ts` | `dkg_memory_search` with WM/SWM/VM fan-out and trust-weighted ranking. |
-| `src/tools/setup.ts` | `dkg_context_graph_create`, `dkg_subscribe`, `dkg_sub_graph_create`. |
+| `src/tools/setup.ts` | `dkg_context_graph_create`, `dkg_context_graph_register`, `dkg_subscribe`, `dkg_sub_graph_create`. |
 | `src/tools/chat.ts` | `dkg_send_message`, `dkg_check_inbox`. |
 | `src/client.ts` | `DkgClient` HTTP wrapper. Re-exported as `@origintrail-official/dkg-mcp/client`. |
 | `src/manifest/{publish,fetch,install}.ts` | Project manifest publish/install pipeline. Re-exported as `@origintrail-official/dkg-mcp/manifest/*` and consumed by the umbrella CLI's daemon routes. |

--- a/packages/mcp-dkg/src/client.ts
+++ b/packages/mcp-dkg/src/client.ts
@@ -72,6 +72,14 @@ function optionalContextGraphId(contextGraphIdOrUri: string | undefined): string
   return normalizeContextGraphId(contextGraphIdOrUri) || undefined;
 }
 
+function pcaAccountIdPayload(value: string | bigint): string {
+  const normalized = typeof value === 'bigint' ? value.toString() : value.trim();
+  if (!/^[1-9]\d*$/.test(normalized)) {
+    throw new Error('pcaAccountId must be a positive decimal integer');
+  }
+  return normalized;
+}
+
 /**
  * Author attestation produced by an external signer. Mirrors the
  * `packages/cli/src/api-client.ts` reference so finalize / create KA flows can
@@ -1038,6 +1046,8 @@ export class DkgClient {
   async registerContextGraph(args: {
     id: string;
     accessPolicy?: number;
+    publishPolicy?: number;
+    pcaAccountId?: string | bigint;
   }): Promise<{
     registered: string;
     onChainId?: string;
@@ -1053,7 +1063,11 @@ export class DkgClient {
         hint?: string;
       }>('POST', '/api/context-graph/register', {
         id: normalizeContextGraphId(args.id),
-        accessPolicy: args.accessPolicy,
+        ...(args.accessPolicy !== undefined ? { accessPolicy: args.accessPolicy } : {}),
+        ...(args.publishPolicy !== undefined ? { publishPolicy: args.publishPolicy } : {}),
+        ...(args.pcaAccountId !== undefined
+          ? { pcaAccountId: pcaAccountIdPayload(args.pcaAccountId) }
+          : {}),
       });
       return { ...response, alreadyRegistered: false };
     } catch (err) {

--- a/packages/mcp-dkg/src/tools/setup.ts
+++ b/packages/mcp-dkg/src/tools/setup.ts
@@ -1,7 +1,7 @@
 /**
  * Context-graph and sub-graph setup tools.
  *
- * Wave-2 P0 + P2 adds (audit §7 items 1, 8, 9). These three tools cover
+ * Wave-2 P0 + P2 adds (audit §7 items 1, 8, 9). These tools cover
  * the SKILL.md Quickstart Step 1 ("create a project") and Step 3 ("join
  * a peer-shared CG") plus the sub-graph staging primitive that the
  * other write tools previously consumed indirectly via
@@ -159,6 +159,71 @@ export function registerSetupTools(
         );
       } catch (e) {
         return errResult(`Failed to create context graph: ${formatError(e)}`);
+      }
+    },
+  );
+
+  // ── dkg_context_graph_register ──────────────────────────────────
+  server.registerTool(
+    'dkg_context_graph_register',
+    {
+      title: 'Register Context Graph On-chain',
+      description:
+        'Register an existing local context graph on-chain so it can publish to Verifiable Memory. ' +
+        'Idempotent when the graph is already registered. `sharing` and `contribution` override the ' +
+        'stored policies when supplied. To use a Publishing Conviction Account, pass its positive decimal ' +
+        '`pcaAccountId`; the registration is forced to curated contribution. The transaction signer must ' +
+        'own that PCA or be a currently registered agent of that exact PCA. An eligible active PCA consumes ' +
+        'one quota-backed registration-deposit waiver, so the signer needs native gas but no separate liquid ' +
+        'TRAC registration deposit.',
+      inputSchema: {
+        contextGraphId: z.string().min(1).describe(EXISTING_CONTEXT_GRAPH_ID_DESCRIPTION),
+        sharing: z
+          .enum(['open', 'invite-only'])
+          .optional()
+          .describe('Optional registration override: "open" = accessPolicy 0, "invite-only" = accessPolicy 1.'),
+        contribution: z
+          .enum(['open', 'curators-only'])
+          .optional()
+          .describe('Optional registration override: "open" = publishPolicy 1, "curators-only" = publishPolicy 0.'),
+        pcaAccountId: z
+          .string()
+          .regex(/^[1-9]\d*$/, 'pcaAccountId must be a positive decimal integer')
+          .optional()
+          .describe('Publishing Conviction Account id. Forces curated contribution and requires this node signer to own or be registered to that exact PCA.'),
+      },
+    },
+    async ({ contextGraphId, sharing, contribution, pcaAccountId }): Promise<ToolResult> => {
+      const cgId = contextGraphId.trim();
+      if (!cgId) return errResult('"contextGraphId" is required.');
+      if (pcaAccountId !== undefined && contribution === 'open') {
+        return errResult('"pcaAccountId" is only valid with curated contribution; use contribution="curators-only".');
+      }
+      const accessPolicy = sharing === undefined ? undefined : sharing === 'open' ? 0 : 1;
+      const publishPolicy = pcaAccountId !== undefined
+        ? 0
+        : contribution === undefined
+          ? undefined
+          : contribution === 'open'
+            ? 1
+            : 0;
+      try {
+        const result = await client.registerContextGraph({
+          id: cgId,
+          ...(accessPolicy !== undefined ? { accessPolicy } : {}),
+          ...(publishPolicy !== undefined ? { publishPolicy } : {}),
+          ...(pcaAccountId !== undefined ? { pcaAccountId } : {}),
+        });
+        if (result.alreadyRegistered) {
+          return ok(`Context graph '${cgId}' is already registered on-chain.`);
+        }
+        return ok(
+          `Registered context graph '${result.registered}' on-chain.` +
+            (result.onChainId ? `\nOn-chain ID: ${result.onChainId}` : '') +
+            (result.txHash ? `\nTransaction: ${result.txHash}` : ''),
+        );
+      } catch (e) {
+        return errResult(`Failed to register context graph: ${formatError(e)}`);
       }
     },
   );

--- a/packages/mcp-dkg/test/context-graph-client.test.ts
+++ b/packages/mcp-dkg/test/context-graph-client.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { DkgClient } from '../src/client.js';
+import { makeConfig } from './harness.js';
+
+describe('DkgClient context-graph registration', () => {
+  const makeClient = () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const client = new DkgClient({
+      config: makeConfig(),
+      fetcher: (async (url, init) => {
+        calls.push({ url: String(url), body: JSON.parse(String(init?.body ?? '{}')) });
+        return new Response(JSON.stringify({
+          registered: 'pca-private',
+          onChainId: '42',
+          txHash: '0xreg',
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }) as typeof fetch,
+    });
+    return { client, calls };
+  };
+
+  it('serializes publishPolicy and a uint256-safe PCA id', async () => {
+    const { client, calls } = makeClient();
+    await client.registerContextGraph({
+      id: 'did:dkg:context-graph:pca-private',
+      accessPolicy: 1,
+      publishPolicy: 0,
+      pcaAccountId: 9007199254740993n,
+    });
+
+    expect(calls[0].url).toContain('/api/context-graph/register');
+    expect(calls[0].body).toEqual({
+      id: 'pca-private',
+      accessPolicy: 1,
+      publishPolicy: 0,
+      pcaAccountId: '9007199254740993',
+    });
+  });
+
+  it('rejects invalid PCA ids before making an HTTP request', async () => {
+    const { client, calls } = makeClient();
+    await expect(client.registerContextGraph({
+      id: 'pca-private',
+      pcaAccountId: '0',
+    })).rejects.toThrow(/positive decimal integer/);
+    expect(calls).toHaveLength(0);
+  });
+});

--- a/packages/mcp-dkg/test/drop-sweep.test.ts
+++ b/packages/mcp-dkg/test/drop-sweep.test.ts
@@ -121,8 +121,10 @@ describe('drop-sweep — none of the 10 W2-dropped tools reappear in tools/list'
   // -2 tools (dkg_publish + dkg_shared_memory_publish), taking the surface from
   // 31 → 29. The one-shot is NOT a new tool: it EXTENDS dkg_knowledge_asset_create
   // with optional quads + alsoShareSwm [D3], so the count drops by exactly 2.
-  it('registered surface contains exactly 29 tools (full production surface, post-PR locked count)', () => {
-    expect(server.tools.size).toBe(29);
+  // PCA-agent CG registration: +1 explicit on-chain registration tool, taking
+  // the full surface from 29 → 30.
+  it('registered surface contains exactly 30 tools (full production surface, post-PR locked count)', () => {
+    expect(server.tools.size).toBe(30);
   });
 });
 

--- a/packages/mcp-dkg/test/harness.ts
+++ b/packages/mcp-dkg/test/harness.ts
@@ -548,7 +548,12 @@ export class FakeClient {
       : { status: 'wm-sealed', sealed: true, publishReady: false };
   }
 
-  async registerContextGraph(args: { id: string }) {
+  async registerContextGraph(args: {
+    id: string;
+    accessPolicy?: number;
+    publishPolicy?: number;
+    pcaAccountId?: string | bigint;
+  }) {
     if (this.overrides.registerContextGraph) return this.overrides.registerContextGraph.call(this, args);
     return {
       registered: args.id,

--- a/packages/mcp-dkg/test/setup-publish-health.test.ts
+++ b/packages/mcp-dkg/test/setup-publish-health.test.ts
@@ -14,14 +14,70 @@ describe('setup tools — context graph + sub-graph + subscribe', () => {
     registerSetupTools(server.asMcpServer(), client.asDkgClient(), makeConfig());
   });
 
-  it('registers all three setup tools', () => {
+  it('registers all four setup tools', () => {
     for (const name of [
       'dkg_context_graph_create',
+      'dkg_context_graph_register',
       'dkg_subscribe',
       'dkg_sub_graph_create',
     ]) {
       expect(server.tools.has(name)).toBe(true);
     }
+  });
+
+  it('registers a private PCA-backed context graph with exact daemon wire options', async () => {
+    let received: Record<string, unknown> | undefined;
+    const localClient = new FakeClient({
+      registerContextGraph: async (args) => {
+        received = args;
+        return {
+          registered: args.id,
+          onChainId: '42',
+          txHash: '0xreg',
+          alreadyRegistered: false,
+        };
+      },
+    });
+    const localServer = new FakeServer();
+    registerSetupTools(localServer.asMcpServer(), localClient.asDkgClient(), makeConfig());
+
+    const result = await localServer.call('dkg_context_graph_register', {
+      contextGraphId: 'pca-private',
+      sharing: 'invite-only',
+      contribution: 'curators-only',
+      pcaAccountId: '8',
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).toMatch(/On-chain ID: 42/);
+    expect(received).toEqual({
+      id: 'pca-private',
+      accessPolicy: 1,
+      publishPolicy: 0,
+      pcaAccountId: '8',
+    });
+  });
+
+  it('rejects an open-contribution PCA registration before calling the daemon', async () => {
+    let called = false;
+    const localClient = new FakeClient({
+      registerContextGraph: async () => {
+        called = true;
+        throw new Error('must not be called');
+      },
+    });
+    const localServer = new FakeServer();
+    registerSetupTools(localServer.asMcpServer(), localClient.asDkgClient(), makeConfig());
+
+    const result = await localServer.call('dkg_context_graph_register', {
+      contextGraphId: 'invalid-pca',
+      contribution: 'open',
+      pcaAccountId: '8',
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/only valid with curated contribution/i);
+    expect(called).toBe(false);
   });
 
   it('dkg_context_graph_create description carries the SKILL.md §6 canonical-naming note', () => {
@@ -105,7 +161,7 @@ describe('setup tools — context graph + sub-graph + subscribe', () => {
   });
 
   it('documents canonical context graph ids for existing-target setup tools', () => {
-    for (const name of ['dkg_subscribe', 'dkg_sub_graph_create']) {
+    for (const name of ['dkg_context_graph_register', 'dkg_subscribe', 'dkg_sub_graph_create']) {
       const contextGraphId = server.get(name).config.inputSchema?.contextGraphId;
       expect(contextGraphId?.description).toContain('dkg_list_context_graphs');
       expect(contextGraphId?.description).toContain('local-notes');


### PR DESCRIPTION
## Summary

- allow a PCA owner **or a wallet registered to that exact PCA** to register a PCA-backed curated Context Graph
- keep registration fail-closed by verifying the live PCA owner, the exact `agentToAccountId` binding, and local-curator/transaction-signer alignment
- expose explicit on-chain Context Graph registration through MCP, including `publishPolicy` and uint256-safe `pcaAccountId` forwarding
- document that an eligible PCA registration consumes a bounded waiver slot rather than a separate liquid-TRAC deposit

## Root cause

The contract behavior merged in #1366 deliberately permits the PCA owner or an exact-account registered agent to consume the quota-backed Context Graph registration-deposit waiver. The agent layer retained the older owner-only preflight, so CLI/API calls with `pcaAccountId` were rejected before a transaction could be submitted. The MCP client also omitted `publishPolicy` / `pcaAccountId` and had no explicit registration tool.

A read-only call against the deployed Gnosis mainnet contracts confirmed the mismatch: the PCA-backed call from a registered agent executed successfully, while the same signer using the direct/non-PCA path reverted for the 100 TRAC registration deposit.

Note: #1347 describes the pre-#1366 owner-only behavior and is now stale relative to the deployed waiver contract.

## Security and ownership invariants

- resolve the PCA owner live and retain it as the on-chain `publishAuthority`
- require the registration signer to be that owner or have `agentToAccountId(signer) == requestedPcaAccountId`
- use strict PCA lookup so an unavailable contract/RPC is not interpreted as “unregistered”
- require the local curator to equal the registration signer, because `ContextGraphs.createContextGraph` mints the Context Graph NFT to `msg.sender`
- reject agents registered to another PCA before any chain write
- map unavailable PCA support to HTTP 503, missing adapter capabilities to 501, and authorization failures to 403

In registered-agent mode, the agent/signer owns the Context Graph NFT while the PCA owner remains the live publish authority, matching the deployed contract.

## Verification

- `pnpm turbo run build --filter=@origintrail-official/dkg-agent --filter=@origintrail-official/dkg --filter=@origintrail-official/dkg-mcp`
- agent PCA registration suites: 18 tests passed
- CLI/context-graph suites: 37 tests passed; focused route suite: 8 tests passed
- full MCP suite: 332 tests passed
- standalone CLI and MCP TypeScript builds passed
- `git diff --check`

No Solidity, ABI, or deployment-registry changes are included; no contract deployment is required.
