### PR TITLE
fix(sync): invalidate stale private CG readiness proof

### DIFF
--- a/packages/cli/src/context-graph-readiness.ts
+++ b/packages/cli/src/context-graph-readiness.ts
@@ -63,28 +63,32 @@ export function classifyExistingContextGraphReadiness(input: {
 
   if (alreadyReady) return { alreadyReady: true };
 
-  if (
-    !input.hasConfirmedMeta &&
-    (input.subscription.metaSynced ||
-      input.subscription.synced ||
-      input.subscription.sharedMemorySynced)
-  ) {
+  if (!input.hasConfirmedMeta) {
+    const stateAlreadyFailClosed =
+      input.subscription.synced === false &&
+      input.subscription.sharedMemorySynced === false &&
+      input.subscription.metaSynced === false &&
+      input.subscription.pendingMeta === true;
     return {
       alreadyReady: false,
-      statePatch: {
-        synced: false,
-        sharedMemorySynced: false,
-        metaSynced: false,
-        pendingMeta: true,
-      },
+      statePatch: stateAlreadyFailClosed
+        ? undefined
+        : {
+            synced: false,
+            sharedMemorySynced: false,
+            metaSynced: false,
+            pendingMeta: true,
+          },
+      // Subscription flags and provenance are persisted independently. A
+      // prior bootstrap may already have reset the flags while leaving v1
+      // proof behind, so metadata absence must invalidate provenance even
+      // when the visible state is already fail-closed.
       readinessPatch: {
         durableVerified: false,
         sharedMemoryVerified: false,
       },
     };
   }
-
-  if (!input.hasConfirmedMeta) return { alreadyReady: false };
 
   const durableVerified =
     currentReadinessProvenance && input.readiness.durableVerified;

--- a/packages/cli/src/context-graph-readiness.ts
+++ b/packages/cli/src/context-graph-readiness.ts
@@ -1,5 +1,5 @@
 import type { DKGAgent } from '@origintrail-official/dkg-agent';
-import { SYSTEM_CONTEXT_GRAPHS } from '@origintrail-official/dkg-core';
+import { DKGEvent, SYSTEM_CONTEXT_GRAPHS } from '@origintrail-official/dkg-core';
 import type {
   ContextGraphReadinessProvenance,
   DashboardDB,
@@ -37,6 +37,27 @@ export interface ContextGraphReadinessPatch {
   sharedMemoryVerified: boolean;
 }
 
+export interface MissingMetadataReadinessPatches {
+  statePatch: ContextGraphSubscriptionStatePatch;
+  readinessPatch: ContextGraphReadinessPatch;
+}
+
+/** Canonical fail-closed state for a graph without authoritative metadata. */
+export function missingMetadataReadinessPatches(): MissingMetadataReadinessPatches {
+  return {
+    statePatch: {
+      synced: false,
+      sharedMemorySynced: false,
+      metaSynced: false,
+      pendingMeta: true,
+    },
+    readinessPatch: {
+      durableVerified: false,
+      sharedMemoryVerified: false,
+    },
+  };
+}
+
 export function classifyExistingContextGraphReadiness(input: {
   subscription: ContextGraphSubscriptionReadinessState;
   readiness: ContextGraphReadinessProvenance;
@@ -64,6 +85,7 @@ export function classifyExistingContextGraphReadiness(input: {
   if (alreadyReady) return { alreadyReady: true };
 
   if (!input.hasConfirmedMeta) {
+    const missingMetadata = missingMetadataReadinessPatches();
     const stateAlreadyFailClosed =
       input.subscription.synced === false &&
       input.subscription.sharedMemorySynced === false &&
@@ -73,20 +95,12 @@ export function classifyExistingContextGraphReadiness(input: {
       alreadyReady: false,
       statePatch: stateAlreadyFailClosed
         ? undefined
-        : {
-            synced: false,
-            sharedMemorySynced: false,
-            metaSynced: false,
-            pendingMeta: true,
-          },
+        : missingMetadata.statePatch,
       // Subscription flags and provenance are persisted independently. A
       // prior bootstrap may already have reset the flags while leaving v1
       // proof behind, so metadata absence must invalidate provenance even
       // when the visible state is already fail-closed.
-      readinessPatch: {
-        durableVerified: false,
-        sharedMemoryVerified: false,
-      },
+      readinessPatch: missingMetadata.readinessPatch,
     };
   }
 
@@ -224,19 +238,11 @@ export function classifyContextGraphCatchupReadiness(input: {
 
   if (catchupResultHasCleanResponse(result)) {
     if (!input.hasConfirmedMeta) {
+      const missingMetadata = missingMetadataReadinessPatches();
       return {
         jobStatus: 'unreachable',
         error: 'No peer delivered authoritative context-graph metadata — the curator may be offline, or responding peers do not host this project.',
-        statePatch: {
-          synced: false,
-          sharedMemorySynced: false,
-          metaSynced: false,
-          pendingMeta: true,
-        },
-        readinessPatch: {
-          durableVerified: false,
-          sharedMemoryVerified: false,
-        },
+        ...missingMetadata,
       };
     }
 
@@ -363,6 +369,65 @@ export function writeContextGraphReadiness(
   });
 }
 
+// Bootstrap invalidation and automatic PROJECT_SYNCED persistence can race
+// during daemon startup. Serialize both against the same agent/CG key so the
+// later operation always revalidates live metadata before it writes.
+const contextGraphReadinessMutationTails = new WeakMap<
+  DKGAgent,
+  Map<string, Promise<void>>
+>();
+
+async function withContextGraphReadinessMutationLock<T>(
+  agent: DKGAgent,
+  contextGraphId: string,
+  task: () => Promise<T>,
+): Promise<T> {
+  let tails = contextGraphReadinessMutationTails.get(agent);
+  if (!tails) {
+    tails = new Map<string, Promise<void>>();
+    contextGraphReadinessMutationTails.set(agent, tails);
+  }
+  const previous = tails.get(contextGraphId) ?? Promise.resolve();
+  const run = previous.catch(() => {}).then(task);
+  const tail = run.then(() => undefined, () => undefined);
+  tails.set(contextGraphId, tail);
+  try {
+    return await run;
+  } finally {
+    if (tails.get(contextGraphId) === tail) tails.delete(contextGraphId);
+  }
+}
+
+/**
+ * Revalidate live metadata and invalidate subscription/provenance together.
+ * Returns false when authoritative metadata arrived before this reset acquired
+ * the readiness lock, in which case newer PROJECT_SYNCED proof is preserved.
+ */
+export async function resetContextGraphReadinessForMissingMetadata(input: {
+  agent: DKGAgent;
+  store: Partial<ContextGraphReadinessStore>;
+  contextGraphId: string;
+}): Promise<boolean> {
+  const contextGraphId = input.contextGraphId.trim();
+  if (!contextGraphId) return false;
+
+  return withContextGraphReadinessMutationLock(input.agent, contextGraphId, async () => {
+    const locallyCurated = typeof input.agent.isCuratorOf === 'function'
+      ? await input.agent.isCuratorOf(contextGraphId).catch(() => false)
+      : false;
+    const hasConfirmedMeta = await input.agent.hasConfirmedMetaState(
+      contextGraphId,
+      { rejectUnregisteredPlaceholder: !locallyCurated },
+    ).catch(() => false);
+    if (hasConfirmedMeta) return false;
+
+    const patches = missingMetadataReadinessPatches();
+    input.agent.markContextGraphSubscriptionState(contextGraphId, patches.statePatch);
+    writeContextGraphReadiness(input.store, contextGraphId, patches.readinessPatch);
+    return true;
+  });
+}
+
 /**
  * Persist readiness proven by the agent's automatic post-approval catch-up.
  * PROJECT_SYNCED is also used as a UI event, so fail closed unless it carries
@@ -385,22 +450,70 @@ export async function persistProjectSyncedReadiness(input: {
     typeof input.store.setContextGraphReadinessProvenance !== 'function'
   ) return false;
 
-  const hasConfirmedMeta = await input.agent.hasConfirmedMetaState(
-    contextGraphId,
-    { rejectUnregisteredPlaceholder: true },
-  )
-    .catch(() => false);
-  if (!hasConfirmedMeta) return false;
+  return withContextGraphReadinessMutationLock(input.agent, contextGraphId, async () => {
+    const hasConfirmedMeta = await input.agent.hasConfirmedMetaState(
+      contextGraphId,
+      { rejectUnregisteredPlaceholder: true },
+    ).catch(() => false);
+    if (!hasConfirmedMeta) return false;
 
-  const current = readContextGraphReadiness(input.store, contextGraphId);
-  const currentVersionVerified = current.version >= CONTEXT_GRAPH_READINESS_VERSION;
-  writeContextGraphReadiness(input.store, contextGraphId, {
-    durableVerified: durableCompleted ||
-      (currentVersionVerified && current.durableVerified),
-    sharedMemoryVerified: sharedMemoryCompleted ||
-      (currentVersionVerified && current.sharedMemoryVerified),
+    const current = readContextGraphReadiness(input.store, contextGraphId);
+    const currentVersionVerified = current.version >= CONTEXT_GRAPH_READINESS_VERSION;
+    writeContextGraphReadiness(input.store, contextGraphId, {
+      durableVerified: durableCompleted ||
+        (currentVersionVerified && current.durableVerified),
+      sharedMemoryVerified: sharedMemoryCompleted ||
+        (currentVersionVerified && current.sharedMemoryVerified),
+    });
+    return true;
   });
-  return true;
+}
+
+export interface ProjectSyncedReadinessPayload {
+  contextGraphId: string;
+  dataSynced: number;
+  sharedMemorySynced: number;
+}
+
+export function parseProjectSyncedReadinessPayload(
+  data: unknown,
+): ProjectSyncedReadinessPayload | null {
+  if (!data || typeof data !== 'object') return null;
+  const candidate = data as Partial<ProjectSyncedReadinessPayload>;
+  if (
+    typeof candidate.contextGraphId !== 'string' ||
+    typeof candidate.dataSynced !== 'number' ||
+    !Number.isFinite(candidate.dataSynced) ||
+    typeof candidate.sharedMemorySynced !== 'number' ||
+    !Number.isFinite(candidate.sharedMemorySynced)
+  ) {
+    return null;
+  }
+  return {
+    contextGraphId: candidate.contextGraphId,
+    dataSynced: candidate.dataSynced,
+    sharedMemorySynced: candidate.sharedMemorySynced,
+  };
+}
+
+export function registerProjectSyncedReadinessPersistence(input: {
+  agent: DKGAgent;
+  store: Partial<ContextGraphReadinessStore>;
+  log: (message: string) => void;
+}): void {
+  input.agent.eventBus.on(DKGEvent.PROJECT_SYNCED, (data: unknown) => {
+    const payload = parseProjectSyncedReadinessPayload(data);
+    if (!payload) return;
+    void persistProjectSyncedReadiness({
+      agent: input.agent,
+      store: input.store,
+      ...payload,
+    }).catch((err) => {
+      input.log(
+        `[warn] Failed to persist PROJECT_SYNCED readiness: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    });
+  });
 }
 
 /**

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -151,7 +151,8 @@ import { createInitialPublisherState, createPublicSnapshotStore, createPublisher
 import { createCatchupRunner, type CatchupJobResult, type CatchupRunner } from '../catchup-runner.js';
 import {
   migrateLegacyContextGraphReadiness,
-  persistProjectSyncedReadiness,
+  registerProjectSyncedReadinessPersistence,
+  resetContextGraphReadinessForMissingMetadata,
   writeContextGraphReadiness,
   type ContextGraphReadinessStore,
 } from '../context-graph-readiness.js';
@@ -1092,20 +1093,15 @@ export async function bootstrapConfiguredContextGraphs(input: {
       // marker and stale metaSynced=true. The explicit remote proof above
       // rejects that marker without depending on mutable subscription state;
       // only now do we persist the fail-closed bootstrap classification.
-      input.agent.markContextGraphSubscriptionState(contextGraphId, {
-        synced: false,
-        sharedMemorySynced: false,
-        metaSynced: false,
-        pendingMeta: true,
+      const reset = await resetContextGraphReadinessForMissingMetadata({
+        agent: input.agent,
+        store: input.readinessStore ?? {},
+        contextGraphId,
       });
-      // Provenance lives outside the subscription row and may still contain
-      // v1 true bits from an earlier successful catch-up. Clear it in the
-      // same bootstrap window so an automatic sync event or HTTP catch-up
-      // cannot reuse stale proof before route-level revalidation runs.
-      writeContextGraphReadiness(input.readinessStore ?? {}, contextGraphId, {
-        durableVerified: false,
-        sharedMemoryVerified: false,
-      });
+      // PROJECT_SYNCED persistence shares the same readiness lock and may
+      // have proved this graph while bootstrap was working from `existing`.
+      // Its live metadata revalidation wins over the stale snapshot.
+      if (!reset) hasAuthoritativeMetadata = true;
     }
 
     if (hasAuthoritativeMetadata) {
@@ -1114,24 +1110,6 @@ export async function bootstrapConfiguredContextGraphs(input: {
     }
     input.log(`Subscribed to configured context graph: ${contextGraphId} (metadata pending)`);
   }
-}
-
-export function registerProjectSyncedReadinessPersistence(input: {
-  agent: DKGAgent;
-  store: Partial<ContextGraphReadinessStore>;
-  log: (message: string) => void;
-}): void {
-  input.agent.eventBus.on(DKGEvent.PROJECT_SYNCED, (data: any) => {
-    void persistProjectSyncedReadiness({
-      agent: input.agent,
-      store: input.store,
-      contextGraphId: typeof data?.contextGraphId === "string" ? data.contextGraphId : "",
-      dataSynced: typeof data?.dataSynced === "number" ? data.dataSynced : 0,
-      sharedMemorySynced: typeof data?.sharedMemorySynced === "number" ? data.sharedMemorySynced : 0,
-    }).catch((err) => {
-      input.log(`[warn] Failed to persist PROJECT_SYNCED readiness: ${err instanceof Error ? err.message : String(err)}`);
-    });
-  });
 }
 
 export async function runDaemonInner(

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1098,6 +1098,14 @@ export async function bootstrapConfiguredContextGraphs(input: {
         metaSynced: false,
         pendingMeta: true,
       });
+      // Provenance lives outside the subscription row and may still contain
+      // v1 true bits from an earlier successful catch-up. Clear it in the
+      // same bootstrap window so an automatic sync event or HTTP catch-up
+      // cannot reuse stale proof before route-level revalidation runs.
+      writeContextGraphReadiness(input.readinessStore ?? {}, contextGraphId, {
+        durableVerified: false,
+        sharedMemoryVerified: false,
+      });
     }
 
     if (hasAuthoritativeMetadata) {
@@ -1106,6 +1114,24 @@ export async function bootstrapConfiguredContextGraphs(input: {
     }
     input.log(`Subscribed to configured context graph: ${contextGraphId} (metadata pending)`);
   }
+}
+
+export function registerProjectSyncedReadinessPersistence(input: {
+  agent: DKGAgent;
+  store: Partial<ContextGraphReadinessStore>;
+  log: (message: string) => void;
+}): void {
+  input.agent.eventBus.on(DKGEvent.PROJECT_SYNCED, (data: any) => {
+    void persistProjectSyncedReadiness({
+      agent: input.agent,
+      store: input.store,
+      contextGraphId: typeof data?.contextGraphId === "string" ? data.contextGraphId : "",
+      dataSynced: typeof data?.dataSynced === "number" ? data.dataSynced : 0,
+      sharedMemorySynced: typeof data?.sharedMemorySynced === "number" ? data.sharedMemorySynced : 0,
+    }).catch((err) => {
+      input.log(`[warn] Failed to persist PROJECT_SYNCED readiness: ${err instanceof Error ? err.message : String(err)}`);
+    });
+  });
 }
 
 export async function runDaemonInner(
@@ -1980,16 +2006,10 @@ export async function runDaemonInner(
   // Register before network startup. A queued join approval can arrive as
   // soon as the messenger is live, before the later UI/SSE listeners are
   // installed, and its automatic catch-up proof must survive restart.
-  agent.eventBus.on(DKGEvent.PROJECT_SYNCED, (data: any) => {
-    void persistProjectSyncedReadiness({
-      agent,
-      store: dashDb,
-      contextGraphId: typeof data?.contextGraphId === "string" ? data.contextGraphId : "",
-      dataSynced: typeof data?.dataSynced === "number" ? data.dataSynced : 0,
-      sharedMemorySynced: typeof data?.sharedMemorySynced === "number" ? data.sharedMemorySynced : 0,
-    }).catch((err) => {
-      log(`[warn] Failed to persist PROJECT_SYNCED readiness: ${err instanceof Error ? err.message : String(err)}`);
-    });
+  registerProjectSyncedReadinessPersistence({
+    agent,
+    store: dashDb,
+    log,
   });
 
   await agent.start();

--- a/packages/cli/test/context-graph-subscribe-readiness.test.ts
+++ b/packages/cli/test/context-graph-subscribe-readiness.test.ts
@@ -146,7 +146,6 @@ describe('context graph subscribe readiness requires authoritative metadata', ()
       latestByContextGraph: new Map<string, string>(),
     };
     let runCalls = 0;
-    let confirmedMetaChecks = 0;
     let readiness = opts.readiness
       ? { ...opts.readiness, updatedAt: opts.readiness.updatedAt ?? Date.now() }
       : undefined;
@@ -173,8 +172,7 @@ describe('context graph subscribe readiness requires authoritative metadata', ()
         state.set(id, { ...state.get(id), ...patch });
       },
       hasConfirmedMetaState: async () => {
-        confirmedMetaChecks += 1;
-        return confirmedMetaChecks > 1
+        return runCalls > 0
           ? opts.hasConfirmedMetaAfterCatchup ?? opts.hasConfirmedMeta
           : opts.hasConfirmedMeta;
       },
@@ -368,6 +366,46 @@ describe('context graph subscribe readiness requires authoritative metadata', ()
     expect(result.response.catchup.status).toBe('queued');
     expect(result.runCalls).toBe(1);
     expect(result.job.status).toBe('unreachable');
+    expect(result.state).toMatchObject({
+      synced: false,
+      sharedMemorySynced: false,
+      metaSynced: true,
+      pendingMeta: false,
+    });
+    expect(result.readiness).toMatchObject({
+      version: 1,
+      durableVerified: false,
+      sharedMemoryVerified: false,
+    });
+  });
+
+  it('clears stale v1 proof when subscription flags are already fail-closed', async () => {
+    const result = await subscribe({
+      hasConfirmedMeta: false,
+      hasConfirmedMetaAfterCatchup: true,
+      isPrivate: true,
+      includeSharedMemory: false,
+      result: privateMetaOnlyResult(),
+      readiness: {
+        version: 1,
+        durableVerified: true,
+        sharedMemoryVerified: true,
+      },
+      initial: {
+        subscribed: true,
+        synced: false,
+        sharedMemorySynced: false,
+        metaSynced: false,
+        pendingMeta: true,
+      },
+    });
+
+    expect(result.response.catchup.status).toBe('queued');
+    expect(result.runCalls).toBe(1);
+    expect(result.job).toMatchObject({
+      status: 'unreachable',
+      error: expect.stringContaining('metadata-only responses cannot prove'),
+    });
     expect(result.state).toMatchObject({
       synced: false,
       sharedMemorySynced: false,

--- a/packages/cli/test/daemon-context-graph-bootstrap.test.ts
+++ b/packages/cli/test/daemon-context-graph-bootstrap.test.ts
@@ -3,8 +3,10 @@ import type { DKGAgent } from '@origintrail-official/dkg-agent';
 import { DKGEvent, SYSTEM_CONTEXT_GRAPHS } from '@origintrail-official/dkg-core';
 import {
   bootstrapConfiguredContextGraphs,
-  registerProjectSyncedReadinessPersistence,
 } from '../src/daemon/lifecycle.js';
+import {
+  registerProjectSyncedReadinessPersistence,
+} from '../src/context-graph-readiness.js';
 
 type Subscription = {
   subscribed?: boolean;
@@ -271,6 +273,79 @@ describe('configured context graph daemon bootstrap', () => {
     );
   });
 
+  it('preserves PROJECT_SYNCED proof that lands during stale bootstrap classification', async () => {
+    const contextGraphId = '0x1234567890123456789012345678901234567890/startup-sync-race';
+    const fixture = createAgent({
+      [contextGraphId]: {
+        subscribed: true,
+        synced: false,
+        sharedMemorySynced: false,
+        metaSynced: false,
+        pendingMeta: true,
+      },
+    });
+    let readiness: {
+      version: number;
+      durableVerified: boolean;
+      sharedMemoryVerified: boolean;
+      updatedAt: number;
+    } | null = null;
+    let projectSyncedHandler: ((data: unknown) => void) | undefined;
+    (fixture.agent as any).eventBus = {
+      on: vi.fn((event: string, handler: (data: unknown) => void) => {
+        if (event === DKGEvent.PROJECT_SYNCED) projectSyncedHandler = handler;
+      }),
+    };
+    vi.mocked(fixture.agent.hasConfirmedMetaState).mockResolvedValue(true);
+    const readinessStore = {
+      getContextGraphReadinessProvenance: () => readiness,
+      setContextGraphReadinessProvenance: vi.fn((id, next) => {
+        expect(id).toBe(contextGraphId);
+        readiness = { ...next, updatedAt: Date.now() };
+      }),
+    };
+    registerProjectSyncedReadinessPersistence({
+      agent: fixture.agent,
+      store: readinessStore,
+      log: vi.fn(),
+    });
+    fixture.subscribeToContextGraph.mockImplementation((id: string) => {
+      const current = fixture.subscriptions.get(id);
+      fixture.subscriptions.set(id, {
+        ...current,
+        subscribed: true,
+        synced: true,
+        metaSynced: true,
+        pendingMeta: false,
+      });
+      projectSyncedHandler?.({
+        contextGraphId: id,
+        dataSynced: 2,
+        sharedMemorySynced: 0,
+      });
+    });
+
+    await bootstrapConfiguredContextGraphs({
+      agent: fixture.agent,
+      configuredContextGraphIds: [contextGraphId],
+      networkDefaultContextGraphIds: [],
+      readinessStore,
+      log: vi.fn(),
+    });
+
+    await vi.waitFor(() => {
+      expect(readiness).toMatchObject({
+        version: 1,
+        durableVerified: true,
+        sharedMemoryVerified: false,
+      });
+    });
+    expect(fixture.markContextGraphSubscriptionState).not.toHaveBeenCalledWith(
+      contextGraphId,
+      expect.objectContaining({ metaSynced: false }),
+    );
+  });
+
   it('fails closed before checking a legacy unregistered configured shadow', async () => {
     const contextGraphId = '0x1234567890123456789012345678901234567890/legacy-shadow';
     const fixture = createAgent({
@@ -296,7 +371,9 @@ describe('configured context graph daemon bootstrap', () => {
       log: vi.fn(),
     });
 
-    expect(fixture.agent.hasConfirmedMetaState).toHaveBeenCalledTimes(1);
+    // The stale-snapshot classification and the locked pre-reset
+    // revalidation must both reject the legacy placeholder.
+    expect(fixture.agent.hasConfirmedMetaState).toHaveBeenCalledTimes(2);
     expect(fixture.agent.hasConfirmedMetaState).toHaveBeenCalledWith(
       contextGraphId,
       { rejectUnregisteredPlaceholder: true },

--- a/packages/cli/test/daemon-context-graph-bootstrap.test.ts
+++ b/packages/cli/test/daemon-context-graph-bootstrap.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { DKGAgent } from '@origintrail-official/dkg-agent';
-import { SYSTEM_CONTEXT_GRAPHS } from '@origintrail-official/dkg-core';
-import { bootstrapConfiguredContextGraphs } from '../src/daemon/lifecycle.js';
+import { DKGEvent, SYSTEM_CONTEXT_GRAPHS } from '@origintrail-official/dkg-core';
+import {
+  bootstrapConfiguredContextGraphs,
+  registerProjectSyncedReadinessPersistence,
+} from '../src/daemon/lifecycle.js';
 
 type Subscription = {
   subscribed?: boolean;
@@ -229,6 +232,45 @@ describe('configured context graph daemon bootstrap', () => {
     });
   });
 
+  it('clears persisted readiness proof while configured metadata is pending', async () => {
+    const contextGraphId = '0x1234567890123456789012345678901234567890/stale-proof';
+    const fixture = createAgent({
+      [contextGraphId]: {
+        subscribed: true,
+        synced: false,
+        sharedMemorySynced: false,
+        metaSynced: false,
+        pendingMeta: true,
+      },
+    });
+    const setContextGraphReadinessProvenance = vi.fn();
+
+    await bootstrapConfiguredContextGraphs({
+      agent: fixture.agent,
+      configuredContextGraphIds: [contextGraphId],
+      networkDefaultContextGraphIds: [],
+      readinessStore: {
+        getContextGraphReadinessProvenance: () => ({
+          version: 1,
+          durableVerified: true,
+          sharedMemoryVerified: true,
+          updatedAt: Date.now(),
+        }),
+        setContextGraphReadinessProvenance,
+      },
+      log: vi.fn(),
+    });
+
+    expect(setContextGraphReadinessProvenance).toHaveBeenCalledWith(
+      contextGraphId,
+      expect.objectContaining({
+        version: 1,
+        durableVerified: false,
+        sharedMemoryVerified: false,
+      }),
+    );
+  });
+
   it('fails closed before checking a legacy unregistered configured shadow', async () => {
     const contextGraphId = '0x1234567890123456789012345678901234567890/legacy-shadow';
     const fixture = createAgent({
@@ -318,5 +360,50 @@ describe('configured context graph daemon bootstrap', () => {
     );
     expect(fixture.subscriptions.has(SYSTEM_CONTEXT_GRAPHS.AGENTS)).toBe(false);
     expect(fixture.subscriptions.has(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY)).toBe(false);
+  });
+
+  it('wires PROJECT_SYNCED persistence to the daemon event bus', async () => {
+    const contextGraphId = 'project-synced-wiring';
+    let handler: ((data: unknown) => void) | undefined;
+    const setContextGraphReadinessProvenance = vi.fn();
+    const agent = {
+      eventBus: {
+        on: vi.fn((event: string, next: (data: unknown) => void) => {
+          if (event === DKGEvent.PROJECT_SYNCED) handler = next;
+        }),
+      },
+      hasConfirmedMetaState: vi.fn(async () => true),
+    } as unknown as DKGAgent;
+
+    registerProjectSyncedReadinessPersistence({
+      agent,
+      store: {
+        getContextGraphReadinessProvenance: () => null,
+        setContextGraphReadinessProvenance,
+      },
+      log: vi.fn(),
+    });
+
+    expect(agent.eventBus.on).toHaveBeenCalledWith(
+      DKGEvent.PROJECT_SYNCED,
+      expect.any(Function),
+    );
+    expect(handler).toBeTypeOf('function');
+    handler?.({
+      contextGraphId,
+      dataSynced: 3,
+      sharedMemorySynced: 0,
+    });
+
+    await vi.waitFor(() => {
+      expect(setContextGraphReadinessProvenance).toHaveBeenCalledWith(
+        contextGraphId,
+        expect.objectContaining({
+          version: 1,
+          durableVerified: true,
+          sharedMemoryVerified: false,
+        }),
+      );
+    });
   });
 });


### PR DESCRIPTION
## Summary

- invalidate per-plane readiness provenance whenever authoritative metadata is absent, even when subscription flags are already fail-closed
- serialize bootstrap invalidation with PROJECT_SYNCED persistence and revalidate live metadata under the shared lock
- centralize the missing-metadata fail-closed patches in the readiness module
- move PROJECT_SYNCED parsing and listener registration beside readiness persistence with a typed payload boundary

Follow-up to #1692.

## Why

A v1 provenance row with durable/shared proof could survive a restart after bootstrap reset only the subscription flags. A later private metadata-only catch-up could then reuse those old bits and stop retrying without current payload proof. During startup, a fresh automatic sync proof must also win over bootstrap classification based on an older subscription snapshot.

## Testing

- pnpm --filter @origintrail-official/dkg... run build
- pnpm --filter @origintrail-official/dkg exec vitest run test/context-graph-subscribe-readiness.test.ts test/daemon-context-graph-bootstrap.test.ts test/context-graph-readiness-migration.test.ts (35 passed)