### PR TITLE
OT-RFC-61 testnet harness — Phase 0 (generalized certification harness, live-validated)

### DIFF
--- a/testnet/.gitignore
+++ b/testnet/.gitignore
@@ -1,0 +1,4 @@
+fleet.json
+policy.json
+runs/
+*.local.json

--- a/testnet/README.md
+++ b/testnet/README.md
@@ -1,0 +1,71 @@
+# DKG Testnet Harness
+
+Implementation of **OT-RFC-61** (dkgv10-spec PR #141): goal-driven functional and
+performance certification of the DKG against the live Base-Sepolia testnet.
+This workspace is **Phase 0** of the RFC's rollout — the generalization of the
+OT-RFC-59 certification harness (`harness.mjs`, single-file) into a modular,
+fleet-configurable tool — plus the scenario/measurement scaffolding Phase 1
+builds on.
+
+Zero runtime dependencies (Node ≥ 20 built-ins only, ESM). No build step:
+runs straight from a laptop without installing or compiling the monorepo.
+Tests use `node --test`.
+
+## Quickstart
+
+```bash
+cp testnet/fleet.example.json  testnet/fleet.json    # fill in your fleet (gitignored)
+cp testnet/policy.example.json testnet/policy.json   # operator safety policy (gitignored)
+
+node testnet/bin/harness.mjs selftest                # offline: unit tests + config validation
+node testnet/bin/harness.mjs monitor                 # read-only fleet snapshot (safe, no load)
+node testnet/bin/harness.mjs baseline                # snapshot + journal cursors, no load
+node testnet/bin/harness.mjs certify --scenario certify-100   # scored run (interactive only)
+```
+
+## Modes and safety
+
+| Mode | Load? | Fleet access | Notes |
+| --- | --- | --- | --- |
+| `selftest` | no | none | unit tests + validates fleet/policy/scenario files |
+| `monitor` | no | read-only | light snapshots on a loop; safe anytime |
+| `baseline` | no | read-only | full snapshot + journal cursor capture |
+| `certify` | YES | read-only | scored workload through the LOCAL edge; S3 watch active |
+
+Per RFC-61 §8 S2, fleet access is observation-only. `--autonomous` runs refuse
+to start unless credential isolation is verified (forced-command key, no agent
+socket); interactive operator runs (the default) may use an operator key but
+still never mutate fleet hosts. S3 abort trips come from `policy.json`
+(defaults + hard maxima in `policy.example.json`); scenarios may only tighten
+them; a missing watch signal fails closed. A tripped run quiesces in-flight
+work and ends as terminal `SAFETY_ABORT`.
+
+## Layout
+
+```
+bin/harness.mjs      CLI entry: mode dispatch, run lifecycle (preflight → baseline → workload → soak → verdict)
+lib/util.mjs         waitFor, fetchRetry, percentile (nearest-rank), parseLastJsonBlock, term normalizers
+lib/config.mjs       fleet.json / policy.json / scenario loading + validation, S2 credential check
+lib/evidence.mjs     append-only JSONL evidence stream (ts + run_id + schema_version), run manifest
+lib/ssh.mjs          bounded-concurrency SSH exec, k=v snapshot parsing (base64 values)
+lib/fleet.mjs        light/full fleet snapshots, build-identity attestation, journal cursors + signature ledger
+lib/edge.mjs         local edge daemon client (status, KA lifecycle, jobs, query, catchup, SSE), CLI runner
+lib/scoring.mjs      outcomes, failure enum, aggregates + coverage gates, verdict builder
+lib/watch.mjs        S3 abort-trip evaluation + quiesce controller
+lib/scenario.mjs     scenario schema + runner; scenarios/certify-100.json is scenario #1
+ledger.json          versioned forbidden-signature classes (gated vs recorded)
+schema/EVIDENCE.md   evidence record types + schema_version contract
+scenarios.json       scenario manifest (drift-guarded against scenarios/ by test)
+```
+
+## Provenance
+
+- Spec: `dkgv10-spec/rfcs/OT-RFC-61-testnet-harness.md` (PR #141)
+- Generalizes: the OT-RFC-59 certification harness (single-file `harness.mjs`)
+- Ports devnet `_bootstrap` primitives: `waitFor`, `fetchRetry`,
+  `parseLastJsonBlock`, SPARQL term normalizers, suite-manifest drift guard.
+
+Phase 0 exit gate: the RFC-59 certify workload (2 waves × (25 public + 25
+private) KAs at concurrency 2, byte-exact readback, 600 s soak, gate battery)
+reproduces under this tool. Phase 1 (observer edge, propagation anchors, full
+op matrix) extends `lib/scenario.mjs` + `lib/edge.mjs` without structural change.

--- a/testnet/STATUS.md
+++ b/testnet/STATUS.md
@@ -116,3 +116,41 @@ the operator deletes the file.
 4. `scenario.mjs` ledger-unavailable signature deltas now emit `gatedTotal`/
    `recordedTotal` `null` (was `0`) + `ledgerVersion: null`, matching
    `fleet.journalSignatureDeltas`' never-silent-zeroes discipline.
+
+## Live shakedown — first scored certify (2026-07-14, certify-94f3c78c-r1)
+
+**Verdict: `SAFETY_ABORT` (exit 3), by design.** ~15 min into the workload,
+core-2's cgroup `memory.current` reached **98.4% of `memory.high`** (threshold
+0.95) — the S3 early-warning trip fired, in-flight ops were quiesced (scored
+`aborted`, excluded from denominators), and the run ended terminal with a
+60-min cooldown (`runs/safety-abort.json`; operator clearance = delete it).
+Core-2 receded to 79% after quiesce. 174 fleet snapshots + 173 host-telemetry
+records + full signature deltas captured.
+
+Everything the review rounds hardened fired for real on the first run:
+- **Mid-run artifact change**: the canary auto-update recycled all 4 core
+  workers during the run → every network-dependent gate scored
+  `INCONCLUSIVE (fleet-artifact-changed)`; only fleet gates scored.
+- **Coverage/partial semantics**: public lane 23/23 success (1.0) before
+  quiesce; per-KA publish p95 reported but not gated (inconclusive).
+- **Terminal SAFETY_ABORT precedence** over gate outcomes, cooldown persisted.
+
+Network findings (for operators, not harness bugs):
+1. **`rfc59-private` CG is publish-dead**: every private-lane publish stalls in
+   ACK collection — cores decline `NO_DATA_IN_SWM` (private ciphertext staging
+   never reaches them; the CG predates the 2026-07-10 core wipes, and today's
+   passing rfc59 smoke used *freshly created* smoke CGs instead). Private-lane
+   certify needs a freshly registered private CG (or the custody fix).
+2. **Core-2's 1.5 GiB `memory.high` is too tight for publish load** (idles at
+   ~80%); any sustained battery will re-trip S3 until the ceiling or the RSS
+   is addressed.
+3. `sync_timeout` signature storms on two cores during the auto-update window;
+   `oom_sigkill` ledger class matched exactly 2 lines/core at restart time —
+   likely the updater's worker SIGKILL, not kernel OOM → ledger v2 TODO:
+   split/disposition that class.
+
+Harness fixes from the shakedown (in this branch): job-poll deadline messages
+now classify as `timeout` (were `error:unclassified`); the inconclusive reason
+is `fleet-artifact-changed` (a same-commit worker recycle also invalidates);
+`ps` KiB→bytes RSS conversion; `reuse:<name>` CG resolution via gitignored
+`fleet.json` `cgs` map (actual ids to the API, logical names in evidence).

--- a/testnet/STATUS.md
+++ b/testnet/STATUS.md
@@ -1,0 +1,118 @@
+# OT-RFC-61 Testnet Harness — Phase 0 Status
+
+Integration status as of 2026-07-14. Zero-dependency (node: builtins only), no build step.
+Node >= 20 required; verified on v22.16.0.
+
+## Test state
+
+`node --test` (from this directory): **194 tests, 194 pass, 0 fail** across 10 suites
+(config 34 + manifest-drift 4, edge 16, evidence + util 43, fleet + ssh 46, scenario 9,
+scoring + watch 42). All suites are hermetic — no real SSH, no external network,
+no fleet required. `node --check` clean on every `.mjs` under `lib/`, `bin/`, `test/`.
+
+Note: never invoke the runner as `node --test test/` — on Node >= 22.16 a directory
+positional is spawned as an entry module and fails. Use bare `node --test` (what
+`npm test` and `harness.mjs selftest` do).
+
+## Modules
+
+- **lib/util.mjs** — percentile (nearest-rank, rfc59 parity), parseLastJsonBlock,
+  normTerm (canonical devnet dialect: structured uri/bnode → `<iri>`/`_:b`),
+  bindingSetDigest, sha256, fetchRetry (transient-network-only), waitFor,
+  seededRandom/fnv1a, isoBasic, promiseWithTimeout, sleep.
+- **lib/evidence.mjs** — EvidenceWriter (append-only JSONL, envelope injection, S6
+  hygiene deep-scan throws on host/ip/sshUser/sshIdentity at any depth; raw material
+  only via writeSidecar), makeRunId, buildManifest, FAILURE_CLASSES closed enum.
+- **lib/config.mjs** — loadFleet/loadPolicy/loadScenario (collect-all-problems errors,
+  sha256 file digests), tighten-only S3 enforcement for scenario trip overrides
+  (POLICY_TRIPS direction table), verifyCredentialIsolation (S2: interactive pass-through;
+  autonomous = no-agent, identity-only, per-core sudo-refused + no-verbatim-exec probes,
+  fail-closed on transport errors).
+- **lib/ssh.mjs** — sshExec (BatchMode, accept-new, `--` separator, retry on exit-255
+  only, per-attempt SIGKILL timeout, never rejects), mapLimit, parseKvOutput (b64-aware),
+  snapshotCommand (single read-only compound), unitFullName.
+- **lib/fleet.mjs** — snapshotCore/snapshotFleet (SSH k=v + public /api/status; reachable
+  = both transports; S6 scrubbing of error strings), attestBuildIdentity/sameArtifact
+  (§3.1 commit+pid+start-ts binding), captureJournalCursors, journalSignatureDeltas
+  (awk single pass after cursor; vacuumed cursor ⇒ cursorValid:false, totals null —
+  never silent zeroes; raw matched lines to sidecar only), loadLedger/validateLedger.
+- **lib/edge.mjs** — EdgeClient over the verified daemon routes (create KA, share-async
+  + share-job poll, vm/publish-async + publisher-job poll, KA state, query, catchup,
+  SSE events with gap tracking), makePayload (rfc59 byte-parity fixtures), verifyReadback
+  (chunked VALUES, normalizes via util.normTerm), parseNquads, runCli (never rejects,
+  16k tail-truncate), resolveEdgeToken.
+- **lib/scoring.mjs** — classifyFailure (closed enum, throws on unknown), aggregate
+  ('aborted' excluded from success-rate denominator), evaluateGate (coverage gates
+  mandatory, fail-closed INCONCLUSIVE), computeVerdict, formatVerdict.
+- **lib/watch.mjs** — evaluateTrips (all S3 trips, fail-closed 'signal-unavailable',
+  PSI sustain window, sticky unreachability), quiesce (cancel inflight → stop edges →
+  flat-counter confirm; never touches fleet hosts), recordSafetyAbort/safetyAbortGate
+  (cooldown file, corrupt ⇒ blocked).
+- **lib/scenario.mjs** — runPublishScenario (lane bursts at per-lane concurrency, §6
+  recovery re-scoring via authoritative KA state, live snapshot/trip loop, soak,
+  final full snapshot + journal deltas even on abort), mergePeak, buildGates,
+  pollVmFinalized.
+- **bin/harness.mjs** — modes selftest | monitor | baseline | certify; exit codes
+  0 PASS, 1 FAIL, 2 INCONCLUSIVE, 3 SAFETY_ABORT (or blocked cooldown), 4 usage/config.
+- **ledger.json** — version 1, 12 signature classes (6 gated, 6 recorded), awk/JS
+  parity tested against fixtures/journal-sample.txt.
+
+## Commands
+
+```sh
+cd testnet
+
+# self-check: unit tests + validate policy/fleet/scenarios (examples as fallback)
+node bin/harness.mjs selftest
+
+# live fleet table every 10 s (Ctrl-C to stop); --once for a single pass;
+# add --run-id <id> to also write fleet_snapshot evidence
+node bin/harness.mjs monitor --interval 10
+node bin/harness.mjs monitor --once
+
+# one full snapshot + journal cursors + build attestation, written as evidence
+node bin/harness.mjs baseline
+
+# certify run (fleet.json + policy.json required; scenario default certify-100)
+node bin/harness.mjs certify --scenario certify-100
+node bin/harness.mjs certify --scenario certify-100 --autonomous --json
+
+npm test   # = node --test
+```
+
+Evidence lands in `runs/<run_id>.jsonl` (+ `.sidecar.jsonl` for raw local-only
+material); certify also writes `runs/<run_id>.verdict.json`. A SAFETY_ABORT writes
+`runs/safety-abort.json` and blocks new certify runs until the cooldown passes or
+the operator deletes the file.
+
+## Known gaps / TODOs
+
+- **Preflight wallet + CG checks are skipped** (Phase 0): `wallets_funded` and
+  `context_graphs_visible` are recorded as `pass: 'skipped'` with TODO evidence and
+  listed in `notRun` (S4 wallet/faucet and CG-visibility preflights unimplemented).
+- **run_verdict gate entries carry an inline `evidence` object**, not the
+  `evidencePointer` name in schema/EVIDENCE.md — scoring.evaluateGate's frozen return
+  uses `evidence`; documented deviation, revisit when a pointer scheme exists.
+- If `ledger.json` is removed, gated-signature gates score INCONCLUSIVE
+  (`ledger_unavailable`, totals null) — honest, never silent zeroes.
+- Phase 1 record types (`propagation_result`, `sse_gap`, `faucet_draw`,
+  `goal_verdict`) are reserved and not emitted.
+- Autonomous credential-isolation probes need a real reachable fleet; they are
+  fail-closed on any SSH transport error.
+- End-to-end certify against a live fleet has not been run yet — everything above is
+  verified by hermetic tests only.
+
+## Integration fixes applied (2026-07-14)
+
+1. `package.json` test script: `node --test test/` → `node --test` (directory
+   positional breaks on Node >= 22.16).
+2. `bin/harness.mjs` cmdSelftest spawned the same broken form (`node --test <dir>`);
+   now bare `--test` with cwd at the package root.
+3. Duplicate-logic sweep: deleted `edge.mjs`'s inlined devnet `normTermFallback` +
+   `normTermSafe` shim (dead once util.mjs landed); `verifyReadback` now defaults to
+   `util.mjs normTerm`. The edge test vector suite was retargeted to util's normTerm
+   (structured uri cell now canonicalizes to `<urn:x>` — dialect change is intentional
+   and tolerated by verifyReadback's unwrapIri).
+4. `scenario.mjs` ledger-unavailable signature deltas now emit `gatedTotal`/
+   `recordedTotal` `null` (was `0`) + `ledgerVersion: null`, matching
+   `fleet.journalSignatureDeltas`' never-silent-zeroes discipline.

--- a/testnet/bin/harness.mjs
+++ b/testnet/bin/harness.mjs
@@ -29,7 +29,7 @@ import * as config from '../lib/config.mjs';
 import { EdgeClient } from '../lib/edge.mjs';
 import * as evidenceMod from '../lib/evidence.mjs';
 import * as fleetMod from '../lib/fleet.mjs';
-import { buildGates, runPublishScenario } from '../lib/scenario.mjs';
+import { buildGates, resolveCgMap, runPublishScenario } from '../lib/scenario.mjs';
 import * as scoringMod from '../lib/scoring.mjs';
 import { sleep } from '../lib/util.mjs';
 import * as watchMod from '../lib/watch.mjs';
@@ -249,6 +249,7 @@ export async function cmdCertify(args, deps = {}) {
     EdgeClient,
     runScenario: runPublishScenario,
     buildGates,
+    resolveCgMap,
     writeFile: writeFileSync,
     log: console.log,
     error: console.error,
@@ -375,6 +376,19 @@ export async function cmdCertify(args, deps = {}) {
     pass: 'skipped',
     evidence: { todo: 'CG registration/visibility preflight not implemented in Phase 0' },
   });
+  // reuse:<name> CG mappings must resolve via local fleet.json cgs (S6: actual
+  // ids stay out of committed files and out of evidence — logical names only).
+  let cgMap = null;
+  try {
+    cgMap = d.resolveCgMap(scenario, fleet);
+    checks.push({
+      id: 'cg_mapping_resolved',
+      pass: true,
+      evidence: { lanes: Object.fromEntries(Object.entries(cgMap).map(([l, s]) => [l, s.logical])) },
+    });
+  } catch (err) {
+    checks.push({ id: 'cg_mapping_resolved', pass: false, evidence: { problem: String(err?.message ?? err) } });
+  }
 
   const preflightOk = checks.every((c) => c.pass === true || c.pass === 'skipped');
   evidence.write('preflight', {
@@ -423,7 +437,7 @@ export async function cmdCertify(args, deps = {}) {
   const ledger = existsSync(ledgerPath) ? d.loadLedger(ledgerPath) : null;
 
   const run = await d.runScenario({
-    scenario, fleet, policy, edge, evidence, runId, baseline, ledger,
+    scenario, fleet, policy, edge, evidence, runId, baseline, ledger, cgMap,
   });
 
   if (run.safetyAborted) {

--- a/testnet/bin/harness.mjs
+++ b/testnet/bin/harness.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // OT-RFC-61 testnet harness CLI — mode dispatch + run lifecycle (§4.1).
-// CONTRACT FILE: implementors replace TODO bodies; flags are frozen:
+// Flags are frozen:
 //   harness.mjs <selftest|monitor|baseline|certify> [--scenario <name>]
 //     [--fleet <path>] [--policy <path>] [--run-id <id>] [--runs-dir <path>]
 //     [--interval <sec>] [--once] [--autonomous] [--json]
@@ -20,6 +20,540 @@
 // baseline: one full snapshot + cursors + attestation, written as evidence.
 // selftest: node --test test/ + validate fleet/policy/scenarios if present.
 
-async function main() { throw new Error('TODO'); }
+import { spawn } from 'node:child_process';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
-main().catch((err) => { console.error(err?.stack || String(err)); process.exit(4); });
+import * as config from '../lib/config.mjs';
+import { EdgeClient } from '../lib/edge.mjs';
+import * as evidenceMod from '../lib/evidence.mjs';
+import * as fleetMod from '../lib/fleet.mjs';
+import { buildGates, runPublishScenario } from '../lib/scenario.mjs';
+import * as scoringMod from '../lib/scoring.mjs';
+import { sleep } from '../lib/util.mjs';
+import * as watchMod from '../lib/watch.mjs';
+
+export const BASE_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+export const USAGE = [
+  'usage: harness.mjs <selftest|monitor|baseline|certify>',
+  '         [--scenario <name>] [--fleet <path>] [--policy <path>]',
+  '         [--run-id <id>] [--runs-dir <path>] [--interval <sec>]',
+  '         [--once] [--autonomous] [--json]',
+].join('\n');
+
+export class UsageError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'UsageError';
+    this.exitCode = 4;
+  }
+}
+
+const MODES = ['selftest', 'monitor', 'baseline', 'certify'];
+const VALUE_FLAGS = {
+  '--scenario': 'scenario',
+  '--fleet': 'fleet',
+  '--policy': 'policy',
+  '--run-id': 'runId',
+  '--runs-dir': 'runsDir',
+  '--interval': 'intervalSec',
+};
+const BOOL_FLAGS = { '--once': 'once', '--autonomous': 'autonomous', '--json': 'json' };
+
+/** Parse argv (post-node, post-script). Throws UsageError (exitCode 4). */
+export function parseArgs(argv) {
+  const out = {
+    mode: null,
+    scenario: 'certify-100',
+    fleet: join(BASE_DIR, 'fleet.json'),
+    policy: join(BASE_DIR, 'policy.json'),
+    runId: null,
+    runsDir: join(BASE_DIR, 'runs'),
+    intervalSec: 10,
+    once: false,
+    autonomous: false,
+    json: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (!arg.startsWith('--')) {
+      if (out.mode) throw new UsageError(`unexpected argument: ${arg}`);
+      if (!MODES.includes(arg)) throw new UsageError(`unknown mode: ${arg}`);
+      out.mode = arg;
+      continue;
+    }
+    if (arg in VALUE_FLAGS) {
+      const value = argv[++i];
+      if (value == null || value.startsWith('--')) throw new UsageError(`${arg} requires a value`);
+      if (arg === '--interval') {
+        const n = Number(value);
+        if (!Number.isFinite(n) || n <= 0) throw new UsageError('--interval must be a positive number of seconds');
+        out.intervalSec = n;
+      } else {
+        out[VALUE_FLAGS[arg]] = value;
+      }
+    } else if (arg in BOOL_FLAGS) {
+      out[BOOL_FLAGS[arg]] = true;
+    } else {
+      throw new UsageError(`unknown flag: ${arg}`);
+    }
+  }
+  if (!out.mode) throw new UsageError('a mode is required');
+  return out;
+}
+
+function fmtMb(bytes) {
+  return Number.isFinite(bytes) ? `${Math.round(bytes / 1e6)}M` : '-';
+}
+
+function fmtGb(bytes) {
+  return Number.isFinite(bytes) ? `${(bytes / 1e9).toFixed(1)}G` : '-';
+}
+
+/** Fixed-width fleet table (aliases only — S6). Degrades per-core. */
+export function formatMonitorTable(snapshot) {
+  const cols = [
+    ['alias', 10], ['state', 12], ['commit', 10], ['rss', 8],
+    ['mem%', 6], ['recvq', 6], ['disk', 8], ['restarts', 8],
+  ];
+  const row = (values) => values.map((v, i) => String(v).padEnd(cols[i][1])).join(' ');
+  const lines = [row(cols.map(([name]) => name))];
+  for (const core of snapshot?.cores || []) {
+    if (core.reachable === false) {
+      lines.push(row([core.alias ?? '?', 'UNREACHABLE', '-', '-', '-', '-', '-', '-']));
+      continue;
+    }
+    const cg = core.cgroup || {};
+    const ceiling = Number.isFinite(cg.memoryHigh) && cg.memoryHigh > 0 ? cg.memoryHigh
+      : Number.isFinite(cg.memoryMax) && cg.memoryMax > 0 ? cg.memoryMax : null;
+    const memPct = ceiling != null && Number.isFinite(cg.memoryCurrent)
+      ? `${Math.round((cg.memoryCurrent / ceiling) * 100)}%` : '-';
+    lines.push(row([
+      core.alias ?? '?',
+      core.systemd?.activeState ?? '?',
+      String(core.build?.commit ?? '').slice(0, 8) || '-',
+      fmtMb(core.rss),
+      memPct,
+      core.listen?.recvQ ?? '-',
+      fmtGb(core.diskFree?.bytes),
+      core.systemd?.nRestarts ?? '-',
+    ]));
+  }
+  return lines.join('\n');
+}
+
+/** Replace path-flag values so evidence never carries local paths (S6). */
+export function sanitizeArgv(argv) {
+  const pathFlags = new Set(['--fleet', '--policy', '--runs-dir']);
+  const out = [];
+  for (let i = 0; i < argv.length; i++) {
+    out.push(argv[i]);
+    if (pathFlags.has(argv[i]) && i + 1 < argv.length) {
+      out.push('<path>');
+      i++;
+    }
+  }
+  return out;
+}
+
+function harnessVersion() {
+  try {
+    return JSON.parse(readFileSync(join(BASE_DIR, 'package.json'), 'utf8')).version || '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+}
+
+// ── monitor ─────────────────────────────────────────────────────────────────
+
+export async function cmdMonitor(args, deps = {}) {
+  const loadFleet = deps.loadFleet || config.loadFleet;
+  const snapshotFleet = deps.snapshotFleet || fleetMod.snapshotFleet;
+  const log = deps.log || console.log;
+  const sleepFn = deps.sleep || sleep;
+  let fleet;
+  try {
+    fleet = loadFleet(args.fleet);
+  } catch (error) {
+    console.error(`monitor: cannot load fleet config: ${error.message}`);
+    return 4;
+  }
+  const writer = args.runId
+    ? new (deps.EvidenceWriter || evidenceMod.EvidenceWriter)({ runId: args.runId, runsDir: args.runsDir })
+    : null;
+  for (;;) {
+    const snapshot = await snapshotFleet(fleet, { light: true });
+    log(formatMonitorTable(snapshot));
+    if (writer) {
+      writer.write('fleet_snapshot', {
+        kind: snapshot.kind ?? 'light',
+        snapshotTs: snapshot.ts ?? null,
+        cores: snapshot.cores ?? [],
+      });
+    }
+    if (args.once) return 0;
+    await sleepFn(args.intervalSec * 1000);
+  }
+}
+
+// ── baseline ────────────────────────────────────────────────────────────────
+
+export async function cmdBaseline(args, deps = {}) {
+  const loadFleet = deps.loadFleet || config.loadFleet;
+  const snapshotFleet = deps.snapshotFleet || fleetMod.snapshotFleet;
+  const captureJournalCursors = deps.captureJournalCursors || fleetMod.captureJournalCursors;
+  const attestBuildIdentity = deps.attestBuildIdentity || fleetMod.attestBuildIdentity;
+  const log = deps.log || console.log;
+  let fleet;
+  try {
+    fleet = loadFleet(args.fleet);
+  } catch (error) {
+    console.error(`baseline: cannot load fleet config: ${error.message}`);
+    return 4;
+  }
+  const runId = args.runId || (deps.makeRunId || evidenceMod.makeRunId)({ phase: 'baseline' });
+  const writer = new (deps.EvidenceWriter || evidenceMod.EvidenceWriter)({ runId, runsDir: args.runsDir });
+  const snapshot = await snapshotFleet(fleet, { light: false });
+  const cursors = await captureJournalCursors(fleet);
+  const attested = (snapshot.cores || []).map((core) => attestBuildIdentity(core));
+  writer.write('fleet_baseline', { snapshot, cursors, attested });
+  log(formatMonitorTable(snapshot));
+  log(`baseline evidence: ${writer.path}`);
+  return 0;
+}
+
+// ── certify ─────────────────────────────────────────────────────────────────
+
+const EXIT_BY_OUTCOME = { PASS: 0, FAIL: 1, INCONCLUSIVE: 2, SAFETY_ABORT: 3 };
+
+export async function cmdCertify(args, deps = {}) {
+  const d = {
+    loadFleet: config.loadFleet,
+    loadPolicy: config.loadPolicy,
+    loadScenario: config.loadScenario,
+    verifyCredentialIsolation: config.verifyCredentialIsolation,
+    snapshotFleet: fleetMod.snapshotFleet,
+    captureJournalCursors: fleetMod.captureJournalCursors,
+    attestBuildIdentity: fleetMod.attestBuildIdentity,
+    loadLedger: fleetMod.loadLedger,
+    safetyAbortGate: watchMod.safetyAbortGate,
+    recordSafetyAbort: watchMod.recordSafetyAbort,
+    evaluateGate: scoringMod.evaluateGate,
+    computeVerdict: scoringMod.computeVerdict,
+    formatVerdict: scoringMod.formatVerdict,
+    EvidenceWriter: evidenceMod.EvidenceWriter,
+    makeRunId: evidenceMod.makeRunId,
+    buildManifest: evidenceMod.buildManifest,
+    EdgeClient,
+    runScenario: runPublishScenario,
+    buildGates,
+    writeFile: writeFileSync,
+    log: console.log,
+    error: console.error,
+    ...deps,
+  };
+
+  // S3: the cooldown gate runs before anything else — a prior SAFETY_ABORT
+  // blocks new load-generating runs until cleared.
+  const gate = d.safetyAbortGate({ runsDir: args.runsDir });
+  if (gate?.blocked) {
+    d.error(`certify: blocked by safety-abort cooldown${gate.until ? ` until ${gate.until}` : ''} `
+      + '(remove runs/safety-abort.json to clear manually)');
+    return 3;
+  }
+
+  let fleet;
+  let policy;
+  let scenarioLoad;
+  try {
+    fleet = d.loadFleet(args.fleet);
+    policy = d.loadPolicy(args.policy);
+    scenarioLoad = d.loadScenario(args.scenario, { policy, baseDir: BASE_DIR });
+  } catch (error) {
+    d.error(`certify: config error: ${error.message}`);
+    return 4;
+  }
+  const scenario = scenarioLoad.scenario;
+  const scenarioDigest = scenarioLoad.digest;
+
+  if (!fleet.edges?.driver) {
+    d.error('certify: fleet.json has no driver edge configured');
+    return 4;
+  }
+
+  // Driver edge status first: supplies the sha8 for the run id and the
+  // commit-attestation preflight check.
+  let edge = null;
+  let driverStatus = null;
+  let driverStatusError = null;
+  try {
+    edge = new d.EdgeClient({
+      dkgHome: fleet.edges.driver.dkgHome,
+      apiPort: fleet.edges.driver.apiPort,
+      label: 'driver',
+    });
+    driverStatus = await edge.status();
+  } catch (error) {
+    driverStatusError = String(error?.message || error);
+  }
+  const sha8 = String(driverStatus?.commit || '').slice(0, 8) || undefined;
+  const runId = args.runId || d.makeRunId({ phase: 'certify', sha8 });
+  const evidence = new d.EvidenceWriter({ runId, runsDir: args.runsDir });
+
+  evidence.write('run_start', {
+    mode: 'certify',
+    scenario: args.scenario,
+    scenarioDigest,
+    fleetDigest: fleet.digest ?? null,
+    policyDigest: policy.digest ?? null,
+    harnessVersion: harnessVersion(),
+    argv: sanitizeArgv(['certify', ...process.argv.slice(3)]),
+    runMode: args.autonomous ? 'autonomous' : 'interactive',
+  });
+
+  // S2: autonomous runs refuse to start without verified credential isolation.
+  let credentialIsolation = null;
+  if (args.autonomous) {
+    credentialIsolation = await d.verifyCredentialIsolation(fleet, { mode: 'autonomous' });
+  }
+
+  // Preflight (§4.1/§3.3): full fleet reachable + observable, driver edge
+  // healthy with an attested commit. Wallet/CG checks are honestly recorded as
+  // skipped in Phase 0 (TODO: S4 wallet/faucet + CG-visibility preflight).
+  const baselineSnapshot = await d.snapshotFleet(fleet, { light: false });
+  const attested = (baselineSnapshot.cores || []).map((core) => d.attestBuildIdentity(core));
+  const checks = [];
+  const expectedCores = (fleet.cores || []).length;
+  const reachableCores = (baselineSnapshot.cores || []).filter((c) => c.reachable !== false);
+  checks.push({
+    id: 'fleet_reachable',
+    pass: expectedCores > 0 && reachableCores.length === expectedCores,
+    evidence: {
+      expected: expectedCores,
+      reachable: reachableCores.length,
+      unreachable: (baselineSnapshot.cores || [])
+        .filter((c) => c.reachable === false)
+        .map((c) => c.alias),
+    },
+  });
+  checks.push({
+    id: 'fleet_build_identity_attested',
+    pass: attested.length === expectedCores && attested.every((a) => a.attested === true),
+    evidence: attested.map((a) => ({
+      alias: a.alias, commit: a.commit ?? null, attested: a.attested === true,
+      inconclusiveReason: a.inconclusiveReason ?? null,
+    })),
+  });
+  checks.push({
+    id: 'driver_edge_status',
+    pass: driverStatus != null,
+    evidence: driverStatus
+      ? { label: 'driver', commit: driverStatus.commit ?? null }
+      : { label: 'driver', error: driverStatusError },
+  });
+  checks.push({
+    id: 'driver_edge_commit_attested',
+    pass: Boolean(driverStatus?.commit),
+    evidence: { commit: driverStatus?.commit ?? null },
+  });
+  if (args.autonomous) {
+    checks.push({
+      id: 'credential_isolation',
+      pass: credentialIsolation?.ok === true,
+      evidence: credentialIsolation?.checks ?? null,
+    });
+  }
+  checks.push({
+    id: 'wallets_funded',
+    pass: 'skipped',
+    evidence: { todo: 'S4 wallet/faucet preflight not implemented in Phase 0' },
+  });
+  checks.push({
+    id: 'context_graphs_visible',
+    pass: 'skipped',
+    evidence: { todo: 'CG registration/visibility preflight not implemented in Phase 0' },
+  });
+
+  const preflightOk = checks.every((c) => c.pass === true || c.pass === 'skipped');
+  evidence.write('preflight', {
+    outcome: preflightOk ? 'ok' : 'inconclusive',
+    mode: args.autonomous ? 'autonomous' : 'interactive',
+    checks,
+    edges: { driver: { label: 'driver', commit: driverStatus?.commit ?? null } },
+    cores: attested,
+  });
+
+  const skipped = checks.filter((c) => c.pass === 'skipped').map((c) => `preflight:${c.id}`);
+  const verdictPath = join(args.runsDir, `${runId}.verdict.json`);
+  const writeVerdictFile = (body) => d.writeFile(verdictPath, `${JSON.stringify(body, null, 2)}\n`);
+
+  if (!preflightOk) {
+    // §3.3: a degraded fleet is not loaded — INCONCLUSIVE, workload NOT_RUN.
+    const notRun = [`workload:${args.scenario}`, ...skipped];
+    evidence.write('run_verdict', { outcome: 'INCONCLUSIVE', gates: [], notRun, reason: 'preflight_failed' });
+    writeVerdictFile({
+      scenario: args.scenario,
+      run_id: runId,
+      outcome: 'INCONCLUSIVE',
+      gates: [],
+      notRun,
+      inconclusive_reasons: checks.filter((c) => c.pass === false).map((c) => c.id),
+      evidence: evidence.path,
+    });
+    d.error(`certify: preflight failed — workload NOT_RUN (verdict: ${verdictPath})`);
+    return 2;
+  }
+
+  // Baseline: full snapshot + journal cursors + attestation (exact deltas).
+  const cursors = await d.captureJournalCursors(fleet);
+  const baseline = { snapshot: baselineSnapshot, cursors, attested };
+  evidence.write('fleet_baseline', {
+    snapshot: {
+      kind: baselineSnapshot.kind ?? 'full',
+      snapshotTs: baselineSnapshot.ts ?? null,
+      cores: baselineSnapshot.cores ?? [],
+    },
+    cursors,
+    attested,
+  });
+
+  const ledgerPath = join(BASE_DIR, 'ledger.json');
+  const ledger = existsSync(ledgerPath) ? d.loadLedger(ledgerPath) : null;
+
+  const run = await d.runScenario({
+    scenario, fleet, policy, edge, evidence, runId, baseline, ledger,
+  });
+
+  if (run.safetyAborted) {
+    d.recordSafetyAbort({ runsDir: args.runsDir, runId, trips: run.trips, policy });
+  }
+
+  const gateInputs = d.buildGates({ scenario, run, baseline });
+  const gates = gateInputs.map((input) => d.evaluateGate(input));
+  const verdict = d.computeVerdict({ gates, safetyAbort: run.safetyAborted });
+
+  const notRun = [...skipped];
+  if (run.safetyAborted) notRun.push(`workload-remainder:${args.scenario}`);
+  const permanentBytesWritten = (run.opResults || [])
+    .filter((o) => o.outcome === 'success')
+    .reduce((n, o) => n + (o.bytes || 0), 0);
+  const manifest = d.buildManifest({
+    attested: { cores: attested, driver: { label: 'driver', commit: driverStatus?.commit ?? null } },
+    scenario,
+    scenarioDigest,
+    fleetDigest: fleet.digest ?? null,
+    policyDigest: policy.digest ?? null,
+    gates: verdict.gates,
+    notRun,
+    permanentBytesWritten,
+  });
+  evidence.write('run_manifest', manifest);
+  evidence.write('run_verdict', { outcome: verdict.outcome, gates: verdict.gates, notRun });
+  writeVerdictFile({
+    scenario: args.scenario,
+    run_id: runId,
+    outcome: verdict.outcome,
+    gates: verdict.gates,
+    notRun,
+    safety_abort: run.safetyAborted === true,
+    trips: run.trips || [],
+    evidence: evidence.path,
+  });
+
+  if (args.json) {
+    d.log(JSON.stringify({ outcome: verdict.outcome, gates: verdict.gates, verdict: verdictPath }, null, 2));
+  } else {
+    d.log(d.formatVerdict(verdict));
+    d.log(`verdict: ${verdictPath}`);
+  }
+  return EXIT_BY_OUTCOME[verdict.outcome] ?? 1;
+}
+
+// ── selftest ────────────────────────────────────────────────────────────────
+
+export async function cmdSelftest(args, deps = {}) {
+  const spawnFn = deps.spawn || spawn;
+  const log = deps.log || console.log;
+  const problems = [];
+
+  const testDir = join(BASE_DIR, 'test');
+  if (existsSync(testDir)) {
+    // Default discovery (bare `node --test`, cwd = package root): a directory
+    // positional is spawned as an entry module on Node >= 22.16 and fails with
+    // "Cannot find module .../test", so never pass test/ as an argument.
+    const testsOk = await new Promise((resolveP) => {
+      const child = spawnFn(process.execPath, ['--test'], { stdio: 'inherit', cwd: BASE_DIR });
+      child.on('error', () => resolveP(false));
+      child.on('exit', (code) => resolveP(code === 0));
+    });
+    if (!testsOk) problems.push('node --test failed');
+  } else {
+    log('selftest: no test/ directory yet (unit tests skipped)');
+  }
+
+  // Config validation — only against files that exist; examples as fallback.
+  let policy = null;
+  const policyPath = existsSync(args.policy) ? args.policy : join(BASE_DIR, 'policy.example.json');
+  try {
+    policy = config.loadPolicy(policyPath);
+    log(`selftest: policy ok (${policyPath === args.policy ? 'policy.json' : 'policy.example.json'})`);
+  } catch (error) {
+    problems.push(`policy invalid: ${error.message}`);
+  }
+  const fleetPath = existsSync(args.fleet) ? args.fleet : join(BASE_DIR, 'fleet.example.json');
+  try {
+    config.loadFleet(fleetPath);
+    log(`selftest: fleet ok (${fleetPath === args.fleet ? 'fleet.json' : 'fleet.example.json'})`);
+  } catch (error) {
+    problems.push(`fleet invalid: ${error.message}`);
+  }
+  if (policy) {
+    try {
+      const manifest = JSON.parse(readFileSync(join(BASE_DIR, 'scenarios.json'), 'utf8'));
+      for (const name of manifest.scenarios || []) {
+        config.loadScenario(name, { policy, baseDir: BASE_DIR });
+      }
+      log(`selftest: scenarios ok (${(manifest.scenarios || []).join(', ')})`);
+    } catch (error) {
+      problems.push(`scenario validation: ${error.message}`);
+    }
+  }
+
+  for (const problem of problems) console.error(`selftest problem: ${problem}`);
+  log(problems.length === 0 ? 'selftest: PASS' : 'selftest: FAIL');
+  return problems.length === 0 ? 0 : 1;
+}
+
+// ── dispatch ────────────────────────────────────────────────────────────────
+
+export async function main(argv = process.argv.slice(2)) {
+  let args;
+  try {
+    args = parseArgs(argv);
+  } catch (error) {
+    if (error instanceof UsageError) {
+      console.error(error.message);
+      console.error(USAGE);
+      return 4;
+    }
+    throw error;
+  }
+  switch (args.mode) {
+    case 'selftest': return cmdSelftest(args);
+    case 'monitor': return cmdMonitor(args);
+    case 'baseline': return cmdBaseline(args);
+    case 'certify': return cmdCertify(args);
+    default: return 4; // unreachable — parseArgs validates the mode
+  }
+}
+
+// Only run when invoked as a script, so tests can import the exported helpers.
+const invokedAsScript = process.argv[1]
+  && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (invokedAsScript) {
+  main()
+    .then((code) => process.exit(code ?? 0))
+    .catch((err) => { console.error(err?.stack || String(err)); process.exit(4); });
+}

--- a/testnet/bin/harness.mjs
+++ b/testnet/bin/harness.mjs
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+// OT-RFC-61 testnet harness CLI — mode dispatch + run lifecycle (§4.1).
+// CONTRACT FILE: implementors replace TODO bodies; flags are frozen:
+//   harness.mjs <selftest|monitor|baseline|certify> [--scenario <name>]
+//     [--fleet <path>] [--policy <path>] [--run-id <id>] [--runs-dir <path>]
+//     [--interval <sec>] [--once] [--autonomous] [--json]
+//
+// Lifecycle (certify): safetyAbortGate → load config/policy/scenario →
+// (autonomous ? verifyCredentialIsolation : record interactive) → preflight
+// (edges healthy incl. driver /api/status commit attestation; FULL fleet
+// reachable+observable — degraded ⇒ INCONCLUSIVE + workload NOT_RUN (§3.3);
+// wallets funded; CGs visible) → fleet_baseline + cursors + attestation →
+// runPublishScenario → buildGates → computeVerdict (SAFETY_ABORT terminal) →
+// run_manifest + run_verdict + verdict.json next to the evidence file →
+// exit codes: 0 PASS, 1 FAIL, 2 INCONCLUSIVE, 3 SAFETY_ABORT, 4 usage/config.
+//
+// monitor: light snapshot loop (--interval, default 10 s; --once for a single
+// pass) printing a fixed-width fleet table (alias, state, commit, rss, mem%,
+// recvq, disk, restarts) and writing fleet_snapshot records when --run-id given.
+// baseline: one full snapshot + cursors + attestation, written as evidence.
+// selftest: node --test test/ + validate fleet/policy/scenarios if present.
+
+async function main() { throw new Error('TODO'); }
+
+main().catch((err) => { console.error(err?.stack || String(err)); process.exit(4); });

--- a/testnet/fixtures/journal-sample.txt
+++ b/testnet/fixtures/journal-sample.txt
@@ -1,0 +1,31 @@
+publish completed ual=did:dkg:base:84532/0xabc/41 in 4210 ms
+listGraphs query timed out after 30000 ms
+sync round complete in 1200 ms
+TimeoutError while running listGraphs against store
+sync request to core-2 timed out (30s)
+GET /api/status 200 in 3 ms
+deadline exceeded during sync catch-up
+store_scheduler_busy: queue depth 128
+operation rejected: queue_wait_timeout after 5000ms
+enqueue failed: queue_full
+worker heartbeat seq=4290 ok
+publish job failed: quorum exhausted after 5 attempts
+QuorumUnmetError: replication quorum impossible
+storage_ack_timeout waiting for member ack
+harmless mention of quorum reached on first attempt
+process killed by cgroup limit: memory.events oom_kill incremented
+oxigraph worker exited with SIGKILL
+A process of this unit has been killed by the OOM killer.
+rejected duplicate publish for ual did:dkg:base:84532/0xabc/7
+transaction already known: duplicate nonce detected
+info: accepted new connection from peer
+forced redial of peer after stall
+watchdog: forced-redial triggered for relay peer
+rpc provider returned HTTP 429 Too Many Requests
+full-pool throttling engaged for provider quota
+listen backlog saturated: accept queue overflow suspected
+changelog.headSeq recomputed via MAX(?seq) full scan
+deleteByPattern.countBefore=182931 countAfter=182930
+store compaction finished before deadline
+store write deadline exceeded (write lane)
+SPARQL probe queryBytes=71 timed out

--- a/testnet/fleet.example.json
+++ b/testnet/fleet.example.json
@@ -1,0 +1,37 @@
+{
+  "$comment": "OT-RFC-61 §3.3/§8 S6: real topology lives ONLY in fleet.json (gitignored). Cores appear in evidence solely by their alias.",
+  "schemaVersion": 1,
+  "network": "base:84532",
+  "cores": [
+    {
+      "alias": "core-1",
+      "host": "100.64.0.10",
+      "sshUser": "observer",
+      "sshIdentity": "~/.ssh/id_harness_readonly",
+      "systemdUnit": "dkg-node",
+      "apiPort": 9200,
+      "listenPort": 9090,
+      "storeFilesystem": "/",
+      "roles": ["core", "relay"]
+    },
+    {
+      "alias": "core-2",
+      "host": "100.64.0.11",
+      "sshUser": "observer",
+      "sshIdentity": "~/.ssh/id_harness_readonly",
+      "systemdUnit": "dkg-node",
+      "apiPort": 9200,
+      "listenPort": 9090,
+      "storeFilesystem": "/",
+      "roles": ["core"]
+    }
+  ],
+  "edges": {
+    "driver": { "dkgHome": "~/.dkg-tn-edge", "apiPort": 9210 },
+    "observer": { "dkgHome": "~/.dkg-tn-observer", "apiPort": 9211 },
+    "nonMember": null
+  },
+  "seeds": [],
+  "sshConcurrency": 2,
+  "sshConnectTimeoutSec": 8
+}

--- a/testnet/ledger.json
+++ b/testnet/ledger.json
@@ -1,0 +1,79 @@
+{
+  "$comment": "OT-RFC-61 §9.2 forbidden-signature ledger. Patterns are POSIX-ERE-compatible regex sources applied PER LINE against the LOWERCASED journal text (journalctl -o cat) — identically by the remote awk pass and the local JS counter (lib/fleet.mjs signatureCountsFromText). Patterns must not contain single quotes or forward slashes (they are embedded in a single-quoted remote awk program) and must avoid awk-hostile syntax (no lookaround, no {n,m} intervals, no \\b). Dispositions: gated = any occurrence fails a binding goal; recorded = reported, never gated. The ledger is versioned against node releases: a wording change that silences a class is ledger breakage (scored INCONCLUSIVE), not zero occurrences. Classes ported from the OT-RFC-59 harness 12-class awk program.",
+  "version": 1,
+  "appliesTo": "ot-node v10 canary journals (Base-Sepolia testnet fleet), journalctl -o cat",
+  "classes": [
+    {
+      "id": "listgraphs_timeout",
+      "disposition": "gated",
+      "pattern": "listgraphs.*(timed out|timeout error|timeouterror|deadline exceeded)|(timed out|timeout error|timeouterror|deadline exceeded).*listgraphs",
+      "description": "listGraphs store scan timed out or exceeded a deadline — the O(store) responder-livelock family behind the 2026-06/07 sync storms (rfc59 class listgraphs_timeouts)."
+    },
+    {
+      "id": "sync_timeout",
+      "disposition": "gated",
+      "pattern": "sync.*(timed out|timeout error|timeouterror|deadline exceeded)|(timed out|timeout error|timeouterror|deadline exceeded).*sync",
+      "description": "A sync/catch-up operation timed out or exceeded its deadline (rfc59 class sync_timeouts)."
+    },
+    {
+      "id": "scheduler_saturation",
+      "disposition": "gated",
+      "pattern": "store_scheduler_busy|queue_wait_timeout|queue_full",
+      "description": "Store scheduler/queue saturation markers: store_scheduler_busy, queue_wait_timeout, queue_full (rfc59 class scheduler_busy)."
+    },
+    {
+      "id": "quorum_terminal_failure",
+      "disposition": "gated",
+      "pattern": "quorum.*(terminal|exhausted|failed permanently|job failed|impossible|no longer reachable)|quorumunmeterror|storage_ack_timeout",
+      "description": "A publish/replication quorum failed terminally (exhausted, impossible, QuorumUnmetError) or a storage ACK timed out (rfc59 class terminal_quorum_failures)."
+    },
+    {
+      "id": "oom_sigkill",
+      "disposition": "gated",
+      "pattern": "oom_kill|oom-kill|oom killer|out of memory|oxigraph.*sigkill|sigkill.*oxigraph",
+      "description": "cgroup OOM kill events, kernel OOM verdicts surfaced by systemd, or the oxigraph store worker dying by SIGKILL (rfc59 class oom_signals)."
+    },
+    {
+      "id": "duplicate_publish",
+      "disposition": "gated",
+      "pattern": "duplicate.*(publish|transaction)|(publish|transaction).*duplicate",
+      "description": "Duplicate publish or duplicate transaction detected — idempotency regression (rfc59 class duplicate_publishes)."
+    },
+    {
+      "id": "forced_redial",
+      "disposition": "recorded",
+      "pattern": "forced redial|forced-redial",
+      "description": "Peer connection forced redial — churn indicator, expected at low rates on a live testnet; reported but never gated (rfc59 class forced_redials)."
+    },
+    {
+      "id": "rpc_throttle",
+      "disposition": "recorded",
+      "pattern": "(^|[^0-9])429([^0-9]|$)|full-pool thrott|too many requests",
+      "description": "Chain RPC throttling: HTTP 429, too-many-requests, or full-pool throttling engaged — provider-side pressure, recorded for context (rfc59 class rpc_throttles)."
+    },
+    {
+      "id": "accept_queue_marker",
+      "disposition": "recorded",
+      "pattern": "accept[ _-]?queue|listen backlog|syn flood",
+      "description": "Accept-queue / listen-backlog wedge markers. Corroboration only per S3: the 2026-07 wedge incident produced no distinctive log line; authoritative detection is the §9.1 socket capture (ss Recv-Q vs backlog) plus the out-of-band TCP connect probe."
+    },
+    {
+      "id": "ostore_scan_storm",
+      "disposition": "recorded",
+      "pattern": "max\\(.seq\\)|changelog\\.headseq|deletebypattern\\.count(before|after)",
+      "description": "O(store) scan-storm markers: changelog MAX(?seq) head recomputation and deleteByPattern catalog count scans (rfc59 classes changelog_max_seq_reads + catalog_count_scans, folded)."
+    },
+    {
+      "id": "store_deadline_timeout",
+      "disposition": "recorded",
+      "pattern": "store.*deadline.*(exceeded|timed out)",
+      "description": "A store operation exceeded its deadline — early scheduler-pressure indicator, recorded ahead of full saturation (rfc59 class store_deadline_timeouts)."
+    },
+    {
+      "id": "probe_query_timeout",
+      "disposition": "recorded",
+      "pattern": "(querybytes[^0-9]*71|71-byte).*(timed out|timeout error|timeouterror|deadline exceeded)|(timed out|timeout error|timeouterror|deadline exceeded).*(querybytes[^0-9]*71|71-byte)",
+      "description": "The tiny fixed-size (71-byte) probe query timed out — the store scheduler cannot serve even trivial reads (rfc59 class query71_timeouts, legacy incident probe kept for continuity)."
+    }
+  ]
+}

--- a/testnet/lib/config.mjs
+++ b/testnet/lib/config.mjs
@@ -166,11 +166,24 @@ export function loadFleet(path) {
     problems.push('fleet: sshConnectTimeoutSec must be a number > 0');
   }
 
+  if (json.cgs !== undefined) {
+    if (!isObj(json.cgs)) {
+      problems.push('fleet: cgs must be an object mapping logical CG names to actual CG ids');
+    } else {
+      for (const [logical, actual] of Object.entries(json.cgs)) {
+        if (!ALIAS_RE_GENERIC.test(logical)) problems.push(`fleet: cgs key '${logical}' must be a logical kebab name`);
+        // S6: never echo the actual id (may embed a wallet address) into errors.
+        if (!isNonEmptyStr(actual)) problems.push(`fleet: cgs['${logical}'] must be a non-empty CG id string`);
+      }
+    }
+  }
+
   throwIfProblems(problems);
   return {
     cores: json.cores,
     edges: json.edges,
     seeds: json.seeds,
+    cgs: json.cgs ?? {},
     sshConcurrency: json.sshConcurrency,
     sshConnectTimeoutSec: json.sshConnectTimeoutSec,
     network: json.network,

--- a/testnet/lib/config.mjs
+++ b/testnet/lib/config.mjs
@@ -1,0 +1,45 @@
+// OT-RFC-61 §3.3/§8 — fleet/policy/scenario loading, validation, S2 credential check.
+// CONTRACT FILE: implementors replace TODO bodies; signatures are frozen.
+
+/**
+ * Load + validate fleet.json (see fleet.example.json). Throws with a list of
+ * problems on invalid shape. Returns {cores, edges, seeds, sshConcurrency,
+ * sshConnectTimeoutSec, network, digest} where digest = sha256 of file bytes.
+ * Aliases must be unique and match /^core-\d+$/ or /^[a-z][a-z0-9-]*$/.
+ * @param {string} path
+ */
+export function loadFleet(path) { throw new Error('TODO'); }
+
+/**
+ * Load + validate policy.json against policy.example.json's shape: every trip in
+ * the example MUST be present; values looser than hardMax are clamped-with-error.
+ * Returns {trips, quiesce, safetyAbort, permanentData, faucet, digest}.
+ * @param {string} path
+ */
+export function loadPolicy(path) { throw new Error('TODO'); }
+
+/**
+ * Load + validate a scenario by name from scenarios/<name>.json and check it is
+ * listed in scenarios.json. Scenario trip overrides may only TIGHTEN policy
+ * (S3) — validate against the loaded policy. Returns {scenario, digest}.
+ * @param {string} name @param {{policy: object, baseDir?: string}} opts
+ */
+export function loadScenario(name, opts) { throw new Error('TODO'); }
+
+/**
+ * S2 credential-isolation check for AUTONOMOUS mode (RFC-61 §8 S2).
+ * Verifies, without mutating anything:
+ *  1. No ambient SSH agent (SSH_AUTH_SOCK unset or empty agent).
+ *  2. The configured sshIdentity exists and is the ONLY credential offered
+ *     (BatchMode, IdentitiesOnly=yes).
+ *  3. A mutation probe is REFUSED: `ssh <core> -- sudo -n true` must fail AND
+ *     an arbitrary command (`echo x`) must NOT round-trip verbatim if a forced
+ *     command is configured (forced command returns snapshot output instead).
+ * Returns {ok: boolean, checks: Array<{id, pass, evidence}>}. NEVER throws on
+ * probe failure — reports. Interactive mode skips this and records mode.
+ * @param {object} fleet @param {{mode: 'autonomous'|'interactive'}} opts
+ */
+export async function verifyCredentialIsolation(fleet, opts) { throw new Error('TODO'); }
+
+/** sha256 hex digest of a file's bytes. @param {string} path */
+export function fileDigest(path) { throw new Error('TODO'); }

--- a/testnet/lib/config.mjs
+++ b/testnet/lib/config.mjs
@@ -1,5 +1,100 @@
 // OT-RFC-61 §3.3/§8 — fleet/policy/scenario loading, validation, S2 credential check.
-// CONTRACT FILE: implementors replace TODO bodies; signatures are frozen.
+//
+// Validation style: each loader collects EVERY problem it finds and throws a
+// single Error whose message is the problems joined with '; ' — one round trip
+// from a broken config file to a complete fix list.
+//
+// S6 hygiene: validation problems and credential-check evidence reference cores
+// by alias (or array index) only — never by host, sshUser, or identity path.
+
+import { execFile } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const PKG_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+// ── policy trip contract (mirrors policy.example.json; drift-guarded by test) ──
+//
+// `direction` states what LOOSER means for the trip's primary value:
+//   ceiling  → a HIGHER value is looser (more pressure tolerated before abort)
+//   floor    → a LOWER  value is looser (e.g. diskFreeFloorBytes: a lower floor
+//              lets the harness run a shared core closer to disk-full)
+//   boolean  → false is looser than true (false disables the trip)
+// `knobs` are secondary tuning fields with their own looseness direction:
+//   sustainSec ceiling                → longer sustain needed before PSI trips
+//   consecutiveProbeFailures ceiling  → more failed probes tolerated
+//   (admissionShedWindowSec is a ceiling: a longer window smooths transient
+//    shed bursts below the fraction threshold, so higher = looser.)
+export const POLICY_TRIPS = Object.freeze({
+  memoryPsiSomeAvg10: { direction: 'ceiling', type: 'number', knobs: { sustainSec: 'ceiling' } },
+  memoryCurrentVsHighFraction: { direction: 'ceiling', type: 'number' },
+  oomKillDelta: { direction: 'ceiling', type: 'number' },
+  coreUnreachableFromBaseline: { direction: 'ceiling', type: 'number' },
+  acceptQueueRecvQAtBacklog: { direction: 'boolean', type: 'boolean', knobs: { consecutiveProbeFailures: 'ceiling' } },
+  diskFreeFloorBytes: { direction: 'floor', type: 'number' },
+  diskFreeFloorFraction: { direction: 'floor', type: 'number' },
+  admissionShedWindowSec: { direction: 'ceiling', type: 'number' },
+  admissionShedFractionOfAttempts: { direction: 'ceiling', type: 'number' },
+  rpcExhaustionDeltaPerRun: { direction: 'ceiling', type: 'number' },
+});
+
+/** True when `value` is LOOSER than `bound` per the trip direction. Equal is never looser. */
+export function isLooser(value, bound, direction) {
+  if (direction === 'floor') return value < bound;
+  if (direction === 'ceiling') return value > bound;
+  if (direction === 'boolean') return value === false && bound === true;
+  throw new Error(`unknown trip direction: ${direction}`);
+}
+
+/** sha256 hex digest of a file's bytes. @param {string} path */
+export function fileDigest(path) {
+  return createHash('sha256').update(readFileSync(path)).digest('hex');
+}
+
+// ── shared low-level helpers ─────────────────────────────────────────────────
+
+function readJsonWithDigest(path, label, problems) {
+  let bytes;
+  try {
+    bytes = readFileSync(path);
+  } catch (e) {
+    problems.push(`${label}: cannot read file: ${e.code || e.message}`);
+    return { json: null, digest: null };
+  }
+  const digest = createHash('sha256').update(bytes).digest('hex');
+  try {
+    const json = JSON.parse(bytes.toString('utf8'));
+    if (json === null || typeof json !== 'object' || Array.isArray(json)) {
+      problems.push(`${label}: top level must be a JSON object`);
+      return { json: null, digest };
+    }
+    return { json, digest };
+  } catch (e) {
+    problems.push(`${label}: invalid JSON: ${e.message}`);
+    return { json: null, digest };
+  }
+}
+
+function throwIfProblems(problems) {
+  if (problems.length) throw new Error(problems.join('; '));
+}
+
+const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
+const isNonEmptyStr = (v) => typeof v === 'string' && v.trim().length > 0;
+const isFiniteNum = (v) => typeof v === 'number' && Number.isFinite(v);
+const isInt = (v) => Number.isInteger(v);
+const isPort = (v) => isInt(v) && v >= 1 && v <= 65535;
+
+// ── fleet ────────────────────────────────────────────────────────────────────
+
+const ALIAS_RE_CORE = /^core-\d+$/;
+const ALIAS_RE_GENERIC = /^[a-z][a-z0-9-]*$/;
+const NETWORK_RE = /^[a-z][a-z0-9-]*:\d+$/;
+const CORE_ROLES = new Set(['core', 'relay']);
+const EDGE_KEYS = ['driver', 'observer', 'nonMember'];
 
 /**
  * Load + validate fleet.json (see fleet.example.json). Throws with a list of
@@ -8,15 +103,181 @@
  * Aliases must be unique and match /^core-\d+$/ or /^[a-z][a-z0-9-]*$/.
  * @param {string} path
  */
-export function loadFleet(path) { throw new Error('TODO'); }
+export function loadFleet(path) {
+  const problems = [];
+  const { json, digest } = readJsonWithDigest(path, 'fleet', problems);
+  if (!json) throwIfProblems(problems);
+
+  if (json.schemaVersion !== 1) problems.push('fleet: schemaVersion must be 1');
+  if (!isNonEmptyStr(json.network) || !NETWORK_RE.test(json.network)) {
+    problems.push("fleet: network must be a '<chain>:<id>' string (e.g. base:84532)");
+  }
+
+  if (!Array.isArray(json.cores) || json.cores.length === 0) {
+    problems.push('fleet: cores must be a non-empty array');
+  } else {
+    const seen = new Set();
+    json.cores.forEach((core, i) => {
+      const where = isNonEmptyStr(core?.alias) ? `cores[${i}] (${core.alias})` : `cores[${i}]`;
+      if (!isObj(core)) { problems.push(`${where}: must be an object`); return; }
+      if (!isNonEmptyStr(core.alias) || !(ALIAS_RE_CORE.test(core.alias) || ALIAS_RE_GENERIC.test(core.alias))) {
+        problems.push(`cores[${i}]: alias must match /^core-\\d+$/ or /^[a-z][a-z0-9-]*$/`);
+      } else if (seen.has(core.alias)) {
+        problems.push(`cores[${i}]: duplicate alias '${core.alias}'`);
+      } else {
+        seen.add(core.alias);
+      }
+      // S6: never echo the VALUES of host/sshUser/sshIdentity into error text.
+      if (!isNonEmptyStr(core.host)) problems.push(`${where}: host must be a non-empty string`);
+      if (!isNonEmptyStr(core.sshUser)) problems.push(`${where}: sshUser must be a non-empty string`);
+      if (!isNonEmptyStr(core.sshIdentity)) problems.push(`${where}: sshIdentity must be a non-empty string`);
+      if (!isNonEmptyStr(core.systemdUnit)) problems.push(`${where}: systemdUnit must be a non-empty string`);
+      if (!isPort(core.apiPort)) problems.push(`${where}: apiPort must be an integer in 1..65535`);
+      if (!isPort(core.listenPort)) problems.push(`${where}: listenPort must be an integer in 1..65535`);
+      if (!isNonEmptyStr(core.storeFilesystem)) problems.push(`${where}: storeFilesystem must be a non-empty string`);
+      if (!Array.isArray(core.roles) || core.roles.length === 0) {
+        problems.push(`${where}: roles must be a non-empty array`);
+      } else {
+        for (const role of core.roles) {
+          if (!CORE_ROLES.has(role)) problems.push(`${where}: unknown role '${role}' (allowed: core, relay)`);
+        }
+      }
+    });
+  }
+
+  if (!isObj(json.edges)) {
+    problems.push('fleet: edges must be an object with driver/observer/nonMember keys');
+  } else {
+    for (const key of EDGE_KEYS) {
+      if (!(key in json.edges)) { problems.push(`fleet: edges.${key} missing (use null when absent)`); continue; }
+      const edge = json.edges[key];
+      if (edge === null) continue;
+      if (!isObj(edge)) { problems.push(`fleet: edges.${key} must be null or an object`); continue; }
+      if (!isNonEmptyStr(edge.dkgHome)) problems.push(`fleet: edges.${key}.dkgHome must be a non-empty string`);
+      if (!isPort(edge.apiPort)) problems.push(`fleet: edges.${key}.apiPort must be an integer in 1..65535`);
+    }
+  }
+
+  if (!Array.isArray(json.seeds)) problems.push('fleet: seeds must be an array');
+  if (!isInt(json.sshConcurrency) || json.sshConcurrency < 1) {
+    problems.push('fleet: sshConcurrency must be an integer >= 1');
+  }
+  if (!isFiniteNum(json.sshConnectTimeoutSec) || json.sshConnectTimeoutSec <= 0) {
+    problems.push('fleet: sshConnectTimeoutSec must be a number > 0');
+  }
+
+  throwIfProblems(problems);
+  return {
+    cores: json.cores,
+    edges: json.edges,
+    seeds: json.seeds,
+    sshConcurrency: json.sshConcurrency,
+    sshConnectTimeoutSec: json.sshConnectTimeoutSec,
+    network: json.network,
+    digest,
+  };
+}
+
+// ── policy ───────────────────────────────────────────────────────────────────
+
+function validateNumField(obj, name, label, problems, { min = null, integer = false } = {}) {
+  const v = obj?.[name];
+  if (!isFiniteNum(v) || (integer && !isInt(v)) || (min !== null && v < min)) {
+    problems.push(`${label}.${name} must be a ${integer ? 'integer' : 'number'}${min !== null ? ` >= ${min}` : ''}`);
+    return false;
+  }
+  return true;
+}
 
 /**
  * Load + validate policy.json against policy.example.json's shape: every trip in
- * the example MUST be present; values looser than hardMax are clamped-with-error.
+ * the example MUST be present; values looser than hardMax are rejected (part of
+ * the collected error list — S3 hard maxima are non-negotiable).
  * Returns {trips, quiesce, safetyAbort, permanentData, faucet, digest}.
  * @param {string} path
  */
-export function loadPolicy(path) { throw new Error('TODO'); }
+export function loadPolicy(path) {
+  const problems = [];
+  const { json, digest } = readJsonWithDigest(path, 'policy', problems);
+  if (!json) throwIfProblems(problems);
+
+  if (json.schemaVersion !== 1) problems.push('policy: schemaVersion must be 1');
+
+  if (!isObj(json.trips)) {
+    problems.push('policy: trips must be an object');
+  } else {
+    for (const [name, spec] of Object.entries(POLICY_TRIPS)) {
+      const trip = json.trips[name];
+      if (!isObj(trip)) { problems.push(`policy.trips.${name} missing (every trip in policy.example.json is required)`); continue; }
+      const typeOk = typeof trip.default === spec.type && typeof trip.hardMax === spec.type
+        && (spec.type !== 'number' || (isFiniteNum(trip.default) && isFiniteNum(trip.hardMax)));
+      if (!typeOk) {
+        problems.push(`policy.trips.${name}: default and hardMax must both be ${spec.type}s`);
+      } else if (isLooser(trip.default, trip.hardMax, spec.direction)) {
+        problems.push(`policy.trips.${name}: default ${trip.default} is LOOSER than hardMax ${trip.hardMax} `
+          + `(direction: ${spec.direction === 'floor' ? 'lower floor is looser' : spec.direction === 'ceiling' ? 'higher ceiling is looser' : 'false is looser than true'})`);
+      }
+      for (const knob of Object.keys(spec.knobs ?? {})) {
+        if (!isFiniteNum(trip[knob]) || trip[knob] <= 0) {
+          problems.push(`policy.trips.${name}.${knob} must be a number > 0`);
+        }
+      }
+    }
+    for (const name of Object.keys(json.trips)) {
+      if (name.startsWith('$')) continue;
+      if (!POLICY_TRIPS[name]) problems.push(`policy.trips.${name}: unknown trip (not in the policy.example.json contract)`);
+    }
+  }
+
+  if (!isObj(json.quiesce)) {
+    problems.push('policy: quiesce must be an object');
+  } else {
+    validateNumField(json.quiesce, 'flatCounterConfirmSec', 'policy.quiesce', problems, { min: 1 });
+    validateNumField(json.quiesce, 'edgeShutdownTimeoutSec', 'policy.quiesce', problems, { min: 1 });
+  }
+  if (!isObj(json.safetyAbort)) {
+    problems.push('policy: safetyAbort must be an object');
+  } else {
+    validateNumField(json.safetyAbort, 'cooldownMin', 'policy.safetyAbort', problems, { min: 0 });
+  }
+  if (!isObj(json.permanentData)) {
+    problems.push('policy: permanentData must be an object');
+  } else {
+    validateNumField(json.permanentData, 'lifetimeBudgetBytes', 'policy.permanentData', problems, { min: 1, integer: true });
+    validateNumField(json.permanentData, 'rollingWindowDays', 'policy.permanentData', problems, { min: 1 });
+    validateNumField(json.permanentData, 'rollingBudgetBytes', 'policy.permanentData', problems, { min: 1, integer: true });
+  }
+  if (!isObj(json.faucet)) {
+    problems.push('policy: faucet must be an object');
+  } else {
+    validateNumField(json.faucet, 'maxTopUpsPerRun', 'policy.faucet', problems, { min: 0, integer: true });
+    validateNumField(json.faucet, 'perWalletPer24h', 'policy.faucet', problems, { min: 0, integer: true });
+  }
+
+  throwIfProblems(problems);
+  return {
+    trips: json.trips,
+    quiesce: json.quiesce,
+    safetyAbort: json.safetyAbort,
+    permanentData: json.permanentData,
+    faucet: json.faucet,
+    digest,
+  };
+}
+
+// ── scenario ─────────────────────────────────────────────────────────────────
+
+const SCENARIO_NAME_RE = /^[a-z0-9][a-z0-9-]*$/;
+const SCENARIO_LANES = new Set(['public', 'private']);
+// Top-level shape contract per scenarios/certify-100.json.
+const SCENARIO_REQUIRED_KEYS = ['schemaVersion', 'scenario', 'lanes', 'cg', 'workload', 'measure', 'readback', 'soakSeconds', 'gates'];
+
+/** Tighten-only check for one scenario trip override vs the loaded policy value. */
+function checkOverrideTightens(problems, tripName, key, direction, overrideValue, policyValue, where) {
+  if (isLooser(overrideValue, policyValue, direction)) {
+    problems.push(`${where}: ${overrideValue} LOOSENS policy ${tripName}${key ? `.${key}` : ''} (${policyValue}) — S3 permits tighten-only`);
+  }
+}
 
 /**
  * Load + validate a scenario by name from scenarios/<name>.json and check it is
@@ -24,22 +285,295 @@ export function loadPolicy(path) { throw new Error('TODO'); }
  * (S3) — validate against the loaded policy. Returns {scenario, digest}.
  * @param {string} name @param {{policy: object, baseDir?: string}} opts
  */
-export function loadScenario(name, opts) { throw new Error('TODO'); }
+export function loadScenario(name, opts) {
+  const { policy, baseDir = PKG_ROOT } = opts ?? {};
+  if (!isObj(policy) || !isObj(policy.trips)) throw new Error('loadScenario: opts.policy must be a policy loaded via loadPolicy');
+  if (!isNonEmptyStr(name) || !SCENARIO_NAME_RE.test(name)) {
+    throw new Error(`scenario name '${name}' must match /^[a-z0-9][a-z0-9-]*$/`);
+  }
+
+  const problems = [];
+  const { json: manifest } = readJsonWithDigest(join(baseDir, 'scenarios.json'), 'scenarios.json', problems);
+  throwIfProblems(problems);
+  if (!Array.isArray(manifest.scenarios) || !manifest.scenarios.every(isNonEmptyStr)) {
+    throw new Error('scenarios.json: scenarios must be an array of names');
+  }
+  if (!manifest.scenarios.includes(name)) {
+    throw new Error(`scenario '${name}' is not listed in scenarios.json (drift guard: file and manifest must agree)`);
+  }
+
+  const { json: sc, digest } = readJsonWithDigest(join(baseDir, 'scenarios', `${name}.json`), `scenario ${name}`, problems);
+  if (!sc) throwIfProblems(problems);
+
+  for (const key of SCENARIO_REQUIRED_KEYS) {
+    if (!(key in sc)) problems.push(`scenario ${name}: missing required key '${key}' (shape per scenarios/certify-100.json)`);
+  }
+  if ('schemaVersion' in sc && sc.schemaVersion !== 1) problems.push(`scenario ${name}: schemaVersion must be 1`);
+  if ('scenario' in sc && sc.scenario !== name) problems.push(`scenario ${name}: 'scenario' field must equal the file basename (got '${sc.scenario}')`);
+
+  let lanes = [];
+  if ('lanes' in sc) {
+    if (!Array.isArray(sc.lanes) || sc.lanes.length === 0 || !sc.lanes.every((l) => SCENARIO_LANES.has(l))) {
+      problems.push(`scenario ${name}: lanes must be a non-empty array drawn from [public, private]`);
+    } else {
+      lanes = sc.lanes;
+    }
+  }
+  if ('cg' in sc) {
+    if (!isObj(sc.cg)) {
+      problems.push(`scenario ${name}: cg must be an object`);
+    } else {
+      for (const lane of lanes) {
+        if (!isNonEmptyStr(sc.cg[lane])) problems.push(`scenario ${name}: cg.${lane} must be a non-empty string`);
+      }
+    }
+  }
+  if ('workload' in sc) {
+    if (!isObj(sc.workload)) {
+      problems.push(`scenario ${name}: workload must be an object`);
+    } else {
+      const w = sc.workload;
+      if (!isNonEmptyStr(w.op)) problems.push(`scenario ${name}: workload.op must be a non-empty string`);
+      validateNumField(w, 'waves', `scenario ${name}: workload`, problems, { min: 1, integer: true });
+      if (!isObj(w.perWave)) {
+        problems.push(`scenario ${name}: workload.perWave must be an object`);
+      } else {
+        for (const lane of lanes) {
+          if (!isInt(w.perWave[lane]) || w.perWave[lane] < 1) {
+            problems.push(`scenario ${name}: workload.perWave.${lane} must be an integer >= 1`);
+          }
+        }
+      }
+      if (!isNonEmptyStr(w.entityShape)) problems.push(`scenario ${name}: workload.entityShape must be a non-empty string`);
+      validateNumField(w, 'controlFixtureEvery', `scenario ${name}: workload`, problems, { min: 0, integer: true });
+      // S3: every scenario declares max concurrency.
+      validateNumField(w, 'concurrency', `scenario ${name}: workload`, problems, { min: 1, integer: true });
+      if (!isNonEmptyStr(w.arrival)) problems.push(`scenario ${name}: workload.arrival must be a non-empty string`);
+    }
+  }
+  if ('measure' in sc && (!Array.isArray(sc.measure) || sc.measure.length === 0 || !sc.measure.every(isNonEmptyStr))) {
+    problems.push(`scenario ${name}: measure must be a non-empty array of strings`);
+  }
+  if ('readback' in sc) {
+    if (!isObj(sc.readback)) {
+      problems.push(`scenario ${name}: readback must be an object`);
+    } else {
+      if (!isNonEmptyStr(sc.readback.where)) problems.push(`scenario ${name}: readback.where must be a non-empty string`);
+      if (typeof sc.readback.byteExact !== 'boolean') problems.push(`scenario ${name}: readback.byteExact must be a boolean`);
+      validateNumField(sc.readback, 'chunkSize', `scenario ${name}: readback`, problems, { min: 1, integer: true });
+    }
+  }
+  if ('soakSeconds' in sc && (!isFiniteNum(sc.soakSeconds) || sc.soakSeconds < 0)) {
+    problems.push(`scenario ${name}: soakSeconds must be a number >= 0`);
+  }
+  if ('gates' in sc && !isObj(sc.gates)) problems.push(`scenario ${name}: gates must be an object`);
+
+  // ── S3 tighten-only: optional scenario.trips overrides vs loaded policy ──
+  if ('trips' in sc) {
+    if (!isObj(sc.trips)) {
+      problems.push(`scenario ${name}: trips must be an object of policy-trip overrides`);
+    } else {
+      for (const [tripName, override] of Object.entries(sc.trips)) {
+        if (tripName.startsWith('$')) continue;
+        const spec = POLICY_TRIPS[tripName];
+        const policyTrip = policy.trips[tripName];
+        if (!spec || !isObj(policyTrip)) {
+          problems.push(`scenario ${name}: trips.${tripName} is not a known policy trip`);
+          continue;
+        }
+        const where = `scenario ${name}: trips.${tripName}`;
+        if (typeof override === spec.type) {
+          checkOverrideTightens(problems, tripName, null, spec.direction, override, policyTrip.default, where);
+        } else if (isObj(override)) {
+          if ('default' in override) {
+            if (typeof override.default !== spec.type) {
+              problems.push(`${where}.default must be a ${spec.type}`);
+            } else {
+              checkOverrideTightens(problems, tripName, 'default', spec.direction, override.default, policyTrip.default, `${where}.default`);
+            }
+          }
+          for (const [knob, value] of Object.entries(override)) {
+            if (knob === 'default' || knob.startsWith('$')) continue;
+            const knobDirection = spec.knobs?.[knob];
+            if (!knobDirection) { problems.push(`${where}.${knob} is not a known knob for this trip`); continue; }
+            if (!isFiniteNum(value)) { problems.push(`${where}.${knob} must be a number`); continue; }
+            checkOverrideTightens(problems, tripName, knob, knobDirection, value, policyTrip[knob], `${where}.${knob}`);
+          }
+        } else {
+          problems.push(`${where} must be a ${spec.type} or an object override`);
+        }
+      }
+    }
+  }
+
+  // ── S3 tighten-only: gates.fleet keys that shadow policy trips (e.g. oomKillDelta) ──
+  if (isObj(sc.gates) && isObj(sc.gates.fleet)) {
+    for (const [gate, value] of Object.entries(sc.gates.fleet)) {
+      const spec = POLICY_TRIPS[gate];
+      const policyTrip = policy.trips[gate];
+      if (!spec || !isObj(policyTrip)) continue; // plain gate, not a trip shadow
+      const where = `scenario ${name}: gates.fleet.${gate}`;
+      if (typeof value !== spec.type) {
+        problems.push(`${where} must be a ${spec.type} (shadows a policy trip)`);
+      } else {
+        checkOverrideTightens(problems, gate, null, spec.direction, value, policyTrip.default, where);
+      }
+    }
+  }
+
+  throwIfProblems(problems);
+  return { scenario: sc, digest };
+}
+
+// ── S2 credential-isolation check ────────────────────────────────────────────
+
+function expandTilde(p, env) {
+  const home = env?.HOME || homedir();
+  return p.replace(/^~(?=\/|$)/, home);
+}
+
+/** Default exec: never throws; resolves {code, stdout, stderr, timedOut}. */
+function defaultExec(file, args, { timeoutMs = 20000, env } = {}) {
+  return new Promise((resolvePromise) => {
+    execFile(file, args, { timeout: timeoutMs, maxBuffer: 8 * 1024 * 1024, encoding: 'utf8', env }, (err, stdout, stderr) => {
+      if (!err) return resolvePromise({ code: 0, stdout: stdout ?? '', stderr: stderr ?? '', timedOut: false });
+      const timedOut = Boolean(err.killed || err.signal === 'SIGTERM');
+      const code = typeof err.code === 'number' ? err.code : 255; // ENOENT etc. → transport-class failure
+      resolvePromise({ code: timedOut ? null : code, stdout: stdout ?? '', stderr: stderr ?? '', timedOut });
+    });
+  });
+}
+
+function sshProbeArgs(core, remoteCmd, connectTimeoutSec, identityPath) {
+  return [
+    '-o', 'BatchMode=yes',
+    '-o', 'IdentitiesOnly=yes',
+    '-o', 'IdentityAgent=none',
+    '-o', `ConnectTimeout=${connectTimeoutSec}`,
+    '-o', 'StrictHostKeyChecking=accept-new',
+    '-i', identityPath,
+    `${core.sshUser}@${core.host}`,
+    '--', remoteCmd,
+  ];
+}
 
 /**
  * S2 credential-isolation check for AUTONOMOUS mode (RFC-61 §8 S2).
  * Verifies, without mutating anything:
  *  1. No ambient SSH agent (SSH_AUTH_SOCK unset or empty agent).
  *  2. The configured sshIdentity exists and is the ONLY credential offered
- *     (BatchMode, IdentitiesOnly=yes).
+ *     (BatchMode, IdentitiesOnly=yes; probes additionally pin IdentityAgent=none).
  *  3. A mutation probe is REFUSED: `ssh <core> -- sudo -n true` must fail AND
  *     an arbitrary command (`echo x`) must NOT round-trip verbatim if a forced
  *     command is configured (forced command returns snapshot output instead).
  * Returns {ok: boolean, checks: Array<{id, pass, evidence}>}. NEVER throws on
  * probe failure — reports. Interactive mode skips this and records mode.
+ * Optional (test) opts: _exec(file, args, {timeoutMs, env}) → {code, stdout,
+ * stderr, timedOut}; _env to replace process.env.
  * @param {object} fleet @param {{mode: 'autonomous'|'interactive'}} opts
  */
-export async function verifyCredentialIsolation(fleet, opts) { throw new Error('TODO'); }
+export async function verifyCredentialIsolation(fleet, opts) {
+  const { mode, _exec = defaultExec, _env = process.env } = opts ?? {};
+  if (mode !== 'autonomous' && mode !== 'interactive') {
+    throw new Error("verifyCredentialIsolation: opts.mode must be 'autonomous' or 'interactive'");
+  }
+  if (mode === 'interactive') {
+    return {
+      ok: true,
+      checks: [{
+        id: 'mode-interactive',
+        pass: true,
+        evidence: { mode: 'interactive', skipped: 'S2 isolation verification applies to autonomous runs only' },
+      }],
+    };
+  }
 
-/** sha256 hex digest of a file's bytes. @param {string} path */
-export function fileDigest(path) { throw new Error('TODO'); }
+  const checks = [];
+  const cores = Array.isArray(fleet?.cores) ? fleet.cores : [];
+  const connectTimeoutSec = isFiniteNum(fleet?.sshConnectTimeoutSec) && fleet.sshConnectTimeoutSec > 0
+    ? fleet.sshConnectTimeoutSec : 8;
+
+  // 1 — no ambient SSH agent.
+  const authSock = (_env.SSH_AUTH_SOCK || '').trim();
+  if (!authSock) {
+    checks.push({ id: 'no-agent', pass: true, evidence: { authSockSet: false } });
+  } else {
+    const res = await _exec('ssh-add', ['-l'], { timeoutMs: 10000, env: { ..._env } });
+    if (res.code === 1) {
+      // "The agent has no identities." — socket exists but offers nothing.
+      checks.push({ id: 'no-agent', pass: true, evidence: { authSockSet: true, agentEmpty: true } });
+    } else if (res.code === 0) {
+      const agentIdentities = res.stdout.split('\n').filter((l) => /\S/.test(l)).length;
+      checks.push({ id: 'no-agent', pass: false, evidence: { authSockSet: true, agentIdentities } });
+    } else {
+      // Cannot prove the agent is empty → fail closed (S2: refuse when unverifiable).
+      checks.push({ id: 'no-agent', pass: false, evidence: { authSockSet: true, reason: 'agent-state-unverifiable', code: res.code } });
+    }
+  }
+
+  // 2 — every core has a configured identity and the file exists.
+  // S6: evidence carries aliases and counts only, never identity paths.
+  const coresMissingIdentity = [];
+  const identityByAlias = new Map();
+  for (const core of cores) {
+    if (!isNonEmptyStr(core.sshIdentity)) { coresMissingIdentity.push(core.alias); continue; }
+    const path = expandTilde(core.sshIdentity, _env);
+    if (!existsSync(path)) { coresMissingIdentity.push(core.alias); continue; }
+    identityByAlias.set(core.alias, path);
+  }
+  checks.push({
+    id: 'identity-only',
+    pass: cores.length > 0 && coresMissingIdentity.length === 0,
+    evidence: {
+      cores: cores.length,
+      identitiesFound: identityByAlias.size,
+      coresMissingIdentity,
+      identitiesOnly: true, // probes force BatchMode + IdentitiesOnly=yes + IdentityAgent=none
+    },
+  });
+
+  // 3 — per-core mutation-refusal probes. Sequential: never a connection storm.
+  for (const core of cores) {
+    const alias = core.alias;
+    const identityPath = identityByAlias.get(alias);
+    if (!identityPath) {
+      checks.push({ id: `sudo-refused:${alias}`, pass: false, evidence: { alias, reason: 'identity-missing-not-probed' } });
+      checks.push({ id: `no-verbatim-exec:${alias}`, pass: false, evidence: { alias, reason: 'identity-missing-not-probed' } });
+      continue;
+    }
+
+    const sudoRes = await _exec(
+      'ssh', sshProbeArgs(core, 'sudo -n true', connectTimeoutSec, identityPath),
+      { timeoutMs: (connectTimeoutSec + 15) * 1000 },
+    );
+    if (sudoRes.timedOut || sudoRes.code === null || sudoRes.code === 255) {
+      // Transport failure: refusal unproven → fail closed.
+      checks.push({ id: `sudo-refused:${alias}`, pass: false, evidence: { alias, code: sudoRes.code, reason: 'ssh-transport-error-cannot-verify' } });
+    } else {
+      const passwordPrompt = /a password is required/i.test(`${sudoRes.stdout}\n${sudoRes.stderr}`);
+      checks.push({
+        id: `sudo-refused:${alias}`,
+        pass: sudoRes.code !== 0 || passwordPrompt,
+        evidence: { alias, code: sudoRes.code, passwordPrompt },
+      });
+    }
+
+    const echoRes = await _exec(
+      'ssh', sshProbeArgs(core, 'echo x', connectTimeoutSec, identityPath),
+      { timeoutMs: (connectTimeoutSec + 15) * 1000 },
+    );
+    if (echoRes.timedOut || echoRes.code === null || echoRes.code === 255) {
+      checks.push({ id: `no-verbatim-exec:${alias}`, pass: false, evidence: { alias, code: echoRes.code, reason: 'ssh-transport-error-cannot-verify' } });
+    } else {
+      // Verbatim 'x' back ⇒ the remote actually RAN our command ⇒ no forced command.
+      const verbatim = echoRes.stdout.replace(/\r?\n$/, '') === 'x';
+      checks.push({
+        id: `no-verbatim-exec:${alias}`,
+        pass: !verbatim,
+        evidence: { alias, code: echoRes.code, verbatim, stdoutBytes: Buffer.byteLength(echoRes.stdout) },
+      });
+    }
+  }
+
+  return { ok: checks.length > 0 && checks.every((c) => c.pass), checks };
+}

--- a/testnet/lib/edge.mjs
+++ b/testnet/lib/edge.mjs
@@ -1,0 +1,84 @@
+// OT-RFC-61 §3.2 — local edge daemon client + CLI runner (driver edge D; Phase 1 adds O/N).
+// CONTRACT FILE: implementors replace TODO bodies; signatures are frozen.
+// Route shapes MUST be verified against the monorepo at ../.. (this worktree is
+// origin/main) — packages/cli/src/daemon/routes/*, packages/cli/src/api-client.ts.
+
+/**
+ * Thin authenticated client for ONE local edge daemon.
+ * Auth: bearer token resolved the way the CLI does (DKG_HOME token files /
+ * DKG_AUTH_TOKEN env) — implementor: verify against packages/cli/src/auth.ts.
+ */
+export class EdgeClient {
+  /** @param {{dkgHome: string, apiPort: number, label: 'driver'|'observer'|'nonMember'}} opts */
+  constructor(opts) { throw new Error('TODO'); }
+
+  /** GET /api/status (public). @returns {Promise<object>} */
+  async status() { throw new Error('TODO'); }
+
+  /** Create KA (WM) + optional share/finalize flags — POST /api/knowledge-assets.
+   * @param {{name: string, cg: string, quads: string, finalize?: boolean}} p */
+  async createKnowledgeAsset(p) { throw new Error('TODO'); }
+
+  /** SHARE WM->SWM async — POST /api/knowledge-assets/:name/swm/share-async → {jobId}.
+   * @param {{name: string, cg: string}} p */
+  async shareAsync(p) { throw new Error('TODO'); }
+
+  /** Poll a share job to terminal state. Returns final job record.
+   * @param {{jobId: string, timeoutMs: number, intervalMs?: number}} p */
+  async waitShareJob(p) { throw new Error('TODO'); }
+
+  /** PUBLISH SWM->VM async — POST /api/knowledge-assets/:name/vm/publish-async → {jobId}.
+   * @param {{name: string, cg: string}} p */
+  async publishAsync(p) { throw new Error('TODO'); }
+
+  /** Poll a publisher job to terminal state (confirmed: ual+txHash | failed).
+   * @param {{jobId: string, timeoutMs: number, intervalMs?: number}} p */
+  async waitPublishJob(p) { throw new Error('TODO'); }
+
+  /** Authoritative KA state — GET /api/knowledge-assets/:name?contextGraphId=…
+   * Used for §6 recovery re-scoring (client timeout ≠ failure) and memoryLayer=VM polling.
+   * @param {{name: string, cg: string}} p */
+  async knowledgeAssetState(p) { throw new Error('TODO'); }
+
+  /** Local SPARQL — POST /api/query {sparql, view, contextGraphId}. view:
+   * 'working-memory'|'shared-working-memory'|'verifiable-memory'.
+   * @param {{sparql: string, view: string, cg?: string}} p @returns SPARQL JSON results */
+  async query(p) { throw new Error('TODO'); }
+
+  /** Sync catch-up status — GET /api/sync/catchup-status?contextGraphId=…
+   * @param {{cg?: string}} p */
+  async catchupStatus(p) { throw new Error('TODO'); }
+
+  /** Subscribe to SSE /api/events. Returns {close(), gaps(): Array<{fromTs,toTs}>}
+   * and invokes onEvent(parsed) per event; tracks disconnect gaps (§4.3 SSE
+   * reliability — gaps are recorded, reconnect is automatic).
+   * @param {{onEvent: (e: object) => void}} p */
+  async events(p) { throw new Error('TODO'); }
+}
+
+/**
+ * Run the dkg CLI as a child process against a DKG_HOME (rfc59 publish path —
+ * kept because certify Phase 0 must reproduce the CLI-driven runs byte-for-byte).
+ * @param {{cliPath: string, dkgHome: string, args: string[], timeoutMs: number}} p
+ * @returns {Promise<{ok, code, signal, stdout, stderr, timedOut, durationMs}>}
+ */
+export async function runCli(p) { throw new Error('TODO'); }
+
+/**
+ * Deterministic single-triple N-Quads payload for op `index` of a run
+ * (subject urn:rfc61:<lane>:<runId>:<index>, schema.org/name object; every
+ * `controlFixtureEvery`-th op uses the Unicode/control-char fixture set —
+ * café/Δ/newline/tab/ — port of rfc59 fixtures).
+ * @param {{runId: string, lane: string, index: number, controlFixtureEvery: number}} p
+ * @returns {{quads: string, subject: string, expectedObject: string, controlFixture: boolean}}
+ */
+export function makePayload(p) { throw new Error('TODO'); }
+
+/**
+ * Byte-exact readback of published fixtures via chunked VALUES queries
+ * (chunk 25 subjects — rfc59 port). Compares normalized terms against expected.
+ * @param {EdgeClient} edge
+ * @param {{items: Array<{subject, expectedObject}>, cg: string, view: string, chunkSize?: number}} p
+ * @returns {Promise<{matched: number, mismatches: Array<{subject, kind}>}>}
+ */
+export async function verifyReadback(edge, p) { throw new Error('TODO'); }

--- a/testnet/lib/edge.mjs
+++ b/testnet/lib/edge.mjs
@@ -1,84 +1,642 @@
 // OT-RFC-61 §3.2 — local edge daemon client + CLI runner (driver edge D; Phase 1 adds O/N).
-// CONTRACT FILE: implementors replace TODO bodies; signatures are frozen.
-// Route shapes MUST be verified against the monorepo at ../.. (this worktree is
-// origin/main) — packages/cli/src/daemon/routes/*, packages/cli/src/api-client.ts.
+//
+// Every route below was verified against the monorepo at this worktree (origin/main):
+//   POST /api/knowledge-assets                       packages/cli/src/daemon/routes/knowledge-assets.ts:715
+//     (quads = array of {subject,predicate,object,graph?} — string quads rejected,
+//      daemon/http-utils.ts:163 isWritableQuad; object term = quoted literal or bare
+//      absolute IRI, http-utils.ts:199; finalize strict boolean, knowledge-assets.ts:771;
+//      201 on success / 207 when an opt-in tail failed, knowledge-assets.ts:945-946)
+//   POST /api/knowledge-assets/:name/swm/share-async knowledge-assets.ts:1301 → 200 {jobId, state:"queued"} (:1325)
+//   GET  /api/knowledge-assets/swm/share-jobs/:jobId knowledge-assets.ts:617-625 →
+//     routes/knowledge-assets-async-share.ts:187-195 → PromoteJob; state enum
+//     packages/publisher/src/async-promote-queue-types.ts:17-24
+//     ('queued'|'running'|'failed_retrying'|'succeeded'|'failed'; terminal: succeeded|failed)
+//   POST /api/knowledge-assets/:name/vm/publish-async knowledge-assets.ts:1348 →
+//     202 {jobId, status:"accepted", ...} (:1376-1386)
+//   GET  /api/publisher/job?id=<jobId>               routes/publisher.ts:370-379 → 200 {job};
+//     job.status enum packages/publisher/src/lift-job-states.ts:1-11
+//     ('accepted'|'claimed'|'validated'|'broadcast'|'included'|'finalized'|'failed';
+//      terminal per TERMINAL_LIFT_JOB_STATES lift-job-states.ts:21: finalized|failed)
+//   GET  /api/knowledge-assets/:identifier?contextGraphId=… knowledge-assets.ts:1009-1015
+//     (lifecycle descriptor: memoryLayer, publishedUal, reservedUal, events, status —
+//      the §6 recovery authority; rfc59 harness pollFinalized consumed exactly this)
+//   POST /api/query {sparql, view, contextGraphId}   routes/query.ts:395-610 →
+//     200 {result: {bindings}, phases}; view names packages/core/src/memory-model.ts:202-204
+//     ('working-memory'|'shared-working-memory'|'verifiable-memory')
+//   GET  /api/sync/catchup-status?contextGraphId=…|jobId=… routes/query.ts:904-931
+//   GET  /api/status (public — no auth; api-client.ts:476 requests it with auth:false)
+//   GET  /api/events (SSE)                           daemon/lifecycle.ts:3449-3464
+//     (frames `event: <name>\ndata: <json>\n\n` per sseBroadcast lifecycle.ts:2921-2927,
+//      `event: connected\ndata: {}` greeting :3457, `: heartbeat` comments :3460;
+//      bearer header or ?token= accepted, auth.ts:837-848)
+//
+// Auth resolution mirrors the CLI (api-client.ts:464-466 + auth.ts:31-33,62-77):
+//   opts.token override → DKG_AUTH_TOKEN env → first non-comment line of
+//   <dkgHome>/auth.token. No token → requests go out without an Authorization
+//   header (the daemon may be running with auth disabled).
+//
+// S6 hygiene: this module never logs or embeds dkgHome paths, tokens, hosts, or
+// wallet addresses in thrown errors — errors carry the edge `label`, route path,
+// HTTP status, and a bounded body tail only.
+
+import { spawn } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { request as httpRequest } from 'node:http';
+import { join } from 'node:path';
+import { normTerm as utilNormTerm } from './util.mjs';
+
+const OUTPUT_TAIL_CHARS = 16_000; // rfc59 harness.mjs commandOutput — tail-truncate cap
+const OUTPUT_ACCUM_CAP = 4 * 1024 * 1024; // rfc59 maxBuffer parity for spawned CLI output
+const XSD_STRING = 'http://www.w3.org/2001/XMLSchema#string';
+
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+/** rfc59 commandOutput port: trim + keep only the LAST 16k chars. */
+export function tailTruncate(value) {
+  const text = String(value ?? '').trim();
+  return text.length > OUTPUT_TAIL_CHARS ? text.slice(-OUTPUT_TAIL_CHARS) : text;
+}
+
+/**
+ * Resolve the bearer token the way the CLI does (api-client.ts:464-466):
+ * explicit override → DKG_AUTH_TOKEN env → first non-comment, non-blank line of
+ * <dkgHome>/auth.token (auth.ts:31-33,62-77). Returns undefined when nothing
+ * resolves (daemon may have auth disabled).
+ * @param {string} dkgHome
+ * @param {{token?: string, env?: object}} [opts]
+ */
+export function resolveEdgeToken(dkgHome, opts = {}) {
+  if (opts.token) return opts.token;
+  const env = opts.env ?? process.env;
+  const envToken = typeof env.DKG_AUTH_TOKEN === 'string' ? env.DKG_AUTH_TOKEN.trim() : '';
+  if (envToken) return envToken;
+  try {
+    const raw = readFileSync(join(dkgHome, 'auth.token'), 'utf8');
+    for (const line of raw.split('\n')) {
+      const t = line.trim();
+      if (t.length > 0 && !t.startsWith('#')) return t;
+    }
+  } catch {
+    /* no token file — fall through */
+  }
+  return undefined;
+}
+
+/**
+ * Parse a deterministic N-Quads document (the makePayload / seed-generator
+ * shapes: IRI subject, IRI predicate, literal-or-IRI object, optional graph)
+ * into the writable-quad objects the create/write routes accept
+ * (daemon/http-utils.ts:163 — string-shaped quads are rejected by the route,
+ * so the client converts). Blank-node terms are refused: the deterministic
+ * generator never emits them and silently guessing would corrupt readback.
+ * @param {string} nquads
+ * @returns {Array<{subject: string, predicate: string, object: string, graph?: string}>}
+ */
+export function parseNquads(nquads) {
+  const LINE =
+    /^\s*<([^>]*)>\s+<([^>]*)>\s+("(?:[^"\\]|\\.)*"(?:\^\^<[^>]*>|@[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*)?|<[^>]*>)\s*(?:<([^>]*)>\s*)?\.\s*$/;
+  const out = [];
+  for (const raw of String(nquads ?? '').split('\n')) {
+    const line = raw.trim();
+    if (!line || line.startsWith('#')) continue;
+    const m = LINE.exec(line);
+    if (!m) throw new Error(`parseNquads: unparseable N-Quads line: ${tailTruncate(line).slice(0, 200)}`);
+    const object = m[3].startsWith('<') ? m[3].slice(1, -1) : m[3];
+    const quad = { subject: m[1], predicate: m[2], object };
+    if (m[4] !== undefined) quad.graph = m[4];
+    out.push(quad);
+  }
+  if (out.length === 0) throw new Error('parseNquads: no quads in payload');
+  return out;
+}
+
+/** Strip surrounding <…> from an IRI term string (tolerates bare IRIs). */
+function unwrapIri(term) {
+  const t = String(term ?? '');
+  return t.startsWith('<') && t.endsWith('>') ? t.slice(1, -1) : t;
+}
+
+/** Drop a redundant explicit xsd:string suffix so both normTerm dialects compare equal. */
+function comparableLiteral(term) {
+  const t = String(term ?? '');
+  const suffix = `^^<${XSD_STRING}>`;
+  return t.endsWith(suffix) ? t.slice(0, -suffix.length) : t;
+}
+
+function extractBindings(json, label) {
+  const bindings = json?.result?.bindings ?? json?.results?.bindings ?? json?.bindings;
+  if (!Array.isArray(bindings)) {
+    throw new Error(`unrecognised /api/query response shape (${label}): ${JSON.stringify(json ?? null).slice(0, 300)}`);
+  }
+  return bindings;
+}
 
 /**
  * Thin authenticated client for ONE local edge daemon.
  * Auth: bearer token resolved the way the CLI does (DKG_HOME token files /
- * DKG_AUTH_TOKEN env) — implementor: verify against packages/cli/src/auth.ts.
+ * DKG_AUTH_TOKEN env) — verified against packages/cli/src/auth.ts:31-77 and
+ * api-client.ts:464-466.
+ *
+ * Optional (non-contract) opts: `token` (override), `env` (env source for
+ * token resolution — tests), `_fetch` (injectable fetch), `requestTimeoutMs`.
  */
 export class EdgeClient {
   /** @param {{dkgHome: string, apiPort: number, label: 'driver'|'observer'|'nonMember'}} opts */
-  constructor(opts) { throw new Error('TODO'); }
+  constructor(opts) {
+    if (!opts || typeof opts.dkgHome !== 'string' || !opts.dkgHome) {
+      throw new Error('EdgeClient: "dkgHome" is required');
+    }
+    if (!Number.isInteger(opts.apiPort) || opts.apiPort <= 0) {
+      throw new Error('EdgeClient: "apiPort" must be a positive integer');
+    }
+    if (!['driver', 'observer', 'nonMember'].includes(opts.label)) {
+      throw new Error('EdgeClient: "label" must be driver|observer|nonMember');
+    }
+    this.dkgHome = opts.dkgHome;
+    this.apiPort = opts.apiPort;
+    this.label = opts.label;
+    this.baseUrl = `http://127.0.0.1:${opts.apiPort}`;
+    this._tokenOverride = opts.token;
+    this._env = opts.env;
+    this._fetch = opts._fetch ?? globalThis.fetch;
+    this._requestTimeoutMs = opts.requestTimeoutMs ?? 30_000;
+    this._cachedToken = undefined;
+  }
+
+  /** Lazily resolved + cached bearer token (re-probed while absent so a daemon
+   *  that mints auth.token after construction is still picked up). */
+  token() {
+    if (this._tokenOverride) return this._tokenOverride;
+    if (this._cachedToken === undefined) {
+      this._cachedToken = resolveEdgeToken(this.dkgHome, { env: this._env }) ?? undefined;
+      if (this._cachedToken === undefined) return undefined;
+    }
+    return this._cachedToken;
+  }
+
+  async #request(method, path, { body, auth = true, timeoutMs } = {}) {
+    const headers = {};
+    if (auth) {
+      const token = this.token();
+      if (token) headers.Authorization = `Bearer ${token}`;
+    }
+    const init = { method, headers, signal: AbortSignal.timeout(timeoutMs ?? this._requestTimeoutMs) };
+    if (body !== undefined) {
+      headers['Content-Type'] = 'application/json';
+      init.body = JSON.stringify(body);
+    }
+    const res = await this._fetch(`${this.baseUrl}${path}`, init);
+    const text = await res.text();
+    let json = null;
+    try {
+      json = text ? JSON.parse(text) : null;
+    } catch {
+      /* non-JSON body — kept as text tail in the error below */
+    }
+    if (!res.ok) {
+      const err = new Error(
+        `${this.label} edge ${method} ${path.split('?')[0]} → HTTP ${res.status}: ${tailTruncate(text).slice(0, 500)}`,
+      );
+      err.status = res.status;
+      err.body = json ?? tailTruncate(text);
+      throw err;
+    }
+    return json;
+  }
 
   /** GET /api/status (public). @returns {Promise<object>} */
-  async status() { throw new Error('TODO'); }
+  async status() {
+    return this.#request('GET', '/api/status', { auth: false, timeoutMs: 10_000 });
+  }
 
   /** Create KA (WM) + optional share/finalize flags — POST /api/knowledge-assets.
+   * `quads` may be an N-Quads string (converted via parseNquads — the route
+   * rejects string-shaped quads, http-utils.ts:163) or a pre-built writable-quad
+   * array. Route default seals the draft (finalize !== false).
    * @param {{name: string, cg: string, quads: string, finalize?: boolean}} p */
-  async createKnowledgeAsset(p) { throw new Error('TODO'); }
+  async createKnowledgeAsset(p) {
+    const quads = typeof p.quads === 'string' ? parseNquads(p.quads) : p.quads;
+    const body = {
+      name: p.name,
+      contextGraphId: p.cg,
+      quads,
+      ...(p.finalize !== undefined ? { finalize: p.finalize } : {}),
+      ...(p.subGraphName !== undefined ? { subGraphName: p.subGraphName } : {}),
+      ...(p.alsoShareSwm !== undefined ? { alsoShareSwm: p.alsoShareSwm } : {}),
+    };
+    return this.#request('POST', '/api/knowledge-assets', { body });
+  }
 
   /** SHARE WM->SWM async — POST /api/knowledge-assets/:name/swm/share-async → {jobId}.
    * @param {{name: string, cg: string}} p */
-  async shareAsync(p) { throw new Error('TODO'); }
+  async shareAsync(p) {
+    return this.#request('POST', `/api/knowledge-assets/${encodeURIComponent(p.name)}/swm/share-async`, {
+      body: { contextGraphId: p.cg, ...(p.subGraphName !== undefined ? { subGraphName: p.subGraphName } : {}) },
+    });
+  }
 
-  /** Poll a share job to terminal state. Returns final job record.
+  /** Poll a share job to terminal state (async-promote-queue-types.ts:17-24 —
+   * terminal = succeeded | failed; failed_retrying is NOT terminal).
+   * Returns {job, pollIntervalMs} (§4.3: polled anchors carry their interval).
    * @param {{jobId: string, timeoutMs: number, intervalMs?: number}} p */
-  async waitShareJob(p) { throw new Error('TODO'); }
+  async waitShareJob(p) {
+    return this.#waitJob({
+      ...p,
+      what: 'share job',
+      fetchJob: () => this.#request('GET', `/api/knowledge-assets/swm/share-jobs/${encodeURIComponent(p.jobId)}`),
+      stateOf: (job) => job?.state,
+      terminal: ['succeeded', 'failed'],
+      defaultIntervalMs: 500,
+    });
+  }
 
   /** PUBLISH SWM->VM async — POST /api/knowledge-assets/:name/vm/publish-async → {jobId}.
    * @param {{name: string, cg: string}} p */
-  async publishAsync(p) { throw new Error('TODO'); }
+  async publishAsync(p) {
+    return this.#request('POST', `/api/knowledge-assets/${encodeURIComponent(p.name)}/vm/publish-async`, {
+      body: { contextGraphId: p.cg, ...(p.subGraphName !== undefined ? { subGraphName: p.subGraphName } : {}) },
+    });
+  }
 
-  /** Poll a publisher job to terminal state (confirmed: ual+txHash | failed).
+  /** Poll a publisher (lift) job to terminal state (lift-job-states.ts:21 —
+   * terminal = finalized | failed; a finalized job carries ual + txHash).
+   * Returns {job, pollIntervalMs}.
    * @param {{jobId: string, timeoutMs: number, intervalMs?: number}} p */
-  async waitPublishJob(p) { throw new Error('TODO'); }
+  async waitPublishJob(p) {
+    return this.#waitJob({
+      ...p,
+      what: 'publish job',
+      fetchJob: async () => {
+        const wrapped = await this.#request('GET', `/api/publisher/job?id=${encodeURIComponent(p.jobId)}`);
+        // publisher.ts:370-379 wraps as {job}; the legacy /jobs/:id route is bare.
+        return wrapped?.job ?? wrapped;
+      },
+      stateOf: (job) => job?.status ?? job?.state,
+      terminal: ['finalized', 'failed'],
+      defaultIntervalMs: 1000,
+    });
+  }
+
+  async #waitJob({ jobId, timeoutMs, intervalMs, what, fetchJob, stateOf, terminal, defaultIntervalMs }) {
+    if (!jobId) throw new Error(`${what} poll requires a jobId`);
+    const pollIntervalMs = intervalMs ?? defaultIntervalMs;
+    const deadline = Date.now() + timeoutMs;
+    let lastError;
+    let lastJob;
+    for (;;) {
+      try {
+        const job = await fetchJob();
+        lastJob = job;
+        if (terminal.includes(stateOf(job))) return { job, pollIntervalMs };
+      } catch (err) {
+        // Transient poll errors never fail the op before the authoritative
+        // deadline (§6 — success is decided by daemon state, not client blips).
+        lastError = err;
+      }
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) break;
+      await sleep(Math.min(pollIntervalMs, remaining));
+    }
+    const err = new Error(
+      `${this.label} edge ${what} ${jobId} did not reach ${terminal.join('|')} within ${timeoutMs}ms` +
+        `${lastJob ? ` (last state: ${stateOf(lastJob)})` : ''}${lastError ? ` (last poll error: ${lastError.message})` : ''}`,
+    );
+    err.timedOut = true;
+    err.lastJob = lastJob;
+    err.pollIntervalMs = pollIntervalMs;
+    throw err;
+  }
 
   /** Authoritative KA state — GET /api/knowledge-assets/:name?contextGraphId=…
-   * Used for §6 recovery re-scoring (client timeout ≠ failure) and memoryLayer=VM polling.
+   * (knowledge-assets.ts:1009-1015 — lifecycle descriptor with memoryLayer,
+   * publishedUal, reservedUal, events). Used for §6 recovery re-scoring
+   * (client timeout ≠ failure) and memoryLayer=VM polling.
    * @param {{name: string, cg: string}} p */
-  async knowledgeAssetState(p) { throw new Error('TODO'); }
+  async knowledgeAssetState(p) {
+    const qs = new URLSearchParams({ contextGraphId: p.cg });
+    if (p.subGraphName !== undefined) qs.set('subGraphName', p.subGraphName);
+    return this.#request('GET', `/api/knowledge-assets/${encodeURIComponent(p.name)}?${qs}`);
+  }
 
   /** Local SPARQL — POST /api/query {sparql, view, contextGraphId}. view:
-   * 'working-memory'|'shared-working-memory'|'verifiable-memory'.
+   * 'working-memory'|'shared-working-memory'|'verifiable-memory'
+   * (core/src/memory-model.ts:202-204). Returns the daemon body verbatim:
+   * {result: {bindings: [...]}, phases} (query.ts:607-610).
    * @param {{sparql: string, view: string, cg?: string}} p @returns SPARQL JSON results */
-  async query(p) { throw new Error('TODO'); }
+  async query(p) {
+    const body = {
+      sparql: p.sparql,
+      ...(p.view !== undefined ? { view: p.view } : {}),
+      ...(p.cg !== undefined ? { contextGraphId: p.cg } : {}),
+    };
+    return this.#request('POST', '/api/query', { body });
+  }
 
   /** Sync catch-up status — GET /api/sync/catchup-status?contextGraphId=…
+   * (query.ts:904-931; also accepts jobId as an optional extra param).
    * @param {{cg?: string}} p */
-  async catchupStatus(p) { throw new Error('TODO'); }
+  async catchupStatus(p = {}) {
+    const qs = new URLSearchParams();
+    if (p.cg !== undefined) qs.set('contextGraphId', p.cg);
+    if (p.jobId !== undefined) qs.set('jobId', p.jobId);
+    return this.#request('GET', `/api/sync/catchup-status?${qs}`);
+  }
 
-  /** Subscribe to SSE /api/events. Returns {close(), gaps(): Array<{fromTs,toTs}>}
-   * and invokes onEvent(parsed) per event; tracks disconnect gaps (§4.3 SSE
-   * reliability — gaps are recorded, reconnect is automatic).
+  /** Subscribe to SSE /api/events (lifecycle.ts:3449-3464). Returns
+   * {close(), gaps(): Array<{fromTs,toTs}>} and invokes onEvent(parsed) per
+   * event; tracks disconnect gaps (§4.3 SSE reliability — gaps are recorded,
+   * reconnect is automatic). onEvent receives {event, data, ts}; heartbeat
+   * comment lines (`: heartbeat`) are ignored. The returned promise resolves
+   * once the first connection is established (rejects after connectTimeoutMs,
+   * default 15s). A still-open disconnection is reported as {fromTs, toTs: null}.
+   * Optional extras: p.retryMs (reconnect delay, default 1000),
+   * p.connectTimeoutMs.
    * @param {{onEvent: (e: object) => void}} p */
-  async events(p) { throw new Error('TODO'); }
+  async events(p) {
+    const onEvent = p?.onEvent ?? (() => {});
+    const retryMs = p?.retryMs ?? 1000;
+    const connectTimeoutMs = p?.connectTimeoutMs ?? 15_000;
+    const token = this.token();
+    const state = {
+      closed: false,
+      gaps: [],
+      gapOpenTs: null,
+      req: null,
+      res: null,
+      timer: null,
+      reconnectScheduled: false,
+      everConnected: false,
+    };
+
+    const handle = {
+      close: () => {
+        state.closed = true;
+        if (state.timer) clearTimeout(state.timer);
+        state.timer = null;
+        try { state.res?.destroy(); } catch { /* already gone */ }
+        try { state.req?.destroy(); } catch { /* already gone */ }
+      },
+      gaps: () =>
+        state.gapOpenTs === null
+          ? state.gaps.map((g) => ({ ...g }))
+          : [...state.gaps.map((g) => ({ ...g })), { fromTs: state.gapOpenTs, toTs: null }],
+    };
+
+    let resolveFirst;
+    let rejectFirst;
+    const first = new Promise((resolve, reject) => {
+      resolveFirst = resolve;
+      rejectFirst = reject;
+    });
+    const firstTimer = setTimeout(() => {
+      handle.close();
+      rejectFirst(new Error(`${this.label} edge /api/events: no SSE connection within ${connectTimeoutMs}ms`));
+    }, connectTimeoutMs);
+
+    const dispatchFrame = (frame) => {
+      let eventName = 'message';
+      const dataLines = [];
+      for (const line of frame.split('\n')) {
+        if (line.startsWith(':')) continue; // comment / heartbeat
+        if (line.startsWith('event:')) eventName = line.slice('event:'.length).trim();
+        else if (line.startsWith('data:')) dataLines.push(line.slice('data:'.length).trimStart());
+      }
+      if (dataLines.length === 0 && eventName === 'message') return; // pure comment frame
+      const raw = dataLines.join('\n');
+      let data = raw;
+      try {
+        data = raw ? JSON.parse(raw) : {};
+      } catch {
+        /* non-JSON payload — deliver raw string */
+      }
+      try {
+        onEvent({ event: eventName, data, ts: Date.now() });
+      } catch {
+        /* listener errors must never kill the stream */
+      }
+    };
+
+    const scheduleReconnect = () => {
+      if (state.closed || state.reconnectScheduled) return;
+      state.reconnectScheduled = true;
+      if (state.gapOpenTs === null) state.gapOpenTs = Date.now();
+      state.timer = setTimeout(() => {
+        state.reconnectScheduled = false;
+        connect();
+      }, retryMs);
+    };
+
+    const connect = () => {
+      if (state.closed) return;
+      const req = httpRequest({
+        host: '127.0.0.1',
+        port: this.apiPort,
+        path: '/api/events',
+        method: 'GET',
+        headers: {
+          Accept: 'text/event-stream',
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+      });
+      state.req = req;
+      req.on('response', (res) => {
+        if (res.statusCode !== 200) {
+          res.resume();
+          scheduleReconnect();
+          return;
+        }
+        state.res = res;
+        if (state.gapOpenTs !== null) {
+          state.gaps.push({ fromTs: state.gapOpenTs, toTs: Date.now() });
+          state.gapOpenTs = null;
+        }
+        if (!state.everConnected) {
+          state.everConnected = true;
+          clearTimeout(firstTimer);
+          resolveFirst(handle);
+        }
+        let buf = '';
+        res.setEncoding('utf8');
+        res.on('data', (chunk) => {
+          buf += chunk;
+          for (;;) {
+            const cut = buf.indexOf('\n\n');
+            if (cut < 0) break;
+            const frame = buf.slice(0, cut);
+            buf = buf.slice(cut + 2);
+            if (frame.trim()) dispatchFrame(frame);
+          }
+        });
+        res.on('close', scheduleReconnect);
+        res.on('error', () => { /* 'close' follows; avoid unhandled 'error' */ });
+      });
+      req.on('error', scheduleReconnect);
+      req.end();
+    };
+
+    connect();
+    return first;
+  }
 }
 
 /**
  * Run the dkg CLI as a child process against a DKG_HOME (rfc59 publish path —
  * kept because certify Phase 0 must reproduce the CLI-driven runs byte-for-byte).
+ * Port of rfc59 publishOne's child_process mechanics: spawn node <cliPath>,
+ * env DKG_HOME, timeout+SIGKILL, capture + tail-truncate 16 KB (commandOutput).
+ * Optional extras: p.env (merged over process.env), p.apiPort (→ DKG_API_PORT),
+ * p.cwd, p.execPath. Never rejects — spawn errors surface as {ok:false, error}.
  * @param {{cliPath: string, dkgHome: string, args: string[], timeoutMs: number}} p
  * @returns {Promise<{ok, code, signal, stdout, stderr, timedOut, durationMs}>}
  */
-export async function runCli(p) { throw new Error('TODO'); }
+export async function runCli(p) {
+  const { cliPath, dkgHome, args, timeoutMs } = p;
+  if (!cliPath || !dkgHome || !Array.isArray(args) || !Number.isFinite(timeoutMs)) {
+    throw new Error('runCli requires {cliPath, dkgHome, args[], timeoutMs}');
+  }
+  const startedAt = Date.now();
+  return new Promise((resolve) => {
+    const child = spawn(p.execPath ?? process.execPath, [cliPath, ...args], {
+      env: {
+        ...process.env,
+        ...(p.env ?? {}),
+        DKG_HOME: dkgHome,
+        ...(p.apiPort !== undefined ? { DKG_API_PORT: String(p.apiPort) } : {}),
+      },
+      ...(p.cwd ? { cwd: p.cwd } : {}),
+    });
+    let stdout = '';
+    let stderr = '';
+    let timedOut = false;
+    let settled = false;
+    const cap = (s) => (s.length > OUTPUT_ACCUM_CAP ? s.slice(-OUTPUT_ACCUM_CAP) : s);
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill('SIGKILL');
+    }, timeoutMs);
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+    child.stdout?.on('data', (d) => { stdout = cap(stdout + d.toString()); });
+    child.stderr?.on('data', (d) => { stderr = cap(stderr + d.toString()); });
+    child.on('error', (err) => {
+      finish({
+        ok: false,
+        code: null,
+        signal: null,
+        stdout: tailTruncate(stdout),
+        stderr: tailTruncate(stderr),
+        timedOut,
+        durationMs: Date.now() - startedAt,
+        error: tailTruncate(err?.message ?? String(err)),
+      });
+    });
+    child.on('close', (code, signal) => {
+      finish({
+        ok: code === 0 && !timedOut,
+        code,
+        signal,
+        stdout: tailTruncate(stdout),
+        stderr: tailTruncate(stderr),
+        timedOut,
+        durationMs: Date.now() - startedAt,
+      });
+    });
+  });
+}
 
 /**
  * Deterministic single-triple N-Quads payload for op `index` of a run
  * (subject urn:rfc61:<lane>:<runId>:<index>, schema.org/name object; every
  * `controlFixtureEvery`-th op uses the Unicode/control-char fixture set —
- * café/Δ/newline/tab/ — port of rfc59 fixtures).
+ * café/Δ/newline/tab/ — port of rfc59 publishOne's fixtures, urn scheme
+ * adapted rfc59→rfc61). controlFixtureEvery <= 0 disables control fixtures.
+ * expectedObject is the JSON/N-Triples-escaped quoted literal, byte-comparable
+ * to the daemon's term-string bindings (the rfc59 readback contract).
  * @param {{runId: string, lane: string, index: number, controlFixtureEvery: number}} p
  * @returns {{quads: string, subject: string, expectedObject: string, controlFixture: boolean}}
  */
-export function makePayload(p) { throw new Error('TODO'); }
+export function makePayload(p) {
+  const { runId, lane, index, controlFixtureEvery } = p;
+  if (typeof runId !== 'string' || !runId) throw new Error('makePayload: "runId" required');
+  if (typeof lane !== 'string' || !lane) throw new Error('makePayload: "lane" required');
+  if (!Number.isInteger(index) || index < 0) throw new Error('makePayload: "index" must be a non-negative integer');
+  const subject = `urn:rfc61:${lane}:${runId}:${index}`;
+  const controlFixture =
+    Number.isInteger(controlFixtureEvery) && controlFixtureEvery > 0 && index % controlFixtureEvery === 0;
+  // rfc59 harness.mjs publishOne literal fixtures, verbatim (certify line kept
+  // byte-identical; steady-state line carries the rfc61 tag).
+  const literalValue = controlFixture
+    ? `certify ${lane} ${runId} #${index} — café Δ line1\nline2\tcontrol:\u0001`
+    : `rfc61 ${lane} ${runId} #${index}`;
+  const expectedObject = JSON.stringify(literalValue);
+  const quads = `<${subject}> <http://schema.org/name> ${expectedObject} .\n`;
+  return { quads, subject, expectedObject, controlFixture };
+}
 
 /**
  * Byte-exact readback of published fixtures via chunked VALUES queries
- * (chunk 25 subjects — rfc59 port). Compares normalized terms against expected.
+ * (chunk 25 subjects — rfc59 verifyReadback port, harness.mjs:947-983).
+ * Object terms are normalized through lib/util.mjs normTerm (devnet
+ * semantics). Mismatch kinds: 'missing' (subject absent from the
+ * view), 'mismatch' (present with a different value), 'query_error' (the
+ * chunk's VALUES query failed — counted per rfc59 discipline: a failed
+ * readback query is a readback failure, never a silent skip).
+ * Optional extras: p._normTerm (injectable normalizer for tests).
  * @param {EdgeClient} edge
  * @param {{items: Array<{subject, expectedObject}>, cg: string, view: string, chunkSize?: number}} p
  * @returns {Promise<{matched: number, mismatches: Array<{subject, kind}>}>}
  */
-export async function verifyReadback(edge, p) { throw new Error('TODO'); }
+export async function verifyReadback(edge, p) {
+  const items = p.items ?? [];
+  const chunkSize = p.chunkSize ?? 25;
+  const normalize = p._normTerm ?? utilNormTerm;
+  let matched = 0;
+  const mismatches = [];
+  for (let i = 0; i < items.length; i += chunkSize) {
+    const chunk = items.slice(i, i + chunkSize);
+    const sparql =
+      `SELECT ?s ?o WHERE { VALUES ?s { ${chunk.map((it) => `<${it.subject}>`).join(' ')} } ` +
+      `?s <http://schema.org/name> ?o }`;
+    let bindings;
+    try {
+      const response = await edge.query({ sparql, view: p.view, cg: p.cg });
+      bindings = extractBindings(response, `${edge.label} readback`);
+    } catch {
+      for (const item of chunk) mismatches.push({ subject: item.subject, kind: 'query_error' });
+      continue;
+    }
+    const observed = new Map(); // bare subject IRI -> Set<comparable object term>
+    for (const b of bindings) {
+      const s = unwrapIri(normalize(b.s));
+      if (!observed.has(s)) observed.set(s, new Set());
+      observed.get(s).add(comparableLiteral(normalize(b.o)));
+    }
+    for (const item of chunk) {
+      const values = observed.get(item.subject);
+      const expected = comparableLiteral(item.expectedObject);
+      // Primary path (daemon term-string bindings) is byte-exact. The raw-value
+      // form tolerates a structured SPARQL-JSON cell, whose normTerm output
+      // carries the UNESCAPED lexical form (devnet normTerm does not re-escape).
+      let rawForm = null;
+      try {
+        rawForm = `"${JSON.parse(item.expectedObject)}"`;
+      } catch {
+        /* expectedObject not a JSON-quoted literal — exact match only */
+      }
+      if (!values) {
+        mismatches.push({ subject: item.subject, kind: 'missing' });
+      } else if (values.has(expected) || (rawForm !== null && values.has(rawForm))) {
+        matched++;
+      } else {
+        mismatches.push({ subject: item.subject, kind: 'mismatch' });
+      }
+    }
+  }
+  return { matched, mismatches };
+}

--- a/testnet/lib/evidence.mjs
+++ b/testnet/lib/evidence.mjs
@@ -2,6 +2,10 @@
 // CONTRACT FILE: implementors replace TODO bodies; signatures are frozen.
 // See schema/EVIDENCE.md for the record-type contract (schema_version 1).
 
+import { appendFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { isoBasic } from './util.mjs';
+
 export const SCHEMA_VERSION = 1;
 
 /**
@@ -14,35 +18,111 @@ export const FAILURE_CLASSES = Object.freeze([
   'finalized_unverified', 'caught_up_unverified', 'aborted',
 ]);
 
+/** Key names that must never appear (at any depth) in a MAIN-stream record —
+ * RFC-61 §8 S6 evidence hygiene: aliases only, no fleet topology or identities. */
+export const FORBIDDEN_RECORD_KEYS = Object.freeze(['host', 'ip', 'sshUser', 'sshIdentity']);
+
+/** Depth-first scan for forbidden key names. Returns the dotted path of the
+ * first offender, or null. Cycle-safe (evidence records must be JSON anyway). */
+function findForbiddenKey(value, path, seen) {
+  if (value === null || typeof value !== 'object') return null;
+  if (seen.has(value)) return null;
+  seen.add(value);
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i++) {
+      const hit = findForbiddenKey(value[i], `${path}[${i}]`, seen);
+      if (hit) return hit;
+    }
+    return null;
+  }
+  for (const key of Object.keys(value)) {
+    const keyPath = path ? `${path}.${key}` : key;
+    if (FORBIDDEN_RECORD_KEYS.includes(key)) return keyPath;
+    const hit = findForbiddenKey(value[key], keyPath, seen);
+    if (hit) return hit;
+  }
+  return null;
+}
+
 /**
  * Evidence writer bound to one run. Appends one JSON object per line to
  * runs/<runId>.jsonl (main) and runs/<runId>.sidecar.jsonl (raw/log text —
  * NEVER hostnames/IPs/keys in the MAIN stream, see EVIDENCE.md hygiene).
  */
 export class EvidenceWriter {
+  #runId;
+  #path;
+  #sidecarPath;
+
   /**
    * @param {{runId: string, runsDir: string}} opts — creates runsDir if missing.
    */
-  constructor(opts) { throw new Error('TODO'); }
+  constructor(opts) {
+    const { runId, runsDir } = opts ?? {};
+    if (!runId || typeof runId !== 'string') throw new Error('EvidenceWriter: runId required');
+    if (!runsDir || typeof runsDir !== 'string') throw new Error('EvidenceWriter: runsDir required');
+    mkdirSync(runsDir, { recursive: true });
+    this.#runId = runId;
+    this.#path = join(runsDir, `${runId}.jsonl`);
+    this.#sidecarPath = join(runsDir, `${runId}.sidecar.jsonl`);
+  }
+
+  /** Compose the envelope; injected fields always win over record fields. */
+  #compose(type, record) {
+    if (!type || typeof type !== 'string') throw new Error('EvidenceWriter: record type required');
+    return {
+      ...(record ?? {}),
+      type,
+      ts: new Date().toISOString(),
+      run_id: this.#runId,
+      schema_version: SCHEMA_VERSION,
+    };
+  }
 
   /** Append a record to the main stream. Injects type/ts/run_id/schema_version.
    * Throws if `type` is missing or record contains a key named host/ip/sshUser.
    * @param {string} type @param {object} record */
-  write(type, record) { throw new Error('TODO'); }
+  write(type, record) {
+    const offender = findForbiddenKey(record ?? {}, '', new Set());
+    if (offender) {
+      throw new Error(
+        `EvidenceWriter hygiene (S6): forbidden key "${offender}" in main-stream record type "${type}" — aliases only; raw material belongs in the sidecar`,
+      );
+    }
+    const line = this.#compose(type, record);
+    appendFileSync(this.#path, `${JSON.stringify(line)}\n`);
+    return line;
+  }
 
   /** Append raw/verbatim material (journal excerpts etc.) to the sidecar only.
    * @param {string} type @param {object} record */
-  writeSidecar(type, record) { throw new Error('TODO'); }
+  writeSidecar(type, record) {
+    const line = this.#compose(type, record);
+    appendFileSync(this.#sidecarPath, `${JSON.stringify(line)}\n`);
+    return line;
+  }
 
   /** Path of the main stream file. @returns {string} */
-  get path() { throw new Error('TODO'); }
+  get path() { return this.#path; }
+
+  /** Path of the (local-only, gitignored) sidecar file. @returns {string} */
+  get sidecarPath() { return this.#sidecarPath; }
 }
 
 /**
  * Compose a run id: `<phase>-<sha8>[-<qualifier>][-r<N>]-<isoBasic>`.
  * @param {{phase: string, sha8?: string, qualifier?: string, attempt?: number, now?: Date}} p
  */
-export function makeRunId(p) { throw new Error('TODO'); }
+export function makeRunId(p) {
+  const { phase, sha8, qualifier, attempt, now } = p ?? {};
+  if (!phase || typeof phase !== 'string') throw new Error('makeRunId: phase required');
+  const parts = [phase];
+  if (sha8) parts.push(String(sha8));
+  if (qualifier) parts.push(String(qualifier));
+  if (Number.isFinite(attempt)) parts.push(`r${attempt}`);
+  parts.push(isoBasic(now));
+  return parts.join('-');
+}
 
 /**
  * Build the run_manifest record (RFC-61 §4.4): attested identities, scenario
@@ -55,4 +135,28 @@ export function makeRunId(p) { throw new Error('TODO'); }
  *   notRun: string[], spend?: {trac?: string, eth?: string}, permanentBytesWritten?: number
  * }} m
  */
-export function buildManifest(m) { throw new Error('TODO'); }
+export function buildManifest(m) {
+  const {
+    attested, scenario, scenarioDigest, fleetDigest, policyDigest,
+    gates, notRun, spend, permanentBytesWritten,
+  } = m ?? {};
+  for (const [name, value] of [
+    ['attested', attested], ['scenario', scenario], ['scenarioDigest', scenarioDigest],
+    ['fleetDigest', fleetDigest], ['policyDigest', policyDigest],
+  ]) {
+    if (value === undefined || value === null) throw new Error(`buildManifest: ${name} required`);
+  }
+  if (!Array.isArray(gates)) throw new Error('buildManifest: gates must be an array');
+  if (!Array.isArray(notRun)) throw new Error('buildManifest: notRun must be an array');
+  return {
+    attested,
+    scenario, // verbatim — the manifest binds evidence to the exact scenario document
+    scenarioDigest,
+    fleetDigest, // digest ONLY — fleet.json content never enters evidence (S6)
+    policyDigest,
+    gates: gates.map((g) => ({ ...g })),
+    notRun,
+    spend: spend ?? {},
+    permanentBytesWritten: permanentBytesWritten ?? 0,
+  };
+}

--- a/testnet/lib/evidence.mjs
+++ b/testnet/lib/evidence.mjs
@@ -1,0 +1,58 @@
+// OT-RFC-61 §4.4 — append-only JSONL evidence stream + run manifest.
+// CONTRACT FILE: implementors replace TODO bodies; signatures are frozen.
+// See schema/EVIDENCE.md for the record-type contract (schema_version 1).
+
+export const SCHEMA_VERSION = 1;
+
+/**
+ * Failure classes — closed enum (RFC-61 §6). `error:<class>` is composed, not listed.
+ */
+export const FAILURE_CLASSES = Object.freeze([
+  'too_low_allowance', 'publisher_wedge', 'transport_error', 'quorum_or_backoff',
+  'admission_shed', 'rpc_exhaustion', 'timeout', 'readback_mismatch',
+  'query_result_mismatch', 'propagation_timeout', 'arrived_during_gap',
+  'finalized_unverified', 'caught_up_unverified', 'aborted',
+]);
+
+/**
+ * Evidence writer bound to one run. Appends one JSON object per line to
+ * runs/<runId>.jsonl (main) and runs/<runId>.sidecar.jsonl (raw/log text —
+ * NEVER hostnames/IPs/keys in the MAIN stream, see EVIDENCE.md hygiene).
+ */
+export class EvidenceWriter {
+  /**
+   * @param {{runId: string, runsDir: string}} opts — creates runsDir if missing.
+   */
+  constructor(opts) { throw new Error('TODO'); }
+
+  /** Append a record to the main stream. Injects type/ts/run_id/schema_version.
+   * Throws if `type` is missing or record contains a key named host/ip/sshUser.
+   * @param {string} type @param {object} record */
+  write(type, record) { throw new Error('TODO'); }
+
+  /** Append raw/verbatim material (journal excerpts etc.) to the sidecar only.
+   * @param {string} type @param {object} record */
+  writeSidecar(type, record) { throw new Error('TODO'); }
+
+  /** Path of the main stream file. @returns {string} */
+  get path() { throw new Error('TODO'); }
+}
+
+/**
+ * Compose a run id: `<phase>-<sha8>[-<qualifier>][-r<N>]-<isoBasic>`.
+ * @param {{phase: string, sha8?: string, qualifier?: string, attempt?: number, now?: Date}} p
+ */
+export function makeRunId(p) { throw new Error('TODO'); }
+
+/**
+ * Build the run_manifest record (RFC-61 §4.4): attested identities, scenario
+ * verbatim + digest, gate outcomes, NOT_RUN list, spend, permanent bytes.
+ * Pure function — caller writes it via EvidenceWriter.
+ * @param {{
+ *   attested: object, scenario: object, scenarioDigest: string,
+ *   fleetDigest: string, policyDigest: string,
+ *   gates: Array<{id: string, outcome: string, observed?: any, threshold?: any}>,
+ *   notRun: string[], spend?: {trac?: string, eth?: string}, permanentBytesWritten?: number
+ * }} m
+ */
+export function buildManifest(m) { throw new Error('TODO'); }

--- a/testnet/lib/fleet.mjs
+++ b/testnet/lib/fleet.mjs
@@ -1,0 +1,65 @@
+// OT-RFC-61 §9 — fleet snapshots, build-identity attestation, journal signature ledger.
+// CONTRACT FILE: implementors replace TODO bodies; signatures are frozen.
+// Depends on lib/ssh.mjs (transport) and node:fetch for public /api/status.
+
+/**
+ * Light or full snapshot of one core. Combines the SSH k=v snapshot with the
+ * public HTTP /api/status (no auth; carries commit/buildTime/version + admission
+ * + chain rpc counters). NEVER throws — unreachable => {alias, reachable:false}.
+ * Returned record uses ONLY the alias (no host/IP — S6). Shape mirrors
+ * schema/EVIDENCE.md `fleet_snapshot` per-core entry.
+ * @param {object} core fleet.json core entry
+ * @param {{light?: boolean, connectTimeoutSec?: number}} [opts]
+ */
+export async function snapshotCore(core, opts) { throw new Error('TODO'); }
+
+/**
+ * Snapshot all cores with bounded concurrency. Returns {ts, kind, cores: [...]}.
+ * @param {object} fleet @param {{light?: boolean}} [opts]
+ */
+export async function snapshotFleet(fleet, opts) { throw new Error('TODO'); }
+
+/**
+ * Build-identity attestation (RFC-61 §3.1, review r1): identity is the
+ * daemon-reported embedded commit/buildTime from /api/status, bound to worker
+ * MainPID + ExecMainStartTimestamp from the same snapshot pass. Returns
+ * {alias, commit, buildTime, workerPid, workerStartTs, attested: boolean,
+ *  inconclusiveReason?: string}. Unknown/missing commit => attested:false.
+ * @param {object} snapshotCoreResult
+ */
+export function attestBuildIdentity(snapshotCoreResult) { throw new Error('TODO'); }
+
+/**
+ * True when two attestations describe the SAME running artifact (commit equal,
+ * pid equal, start ts equal). Used to detect mid-run SHA changes (§3.1: a
+ * change invalidates all network-dependent SLIs).
+ */
+export function sameArtifact(a, b) { throw new Error('TODO'); }
+
+/**
+ * Capture per-core journal cursors (full snapshot includes them). Returns
+ * {alias, cursor, valid}.
+ * @param {object} fleet
+ */
+export async function captureJournalCursors(fleet) { throw new Error('TODO'); }
+
+/**
+ * Count forbidden-signature classes strictly after per-core cursors
+ * (`journalctl -u <unit> --after-cursor=<c> -o cat` piped to a single awk/grep
+ * program composed from ledger.json). Exit status checked: a vacuumed/invalid
+ * cursor yields {cursorValid:false} and the caller scores INCONCLUSIVE — never
+ * silent zeroes (§9.2). Raw matched lines go to the sidecar via the provided
+ * callback, never returned in counts.
+ * @param {object} fleet
+ * @param {Array<{alias: string, cursor: string}>} cursors
+ * @param {{ledger: object, sidecar?: (alias: string, lines: string[]) => void}} opts
+ * @returns {Promise<Array<{alias, cursorValid, counts: Record<string, number>, gatedTotal, recordedTotal}>>}
+ */
+export async function journalSignatureDeltas(fleet, cursors, opts) { throw new Error('TODO'); }
+
+/**
+ * Load + validate ledger.json: {version, classes: [{id, disposition:
+ * 'gated'|'recorded', pattern (RegExp source, applied per line), description}]}.
+ * @param {string} path
+ */
+export function loadLedger(path) { throw new Error('TODO'); }

--- a/testnet/lib/fleet.mjs
+++ b/testnet/lib/fleet.mjs
@@ -1,6 +1,86 @@
 // OT-RFC-61 §9 — fleet snapshots, build-identity attestation, journal signature ledger.
-// CONTRACT FILE: implementors replace TODO bodies; signatures are frozen.
-// Depends on lib/ssh.mjs (transport) and node:fetch for public /api/status.
+// Depends on lib/ssh.mjs (transport) and fetch for the public /api/status.
+// S6: every record produced here carries ONLY the fleet.json alias — no host,
+// IP, ssh user, or key path; error strings are scrubbed of target references.
+
+import { readFileSync } from 'node:fs';
+import { sshExec, mapLimit, parseKvOutput, snapshotCommand, unitFullName } from './ssh.mjs';
+
+/** journald cursor charset (rfc59): safe inside a single-quoted remote arg. */
+export const JOURNAL_CURSOR_RE = /^[A-Za-z0-9_:;=.\-]+$/;
+
+const LIGHT_SSH_TIMEOUT_MS = 20_000;
+const FULL_SSH_TIMEOUT_MS = 70_000;
+const STATUS_TIMEOUT_MS = 5_000;
+const SIDECAR_CAP_BYTES = 65_536;
+
+function intOrNull(v) {
+  const n = Number.parseInt(String(v ?? '').trim(), 10);
+  return Number.isFinite(n) ? n : null;
+}
+
+function floatOrNull(v) {
+  const n = Number.parseFloat(String(v ?? '').trim());
+  return Number.isFinite(n) ? n : null;
+}
+
+/** systemd-style limits: 'max'/'infinity'/'[not set]'/'' -> null. */
+function limitOrNull(v) {
+  const t = String(v ?? '').trim().toLowerCase();
+  if (!t || t === 'max' || t === 'infinity' || t === '[not set]') return null;
+  return intOrNull(t);
+}
+
+function numOrNull(v) {
+  const n = Number(v);
+  return typeof v === 'number' || (typeof v === 'string' && v.trim() !== '') ? (Number.isFinite(n) ? n : null) : null;
+}
+
+/**
+ * Remove target-identifying strings (host, ssh user, identity path) from a
+ * transport error message so it can travel in main-stream evidence (S6).
+ * Extra exported helper (not part of the frozen contract).
+ * @param {string} text @param {object} core
+ */
+export function scrubTargetRefs(text, core) {
+  let out = String(text ?? '');
+  for (const needle of [core?.host, core?.sshUser, core?.sshIdentity]) {
+    if (needle) out = out.split(String(needle)).join('[redacted]');
+  }
+  return out.length > 400 ? `${out.slice(0, 400)}...` : out;
+}
+
+function sshTarget(core) {
+  return { host: core.host, sshUser: core.sshUser, sshIdentity: core.sshIdentity };
+}
+
+async function fetchStatus(core, fetchImpl, timeoutMs) {
+  if (!core.apiPort) return { reachable: false, error: 'no_api_port' };
+  try {
+    const res = await fetchImpl(`http://${core.host}:${core.apiPort}/api/status`, {
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!res.ok) return { reachable: false, error: `http_${res.status}` };
+    const body = await res.json();
+    return { reachable: true, body: body && typeof body === 'object' ? body : {} };
+  } catch (err) {
+    const name = err?.name;
+    if (name === 'TimeoutError' || name === 'AbortError') return { reachable: false, error: 'status_timeout' };
+    const cause = err?.cause?.message ? `: ${err.cause.message}` : '';
+    return { reachable: false, error: `${String(err?.message ?? err)}${cause}` };
+  }
+}
+
+/** Defensive extraction of admission/chain counters from /api/status JSON. */
+function apiCounters(status) {
+  const adm = status?.admission;
+  const chain = status?.chain;
+  return {
+    admissionRejected: numOrNull(adm?.rejected ?? adm?.rejectedTotal ?? adm?.rejectedCount ?? adm?.shed),
+    rpcFailovers: numOrNull(chain?.rpcFailovers ?? status?.rpcFailovers),
+    rpcExhaustions: numOrNull(chain?.rpcExhaustions ?? status?.rpcExhaustions),
+  };
+}
 
 /**
  * Light or full snapshot of one core. Combines the SSH k=v snapshot with the
@@ -10,14 +90,104 @@
  * schema/EVIDENCE.md `fleet_snapshot` per-core entry.
  * @param {object} core fleet.json core entry
  * @param {{light?: boolean, connectTimeoutSec?: number}} [opts]
+ *   Optional extras: _sshExec/_fetch (injectable for tests), sshTimeoutMs,
+ *   statusTimeoutMs.
  */
-export async function snapshotCore(core, opts) { throw new Error('TODO'); }
+export async function snapshotCore(core, opts = {}) {
+  const light = Boolean(opts.light);
+  const alias = core?.alias ?? 'unknown';
+  try {
+    const exec = opts._sshExec ?? sshExec;
+    const fetchImpl = opts._fetch ?? globalThis.fetch;
+    const cmd = snapshotCommand(core, { light });
+    const [sshRes, apiRes] = await Promise.all([
+      exec(sshTarget(core), cmd, {
+        timeoutMs: opts.sshTimeoutMs ?? (light ? LIGHT_SSH_TIMEOUT_MS : FULL_SSH_TIMEOUT_MS),
+        connectTimeoutSec: opts.connectTimeoutSec ?? 8,
+      }),
+      fetchStatus(core, fetchImpl, opts.statusTimeoutMs ?? STATUS_TIMEOUT_MS),
+    ]);
+    const sshOk = Boolean(sshRes?.ok);
+    const kv = sshOk ? parseKvOutput(sshRes.stdout) : {};
+    const status = apiRes.reachable ? apiRes.body : {};
+    const workerRssKb = intOrNull(kv.worker_rss_kb);
+    const mainRssKb = intOrNull(kv.main_rss_kb);
+    const usedPct = intOrNull(kv.disk_used_pct);
+    const record = {
+      alias,
+      kind: light ? 'light' : 'full',
+      ts: new Date().toISOString(),
+      // A core is "reachable" for §3.3 purposes only when both observation
+      // transports answered: the SSH snapshot AND the public /api/status.
+      reachable: sshOk && apiRes.reachable,
+      transport: { ssh: sshOk, api: apiRes.reachable },
+      systemd: sshOk ? {
+        activeState: kv.active_state || null,
+        subState: kv.sub_state || null,
+        execMainStartTs: kv.exec_main_start || null,
+        nRestarts: intOrNull(kv.n_restarts),
+        mainPid: intOrNull(kv.main_pid),
+      } : null,
+      workerPid: sshOk ? intOrNull(kv.worker_pid) : null,
+      build: apiRes.reachable ? {
+        commit: status.commit ?? status.commitShort ?? status.build?.commit ?? null,
+        buildTime: status.buildTime ?? status.build?.time ?? null,
+        version: status.version ?? null,
+      } : null,
+      // rss is BYTES (ps reports KiB; converted here) — cgroup fields and the
+      // monitor formatter all speak bytes, so the snapshot does too.
+      rss: (workerRssKb ?? mainRssKb) === null ? null : (workerRssKb ?? mainRssKb) * 1024,
+      rssDetail: sshOk ? { mainKb: mainRssKb, workerKb: workerRssKb } : null,
+      cgroup: sshOk ? {
+        memoryCurrent: intOrNull(kv.memory_current),
+        memoryPeak: intOrNull(kv.memory_peak),
+        memoryHigh: limitOrNull(kv.memory_high),
+        memoryMax: limitOrNull(kv.memory_max),
+        oomKills: intOrNull(kv.oom_kills) ?? 0,
+        psiSomeAvg10: floatOrNull(kv.psi_some_avg10),
+      } : null,
+      listen: sshOk ? {
+        recvQ: intOrNull(kv.listen_recvq),
+        backlog: intOrNull(kv.listen_backlog),
+        connectProbeOk: kv.probe_ok === '1',
+      } : null,
+      diskFree: sshOk ? {
+        bytes: intOrNull(kv.disk_avail_bytes),
+        fraction: usedPct === null ? null : (100 - usedPct) / 100,
+      } : null,
+      api: { reachable: apiRes.reachable, ...apiCounters(status) },
+    };
+    if (!light && sshOk) {
+      record.storeBytes = intOrNull(kv.store_bytes);
+      record.journalCursor = kv.journal_cursor || null;
+    }
+    if (sshOk && kv.snapshot_complete !== '1') record.snapshotTruncated = true;
+    if (!record.reachable) {
+      const parts = [];
+      if (!sshOk) {
+        parts.push(sshRes?.timedOut
+          ? 'ssh_timeout'
+          : `ssh_failed(code=${sshRes?.code ?? 'null'})${sshRes?.stderr ? `: ${sshRes.stderr.slice(0, 200)}` : ''}`);
+      }
+      if (!apiRes.reachable) parts.push(`api_status: ${apiRes.error}`);
+      record.error = scrubTargetRefs(parts.join('; '), core);
+    }
+    return record;
+  } catch (err) {
+    return { alias, reachable: false, error: scrubTargetRefs(String(err?.message ?? err), core) };
+  }
+}
 
 /**
  * Snapshot all cores with bounded concurrency. Returns {ts, kind, cores: [...]}.
  * @param {object} fleet @param {{light?: boolean}} [opts]
  */
-export async function snapshotFleet(fleet, opts) { throw new Error('TODO'); }
+export async function snapshotFleet(fleet, opts = {}) {
+  const cores = fleet?.cores ?? [];
+  const perCore = { connectTimeoutSec: fleet?.sshConnectTimeoutSec, ...opts };
+  const results = await mapLimit(cores, fleet?.sshConcurrency ?? 2, (core) => snapshotCore(core, perCore));
+  return { ts: new Date().toISOString(), kind: opts.light ? 'light' : 'full', cores: results };
+}
 
 /**
  * Build-identity attestation (RFC-61 §3.1, review r1): identity is the
@@ -27,21 +197,94 @@ export async function snapshotFleet(fleet, opts) { throw new Error('TODO'); }
  *  inconclusiveReason?: string}. Unknown/missing commit => attested:false.
  * @param {object} snapshotCoreResult
  */
-export function attestBuildIdentity(snapshotCoreResult) { throw new Error('TODO'); }
+export function attestBuildIdentity(snapshotCoreResult) {
+  const s = snapshotCoreResult;
+  const out = {
+    alias: s?.alias ?? null,
+    commit: s?.build?.commit ?? null,
+    buildTime: s?.build?.buildTime ?? null,
+    workerPid: s?.workerPid ?? s?.systemd?.mainPid ?? null,
+    workerStartTs: s?.systemd?.execMainStartTs ?? null,
+    attested: false,
+  };
+  if (!s || s.reachable !== true) return { ...out, inconclusiveReason: 'core_unreachable' };
+  const commitText = String(out.commit ?? '').trim();
+  if (!commitText || /^(unknown|null|undefined|none)$/i.test(commitText)) {
+    return { ...out, inconclusiveReason: 'missing_build_identity' };
+  }
+  if (/dirty/i.test(commitText)) return { ...out, inconclusiveReason: 'dirty_build_identity' };
+  if (!out.workerPid || !out.workerStartTs) return { ...out, inconclusiveReason: 'missing_process_binding' };
+  return { ...out, attested: true };
+}
 
 /**
  * True when two attestations describe the SAME running artifact (commit equal,
  * pid equal, start ts equal). Used to detect mid-run SHA changes (§3.1: a
  * change invalidates all network-dependent SLIs).
  */
-export function sameArtifact(a, b) { throw new Error('TODO'); }
+export function sameArtifact(a, b) {
+  if (!a?.attested || !b?.attested) return false;
+  if (a.alias != null && b.alias != null && a.alias !== b.alias) return false;
+  return a.commit === b.commit && a.workerPid === b.workerPid && a.workerStartTs === b.workerStartTs;
+}
 
 /**
  * Capture per-core journal cursors (full snapshot includes them). Returns
  * {alias, cursor, valid}.
  * @param {object} fleet
+ * @param {{_sshExec?: Function, timeoutMs?: number, connectTimeoutSec?: number}} [opts]
  */
-export async function captureJournalCursors(fleet) { throw new Error('TODO'); }
+export async function captureJournalCursors(fleet, opts = {}) {
+  const exec = opts._sshExec ?? sshExec;
+  return mapLimit(fleet?.cores ?? [], fleet?.sshConcurrency ?? 2, async (core) => {
+    const unit = unitFullName(core.systemdUnit);
+    const res = await exec(
+      sshTarget(core),
+      `journalctl -u ${unit} -n 0 --show-cursor --no-pager 2>/dev/null`,
+      {
+        timeoutMs: opts.timeoutMs ?? LIGHT_SSH_TIMEOUT_MS,
+        connectTimeoutSec: opts.connectTimeoutSec ?? fleet?.sshConnectTimeoutSec ?? 8,
+      },
+    );
+    const m = res?.ok ? String(res.stdout).match(/^-- cursor: (.+)$/m) : null;
+    const cursor = m ? m[1].trim() : null;
+    return { alias: core.alias, cursor, valid: Boolean(cursor && JOURNAL_CURSOR_RE.test(cursor)) };
+  });
+}
+
+/**
+ * Compose the single-pass awk program that counts every ledger class into a
+ * per-class variable and prints `sig_<id>=<n>` lines. One journal read, one
+ * regex test per class per line, against the lowercased line — semantics kept
+ * identical to signatureCountsFromText (a test asserts awk/JS parity).
+ * Extra exported helper (not part of the frozen contract).
+ * @param {object} ledger validated ledger
+ */
+export function composeSignatureAwk(ledger) {
+  const inits = ledger.classes.map((_, i) => `c${i}=0`).join('; ');
+  const body = ledger.classes.map((cls, i) => `if (l ~ /${cls.pattern}/) c${i}++`);
+  const prints = ledger.classes.map((cls, i) => `print "sig_${cls.id}=" c${i}`).join('; ');
+  return [`BEGIN { ${inits} }`, '{ l=tolower($0)', ...body, '}', `END { ${prints} }`].join('; ');
+}
+
+/**
+ * Local JS twin of the remote awk pass: count ledger classes per line over
+ * lowercased text. Used by tests and for local (edge) log deltas.
+ * Extra exported helper (not part of the frozen contract).
+ * @param {string} text @param {object} ledger
+ * @returns {Record<string, number>}
+ */
+export function signatureCountsFromText(text, ledger) {
+  validateLedger(ledger);
+  const matchers = ledger.classes.map((cls) => ({ id: cls.id, re: new RegExp(cls.pattern) }));
+  const counts = Object.fromEntries(ledger.classes.map((cls) => [cls.id, 0]));
+  for (const raw of String(text ?? '').split('\n')) {
+    if (!raw) continue;
+    const line = raw.toLowerCase();
+    for (const { id, re } of matchers) if (re.test(line)) counts[id] += 1;
+  }
+  return counts;
+}
 
 /**
  * Count forbidden-signature classes strictly after per-core cursors
@@ -53,13 +296,134 @@ export async function captureJournalCursors(fleet) { throw new Error('TODO'); }
  * @param {object} fleet
  * @param {Array<{alias: string, cursor: string}>} cursors
  * @param {{ledger: object, sidecar?: (alias: string, lines: string[]) => void}} opts
+ *   Optional extras: _sshExec (injectable for tests), timeoutMs.
  * @returns {Promise<Array<{alias, cursorValid, counts: Record<string, number>, gatedTotal, recordedTotal}>>}
  */
-export async function journalSignatureDeltas(fleet, cursors, opts) { throw new Error('TODO'); }
+export async function journalSignatureDeltas(fleet, cursors, opts) {
+  const { ledger, sidecar, _sshExec, timeoutMs = 45_000 } = opts ?? {};
+  validateLedger(ledger);
+  const exec = _sshExec ?? sshExec;
+  const byAlias = new Map((fleet?.cores ?? []).map((core) => [core.alias, core]));
+  const awk = composeSignatureAwk(ledger);
+  return mapLimit(cursors ?? [], fleet?.sshConcurrency ?? 2, async (entry) => {
+    const alias = entry?.alias ?? 'unknown';
+    // Totals are null (never zero) whenever counting could not run — silent
+    // zeroes are exactly what §9.2 forbids.
+    const inconclusive = (error) => ({
+      alias, cursorValid: false, counts: {}, gatedTotal: null, recordedTotal: null,
+      ledgerVersion: ledger.version, error,
+    });
+    const core = byAlias.get(alias);
+    if (!core) return inconclusive('unknown_alias');
+    const cursor = entry?.cursor;
+    if (!cursor || !JOURNAL_CURSOR_RE.test(cursor)) return inconclusive('missing_or_invalid_journal_cursor');
+    const unit = unitFullName(core.systemdUnit);
+    const execOpts = { timeoutMs, connectTimeoutSec: fleet?.sshConnectTimeoutSec ?? 8 };
+    // Capture journalctl before piping so a stale/vacuumed cursor cannot be
+    // converted into an apparently clean set of awk zeroes (rfc59 mechanic).
+    const remote =
+      `logs=$(journalctl -u ${unit} --after-cursor='${cursor}' --no-pager -o cat 2>&1); ` +
+      'journal_status=$?; echo journal_status=$journal_status; ' +
+      'if [ "$journal_status" -ne 0 ]; then echo cursor_valid=0; ' +
+      `else echo cursor_valid=1; printf '%s\\n' "$logs" | awk '${awk}'; fi`;
+    const res = await exec(sshTarget(core), remote, execOpts);
+    if (!res?.ok) return inconclusive(res?.timedOut ? 'ssh_timeout' : 'ssh_failed');
+    const kv = parseKvOutput(res.stdout);
+    if (kv.cursor_valid !== '1') return inconclusive('cursor_vacuumed_or_invalid');
+    const counts = {};
+    for (const cls of ledger.classes) {
+      const n = Number.parseInt(kv[`sig_${cls.id}`] ?? '', 10);
+      // A missing/garbled per-class count is ledger or transport breakage —
+      // INCONCLUSIVE, never a zero (§9.2 wording-drift rule).
+      if (!Number.isFinite(n)) return inconclusive('signature_output_incomplete');
+      counts[cls.id] = n;
+    }
+    let gatedTotal = 0;
+    let recordedTotal = 0;
+    for (const cls of ledger.classes) {
+      if (cls.disposition === 'gated') gatedTotal += counts[cls.id];
+      else recordedTotal += counts[cls.id];
+    }
+    if (sidecar && gatedTotal + recordedTotal > 0) {
+      // Second, capped pass ONLY when a sidecar wants raw lines. Matched text
+      // never enters the main-stream record (S6).
+      const combined = ledger.classes.map((cls) => `(${cls.pattern})`).join('|');
+      const rawRes = await exec(
+        sshTarget(core),
+        `journalctl -u ${unit} --after-cursor='${cursor}' --no-pager -o cat 2>/dev/null | ` +
+        `grep -iE '${combined}' | head -c ${SIDECAR_CAP_BYTES}`,
+        execOpts,
+      );
+      if (rawRes?.ok) {
+        const lines = String(rawRes.stdout).split('\n').filter((l) => l.trim().length > 0);
+        try { sidecar(alias, lines); } catch { /* sidecar failures never poison counts */ }
+      }
+    }
+    return { alias, cursorValid: true, counts, gatedTotal, recordedTotal, ledgerVersion: ledger.version };
+  });
+}
+
+/**
+ * Validate a parsed ledger object (shape per loadLedger). Throws with a list
+ * of problems. Extra exported helper (not part of the frozen contract).
+ * @param {object} ledger @param {string} [label]
+ */
+export function validateLedger(ledger, label = 'ledger') {
+  const problems = [];
+  if (!ledger || typeof ledger !== 'object') {
+    problems.push('not an object');
+  } else {
+    if (!Number.isInteger(ledger.version) || ledger.version < 1) problems.push('version must be an integer >= 1');
+    if (!Array.isArray(ledger.classes) || ledger.classes.length === 0) {
+      problems.push('classes must be a non-empty array');
+    } else {
+      const seen = new Set();
+      ledger.classes.forEach((cls, i) => {
+        const where = `classes[${i}]`;
+        if (!cls || typeof cls !== 'object') { problems.push(`${where}: not an object`); return; }
+        if (typeof cls.id !== 'string' || !/^[a-z][a-z0-9_]*$/.test(cls.id)) {
+          problems.push(`${where}: id must match /^[a-z][a-z0-9_]*$/`);
+        } else if (seen.has(cls.id)) {
+          problems.push(`${where}: duplicate id ${cls.id}`);
+        } else {
+          seen.add(cls.id);
+        }
+        if (cls.disposition !== 'gated' && cls.disposition !== 'recorded') {
+          problems.push(`${where}: disposition must be 'gated' or 'recorded'`);
+        }
+        if (typeof cls.description !== 'string' || cls.description.trim().length === 0) {
+          problems.push(`${where}: description required`);
+        }
+        if (typeof cls.pattern !== 'string' || cls.pattern.length === 0) {
+          problems.push(`${where}: pattern required`);
+        } else {
+          if (cls.pattern.includes("'") || cls.pattern.includes('/')) {
+            problems.push(`${where}: pattern must not contain single quotes or slashes (embedded in a single-quoted remote awk program)`);
+          }
+          try {
+            void new RegExp(cls.pattern);
+          } catch (err) {
+            problems.push(`${where}: pattern does not compile: ${err.message}`);
+          }
+        }
+      });
+    }
+  }
+  if (problems.length > 0) throw new Error(`${label}: ${problems.join('; ')}`);
+  return ledger;
+}
 
 /**
  * Load + validate ledger.json: {version, classes: [{id, disposition:
  * 'gated'|'recorded', pattern (RegExp source, applied per line), description}]}.
  * @param {string} path
  */
-export function loadLedger(path) { throw new Error('TODO'); }
+export function loadLedger(path) {
+  let parsed;
+  try {
+    parsed = JSON.parse(readFileSync(path, 'utf8'));
+  } catch (err) {
+    throw new Error(`ledger ${path}: ${err.message}`);
+  }
+  return validateLedger(parsed, `ledger ${path}`);
+}

--- a/testnet/lib/scenario.mjs
+++ b/testnet/lib/scenario.mjs
@@ -80,11 +80,43 @@ export function attestationFromSnapshotCore(core) {
   };
 }
 
+/**
+ * Resolve the scenario's per-lane CG spec to {logical, actual} pairs.
+ * `reuse:<name>` looks <name> up in fleet.cgs (local, gitignored — actual ids
+ * may embed wallet addresses, which never enter committed files or evidence);
+ * a bare value is used as-is for both. Missing reuse mapping → throw (the
+ * caller turns this into a failing preflight check, not a crash mid-workload).
+ * @param {object} scenario @param {object} fleet
+ * @returns {Record<string, {logical: string, actual: string}>}
+ */
+export function resolveCgMap(scenario, fleet) {
+  const out = {};
+  for (const lane of scenario.lanes || Object.keys(scenario.cg || {})) {
+    const raw = (scenario.cg || {})[lane];
+    if (typeof raw !== 'string' || raw.length === 0) {
+      throw new Error(`resolveCgMap: scenario.cg.${lane} missing`);
+    }
+    if (raw.startsWith('reuse:')) {
+      const logical = raw.slice('reuse:'.length);
+      const actual = (fleet?.cgs || {})[logical];
+      if (typeof actual !== 'string' || actual.length === 0) {
+        throw new Error(`resolveCgMap: fleet.json cgs['${logical}'] mapping missing for lane '${lane}'`);
+      }
+      out[lane] = { logical, actual };
+    } else {
+      out[lane] = { logical: raw, actual: raw };
+    }
+  }
+  return out;
+}
+
 /** One full KA lifecycle op: create → share → publish → VM finalization. */
 async function runOneOp(ctx, lane, index, wave) {
   const { scenario, edge, evidence, runId, ctl, now, pollIntervalMs, opTimeoutMs } = ctx;
   const workload = scenario.workload || {};
-  const cg = (scenario.cg || {})[lane];
+  // API calls speak the ACTUAL CG id; evidence records carry the LOGICAL name (S6).
+  const cgSpec = ctx.cgMap?.[lane] ?? { logical: (scenario.cg || {})[lane], actual: (scenario.cg || {})[lane] };
+  const cg = cgSpec.actual;
   const payload = ctx.makePayload({
     runId,
     lane,
@@ -105,7 +137,7 @@ async function runOneOp(ctx, lane, index, wave) {
     const record = {
       op: workload.op || 'publish',
       lane,
-      cg,
+      cg: cgSpec.logical,
       index,
       wave,
       name,
@@ -259,6 +291,7 @@ async function runLaneBurst(ctx, { lane, wave, count, indexOffset, concurrency }
  */
 export async function runPublishScenario(p) {
   const { scenario, fleet, policy, edge, evidence, runId, baseline, snapshotIntervalMs = 5000 } = p;
+  const cgMap = p.cgMap ?? resolveCgMap(scenario, fleet);
   const now = p._now || Date.now;
   const snapshotFleetFn = p._snapshotFleet || fleetMod.snapshotFleet;
   const evaluateTripsFn = p._evaluateTrips || watchMod.evaluateTrips;
@@ -282,7 +315,7 @@ export async function runPublishScenario(p) {
 
   const ctx = {
     scenario, edge, evidence, runId, ctl, now, pollIntervalMs, opTimeoutMs,
-    inflight, attemptsLog, opResults, makePayload,
+    inflight, attemptsLog, opResults, makePayload, cgMap,
     // classifyFailure throws on unknown modes (never fold silently); the
     // composed `error:<class>` form is the sanctioned catch-side fallback.
     classify: (e) => {
@@ -388,7 +421,7 @@ export async function runPublishScenario(p) {
             ? { matched: 0, mismatches: [] }
             : await verifyReadbackFn(edge, {
               items,
-              cg: scenario.cg?.[lane],
+              cg: cgMap?.[lane]?.actual ?? scenario.cg?.[lane],
               view: 'verifiable-memory',
               chunkSize: scenario.readback?.chunkSize,
             });
@@ -592,15 +625,19 @@ export function buildGates(p) {
   const successes = scored.filter((o) => o.outcome === 'success');
   const gates = [];
 
-  // §3.1 mid-run SHA change: final snapshot attestation vs baseline attestation.
-  let shaChanged = false;
+  // §3.1 mid-run running-artifact change: final snapshot attestation vs
+  // baseline. sameArtifact compares commit AND pid AND start-ts, so an
+  // auto-update recycle onto the SAME commit still (correctly) invalidates —
+  // the label says "artifact", not "sha", for exactly that case (seen live:
+  // certify-94f3c78c-r1 caught a fleet-wide worker recycle mid-run).
+  let artifactChanged = false;
   for (const core of run.finalSnapshot?.cores || []) {
     if (core.reachable === false) continue;
     const base = (baseline?.attested || []).find((a) => a.alias === core.alias);
     if (!base || base.attested === false) continue;
-    if (!sameArtifact(base, attestationFromSnapshotCore(core))) { shaChanged = true; break; }
+    if (!sameArtifact(base, attestationFromSnapshotCore(core))) { artifactChanged = true; break; }
   }
-  const inc = shaChanged ? { inconclusiveReason: 'fleet-sha-changed' } : {};
+  const inc = artifactChanged ? { inconclusiveReason: 'fleet-artifact-changed' } : {};
 
   const sr = g.successRate || {};
   gates.push({

--- a/testnet/lib/scenario.mjs
+++ b/testnet/lib/scenario.mjs
@@ -1,26 +1,254 @@
 // OT-RFC-61 §4.2/§5 — scenario runner. Phase 0: the certify workload.
-// CONTRACT FILE: implementors replace TODO bodies; signatures are frozen.
 // Orchestrates: edge.mjs (ops) + fleet.mjs (snapshots) + watch.mjs (trips) +
 // scoring.mjs (aggregates/gates) + evidence.mjs (records). bin/harness.mjs owns
 // the outer mode dispatch; this module owns the workload loop.
+//
+// rfc59 provenance: runPublishScenario reproduces publishBurst/publishLanePair/
+// pollFinalized + the certify branch of main(); mergePeak is the rfc59 mergePeak
+// keyed by alias with attestation-based restart detection.
+
+import os from 'node:os';
+
+import * as edgeMod from './edge.mjs';
+import * as fleetMod from './fleet.mjs';
+import * as scoringMod from './scoring.mjs';
+import { percentile as utilPercentile, sleep } from './util.mjs';
+import * as watchMod from './watch.mjs';
+
+function jobFailed(job) {
+  if (!job) return true;
+  const status = String(job.status || '').toLowerCase();
+  return status === 'failed' || status === 'error' || job.error != null;
+}
+
+function jobErrorText(job) {
+  return String(job?.error || job?.reason || job?.status || 'job_failed');
+}
+
+/**
+ * rfc59 pollFinalized port over the new EdgeClient: poll authoritative KA state
+ * (GET /api/knowledge-assets/:name) until memoryLayer=VM or the deadline.
+ * deadlineMs <= now means exactly ONE authoritative read (used to re-score a
+ * daemon-terminal job failure without a long poll).
+ * Extra exported helper (additive to the frozen contract).
+ * @param {object} edge EdgeClient
+ * @param {{name: string, cg: string, deadlineMs: number, intervalMs?: number,
+ *          _now?: () => number, _sleep?: (ms: number) => Promise<void>,
+ *          isAborted?: () => boolean}} opts
+ * @returns {Promise<{finalized: boolean, ual?: string|null, reservedUal?: string|null, tx?: string|null, reason?: string}>}
+ */
+export async function pollVmFinalized(edge, opts) {
+  const { name, cg, deadlineMs, intervalMs = 1000, isAborted } = opts;
+  const now = opts._now || Date.now;
+  const zzz = opts._sleep || sleep;
+  for (;;) {
+    try {
+      const s = await edge.knowledgeAssetState({ name, cg });
+      const layer = String(s?.memoryLayer || '').toUpperCase();
+      const events = (s?.events || []).map((e) => String(e.toLayer || e.type || '').toUpperCase());
+      if (layer === 'VM' || events.some((e) => e === 'VM' || /FINALIZ/.test(e))) {
+        // reservedUal is a prepublish identity; only publishedUal is on-chain.
+        return {
+          finalized: true,
+          ual: s.publishedUal || null,
+          reservedUal: s.reservedUal || null,
+          tx: s.txHash || s.tx || null,
+        };
+      }
+      if (/FAIL|ERROR|REVERT/i.test(String(s?.status || ''))) {
+        return { finalized: false, reason: `state:${s.status}` };
+      }
+    } catch {
+      /* keep polling until the authoritative deadline */
+    }
+    if (isAborted && isAborted()) return { finalized: false, reason: 'harness_quiesce' };
+    const remaining = deadlineMs - now();
+    if (remaining <= 0) break;
+    await zzz(Math.min(intervalMs, remaining));
+  }
+  return { finalized: false, reason: 'vm_poll_timeout' };
+}
+
+/** Build the attestation-comparable shape from a fleet_snapshot per-core entry. */
+export function attestationFromSnapshotCore(core) {
+  return {
+    alias: core.alias,
+    commit: core.build?.commit ?? null,
+    buildTime: core.build?.buildTime ?? null,
+    workerPid: core.workerPid ?? null,
+    workerStartTs: core.systemd?.execMainStartTs ?? null,
+  };
+}
+
+/** One full KA lifecycle op: create → share → publish → VM finalization. */
+async function runOneOp(ctx, lane, index, wave) {
+  const { scenario, edge, evidence, runId, ctl, now, pollIntervalMs, opTimeoutMs } = ctx;
+  const workload = scenario.workload || {};
+  const cg = (scenario.cg || {})[lane];
+  const payload = ctx.makePayload({
+    runId,
+    lane,
+    index,
+    controlFixtureEvery: workload.controlFixtureEvery ?? 10,
+  });
+  const name = `rfc61-${runId}-${lane}-${index}`;
+  const durations = { create: null, share: null, publish: null, vm_finalization: null };
+  const attempt = { ts: now(), shed: false };
+  ctx.attemptsLog.push(attempt);
+  const opState = { cancelled: false };
+  const handle = { cancel: async () => { opState.cancelled = true; } };
+  ctx.inflight.add(handle);
+
+  const aborted = () => ctl.aborted || opState.cancelled;
+
+  const finish = (outcome, reason, extra = {}) => {
+    const record = {
+      op: workload.op || 'publish',
+      lane,
+      cg,
+      index,
+      wave,
+      name,
+      subject: payload.subject,
+      expected_object: payload.expectedObject,
+      bytes: Buffer.byteLength(String(payload.quads || ''), 'utf8'),
+      outcome,
+      reason: reason ?? null,
+      durations_ms: { ...durations },
+      anchor_meta: { poll_interval_ms: pollIntervalMs },
+      ual: extra.ual ?? null,
+      tx: extra.tx ?? null,
+      control_fixture: payload.controlFixture === true,
+      recovered_after_client_error: extra.recovered === true,
+    };
+    if (outcome === 'admission_shed') attempt.shed = true;
+    evidence.write('op_result', record);
+    ctx.opResults.push(record);
+    return record;
+  };
+
+  let phase = 'create';
+  let phaseStart = now();
+  try {
+    if (aborted()) return finish('aborted', 'harness_quiesce');
+    await edge.createKnowledgeAsset({ name, cg, quads: payload.quads });
+    durations.create = now() - phaseStart;
+
+    phase = 'share';
+    if (aborted()) return finish('aborted', 'harness_quiesce');
+    phaseStart = now();
+    const shareJob = await edge.shareAsync({ name, cg });
+    const shared = await edge.waitShareJob({
+      jobId: shareJob.jobId, timeoutMs: opTimeoutMs, intervalMs: pollIntervalMs,
+    });
+    durations.share = now() - phaseStart;
+    if (jobFailed(shared)) {
+      // Create/share failures have no publish to recover (rfc59 §6 rule).
+      return finish(ctx.classify({ jobError: jobErrorText(shared) }), jobErrorText(shared));
+    }
+
+    phase = 'publish';
+    if (aborted()) return finish('aborted', 'harness_quiesce');
+    phaseStart = now();
+    const publishJob = await edge.publishAsync({ name, cg });
+    const published = await edge.waitPublishJob({
+      jobId: publishJob.jobId, timeoutMs: opTimeoutMs, intervalMs: pollIntervalMs,
+    });
+    durations.publish = now() - phaseStart;
+
+    let ual = published?.ual ?? null;
+    let tx = published?.txHash ?? published?.tx ?? null;
+    let recovered = false;
+    if (jobFailed(published)) {
+      // §6 recovery re-scoring: one authoritative KA-state read before failing —
+      // the daemon said failed, so a single read decides (no long re-poll).
+      const t = now();
+      const rescored = await pollVmFinalized(edge, {
+        name, cg, deadlineMs: now(), intervalMs: pollIntervalMs, _now: now,
+      });
+      if (durations.vm_finalization == null) durations.vm_finalization = now() - t;
+      if (!rescored.finalized) {
+        return finish(ctx.classify({ jobError: jobErrorText(published) }), jobErrorText(published));
+      }
+      ual = rescored.ual;
+      tx = rescored.tx ?? tx;
+      recovered = true;
+    }
+
+    if (!recovered) {
+      phase = 'vm_finalization';
+      if (aborted()) return finish('aborted', 'harness_quiesce', { ual, tx });
+      phaseStart = now();
+      const finalized = await pollVmFinalized(edge, {
+        name, cg, deadlineMs: now() + opTimeoutMs, intervalMs: pollIntervalMs,
+        _now: now, isAborted: aborted,
+      });
+      durations.vm_finalization = now() - phaseStart;
+      if (aborted() && !finalized.finalized) return finish('aborted', 'harness_quiesce', { ual, tx });
+      if (!finalized.finalized) {
+        const reason = finalized.reason || 'vm_poll_timeout';
+        return finish(ctx.classify({ jobError: reason }), reason, { ual, tx });
+      }
+      ual = finalized.ual ?? ual;
+      tx = finalized.tx ?? tx;
+    }
+
+    return finish('success', null, { ual, tx, recovered });
+  } catch (error) {
+    if (durations[phase] == null) durations[phase] = now() - phaseStart;
+    if (aborted()) return finish('aborted', 'harness_quiesce');
+    if (phase === 'publish' || phase === 'vm_finalization') {
+      // Client-side error after the daemon may have accepted work: re-score
+      // against authoritative KA state for up to the op timeout (rfc59
+      // "recovered_after_cli_error" port — here recovered_after_client_error).
+      const t = now();
+      const rescored = await pollVmFinalized(edge, {
+        name, cg, deadlineMs: now() + opTimeoutMs, intervalMs: pollIntervalMs,
+        _now: now, isAborted: aborted,
+      });
+      if (durations.vm_finalization == null) durations.vm_finalization = now() - t;
+      if (rescored.finalized) {
+        return finish('success', null, { ual: rescored.ual, tx: rescored.tx, recovered: true });
+      }
+      if (aborted()) return finish('aborted', 'harness_quiesce');
+    }
+    const text = String(error?.message || error);
+    return finish(ctx.classify({ jobError: text }), text);
+  } finally {
+    ctx.inflight.delete(handle);
+  }
+}
+
+/** rfc59 publishBurst port: `count` ops on one lane at bounded concurrency. */
+async function runLaneBurst(ctx, { lane, wave, count, indexOffset, concurrency }) {
+  const results = [];
+  let next = 0;
+  const workerCount = Math.max(1, Math.min(concurrency, Math.max(count, 1)));
+  const workers = Array.from({ length: workerCount }, async () => {
+    for (;;) {
+      if (ctx.ctl.aborted) return;
+      const i = next++;
+      if (i >= count) return;
+      results.push(await runOneOp(ctx, lane, indexOffset + i, wave));
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}
 
 /**
  * Execute a publish-scenario workload (Phase 0: certify-100 shape) against the
- * driver edge with a live S3 watch. Responsibilities:
- *  - waves × per-lane bursts at scenario concurrency (lanes run in parallel,
- *    rfc59 publishLanePair port) using edge.makePayload / createKnowledgeAsset /
- *    shareAsync / publishAsync + §6 recovery re-scoring via knowledgeAssetState;
- *  - one op_result per KA with per-phase durations + anchor_meta.poll_interval_ms;
- *  - light fleet snapshot loop every snapshotIntervalMs on a timer; host_telemetry
- *    records at the same cadence; evaluateTrips after every snapshot — on fire:
- *    quiesce + safety_abort record + stop (partial aggregates flagged);
- *  - per-wave byte-exact readback (edge.verifyReadback) → readback_result;
- *  - soak (scenario.soakSeconds) with the watch still active;
- *  - final full snapshot + journalSignatureDeltas vs baseline cursors.
- * Returns everything bin needs for gating:
+ * driver edge with a live S3 watch. See the contract JSDoc in the header of
+ * this file's stub for responsibilities; additive optional fields on `p`:
+ *   pollIntervalMs (default 1000), opTimeoutMs (default 180000), ledger
+ *   (loaded ledger.json for journal deltas; absent => deltas score
+ *   cursorValid:false / 'ledger_unavailable', never silent zeroes),
+ *   _snapshotFleet, _journalSignatureDeltas, _evaluateTrips, _quiesce,
+ *   _makePayload, _verifyReadback, _classifyFailure, _sameArtifact, _now
+ *   (test injection; real modules used when absent).
  * @param {{
- *   scenario: object, fleet: object, policy: object, edge: object /* EdgeClient *\/,
- *   evidence: object /* EvidenceWriter *\/, runId: string,
+ *   scenario: object, fleet: object, policy: object, edge: object,
+ *   evidence: object, runId: string,
  *   baseline: {snapshot: object, cursors: object[], attested: object[]},
  *   snapshotIntervalMs?: number
  * }} p
@@ -29,24 +257,477 @@
  *   finalSnapshot: object, peak: object, safetyAborted: boolean, trips: object[]
  * }>}
  */
-export async function runPublishScenario(p) { throw new Error('TODO'); }
+export async function runPublishScenario(p) {
+  const { scenario, fleet, policy, edge, evidence, runId, baseline, snapshotIntervalMs = 5000 } = p;
+  const now = p._now || Date.now;
+  const snapshotFleetFn = p._snapshotFleet || fleetMod.snapshotFleet;
+  const evaluateTripsFn = p._evaluateTrips || watchMod.evaluateTrips;
+  const quiesceFn = p._quiesce || watchMod.quiesce;
+  const makePayload = p._makePayload || edgeMod.makePayload;
+  const verifyReadbackFn = p._verifyReadback || edgeMod.verifyReadback;
+  const classifyFn = p._classifyFailure || scoringMod.classifyFailure;
+  const sameArtifact = p._sameArtifact || fleetMod.sameArtifact;
+  const pollIntervalMs = p.pollIntervalMs ?? 1000;
+  const opTimeoutMs = p.opTimeoutMs ?? 180_000;
+
+  const ctl = { aborted: false };
+  const trips = [];
+  const opResults = [];
+  const readbacks = [];
+  const inflight = new Set();
+  const attemptsLog = [];
+  const snapshotHistory = [];
+  let peak = null;
+  let quiesceResult = null;
+
+  const ctx = {
+    scenario, edge, evidence, runId, ctl, now, pollIntervalMs, opTimeoutMs,
+    inflight, attemptsLog, opResults, makePayload,
+    // classifyFailure throws on unknown modes (never fold silently); the
+    // composed `error:<class>` form is the sanctioned catch-side fallback.
+    classify: (e) => {
+      try { return classifyFn(e); } catch { return 'error:unclassified'; }
+    },
+  };
+
+  const windowSecRaw = policy?.trips?.admissionShedWindowSec;
+  const windowSec = Number(
+    (windowSecRaw && typeof windowSecRaw === 'object' ? windowSecRaw.default : windowSecRaw) ?? 60,
+  );
+  const edgeWindow = () => {
+    const cutoff = now() - windowSec * 1000;
+    const recent = attemptsLog.filter((a) => a.ts >= cutoff);
+    return { attempts: recent.length, shed: recent.filter((a) => a.shed).length, windowSec };
+  };
+
+  const onTrip = async (fired) => {
+    if (ctl.aborted) return;
+    ctl.aborted = true;
+    trips.push(...fired);
+    clearInterval(timer);
+    quiesceResult = await quiesceFn({
+      inflight: [...inflight],
+      edges: [edge],
+      policy,
+      confirmFlat: async () => inflight.size === 0,
+    });
+    for (const trip of fired) {
+      evidence.write('safety_abort', { ...trip, quiesce: quiesceResult });
+    }
+  };
+
+  let ticking = false;
+  const tick = async () => {
+    if (ticking || ctl.aborted) return;
+    ticking = true;
+    try {
+      const snapshot = await snapshotFleetFn(fleet, { light: true });
+      snapshotHistory.push(snapshot);
+      peak = mergePeak(peak, snapshot, baseline?.attested || [], { _sameArtifact: sameArtifact });
+      evidence.write('fleet_snapshot', {
+        kind: snapshot.kind ?? 'light',
+        snapshotTs: snapshot.ts ?? null,
+        cores: snapshot.cores ?? [],
+      });
+      evidence.write('host_telemetry', {
+        loadavg: os.loadavg(),
+        cpuFraction: os.cpus().length ? os.loadavg()[0] / os.cpus().length : null,
+        memFreeBytes: os.freemem(),
+        note: 'driver-laptop',
+      });
+      let fired;
+      try {
+        fired = evaluateTripsFn({
+          policy,
+          baseline: baseline?.snapshot,
+          snapshot,
+          snapshotHistory,
+          edgeWindow: edgeWindow(),
+        });
+      } catch (error) {
+        // S3 fail-closed: a watch that cannot evaluate is itself a fired trip.
+        fired = [{
+          trip: 'watch_evaluation_error',
+          observed: String(error?.message || error),
+          threshold: null,
+          reason: 'signal-unavailable',
+        }];
+      }
+      if (Array.isArray(fired) && fired.length > 0) await onTrip(fired);
+    } finally {
+      ticking = false;
+    }
+  };
+  const timer = setInterval(tick, snapshotIntervalMs);
+  timer.unref?.();
+
+  try {
+    const lanes = scenario.lanes || [];
+    const waves = Number(scenario.workload?.waves ?? 1);
+    const concurrency = Math.max(1, Number(scenario.workload?.concurrency ?? 1));
+
+    for (let wave = 1; wave <= waves && !ctl.aborted; wave++) {
+      // Lane pairs run in parallel at PER-LANE concurrency (rfc59 publishLanePair).
+      const laneResults = await Promise.all(lanes.map((lane) => {
+        const perWave = Number(scenario.workload?.perWave?.[lane] ?? 0);
+        return runLaneBurst(ctx, {
+          lane, wave, count: perWave, indexOffset: (wave - 1) * perWave, concurrency,
+        });
+      }));
+      if (ctl.aborted) break;
+
+      for (let i = 0; i < lanes.length; i++) {
+        if (ctl.aborted) break;
+        const lane = lanes[i];
+        const successes = laneResults[i].filter((r) => r.outcome === 'success');
+        const items = successes.map((r) => ({ subject: r.subject, expectedObject: r.expected_object }));
+        const indexBySubject = new Map(successes.map((r) => [r.subject, r.index]));
+        let rb;
+        try {
+          const verified = items.length === 0
+            ? { matched: 0, mismatches: [] }
+            : await verifyReadbackFn(edge, {
+              items,
+              cg: scenario.cg?.[lane],
+              view: 'verifiable-memory',
+              chunkSize: scenario.readback?.chunkSize,
+            });
+          rb = {
+            lane,
+            wave,
+            expected: items.length,
+            matched: verified.matched,
+            mismatches: (verified.mismatches || []).map((m) => ({
+              index: indexBySubject.get(m.subject) ?? null,
+              kind: m.kind,
+            })),
+            byteExact: scenario.readback?.byteExact !== false,
+          };
+        } catch (error) {
+          rb = {
+            lane,
+            wave,
+            expected: items.length,
+            matched: 0,
+            mismatches: items.map((it) => ({
+              index: indexBySubject.get(it.subject) ?? null,
+              kind: 'readback_query_failed',
+            })),
+            byteExact: scenario.readback?.byteExact !== false,
+            error: String(error?.message || error),
+          };
+        }
+        evidence.write('readback_result', rb);
+        readbacks.push(rb);
+      }
+    }
+
+    // Soak: workload stopped, ONLY the snapshot/trip loop keeps running.
+    const soakSeconds = Number(scenario.soakSeconds ?? 0);
+    if (!ctl.aborted && soakSeconds > 0) {
+      evidence.write('soak_start', { soakSeconds });
+      const soakEnd = now() + soakSeconds * 1000;
+      while (!ctl.aborted && now() < soakEnd) {
+        await sleep(Math.min(1000, Math.max(1, soakEnd - now())));
+      }
+      evidence.write('soak_end', { soakSeconds });
+    }
+  } finally {
+    clearInterval(timer);
+  }
+
+  // Final FULL snapshot + exact journal signature deltas (also on abort — the
+  // partial evidence must still bind to a final fleet state).
+  const finalSnapshot = await snapshotFleetFn(fleet, { light: false });
+  peak = mergePeak(peak, finalSnapshot, baseline?.attested || [], { _sameArtifact: sameArtifact });
+  evidence.write('fleet_snapshot', {
+    kind: finalSnapshot.kind ?? 'full',
+    snapshotTs: finalSnapshot.ts ?? null,
+    cores: finalSnapshot.cores ?? [],
+  });
+
+  let signatureDeltas;
+  if (p._journalSignatureDeltas) {
+    signatureDeltas = await p._journalSignatureDeltas(fleet, baseline?.cursors || []);
+  } else if (p.ledger) {
+    signatureDeltas = await fleetMod.journalSignatureDeltas(fleet, baseline?.cursors || [], {
+      ledger: p.ledger,
+      sidecar: (alias, lines) => evidence.writeSidecar('journal_signature_raw', { alias, lines }),
+    });
+  } else {
+    // No ledger available: never silent zeroes (§9.2) — score INCONCLUSIVE.
+    // Totals are null on breakage, matching fleet.journalSignatureDeltas.
+    signatureDeltas = (baseline?.cursors || []).map((c) => ({
+      alias: c.alias,
+      cursorValid: false,
+      counts: {},
+      gatedTotal: null,
+      recordedTotal: null,
+      ledgerVersion: null,
+      error: 'ledger_unavailable',
+    }));
+  }
+  evidence.write('journal_signature_deltas', {
+    cores: signatureDeltas,
+    ledgerVersion: p.ledger?.version ?? null,
+  });
+
+  return {
+    opResults,
+    readbacks,
+    signatureDeltas,
+    finalSnapshot,
+    peak: peak || {},
+    safetyAborted: ctl.aborted,
+    trips,
+    partial: ctl.aborted,
+    quiesce: quiesceResult,
+  };
+}
 
 /**
  * Track fleet peaks across snapshots (max RSS, max memory.current fraction,
  * restart-count/pid/start-ts changes vs baseline attestation — sticky
  * unreachability). rfc59 mergePeak port keyed by alias.
  * @param {object|null} peak @param {object} snapshot @param {object[]} baselineAttested
+ * @param {{_sameArtifact?: Function}} [opts] additive test injection
  */
-export function mergePeak(peak, snapshot, baselineAttested) { throw new Error('TODO'); }
+export function mergePeak(peak, snapshot, baselineAttested, opts = {}) {
+  const sameArtifact = opts._sameArtifact || fleetMod.sameArtifact;
+  const out = peak || {};
+  for (const core of snapshot?.cores || []) {
+    if (!core?.alias) continue;
+    let entry = out[core.alias];
+    if (!entry) {
+      entry = out[core.alias] = {
+        alias: core.alias,
+        reachable: true,
+        restartDetected: false,
+        lastError: null,
+        maxRss: 0,
+        maxMemoryCurrentBytes: 0,
+        maxMemoryCurrentFraction: null,
+        maxMemoryPeakBytes: 0,
+        maxOomKills: 0,
+        maxNRestarts: 0,
+        maxRecvQ: 0,
+        minDiskFreeBytes: null,
+        minDiskFreeFraction: null,
+        activeState: null,
+        commit: null,
+        samples: 0,
+      };
+    }
+    if (core.reachable === false) {
+      // Reachability is a whole-window invariant: sticky once lost.
+      entry.reachable = false;
+      entry.lastError = core.error || 'unreachable';
+      continue;
+    }
+    entry.samples += 1;
+    if (Number.isFinite(core.rss) && core.rss > entry.maxRss) entry.maxRss = core.rss;
+    const cg = core.cgroup || {};
+    if (Number.isFinite(cg.memoryCurrent) && cg.memoryCurrent > entry.maxMemoryCurrentBytes) {
+      entry.maxMemoryCurrentBytes = cg.memoryCurrent;
+    }
+    const ceiling = Number.isFinite(cg.memoryHigh) && cg.memoryHigh > 0 ? cg.memoryHigh
+      : Number.isFinite(cg.memoryMax) && cg.memoryMax > 0 ? cg.memoryMax : null;
+    if (ceiling != null && Number.isFinite(cg.memoryCurrent)) {
+      const fraction = cg.memoryCurrent / ceiling;
+      if (entry.maxMemoryCurrentFraction == null || fraction > entry.maxMemoryCurrentFraction) {
+        entry.maxMemoryCurrentFraction = fraction;
+      }
+    }
+    if (Number.isFinite(cg.memoryPeak) && cg.memoryPeak > entry.maxMemoryPeakBytes) {
+      entry.maxMemoryPeakBytes = cg.memoryPeak;
+    }
+    if (Number.isFinite(cg.oomKills) && cg.oomKills > entry.maxOomKills) entry.maxOomKills = cg.oomKills;
+    const sysd = core.systemd || {};
+    if (Number.isFinite(sysd.nRestarts) && sysd.nRestarts > entry.maxNRestarts) {
+      entry.maxNRestarts = sysd.nRestarts;
+    }
+    if (Number.isFinite(core.listen?.recvQ) && core.listen.recvQ > entry.maxRecvQ) {
+      entry.maxRecvQ = core.listen.recvQ;
+    }
+    const disk = core.diskFree || {};
+    if (Number.isFinite(disk.bytes) && (entry.minDiskFreeBytes == null || disk.bytes < entry.minDiskFreeBytes)) {
+      entry.minDiskFreeBytes = disk.bytes;
+    }
+    if (Number.isFinite(disk.fraction) && (entry.minDiskFreeFraction == null || disk.fraction < entry.minDiskFreeFraction)) {
+      entry.minDiskFreeFraction = disk.fraction;
+    }
+    if (sysd.activeState) entry.activeState = sysd.activeState;
+    if (core.build?.commit) entry.commit = core.build.commit;
+
+    const base = (baselineAttested || []).find((a) => a.alias === core.alias);
+    if (base && base.attested !== false) {
+      // §9.1: restart detection combines counters WITH pid/start-ts deltas —
+      // sameArtifact covers commit + pid + start ts against the baseline.
+      const current = attestationFromSnapshotCore(core);
+      if (!sameArtifact(base, current)) entry.restartDetected = true;
+    }
+  }
+  return out;
+}
+
+function rate(successes, attempts) {
+  return attempts > 0 ? successes / attempts : 0;
+}
 
 /**
  * Map scenario.gates + run artifacts to scoring.evaluateGate inputs (Phase 0
- * certify battery: overall/per-lane success with minSamples, publish p95 with
- * coverage, control fixtures, unique UALs, readback, fleet gates incl.
- * memoryPeakFraction from sampled memory.current (§9.4), core restarts via
- * attestation deltas, oom delta, gated signatures with cursorValid handling,
- * mid-run SHA change => all network-dependent gates INCONCLUSIVE).
+ * certify battery). Pure. Additive optional injection on `p`: _percentile
+ * (defaults util.percentile), _sameArtifact (defaults fleet.sameArtifact).
  * @param {{scenario: object, run: object, baseline: object}} p
  * @returns {Array<object>} gate inputs for scoring.evaluateGate
  */
-export function buildGates(p) { throw new Error('TODO'); }
+export function buildGates(p) {
+  const { scenario, run, baseline } = p;
+  const pctl = p._percentile || utilPercentile;
+  const sameArtifact = p._sameArtifact || fleetMod.sameArtifact;
+  const g = scenario.gates || {};
+  const ops = run.opResults || [];
+  // §6: harness-quiesce 'aborted' ops are excluded from every denominator.
+  const scored = ops.filter((o) => o.outcome !== 'aborted');
+  const successes = scored.filter((o) => o.outcome === 'success');
+  const gates = [];
+
+  // §3.1 mid-run SHA change: final snapshot attestation vs baseline attestation.
+  let shaChanged = false;
+  for (const core of run.finalSnapshot?.cores || []) {
+    if (core.reachable === false) continue;
+    const base = (baseline?.attested || []).find((a) => a.alias === core.alias);
+    if (!base || base.attested === false) continue;
+    if (!sameArtifact(base, attestationFromSnapshotCore(core))) { shaChanged = true; break; }
+  }
+  const inc = shaChanged ? { inconclusiveReason: 'fleet-sha-changed' } : {};
+
+  const sr = g.successRate || {};
+  gates.push({
+    id: 'success_rate_overall',
+    kind: 'successRate',
+    threshold: sr.overall ?? 0.95,
+    observed: rate(successes.length, scored.length),
+    samples: scored.length,
+    minSamples: sr.minSamples?.overall ?? 0,
+    ...inc,
+  });
+  for (const lane of scenario.lanes || []) {
+    const laneScored = scored.filter((o) => o.lane === lane);
+    const laneOk = laneScored.filter((o) => o.outcome === 'success');
+    gates.push({
+      id: `success_rate_${lane}`,
+      kind: 'successRate',
+      threshold: sr.perLane ?? sr.overall ?? 0.95,
+      observed: rate(laneOk.length, laneScored.length),
+      samples: laneScored.length,
+      minSamples: sr.minSamples?.perLane ?? 0,
+      ...inc,
+    });
+  }
+
+  if (g.publishP95Ms != null) {
+    // Percentile over SUCCESSFUL publish durations only, with mandatory
+    // coverage (minSamples + minSuccessRate) per §6.
+    const values = successes.map((o) => o.durations_ms?.publish).filter(Number.isFinite);
+    gates.push({
+      id: 'publish_p95_ms',
+      kind: 'percentile',
+      threshold: g.publishP95Ms,
+      observed: pctl(values, 95),
+      samples: values.length,
+      minSamples: sr.minSamples?.overall ?? 1,
+      successRate: rate(successes.length, scored.length),
+      minSuccessRate: sr.overall ?? 0.95,
+      ...inc,
+    });
+  }
+
+  if (g.controlFixtures) {
+    const fixtures = scored.filter((o) => o.control_fixture);
+    const finalized = fixtures.filter((o) => o.outcome === 'success');
+    const mismatchKeys = new Set((run.readbacks || []).flatMap((rb) =>
+      (rb.mismatches || []).map((m) => `${rb.lane}:${m.index}`)));
+    const readBack = finalized.filter((o) => !mismatchKeys.has(`${o.lane}:${o.index}`));
+    const ok = fixtures.length > 0
+      && (!g.controlFixtures.mustFinalize || finalized.length === fixtures.length)
+      && (!g.controlFixtures.mustReadBack || readBack.length === fixtures.length);
+    gates.push({
+      id: 'control_fixtures',
+      kind: 'bool',
+      threshold: true,
+      observed: ok,
+      evidence: { expected: fixtures.length, finalized: finalized.length, readBack: readBack.length },
+      ...inc,
+    });
+  }
+
+  if (g.uniqueUals) {
+    const uals = successes.map((o) => o.ual).filter(Boolean);
+    const ok = uals.length === successes.length && new Set(uals).size === uals.length;
+    gates.push({
+      id: 'unique_uals',
+      kind: 'bool',
+      threshold: true,
+      observed: ok,
+      evidence: { successes: successes.length, uals: uals.length, unique: new Set(uals).size },
+      ...inc,
+    });
+  }
+
+  const totalMismatches = (run.readbacks || []).reduce((n, rb) => n + (rb.mismatches?.length || 0), 0);
+  gates.push({
+    id: 'readback_mismatches',
+    kind: 'exactZero',
+    threshold: 0,
+    observed: totalMismatches,
+    ...inc,
+  });
+
+  const f = g.fleet || {};
+  const peakEntries = Object.values(run.peak || {});
+  if (f.coreRestarts != null) {
+    // Deliberately NOT marked inconclusive on SHA change — the restart gate IS
+    // the evidence of the change; workload gates carry the inconclusive flag.
+    const restarts = peakEntries.filter((e) => e.restartDetected).length;
+    gates.push({ id: 'fleet_core_restarts', kind: 'exactZero', threshold: f.coreRestarts, observed: restarts });
+  }
+  if (f.oomKillDelta != null) {
+    const baseByAlias = new Map((baseline?.snapshot?.cores || []).map((c) => [c.alias, c]));
+    let delta = 0;
+    for (const e of peakEntries) {
+      const b = baseByAlias.get(e.alias);
+      delta += Math.max(0, (e.maxOomKills || 0) - (b?.cgroup?.oomKills || 0));
+    }
+    gates.push({ id: 'fleet_oom_kill_delta', kind: 'exactZero', threshold: f.oomKillDelta, observed: delta });
+  }
+  if (f.gatedSignatures != null) {
+    const deltas = run.signatureDeltas || [];
+    const invalid = deltas.filter((d) => d.cursorValid === false);
+    const gatedTotal = deltas.reduce((n, d) => n + (d.gatedTotal || 0), 0);
+    gates.push({
+      id: 'fleet_gated_signatures',
+      kind: 'exactZero',
+      threshold: f.gatedSignatures,
+      observed: gatedTotal,
+      ...(invalid.length > 0 ? { inconclusiveReason: 'journal-cursor-invalid' } : {}),
+    });
+  }
+  if (f.memoryPeakFraction != null) {
+    // §9.4: sampled memory.current ÷ effective ceiling — cgroup lifetime
+    // memory.peak is supporting evidence only (tracked in mergePeak).
+    const fractions = peakEntries
+      .map((e) => e.maxMemoryCurrentFraction)
+      .filter((v) => Number.isFinite(v));
+    const missing = peakEntries.some((e) => e.reachable !== false && !Number.isFinite(e.maxMemoryCurrentFraction));
+    gates.push({
+      id: 'fleet_memory_peak_fraction',
+      kind: 'max',
+      threshold: f.memoryPeakFraction,
+      observed: fractions.length ? Math.max(...fractions) : null,
+      ...(missing || fractions.length === 0 ? { inconclusiveReason: 'memory-signal-unavailable' } : {}),
+    });
+  }
+
+  return gates;
+}

--- a/testnet/lib/scenario.mjs
+++ b/testnet/lib/scenario.mjs
@@ -1,0 +1,52 @@
+// OT-RFC-61 §4.2/§5 — scenario runner. Phase 0: the certify workload.
+// CONTRACT FILE: implementors replace TODO bodies; signatures are frozen.
+// Orchestrates: edge.mjs (ops) + fleet.mjs (snapshots) + watch.mjs (trips) +
+// scoring.mjs (aggregates/gates) + evidence.mjs (records). bin/harness.mjs owns
+// the outer mode dispatch; this module owns the workload loop.
+
+/**
+ * Execute a publish-scenario workload (Phase 0: certify-100 shape) against the
+ * driver edge with a live S3 watch. Responsibilities:
+ *  - waves × per-lane bursts at scenario concurrency (lanes run in parallel,
+ *    rfc59 publishLanePair port) using edge.makePayload / createKnowledgeAsset /
+ *    shareAsync / publishAsync + §6 recovery re-scoring via knowledgeAssetState;
+ *  - one op_result per KA with per-phase durations + anchor_meta.poll_interval_ms;
+ *  - light fleet snapshot loop every snapshotIntervalMs on a timer; host_telemetry
+ *    records at the same cadence; evaluateTrips after every snapshot — on fire:
+ *    quiesce + safety_abort record + stop (partial aggregates flagged);
+ *  - per-wave byte-exact readback (edge.verifyReadback) → readback_result;
+ *  - soak (scenario.soakSeconds) with the watch still active;
+ *  - final full snapshot + journalSignatureDeltas vs baseline cursors.
+ * Returns everything bin needs for gating:
+ * @param {{
+ *   scenario: object, fleet: object, policy: object, edge: object /* EdgeClient *\/,
+ *   evidence: object /* EvidenceWriter *\/, runId: string,
+ *   baseline: {snapshot: object, cursors: object[], attested: object[]},
+ *   snapshotIntervalMs?: number
+ * }} p
+ * @returns {Promise<{
+ *   opResults: object[], readbacks: object[], signatureDeltas: object[],
+ *   finalSnapshot: object, peak: object, safetyAborted: boolean, trips: object[]
+ * }>}
+ */
+export async function runPublishScenario(p) { throw new Error('TODO'); }
+
+/**
+ * Track fleet peaks across snapshots (max RSS, max memory.current fraction,
+ * restart-count/pid/start-ts changes vs baseline attestation — sticky
+ * unreachability). rfc59 mergePeak port keyed by alias.
+ * @param {object|null} peak @param {object} snapshot @param {object[]} baselineAttested
+ */
+export function mergePeak(peak, snapshot, baselineAttested) { throw new Error('TODO'); }
+
+/**
+ * Map scenario.gates + run artifacts to scoring.evaluateGate inputs (Phase 0
+ * certify battery: overall/per-lane success with minSamples, publish p95 with
+ * coverage, control fixtures, unique UALs, readback, fleet gates incl.
+ * memoryPeakFraction from sampled memory.current (§9.4), core restarts via
+ * attestation deltas, oom delta, gated signatures with cursorValid handling,
+ * mid-run SHA change => all network-dependent gates INCONCLUSIVE).
+ * @param {{scenario: object, run: object, baseline: object}} p
+ * @returns {Array<object>} gate inputs for scoring.evaluateGate
+ */
+export function buildGates(p) { throw new Error('TODO'); }

--- a/testnet/lib/scoring.mjs
+++ b/testnet/lib/scoring.mjs
@@ -63,7 +63,11 @@ export function classifyFailure(e) {
   }
   if (/readback[^a-z]{0,10}mismatch/.test(t)) return 'readback_mismatch';
   if (t.includes('timed out') || t.includes('timeout') || t.includes('etimedout')
-    || t.includes('deadline exceeded')) return 'timeout';
+    || t.includes('deadline exceeded')
+    // edge.mjs job-poll deadline message: "... did not reach finalized|failed
+    // within 180000ms (last state: validated)" — first live certify run
+    // (certify-94f3c78c-r1) surfaced this as error:unclassified.
+    || /did not reach .{0,40} within \d+ms/.test(t)) return 'timeout';
   if (t.includes('operation was aborted') || t.includes('aborterror')) return 'aborted';
 
   const excerpt = raw.trim().slice(0, 200) || '<empty>';

--- a/testnet/lib/scoring.mjs
+++ b/testnet/lib/scoring.mjs
@@ -1,0 +1,48 @@
+// OT-RFC-61 §6 — scoring semantics: aggregates, coverage gates, verdict.
+// CONTRACT FILE: implementors replace TODO bodies; signatures are frozen.
+
+/** Run outcomes. */
+export const OUTCOMES = Object.freeze(['PASS', 'FAIL', 'INCONCLUSIVE', 'SAFETY_ABORT', 'NOT_RUN']);
+
+/**
+ * Classify a failure from client output/daemon state into the closed enum
+ * (evidence.mjs FAILURE_CLASSES) — rfc59 classifyFailure port, extended.
+ * Unknown → throws (never fold silently); caller may catch and use `error:<class>`.
+ * @param {{stdout?: string, stderr?: string, jobError?: string, httpStatus?: number}} e
+ * @returns {string}
+ */
+export function classifyFailure(e) { throw new Error('TODO'); }
+
+/**
+ * Aggregate op_result records for one (op, lane): attempts, successes,
+ * successRate, nearest-rank p50/p95/p99/max over SUCCESSFUL durations only,
+ * failure counts by class, partial flag + attempted/completed/inFlight when the
+ * run was quiesced (§6: in-flight at harness quiesce => 'aborted', excluded
+ * from the success-rate denominator; SUT-aborted remain failures).
+ * @param {Array<object>} opResults @param {{op: string, lane: string, durationField: string, partial?: boolean}} opts
+ */
+export function aggregate(opResults, opts) { throw new Error('TODO'); }
+
+/**
+ * Evaluate one gate. Every latency/percentile gate REQUIRES minSamples and
+ * minSuccessRate (RFC-61 §6 coverage gates) — absent coverage fields => throw
+ * (a spec bug, not a runtime condition). Returns {id, outcome: 'PASS'|'FAIL'|
+ * 'INCONCLUSIVE', observed, threshold, evidence}.
+ * @param {{id: string, kind: 'successRate'|'percentile'|'exactZero'|'bool'|'max',
+ *          threshold: any, observed: any, samples?: number, minSamples?: number,
+ *          successRate?: number, minSuccessRate?: number, inconclusiveReason?: string}} gate
+ */
+export function evaluateGate(gate) { throw new Error('TODO'); }
+
+/**
+ * Fold gate outcomes into the run verdict:
+ * any FAIL => FAIL; else any INCONCLUSIVE => INCONCLUSIVE; else PASS.
+ * A safetyAbort flag forces SAFETY_ABORT regardless (terminal, consumes attempt).
+ * @param {{gates: Array<object>, safetyAbort?: boolean}} p
+ * @returns {{outcome: string, gates: Array<object>}}
+ */
+export function computeVerdict(p) { throw new Error('TODO'); }
+
+/** Render a human verdict table (fixed-width, no color) for terminal output.
+ * @param {{outcome: string, gates: Array<object>}} verdict @returns {string} */
+export function formatVerdict(verdict) { throw new Error('TODO'); }

--- a/testnet/lib/scoring.mjs
+++ b/testnet/lib/scoring.mjs
@@ -1,48 +1,288 @@
 // OT-RFC-61 §6 — scoring semantics: aggregates, coverage gates, verdict.
-// CONTRACT FILE: implementors replace TODO bodies; signatures are frozen.
+// Implements the Phase 0 contract; exported signatures are frozen.
+
+import { FAILURE_CLASSES } from './evidence.mjs';
+import { percentile as utilPercentile } from './util.mjs';
 
 /** Run outcomes. */
 export const OUTCOMES = Object.freeze(['PASS', 'FAIL', 'INCONCLUSIVE', 'SAFETY_ABORT', 'NOT_RUN']);
 
+/** Gate kinds understood by evaluateGate (extra export; scenario.buildGates may reuse). */
+export const GATE_KINDS = Object.freeze(['successRate', 'percentile', 'exactZero', 'bool', 'max']);
+
+const GATE_OUTCOMES = Object.freeze(['PASS', 'FAIL', 'INCONCLUSIVE']);
+
+const isNum = (v) => typeof v === 'number' && Number.isFinite(v);
+
 /**
  * Classify a failure from client output/daemon state into the closed enum
  * (evidence.mjs FAILURE_CLASSES) — rfc59 classifyFailure port, extended.
+ * Recognition order:
+ *  1. an input field that IS an enum member (or a pre-composed `error:<class>`)
+ *     passes through verbatim — daemon jobs / callers may pre-classify;
+ *  2. HTTP 503 or shed markers => admission_shed (word-boundary matched:
+ *     "established"/"published" never classify as shed);
+ *  3. the rfc59 text patterns in their original precedence
+ *     (allowance, wallet-lock wedge, transport, quorum/backoff, timeout),
+ *     extended with rpc_exhaustion, readback_mismatch, and client-abort markers.
  * Unknown → throws (never fold silently); caller may catch and use `error:<class>`.
  * @param {{stdout?: string, stderr?: string, jobError?: string, httpStatus?: number}} e
  * @returns {string}
  */
-export function classifyFailure(e) { throw new Error('TODO'); }
+export function classifyFailure(e) {
+  const fields = [e?.jobError, e?.stderr, e?.stdout];
+
+  // 1. exact class token / pre-composed error:<class> passthrough
+  for (const f of fields) {
+    if (typeof f !== 'string') continue;
+    const v = f.trim().toLowerCase();
+    if (FAILURE_CLASSES.includes(v)) return v;
+    if (/^error:[a-z0-9_.-]+$/i.test(v)) return v;
+  }
+
+  const raw = fields.filter((f) => typeof f === 'string' && f.length > 0).join('\n');
+  const t = raw.toLowerCase();
+
+  // 2. admission shed: HTTP 503 or explicit shed markers
+  if (e?.httpStatus === 503) return 'admission_shed';
+  if (/\bshed\b|\bshedding\b|load[ _-]?shed|admission[^a-z]{0,10}reject|service unavailable|\b503\b/.test(t)) {
+    return 'admission_shed';
+  }
+
+  // 3. rfc59 patterns (original precedence), extended
+  if (t.includes('toolowallowance') || t.includes('allowance')) return 'too_low_allowance';
+  if ((t.includes('wallet') && t.includes('lock')) || t.includes('wedge')) return 'publisher_wedge';
+  if (t.includes('negotiate') || t.includes('transport') || t.includes('stream has been reset')
+    || t.includes('econnreset') || t.includes('econnrefused') || t.includes('socket hang up')
+    || t.includes('epipe')) return 'transport_error';
+  if (t.includes('quorum') || t.includes('temporarily_unavailable') || t.includes('backoff')) {
+    return 'quorum_or_backoff';
+  }
+  if (t.includes('rpc') && (t.includes('exhaust') || t.includes('failover') || t.includes('all providers'))) {
+    return 'rpc_exhaustion';
+  }
+  if (/readback[^a-z]{0,10}mismatch/.test(t)) return 'readback_mismatch';
+  if (t.includes('timed out') || t.includes('timeout') || t.includes('etimedout')
+    || t.includes('deadline exceeded')) return 'timeout';
+  if (t.includes('operation was aborted') || t.includes('aborterror')) return 'aborted';
+
+  const excerpt = raw.trim().slice(0, 200) || '<empty>';
+  const status = e?.httpStatus !== undefined ? ` (httpStatus=${e.httpStatus})` : '';
+  throw new Error(`classifyFailure: unclassifiable failure${status} — never fold silently: "${excerpt}"`);
+}
 
 /**
  * Aggregate op_result records for one (op, lane): attempts, successes,
  * successRate, nearest-rank p50/p95/p99/max over SUCCESSFUL durations only,
  * failure counts by class, partial flag + attempted/completed/inFlight when the
- * run was quiesced (§6: in-flight at harness quiesce => 'aborted', excluded
- * from the success-rate denominator; SUT-aborted remain failures).
- * @param {Array<object>} opResults @param {{op: string, lane: string, durationField: string, partial?: boolean}} opts
+ * run was quiesced (§6: in-flight at harness quiesce => outcome 'aborted',
+ * excluded from the success-rate denominator; SUT-aborted ops carry an ordinary
+ * failure class on their op_result and remain failures).
+ * Records carrying op/lane fields are filtered to the requested pair; records
+ * without those fields are assumed pre-filtered by the caller.
+ * A non-success outcome outside FAILURE_CLASSES / `error:<class>` throws.
+ * Returns {op, lane, attempts, successes, failed, aborted, successRate,
+ *   durationsMs: {field, count, p50, p95, p99, max}, failuresByClass, partial,
+ *   attempted?, completed?, inFlight?}.
+ * @param {Array<object>} opResults
+ * @param {{op: string, lane: string, durationField: string, partial?: boolean,
+ *          _percentile?: (values: number[], p: number) => number|null}} opts
  */
-export function aggregate(opResults, opts) { throw new Error('TODO'); }
+export function aggregate(opResults, opts) {
+  if (!opts || typeof opts.op !== 'string' || typeof opts.lane !== 'string'
+    || typeof opts.durationField !== 'string') {
+    throw new TypeError('aggregate: opts {op, lane, durationField} required');
+  }
+  const pct = opts._percentile ?? utilPercentile;
+  const rows = (Array.isArray(opResults) ? opResults : []).filter((r) => r
+    && (r.op === undefined || r.op === opts.op)
+    && (r.lane === undefined || r.lane === opts.lane));
+
+  let successes = 0;
+  let aborted = 0;
+  const failuresByClass = {};
+  const durations = [];
+  for (const r of rows) {
+    const outcome = r.outcome;
+    if (outcome === 'success') {
+      successes += 1;
+      const d = r.durations_ms?.[opts.durationField] ?? r[opts.durationField];
+      if (isNum(d)) durations.push(d);
+    } else if (outcome === 'aborted') {
+      aborted += 1; // harness quiesce — environment-invalidated (§6)
+    } else {
+      const cls = typeof outcome === 'string' ? outcome : '';
+      if (!FAILURE_CLASSES.includes(cls) && !cls.startsWith('error:')) {
+        throw new Error(`aggregate: op_result outcome outside the closed failure enum: ${JSON.stringify(outcome)}`);
+      }
+      failuresByClass[cls] = (failuresByClass[cls] ?? 0) + 1;
+    }
+  }
+
+  const attempts = rows.length;
+  const denominator = attempts - aborted;
+  const out = {
+    op: opts.op,
+    lane: opts.lane,
+    attempts,
+    successes,
+    failed: attempts - successes - aborted,
+    aborted,
+    successRate: denominator > 0 ? successes / denominator : null,
+    durationsMs: {
+      field: opts.durationField,
+      count: durations.length,
+      p50: pct(durations, 50),
+      p95: pct(durations, 95),
+      p99: pct(durations, 99),
+      max: durations.length > 0 ? Math.max(...durations) : null,
+    },
+    failuresByClass,
+    partial: opts.partial === true,
+  };
+  if (out.partial) {
+    out.attempted = attempts;
+    out.completed = attempts - aborted;
+    out.inFlight = aborted;
+  }
+  return out;
+}
 
 /**
  * Evaluate one gate. Every latency/percentile gate REQUIRES minSamples and
  * minSuccessRate (RFC-61 §6 coverage gates) — absent coverage fields => throw
- * (a spec bug, not a runtime condition). Returns {id, outcome: 'PASS'|'FAIL'|
- * 'INCONCLUSIVE', observed, threshold, evidence}.
+ * (a spec bug, not a runtime condition); successRate gates require minSamples
+ * (their threshold IS the minimum success rate). Coverage shortfall or a
+ * missing/NaN observed value => INCONCLUSIVE with a reason; an explicit
+ * inconclusiveReason forces INCONCLUSIVE. Otherwise threshold compare:
+ *   successRate: observed >= threshold; percentile/max: observed <= threshold;
+ *   exactZero: observed === 0; bool: observed === true.
+ * Returns {id, kind, outcome: 'PASS'|'FAIL'|'INCONCLUSIVE', observed, threshold, evidence}.
  * @param {{id: string, kind: 'successRate'|'percentile'|'exactZero'|'bool'|'max',
  *          threshold: any, observed: any, samples?: number, minSamples?: number,
  *          successRate?: number, minSuccessRate?: number, inconclusiveReason?: string}} gate
  */
-export function evaluateGate(gate) { throw new Error('TODO'); }
+export function evaluateGate(gate) {
+  if (!gate || typeof gate.id !== 'string' || gate.id.length === 0) {
+    throw new TypeError('evaluateGate: gate.id required');
+  }
+  const { id, kind } = gate;
+  if (!GATE_KINDS.includes(kind)) {
+    throw new TypeError(`evaluateGate: gate '${id}' has unknown kind ${JSON.stringify(kind)}`);
+  }
+
+  // RFC-61 §6: coverage gates are mandatory on latency SLOs — absence is a spec bug.
+  if (kind === 'percentile') {
+    if (!isNum(gate.minSamples)) {
+      throw new Error(`gate '${id}': percentile SLO without minSamples — RFC-61 §6 coverage gates are mandatory (spec bug, fix the scenario/goal)`);
+    }
+    if (!isNum(gate.minSuccessRate)) {
+      throw new Error(`gate '${id}': percentile SLO without minSuccessRate — RFC-61 §6 coverage gates are mandatory (spec bug, fix the scenario/goal)`);
+    }
+  }
+  if (kind === 'successRate' && !isNum(gate.minSamples)) {
+    throw new Error(`gate '${id}': successRate gate without minSamples — RFC-61 §6 coverage gates are mandatory (spec bug, fix the scenario/goal)`);
+  }
+
+  const threshold = kind === 'exactZero' ? 0 : kind === 'bool' ? true : gate.threshold;
+  if (kind !== 'exactZero' && kind !== 'bool' && !isNum(threshold)) {
+    throw new TypeError(`gate '${id}': numeric threshold required for kind '${kind}'`);
+  }
+
+  const evidence = {};
+  for (const k of ['samples', 'minSamples', 'successRate', 'minSuccessRate']) {
+    if (gate[k] !== undefined) evidence[k] = gate[k];
+  }
+  const done = (outcome, reason) => {
+    if (reason) evidence.reason = reason;
+    return { id, kind, outcome, observed: gate.observed ?? null, threshold, evidence };
+  };
+
+  if (gate.inconclusiveReason) return done('INCONCLUSIVE', gate.inconclusiveReason);
+
+  if (kind === 'percentile' || kind === 'successRate') {
+    const samples = isNum(gate.samples) ? gate.samples : 0;
+    evidence.samples = samples;
+    if (samples < gate.minSamples) {
+      return done('INCONCLUSIVE', `insufficient samples: ${samples} < minSamples ${gate.minSamples}`);
+    }
+  }
+  if (kind === 'percentile') {
+    const sr = isNum(gate.successRate) ? gate.successRate : null;
+    if (sr === null || sr < gate.minSuccessRate) {
+      return done('INCONCLUSIVE', `success rate ${sr === null ? 'unavailable' : sr} below coverage minSuccessRate ${gate.minSuccessRate}`);
+    }
+  }
+
+  const obs = gate.observed;
+  if (kind === 'bool') {
+    if (typeof obs !== 'boolean') return done('INCONCLUSIVE', 'observed-unavailable');
+    return done(obs === true ? 'PASS' : 'FAIL');
+  }
+  if (!isNum(obs)) return done('INCONCLUSIVE', 'observed-unavailable');
+  switch (kind) {
+    case 'successRate': return done(obs >= threshold ? 'PASS' : 'FAIL');
+    case 'percentile':
+    case 'max': return done(obs <= threshold ? 'PASS' : 'FAIL');
+    case 'exactZero': return done(obs === 0 ? 'PASS' : 'FAIL');
+    /* c8 ignore next */
+    default: throw new Error(`unreachable kind ${kind}`);
+  }
+}
 
 /**
  * Fold gate outcomes into the run verdict:
  * any FAIL => FAIL; else any INCONCLUSIVE => INCONCLUSIVE; else PASS.
  * A safetyAbort flag forces SAFETY_ABORT regardless (terminal, consumes attempt).
+ * A gate outcome outside PASS/FAIL/INCONCLUSIVE throws (fail loudly, §6).
  * @param {{gates: Array<object>, safetyAbort?: boolean}} p
  * @returns {{outcome: string, gates: Array<object>}}
  */
-export function computeVerdict(p) { throw new Error('TODO'); }
+export function computeVerdict(p) {
+  const gates = Array.isArray(p?.gates) ? p.gates : [];
+  for (const g of gates) {
+    if (!g || !GATE_OUTCOMES.includes(g.outcome)) {
+      throw new TypeError(`computeVerdict: gate ${JSON.stringify(g?.id)} has invalid outcome ${JSON.stringify(g?.outcome)}`);
+    }
+  }
+  let outcome;
+  if (p?.safetyAbort === true) outcome = 'SAFETY_ABORT';
+  else if (gates.some((g) => g.outcome === 'FAIL')) outcome = 'FAIL';
+  else if (gates.some((g) => g.outcome === 'INCONCLUSIVE')) outcome = 'INCONCLUSIVE';
+  else outcome = 'PASS';
+  return { outcome, gates };
+}
+
+function formatCell(v) {
+  if (v === null || v === undefined) return '-';
+  if (typeof v === 'boolean') return String(v);
+  if (typeof v === 'number') {
+    if (Number.isInteger(v)) return String(v);
+    return String(Number(v.toPrecision(4)));
+  }
+  return String(v);
+}
 
 /** Render a human verdict table (fixed-width, no color) for terminal output.
  * @param {{outcome: string, gates: Array<object>}} verdict @returns {string} */
-export function formatVerdict(verdict) { throw new Error('TODO'); }
+export function formatVerdict(verdict) {
+  const gates = Array.isArray(verdict?.gates) ? verdict.gates : [];
+  const header = ['GATE', 'OUTCOME', 'OBSERVED', 'THRESHOLD', 'NOTE'];
+  const rows = gates.map((g) => [
+    formatCell(g.id),
+    formatCell(g.outcome),
+    formatCell(g.observed),
+    formatCell(g.threshold),
+    formatCell(g.evidence?.reason ?? g.reason ?? ''),
+  ]);
+  const widths = header.map((h, i) => Math.max(h.length, ...rows.map((r) => r[i].length)));
+  const fmtRow = (cells) => cells.map((c, i) => c.padEnd(widths[i])).join('  ').trimEnd();
+  const tally = { PASS: 0, FAIL: 0, INCONCLUSIVE: 0 };
+  for (const g of gates) if (tally[g.outcome] !== undefined) tally[g.outcome] += 1;
+  return [
+    `VERDICT: ${verdict?.outcome ?? 'UNKNOWN'}  (${tally.PASS} pass, ${tally.FAIL} fail, ${tally.INCONCLUSIVE} inconclusive of ${gates.length} gates)`,
+    fmtRow(header),
+    widths.map((w) => '-'.repeat(w)).join('  '),
+    ...rows.map(fmtRow),
+  ].join('\n');
+}

--- a/testnet/lib/ssh.mjs
+++ b/testnet/lib/ssh.mjs
@@ -1,5 +1,65 @@
 // Bounded-concurrency read-only SSH exec + k=v snapshot parsing (rfc59 port).
-// CONTRACT FILE: implementors replace TODO bodies; signatures are frozen.
+// OT-RFC-61 §9.1 transport layer. Zero deps; Node >= 20 built-ins only.
+//
+// S2 note: this module is transport only and never composes sudo/systemctl/
+// write commands. snapshotCommand() is audited read-only by test/ssh.test.mjs.
+
+import { spawn } from 'node:child_process';
+import { setTimeout as delay } from 'node:timers/promises';
+
+const MAX_CAPTURE_BYTES = 8 * 1024 * 1024;
+const UNIT_RE = /^[A-Za-z0-9@:._-]+$/;
+const PATH_RE = /^[A-Za-z0-9/._-]+$/;
+
+/**
+ * Validate a systemd unit name for safe shell interpolation and normalize it
+ * to its full `<name>.service` form. Throws TypeError on unsafe input.
+ * (Extra helper beyond the frozen contract; also used by lib/fleet.mjs.)
+ * @param {string} unit
+ */
+export function unitFullName(unit) {
+  const u = String(unit ?? '').trim();
+  if (!u || !UNIT_RE.test(u)) {
+    throw new TypeError(`unsafe systemd unit name: ${JSON.stringify(unit)}`);
+  }
+  return u.endsWith('.service') ? u : `${u}.service`;
+}
+
+function spawnOnce(spawnImpl, args, timeoutMs) {
+  return new Promise((resolvePromise) => {
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+    let timedOut = false;
+    let timer = null;
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      resolvePromise(result);
+    };
+    let child;
+    try {
+      child = spawnImpl('ssh', args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    } catch (err) {
+      finish({ ok: false, code: null, stdout: '', stderr: String(err?.message ?? err), timedOut: false });
+      return;
+    }
+    timer = setTimeout(() => {
+      timedOut = true;
+      try { child.kill('SIGKILL'); } catch { /* already gone */ }
+      finish({ ok: false, code: null, stdout, stderr, timedOut: true });
+    }, timeoutMs);
+    child.stdout?.on('data', (d) => { if (stdout.length < MAX_CAPTURE_BYTES) stdout += d; });
+    child.stderr?.on('data', (d) => { if (stderr.length < MAX_CAPTURE_BYTES) stderr += d; });
+    child.on('error', (err) => {
+      finish({ ok: false, code: null, stdout, stderr: stderr || String(err?.message ?? err), timedOut });
+    });
+    child.on('close', (code) => {
+      finish({ ok: code === 0 && !timedOut, code, stdout, stderr, timedOut });
+    });
+  });
+}
 
 /**
  * Run one remote command over SSH. STRICTLY read-only by convention — this
@@ -11,9 +71,38 @@
  * @param {{host: string, sshUser: string, sshIdentity?: string}} target
  * @param {string} remoteCmd
  * @param {{timeoutMs?: number, connectTimeoutSec?: number}} [opts]
+ *   Optional extras: _spawn (injectable spawn for tests), _retryDelayMs.
  * @returns {Promise<{ok: boolean, code: number|null, stdout: string, stderr: string, timedOut: boolean}>}
  */
-export async function sshExec(target, remoteCmd, opts) { throw new Error('TODO'); }
+export async function sshExec(target, remoteCmd, opts = {}) {
+  const {
+    timeoutMs = 30_000,
+    connectTimeoutSec = 8,
+    _spawn = spawn,
+    _retryDelayMs = 1500,
+  } = opts;
+  if (!target?.host || !target?.sshUser) {
+    return { ok: false, code: null, stdout: '', stderr: 'sshExec: target requires host and sshUser', timedOut: false };
+  }
+  const args = [
+    '-o', 'BatchMode=yes',
+    '-o', 'StrictHostKeyChecking=accept-new',
+    '-o', `ConnectTimeout=${Math.max(1, Math.floor(connectTimeoutSec))}`,
+    ...(target.sshIdentity ? ['-i', target.sshIdentity, '-o', 'IdentitiesOnly=yes'] : []),
+    `${target.sshUser}@${target.host}`,
+    '--',
+    String(remoteCmd),
+  ];
+  let last = null;
+  for (let attempt = 0; attempt < 2; attempt++) {
+    last = await spawnOnce(_spawn, args, timeoutMs);
+    // ssh exits 255 on connection/transport failure; anything else means the
+    // remote command actually ran (or the local spawn failed) — do not retry.
+    if (last.code !== 255) return last;
+    if (attempt === 0 && _retryDelayMs > 0) await delay(_retryDelayMs);
+  }
+  return last;
+}
 
 /**
  * Map over targets with a concurrency cap (fleet.sshConcurrency, default 2 —
@@ -22,7 +111,27 @@ export async function sshExec(target, remoteCmd, opts) { throw new Error('TODO')
  * @template T,R @param {T[]} targets @param {number} limit @param {(t:T)=>Promise<R>} fn
  * @returns {Promise<R[]>}
  */
-export async function mapLimit(targets, limit, fn) { throw new Error('TODO'); }
+export async function mapLimit(targets, limit, fn) {
+  const items = Array.from(targets ?? []);
+  const results = new Array(items.length);
+  const cap = Math.max(1, Math.floor(Number(limit)) || 1);
+  let next = 0;
+  const worker = async () => {
+    while (next < items.length) {
+      const i = next;
+      next += 1;
+      try {
+        results[i] = await fn(items[i]);
+      } catch (err) {
+        results[i] = { ok: false, error: String(err?.message ?? err) };
+      }
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(cap, items.length) }, () => worker()));
+  return results;
+}
+
+const KV_KEY_RE = /^[A-Za-z_][A-Za-z0-9_.-]*$/;
 
 /**
  * Parse `key=value` lines (one per line) from snapshot command output into an
@@ -30,7 +139,22 @@ export async function mapLimit(targets, limit, fn) { throw new Error('TODO'); }
  * decoded transparently. Unknown lines ignored. (rfc59 k=v pattern.)
  * @param {string} stdout @returns {Record<string, string>}
  */
-export function parseKvOutput(stdout) { throw new Error('TODO'); }
+export function parseKvOutput(stdout) {
+  const out = {};
+  for (const rawLine of String(stdout ?? '').split('\n')) {
+    const line = rawLine.replace(/\r$/, '');
+    const i = line.indexOf('=');
+    if (i <= 0) continue;
+    const key = line.slice(0, i).trim();
+    if (!KV_KEY_RE.test(key)) continue;
+    let value = line.slice(i + 1).trim();
+    if (value.startsWith('b64:')) {
+      value = Buffer.from(value.slice(4), 'base64').toString('utf8').trim();
+    }
+    out[key] = value;
+  }
+  return out;
+}
 
 /**
  * Compose the ONE compound read-only snapshot command for a core (light or
@@ -43,7 +167,68 @@ export function parseKvOutput(stdout) { throw new Error('TODO'); }
  * cursor (`journalctl -u <unit> -n 0 --show-cursor`).
  * MUST NOT contain sudo, systemctl (other than `systemctl show`), redirects to
  * files, or any state-changing construct — a test greps for this.
+ *
+ * S6 note: no remote path/hostname/username values are emitted in a form the
+ * per-core record keeps — spaced values (timestamps) travel as b64:<data>
+ * (remote is Linux, so `base64 -w0` is safe; never rely on macOS flags here).
  * @param {{systemdUnit: string, listenPort: number, storeFilesystem: string}} core
  * @param {{light?: boolean}} [opts] @returns {string}
  */
-export function snapshotCommand(core, opts) { throw new Error('TODO'); }
+export function snapshotCommand(core, opts = {}) {
+  const { light = false } = opts;
+  const unit = unitFullName(core.systemdUnit);
+  const port = Number(core.listenPort);
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+    throw new TypeError(`invalid listenPort: ${JSON.stringify(core.listenPort)}`);
+  }
+  const storeFs = String(core.storeFilesystem ?? '/');
+  if (!PATH_RE.test(storeFs)) {
+    throw new TypeError(`unsafe storeFilesystem path: ${JSON.stringify(core.storeFilesystem)}`);
+  }
+  const show = (prop) => `systemctl show ${unit} --property=${prop} --value 2>/dev/null`;
+  const parts = [
+    `echo active_state=$(${show('ActiveState')})`,
+    `echo sub_state=$(${show('SubState')})`,
+    `echo n_restarts=$(${show('NRestarts')})`,
+    // ExecMainStartTimestamp contains spaces -> b64-wrap.
+    `echo exec_main_start=b64:$(${show('ExecMainStartTimestamp')} | base64 -w0)`,
+    `pid=$(${show('MainPID')}); echo main_pid=$pid`,
+    `if [ -n "$pid" ] && [ "$pid" != 0 ]; then echo main_rss_kb=$(ps -o rss= -p "$pid" 2>/dev/null | awk '{print $1+0}'); else echo main_rss_kb=; fi`,
+    // The userland supervisor absorbs worker deaths (§9.1) — capture the
+    // foreground worker separately so PID deltas surface restarts.
+    `worker_pid=$(pgrep -P "$pid" -f daemon-foreground-worker 2>/dev/null | head -1); echo worker_pid=$worker_pid`,
+    `if [ -n "$worker_pid" ]; then echo worker_rss_kb=$(ps -o rss= -p "$worker_pid" 2>/dev/null | awk '{print $1+0}'); else echo worker_rss_kb=; fi`,
+    // cgroup path resolved from the systemd unit; ControlGroup via
+    // `systemctl show` first, static /system.slice/<unit> path as fallback.
+    `cg=$(${show('ControlGroup')}); [ -n "$cg" ] || cg=/system.slice/${unit}; cg_dir=/sys/fs/cgroup$cg`,
+    `echo memory_current=$(cat "$cg_dir/memory.current" 2>/dev/null)`,
+    `echo memory_peak=$(cat "$cg_dir/memory.peak" 2>/dev/null)`,
+    `echo memory_high=$(cat "$cg_dir/memory.high" 2>/dev/null)`,
+    `echo memory_max=$(cat "$cg_dir/memory.max" 2>/dev/null)`,
+    `echo oom_kills=$(awk '$1=="oom_kill" {print $2}' "$cg_dir/memory.events" 2>/dev/null)`,
+    `echo psi_some_avg10=$(awk '$1=="some" {sub("avg10=","",$2); print $2}' "$cg_dir/memory.pressure" 2>/dev/null)`,
+    // Listener accept-queue state (review-mandated §9.1 field): for LISTEN
+    // sockets ss reports Recv-Q = current accept-queue depth, Send-Q = backlog.
+    `ss_line=$(ss -H -tln sport = :${port} 2>/dev/null | head -1)`,
+    `echo listen_recvq=$(printf '%s' "$ss_line" | awk '{print $2}')`,
+    `echo listen_backlog=$(printf '%s' "$ss_line" | awk '{print $3}')`,
+    // Out-of-band TCP connect probe — catches the wedge ss cannot show.
+    `timeout 2 bash -c 'exec 3<>/dev/tcp/127.0.0.1/${port}' 2>/dev/null && echo probe_ok=1 || echo probe_ok=0`,
+    // Disk floor input (S3): GNU df --output first, POSIX df -P fallback.
+    `df_line=$(df -B1 --output=avail,pcent ${storeFs} 2>/dev/null | tail -1); [ -n "$df_line" ] || df_line=$(df -P -B1 ${storeFs} 2>/dev/null | awk 'NR==2 {print $4" "$5}')`,
+    `echo disk_avail_bytes=$(printf '%s' "$df_line" | awk '{print $1+0}')`,
+    `echo disk_used_pct=$(printf '%s' "$df_line" | awk '{gsub("%","",$2); print $2+0}')`,
+  ];
+  if (!light) {
+    parts.push(
+      // Store size via unit WorkingDirectory heuristic (full mode only — du is
+      // too heavy for the light loop). The path itself is NOT emitted (S6: a
+      // WorkingDirectory under /home/<user> would leak the username).
+      `wd=$(${show('WorkingDirectory')}); if [ -z "$wd" ] || [ "$wd" = "/" ]; then wd=$(readlink -f /proc/$pid/cwd 2>/dev/null); fi`,
+      `store_bytes=$(du -sb "$wd/data" 2>/dev/null | awk '{print $1+0}'); [ -n "$store_bytes" ] || store_bytes=$(du -sb "$wd" 2>/dev/null | awk '{print $1+0}'); echo store_bytes=$store_bytes`,
+      `echo journal_cursor=$(journalctl -u ${unit} -n 0 --show-cursor --no-pager 2>/dev/null | sed -n 's/^-- cursor: //p' | tail -1)`,
+    );
+  }
+  parts.push('echo snapshot_complete=1');
+  return parts.join('; ');
+}

--- a/testnet/lib/ssh.mjs
+++ b/testnet/lib/ssh.mjs
@@ -1,0 +1,49 @@
+// Bounded-concurrency read-only SSH exec + k=v snapshot parsing (rfc59 port).
+// CONTRACT FILE: implementors replace TODO bodies; signatures are frozen.
+
+/**
+ * Run one remote command over SSH. STRICTLY read-only by convention — this
+ * module never composes sudo/systemctl/write commands (S2 lives in config +
+ * the snapshot script; this is just transport).
+ * Options: BatchMode=yes, IdentitiesOnly=yes when identity given,
+ * ConnectTimeout from fleet config, StrictHostKeyChecking=accept-new,
+ * 2 attempts on connect failure.
+ * @param {{host: string, sshUser: string, sshIdentity?: string}} target
+ * @param {string} remoteCmd
+ * @param {{timeoutMs?: number, connectTimeoutSec?: number}} [opts]
+ * @returns {Promise<{ok: boolean, code: number|null, stdout: string, stderr: string, timedOut: boolean}>}
+ */
+export async function sshExec(target, remoteCmd, opts) { throw new Error('TODO'); }
+
+/**
+ * Map over targets with a concurrency cap (fleet.sshConcurrency, default 2 —
+ * avoid tailnet connection storms). Never rejects; per-target result or
+ * {ok:false, error} placeholder.
+ * @template T,R @param {T[]} targets @param {number} limit @param {(t:T)=>Promise<R>} fn
+ * @returns {Promise<R[]>}
+ */
+export async function mapLimit(targets, limit, fn) { throw new Error('TODO'); }
+
+/**
+ * Parse `key=value` lines (one per line) from snapshot command output into an
+ * object. Values may be base64-wrapped as b64:<data> (paths, multiline) —
+ * decoded transparently. Unknown lines ignored. (rfc59 k=v pattern.)
+ * @param {string} stdout @returns {Record<string, string>}
+ */
+export function parseKvOutput(stdout) { throw new Error('TODO'); }
+
+/**
+ * Compose the ONE compound read-only snapshot command for a core (light or
+ * full). Emits k=v lines. Light: systemd show (ActiveState, MainPID,
+ * NRestarts, ExecMainStartTimestamp), worker pid + rss (ps), cgroup
+ * memory.current/peak/high/max + memory.events oom_kill + memory.pressure
+ * (some avg10), `ss -tln` recv-q/backlog for listenPort, TCP connect probe
+ * (bash /dev/tcp with timeout), df -B1 of storeFilesystem.
+ * Full adds: store dir du -sb (via unit WorkingDirectory heuristic), journal
+ * cursor (`journalctl -u <unit> -n 0 --show-cursor`).
+ * MUST NOT contain sudo, systemctl (other than `systemctl show`), redirects to
+ * files, or any state-changing construct — a test greps for this.
+ * @param {{systemdUnit: string, listenPort: number, storeFilesystem: string}} core
+ * @param {{light?: boolean}} [opts] @returns {string}
+ */
+export function snapshotCommand(core, opts) { throw new Error('TODO'); }

--- a/testnet/lib/util.mjs
+++ b/testnet/lib/util.mjs
@@ -2,6 +2,8 @@
 // Ports of devnet _bootstrap/harness.ts + rfc59 harness.mjs helpers. Zero deps.
 // CONTRACT FILE: implementors replace TODO bodies; signatures are frozen.
 
+import { createHash } from 'node:crypto';
+
 /** Sleep for ms. */
 export function sleep(ms) { return new Promise((r) => setTimeout(r, ms)); }
 
@@ -14,7 +16,30 @@ export function sleep(ms) { return new Promise((r) => setTimeout(r, ms)); }
  * @param {number} intervalMs
  * @param {() => Promise<any>|any} probe
  */
-export async function waitFor(label, timeoutMs, intervalMs, probe) { throw new Error('TODO'); }
+export async function waitFor(label, timeoutMs, intervalMs, probe) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const v = await probe();
+    if (v) return v;
+    if (Date.now() >= deadline) throw new Error(`waitFor timeout: ${label}`);
+    await sleep(intervalMs);
+  }
+}
+
+/** True when the error (or any link of its `cause` chain) is a transient
+ * network-level failure worth retrying: ECONNRESET / ECONNREFUSED / socket
+ * hang-up. HTTP statuses never reach here (fetch does not throw on them). */
+export function isTransientNetworkError(err) {
+  const seen = new Set();
+  for (let e = err; e && typeof e === 'object' && !seen.has(e); e = e.cause) {
+    seen.add(e);
+    const code = String(e.code ?? '');
+    if (code === 'ECONNRESET' || code === 'ECONNREFUSED' || code === 'UND_ERR_SOCKET') return true;
+    const msg = String(e.message ?? '');
+    if (/ECONNRESET|ECONNREFUSED|socket hang ?up|other side closed/i.test(msg)) return true;
+  }
+  return false;
+}
 
 /**
  * fetch() with retries on transient network errors (ECONNRESET/ECONNREFUSED/socket hangup)
@@ -22,55 +47,172 @@ export async function waitFor(label, timeoutMs, intervalMs, probe) { throw new E
  * @param {string} url @param {object} [init] @param {{retries?: number, backoffMs?: number, timeoutMs?: number}} [opts]
  * @returns {Promise<Response>}
  */
-export async function fetchRetry(url, init, opts) { throw new Error('TODO'); }
+export async function fetchRetry(url, init, opts) {
+  const o = opts ?? {};
+  const retries = o.retries ?? 2; // retries AFTER the first attempt: 3 tries total (devnet parity)
+  const backoffMs = o.backoffMs ?? 400;
+  const doFetch = o._fetch ?? fetch; // injectable for hermetic tests
+  const doSleep = o._sleep ?? sleep;
+  let lastErr;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      const perTryInit = { ...(init ?? {}) };
+      if (o.timeoutMs && !perTryInit.signal) perTryInit.signal = AbortSignal.timeout(o.timeoutMs);
+      return await doFetch(url, perTryInit);
+    } catch (err) {
+      lastErr = err;
+      if (!isTransientNetworkError(err) || attempt === retries) throw err;
+      await doSleep(backoffMs * (attempt + 1));
+    }
+  }
+  throw lastErr; // unreachable; keeps control flow explicit
+}
+
+/** Is the double-quote at text[i] escaped (odd number of preceding backslashes)? */
+function isEscapedQuote(text, i) {
+  let n = 0;
+  for (let j = i - 1; j >= 0 && text[j] === '\\'; j--) n++;
+  return n % 2 === 1;
+}
+
+/** Backward brace-balance scan: find the '{' matching the '}' at `end`
+ * (string-aware, so braces inside JSON string literals do not count).
+ * Returns the index of the matching '{' or -1. */
+function matchOpenBrace(text, end) {
+  let depth = 0;
+  let inString = false;
+  for (let i = end; i >= 0; i--) {
+    const c = text[i];
+    if (c === '"' && !isEscapedQuote(text, i)) { inString = !inString; continue; }
+    if (inString) continue;
+    if (c === '}') depth++;
+    else if (c === '{' && --depth === 0) return i;
+  }
+  return -1;
+}
 
 /**
  * Extract the LAST balanced top-level JSON object from mixed text (CLI stdout).
  * Returns parsed object or null. (Port of devnet parseLastJsonBlock.)
  * @param {string} text
  */
-export function parseLastJsonBlock(text) { throw new Error('TODO'); }
+export function parseLastJsonBlock(text) {
+  if (typeof text !== 'string' || text.length === 0) return null;
+  // Walk candidate object ends ('}') from the end of the text; for each,
+  // brace-balance backwards to its matching '{' and try JSON.parse on the
+  // span. First success wins => the LAST balanced top-level object.
+  for (let end = text.lastIndexOf('}'); end >= 0; end = end === 0 ? -1 : text.lastIndexOf('}', end - 1)) {
+    const start = matchOpenBrace(text, end);
+    if (start < 0) continue;
+    try {
+      const v = JSON.parse(text.slice(start, end + 1));
+      if (v !== null && typeof v === 'object' && !Array.isArray(v)) return v;
+    } catch {
+      // keep scanning earlier object ends
+    }
+  }
+  return null;
+}
 
 /**
  * Nearest-rank percentile over a numeric array (RFC-61 §6). p in (0,100].
  * Empty array -> null. Does NOT interpolate.
+ * (Parity with rfc59 harness.mjs percentile, which takes q in [0,1].)
  * @param {number[]} values @param {number} p
  * @returns {number|null}
  */
-export function percentile(values, p) { throw new Error('TODO'); }
+export function percentile(values, p) {
+  const sorted = (values ?? []).filter(Number.isFinite).slice().sort((a, b) => a - b);
+  if (sorted.length === 0) return null;
+  const q = Math.max(0, Math.min(100, p)) / 100;
+  return sorted[Math.max(0, Math.ceil(q * sorted.length) - 1)];
+}
+
+const XSD_STRING = 'http://www.w3.org/2001/XMLSchema#string';
 
 /**
  * Normalize a SPARQL JSON-results term to a comparable string
  * ("<iri>" | '"lexical"^^<datatype>' | '"lexical"@lang' | '_:b'). Port of devnet normTerm.
+ * Idempotent on cells already in N-Triples term-string form; elides the
+ * redundant xsd:string datatype.
  * @param {{type: string, value: string, datatype?: string, "xml:lang"?: string}} term
  */
-export function normTerm(term) { throw new Error('TODO'); }
+export function normTerm(term) {
+  if (typeof term === 'string') return term;
+  const o = term ?? {};
+  if (o.value === undefined) return '';
+  const lang = o['xml:lang'] ?? o.lang;
+  if (lang) return `"${o.value}"@${lang}`;
+  if (o.datatype && o.datatype !== XSD_STRING) return `"${o.value}"^^<${o.datatype}>`;
+  if (o.type === 'uri') return o.value.startsWith('<') ? o.value : `<${o.value}>`;
+  if (o.type === 'bnode') return o.value.startsWith('_:') ? o.value : `_:${o.value}`;
+  return /^["_<]/.test(o.value) ? o.value : `"${o.value}"`;
+}
 
 /**
  * Canonical digest (sha256 hex) of a SPARQL SELECT result: rows -> sorted normalized
  * tuples -> newline-joined. Order-insensitive. For §6 query_result_mismatch checks.
+ * Each row is its bound var=term pairs (vars sorted; unbound vars omitted)
+ * joined with \t; rows are sorted AFTER normalization and joined with \n.
  * @param {{head: {vars: string[]}, results: {bindings: object[]}}} json
  */
-export function bindingSetDigest(json) { throw new Error('TODO'); }
+export function bindingSetDigest(json) {
+  const bindings = json?.results?.bindings ?? [];
+  const rows = bindings.map((binding) =>
+    Object.keys(binding)
+      .sort()
+      .map((v) => `${v}=${normTerm(binding[v])}`)
+      .join('\t'));
+  rows.sort();
+  return sha256(rows.join('\n'));
+}
 
 /**
  * sha256 hex of a string or Buffer.
  * @param {string|Buffer} data
  */
-export function sha256(data) { throw new Error('TODO'); }
+export function sha256(data) {
+  return createHash('sha256').update(data).digest('hex');
+}
 
 /**
  * Wrap a promise with a timeout. Rejects Error(`${label} timeout after ${ms}ms`).
  * @template T @param {Promise<T>} promise @param {number} ms @param {string} label
  * @returns {Promise<T>}
  */
-export function promiseWithTimeout(promise, ms, label) { throw new Error('TODO'); }
+export function promiseWithTimeout(promise, ms, label) {
+  let timer;
+  const timeout = new Promise((_resolve, reject) => {
+    timer = setTimeout(() => reject(new Error(`${label} timeout after ${ms}ms`)), ms);
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
+
+/** FNV-1a 32-bit hash of a string (seed derivation for seededRandom). */
+export function fnv1a(str) {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return h >>> 0;
+}
 
 /**
  * Deterministic PRNG (mulberry32) seeded from a string. Returns () => float [0,1).
  * Used so workload generation is reproducible per (scenario, run_id). @param {string} seed
  */
-export function seededRandom(seed) { throw new Error('TODO'); }
+export function seededRandom(seed) {
+  let a = fnv1a(String(seed));
+  return function mulberry32() {
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
 
 /** ISO basic timestamp (YYYYMMDDTHHMMSSZ) for run ids. @param {Date} [d] */
-export function isoBasic(d) { throw new Error('TODO'); }
+export function isoBasic(d) {
+  return (d ?? new Date()).toISOString().replace(/\.\d+/, '').replace(/[-:]/g, '');
+}

--- a/testnet/lib/util.mjs
+++ b/testnet/lib/util.mjs
@@ -1,0 +1,76 @@
+// OT-RFC-61 harness — shared primitives.
+// Ports of devnet _bootstrap/harness.ts + rfc59 harness.mjs helpers. Zero deps.
+// CONTRACT FILE: implementors replace TODO bodies; signatures are frozen.
+
+/** Sleep for ms. */
+export function sleep(ms) { return new Promise((r) => setTimeout(r, ms)); }
+
+/**
+ * Poll `probe` every `intervalMs` until it returns a truthy value or `timeoutMs` elapses.
+ * Resolves the truthy value; throws Error(`waitFor timeout: ${label}`) on timeout.
+ * (Port of devnet harness.ts waitFor.)
+ * @param {string} label
+ * @param {number} timeoutMs
+ * @param {number} intervalMs
+ * @param {() => Promise<any>|any} probe
+ */
+export async function waitFor(label, timeoutMs, intervalMs, probe) { throw new Error('TODO'); }
+
+/**
+ * fetch() with retries on transient network errors (ECONNRESET/ECONNREFUSED/socket hangup)
+ * only — HTTP error statuses are returned, not retried. (Port of devnet fetchRetry.)
+ * @param {string} url @param {object} [init] @param {{retries?: number, backoffMs?: number, timeoutMs?: number}} [opts]
+ * @returns {Promise<Response>}
+ */
+export async function fetchRetry(url, init, opts) { throw new Error('TODO'); }
+
+/**
+ * Extract the LAST balanced top-level JSON object from mixed text (CLI stdout).
+ * Returns parsed object or null. (Port of devnet parseLastJsonBlock.)
+ * @param {string} text
+ */
+export function parseLastJsonBlock(text) { throw new Error('TODO'); }
+
+/**
+ * Nearest-rank percentile over a numeric array (RFC-61 §6). p in (0,100].
+ * Empty array -> null. Does NOT interpolate.
+ * @param {number[]} values @param {number} p
+ * @returns {number|null}
+ */
+export function percentile(values, p) { throw new Error('TODO'); }
+
+/**
+ * Normalize a SPARQL JSON-results term to a comparable string
+ * ("<iri>" | '"lexical"^^<datatype>' | '"lexical"@lang' | '_:b'). Port of devnet normTerm.
+ * @param {{type: string, value: string, datatype?: string, "xml:lang"?: string}} term
+ */
+export function normTerm(term) { throw new Error('TODO'); }
+
+/**
+ * Canonical digest (sha256 hex) of a SPARQL SELECT result: rows -> sorted normalized
+ * tuples -> newline-joined. Order-insensitive. For §6 query_result_mismatch checks.
+ * @param {{head: {vars: string[]}, results: {bindings: object[]}}} json
+ */
+export function bindingSetDigest(json) { throw new Error('TODO'); }
+
+/**
+ * sha256 hex of a string or Buffer.
+ * @param {string|Buffer} data
+ */
+export function sha256(data) { throw new Error('TODO'); }
+
+/**
+ * Wrap a promise with a timeout. Rejects Error(`${label} timeout after ${ms}ms`).
+ * @template T @param {Promise<T>} promise @param {number} ms @param {string} label
+ * @returns {Promise<T>}
+ */
+export function promiseWithTimeout(promise, ms, label) { throw new Error('TODO'); }
+
+/**
+ * Deterministic PRNG (mulberry32) seeded from a string. Returns () => float [0,1).
+ * Used so workload generation is reproducible per (scenario, run_id). @param {string} seed
+ */
+export function seededRandom(seed) { throw new Error('TODO'); }
+
+/** ISO basic timestamp (YYYYMMDDTHHMMSSZ) for run ids. @param {Date} [d] */
+export function isoBasic(d) { throw new Error('TODO'); }

--- a/testnet/lib/watch.mjs
+++ b/testnet/lib/watch.mjs
@@ -1,0 +1,51 @@
+// OT-RFC-61 §8 S3 — abort-trip evaluation + quiesce controller.
+// CONTRACT FILE: implementors replace TODO bodies; signatures are frozen.
+
+/**
+ * Evaluate all S3 trips against the latest fleet snapshot + edge-side counters.
+ * FAIL-CLOSED: a signal that is missing/unreadable for a reachable core fires
+ * its trip with reason 'signal-unavailable'. Trips (policy.trips keys):
+ *  - memoryPsiSomeAvg10 (sustained — caller passes history window)
+ *  - memoryCurrentVsHighFraction
+ *  - oomKillDelta (vs baseline)
+ *  - coreUnreachableFromBaseline (ANY baseline-reachable core lost)
+ *  - acceptQueueRecvQAtBacklog (or N consecutive connect-probe failures)
+ *  - diskFreeFloorBytes / diskFreeFloorFraction
+ *  - admissionShedFractionOfAttempts over admissionShedWindowSec (edge-side)
+ *    OR fleet /api/status admission-rejection delta
+ *  - rpcExhaustionDeltaPerRun (fleet /api/status counters vs baseline)
+ * @param {{
+ *   policy: object, baseline: object, snapshot: object,
+ *   snapshotHistory: object[], edgeWindow: {attempts: number, shed: number, windowSec: number}
+ * }} p
+ * @returns {Array<{trip: string, alias?: string, observed: any, threshold: any, reason?: string}>} fired trips ([] = healthy)
+ */
+export function evaluateTrips(p) { throw new Error('TODO'); }
+
+/**
+ * Quiesce controller (S3): stop submitting; cancel/abandon in-flight client
+ * operations via the provided handles; if any remain, stop the local edge
+ * daemon(s) within policy.quiesce.edgeShutdownTimeoutSec; then confirm flat
+ * counters (no admission attempts from us, no publisher jobs progressing) for
+ * policy.quiesce.flatCounterConfirmSec before returning.
+ * NEVER touches fleet hosts.
+ * @param {{
+ *   inflight: Array<{cancel: () => Promise<void>}>,
+ *   edges: Array<object>, policy: object,
+ *   confirmFlat: () => Promise<boolean>
+ * }} p
+ * @returns {Promise<{cancelled: number, edgeShutdown: boolean, flatConfirmed: boolean}>}
+ */
+export async function quiesce(p) { throw new Error('TODO'); }
+
+/**
+ * SAFETY_ABORT bookkeeping: persist runs/safety-abort.json {ts, runId, trips,
+ * cooldownUntil} and refuse new load-generating runs until cooldownUntil passes
+ * or the file is removed by the operator (manual clearance).
+ * @param {{runsDir: string, runId: string, trips: object[], policy: object}} p
+ */
+export function recordSafetyAbort(p) { throw new Error('TODO'); }
+
+/** Check the cooldown gate before a load-generating run. Returns
+ * {blocked: boolean, until?: string}. @param {{runsDir: string}} p */
+export function safetyAbortGate(p) { throw new Error('TODO'); }

--- a/testnet/lib/watch.mjs
+++ b/testnet/lib/watch.mjs
@@ -1,34 +1,312 @@
 // OT-RFC-61 §8 S3 — abort-trip evaluation + quiesce controller.
-// CONTRACT FILE: implementors replace TODO bodies; signatures are frozen.
+// Implements the Phase 0 contract; exported signatures are frozen.
+// Hygiene (S6): everything emitted here identifies cores by ALIAS only.
+
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ABORT_FILE = 'safety-abort.json';
+
+const isNum = (v) => typeof v === 'number' && Number.isFinite(v);
+
+function tsMs(ts) {
+  if (isNum(ts)) return ts;
+  const ms = Date.parse(ts ?? '');
+  if (!Number.isFinite(ms)) throw new TypeError(`watch: snapshot ts unparseable: ${JSON.stringify(ts)}`);
+  return ms;
+}
+
+/** Accept either a fleet snapshot ({ts, kind, cores}) or a baseline wrapper ({snapshot, ...}). */
+function coresOf(s) {
+  if (Array.isArray(s?.cores)) return s.cores;
+  if (Array.isArray(s?.snapshot?.cores)) return s.snapshot.cores;
+  return [];
+}
+
+function tripCfg(policy, name) {
+  const cfg = policy?.trips?.[name];
+  if (!cfg || typeof cfg !== 'object') {
+    // Policy is validated upstream (config.loadPolicy requires every trip):
+    // a missing trip block here is a config bug, not a runtime condition.
+    throw new Error(`watch: policy.trips.${name} missing — S3 trips are mandatory`);
+  }
+  return cfg;
+}
+
+/** Effective threshold: loadPolicy/scenario tightening may set .value; else .default. */
+function tripValue(cfg) {
+  return cfg.value !== undefined ? cfg.value : cfg.default;
+}
+
+function coreIn(snap, alias) {
+  return coresOf(snap).find((c) => c?.alias === alias);
+}
 
 /**
  * Evaluate all S3 trips against the latest fleet snapshot + edge-side counters.
- * FAIL-CLOSED: a signal that is missing/unreadable for a reachable core fires
- * its trip with reason 'signal-unavailable'. Trips (policy.trips keys):
- *  - memoryPsiSomeAvg10 (sustained — caller passes history window)
- *  - memoryCurrentVsHighFraction
+ * FAIL-CLOSED: a signal that is missing/unreadable (undefined/NaN) for a core
+ * reachable in `snapshot` fires its trip with reason 'signal-unavailable'.
+ * Trips (policy.trips keys):
+ *  - memoryPsiSomeAvg10 (sustained — fires only when every snapshot in
+ *    [snapshotHistory..snapshot] covering sustainSec exceeds the threshold)
+ *  - memoryCurrentVsHighFraction (ceiling = memory.high, else memory.max)
  *  - oomKillDelta (vs baseline)
  *  - coreUnreachableFromBaseline (ANY baseline-reachable core lost)
- *  - acceptQueueRecvQAtBacklog (or N consecutive connect-probe failures)
+ *  - acceptQueueRecvQAtBacklog (or consecutiveProbeFailures consecutive
+ *    connect-probe failures across the trailing snapshots)
  *  - diskFreeFloorBytes / diskFreeFloorFraction
  *  - admissionShedFractionOfAttempts over admissionShedWindowSec (edge-side)
- *    OR fleet /api/status admission-rejection delta
- *  - rpcExhaustionDeltaPerRun (fleet /api/status counters vs baseline)
+ *    OR fleet /api/status admission-rejection delta vs baseline (either fires;
+ *    the fleet-delta threshold is scenario-declared via the optional
+ *    policy.trips.admissionShedFractionOfAttempts.fleetDeltaPerRun — absent =>
+ *    fleet source not configured, edge window still watched)
+ *  - rpcExhaustionDeltaPerRun (fleet /api/status exhaustion+failover counters
+ *    vs baseline)
  * @param {{
  *   policy: object, baseline: object, snapshot: object,
  *   snapshotHistory: object[], edgeWindow: {attempts: number, shed: number, windowSec: number}
  * }} p
  * @returns {Array<{trip: string, alias?: string, observed: any, threshold: any, reason?: string}>} fired trips ([] = healthy)
  */
-export function evaluateTrips(p) { throw new Error('TODO'); }
+export function evaluateTrips(p) {
+  const { policy, baseline, snapshot, edgeWindow } = p ?? {};
+  if (!policy?.trips) throw new TypeError('evaluateTrips: policy.trips required');
+  if (!snapshot) throw new TypeError('evaluateTrips: snapshot required');
+  const history = Array.isArray(p.snapshotHistory) ? p.snapshotHistory : [];
+
+  const fired = [];
+  const unavailable = (trip, alias, threshold) => {
+    fired.push({ trip, alias, observed: null, threshold, reason: 'signal-unavailable' });
+  };
+
+  const baseCores = new Map(coresOf(baseline).map((c) => [c.alias, c]));
+  const curCores = coresOf(snapshot);
+  const curByAlias = new Map(curCores.map((c) => [c.alias, c]));
+  const curTs = tsMs(snapshot.ts);
+  const timeline = history
+    .filter((s) => s && s !== snapshot)
+    .concat([snapshot])
+    .map((s) => ({ ms: tsMs(s.ts), s }))
+    .filter((e) => e.ms <= curTs)
+    .sort((a, b) => a.ms - b.ms);
+
+  // ── coreUnreachableFromBaseline — ANY baseline-reachable core lost.
+  const unreachCfg = tripCfg(policy, 'coreUnreachableFromBaseline');
+  const unreachThresh = tripValue(unreachCfg);
+  const lost = [];
+  for (const [alias, b] of baseCores) {
+    if (b.reachable === false) continue;
+    const cur = curByAlias.get(alias);
+    if (!cur || cur.reachable === false) lost.push(alias);
+  }
+  if (lost.length >= unreachThresh) {
+    for (const alias of lost) {
+      fired.push({
+        trip: 'coreUnreachableFromBaseline', alias,
+        observed: lost.length, threshold: unreachThresh,
+        reason: 'baseline-reachable core unreachable during workload',
+      });
+    }
+  }
+
+  // Per-core signal trips run only over cores reachable NOW (an unreachable
+  // core already fired its own trip above — the primary signal for that state).
+  const reachable = curCores.filter((c) => c && c.reachable !== false);
+
+  // ── memoryPsiSomeAvg10 (sustained)
+  const psiCfg = tripCfg(policy, 'memoryPsiSomeAvg10');
+  const psiThresh = tripValue(psiCfg);
+  const sustainMs = (isNum(psiCfg.sustainSec) ? psiCfg.sustainSec : 60) * 1000;
+  for (const c of reachable) {
+    const psi = c.cgroup?.psiSomeAvg10;
+    if (!isNum(psi)) { unavailable('memoryPsiSomeAvg10', c.alias, psiThresh); continue; }
+    if (psi <= psiThresh) continue;
+    // Walk backwards over consecutive exceeding snapshots; sustained iff the
+    // exceedance chain spans >= sustainSec ending at the current snapshot.
+    let earliest = curTs;
+    for (let i = timeline.length - 1; i >= 0; i -= 1) {
+      const v = coreIn(timeline[i].s, c.alias)?.cgroup?.psiSomeAvg10;
+      if (!isNum(v) || v <= psiThresh) break;
+      earliest = timeline[i].ms;
+    }
+    if (curTs - earliest >= sustainMs) {
+      fired.push({
+        trip: 'memoryPsiSomeAvg10', alias: c.alias, observed: psi, threshold: psiThresh,
+        reason: `memory PSI some avg10 > ${psiThresh} sustained >= ${sustainMs / 1000}s`,
+      });
+    }
+  }
+
+  // ── memoryCurrentVsHighFraction
+  const memFracCfg = tripCfg(policy, 'memoryCurrentVsHighFraction');
+  const memFracThresh = tripValue(memFracCfg);
+  for (const c of reachable) {
+    const cur = c.cgroup?.memoryCurrent;
+    const high = c.cgroup?.memoryHigh;
+    const ceiling = isNum(high) && high > 0 ? high : c.cgroup?.memoryMax;
+    if (!isNum(cur) || !isNum(ceiling) || ceiling <= 0) {
+      unavailable('memoryCurrentVsHighFraction', c.alias, memFracThresh);
+      continue;
+    }
+    const frac = cur / ceiling;
+    if (frac >= memFracThresh) {
+      fired.push({
+        trip: 'memoryCurrentVsHighFraction', alias: c.alias,
+        observed: frac, threshold: memFracThresh,
+        reason: 'memory.current within trip fraction of effective ceiling',
+      });
+    }
+  }
+
+  // ── oomKillDelta (vs baseline)
+  const oomCfg = tripCfg(policy, 'oomKillDelta');
+  const oomThresh = tripValue(oomCfg);
+  for (const c of reachable) {
+    const curOom = c.cgroup?.oomKills;
+    const baseOom = baseCores.get(c.alias)?.cgroup?.oomKills;
+    if (!isNum(curOom) || !isNum(baseOom)) { unavailable('oomKillDelta', c.alias, oomThresh); continue; }
+    const delta = curOom - baseOom;
+    if (delta > oomThresh) {
+      fired.push({
+        trip: 'oomKillDelta', alias: c.alias, observed: delta, threshold: oomThresh,
+        reason: 'cgroup oom_kill counter grew during workload',
+      });
+    }
+  }
+
+  // ── acceptQueueRecvQAtBacklog (+ consecutive connect-probe failures)
+  const aqCfg = tripCfg(policy, 'acceptQueueRecvQAtBacklog');
+  if (tripValue(aqCfg)) {
+    const probeN = isNum(aqCfg.consecutiveProbeFailures) ? aqCfg.consecutiveProbeFailures : 3;
+    for (const c of reachable) {
+      const l = c.listen;
+      if (!l || !isNum(l.recvQ) || !isNum(l.backlog) || typeof l.connectProbeOk !== 'boolean') {
+        unavailable('acceptQueueRecvQAtBacklog', c.alias, true);
+        continue;
+      }
+      if (l.backlog > 0 && l.recvQ >= l.backlog) {
+        fired.push({
+          trip: 'acceptQueueRecvQAtBacklog', alias: c.alias,
+          observed: { recvQ: l.recvQ, backlog: l.backlog }, threshold: true,
+          reason: 'listener Recv-Q at backlog',
+        });
+        continue;
+      }
+      const lastN = timeline.slice(-probeN);
+      const allFailed = lastN.length >= probeN
+        && lastN.every(({ s }) => coreIn(s, c.alias)?.listen?.connectProbeOk === false);
+      if (allFailed) {
+        fired.push({
+          trip: 'acceptQueueRecvQAtBacklog', alias: c.alias,
+          observed: { consecutiveProbeFailures: probeN }, threshold: true,
+          reason: `connect probe failed ${probeN} consecutive polls`,
+        });
+      }
+    }
+  }
+
+  // ── disk floors
+  const diskBytesCfg = tripCfg(policy, 'diskFreeFloorBytes');
+  const diskBytesFloor = tripValue(diskBytesCfg);
+  const diskFracCfg = tripCfg(policy, 'diskFreeFloorFraction');
+  const diskFracFloor = tripValue(diskFracCfg);
+  for (const c of reachable) {
+    const d = c.diskFree;
+    if (!d || !isNum(d.bytes)) unavailable('diskFreeFloorBytes', c.alias, diskBytesFloor);
+    else if (d.bytes < diskBytesFloor) {
+      fired.push({
+        trip: 'diskFreeFloorBytes', alias: c.alias, observed: d.bytes, threshold: diskBytesFloor,
+        reason: 'store filesystem free space below byte floor',
+      });
+    }
+    if (!d || !isNum(d.fraction)) unavailable('diskFreeFloorFraction', c.alias, diskFracFloor);
+    else if (d.fraction < diskFracFloor) {
+      fired.push({
+        trip: 'diskFreeFloorFraction', alias: c.alias, observed: d.fraction, threshold: diskFracFloor,
+        reason: 'store filesystem free space below fractional floor',
+      });
+    }
+  }
+
+  // ── admission shed — edge-side window AND fleet counter delta; either fires.
+  const shedCfg = tripCfg(policy, 'admissionShedFractionOfAttempts');
+  const shedThresh = tripValue(shedCfg);
+  const shedWindowSec = tripValue(tripCfg(policy, 'admissionShedWindowSec'));
+  if (edgeWindow && isNum(edgeWindow.attempts) && edgeWindow.attempts > 0) {
+    const frac = (isNum(edgeWindow.shed) ? edgeWindow.shed : 0) / edgeWindow.attempts;
+    if (frac > shedThresh) {
+      fired.push({
+        trip: 'admissionShedFractionOfAttempts',
+        observed: frac, threshold: shedThresh,
+        reason: `edge-side shed ${edgeWindow.shed}/${edgeWindow.attempts} attempts over ${edgeWindow.windowSec ?? shedWindowSec}s window`,
+      });
+    }
+  }
+  const fleetShedThresh = shedCfg.fleetDeltaPerRun; // scenario-declared (S3); optional
+  if (isNum(fleetShedThresh)) {
+    let delta = 0;
+    for (const c of reachable) {
+      const cur = c.api?.admissionRejected;
+      const base = baseCores.get(c.alias)?.api?.admissionRejected;
+      if (!isNum(cur) || !isNum(base)) {
+        unavailable('admissionShedFractionOfAttempts', c.alias, fleetShedThresh);
+        continue;
+      }
+      delta += cur - base;
+    }
+    if (delta > fleetShedThresh) {
+      fired.push({
+        trip: 'admissionShedFractionOfAttempts',
+        observed: delta, threshold: fleetShedThresh,
+        reason: 'fleet admission-rejection counter delta exceeded scenario-declared rate',
+      });
+    }
+  }
+
+  // ── rpcExhaustionDeltaPerRun — fleet-wide exhaustion(+failover) counter delta.
+  const rpcCfg = tripCfg(policy, 'rpcExhaustionDeltaPerRun');
+  const rpcThresh = tripValue(rpcCfg);
+  const rpcCount = (core) => {
+    const a = core?.api;
+    if (!a || !isNum(a.rpcExhaustions)) return null;
+    return a.rpcExhaustions + (isNum(a.rpcFailovers) ? a.rpcFailovers : 0);
+  };
+  let rpcDelta = 0;
+  for (const c of reachable) {
+    const cur = rpcCount(c);
+    const base = rpcCount(baseCores.get(c.alias));
+    if (cur === null || base === null) { unavailable('rpcExhaustionDeltaPerRun', c.alias, rpcThresh); continue; }
+    rpcDelta += cur - base;
+  }
+  if (rpcDelta > rpcThresh) {
+    fired.push({
+      trip: 'rpcExhaustionDeltaPerRun', observed: rpcDelta, threshold: rpcThresh,
+      reason: 'fleet RPC failover/exhaustion counter delta exceeded per-run threshold',
+    });
+  }
+
+  return fired;
+}
+
+function withTimeout(promise, ms, label) {
+  let timer;
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`${label} timeout after ${ms}ms`)), ms);
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
 
 /**
  * Quiesce controller (S3): stop submitting; cancel/abandon in-flight client
- * operations via the provided handles; if any remain, stop the local edge
- * daemon(s) within policy.quiesce.edgeShutdownTimeoutSec; then confirm flat
- * counters (no admission attempts from us, no publisher jobs progressing) for
- * policy.quiesce.flatCounterConfirmSec before returning.
- * NEVER touches fleet hosts.
+ * operations via the provided handles (Promise.allSettled — a hung cancel is
+ * bounded by policy.quiesce.cancelTimeoutSec, default 30); stop the local edge
+ * daemon(s) via their stop() within policy.quiesce.edgeShutdownTimeoutSec (an
+ * edge without stop() is skipped and reported edgeShutdown:false); then poll
+ * confirmFlat() until policy.quiesce.flatCounterConfirmSec of CONSECUTIVE flat
+ * readings, or until policy.quiesce.flatConfirmTimeoutSec (default
+ * 3×flatCounterConfirmSec + 60) elapses. A confirmFlat error counts as
+ * not-flat (fail closed). NEVER touches fleet hosts.
+ * Test seams (optional): _now, _sleep, _pollIntervalMs.
  * @param {{
  *   inflight: Array<{cancel: () => Promise<void>}>,
  *   edges: Array<object>, policy: object,
@@ -36,16 +314,100 @@ export function evaluateTrips(p) { throw new Error('TODO'); }
  * }} p
  * @returns {Promise<{cancelled: number, edgeShutdown: boolean, flatConfirmed: boolean}>}
  */
-export async function quiesce(p) { throw new Error('TODO'); }
+export async function quiesce(p) {
+  const { policy, confirmFlat } = p ?? {};
+  const inflight = Array.isArray(p?.inflight) ? p.inflight : [];
+  const edges = Array.isArray(p?.edges) ? p.edges : [];
+  const nowFn = p?._now ?? Date.now;
+  const sleepFn = p?._sleep ?? ((ms) => new Promise((r) => setTimeout(r, ms)));
+  const intervalMs = isNum(p?._pollIntervalMs) ? p._pollIntervalMs : 1000;
+
+  // 1. cancel in-flight client operations
+  const cancelTimeoutMs = (isNum(policy?.quiesce?.cancelTimeoutSec) ? policy.quiesce.cancelTimeoutSec : 30) * 1000;
+  const settled = await Promise.allSettled(inflight.map((h) => withTimeout(
+    Promise.resolve().then(() => h.cancel()), cancelTimeoutMs, 'inflight cancel',
+  )));
+  const cancelled = settled.filter((r) => r.status === 'fulfilled').length;
+
+  // 2. stop local edge daemons (where cancellation is unavailable, this is the stop)
+  const shutdownMs = (isNum(policy?.quiesce?.edgeShutdownTimeoutSec) ? policy.quiesce.edgeShutdownTimeoutSec : 60) * 1000;
+  let edgeShutdown = true;
+  for (const edge of edges) {
+    if (typeof edge?.stop !== 'function') { edgeShutdown = false; continue; }
+    try {
+      await withTimeout(Promise.resolve().then(() => edge.stop()), shutdownMs, 'edge stop');
+    } catch {
+      edgeShutdown = false;
+    }
+  }
+
+  // 3. confirm flat counters for flatCounterConfirmSec consecutive seconds
+  const confirmSec = isNum(policy?.quiesce?.flatCounterConfirmSec) ? policy.quiesce.flatCounterConfirmSec : 20;
+  const confirmMs = confirmSec * 1000;
+  const timeoutMs = (isNum(policy?.quiesce?.flatConfirmTimeoutSec)
+    ? policy.quiesce.flatConfirmTimeoutSec : confirmSec * 3 + 60) * 1000;
+  let flatConfirmed = false;
+  if (typeof confirmFlat === 'function') {
+    const deadline = nowFn() + timeoutMs;
+    let flatSince = null;
+    while (nowFn() <= deadline) {
+      let flat = false;
+      try { flat = (await confirmFlat()) === true; } catch { flat = false; }
+      const t = nowFn();
+      if (flat) {
+        if (flatSince === null) flatSince = t;
+        if (t - flatSince >= confirmMs) { flatConfirmed = true; break; }
+      } else {
+        flatSince = null;
+      }
+      await sleepFn(intervalMs);
+    }
+  }
+
+  return { cancelled, edgeShutdown, flatConfirmed };
+}
 
 /**
  * SAFETY_ABORT bookkeeping: persist runs/safety-abort.json {ts, runId, trips,
  * cooldownUntil} and refuse new load-generating runs until cooldownUntil passes
- * or the file is removed by the operator (manual clearance).
- * @param {{runsDir: string, runId: string, trips: object[], policy: object}} p
+ * or the file is removed by the operator (manual clearance). Returns the record.
+ * @param {{runsDir: string, runId: string, trips: object[], policy: object, _now?: () => number}} p
  */
-export function recordSafetyAbort(p) { throw new Error('TODO'); }
+export function recordSafetyAbort(p) {
+  const { runsDir, runId, trips, policy } = p ?? {};
+  if (typeof runsDir !== 'string' || runsDir.length === 0) throw new TypeError('recordSafetyAbort: runsDir required');
+  if (typeof runId !== 'string' || runId.length === 0) throw new TypeError('recordSafetyAbort: runId required');
+  const now = typeof p._now === 'function' ? p._now() : Date.now();
+  const cooldownMin = isNum(policy?.safetyAbort?.cooldownMin) ? policy.safetyAbort.cooldownMin : 60;
+  const record = {
+    ts: new Date(now).toISOString(),
+    runId,
+    trips: Array.isArray(trips) ? trips : [],
+    cooldownUntil: new Date(now + cooldownMin * 60_000).toISOString(),
+  };
+  mkdirSync(runsDir, { recursive: true });
+  writeFileSync(join(runsDir, ABORT_FILE), `${JSON.stringify(record, null, 2)}\n`);
+  return record;
+}
 
-/** Check the cooldown gate before a load-generating run. Returns
- * {blocked: boolean, until?: string}. @param {{runsDir: string}} p */
-export function safetyAbortGate(p) { throw new Error('TODO'); }
+/** Check the cooldown gate before a load-generating run. Missing file =>
+ * unblocked; unreadable/corrupt file or unparseable cooldownUntil => BLOCKED
+ * (fail closed — the operator clears by removing the file). Returns
+ * {blocked: boolean, until?: string}. @param {{runsDir: string, _now?: () => number}} p */
+export function safetyAbortGate(p) {
+  const file = join(p.runsDir, ABORT_FILE);
+  let raw;
+  try {
+    raw = readFileSync(file, 'utf8');
+  } catch (err) {
+    if (err?.code === 'ENOENT') return { blocked: false };
+    return { blocked: true };
+  }
+  let record;
+  try { record = JSON.parse(raw); } catch { return { blocked: true }; }
+  const until = record?.cooldownUntil;
+  const untilMs = Date.parse(until ?? '');
+  if (!Number.isFinite(untilMs)) return { blocked: true };
+  const now = typeof p._now === 'function' ? p._now() : Date.now();
+  return now < untilMs ? { blocked: true, until } : { blocked: false };
+}

--- a/testnet/package.json
+++ b/testnet/package.json
@@ -6,6 +6,6 @@
   "description": "OT-RFC-61 testnet harness — Phase 0 (zero-dependency, no build step)",
   "engines": { "node": ">=20" },
   "scripts": {
-    "test": "node --test test/"
+    "test": "node --test"
   }
 }

--- a/testnet/package.json
+++ b/testnet/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@origintrail/dkg-testnet-harness",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "OT-RFC-61 testnet harness — Phase 0 (zero-dependency, no build step)",
+  "engines": { "node": ">=20" },
+  "scripts": {
+    "test": "node --test test/"
+  }
+}

--- a/testnet/policy.example.json
+++ b/testnet/policy.example.json
@@ -1,0 +1,33 @@
+{
+  "$comment": "OT-RFC-61 §8 S3: immutable operator safety policy. Scenarios may only TIGHTEN these. 'hardMax' is the loosest any scenario/operator override may ever go. A missing watch signal fails closed (trip fires).",
+  "schemaVersion": 1,
+  "trips": {
+    "memoryPsiSomeAvg10": { "default": 0.4, "hardMax": 0.6, "sustainSec": 60 },
+    "memoryCurrentVsHighFraction": { "default": 0.95, "hardMax": 0.98 },
+    "oomKillDelta": { "default": 0, "hardMax": 0 },
+    "coreUnreachableFromBaseline": { "default": 1, "hardMax": 1 },
+    "acceptQueueRecvQAtBacklog": { "default": true, "hardMax": true, "consecutiveProbeFailures": 3 },
+    "diskFreeFloorBytes": { "default": 16106127360, "hardMax": 10737418240 },
+    "diskFreeFloorFraction": { "default": 0.2, "hardMax": 0.1 },
+    "admissionShedWindowSec": { "default": 60, "hardMax": 60 },
+    "admissionShedFractionOfAttempts": { "default": 0.5, "hardMax": 0.7 },
+    "rpcExhaustionDeltaPerRun": { "default": 100, "hardMax": 500 }
+  },
+  "quiesce": {
+    "flatCounterConfirmSec": 20,
+    "edgeShutdownTimeoutSec": 60
+  },
+  "safetyAbort": {
+    "cooldownMin": 60
+  },
+  "permanentData": {
+    "$comment": "S7 cumulative allocation across ALL harness VM writes. Operator-owned.",
+    "lifetimeBudgetBytes": 268435456,
+    "rollingWindowDays": 7,
+    "rollingBudgetBytes": 67108864
+  },
+  "faucet": {
+    "maxTopUpsPerRun": 1,
+    "perWalletPer24h": 1
+  }
+}

--- a/testnet/scenarios.json
+++ b/testnet/scenarios.json
@@ -1,0 +1,5 @@
+{
+  "$comment": "Scenario manifest — drift-guarded: test/manifest-drift.test.mjs asserts this list == files in scenarios/. Add a scenario file without listing it here (or vice versa) and the suite fails.",
+  "schemaVersion": 1,
+  "scenarios": ["certify-100"]
+}

--- a/testnet/scenarios/certify-100.json
+++ b/testnet/scenarios/certify-100.json
@@ -1,0 +1,31 @@
+{
+  "$comment": "Scenario #1 — the OT-RFC-59 certification workload, frozen (RFC-61 §10 Phase 0 exit gate). 2 waves x (25 public + 25 private) single-triple KAs at concurrency 2, control fixtures every 10th, byte-exact readback per wave, 600 s soak, gate battery.",
+  "schemaVersion": 1,
+  "scenario": "certify-100",
+  "lanes": ["public", "private"],
+  "cg": { "public": "reuse:loadtest-public", "private": "reuse:loadtest-private" },
+  "workload": {
+    "op": "publish",
+    "waves": 2,
+    "perWave": { "public": 25, "private": 25 },
+    "entityShape": "single-triple",
+    "controlFixtureEvery": 10,
+    "concurrency": 2,
+    "arrival": "closed-loop"
+  },
+  "measure": ["share.duration", "publish.duration", "vm.finalization"],
+  "readback": { "where": "driver", "byteExact": true, "chunkSize": 25 },
+  "soakSeconds": 600,
+  "gates": {
+    "successRate": { "overall": 0.95, "perLane": 0.96, "minSamples": { "overall": 100, "perLane": 50 } },
+    "publishP95Ms": 60000,
+    "controlFixtures": { "mustFinalize": true, "mustReadBack": true },
+    "uniqueUals": true,
+    "fleet": {
+      "coreRestarts": 0,
+      "oomKillDelta": 0,
+      "gatedSignatures": 0,
+      "memoryPeakFraction": 0.9
+    }
+  }
+}

--- a/testnet/schema/EVIDENCE.md
+++ b/testnet/schema/EVIDENCE.md
@@ -1,0 +1,46 @@
+# Evidence stream contract (schema_version 1)
+
+Append-only `runs/<run_id>.jsonl`. Every record carries:
+
+```json
+{ "type": "<record type>", "schema_version": 1, "ts": "<ISO 8601>", "run_id": "<id>" }
+```
+
+Run IDs: `<phase>-<sha8>[-qualifier][-rN]-<ISO basic timestamp>`, e.g.
+`certify-06419722-r1-20260714T190000Z`. Never reuse a run_id; verdicts are never
+overwritten.
+
+Hygiene (RFC-61 §4.4/S6): cores appear ONLY by `fleet.json` alias. No hostnames,
+IPs, usernames, key paths, or wallet addresses in any record. Raw matched log
+text goes to a local sidecar (`runs/<run_id>.sidecar.jsonl`, gitignored with the
+rest of runs/), never the main stream. The manifest records the fleet.json
+sha256 digest, not its content.
+
+## Record types (Phase 0 set)
+
+| type | emitted | payload (beyond envelope) |
+| --- | --- | --- |
+| `run_start` | once | mode, scenario name+sha256, fleet digest, policy digest, harness version, argv (sanitized) |
+| `preflight` | once | outcome (`ok`\|`inconclusive`), checks: [{id, pass, evidence}], edges attested {commit, apiPort-alias}, cores attested {alias, commit, buildTime, workerPid, workerStartTs} |
+| `fleet_baseline` | once | per-core full snapshot + journalCursor |
+| `fleet_snapshot` | loop | kind (`light`\|`full`), per-core: alias, reachable, systemd {activeState, execMainStartTs, nRestarts, mainPid}, workerPid, build {commit, buildTime}, rss, cgroup {memoryCurrent, memoryPeak, memoryHigh, memoryMax, oomKills, psiSomeAvg10}, listen {recvQ, backlog, connectProbeOk}, diskFree {bytes, fraction}, api {admissionRejected, rpcFailovers, rpcExhaustions} |
+| `host_telemetry` | loop | loadavg, cpuFraction, memFreeBytes, note (driver laptop, §3.2) |
+| `op_result` | per op | op, lane, cg (logical name), index, wave, bytes, outcome (`success`\|failure class), reason, durations_ms {create, share, publish, vm_finalization}, anchor_meta {poll_interval_ms}, ual, tx, control_fixture, recovered_after_client_error |
+| `readback_result` | per wave | lane, expected, matched, mismatches: [{index, kind}], byteExact |
+| `journal_signature_deltas` | baseline→final | per-core: alias, cursorValid, counts by class id, gatedTotal, recordedTotal, ledgerVersion |
+| `soak_start` / `soak_end` | certify | soakSeconds |
+| `safety_abort` | on trip | trip id, observed, threshold, quiesce {cancelled, edgeShutdown, flatConfirmed} |
+| `run_verdict` | once | outcome (`PASS`\|`FAIL`\|`INCONCLUSIVE`\|`SAFETY_ABORT`), gates: [{id, outcome, observed, threshold, evidencePointer}], notRun: [] |
+| `run_manifest` | once | attested identities, scenario verbatim, gate outcomes, notRun list, spend {trac, eth}, permanentBytesWritten |
+
+Phase 1 adds: `propagation_result`, `sse_gap`, `faucet_draw`, `goal_verdict`
+(reserved — do not repurpose).
+
+## Failure classes (closed enum, §6)
+
+`too_low_allowance`, `publisher_wedge`, `transport_error`, `quorum_or_backoff`,
+`admission_shed`, `rpc_exhaustion`, `timeout`, `readback_mismatch`,
+`query_result_mismatch`, `propagation_timeout`, `arrived_during_gap`,
+`finalized_unverified`, `caught_up_unverified`, `aborted`, `error:<class>`.
+
+Unclassified failures MUST throw, not fold into a bucket.

--- a/testnet/test/config.test.mjs
+++ b/testnet/test/config.test.mjs
@@ -1,0 +1,523 @@
+// Tests for lib/config.mjs — hermetic: fixture files in a temp dir, fake _exec
+// for the S2 credential probes. No SSH, no network, no real fleet.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  POLICY_TRIPS,
+  fileDigest,
+  isLooser,
+  loadFleet,
+  loadPolicy,
+  loadScenario,
+  verifyCredentialIsolation,
+} from '../lib/config.mjs';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const FLEET_EXAMPLE = JSON.parse(readFileSync(join(ROOT, 'fleet.example.json'), 'utf8'));
+const POLICY_EXAMPLE = JSON.parse(readFileSync(join(ROOT, 'policy.example.json'), 'utf8'));
+const SCENARIO_EXAMPLE = JSON.parse(readFileSync(join(ROOT, 'scenarios', 'certify-100.json'), 'utf8'));
+
+const tmp = mkdtempSync(join(tmpdir(), 'rfc61-config-'));
+let seq = 0;
+function writeJson(obj) {
+  const path = join(tmp, `fixture-${seq++}.json`);
+  writeFileSync(path, JSON.stringify(obj, null, 2));
+  return path;
+}
+
+/** Build a scenario baseDir: scenarios.json manifest + scenarios/<name>.json files. */
+function scenarioBaseDir(scenarioByName, manifestNames = Object.keys(scenarioByName)) {
+  const base = join(tmp, `scen-${seq++}`);
+  mkdirSync(join(base, 'scenarios'), { recursive: true });
+  writeFileSync(join(base, 'scenarios.json'), JSON.stringify({ schemaVersion: 1, scenarios: manifestNames }));
+  for (const [name, sc] of Object.entries(scenarioByName)) {
+    writeFileSync(join(base, 'scenarios', `${name}.json`), JSON.stringify(sc, null, 2));
+  }
+  return base;
+}
+
+const clone = (o) => structuredClone(o);
+
+/** Run fn, return the thrown error (node:assert's throws() does not return it). */
+function capture(fn) {
+  try {
+    fn();
+  } catch (e) {
+    return e;
+  }
+  return assert.fail('expected the call to throw');
+}
+
+// ── fileDigest ───────────────────────────────────────────────────────────────
+
+test('fileDigest is sha256 of the raw file bytes', () => {
+  const path = join(tmp, 'digest-probe.bin');
+  writeFileSync(path, 'exact bytes\n');
+  const expected = createHash('sha256').update('exact bytes\n').digest('hex');
+  assert.equal(fileDigest(path), expected);
+});
+
+// ── loadFleet ────────────────────────────────────────────────────────────────
+
+test('loadFleet: the example fleet loads and returns the contract shape + digest', () => {
+  const path = writeJson(FLEET_EXAMPLE);
+  const fleet = loadFleet(path);
+  assert.equal(fleet.network, 'base:84532');
+  assert.equal(fleet.cores.length, 2);
+  assert.deepEqual(fleet.cores.map((c) => c.alias), ['core-1', 'core-2']);
+  assert.equal(fleet.sshConcurrency, 2);
+  assert.equal(fleet.sshConnectTimeoutSec, 8);
+  assert.equal(fleet.edges.nonMember, null);
+  assert.deepEqual(fleet.seeds, []);
+  assert.equal(fleet.digest, fileDigest(path));
+});
+
+test('loadFleet: collects ALL problems into one error joined with "; "', () => {
+  const bad = clone(FLEET_EXAMPLE);
+  bad.cores[0].alias = 'Core_1'; // bad alias format
+  bad.cores[1].apiPort = 0; // bad port
+  delete bad.cores[1].host; // missing host
+  bad.sshConcurrency = 0; // bad concurrency
+  const err = capture(() => loadFleet(writeJson(bad)));
+  assert.match(err.message, /alias/);
+  assert.match(err.message, /apiPort/);
+  assert.match(err.message, /host/);
+  assert.match(err.message, /sshConcurrency/);
+  assert.ok(err.message.split('; ').length >= 4, `expected >=4 joined problems: ${err.message}`);
+});
+
+test('loadFleet: duplicate aliases, bad network, missing edge key, unknown role all rejected', () => {
+  const bad = clone(FLEET_EXAMPLE);
+  bad.cores[1].alias = 'core-1';
+  bad.network = 'base sepolia';
+  delete bad.edges.nonMember;
+  bad.cores[0].roles = ['core', 'gateway'];
+  const err = capture(() => loadFleet(writeJson(bad)));
+  assert.match(err.message, /duplicate alias 'core-1'/);
+  assert.match(err.message, /network/);
+  assert.match(err.message, /edges\.nonMember/);
+  assert.match(err.message, /unknown role 'gateway'/);
+});
+
+test('loadFleet: empty cores and non-object edges rejected', () => {
+  const bad = clone(FLEET_EXAMPLE);
+  bad.cores = [];
+  bad.edges = 'nope';
+  const err = capture(() => loadFleet(writeJson(bad)));
+  assert.match(err.message, /cores must be a non-empty array/);
+  assert.match(err.message, /edges must be an object/);
+});
+
+test('loadFleet: invalid JSON and unreadable files throw, not crash', () => {
+  const path = join(tmp, 'not-json.json');
+  writeFileSync(path, '{ nope');
+  assert.throws(() => loadFleet(path), /invalid JSON/);
+  assert.throws(() => loadFleet(join(tmp, 'missing.json')), /cannot read file/);
+});
+
+test('loadFleet: S6 — error text never echoes host/sshUser/sshIdentity values', () => {
+  const bad = clone(FLEET_EXAMPLE);
+  bad.cores[0].host = '203.0.113.77'; // sentinel topology values on a core that ALSO has errors
+  bad.cores[0].sshUser = 'sentinel-user-zz';
+  bad.cores[0].sshIdentity = '/sentinel/key/path';
+  bad.cores[0].apiPort = -1;
+  bad.cores[0].systemdUnit = '';
+  const err = capture(() => loadFleet(writeJson(bad)));
+  assert.ok(!err.message.includes('203.0.113.77'), 'host leaked into error text');
+  assert.ok(!err.message.includes('sentinel-user-zz'), 'sshUser leaked into error text');
+  assert.ok(!err.message.includes('/sentinel/key/path'), 'sshIdentity leaked into error text');
+  assert.match(err.message, /core-1/); // referenced by alias instead
+});
+
+// ── loadPolicy ───────────────────────────────────────────────────────────────
+
+test('loadPolicy: the example policy loads and returns the contract shape + digest', () => {
+  const path = writeJson(POLICY_EXAMPLE);
+  const policy = loadPolicy(path);
+  assert.deepEqual(
+    Object.keys(policy).sort(),
+    ['digest', 'faucet', 'permanentData', 'quiesce', 'safetyAbort', 'trips'],
+  );
+  assert.equal(policy.trips.diskFreeFloorBytes.default, 16106127360);
+  assert.equal(policy.quiesce.flatCounterConfirmSec, 20);
+  assert.equal(policy.digest, fileDigest(path));
+});
+
+test('POLICY_TRIPS direction table covers exactly the policy.example.json trips (drift guard)', () => {
+  const exampleTrips = Object.keys(POLICY_EXAMPLE.trips).filter((k) => !k.startsWith('$')).sort();
+  assert.deepEqual(Object.keys(POLICY_TRIPS).sort(), exampleTrips);
+});
+
+test('loadPolicy: every example trip is required', () => {
+  const bad = clone(POLICY_EXAMPLE);
+  delete bad.trips.diskFreeFloorBytes;
+  assert.throws(() => loadPolicy(writeJson(bad)), /trips\.diskFreeFloorBytes missing/);
+});
+
+test('loadPolicy: hardMax FLOOR direction — a LOWER disk floor is looser and throws', () => {
+  const bad = clone(POLICY_EXAMPLE);
+  bad.trips.diskFreeFloorBytes.default = 8 * 1024 ** 3; // below hardMax floor 10 GiB
+  assert.throws(() => loadPolicy(writeJson(bad)), /diskFreeFloorBytes.*LOOSER than hardMax/);
+
+  const ok = clone(POLICY_EXAMPLE);
+  ok.trips.diskFreeFloorBytes.default = 20 * 1024 ** 3; // higher floor = tighter
+  assert.equal(loadPolicy(writeJson(ok)).trips.diskFreeFloorBytes.default, 20 * 1024 ** 3);
+});
+
+test('loadPolicy: hardMax CEILING direction — a HIGHER rpc delta is looser and throws', () => {
+  const bad = clone(POLICY_EXAMPLE);
+  bad.trips.rpcExhaustionDeltaPerRun.default = 1000; // above hardMax ceiling 500
+  assert.throws(() => loadPolicy(writeJson(bad)), /rpcExhaustionDeltaPerRun.*LOOSER than hardMax/);
+
+  const ok = clone(POLICY_EXAMPLE);
+  ok.trips.rpcExhaustionDeltaPerRun.default = 50; // lower ceiling = tighter
+  assert.equal(loadPolicy(writeJson(ok)).trips.rpcExhaustionDeltaPerRun.default, 50);
+});
+
+test('loadPolicy: hardMax BOOLEAN direction — disabling a true-hardMax trip throws', () => {
+  const bad = clone(POLICY_EXAMPLE);
+  bad.trips.acceptQueueRecvQAtBacklog.default = false;
+  assert.throws(() => loadPolicy(writeJson(bad)), /acceptQueueRecvQAtBacklog.*LOOSER than hardMax/);
+});
+
+test('loadPolicy: unknown trips, bad types, missing knobs and blocks all collected in one error', () => {
+  const bad = clone(POLICY_EXAMPLE);
+  bad.trips.totallyMadeUp = { default: 1, hardMax: 2 };
+  bad.trips.oomKillDelta.default = 'zero';
+  delete bad.trips.memoryPsiSomeAvg10.sustainSec;
+  delete bad.quiesce;
+  bad.faucet.maxTopUpsPerRun = -1;
+  const err = capture(() => loadPolicy(writeJson(bad)));
+  assert.match(err.message, /totallyMadeUp.*unknown trip/);
+  assert.match(err.message, /oomKillDelta.*must both be numbers/);
+  assert.match(err.message, /memoryPsiSomeAvg10\.sustainSec/);
+  assert.match(err.message, /quiesce must be an object/);
+  assert.match(err.message, /faucet\.maxTopUpsPerRun/);
+});
+
+test('isLooser: direction semantics', () => {
+  assert.equal(isLooser(5, 10, 'floor'), true); // lower floor = looser
+  assert.equal(isLooser(15, 10, 'floor'), false);
+  assert.equal(isLooser(15, 10, 'ceiling'), true); // higher ceiling = looser
+  assert.equal(isLooser(5, 10, 'ceiling'), false);
+  assert.equal(isLooser(10, 10, 'ceiling'), false); // equal is never looser
+  assert.equal(isLooser(false, true, 'boolean'), true);
+  assert.equal(isLooser(true, true, 'boolean'), false);
+});
+
+// ── loadScenario ─────────────────────────────────────────────────────────────
+
+const policy = loadPolicy(writeJson(POLICY_EXAMPLE));
+
+test('loadScenario: the shipped certify-100 scenario loads against the example policy', () => {
+  const base = scenarioBaseDir({ 'certify-100': SCENARIO_EXAMPLE });
+  const { scenario, digest } = loadScenario('certify-100', { policy, baseDir: base });
+  assert.equal(scenario.scenario, 'certify-100');
+  assert.deepEqual(scenario.lanes, ['public', 'private']);
+  assert.equal(digest, fileDigest(join(base, 'scenarios', 'certify-100.json')));
+});
+
+test('loadScenario: a scenario missing from scenarios.json is refused (manifest drift)', () => {
+  const base = scenarioBaseDir({ 'certify-100': SCENARIO_EXAMPLE }, []); // file on disk, not listed
+  assert.throws(() => loadScenario('certify-100', { policy, baseDir: base }), /not listed in scenarios\.json/);
+});
+
+test('loadScenario: listed but file missing throws; traversal-shaped names are rejected outright', () => {
+  const base = scenarioBaseDir({}, ['ghost']);
+  assert.throws(() => loadScenario('ghost', { policy, baseDir: base }), /cannot read file/);
+  assert.throws(() => loadScenario('../evil', { policy, baseDir: base }), /must match/);
+});
+
+test('loadScenario: shape per certify-100.json — missing keys and field mismatch collected', () => {
+  const bad = clone(SCENARIO_EXAMPLE);
+  delete bad.readback;
+  delete bad.soakSeconds;
+  bad.scenario = 'other-name';
+  bad.workload.concurrency = 0;
+  bad.lanes = ['public', 'sideband'];
+  const base = scenarioBaseDir({ 'certify-100': bad });
+  const err = capture(() => loadScenario('certify-100', { policy, baseDir: base }));
+  assert.match(err.message, /missing required key 'readback'/);
+  assert.match(err.message, /missing required key 'soakSeconds'/);
+  assert.match(err.message, /'scenario' field must equal the file basename/);
+  assert.match(err.message, /workload\.concurrency/);
+  assert.match(err.message, /lanes/);
+});
+
+test('loadScenario S3: a scalar trip override may only tighten (ceiling)', () => {
+  const loosened = clone(SCENARIO_EXAMPLE);
+  loosened.trips = { rpcExhaustionDeltaPerRun: 200 }; // policy default 100 → looser
+  let base = scenarioBaseDir({ 'certify-100': loosened });
+  assert.throws(
+    () => loadScenario('certify-100', { policy, baseDir: base }),
+    /trips\.rpcExhaustionDeltaPerRun.*LOOSENS policy/,
+  );
+
+  const tightened = clone(SCENARIO_EXAMPLE);
+  tightened.trips = { rpcExhaustionDeltaPerRun: 50 };
+  base = scenarioBaseDir({ 'certify-100': tightened });
+  const { scenario } = loadScenario('certify-100', { policy, baseDir: base });
+  assert.equal(scenario.trips.rpcExhaustionDeltaPerRun, 50);
+});
+
+test('loadScenario S3: a scalar trip override may only tighten (floor — LOWER is looser)', () => {
+  const loosened = clone(SCENARIO_EXAMPLE);
+  loosened.trips = { diskFreeFloorBytes: 8 * 1024 ** 3 }; // policy default 15 GiB → looser
+  let base = scenarioBaseDir({ 'certify-100': loosened });
+  assert.throws(
+    () => loadScenario('certify-100', { policy, baseDir: base }),
+    /trips\.diskFreeFloorBytes.*LOOSENS policy/,
+  );
+
+  const tightened = clone(SCENARIO_EXAMPLE);
+  tightened.trips = { diskFreeFloorBytes: 20 * 1024 ** 3 }; // higher floor = tighter
+  base = scenarioBaseDir({ 'certify-100': tightened });
+  loadScenario('certify-100', { policy, baseDir: base }); // must not throw
+});
+
+test('loadScenario S3: object overrides check both the default and per-knob directions', () => {
+  const loosenedKnob = clone(SCENARIO_EXAMPLE);
+  loosenedKnob.trips = { memoryPsiSomeAvg10: { default: 0.3, sustainSec: 120 } }; // 120 > policy 60 → looser
+  let base = scenarioBaseDir({ 'certify-100': loosenedKnob });
+  assert.throws(
+    () => loadScenario('certify-100', { policy, baseDir: base }),
+    /memoryPsiSomeAvg10\.sustainSec.*LOOSENS policy/,
+  );
+
+  const tightened = clone(SCENARIO_EXAMPLE);
+  tightened.trips = { memoryPsiSomeAvg10: { default: 0.3, sustainSec: 30 } };
+  base = scenarioBaseDir({ 'certify-100': tightened });
+  loadScenario('certify-100', { policy, baseDir: base }); // must not throw
+
+  const booleanOff = clone(SCENARIO_EXAMPLE);
+  booleanOff.trips = { acceptQueueRecvQAtBacklog: false }; // disabling the trip = loosening
+  base = scenarioBaseDir({ 'certify-100': booleanOff });
+  assert.throws(
+    () => loadScenario('certify-100', { policy, baseDir: base }),
+    /acceptQueueRecvQAtBacklog.*LOOSENS policy/,
+  );
+
+  const unknown = clone(SCENARIO_EXAMPLE);
+  unknown.trips = { madeUpTrip: 1 };
+  base = scenarioBaseDir({ 'certify-100': unknown });
+  assert.throws(
+    () => loadScenario('certify-100', { policy, baseDir: base }),
+    /trips\.madeUpTrip is not a known policy trip/,
+  );
+});
+
+test('loadScenario S3: gates.fleet keys that shadow policy trips are tighten-only too', () => {
+  const loosened = clone(SCENARIO_EXAMPLE);
+  loosened.gates.fleet.oomKillDelta = 2; // policy trip default 0 → looser
+  let base = scenarioBaseDir({ 'certify-100': loosened });
+  assert.throws(
+    () => loadScenario('certify-100', { policy, baseDir: base }),
+    /gates\.fleet\.oomKillDelta.*LOOSENS policy/,
+  );
+
+  const equal = clone(SCENARIO_EXAMPLE); // shipped gate is 0 == policy default 0
+  base = scenarioBaseDir({ 'certify-100': equal });
+  loadScenario('certify-100', { policy, baseDir: base }); // equal is not looser
+});
+
+// ── verifyCredentialIsolation (S2) ───────────────────────────────────────────
+
+const HOME = join(tmp, 'home');
+mkdirSync(join(HOME, '.ssh'), { recursive: true });
+writeFileSync(join(HOME, '.ssh', 'id_harness_readonly'), 'FAKE KEY MATERIAL\n');
+
+const SENTINEL_HOST = '203.0.113.10';
+const SENTINEL_USER = 'obsvr-sentinel';
+function makeFleet(overrides = {}) {
+  return {
+    cores: [{
+      alias: 'core-1',
+      host: SENTINEL_HOST,
+      sshUser: SENTINEL_USER,
+      sshIdentity: '~/.ssh/id_harness_readonly',
+      systemdUnit: 'dkg-node',
+      apiPort: 9200,
+      listenPort: 9090,
+      storeFilesystem: '/',
+      roles: ['core'],
+      ...overrides,
+    }],
+    sshConnectTimeoutSec: 8,
+  };
+}
+
+/** Fake _exec: records calls, answers via responder({file, args}). Never throws. */
+function makeExec(responder) {
+  const calls = [];
+  const exec = async (file, args, opts) => {
+    calls.push({ file, args, opts });
+    return { stdout: '', stderr: '', code: 0, timedOut: false, ...responder({ file, args }) };
+  };
+  return { exec, calls };
+}
+
+const remoteCmdOf = (args) => args[args.length - 1];
+
+/** Responder for a correctly isolated fleet: allowlisted forced command rejects everything. */
+function isolatedResponder({ file, args }) {
+  if (file === 'ssh-add') return { code: 1, stdout: 'The agent has no identities.\n' };
+  const cmd = remoteCmdOf(args);
+  if (cmd === 'sudo -n true') return { code: 12, stderr: 'snapshot-only key: command rejected\n' };
+  if (cmd === 'echo x') return { code: 0, stdout: 'host=b64:aG9zdA==\nactive_state=active\n' }; // forced snapshot output, not 'x'
+  throw new Error(`unexpected probe command: ${cmd}`);
+}
+
+test('verifyCredentialIsolation: interactive mode skips probes and records the mode', async () => {
+  const { exec, calls } = makeExec(() => ({}));
+  const res = await verifyCredentialIsolation(makeFleet(), { mode: 'interactive', _exec: exec, _env: {} });
+  assert.equal(res.ok, true);
+  assert.equal(res.checks.length, 1);
+  assert.equal(res.checks[0].id, 'mode-interactive');
+  assert.equal(res.checks[0].evidence.mode, 'interactive');
+  assert.equal(calls.length, 0);
+});
+
+test('verifyCredentialIsolation: autonomous happy path — isolated key passes all checks', async () => {
+  const { exec, calls } = makeExec(isolatedResponder);
+  const res = await verifyCredentialIsolation(makeFleet(), { mode: 'autonomous', _exec: exec, _env: { HOME } });
+  assert.equal(res.ok, true, JSON.stringify(res.checks, null, 2));
+  assert.deepEqual(
+    res.checks.map((c) => c.id),
+    ['no-agent', 'identity-only', 'sudo-refused:core-1', 'no-verbatim-exec:core-1'],
+  );
+  assert.ok(res.checks.every((c) => c.pass));
+
+  // No agent socket → ssh-add never consulted; exactly the two ssh probes ran.
+  assert.deepEqual(calls.map((c) => c.file), ['ssh', 'ssh']);
+  for (const call of calls) {
+    const flat = call.args.join(' ');
+    assert.match(flat, /BatchMode=yes/);
+    assert.match(flat, /IdentitiesOnly=yes/);
+    assert.match(flat, /IdentityAgent=none/);
+    assert.match(flat, /StrictHostKeyChecking=accept-new/);
+    assert.ok(call.args.includes('-i'), 'probe must pin the identity file');
+    assert.equal(call.args[call.args.length - 2], '--');
+  }
+  assert.equal(remoteCmdOf(calls[0].args), 'sudo -n true');
+  assert.equal(remoteCmdOf(calls[1].args), 'echo x');
+});
+
+test('verifyCredentialIsolation: verbatim echo round-trip means NO forced command — fail', async () => {
+  const { exec } = makeExec((call) => {
+    if (remoteCmdOf(call.args) === 'echo x') return { code: 0, stdout: 'x\n' };
+    return isolatedResponder(call);
+  });
+  const res = await verifyCredentialIsolation(makeFleet(), { mode: 'autonomous', _exec: exec, _env: { HOME } });
+  assert.equal(res.ok, false);
+  const echoCheck = res.checks.find((c) => c.id === 'no-verbatim-exec:core-1');
+  assert.equal(echoCheck.pass, false);
+  assert.equal(echoCheck.evidence.verbatim, true);
+});
+
+test('verifyCredentialIsolation: sudo probe succeeding (exit 0) fails the isolation check', async () => {
+  const { exec } = makeExec((call) => {
+    if (remoteCmdOf(call.args) === 'sudo -n true') return { code: 0, stdout: '' };
+    return isolatedResponder(call);
+  });
+  const res = await verifyCredentialIsolation(makeFleet(), { mode: 'autonomous', _exec: exec, _env: { HOME } });
+  assert.equal(res.ok, false);
+  assert.equal(res.checks.find((c) => c.id === 'sudo-refused:core-1').pass, false);
+});
+
+test('verifyCredentialIsolation: sudo refusal via password-required message passes', async () => {
+  const { exec } = makeExec((call) => {
+    if (remoteCmdOf(call.args) === 'sudo -n true') {
+      return { code: 1, stderr: 'sudo: a password is required\n' };
+    }
+    return isolatedResponder(call);
+  });
+  const res = await verifyCredentialIsolation(makeFleet(), { mode: 'autonomous', _exec: exec, _env: { HOME } });
+  const sudoCheck = res.checks.find((c) => c.id === 'sudo-refused:core-1');
+  assert.equal(sudoCheck.pass, true);
+  assert.equal(sudoCheck.evidence.passwordPrompt, true);
+});
+
+test('verifyCredentialIsolation: ambient agent WITH identities fails; empty agent passes', async () => {
+  const withKeys = makeExec((call) => {
+    if (call.file === 'ssh-add') return { code: 0, stdout: '256 SHA256:abcdef laptop-key (ED25519)\n' };
+    return isolatedResponder(call);
+  });
+  const env = { HOME, SSH_AUTH_SOCK: join(tmp, 'agent.sock') };
+  const res1 = await verifyCredentialIsolation(makeFleet(), { mode: 'autonomous', _exec: withKeys.exec, _env: env });
+  assert.equal(res1.ok, false);
+  const agentCheck = res1.checks.find((c) => c.id === 'no-agent');
+  assert.deepEqual(agentCheck, { id: 'no-agent', pass: false, evidence: { authSockSet: true, agentIdentities: 1 } });
+  assert.equal(withKeys.calls[0].file, 'ssh-add');
+  assert.deepEqual(withKeys.calls[0].args, ['-l']);
+
+  const empty = makeExec(isolatedResponder); // ssh-add → code 1 "no identities"
+  const res2 = await verifyCredentialIsolation(makeFleet(), { mode: 'autonomous', _exec: empty.exec, _env: env });
+  assert.equal(res2.ok, true);
+  assert.deepEqual(res2.checks.find((c) => c.id === 'no-agent').evidence, { authSockSet: true, agentEmpty: true });
+});
+
+test('verifyCredentialIsolation: unverifiable agent state fails closed', async () => {
+  const { exec } = makeExec((call) => {
+    if (call.file === 'ssh-add') return { code: 2, stderr: 'Error connecting to agent\n' };
+    return isolatedResponder(call);
+  });
+  const res = await verifyCredentialIsolation(makeFleet(), {
+    mode: 'autonomous', _exec: exec, _env: { HOME, SSH_AUTH_SOCK: '/dead/agent.sock' },
+  });
+  assert.equal(res.ok, false);
+  assert.equal(res.checks.find((c) => c.id === 'no-agent').evidence.reason, 'agent-state-unverifiable');
+});
+
+test('verifyCredentialIsolation: ssh transport failure (255) fails BOTH probes closed', async () => {
+  const { exec } = makeExec((call) => {
+    if (call.file === 'ssh') return { code: 255, stderr: 'Connection timed out\n' };
+    return isolatedResponder(call);
+  });
+  const res = await verifyCredentialIsolation(makeFleet(), { mode: 'autonomous', _exec: exec, _env: { HOME } });
+  assert.equal(res.ok, false);
+  for (const id of ['sudo-refused:core-1', 'no-verbatim-exec:core-1']) {
+    const check = res.checks.find((c) => c.id === id);
+    assert.equal(check.pass, false);
+    assert.equal(check.evidence.reason, 'ssh-transport-error-cannot-verify');
+  }
+});
+
+test('verifyCredentialIsolation: missing identity file fails and is never probed over ssh', async () => {
+  const { exec, calls } = makeExec(isolatedResponder);
+  const fleet = makeFleet({ sshIdentity: '~/.ssh/no-such-key' });
+  const res = await verifyCredentialIsolation(fleet, { mode: 'autonomous', _exec: exec, _env: { HOME } });
+  assert.equal(res.ok, false);
+  const idCheck = res.checks.find((c) => c.id === 'identity-only');
+  assert.equal(idCheck.pass, false);
+  assert.deepEqual(idCheck.evidence.coresMissingIdentity, ['core-1']);
+  for (const id of ['sudo-refused:core-1', 'no-verbatim-exec:core-1']) {
+    assert.equal(res.checks.find((c) => c.id === id).evidence.reason, 'identity-missing-not-probed');
+  }
+  assert.equal(calls.filter((c) => c.file === 'ssh').length, 0, 'must not ssh without a pinned identity');
+});
+
+test('verifyCredentialIsolation: S6 — checks carry aliases only, never host/user/key-path', async () => {
+  const { exec } = makeExec((call) => {
+    if (call.file === 'ssh') return { code: 255, stderr: `connect to ${SENTINEL_HOST}: refused\n` };
+    return isolatedResponder(call);
+  });
+  const res = await verifyCredentialIsolation(makeFleet(), { mode: 'autonomous', _exec: exec, _env: { HOME } });
+  const serialized = JSON.stringify(res);
+  assert.ok(!serialized.includes(SENTINEL_HOST), 'host leaked into checks');
+  assert.ok(!serialized.includes(SENTINEL_USER), 'sshUser leaked into checks');
+  assert.ok(!serialized.includes('id_harness_readonly'), 'identity path leaked into checks');
+  assert.ok(serialized.includes('core-1'), 'cores must be referenced by alias');
+});
+
+test('verifyCredentialIsolation: invalid mode throws (config error, not probe result)', async () => {
+  await assert.rejects(
+    () => verifyCredentialIsolation(makeFleet(), { mode: 'yolo' }),
+    /mode must be 'autonomous' or 'interactive'/,
+  );
+});

--- a/testnet/test/edge.test.mjs
+++ b/testnet/test/edge.test.mjs
@@ -1,0 +1,521 @@
+// Hermetic tests for lib/edge.mjs — no real SSH, no external network, no fleet.
+// A local node:http fake daemon on 127.0.0.1 stands in for the edge; token
+// resolution runs against a temp DKG_HOME; runCli runs against stub node scripts.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  EdgeClient,
+  runCli,
+  makePayload,
+  verifyReadback,
+  parseNquads,
+  resolveEdgeToken,
+  tailTruncate,
+} from '../lib/edge.mjs';
+import { normTerm } from '../lib/util.mjs';
+
+const TOKEN = 'tok-abc123';
+
+function makeDkgHome({ token = TOKEN } = {}) {
+  const home = mkdtempSync(join(tmpdir(), 'rfc61-edge-home-'));
+  if (token !== null) {
+    writeFileSync(
+      join(home, 'auth.token'),
+      `# DKG node API token — treat this like a password\n\n${token}\n`,
+    );
+  }
+  return home;
+}
+
+function listen(server) {
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => resolve(server.address().port));
+  });
+}
+
+async function readBody(req) {
+  let raw = '';
+  for await (const chunk of req) raw += chunk;
+  return raw ? JSON.parse(raw) : null;
+}
+
+async function waitUntil(label, cond, timeoutMs = 3000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (cond()) return;
+    await new Promise((r) => setTimeout(r, 5));
+  }
+  throw new Error(`waitUntil timeout: ${label}`);
+}
+
+// ── token resolution ─────────────────────────────────────────────────────────
+
+test('resolveEdgeToken: override > DKG_AUTH_TOKEN env > auth.token file > undefined', () => {
+  const home = makeDkgHome();
+  assert.equal(resolveEdgeToken(home, { env: {} }), TOKEN);
+  assert.equal(resolveEdgeToken(home, { env: { DKG_AUTH_TOKEN: ' env-tok ' } }), 'env-tok');
+  assert.equal(resolveEdgeToken(home, { token: 'override', env: { DKG_AUTH_TOKEN: 'env-tok' } }), 'override');
+  const empty = makeDkgHome({ token: null });
+  assert.equal(resolveEdgeToken(empty, { env: {} }), undefined);
+});
+
+test('auth.token parsing skips comments and blank lines (auth.ts contract)', () => {
+  const home = mkdtempSync(join(tmpdir(), 'rfc61-edge-home-'));
+  writeFileSync(join(home, 'auth.token'), '# comment\n\n# more\nfirst-token\nsecond-token\n');
+  assert.equal(resolveEdgeToken(home, { env: {} }), 'first-token');
+});
+
+// ── EdgeClient lifecycle against a fake daemon ───────────────────────────────
+
+test('EdgeClient: create / share-async / job poll / publish-async / publisher poll / KA state / query / catchup', async (t) => {
+  const home = makeDkgHome();
+  const seen = [];
+  let sharePolls = 0;
+  let publishPolls = 0;
+  const server = createServer(async (req, res) => {
+    const url = new URL(req.url, 'http://127.0.0.1');
+    const record = {
+      method: req.method,
+      path: url.pathname,
+      search: Object.fromEntries(url.searchParams),
+      auth: req.headers.authorization ?? null,
+      body: req.method === 'POST' ? await readBody(req) : null,
+    };
+    seen.push(record);
+    const send = (status, body) => {
+      res.writeHead(status, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(body));
+    };
+    if (req.method === 'GET' && url.pathname === '/api/status') {
+      return send(200, { name: 'tn-edge', nodeRole: 'edge', commit: 'deadbeef', uptimeMs: 1 });
+    }
+    if (req.method === 'POST' && url.pathname === '/api/knowledge-assets') {
+      return send(201, { name: record.body.name, assertionUri: 'urn:a', alreadyExists: false, status: 'wm-sealed', merkleRoot: '0xmr' });
+    }
+    if (req.method === 'POST' && url.pathname === '/api/knowledge-assets/ka-1/swm/share-async') {
+      return send(200, { jobId: 'sj-1', state: 'queued' });
+    }
+    if (req.method === 'GET' && url.pathname === '/api/knowledge-assets/swm/share-jobs/sj-1') {
+      sharePolls++;
+      if (sharePolls < 3) return send(200, { jobId: 'sj-1', state: 'running' });
+      return send(200, { jobId: 'sj-1', state: 'succeeded', result: { promotedCount: 1 } });
+    }
+    if (req.method === 'POST' && url.pathname === '/api/knowledge-assets/ka-1/vm/publish-async') {
+      return send(202, { jobId: 'pj-1', status: 'accepted', contextGraphId: record.body.contextGraphId, name: 'ka-1' });
+    }
+    if (req.method === 'GET' && url.pathname === '/api/publisher/job') {
+      publishPolls++;
+      if (publishPolls < 2) return send(200, { job: { jobId: url.searchParams.get('id'), status: 'broadcast' } });
+      return send(200, { job: { jobId: url.searchParams.get('id'), status: 'finalized', ual: 'did:dkg:base:84532/0xabc/7', txHash: '0xtx' } });
+    }
+    if (req.method === 'GET' && url.pathname === '/api/knowledge-assets/ka-1') {
+      return send(200, { name: 'ka-1', memoryLayer: 'VM', publishedUal: 'did:dkg:base:84532/0xabc/7', reservedUal: 'did:dkg:reserved', events: [{ toLayer: 'VM' }] });
+    }
+    if (req.method === 'POST' && url.pathname === '/api/query') {
+      return send(200, { result: { bindings: [{ s: 'urn:x', o: '"y"' }] }, phases: { execute: 1, serverTotal: 2 } });
+    }
+    if (req.method === 'GET' && url.pathname === '/api/sync/catchup-status') {
+      return send(200, { jobId: 'cu-1', state: 'done', bytesReceived: 42 });
+    }
+    return send(404, { error: `unexpected ${req.method} ${url.pathname}` });
+  });
+  const port = await listen(server);
+  t.after(() => server.close());
+
+  const edge = new EdgeClient({ dkgHome: home, apiPort: port, label: 'driver', env: {} });
+
+  // status() is the PUBLIC route — must not send Authorization (api-client.ts auth:false).
+  const status = await edge.status();
+  assert.equal(status.name, 'tn-edge');
+  assert.equal(seen.at(-1).auth, null);
+
+  // create: N-Quads string converted to writable-quad objects; finalize passthrough.
+  const payload = makePayload({ runId: 'r1', lane: 'public', index: 3, controlFixtureEvery: 10 });
+  const created = await edge.createKnowledgeAsset({ name: 'ka-1', cg: '0xADDR/cg-pub', quads: payload.quads, finalize: true });
+  assert.equal(created.status, 'wm-sealed');
+  const createReq = seen.at(-1);
+  assert.equal(createReq.auth, `Bearer ${TOKEN}`);
+  assert.equal(createReq.body.contextGraphId, '0xADDR/cg-pub');
+  assert.equal(createReq.body.finalize, true);
+  assert.ok(Array.isArray(createReq.body.quads), 'quads must be the array shape the route accepts');
+  assert.deepEqual(createReq.body.quads, [{
+    subject: payload.subject,
+    predicate: 'http://schema.org/name',
+    object: payload.expectedObject,
+  }]);
+
+  // share-async → waitShareJob (terminal 'succeeded', non-terminal 'running' polled through).
+  const share = await edge.shareAsync({ name: 'ka-1', cg: '0xADDR/cg-pub' });
+  assert.deepEqual(share, { jobId: 'sj-1', state: 'queued' });
+  assert.equal(seen.at(-1).body.contextGraphId, '0xADDR/cg-pub');
+  const shareDone = await edge.waitShareJob({ jobId: 'sj-1', timeoutMs: 3000, intervalMs: 10 });
+  assert.equal(shareDone.job.state, 'succeeded');
+  assert.equal(shareDone.pollIntervalMs, 10);
+  assert.equal(sharePolls, 3);
+
+  // publish-async → waitPublishJob (terminal 'finalized' with ual+txHash).
+  const pub = await edge.publishAsync({ name: 'ka-1', cg: '0xADDR/cg-pub' });
+  assert.equal(pub.jobId, 'pj-1');
+  assert.equal(pub.status, 'accepted');
+  const pubDone = await edge.waitPublishJob({ jobId: 'pj-1', timeoutMs: 3000, intervalMs: 10 });
+  assert.equal(pubDone.job.status, 'finalized');
+  assert.equal(pubDone.job.ual, 'did:dkg:base:84532/0xabc/7');
+  assert.equal(pubDone.job.txHash, '0xtx');
+  assert.equal(pubDone.pollIntervalMs, 10);
+
+  // knowledgeAssetState — the §6 recovery authority.
+  const state = await edge.knowledgeAssetState({ name: 'ka-1', cg: '0xADDR/cg-pub' });
+  assert.equal(state.memoryLayer, 'VM');
+  assert.equal(state.publishedUal, 'did:dkg:base:84532/0xabc/7');
+  assert.equal(seen.at(-1).search.contextGraphId, '0xADDR/cg-pub');
+
+  // query — body field is `sparql` (NOT `query`), view + contextGraphId forwarded.
+  const q = await edge.query({ sparql: 'SELECT ?s WHERE { ?s ?p ?o }', view: 'verifiable-memory', cg: '0xADDR/cg-pub' });
+  assert.ok(Array.isArray(q.result.bindings));
+  const queryReq = seen.at(-1);
+  assert.equal(queryReq.body.sparql, 'SELECT ?s WHERE { ?s ?p ?o }');
+  assert.equal(queryReq.body.view, 'verifiable-memory');
+  assert.equal(queryReq.body.contextGraphId, '0xADDR/cg-pub');
+  assert.equal(queryReq.auth, `Bearer ${TOKEN}`);
+
+  // catchup-status.
+  const cu = await edge.catchupStatus({ cg: '0xADDR/cg-pub' });
+  assert.equal(cu.state, 'done');
+  assert.equal(seen.at(-1).search.contextGraphId, '0xADDR/cg-pub');
+});
+
+test('EdgeClient: non-2xx responses throw with status attached; waitShareJob times out on a never-terminal job', async (t) => {
+  const home = makeDkgHome();
+  const server = createServer(async (req, res) => {
+    const url = new URL(req.url, 'http://127.0.0.1');
+    if (req.method === 'POST') await readBody(req);
+    if (url.pathname.startsWith('/api/knowledge-assets/swm/share-jobs/')) {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      return res.end(JSON.stringify({ jobId: 'sj-stuck', state: 'failed_retrying' }));
+    }
+    res.writeHead(409, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Promote job already active', existingJobId: 'sj-0' }));
+  });
+  const port = await listen(server);
+  t.after(() => server.close());
+  const edge = new EdgeClient({ dkgHome: home, apiPort: port, label: 'driver', env: {} });
+
+  await assert.rejects(
+    edge.shareAsync({ name: 'ka-1', cg: 'cg' }),
+    (err) => err.status === 409 && err.body.existingJobId === 'sj-0',
+  );
+  // failed_retrying is NOT terminal (async-promote-queue-types.ts) — must poll to deadline.
+  await assert.rejects(
+    edge.waitShareJob({ jobId: 'sj-stuck', timeoutMs: 80, intervalMs: 10 }),
+    (err) => err.timedOut === true && /failed_retrying/.test(err.message),
+  );
+});
+
+// ── SSE events: parse, auth, forced disconnect → gap + auto-reconnect ────────
+
+test('events(): parses SSE frames, records disconnect gap, reconnects automatically', async (t) => {
+  const home = makeDkgHome();
+  const connections = [];
+  const server = createServer((req, res) => {
+    const url = new URL(req.url, 'http://127.0.0.1');
+    assert.equal(url.pathname, '/api/events');
+    connections.push({ auth: req.headers.authorization ?? null, accept: req.headers.accept, res });
+    res.writeHead(200, { 'Content-Type': 'text/event-stream; charset=utf-8', 'Cache-Control': 'no-cache' });
+    // Exact daemon greeting + broadcast shape (lifecycle.ts:3457, 2921-2927).
+    res.write('event: connected\ndata: {}\n\n');
+    res.write(': heartbeat\n\n');
+    const n = connections.length;
+    res.write(`event: memory_graph_changed\ndata: ${JSON.stringify({ contextGraphId: 'cg-1', operation: 'assertion_promoted', conn: n })}\n\n`);
+  });
+  const port = await listen(server);
+  t.after(() => server.close());
+
+  const edge = new EdgeClient({ dkgHome: home, apiPort: port, label: 'observer', env: {} });
+  const received = [];
+  const handle = await edge.events({ onEvent: (e) => received.push(e), retryMs: 25, connectTimeoutMs: 2000 });
+  t.after(() => handle.close());
+
+  await waitUntil('first connection events', () => received.filter((e) => e.event === 'memory_graph_changed').length >= 1);
+  assert.equal(connections.length, 1);
+  assert.equal(connections[0].auth, `Bearer ${TOKEN}`);
+  assert.equal(connections[0].accept, 'text/event-stream');
+  assert.equal(received[0].event, 'connected');
+  assert.deepEqual(received[0].data, {});
+  const mgc = received.find((e) => e.event === 'memory_graph_changed');
+  assert.equal(mgc.data.contextGraphId, 'cg-1');
+  assert.equal(mgc.data.conn, 1);
+  assert.equal(typeof mgc.ts, 'number');
+  // No gap yet — the stream has never dropped.
+  assert.deepEqual(handle.gaps(), []);
+
+  // Forced disconnect (§4.3 SSE reliability): daemon side kills the socket.
+  connections[0].res.destroy();
+  await waitUntil('reconnect + second stream events', () =>
+    received.filter((e) => e.event === 'memory_graph_changed').length >= 2);
+  assert.equal(connections.length, 2, 'client must reconnect automatically');
+  assert.equal(received.filter((e) => e.event === 'memory_graph_changed').at(-1).data.conn, 2);
+
+  const gaps = handle.gaps();
+  assert.equal(gaps.length, 1, 'exactly one disconnect gap recorded');
+  assert.equal(typeof gaps[0].fromTs, 'number');
+  assert.equal(typeof gaps[0].toTs, 'number');
+  assert.ok(gaps[0].fromTs <= gaps[0].toTs, 'gap interval must be ordered');
+
+  handle.close();
+  const countAfterClose = connections.length;
+  await new Promise((r) => setTimeout(r, 80));
+  assert.equal(connections.length, countAfterClose, 'close() must stop reconnecting');
+});
+
+test('events(): rejects when no connection within connectTimeoutMs', async () => {
+  const home = makeDkgHome();
+  // Grab a port and close the server so nothing listens there.
+  const server = createServer(() => {});
+  const port = await listen(server);
+  await new Promise((r) => server.close(r));
+  const edge = new EdgeClient({ dkgHome: home, apiPort: port, label: 'observer', env: {} });
+  await assert.rejects(
+    edge.events({ onEvent: () => {}, retryMs: 20, connectTimeoutMs: 120 }),
+    /no SSE connection within 120ms/,
+  );
+});
+
+// ── makePayload determinism + fixture cadence ────────────────────────────────
+
+test('makePayload: deterministic, urn:rfc61 subject scheme, control fixtures every Nth', () => {
+  const a = makePayload({ runId: 'run-1', lane: 'private', index: 7, controlFixtureEvery: 10 });
+  const b = makePayload({ runId: 'run-1', lane: 'private', index: 7, controlFixtureEvery: 10 });
+  assert.deepEqual(a, b, 'same inputs must produce identical payloads');
+  assert.equal(a.subject, 'urn:rfc61:private:run-1:7');
+  assert.equal(a.controlFixture, false);
+  assert.equal(a.expectedObject, JSON.stringify('rfc61 private run-1 #7'));
+  assert.equal(a.quads, `<urn:rfc61:private:run-1:7> <http://schema.org/name> ${a.expectedObject} .\n`);
+
+  // Cadence: indices 0 and 10 are control fixtures with controlFixtureEvery=10; 1..9 are not.
+  for (let i = 0; i <= 10; i++) {
+    const p = makePayload({ runId: 'run-1', lane: 'public', index: i, controlFixtureEvery: 10 });
+    assert.equal(p.controlFixture, i % 10 === 0, `index ${i}`);
+  }
+  // Control fixture carries the rfc59 Unicode/control-char set: café / Δ / \n / \t / \u0001.
+  const cf = makePayload({ runId: 'run-1', lane: 'public', index: 20, controlFixtureEvery: 10 });
+  const literal = JSON.parse(cf.expectedObject);
+  assert.ok(literal.includes('café'));
+  assert.ok(literal.includes('Δ'));
+  assert.ok(literal.includes('\n'));
+  assert.ok(literal.includes('\t'));
+  assert.ok(literal.includes('\u0001'));
+  assert.ok(cf.expectedObject.includes('\\n') && cf.expectedObject.includes('\\t') && cf.expectedObject.includes('\\u0001'),
+    'expectedObject must be the escaped term form');
+  // Disabled cadence.
+  assert.equal(makePayload({ runId: 'r', lane: 'l', index: 0, controlFixtureEvery: 0 }).controlFixture, false);
+
+  // The generated N-Quads round-trip through the route-shape converter.
+  assert.deepEqual(parseNquads(cf.quads), [{
+    subject: cf.subject,
+    predicate: 'http://schema.org/name',
+    object: cf.expectedObject,
+  }]);
+});
+
+test('parseNquads: IRI objects unwrap to bare IRIs, graphs and datatypes survive, junk throws', () => {
+  assert.deepEqual(parseNquads('<urn:s> <urn:p> <urn:o> .'), [
+    { subject: 'urn:s', predicate: 'urn:p', object: 'urn:o' },
+  ]);
+  assert.deepEqual(parseNquads('<urn:s> <urn:p> "v"^^<http://www.w3.org/2001/XMLSchema#integer> <urn:g> .'), [
+    { subject: 'urn:s', predicate: 'urn:p', object: '"v"^^<http://www.w3.org/2001/XMLSchema#integer>', graph: 'urn:g' },
+  ]);
+  assert.deepEqual(parseNquads('<urn:s> <urn:p> "v"@en .'), [
+    { subject: 'urn:s', predicate: 'urn:p', object: '"v"@en' },
+  ]);
+  assert.throws(() => parseNquads('bare junk line'), /unparseable N-Quads line/);
+  assert.throws(() => parseNquads('\n# only a comment\n'), /no quads/);
+});
+
+// ── runCli (rfc59 publishOne child_process mechanics) ────────────────────────
+
+test('runCli: spawns node <cliPath> with DKG_HOME, captures output, reports duration', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'rfc61-cli-'));
+  const script = join(dir, 'ok.mjs');
+  writeFileSync(script, [
+    "console.log('HOME=' + process.env.DKG_HOME);",
+    "console.log('ARGS=' + JSON.stringify(process.argv.slice(2)));",
+    "console.error('warn-line');",
+    'process.exit(0);',
+  ].join('\n'));
+  const home = join(dir, 'dkg-home');
+  const r = await runCli({ cliPath: script, dkgHome: home, args: ['ka', 'create', 'x'], timeoutMs: 10_000 });
+  assert.equal(r.ok, true);
+  assert.equal(r.code, 0);
+  assert.equal(r.signal, null);
+  assert.equal(r.timedOut, false);
+  assert.ok(r.stdout.includes(`HOME=${home}`), 'DKG_HOME must be injected into the child env');
+  assert.ok(r.stdout.includes('ARGS=["ka","create","x"]'));
+  assert.equal(r.stderr, 'warn-line');
+  assert.ok(Number.isFinite(r.durationMs) && r.durationMs >= 0);
+});
+
+test('runCli: timeout SIGKILLs the child and reports timedOut', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'rfc61-cli-'));
+  const script = join(dir, 'hang.mjs');
+  writeFileSync(script, "console.log('started'); setTimeout(() => {}, 60_000);");
+  const started = Date.now();
+  const r = await runCli({ cliPath: script, dkgHome: dir, args: [], timeoutMs: 300 });
+  assert.equal(r.ok, false);
+  assert.equal(r.timedOut, true);
+  assert.equal(r.signal, 'SIGKILL');
+  assert.ok(Date.now() - started < 5000, 'must not wait for the child’s own exit');
+});
+
+test('runCli: output is tail-truncated to 16k chars (rfc59 commandOutput)', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'rfc61-cli-'));
+  const script = join(dir, 'big.mjs');
+  writeFileSync(script, "process.stdout.write('x'.repeat(20000) + 'TAILMARK');");
+  const r = await runCli({ cliPath: script, dkgHome: dir, args: [], timeoutMs: 10_000 });
+  assert.equal(r.ok, true);
+  assert.equal(r.stdout.length, 16_000);
+  assert.ok(r.stdout.endsWith('TAILMARK'), 'truncation must keep the TAIL');
+  // Direct helper check as well.
+  assert.equal(tailTruncate('  ab  '), 'ab');
+  assert.equal(tailTruncate('y'.repeat(17_000)).length, 16_000);
+});
+
+test('runCli: spawn failure resolves ok:false with error instead of rejecting', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'rfc61-cli-'));
+  const r = await runCli({
+    cliPath: 'whatever.mjs',
+    dkgHome: dir,
+    args: [],
+    timeoutMs: 2000,
+    execPath: join(dir, 'no-such-binary'),
+  });
+  assert.equal(r.ok, false);
+  assert.equal(r.code, null);
+  assert.ok(r.error.length > 0);
+});
+
+// ── verifyReadback (chunked VALUES SELECT + normTerm) ────────────────────────
+
+function readbackServer(behavior) {
+  const queries = [];
+  const server = createServer(async (req, res) => {
+    const url = new URL(req.url, 'http://127.0.0.1');
+    assert.equal(url.pathname, '/api/query');
+    const body = await readBody(req);
+    queries.push(body);
+    const send = (status, payload) => {
+      res.writeHead(status, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(payload));
+    };
+    const subjects = [...body.sparql.matchAll(/<([^>]+)>/g)]
+      .map((m) => m[1])
+      .filter((iri) => iri.startsWith('urn:rfc61:'));
+    const out = behavior(subjects, body);
+    if (out.status) return send(out.status, out.body ?? { error: 'boom' });
+    return send(200, { result: { bindings: out.bindings }, phases: { execute: 1, serverTotal: 1 } });
+  });
+  return { server, queries };
+}
+
+test('verifyReadback: byte-exact matches, missing + mismatch classification, chunking', async (t) => {
+  const home = makeDkgHome();
+  const items = Array.from({ length: 5 }, (_, i) =>
+    makePayload({ runId: 'rb', lane: 'public', index: i, controlFixtureEvery: 3 }));
+  const wrongSubject = items[3].subject;
+  const missingSubject = items[4].subject;
+  const { server, queries } = readbackServer((subjects) => ({
+    bindings: subjects
+      .filter((s) => s !== missingSubject)
+      .map((s) => ({
+        s,
+        o: s === wrongSubject ? '"tampered"' : items.find((it) => it.subject === s).expectedObject,
+      })),
+  }));
+  const port = await listen(server);
+  t.after(() => server.close());
+  const edge = new EdgeClient({ dkgHome: home, apiPort: port, label: 'driver', env: {} });
+
+  const result = await verifyReadback(edge, {
+    items,
+    cg: '0xADDR/cg-pub',
+    view: 'verifiable-memory',
+    chunkSize: 2,
+  });
+  assert.equal(result.matched, 3);
+  assert.deepEqual(result.mismatches, [
+    { subject: wrongSubject, kind: 'mismatch' },
+    { subject: missingSubject, kind: 'missing' },
+  ]);
+  // 5 items at chunkSize 2 → 3 VALUES queries, each carrying view + cg.
+  assert.equal(queries.length, 3);
+  for (const q of queries) {
+    assert.ok(q.sparql.startsWith('SELECT ?s ?o WHERE { VALUES ?s {'));
+    assert.ok(q.sparql.includes('<http://schema.org/name>'));
+    assert.equal(q.view, 'verifiable-memory');
+    assert.equal(q.contextGraphId, '0xADDR/cg-pub');
+  }
+  assert.ok(queries[0].sparql.includes(`<${items[0].subject}> <${items[1].subject}>`));
+});
+
+test('verifyReadback: structured SPARQL-JSON cells normalize via normTerm (control fixture incl.)', async (t) => {
+  const home = makeDkgHome();
+  const items = [
+    makePayload({ runId: 'rb2', lane: 'private', index: 0, controlFixtureEvery: 1 }), // control fixture
+    makePayload({ runId: 'rb2', lane: 'private', index: 1, controlFixtureEvery: 0 }),
+  ];
+  const { server } = readbackServer((subjects) => ({
+    bindings: subjects.map((s) => ({
+      s: { type: 'uri', value: s },
+      o: { type: 'literal', value: JSON.parse(items.find((it) => it.subject === s).expectedObject) },
+    })),
+  }));
+  const port = await listen(server);
+  t.after(() => server.close());
+  const edge = new EdgeClient({ dkgHome: home, apiPort: port, label: 'driver', env: {} });
+  const result = await verifyReadback(edge, { items, cg: 'cg', view: 'shared-working-memory' });
+  assert.equal(result.matched, 2);
+  assert.deepEqual(result.mismatches, []);
+});
+
+test('verifyReadback: a failed chunk query marks every chunk item query_error, other chunks still score', async (t) => {
+  const home = makeDkgHome();
+  const items = Array.from({ length: 4 }, (_, i) =>
+    makePayload({ runId: 'rb3', lane: 'public', index: i, controlFixtureEvery: 0 }));
+  let call = 0;
+  const { server } = readbackServer((subjects) => {
+    call++;
+    if (call === 1) return { status: 500 };
+    return { bindings: subjects.map((s) => ({ s, o: items.find((it) => it.subject === s).expectedObject })) };
+  });
+  const port = await listen(server);
+  t.after(() => server.close());
+  const edge = new EdgeClient({ dkgHome: home, apiPort: port, label: 'driver', env: {} });
+  const result = await verifyReadback(edge, { items, cg: 'cg', view: 'verifiable-memory', chunkSize: 2 });
+  assert.equal(result.matched, 2);
+  assert.deepEqual(result.mismatches, [
+    { subject: items[0].subject, kind: 'query_error' },
+    { subject: items[1].subject, kind: 'query_error' },
+  ]);
+});
+
+// Seam guard: verifyReadback's default normalizer is util.normTerm — these
+// vectors lock the semantics verifyReadback depends on (term-string
+// passthrough, lang tags, datatype rendering with xsd:string elision,
+// structured uri cells canonicalized to <iri> which unwrapIri then strips).
+test('util normTerm satisfies the verifyReadback normalization contract', () => {
+  assert.equal(normTerm('"already-a-term"'), '"already-a-term"');
+  assert.equal(normTerm({ type: 'uri', value: 'urn:x' }), '<urn:x>');
+  assert.equal(normTerm({ type: 'literal', value: 'v', 'xml:lang': 'en' }), '"v"@en');
+  assert.equal(
+    normTerm({ type: 'literal', value: '5', datatype: 'http://www.w3.org/2001/XMLSchema#integer' }),
+    '"5"^^<http://www.w3.org/2001/XMLSchema#integer>',
+  );
+  assert.equal(
+    normTerm({ type: 'literal', value: 'plain', datatype: 'http://www.w3.org/2001/XMLSchema#string' }),
+    '"plain"',
+  );
+  assert.equal(normTerm(undefined), '');
+});

--- a/testnet/test/evidence.test.mjs
+++ b/testnet/test/evidence.test.mjs
@@ -1,0 +1,210 @@
+// Hermetic tests for lib/evidence.mjs — temp dirs only, no fleet, no network.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  EvidenceWriter,
+  FAILURE_CLASSES,
+  FORBIDDEN_RECORD_KEYS,
+  SCHEMA_VERSION,
+  buildManifest,
+  makeRunId,
+} from '../lib/evidence.mjs';
+import { sha256 } from '../lib/util.mjs';
+
+function tempRunsDir(t) {
+  const dir = mkdtempSync(join(tmpdir(), 'rfc61-evidence-'));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  return dir;
+}
+
+function readJsonl(path) {
+  return readFileSync(path, 'utf8').split('\n').filter(Boolean).map((l) => JSON.parse(l));
+}
+
+// ── EvidenceWriter ───────────────────────────────────────────────────────────
+
+test('EvidenceWriter: creates runsDir recursively and round-trips JSONL', (t) => {
+  const base = tempRunsDir(t);
+  const runsDir = join(base, 'deep', 'nested', 'runs'); // does not exist yet
+  const w = new EvidenceWriter({ runId: 'certify-aaaaaaaa-20260714T190000Z', runsDir });
+  assert.equal(w.path, join(runsDir, 'certify-aaaaaaaa-20260714T190000Z.jsonl'));
+
+  w.write('run_start', { mode: 'certify', scenario: 'certify-100' });
+  w.write('op_result', { op: 'publish', lane: 'public', index: 0, outcome: 'success' });
+
+  const records = readJsonl(w.path);
+  assert.equal(records.length, 2);
+  for (const r of records) {
+    assert.equal(r.schema_version, SCHEMA_VERSION);
+    assert.equal(r.run_id, 'certify-aaaaaaaa-20260714T190000Z');
+    assert.match(r.ts, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+  }
+  assert.equal(records[0].type, 'run_start');
+  assert.equal(records[0].mode, 'certify');
+  assert.equal(records[1].type, 'op_result');
+  assert.equal(records[1].outcome, 'success');
+});
+
+test('EvidenceWriter: injected envelope fields win over record fields', (t) => {
+  const w = new EvidenceWriter({ runId: 'r1', runsDir: tempRunsDir(t) });
+  const line = w.write('real_type', {
+    type: 'spoofed', run_id: 'spoofed', schema_version: 999, ts: '1970-01-01T00:00:00Z',
+  });
+  assert.equal(line.type, 'real_type');
+  assert.equal(line.run_id, 'r1');
+  assert.equal(line.schema_version, SCHEMA_VERSION);
+  assert.notEqual(line.ts, '1970-01-01T00:00:00Z');
+  const [rec] = readJsonl(w.path);
+  assert.equal(rec.type, 'real_type');
+});
+
+test('EvidenceWriter: missing type throws; nothing is appended', (t) => {
+  const w = new EvidenceWriter({ runId: 'r1', runsDir: tempRunsDir(t) });
+  assert.throws(() => w.write('', { a: 1 }), /type required/);
+  assert.throws(() => w.write(undefined, { a: 1 }), /type required/);
+  assert.equal(existsSync(w.path), false);
+});
+
+test('EvidenceWriter: constructor validates opts', (t) => {
+  const dir = tempRunsDir(t);
+  assert.throws(() => new EvidenceWriter(), /runId required/);
+  assert.throws(() => new EvidenceWriter({ runsDir: dir }), /runId required/);
+  assert.throws(() => new EvidenceWriter({ runId: 'r1' }), /runsDir required/);
+});
+
+test('EvidenceWriter S6 hygiene: forbidden keys throw at any depth, file untouched', (t) => {
+  const w = new EvidenceWriter({ runId: 'r1', runsDir: tempRunsDir(t) });
+  assert.throws(() => w.write('fleet_snapshot', { host: 'core-1.internal' }), /forbidden key "host"/);
+  assert.throws(() => w.write('fleet_snapshot', { a: { b: { ip: '10.0.0.1' } } }), /forbidden key "a\.b\.ip"/);
+  assert.throws(() => w.write('fleet_snapshot', { cores: [{ alias: 'core-1' }, { sshUser: 'admin' }] }), /forbidden key "cores\[1\]\.sshUser"/);
+  assert.throws(() => w.write('preflight', { sshIdentity: '/home/x/.ssh/id' }), /forbidden key "sshIdentity"/);
+  assert.equal(existsSync(w.path), false); // hygiene failures never reach disk
+
+  // alias-shaped records pass — exact key match only, no false positives
+  w.write('fleet_snapshot', { alias: 'core-1', hostAlias: 'core-1', reachable: true, chip: 'm3' });
+  assert.equal(readJsonl(w.path).length, 1);
+});
+
+test('EvidenceWriter: sidecar created only on first writeSidecar, hygiene NOT enforced there', (t) => {
+  const w = new EvidenceWriter({ runId: 'r1', runsDir: tempRunsDir(t) });
+  w.write('run_start', { mode: 'monitor' });
+  assert.equal(existsSync(w.sidecarPath), false); // main writes never touch the sidecar
+
+  w.writeSidecar('journal_raw', { host: 'core-1.internal', raw: 'Jul 14 core-1 sshd[1]: ...' });
+  assert.equal(existsSync(w.sidecarPath), true);
+  const [side] = readJsonl(w.sidecarPath);
+  assert.equal(side.type, 'journal_raw');
+  assert.equal(side.host, 'core-1.internal'); // raw material allowed in local-only sidecar
+  assert.equal(side.run_id, 'r1');
+  assert.equal(side.schema_version, SCHEMA_VERSION);
+
+  // sidecar records never leak into the main stream
+  const main = readJsonl(w.path);
+  assert.equal(main.length, 1);
+  assert.equal(main[0].type, 'run_start');
+});
+
+test('FAILURE_CLASSES: frozen closed enum matching EVIDENCE.md', () => {
+  assert.ok(Object.isFrozen(FAILURE_CLASSES));
+  for (const c of ['too_low_allowance', 'publisher_wedge', 'transport_error', 'quorum_or_backoff',
+    'admission_shed', 'rpc_exhaustion', 'timeout', 'readback_mismatch', 'query_result_mismatch',
+    'propagation_timeout', 'arrived_during_gap', 'finalized_unverified', 'caught_up_unverified', 'aborted']) {
+    assert.ok(FAILURE_CLASSES.includes(c), `missing failure class: ${c}`);
+  }
+  assert.equal(FAILURE_CLASSES.length, 14); // error:<class> is composed, never listed
+  assert.deepEqual(FORBIDDEN_RECORD_KEYS, ['host', 'ip', 'sshUser', 'sshIdentity']);
+});
+
+// ── makeRunId ────────────────────────────────────────────────────────────────
+
+test('makeRunId: full form matches the EVIDENCE.md example shape', () => {
+  const now = new Date('2026-07-14T19:00:00Z');
+  assert.equal(
+    makeRunId({ phase: 'certify', sha8: '06419722', attempt: 1, now }),
+    'certify-06419722-r1-20260714T190000Z',
+  );
+  assert.equal(
+    makeRunId({ phase: 'certify', sha8: '06419722', qualifier: 'soak', attempt: 2, now }),
+    'certify-06419722-soak-r2-20260714T190000Z',
+  );
+});
+
+test('makeRunId: omits missing parts cleanly — no double dashes', () => {
+  const now = new Date('2026-07-14T19:00:00Z');
+  assert.equal(makeRunId({ phase: 'monitor', now }), 'monitor-20260714T190000Z');
+  assert.equal(makeRunId({ phase: 'certify', qualifier: 'q', now }), 'certify-q-20260714T190000Z');
+  assert.equal(makeRunId({ phase: 'certify', sha8: 'deadbeef', now }), 'certify-deadbeef-20260714T190000Z');
+  for (const id of [
+    makeRunId({ phase: 'monitor', now }),
+    makeRunId({ phase: 'certify', attempt: 3, now }),
+  ]) {
+    assert.ok(!id.includes('--'), `double dash in run id: ${id}`);
+  }
+  assert.throws(() => makeRunId({}), /phase required/);
+});
+
+// ── buildManifest ────────────────────────────────────────────────────────────
+
+test('buildManifest: binds digests, gates, notRun; defaults spend and bytes', () => {
+  const scenario = { name: 'certify-100', waves: 2 };
+  const m = buildManifest({
+    attested: { edge: { commit: 'abc123' }, cores: [{ alias: 'core-1', commit: 'abc123' }] },
+    scenario,
+    scenarioDigest: sha256(JSON.stringify(scenario)),
+    fleetDigest: 'f'.repeat(64),
+    policyDigest: 'p'.repeat(64),
+    gates: [
+      { id: 'publish.success_rate', outcome: 'PASS', observed: 1, threshold: 1 },
+      { id: 'soak.forbidden_signatures', outcome: 'NOT_RUN' },
+    ],
+    notRun: ['soak.forbidden_signatures'],
+  });
+  assert.equal(m.scenario, scenario); // verbatim
+  assert.equal(m.scenarioDigest, sha256(JSON.stringify(scenario)));
+  assert.equal(m.fleetDigest, 'f'.repeat(64));
+  assert.equal(m.policyDigest, 'p'.repeat(64));
+  assert.deepEqual(m.notRun, ['soak.forbidden_signatures']);
+  assert.deepEqual(m.spend, {});
+  assert.equal(m.permanentBytesWritten, 0);
+  assert.equal(m.gates.length, 2);
+  assert.equal(m.gates[0].id, 'publish.success_rate');
+  assert.equal(m.gates[0].outcome, 'PASS');
+});
+
+test('buildManifest: preserves explicit spend/bytes and rejects missing required fields', () => {
+  const ok = {
+    attested: {}, scenario: {}, scenarioDigest: 'd', fleetDigest: 'f', policyDigest: 'p',
+    gates: [], notRun: [],
+  };
+  const m = buildManifest({ ...ok, spend: { trac: '1.5', eth: '0.01' }, permanentBytesWritten: 4096 });
+  assert.deepEqual(m.spend, { trac: '1.5', eth: '0.01' });
+  assert.equal(m.permanentBytesWritten, 4096);
+
+  for (const missing of ['attested', 'scenario', 'scenarioDigest', 'fleetDigest', 'policyDigest']) {
+    const bad = { ...ok };
+    delete bad[missing];
+    assert.throws(() => buildManifest(bad), new RegExp(`${missing} required`));
+  }
+  assert.throws(() => buildManifest({ ...ok, gates: 'nope' }), /gates must be an array/);
+  assert.throws(() => buildManifest({ ...ok, notRun: 'nope' }), /notRun must be an array/);
+});
+
+test('buildManifest + EvidenceWriter: manifest record round-trips through the main stream', (t) => {
+  const w = new EvidenceWriter({ runId: makeRunId({ phase: 'certify', sha8: 'abcd1234' }), runsDir: tempRunsDir(t) });
+  const manifest = buildManifest({
+    attested: { cores: [{ alias: 'core-1', commit: 'abc' }] },
+    scenario: { name: 'certify-100' },
+    scenarioDigest: 'd', fleetDigest: 'f', policyDigest: 'p',
+    gates: [{ id: 'g1', outcome: 'PASS' }],
+    notRun: [],
+  });
+  w.write('run_manifest', manifest); // passes S6 hygiene: aliases + digests only
+  const records = readJsonl(w.path);
+  assert.equal(records.at(-1).type, 'run_manifest');
+  assert.equal(records.at(-1).fleetDigest, 'f');
+  assert.deepEqual(records.at(-1).gates, [{ id: 'g1', outcome: 'PASS' }]);
+});

--- a/testnet/test/fleet.test.mjs
+++ b/testnet/test/fleet.test.mjs
@@ -1,0 +1,498 @@
+// Hermetic tests for lib/fleet.mjs + ledger.json — no real SSH, no external
+// network. Fakes for transport; a local 127.0.0.1 node:http server for the
+// /api/status path; the real awk binary (local, offline) for ledger parity.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, writeFileSync, mkdtempSync } from 'node:fs';
+import { execFile } from 'node:child_process';
+import { createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  snapshotCore, snapshotFleet, attestBuildIdentity, sameArtifact,
+  captureJournalCursors, journalSignatureDeltas, loadLedger, validateLedger,
+  signatureCountsFromText, composeSignatureAwk, scrubTargetRefs,
+} from '../lib/fleet.mjs';
+
+const LEDGER_PATH = fileURLToPath(new URL('../ledger.json', import.meta.url));
+const FIXTURE_PATH = fileURLToPath(new URL('../fixtures/journal-sample.txt', import.meta.url));
+const ledger = loadLedger(LEDGER_PATH);
+const fixture = readFileSync(FIXTURE_PATH, 'utf8');
+
+const CURSOR = 's=abc123;i=1f4;b=cafe;m=1;t=2;x=3';
+
+const CORE = {
+  alias: 'core-1',
+  host: '203.0.113.7',
+  sshUser: 'observer',
+  sshIdentity: '~/.ssh/id_test',
+  systemdUnit: 'dkg-node',
+  apiPort: 9200,
+  listenPort: 9090,
+  storeFilesystem: '/',
+};
+const FLEET = { cores: [CORE], sshConcurrency: 2, sshConnectTimeoutSec: 4 };
+
+// Expected per-class counts for fixtures/journal-sample.txt. Update both the
+// fixture and this table together — the ledger's teeth are proven against it.
+const EXPECTED_COUNTS = {
+  listgraphs_timeout: 2,
+  sync_timeout: 2,
+  scheduler_saturation: 3,
+  quorum_terminal_failure: 3,
+  oom_sigkill: 3,
+  duplicate_publish: 2,
+  forced_redial: 2,
+  rpc_throttle: 2,
+  accept_queue_marker: 1,
+  ostore_scan_storm: 2,
+  store_deadline_timeout: 1,
+  probe_query_timeout: 1,
+};
+
+function expectedTotals() {
+  let gated = 0;
+  let recorded = 0;
+  for (const cls of ledger.classes) {
+    if (cls.disposition === 'gated') gated += EXPECTED_COUNTS[cls.id];
+    else recorded += EXPECTED_COUNTS[cls.id];
+  }
+  return { gated, recorded };
+}
+
+function runAwk(program, input) {
+  return new Promise((resolve, reject) => {
+    const child = execFile('awk', [program], (err, stdout, stderr) => {
+      if (err) reject(new Error(`awk failed: ${err.message}\n${stderr}`));
+      else resolve(stdout);
+    });
+    child.stdin.end(input);
+  });
+}
+
+// ── ledger.json contract ─────────────────────────────────────────────────────
+
+test('ledger.json is version 1 and carries the RFC §9.2 classes with dispositions', () => {
+  assert.equal(ledger.version, 1);
+  const byId = new Map(ledger.classes.map((c) => [c.id, c]));
+  for (const id of ['listgraphs_timeout', 'sync_timeout', 'scheduler_saturation',
+    'quorum_terminal_failure', 'oom_sigkill', 'duplicate_publish']) {
+    assert.equal(byId.get(id)?.disposition, 'gated', `${id} must be gated`);
+  }
+  for (const id of ['forced_redial', 'rpc_throttle', 'accept_queue_marker']) {
+    assert.equal(byId.get(id)?.disposition, 'recorded', `${id} must be recorded`);
+  }
+  for (const cls of ledger.classes) {
+    assert.ok(cls.description.length > 20, `${cls.id}: description must actually document the class`);
+    assert.ok(!cls.pattern.includes("'") && !cls.pattern.includes('/'),
+      `${cls.id}: pattern must survive single-quoted awk embedding`);
+    assert.doesNotThrow(() => new RegExp(cls.pattern));
+  }
+  // Every EXPECTED_COUNTS key must exist in the ledger and vice versa.
+  assert.deepEqual([...byId.keys()].sort(), Object.keys(EXPECTED_COUNTS).sort());
+});
+
+test('validateLedger rejects malformed ledgers', () => {
+  assert.throws(() => validateLedger({ version: 0, classes: [] }), /version/);
+  assert.throws(() => validateLedger({
+    version: 1,
+    classes: [{ id: 'x', disposition: 'gated', pattern: "bad'quote", description: 'a description long enough' }],
+  }), /single quotes/);
+  assert.throws(() => validateLedger({
+    version: 1,
+    classes: [{ id: 'x', disposition: 'maybe', pattern: 'ok', description: 'a description long enough' }],
+  }), /disposition/);
+  assert.throws(() => validateLedger({
+    version: 1,
+    classes: [
+      { id: 'x', disposition: 'gated', pattern: 'ok', description: 'a description long enough' },
+      { id: 'x', disposition: 'gated', pattern: 'ok', description: 'a description long enough' },
+    ],
+  }), /duplicate/);
+});
+
+test('loadLedger surfaces JSON and shape problems with the path in the message', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'ledger-test-'));
+  const bad = join(dir, 'bad.json');
+  writeFileSync(bad, '{ not json');
+  assert.throws(() => loadLedger(bad), /bad\.json/);
+  writeFileSync(bad, JSON.stringify({ version: 1, classes: [{ id: 'x' }] }));
+  assert.throws(() => loadLedger(bad), /pattern required/);
+});
+
+// ── signature counting: JS twin + awk parity ─────────────────────────────────
+
+test('signatureCountsFromText counts every fixture class exactly (and only) once per line', () => {
+  assert.deepEqual(signatureCountsFromText(fixture, ledger), EXPECTED_COUNTS);
+});
+
+test('the composed awk program produces identical counts to the JS twin (real awk)', async () => {
+  const program = composeSignatureAwk(ledger);
+  const stdout = await runAwk(program, fixture);
+  const got = {};
+  for (const line of stdout.trim().split('\n')) {
+    const [k, v] = line.split('=');
+    assert.ok(k.startsWith('sig_'), `unexpected awk output line: ${line}`);
+    got[k.slice(4)] = Number(v);
+  }
+  assert.deepEqual(got, EXPECTED_COUNTS);
+});
+
+// ── journalSignatureDeltas ───────────────────────────────────────────────────
+
+// Fake transport that actually executes the remote command's awk/grep stage
+// against the fixture, so compose -> remote-shape -> parse is covered end to end.
+function makeJournalFakeExec(journalText = fixture) {
+  const calls = [];
+  const fn = async (target, cmd, opts) => {
+    calls.push({ target, cmd, opts });
+    const awkMatch = cmd.match(/\| awk '([^]*)'; fi$/);
+    if (awkMatch) {
+      assert.ok(cmd.includes(`--after-cursor='${CURSOR}'`), 'counting pass must use the exact cursor');
+      assert.ok(cmd.includes('-o cat'), 'counting pass must read raw message text');
+      const out = await runAwk(awkMatch[1], journalText);
+      return { ok: true, code: 0, stdout: `journal_status=0\ncursor_valid=1\n${out}`, stderr: '', timedOut: false };
+    }
+    const grepMatch = cmd.match(/grep -iE '([^]*)' \| head -c 65536$/);
+    if (grepMatch) {
+      const re = new RegExp(grepMatch[1], 'i');
+      const lines = journalText.split('\n').filter((l) => l && re.test(l));
+      return { ok: true, code: 0, stdout: `${lines.join('\n')}\n`, stderr: '', timedOut: false };
+    }
+    throw new Error(`unexpected remote command: ${cmd}`);
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+test('journalSignatureDeltas counts after the exact cursor and totals by disposition', async () => {
+  const exec = makeJournalFakeExec();
+  const [res] = await journalSignatureDeltas(FLEET, [{ alias: 'core-1', cursor: CURSOR }], {
+    ledger, _sshExec: exec,
+  });
+  const totals = expectedTotals();
+  assert.equal(res.alias, 'core-1');
+  assert.equal(res.cursorValid, true);
+  assert.deepEqual(res.counts, EXPECTED_COUNTS);
+  assert.equal(res.gatedTotal, totals.gated);
+  assert.equal(res.recordedTotal, totals.recorded);
+  assert.equal(res.ledgerVersion, 1);
+  assert.equal(exec.calls.length, 1, 'no sidecar callback -> no second raw-line pass');
+});
+
+test('journalSignatureDeltas runs the capped raw-line pass ONLY for a sidecar, and keeps raw text out of counts', async () => {
+  const exec = makeJournalFakeExec();
+  const sidecarCalls = [];
+  const [res] = await journalSignatureDeltas(FLEET, [{ alias: 'core-1', cursor: CURSOR }], {
+    ledger, _sshExec: exec, sidecar: (alias, lines) => sidecarCalls.push({ alias, lines }),
+  });
+  assert.equal(exec.calls.length, 2, 'sidecar -> exactly one extra pass');
+  assert.ok(exec.calls[1].cmd.includes('head -c 65536'), 'raw-line pass must be byte-capped');
+  assert.equal(sidecarCalls.length, 1);
+  assert.equal(sidecarCalls[0].alias, 'core-1');
+  const expectedLines = fixture.split('\n').filter((l) => l && ledger.classes.some(
+    (cls) => new RegExp(cls.pattern).test(l.toLowerCase()),
+  ));
+  assert.deepEqual(sidecarCalls[0].lines, expectedLines);
+  // Raw matched text never appears in the main-stream record.
+  const serialized = JSON.stringify(res);
+  assert.ok(!serialized.includes('listGraphs query timed out'), 'raw journal text leaked into counts record');
+  assert.deepEqual(res.counts, EXPECTED_COUNTS);
+});
+
+test('journalSignatureDeltas refuses a missing or shell-unsafe cursor without touching the fleet', async () => {
+  const exec = makeJournalFakeExec();
+  const results = await journalSignatureDeltas(FLEET, [
+    { alias: 'core-1', cursor: "s=1'; rm -rf /; echo '" },
+    { alias: 'core-1', cursor: null },
+  ], { ledger, _sshExec: exec });
+  assert.equal(exec.calls.length, 0, 'invalid cursors must never reach ssh');
+  for (const res of results) {
+    assert.equal(res.cursorValid, false);
+    assert.equal(res.gatedTotal, null, 'no silent zeroes');
+    assert.equal(res.recordedTotal, null);
+    assert.equal(res.error, 'missing_or_invalid_journal_cursor');
+  }
+});
+
+test('journalSignatureDeltas maps a vacuumed cursor to cursorValid:false (never zeroes)', async () => {
+  const exec = async () => ({ ok: true, code: 0, stdout: 'journal_status=1\ncursor_valid=0\n', stderr: '', timedOut: false });
+  const [res] = await journalSignatureDeltas(FLEET, [{ alias: 'core-1', cursor: CURSOR }], { ledger, _sshExec: exec });
+  assert.equal(res.cursorValid, false);
+  assert.equal(res.gatedTotal, null);
+  assert.equal(res.error, 'cursor_vacuumed_or_invalid');
+});
+
+test('journalSignatureDeltas treats incomplete signature output as breakage, not zeroes', async () => {
+  const exec = async () => ({
+    ok: true, code: 0, timedOut: false, stderr: '',
+    stdout: 'journal_status=0\ncursor_valid=1\nsig_listgraphs_timeout=0\n', // missing the other classes
+  });
+  const [res] = await journalSignatureDeltas(FLEET, [{ alias: 'core-1', cursor: CURSOR }], { ledger, _sshExec: exec });
+  assert.equal(res.cursorValid, false);
+  assert.equal(res.error, 'signature_output_incomplete');
+  assert.equal(res.gatedTotal, null);
+});
+
+test('journalSignatureDeltas reports ssh transport failure as INCONCLUSIVE material', async () => {
+  const exec = async () => ({ ok: false, code: 255, stdout: '', stderr: 'no route', timedOut: false });
+  const [res] = await journalSignatureDeltas(FLEET, [{ alias: 'core-1', cursor: CURSOR }], { ledger, _sshExec: exec });
+  assert.equal(res.cursorValid, false);
+  assert.equal(res.error, 'ssh_failed');
+  const unknown = await journalSignatureDeltas(FLEET, [{ alias: 'core-9', cursor: CURSOR }], { ledger, _sshExec: exec });
+  assert.equal(unknown[0].error, 'unknown_alias');
+});
+
+// ── snapshotCore / snapshotFleet ─────────────────────────────────────────────
+
+const EXEC_START = 'Mon 2026-07-13 09:14:02 UTC';
+
+function snapshotStdout({ full = true } = {}) {
+  const b64 = Buffer.from(EXEC_START, 'utf8').toString('base64');
+  const lines = [
+    'active_state=active',
+    'sub_state=running',
+    'n_restarts=2',
+    `exec_main_start=b64:${b64}`,
+    'main_pid=1234',
+    'main_rss_kb=210000',
+    'worker_pid=1301',
+    'worker_rss_kb=812345',
+    'memory_current=4831838208',
+    'memory_peak=6442450944',
+    'memory_high=max',
+    'memory_max=7516192768',
+    'oom_kills=0',
+    'psi_some_avg10=0.13',
+    'listen_recvq=0',
+    'listen_backlog=511',
+    'probe_ok=1',
+    'disk_avail_bytes=52613349376',
+    'disk_used_pct=37',
+  ];
+  if (full) {
+    lines.push('store_bytes=9663676416', `journal_cursor=${CURSOR}`);
+  }
+  lines.push('snapshot_complete=1');
+  return `${lines.join('\n')}\n`;
+}
+
+const STATUS_BODY = {
+  version: '10.1.0',
+  commit: '0641972200aa',
+  buildTime: '2026-07-12T10:00:00Z',
+  admission: { rejected: 7 },
+  chain: { rpcFailovers: 2, rpcExhaustions: 1 },
+};
+
+function fakeExecOk(stdout) {
+  const fn = async (target, cmd, opts) => {
+    fn.calls.push({ target, cmd, opts });
+    return { ok: true, code: 0, stdout, stderr: '', timedOut: false };
+  };
+  fn.calls = [];
+  return fn;
+}
+
+const fakeFetchOk = async () => ({ ok: true, status: 200, json: async () => STATUS_BODY });
+
+test('snapshotCore (full) maps the k=v snapshot + /api/status into the EVIDENCE.md shape', async () => {
+  const exec = fakeExecOk(snapshotStdout());
+  const record = await snapshotCore(CORE, { _sshExec: exec, _fetch: fakeFetchOk });
+  assert.ok(exec.calls[0].cmd.includes('systemctl show dkg-node.service'));
+  assert.equal(record.alias, 'core-1');
+  assert.equal(record.reachable, true);
+  assert.equal(record.kind, 'full');
+  assert.deepEqual(record.systemd, {
+    activeState: 'active', subState: 'running', execMainStartTs: EXEC_START, nRestarts: 2, mainPid: 1234,
+  });
+  assert.equal(record.workerPid, 1301);
+  assert.deepEqual(record.build, { commit: '0641972200aa', buildTime: '2026-07-12T10:00:00Z', version: '10.1.0' });
+  assert.equal(record.rss, 812345 * 1024); // ps reports KiB; snapshot rss is bytes
+  assert.deepEqual(record.cgroup, {
+    memoryCurrent: 4831838208, memoryPeak: 6442450944, memoryHigh: null, memoryMax: 7516192768,
+    oomKills: 0, psiSomeAvg10: 0.13,
+  });
+  assert.deepEqual(record.listen, { recvQ: 0, backlog: 511, connectProbeOk: true });
+  assert.deepEqual(record.diskFree, { bytes: 52613349376, fraction: 0.63 });
+  assert.deepEqual(record.api, { reachable: true, admissionRejected: 7, rpcFailovers: 2, rpcExhaustions: 1 });
+  assert.equal(record.storeBytes, 9663676416);
+  assert.equal(record.journalCursor, CURSOR);
+});
+
+test('snapshotCore (light) omits full-only fields and asks for the light command', async () => {
+  const exec = fakeExecOk(snapshotStdout({ full: false }));
+  const record = await snapshotCore(CORE, { light: true, _sshExec: exec, _fetch: fakeFetchOk });
+  assert.equal(record.kind, 'light');
+  assert.ok(!exec.calls[0].cmd.includes('journalctl'), 'light snapshot must not touch the journal');
+  assert.ok(!('journalCursor' in record));
+  assert.ok(!('storeBytes' in record));
+});
+
+test('snapshotCore records carry ONLY the alias — no host, user, or key path (S6)', async () => {
+  const exec = fakeExecOk(snapshotStdout());
+  const record = await snapshotCore(CORE, { _sshExec: exec, _fetch: fakeFetchOk });
+  const serialized = JSON.stringify(record);
+  for (const secret of [CORE.host, CORE.sshUser, CORE.sshIdentity]) {
+    assert.ok(!serialized.includes(secret), `record leaked ${secret}`);
+  }
+});
+
+test('snapshotCore never throws: ssh transport failure -> reachable:false with scrubbed error', async () => {
+  const exec = async () => ({
+    ok: false, code: 255, stdout: '',
+    stderr: 'ssh: connect to host 203.0.113.7 port 22: No route to host (user observer, key ~/.ssh/id_test)',
+    timedOut: false,
+  });
+  const record = await snapshotCore(CORE, { _sshExec: exec, _fetch: fakeFetchOk });
+  assert.equal(record.alias, 'core-1');
+  assert.equal(record.reachable, false);
+  assert.equal(record.systemd, null);
+  const serialized = JSON.stringify(record);
+  for (const secret of [CORE.host, CORE.sshUser, CORE.sshIdentity]) {
+    assert.ok(!serialized.includes(secret), `unreachable record leaked ${secret}`);
+  }
+  assert.match(record.error, /ssh_failed/);
+});
+
+test('snapshotCore reads a real /api/status over local HTTP (default fetch path)', async () => {
+  const server = createServer((req, res) => {
+    if (req.url === '/api/status') {
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify(STATUS_BODY));
+    } else {
+      res.statusCode = 404;
+      res.end('nope');
+    }
+  });
+  await new Promise((r) => server.listen(0, '127.0.0.1', r));
+  const port = server.address().port;
+  try {
+    const core = { ...CORE, host: '127.0.0.1', apiPort: port };
+    const record = await snapshotCore(core, { light: true, _sshExec: fakeExecOk(snapshotStdout({ full: false })) });
+    assert.equal(record.reachable, true);
+    assert.equal(record.build.commit, '0641972200aa');
+    assert.equal(record.api.admissionRejected, 7);
+  } finally {
+    await new Promise((r) => server.close(r));
+  }
+});
+
+test('snapshotCore marks the core unreachable when only /api/status is down, keeping ssh fields', async () => {
+  // Grab a 127.0.0.1 port that is then closed again -> fast ECONNREFUSED.
+  const server = createServer(() => {});
+  await new Promise((r) => server.listen(0, '127.0.0.1', r));
+  const port = server.address().port;
+  await new Promise((r) => server.close(r));
+  const core = { ...CORE, host: '127.0.0.1', apiPort: port };
+  const record = await snapshotCore(core, { light: true, _sshExec: fakeExecOk(snapshotStdout({ full: false })) });
+  assert.equal(record.reachable, false);
+  assert.equal(record.api.reachable, false);
+  assert.equal(record.build, null);
+  assert.equal(record.systemd.activeState, 'active', 'ssh-side fields must survive an api outage');
+  assert.ok(!JSON.stringify(record).includes('127.0.0.1'), 'api error text leaked the host');
+});
+
+test('snapshotCore handles defensively a status body without counters', async () => {
+  const exec = fakeExecOk(snapshotStdout());
+  const fetchBare = async () => ({ ok: true, status: 200, json: async () => ({ version: '10.1.0' }) });
+  const record = await snapshotCore(CORE, { _sshExec: exec, _fetch: fetchBare });
+  assert.deepEqual(record.api, { reachable: true, admissionRejected: null, rpcFailovers: null, rpcExhaustions: null });
+  assert.equal(record.build.commit, null);
+});
+
+test('snapshotFleet snapshots every core with bounded concurrency and stamps ts/kind', async () => {
+  const fleet = {
+    cores: [CORE, { ...CORE, alias: 'core-2', host: '203.0.113.8' }],
+    sshConcurrency: 1,
+    sshConnectTimeoutSec: 4,
+  };
+  const exec = fakeExecOk(snapshotStdout({ full: false }));
+  const out = await snapshotFleet(fleet, { light: true, _sshExec: exec, _fetch: fakeFetchOk });
+  assert.equal(out.kind, 'light');
+  assert.ok(Date.parse(out.ts) > 0);
+  assert.deepEqual(out.cores.map((c) => c.alias), ['core-1', 'core-2']);
+  assert.equal(exec.calls[0].opts.connectTimeoutSec, 4, 'fleet sshConnectTimeoutSec must reach the transport');
+});
+
+// ── attestation ──────────────────────────────────────────────────────────────
+
+async function goodSnapshot() {
+  return snapshotCore(CORE, { _sshExec: fakeExecOk(snapshotStdout()), _fetch: fakeFetchOk });
+}
+
+test('attestBuildIdentity binds daemon commit to worker pid + start timestamp', async () => {
+  const att = attestBuildIdentity(await goodSnapshot());
+  assert.deepEqual(att, {
+    alias: 'core-1',
+    commit: '0641972200aa',
+    buildTime: '2026-07-12T10:00:00Z',
+    workerPid: 1301,
+    workerStartTs: EXEC_START,
+    attested: true,
+  });
+});
+
+test('attestBuildIdentity: missing/unknown/dirty commit is NOT attested (§3.1)', async () => {
+  const snap = await goodSnapshot();
+  const missing = attestBuildIdentity({ ...snap, build: { ...snap.build, commit: null } });
+  assert.equal(missing.attested, false);
+  assert.equal(missing.inconclusiveReason, 'missing_build_identity');
+  const unknown = attestBuildIdentity({ ...snap, build: { ...snap.build, commit: 'unknown' } });
+  assert.equal(unknown.inconclusiveReason, 'missing_build_identity');
+  const dirty = attestBuildIdentity({ ...snap, build: { ...snap.build, commit: '0641972200aa-dirty' } });
+  assert.equal(dirty.attested, false);
+  assert.equal(dirty.inconclusiveReason, 'dirty_build_identity');
+});
+
+test('attestBuildIdentity: unreachable core or missing process binding is inconclusive', async () => {
+  const unreachable = attestBuildIdentity({ alias: 'core-1', reachable: false });
+  assert.equal(unreachable.attested, false);
+  assert.equal(unreachable.inconclusiveReason, 'core_unreachable');
+  const snap = await goodSnapshot();
+  const noPid = attestBuildIdentity({ ...snap, workerPid: null, systemd: { ...snap.systemd, mainPid: null } });
+  assert.equal(noPid.inconclusiveReason, 'missing_process_binding');
+});
+
+test('sameArtifact detects mid-run SHA/PID/restart changes', async () => {
+  const a = attestBuildIdentity(await goodSnapshot());
+  assert.equal(sameArtifact(a, { ...a }), true);
+  assert.equal(sameArtifact(a, { ...a, commit: 'deadbeef' }), false, 'commit change');
+  assert.equal(sameArtifact(a, { ...a, workerPid: 1400 }), false, 'worker restart (pid)');
+  assert.equal(sameArtifact(a, { ...a, workerStartTs: 'Tue 2026-07-14 01:00:00 UTC' }), false, 'restart (start ts)');
+  assert.equal(sameArtifact(a, { ...a, alias: 'core-2' }), false, 'different core');
+  assert.equal(sameArtifact(a, { ...a, attested: false }), false, 'unattested never matches');
+  assert.equal(sameArtifact(null, a), false);
+});
+
+// ── journal cursors ──────────────────────────────────────────────────────────
+
+test('captureJournalCursors parses the "-- cursor:" line and validates its charset', async () => {
+  const exec = async (target, cmd) => {
+    assert.ok(cmd.includes('journalctl -u dkg-node.service -n 0 --show-cursor'));
+    return { ok: true, code: 0, stdout: `-- cursor: ${CURSOR}\n`, stderr: '', timedOut: false };
+  };
+  const [entry] = await captureJournalCursors(FLEET, { _sshExec: exec });
+  assert.deepEqual(entry, { alias: 'core-1', cursor: CURSOR, valid: true });
+});
+
+test('captureJournalCursors reports invalid on transport failure or garbage', async () => {
+  const dead = async () => ({ ok: false, code: 255, stdout: '', stderr: 'no route', timedOut: false });
+  const [entry] = await captureJournalCursors(FLEET, { _sshExec: dead });
+  assert.deepEqual(entry, { alias: 'core-1', cursor: null, valid: false });
+  const garbage = async () => ({ ok: true, code: 0, stdout: '-- cursor: bad cursor with spaces\n', stderr: '', timedOut: false });
+  const [entry2] = await captureJournalCursors(FLEET, { _sshExec: garbage });
+  assert.equal(entry2.valid, false);
+});
+
+// ── scrubbing helper ─────────────────────────────────────────────────────────
+
+test('scrubTargetRefs removes host, user, and key path from error text', () => {
+  const text = 'ssh: connect to host 203.0.113.7 port 22 as observer with ~/.ssh/id_test failed';
+  const out = scrubTargetRefs(text, CORE);
+  assert.ok(!out.includes('203.0.113.7'));
+  assert.ok(!out.includes('observer'));
+  assert.ok(!out.includes('id_test'));
+  assert.ok(out.includes('[redacted]'));
+});

--- a/testnet/test/manifest-drift.test.mjs
+++ b/testnet/test/manifest-drift.test.mjs
@@ -1,0 +1,54 @@
+// Drift-guard for the scenario manifest (scenarios.json) — port of the devnet
+// suite-manifest drift guard (_bootstrap/suite-manifest.test.ts): pure
+// filesystem/JSON, no live fleet, so it runs everywhere and catches the classic
+// failure where a scenario file is added under scenarios/ but forgotten in
+// scenarios.json (or a manifest entry goes stale) — loadScenario refuses
+// unlisted scenarios, so drift silently bricks them.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { loadPolicy, loadScenario } from '../lib/config.mjs';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const manifest = JSON.parse(readFileSync(join(ROOT, 'scenarios.json'), 'utf8'));
+
+const onDisk = readdirSync(join(ROOT, 'scenarios'), { withFileTypes: true })
+  .filter((e) => e.isFile() && e.name.endsWith('.json'))
+  .map((e) => e.name.replace(/\.json$/, ''))
+  .sort();
+
+test('scenarios.json has the manifest shape', () => {
+  assert.equal(manifest.schemaVersion, 1);
+  assert.ok(Array.isArray(manifest.scenarios) && manifest.scenarios.length > 0);
+  assert.ok(manifest.scenarios.every((s) => typeof s === 'string' && s.length > 0));
+  assert.equal(new Set(manifest.scenarios).size, manifest.scenarios.length, 'duplicate manifest entries');
+});
+
+test('manifest == on-disk scenarios (no untracked files, no stale entries)', () => {
+  const listed = [...manifest.scenarios].sort();
+  const untracked = onDisk.filter((s) => !manifest.scenarios.includes(s));
+  const stale = manifest.scenarios.filter((s) => !onDisk.includes(s));
+  assert.deepEqual(untracked, [], `scenario files on disk but MISSING from scenarios.json: ${untracked.join(', ')}`);
+  assert.deepEqual(stale, [], `scenarios.json entries with NO file under scenarios/: ${stale.join(', ')}`);
+  assert.deepEqual(listed, onDisk);
+});
+
+test('every listed scenario file is internally sound (parses; name and version match)', () => {
+  for (const name of manifest.scenarios) {
+    const sc = JSON.parse(readFileSync(join(ROOT, 'scenarios', `${name}.json`), 'utf8'));
+    assert.equal(sc.scenario, name, `${name}.json 'scenario' field must equal its basename`);
+    assert.equal(sc.schemaVersion, 1, `${name}.json schemaVersion must be 1`);
+  }
+});
+
+test('every listed scenario validates via loadScenario against the example policy (S3 tighten-only)', () => {
+  const policy = loadPolicy(join(ROOT, 'policy.example.json'));
+  for (const name of manifest.scenarios) {
+    const { scenario, digest } = loadScenario(name, { policy, baseDir: ROOT });
+    assert.equal(scenario.scenario, name);
+    assert.match(digest, /^[0-9a-f]{64}$/);
+  }
+});

--- a/testnet/test/scenario.test.mjs
+++ b/testnet/test/scenario.test.mjs
@@ -88,9 +88,12 @@ function makeFakeEdge({ recover = new Set(), hardFail = new Set(), phaseDelayMs 
   let jobSeq = 0;
   const jobs = new Map();
   const opKey = (name) => name.slice(name.indexOf(RUN_ID) + RUN_ID.length + 1); // "<lane>-<index>"
+  const cgSeen = new Set();
   return {
+    cgSeen, // ACTUAL cg ids the API layer received (reuse:-resolution teeth)
     async status() { return { commit: 'deadbeefcafe0123', name: 'driver-fake' }; },
     async createKnowledgeAsset(p) {
+      cgSeen.add(p.cg);
       if (phaseDelayMs) await sleep(phaseDelayMs);
       return { ok: true, name: p.name };
     },
@@ -213,7 +216,9 @@ const policyFixture = () => ({
 function baseRunParams(overrides = {}) {
   return {
     scenario: scenarioFixture(),
-    fleet: { cores: [{ alias: 'core-1' }] },
+    // reuse: specs resolve through fleet.cgs — evidence must carry the LOGICAL
+    // names (pub/priv); API calls must receive the ACTUAL ids (cg-*-actual).
+    fleet: { cores: [{ alias: 'core-1' }], cgs: { pub: 'cg-pub-actual', priv: 'cg-priv-actual' } },
     policy: policyFixture(),
     evidence: new FakeEvidence(),
     runId: RUN_ID,
@@ -273,6 +278,11 @@ test('healthy run: op_results, recovery re-scoring, readbacks, PASS verdict', as
   // Unique UALs across the run.
   assert.equal(new Set(run.opResults.map((o) => o.ual)).size, 12);
 
+  // reuse: CG resolution split (S6): the API layer received the ACTUAL ids from
+  // fleet.cgs, while every evidence record carries only the LOGICAL names.
+  assert.deepEqual([...edge.cgSeen].sort(), ['cg-priv-actual', 'cg-pub-actual']);
+  assert.ok(run.opResults.every((o) => o.cg === 'pub' || o.cg === 'priv'));
+
   // Per-wave, per-lane byte-exact readback.
   assert.equal(run.readbacks.length, 4);
   assert.ok(run.readbacks.every((rb) => rb.expected === 3 && rb.matched === 3
@@ -326,7 +336,7 @@ test('healthy run: op_results, recovery re-scoring, readbacks, PASS verdict', as
   });
   for (const id of ['success_rate_overall', 'success_rate_public', 'success_rate_private',
     'publish_p95_ms', 'control_fixtures', 'unique_uals', 'readback_mismatches']) {
-    assert.equal(changed.find((g) => g.id === id).inconclusiveReason, 'fleet-sha-changed', id);
+    assert.equal(changed.find((g) => g.id === id).inconclusiveReason, 'fleet-artifact-changed', id);
   }
   assert.equal(changed.find((g) => g.id === 'fleet_core_restarts').inconclusiveReason, undefined);
   const changedVerdict = localComputeVerdict({ gates: changed.map(localEvaluateGate), safetyAbort: false });

--- a/testnet/test/scenario.test.mjs
+++ b/testnet/test/scenario.test.mjs
@@ -1,0 +1,551 @@
+// Hermetic tests for lib/scenario.mjs + bin/harness.mjs parseArgs.
+// No SSH, no network, no real fleet: fake EdgeClient, injected fakes for every
+// cross-module seam (the sibling modules are contract stubs written
+// concurrently), and contract-faithful local evaluateGate/computeVerdict
+// (scoring.mjs's frozen contract) to fold buildGates output into a verdict.
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  parseArgs, UsageError, formatMonitorTable, sanitizeArgv,
+} from '../bin/harness.mjs';
+import {
+  buildGates, mergePeak, pollVmFinalized, runPublishScenario,
+} from '../lib/scenario.mjs';
+import { sleep } from '../lib/util.mjs';
+
+// ── contract-faithful local scoring (scoring.mjs frozen contract) ──────────
+
+function localPercentile(values, p) {
+  const sorted = values.filter(Number.isFinite).slice().sort((a, b) => a - b);
+  if (sorted.length === 0) return null;
+  return sorted[Math.max(0, Math.ceil((p / 100) * sorted.length) - 1)];
+}
+
+function localEvaluateGate(gate) {
+  const result = { id: gate.id, observed: gate.observed, threshold: gate.threshold };
+  if (gate.inconclusiveReason) return { ...result, outcome: 'INCONCLUSIVE' };
+  if ((gate.kind === 'percentile' || gate.kind === 'successRate')
+      && gate.minSamples != null && (gate.samples ?? 0) < gate.minSamples) {
+    return { ...result, outcome: 'INCONCLUSIVE' };
+  }
+  if (gate.kind === 'percentile'
+      && gate.minSuccessRate != null && (gate.successRate ?? 0) < gate.minSuccessRate) {
+    return { ...result, outcome: 'INCONCLUSIVE' };
+  }
+  let pass;
+  switch (gate.kind) {
+    case 'successRate': pass = gate.observed >= gate.threshold; break;
+    case 'percentile':
+    case 'max': pass = gate.observed != null && gate.observed <= gate.threshold; break;
+    case 'exactZero': pass = gate.observed === 0; break;
+    case 'bool': pass = gate.observed === true; break;
+    default: throw new Error(`unknown gate kind: ${gate.kind}`);
+  }
+  return { ...result, outcome: pass ? 'PASS' : 'FAIL' };
+}
+
+function localComputeVerdict({ gates, safetyAbort }) {
+  if (safetyAbort) return { outcome: 'SAFETY_ABORT', gates };
+  if (gates.some((g) => g.outcome === 'FAIL')) return { outcome: 'FAIL', gates };
+  if (gates.some((g) => g.outcome === 'INCONCLUSIVE')) return { outcome: 'INCONCLUSIVE', gates };
+  return { outcome: 'PASS', gates };
+}
+
+// ── fakes ───────────────────────────────────────────────────────────────────
+
+class FakeEvidence {
+  constructor() {
+    this.records = [];
+    this.sidecarRecords = [];
+  }
+
+  write(type, record) {
+    for (const key of ['host', 'ip', 'sshUser']) {
+      if (record && Object.hasOwn(record, key)) throw new Error(`hygiene: forbidden key ${key}`);
+    }
+    this.records.push({ type, ...record });
+  }
+
+  writeSidecar(type, record) {
+    this.sidecarRecords.push({ type, ...record });
+  }
+
+  ofType(type) {
+    return this.records.filter((r) => r.type === type);
+  }
+
+  get path() { return '/dev/null'; }
+}
+
+const RUN_ID = 'certify-testfake-20260714T000000Z';
+
+// Fake EdgeClient: in-memory job progression. `recover` op keys throw a
+// client-side timeout from waitPublishJob but the authoritative KA state is
+// VM (the §6 recovery case); `hardFail` keys fail terminally and stay at SWM.
+function makeFakeEdge({ recover = new Set(), hardFail = new Set(), phaseDelayMs = 0 } = {}) {
+  let jobSeq = 0;
+  const jobs = new Map();
+  const opKey = (name) => name.slice(name.indexOf(RUN_ID) + RUN_ID.length + 1); // "<lane>-<index>"
+  return {
+    async status() { return { commit: 'deadbeefcafe0123', name: 'driver-fake' }; },
+    async createKnowledgeAsset(p) {
+      if (phaseDelayMs) await sleep(phaseDelayMs);
+      return { ok: true, name: p.name };
+    },
+    async shareAsync(p) {
+      const jobId = `share-${jobSeq++}`;
+      jobs.set(jobId, p);
+      return { jobId };
+    },
+    async waitShareJob() {
+      if (phaseDelayMs) await sleep(phaseDelayMs);
+      return { status: 'succeeded' };
+    },
+    async publishAsync(p) {
+      const jobId = `pub-${jobSeq++}`;
+      jobs.set(jobId, p);
+      return { jobId };
+    },
+    async waitPublishJob({ jobId }) {
+      if (phaseDelayMs) await sleep(phaseDelayMs);
+      const key = opKey(jobs.get(jobId).name);
+      if (recover.has(key)) throw new Error('client poll timed out');
+      if (hardFail.has(key)) return { status: 'failed', error: 'quorum exhausted: no ack quorum' };
+      return { status: 'confirmed', ual: `did:dkg:base:84532/0xstub/${key}`, txHash: `0x${key}` };
+    },
+    async knowledgeAssetState({ name }) {
+      const key = opKey(name);
+      if (hardFail.has(key)) return { memoryLayer: 'SWM', status: 'swm-shared' };
+      return {
+        memoryLayer: 'VM',
+        publishedUal: `did:dkg:base:84532/0xstub/${key}`,
+        txHash: `0x${key}`,
+      };
+    },
+  };
+}
+
+const fakeMakePayload = ({ runId, lane, index, controlFixtureEvery }) => ({
+  quads: `<urn:rfc61:${lane}:${runId}:${index}> <http://schema.org/name> "v${index}" .`,
+  subject: `urn:rfc61:${lane}:${runId}:${index}`,
+  expectedObject: `"v${index}"`,
+  controlFixture: index % controlFixtureEvery === 0,
+});
+
+const fakeVerifyReadback = async (edge, { items }) => ({ matched: items.length, mismatches: [] });
+
+const fakeClassify = (e) => {
+  const text = String(e?.jobError || e?.stderr || e?.stdout || '').toLowerCase();
+  if (text.includes('quorum')) return 'quorum_or_backoff';
+  if (text.includes('tim')) return 'timeout';
+  throw new Error(`unclassified: ${text}`);
+};
+
+function coreEntry(overrides = {}) {
+  return {
+    alias: 'core-1',
+    reachable: true,
+    systemd: { activeState: 'active', execMainStartTs: 't0', nRestarts: 0, mainPid: 11 },
+    workerPid: 100,
+    build: { commit: 'aaaa1111', buildTime: 'b0' },
+    rss: 1_000_000,
+    cgroup: {
+      memoryCurrent: 100, memoryPeak: 150, memoryHigh: 1000, memoryMax: 2000,
+      oomKills: 0, psiSomeAvg10: 0,
+    },
+    listen: { recvQ: 0, backlog: 128, connectProbeOk: true },
+    diskFree: { bytes: 100e9, fraction: 0.5 },
+    api: { admissionRejected: 0, rpcFailovers: 0, rpcExhaustions: 0 },
+    ...overrides,
+  };
+}
+
+const fakeSnapshotFleet = async (fleet, opts) => ({
+  ts: new Date().toISOString(),
+  kind: opts?.light ? 'light' : 'full',
+  cores: [coreEntry()],
+});
+
+const fakeJournalDeltas = async (fleet, cursors) => cursors.map((c) => ({
+  alias: c.alias, cursorValid: true, counts: {}, gatedTotal: 0, recordedTotal: 0,
+}));
+
+const sameArtifact = (a, b) => a.commit === b.commit
+  && a.workerPid === b.workerPid && a.workerStartTs === b.workerStartTs;
+
+const baselineFixture = () => ({
+  snapshot: { ts: 't', kind: 'full', cores: [coreEntry()] },
+  cursors: [{ alias: 'core-1', cursor: 'c1', valid: true }],
+  attested: [{
+    alias: 'core-1', commit: 'aaaa1111', buildTime: 'b0',
+    workerPid: 100, workerStartTs: 't0', attested: true,
+  }],
+});
+
+const scenarioFixture = (overrides = {}) => ({
+  scenario: 'test-certify',
+  lanes: ['public', 'private'],
+  cg: { public: 'reuse:pub', private: 'reuse:priv' },
+  workload: {
+    op: 'publish', waves: 2, perWave: { public: 3, private: 3 },
+    controlFixtureEvery: 10, concurrency: 2, arrival: 'closed-loop',
+  },
+  readback: { where: 'driver', byteExact: true, chunkSize: 25 },
+  soakSeconds: 0,
+  gates: {
+    successRate: { overall: 0.95, perLane: 0.9, minSamples: { overall: 10, perLane: 5 } },
+    publishP95Ms: 60000,
+    controlFixtures: { mustFinalize: true, mustReadBack: true },
+    uniqueUals: true,
+    fleet: { coreRestarts: 0, oomKillDelta: 0, gatedSignatures: 0, memoryPeakFraction: 0.9 },
+  },
+  ...overrides,
+});
+
+const policyFixture = () => ({
+  trips: { admissionShedWindowSec: { default: 60 } },
+  quiesce: { flatCounterConfirmSec: 0, edgeShutdownTimeoutSec: 1 },
+  safetyAbort: { cooldownMin: 60 },
+});
+
+function baseRunParams(overrides = {}) {
+  return {
+    scenario: scenarioFixture(),
+    fleet: { cores: [{ alias: 'core-1' }] },
+    policy: policyFixture(),
+    evidence: new FakeEvidence(),
+    runId: RUN_ID,
+    baseline: baselineFixture(),
+    snapshotIntervalMs: 5,
+    pollIntervalMs: 5,
+    opTimeoutMs: 2000,
+    _snapshotFleet: fakeSnapshotFleet,
+    _journalSignatureDeltas: fakeJournalDeltas,
+    _evaluateTrips: () => [],
+    _quiesce: async () => ({ cancelled: 0, edgeShutdown: false, flatConfirmed: true }),
+    _makePayload: fakeMakePayload,
+    _verifyReadback: fakeVerifyReadback,
+    _classifyFailure: fakeClassify,
+    _sameArtifact: sameArtifact,
+    ...overrides,
+  };
+}
+
+// ── runPublishScenario: healthy end-to-end ──────────────────────────────────
+
+test('healthy run: op_results, recovery re-scoring, readbacks, PASS verdict', async () => {
+  const evidence = new FakeEvidence();
+  const edge = makeFakeEdge({ recover: new Set(['public-1']), phaseDelayMs: 3 });
+  const tripCalls = [];
+  const params = baseRunParams({
+    evidence,
+    edge,
+    _evaluateTrips: (args) => { tripCalls.push(args); return []; },
+  });
+  const run = await runPublishScenario(params);
+
+  // 2 waves x (3 public + 3 private) = 12 ops, all successful.
+  assert.equal(run.opResults.length, 12);
+  assert.ok(run.opResults.every((o) => o.outcome === 'success'));
+  assert.equal(run.safetyAborted, false);
+  assert.deepEqual(run.trips, []);
+  assert.equal(run.partial, false);
+
+  // The client-timeout op recovered via authoritative KA state (§6).
+  const recovered = run.opResults.find((o) => o.lane === 'public' && o.index === 1);
+  assert.equal(recovered.recovered_after_client_error, true);
+  assert.equal(recovered.outcome, 'success');
+  assert.match(recovered.ual, /^did:dkg:/);
+  const others = run.opResults.filter((o) => !(o.lane === 'public' && o.index === 1));
+  assert.ok(others.every((o) => o.recovered_after_client_error === false));
+
+  // Per-phase durations + polled-anchor metadata on every op_result.
+  for (const o of run.opResults) {
+    for (const phase of ['create', 'share', 'publish', 'vm_finalization']) {
+      assert.ok(Number.isFinite(o.durations_ms[phase]) && o.durations_ms[phase] >= 0,
+        `${o.lane}#${o.index} missing duration ${phase}`);
+    }
+    assert.equal(o.anchor_meta.poll_interval_ms, 5);
+    assert.ok(o.ual);
+  }
+  // Unique UALs across the run.
+  assert.equal(new Set(run.opResults.map((o) => o.ual)).size, 12);
+
+  // Per-wave, per-lane byte-exact readback.
+  assert.equal(run.readbacks.length, 4);
+  assert.ok(run.readbacks.every((rb) => rb.expected === 3 && rb.matched === 3
+    && rb.mismatches.length === 0 && rb.byteExact === true));
+
+  // Evidence stream contents.
+  assert.equal(evidence.ofType('op_result').length, 12);
+  assert.equal(evidence.ofType('readback_result').length, 4);
+  assert.equal(evidence.ofType('journal_signature_deltas').length, 1);
+  assert.ok(evidence.ofType('fleet_snapshot').length >= 1);
+  assert.ok(evidence.ofType('host_telemetry').length >= 1, 'snapshot loop emitted host telemetry');
+  assert.equal(evidence.ofType('safety_abort').length, 0);
+  assert.equal(evidence.ofType('soak_start').length, 0); // soakSeconds 0 => skipped
+
+  // Trip evaluation received the documented inputs.
+  assert.ok(tripCalls.length >= 1);
+  assert.equal(tripCalls[0].edgeWindow.windowSec, 60);
+  assert.ok(tripCalls[0].snapshot.cores.length === 1);
+  assert.ok(Array.isArray(tripCalls[0].snapshotHistory));
+
+  // Final full snapshot + peak keyed by alias.
+  assert.equal(run.finalSnapshot.kind, 'full');
+  assert.equal(run.peak['core-1'].alias, 'core-1');
+  assert.ok(run.peak['core-1'].maxRss > 0);
+  assert.equal(run.peak['core-1'].restartDetected, false);
+  assert.equal(run.signatureDeltas.length, 1);
+  assert.equal(run.signatureDeltas[0].cursorValid, true);
+
+  // buildGates → evaluateGate → computeVerdict folds to PASS.
+  const inputs = buildGates({
+    scenario: params.scenario, run, baseline: params.baseline,
+    _percentile: localPercentile, _sameArtifact: sameArtifact,
+  });
+  const ids = inputs.map((g) => g.id);
+  for (const id of ['success_rate_overall', 'success_rate_public', 'success_rate_private',
+    'publish_p95_ms', 'control_fixtures', 'unique_uals', 'readback_mismatches',
+    'fleet_core_restarts', 'fleet_oom_kill_delta', 'fleet_gated_signatures',
+    'fleet_memory_peak_fraction']) {
+    assert.ok(ids.includes(id), `missing gate ${id}`);
+  }
+  const verdict = localComputeVerdict({
+    gates: inputs.map(localEvaluateGate),
+    safetyAbort: run.safetyAborted,
+  });
+  assert.equal(verdict.outcome, 'PASS');
+
+  // Mid-run SHA change: network-dependent gates become INCONCLUSIVE.
+  const changed = buildGates({
+    scenario: params.scenario, run, baseline: params.baseline,
+    _percentile: localPercentile, _sameArtifact: () => false,
+  });
+  for (const id of ['success_rate_overall', 'success_rate_public', 'success_rate_private',
+    'publish_p95_ms', 'control_fixtures', 'unique_uals', 'readback_mismatches']) {
+    assert.equal(changed.find((g) => g.id === id).inconclusiveReason, 'fleet-sha-changed', id);
+  }
+  assert.equal(changed.find((g) => g.id === 'fleet_core_restarts').inconclusiveReason, undefined);
+  const changedVerdict = localComputeVerdict({ gates: changed.map(localEvaluateGate), safetyAbort: false });
+  assert.equal(changedVerdict.outcome, 'INCONCLUSIVE');
+});
+
+// ── runPublishScenario: hard failure ────────────────────────────────────────
+
+test('hard failure: terminal job failure classified, not recovered, gates FAIL', async () => {
+  const evidence = new FakeEvidence();
+  const edge = makeFakeEdge({ hardFail: new Set(['public-1']) });
+  const scenario = scenarioFixture({
+    workload: {
+      op: 'publish', waves: 1, perWave: { public: 2, private: 2 },
+      controlFixtureEvery: 10, concurrency: 2,
+    },
+    gates: {
+      successRate: { overall: 0.95, perLane: 0.9, minSamples: { overall: 4, perLane: 2 } },
+      publishP95Ms: 60000,
+      uniqueUals: true,
+      fleet: { coreRestarts: 0, oomKillDelta: 0, gatedSignatures: 0, memoryPeakFraction: 0.9 },
+    },
+  });
+  const params = baseRunParams({ evidence, edge, scenario });
+  const run = await runPublishScenario(params);
+
+  assert.equal(run.opResults.length, 4);
+  const failed = run.opResults.find((o) => o.lane === 'public' && o.index === 1);
+  assert.equal(failed.outcome, 'quorum_or_backoff');
+  assert.equal(failed.recovered_after_client_error, false);
+  assert.equal(failed.ual, null);
+  assert.equal(run.opResults.filter((o) => o.outcome === 'success').length, 3);
+
+  // Readback only covers successes: public wave expected 1, private expected 2.
+  const publicRb = run.readbacks.find((rb) => rb.lane === 'public');
+  assert.equal(publicRb.expected, 1);
+
+  const inputs = buildGates({
+    scenario, run, baseline: params.baseline,
+    _percentile: localPercentile, _sameArtifact: sameArtifact,
+  });
+  const verdict = localComputeVerdict({ gates: inputs.map(localEvaluateGate), safetyAbort: false });
+  assert.equal(verdict.outcome, 'FAIL'); // 3/4 = 0.75 < 0.95
+  assert.equal(inputs.find((g) => g.id === 'success_rate_overall').observed, 0.75);
+});
+
+// ── runPublishScenario: S3 trip fires ───────────────────────────────────────
+
+test('trip fires: quiesce runs, safety_abort recorded, partial aborted results', async () => {
+  const evidence = new FakeEvidence();
+  const edge = makeFakeEdge({ phaseDelayMs: 60 });
+  const firedTrip = {
+    trip: 'memoryCurrentVsHighFraction', alias: 'core-1', observed: 0.99, threshold: 0.95,
+  };
+  let tripCalls = 0;
+  let quiesceArgs = null;
+  const scenario = scenarioFixture({
+    workload: {
+      op: 'publish', waves: 1, perWave: { public: 2, private: 2 },
+      controlFixtureEvery: 10, concurrency: 1,
+    },
+    soakSeconds: 600, // must be skipped on abort — the test would hang otherwise
+  });
+  const params = baseRunParams({
+    evidence,
+    edge,
+    scenario,
+    snapshotIntervalMs: 5,
+    _evaluateTrips: () => (++tripCalls === 1 ? [firedTrip] : []),
+    _quiesce: async (q) => {
+      quiesceArgs = q;
+      for (const handle of q.inflight) await handle.cancel();
+      return { cancelled: q.inflight.length, edgeShutdown: false, flatConfirmed: true };
+    },
+  });
+  const run = await runPublishScenario(params);
+
+  assert.equal(run.safetyAborted, true);
+  assert.equal(run.partial, true);
+  assert.equal(run.trips.length, 1);
+  assert.equal(run.trips[0].trip, 'memoryCurrentVsHighFraction');
+
+  // Quiesce saw the in-flight handles, the local edge, and the policy.
+  assert.ok(quiesceArgs, 'quiesce was invoked');
+  assert.equal(quiesceArgs.edges[0], edge);
+  assert.equal(quiesceArgs.policy, params.policy);
+  assert.ok(quiesceArgs.inflight.length >= 1);
+  assert.equal(typeof quiesceArgs.confirmFlat, 'function');
+
+  // One op per lane was in flight; both settle as harness-quiesce 'aborted'.
+  assert.equal(run.opResults.length, 2);
+  assert.ok(run.opResults.every((o) => o.outcome === 'aborted'));
+
+  const abortRecords = evidence.ofType('safety_abort');
+  assert.equal(abortRecords.length, 1);
+  assert.equal(abortRecords[0].trip, 'memoryCurrentVsHighFraction');
+  assert.deepEqual(abortRecords[0].quiesce, { cancelled: 2, edgeShutdown: false, flatConfirmed: true });
+  assert.equal(evidence.ofType('soak_start').length, 0);
+  assert.equal(evidence.ofType('readback_result').length, 0);
+
+  // Final snapshot + deltas still bind the partial evidence.
+  assert.equal(run.finalSnapshot.kind, 'full');
+  assert.equal(run.signatureDeltas.length, 1);
+
+  // SAFETY_ABORT is terminal regardless of gate outcomes.
+  const inputs = buildGates({
+    scenario, run, baseline: params.baseline,
+    _percentile: localPercentile, _sameArtifact: sameArtifact,
+  });
+  const verdict = localComputeVerdict({
+    gates: inputs.map(localEvaluateGate),
+    safetyAbort: run.safetyAborted,
+  });
+  assert.equal(verdict.outcome, 'SAFETY_ABORT');
+});
+
+// ── pollVmFinalized ─────────────────────────────────────────────────────────
+
+test('pollVmFinalized: VM state resolves; deadline yields vm_poll_timeout', async () => {
+  const vmEdge = {
+    async knowledgeAssetState() {
+      return { memoryLayer: 'VM', publishedUal: 'did:dkg:x/1', txHash: '0xa' };
+    },
+  };
+  const done = await pollVmFinalized(vmEdge, { name: 'n', cg: 'c', deadlineMs: Date.now() });
+  assert.deepEqual(done, { finalized: true, ual: 'did:dkg:x/1', reservedUal: null, tx: '0xa' });
+
+  const stuckEdge = { async knowledgeAssetState() { return { memoryLayer: 'SWM' }; } };
+  const stuck = await pollVmFinalized(stuckEdge, {
+    name: 'n', cg: 'c', deadlineMs: Date.now() + 20, intervalMs: 5,
+  });
+  assert.deepEqual(stuck, { finalized: false, reason: 'vm_poll_timeout' });
+});
+
+// ── mergePeak ───────────────────────────────────────────────────────────────
+
+test('mergePeak: peaks, sticky unreachability, attestation restart detection', () => {
+  const attested = baselineFixture().attested;
+  // null peak → created.
+  let peak = mergePeak(null, { cores: [coreEntry()] }, attested, { _sameArtifact: sameArtifact });
+  assert.equal(peak['core-1'].maxRss, 1_000_000);
+  assert.equal(peak['core-1'].restartDetected, false);
+  assert.equal(peak['core-1'].maxMemoryCurrentFraction, 0.1); // 100 / high 1000
+
+  // Unreachable is sticky, but later measurements still merge.
+  peak = mergePeak(peak, { cores: [{ alias: 'core-1', reachable: false, error: 'ssh timeout' }] },
+    attested, { _sameArtifact: sameArtifact });
+  assert.equal(peak['core-1'].reachable, false);
+  assert.equal(peak['core-1'].lastError, 'ssh timeout');
+  peak = mergePeak(peak, {
+    cores: [coreEntry({ rss: 2_000_000, cgroup: { memoryCurrent: 900, memoryHigh: 1000, oomKills: 1 } })],
+  }, attested, { _sameArtifact: sameArtifact });
+  assert.equal(peak['core-1'].reachable, false, 'unreachability stays sticky');
+  assert.equal(peak['core-1'].maxRss, 2_000_000);
+  assert.equal(peak['core-1'].maxMemoryCurrentFraction, 0.9);
+  assert.equal(peak['core-1'].maxOomKills, 1);
+
+  // A worker pid change vs the baseline attestation flags a restart.
+  peak = mergePeak(peak, { cores: [coreEntry({ workerPid: 999 })] }, attested,
+    { _sameArtifact: sameArtifact });
+  assert.equal(peak['core-1'].restartDetected, true);
+});
+
+// ── bin/harness.mjs: parseArgs + helpers ────────────────────────────────────
+
+test('parseArgs: modes, defaults, flags', () => {
+  const monitor = parseArgs(['monitor', '--once']);
+  assert.equal(monitor.mode, 'monitor');
+  assert.equal(monitor.once, true);
+  assert.equal(monitor.intervalSec, 10);
+  assert.equal(monitor.scenario, 'certify-100');
+  assert.ok(monitor.fleet.endsWith('/fleet.json'));
+  assert.ok(monitor.policy.endsWith('/policy.json'));
+  assert.ok(monitor.runsDir.endsWith('/runs'));
+  assert.equal(monitor.runId, null);
+  assert.equal(monitor.autonomous, false);
+  assert.equal(monitor.json, false);
+
+  const certify = parseArgs([
+    'certify', '--scenario', 'certify-100', '--run-id', 'r1', '--interval', '5',
+    '--json', '--autonomous', '--fleet', '/tmp/f.json', '--policy', '/tmp/p.json',
+    '--runs-dir', '/tmp/runs',
+  ]);
+  assert.equal(certify.mode, 'certify');
+  assert.equal(certify.scenario, 'certify-100');
+  assert.equal(certify.runId, 'r1');
+  assert.equal(certify.intervalSec, 5);
+  assert.equal(certify.json, true);
+  assert.equal(certify.autonomous, true);
+  assert.equal(certify.fleet, '/tmp/f.json');
+  assert.equal(certify.policy, '/tmp/p.json');
+  assert.equal(certify.runsDir, '/tmp/runs');
+});
+
+test('parseArgs: usage errors carry exitCode 4', () => {
+  for (const argv of [[], ['bogus'], ['monitor', '--nope'], ['monitor', '--interval'],
+    ['monitor', '--interval', 'zero'], ['monitor', '--interval', '-3'],
+    ['monitor', 'baseline'], ['monitor', '--fleet', '--once']]) {
+    assert.throws(() => parseArgs(argv), (e) => e instanceof UsageError && e.exitCode === 4,
+      JSON.stringify(argv));
+  }
+});
+
+test('formatMonitorTable: aliases only, unreachable rows degrade per-core', () => {
+  const table = formatMonitorTable({
+    cores: [
+      coreEntry(),
+      { alias: 'core-2', reachable: false, error: 'ssh: connect timeout host 10.0.0.9' },
+    ],
+  });
+  assert.match(table, /alias\s+state\s+commit\s+rss\s+mem%\s+recvq\s+disk\s+restarts/);
+  assert.match(table, /core-1\s+active\s+aaaa1111\s+1M\s+10%/);
+  assert.match(table, /core-2\s+UNREACHABLE/);
+  assert.ok(!table.includes('10.0.0.9'), 'raw error text (may carry hosts) never printed');
+});
+
+test('sanitizeArgv: path flag values are redacted', () => {
+  assert.deepEqual(
+    sanitizeArgv(['certify', '--fleet', '/Users/op/fleet.json', '--json', '--policy', '/tmp/p.json']),
+    ['certify', '--fleet', '<path>', '--json', '--policy', '<path>'],
+  );
+});

--- a/testnet/test/scoring.test.mjs
+++ b/testnet/test/scoring.test.mjs
@@ -1,0 +1,265 @@
+// Hermetic tests for lib/scoring.mjs — no network, no fleet, no child processes.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  OUTCOMES, GATE_KINDS,
+  classifyFailure, aggregate, evaluateGate, computeVerdict, formatVerdict,
+} from '../lib/scoring.mjs';
+import { FAILURE_CLASSES } from '../lib/evidence.mjs';
+
+// util.percentile is a concurrent module; inject a local nearest-rank
+// implementation matching its frozen contract (p in (0,100], empty -> null).
+const nearestRank = (values, p) => {
+  const s = values.filter(Number.isFinite).slice().sort((a, b) => a - b);
+  if (s.length === 0) return null;
+  return s[Math.max(0, Math.ceil((p / 100) * s.length) - 1)];
+};
+
+// ── classifyFailure ──────────────────────────────────────────────────────────
+
+test('classifyFailure ports the rfc59 patterns to the closed enum', () => {
+  assert.equal(classifyFailure({ stdout: 'Error: TooLowAllowance(0x123)' }), 'too_low_allowance');
+  assert.equal(classifyFailure({ stderr: 'wallet is locked by another publish' }), 'publisher_wedge');
+  assert.equal(classifyFailure({ stdout: 'failed to negotiate security protocol' }), 'transport_error');
+  assert.equal(classifyFailure({ stdout: 'stream has been reset' }), 'transport_error');
+  assert.equal(classifyFailure({ stderr: 'read ECONNRESET' }), 'transport_error');
+  assert.equal(classifyFailure({ stdout: 'ACK quorum not met after 3 rounds' }), 'quorum_or_backoff');
+  assert.equal(classifyFailure({ stdout: 'peer TEMPORARILY_UNAVAILABLE, backoff scheduled' }), 'quorum_or_backoff');
+  assert.equal(classifyFailure({ stderr: 'client timed out after 30000ms' }), 'timeout');
+  assert.equal(classifyFailure({ jobError: 'job deadline exceeded' }), 'timeout');
+});
+
+test('classifyFailure extends the enum: shed, rpc exhaustion, readback, aborted', () => {
+  assert.equal(classifyFailure({ httpStatus: 503 }), 'admission_shed');
+  assert.equal(classifyFailure({ stdout: 'request shed by admission control' }), 'admission_shed');
+  assert.equal(classifyFailure({ stderr: 'HTTP 503 Service Unavailable' }), 'admission_shed');
+  assert.equal(classifyFailure({ stderr: 'RPC providers exhausted after failover' }), 'rpc_exhaustion');
+  assert.equal(classifyFailure({ stdout: 'readback mismatch on subject 12' }), 'readback_mismatch');
+  assert.equal(classifyFailure({ stderr: 'AbortError: The operation was aborted' }), 'aborted');
+});
+
+test('classifyFailure passes exact enum tokens and error:<class> through', () => {
+  for (const cls of FAILURE_CLASSES) {
+    assert.equal(classifyFailure({ jobError: cls }), cls);
+  }
+  assert.equal(classifyFailure({ jobError: ' propagation_timeout ' }), 'propagation_timeout');
+  assert.equal(classifyFailure({ jobError: 'error:HttpError' }), 'error:httperror');
+});
+
+test('classifyFailure never matches shed inside established/published words', () => {
+  // "established"/"published" contain the substring "shed" — must NOT classify.
+  assert.throws(() => classifyFailure({ stdout: 'connection established with peer' }), /unclassifiable/);
+  assert.throws(() => classifyFailure({ stdout: 'entity was garbled-published mystery state' }), /unclassifiable/);
+});
+
+test('classifyFailure throws loudly on unknown input, with the offending excerpt', () => {
+  assert.throws(
+    () => classifyFailure({ stdout: 'some novel garbage nobody classified' }),
+    (err) => err.message.includes('novel garbage') && /unclassifiable/.test(err.message),
+  );
+  assert.throws(() => classifyFailure({}), /unclassifiable/);
+  assert.throws(() => classifyFailure({ httpStatus: 500 }), /httpStatus=500/);
+});
+
+// ── aggregate ────────────────────────────────────────────────────────────────
+
+const opRow = (outcome, publishMs, over = {}) => ({
+  op: 'publish', lane: 'public', outcome,
+  durations_ms: publishMs === undefined ? undefined : { publish: publishMs },
+  ...over,
+});
+
+test('aggregate: successes-only percentiles, aborted excluded from denominator', () => {
+  const rows = [
+    opRow('success', 100), opRow('success', 200), opRow('success', 300),
+    opRow('success', 400), opRow('success', 500), opRow('success', 600),
+    opRow('timeout', undefined), opRow('quorum_or_backoff', undefined),
+    opRow('aborted', undefined), opRow('aborted', undefined),
+  ];
+  const agg = aggregate(rows, { op: 'publish', lane: 'public', durationField: 'publish', _percentile: nearestRank });
+  assert.equal(agg.attempts, 10);
+  assert.equal(agg.successes, 6);
+  assert.equal(agg.failed, 2);
+  assert.equal(agg.aborted, 2);
+  // §6: aborted (harness quiesce) excluded from the success-rate denominator
+  assert.equal(agg.successRate, 6 / 8);
+  assert.equal(agg.durationsMs.count, 6);
+  assert.equal(agg.durationsMs.p50, 300);
+  assert.equal(agg.durationsMs.p95, 600);
+  assert.equal(agg.durationsMs.p99, 600);
+  assert.equal(agg.durationsMs.max, 600);
+  assert.deepEqual(agg.failuresByClass, { timeout: 1, quorum_or_backoff: 1 });
+  assert.equal(agg.partial, false);
+});
+
+test('aggregate: failed-op latencies never enter percentiles', () => {
+  const rows = [
+    opRow('success', 50_000),
+    opRow('timeout', 5, { durations_ms: { publish: 5 } }), // fast failure must not improve p95
+  ];
+  const agg = aggregate(rows, { op: 'publish', lane: 'public', durationField: 'publish', _percentile: nearestRank });
+  assert.equal(agg.durationsMs.p95, 50_000);
+  assert.equal(agg.durationsMs.count, 1);
+});
+
+test('aggregate: partial runs carry attempted/completed/inFlight', () => {
+  const rows = [opRow('success', 10), opRow('aborted'), opRow('aborted'), opRow('transport_error')];
+  const agg = aggregate(rows, { op: 'publish', lane: 'public', durationField: 'publish', partial: true, _percentile: nearestRank });
+  assert.equal(agg.partial, true);
+  assert.equal(agg.attempted, 4);
+  assert.equal(agg.completed, 2);
+  assert.equal(agg.inFlight, 2);
+  assert.equal(agg.successRate, 1 / 2);
+});
+
+test('aggregate: filters to the requested (op, lane); pre-filtered rows pass', () => {
+  const rows = [
+    opRow('success', 10),
+    opRow('success', 99, { lane: 'private' }),
+    opRow('success', 98, { op: 'query' }),
+    { outcome: 'success', durations_ms: { publish: 20 } }, // no op/lane => caller pre-filtered
+  ];
+  const agg = aggregate(rows, { op: 'publish', lane: 'public', durationField: 'publish', _percentile: nearestRank });
+  assert.equal(agg.attempts, 2);
+  assert.equal(agg.durationsMs.max, 20);
+});
+
+test('aggregate: zero rows and error:<class> outcomes', () => {
+  const empty = aggregate([], { op: 'publish', lane: 'public', durationField: 'publish', _percentile: nearestRank });
+  assert.equal(empty.attempts, 0);
+  assert.equal(empty.successRate, null);
+  assert.equal(empty.durationsMs.p95, null);
+
+  const agg = aggregate([opRow('error:HttpError')], { op: 'publish', lane: 'public', durationField: 'publish', _percentile: nearestRank });
+  assert.deepEqual(agg.failuresByClass, { 'error:HttpError': 1 });
+});
+
+test('aggregate: outcome outside the closed enum throws — never fold silently', () => {
+  assert.throws(
+    () => aggregate([opRow('mystery_class')], { op: 'publish', lane: 'public', durationField: 'publish', _percentile: nearestRank }),
+    /closed failure enum/,
+  );
+});
+
+// ── evaluateGate ─────────────────────────────────────────────────────────────
+
+test('evaluateGate: percentile gate without coverage fields throws (spec bug)', () => {
+  assert.throws(
+    () => evaluateGate({ id: 'p95', kind: 'percentile', threshold: 60_000, observed: 1000 }),
+    /minSamples/,
+  );
+  assert.throws(
+    () => evaluateGate({ id: 'p95', kind: 'percentile', threshold: 60_000, observed: 1000, minSamples: 100 }),
+    /minSuccessRate/,
+  );
+  assert.throws(
+    () => evaluateGate({ id: 'sr', kind: 'successRate', threshold: 0.95, observed: 1 }),
+    /minSamples/,
+  );
+});
+
+test('evaluateGate: coverage shortfall is INCONCLUSIVE, not PASS/FAIL', () => {
+  const lowSamples = evaluateGate({
+    id: 'p95', kind: 'percentile', threshold: 60_000, observed: 1000,
+    samples: 40, minSamples: 100, successRate: 1, minSuccessRate: 0.95,
+  });
+  assert.equal(lowSamples.outcome, 'INCONCLUSIVE');
+  assert.match(lowSamples.evidence.reason, /insufficient samples: 40 < minSamples 100/);
+
+  const lowSuccess = evaluateGate({
+    id: 'p95', kind: 'percentile', threshold: 60_000, observed: 1000,
+    samples: 100, minSamples: 100, successRate: 0.5, minSuccessRate: 0.95,
+  });
+  assert.equal(lowSuccess.outcome, 'INCONCLUSIVE');
+  assert.match(lowSuccess.evidence.reason, /below coverage/);
+
+  const srLow = evaluateGate({
+    id: 'sr', kind: 'successRate', threshold: 0.95, observed: 1, samples: 3, minSamples: 100,
+  });
+  assert.equal(srLow.outcome, 'INCONCLUSIVE');
+});
+
+test('evaluateGate: threshold comparison per kind', () => {
+  const covered = { samples: 100, minSamples: 100, successRate: 0.97, minSuccessRate: 0.95 };
+  assert.equal(evaluateGate({ id: 'g', kind: 'percentile', threshold: 60_000, observed: 42_000, ...covered }).outcome, 'PASS');
+  assert.equal(evaluateGate({ id: 'g', kind: 'percentile', threshold: 60_000, observed: 61_000, ...covered }).outcome, 'FAIL');
+  assert.equal(evaluateGate({ id: 'g', kind: 'successRate', threshold: 0.95, observed: 0.97, samples: 100, minSamples: 100 }).outcome, 'PASS');
+  assert.equal(evaluateGate({ id: 'g', kind: 'successRate', threshold: 0.95, observed: 0.90, samples: 100, minSamples: 100 }).outcome, 'FAIL');
+  assert.equal(evaluateGate({ id: 'g', kind: 'exactZero', observed: 0 }).outcome, 'PASS');
+  const ez = evaluateGate({ id: 'g', kind: 'exactZero', observed: 2 });
+  assert.equal(ez.outcome, 'FAIL');
+  assert.equal(ez.threshold, 0);
+  assert.equal(evaluateGate({ id: 'g', kind: 'bool', observed: true }).outcome, 'PASS');
+  assert.equal(evaluateGate({ id: 'g', kind: 'bool', observed: false }).outcome, 'FAIL');
+  assert.equal(evaluateGate({ id: 'g', kind: 'max', threshold: 0.9, observed: 0.85 }).outcome, 'PASS');
+  assert.equal(evaluateGate({ id: 'g', kind: 'max', threshold: 0.9, observed: 0.95 }).outcome, 'FAIL');
+});
+
+test('evaluateGate: inconclusiveReason passthrough and missing observed fail closed', () => {
+  const forced = evaluateGate({
+    id: 'g', kind: 'bool', observed: true, inconclusiveReason: 'fleet SHA changed mid-run',
+  });
+  assert.equal(forced.outcome, 'INCONCLUSIVE');
+  assert.equal(forced.evidence.reason, 'fleet SHA changed mid-run');
+
+  assert.equal(evaluateGate({ id: 'g', kind: 'max', threshold: 1, observed: NaN }).outcome, 'INCONCLUSIVE');
+  assert.equal(evaluateGate({ id: 'g', kind: 'exactZero', observed: undefined }).outcome, 'INCONCLUSIVE');
+  assert.equal(evaluateGate({ id: 'g', kind: 'bool', observed: undefined }).outcome, 'INCONCLUSIVE');
+});
+
+test('evaluateGate: invalid kind or missing id throws', () => {
+  assert.throws(() => evaluateGate({ id: 'g', kind: 'median', threshold: 1, observed: 1 }), /unknown kind/);
+  assert.throws(() => evaluateGate({ kind: 'bool', observed: true }), /gate\.id/);
+  assert.deepEqual([...GATE_KINDS], ['successRate', 'percentile', 'exactZero', 'bool', 'max']);
+});
+
+// ── computeVerdict / formatVerdict ──────────────────────────────────────────
+
+const g = (id, outcome) => ({ id, outcome, observed: 1, threshold: 1, evidence: {} });
+
+test('computeVerdict folds FAIL > INCONCLUSIVE > PASS', () => {
+  assert.equal(computeVerdict({ gates: [g('a', 'PASS'), g('b', 'PASS')] }).outcome, 'PASS');
+  assert.equal(computeVerdict({ gates: [g('a', 'PASS'), g('b', 'INCONCLUSIVE')] }).outcome, 'INCONCLUSIVE');
+  assert.equal(computeVerdict({ gates: [g('a', 'FAIL'), g('b', 'INCONCLUSIVE'), g('c', 'PASS')] }).outcome, 'FAIL');
+});
+
+test('computeVerdict: SAFETY_ABORT takes precedence over everything', () => {
+  const v = computeVerdict({ gates: [g('a', 'PASS'), g('b', 'PASS')], safetyAbort: true });
+  assert.equal(v.outcome, 'SAFETY_ABORT');
+  assert.equal(computeVerdict({ gates: [g('a', 'FAIL')], safetyAbort: true }).outcome, 'SAFETY_ABORT');
+  assert.ok(OUTCOMES.includes(v.outcome));
+});
+
+test('computeVerdict rejects invalid gate outcomes', () => {
+  assert.throws(() => computeVerdict({ gates: [g('a', 'MAYBE')] }), /invalid outcome/);
+});
+
+test('formatVerdict renders a fixed-width row per gate with the outcome header', () => {
+  const verdict = computeVerdict({
+    gates: [
+      { id: 'overall-success-rate', outcome: 'PASS', observed: 0.97, threshold: 0.95, evidence: {} },
+      { id: 'publish-p95-ms', outcome: 'FAIL', observed: 61_000, threshold: 60_000, evidence: {} },
+      { id: 'gated-signatures', outcome: 'INCONCLUSIVE', observed: null, threshold: 0, evidence: { reason: 'cursor vacuumed' } },
+    ],
+  });
+  const text = formatVerdict(verdict);
+  const lines = text.split('\n');
+  assert.match(lines[0], /^VERDICT: FAIL {2}\(1 pass, 1 fail, 1 inconclusive of 3 gates\)$/);
+  assert.match(lines[1], /^GATE\s+OUTCOME\s+OBSERVED\s+THRESHOLD\s+NOTE$/);
+  // one row per gate, and the OUTCOME column is aligned across all rows
+  const idWidth = Math.max('GATE'.length, ...verdict.gates.map((x) => x.id.length));
+  for (const gate of verdict.gates) {
+    const row = lines.find((l) => l.startsWith(gate.id));
+    assert.ok(row, `row for ${gate.id}`);
+    assert.equal(row.indexOf(gate.outcome), idWidth + 2);
+  }
+  assert.ok(lines.find((l) => l.includes('cursor vacuumed')));
+  // fixed-width and colorless
+  assert.ok(!text.includes('['));
+});
+
+test('formatVerdict for SAFETY_ABORT verdicts', () => {
+  const text = formatVerdict(computeVerdict({ gates: [g('a', 'PASS')], safetyAbort: true }));
+  assert.match(text, /^VERDICT: SAFETY_ABORT/);
+});

--- a/testnet/test/ssh.test.mjs
+++ b/testnet/test/ssh.test.mjs
@@ -1,0 +1,269 @@
+// Hermetic tests for lib/ssh.mjs — no real SSH, no network; injected fakes only.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { sshExec, mapLimit, parseKvOutput, snapshotCommand, unitFullName } from '../lib/ssh.mjs';
+
+// ── fakes ────────────────────────────────────────────────────────────────────
+
+function fakeProc({ code = 0, stdout = '', stderr = '', neverExit = false, emitError = null } = {}) {
+  const proc = new EventEmitter();
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.killed = false;
+  proc.kill = () => { proc.killed = true; };
+  queueMicrotask(() => {
+    if (stdout) proc.stdout.emit('data', Buffer.from(stdout));
+    if (stderr) proc.stderr.emit('data', Buffer.from(stderr));
+    if (emitError) { proc.emit('error', emitError); return; }
+    if (!neverExit) proc.emit('close', code, null);
+  });
+  return proc;
+}
+
+function fakeSpawn(script) {
+  const calls = [];
+  const fn = (cmd, args, options) => {
+    calls.push({ cmd, args, options });
+    const spec = script[Math.min(calls.length - 1, script.length - 1)];
+    return fakeProc(spec);
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+const TARGET = { host: '203.0.113.5', sshUser: 'obs', sshIdentity: '~/.ssh/id_test' };
+
+// ── sshExec ──────────────────────────────────────────────────────────────────
+
+test('sshExec composes the exact ssh argv (with identity)', async () => {
+  const spy = fakeSpawn([{ code: 0, stdout: 'hi\n' }]);
+  const res = await sshExec(TARGET, 'echo hi', { _spawn: spy, connectTimeoutSec: 8 });
+  assert.equal(res.ok, true);
+  assert.equal(res.code, 0);
+  assert.equal(res.stdout, 'hi\n');
+  assert.equal(res.timedOut, false);
+  assert.equal(spy.calls[0].cmd, 'ssh');
+  assert.deepEqual(spy.calls[0].args, [
+    '-o', 'BatchMode=yes',
+    '-o', 'StrictHostKeyChecking=accept-new',
+    '-o', 'ConnectTimeout=8',
+    '-i', '~/.ssh/id_test', '-o', 'IdentitiesOnly=yes',
+    'obs@203.0.113.5',
+    '--',
+    'echo hi',
+  ]);
+});
+
+test('sshExec omits identity flags when no sshIdentity', async () => {
+  const spy = fakeSpawn([{ code: 0 }]);
+  await sshExec({ host: 'h1', sshUser: 'u1' }, 'true', { _spawn: spy, connectTimeoutSec: 3 });
+  assert.deepEqual(spy.calls[0].args, [
+    '-o', 'BatchMode=yes',
+    '-o', 'StrictHostKeyChecking=accept-new',
+    '-o', 'ConnectTimeout=3',
+    'u1@h1',
+    '--',
+    'true',
+  ]);
+});
+
+test('sshExec retries once on connect failure (exit 255)', async () => {
+  const spy = fakeSpawn([{ code: 255, stderr: 'ssh: connect refused' }, { code: 0, stdout: 'ok\n' }]);
+  const res = await sshExec(TARGET, 'echo ok', { _spawn: spy, _retryDelayMs: 0 });
+  assert.equal(spy.calls.length, 2);
+  assert.equal(res.ok, true);
+  assert.equal(res.stdout, 'ok\n');
+});
+
+test('sshExec gives up after two 255 attempts', async () => {
+  const spy = fakeSpawn([{ code: 255, stderr: 'no route' }]);
+  const res = await sshExec(TARGET, 'true', { _spawn: spy, _retryDelayMs: 0 });
+  assert.equal(spy.calls.length, 2);
+  assert.equal(res.ok, false);
+  assert.equal(res.code, 255);
+});
+
+test('sshExec does NOT retry a non-255 remote failure', async () => {
+  const spy = fakeSpawn([{ code: 1, stderr: 'remote command failed' }]);
+  const res = await sshExec(TARGET, 'false', { _spawn: spy, _retryDelayMs: 0 });
+  assert.equal(spy.calls.length, 1);
+  assert.equal(res.ok, false);
+  assert.equal(res.code, 1);
+  assert.equal(res.stderr, 'remote command failed');
+});
+
+test('sshExec times out a hung command and reports timedOut', async () => {
+  const spy = fakeSpawn([{ neverExit: true, stdout: 'partial' }]);
+  const res = await sshExec(TARGET, 'sleep 999', { _spawn: spy, timeoutMs: 25, _retryDelayMs: 0 });
+  assert.equal(res.ok, false);
+  assert.equal(res.timedOut, true);
+  assert.equal(res.code, null);
+  assert.equal(res.stdout, 'partial');
+});
+
+test('sshExec never rejects on spawn error events', async () => {
+  const spy = fakeSpawn([{ emitError: new Error('spawn ssh ENOENT') }]);
+  const res = await sshExec(TARGET, 'true', { _spawn: spy, _retryDelayMs: 0 });
+  assert.equal(res.ok, false);
+  assert.equal(res.code, null);
+  assert.match(res.stderr, /ENOENT/);
+});
+
+test('sshExec returns a failure result for a malformed target', async () => {
+  const spy = fakeSpawn([{ code: 0 }]);
+  const res = await sshExec({ host: '' }, 'true', { _spawn: spy });
+  assert.equal(res.ok, false);
+  assert.equal(spy.calls.length, 0);
+});
+
+// ── mapLimit ─────────────────────────────────────────────────────────────────
+
+test('mapLimit preserves order and honors the concurrency cap', async () => {
+  let active = 0;
+  let maxActive = 0;
+  const items = [10, 20, 30, 40, 50];
+  const results = await mapLimit(items, 2, async (n) => {
+    active += 1;
+    maxActive = Math.max(maxActive, active);
+    await new Promise((r) => setTimeout(r, 10));
+    active -= 1;
+    return n * 2;
+  });
+  assert.deepEqual(results, [20, 40, 60, 80, 100]);
+  assert.ok(maxActive <= 2, `expected concurrency <= 2, saw ${maxActive}`);
+  assert.ok(maxActive >= 2, 'expected the pool to actually run in parallel');
+});
+
+test('mapLimit never rejects: thrown fn becomes an {ok:false, error} placeholder', async () => {
+  const results = await mapLimit([1, 2, 3], 2, async (n) => {
+    if (n === 2) throw new Error('boom-2');
+    return n;
+  });
+  assert.equal(results[0], 1);
+  assert.deepEqual(results[1], { ok: false, error: 'boom-2' });
+  assert.equal(results[2], 3);
+});
+
+test('mapLimit handles empty input', async () => {
+  assert.deepEqual(await mapLimit([], 4, async () => 1), []);
+});
+
+// ── parseKvOutput ────────────────────────────────────────────────────────────
+
+test('parseKvOutput parses plain k=v lines and ignores noise', () => {
+  const out = parseKvOutput([
+    'active_state=active',
+    'n_restarts=2',
+    'this line has no marker at all',   // ignored: no '='
+    '  === weird banner ===',           // ignored: bad key
+    'value_with_equals=a=b=c',          // value keeps embedded '='
+    'empty_value=',
+    'spaced_key name=x',                // ignored: key fails identifier check
+  ].join('\n'));
+  assert.deepEqual(out, {
+    active_state: 'active',
+    n_restarts: '2',
+    value_with_equals: 'a=b=c',
+    empty_value: '',
+  });
+});
+
+test('parseKvOutput transparently decodes b64: values (paths, spaces)', () => {
+  const raw = 'Mon 2026-07-13 09:14:02 UTC';
+  const b64 = Buffer.from(raw, 'utf8').toString('base64');
+  const out = parseKvOutput(`exec_main_start=b64:${b64}\nempty_b64=b64:\nplain=ok`);
+  assert.equal(out.exec_main_start, raw);
+  assert.equal(out.empty_b64, '');
+  assert.equal(out.plain, 'ok');
+});
+
+test('parseKvOutput tolerates CRLF and duplicate keys (last wins)', () => {
+  const out = parseKvOutput('a=1\r\na=2\r\n');
+  assert.deepEqual(out, { a: '2' });
+});
+
+// ── snapshotCommand ──────────────────────────────────────────────────────────
+
+const CORE = { systemdUnit: 'dkg-node', listenPort: 9090, storeFilesystem: '/' };
+
+test('snapshotCommand (light) carries every review-mandated probe', () => {
+  const cmd = snapshotCommand(CORE, { light: true });
+  for (const needle of [
+    'systemctl show dkg-node.service --property=ActiveState',
+    '--property=SubState',
+    '--property=NRestarts',
+    '--property=ExecMainStartTimestamp',
+    '--property=MainPID',
+    '--property=ControlGroup',
+    '/system.slice/dkg-node.service',
+    'memory.current', 'memory.peak', 'memory.high', 'memory.max',
+    'memory.events', 'oom_kill',
+    'memory.pressure', 'avg10',
+    'ss -H -tln sport = :9090',
+    "timeout 2 bash -c 'exec 3<>/dev/tcp/127.0.0.1/9090'",
+    'probe_ok=1', 'probe_ok=0',
+    'df -B1 --output=avail,pcent /',
+    'df -P -B1 /',
+    'pgrep -P',
+    'base64 -w0',
+    'snapshot_complete=1',
+  ]) {
+    assert.ok(cmd.includes(needle), `light command missing: ${needle}`);
+  }
+  assert.ok(!cmd.includes('journalctl'), 'light must not touch the journal');
+  assert.ok(!cmd.includes('du -sb'), 'light must not du the store');
+});
+
+test('snapshotCommand (full) adds store size + journal cursor', () => {
+  const cmd = snapshotCommand(CORE, { light: false });
+  assert.ok(cmd.includes('du -sb'));
+  assert.ok(cmd.includes('--property=WorkingDirectory'));
+  assert.ok(cmd.includes('journalctl -u dkg-node.service -n 0 --show-cursor --no-pager'));
+  assert.ok(cmd.includes('-- cursor: '));
+});
+
+test('snapshotCommand never emits remote paths that could leak a username (S6)', () => {
+  const cmd = snapshotCommand(CORE, { light: false });
+  // The WorkingDirectory heuristic must consume $wd remotely, never echo it.
+  assert.ok(!/echo [a-z_]*=\$wd\b/.test(cmd), 'must not emit the store dir path');
+  assert.ok(!cmd.includes('echo cwd'), 'must not emit the process cwd');
+  assert.ok(!cmd.includes('hostname'), 'must not emit the hostname');
+});
+
+test('snapshotCommand is strictly read-only (S2 audit)', () => {
+  for (const light of [true, false]) {
+    const cmd = snapshotCommand(CORE, { light });
+    assert.ok(!/\bsudo\b/.test(cmd), 'no sudo');
+    for (const m of cmd.matchAll(/systemctl\s+(\S+)/g)) {
+      assert.equal(m[1], 'show', `only 'systemctl show' allowed, saw 'systemctl ${m[1]}'`);
+    }
+    assert.ok(!/\b(rm|mv|cp|dd|tee|truncate|chmod|chown|mkdir|touch|ln|kill|pkill|reboot|shutdown|systemd-run|sysctl)\b/.test(cmd),
+      'no state-changing binaries');
+    assert.ok(!cmd.includes('--vacuum'), 'no journal vacuum');
+    assert.ok(!cmd.includes('curl'), 'no in-band store queries');
+    // Every '>' must belong to a /dev/null redirect or the /dev/tcp probe.
+    const stripped = cmd
+      .replaceAll('2>/dev/null', '')
+      .replaceAll('3<>/dev/tcp/127.0.0.1/9090', '');
+    assert.ok(!stripped.includes('>'), `unexpected redirect in: ${cmd}`);
+    assert.ok(!stripped.includes('<'), `unexpected input redirect in: ${cmd}`);
+  }
+});
+
+test('snapshotCommand rejects shell-unsafe fleet values', () => {
+  assert.throws(() => snapshotCommand({ ...CORE, systemdUnit: 'dkg;rm -rf' }), TypeError);
+  assert.throws(() => snapshotCommand({ ...CORE, systemdUnit: 'dkg node' }), TypeError);
+  assert.throws(() => snapshotCommand({ ...CORE, listenPort: 'x' }), TypeError);
+  assert.throws(() => snapshotCommand({ ...CORE, listenPort: 0 }), TypeError);
+  assert.throws(() => snapshotCommand({ ...CORE, storeFilesystem: '/; rm -rf /' }), TypeError);
+  assert.throws(() => snapshotCommand({ ...CORE, storeFilesystem: '$(reboot)' }), TypeError);
+});
+
+test('unitFullName normalizes and validates', () => {
+  assert.equal(unitFullName('dkg-node'), 'dkg-node.service');
+  assert.equal(unitFullName('dkg-node.service'), 'dkg-node.service');
+  assert.throws(() => unitFullName('a b'), TypeError);
+  assert.throws(() => unitFullName(''), TypeError);
+  assert.throws(() => unitFullName("dkg'"), TypeError);
+});

--- a/testnet/test/util.test.mjs
+++ b/testnet/test/util.test.mjs
@@ -1,0 +1,306 @@
+// Hermetic tests for lib/util.mjs — no network, no fleet, no SSH.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  bindingSetDigest,
+  fetchRetry,
+  fnv1a,
+  isoBasic,
+  isTransientNetworkError,
+  normTerm,
+  parseLastJsonBlock,
+  percentile,
+  promiseWithTimeout,
+  seededRandom,
+  sha256,
+  sleep,
+  waitFor,
+} from '../lib/util.mjs';
+
+// ── percentile (nearest-rank, rfc59 parity) ─────────────────────────────────
+
+test('percentile: empty array -> null', () => {
+  assert.equal(percentile([], 50), null);
+  assert.equal(percentile([], 99), null);
+  assert.equal(percentile([NaN, Infinity], 95), null); // non-finite filtered out
+});
+
+test('percentile: single element is every percentile', () => {
+  assert.equal(percentile([42], 50), 42);
+  assert.equal(percentile([42], 95), 42);
+  assert.equal(percentile([42], 99), 42);
+  assert.equal(percentile([42], 100), 42);
+});
+
+test('percentile: rfc59 harness parity on its own test vector', () => {
+  // rfc59 harness.test.mjs: percentile([50,10,40,20,30], 0.5) === 30, 0.95 === 50
+  assert.equal(percentile([50, 10, 40, 20, 30], 50), 30);
+  assert.equal(percentile([50, 10, 40, 20, 30], 95), 50);
+  assert.equal(percentile([50, 10, 40, 20, 30], 99), 50);
+});
+
+test('percentile: exact-rank boundaries, no interpolation', () => {
+  const v = [10, 20, 30, 40];
+  assert.equal(percentile(v, 25), 10); // ceil(0.25*4)=1 -> rank 1
+  assert.equal(percentile(v, 50), 20); // ceil(0.5*4)=2 -> rank 2
+  assert.equal(percentile(v, 75), 30);
+  assert.equal(percentile(v, 76), 40); // just past the exact boundary
+  assert.equal(percentile(v, 100), 40);
+});
+
+test('percentile: does not mutate its input', () => {
+  const v = [3, 1, 2];
+  percentile(v, 50);
+  assert.deepEqual(v, [3, 1, 2]);
+});
+
+// ── parseLastJsonBlock ───────────────────────────────────────────────────────
+
+test('parseLastJsonBlock: noisy CLI stdout with logs before and after', () => {
+  const out = [
+    '[2026-07-14T19:00:00Z] INFO starting publish…',
+    'progress: 10% {not json here',
+    '{"status":"COMPLETED","ual":"did:dkg:base:84532/0xabc/1","durationMs":1234}',
+    'INFO done, exiting with code 0',
+  ].join('\n');
+  assert.deepEqual(parseLastJsonBlock(out), {
+    status: 'COMPLETED',
+    ual: 'did:dkg:base:84532/0xabc/1',
+    durationMs: 1234,
+  });
+});
+
+test('parseLastJsonBlock: multiple objects -> the LAST one wins', () => {
+  const out = '{"first":1}\nsome noise\n{"second":2}';
+  assert.deepEqual(parseLastJsonBlock(out), { second: 2 });
+});
+
+test('parseLastJsonBlock: nested object returns the outermost (top-level) block', () => {
+  const out = 'log line\n{"outer":{"inner":{"deep":true}},"n":1}';
+  assert.deepEqual(parseLastJsonBlock(out), { outer: { inner: { deep: true } }, n: 1 });
+});
+
+test('parseLastJsonBlock: braces and escaped quotes inside strings do not break the scan', () => {
+  const out = 'x\n{"msg":"boom } zap { \\" }","ok":true}';
+  assert.deepEqual(parseLastJsonBlock(out), { msg: 'boom } zap { " }', ok: true });
+});
+
+test('parseLastJsonBlock: trailing stray brace after the JSON is skipped', () => {
+  const out = '{"a":1} trailing } noise';
+  assert.deepEqual(parseLastJsonBlock(out), { a: 1 });
+});
+
+test('parseLastJsonBlock: pure JSON and whitespace-padded JSON', () => {
+  assert.deepEqual(parseLastJsonBlock('{"a":1}'), { a: 1 });
+  assert.deepEqual(parseLastJsonBlock('  {"a":1}\n\n'), { a: 1 });
+});
+
+test('parseLastJsonBlock: no JSON object -> null', () => {
+  assert.equal(parseLastJsonBlock('no json here at all'), null);
+  assert.equal(parseLastJsonBlock(''), null);
+  assert.equal(parseLastJsonBlock('{"unclosed": true'), null);
+  assert.equal(parseLastJsonBlock('[1,2,3]'), null); // arrays are not objects
+});
+
+// ── normTerm / bindingSetDigest ──────────────────────────────────────────────
+
+test('normTerm: canonical forms per term type', () => {
+  assert.equal(normTerm({ type: 'uri', value: 'http://ex/a' }), '<http://ex/a>');
+  assert.equal(normTerm({ type: 'bnode', value: 'b0' }), '_:b0');
+  assert.equal(normTerm({ type: 'literal', value: 'plain' }), '"plain"');
+  assert.equal(
+    normTerm({ type: 'literal', value: '5', datatype: 'http://www.w3.org/2001/XMLSchema#integer' }),
+    '"5"^^<http://www.w3.org/2001/XMLSchema#integer>',
+  );
+  assert.equal(
+    normTerm({ type: 'literal', value: 'x', datatype: 'http://www.w3.org/2001/XMLSchema#string' }),
+    '"x"', // xsd:string is elided (devnet parity)
+  );
+  assert.equal(normTerm({ type: 'literal', value: 'chat', 'xml:lang': 'fr' }), '"chat"@fr');
+});
+
+test('normTerm: idempotent on N-Triples term strings, tolerant of empty cells', () => {
+  assert.equal(normTerm('<http://ex/a>'), '<http://ex/a>');
+  assert.equal(normTerm('"v"@en'), '"v"@en');
+  assert.equal(normTerm('_:b1'), '_:b1');
+  assert.equal(normTerm({ type: 'uri', value: '<http://ex/a>' }), '<http://ex/a>');
+  assert.equal(normTerm(null), '');
+  assert.equal(normTerm(undefined), '');
+  assert.equal(normTerm({}), '');
+});
+
+test('bindingSetDigest: insensitive to row order and binding key order', () => {
+  const a = {
+    head: { vars: ['s', 'o'] },
+    results: {
+      bindings: [
+        { s: { type: 'uri', value: 'http://ex/1' }, o: { type: 'literal', value: 'x' } },
+        { s: { type: 'uri', value: 'http://ex/2' }, o: { type: 'literal', value: 'y' } },
+      ],
+    },
+  };
+  const b = {
+    head: { vars: ['o', 's'] },
+    results: {
+      bindings: [
+        { o: { type: 'literal', value: 'y' }, s: { type: 'uri', value: 'http://ex/2' } },
+        { o: { type: 'literal', value: 'x' }, s: { type: 'uri', value: 'http://ex/1' } },
+      ],
+    },
+  };
+  assert.equal(bindingSetDigest(a), bindingSetDigest(b));
+});
+
+test('bindingSetDigest: different content -> different digest; empty set is stable', () => {
+  const base = {
+    head: { vars: ['s'] },
+    results: { bindings: [{ s: { type: 'uri', value: 'http://ex/1' } }] },
+  };
+  const other = {
+    head: { vars: ['s'] },
+    results: { bindings: [{ s: { type: 'uri', value: 'http://ex/2' } }] },
+  };
+  assert.notEqual(bindingSetDigest(base), bindingSetDigest(other));
+  assert.equal(
+    bindingSetDigest({ head: { vars: [] }, results: { bindings: [] } }),
+    sha256(''),
+  );
+});
+
+test('bindingSetDigest: structured and term-string cells digest identically', () => {
+  const structured = {
+    head: { vars: ['s'] },
+    results: { bindings: [{ s: { type: 'uri', value: 'http://ex/1' } }] },
+  };
+  const termString = {
+    head: { vars: ['s'] },
+    results: { bindings: [{ s: '<http://ex/1>' }] },
+  };
+  assert.equal(bindingSetDigest(structured), bindingSetDigest(termString));
+});
+
+// ── sha256 ───────────────────────────────────────────────────────────────────
+
+test('sha256: known vectors, string and Buffer', () => {
+  assert.equal(
+    sha256('abc'),
+    'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad',
+  );
+  assert.equal(sha256(Buffer.from('abc')), sha256('abc'));
+  assert.equal(
+    sha256(''),
+    'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+  );
+});
+
+// ── waitFor / promiseWithTimeout / fetchRetry ───────────────────────────────
+
+test('waitFor: resolves the truthy probe value', async () => {
+  let calls = 0;
+  const v = await waitFor('thing', 500, 1, () => (++calls >= 3 ? { got: calls } : null));
+  assert.deepEqual(v, { got: 3 });
+  assert.equal(calls, 3);
+});
+
+test('waitFor: throws the contract timeout message', async () => {
+  await assert.rejects(
+    waitFor('never-ready', 10, 1, () => false),
+    { message: 'waitFor timeout: never-ready' },
+  );
+});
+
+test('promiseWithTimeout: passes through a fast promise', async () => {
+  assert.equal(await promiseWithTimeout(Promise.resolve(7), 100, 'fast'), 7);
+});
+
+test('promiseWithTimeout: rejects with the contract message on timeout', async () => {
+  await assert.rejects(
+    promiseWithTimeout(sleep(200), 10, 'slow-op'),
+    { message: 'slow-op timeout after 10ms' },
+  );
+});
+
+test('promiseWithTimeout: propagates the inner rejection', async () => {
+  await assert.rejects(
+    promiseWithTimeout(Promise.reject(new Error('inner')), 100, 'x'),
+    { message: 'inner' },
+  );
+});
+
+test('fetchRetry: retries transient errors then succeeds', async () => {
+  let calls = 0;
+  const resp = { ok: true, status: 200 };
+  const _fetch = async () => {
+    calls++;
+    if (calls < 3) throw Object.assign(new Error('fetch failed'), { cause: { code: 'ECONNRESET' } });
+    return resp;
+  };
+  const got = await fetchRetry('http://127.0.0.1:1/x', undefined, { _fetch, backoffMs: 0 });
+  assert.equal(got, resp);
+  assert.equal(calls, 3);
+});
+
+test('fetchRetry: HTTP error statuses are returned, never retried', async () => {
+  let calls = 0;
+  const _fetch = async () => { calls++; return { ok: false, status: 503 }; };
+  const got = await fetchRetry('http://127.0.0.1:1/x', undefined, { _fetch, backoffMs: 0 });
+  assert.equal(got.status, 503);
+  assert.equal(calls, 1);
+});
+
+test('fetchRetry: non-transient errors are rethrown without retry', async () => {
+  let calls = 0;
+  const _fetch = async () => { calls++; throw new Error('certificate has expired'); };
+  await assert.rejects(
+    fetchRetry('http://127.0.0.1:1/x', undefined, { _fetch, backoffMs: 0 }),
+    { message: 'certificate has expired' },
+  );
+  assert.equal(calls, 1);
+});
+
+test('fetchRetry: exhausts retries and rethrows the last transient error', async () => {
+  let calls = 0;
+  const _fetch = async () => { calls++; throw Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' }); };
+  await assert.rejects(
+    fetchRetry('http://127.0.0.1:1/x', undefined, { _fetch, retries: 2, backoffMs: 0 }),
+    { message: 'socket hang up' },
+  );
+  assert.equal(calls, 3); // 1 initial + 2 retries (devnet 3-tries parity)
+});
+
+test('isTransientNetworkError: classification, including undici cause chains', () => {
+  assert.equal(isTransientNetworkError(Object.assign(new Error('x'), { code: 'ECONNREFUSED' })), true);
+  assert.equal(isTransientNetworkError(Object.assign(new TypeError('fetch failed'), { cause: { code: 'UND_ERR_SOCKET', message: 'other side closed' } })), true);
+  assert.equal(isTransientNetworkError(new Error('socket hang up')), true);
+  assert.equal(isTransientNetworkError(new Error('ENOTFOUND example.invalid')), false);
+  assert.equal(isTransientNetworkError(undefined), false);
+});
+
+// ── seededRandom / fnv1a / isoBasic ─────────────────────────────────────────
+
+test('seededRandom: deterministic per seed, divergent across seeds, range [0,1)', () => {
+  const a1 = seededRandom('certify-100:run-1');
+  const a2 = seededRandom('certify-100:run-1');
+  const b = seededRandom('certify-100:run-2');
+  const seqA1 = Array.from({ length: 8 }, () => a1());
+  const seqA2 = Array.from({ length: 8 }, () => a2());
+  const seqB = Array.from({ length: 8 }, () => b());
+  assert.deepEqual(seqA1, seqA2);
+  assert.notDeepEqual(seqA1, seqB);
+  for (const x of [...seqA1, ...seqB]) {
+    assert.equal(typeof x, 'number');
+    assert.ok(x >= 0 && x < 1, `out of range: ${x}`);
+  }
+});
+
+test('fnv1a: stable 32-bit reference values', () => {
+  assert.equal(fnv1a(''), 0x811c9dc5);
+  assert.equal(fnv1a('a'), 0xe40c292c);
+  assert.equal(fnv1a('foobar'), 0xbf9cf968);
+});
+
+test('isoBasic: YYYYMMDDTHHMMSSZ, UTC, no separators', () => {
+  assert.equal(isoBasic(new Date('2026-07-14T19:00:00.123Z')), '20260714T190000Z');
+  assert.match(isoBasic(), /^\d{8}T\d{6}Z$/);
+});

--- a/testnet/test/watch.test.mjs
+++ b/testnet/test/watch.test.mjs
@@ -1,0 +1,401 @@
+// Hermetic tests for lib/watch.mjs — no SSH, no network, no real fleet.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { evaluateTrips, quiesce, recordSafetyAbort, safetyAbortGate } from '../lib/watch.mjs';
+
+// ── fixtures ─────────────────────────────────────────────────────────────────
+
+function mkPolicy(over = {}) {
+  return {
+    trips: {
+      memoryPsiSomeAvg10: { default: 0.4, hardMax: 0.6, sustainSec: 60 },
+      memoryCurrentVsHighFraction: { default: 0.95, hardMax: 0.98 },
+      oomKillDelta: { default: 0, hardMax: 0 },
+      coreUnreachableFromBaseline: { default: 1, hardMax: 1 },
+      acceptQueueRecvQAtBacklog: { default: true, hardMax: true, consecutiveProbeFailures: 3 },
+      diskFreeFloorBytes: { default: 16_106_127_360, hardMax: 10_737_418_240 },
+      diskFreeFloorFraction: { default: 0.2, hardMax: 0.1 },
+      admissionShedWindowSec: { default: 60, hardMax: 60 },
+      admissionShedFractionOfAttempts: { default: 0.5, hardMax: 0.7 },
+      rpcExhaustionDeltaPerRun: { default: 100, hardMax: 500 },
+      ...over.trips,
+    },
+    quiesce: { flatCounterConfirmSec: 20, edgeShutdownTimeoutSec: 60, ...over.quiesce },
+    safetyAbort: { cooldownMin: 60, ...over.safetyAbort },
+  };
+}
+
+function mkCore(alias, over = {}) {
+  const base = {
+    alias,
+    reachable: true,
+    systemd: { activeState: 'active', execMainStartTs: '2026-07-14T00:00:00Z', nRestarts: 0, mainPid: 100 },
+    workerPid: 200,
+    build: { commit: 'deadbeef', buildTime: '2026-07-01T00:00:00Z' },
+    rss: 1_000_000_000,
+    cgroup: { memoryCurrent: 4e9, memoryPeak: 5e9, memoryHigh: 8e9, memoryMax: 8e9, oomKills: 0, psiSomeAvg10: 0.01 },
+    listen: { recvQ: 0, backlog: 128, connectProbeOk: true },
+    diskFree: { bytes: 60e9, fraction: 0.5 },
+    api: { admissionRejected: 0, rpcFailovers: 0, rpcExhaustions: 0 },
+  };
+  const out = { ...base, ...over };
+  for (const k of ['systemd', 'cgroup', 'listen', 'diskFree', 'api']) {
+    if (over[k] === null) delete out[k];
+    else if (over[k]) out[k] = { ...base[k], ...over[k] };
+  }
+  return out;
+}
+
+const T0 = Date.parse('2026-07-14T12:00:00Z');
+const snap = (ms, cores) => ({ ts: ms, kind: 'light', cores });
+const healthyPair = () => [mkCore('core-1'), mkCore('core-2')];
+
+function run(overrides = {}) {
+  return evaluateTrips({
+    policy: mkPolicy(),
+    baseline: snap(T0 - 600_000, healthyPair()),
+    snapshot: snap(T0, healthyPair()),
+    snapshotHistory: [],
+    edgeWindow: { attempts: 20, shed: 0, windowSec: 60 },
+    ...overrides,
+  });
+}
+
+// ── evaluateTrips ────────────────────────────────────────────────────────────
+
+test('a healthy fleet fires no trips', () => {
+  assert.deepEqual(run(), []);
+});
+
+test('coreUnreachableFromBaseline fires for any baseline-reachable core lost', () => {
+  const fired = run({ snapshot: snap(T0, [mkCore('core-1'), { alias: 'core-2', reachable: false }]) });
+  assert.equal(fired.length, 1);
+  assert.equal(fired[0].trip, 'coreUnreachableFromBaseline');
+  assert.equal(fired[0].alias, 'core-2');
+  // hygiene (S6): fired trips carry aliases only
+  assert.ok(!JSON.stringify(fired).match(/100\.64|host|sshUser/));
+});
+
+test('a core missing from the snapshot entirely counts as unreachable', () => {
+  const fired = run({ snapshot: snap(T0, [mkCore('core-1')]) });
+  assert.deepEqual(fired.map((f) => [f.trip, f.alias]), [['coreUnreachableFromBaseline', 'core-2']]);
+});
+
+test('memoryPsiSomeAvg10 fires only when sustained across the full window', () => {
+  const hot = (ms, psi1) => snap(ms, [mkCore('core-1', { cgroup: { psiSomeAvg10: psi1 } }), mkCore('core-2')]);
+
+  // sustained 90s > 60s => fires once, for core-1 only
+  const sustained = run({
+    snapshotHistory: [hot(T0 - 90_000, 0.5), hot(T0 - 60_000, 0.5), hot(T0 - 30_000, 0.5)],
+    snapshot: hot(T0, 0.5),
+  });
+  assert.equal(sustained.length, 1);
+  assert.deepEqual([sustained[0].trip, sustained[0].alias, sustained[0].observed], ['memoryPsiSomeAvg10', 'core-1', 0.5]);
+
+  // exactly sustainSec of exceedance fires (>=)
+  const boundary = run({
+    snapshotHistory: [hot(T0 - 60_000, 0.5), hot(T0 - 30_000, 0.5)],
+    snapshot: hot(T0, 0.5),
+  });
+  assert.equal(boundary.length, 1);
+
+  // a dip inside the window breaks the sustain chain
+  const interrupted = run({
+    snapshotHistory: [hot(T0 - 90_000, 0.5), hot(T0 - 60_000, 0.5), hot(T0 - 30_000, 0.1)],
+    snapshot: hot(T0, 0.5),
+  });
+  assert.deepEqual(interrupted, []);
+
+  // exceedance younger than sustainSec does not fire
+  const short = run({
+    snapshotHistory: [hot(T0 - 30_000, 0.5)],
+    snapshot: hot(T0, 0.5),
+  });
+  assert.deepEqual(short, []);
+});
+
+test('memoryCurrentVsHighFraction fires at the fraction, falling back to memory.max', () => {
+  const viaHigh = run({
+    snapshot: snap(T0, [mkCore('core-1', { cgroup: { memoryCurrent: 7.8e9 } }), mkCore('core-2')]),
+  });
+  assert.equal(viaHigh.length, 1);
+  assert.equal(viaHigh[0].trip, 'memoryCurrentVsHighFraction');
+  assert.ok(viaHigh[0].observed >= 0.95);
+
+  const viaMax = run({
+    snapshot: snap(T0, [mkCore('core-1', { cgroup: { memoryCurrent: 7.8e9, memoryHigh: undefined } }), mkCore('core-2')]),
+  });
+  assert.equal(viaMax.length, 1);
+  assert.equal(viaMax[0].trip, 'memoryCurrentVsHighFraction');
+});
+
+test('oomKillDelta fires on counter growth vs baseline', () => {
+  const fired = run({
+    snapshot: snap(T0, [mkCore('core-1', { cgroup: { oomKills: 1 } }), mkCore('core-2')]),
+  });
+  assert.equal(fired.length, 1);
+  assert.deepEqual([fired[0].trip, fired[0].alias, fired[0].observed], ['oomKillDelta', 'core-1', 1]);
+});
+
+test('acceptQueueRecvQAtBacklog fires on Recv-Q at backlog', () => {
+  const fired = run({
+    snapshot: snap(T0, [mkCore('core-1', { listen: { recvQ: 128, backlog: 128 } }), mkCore('core-2')]),
+  });
+  assert.equal(fired.length, 1);
+  assert.equal(fired[0].trip, 'acceptQueueRecvQAtBacklog');
+  assert.match(fired[0].reason, /Recv-Q at backlog/);
+});
+
+test('acceptQueueRecvQAtBacklog fires on N consecutive connect-probe failures', () => {
+  const probeDown = (ms) => snap(ms, [mkCore('core-1', { listen: { connectProbeOk: false } }), mkCore('core-2')]);
+
+  const fired = run({
+    snapshotHistory: [probeDown(T0 - 20_000), probeDown(T0 - 10_000)],
+    snapshot: probeDown(T0),
+  });
+  assert.equal(fired.length, 1);
+  assert.match(fired[0].reason, /3 consecutive/);
+
+  // only two consecutive failures: below the policy threshold, no fire
+  const twoOnly = run({
+    snapshotHistory: [probeDown(T0 - 10_000)],
+    snapshot: probeDown(T0),
+  });
+  assert.deepEqual(twoOnly, []);
+});
+
+test('disk floors fire independently on bytes and fraction', () => {
+  const bytes = run({
+    snapshot: snap(T0, [mkCore('core-1', { diskFree: { bytes: 10e9 } }), mkCore('core-2')]),
+  });
+  assert.deepEqual(bytes.map((f) => f.trip), ['diskFreeFloorBytes']);
+
+  const fraction = run({
+    snapshot: snap(T0, [mkCore('core-1', { diskFree: { fraction: 0.15 } }), mkCore('core-2')]),
+  });
+  assert.deepEqual(fraction.map((f) => f.trip), ['diskFreeFloorFraction']);
+});
+
+test('admission shed fires from the edge-side window', () => {
+  const fired = run({ edgeWindow: { attempts: 10, shed: 6, windowSec: 60 } });
+  assert.equal(fired.length, 1);
+  assert.equal(fired[0].trip, 'admissionShedFractionOfAttempts');
+  assert.equal(fired[0].observed, 0.6);
+
+  // exactly at threshold does not "exceed"
+  assert.deepEqual(run({ edgeWindow: { attempts: 10, shed: 5, windowSec: 60 } }), []);
+  // absent edge window (e.g. soak) => only the fleet counter is live
+  assert.deepEqual(run({ edgeWindow: undefined }), []);
+});
+
+test('admission shed fires from the fleet counter delta when scenario-declared', () => {
+  const policy = mkPolicy();
+  policy.trips.admissionShedFractionOfAttempts.fleetDeltaPerRun = 50;
+  const fired = run({
+    policy,
+    edgeWindow: undefined,
+    snapshot: snap(T0, [
+      mkCore('core-1', { api: { admissionRejected: 40 } }),
+      mkCore('core-2', { api: { admissionRejected: 30 } }),
+    ]),
+  });
+  assert.equal(fired.length, 1);
+  assert.equal(fired[0].trip, 'admissionShedFractionOfAttempts');
+  assert.equal(fired[0].observed, 70);
+  assert.match(fired[0].reason, /fleet admission-rejection/);
+});
+
+test('rpcExhaustionDeltaPerRun fires on the fleet-wide counter delta', () => {
+  const fired = run({
+    snapshot: snap(T0, [
+      mkCore('core-1', { api: { rpcExhaustions: 80 } }),
+      mkCore('core-2', { api: { rpcExhaustions: 90 } }),
+    ]),
+  });
+  assert.equal(fired.length, 1);
+  assert.deepEqual([fired[0].trip, fired[0].observed, fired[0].threshold], ['rpcExhaustionDeltaPerRun', 170, 100]);
+});
+
+test('FAIL-CLOSED: a missing signal on a reachable core fires signal-unavailable', () => {
+  const noPsi = run({
+    snapshot: snap(T0, [mkCore('core-1', { cgroup: { psiSomeAvg10: undefined } }), mkCore('core-2')]),
+  });
+  assert.equal(noPsi.length, 1);
+  assert.deepEqual(
+    [noPsi[0].trip, noPsi[0].alias, noPsi[0].reason],
+    ['memoryPsiSomeAvg10', 'core-1', 'signal-unavailable'],
+  );
+
+  const noListen = run({
+    snapshot: snap(T0, [mkCore('core-1', { listen: null }), mkCore('core-2')]),
+  });
+  assert.deepEqual(noListen.map((f) => [f.trip, f.reason]), [['acceptQueueRecvQAtBacklog', 'signal-unavailable']]);
+
+  const noRpc = run({
+    snapshot: snap(T0, [mkCore('core-1', { api: { rpcExhaustions: undefined } }), mkCore('core-2')]),
+  });
+  assert.deepEqual(noRpc.map((f) => [f.trip, f.alias, f.reason]), [['rpcExhaustionDeltaPerRun', 'core-1', 'signal-unavailable']]);
+
+  const noDisk = run({
+    snapshot: snap(T0, [mkCore('core-1', { diskFree: null }), mkCore('core-2')]),
+  });
+  assert.deepEqual(new Set(noDisk.map((f) => f.trip)), new Set(['diskFreeFloorBytes', 'diskFreeFloorFraction']));
+  assert.ok(noDisk.every((f) => f.reason === 'signal-unavailable'));
+});
+
+test('an unreachable core fires only its reachability trip, not a signal storm', () => {
+  const fired = run({
+    snapshot: snap(T0, [mkCore('core-1'), { alias: 'core-2', reachable: false }]),
+  });
+  assert.deepEqual(fired.map((f) => f.trip), ['coreUnreachableFromBaseline']);
+});
+
+// ── quiesce ──────────────────────────────────────────────────────────────────
+
+function fakeClock() {
+  let now = 0;
+  return {
+    _now: () => now,
+    _sleep: async (ms) => { now += ms; },
+    _pollIntervalMs: 1000,
+  };
+}
+
+test('quiesce cancels in-flight handles, stops edges, confirms flat counters', async () => {
+  const cancelled = [];
+  const stops = [];
+  const inflight = [
+    { cancel: async () => { cancelled.push(1); } },
+    { cancel: async () => { cancelled.push(2); } },
+    { cancel: async () => { throw new Error('already gone'); } },
+  ];
+  const edges = [{ stop: async () => { stops.push('driver'); } }];
+  let flatCalls = 0;
+  const result = await quiesce({
+    inflight,
+    edges,
+    policy: mkPolicy({ quiesce: { flatCounterConfirmSec: 3 } }),
+    confirmFlat: async () => { flatCalls += 1; return true; },
+    ...fakeClock(),
+  });
+  assert.deepEqual(result, { cancelled: 2, edgeShutdown: true, flatConfirmed: true });
+  assert.deepEqual(cancelled, [1, 2]);
+  assert.deepEqual(stops, ['driver']);
+  assert.equal(flatCalls, 4); // t=0,1,2,3s => 3s consecutive flat
+});
+
+test('quiesce requires CONSECUTIVE flat readings — a bump resets the window', async () => {
+  const readings = [true, false, true, true, true, true];
+  let i = 0;
+  const result = await quiesce({
+    inflight: [],
+    edges: [],
+    policy: mkPolicy({ quiesce: { flatCounterConfirmSec: 3 } }),
+    confirmFlat: async () => readings[Math.min(i++, readings.length - 1)],
+    ...fakeClock(),
+  });
+  assert.equal(result.flatConfirmed, true);
+  assert.equal(i, 6); // reset at the false, then 3s consecutive from t=2s
+});
+
+test('quiesce times out when counters never go flat; confirmFlat errors fail closed', async () => {
+  let calls = 0;
+  const result = await quiesce({
+    inflight: [],
+    edges: [],
+    policy: mkPolicy({ quiesce: { flatCounterConfirmSec: 3, flatConfirmTimeoutSec: 5 } }),
+    confirmFlat: async () => { calls += 1; throw new Error('counter read failed'); },
+    ...fakeClock(),
+  });
+  assert.equal(result.flatConfirmed, false);
+  assert.ok(calls >= 5);
+});
+
+test('quiesce reports edgeShutdown:false when an edge has no stop() or stop hangs', async () => {
+  const noStop = await quiesce({
+    inflight: [],
+    edges: [{ stop: async () => {} }, {}],
+    policy: mkPolicy({ quiesce: { flatCounterConfirmSec: 1 } }),
+    confirmFlat: async () => true,
+    ...fakeClock(),
+  });
+  assert.equal(noStop.edgeShutdown, false);
+  assert.equal(noStop.flatConfirmed, true);
+
+  const hung = await quiesce({
+    inflight: [],
+    edges: [{ stop: () => new Promise(() => {}) }], // never resolves
+    policy: mkPolicy({ quiesce: { flatCounterConfirmSec: 1, edgeShutdownTimeoutSec: 0.05 } }),
+    confirmFlat: async () => true,
+    ...fakeClock(),
+  });
+  assert.equal(hung.edgeShutdown, false);
+});
+
+// ── safety-abort bookkeeping ─────────────────────────────────────────────────
+
+test('recordSafetyAbort blocks new runs until the cooldown passes', () => {
+  const runsDir = mkdtempSync(join(tmpdir(), 'rfc61-watch-'));
+  try {
+    const t = Date.parse('2026-07-14T12:00:00Z');
+    const record = recordSafetyAbort({
+      runsDir,
+      runId: 'certify-deadbeef-r1-20260714T120000Z',
+      trips: [{ trip: 'oomKillDelta', alias: 'core-1', observed: 1, threshold: 0 }],
+      policy: mkPolicy(),
+      _now: () => t,
+    });
+    assert.equal(record.cooldownUntil, new Date(t + 60 * 60_000).toISOString());
+
+    const during = safetyAbortGate({ runsDir, _now: () => t + 30 * 60_000 });
+    assert.deepEqual(during, { blocked: true, until: record.cooldownUntil });
+
+    const after = safetyAbortGate({ runsDir, _now: () => t + 61 * 60_000 });
+    assert.deepEqual(after, { blocked: false });
+  } finally {
+    rmSync(runsDir, { recursive: true, force: true });
+  }
+});
+
+test('safetyAbortGate: missing file unblocks; corrupt file fails closed', () => {
+  const runsDir = mkdtempSync(join(tmpdir(), 'rfc61-watch-'));
+  try {
+    assert.deepEqual(safetyAbortGate({ runsDir }), { blocked: false });
+    assert.deepEqual(safetyAbortGate({ runsDir: join(runsDir, 'does-not-exist') }), { blocked: false });
+
+    // a stale file with a PAST cooldown unblocks (operator clearance not needed)
+    writeFileSync(join(runsDir, 'safety-abort.json'), JSON.stringify({
+      ts: '2026-01-01T00:00:00Z', runId: 'old', trips: [], cooldownUntil: '2026-01-01T01:00:00Z',
+    }));
+    assert.deepEqual(safetyAbortGate({ runsDir }), { blocked: false });
+
+    // corrupt JSON or missing cooldownUntil => blocked (fail closed)
+    writeFileSync(join(runsDir, 'safety-abort.json'), '{not json');
+    assert.deepEqual(safetyAbortGate({ runsDir }), { blocked: true });
+    writeFileSync(join(runsDir, 'safety-abort.json'), JSON.stringify({ ts: 'x', runId: 'y', trips: [] }));
+    assert.deepEqual(safetyAbortGate({ runsDir }), { blocked: true });
+  } finally {
+    rmSync(runsDir, { recursive: true, force: true });
+  }
+});
+
+test('recordSafetyAbort creates the runs dir and keeps aliases-only evidence', () => {
+  const base = mkdtempSync(join(tmpdir(), 'rfc61-watch-'));
+  try {
+    const runsDir = join(base, 'nested', 'runs');
+    const record = recordSafetyAbort({
+      runsDir,
+      runId: 'r',
+      trips: [{ trip: 'coreUnreachableFromBaseline', alias: 'core-2', observed: 1, threshold: 1 }],
+      policy: mkPolicy(),
+    });
+    assert.equal(safetyAbortGate({ runsDir, _now: () => Date.now() }).blocked, true);
+    assert.ok(!JSON.stringify(record).match(/100\.64|sshUser|@/));
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## What

Phase 0 of **OT-RFC-61** ([dkgv10-spec PR #141](https://github.com/OriginTrail/dkgv10-spec/pull/141)): the OT-RFC-59 single-file certification harness generalized into a modular `testnet/` workspace. Zero runtime dependencies (Node ≥ 20 built-ins, ESM, no build step — runs from a laptop without compiling the monorepo). `node --test`: **194/194 green**.

## Modules

| Module | Role |
| --- | --- |
| `lib/config` | fleet/policy/scenario loading (collect-all validation), S3 tighten-only enforcement with per-trip looseness directions, **S2 credential-isolation check** — autonomous mode refuses without a mutation-incapable forced-command key |
| `lib/ssh` + `lib/fleet` | bounded read-only SSH transport; one compound k=v snapshot (systemd, worker RSS, cgroup memory/PSI/oom, `ss` Recv-Q + connect probe, disk); **build-identity attestation** from `/api/status` commit bound to PID/start-ts; journal cursors + versioned 12-class forbidden-signature ledger (never-silent-zeroes) |
| `lib/edge` | daemon client with every route verified against `main` at file:line (create / share-async / publish-async / job polling / query views / catchup / SSE with gap tracking); CLI runner; deterministic payloads with rfc59 control fixtures; chunked byte-exact readback |
| `lib/scoring` + `lib/watch` | closed failure enum, nearest-rank percentiles over successes only, **mandatory coverage gates** (minSamples/minSuccessRate), fail-closed S3 trips, quiesce controller, `SAFETY_ABORT` + cooldown gate |
| `lib/scenario` + `bin/harness` | certify workload runner (waves, lane pairs, recovery re-scoring, snapshot/trip loop, soak, signature deltas); modes `selftest \| monitor \| baseline \| certify`, exit codes 0/1/2/3/4 |

Scenario #1 (`scenarios/certify-100.json`) is the frozen RFC-59 certify battery — the Phase 0 exit gate is reproducing those runs under this tool.

## Live validation (read-only, done)

`monitor --once` and `baseline` ran against the 4-core Base-Sepolia fleet: all cores attested at canary `94f3c78c`, valid journal cursors, Recv-Q 0, correct RSS/memory/disk. The monitor caught core-1 mid worker-recycle during the canary auto-update — the §3.1 moving-target behavior, detected as designed. Evidence hygiene verified: no hosts/IPs/identities in emitted records (aliases only; real topology lives in gitignored `fleet.json`).

## Not in Phase 0 (per RFC rollout)

- Scored `certify` against the live fleet (operator-triggered; needs funded wallets + CG preflight, currently honest `skipped` checks listed in `notRun`).
- Phase 1: observer edge + propagation anchors + full op matrix; Phase 2: goal layer (`/goal`); Phase 3: trend store + metrics-backend convergence.
- Node-side diagnostics flagged in RFC §10 (per-peer sync attribution, source-aware GET, SSE op identifiers).

See `testnet/STATUS.md` for the detailed state and known gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)