### PR TITLE
Fix private CG join-policy preflight load

### DIFF
--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -865,6 +865,16 @@ export class DKGAgentBase {
     Math.max(1, Number(process.env['DKG_LIST_CONTEXT_GRAPHS_SCAN_BUDGET_MS']) || 5_000);
   static readonly LIST_CONTEXT_GRAPHS_AUTH_BUDGET_MS =
     Math.max(1, Number(process.env['DKG_LIST_CONTEXT_GRAPHS_AUTH_BUDGET_MS']) || 5_000);
+  /**
+   * Per-row list enrichment can issue several store queries. Keep the aggregate
+   * fan-out comfortably below the store scheduler's normal-queue limit even on
+   * nodes that have discovered hundreds of context graphs.
+   */
+  static readonly LIST_CONTEXT_GRAPHS_ROW_CONCURRENCY =
+    Math.min(8, Math.max(
+      1,
+      Math.floor(Number(process.env['DKG_LIST_CONTEXT_GRAPHS_ROW_CONCURRENCY']) || 4),
+    ));
 
   protected messageHandler: MessageHandler | null = null;
   protected chainPoller: ChainEventPoller | null = null;

--- a/packages/agent/src/dkg-agent-cg-resolve.ts
+++ b/packages/agent/src/dkg-agent-cg-resolve.ts
@@ -405,6 +405,7 @@ import {
 import { DKGAgentBase } from './dkg-agent-base.js';
 import type { ContextGraphMetaRecord } from './context-graph-meta-projection.js';
 import type { DKGAgent } from './dkg-agent.js';
+import { mapWithConcurrency } from './map-with-concurrency.js';
 import {
   runCuratorMetaRefresh,
   type CuratorMetaRefreshOptions,
@@ -430,6 +431,30 @@ function throwIfSyncAuthAborted(signal: AbortSignal | undefined): void {
 type InternalContextGraphListRow = ListContextGraphsRow & {
   policyKnown?: boolean;
 };
+
+function mapContextGraphListRows<T, R>(
+  items: readonly T[],
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  return mapWithConcurrency(
+    items,
+    DKGAgentBase.LIST_CONTEXT_GRAPHS_ROW_CONCURRENCY,
+    fn,
+  );
+}
+
+async function mapContextGraphListRowsSettled<T, R>(
+  items: readonly T[],
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<PromiseSettledResult<R>[]> {
+  return mapContextGraphListRows(items, async (item, index) => {
+    try {
+      return { status: 'fulfilled', value: await fn(item, index) } as const;
+    } catch (reason) {
+      return { status: 'rejected', reason } as const;
+    }
+  });
+}
 
 function listContextGraphsProjectionEnabled(): boolean {
   // Before enabling this default-on: thread the caller signal into getCgMeta
@@ -479,11 +504,11 @@ async function applyContextGraphListPrivacy(
       .map(({ policyKnown: _policyKnown, ...row }) => row);
   }
 
-  const annotated = await Promise.all(visibleRows.map(async (r) => {
+  const annotated = await mapContextGraphListRows(visibleRows, async (r) => {
     const curatorMatch = agent.curatorDidMatchesChecksumAgent(r.curator, checksum);
     const allowlisted = await agent.callerIsAllowlistedAgentParticipant(r.id, checksum);
     return { ...r, callerInvolved: curatorMatch || allowlisted };
-  }));
+  });
 
   return annotated
     .filter((r) => {
@@ -517,7 +542,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       candidateIds.add(id);
     }
 
-    const rows = await Promise.all([...candidateIds].sort().map(async (id): Promise<InternalContextGraphListRow | null> => {
+    const rows = await mapContextGraphListRows([...candidateIds].sort(), async (id): Promise<InternalContextGraphListRow | null> => {
       if (!id) return null;
       const sub = this.subscribedContextGraphs.get(id);
       const meta = await this.getCgMeta(id);
@@ -546,7 +571,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
         onChainId: sub?.onChainId ?? meta.onChainId,
         policyKnown,
       };
-    }));
+    });
 
     return applyContextGraphListPrivacy(
       this,
@@ -2035,8 +2060,9 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
         if (!uri || byUri.has(uri)) continue;
         byUri.set(uri, row);
       }
-      // Parallel lookups — sequential await per ontology row multiplied list latency noticeably.
-      const definitionSettled = await Promise.allSettled([...byUri.values()].map(async (row) => {
+      // Bounded parallel lookups avoid multiplying latency without flooding
+      // the store scheduler when the registry contains hundreds of rows.
+      const definitionSettled = await mapContextGraphListRowsSettled([...byUri.values()], async (row) => {
         const uri = row['ctxGraph'] ?? '';
         if (seen.has(uri)) return;
         const id = uri.startsWith(prefix) ? uri.slice(prefix.length) : uri;
@@ -2069,7 +2095,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
           synced: sub?.synced ?? false,
           ...(onChainId ? { onChainId } : {}),
         }, policyPrivacy(row['access']));
-      }));
+      });
       for (const entry of definitionSettled) {
         if (entry.status === 'rejected') throw entry.reason;
       }
@@ -2255,7 +2281,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
      * for the same CG; projection resolves policy with _meta-first source
      * precedence, then AGENTS, then ONTOLOGY.
      */
-    const projectedRows = await Promise.allSettled(rows.map(async (r) => {
+    const projectedRows = await mapContextGraphListRowsSettled(rows, async (r) => {
       const metaRead = await withBudget(
         (signal) => this.getCgMeta(r.id, { signal }),
         `projection lookup for ${r.id}`,
@@ -2287,20 +2313,20 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
         isSystem: meta.isSystem || r.isSystem,
         onChainId: meta.onChainId ?? r.onChainId,
       };
-    }));
+    });
     rows = projectedRows.map((entry) => {
       if (entry.status === 'fulfilled') return entry.value;
       throw entry.reason;
     });
 
-    const curatorBackfills = await Promise.allSettled(rows.map(async (r) => {
+    const curatorBackfills = await mapContextGraphListRowsSettled(rows, async (r) => {
       if (r.curator?.trim()) return r;
       const c = await optional(
         (signal) => this.getContextGraphCurator(r.id, { signal }),
         `curator lookup for ${r.id}`,
       );
       return c ? { ...r, curator: c } : r;
-    }));
+    });
     rows = curatorBackfills.map((entry, index) => {
       if (entry.status === 'fulfilled') return entry.value;
       throw entry.reason;
@@ -2320,10 +2346,10 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       }
       return legacyRead.value ? 'private' : 'public';
     };
-    const privacySettled = await Promise.allSettled(rows.map(async (row) => ({
+    const privacySettled = await mapContextGraphListRowsSettled(rows, async (row) => ({
       uri: row.uri,
       privacy: await resolveRowPrivacy(row),
-    })));
+    }));
     const resolvedPrivacyByUri = new Map<string, ListContextGraphsPrivacy>();
     for (const entry of privacySettled) {
       if (entry.status === 'fulfilled') {
@@ -2349,7 +2375,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       };
     }
 
-    const annotatedSettled = await Promise.allSettled(rows.map(async (r): Promise<{
+    const annotatedSettled = await mapContextGraphListRowsSettled(rows, async (r): Promise<{
       row: ListContextGraphsRow;
       privacy: ListContextGraphsPrivacy;
     }> => {
@@ -2373,7 +2399,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       // Using local node identity (`creatorIsSelf`) leaks curated rows to unrelated callers.
       if (!allowlistRead.ok) return { row: r, privacy };
       return { row: { ...r, callerInvolved: allowlistRead.value }, privacy };
-    }));
+    });
     const annotated = annotatedSettled.map((entry, index) => {
       if (entry.status === 'fulfilled') return entry.value;
       throw entry.reason;

--- a/packages/agent/test/context-graph-list-concurrency.test.ts
+++ b/packages/agent/test/context-graph-list-concurrency.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import { contextGraphDataUri } from '@origintrail-official/dkg-core';
+import { ContextGraphResolveMethods } from '../src/dkg-agent-cg-resolve.js';
+import { DKGAgentBase } from '../src/dkg-agent-base.js';
+
+const CALLER_ADDRESS = '0x1111111111111111111111111111111111111111';
+const IDS = Array.from({ length: 24 }, (_, index) => `bounded-list-${index}`);
+
+function projectedMeta(id: string) {
+  return {
+    id,
+    uri: contextGraphDataUri(id),
+    declared: true,
+    isSystem: false,
+    name: id,
+    creators: [],
+    curators: [],
+    allowedPeers: [],
+    allowedAgents: [],
+    participantAgents: [],
+    participantIdentityIds: [],
+    revokedAgents: [],
+    subGraphs: [],
+    hasAgentGate: false,
+    hasPeerGate: false,
+    hasLegacyParticipantGate: false,
+  };
+}
+
+function concurrencyProbe() {
+  let inFlight = 0;
+  let peak = 0;
+  return {
+    run: async <T>(value: T): Promise<T> => {
+      inFlight += 1;
+      peak = Math.max(peak, inFlight);
+      try {
+        await new Promise((resolve) => setTimeout(resolve, 2));
+        return value;
+      } finally {
+        inFlight -= 1;
+      }
+    },
+    peak: () => peak,
+  };
+}
+
+describe('context graph list row concurrency', () => {
+  it('bounds projection metadata and privacy fan-out', async () => {
+    const probe = concurrencyProbe();
+    const fakeAgent = {
+      contextGraphMetaProjection: {
+        listDeclaredContextGraphIds: async () => IDS,
+      },
+      subscribedContextGraphs: new Map(),
+      store: {
+        listGraphsByPrefix: async () => [],
+      },
+      getCgMeta: async (id: string) => probe.run({
+        ...projectedMeta(id),
+        accessPolicy: 'public',
+      }),
+      curatorDidMatchesChecksumAgent: () => false,
+      callerIsAllowlistedAgentParticipant: async () => probe.run(false),
+    };
+
+    const rows = await (ContextGraphResolveMethods.prototype.listContextGraphsFromProjection as any)
+      .call(fakeAgent, { callerAgentAddress: CALLER_ADDRESS });
+
+    expect(rows).toHaveLength(IDS.length);
+    expect(probe.peak()).toBeGreaterThan(1);
+    expect(probe.peak()).toBeLessThanOrEqual(DKGAgentBase.LIST_CONTEXT_GRAPHS_ROW_CONCURRENCY);
+  });
+
+  it('bounds every legacy per-row enrichment wave', async () => {
+    const probe = concurrencyProbe();
+    const fakeAgent = {
+      subscribedContextGraphs: new Map(),
+      store: {
+        query: async () => ({
+          type: 'bindings',
+          bindings: IDS.map((id) => ({
+            ctxGraph: contextGraphDataUri(id),
+            name: `"${id}"`,
+          })),
+        }),
+        listGraphsByPrefix: async () => [],
+      },
+      getContextGraphOnChainId: async () => probe.run(undefined),
+      getCgMeta: async (id: string) => probe.run(projectedMeta(id)),
+      getContextGraphCurator: async () => probe.run(undefined),
+      isPrivateContextGraph: async () => probe.run(false),
+      curatorDidMatchesChecksumAgent: () => false,
+      callerIsAllowlistedAgentParticipant: async () => probe.run(false),
+    };
+
+    const result = await (ContextGraphResolveMethods.prototype as any)
+      .listContextGraphsUncached.call(fakeAgent, CALLER_ADDRESS, true);
+
+    expect(result.rows).toHaveLength(IDS.length);
+    expect(probe.peak()).toBeGreaterThan(1);
+    expect(probe.peak()).toBeLessThanOrEqual(DKGAgentBase.LIST_CONTEXT_GRAPHS_ROW_CONCURRENCY);
+  });
+});

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -75,6 +75,7 @@ export default defineConfig({
       "test/sync-responder-agents-meta-serve-skip.test.ts",
       "test/messenger-substrate.test.ts",
       "test/context-graph-join-policy.test.ts",
+      "test/context-graph-list-concurrency.test.ts",
       "test/cg-resolve-refresh.test.ts",
       "test/private-cg-membership-bootstrap.test.ts",
       "test/workspace-crypto-delegatee-filter.test.ts",

--- a/packages/cli/src/daemon/routes/context-graph.ts
+++ b/packages/cli/src/daemon/routes/context-graph.ts
@@ -1109,11 +1109,18 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
   }
   if (req.method === 'PUT' && joinPolicyMatch) {
     const contextGraphId = decodeURIComponent(joinPolicyMatch[1]);
+    // A node-admin token intentionally has no agent-scoped identity, while
+    // requestAgentAddress resolves it to the node's default owner. Use that
+    // same owner for exact preflight and the policy mutation; otherwise a
+    // private CG cannot fast-accept and falls back to the global CG listing.
     const resolvedContextGraphId = await resolveRequiredWriteContextGraphId(
       agent,
       contextGraphId,
       res,
-      writePreflightContextGraphOpts,
+      {
+        callerAgentAddress: requestAgentAddress,
+        allowLocalExactFallback: !requestAgentAddress,
+      },
     );
     if (!resolvedContextGraphId) return;
     try {

--- a/packages/cli/test/context-graph-join-policy-route.test.ts
+++ b/packages/cli/test/context-graph-join-policy-route.test.ts
@@ -51,12 +51,14 @@ describe('GET/PUT /api/context-graph/{id}/join-policy', () => {
         memberCount: 1,
       }),
     );
+    const resolveAgentByToken = (token?: string) => {
+      if (token === 'owner-token') return OWNER_ADDRESS;
+      if (token === 'other-token') return OTHER_ADDRESS;
+      return undefined;
+    };
     const agent: Record<string, any> = {
-      resolveAgentByToken: (token?: string) => {
-        if (token === 'owner-token') return OWNER_ADDRESS;
-        if (token === 'other-token') return OTHER_ADDRESS;
-        return undefined;
-      },
+      resolveAgentByToken,
+      resolveAgentAddress: (token?: string) => resolveAgentByToken(token) ?? OWNER_ADDRESS,
       probeContextGraphWritePreflight: vi.fn().mockResolvedValue(ACCEPT_WRITE_PREFLIGHT),
       listContextGraphs: vi.fn().mockRejectedValue(new Error('write preflight should fast-accept')),
       getContextGraphJoinPolicy,
@@ -93,14 +95,14 @@ describe('GET/PUT /api/context-graph/{id}/join-policy', () => {
         assertionImportLocks: new Map(),
         vectorStore: {},
         embeddingProvider: null,
-        validTokens: new Set(['owner-token', 'other-token']),
+        validTokens: new Set(['owner-token', 'other-token', 'node-token']),
         apiHost: '127.0.0.1',
         apiPortRef: { value: 0 },
         routePlugins: [],
         url,
         path: url.pathname,
         requestToken,
-        requestAgentAddress: agent.resolveAgentByToken(requestToken),
+        requestAgentAddress: agent.resolveAgentAddress(requestToken),
       } as any);
       if (!res.writableEnded) {
         res.writeHead(404, { 'content-type': 'application/json' });
@@ -191,6 +193,50 @@ describe('GET/PUT /api/context-graph/{id}/join-policy', () => {
     expect(probeContextGraphWritePreflight).toHaveBeenCalledWith(CONTEXT_GRAPH_ID, {
       callerAgentAddress: OWNER_ADDRESS,
     });
+    expect(setContextGraphJoinPolicy).toHaveBeenCalledWith(
+      CONTEXT_GRAPH_ID,
+      {
+        mode: 'open',
+        maxMembers: 25,
+        maxApprovalsPerHour: 4,
+        acknowledgeOpenEnrollment: true,
+      },
+      OWNER_ADDRESS,
+    );
+  });
+
+  it('uses the default owner for node-admin preflight without listing every context graph', async () => {
+    const setContextGraphJoinPolicy = vi.fn().mockResolvedValue({
+      contextGraphId: CONTEXT_GRAPH_ID,
+      mode: 'open',
+      maxMembers: 25,
+      maxApprovalsPerHour: 4,
+    });
+    const probeContextGraphWritePreflight = vi.fn().mockResolvedValue(ACCEPT_WRITE_PREFLIGHT);
+    const listContextGraphs = vi.fn().mockRejectedValue(
+      new Error('global context graph listing must not run'),
+    );
+    const result = await requestJoinPolicy({
+      method: 'PUT',
+      token: 'node-token',
+      body: {
+        mode: 'open',
+        maxMembers: 25,
+        maxApprovalsPerHour: 4,
+        acknowledgeOpenEnrollment: true,
+      },
+      agentOverrides: {
+        setContextGraphJoinPolicy,
+        probeContextGraphWritePreflight,
+        listContextGraphs,
+      },
+    });
+
+    expect(result.status).toBe(200);
+    expect(probeContextGraphWritePreflight).toHaveBeenCalledWith(CONTEXT_GRAPH_ID, {
+      callerAgentAddress: OWNER_ADDRESS,
+    });
+    expect(listContextGraphs).not.toHaveBeenCalled();
     expect(setContextGraphJoinPolicy).toHaveBeenCalledWith(
       CONTEXT_GRAPH_ID,
       {


### PR DESCRIPTION
## Summary

- use the resolved request owner for join-policy write preflight, including node-admin tokens, so private CG updates take the exact fast path instead of enumerating every known CG
- bound legacy and projection `listContextGraphs` row enrichment to four concurrent rows by default (hard-capped at eight) to prevent large registries from filling the store scheduler queue
- add regressions for node-admin open enrollment and both list implementations

## Testnet failure addressed

The private-CG harness was returning `CONTEXT_GRAPH_VALIDATION_UNAVAILABLE` with `Store scheduler queue full (normal: sparql-http.query)` while enabling open enrollment. The policy mutation already resolved the node-admin token to the default owner, but preflight discarded that identity and fell back to the expensive global list. This keeps the identity consistent and limits the fallback load for other callers.

## Verification

- agent build and type-contract suite
- CLI TypeScript check
- 39 related agent tests
- 9 join-policy route tests