### PR TITLE
feat: sample rootless KAs from exact graphs

### DIFF
--- a/packages/core/src/ka-content-scope.ts
+++ b/packages/core/src/ka-content-scope.ts
@@ -70,6 +70,7 @@ export class LegacyKnowledgeAssetReadOnlyError extends Error {
 }
 
 const DETERMINISTIC_KA_UAL_RE = /^did:dkg:([^/]+)\/(0x[0-9a-fA-F]{40})\/([0-9]+)$/;
+const MAX_KA_NUMBER_EXCLUSIVE = 1n << 96n;
 
 /**
  * Parse and canonicalize the deterministic Option-1 UAL used as graph identity.
@@ -93,7 +94,13 @@ export function parseDeterministicKnowledgeAssetUal(
   const [, chainId, rawAgentAddress, rawKaNumber] = match;
   const agentAddress = canonicalKnowledgeAssetAgentAddress(rawAgentAddress);
   // BigInt canonicalisation prevents leading-zero aliases for one graph.
-  const kaNumber = BigInt(rawKaNumber).toString();
+  const parsedKaNumber = BigInt(rawKaNumber);
+  if (parsedKaNumber >= MAX_KA_NUMBER_EXCLUSIVE) {
+    throw new Error(
+      `Graph-scoped KA number must fit the uint96 on-chain identity field: ${rawKaNumber}`,
+    );
+  }
+  const kaNumber = parsedKaNumber.toString();
   return {
     ual: `did:dkg:${chainId}/${agentAddress}/${kaNumber}`,
     chainId,

--- a/packages/core/test/ka-content-scope.test.ts
+++ b/packages/core/test/ka-content-scope.test.ts
@@ -30,6 +30,14 @@ describe('KA content scope', () => {
     });
   });
 
+  it('rejects KA numbers outside the uint96 on-chain identity domain', () => {
+    const tooLarge = 1n << 96n;
+    const ual = `did:dkg:base:8453/0x70997970c51812dc3a010C7d01b50e0d17dc79C8/${tooLarge}`;
+
+    expect(() => parseDeterministicKnowledgeAssetUal(ual))
+      .toThrow(/uint96 on-chain identity field/);
+  });
+
   it('derives one stable per-KA graph while assertion version remains explicit', () => {
     const v1 = createGraphKnowledgeAssetScope(UAL, 1);
     const v2 = createGraphKnowledgeAssetScope(UAL, 2);

--- a/packages/random-sampling/src/ka-extractor.ts
+++ b/packages/random-sampling/src/ka-extractor.ts
@@ -4,6 +4,9 @@ import {
   contextGraphMetaUri,
   contextGraphLayerUri,
   contextGraphSubGraphUri,
+  createGraphKnowledgeAssetScope,
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  knowledgeAssetLayerGraphUri,
   validateSubGraphName,
   MemoryLayer,
   hashTripleV10,
@@ -209,6 +212,21 @@ export async function extractV10KCFromStore(
   if (cgName === null) {
     throw new KCNotFoundError(cgId, kaId);
   }
+
+  // V2/rootless KAs are atomic graphs. Resolve their constant-size label
+  // metadata first and read the exact per-KA VM graph directly; no subject
+  // discovery or shared per-cgId data copy is involved. A missing V2 row falls
+  // through to the legacy root-based extractor below so historical KAs remain
+  // readable during the transition.
+  const graphScoped = await extractGraphScopedV10KC(
+    store,
+    cgName,
+    cgId,
+    kaId,
+    subGraphNameHint,
+  );
+  if (graphScoped) return graphScoped;
+
   const metaGraph = contextGraphMetaUri(cgName, cgIdStr);
   const dataGraph = contextGraphDataUri(cgName, cgIdStr);
   // No assertSafeIri on derived URIs — `cgIdStr` is a bigint stringification
@@ -398,6 +416,117 @@ export async function extractV10KCFromStore(
   for (const root of privateRoots) leaves.push(root);
 
   return { contextGraphName: cgName, dataGraph, subGraphName, ual, rootEntities, triples, privateRoots, leaves };
+}
+
+async function extractGraphScopedV10KC(
+  store: TripleStore,
+  cgName: string,
+  cgId: bigint,
+  kaId: bigint,
+  _subGraphNameHint?: string,
+): Promise<KCExtractionResult | null> {
+  const labelMetaGraph = contextGraphMetaUri(cgName);
+  const result = await store.query(
+    `SELECT ?ual ?scope ?version ?publicCount ?privateCount ?privateRoot ?assertionGraph ?subGraph WHERE {
+       GRAPH <${labelMetaGraph}> {
+         ?ual <${DKG}batchId> "${kaId}"^^<${XSD}integer> ;
+           <${DKG}contentScopeVersion> ?scope ;
+           <${DKG}assertionVersion> ?version ;
+           <${DKG}publicTripleCount> ?publicCount ;
+           <${DKG}privateTripleCount> ?privateCount ;
+           <${DKG}assertionGraph> ?assertionGraph .
+         OPTIONAL { ?ual <${DKG}privateMerkleRoot> ?privateRoot }
+         OPTIONAL { ?ual <${DKG}subGraphName> ?subGraph }
+       }
+     } LIMIT 1`,
+  );
+  if (result.type !== 'bindings' || result.bindings.length === 0) return null;
+
+  const row = result.bindings[0];
+  const contentScopeVersion = Number(stripQuotes(row['scope'] ?? ''));
+  if (contentScopeVersion !== GRAPH_KA_CONTENT_SCOPE_VERSION) {
+    throw new Error(
+      `Unsupported content scope version ${contentScopeVersion} for KC ${kaId} in cg ${cgId}`,
+    );
+  }
+  const ual = stripQuotes(row['ual'] ?? '');
+  const assertionVersion = stripQuotes(row['version'] ?? '');
+  const scope = createGraphKnowledgeAssetScope(ual, assertionVersion);
+  const packedKaId = (BigInt(scope.agentAddress) << 96n) | BigInt(scope.kaNumber);
+  if (scope.ual !== ual || packedKaId !== kaId) {
+    throw new Error(`Graph-scoped KC identity does not match kaId ${kaId} in cg ${cgId}`);
+  }
+
+  const publicTripleCount = Number(stripQuotes(row['publicCount'] ?? ''));
+  const privateTripleCount = Number(stripQuotes(row['privateCount'] ?? ''));
+  if (
+    !Number.isSafeInteger(publicTripleCount)
+    || publicTripleCount < 0
+    || !Number.isSafeInteger(privateTripleCount)
+    || privateTripleCount < 0
+    || (publicTripleCount === 0 && privateTripleCount === 0)
+  ) {
+    throw new Error(`Invalid graph-scoped content counts for KC ${kaId} in cg ${cgId}`);
+  }
+
+  const metaSubGraph = stripQuotes(row['subGraph'] ?? '') || undefined;
+  if (metaSubGraph && !validateSubGraphName(metaSubGraph).valid) {
+    throw new Error(`Invalid graph-scoped sub-graph metadata for KC ${kaId} in cg ${cgId}`);
+  }
+  // V2 metadata is authoritative: an absent subGraphName means the CG root.
+  // Caller hints are only a legacy discovery optimization and must never move
+  // an atomic KA to a different physical graph.
+  const subGraphName = metaSubGraph;
+  const assertionGraph = row['assertionGraph'] ?? '';
+  const expectedGraph = knowledgeAssetLayerGraphUri(
+    cgName,
+    MemoryLayer.VerifiableMemory,
+    scope,
+    subGraphName,
+  );
+  if (assertionGraph !== expectedGraph) {
+    throw new Error(`Graph-scoped assertion graph mismatch for KC ${kaId} in cg ${cgId}`);
+  }
+
+  const privateRootLiteral = stripQuotes(row['privateRoot'] ?? '');
+  const privateRoots = privateRootLiteral ? [parseHexBytes(privateRootLiteral)] : [];
+  if (
+    (privateTripleCount > 0 && (privateRoots.length !== 1 || privateRoots[0].length !== 32))
+    || (privateTripleCount === 0 && privateRoots.length !== 0)
+  ) {
+    throw new Error(`Invalid graph-scoped private commitment for KC ${kaId} in cg ${cgId}`);
+  }
+
+  const graphResult = await store.query(
+    `CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${assertionGraph}> { ?s ?p ?o } }`,
+  );
+  const triples: KCTriple[] = graphResult.type === 'quads'
+    ? graphResult.quads
+      .filter((quad) => !POST_PUBLISH_PREDICATES_TO_SKIP.has(quad.predicate))
+      .map((quad) => ({
+        subject: quad.subject,
+        predicate: quad.predicate,
+        object: quad.object,
+        graph: assertionGraph,
+      }))
+    : [];
+  if (triples.length !== publicTripleCount) {
+    throw new KCDataMissingError(cgId, kaId, ual, []);
+  }
+
+  const leaves = triples.map((triple) =>
+    hashTripleV10(triple.subject, triple.predicate, triple.object));
+  leaves.push(...privateRoots);
+  return {
+    contextGraphName: cgName,
+    dataGraph: assertionGraph,
+    subGraphName,
+    ual,
+    rootEntities: [],
+    triples,
+    privateRoots,
+    leaves,
+  };
 }
 
 // ── Internal helpers ───────────────────────────────────────────────────

--- a/packages/random-sampling/src/ka-extractor.ts
+++ b/packages/random-sampling/src/ka-extractor.ts
@@ -426,50 +426,143 @@ async function extractGraphScopedV10KC(
   _subGraphNameHint?: string,
 ): Promise<KCExtractionResult | null> {
   const labelMetaGraph = contextGraphMetaUri(cgName);
-  const result = await store.query(
-    `SELECT ?ual ?scope ?version ?publicCount ?privateCount ?privateRoot ?assertionGraph ?subGraph WHERE {
+  // Resolve the V2 discriminator separately from the envelope. A partial or
+  // conflicting V2 row must never disappear into the legacy extractor merely
+  // because one required predicate is absent or LIMIT 1 selected one value.
+  const discriminator = await store.query(
+    `SELECT ?ual ?scope WHERE {
        GRAPH <${labelMetaGraph}> {
          ?ual <${DKG}batchId> "${kaId}"^^<${XSD}integer> ;
-           <${DKG}contentScopeVersion> ?scope ;
-           <${DKG}assertionVersion> ?version ;
-           <${DKG}publicTripleCount> ?publicCount ;
-           <${DKG}privateTripleCount> ?privateCount ;
-           <${DKG}assertionGraph> ?assertionGraph .
-         OPTIONAL { ?ual <${DKG}privateMerkleRoot> ?privateRoot }
-         OPTIONAL { ?ual <${DKG}subGraphName> ?subGraph }
+           <${DKG}contentScopeVersion> ?scope .
        }
-     } LIMIT 1`,
+     }`,
   );
-  if (result.type !== 'bindings' || result.bindings.length === 0) return null;
+  if (discriminator.type !== 'bindings' || discriminator.bindings.length === 0) {
+    return null;
+  }
 
-  const row = result.bindings[0];
-  const contentScopeVersion = Number(stripQuotes(row['scope'] ?? ''));
-  if (contentScopeVersion !== GRAPH_KA_CONTENT_SCOPE_VERSION) {
+  const discriminatorUals = new Set(
+    discriminator.bindings.map((row) => row['ual'] ?? '').filter(Boolean),
+  );
+  const discriminatorScopes = new Set(
+    discriminator.bindings.map((row) => row['scope'] ?? '').filter(Boolean),
+  );
+  if (discriminatorUals.size !== 1 || discriminatorScopes.size !== 1) {
+    throw new Error(`Conflicting graph-scoped discriminator for KC ${kaId} in cg ${cgId}`);
+  }
+  const ual = stripQuotes([...discriminatorUals][0]);
+  const contentScopeVersion = parseXsdIntegerLiteral(
+    [...discriminatorScopes][0],
+    'contentScopeVersion',
+    cgId,
+    kaId,
+  );
+  if (contentScopeVersion <= 1n) return null;
+  if (contentScopeVersion !== BigInt(GRAPH_KA_CONTENT_SCOPE_VERSION)) {
     throw new Error(
       `Unsupported content scope version ${contentScopeVersion} for KC ${kaId} in cg ${cgId}`,
     );
   }
-  const ual = stripQuotes(row['ual'] ?? '');
-  const assertionVersion = stripQuotes(row['version'] ?? '');
+  assertSafeIri(ual);
+
+  // Read the bounded metadata subject as predicate/object rows, then enforce
+  // exactly one distinct value for every required field. RDF set semantics
+  // collapse byte-identical duplicates while conflicting convergence rows stay
+  // visible and fail closed.
+  const metadata = await store.query(
+    `SELECT ?predicate ?object WHERE {
+       GRAPH <${labelMetaGraph}> {
+         <${ual}> ?predicate ?object .
+       }
+     }`,
+  );
+  if (metadata.type !== 'bindings') {
+    throw new Error(`Malformed graph-scoped metadata for KC ${kaId} in cg ${cgId}`);
+  }
+  const valuesByPredicate = new Map<string, Set<string>>();
+  for (const row of metadata.bindings) {
+    const predicate = row['predicate'] ?? '';
+    const object = row['object'] ?? '';
+    if (!predicate || !object) continue;
+    const values = valuesByPredicate.get(predicate) ?? new Set<string>();
+    values.add(object);
+    valuesByPredicate.set(predicate, values);
+  }
+  const requiredValue = (predicate: string, field: string): string => {
+    const values = valuesByPredicate.get(predicate);
+    if (!values || values.size !== 1) {
+      throw new Error(
+        `Graph-scoped ${field} must have exactly one value for KC ${kaId} in cg ${cgId}`,
+      );
+    }
+    return [...values][0];
+  };
+  const optionalValue = (predicate: string, field: string): string | undefined => {
+    const values = valuesByPredicate.get(predicate);
+    if (!values || values.size === 0) return undefined;
+    if (values.size !== 1) {
+      throw new Error(
+        `Graph-scoped ${field} must have at most one value for KC ${kaId} in cg ${cgId}`,
+      );
+    }
+    return [...values][0];
+  };
+
+  const status = stripQuotes(requiredValue(`${DKG}status`, 'status'));
+  if (status !== 'confirmed') return null;
+
+  const envelopeScopeVersion = parseXsdIntegerLiteral(
+    requiredValue(`${DKG}contentScopeVersion`, 'contentScopeVersion'),
+    'contentScopeVersion',
+    cgId,
+    kaId,
+  );
+  if (envelopeScopeVersion !== contentScopeVersion) {
+    throw new Error(`Conflicting graph-scoped content scope for KC ${kaId} in cg ${cgId}`);
+  }
+  const envelopeBatchId = parseXsdIntegerLiteral(
+    requiredValue(`${DKG}batchId`, 'batchId'),
+    'batchId',
+    cgId,
+    kaId,
+  );
+  if (envelopeBatchId !== kaId) {
+    throw new Error(`Graph-scoped batchId does not match KC ${kaId} in cg ${cgId}`);
+  }
+  const assertionVersion = parseXsdIntegerLiteral(
+    requiredValue(`${DKG}assertionVersion`, 'assertionVersion'),
+    'assertionVersion',
+    cgId,
+    kaId,
+  );
   const scope = createGraphKnowledgeAssetScope(ual, assertionVersion);
   const packedKaId = (BigInt(scope.agentAddress) << 96n) | BigInt(scope.kaNumber);
   if (scope.ual !== ual || packedKaId !== kaId) {
     throw new Error(`Graph-scoped KC identity does not match kaId ${kaId} in cg ${cgId}`);
   }
 
-  const publicTripleCount = Number(stripQuotes(row['publicCount'] ?? ''));
-  const privateTripleCount = Number(stripQuotes(row['privateCount'] ?? ''));
+  const publicTripleCount = safeGraphScopedCount(
+    requiredValue(`${DKG}publicTripleCount`, 'publicTripleCount'),
+    'publicTripleCount',
+    cgId,
+    kaId,
+  );
+  const privateTripleCount = safeGraphScopedCount(
+    requiredValue(`${DKG}privateTripleCount`, 'privateTripleCount'),
+    'privateTripleCount',
+    cgId,
+    kaId,
+  );
   if (
-    !Number.isSafeInteger(publicTripleCount)
-    || publicTripleCount < 0
-    || !Number.isSafeInteger(privateTripleCount)
-    || privateTripleCount < 0
-    || (publicTripleCount === 0 && privateTripleCount === 0)
+    publicTripleCount === 0
+    && privateTripleCount === 0
   ) {
     throw new Error(`Invalid graph-scoped content counts for KC ${kaId} in cg ${cgId}`);
   }
 
-  const metaSubGraph = stripQuotes(row['subGraph'] ?? '') || undefined;
+  const metaSubGraph = stripQuotes(
+    optionalValue(`${DKG}subGraphName`, 'subGraphName') ?? '',
+  ) || undefined;
   if (metaSubGraph && !validateSubGraphName(metaSubGraph).valid) {
     throw new Error(`Invalid graph-scoped sub-graph metadata for KC ${kaId} in cg ${cgId}`);
   }
@@ -477,7 +570,7 @@ async function extractGraphScopedV10KC(
   // Caller hints are only a legacy discovery optimization and must never move
   // an atomic KA to a different physical graph.
   const subGraphName = metaSubGraph;
-  const assertionGraph = row['assertionGraph'] ?? '';
+  const assertionGraph = requiredValue(`${DKG}assertionGraph`, 'assertionGraph');
   const expectedGraph = knowledgeAssetLayerGraphUri(
     cgName,
     MemoryLayer.VerifiableMemory,
@@ -488,7 +581,12 @@ async function extractGraphScopedV10KC(
     throw new Error(`Graph-scoped assertion graph mismatch for KC ${kaId} in cg ${cgId}`);
   }
 
-  const privateRootLiteral = stripQuotes(row['privateRoot'] ?? '');
+  const privateRootLiteral = stripQuotes(
+    optionalValue(`${DKG}privateMerkleRoot`, 'privateMerkleRoot') ?? '',
+  );
+  if (privateRootLiteral && !/^(?:0x)?[0-9a-fA-F]{64}$/.test(privateRootLiteral)) {
+    throw new Error(`Invalid graph-scoped private commitment for KC ${kaId} in cg ${cgId}`);
+  }
   const privateRoots = privateRootLiteral ? [parseHexBytes(privateRootLiteral)] : [];
   if (
     (privateTripleCount > 0 && (privateRoots.length !== 1 || privateRoots[0].length !== 32))
@@ -527,6 +625,40 @@ async function extractGraphScopedV10KC(
     privateRoots,
     leaves,
   };
+}
+
+function parseXsdIntegerLiteral(
+  literal: string,
+  field: string,
+  cgId: bigint,
+  kaId: bigint,
+): bigint {
+  const match = /^"([+-]?[0-9]+)"\^\^<http:\/\/www\.w3\.org\/2001\/XMLSchema#integer>$/.exec(literal);
+  if (!match) {
+    throw new Error(
+      `Graph-scoped ${field} is not a valid xsd:integer for KC ${kaId} in cg ${cgId}`,
+    );
+  }
+  try {
+    return BigInt(match[1]);
+  } catch {
+    throw new Error(
+      `Graph-scoped ${field} is not a valid xsd:integer for KC ${kaId} in cg ${cgId}`,
+    );
+  }
+}
+
+function safeGraphScopedCount(
+  literal: string,
+  field: string,
+  cgId: bigint,
+  kaId: bigint,
+): number {
+  const value = parseXsdIntegerLiteral(literal, field, cgId, kaId);
+  if (value < 0n || value > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new Error(`Invalid graph-scoped ${field} for KC ${kaId} in cg ${cgId}`);
+  }
+  return Number(value);
 }
 
 // ── Internal helpers ───────────────────────────────────────────────────
@@ -638,7 +770,7 @@ function stripQuotes(v: string): string {
  */
 function parseHexBytes(hex: string): Uint8Array {
   const h = hex.startsWith('0x') ? hex.slice(2) : hex;
-  if (h.length === 0 || h.length % 2 !== 0) {
+  if (h.length === 0 || h.length % 2 !== 0 || !/^[0-9a-fA-F]+$/.test(h)) {
     throw new Error(`Invalid hex literal length: "${hex}"`);
   }
   const out = new Uint8Array(h.length / 2);

--- a/packages/random-sampling/test/ka-extractor.test.ts
+++ b/packages/random-sampling/test/ka-extractor.test.ts
@@ -321,6 +321,17 @@ describe('extractV10KCFromStore — graph-scoped rootless KAs', () => {
     ]);
   });
 
+  it('rejects an overfull graph-scoped VM graph instead of proving extra data', async () => {
+    const store = new OxigraphStore();
+    await seedGraphScoped(store, [
+      { subject: 'urn:asset:counted', predicate: 'urn:p:value', object: '"committed"' },
+      { subject: 'urn:asset:counted', predicate: 'urn:p:extra', object: '"uncommitted"' },
+    ], { publicCountLiteral: `"1"^^<${XSD}integer>` });
+
+    await expect(extractV10KCFromStore(store, CG_ID, KA_ID))
+      .rejects.toBeInstanceOf(KCDataMissingError);
+  });
+
   it('rejects partial and conflicting confirmed V2 envelopes without legacy fallback', async () => {
     const partialStore = new OxigraphStore();
     await seedGraphScoped(partialStore, [

--- a/packages/random-sampling/test/ka-extractor.test.ts
+++ b/packages/random-sampling/test/ka-extractor.test.ts
@@ -618,6 +618,31 @@ describe('extractV10KCFromStore — error paths', () => {
     );
   });
 
+  it('rejects a malformed legacy private Merkle root before building proof leaves', async () => {
+    const fixture: KCFixture = {
+      cgId: 2n,
+      kaId: 8n,
+      ual: 'did:dkg:hardhat:31337/0xpub/8',
+      rootEntities: ['urn:legacy:private-root'],
+      publicTriples: [
+        { subject: 'urn:legacy:private-root', predicate: 'urn:p:k', object: '"v"' },
+      ],
+    };
+    await seedKC(store, fixture);
+
+    const metaGraph = contextGraphMetaUri('cg-2', '2');
+    await store.insert([{
+      subject: `${fixture.ual}/1`,
+      predicate: `${DKG}privateMerkleRoot`,
+      object: `"${'0g'.repeat(32)}"`,
+      graph: metaGraph,
+    }]);
+
+    await expect(
+      extractV10KCFromStore(store, fixture.cgId, fixture.kaId),
+    ).rejects.toThrow('Invalid hex literal');
+  });
+
   it('uses a typed integer literal so kaId 1 vs 10 do not collide (P-18 lesson, mirrored)', async () => {
     // Two KCs with different batchIds in the same _meta graph. If the
     // SPARQL accidentally string-prefix-matches "1" against "10", we'd

--- a/packages/random-sampling/test/ka-extractor.test.ts
+++ b/packages/random-sampling/test/ka-extractor.test.ts
@@ -33,6 +33,9 @@ import {
   contextGraphMetaUri,
   contextGraphLayerUri,
   contextGraphSubGraphUri,
+  createGraphKnowledgeAssetScope,
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  knowledgeAssetLayerGraphUri,
   MemoryLayer,
 } from '@origintrail-official/dkg-core';
 import {
@@ -133,6 +136,85 @@ async function seedKC(store: OxigraphStore, fixture: KCFixture): Promise<void> {
     fixture.publicTriples.map((t) => ({ ...t, graph: dataGraph })),
   );
 }
+
+describe('extractV10KCFromStore — graph-scoped rootless KAs', () => {
+  const CG_ID = 77n;
+  const CG_NAME = 'rootless-rs';
+  const AUTHOR = '0x1111111111111111111111111111111111111111';
+  const KA_NUMBER = 9n;
+  const KA_ID = (BigInt(AUTHOR) << 96n) | KA_NUMBER;
+  const UAL = `did:dkg:otp:20430/${AUTHOR}/${KA_NUMBER}`;
+
+  async function seedGraphScoped(
+    store: OxigraphStore,
+    publicTriples: Array<{ subject: string; predicate: string; object: string }>,
+    privateRoot?: Uint8Array,
+  ): Promise<string> {
+    await seedOntology(store, CG_NAME, CG_ID);
+    const scope = createGraphKnowledgeAssetScope(UAL, '2');
+    const vmGraph = knowledgeAssetLayerGraphUri(
+      CG_NAME,
+      MemoryLayer.VerifiableMemory,
+      scope,
+    );
+    const metaGraph = contextGraphMetaUri(CG_NAME);
+    const metadata: Quad[] = [
+      { subject: UAL, predicate: `${DKG}batchId`, object: `"${KA_ID}"^^<${XSD}integer>`, graph: metaGraph },
+      { subject: UAL, predicate: `${DKG}contentScopeVersion`, object: `"${GRAPH_KA_CONTENT_SCOPE_VERSION}"^^<${XSD}integer>`, graph: metaGraph },
+      { subject: UAL, predicate: `${DKG}assertionVersion`, object: '"2"^^<http://www.w3.org/2001/XMLSchema#integer>', graph: metaGraph },
+      { subject: UAL, predicate: `${DKG}publicTripleCount`, object: `"${publicTriples.length}"^^<${XSD}integer>`, graph: metaGraph },
+      { subject: UAL, predicate: `${DKG}privateTripleCount`, object: `"${privateRoot ? 1 : 0}"^^<${XSD}integer>`, graph: metaGraph },
+      { subject: UAL, predicate: `${DKG}assertionGraph`, object: vmGraph, graph: metaGraph },
+    ];
+    if (privateRoot) {
+      metadata.push({
+        subject: UAL,
+        predicate: `${DKG}privateMerkleRoot`,
+        object: `"${toHexNoPrefix(privateRoot)}"`,
+        graph: metaGraph,
+      });
+    }
+    await store.insert(metadata);
+    await store.insert(publicTriples.map((triple) => ({ ...triple, graph: vmGraph })));
+    return vmGraph;
+  }
+
+  it('reads the complete exact VM graph without discovering RDF roots', async () => {
+    const store = new OxigraphStore();
+    const privateRoot = new Uint8Array(32).fill(0x5a);
+    const triples = [
+      { subject: 'urn:any:one', predicate: 'urn:p:value', object: '"one"' },
+      { subject: 'urn:unrelated:two', predicate: 'urn:p:value', object: '"two"' },
+    ];
+    const vmGraph = await seedGraphScoped(store, triples, privateRoot);
+
+    const result = await extractV10KCFromStore(store, CG_ID, KA_ID);
+
+    expect(result.dataGraph).toBe(vmGraph);
+    expect(result.rootEntities).toEqual([]);
+    expect(result.triples).toHaveLength(2);
+    expect(result.privateRoots).toEqual([privateRoot]);
+    const expectedLeaves = [
+      ...triples.map((triple) => hashTripleV10(triple.subject, triple.predicate, triple.object)),
+      privateRoot,
+    ];
+    expect(new V10MerkleTree(result.leaves).root)
+      .toEqual(new V10MerkleTree(expectedLeaves).root);
+  });
+
+  it('supports a fully private KA with an empty public VM graph', async () => {
+    const store = new OxigraphStore();
+    const privateRoot = new Uint8Array(32).fill(0x33);
+    const vmGraph = await seedGraphScoped(store, [], privateRoot);
+
+    const result = await extractV10KCFromStore(store, CG_ID, KA_ID);
+
+    expect(result.dataGraph).toBe(vmGraph);
+    expect(result.triples).toEqual([]);
+    expect(result.rootEntities).toEqual([]);
+    expect(result.leaves).toEqual([privateRoot]);
+  });
+});
 
 describe('extractV10KCFromStore — happy path / publisher round-trip parity', () => {
   let store: OxigraphStore;

--- a/packages/random-sampling/test/ka-extractor.test.ts
+++ b/packages/random-sampling/test/ka-extractor.test.ts
@@ -145,10 +145,22 @@ describe('extractV10KCFromStore — graph-scoped rootless KAs', () => {
   const KA_ID = (BigInt(AUTHOR) << 96n) | KA_NUMBER;
   const UAL = `did:dkg:otp:20430/${AUTHOR}/${KA_NUMBER}`;
 
+  interface GraphScopedSeedOptions {
+    privateRoot?: Uint8Array;
+    privateRootLiteral?: string;
+    subGraphName?: string;
+    status?: string;
+    contentScopeLiteral?: string;
+    assertionVersionLiteral?: string;
+    publicCountLiteral?: string;
+    privateCountLiteral?: string;
+    omit?: 'assertionGraph';
+  }
+
   async function seedGraphScoped(
     store: OxigraphStore,
     publicTriples: Array<{ subject: string; predicate: string; object: string }>,
-    privateRoot?: Uint8Array,
+    options: GraphScopedSeedOptions = {},
   ): Promise<string> {
     await seedOntology(store, CG_NAME, CG_ID);
     const scope = createGraphKnowledgeAssetScope(UAL, '2');
@@ -156,21 +168,67 @@ describe('extractV10KCFromStore — graph-scoped rootless KAs', () => {
       CG_NAME,
       MemoryLayer.VerifiableMemory,
       scope,
+      options.subGraphName,
     );
     const metaGraph = contextGraphMetaUri(CG_NAME);
+    const privateRootLiteral = options.privateRootLiteral
+      ?? (options.privateRoot ? toHexNoPrefix(options.privateRoot) : undefined);
     const metadata: Quad[] = [
       { subject: UAL, predicate: `${DKG}batchId`, object: `"${KA_ID}"^^<${XSD}integer>`, graph: metaGraph },
-      { subject: UAL, predicate: `${DKG}contentScopeVersion`, object: `"${GRAPH_KA_CONTENT_SCOPE_VERSION}"^^<${XSD}integer>`, graph: metaGraph },
-      { subject: UAL, predicate: `${DKG}assertionVersion`, object: '"2"^^<http://www.w3.org/2001/XMLSchema#integer>', graph: metaGraph },
-      { subject: UAL, predicate: `${DKG}publicTripleCount`, object: `"${publicTriples.length}"^^<${XSD}integer>`, graph: metaGraph },
-      { subject: UAL, predicate: `${DKG}privateTripleCount`, object: `"${privateRoot ? 1 : 0}"^^<${XSD}integer>`, graph: metaGraph },
-      { subject: UAL, predicate: `${DKG}assertionGraph`, object: vmGraph, graph: metaGraph },
+      {
+        subject: UAL,
+        predicate: `${DKG}contentScopeVersion`,
+        object: options.contentScopeLiteral
+          ?? `"${GRAPH_KA_CONTENT_SCOPE_VERSION}"^^<${XSD}integer>`,
+        graph: metaGraph,
+      },
+      {
+        subject: UAL,
+        predicate: `${DKG}assertionVersion`,
+        object: options.assertionVersionLiteral ?? `"2"^^<${XSD}integer>`,
+        graph: metaGraph,
+      },
+      {
+        subject: UAL,
+        predicate: `${DKG}publicTripleCount`,
+        object: options.publicCountLiteral ?? `"${publicTriples.length}"^^<${XSD}integer>`,
+        graph: metaGraph,
+      },
+      {
+        subject: UAL,
+        predicate: `${DKG}privateTripleCount`,
+        object: options.privateCountLiteral
+          ?? `"${privateRootLiteral ? 1 : 0}"^^<${XSD}integer>`,
+        graph: metaGraph,
+      },
+      {
+        subject: UAL,
+        predicate: `${DKG}status`,
+        object: `"${options.status ?? 'confirmed'}"`,
+        graph: metaGraph,
+      },
     ];
-    if (privateRoot) {
+    if (options.omit !== 'assertionGraph') {
+      metadata.push({
+        subject: UAL,
+        predicate: `${DKG}assertionGraph`,
+        object: vmGraph,
+        graph: metaGraph,
+      });
+    }
+    if (options.subGraphName) {
+      metadata.push({
+        subject: UAL,
+        predicate: `${DKG}subGraphName`,
+        object: `"${options.subGraphName}"`,
+        graph: metaGraph,
+      });
+    }
+    if (privateRootLiteral) {
       metadata.push({
         subject: UAL,
         predicate: `${DKG}privateMerkleRoot`,
-        object: `"${toHexNoPrefix(privateRoot)}"`,
+        object: `"${privateRootLiteral}"`,
         graph: metaGraph,
       });
     }
@@ -186,7 +244,7 @@ describe('extractV10KCFromStore — graph-scoped rootless KAs', () => {
       { subject: 'urn:any:one', predicate: 'urn:p:value', object: '"one"' },
       { subject: 'urn:unrelated:two', predicate: 'urn:p:value', object: '"two"' },
     ];
-    const vmGraph = await seedGraphScoped(store, triples, privateRoot);
+    const vmGraph = await seedGraphScoped(store, triples, { privateRoot });
 
     const result = await extractV10KCFromStore(store, CG_ID, KA_ID);
 
@@ -205,7 +263,7 @@ describe('extractV10KCFromStore — graph-scoped rootless KAs', () => {
   it('supports a fully private KA with an empty public VM graph', async () => {
     const store = new OxigraphStore();
     const privateRoot = new Uint8Array(32).fill(0x33);
-    const vmGraph = await seedGraphScoped(store, [], privateRoot);
+    const vmGraph = await seedGraphScoped(store, [], { privateRoot });
 
     const result = await extractV10KCFromStore(store, CG_ID, KA_ID);
 
@@ -213,6 +271,99 @@ describe('extractV10KCFromStore — graph-scoped rootless KAs', () => {
     expect(result.triples).toEqual([]);
     expect(result.rootEntities).toEqual([]);
     expect(result.leaves).toEqual([privateRoot]);
+  });
+
+  it('ignores tentative graph-scoped metadata instead of proving future VM leaves', async () => {
+    const store = new OxigraphStore();
+    await seedGraphScoped(store, [
+      { subject: 'urn:future', predicate: 'urn:p:value', object: '"future"' },
+    ], { status: 'tentative' });
+
+    await expect(extractV10KCFromStore(store, CG_ID, KA_ID))
+      .rejects.toBeInstanceOf(KCNotFoundError);
+  });
+
+  it('uses authoritative named-subgraph metadata and ignores a stale caller hint', async () => {
+    const store = new OxigraphStore();
+    const triples = [
+      { subject: 'urn:research:item', predicate: 'urn:p:value', object: '"paper"' },
+    ];
+    const vmGraph = await seedGraphScoped(store, triples, { subGraphName: 'research' });
+
+    const result = await extractV10KCFromStore(store, CG_ID, KA_ID, 'stale-hint');
+
+    expect(result.subGraphName).toBe('research');
+    expect(result.dataGraph).toBe(vmGraph);
+    expect(result.triples.map((triple) => triple.subject)).toEqual(['urn:research:item']);
+  });
+
+  it('excludes graph-scoped post-publish trust stamps from the proof leaves', async () => {
+    const store = new OxigraphStore();
+    const committed = {
+      subject: 'urn:asset:trusted',
+      predicate: 'urn:p:value',
+      object: '"committed"',
+    };
+    const vmGraph = await seedGraphScoped(store, [committed]);
+    await store.insert([{
+      subject: committed.subject,
+      predicate: `${DKG}trustLevel`,
+      object: '"self-attested"',
+      graph: vmGraph,
+    }]);
+
+    const result = await extractV10KCFromStore(store, CG_ID, KA_ID);
+
+    expect(result.triples).toHaveLength(1);
+    expect(result.triples[0]).toMatchObject(committed);
+    expect(result.leaves).toEqual([
+      hashTripleV10(committed.subject, committed.predicate, committed.object),
+    ]);
+  });
+
+  it('rejects partial and conflicting confirmed V2 envelopes without legacy fallback', async () => {
+    const partialStore = new OxigraphStore();
+    await seedGraphScoped(partialStore, [
+      { subject: 'urn:partial', predicate: 'urn:p:value', object: '"partial"' },
+    ], { omit: 'assertionGraph' });
+    await expect(extractV10KCFromStore(partialStore, CG_ID, KA_ID))
+      .rejects.toThrow(/assertionGraph must have exactly one value/);
+
+    const conflictingStore = new OxigraphStore();
+    await seedGraphScoped(conflictingStore, [
+      { subject: 'urn:conflict', predicate: 'urn:p:value', object: '"conflict"' },
+    ]);
+    await conflictingStore.insert([{
+      subject: UAL,
+      predicate: `${DKG}assertionVersion`,
+      object: `"3"^^<${XSD}integer>`,
+      graph: contextGraphMetaUri(CG_NAME),
+    }]);
+    await expect(extractV10KCFromStore(conflictingStore, CG_ID, KA_ID))
+      .rejects.toThrow(/assertionVersion must have exactly one value/);
+  });
+
+  it('rejects non-xsd integer envelopes and malformed private commitments', async () => {
+    const malformedScopeStore = new OxigraphStore();
+    await seedGraphScoped(malformedScopeStore, [
+      { subject: 'urn:scope', predicate: 'urn:p:value', object: '"scope"' },
+    ], { contentScopeLiteral: `"2e0"^^<${XSD}integer>` });
+    await expect(extractV10KCFromStore(malformedScopeStore, CG_ID, KA_ID))
+      .rejects.toThrow(/contentScopeVersion is not a valid xsd:integer/);
+
+    const malformedCountStore = new OxigraphStore();
+    await seedGraphScoped(malformedCountStore, [
+      { subject: 'urn:count', predicate: 'urn:p:value', object: '"count"' },
+    ], { publicCountLiteral: `"1e0"^^<${XSD}integer>` });
+    await expect(extractV10KCFromStore(malformedCountStore, CG_ID, KA_ID))
+      .rejects.toThrow(/publicTripleCount is not a valid xsd:integer/);
+
+    const malformedRootStore = new OxigraphStore();
+    await seedGraphScoped(malformedRootStore, [], {
+      privateRootLiteral: '0g'.repeat(32),
+    });
+    await expect(extractV10KCFromStore(malformedRootStore, CG_ID, KA_ID))
+      .rejects.toThrow(/Invalid graph-scoped private commitment/);
   });
 });
 


### PR DESCRIPTION
## Summary

- reconstruct V2 Knowledge Assets from their exact UAL-derived VM graph instead of legacy root-entity traversal
- validate the constant-size content envelope, assertion graph, counts, private commitment, and canonical UAL before proving
- support fully private rootless KAs with zero public triples while retaining the legacy extractor as a mixed-fleet fallback

## Validation

- `pnpm --filter @origintrail-official/dkg-random-sampling test` — 81/81 passed
- `pnpm --filter @origintrail-official/dkg-random-sampling build` — passed

## Stack

Depends on #1715.