### PR TITLE
refactor(storage): clarify priority coordination

### DIFF
--- a/packages/agent/test/finalization-handler.test.ts
+++ b/packages/agent/test/finalization-handler.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { OxigraphStore, GraphManager, type Quad } from '@origintrail-official/dkg-storage';
+import {
+  OxigraphStore,
+  GraphManager,
+  type Quad,
+  type QueryOptions,
+} from '@origintrail-official/dkg-storage';
 import {
   encodeFinalizationMessage, type FinalizationMessageMsg, encodePublishRequest, createOperationContext,
   contextGraphWorkspaceGraphUri, contextGraphWorkspaceMetaGraphUri,
@@ -422,10 +427,31 @@ describe('FinalizationHandler.handleChainReconciledKC (Phase B)', () => {
   it('promotes a chain-registered KC when the CG binding + recomputed merkle match', async () => {
     const store = new OxigraphStore();
     const merkleRoot = await seedSwmSnapshot(store);
+    const queryOptions: QueryOptions[] = [];
+    const graphDiscoveryOptions: QueryOptions[] = [];
+    const origQuery = store.query.bind(store);
+    store.query = (async (sparql: string, options?: QueryOptions) => {
+      if (options?.source === 'agent.finalization.sharedMemorySlice') {
+        queryOptions.push(options);
+      }
+      return origQuery(sparql, options);
+    }) as typeof store.query;
+    const origListGraphs = store.listGraphs.bind(store);
+    store.listGraphs = async (options?: QueryOptions) => {
+      if (options?.source === 'agent.finalization.sharedMemorySlice') {
+        graphDiscoveryOptions.push(options);
+      }
+      return origListGraphs(options);
+    };
     const handler = new FinalizationHandler(store, makeBindingChain(42n));
 
     const outcome = await handler.handleChainReconciledKC(input(merkleRoot), createOperationContext('system'));
     expect(outcome).toBe('promoted');
+    expect(queryOptions.length).toBeGreaterThan(0);
+    expect(graphDiscoveryOptions.length).toBeGreaterThan(0);
+    expect([...queryOptions, ...graphDiscoveryOptions].every(
+      (options) => options.priority === 'background',
+    )).toBe(true);
 
     const perCgGraph = `did:dkg:context-graph:${CONTEXT_GRAPH}/context/${ON_CHAIN_CG}`;
     const promoted = await store.query(

--- a/packages/agent/test/swm-slice-ka-bound.test.ts
+++ b/packages/agent/test/swm-slice-ka-bound.test.ts
@@ -89,14 +89,24 @@ function captureQuerySources(store: OxigraphStore): string[] {
   return sources;
 }
 
-function captureQueryOptions(store: OxigraphStore): QueryOptions[] {
-  const options: QueryOptions[] = [];
-  const orig = store.query.bind(store);
+type CapturedReadOptions = {
+  queries: QueryOptions[];
+  graphDiscovery: QueryOptions[];
+};
+
+function captureReadOptions(store: OxigraphStore): CapturedReadOptions {
+  const captured: CapturedReadOptions = { queries: [], graphDiscovery: [] };
+  const origQuery = store.query.bind(store);
   store.query = (async (sparql: string, opts?: QueryOptions) => {
-    if (opts) options.push(opts);
-    return orig(sparql, opts);
+    if (opts) captured.queries.push(opts);
+    return origQuery(sparql, opts);
   }) as typeof store.query;
-  return options;
+  const origListGraphs = store.listGraphs.bind(store);
+  store.listGraphs = async (opts?: QueryOptions) => {
+    if (opts) captured.graphDiscovery.push(opts);
+    return origListGraphs(opts);
+  };
+  return captured;
 }
 
 /** A minimal chain whose KCCreated event verifies the given finalization. */
@@ -204,54 +214,42 @@ describe('deriveSwmKaGraphBound (T4)', () => {
   });
 
   it('wires a derived bound through to the SWM read (and no bound leaves it plain)', async () => {
-    const sliceQueriesFor = async (msg: FinalizationMessageMsg): Promise<QueryOptions[]> => {
+    const sliceReadsFor = async (msg: FinalizationMessageMsg): Promise<CapturedReadOptions> => {
       const store = new OxigraphStore();
-      const options = captureQueryOptions(store);
+      const captured = captureReadOptions(store);
       const handler = new FinalizationHandler(store, undefined);
       await handler.handleFinalizationMessage(encodeFinalizationMessage(msg), CG);
-      return options.filter((entry) => entry.source?.startsWith(SLICE));
+      return {
+        queries: captured.queries.filter((entry) => entry.source?.startsWith(SLICE)),
+        graphDiscovery: captured.graphDiscovery.filter((entry) => entry.source?.startsWith(SLICE)),
+      };
+    };
+    const expectBackgroundReads = (
+      captured: CapturedReadOptions,
+      expectedSources: string[],
+    ) => {
+      for (const options of [captured.graphDiscovery, captured.queries]) {
+        expect(options.map((entry) => entry.source)).toEqual(
+          expect.arrayContaining(expectedSources),
+        );
+        expect(options.every((entry) => entry.priority === 'background')).toBe(true);
+      }
     };
 
-    const bounded = await sliceQueriesFor(makeMsg({ startKAId: packA(7), endKAId: packA(7) }));
-    expect(bounded.map((entry) => entry.source)).toContain(SLICE_BOUNDED);
-    expect(bounded.every((entry) => entry.priority === 'background')).toBe(true);
+    const bounded = await sliceReadsFor(makeMsg({ startKAId: packA(7), endKAId: packA(7) }));
+    expectBackgroundReads(bounded, [SLICE_BOUNDED, SLICE_WIDENED]);
 
-    const unbounded = await sliceQueriesFor(makeMsg({ startKAId: 0, endKAId: 0 }));
-    expect(unbounded.map((entry) => entry.source)).not.toContain(SLICE_BOUNDED);
-    expect(unbounded.map((entry) => entry.source)).toContain(SLICE);
-    expect(unbounded.every((entry) => entry.priority === 'background')).toBe(true);
+    const unbounded = await sliceReadsFor(makeMsg({ startKAId: 0, endKAId: 0 }));
+    expectBackgroundReads(unbounded, [SLICE]);
+    expect([...unbounded.graphDiscovery, ...unbounded.queries].map((entry) => entry.source))
+      .not.toContain(SLICE_BOUNDED);
 
     // Kill-switch is applied at the boundary: a derivable bound is not used.
     process.env.DKG_DISABLE_SWM_KA_BOUND = '1';
-    const killed = await sliceQueriesFor(makeMsg({ startKAId: packA(7), endKAId: packA(7) }));
-    expect(killed.map((entry) => entry.source)).not.toContain(SLICE_BOUNDED);
-    expect(killed.map((entry) => entry.source)).toContain(SLICE);
-    expect(killed.every((entry) => entry.priority === 'background')).toBe(true);
-  });
-
-  it('runs the chain-reconcile unbounded backstop in the background lane', async () => {
-    const store = new OxigraphStore();
-    const root = 'urn:test:chain-reconcile-priority';
-    await store.insert([{
-      subject: root,
-      predicate: 'http://schema.org/name',
-      object: '"priority"',
-      graph: swmGraph(AUTHOR_A, 7),
-    }]);
-    const options = captureQueryOptions(store);
-    const handler = new FinalizationHandler(store, undefined);
-    const seam = handler as unknown as {
-      getSharedMemoryQuadsForRoots: (
-        contextGraphId: string,
-        rootEntities: string[],
-        subGraphName?: string,
-      ) => Promise<Quad[]>;
-    };
-
-    await expect(seam.getSharedMemoryQuadsForRoots(CG, [root])).resolves.toHaveLength(1);
-    const sliceQueries = options.filter((entry) => entry.source === SLICE);
-    expect(sliceQueries.length).toBeGreaterThan(0);
-    expect(sliceQueries.every((entry) => entry.priority === 'background')).toBe(true);
+    const killed = await sliceReadsFor(makeMsg({ startKAId: packA(7), endKAId: packA(7) }));
+    expectBackgroundReads(killed, [SLICE]);
+    expect([...killed.graphDiscovery, ...killed.queries].map((entry) => entry.source))
+      .not.toContain(SLICE_BOUNDED);
   });
 });
 

--- a/packages/storage/src/graph-manager.ts
+++ b/packages/storage/src/graph-manager.ts
@@ -469,12 +469,7 @@ export async function loadSharedMemorySliceWithKaBoundFallback(
   optionsOrSources: LoadSharedMemorySliceWithKaBoundFallbackOptions | SwmSliceSourceTags,
   legacyCreateAccept?: () => Promise<(quads: Quad[]) => Quad[] | null>,
 ): Promise<{ quads: Quad[]; accepted: Quad[] | null }> {
-  if (!('sources' in optionsOrSources) && !legacyCreateAccept) {
-    throw new TypeError('loadSharedMemorySliceWithKaBoundFallback requires createAccept');
-  }
-  const options: LoadSharedMemorySliceWithKaBoundFallbackOptions = 'sources' in optionsOrSources
-    ? optionsOrSources
-    : { sources: optionsOrSources, createAccept: legacyCreateAccept! };
+  const options = normalizeLoadSharedMemorySliceOptions(optionsOrSources, legacyCreateAccept);
   const { sources, createAccept, queryOptions = {} } = options;
   const readComplete = (source: QueryOptions['source']): Promise<Quad[]> =>
     loadSelectedSharedMemoryQuads(store, bucketGraph, selection, { queryOptions, querySource: source });
@@ -500,6 +495,17 @@ export async function loadSharedMemorySliceWithKaBoundFallback(
     accepted = accept(quads);
   }
   return { quads, accepted };
+}
+
+function normalizeLoadSharedMemorySliceOptions(
+  optionsOrSources: LoadSharedMemorySliceWithKaBoundFallbackOptions | SwmSliceSourceTags,
+  legacyCreateAccept: (() => Promise<(quads: Quad[]) => Quad[] | null>) | undefined,
+): LoadSharedMemorySliceWithKaBoundFallbackOptions {
+  if ('sources' in optionsOrSources) return optionsOrSources;
+  if (!legacyCreateAccept) {
+    throw new TypeError('loadSharedMemorySliceWithKaBoundFallback requires createAccept');
+  }
+  return { sources: optionsOrSources, createAccept: legacyCreateAccept };
 }
 
 function sharedMemorySelectionGraphPattern(

--- a/packages/storage/src/graph-set-index-store.ts
+++ b/packages/storage/src/graph-set-index-store.ts
@@ -9,6 +9,7 @@ import type {
   TripleStore,
   UpdateOptions,
 } from './triple-store.js';
+import { storeWorkPriorityRank } from './store-priority-scheduler.js';
 import { UnsupportedTripleStoreCapabilityError } from './unsupported-capability-error.js';
 
 export const DEFAULT_GRAPH_SET_REVALIDATE_MS = 30_000;
@@ -29,15 +30,6 @@ export type GraphSetMutationSource =
 type TouchedGraphMutationSource = 'delete' | 'deleteByPattern' | 'deleteBySubjectPrefix' | 'update';
 type GraphSetRefreshSource = 'seed' | 'revalidate' | TouchedGraphMutationSource | 'query';
 type PendingFullRefreshSource = Exclude<GraphSetRefreshSource, 'seed' | 'revalidate'>;
-
-interface GraphSetRefreshFlight {
-  priority: StoreWorkPriority;
-  task: Promise<Set<string>>;
-}
-
-interface GraphSetRefreshScanState {
-  lastSequence: number;
-}
 
 export type GraphSetMutationEvent =
   | {
@@ -75,6 +67,84 @@ export interface GraphSetIndexStoreOptions {
   onMutation?: (event: GraphSetMutationEvent) => void;
 }
 
+interface RefreshFlight<T> {
+  readonly priority: StoreWorkPriority;
+  readonly task: Promise<T>;
+  lastScanSequence: number;
+}
+
+interface RefreshScan {
+  readonly sequence: number;
+}
+
+/**
+ * Coordinates priority-promoted refresh flights independently of graph-cache
+ * mechanics. A caller may reuse a flight at its own or a higher priority; a
+ * higher-priority caller starts a separate flight. Monotonic scan tokens then
+ * fence both stale publication and stale failure handling.
+ */
+class RefreshCoordinator<T> {
+  private readonly flights = new Map<StoreWorkPriority, RefreshFlight<T>>();
+  private nextScanSequence = 0;
+  private latestPublishedScanSequence = 0;
+
+  run(
+    priority: StoreWorkPriority,
+    start: (flight: RefreshFlight<T>) => Promise<T>,
+  ): Promise<T> {
+    const reusable = this.bestReusableFlight(priority);
+    if (reusable) return reusable.task;
+
+    // Register the flight before its work starts so even a re-entrant caller
+    // sees a complete single-flight view.
+    let resolveTask!: (value: T) => void;
+    let rejectTask!: (reason?: unknown) => void;
+    const task = new Promise<T>((resolve, reject) => {
+      resolveTask = resolve;
+      rejectTask = reject;
+    });
+    const flight: RefreshFlight<T> = { priority, task, lastScanSequence: 0 };
+    this.flights.set(priority, flight);
+    void (async () => {
+      try {
+        resolveTask(await start(flight));
+      } catch (error: unknown) {
+        rejectTask(error);
+      } finally {
+        if (this.flights.get(priority) === flight) this.flights.delete(priority);
+      }
+    })();
+    return task;
+  }
+
+  beginScan(flight: RefreshFlight<T>): RefreshScan {
+    const scan = { sequence: ++this.nextScanSequence };
+    flight.lastScanSequence = scan.sequence;
+    return scan;
+  }
+
+  tryPublish(scan: RefreshScan): boolean {
+    if (scan.sequence < this.latestPublishedScanSequence) return false;
+    this.latestPublishedScanSequence = scan.sequence;
+    return true;
+  }
+
+  shouldApplyFailureBackoff(flight: RefreshFlight<T>): boolean {
+    return flight.lastScanSequence >= this.latestPublishedScanSequence;
+  }
+
+  private bestReusableFlight(priority: StoreWorkPriority): RefreshFlight<T> | undefined {
+    const requestedRank = storeWorkPriorityRank(priority);
+    let best: RefreshFlight<T> | undefined;
+    for (const candidate of this.flights.values()) {
+      const candidateRank = storeWorkPriorityRank(candidate.priority);
+      if (candidateRank > requestedRank) continue;
+      if (!best || candidateRank < storeWorkPriorityRank(best.priority)) best = candidate;
+    }
+    return best;
+  }
+}
+
 /**
  * Write-through named-graph index for stores whose `listGraphs()` implementation
  * is a full-store scan. The index follows the repo's existing graph semantics:
@@ -102,9 +172,7 @@ export class GraphSetIndexStore implements TripleStore {
   private nextRevalidateAt = 0;
   private revalidateFailureCount = 0;
   private mutationGeneration = 0;
-  private readonly refreshesInFlight = new Map<StoreWorkPriority, GraphSetRefreshFlight>();
-  private refreshScanSequence = 0;
-  private latestPublishedRefreshScan = 0;
+  private readonly refreshCoordinator = new RefreshCoordinator<Set<string>>();
   /**
    * Pending full rebuild requested by a mutation whose exact graph effects can't
    * be applied incrementally. The stored source preserves the observer contract
@@ -315,19 +383,15 @@ export class GraphSetIndexStore implements TripleStore {
   }
 
   private async refreshIndex(source: GraphSetRefreshSource, options?: QueryOptions): Promise<Set<string>> {
-    // A lower-priority cold seed/revalidation must not capture a later normal or
-    // ACK reader. The higher-priority caller starts its own scan so the external
-    // scheduler can use the capacity reserved for that lane; equal/lower callers
-    // still coalesce onto the best in-flight scan. Dirty rebuilds remain forced
-    // to background, regardless of the waiting reader's requested priority.
     const priority = refreshPriority(source, options);
-    const coalesced = this.coalescableRefresh(priority);
-    if (coalesced) return coalesced.task;
-
-    const scanState: GraphSetRefreshScanState = { lastSequence: 0 };
-    let task = this.refreshIndexLoop(source, options, scanState);
-    if (source === 'revalidate') {
-      task = task.catch((error: unknown) => {
+    // The coordinator owns the complete promotion policy: lower-priority cold
+    // seeds/revalidations cannot capture later normal or ACK readers, while
+    // equal/lower-priority callers reuse the best in-flight scan.
+    return this.refreshCoordinator.run(priority, async (flight) => {
+      try {
+        return await this.refreshIndexLoop(source, options, flight);
+      } catch (error: unknown) {
+        if (source !== 'revalidate') throw error;
         // Cancellation, cold seeds, and mutation-dirty rebuilds are strict
         // correctness paths even if another refresh published in parallel.
         if (options?.signal?.aborted || !this.graphs || this.pendingFullRefresh) {
@@ -336,12 +400,7 @@ export class GraphSetIndexStore implements TripleStore {
         // A newer promoted refresh already published a usable graph set. Do
         // not let this older failed scan overwrite its healthy schedule with
         // failure backoff.
-        if (
-          scanState.lastSequence < this.latestPublishedRefreshScan &&
-          this.graphs
-        ) {
-          return this.graphs;
-        }
+        if (!this.refreshCoordinator.shouldApplyFailureBackoff(flight)) return this.graphs;
         // Periodic discovery of out-of-contract writers is advisory once the
         // write-through index is warm. Preserve that last known set and back
         // off after a store failure instead of making every graph reader repeat
@@ -350,33 +409,14 @@ export class GraphSetIndexStore implements TripleStore {
         // fails, keep the original strict rejection behavior.
         this.noteRevalidationFailure();
         return this.graphs;
-      });
-    }
-    const flight: GraphSetRefreshFlight = { priority, task };
-    this.refreshesInFlight.set(priority, flight);
-    try {
-      return await task;
-    } finally {
-      if (this.refreshesInFlight.get(priority) === flight) {
-        this.refreshesInFlight.delete(priority);
       }
-    }
-  }
-
-  private coalescableRefresh(priority: StoreWorkPriority): GraphSetRefreshFlight | undefined {
-    const maxRank = refreshPriorityRank(priority);
-    for (const candidate of REFRESH_PRIORITIES) {
-      if (refreshPriorityRank(candidate) > maxRank) break;
-      const flight = this.refreshesInFlight.get(candidate);
-      if (flight) return flight;
-    }
-    return undefined;
+    });
   }
 
   private async refreshIndexLoop(
     source: GraphSetRefreshSource,
     options: QueryOptions | undefined,
-    scanState: GraphSetRefreshScanState,
+    flight: RefreshFlight<Set<string>>,
   ): Promise<Set<string>> {
     for (;;) {
       const isDirtyRebuild = this.pendingFullRefresh != null;
@@ -394,14 +434,13 @@ export class GraphSetIndexStore implements TripleStore {
       const scanOptions: QueryOptions | undefined = isDirtyRebuild
         ? { ...options, priority: 'background', source: 'graph-set-index.rebuild' }
         : options;
-      const scanSequence = ++this.refreshScanSequence;
-      scanState.lastSequence = scanSequence;
+      const scan = this.refreshCoordinator.beginScan(flight);
       const next = new Set((await this.inner.listGraphs(scanOptions)).filter(Boolean));
       if (generation !== this.mutationGeneration) continue;
       // Priority promotion intentionally permits overlapping scans. Fence the
       // shared cache by scan start order so an older, slower background response
       // cannot overwrite a later ACK/normal snapshot that already published.
-      if (scanSequence < this.latestPublishedRefreshScan) {
+      if (!this.refreshCoordinator.tryPublish(scan)) {
         return this.graphs ?? next;
       }
       // This scan reflects every mutation up to `generation` (synchronous from
@@ -409,7 +448,6 @@ export class GraphSetIndexStore implements TripleStore {
       // the clear; if one had, it would have bumped the generation above and we
       // would have retried, preserving the pending refresh source for the next
       // scan attempt).
-      this.latestPublishedRefreshScan = scanSequence;
       this.pendingFullRefresh = null;
       this.replaceGraphSet(next, sourceForScan);
       return this.graphs!;
@@ -567,12 +605,6 @@ function refreshPriority(
   return source === 'seed' || source === 'revalidate'
     ? options?.priority ?? 'normal'
     : 'background';
-}
-
-const REFRESH_PRIORITIES: readonly StoreWorkPriority[] = ['ack', 'normal', 'background'];
-
-function refreshPriorityRank(priority: StoreWorkPriority): number {
-  return REFRESH_PRIORITIES.indexOf(priority);
 }
 
 function throwIfAborted(signal: AbortSignal | undefined): void {

--- a/packages/storage/src/store-priority-scheduler.ts
+++ b/packages/storage/src/store-priority-scheduler.ts
@@ -63,11 +63,26 @@ interface QueueEntry<T> {
   waitTimer?: ReturnType<typeof setTimeout>;
 }
 
-interface NonAckLaneCapacity {
-  limit: number;
-  normalReservedSlots: number;
-  backgroundReservedSlots: number;
+interface NonAckLanePolicy {
+  /** Shared normal/background capacity after the ACK reservation. */
+  totalLimit: number;
+  /** Capacity protected from background work. */
+  normalFloor: number;
+  /** Normal ceiling while queued background work owns its floor. */
+  normalLimitWhileBackgroundQueued: number;
+  /** Background progress guarantee while background work is queued. */
+  backgroundFloor: number;
+  /** Background ceiling that protects the normal floor. */
   backgroundLimit: number;
+}
+
+interface LegacyStorePrioritySchedulerArguments {
+  argumentCount: number;
+  ackReservedSlots?: number;
+  now?: () => number;
+  backgroundReservedSlots?: number;
+  queueLimits?: number | Partial<StorePriorityQueueLimits>;
+  queueWaitTimeoutMs?: number;
 }
 
 const DEFAULT_MAX_CONCURRENT = 8;
@@ -122,13 +137,57 @@ function normalizeQueueLimit(value: number | undefined): number {
     : DEFAULT_STORE_QUEUE_LIMIT;
 }
 
+function normalizeStorePrioritySchedulerOptions(
+  optionsOrMaxConcurrent: StorePrioritySchedulerOptions | number | undefined,
+  legacy: LegacyStorePrioritySchedulerArguments,
+): StorePrioritySchedulerOptions {
+  const legacyCall = typeof optionsOrMaxConcurrent === 'number' || legacy.argumentCount > 1;
+  if (!legacyCall) return optionsOrMaxConcurrent ?? {};
+
+  return {
+    maxConcurrent: typeof optionsOrMaxConcurrent === 'number'
+      ? optionsOrMaxConcurrent
+      : undefined,
+    ackReservedSlots: legacy.ackReservedSlots,
+    now: legacy.now,
+    backgroundReservedSlots: legacy.backgroundReservedSlots,
+    queueLimits: legacy.queueLimits,
+    queueWaitTimeoutMs: legacy.queueWaitTimeoutMs,
+  };
+}
+
+function normalizeNonAckLanePolicy(
+  totalLimit: number,
+  requestedNormalFloor: number,
+  requestedBackgroundFloor: number,
+): NonAckLanePolicy {
+  const normalFloor = Math.min(
+    Math.max(0, requestedNormalFloor),
+    Math.max(0, totalLimit - 1),
+  );
+  const backgroundLimit = Math.max(1, totalLimit - normalFloor);
+  const backgroundFloor = Math.min(
+    Math.max(0, requestedBackgroundFloor),
+    backgroundLimit,
+    Math.max(0, totalLimit - 1),
+  );
+  const normalLimitWhileBackgroundQueued = totalLimit - backgroundFloor;
+  return {
+    totalLimit,
+    normalFloor,
+    normalLimitWhileBackgroundQueued,
+    backgroundFloor,
+    backgroundLimit,
+  };
+}
+
 function metricOperation(operation: string): string {
   const trimmed = operation.trim();
   if (!trimmed) return 'unknown';
   return trimmed.replace(/[^\w:./-]/g, '_').slice(0, 80) || 'unknown';
 }
 
-function priorityRank(priority: StoreWorkPriority): number {
+export function storeWorkPriorityRank(priority: StoreWorkPriority): number {
   if (priority === 'ack') return 0;
   if (priority === 'normal') return 1;
   return 2;
@@ -146,11 +205,10 @@ export class StorePriorityScheduler {
   private backgroundInflight = 0;
   private readonly maxConcurrent: number;
   private readonly ackReservedSlots: number;
-  private readonly normalReservedSlots: number;
-  private readonly backgroundReservedSlots: number;
   private readonly queueWaitTimeoutMs: number;
   private readonly now: () => number;
   private readonly queueLimits: StorePriorityQueueLimits;
+  private readonly nonAckLanePolicy: NonAckLanePolicy;
 
   constructor(options?: StorePrioritySchedulerOptions);
   /** @deprecated Use the named options object. Retained for package compatibility. */
@@ -170,30 +228,34 @@ export class StorePriorityScheduler {
     legacyQueueLimits?: number | Partial<StorePriorityQueueLimits>,
     legacyQueueWaitTimeoutMs?: number,
   ) {
-    const legacyCall = typeof optionsOrMaxConcurrent === 'number' || arguments.length > 1;
-    const options: StorePrioritySchedulerOptions = legacyCall
-      ? {
-          maxConcurrent: typeof optionsOrMaxConcurrent === 'number'
-            ? optionsOrMaxConcurrent
-            : undefined,
-          ackReservedSlots: legacyAckReservedSlots,
-          now: legacyNow,
-          backgroundReservedSlots: legacyBackgroundReservedSlots,
-          queueLimits: legacyQueueLimits,
-          queueWaitTimeoutMs: legacyQueueWaitTimeoutMs,
-        }
-      : optionsOrMaxConcurrent;
+    const options = normalizeStorePrioritySchedulerOptions(optionsOrMaxConcurrent, {
+      argumentCount: arguments.length,
+      ackReservedSlots: legacyAckReservedSlots,
+      now: legacyNow,
+      backgroundReservedSlots: legacyBackgroundReservedSlots,
+      queueLimits: legacyQueueLimits,
+      queueWaitTimeoutMs: legacyQueueWaitTimeoutMs,
+    });
     this.maxConcurrent = options.maxConcurrent
       ?? parsePositiveIntegerEnv('DKG_STORE_MAX_CONCURRENT', DEFAULT_MAX_CONCURRENT);
-    this.ackReservedSlots = options.ackReservedSlots
+    const requestedAckReservedSlots = options.ackReservedSlots
       ?? parsePositiveIntegerEnv('DKG_STORE_ACK_RESERVED_SLOTS', DEFAULT_ACK_RESERVED_SLOTS);
-    this.normalReservedSlots = options.normalReservedSlots
+    this.ackReservedSlots = Math.min(
+      requestedAckReservedSlots,
+      Math.max(0, this.maxConcurrent - 1),
+    );
+    const requestedNormalFloor = options.normalReservedSlots
       ?? parseNonNegativeIntegerEnv('DKG_STORE_NORMAL_RESERVED_SLOTS', DEFAULT_NORMAL_RESERVED_SLOTS);
-    this.backgroundReservedSlots = options.backgroundReservedSlots
+    const requestedBackgroundFloor = options.backgroundReservedSlots
       ?? parseNonNegativeIntegerEnv(
         'DKG_STORE_BACKGROUND_RESERVED_SLOTS',
         DEFAULT_BACKGROUND_RESERVED_SLOTS,
       );
+    this.nonAckLanePolicy = normalizeNonAckLanePolicy(
+      Math.max(1, this.maxConcurrent - this.ackReservedSlots),
+      requestedNormalFloor,
+      requestedBackgroundFloor,
+    );
     this.queueWaitTimeoutMs = options.queueWaitTimeoutMs
       ?? parsePositiveIntegerEnv(
         'DKG_STORE_QUEUE_WAIT_TIMEOUT_MS',
@@ -204,7 +266,6 @@ export class StorePriorityScheduler {
   }
 
   get snapshot(): StorePrioritySchedulerSnapshot {
-    const laneCapacity = this.nonAckLaneCapacity();
     return {
       ackInflight: this.ackInflight,
       normalInflight: this.normalInflight,
@@ -213,9 +274,9 @@ export class StorePriorityScheduler {
       normalQueued: this.queues.normal.length,
       backgroundQueued: this.queues.background.length,
       maxConcurrent: this.maxConcurrent,
-      ackReservedSlots: this.effectiveAckReserve(),
-      normalReservedSlots: laneCapacity.normalReservedSlots,
-      backgroundReservedSlots: laneCapacity.backgroundReservedSlots,
+      ackReservedSlots: this.ackReservedSlots,
+      normalReservedSlots: this.nonAckLanePolicy.normalFloor,
+      backgroundReservedSlots: this.nonAckLanePolicy.backgroundFloor,
       ackQueueLimit: this.queueLimits.ack,
       normalQueueLimit: this.queueLimits.normal,
       backgroundQueueLimit: this.queueLimits.background,
@@ -291,7 +352,7 @@ export class StorePriorityScheduler {
 
   private nextRunnable(): QueueEntry<unknown> | undefined {
     const priorities: StoreWorkPriority[] = ['ack', 'normal', 'background'];
-    priorities.sort((a, b) => priorityRank(a) - priorityRank(b));
+    priorities.sort((a, b) => storeWorkPriorityRank(a) - storeWorkPriorityRank(b));
     for (const priority of priorities) {
       const queue = this.queues[priority];
       if (queue.length === 0) continue;
@@ -306,48 +367,15 @@ export class StorePriorityScheduler {
     if (totalInflight >= this.maxConcurrent) return false;
     if (priority === 'ack') return true;
 
-    const laneCapacity = this.nonAckLaneCapacity();
+    const lanePolicy = this.nonAckLanePolicy;
     const nonAckInflight = this.normalInflight + this.backgroundInflight;
-    if (nonAckInflight >= laneCapacity.limit) return false;
-    if (priority === 'background' && this.backgroundInflight >= laneCapacity.backgroundLimit) {
+    if (nonAckInflight >= lanePolicy.totalLimit) return false;
+    if (priority === 'background' && this.backgroundInflight >= lanePolicy.backgroundLimit) {
       return false;
     }
-    if (
-      priority === 'normal' &&
-      this.shouldHoldBackgroundFloor(laneCapacity.backgroundReservedSlots)
-    ) {
-      return false;
-    }
-    return true;
-  }
-
-  private shouldHoldBackgroundFloor(backgroundReservedSlots: number): boolean {
-    return backgroundReservedSlots > 0 &&
-      this.queues.background.length > 0 &&
-      this.backgroundInflight < backgroundReservedSlots;
-  }
-
-  private effectiveAckReserve(): number {
-    return Math.min(this.ackReservedSlots, Math.max(0, this.maxConcurrent - 1));
-  }
-
-  private nonAckLimit(): number {
-    return Math.max(1, this.maxConcurrent - this.effectiveAckReserve());
-  }
-
-  private nonAckLaneCapacity(): NonAckLaneCapacity {
-    const limit = this.nonAckLimit();
-    const normalReservedSlots = Math.min(
-      Math.max(0, this.normalReservedSlots),
-      Math.max(0, limit - 1),
-    );
-    const backgroundLimit = Math.max(1, limit - normalReservedSlots);
-    const backgroundReservedSlots = Math.min(
-      Math.max(0, this.backgroundReservedSlots),
-      backgroundLimit,
-      Math.max(0, limit - 1),
-    );
-    return { limit, normalReservedSlots, backgroundReservedSlots, backgroundLimit };
+    if (priority === 'background' || this.queues.background.length === 0) return true;
+    return this.backgroundInflight >= lanePolicy.backgroundFloor &&
+      this.normalInflight < lanePolicy.normalLimitWhileBackgroundQueued;
   }
 
   private start(entry: QueueEntry<unknown>): void {

--- a/packages/storage/test/graph-manager-swm-bound.test.ts
+++ b/packages/storage/test/graph-manager-swm-bound.test.ts
@@ -545,6 +545,34 @@ describe('loadSharedMemorySliceWithKaBoundFallback — the safe bounded read', (
     }
   });
 
+  it('deprecated positional options preserve bounded widening behavior', async () => {
+    const store = await createTripleStore({ backend: 'oxigraph' });
+    const swm = contextGraphSharedMemoryUri('fb-legacy');
+    const root = 'urn:fb:legacy';
+    const widenedObject = '"widened"';
+    try {
+      await store.insert([
+        { subject: root, predicate: 'urn:p', object: '"bounded"', graph: `${swm}/${AUTHOR_A_MIXED}/7` },
+        { subject: root, predicate: 'urn:p', object: widenedObject, graph: `${swm}/${AUTHOR_B}/12` },
+      ]);
+
+      const { quads, accepted } = await loadSharedMemorySliceWithKaBoundFallback(
+        store,
+        swm,
+        { rootEntities: [root] },
+        { agentAddress: AUTHOR_A, startNumber: 7n, endNumber: 7n },
+        SOURCES,
+        async () => (candidate) =>
+          candidate.some((quad) => quad.object === widenedObject) ? candidate : null,
+      );
+
+      expect(quads.map((quad) => quad.object).sort()).toEqual(['"bounded"', widenedObject]);
+      expect(accepted).toEqual(quads);
+    } finally {
+      await store.close();
+    }
+  });
+
   it('no bound: one complete read, accept predicate applied once', async () => {
     const store = await createTripleStore({ backend: 'oxigraph' });
     const swm = contextGraphSharedMemoryUri('fb-none');

--- a/packages/storage/test/graph-set-index-store.test.ts
+++ b/packages/storage/test/graph-set-index-store.test.ts
@@ -459,6 +459,152 @@ describe('GraphSetIndexStore', () => {
     }
   });
 
+  it('lets a normal seed bypass an in-flight background seed through the reserved scheduler lane', async () => {
+    const scheduler = new StorePriorityScheduler({
+      maxConcurrent: 2,
+      ackReservedSlots: 0,
+      normalReservedSlots: 1,
+      backgroundReservedSlots: 0,
+    });
+    const inner = new OxigraphStore();
+    const staleGraph = 'did:dkg:context-graph:background-normal-promotion';
+    const freshGraph = 'did:dkg:context-graph:normal-promoted-snapshot';
+    const scheduled = new ScheduledGraphListStore(inner, scheduler);
+    scheduled.listGraphsResults.background = [staleGraph];
+    scheduled.listGraphsResults.normal = [freshGraph];
+    let releaseBackground!: () => void;
+    let releaseNormal!: () => void;
+    scheduled.listGraphsGates.background = new Promise<void>((resolve) => {
+      releaseBackground = resolve;
+    });
+    scheduled.listGraphsGates.normal = new Promise<void>((resolve) => {
+      releaseNormal = resolve;
+    });
+    const store = new GraphSetIndexStore(scheduled);
+    const background = store.listGraphs({
+      priority: 'background',
+      source: 'agent.finalization.sharedMemorySlice',
+    });
+    let normal: Promise<string[]> | undefined;
+
+    try {
+      await Promise.resolve();
+      expect(scheduled.listGraphsCalls).toBe(1);
+      expect(scheduler.snapshot).toMatchObject({
+        normalInflight: 0,
+        normalQueued: 0,
+        backgroundInflight: 1,
+      });
+
+      normal = store.listGraphs({
+        priority: 'normal',
+        source: 'agent.query.sharedMemorySlice',
+      });
+      await Promise.resolve();
+
+      expect(scheduled.listGraphsCalls).toBe(2);
+      expect(scheduled.listGraphsOptions).toEqual([
+        {
+          priority: 'background',
+          source: 'agent.finalization.sharedMemorySlice',
+        },
+        {
+          priority: 'normal',
+          source: 'agent.query.sharedMemorySlice',
+        },
+      ]);
+      expect(scheduler.snapshot).toMatchObject({
+        normalInflight: 1,
+        normalQueued: 0,
+        backgroundInflight: 1,
+      });
+
+      // Normal completes through its reserved lane while background remains
+      // blocked; graph-index coalescing must not capture it first.
+      releaseNormal();
+      await expect(normal).resolves.toEqual([freshGraph]);
+      expect(scheduler.snapshot).toMatchObject({
+        normalInflight: 0,
+        backgroundInflight: 1,
+      });
+
+      releaseBackground();
+      await expect(background).resolves.toEqual([freshGraph]);
+      await expect(store.listGraphs()).resolves.toEqual([freshGraph]);
+      expect(scheduled.listGraphsCalls).toBe(2);
+    } finally {
+      releaseNormal();
+      releaseBackground();
+      await Promise.allSettled([background, ...(normal ? [normal] : [])]);
+    }
+  });
+
+  it('ignores an older failed background revalidation after a promoted refresh publishes', async () => {
+    let now = 1_000;
+    const scheduler = new StorePriorityScheduler({
+      maxConcurrent: 2,
+      ackReservedSlots: 0,
+      normalReservedSlots: 1,
+      backgroundReservedSlots: 0,
+    });
+    const cachedGraph = 'did:dkg:context-graph:cached-before-promotion';
+    const freshGraph = 'did:dkg:context-graph:fresh-promoted-snapshot';
+    const nextGraph = 'did:dkg:context-graph:next-periodic-snapshot';
+    const scheduled = new ScheduledGraphListStore(new OxigraphStore(), scheduler);
+    scheduled.listGraphsResults.normal = [cachedGraph];
+    const store = new GraphSetIndexStore(scheduled, {
+      revalidateMs: 100,
+      revalidateFailureBackoffMs: 1_000,
+      now: () => now,
+    });
+
+    await expect(store.listGraphs()).resolves.toEqual([cachedGraph]);
+    expect(scheduled.listGraphsCalls).toBe(1);
+
+    now += 100;
+    let rejectBackground!: (error: Error) => void;
+    scheduled.listGraphsGates.background = new Promise<void>((_resolve, reject) => {
+      rejectBackground = reject;
+    });
+    const background = store.listGraphs({
+      priority: 'background',
+      source: 'agent.finalization.sharedMemorySlice',
+    });
+
+    try {
+      await Promise.resolve();
+      expect(scheduled.listGraphsCalls).toBe(2);
+      expect(scheduler.snapshot.backgroundInflight).toBe(1);
+
+      scheduled.listGraphsResults.normal = [freshGraph];
+      const normal = store.listGraphs({
+        priority: 'normal',
+        source: 'agent.query.sharedMemorySlice',
+      });
+      await expect(normal).resolves.toEqual([freshGraph]);
+      expect(scheduled.listGraphsCalls).toBe(3);
+      expect(scheduler.snapshot.backgroundInflight).toBe(1);
+
+      // The older failure is superseded by the normal publication: its waiter
+      // receives the fresh set instead of rejecting or applying failure backoff.
+      rejectBackground(new Error('older background revalidation failed'));
+      await expect(background).resolves.toEqual([freshGraph]);
+
+      // The promoted success scheduled the next normal revalidation for +100ms.
+      // If the older failure applied its 1s backoff, this read would not scan.
+      now += 100;
+      scheduled.listGraphsResults.normal = [freshGraph, nextGraph];
+      await expect(store.listGraphs({ priority: 'normal' })).resolves.toEqual([
+        freshGraph,
+        nextGraph,
+      ]);
+      expect(scheduled.listGraphsCalls).toBe(4);
+    } finally {
+      rejectBackground(new Error('test cleanup'));
+      await Promise.allSettled([background]);
+    }
+  });
+
   it('restarts an in-flight refresh when a local write lands during the scan', async () => {
     const inner = new OxigraphStore();
     await inner.insert([q('did:dkg:context-graph:before')]);

--- a/packages/storage/test/store-priority-scheduler.test.ts
+++ b/packages/storage/test/store-priority-scheduler.test.ts
@@ -170,6 +170,94 @@ describe('StorePriorityScheduler', () => {
     });
   });
 
+  it('preserves queue admission settings in the deprecated positional constructor', async () => {
+    vi.useFakeTimers();
+    let releaseNormal1: (() => void) | undefined;
+    let releaseNormal2: (() => void) | undefined;
+    let releaseBackground: (() => void) | undefined;
+    const running: Array<Promise<unknown>> = [];
+    try {
+      const scheduler = new StorePriorityScheduler(
+        2,
+        0,
+        undefined,
+        1,
+        { ack: 3, normal: 2, background: 1 },
+        25,
+      );
+      expect(scheduler.snapshot).toMatchObject({
+        maxConcurrent: 2,
+        ackReservedSlots: 0,
+        backgroundReservedSlots: 1,
+        ackQueueLimit: 3,
+        normalQueueLimit: 2,
+        backgroundQueueLimit: 1,
+        queueWaitTimeoutMs: 25,
+      });
+
+      const events: string[] = [];
+      const normal1 = scheduler.run('normal', 'legacy.normal.1', async () => {
+        events.push('normal-1:start');
+        await new Promise<void>((resolve) => {
+          releaseNormal1 = resolve;
+        });
+        events.push('normal-1:end');
+      });
+      const normal2 = scheduler.run('normal', 'legacy.normal.2', async () => {
+        events.push('normal-2:start');
+        await new Promise<void>((resolve) => {
+          releaseNormal2 = resolve;
+        });
+      });
+      const background = scheduler.run('background', 'legacy.background', async () => {
+        events.push('background:start');
+        await new Promise<void>((resolve) => {
+          releaseBackground = resolve;
+        });
+      });
+      const timedOutNormal = scheduler.run('normal', 'legacy.normal.timeout', async () => {
+        events.push('timed-out-normal:start');
+      });
+      const timedOutNormalAssertion = expect(timedOutNormal).rejects.toMatchObject({
+        reason: 'queue_wait_timeout',
+        priority: 'normal',
+      });
+      running.push(normal1, normal2, background, timedOutNormal);
+
+      await expect(
+        scheduler.run('background', 'legacy.background.queue-full', async () => undefined),
+      ).rejects.toMatchObject({
+        reason: 'queue_full',
+        priority: 'background',
+      });
+
+      releaseNormal1();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(events).toEqual([
+        'normal-1:start',
+        'normal-2:start',
+        'normal-1:end',
+        'background:start',
+      ]);
+
+      await vi.advanceTimersByTimeAsync(25);
+      await timedOutNormalAssertion;
+      expect(events).not.toContain('timed-out-normal:start');
+
+      releaseBackground();
+      releaseNormal2();
+      await Promise.all([normal1, normal2, background]);
+    } finally {
+      releaseNormal1?.();
+      releaseNormal2?.();
+      await vi.advanceTimersByTimeAsync(0);
+      releaseBackground?.();
+      await vi.runAllTimersAsync();
+      await Promise.allSettled(running);
+      vi.useRealTimers();
+    }
+  });
+
   it('lets ACK work jump ahead of queued background work', async () => {
     const scheduler = new StorePriorityScheduler({ maxConcurrent: 2, ackReservedSlots: 1 });
     const events: string[] = [];


### PR DESCRIPTION
## Summary

Follow-up to #1701 that addresses the deferred maintainability and regression-coverage review items while preserving its foreground-capacity behavior.

- normalize scheduler configuration into an explicit non-ACK lane policy and isolate deprecated positional parsing
- extract graph refresh promotion, coalescing, scan fencing, and failure-backoff decisions into a focused coordinator using the scheduler priority ordering
- add compatibility coverage for both retained legacy APIs
- cover normal-over-background graph refresh promotion and older failed revalidation after a promoted success
- verify SWM graph discovery as well as queries use the background lane, including the public chain-reconcile path

## Verification

- storage, query, publisher, random-sampling, and agent builds passed, including agent type tests
- storage suite: 390 passed, 26 skipped
- focused agent suites: 37 passed
- independent integration audit: no blockers
- git diff --check passed