### PR TITLE
fix(sync): retry SWM pages with fresh authenticated envelopes

### DIFF
--- a/packages/agent/src/dkg-agent-constants.ts
+++ b/packages/agent/src/dkg-agent-constants.ts
@@ -18,7 +18,7 @@ export const SYNC_PAGE_RETRY_ATTEMPTS = 3;
 export const SYNC_TOTAL_TIMEOUT_MS = 120_000;
 /** Per-page timeout for sync when we have budget (relay links can be slow). */
 export const SYNC_PAGE_TIMEOUT_MS = 45_000;
-/** Fresh signed request attempts; the lower ProtocolRouter is capped at one attempt per envelope. */
+/** Fresh signed request attempts; each envelope is marked single-use at the ProtocolRouter boundary. */
 export const SYNC_ROUTER_ATTEMPTS = 3;
 export const SYNC_PROTOCOL_CHECK_ATTEMPTS = 3;
 export const SYNC_PROTOCOL_CHECK_DELAY_MS = 500;

--- a/packages/agent/src/dkg-agent-constants.ts
+++ b/packages/agent/src/dkg-agent-constants.ts
@@ -18,7 +18,7 @@ export const SYNC_PAGE_RETRY_ATTEMPTS = 3;
 export const SYNC_TOTAL_TIMEOUT_MS = 120_000;
 /** Per-page timeout for sync when we have budget (relay links can be slow). */
 export const SYNC_PAGE_TIMEOUT_MS = 45_000;
-/** ProtocolRouter.send retries internally 3 times with the same timeout; cap so 3× fits in remaining budget. */
+/** Fresh signed request attempts; the lower ProtocolRouter is capped at one attempt per envelope. */
 export const SYNC_ROUTER_ATTEMPTS = 3;
 export const SYNC_PROTOCOL_CHECK_ATTEMPTS = 3;
 export const SYNC_PROTOCOL_CHECK_DELAY_MS = 500;

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -4301,15 +4301,15 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       // back NOW to advance pagination); `sendToPeer` returns the
       // response bytes directly, and sync's own `withRetry`
       // (sync-transport.ts) handles retry + backoff. Force one lower-layer
-      // attempt per signed envelope: ProtocolRouter's default retry loop would
-      // otherwise resend the same requestId after a slow response, and the
-      // responder's replay defence would correctly deny it before the outer
-      // sync retry could mint fresh bytes. The per-attempt `messageId` remains
-      // unused by this raw adapter.
-      send: async (peerId, protocolId, data, sendTimeoutMs, _messageId, sendSignal, maxTransportAttempts) =>
+      // attempt per signed envelope: ProtocolRouter's default retry/pooling
+      // paths would otherwise resend the same requestId after a slow response,
+      // and the responder's replay defence would correctly deny it before the
+      // outer sync retry could mint fresh bytes. The per-attempt `messageId`
+      // remains unused by this raw adapter.
+      send: async (peerId, protocolId, data, sendTimeoutMs, _messageId, sendSignal) =>
         this.messenger.sendToPeer(peerId, protocolId, data, {
           timeoutMs: sendTimeoutMs,
-          maxAttempts: maxTransportAttempts,
+          payloadReuse: 'single-use',
           signal: sendSignal,
         }),
       logWarn: (opCtx, message) => this.log.warn(opCtx, message),

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -152,6 +152,7 @@ import { SyncVerifyWorker } from './sync-verify-worker.js';
 import { bindRandomSampling, type RandomSamplingHandle, type RandomSamplingStatus } from './random-sampling-bind.js';
 import { connectToMultiaddr, ensurePeerConnected as ensurePeerConnectedAtom, primeCatchupConnections as primeCatchupConnectionsAtom } from './p2p/peer-connect.js';
 import { Messenger, type SloProtocolStats } from './p2p/messenger.js';
+import { createSingleUseSyncSender } from './p2p/sync-transport.js';
 import { NetworkAdmissionService } from './p2p/network-admission.js';
 import {
   NetworkAdmissionCoordinator,
@@ -4299,19 +4300,11 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       // ~2.9 GB node-ui.db bloat — see PROTOCOL_SYNC declaration). Sync
       // RPC is synchronous-by-contract (the caller needs the page bytes
       // back NOW to advance pagination); `sendToPeer` returns the
-      // response bytes directly, and sync's own `withRetry`
-      // (sync-transport.ts) handles retry + backoff. Force one lower-layer
-      // attempt per signed envelope: ProtocolRouter's default retry/pooling
-      // paths would otherwise resend the same requestId after a slow response,
-      // and the responder's replay defence would correctly deny it before the
-      // outer sync retry could mint fresh bytes. The per-attempt `messageId`
-      // remains unused by this raw adapter.
-      send: async (peerId, protocolId, data, sendTimeoutMs, _messageId, sendSignal) =>
-        this.messenger.sendToPeer(peerId, protocolId, data, {
-          timeoutMs: sendTimeoutMs,
-          payloadReuse: 'single-use',
-          signal: sendSignal,
-        }),
+      // response bytes directly, and sync's own transport handles fresh-envelope
+      // retry + backoff. The named factory owns the single-use router policy so
+      // lifecycle code cannot accidentally configure authenticated sync bytes as
+      // reusable.
+      send: createSingleUseSyncSender(this.messenger),
       logWarn: (opCtx, message) => this.log.warn(opCtx, message),
       logInfo: (opCtx, message) => this.log.info(opCtx, message),
       logDebug: (opCtx, message) => this.log.debug(opCtx, message),

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -4300,12 +4300,18 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       // RPC is synchronous-by-contract (the caller needs the page bytes
       // back NOW to advance pagination); `sendToPeer` returns the
       // response bytes directly, and sync's own `withRetry`
-      // (sync-transport.ts) handles retry + backoff. The per-attempt
-      // `messageId` minted by sync-transport.ts is now unused by this
-      // adapter — harmless, left in place to keep the transport surface
-      // stable (reverts rc.9 PR-E for sync only).
-      send: async (peerId, protocolId, data, sendTimeoutMs, _messageId, sendSignal) =>
-        this.messenger.sendToPeer(peerId, protocolId, data, { timeoutMs: sendTimeoutMs, signal: sendSignal }),
+      // (sync-transport.ts) handles retry + backoff. Force one lower-layer
+      // attempt per signed envelope: ProtocolRouter's default retry loop would
+      // otherwise resend the same requestId after a slow response, and the
+      // responder's replay defence would correctly deny it before the outer
+      // sync retry could mint fresh bytes. The per-attempt `messageId` remains
+      // unused by this raw adapter.
+      send: async (peerId, protocolId, data, sendTimeoutMs, _messageId, sendSignal, maxTransportAttempts) =>
+        this.messenger.sendToPeer(peerId, protocolId, data, {
+          timeoutMs: sendTimeoutMs,
+          maxAttempts: maxTransportAttempts,
+          signal: sendSignal,
+        }),
       logWarn: (opCtx, message) => this.log.warn(opCtx, message),
       logInfo: (opCtx, message) => this.log.info(opCtx, message),
       logDebug: (opCtx, message) => this.log.debug(opCtx, message),

--- a/packages/agent/src/p2p/messenger.ts
+++ b/packages/agent/src/p2p/messenger.ts
@@ -186,11 +186,11 @@ export interface MessengerDeps {
 export interface SendOpts {
   timeoutMs?: number;
   /**
-   * Maximum ProtocolRouter attempts for these exact bytes. Authenticated
-   * callers with single-use nonces should set `1` and own fresh-payload
-   * retries above Messenger.
+   * Whether the router may reuse these exact bytes for retry, pooling, or
+   * multi-path delivery. Authenticated callers with single-use nonces should
+   * select `single-use` and rebuild the payload above Messenger when retrying.
    */
-  maxAttempts?: number;
+  payloadReuse?: 'reusable' | 'single-use';
   signal?: AbortSignal;
 }
 

--- a/packages/agent/src/p2p/messenger.ts
+++ b/packages/agent/src/p2p/messenger.ts
@@ -10,6 +10,7 @@ import {
   type MessageIdempotencyStore,
   type ProtocolOutboxEntry,
   type ProtocolRouter,
+  type SendOptions,
 } from '@origintrail-official/dkg-core';
 import {
   OutboxDrainer,
@@ -183,16 +184,8 @@ export interface MessengerDeps {
   outboxDrain?: OutboxDrainerOptions;
 }
 
-export interface SendOpts {
-  timeoutMs?: number;
-  /**
-   * Whether the router may reuse these exact bytes for retry, pooling, or
-   * multi-path delivery. Authenticated callers with single-use nonces should
-   * select `single-use` and rebuild the payload above Messenger when retrying.
-   */
-  payloadReuse?: 'reusable' | 'single-use';
-  signal?: AbortSignal;
-}
+/** Router options exposed by Messenger's legacy pass-through send. */
+export type SendOpts = Pick<SendOptions, 'timeoutMs' | 'payloadReuse' | 'signal'>;
 
 export interface SendReliableOpts {
   /**

--- a/packages/agent/src/p2p/messenger.ts
+++ b/packages/agent/src/p2p/messenger.ts
@@ -185,6 +185,12 @@ export interface MessengerDeps {
 
 export interface SendOpts {
   timeoutMs?: number;
+  /**
+   * Maximum ProtocolRouter attempts for these exact bytes. Authenticated
+   * callers with single-use nonces should set `1` and own fresh-payload
+   * retries above Messenger.
+   */
+  maxAttempts?: number;
   signal?: AbortSignal;
 }
 

--- a/packages/agent/src/p2p/sync-transport.ts
+++ b/packages/agent/src/p2p/sync-transport.ts
@@ -60,11 +60,10 @@ interface SyncSendParams {
    */
   requestFactory: () => Promise<Uint8Array>;
   /**
-   * Per-attempt send hook. Receives a fresh `messageId` on every
-   * attempt and a lower-layer attempt cap of `1` — see jsdoc on
-   * `sendSyncRequest` for the rationale. The lower transport must not replay
-   * these exact authenticated bytes; only this outer retry may try again after
-   * `requestFactory` has minted a fresh request ID.
+   * Per-attempt send hook. Receives a fresh `messageId` on every attempt — see
+   * jsdoc on `sendSyncRequest` for the rationale. Production owns the
+   * single-use payload policy at the Messenger adapter boundary; this helper
+   * owns only rebuilding the authenticated request between outer retries.
    */
   send: (
     peerId: string,
@@ -72,8 +71,7 @@ interface SyncSendParams {
     data: Uint8Array,
     timeoutMs: number,
     messageId: string,
-    signal: AbortSignal | undefined,
-    maxTransportAttempts: 1,
+    signal?: AbortSignal,
   ) => Promise<Uint8Array>;
   /**
    * Optional per-attempt response validator. Throwing here keeps the attempt
@@ -105,7 +103,6 @@ export async function sendSyncRequest(params: SyncSendParams): Promise<Uint8Arra
           params.timeoutMs,
           messageId,
           params.signal,
-          1,
         );
       } catch (error) {
         markSyncTransportFailure(error);

--- a/packages/agent/src/p2p/sync-transport.ts
+++ b/packages/agent/src/p2p/sync-transport.ts
@@ -1,6 +1,37 @@
 import { randomUUID } from 'node:crypto';
 import { withRetry, withSpan, getMetrics } from '@origintrail-official/dkg-core';
 import { markSyncTransportFailure } from '../sync/error-tags.js';
+import type { Messenger } from './messenger.js';
+
+/**
+ * Per-attempt sync sender. Production instances must be created with
+ * {@link createSingleUseSyncSender} so the router never reuses authenticated
+ * envelope bytes before this transport can rebuild them for an outer retry.
+ */
+export type SingleUseSyncSender = (
+  peerId: string,
+  protocolId: string,
+  data: Uint8Array,
+  timeoutMs: number,
+  messageId: string,
+  signal?: AbortSignal,
+) => Promise<Uint8Array>;
+
+/**
+ * Own the sync payload-reuse invariant at the sync transport boundary.
+ * `messageId` remains part of the callback contract for test/telemetry
+ * stability, but raw sync delivery does not use the reliable-message frame.
+ */
+export function createSingleUseSyncSender(
+  messenger: Pick<Messenger, 'sendToPeer'>,
+): SingleUseSyncSender {
+  return (peerId, protocolId, data, timeoutMs, _messageId, signal) =>
+    messenger.sendToPeer(peerId, protocolId, data, {
+      timeoutMs,
+      payloadReuse: 'single-use',
+      signal,
+    });
+}
 
 /**
  * Sync-page transport. Wraps `withRetry` around a per-attempt
@@ -60,19 +91,12 @@ interface SyncSendParams {
    */
   requestFactory: () => Promise<Uint8Array>;
   /**
-   * Per-attempt send hook. Receives a fresh `messageId` on every attempt — see
-   * jsdoc on `sendSyncRequest` for the rationale. Production owns the
-   * single-use payload policy at the Messenger adapter boundary; this helper
-   * owns only rebuilding the authenticated request between outer retries.
+   * Per-attempt single-use send hook. Receives a fresh `messageId` on every
+   * attempt — see jsdoc on `sendSyncRequest` for the rationale. Production
+   * callers construct it with `createSingleUseSyncSender`; this helper owns
+   * rebuilding the authenticated request between outer retries.
    */
-  send: (
-    peerId: string,
-    protocolId: string,
-    data: Uint8Array,
-    timeoutMs: number,
-    messageId: string,
-    signal?: AbortSignal,
-  ) => Promise<Uint8Array>;
+  send: SingleUseSyncSender;
   /**
    * Optional per-attempt response validator. Throwing here keeps the attempt
    * inside `withRetry`, which lets sync-level retry sentinels share the same

--- a/packages/agent/src/p2p/sync-transport.ts
+++ b/packages/agent/src/p2p/sync-transport.ts
@@ -61,7 +61,10 @@ interface SyncSendParams {
   requestFactory: () => Promise<Uint8Array>;
   /**
    * Per-attempt send hook. Receives a fresh `messageId` on every
-   * attempt — see jsdoc on `sendSyncRequest` for the rationale.
+   * attempt and a lower-layer attempt cap of `1` — see jsdoc on
+   * `sendSyncRequest` for the rationale. The lower transport must not replay
+   * these exact authenticated bytes; only this outer retry may try again after
+   * `requestFactory` has minted a fresh request ID.
    */
   send: (
     peerId: string,
@@ -69,7 +72,8 @@ interface SyncSendParams {
     data: Uint8Array,
     timeoutMs: number,
     messageId: string,
-    signal?: AbortSignal,
+    signal: AbortSignal | undefined,
+    maxTransportAttempts: 1,
   ) => Promise<Uint8Array>;
   /**
    * Optional per-attempt response validator. Throwing here keeps the attempt
@@ -101,6 +105,7 @@ export async function sendSyncRequest(params: SyncSendParams): Promise<Uint8Arra
           params.timeoutMs,
           messageId,
           params.signal,
+          1,
         );
       } catch (error) {
         markSyncTransportFailure(error);

--- a/packages/agent/src/sync/requester/page-fetch.ts
+++ b/packages/agent/src/sync/requester/page-fetch.ts
@@ -132,9 +132,9 @@ interface FetchSyncPagesParams {
    * enabled silent replay of stale cached responses past sync's
    * app-layer freshness gate (`SYNC_AUTH_MAX_AGE_MS`). Fresh-per-
    * attempt is the only design that holds under all timing scenarios —
-   * see jsdoc on `sendSyncRequest` for the full rationale. The final argument
-   * is always `1`: a lower-layer retry would resend the same authenticated
-   * bytes instead of returning control here to build a fresh envelope.
+   * see jsdoc on `sendSyncRequest` for the full rationale. The production
+   * adapter independently marks each envelope as single-use at the router
+   * boundary so lower layers cannot replay it.
    */
   send: (
     peerId: string,
@@ -142,8 +142,7 @@ interface FetchSyncPagesParams {
     data: Uint8Array,
     timeoutMs: number,
     messageId: string,
-    signal: AbortSignal | undefined,
-    maxTransportAttempts: 1,
+    signal?: AbortSignal,
   ) => Promise<Uint8Array>;
   logWarn: (ctx: OperationContext, message: string) => void;
   logInfo: (ctx: OperationContext, message: string) => void;

--- a/packages/agent/src/sync/requester/page-fetch.ts
+++ b/packages/agent/src/sync/requester/page-fetch.ts
@@ -132,7 +132,9 @@ interface FetchSyncPagesParams {
    * enabled silent replay of stale cached responses past sync's
    * app-layer freshness gate (`SYNC_AUTH_MAX_AGE_MS`). Fresh-per-
    * attempt is the only design that holds under all timing scenarios —
-   * see jsdoc on `sendSyncRequest` for the full rationale.
+   * see jsdoc on `sendSyncRequest` for the full rationale. The final argument
+   * is always `1`: a lower-layer retry would resend the same authenticated
+   * bytes instead of returning control here to build a fresh envelope.
    */
   send: (
     peerId: string,
@@ -140,7 +142,8 @@ interface FetchSyncPagesParams {
     data: Uint8Array,
     timeoutMs: number,
     messageId: string,
-    signal?: AbortSignal,
+    signal: AbortSignal | undefined,
+    maxTransportAttempts: 1,
   ) => Promise<Uint8Array>;
   logWarn: (ctx: OperationContext, message: string) => void;
   logInfo: (ctx: OperationContext, message: string) => void;

--- a/packages/agent/src/sync/requester/page-fetch.ts
+++ b/packages/agent/src/sync/requester/page-fetch.ts
@@ -1,6 +1,9 @@
 import type { OperationContext } from '@origintrail-official/dkg-core';
 import type { Quad } from '@origintrail-official/dkg-storage';
-import { sendSyncRequest } from '../../p2p/sync-transport.js';
+import {
+  sendSyncRequest,
+  type SingleUseSyncSender,
+} from '../../p2p/sync-transport.js';
 import { markSyncPeerResponded } from '../error-tags.js';
 import { appendInPlace } from '../append-in-place.js';
 import type { SyncPhase } from '../auth/request-build.js';
@@ -132,18 +135,11 @@ interface FetchSyncPagesParams {
    * enabled silent replay of stale cached responses past sync's
    * app-layer freshness gate (`SYNC_AUTH_MAX_AGE_MS`). Fresh-per-
    * attempt is the only design that holds under all timing scenarios —
-   * see jsdoc on `sendSyncRequest` for the full rationale. The production
-   * adapter independently marks each envelope as single-use at the router
-   * boundary so lower layers cannot replay it.
+   * see jsdoc on `sendSyncRequest` for the full rationale. Production creates
+   * this hook with `createSingleUseSyncSender`, which prevents lower layers
+   * from replaying an envelope before the outer retry can rebuild it.
    */
-  send: (
-    peerId: string,
-    protocolId: string,
-    data: Uint8Array,
-    timeoutMs: number,
-    messageId: string,
-    signal?: AbortSignal,
-  ) => Promise<Uint8Array>;
+  send: SingleUseSyncSender;
   logWarn: (ctx: OperationContext, message: string) => void;
   logInfo: (ctx: OperationContext, message: string) => void;
   logDebug: (ctx: OperationContext, message: string) => void;

--- a/packages/agent/test/p2p-messenger.test.ts
+++ b/packages/agent/test/p2p-messenger.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { Messenger } from '../src/p2p/messenger.js';
-import type { ProtocolRouter } from '@origintrail-official/dkg-core';
+import type { ProtocolRouter, SendOptions } from '@origintrail-official/dkg-core';
 
 // NO MOCKS: the Messenger is real; `router` is a DI seam it's designed to
 // accept (ProtocolRouter). We substitute a plain hand-rolled recorder that
@@ -17,10 +17,10 @@ function recorder<A extends unknown[], R>(impl: (...args: A) => R) {
 const PEER_A = '12D3KooWAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
 const PEER_B = '12D3KooWQz2bQbQueABKRSjV9koF8VYsXk5TdCsUmPf5zAEZg3q6';
 
-// router.send's 4th arg is the send-options object ({ timeoutMs?, signal? }).
+// router.send's 4th arg is the core SendOptions contract.
 type RouterSendRecorder = ReturnType<
   typeof recorder<
-    [string, string, Uint8Array, { timeoutMs?: number; signal?: AbortSignal } | undefined],
+    [string, string, Uint8Array, SendOptions | undefined],
     Promise<Uint8Array>
   >
 >;
@@ -65,12 +65,13 @@ describe('Messenger.sendToPeer', () => {
     expect(out).toEqual(new Uint8Array([0x01, 0x02]));
   });
 
-  it('forwards timeoutMs and signal to router.send', async () => {
+  it('forwards timeoutMs, payloadReuse, and signal to router.send', async () => {
     const { messenger, mocks } = makeMessenger();
     const controller = new AbortController();
 
     await messenger.sendToPeer(PEER_A, '/dkg/test/1.0.0', new Uint8Array([0xff]), {
       timeoutMs: 5000,
+      payloadReuse: 'single-use',
       signal: controller.signal,
     });
 
@@ -78,7 +79,7 @@ describe('Messenger.sendToPeer', () => {
       PEER_A,
       '/dkg/test/1.0.0',
       expect.any(Uint8Array),
-      { timeoutMs: 5000, signal: controller.signal },
+      { timeoutMs: 5000, payloadReuse: 'single-use', signal: controller.signal },
     ]);
   });
 

--- a/packages/agent/test/sync-fresh-per-attempt.test.ts
+++ b/packages/agent/test/sync-fresh-per-attempt.test.ts
@@ -1057,56 +1057,6 @@ describe('fetchSyncPages: fresh envelope + fresh messageId per retry attempt', (
     }
   });
 
-  it('caps the lower transport at one attempt for every signed envelope', async () => {
-    const observedTransportAttemptCaps: Array<number | undefined> = [];
-    let sendAttempts = 0;
-
-    await runFetchWithFakeTimers(
-      fetchSyncPages({
-        ctx: makeCtx(),
-        remotePeerId: REMOTE_PEER_ID,
-        contextGraphId: CG_ID,
-        includeSharedMemory: true,
-        phase: 'meta',
-        graphUri: GRAPH_URI,
-        deadline: Date.now() + 60_000,
-        syncPageTimeoutMs: 5_000,
-        syncRouterAttempts: 3,
-        syncPageRetryAttempts: 3,
-        syncPageSize: 100,
-        syncDeniedResponse: '#DENIED',
-        debugSyncProgress: false,
-        protocolSync: PROTOCOL_ID,
-        checkpointStore: {
-          get: () => undefined,
-          set: () => {},
-          delete: () => {},
-        },
-        buildSyncRequest: async () => new TextEncoder().encode(`request-${sendAttempts + 1}`),
-        parseAndFilter: singleQuadParser,
-        send: async (
-          _peerId,
-          _protocolId,
-          _data,
-          _timeoutMs,
-          _messageId,
-          _signal,
-          maxTransportAttempts,
-        ) => {
-          observedTransportAttemptCaps.push(maxTransportAttempts);
-          sendAttempts++;
-          if (sendAttempts < 3) throw new Error(`slow response ${sendAttempts}`);
-          return new Uint8Array();
-        },
-        logWarn: noopLog,
-        logInfo: noopLog,
-        logDebug: noopLog,
-      }),
-    );
-
-    expect(observedTransportAttemptCaps).toEqual([1, 1, 1]);
-  });
-
   /**
    * Codex review #569 follow-up #8: stable messageId across retries
    * is unsafe because the substrate's 24h outbox-retry window can

--- a/packages/agent/test/sync-fresh-per-attempt.test.ts
+++ b/packages/agent/test/sync-fresh-per-attempt.test.ts
@@ -1057,6 +1057,56 @@ describe('fetchSyncPages: fresh envelope + fresh messageId per retry attempt', (
     }
   });
 
+  it('caps the lower transport at one attempt for every signed envelope', async () => {
+    const observedTransportAttemptCaps: Array<number | undefined> = [];
+    let sendAttempts = 0;
+
+    await runFetchWithFakeTimers(
+      fetchSyncPages({
+        ctx: makeCtx(),
+        remotePeerId: REMOTE_PEER_ID,
+        contextGraphId: CG_ID,
+        includeSharedMemory: true,
+        phase: 'meta',
+        graphUri: GRAPH_URI,
+        deadline: Date.now() + 60_000,
+        syncPageTimeoutMs: 5_000,
+        syncRouterAttempts: 3,
+        syncPageRetryAttempts: 3,
+        syncPageSize: 100,
+        syncDeniedResponse: '#DENIED',
+        debugSyncProgress: false,
+        protocolSync: PROTOCOL_ID,
+        checkpointStore: {
+          get: () => undefined,
+          set: () => {},
+          delete: () => {},
+        },
+        buildSyncRequest: async () => new TextEncoder().encode(`request-${sendAttempts + 1}`),
+        parseAndFilter: singleQuadParser,
+        send: async (
+          _peerId,
+          _protocolId,
+          _data,
+          _timeoutMs,
+          _messageId,
+          _signal,
+          maxTransportAttempts,
+        ) => {
+          observedTransportAttemptCaps.push(maxTransportAttempts);
+          sendAttempts++;
+          if (sendAttempts < 3) throw new Error(`slow response ${sendAttempts}`);
+          return new Uint8Array();
+        },
+        logWarn: noopLog,
+        logInfo: noopLog,
+        logDebug: noopLog,
+      }),
+    );
+
+    expect(observedTransportAttemptCaps).toEqual([1, 1, 1]);
+  });
+
   /**
    * Codex review #569 follow-up #8: stable messageId across retries
    * is unsafe because the substrate's 24h outbox-retry window can

--- a/packages/agent/test/sync-single-use-policy-wiring.test.ts
+++ b/packages/agent/test/sync-single-use-policy-wiring.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fetchSyncPagesMock = vi.hoisted(() => vi.fn(async (params: any) => {
+  await params.send(
+    params.remotePeerId,
+    params.protocolSync,
+    new Uint8Array([0xA1]),
+    1_234,
+    'fresh-message-id',
+    params.signal,
+  );
+  return {
+    quads: [],
+    bytesReceived: 0,
+    resumedFromOffset: 0,
+    nextOffset: 0,
+    checkpointKey: 'test-checkpoint',
+    completed: true,
+    timedOut: false,
+  };
+}));
+
+vi.mock('../src/sync/requester/page-fetch.js', () => ({
+  fetchSyncPages: fetchSyncPagesMock,
+}));
+
+import { PROTOCOL_SYNC } from '@origintrail-official/dkg-core';
+import { LifecycleSyncMethods } from '../src/dkg-agent-lifecycle.js';
+
+describe('LifecycleSyncMethods sync transport policy wiring', () => {
+  beforeEach(() => {
+    fetchSyncPagesMock.mockClear();
+  });
+
+  it('marks every real sync adapter send as a single-use payload', async () => {
+    const sendToPeer = vi.fn(async () => new Uint8Array());
+    const stopController = new AbortController();
+    const agent: any = {
+      node: { stopSignal: stopController.signal },
+      messenger: { sendToPeer },
+      syncCheckpoints: new Map(),
+      buildSyncRequest: vi.fn(),
+      getOrCreateSyncVerifyWorker: () => ({ parseAndFilter: vi.fn() }),
+      log: { warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+    };
+
+    await (LifecycleSyncMethods.prototype.fetchSyncPages as any).call(
+      agent,
+      { operationId: 'sync-policy-wiring' },
+      'remote-peer',
+      'private-context-graph',
+      true,
+      'meta',
+      'did:dkg:private-context-graph/_meta',
+      Date.now() + 60_000,
+    );
+
+    expect(fetchSyncPagesMock).toHaveBeenCalledTimes(1);
+    expect(sendToPeer).toHaveBeenCalledTimes(1);
+    expect(sendToPeer).toHaveBeenCalledWith(
+      'remote-peer',
+      PROTOCOL_SYNC,
+      new Uint8Array([0xA1]),
+      {
+        timeoutMs: 1_234,
+        payloadReuse: 'single-use',
+        signal: expect.any(AbortSignal),
+      },
+    );
+  });
+});

--- a/packages/core/src/protocol-router.ts
+++ b/packages/core/src/protocol-router.ts
@@ -66,6 +66,16 @@ export interface SendOptions {
   /** Overall send timeout (resolver + dial + write + read). Default {@link DEFAULT_SEND_TIMEOUT_MS}. */
   timeoutMs?: number;
   /**
+   * Maximum one-shot wire attempts for this exact payload. Defaults to **3**.
+   *
+   * Set this to `1` when a higher layer owns retries and must rebuild the
+   * payload between attempts (for example, authenticated sync envelopes with
+   * single-use request IDs). Retrying those bytes inside `ProtocolRouter`
+   * would replay an already-consumed nonce before the higher layer can mint a
+   * fresh envelope.
+   */
+  maxAttempts?: number;
+  /**
    * Race up to N parallel `newStream` attempts across the peer's live
    * connections (different relay paths where the natural connection
    * list provides them). First successful response wins; loser
@@ -586,6 +596,9 @@ export class ProtocolRouter {
     const opts: SendOptions =
       typeof timeoutMsOrOpts === 'number' ? { timeoutMs: timeoutMsOrOpts } : timeoutMsOrOpts;
     const timeoutMs = opts.timeoutMs ?? DEFAULT_SEND_TIMEOUT_MS;
+    const maxAttempts = opts.maxAttempts === undefined || !Number.isFinite(opts.maxAttempts)
+      ? 3
+      : Math.max(1, Math.floor(opts.maxAttempts));
     const parallelPaths = Math.max(1, Math.floor(opts.parallelPaths ?? 1));
     const overallStartedAt = Date.now();
     const overallDeadline = AbortSignal.timeout(timeoutMs);
@@ -747,8 +760,9 @@ export class ProtocolRouter {
     // libp2p internally upgrades relay connections to direct during
     // dialProtocol/newStream (peerStore.merge triggers the connection manager
     // to dial the peer directly, closing the relay and any in-flight streams).
-    // We retry up to 3 times with back-off so the direct connection can
-    // stabilise before the next attempt.
+    // By default we retry up to 3 times with back-off so the direct connection
+    // can stabilise before the next attempt. Callers whose payload is
+    // single-use can set maxAttempts=1 and rebuild it in their outer retry.
     //
     // Per-call exclude-set for the fast path: when an existing-connection
     // reuse hits a recoverable failure (stream came back live but
@@ -763,7 +777,7 @@ export class ProtocolRouter {
     // specifically to recover from this case.
     const triedConnections = new WeakSet<ReusableConnection>();
     let lastErr: unknown;
-    for (let attempt = 0; attempt < 3; attempt++) {
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
       const remaining = timeoutMs - (Date.now() - startedAt);
       if (remaining <= 0) {
         lastErr = new Error('send timeout elapsed');
@@ -950,7 +964,7 @@ export class ProtocolRouter {
           triedConnections.add(pickedConnection);
         }
         if (attemptSignal.aborted || overallSignal.aborted) throw err;
-        if (!isRecoverableSendError(err) || attempt >= 2) throw err;
+        if (!isRecoverableSendError(err) || attempt >= maxAttempts - 1) throw err;
         const backoff = (attempt + 1) * 500;
         // Make the backoff abortable so the overall deadline is
         // honored. Codex PR #560 round-5 caught: if the pool burned

--- a/packages/core/src/protocol-router.ts
+++ b/packages/core/src/protocol-router.ts
@@ -66,15 +66,15 @@ export interface SendOptions {
   /** Overall send timeout (resolver + dial + write + read). Default {@link DEFAULT_SEND_TIMEOUT_MS}. */
   timeoutMs?: number;
   /**
-   * Maximum one-shot wire attempts for this exact payload. Defaults to **3**.
+   * Whether these exact payload bytes may be reused by router-level delivery
+   * optimizations. Defaults to `reusable`.
    *
-   * Set this to `1` when a higher layer owns retries and must rebuild the
-   * payload between attempts (for example, authenticated sync envelopes with
-   * single-use request IDs). Retrying those bytes inside `ProtocolRouter`
-   * would replay an already-consumed nonce before the higher layer can mint a
-   * fresh envelope.
+   * `single-use` forces the one-shot transport, disables internal retries, and
+   * rejects multi-path fan-out. Use it for authenticated envelopes containing
+   * a single-use nonce; any retry must happen above `ProtocolRouter` after the
+   * caller rebuilds the payload.
    */
-  maxAttempts?: number;
+  payloadReuse?: 'reusable' | 'single-use';
   /**
    * Race up to N parallel `newStream` attempts across the peer's live
    * connections (different relay paths where the natural connection
@@ -596,10 +596,12 @@ export class ProtocolRouter {
     const opts: SendOptions =
       typeof timeoutMsOrOpts === 'number' ? { timeoutMs: timeoutMsOrOpts } : timeoutMsOrOpts;
     const timeoutMs = opts.timeoutMs ?? DEFAULT_SEND_TIMEOUT_MS;
-    const maxAttempts = opts.maxAttempts === undefined || !Number.isFinite(opts.maxAttempts)
-      ? 3
-      : Math.max(1, Math.floor(opts.maxAttempts));
+    const singleUsePayload = opts.payloadReuse === 'single-use';
+    const maxAttempts = singleUsePayload ? 1 : 3;
     const parallelPaths = Math.max(1, Math.floor(opts.parallelPaths ?? 1));
+    if (singleUsePayload && parallelPaths > 1) {
+      throw new Error('single-use payloads cannot use parallelPaths > 1');
+    }
     const overallStartedAt = Date.now();
     const overallDeadline = AbortSignal.timeout(timeoutMs);
     const stopSignal = this.node.stopSignal;
@@ -636,7 +638,7 @@ export class ProtocolRouter {
     // is exhausted.
     const overlay = this.pooledByLogical.get(protocolId);
     const memoizedVariant = this.peerWireVariantFor(peerIdStr, protocolId);
-    if (overlay && memoizedVariant !== 'one-shot') {
+    if (!singleUsePayload && overlay && memoizedVariant !== 'one-shot') {
       try {
         const remainingForPool = Math.max(0, timeoutMs - (Date.now() - overallStartedAt));
         const response = await overlay.pool.send(peerIdStr, data, {
@@ -761,8 +763,8 @@ export class ProtocolRouter {
     // dialProtocol/newStream (peerStore.merge triggers the connection manager
     // to dial the peer directly, closing the relay and any in-flight streams).
     // By default we retry up to 3 times with back-off so the direct connection
-    // can stabilise before the next attempt. Callers whose payload is
-    // single-use can set maxAttempts=1 and rebuild it in their outer retry.
+    // can stabilise before the next attempt. A single-use payload gets exactly
+    // one one-shot attempt and must be rebuilt by its caller before retrying.
     //
     // Per-call exclude-set for the fast path: when an existing-connection
     // reuse hits a recoverable failure (stream came back live but

--- a/packages/core/test/protocol-router.test.ts
+++ b/packages/core/test/protocol-router.test.ts
@@ -929,6 +929,30 @@ describe('ProtocolRouter', () => {
       expect(resolveCalls).toBe(3);
     });
 
+    it('honors maxAttempts=1 when a higher layer must rebuild single-use payloads', async () => {
+      let resolveCalls = 0;
+      let dialCalls = 0;
+      const router = makeRouter({
+        onResolve: () => { resolveCalls += 1; },
+        dialBehavior: async () => {
+          dialCalls += 1;
+          throw new Error('The operation was aborted due to timeout');
+        },
+      });
+
+      await expect(
+        router.send(
+          FAKE_PEER_ID,
+          '/dkg/test/single-use/1.0.0',
+          new Uint8Array([1, 2, 3]),
+          { timeoutMs: 5_000, maxAttempts: 1 },
+        ),
+      ).rejects.toThrow(/timeout/);
+
+      expect(dialCalls).toBe(1);
+      expect(resolveCalls).toBe(1);
+    });
+
     it('stops retrying once a resolver-re-prime followed by dial succeeds', async () => {
       let resolveCalls = 0;
       let dialCalls = 0;

--- a/packages/core/test/protocol-router.test.ts
+++ b/packages/core/test/protocol-router.test.ts
@@ -929,14 +929,51 @@ describe('ProtocolRouter', () => {
       expect(resolveCalls).toBe(3);
     });
 
-    it('honors maxAttempts=1 when a higher layer must rebuild single-use payloads', async () => {
+    it('uses one one-shot attempt for a single-use payload and skips pooling', async () => {
+      let resolveCalls = 0;
+      let dialCalls = 0;
+      let poolCalls = 0;
+      const protocolId = '/dkg/test/single-use/1.0.0';
+      const router = makeRouter({
+        onResolve: () => { resolveCalls += 1; },
+        dialBehavior: async () => {
+          dialCalls += 1;
+          throw new Error('The operation was aborted due to timeout');
+        },
+      });
+      (router as any).pooledByLogical.set(protocolId, {
+        logicalProtocolId: protocolId,
+        wireProtocolId: '/dkg/test/single-use-pooled/1.0.0',
+        pool: {
+          send: async () => {
+            poolCalls += 1;
+            return new Uint8Array([0xFF]);
+          },
+        },
+      });
+
+      await expect(
+        router.send(
+          FAKE_PEER_ID,
+          protocolId,
+          new Uint8Array([1, 2, 3]),
+          { timeoutMs: 5_000, payloadReuse: 'single-use' },
+        ),
+      ).rejects.toThrow(/timeout/);
+
+      expect(poolCalls).toBe(0);
+      expect(dialCalls).toBe(1);
+      expect(resolveCalls).toBe(1);
+    });
+
+    it('rejects multi-path fan-out for a single-use payload before any wire attempt', async () => {
       let resolveCalls = 0;
       let dialCalls = 0;
       const router = makeRouter({
         onResolve: () => { resolveCalls += 1; },
         dialBehavior: async () => {
           dialCalls += 1;
-          throw new Error('The operation was aborted due to timeout');
+          return makeStubStream(new Uint8Array([0xFF])) as any;
         },
       });
 
@@ -945,12 +982,12 @@ describe('ProtocolRouter', () => {
           FAKE_PEER_ID,
           '/dkg/test/single-use/1.0.0',
           new Uint8Array([1, 2, 3]),
-          { timeoutMs: 5_000, maxAttempts: 1 },
+          { payloadReuse: 'single-use', parallelPaths: 2 },
         ),
-      ).rejects.toThrow(/timeout/);
+      ).rejects.toThrow(/single-use payloads cannot use parallelPaths > 1/);
 
-      expect(dialCalls).toBe(1);
-      expect(resolveCalls).toBe(1);
+      expect(dialCalls).toBe(0);
+      expect(resolveCalls).toBe(0);
     });
 
     it('stops retrying once a resolver-re-prime followed by dial succeeds', async () => {


### PR DESCRIPTION
## Summary

- add a per-send ProtocolRouter attempt cap while preserving the existing three-attempt default
- make SWM sync use one lower wire attempt per authenticated envelope
- leave retry ownership with the sync layer so every retry mints a fresh request ID and signature

## Root cause

A slow authorized SWM page could consume its single-use request ID on the responder and then time out at the sender. ProtocolRouter retried the exact same signed bytes internally, so replay protection denied that retry before the outer sync layer could create a fresh envelope. Repeated cycles left metadata recovered but SWM at zero.

## Verification

- full workspace build: pass
- ProtocolRouter suite: 60/60
- sync freshness suite: 24/24
- SWM recovery and catch-up suites: 33/33
- CLI catch-up suites: 18/18
- six-node private-CG harness with autoApprove: pass; pre-admission fail-closed, automatic admission observed, root SWM 3/3 and subgraph SWM 5/5 recovered, state persisted after joiner restart