### PR TITLE
feat: add graph-scoped KA lifecycle and publish queue

### DIFF
--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -474,6 +474,13 @@ export function createListContextGraphsCacheInvalidatingStore(
         () => markProjectionDirty?.(),
       );
     },
+    replaceGraph: innerStore.replaceGraph
+      ? (graphUri, quads, options) => invalidateAfterMutation(
+          () => innerStore.replaceGraph!(graphUri, quads, options),
+          () => true,
+          () => markProjectionDirty?.(),
+        )
+      : undefined,
     listGraphs(options) {
       return innerStore.listGraphs(options);
     },

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -44,6 +44,10 @@ import {
   buildAuthorAttestationTypedData, buildUpdateAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1, type AuthorAttestationTypedData,
   buildAssertionSealQuads, buildAssertionPublishReceiptQuads,
   parseAssertionSealQuads, type AssertionSeal,
+  ASSERTION_SEAL_PREDICATES,
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  LegacyKnowledgeAssetReadOnlyError,
+  createGraphKnowledgeAssetScope,
   WORKSPACE_AGENT_ENCRYPTION_KEY_ALGORITHM_X25519,
   WORKSPACE_RECIPIENT_ENCRYPTION_KEY_PURPOSE,
   computeWorkspaceAgentEncryptionKeyProofPayload,
@@ -108,7 +112,13 @@ import {
   ACKCollector, StorageACKHandler,
   VerifyCollector, VerifyProposalHandler, buildVerificationMetadata,
   resolveWorkspaceAgentRecipients,
-  computeTripleHashV10 as computeTripleHash, computeFlatKCRootV10 as computeFlatKCRoot, skolemizeByEntity, isReservedSubject,
+  computeTripleHashV10 as computeTripleHash,
+  computeFlatKCRootV10 as computeFlatKCRoot,
+  computePrivateRootV10 as computePrivateRoot,
+  skolemizeByEntity,
+  skolemizeKnowledgeAsset,
+  skolemizeKnowledgeAssetParts,
+  isReservedSubject,
   canonicalPublishPayload,
   generatedPrivateCatalogTripleKeys,
   appendMissingGeneratedPrivateCatalogFloor,
@@ -148,10 +158,7 @@ import {
   type QueryRequest, type QueryResponse, type QueryAccessConfig, type LookupType,
 } from '@origintrail-official/dkg-query';
 import { DKGAgentWallet, type AgentWallet } from './agent-wallet.js';
-import {
-  prepareFinalizedLifecycleSwmForPublish,
-  sharedMemoryScopeForFinalizedLifecycle,
-} from './finalized-lifecycle-swm.js';
+import { sharedMemoryScopeForFinalizedLifecycle } from './finalized-lifecycle-swm.js';
 
 import { ProfileManager } from './profile-manager.js';
 import { DiscoveryClient, type SkillSearchOptions, type DiscoveredAgent, type DiscoveredOffering } from './discovery.js';
@@ -1628,6 +1635,12 @@ export class PublishMethods extends DKGAgentBase {
       precomputedUpdateAttestation?: PublishOptions['precomputedUpdateAttestation'];
       publisherOverride?: DKGPublisher;
       subGraphName?: string;
+      contentScopeVersion?: PublishOptions['contentScopeVersion'];
+      kaUal?: PublishOptions['kaUal'];
+      assertionVersion?: PublishOptions['assertionVersion'];
+      publicTripleCount?: PublishOptions['publicTripleCount'];
+      privateMerkleRoot?: PublishOptions['privateMerkleRoot'];
+      privateTripleCount?: PublishOptions['privateTripleCount'];
     },
   ): Promise<PublishResult> {
     const ctx = opts?.operationCtx ?? createOperationContext('update');
@@ -1738,9 +1751,8 @@ export class PublishMethods extends DKGAgentBase {
     const updateQuads = preparedUpdateCatalog?.quads ?? quads;
 
     const publisher = opts?.publisherOverride ?? this.publisher;
-    const result = await publisher.update(kaId, {
+    const publisherUpdateOptions = {
       contextGraphId,
-      quads: updateQuads,
       privateQuads,
       publisherPeerId: this.node.peerId.toString(),
       publishContextGraphId: updateOnChainId ?? undefined,
@@ -1748,6 +1760,12 @@ export class PublishMethods extends DKGAgentBase {
       onPhase,
       subGraphName: opts?.subGraphName,
       precomputedUpdateAttestation: opts?.precomputedUpdateAttestation,
+      contentScopeVersion: opts?.contentScopeVersion,
+      kaUal: opts?.kaUal,
+      assertionVersion: opts?.assertionVersion,
+      publicTripleCount: opts?.publicTripleCount,
+      privateMerkleRoot: opts?.privateMerkleRoot,
+      privateTripleCount: opts?.privateTripleCount,
       trustedNonManifestCatalogTriples:
         preparedUpdateCatalog?.trustedNonManifestCatalogTriples,
       v10UpdateACKProvider,
@@ -1758,7 +1776,10 @@ export class PublishMethods extends DKGAgentBase {
       // Curated → the chunked emitter the producer prefers to fan the updated
       // private payload out to CG members (member distribution). Public → undefined.
       encryptInlineChunked: updateEncryptInlineChunked,
-    });
+    };
+    const result = opts?.contentScopeVersion === GRAPH_KA_CONTENT_SCOPE_VERSION
+      ? await publisher.updateKnowledgeAssetFromSharedMemory(kaId, publisherUpdateOptions)
+      : await publisher.update(kaId, { ...publisherUpdateOptions, quads: updateQuads });
     this.log.info(ctx, `Update complete — status=${result.status}`);
 
     onPhase?.('broadcast', 'start');
@@ -2097,6 +2118,12 @@ export class PublishMethods extends DKGAgentBase {
     reservedKaId: bigint;
     /** Internal exact payload boundary used by seal-in-SWM migration. */
     rootEntities: string[];
+    contentScopeVersion: typeof GRAPH_KA_CONTENT_SCOPE_VERSION;
+    kaUal: string;
+    assertionVersion: string;
+    publicTripleCount: number;
+    privateMerkleRoot?: Uint8Array;
+    privateTripleCount: number;
     schemeVersion: number;
     chainId: bigint;
     kav10Address: string;
@@ -2119,6 +2146,73 @@ export class PublishMethods extends DKGAgentBase {
       opts?.subGraphName,
     );
     const metaGraph = contextGraphMetaUri(contextGraphId);
+    const lifecycleUri = assertionLifecycleUri(
+      contextGraphId,
+      agentAddress,
+      name,
+      opts?.subGraphName,
+    );
+    const sourceWmGraphUri = await this.publisher.wmGraphUri(
+      contextGraphId,
+      agentAddress,
+      name,
+      opts?.subGraphName,
+    );
+    const xsdInteger = '<http://www.w3.org/2001/XMLSchema#integer>';
+    const stampFinalizedLifecycle = async (
+      assertionVersion: string | bigint,
+      finalizedMerkleRoot: Uint8Array,
+    ): Promise<void> => {
+      // Keep the v2 mutation gate present throughout recovery. The assertion
+      // version may need replacement, but a failure after its delete is safe:
+      // the durable seal is written first and an idempotent finalize retry
+      // repairs this row before returning.
+      await this.store.deleteByPattern({
+        graph: metaGraph,
+        subject: lifecycleUri,
+        predicate: ASSERTION_SEAL_PREDICATES.ASSERTION_VERSION,
+      });
+      await this.store.insert([
+        {
+          subject: lifecycleUri,
+          predicate: ASSERTION_SEAL_PREDICATES.CONTENT_SCOPE_VERSION,
+          object: `"${GRAPH_KA_CONTENT_SCOPE_VERSION}"^^${xsdInteger}`,
+          graph: metaGraph,
+        },
+        {
+          subject: lifecycleUri,
+          predicate: ASSERTION_SEAL_PREDICATES.ASSERTION_VERSION,
+          object: `"${assertionVersion}"^^${xsdInteger}`,
+          graph: metaGraph,
+        },
+      ]);
+      const merkleHexBare = ethers.hexlify(finalizedMerkleRoot).slice(2);
+      await this._stampPointerIfDivergedFromVm(
+        lifecycleUri,
+        WM_CURRENT_ASSERTION_PRED,
+        merkleHexBare,
+        metaGraph,
+      );
+    };
+
+    // Read any durable seal before loading the private partition. A completed
+    // finalize removes the mutable private draft, so an idempotent retry must
+    // recover that partition from the immutable `(UAL, assertionVersion)` graph.
+    const existingMetaResult = await this.store.query(
+      `CONSTRUCT { <${assertionUri}> ?p ?o } WHERE { GRAPH <${metaGraph}> { <${assertionUri}> ?p ?o } }`,
+    );
+    const existingMetaQuads =
+      existingMetaResult.type === 'quads' ? existingMetaResult.quads : [];
+    let existingSeal: AssertionSeal | undefined;
+    try {
+      existingSeal = parseAssertionSealQuads(existingMetaQuads, assertionUri);
+    } catch (err) {
+      throw new Error(
+        `assertionFinalize: existing _meta seal for <${assertionUri}> is corrupt: ` +
+          (err instanceof Error ? err.message : String(err)),
+      );
+    }
+    const privateStore = new PrivateContentStore(this.store, new GraphManager(this.store));
 
     // 2. Pull the assertion's quads. Refuse to finalize an empty
     //    assertion — there's nothing to commit. The public DCAT catalog entry
@@ -2131,7 +2225,26 @@ export class PublishMethods extends DKGAgentBase {
       agentAddress,
       opts?.subGraphName,
     );
-    if (rawQuads.length === 0) {
+    let rawPrivateQuads = await this.publisher.assertionQueryPrivate(
+      contextGraphId,
+      name,
+      agentAddress,
+      opts?.subGraphName,
+    );
+    if (
+      rawPrivateQuads.length === 0
+      && existingSeal?.contentScopeVersion === GRAPH_KA_CONTENT_SCOPE_VERSION
+      && existingSeal.kaUal !== undefined
+      && existingSeal.assertionVersion !== undefined
+      && (existingSeal.privateTripleCount ?? 0) > 0
+    ) {
+      rawPrivateQuads = await privateStore.getKnowledgeAssetPrivateTriples(
+        contextGraphId,
+        createGraphKnowledgeAssetScope(existingSeal.kaUal, existingSeal.assertionVersion),
+        opts?.subGraphName,
+      );
+    }
+    if (rawQuads.length === 0 && rawPrivateQuads.length === 0) {
       throw new Error(
         `Cannot finalize assertion <${assertionUri}>: it has no quads. ` +
           `Write at least one quad with /api/knowledge-assets/${name}/wm/write before finalizing.`,
@@ -2148,12 +2261,15 @@ export class PublishMethods extends DKGAgentBase {
     //     can never recompute. (Round 4 review §8 — "assertionFinalize
     //     hashes WM-only urn:dkg:file: rows".)
     const userQuads = rawQuads.filter((q) => !isReservedSubject(q.subject) && !isTrustLevelQuad(q));
-    if (userQuads.length === 0) {
+    const userPrivateQuads = rawPrivateQuads.filter(
+      (q) => !isReservedSubject(q.subject) && !isTrustLevelQuad(q),
+    );
+    if (userQuads.length === 0 && userPrivateQuads.length === 0) {
       throw new Error(
         `Cannot finalize assertion <${assertionUri}>: every quad has a ` +
           `reserved-namespace subject (urn:dkg:file:* / urn:dkg:extraction:*) ` +
           `which is filtered out before SWM. Add at least one user-authored ` +
-          `quad on a non-reserved subject before finalizing.`,
+          `public or private quad on a non-reserved subject before finalizing.`,
       );
     }
 
@@ -2182,93 +2298,59 @@ export class PublishMethods extends DKGAgentBase {
       quads.push(...catalogQuads);
     }
 
-    // 3. Compute merkleRoot using the SAME algorithm the publisher
-    //    uses at publish-time (V10: keccak256-based merkle, sort+dedupe
-    //    leaves). Drift between these two compute paths is the silent
-    //    failure mode this whole architecture is trying to eliminate —
-    //    so we reuse the publisher's exported helpers verbatim.
-    //
-    //    Round 5 review §1 — `kaMap` may contain unsafe-IRI roots
-    //    (e.g. RFC-3987-valid IRIs with `|` `^` etc that fail
-    //    `isSafeIri`'s SPARQL-interpolation rules). Those cannot be
-    //    referenced from the SPARQL CONSTRUCT that
-    //    `publishFromFinalizedAssertion` uses to reload the
-    //    promoted-SWM payload, so they MUST NOT contribute to the
-    //    sealed merkleRoot — otherwise the seal commits to a root
-    //    the publish path can never recompute. Reject finalize
-    //    instead of silently dropping content: silent-drop hides a
-    //    real input error and would let a partial assertion ship
-    //    with a seal that doesn't cover all of its quads.
-    //    Defense-in-depth: the current oxigraph storage adapter
-    //    rejects most unsafe characters at write time, so this guard
-    //    is rarely triggered through `assertion.write`. It still
-    //    matters for non-oxigraph adapters and for code paths that
-    //    seed the WM graph directly (bulk-import / `_meta` fixtures
-    //    / future storage backends). The canonical wire pin lives
-    //    at `core/test/assertion-seal-root-entities.test.ts` —
-    //    `buildAssertionSealQuads` rejects unsafe roots at the seal
-    //    boundary. This guard surfaces the same failure earlier
-    //    with a more actionable message.
-    const kaMap = skolemizeByEntity(quads);
-    const allRootEntities = [...kaMap.keys()];
-    const unsafeRootEntities = allRootEntities.filter((r) => !isSafeIri(r));
-    if (unsafeRootEntities.length > 0) {
-      const sample = unsafeRootEntities
-        .slice(0, 3)
-        .map((r) => `<${r}>`)
-        .join(', ');
-      const more = unsafeRootEntities.length > 3 ? ` (+${unsafeRootEntities.length - 3} more)` : '';
-      throw new Error(
-        `Cannot finalize assertion <${assertionUri}>: ${unsafeRootEntities.length} root ` +
-          `entit${unsafeRootEntities.length === 1 ? 'y has' : 'ies have'} an unsafe IRI: ${sample}${more}. ` +
-          `The publish path reloads SWM via SPARQL CONSTRUCT scoped to these roots — unsafe IRIs ` +
-          `would be filtered, recomputing a different merkleRoot from the truncated payload, so the ` +
-          `sealed assertion could never be republished. Rename these subjects to safe IRIs ` +
-          `(no blank nodes, control chars, or unbalanced delimiters) before finalizing.`,
-      );
-    }
-    const allSkolemizedQuads = [...kaMap.values()].flat();
-    const merkleRoot = computeFlatKCRoot(allSkolemizedQuads, []);
-    // 3b. Capture rootEntities from the SAME `skolemizeByEntity` call that
-    //     drives the merkle leaves. The seal binds these so
-    //     `publishFromFinalizedAssertion` can scope its SWM CONSTRUCT
-    //     instead of bundling everything currently sitting in shared
-    //     memory (Round 4 review §9). Now safe by construction — the
-    //     guard above guarantees every key passes `isSafeIri`.
-    const canonicalForManifest = canonicalPublishPayload(quads, [], {
-      trustedNonManifestCatalogTriples: trustedGeneratedCatalogTriples,
+    // 3. Canonicalize the COMPLETE RDF set once at KA scope. Subjects are data,
+    // not partitions: 1,000 distinct subjects still produce one asset, one
+    // Merkle tree, and (downstream) one graph operation. The linear skolemizer
+    // also permits a valid all-blank-node component, which the root-based model
+    // could not represent.
+    const normalizedParts = await skolemizeKnowledgeAssetParts(quads, userPrivateQuads, {
+      // The first finalize sees user data already checked at assertionWrite;
+      // an interrupted retry can see our own canonical WM target. Accept only
+      // exact c14nN terms here, never arbitrary names in the reserved prefix.
+      allowCanonicalSkolemTerms: true,
     });
-    const rootEntities = canonicalForManifest.manifestEntries.map((m) => m.rootEntity);
-    if (rootEntities.length === 0) {
-      throw new Error(
-        `Cannot finalize assertion <${assertionUri}>: skolemizeByEntity produced ` +
-          `no root entities. The assertion has no quads; add at least one ` +
-          `user-authored quad on a non-reserved subject before finalizing.`,
-      );
-    }
+    const normalizedKnowledgeAssetQuads = normalizedParts.publicQuads;
+    const normalizedPrivateKnowledgeAssetQuads = normalizedParts.privateQuads;
+    const privateMerkleRoot = computePrivateRoot(normalizedPrivateKnowledgeAssetQuads);
+    const privateTripleCount = normalizedPrivateKnowledgeAssetQuads.length;
+    const merkleRoot = computeFlatKCRoot(
+      normalizedKnowledgeAssetQuads,
+      privateMerkleRoot ? [privateMerkleRoot] : [],
+    );
+    const publicTripleCount = normalizedKnowledgeAssetQuads.length;
 
     // 4. Idempotency: if a seal already exists for this assertion,
     //    return it as-is when the merkleRoot matches. Mismatch means
     //    the assertion was mutated since the previous finalize —
     //    refuse to overwrite silently.
-    const existingMetaResult = await this.store.query(
-      `CONSTRUCT { <${assertionUri}> ?p ?o } WHERE { GRAPH <${metaGraph}> { <${assertionUri}> ?p ?o } }`,
-    );
-    const existingMetaQuads =
-      existingMetaResult.type === 'quads' ? existingMetaResult.quads : [];
-    let existingSeal: AssertionSeal | undefined;
-    try {
-      existingSeal = parseAssertionSealQuads(existingMetaQuads, assertionUri);
-    } catch (err) {
-      // Corrupt seal — surface to the caller. Do NOT silently overwrite
-      // because the original author's signature is still on record and
-      // overwriting would lose the audit trail.
-      throw new Error(
-        `assertionFinalize: existing _meta seal for <${assertionUri}> is corrupt: ` +
-          (err instanceof Error ? err.message : String(err)),
-      );
-    }
     if (existingSeal) {
+      if (existingSeal.contentScopeVersion !== GRAPH_KA_CONTENT_SCOPE_VERSION) {
+        throw new LegacyKnowledgeAssetReadOnlyError();
+      }
+      if (
+        !existingSeal.kaUal ||
+        !existingSeal.assertionVersion ||
+        existingSeal.publicTripleCount === undefined ||
+        existingSeal.privateTripleCount === undefined
+      ) {
+        throw new Error(`Graph-scoped assertion seal for <${assertionUri}> is incomplete`);
+      }
+      const existingPrivateRoot = existingSeal.privateMerkleRoot;
+      const privateRootMatches =
+        existingPrivateRoot === undefined
+          ? privateMerkleRoot === undefined
+          : privateMerkleRoot !== undefined
+            && existingPrivateRoot.length === privateMerkleRoot.length
+            && existingPrivateRoot.every((byte, index) => byte === privateMerkleRoot[index]);
+      if (
+        existingSeal.publicTripleCount !== publicTripleCount
+        || existingSeal.privateTripleCount !== privateTripleCount
+        || !privateRootMatches
+      ) {
+        throw new Error(
+          `assertionFinalize: assertion <${assertionUri}> private/public partition differs from its existing seal`,
+        );
+      }
       if (
         existingSeal.merkleRoot.length !== merkleRoot.length ||
         !existingSeal.merkleRoot.every((b, i) => b === merkleRoot[i])
@@ -2305,12 +2387,58 @@ export class PublishMethods extends DKGAgentBase {
         reservedKaId: reReservedKaId,
         schemeVersion: existingSeal.authorSchemeVersion,
       });
+      // A prior attempt may have stopped after the target swap, after the seal,
+      // or before source cleanup. Re-materialize and repair in that order so an
+      // idempotent finalize always converges to one exact canonical WM graph.
+      const canonicalWmGraphUri = await this.publisher.materializeCanonicalWorkingMemory(
+        contextGraphId,
+        existingSeal.kaUal,
+        existingSeal.assertionVersion,
+        normalizedKnowledgeAssetQuads,
+        opts?.subGraphName,
+      );
+      const existingScope = createGraphKnowledgeAssetScope(
+        existingSeal.kaUal,
+        existingSeal.assertionVersion,
+      );
+      await privateStore.replaceKnowledgeAssetPrivateTriples(
+        contextGraphId,
+        existingScope,
+        normalizedPrivateKnowledgeAssetQuads,
+        opts?.subGraphName,
+      );
+      await stampFinalizedLifecycle(
+        existingSeal.assertionVersion,
+        existingSeal.merkleRoot,
+      );
+      await this.publisher.cleanupCanonicalWorkingMemorySources(
+        contextGraphId,
+        name,
+        agentAddress,
+        canonicalWmGraphUri,
+        [sourceWmGraphUri],
+        opts?.subGraphName,
+      );
+      await privateStore.deleteKnowledgeAssetPrivateDraft(
+        contextGraphId,
+        agentAddress,
+        name,
+        opts?.subGraphName,
+      );
       return {
         assertionUri,
         merkleRoot: existingSeal.merkleRoot,
         authorAddress: existingSeal.authorAddress,
         reservedKaId: reReservedKaId,
-        rootEntities: [...existingSeal.rootEntities],
+        rootEntities: [],
+        contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+        kaUal: existingSeal.kaUal,
+        assertionVersion: existingSeal.assertionVersion,
+        publicTripleCount: existingSeal.publicTripleCount,
+        ...(existingSeal.privateMerkleRoot !== undefined
+          ? { privateMerkleRoot: existingSeal.privateMerkleRoot }
+          : {}),
+        privateTripleCount: existingSeal.privateTripleCount,
         schemeVersion: existingSeal.authorSchemeVersion,
         chainId: existingSeal.chainId,
         kav10Address: existingSeal.kav10Address,
@@ -2407,8 +2535,37 @@ export class PublishMethods extends DKGAgentBase {
     //   • update of a previously-stamped name → reuse the stable existing number;
     //   • fresh create with an allocator → reconcile-once then allocate ONE number;
     //   • no allocator → 0n (non-Option-1; the on-chain namespace check rejects).
-    const lifecycleUri = assertionLifecycleUri(contextGraphId, agentAddress, name, opts?.subGraphName);
-    const xsdInteger = '<http://www.w3.org/2001/XMLSchema#integer>';
+    const lifecycleScopeResult = await this.store.query(
+      `SELECT ?scope ?version ?vm WHERE { GRAPH <${metaGraph}> {
+        OPTIONAL { <${lifecycleUri}> <${ASSERTION_SEAL_PREDICATES.CONTENT_SCOPE_VERSION}> ?scope }
+        OPTIONAL { <${lifecycleUri}> <${ASSERTION_SEAL_PREDICATES.ASSERTION_VERSION}> ?version }
+        OPTIONAL { <${lifecycleUri}> <${VM_CURRENT_ASSERTION_PRED}> ?vm }
+      } } LIMIT 1`,
+    );
+    const lifecycleScopeRow = lifecycleScopeResult.type === 'bindings'
+      ? lifecycleScopeResult.bindings[0]
+      : undefined;
+    const stripLifecycleLiteral = (value: unknown): string | undefined => {
+      if (value === undefined) return undefined;
+      return String(value).replace(/^"/, '').replace(/"(\^\^<[^>]+>)?$/, '').trim();
+    };
+    const persistedScopeVersion = stripLifecycleLiteral(lifecycleScopeRow?.['scope']);
+    const persistedAssertionVersion = stripLifecycleLiteral(lifecycleScopeRow?.['version']);
+    const hasConfirmedVm = lifecycleScopeRow?.['vm'] !== undefined;
+    if (persistedScopeVersion !== String(GRAPH_KA_CONTENT_SCOPE_VERSION)) {
+      throw new LegacyKnowledgeAssetReadOnlyError();
+    }
+    let assertionVersion = 1n;
+    if (hasConfirmedVm) {
+      if (persistedAssertionVersion === undefined) {
+        throw new Error(
+          `Graph-scoped lifecycle <${lifecycleUri}> is missing its assertion version`,
+        );
+      }
+      assertionVersion = BigInt(persistedAssertionVersion) + 1n;
+    } else if (persistedAssertionVersion !== undefined) {
+      assertionVersion = BigInt(persistedAssertionVersion);
+    }
     const existingKaIdRes = await this.store.query(
       `SELECT ?n WHERE { GRAPH <${metaGraph}> { <${lifecycleUri}> <${KA_ID_PRED}> ?n } } LIMIT 1`,
     );
@@ -2627,6 +2784,8 @@ export class PublishMethods extends DKGAgentBase {
 
     // 10. Persist the seal as `_meta` triples.
     const finalizedAtIso = new Date().toISOString();
+    const kaNumber = reservedKaId & ((1n << 96n) - 1n);
+    const kaUal = `did:dkg:${this.chain.chainId}/${authorAddress.toLowerCase()}/${kaNumber}`;
     const sealQuads = buildAssertionSealQuads({
       assertionUri,
       metaGraph,
@@ -2639,7 +2798,12 @@ export class PublishMethods extends DKGAgentBase {
       kav10Address,
       reservedKaId,
       finalizedAtIso,
-      rootEntities,
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      kaUal,
+      assertionVersion,
+      publicTripleCount,
+      privateMerkleRoot,
+      privateTripleCount,
     });
 
     // ── OT-RFC-43 A2 — stamp the per-author kaId + reservedUal + WM pointer ──
@@ -2652,18 +2816,7 @@ export class PublishMethods extends DKGAgentBase {
     // down so the publisher REUSES it. freshNumber is set only for a fresh create
     // (or a not-yet-stamped preSigned slot); an update of a previously-stamped
     // name keeps its STABLE kaId — no re-stamp.
-    const merkleHexBare = ethers.hexlify(merkleRoot).slice(2);
-    // Re-stamp the WM pointer (idempotent: drop any prior value first so a
-    // re-finalize / update advances WM without accumulating stale pointers).
-    // RFC ka-metadata-trim Phase 2: only materialised when it diverges from
-    // VM — readers COALESCE a missing wm pointer to vm.
-    await this._stampPointerIfDivergedFromVm(lifecycleUri, WM_CURRENT_ASSERTION_PRED, merkleHexBare, metaGraph);
-
     if (freshNumber !== undefined) {
-      // chainId here is the EVM uint256 from getEvmChainId(); the reservedUal
-      // uses the adapter's canonical chainId string to match resolveKaUal's
-      // UAL shape (did:dkg:<chainId>/<addr>/<number>).
-      const reservedUal = `did:dkg:${this.chain.chainId}/${authorAddress.toLowerCase()}/${freshNumber}`;
       sealQuads.push({
         subject: lifecycleUri,
         predicate: KA_ID_PRED,
@@ -2673,19 +2826,62 @@ export class PublishMethods extends DKGAgentBase {
       sealQuads.push({
         subject: lifecycleUri,
         predicate: RESERVED_UAL_PRED,
-        object: `"${reservedUal}"`,
+        object: `"${kaUal}"`,
         graph: metaGraph,
       });
     }
 
+    // Crash-safe commit order:
+    //   1. atomically materialize the complete canonical target;
+    //   2. persist the seal (and a fresh identity, when needed);
+    //   3. repair lifecycle pointers/version;
+    //   4. remove obsolete source graphs.
+    // Any interruption leaves either the original source or the canonical
+    // target plus enough durable seal data for the idempotent branch above to
+    // finish the transition on retry.
+    const canonicalWmGraphUri = await this.publisher.materializeCanonicalWorkingMemory(
+      contextGraphId,
+      kaUal,
+      assertionVersion,
+      normalizedKnowledgeAssetQuads,
+      opts?.subGraphName,
+    );
+    const canonicalScope = createGraphKnowledgeAssetScope(kaUal, assertionVersion);
+    await privateStore.replaceKnowledgeAssetPrivateTriples(
+      contextGraphId,
+      canonicalScope,
+      normalizedPrivateKnowledgeAssetQuads,
+      opts?.subGraphName,
+    );
     await this.store.insert(sealQuads);
+    await stampFinalizedLifecycle(assertionVersion, merkleRoot);
+    await this.publisher.cleanupCanonicalWorkingMemorySources(
+      contextGraphId,
+      name,
+      agentAddress,
+      canonicalWmGraphUri,
+      [sourceWmGraphUri],
+      opts?.subGraphName,
+    );
+    await privateStore.deleteKnowledgeAssetPrivateDraft(
+      contextGraphId,
+      agentAddress,
+      name,
+      opts?.subGraphName,
+    );
 
     return {
       assertionUri,
       merkleRoot,
       authorAddress,
       reservedKaId,
-      rootEntities: [...rootEntities],
+      rootEntities: [],
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      kaUal,
+      assertionVersion: assertionVersion.toString(),
+      publicTripleCount,
+      ...(privateMerkleRoot !== undefined ? { privateMerkleRoot } : {}),
+      privateTripleCount,
       schemeVersion,
       chainId,
       kav10Address,
@@ -3506,7 +3702,17 @@ export class PublishMethods extends DKGAgentBase {
         { code: 'PUBLISH_INTENT_STALE' },
       );
     }
-
+    if (seal.contentScopeVersion !== GRAPH_KA_CONTENT_SCOPE_VERSION) {
+      throw new LegacyKnowledgeAssetReadOnlyError();
+    }
+    if (
+      seal.kaUal === undefined
+      || seal.assertionVersion === undefined
+      || seal.publicTripleCount === undefined
+      || seal.privateTripleCount === undefined
+    ) {
+      throw new Error(`Graph-scoped assertion seal for <${assertionUri}> is incomplete`);
+    }
     const latestPromote = [...history.events]
       .reverse()
       .find((event) => event.type === 'promoted' && event.shareOperationId);
@@ -3516,20 +3722,6 @@ export class PublishMethods extends DKGAgentBase {
         new Error(
           `Cannot publish "${name}" asynchronously: the current SWM share is missing a shareOperationId. ` +
             `Re-share the asset through /api/knowledge-assets/${encodeURIComponent(name)}/swm/share before publishing.`,
-        ),
-        { code: 'PUBLISH_INTENT_STALE' },
-      );
-    }
-
-    const roots = [...new Set([
-      ...(latestPromote?.rootEntities ?? []),
-      ...(latestPromote?.rootEntities?.length ? [] : seal.rootEntities),
-    ])].sort();
-    if (roots.length === 0) {
-      throw Object.assign(
-        new Error(
-          `Cannot publish "${name}" asynchronously: the current SWM share has no recorded root entities. ` +
-            `Re-share the full asset before publishing.`,
         ),
         { code: 'PUBLISH_INTENT_STALE' },
       );
@@ -3565,7 +3757,15 @@ export class PublishMethods extends DKGAgentBase {
       agentAddress,
       subGraphName: opts?.subGraphName ?? null,
       shareOperationId,
-      roots,
+      roots: [],
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      kaUal: seal.kaUal,
+      assertionVersion: seal.assertionVersion,
+      publicTripleCount: seal.publicTripleCount,
+      privateMerkleRoot: seal.privateMerkleRoot
+        ? ethers.hexlify(seal.privateMerkleRoot).toLowerCase()
+        : null,
+      privateTripleCount: seal.privateTripleCount,
       sealMerkleRoot: sealMerkleRoot.toLowerCase(),
       seal: queuedSeal,
       sealChainId: seal.chainId.toString(),
@@ -3588,7 +3788,15 @@ export class PublishMethods extends DKGAgentBase {
       agentAddress,
       ...(opts?.subGraphName ? { subGraphName: opts.subGraphName } : {}),
       shareOperationId,
-      roots,
+      roots: [],
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      kaUal: seal.kaUal,
+      assertionVersion: seal.assertionVersion,
+      publicTripleCount: seal.publicTripleCount,
+      ...(seal.privateMerkleRoot
+        ? { privateMerkleRoot: ethers.hexlify(seal.privateMerkleRoot) as `0x${string}` }
+        : {}),
+      privateTripleCount: seal.privateTripleCount,
       seal: queuedSeal,
       sealChainId: seal.chainId.toString() as `${bigint}`,
       sealKav10Address: ethers.getAddress(seal.kav10Address) as `0x${string}`,
@@ -3631,6 +3839,7 @@ export class PublishMethods extends DKGAgentBase {
         );
       }
     } catch (err) {
+      if (err instanceof LegacyKnowledgeAssetReadOnlyError) throw err;
       const wrapped = new Error(
         `Cannot enqueue VM publish for "${request.name}" because share snapshot ` +
           `${request.shareOperationId} is unavailable or stale. Re-share the knowledge asset before enqueueing: ` +
@@ -3646,6 +3855,17 @@ export class PublishMethods extends DKGAgentBase {
     request: KnowledgeAssetVmPublishRequest,
     opts?: { publisherOverride?: DKGPublisher },
   ): Promise<AsyncKnowledgeAssetVmPublishPreflightResult> {
+    if (
+      request.contentScopeVersion !== GRAPH_KA_CONTENT_SCOPE_VERSION
+      || request.kaUal === undefined
+      || request.assertionVersion === undefined
+      || request.publicTripleCount === undefined
+      || request.privateTripleCount === undefined
+      || request.roots.length !== 0
+    ) {
+      throw new LegacyKnowledgeAssetReadOnlyError();
+    }
+    createGraphKnowledgeAssetScope(request.kaUal, request.assertionVersion);
     const bareRoot = (value?: string | null): string | undefined => {
       const trimmed = value?.trim().toLowerCase();
       if (!trimmed) return undefined;
@@ -3817,6 +4037,18 @@ export class PublishMethods extends DKGAgentBase {
     ctx: OperationContext,
   ): Promise<void> {
     const { request, job, recovery } = input;
+    if (
+      request.contentScopeVersion !== GRAPH_KA_CONTENT_SCOPE_VERSION
+      || request.kaUal === undefined
+      || request.assertionVersion === undefined
+      || request.roots.length !== 0
+    ) {
+      throw new LegacyKnowledgeAssetReadOnlyError();
+    }
+    const queuedScope = createGraphKnowledgeAssetScope(
+      request.kaUal,
+      request.assertionVersion,
+    );
     const recovered = await normalizeRecoveredNamedKaPublish({
       request,
       job,
@@ -3883,17 +4115,19 @@ export class PublishMethods extends DKGAgentBase {
 
     if (!recovered.materialization.superseded) {
       const publisher = input.publisher ?? this.publisher;
-      const sharedMemoryScope = sharedMemoryScopeForFinalizedLifecycle(
-        request.seal.authorAddress,
-        recovered.reservedKaId,
-      );
+      const sharedMemoryScope: SharedMemoryGraphScope = {
+        kind: 'named-lifecycle',
+        identity: {
+          agentAddress: queuedScope.agentAddress,
+          kaNumber: BigInt(queuedScope.kaNumber),
+        },
+      };
       try {
-        await publisher.clearPublishedSwmRoots(
+        await publisher.clearPublishedKnowledgeAssetSwm(
           request.contextGraphId,
-          [...request.roots],
+          sharedMemoryScope,
           request.subGraphName,
           ctx,
-          sharedMemoryScope,
         );
         if (request.clearSharedMemoryAfter === true) {
           await publisher.clearRemainingSharedMemory(request.contextGraphId, request.subGraphName, ctx);
@@ -3931,6 +4165,25 @@ export class PublishMethods extends DKGAgentBase {
   ): Promise<PublishResult & { assertionUri: string; seal: AssertionSeal }> {
     const ctx = opts?.operationCtx ?? publishOptions.operationCtx ?? createOperationContext('publishFromSWM');
     const publisher = opts?.publisherOverride ?? this.publisher;
+    if (request.contentScopeVersion !== GRAPH_KA_CONTENT_SCOPE_VERSION) {
+      throw new LegacyKnowledgeAssetReadOnlyError();
+    }
+    if (
+      request.roots.length !== 0
+      || request.kaUal === undefined
+      || request.assertionVersion === undefined
+      || request.publicTripleCount === undefined
+      || request.privateTripleCount === undefined
+    ) {
+      throw new Error('Queued graph-scoped VM publish has an incomplete KA content envelope');
+    }
+    const graphScope = createGraphKnowledgeAssetScope(
+      request.kaUal,
+      request.assertionVersion,
+    );
+    const queuedPrivateMerkleRoot = request.privateMerkleRoot
+      ? ethers.getBytes(request.privateMerkleRoot)
+      : undefined;
     const agentAddress = request.agentAddress ?? this.defaultAgentAddress ?? this.peerId;
     const assertionUri = contextGraphAssertionUri(
       request.contextGraphId,
@@ -3955,7 +4208,13 @@ export class PublishMethods extends DKGAgentBase {
       chainId: BigInt(request.sealChainId),
       kav10Address: ethers.getAddress(request.sealKav10Address),
       finalizedAtIso: request.sealFinalizedAtIso,
-      rootEntities: [...request.roots],
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      kaUal: graphScope.ual,
+      assertionVersion: graphScope.assertionVersion,
+      publicTripleCount: request.publicTripleCount,
+      ...(queuedPrivateMerkleRoot ? { privateMerkleRoot: queuedPrivateMerkleRoot } : {}),
+      privateTripleCount: request.privateTripleCount,
+      rootEntities: [],
       ...(request.seal.reservedKaId !== undefined ? { reservedKaId: BigInt(request.seal.reservedKaId) } : {}),
     };
     const queuedMerkleRoot = ethers.hexlify(seal.merkleRoot).toLowerCase();
@@ -3989,13 +4248,47 @@ export class PublishMethods extends DKGAgentBase {
       }
     }
 
-    const snapshotQuads = publishOptions.quads.map((q) => ({ ...q, graph: '' }));
-    const snapshotPrivateQuads = (publishOptions.privateQuads ?? []).map((q) => ({ ...q, graph: '' }));
+    const snapshotParts = await skolemizeKnowledgeAssetParts(
+      publishOptions.quads.map((q) => ({ ...q, graph: '' })),
+      (publishOptions.privateQuads ?? []).map((q) => ({ ...q, graph: '' })),
+      { allowCanonicalSkolemTerms: true },
+    );
+    const snapshotQuads = snapshotParts.publicQuads;
+    const snapshotPrivateQuads = snapshotParts.privateQuads;
     if (snapshotQuads.length === 0 && snapshotPrivateQuads.length === 0) {
       throw new Error(
         `No queued shared-memory snapshot quads for context graph ${request.contextGraphId} ` +
           `share operation ${request.shareOperationId}`,
       );
+    }
+    if (
+      snapshotQuads.length !== seal.publicTripleCount
+      || snapshotPrivateQuads.length !== seal.privateTripleCount
+    ) {
+      throw new Error(
+        `Queued graph-scoped VM publish triple-count mismatch for ${graphScope.ual}: ` +
+          `seal=${seal.publicTripleCount}/${seal.privateTripleCount}, ` +
+          `snapshot=${snapshotQuads.length}/${snapshotPrivateQuads.length}`,
+      );
+    }
+    const snapshotPrivateRoot = computePrivateRoot(snapshotPrivateQuads);
+    const privateRootMatches = seal.privateMerkleRoot === undefined
+      ? snapshotPrivateRoot === undefined
+      : snapshotPrivateRoot !== undefined
+        && seal.privateMerkleRoot.length === snapshotPrivateRoot.length
+        && seal.privateMerkleRoot.every((byte, index) => byte === snapshotPrivateRoot[index]);
+    if (!privateRootMatches) {
+      throw new Error(`Queued graph-scoped VM publish private Merkle mismatch for ${graphScope.ual}`);
+    }
+    const snapshotMerkleRoot = computeFlatKCRoot(
+      snapshotQuads,
+      snapshotPrivateRoot ? [snapshotPrivateRoot] : [],
+    );
+    if (
+      snapshotMerkleRoot.length !== seal.merkleRoot.length
+      || !snapshotMerkleRoot.every((byte, index) => byte === seal.merkleRoot[index])
+    ) {
+      throw new Error(`Queued graph-scoped VM publish Merkle mismatch for ${graphScope.ual}`);
     }
 
     const pointerRes = await this.store.query(
@@ -4009,39 +4302,50 @@ export class PublishMethods extends DKGAgentBase {
     const vmCurrent = request.vmCurrentAssertion ?? stripLit(pointerRow?.['vm']);
     const stampedNumberStr = request.kaNumber ?? stripLit(pointerRow?.['kaNum']);
 
-    let packedKaId: bigint | undefined;
-    if (stampedNumberStr != null && stampedNumberStr !== '') {
-      try {
-        const authorBits = BigInt(ethers.getAddress(seal.authorAddress));
-        packedKaId = (authorBits << 96n) | BigInt(stampedNumberStr);
-      } catch (err) {
-        this.log.warn(
-          ctx,
-          `Failed to re-pack queued kaId number "${stampedNumberStr}" for <${lifecycleUri}>: ` +
-            (err instanceof Error ? err.message : String(err)),
-        );
-      }
+    if (graphScope.agentAddress.toLowerCase() !== seal.authorAddress.toLowerCase()) {
+      throw new Error(
+        `Queued graph-scoped seal author ${seal.authorAddress} does not match UAL author ${graphScope.agentAddress}`,
+      );
     }
-    const sharedMemoryScope = sharedMemoryScopeForFinalizedLifecycle(
-      seal.authorAddress,
-      seal.reservedKaId ?? packedKaId,
-    );
+    if (
+      stampedNumberStr !== undefined
+      && stampedNumberStr !== ''
+      && BigInt(stampedNumberStr) !== BigInt(graphScope.kaNumber)
+    ) {
+      throw new Error(
+        `Queued lifecycle kaId number ${stampedNumberStr} does not match UAL number ${graphScope.kaNumber}`,
+      );
+    }
+    const packedKaId =
+      (BigInt(graphScope.agentAddress) << 96n)
+      | BigInt(graphScope.kaNumber);
+    if (seal.reservedKaId !== undefined && seal.reservedKaId !== packedKaId) {
+      throw new Error(
+        `Queued seal reservedKaId ${seal.reservedKaId} does not match UAL-derived kaId ${packedKaId}`,
+      );
+    }
+    const sharedMemoryScope: SharedMemoryGraphScope = {
+      kind: 'named-lifecycle',
+      identity: {
+        agentAddress: graphScope.agentAddress,
+        kaNumber: BigInt(graphScope.kaNumber),
+      },
+    };
 
     const newMerkleHexBare = ethers.hexlify(seal.merkleRoot).slice(2);
     let result: PublishResult;
-    const clearPublishedRoots = async (label: string): Promise<void> => {
+    const clearPublishedGraph = async (label: string): Promise<void> => {
       try {
-        await publisher.clearPublishedSwmRoots(
+        await publisher.clearPublishedKnowledgeAssetSwm(
           request.contextGraphId,
-          [...request.roots],
+          sharedMemoryScope,
           request.subGraphName,
           ctx,
-          sharedMemoryScope,
         );
       } catch (err) {
         this.log.warn(
           ctx,
-          `Failed to clear published SWM roots after confirmed queued ${label} of <${lifecycleUri}>: ` +
+          `Failed to clear published SWM graph after confirmed queued ${label} of <${lifecycleUri}>: ` +
             (err instanceof Error ? err.message : String(err)),
         );
       }
@@ -4079,11 +4383,17 @@ export class PublishMethods extends DKGAgentBase {
           precomputedUpdateAttestation: updateAttestation,
           publisherOverride: publisher,
           subGraphName: request.subGraphName,
+          contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+          kaUal: graphScope.ual,
+          assertionVersion: graphScope.assertionVersion,
+          publicTripleCount: seal.publicTripleCount,
+          ...(snapshotPrivateRoot ? { privateMerkleRoot: snapshotPrivateRoot } : {}),
+          privateTripleCount: seal.privateTripleCount,
         },
       );
 
       if (result.status === 'confirmed') {
-        await clearPublishedRoots('update');
+        await clearPublishedGraph('update');
         if (request.clearSharedMemoryAfter === true) {
           await clearRemainingSharedMemory();
         }
@@ -4188,6 +4498,12 @@ export class PublishMethods extends DKGAgentBase {
         privateQuads: snapshotPrivateQuads.length > 0 ? snapshotPrivateQuads : undefined,
         publisherPeerId: publishOptions.publisherPeerId ?? this.peerId,
         subGraphName: request.subGraphName,
+        contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+        kaUal: graphScope.ual,
+        assertionVersion: graphScope.assertionVersion,
+        publicTripleCount: seal.publicTripleCount,
+        ...(snapshotPrivateRoot ? { privateMerkleRoot: snapshotPrivateRoot } : {}),
+        privateTripleCount: seal.privateTripleCount,
         operationCtx: ctx,
         onPhase: opts?.onPhase ?? publishOptions.onPhase,
         skipContextGraphEnsure: true,
@@ -4232,7 +4548,7 @@ export class PublishMethods extends DKGAgentBase {
       }
 
       if (result.status === 'confirmed') {
-        await clearPublishedRoots('publish');
+        await clearPublishedGraph('publish');
         if (request.clearSharedMemoryAfter === true) {
           await clearRemainingSharedMemory();
         }
@@ -4256,9 +4572,7 @@ export class PublishMethods extends DKGAgentBase {
     }
 
     if (result.status === 'confirmed' && result.onChainResult) {
-      const rootEntities = result.kaManifest.length > 0
-        ? result.kaManifest.map((ka) => ka.rootEntity)
-        : [...request.roots];
+      const rootEntities: string[] = [];
       const broadcastCgId = queuedOnChainContextGraphId ?? (onChainCapable
         ? normalizeOptionalContextGraphId(await this.getContextGraphOnChainId(request.contextGraphId))
         : undefined);
@@ -4364,6 +4678,20 @@ export class PublishMethods extends DKGAgentBase {
           `Call /api/knowledge-assets/${name}/wm/finalize before publishing.`,
       );
     }
+    if (seal.contentScopeVersion !== GRAPH_KA_CONTENT_SCOPE_VERSION) {
+      throw new LegacyKnowledgeAssetReadOnlyError();
+    }
+    if (
+      seal.kaUal === undefined
+      || seal.assertionVersion === undefined
+      || seal.publicTripleCount === undefined
+    ) {
+      throw new Error(`Graph-scoped assertion seal for <${assertionUri}> is incomplete`);
+    }
+    const graphScope = createGraphKnowledgeAssetScope(
+      seal.kaUal,
+      seal.assertionVersion,
+    );
 
     // 2. Cross-check chain target — refuse to publish a sig signed
     //    against a different deployment than this daemon currently
@@ -4450,72 +4778,110 @@ export class PublishMethods extends DKGAgentBase {
     const vmCurrent = stripLit(pointerRow?.['vm']);
     const stampedNumberStr = stripLit(pointerRow?.['kaNum']);
 
-    // Re-pack the stamped per-author NUMBER into the full packed kaId:
-    //   kaId = (uint160(author) << 96) | number   (matches KaNumberAllocator)
-    let packedKaId: bigint | undefined;
-    if (stampedNumberStr != null && stampedNumberStr !== '') {
-      try {
-        const authorBits = BigInt(ethers.getAddress(seal.authorAddress));
-        packedKaId = (authorBits << 96n) | BigInt(stampedNumberStr);
-      } catch (err) {
-        this.log.warn(
-          opts?.operationCtx ?? createOperationContext('publishFromSWM'),
-          `Failed to re-pack stamped kaId number "${stampedNumberStr}" for <${lifecycleUri}>: ` +
-            (err instanceof Error ? err.message : String(err)),
-        );
-      }
+    if (graphScope.agentAddress.toLowerCase() !== seal.authorAddress.toLowerCase()) {
+      throw new Error(
+        `Graph-scoped seal author ${seal.authorAddress} does not match UAL author ${graphScope.agentAddress}`,
+      );
     }
-    const finalizedLifecycleSelection = { rootEntities: seal.rootEntities };
-
+    const packedKaId =
+      (BigInt(graphScope.agentAddress) << 96n)
+      | BigInt(graphScope.kaNumber);
+    if (
+      stampedNumberStr !== undefined
+      && stampedNumberStr !== ''
+      && BigInt(stampedNumberStr) !== BigInt(graphScope.kaNumber)
+    ) {
+      throw new Error(
+        `Lifecycle kaId number ${stampedNumberStr} does not match graph-scoped UAL number ${graphScope.kaNumber}`,
+      );
+    }
     const newMerkleHexBare = ethers.hexlify(seal.merkleRoot).slice(2);
     const recoveredReservedKaId = seal.reservedKaId ?? packedKaId;
-    const isExistingVmLifecycle = Boolean(vmCurrent && packedKaId !== undefined);
-    // FAIL FAST when this is an on-chain-capable daemon: a new mint below will
-    // submit the precomputed attestation, and a missing packed id would revert.
-    // Keep this validation before the compatibility preflight so an invalid
-    // legacy mint cannot mutate SWM while it is already known to be unusable.
-    const onChainCapable =
-      typeof this.chain.getEvmChainId === 'function' &&
-      typeof this.chain.getKnowledgeAssetsLifecycleAddress === 'function';
-    if (!isExistingVmLifecycle && recoveredReservedKaId === undefined && onChainCapable) {
+    if (recoveredReservedKaId !== packedKaId) {
       throw new Error(
-        `publishFromFinalizedAssertion: cannot recover the §F2 reservedKaId for ` +
-          `<${assertionUri}> — the seal has neither a persisted reservedKaId nor a ` +
-          `stamped lifecycle kaId (legacy pre-OT-RFC-43-§F2 finalize). Minting with a ` +
-          `0n placeholder id would revert on-chain with KaIdNamespaceMismatch. ` +
-          `Re-finalize the assertion (POST /api/knowledge-assets/${name}/wm/finalize) ` +
-          `so the AuthorAttestation binds a valid packed kaId before publishing.`,
+        `Graph-scoped seal reservedKaId ${recoveredReservedKaId} does not match UAL-derived kaId ${packedKaId}`,
+      );
+    }
+    const sharedMemoryScope: SharedMemoryGraphScope = {
+      kind: 'named-lifecycle',
+      identity: {
+        agentAddress: graphScope.agentAddress,
+        kaNumber: BigInt(graphScope.kaNumber),
+      },
+    };
+    const scopedSwmQuads = await this._loadSelectedSWMQuads(
+      contextGraphId,
+      'all',
+      opts?.subGraphName,
+      sharedMemoryScope,
+    );
+    const privateStore = new PrivateContentStore(this.store, new GraphManager(this.store));
+    const scopedPrivateQuads = await privateStore.getKnowledgeAssetPrivateTriples(
+      contextGraphId,
+      graphScope,
+      opts?.subGraphName,
+    );
+    if (scopedSwmQuads.length === 0 && scopedPrivateQuads.length === 0) {
+      throw new Error(
+        `No public or private quads in shared memory for context graph ${contextGraphId} ` +
+          `matching graph-scoped KA ${graphScope.ual}`,
+      );
+    }
+    const canonicalParts = await skolemizeKnowledgeAssetParts(
+      scopedSwmQuads,
+      scopedPrivateQuads,
+      { allowCanonicalSkolemTerms: true },
+    );
+    const canonicalSwmQuads = canonicalParts.publicQuads;
+    const canonicalPrivateQuads = canonicalParts.privateQuads;
+    if (canonicalSwmQuads.length !== seal.publicTripleCount) {
+      throw new Error(
+        `Graph-scoped SWM triple count mismatch for ${graphScope.ual}: ` +
+          `seal=${seal.publicTripleCount}, store=${canonicalSwmQuads.length}`,
+      );
+    }
+    if (canonicalPrivateQuads.length !== seal.privateTripleCount) {
+      throw new Error(
+        `Graph-scoped private triple count mismatch for ${graphScope.ual}: ` +
+          `seal=${seal.privateTripleCount}, store=${canonicalPrivateQuads.length}`,
+      );
+    }
+    const privateMerkleRoot = computePrivateRoot(canonicalPrivateQuads);
+    const privateRootMatches = seal.privateMerkleRoot === undefined
+      ? privateMerkleRoot === undefined
+      : privateMerkleRoot !== undefined
+        && seal.privateMerkleRoot.length === privateMerkleRoot.length
+        && seal.privateMerkleRoot.every((byte, index) => byte === privateMerkleRoot[index]);
+    if (!privateRootMatches) {
+      throw new Error(
+        `Graph-scoped private Merkle root mismatch for ${graphScope.ual}: ` +
+          `seal=${seal.privateMerkleRoot ? ethers.hexlify(seal.privateMerkleRoot) : '(none)'}, ` +
+          `store=${privateMerkleRoot ? ethers.hexlify(privateMerkleRoot) : '(none)'}`,
+      );
+    }
+    const swmMerkleRoot = computeFlatKCRoot(
+      canonicalSwmQuads,
+      privateMerkleRoot ? [privateMerkleRoot] : [],
+    );
+    if (
+      swmMerkleRoot.length !== seal.merkleRoot.length
+      || !swmMerkleRoot.every((byte, index) => byte === seal.merkleRoot[index])
+    ) {
+      throw new Error(
+        `Graph-scoped SWM Merkle root mismatch for ${graphScope.ual}: ` +
+          `seal=${ethers.hexlify(seal.merkleRoot)}, store=${ethers.hexlify(swmMerkleRoot)}`,
       );
     }
 
-    const finalizedLifecycleSwm = await prepareFinalizedLifecycleSwmForPublish({
-      publisher,
-      operationContext: opts?.operationCtx ?? createOperationContext('publishFromSWM'),
-      authorAddress: seal.authorAddress,
-      packedKaId: recoveredReservedKaId,
-      contextGraphId,
-      assertionName: name,
-      assertionLifecycleAgentAddress: agentAddress,
-      subGraphName: opts?.subGraphName,
-      rootEntities: seal.rootEntities,
-      load: (scope) => this._loadSelectedSWMQuads(
-        contextGraphId,
-        finalizedLifecycleSelection,
-        opts?.subGraphName,
-        scope,
-      ),
-    });
-    const sharedMemoryScope = finalizedLifecycleSwm.scope;
-
     let result: PublishResult;
-    if (vmCurrent && packedKaId !== undefined) {
+    if (vmCurrent) {
       // ── UPDATE PATH ──
       // The name already has a confirmed VM version. Reuse its kaId and call
       // the on-chain update primitive. The publisher's update path recomputes
       // the merkle from the SWM-selected quads and requires a
       // precomputedUpdateAttestation over (kaId, newMerkleRoot, author); we
       // mint it here from the seal's merkle using the seal's author signer.
-      const updateQuads = finalizedLifecycleSwm.quads;
+      const updateQuads = canonicalSwmQuads;
       const updateAttestation = await this._buildPrecomputedUpdateAttestationForSeal(
         packedKaId,
         seal,
@@ -4525,13 +4891,19 @@ export class PublishMethods extends DKGAgentBase {
         packedKaId,
         contextGraphId,
         updateQuads.map((q) => ({ ...q, graph: '' })),
-        [],
+        canonicalPrivateQuads.map((q) => ({ ...q, graph: '' })),
         {
           operationCtx: opts?.operationCtx,
           onPhase: opts?.onPhase,
           precomputedUpdateAttestation: updateAttestation,
           publisherOverride: publisher,
           subGraphName: opts?.subGraphName,
+          contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+          kaUal: graphScope.ual,
+          assertionVersion: graphScope.assertionVersion,
+          publicTripleCount: seal.publicTripleCount,
+          ...(privateMerkleRoot ? { privateMerkleRoot } : {}),
+          privateTripleCount: seal.privateTripleCount,
         },
       );
 
@@ -4542,12 +4914,11 @@ export class PublishMethods extends DKGAgentBase {
       // that mirrored the share), so SWM and VM permanently disagreed.
       if (result.status === 'confirmed') {
         try {
-          await publisher.clearPublishedSwmRoots(
+          await publisher.clearPublishedKnowledgeAssetSwm(
             contextGraphId,
-            seal.rootEntities,
+            sharedMemoryScope,
             opts?.subGraphName,
             opts?.operationCtx ?? createOperationContext('publishFromSWM'),
-            sharedMemoryScope,
           );
         } catch (err) {
           this.log.warn(
@@ -4610,7 +4981,7 @@ export class PublishMethods extends DKGAgentBase {
       // mapping (/No quads in shared memory/) still applies.
       result = await this.publishFromSharedMemory(
         contextGraphId,
-        { rootEntities: seal.rootEntities },
+        'all',
         {
           operationCtx: opts?.operationCtx,
           onPhase: opts?.onPhase,
@@ -4619,6 +4990,12 @@ export class PublishMethods extends DKGAgentBase {
           publishEpochs: opts?.publishEpochs,
           reservedKaId: recoveredReservedKaId,
           sharedMemoryScope,
+          contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+          kaUal: graphScope.ual,
+          assertionVersion: graphScope.assertionVersion,
+          publicTripleCount: seal.publicTripleCount,
+          ...(privateMerkleRoot ? { privateMerkleRoot } : {}),
+          privateTripleCount: seal.privateTripleCount,
           // Wired through to the inner publisher.publish() via
           // publishFromSharedMemory's `precomputedAttestation` option.
           // Skips the publisher's signing entirely.
@@ -5069,6 +5446,12 @@ export class PublishMethods extends DKGAgentBase {
        */
       reservedKaId?: bigint;
       sharedMemoryScope?: SharedMemoryGraphScope;
+      contentScopeVersion?: PublishOptions['contentScopeVersion'];
+      kaUal?: PublishOptions['kaUal'];
+      assertionVersion?: PublishOptions['assertionVersion'];
+      publicTripleCount?: PublishOptions['publicTripleCount'];
+      privateMerkleRoot?: PublishOptions['privateMerkleRoot'];
+      privateTripleCount?: PublishOptions['privateTripleCount'];
       /**
        * RFC-001 §9.x — pre-computed attestation captured by
        * `agent.assertion.finalize()`. When the caller has already
@@ -5252,6 +5635,12 @@ export class PublishMethods extends DKGAgentBase {
       // OT-RFC-43 A2 — reuse the finalize-stamped packed kaId (no re-allocate).
       reservedKaId: options?.reservedKaId,
       sharedMemoryScope: options?.sharedMemoryScope,
+      contentScopeVersion: options?.contentScopeVersion,
+      kaUal: options?.kaUal,
+      assertionVersion: options?.assertionVersion,
+      publicTripleCount: options?.publicTripleCount,
+      privateMerkleRoot: options?.privateMerkleRoot,
+      privateTripleCount: options?.privateTripleCount,
       encryptInlinePayload,
       encryptInlineChunked,
     });

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -2287,22 +2287,46 @@ export class DKGAgent extends DKGAgentBase {
         opts?: { subGraphName?: string; agentAddress?: string },
       ): Promise<void> {
         const writeAgentAddress = opts?.agentAddress ?? agentAddress;
-        let quads: import('@origintrail-official/dkg-storage').Quad[];
+        let publicQuads: import('@origintrail-official/dkg-storage').Quad[] = [];
+        let privateQuads: import('@origintrail-official/dkg-storage').Quad[] = [];
         if (Array.isArray(input) && input.length > 0 && 'graph' in input[0]) {
-          quads = input as import('@origintrail-official/dkg-storage').Quad[];
+          publicQuads = input as import('@origintrail-official/dkg-storage').Quad[];
         } else if (!Array.isArray(input) || (input.length > 0 && !('subject' in input[0]))) {
-          const { publicQuads, privateQuads } = await jsonLdToQuads(input as JsonLdContent);
-          quads = [...publicQuads, ...privateQuads];
+          ({ publicQuads, privateQuads } = await jsonLdToQuads(
+            input as JsonLdContent,
+            { syntheticPrivateAnchor: false },
+          ));
         } else {
-          quads = (input as Array<{ subject: string; predicate: string; object: string }>)
+          publicQuads = (input as Array<{ subject: string; predicate: string; object: string }>)
             .map(t => ({ subject: t.subject, predicate: t.predicate, object: t.object, graph: '' }));
         }
-        return agent.publisher.assertionWrite(contextGraphId, name, writeAgentAddress, quads, opts?.subGraphName);
+        if (publicQuads.length > 0) {
+          await agent.publisher.assertionWrite(
+            contextGraphId,
+            name,
+            writeAgentAddress,
+            publicQuads,
+            opts?.subGraphName,
+          );
+        }
+        if (privateQuads.length > 0) {
+          await agent.publisher.assertionWritePrivate(
+            contextGraphId,
+            name,
+            writeAgentAddress,
+            privateQuads,
+            opts?.subGraphName,
+          );
+        }
       },
 
       async query(contextGraphId: string, name: string, opts?: { subGraphName?: string; agentAddress?: string }): Promise<import('@origintrail-official/dkg-storage').Quad[]> {
         const queryAgentAddress = opts?.agentAddress ?? agentAddress;
         return agent.publisher.assertionQuery(contextGraphId, name, queryAgentAddress, opts?.subGraphName);
+      },
+      async queryPrivate(contextGraphId: string, name: string, opts?: { subGraphName?: string; agentAddress?: string }): Promise<import('@origintrail-official/dkg-storage').Quad[]> {
+        const queryAgentAddress = opts?.agentAddress ?? agentAddress;
+        return agent.publisher.assertionQueryPrivate(contextGraphId, name, queryAgentAddress, opts?.subGraphName);
       },
       /** OT-RFC-43 §10.5.3 — seed a fresh WM draft from this file's SWM/VM state. */
       async pullFrom(

--- a/packages/agent/test/ka-graph-finalization-recovery.test.ts
+++ b/packages/agent/test/ka-graph-finalization-recovery.test.ts
@@ -1,0 +1,458 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  ASSERTION_SEAL_PREDICATES,
+  MemoryLayer,
+  assertionLifecycleUri,
+  contextGraphAssertionUri,
+  contextGraphMetaUri,
+  createGraphKnowledgeAssetScope,
+  knowledgeAssetLayerGraphUri,
+} from '@origintrail-official/dkg-core';
+import { assertionScopedGraphUri } from '@origintrail-official/dkg-publisher';
+import { GraphManager, PrivateContentStore } from '@origintrail-official/dkg-storage';
+import { DKGAgent } from '../src/index.js';
+import { createEVMAdapter, HARDHAT_KEYS } from '../../chain/test/evm-test-context.js';
+import { makeTestKaNumberAllocator } from './_helpers/ka-allocator.js';
+
+const agents: DKGAgent[] = [];
+
+afterEach(async () => {
+  for (const agent of agents) {
+    try {
+      await agent.stop();
+    } catch {
+      // best-effort test cleanup
+    }
+  }
+  agents.length = 0;
+});
+
+async function createAgent(): Promise<DKGAgent> {
+  const agent = await DKGAgent.create({
+    name: 'RootlessFinalizeRecovery',
+    listenPort: 0,
+    chainAdapter: createEVMAdapter(HARDHAT_KEYS.CORE_OP),
+    kaNumberAllocator: makeTestKaNumberAllocator(),
+    nodeRole: 'core',
+  });
+  agents.push(agent);
+  await agent.start();
+  return agent;
+}
+
+async function hasSeal(agent: DKGAgent, contextGraphId: string, name: string): Promise<boolean> {
+  const author = agent.defaultAgentAddress ?? agent.peerId;
+  const assertion = contextGraphAssertionUri(contextGraphId, author, name);
+  const meta = contextGraphMetaUri(contextGraphId);
+  const result = await agent.store.query(
+    `ASK { GRAPH <${meta}> { <${assertion}> <${ASSERTION_SEAL_PREDICATES.ASSERTION_MERKLE_ROOT}> ?root } }`,
+  );
+  return result.type === 'boolean' && result.value;
+}
+
+async function assertCanonicalFinalizedGraph(
+  agent: DKGAgent,
+  contextGraphId: string,
+  result: { kaUal: string; assertionVersion: string; publicTripleCount: number },
+): Promise<void> {
+  const target = knowledgeAssetLayerGraphUri(
+    contextGraphId,
+    MemoryLayer.WorkingMemory,
+    createGraphKnowledgeAssetScope(result.kaUal, result.assertionVersion),
+  );
+  expect(await agent.store.countQuads(target)).toBe(result.publicTripleCount);
+  const rows = await agent.store.query(
+    `SELECT ?s ?o WHERE { GRAPH <${target}> { ?s ?p ?o } }`,
+  );
+  expect(rows.type).toBe('bindings');
+  if (rows.type !== 'bindings') throw new Error('expected bindings');
+  expect(rows.bindings.some((row) => row['s']?.startsWith('_:'))).toBe(false);
+  expect(rows.bindings.some((row) => row['o']?.startsWith('_:'))).toBe(false);
+}
+
+describe('graph-scoped assertion finalization recovery', () => {
+  it('converges after failures before swap, after swap, after seal, and during source cleanup', async () => {
+    const agent = await createAgent();
+    const contextGraphId = `rootless-finalize-recovery-${Date.now()}`;
+    await agent.createContextGraph({ id: contextGraphId, name: 'Rootless finalize recovery' });
+    const author = agent.defaultAgentAddress ?? agent.peerId;
+
+    // Failure before the atomic target swap: the writable draft remains intact.
+    const beforeSwap = 'before-swap';
+    await agent.assertion.create(contextGraphId, beforeSwap);
+    await agent.assertion.write(contextGraphId, beforeSwap, [
+      { subject: 'urn:before:swap', predicate: 'urn:predicate:value', object: '"draft"' },
+    ]);
+    const realReplace = agent.store.replaceGraph?.bind(agent.store);
+    agent.store.replaceGraph = async () => {
+      throw new Error('injected before-swap failure');
+    };
+    await expect(agent.assertion.finalize(contextGraphId, beforeSwap)).rejects.toThrow(
+      'injected before-swap failure',
+    );
+    expect(await agent.assertion.query(contextGraphId, beforeSwap)).toHaveLength(1);
+    expect(await hasSeal(agent, contextGraphId, beforeSwap)).toBe(false);
+    agent.store.replaceGraph = realReplace;
+    const beforeSwapRecovered = await agent.assertion.finalize(contextGraphId, beforeSwap) as never as {
+      kaUal: string; assertionVersion: string; publicTripleCount: number;
+    };
+    await assertCanonicalFinalizedGraph(agent, contextGraphId, beforeSwapRecovered);
+
+    // Failure immediately after the swap, when the seal insert begins. The
+    // canonical graph is durable, no seal is exposed, and retry seals it.
+    const afterSwap = 'after-swap';
+    await agent.assertion.create(contextGraphId, afterSwap);
+    await agent.assertion.write(contextGraphId, afterSwap, [
+      { subject: 'urn:after:swap', predicate: 'urn:predicate:child', object: '_:child' },
+      { subject: '_:child', predicate: 'urn:predicate:value', object: '"canonical"' },
+    ]);
+    const afterSwapWm = await agent.publisher.wmGraphUri(contextGraphId, author, afterSwap);
+    const realInsert = agent.store.insert.bind(agent.store);
+    let stoppedBeforeSeal = false;
+    agent.store.insert = async (quads, options) => {
+      if (
+        !stoppedBeforeSeal &&
+        quads.some((quad) => quad.predicate === ASSERTION_SEAL_PREDICATES.ASSERTION_MERKLE_ROOT)
+      ) {
+        stoppedBeforeSeal = true;
+        throw new Error('injected after-swap failure');
+      }
+      return realInsert(quads, options);
+    };
+    await expect(agent.assertion.finalize(contextGraphId, afterSwap)).rejects.toThrow(
+      'injected after-swap failure',
+    );
+    expect(await hasSeal(agent, contextGraphId, afterSwap)).toBe(false);
+    const swappedRows = await agent.store.query(
+      `SELECT ?s ?o WHERE { GRAPH <${afterSwapWm}> { ?s ?p ?o } }`,
+    );
+    expect(swappedRows.type).toBe('bindings');
+    if (swappedRows.type !== 'bindings') throw new Error('expected bindings');
+    expect(swappedRows.bindings.some((row) => row['s']?.startsWith('_:'))).toBe(false);
+    expect(swappedRows.bindings.some((row) => row['o']?.startsWith('_:'))).toBe(false);
+    agent.store.insert = realInsert;
+    const afterSwapRecovered = await agent.assertion.finalize(contextGraphId, afterSwap) as never as {
+      kaUal: string; assertionVersion: string; publicTripleCount: number;
+    };
+    await assertCanonicalFinalizedGraph(agent, contextGraphId, afterSwapRecovered);
+
+    // Failure after the seal, while lifecycle version repair starts. The seal
+    // makes the next finalize enter its idempotent repair branch.
+    const afterSeal = 'after-seal';
+    await agent.assertion.create(contextGraphId, afterSeal);
+    await agent.assertion.write(contextGraphId, afterSeal, [
+      { subject: 'urn:after:seal', predicate: 'urn:predicate:value', object: '"sealed"' },
+    ]);
+    const lifecycle = assertionLifecycleUri(contextGraphId, author, afterSeal);
+    const realDeleteByPattern = agent.store.deleteByPattern.bind(agent.store);
+    let stoppedAfterSeal = false;
+    agent.store.deleteByPattern = async (pattern, options) => {
+      if (
+        !stoppedAfterSeal &&
+        pattern.subject === lifecycle &&
+        pattern.predicate === ASSERTION_SEAL_PREDICATES.ASSERTION_VERSION
+      ) {
+        stoppedAfterSeal = true;
+        throw new Error('injected after-seal failure');
+      }
+      return realDeleteByPattern(pattern, options);
+    };
+    await expect(agent.assertion.finalize(contextGraphId, afterSeal)).rejects.toThrow(
+      'injected after-seal failure',
+    );
+    expect(await hasSeal(agent, contextGraphId, afterSeal)).toBe(true);
+    agent.store.deleteByPattern = realDeleteByPattern;
+    const afterSealRecovered = await agent.assertion.finalize(contextGraphId, afterSeal) as never as {
+      kaUal: string; assertionVersion: string; publicTripleCount: number;
+    };
+    await assertCanonicalFinalizedGraph(agent, contextGraphId, afterSealRecovered);
+    const lifecycleVersion = await agent.store.query(
+      `SELECT ?v WHERE { GRAPH <${contextGraphMetaUri(contextGraphId)}> {
+        <${lifecycle}> <${ASSERTION_SEAL_PREDICATES.ASSERTION_VERSION}> ?v
+      } }`,
+    );
+    expect(lifecycleVersion.type).toBe('bindings');
+    if (lifecycleVersion.type !== 'bindings') throw new Error('expected bindings');
+    expect(lifecycleVersion.bindings).toHaveLength(1);
+
+    // Failure during cleanup: canonical content and seal survive; retry removes
+    // the encoded original-named-graph source without duplicating the payload.
+    const duringCleanup = 'during-cleanup';
+    const originalNamedGraph = 'urn:input:named-graph';
+    await agent.assertion.create(contextGraphId, duringCleanup);
+    await agent.assertion.write(contextGraphId, duringCleanup, [
+      {
+        subject: 'urn:during:cleanup',
+        predicate: 'urn:predicate:value',
+        object: '"cleanup"',
+        graph: originalNamedGraph,
+      },
+    ]);
+    const cleanupWm = await agent.publisher.wmGraphUri(contextGraphId, author, duringCleanup);
+    const scopedNamedGraph = assertionScopedGraphUri(cleanupWm, originalNamedGraph);
+    expect(await agent.store.hasGraph(scopedNamedGraph)).toBe(true);
+    const realDropGraph = agent.store.dropGraph.bind(agent.store);
+    let stoppedDuringCleanup = false;
+    agent.store.dropGraph = async (graphUri, options) => {
+      if (!stoppedDuringCleanup && graphUri === scopedNamedGraph) {
+        stoppedDuringCleanup = true;
+        throw new Error('injected cleanup failure');
+      }
+      return realDropGraph(graphUri, options);
+    };
+    await expect(agent.assertion.finalize(contextGraphId, duringCleanup)).rejects.toThrow(
+      'injected cleanup failure',
+    );
+    expect(await hasSeal(agent, contextGraphId, duringCleanup)).toBe(true);
+    expect(await agent.store.hasGraph(scopedNamedGraph)).toBe(true);
+    agent.store.dropGraph = realDropGraph;
+    const cleanupRecovered = await agent.assertion.finalize(contextGraphId, duringCleanup) as never as {
+      kaUal: string; assertionVersion: string; publicTripleCount: number;
+    };
+    await assertCanonicalFinalizedGraph(agent, contextGraphId, cleanupRecovered);
+    expect(await agent.store.hasGraph(scopedNamedGraph)).toBe(false);
+
+    // WM->SWM uses the same atomic exact-graph primitive. A failed swap leaves
+    // both canonical WM and the prior complete SWM graph untouched; retry then
+    // replaces SWM exactly and removes WM only after the swap succeeds.
+    const promoteRetry = 'promote-retry';
+    await agent.assertion.create(contextGraphId, promoteRetry);
+    await agent.assertion.write(contextGraphId, promoteRetry, [
+      { subject: 'urn:promote:new:1', predicate: 'urn:predicate:value', object: '"one"' },
+      { subject: 'urn:promote:new:2', predicate: 'urn:predicate:value', object: '"two"' },
+    ]);
+    const promoteSeal = await agent.assertion.finalize(
+      contextGraphId,
+      promoteRetry,
+    ) as never as {
+      kaUal: string; assertionVersion: string; publicTripleCount: number;
+    };
+    const promoteScope = createGraphKnowledgeAssetScope(
+      promoteSeal.kaUal,
+      promoteSeal.assertionVersion,
+    );
+    const swmTarget = knowledgeAssetLayerGraphUri(
+      contextGraphId,
+      MemoryLayer.SharedWorkingMemory,
+      promoteScope,
+    );
+    await agent.store.insert([{
+      subject: 'urn:promote:prior',
+      predicate: 'urn:predicate:value',
+      object: '"prior"',
+      graph: swmTarget,
+    }]);
+    const replaceBeforePromote = agent.store.replaceGraph?.bind(agent.store);
+    agent.store.replaceGraph = async (graphUri, quads, options) => {
+      if (graphUri === swmTarget) throw new Error('injected SWM swap failure');
+      if (!replaceBeforePromote) throw new Error('replaceGraph unavailable');
+      return replaceBeforePromote(graphUri, quads, options);
+    };
+    await expect(agent.assertion.promote(contextGraphId, promoteRetry)).rejects.toThrow(
+      'injected SWM swap failure',
+    );
+    expect(await agent.assertion.query(contextGraphId, promoteRetry)).toHaveLength(2);
+    const priorSwm = await agent.store.query(
+      `SELECT ?s WHERE { GRAPH <${swmTarget}> { ?s <urn:predicate:value> ?o } }`,
+    );
+    expect(priorSwm.type).toBe('bindings');
+    if (priorSwm.type !== 'bindings') throw new Error('expected bindings');
+    expect(priorSwm.bindings).toEqual([{ s: 'urn:promote:prior' }]);
+
+    agent.store.replaceGraph = replaceBeforePromote;
+    const promoted = await agent.assertion.promote(contextGraphId, promoteRetry);
+    expect(promoted.promotedCount).toBe(2);
+    expect(await agent.assertion.query(contextGraphId, promoteRetry)).toHaveLength(0);
+    const currentSwm = await agent.store.query(
+      `SELECT ?s WHERE { GRAPH <${swmTarget}> { ?s <urn:predicate:value> ?o } } ORDER BY ?s`,
+    );
+    expect(currentSwm.type).toBe('bindings');
+    if (currentSwm.type !== 'bindings') throw new Error('expected bindings');
+    expect(currentSwm.bindings).toEqual([
+      { s: 'urn:promote:new:1' },
+      { s: 'urn:promote:new:2' },
+    ]);
+
+    const leakedInternalGraphs = (await agent.store.listGraphs()).filter((graph) =>
+      graph.startsWith('urn:dkg:internal:atomic-graph-replace:'),
+    );
+    expect(leakedInternalGraphs).toEqual([]);
+  }, 60_000);
+
+  it('publishes only the exact sealed SWM graph and fails before chain work on tampering', async () => {
+    const agent = await createAgent();
+    const contextGraphId = `rootless-vm-boundary-${Date.now()}`;
+    await agent.createContextGraph({ id: contextGraphId, name: 'Rootless VM boundary' });
+    const author = agent.defaultAgentAddress ?? agent.peerId;
+    const name = 'exact-vm-boundary';
+    await agent.assertion.create(contextGraphId, name);
+    await agent.assertion.write(contextGraphId, name, [
+      { subject: 'urn:vm:one', predicate: 'urn:predicate:child', object: '_:child' },
+      { subject: '_:child', predicate: 'urn:predicate:value', object: '"canonical"' },
+      { subject: 'urn:vm:two', predicate: 'urn:predicate:value', object: '"ordinary"' },
+    ]);
+    const finalized = await agent.assertion.finalize(contextGraphId, name) as never as {
+      kaUal: string;
+      assertionVersion: string;
+      publicTripleCount: number;
+      merkleRoot: Uint8Array;
+    };
+    await agent.assertion.promote(contextGraphId, name);
+    const scope = createGraphKnowledgeAssetScope(
+      finalized.kaUal,
+      finalized.assertionVersion,
+    );
+    const swmGraph = knowledgeAssetLayerGraphUri(
+      contextGraphId,
+      MemoryLayer.SharedWorkingMemory,
+      scope,
+    );
+
+    // A sibling KA graph must never widen the named publish boundary.
+    const siblingScope = createGraphKnowledgeAssetScope(
+      `did:dkg:${scope.chainId}/${scope.agentAddress}/${BigInt(scope.kaNumber) + 1n}`,
+      1,
+    );
+    await agent.store.insert([{
+      subject: 'urn:sibling:must-not-publish',
+      predicate: 'urn:predicate:value',
+      object: '"sibling"',
+      graph: knowledgeAssetLayerGraphUri(
+        contextGraphId,
+        MemoryLayer.SharedWorkingMemory,
+        siblingScope,
+      ),
+    }]);
+
+    const tamperQuad = {
+      subject: 'urn:tamper:extra',
+      predicate: 'urn:predicate:value',
+      object: '"tampered"',
+      graph: swmGraph,
+    };
+    await agent.store.insert([tamperQuad]);
+    await expect(
+      agent.publishFromFinalizedAssertion(contextGraphId, name),
+    ).rejects.toThrow(/SWM triple count mismatch/);
+    await agent.store.delete([tamperQuad]);
+
+    let captured: {
+      selection: unknown;
+      options: Record<string, unknown>;
+    } | undefined;
+    const packedKaId =
+      (BigInt(scope.agentAddress) << 96n)
+      | BigInt(scope.kaNumber);
+    const originalPublishFromSharedMemory = agent.publishFromSharedMemory.bind(agent);
+    (agent as unknown as {
+      publishFromSharedMemory: (...args: unknown[]) => Promise<unknown>;
+    }).publishFromSharedMemory = async (...args: unknown[]) => {
+      const [, selection, options] = args;
+      captured = { selection, options: options as Record<string, unknown> };
+      return {
+        kaId: packedKaId,
+        ual: scope.ual,
+        merkleRoot: finalized.merkleRoot,
+        kaManifest: [],
+        status: 'tentative',
+        publicQuads: [],
+      };
+    };
+    try {
+      const result = await agent.publishFromFinalizedAssertion(contextGraphId, name);
+      expect(result.ual).toBe(scope.ual);
+      expect(captured?.selection).toBe('all');
+      expect(captured?.options).toMatchObject({
+        contentScopeVersion: 2,
+        kaUal: scope.ual,
+        assertionVersion: scope.assertionVersion,
+        publicTripleCount: finalized.publicTripleCount,
+        reservedKaId: packedKaId,
+        sharedMemoryScope: {
+          kind: 'named-lifecycle',
+          identity: {
+            agentAddress: scope.agentAddress,
+            kaNumber: BigInt(scope.kaNumber),
+          },
+        },
+      });
+    } finally {
+      (agent as unknown as {
+        publishFromSharedMemory: typeof originalPublishFromSharedMemory;
+      }).publishFromSharedMemory = originalPublishFromSharedMemory;
+    }
+  }, 60_000);
+
+  it('commits, promotes, and republishes a fully private KA without a synthetic public root', async () => {
+    const agent = await createAgent();
+    const contextGraphId = `rootless-private-only-${Date.now()}`;
+    await agent.createContextGraph({ id: contextGraphId, name: 'Rootless private-only lifecycle' });
+    const name = 'private-only';
+    await agent.assertion.create(contextGraphId, name);
+    await agent.assertion.write(contextGraphId, name, {
+      private: {
+        '@context': { secret: 'urn:predicate:secret' },
+        '@id': 'urn:private:subject',
+        secret: 'hidden',
+      },
+    });
+
+    expect(await agent.assertion.query(contextGraphId, name)).toEqual([]);
+    expect(await agent.assertion.queryPrivate(contextGraphId, name)).toHaveLength(1);
+    const finalized = await agent.assertion.finalize(contextGraphId, name) as never as {
+      kaUal: string;
+      assertionVersion: string;
+      publicTripleCount: number;
+      privateMerkleRoot: Uint8Array;
+      privateTripleCount: number;
+      merkleRoot: Uint8Array;
+    };
+    expect(finalized.publicTripleCount).toBe(0);
+    expect(finalized.privateTripleCount).toBe(1);
+    expect(finalized.privateMerkleRoot).toHaveLength(32);
+    expect(await agent.assertion.queryPrivate(contextGraphId, name)).toEqual([]);
+
+    const scope = createGraphKnowledgeAssetScope(finalized.kaUal, finalized.assertionVersion);
+    const privateStore = new PrivateContentStore(agent.store, new GraphManager(agent.store));
+    expect(await privateStore.getKnowledgeAssetPrivateTriples(contextGraphId, scope)).toHaveLength(1);
+
+    const promoted = await agent.assertion.promote(contextGraphId, name);
+    expect(promoted).toMatchObject({ promotedCount: 1, sealed: true, publishReady: true });
+    expect(await agent.store.countQuads(knowledgeAssetLayerGraphUri(
+      contextGraphId,
+      MemoryLayer.SharedWorkingMemory,
+      scope,
+    ))).toBe(0);
+
+    let capturedOptions: Record<string, unknown> | undefined;
+    const originalPublishFromSharedMemory = agent.publishFromSharedMemory.bind(agent);
+    (agent as unknown as {
+      publishFromSharedMemory: (...args: unknown[]) => Promise<unknown>;
+    }).publishFromSharedMemory = async (...args: unknown[]) => {
+      capturedOptions = args[2] as Record<string, unknown>;
+      return {
+        kaId: (BigInt(scope.agentAddress) << 96n) | BigInt(scope.kaNumber),
+        ual: scope.ual,
+        merkleRoot: finalized.merkleRoot,
+        kaManifest: [],
+        status: 'tentative',
+        publicQuads: [],
+      };
+    };
+    try {
+      await agent.publishFromFinalizedAssertion(contextGraphId, name);
+      expect(capturedOptions).toMatchObject({
+        contentScopeVersion: 2,
+        kaUal: scope.ual,
+        assertionVersion: scope.assertionVersion,
+        publicTripleCount: 0,
+        privateTripleCount: 1,
+      });
+      expect(capturedOptions?.privateMerkleRoot).toEqual(finalized.privateMerkleRoot);
+    } finally {
+      (agent as unknown as {
+        publishFromSharedMemory: typeof originalPublishFromSharedMemory;
+      }).publishFromSharedMemory = originalPublishFromSharedMemory;
+    }
+  }, 60_000);
+});

--- a/packages/agent/test/ka-graph-finalization-recovery.test.ts
+++ b/packages/agent/test/ka-graph-finalization-recovery.test.ts
@@ -383,6 +383,57 @@ describe('graph-scoped assertion finalization recovery', () => {
     }
   }, 60_000);
 
+  it('recovers a promotion that fails between the SWM swap and its durable writes', async () => {
+    const agent = await createAgent();
+    const contextGraphId = `rootless-promote-recovery-${Date.now()}`;
+    await agent.createContextGraph({ id: contextGraphId, name: 'Rootless promote recovery' });
+    const name = 'promote-crash';
+    await agent.assertion.create(contextGraphId, name);
+    await agent.assertion.write(contextGraphId, name, [
+      { subject: 'urn:promote:crash', predicate: 'urn:predicate:value', object: '"promoted"' },
+    ]);
+    const finalized = await agent.assertion.finalize(contextGraphId, name) as never as {
+      kaUal: string; assertionVersion: string; publicTripleCount: number;
+    };
+    const scope = createGraphKnowledgeAssetScope(finalized.kaUal, finalized.assertionVersion);
+    const wmGraph = knowledgeAssetLayerGraphUri(contextGraphId, MemoryLayer.WorkingMemory, scope);
+    const swmGraph = knowledgeAssetLayerGraphUri(contextGraphId, MemoryLayer.SharedWorkingMemory, scope);
+    expect(await agent.store.countQuads(wmGraph)).toBe(1);
+
+    // Crash inside the post-swap tail: the memory-layer meta rewrite is the
+    // first durable write after the SWM replacement.
+    const realInsert = agent.store.insert.bind(agent.store);
+    let crashed = false;
+    agent.store.insert = async (quads, options) => {
+      if (
+        !crashed
+        && quads.some((quad) =>
+          quad.predicate === 'http://dkg.io/ontology/memoryLayer' && quad.object === '"SWM"')
+      ) {
+        crashed = true;
+        throw new Error('injected post-swap promote failure');
+      }
+      return realInsert(quads, options);
+    };
+    try {
+      await expect(agent.assertion.promote(contextGraphId, name)).rejects.toThrow(
+        'injected post-swap promote failure',
+      );
+    } finally {
+      agent.store.insert = realInsert;
+    }
+
+    // The WM source must survive the failed tail: dropping it before the
+    // durable writes strands the promotion — a retry then reads empty working
+    // memory and aborts instead of converging.
+    expect(await agent.store.countQuads(wmGraph)).toBe(1);
+
+    const retried = await agent.assertion.promote(contextGraphId, name);
+    expect(retried).toMatchObject({ promotedCount: 1 });
+    expect(await agent.store.countQuads(swmGraph)).toBe(1);
+    expect(await agent.store.countQuads(wmGraph)).toBe(0);
+  }, 60_000);
+
   it('commits, promotes, and republishes a fully private KA without a synthetic public root', async () => {
     const agent = await createAgent();
     const contextGraphId = `rootless-private-only-${Date.now()}`;

--- a/packages/core/src/assertion-seal.ts
+++ b/packages/core/src/assertion-seal.ts
@@ -66,6 +66,10 @@ export const ASSERTION_SEAL_PREDICATES = {
   ASSERTION_VERSION: `${ONT}assertionVersion`,
   /** Complete public RDF triple count for the graph-scoped assertion. */
   PUBLIC_TRIPLE_COUNT: `${ONT}publicTripleCount`,
+  /** Single KA-level private Merkle commitment (xsd:hexBinary). */
+  PRIVATE_MERKLE_ROOT: `${ONT}privateMerkleRoot`,
+  /** Number of private RDF triples committed by PRIVATE_MERKLE_ROOT. */
+  PRIVATE_TRIPLE_COUNT: `${ONT}privateTripleCount`,
   /**
    * Root entity bound to the seal (multi-valued). Recorded at finalize
    * time so that `publishFromFinalizedAssertion` can scope the SWM
@@ -157,6 +161,8 @@ export type AssertionSealBuildArgs = AssertionSealBuildBaseArgs & (
       kaUal: string;
       assertionVersion: string | number | bigint;
       publicTripleCount: number;
+      privateMerkleRoot?: Uint8Array;
+      privateTripleCount: number;
       rootEntities?: never;
     }
 );
@@ -174,12 +180,34 @@ export function buildAssertionSealQuads(args: AssertionSealBuildArgs): Array<{ s
   let graphScope: ReturnType<typeof createGraphKnowledgeAssetScope> | undefined;
   let legacyRootEntities: ReadonlyArray<string> = [];
   let graphPublicTripleCount: number | undefined;
+  let graphPrivateTripleCount: number | undefined;
+  let graphPrivateMerkleRoot: Uint8Array | undefined;
   if (args.contentScopeVersion === GRAPH_KA_CONTENT_SCOPE_VERSION) {
     graphScope = createGraphKnowledgeAssetScope(args.kaUal, args.assertionVersion);
     graphPublicTripleCount = args.publicTripleCount;
-    if (!Number.isSafeInteger(graphPublicTripleCount) || graphPublicTripleCount < 1) {
+    graphPrivateTripleCount = args.privateTripleCount;
+    graphPrivateMerkleRoot = args.privateMerkleRoot;
+    if (!Number.isSafeInteger(graphPublicTripleCount) || graphPublicTripleCount < 0) {
       throw new Error(
-        `Graph-scoped assertion publicTripleCount must be a positive safe integer, got ${graphPublicTripleCount}`,
+        `Graph-scoped assertion publicTripleCount must be a non-negative safe integer, got ${graphPublicTripleCount}`,
+      );
+    }
+    if (!Number.isSafeInteger(graphPrivateTripleCount) || graphPrivateTripleCount < 0) {
+      throw new Error(
+        `Graph-scoped assertion privateTripleCount must be a non-negative safe integer, got ${graphPrivateTripleCount}`,
+      );
+    }
+    if (graphPublicTripleCount === 0 && graphPrivateTripleCount === 0) {
+      throw new Error('Graph-scoped assertion must contain at least one public or private triple');
+    }
+    if (graphPrivateTripleCount > 0 && graphPrivateMerkleRoot?.length !== 32) {
+      throw new Error(
+        'Graph-scoped assertion with private triples requires one 32-byte privateMerkleRoot',
+      );
+    }
+    if (graphPrivateTripleCount === 0 && graphPrivateMerkleRoot !== undefined) {
+      throw new Error(
+        'Graph-scoped assertion privateMerkleRoot requires a positive privateTripleCount',
       );
     }
   } else {
@@ -240,6 +268,14 @@ export function buildAssertionSealQuads(args: AssertionSealBuildArgs): Array<{ s
       ASSERTION_SEAL_PREDICATES.PUBLIC_TRIPLE_COUNT,
       `"${graphPublicTripleCount}"^^${xsdInteger}`,
     ),
+    quad(
+      ASSERTION_SEAL_PREDICATES.PRIVATE_TRIPLE_COUNT,
+      `\"${graphPrivateTripleCount}\"^^${xsdInteger}`,
+    ),
+    ...(graphPrivateMerkleRoot ? [quad(
+      ASSERTION_SEAL_PREDICATES.PRIVATE_MERKLE_ROOT,
+      `\"${bytesToHexLower(graphPrivateMerkleRoot)}\"^^${xsdHexBinary}`,
+    )] : []),
   ] : [];
 
   return [
@@ -342,6 +378,10 @@ export interface AssertionSeal {
   assertionVersion?: string;
   /** Present only for graph-scoped v2 seals. */
   publicTripleCount?: number;
+  /** Present only for graph-scoped v2 seals with private content. */
+  privateMerkleRoot?: Uint8Array;
+  /** Present only for graph-scoped v2 seals. */
+  privateTripleCount?: number;
   /**
    * Root entities the seal commits to. Set at finalize time, used at
    * publish time to scope the SWM SPARQL CONSTRUCT (so a named publish
@@ -411,11 +451,14 @@ export function parseAssertionSealQuads(
   let kaUal: string | undefined;
   let assertionVersion: string | undefined;
   let publicTripleCount: number | undefined;
+  let privateMerkleRoot: Uint8Array | undefined;
+  let privateTripleCount: number | undefined;
   if (contentScopeVersion === GRAPH_KA_CONTENT_SCOPE_VERSION) {
     const graphRequired = [
       ASSERTION_SEAL_PREDICATES.KA_UAL,
       ASSERTION_SEAL_PREDICATES.ASSERTION_VERSION,
       ASSERTION_SEAL_PREDICATES.PUBLIC_TRIPLE_COUNT,
+      ASSERTION_SEAL_PREDICATES.PRIVATE_TRIPLE_COUNT,
     ];
     for (const predicate of graphRequired) {
       if (!seen.has(predicate)) {
@@ -436,14 +479,47 @@ export function parseAssertionSealQuads(
     const count = integerLiteralToValue(
       seen.get(ASSERTION_SEAL_PREDICATES.PUBLIC_TRIPLE_COUNT)!,
     );
-    if (count < 1n || count > BigInt(Number.MAX_SAFE_INTEGER)) {
+    const privateCount = integerLiteralToValue(
+      seen.get(ASSERTION_SEAL_PREDICATES.PRIVATE_TRIPLE_COUNT)!,
+    );
+    if (count < 0n || count > BigInt(Number.MAX_SAFE_INTEGER)) {
       throw new Error(
         `Invalid graph-scoped publicTripleCount for <${assertionUri}>: ${count}`,
+      );
+    }
+    if (privateCount < 0n || privateCount > BigInt(Number.MAX_SAFE_INTEGER)) {
+      throw new Error(
+        `Invalid graph-scoped privateTripleCount for <${assertionUri}>: ${privateCount}`,
+      );
+    }
+    if (count === 0n && privateCount === 0n) {
+      throw new Error(
+        `Graph-scoped assertion seal for <${assertionUri}> contains no public or private triples`,
+      );
+    }
+    const privateRootObject = seen.get(ASSERTION_SEAL_PREDICATES.PRIVATE_MERKLE_ROOT);
+    if (privateCount > 0n) {
+      if (privateRootObject === undefined) {
+        throw new Error(
+          `Partial graph-scoped assertion seal for <${assertionUri}>: missing ` +
+            `<${ASSERTION_SEAL_PREDICATES.PRIVATE_MERKLE_ROOT}>.`,
+        );
+      }
+      privateMerkleRoot = hexBinaryLiteralToBytes(privateRootObject);
+      if (privateMerkleRoot.length !== 32) {
+        throw new Error(
+          `Invalid graph-scoped privateMerkleRoot for <${assertionUri}>: expected 32 bytes, got ${privateMerkleRoot.length}`,
+        );
+      }
+    } else if (privateRootObject !== undefined) {
+      throw new Error(
+        `Graph-scoped assertion seal for <${assertionUri}> has privateMerkleRoot with zero privateTripleCount`,
       );
     }
     kaUal = scope.ual;
     assertionVersion = scope.assertionVersion;
     publicTripleCount = Number(count);
+    privateTripleCount = Number(privateCount);
   } else if (contentScopeVersion === LEGACY_ROOT_CONTENT_SCOPE_VERSION) {
     if (rootEntities.length === 0) {
       throw new Error(
@@ -491,6 +567,8 @@ export function parseAssertionSealQuads(
     ...(kaUal ? { kaUal } : {}),
     ...(assertionVersion ? { assertionVersion } : {}),
     ...(publicTripleCount !== undefined ? { publicTripleCount } : {}),
+    ...(privateMerkleRoot !== undefined ? { privateMerkleRoot } : {}),
+    ...(privateTripleCount !== undefined ? { privateTripleCount } : {}),
     rootEntities,
   };
 }

--- a/packages/core/src/proto/finalization.ts
+++ b/packages/core/src/proto/finalization.ts
@@ -88,7 +88,13 @@ export const FinalizationMessageSchema = new Type('FinalizationMessage')
   // preventing a stale same-block publish-promotion from clobbering an
   // already-applied update. Legacy publishers omit the field and the
   // receiver falls back to 0 (matching the pre-fix shape).
-  .add(new Field('txIndex', 17, 'uint32'));
+  .add(new Field('txIndex', 17, 'uint32'))
+  // Rootless KA scope. `ual` is already field 1; no physical graph IRI is sent.
+  .add(new Field('contentScopeVersion', 18, 'uint32'))
+  .add(new Field('assertionVersion', 19, 'string'))
+  .add(new Field('publicTripleCount', 20, 'uint32'))
+  .add(new Field('privateMerkleRoot', 21, 'bytes'))
+  .add(new Field('privateTripleCount', 22, 'uint32'));
 
 type Long = { low: number; high: number; unsigned: boolean };
 
@@ -148,6 +154,16 @@ export interface FinalizationMessageMsg {
    * receiver falls back to 0.
    */
   txIndex?: number;
+  /** Rootless KA graph-scope discriminator. New writers emit exactly 2. */
+  contentScopeVersion?: number;
+  /** One-based assertion/Merkle-root index encoded as a decimal string. */
+  assertionVersion?: string;
+  /** Number of public RDF triples in the complete assertion. */
+  publicTripleCount?: number;
+  /** Optional single KA-level private commitment. */
+  privateMerkleRoot?: Uint8Array;
+  /** Number of private RDF triples committed by privateMerkleRoot. */
+  privateTripleCount?: number;
 }
 
 const MAX_UINT64 = (1n << 64n) - 1n;

--- a/packages/core/src/proto/ka-update.ts
+++ b/packages/core/src/proto/ka-update.ts
@@ -35,6 +35,13 @@ export const KAUpdateRequestSchema = new Type('KAUpdateRequest')
   .add(new Field('newMerkleRoot', 9, 'bytes'))
   .add(new Field('timestampMs', 10, 'uint64'))
   .add(new Field('operationId', 11, 'string'))
+  // Rootless KA scope. Legacy per-root manifest MUST be empty for version 2.
+  .add(new Field('contentScopeVersion', 12, 'uint32'))
+  .add(new Field('kaUal', 13, 'string'))
+  .add(new Field('assertionVersion', 14, 'string'))
+  .add(new Field('publicTripleCount', 15, 'uint32'))
+  .add(new Field('privateMerkleRoot', 16, 'bytes'))
+  .add(new Field('privateTripleCount', 17, 'uint32'))
   .add(KAUpdateManifestEntrySchema);
 
 type Long = { low: number; high: number; unsigned: boolean };
@@ -59,6 +66,18 @@ export interface KAUpdateRequestMsg {
   timestampMs: number | bigint;
   /** Originator's operation ID for cross-node log correlation. */
   operationId?: string;
+  /** Rootless KA graph-scope discriminator. New writers emit exactly 2. */
+  contentScopeVersion?: number;
+  /** Canonical deterministic UAL for the updated KA. */
+  kaUal?: string;
+  /** One-based post-update assertion/Merkle-root index. */
+  assertionVersion?: string;
+  /** Number of public RDF triples in the replacement assertion. */
+  publicTripleCount?: number;
+  /** Optional single KA-level private commitment. */
+  privateMerkleRoot?: Uint8Array;
+  /** Number of private RDF triples committed by privateMerkleRoot. */
+  privateTripleCount?: number;
 }
 
 function toBigInt(v: string | number | bigint | Long | unknown): bigint {

--- a/packages/core/src/proto/publish-intent.ts
+++ b/packages/core/src/proto/publish-intent.ts
@@ -93,7 +93,15 @@ export const PublishIntentSchema = new Type('PublishIntent')
   // the exact KC root as hash(public subtree, collapse(private roots)). Sent
   // only over `PROTOCOL_STORAGE_ACK_V2` so V1 cores never silently ignore the
   // commitments during rolling upgrades.
-  .add(new Field('privateMerkleRoots', 20, 'bytes', 'repeated'));
+  .add(new Field('privateMerkleRoots', 20, 'bytes', 'repeated'))
+  // Rootless KA scope. The legacy rootEntities/privateMerkleRoots fields MUST
+  // be empty when contentScopeVersion is 2.
+  .add(new Field('contentScopeVersion', 21, 'uint32'))
+  .add(new Field('kaUal', 22, 'string'))
+  .add(new Field('assertionVersion', 23, 'string'))
+  .add(new Field('publicTripleCount', 24, 'uint32'))
+  .add(new Field('privateMerkleRoot', 25, 'bytes'))
+  .add(new Field('privateTripleCount', 26, 'uint32'));
 
 type Long = { low: number; high: number; unsigned: boolean };
 
@@ -203,6 +211,18 @@ export interface PublishIntentMsg {
    * V1 peers are not compatible because they ignore field 20.
    */
   privateMerkleRoots?: Uint8Array[];
+  /** Rootless KA graph-scope discriminator. New writers emit exactly 2. */
+  contentScopeVersion?: number;
+  /** Canonical deterministic UAL for the single atomic KA assertion. */
+  kaUal?: string;
+  /** One-based assertion/Merkle-root index encoded as a decimal string. */
+  assertionVersion?: string;
+  /** Number of public RDF triples in the assertion. */
+  publicTripleCount?: number;
+  /** Optional single KA-level private commitment. */
+  privateMerkleRoot?: Uint8Array;
+  /** Number of private RDF triples committed by privateMerkleRoot. */
+  privateTripleCount?: number;
 }
 
 /** Sent in `ackProtocolVersion` for LU-11 chunked ACKs. */

--- a/packages/core/src/proto/publish.ts
+++ b/packages/core/src/proto/publish.ts
@@ -36,6 +36,12 @@ export const PublishRequestSchema = new Type('PublishRequest')
   .add(new Field('blockNumber', 13, 'uint64'))
   .add(new Field('operationId', 14, 'string'))
   .add(new Field('subGraphName', 15, 'string'))
+  // Rootless KA scope. `ual` is already field 1; legacy `kas` MUST be empty.
+  .add(new Field('contentScopeVersion', 16, 'uint32'))
+  .add(new Field('assertionVersion', 17, 'string'))
+  .add(new Field('publicTripleCount', 18, 'uint32'))
+  .add(new Field('privateMerkleRoot', 19, 'bytes'))
+  .add(new Field('privateTripleCount', 20, 'uint32'))
   .add(KAManifestEntrySchema);
 
 export const PublishAckSchema = new Type('PublishAck')
@@ -74,6 +80,16 @@ export interface PublishRequestMsg {
   operationId?: string;
   /** Sub-graph within the context graph. Receivers store in sub-graph data graph if set. */
   subGraphName?: string;
+  /** Rootless KA graph-scope discriminator. New writers emit exactly 2. */
+  contentScopeVersion?: number;
+  /** One-based assertion/Merkle-root index encoded as a decimal string. */
+  assertionVersion?: string;
+  /** Number of public RDF triples in the complete assertion. */
+  publicTripleCount?: number;
+  /** Optional single KA-level private commitment. */
+  privateMerkleRoot?: Uint8Array;
+  /** Number of private RDF triples committed by privateMerkleRoot. */
+  privateTripleCount?: number;
 }
 
 export interface PublishAckMsg {

--- a/packages/core/src/proto/update-intent.ts
+++ b/packages/core/src/proto/update-intent.ts
@@ -65,7 +65,15 @@ export const UpdateIntentSchema = new Type('UpdateIntent')
   /** When true, `stagingQuads` is opaque ciphertext (curated CG); peer skips plaintext recompute. */
   .add(new Field('isEncryptedPayload', 16, 'bool'))
   /** ACK protocol version negotiated for this update (absent/0/1 → v1). */
-  .add(new Field('ackProtocolVersion', 17, 'uint32'));
+  .add(new Field('ackProtocolVersion', 17, 'uint32'))
+  // Rootless KA scope. The assertion version MUST equal
+  // preUpdateMerkleRootCount + 1 for a state-changing update.
+  .add(new Field('contentScopeVersion', 18, 'uint32'))
+  .add(new Field('kaUal', 19, 'string'))
+  .add(new Field('assertionVersion', 20, 'string'))
+  .add(new Field('publicTripleCount', 21, 'uint32'))
+  .add(new Field('privateMerkleRoot', 22, 'bytes'))
+  .add(new Field('privateTripleCount', 23, 'uint32'));
 
 type Long = { low: number; high: number; unsigned: boolean };
 
@@ -115,6 +123,18 @@ export interface UpdateIntentMsg {
   isEncryptedPayload?: boolean;
   /** ACK protocol version negotiated for this update (absent/0/1 → v1). */
   ackProtocolVersion?: number;
+  /** Rootless KA graph-scope discriminator. New writers emit exactly 2. */
+  contentScopeVersion?: number;
+  /** Canonical deterministic UAL for the updated KA. */
+  kaUal?: string;
+  /** One-based post-update assertion/Merkle-root index. */
+  assertionVersion?: string;
+  /** Number of public RDF triples in the replacement assertion. */
+  publicTripleCount?: number;
+  /** Optional single KA-level private commitment. */
+  privateMerkleRoot?: Uint8Array;
+  /** Number of private RDF triples committed by privateMerkleRoot. */
+  privateTripleCount?: number;
 }
 
 export function encodeUpdateIntent(msg: UpdateIntentMsg): Uint8Array {

--- a/packages/core/src/proto/workspace.ts
+++ b/packages/core/src/proto/workspace.ts
@@ -40,6 +40,14 @@ export const WorkspacePublishRequestSchema = new Type('WorkspacePublishRequest')
   // OT-RFC-46 — per-KA SWM identity: receivers/sync target …/_shared_memory/{addr}/{number}
   .add(new Field('agentAddress', 10, 'string'))
   .add(new Field('kaNumber', 11, 'string'))
+  // Rootless KA scope. Messages on the graph-scope protocol MUST set version
+  // 2 and leave the legacy per-root manifest empty.
+  .add(new Field('contentScopeVersion', 12, 'uint32'))
+  .add(new Field('kaUal', 13, 'string'))
+  .add(new Field('assertionVersion', 14, 'string'))
+  .add(new Field('publicTripleCount', 15, 'uint32'))
+  .add(new Field('privateMerkleRoot', 16, 'bytes'))
+  .add(new Field('privateTripleCount', 17, 'uint32'))
   .add(WorkspaceManifestEntrySchema)
   .add(WorkspaceCASConditionSchema);
 
@@ -75,6 +83,18 @@ export interface WorkspacePublishRequestMsg {
   agentAddress?: string;
   /** OT-RFC-46 — the KA number (bigint as string); the per-KA SWM graph key. */
   kaNumber?: string;
+  /** Rootless KA graph-scope discriminator. New writers emit exactly 2. */
+  contentScopeVersion?: number;
+  /** Canonical deterministic UAL; authoritative over agentAddress/kaNumber. */
+  kaUal?: string;
+  /** One-based assertion/Merkle-root index encoded as a decimal string. */
+  assertionVersion?: string;
+  /** Number of public RDF triples in this complete KA assertion. */
+  publicTripleCount?: number;
+  /** Optional single KA-level private commitment (never private plaintext). */
+  privateMerkleRoot?: Uint8Array;
+  /** Number of private RDF triples committed by privateMerkleRoot. */
+  privateTripleCount?: number;
 }
 
 export function encodeWorkspacePublishRequest(msg: WorkspacePublishRequestMsg): Uint8Array {

--- a/packages/core/test/assertion-seal-graph-scope.test.ts
+++ b/packages/core/test/assertion-seal-graph-scope.test.ts
@@ -1,60 +1,95 @@
 import { describe, expect, it } from 'vitest';
 import {
   ASSERTION_SEAL_PREDICATES,
-  GRAPH_KA_CONTENT_SCOPE_VERSION,
   buildAssertionSealQuads,
   parseAssertionSealQuads,
-} from '../src/index.js';
+} from '../src/assertion-seal.js';
+import { GRAPH_KA_CONTENT_SCOPE_VERSION } from '../src/ka-content-scope.js';
 
 const ASSERTION_URI = 'urn:dkg:assertion:graph-scope';
-const UAL = 'did:dkg:base:8453/0x70997970C51812dc3A010C7d01b50e0d17dc79C8/0007';
+const META_GRAPH = 'did:dkg:context-graph:cg-1/_meta';
 
-function buildGraphSeal() {
-  return buildAssertionSealQuads({
-    assertionUri: ASSERTION_URI,
-    metaGraph: 'did:dkg:context-graph:cg-1/_meta',
-    merkleRoot: new Uint8Array(32).fill(0xab),
-    authorAddress: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
-    authorAttestationR: new Uint8Array(32).fill(0x11),
-    authorAttestationVS: new Uint8Array(32).fill(0x22),
-    authorSchemeVersion: 1,
-    chainId: 8453n,
-    kav10Address: '0x666D0c3da3dBc946D5128D06115bb4eed4595580',
-    reservedKaId: (BigInt('0x70997970C51812dc3A010C7d01b50e0d17dc79C8') << 96n) | 7n,
-    finalizedAtIso: '2026-07-15T00:00:00.000Z',
-    contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
-    kaUal: UAL,
-    assertionVersion: 2,
-    publicTripleCount: 1_000,
-  });
-}
+const baseArgs = {
+  assertionUri: ASSERTION_URI,
+  metaGraph: META_GRAPH,
+  merkleRoot: new Uint8Array(32).fill(0xab),
+  authorAddress: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
+  authorAttestationR: new Uint8Array(32).fill(0x11),
+  authorAttestationVS: new Uint8Array(32).fill(0x22),
+  authorSchemeVersion: 1,
+  chainId: 31337n,
+  kav10Address: '0x666D0c3da3dBc946D5128D06115bb4eed4595580',
+  reservedKaId: (BigInt('0x70997970C51812dc3A010C7d01b50e0d17dc79C8') << 96n) | 1n,
+  finalizedAtIso: '2026-07-15T00:00:00.000Z',
+  contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+  kaUal: 'did:dkg:otp:20430/0x70997970c51812dc3a010c7d01b50e0d17dc79c8/1',
+  assertionVersion: '2',
+} as const;
 
 describe('graph-scoped assertion seal', () => {
-  it('round-trips one KA identity and emits no root membership rows', () => {
-    const quads = buildGraphSeal();
-    expect(quads.some((quad) =>
-      quad.predicate === ASSERTION_SEAL_PREDICATES.ASSERTION_ROOT_ENTITY ||
-      quad.predicate === ASSERTION_SEAL_PREDICATES.ASSERTION_ENTITY,
-    )).toBe(false);
+  it('round-trips one KA-level private commitment without root entities', () => {
+    const privateMerkleRoot = new Uint8Array(32).fill(0xcd);
+    const quads = buildAssertionSealQuads({
+      ...baseArgs,
+      publicTripleCount: 7,
+      privateMerkleRoot,
+      privateTripleCount: 3,
+    });
 
-    expect(parseAssertionSealQuads(quads, ASSERTION_URI)).toMatchObject({
+    const seal = parseAssertionSealQuads(quads, ASSERTION_URI);
+    expect(seal).toMatchObject({
       contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
-      kaUal: 'did:dkg:base:8453/0x70997970c51812dc3a010c7d01b50e0d17dc79c8/7',
+      kaUal: baseArgs.kaUal,
       assertionVersion: '2',
-      publicTripleCount: 1_000,
+      publicTripleCount: 7,
+      privateTripleCount: 3,
       rootEntities: [],
+    });
+    expect(seal?.privateMerkleRoot).toEqual(privateMerkleRoot);
+    expect(quads.some((quad) =>
+      quad.predicate === ASSERTION_SEAL_PREDICATES.ASSERTION_ROOT_ENTITY
+    )).toBe(false);
+  });
+
+  it('allows fully public and fully private graph-scoped assertions', () => {
+    expect(parseAssertionSealQuads(buildAssertionSealQuads({
+      ...baseArgs,
+      publicTripleCount: 1,
+      privateTripleCount: 0,
+    }), ASSERTION_URI)).toMatchObject({
+      publicTripleCount: 1,
+      privateTripleCount: 0,
+    });
+
+    expect(parseAssertionSealQuads(buildAssertionSealQuads({
+      ...baseArgs,
+      publicTripleCount: 0,
+      privateMerkleRoot: new Uint8Array(32).fill(0xef),
+      privateTripleCount: 1,
+    }), ASSERTION_URI)).toMatchObject({
+      publicTripleCount: 0,
+      privateTripleCount: 1,
     });
   });
 
-  it('fails closed if v2 is mixed with a legacy root row', () => {
-    const quads = buildGraphSeal();
-    quads.push({
-      subject: ASSERTION_URI,
-      predicate: ASSERTION_SEAL_PREDICATES.ASSERTION_ROOT_ENTITY,
-      object: '<urn:legacy:root>',
-      graph: 'did:dkg:context-graph:cg-1/_meta',
-    });
-    expect(() => parseAssertionSealQuads(quads, ASSERTION_URI))
-      .toThrow(/must not contain root entities/);
+  it('rejects empty content and inconsistent private commitment metadata', () => {
+    expect(() => buildAssertionSealQuads({
+      ...baseArgs,
+      publicTripleCount: 0,
+      privateTripleCount: 0,
+    })).toThrow(/at least one public or private triple/);
+
+    expect(() => buildAssertionSealQuads({
+      ...baseArgs,
+      publicTripleCount: 1,
+      privateTripleCount: 1,
+    })).toThrow(/32-byte privateMerkleRoot/);
+
+    expect(() => buildAssertionSealQuads({
+      ...baseArgs,
+      publicTripleCount: 1,
+      privateMerkleRoot: new Uint8Array(32),
+      privateTripleCount: 0,
+    })).toThrow(/positive privateTripleCount/);
   });
 });

--- a/packages/core/test/proto-ka-content-scope.test.ts
+++ b/packages/core/test/proto-ka-content-scope.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from 'vitest';
+import {
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  decodeFinalizationMessage,
+  decodeKAUpdateRequest,
+  decodePublishIntent,
+  decodePublishRequest,
+  decodeSharePublishRequest,
+  decodeUpdateIntent,
+  encodeFinalizationMessage,
+  encodeKAUpdateRequest,
+  encodePublishIntent,
+  encodePublishRequest,
+  encodeSharePublishRequest,
+  encodeUpdateIntent,
+} from '../src/index.js';
+
+const UAL = 'did:dkg:base:8453/0x70997970c51812dc3a010c7d01b50e0d17dc79c8/7';
+const PRIVATE_ROOT = new Uint8Array(32).fill(0x42);
+
+function expectGraphScope(
+  decoded: {
+    contentScopeVersion?: number;
+    assertionVersion?: string;
+    publicTripleCount?: number;
+    privateMerkleRoot?: Uint8Array;
+    privateTripleCount?: number;
+  },
+): void {
+  expect(decoded.contentScopeVersion).toBe(GRAPH_KA_CONTENT_SCOPE_VERSION);
+  expect(decoded.assertionVersion).toBe('2');
+  expect(decoded.publicTripleCount).toBe(1_000);
+  expect(new Uint8Array(decoded.privateMerkleRoot ?? [])).toEqual(PRIVATE_ROOT);
+  expect(decoded.privateTripleCount).toBe(11);
+}
+
+describe('rootless KA graph scope wire contract', () => {
+  it('round-trips one KA scope through SWM share gossip', () => {
+    const decoded = decodeSharePublishRequest(encodeSharePublishRequest({
+      contextGraphId: 'private-cg',
+      nquads: new TextEncoder().encode('<urn:s> <urn:p> "value" .'),
+      manifest: [],
+      publisherPeerId: '12D3KooWPublisher',
+      shareOperationId: 'share-1',
+      timestampMs: 1,
+      agentAddress: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+      kaNumber: '7',
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      kaUal: UAL,
+      assertionVersion: '2',
+      publicTripleCount: 1_000,
+      privateMerkleRoot: PRIVATE_ROOT,
+      privateTripleCount: 11,
+    }));
+
+    expect(decoded.kaUal).toBe(UAL);
+    expect(decoded.manifest).toEqual([]);
+    expectGraphScope(decoded);
+  });
+
+  it('round-trips one KA scope through publish ACK intent', () => {
+    const decoded = decodePublishIntent(encodePublishIntent({
+      merkleRoot: new Uint8Array(32).fill(0x11),
+      contextGraphId: '42',
+      publisherPeerId: '12D3KooWPublisher',
+      publicByteSize: 12_345,
+      isPrivate: true,
+      kaCount: 1,
+      rootEntities: [],
+      privateMerkleRoots: [],
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      kaUal: UAL,
+      assertionVersion: '2',
+      publicTripleCount: 1_000,
+      privateMerkleRoot: PRIVATE_ROOT,
+      privateTripleCount: 11,
+    }));
+
+    expect(decoded.kaUal).toBe(UAL);
+    expect(decoded.rootEntities).toEqual([]);
+    expect(decoded.privateMerkleRoots).toEqual([]);
+    expectGraphScope(decoded);
+  });
+
+  it('round-trips one KA scope through finalization gossip', () => {
+    const decoded = decodeFinalizationMessage(encodeFinalizationMessage({
+      ual: UAL,
+      contextGraphId: 'private-cg',
+      kcMerkleRoot: new Uint8Array(32).fill(0x11),
+      txHash: '0xabc',
+      blockNumber: 10,
+      batchId: 7,
+      startKAId: 7,
+      endKAId: 7,
+      publisherAddress: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+      rootEntities: [],
+      timestampMs: 2,
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      assertionVersion: '2',
+      publicTripleCount: 1_000,
+      privateMerkleRoot: PRIVATE_ROOT,
+      privateTripleCount: 11,
+    }));
+
+    expect(decoded.ual).toBe(UAL);
+    expect(decoded.rootEntities).toEqual([]);
+    expectGraphScope(decoded);
+  });
+
+  it('round-trips one KA scope through replica publish', () => {
+    const decoded = decodePublishRequest(encodePublishRequest({
+      ual: UAL,
+      nquads: new TextEncoder().encode('<urn:s> <urn:p> "value" .'),
+      contextGraphId: 'private-cg',
+      kas: [],
+      publisherIdentity: new Uint8Array(32),
+      publisherAddress: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+      startKAId: 7,
+      endKAId: 7,
+      chainId: 'base:8453',
+      publisherSignatureR: new Uint8Array(32),
+      publisherSignatureVs: new Uint8Array(32),
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      assertionVersion: '2',
+      publicTripleCount: 1_000,
+      privateMerkleRoot: PRIVATE_ROOT,
+      privateTripleCount: 11,
+    }));
+
+    expect(decoded.ual).toBe(UAL);
+    expect(decoded.kas).toEqual([]);
+    expectGraphScope(decoded);
+  });
+
+  it('round-trips one KA scope through update gossip', () => {
+    const decoded = decodeKAUpdateRequest(encodeKAUpdateRequest({
+      contextGraphId: 'private-cg',
+      batchId: 7,
+      nquads: new TextEncoder().encode('<urn:s> <urn:p> "updated" .'),
+      manifest: [],
+      publisherPeerId: '12D3KooWPublisher',
+      publisherAddress: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+      txHash: '0xdef',
+      blockNumber: 10,
+      newMerkleRoot: new Uint8Array(32).fill(0x11),
+      timestampMs: 3,
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      kaUal: UAL,
+      assertionVersion: '2',
+      publicTripleCount: 1_000,
+      privateMerkleRoot: PRIVATE_ROOT,
+      privateTripleCount: 11,
+    }));
+
+    expect(decoded.kaUal).toBe(UAL);
+    expect(decoded.manifest).toEqual([]);
+    expectGraphScope(decoded);
+  });
+
+  it('round-trips one KA scope through update ACK intent', () => {
+    const decoded = decodeUpdateIntent(encodeUpdateIntent({
+      kaId: '7',
+      contextGraphId: '42',
+      preUpdateMerkleRootCount: 1,
+      newMerkleRoot: new Uint8Array(32).fill(0x11),
+      newByteSize: 12_345,
+      newTokenAmount: '1',
+      newMerkleLeafCount: 1_001,
+      publisherPeerId: '12D3KooWPublisher',
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      kaUal: UAL,
+      assertionVersion: '2',
+      publicTripleCount: 1_000,
+      privateMerkleRoot: PRIVATE_ROOT,
+      privateTripleCount: 11,
+    }));
+
+    expect(decoded.kaUal).toBe(UAL);
+    expectGraphScope(decoded);
+  });
+
+  it('keeps archived root messages distinguishable by absent scope version', () => {
+    const decoded = decodeSharePublishRequest(encodeSharePublishRequest({
+      contextGraphId: 'legacy-cg',
+      nquads: new Uint8Array(),
+      manifest: [{ rootEntity: 'urn:legacy:entity', privateTripleCount: 0 }],
+      publisherPeerId: '12D3KooWLegacy',
+      shareOperationId: 'legacy-share',
+      timestampMs: 1,
+    }));
+
+    expect(decoded.contentScopeVersion).toBeUndefined();
+    expect(decoded.kaUal).toBeUndefined();
+    expect(decoded.manifest[0].rootEntity).toBe('urn:legacy:entity');
+  });
+});

--- a/packages/core/test/proto-ka-content-scope.test.ts
+++ b/packages/core/test/proto-ka-content-scope.test.ts
@@ -107,7 +107,7 @@ describe('rootless KA graph scope wire contract', () => {
     expectGraphScope(decoded);
   });
 
-  it('round-trips one KA scope through replica publish', () => {
+  it('round-trips one KA scope through receiving-node publish', () => {
     const decoded = decodePublishRequest(encodePublishRequest({
       ual: UAL,
       nquads: new TextEncoder().encode('<urn:s> <urn:p> "value" .'),

--- a/packages/publisher/src/async-lift-publish-options.ts
+++ b/packages/publisher/src/async-lift-publish-options.ts
@@ -179,6 +179,9 @@ export function mapLiftRequestToPublishOptions(input: LiftPublishMappingInput): 
   const publisherNodeIdentityIdOverride = input.request.publisherNodeIdentityIdOverride !== undefined
     ? BigInt(input.request.publisherNodeIdentityIdOverride)
     : undefined;
+  const privateMerkleRoot = input.request.privateMerkleRoot !== undefined
+    ? decodeSealField('privateMerkleRoot', input.request.privateMerkleRoot, 32)
+    : undefined;
 
   return {
     contextGraphId: input.request.contextGraphId,
@@ -195,6 +198,12 @@ export function mapLiftRequestToPublishOptions(input: LiftPublishMappingInput): 
     onPhase: input.resolved.onPhase,
     receiverSignatureProvider: input.resolved.receiverSignatureProvider,
     publishContextGraphId: input.resolved.publishContextGraphId,
+    contentScopeVersion: input.request.contentScopeVersion,
+    kaUal: input.request.kaUal,
+    assertionVersion: input.request.assertionVersion,
+    publicTripleCount: input.request.publicTripleCount,
+    privateMerkleRoot,
+    privateTripleCount: input.request.privateTripleCount,
     encryptInlinePayload,
     encryptInlineChunked,
     ...(publishEpochs !== undefined

--- a/packages/publisher/src/async-lift-publisher-impl.ts
+++ b/packages/publisher/src/async-lift-publisher-impl.ts
@@ -1,5 +1,10 @@
 import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
 import { GraphManager, PrivateContentStore } from '@origintrail-official/dkg-storage';
+import {
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  LegacyKnowledgeAssetReadOnlyError,
+  createGraphKnowledgeAssetScope,
+} from '@origintrail-official/dkg-core';
 import type { PhaseCallback, PublishResult } from './publisher.js';
 import {
   LIFT_JOB_STATES,
@@ -79,6 +84,42 @@ type AsyncLiftJobHandler = {
   readonly canRetryFailedRecovery: (job: PersistedFailedJob) => boolean;
   readonly shouldPromoteFinalizedPrivateStaging: (job: LiftJob) => boolean;
 };
+
+function assertGraphScopedLiftSnapshot(request: LiftPublishSnapshotRequest): void {
+  if (request.contentScopeVersion !== GRAPH_KA_CONTENT_SCOPE_VERSION) {
+    throw new LegacyKnowledgeAssetReadOnlyError();
+  }
+  if (request.roots.length !== 0) {
+    throw new Error('Graph-scoped async publish must not contain root entities');
+  }
+  if (
+    request.kaUal === undefined
+    || request.assertionVersion === undefined
+    || request.publicTripleCount === undefined
+    || request.privateTripleCount === undefined
+  ) {
+    throw new Error('Graph-scoped async publish requires a complete KA content envelope');
+  }
+  createGraphKnowledgeAssetScope(request.kaUal, request.assertionVersion);
+  if (
+    !Number.isSafeInteger(request.publicTripleCount)
+    || request.publicTripleCount < 0
+    || !Number.isSafeInteger(request.privateTripleCount)
+    || request.privateTripleCount < 0
+    || (request.publicTripleCount === 0 && request.privateTripleCount === 0)
+  ) {
+    throw new Error('Graph-scoped async publish has invalid public/private triple counts');
+  }
+  if (
+    request.privateTripleCount > 0
+    && !/^0x[0-9a-f]{64}$/i.test(request.privateMerkleRoot ?? '')
+  ) {
+    throw new Error('Graph-scoped async publish with private content requires one 32-byte privateMerkleRoot');
+  }
+  if (request.privateTripleCount === 0 && request.privateMerkleRoot !== undefined) {
+    throw new Error('Graph-scoped async publish privateMerkleRoot requires private content');
+  }
+}
 
 function resolveKnowledgeAssetVmPublishHandler(
   config: AsyncLiftPublisherConfig,
@@ -197,9 +238,7 @@ export class TripleStoreAsyncLiftPublisher implements AsyncLiftPublisher {
       if (!request.shareOperationId.trim()) {
         throw new Error('Knowledge asset VM publish requires a shareOperationId');
       }
-      if (request.roots.length === 0) {
-        throw new Error('Knowledge asset VM publish requires at least one shared root');
-      }
+      assertGraphScopedLiftSnapshot(request);
       const existing = await this.findActiveKnowledgeAssetVmPublishJob(request);
       if (existing?.compatible) {
         if (isFailedJob(existing.job)) {

--- a/packages/publisher/src/async-lift-publisher-utils.ts
+++ b/packages/publisher/src/async-lift-publisher-utils.ts
@@ -68,6 +68,22 @@ export function createKnowledgeAssetVmPublishSnapshotRequest(
     shareOperationId: request.shareOperationId,
     roots: request.roots,
     contextGraphId: request.contextGraphId,
+    ...(request.contentScopeVersion !== undefined
+      ? { contentScopeVersion: request.contentScopeVersion }
+      : {}),
+    ...(request.kaUal !== undefined ? { kaUal: request.kaUal } : {}),
+    ...(request.assertionVersion !== undefined
+      ? { assertionVersion: request.assertionVersion }
+      : {}),
+    ...(request.publicTripleCount !== undefined
+      ? { publicTripleCount: request.publicTripleCount }
+      : {}),
+    ...(request.privateMerkleRoot !== undefined
+      ? { privateMerkleRoot: request.privateMerkleRoot }
+      : {}),
+    ...(request.privateTripleCount !== undefined
+      ? { privateTripleCount: request.privateTripleCount }
+      : {}),
     ...(request.subGraphName ? { subGraphName: request.subGraphName } : {}),
     ...(request.publishEpochs !== undefined ? { publishEpochs: request.publishEpochs } : {}),
     ...(request.publisherNodeIdentityIdOverride !== undefined
@@ -193,6 +209,12 @@ function parseRawLiftRequest(value: unknown, path: string): RawLiftRequest {
     shareOperationId: expectString(record, 'shareOperationId', path),
     roots: expectStringArray(record, 'roots', path),
     contextGraphId: expectString(record, 'contextGraphId', path),
+    ...optionalNumberField(record, 'contentScopeVersion', path),
+    ...optionalStringField(record, 'kaUal', path),
+    ...optionalStringField(record, 'assertionVersion', path),
+    ...optionalNumberField(record, 'publicTripleCount', path),
+    ...optionalHexStringField(record, 'privateMerkleRoot', path),
+    ...optionalNumberField(record, 'privateTripleCount', path),
     namespace: expectString(record, 'namespace', path),
     scope: expectString(record, 'scope', path),
     transitionType: expectEnum(record, 'transitionType', LIFT_TRANSITION_TYPES, path),
@@ -217,6 +239,12 @@ function parseKnowledgeAssetVmPublishRequest(value: unknown, path: string): Know
     ...optionalStringField(record, 'subGraphName', path),
     shareOperationId: expectString(record, 'shareOperationId', path),
     roots: expectStringArray(record, 'roots', path),
+    ...optionalNumberField(record, 'contentScopeVersion', path),
+    ...optionalStringField(record, 'kaUal', path),
+    ...optionalStringField(record, 'assertionVersion', path),
+    ...optionalNumberField(record, 'publicTripleCount', path),
+    ...optionalHexStringField(record, 'privateMerkleRoot', path),
+    ...optionalNumberField(record, 'privateTripleCount', path),
     seal: parseSeal(record.seal, `${path}.seal`),
     sealChainId: expectBigIntString(record, 'sealChainId', path),
     sealKav10Address: expectHexString(record, 'sealKav10Address', path),
@@ -378,6 +406,17 @@ function optionalBigIntStringField<T extends string>(
 ): Partial<Record<T, `${bigint}`>> {
   if (record[field] === undefined) return {};
   return { [field]: expectBigIntString(record, field, path) } as Partial<Record<T, `${bigint}`>>;
+}
+
+function optionalHexStringField<T extends string>(
+  record: Record<string, unknown>,
+  field: T,
+  path: string,
+): Partial<Record<T, `0x${string}`>> {
+  if (record[field] === undefined) return {};
+  return {
+    [field]: expectHexString(record, field, path),
+  } as Partial<Record<T, `0x${string}`>>;
 }
 
 function optionalAccessPolicyField(

--- a/packages/publisher/src/async-lift-validation.ts
+++ b/packages/publisher/src/async-lift-validation.ts
@@ -1,4 +1,8 @@
 import type { Quad } from '@origintrail-official/dkg-storage';
+import {
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  createGraphKnowledgeAssetScope,
+} from '@origintrail-official/dkg-core';
 import type { LiftResolvedPublishSlice } from './async-lift-publish-options.js';
 import { normalizeLiftPublishInput } from './async-lift-publish-input.js';
 import type {
@@ -29,23 +33,70 @@ export function validateLiftPublishPayload(input: LiftValidationInput): Validate
   const priorVersion = normalizePriorVersion(input.request.priorVersion);
   validatePriorVersion(metadata.transitionType, priorVersion);
 
+  if (input.request.contentScopeVersion === GRAPH_KA_CONTENT_SCOPE_VERSION) {
+    if (input.request.roots.length !== 0) {
+      throw new Error('Graph-scoped Lift validation rejects root entities');
+    }
+    if (
+      input.request.kaUal === undefined
+      || input.request.assertionVersion === undefined
+      || input.request.publicTripleCount === undefined
+      || input.request.privateTripleCount === undefined
+    ) {
+      throw new Error('Graph-scoped Lift validation requires a complete KA content envelope');
+    }
+    createGraphKnowledgeAssetScope(input.request.kaUal, input.request.assertionVersion);
+    if (
+      !Number.isSafeInteger(input.request.publicTripleCount)
+      || input.request.publicTripleCount < 0
+      || !Number.isSafeInteger(input.request.privateTripleCount)
+      || input.request.privateTripleCount < 0
+    ) {
+      throw new Error('Graph-scoped Lift validation requires non-negative safe triple counts');
+    }
+    if (input.resolved.quads.length !== input.request.publicTripleCount) {
+      throw new Error('Graph-scoped Lift validation public triple count mismatch');
+    }
+    if ((input.resolved.privateQuads?.length ?? 0) !== input.request.privateTripleCount) {
+      throw new Error('Graph-scoped Lift validation private triple count mismatch');
+    }
+
+    const graphSwmQuadCount = input.resolved.quads.length + (input.resolved.privateQuads?.length ?? 0);
+    if (graphSwmQuadCount === 0) {
+      throw new Error('Lift validation requires at least one resolved shared-memory quad');
+    }
+    return {
+      validation: {
+        canonicalRoots: [],
+        canonicalRootMap: {},
+        swmQuadCount: graphSwmQuadCount,
+        authorityProofRef,
+        transitionType: metadata.transitionType,
+        priorVersion,
+      },
+      resolved: input.resolved,
+    };
+  }
+
+  // Raw Lift jobs are migrated in the later mutation-cutover PR. Keep their
+  // existing root-scoped contract intact in this lifecycle PR so the stacked
+  // change remains independently deployable. Named KA jobs are already
+  // fail-closed at enqueue and can only enter through the graph-scoped branch.
   const requestedRoots = normalizeRoots(input.request.roots);
   if (requestedRoots.length === 0) {
     throw new Error('Lift validation requires at least one valid root');
   }
-
   const swmQuadCount = input.resolved.quads.length + (input.resolved.privateQuads?.length ?? 0);
   if (swmQuadCount === 0) {
     throw new Error('Lift validation requires at least one resolved shared-memory quad');
   }
-
   assertSubjectsBelongToRoots(input.resolved.quads, requestedRoots);
   assertSubjectsBelongToRoots(input.resolved.privateQuads ?? [], requestedRoots);
-
-  const canonicalRootMap = Object.fromEntries(requestedRoots.map((root) => [root, canonicalRootIri(input.request, root)]));
+  const canonicalRootMap = Object.fromEntries(
+    requestedRoots.map((root) => [root, canonicalRootIri(input.request, root)]),
+  );
   assertNoCanonicalRootCollisions(canonicalRootMap);
   const canonicalRoots = requestedRoots.map((root) => canonicalRootMap[root] as string);
-
   const resolved: LiftResolvedPublishSlice = {
     ...input.resolved,
     quads: canonicalizeQuads(input.resolved.quads, canonicalRootMap),
@@ -53,7 +104,6 @@ export function validateLiftPublishPayload(input: LiftValidationInput): Validate
       ? canonicalizeQuads(input.resolved.privateQuads, canonicalRootMap)
       : undefined,
   };
-
   return {
     validation: {
       canonicalRoots,
@@ -65,6 +115,7 @@ export function validateLiftPublishPayload(input: LiftValidationInput): Validate
     },
     resolved,
   };
+
 }
 
 function validatePriorVersion(transitionType: LiftRequest['transitionType'], priorVersion?: string): void {

--- a/packages/publisher/src/auto-partition.ts
+++ b/packages/publisher/src/auto-partition.ts
@@ -29,6 +29,34 @@ export interface SkolemizedKnowledgeAssetParts {
 const PUBLIC_CANONICALIZATION_GRAPH = 'urn:dkg:ka-canonicalization:public';
 const PRIVATE_CANONICALIZATION_GRAPH = 'urn:dkg:ka-canonicalization:private';
 
+const CANONICAL_KA_SKOLEM_CAPTURE_RE = /^urn:dkg:ka-skolem:(c14n[0-9]+)$/;
+
+/**
+ * Restore canonical KA skolem IRIs to plain blank nodes for a re-opened draft.
+ *
+ * Stored assertions carry `urn:dkg:ka-skolem:c14nN` IRIs, which user-input
+ * guards rightly reject and which must never MIX with newly authored blank
+ * nodes at the next finalize. Converting them back to `_:c14nN` makes the
+ * draft fully unlabelled: an unmodified re-finalize re-derives the identical
+ * canonical labels (RDFC-1.0 is deterministic over graph structure), while an
+ * edited draft canonicalizes as one uniform blank-node set.
+ */
+export function deskolemizeKnowledgeAssetQuads(quads: readonly Quad[]): Quad[] {
+  return quads.map((quad) => {
+    const subjectMatch = CANONICAL_KA_SKOLEM_CAPTURE_RE.exec(unwrapIri(quad.subject));
+    const objectMatch = quad.object.startsWith('"')
+      ? null
+      : CANONICAL_KA_SKOLEM_CAPTURE_RE.exec(unwrapIri(quad.object));
+    if (!subjectMatch && !objectMatch) return { ...quad, graph: '' };
+    return {
+      ...quad,
+      subject: subjectMatch ? `_:${subjectMatch[1]}` : quad.subject,
+      object: objectMatch ? `_:${objectMatch[1]}` : quad.object,
+      graph: '',
+    };
+  });
+}
+
 /** Reject every user-authored occurrence of the protocol's KA-local namespace. */
 export function assertNoUserAuthoredKnowledgeAssetSkolemTerms(
   quads: readonly Quad[],

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -1731,9 +1731,18 @@ export class DKGPublisher implements Publisher {
       sharedMemoryScope,
       loadOptions,
     );
+    const privateQuads = graphPublish
+      ? await this.privateStore.getKnowledgeAssetPrivateTriples(
+          contextGraphId,
+          graphPublish.scope,
+          options?.subGraphName,
+        )
+      : [];
 
-    if (quads.length === 0) {
-      throw new Error(`No quads in shared memory for context graph ${contextGraphId} matching selection`);
+    if (quads.length === 0 && privateQuads.length === 0) {
+      throw new Error(
+        `No public or private quads for context graph ${contextGraphId} matching the selected Knowledge Asset`,
+      );
     }
     // OT-RFC-44 / Design B: once the caller has selected one lifecycle/file,
     // that payload may contain N root entities and still publish as ONE KA in a
@@ -1777,10 +1786,11 @@ export class DKGPublisher implements Publisher {
       onChainContextGraphId: chainCgId,
     });
 
-    this.log.info(ctx, `Publishing ${quads.length} quads from shared memory to ${ctxGraphId ? `context graph ${ctxGraphId}` : 'data graph'}${chainCgId && !ctxGraphId ? ` (on-chain CG ${chainCgId})` : ''}${options?.subGraphName ? ` (sub-graph: ${options.subGraphName})` : ''}`);
+    this.log.info(ctx, `Publishing ${quads.length} public and ${privateQuads.length} private quads from shared memory to ${ctxGraphId ? `context graph ${ctxGraphId}` : 'data graph'}${chainCgId && !ctxGraphId ? ` (on-chain CG ${chainCgId})` : ''}${options?.subGraphName ? ` (sub-graph: ${options.subGraphName})` : ''}`);
     const internalPublishOptions: InternalPublishOptions = {
       contextGraphId,
       quads: quads.map((q) => ({ ...q, graph: '' })),
+      ...(graphPublish ? { privateQuads } : {}),
       operationCtx: ctx,
       onPhase: options?.onPhase,
       publisherPeerId: options?.publisherPeerId,
@@ -6214,6 +6224,8 @@ export class DKGPublisher implements Publisher {
       `${A2_DKG}wmCurrentAssertion`,
       `${A2_DKG}swmCurrentAssertion`,
       `${A2_DKG}vmCurrentAssertion`,
+      `${A2_DKG}contentScopeVersion`,
+      `${A2_DKG}assertionVersion`,
       'http://www.w3.org/ns/prov#wasRevisionOf',
       // #1116: the promote-stamped member rows (dkg:rootEntity / dkg:entity) are
       // the SEAL-INDEPENDENT recovery source readPromotedRootEntities uses. Pull-from
@@ -6239,6 +6251,16 @@ export class DKGPublisher implements Publisher {
       `SELECT ?p ?o WHERE { GRAPH <${metaGraph}> { <${lifecycleSubject}> ?p ?o } }`,
     );
     if (preserveRes.type === 'bindings') {
+      const scopeObject = preserveRes.bindings.find(
+        (row) => row['p'] === `${A2_DKG}contentScopeVersion`,
+      )?.['o'];
+      const scopeVersion = scopeObject?.match(/(\d+)/)?.[1];
+      if (
+        (scopeVersion !== undefined && scopeVersion !== String(GRAPH_KA_CONTENT_SCOPE_VERSION)) ||
+        (scopeVersion === undefined && preserveRes.bindings.length > 0)
+      ) {
+        throw new LegacyKnowledgeAssetReadOnlyError();
+      }
       for (const row of preserveRes.bindings) {
         const p = row['p'];
         const o = row['o'];
@@ -6300,6 +6322,14 @@ export class DKGPublisher implements Publisher {
       kaNumber,
       reservedUal,
     }, { provenanceEvents: this.provenanceEvents });
+    if (!preserved.some((quad) => quad.predicate === `${A2_DKG}contentScopeVersion`)) {
+      lifecycleQuads.push({
+        subject: lifecycleSubject,
+        predicate: `${A2_DKG}contentScopeVersion`,
+        object: `"${GRAPH_KA_CONTENT_SCOPE_VERSION}"^^<http://www.w3.org/2001/XMLSchema#integer>`,
+        graph: metaGraph,
+      });
+    }
     await this.store.insert(lifecycleQuads);
 
     await this.store.insert([{
@@ -6319,7 +6349,22 @@ export class DKGPublisher implements Publisher {
     input: Quad[] | Array<{ subject: string; predicate: string; object: string }>,
     subGraphName?: string,
   ): Promise<void> {
+    // Reject protocol-reserved user data before any lifecycle/store read. This
+    // keeps the security boundary deterministic even when the addressed KA is
+    // legacy/read-only or does not exist.
+    rejectUserAuthoredProtocolMetadata(input.map((quad) => ({
+      subject: quad.subject,
+      predicate: quad.predicate,
+      object: quad.object,
+      graph: 'graph' in quad ? String(quad.graph ?? '') : '',
+    })));
     await this.ensureSubGraphRegistered(contextGraphId, subGraphName);
+    await this.assertGraphScopedLifecycleWritable(
+      contextGraphId,
+      agentAddress,
+      name,
+      subGraphName,
+    );
     const graphUri = await this.wmGraphUri(contextGraphId, agentAddress, name, subGraphName);
     const scopedGraphs = new Set<string>([graphUri]);
     const quads = input.map((t) => {
@@ -6349,6 +6394,36 @@ export class DKGPublisher implements Publisher {
     await this.store.insert(quads);
   }
 
+  /**
+   * Append private content to the mutable draft of one graph-scoped KA.
+   * Private draft triples never enter the public WM graph; finalize
+   * canonicalizes both partitions together and commits one private root.
+   */
+  async assertionWritePrivate(
+    contextGraphId: string,
+    name: string,
+    agentAddress: string,
+    input: Quad[],
+    subGraphName?: string,
+  ): Promise<void> {
+    rejectUserAuthoredProtocolMetadata(input.map((quad) => ({ ...quad, graph: '' })));
+    await this.ensureSubGraphRegistered(contextGraphId, subGraphName);
+    await this.assertGraphScopedLifecycleWritable(
+      contextGraphId,
+      agentAddress,
+      name,
+      subGraphName,
+    );
+    rejectOversizedRdfLiterals(input, 'assertionWritePrivate.quads');
+    await this.privateStore.storeKnowledgeAssetPrivateDraftTriples(
+      contextGraphId,
+      agentAddress,
+      name,
+      input,
+      subGraphName,
+    );
+  }
+
   async assertionQuery(
     contextGraphId: string,
     name: string,
@@ -6358,6 +6433,21 @@ export class DKGPublisher implements Publisher {
     DKGPublisher.validateOptionalSubGraph(subGraphName);
     const graphUri = await this.wmGraphUri(contextGraphId, agentAddress, name, subGraphName);
     return this.assertionScopedQuads(graphUri);
+  }
+
+  async assertionQueryPrivate(
+    contextGraphId: string,
+    name: string,
+    agentAddress: string,
+    subGraphName?: string,
+  ): Promise<Quad[]> {
+    DKGPublisher.validateOptionalSubGraph(subGraphName);
+    return this.privateStore.getKnowledgeAssetPrivateDraftTriples(
+      contextGraphId,
+      agentAddress,
+      name,
+      subGraphName,
+    );
   }
 
   /**
@@ -6581,8 +6671,75 @@ export class DKGPublisher implements Publisher {
     // swallow, or change control flow, and the `store.insert` write itself is
     // deliberately left untagged.
     await tagPromoteStep('ensureSubGraphRegistered', () => this.ensureSubGraphRegistered(contextGraphId, opts?.subGraphName));
-    const graphUri = await tagPromoteStep('wmGraphUri', () => this.wmGraphUri(contextGraphId, agentAddress, name, opts?.subGraphName));
-    const swmGraphUri = await tagPromoteStep('swmGraphUri', () => this.swmGraphUri(contextGraphId, agentAddress, name, opts?.subGraphName));
+    await tagPromoteStep('assertGraphScopedLifecycleWritable', () =>
+      this.assertGraphScopedLifecycleWritable(
+        contextGraphId,
+        agentAddress,
+        name,
+        opts?.subGraphName,
+      ));
+    if (opts?.entities && opts.entities !== 'all') {
+      throw Object.assign(
+        new Error(
+          'A graph-scoped Knowledge Asset is atomic. Create a new KA instead of sharing a subject subset.',
+        ),
+        { code: 'KA_ATOMIC_SHARE_REQUIRED' },
+      );
+    }
+    const sealSubject = contextGraphAssertionUri(
+      contextGraphId,
+      agentAddress,
+      name,
+      opts?.subGraphName,
+    );
+    const promoteMetaGraph = contextGraphMetaUri(contextGraphId);
+    const sealResult = await this.store.query(
+      `CONSTRUCT { <${assertSafeIri(sealSubject)}> ?p ?o } WHERE {
+        GRAPH <${assertSafeIri(promoteMetaGraph)}> { <${assertSafeIri(sealSubject)}> ?p ?o }
+      }`,
+    );
+    const seal = parseAssertionSealQuads(
+      sealResult.type === 'quads' ? sealResult.quads : [],
+      sealSubject,
+    );
+    if (!seal) {
+      throw Object.assign(
+        new Error('Graph-scoped KA sharing requires a finalized v2 assertion seal'),
+        { code: 'UNSEALED_SHARE_BLOCKED' },
+      );
+    }
+    if (seal.contentScopeVersion !== GRAPH_KA_CONTENT_SCOPE_VERSION) {
+      throw new LegacyKnowledgeAssetReadOnlyError();
+    }
+    if (
+      !seal.kaUal
+      || !seal.assertionVersion
+      || seal.publicTripleCount === undefined
+      || seal.privateTripleCount === undefined
+    ) {
+      throw new Error(`Graph-scoped assertion seal for <${sealSubject}> is incomplete`);
+    }
+    const contentScope = createGraphKnowledgeAssetScope(seal.kaUal, seal.assertionVersion);
+    const immutablePrivateQuads = await tagPromoteStep(
+      'knowledgeAssetPrivateQuads',
+      () => this.privateStore.getKnowledgeAssetPrivateTriples(
+        contextGraphId,
+        contentScope,
+        opts?.subGraphName,
+      ),
+    );
+    const graphUri = knowledgeAssetLayerGraphUri(
+      contextGraphId,
+      MemoryLayer.WorkingMemory,
+      contentScope,
+      opts?.subGraphName,
+    );
+    const swmGraphUri = knowledgeAssetLayerGraphUri(
+      contextGraphId,
+      MemoryLayer.SharedWorkingMemory,
+      contentScope,
+      opts?.subGraphName,
+    );
 
     // #1116 (round 10) — the swmShareComplete marker MUST be maintained on EVERY
     // return path of assertionPromote, not just the success tail. A non-full share
@@ -6594,9 +6751,8 @@ export class DKGPublisher implements Publisher {
     // return with `isFull = promotingAllEntities && promotedAllRoots` for that path.
     // (Member-row REPLACE stays at the success path — it only matters when quads
     // are actually promoted; the MARKER is the cross-cutting invariant.)
-    const promotingAllEntities = !opts?.entities || opts.entities === 'all';
+    const promotingAllEntities = true;
     const lifecycleSubject = assertionLifecycleUri(contextGraphId, agentAddress, name, opts?.subGraphName);
-    const promoteMetaGraph = contextGraphMetaUri(contextGraphId);
     const clearCurrentShareOperationId = async (): Promise<void> => {
       await this.store.deleteByPattern({
         graph: promoteMetaGraph,
@@ -6614,34 +6770,14 @@ export class DKGPublisher implements Publisher {
     };
 
     const assertionQuads = await tagPromoteStep('assertionScopedQuads', () => this.assertionScopedQuads(graphUri));
-    if (assertionQuads.length === 0) {
-      // Issue #864 — when the assertion data graph is empty, distinguish two
-      // failure modes so the caller (and ultimately the UI) gets an
-      // actionable signal instead of a silent "Promoted 0 triples":
-      //
-      //   a) genuine empty assertion (never imported, never written, or
-      //      already discarded) → keep the legacy `{ promotedCount: 0 }`
-      //      success-shape return so polling/retry paths keep working.
-      //   b) `_meta` says structural extraction *completed* with a non-zero
-      //      triple count → the data graph SHOULD hold content. Returning
-      //      0 here silently leaves the user staring at "Promoted 0" with
-      //      no recovery path; raise a typed error so the daemon route
-      //      can map it to a 409 the UI knows to surface.
-      //
-      // Rows 18 (`dkg:extractionStatus`) and 19 (`dkg:structuralTripleCount`)
-      // are stamped by the daemon's import-file flow on the data-graph URI
-      // subject (NOT the lifecycle URN) — see
-      // `packages/cli/src/daemon/routes/assertion.ts:metaQuads`. That makes
-      // them a clean witness of "extraction landed", scoped to the same
-      // graphUri we just CONSTRUCTed against. Lifecycle-URN rows from
-      // `assertionCreate` are not consulted: they fire for empty-write
-      // flows where promoting nothing is legitimate.
-      await this.assertAssertionDataPersisted(contextGraphId, graphUri);
-      // No roots to promote is a no-op, not a fresh full share. Clear any prior
-      // marker and current share intent so an empty WM retry cannot re-arm async
-      // VM publish with an old shareOperationId.
+    if (assertionQuads.length === 0 && immutablePrivateQuads.length === 0) {
       await maintainMarker(false);
-      return { promotedCount: 0, promotedAllRoots: false };
+      throw Object.assign(
+        new Error(
+          `Finalized graph-scoped assertion <${sealSubject}> has no materialized public or private content`,
+        ),
+        { code: 'KA_GRAPH_CONTENT_MISSING' },
+      );
     }
 
     let quadsToPromote = assertionQuads;
@@ -6714,34 +6850,17 @@ export class DKGPublisher implements Publisher {
       onChainContextGraphId: opts?.onChainContextGraphId,
       allowLocalPrivateContextGraph: true,
     }));
-    const trustedGeneratedCatalogTriples = trustedCatalogTripleKeySet(
-      opts?.trustedNonManifestCatalogTriples,
+    const privateQuadsToPromote = immutablePrivateQuads.filter(
+      (q) => !isReservedSubject(q.subject) && !isTrustLevelQuad(q),
     );
-    const trustedGeneratedCatalogQuads = trustedGeneratedCatalogTriples.size > 0
-      ? quadsToPromote.filter((q) => trustedGeneratedCatalogTriples.has(catalogTripleKey(q)))
-      : [];
-    if (trustedGeneratedCatalogQuads.length > 0) {
-      quadsToPromote = quadsToPromote.filter(
-        (q) => !trustedGeneratedCatalogTriples.has(catalogTripleKey(q)),
-      );
-    }
-
-    if (opts?.entities && opts.entities !== 'all') {
-      const entitySet = new Set(opts.entities);
-      const genidPrefixes = opts.entities.map((e) => `${e}/.well-known/genid/`);
-      quadsToPromote = quadsToPromote.filter(
-        (q) =>
-          entitySet.has(q.subject) ||
-          genidPrefixes.some((prefix) => q.subject.startsWith(prefix)),
-      );
-    }
-
-    // Nothing left after reserved-subject or selective-entity filtering is also
-    // a no-op. It must clear stale full-share state rather than act like a fresh
-    // complete share.
-    if (quadsToPromote.length === 0) {
+    if (quadsToPromote.length === 0 && privateQuadsToPromote.length === 0) {
       await maintainMarker(false);
-      return { promotedCount: 0, promotedAllRoots: false };
+      throw Object.assign(
+        new Error(
+          `Finalized graph-scoped assertion <${sealSubject}> contains only filtered protocol metadata`,
+        ),
+        { code: 'KA_GRAPH_CONTENT_MISSING' },
+      );
     }
 
     const namedGraphs = [...new Set(quadsToPromote
@@ -6760,26 +6879,57 @@ export class DKGPublisher implements Publisher {
 
     const operationId = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
 
-    // Skolemize blank nodes so local SWM and gossip peers store identical data.
-    const kaMap = skolemizeByEntity(quadsToPromote);
-    if (kaMap.size === 0) {
+    // Canonicalize both partitions together so blank-node labels stay stable
+    // across the public/private boundary and validate the complete sealed KA.
+    const normalizedParts = await skolemizeKnowledgeAssetParts(
+      quadsToPromote,
+      privateQuadsToPromote,
+      {
+      allowCanonicalSkolemTerms: true,
+      },
+    );
+    const normalizedQuads = normalizedParts.publicQuads;
+    const normalizedPrivateQuads = normalizedParts.privateQuads;
+    if (normalizedQuads.length !== seal.publicTripleCount) {
       throw new Error(
-        'Cannot promote assertion: no root entities found. ' +
-        'Assertions must contain at least one named (non-blank-node) subject.',
+        `Graph-scoped assertion triple-count mismatch: seal=${seal.publicTripleCount}, ` +
+        `working-memory=${normalizedQuads.length}`,
       );
     }
-    const normalizedQuads = [...kaMap.values()].flat();
-    const rootEntities = [...kaMap.keys()];
-
-    const swmMetaGraph = this.graphManager.sharedMemoryMetaUri(contextGraphId, opts?.subGraphName);
-    const ownershipKey = opts?.subGraphName ? `${contextGraphId}\0${opts.subGraphName}` : contextGraphId;
-    const swmOwners = await tagPromoteStep('sharedMemoryOwnersForPromotion', () => this.sharedMemoryOwnersForPromotion(
-      contextGraphId,
-      opts?.subGraphName,
-      ownershipKey,
-      rootEntities,
-    ));
-    const swmOwned = this.sharedMemoryOwnedEntities.get(ownershipKey) ?? new Map<string, string>();
+    if (normalizedPrivateQuads.length !== seal.privateTripleCount) {
+      throw new Error(
+        `Graph-scoped assertion private triple-count mismatch: seal=${seal.privateTripleCount}, ` +
+        `private-store=${normalizedPrivateQuads.length}`,
+      );
+    }
+    const promotedPrivateRoot = computePrivateRoot(normalizedPrivateQuads);
+    const privateRootMatches = seal.privateMerkleRoot === undefined
+      ? promotedPrivateRoot === undefined
+      : promotedPrivateRoot !== undefined
+        && seal.privateMerkleRoot.length === promotedPrivateRoot.length
+        && seal.privateMerkleRoot.every((byte, index) => byte === promotedPrivateRoot[index]);
+    if (!privateRootMatches) {
+      throw new Error(
+        `Graph-scoped assertion private Merkle mismatch: seal=${seal.privateMerkleRoot
+          ? ethers.hexlify(seal.privateMerkleRoot)
+          : '(none)'}, private-store=${promotedPrivateRoot
+          ? ethers.hexlify(promotedPrivateRoot)
+          : '(none)'}`,
+      );
+    }
+    const promotedMerkleRoot = computeFlatKCRoot(
+      normalizedQuads,
+      promotedPrivateRoot ? [promotedPrivateRoot] : [],
+    );
+    if (
+      promotedMerkleRoot.length !== seal.merkleRoot.length ||
+      !promotedMerkleRoot.every((byte, index) => byte === seal.merkleRoot[index])
+    ) {
+      throw new Error(
+        `Graph-scoped assertion Merkle mismatch: seal=${ethers.hexlify(seal.merkleRoot)}, ` +
+        `working-memory=${ethers.hexlify(promotedMerkleRoot)}`,
+      );
+    }
 
     // Pre-encode gossip message and enforce size limit BEFORE any destructive
     // mutations, so oversized promotions are rejected cleanly while the
@@ -6793,24 +6943,24 @@ export class DKGPublisher implements Publisher {
             `<${q.subject}> <${q.predicate}> ${q.object.startsWith('"') ? q.object : `<${q.object}>`} <${dataGraph}> .`,
         )
         .join('\n');
-      const manifestEntries = rootEntities.map((rootEntity) => ({
-        rootEntity,
-        privateMerkleRoot: undefined,
-        privateTripleCount: 0,
-      }));
       const timestampMs = Date.now();
-      const promoteKaNumber = await tagPromoteStep('resolveKaNumber', () => this.resolveKaNumber(contextGraphId, agentAddress, name, opts?.subGraphName));
       const encoded = encodeWorkspacePublishRequest({
         contextGraphId: contextGraphId,
         nquads: new TextEncoder().encode(nquadsStr),
-        manifest: manifestEntries,
+        manifest: [],
         publisherPeerId: opts.publisherPeerId,
         shareOperationId: operationId,
         timestampMs,
         operationId,
         subGraphName: opts.subGraphName,
-        agentAddress,
-        kaNumber: promoteKaNumber !== null ? String(promoteKaNumber) : undefined,
+        agentAddress: contentScope.agentAddress,
+        kaNumber: contentScope.kaNumber,
+        contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+        kaUal: contentScope.ual,
+        assertionVersion: contentScope.assertionVersion,
+        publicTripleCount: normalizedQuads.length,
+        ...(promotedPrivateRoot ? { privateMerkleRoot: promotedPrivateRoot } : {}),
+        privateTripleCount: normalizedPrivateQuads.length,
       });
 
       // Wrap the plaintext publish-request in the encrypted envelope
@@ -6838,7 +6988,7 @@ export class DKGPublisher implements Publisher {
       ));
 
       if (wrapped.length > DKG_GOSSIP_MAX_MESSAGE_BYTES) {
-        const hint = `Promote fewer entities per call.`;
+        const hint = 'Reduce the complete assertion payload size.';
         throw new SwmGossipPayloadTooLargeError({
           actualBytes: wrapped.length,
           maxBytes: DKG_GOSSIP_MAX_MESSAGE_BYTES,
@@ -6870,91 +7020,15 @@ export class DKGPublisher implements Publisher {
       }
     }
 
-    // OT-RFC-46 §17.4 / rc.17 D6 — workspaceOwner is now an ADVISORY hint, not a
-    // hard exclusivity gate: a foreign co-claim is no longer REJECTED (the Rule-4
-    // throw is removed). While SWM is still a shared bucket (pre rc.17b per-KA
-    // conversion) we SKIP foreign-owned roots so a co-claim cannot clobber the
-    // owner's quads in the shared graph; once SWM is per-KA (each peer owns its own
-    // graph) this skip is dropped entirely and overlap is fully allowed.
-    const skippedRoots = new Set<string>();
-    for (const root of rootEntities) {
-      const owner = swmOwners.get(root);
-      if (!owner) continue;
-      if (opts?.publisherPeerId && owner === opts.publisherPeerId) continue; // self-owned — proceed
-      this.log.warn(
-        createOperationContext('share'),
-        `Skipping entity <${root}>: owned by peer ${owner} in SWM (advisory ownership; co-claim not rejected). caller=${opts?.publisherPeerId ?? '(none)'}`,
-      );
-      skippedRoots.add(root);
-    }
-
-    // Filter out skipped roots so subsequent mutations don't touch foreign-owned data.
-    const effectiveRoots = skippedRoots.size > 0
-      ? rootEntities.filter(r => !skippedRoots.has(r))
-      : rootEntities;
-    const effectiveQuads = skippedRoots.size > 0
-      ? normalizedQuads.filter(q => !skippedRoots.has(q.subject) && !skippedRoots.has(q.subject.split('/.well-known/genid/')[0]))
-      : normalizedQuads;
-
-    // #1116 FIX 1 — did this promote cover the FULL requested/sealed root set?
-    // A FULL share seals ALL of `rootEntities`, but the advisory ownership skip
-    // above can promote only `effectiveRoots`. When any root is foreign-skipped
-    // the SWM copy is missing part of the sealed set, so the seal exists but the
-    // asset is NOT publish-ready (publishFromFinalizedAssertion would recompute a
-    // different merkleRoot over the partial SWM slice and fail the seal guard).
-    // The agent's promote() threads this into `publishReady`. A no-op with roots
-    // but no effective quads is not a complete share and must not stamp a fresh
-    // shareOperationId for async VM publish.
-    const promotedAllRoots = skippedRoots.size === 0 && effectiveQuads.length > 0;
-
-    if (effectiveRoots.length === 0 || effectiveQuads.length === 0) {
-      // Nothing is actually promoted, either because every root was skipped or
-      // because the remaining root set has no publishable quads. This is never a
-      // complete full share.
-      await maintainMarker(false);
-      return { promotedCount: 0, promotedAllRoots: false };
-    }
-
-    // Delete-then-insert for existing SWM entities (upsert), matching
-    // _shareImpl and SharedMemoryHandler so re-promotes replace stale triples.
-    // Safe after the ownership check above — only self-owned or unowned roots remain.
-    for (const root of effectiveRoots) {
-      if (swmOwned.has(root)) {
-        await this.store.deleteByPattern({ graph: swmGraphUri, subject: root });
-        await this.store.deleteBySubjectPrefix(swmGraphUri, root + '/.well-known/genid/');
-        await this.deleteMetaForRoot(swmMetaGraph, root);
-      }
-    }
-
-    const swmQuads = effectiveQuads.map((q) => ({ ...q, graph: swmGraphUri }));
-    await this.store.insert(swmQuads);
-
-    // Delete promoted triples from assertion graph (only the effective, non-skipped roots)
-    const effectivePromoteQuads = skippedRoots.size > 0
-      ? quadsToPromote.filter(q => !skippedRoots.has(q.subject) && !skippedRoots.has(q.subject.split('/.well-known/genid/')[0]))
-      : quadsToPromote;
-    const wmQuadsToDelete = [...effectivePromoteQuads, ...trustedGeneratedCatalogQuads];
-    // A full promote that consumes every WM quad can drop its assertion-scoped
-    // graphs directly. Besides being cheaper, this avoids serializing a large
-    // connected blank-node component as one DELETE ... WHERE pattern. Such a
-    // pattern is legal SPARQL but its self-join can grow combinatorially (a
-    // 100-triple Wikidata assertion took minutes of one-core Oxigraph CPU).
-    //
-    // Keep the precise delete path whenever anything must remain in WM:
-    // subset shares, foreign-owned-root skips, or reserved provenance/trust
-    // rows filtered out of the SWM payload. `wmQuadsToDelete` is derived only
-    // from `assertionQuads`, and the trusted catalog subset is disjoint from
-    // `effectivePromoteQuads`, so equal lengths prove the full graph is
-    // consumed without a second store scan.
-    const consumesEntireAssertion =
-      promotingAllEntities
-      && skippedRoots.size === 0
-      && wmQuadsToDelete.length === assertionQuads.length;
-    if (consumesEntireAssertion) {
-      await this.dropAssertionScopedGraphs(graphUri);
-    } else {
-      await this.deleteAssertionScopedQuads(graphUri, wmQuadsToDelete);
-    }
+    // The UAL-derived graph is the ownership boundary. Replace the complete
+    // graph; never inspect, claim, skip, or delete individual RDF subjects.
+    const swmQuads = normalizedQuads.map((q) => ({ ...q, graph: swmGraphUri }));
+    await this.replaceExactKnowledgeAssetGraph(
+      swmGraphUri,
+      swmQuads,
+      'Knowledge Asset WM-to-SWM promotion',
+    );
+    await this.dropAssertionScopedGraphs(graphUri);
 
     // Update the assertion's memory layer from WM → SWM in _meta
     const assertionMetaGraph = contextGraphMetaUri(contextGraphId);
@@ -6965,55 +7039,26 @@ export class DKGPublisher implements Publisher {
       predicate: DKG_MEMORY_LAYER,
     });
     await this.store.insert([{
-      subject: graphUri,
+      subject: swmGraphUri,
       predicate: DKG_MEMORY_LAYER,
       object: '"SWM"',
       graph: assertionMetaGraph,
     }]);
-
-    // RFC ka-metadata-trim Phase 3 (P3.4): the `ShareTransition` record
-    // (spec §8) is no longer written. Its only consumer — the node-ui
-    // on-chain-receipt hook — now reads the seal-subject receipt rows in
-    // `_meta` directly (read-both: it still falls back to ShareTransition
-    // rows for old stores). The entity→assertion bridge it provided is
-    // carried by the seal's `dkg:assertionRootEntity`/`dkg:assertionEntity`
-    // rows and the lifecycle record's member-entity stamps.
-
-    // #1116 (round 7) — REPLACE (not append) the lifecycle-URN member rows on a
-    // FULL-COMPLETE share. `generateAssertionPromotedMetadata` only INSERTs the
-    // member rows (its delete set never removes prior ones — metadata.ts), so a
-    // full {A,C} → discard → recreate → full {A,B} cycle (or a no-discard full
-    // re-share) accumulates the stale UNION {A,B,C}. The seal-less SWM
-    // reconstruction (readPromotedRootEntities) then seals a stale SUPERSET. When
-    // this promote is the AUTHORITATIVE current full set (entities:"all" AND no
-    // foreign root skipped — exactly the markSwmShareComplete condition), the rows
-    // must end up as EXACTLY the just-promoted roots. Clear the prior member rows
-    // for the lifecycle URN here, then stamp the current ones below.
-    //
-    // A SUBSET / partial promote is intentionally NOT replaced: it shares only some
-    // roots, the marker is cleared (round 6) so readPromotedRootEntities output is
-    // gated-out, and over-deleting could drop a still-valid member. The audit
-    // confirmed no reader needs the cumulative historical union; all read the
-    // CURRENT set, so REPLACE-on-full is strictly more correct.
-    // `promotingAllEntities` is hoisted to the top of the method (round 10) so the
-    // early-return marker maintenance can use it; reuse it here.
-    const isFullCompletePromote = promotingAllEntities && promotedAllRoots;
+    const promotedAllRoots = true; // compatibility return name; v2 has no roots.
+    const isFullCompletePromote = true;
     await clearCurrentShareOperationId();
-    if (isFullCompletePromote) {
-      await this.store.deleteByPattern({ graph: promoteMetaGraph, subject: lifecycleSubject, predicate: DKG_ROOT_ENTITY_LEGACY });
-      await this.store.deleteByPattern({ graph: promoteMetaGraph, subject: lifecycleSubject, predicate: DKG_ENTITY });
-    }
+    await this.store.deleteByPattern({ graph: promoteMetaGraph, subject: lifecycleSubject, predicate: DKG_ROOT_ENTITY_LEGACY });
+    await this.store.deleteByPattern({ graph: promoteMetaGraph, subject: lifecycleSubject, predicate: DKG_ENTITY });
 
     // Update assertion lifecycle record in _meta: created → promoted
-    const promotedKaNumber = await this.resolveKaNumber(contextGraphId, agentAddress, name, opts?.subGraphName);
     const promoted = generateAssertionPromotedMetadata({
       contextGraphId,
       agentAddress,
       assertionName: name,
       subGraphName: opts?.subGraphName,
-      kaNumber: promotedKaNumber ?? undefined,
+      kaNumber: BigInt(contentScope.kaNumber),
       shareOperationId: operationId,
-      rootEntities: effectiveRoots,
+      rootEntities: [],
       timestamp: new Date(),
     }, { provenanceEvents: this.provenanceEvents });
     await this.store.delete(promoted.delete);
@@ -7029,53 +7074,39 @@ export class DKGPublisher implements Publisher {
     // EVERY caller of the public assertionPromote — no desync on a direct caller.
     await maintainMarker(isFullCompletePromote);
 
-    // Write WorkspaceOperation metadata + ownership quads, mirroring what
-    // _shareImpl and the remote SharedMemoryHandler both produce, so the
-    // promoting node and replicas converge on identical ownership state.
-    if (opts?.publisherPeerId) {
-      const operationTimestamp = new Date();
-      await storeWorkspaceOperationPublicQuads({
-        store: this.store,
-        graphManager: this.graphManager,
-        contextGraphId,
-        shareOperationId: operationId,
-        rootEntities: effectiveRoots,
-        quads: swmQuads,
-        publisherPeerId: opts.publisherPeerId,
-        agentAddress,
-        subGraphName: opts.subGraphName,
-        timestamp: operationTimestamp,
-        publicSnapshotStore: this.publicSnapshotStore,
-      });
+    await storeKnowledgeAssetOperationPublicQuads({
+      store: this.store,
+      graphManager: this.graphManager,
+      contextGraphId,
+      shareOperationId: operationId,
+      kaUal: contentScope.ual,
+      assertionVersion: contentScope.assertionVersion,
+      quads: swmQuads,
+      ...(promotedPrivateRoot ? { privateMerkleRoot: promotedPrivateRoot } : {}),
+      privateTripleCount: normalizedPrivateQuads.length,
+      publisherPeerId: opts?.publisherPeerId,
+      agentAddress: contentScope.agentAddress,
+      subGraphName: opts?.subGraphName,
+      timestamp: new Date(),
+      publicSnapshotStore: this.publicSnapshotStore,
+    });
 
-      if (!this.sharedMemoryOwnedEntities.has(ownershipKey)) {
-        this.sharedMemoryOwnedEntities.set(ownershipKey, new Map());
-      }
-      const liveOwned = this.sharedMemoryOwnedEntities.get(ownershipKey)!;
-      const newOwnershipEntries: { rootEntity: string; creatorPeerId: string }[] = [];
-      for (const r of effectiveRoots) {
-        if (!liveOwned.has(r)) {
-          newOwnershipEntries.push({ rootEntity: r, creatorPeerId: opts.publisherPeerId });
-        }
-      }
-      if (newOwnershipEntries.length > 0) {
-        for (const entry of newOwnershipEntries) {
-          await this.store.deleteByPattern({
-            graph: swmMetaGraph, subject: entry.rootEntity, predicate: 'http://dkg.io/ontology/workspaceOwner',
-          });
-        }
-        await this.store.insert(generateOwnershipQuads(newOwnershipEntries, swmMetaGraph));
-        for (const entry of newOwnershipEntries) {
-          liveOwned.set(entry.rootEntity, entry.creatorPeerId);
-        }
-      }
-    }
-
-    return { promotedCount: swmQuads.length, gossipMessage, promotedAllRoots, shareOperationId: operationId };
+    return {
+      promotedCount: swmQuads.length + normalizedPrivateQuads.length,
+      gossipMessage,
+      promotedAllRoots,
+      shareOperationId: operationId,
+    };
   }
 
   async assertionDiscard(contextGraphId: string, name: string, agentAddress: string, subGraphName?: string): Promise<void> {
     DKGPublisher.validateOptionalSubGraph(subGraphName);
+    await this.assertGraphScopedLifecycleWritable(
+      contextGraphId,
+      agentAddress,
+      name,
+      subGraphName,
+    );
     const graphUri = await this.wmGraphUri(contextGraphId, agentAddress, name, subGraphName);
     // Drop the assertion data graph AND clean up any `_meta` rows keyed
     // by this assertion's UAL in the CG root `_meta` graph. Without this
@@ -7183,6 +7214,12 @@ export class DKGPublisher implements Publisher {
       await this.clearAssertionSeal(contextGraphId, name, agentAddress, subGraphName);
     }
     await this.dropAssertionScopedGraphs(graphUri);
+    await this.privateStore.deleteKnowledgeAssetPrivateDraft(
+      contextGraphId,
+      agentAddress,
+      name,
+      subGraphName,
+    );
   }
 
   /**

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -3866,7 +3866,11 @@ export class DKGPublisher implements Publisher {
       scope,
       { quadFilter: (quad) => !isSwmMerkleExcludedQuad(quad) },
     );
-    if (quads.length === 0) {
+    // Fully private KAs legitimately have ZERO public SWM quads — the update
+    // then carries only the private partition and its commitment (an empty
+    // envelope is already rejected by the descriptor). Reject only when the
+    // envelope promises public content that shared memory lacks.
+    if (quads.length === 0 && descriptor.publicTripleCount > 0) {
       throw new Error(
         `No quads in shared memory for graph-scoped KA ${descriptor.scope.ual}`,
       );
@@ -7028,7 +7032,11 @@ export class DKGPublisher implements Publisher {
       swmQuads,
       'Knowledge Asset WM-to-SWM promotion',
     );
-    await this.dropAssertionScopedGraphs(graphUri);
+    // NB: WM source cleanup and the pending-share-operation clear happen at the
+    // very END of this tail. Every write between here and there is fallible; if
+    // WM were dropped now (or the recovery pointer cleared), a failure below
+    // would strand the promotion: retry re-enters, reads empty WM, and aborts
+    // with KA_GRAPH_CONTENT_MISSING / a seal count mismatch.
 
     // Update the assertion's memory layer from WM → SWM in _meta
     const assertionMetaGraph = contextGraphMetaUri(contextGraphId);
@@ -7046,7 +7054,6 @@ export class DKGPublisher implements Publisher {
     }]);
     const promotedAllRoots = true; // compatibility return name; v2 has no roots.
     const isFullCompletePromote = true;
-    await clearCurrentShareOperationId();
     await this.store.deleteByPattern({ graph: promoteMetaGraph, subject: lifecycleSubject, predicate: DKG_ROOT_ENTITY_LEGACY });
     await this.store.deleteByPattern({ graph: promoteMetaGraph, subject: lifecycleSubject, predicate: DKG_ENTITY });
 
@@ -7090,6 +7097,13 @@ export class DKGPublisher implements Publisher {
       timestamp: new Date(),
       publicSnapshotStore: this.publicSnapshotStore,
     });
+
+    // Only after every durable write above: consume the pending share
+    // operation and drop the WM source. A failure anywhere above leaves WM and
+    // the recovery pointer intact, so a retry re-promotes the exact same
+    // content instead of aborting on empty working memory.
+    await clearCurrentShareOperationId();
+    await this.dropAssertionScopedGraphs(graphUri);
 
     return {
       promotedCount: swmQuads.length + normalizedPrivateQuads.length,

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -5,7 +5,7 @@ import type { EventBus, GraphKnowledgeAssetScope, OperationContext } from '@orig
 import { DKGEvent, Logger, createOperationContext, sha256, encodeWorkspacePublishRequest, encodeEncryptedWorkspacePayload, encryptWorkspacePayload, contextGraphDataUri, contextGraphDataGraphUri, contextGraphMetaUri, contextGraphAssertionUri, contextGraphLayerUri, MemoryLayer, assertionLifecycleUri, contextGraphSubGraphUri, contextGraphSubGraphMetaUri, SYSTEM_CONTEXT_GRAPHS, validateSubGraphName, isSafeIri, assertSafeIri, assertSafeRdfTerm, assertQuadLiteralsMutf8Safe, DKG_GOSSIP_MAX_MESSAGE_BYTES, SwmGossipPayloadTooLargeError, STORAGE_ACK_MAX_STAGING_BYTES, type Ed25519Keypair, buildAuthorAttestationTypedData, buildUpdateAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1, TrustLevel, TRUST_LEVEL_PREDICATE, assertNoUserAuthoredTrustLevelQuads, buildTrustLevelQuads, isTrustLevelQuad, isSwmMerkleExcludedQuad, WORKSPACE_OWNER_PREDICATE, DKG_ENTITY, DKG_ROOT_ENTITY_LEGACY, ENTITY_PRED_ALT, parseAssertionSealQuads, ASSERTION_SEAL_PREDICATES, sharedMemoryReadBothFilter, DKG_ONTOLOGY, GRAPH_KA_CONTENT_SCOPE_VERSION, LegacyKnowledgeAssetReadOnlyError, createGraphKnowledgeAssetScope, knowledgeAssetLayerGraphUri } from '@origintrail-official/dkg-core';
 import { GraphManager, PrivateContentStore, loadSharedMemoryQuadsForScope, loadSelectedSharedMemoryQuads, migrateSharedMemoryRootClosureToNamedLifecycle, resolveSharedMemoryScopeGraphs, tryReplaceGraphAtomically, type NamedLifecycleSharedMemoryMigrationResult } from '@origintrail-official/dkg-storage';
 import { DEFAULT_PUBLISH_EPOCHS, MAX_PUBLISH_EPOCHS, type Publisher, type PublishOptions, type PublishResult, type KAManifestEntry, type PhaseCallback, type V10CoreNodeACK, type V10ACKProviderParams, type V10ACKProviderObject, type LegacyV10ACKProvider } from './publisher.js';
-import { assertNoUserAuthoredKnowledgeAssetSkolemTerms, skolemizeByEntity, skolemizeKnowledgeAsset, skolemizeKnowledgeAssetParts } from './auto-partition.js';
+import { assertNoUserAuthoredKnowledgeAssetSkolemTerms, deskolemizeKnowledgeAssetQuads, skolemizeByEntity, skolemizeKnowledgeAsset, skolemizeKnowledgeAssetParts } from './auto-partition.js';
 import { withKeyedLocks } from './keyed-lock.js';
 import { tagPromoteStep } from './promote-step-tag.js';
 import { canonicalPublishPayload } from './canonical-publish-payload.js';
@@ -57,7 +57,7 @@ import {
   type KAMetadata,
   type OnChainProvenance,
 } from './metadata.js';
-import { storeKnowledgeAssetOperationPublicQuads, storeWorkspaceOperationPublicQuads } from './workspace-resolution.js';
+import { resolveKnowledgeAssetOperationPublicQuads, resolveKnowledgeAssetWorkspaceHead, storeKnowledgeAssetOperationPublicQuads, storeWorkspaceOperationPublicQuads } from './workspace-resolution.js';
 import type { WorkspacePublicSnapshotStore } from './workspace-snapshot-store.js';
 import { ethers } from 'ethers';
 import type { WorkspaceAgentRecipientResolver } from './workspace-agent-recipients.js';
@@ -6481,19 +6481,19 @@ export class DKGPublisher implements Publisher {
     await this.ensureSubGraphRegistered(contextGraphId, subGraphName);
     const wmGraph = await this.wmGraphUri(contextGraphId, agentAddress, name, subGraphName);
     const metaGraph = contextGraphMetaUri(contextGraphId);
-    const sourceGraph = sourceLayer === 'swm'
-      ? this.graphManager.sharedMemoryUri(contextGraphId, subGraphName)
-      // PR #972/a6740ac: a sub-scoped VM pull reads the SUBGRAPH's data graph,
-      // not the root data graph (mirrors the SWM branch's subGraphName handling).
-      : subGraphName
-        ? this.graphManager.subGraphUri(contextGraphId, subGraphName)
-        : this.graphManager.dataGraphUri(contextGraphId);
 
-    // onConflict: refuse to clobber a dirty WM draft unless told to replace it.
-    // NB: the actual DROP happens only AFTER the source is validated non-empty
-    // (below) — PR #972/335e8d8: dropping first could destroy an open draft when
-    // the pull turns out to have no source quads.
-    const hasDraft = await this.assertionScopedHasQuads(wmGraph);
+    // onConflict: refuse to clobber a dirty WM draft (public OR private) unless
+    // told to replace it. NB: the actual DROP happens only AFTER the source is
+    // validated non-empty (below) — PR #972/335e8d8: dropping first could
+    // destroy an open draft when the pull turns out to have no source quads.
+    const hasPublicDraft = await this.assertionScopedHasQuads(wmGraph);
+    const hasPrivateDraft = (await this.privateStore.getKnowledgeAssetPrivateDraftTriples(
+      contextGraphId,
+      agentAddress,
+      name,
+      subGraphName,
+    )).length > 0;
+    const hasDraft = hasPublicDraft || hasPrivateDraft;
     if (hasDraft && (opts?.onConflict ?? 'reject') === 'reject') {
       throw Object.assign(
         new Error(`A WM draft already exists for "${name}" in context graph "${contextGraphId}"; pass onConflict:"replace" to overwrite it.`),
@@ -6501,21 +6501,12 @@ export class DKGPublisher implements Publisher {
       );
     }
 
-    // Resolve the file's member entities from the SEAL. PR #972/335e8d8: the
-    // seal is stamped at finalize under the assertion-graph URI
-    // (`contextGraphAssertionUri`) in the meta graph — NOT under the
-    // lifecycle URN. The prior code read `assertionLifecycleUri`, a
-    // different subject, so the lookup found nothing and pull-from failed for
-    // EVERY finalized assertion.
-    //
-    // #1094: the same class of bug, second occurrence. `wmGraphUri()` only
-    // equals `contextGraphAssertionUri` BEFORE a kaId is minted; finalize
-    // stamps `dkg:kaId`, after which `wmGraphUri()` resolves to the numbered
-    // per-KA layer URI (`…/_working_memory/<addr>/<n>`). Reading the seal
-    // under `wmGraph` therefore failed for every finalized-AND-minted
-    // assertion — exactly the population pull-from exists for. The seal's
-    // canonical subject is the name-keyed assertion URI; check it first and
-    // keep the wmGraph subject as a legacy fallback (they coincide pre-mint).
+    // Resolve the seal. PR #972/335e8d8: the seal is stamped at finalize under
+    // the assertion-graph URI (`contextGraphAssertionUri`) in the meta graph —
+    // NOT under the lifecycle URN. #1094: after a kaId is minted, `wmGraphUri`
+    // resolves to the numbered per-KA layer URI, so check the canonical
+    // name-keyed subject first and keep the wmGraph subject as a legacy
+    // fallback (they coincide pre-mint).
     const sealSubject = contextGraphAssertionUri(contextGraphId, agentAddress, name, subGraphName);
     let sealRes = await this.store.query(
       `CONSTRUCT { <${sealSubject}> ?p ?o } WHERE { GRAPH <${metaGraph}> { <${sealSubject}> ?p ?o } }`,
@@ -6527,108 +6518,132 @@ export class DKGPublisher implements Publisher {
       );
       seal = parseAssertionSealQuads(sealRes.type === 'quads' ? sealRes.quads : [], wmGraph);
     }
-    // #1116: a seal is no longer required to pull from SWM. When the asset was
-    // shared UNSEALED (a `skipSeal` share, or an asset stuck unsealed under the
-    // old auto-finalize-swallow behavior), fall back to the member entities
-    // stamped on the lifecycle URN by every promote
-    // (`generateAssertionPromotedMetadata`, predicate dkg:rootEntity) — recorded
-    // independent of any seal. This is what lets seal-in-SWM (finalize
-    // layer=swm) and recovery reconstruct the WM draft without first finalizing.
-    // VM pulls still require the seal (VM content is keyed by the published
-    // roots, which only the seal records).
-    // #1116 (review A1, rounds 5/7/8) — the SWM reconstruction is the ROOT of the
-    // subset-publishability bypass, and the guard MUST live here at the single
-    // publisher chokepoint so EVERY caller is covered (the finalize(layer:"swm")
-    // wrapper AND the direct wm/pull-from route + a plain finalize).
-    //
-    // Crucially, an SWM pull must NEVER trust the seal's rootEntities for scope:
-    // a stale FULL seal survives a SUBSET re-share (a subset share never
-    // re-seals, and `create` without a discard does not clear the seal — it lives
-    // on the name-keyed assertion URI, outside the lifecycle-URN clean-slate). If
-    // we read that stale seal it would short-circuit the subset gate below and let
-    // the direct route reconstruct + publish a superseded/partial asset under the
-    // KA name (round-8 live repro). So for SWM we ALWAYS resolve from the
-    // promote-stamped member rows, gated on the full-share completeness marker —
-    // the seal is rebuilt at the next finalize anyway (and torn down below). VM
-    // pulls still use the seal (VM content is keyed by the published roots, which
-    // only the seal records).
-    let entities: string[];
-    if (sourceLayer === 'swm') {
-      const promotedRoots = await this.readPromotedRootEntities(contextGraphId, agentAddress, name, subGraphName);
-      if (promotedRoots.length > 0) {
-        const fullyShared = await this.hasSwmShareComplete(contextGraphId, name, agentAddress, subGraphName);
-        if (!fullyShared) {
-          throw Object.assign(
-            new Error(
-              `"${name}" in context graph "${contextGraphId}" was only shared to SWM as a SUBSET — `
-              + `reconstructing or sealing it would publish a partial asset under the KA name. `
-              + `Share the full asset (entities:"all") before sealing in SWM.`,
-            ),
-            { code: 'SWM_SUBSET_NOT_SEALABLE' },
-          );
-        }
-      }
-      entities = promotedRoots;
-    } else {
-      entities = seal?.rootEntities ?? [];
+
+    // A graph-scoped KA is atomic: pulls restore the COMPLETE assertion (public
+    // graph + private partition) by KA identity — RDF subjects never act as
+    // lifecycle identity. Legacy root-scoped assets are read-only on this
+    // model, so fail closed before any draft mutation.
+    if (seal && seal.contentScopeVersion !== GRAPH_KA_CONTENT_SCOPE_VERSION) {
+      throw new LegacyKnowledgeAssetReadOnlyError();
     }
-    if (entities.length === 0) {
-      throw new Error(
-        `No member entities for "${name}" in context graph "${contextGraphId}" — pull-from `
-        + `requires either a finalized assertion (its seal records the members) or a prior `
-        + `promote to SWM (which stamps the members on the lifecycle record). Found neither.`,
+
+    // Identity: the seal's UAL when sealed; else the lifecycle identity a prior
+    // finalize preserved (pull-from itself clears the seal on re-open, so a
+    // second pull legitimately arrives unsealed).
+    let kaUal = seal?.kaUal;
+    if (!kaUal) {
+      const identity = await this.resolveKaGraphIdentity(contextGraphId, agentAddress, name, subGraphName);
+      kaUal = identity?.kaUal;
+    }
+    if (!kaUal) {
+      throw Object.assign(
+        new Error(
+          `"${name}" in context graph "${contextGraphId}" has no graph-scoped KA identity — `
+          + `pull-from requires a finalized assertion (its seal records the KA UAL) or a `
+          + `preserved reserved UAL from a prior finalize.`,
+        ),
+        { code: 'PULL_FROM_NO_KA_IDENTITY' },
       );
     }
 
-    // Gather the source-layer quads scoped to the entity set + skolem children
-    // (same filter the publish gather / RS prover use), minus trust/ownership
-    // bookkeeping that never belongs in a working draft.
-    const values = entities.map((e) => `<${e}>`).join(' ');
-    // #1094: a per-KA `vm/publish` writes the canonical quads into the
-    // numbered per-KA VM graph `…/_verifiable_memory/{author}/{number}`
-    // (see SUBSTRATE-2 in dkg-agent-publish.ts) and, for on-chain CGs,
-    // into the per-on-chain-id partition `…/context/{ctxGraphId}` — NOT
-    // (only) the bare data graph this branch used to read. Pulling from
-    // "vm" therefore came back empty for exactly the published KAs the
-    // edit loop exists for. Scan the data graph PLUS both VM-side graph
-    // families; CONSTRUCT output is a set, so overlapping copies dedup.
-    const vmBase = subGraphName
-      ? `did:dkg:context-graph:${contextGraphId}/${subGraphName}`
-      : `did:dkg:context-graph:${contextGraphId}`;
-    const vmGraphFilter =
-      `FILTER(STR(?g) = "${sourceGraph}" ` +
-      `|| STRSTARTS(STR(?g), "${vmBase}/_verifiable_memory/") ` +
-      `|| STRSTARTS(STR(?g), "did:dkg:context-graph:${contextGraphId}/context/"))`;
-    // Per-KA SWM: when pulling from SWM the source spans the per-KA prefix, not one bucket.
-    const sourcePattern = sourceLayer === 'swm'
-      ? `GRAPH ?g { VALUES ?root { ${values} } ?s ?p ?o . FILTER(?s = ?root || STRSTARTS(STR(?s), CONCAT(STR(?root), "/.well-known/genid/"))) } ${sharedMemoryReadBothFilter(sourceGraph)}`
-      : `GRAPH ?g { VALUES ?root { ${values} } ?s ?p ?o . FILTER(?s = ?root || STRSTARTS(STR(?s), CONCAT(STR(?root), "/.well-known/genid/"))) } ${vmGraphFilter}`;
-    const gather = await this.store.query(
-      `CONSTRUCT { ?s ?p ?o } WHERE { ${sourcePattern} }`,
+    let publicQuads: Quad[];
+    let privateQuads: Quad[];
+    let pulledAssertionVersion: string;
+    if (sourceLayer === 'swm') {
+      // The durable SWM head names the exact current assertion; the immutable
+      // operation snapshot it points at is digest-validated, so a torn or
+      // partially-replaced live graph can never seed a draft silently.
+      const head = await resolveKnowledgeAssetWorkspaceHead({
+        store: this.store,
+        graphManager: this.graphManager,
+        contextGraphId,
+        kaUal,
+        subGraphName,
+      });
+      if (!head) {
+        throw Object.assign(
+          new Error(
+            `No SWM state found for "${name}" (${kaUal}) in context graph "${contextGraphId}"; `
+            + `WM draft was not modified.`,
+          ),
+          { code: 'PULL_FROM_EMPTY_SOURCE' },
+        );
+      }
+      const snapshot = await resolveKnowledgeAssetOperationPublicQuads({
+        store: this.store,
+        graphManager: this.graphManager,
+        contextGraphId,
+        shareOperationId: head.shareOperationId,
+        kaUal,
+        assertionVersion: head.assertionVersion,
+        subGraphName,
+        publicSnapshotStore: this.publicSnapshotStore,
+      });
+      publicQuads = snapshot.quads;
+      pulledAssertionVersion = head.assertionVersion;
+    } else {
+      if (!seal) {
+        throw Object.assign(
+          new Error(
+            `A VM pull for "${name}" in context graph "${contextGraphId}" requires the assertion `
+            + `seal — only the seal records which published assertion version VM holds.`,
+          ),
+          { code: 'PULL_FROM_UNSEALED_VM' },
+        );
+      }
+      pulledAssertionVersion = seal.assertionVersion!;
+      const vmScope = createGraphKnowledgeAssetScope(kaUal, pulledAssertionVersion);
+      const vmGraph = knowledgeAssetLayerGraphUri(
+        contextGraphId,
+        MemoryLayer.VerifiableMemory,
+        vmScope,
+        subGraphName,
+      );
+      const gathered = await this.store.query(
+        `CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${assertSafeIri(vmGraph)}> { ?s ?p ?o } }`,
+      );
+      publicQuads = gathered.type === 'quads'
+        ? gathered.quads.map((quad) => ({ ...quad, graph: '' }))
+        : [];
+    }
+    publicQuads = publicQuads.filter((quad) => !isSwmMerkleExcludedQuad(quad));
+    privateQuads = await this.privateStore.getKnowledgeAssetPrivateTriples(
+      contextGraphId,
+      createGraphKnowledgeAssetScope(kaUal, pulledAssertionVersion),
+      subGraphName,
     );
-    const gathered = gather.type === 'quads'
-      ? gather.quads.filter((q) => !isSwmMerkleExcludedQuad(q))
-      : [];
 
     // Validate the source has content BEFORE touching the draft (PR #972/335e8d8:
     // a drop-before-validate could destroy an open WM draft when the source
     // turned out empty — e.g. pulling from a layer the file was never shared to).
-    if (gathered.length === 0) {
+    if (publicQuads.length + privateQuads.length === 0) {
       throw Object.assign(
         new Error(
-          `No ${sourceLayer.toUpperCase()} quads found for "${name}" in context graph "${contextGraphId}" `
-          + `using the assertion seal's ${entities.length} root entit${entities.length === 1 ? 'y' : 'ies'}; `
-          + `WM draft was not modified.`,
+          `No ${sourceLayer.toUpperCase()} content found for "${name}" (${kaUal}) in context graph `
+          + `"${contextGraphId}"; WM draft was not modified.`,
         ),
         { code: 'PULL_FROM_EMPTY_SOURCE' },
       );
     }
 
+    // Stored assertions carry canonical `urn:dkg:ka-skolem:c14nN` IRIs; restore
+    // them to blank nodes so the re-opened draft is fully unlabelled (see
+    // deskolemizeKnowledgeAssetQuads) and passes the user-input write guards.
+    const draftPublic = deskolemizeKnowledgeAssetQuads(publicQuads);
+    const draftPrivate = deskolemizeKnowledgeAssetQuads(privateQuads);
+
     // Source validated — now (re)open a fresh WM draft (clears stale
-    // lifecycle/seal) and seed it.
-    if (hasDraft) {
+    // lifecycle/seal) and seed it. The private draft is replaced alongside the
+    // public draft: a pull restores ONE complete assertion state.
+    if (hasPublicDraft) {
       await this.dropAssertionScopedGraphs(wmGraph); // 'replace' — git force-checkout, after source validation
     }
+    await this.privateStore.deleteKnowledgeAssetPrivateDraft(
+      contextGraphId,
+      agentAddress,
+      name,
+      subGraphName,
+    );
     await this.assertionCreate(contextGraphId, name, agentAddress, subGraphName);
     // #1094: `assertionCreate`'s clean-slate wipe only covers subjects under
     // the lifecycle URN — the SEAL lives under the name-keyed assertion URI
@@ -6637,13 +6652,20 @@ export class DKGPublisher implements Publisher {
     // "already finalized with a different merkleRoot" and the edit loop was
     // permanently wedged. Pull-from re-opens the draft for editing, so the
     // stale seal MUST go (it is rebuilt — same reservedKaId, preserved by
-    // assertionCreate's A2 carry-over — at the next finalize). Reuse the single
-    // clearAssertionSeal helper so the seal subject/predicate set has one source
-    // of truth (sealSubject == the helper's name-keyed assertion URI; wmGraph is
-    // re-resolved identically).
+    // assertionCreate's A2 carry-over — at the next finalize).
     await this.clearAssertionSeal(contextGraphId, name, agentAddress, subGraphName);
-    await this.assertionWrite(contextGraphId, name, agentAddress, gathered, subGraphName);
-    return { seeded: gathered.length, fromLayer: sourceLayer, entities: entities.length };
+    if (draftPublic.length > 0) {
+      await this.assertionWrite(contextGraphId, name, agentAddress, draftPublic, subGraphName);
+    }
+    if (draftPrivate.length > 0) {
+      await this.assertionWritePrivate(contextGraphId, name, agentAddress, draftPrivate, subGraphName);
+    }
+    return {
+      seeded: draftPublic.length + draftPrivate.length,
+      fromLayer: sourceLayer,
+      // One atomic graph-scoped KA — member-entity counts are a legacy concept.
+      entities: 1,
+    };
   }
 
   async assertionPromote(

--- a/packages/publisher/src/lift-job-types.ts
+++ b/packages/publisher/src/lift-job-types.ts
@@ -46,6 +46,18 @@ export interface KnowledgeAssetVmPublishRequest {
   readonly subGraphName?: string;
   readonly shareOperationId: string;
   readonly roots: readonly string[];
+  /** Graph-scoped v2 discriminator. Missing/one is a legacy read-only job. */
+  readonly contentScopeVersion?: number;
+  /** Canonical UAL for the one atomic queued Knowledge Asset. */
+  readonly kaUal?: string;
+  /** One-based assertion version included in the immutable graph identity. */
+  readonly assertionVersion?: string;
+  /** Exact public triple count committed by the queued seal. */
+  readonly publicTripleCount?: number;
+  /** Optional single KA-level private commitment. */
+  readonly privateMerkleRoot?: LiftJobHex;
+  /** Exact private triple count committed by privateMerkleRoot. */
+  readonly privateTripleCount?: number;
   /** Author seal captured with the queued SWM share snapshot. */
   readonly seal: LiftRequestAuthorSeal;
   readonly sealChainId: LiftJobBigInt;
@@ -67,6 +79,13 @@ export interface LiftPublishSnapshotRequest {
   readonly shareOperationId: string;
   readonly roots: readonly string[];
   readonly contextGraphId: string;
+  /** Graph-scoped v2 discriminator. Missing/one is a legacy read-only snapshot. */
+  readonly contentScopeVersion?: number;
+  readonly kaUal?: string;
+  readonly assertionVersion?: string;
+  readonly publicTripleCount?: number;
+  readonly privateMerkleRoot?: LiftJobHex;
+  readonly privateTripleCount?: number;
   readonly priorVersion?: string;
   readonly subGraphName?: string;
   readonly accessPolicy?: LiftAccessPolicy;

--- a/packages/publisher/src/workspace-resolution.ts
+++ b/packages/publisher/src/workspace-resolution.ts
@@ -17,6 +17,7 @@ import {
   generateShareMetadata,
   toHex,
 } from './metadata.js';
+import { computePrivateRootV10 as computePrivateRoot } from './merkle.js';
 import { workspacePublicQuadsDigest, type WorkspacePublicSnapshotStore } from './workspace-snapshot-store.js';
 
 const DKG = 'http://dkg.io/ontology/';
@@ -573,6 +574,80 @@ export async function resolveLiftWorkspaceSlice(params: {
   const request = params.request;
   const shareOperationId = request.shareOperationId;
   const subGraphName = normalizeOptionalSubGraphName(request.subGraphName);
+  if (request.contentScopeVersion === GRAPH_KA_CONTENT_SCOPE_VERSION) {
+    if (request.roots.length !== 0) {
+      throw new Error('Graph-scoped Lift snapshot must not contain root entities');
+    }
+    if (
+      request.kaUal === undefined
+      || request.assertionVersion === undefined
+      || request.publicTripleCount === undefined
+      || request.privateTripleCount === undefined
+    ) {
+      throw new Error('Graph-scoped Lift snapshot is missing its KA content envelope');
+    }
+    if (
+      !Number.isSafeInteger(request.publicTripleCount)
+      || request.publicTripleCount < 0
+      || !Number.isSafeInteger(request.privateTripleCount)
+      || request.privateTripleCount < 0
+      || (request.publicTripleCount === 0 && request.privateTripleCount === 0)
+    ) {
+      throw new Error('Graph-scoped Lift snapshot has invalid public/private triple counts');
+    }
+    const scope = createGraphKnowledgeAssetScope(request.kaUal, request.assertionVersion);
+    const publicSnapshot = await resolveKnowledgeAssetOperationPublicQuads({
+      store: params.store,
+      graphManager: params.graphManager,
+      contextGraphId: request.contextGraphId,
+      shareOperationId,
+      kaUal: scope.ual,
+      assertionVersion: scope.assertionVersion,
+      subGraphName,
+      publicSnapshotStore: params.publicSnapshotStore,
+    });
+    if (publicSnapshot.quads.length !== request.publicTripleCount) {
+      throw new Error(
+        `Graph-scoped Lift public triple count mismatch for ${scope.ual}: ` +
+          `snapshot=${publicSnapshot.quads.length}, request=${request.publicTripleCount}`,
+      );
+    }
+    const privateStore = new PrivateContentStore(params.store, params.graphManager);
+    const privateQuads = await privateStore.getKnowledgeAssetPrivateTriples(
+      request.contextGraphId,
+      scope,
+      subGraphName,
+    );
+    if (privateQuads.length !== request.privateTripleCount) {
+      throw new Error(
+        `Graph-scoped Lift private triple count mismatch for ${scope.ual}: ` +
+          `store=${privateQuads.length}, request=${request.privateTripleCount}`,
+      );
+    }
+    const privateRoot = computePrivateRoot(privateQuads);
+    const actualPrivateRoot = privateRoot ? `0x${toHex(privateRoot)}`.toLowerCase() : undefined;
+    const expectedPrivateRoot = request.privateMerkleRoot?.toLowerCase();
+    if (actualPrivateRoot !== expectedPrivateRoot) {
+      throw new Error(
+        `Graph-scoped Lift private Merkle commitment mismatch for ${scope.ual}`,
+      );
+    }
+    const publishContextGraphId = await resolveOnChainContextGraphId({
+      store: params.store,
+      contextGraphId: request.contextGraphId,
+    });
+    return {
+      quads: publicSnapshot.quads,
+      privateQuads: privateQuads.length > 0 ? privateQuads : undefined,
+      publisherPeerId: publicSnapshot.publisherPeerId,
+      accessPolicy: request.accessPolicy,
+      allowedPeers: request.allowedPeers ? [...request.allowedPeers] : undefined,
+      publishContextGraphId,
+    };
+  }
+  // Raw Lift jobs retain their existing root-scoped staging contract until
+  // the dedicated mutation-cutover PR. Named KA jobs are guarded at enqueue
+  // and therefore never reach this compatibility branch.
   const requestedRoots = normalizeRoots(request.roots);
   if (requestedRoots.length === 0) {
     throw new Error(`No valid Lift shared-memory roots provided for context graph ${request.contextGraphId}`);
@@ -616,16 +691,19 @@ export async function resolveLiftWorkspaceSlice(params: {
   const privateQuads = (
     await Promise.all(
       requestedRoots.map((root) =>
-        privateStore.getPrivateTriplesForOperation(request.contextGraphId, shareOperationId, root, subGraphName),
+        privateStore.getPrivateTriplesForOperation(
+          request.contextGraphId,
+          shareOperationId,
+          root,
+          subGraphName,
+        ),
       ),
     )
   ).flat();
-
   const publishContextGraphId = await resolveOnChainContextGraphId({
     store: params.store,
     contextGraphId: request.contextGraphId,
   });
-
   return {
     quads: publicSnapshot.quads,
     privateQuads: privateQuads.length > 0 ? privateQuads : undefined,

--- a/packages/publisher/test/assertion-pull-from.test.ts
+++ b/packages/publisher/test/assertion-pull-from.test.ts
@@ -1,31 +1,48 @@
 import { describe, expect, it } from 'vitest';
 import { NoChainAdapter } from '@origintrail-official/dkg-chain';
 import {
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  MemoryLayer,
   TypedEventBus,
-  generateEd25519Keypair,
-  buildAssertionSealQuads,
-  contextGraphMetaUri,
-  contextGraphAssertionUri,
   assertionLifecycleUri,
+  buildAssertionSealQuads,
+  contextGraphAssertionUri,
+  contextGraphMetaUri,
+  createGraphKnowledgeAssetScope,
+  generateEd25519Keypair,
+  knowledgeAssetLayerGraphUri,
 } from '@origintrail-official/dkg-core';
-import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
-import { DKGPublisher, assertionScopedGraphUri } from '../src/index.js';
+import { GraphManager, OxigraphStore, PrivateContentStore, type Quad } from '@origintrail-official/dkg-storage';
+import {
+  DKGPublisher,
+  computePrivateRootV10,
+  skolemizeKnowledgeAsset,
+} from '../src/index.js';
+import { deskolemizeKnowledgeAssetQuads } from '../src/auto-partition.js';
+import {
+  storeKnowledgeAssetOperationPublicQuads,
+  storeKnowledgeAssetWorkspaceHead,
+} from '../src/workspace-resolution.js';
 
-// OT-RFC-43 §10.5.3 — `wm/pull-from` seeds a fresh WM draft from the file's
-// current SWM/VM state. These are store-backed (real OxigraphStore) so the
-// entity-scoped gather + onConflict behavior is exercised end to end.
+// OT-RFC-43 §10.5.3 (`wm/pull-from`) under the graph-scoped model: a KA is
+// atomic, so a pull restores the COMPLETE assertion — the exact public graph
+// (via the digest-validated operation snapshot for SWM, the stable UAL graph
+// for VM) plus the private partition — with canonical skolem IRIs restored to
+// blank nodes so the re-opened draft is fully unlabelled.
 
 const CG = 'pull-from-test';
 const AGENT = '0x00000000000000000000000000000000000000a1';
 const NAME = 'meeting-notes';
-const SWM_GRAPH = `did:dkg:context-graph:${CG}/_shared_memory`;
+const KA_NUMBER = 9n;
+const UAL = `did:dkg:base:8453/${AGENT}/${KA_NUMBER}`;
+const PACKED_KA_ID = (BigInt(AGENT) << 96n) | KA_NUMBER;
 const SCHEMA = 'http://schema.org/name';
 const DKG = 'http://dkg.io/ontology/';
+const META_GRAPH = contextGraphMetaUri(CG);
 
-const ENTITY_1 = 'urn:e:alice';
-const ENTITY_2 = 'urn:e:bob';
-const SKOLEM_1 = `${ENTITY_1}/.well-known/genid/n1`;
-const OTHER_FILE_ENTITY = 'urn:e:carol-other-file';
+function q(subject: string, predicate: string, object: string, graph = ''): Quad {
+  return { subject, predicate, object, graph };
+}
 
 async function makePublisher() {
   const store = new OxigraphStore();
@@ -35,24 +52,18 @@ async function makePublisher() {
     eventBus: new TypedEventBus(),
     keypair: await generateEd25519Keypair(),
   });
-  return { publisher, store };
+  return { publisher, store, graphManager: new GraphManager(store) };
 }
 
-function q(subject: string, predicate: string, object: string, graph: string): Quad {
-  return { subject, predicate, object, graph };
-}
-
-/**
- * Seal: build a REAL assertion seal under the assertion-graph URI
- * (`contextGraphAssertionUri`) in `_meta`, exactly as `finalize` does — this is
- * where `assertionPullFrom` reads it via `parseAssertionSealQuads`
- * (PR #972/335e8d8). The previous helper wrote a bare `assertionRootEntity` on
- * the lifecycle URN, which only matched the old (buggy) read.
- */
-function sealEntities(entities: string[]): Quad[] {
+function sealQuads(args: {
+  assertionVersion: number;
+  publicTripleCount: number;
+  privateTripleCount?: number;
+  privateMerkleRoot?: Uint8Array;
+}): Quad[] {
   return buildAssertionSealQuads({
     assertionUri: contextGraphAssertionUri(CG, AGENT, NAME),
-    metaGraph: contextGraphMetaUri(CG),
+    metaGraph: META_GRAPH,
     merkleRoot: new Uint8Array(32).fill(7),
     authorAddress: AGENT,
     authorAttestationR: new Uint8Array(32).fill(1),
@@ -60,509 +71,301 @@ function sealEntities(entities: string[]): Quad[] {
     authorSchemeVersion: 1,
     chainId: 31337n,
     kav10Address: AGENT,
-    // §F2 — the seal now carries the packed reservedKaId
-    // (uint160(author) << 96 | number). This test only consumes the seal's
-    // rootEntities for scoping, so number=1 is sufficient. AGENT is already a
-    // 20-byte hex literal, so BigInt() packs it without ethers.
-    reservedKaId: (BigInt(AGENT) << 96n) | 1n,
+    reservedKaId: PACKED_KA_ID,
     finalizedAtIso: '2026-01-01T00:00:00.000Z',
-    rootEntities: entities,
+    contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+    kaUal: UAL,
+    assertionVersion: args.assertionVersion,
+    publicTripleCount: args.publicTripleCount,
+    privateTripleCount: args.privateTripleCount ?? 0,
+    ...(args.privateMerkleRoot ? { privateMerkleRoot: args.privateMerkleRoot } : {}),
   }) as Quad[];
 }
 
-async function wmQuads(store: OxigraphStore): Promise<Quad[]> {
-  const wm = contextGraphAssertionUri(CG, AGENT, NAME);
-  const r = await store.query(`CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${wm}> { ?s ?p ?o } }`);
-  return r.type === 'quads' ? r.quads : [];
+function legacySealQuads(rootEntities: string[]): Quad[] {
+  return buildAssertionSealQuads({
+    assertionUri: contextGraphAssertionUri(CG, AGENT, NAME),
+    metaGraph: META_GRAPH,
+    merkleRoot: new Uint8Array(32).fill(7),
+    authorAddress: AGENT,
+    authorAttestationR: new Uint8Array(32).fill(1),
+    authorAttestationVS: new Uint8Array(32).fill(2),
+    authorSchemeVersion: 1,
+    chainId: 31337n,
+    kav10Address: AGENT,
+    reservedKaId: PACKED_KA_ID,
+    finalizedAtIso: '2026-01-01T00:00:00.000Z',
+    rootEntities,
+  }) as Quad[];
 }
 
-describe('assertionPullFrom (OT-RFC-43 §10.5.3 wm/pull-from)', () => {
-  it('seeds a WM draft from SWM, scoped to the file\'s sealed entities (+ skolem children)', async () => {
-    const { publisher, store } = await makePublisher();
-    const lifecycleUri = assertionLifecycleUri(CG, AGENT, NAME);
-    const metaGraph = contextGraphMetaUri(CG);
-    await store.insert([
-      // this file's entities in SWM
-      q(ENTITY_1, SCHEMA, '"Alice"', SWM_GRAPH),
-      q(SKOLEM_1, SCHEMA, '"Alice detail"', SWM_GRAPH),
-      q(ENTITY_2, SCHEMA, '"Bob"', SWM_GRAPH),
-      // trust/ownership bookkeeping that must NOT land in the draft
-      q(ENTITY_1, `${DKG}workspaceOwner`, '"peer-a"', SWM_GRAPH),
-      // a DIFFERENT file's entity co-resident in the same SWM graph
-      q(OTHER_FILE_ENTITY, SCHEMA, '"Carol"', SWM_GRAPH),
-      ...sealEntities([ENTITY_1, ENTITY_2]),
-      // #1116 (round 8): an SWM pull resolves scope from the promote-stamped
-      // member rows + the full-share marker, NOT the seal (a stale seal must
-      // never short-circuit the subset gate). Represent a legitimately-finalized
-      // FULL share by stamping the member rows for the sealed set.
-      q(lifecycleUri, `${DKG}rootEntity`, ENTITY_1, metaGraph),
-      q(lifecycleUri, `${DKG}rootEntity`, ENTITY_2, metaGraph),
-    ]);
-    await publisher.markSwmShareComplete(CG, NAME, AGENT);
+/**
+ * Seed one accepted graph-scoped assertion in SWM exactly as promote/gossip
+ * does: exact per-KA graph + digest-validated immutable operation snapshot +
+ * durable head, plus the (UAL, version)-keyed private partition.
+ */
+async function seedSharedMemoryAssertion(
+  store: OxigraphStore,
+  graphManager: GraphManager,
+  args: {
+    version: number;
+    publicQuads: Quad[];
+    privateQuads?: Quad[];
+  },
+): Promise<{ canonicalPublic: Quad[]; canonicalPrivate: Quad[] }> {
+  const canonicalPublic = await skolemizeKnowledgeAsset(args.publicQuads);
+  const canonicalPrivate = await skolemizeKnowledgeAsset(args.privateQuads ?? []);
+  const scope = createGraphKnowledgeAssetScope(UAL, args.version);
+  const swmGraph = knowledgeAssetLayerGraphUri(CG, MemoryLayer.SharedWorkingMemory, scope);
+  if (canonicalPublic.length > 0) {
+    await store.insert(canonicalPublic.map((quad) => ({ ...quad, graph: swmGraph })));
+  }
+  const privateMerkleRoot = computePrivateRootV10(canonicalPrivate);
+  await storeKnowledgeAssetOperationPublicQuads({
+    store,
+    graphManager,
+    contextGraphId: CG,
+    shareOperationId: `op-v${args.version}`,
+    kaUal: UAL,
+    assertionVersion: args.version,
+    quads: canonicalPublic,
+    ...(privateMerkleRoot ? { privateMerkleRoot } : {}),
+    privateTripleCount: canonicalPrivate.length,
+    publisherPeerId: 'seed-peer',
+  });
+  await storeKnowledgeAssetWorkspaceHead({
+    store,
+    graphManager,
+    contextGraphId: CG,
+    kaUal: UAL,
+    assertionVersion: args.version,
+    shareOperationId: `op-v${args.version}`,
+  });
+  if (canonicalPrivate.length > 0) {
+    const privateStore = new PrivateContentStore(store, graphManager);
+    await privateStore.replaceKnowledgeAssetPrivateTriples(CG, scope, canonicalPrivate);
+  }
+  return { canonicalPublic, canonicalPrivate };
+}
+
+describe('assertionPullFrom (OT-RFC-43 §10.5.3 wm/pull-from, graph-scoped)', () => {
+  it('seeds a WM draft from the SWM head snapshot: whole KA, de-skolemized, private restored', async () => {
+    const { publisher, store, graphManager } = await makePublisher();
+    const { canonicalPublic, canonicalPrivate } = await seedSharedMemoryAssertion(store, graphManager, {
+      version: 1,
+      publicQuads: [
+        q('urn:e:alice', SCHEMA, '"Alice"'),
+        q('urn:e:alice', 'urn:predicate:detail', '_:detail'),
+        q('_:detail', SCHEMA, '"Alice detail"'),
+      ],
+      privateQuads: [q('urn:p:secret', 'urn:predicate:secret', '"classified"')],
+    });
+    await store.insert(sealQuads({
+      assertionVersion: 1,
+      publicTripleCount: canonicalPublic.length,
+      privateTripleCount: canonicalPrivate.length,
+      privateMerkleRoot: computePrivateRootV10(canonicalPrivate),
+    }));
 
     const result = await publisher.assertionPullFrom(CG, NAME, AGENT, 'swm');
     expect(result.fromLayer).toBe('swm');
-    expect(result.entities).toBe(2);
+    expect(result.seeded).toBe(canonicalPublic.length + canonicalPrivate.length);
+    expect(result.entities).toBe(1);
 
-    const draft = await wmQuads(store);
-    const subjects = new Set(draft.map((d) => d.subject));
-    // the file's entities + skolem child are present...
-    expect(subjects.has(ENTITY_1)).toBe(true);
-    expect(subjects.has(SKOLEM_1)).toBe(true);
-    expect(subjects.has(ENTITY_2)).toBe(true);
-    // ...the co-resident other-file entity is NOT pulled in...
-    expect(subjects.has(OTHER_FILE_ENTITY)).toBe(false);
-    // ...and the workspaceOwner bookkeeping is filtered out.
-    expect(draft.some((d) => d.predicate === `${DKG}workspaceOwner`)).toBe(false);
+    const draft = await publisher.assertionQuery(CG, NAME, AGENT);
+    expect(draft).toHaveLength(canonicalPublic.length);
+    // Canonical skolem IRIs come back as blank nodes (fully unlabelled draft)…
+    expect(draft.some((quad) => quad.subject.startsWith('_:') || quad.object.startsWith('_:'))).toBe(true);
+    expect(draft.some((quad) =>
+      quad.subject.startsWith('urn:dkg:ka-skolem:') || quad.object.startsWith('urn:dkg:ka-skolem:'),
+    )).toBe(false);
+    // …and an unmodified draft re-canonicalizes to the identical assertion.
+    expect(await skolemizeKnowledgeAsset(draft)).toEqual(canonicalPublic);
+
+    const privateDraft = await publisher.assertionQueryPrivate(CG, NAME, AGENT);
+    expect(await skolemizeKnowledgeAsset(privateDraft)).toEqual(canonicalPrivate);
+
+    // The pull re-opens the draft for editing: the stale seal is cleared.
+    const sealCheck = await store.query(
+      `ASK { GRAPH <${META_GRAPH}> { <${contextGraphAssertionUri(CG, AGENT, NAME)}> <${DKG}assertionMerkleRoot> ?r } }`,
+    );
+    expect(sealCheck.type === 'boolean' ? sealCheck.value : true).toBe(false);
+  });
+
+  it('pulls the newest accepted SWM assertion version', async () => {
+    const { publisher, store, graphManager } = await makePublisher();
+    await seedSharedMemoryAssertion(store, graphManager, {
+      version: 1,
+      publicQuads: [q('urn:e:alice', SCHEMA, '"v1"')],
+    });
+    const v2 = await seedSharedMemoryAssertion(store, graphManager, {
+      version: 2,
+      publicQuads: [q('urn:e:alice', SCHEMA, '"v2"')],
+    });
+    await store.insert(sealQuads({ assertionVersion: 2, publicTripleCount: 1 }));
+
+    await publisher.assertionPullFrom(CG, NAME, AGENT, 'swm');
+    const draft = await publisher.assertionQuery(CG, NAME, AGENT);
+    expect(await skolemizeKnowledgeAsset(draft)).toEqual(v2.canonicalPublic);
   });
 
   it('rejects with WM_DRAFT_CONFLICT when a draft already exists (default onConflict)', async () => {
-    const { publisher, store } = await makePublisher();
-    await store.insert([q(ENTITY_1, SCHEMA, '"Alice"', SWM_GRAPH), ...sealEntities([ENTITY_1])]);
-    // open + dirty a WM draft
-    await publisher.assertionWrite(CG, NAME, AGENT, [{ subject: ENTITY_1, predicate: SCHEMA, object: '"local edit"' }]);
-
-    const err = await publisher.assertionPullFrom(CG, NAME, AGENT, 'swm').catch((e) => e);
-    expect(err).toBeInstanceOf(Error);
-    expect((err as any).code).toBe('WM_DRAFT_CONFLICT');
-  });
-
-  it('onConflict:"replace" overwrites a dirty draft with the source layer', async () => {
-    const { publisher, store } = await makePublisher();
-    await store.insert([
-      q(ENTITY_2, SCHEMA, '"Bob from SWM"', SWM_GRAPH),
-      ...sealEntities([ENTITY_2]),
-      // #1116 (round 8): SWM scope comes from the member rows + marker, not the seal.
-      q(assertionLifecycleUri(CG, AGENT, NAME), `${DKG}rootEntity`, ENTITY_2, contextGraphMetaUri(CG)),
-    ]);
-    await publisher.markSwmShareComplete(CG, NAME, AGENT);
-    await publisher.assertionWrite(CG, NAME, AGENT, [{ subject: ENTITY_1, predicate: SCHEMA, object: '"stale local"' }]);
-
-    const result = await publisher.assertionPullFrom(CG, NAME, AGENT, 'swm', { onConflict: 'replace' });
-    expect(result.fromLayer).toBe('swm');
-
-    const draft = await wmQuads(store);
-    const subjects = new Set(draft.map((d) => d.subject));
-    expect(subjects.has(ENTITY_2)).toBe(true);   // the SWM content
-    expect(subjects.has(ENTITY_1)).toBe(false);  // the stale local edit is gone
-  });
-
-  it('rejects named-graph-only dirty drafts with WM_DRAFT_CONFLICT', async () => {
-    const { publisher, store } = await makePublisher();
-    const localGraph = 'urn:test:graph:pull-from-local-only';
-    const wmGraph = contextGraphAssertionUri(CG, AGENT, NAME);
-    const scopedLocalGraph = assertionScopedGraphUri(wmGraph, localGraph);
-    await store.insert([
-      q(ENTITY_2, SCHEMA, '"Bob from SWM"', SWM_GRAPH),
-      q(assertionLifecycleUri(CG, AGENT, NAME), `${DKG}rootEntity`, ENTITY_2, contextGraphMetaUri(CG)),
-    ]);
-    await publisher.markSwmShareComplete(CG, NAME, AGENT);
-    await publisher.assertionWrite(CG, NAME, AGENT, [{
-      subject: ENTITY_1,
-      predicate: SCHEMA,
-      object: '"local named edit"',
-      graph: localGraph,
-    }]);
-
-    const err = await publisher.assertionPullFrom(CG, NAME, AGENT, 'swm').catch((e) => e);
-
-    expect(err).toBeInstanceOf(Error);
-    expect((err as any).code).toBe('WM_DRAFT_CONFLICT');
-    expect(await store.listGraphs()).toContain(scopedLocalGraph);
-    expect(await publisher.assertionQuery(CG, NAME, AGENT)).toEqual([
-      expect.objectContaining({ subject: ENTITY_1, graph: localGraph }),
-    ]);
-  });
-
-  it('onConflict:"replace" removes named-graph-only dirty draft children', async () => {
-    const { publisher, store } = await makePublisher();
-    const localGraph = 'urn:test:graph:pull-from-stale-child';
-    const wmGraph = contextGraphAssertionUri(CG, AGENT, NAME);
-    const scopedLocalGraph = assertionScopedGraphUri(wmGraph, localGraph);
-    await store.insert([
-      q(ENTITY_2, SCHEMA, '"Bob from SWM"', SWM_GRAPH),
-      q(assertionLifecycleUri(CG, AGENT, NAME), `${DKG}rootEntity`, ENTITY_2, contextGraphMetaUri(CG)),
-    ]);
-    await publisher.markSwmShareComplete(CG, NAME, AGENT);
-    await publisher.assertionWrite(CG, NAME, AGENT, [{
-      subject: ENTITY_1,
-      predicate: SCHEMA,
-      object: '"stale named local"',
-      graph: localGraph,
-    }]);
-    expect(await store.listGraphs()).toContain(scopedLocalGraph);
-
-    const result = await publisher.assertionPullFrom(CG, NAME, AGENT, 'swm', { onConflict: 'replace' });
-
-    expect(result.fromLayer).toBe('swm');
-    expect(await store.listGraphs()).not.toContain(scopedLocalGraph);
-    const draft = await publisher.assertionQuery(CG, NAME, AGENT);
-    expect(draft).toEqual(expect.arrayContaining([
-      expect.objectContaining({ subject: ENTITY_2, object: '"Bob from SWM"', graph: '' }),
-    ]));
-    expect(draft.some((quad) => quad.subject === ENTITY_1 || quad.graph === localGraph)).toBe(false);
-  });
-
-  it('validates the source BEFORE dropping — an empty-source replace pull preserves the dirty draft (PR #972/335e8d8)', async () => {
-    const { publisher, store } = await makePublisher();
-    // Finalized FULL share whose member entity has NO quads in SWM (e.g. never
-    // shared there), plus a dirty WM draft holding a precious local edit. The
-    // member row + marker represent the full-share scope; the gather finds
-    // nothing in SWM, so the pull rejects with PULL_FROM_EMPTY_SOURCE BEFORE any
-    // drop. #1116 (round 8): SWM scope is the member rows, not the seal.
-    await store.insert([
-      ...sealEntities([ENTITY_1]), // note: no ENTITY_1 quads in SWM_GRAPH
-      q(assertionLifecycleUri(CG, AGENT, NAME), `${DKG}rootEntity`, ENTITY_1, contextGraphMetaUri(CG)),
-    ]);
-    await publisher.markSwmShareComplete(CG, NAME, AGENT);
-    await publisher.assertionWrite(CG, NAME, AGENT, [{ subject: ENTITY_1, predicate: SCHEMA, object: '"precious local edit"' }]);
-
-    const err = await publisher.assertionPullFrom(CG, NAME, AGENT, 'swm', { onConflict: 'replace' }).catch((e) => e);
-    expect(err).toBeInstanceOf(Error);
-    expect((err as any).code).toBe('PULL_FROM_EMPTY_SOURCE');
-
-    // The draft must be UNTOUCHED — the empty pull validated the source before
-    // any drop, so the precious local edit survives.
-    const draft = await wmQuads(store);
-    expect(draft.some((d) => d.subject === ENTITY_1 && d.object === '"precious local edit"')).toBe(true);
-  });
-
-  it('throws when the file has neither a seal nor a prior promote (no member entities)', async () => {
-    const { publisher, store } = await makePublisher();
-    await store.insert([q(ENTITY_1, SCHEMA, '"Alice"', SWM_GRAPH)]); // no seal, no promoted rows
-    const err = await publisher.assertionPullFrom(CG, NAME, AGENT, 'swm').catch((e) => e);
-    expect(err).toBeInstanceOf(Error);
-    expect((err as Error).message).toMatch(/requires either a finalized assertion.*or a prior promote/i);
-  });
-
-  // #1116: seal-INDEPENDENT pull-from. An asset shared UNSEALED (a skipSeal
-  // share, or stuck unsealed under the old behavior) records its member
-  // entities on the lifecycle URN (dkg:rootEntity) even with no seal —
-  // pull-from falls back to those so seal-in-SWM / recovery can reconstruct the
-  // WM draft without first finalizing.
-  it('seeds a WM draft from SWM via the promoted member entities when there is NO seal', async () => {
-    const { publisher, store } = await makePublisher();
-    await store.insert([
-      q(ENTITY_1, SCHEMA, '"Alice"', SWM_GRAPH),
-      q(SKOLEM_1, SCHEMA, '"Alice detail"', SWM_GRAPH),
-      // NO seal — instead the promote-stamped member row on the lifecycle URN:
-      q(assertionLifecycleUri(CG, AGENT, NAME), `${DKG}rootEntity`, ENTITY_1, contextGraphMetaUri(CG)),
-    ]);
-    // #1116 (round 5): the seal-less SWM reconstruction now requires the
-    // full-share marker (else it's a SUBSET share, not publishable). A real
-    // skipSeal FULL share stamps it via promote(); set it here to represent
-    // that legitimate full-share state.
-    await publisher.markSwmShareComplete(CG, NAME, AGENT);
-    const result = await publisher.assertionPullFrom(CG, NAME, AGENT, 'swm');
-    expect(result.fromLayer).toBe('swm');
-    expect(result.entities).toBe(1);
-    const subjects = new Set((await wmQuads(store)).map((d) => d.subject));
-    expect(subjects.has(ENTITY_1)).toBe(true);
-    expect(subjects.has(SKOLEM_1)).toBe(true);
-  });
-
-  // #1116 atomicity: a pull-from re-opens the WM draft via `assertionCreate`,
-  // whose clean-slate WIPES every row under the lifecycle URN before re-seeding.
-  // The promote-stamped member rows (dkg:rootEntity) are the SEAL-INDEPENDENT
-  // recovery source pull-from falls back to — so they MUST survive that wipe, or
-  // a SECOND pull-from (and seal-in-SWM recovery in general) would lose the
-  // members and fail. #1116 added dkg:rootEntity to assertionCreate's
-  // A2_PRESERVE_PREDS carry-over; this guards that.
-  it('#1116: dkg:rootEntity rows on the lifecycle URN SURVIVE a replace pull-from (a second pull still finds the members)', async () => {
-    const { publisher, store } = await makePublisher();
-    const lifecycleUri = assertionLifecycleUri(CG, AGENT, NAME);
-    const metaGraph = contextGraphMetaUri(CG);
-
-    // Unsealed, promote-stamped asset: SWM content + the dkg:rootEntity member
-    // row on the lifecycle URN, NO seal — exactly what seal-in-SWM consumes.
-    await store.insert([
-      q(ENTITY_1, SCHEMA, '"Alice"', SWM_GRAPH),
-      q(SKOLEM_1, SCHEMA, '"Alice detail"', SWM_GRAPH),
-      q(lifecycleUri, `${DKG}rootEntity`, ENTITY_1, metaGraph),
-    ]);
-    // #1116 (round 5): a real FULL skipSeal share stamps the full-share marker
-    // (it survives assertionCreate's clean-slate via A2_PRESERVE), so the
-    // seal-less reconstruction is allowed; mark it to represent that state.
-    await publisher.markSwmShareComplete(CG, NAME, AGENT);
-
-    // Mirror readPromotedRootEntities: the seal-independent member lookup.
-    const readRoots = async (): Promise<string[]> => {
-      const r = await store.query(
-        `SELECT ?root WHERE { GRAPH <${metaGraph}> { <${lifecycleUri}> <${DKG}rootEntity> ?root } }`,
-      );
-      return r.type === 'bindings' ? r.bindings.map((b) => String(b['root'])) : [];
-    };
-
-    // First pull-from succeeds via the rootEntity fallback...
-    const first = await publisher.assertionPullFrom(CG, NAME, AGENT, 'swm', { onConflict: 'replace' });
-    expect(first.entities).toBe(1);
-    // ...and the row survived assertionCreate's clean-slate (it routes through
-    // the A2_PRESERVE_PREDS carry-over).
-    expect(await readRoots()).toContain(ENTITY_1);
-
-    // The crux: a SECOND replace pull-from still resolves the member — only
-    // possible if the dkg:rootEntity row was preserved across the first pull's
-    // clean-slate. Pre-#1116 (row wiped) this threw "No member entities".
-    const second = await publisher.assertionPullFrom(CG, NAME, AGENT, 'swm', { onConflict: 'replace' });
-    expect(second.entities).toBe(1);
-    expect(await readRoots()).toContain(ENTITY_1);
-
-    // And the reconstructed draft still holds the member + its skolem child.
-    const subjects = new Set((await wmQuads(store)).map((d) => d.subject));
-    expect(subjects.has(ENTITY_1)).toBe(true);
-    expect(subjects.has(SKOLEM_1)).toBe(true);
-  });
-
-  // #1116 (review A1): the swmShareComplete marker gates finalize(layer:"swm").
-  // seal-in-SWM runs a replace pull-from (assertionCreate clean-slate) BEFORE
-  // sealing — so the marker MUST survive that wipe (it was added to
-  // A2_PRESERVE_PREDS), otherwise a finalize that fails after the re-seed would
-  // strip the marker and make an already-fully-shared asset un-sealable.
-  it('#1116: swmShareComplete marker SURVIVES a replace pull-from (A2 preserve)', async () => {
-    const { publisher, store } = await makePublisher();
-    const lifecycleUri = assertionLifecycleUri(CG, AGENT, NAME);
-    const metaGraph = contextGraphMetaUri(CG);
-
-    // Fully-shared (marker present) + the seal-independent member row, NO seal —
-    // exactly the state seal-in-SWM reconstructs from.
-    await publisher.markSwmShareComplete(CG, NAME, AGENT);
-    await store.insert([
-      q(ENTITY_1, SCHEMA, '"Alice"', SWM_GRAPH),
-      q(lifecycleUri, `${DKG}rootEntity`, ENTITY_1, metaGraph),
-    ]);
-    expect(await publisher.hasSwmShareComplete(CG, NAME, AGENT)).toBe(true);
-
-    // The replace pull-from re-opens the WM draft via assertionCreate's clean
-    // slate; the marker must carry over.
-    const result = await publisher.assertionPullFrom(CG, NAME, AGENT, 'swm', { onConflict: 'replace' });
-    expect(result.entities).toBe(1);
-    expect(await publisher.hasSwmShareComplete(CG, NAME, AGENT)).toBe(true);
-
-    // markSwmShareComplete is idempotent — re-marking leaves exactly one row.
-    await publisher.markSwmShareComplete(CG, NAME, AGENT);
-    const rows = await store.query(
-      `SELECT ?o WHERE { GRAPH <${metaGraph}> { <${lifecycleUri}> <${DKG}swmShareComplete> ?o } }`,
-    );
-    expect(rows.type === 'bindings' && rows.bindings.length).toBe(1);
-  });
-
-  // #1116 (round 5): the marker MUST be cleared on discard — otherwise the
-  // A2_PRESERVE carry-over re-arms it on a recreate, and a full-share → discard
-  // → recreate → subset-share cycle would keep a stale marker and let
-  // finalize(layer:"swm") publish a partial asset under the KA name.
-  it('#1116: hasSwmShareComplete is FALSE after assertionDiscard (marker cleared)', async () => {
-    const { publisher } = await makePublisher();
-
-    // Open a WM draft, then fully-share (mark complete) — the state a full share
-    // leaves behind.
-    await publisher.assertionWrite(CG, NAME, AGENT, [
-      { subject: ENTITY_1, predicate: SCHEMA, object: '"Alice"' },
-    ]);
-    await publisher.markSwmShareComplete(CG, NAME, AGENT);
-    expect(await publisher.hasSwmShareComplete(CG, NAME, AGENT)).toBe(true);
-
-    // Discard MUST clear the marker.
-    await publisher.assertionDiscard(CG, NAME, AGENT);
-    expect(await publisher.hasSwmShareComplete(CG, NAME, AGENT)).toBe(false);
-  });
-
-  it('#1116: hasSwmShareComplete stays FALSE after discard + recreate (no stale re-arm)', async () => {
-    const { publisher } = await makePublisher();
-
-    await publisher.assertionWrite(CG, NAME, AGENT, [
-      { subject: ENTITY_1, predicate: SCHEMA, object: '"Alice"' },
-    ]);
-    await publisher.markSwmShareComplete(CG, NAME, AGENT);
-    await publisher.assertionDiscard(CG, NAME, AGENT);
-
-    // Recreate on the same name — assertionCreate's A2_PRESERVE clean-slate must
-    // NOT resurrect a marker that discard cleared (it was already gone, so there
-    // is nothing to preserve). The recreated draft is un-marked: a later seal-in-
-    // SWM must re-prove completeness.
-    await publisher.assertionCreate(CG, NAME, AGENT);
-    expect(await publisher.hasSwmShareComplete(CG, NAME, AGENT)).toBe(false);
-  });
-
-  // #1116 (round 5): the subset-publishability bypass is closed at the ROOT —
-  // the seal-less SWM reconstruction. A SUBSET share stamps dkg:rootEntity rows
-  // but NOT the full-share marker, so reconstructing/sealing it (reachable via
-  // the wm/pull-from route + a plain finalize, which bypasses the finalize(
-  // layer:"swm") wrapper guard) must be refused with SWM_SUBSET_NOT_SEALABLE.
-  it('#1116: seal-less SWM pull-from REJECTS a subset-only asset (no full-share marker)', async () => {
-    const { publisher, store } = await makePublisher();
-    const lifecycleUri = assertionLifecycleUri(CG, AGENT, NAME);
-    const metaGraph = contextGraphMetaUri(CG);
-
-    // SUBSET-shared, unsealed: SWM content + the promoted member row, but NO
-    // swmShareComplete marker (a subset share never sets it).
-    await store.insert([
-      q(ENTITY_1, SCHEMA, '"Alice"', SWM_GRAPH),
-      q(lifecycleUri, `${DKG}rootEntity`, ENTITY_1, metaGraph),
-    ]);
-    expect(await publisher.hasSwmShareComplete(CG, NAME, AGENT)).toBe(false);
-
-    const err = await publisher
-      .assertionPullFrom(CG, NAME, AGENT, 'swm')
-      .catch((e) => e);
-    expect((err as any).code).toBe('SWM_SUBSET_NOT_SEALABLE');
-  });
-
-  // ── round 7: lifecycle-URN member-row staleness (append-only bug) ──
-  // The member rows (dkg:rootEntity) are the seal-less reconstruction source.
-  // generateAssertionPromotedMetadata only INSERTs them (never deletes prior),
-  // and they survive discard+recreate via A2_PRESERVE — so without round-7 they
-  // accumulate a stale UNION and the seal-less reconstruction seals a SUPERSET.
-
-  // Read the lifecycle-URN member roots exactly as readPromotedRootEntities does.
-  async function readMemberRoots(store: OxigraphStore): Promise<Set<string>> {
-    const lifecycleUri = assertionLifecycleUri(CG, AGENT, NAME);
-    const metaGraph = contextGraphMetaUri(CG);
-    const r = await store.query(
-      `SELECT DISTINCT ?root WHERE { GRAPH <${metaGraph}> { <${lifecycleUri}> (<${DKG}rootEntity>|<${DKG}entity>) ?root } }`,
-    );
-    const out = new Set<string>();
-    if (r.type === 'bindings') for (const b of r.bindings) if (b['root']) out.add(String(b['root']));
-    return out;
-  }
-
-  it('#1116 (round 7): member rows are CLEARED after assertionDiscard (no VM version)', async () => {
-    const { publisher, store } = await makePublisher();
-    const lifecycleUri = assertionLifecycleUri(CG, AGENT, NAME);
-    const metaGraph = contextGraphMetaUri(CG);
-
-    // A promoted (unsealed) asset: SWM content + the promote-stamped member rows.
-    await publisher.assertionWrite(CG, NAME, AGENT, [
-      { subject: ENTITY_1, predicate: SCHEMA, object: '"Alice"' },
-    ]);
-    await store.insert([
-      q(lifecycleUri, `${DKG}rootEntity`, ENTITY_1, metaGraph),
-      q(lifecycleUri, `${DKG}rootEntity`, ENTITY_2, metaGraph),
-    ]);
-    expect((await readMemberRoots(store)).size).toBe(2);
-
-    // Discard a NON-published asset → membership is gone (nothing to reconstruct).
-    await publisher.assertionDiscard(CG, NAME, AGENT);
-    expect((await readMemberRoots(store)).size).toBe(0);
-  });
-
-  it('#1116 (round 7): a stale member row does NOT survive discard+recreate into a new draft', async () => {
-    const { publisher, store } = await makePublisher();
-    const lifecycleUri = assertionLifecycleUri(CG, AGENT, NAME);
-    const metaGraph = contextGraphMetaUri(CG);
-
-    await publisher.assertionWrite(CG, NAME, AGENT, [
-      { subject: ENTITY_1, predicate: SCHEMA, object: '"Alice"' },
-    ]);
-    await store.insert([q(lifecycleUri, `${DKG}rootEntity`, ENTITY_1, metaGraph)]);
-    await publisher.assertionDiscard(CG, NAME, AGENT);
-    // Recreate the SAME name: A2_PRESERVE must NOT carry the member row that
-    // discard cleared (the round-7 stale-superset bug starts here).
-    await publisher.assertionCreate(CG, NAME, AGENT);
-    expect((await readMemberRoots(store)).size).toBe(0);
-  });
-
-  it('#1116 (round 7): a FULL-COMPLETE promote REPLACES the member rows (drops a stale prior root)', async () => {
-    const { publisher, store } = await makePublisher();
-    const lifecycleUri = assertionLifecycleUri(CG, AGENT, NAME);
-    const metaGraph = contextGraphMetaUri(CG);
-
-    // Pre-seed a STALE member row for a root NOT in the current draft (e.g. left
-    // over from a prior full share {A, OTHER} that A2_PRESERVE carried across a
-    // recreate).
-    await store.insert([q(lifecycleUri, `${DKG}rootEntity`, OTHER_FILE_ENTITY, metaGraph)]);
-
-    // Current draft holds A and B; a FULL promote (entities:"all", no skip) is the
-    // authoritative current set → member rows must become EXACTLY {A, B}, not the
-    // union {A, B, OTHER}.
-    await publisher.assertionWrite(CG, NAME, AGENT, [
-      { subject: ENTITY_1, predicate: SCHEMA, object: '"Alice"' },
-      { subject: ENTITY_2, predicate: SCHEMA, object: '"Bob"' },
-    ]);
-    const res = await publisher.assertionPromote(CG, NAME, AGENT, { publisherPeerId: 'peer-self' });
-    expect(res.promotedAllRoots).toBe(true);
-
-    const rows = await readMemberRoots(store);
-    expect(rows.has(ENTITY_1)).toBe(true);
-    expect(rows.has(ENTITY_2)).toBe(true);
-    // The stale prior root is GONE — replaced, not appended.
-    expect(rows.has(OTHER_FILE_ENTITY)).toBe(false);
-    expect(rows.size).toBe(2);
-  });
-
-  // #1116 (round 8): the subset gate must hold even when a STALE FULL seal exists.
-  // A subset re-share never re-seals, and `create` without discard doesn't clear
-  // the seal (it lives on the name-keyed assertion URI, outside the lifecycle-URN
-  // clean-slate) — so an SWM pull that trusts the seal's rootEntities would short-
-  // circuit the gate and reconstruct/publish the superseded FULL set. The fix
-  // resolves SWM scope ALWAYS from the marker-gated member rows, never the seal.
-  // This pins it: stale seal {A,B} + member rows {A,B} + marker CLEARED (the
-  // subset-reshare state) → the SWM pull must REJECT, NOT trust the seal.
-  it('#1116 (round 8): a STALE full seal does NOT bypass the subset gate on an SWM pull', async () => {
-    const { publisher, store } = await makePublisher();
-    const lifecycleUri = assertionLifecycleUri(CG, AGENT, NAME);
-    const metaGraph = contextGraphMetaUri(CG);
-
-    await store.insert([
-      // SWM content for both entities (a prior full share left them here)...
-      q(ENTITY_1, SCHEMA, '"Alice"', SWM_GRAPH),
-      q(ENTITY_2, SCHEMA, '"Bob"', SWM_GRAPH),
-      // ...a STALE FULL seal over {A, B} (a subset re-share never re-sealed it)...
-      ...sealEntities([ENTITY_1, ENTITY_2]),
-      // ...and the promote-stamped member rows {A, B}.
-      q(lifecycleUri, `${DKG}rootEntity`, ENTITY_1, metaGraph),
-      q(lifecycleUri, `${DKG}rootEntity`, ENTITY_2, metaGraph),
-    ]);
-    // The marker is CLEARED — this is the post-subset-reshare state (round 6
-    // clears it on a subset share). The member rows still exist (subset append),
-    // but the asset is NOT a publishable full share.
-    expect(await publisher.hasSwmShareComplete(CG, NAME, AGENT)).toBe(false);
-
-    // Pre-round-8 the seal's rootEntities short-circuited scope and the pull
-    // SUCCEEDED, reconstructing the stale full {A, B}. Now it must REJECT.
-    const err = await publisher
-      .assertionPullFrom(CG, NAME, AGENT, 'swm', { onConflict: 'replace' })
-      .catch((e) => e);
-    expect((err as any).code).toBe('SWM_SUBSET_NOT_SEALABLE');
-  });
-
-  // #1116 (round 10): assertionPromote must maintain the swmShareComplete marker
-  // on EVERY return path — including the EARLY RETURN where a subset selection
-  // filters to ZERO promotable quads (the `quadsToPromote.length === 0` exit).
-  // Pre-fix that path returned BEFORE the marker maintenance, so a prior FULL
-  // share's marker SURVIVED a later zero-quad subset share, and finalize(layer:
-  // "swm")/pull-from then passed its gate against the OLD SWM contents.
-  it('#1116 (round 10): a zero-quad SUBSET share (early return) CLEARS a stale full-share marker', async () => {
-    const { publisher, store } = await makePublisher();
-
-    // 1. FULL share {A, B} — sets the marker, stamps member rows {A, B}, empties WM.
-    await publisher.assertionWrite(CG, NAME, AGENT, [
-      { subject: ENTITY_1, predicate: SCHEMA, object: '"Alice"' },
-      { subject: ENTITY_2, predicate: SCHEMA, object: '"Bob"' },
-    ]);
-    const full = await publisher.assertionPromote(CG, NAME, AGENT, { publisherPeerId: 'peer-self' });
-    expect(full.promotedAllRoots).toBe(true);
-    expect(await publisher.hasSwmShareComplete(CG, NAME, AGENT)).toBe(true);
-
-    // 2. Re-write a fresh WM draft, then SUBSET-share a selection that matches NONE
-    //    of the current draft's subjects → the selective filter empties
-    //    quadsToPromote → the early `length === 0` return path fires.
-    await publisher.assertionWrite(CG, NAME, AGENT, [
-      { subject: ENTITY_1, predicate: SCHEMA, object: '"Alice v2"' },
-      { subject: ENTITY_2, predicate: SCHEMA, object: '"Bob v2"' },
-    ]);
-    const zeroQuadSubset = await publisher.assertionPromote(CG, NAME, AGENT, {
-      entities: [OTHER_FILE_ENTITY], // not present in the draft → zero quads promoted
-      publisherPeerId: 'peer-self',
+    const { publisher, store, graphManager } = await makePublisher();
+    const seeded = await seedSharedMemoryAssertion(store, graphManager, {
+      version: 1,
+      publicQuads: [q('urn:e:alice', SCHEMA, '"from swm"')],
     });
-    expect(zeroQuadSubset.promotedCount).toBe(0); // confirms the early-return path
+    await store.insert(sealQuads({ assertionVersion: 1, publicTripleCount: 1 }));
 
-    // 3. The stale full-share marker MUST be cleared (round 10 fix).
-    expect(await publisher.hasSwmShareComplete(CG, NAME, AGENT)).toBe(false);
+    await publisher.assertionCreate(CG, NAME, AGENT);
+    await publisher.assertionWrite(CG, NAME, AGENT, [q('urn:e:dirty', SCHEMA, '"dirty edit"')]);
 
-    // 4. And the SWM pull / seal-in-SWM source now REJECTS (marker gone).
-    const err = await publisher
-      .assertionPullFrom(CG, NAME, AGENT, 'swm', { onConflict: 'replace' })
-      .catch((e) => e);
-    expect((err as any).code).toBe('SWM_SUBSET_NOT_SEALABLE');
+    await expect(publisher.assertionPullFrom(CG, NAME, AGENT, 'swm'))
+      .rejects.toMatchObject({ code: 'WM_DRAFT_CONFLICT' });
+    // The dirty draft is untouched.
+    const draft = await publisher.assertionQuery(CG, NAME, AGENT);
+    expect(draft.map((quad) => quad.subject)).toEqual(['urn:e:dirty']);
+
+    // onConflict:"replace" overwrites it with the source layer.
+    const replaced = await publisher.assertionPullFrom(CG, NAME, AGENT, 'swm', { onConflict: 'replace' });
+    expect(replaced.seeded).toBe(1);
+    const pulled = await publisher.assertionQuery(CG, NAME, AGENT);
+    expect(await skolemizeKnowledgeAsset(pulled)).toEqual(seeded.canonicalPublic);
+  });
+
+  it('treats a private-only dirty draft as a conflict too', async () => {
+    const { publisher, store, graphManager } = await makePublisher();
+    await seedSharedMemoryAssertion(store, graphManager, {
+      version: 1,
+      publicQuads: [q('urn:e:alice', SCHEMA, '"from swm"')],
+    });
+    await store.insert(sealQuads({ assertionVersion: 1, publicTripleCount: 1 }));
+
+    await publisher.assertionCreate(CG, NAME, AGENT);
+    await publisher.assertionWritePrivate(CG, NAME, AGENT, [
+      q('urn:p:draft', 'urn:predicate:secret', '"unsaved private edit"'),
+    ]);
+
+    await expect(publisher.assertionPullFrom(CG, NAME, AGENT, 'swm'))
+      .rejects.toMatchObject({ code: 'WM_DRAFT_CONFLICT' });
+
+    // replace overwrites the private draft alongside the public one.
+    await publisher.assertionPullFrom(CG, NAME, AGENT, 'swm', { onConflict: 'replace' });
+    expect(await publisher.assertionQueryPrivate(CG, NAME, AGENT)).toEqual([]);
+  });
+
+  it('restores a fully private KA (zero public triples)', async () => {
+    const { publisher, store, graphManager } = await makePublisher();
+    const seeded = await seedSharedMemoryAssertion(store, graphManager, {
+      version: 1,
+      publicQuads: [],
+      privateQuads: [q('urn:p:secret', 'urn:predicate:secret', '"only private"')],
+    });
+    await store.insert(sealQuads({
+      assertionVersion: 1,
+      publicTripleCount: 0,
+      privateTripleCount: 1,
+      privateMerkleRoot: computePrivateRootV10(seeded.canonicalPrivate),
+    }));
+
+    const result = await publisher.assertionPullFrom(CG, NAME, AGENT, 'swm');
+    expect(result.seeded).toBe(1);
+    expect(await publisher.assertionQuery(CG, NAME, AGENT)).toEqual([]);
+    const privateDraft = await publisher.assertionQueryPrivate(CG, NAME, AGENT);
+    expect(await skolemizeKnowledgeAsset(privateDraft)).toEqual(seeded.canonicalPrivate);
+  });
+
+  it('pulls the published assertion from VM using the seal version', async () => {
+    const { publisher, store, graphManager } = await makePublisher();
+    const canonicalPublic = await skolemizeKnowledgeAsset([
+      q('urn:e:alice', SCHEMA, '"published"'),
+      q('urn:e:alice', 'urn:predicate:child', '_:child'),
+      q('_:child', SCHEMA, '"published child"'),
+    ]);
+    const canonicalPrivate = await skolemizeKnowledgeAsset([
+      q('urn:p:secret', 'urn:predicate:secret', '"published secret"'),
+    ]);
+    const scope = createGraphKnowledgeAssetScope(UAL, 3);
+    const vmGraph = knowledgeAssetLayerGraphUri(CG, MemoryLayer.VerifiableMemory, scope);
+    await store.insert(canonicalPublic.map((quad) => ({ ...quad, graph: vmGraph })));
+    const privateStore = new PrivateContentStore(store, graphManager);
+    await privateStore.replaceKnowledgeAssetPrivateTriples(CG, scope, canonicalPrivate);
+    await store.insert(sealQuads({
+      assertionVersion: 3,
+      publicTripleCount: canonicalPublic.length,
+      privateTripleCount: canonicalPrivate.length,
+      privateMerkleRoot: computePrivateRootV10(canonicalPrivate),
+    }));
+
+    const result = await publisher.assertionPullFrom(CG, NAME, AGENT, 'vm');
+    expect(result.fromLayer).toBe('vm');
+    expect(result.seeded).toBe(canonicalPublic.length + canonicalPrivate.length);
+    const draft = await publisher.assertionQuery(CG, NAME, AGENT);
+    expect(await skolemizeKnowledgeAsset(draft)).toEqual(canonicalPublic);
+    expect(await skolemizeKnowledgeAsset(
+      await publisher.assertionQueryPrivate(CG, NAME, AGENT),
+    )).toEqual(canonicalPrivate);
+  });
+
+  it('requires the seal for VM pulls and a durable head for SWM pulls', async () => {
+    const { publisher, store, graphManager } = await makePublisher();
+    // No seal at all → VM pull cannot know which version VM holds.
+    await expect(publisher.assertionPullFrom(CG, NAME, AGENT, 'vm'))
+      .rejects.toMatchObject({ code: 'PULL_FROM_NO_KA_IDENTITY' });
+
+    // Sealed but never shared to SWM → clear empty-source error, draft untouched.
+    await store.insert(sealQuads({ assertionVersion: 1, publicTripleCount: 1 }));
+    await expect(publisher.assertionPullFrom(CG, NAME, AGENT, 'swm'))
+      .rejects.toMatchObject({ code: 'PULL_FROM_EMPTY_SOURCE' });
+
+    // Sealed but VM empty → empty-source error too.
+    await expect(publisher.assertionPullFrom(CG, NAME, AGENT, 'vm'))
+      .rejects.toMatchObject({ code: 'PULL_FROM_EMPTY_SOURCE' });
+    void graphManager;
+  });
+
+  it('re-pulls after a pull cleared the seal, via the preserved lifecycle identity', async () => {
+    const { publisher, store, graphManager } = await makePublisher();
+    const seeded = await seedSharedMemoryAssertion(store, graphManager, {
+      version: 1,
+      publicQuads: [q('urn:e:alice', SCHEMA, '"stable"')],
+    });
+    await store.insert(sealQuads({ assertionVersion: 1, publicTripleCount: 1 }));
+    // Simulate finalize's identity stamp so the KA survives seal teardown.
+    const lifecycle = assertionLifecycleUri(CG, AGENT, NAME);
+    await store.insert([
+      q(lifecycle, `${DKG}contentScopeVersion`, `"${GRAPH_KA_CONTENT_SCOPE_VERSION}"^^<http://www.w3.org/2001/XMLSchema#integer>`, META_GRAPH),
+      q(lifecycle, `${DKG}kaId`, `"${KA_NUMBER}"^^<http://www.w3.org/2001/XMLSchema#integer>`, META_GRAPH),
+      q(lifecycle, `${DKG}reservedUal`, `"${UAL}"`, META_GRAPH),
+    ]);
+
+    await publisher.assertionPullFrom(CG, NAME, AGENT, 'swm');
+    // First pull tore down the seal; identity must carry the second pull.
+    const again = await publisher.assertionPullFrom(CG, NAME, AGENT, 'swm', { onConflict: 'replace' });
+    expect(again.seeded).toBe(1);
+    const draft = await publisher.assertionQuery(CG, NAME, AGENT);
+    expect(await skolemizeKnowledgeAsset(draft)).toEqual(seeded.canonicalPublic);
+  });
+
+  it('fails closed on legacy root-scoped seals', async () => {
+    const { publisher, store } = await makePublisher();
+    await store.insert(legacySealQuads(['urn:e:alice']));
+    await store.insert([q('urn:e:alice', SCHEMA, '"Alice"', `did:dkg:context-graph:${CG}/_shared_memory`)]);
+    await expect(publisher.assertionPullFrom(CG, NAME, AGENT, 'swm'))
+      .rejects.toMatchObject({ code: 'LEGACY_KA_READ_ONLY' });
+  });
+
+  it('de-skolemization round-trips through canonicalization', async () => {
+    const canonical = await skolemizeKnowledgeAsset([
+      q('urn:e:root', 'urn:predicate:child', '_:a'),
+      q('_:a', 'urn:predicate:peer', '_:b'),
+      q('_:b', SCHEMA, '"leaf"'),
+      q('urn:e:root', SCHEMA, '"root"'),
+    ]);
+    const unlabelled = deskolemizeKnowledgeAssetQuads(canonical);
+    expect(unlabelled.some((quad) =>
+      quad.subject.startsWith('urn:dkg:ka-skolem:') || quad.object.startsWith('urn:dkg:ka-skolem:'),
+    )).toBe(false);
+    expect(await skolemizeKnowledgeAsset(unlabelled)).toEqual(canonical);
   });
 });

--- a/packages/publisher/test/async-lift-ka-broadcast-progress.test.ts
+++ b/packages/publisher/test/async-lift-ka-broadcast-progress.test.ts
@@ -10,7 +10,7 @@ import {
   jobSubject,
   walletLockSubject,
 } from '../src/async-lift-control-plane.js';
-import { storeWorkspaceOperationPublicQuads } from '../src/workspace-resolution.js';
+import { storeKnowledgeAssetOperationPublicQuads } from '../src/workspace-resolution.js';
 
 describe('KA async VM publish broadcast progress', () => {
   let now = 1_000;
@@ -38,11 +38,17 @@ describe('KA async VM publish broadcast progress', () => {
   function kaVmPublishRequest(overrides: Partial<Parameters<TripleStoreAsyncLiftPublisher['enqueueKnowledgeAssetVmPublish']>[0]> = {}) {
     const authorAddress = '0x1111111111111111111111111111111111111111';
     const kaNumber = 7n;
+    const kaUal = `did:dkg:31337/${authorAddress}/${kaNumber.toString()}`;
     return {
       contextGraphId: 'music-social',
       name: 'albums',
       shareOperationId: 'share-op-1',
-      roots: ['urn:album:one', 'urn:album:two'],
+      roots: [],
+      contentScopeVersion: 2 as const,
+      kaUal,
+      assertionVersion: '1',
+      publicTripleCount: 2,
+      privateTripleCount: 0,
       seal: {
         merkleRoot: (`0x${'12'.repeat(32)}`) as `0x${string}`,
         authorAddress: authorAddress as `0x${string}`,
@@ -61,18 +67,20 @@ describe('KA async VM publish broadcast progress', () => {
       wmCurrentAssertion: '12'.repeat(32),
       swmCurrentAssertion: '12'.repeat(32),
       kaNumber: kaNumber.toString(),
-      reservedUal: `did:dkg:31337/${authorAddress}/${kaNumber.toString()}`,
+      reservedUal: kaUal,
       ...overrides,
     };
   }
 
   async function stageShareSnapshot(): Promise<void> {
-    await storeWorkspaceOperationPublicQuads({
+    const request = kaVmPublishRequest();
+    await storeKnowledgeAssetOperationPublicQuads({
       store,
       graphManager,
       contextGraphId: 'music-social',
       shareOperationId: 'share-op-1',
-      rootEntities: ['urn:album:one', 'urn:album:two'],
+      kaUal: request.kaUal,
+      assertionVersion: request.assertionVersion,
       publisherPeerId: 'peer-1',
       quads: [
         { subject: 'urn:album:one', predicate: 'http://schema.org/name', object: '"One"', graph: '' },
@@ -120,7 +128,7 @@ describe('KA async VM publish broadcast progress', () => {
     await publisher.claimNext('wallet-1');
     await publisher.update(jobId, 'validated', {
       validation: {
-        canonicalRoots: ['urn:album:one', 'urn:album:two'],
+        canonicalRoots: [],
         canonicalRootMap: {},
         swmQuadCount: 2,
         authorityProofRef: 'knowledge-asset-lifecycle',
@@ -188,7 +196,7 @@ describe('KA async VM publish broadcast progress', () => {
     await publisher.claimNext('wallet-1');
     await publisher.update(jobId, 'validated', {
       validation: {
-        canonicalRoots: ['urn:album:one', 'urn:album:two'],
+        canonicalRoots: [],
         canonicalRootMap: {},
         swmQuadCount: 2,
         authorityProofRef: 'knowledge-asset-lifecycle',
@@ -214,7 +222,7 @@ describe('KA async VM publish broadcast progress', () => {
     await publisher.claimNext('wallet-1');
     await publisher.update(includedJobId, 'validated', {
       validation: {
-        canonicalRoots: ['urn:album:one', 'urn:album:two'],
+        canonicalRoots: [],
         canonicalRootMap: {},
         swmQuadCount: 2,
         authorityProofRef: 'knowledge-asset-lifecycle',
@@ -274,7 +282,7 @@ describe('KA async VM publish broadcast progress', () => {
     await publisher.claimNext('wallet-1');
     await publisher.update(jobId, 'validated', {
       validation: {
-        canonicalRoots: ['urn:album:one', 'urn:album:two'],
+        canonicalRoots: [],
         canonicalRootMap: {},
         swmQuadCount: 2,
         authorityProofRef: 'knowledge-asset-lifecycle',

--- a/packages/publisher/test/async-lift-publisher.test.ts
+++ b/packages/publisher/test/async-lift-publisher.test.ts
@@ -13,6 +13,7 @@ import {
   QuorumUnmetError,
   TripleStoreAsyncLiftPublisher,
   createLiftJobFailureMetadata,
+  storeKnowledgeAssetOperationPublicQuads,
   type AsyncLiftPublisherConfig,
   type AsyncLiftPublisherRecoveryResult,
   type LiftRequest,
@@ -104,7 +105,13 @@ describe('TripleStoreAsyncLiftPublisher', () => {
       contextGraphId: 'music-social',
       name: 'albums',
       shareOperationId: 'share-op-1',
-      roots: ['urn:album:one', 'urn:album:two'],
+      // Graph-scoped v2 envelope: one atomic KA, no root entities.
+      roots: [] as string[],
+      contentScopeVersion: 2,
+      kaUal: 'did:dkg:31337/0x1111111111111111111111111111111111111111/7',
+      assertionVersion: '1',
+      publicTripleCount: 2,
+      privateTripleCount: 0,
       seal: {
         merkleRoot: (`0x${'12'.repeat(32)}`) as `0x${string}`,
         authorAddress: authorAddress as `0x${string}`,
@@ -279,14 +286,19 @@ describe('TripleStoreAsyncLiftPublisher', () => {
 
     expect(jobId).toBe('job-1');
     expect(job?.status).toBe('accepted');
-    expect(job?.jobSlug).toBe('music-social/knowledge-assets/albums/vm-publish/share-op-1/one-two');
+    expect(job?.jobSlug).toBe('music-social/knowledge-assets/albums/vm-publish/share-op-1/no-roots');
     expect(job?.request.jobType).toBe('knowledge-asset-vm-publish');
     expect(job?.request.knowledgeAssetVmPublish).toEqual({
       contextGraphId: 'music-social',
       name: 'albums',
       subGraphName: 'research',
       shareOperationId: 'share-op-1',
-      roots: ['urn:album:one', 'urn:album:two'],
+      roots: [],
+      contentScopeVersion: 2,
+      kaUal: 'did:dkg:31337/0x1111111111111111111111111111111111111111/7',
+      assertionVersion: '1',
+      publicTripleCount: 2,
+      privateTripleCount: 0,
       seal: {
         merkleRoot: `0x${'12'.repeat(32)}`,
         authorAddress: '0x1111111111111111111111111111111111111111',
@@ -496,21 +508,24 @@ describe('TripleStoreAsyncLiftPublisher', () => {
         },
       },
     });
-    const publisherContract: Publisher = makeTestPublisher({
+    // Graph-scoped v2: the queued job resolves its content from the immutable
+    // digest-validated operation snapshot, not the legacy root-scoped bucket.
+    await storeKnowledgeAssetOperationPublicQuads({
       store,
-      chain: createEVMAdapter(HARDHAT_KEYS.CORE_OP),
-      eventBus: new TypedEventBus(),
-      keypair: await generateEd25519Keypair(),
-      publisherPrivateKey: HARDHAT_KEYS.CORE_OP,
-      publisherNodeIdentityId: BigInt(getSharedContext().coreProfileId),
+      graphManager: new GraphManager(store),
+      contextGraphId: 'music-social',
+      shareOperationId: 'share-op-1',
+      kaUal: 'did:dkg:31337/0x1111111111111111111111111111111111111111/7',
+      assertionVersion: '1',
+      quads: [
+        { subject: 'urn:album:one', predicate: 'http://schema.org/name', object: '"One"', graph: '' },
+        { subject: 'urn:album:two', predicate: 'http://schema.org/name', object: '"Two"', graph: '' },
+      ],
+      privateTripleCount: 0,
+      publisherPeerId: 'peer-1',
     });
-    const share = await publisherContract.share('music-social', [
-      { subject: 'urn:album:one', predicate: 'http://schema.org/name', object: '"One"', graph: '' },
-      { subject: 'urn:album:two', predicate: 'http://schema.org/name', object: '"Two"', graph: '' },
-    ], { publisherPeerId: 'peer-1' });
 
     const jobId = await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest({
-      shareOperationId: share.shareOperationId,
       clearSharedMemoryAfter: true,
     }));
     const processed = await publisher.processNext('wallet-1');
@@ -524,8 +539,8 @@ describe('TripleStoreAsyncLiftPublisher', () => {
         request: {
           contextGraphId: 'music-social',
           name: 'albums',
-          shareOperationId: share.shareOperationId,
-          roots: ['urn:album:one', 'urn:album:two'],
+          shareOperationId: 'share-op-1',
+          roots: [],
           seal: {
             merkleRoot: `0x${'12'.repeat(32)}`,
             authorAddress: '0x1111111111111111111111111111111111111111',
@@ -547,7 +562,7 @@ describe('TripleStoreAsyncLiftPublisher', () => {
           clearSharedMemoryAfter: true,
         },
         validation: {
-          canonicalRoots: ['urn:album:one', 'urn:album:two'],
+          canonicalRoots: [],
           swmQuadCount: 2,
           transitionType: 'CREATE',
         },
@@ -556,10 +571,11 @@ describe('TripleStoreAsyncLiftPublisher', () => {
         },
         publishOptions: {
           publisherPeerId: 'peer-1',
-          quads: [
+          // Snapshot reads are RDF sets — order-insensitive.
+          quads: expect.arrayContaining([
             { subject: 'urn:album:one', predicate: 'http://schema.org/name', object: '"One"', graph: '' },
             { subject: 'urn:album:two', predicate: 'http://schema.org/name', object: '"Two"', graph: '' },
-          ],
+          ]),
         },
       });
   });

--- a/packages/publisher/test/async-lift-validation.test.ts
+++ b/packages/publisher/test/async-lift-validation.test.ts
@@ -48,6 +48,47 @@ describe('validateLiftPublishPayload', () => {
     };
   }
 
+  function graphInput(): LiftValidationInput {
+    const input = baseInput();
+    return {
+      ...input,
+      request: {
+        ...input.request,
+        roots: [],
+        contentScopeVersion: 2,
+        kaUal: 'did:dkg:31337/0x1111111111111111111111111111111111111111/7',
+        assertionVersion: '1',
+        publicTripleCount: 3,
+        privateMerkleRoot: `0x${'12'.repeat(32)}`,
+        privateTripleCount: 1,
+      },
+    };
+  }
+
+  it('validates a complete graph-scoped KA without deriving root entities', () => {
+    const input = graphInput();
+    const validated = validateLiftPublishPayload(input);
+
+    expect(validated.validation).toMatchObject({
+      canonicalRoots: [],
+      canonicalRootMap: {},
+      swmQuadCount: 4,
+    });
+    expect(validated.resolved).toEqual(input.resolved);
+  });
+
+  it('rejects root manifests and count drift in graph-scoped jobs', () => {
+    const input = graphInput();
+    expect(() => validateLiftPublishPayload({
+      ...input,
+      request: { ...input.request, roots: ['urn:legacy:root'] },
+    })).toThrow('Graph-scoped Lift validation rejects root entities');
+    expect(() => validateLiftPublishPayload({
+      ...input,
+      request: { ...input.request, publicTripleCount: 2 },
+    })).toThrow('Graph-scoped Lift validation public triple count mismatch');
+  });
+
   // GH #1122 — the async lift now PRESERVES caller root IRIs (parity with sync),
   // so the "canonical" root is the caller root itself (identity).
   it('validates lift payloads while preserving caller root IRIs (GH #1122 parity)', () => {

--- a/packages/publisher/test/ka-graph-private-only-publish.test.ts
+++ b/packages/publisher/test/ka-graph-private-only-publish.test.ts
@@ -1,0 +1,201 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { NoChainAdapter } from '@origintrail-official/dkg-chain';
+import {
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  MemoryLayer,
+  TypedEventBus,
+  createGraphKnowledgeAssetScope,
+  generateEd25519Keypair,
+  knowledgeAssetLayerGraphUri,
+} from '@origintrail-official/dkg-core';
+import { OxigraphStore, PrivateContentStore, GraphManager, type Quad } from '@origintrail-official/dkg-storage';
+import {
+  DKGPublisher,
+  computePrivateRootV10,
+  skolemizeKnowledgeAsset,
+} from '../src/index.js';
+
+const CONTEXT_GRAPH = 'rootless-private-only';
+const META_GRAPH = `did:dkg:context-graph:${CONTEXT_GRAPH}/_meta`;
+const AUTHOR = '0x70997970c51812dc3a010c7d01b50e0d17dc79c8';
+const UAL = `did:dkg:base:8453/${AUTHOR}/55`;
+
+function quad(subject: string, predicate: string, object: string): Quad {
+  return { subject, predicate, object, graph: '' };
+}
+
+/**
+ * Fully private (zero-public) graph-scoped KAs through the REAL publisher
+ * paths — no stubbing of publishFromSharedMemory/update. Guards against a
+ * regression that reinstates an unconditional empty-public rejection, which
+ * would make private-only KAs unpublishable and un-updatable locally.
+ * (The V10 on-chain ACK path for zero public leaves remains a separate open
+ * protocol question — see PR #1713 review.)
+ */
+describe('fully private graph-scoped KA publish/update (real paths)', () => {
+  let store: OxigraphStore;
+  let publisher: DKGPublisher;
+  let privateStore: PrivateContentStore;
+
+  beforeEach(async () => {
+    store = new OxigraphStore();
+    publisher = new DKGPublisher({
+      store,
+      chain: new NoChainAdapter(),
+      eventBus: new TypedEventBus(),
+      keypair: await generateEd25519Keypair(),
+    });
+    privateStore = new PrivateContentStore(store, new GraphManager(store));
+  });
+
+  it('publishes a private-only KA from shared memory through the real path', async () => {
+    const scope = createGraphKnowledgeAssetScope(UAL, 1);
+    const canonicalPrivate = await skolemizeKnowledgeAsset([
+      quad('urn:private:only', 'urn:predicate:secret', '"nothing public here"'),
+    ]);
+    const privateMerkleRoot = computePrivateRootV10(canonicalPrivate)!;
+    await privateStore.replaceKnowledgeAssetPrivateTriples(
+      CONTEXT_GRAPH,
+      scope,
+      canonicalPrivate,
+    );
+
+    const result = await publisher.publishFromSharedMemory(CONTEXT_GRAPH, 'all', {
+      sharedMemoryScope: {
+        kind: 'named-lifecycle',
+        identity: { agentAddress: scope.agentAddress, kaNumber: BigInt(scope.kaNumber) },
+      },
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      kaUal: UAL,
+      assertionVersion: 1,
+      publicTripleCount: 0,
+      privateTripleCount: 1,
+      privateMerkleRoot,
+      publisherPeerId: 'rootless-publisher', // private content defaults to ownerOnly
+    });
+
+    expect(result.ual).toBe(UAL);
+    expect(result.status).toBe('tentative');
+    expect(result.publicQuads).toEqual([]);
+    expect(result.kaManifest).toEqual([]);
+
+    const meta = await store.query(
+      `SELECT ?p ?o WHERE { GRAPH <${META_GRAPH}> { <${UAL}> ?p ?o } }`,
+    );
+    expect(meta.type).toBe('bindings');
+    if (meta.type !== 'bindings') throw new Error('expected bindings');
+    const rows = new Map(meta.bindings.map((b) => [b['p'], b['o']]));
+    expect(rows.get('http://dkg.io/ontology/publicTripleCount')).toContain('"0"');
+    expect(rows.get('http://dkg.io/ontology/privateTripleCount')).toContain('"1"');
+    expect(rows.get('http://dkg.io/ontology/privateMerkleRoot'))
+      .toContain(Buffer.from(privateMerkleRoot).toString('hex'));
+    expect(
+      await privateStore.getKnowledgeAssetPrivateTriples(CONTEXT_GRAPH, scope),
+    ).toEqual(canonicalPrivate);
+  });
+
+  it('updates a KA to fully private content through the real update path', async () => {
+    const v1Public = [quad('urn:public:v1', 'urn:predicate:value', '"public v1"')];
+    const first = await publisher.publish({
+      contextGraphId: CONTEXT_GRAPH,
+      quads: v1Public,
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      kaUal: UAL,
+      assertionVersion: 1,
+      publicTripleCount: 1,
+    });
+
+    const canonicalPrivate = await skolemizeKnowledgeAsset([
+      quad('urn:private:v2', 'urn:predicate:secret', '"went dark"'),
+    ]);
+    const privateMerkleRoot = computePrivateRootV10(canonicalPrivate)!;
+    const updated = await publisher.update(first.kaId, {
+      contextGraphId: CONTEXT_GRAPH,
+      quads: [],
+      privateQuads: canonicalPrivate,
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      kaUal: UAL,
+      assertionVersion: 2,
+      publicTripleCount: 0,
+      privateTripleCount: 1,
+      privateMerkleRoot,
+    });
+    expect(updated.ual).toBe(UAL);
+
+    // The public-to-private-only transition must remove the public VM graph
+    // content while the v2 private commitment becomes readable.
+    const scope2 = createGraphKnowledgeAssetScope(UAL, 2);
+    const vmGraph = knowledgeAssetLayerGraphUri(
+      CONTEXT_GRAPH,
+      MemoryLayer.VerifiableMemory,
+      scope2,
+    );
+    expect(await store.countQuads(vmGraph)).toBe(0);
+    expect(
+      await privateStore.getKnowledgeAssetPrivateTriples(CONTEXT_GRAPH, scope2),
+    ).toEqual(canonicalPrivate);
+
+    const meta = await store.query(
+      `SELECT ?o WHERE { GRAPH <${META_GRAPH}> { <${UAL}> <http://dkg.io/ontology/assertionVersion> ?o } }`,
+    );
+    expect(meta.type).toBe('bindings');
+    if (meta.type !== 'bindings') throw new Error('expected bindings');
+    // NB: exact one-row convergence is pinned by #1712's regression test (the
+    // stale-row fix lands there and reaches this branch on restack); here we
+    // only require the new head version to be recorded.
+    expect(meta.bindings.map((b) => b['o'])).toContainEqual(
+      expect.stringContaining('"2"'),
+    );
+  });
+
+  it('updateKnowledgeAssetFromSharedMemory accepts a private-only envelope with empty SWM', async () => {
+    const first = await publisher.publish({
+      contextGraphId: CONTEXT_GRAPH,
+      quads: [quad('urn:public:v1', 'urn:predicate:value', '"public v1"')],
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      kaUal: UAL,
+      assertionVersion: 1,
+      publicTripleCount: 1,
+    });
+
+    const canonicalPrivate = await skolemizeKnowledgeAsset([
+      quad('urn:private:v2', 'urn:predicate:secret', '"swm has no public rows"'),
+    ]);
+    const privateMerkleRoot = computePrivateRootV10(canonicalPrivate)!;
+
+    // Regression: this used to throw "No quads in shared memory" for every
+    // fully private KA, because zero public SWM rows were treated as an error
+    // regardless of the private partition.
+    const updated = await publisher.updateKnowledgeAssetFromSharedMemory(first.kaId, {
+      contextGraphId: CONTEXT_GRAPH,
+      privateQuads: canonicalPrivate,
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      kaUal: UAL,
+      assertionVersion: 2,
+      publicTripleCount: 0,
+      privateTripleCount: 1,
+      privateMerkleRoot,
+    });
+    expect(updated.ual).toBe(UAL);
+    expect(
+      await privateStore.getKnowledgeAssetPrivateTriples(
+        CONTEXT_GRAPH,
+        createGraphKnowledgeAssetScope(UAL, 2),
+      ),
+    ).toEqual(canonicalPrivate);
+
+    // Fail-closed stays: an envelope PROMISING public content that shared
+    // memory does not hold is still rejected.
+    await expect(
+      publisher.updateKnowledgeAssetFromSharedMemory(first.kaId, {
+        contextGraphId: CONTEXT_GRAPH,
+        contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+        kaUal: UAL,
+        assertionVersion: 3,
+        publicTripleCount: 2,
+        privateTripleCount: 1,
+        privateMerkleRoot,
+      }),
+    ).rejects.toThrow(/No quads in shared memory/);
+  });
+});

--- a/packages/publisher/test/promote-step-tag.test.ts
+++ b/packages/publisher/test/promote-step-tag.test.ts
@@ -78,8 +78,7 @@ describe('#1464 promote step tagging — assertionPromote integration', () => {
     const store = new OxigraphStore();
     const boom = new Error('SPARQL HTTP query failed (500): oxigraph worker unavailable');
     (boom as { code?: unknown }).code = 'OXIGRAPH_DOWN';
-    // The first pre-insert awaited op in assertionPromote is
-    // wmGraphUri → resolveKaNumber → store.query. Reject there.
+    // The graph-scoped lifecycle write gate is the first pre-insert store read.
     store.query = async () => {
       throw boom;
     };
@@ -97,10 +96,10 @@ describe('#1464 promote step tagging — assertionPromote integration', () => {
         'my-assertion',
         '0x1234567890abcdef1234567890abcdef12345678',
       ),
-    ).rejects.toThrow(/^\[promote:wmGraphUri\] SPARQL HTTP query failed \(500\)/);
+    ).rejects.toThrow(/^\[promote:assertGraphScopedLifecycleWritable\] SPARQL HTTP query failed \(500\)/);
 
     // Original error identity + classification code preserved for PR2.
-    expect(boom.message).toContain('[promote:wmGraphUri]');
+    expect(boom.message).toContain('[promote:assertGraphScopedLifecycleWritable]');
     expect((boom as { code?: unknown }).code).toBe('OXIGRAPH_DOWN');
   });
 });

--- a/packages/publisher/vitest.unit.config.ts
+++ b/packages/publisher/vitest.unit.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
       'test/ka-graph-workspace-snapshot.test.ts',
       'test/ka-graph-finalization-storage.test.ts',
       'test/ka-graph-publish-storage.test.ts',
+      'test/ka-graph-private-only-publish.test.ts',
       'test/agents-meta-bound.test.ts',
       'test/ack-collector.test.ts',
       'test/publish-lifecycle-logger.test.ts',

--- a/packages/storage/src/private-store.ts
+++ b/packages/storage/src/private-store.ts
@@ -166,6 +166,82 @@ export class PrivateContentStore {
   }
 
   /**
+   * Mutable private draft paired with one named WM lifecycle.
+   *
+   * The final assertion version is not known until finalize, so drafts cannot
+   * use the immutable `(UAL, assertionVersion)` graph yet. Keep them in a
+   * lifecycle-keyed graph under the private bucket, then atomically materialize
+   * the canonical assertion-versioned graph before exposing the seal.
+   */
+  knowledgeAssetPrivateDraftGraphUri(
+    contextGraphId: string,
+    agentAddress: string,
+    assertionName: string,
+    subGraphName?: string,
+  ): string {
+    const bucket = this.privateGraph(contextGraphId, subGraphName);
+    const identity = [agentAddress.toLowerCase(), assertionName]
+      .map((part) => encodeURIComponent(part))
+      .join(':');
+    return assertSafeIri(`${bucket}/_working_memory/${identity}`);
+  }
+
+  /** Append private triples to a mutable named-KA draft. */
+  async storeKnowledgeAssetPrivateDraftTriples(
+    contextGraphId: string,
+    agentAddress: string,
+    assertionName: string,
+    quads: readonly Quad[],
+    subGraphName?: string,
+  ): Promise<void> {
+    if (quads.length === 0) return;
+    for (const quad of quads) assertSafePrivateQuad(quad);
+    const graphUri = this.knowledgeAssetPrivateDraftGraphUri(
+      contextGraphId,
+      agentAddress,
+      assertionName,
+      subGraphName,
+    );
+    await this.withGraphWriteLock(graphUri, async () => {
+      await this.store.insert(quads.map((quad) => ({ ...quad, graph: graphUri })));
+    });
+  }
+
+  /** Read the complete mutable private draft without exposing its storage graph. */
+  async getKnowledgeAssetPrivateDraftTriples(
+    contextGraphId: string,
+    agentAddress: string,
+    assertionName: string,
+    subGraphName?: string,
+  ): Promise<Quad[]> {
+    const graphUri = this.knowledgeAssetPrivateDraftGraphUri(
+      contextGraphId,
+      agentAddress,
+      assertionName,
+      subGraphName,
+    );
+    const result = await this.store.query(
+      `CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${graphUri}> { ?s ?p ?o } }`,
+    );
+    if (result.type !== 'quads') return [];
+    return result.quads.map((quad) => ({ ...quad, graph: '' }));
+  }
+
+  async deleteKnowledgeAssetPrivateDraft(
+    contextGraphId: string,
+    agentAddress: string,
+    assertionName: string,
+    subGraphName?: string,
+  ): Promise<void> {
+    await this.store.dropGraph(this.knowledgeAssetPrivateDraftGraphUri(
+      contextGraphId,
+      agentAddress,
+      assertionName,
+      subGraphName,
+    ));
+  }
+
+  /**
    * Exact private content graph for one rootless KA assertion.
    *
    * Public VM currently materializes the latest assertion in a stable UAL-derived


### PR DESCRIPTION
## Summary

Stacked on #1712.

- extend v2 assertion seals with exact public/private triple counts and one private Merkle commitment, with no root-entity manifest
- keep mutable private drafts separate, materialize immutable private content by UAL plus assertion version, and support fully private KAs without synthetic public anchors
- make finalize, WM-to-SWM promote, direct publish/update, and recovery operate on the complete exact KA graph
- persist the graph-scoped identity and commitments through named-KA async jobs, and reject legacy named-KA mutation jobs
- add failure-injection coverage for atomic finalization/promotion recovery and private-only lifecycle behavior

The older raw Lift API remains on its existing root-scoped contract in this PR. Its mutation cutover is intentionally deferred to the later compatibility PR. Receiver-side graph-scoped SWM handling and bounded sync are also isolated in the next stacked PR.

## Validation

- `pnpm --filter @origintrail-official/dkg-agent... build`
- core focused tests: 10 passed
- publisher unit suite: 306 passed
- agent graph finalization recovery suite: 3 passed

All validation above was run from a clean detached worktree at commit `862f4337a`.