### PR TITLE
fix(storage): preserve foreground capacity during finalization load

### DIFF
--- a/packages/agent/src/finalization-handler.ts
+++ b/packages/agent/src/finalization-handler.ts
@@ -615,9 +615,15 @@ export class FinalizationHandler {
       this.finalizationSwmBucketUri(contextGraphId, subGraphName),
       { rootEntities: safeRoots },
       kaGraphBound,
-      { bounded: SWM_SLICE_SOURCE_BOUNDED, widened: SWM_SLICE_SOURCE_WIDENED, unbounded: SWM_SLICE_SOURCE },
-      createAccept,
-      { priority: 'background' },
+      {
+        sources: {
+          bounded: SWM_SLICE_SOURCE_BOUNDED,
+          widened: SWM_SLICE_SOURCE_WIDENED,
+          unbounded: SWM_SLICE_SOURCE,
+        },
+        createAccept,
+        queryOptions: { priority: 'background' },
+      },
     );
     return { quads, matched: accepted };
   }

--- a/packages/agent/src/finalization-handler.ts
+++ b/packages/agent/src/finalization-handler.ts
@@ -617,6 +617,7 @@ export class FinalizationHandler {
       kaGraphBound,
       { bounded: SWM_SLICE_SOURCE_BOUNDED, widened: SWM_SLICE_SOURCE_WIDENED, unbounded: SWM_SLICE_SOURCE },
       createAccept,
+      { priority: 'background' },
     );
     return { quads, matched: accepted };
   }
@@ -633,7 +634,7 @@ export class FinalizationHandler {
       this.store,
       this.finalizationSwmBucketUri(contextGraphId, subGraphName),
       { rootEntities: safeRoots },
-      { querySource: SWM_SLICE_SOURCE },
+      { queryOptions: { priority: 'background' }, querySource: SWM_SLICE_SOURCE },
     );
   }
 

--- a/packages/agent/test/swm-slice-ka-bound.test.ts
+++ b/packages/agent/test/swm-slice-ka-bound.test.ts
@@ -293,8 +293,14 @@ describe('bounded SWM read is merkle-equivalent to the unbounded read (T5b)', ()
     // fallback-owning primitive, never the raw unsafe loader.
     const { quads: bounded } = await loadSharedMemorySliceWithKaBoundFallback(
       store, bucket, { rootEntities: [root] }, bound,
-      { bounded: 'test.bounded', widened: 'test.widened', unbounded: 'test.unbounded' },
-      async () => (qs) => qs,
+      {
+        sources: {
+          bounded: 'test.bounded',
+          widened: 'test.widened',
+          unbounded: 'test.unbounded',
+        },
+        createAccept: async () => (qs) => qs,
+      },
     );
     const unbounded = await loadSelectedSharedMemoryQuads(store, bucket, { rootEntities: [root] });
 

--- a/packages/agent/test/swm-slice-ka-bound.test.ts
+++ b/packages/agent/test/swm-slice-ka-bound.test.ts
@@ -3,6 +3,7 @@ import {
   OxigraphStore,
   loadSelectedSharedMemoryQuads,
   loadSharedMemorySliceWithKaBoundFallback,
+  type QueryOptions,
   type SwmKaGraphBound,
   type Quad,
 } from '@origintrail-official/dkg-storage';
@@ -86,6 +87,16 @@ function captureQuerySources(store: OxigraphStore): string[] {
     return (orig as (s: string, o?: unknown) => unknown)(sparql, opts);
   }) as typeof store.query;
   return sources;
+}
+
+function captureQueryOptions(store: OxigraphStore): QueryOptions[] {
+  const options: QueryOptions[] = [];
+  const orig = store.query.bind(store);
+  store.query = (async (sparql: string, opts?: QueryOptions) => {
+    if (opts) options.push(opts);
+    return orig(sparql, opts);
+  }) as typeof store.query;
+  return options;
 }
 
 /** A minimal chain whose KCCreated event verifies the given finalization. */
@@ -193,26 +204,54 @@ describe('deriveSwmKaGraphBound (T4)', () => {
   });
 
   it('wires a derived bound through to the SWM read (and no bound leaves it plain)', async () => {
-    const sliceSourcesFor = async (msg: FinalizationMessageMsg): Promise<string[]> => {
+    const sliceQueriesFor = async (msg: FinalizationMessageMsg): Promise<QueryOptions[]> => {
       const store = new OxigraphStore();
-      const sources = captureQuerySources(store);
+      const options = captureQueryOptions(store);
       const handler = new FinalizationHandler(store, undefined);
       await handler.handleFinalizationMessage(encodeFinalizationMessage(msg), CG);
-      return sources.filter((s) => s.startsWith(SLICE));
+      return options.filter((entry) => entry.source?.startsWith(SLICE));
     };
 
-    const bounded = await sliceSourcesFor(makeMsg({ startKAId: packA(7), endKAId: packA(7) }));
-    expect(bounded).toContain(SLICE_BOUNDED);
+    const bounded = await sliceQueriesFor(makeMsg({ startKAId: packA(7), endKAId: packA(7) }));
+    expect(bounded.map((entry) => entry.source)).toContain(SLICE_BOUNDED);
+    expect(bounded.every((entry) => entry.priority === 'background')).toBe(true);
 
-    const unbounded = await sliceSourcesFor(makeMsg({ startKAId: 0, endKAId: 0 }));
-    expect(unbounded).not.toContain(SLICE_BOUNDED);
-    expect(unbounded).toContain(SLICE);
+    const unbounded = await sliceQueriesFor(makeMsg({ startKAId: 0, endKAId: 0 }));
+    expect(unbounded.map((entry) => entry.source)).not.toContain(SLICE_BOUNDED);
+    expect(unbounded.map((entry) => entry.source)).toContain(SLICE);
+    expect(unbounded.every((entry) => entry.priority === 'background')).toBe(true);
 
     // Kill-switch is applied at the boundary: a derivable bound is not used.
     process.env.DKG_DISABLE_SWM_KA_BOUND = '1';
-    const killed = await sliceSourcesFor(makeMsg({ startKAId: packA(7), endKAId: packA(7) }));
-    expect(killed).not.toContain(SLICE_BOUNDED);
-    expect(killed).toContain(SLICE);
+    const killed = await sliceQueriesFor(makeMsg({ startKAId: packA(7), endKAId: packA(7) }));
+    expect(killed.map((entry) => entry.source)).not.toContain(SLICE_BOUNDED);
+    expect(killed.map((entry) => entry.source)).toContain(SLICE);
+    expect(killed.every((entry) => entry.priority === 'background')).toBe(true);
+  });
+
+  it('runs the chain-reconcile unbounded backstop in the background lane', async () => {
+    const store = new OxigraphStore();
+    const root = 'urn:test:chain-reconcile-priority';
+    await store.insert([{
+      subject: root,
+      predicate: 'http://schema.org/name',
+      object: '"priority"',
+      graph: swmGraph(AUTHOR_A, 7),
+    }]);
+    const options = captureQueryOptions(store);
+    const handler = new FinalizationHandler(store, undefined);
+    const seam = handler as unknown as {
+      getSharedMemoryQuadsForRoots: (
+        contextGraphId: string,
+        rootEntities: string[],
+        subGraphName?: string,
+      ) => Promise<Quad[]>;
+    };
+
+    await expect(seam.getSharedMemoryQuadsForRoots(CG, [root])).resolves.toHaveLength(1);
+    const sliceQueries = options.filter((entry) => entry.source === SLICE);
+    expect(sliceQueries.length).toBeGreaterThan(0);
+    expect(sliceQueries.every((entry) => entry.priority === 'background')).toBe(true);
   });
 });
 

--- a/packages/publisher/test/storage-ack-priority-lane.test.ts
+++ b/packages/publisher/test/storage-ack-priority-lane.test.ts
@@ -201,7 +201,7 @@ function createHandler(
 
 describe('StorageACKHandler priority store lane', () => {
   it('completes ACK verification while slow listGraphs/count jobs are queued', async () => {
-    const scheduler = new StorePriorityScheduler(2, 1);
+    const scheduler = new StorePriorityScheduler({ maxConcurrent: 2, ackReservedSlots: 1 });
     const events: string[] = [];
     const store = new PriorityLaneStore(scheduler, events);
 
@@ -239,7 +239,7 @@ describe('StorageACKHandler priority store lane', () => {
   });
 
   it('still declines when the prioritized ACK store operation itself exceeds the deadline', async () => {
-    const scheduler = new StorePriorityScheduler(2, 1);
+    const scheduler = new StorePriorityScheduler({ maxConcurrent: 2, ackReservedSlots: 1 });
     const events: string[] = [];
     const store = new PriorityLaneStore(scheduler, events, { hangAck: true });
     const onDecline = vi.fn();
@@ -257,7 +257,7 @@ describe('StorageACKHandler priority store lane', () => {
   });
 
   it('passes ACK priority options through inline staging writes and flushes', async () => {
-    const scheduler = new StorePriorityScheduler(2, 1);
+    const scheduler = new StorePriorityScheduler({ maxConcurrent: 2, ackReservedSlots: 1 });
     const events: string[] = [];
     const store = new PriorityLaneStore(scheduler, events);
     const handler = createHandler(store, { ackHandlerDeadlineMs: 1_000 });

--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -89,6 +89,11 @@ already have reached the store.
 | `DKG_STORE_QUEUE_WAIT_TIMEOUT_MS` | `10000` | Maximum pre-dispatch wait before a retryable busy rejection. |
 | `DKG_BLAZEGRAPH_OPERATION_TIMEOUT_MS` | `30000` | Blazegraph end-to-end operation deadline, including scheduler wait, HTTP, response decoding, and mapping. |
 
+Normal and background reserves are normalized against the available non-ACK
+capacity. At least one background slot remains available, and the background
+progress floor is capped to its admission ceiling so conflicting custom values
+cannot leave usable capacity idle.
+
 Blazegraph's deadline can also be set per store, which takes precedence over
 the environment default:
 

--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -80,6 +80,7 @@ already have reached the store.
 |---|---:|---|
 | `DKG_STORE_MAX_CONCURRENT` | `8` | Maximum external-store operations in flight. |
 | `DKG_STORE_ACK_RESERVED_SLOTS` | `1` | In-flight capacity reserved for ACK work. |
+| `DKG_STORE_NORMAL_RESERVED_SLOTS` | `1` | Non-ACK capacity kept available for normal work while background operations are in flight. |
 | `DKG_STORE_BACKGROUND_RESERVED_SLOTS` | `1` | Non-ACK capacity reserved for background progress. |
 | `DKG_STORE_QUEUE_LIMIT` | `64` | Maximum waiting operations in each priority queue. |
 | `DKG_STORE_ACK_QUEUE_LIMIT` | common limit | Optional ACK queue override. |

--- a/packages/storage/src/graph-manager.ts
+++ b/packages/storage/src/graph-manager.ts
@@ -424,7 +424,7 @@ export interface SwmSliceSourceTags {
 export interface LoadSharedMemorySliceWithKaBoundFallbackOptions {
   sources: SwmSliceSourceTags;
   createAccept: () => Promise<(quads: Quad[]) => Quad[] | null>;
-  queryOptions?: QueryOptions;
+  queryOptions?: Omit<QueryOptions, 'source'>;
 }
 
 /**

--- a/packages/storage/src/graph-manager.ts
+++ b/packages/storage/src/graph-manager.ts
@@ -421,6 +421,12 @@ export interface SwmSliceSourceTags {
   unbounded: QueryOptions['source'];
 }
 
+export interface LoadSharedMemorySliceWithKaBoundFallbackOptions {
+  sources: SwmSliceSourceTags;
+  createAccept: () => Promise<(quads: Quad[]) => Quad[] | null>;
+  queryOptions?: QueryOptions;
+}
+
 /**
  * The ONLY safe way to read a KA-bounded SWM slice: read bounded first, then WIDEN
  * to the complete read on an empty-or-mismatched result before returning (#1549).
@@ -439,15 +445,37 @@ export interface SwmSliceSourceTags {
  * input — never accept→defer, sometimes defer→accept under recurrence.
  * `queryOptions` is applied to graph discovery and every bounded or widened read.
  */
-export async function loadSharedMemorySliceWithKaBoundFallback(
+export function loadSharedMemorySliceWithKaBoundFallback(
+  store: TripleStore,
+  bucketGraph: string,
+  selection: SharedMemoryReadSelection,
+  kaGraphBound: SwmKaGraphBound | undefined,
+  options: LoadSharedMemorySliceWithKaBoundFallbackOptions,
+): Promise<{ quads: Quad[]; accepted: Quad[] | null }>;
+/** @deprecated Use the named options object. Retained for package compatibility. */
+export function loadSharedMemorySliceWithKaBoundFallback(
   store: TripleStore,
   bucketGraph: string,
   selection: SharedMemoryReadSelection,
   kaGraphBound: SwmKaGraphBound | undefined,
   sources: SwmSliceSourceTags,
   createAccept: () => Promise<(quads: Quad[]) => Quad[] | null>,
-  queryOptions: QueryOptions = {},
+): Promise<{ quads: Quad[]; accepted: Quad[] | null }>;
+export async function loadSharedMemorySliceWithKaBoundFallback(
+  store: TripleStore,
+  bucketGraph: string,
+  selection: SharedMemoryReadSelection,
+  kaGraphBound: SwmKaGraphBound | undefined,
+  optionsOrSources: LoadSharedMemorySliceWithKaBoundFallbackOptions | SwmSliceSourceTags,
+  legacyCreateAccept?: () => Promise<(quads: Quad[]) => Quad[] | null>,
 ): Promise<{ quads: Quad[]; accepted: Quad[] | null }> {
+  if (!('sources' in optionsOrSources) && !legacyCreateAccept) {
+    throw new TypeError('loadSharedMemorySliceWithKaBoundFallback requires createAccept');
+  }
+  const options: LoadSharedMemorySliceWithKaBoundFallbackOptions = 'sources' in optionsOrSources
+    ? optionsOrSources
+    : { sources: optionsOrSources, createAccept: legacyCreateAccept! };
+  const { sources, createAccept, queryOptions = {} } = options;
   const readComplete = (source: QueryOptions['source']): Promise<Quad[]> =>
     loadSelectedSharedMemoryQuads(store, bucketGraph, selection, { queryOptions, querySource: source });
 

--- a/packages/storage/src/graph-manager.ts
+++ b/packages/storage/src/graph-manager.ts
@@ -437,6 +437,7 @@ export interface SwmSliceSourceTags {
  * With no bound this is a single complete read (safe by construction). With a
  * bound the result is exactly what the unbounded read would have produced on any
  * input — never accept→defer, sometimes defer→accept under recurrence.
+ * `queryOptions` is applied to graph discovery and every bounded or widened read.
  */
 export async function loadSharedMemorySliceWithKaBoundFallback(
   store: TripleStore,
@@ -445,12 +446,14 @@ export async function loadSharedMemorySliceWithKaBoundFallback(
   kaGraphBound: SwmKaGraphBound | undefined,
   sources: SwmSliceSourceTags,
   createAccept: () => Promise<(quads: Quad[]) => Quad[] | null>,
+  queryOptions: QueryOptions = {},
 ): Promise<{ quads: Quad[]; accepted: Quad[] | null }> {
   const readComplete = (source: QueryOptions['source']): Promise<Quad[]> =>
-    loadSelectedSharedMemoryQuads(store, bucketGraph, selection, { querySource: source });
+    loadSelectedSharedMemoryQuads(store, bucketGraph, selection, { queryOptions, querySource: source });
 
   let quads = kaGraphBound
     ? await loadKaBoundedSharedMemoryQuads(store, bucketGraph, selection, kaGraphBound, {
+        queryOptions,
         querySource: sources.bounded,
       })
     : await readComplete(sources.unbounded);

--- a/packages/storage/src/graph-set-index-store.ts
+++ b/packages/storage/src/graph-set-index-store.ts
@@ -1,6 +1,14 @@
 import { performance } from 'node:perf_hooks';
 import { isSparqlUpdateOperation } from '@origintrail-official/dkg-core';
-import type { Quad, QueryOptions, QueryResult, StorePressureSnapshot, TripleStore, UpdateOptions } from './triple-store.js';
+import type {
+  Quad,
+  QueryOptions,
+  QueryResult,
+  StorePressureSnapshot,
+  StoreWorkPriority,
+  TripleStore,
+  UpdateOptions,
+} from './triple-store.js';
 import { UnsupportedTripleStoreCapabilityError } from './unsupported-capability-error.js';
 
 export const DEFAULT_GRAPH_SET_REVALIDATE_MS = 30_000;
@@ -21,6 +29,15 @@ export type GraphSetMutationSource =
 type TouchedGraphMutationSource = 'delete' | 'deleteByPattern' | 'deleteBySubjectPrefix' | 'update';
 type GraphSetRefreshSource = 'seed' | 'revalidate' | TouchedGraphMutationSource | 'query';
 type PendingFullRefreshSource = Exclude<GraphSetRefreshSource, 'seed' | 'revalidate'>;
+
+interface GraphSetRefreshFlight {
+  priority: StoreWorkPriority;
+  task: Promise<Set<string>>;
+}
+
+interface GraphSetRefreshScanState {
+  lastSequence: number;
+}
 
 export type GraphSetMutationEvent =
   | {
@@ -85,7 +102,9 @@ export class GraphSetIndexStore implements TripleStore {
   private nextRevalidateAt = 0;
   private revalidateFailureCount = 0;
   private mutationGeneration = 0;
-  private refreshInFlight: Promise<Set<string>> | null = null;
+  private readonly refreshesInFlight = new Map<StoreWorkPriority, GraphSetRefreshFlight>();
+  private refreshScanSequence = 0;
+  private latestPublishedRefreshScan = 0;
   /**
    * Pending full rebuild requested by a mutation whose exact graph effects can't
    * be applied incrementally. The stored source preserves the observer contract
@@ -296,32 +315,69 @@ export class GraphSetIndexStore implements TripleStore {
   }
 
   private async refreshIndex(source: GraphSetRefreshSource, options?: QueryOptions): Promise<Set<string>> {
-    if (this.refreshInFlight) return this.refreshInFlight;
-    let task = this.refreshIndexLoop(source, options);
+    // A lower-priority cold seed/revalidation must not capture a later normal or
+    // ACK reader. The higher-priority caller starts its own scan so the external
+    // scheduler can use the capacity reserved for that lane; equal/lower callers
+    // still coalesce onto the best in-flight scan. Dirty rebuilds remain forced
+    // to background, regardless of the waiting reader's requested priority.
+    const priority = refreshPriority(source, options);
+    const coalesced = this.coalescableRefresh(priority);
+    if (coalesced) return coalesced.task;
+
+    const scanState: GraphSetRefreshScanState = { lastSequence: 0 };
+    let task = this.refreshIndexLoop(source, options, scanState);
     if (source === 'revalidate') {
       task = task.catch((error: unknown) => {
+        // Cancellation, cold seeds, and mutation-dirty rebuilds are strict
+        // correctness paths even if another refresh published in parallel.
+        if (options?.signal?.aborted || !this.graphs || this.pendingFullRefresh) {
+          throw error;
+        }
+        // A newer promoted refresh already published a usable graph set. Do
+        // not let this older failed scan overwrite its healthy schedule with
+        // failure backoff.
+        if (
+          scanState.lastSequence < this.latestPublishedRefreshScan &&
+          this.graphs
+        ) {
+          return this.graphs;
+        }
         // Periodic discovery of out-of-contract writers is advisory once the
         // write-through index is warm. Preserve that last known set and back
         // off after a store failure instead of making every graph reader repeat
         // the same expensive scan. Cold seeds and mutation-dirty rebuilds are
         // correctness paths: if either condition applies by the time the scan
         // fails, keep the original strict rejection behavior.
-        if (options?.signal?.aborted || !this.graphs || this.pendingFullRefresh) {
-          throw error;
-        }
         this.noteRevalidationFailure();
         return this.graphs;
       });
     }
-    this.refreshInFlight = task;
+    const flight: GraphSetRefreshFlight = { priority, task };
+    this.refreshesInFlight.set(priority, flight);
     try {
       return await task;
     } finally {
-      if (this.refreshInFlight === task) this.refreshInFlight = null;
+      if (this.refreshesInFlight.get(priority) === flight) {
+        this.refreshesInFlight.delete(priority);
+      }
     }
   }
 
-  private async refreshIndexLoop(source: GraphSetRefreshSource, options?: QueryOptions): Promise<Set<string>> {
+  private coalescableRefresh(priority: StoreWorkPriority): GraphSetRefreshFlight | undefined {
+    const maxRank = refreshPriorityRank(priority);
+    for (const candidate of REFRESH_PRIORITIES) {
+      if (refreshPriorityRank(candidate) > maxRank) break;
+      const flight = this.refreshesInFlight.get(candidate);
+      if (flight) return flight;
+    }
+    return undefined;
+  }
+
+  private async refreshIndexLoop(
+    source: GraphSetRefreshSource,
+    options: QueryOptions | undefined,
+    scanState: GraphSetRefreshScanState,
+  ): Promise<Set<string>> {
     for (;;) {
       const isDirtyRebuild = this.pendingFullRefresh != null;
       const sourceForScan = this.pendingFullRefresh ?? source;
@@ -338,13 +394,22 @@ export class GraphSetIndexStore implements TripleStore {
       const scanOptions: QueryOptions | undefined = isDirtyRebuild
         ? { ...options, priority: 'background', source: 'graph-set-index.rebuild' }
         : options;
+      const scanSequence = ++this.refreshScanSequence;
+      scanState.lastSequence = scanSequence;
       const next = new Set((await this.inner.listGraphs(scanOptions)).filter(Boolean));
       if (generation !== this.mutationGeneration) continue;
+      // Priority promotion intentionally permits overlapping scans. Fence the
+      // shared cache by scan start order so an older, slower background response
+      // cannot overwrite a later ACK/normal snapshot that already published.
+      if (scanSequence < this.latestPublishedRefreshScan) {
+        return this.graphs ?? next;
+      }
       // This scan reflects every mutation up to `generation` (synchronous from
       // here — no await — so a concurrent write can't slip between the check and
       // the clear; if one had, it would have bumped the generation above and we
       // would have retried, preserving the pending refresh source for the next
       // scan attempt).
+      this.latestPublishedRefreshScan = scanSequence;
       this.pendingFullRefresh = null;
       this.replaceGraphSet(next, sourceForScan);
       return this.graphs!;
@@ -493,6 +558,21 @@ function queryOptionsFromUpdateOptions(options: UpdateOptions): QueryOptions {
 
 function positiveFiniteMs(value: number | undefined, fallback: number): number {
   return Number.isFinite(value) && (value as number) > 0 ? value as number : fallback;
+}
+
+function refreshPriority(
+  source: GraphSetRefreshSource,
+  options: QueryOptions | undefined,
+): StoreWorkPriority {
+  return source === 'seed' || source === 'revalidate'
+    ? options?.priority ?? 'normal'
+    : 'background';
+}
+
+const REFRESH_PRIORITIES: readonly StoreWorkPriority[] = ['ack', 'normal', 'background'];
+
+function refreshPriorityRank(priority: StoreWorkPriority): number {
+  return REFRESH_PRIORITIES.indexOf(priority);
 }
 
 function throwIfAborted(signal: AbortSignal | undefined): void {

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -32,6 +32,7 @@ export {
   DEFAULT_STORE_QUEUE_LIMIT,
   DEFAULT_STORE_QUEUE_WAIT_TIMEOUT_MS,
   type StorePrioritySchedulerSnapshot,
+  type StorePrioritySchedulerOptions,
   type StorePriorityQueueLimits,
   type StoreSchedulerBusyReason,
 } from './store-priority-scheduler.js';
@@ -105,6 +106,7 @@ export {
   type SharedMemoryGraphScope,
   type SwmKaGraphBound,
   type SwmSliceSourceTags,
+  type LoadSharedMemorySliceWithKaBoundFallbackOptions,
 } from './graph-manager.js';
 export { PrivateContentStore } from './private-store.js';
 

--- a/packages/storage/src/store-priority-scheduler.ts
+++ b/packages/storage/src/store-priority-scheduler.ts
@@ -41,6 +41,16 @@ export class StoreSchedulerBusyError extends Error {
 
 export type StorePriorityQueueLimits = Record<StoreWorkPriority, number>;
 
+export interface StorePrioritySchedulerOptions {
+  maxConcurrent?: number;
+  ackReservedSlots?: number;
+  normalReservedSlots?: number;
+  backgroundReservedSlots?: number;
+  queueLimits?: number | Partial<StorePriorityQueueLimits>;
+  queueWaitTimeoutMs?: number;
+  now?: () => number;
+}
+
 interface QueueEntry<T> {
   priority: StoreWorkPriority;
   operation: string;
@@ -51,6 +61,13 @@ interface QueueEntry<T> {
   signal?: AbortSignal;
   onAbort?: () => void;
   waitTimer?: ReturnType<typeof setTimeout>;
+}
+
+interface NonAckLaneCapacity {
+  limit: number;
+  normalReservedSlots: number;
+  backgroundReservedSlots: number;
+  backgroundLimit: number;
 }
 
 const DEFAULT_MAX_CONCURRENT = 8;
@@ -127,33 +144,67 @@ export class StorePriorityScheduler {
   private ackInflight = 0;
   private normalInflight = 0;
   private backgroundInflight = 0;
+  private readonly maxConcurrent: number;
+  private readonly ackReservedSlots: number;
+  private readonly normalReservedSlots: number;
+  private readonly backgroundReservedSlots: number;
+  private readonly queueWaitTimeoutMs: number;
+  private readonly now: () => number;
   private readonly queueLimits: StorePriorityQueueLimits;
 
+  constructor(options?: StorePrioritySchedulerOptions);
+  /** @deprecated Use the named options object. Retained for package compatibility. */
   constructor(
-    private readonly maxConcurrent = parsePositiveIntegerEnv('DKG_STORE_MAX_CONCURRENT', DEFAULT_MAX_CONCURRENT),
-    private readonly ackReservedSlots = parsePositiveIntegerEnv(
-      'DKG_STORE_ACK_RESERVED_SLOTS',
-      DEFAULT_ACK_RESERVED_SLOTS,
-    ),
-    private readonly now = () => performance.now(),
-    private readonly backgroundReservedSlots = parseNonNegativeIntegerEnv(
-      'DKG_STORE_BACKGROUND_RESERVED_SLOTS',
-      DEFAULT_BACKGROUND_RESERVED_SLOTS,
-    ),
-    queueLimits: number | Partial<StorePriorityQueueLimits> = resolveQueueLimitsFromEnv(),
-    private readonly queueWaitTimeoutMs = parsePositiveIntegerEnv(
-      'DKG_STORE_QUEUE_WAIT_TIMEOUT_MS',
-      DEFAULT_STORE_QUEUE_WAIT_TIMEOUT_MS,
-    ),
-    private readonly normalReservedSlots = parseNonNegativeIntegerEnv(
-      'DKG_STORE_NORMAL_RESERVED_SLOTS',
-      DEFAULT_NORMAL_RESERVED_SLOTS,
-    ),
+    maxConcurrent?: number,
+    ackReservedSlots?: number,
+    now?: () => number,
+    backgroundReservedSlots?: number,
+    queueLimits?: number | Partial<StorePriorityQueueLimits>,
+    queueWaitTimeoutMs?: number,
+  );
+  constructor(
+    optionsOrMaxConcurrent: StorePrioritySchedulerOptions | number = {},
+    legacyAckReservedSlots?: number,
+    legacyNow?: () => number,
+    legacyBackgroundReservedSlots?: number,
+    legacyQueueLimits?: number | Partial<StorePriorityQueueLimits>,
+    legacyQueueWaitTimeoutMs?: number,
   ) {
-    this.queueLimits = normalizeQueueLimits(queueLimits);
+    const legacyCall = typeof optionsOrMaxConcurrent === 'number' || arguments.length > 1;
+    const options: StorePrioritySchedulerOptions = legacyCall
+      ? {
+          maxConcurrent: typeof optionsOrMaxConcurrent === 'number'
+            ? optionsOrMaxConcurrent
+            : undefined,
+          ackReservedSlots: legacyAckReservedSlots,
+          now: legacyNow,
+          backgroundReservedSlots: legacyBackgroundReservedSlots,
+          queueLimits: legacyQueueLimits,
+          queueWaitTimeoutMs: legacyQueueWaitTimeoutMs,
+        }
+      : optionsOrMaxConcurrent;
+    this.maxConcurrent = options.maxConcurrent
+      ?? parsePositiveIntegerEnv('DKG_STORE_MAX_CONCURRENT', DEFAULT_MAX_CONCURRENT);
+    this.ackReservedSlots = options.ackReservedSlots
+      ?? parsePositiveIntegerEnv('DKG_STORE_ACK_RESERVED_SLOTS', DEFAULT_ACK_RESERVED_SLOTS);
+    this.normalReservedSlots = options.normalReservedSlots
+      ?? parseNonNegativeIntegerEnv('DKG_STORE_NORMAL_RESERVED_SLOTS', DEFAULT_NORMAL_RESERVED_SLOTS);
+    this.backgroundReservedSlots = options.backgroundReservedSlots
+      ?? parseNonNegativeIntegerEnv(
+        'DKG_STORE_BACKGROUND_RESERVED_SLOTS',
+        DEFAULT_BACKGROUND_RESERVED_SLOTS,
+      );
+    this.queueWaitTimeoutMs = options.queueWaitTimeoutMs
+      ?? parsePositiveIntegerEnv(
+        'DKG_STORE_QUEUE_WAIT_TIMEOUT_MS',
+        DEFAULT_STORE_QUEUE_WAIT_TIMEOUT_MS,
+      );
+    this.now = options.now ?? (() => performance.now());
+    this.queueLimits = normalizeQueueLimits(options.queueLimits ?? resolveQueueLimitsFromEnv());
   }
 
   get snapshot(): StorePrioritySchedulerSnapshot {
+    const laneCapacity = this.nonAckLaneCapacity();
     return {
       ackInflight: this.ackInflight,
       normalInflight: this.normalInflight,
@@ -163,8 +214,8 @@ export class StorePriorityScheduler {
       backgroundQueued: this.queues.background.length,
       maxConcurrent: this.maxConcurrent,
       ackReservedSlots: this.effectiveAckReserve(),
-      normalReservedSlots: this.effectiveNormalReserve(),
-      backgroundReservedSlots: this.effectiveBackgroundReserve(),
+      normalReservedSlots: laneCapacity.normalReservedSlots,
+      backgroundReservedSlots: laneCapacity.backgroundReservedSlots,
       ackQueueLimit: this.queueLimits.ack,
       normalQueueLimit: this.queueLimits.normal,
       backgroundQueueLimit: this.queueLimits.background,
@@ -255,19 +306,25 @@ export class StorePriorityScheduler {
     if (totalInflight >= this.maxConcurrent) return false;
     if (priority === 'ack') return true;
 
-    const nonAckLimit = this.nonAckLimit();
+    const laneCapacity = this.nonAckLaneCapacity();
     const nonAckInflight = this.normalInflight + this.backgroundInflight;
-    if (nonAckInflight >= nonAckLimit) return false;
-    if (priority === 'background' && this.backgroundInflight >= this.backgroundLimit()) return false;
-    if (priority === 'normal' && this.shouldHoldBackgroundFloor()) return false;
+    if (nonAckInflight >= laneCapacity.limit) return false;
+    if (priority === 'background' && this.backgroundInflight >= laneCapacity.backgroundLimit) {
+      return false;
+    }
+    if (
+      priority === 'normal' &&
+      this.shouldHoldBackgroundFloor(laneCapacity.backgroundReservedSlots)
+    ) {
+      return false;
+    }
     return true;
   }
 
-  private shouldHoldBackgroundFloor(): boolean {
-    const backgroundReserve = this.effectiveBackgroundReserve();
-    return backgroundReserve > 0 &&
+  private shouldHoldBackgroundFloor(backgroundReservedSlots: number): boolean {
+    return backgroundReservedSlots > 0 &&
       this.queues.background.length > 0 &&
-      this.backgroundInflight < backgroundReserve;
+      this.backgroundInflight < backgroundReservedSlots;
   }
 
   private effectiveAckReserve(): number {
@@ -278,16 +335,19 @@ export class StorePriorityScheduler {
     return Math.max(1, this.maxConcurrent - this.effectiveAckReserve());
   }
 
-  private effectiveBackgroundReserve(): number {
-    return Math.min(this.backgroundReservedSlots, Math.max(0, this.nonAckLimit() - 1));
-  }
-
-  private effectiveNormalReserve(): number {
-    return Math.min(this.normalReservedSlots, Math.max(0, this.nonAckLimit() - 1));
-  }
-
-  private backgroundLimit(): number {
-    return Math.max(1, this.nonAckLimit() - this.effectiveNormalReserve());
+  private nonAckLaneCapacity(): NonAckLaneCapacity {
+    const limit = this.nonAckLimit();
+    const normalReservedSlots = Math.min(
+      Math.max(0, this.normalReservedSlots),
+      Math.max(0, limit - 1),
+    );
+    const backgroundLimit = Math.max(1, limit - normalReservedSlots);
+    const backgroundReservedSlots = Math.min(
+      Math.max(0, this.backgroundReservedSlots),
+      backgroundLimit,
+      Math.max(0, limit - 1),
+    );
+    return { limit, normalReservedSlots, backgroundReservedSlots, backgroundLimit };
   }
 
   private start(entry: QueueEntry<unknown>): void {

--- a/packages/storage/src/store-priority-scheduler.ts
+++ b/packages/storage/src/store-priority-scheduler.ts
@@ -11,6 +11,7 @@ export interface StorePrioritySchedulerSnapshot extends StorePressureSnapshot {
   backgroundQueued: number;
   maxConcurrent: number;
   ackReservedSlots: number;
+  normalReservedSlots: number;
   backgroundReservedSlots: number;
   ackQueueLimit: number;
   normalQueueLimit: number;
@@ -54,6 +55,7 @@ interface QueueEntry<T> {
 
 const DEFAULT_MAX_CONCURRENT = 8;
 const DEFAULT_ACK_RESERVED_SLOTS = 1;
+const DEFAULT_NORMAL_RESERVED_SLOTS = 1;
 const DEFAULT_BACKGROUND_RESERVED_SLOTS = 1;
 export const DEFAULT_STORE_QUEUE_LIMIT = 64;
 export const DEFAULT_STORE_QUEUE_WAIT_TIMEOUT_MS = 10_000;
@@ -143,6 +145,10 @@ export class StorePriorityScheduler {
       'DKG_STORE_QUEUE_WAIT_TIMEOUT_MS',
       DEFAULT_STORE_QUEUE_WAIT_TIMEOUT_MS,
     ),
+    private readonly normalReservedSlots = parseNonNegativeIntegerEnv(
+      'DKG_STORE_NORMAL_RESERVED_SLOTS',
+      DEFAULT_NORMAL_RESERVED_SLOTS,
+    ),
   ) {
     this.queueLimits = normalizeQueueLimits(queueLimits);
   }
@@ -157,6 +163,7 @@ export class StorePriorityScheduler {
       backgroundQueued: this.queues.background.length,
       maxConcurrent: this.maxConcurrent,
       ackReservedSlots: this.effectiveAckReserve(),
+      normalReservedSlots: this.effectiveNormalReserve(),
       backgroundReservedSlots: this.effectiveBackgroundReserve(),
       ackQueueLimit: this.queueLimits.ack,
       normalQueueLimit: this.queueLimits.normal,
@@ -251,6 +258,7 @@ export class StorePriorityScheduler {
     const nonAckLimit = this.nonAckLimit();
     const nonAckInflight = this.normalInflight + this.backgroundInflight;
     if (nonAckInflight >= nonAckLimit) return false;
+    if (priority === 'background' && this.backgroundInflight >= this.backgroundLimit()) return false;
     if (priority === 'normal' && this.shouldHoldBackgroundFloor()) return false;
     return true;
   }
@@ -272,6 +280,14 @@ export class StorePriorityScheduler {
 
   private effectiveBackgroundReserve(): number {
     return Math.min(this.backgroundReservedSlots, Math.max(0, this.nonAckLimit() - 1));
+  }
+
+  private effectiveNormalReserve(): number {
+    return Math.min(this.normalReservedSlots, Math.max(0, this.nonAckLimit() - 1));
+  }
+
+  private backgroundLimit(): number {
+    return Math.max(1, this.nonAckLimit() - this.effectiveNormalReserve());
   }
 
   private start(entry: QueueEntry<unknown>): void {

--- a/packages/storage/src/triple-store.ts
+++ b/packages/storage/src/triple-store.ts
@@ -54,6 +54,7 @@ export interface StorePressureSnapshot {
   backgroundQueued: number;
   maxConcurrent: number;
   ackReservedSlots: number;
+  normalReservedSlots?: number;
   backgroundReservedSlots?: number;
 }
 

--- a/packages/storage/test/blazegraph.unit.test.ts
+++ b/packages/storage/test/blazegraph.unit.test.ts
@@ -437,7 +437,9 @@ describe('BlazegraphStore (mocked HTTP)', () => {
     const before = getExternalStorePrioritySchedulerSnapshot();
     expect(before.maxConcurrent).toBeGreaterThan(1);
     expect(before.ackReservedSlots).toBeGreaterThan(0);
-    const backgroundSlots = before.maxConcurrent - before.ackReservedSlots;
+    const backgroundSlots = before.maxConcurrent
+      - before.ackReservedSlots
+      - before.normalReservedSlots;
     const arrivals: Array<'listGraphs' | 'ack' | 'other'> = [];
     const releaseHeldListGraphs: Array<() => void> = [];
     const backgroundWork: Array<Promise<unknown>> = [];

--- a/packages/storage/test/graph-manager-swm-bound.test.ts
+++ b/packages/storage/test/graph-manager-swm-bound.test.ts
@@ -500,8 +500,10 @@ describe('loadSharedMemorySliceWithKaBoundFallback — the safe bounded read', (
       const { quads, accepted } = await loadSharedMemorySliceWithKaBoundFallback(
         store, swm, { rootEntities: [r] },
         { agentAddress: AUTHOR_A, startNumber: 7n, endNumber: 7n },
-        SOURCES,
-        async () => (qs) => { accepts += 1; return qs; },
+        {
+          sources: SOURCES,
+          createAccept: async () => (qs) => { accepts += 1; return qs; },
+        },
       );
 
       // Bounded read excluded the out-of-range graph, and the accept predicate
@@ -530,8 +532,10 @@ describe('loadSharedMemorySliceWithKaBoundFallback — the safe bounded read', (
       const { quads, accepted } = await loadSharedMemorySliceWithKaBoundFallback(
         store, swm, { rootEntities: [r] },
         { agentAddress: AUTHOR_A, startNumber: 7n, endNumber: 7n },
-        SOURCES,
-        async () => (qs) => (qs.some((q) => q.object === outObj) ? qs : null),
+        {
+          sources: SOURCES,
+          createAccept: async () => (qs) => (qs.some((q) => q.object === outObj) ? qs : null),
+        },
       );
 
       expect(accepted).not.toBeNull();
@@ -555,8 +559,10 @@ describe('loadSharedMemorySliceWithKaBoundFallback — the safe bounded read', (
       const { quads } = await loadSharedMemorySliceWithKaBoundFallback(
         store, swm, { rootEntities: [r] },
         undefined,
-        SOURCES,
-        async () => (qs) => { accepts += 1; return qs; },
+        {
+          sources: SOURCES,
+          createAccept: async () => (qs) => { accepts += 1; return qs; },
+        },
       );
 
       // Unbounded ⇒ both authors read; accept applied exactly once.

--- a/packages/storage/test/graph-set-index-store.test.ts
+++ b/packages/storage/test/graph-set-index-store.test.ts
@@ -5,10 +5,12 @@ import { describe, expect, it } from 'vitest';
 import {
   GraphSetIndexStore,
   OxigraphStore,
+  StorePriorityScheduler,
   createTripleStore,
   registerTripleStoreAdapter,
   type GraphSetMutationEvent,
   type QueryOptions,
+  type StoreWorkPriority,
 } from '../src/index.js';
 import { CountingStore, MutationHookStore, emptyBindings, q } from './graph-set-index-store-harness.js';
 
@@ -28,6 +30,36 @@ class GatedMaintenanceStore extends CountingStore {
     const present = await super.hasGraph(graphUri, options);
     if (this.hasGraphGate) await this.hasGraphGate;
     return present;
+  }
+}
+
+class ScheduledGraphListStore extends CountingStore {
+  readonly listGraphsGates: Partial<Record<StoreWorkPriority, Promise<void>>> = {};
+  readonly listGraphsResults: Partial<Record<StoreWorkPriority, string[]>> = {};
+
+  constructor(
+    inner: OxigraphStore,
+    private readonly scheduler: StorePriorityScheduler,
+  ) {
+    super(inner);
+  }
+
+  override listGraphs(options?: QueryOptions): Promise<string[]> {
+    return this.scheduler.run(
+      options?.priority,
+      options?.source ?? 'test.graph-set.listGraphs',
+      async () => {
+        this.listGraphsCalls++;
+        this.listGraphsOptions.push(options);
+        const priority = options?.priority ?? 'normal';
+        const gate = this.listGraphsGates[priority];
+        if (gate) await gate;
+        const result = this.listGraphsResults[priority];
+        if (result) return result;
+        return this.inner.listGraphs(options);
+      },
+      options?.signal,
+    );
   }
 }
 
@@ -345,6 +377,86 @@ describe('GraphSetIndexStore', () => {
     expect(a).toEqual(['did:dkg:context-graph:coalesced']);
     expect(b).toEqual(['did:dkg:context-graph:coalesced']);
     expect(c).toEqual(['did:dkg:context-graph:coalesced']);
+  });
+
+  it('lets an ack seed bypass an in-flight background seed through the reserved scheduler lane', async () => {
+    const scheduler = new StorePriorityScheduler({
+      maxConcurrent: 2,
+      ackReservedSlots: 1,
+      normalReservedSlots: 0,
+      backgroundReservedSlots: 0,
+    });
+    const inner = new OxigraphStore();
+    const staleGraph = 'did:dkg:context-graph:background-snapshot';
+    const freshGraph = 'did:dkg:context-graph:ack-snapshot';
+    const scheduled = new ScheduledGraphListStore(inner, scheduler);
+    scheduled.listGraphsResults.background = [staleGraph];
+    scheduled.listGraphsResults.ack = [freshGraph];
+    let releaseBackground!: () => void;
+    let releaseAck!: () => void;
+    scheduled.listGraphsGates.background = new Promise<void>((resolve) => {
+      releaseBackground = resolve;
+    });
+    scheduled.listGraphsGates.ack = new Promise<void>((resolve) => {
+      releaseAck = resolve;
+    });
+    const store = new GraphSetIndexStore(scheduled);
+    const background = store.listGraphs({
+      priority: 'background',
+      source: 'agent.finalization.sharedMemorySlice',
+    });
+    let ack: Promise<string[]> | undefined;
+
+    try {
+      await Promise.resolve();
+      expect(scheduled.listGraphsCalls).toBe(1);
+      expect(scheduler.snapshot).toMatchObject({
+        ackInflight: 0,
+        ackQueued: 0,
+        backgroundInflight: 1,
+      });
+
+      ack = store.listGraphs({
+        priority: 'ack',
+        source: 'publisher.storageACK.sharedMemorySlice',
+      });
+      await Promise.resolve();
+
+      expect(scheduled.listGraphsCalls).toBe(2);
+      expect(scheduled.listGraphsOptions).toEqual([
+        {
+          priority: 'background',
+          source: 'agent.finalization.sharedMemorySlice',
+        },
+        {
+          priority: 'ack',
+          source: 'publisher.storageACK.sharedMemorySlice',
+        },
+      ]);
+      expect(scheduler.snapshot).toMatchObject({
+        ackInflight: 1,
+        ackQueued: 0,
+        backgroundInflight: 1,
+      });
+
+      releaseAck();
+      await expect(ack).resolves.toEqual([freshGraph]);
+      expect(scheduler.snapshot).toMatchObject({
+        ackInflight: 0,
+        backgroundInflight: 1,
+      });
+
+      // The older background response completes last with a stale snapshot. It
+      // must neither overwrite the ACK result nor return stale data to its waiter.
+      releaseBackground();
+      await expect(background).resolves.toEqual([freshGraph]);
+      await expect(store.listGraphs()).resolves.toEqual([freshGraph]);
+      expect(scheduled.listGraphsCalls).toBe(2);
+    } finally {
+      releaseAck();
+      releaseBackground();
+      await Promise.allSettled([background, ...(ack ? [ack] : [])]);
+    }
   });
 
   it('restarts an in-flight refresh when a local write lands during the scan', async () => {

--- a/packages/storage/test/sparql-http.test.ts
+++ b/packages/storage/test/sparql-http.test.ts
@@ -193,7 +193,9 @@ describe('SparqlHttpStore (test server)', () => {
     const before = getExternalStorePrioritySchedulerSnapshot();
     expect(before.maxConcurrent).toBeGreaterThan(1);
     expect(before.ackReservedSlots).toBeGreaterThan(0);
-    const backgroundSlots = before.maxConcurrent - before.ackReservedSlots;
+    const backgroundSlots = before.maxConcurrent
+      - before.ackReservedSlots
+      - before.normalReservedSlots;
     const arrivals: Array<'listGraphs' | 'ack' | 'other'> = [];
     const heldListGraphResponses: ServerResponse[] = [];
     let listGraphRequests = 0;

--- a/packages/storage/test/store-priority-scheduler.test.ts
+++ b/packages/storage/test/store-priority-scheduler.test.ts
@@ -199,6 +199,47 @@ describe('StorePriorityScheduler', () => {
     ]);
   });
 
+  it('keeps normal capacity available while long background work is in flight', async () => {
+    const scheduler = new StorePriorityScheduler(3, 1, undefined, 1, 64, 1_000, 1);
+    const events: string[] = [];
+    let releaseBackground!: () => void;
+
+    const firstBackground = scheduler.run('background', 'finalization.slice.1', async () => {
+      events.push('background-1:start');
+      await new Promise<void>((resolve) => {
+        releaseBackground = resolve;
+      });
+      events.push('background-1:end');
+      return 'background-1';
+    });
+    await tick();
+
+    const secondBackground = scheduler.run('background', 'finalization.slice.2', async () => {
+      events.push('background-2:start');
+      return 'background-2';
+    });
+    await tick();
+
+    expect(scheduler.snapshot).toMatchObject({
+      backgroundInflight: 1,
+      backgroundQueued: 1,
+      normalReservedSlots: 1,
+    });
+
+    const normal = scheduler.run('normal', 'join-policy.validation', async () => {
+      events.push('normal:start');
+      return 'normal';
+    });
+    await expect(normal).resolves.toBe('normal');
+    expect(events).toEqual(['background-1:start', 'normal:start']);
+
+    releaseBackground();
+    await expect(Promise.all([firstBackground, secondBackground])).resolves.toEqual([
+      'background-1',
+      'background-2',
+    ]);
+  });
+
   it('releases an inflight slot when work throws synchronously', async () => {
     const scheduler = new StorePriorityScheduler(1, 0);
     const boom = () => {
@@ -319,6 +360,7 @@ describe('StorePriorityScheduler', () => {
       backgroundInflight: 1,
       backgroundQueued: 1,
       normalQueued: 1,
+      normalReservedSlots: 0,
       backgroundReservedSlots: 0,
     });
 

--- a/packages/storage/test/store-priority-scheduler.test.ts
+++ b/packages/storage/test/store-priority-scheduler.test.ts
@@ -10,11 +10,13 @@ const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
 describe('StorePriorityScheduler', () => {
   for (const priority of ['ack', 'normal', 'background'] as const satisfies readonly StoreWorkPriority[]) {
     it(`bounds the ${priority} queue and returns a typed retryable rejection`, async () => {
-      const scheduler = new StorePriorityScheduler(1, 0, undefined, 0, {
-        ack: 1,
-        normal: 1,
-        background: 1,
-      }, 1_000);
+      const scheduler = new StorePriorityScheduler({
+        maxConcurrent: 1,
+        ackReservedSlots: 0,
+        backgroundReservedSlots: 0,
+        queueLimits: { ack: 1, normal: 1, background: 1 },
+        queueWaitTimeoutMs: 1_000,
+      });
       let release!: () => void;
       let queuedStarted = false;
       let rejectedStarted = false;
@@ -45,7 +47,13 @@ describe('StorePriorityScheduler', () => {
     });
 
     it(`expires ${priority} work before dispatch and recovers after pressure clears`, async () => {
-      const scheduler = new StorePriorityScheduler(1, 0, undefined, 0, 2, 20);
+      const scheduler = new StorePriorityScheduler({
+        maxConcurrent: 1,
+        ackReservedSlots: 0,
+        backgroundReservedSlots: 0,
+        queueLimits: 2,
+        queueWaitTimeoutMs: 20,
+      });
       let release!: () => void;
       let expiredStarted = false;
       const blocker = scheduler.run(priority, `${priority}.blocker`, async () => {
@@ -75,7 +83,13 @@ describe('StorePriorityScheduler', () => {
   it('removes a cancelled queued entry and releases its abort listener and wait timer', async () => {
     vi.useFakeTimers();
     try {
-      const scheduler = new StorePriorityScheduler(1, 0, undefined, 0, 1, 100);
+      const scheduler = new StorePriorityScheduler({
+        maxConcurrent: 1,
+        ackReservedSlots: 0,
+        backgroundReservedSlots: 0,
+        queueLimits: 1,
+        queueWaitTimeoutMs: 100,
+      });
       let release!: () => void;
       const blocker = scheduler.run('normal', 'normal.blocker', async () => {
         await new Promise<void>((resolve) => {
@@ -112,7 +126,13 @@ describe('StorePriorityScheduler', () => {
   it('cleans up admission state when queued work starts normally', async () => {
     vi.useFakeTimers();
     try {
-      const scheduler = new StorePriorityScheduler(1, 0, undefined, 0, 1, 100);
+      const scheduler = new StorePriorityScheduler({
+        maxConcurrent: 1,
+        ackReservedSlots: 0,
+        backgroundReservedSlots: 0,
+        queueLimits: 1,
+        queueWaitTimeoutMs: 100,
+      });
       let release!: () => void;
       const blocker = scheduler.run('normal', 'normal.blocker', async () => {
         await new Promise<void>((resolve) => {
@@ -151,7 +171,7 @@ describe('StorePriorityScheduler', () => {
   });
 
   it('lets ACK work jump ahead of queued background work', async () => {
-    const scheduler = new StorePriorityScheduler(2, 1);
+    const scheduler = new StorePriorityScheduler({ maxConcurrent: 2, ackReservedSlots: 1 });
     const events: string[] = [];
     let releaseBackground!: () => void;
     const backgroundGate = new Promise<void>((resolve) => {
@@ -200,7 +220,14 @@ describe('StorePriorityScheduler', () => {
   });
 
   it('keeps normal capacity available while long background work is in flight', async () => {
-    const scheduler = new StorePriorityScheduler(3, 1, undefined, 1, 64, 1_000, 1);
+    const scheduler = new StorePriorityScheduler({
+      maxConcurrent: 3,
+      ackReservedSlots: 1,
+      normalReservedSlots: 1,
+      backgroundReservedSlots: 1,
+      queueLimits: 64,
+      queueWaitTimeoutMs: 1_000,
+    });
     const events: string[] = [];
     let releaseBackground!: () => void;
 
@@ -240,8 +267,88 @@ describe('StorePriorityScheduler', () => {
     ]);
   });
 
+  it('normalizes conflicting reserves so normal work can use idle capacity', async () => {
+    const scheduler = new StorePriorityScheduler({
+      maxConcurrent: 4,
+      ackReservedSlots: 1,
+      normalReservedSlots: 2,
+      backgroundReservedSlots: 2,
+    });
+    const events: string[] = [];
+    let releaseBackground!: () => void;
+
+    const firstBackground = scheduler.run('background', 'finalization.slice.1', async () => {
+      events.push('background-1:start');
+      await new Promise<void>((resolve) => {
+        releaseBackground = resolve;
+      });
+      return 'background-1';
+    });
+    const secondBackground = scheduler.run('background', 'finalization.slice.2', async () => {
+      events.push('background-2:start');
+      return 'background-2';
+    });
+    await tick();
+
+    expect(scheduler.snapshot).toMatchObject({
+      normalReservedSlots: 2,
+      backgroundReservedSlots: 1,
+      backgroundInflight: 1,
+      backgroundQueued: 1,
+    });
+
+    const normal = scheduler.run('normal', 'join-policy.validation', async () => {
+      events.push('normal:start');
+      return 'normal';
+    });
+    await expect(normal).resolves.toBe('normal');
+    expect(events).toEqual(['background-1:start', 'normal:start']);
+
+    releaseBackground();
+    await expect(Promise.all([firstBackground, secondBackground])).resolves.toEqual([
+      'background-1',
+      'background-2',
+    ]);
+  });
+
+  it('reads the normal reserve from DKG_STORE_NORMAL_RESERVED_SLOTS', async () => {
+    const previous = process.env.DKG_STORE_NORMAL_RESERVED_SLOTS;
+    let releaseBackground: (() => void) | undefined;
+    const backgroundWork: Array<Promise<unknown>> = [];
+    process.env.DKG_STORE_NORMAL_RESERVED_SLOTS = '2';
+    try {
+      const scheduler = new StorePriorityScheduler({
+        maxConcurrent: 4,
+        ackReservedSlots: 1,
+        backgroundReservedSlots: 1,
+      });
+      const firstBackground = scheduler.run('background', 'env.background.1', async () => {
+        await new Promise<void>((resolve) => {
+          releaseBackground = resolve;
+        });
+      });
+      const secondBackground = scheduler.run('background', 'env.background.2', async () => undefined);
+      backgroundWork.push(firstBackground, secondBackground);
+      await tick();
+
+      expect(scheduler.snapshot).toMatchObject({
+        normalReservedSlots: 2,
+        backgroundInflight: 1,
+        backgroundQueued: 1,
+      });
+
+      releaseBackground?.();
+      await Promise.all([firstBackground, secondBackground]);
+    } finally {
+      releaseBackground?.();
+      await Promise.allSettled(backgroundWork);
+      if (previous === undefined) delete process.env.DKG_STORE_NORMAL_RESERVED_SLOTS;
+      else process.env.DKG_STORE_NORMAL_RESERVED_SLOTS = previous;
+    }
+  });
+
   it('releases an inflight slot when work throws synchronously', async () => {
-    const scheduler = new StorePriorityScheduler(1, 0);
+    const scheduler = new StorePriorityScheduler({ maxConcurrent: 1, ackReservedSlots: 0 });
     const boom = () => {
       throw new Error('sync boom');
     };
@@ -260,7 +367,7 @@ describe('StorePriorityScheduler', () => {
   });
 
   it('reserves a non-ACK slot for queued background work behind normal traffic', async () => {
-    const scheduler = new StorePriorityScheduler(2, 0);
+    const scheduler = new StorePriorityScheduler({ maxConcurrent: 2, ackReservedSlots: 0 });
     const events: string[] = [];
     let releaseNormal1!: () => void;
     let releaseNormal2!: () => void;
@@ -321,7 +428,7 @@ describe('StorePriorityScheduler', () => {
   });
 
   it('does not reserve the only non-ACK slot for background work', async () => {
-    const scheduler = new StorePriorityScheduler(2, 1);
+    const scheduler = new StorePriorityScheduler({ maxConcurrent: 2, ackReservedSlots: 1 });
     const events: string[] = [];
     let releaseAck!: () => void;
     let releaseBackground!: () => void;


### PR DESCRIPTION
## Summary

- classify finalization shared-memory slice reads, including bounded fallbacks and chain-reconcile backstops, as background store work
- keep one normal-priority slot available while long background operations are in flight
- thread query options through the safe bounded-to-unbounded shared-memory loader
- document the configurable `DKG_STORE_NORMAL_RESERVED_SLOTS` setting and cover adapter saturation math

## Why

Under sustained finalization load, slow `agent.finalization.sharedMemorySlice` queries were admitted as normal work. They could fill the normal queue and make owner-scoped policy writes fail before authorization validation with `Store scheduler queue full (normal: sparql-http.query)`.

This separates finalization maintenance reads from foreground API validation while preserving the existing fail-closed private-CG checks. A bounded normal reserve also prevents already-running background reads from consuming every non-ACK slot.

## Safety

- StorageACK priority and its reserved capacity are unchanged
- private-CG authorization and context-graph validation are unchanged
- the normal reserve clips to zero when only one non-ACK slot exists, so background reconciliation still progresses
- the default is one slot and can be tuned with `DKG_STORE_NORMAL_RESERVED_SLOTS`
- this is complementary to #1650, which handles scheduling fairness once capacity becomes available

## Validation

- `pnpm --filter @origintrail-official/dkg-agent... build`
- `pnpm --filter @origintrail-official/dkg-storage test` — 383 passed, 26 expected integration skips
- `pnpm --filter @origintrail-official/dkg-agent exec vitest run --config vitest.unit.config.ts test/swm-slice-ka-bound.test.ts` — 15 passed
- `git diff --check`
