### PR TITLE
ci: add fail-closed delta routing and cut full PR CI to six minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,17 +67,30 @@ jobs:
       evm_matrix: ${{ steps.plan.outputs.evm_matrix }}
       plan_json: ${{ steps.plan.outputs.plan_json }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      # The merge candidate is untrusted input: use it only to calculate the
+      # changed-file set, and never execute its CI planner or validator here.
+      - name: Checkout merge candidate
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           # The PR checkout is a synthetic merge commit; depth 2 normally
           # includes that commit and both parents without cloning full history.
           fetch-depth: 2
-      # Package README files are documentation for routing purposes, but they
-      # are also npm metadata. Keep this cheap gate in the always-run planner
-      # so a docs-only PR cannot bypass the existing stale-v9 check.
-      - name: Validate npm metadata points to v10
-        run: node scripts/check-npm-metadata.mjs
+          path: candidate
+      # This immutable controller is the authority for test selection. A
+      # policy update intentionally uses a new reviewed commit SHA; never use
+      # the merge candidate or a mutable branch here.
+      - name: Checkout trusted CI controller
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: OriginTrail/dkg
+          ref: c441bd6766ace67e331c0dfc6e22cb1325a6e1f6
+          persist-credentials: false
+          path: trusted-ci
+          sparse-checkout: |
+            scripts/ci
+            scripts/lib
+          sparse-checkout-cone-mode: false
       - name: Compute fail-closed CI plan
         id: plan
         env:
@@ -99,14 +112,15 @@ jobs:
               echo "::error::Missing pull-request base/merge SHA"
               exit 1
             fi
-            if ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
-              git fetch --no-tags --depth=1 origin "${BASE_SHA}"
+            if ! git -C candidate cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+              git -C candidate fetch --no-tags --depth=1 origin "${BASE_SHA}"
             fi
-            git cat-file -e "${MERGE_SHA}^{commit}"
+            git -C candidate cat-file -e "${MERGE_SHA}^{commit}"
             # Compare the latest base with GitHub's synthetic merge candidate.
             # Comparing base directly to a behind PR head would misclassify
             # unrelated changes that landed on base as part of this PR.
-            git diff --name-status -z "${BASE_SHA}" "${MERGE_SHA}" > "${CHANGES_FILE}"
+            git -C candidate diff --name-status -z \
+              "${BASE_SHA}" "${MERGE_SHA}" > "${CHANGES_FILE}"
           fi
 
           PLAN_EVENT="${EVENT_NAME}"
@@ -114,13 +128,18 @@ jobs:
             PLAN_EVENT="pull_request_delta_disabled"
           fi
 
-          node scripts/ci/plan-ci.mjs \
+          node trusted-ci/scripts/ci/plan-ci.mjs \
             --event "${PLAN_EVENT}" \
             --changes-z "${CHANGES_FILE}" \
             --labels-json "${PR_LABELS:-[]}" \
             --sample-key "${SAMPLE_KEY}" \
             --github-output "${GITHUB_OUTPUT}" \
             --summary "${GITHUB_STEP_SUMMARY}"
+      # Package README files are documentation for routing purposes, but they
+      # are also npm metadata. Candidate code runs only after the trusted plan
+      # has finalized its outputs, so it cannot influence test selection.
+      - name: Validate npm metadata points to v10
+        run: node candidate/scripts/check-npm-metadata.mjs
 
   # ------------------------------------------------------------------
   # One canonical build. Every test job downloads this artifact instead
@@ -1369,12 +1388,22 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      # The aggregate verdict must come from the same immutable controller as
+      # the planner, never from the merge candidate being evaluated.
+      - name: Checkout trusted CI controller
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          repository: OriginTrail/dkg
+          ref: c441bd6766ace67e331c0dfc6e22cb1325a6e1f6
           persist-credentials: false
+          path: trusted-ci
+          sparse-checkout: |
+            scripts/ci
+            scripts/lib
+          sparse-checkout-cone-mode: false
       - name: Verify selected lanes completed
         env:
           EVENT_NAME: ${{ github.event_name }}
           PLAN_JSON: ${{ needs.changes.outputs.plan_json }}
           NEEDS_JSON: ${{ toJSON(needs) }}
-        run: node scripts/ci/assert-ci-results.mjs --workflow primary
+        run: node trusted-ci/scripts/ci/assert-ci-results.mjs --workflow primary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,10 @@
 name: CI
 
-# Trigger rules — chosen so the same SHA is never tested twice:
-#   * push to main/v10-rc/release/rc.12 : always runs (merge-gate safety
-#     net, full Solidity coverage, required status checks for protected
-#     branches). `release/rc.12` is the active release-stabilisation
-#     branch that feature/fix work currently lands on (and where bugs
-#     are reproduced/fixed), so it gets the same gate as main/v10-rc —
-#     otherwise the Node test suites only run once rc.12 merges upward.
-#   * pull_request         : runs on every open/synchronize/reopen event.
+# Trigger rules:
+#   * pull_request : fail-closed delta plan for fast iteration. Label changes
+#                    retrigger the workflow so `ci:full` is an override.
+#   * merge_group : full CI against the exact pre-merge candidate.
+#   * protected push / manual dispatch : full CI safety net.
 #   * No `push` trigger on feature branches (e.g. `test/**`). When a PR
 #     is open, the `pull_request` event already covers every new commit;
 #     when a PR is not open yet, developers can either open a draft PR
@@ -17,6 +14,11 @@ on:
     branches: [main, v10-rc, release/rc.12, rc17-vm-wip]
   pull_request:
     branches: [main, v10-rc, release/rc.12, rc17-vm-wip]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+  # When merge queue is enabled, this is the pre-merge full-CI safety net.
+  # It validates the exact candidate that will land, without introducing a
+  # develop branch that batches unrelated failures into one large PR.
+  merge_group:
   workflow_dispatch:
 
 concurrency:
@@ -38,56 +40,93 @@ permissions:
 
 jobs:
   # ------------------------------------------------------------------
-  # Detect which surface changed so we can gate the heavy Solidity
-  # coverage+ratchet run to contract-touching PRs. On `push` events (merges
-  # into v10-rc / main) the safety net always runs regardless of filters.
+  # Produce one fail-closed test plan for every workflow in this repository.
+  # PRs run the affected package lane plus declared downstream consumers.
+  # Protected pushes, merge queue candidates, manual runs, global/unknown
+  # changes, package manifests, large changes, and `ci:full` run everything.
   # ------------------------------------------------------------------
   changes:
-    name: Detect changes
+    name: Plan CI delta
     runs-on: ubuntu-latest
-    timeout-minutes: 2
-    permissions:
-      contents: read
-      # `dorny/paths-filter` on a `pull_request` event reads the PR file
-      # list via the Pull Requests REST API (`GET /repos/{owner}/{repo}/
-      # pulls/{number}/files`). Without `pull-requests: read` here, the
-      # action fails with `Resource not accessible by integration` and
-      # the whole CI run dies before the test matrix starts. Scoped to
-      # this job only — every other job in this workflow does not call
-      # the API and stays read-only on `contents`.
-      pull-requests: read
+    timeout-minutes: 5
     outputs:
-      contracts: ${{ steps.filter.outputs.contracts }}
+      full_ci: ${{ steps.plan.outputs.full_ci }}
+      run_node: ${{ steps.plan.outputs.run_node }}
+      tornado_core: ${{ steps.plan.outputs.tornado_core }}
+      tornado_blazegraph: ${{ steps.plan.outputs.tornado_blazegraph }}
+      tornado_publisher: ${{ steps.plan.outputs.tornado_publisher }}
+      tornado_agent: ${{ steps.plan.outputs.tornado_agent }}
+      bura_cli: ${{ steps.plan.outputs.bura_cli }}
+      bura_blazegraph_arm64: ${{ steps.plan.outputs.bura_blazegraph_arm64 }}
+      bura_query: ${{ steps.plan.outputs.bura_query }}
+      kosava_node_ui: ${{ steps.plan.outputs.kosava_node_ui }}
+      kosava_node_ui_e2e: ${{ steps.plan.outputs.kosava_node_ui_e2e }}
+      kosava_supporting: ${{ steps.plan.outputs.kosava_supporting }}
+      kosava_hardhat_plugins: ${{ steps.plan.outputs.kosava_hardhat_plugins }}
+      contracts: ${{ steps.plan.outputs.contracts }}
+      evm_matrix: ${{ steps.plan.outputs.evm_matrix }}
+      plan_json: ${{ steps.plan.outputs.plan_json }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
-        id: filter
-        with:
-          filters: |
-            contracts:
-              - 'packages/evm-module/contracts/**'
-              - 'packages/evm-module/test/**'
-              - 'packages/evm-module/deploy/**'
-              - 'packages/evm-module/scripts/**'
-              - 'packages/evm-module/hardhat.*'
-              - 'packages/evm-module/package.json'
-              - 'packages/evm-module/slither.config.json'
-              - 'packages/evm-module/.solhint.json'
-              - 'packages/evm-module/.solhintignore'
-              - 'packages/evm-module/aderyn.toml'
-              - 'package.json'
-              - 'pnpm-lock.yaml'
-              - 'pnpm-workspace.yaml'
-              - '.github/workflows/ci.yml'
+          # The PR checkout is a synthetic merge commit; depth 2 normally
+          # includes that commit and both parents without cloning full history.
+          fetch-depth: 2
+      # Package README files are documentation for routing purposes, but they
+      # are also npm metadata. Keep this cheap gate in the always-run planner
+      # so a docs-only PR cannot bypass the existing stale-v9 check.
+      - name: Validate npm metadata points to v10
+        run: node scripts/check-npm-metadata.mjs
+      - name: Compute fail-closed CI plan
+        id: plan
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          MERGE_SHA: ${{ github.sha }}
+          PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+          SAMPLE_KEY: ${{ github.event.pull_request.head.sha || github.sha }}
+          # Initial rollout is main-only. Release/RC PRs stay full until they
+          # have equivalent required-gate + merge-queue protection.
+          DELTA_ENABLED: ${{ vars.CI_DELTA_ENABLED == 'true' && github.base_ref == 'main' }}
+        run: |
+          set -euo pipefail
+          CHANGES_FILE="${RUNNER_TEMP}/ci-name-status.z"
+          : > "${CHANGES_FILE}"
+
+          if [[ "${EVENT_NAME}" == "pull_request" ]]; then
+            if [[ -z "${BASE_SHA}" || -z "${MERGE_SHA}" ]]; then
+              echo "::error::Missing pull-request base/merge SHA"
+              exit 1
+            fi
+            if ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+              git fetch --no-tags --depth=1 origin "${BASE_SHA}"
+            fi
+            git cat-file -e "${MERGE_SHA}^{commit}"
+            # Compare the latest base with GitHub's synthetic merge candidate.
+            # Comparing base directly to a behind PR head would misclassify
+            # unrelated changes that landed on base as part of this PR.
+            git diff --name-status -z "${BASE_SHA}" "${MERGE_SHA}" > "${CHANGES_FILE}"
+          fi
+
+          PLAN_EVENT="${EVENT_NAME}"
+          if [[ "${EVENT_NAME}" == "pull_request" && "${DELTA_ENABLED}" != "true" ]]; then
+            PLAN_EVENT="pull_request_delta_disabled"
+          fi
+
+          node scripts/ci/plan-ci.mjs \
+            --event "${PLAN_EVENT}" \
+            --changes-z "${CHANGES_FILE}" \
+            --labels-json "${PR_LABELS:-[]}" \
+            --sample-key "${SAMPLE_KEY}" \
+            --github-output "${GITHUB_OUTPUT}" \
+            --summary "${GITHUB_STEP_SUMMARY}"
 
   # ------------------------------------------------------------------
   # One canonical build. Every test job downloads this artifact instead
   # of rebuilding from scratch (saves ~3-4 min per job).
   #
-  # IMPORTANT — two optimizations here make the sub-5-min wall-clock
-  # possible:
+  # IMPORTANT — two optimizations keep this shared build short:
   #
   # 1. `--filter='!@dkg-evm-module'` skips the 1m 54s hardhat compile
   #    (Solidity→bytecode + typechain). No Node test lane consumes its
@@ -113,6 +152,8 @@ jobs:
   # ------------------------------------------------------------------
   build:
     name: Build packages
+    needs: changes
+    if: needs.changes.outputs.run_node == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -238,7 +279,8 @@ jobs:
   # ------------------------------------------------------------------
   tornado-core:
     name: "Tornado: core + storage + chain"
-    needs: build
+    needs: [changes, build]
+    if: needs.changes.outputs.tornado_core == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -261,6 +303,8 @@ jobs:
 
       - name: "Core (442 tests)"
         run: pnpm --filter @origintrail-official/dkg-core test
+      - name: "RDF utilities"
+        run: pnpm --filter @origintrail-official/dkg-rdf-utils test
       - name: "Storage (78 tests)"
         run: pnpm --filter @origintrail-official/dkg-storage test
       - name: "Chain unit (46 tests)"
@@ -291,7 +335,8 @@ jobs:
   # ------------------------------------------------------------------
   tornado-blazegraph:
     name: "Tornado: storage Blazegraph integration (live server)"
-    needs: build
+    needs: [changes, build]
+    if: needs.changes.outputs.tornado_blazegraph == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     services:
@@ -358,7 +403,8 @@ jobs:
   # ------------------------------------------------------------------
   tornado-publisher:
     name: "Tornado: publisher [${{ matrix.shard }}/4]"
-    needs: build
+    needs: [changes, build]
+    if: needs.changes.outputs.tornado_publisher == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
@@ -412,7 +458,8 @@ jobs:
   # ------------------------------------------------------------------
   tornado-agent:
     name: "Tornado: agent [${{ matrix.shard }}/10]"
-    needs: build
+    needs: [changes, build]
+    if: needs.changes.outputs.tornado_agent == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
@@ -457,7 +504,8 @@ jobs:
   # ------------------------------------------------------------------
   bura-cli:
     name: "Bura: cli"
-    needs: build
+    needs: [changes, build]
+    if: needs.changes.outputs.bura_cli == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -484,6 +532,8 @@ jobs:
 
   bura-blazegraph-arm64:
     name: "Bura: Blazegraph arm64 image (native)"
+    needs: changes
+    if: needs.changes.outputs.bura_blazegraph_arm64 == 'true'
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 10
     steps:
@@ -495,7 +545,8 @@ jobs:
 
   bura-supporting:
     name: "Bura: query"
-    needs: build
+    needs: [changes, build]
+    if: needs.changes.outputs.bura_query == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -529,7 +580,8 @@ jobs:
   # ------------------------------------------------------------------
   kosava-node-ui:
     name: "Kosava: node-ui"
-    needs: build
+    needs: [changes, build]
+    if: needs.changes.outputs.kosava_node_ui == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -573,7 +625,8 @@ jobs:
   # (see `ciChromium`) since we only `playwright install chromium`.
   kosava-node-ui-e2e:
     name: "Kosava: node-ui e2e (Playwright real-node devnet)"
-    needs: build
+    needs: [changes, build]
+    if: needs.changes.outputs.kosava_node_ui_e2e == 'true'
     runs-on: ubuntu-latest
     # Cold devnet boot (Solidity compile + 2-node bring-up + on-chain
     # staking/CG registration) + the full real-node suite at 1 worker with
@@ -643,8 +696,9 @@ jobs:
           if-no-files-found: ignore
 
   kosava-supporting:
-    name: "Kosava: adapters + epcis + graph-viz + mcp-server + network-sim"
-    needs: build
+    name: "Kosava: adapters + utilities + demo"
+    needs: [changes, build]
+    if: needs.changes.outputs.kosava_supporting == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -691,9 +745,11 @@ jobs:
             --filter @origintrail-official/dkg-mcp \
             --filter @origintrail-official/dkg-network-sim \
             --filter @origintrail-official/dkg-graph-viz \
+            --filter @origintrail-official/dkg-okf \
             --filter @origintrail-official/dkg-adapter-elizaos \
             --filter @origintrail-official/dkg-adapter-hermes \
             --filter @origintrail-official/dkg-adapter-openclaw \
+            --filter @origintrail-official/dkg-demo \
             run test
 
   # ------------------------------------------------------------------
@@ -711,7 +767,8 @@ jobs:
   # ------------------------------------------------------------------
   kosava-hardhat-plugins:
     name: "Kosava: random-sampling + kafka-plugin (real Hardhat)"
-    needs: build
+    needs: [changes, build]
+    if: needs.changes.outputs.kosava_hardhat_plugins == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -825,11 +882,13 @@ jobs:
   # Tornado Solidity lane — `packages/evm-module` is TORNADO-tier
   # (`dkgv10-spec/CRITICALITY_CATEGORIZATION.md` §1): bugs in the
   # contracts mean financial loss or consensus divergence.
-  #   - PR + no contract changes : no-op fast pass (keeps the required
-  #     check green without spinning up Hardhat).
+  #   - PR + no contract changes : matrix is skipped before runner fan-out;
+  #                                the always-present CI gate stays green.
   #   - PR + contract changes    : 4-way sharded hardhat test, no
   #                                coverage (~5-6 min per shard in
   #                                parallel; previously ~20 min single).
+  #   - merge queue candidate    : same sharded full test suite as a PR,
+  #                                keeping the pre-merge critical path short.
   #   - push (main / v10-rc / …) : full coverage + ratchet safety net,
   #                                single job (coverage reports don't
   #                                compose across shards, so we keep
@@ -840,9 +899,9 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    # PR lane only — sharded 4 ways. Push lane runs the separate
-    # solidity-coverage job below (full coverage + ratchet check).
-    if: github.event_name == 'pull_request'
+    # Candidate lane only — sharded 4 ways. Protected pushes and manual runs
+    # use the separate coverage+ratchet job below.
+    if: (github.event_name == 'pull_request' || github.event_name == 'merge_group') && needs.changes.outputs.contracts == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -851,25 +910,18 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - name: Skip — no contract changes on this PR
-        if: needs.changes.outputs.contracts != 'true'
-        run: echo "::notice::No contracts/*/test/hardhat changes detected — skipping Solidity shard ${{ matrix.shard }}/4. Full coverage still runs on push to main/v10-rc."
 
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
-        if: needs.changes.outputs.contracts == 'true'
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        if: needs.changes.outputs.contracts == 'true'
         with:
           node-version-file: .nvmrc
           cache: pnpm
 
       - name: Install dependencies
-        if: needs.changes.outputs.contracts == 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Cache Hardhat artifacts (NOT typechain)
-        if: needs.changes.outputs.contracts == 'true'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           # `packages/evm-module/typechain` is INTENTIONALLY omitted.
@@ -903,12 +955,10 @@ jobs:
           key: hardhat-${{ runner.os }}-${{ hashFiles('packages/evm-module/contracts/**/*.sol', 'packages/evm-module/hardhat.node.config.ts') }}
 
       - name: Compile contracts
-        if: needs.changes.outputs.contracts == 'true'
         run: npx hardhat compile --config hardhat.node.config.ts
         working-directory: packages/evm-module
 
       - name: Generate TypeChain bindings (always fresh)
-        if: needs.changes.outputs.contracts == 'true'
         # Typechain is never cached (see Cache Hardhat artifacts step),
         # so the output dir is always empty here on a cache hit and
         # we generate from scratch against the artifacts that were
@@ -940,7 +990,6 @@ jobs:
         working-directory: packages/evm-module
 
       - name: "Hardhat tests (shard ${{ matrix.shard }}/4)"
-        if: needs.changes.outputs.contracts == 'true'
         # Round-robin distribute the 48 .test.ts files across 4
         # shards. `sort` gives deterministic ordering so the same file
         # always lands in the same shard across runs — makes failure
@@ -965,8 +1014,8 @@ jobs:
           NODE_OPTIONS: --max-old-space-size=8192
 
   # ------------------------------------------------------------------
-  # Tornado Solidity coverage lane — safety net on push to main/v10-rc
-  # only. Full Solidity suite + solidity-coverage + coverage ratchet.
+  # Tornado Solidity coverage lane — safety net on protected push or manual
+  # dispatch. Full Solidity suite + solidity-coverage + coverage ratchet.
   # Not sharded because solidity-coverage's instrumentation state
   # doesn't compose across parallel runners. Wall-clock on push is
   # not on the critical path so ~20-25 min here is acceptable.
@@ -976,7 +1025,7 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' && github.event_name != 'merge_group'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -1180,3 +1229,40 @@ jobs:
         with:
           sarif_file: packages/evm-module/solhint.sarif
           category: solhint
+
+  # One stable branch-protection check. It also verifies that every lane the
+  # planner selected actually ran successfully, so a typo in a job-level `if`
+  # cannot silently turn a required test into a green skip.
+  ci-gate:
+    name: CI gate
+    if: always()
+    needs:
+      - changes
+      - build
+      - tornado-core
+      - tornado-blazegraph
+      - tornado-publisher
+      - tornado-agent
+      - bura-cli
+      - bura-blazegraph-arm64
+      - bura-supporting
+      - kosava-node-ui
+      - kosava-node-ui-e2e
+      - kosava-supporting
+      - kosava-hardhat-plugins
+      - abi-freshness
+      - solidity
+      - solidity-coverage
+      - tornado-static-analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Verify selected lanes completed
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PLAN_JSON: ${{ needs.changes.outputs.plan_json }}
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: node scripts/ci/assert-ci-results.mjs --workflow primary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,15 +274,95 @@ jobs:
           if-no-files-found: error
 
   # ------------------------------------------------------------------
-  # Tornado core lane: core + storage + chain unit tests. These are all
-  # sub-minute suites so we keep them bundled on one runner.
+  # Compile each EVM flavor ONCE, in parallel with the shared Node build.
+  # Several downstream jobs previously repeated the same 65-90 second
+  # compile on every runner. The immutable workflow artifact lets all shards
+  # consume byte-for-byte identical outputs without putting Solidity compile
+  # time on their critical path.
+  # ------------------------------------------------------------------
+  evm-node-test-artifacts:
+    name: Compile EVM test artifacts (0.8.20/london)
+    needs: changes
+    if: needs.changes.outputs.tornado_core == 'true' || needs.changes.outputs.bura_cli == 'true' || needs.changes.outputs.kosava_hardhat_plugins == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Compile EVM contracts for shared Hardhat harnesses
+        run: pnpm --filter @origintrail-official/dkg-evm-module exec hardhat compile --config hardhat.node.config.ts
+      - name: Package EVM test artifacts
+        run: tar -czf /tmp/evm-node-test-artifacts.tgz packages/evm-module/artifacts packages/evm-module/cache
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: evm-node-test-artifacts
+          path: /tmp/evm-node-test-artifacts.tgz
+          retention-days: 1
+          if-no-files-found: error
+
+  evm-devnet-test-artifacts:
+    name: Compile devnet EVM artifacts (0.8.24/cancun)
+    needs: changes
+    if: needs.changes.outputs.kosava_node_ui_e2e == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Compile EVM contracts for the real-node devnet
+        run: pnpm --filter @origintrail-official/dkg-evm-module exec hardhat compile --config hardhat.devnet.config.ts
+      - name: Package devnet EVM artifacts
+        run: tar -czf /tmp/evm-devnet-test-artifacts.tgz packages/evm-module/artifacts-devnet packages/evm-module/cache-devnet
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: evm-devnet-test-artifacts
+          path: /tmp/evm-devnet-test-artifacts.tgz
+          retention-days: 1
+          if-no-files-found: error
+
+  # ------------------------------------------------------------------
+  # Tornado core lane. Pure core/RDF/storage tests share one runner; the
+  # serial real-Hardhat chain suite is split across isolated runners. Every
+  # chain shard gets its own node and test context, so no state is shared.
   # ------------------------------------------------------------------
   tornado-core:
-    name: "Tornado: core + storage + chain"
-    needs: [changes, build]
+    name: "Tornado: ${{ matrix.label }}"
+    needs: [changes, build, evm-node-test-artifacts]
     if: needs.changes.outputs.tornado_core == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: core + RDF + storage
+            suite: core
+            shard: 0
+          - label: chain [1/3]
+            suite: chain
+            shard: 1
+          - label: chain [2/3]
+            suite: chain
+            shard: 2
+          - label: chain [3/3]
+            suite: chain
+            shard: 3
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -300,15 +380,30 @@ jobs:
           path: /tmp
       - name: Restore build outputs
         run: tar -xzf /tmp/build-outputs.tgz
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        if: matrix.suite == 'chain'
+        with:
+          name: evm-node-test-artifacts
+          path: /tmp
+      - name: Restore EVM test artifacts
+        if: matrix.suite == 'chain'
+        run: tar -xzf /tmp/evm-node-test-artifacts.tgz
 
-      - name: "Core (442 tests)"
-        run: pnpm --filter @origintrail-official/dkg-core test
-      - name: "RDF utilities"
-        run: pnpm --filter @origintrail-official/dkg-rdf-utils test
-      - name: "Storage (78 tests)"
-        run: pnpm --filter @origintrail-official/dkg-storage test
-      - name: "Chain unit (46 tests)"
-        run: pnpm --filter @origintrail-official/dkg-chain test
+      - name: Core, RDF utilities, and storage tests
+        if: matrix.suite == 'core'
+        run: |
+          pnpm --filter @origintrail-official/dkg-core test
+          pnpm --filter @origintrail-official/dkg-rdf-utils test
+          pnpm --filter @origintrail-official/dkg-storage test
+      - name: "Chain tests (shard ${{ matrix.shard }}/3)"
+        if: matrix.suite == 'chain'
+        env:
+          SHARD_ID: ${{ matrix.shard }}
+        run: |
+          set -euo pipefail
+          mapfile -t SHARD_FILES < <(node scripts/ci/plan-vitest-shard.mjs chain "$SHARD_ID")
+          test "${#SHARD_FILES[@]}" -gt 0
+          pnpm --filter @origintrail-official/dkg-chain exec vitest run "${SHARD_FILES[@]}"
 
   # ------------------------------------------------------------------
   # Tornado Blazegraph integration lane — runs the storage adapter's
@@ -495,19 +590,25 @@ jobs:
 
   # ------------------------------------------------------------------
   # Bura lane — `cli` is the heaviest BURA package (CLI daemon, HTTP API,
-  # auth, keystore, migration, indexer) so it owns a runner. The
-  # remaining BURA package (`query`) runs on its own runner.
+  # auth, keystore, migration, indexer). It is intentionally configured with
+  # one Vitest worker because every file shares a real Hardhat harness, so we
+  # parallelize safely across isolated CI runners instead. The remaining BURA
+  # package (`query`) runs on its own runner.
   #
   # Tier: BURA — `dkgv10-spec/CRITICALITY_CATEGORIZATION.md` §1. Packages
   # on the critical path for users/operators; auth & quorum bugs here
   # degrade service but do not threaten protocol consensus.
   # ------------------------------------------------------------------
   bura-cli:
-    name: "Bura: cli"
-    needs: [changes, build]
+    name: "Bura: cli [${{ matrix.shard }}/4]"
+    needs: [changes, build, evm-node-test-artifacts]
     if: needs.changes.outputs.bura_cli == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -525,10 +626,23 @@ jobs:
           path: /tmp
       - name: Restore build outputs
         run: tar -xzf /tmp/build-outputs.tgz
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: evm-node-test-artifacts
+          path: /tmp
+      - name: Restore EVM test artifacts
+        run: tar -xzf /tmp/evm-node-test-artifacts.tgz
       - name: "Verify provisioned Blazegraph image contract"
+        if: matrix.shard == 1
         run: bash scripts/ci/verify-blazegraph-image-contract.sh
-      - name: "CLI tests"
-        run: pnpm --filter @origintrail-official/dkg test
+      - name: "CLI tests (shard ${{ matrix.shard }}/4)"
+        env:
+          SHARD_ID: ${{ matrix.shard }}
+        run: |
+          set -euo pipefail
+          mapfile -t SHARD_FILES < <(node scripts/ci/plan-vitest-shard.mjs cli "$SHARD_ID")
+          test "${#SHARD_FILES[@]}" -gt 0
+          pnpm --filter @origintrail-official/dkg exec vitest run "${SHARD_FILES[@]}"
 
   bura-blazegraph-arm64:
     name: "Bura: Blazegraph arm64 image (native)"
@@ -606,12 +720,14 @@ jobs:
       - name: "node-ui tests"
         run: pnpm --filter @origintrail-official/dkg-node-ui test
 
-  # node-ui Playwright e2e — REAL NODE, NO MOCKS. The suite boots a live
-  # 4-node devnet (Hardhat + four DKG daemons) via Playwright's `webServer`
-  # (see `e2e/bootstrap-devnet.ts`, chained `bootstrap && pnpm dev:ui`),
-  # drives the real UI against node 1's live `/api`, and tears the devnet
-  # down in `e2e/global-teardown.ts` when the run finishes. There is no
-  # route-mock lane anymore: every test exercises real daemon round-trips.
+  # node-ui Playwright e2e — REAL NODE, NO MOCKS. Each shard boots its OWN
+  # isolated 4-node devnet (Hardhat + four DKG daemons) via Playwright's
+  # `webServer` (see `e2e/bootstrap-devnet.ts`, chained `bootstrap && pnpm
+  # dev:ui`), drives the real UI against node 1's live `/api`, and tears that
+  # devnet down in `e2e/global-teardown.ts`. There is no route-mock lane:
+  # every test still exercises real daemon round-trips. Sharding across
+  # runners preserves the one-worker-per-devnet contention guard in
+  # playwright.config.ts while removing the 326-test serial wall-clock tail.
   #
   # Why 4 nodes: VM publishing needs StorageACK quorum, and scripts/devnet.sh
   # pins `minimumRequiredSignatures = 3` (the real mainnet 3-of-N quorum — DO
@@ -624,15 +740,18 @@ jobs:
   # Channel is pinned to bundled chromium in playwright.config.ts under CI
   # (see `ciChromium`) since we only `playwright install chromium`.
   kosava-node-ui-e2e:
-    name: "Kosava: node-ui e2e (Playwright real-node devnet)"
-    needs: [changes, build]
+    name: "Kosava: node-ui e2e [${{ matrix.shard }}/7] (Playwright real-node devnet)"
+    needs: [changes, build, evm-devnet-test-artifacts]
     if: needs.changes.outputs.kosava_node_ui_e2e == 'true'
     runs-on: ubuntu-latest
-    # Cold devnet boot (Solidity compile + 2-node bring-up + on-chain
-    # staking/CG registration) + the full real-node suite at 1 worker with
-    # retries. Generous so a slow runner or a publish retry never flakes the
-    # whole lane on a timeout.
+    # Cold 4-node bring-up + on-chain staking/CG registration + one seventh of
+    # the real-node suite at one worker, with retries. Generous so a slow
+    # runner or a publish retry never flakes the whole lane on a timeout.
     timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4, 5, 6, 7]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -650,30 +769,23 @@ jobs:
           path: /tmp
       - name: Restore build outputs
         run: tar -xzf /tmp/build-outputs.tgz
-      # The shared `build` artifact skips the Solidity compile (DKG_SKIP_EVM_BUILD=1),
-      # so the EVM artifacts/typechain bindings the devnet's `hardhat node` +
-      # `hardhat deploy` need aren't present. Compile them HERE — in a dedicated,
-      # observable step — so the devnet boot inside Playwright's `webServer`
-      # reuses cached artifacts and stays well inside the webServer timeout
-      # (and a compile failure is localised to this step, not buried in a
-      # webServer timeout). devnet.sh now compiles + boots with the DEVNET
-      # hardhat config (`--config hardhat.devnet.config.ts`: solc 0.8.24 +
-      # cancun), so warm the SAME config here — otherwise this step compiles the
-      # default 0.8.20/london bytecode and the real devnet-config compile moves
-      # back into the webServer boot (otReviewAgent #1403 P2).
-      - name: Compile EVM contracts (for the devnet boot)
-        run: pnpm --filter @origintrail-official/dkg-evm-module exec hardhat compile --config hardhat.devnet.config.ts
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: evm-devnet-test-artifacts
+          path: /tmp
+      - name: Restore devnet EVM artifacts
+        run: tar -xzf /tmp/evm-devnet-test-artifacts.tgz
       - name: Install Playwright Chromium
         run: pnpm --filter @origintrail-official/dkg-node-ui exec playwright install chromium --with-deps
-      - name: "node-ui real-node Playwright e2e (boots + tears down a live devnet)"
-        run: pnpm --filter @origintrail-official/dkg-node-ui test:e2e
+      - name: "node-ui real-node Playwright e2e (shard ${{ matrix.shard }}/7)"
+        run: pnpm --filter @origintrail-official/dkg-node-ui exec playwright test --shard=${{ matrix.shard }}/7
       # Upload the HTML report + traces so intermittent browser/devnet failures
       # are diagnosable from the Actions UI (Codex review on PR #832).
       - name: Upload Playwright report
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: node-ui-playwright-report
+          name: node-ui-playwright-report-${{ matrix.shard }}-of-7
           path: |
             packages/node-ui/playwright-report/
             packages/node-ui/test-results/
@@ -687,7 +799,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: node-ui-devnet-logs
+          name: node-ui-devnet-logs-${{ matrix.shard }}-of-7
           path: |
             .devnet/node*/daemon.log
             .devnet/hardhat/node.log
@@ -761,13 +873,13 @@ jobs:
   # node via the shared `../chain/test/hardhat-global-setup.ts`
   # (hardhat-harness deploys with `hardhat.node.config.ts`) on every
   # vitest run — that needs the Solidity artifacts the shared `build`
-  # deliberately skips (DKG_SKIP_EVM_BUILD=1). So they get their own
-  # lane with an explicit compile step, mirroring the node-ui e2e lane.
+  # deliberately skips (DKG_SKIP_EVM_BUILD=1). The parallel EVM artifact
+  # producer above compiles them once for this and the other harness users.
   # No mocks: real contracts, real chain.
   # ------------------------------------------------------------------
   kosava-hardhat-plugins:
     name: "Kosava: random-sampling + kafka-plugin (real Hardhat)"
-    needs: [changes, build]
+    needs: [changes, build, evm-node-test-artifacts]
     if: needs.changes.outputs.kosava_hardhat_plugins == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -788,14 +900,12 @@ jobs:
           path: /tmp
       - name: Restore build outputs
         run: tar -xzf /tmp/build-outputs.tgz
-      # The shared build skips the Solidity compile (DKG_SKIP_EVM_BUILD=1),
-      # so the artifacts the Hardhat globalSetup's `hardhat deploy` needs
-      # aren't present. Compile them HERE — same config the harness deploys
-      # with — in a dedicated, observable step so the globalSetup reuses
-      # cached artifacts and a compile failure is localised here rather
-      # than buried inside a test timeout.
-      - name: Compile EVM contracts (for the Hardhat globalSetup)
-        run: pnpm --filter @origintrail-official/dkg-evm-module exec hardhat compile --config hardhat.node.config.ts
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: evm-node-test-artifacts
+          path: /tmp
+      - name: Restore EVM test artifacts
+        run: tar -xzf /tmp/evm-node-test-artifacts.tgz
       - name: "random-sampling tests (real Hardhat, no mocks)"
         run: pnpm --filter @origintrail-official/dkg-random-sampling test
       - name: "kafka-plugin tests (real Hardhat, no mocks)"
@@ -1239,6 +1349,8 @@ jobs:
     needs:
       - changes
       - build
+      - evm-node-test-artifacts
+      - evm-devnet-test-artifacts
       - tornado-core
       - tornado-blazegraph
       - tornado-publisher

--- a/.github/workflows/evm-integration.yml
+++ b/.github/workflows/evm-integration.yml
@@ -3,30 +3,14 @@ name: EVM Integration Tests
 on:
   push:
     branches: [main, v10-rc, release/rc.12, rc17-vm-wip]
-    paths:
-      - 'packages/chain/**'
-      - 'packages/publisher/**'
-      - 'packages/agent/**'
-      - 'packages/core/**'
-      - 'packages/evm-module/contracts/**'
-      - 'packages/evm-module/deploy/**'
-      - 'scripts/test-evm-integration.sh'
-      - '.github/workflows/evm-integration.yml'
   pull_request:
     branches: [main, v10-rc, release/rc.12, rc17-vm-wip]
-    paths:
-      - 'packages/chain/**'
-      - 'packages/publisher/**'
-      - 'packages/agent/**'
-      - 'packages/core/**'
-      - 'packages/evm-module/contracts/**'
-      - 'packages/evm-module/deploy/**'
-      - 'scripts/test-evm-integration.sh'
-      - '.github/workflows/evm-integration.yml'
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+  merge_group:
   workflow_dispatch:
 
 concurrency:
-  group: evm-integration-${{ github.ref }}
+  group: evm-integration-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 # Minimum-needed token scope (see ci.yml header for rationale).
@@ -34,19 +18,72 @@ permissions:
   contents: read
 
 jobs:
+  plan:
+    name: Plan EVM delta
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      evm_matrix: ${{ steps.plan.outputs.evm_matrix }}
+      plan_json: ${{ steps.plan.outputs.plan_json }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 2
+      - name: Compute fail-closed EVM plan
+        id: plan
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          MERGE_SHA: ${{ github.sha }}
+          PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+          SAMPLE_KEY: ${{ github.event.pull_request.head.sha || github.sha }}
+          DELTA_ENABLED: ${{ vars.CI_DELTA_ENABLED == 'true' && github.base_ref == 'main' }}
+        run: |
+          set -euo pipefail
+          CHANGES_FILE="${RUNNER_TEMP}/ci-name-status.z"
+          : > "${CHANGES_FILE}"
+
+          if [[ "${EVENT_NAME}" == "pull_request" ]]; then
+            if [[ -z "${BASE_SHA}" || -z "${MERGE_SHA}" ]]; then
+              echo "::error::Missing pull-request base/merge SHA"
+              exit 1
+            fi
+            if ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+              git fetch --no-tags --depth=1 origin "${BASE_SHA}"
+            fi
+            git cat-file -e "${MERGE_SHA}^{commit}"
+            git diff --name-status -z "${BASE_SHA}" "${MERGE_SHA}" > "${CHANGES_FILE}"
+          fi
+
+          PLAN_EVENT="${EVENT_NAME}"
+          if [[ "${EVENT_NAME}" == "pull_request" && "${DELTA_ENABLED}" != "true" ]]; then
+            PLAN_EVENT="pull_request_delta_disabled"
+          fi
+
+          node scripts/ci/plan-ci.mjs \
+            --event "${PLAN_EVENT}" \
+            --changes-z "${CHANGES_FILE}" \
+            --labels-json "${PR_LABELS:-[]}" \
+            --sample-key "${SAMPLE_KEY}" \
+            --github-output "${GITHUB_OUTPUT}" \
+            --summary "${GITHUB_STEP_SUMMARY}"
+
   # All three matrix scopes (chain, publisher, agent) are TORNADO-tier per
   # `dkgv10-spec/CRITICALITY_CATEGORIZATION.md` §1 — this workflow drives
   # them against a real Hardhat node to catch EVM-side regressions the
   # unit-test lanes in `ci.yml` can't reach.
   evm-integration:
     name: "Tornado EVM integration: ${{ matrix.scope }}"
+    needs: plan
+    if: needs.plan.outputs.evm_matrix != '[]'
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
     strategy:
       fail-fast: false
       matrix:
-        scope: [chain, publisher, agent]
+        scope: ${{ fromJSON(needs.plan.outputs.evm_matrix) }}
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -76,5 +113,24 @@ jobs:
       - name: Build packages
         run: pnpm run build:packages
 
-      - name: Run EVM integration tests (${{ matrix.scope }})
-        run: ./scripts/test-evm-integration.sh ${{ matrix.scope }}
+      - name: Run selected EVM integration scope
+        env:
+          EVM_SCOPE: ${{ matrix.scope }}
+        run: ./scripts/test-evm-integration.sh "${EVM_SCOPE}"
+
+  evm-gate:
+    name: EVM integration gate
+    if: always()
+    needs: [plan, evm-integration]
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Verify selected EVM scopes completed
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PLAN_JSON: ${{ needs.plan.outputs.plan_json }}
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: node scripts/ci/assert-ci-results.mjs --workflow evm

--- a/.github/workflows/evm-integration.yml
+++ b/.github/workflows/evm-integration.yml
@@ -26,10 +26,27 @@ jobs:
       evm_matrix: ${{ steps.plan.outputs.evm_matrix }}
       plan_json: ${{ steps.plan.outputs.plan_json }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      # The merge candidate is untrusted input: use it only to calculate the
+      # changed-file set, and never execute its CI planner or validator here.
+      - name: Checkout merge candidate
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           fetch-depth: 2
+          path: candidate
+      # Keep CI policy outside the merge candidate and pin it to an immutable,
+      # reviewed commit. Policy updates deliberately rotate this SHA.
+      - name: Checkout trusted CI controller
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: OriginTrail/dkg
+          ref: c441bd6766ace67e331c0dfc6e22cb1325a6e1f6
+          persist-credentials: false
+          path: trusted-ci
+          sparse-checkout: |
+            scripts/ci
+            scripts/lib
+          sparse-checkout-cone-mode: false
       - name: Compute fail-closed EVM plan
         id: plan
         env:
@@ -49,11 +66,12 @@ jobs:
               echo "::error::Missing pull-request base/merge SHA"
               exit 1
             fi
-            if ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
-              git fetch --no-tags --depth=1 origin "${BASE_SHA}"
+            if ! git -C candidate cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+              git -C candidate fetch --no-tags --depth=1 origin "${BASE_SHA}"
             fi
-            git cat-file -e "${MERGE_SHA}^{commit}"
-            git diff --name-status -z "${BASE_SHA}" "${MERGE_SHA}" > "${CHANGES_FILE}"
+            git -C candidate cat-file -e "${MERGE_SHA}^{commit}"
+            git -C candidate diff --name-status -z \
+              "${BASE_SHA}" "${MERGE_SHA}" > "${CHANGES_FILE}"
           fi
 
           PLAN_EVENT="${EVENT_NAME}"
@@ -61,7 +79,7 @@ jobs:
             PLAN_EVENT="pull_request_delta_disabled"
           fi
 
-          node scripts/ci/plan-ci.mjs \
+          node trusted-ci/scripts/ci/plan-ci.mjs \
             --event "${PLAN_EVENT}" \
             --changes-z "${CHANGES_FILE}" \
             --labels-json "${PR_LABELS:-[]}" \
@@ -125,12 +143,20 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Checkout trusted CI controller
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          repository: OriginTrail/dkg
+          ref: c441bd6766ace67e331c0dfc6e22cb1325a6e1f6
           persist-credentials: false
+          path: trusted-ci
+          sparse-checkout: |
+            scripts/ci
+            scripts/lib
+          sparse-checkout-cone-mode: false
       - name: Verify selected EVM scopes completed
         env:
           EVENT_NAME: ${{ github.event_name }}
           PLAN_JSON: ${{ needs.plan.outputs.plan_json }}
           NEEDS_JSON: ${{ toJSON(needs) }}
-        run: node scripts/ci/assert-ci-results.mjs --workflow evm
+        run: node trusted-ci/scripts/ci/assert-ci-results.mjs --workflow evm

--- a/demo/package.json
+++ b/demo/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "node --test kafka-streams/test/*.mjs"
+    "test": "node --test kafka-streams/test/*.mjs epcis-bike/test/*.mjs"
   },
   "dependencies": {
     "@multiformats/multiaddr": "^13.0.3",

--- a/docs/ci-delta-policy.md
+++ b/docs/ci-delta-policy.md
@@ -105,11 +105,34 @@ for about 86% of compute.
 - A leaf supporting-package change should take roughly 3 minutes instead of 14
   (shared build plus the supporting lane).
 - A Hardhat-plugin-only change should take roughly 5 minutes.
-- UI and shared protocol changes retain expensive downstream E2E lanes, so
-  their isolated wall time may not fall much. They still launch fewer runners,
-  reducing queue pressure for every concurrent PR.
+- UI and shared protocol changes still run the real-node E2E suite, but its 326
+  tests now run in seven isolated devnet shards instead of one serial lane.
 
-These are measured projections, not latency guarantees; runner availability
+The full PR path was also measured independently of delta selection. On the
+same PR, the original full workflow took
+[13m07s](https://github.com/OriginTrail/dkg/actions/runs/29321182804); after
+sharing EVM compilation and sharding the long CLI, chain, and real-node suites,
+the full workflow and its final gate passed in
+[6m05s](https://github.com/OriginTrail/dkg/actions/runs/29325452377), a 53.5%
+wall-time reduction. That validation deliberately ran with delta disabled and
+retained the complete key-suite totals:
+
+- CLI: 2,705 passed + 12 skipped = 2,717 tests across 190 files.
+- Chain: 1,033 passed + 1 skipped = 1,034 tests across 58 files.
+- Real-node Playwright: 318 passed + 8 skipped = 326 tests.
+
+Parallelizing a forced-full PR trades compute for latency: the measured runner
+total increased from 87.9 to 109.0 minutes. Delta routing is what reduces
+runner use on ordinary leaf/documentation PRs; full global/high-risk changes
+pay the extra parallel compute to keep feedback near six minutes.
+
+Protected-branch pushes and manual runs additionally retain the unsharded
+Solidity coverage ratchet. That post-merge safety net currently takes about
+25 minutes and is intentionally outside the PR feedback target. Safely
+parallelizing it requires merging raw coverage counters and proving the merged
+result equals the full baseline; concatenating LCOV files would be incorrect.
+
+Measured runs and projections are not latency guarantees; runner availability
 and test variance still affect elapsed time.
 
 ## Local verification

--- a/docs/ci-delta-policy.md
+++ b/docs/ci-delta-policy.md
@@ -1,0 +1,120 @@
+# Delta CI policy
+
+## Decision
+
+Use affected-lane CI for pull-request feedback, then run full CI against the
+exact merge candidate in GitHub's merge queue. Keep full CI on protected-branch
+pushes and manual dispatches. Do not add a `develop` branch solely for CI: that
+would postpone integration failures and collect unrelated changes into a large
+`develop -> main` batch.
+
+The delta planner is deliberately conservative. It selects the changed
+workspace's owning lane plus known downstream consumers, and falls back to full
+CI whenever it cannot prove that a smaller plan is safe.
+
+## Policy
+
+| Change/event | CI behavior |
+| --- | --- |
+| Pull request, known workspace | Owning lane plus declared downstream unit/integration lanes |
+| Documentation only | Planner and aggregate gates only |
+| `core` / `rdf-utils` | All downstream Node and real-EVM lanes |
+| `evm-module` | Full CI, including Solidity |
+| Root dependency/build config, workflow, planner, or generic scripts | Full CI |
+| Any workspace `package.json` | Full CI because the base and head dependency graphs may differ |
+| Rename, copy, deletion, unknown path, or no diff | Full CI |
+| More than 100 production files or at least 4 workspaces | Full CI |
+| PR with `ci:full` label | Full CI |
+| Deterministic 5% PR audit sample | Full CI |
+| Merge queue, protected-branch push, or manual dispatch | Full CI |
+
+The planner reads `git diff --name-status -z`, so spaces and other shell-hostile
+file names cannot alter the decision. Its routing table lives in
+`scripts/lib/ci-delta.mjs` and is covered by table/snapshot-style tests in
+`scripts/lib/__tests__/ci-delta.test.mjs`.
+
+## Reliability controls
+
+- Every code PR selected for Node tests still builds the entire Node workspace,
+  catching cross-package type and build failures even when a test lane is
+  skipped.
+- Shared packages run conservative reverse consumers and explicit integrations;
+  this includes undeclared edges such as committed EVM ABIs consumed by `chain`
+  and the real devnet used by node-UI E2E.
+- Unknown inputs fail closed to full CI instead of silently receiving no tests.
+- `CI gate` and `EVM integration gate` are always present. They fail when a
+  selected job was accidentally skipped, failed, or was cancelled.
+- Full merge-queue CI tests the exact combined commit before it lands. Full
+  protected-branch CI remains a second safety net after merge.
+- Five percent of PR commits run full CI even when delta would be possible. This
+  continuously audits the routing model and exposes a missing dependency edge.
+- The routing tests enumerate all package/demo workspaces with a `test` script.
+  They also close three existing coverage holes: `rdf-utils`, `okf`, and `demo`
+  are now included in explicit CI lanes.
+
+Test-result snapshots are useful for checking that the routing plan stays
+stable, but they cannot establish that a skipped test would have passed. That
+is why snapshots guard the planner while full merge-queue CI remains the final
+correctness gate.
+
+## Required repository settings
+
+Delta selection is **default-off**. Until the repository variable
+`CI_DELTA_ENABLED` is exactly `true`, PRs deliberately receive full CI. Activate
+it only after all safeguards below are configured:
+
+1. Create the `ci:full` label.
+2. Enable GitHub merge queue for `main`.
+3. Require the `CI gate` and `EVM integration gate` status checks in the branch
+   ruleset. Individual matrix job names should not be required because skipped
+   lanes intentionally do not exist on every PR.
+4. Set the Actions repository variable `CI_DELTA_ENABLED=true`.
+
+This ordering prevents selective CI from becoming active while GitHub can still
+merge without a full candidate run. Removing the variable (or setting it to any
+value other than `true`) is the immediate rollback switch.
+
+The initial workflow allowlist enables delta only for PRs whose base is `main`.
+Release/RC PRs continue to run full CI even when the variable is true. Add a
+release branch to that expression only after it has the same required gates and
+merge-queue protection.
+
+## Developer workflow
+
+- Open or update a PR normally. The **Plan CI delta** job summary lists selected
+  and skipped lanes and explains the reason.
+- Add `ci:full` when the change is riskier than its paths imply or when a
+  reviewer asks for the complete suite. Adding/removing the label reruns CI.
+- Use **Run workflow** for an unconditional full run on any branch.
+- If a new package, dependency edge, or integration consumer is introduced,
+  update `WORKSPACE_RULES` and its routing snapshot in the same PR. A package
+  manifest change already forces full CI for that PR.
+
+## Measured baseline and expected effect
+
+After the guarded rollout is activated:
+
+Ten recent successful PR runs had a median wall time of about **14.0 minutes**
+and used about **84.6 runner-minutes**. The five largest consumers were agent,
+publisher, real-devnet UI E2E, CLI, and core/storage/chain, together accounting
+for about 86% of compute.
+
+- A CHANGELOG-only PR ([#1672](https://github.com/OriginTrail/dkg/pull/1672))
+  launched 28 successful runners, used 83.6 runner-minutes, and took 12m57s;
+  it now needs only planners and aggregate gates.
+- A leaf supporting-package change should take roughly 3 minutes instead of 14
+  (shared build plus the supporting lane).
+- A Hardhat-plugin-only change should take roughly 5 minutes.
+- UI and shared protocol changes retain expensive downstream E2E lanes, so
+  their isolated wall time may not fall much. They still launch fewer runners,
+  reducing queue pressure for every concurrent PR.
+
+These are measured projections, not latency guarantees; runner availability
+and test variance still affect elapsed time.
+
+## Local verification
+
+```sh
+node --test scripts/lib/__tests__/ci-delta.test.mjs
+actionlint .github/workflows/ci.yml .github/workflows/evm-integration.yml
+```

--- a/packages/chain/test/bounded-retry-fetch.test.ts
+++ b/packages/chain/test/bounded-retry-fetch.test.ts
@@ -68,6 +68,23 @@ describe('boundedRetryFetchRequest — current single-arg retry budget (#894)', 
     // No timer advance — if the impl slept here this would still be pending.
     await expect(verdict).resolves.toBe(false);
   });
+
+  it('starts a fresh retry budget after the request object has aged past the old wall-clock deadline', async () => {
+    // Regression guard: the budget was once a Date.now() deadline captured at
+    // FetchRequest construction. Once that deadline elapsed, every later
+    // top-level request stopped retrying. Drive the retry function directly so
+    // this contract is deterministic and independent of real HTTP backoff.
+    vi.useFakeTimers({ now: 0 });
+    const req = boundedRetryFetchRequest(URL);
+    const retry = req.retryFunc!;
+
+    expect(await decideWithFakeTimers(retry, req, 0)).toBe(true);
+
+    // A new top-level request begins again at attempt 0, even long after the
+    // old construction-time budget would have expired.
+    vi.setSystemTime(60_000);
+    expect(await decideWithFakeTimers(retry, req, 0)).toBe(true);
+  });
 });
 
 // The parametrised `(url, maxRetries)` contract — the core of immediate failover:

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -2369,36 +2369,6 @@ describe('init() RPC-exhaustion bounding (perpetual 429)', () => {
     expect(elapsed).toBeLessThan(45_000);
   }, 60_000);
 
-  it('keeps the retry budget PER-REQUEST — a later request still retries (Codex PR #901 round-3 :125)', async () => {
-    // Regression guard: the budget was once a `Date.now()` deadline captured at
-    // provider construction, so after the budget elapsed (node uptime) EVERY
-    // later request lost all retries. Two sequential reads, spaced past the
-    // backoff budget, must BOTH retry the RPC multiple times.
-    let hits = 0;
-    server = createServer((_req, res) => {
-      hits += 1;
-      res.writeHead(429, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ jsonrpc: '2.0', id: null, error: { code: -32005, message: 'rate limited' } }));
-    });
-    await new Promise<void>((resolve) => server!.listen(0, '127.0.0.1', () => resolve()));
-    const addr = server.address();
-    if (!addr || typeof addr === 'string') throw new Error('mock RPC failed to bind');
-    url = `http://127.0.0.1:${addr.port}`;
-    const a = track(new EVMChainAdapter(minimalConfig({ rpcUrl: url, rpcUrls: [] })));
-
-    // First read: exhaust + count its retries. >1 hit ⇒ it retried.
-    hits = 0;
-    await a.createOnChainContextGraph({ accessPolicy: 1, publishPolicy: 0 }).catch(() => {});
-    const firstRequestHits = hits;
-    expect(firstRequestHits).toBeGreaterThan(1);
-
-    // Second read (provider already "aged" past the old construction-time
-    // deadline by the first request's ~7.5s of backoff): must ALSO retry. Under
-    // the construction-time-deadline bug this would have made exactly 1 hit.
-    hits = 0;
-    await a.createOnChainContextGraph({ accessPolicy: 1, publishPolicy: 0 }).catch(() => {});
-    expect(hits).toBeGreaterThan(1);
-  }, 60_000);
 });
 
 describe('PR3 / RC11 — publish-preflight TTL cache', () => {

--- a/packages/node-ui/test/markdown-message.test.ts
+++ b/packages/node-ui/test/markdown-message.test.ts
@@ -232,6 +232,14 @@ describe('MarkdownMessage rendering', () => {
     expect(container.querySelector('.v10-md-pre-fallback, .v10-md-pre-rendered')).toBeTruthy();
     // Copy button is part of the CodeBlock.
     expect(container.querySelector('.v10-md-copy')).toBeTruthy();
+    // Wait for the dynamic import's mock factory before the next test resets
+    // the module cache and import counter. Otherwise a late resolution can be
+    // misattributed to the following no-shiki test under full-suite load.
+    await act(async () => {
+      await vi.waitFor(() => {
+        expect(shikiImportCount).toBe(1);
+      });
+    });
     await unmount();
   });
 

--- a/scripts/ci/assert-ci-results.mjs
+++ b/scripts/ci/assert-ci-results.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+
+import { parseArgs } from 'node:util';
+import {
+  validateEvmResults,
+  validatePrimaryResults,
+} from '../lib/ci-results.mjs';
+
+const { values } = parseArgs({
+  options: {
+    workflow: { type: 'string' },
+  },
+  strict: true,
+});
+
+if (!['primary', 'evm'].includes(values.workflow)) {
+  throw new Error('--workflow must be primary or evm');
+}
+
+const plan = JSON.parse(process.env.PLAN_JSON ?? 'null');
+const needs = JSON.parse(process.env.NEEDS_JSON ?? 'null');
+if (!plan || !needs) throw new Error('PLAN_JSON and NEEDS_JSON are required');
+
+const errors = values.workflow === 'primary'
+  ? validatePrimaryResults({ eventName: process.env.EVENT_NAME, plan, needs })
+  : validateEvmResults({ eventName: process.env.EVENT_NAME, plan, needs });
+
+if (errors.length) {
+  for (const error of errors) process.stderr.write(`::error::${error}\n`);
+  process.exitCode = 1;
+} else {
+  process.stdout.write(`CI ${values.workflow} gate passed.\n`);
+}

--- a/scripts/ci/plan-ci.mjs
+++ b/scripts/ci/plan-ci.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import { parseArgs } from 'node:util';
+import {
+  githubOutputsForPlan,
+  parseNameStatusZ,
+  planCi,
+  renderPlanSummary,
+} from '../lib/ci-delta.mjs';
+
+const { values } = parseArgs({
+  options: {
+    event: { type: 'string' },
+    'changes-z': { type: 'string' },
+    'labels-json': { type: 'string', default: '[]' },
+    'sample-key': { type: 'string', default: '' },
+    'github-output': { type: 'string' },
+    summary: { type: 'string' },
+  },
+  strict: true,
+});
+
+if (!values.event) throw new Error('--event is required');
+
+const changeEntries = values['changes-z']
+  ? parseNameStatusZ(fs.readFileSync(values['changes-z']))
+  : [];
+const labels = JSON.parse(values['labels-json']) ?? [];
+if (!Array.isArray(labels) || labels.some((label) => typeof label !== 'string')) {
+  throw new TypeError('--labels-json must contain a JSON string array');
+}
+
+const plan = planCi({
+  eventName: values.event,
+  changeEntries,
+  labels,
+  sampleKey: values['sample-key'],
+});
+
+if (values['github-output']) {
+  const output = Object.entries(githubOutputsForPlan(plan))
+    .map(([key, value]) => `${key}=${value}`)
+    .join('\n');
+  fs.appendFileSync(values['github-output'], `${output}\n`);
+}
+
+if (values.summary) {
+  fs.appendFileSync(values.summary, renderPlanSummary(plan));
+}
+
+process.stdout.write(`${JSON.stringify(plan, null, 2)}\n`);

--- a/scripts/ci/plan-vitest-shard.mjs
+++ b/scripts/ci/plan-vitest-shard.mjs
@@ -1,0 +1,451 @@
+#!/usr/bin/env node
+/**
+ * Runtime-discovered, duration-weighted Vitest shards for the CLI and chain
+ * packages.
+ *
+ * Durations are test-body timings from GitHub Actions run 29321182804:
+ * - CLI job 87046972140
+ * - core/storage/chain job 87046972116
+ *
+ * Each file also receives PER_FILE_OVERHEAD_MS to account for import and
+ * collection work that Vitest reports separately from test-body duration.
+ * Files absent from the timing snapshot are still included and receive a
+ * deliberately conservative UNKNOWN_FILE_BODY_MS estimate.
+ *
+ * Usage from the repository root:
+ *   node scripts/ci/plan-vitest-shard.mjs cli 1
+ *   node scripts/ci/plan-vitest-shard.mjs chain 1
+ *
+ * Stdout contains only paths relative to the package root, one per line.
+ * A short diagnostic summary is written to stderr.
+ */
+import { readdirSync } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+export const PER_FILE_OVERHEAD_MS = 600;
+export const UNKNOWN_FILE_BODY_MS = 60_000;
+
+const CLI_BODY_MS = Object.freeze({
+  'test/activity-notification.test.ts': 535,
+  'test/agent-chat-update-route.test.ts': 3435,
+  'test/agent-connect-routes.test.ts': 8,
+  'test/agent-encryption-key-routes.test.ts': 8,
+  'test/api-client.test.ts': 50,
+  'test/api-slo-route.test.ts': 37,
+  'test/assertion-cli-smoke.test.ts': 13710,
+  'test/async-promote-queue-e2e.test.ts': 304,
+  'test/async-promote-worker.test.ts': 179,
+  'test/auth.test.ts': 67,
+  'test/auto-update-jitter.test.ts': 10,
+  'test/auto-update-versioned-e2e.test.ts': 2740,
+  'test/auto-update.test.ts': 65,
+  'test/backfill-rs-percgid-meta-route.test.ts': 91,
+  'test/batching.test.ts': 5,
+  'test/blazegraph-docker.test.ts': 109,
+  'test/blazegraph-image-metadata.test.ts': 29,
+  'test/blazegraph-integration.test.ts': 0,
+  'test/blue-green-integration.test.ts': 883,
+  'test/catchup-runner-worker-impl.test.ts': 63,
+  'test/catchup-runner.test.ts': 3,
+  'test/chain-discovery-scan-mode.test.ts': 4,
+  'test/chain-reset-wipe-backup.test.ts': 67,
+  'test/chain-reset-wipe.test.ts': 33,
+  'test/chain-rpc-transport-status.test.ts': 4,
+  'test/chat-acl.test.ts': 7,
+  'test/cli-rpc.test.ts': 21,
+  'test/config.test.ts': 51,
+  'test/context-graph-cli-smoke.test.ts': 2459,
+  'test/context-graph-subscriptions-route.test.ts': 31,
+  'test/context-graph-write-path-validation.test.ts': 3416,
+  'test/core-prereq-check.test.ts': 16,
+  'test/daemon-auth-signed-extra.test.ts': 41,
+  'test/daemon-context-graph-register.test.ts': 45,
+  'test/daemon-entrypoint-resolution.test.ts': 9,
+  'test/daemon-hermes.test.ts': 130,
+  'test/daemon-http-behavior-extra.test.ts': 12770,
+  'test/daemon-http-inflight-cap.test.ts': 2934,
+  'test/daemon-http-replication.test.ts': 3293,
+  'test/daemon-ka-transport.test.ts': 10,
+  'test/daemon-keystore-extra.test.ts': 546,
+  'test/daemon-lifecycle-memory-agent-address.test.ts': 3,
+  'test/daemon-lifecycle.test.ts': 2450,
+  'test/daemon-log-rotation-io.test.ts': 4,
+  'test/daemon-log-rotation.test.ts': 9,
+  'test/daemon-openclaw.part-01.test.ts': 11,
+  'test/daemon-openclaw.part-02.test.ts': 23,
+  'test/daemon-openclaw.part-03.test.ts': 22,
+  'test/daemon-openclaw.part-04.test.ts': 26,
+  'test/daemon-openclaw.part-05.test.ts': 26,
+  'test/daemon-openclaw.part-06.test.ts': 33,
+  'test/daemon-openclaw.part-07.test.ts': 3,
+  'test/daemon-openclaw.part-08.test.ts': 8,
+  'test/daemon-openclaw.part-09.test.ts': 5,
+  'test/daemon-openclaw.part-10.test.ts': 3,
+  'test/daemon-openclaw.part-11.test.ts': 13,
+  'test/daemon-openclaw.part-12.test.ts': 13,
+  'test/daemon-openclaw.part-13.test.ts': 12,
+  'test/daemon-openclaw.part-14.test.ts': 3,
+  'test/daemon-openclaw.part-15.test.ts': 3,
+  'test/daemon-openclaw.part-16.test.ts': 24,
+  'test/daemon-openclaw.part-17.test.ts': 27,
+  'test/daemon-openclaw.part-18.test.ts': 10,
+  'test/daemon-openclaw.part-19.test.ts': 3,
+  'test/daemon-operational-wallet-routes.test.ts': 13,
+  'test/daemon-pca-routes.test.ts': 52,
+  'test/daemon-publish-encryption-factory.test.ts': 2,
+  'test/daemon-startup-validation.test.ts': 347,
+  'test/daemon-storage-ack-timing-wiring.test.ts': 10109,
+  'test/daemon-sync-agents-meta-wiring.test.ts': 82,
+  'test/daemon/plugin-loader.test.ts': 38,
+  'test/daemon/plugin-routes-api.e2e.test.ts': 5353,
+  'test/daemon/routes/plugins.test.ts': 10,
+  'test/daemon/routes/query.test.ts': 3285,
+  'test/dashboard-log-volume-pruner.test.ts': 5,
+  'test/devnet-publish-helpers-smoke.test.ts': 12027,
+  'test/dkg-doctor.test.ts': 16,
+  'test/document-processor-e2e.test.ts': 10,
+  'test/edge-auto-update-entrypoint-e2e.test.ts': 70,
+  'test/epcis-api-client.test.ts': 8,
+  'test/epcis-route-readiness.test.ts': 19,
+  'test/epcis-subcommands.test.ts': 17865,
+  'test/extraction-markdown.test.ts': 21,
+  'test/extraction-markitdown.test.ts': 14,
+  'test/extraction-status.test.ts': 9,
+  'test/file-store.test.ts': 92,
+  'test/finalize-author-token-attribution.test.ts': 4,
+  'test/foreground-supervisor-command.test.ts': 1386,
+  'test/foreground-supervisor.test.ts': 1580,
+  'test/hermes-setup-cli-args.test.ts': 7,
+  'test/hermes-setup-orchestration.test.ts': 631,
+  'test/http-admission-control.test.ts': 48,
+  'test/http-literal-size-validation.test.ts': 4,
+  'test/import-artifact-routes.test.ts': 234,
+  'test/import-file-integration.part-01.test.ts': 49,
+  'test/import-file-integration.part-02.test.ts': 33,
+  'test/import-file-integration.part-03.test.ts': 34,
+  'test/import-file-integration.part-04.test.ts': 39,
+  'test/import-file-integration.part-05.test.ts': 36,
+  'test/import-file-integration.part-06.test.ts': 43,
+  'test/import-file-integration.part-07.test.ts': 237,
+  'test/import-file-integration.part-08.test.ts': 28,
+  'test/import-file-integration.part-09.test.ts': 31,
+  'test/import-file-integration.part-10.test.ts': 2,
+  'test/import-file-integration.part-11.test.ts': 13,
+  'test/indexer-solidity-ast.test.ts': 14,
+  'test/indexer.test.ts': 32,
+  'test/init.test.ts': 7,
+  'test/integrations.test.ts': 61,
+  'test/issue-306-787-write-quad-validation.test.ts': 3423,
+  'test/kc-author-route.e2e.test.ts': 50,
+  'test/keystore.test.ts': 1156,
+  'test/knowledge-asset-cli-smoke.test.ts': 57816,
+  'test/knowledge-assets-1116-share-errors.test.ts': 255,
+  'test/knowledge-assets-no-funded-wallet-route.test.ts': 35,
+  'test/knowledge-assets-route.test.ts': 5596,
+  'test/lifecycle-public-rpc-warn.test.ts': 4,
+  'test/log-sink.test.ts': 5,
+  'test/markitdown-binaries.test.ts': 76,
+  'test/mcp-setup.test.ts': 331,
+  'test/memory-graph-events.test.ts': 3303,
+  'test/memory-search-sparql-injection.test.ts': 5,
+  'test/memory-turn-route.test.ts': 8,
+  'test/metrics-presence.test.ts': 3,
+  'test/metrics-queries.test.ts': 6,
+  'test/migration.test.ts': 131,
+  'test/multipart.test.ts': 9,
+  'test/nat-status.test.ts': 913,
+  'test/no-funded-publisher-wallet-helpers.test.ts': 6,
+  'test/node-ops-receipt-timeout.test.ts': 161,
+  'test/node-ui-static.test.ts': 4,
+  'test/notifications-route-pca.test.ts': 7,
+  'test/notifications-route.test.ts': 3076,
+  'test/okf-private-lifecycle.test.ts': 14030,
+  'test/okf-subcommands.test.ts': 13431,
+  'test/openclaw-setup-cli-args.test.ts': 5,
+  'test/oxigraph-binary.test.ts': 39,
+  'test/oxigraph-listen-port.test.ts': 2,
+  'test/oxigraph-managed.test.ts': 2962,
+  'test/oxigraph-memory.test.ts': 3,
+  'test/oxigraph-parent-watchdog.test.ts': 17,
+  'test/oxigraph-server.test.ts': 3567,
+  'test/pca-command-render.test.ts': 7,
+  'test/pca-confirmation-wire.test.ts': 4,
+  'test/preferred-relays.test.ts': 6,
+  'test/promote-async-daemon-lifecycle.test.ts': 89,
+  'test/promote-async-routes.test.ts': 166,
+  'test/promote-route-not-persisted.test.ts': 35,
+  'test/publish-async-get-benchmark.test.ts': 129,
+  'test/publisher-availability.test.ts': 6,
+  'test/publisher-findings.local.test.ts': 0,
+  'test/publisher-route-snapshot.test.ts': 62,
+  'test/publisher-runner-ack-transport.test.ts': 123,
+  'test/publisher-runner-lu11.test.ts': 123,
+  'test/publisher-runner-private-encryption.test.ts': 123,
+  'test/publisher-runner-rpc-usage.test.ts': 207,
+  'test/publisher-runtime-chain-config.test.ts': 2,
+  'test/publisher-wallets.test.ts': 1069,
+  'test/random-sampling-status.test.ts': 2,
+  'test/rdf-parser.test.ts': 10,
+  'test/reconcile-503-mapping.test.ts': 4,
+  'test/relay-status-block.test.ts': 4,
+  'test/repro-issue-633.test.ts': 74,
+  'test/resolve-standalone-install.test.ts': 5,
+  'test/rfc-41-bundle-b.test.ts': 31,
+  'test/rollback-node-ui.test.ts': 5,
+  'test/rollback.test.ts': 652,
+  'test/rpc-usage-log.test.ts': 262,
+  'test/shared-memory-catchup-durable.test.ts': 10,
+  'test/shutdown-timeout.test.ts': 1243,
+  'test/skill-endpoint.test.ts': 37,
+  'test/skill-route-parity.test.ts': 5,
+  'test/slot-helpers.test.ts': 603,
+  'test/source-worker-daemon-client-validation.test.ts': 19,
+  'test/source-worker-daemon-client.test.ts': 3464,
+  'test/source-worker-runner.test.ts': 3445,
+  'test/status-command-store.test.ts': 5,
+  'test/status-route-rpc.test.ts': 3316,
+  'test/status-route-store-quads.test.ts': 46,
+  'test/store-health-check.test.ts': 38,
+  'test/store-identity-tag.test.ts': 19,
+  'test/store-wizard.test.ts': 15,
+  'test/supervisor-liveness.test.ts': 174,
+  'test/swm-large-payload-benchmark.test.ts': 5,
+  'test/swm-triple-volume-benchmark.test.ts': 10,
+  'test/telemetry-config.test.ts': 4,
+  'test/trust-endpoint-validation.test.ts': 3283,
+  'test/validate-store-config.test.ts': 6,
+  'test/vector-store-extra.test.ts': 266,
+  'test/write-preflight-resilience.test.ts': 849,
+});
+
+const CHAIN_BODY_MS = Object.freeze({
+  'test/abi-pinning.test.ts': 13,
+  'test/agent-provenance-cross-cutting.test.ts': 653,
+  'test/bounded-retry-fetch.test.ts': 9,
+  'test/build-knowledge-asset-ual.test.ts': 5,
+  'test/chain-lifecycle-extra.test.ts': 3264,
+  'test/chain-rpc-telemetry.unit.test.ts': 80,
+  'test/chain-rpc-transport-error.test.ts': 7,
+  'test/context-graph-registry-scan.unit.test.ts': 268,
+  'test/conviction-cost-covered-decode.test.ts': 24,
+  'test/endpoint-stickiness.acceptance.unit.test.ts': 46,
+  'test/enrich-evm-error-extra.test.ts': 35,
+  'test/evm-adapter-cg-deposit-failover.unit.test.ts': 62,
+  'test/evm-adapter-cg-deposit.test.ts': 840,
+  'test/evm-adapter-cg-policy-read-stickiness.unit.test.ts': 60,
+  'test/evm-adapter-hub-rotation.e2e.test.ts': 31747,
+  'test/evm-adapter-nonce-serialization.unit.test.ts': 291,
+  'test/evm-adapter-op-wallet.unit.test.ts': 98,
+  'test/evm-adapter-pca-enrich.test.ts': 84,
+  'test/evm-adapter-pca-rpc.unit.test.ts': 127,
+  'test/evm-adapter-random-sampling.test.ts': 28182,
+  'test/evm-adapter-resolve-contract-memo.unit.test.ts': 96,
+  'test/evm-adapter-tip-read-carveouts.unit.test.ts': 1103,
+  'test/evm-adapter.test.ts': 28092,
+  'test/evm-adapter.unit.test.ts': 14289,
+  'test/evm-event-decode.test.ts': 99,
+  'test/evm-relay-registry.test.ts': 555,
+  'test/filter-error-console-suppressor.test.ts': 8,
+  'test/filter-error-silencer.test.ts': 14,
+  'test/getmaxka-view-e2e.test.ts': 27467,
+  'test/getmaxkanumberforauthor.unit.test.ts': 258,
+  'test/hardhat-harness-parser.test.ts': 5,
+  'test/hub-resolution-cache.unit.test.ts': 7,
+  'test/hub-rotation-poller.unit.test.ts': 52,
+  'test/keyed-mutex.unit.test.ts': 124,
+  'test/keyed-ttl-single-flight-cache.unit.test.ts': 11,
+  'test/mock-adapter-kc-views.test.ts': 13,
+  'test/mock-adapter-parity.test.ts': 59,
+  'test/mock-adapter-publishing-conviction-v10.test.ts': 171,
+  'test/mock-adapter-random-sampling.test.ts': 14,
+  'test/mock-adapter-relay-registry.test.ts': 9,
+  'test/mock-publish-cg-events.test.ts': 8,
+  'test/multi-rpc-provider-shape.test.ts': 44,
+  'test/multi-rpc-read-failover.test.ts': 107,
+  'test/multi-rpc-write-failover.test.ts': 120,
+  'test/no-chain-adapter-extra.test.ts': 11,
+  'test/no-chain-adapter.test.ts': 7,
+  'test/publisher-plan.unit.test.ts': 9,
+  'test/publishing-conviction-account-v10.test.ts': 4863,
+  'test/readwithfailover-loop.unit.test.ts': 83,
+  'test/receipt-wait.unit.test.ts': 18,
+  'test/rpc-failover-client.unit.test.ts': 43,
+  'test/rpc-failover-log.test.ts': 13,
+  'test/rpc-failover-telemetry.unit.test.ts': 36,
+  'test/rpc-usage.unit.test.ts': 18052,
+  'test/v10-update-ack-digest-parity.unit.test.ts': 89,
+  'test/v8-v9-archive.test.ts': 16,
+  'test/vitest-config-extra.test.ts': 5,
+  'test/write-tx-safety-invariants.unit.test.ts': 93,
+});
+
+export const PACKAGE_SPECS = Object.freeze({
+  cli: Object.freeze({
+    packageDirectory: 'packages/cli',
+    shardCount: 4,
+    excludedPrefixes: Object.freeze([]),
+    bodyWeightsMs: CLI_BODY_MS,
+  }),
+  chain: Object.freeze({
+    packageDirectory: 'packages/chain',
+    shardCount: 3,
+    excludedPrefixes: Object.freeze(['test/archive/']),
+    bodyWeightsMs: CHAIN_BODY_MS,
+  }),
+});
+
+function compareAscii(left, right) {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}
+
+function walk(directory, packageRoot, output) {
+  const entries = readdirSync(directory, { withFileTypes: true })
+    .sort((left, right) => compareAscii(left.name, right.name));
+
+  for (const entry of entries) {
+    const absolutePath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      walk(absolutePath, packageRoot, output);
+    } else if (entry.isFile() && entry.name.endsWith('.test.ts')) {
+      const relativePath = path.relative(packageRoot, absolutePath).split(path.sep).join('/');
+      if (relativePath.includes('\n') || relativePath.includes('\r')) {
+        throw new Error('Test file paths may not contain newlines: ' + relativePath);
+      }
+      output.push(relativePath);
+    }
+  }
+}
+
+export function discoverEligibleTestFiles(packageName, repoRoot) {
+  const spec = PACKAGE_SPECS[packageName];
+  if (!spec) {
+    throw new Error('Unsupported package ' + packageName + '; expected cli or chain');
+  }
+
+  const packageRoot = path.join(repoRoot, spec.packageDirectory);
+  const testRoot = path.join(packageRoot, 'test');
+  const files = [];
+  walk(testRoot, packageRoot, files);
+
+  return files
+    .filter((file) => !spec.excludedPrefixes.some((prefix) => file.startsWith(prefix)))
+    .sort(compareAscii);
+}
+
+export function planWeightedShards({
+  files,
+  bodyWeightsMs,
+  shardCount,
+  perFileOverheadMs = PER_FILE_OVERHEAD_MS,
+  unknownFileBodyMs = UNKNOWN_FILE_BODY_MS,
+}) {
+  if (!Number.isInteger(shardCount) || shardCount < 1) {
+    throw new Error('shardCount must be a positive integer');
+  }
+  if (!Array.isArray(files) || files.length < shardCount) {
+    throw new Error('Need at least one eligible test file per shard');
+  }
+  if (new Set(files).size !== files.length) {
+    throw new Error('Eligible test file list contains duplicates');
+  }
+
+  const weightedFiles = files.map((file) => {
+    const known = Object.hasOwn(bodyWeightsMs, file);
+    const bodyMs = known ? bodyWeightsMs[file] : unknownFileBodyMs;
+    if (!Number.isFinite(bodyMs) || bodyMs < 0) {
+      throw new Error('Invalid test duration for ' + file);
+    }
+    return {
+      file,
+      known,
+      weightMs: bodyMs + perFileOverheadMs,
+    };
+  }).sort((left, right) => (
+    right.weightMs - left.weightMs || compareAscii(left.file, right.file)
+  ));
+
+  const shards = Array.from({ length: shardCount }, (_, index) => ({
+    index: index + 1,
+    estimatedMs: 0,
+    files: [],
+    unknownFiles: [],
+  }));
+
+  for (const weightedFile of weightedFiles) {
+    let target = shards[0];
+    for (const candidate of shards.slice(1)) {
+      if (
+        candidate.estimatedMs < target.estimatedMs
+        || (
+          candidate.estimatedMs === target.estimatedMs
+          && candidate.index < target.index
+        )
+      ) {
+        target = candidate;
+      }
+    }
+    target.estimatedMs += weightedFile.weightMs;
+    target.files.push(weightedFile.file);
+    if (!weightedFile.known) target.unknownFiles.push(weightedFile.file);
+  }
+
+  for (const shard of shards) {
+    shard.files.sort(compareAscii);
+    shard.unknownFiles.sort(compareAscii);
+  }
+  return shards;
+}
+
+export function planPackageShards(packageName, repoRoot) {
+  const spec = PACKAGE_SPECS[packageName];
+  if (!spec) {
+    throw new Error('Unsupported package ' + packageName + '; expected cli or chain');
+  }
+  const files = discoverEligibleTestFiles(packageName, repoRoot);
+  return planWeightedShards({
+    files,
+    bodyWeightsMs: spec.bodyWeightsMs,
+    shardCount: spec.shardCount,
+  });
+}
+
+export function defaultRepoRoot() {
+  return path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+}
+
+function runCli() {
+  const [packageName, shardText] = process.argv.slice(2);
+  const spec = PACKAGE_SPECS[packageName];
+  const shardNumber = Number.parseInt(shardText, 10);
+  if (
+    !spec
+    || String(shardNumber) !== shardText
+    || shardNumber < 1
+    || shardNumber > spec.shardCount
+  ) {
+    console.error(
+      'Usage: node scripts/ci/plan-vitest-shard.mjs <cli|chain> <shard>; '
+      + 'CLI has 4 shards and chain has 3 shards.',
+    );
+    process.exitCode = 2;
+    return;
+  }
+
+  const shard = planPackageShards(packageName, defaultRepoRoot())[shardNumber - 1];
+  const estimatedSeconds = (shard.estimatedMs / 1000).toFixed(1);
+  console.error(
+    'vitest-shard: ' + packageName + ' ' + shardNumber + '/' + spec.shardCount
+    + ' files=' + shard.files.length
+    + ' estimated=' + estimatedSeconds + 's'
+    + ' unknown=' + shard.unknownFiles.length,
+  );
+  process.stdout.write(shard.files.join('\n') + '\n');
+}
+
+const isMain = process.argv[1]
+  && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) runCli();

--- a/scripts/lib/__tests__/ci-delta.test.mjs
+++ b/scripts/lib/__tests__/ci-delta.test.mjs
@@ -1,0 +1,412 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import {
+  CI_LANES,
+  EVM_SCOPES,
+  WORKSPACE_OWNING_EVM_SCOPES,
+  WORKSPACE_OWNING_LANES,
+  WORKSPACE_RULES,
+  githubOutputsForPlan,
+  parseNameStatusZ,
+  planCi,
+} from '../ci-delta.mjs';
+import {
+  PRIMARY_LANE_JOBS,
+  validateEvmResults,
+  validatePrimaryResults,
+} from '../ci-results.mjs';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+
+function change(filePath, status = 'M') {
+  return { status, paths: [filePath] };
+}
+
+function pullRequestPlan(changeEntries, overrides = {}) {
+  return planCi({
+    eventName: 'pull_request',
+    changeEntries,
+    sampleKey: 'ffffffffffffffffffffffffffffffffffffffff',
+    ...overrides,
+  });
+}
+
+function selectedLanes(plan) {
+  return CI_LANES.filter((lane) => plan.lanes[lane]);
+}
+
+test('parses NUL-delimited git name-status output without shell-splitting file names', () => {
+  const input = Buffer.from('M\0packages/agent/src/a file.ts\0R100\0old.md\0new.md\0');
+  assert.deepEqual(parseNameStatusZ(input), [
+    { status: 'M', paths: ['packages/agent/src/a file.ts'] },
+    { status: 'R100', paths: ['old.md', 'new.md'] },
+  ]);
+});
+
+test('push, merge queue, manual, and explicit label plans are always full', () => {
+  for (const eventName of ['push', 'merge_group', 'workflow_dispatch']) {
+    const plan = planCi({ eventName });
+    assert.equal(plan.fullCi, true, eventName);
+    assert.deepEqual(selectedLanes(plan), CI_LANES, eventName);
+    assert.deepEqual(plan.evmScopes, EVM_SCOPES, eventName);
+  }
+
+  const labeled = pullRequestPlan([change('CHANGELOG.md')], { labels: ['ci:full'] });
+  assert.equal(labeled.fullCi, true);
+});
+
+test('five percent of PR SHAs are deterministic full-CI audit samples', () => {
+  const sampled = pullRequestPlan([change('CHANGELOG.md')], { sampleKey: '00000000ffffffff' });
+  const normal = pullRequestPlan([change('CHANGELOG.md')], { sampleKey: 'ffffffffffffffff' });
+  assert.equal(sampled.auditSampled, true);
+  assert.equal(sampled.fullCi, true);
+  assert.equal(normal.auditSampled, false);
+  assert.equal(normal.fullCi, false);
+});
+
+test('documentation-only PRs select no test lane or shared build', () => {
+  const plan = pullRequestPlan([
+    change('CHANGELOG.md'),
+    change('docs/ci/overview.md'),
+    change('packages/agent/README.md'),
+  ]);
+  assert.equal(plan.mode, 'docs-only');
+  assert.equal(plan.runNode, false);
+  assert.deepEqual(selectedLanes(plan), []);
+  assert.deepEqual(plan.evmScopes, []);
+});
+
+test('markdown test fixtures are code inputs, not documentation-only changes', () => {
+  const plan = pullRequestPlan([change('packages/okf/test/fixtures/example.md')]);
+  assert.equal(plan.mode, 'delta');
+  assert.ok(plan.lanes.kosava_supporting);
+});
+
+test('code and config files under documentation trees fail closed', () => {
+  for (const filePath of ['docs/tool.mjs', 'docs/archive/input.json']) {
+    assert.equal(pullRequestPlan([change(filePath)]).fullCi, true, filePath);
+  }
+  const demoScript = pullRequestPlan([change('demo/docs/check.sh')]);
+  assert.equal(demoScript.mode, 'delta');
+  assert.ok(demoScript.lanes.kosava_supporting);
+  assert.equal(pullRequestPlan([change('docs/diagram.png')]).mode, 'docs-only');
+});
+
+test('leaf and shared package snapshots include conservative downstream consumers', () => {
+  const agent = pullRequestPlan([change('packages/agent/src/agent.ts')]);
+  assert.deepEqual(selectedLanes(agent), [
+    'tornado_agent',
+    'bura_cli',
+    'kosava_node_ui_e2e',
+    'kosava_supporting',
+    'kosava_hardhat_plugins',
+  ]);
+  assert.deepEqual(agent.evmScopes, ['agent']);
+
+  const networkSim = pullRequestPlan([change('packages/network-sim/src/index.ts')]);
+  assert.deepEqual(selectedLanes(networkSim), ['kosava_supporting']);
+  assert.deepEqual(networkSim.evmScopes, []);
+
+  const core = pullRequestPlan([change('packages/core/src/index.ts')]);
+  assert.deepEqual(selectedLanes(core), [
+    'tornado_core',
+    'tornado_blazegraph',
+    'tornado_publisher',
+    'tornado_agent',
+    'bura_cli',
+    'bura_query',
+    'kosava_node_ui',
+    'kosava_node_ui_e2e',
+    'kosava_supporting',
+    'kosava_hardhat_plugins',
+  ]);
+  assert.deepEqual(core.evmScopes, EVM_SCOPES);
+});
+
+test('highest-risk, global, unknown, manifest, large, and ambiguous changes fail closed', () => {
+  const cases = [
+    [change('packages/evm-module/contracts/KnowledgeAssets.sol')],
+    [change('pnpm-lock.yaml')],
+    [change('packages/agent/package.json')],
+    [change('new-root-tool.ts')],
+    [change('packages/agent/src/removed.ts', 'D')],
+    [
+      change('packages/agent/src/a.ts'),
+      change('packages/cli/src/a.ts'),
+      change('packages/query/src/a.ts'),
+      change('packages/node-ui/src/a.ts'),
+    ],
+  ];
+
+  for (const changeEntries of cases) {
+    assert.equal(pullRequestPlan(changeEntries).fullCi, true, JSON.stringify(changeEntries));
+  }
+
+  const large = Array.from({ length: 101 }, (_, index) => change(`packages/agent/src/file-${index}.ts`));
+  const largePlan = pullRequestPlan(large);
+  assert.equal(largePlan.fullCi, true);
+  assert.equal(largePlan.changedFileCount, 101);
+
+  const huge = Array.from({ length: 1000 }, (_, index) => change(`packages/agent/src/file-${index}.ts`));
+  const hugePlan = pullRequestPlan(huge);
+  assert.equal(hugePlan.changedFileCount, 1000);
+  assert.equal(hugePlan.changedFiles.length, 200, 'GitHub output must stay bounded');
+});
+
+test('Blazegraph provisioning changes include the native arm64 contract lane', () => {
+  const rootContract = pullRequestPlan([change('blazegraph-image.json')]);
+  assert.deepEqual(selectedLanes(rootContract), ['bura_cli', 'bura_blazegraph_arm64']);
+
+  const cliProvisioner = pullRequestPlan([
+    change('packages/cli/src/daemon/blazegraph-new-provisioner.ts'),
+  ]);
+  assert.deepEqual(selectedLanes(cliProvisioner), [
+    'bura_cli',
+    'bura_blazegraph_arm64',
+    'kosava_node_ui_e2e',
+    'kosava_hardhat_plugins',
+  ]);
+});
+
+test('every tested workspace is represented by the routing manifest', () => {
+  const manifests = [
+    ...fs.readdirSync(path.join(REPO_ROOT, 'packages'), { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => `packages/${entry.name}`),
+    'demo',
+  ];
+
+  const testedWorkspaces = manifests.filter((workspace) => {
+    const manifestPath = path.join(REPO_ROOT, workspace, 'package.json');
+    if (!fs.existsSync(manifestPath)) return false;
+    return Boolean(JSON.parse(fs.readFileSync(manifestPath, 'utf8')).scripts?.test);
+  });
+
+  assert.deepEqual(
+    testedWorkspaces.filter((workspace) => !WORKSPACE_RULES[workspace]),
+    [],
+    'every workspace with a test script must be classified',
+  );
+
+  for (const [workspace, rule] of Object.entries(WORKSPACE_RULES)) {
+    for (const lane of rule.lanes) {
+      assert.ok(CI_LANES.includes(lane), `${workspace} references unknown lane ${lane}`);
+    }
+    for (const scope of rule.evmScopes) {
+      assert.ok(EVM_SCOPES.includes(scope), `${workspace} references unknown EVM scope ${scope}`);
+    }
+  }
+});
+
+test('routing rules cover every current reverse workspace dependency', () => {
+  const manifests = new Map(Object.keys(WORKSPACE_RULES).map((workspace) => {
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(REPO_ROOT, workspace, 'package.json'), 'utf8'),
+    );
+    return [workspace, manifest];
+  }));
+  const workspaceByPackageName = new Map(
+    [...manifests].map(([workspace, manifest]) => [manifest.name, workspace]),
+  );
+  const reverseDependencies = new Map(
+    [...manifests.keys()].map((workspace) => [workspace, new Set()]),
+  );
+
+  for (const [consumer, manifest] of manifests) {
+    const dependencies = {
+      ...manifest.dependencies,
+      ...manifest.devDependencies,
+      ...manifest.optionalDependencies,
+      ...manifest.peerDependencies,
+    };
+    for (const dependencyName of Object.keys(dependencies)) {
+      const provider = workspaceByPackageName.get(dependencyName);
+      if (provider) reverseDependencies.get(provider).add(consumer);
+    }
+  }
+
+  for (const [changedWorkspace, rule] of Object.entries(WORKSPACE_RULES)) {
+    assert.ok(WORKSPACE_OWNING_LANES[changedWorkspace], `${changedWorkspace} needs an owning lane`);
+    if (rule.forceFull) continue;
+
+    const downstream = new Set([changedWorkspace]);
+    const queue = [changedWorkspace];
+    while (queue.length) {
+      const provider = queue.shift();
+      for (const consumer of reverseDependencies.get(provider)) {
+        if (downstream.has(consumer)) continue;
+        downstream.add(consumer);
+        queue.push(consumer);
+      }
+    }
+
+    const requiredLanes = new Set(
+      [...downstream].flatMap((workspace) => WORKSPACE_OWNING_LANES[workspace]),
+    );
+    const requiredEvmScopes = new Set(
+      [...downstream].flatMap((workspace) => WORKSPACE_OWNING_EVM_SCOPES[workspace] ?? []),
+    );
+    const missing = [...requiredLanes].filter((lane) => !rule.lanes.includes(lane));
+    assert.deepEqual(
+      missing,
+      [],
+      `${changedWorkspace} misses downstream owner lanes for ${[...downstream].join(', ')}`,
+    );
+    assert.deepEqual(
+      [...requiredEvmScopes].filter((scope) => !rule.evmScopes.includes(scope)),
+      [],
+      `${changedWorkspace} misses downstream EVM scopes for ${[...downstream].join(', ')}`,
+    );
+  }
+});
+
+test('every planner output is wired to a real workflow job and omitted tests stay covered', () => {
+  const workflow = fs.readFileSync(path.join(REPO_ROOT, '.github/workflows/ci.yml'), 'utf8');
+  for (const [lane, job] of Object.entries(PRIMARY_LANE_JOBS)) {
+    assert.match(workflow, new RegExp(`^  ${job}:`, 'm'), `${lane} must map to job ${job}`);
+    assert.ok(
+      workflow.includes(`needs.changes.outputs.${lane} == 'true'`),
+      `${job} must be gated by ${lane}`,
+    );
+  }
+  assert.ok(workflow.includes("needs.changes.outputs.contracts == 'true'"));
+  assert.ok(
+    workflow.includes('run: node scripts/check-npm-metadata.mjs'),
+    'docs-only package README changes must retain the npm metadata gate',
+  );
+  assert.ok(
+    workflow.includes("vars.CI_DELTA_ENABLED == 'true'"),
+    'delta rollout must remain default-off until repository safeguards are active',
+  );
+  assert.ok(workflow.includes("github.base_ref == 'main'"));
+  assert.ok(workflow.includes('git diff --name-status -z "${BASE_SHA}" "${MERGE_SHA}"'));
+  assert.equal(workflow.includes('git diff --name-status -z "${BASE_SHA}" "${HEAD_SHA}"'), false);
+
+  for (const packageName of [
+    '@origintrail-official/dkg-rdf-utils',
+    '@origintrail-official/dkg-okf',
+    '@origintrail-official/dkg-demo',
+  ]) {
+    assert.ok(workflow.includes(`--filter ${packageName}`), `${packageName} tests must stay in CI`);
+  }
+
+  const evmWorkflow = fs.readFileSync(
+    path.join(REPO_ROOT, '.github/workflows/evm-integration.yml'),
+    'utf8',
+  );
+  assert.ok(evmWorkflow.includes('fromJSON(needs.plan.outputs.evm_matrix)'));
+  assert.ok(evmWorkflow.includes("vars.CI_DELTA_ENABLED == 'true'"));
+  assert.ok(evmWorkflow.includes("github.base_ref == 'main'"));
+  assert.ok(evmWorkflow.includes('git diff --name-status -z "${BASE_SHA}" "${MERGE_SHA}"'));
+  assert.match(evmWorkflow, /^  evm-gate:/m);
+
+  const demoManifest = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, 'demo/package.json'), 'utf8'));
+  assert.match(demoManifest.scripts.test, /kafka-streams\/test\/\*\.mjs/);
+  assert.match(demoManifest.scripts.test, /epcis-bike\/test\/\*\.mjs/);
+});
+
+test('GitHub outputs are booleans plus compact JSON matrices', () => {
+  const outputs = githubOutputsForPlan(pullRequestPlan([change('packages/network-sim/src/index.ts')]));
+  assert.equal(outputs.kosava_supporting, 'true');
+  assert.equal(outputs.tornado_agent, 'false');
+  assert.equal(outputs.run_node, 'true');
+  assert.equal(outputs.evm_matrix, '[]');
+  const gatePlan = JSON.parse(outputs.plan_json);
+  assert.equal(gatePlan.mode, 'delta');
+  assert.equal(gatePlan.lanes.kosava_supporting, true);
+  assert.equal('changedFiles' in gatePlan, false);
+  assert.equal('reasons' in gatePlan, false);
+});
+
+test('aggregate gates reject failed or accidentally skipped selected jobs', () => {
+  const plan = pullRequestPlan([change('packages/network-sim/src/index.ts')]);
+  const needs = {
+    changes: { result: 'success' },
+    build: { result: 'success' },
+    'abi-freshness': { result: 'skipped' },
+    solidity: { result: 'skipped' },
+    'solidity-coverage': { result: 'skipped' },
+    'tornado-static-analysis': { result: 'skipped' },
+    ...Object.fromEntries(Object.values(PRIMARY_LANE_JOBS).map((job) => [job, { result: 'skipped' }])),
+  };
+  needs['kosava-supporting'].result = 'success';
+  assert.deepEqual(validatePrimaryResults({ eventName: 'pull_request', plan, needs }), []);
+
+  needs['kosava-supporting'].result = 'skipped';
+  assert.match(validatePrimaryResults({ eventName: 'pull_request', plan, needs }).join('\n'), /selected/);
+
+  const evmPlan = pullRequestPlan([change('packages/agent/src/index.ts')]);
+  assert.deepEqual(validateEvmResults({
+    eventName: 'pull_request',
+    plan: evmPlan,
+    needs: { plan: { result: 'success' }, 'evm-integration': { result: 'success' } },
+  }), []);
+  assert.match(validateEvmResults({
+    eventName: 'pull_request',
+    plan: evmPlan,
+    needs: { plan: { result: 'success' }, 'evm-integration': { result: 'failure' } },
+  }).join('\n'), /failure/);
+});
+
+test('aggregate gate accepts the full-push and docs-only job shapes', () => {
+  const laneJobs = Object.values(PRIMARY_LANE_JOBS);
+  const full = planCi({ eventName: 'push' });
+  const fullNeeds = {
+    changes: { result: 'success' },
+    build: { result: 'success' },
+    ...Object.fromEntries(laneJobs.map((job) => [job, { result: 'success' }])),
+    'abi-freshness': { result: 'success' },
+    solidity: { result: 'skipped' },
+    'solidity-coverage': { result: 'success' },
+    'tornado-static-analysis': { result: 'success' },
+  };
+  assert.deepEqual(validatePrimaryResults({ eventName: 'push', plan: full, needs: fullNeeds }), []);
+
+  const mergeNeeds = structuredClone(fullNeeds);
+  mergeNeeds.solidity.result = 'success';
+  mergeNeeds['solidity-coverage'].result = 'skipped';
+  assert.deepEqual(validatePrimaryResults({
+    eventName: 'merge_group',
+    plan: full,
+    needs: mergeNeeds,
+  }), []);
+  assert.deepEqual(validateEvmResults({
+    eventName: 'merge_group',
+    plan: full,
+    needs: { plan: { result: 'success' }, 'evm-integration': { result: 'success' } },
+  }), []);
+
+  const docs = pullRequestPlan([change('CHANGELOG.md')]);
+  const docsNeeds = {
+    changes: { result: 'success' },
+    build: { result: 'skipped' },
+    ...Object.fromEntries(laneJobs.map((job) => [job, { result: 'skipped' }])),
+    'abi-freshness': { result: 'skipped' },
+    solidity: { result: 'skipped' },
+    'solidity-coverage': { result: 'skipped' },
+    'tornado-static-analysis': { result: 'skipped' },
+  };
+  assert.deepEqual(validatePrimaryResults({ eventName: 'pull_request', plan: docs, needs: docsNeeds }), []);
+  assert.deepEqual(validateEvmResults({
+    eventName: 'pull_request',
+    plan: docs,
+    needs: { plan: { result: 'success' }, 'evm-integration': { result: 'skipped' } },
+  }), []);
+
+  const malformed = structuredClone(docs);
+  delete malformed.lanes.tornado_agent;
+  assert.match(validateEvmResults({
+    eventName: 'pull_request',
+    plan: malformed,
+    needs: { plan: { result: 'success' }, 'evm-integration': { result: 'skipped' } },
+  }).join('\n'), /tornado_agent must be a boolean/);
+
+  assert.match(validateEvmResults({
+    eventName: 'merge_group',
+    plan: docs,
+    needs: { plan: { result: 'success' }, 'evm-integration': { result: 'skipped' } },
+  }).join('\n'), /merge_group events must use full CI mode/);
+});

--- a/scripts/lib/__tests__/ci-delta.test.mjs
+++ b/scripts/lib/__tests__/ci-delta.test.mjs
@@ -1,5 +1,7 @@
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
@@ -20,6 +22,7 @@ import {
 } from '../ci-results.mjs';
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const TRUSTED_CI_CONTROLLER_SHA = 'c441bd6766ace67e331c0dfc6e22cb1325a6e1f6';
 
 function change(filePath, status = 'M') {
   return { status, paths: [filePath] };
@@ -156,6 +159,36 @@ test('highest-risk, global, unknown, manifest, large, and ambiguous changes fail
   assert.equal(hugePlan.changedFiles.length, 200, 'GitHub output must stay bounded');
 });
 
+test('workflow, planner, and aggregate-gate changes always force every CI lane', () => {
+  const controlPlanePaths = [
+    '.github/workflows/ci.yml',
+    '.github/workflows/evm-integration.yml',
+    '.github/workflows/nested/policy.yml',
+    'scripts/ci/plan-ci.mjs',
+    'scripts/ci/assert-ci-results.mjs',
+    'scripts/lib/ci-delta.mjs',
+    'scripts/lib/ci-results.mjs',
+    'scripts/unrelated-maintenance.mjs',
+  ];
+
+  for (const filePath of controlPlanePaths) {
+    const plan = pullRequestPlan([change(filePath)]);
+    assert.equal(plan.mode, 'full', filePath);
+    assert.equal(plan.fullCi, true, filePath);
+    assert.equal(plan.runNode, true, filePath);
+    assert.deepEqual(selectedLanes(plan), CI_LANES, filePath);
+    assert.deepEqual(plan.evmScopes, EVM_SCOPES, filePath);
+  }
+});
+
+test('ordinary network-sim changes remain a narrow delta after the trust hardening', () => {
+  const plan = pullRequestPlan([change('packages/network-sim/src/index.ts')]);
+  assert.equal(plan.mode, 'delta');
+  assert.equal(plan.fullCi, false);
+  assert.deepEqual(selectedLanes(plan), ['kosava_supporting']);
+  assert.deepEqual(plan.evmScopes, []);
+});
+
 test('Blazegraph provisioning changes include the native arm64 contract lane', () => {
   const rootContract = pullRequestPlan([change('blazegraph-image.json')]);
   assert.deepEqual(selectedLanes(rootContract), ['bura_cli', 'bura_blazegraph_arm64']);
@@ -263,6 +296,127 @@ test('routing rules cover every current reverse workspace dependency', () => {
   }
 });
 
+test('workflows execute the planner and aggregate gates from one immutable trusted checkout', () => {
+  const workflows = new Map([
+    ['primary', fs.readFileSync(path.join(REPO_ROOT, '.github/workflows/ci.yml'), 'utf8')],
+    ['evm', fs.readFileSync(path.join(REPO_ROOT, '.github/workflows/evm-integration.yml'), 'utf8')],
+  ]);
+
+  for (const [name, workflow] of workflows) {
+    const trustedCheckoutCount = workflow.match(/^\s+path: trusted-ci$/gm)?.length ?? 0;
+    const trustedPinCount = workflow.match(
+      new RegExp(`^\\s+ref: ${TRUSTED_CI_CONTROLLER_SHA}$`, 'gm'),
+    )?.length ?? 0;
+    const trustedRepositoryCount = workflow.match(
+      /^\s+repository: OriginTrail\/dkg$/gm,
+    )?.length ?? 0;
+
+    assert.match(TRUSTED_CI_CONTROLLER_SHA, /^[0-9a-f]{40}$/);
+    assert.ok(trustedCheckoutCount >= 2, `${name} must trust-pin both its planner and gate`);
+    assert.equal(
+      trustedPinCount,
+      trustedCheckoutCount,
+      `${name} trusted checkouts must all use the reviewed controller SHA`,
+    );
+    assert.equal(
+      trustedRepositoryCount,
+      trustedCheckoutCount,
+      `${name} trusted checkouts must all use the base repository`,
+    );
+    assert.match(workflow, /node trusted-ci\/scripts\/ci\/plan-ci\.mjs\b/);
+    assert.match(workflow, /node trusted-ci\/scripts\/ci\/assert-ci-results\.mjs\b/);
+    assert.doesNotMatch(
+      workflow,
+      /node (?:\.\/)?scripts\/ci\/(?:plan-ci|assert-ci-results)\.mjs\b/,
+      `${name} must not execute CI policy from the merge candidate`,
+    );
+  }
+
+  const primaryWorkflow = workflows.get('primary');
+  assert.ok(
+    primaryWorkflow.indexOf('run: node candidate/scripts/check-npm-metadata.mjs')
+      > primaryWorkflow.indexOf('node trusted-ci/scripts/ci/plan-ci.mjs'),
+    'candidate npm metadata validation must happen only after the trusted plan is fixed',
+  );
+});
+
+test('trusted planner and gates reject the all-skipped candidate-control attack', (t) => {
+  const temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'dkg-ci-trust-'));
+  t.after(() => fs.rmSync(temporaryDirectory, { recursive: true, force: true }));
+
+  // Model a candidate that edits both control scripts. Even if its copies
+  // would emit an all-false plan and exit zero, the trusted planner must force
+  // a full run and the trusted gates must reject the resulting skipped jobs.
+  const changesPath = path.join(temporaryDirectory, 'changes.z');
+  fs.writeFileSync(
+    changesPath,
+    Buffer.from('M\0scripts/ci/plan-ci.mjs\0M\0scripts/ci/assert-ci-results.mjs\0'),
+  );
+
+  const planner = spawnSync(process.execPath, [
+    path.join(REPO_ROOT, 'scripts/ci/plan-ci.mjs'),
+    '--event',
+    'pull_request',
+    '--changes-z',
+    changesPath,
+    '--sample-key',
+    'ffffffffffffffffffffffffffffffffffffffff',
+  ], { encoding: 'utf8' });
+  assert.equal(planner.status, 0, planner.stderr);
+  const plan = JSON.parse(planner.stdout);
+  assert.equal(plan.mode, 'full');
+  assert.deepEqual(selectedLanes(plan), CI_LANES);
+  assert.deepEqual(plan.evmScopes, EVM_SCOPES);
+
+  const primaryNeeds = {
+    changes: { result: 'success' },
+    build: { result: 'skipped' },
+    'evm-node-test-artifacts': { result: 'skipped' },
+    'evm-devnet-test-artifacts': { result: 'skipped' },
+    ...Object.fromEntries(
+      Object.values(PRIMARY_LANE_JOBS).map((job) => [job, { result: 'skipped' }]),
+    ),
+    'abi-freshness': { result: 'skipped' },
+    solidity: { result: 'skipped' },
+    'solidity-coverage': { result: 'skipped' },
+    'tornado-static-analysis': { result: 'skipped' },
+  };
+  const primaryGate = spawnSync(process.execPath, [
+    path.join(REPO_ROOT, 'scripts/ci/assert-ci-results.mjs'),
+    '--workflow',
+    'primary',
+  ], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      EVENT_NAME: 'pull_request',
+      PLAN_JSON: JSON.stringify(plan),
+      NEEDS_JSON: JSON.stringify(primaryNeeds),
+    },
+  });
+  assert.equal(primaryGate.status, 1);
+  assert.match(primaryGate.stderr, /selected but ended with skipped/);
+
+  const evmGate = spawnSync(process.execPath, [
+    path.join(REPO_ROOT, 'scripts/ci/assert-ci-results.mjs'),
+    '--workflow',
+    'evm',
+  ], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      EVENT_NAME: 'pull_request',
+      PLAN_JSON: JSON.stringify(plan),
+      NEEDS_JSON: JSON.stringify({
+        plan: { result: 'success' },
+        'evm-integration': { result: 'skipped' },
+      }),
+    },
+  });
+  assert.equal(evmGate.status, 1);
+  assert.match(evmGate.stderr, /selected but ended with skipped/);
+});
+
 test('every planner output is wired to a real workflow job and omitted tests stay covered', () => {
   const workflow = fs.readFileSync(path.join(REPO_ROOT, '.github/workflows/ci.yml'), 'utf8');
   for (const [lane, job] of Object.entries(PRIMARY_LANE_JOBS)) {
@@ -274,7 +428,7 @@ test('every planner output is wired to a real workflow job and omitted tests sta
   }
   assert.ok(workflow.includes("needs.changes.outputs.contracts == 'true'"));
   assert.ok(
-    workflow.includes('run: node scripts/check-npm-metadata.mjs'),
+    workflow.includes('run: node candidate/scripts/check-npm-metadata.mjs'),
     'docs-only package README changes must retain the npm metadata gate',
   );
   assert.ok(
@@ -282,8 +436,9 @@ test('every planner output is wired to a real workflow job and omitted tests sta
     'delta rollout must remain default-off until repository safeguards are active',
   );
   assert.ok(workflow.includes("github.base_ref == 'main'"));
-  assert.ok(workflow.includes('git diff --name-status -z "${BASE_SHA}" "${MERGE_SHA}"'));
-  assert.equal(workflow.includes('git diff --name-status -z "${BASE_SHA}" "${HEAD_SHA}"'), false);
+  assert.ok(workflow.includes('git -C candidate diff --name-status -z \\\n'));
+  assert.ok(workflow.includes('"${BASE_SHA}" "${MERGE_SHA}" > "${CHANGES_FILE}"'));
+  assert.equal(workflow.includes('"${BASE_SHA}" "${HEAD_SHA}"'), false);
   assert.match(workflow, /^  evm-node-test-artifacts:/m);
   assert.match(workflow, /^  evm-devnet-test-artifacts:/m);
   assert.ok(workflow.includes('plan-vitest-shard.mjs chain "$SHARD_ID"'));
@@ -314,7 +469,8 @@ test('every planner output is wired to a real workflow job and omitted tests sta
   assert.ok(evmWorkflow.includes('fromJSON(needs.plan.outputs.evm_matrix)'));
   assert.ok(evmWorkflow.includes("vars.CI_DELTA_ENABLED == 'true'"));
   assert.ok(evmWorkflow.includes("github.base_ref == 'main'"));
-  assert.ok(evmWorkflow.includes('git diff --name-status -z "${BASE_SHA}" "${MERGE_SHA}"'));
+  assert.ok(evmWorkflow.includes('git -C candidate diff --name-status -z \\\n'));
+  assert.ok(evmWorkflow.includes('"${BASE_SHA}" "${MERGE_SHA}" > "${CHANGES_FILE}"'));
   assert.match(evmWorkflow, /^  evm-gate:/m);
 
   const demoManifest = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, 'demo/package.json'), 'utf8'));

--- a/scripts/lib/__tests__/ci-delta.test.mjs
+++ b/scripts/lib/__tests__/ci-delta.test.mjs
@@ -284,6 +284,20 @@ test('every planner output is wired to a real workflow job and omitted tests sta
   assert.ok(workflow.includes("github.base_ref == 'main'"));
   assert.ok(workflow.includes('git diff --name-status -z "${BASE_SHA}" "${MERGE_SHA}"'));
   assert.equal(workflow.includes('git diff --name-status -z "${BASE_SHA}" "${HEAD_SHA}"'), false);
+  assert.match(workflow, /^  evm-node-test-artifacts:/m);
+  assert.match(workflow, /^  evm-devnet-test-artifacts:/m);
+  assert.ok(workflow.includes('plan-vitest-shard.mjs chain "$SHARD_ID"'));
+  assert.ok(workflow.includes('plan-vitest-shard.mjs cli "$SHARD_ID"'));
+  assert.equal(
+    workflow.includes('@origintrail-official/dkg-chain exec vitest run --shard='),
+    false,
+  );
+  assert.equal(
+    workflow.includes('@origintrail-official/dkg exec vitest run --shard='),
+    false,
+  );
+  assert.ok(workflow.includes('shard: [1, 2, 3, 4, 5, 6, 7]'));
+  assert.ok(workflow.includes('playwright test --shard=${{ matrix.shard }}/7'));
 
   for (const packageName of [
     '@origintrail-official/dkg-rdf-utils',
@@ -330,6 +344,8 @@ test('aggregate gates reject failed or accidentally skipped selected jobs', () =
     solidity: { result: 'skipped' },
     'solidity-coverage': { result: 'skipped' },
     'tornado-static-analysis': { result: 'skipped' },
+    'evm-node-test-artifacts': { result: 'skipped' },
+    'evm-devnet-test-artifacts': { result: 'skipped' },
     ...Object.fromEntries(Object.values(PRIMARY_LANE_JOBS).map((job) => [job, { result: 'skipped' }])),
   };
   needs['kosava-supporting'].result = 'success';
@@ -362,8 +378,24 @@ test('aggregate gate accepts the full-push and docs-only job shapes', () => {
     solidity: { result: 'skipped' },
     'solidity-coverage': { result: 'success' },
     'tornado-static-analysis': { result: 'success' },
+    'evm-node-test-artifacts': { result: 'success' },
+    'evm-devnet-test-artifacts': { result: 'success' },
   };
   assert.deepEqual(validatePrimaryResults({ eventName: 'push', plan: full, needs: fullNeeds }), []);
+
+  const missingNodeArtifacts = structuredClone(fullNeeds);
+  missingNodeArtifacts['evm-node-test-artifacts'].result = 'skipped';
+  assert.match(
+    validatePrimaryResults({ eventName: 'push', plan: full, needs: missingNodeArtifacts }).join('\n'),
+    /evm-node-test-artifacts was selected but ended with skipped/,
+  );
+
+  const missingDevnetArtifacts = structuredClone(fullNeeds);
+  missingDevnetArtifacts['evm-devnet-test-artifacts'].result = 'skipped';
+  assert.match(
+    validatePrimaryResults({ eventName: 'push', plan: full, needs: missingDevnetArtifacts }).join('\n'),
+    /evm-devnet-test-artifacts was selected but ended with skipped/,
+  );
 
   const mergeNeeds = structuredClone(fullNeeds);
   mergeNeeds.solidity.result = 'success';
@@ -388,6 +420,8 @@ test('aggregate gate accepts the full-push and docs-only job shapes', () => {
     solidity: { result: 'skipped' },
     'solidity-coverage': { result: 'skipped' },
     'tornado-static-analysis': { result: 'skipped' },
+    'evm-node-test-artifacts': { result: 'skipped' },
+    'evm-devnet-test-artifacts': { result: 'skipped' },
   };
   assert.deepEqual(validatePrimaryResults({ eventName: 'pull_request', plan: docs, needs: docsNeeds }), []);
   assert.deepEqual(validateEvmResults({

--- a/scripts/lib/__tests__/vitest-shards.test.mjs
+++ b/scripts/lib/__tests__/vitest-shards.test.mjs
@@ -1,0 +1,195 @@
+import assert from 'node:assert/strict';
+import { readdirSync } from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import {
+  PACKAGE_SPECS,
+  PER_FILE_OVERHEAD_MS,
+  UNKNOWN_FILE_BODY_MS,
+  planPackageShards,
+  planWeightedShards,
+} from '../../ci/plan-vitest-shard.mjs';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const SCRIPT_PATH = path.join(REPO_ROOT, 'scripts/ci/plan-vitest-shard.mjs');
+
+function compareAscii(left, right) {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}
+
+function independentlyDiscover(packageDirectory, excludeArchive) {
+  const packageRoot = path.join(REPO_ROOT, packageDirectory);
+  const testRoot = path.join(packageRoot, 'test');
+  const files = [];
+
+  function walk(directory) {
+    const entries = readdirSync(directory, { withFileTypes: true });
+    for (const entry of entries) {
+      const absolutePath = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        walk(absolutePath);
+      } else if (entry.isFile() && entry.name.endsWith('.test.ts')) {
+        files.push(path.relative(packageRoot, absolutePath).split(path.sep).join('/'));
+      }
+    }
+  }
+
+  walk(testRoot);
+  return files
+    .filter((file) => !excludeArchive || !file.startsWith('test/archive/'))
+    .sort(compareAscii);
+}
+
+for (const packageName of ['cli', 'chain']) {
+  test(packageName + ' shards cover every eligible file exactly once', () => {
+    const spec = PACKAGE_SPECS[packageName];
+    const expected = independentlyDiscover(
+      spec.packageDirectory,
+      packageName === 'chain',
+    );
+    const shards = planPackageShards(packageName, REPO_ROOT);
+    const flattened = shards.flatMap((shard) => shard.files);
+
+    assert.equal(shards.length, spec.shardCount);
+    assert.ok(shards.every((shard) => shard.files.length > 0));
+    assert.equal(new Set(flattened).size, flattened.length, 'shards must not overlap');
+    assert.deepEqual([...flattened].sort(compareAscii), expected);
+
+    for (const shard of shards) {
+      assert.deepEqual(shard.files, [...shard.files].sort(compareAscii));
+    }
+  });
+
+  test(packageName + ' shard planning is deterministic and balanced for the timing snapshot', () => {
+    const first = planPackageShards(packageName, REPO_ROOT);
+    const second = planPackageShards(packageName, REPO_ROOT);
+    assert.deepEqual(second, first);
+
+    const unknownCount = first.reduce(
+      (count, shard) => count + shard.unknownFiles.length,
+      0,
+    );
+    if (unknownCount === 0) {
+      const loads = first.map((shard) => shard.estimatedMs);
+      assert.ok(
+        Math.max(...loads) - Math.min(...loads) < 1_000,
+        'latest-run weights should keep shard estimates within one second',
+      );
+    }
+  });
+}
+
+test('chain discovery excludes only the archived directory', () => {
+  const shards = planPackageShards('chain', REPO_ROOT);
+  const files = shards.flatMap((shard) => shard.files);
+  assert.ok(files.includes('test/v8-v9-archive.test.ts'));
+  assert.ok(files.every((file) => !file.startsWith('test/archive/')));
+});
+
+test('unknown files are conservatively weighted and still assigned exactly once', () => {
+  const shards = planWeightedShards({
+    files: [
+      'test/a.test.ts',
+      'test/new-unmeasured.test.ts',
+      'test/z.test.ts',
+    ],
+    bodyWeightsMs: {
+      'test/a.test.ts': 100,
+      'test/z.test.ts': 200,
+    },
+    shardCount: 2,
+  });
+  const flattened = shards.flatMap((shard) => shard.files);
+  const unknowns = shards.flatMap((shard) => shard.unknownFiles);
+
+  assert.deepEqual([...flattened].sort(compareAscii), [
+    'test/a.test.ts',
+    'test/new-unmeasured.test.ts',
+    'test/z.test.ts',
+  ]);
+  assert.equal(new Set(flattened).size, 3);
+  assert.deepEqual(unknowns, ['test/new-unmeasured.test.ts']);
+
+  const unknownShard = shards.find((shard) =>
+    shard.files.includes('test/new-unmeasured.test.ts'));
+  assert.ok(unknownShard);
+  assert.ok(
+    unknownShard.estimatedMs >= UNKNOWN_FILE_BODY_MS + PER_FILE_OVERHEAD_MS,
+  );
+});
+
+test('equal weights use stable path and shard-index tie breakers', () => {
+  const plan = () => planWeightedShards({
+    files: [
+      'test/d.test.ts',
+      'test/c.test.ts',
+      'test/b.test.ts',
+      'test/a.test.ts',
+    ],
+    bodyWeightsMs: {
+      'test/a.test.ts': 0,
+      'test/b.test.ts': 0,
+      'test/c.test.ts': 0,
+      'test/d.test.ts': 0,
+    },
+    shardCount: 2,
+  });
+
+  assert.deepEqual(plan(), [
+    {
+      index: 1,
+      estimatedMs: PER_FILE_OVERHEAD_MS * 2,
+      files: ['test/a.test.ts', 'test/c.test.ts'],
+      unknownFiles: [],
+    },
+    {
+      index: 2,
+      estimatedMs: PER_FILE_OVERHEAD_MS * 2,
+      files: ['test/b.test.ts', 'test/d.test.ts'],
+      unknownFiles: [],
+    },
+  ]);
+  assert.deepEqual(plan(), plan());
+});
+
+test('the executable prints only its selected shard to stdout', () => {
+  const expected = planPackageShards('cli', REPO_ROOT)[0].files;
+  const result = spawnSync(process.execPath, [SCRIPT_PATH, 'cli', '1'], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(result.stdout.trimEnd().split('\n'), expected);
+  assert.match(result.stderr, /vitest-shard: cli 1\/4/);
+
+  const invalid = spawnSync(process.execPath, [SCRIPT_PATH, 'chain', '4'], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+  });
+  assert.equal(invalid.status, 2);
+  assert.match(invalid.stderr, /CLI has 4 shards and chain has 3 shards/);
+});
+
+test('invalid or duplicate planning inputs fail loudly', () => {
+  assert.throws(
+    () => planWeightedShards({
+      files: ['test/a.test.ts'],
+      bodyWeightsMs: {},
+      shardCount: 2,
+    }),
+    /at least one eligible test file per shard/,
+  );
+  assert.throws(
+    () => planWeightedShards({
+      files: ['test/a.test.ts', 'test/a.test.ts'],
+      bodyWeightsMs: {},
+      shardCount: 1,
+    }),
+    /contains duplicates/,
+  );
+});

--- a/scripts/lib/ci-delta.mjs
+++ b/scripts/lib/ci-delta.mjs
@@ -1,0 +1,506 @@
+export const CI_LANES = Object.freeze([
+  'tornado_core',
+  'tornado_blazegraph',
+  'tornado_publisher',
+  'tornado_agent',
+  'bura_cli',
+  'bura_blazegraph_arm64',
+  'bura_query',
+  'kosava_node_ui',
+  'kosava_node_ui_e2e',
+  'kosava_supporting',
+  'kosava_hardhat_plugins',
+  'contracts',
+]);
+
+export const EVM_SCOPES = Object.freeze(['chain', 'publisher', 'agent']);
+
+export const WORKSPACE_RULES = Object.freeze({
+  'packages/core': {
+    lanes: [
+      'tornado_core',
+      'tornado_blazegraph',
+      'tornado_publisher',
+      'tornado_agent',
+      'bura_cli',
+      'bura_query',
+      'kosava_node_ui',
+      'kosava_node_ui_e2e',
+      'kosava_supporting',
+      'kosava_hardhat_plugins',
+    ],
+    evmScopes: EVM_SCOPES,
+  },
+  'packages/rdf-utils': {
+    lanes: [
+      'tornado_core',
+      'tornado_blazegraph',
+      'tornado_publisher',
+      'tornado_agent',
+      'bura_cli',
+      'bura_query',
+      'kosava_node_ui',
+      'kosava_node_ui_e2e',
+      'kosava_supporting',
+      'kosava_hardhat_plugins',
+    ],
+    evmScopes: EVM_SCOPES,
+  },
+  'packages/storage': {
+    lanes: [
+      'tornado_core',
+      'tornado_blazegraph',
+      'tornado_publisher',
+      'tornado_agent',
+      'bura_cli',
+      'bura_query',
+      'kosava_node_ui_e2e',
+      'kosava_supporting',
+      'kosava_hardhat_plugins',
+    ],
+    evmScopes: ['publisher', 'agent'],
+  },
+  'packages/chain': {
+    lanes: [
+      'tornado_core',
+      'tornado_publisher',
+      'tornado_agent',
+      'bura_cli',
+      'kosava_node_ui_e2e',
+      'kosava_supporting',
+      'kosava_hardhat_plugins',
+    ],
+    evmScopes: EVM_SCOPES,
+  },
+  'packages/query': {
+    lanes: [
+      'tornado_publisher',
+      'tornado_agent',
+      'bura_cli',
+      'bura_query',
+      'kosava_node_ui_e2e',
+      'kosava_supporting',
+      'kosava_hardhat_plugins',
+    ],
+    evmScopes: ['publisher', 'agent'],
+  },
+  'packages/publisher': {
+    lanes: [
+      'tornado_publisher',
+      'tornado_agent',
+      'bura_cli',
+      'kosava_node_ui_e2e',
+      'kosava_supporting',
+      'kosava_hardhat_plugins',
+    ],
+    evmScopes: ['publisher', 'agent'],
+  },
+  'packages/random-sampling': {
+    lanes: [
+      'tornado_agent',
+      'bura_cli',
+      'kosava_node_ui_e2e',
+      'kosava_supporting',
+      'kosava_hardhat_plugins',
+    ],
+    evmScopes: ['agent'],
+  },
+  'packages/agent': {
+    lanes: [
+      'tornado_agent',
+      'bura_cli',
+      'kosava_node_ui_e2e',
+      'kosava_supporting',
+      'kosava_hardhat_plugins',
+    ],
+    evmScopes: ['agent'],
+  },
+  'packages/cli': {
+    lanes: ['bura_cli', 'kosava_node_ui_e2e', 'kosava_hardhat_plugins'],
+    evmScopes: [],
+  },
+  'packages/node-ui': {
+    lanes: ['bura_cli', 'kosava_node_ui', 'kosava_node_ui_e2e', 'kosava_hardhat_plugins'],
+    evmScopes: [],
+  },
+  'packages/graph-viz': {
+    lanes: [
+      'bura_cli',
+      'kosava_node_ui',
+      'kosava_node_ui_e2e',
+      'kosava_supporting',
+      'kosava_hardhat_plugins',
+    ],
+    evmScopes: [],
+  },
+  'packages/epcis': {
+    lanes: ['bura_cli', 'kosava_node_ui_e2e', 'kosava_supporting', 'kosava_hardhat_plugins'],
+    evmScopes: [],
+  },
+  'packages/mcp-dkg': {
+    lanes: ['bura_cli', 'kosava_node_ui_e2e', 'kosava_supporting', 'kosava_hardhat_plugins'],
+    evmScopes: [],
+  },
+  'packages/okf': {
+    lanes: ['bura_cli', 'kosava_node_ui_e2e', 'kosava_supporting', 'kosava_hardhat_plugins'],
+    evmScopes: [],
+  },
+  'packages/adapter-hermes': {
+    lanes: ['bura_cli', 'kosava_node_ui_e2e', 'kosava_supporting', 'kosava_hardhat_plugins'],
+    evmScopes: [],
+  },
+  'packages/adapter-openclaw': {
+    lanes: ['bura_cli', 'kosava_node_ui_e2e', 'kosava_supporting', 'kosava_hardhat_plugins'],
+    evmScopes: [],
+  },
+  'packages/adapter-elizaos': {
+    lanes: ['kosava_supporting'],
+    evmScopes: [],
+  },
+  'packages/network-sim': {
+    lanes: ['kosava_supporting'],
+    evmScopes: [],
+  },
+  'packages/kafka-plugin': {
+    lanes: ['kosava_hardhat_plugins'],
+    evmScopes: [],
+  },
+  'packages/evm-module': {
+    forceFull: true,
+    lanes: [],
+    evmScopes: EVM_SCOPES,
+  },
+  demo: {
+    lanes: ['kosava_supporting'],
+    evmScopes: [],
+  },
+});
+
+// Each workspace's direct test owner. The routing test computes the reverse
+// workspace dependency graph and proves that every rule includes the owners of
+// all current downstream consumers. Explicit integration lanes remain in
+// WORKSPACE_RULES in addition to this mechanically checked minimum.
+export const WORKSPACE_OWNING_LANES = Object.freeze({
+  'packages/core': ['tornado_core'],
+  'packages/rdf-utils': ['tornado_core'],
+  'packages/storage': ['tornado_core', 'tornado_blazegraph'],
+  'packages/chain': ['tornado_core'],
+  'packages/query': ['bura_query'],
+  'packages/publisher': ['tornado_publisher'],
+  'packages/random-sampling': ['kosava_hardhat_plugins'],
+  'packages/agent': ['tornado_agent'],
+  'packages/cli': ['bura_cli'],
+  'packages/node-ui': ['kosava_node_ui'],
+  'packages/graph-viz': ['kosava_supporting'],
+  'packages/epcis': ['kosava_supporting'],
+  'packages/mcp-dkg': ['kosava_supporting'],
+  'packages/okf': ['kosava_supporting'],
+  'packages/adapter-hermes': ['kosava_supporting'],
+  'packages/adapter-openclaw': ['kosava_supporting'],
+  'packages/adapter-elizaos': ['kosava_supporting'],
+  'packages/network-sim': ['kosava_supporting'],
+  'packages/kafka-plugin': ['kosava_hardhat_plugins'],
+  'packages/evm-module': ['contracts'],
+  demo: ['kosava_supporting'],
+});
+
+export const WORKSPACE_OWNING_EVM_SCOPES = Object.freeze({
+  'packages/chain': ['chain'],
+  'packages/publisher': ['publisher'],
+  'packages/agent': ['agent'],
+});
+
+const GLOBAL_FULL_PATHS = new Set([
+  '.npmrc',
+  '.nvmrc',
+  'package.json',
+  'pnpm-lock.yaml',
+  'pnpm-workspace.yaml',
+  'tsconfig.base.json',
+  'turbo.json',
+  'vitest.config.ts',
+  'vitest.coverage.ts',
+  'vitest.evm-integration.ts',
+]);
+
+const BLAZEGRAPH_ARM64_PATHS = new Set([
+  'blazegraph-image.json',
+  'packages/cli/blazegraph-image-metadata.cjs',
+  'packages/cli/src/daemon/blazegraph-docker.ts',
+  'packages/cli/test/blazegraph-docker.test.ts',
+  'packages/cli/test/blazegraph-image-metadata.test.ts',
+  'packages/cli/test/blazegraph-integration.test.ts',
+]);
+
+function isBlazegraphArm64Path(filePath) {
+  return BLAZEGRAPH_ARM64_PATHS.has(filePath)
+    || /^packages\/cli\/(?:src|test)\/.*blazegraph.*\.(?:[cm]?[jt]s|json)$/i.test(filePath);
+}
+
+const NODE_LANES = CI_LANES.filter((lane) => lane !== 'contracts' && lane !== 'bura_blazegraph_arm64');
+const MAX_REPORTED_FILES = 200;
+
+function emptyLanes() {
+  return Object.fromEntries(CI_LANES.map((lane) => [lane, false]));
+}
+
+function fullPlan(reasons, changedFiles = [], auditSampled = false) {
+  return {
+    mode: 'full',
+    fullCi: true,
+    auditSampled,
+    runNode: true,
+    lanes: Object.fromEntries(CI_LANES.map((lane) => [lane, true])),
+    evmScopes: [...EVM_SCOPES],
+    changedFileCount: changedFiles.length,
+    changedFiles: changedFiles.slice(0, MAX_REPORTED_FILES),
+    reasons,
+  };
+}
+
+function normalizePath(filePath) {
+  return filePath.replaceAll('\\', '/').replace(/^\.\//, '');
+}
+
+const DOCUMENTATION_EXTENSIONS = new Set([
+  'docx',
+  'gif',
+  'jpeg',
+  'jpg',
+  'md',
+  'mdx',
+  'pdf',
+  'png',
+  'svg',
+  'txt',
+  'webp',
+]);
+
+function hasDocumentationExtension(filePath) {
+  const extension = filePath.split('.').at(-1)?.toLowerCase();
+  return DOCUMENTATION_EXTENSIONS.has(extension);
+}
+
+function isDocumentationOnlyPath(filePath) {
+  if (
+    filePath === 'LICENSE'
+    || filePath === 'SECURITY.md'
+    || filePath === 'CODE_OF_CONDUCT.md'
+    || filePath === 'CONTRIBUTING.md'
+    || filePath === '.editorconfig'
+    || filePath === '.gitignore'
+    || /^[^/]+\.(?:md|mdx)$/i.test(filePath)
+    || ((filePath.startsWith('docs/') || filePath.startsWith('dkgv10-spec/'))
+      && hasDocumentationExtension(filePath))
+    || (filePath.startsWith('.changeset/') && hasDocumentationExtension(filePath))
+    || (filePath.startsWith('.github/ISSUE_TEMPLATE/')
+      && /\.(?:md|ya?ml)$/i.test(filePath))
+    || (filePath.startsWith('.github/PULL_REQUEST_TEMPLATE/')
+      && /\.md$/i.test(filePath))
+  ) {
+    return true;
+  }
+
+  return /^packages\/[^/]+\/(?:README|CHANGELOG|CONTRIBUTING|LICENSE)(?:\.(?:md|mdx|txt))?$/i.test(filePath)
+    || (/^packages\/[^/]+\/docs\//.test(filePath) && hasDocumentationExtension(filePath))
+    || /^demo\/(?:README|CHANGELOG|CONTRIBUTING|LICENSE)(?:\.(?:md|mdx|txt))?$/i.test(filePath)
+    || (filePath.startsWith('demo/docs/') && hasDocumentationExtension(filePath));
+}
+
+function isGlobalFullPath(filePath) {
+  return GLOBAL_FULL_PATHS.has(filePath)
+    || filePath.startsWith('.github/workflows/')
+    || filePath.startsWith('patches/')
+    || filePath.startsWith('scripts/')
+    || /^tsconfig(?:\.[^/]+)?\.json$/.test(filePath);
+}
+
+function workspaceForPath(filePath) {
+  return Object.keys(WORKSPACE_RULES)
+    .sort((left, right) => right.length - left.length)
+    .find((workspace) => filePath === workspace || filePath.startsWith(`${workspace}/`));
+}
+
+function isAuditSample(sampleKey, percentage) {
+  if (!sampleKey || percentage <= 0) return false;
+  const prefix = sampleKey.match(/^[0-9a-f]{8}/i)?.[0];
+  if (!prefix) return false;
+  return Number.parseInt(prefix, 16) % 100 < percentage;
+}
+
+export function parseNameStatusZ(buffer) {
+  if (!buffer?.length) return [];
+  const fields = buffer.toString('utf8').split('\0');
+  if (fields.at(-1) === '') fields.pop();
+
+  const entries = [];
+  for (let index = 0; index < fields.length;) {
+    const status = fields[index++];
+    if (!status) throw new Error('Missing git change status');
+
+    const code = status[0];
+    const oldPath = fields[index++];
+    if (!oldPath) throw new Error(`Missing path for git change status ${status}`);
+
+    if (code === 'R' || code === 'C') {
+      const newPath = fields[index++];
+      if (!newPath) throw new Error(`Missing destination path for git change status ${status}`);
+      entries.push({ status, paths: [normalizePath(oldPath), normalizePath(newPath)] });
+    } else {
+      entries.push({ status, paths: [normalizePath(oldPath)] });
+    }
+  }
+
+  return entries;
+}
+
+export function planCi({
+  eventName,
+  changeEntries = [],
+  labels = [],
+  sampleKey = '',
+  auditPercentage = 5,
+} = {}) {
+  const changedFiles = [...new Set(changeEntries.flatMap((entry) => entry.paths).map(normalizePath))];
+
+  if (eventName !== 'pull_request') {
+    return fullPlan([`${eventName || 'unknown'} events always run full CI`], changedFiles);
+  }
+
+  if (labels.includes('ci:full')) {
+    return fullPlan(['PR has the ci:full override label'], changedFiles);
+  }
+
+  if (isAuditSample(sampleKey, auditPercentage)) {
+    return fullPlan([`${auditPercentage}% deterministic audit sample`], changedFiles, true);
+  }
+
+  if (changeEntries.length === 0 || changedFiles.length === 0) {
+    return fullPlan(['No changed files were reported; failing closed'], changedFiles);
+  }
+
+  const riskyChange = changeEntries.find(({ status }) => ['D', 'R', 'C', 'T', 'U', 'X', 'B'].includes(status[0]));
+  if (riskyChange) {
+    return fullPlan([`Git change status ${riskyChange.status} cannot be narrowed safely`], changedFiles);
+  }
+
+  const productionFiles = changedFiles.filter((filePath) => !isDocumentationOnlyPath(filePath));
+  if (productionFiles.length === 0) {
+    return {
+      mode: 'docs-only',
+      fullCi: false,
+      auditSampled: false,
+      runNode: false,
+      lanes: emptyLanes(),
+      evmScopes: [],
+      changedFileCount: changedFiles.length,
+      changedFiles: changedFiles.slice(0, MAX_REPORTED_FILES),
+      reasons: ['Only documentation or repository metadata changed'],
+    };
+  }
+
+  if (productionFiles.length > 100) {
+    return fullPlan([`Large PR (${productionFiles.length} non-documentation files)`], changedFiles);
+  }
+
+  const touchedWorkspaces = new Set(productionFiles.map(workspaceForPath).filter(Boolean));
+  if (touchedWorkspaces.size >= 4) {
+    return fullPlan([`Cross-cutting PR (${touchedWorkspaces.size} production workspaces)`], changedFiles);
+  }
+
+  const lanes = emptyLanes();
+  const evmScopes = new Set();
+  const reasons = [];
+
+  for (const filePath of productionFiles) {
+    if (isGlobalFullPath(filePath)) {
+      return fullPlan([`Global CI input changed: ${filePath}`], changedFiles);
+    }
+
+    const blazegraphProvisioningChange = isBlazegraphArm64Path(filePath);
+    if (blazegraphProvisioningChange) {
+      lanes.bura_cli = true;
+      lanes.bura_blazegraph_arm64 = true;
+      reasons.push(`Blazegraph provisioning contract changed: ${filePath}`);
+    }
+
+    const workspace = workspaceForPath(filePath);
+    if (!workspace) {
+      if (blazegraphProvisioningChange) continue;
+      return fullPlan([`Unclassified path changed: ${filePath}`], changedFiles);
+    }
+
+    if (filePath === `${workspace}/package.json`) {
+      return fullPlan([`Workspace dependency manifest changed: ${filePath}`], changedFiles);
+    }
+
+    const rule = WORKSPACE_RULES[workspace];
+    if (rule.forceFull) {
+      return fullPlan([`Highest-risk workspace changed: ${workspace}`], changedFiles);
+    }
+
+    for (const lane of rule.lanes) lanes[lane] = true;
+    for (const scope of rule.evmScopes) evmScopes.add(scope);
+    reasons.push(`${workspace} and its downstream consumers`);
+  }
+
+  const deduplicatedReasons = [...new Set(reasons)];
+  const runNode = NODE_LANES.some((lane) => lanes[lane]);
+  if (!runNode && !lanes.bura_blazegraph_arm64 && !lanes.contracts && evmScopes.size === 0) {
+    return fullPlan(['Planner selected no lane for a production change; failing closed'], changedFiles);
+  }
+
+  return {
+    mode: 'delta',
+    fullCi: false,
+    auditSampled: false,
+    runNode,
+    lanes,
+    evmScopes: EVM_SCOPES.filter((scope) => evmScopes.has(scope)),
+    changedFileCount: changedFiles.length,
+    changedFiles: changedFiles.slice(0, MAX_REPORTED_FILES),
+    reasons: deduplicatedReasons,
+  };
+}
+
+export function githubOutputsForPlan(plan) {
+  const gatePlan = {
+    mode: plan.mode,
+    fullCi: plan.fullCi,
+    runNode: plan.runNode,
+    lanes: plan.lanes,
+    evmScopes: plan.evmScopes,
+  };
+  return {
+    full_ci: String(plan.fullCi),
+    run_node: String(plan.runNode),
+    ...Object.fromEntries(CI_LANES.map((lane) => [lane, String(plan.lanes[lane])])),
+    evm_matrix: JSON.stringify(plan.evmScopes),
+    plan_json: JSON.stringify(gatePlan),
+  };
+}
+
+export function renderPlanSummary(plan) {
+  const selected = CI_LANES.filter((lane) => plan.lanes[lane]);
+  const skipped = CI_LANES.filter((lane) => !plan.lanes[lane]);
+  const safe = (value) => value.replace(/[|`\r\n]/g, '_');
+
+  return [
+    '## CI delta plan',
+    '',
+    `- Mode: **${plan.mode}**`,
+    `- Full-CI audit sample: **${plan.auditSampled ? 'yes' : 'no'}**`,
+    `- Selected lanes: ${selected.length ? selected.map((lane) => `\`${lane}\``).join(', ') : '_none_'}`,
+    `- Skipped lanes: ${skipped.length ? skipped.map((lane) => `\`${lane}\``).join(', ') : '_none_'}`,
+    `- EVM scopes: ${plan.evmScopes.length ? plan.evmScopes.map((scope) => `\`${scope}\``).join(', ') : '_none_'}`,
+    `- Reason: ${plan.reasons.map(safe).join('; ')}`,
+    '',
+    '<details><summary>Changed files</summary>',
+    '',
+    ...plan.changedFiles.slice(0, 100).map((filePath) => `- \`${safe(filePath)}\``),
+    ...(plan.changedFileCount > 100 ? [`- _and ${plan.changedFileCount - 100} more_`] : []),
+    '',
+    '</details>',
+    '',
+  ].join('\n');
+}

--- a/scripts/lib/ci-results.mjs
+++ b/scripts/lib/ci-results.mjs
@@ -76,6 +76,19 @@ export function validatePrimaryResults({ eventName, plan, needs }) {
   requireSuccess(needs, 'changes', true, errors);
   requireSuccess(needs, 'build', plan.runNode, errors);
 
+  const needsNodeTestArtifacts = Boolean(
+    plan.lanes?.tornado_core
+    || plan.lanes?.bura_cli
+    || plan.lanes?.kosava_hardhat_plugins
+  );
+  requireSuccess(needs, 'evm-node-test-artifacts', needsNodeTestArtifacts, errors);
+  requireSuccess(
+    needs,
+    'evm-devnet-test-artifacts',
+    Boolean(plan.lanes?.kosava_node_ui_e2e),
+    errors,
+  );
+
   for (const [lane, job] of Object.entries(PRIMARY_LANE_JOBS)) {
     requireSuccess(needs, job, Boolean(plan.lanes?.[lane]), errors);
   }

--- a/scripts/lib/ci-results.mjs
+++ b/scripts/lib/ci-results.mjs
@@ -1,0 +1,112 @@
+import { CI_LANES, EVM_SCOPES } from './ci-delta.mjs';
+
+export const PRIMARY_LANE_JOBS = Object.freeze({
+  tornado_core: 'tornado-core',
+  tornado_blazegraph: 'tornado-blazegraph',
+  tornado_publisher: 'tornado-publisher',
+  tornado_agent: 'tornado-agent',
+  bura_cli: 'bura-cli',
+  bura_blazegraph_arm64: 'bura-blazegraph-arm64',
+  bura_query: 'bura-supporting',
+  kosava_node_ui: 'kosava-node-ui',
+  kosava_node_ui_e2e: 'kosava-node-ui-e2e',
+  kosava_supporting: 'kosava-supporting',
+  kosava_hardhat_plugins: 'kosava-hardhat-plugins',
+});
+
+function checkNoFailedJobs(needs, errors) {
+  for (const [job, state] of Object.entries(needs)) {
+    if (state.result === 'failure' || state.result === 'cancelled') {
+      errors.push(`${job} ended with ${state.result}`);
+    }
+  }
+}
+
+function requireSuccess(needs, job, shouldRun, errors) {
+  const result = needs[job]?.result;
+  if (!result) {
+    errors.push(`${job} is missing from the aggregate gate`);
+  } else if (shouldRun && result !== 'success') {
+    errors.push(`${job} was selected but ended with ${result}`);
+  }
+}
+
+function checkPlanShape(plan, eventName, errors) {
+  if (!plan || typeof plan !== 'object') {
+    errors.push('CI plan is missing or is not an object');
+    return;
+  }
+  if (!['full', 'delta', 'docs-only'].includes(plan.mode)) {
+    errors.push(`CI plan has invalid mode ${plan.mode}`);
+  }
+  if (typeof plan.fullCi !== 'boolean' || typeof plan.runNode !== 'boolean') {
+    errors.push('CI plan fullCi/runNode flags must be booleans');
+  }
+  for (const lane of CI_LANES) {
+    if (typeof plan.lanes?.[lane] !== 'boolean') {
+      errors.push(`CI plan lane ${lane} must be a boolean`);
+    }
+  }
+  if (
+    !Array.isArray(plan.evmScopes)
+    || plan.evmScopes.some((scope) => !EVM_SCOPES.includes(scope))
+    || new Set(plan.evmScopes).size !== plan.evmScopes.length
+  ) {
+    errors.push('CI plan has an invalid EVM scope matrix');
+  }
+  if (plan.mode === 'full') {
+    if (!plan.fullCi || CI_LANES.some((lane) => plan.lanes?.[lane] !== true)) {
+      errors.push('Full CI mode must select every lane');
+    }
+    if (EVM_SCOPES.some((scope) => !plan.evmScopes?.includes(scope))) {
+      errors.push('Full CI mode must select every EVM scope');
+    }
+  } else if (plan.fullCi) {
+    errors.push(`${plan.mode} mode cannot set fullCi=true`);
+  }
+  if (eventName !== 'pull_request' && plan.mode !== 'full') {
+    errors.push(`${eventName || 'unknown'} events must use full CI mode`);
+  }
+}
+
+export function validatePrimaryResults({ eventName, plan, needs }) {
+  const errors = [];
+  checkPlanShape(plan, eventName, errors);
+  checkNoFailedJobs(needs, errors);
+  requireSuccess(needs, 'changes', true, errors);
+  requireSuccess(needs, 'build', plan.runNode, errors);
+
+  for (const [lane, job] of Object.entries(PRIMARY_LANE_JOBS)) {
+    requireSuccess(needs, job, Boolean(plan.lanes?.[lane]), errors);
+  }
+
+  const contracts = Boolean(plan.lanes?.contracts);
+  requireSuccess(needs, 'abi-freshness', contracts, errors);
+  const candidateEvent = eventName === 'pull_request' || eventName === 'merge_group';
+  requireSuccess(needs, 'solidity', candidateEvent && contracts, errors);
+  requireSuccess(needs, 'solidity-coverage', !candidateEvent, errors);
+  requireSuccess(
+    needs,
+    'tornado-static-analysis',
+    eventName !== 'pull_request' || contracts,
+    errors,
+  );
+
+  const selectedNodeLane = Object.keys(PRIMARY_LANE_JOBS)
+    .filter((lane) => lane !== 'bura_blazegraph_arm64')
+    .some((lane) => plan.lanes?.[lane]);
+  if (selectedNodeLane !== Boolean(plan.runNode)) {
+    errors.push(`runNode=${plan.runNode} is inconsistent with selected Node lanes`);
+  }
+
+  return errors;
+}
+
+export function validateEvmResults({ eventName, plan, needs }) {
+  const errors = [];
+  checkPlanShape(plan, eventName, errors);
+  checkNoFailedJobs(needs, errors);
+  requireSuccess(needs, 'plan', true, errors);
+  requireSuccess(needs, 'evm-integration', plan.evmScopes?.length > 0, errors);
+  return errors;
+}


### PR DESCRIPTION
## Why

Pull requests currently fan out across almost the entire monorepo test matrix, even when they change only documentation or one isolated package. Ten recent successful PR runs had a 14-minute median, and the same full workflow on this PR originally took 13m07s.

## What changed

- Adds a deterministic, fail-closed planner that maps PR changes to owning and downstream Node lanes plus affected EVM integration scopes.
- Keeps full CI for merge-queue candidates, protected-branch pushes, manual runs, global or unknown files, manifests, high-risk packages, large/ambiguous diffs, a `ci:full` override, and a deterministic 5% audit sample.
- Adds stable `CI gate` and `EVM integration gate` jobs that fail if any selected lane is skipped, fails, or is cancelled.
- Compiles the two EVM test configurations once and shares immutable artifacts with their consumers.
- Splits the long full-CI bottlenecks across isolated runners: CLI into four duration-balanced shards, chain into three duration-balanced shards, and all 326 real-node Playwright tests into seven separate four-node devnets.
- Discovers CLI and chain test files at runtime and tests the shard planner for exact union, no overlap, deterministic output, and conservative handling of new files.
- Runs sharded Solidity tests on PR and merge-queue candidates while retaining the full coverage ratchet on protected pushes and manual runs.
- Adds previously omitted RDF utilities, OKF, and demo tests; the demo command includes both Kafka Streams and EPCIS Bike suites.
- Stabilizes two pre-existing false failures exposed by full validation: the Node UI test now waits for its lazy Shiki import, and the chain retry-budget test uses deterministic fake timers.

This avoids introducing a `develop` branch: PRs get fast feedback, while GitHub's merge queue validates the exact combined candidate before merge. Snapshot-style tests guard the routing decisions and dependency closure.

## Safety and rollout

Delta routing is deliberately **disabled by default**. Until repository administrators set `CI_DELTA_ENABLED=true`, PRs continue to exercise full CI; the live benchmark below therefore validates the complete path, not a selective shortcut.

Before enabling the variable:

1. Create the `ci:full` label.
2. Enable merge queue for `main`.
3. Require `CI gate` and `EVM integration gate`.
4. Set `CI_DELTA_ENABLED=true`.

Every matrix shard uses its own runner and isolated Hardhat/devnet state. Unknown paths fail closed to full CI, and the aggregate gate checks both shared artifact producers and every selected matrix job.

Forced-full parallel CI trades compute for latency: the measured runner total increased from 87.9 to 109.0 minutes. Delta routing reduces runner use on ordinary leaf/docs PRs; global and high-risk changes pay the extra parallel compute for near-six-minute feedback. The unsharded Solidity coverage ratchet remains a roughly 25-minute push/manual safety net and is outside the PR feedback path.

## Validation

- Full live GitHub run: [6m05s, 46 successful jobs, one policy-skipped coverage job, zero failures](https://github.com/OriginTrail/dkg/actions/runs/29325452377), down from [13m07s](https://github.com/OriginTrail/dkg/actions/runs/29321182804) on the same PR (53.5% faster).
- CLI: 2,705 passed + 12 skipped = 2,717 tests across all 190 files; four shards resolved exactly once.
- Chain: 1,033 passed + 1 skipped = 1,034 tests across all 58 active files; three shards resolved exactly once.
- Real-node Playwright: 318 passed + 8 skipped = all 326 tests across seven isolated four-node devnets.
- `pnpm test:scripts`: 86/86 passed, including planner, exact-coverage, and aggregate-gate tests.
- `actionlint`, Zizmor auditor, and `git diff --check`: passed; Zizmor reported no findings.
- `DKG_SKIP_EVM_BUILD=1 pnpm run build:packages`: 22/22 tasks passed in the earlier full validation.

The workflow documentation records the measured timings, retained coverage, rollout controls, and the latency/compute trade-off.
