### PR TITLE
Fix trusted private CG write preflight overload

### DIFF
--- a/packages/cli/src/daemon/http-utils.ts
+++ b/packages/cli/src/daemon/http-utils.ts
@@ -737,9 +737,21 @@ function exactProbeCanFastAccept(
   probe: ContextGraphWritePreflightProbe,
   requireLocalWritable: boolean,
   callerAgentAddress: string | null,
+  allowLocalExactFallback: boolean,
 ): boolean {
   if (!exactProbeIsLocallyWritable(probe, requireLocalWritable)) return false;
-  if (!callerAgentAddress) return probe.accessPolicy === "public";
+  if (!callerAgentAddress) {
+    // Node-admin / trusted-local routes already opt into the exact-local
+    // fallback below after listContextGraphs. When the exact probe has all of
+    // the same positive evidence up front, accept a known PRIVATE graph here
+    // instead of enumerating every context graph first. This does not broaden
+    // access: scoped agent callers never set allowLocalExactFallback, and an
+    // unavailable/unknown store cannot satisfy exactProbeIsLocallyWritable.
+    return (
+      probe.accessPolicy === "public" ||
+      (allowLocalExactFallback && probe.accessPolicy === "private")
+    );
+  }
   return probe.callerAuthorized === true;
 }
 
@@ -903,17 +915,28 @@ async function evaluateExactWritePreflight(
     callerAgentAddress: string | null;
     requireLocalWritable: boolean;
     isBareCandidateId: boolean;
+    allowLocalExactFallback: boolean;
   },
 ): Promise<ExactPreflightDecision> {
   if (!agent.probeContextGraphWritePreflight) return { kind: "continueToList" };
-  const { callerAgentAddress, requireLocalWritable, isBareCandidateId } = opts;
+  const {
+    callerAgentAddress,
+    requireLocalWritable,
+    isBareCandidateId,
+    allowLocalExactFallback,
+  } = opts;
   try {
     const probe = await agent.probeContextGraphWritePreflight(candidateId, {
       callerAgentAddress,
     });
     // Fast-accept wins even under a degraded store (it never rests on UNKNOWN
     // store fields), so check it before any deny/unavailable interpretation.
-    if (exactProbeCanFastAccept(probe, requireLocalWritable, callerAgentAddress)) {
+    if (exactProbeCanFastAccept(
+      probe,
+      requireLocalWritable,
+      callerAgentAddress,
+      allowLocalExactFallback,
+    )) {
       return { kind: "accept" };
     }
     if (probe.storeUnavailable === true) {
@@ -977,6 +1000,12 @@ export async function resolveRequiredWriteContextGraphId(
   opts: {
     callerAgentAddress?: string | null;
     requireLocalWritable?: boolean;
+    /**
+     * Trusted local / node-admin routes may accept an exact, store-backed
+     * private graph without first enumerating all visible context graphs.
+     * Scoped agent routes must leave this false so their per-caller private
+     * authorization remains authoritative.
+     */
     allowLocalExactFallback?: boolean;
     /**
      * Test-only seam: override the store-outage rescue eth_call timeout so the
@@ -1010,6 +1039,7 @@ export async function resolveRequiredWriteContextGraphId(
     callerAgentAddress,
     requireLocalWritable,
     isBareCandidateId,
+    allowLocalExactFallback: opts.allowLocalExactFallback === true,
   });
   if (exactDecision.kind === "accept") return candidateId;
   if (exactDecision.kind === "rejectUnknown") {

--- a/packages/cli/test/write-preflight-resilience.test.ts
+++ b/packages/cli/test/write-preflight-resilience.test.ts
@@ -46,7 +46,9 @@ import {
 } from '@origintrail-official/dkg-core';
 
 const CG = 'resilience-cg';
+const CALLER = '0x2222222222222222222222222222222222222222';
 const UNSCOPED = { callerAgentAddress: undefined, allowLocalExactFallback: true } as const;
+const SCOPED = { callerAgentAddress: CALLER, allowLocalExactFallback: false } as const;
 
 // Real prototype methods from the agent mixin — the exact code the daemon
 // runs, bound to a narrow harness instead of a full DKGAgent (which would
@@ -552,6 +554,86 @@ describe('resolveRequiredWriteContextGraphId — healthy-store paths unchanged',
     const probe = await harness.probeContextGraphWritePreflight(seededCg);
     expect(probe.storeUnavailable).toBeUndefined();
     expect(probe.exists).toBe(true);
+  });
+
+  it('fast-accepts an exact private synced CG for a trusted local caller without listing every CG', async () => {
+    const seededCg = '0x1111111111111111111111111111111111111111/private-fast-path';
+    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+    const cgUri = `did:dkg:context-graph:${seededCg}`;
+    await healthyStore.insert([
+      {
+        subject: cgUri,
+        predicate: DKG_ONTOLOGY.RDF_TYPE,
+        object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH,
+        graph: ontologyGraph,
+      },
+      {
+        subject: cgUri,
+        predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY,
+        object: '"private"',
+        graph: ontologyGraph,
+      },
+    ]);
+    const harness = agentHarness(
+      healthyStore,
+      new Map([[seededCg, { subscribed: true, synced: true }]]),
+    );
+    const { provider, listCalls } = providerFor(harness);
+    const { res, out } = captureRes();
+
+    const resolved = await resolveRequiredWriteContextGraphId(
+      provider,
+      seededCg,
+      res,
+      UNSCOPED,
+    );
+
+    expect(resolved).toBe(seededCg);
+    expect(out.status).toBeUndefined();
+    expect(listCalls).toEqual([]);
+    await expect(harness.probeContextGraphWritePreflight(seededCg)).resolves.toMatchObject({
+      storeAvailable: true,
+      exists: true,
+      accessPolicy: 'private',
+    });
+  });
+
+  it('does not extend the trusted local private fast path to a scoped unauthorized agent', async () => {
+    const seededCg = '0x1111111111111111111111111111111111111111/private-scoped-deny';
+    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+    const cgUri = `did:dkg:context-graph:${seededCg}`;
+    await healthyStore.insert([
+      {
+        subject: cgUri,
+        predicate: DKG_ONTOLOGY.RDF_TYPE,
+        object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH,
+        graph: ontologyGraph,
+      },
+      {
+        subject: cgUri,
+        predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY,
+        object: '"private"',
+        graph: ontologyGraph,
+      },
+    ]);
+    const harness = agentHarness(
+      healthyStore,
+      new Map([[seededCg, { subscribed: true, synced: true }]]),
+    );
+    const { provider, listCalls } = providerFor(harness);
+    const { res, out } = captureRes();
+
+    const resolved = await resolveRequiredWriteContextGraphId(
+      provider,
+      seededCg,
+      res,
+      SCOPED,
+    );
+
+    expect(resolved).toBeNull();
+    expect(out.status).toBe(400);
+    expect(out.body).toMatchObject({ code: 'CONTEXT_GRAPH_NOT_FOUND' });
+    expect(listCalls).toEqual([]);
   });
 
   it('(e) a storeUnavailable exact probe does not poison a healthy list leg (list evidence still accepts)', async () => {


### PR DESCRIPTION
## Summary

- let trusted local/node-admin write routes fast-accept an exact private context graph after the exact probe proves that the local store is available, the graph exists, and it is locally writable
- avoid falling through to the global `listContextGraphs()` validation path for that case, which was failing under store scheduler pressure
- preserve the stricter scoped-agent boundary: an agent-address caller still requires `callerAuthorized === true`

## Root cause

On testnet-canary, local private writes had enough exact evidence to establish that the target graph existed and was writable, but the resolver only fast-accepted public graphs or explicitly authorized scoped-agent requests. Trusted unscoped private writes therefore fell through to a global graph-list query and failed before publishing with:

```
Failed to validate contextGraphId against known context graphs: Store scheduler queue full (normal: sparql-http.query)
```

The later local fallback already allowed this trusted route to use a hidden private graph. This change makes that existing behavior available at the exact-probe stage, with stricter evidence and without the expensive global listing.

## Testnet evidence

Deployed canary revision: `06419722490076ea3a11cd1833e8ac2c8fc68be8`.

Before the fix:

- `smoke-06419722-10x2-20260714T185723Z`: 9/20 finalized overall; public 9/10, private 0/10
- `smoke-private-retry-06419722-20260714T190433Z`: private 0/10

With the patch build (`3610f2f8`, subsequently rebased unchanged onto current `main` as this PR head):

- `fix-probe-private-3610f2f8-20260714T191602Z`: private 1/1 finalized
- `fix-validation-3610f2f8-10x2-20260714T191724Z`: 20/20 finalized — public 10/10 and private 10/10
- exact RDF readback: public 10/10 and private 10/10
- fleet delta: zero daemon restarts, zero sync timeouts, and zero daemon/Oxigraph OOM kills

## Verification

- `pnpm --filter @origintrail-official/dkg run build`
- `pnpm exec vitest run --config vitest.unit.config.ts test/write-preflight-resilience.test.ts` — 21/21
- `pnpm exec vitest run --config vitest.config.ts test/context-graph-write-path-validation.test.ts` — 27/27

The focused tests and build were rerun after rebasing onto current `main`.

## Relationship to #1705

This is complementary to #1705. That PR fixes private-CG join-policy owner resolution and bounds graph-list fanout. This PR removes the global graph-list dependency from trusted exact KA/general write preflight while keeping scoped-agent authorization authoritative.
