### PR TITLE
feat: finalize rootless KAs by graph identity

### DIFF
--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -4594,6 +4594,11 @@ export class PublishMethods extends DKGAgentBase {
         targetContextGraphId: result.contextGraphError ? undefined : broadcastCgId,
         subGraphName: request.subGraphName,
         keepRootCopyOnLabel,
+        contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+        assertionVersion: graphScope.assertionVersion,
+        publicTripleCount: seal.publicTripleCount,
+        ...(snapshotPrivateRoot ? { privateMerkleRoot: snapshotPrivateRoot } : {}),
+        privateTripleCount: seal.privateTripleCount,
       };
       const topic = contextGraphFinalizationTopic(request.contextGraphId);
       try {
@@ -5698,6 +5703,17 @@ export class PublishMethods extends DKGAgentBase {
         targetContextGraphId: result.contextGraphError ? undefined : broadcastCgId,
         subGraphName: options?.subGraphName,
         keepRootCopyOnLabel,
+        ...(options?.contentScopeVersion === GRAPH_KA_CONTENT_SCOPE_VERSION
+          ? {
+              contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+              assertionVersion: String(options.assertionVersion),
+              publicTripleCount: options.publicTripleCount ?? 0,
+              ...(options.privateMerkleRoot
+                ? { privateMerkleRoot: options.privateMerkleRoot }
+                : {}),
+              privateTripleCount: options.privateTripleCount ?? 0,
+            }
+          : {}),
       };
 
       const topic = contextGraphFinalizationTopic(contextGraphId);

--- a/packages/agent/src/dkg-agent-swm-substrate.ts
+++ b/packages/agent/src/dkg-agent-swm-substrate.ts
@@ -1651,6 +1651,10 @@ export class SwmSubstrateMethods extends DKGAgentBase {
           localPeerId: this.peerId,
           localNodeIdentityId: this.identityId.toString(),
         },
+        // Graph-scoped recovery resolves immutable operation snapshots; when
+        // the node stores them in the file-backed snapshot store the handler
+        // needs the same store to read them back.
+        this.publicSnapshotStore,
       );
     }
     return this.finalizationHandler;

--- a/packages/agent/src/finalization-handler.ts
+++ b/packages/agent/src/finalization-handler.ts
@@ -8,22 +8,39 @@ import {
   type EventBus,
   type FinalizationMessageMsg,
   type OperationContext,
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  MemoryLayer,
+  createGraphKnowledgeAssetScope,
+  knowledgeAssetLayerGraphUri,
   DKG_ENTITY,
   DKG_ROOT_ENTITY_LEGACY,
   ENTITY_PRED_ALT,
 } from '@origintrail-official/dkg-core';
-import { GraphManager, loadSelectedSharedMemoryQuads, loadSharedMemorySliceWithKaBoundFallback, asGraphWriteGenSource, type GraphWriteGenSource, type SwmKaGraphBound, type TripleStore, type Quad } from '@origintrail-official/dkg-storage';
+import {
+  GraphManager,
+  loadSelectedSharedMemoryQuads,
+  loadSharedMemorySliceWithKaBoundFallback,
+  asGraphWriteGenSource,
+  tryReplaceGraphAtomically,
+  type GraphWriteGenSource,
+  type SwmKaGraphBound,
+  type TripleStore,
+  type Quad,
+} from '@origintrail-official/dkg-storage';
 import { type ChainAdapter, type EventFilter } from '@origintrail-official/dkg-chain';
 import {
   computeFlatKCRootV10 as computeFlatKCRoot, skolemizeByEntity,
   generatedPrivateCatalogFloorQuads,
   generatedPrivateCatalogTripleKeys,
-  generateConfirmedFullMetadata, buildDeterministicTokenRows, compareRootIris, getTentativeStatusQuad,
+  generateConfirmedFullMetadata, generateGraphKnowledgeAssetMetadata,
+  buildDeterministicTokenRows, compareRootIris, getTentativeStatusQuad,
   insertBoundedAgentRegistryMeta,
   generateSubGraphRegistration,
   splitTrustedGeneratedCatalogRootMap,
   shouldApplyMaterialization, writeMaterializedVersion, withMaterializationLock,
+  resolveKnowledgeAssetWorkspaceHead,
   type MaterializedVersion,
+  type KnowledgeAssetWorkspaceHead,
   type KCMetadata, type KAMetadata, type OnChainProvenance,
 } from '@origintrail-official/dkg-publisher';
 const DKG_NS = 'http://dkg.io/ontology/';
@@ -119,6 +136,11 @@ function sameBigIntLiteral(left: string | bigint | null | undefined, right: stri
   } catch {
     return false;
   }
+}
+
+function equalBytes(left: Uint8Array, right: Uint8Array): boolean {
+  return left.length === right.length
+    && left.every((byte, index) => byte === right[index]);
 }
 
 /**
@@ -229,8 +251,20 @@ export class FinalizationHandler {
         return;
       }
 
-      if (!msg.ual || !msg.txHash || msg.rootEntities.length === 0) {
-        this.log.warn(ctx, `Finalization: incomplete message (ual=${msg.ual}, txHash=${msg.txHash}, roots=${msg.rootEntities.length}), ignoring`);
+      const isGraphScoped = msg.contentScopeVersion === GRAPH_KA_CONTENT_SCOPE_VERSION;
+      if (
+        msg.contentScopeVersion !== undefined
+        && msg.contentScopeVersion !== 0
+        && !isGraphScoped
+      ) {
+        this.log.warn(
+          ctx,
+          `Finalization: unsupported content scope version ${msg.contentScopeVersion}, ignoring`,
+        );
+        return;
+      }
+      if (!msg.ual || !msg.txHash || (!isGraphScoped && msg.rootEntities.length === 0)) {
+        this.log.warn(ctx, `Finalization: incomplete message (ual=${msg.ual}, txHash=${msg.txHash}, roots=${msg.rootEntities.length}, scope=${msg.contentScopeVersion ?? 0}), ignoring`);
         return;
       }
 
@@ -314,6 +348,20 @@ export class FinalizationHandler {
       const targetMetaGraph = ctxGraphId
         ? contextGraphMetaUri(contextGraphId, ctxGraphId)
         : `did:dkg:context-graph:${contextGraphId}/_meta`;
+      if (isGraphScoped) {
+        const graphOutcome = await this.handleGraphScopedFinalization({
+          msg,
+          contextGraphId,
+          ctxGraphId,
+          subGraphName,
+          blockNumber,
+          ctx,
+        });
+        if (graphOutcome === 'applied' || graphOutcome === 'already-confirmed') {
+          this.markProcessed(dedupeKey);
+        }
+        return;
+      }
       const alreadyPromoted = await this.isAlreadyConfirmed(
         msg.ual, targetMetaGraph, `did:dkg:context-graph:${contextGraphId}/_meta`,
       );
@@ -547,11 +595,575 @@ export class FinalizationHandler {
     }
   }
 
+  /**
+   * Apply a V2 finalization without rediscovering RDF roots. The wire carries
+   * only the canonical UAL, assertion version, counts, and one private
+   * commitment; the physical SWM/VM graph names are derived locally.
+   */
+  private async handleGraphScopedFinalization(input: {
+    msg: FinalizationMessageMsg;
+    contextGraphId: string;
+    ctxGraphId?: string;
+    subGraphName?: string;
+    blockNumber: number;
+    ctx: OperationContext;
+  }): Promise<'applied' | 'already-confirmed' | 'deferred'> {
+    const {
+      msg,
+      contextGraphId,
+      ctxGraphId,
+      subGraphName,
+      blockNumber,
+      ctx,
+    } = input;
+    if (msg.rootEntities.length !== 0) {
+      this.log.warn(ctx, `Finalization: graph-scoped message for ${msg.ual} carries legacy root entities, ignoring`);
+      return 'deferred';
+    }
+    const assertionVersion = String(msg.assertionVersion ?? '').trim();
+    if (!assertionVersion) {
+      this.log.warn(ctx, `Finalization: graph-scoped message for ${msg.ual} is missing assertionVersion`);
+      return 'deferred';
+    }
+    let scope: ReturnType<typeof createGraphKnowledgeAssetScope>;
+    try {
+      scope = createGraphKnowledgeAssetScope(msg.ual, assertionVersion);
+    } catch (err) {
+      this.log.warn(
+        ctx,
+        `Finalization: invalid graph-scoped identity: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return 'deferred';
+    }
+    if (scope.ual !== msg.ual) {
+      this.log.warn(ctx, `Finalization: non-canonical graph-scoped UAL ${msg.ual}, ignoring`);
+      return 'deferred';
+    }
+
+    const publicTripleCount = Number(msg.publicTripleCount ?? 0);
+    const privateTripleCount = Number(msg.privateTripleCount ?? 0);
+    const privateMerkleRoot = msg.privateMerkleRoot?.length
+      ? new Uint8Array(msg.privateMerkleRoot)
+      : undefined;
+    if (
+      !Number.isSafeInteger(publicTripleCount)
+      || publicTripleCount < 0
+      || !Number.isSafeInteger(privateTripleCount)
+      || privateTripleCount < 0
+      || (publicTripleCount === 0 && privateTripleCount === 0)
+      || (privateTripleCount > 0 && privateMerkleRoot?.length !== 32)
+      || (privateTripleCount === 0 && privateMerkleRoot !== undefined)
+    ) {
+      this.log.warn(ctx, `Finalization: invalid graph-scoped content envelope for ${scope.ual}, ignoring`);
+      return 'deferred';
+    }
+
+    const packedKaId =
+      (BigInt(scope.agentAddress) << 96n)
+      | BigInt(scope.kaNumber);
+    let startKAId: bigint;
+    let endKAId: bigint;
+    let batchId: bigint;
+    try {
+      startKAId = protoToBigInt(msg.startKAId);
+      endKAId = protoToBigInt(msg.endKAId);
+      batchId = protoToBigInt(msg.batchId);
+    } catch {
+      this.log.warn(ctx, `Finalization: invalid on-chain identifiers for graph-scoped KA ${scope.ual}`);
+      return 'deferred';
+    }
+    if (startKAId !== packedKaId || endKAId !== packedKaId) {
+      this.log.warn(
+        ctx,
+        `Finalization: UAL-derived kaId ${packedKaId} does not match wire range ${startKAId}..${endKAId}`,
+      );
+      return 'deferred';
+    }
+
+    const graphManager = new GraphManager(this.store);
+    await graphManager.ensureContextGraph(contextGraphId);
+    if (subGraphName) await graphManager.ensureSubGraph(contextGraphId, subGraphName);
+    const swmGraph = knowledgeAssetLayerGraphUri(
+      contextGraphId,
+      MemoryLayer.SharedWorkingMemory,
+      scope,
+      subGraphName,
+    );
+    if (
+      await this.graphScopedConfirmationState(
+        contextGraphId,
+        scope.ual,
+        msg.kcMerkleRoot,
+        subGraphName,
+      ) === 'matching'
+    ) {
+      // A prior attempt may have crashed after VM+metadata but before SWM
+      // cleanup. Complete that final idempotent step here.
+      await this.store.dropGraph(swmGraph);
+      this.log.info(ctx, `Finalization: graph-scoped KA ${scope.ual} is already confirmed`);
+      return 'already-confirmed';
+    }
+
+    let head;
+    try {
+      head = await resolveKnowledgeAssetWorkspaceHead({
+        store: this.store,
+        graphManager,
+        contextGraphId,
+        kaUal: scope.ual,
+        subGraphName,
+      });
+    } catch (err) {
+      this.log.warn(
+        ctx,
+        `Finalization: corrupt graph-scoped SWM head for ${scope.ual}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return 'deferred';
+    }
+    if (
+      !head
+      || head.assertionVersion !== scope.assertionVersion
+      || head.publicTripleCount !== publicTripleCount
+      || head.privateTripleCount !== privateTripleCount
+      || (head.privateMerkleRoot?.toLowerCase() ?? undefined)
+        !== (privateMerkleRoot ? ethers.hexlify(privateMerkleRoot).toLowerCase() : undefined)
+    ) {
+      this.log.warn(ctx, `Finalization: no matching graph-scoped SWM head for ${scope.ual}`);
+      return 'deferred';
+    }
+
+    const swmResult = await this.store.query(
+      `CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${assertSafeIri(swmGraph)}> { ?s ?p ?o } }`,
+    );
+    const swmQuads = swmResult.type === 'quads'
+      ? swmResult.quads.map((quad) => ({ ...quad, graph: '' }))
+      : [];
+    if (swmQuads.length !== publicTripleCount) {
+      this.log.warn(
+        ctx,
+        `Finalization: graph-scoped SWM count mismatch for ${scope.ual}: `
+          + `wire=${publicTripleCount}, store=${swmQuads.length}`,
+      );
+      return 'deferred';
+    }
+    const computedMerkleRoot = computeFlatKCRoot(
+      swmQuads,
+      privateMerkleRoot ? [privateMerkleRoot] : [],
+    );
+    if (!equalBytes(computedMerkleRoot, msg.kcMerkleRoot)) {
+      this.log.warn(ctx, `Finalization: graph-scoped Merkle mismatch for ${scope.ual}`);
+      return 'deferred';
+    }
+
+    const verified = await this.verifyOnChain(
+      msg.txHash,
+      blockNumber,
+      msg.kcMerkleRoot,
+      msg.publisherAddress,
+      startKAId,
+      endKAId,
+      ctx,
+      ctxGraphId,
+      batchId,
+    );
+    if (!verified.verified) {
+      this.log.info(ctx, `Finalization: on-chain verification pending for graph-scoped KA ${scope.ual}`);
+      return 'deferred';
+    }
+
+    const outcome = await this.applyVerifiedGraphScopedFinalization({
+      contextGraphId,
+      scope,
+      swmQuads,
+      head,
+      privateMerkleRoot,
+      computedMerkleRoot,
+      publisherAddress: msg.publisherAddress,
+      txHash: msg.txHash,
+      blockNumber,
+      batchId,
+      authorAddress: verified.authorAddress,
+      materializedVersion: {
+        blockNumber,
+        txIndex: verified.txIndex ?? 0,
+      },
+      subGraphName,
+      source: 'finalization',
+      ctx,
+    });
+    if (outcome === 'stale') {
+      this.log.info(ctx, `Finalization: newer graph-scoped assertion already materialized for ${scope.ual}`);
+      return 'already-confirmed';
+    }
+
+    this.log.info(
+      ctx,
+      `Finalization: promoted graph-scoped KA ${scope.ual} (${publicTripleCount} public, ${privateTripleCount} private)`,
+    );
+    return 'applied';
+  }
+
+  /**
+   * Resolve and promote the exact graph-scoped SWM assertion for a chain-known
+   * KA. `undefined` means no V2 head exists and the caller may try the legacy
+   * root-operation recovery path; every other result is authoritative for V2.
+   */
+  private async reconcileGraphScopedKC(input: {
+    contextGraphId: string;
+    ual: string;
+    merkleRoot: Uint8Array;
+    publisherAddress: string;
+    kaId: bigint;
+    versionBlock: number;
+    authorAddress?: string;
+    subGraphName?: string;
+  }, ctx: OperationContext): Promise<
+    'promoted' | 'already-confirmed' | 'no-swm' | 'stale-target' | undefined
+  > {
+    const {
+      contextGraphId,
+      ual,
+      merkleRoot,
+      publisherAddress,
+      kaId,
+      versionBlock,
+      authorAddress,
+      subGraphName,
+    } = input;
+    // Historical UAL shapes can be valid inputs to the legacy root-scoped
+    // recovery code but cannot name a V2 per-KA graph. Do not let the strict
+    // V2 parser turn those into a terminal "corrupt head" result.
+    try {
+      createGraphKnowledgeAssetScope(ual, 1);
+    } catch {
+      return undefined;
+    }
+    if (
+      await this.graphScopedConfirmationState(
+        contextGraphId,
+        ual,
+        merkleRoot,
+        subGraphName,
+      ) === 'matching'
+    ) {
+      return 'already-confirmed';
+    }
+    const graphManager = new GraphManager(this.store);
+    let head: KnowledgeAssetWorkspaceHead | undefined;
+    try {
+      head = await resolveKnowledgeAssetWorkspaceHead({
+        store: this.store,
+        graphManager,
+        contextGraphId,
+        kaUal: ual,
+        subGraphName,
+      });
+    } catch (err) {
+      this.log.warn(
+        ctx,
+        `Chain-reconcile: corrupt graph-scoped SWM head for ${ual}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return 'no-swm';
+    }
+    if (!head) return undefined;
+
+    let scope: ReturnType<typeof createGraphKnowledgeAssetScope>;
+    try {
+      scope = createGraphKnowledgeAssetScope(ual, head.assertionVersion);
+    } catch (err) {
+      this.log.warn(
+        ctx,
+        `Chain-reconcile: invalid graph-scoped identity for ${ual}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return 'no-swm';
+    }
+    const packedKaId = (BigInt(scope.agentAddress) << 96n) | BigInt(scope.kaNumber);
+    if (scope.ual !== ual || packedKaId !== kaId) {
+      this.log.warn(
+        ctx,
+        `Chain-reconcile: UAL-derived kaId ${packedKaId} does not match chain kaId ${kaId} for ${ual}`,
+      );
+      return 'no-swm';
+    }
+    if (head.publicTripleCount === 0 && head.privateTripleCount === 0) {
+      this.log.warn(ctx, `Chain-reconcile: empty graph-scoped content envelope for ${ual}`);
+      return 'no-swm';
+    }
+
+    let privateMerkleRoot: Uint8Array | undefined;
+    try {
+      privateMerkleRoot = head.privateMerkleRoot
+        ? ethers.getBytes(head.privateMerkleRoot)
+        : undefined;
+    } catch {
+      this.log.warn(ctx, `Chain-reconcile: invalid private commitment for graph-scoped KA ${ual}`);
+      return 'no-swm';
+    }
+    const swmGraph = knowledgeAssetLayerGraphUri(
+      contextGraphId,
+      MemoryLayer.SharedWorkingMemory,
+      scope,
+      subGraphName,
+    );
+    const swmResult = await this.store.query(
+      `CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${assertSafeIri(swmGraph)}> { ?s ?p ?o } }`,
+    );
+    const swmQuads = swmResult.type === 'quads'
+      ? swmResult.quads.map((quad) => ({ ...quad, graph: '' }))
+      : [];
+    if (swmQuads.length !== head.publicTripleCount) {
+      this.log.info(
+        ctx,
+        `Chain-reconcile: graph-scoped SWM count mismatch for ${ual}: head=${head.publicTripleCount}, store=${swmQuads.length}`,
+      );
+      return 'no-swm';
+    }
+    const computedMerkleRoot = computeFlatKCRoot(
+      swmQuads,
+      privateMerkleRoot ? [privateMerkleRoot] : [],
+    );
+    if (!equalBytes(computedMerkleRoot, merkleRoot)) {
+      this.log.info(
+        ctx,
+        `Chain-reconcile: exact graph-scoped SWM assertion does not match the chain root for ${ual}`,
+      );
+      return 'no-swm';
+    }
+
+    const outcome = await this.applyVerifiedGraphScopedFinalization({
+      contextGraphId,
+      scope,
+      swmQuads,
+      head,
+      privateMerkleRoot,
+      computedMerkleRoot,
+      publisherAddress,
+      txHash: '',
+      blockNumber: versionBlock,
+      batchId: kaId,
+      authorAddress,
+      materializedVersion: { blockNumber: versionBlock, txIndex: 0 },
+      subGraphName,
+      source: 'chain-reconcile',
+      ctx,
+    });
+    if (outcome === 'stale') return 'stale-target';
+    this.log.info(
+      ctx,
+      `Chain-reconcile: promoted exact graph-scoped SWM assertion to VM for ${ual} (ka=${kaId})`,
+    );
+    return 'promoted';
+  }
+
+  /**
+   * Materialize a graph-scoped assertion after its content and chain binding
+   * have been verified. Gossip finalization and chain reconciliation deliberately
+   * share this atomic SWM→VM transition so a late joiner cannot produce a
+   * different storage shape from a node that saw the live finalization message.
+   */
+  private async applyVerifiedGraphScopedFinalization(input: {
+    contextGraphId: string;
+    scope: ReturnType<typeof createGraphKnowledgeAssetScope>;
+    swmQuads: Quad[];
+    head: KnowledgeAssetWorkspaceHead;
+    privateMerkleRoot?: Uint8Array;
+    computedMerkleRoot: Uint8Array;
+    publisherAddress: string;
+    txHash: string;
+    blockNumber: number;
+    batchId: bigint;
+    authorAddress?: string;
+    materializedVersion: MaterializedVersion;
+    subGraphName?: string;
+    source: 'finalization' | 'chain-reconcile';
+    ctx: OperationContext;
+  }): Promise<'applied' | 'stale'> {
+    const {
+      contextGraphId,
+      scope,
+      swmQuads,
+      head,
+      privateMerkleRoot,
+      computedMerkleRoot,
+      publisherAddress,
+      txHash,
+      blockNumber,
+      batchId,
+      authorAddress,
+      materializedVersion,
+      subGraphName,
+      source,
+      ctx,
+    } = input;
+    const publicTripleCount = head.publicTripleCount;
+    const privateTripleCount = head.privateTripleCount;
+    const swmGraph = knowledgeAssetLayerGraphUri(
+      contextGraphId,
+      MemoryLayer.SharedWorkingMemory,
+      scope,
+      subGraphName,
+    );
+    const vmGraph = knowledgeAssetLayerGraphUri(
+      contextGraphId,
+      MemoryLayer.VerifiableMemory,
+      scope,
+      subGraphName,
+    );
+    const metaGraph = contextGraphMetaUri(contextGraphId);
+
+    const outcome = await withMaterializationLock(metaGraph, scope.ual, async () => {
+      if (!(await shouldApplyMaterialization(
+        this.store,
+        metaGraph,
+        scope.ual,
+        materializedVersion,
+      ))) {
+        return 'stale' as const;
+      }
+      const vmQuads = swmQuads.map((quad) => ({ ...quad, graph: vmGraph }));
+      const replaced = await tryReplaceGraphAtomically(
+        this.store,
+        vmGraph,
+        vmQuads,
+        { source: 'agent.finalization.graphScopedReplace' },
+      );
+      if (!replaced) {
+        throw Object.assign(
+          new Error('Graph-scoped VM finalization requires atomic TripleStore.update() support'),
+          { code: 'VM_ATOMIC_REPLACE_UNSUPPORTED' },
+        );
+      }
+
+      let blockTimestamp = Math.floor(Date.now() / 1000);
+      if (this.chain && typeof (this.chain as any).getBlockTimestamp === 'function') {
+        try {
+          blockTimestamp = await (this.chain as any).getBlockTimestamp(blockNumber);
+        } catch {
+          this.log.info(ctx, `Could not fetch block timestamp for block ${blockNumber}, using local time`);
+        }
+      }
+      const provenance: OnChainProvenance = {
+        txHash,
+        blockNumber,
+        blockTimestamp,
+        publisherAddress,
+        batchId,
+        chainId: this.chain?.chainId ?? 'unknown',
+      };
+      const metadata = generateGraphKnowledgeAssetMetadata(
+        {
+          ual: scope.ual,
+          contextGraphId,
+          merkleRoot: computedMerkleRoot,
+          publisherPeerId: head.publisherPeerId,
+          accessPolicy: privateTripleCount > 0 ? 'ownerOnly' : 'public',
+          timestamp: new Date(),
+          subGraphName,
+          ...(authorAddress ? { authorAddress } : {}),
+          assertionVersion: scope.assertionVersion,
+          publicTripleCount,
+          ...(privateMerkleRoot ? { privateMerkleRoot } : {}),
+          privateTripleCount,
+          assertionGraph: vmGraph,
+        },
+        'confirmed',
+        provenance,
+      );
+      await this.store.deleteByPattern({ graph: metaGraph, subject: scope.ual });
+      await this.store.insert(metadata);
+      await writeMaterializedVersion(
+        this.store,
+        metaGraph,
+        scope.ual,
+        materializedVersion,
+      );
+      await this.store.dropGraph(swmGraph);
+      return 'applied' as const;
+    });
+    if (outcome === 'stale') return outcome;
+
+    this.eventBus?.emit(DKGEvent.MEMORY_GRAPH_CHANGED, {
+      contextGraphId,
+      layers: ['swm', 'vm'],
+      subGraphName,
+      operation: 'verifiable_memory_finalized',
+      source,
+      counts: { roots: 0, triples: publicTripleCount },
+    });
+    return 'applied';
+  }
+
   private markProcessed(dedupeKey: string): void {
     this.processedUals.add(dedupeKey);
     if (this.processedUals.size > 10_000) {
       const first = this.processedUals.values().next().value;
       if (first) this.processedUals.delete(first);
+    }
+  }
+
+  /**
+   * Distinguish an exact confirmed V2 assertion from an older/different V2
+   * assertion. A plain `dkg:status confirmed` check is insufficient once one
+   * UAL can advance through assertion versions: it would incorrectly suppress
+   * reconciliation of the latest chain root after an update.
+   */
+  private async graphScopedConfirmationState(
+    contextGraphId: string,
+    ual: string,
+    merkleRoot: Uint8Array,
+    subGraphName?: string,
+  ): Promise<'matching' | 'different' | 'absent'> {
+    let metaGraph: string;
+    let safeUal: string;
+    try {
+      metaGraph = assertSafeIri(contextGraphMetaUri(contextGraphId));
+      safeUal = assertSafeIri(ual);
+    } catch {
+      return 'absent';
+    }
+    const result = await this.store.query(
+      `SELECT ?scope ?version ?root ?assertionGraph ?publicCount ?status WHERE {
+        GRAPH <${metaGraph}> {
+          <${safeUal}> <${DKG_NS}contentScopeVersion> ?scope .
+          OPTIONAL { <${safeUal}> <${DKG_NS}assertionVersion> ?version }
+          OPTIONAL { <${safeUal}> <${DKG_NS}merkleRoot> ?root }
+          OPTIONAL { <${safeUal}> <${DKG_NS}assertionGraph> ?assertionGraph }
+          OPTIONAL { <${safeUal}> <${DKG_NS}publicTripleCount> ?publicCount }
+          OPTIONAL { <${safeUal}> <${DKG_NS}status> ?status }
+        }
+      } LIMIT 1`,
+    );
+    if (result.type !== 'bindings' || result.bindings.length === 0) return 'absent';
+    const row = result.bindings[0];
+    const scopeVersion = Number(stripOptionalLiteral(row['scope']));
+    if (scopeVersion !== GRAPH_KA_CONTENT_SCOPE_VERSION) return 'different';
+
+    try {
+      const assertionVersion = stripOptionalLiteral(row['version']) ?? '';
+      const scope = createGraphKnowledgeAssetScope(ual, assertionVersion);
+      const expectedGraph = knowledgeAssetLayerGraphUri(
+        contextGraphId,
+        MemoryLayer.VerifiableMemory,
+        scope,
+        subGraphName,
+      );
+      const publicTripleCount = Number(stripOptionalLiteral(row['publicCount']));
+      const storedRoot = stripOptionalLiteral(row['root'])?.toLowerCase();
+      const status = stripOptionalLiteral(row['status']);
+      if (
+        row['assertionGraph'] !== expectedGraph
+        || !Number.isSafeInteger(publicTripleCount)
+        || publicTripleCount < 0
+        || storedRoot !== ethers.hexlify(merkleRoot).toLowerCase()
+        || status !== 'confirmed'
+      ) {
+        return 'different';
+      }
+      return await this.store.countQuads(expectedGraph) === publicTripleCount
+        ? 'matching'
+        : 'different';
+    } catch {
+      return 'different';
     }
   }
 
@@ -1013,11 +1625,28 @@ export class FinalizationHandler {
       ? contextGraphMetaUri(contextGraphId, ctxGraphId)
       : `did:dkg:context-graph:${contextGraphId}/_meta`;
 
-    // Idempotency — VM may already hold this (gossip beat the chain path, or a
-    // prior sweep promoted it). Treat as success so the cursor can advance.
-    // Read-both (review F5): the minimal per-cgId partition shape carries no
-    // `dkg:status` row — the status lives in the label `_meta` graph.
-    if (await this.isAlreadyConfirmed(ual, targetMetaGraph, `did:dkg:context-graph:${contextGraphId}/_meta`)) {
+    // V2 idempotency is assertion-specific. A bare confirmed status may refer
+    // to an older assertion of the same UAL and must not hide the latest chain
+    // root. Legacy metadata has no content-scope marker, so it keeps the prior
+    // read-both status behavior unchanged.
+    const graphConfirmation = await this.graphScopedConfirmationState(
+      contextGraphId,
+      ual,
+      merkleRoot,
+      subGraphName,
+    );
+    if (graphConfirmation === 'matching') {
+      this.log.info(ctx, `Chain-reconcile: ${ual} already confirmed in VM, skipping`);
+      return 'already-confirmed';
+    }
+    if (
+      graphConfirmation === 'absent'
+      && await this.isAlreadyConfirmed(
+        ual,
+        targetMetaGraph,
+        `did:dkg:context-graph:${contextGraphId}/_meta`,
+      )
+    ) {
       this.log.info(ctx, `Chain-reconcile: ${ual} already confirmed in VM, skipping`);
       return 'already-confirmed';
     }
@@ -1028,6 +1657,29 @@ export class FinalizationHandler {
     if (!(await this.verifyChainCgBinding(kaId, onChainCgId, ctx))) {
       this.log.info(ctx, `Chain-reconcile: chain CG binding for ${ual} (ka=${kaId}) not confirmed against cg ${onChainCgId}; deferring to sweep retry`);
       return 'unverified';
+    }
+
+    // V2 recovery is O(1) in the number of prior workspace operations: the
+    // durable per-KA head names one exact assertion graph and carries its
+    // constant-size commitment envelope. Only when no V2 head exists do we
+    // enter the legacy root-operation scan below.
+    const graphScopedOutcome = await this.reconcileGraphScopedKC({
+      contextGraphId,
+      ual,
+      merkleRoot,
+      publisherAddress,
+      kaId,
+      versionBlock,
+      authorAddress,
+      subGraphName,
+    }, ctx);
+    if (graphScopedOutcome !== undefined) return graphScopedOutcome;
+    if (graphConfirmation === 'different') {
+      this.log.info(
+        ctx,
+        `Chain-reconcile: graph-scoped metadata exists for ${ual} but no exact SWM head matches the latest chain root`,
+      );
+      return 'no-swm';
     }
 
     // Recover the published roots from the local SWM snapshot. The gossip path

--- a/packages/agent/src/finalization-handler.ts
+++ b/packages/agent/src/finalization-handler.ts
@@ -38,10 +38,14 @@ import {
   generateSubGraphRegistration,
   splitTrustedGeneratedCatalogRootMap,
   shouldApplyMaterialization, writeMaterializedVersion, withMaterializationLock,
+  listKnowledgeAssetOperationCandidates,
+  resolveKnowledgeAssetOperationPublicQuads,
   resolveKnowledgeAssetWorkspaceHead,
+  type KnowledgeAssetOperationCandidate,
   type MaterializedVersion,
   type KnowledgeAssetWorkspaceHead,
   type KCMetadata, type KAMetadata, type OnChainProvenance,
+  type WorkspacePublicSnapshotStore,
 } from '@origintrail-official/dkg-publisher';
 const DKG_NS = 'http://dkg.io/ontology/';
 
@@ -144,6 +148,49 @@ function equalBytes(left: Uint8Array, right: Uint8Array): boolean {
 }
 
 /**
+ * Canonical bare-hex form for a stored/derived Merkle-root literal. The
+ * graph-scoped metadata writers persist bare lowercase hex (`toHex`) while the
+ * wire/chain side is usually `0x`-prefixed (`ethers.hexlify`); comparisons of
+ * the two MUST normalize or an exact confirmed assertion reads as `different`.
+ */
+function bareRootHex(value: string | Uint8Array | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  const hex = typeof value === 'string' ? value : ethers.hexlify(value);
+  const bare = hex.toLowerCase().replace(/^0x/, '');
+  return /^[0-9a-f]{64}$/.test(bare) ? bare : undefined;
+}
+
+const KA_ID_NUMBER_MASK = (1n << 96n) - 1n;
+
+/**
+ * Derive the canonical V2 (graph-scoped) UAL from chain truth. The packed
+ * on-chain kaId is `(author << 96) | perAuthorNumber`, and the V2 UAL is
+ * `did:dkg:<chain>/<author>/<number>`. Callers of the chain-reconcile sweep
+ * historically build a legacy-shaped `did:dkg:<chain>/<storage-contract>/<packed-id>`
+ * UAL, which parses but can never name a V2 workspace head — so the graph-scoped
+ * recovery path derives its own identity from `kaId` instead of trusting the
+ * caller's UAL shape. Returns undefined when `kaId` is not a V2 packed id
+ * (author bits are zero), which routes the caller to the legacy recovery path.
+ */
+function deriveGraphScopedUalFromChainIdentity(ual: string, kaId: bigint): string | undefined {
+  if (kaId <= 0n) return undefined;
+  const author = kaId >> 96n;
+  if (author === 0n) return undefined;
+  const chainPart = /^did:dkg:([^/]+)\//.exec(String(ual ?? '').trim())?.[1];
+  if (!chainPart) return undefined;
+  const authorAddress = `0x${author.toString(16).padStart(40, '0')}`;
+  const kaNumber = (kaId & KA_ID_NUMBER_MASK).toString();
+  try {
+    return createGraphKnowledgeAssetScope(
+      `did:dkg:${chainPart}/${authorAddress}/${kaNumber}`,
+      1,
+    ).ual;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Ops kill-switch for the #1549 bounded SWM read. Set `DKG_DISABLE_SWM_KA_BOUND=1`
  * to fall back to the unbounded read with no redeploy. Read here at the
  * orchestration boundary so `deriveSwmKaGraphBound` (in `swm-ka-bound.ts`) stays a
@@ -206,6 +253,11 @@ export class FinalizationHandler {
   // a restart clears it (fail-open).
   private readonly negativeSnapshotMemo = new Map<string, NegativeSnapshotMemoEntry>();
 
+  // Optional store-backed immutable operation snapshots (RFC ka-metadata-trim
+  // Phase 2). When absent, snapshot resolution still works for graph-backed
+  // snapshots; store-backed refs simply fail closed to the live-head path.
+  private readonly publicSnapshotStore?: WorkspacePublicSnapshotStore;
+
   constructor(
     store: TripleStore,
     chain: ChainAdapter | undefined,
@@ -213,6 +265,7 @@ export class FinalizationHandler {
     resolveContextGraphOnChainId?: ResolveContextGraphOnChainId,
     markContextGraphMetaDirtyFromQuads?: MarkContextGraphMetaDirtyFromQuads,
     lifecycleLogOptions?: FinalizationLifecycleLogOptions,
+    publicSnapshotStore?: WorkspacePublicSnapshotStore,
   ) {
     this.store = store;
     this.graphWriteGen = asGraphWriteGenSource(store);
@@ -221,6 +274,7 @@ export class FinalizationHandler {
     this.resolveContextGraphOnChainId = resolveContextGraphOnChainId;
     this.markContextGraphMetaDirtyFromQuads = markContextGraphMetaDirtyFromQuads;
     this.lifecycle = new FinalizationLifecycleLogger(this.log, lifecycleLogOptions);
+    this.publicSnapshotStore = publicSnapshotStore;
   }
 
   async handleFinalizationMessage(data: Uint8Array, contextGraphId: string): Promise<void> {
@@ -672,10 +726,15 @@ export class FinalizationHandler {
       this.log.warn(ctx, `Finalization: invalid on-chain identifiers for graph-scoped KA ${scope.ual}`);
       return 'deferred';
     }
-    if (startKAId !== packedKaId || endKAId !== packedKaId) {
+    if (startKAId !== packedKaId || endKAId !== packedKaId || batchId !== packedKaId) {
+      // V10 identity invariant: one graph-scoped publish mints exactly one KA,
+      // so batchId === kaId === startKAId === endKAId. `batchId` is written to
+      // provenance/lookup metadata as authoritative, so an unverified wire
+      // value must not survive past this gate.
       this.log.warn(
         ctx,
-        `Finalization: UAL-derived kaId ${packedKaId} does not match wire range ${startKAId}..${endKAId}`,
+        `Finalization: UAL-derived kaId ${packedKaId} does not match wire identity `
+          + `batch=${batchId} range=${startKAId}..${endKAId}`,
       );
       return 'deferred';
     }
@@ -695,57 +754,36 @@ export class FinalizationHandler {
         scope.ual,
         msg.kcMerkleRoot,
         subGraphName,
+        scope.assertionVersion,
       ) === 'matching'
     ) {
       // A prior attempt may have crashed after VM+metadata but before SWM
-      // cleanup. Complete that final idempotent step here.
-      await this.store.dropGraph(swmGraph);
+      // cleanup. Complete that final idempotent step here — but only while
+      // the per-KA SWM graph still belongs to THIS assertion: a newer
+      // accepted assertion shares the same physical graph and must not be
+      // erased by an older duplicate finalization.
+      await this.dropSwmGraphIfStillCurrent(
+        contextGraphId, scope, swmGraph, subGraphName, ctx,
+      );
       this.log.info(ctx, `Finalization: graph-scoped KA ${scope.ual} is already confirmed`);
       return 'already-confirmed';
     }
 
-    let head;
-    try {
-      head = await resolveKnowledgeAssetWorkspaceHead({
-        store: this.store,
-        graphManager,
-        contextGraphId,
-        kaUal: scope.ual,
-        subGraphName,
-      });
-    } catch (err) {
-      this.log.warn(
-        ctx,
-        `Finalization: corrupt graph-scoped SWM head for ${scope.ual}: ${err instanceof Error ? err.message : String(err)}`,
-      );
+    const resolved = await this.resolveGraphScopedAssertionContent({
+      contextGraphId,
+      scope,
+      swmGraph,
+      publicTripleCount,
+      privateTripleCount,
+      privateMerkleRoot,
+      subGraphName,
+      ctx,
+    });
+    if (!resolved) {
+      this.log.warn(ctx, `Finalization: no matching graph-scoped SWM assertion for ${scope.ual}`);
       return 'deferred';
     }
-    if (
-      !head
-      || head.assertionVersion !== scope.assertionVersion
-      || head.publicTripleCount !== publicTripleCount
-      || head.privateTripleCount !== privateTripleCount
-      || (head.privateMerkleRoot?.toLowerCase() ?? undefined)
-        !== (privateMerkleRoot ? ethers.hexlify(privateMerkleRoot).toLowerCase() : undefined)
-    ) {
-      this.log.warn(ctx, `Finalization: no matching graph-scoped SWM head for ${scope.ual}`);
-      return 'deferred';
-    }
-
-    const swmResult = await this.store.query(
-      `CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${assertSafeIri(swmGraph)}> { ?s ?p ?o } }`,
-    );
-    const swmQuads = swmResult.type === 'quads'
-      ? swmResult.quads.map((quad) => ({ ...quad, graph: '' }))
-      : [];
-    if (swmQuads.length !== publicTripleCount) {
-      this.log.warn(
-        ctx,
-        `Finalization: graph-scoped SWM count mismatch for ${scope.ual}: `
-          + `wire=${publicTripleCount}, store=${swmQuads.length}`,
-      );
-      return 'deferred';
-    }
+    const { swmQuads, fromLiveHead, publisherPeerId } = resolved;
     const computedMerkleRoot = computeFlatKCRoot(
       swmQuads,
       privateMerkleRoot ? [privateMerkleRoot] : [],
@@ -775,7 +813,9 @@ export class FinalizationHandler {
       contextGraphId,
       scope,
       swmQuads,
-      head,
+      publicTripleCount,
+      privateTripleCount,
+      publisherPeerId,
       privateMerkleRoot,
       computedMerkleRoot,
       publisherAddress: msg.publisherAddress,
@@ -789,6 +829,10 @@ export class FinalizationHandler {
       },
       subGraphName,
       source: 'finalization',
+      // Only the live-head path may clean the shared per-KA SWM graph: the
+      // snapshot-recovery path materializes an assertion that no longer owns
+      // that graph (a newer accepted assertion does).
+      dropSwmGraph: fromLiveHead,
       ctx,
     });
     if (outcome === 'stale') {
@@ -801,6 +845,186 @@ export class FinalizationHandler {
       `Finalization: promoted graph-scoped KA ${scope.ual} (${publicTripleCount} public, ${privateTripleCount} private)`,
     );
     return 'applied';
+  }
+
+  /**
+   * Drop the shared per-KA SWM graph only while the durable head still points
+   * at the given assertion version (or no head exists at all). The physical
+   * graph is version-agnostic: a NEWER accepted assertion stages into the same
+   * graph, so an older/duplicate finalizer must never delete it — an exact
+   * resend of the newer finalization would be treated as a duplicate and the
+   * staged content never restored.
+   */
+  private async dropSwmGraphIfStillCurrent(
+    contextGraphId: string,
+    scope: ReturnType<typeof createGraphKnowledgeAssetScope>,
+    swmGraph: string,
+    subGraphName: string | undefined,
+    ctx: OperationContext,
+  ): Promise<void> {
+    let head: KnowledgeAssetWorkspaceHead | undefined;
+    try {
+      head = await resolveKnowledgeAssetWorkspaceHead({
+        store: this.store,
+        graphManager: new GraphManager(this.store),
+        contextGraphId,
+        kaUal: scope.ual,
+        subGraphName,
+      });
+    } catch {
+      // Corrupt head: fail closed — keep the staged content for inspection.
+      this.log.warn(ctx, `Finalization: skipping SWM cleanup for ${scope.ual}: corrupt workspace head`);
+      return;
+    }
+    if (!head || head.assertionVersion === scope.assertionVersion) {
+      await this.store.dropGraph(swmGraph);
+    }
+  }
+
+  /**
+   * Resolve the exact public quads for one (UAL, assertionVersion) assertion.
+   * Prefers the live per-KA SWM graph while the durable head still points at
+   * this assertion; otherwise falls back to the immutable graph-scoped
+   * operation snapshot recorded at share time. The fallback keeps a
+   * chain-confirmed assertion recoverable after a NEWER assertion has replaced
+   * the shared physical SWM graph (out-of-order finalization delivery).
+   */
+  private async resolveGraphScopedAssertionContent(input: {
+    contextGraphId: string;
+    scope: ReturnType<typeof createGraphKnowledgeAssetScope>;
+    swmGraph: string;
+    publicTripleCount: number;
+    privateTripleCount: number;
+    privateMerkleRoot?: Uint8Array;
+    subGraphName?: string;
+    ctx: OperationContext;
+  }): Promise<{ swmQuads: Quad[]; fromLiveHead: boolean; publisherPeerId: string } | undefined> {
+    const {
+      contextGraphId, scope, swmGraph, publicTripleCount, privateTripleCount,
+      privateMerkleRoot, subGraphName, ctx,
+    } = input;
+    const graphManager = new GraphManager(this.store);
+    const wirePrivateRoot = bareRootHex(privateMerkleRoot);
+    let head: KnowledgeAssetWorkspaceHead | undefined;
+    try {
+      head = await resolveKnowledgeAssetWorkspaceHead({
+        store: this.store,
+        graphManager,
+        contextGraphId,
+        kaUal: scope.ual,
+        subGraphName,
+      });
+    } catch (err) {
+      // A corrupt head must not make a chain-confirmed assertion terminally
+      // unrecoverable — the immutable operation snapshot below still can.
+      this.log.warn(
+        ctx,
+        `Finalization: corrupt graph-scoped SWM head for ${scope.ual}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      head = undefined;
+    }
+    if (
+      head
+      && head.assertionVersion === scope.assertionVersion
+      && head.publicTripleCount === publicTripleCount
+      && head.privateTripleCount === privateTripleCount
+      && bareRootHex(head.privateMerkleRoot) === wirePrivateRoot
+    ) {
+      const swmResult = await this.store.query(
+        `CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${assertSafeIri(swmGraph)}> { ?s ?p ?o } }`,
+      );
+      const swmQuads = swmResult.type === 'quads'
+        ? swmResult.quads.map((quad) => ({ ...quad, graph: '' }))
+        : [];
+      if (swmQuads.length === publicTripleCount) {
+        return { swmQuads, fromLiveHead: true, publisherPeerId: head.publisherPeerId };
+      }
+      this.log.warn(
+        ctx,
+        `Finalization: graph-scoped SWM count mismatch for ${scope.ual}: `
+          + `wire=${publicTripleCount}, store=${swmQuads.length}`,
+      );
+    }
+
+    const snapshot = await this.resolveGraphScopedOperationSnapshot({
+      contextGraphId,
+      kaUal: scope.ual,
+      assertionVersion: scope.assertionVersion,
+      expectedPublicCount: publicTripleCount,
+      expectedPrivateTripleCount: privateTripleCount,
+      expectedPrivateRoot: wirePrivateRoot,
+      subGraphName,
+      ctx,
+    });
+    if (!snapshot) return undefined;
+    return { swmQuads: snapshot.quads, fromLiveHead: false, publisherPeerId: snapshot.publisherPeerId };
+  }
+
+  /**
+   * Resolve one integrity-checked immutable operation snapshot for a KA. When
+   * `assertionVersion` is set only that assertion qualifies; expected counts /
+   * private commitment (bare hex) must match the candidate's metadata exactly.
+   */
+  private async resolveGraphScopedOperationSnapshot(input: {
+    contextGraphId: string;
+    kaUal: string;
+    assertionVersion?: string;
+    expectedPublicCount?: number;
+    expectedPrivateTripleCount?: number;
+    expectedPrivateRoot?: string;
+    subGraphName?: string;
+    ctx: OperationContext;
+  }): Promise<{
+    quads: Quad[];
+    publisherPeerId: string;
+    candidate: KnowledgeAssetOperationCandidate;
+  } | undefined> {
+    const graphManager = new GraphManager(this.store);
+    let candidates: KnowledgeAssetOperationCandidate[];
+    try {
+      candidates = await listKnowledgeAssetOperationCandidates({
+        store: this.store,
+        graphManager,
+        contextGraphId: input.contextGraphId,
+        kaUal: input.kaUal,
+        assertionVersion: input.assertionVersion,
+        subGraphName: input.subGraphName,
+      });
+    } catch {
+      return undefined;
+    }
+    for (const candidate of candidates) {
+      if (input.expectedPublicCount !== undefined && candidate.publicTripleCount !== input.expectedPublicCount) continue;
+      if (input.expectedPrivateTripleCount !== undefined && candidate.privateTripleCount !== input.expectedPrivateTripleCount) continue;
+      if (input.expectedPrivateRoot !== undefined || candidate.privateMerkleRoot !== undefined) {
+        if (bareRootHex(candidate.privateMerkleRoot) !== input.expectedPrivateRoot) continue;
+      }
+      try {
+        const snapshot = await resolveKnowledgeAssetOperationPublicQuads({
+          store: this.store,
+          graphManager,
+          contextGraphId: input.contextGraphId,
+          shareOperationId: candidate.shareOperationId,
+          kaUal: input.kaUal,
+          assertionVersion: candidate.assertionVersion,
+          subGraphName: input.subGraphName,
+          publicSnapshotStore: this.publicSnapshotStore,
+        });
+        return {
+          quads: snapshot.quads,
+          publisherPeerId: snapshot.publisherPeerId ?? candidate.publisherPeerId ?? 'unknown',
+          candidate,
+        };
+      } catch (err) {
+        this.log.info(
+          input.ctx,
+          `Finalization: graph-scoped snapshot for ${input.kaUal} v${candidate.assertionVersion} unavailable: `
+            + (err instanceof Error ? err.message : String(err)),
+        );
+        continue;
+      }
+    }
+    return undefined;
   }
 
   /**
@@ -830,18 +1054,17 @@ export class FinalizationHandler {
       authorAddress,
       subGraphName,
     } = input;
-    // Historical UAL shapes can be valid inputs to the legacy root-scoped
-    // recovery code but cannot name a V2 per-KA graph. Do not let the strict
-    // V2 parser turn those into a terminal "corrupt head" result.
-    try {
-      createGraphKnowledgeAssetScope(ual, 1);
-    } catch {
-      return undefined;
-    }
+    // Chain-sweep callers historically construct a legacy-shaped
+    // `did:dkg:<chain>/<storage-contract>/<packed-id>` UAL. That shape parses,
+    // but can never name a V2 per-KA graph or workspace head — so the V2
+    // identity is derived from the packed on-chain kaId instead of trusting
+    // the caller's UAL shape. A non-V2 kaId routes to the legacy recovery path.
+    const canonicalUal = deriveGraphScopedUalFromChainIdentity(ual, kaId);
+    if (!canonicalUal) return undefined;
     if (
       await this.graphScopedConfirmationState(
         contextGraphId,
-        ual,
+        canonicalUal,
         merkleRoot,
         subGraphName,
       ) === 'matching'
@@ -850,54 +1073,159 @@ export class FinalizationHandler {
     }
     const graphManager = new GraphManager(this.store);
     let head: KnowledgeAssetWorkspaceHead | undefined;
+    let headCorrupt = false;
     try {
       head = await resolveKnowledgeAssetWorkspaceHead({
         store: this.store,
         graphManager,
         contextGraphId,
-        kaUal: ual,
+        kaUal: canonicalUal,
         subGraphName,
       });
     } catch (err) {
       this.log.warn(
         ctx,
-        `Chain-reconcile: corrupt graph-scoped SWM head for ${ual}: ${err instanceof Error ? err.message : String(err)}`,
+        `Chain-reconcile: corrupt graph-scoped SWM head for ${canonicalUal}: ${err instanceof Error ? err.message : String(err)}`,
       );
-      return 'no-swm';
+      head = undefined;
+      headCorrupt = true;
     }
-    if (!head) return undefined;
 
+    // Fast path: the durable head names the exact assertion the chain
+    // confirmed — promote straight from the live per-KA SWM graph.
+    if (
+      head
+      && (head.publicTripleCount > 0 || head.privateTripleCount > 0)
+    ) {
+      const liveOutcome = await this.reconcileGraphScopedFromLiveHead({
+        contextGraphId, canonicalUal, head, merkleRoot, publisherAddress,
+        kaId, versionBlock, authorAddress, subGraphName, ctx,
+      });
+      if (liveOutcome !== undefined) return liveOutcome;
+    }
+
+    // Recovery path: the head is missing, corrupt, or points at a NEWER
+    // assertion than the chain root being reconciled (out-of-order publish /
+    // failed newer publish). The immutable per-operation snapshots keep every
+    // accepted assertion addressable, so scan them (bounded by the number of
+    // versions of THIS one KA) for the one whose recomputed flat-KC root
+    // matches the chain root.
+    let candidates: KnowledgeAssetOperationCandidate[] = [];
+    try {
+      candidates = await listKnowledgeAssetOperationCandidates({
+        store: this.store,
+        graphManager,
+        contextGraphId,
+        kaUal: canonicalUal,
+        subGraphName,
+      });
+    } catch {
+      candidates = [];
+    }
+    for (const candidate of candidates) {
+      let scope: ReturnType<typeof createGraphKnowledgeAssetScope>;
+      let privateMerkleRoot: Uint8Array | undefined;
+      let quads: Quad[];
+      let publisherPeerId: string;
+      try {
+        scope = createGraphKnowledgeAssetScope(canonicalUal, candidate.assertionVersion);
+        privateMerkleRoot = candidate.privateMerkleRoot
+          ? ethers.getBytes(candidate.privateMerkleRoot)
+          : undefined;
+        const snapshot = await resolveKnowledgeAssetOperationPublicQuads({
+          store: this.store,
+          graphManager,
+          contextGraphId,
+          shareOperationId: candidate.shareOperationId,
+          kaUal: canonicalUal,
+          assertionVersion: candidate.assertionVersion,
+          subGraphName,
+          publicSnapshotStore: this.publicSnapshotStore,
+        });
+        quads = snapshot.quads;
+        publisherPeerId = snapshot.publisherPeerId ?? candidate.publisherPeerId ?? 'unknown';
+      } catch {
+        continue;
+      }
+      const computedMerkleRoot = computeFlatKCRoot(
+        quads,
+        privateMerkleRoot ? [privateMerkleRoot] : [],
+      );
+      if (!equalBytes(computedMerkleRoot, merkleRoot)) continue;
+
+      const outcome = await this.applyVerifiedGraphScopedFinalization({
+        contextGraphId,
+        scope,
+        swmQuads: quads,
+        publicTripleCount: candidate.publicTripleCount,
+        privateTripleCount: candidate.privateTripleCount,
+        publisherPeerId,
+        privateMerkleRoot,
+        computedMerkleRoot,
+        publisherAddress,
+        txHash: '',
+        blockNumber: versionBlock,
+        batchId: kaId,
+        authorAddress,
+        materializedVersion: { blockNumber: versionBlock, txIndex: 0 },
+        subGraphName,
+        source: 'chain-reconcile',
+        // The snapshot path only owns the live SWM graph when the head still
+        // points at this same assertion; the guarded drop checks that.
+        dropSwmGraph: head?.shareOperationId === candidate.shareOperationId,
+        ctx,
+      });
+      if (outcome === 'stale') return 'stale-target';
+      this.log.info(
+        ctx,
+        `Chain-reconcile: promoted exact graph-scoped assertion v${candidate.assertionVersion} to VM for ${canonicalUal} (ka=${kaId})`,
+      );
+      return 'promoted';
+    }
+
+    if (!head && !headCorrupt && candidates.length === 0) return undefined;
+    this.log.info(
+      ctx,
+      `Chain-reconcile: no graph-scoped SWM assertion matches the chain root for ${canonicalUal}`,
+    );
+    return 'no-swm';
+  }
+
+  /**
+   * Promote from the live per-KA SWM graph when the durable head names the
+   * exact chain-confirmed assertion. `undefined` defers to the immutable
+   * snapshot scan in `reconcileGraphScopedKC`.
+   */
+  private async reconcileGraphScopedFromLiveHead(input: {
+    contextGraphId: string;
+    canonicalUal: string;
+    head: KnowledgeAssetWorkspaceHead;
+    merkleRoot: Uint8Array;
+    publisherAddress: string;
+    kaId: bigint;
+    versionBlock: number;
+    authorAddress?: string;
+    subGraphName?: string;
+    ctx: OperationContext;
+  }): Promise<'promoted' | 'stale-target' | undefined> {
+    const {
+      contextGraphId, canonicalUal, head, merkleRoot, publisherAddress,
+      kaId, versionBlock, authorAddress, subGraphName, ctx,
+    } = input;
     let scope: ReturnType<typeof createGraphKnowledgeAssetScope>;
     try {
-      scope = createGraphKnowledgeAssetScope(ual, head.assertionVersion);
-    } catch (err) {
-      this.log.warn(
-        ctx,
-        `Chain-reconcile: invalid graph-scoped identity for ${ual}: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      return 'no-swm';
+      scope = createGraphKnowledgeAssetScope(canonicalUal, head.assertionVersion);
+    } catch {
+      return undefined;
     }
-    const packedKaId = (BigInt(scope.agentAddress) << 96n) | BigInt(scope.kaNumber);
-    if (scope.ual !== ual || packedKaId !== kaId) {
-      this.log.warn(
-        ctx,
-        `Chain-reconcile: UAL-derived kaId ${packedKaId} does not match chain kaId ${kaId} for ${ual}`,
-      );
-      return 'no-swm';
-    }
-    if (head.publicTripleCount === 0 && head.privateTripleCount === 0) {
-      this.log.warn(ctx, `Chain-reconcile: empty graph-scoped content envelope for ${ual}`);
-      return 'no-swm';
-    }
-
     let privateMerkleRoot: Uint8Array | undefined;
     try {
       privateMerkleRoot = head.privateMerkleRoot
         ? ethers.getBytes(head.privateMerkleRoot)
         : undefined;
     } catch {
-      this.log.warn(ctx, `Chain-reconcile: invalid private commitment for graph-scoped KA ${ual}`);
-      return 'no-swm';
+      this.log.warn(ctx, `Chain-reconcile: invalid private commitment for graph-scoped KA ${canonicalUal}`);
+      return undefined;
     }
     const swmGraph = knowledgeAssetLayerGraphUri(
       contextGraphId,
@@ -914,9 +1242,9 @@ export class FinalizationHandler {
     if (swmQuads.length !== head.publicTripleCount) {
       this.log.info(
         ctx,
-        `Chain-reconcile: graph-scoped SWM count mismatch for ${ual}: head=${head.publicTripleCount}, store=${swmQuads.length}`,
+        `Chain-reconcile: graph-scoped SWM count mismatch for ${canonicalUal}: head=${head.publicTripleCount}, store=${swmQuads.length}`,
       );
-      return 'no-swm';
+      return undefined;
     }
     const computedMerkleRoot = computeFlatKCRoot(
       swmQuads,
@@ -925,16 +1253,18 @@ export class FinalizationHandler {
     if (!equalBytes(computedMerkleRoot, merkleRoot)) {
       this.log.info(
         ctx,
-        `Chain-reconcile: exact graph-scoped SWM assertion does not match the chain root for ${ual}`,
+        `Chain-reconcile: current graph-scoped SWM assertion does not match the chain root for ${canonicalUal}`,
       );
-      return 'no-swm';
+      return undefined;
     }
 
     const outcome = await this.applyVerifiedGraphScopedFinalization({
       contextGraphId,
       scope,
       swmQuads,
-      head,
+      publicTripleCount: head.publicTripleCount,
+      privateTripleCount: head.privateTripleCount,
+      publisherPeerId: head.publisherPeerId,
       privateMerkleRoot,
       computedMerkleRoot,
       publisherAddress,
@@ -945,12 +1275,13 @@ export class FinalizationHandler {
       materializedVersion: { blockNumber: versionBlock, txIndex: 0 },
       subGraphName,
       source: 'chain-reconcile',
+      dropSwmGraph: true,
       ctx,
     });
     if (outcome === 'stale') return 'stale-target';
     this.log.info(
       ctx,
-      `Chain-reconcile: promoted exact graph-scoped SWM assertion to VM for ${ual} (ka=${kaId})`,
+      `Chain-reconcile: promoted exact graph-scoped SWM assertion to VM for ${canonicalUal} (ka=${kaId})`,
     );
     return 'promoted';
   }
@@ -965,7 +1296,9 @@ export class FinalizationHandler {
     contextGraphId: string;
     scope: ReturnType<typeof createGraphKnowledgeAssetScope>;
     swmQuads: Quad[];
-    head: KnowledgeAssetWorkspaceHead;
+    publicTripleCount: number;
+    privateTripleCount: number;
+    publisherPeerId: string;
     privateMerkleRoot?: Uint8Array;
     computedMerkleRoot: Uint8Array;
     publisherAddress: string;
@@ -976,13 +1309,22 @@ export class FinalizationHandler {
     materializedVersion: MaterializedVersion;
     subGraphName?: string;
     source: 'finalization' | 'chain-reconcile';
+    /**
+     * Whether this materialization may clean the shared per-KA SWM graph.
+     * Only content resolved from the LIVE head owns that graph; even then the
+     * drop re-checks the head inside the materialization lock so a newer
+     * assertion accepted mid-verification is never erased.
+     */
+    dropSwmGraph: boolean;
     ctx: OperationContext;
   }): Promise<'applied' | 'stale'> {
     const {
       contextGraphId,
       scope,
       swmQuads,
-      head,
+      publicTripleCount,
+      privateTripleCount,
+      publisherPeerId,
       privateMerkleRoot,
       computedMerkleRoot,
       publisherAddress,
@@ -993,10 +1335,9 @@ export class FinalizationHandler {
       materializedVersion,
       subGraphName,
       source,
+      dropSwmGraph,
       ctx,
     } = input;
-    const publicTripleCount = head.publicTripleCount;
-    const privateTripleCount = head.privateTripleCount;
     const swmGraph = knowledgeAssetLayerGraphUri(
       contextGraphId,
       MemoryLayer.SharedWorkingMemory,
@@ -1055,7 +1396,7 @@ export class FinalizationHandler {
           ual: scope.ual,
           contextGraphId,
           merkleRoot: computedMerkleRoot,
-          publisherPeerId: head.publisherPeerId,
+          publisherPeerId,
           accessPolicy: privateTripleCount > 0 ? 'ownerOnly' : 'public',
           timestamp: new Date(),
           subGraphName,
@@ -1077,7 +1418,11 @@ export class FinalizationHandler {
         scope.ual,
         materializedVersion,
       );
-      await this.store.dropGraph(swmGraph);
+      if (dropSwmGraph) {
+        await this.dropSwmGraphIfStillCurrent(
+          contextGraphId, scope, swmGraph, subGraphName, ctx,
+        );
+      }
       return 'applied' as const;
     });
     if (outcome === 'stale') return outcome;
@@ -1112,6 +1457,14 @@ export class FinalizationHandler {
     ual: string,
     merkleRoot: Uint8Array,
     subGraphName?: string,
+    /**
+     * When set (gossip finalization carries the exact assertion version), the
+     * stored metadata must ALSO be for this version: graph-scoped storage
+     * derives physical graphs from the version, so a later assertion whose
+     * content root happens to equal an older confirmed one must not be
+     * mistaken for it (its own graph would never materialize).
+     */
+    expectedAssertionVersion?: string,
   ): Promise<'matching' | 'different' | 'absent'> {
     let metaGraph: string;
     let safeUal: string;
@@ -1148,14 +1501,20 @@ export class FinalizationHandler {
         subGraphName,
       );
       const publicTripleCount = Number(stripOptionalLiteral(row['publicCount']));
-      const storedRoot = stripOptionalLiteral(row['root'])?.toLowerCase();
+      // Writer (`generateGraphKnowledgeAssetMetadata`) persists bare lowercase
+      // hex; the wire/chain side is `0x`-prefixed. Compare in one canonical
+      // form or an exactly-confirmed assertion reads as `different` forever.
+      const storedRoot = bareRootHex(stripOptionalLiteral(row['root']));
       const status = stripOptionalLiteral(row['status']);
       if (
         row['assertionGraph'] !== expectedGraph
         || !Number.isSafeInteger(publicTripleCount)
         || publicTripleCount < 0
-        || storedRoot !== ethers.hexlify(merkleRoot).toLowerCase()
+        || storedRoot === undefined
+        || storedRoot !== bareRootHex(merkleRoot)
         || status !== 'confirmed'
+        || (expectedAssertionVersion !== undefined
+          && scope.assertionVersion !== createGraphKnowledgeAssetScope(ual, expectedAssertionVersion).assertionVersion)
       ) {
         return 'different';
       }
@@ -1628,10 +1987,13 @@ export class FinalizationHandler {
     // V2 idempotency is assertion-specific. A bare confirmed status may refer
     // to an older assertion of the same UAL and must not hide the latest chain
     // root. Legacy metadata has no content-scope marker, so it keeps the prior
-    // read-both status behavior unchanged.
+    // read-both status behavior unchanged. V2 metadata lives under the
+    // canonical `did:dkg:<chain>/<author>/<number>` subject, which chain-sweep
+    // callers do not construct — derive it from the packed kaId instead.
+    const canonicalV2Ual = deriveGraphScopedUalFromChainIdentity(ual, kaId);
     const graphConfirmation = await this.graphScopedConfirmationState(
       contextGraphId,
-      ual,
+      canonicalV2Ual ?? ual,
       merkleRoot,
       subGraphName,
     );

--- a/packages/agent/test/ka-graph-finalization-envelope.test.ts
+++ b/packages/agent/test/ka-graph-finalization-envelope.test.ts
@@ -1,0 +1,176 @@
+/**
+ * PR #1715 review — the receiver tests inject hand-built finalization
+ * messages, so the PRODUCTION envelope construction was unprotected: a wrong
+ * `publicTripleCount`, a mis-stringified `assertionVersion`, or a dropped
+ * `privateMerkleRoot` would pass every handler test while breaking real
+ * interop. This decodes the actual broadcast payload emitted by
+ * `publishFromSharedMemory` with a graph-scoped content envelope.
+ */
+import { describe, expect, it } from 'vitest';
+import { MockChainAdapter } from '@origintrail-official/dkg-chain';
+import {
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  contextGraphFinalizationTopic,
+  decodeFinalizationMessage,
+} from '@origintrail-official/dkg-core';
+import { computeFlatKCRootV10, computePrivateRootV10 } from '@origintrail-official/dkg-publisher';
+import type { Quad } from '@origintrail-official/dkg-storage';
+import { DKGAgent } from '../src/index.js';
+
+const CG = 'finalization-envelope-cg';
+const AUTHOR = '0x3333333333333333333333333333333333333333';
+const PUBLISHER = '0x4444444444444444444444444444444444444444';
+const KA_UAL = `did:dkg:hardhat:31337/${AUTHOR}/11`;
+const PACKED_KA_ID = (BigInt(AUTHOR) << 96n) | 11n;
+
+class CapturingGossip {
+  published: Array<{ topic: string; data: Uint8Array }> = [];
+
+  subscribe(_topic: string): void {}
+  unsubscribe(_topic: string): void {}
+  onMessage(
+    _topic: string,
+    _handler: (topic: string, data: Uint8Array, from?: string) => void | Promise<void>,
+  ): void {}
+
+  async publish(topic: string, data: Uint8Array): Promise<void> {
+    this.published.push({ topic, data });
+  }
+
+  getSubscribers(_topic: string): string[] { return []; }
+}
+
+describe('outgoing graph-scoped finalization envelope', () => {
+  it('broadcasts the exact content envelope the finalization handler verifies', async () => {
+    const agent = await DKGAgent.create({
+      name: 'GraphScopedEnvelope',
+      chainAdapter: new MockChainAdapter(),
+    });
+    const gossip = new CapturingGossip();
+    (agent as unknown as { gossip: CapturingGossip }).gossip = gossip;
+    Object.defineProperty((agent as unknown as { node: object }).node, 'peerId', {
+      value: { toString: () => '12D3KooWEnvelopePublisher' },
+      configurable: true,
+    });
+
+    const privateQuads: Quad[] = [{
+      subject: 'urn:asset:secret',
+      predicate: 'urn:predicate:value',
+      object: '"hidden"',
+      graph: '',
+    }];
+    const privateMerkleRoot = computePrivateRootV10(privateQuads);
+    if (!privateMerkleRoot) throw new Error('expected private commitment');
+    const publicQuads: Quad[] = [
+      { subject: 'urn:asset:one', predicate: 'urn:predicate:value', object: '"one"', graph: '' },
+      { subject: 'urn:asset:two', predicate: 'urn:predicate:value', object: '"two"', graph: '' },
+    ];
+    const merkleRoot = computeFlatKCRootV10(publicQuads, [privateMerkleRoot]);
+
+    // The publisher result is stubbed: this test pins the AGENT-side envelope
+    // construction from the confirmed publish result + graph-scoped options.
+    const publisherStub = {
+      publishFromSharedMemory: async () => ({
+        status: 'confirmed' as const,
+        ual: KA_UAL,
+        merkleRoot,
+        kaManifest: [],
+        onChainResult: {
+          txHash: `0x${'12'.repeat(32)}`,
+          blockNumber: 321,
+          txIndex: 5,
+          batchId: PACKED_KA_ID,
+          startKAId: PACKED_KA_ID,
+          endKAId: PACKED_KA_ID,
+          publisherAddress: PUBLISHER,
+        },
+      }),
+    };
+
+    await agent.publishFromSharedMemory(CG, 'all', {
+      publisherOverride: publisherStub as never,
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      kaUal: KA_UAL,
+      assertionVersion: 1,
+      publicTripleCount: publicQuads.length,
+      privateMerkleRoot,
+      privateTripleCount: privateQuads.length,
+    });
+
+    const broadcast = gossip.published.find(
+      (entry) => entry.topic === contextGraphFinalizationTopic(CG),
+    );
+    expect(broadcast).toBeDefined();
+    const decoded = decodeFinalizationMessage(broadcast!.data);
+
+    expect(decoded.ual).toBe(KA_UAL);
+    expect(decoded.contextGraphId).toBe(CG);
+    expect(decoded.contentScopeVersion).toBe(GRAPH_KA_CONTENT_SCOPE_VERSION);
+    expect(String(decoded.assertionVersion)).toBe('1');
+    expect(Number(decoded.publicTripleCount)).toBe(2);
+    expect(Number(decoded.privateTripleCount)).toBe(1);
+    expect(decoded.privateMerkleRoot ? Array.from(decoded.privateMerkleRoot) : undefined)
+      .toEqual(Array.from(privateMerkleRoot));
+    expect(Array.from(decoded.kcMerkleRoot)).toEqual(Array.from(merkleRoot));
+    expect(decoded.rootEntities).toEqual([]);
+    expect(BigInt(decoded.batchId)).toBe(PACKED_KA_ID);
+    expect(BigInt(decoded.startKAId)).toBe(PACKED_KA_ID);
+    expect(BigInt(decoded.endKAId)).toBe(PACKED_KA_ID);
+    expect(decoded.publisherAddress).toBe(PUBLISHER);
+    expect(decoded.txHash).toBe(`0x${'12'.repeat(32)}`);
+  });
+
+  it('omits the private commitment for a public-only graph-scoped publish', async () => {
+    const agent = await DKGAgent.create({
+      name: 'GraphScopedEnvelopePublic',
+      chainAdapter: new MockChainAdapter(),
+    });
+    const gossip = new CapturingGossip();
+    (agent as unknown as { gossip: CapturingGossip }).gossip = gossip;
+    Object.defineProperty((agent as unknown as { node: object }).node, 'peerId', {
+      value: { toString: () => '12D3KooWEnvelopePublisher' },
+      configurable: true,
+    });
+
+    const publicQuads: Quad[] = [
+      { subject: 'urn:asset:solo', predicate: 'urn:predicate:value', object: '"solo"', graph: '' },
+    ];
+    const merkleRoot = computeFlatKCRootV10(publicQuads, []);
+    const publisherStub = {
+      publishFromSharedMemory: async () => ({
+        status: 'confirmed' as const,
+        ual: KA_UAL,
+        merkleRoot,
+        kaManifest: [],
+        onChainResult: {
+          txHash: `0x${'34'.repeat(32)}`,
+          blockNumber: 322,
+          txIndex: 0,
+          batchId: PACKED_KA_ID,
+          startKAId: PACKED_KA_ID,
+          endKAId: PACKED_KA_ID,
+          publisherAddress: PUBLISHER,
+        },
+      }),
+    };
+
+    await agent.publishFromSharedMemory(CG, 'all', {
+      publisherOverride: publisherStub as never,
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      kaUal: KA_UAL,
+      assertionVersion: 1,
+      publicTripleCount: publicQuads.length,
+      privateTripleCount: 0,
+    });
+
+    const broadcast = gossip.published.find(
+      (entry) => entry.topic === contextGraphFinalizationTopic(CG),
+    );
+    expect(broadcast).toBeDefined();
+    const decoded = decodeFinalizationMessage(broadcast!.data);
+    expect(decoded.contentScopeVersion).toBe(GRAPH_KA_CONTENT_SCOPE_VERSION);
+    expect(Number(decoded.publicTripleCount)).toBe(1);
+    expect(Number(decoded.privateTripleCount)).toBe(0);
+    expect(decoded.privateMerkleRoot?.length ?? 0).toBe(0);
+  });
+});

--- a/packages/agent/test/ka-graph-finalization-handler.test.ts
+++ b/packages/agent/test/ka-graph-finalization-handler.test.ts
@@ -1,0 +1,381 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  MemoryLayer,
+  createOperationContext,
+  createGraphKnowledgeAssetScope,
+  encodeFinalizationMessage,
+  knowledgeAssetLayerGraphUri,
+  type FinalizationMessageMsg,
+} from '@origintrail-official/dkg-core';
+import {
+  GraphManager,
+  OxigraphStore,
+  type Quad,
+} from '@origintrail-official/dkg-storage';
+import {
+  computeFlatKCRootV10,
+  computePrivateRootV10,
+  storeKnowledgeAssetOperationPublicQuads,
+  storeKnowledgeAssetWorkspaceHead,
+} from '@origintrail-official/dkg-publisher';
+import { FinalizationHandler } from '../src/finalization-handler.js';
+
+const CG = 'rootless-finalization';
+const AUTHOR = '0x1111111111111111111111111111111111111111';
+const PUBLISHER = '0x2222222222222222222222222222222222222222';
+const UAL = `did:dkg:otp:20430/${AUTHOR}/7`;
+const SHARE_ID = 'graph-finalization-share';
+const VERSION = '1';
+const PACKED_KA_ID = (BigInt(AUTHOR) << 96n) | 7n;
+
+describe('graph-scoped finalization handler', () => {
+  let store: OxigraphStore;
+  let graphManager: GraphManager;
+  let handler: FinalizationHandler;
+
+  beforeEach(() => {
+    store = new OxigraphStore();
+    graphManager = new GraphManager(store);
+    handler = new FinalizationHandler(store, undefined);
+    (handler as unknown as {
+      verifyOnChain: () => Promise<{ verified: boolean; authorAddress: string; txIndex: number }>;
+    }).verifyOnChain = async () => ({
+      verified: true,
+      authorAddress: AUTHOR,
+      txIndex: 4,
+    });
+  });
+
+  async function stageGraph(): Promise<{
+    message: FinalizationMessageMsg;
+    swmGraph: string;
+    vmGraph: string;
+  }> {
+    const scope = createGraphKnowledgeAssetScope(UAL, VERSION);
+    const swmGraph = knowledgeAssetLayerGraphUri(
+      CG,
+      MemoryLayer.SharedWorkingMemory,
+      scope,
+    );
+    const vmGraph = knowledgeAssetLayerGraphUri(
+      CG,
+      MemoryLayer.VerifiableMemory,
+      scope,
+    );
+    const publicQuads: Quad[] = [
+      { subject: 'urn:asset:one', predicate: 'urn:predicate:value', object: '"one"', graph: swmGraph },
+      { subject: 'urn:asset:two', predicate: 'urn:predicate:value', object: '"two"', graph: swmGraph },
+    ];
+    const privateQuads: Quad[] = [
+      { subject: 'urn:asset:secret', predicate: 'urn:predicate:value', object: '"hidden"', graph: '' },
+    ];
+    const privateMerkleRoot = computePrivateRootV10(privateQuads);
+    if (!privateMerkleRoot) throw new Error('expected private commitment');
+    const merkleRoot = computeFlatKCRootV10(
+      publicQuads.map((quad) => ({ ...quad, graph: '' })),
+      [privateMerkleRoot],
+    );
+
+    await store.insert(publicQuads);
+    await store.insert([{
+      subject: 'urn:stale:must-be-replaced',
+      predicate: 'urn:predicate:value',
+      object: '"stale"',
+      graph: vmGraph,
+    }]);
+    await storeKnowledgeAssetOperationPublicQuads({
+      store,
+      graphManager,
+      contextGraphId: CG,
+      shareOperationId: SHARE_ID,
+      kaUal: scope.ual,
+      assertionVersion: scope.assertionVersion,
+      quads: publicQuads,
+      privateMerkleRoot,
+      privateTripleCount: privateQuads.length,
+      publisherPeerId: '12D3KooWPublisher',
+    });
+    await storeKnowledgeAssetWorkspaceHead({
+      store,
+      graphManager,
+      contextGraphId: CG,
+      shareOperationId: SHARE_ID,
+      kaUal: scope.ual,
+      assertionVersion: scope.assertionVersion,
+    });
+
+    return {
+      swmGraph,
+      vmGraph,
+      message: {
+        ual: scope.ual,
+        contextGraphId: CG,
+        kcMerkleRoot: merkleRoot,
+        txHash: `0x${'ab'.repeat(32)}`,
+        blockNumber: 123,
+        txIndex: 4,
+        batchId: PACKED_KA_ID,
+        startKAId: PACKED_KA_ID,
+        endKAId: PACKED_KA_ID,
+        publisherAddress: PUBLISHER,
+        rootEntities: [],
+        timestampMs: Date.now(),
+        operationId: 'graph-finalization-op',
+        targetContextGraphId: '42',
+        contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+        assertionVersion: scope.assertionVersion,
+        publicTripleCount: publicQuads.length,
+        privateMerkleRoot,
+        privateTripleCount: privateQuads.length,
+      },
+    };
+  }
+
+  it('atomically replaces the exact VM graph and emits constant-size rootless metadata', async () => {
+    const { message, swmGraph, vmGraph } = await stageGraph();
+
+    await handler.handleFinalizationMessage(encodeFinalizationMessage(message), CG);
+
+    expect(await store.countQuads(vmGraph)).toBe(2);
+    expect(await store.countQuads(swmGraph)).toBe(0);
+    const stale = await store.query(
+      `ASK { GRAPH <${vmGraph}> { <urn:stale:must-be-replaced> ?p ?o } }`,
+    );
+    expect(stale).toMatchObject({ type: 'boolean', value: false });
+
+    const metaGraph = `did:dkg:context-graph:${CG}/_meta`;
+    const metadata = await store.query(
+      `SELECT ?scope ?version ?count ?privateCount ?graph ?policy WHERE {
+        GRAPH <${metaGraph}> {
+          <${UAL}> <http://dkg.io/ontology/contentScopeVersion> ?scope ;
+            <http://dkg.io/ontology/assertionVersion> ?version ;
+            <http://dkg.io/ontology/publicTripleCount> ?count ;
+            <http://dkg.io/ontology/privateTripleCount> ?privateCount ;
+            <http://dkg.io/ontology/assertionGraph> ?graph ;
+            <http://dkg.io/ontology/accessPolicy> ?policy ;
+            <http://dkg.io/ontology/status> "confirmed" .
+        }
+      }`,
+    );
+    expect(metadata.type).toBe('bindings');
+    if (metadata.type !== 'bindings') throw new Error('expected bindings');
+    expect(metadata.bindings).toHaveLength(1);
+    expect(metadata.bindings[0]).toMatchObject({
+      scope: '"2"^^<http://www.w3.org/2001/XMLSchema#integer>',
+      version: '"1"^^<http://www.w3.org/2001/XMLSchema#integer>',
+      count: '"2"^^<http://www.w3.org/2001/XMLSchema#integer>',
+      privateCount: '"1"^^<http://www.w3.org/2001/XMLSchema#integer>',
+      graph: vmGraph,
+      policy: '"ownerOnly"',
+    });
+    const legacyRoots = await store.query(
+      `ASK { GRAPH <${metaGraph}> { ?s <http://dkg.io/ontology/rootEntity> ?root } }`,
+    );
+    expect(legacyRoots).toMatchObject({ type: 'boolean', value: false });
+  });
+
+  it('finalizes a fully private KA without requiring a public root or placeholder triple', async () => {
+    const scope = createGraphKnowledgeAssetScope(UAL, VERSION);
+    const vmGraph = knowledgeAssetLayerGraphUri(
+      CG,
+      MemoryLayer.VerifiableMemory,
+      scope,
+    );
+    const privateQuads: Quad[] = [{
+      subject: 'urn:asset:private-only',
+      predicate: 'urn:predicate:value',
+      object: '"hidden"',
+      graph: '',
+    }];
+    const privateMerkleRoot = computePrivateRootV10(privateQuads);
+    if (!privateMerkleRoot) throw new Error('expected private commitment');
+    const merkleRoot = computeFlatKCRootV10([], [privateMerkleRoot]);
+
+    await storeKnowledgeAssetOperationPublicQuads({
+      store,
+      graphManager,
+      contextGraphId: CG,
+      shareOperationId: SHARE_ID,
+      kaUal: scope.ual,
+      assertionVersion: scope.assertionVersion,
+      quads: [],
+      privateMerkleRoot,
+      privateTripleCount: privateQuads.length,
+      publisherPeerId: '12D3KooWPublisher',
+    });
+    await storeKnowledgeAssetWorkspaceHead({
+      store,
+      graphManager,
+      contextGraphId: CG,
+      shareOperationId: SHARE_ID,
+      kaUal: scope.ual,
+      assertionVersion: scope.assertionVersion,
+    });
+
+    await handler.handleFinalizationMessage(encodeFinalizationMessage({
+      ual: scope.ual,
+      contextGraphId: CG,
+      kcMerkleRoot: merkleRoot,
+      txHash: `0x${'cd'.repeat(32)}`,
+      blockNumber: 123,
+      txIndex: 4,
+      batchId: PACKED_KA_ID,
+      startKAId: PACKED_KA_ID,
+      endKAId: PACKED_KA_ID,
+      publisherAddress: PUBLISHER,
+      rootEntities: [],
+      timestampMs: Date.now(),
+      operationId: 'fully-private-finalization-op',
+      targetContextGraphId: '42',
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      assertionVersion: scope.assertionVersion,
+      publicTripleCount: 0,
+      privateMerkleRoot,
+      privateTripleCount: privateQuads.length,
+    }), CG);
+
+    expect(await store.countQuads(vmGraph)).toBe(0);
+    const metadata = await store.query(
+      `ASK { GRAPH <did:dkg:context-graph:${CG}/_meta> {
+        <${UAL}> <http://dkg.io/ontology/status> "confirmed" ;
+          <http://dkg.io/ontology/publicTripleCount> "0"^^<http://www.w3.org/2001/XMLSchema#integer> ;
+          <http://dkg.io/ontology/privateTripleCount> "1"^^<http://www.w3.org/2001/XMLSchema#integer> ;
+          <http://dkg.io/ontology/privateMerkleRoot> "${Buffer.from(privateMerkleRoot).toString('hex')}" .
+      } }`,
+    );
+    expect(metadata).toMatchObject({ type: 'boolean', value: true });
+  });
+
+  it('keeps the old VM graph and remains retryable when the atomic swap fails', async () => {
+    const { message, swmGraph, vmGraph } = await stageGraph();
+    const replaceGraph = store.replaceGraph?.bind(store);
+    if (!replaceGraph) throw new Error('Oxigraph replaceGraph unavailable');
+    store.replaceGraph = async (graphUri, quads, options) => {
+      if (graphUri === vmGraph) throw new Error('injected graph finalization failure');
+      return replaceGraph(graphUri, quads, options);
+    };
+
+    await handler.handleFinalizationMessage(encodeFinalizationMessage(message), CG);
+    expect(await store.countQuads(vmGraph)).toBe(1);
+    expect(await store.countQuads(swmGraph)).toBe(2);
+
+    store.replaceGraph = replaceGraph;
+    await handler.handleFinalizationMessage(encodeFinalizationMessage(message), CG);
+    expect(await store.countQuads(vmGraph)).toBe(2);
+    expect(await store.countQuads(swmGraph)).toBe(0);
+  });
+
+  it('rejects mixed graph-scope and legacy-root finalization envelopes', async () => {
+    const { message, swmGraph, vmGraph } = await stageGraph();
+    await handler.handleFinalizationMessage(
+      encodeFinalizationMessage({ ...message, rootEntities: ['urn:legacy:root'] }),
+      CG,
+    );
+    expect(await store.countQuads(vmGraph)).toBe(1);
+    expect(await store.countQuads(swmGraph)).toBe(2);
+  });
+
+  it('chain-reconciles a late joiner from the exact KA head without scanning legacy roots', async () => {
+    const { message, swmGraph, vmGraph } = await stageGraph();
+    const internals = handler as unknown as {
+      verifyChainCgBinding: (kaId: bigint, cgId: string) => Promise<boolean>;
+      findSwmSnapshotForMerkleRoot: () => Promise<never>;
+    };
+    internals.verifyChainCgBinding = async () => true;
+    internals.findSwmSnapshotForMerkleRoot = async () => {
+      throw new Error('legacy root scan must not run for graph-scoped SWM');
+    };
+
+    const outcome = await handler.handleChainReconciledKC({
+      contextGraphId: CG,
+      onChainCgId: '42',
+      ual: UAL,
+      merkleRoot: message.kcMerkleRoot,
+      publisherAddress: PUBLISHER,
+      kaId: PACKED_KA_ID,
+      versionBlock: 123,
+      authorAddress: AUTHOR,
+    }, createOperationContext('system'));
+
+    expect(outcome).toBe('promoted');
+    expect(await store.countQuads(vmGraph)).toBe(2);
+    expect(await store.countQuads(swmGraph)).toBe(0);
+  });
+
+  it('does not let an older confirmed assertion mask reconciliation of a newer chain root', async () => {
+    const first = await stageGraph();
+    await handler.handleFinalizationMessage(encodeFinalizationMessage(first.message), CG);
+
+    const nextScope = createGraphKnowledgeAssetScope(UAL, '2');
+    const nextSwmGraph = knowledgeAssetLayerGraphUri(
+      CG,
+      MemoryLayer.SharedWorkingMemory,
+      nextScope,
+    );
+    const nextVmGraph = knowledgeAssetLayerGraphUri(
+      CG,
+      MemoryLayer.VerifiableMemory,
+      nextScope,
+    );
+    const nextQuads: Quad[] = [{
+      subject: 'urn:asset:next',
+      predicate: 'urn:predicate:value',
+      object: '"two"',
+      graph: nextSwmGraph,
+    }];
+    await store.insert(nextQuads);
+    await storeKnowledgeAssetOperationPublicQuads({
+      store,
+      graphManager,
+      contextGraphId: CG,
+      shareOperationId: 'graph-finalization-update',
+      kaUal: UAL,
+      assertionVersion: nextScope.assertionVersion,
+      quads: nextQuads,
+      privateTripleCount: 0,
+      publisherPeerId: '12D3KooWPublisher',
+    });
+    await storeKnowledgeAssetWorkspaceHead({
+      store,
+      graphManager,
+      contextGraphId: CG,
+      shareOperationId: 'graph-finalization-update',
+      kaUal: UAL,
+      assertionVersion: nextScope.assertionVersion,
+    });
+    const nextMerkleRoot = computeFlatKCRootV10(
+      nextQuads.map((quad) => ({ ...quad, graph: '' })),
+      [],
+    );
+    const internals = handler as unknown as {
+      verifyChainCgBinding: (kaId: bigint, cgId: string) => Promise<boolean>;
+      findSwmSnapshotForMerkleRoot: () => Promise<never>;
+    };
+    internals.verifyChainCgBinding = async () => true;
+    internals.findSwmSnapshotForMerkleRoot = async () => {
+      throw new Error('legacy root scan must not run for a V2 update');
+    };
+
+    const outcome = await handler.handleChainReconciledKC({
+      contextGraphId: CG,
+      onChainCgId: '42',
+      ual: UAL,
+      merkleRoot: nextMerkleRoot,
+      publisherAddress: PUBLISHER,
+      kaId: PACKED_KA_ID,
+      versionBlock: 124,
+      authorAddress: AUTHOR,
+    }, createOperationContext('system'));
+
+    expect(outcome).toBe('promoted');
+    expect(await store.countQuads(nextVmGraph)).toBe(1);
+    expect(await store.countQuads(nextSwmGraph)).toBe(0);
+    const version = await store.query(
+      `ASK { GRAPH <did:dkg:context-graph:${CG}/_meta> {
+        <${UAL}> <http://dkg.io/ontology/assertionVersion> "2"^^<http://www.w3.org/2001/XMLSchema#integer> .
+      } }`,
+    );
+    expect(version).toMatchObject({ type: 'boolean', value: true });
+  });
+});

--- a/packages/agent/test/ka-graph-finalization-handler.test.ts
+++ b/packages/agent/test/ka-graph-finalization-handler.test.ts
@@ -378,4 +378,279 @@ describe('graph-scoped finalization handler', () => {
     );
     expect(version).toMatchObject({ type: 'boolean', value: true });
   });
+
+  it('does not finalize graph-scoped gossip that fails on-chain verification', async () => {
+    const { message, swmGraph, vmGraph } = await stageGraph();
+    (handler as unknown as {
+      verifyOnChain: () => Promise<{ verified: boolean }>;
+    }).verifyOnChain = async () => ({ verified: false });
+
+    await handler.handleFinalizationMessage(encodeFinalizationMessage(message), CG);
+
+    // Unverified gossip must not replace VM, confirm metadata, or consume SWM.
+    expect(await store.countQuads(vmGraph)).toBe(1);
+    expect(await store.countQuads(swmGraph)).toBe(2);
+    const confirmed = await store.query(
+      `ASK { GRAPH <did:dkg:context-graph:${CG}/_meta> { <${UAL}> <http://dkg.io/ontology/status> "confirmed" } }`,
+    );
+    expect(confirmed).toMatchObject({ type: 'boolean', value: false });
+
+    // The message stays retryable: restoring the verifier finalizes it.
+    (handler as unknown as {
+      verifyOnChain: () => Promise<{ verified: boolean; authorAddress: string; txIndex: number }>;
+    }).verifyOnChain = async () => ({ verified: true, authorAddress: AUTHOR, txIndex: 4 });
+    await handler.handleFinalizationMessage(encodeFinalizationMessage(message), CG);
+    expect(await store.countQuads(vmGraph)).toBe(2);
+    expect(await store.countQuads(swmGraph)).toBe(0);
+  });
+
+  it('rejects a graph-scoped envelope whose batchId does not match the UAL-derived kaId', async () => {
+    const { message, swmGraph, vmGraph } = await stageGraph();
+    await handler.handleFinalizationMessage(
+      encodeFinalizationMessage({ ...message, batchId: PACKED_KA_ID + 1n }),
+      CG,
+    );
+    expect(await store.countQuads(vmGraph)).toBe(1);
+    expect(await store.countQuads(swmGraph)).toBe(2);
+  });
+
+  it('recognizes an already-confirmed assertion across restart and chain reconciliation', async () => {
+    const { message } = await stageGraph();
+    await handler.handleFinalizationMessage(encodeFinalizationMessage(message), CG);
+
+    // Fresh handler: the in-memory gossip dedupe is gone, exactly like a
+    // restart. Stored metadata roots are bare hex while the chain root is
+    // bytes — the comparison must normalize or this loops as `no-swm` forever.
+    const restarted = new FinalizationHandler(store, undefined);
+    (restarted as unknown as {
+      verifyChainCgBinding: () => Promise<boolean>;
+    }).verifyChainCgBinding = async () => true;
+    const outcome = await restarted.handleChainReconciledKC({
+      contextGraphId: CG,
+      onChainCgId: '42',
+      ual: UAL,
+      merkleRoot: message.kcMerkleRoot,
+      publisherAddress: PUBLISHER,
+      kaId: PACKED_KA_ID,
+      versionBlock: 123,
+    }, createOperationContext('system'));
+    expect(outcome).toBe('already-confirmed');
+
+    // Duplicate gossip after restart is acknowledged, not deferred.
+    (restarted as unknown as {
+      verifyOnChain: () => Promise<{ verified: boolean; authorAddress: string; txIndex: number }>;
+    }).verifyOnChain = async () => ({ verified: true, authorAddress: AUTHOR, txIndex: 4 });
+    const confirmed = await store.query(
+      `ASK { GRAPH <did:dkg:context-graph:${CG}/_meta> { <${UAL}> <http://dkg.io/ontology/status> "confirmed" } }`,
+    );
+    expect(confirmed).toMatchObject({ type: 'boolean', value: true });
+  });
+
+  it('treats a newer assertion with an identical Merkle root as new work, not a duplicate', async () => {
+    const first = await stageGraph();
+    await handler.handleFinalizationMessage(encodeFinalizationMessage(first.message), CG);
+
+    // Version 2 has byte-identical content, therefore the same flat-KC root.
+    const nextScope = createGraphKnowledgeAssetScope(UAL, '2');
+    const swmGraph = knowledgeAssetLayerGraphUri(CG, MemoryLayer.SharedWorkingMemory, nextScope);
+    const vmGraph = knowledgeAssetLayerGraphUri(CG, MemoryLayer.VerifiableMemory, nextScope);
+    const publicQuads: Quad[] = [
+      { subject: 'urn:asset:one', predicate: 'urn:predicate:value', object: '"one"', graph: swmGraph },
+      { subject: 'urn:asset:two', predicate: 'urn:predicate:value', object: '"two"', graph: swmGraph },
+    ];
+    const privateQuads: Quad[] = [
+      { subject: 'urn:asset:secret', predicate: 'urn:predicate:value', object: '"hidden"', graph: '' },
+    ];
+    const privateMerkleRoot = computePrivateRootV10(privateQuads);
+    if (!privateMerkleRoot) throw new Error('expected private commitment');
+    await store.insert(publicQuads);
+    await storeKnowledgeAssetOperationPublicQuads({
+      store,
+      graphManager,
+      contextGraphId: CG,
+      shareOperationId: 'same-root-update',
+      kaUal: UAL,
+      assertionVersion: nextScope.assertionVersion,
+      quads: publicQuads,
+      privateMerkleRoot,
+      privateTripleCount: privateQuads.length,
+      publisherPeerId: '12D3KooWPublisher',
+    });
+    await storeKnowledgeAssetWorkspaceHead({
+      store,
+      graphManager,
+      contextGraphId: CG,
+      shareOperationId: 'same-root-update',
+      kaUal: UAL,
+      assertionVersion: nextScope.assertionVersion,
+    });
+
+    await handler.handleFinalizationMessage(encodeFinalizationMessage({
+      ...first.message,
+      txHash: `0x${'ef'.repeat(32)}`,
+      blockNumber: 124,
+      assertionVersion: nextScope.assertionVersion,
+      operationId: 'same-root-update-op',
+    }), CG);
+
+    // The v2 assertion must be materialized as v2 — not skipped as an
+    // already-confirmed duplicate of v1 (which would also delete its SWM).
+    expect(await store.countQuads(vmGraph)).toBe(2);
+    const version = await store.query(
+      `ASK { GRAPH <did:dkg:context-graph:${CG}/_meta> {
+        <${UAL}> <http://dkg.io/ontology/assertionVersion> "2"^^<http://www.w3.org/2001/XMLSchema#integer> ;
+          <http://dkg.io/ontology/status> "confirmed" .
+      } }`,
+    );
+    expect(version).toMatchObject({ type: 'boolean', value: true });
+    expect(await store.countQuads(swmGraph)).toBe(0);
+  });
+
+  it('finalizes a chain-confirmed older assertion after a newer SWM write, without erasing it', async () => {
+    // Stage v1 but do NOT finalize it yet.
+    const first = await stageGraph();
+
+    // A v2 update is accepted into SWM before v1's finalization arrives:
+    // the shared per-KA graph now holds v2 content and the head moved on.
+    const nextScope = createGraphKnowledgeAssetScope(UAL, '2');
+    const sharedSwmGraph = knowledgeAssetLayerGraphUri(CG, MemoryLayer.SharedWorkingMemory, nextScope);
+    const nextQuads: Quad[] = [{
+      subject: 'urn:asset:next',
+      predicate: 'urn:predicate:value',
+      object: '"v2"',
+      graph: sharedSwmGraph,
+    }];
+    await store.dropGraph(sharedSwmGraph);
+    await store.insert(nextQuads);
+    await storeKnowledgeAssetOperationPublicQuads({
+      store,
+      graphManager,
+      contextGraphId: CG,
+      shareOperationId: 'out-of-order-update',
+      kaUal: UAL,
+      assertionVersion: nextScope.assertionVersion,
+      quads: nextQuads,
+      privateTripleCount: 0,
+      publisherPeerId: '12D3KooWPublisher',
+    });
+    await storeKnowledgeAssetWorkspaceHead({
+      store,
+      graphManager,
+      contextGraphId: CG,
+      shareOperationId: 'out-of-order-update',
+      kaUal: UAL,
+      assertionVersion: nextScope.assertionVersion,
+    });
+
+    // Deliver the verified v1 finalization AFTER the v2 SWM write.
+    await handler.handleFinalizationMessage(encodeFinalizationMessage(first.message), CG);
+
+    // v1 (the chain-confirmed state) is materialized from its immutable
+    // operation snapshot...
+    const vmGraph = first.vmGraph;
+    expect(await store.countQuads(vmGraph)).toBe(2);
+    const confirmed = await store.query(
+      `ASK { GRAPH <did:dkg:context-graph:${CG}/_meta> {
+        <${UAL}> <http://dkg.io/ontology/assertionVersion> "1"^^<http://www.w3.org/2001/XMLSchema#integer> ;
+          <http://dkg.io/ontology/status> "confirmed" .
+      } }`,
+    );
+    expect(confirmed).toMatchObject({ type: 'boolean', value: true });
+    // ...and the newer staged v2 content is NOT erased by the older finalizer.
+    expect(await store.countQuads(sharedSwmGraph)).toBe(1);
+
+    // The chain sweep for the v1 root now converges instead of looping no-swm.
+    const internals = handler as unknown as { verifyChainCgBinding: () => Promise<boolean> };
+    internals.verifyChainCgBinding = async () => true;
+    const outcome = await handler.handleChainReconciledKC({
+      contextGraphId: CG,
+      onChainCgId: '42',
+      ual: UAL,
+      merkleRoot: first.message.kcMerkleRoot,
+      publisherAddress: PUBLISHER,
+      kaId: PACKED_KA_ID,
+      versionBlock: 123,
+    }, createOperationContext('system'));
+    expect(outcome).toBe('already-confirmed');
+  });
+
+  it('late-join sweep locates the V2 head even when the caller passes a legacy-shaped UAL', async () => {
+    const { message, swmGraph, vmGraph } = await stageGraph();
+    const internals = handler as unknown as {
+      verifyChainCgBinding: (kaId: bigint, cgId: string) => Promise<boolean>;
+      findSwmSnapshotForMerkleRoot: () => Promise<never>;
+    };
+    internals.verifyChainCgBinding = async () => true;
+    internals.findSwmSnapshotForMerkleRoot = async () => {
+      throw new Error('legacy root scan must not run for graph-scoped SWM');
+    };
+
+    // Production `reconcileChainOrdinal` builds
+    // did:dkg:<chain>/<storage-contract>/<packed-id> — the V2 identity must be
+    // recovered from the packed kaId, not from the caller's UAL shape.
+    const legacyShapedUal = `did:dkg:otp:20430/0x9999999999999999999999999999999999999999/${PACKED_KA_ID}`;
+    const outcome = await handler.handleChainReconciledKC({
+      contextGraphId: CG,
+      onChainCgId: '42',
+      ual: legacyShapedUal,
+      merkleRoot: message.kcMerkleRoot,
+      publisherAddress: PUBLISHER,
+      kaId: PACKED_KA_ID,
+      versionBlock: 123,
+      authorAddress: AUTHOR,
+    }, createOperationContext('system'));
+
+    expect(outcome).toBe('promoted');
+    expect(await store.countQuads(vmGraph)).toBe(2);
+    expect(await store.countQuads(swmGraph)).toBe(0);
+    const confirmed = await store.query(
+      `ASK { GRAPH <did:dkg:context-graph:${CG}/_meta> { <${UAL}> <http://dkg.io/ontology/status> "confirmed" } }`,
+    );
+    expect(confirmed).toMatchObject({ type: 'boolean', value: true });
+  });
+
+  it('does not let a duplicate older finalization drop a newer staged assertion after restart', async () => {
+    const first = await stageGraph();
+    await handler.handleFinalizationMessage(encodeFinalizationMessage(first.message), CG);
+
+    // v2 staged after v1 confirmed: same physical SWM graph, head at v2.
+    const nextScope = createGraphKnowledgeAssetScope(UAL, '2');
+    const sharedSwmGraph = knowledgeAssetLayerGraphUri(CG, MemoryLayer.SharedWorkingMemory, nextScope);
+    const nextQuads: Quad[] = [{
+      subject: 'urn:asset:next',
+      predicate: 'urn:predicate:value',
+      object: '"v2"',
+      graph: sharedSwmGraph,
+    }];
+    await store.insert(nextQuads);
+    await storeKnowledgeAssetOperationPublicQuads({
+      store,
+      graphManager,
+      contextGraphId: CG,
+      shareOperationId: 'post-confirm-update',
+      kaUal: UAL,
+      assertionVersion: nextScope.assertionVersion,
+      quads: nextQuads,
+      privateTripleCount: 0,
+      publisherPeerId: '12D3KooWPublisher',
+    });
+    await storeKnowledgeAssetWorkspaceHead({
+      store,
+      graphManager,
+      contextGraphId: CG,
+      shareOperationId: 'post-confirm-update',
+      kaUal: UAL,
+      assertionVersion: nextScope.assertionVersion,
+    });
+
+    // Restarted node re-receives the v1 finalization (no in-memory dedupe).
+    const restarted = new FinalizationHandler(store, undefined);
+    (restarted as unknown as {
+      verifyOnChain: () => Promise<{ verified: boolean; authorAddress: string; txIndex: number }>;
+    }).verifyOnChain = async () => ({ verified: true, authorAddress: AUTHOR, txIndex: 4 });
+    await restarted.handleFinalizationMessage(encodeFinalizationMessage(first.message), CG);
+
+    // Already-confirmed cleanup must not delete v2's staged content.
+    expect(await store.countQuads(sharedSwmGraph)).toBe(1);
+  });
 });

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -62,6 +62,7 @@ export default defineConfig({
       "test/chain-reconciler.test.ts",
       "test/finalization-lifecycle-logger.test.ts",
       "test/ka-graph-finalization-handler.test.ts",
+      "test/ka-graph-finalization-envelope.test.ts",
       "test/swm-slice-ka-bound.test.ts",
       "test/ka-lifecycle-asset-ual-timeout.test.ts",
       "test/storage-ack-lifecycle-identity.test.ts",

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -61,6 +61,7 @@ export default defineConfig({
       "test/chain-cursor-wiring.test.ts",
       "test/chain-reconciler.test.ts",
       "test/finalization-lifecycle-logger.test.ts",
+      "test/ka-graph-finalization-handler.test.ts",
       "test/swm-slice-ka-bound.test.ts",
       "test/ka-lifecycle-asset-ual-timeout.test.ts",
       "test/storage-ack-lifecycle-identity.test.ts",

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -57,7 +57,11 @@ import {
   type KAMetadata,
   type OnChainProvenance,
 } from './metadata.js';
-import { storeKnowledgeAssetOperationPublicQuads, storeWorkspaceOperationPublicQuads } from './workspace-resolution.js';
+import {
+  storeKnowledgeAssetOperationPublicQuads,
+  storeKnowledgeAssetWorkspaceHead,
+  storeWorkspaceOperationPublicQuads,
+} from './workspace-resolution.js';
 import type { WorkspacePublicSnapshotStore } from './workspace-snapshot-store.js';
 import { ethers } from 'ethers';
 import type { WorkspaceAgentRecipientResolver } from './workspace-agent-recipients.js';
@@ -7089,6 +7093,19 @@ export class DKGPublisher implements Publisher {
       subGraphName: opts?.subGraphName,
       timestamp: new Date(),
       publicSnapshotStore: this.publicSnapshotStore,
+    });
+    // The originator does not receive its own GossipSub message, so it must
+    // persist the same monotonic KA head the receiver writes. Without this,
+    // a delayed older peer replay could look like the first version locally
+    // and replace the freshly promoted graph.
+    await storeKnowledgeAssetWorkspaceHead({
+      store: this.store,
+      graphManager: this.graphManager,
+      contextGraphId,
+      shareOperationId: operationId,
+      kaUal: contentScope.ual,
+      assertionVersion: contentScope.assertionVersion,
+      subGraphName: opts?.subGraphName,
     });
 
     return {

--- a/packages/publisher/src/index.ts
+++ b/packages/publisher/src/index.ts
@@ -40,11 +40,13 @@ export {
   type PreparedGeneratedPrivateCatalogFloor,
 } from './catalog-trust.js';
 export {
+  listKnowledgeAssetOperationCandidates,
   resolveKnowledgeAssetWorkspaceHead,
   resolveKnowledgeAssetOperationPublicQuads,
   resolveLiftWorkspaceSlice,
   storeKnowledgeAssetWorkspaceHead,
   storeKnowledgeAssetOperationPublicQuads,
+  type KnowledgeAssetOperationCandidate,
   type KnowledgeAssetWorkspaceHead,
   type KnowledgeAssetOperationPublicSnapshot,
 } from './workspace-resolution.js';

--- a/packages/publisher/src/index.ts
+++ b/packages/publisher/src/index.ts
@@ -40,9 +40,12 @@ export {
   type PreparedGeneratedPrivateCatalogFloor,
 } from './catalog-trust.js';
 export {
+  resolveKnowledgeAssetWorkspaceHead,
   resolveKnowledgeAssetOperationPublicQuads,
   resolveLiftWorkspaceSlice,
+  storeKnowledgeAssetWorkspaceHead,
   storeKnowledgeAssetOperationPublicQuads,
+  type KnowledgeAssetWorkspaceHead,
   type KnowledgeAssetOperationPublicSnapshot,
 } from './workspace-resolution.js';
 export {

--- a/packages/publisher/src/workspace-resolution.ts
+++ b/packages/publisher/src/workspace-resolution.ts
@@ -423,6 +423,100 @@ export async function storeKnowledgeAssetOperationPublicQuads(params: {
   await params.store.insert(metadata);
 }
 
+/**
+ * One immutable graph-scoped operation snapshot recorded for a KA. The head
+ * points at the latest accepted assertion only; recovery paths that must
+ * materialize an EARLIER chain-confirmed assertion (out-of-order finalization,
+ * late-join reconciliation after a newer SWM write) enumerate these instead.
+ */
+export interface KnowledgeAssetOperationCandidate {
+  readonly shareOperationId: string;
+  readonly assertionVersion: string;
+  readonly publicTripleCount: number;
+  readonly privateTripleCount: number;
+  /** `0x`-prefixed lowercase hex, present iff privateTripleCount > 0. */
+  readonly privateMerkleRoot?: string;
+  readonly publisherPeerId?: string;
+}
+
+/**
+ * List every graph-scoped operation snapshot stored for one KA, newest
+ * assertion version first. Malformed rows are skipped (fail closed per row)
+ * so one corrupt operation cannot poison recovery of the others.
+ */
+export async function listKnowledgeAssetOperationCandidates(params: {
+  store: TripleStore;
+  graphManager: GraphManager;
+  contextGraphId: string;
+  kaUal: string;
+  assertionVersion?: string | number | bigint;
+  subGraphName?: string;
+}): Promise<KnowledgeAssetOperationCandidate[]> {
+  const scope = createGraphKnowledgeAssetScope(params.kaUal, 1);
+  const subGraphName = normalizeOptionalSubGraphName(params.subGraphName);
+  const metaGraph = params.graphManager.sharedMemoryMetaUri(
+    params.contextGraphId,
+    subGraphName,
+  );
+  const result = await params.store.query(
+    `SELECT ?operation ?scopeVersion ?shareOperationId ?version ?publicCount ?privateCount ?privateRoot ?publisherPeerId WHERE {
+      GRAPH <${assertSafeIri(metaGraph)}> {
+        ?operation <${DKG}contentScopeVersion> ?scopeVersion ;
+          <${DKG}kaUal> <${assertSafeIri(scope.ual)}> ;
+          <${DKG}shareOperationId> ?shareOperationId ;
+          <${DKG}assertionVersion> ?version ;
+          <${DKG}publicQuadsCount> ?publicCount ;
+          <${DKG}privateTripleCount> ?privateCount .
+        OPTIONAL { ?operation <${DKG}privateMerkleRoot> ?privateRoot }
+        OPTIONAL { ?operation <${DKG}publisherPeerId> ?publisherPeerId }
+      }
+    }`,
+  );
+  if (result.type !== 'bindings') return [];
+
+  const requestedVersion = params.assertionVersion !== undefined
+    ? createGraphKnowledgeAssetScope(scope.ual, params.assertionVersion).assertionVersion
+    : undefined;
+  const byOperation = new Map<string, KnowledgeAssetOperationCandidate>();
+  for (const row of result.bindings) {
+    try {
+      if (parseIntegerLiteral(row?.['scopeVersion']) !== GRAPH_KA_CONTENT_SCOPE_VERSION) continue;
+      const shareOperationId = stripLiteral(row?.['shareOperationId'])?.trim() ?? '';
+      if (!shareOperationId) continue;
+      // Only accept rows under the canonical operation subject so spoofed
+      // rows in the meta graph cannot masquerade as an operation snapshot.
+      if (row?.['operation'] !== workspaceOperationSubject(params.contextGraphId, shareOperationId)) continue;
+      const assertionVersion = parsePositiveBigIntLiteral(row?.['version']).toString();
+      if (requestedVersion !== undefined && assertionVersion !== requestedVersion) continue;
+      const publicTripleCount = parseIntegerLiteral(row?.['publicCount']);
+      const privateTripleCount = parseIntegerLiteral(row?.['privateCount']);
+      const privateMerkleRoot = stripLiteral(row?.['privateRoot'])?.trim();
+      if (
+        !Number.isSafeInteger(publicTripleCount) || publicTripleCount < 0 ||
+        !Number.isSafeInteger(privateTripleCount) || privateTripleCount < 0 ||
+        (publicTripleCount === 0 && privateTripleCount === 0) ||
+        (privateTripleCount > 0 && !/^0x[0-9a-f]{64}$/i.test(privateMerkleRoot ?? '')) ||
+        (privateTripleCount === 0 && privateMerkleRoot !== undefined)
+      ) continue;
+      byOperation.set(shareOperationId, {
+        shareOperationId,
+        assertionVersion,
+        publicTripleCount,
+        privateTripleCount,
+        privateMerkleRoot,
+        publisherPeerId: stripLiteral(row?.['publisherPeerId'])?.trim() || undefined,
+      });
+    } catch {
+      continue;
+    }
+  }
+  return [...byOperation.values()].sort((a, b) => {
+    const left = BigInt(a.assertionVersion);
+    const right = BigInt(b.assertionVersion);
+    return left === right ? 0 : (left > right ? -1 : 1);
+  });
+}
+
 /** Resolve and integrity-check a complete graph-scoped KA operation snapshot. */
 export async function resolveKnowledgeAssetOperationPublicQuads(params: {
   store: TripleStore;

--- a/packages/publisher/test/ka-graph-promote-head.test.ts
+++ b/packages/publisher/test/ka-graph-promote-head.test.ts
@@ -1,0 +1,120 @@
+/**
+ * PR #1715 review — the originator does not receive its own GossipSub
+ * finalization, so `assertionPromote` must persist the same monotonic
+ * graph-scoped workspace head the receiver path writes. Without it a delayed
+ * older peer replay can look like the first version locally and replace the
+ * freshly promoted graph. Receiver-side tests stage heads manually, so this
+ * covers the originator-only write.
+ */
+import { describe, expect, it } from 'vitest';
+import { NoChainAdapter } from '@origintrail-official/dkg-chain';
+import {
+  TypedEventBus,
+  generateEd25519Keypair,
+  buildAssertionSealQuads,
+  contextGraphAssertionUri,
+  contextGraphMetaUri,
+  assertionLifecycleUri,
+  createGraphKnowledgeAssetScope,
+  knowledgeAssetLayerGraphUri,
+  MemoryLayer,
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+} from '@origintrail-official/dkg-core';
+import { GraphManager, OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
+import {
+  DKGPublisher,
+  computeFlatKCRootV10,
+  resolveKnowledgeAssetWorkspaceHead,
+  resolveKnowledgeAssetOperationPublicQuads,
+} from '../src/index.js';
+
+const CG = 'promote-head-cg';
+const AGENT = '0x00000000000000000000000000000000000000a1';
+const NAME = 'promote-head-asset';
+const KA_UAL = `did:dkg:31337/${AGENT}/9`;
+const DKG = 'http://dkg.io/ontology/';
+
+describe('assertionPromote graph-scoped workspace head (originator replay fence)', () => {
+  it('persists the monotonic KA head alongside the immutable operation snapshot', async () => {
+    const store = new OxigraphStore();
+    const publisher = new DKGPublisher({
+      store,
+      chain: new NoChainAdapter(),
+      eventBus: new TypedEventBus(),
+      keypair: await generateEd25519Keypair(),
+    });
+    const graphManager = new GraphManager(store);
+    const scope = createGraphKnowledgeAssetScope(KA_UAL, 1);
+    const wmGraph = knowledgeAssetLayerGraphUri(CG, MemoryLayer.WorkingMemory, scope);
+    const swmGraph = knowledgeAssetLayerGraphUri(CG, MemoryLayer.SharedWorkingMemory, scope);
+    const publicQuads: Quad[] = [
+      { subject: 'urn:e:head-one', predicate: 'http://schema.org/name', object: '"One"', graph: '' },
+      { subject: 'urn:e:head-two', predicate: 'http://schema.org/name', object: '"Two"', graph: '' },
+    ];
+    const merkleRoot = computeFlatKCRootV10(publicQuads, []);
+
+    await store.insert(publicQuads.map((quad) => ({ ...quad, graph: wmGraph })));
+    await store.insert(buildAssertionSealQuads({
+      assertionUri: contextGraphAssertionUri(CG, AGENT, NAME),
+      metaGraph: contextGraphMetaUri(CG),
+      merkleRoot,
+      authorAddress: AGENT,
+      authorAttestationR: new Uint8Array(32).fill(1),
+      authorAttestationVS: new Uint8Array(32).fill(2),
+      authorSchemeVersion: 1,
+      chainId: 31337n,
+      kav10Address: AGENT,
+      reservedKaId: (BigInt(AGENT) << 96n) | 9n,
+      finalizedAtIso: '2026-01-01T00:00:00.000Z',
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      kaUal: KA_UAL,
+      assertionVersion: 1,
+      publicTripleCount: publicQuads.length,
+      privateTripleCount: 0,
+    }) as Quad[]);
+    // The graph-scoped write gate reads the lifecycle URN's scope marker.
+    await store.insert([{
+      subject: assertionLifecycleUri(CG, AGENT, NAME),
+      predicate: `${DKG}contentScopeVersion`,
+      object: `"${GRAPH_KA_CONTENT_SCOPE_VERSION}"^^<http://www.w3.org/2001/XMLSchema#integer>`,
+      graph: contextGraphMetaUri(CG),
+    }]);
+
+    const promoted = await publisher.assertionPromote(CG, NAME, AGENT);
+    expect(promoted.promotedCount).toBe(2);
+    expect(promoted.shareOperationId).toBeTruthy();
+
+    // The durable head is the receiver-parity replay fence: it must exist,
+    // name this exact assertion, and point at the promoted operation.
+    const head = await resolveKnowledgeAssetWorkspaceHead({
+      store,
+      graphManager,
+      contextGraphId: CG,
+      kaUal: KA_UAL,
+    });
+    expect(head).toBeDefined();
+    expect(head).toMatchObject({
+      kaUal: KA_UAL,
+      assertionVersion: '1',
+      assertionGraph: swmGraph,
+      publicTripleCount: 2,
+      privateTripleCount: 0,
+      shareOperationId: promoted.shareOperationId,
+    });
+
+    // The head's operation snapshot resolves back to the exact promoted quads,
+    // so a stale replay can be detected against real content, not just a row.
+    const snapshot = await resolveKnowledgeAssetOperationPublicQuads({
+      store,
+      graphManager,
+      contextGraphId: CG,
+      shareOperationId: promoted.shareOperationId!,
+      kaUal: KA_UAL,
+      assertionVersion: 1,
+    });
+    expect(snapshot.quads).toHaveLength(2);
+    expect(new Set(snapshot.quads.map((quad) => quad.subject))).toEqual(
+      new Set(['urn:e:head-one', 'urn:e:head-two']),
+    );
+  });
+});

--- a/packages/publisher/vitest.unit.config.ts
+++ b/packages/publisher/vitest.unit.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
       'test/ka-graph-workspace-receiver.test.ts',
       'test/ka-graph-finalization-storage.test.ts',
       'test/ka-graph-publish-storage.test.ts',
+      'test/ka-graph-promote-head.test.ts',
       'test/agents-meta-bound.test.ts',
       'test/ack-collector.test.ts',
       'test/publish-lifecycle-logger.test.ts',


### PR DESCRIPTION
## Summary

- adds the graph-scoped content envelope to finalization gossip and rejects mixed V2 plus legacy-root messages
- verifies the exact UAL and assertion-version SWM graph, then replaces the derived VM graph and emits constant-size rootless metadata
- persists the publisher workspace head and uses it for bounded late-join chain reconciliation before legacy root scanning
- preserves retryability and idempotency across failed swaps, duplicate finalization, and newer assertion versions
- covers public-plus-private and fully private KAs without placeholder roots or triples

## Stack

Stacked on #1714. Review this PR as the graph finalization and late-join recovery slice; mutation, query, access-policy, and backend-parity cutovers follow separately.

## Validation

- pnpm --filter @origintrail-official/dkg-agent... build
- agent unit suite: 830 passed
- publisher unit suite: 313 passed
- focused graph finalization suite: 6 passed