### PR TITLE
fix(ci): delta planner diffed against a stale base SHA, routing ordinary PRs to full CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,6 @@ jobs:
         id: plan
         env:
           EVENT_NAME: ${{ github.event_name }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
           MERGE_SHA: ${{ github.sha }}
           PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
           SAMPLE_KEY: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -108,17 +107,18 @@ jobs:
           : > "${CHANGES_FILE}"
 
           if [[ "${EVENT_NAME}" == "pull_request" ]]; then
-            if [[ -z "${BASE_SHA}" || -z "${MERGE_SHA}" ]]; then
-              echo "::error::Missing pull-request base/merge SHA"
+            if [[ -z "${MERGE_SHA}" ]]; then
+              echo "::error::Missing pull-request merge SHA"
               exit 1
             fi
-            if ! git -C candidate cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
-              git -C candidate fetch --no-tags --depth=1 origin "${BASE_SHA}"
-            fi
             git -C candidate cat-file -e "${MERGE_SHA}^{commit}"
-            # Compare the latest base with GitHub's synthetic merge candidate.
-            # Comparing base directly to a behind PR head would misclassify
-            # unrelated changes that landed on base as part of this PR.
+            # Diff the synthetic merge candidate against its FIRST PARENT: the
+            # base-branch tip GitHub merged against when it built the candidate
+            # (fetch-depth 2 above always includes it). The event payload's
+            # pull_request.base.sha is a STALE snapshot — after any unrelated
+            # merge to base it drags those files into this diff and misroutes
+            # the PR to full CI (observed on PR #1690 right after #1687 landed).
+            BASE_SHA="$(git -C candidate rev-parse "${MERGE_SHA}^1")"
             git -C candidate diff --name-status -z \
               "${BASE_SHA}" "${MERGE_SHA}" > "${CHANGES_FILE}"
           fi

--- a/.github/workflows/evm-integration.yml
+++ b/.github/workflows/evm-integration.yml
@@ -51,7 +51,6 @@ jobs:
         id: plan
         env:
           EVENT_NAME: ${{ github.event_name }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
           MERGE_SHA: ${{ github.sha }}
           PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
           SAMPLE_KEY: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -62,14 +61,15 @@ jobs:
           : > "${CHANGES_FILE}"
 
           if [[ "${EVENT_NAME}" == "pull_request" ]]; then
-            if [[ -z "${BASE_SHA}" || -z "${MERGE_SHA}" ]]; then
-              echo "::error::Missing pull-request base/merge SHA"
+            if [[ -z "${MERGE_SHA}" ]]; then
+              echo "::error::Missing pull-request merge SHA"
               exit 1
             fi
-            if ! git -C candidate cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
-              git -C candidate fetch --no-tags --depth=1 origin "${BASE_SHA}"
-            fi
             git -C candidate cat-file -e "${MERGE_SHA}^{commit}"
+            # First parent of the synthetic merge = the CURRENT base tip; the
+            # event's pull_request.base.sha is a stale snapshot that misroutes
+            # PRs to full CI after unrelated merges to base (see ci.yml).
+            BASE_SHA="$(git -C candidate rev-parse "${MERGE_SHA}^1")"
             git -C candidate diff --name-status -z \
               "${BASE_SHA}" "${MERGE_SHA}" > "${CHANGES_FILE}"
           fi

--- a/scripts/lib/__tests__/ci-delta.test.mjs
+++ b/scripts/lib/__tests__/ci-delta.test.mjs
@@ -439,6 +439,12 @@ test('every planner output is wired to a real workflow job and omitted tests sta
   assert.ok(workflow.includes('git -C candidate diff --name-status -z \\\n'));
   assert.ok(workflow.includes('"${BASE_SHA}" "${MERGE_SHA}" > "${CHANGES_FILE}"'));
   assert.equal(workflow.includes('"${BASE_SHA}" "${HEAD_SHA}"'), false);
+  // The diff base must be the merge candidate's first parent (the CURRENT
+  // base tip). The event payload's pull_request.base.sha is a stale snapshot:
+  // it drags unrelated already-merged base changes into the diff and misroutes
+  // ordinary PRs to full CI (observed on PR #1690 after #1687 merged).
+  assert.ok(workflow.includes('BASE_SHA="$(git -C candidate rev-parse "${MERGE_SHA}^1")"'));
+  assert.equal(workflow.includes('github.event.pull_request.base.sha'), false);
   assert.match(workflow, /^  evm-node-test-artifacts:/m);
   assert.match(workflow, /^  evm-devnet-test-artifacts:/m);
   assert.ok(workflow.includes('plan-vitest-shard.mjs chain "$SHARD_ID"'));
@@ -471,6 +477,8 @@ test('every planner output is wired to a real workflow job and omitted tests sta
   assert.ok(evmWorkflow.includes("github.base_ref == 'main'"));
   assert.ok(evmWorkflow.includes('git -C candidate diff --name-status -z \\\n'));
   assert.ok(evmWorkflow.includes('"${BASE_SHA}" "${MERGE_SHA}" > "${CHANGES_FILE}"'));
+  assert.ok(evmWorkflow.includes('BASE_SHA="$(git -C candidate rev-parse "${MERGE_SHA}^1")"'));
+  assert.equal(evmWorkflow.includes('github.event.pull_request.base.sha'), false);
   assert.match(evmWorkflow, /^  evm-gate:/m);
 
   const demoManifest = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, 'demo/package.json'), 'utf8'));


### PR DESCRIPTION
## Why

The first live delta-enabled run (PR #1690, [plan job](https://github.com/OriginTrail/dkg/actions/runs/29335180234/job/87092515106)) went to **full CI** with reason `Cross-cutting PR (5 production workspaces)` — but #1690 only touches two workspaces (`agent`, `cli`). The planner's changed-file set contained **PR #1687's own files** (`scripts/lib/ci-delta.mjs`, workflow files, `docs/ci-delta-policy.md`), which are on `main`, not in #1690.

Root cause: the planner diffs `github.event.pull_request.base.sha` against the synthetic merge commit (`github.sha`). GitHub recomputes the merge candidate against the **current** base tip on every event, but the event payload's `base.sha` is a **stale snapshot** (on #1690 it predated the #1687 merge even though the run fired 26 minutes after it). The diff therefore becomes "this PR **plus** everything merged to base since the snapshot", and any global-path merge to `main` poisons every open PR into full CI.

Failure direction is safe (over-testing only, never under-testing), but it defeats the delta routing on an active repo.

## What changed

- Both planner jobs derive the diff base from the merge candidate's **first parent** — which *is* the base tip GitHub just merged against, and is always present thanks to `fetch-depth: 2`:
  ```bash
  BASE_SHA="$(git -C candidate rev-parse "${MERGE_SHA}^1")"
  ```
- Dropped the stale-base `fetch --depth=1` fallback (no longer reachable).
- The planner test now asserts the first-parent derivation in both workflows and **forbids any reference to `github.event.pull_request.base.sha`**, so the stale field can't come back.

No changes to the pinned trusted-controller scripts — the runtime planner (`plan-ci.mjs`, `ci-delta.mjs`, `ci-results.mjs`) is untouched, so no pin rotation is needed. This PR touches workflows, so the planner will (correctly) route it to full CI.

## Validation

- `node --test scripts/lib/__tests__/ci-delta.test.mjs scripts/lib/__tests__/vitest-shards.test.mjs`: 28/28 pass, including the new assertions.
- `actionlint` on both workflows: clean.
- Evidence trail: #1690 event `base.sha` = `0ff9272` (pre-#1687) while the candidate merged against post-#1687 `main`; the plan-job log shows #1687's files in the changed set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)