### PR TITLE
feat: update rootless KAs by graph identity

### DIFF
--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -12,7 +12,7 @@ import { createHash } from 'node:crypto';
 import {
   DKGNode, ProtocolRouter, GossipSubManager, TypedEventBus, DKGEvent,
   LibP2PNetwork, PeerResolver, StubNetworkStateRegistry,
-  PROTOCOL_ACCESS, PROTOCOL_PUBLISH, PROTOCOL_SYNC, PROTOCOL_SYNC_CHANGELOG, PROTOCOL_QUERY_REMOTE, PROTOCOL_STORAGE_ACK, PROTOCOL_STORAGE_ACK_V2, PROTOCOL_STORAGE_UPDATE_ACK, PROTOCOL_GET_CIPHERTEXT_CHUNK, PROTOCOL_VERIFY_PROPOSAL, PROTOCOL_JOIN_REQUEST,
+  PROTOCOL_ACCESS, PROTOCOL_PUBLISH, PROTOCOL_SYNC, PROTOCOL_SYNC_CHANGELOG, PROTOCOL_QUERY_REMOTE, PROTOCOL_STORAGE_ACK, PROTOCOL_STORAGE_ACK_V2, PROTOCOL_STORAGE_UPDATE_ACK, PROTOCOL_STORAGE_UPDATE_ACK_V2, PROTOCOL_GET_CIPHERTEXT_CHUNK, PROTOCOL_VERIFY_PROPOSAL, PROTOCOL_JOIN_REQUEST,
   PROTOCOL_NETWORK_IDENTITY,
   PROTOCOL_SWM_SENDER_KEY, PROTOCOL_SWM_UPDATE, PROTOCOL_SWM_SHARE_ACK, PROTOCOL_SWM_HOST_CATCHUP, PROTOCOL_MESSAGE,
   contextGraphPublishTopic, contextGraphWorkspaceTopic, contextGraphAppTopic, contextGraphUpdateTopic, contextGraphFinalizationTopic,
@@ -1512,6 +1512,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
                 this.router.unregister(PROTOCOL_STORAGE_ACK);
                 this.router.unregister(PROTOCOL_STORAGE_ACK_V2);
                 this.router.unregister(PROTOCOL_STORAGE_UPDATE_ACK);
+                this.router.unregister(PROTOCOL_STORAGE_UPDATE_ACK_V2);
                 this.log.warn(
                   attemptCtx,
                   `Unregistered V10 StorageACK handler: signer ${ackSignerWallet.address} ` +
@@ -1645,6 +1646,10 @@ export class LifecycleSyncMethods extends DKGAgentBase {
             // this, so an UPDATE-aware publisher gracefully falls back
             // (the dial fails as peer-unreachable against the quorum).
             this.messenger.register(PROTOCOL_STORAGE_UPDATE_ACK, async (data, peerIdStr) => {
+              const peerId = { toString: () => peerIdStr, toBytes: () => new Uint8Array() };
+              return ackHandler.updateHandler(data, peerId);
+            });
+            this.messenger.register(PROTOCOL_STORAGE_UPDATE_ACK_V2, async (data, peerIdStr) => {
               const peerId = { toString: () => peerIdStr, toBytes: () => new Uint8Array() };
               return ackHandler.updateHandler(data, peerId);
             });

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -48,6 +48,7 @@ import {
   GRAPH_KA_CONTENT_SCOPE_VERSION,
   LegacyKnowledgeAssetReadOnlyError,
   createGraphKnowledgeAssetScope,
+  knowledgeAssetLayerGraphUri,
   WORKSPACE_AGENT_ENCRYPTION_KEY_ALGORITHM_X25519,
   WORKSPACE_RECIPIENT_ENCRYPTION_KEY_PURPOSE,
   computeWorkspaceAgentEncryptionKeyProofPayload,
@@ -1785,7 +1786,18 @@ export class PublishMethods extends DKGAgentBase {
     onPhase?.('broadcast', 'start');
     if (result.onChainResult && result.publicQuads) {
       try {
-        const dataGraph = `did:dkg:context-graph:${contextGraphId}`;
+        const isGraphUpdate = opts?.contentScopeVersion === GRAPH_KA_CONTENT_SCOPE_VERSION;
+        const graphScope = isGraphUpdate
+          ? createGraphKnowledgeAssetScope(opts?.kaUal ?? '', opts?.assertionVersion ?? '')
+          : undefined;
+        const dataGraph = graphScope
+          ? knowledgeAssetLayerGraphUri(
+              contextGraphId,
+              MemoryLayer.VerifiableMemory,
+              graphScope,
+              opts?.subGraphName,
+            )
+          : `did:dkg:context-graph:${contextGraphId}`;
         const nquadsStr = result.publicQuads
           .map((q) => `<${q.subject}> <${q.predicate}> ${q.object.startsWith('"') ? q.object : `<${q.object}>`} <${dataGraph}> .`)
           .join('\n');
@@ -1794,11 +1806,13 @@ export class PublishMethods extends DKGAgentBase {
           contextGraphId: contextGraphId,
           batchId: kaId,
           nquads: nquadsBytes,
-          manifest: result.kaManifest.map((m) => ({
-            rootEntity: m.rootEntity,
-            privateMerkleRoot: m.privateMerkleRoot,
-            privateTripleCount: m.privateTripleCount ?? 0,
-          })),
+          manifest: graphScope
+            ? []
+            : result.kaManifest.map((m) => ({
+                rootEntity: m.rootEntity,
+                privateMerkleRoot: m.privateMerkleRoot,
+                privateTripleCount: m.privateTripleCount ?? 0,
+              })),
           publisherPeerId: this.node.peerId.toString(),
           publisherAddress: result.onChainResult.publisherAddress,
           txHash: result.onChainResult.txHash,
@@ -1806,6 +1820,19 @@ export class PublishMethods extends DKGAgentBase {
           newMerkleRoot: result.merkleRoot,
           timestampMs: Date.now(),
           operationId: ctx.operationId,
+          ...(graphScope
+            ? {
+                contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+                kaUal: graphScope.ual,
+                assertionVersion: graphScope.assertionVersion,
+                publicTripleCount: opts?.publicTripleCount ?? 0,
+                ...(opts?.privateMerkleRoot
+                  ? { privateMerkleRoot: opts.privateMerkleRoot }
+                  : {}),
+                privateTripleCount: opts?.privateTripleCount ?? 0,
+                subGraphName: opts?.subGraphName,
+              }
+            : {}),
         });
         const topic = contextGraphUpdateTopic(contextGraphId);
         await this.gossip.publish(topic, message);

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1983,10 +1983,15 @@ export class DKGAgent extends DKGAgentBase {
           `Register the CG on-chain via ContextGraphs.createContextGraph first.`,
         );
       }
-      if (!Number.isInteger(params.merkleLeafCount) || params.merkleLeafCount < 1) {
+      const allowsEmptyPublicTree = params.ackMode.kind === 'curated-catalog';
+      if (
+        !Number.isInteger(params.merkleLeafCount)
+        || params.merkleLeafCount < 0
+        || (params.merkleLeafCount === 0 && !allowsEmptyPublicTree)
+      ) {
         throw new Error(
-          `V10 ACK collection requires a positive integer merkleLeafCount; got ${params.merkleLeafCount}. ` +
-          'Publishers must pass the V10 flat-KC leaf count computed by V10MerkleTree.',
+          `V10 ACK collection requires a positive integer merkleLeafCount for public KAs ` +
+          `(zero is valid only for curated-catalog ACKs); got ${params.merkleLeafCount}.`,
         );
       }
 
@@ -2125,6 +2130,12 @@ export class DKGAgent extends DKGAgentBase {
       stagingQuads?: Uint8Array;
       swmGraphId?: string;
       subGraphName?: string;
+      contentScopeVersion?: number;
+      kaUal?: string;
+      assertionVersion?: string;
+      publicTripleCount?: number;
+      privateMerkleRoot?: Uint8Array;
+      privateTripleCount?: number;
     }): Promise<V10CoreNodeACK[]> => {
       // The TARGET cgId for the digest is the on-chain numeric id the
       // adapter resolved (`params.contextGraphId`). Reject non-numeric /
@@ -2143,9 +2154,15 @@ export class DKGAgent extends DKGAgentBase {
           `V10 UPDATE ACK collection requires a positive on-chain context graph id; got ${cgIdBigInt}.`,
         );
       }
-      if (!Number.isInteger(params.newMerkleLeafCount) || params.newMerkleLeafCount < 1) {
+      const allowsEmptyPublicTree = params.isEncryptedPayload === true;
+      if (
+        !Number.isInteger(params.newMerkleLeafCount)
+        || params.newMerkleLeafCount < 0
+        || (params.newMerkleLeafCount === 0 && !allowsEmptyPublicTree)
+      ) {
         throw new Error(
-          `V10 UPDATE ACK collection requires a positive integer newMerkleLeafCount; got ${params.newMerkleLeafCount}.`,
+          `V10 UPDATE ACK collection requires a positive integer newMerkleLeafCount for public KAs ` +
+          `(zero is valid only for curated encrypted updates); got ${params.newMerkleLeafCount}.`,
         );
       }
 
@@ -2198,6 +2215,12 @@ export class DKGAgent extends DKGAgentBase {
         // OT-RFC-49 / WS-D — stamp `UpdateIntent.isEncryptedPayload` for a
         // curated update so cores rebuild/verify/persist the inline catalog.
         isEncryptedPayload: params.isEncryptedPayload,
+        contentScopeVersion: params.contentScopeVersion,
+        kaUal: params.kaUal,
+        assertionVersion: params.assertionVersion,
+        publicTripleCount: params.publicTripleCount,
+        privateMerkleRoot: params.privateMerkleRoot,
+        privateTripleCount: params.privateTripleCount,
       });
       return result.acks;
     };

--- a/packages/agent/test/v10-ack-provider-wiring.test.ts
+++ b/packages/agent/test/v10-ack-provider-wiring.test.ts
@@ -38,6 +38,7 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { MockChainAdapter } from '@origintrail-official/dkg-chain';
+import { decodeKAUpdateRequest } from '@origintrail-official/dkg-core';
 import { ethers } from 'ethers';
 // Codex review feedback: the chain package exports the verifier
 // result type as `VerifyACKIdentityResult`; `ACKVerifyResult` is the
@@ -335,6 +336,101 @@ describe('DKGAgent.createV10ACKProvider — structured ACK verifier wiring (PR #
       burnTokenIds: [],
       newMerkleLeafCount: 0,
     })).rejects.toThrow('zero is valid only for curated encrypted updates');
+  });
+
+  it('forwards the complete graph-scoped envelope to the update ACK collector', async () => {
+    const boot = await bootProviderAgent();
+    agent = boot.agent;
+    const provider = boot.internals.createV10UpdateACKProvider('test-cg') as V10UpdateACKProvider;
+    const privateRoot = new Uint8Array(32).fill(7);
+
+    await provider({
+      kaId: 9n,
+      contextGraphId: '42',
+      preUpdateMerkleRootCount: 1n,
+      newMerkleRoot: new Uint8Array(32).fill(3),
+      newByteSize: 10n,
+      newTokenAmount: 1n,
+      mintAmount: 0n,
+      burnTokenIds: [],
+      newMerkleLeafCount: 1,
+      contentScopeVersion: 2,
+      kaUal: 'did:dkg:mock:31337/0x1111111111111111111111111111111111111111/9',
+      assertionVersion: '2',
+      publicTripleCount: 4,
+      privateMerkleRoot: privateRoot,
+      privateTripleCount: 5,
+      subGraphName: 'curated',
+    });
+
+    expect(capturedUpdateCollectParams).toHaveLength(1);
+    expect(capturedUpdateCollectParams[0]).toEqual(expect.objectContaining({
+      contentScopeVersion: 2,
+      kaUal: 'did:dkg:mock:31337/0x1111111111111111111111111111111111111111/9',
+      assertionVersion: '2',
+      publicTripleCount: 4,
+      privateMerkleRoot: privateRoot,
+      privateTripleCount: 5,
+      subGraphName: 'curated',
+    }));
+  });
+
+  it('broadcasts the complete graph-scoped update envelope', async () => {
+    const published: Uint8Array[] = [];
+    const author = '0x1111111111111111111111111111111111111111';
+    const kaUal = `did:dkg:otp:20430/${author}/7`;
+    const publicQuads = [{
+      subject: 'urn:entity:a', predicate: 'urn:p:value', object: '"new"', graph: '',
+    }];
+    const publisherUpdate = vi.fn(async () => ({
+      status: 'confirmed',
+      onChainResult: {
+        publisherAddress: author,
+        txHash: `0x${'ab'.repeat(32)}`,
+        blockNumber: 20,
+      },
+      publicQuads,
+      kaManifest: [],
+      merkleRoot: new Uint8Array(32).fill(4),
+    }));
+    const agentLike = {
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+      getContextGraphOnChainId: vi.fn(async () => '42'),
+      createV10UpdateACKProvider: vi.fn(() => undefined),
+      node: { peerId: { toString: () => 'peer-1' } },
+      publisher: { updateKnowledgeAssetFromSharedMemory: publisherUpdate },
+      _resolveEncryptInlinePayload: vi.fn(async () => undefined),
+      _resolveEncryptInlineChunked: vi.fn(async () => undefined),
+      gossip: { publish: async (_topic: string, data: Uint8Array) => { published.push(data); } },
+    } as any;
+
+    await (DKGAgent.prototype as any).update.call(
+      agentLike,
+      7n,
+      'public-cg',
+      publicQuads,
+      undefined,
+      {
+        contentScopeVersion: 2,
+        kaUal,
+        assertionVersion: '2',
+        publicTripleCount: 1,
+        privateTripleCount: 0,
+        subGraphName: 'nested',
+      },
+    );
+
+    expect(published).toHaveLength(1);
+    const decoded = decodeKAUpdateRequest(published[0]);
+    expect(decoded).toMatchObject({
+      contentScopeVersion: 2,
+      kaUal,
+      assertionVersion: '2',
+      publicTripleCount: 1,
+      privateTripleCount: 0,
+      subGraphName: 'nested',
+    });
+    expect(decoded.manifest).toEqual([]);
   });
 
   it('passes ackSendTimeoutMs through publish and update ACK provider sendP2P closures', async () => {

--- a/packages/agent/test/v10-ack-provider-wiring.test.ts
+++ b/packages/agent/test/v10-ack-provider-wiring.test.ts
@@ -43,6 +43,10 @@ import { ethers } from 'ethers';
 // result type as `VerifyACKIdentityResult`; `ACKVerifyResult` is the
 // publisher-side mirror (same shape, different export site).
 import type { VerifyACKIdentityResult } from '@origintrail-official/dkg-chain';
+import type {
+  V10ACKProviderObject,
+  V10UpdateACKProvider,
+} from '@origintrail-official/dkg-publisher';
 import { DKGAgent } from '../src/index.js';
 
 /**
@@ -51,6 +55,8 @@ import { DKGAgent } from '../src/index.js';
  */
 const capturedAckCollectorDeps: unknown[] = [];
 const capturedStorageACKHandlerConfigs: unknown[] = [];
+const capturedPublishCollectParams: unknown[] = [];
+const capturedUpdateCollectParams: unknown[] = [];
 
 vi.mock('@origintrail-official/dkg-publisher', async () => {
   const actual = await vi.importActual<typeof import('@origintrail-official/dkg-publisher')>(
@@ -66,11 +72,15 @@ vi.mock('@origintrail-official/dkg-publisher', async () => {
       constructor(deps: unknown) {
         capturedAckCollectorDeps.push(deps);
       }
-      // Required for the agent's outer closure shape — never called
-      // in this file, but TypeScript's structural matching expects
-      // the surface to exist.
-      async collect(): Promise<never> {
-        throw new Error('CapturingACKCollector.collect should not be invoked in wiring tests');
+      // Capture calls made through the returned provider closures so wiring
+      // tests can pin the agent-side validation boundary as well as deps.
+      async collect(params: unknown): Promise<{ acks: [] }> {
+        capturedPublishCollectParams.push(params);
+        return { acks: [] };
+      }
+      async collectUpdate(params: unknown): Promise<{ acks: [] }> {
+        capturedUpdateCollectParams.push(params);
+        return { acks: [] };
       }
     },
     StorageACKHandler: class CapturingStorageACKHandler {
@@ -172,6 +182,8 @@ describe('DKGAgent.createV10ACKProvider — structured ACK verifier wiring (PR #
   beforeEach(() => {
     capturedAckCollectorDeps.length = 0;
     capturedStorageACKHandlerConfigs.length = 0;
+    capturedPublishCollectParams.length = 0;
+    capturedUpdateCollectParams.length = 0;
   });
 
   afterEach(async () => {
@@ -265,6 +277,64 @@ describe('DKGAgent.createV10ACKProvider — structured ACK verifier wiring (PR #
       42n,
     );
     expect(verdict).toBe(false);
+  });
+
+  it('allows zero public Merkle leaves only for curated publish and update ACK modes', async () => {
+    const boot = await bootProviderAgent();
+    agent = boot.agent;
+    const internals = boot.internals;
+    const publishProvider = internals.createV10ACKProvider('test-cg') as V10ACKProviderObject;
+    const updateProvider = internals.createV10UpdateACKProvider('test-cg') as V10UpdateACKProvider;
+    const root = new Uint8Array(32);
+
+    await expect(publishProvider({
+      merkleRoot: root,
+      contextGraphId: '42',
+      kaCount: 1,
+      rootEntities: [],
+      publicByteSize: 1n,
+      merkleLeafCount: 0,
+      stagingQuads: new Uint8Array([1]),
+      ackMode: {
+        kind: 'curated-catalog',
+        catalogCommitment: { catalogRoot: root, catalogLeafCount: 1 },
+      },
+    })).resolves.toEqual([]);
+    await expect(updateProvider({
+      kaId: 1n,
+      contextGraphId: '42',
+      preUpdateMerkleRootCount: 1n,
+      newMerkleRoot: root,
+      newByteSize: 1n,
+      newTokenAmount: 1n,
+      mintAmount: 0n,
+      burnTokenIds: [],
+      newMerkleLeafCount: 0,
+      isEncryptedPayload: true,
+    })).resolves.toEqual([]);
+
+    expect(capturedPublishCollectParams).toHaveLength(1);
+    expect(capturedUpdateCollectParams).toHaveLength(1);
+    await expect(publishProvider({
+      merkleRoot: root,
+      contextGraphId: '42',
+      kaCount: 1,
+      rootEntities: [],
+      publicByteSize: 0n,
+      merkleLeafCount: 0,
+      ackMode: { kind: 'public' },
+    })).rejects.toThrow('zero is valid only for curated-catalog ACKs');
+    await expect(updateProvider({
+      kaId: 1n,
+      contextGraphId: '42',
+      preUpdateMerkleRootCount: 1n,
+      newMerkleRoot: root,
+      newByteSize: 0n,
+      newTokenAmount: 1n,
+      mintAmount: 0n,
+      burnTokenIds: [],
+      newMerkleLeafCount: 0,
+    })).rejects.toThrow('zero is valid only for curated encrypted updates');
   });
 
   it('passes ackSendTimeoutMs through publish and update ACK provider sendP2P closures', async () => {

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -271,6 +271,8 @@ export interface KAUpdateVerification {
   blockNumber?: number;
   /** The transaction index within the block (for deterministic same-block ordering). */
   txIndex?: number;
+  /** Chain-truth Merkle-root array length after this update. */
+  merkleRootCount?: bigint;
 }
 
 export interface ChainEvent {

--- a/packages/chain/src/evm-adapter-publish.ts
+++ b/packages/chain/src/evm-adapter-publish.ts
@@ -326,15 +326,49 @@ export class PublishMethods extends EVMChainAdapterBase {
 
       if (!onChainMerkleRoot) return { verified: false };
 
-      // Check publisher address: try V10 storage first, then V9
+      // Read the V10 root history at the receipt block, not latest. Besides
+      // producing the post-update assertion index, this prevents a later
+      // update by another publisher from making verification of this older,
+      // otherwise-valid transaction fail. The block tag excludes future
+      // blocks; matching the event root selects this update when the block
+      // contains multiple updates for the same KA.
       let onChainPublisher: string | undefined;
+      let merkleRootCount: bigint | undefined;
       if (this.contracts.knowledgeAssetStorage) {
         try {
-          onChainPublisher = await this.readContract(
-            this.contracts.knowledgeAssetStorage, 'kas.getLatestMerkleRootPublisher',
-            'getLatestMerkleRootPublisher', batchId,
-          );
-        } catch { /* not found in V10 storage */ }
+          const roots = await this.readContract(
+            this.contracts.knowledgeAssetStorage,
+            'kas.getMerkleRootsAtUpdateBlock',
+            'getMerkleRoots',
+            batchId,
+            { blockTag: receipt.blockNumber },
+          ) as Array<{ publisher?: string; merkleRoot?: string } | readonly unknown[]>;
+          let matchedIndex = -1;
+          for (let i = roots.length - 1; i >= 0; i--) {
+            const root = roots[i] as { publisher?: string; merkleRoot?: string };
+            const rootPublisher = root.publisher ?? String((root as readonly unknown[])[0] ?? '');
+            const rootValue = root.merkleRoot ?? String((root as readonly unknown[])[1] ?? '');
+            if (
+              rootPublisher.toLowerCase() === publisherAddress.toLowerCase()
+              && rootValue.toLowerCase() === ethers.hexlify(onChainMerkleRoot).toLowerCase()
+            ) {
+              matchedIndex = i;
+              onChainPublisher = rootPublisher;
+              break;
+            }
+          }
+          if (roots.length > 0) {
+            merkleRootCount = BigInt(matchedIndex >= 0 ? matchedIndex + 1 : roots.length);
+          }
+        } catch { /* optional historical V10 view */ }
+        if (!onChainPublisher) {
+          try {
+            onChainPublisher = await this.readContract(
+              this.contracts.knowledgeAssetStorage, 'kas.getLatestMerkleRootPublisher',
+              'getLatestMerkleRootPublisher', batchId,
+            );
+          } catch { /* not found in V10 storage */ }
+        }
       }
       if ((!onChainPublisher || onChainPublisher === ethers.ZeroAddress) && this.contracts.knowledgeAssetsStorage) {
         try {
@@ -353,6 +387,7 @@ export class PublishMethods extends EVMChainAdapterBase {
         onChainMerkleRoot,
         blockNumber: receipt.blockNumber,
         txIndex: receipt.index,
+        merkleRootCount,
       };
     } catch {
       return { verified: false };

--- a/packages/chain/src/evm-adapter-publish.ts
+++ b/packages/chain/src/evm-adapter-publish.ts
@@ -357,20 +357,22 @@ export class PublishMethods extends EVMChainAdapterBase {
               break;
             }
           }
-          if (roots.length > 0) {
-            merkleRootCount = BigInt(matchedIndex >= 0 ? matchedIndex + 1 : roots.length);
+          if (matchedIndex < 0) {
+            return { verified: false };
           }
-        } catch { /* optional historical V10 view */ }
-        if (!onChainPublisher) {
-          try {
-            onChainPublisher = await this.readContract(
-              this.contracts.knowledgeAssetStorage, 'kas.getLatestMerkleRootPublisher',
-              'getLatestMerkleRootPublisher', batchId,
-            );
-          } catch { /* not found in V10 storage */ }
+          merkleRootCount = BigInt(matchedIndex + 1);
+        } catch {
+          // A latest-state fallback can authenticate a historical receipt with
+          // a different publisher/root after a later update. V10 verification
+          // therefore fails closed when the receipt-block view is unavailable.
+          return { verified: false };
         }
       }
-      if ((!onChainPublisher || onChainPublisher === ethers.ZeroAddress) && this.contracts.knowledgeAssetsStorage) {
+      if (
+        !this.contracts.knowledgeAssetStorage
+        && (!onChainPublisher || onChainPublisher === ethers.ZeroAddress)
+        && this.contracts.knowledgeAssetsStorage
+      ) {
         try {
           onChainPublisher = await this.readContract(
             this.contracts.knowledgeAssetsStorage, 'kasV9.getBatchPublisher',

--- a/packages/chain/src/mock-adapter.ts
+++ b/packages/chain/src/mock-adapter.ts
@@ -74,6 +74,8 @@ export class MockChainAdapter implements ChainAdapter {
     kaCount: number;
     /** V10 flat-KC merkle leaf count (sorted + deduped). 0 for legacy V8 entries. */
     merkleLeafCount: number;
+    /** Number of committed Merkle roots, including the initial publish. */
+    merkleRootCount: bigint;
     /** Publisher EOA from `createKnowledgeAssets`; default to mock signer for V8 paths. */
     publisherAddress: string;
     /**
@@ -350,6 +352,7 @@ export class MockChainAdapter implements ChainAdapter {
     if (collection) {
       collection.merkleRoot = params.newMerkleRoot;
       collection.merkleLeafCount = params.newMerkleLeafCount;
+      collection.merkleRootCount += 1n;
     }
     const hintedPublisherAddress = params.publisherAddress
       ? ethers.getAddress(params.publisherAddress)
@@ -366,6 +369,7 @@ export class MockChainAdapter implements ChainAdapter {
       publisherAddress,
       txHash,
       txIndex,
+      merkleRootCount: collection?.merkleRootCount?.toString(),
     });
 
     return {
@@ -388,6 +392,9 @@ export class MockChainAdapter implements ChainAdapter {
       onChainMerkleRoot: fromHex(match.data.newMerkleRoot as string),
       blockNumber: match.blockNumber,
       txIndex: typeof match.data.txIndex === 'number' ? match.data.txIndex : 0,
+      merkleRootCount: match.data.merkleRootCount
+        ? BigInt(String(match.data.merkleRootCount))
+        : undefined,
     };
   }
 
@@ -399,6 +406,7 @@ export class MockChainAdapter implements ChainAdapter {
       merkleRoot: params.merkleRoot,
       kaCount: params.knowledgeAssetsCount,
       merkleLeafCount: 0,
+      merkleRootCount: 1n,
       publisherAddress: this.signerAddress,
       // Legacy V8 path — no attestation, mirror the on-chain `address(0)`.
       authorAddress: ethers.ZeroAddress,
@@ -1494,6 +1502,7 @@ export class MockChainAdapter implements ChainAdapter {
       merkleRoot: params.merkleRoot,
       kaCount: params.knowledgeAssetsAmount,
       merkleLeafCount: params.merkleLeafCount,
+      merkleRootCount: 1n,
       publisherAddress,
       authorAddress: ethers.getAddress(params.author.address),
       cgId: params.contextGraphId,
@@ -1705,6 +1714,7 @@ export class MockChainAdapter implements ChainAdapter {
       merkleRoot: fromHex(input.merkleRootHex),
       kaCount: input.chunks.length,
       merkleLeafCount: input.merkleLeafCount ?? input.chunks.length,
+      merkleRootCount: 1n,
       publisherAddress: input.publisherAddress ?? this.signerAddress,
       // `__registerKC` is a Random-Sampling test bridge that bypasses the
       // V10 publish path entirely; no attestation is signed, so mirror

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -48,6 +48,63 @@ it('rejects an explicitly invalid receipt deadline at the adapter boundary', () 
     .toThrow(/receiptTimeoutMs must be a finite number >= 1000/);
 });
 
+describe('EVMChainAdapter historical KA update verification', () => {
+  const kaId = 42n;
+  const publisher = '0x1111111111111111111111111111111111111111';
+  const storageAddress = '0x2222222222222222222222222222222222222222';
+  const root = ethers.keccak256(ethers.toUtf8Bytes('historical-update'));
+  const iface = new Interface([
+    'event KnowledgeAssetUpdated(uint256 indexed id, address indexed author, string updateOperationId, bytes32 merkleRoot, uint256 byteSize, uint96 tokenAmount)',
+  ]);
+
+  function adapterWithHistoricalRead(
+    roots: unknown[] | Error,
+  ): { adapter: EVMChainAdapter; latestRead: ReturnType<typeof recorder> } {
+    const adapter: any = new EVMChainAdapter(minimalConfig());
+    adapter.initialized = true;
+    adapter.init = async () => {};
+    const encoded = iface.encodeEventLog(
+      iface.getEvent('KnowledgeAssetUpdated')!,
+      [kaId, publisher, 'op', root, 10n, 1n],
+    );
+    adapter.getTransactionReceiptWithFailover = async () => ({
+      status: 1,
+      blockNumber: 77,
+      index: 2,
+      logs: [{ address: storageAddress, topics: encoded.topics, data: encoded.data }],
+    });
+    adapter.contracts.knowledgeAssetStorage = {
+      getAddress: async () => storageAddress,
+      interface: iface,
+    };
+    const latestRead = recorder(async () => publisher);
+    adapter.readContract = async (
+      _contract: unknown,
+      _label: string,
+      method: string,
+    ) => {
+      if (method === 'getMerkleRoots') {
+        if (roots instanceof Error) throw roots;
+        return roots;
+      }
+      if (method === 'getLatestMerkleRootPublisher') return latestRead();
+      throw new Error(`unexpected method ${method}`);
+    };
+    return { adapter, latestRead };
+  }
+
+  it.each([
+    ['receipt-block history has no matching publisher/root', [{ publisher, merkleRoot: ethers.ZeroHash }]],
+    ['receipt-block history cannot be read', new Error('archive state unavailable')],
+  ])('fails closed when %s', async (_label, historicalResult) => {
+    const { adapter, latestRead } = adapterWithHistoricalRead(historicalResult as unknown[] | Error);
+
+    await expect(adapter.verifyKAUpdate('0xreceipt', kaId, publisher))
+      .resolves.toEqual({ verified: false });
+    expect(latestRead.calls).toHaveLength(0);
+  });
+});
+
 describe('EVMChainAdapter getIdentityIdForAddress cache', () => {
   const ADDR = '0x00000000000000000000000000000000000000a1';
   const ADDR2 = '0x00000000000000000000000000000000000000a2';

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -159,6 +159,15 @@ export const PROTOCOL_STORAGE_ACK_V2 = '/dkg/10.0.2/storage-ack';
 export const PROTOCOL_STORAGE_UPDATE_ACK = '/dkg/10.0.1/storage-update-ack';
 
 /**
+ * Graph-scoped UPDATE StorageACK protocol. V1 update responders interpret
+ * `subGraphName` using the legacy entity-root layout and do not validate the
+ * graph-scoped content envelope. Keep V2 on a distinct capability so a
+ * rootless update can never be acknowledged by a peer that silently ignores
+ * its scope/version fields.
+ */
+export const PROTOCOL_STORAGE_UPDATE_ACK_V2 = '/dkg/10.0.2/storage-update-ack';
+
+/**
  * OT-RFC-38 LU-11 / OT-RFC-39 — point-to-point sync verb for one
  * curated-CG ciphertext chunk identified by (cgId, batchId,
  * chunkIndex). Used by late-joining hosting cores (and any

--- a/packages/core/src/proto/ka-update.ts
+++ b/packages/core/src/proto/ka-update.ts
@@ -42,6 +42,7 @@ export const KAUpdateRequestSchema = new Type('KAUpdateRequest')
   .add(new Field('publicTripleCount', 15, 'uint32'))
   .add(new Field('privateMerkleRoot', 16, 'bytes'))
   .add(new Field('privateTripleCount', 17, 'uint32'))
+  .add(new Field('subGraphName', 18, 'string'))
   .add(KAUpdateManifestEntrySchema);
 
 type Long = { low: number; high: number; unsigned: boolean };
@@ -78,6 +79,8 @@ export interface KAUpdateRequestMsg {
   privateMerkleRoot?: Uint8Array;
   /** Number of private RDF triples committed by privateMerkleRoot. */
   privateTripleCount?: number;
+  /** Optional named sub-graph containing this KA. */
+  subGraphName?: string;
 }
 
 function toBigInt(v: string | number | bigint | Long | unknown): bigint {

--- a/packages/core/test/proto-ka-content-scope.test.ts
+++ b/packages/core/test/proto-ka-content-scope.test.ts
@@ -51,10 +51,12 @@ describe('rootless KA graph scope wire contract', () => {
       publicTripleCount: 1_000,
       privateMerkleRoot: PRIVATE_ROOT,
       privateTripleCount: 11,
+      subGraphName: 'updates',
     }));
 
     expect(decoded.kaUal).toBe(UAL);
     expect(decoded.manifest).toEqual([]);
+    expect(decoded.subGraphName).toBe('updates');
     expectGraphScope(decoded);
   });
 
@@ -150,10 +152,12 @@ describe('rootless KA graph scope wire contract', () => {
       publicTripleCount: 1_000,
       privateMerkleRoot: PRIVATE_ROOT,
       privateTripleCount: 11,
+      subGraphName: 'updates',
     }));
 
     expect(decoded.kaUal).toBe(UAL);
     expect(decoded.manifest).toEqual([]);
+    expect(decoded.subGraphName).toBe('updates');
     expectGraphScope(decoded);
   });
 

--- a/packages/publisher/src/ack-collector.ts
+++ b/packages/publisher/src/ack-collector.ts
@@ -280,9 +280,20 @@ export class ACKCollector {
     } = ctx;
 
     const log = this.deps.log ?? (() => {});
-    if (!Number.isInteger(params.merkleLeafCount) || params.merkleLeafCount < 1) {
+    const ackMode = params.ackMode ?? { kind: 'public' as const };
+    // Curated KAs are challenged against their public catalog commitment,
+    // not the private assertion's public-leaf tree. The lifecycle contract
+    // consequently permits merkleLeafCount=0 for curated KAs while rejecting
+    // it for public KAs. Keep that distinction on the ACK wire too so a fully
+    // private curated KA does not need a synthetic public placeholder triple.
+    if (
+      !Number.isInteger(params.merkleLeafCount)
+      || params.merkleLeafCount < 0
+      || (params.merkleLeafCount === 0 && ackMode.kind !== 'curated-catalog')
+    ) {
       throw new Error(
-        `ACK collection failed: merkleLeafCount must be a positive integer, got ${params.merkleLeafCount}`,
+        `ACK collection failed: merkleLeafCount must be positive for public KAs ` +
+          `(zero is valid only for curated-catalog ACKs), got ${params.merkleLeafCount}`,
       );
     }
     if (params.kaCount !== 1) {
@@ -290,7 +301,6 @@ export class ACKCollector {
         `ACK collection failed: V10 publish requires exactly one Knowledge Asset (kaCount=1); got ${params.kaCount}`,
       );
     }
-    const ackMode = params.ackMode ?? { kind: 'public' as const };
     const privateMerkleRoots = ackMode.kind === 'folded-private'
       ? ackMode.privateMerkleRoots
       : [];
@@ -486,6 +496,12 @@ export class ACKCollector {
     stagingQuads?: Uint8Array;
     isEncryptedPayload?: boolean;
     ackProtocolVersion?: number;
+    contentScopeVersion?: number;
+    kaUal?: string;
+    assertionVersion?: string;
+    publicTripleCount?: number;
+    privateMerkleRoot?: Uint8Array;
+    privateTripleCount?: number;
   }): Promise<ACKCollectionResult> {
     const {
       kaId, contextGraphId, preUpdateMerkleRootCount, newMerkleRoot,
@@ -500,9 +516,17 @@ export class ACKCollector {
         `UPDATE ACK collection failed: newMerkleRoot must be 32 bytes, got ${newMerkleRoot.length}`,
       );
     }
-    if (!Number.isInteger(newMerkleLeafCount) || newMerkleLeafCount < 1) {
+    // The contract samples curated KAs through newCatalogLeafCount, so their
+    // private assertion may legitimately have zero public challenge leaves.
+    // Public updates must remain positive or the on-chain update reverts.
+    if (
+      !Number.isInteger(newMerkleLeafCount)
+      || newMerkleLeafCount < 0
+      || (newMerkleLeafCount === 0 && params.isEncryptedPayload !== true)
+    ) {
       throw new Error(
-        `UPDATE ACK collection failed: newMerkleLeafCount must be a positive integer, got ${newMerkleLeafCount}`,
+        `UPDATE ACK collection failed: newMerkleLeafCount must be positive for public KAs ` +
+          `(zero is valid only for curated encrypted updates), got ${newMerkleLeafCount}`,
       );
     }
 
@@ -530,6 +554,12 @@ export class ACKCollector {
       stagingQuads: params.stagingQuads,
       isEncryptedPayload: params.isEncryptedPayload === true ? true : undefined,
       ackProtocolVersion: params.ackProtocolVersion,
+      contentScopeVersion: params.contentScopeVersion,
+      kaUal: params.kaUal,
+      assertionVersion: params.assertionVersion,
+      publicTripleCount: params.publicTripleCount,
+      privateMerkleRoot: params.privateMerkleRoot,
+      privateTripleCount: params.privateTripleCount,
     };
     const intentBytes = encodeUpdateIntent(p2pMsg);
 

--- a/packages/publisher/src/ack-collector.ts
+++ b/packages/publisher/src/ack-collector.ts
@@ -2,6 +2,8 @@ import {
   PROTOCOL_STORAGE_ACK,
   PROTOCOL_STORAGE_ACK_V2,
   PROTOCOL_STORAGE_UPDATE_ACK,
+  PROTOCOL_STORAGE_UPDATE_ACK_V2,
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
   encodePublishIntent,
   encodeUpdateIntent,
   decodeStorageACK,
@@ -565,7 +567,10 @@ export class ACKCollector {
 
     log(`[ACKCollector] Collecting UPDATE ACKs via direct P2P (kaId=${kaId}, newMerkleRoot=${ethers.hexlify(newMerkleRoot).slice(0, 18)}...)`);
 
-    const corePeers = this.deps.getConnectedCorePeers(PROTOCOL_STORAGE_UPDATE_ACK);
+    const updateAckProtocolId = params.contentScopeVersion === GRAPH_KA_CONTENT_SCOPE_VERSION
+      ? PROTOCOL_STORAGE_UPDATE_ACK_V2
+      : PROTOCOL_STORAGE_UPDATE_ACK;
+    const corePeers = this.deps.getConnectedCorePeers(updateAckProtocolId);
     if (corePeers.length === 0) {
       throw new QuorumUnmetError({
         collected: 0,
@@ -609,7 +614,7 @@ export class ACKCollector {
 
     return this.runACKRound({
       intentBytes,
-      ackProtocolId: PROTOCOL_STORAGE_UPDATE_ACK,
+      ackProtocolId: updateAckProtocolId,
       ackDigest,
       merkleRoot: newMerkleRoot,
       contextGraphId,

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -2254,6 +2254,7 @@ export class DKGPublisher implements Publisher {
         allSkolemizedQuads.map((quad) => ({ ...quad, graph: vmGraph })),
         vmGraph,
         graphPublish.publicTripleCount,
+        { allowCanonicalSkolemTerms: true },
       );
       if (!validation.valid) {
         throw new Error(`Validation failed: ${validation.errors.join('; ')}`);
@@ -4026,6 +4027,7 @@ export class DKGPublisher implements Publisher {
         allSkolemizedQuads.map((quad) => ({ ...quad, graph: dataGraph })),
         dataGraph,
         graphUpdate.publicTripleCount,
+        { allowCanonicalSkolemTerms: true },
       );
       if (!validation.valid) {
         throw new Error(`Validation failed: ${validation.errors.join('; ')}`);
@@ -4117,6 +4119,18 @@ export class DKGPublisher implements Publisher {
       onPhase?.('store', 'start');
 
       if (graphUpdate) {
+        const labelMeta = options.targetMetaGraphUri
+          ?? this.graphManager.metaGraphUri(contextGraphId);
+        const inherited = await this.readGraphKnowledgeAssetIdentity(
+          labelMeta,
+          graphUpdate.scope.ual,
+        );
+        if (inherited.subGraphName !== options.subGraphName) {
+          throw new Error(
+            `Graph-scoped KA update cannot move ${graphUpdate.scope.ual} from ` +
+              `${inherited.subGraphName ?? '(root)'} to ${options.subGraphName ?? '(root)'}`,
+          );
+        }
         await this.replaceExactKnowledgeAssetGraph(
           dataGraph,
           allSkolemizedQuads,
@@ -4128,19 +4142,19 @@ export class DKGPublisher implements Publisher {
           canonicalPrivateQuads,
           options.subGraphName,
         );
-        const labelMeta = options.targetMetaGraphUri
-          ?? this.graphManager.metaGraphUri(contextGraphId);
         const metadata = generateGraphKnowledgeAssetMetadata(
           {
             ual: graphUpdate.scope.ual,
             contextGraphId,
             merkleRoot: kcMerkleRoot,
-            publisherPeerId: options.publisherPeerId?.trim() || 'unknown',
-            accessPolicy: options.accessPolicy,
-            allowedPeers: options.allowedPeers,
+            publisherPeerId: inherited.publisherPeerId,
+            accessPolicy: inherited.accessPolicy,
+            ...(inherited.accessPolicy === 'allowList'
+              ? { allowedPeers: inherited.allowedPeers }
+              : {}),
             timestamp: new Date(),
-            subGraphName: options.subGraphName,
-            authorAddress: options.precomputedUpdateAttestation?.authorAddress,
+            subGraphName: inherited.subGraphName,
+            authorAddress: inherited.authorAddress,
             assertionVersion: graphUpdate.scope.assertionVersion,
             publicTripleCount: graphUpdate.publicTripleCount,
             privateTripleCount: graphUpdate.privateTripleCount,
@@ -5915,6 +5929,75 @@ export class DKGPublisher implements Publisher {
     if (stale.length > 0) await this.store.delete(stale);
   }
 
+  /** Load the immutable access/sub-graph identity of an existing graph KA. */
+  private async readGraphKnowledgeAssetIdentity(
+    metaGraph: string,
+    ual: string,
+  ): Promise<{
+    accessPolicy: 'public' | 'ownerOnly' | 'allowList';
+    allowedPeers: string[];
+    publisherPeerId: string;
+    authorAddress?: string;
+    subGraphName?: string;
+  }> {
+    const dkg = 'http://dkg.io/ontology/';
+    const result = await this.store.query(
+      `SELECT ?scopeVersion ?policy ?allowedPeer ?publisherPeerId ?attributedTo ?subGraphName WHERE {
+         GRAPH <${assertSafeIri(metaGraph)}> {
+           OPTIONAL { <${assertSafeIri(ual)}> <${dkg}contentScopeVersion> ?scopeVersion }
+           OPTIONAL { <${assertSafeIri(ual)}> <${dkg}accessPolicy> ?policy }
+           OPTIONAL { <${assertSafeIri(ual)}> <${dkg}allowedPeer> ?allowedPeer }
+           OPTIONAL { <${assertSafeIri(ual)}> <${dkg}publisherPeerId> ?publisherPeerId }
+           OPTIONAL { <${assertSafeIri(ual)}> <http://www.w3.org/ns/prov#wasAttributedTo> ?attributedTo }
+           OPTIONAL { <${assertSafeIri(ual)}> <${dkg}subGraphName> ?subGraphName }
+         }
+       }`,
+    );
+    if (result.type !== 'bindings' || result.bindings.length === 0) {
+      throw new Error(`Graph-scoped KA update requires existing metadata for ${ual}`);
+    }
+    const values = (name: string): Set<string> => new Set(
+      result.bindings
+        .map((row) => rdfLexicalValue(row[name]))
+        .filter((value): value is string => value !== undefined && value.length > 0),
+    );
+    const single = (name: string, required: boolean): string | undefined => {
+      const found = values(name);
+      if (found.size > 1 || (required && found.size !== 1)) {
+        throw new Error(
+          `Graph-scoped KA update found ambiguous or missing ${name} metadata for ${ual}`,
+        );
+      }
+      return [...found][0];
+    };
+    if (single('scopeVersion', true) !== String(GRAPH_KA_CONTENT_SCOPE_VERSION)) {
+      throw new Error(`Graph-scoped KA update requires V2 metadata for ${ual}`);
+    }
+    const policy = single('policy', true);
+    if (policy !== 'public' && policy !== 'ownerOnly' && policy !== 'allowList') {
+      throw new Error(`Graph-scoped KA update has invalid access policy for ${ual}`);
+    }
+    const allowedPeers = [...values('allowedPeer')];
+    if (
+      (policy === 'allowList' && allowedPeers.length === 0)
+      || (policy !== 'allowList' && allowedPeers.length > 0)
+    ) {
+      throw new Error(`Graph-scoped KA update has inconsistent allow-list metadata for ${ual}`);
+    }
+    const attributedTo = single('attributedTo', false);
+    const subGraphName = single('subGraphName', false);
+    const authorMatch = attributedTo
+      ? /^did:dkg:agent:(0x[0-9a-f]{40})$/i.exec(attributedTo)
+      : null;
+    return {
+      accessPolicy: policy,
+      allowedPeers,
+      publisherPeerId: single('publisherPeerId', true)!,
+      ...(authorMatch ? { authorAddress: authorMatch[1] } : {}),
+      ...(subGraphName ? { subGraphName } : {}),
+    };
+  }
+
   /**
    * Materialize the exact canonical WM payload under its deterministic UAL graph.
    *
@@ -7420,6 +7503,10 @@ function stripSparqlLiteral(value: string | undefined): string | undefined {
   if (!value) return undefined;
   if (!value.startsWith('"')) return value;
   return value.replace(/^"/, '').replace(/"(\^\^<[^>]+>)?$/, '');
+}
+
+function rdfLexicalValue(value: string | undefined): string | undefined {
+  return stripSparqlLiteral(value);
 }
 
 function addOwner(owners: Map<string, Set<string>>, root: string, owner: string): void {

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -6688,8 +6688,29 @@ export class DKGPublisher implements Publisher {
     // the seal is rebuilt at the next finalize anyway (and torn down below). VM
     // pulls still use the seal (VM content is keyed by the published roots, which
     // only the seal records).
+    let graphScope: ReturnType<typeof createGraphKnowledgeAssetScope> | undefined;
+    if (seal?.contentScopeVersion === GRAPH_KA_CONTENT_SCOPE_VERSION) {
+      if (!seal.kaUal || !seal.assertionVersion) {
+        throw new Error(`Graph-scoped assertion seal for <${sealSubject}> is incomplete`);
+      }
+      graphScope = createGraphKnowledgeAssetScope(seal.kaUal, seal.assertionVersion);
+    }
+
     let entities: string[];
-    if (sourceLayer === 'swm') {
+    if (graphScope && sourceLayer === 'swm') {
+      // A graph-scoped KA is atomic and intentionally carries no legacy root
+      // rows. The full-share marker is still the durable proof that the exact
+      // per-KA SWM graph is a complete reconstruction source.
+      if (!(await this.hasSwmShareComplete(contextGraphId, name, agentAddress, subGraphName))) {
+        throw Object.assign(
+          new Error(
+            `"${name}" in context graph "${contextGraphId}" has no complete graph-scoped SWM share to pull from.`,
+          ),
+          { code: 'SWM_SUBSET_NOT_SEALABLE' },
+        );
+      }
+      entities = [];
+    } else if (sourceLayer === 'swm') {
       const promotedRoots = await this.readPromotedRootEntities(contextGraphId, agentAddress, name, subGraphName);
       if (promotedRoots.length > 0) {
         const fullyShared = await this.hasSwmShareComplete(contextGraphId, name, agentAddress, subGraphName);
@@ -6708,7 +6729,7 @@ export class DKGPublisher implements Publisher {
     } else {
       entities = seal?.rootEntities ?? [];
     }
-    if (entities.length === 0) {
+    if (entities.length === 0 && !graphScope) {
       throw new Error(
         `No member entities for "${name}" in context graph "${contextGraphId}" — pull-from `
         + `requires either a finalized assertion (its seal records the members) or a prior `
@@ -6736,9 +6757,19 @@ export class DKGPublisher implements Publisher {
       `|| STRSTARTS(STR(?g), "${vmBase}/_verifiable_memory/") ` +
       `|| STRSTARTS(STR(?g), "did:dkg:context-graph:${contextGraphId}/context/"))`;
     // Per-KA SWM: when pulling from SWM the source spans the per-KA prefix, not one bucket.
-    const sourcePattern = sourceLayer === 'swm'
-      ? `GRAPH ?g { VALUES ?root { ${values} } ?s ?p ?o . FILTER(?s = ?root || STRSTARTS(STR(?s), CONCAT(STR(?root), "/.well-known/genid/"))) } ${sharedMemoryReadBothFilter(sourceGraph)}`
-      : `GRAPH ?g { VALUES ?root { ${values} } ?s ?p ?o . FILTER(?s = ?root || STRSTARTS(STR(?s), CONCAT(STR(?root), "/.well-known/genid/"))) } ${vmGraphFilter}`;
+    const graphScopedSource = graphScope
+      ? knowledgeAssetLayerGraphUri(
+          contextGraphId,
+          sourceLayer === 'swm' ? MemoryLayer.SharedWorkingMemory : MemoryLayer.VerifiableMemory,
+          graphScope,
+          subGraphName,
+        )
+      : undefined;
+    const sourcePattern = graphScopedSource
+      ? `GRAPH <${graphScopedSource}> { ?s ?p ?o }`
+      : sourceLayer === 'swm'
+        ? `GRAPH ?g { VALUES ?root { ${values} } ?s ?p ?o . FILTER(?s = ?root || STRSTARTS(STR(?s), CONCAT(STR(?root), "/.well-known/genid/"))) } ${sharedMemoryReadBothFilter(sourceGraph)}`
+        : `GRAPH ?g { VALUES ?root { ${values} } ?s ?p ?o . FILTER(?s = ?root || STRSTARTS(STR(?s), CONCAT(STR(?root), "/.well-known/genid/"))) } ${vmGraphFilter}`;
     const gather = await this.store.query(
       `CONSTRUCT { ?s ?p ?o } WHERE { ${sourcePattern} }`,
     );
@@ -6753,7 +6784,9 @@ export class DKGPublisher implements Publisher {
       throw Object.assign(
         new Error(
           `No ${sourceLayer.toUpperCase()} quads found for "${name}" in context graph "${contextGraphId}" `
-          + `using the assertion seal's ${entities.length} root entit${entities.length === 1 ? 'y' : 'ies'}; `
+          + (graphScopedSource
+            ? `in exact graph <${graphScopedSource}>; `
+            : `using the assertion seal's ${entities.length} root entit${entities.length === 1 ? 'y' : 'ies'}; `)
           + `WM draft was not modified.`,
         ),
         { code: 'PULL_FROM_EMPTY_SOURCE' },

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -12,6 +12,7 @@ import { canonicalPublishPayload } from './canonical-publish-payload.js';
 import {
   assertTrustedCatalogTriplesAreGeneratedFloor,
   catalogTripleKey,
+  replaceCatalogPartitionWithGeneratedPrivateFloor,
   splitTrustedGeneratedCatalogRootMap,
   trustedCatalogTripleKeySet,
 } from './catalog-trust.js';
@@ -1853,7 +1854,16 @@ export class DKGPublisher implements Publisher {
     // when only `chainCgId` is set — the target cgId is always
     // `ctxGraphId ?? chainCgId`.
     const targetCgId = ctxGraphId ?? chainCgId;
-    if (targetCgId && publishResult.status === 'confirmed' && publishResult.onChainResult) {
+    // V2/rootless KAs remain in their exact per-KA VM graph. Random sampling
+    // resolves that graph from constant-size label metadata, so copying their
+    // triples into the legacy shared per-cgId partition would only duplicate
+    // storage and would make rootless updates impossible to replace safely.
+    if (
+      !graphPublish
+      && targetCgId
+      && publishResult.status === 'confirmed'
+      && publishResult.onChainResult
+    ) {
       // V10 publishDirect already registered the KC to the context graph
       // inside publishDirect, via a Hub-authorized internal call to
       // ContextGraphs.registerKnowledgeAsset (EOAs cannot call it directly),
@@ -3863,22 +3873,42 @@ export class DKGPublisher implements Publisher {
         kaNumber: BigInt(descriptor.scope.kaNumber),
       },
     };
-    const quads = await loadSharedMemoryQuadsForScope(
+    let quads = await loadSharedMemoryQuadsForScope(
       this.store,
       swmBucket,
       'all',
       scope,
       { quadFilter: (quad) => !isSwmMerkleExcludedQuad(quad) },
     );
-    if (quads.length === 0) {
+    const hasTrustedCatalogTriples =
+      trustedCatalogTripleKeySet(options.trustedNonManifestCatalogTriples).size > 0;
+    if (hasTrustedCatalogTriples) {
+      // Curated updates refresh the deterministic public catalog floor. The
+      // trusted entrypoint still sources all user content from the exact SWM
+      // graph; only the four validated protocol-owned catalog triples are
+      // replaced here, so callers cannot smuggle arbitrary RDF around that
+      // boundary. `update()` re-validates the exact key set below.
+      assertTrustedCatalogTriplesAreGeneratedFloor(
+        options.contextGraphId,
+        options.trustedNonManifestCatalogTriples,
+      );
+      quads = replaceCatalogPartitionWithGeneratedPrivateFloor(
+        options.contextGraphId,
+        quads,
+      ).quads;
+    }
+    if (quads.length === 0 && (options.privateQuads?.length ?? 0) === 0) {
       throw new Error(
-        `No quads in shared memory for graph-scoped KA ${descriptor.scope.ual}`,
+        `No public or private quads available for graph-scoped KA ${descriptor.scope.ual}`,
       );
     }
     return this.update(kaId, {
       ...options,
       quads: quads.map((quad) => ({ ...quad, graph: '' })),
       [INTERNAL_ORIGIN_TOKEN]: true,
+      ...(hasTrustedCatalogTriples
+        ? { [TRUSTED_CATALOG_ORIGIN_TOKEN]: true as const }
+        : {}),
     } as InternalPublishOptions);
   }
 
@@ -4272,7 +4302,7 @@ export class DKGPublisher implements Publisher {
     const updateNquadsStr = allSkolemizedQuads
       .map(
         (q: { subject: string; predicate: string; object: string; graph?: string }) =>
-          `<${q.subject}> <${q.predicate}> ${q.object.startsWith('"') ? q.object : `<${q.object}>`} <${q.graph || ''}> .`,
+          `<${q.subject}> <${q.predicate}> ${q.object.startsWith('"') ? q.object : `<${q.object}>`} <${q.graph || dataGraph}> .`,
       )
       .join('\n');
     const updateByteSize = BigInt(new TextEncoder().encode(updateNquadsStr).length);
@@ -4536,6 +4566,16 @@ export class DKGPublisher implements Publisher {
           mintAmount: 0n,
           burnTokenIds: [],
         });
+        if (
+          graphUpdate
+          && BigInt(graphUpdate.scope.assertionVersion)
+            !== digestFields.preUpdateMerkleRootCount + 1n
+        ) {
+          throw new Error(
+            `Graph-scoped update assertionVersion ${graphUpdate.scope.assertionVersion} must equal ` +
+              `preUpdateMerkleRootCount + 1 (${digestFields.preUpdateMerkleRootCount + 1n})`,
+          );
+        }
         boundUpdateTokenAmount = digestFields.newTokenAmount;
         v10UpdateACKs = await v10UpdateACKProvider({
           kaId,
@@ -4570,6 +4610,19 @@ export class DKGPublisher implements Publisher {
           // falls back to verifying against its SWM copy. Selected above.
           stagingQuads: updateStagingQuads,
           swmGraphId: contextGraphId,
+          subGraphName: options.subGraphName,
+          ...(graphUpdate
+            ? {
+                contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+                kaUal: graphUpdate.scope.ual,
+                assertionVersion: graphUpdate.scope.assertionVersion,
+                publicTripleCount: graphUpdate.publicTripleCount,
+                ...(updatePrivateRoots[0]
+                  ? { privateMerkleRoot: updatePrivateRoots[0] }
+                  : {}),
+                privateTripleCount: graphUpdate.privateTripleCount,
+              }
+            : {}),
         });
         this.log.info(
           ctx,

--- a/packages/publisher/src/publisher.ts
+++ b/packages/publisher/src/publisher.ts
@@ -177,6 +177,13 @@ export type V10UpdateACKProvider = (params: {
   /** Source SWM graph id (defaults to contextGraphId). */
   swmGraphId?: string;
   subGraphName?: string;
+  /** Complete rootless-KA envelope; omitted together for legacy updates. */
+  contentScopeVersion?: number;
+  kaUal?: string;
+  assertionVersion?: string;
+  publicTripleCount?: number;
+  privateMerkleRoot?: Uint8Array;
+  privateTripleCount?: number;
 }) => Promise<V10CoreNodeACK[]>;
 
 /**

--- a/packages/publisher/src/storage-ack-handler.ts
+++ b/packages/publisher/src/storage-ack-handler.ts
@@ -1747,6 +1747,10 @@ export class StorageACKHandler {
         // unrelated graph.
         inlineByteLength === undefined ? swmGraphUri : inlineVmGraphUri!,
         graphUpdate.publicTripleCount,
+        // The producer has already canonicalized blank nodes into the exact
+        // RDFC `urn:dkg:ka-skolem:c14nN` namespace before computing the root.
+        // Keep rejecting every other reserved-namespace term.
+        { allowCanonicalSkolemTerms: true },
       );
       if (!validation.valid) {
         return this.encodeDecline(

--- a/packages/publisher/src/storage-ack-handler.ts
+++ b/packages/publisher/src/storage-ack-handler.ts
@@ -12,6 +12,7 @@ import type {
   StorageACKDeclineCode,
   StorageACKMsg,
   SubscriptionSource,
+  UpdateIntentMsg,
 } from '@origintrail-official/dkg-core';
 import {
   Logger,
@@ -35,6 +36,11 @@ import {
   contextGraphCatalogUri,
   isSwmMerkleExcludedQuad,
   STORAGE_ACK_MAX_STAGING_BYTES,
+  createGraphKnowledgeAssetScope,
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  knowledgeAssetLayerGraphUri,
+  MemoryLayer,
+  validateSubGraphName,
 } from '@origintrail-official/dkg-core';
 import {
   computeFlatKCRootV10 as computeFlatKCRoot,
@@ -45,6 +51,92 @@ import { replaceCatalogQuads } from './catalog-persistence.js';
 import { ethers } from 'ethers';
 
 type PeerId = { toString(): string };
+
+type GraphScopedUpdateIntent = {
+  scope: ReturnType<typeof createGraphKnowledgeAssetScope>;
+  publicTripleCount: number;
+  privateTripleCount: number;
+  privateMerkleRoot?: Uint8Array;
+  subGraphName?: string;
+};
+
+function updateIntentUint64(value: number | { low: number; high: number }): bigint {
+  return typeof value === 'number'
+    ? BigInt(value)
+    : BigInt(value.low >>> 0) | (BigInt(value.high >>> 0) << 32n);
+}
+
+function resolveGraphScopedUpdateIntent(
+  intent: UpdateIntentMsg,
+): GraphScopedUpdateIntent | undefined {
+  const privateMerkleRoot = intent.privateMerkleRoot?.length
+    ? new Uint8Array(intent.privateMerkleRoot)
+    : undefined;
+  const hasGraphField =
+    (intent.contentScopeVersion ?? 0) !== 0
+    || Boolean(intent.kaUal)
+    || Boolean(intent.assertionVersion)
+    || (intent.publicTripleCount ?? 0) > 0
+    || privateMerkleRoot !== undefined
+    || (intent.privateTripleCount ?? 0) > 0
+    || Boolean(intent.subGraphName);
+  if (!hasGraphField) return undefined;
+  if (intent.contentScopeVersion !== GRAPH_KA_CONTENT_SCOPE_VERSION) {
+    throw new Error(
+      `UpdateStorageACK: graph-scoped update requires contentScopeVersion=${GRAPH_KA_CONTENT_SCOPE_VERSION}`,
+    );
+  }
+  if (!intent.kaUal || !intent.assertionVersion) {
+    throw new Error('UpdateStorageACK: graph-scoped update requires kaUal and assertionVersion');
+  }
+  const publicTripleCount = intent.publicTripleCount ?? 0;
+  const privateTripleCount = intent.privateTripleCount ?? 0;
+  if (
+    !Number.isSafeInteger(publicTripleCount)
+    || publicTripleCount < 0
+    || !Number.isSafeInteger(privateTripleCount)
+    || privateTripleCount < 0
+    || (publicTripleCount === 0 && privateTripleCount === 0)
+    || (privateTripleCount > 0 && privateMerkleRoot?.length !== 32)
+    || (privateTripleCount === 0 && privateMerkleRoot !== undefined)
+  ) {
+    throw new Error('UpdateStorageACK: invalid graph-scoped content envelope');
+  }
+  const scope = createGraphKnowledgeAssetScope(intent.kaUal, intent.assertionVersion);
+  if (scope.ual !== intent.kaUal) {
+    throw new Error('UpdateStorageACK: graph-scoped kaUal is not canonical');
+  }
+  const kaId = BigInt(intent.kaId);
+  const packedKaId = (BigInt(scope.agentAddress) << 96n) | BigInt(scope.kaNumber);
+  if (packedKaId !== kaId) {
+    throw new Error(
+      `UpdateStorageACK: UAL-derived kaId ${packedKaId} does not match intent kaId ${kaId}`,
+    );
+  }
+  const expectedAssertionVersion = updateIntentUint64(intent.preUpdateMerkleRootCount) + 1n;
+  if (BigInt(scope.assertionVersion) !== expectedAssertionVersion) {
+    throw new Error(
+      `UpdateStorageACK: assertionVersion ${scope.assertionVersion} must equal ` +
+        `preUpdateMerkleRootCount + 1 (${expectedAssertionVersion})`,
+    );
+  }
+  const subGraphName = intent.subGraphName || undefined;
+  if (subGraphName) {
+    const validation = validateSubGraphName(subGraphName);
+    if (!validation.valid) {
+      throw new Error(
+        `UpdateStorageACK: invalid graph-scoped subGraphName: ${validation.reason}`,
+      );
+    }
+  }
+  return {
+    scope,
+    publicTripleCount,
+    privateTripleCount,
+    ...(privateMerkleRoot ? { privateMerkleRoot } : {}),
+    ...(subGraphName ? { subGraphName } : {}),
+  };
+}
 
 export interface StorageAckDecision {
   encoded: Uint8Array;
@@ -1024,11 +1116,15 @@ export class StorageACKHandler {
         );
       }
       const claimedLeafCount = intent.merkleLeafCount == null ? 0 : Number(intent.merkleLeafCount);
-      if (claimedLeafCount < 1) {
+      // Curated KAs are sampled through the independently verified catalog
+      // commitment above. Their private assertion may therefore contain zero
+      // public leaves; requiring a positive count here forced an unnecessary
+      // public placeholder that the lifecycle contract itself does not need.
+      if (!Number.isInteger(claimedLeafCount) || claimedLeafCount < 0) {
         return this.encodeDecline(
           cgId,
           STORAGE_ACK_DECLINE_CODES.MERKLE_MISMATCH_IN_SWM,
-          `curated PublishIntent.merkleLeafCount must be a positive integer; got ${claimedLeafCount}`,
+          `curated PublishIntent.merkleLeafCount must be a non-negative integer; got ${claimedLeafCount}`,
         );
       }
 
@@ -1441,6 +1537,7 @@ export class StorageACKHandler {
     }
 
     const intent = decodeUpdateIntent(data);
+    const graphUpdate = resolveGraphScopedUpdateIntent(intent);
     // `cgId` is the TARGET on-chain numeric id used by the UPDATE ACK
     // digest and the update tx. `swmGraphId` (optional) is the SOURCE
     // graph where the data lives in SWM. When absent, fall back to `cgId`.
@@ -1448,9 +1545,11 @@ export class StorageACKHandler {
     const swmGraphId = intent.swmGraphId && intent.swmGraphId.length > 0
       ? intent.swmGraphId
       : cgId;
-    const subGraphName = intent.subGraphName && intent.subGraphName.length > 0
-      ? intent.subGraphName
-      : undefined;
+    const subGraphName = graphUpdate?.subGraphName ?? (
+      intent.subGraphName && intent.subGraphName.length > 0
+        ? intent.subGraphName
+        : undefined
+    );
     const newMerkleRoot = intent.newMerkleRoot instanceof Uint8Array
       ? intent.newMerkleRoot
       : new Uint8Array(intent.newMerkleRoot);
@@ -1460,7 +1559,14 @@ export class StorageACKHandler {
       );
     }
 
-    const swmGraphUri = this.config.contextGraphSharedMemoryUri(swmGraphId, subGraphName);
+    const swmGraphUri = graphUpdate
+      ? knowledgeAssetLayerGraphUri(
+          swmGraphId,
+          MemoryLayer.SharedWorkingMemory,
+          graphUpdate.scope,
+          subGraphName,
+        )
+      : this.config.contextGraphSharedMemoryUri(swmGraphId, subGraphName);
 
     // Verify the new Merkle root the same way the publish path does:
     // recompute over the updated quads and compare to the publisher's
@@ -1594,6 +1700,60 @@ export class StorageACKHandler {
       }
       // Encrypted updates trust the publisher's claimed newMerkleRoot —
       // no recompute. Fall through to the digest sign below.
+    } else if (graphUpdate) {
+      let publicQuads: Quad[];
+      let inlineByteLength: number | undefined;
+      if (intent.stagingQuads && intent.stagingQuads.length > 0) {
+        if (intent.stagingQuads.length > STORAGE_ACK_MAX_STAGING_BYTES) {
+          throw new Error(
+            `UpdateStorageACK: stagingQuads payload (${intent.stagingQuads.length} bytes) exceeds ` +
+            `${STORAGE_ACK_MAX_STAGING_BYTES} byte limit — rejecting request`,
+          );
+        }
+        publicQuads = parseSimpleNQuads(new TextDecoder().decode(intent.stagingQuads));
+        inlineByteLength = intent.stagingQuads.length;
+      } else if (graphUpdate.publicTripleCount === 0) {
+        publicQuads = [];
+      } else {
+        const loadedSWM = await this.loadSWMOrDecline(cgId, swmGraphUri, [], signal);
+        if (!loadedSWM.ok) return loadedSWM.decline;
+        publicQuads = loadedSWM.quads;
+      }
+      if (publicQuads.length !== graphUpdate.publicTripleCount) {
+        return this.encodeDecline(
+          cgId,
+          STORAGE_ACK_DECLINE_CODES.MERKLE_MISMATCH_IN_SWM,
+          `UpdateStorageACK: graph-scoped public triple count mismatch: ` +
+            `intent=${graphUpdate.publicTripleCount}, local=${publicQuads.length}`,
+        );
+      }
+      const privateRoots = graphUpdate.privateMerkleRoot
+        ? [graphUpdate.privateMerkleRoot]
+        : [];
+      const recomputedRoot = computeFlatKCRoot(publicQuads, privateRoots);
+      if (!bytesEqual(recomputedRoot, newMerkleRoot)) {
+        return this.encodeDecline(
+          cgId,
+          STORAGE_ACK_DECLINE_CODES.MERKLE_MISMATCH_IN_SWM,
+          `UpdateStorageACK: graph-scoped newMerkleRoot mismatch: ` +
+            `publisher=${ethers.hexlify(newMerkleRoot).slice(0, 18)}..., ` +
+            `computed=${ethers.hexlify(recomputedRoot).slice(0, 18)}... ` +
+            `(${publicQuads.length} public triples)`,
+        );
+      }
+      if (inlineByteLength !== undefined) {
+        publicUpdateByteSizeFloor = BigInt(inlineByteLength);
+        publicUpdateFloorBasis = 'exact inline payload bytes';
+      } else {
+        publicUpdateByteSizeFloor = 0n;
+        for (const quad of publicQuads) {
+          publicUpdateByteSizeFloor +=
+            BigInt(Buffer.byteLength(quad.subject, 'utf8'))
+            + BigInt(Buffer.byteLength(quad.predicate, 'utf8'))
+            + BigInt(Buffer.byteLength(quad.object, 'utf8'));
+        }
+        publicUpdateFloorBasis = 'Σ UTF-8 term bytes (lower bound)';
+      }
     } else if (intent.stagingQuads && intent.stagingQuads.length > 0) {
       if (intent.stagingQuads.length > STORAGE_ACK_MAX_STAGING_BYTES) {
         throw new Error(
@@ -1683,10 +1843,7 @@ export class StorageACKHandler {
     } catch {
       throw new Error(`UpdateStorageACK: kaId must be a numeric decimal string; got '${intent.kaId}'.`);
     }
-    const preUpdateMerkleRootCount = typeof intent.preUpdateMerkleRootCount === 'number'
-      ? BigInt(intent.preUpdateMerkleRootCount)
-      : BigInt(intent.preUpdateMerkleRootCount.low >>> 0)
-        | (BigInt(intent.preUpdateMerkleRootCount.high >>> 0) << 32n);
+    const preUpdateMerkleRootCount = updateIntentUint64(intent.preUpdateMerkleRootCount);
     const newByteSize = typeof intent.newByteSize === 'number'
       ? BigInt(intent.newByteSize)
       : BigInt(intent.newByteSize.low >>> 0) | (BigInt(intent.newByteSize.high >>> 0) << 32n);
@@ -1716,9 +1873,18 @@ export class StorageACKHandler {
           : BigInt(intent.mintAmount.low >>> 0) | (BigInt(intent.mintAmount.high >>> 0) << 32n));
     const burnTokenIds = (intent.burnTokenIds ?? []).map((id) => BigInt(id));
     const newMerkleLeafCount = intent.newMerkleLeafCount == null ? 0 : Number(intent.newMerkleLeafCount);
-    if (!Number.isInteger(newMerkleLeafCount) || newMerkleLeafCount < 1) {
+    // The encrypted branch above has already proven this is a curated CG and,
+    // when supplied, independently verified its public catalog commitment.
+    // Curated sampling uses that catalog count, so a fully private assertion
+    // legitimately has zero public Merkle leaves. Public updates stay > 0.
+    if (
+      !Number.isInteger(newMerkleLeafCount)
+      || newMerkleLeafCount < 0
+      || (newMerkleLeafCount === 0 && intent.isEncryptedPayload !== true)
+    ) {
       throw new Error(
-        `UpdateStorageACK: newMerkleLeafCount must be a positive integer; got ${newMerkleLeafCount}`,
+        `UpdateStorageACK: newMerkleLeafCount must be positive for public KAs ` +
+          `(zero is valid only for curated encrypted updates); got ${newMerkleLeafCount}`,
       );
     }
 

--- a/packages/publisher/src/storage-ack-handler.ts
+++ b/packages/publisher/src/storage-ack-handler.ts
@@ -48,6 +48,7 @@ import {
 } from './merkle.js';
 import { parseSimpleNQuads } from './publish-handler.js';
 import { replaceCatalogQuads } from './catalog-persistence.js';
+import { validateKnowledgeAssetPublishRequest } from './validation.js';
 import { ethers } from 'ethers';
 
 type PeerId = { toString(): string };
@@ -78,8 +79,7 @@ function resolveGraphScopedUpdateIntent(
     || Boolean(intent.assertionVersion)
     || (intent.publicTripleCount ?? 0) > 0
     || privateMerkleRoot !== undefined
-    || (intent.privateTripleCount ?? 0) > 0
-    || Boolean(intent.subGraphName);
+    || (intent.privateTripleCount ?? 0) > 0;
   if (!hasGraphField) return undefined;
   if (intent.contentScopeVersion !== GRAPH_KA_CONTENT_SCOPE_VERSION) {
     throw new Error(
@@ -1727,6 +1727,20 @@ export class StorageACKHandler {
             `intent=${graphUpdate.publicTripleCount}, local=${publicQuads.length}`,
         );
       }
+      const validation = validateKnowledgeAssetPublishRequest(
+        inlineByteLength === undefined
+          ? publicQuads.map((quad) => ({ ...quad, graph: swmGraphUri }))
+          : publicQuads,
+        swmGraphUri,
+        graphUpdate.publicTripleCount,
+      );
+      if (!validation.valid) {
+        return this.encodeDecline(
+          cgId,
+          STORAGE_ACK_DECLINE_CODES.MERKLE_MISMATCH_IN_SWM,
+          `UpdateStorageACK: invalid graph-scoped RDF: ${validation.errors.join('; ')}`,
+        );
+      }
       const privateRoots = graphUpdate.privateMerkleRoot
         ? [graphUpdate.privateMerkleRoot]
         : [];
@@ -1739,6 +1753,18 @@ export class StorageACKHandler {
             `publisher=${ethers.hexlify(newMerkleRoot).slice(0, 18)}..., ` +
             `computed=${ethers.hexlify(recomputedRoot).slice(0, 18)}... ` +
             `(${publicQuads.length} public triples)`,
+        );
+      }
+      const recomputedLeafCount = computeFlatKCMerkleLeafCountV10(publicQuads, privateRoots);
+      const claimedLeafCount = intent.newMerkleLeafCount == null
+        ? 0
+        : Number(intent.newMerkleLeafCount);
+      if (claimedLeafCount !== recomputedLeafCount) {
+        return this.encodeDecline(
+          cgId,
+          STORAGE_ACK_DECLINE_CODES.MERKLE_MISMATCH_IN_SWM,
+          `UpdateStorageACK: graph-scoped newMerkleLeafCount mismatch: ` +
+            `intent=${claimedLeafCount}, computed=${recomputedLeafCount}`,
         );
       }
       if (inlineByteLength !== undefined) {

--- a/packages/publisher/src/storage-ack-handler.ts
+++ b/packages/publisher/src/storage-ack-handler.ts
@@ -1567,6 +1567,14 @@ export class StorageACKHandler {
           subGraphName,
         )
       : this.config.contextGraphSharedMemoryUri(swmGraphId, subGraphName);
+    const inlineVmGraphUri = graphUpdate
+      ? knowledgeAssetLayerGraphUri(
+          swmGraphId,
+          MemoryLayer.VerifiableMemory,
+          graphUpdate.scope,
+          subGraphName,
+        )
+      : undefined;
 
     // Verify the new Merkle root the same way the publish path does:
     // recompute over the updated quads and compare to the publisher's
@@ -1731,7 +1739,13 @@ export class StorageACKHandler {
         inlineByteLength === undefined
           ? publicQuads.map((quad) => ({ ...quad, graph: swmGraphUri }))
           : publicQuads,
-        swmGraphUri,
+        // Inline public graph updates are emitted by DKGPublisher from its
+        // materialized per-KA VM graph. Only the no-inline fallback loads the
+        // source per-KA SWM graph. Keeping these provenance-specific graph
+        // expectations separate prevents every ordinary public update from
+        // being declined while still rejecting a payload stamped for an
+        // unrelated graph.
+        inlineByteLength === undefined ? swmGraphUri : inlineVmGraphUri!,
         graphUpdate.publicTripleCount,
       );
       if (!validation.valid) {

--- a/packages/publisher/src/update-handler.ts
+++ b/packages/publisher/src/update-handler.ts
@@ -1,8 +1,24 @@
 import type { TripleStore, Quad } from '@origintrail-official/dkg-storage';
-import { GraphManager } from '@origintrail-official/dkg-storage';
-import type { EventBus } from '@origintrail-official/dkg-core';
+import { GraphManager, tryReplaceGraphAtomically } from '@origintrail-official/dkg-storage';
+import type {
+  EventBus,
+  KAUpdateRequestMsg,
+  OperationContext,
+} from '@origintrail-official/dkg-core';
 import type { ChainAdapter, KAUpdateVerification } from '@origintrail-official/dkg-chain';
-import { Logger, createOperationContext, DKGEvent, sparqlInt, contextGraphMetaUri, contextGraphLayerUri, MemoryLayer } from '@origintrail-official/dkg-core';
+import {
+  Logger,
+  createOperationContext,
+  DKGEvent,
+  sparqlInt,
+  contextGraphMetaUri,
+  contextGraphLayerUri,
+  MemoryLayer,
+  createGraphKnowledgeAssetScope,
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  knowledgeAssetLayerGraphUri,
+  validateSubGraphName,
+} from '@origintrail-official/dkg-core';
 import { decodeKAUpdateRequest } from '@origintrail-official/dkg-core';
 import { parseSimpleNQuads } from './publish-handler.js';
 import { skolemizeByEntity } from './auto-partition.js';
@@ -11,7 +27,12 @@ import {
   promoteUpdatedKaToPerCgId,
   resolveUalByBatchId,
   restateLabelGraphForUpdate,
+  generateGraphKnowledgeAssetMetadata,
+  shouldApplyMaterialization,
+  withMaterializationLock,
+  writeMaterializedVersion,
   type MaterializedVersion,
+  type OnChainProvenance,
 } from './metadata.js';
 
 /**
@@ -23,6 +44,81 @@ export type ResolveOnChainCgId = (cgName: string) => Promise<string | null>;
 
 const SKOLEM_INFIX = '/.well-known/genid/';
 const EXPECTED_MERKLE_ROOT_LEN = 32;
+const DKG_NS = 'http://dkg.io/ontology/';
+const PROV_NS = 'http://www.w3.org/ns/prov#';
+
+interface GraphScopedUpdateRequest {
+  scope: ReturnType<typeof createGraphKnowledgeAssetScope>;
+  publicTripleCount: number;
+  privateTripleCount: number;
+  privateMerkleRoot?: Uint8Array;
+  subGraphName?: string;
+}
+
+function resolveGraphScopedUpdateRequest(
+  request: KAUpdateRequestMsg,
+): GraphScopedUpdateRequest | undefined {
+  const privateMerkleRoot = request.privateMerkleRoot?.length
+    ? new Uint8Array(request.privateMerkleRoot)
+    : undefined;
+  const hasGraphField =
+    (request.contentScopeVersion ?? 0) !== 0
+    || Boolean(request.kaUal)
+    || Boolean(request.assertionVersion)
+    || (request.publicTripleCount ?? 0) > 0
+    || privateMerkleRoot !== undefined
+    || (request.privateTripleCount ?? 0) > 0
+    || Boolean(request.subGraphName);
+  if (!hasGraphField) return undefined;
+  if (request.contentScopeVersion !== GRAPH_KA_CONTENT_SCOPE_VERSION) {
+    throw new Error(
+      `KA update graph scope requires contentScopeVersion=${GRAPH_KA_CONTENT_SCOPE_VERSION}`,
+    );
+  }
+  if (!request.kaUal || !request.assertionVersion) {
+    throw new Error('KA update graph scope requires kaUal and assertionVersion');
+  }
+  if (request.manifest.length !== 0) {
+    throw new Error('KA update graph scope must not carry a legacy root manifest');
+  }
+  const publicTripleCount = request.publicTripleCount ?? 0;
+  const privateTripleCount = request.privateTripleCount ?? 0;
+  if (
+    !Number.isSafeInteger(publicTripleCount)
+    || publicTripleCount < 0
+    || !Number.isSafeInteger(privateTripleCount)
+    || privateTripleCount < 0
+    || (publicTripleCount === 0 && privateTripleCount === 0)
+    || (privateTripleCount > 0 && privateMerkleRoot?.length !== 32)
+    || (privateTripleCount === 0 && privateMerkleRoot !== undefined)
+  ) {
+    throw new Error('KA update has an invalid graph-scoped content envelope');
+  }
+  const scope = createGraphKnowledgeAssetScope(request.kaUal, request.assertionVersion);
+  if (scope.ual !== request.kaUal) {
+    throw new Error(`KA update UAL is not canonical: ${request.kaUal}`);
+  }
+  const packedKaId = (BigInt(scope.agentAddress) << 96n) | BigInt(scope.kaNumber);
+  if (packedKaId !== BigInt(request.batchId)) {
+    throw new Error(
+      `KA update UAL-derived kaId ${packedKaId} does not match batchId ${request.batchId}`,
+    );
+  }
+  const subGraphName = request.subGraphName || undefined;
+  if (subGraphName) {
+    const validation = validateSubGraphName(subGraphName);
+    if (!validation.valid) {
+      throw new Error(`KA update has invalid subGraphName: ${validation.reason}`);
+    }
+  }
+  return {
+    scope,
+    publicTripleCount,
+    privateTripleCount,
+    ...(privateMerkleRoot ? { privateMerkleRoot } : {}),
+    ...(subGraphName ? { subGraphName } : {}),
+  };
+}
 
 interface AppliedUpdate {
   blockNumber: number;
@@ -87,6 +183,7 @@ export class UpdateHandler {
       if (request.operationId) {
         ctx = createOperationContext('ka-update', request.operationId);
       }
+      const graphUpdate = resolveGraphScopedUpdateRequest(request);
       const {
         contextGraphId: contextGraphId,
         batchId,
@@ -119,6 +216,7 @@ export class UpdateHandler {
       let verifiedMerkleRoot: Uint8Array | undefined;
       let verifiedBlockNumber: number | undefined;
       let verifiedTxIndex: number | undefined;
+      let verifiedMerkleRootCount: bigint | undefined;
 
       if (!this.chain.verifyKAUpdate) {
         if (this.chain.chainId !== 'none') {
@@ -134,6 +232,7 @@ export class UpdateHandler {
         verifiedMerkleRoot = verification.onChainMerkleRoot;
         verifiedBlockNumber = verification.blockNumber;
         verifiedTxIndex = verification.txIndex ?? 0;
+        verifiedMerkleRootCount = verification.merkleRootCount;
       }
 
       // Ordering: use canonical (blockNumber, txIndex) for deterministic state across nodes.
@@ -151,6 +250,20 @@ export class UpdateHandler {
             return;
           }
         }
+      }
+
+      if (graphUpdate) {
+        await this.applyGraphScopedUpdate({
+          request,
+          graphUpdate,
+          fromPeerId,
+          verifiedMerkleRoot,
+          verifiedBlockNumber,
+          verifiedTxIndex,
+          verifiedMerkleRootCount,
+          ctx,
+        });
+        return;
       }
 
       // Merkle root integrity: recompute from the received payload (flat mode).
@@ -377,6 +490,344 @@ export class UpdateHandler {
     }
   }
 
+  private async applyGraphScopedUpdate(input: {
+    request: KAUpdateRequestMsg;
+    graphUpdate: GraphScopedUpdateRequest;
+    fromPeerId: string;
+    verifiedMerkleRoot?: Uint8Array;
+    verifiedBlockNumber?: number;
+    verifiedTxIndex?: number;
+    verifiedMerkleRootCount?: bigint;
+    ctx: OperationContext;
+  }): Promise<void> {
+    const {
+      request,
+      graphUpdate,
+      fromPeerId,
+      verifiedMerkleRoot,
+      verifiedBlockNumber,
+      verifiedTxIndex,
+      verifiedMerkleRootCount,
+      ctx,
+    } = input;
+    const kaId = BigInt(request.batchId);
+    if (
+      this.chain.chainId !== 'none'
+      && graphUpdate.scope.chainId !== this.chain.chainId
+    ) {
+      this.log.warn(
+        ctx,
+        `KA update rejected: UAL chain namespace ${graphUpdate.scope.chainId} does not ` +
+          `match local chain ${this.chain.chainId}`,
+      );
+      return;
+    }
+    if (this.chain.chainId !== 'none') {
+      if (!this.chain.getKAContextGraphId || !this.resolveOnChainCgId) {
+        this.log.warn(
+          ctx,
+          'KA update rejected: graph-scoped chain/context-graph binding views are unavailable',
+        );
+        return;
+      }
+      try {
+        const [chainContextGraphId, requestedContextGraphId] = await Promise.all([
+          this.chain.getKAContextGraphId(kaId),
+          this.resolveOnChainCgId(request.contextGraphId),
+        ]);
+        if (
+          requestedContextGraphId === null
+          || BigInt(requestedContextGraphId) !== chainContextGraphId
+        ) {
+          this.log.warn(
+            ctx,
+            `KA update rejected: context graph ${request.contextGraphId} resolves to ` +
+              `${requestedContextGraphId ?? '(unknown)'}, but chain binds kaId=${kaId} to ` +
+              `${chainContextGraphId}`,
+          );
+          return;
+        }
+      } catch (err) {
+        this.log.warn(
+          ctx,
+          `KA update rejected: unable to verify chain/context-graph binding for kaId=${kaId}: ` +
+            `${err instanceof Error ? err.message : String(err)}`,
+        );
+        return;
+      }
+    }
+    if (
+      verifiedMerkleRootCount !== undefined
+      && BigInt(graphUpdate.scope.assertionVersion) !== verifiedMerkleRootCount
+    ) {
+      this.log.warn(
+        ctx,
+        `KA update rejected: assertionVersion=${graphUpdate.scope.assertionVersion} does not ` +
+          `match chain Merkle-root count ${verifiedMerkleRootCount} for kaId=${kaId}`,
+      );
+      return;
+    }
+
+    const parsed = parseSimpleNQuads(new TextDecoder().decode(request.nquads));
+    const publicQuads = parsed.map((quad) => ({ ...quad, graph: '' }));
+    if (publicQuads.length !== graphUpdate.publicTripleCount) {
+      this.log.warn(
+        ctx,
+        `KA update rejected: graph-scoped public triple count mismatch for kaId=${kaId} ` +
+          `(wire=${graphUpdate.publicTripleCount}, parsed=${publicQuads.length})`,
+      );
+      return;
+    }
+    const computedRoot = computeFlatKCRoot(
+      publicQuads,
+      graphUpdate.privateMerkleRoot ? [graphUpdate.privateMerkleRoot] : [],
+    );
+    const referenceRoot = verifiedMerkleRoot ?? request.newMerkleRoot;
+    if (!referenceRoot || referenceRoot.length !== EXPECTED_MERKLE_ROOT_LEN) {
+      this.log.warn(
+        ctx,
+        `KA update rejected: graph-scoped Merkle root missing or wrong length for kaId=${kaId}`,
+      );
+      return;
+    }
+    if (!buffersEqual(computedRoot, new Uint8Array(referenceRoot))) {
+      this.log.warn(
+        ctx,
+        `KA update rejected: graph-scoped Merkle root mismatch for kaId=${kaId}`,
+      );
+      return;
+    }
+
+    await this.graphManager.ensureContextGraph(request.contextGraphId);
+    if (graphUpdate.subGraphName) {
+      await this.graphManager.ensureSubGraph(request.contextGraphId, graphUpdate.subGraphName);
+    }
+    const vmGraph = knowledgeAssetLayerGraphUri(
+      request.contextGraphId,
+      MemoryLayer.VerifiableMemory,
+      graphUpdate.scope,
+      graphUpdate.subGraphName,
+    );
+    const swmGraph = knowledgeAssetLayerGraphUri(
+      request.contextGraphId,
+      MemoryLayer.SharedWorkingMemory,
+      graphUpdate.scope,
+      graphUpdate.subGraphName,
+    );
+    const metaGraph = contextGraphMetaUri(request.contextGraphId);
+    const prior = await this.readGraphScopedMetadata(
+      metaGraph,
+      graphUpdate.scope.ual,
+    );
+    // An update replaces content but must inherit access control, publisher,
+    // author, and sub-graph identity from the already-synced KA. Applying it
+    // without the V2 label row would invent those security attributes from
+    // gossip. Defer instead; normal durable sync supplies the authoritative
+    // metadata and current graph together.
+    if (
+      prior.contentScopeVersion !== GRAPH_KA_CONTENT_SCOPE_VERSION
+      || prior.assertionVersion === undefined
+    ) {
+      this.log.warn(
+        ctx,
+        `KA update deferred: graph-scoped metadata for ${graphUpdate.scope.ual} is not synced`,
+      );
+      return;
+    }
+    if (
+      prior.subGraphName !== undefined
+      && prior.subGraphName !== graphUpdate.subGraphName
+    ) {
+      this.log.warn(
+        ctx,
+        `KA update rejected: subGraphName ${graphUpdate.subGraphName ?? '(root)'} conflicts with ` +
+          `existing ${prior.subGraphName} for ${graphUpdate.scope.ual}`,
+      );
+      return;
+    }
+    if (
+      verifiedMerkleRootCount === undefined
+      && prior.assertionVersion !== undefined
+      && BigInt(graphUpdate.scope.assertionVersion) !== prior.assertionVersion + 1n
+    ) {
+      this.log.warn(
+        ctx,
+        `KA update rejected: assertionVersion ${graphUpdate.scope.assertionVersion} does not ` +
+          `follow existing version ${prior.assertionVersion}`,
+      );
+      return;
+    }
+
+    const updateVersion: MaterializedVersion = {
+      blockNumber: verifiedBlockNumber ?? 0,
+      txIndex: verifiedTxIndex ?? 0,
+    };
+    const provenance: OnChainProvenance = {
+      txHash: request.txHash,
+      blockNumber: verifiedBlockNumber ?? Number(request.blockNumber),
+      blockTimestamp: Math.floor(Date.now() / 1000),
+      publisherAddress: request.publisherAddress,
+      batchId: kaId,
+      chainId: this.chain.chainId,
+    };
+    const accessPolicy = prior.accessPolicy
+      ?? (graphUpdate.privateTripleCount > 0 ? 'ownerOnly' : 'public');
+    const metadata = generateGraphKnowledgeAssetMetadata(
+      {
+        ual: graphUpdate.scope.ual,
+        contextGraphId: request.contextGraphId,
+        merkleRoot: computedRoot,
+        publisherPeerId: prior.publisherPeerId ?? request.publisherPeerId ?? fromPeerId,
+        accessPolicy,
+        ...(accessPolicy === 'allowList' && prior.allowedPeers.length > 0
+          ? { allowedPeers: prior.allowedPeers }
+          : {}),
+        timestamp: new Date(),
+        subGraphName: graphUpdate.subGraphName,
+        authorAddress: prior.authorAddress ?? graphUpdate.scope.agentAddress,
+        assertionVersion: graphUpdate.scope.assertionVersion,
+        publicTripleCount: graphUpdate.publicTripleCount,
+        privateTripleCount: graphUpdate.privateTripleCount,
+        ...(graphUpdate.privateMerkleRoot
+          ? { privateMerkleRoot: graphUpdate.privateMerkleRoot }
+          : {}),
+        assertionGraph: vmGraph,
+      },
+      'confirmed',
+      provenance,
+    );
+
+    const outcome = await withMaterializationLock(
+      metaGraph,
+      graphUpdate.scope.ual,
+      async () => {
+        if (!(await shouldApplyMaterialization(
+          this.store,
+          metaGraph,
+          graphUpdate.scope.ual,
+          updateVersion,
+        ))) {
+          return 'stale' as const;
+        }
+        const replaced = await tryReplaceGraphAtomically(
+          this.store,
+          vmGraph,
+          publicQuads.map((quad) => ({ ...quad, graph: vmGraph })),
+          { source: 'publisher.updateHandler.graphScopedReplace' },
+        );
+        if (!replaced) {
+          throw Object.assign(
+            new Error('Graph-scoped KA update requires atomic TripleStore.update() support'),
+            { code: 'VM_ATOMIC_REPLACE_UNSUPPORTED' },
+          );
+        }
+        await this.store.deleteByPattern({ graph: metaGraph, subject: graphUpdate.scope.ual });
+        await this.store.insert(metadata);
+        await writeMaterializedVersion(
+          this.store,
+          metaGraph,
+          graphUpdate.scope.ual,
+          updateVersion,
+        );
+        await this.store.dropGraph(swmGraph);
+        return 'applied' as const;
+      },
+    );
+    if (outcome === 'stale') {
+      this.log.info(
+        ctx,
+        `KA update skipped: a newer graph-scoped assertion is already materialized for kaId=${kaId}`,
+      );
+      return;
+    }
+
+    if (verifiedBlockNumber !== undefined) {
+      this.appliedUpdates.set(`${request.contextGraphId}:${request.batchId}`, {
+        blockNumber: verifiedBlockNumber,
+        txIndex: verifiedTxIndex ?? 0,
+      });
+    }
+    this.log.info(
+      ctx,
+      `Applied graph-scoped KA update: ${publicQuads.length} public triples for kaId=${kaId}`,
+    );
+    this.eventBus.emit(DKGEvent.KA_UPDATED, {
+      contextGraphId: request.contextGraphId,
+      batchId: kaId,
+      rootEntities: [],
+      ual: graphUpdate.scope.ual,
+      assertionVersion: graphUpdate.scope.assertionVersion,
+      txHash: request.txHash,
+      fromPeerId,
+    });
+  }
+
+  private async readGraphScopedMetadata(
+    metaGraph: string,
+    ual: string,
+  ): Promise<{
+    accessPolicy?: 'public' | 'ownerOnly' | 'allowList';
+    allowedPeers: string[];
+    publisherPeerId?: string;
+    authorAddress?: string;
+    subGraphName?: string;
+    assertionVersion?: bigint;
+    contentScopeVersion?: number;
+  }> {
+    const result = await this.store.query(
+      `SELECT ?policy ?allowedPeer ?publisherPeerId ?attributedTo ?subGraphName ?version ?scopeVersion WHERE {
+         GRAPH <${metaGraph}> {
+           OPTIONAL { <${ual}> <${DKG_NS}accessPolicy> ?policy }
+           OPTIONAL { <${ual}> <${DKG_NS}allowedPeer> ?allowedPeer }
+           OPTIONAL { <${ual}> <${DKG_NS}publisherPeerId> ?publisherPeerId }
+           OPTIONAL { <${ual}> <${PROV_NS}wasAttributedTo> ?attributedTo }
+           OPTIONAL { <${ual}> <${DKG_NS}subGraphName> ?subGraphName }
+           OPTIONAL { <${ual}> <${DKG_NS}assertionVersion> ?version }
+           OPTIONAL { <${ual}> <${DKG_NS}contentScopeVersion> ?scopeVersion }
+         }
+       }`,
+    );
+    if (result.type !== 'bindings') return { allowedPeers: [] };
+    const allowedPeers = new Set<string>();
+    let accessPolicy: 'public' | 'ownerOnly' | 'allowList' | undefined;
+    let publisherPeerId: string | undefined;
+    let authorAddress: string | undefined;
+    let subGraphName: string | undefined;
+    let assertionVersion: bigint | undefined;
+    let contentScopeVersion: number | undefined;
+    for (const row of result.bindings) {
+      const policy = stripRdfLiteral(row['policy']);
+      if (policy === 'public' || policy === 'ownerOnly' || policy === 'allowList') {
+        accessPolicy = policy;
+      }
+      const allowedPeer = stripRdfLiteral(row['allowedPeer']);
+      if (allowedPeer) allowedPeers.add(allowedPeer);
+      publisherPeerId ??= stripRdfLiteral(row['publisherPeerId']) || undefined;
+      subGraphName ??= stripRdfLiteral(row['subGraphName']) || undefined;
+      const attributedTo = row['attributedTo'] ?? '';
+      const authorMatch = /^did:dkg:agent:(0x[0-9a-f]{40})$/i.exec(attributedTo);
+      if (authorMatch) authorAddress ??= authorMatch[1];
+      const version = stripRdfLiteral(row['version']);
+      if (version && assertionVersion === undefined) {
+        try { assertionVersion = BigInt(version); } catch { /* malformed prior metadata */ }
+      }
+      const scopeVersion = stripRdfLiteral(row['scopeVersion']);
+      if (scopeVersion && contentScopeVersion === undefined) {
+        const parsed = Number(scopeVersion);
+        if (Number.isSafeInteger(parsed)) contentScopeVersion = parsed;
+      }
+    }
+    return {
+      accessPolicy,
+      allowedPeers: [...allowedPeers],
+      publisherPeerId,
+      authorAddress,
+      subGraphName,
+      assertionVersion,
+      contentScopeVersion,
+    };
+  }
+
   /**
    * Look up the context graph a batch was originally published on by querying local
    * KC metadata. Returns undefined if the batch is unknown to this node.
@@ -437,4 +888,14 @@ function buffersEqual(a: Uint8Array, b: Uint8Array): boolean {
     if (a[i] !== b[i]) return false;
   }
   return true;
+}
+
+function stripRdfLiteral(value: string | undefined): string {
+  if (!value?.startsWith('"')) return value ?? '';
+  const typedIndex = value.indexOf('"^^');
+  if (typedIndex > 0) return value.slice(1, typedIndex);
+  const languageIndex = value.lastIndexOf('"@');
+  if (languageIndex > 0) return value.slice(1, languageIndex);
+  const lastQuote = value.lastIndexOf('"');
+  return value.slice(1, lastQuote > 0 ? lastQuote : undefined);
 }

--- a/packages/publisher/src/update-handler.ts
+++ b/packages/publisher/src/update-handler.ts
@@ -1,5 +1,5 @@
 import type { TripleStore, Quad } from '@origintrail-official/dkg-storage';
-import { GraphManager, tryReplaceGraphAtomically } from '@origintrail-official/dkg-storage';
+import { GraphManager } from '@origintrail-official/dkg-storage';
 import type {
   EventBus,
   KAUpdateRequestMsg,
@@ -18,10 +18,13 @@ import {
   GRAPH_KA_CONTENT_SCOPE_VERSION,
   knowledgeAssetLayerGraphUri,
   validateSubGraphName,
+  assertSafeIri,
+  assertSafeRdfTerm,
 } from '@origintrail-official/dkg-core';
 import { decodeKAUpdateRequest } from '@origintrail-official/dkg-core';
 import { parseSimpleNQuads } from './publish-handler.js';
 import { skolemizeByEntity } from './auto-partition.js';
+import { validateKnowledgeAssetPublishRequest } from './validation.js';
 import { computeTripleHashV10 as computeTripleHash, computeFlatKCRootV10 as computeFlatKCRoot } from './merkle.js';
 import {
   promoteUpdatedKaToPerCgId,
@@ -30,7 +33,6 @@ import {
   generateGraphKnowledgeAssetMetadata,
   shouldApplyMaterialization,
   withMaterializationLock,
-  writeMaterializedVersion,
   type MaterializedVersion,
   type OnChainProvenance,
 } from './metadata.js';
@@ -67,8 +69,7 @@ function resolveGraphScopedUpdateRequest(
     || Boolean(request.assertionVersion)
     || (request.publicTripleCount ?? 0) > 0
     || privateMerkleRoot !== undefined
-    || (request.privateTripleCount ?? 0) > 0
-    || Boolean(request.subGraphName);
+    || (request.privateTripleCount ?? 0) > 0;
   if (!hasGraphField) return undefined;
   if (request.contentScopeVersion !== GRAPH_KA_CONTENT_SCOPE_VERSION) {
     throw new Error(
@@ -615,6 +616,18 @@ export class UpdateHandler {
       graphUpdate.subGraphName,
     );
     const metaGraph = contextGraphMetaUri(request.contextGraphId);
+    const validation = validateKnowledgeAssetPublishRequest(
+      parsed,
+      vmGraph,
+      graphUpdate.publicTripleCount,
+    );
+    if (!validation.valid) {
+      this.log.warn(
+        ctx,
+        `KA update rejected: invalid graph-scoped RDF for kaId=${kaId}: ${validation.errors.join('; ')}`,
+      );
+      return;
+    }
     const prior = await this.readGraphScopedMetadata(
       metaGraph,
       graphUpdate.scope.ual,
@@ -635,8 +648,7 @@ export class UpdateHandler {
       return;
     }
     if (
-      prior.subGraphName !== undefined
-      && prior.subGraphName !== graphUpdate.subGraphName
+      prior.subGraphName !== graphUpdate.subGraphName
     ) {
       this.log.warn(
         ctx,
@@ -709,26 +721,22 @@ export class UpdateHandler {
         ))) {
           return 'stale' as const;
         }
-        const replaced = await tryReplaceGraphAtomically(
-          this.store,
+        const replaced = await this.replaceGraphScopedMaterializationAtomically({
           vmGraph,
-          publicQuads.map((quad) => ({ ...quad, graph: vmGraph })),
-          { source: 'publisher.updateHandler.graphScopedReplace' },
-        );
+          metaGraph,
+          ual: graphUpdate.scope.ual,
+          publicQuads,
+          metadata,
+          version: updateVersion,
+        });
         if (!replaced) {
           throw Object.assign(
-            new Error('Graph-scoped KA update requires atomic TripleStore.update() support'),
-            { code: 'VM_ATOMIC_REPLACE_UNSUPPORTED' },
+            new Error(
+              'Graph-scoped KA update requires atomic cross-graph TripleStore.update() support',
+            ),
+            { code: 'KA_MATERIALIZATION_ATOMIC_UPDATE_UNSUPPORTED' },
           );
         }
-        await this.store.deleteByPattern({ graph: metaGraph, subject: graphUpdate.scope.ual });
-        await this.store.insert(metadata);
-        await writeMaterializedVersion(
-          this.store,
-          metaGraph,
-          graphUpdate.scope.ual,
-          updateVersion,
-        );
         await this.store.dropGraph(swmGraph);
         return 'applied' as const;
       },
@@ -760,6 +768,52 @@ export class UpdateHandler {
       txHash: request.txHash,
       fromPeerId,
     });
+  }
+
+  /**
+   * Replace the authoritative VM payload, its complete metadata row set, and
+   * the materialization version in one backend transaction. A crash can no
+   * longer commit the new payload while deleting the only access/version
+   * metadata needed to replay it.
+   */
+  private async replaceGraphScopedMaterializationAtomically(input: {
+    vmGraph: string;
+    metaGraph: string;
+    ual: string;
+    publicQuads: readonly Quad[];
+    metadata: readonly Quad[];
+    version: MaterializedVersion;
+  }): Promise<boolean> {
+    if (typeof this.store.update !== 'function') return false;
+    const vmGraph = assertSafeIri(input.vmGraph);
+    const metaGraph = assertSafeIri(input.metaGraph);
+    const ual = assertSafeIri(input.ual);
+    const vmTriples = input.publicQuads
+      .map((quad) => formatSparqlTriple({ ...quad, graph: vmGraph }))
+      .join('\n');
+    const metaRows: Quad[] = [
+      ...input.metadata.map((quad) => ({ ...quad, graph: metaGraph })),
+      {
+        subject: ual,
+        predicate: `${DKG_NS}materializedVersion`,
+        object: `"${input.version.blockNumber}:${input.version.txIndex}"`,
+        graph: metaGraph,
+      },
+    ];
+    const metaTriples = metaRows.map(formatSparqlTriple).join('\n');
+    const update = [
+      `DROP SILENT GRAPH <${vmGraph}>`,
+      vmTriples.length > 0
+        ? `INSERT DATA { GRAPH <${vmGraph}> {\n${vmTriples}\n} }`
+        : '',
+      `DELETE WHERE { GRAPH <${metaGraph}> { <${ual}> ?p ?o } }`,
+      `INSERT DATA { GRAPH <${metaGraph}> {\n${metaTriples}\n} }`,
+    ].filter(Boolean).join(';\n');
+    await this.store.update(update, {
+      touchedGraphs: [vmGraph, metaGraph],
+      source: 'publisher.updateHandler.graphScopedMaterialization',
+    });
+    return true;
   }
 
   private async readGraphScopedMetadata(
@@ -898,4 +952,21 @@ function stripRdfLiteral(value: string | undefined): string {
   if (languageIndex > 0) return value.slice(1, languageIndex);
   const lastQuote = value.lastIndexOf('"');
   return value.slice(1, lastQuote > 0 ? lastQuote : undefined);
+}
+
+function formatSparqlTriple(quad: Quad): string {
+  const resource = (term: string): string => {
+    const unwrapped = term.startsWith('<') && term.endsWith('>')
+      ? term.slice(1, -1)
+      : term;
+    return `<${assertSafeIri(unwrapped)}>`;
+  };
+  let object: string;
+  if (quad.object.startsWith('"')) {
+    assertSafeRdfTerm(quad.object);
+    object = quad.object;
+  } else {
+    object = resource(quad.object);
+  }
+  return `${resource(quad.subject)} ${resource(quad.predicate)} ${object} .`;
 }

--- a/packages/publisher/src/update-handler.ts
+++ b/packages/publisher/src/update-handler.ts
@@ -620,6 +620,10 @@ export class UpdateHandler {
       parsed,
       vmGraph,
       graphUpdate.publicTripleCount,
+      // Graph-scoped update wire data is the producer's canonical payload.
+      // `validateKnowledgeAssetPublishRequest` still rejects non-canonical
+      // terms in the protocol-reserved namespace.
+      { allowCanonicalSkolemTerms: true },
     );
     if (!validation.valid) {
       this.log.warn(

--- a/packages/publisher/src/validation.ts
+++ b/packages/publisher/src/validation.ts
@@ -7,6 +7,7 @@ import {
   trustedCatalogTripleKeySet,
   type TrustedCatalogTripleKeys,
 } from './catalog-trust.js';
+import { KNOWLEDGE_ASSET_SKOLEM_PREFIX } from './auto-partition.js';
 
 export interface ValidationResult {
   valid: boolean;
@@ -38,6 +39,7 @@ export function validateKnowledgeAssetPublishRequest(
   nquads: readonly Quad[],
   expectedGraph: string,
   publicTripleCount: number,
+  options: { allowCanonicalSkolemTerms?: boolean } = {},
 ): ValidationResult {
   const errors: string[] = [];
 
@@ -68,9 +70,13 @@ export function validateKnowledgeAssetPublishRequest(
       );
     } else if (!isSafeIri(quad.subject)) {
       errors.push(`Graph-scoped KA quad ${index} has an unsafe subject IRI`);
+    } else if (isForbiddenKnowledgeAssetSkolemTerm(quad.subject, options)) {
+      errors.push(`Graph-scoped KA quad ${index} uses the reserved KA skolem namespace in its subject`);
     }
     if (!isSafeIri(quad.predicate)) {
       errors.push(`Graph-scoped KA quad ${index} has an unsafe predicate IRI`);
+    } else if (quad.predicate.toLowerCase().startsWith(KNOWLEDGE_ASSET_SKOLEM_PREFIX)) {
+      errors.push(`Graph-scoped KA quad ${index} uses the reserved KA skolem namespace in its predicate`);
     }
     if (isBlankNode(quad.object)) {
       errors.push(
@@ -85,10 +91,30 @@ export function validateKnowledgeAssetPublishRequest(
       } catch {
         errors.push(`Graph-scoped KA quad ${index} has an unsafe RDF object`);
       }
+      if (
+        !quad.object.startsWith('"')
+        && isForbiddenKnowledgeAssetSkolemTerm(quad.object, options)
+      ) {
+        errors.push(`Graph-scoped KA quad ${index} uses the reserved KA skolem namespace in its object`);
+      }
+    }
+    if (quad.graph.toLowerCase().startsWith(KNOWLEDGE_ASSET_SKOLEM_PREFIX)) {
+      errors.push(`Graph-scoped KA quad ${index} uses the reserved KA skolem namespace as its graph`);
     }
   }
 
   return { valid: errors.length === 0, errors };
+}
+
+function isForbiddenKnowledgeAssetSkolemTerm(
+  term: string,
+  options: { allowCanonicalSkolemTerms?: boolean },
+): boolean {
+  if (!term.toLowerCase().startsWith(KNOWLEDGE_ASSET_SKOLEM_PREFIX)) return false;
+  return !(
+    options.allowCanonicalSkolemTerms === true
+    && /^urn:dkg:ka-skolem:c14n[0-9]+$/.test(term)
+  );
 }
 
 /**

--- a/packages/publisher/test/ka-graph-publish-storage.test.ts
+++ b/packages/publisher/test/ka-graph-publish-storage.test.ts
@@ -172,6 +172,48 @@ describe('graph-scoped KA publish storage', () => {
     expect(replaced.bindings).toEqual([{ s: 'urn:version:two' }]);
   });
 
+  it.each([
+    ['ownerOnly' as const, undefined],
+    ['allowList' as const, ['peer-a', 'peer-b']],
+  ])('inherits %s access metadata on originator updates', async (accessPolicy, allowedPeers) => {
+    const initial = await publisher.publish({
+      contextGraphId: CONTEXT_GRAPH,
+      quads: [quad('urn:access:data', 'urn:predicate:value', '"old"')],
+      publisherPeerId: 'original-peer',
+      accessPolicy,
+      ...(allowedPeers ? { allowedPeers } : {}),
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      kaUal: UAL,
+      assertionVersion: 1,
+      publicTripleCount: 1,
+    });
+
+    await publisher.update(initial.kaId, {
+      contextGraphId: CONTEXT_GRAPH,
+      quads: [quad('urn:access:data', 'urn:predicate:value', '"new"')],
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      kaUal: UAL,
+      assertionVersion: 2,
+      publicTripleCount: 1,
+    });
+
+    const metaGraph = `did:dkg:context-graph:${CONTEXT_GRAPH}/_meta`;
+    const rows = await store.query(
+      `SELECT ?policy ?peer ?publisher WHERE { GRAPH <${metaGraph}> {
+         <${UAL}> <http://dkg.io/ontology/accessPolicy> ?policy ;
+           <http://dkg.io/ontology/publisherPeerId> ?publisher .
+         OPTIONAL { <${UAL}> <http://dkg.io/ontology/allowedPeer> ?peer }
+       } }`,
+    );
+    expect(rows.type).toBe('bindings');
+    if (rows.type !== 'bindings') throw new Error('expected access metadata bindings');
+    expect(new Set(rows.bindings.map((row) => row.policy))).toEqual(new Set([`"${accessPolicy}"`]));
+    expect(new Set(rows.bindings.map((row) => row.publisher))).toEqual(new Set(['"original-peer"']));
+    expect(new Set(rows.bindings.map((row) => row.peer).filter(Boolean))).toEqual(
+      new Set(allowedPeers?.map((peer) => `"${peer}"`) ?? []),
+    );
+  });
+
   it('updates a fully private KA from SWM without requiring a public placeholder', async () => {
     const initialPrivate = [
       quad('urn:private:only', 'urn:predicate:secret', '"one"'),

--- a/packages/publisher/test/ka-graph-publish-storage.test.ts
+++ b/packages/publisher/test/ka-graph-publish-storage.test.ts
@@ -12,6 +12,7 @@ import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
 import {
   DKGPublisher,
   computePrivateRootV10,
+  generatedPrivateCatalogTripleKeys,
   skolemizeKnowledgeAsset,
 } from '../src/index.js';
 
@@ -169,6 +170,103 @@ describe('graph-scoped KA publish storage', () => {
     expect(replaced.type).toBe('bindings');
     if (replaced.type !== 'bindings') throw new Error('expected bindings');
     expect(replaced.bindings).toEqual([{ s: 'urn:version:two' }]);
+  });
+
+  it('updates a fully private KA from SWM without requiring a public placeholder', async () => {
+    const initialPrivate = [
+      quad('urn:private:only', 'urn:predicate:secret', '"one"'),
+    ];
+    const canonicalInitial = await skolemizeKnowledgeAsset(initialPrivate);
+    const initial = await publisher.publish({
+      contextGraphId: CONTEXT_GRAPH,
+      quads: [],
+      privateQuads: initialPrivate,
+      publisherPeerId: 'rootless-private-publisher',
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      kaUal: UAL,
+      assertionVersion: 1,
+      publicTripleCount: 0,
+      privateTripleCount: canonicalInitial.length,
+      privateMerkleRoot: computePrivateRootV10(canonicalInitial),
+    });
+    const replacementPrivate = [
+      quad('urn:private:only', 'urn:predicate:secret', '"two"'),
+      quad('urn:private:second', 'urn:predicate:secret', '"three"'),
+    ];
+    const canonicalReplacement = await skolemizeKnowledgeAsset(replacementPrivate);
+
+    const updated = await publisher.updateKnowledgeAssetFromSharedMemory(initial.kaId, {
+      contextGraphId: CONTEXT_GRAPH,
+      privateQuads: replacementPrivate,
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      kaUal: UAL,
+      assertionVersion: 2,
+      publicTripleCount: 0,
+      privateTripleCount: canonicalReplacement.length,
+      privateMerkleRoot: computePrivateRootV10(canonicalReplacement),
+    });
+
+    expect(updated.status).toBe('tentative');
+    expect(updated.publicQuads).toEqual([]);
+    const privateStore = (publisher as unknown as {
+      privateStore: {
+        getKnowledgeAssetPrivateTriples: (
+          contextGraphId: string,
+          scope: ReturnType<typeof createGraphKnowledgeAssetScope>,
+        ) => Promise<Quad[]>;
+      };
+    }).privateStore;
+    expect(await privateStore.getKnowledgeAssetPrivateTriples(
+      CONTEXT_GRAPH,
+      createGraphKnowledgeAssetScope(UAL, 2),
+    )).toEqual(canonicalReplacement);
+  });
+
+  it('refreshes only the deterministic curated catalog floor on a trusted SWM update', async () => {
+    const initial = await publisher.publish({
+      contextGraphId: CONTEXT_GRAPH,
+      quads: [quad('urn:curated:data', 'urn:predicate:value', '"old"')],
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      kaUal: UAL,
+      assertionVersion: 1,
+      publicTripleCount: 1,
+    });
+    const scope = createGraphKnowledgeAssetScope(UAL, 2);
+    const swmGraph = knowledgeAssetLayerGraphUri(
+      CONTEXT_GRAPH,
+      MemoryLayer.SharedWorkingMemory,
+      scope,
+    );
+    await store.insert([{
+      ...quad('urn:curated:data', 'urn:predicate:value', '"new"'),
+      graph: swmGraph,
+    }]);
+
+    await publisher.updateKnowledgeAssetFromSharedMemory(initial.kaId, {
+      contextGraphId: CONTEXT_GRAPH,
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      kaUal: UAL,
+      assertionVersion: 2,
+      publicTripleCount: 5,
+      privateTripleCount: 0,
+      trustedNonManifestCatalogTriples:
+        generatedPrivateCatalogTripleKeys(CONTEXT_GRAPH),
+    });
+
+    const vmGraph = knowledgeAssetLayerGraphUri(
+      CONTEXT_GRAPH,
+      MemoryLayer.VerifiableMemory,
+      scope,
+    );
+    expect(await store.countQuads(vmGraph)).toBe(5);
+    const catalogRows = await store.query(
+      `SELECT ?p ?o WHERE { GRAPH <${vmGraph}> {
+         <did:dkg:context-graph:${CONTEXT_GRAPH}> ?p ?o
+       } }`,
+    );
+    expect(catalogRows.type).toBe('bindings');
+    if (catalogRows.type !== 'bindings') throw new Error('expected catalog bindings');
+    expect(catalogRows.bindings).toHaveLength(4);
   });
 
   it('rejects legacy and incomplete mutation envelopes before writing', async () => {

--- a/packages/publisher/test/ka-graph-pull-from.test.ts
+++ b/packages/publisher/test/ka-graph-pull-from.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import { NoChainAdapter } from '@origintrail-official/dkg-chain';
+import {
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  MemoryLayer,
+  TypedEventBus,
+  assertionLifecycleUri,
+  buildAssertionSealQuads,
+  contextGraphAssertionUri,
+  contextGraphMetaUri,
+  createGraphKnowledgeAssetScope,
+  generateEd25519Keypair,
+  knowledgeAssetLayerGraphUri,
+} from '@origintrail-official/dkg-core';
+import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
+import { DKGPublisher } from '../src/index.js';
+
+const CG = 'graph-pull-from-test';
+const AGENT = '0x00000000000000000000000000000000000000a1';
+const NAME = 'rootless-public-update';
+const DKG = 'http://dkg.io/ontology/';
+const UAL = `did:dkg:evm:31337/${AGENT}/7`;
+
+function q(subject: string, predicate: string, object: string, graph: string): Quad {
+  return { subject, predicate, object, graph };
+}
+
+describe('graph-scoped KA pull-from', () => {
+  it('reopens a rootless public KA from its exact VM graph', async () => {
+    const store = new OxigraphStore();
+    const publisher = new DKGPublisher({
+      store,
+      chain: new NoChainAdapter(),
+      eventBus: new TypedEventBus(),
+      keypair: await generateEd25519Keypair(),
+    });
+    const scope = createGraphKnowledgeAssetScope(UAL, 1);
+    const vmGraph = knowledgeAssetLayerGraphUri(CG, MemoryLayer.VerifiableMemory, scope);
+    const adjacentVmGraph = knowledgeAssetLayerGraphUri(
+      CG,
+      MemoryLayer.VerifiableMemory,
+      createGraphKnowledgeAssetScope(`did:dkg:evm:31337/${AGENT}/8`, 1),
+    );
+    const assertionUri = contextGraphAssertionUri(CG, AGENT, NAME);
+    const lifecycle = assertionLifecycleUri(CG, AGENT, NAME);
+    const metaGraph = contextGraphMetaUri(CG);
+    const seal = buildAssertionSealQuads({
+      assertionUri,
+      metaGraph,
+      merkleRoot: new Uint8Array(32).fill(9),
+      authorAddress: AGENT,
+      authorAttestationR: new Uint8Array(32).fill(1),
+      authorAttestationVS: new Uint8Array(32).fill(2),
+      authorSchemeVersion: 1,
+      chainId: 31337n,
+      kav10Address: AGENT,
+      reservedKaId: (BigInt(AGENT) << 96n) | 7n,
+      finalizedAtIso: '2026-01-01T00:00:00.000Z',
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      kaUal: UAL,
+      assertionVersion: 1,
+      publicTripleCount: 2,
+      privateTripleCount: 0,
+    }) as Quad[];
+    await store.insert([
+      q('urn:entity:alice', 'http://schema.org/name', '"Alice v1"', vmGraph),
+      q('urn:entity:bob', 'http://schema.org/name', '"Bob v1"', vmGraph),
+      q('urn:entity:mallory', 'http://schema.org/name', '"Adjacent KA"', adjacentVmGraph),
+      ...seal,
+      q(lifecycle, `${DKG}kaId`, '"7"^^<http://www.w3.org/2001/XMLSchema#integer>', metaGraph),
+      q(lifecycle, `${DKG}reservedUal`, `"${UAL}"`, metaGraph),
+      q(lifecycle, `${DKG}contentScopeVersion`, `"${GRAPH_KA_CONTENT_SCOPE_VERSION}"^^<http://www.w3.org/2001/XMLSchema#integer>`, metaGraph),
+    ]);
+
+    const result = await publisher.assertionPullFrom(CG, NAME, AGENT, 'vm');
+
+    expect(result).toMatchObject({ fromLayer: 'vm', entities: 0, seeded: 2 });
+    expect(await publisher.assertionQuery(CG, NAME, AGENT)).toEqual(expect.arrayContaining([
+      expect.objectContaining({ subject: 'urn:entity:alice', object: '"Alice v1"' }),
+      expect.objectContaining({ subject: 'urn:entity:bob', object: '"Bob v1"' }),
+    ]));
+    expect(await publisher.assertionQuery(CG, NAME, AGENT)).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ subject: 'urn:entity:mallory' }),
+    ]));
+    const staleSeal = await store.query(
+      `ASK { GRAPH <${metaGraph}> { <${assertionUri}> <${DKG}assertionMerkleRoot> ?root } }`,
+    );
+    expect(staleSeal).toMatchObject({ type: 'boolean', value: false });
+  });
+});

--- a/packages/publisher/test/ka-graph-update-ack.test.ts
+++ b/packages/publisher/test/ka-graph-update-ack.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it } from 'vitest';
+import { ethers } from 'ethers';
+import {
+  computeCatalogRoot,
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  MemoryLayer,
+  STORAGE_ACK_DECLINE_CODES,
+  TypedEventBus,
+  createGraphKnowledgeAssetScope,
+  decodeStorageACK,
+  encodeUpdateIntent,
+  isStorageACKDecline,
+  knowledgeAssetLayerGraphUri,
+} from '@origintrail-official/dkg-core';
+import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
+import { ACKCollector, type ACKCollectorDeps } from '../src/ack-collector.js';
+import {
+  StorageACKHandler,
+  type StorageACKHandlerConfig,
+} from '../src/storage-ack-handler.js';
+import {
+  computeFlatKCMerkleLeafCountV10,
+  computeFlatKCRootV10,
+} from '../src/merkle.js';
+
+const TARGET_CG_ID = '42';
+const SOURCE_CG_ID = 'private-rootless-cg';
+const AUTHOR = '0x1111111111111111111111111111111111111111';
+const UAL = `did:dkg:otp:20430/${AUTHOR}/7`;
+const KA_ID = (BigInt(AUTHOR) << 96n) | 7n;
+const SCOPE = createGraphKnowledgeAssetScope(UAL, 2);
+const EXACT_SWM_GRAPH = knowledgeAssetLayerGraphUri(
+  SOURCE_CG_ID,
+  MemoryLayer.SharedWorkingMemory,
+  SCOPE,
+);
+const LEGACY_SWM_GRAPH = `did:dkg:context-graph:${SOURCE_CG_ID}/_shared_memory`;
+const PRIVATE_ROOT = ethers.getBytes(
+  ethers.keccak256(ethers.toUtf8Bytes('rootless-private-update')),
+);
+const PEER = { toString: () => 'publisher-peer' };
+
+function config(wallet: ethers.Wallet, curated = false): StorageACKHandlerConfig {
+  return {
+    nodeRole: 'core',
+    nodeIdentityId: 17n,
+    signerWallet: wallet,
+    contextGraphSharedMemoryUri: (cgId: string) =>
+      `did:dkg:context-graph:${cgId}/_shared_memory`,
+    chainId: 31337n,
+    kav10Address: '0x000000000000000000000000000000000000c10a',
+    isCgCurated: async () => curated,
+  };
+}
+
+function byteSizeFloor(quads: readonly Quad[]): number {
+  return quads.reduce(
+    (sum, quad) => sum
+      + Buffer.byteLength(quad.subject, 'utf8')
+      + Buffer.byteLength(quad.predicate, 'utf8')
+      + Buffer.byteLength(quad.object, 'utf8'),
+    0,
+  );
+}
+
+function intent(
+  publicQuads: readonly Quad[],
+  privateTripleCount: number,
+  overrides: Record<string, unknown> = {},
+): Uint8Array {
+  const privateRoots = privateTripleCount > 0 ? [PRIVATE_ROOT] : [];
+  return encodeUpdateIntent({
+    kaId: KA_ID.toString(),
+    contextGraphId: TARGET_CG_ID,
+    swmGraphId: SOURCE_CG_ID,
+    preUpdateMerkleRootCount: 1,
+    newMerkleRoot: computeFlatKCRootV10([...publicQuads], privateRoots),
+    newByteSize: Math.max(1, byteSizeFloor(publicQuads)),
+    newTokenAmount: '1000',
+    mintAmount: 0,
+    burnTokenIds: [],
+    newMerkleLeafCount: computeFlatKCMerkleLeafCountV10(
+      [...publicQuads],
+      privateRoots,
+    ),
+    publisherPeerId: 'publisher-peer',
+    contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+    kaUal: UAL,
+    assertionVersion: '2',
+    publicTripleCount: publicQuads.length,
+    ...(privateTripleCount > 0 ? { privateMerkleRoot: PRIVATE_ROOT } : {}),
+    privateTripleCount,
+    ...overrides,
+  });
+}
+
+describe('StorageACKHandler graph-scoped updates', () => {
+  it('verifies a public-plus-private update from only its exact per-KA SWM graph', async () => {
+    const store = new OxigraphStore();
+    const quads: Quad[] = [
+      { subject: 'urn:entity:a', predicate: 'urn:p:value', object: '"a"', graph: EXACT_SWM_GRAPH },
+      { subject: 'urn:entity:b', predicate: 'urn:p:value', object: '"b"', graph: EXACT_SWM_GRAPH },
+    ];
+    await store.insert([
+      ...quads,
+      // Deliberately poison the legacy shared bucket. A fallback to it would
+      // change both the triple count and Merkle root and therefore decline.
+      { subject: 'urn:legacy', predicate: 'urn:p:value', object: '"wrong"', graph: LEGACY_SWM_GRAPH },
+    ]);
+    const handler = new StorageACKHandler(
+      store,
+      config(ethers.Wallet.createRandom()),
+      new TypedEventBus(),
+    );
+
+    const ack = decodeStorageACK(await handler.updateHandler(intent(quads, 3), PEER));
+
+    expect(isStorageACKDecline(ack)).toBe(false);
+    expect(ethers.hexlify(ack.merkleRoot)).toBe(
+      ethers.hexlify(computeFlatKCRootV10(quads, [PRIVATE_ROOT])),
+    );
+  });
+
+  it('collects an ACK for a fully private curated update without a public placeholder', async () => {
+    const store = new OxigraphStore();
+    // The legacy bucket must not become an accidental public placeholder.
+    await store.insert([{
+      subject: 'urn:legacy',
+      predicate: 'urn:p:value',
+      object: '"wrong"',
+      graph: LEGACY_SWM_GRAPH,
+    }]);
+    const handler = new StorageACKHandler(
+      store,
+      config(ethers.Wallet.createRandom(), true),
+      new TypedEventBus(),
+    );
+    const catalogTriples = [{
+      subject: `did:dkg:context-graph:${TARGET_CG_ID}`,
+      predicate: 'http://purl.org/dc/terms/identifier',
+      object: `"did:dkg:context-graph:${TARGET_CG_ID}"`,
+    }];
+    const catalogCommitment = computeCatalogRoot(catalogTriples);
+    const catalogNquads = new TextEncoder().encode(
+      catalogTriples.map((quad) =>
+        `<${quad.subject}> <${quad.predicate}> ${quad.object} .`,
+      ).join('\n'),
+    );
+    const root = computeFlatKCRootV10([], [PRIVATE_ROOT]);
+    const deps: ACKCollectorDeps = {
+      gossipPublish: async () => {},
+      sendP2P: async (_peerId, _protocol, data) => handler.updateHandler(data, PEER),
+      getConnectedCorePeers: () => ['core-1'],
+      verifyIdentity: async () => true,
+      log: () => {},
+    };
+    const collector = new ACKCollector(deps);
+
+    const result = await collector.collectUpdate({
+      kaId: KA_ID,
+      contextGraphId: BigInt(TARGET_CG_ID),
+      preUpdateMerkleRootCount: 1n,
+      newMerkleRoot: root,
+      newByteSize: BigInt(catalogNquads.length),
+      newTokenAmount: 1000n,
+      mintAmount: 0n,
+      burnTokenIds: [],
+      newMerkleLeafCount: 0,
+      newCatalogRoot: catalogCommitment.root,
+      newCatalogLeafCount: catalogCommitment.leafCount,
+      chainId: 31337n,
+      kav10Address: '0x000000000000000000000000000000000000c10a',
+      publisherPeerId: 'publisher-peer',
+      requiredACKs: 1,
+      swmGraphId: SOURCE_CG_ID,
+      stagingQuads: catalogNquads,
+      isEncryptedPayload: true,
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      kaUal: UAL,
+      assertionVersion: '2',
+      publicTripleCount: 0,
+      privateMerkleRoot: PRIVATE_ROOT,
+      privateTripleCount: 9,
+    });
+
+    expect(result.acks).toHaveLength(1);
+    expect(ethers.hexlify(result.merkleRoot)).toBe(ethers.hexlify(root));
+  });
+
+  it('does not discover graph-scoped update data from the legacy shared bucket', async () => {
+    const store = new OxigraphStore();
+    const content: Quad[] = [{
+      subject: 'urn:entity:a',
+      predicate: 'urn:p:value',
+      object: '"a"',
+      graph: LEGACY_SWM_GRAPH,
+    }];
+    await store.insert(content);
+    const handler = new StorageACKHandler(
+      store,
+      config(ethers.Wallet.createRandom()),
+      new TypedEventBus(),
+    );
+
+    const ack = decodeStorageACK(await handler.updateHandler(intent(content, 0), PEER));
+
+    expect(isStorageACKDecline(ack)).toBe(true);
+    expect(ack.declineCode).toBe(STORAGE_ACK_DECLINE_CODES.MERKLE_MISMATCH_IN_SWM);
+    expect(ack.declineMessage).toContain('public triple count mismatch');
+  });
+
+  it('rejects an assertion version that is not pre-update count plus one', async () => {
+    const handler = new StorageACKHandler(
+      new OxigraphStore(),
+      config(ethers.Wallet.createRandom()),
+      new TypedEventBus(),
+    );
+
+    await expect(handler.updateHandler(intent([], 1, {
+      assertionVersion: '3',
+    }), PEER)).rejects.toThrow('must equal preUpdateMerkleRootCount + 1');
+  });
+
+  it('rejects a non-canonical sub-graph before deriving an SWM graph URI', async () => {
+    const handler = new StorageACKHandler(
+      new OxigraphStore(),
+      config(ethers.Wallet.createRandom()),
+      new TypedEventBus(),
+    );
+
+    await expect(handler.updateHandler(intent([], 1, {
+      subGraphName: 'nested/graph',
+    }), PEER)).rejects.toThrow('invalid graph-scoped subGraphName');
+  });
+});

--- a/packages/publisher/test/ka-graph-update-ack.test.ts
+++ b/packages/publisher/test/ka-graph-update-ack.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import { ethers } from 'ethers';
 import {
+  MockChainAdapter,
+  NoChainAdapter,
+  type TxResult,
+  type V10UpdateKAParams,
+} from '@origintrail-official/dkg-chain';
+import {
   computeCatalogRoot,
   GRAPH_KA_CONTENT_SCOPE_VERSION,
   MemoryLayer,
@@ -10,11 +16,13 @@ import {
   createGraphKnowledgeAssetScope,
   decodeStorageACK,
   encodeUpdateIntent,
+  generateEd25519Keypair,
   isStorageACKDecline,
   knowledgeAssetLayerGraphUri,
 } from '@origintrail-official/dkg-core';
 import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
 import { ACKCollector, type ACKCollectorDeps } from '../src/ack-collector.js';
+import { DKGPublisher } from '../src/dkg-publisher.js';
 import {
   StorageACKHandler,
   type StorageACKHandlerConfig,
@@ -23,13 +31,22 @@ import {
   computeFlatKCMerkleLeafCountV10,
   computeFlatKCRootV10,
 } from '../src/merkle.js';
+import { buildUpdateSeal, mockSealCtx } from './_helpers/seal.js';
 
 const TARGET_CG_ID = '42';
 const SOURCE_CG_ID = 'private-rootless-cg';
-const AUTHOR = '0x1111111111111111111111111111111111111111';
+const PRODUCER_WALLET = new ethers.Wallet(
+  '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d',
+);
+const AUTHOR = PRODUCER_WALLET.address.toLowerCase();
 const UAL = `did:dkg:otp:20430/${AUTHOR}/7`;
 const KA_ID = (BigInt(AUTHOR) << 96n) | 7n;
 const SCOPE = createGraphKnowledgeAssetScope(UAL, 2);
+const EXACT_VM_GRAPH = knowledgeAssetLayerGraphUri(
+  SOURCE_CG_ID,
+  MemoryLayer.VerifiableMemory,
+  SCOPE,
+);
 const EXACT_SWM_GRAPH = knowledgeAssetLayerGraphUri(
   SOURCE_CG_ID,
   MemoryLayer.SharedWorkingMemory,
@@ -40,6 +57,36 @@ const PRIVATE_ROOT = ethers.getBytes(
   ethers.keccak256(ethers.toUtf8Bytes('rootless-private-update')),
 );
 const PEER = { toString: () => 'publisher-peer' };
+const UPDATE_TX_HASH = `0x${'42'.padStart(64, '0')}`;
+
+class ProducerUpdateChain extends MockChainAdapter {
+  constructor() {
+    super('mock:31337', AUTHOR);
+  }
+
+  async getUpdateAckDigestFields() {
+    return {
+      contextGraphId: BigInt(TARGET_CG_ID),
+      preUpdateMerkleRootCount: 1n,
+      newTokenAmount: 1000n,
+      mintAmount: 0n,
+      burnTokenIds: [],
+    };
+  }
+
+  override async updateKnowledgeCollectionV10(
+    params: V10UpdateKAParams,
+  ): Promise<TxResult> {
+    await params.onBroadcast?.({ txHash: UPDATE_TX_HASH });
+    return {
+      success: true,
+      hash: UPDATE_TX_HASH,
+      blockNumber: 2,
+      txIndex: 0,
+      publisherAddress: AUTHOR,
+    };
+  }
+}
 
 function config(wallet: ethers.Wallet, curated = false): StorageACKHandlerConfig {
   return {
@@ -102,6 +149,100 @@ function intent(
 }
 
 describe('StorageACKHandler graph-scoped updates', () => {
+  it('accepts the inline VM payload emitted by a public graph-update producer', async () => {
+    const store = new OxigraphStore();
+    const publisher = new DKGPublisher({
+      store,
+      chain: new NoChainAdapter(),
+      eventBus: new TypedEventBus(),
+      keypair: await generateEd25519Keypair(),
+      publisherAddress: AUTHOR,
+    });
+    const initial = await publisher.publish({
+      contextGraphId: SOURCE_CG_ID,
+      quads: [{
+        subject: 'urn:entity:producer',
+        predicate: 'urn:p:value',
+        object: '"v1"',
+        graph: 'urn:input:is-restamped',
+      }],
+      publisherPeerId: 'publisher-peer',
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      kaUal: UAL,
+      assertionVersion: 1,
+      publicTripleCount: 1,
+      privateTripleCount: 0,
+    });
+    expect(initial.kaId).toBe(KA_ID);
+
+    const updatedSWMQuad: Quad = {
+      subject: 'urn:entity:producer',
+      predicate: 'urn:p:value',
+      object: '"v2"',
+      graph: EXACT_SWM_GRAPH,
+    };
+    await store.insert([updatedSWMQuad]);
+
+    const chain = new ProducerUpdateChain();
+    chain.__registerKC({
+      kaId: KA_ID,
+      contextGraphId: BigInt(TARGET_CG_ID),
+      merkleRootHex: ethers.hexlify(initial.merkleRoot),
+      chunks: [],
+      merkleLeafCount: 1,
+      publisherAddress: AUTHOR,
+    });
+    (publisher as unknown as { chain: ProducerUpdateChain }).chain = chain;
+
+    const handler = new StorageACKHandler(
+      new OxigraphStore(),
+      config(ethers.Wallet.createRandom()),
+      new TypedEventBus(),
+    );
+    const deps: ACKCollectorDeps = {
+      gossipPublish: async () => {},
+      sendP2P: async (_peerId, _protocol, data) => handler.updateHandler(data, PEER),
+      getConnectedCorePeers: () => ['core-1'],
+      verifyIdentity: async () => true,
+      log: () => {},
+    };
+    const collector = new ACKCollector(deps);
+    let producedStagingQuads: Uint8Array | undefined;
+    const updateSeal = await buildUpdateSeal({
+      kaId: KA_ID,
+      quads: [{ ...updatedSWMQuad, graph: '' }],
+      author: PRODUCER_WALLET,
+      ctx: mockSealCtx(),
+    });
+
+    const result = await publisher.updateKnowledgeAssetFromSharedMemory(KA_ID, {
+      contextGraphId: SOURCE_CG_ID,
+      publishContextGraphId: TARGET_CG_ID,
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      kaUal: UAL,
+      assertionVersion: 2,
+      publicTripleCount: 1,
+      privateTripleCount: 0,
+      precomputedUpdateAttestation: updateSeal,
+      v10UpdateACKProvider: async (params) => {
+        producedStagingQuads = params.stagingQuads;
+        const collected = await collector.collectUpdate({
+          ...params,
+          contextGraphId: BigInt(params.contextGraphId),
+          chainId: 31337n,
+          kav10Address: '0x000000000000000000000000000000000000c10a',
+          publisherPeerId: 'publisher-peer',
+          requiredACKs: 1,
+        });
+        return collected.acks;
+      },
+    });
+
+    expect(result.status).toBe('confirmed');
+    expect(new TextDecoder().decode(producedStagingQuads)).toContain(`<${EXACT_VM_GRAPH}>`);
+    expect(new TextDecoder().decode(producedStagingQuads)).not.toContain(`<${EXACT_SWM_GRAPH}>`);
+  });
+
   it('verifies a public-plus-private update from only its exact per-KA SWM graph', async () => {
     const store = new OxigraphStore();
     const quads: Quad[] = [

--- a/packages/publisher/test/ka-graph-update-ack.test.ts
+++ b/packages/publisher/test/ka-graph-update-ack.test.ts
@@ -22,6 +22,7 @@ import {
 } from '@origintrail-official/dkg-core';
 import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
 import { ACKCollector, type ACKCollectorDeps } from '../src/ack-collector.js';
+import { skolemizeKnowledgeAsset } from '../src/auto-partition.js';
 import { DKGPublisher } from '../src/dkg-publisher.js';
 import {
   StorageACKHandler,
@@ -269,6 +270,60 @@ describe('StorageACKHandler graph-scoped updates', () => {
     );
   });
 
+  it('preserves a nested sub-graph through the collector wire path and exact SWM lookup', async () => {
+    const nestedSwmGraph = knowledgeAssetLayerGraphUri(
+      SOURCE_CG_ID,
+      MemoryLayer.SharedWorkingMemory,
+      SCOPE,
+      'nested',
+    );
+    const quads: Quad[] = [{
+      subject: 'urn:entity:nested',
+      predicate: 'urn:p:value',
+      object: '"nested"',
+      graph: nestedSwmGraph,
+    }];
+    const store = new OxigraphStore();
+    await store.insert(quads);
+    const handler = new StorageACKHandler(
+      store,
+      config(ethers.Wallet.createRandom()),
+      new TypedEventBus(),
+    );
+    const collector = new ACKCollector({
+      gossipPublish: async () => {},
+      sendP2P: async (_peerId, _protocol, data) => handler.updateHandler(data, PEER),
+      getConnectedCorePeers: () => ['core-1'],
+      verifyIdentity: async () => true,
+      log: () => {},
+    });
+
+    const result = await collector.collectUpdate({
+      kaId: KA_ID,
+      contextGraphId: BigInt(TARGET_CG_ID),
+      preUpdateMerkleRootCount: 1n,
+      newMerkleRoot: computeFlatKCRootV10(quads, []),
+      newByteSize: BigInt(byteSizeFloor(quads)),
+      newTokenAmount: 1000n,
+      mintAmount: 0n,
+      burnTokenIds: [],
+      newMerkleLeafCount: computeFlatKCMerkleLeafCountV10(quads, []),
+      chainId: 31337n,
+      kav10Address: '0x000000000000000000000000000000000000c10a',
+      publisherPeerId: 'publisher-peer',
+      requiredACKs: 1,
+      swmGraphId: SOURCE_CG_ID,
+      subGraphName: 'nested',
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      kaUal: UAL,
+      assertionVersion: '2',
+      publicTripleCount: quads.length,
+      privateTripleCount: 0,
+    });
+
+    expect(result.acks).toHaveLength(1);
+  });
+
   it('collects an ACK for a fully private curated update without a public placeholder', async () => {
     const store = new OxigraphStore();
     // The legacy bucket must not become an accidental public placeholder.
@@ -445,18 +500,31 @@ describe('StorageACKHandler graph-scoped updates', () => {
     expect(isStorageACKDecline(ack)).toBe(false);
   });
 
-  it('declines reserved skolem terms received over the graph-scoped ACK protocol', async () => {
-    const malicious: Quad[] = [{
-      subject: 'urn:dkg:ka-skolem:c14n0',
+  it('accepts canonical blank-node skolems but declines non-canonical reserved terms', async () => {
+    const canonical = (await skolemizeKnowledgeAsset([{
+      subject: '_:blank',
       predicate: 'urn:p:value',
-      object: '"attacker-authored"',
-      graph: EXACT_SWM_GRAPH,
-    }];
+      object: '"canonical"',
+      graph: '',
+    }])).map((quad) => ({ ...quad, graph: EXACT_VM_GRAPH }));
+    expect(canonical[0]?.subject).toBe('urn:dkg:ka-skolem:c14n0');
     const handler = new StorageACKHandler(
       new OxigraphStore(),
       config(ethers.Wallet.createRandom()),
       new TypedEventBus(),
     );
+    const accepted = decodeStorageACK(await handler.updateHandler(intent(canonical, 0, {
+      stagingQuads: wireNquads(canonical),
+      newByteSize: wireNquads(canonical).length,
+    }), PEER));
+    expect(isStorageACKDecline(accepted)).toBe(false);
+
+    const malicious: Quad[] = [{
+      subject: 'urn:dkg:ka-skolem:attacker',
+      predicate: 'urn:p:value',
+      object: '"attacker-authored"',
+      graph: EXACT_SWM_GRAPH,
+    }];
 
     const ack = decodeStorageACK(await handler.updateHandler(intent(malicious, 0, {
       stagingQuads: wireNquads(malicious),

--- a/packages/publisher/test/ka-graph-update-ack.test.ts
+++ b/packages/publisher/test/ka-graph-update-ack.test.ts
@@ -4,6 +4,7 @@ import {
   computeCatalogRoot,
   GRAPH_KA_CONTENT_SCOPE_VERSION,
   MemoryLayer,
+  PROTOCOL_STORAGE_UPDATE_ACK_V2,
   STORAGE_ACK_DECLINE_CODES,
   TypedEventBus,
   createGraphKnowledgeAssetScope,
@@ -61,6 +62,12 @@ function byteSizeFloor(quads: readonly Quad[]): number {
       + Buffer.byteLength(quad.object, 'utf8'),
     0,
   );
+}
+
+function wireNquads(quads: readonly Quad[]): Uint8Array {
+  return new TextEncoder().encode(quads.map((quad) =>
+    `<${quad.subject}> <${quad.predicate}> ${quad.object.startsWith('"') ? quad.object : `<${quad.object}>`} <${quad.graph}> .`,
+  ).join('\n'));
 }
 
 function intent(
@@ -147,10 +154,17 @@ describe('StorageACKHandler graph-scoped updates', () => {
       ).join('\n'),
     );
     const root = computeFlatKCRootV10([], [PRIVATE_ROOT]);
+    const selectedProtocols: string[] = [];
     const deps: ACKCollectorDeps = {
       gossipPublish: async () => {},
-      sendP2P: async (_peerId, _protocol, data) => handler.updateHandler(data, PEER),
-      getConnectedCorePeers: () => ['core-1'],
+      sendP2P: async (_peerId, protocol, data) => {
+        selectedProtocols.push(protocol);
+        return handler.updateHandler(data, PEER);
+      },
+      getConnectedCorePeers: (protocol) => {
+        selectedProtocols.push(protocol ?? '');
+        return ['core-1'];
+      },
       verifyIdentity: async () => true,
       log: () => {},
     };
@@ -185,6 +199,10 @@ describe('StorageACKHandler graph-scoped updates', () => {
 
     expect(result.acks).toHaveLength(1);
     expect(ethers.hexlify(result.merkleRoot)).toBe(ethers.hexlify(root));
+    expect(selectedProtocols).toEqual([
+      PROTOCOL_STORAGE_UPDATE_ACK_V2,
+      PROTOCOL_STORAGE_UPDATE_ACK_V2,
+    ]);
   });
 
   it('does not discover graph-scoped update data from the legacy shared bucket', async () => {
@@ -231,5 +249,80 @@ describe('StorageACKHandler graph-scoped updates', () => {
     await expect(handler.updateHandler(intent([], 1, {
       subGraphName: 'nested/graph',
     }), PEER)).rejects.toThrow('invalid graph-scoped subGraphName');
+  });
+
+  it('declines a graph update whose signed leaf count was not recomputed', async () => {
+    const store = new OxigraphStore();
+    const quads: Quad[] = [{
+      subject: 'urn:entity:a', predicate: 'urn:p:value', object: '"a"', graph: EXACT_SWM_GRAPH,
+    }];
+    await store.insert(quads);
+    const handler = new StorageACKHandler(
+      store,
+      config(ethers.Wallet.createRandom()),
+      new TypedEventBus(),
+    );
+
+    const ack = decodeStorageACK(await handler.updateHandler(intent(quads, 0, {
+      newMerkleLeafCount: 999,
+    }), PEER));
+
+    expect(isStorageACKDecline(ack)).toBe(true);
+    expect(ack.declineMessage).toContain('newMerkleLeafCount mismatch');
+  });
+
+  it('keeps a legacy sub-graph update on the legacy handler', async () => {
+    const quad: Quad = {
+      subject: 'urn:legacy:entity',
+      predicate: 'urn:p:value',
+      object: '"legacy"',
+      graph: `did:dkg:context-graph:${SOURCE_CG_ID}/sub/_shared_memory`,
+    };
+    const stagingQuads = wireNquads([quad]);
+    const handler = new StorageACKHandler(
+      new OxigraphStore(),
+      config(ethers.Wallet.createRandom()),
+      new TypedEventBus(),
+    );
+    const encoded = encodeUpdateIntent({
+      kaId: KA_ID.toString(),
+      contextGraphId: TARGET_CG_ID,
+      swmGraphId: SOURCE_CG_ID,
+      subGraphName: 'sub',
+      preUpdateMerkleRootCount: 1,
+      newMerkleRoot: computeFlatKCRootV10([quad], []),
+      newByteSize: stagingQuads.length,
+      newTokenAmount: '1000',
+      mintAmount: 0,
+      burnTokenIds: [],
+      newMerkleLeafCount: computeFlatKCMerkleLeafCountV10([quad], []),
+      publisherPeerId: 'publisher-peer',
+      stagingQuads,
+    });
+
+    const ack = decodeStorageACK(await handler.updateHandler(encoded, PEER));
+    expect(isStorageACKDecline(ack)).toBe(false);
+  });
+
+  it('declines reserved skolem terms received over the graph-scoped ACK protocol', async () => {
+    const malicious: Quad[] = [{
+      subject: 'urn:dkg:ka-skolem:c14n0',
+      predicate: 'urn:p:value',
+      object: '"attacker-authored"',
+      graph: EXACT_SWM_GRAPH,
+    }];
+    const handler = new StorageACKHandler(
+      new OxigraphStore(),
+      config(ethers.Wallet.createRandom()),
+      new TypedEventBus(),
+    );
+
+    const ack = decodeStorageACK(await handler.updateHandler(intent(malicious, 0, {
+      stagingQuads: wireNquads(malicious),
+      newByteSize: wireNquads(malicious).length,
+    }), PEER));
+
+    expect(isStorageACKDecline(ack)).toBe(true);
+    expect(ack.declineMessage).toContain('reserved KA skolem namespace');
   });
 });

--- a/packages/publisher/test/ka-graph-update-handler.test.ts
+++ b/packages/publisher/test/ka-graph-update-handler.test.ts
@@ -1,0 +1,224 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  MemoryLayer,
+  TypedEventBus,
+  createGraphKnowledgeAssetScope,
+  encodeKAUpdateRequest,
+  knowledgeAssetLayerGraphUri,
+} from '@origintrail-official/dkg-core';
+import type { ChainAdapter } from '@origintrail-official/dkg-chain';
+import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
+import {
+  UpdateHandler,
+  computeFlatKCRootV10,
+  computePrivateRootV10,
+} from '../src/index.js';
+
+const CG = 'rootless-update';
+const AUTHOR = '0x1111111111111111111111111111111111111111';
+const PUBLISHER = '0x2222222222222222222222222222222222222222';
+const UAL = `did:dkg:otp:20430/${AUTHOR}/7`;
+const KA_ID = (BigInt(AUTHOR) << 96n) | 7n;
+const META = `did:dkg:context-graph:${CG}/_meta`;
+const DKG = 'http://dkg.io/ontology/';
+const PROV = 'http://www.w3.org/ns/prov#';
+const XSD = 'http://www.w3.org/2001/XMLSchema#';
+
+function nquads(quads: readonly Quad[], graph: string): Uint8Array {
+  return new TextEncoder().encode(quads.map((quad) =>
+    `<${quad.subject}> <${quad.predicate}> ${quad.object.startsWith('"') ? quad.object : `<${quad.object}>`} <${graph}> .`,
+  ).join('\n'));
+}
+
+describe('UpdateHandler graph-scoped updates', () => {
+  let store: OxigraphStore;
+  let events: TypedEventBus;
+  let chainRoot: Uint8Array;
+  let chainRootCount: bigint;
+  let handler: UpdateHandler;
+  const scope = createGraphKnowledgeAssetScope(UAL, '2');
+  const vmGraph = knowledgeAssetLayerGraphUri(CG, MemoryLayer.VerifiableMemory, scope);
+  const swmGraph = knowledgeAssetLayerGraphUri(CG, MemoryLayer.SharedWorkingMemory, scope);
+
+  beforeEach(() => {
+    store = new OxigraphStore();
+    events = new TypedEventBus();
+    chainRoot = new Uint8Array(32);
+    chainRootCount = 2n;
+    const chain = {
+      chainId: 'otp:20430',
+      verifyKAUpdate: async () => ({
+        verified: true,
+        onChainMerkleRoot: chainRoot,
+        blockNumber: 20,
+        txIndex: 3,
+        merkleRootCount: chainRootCount,
+      }),
+      getKAContextGraphId: async () => 42n,
+    } as unknown as ChainAdapter;
+    handler = new UpdateHandler(store, chain, events, {
+      knownBatchContextGraphs: new Map([[KA_ID.toString(), CG]]),
+      resolveOnChainCgId: async (name) => name === CG ? '42' : null,
+    });
+  });
+
+  async function seedPriorMetadata(): Promise<void> {
+    await store.insert([
+      { subject: UAL, predicate: `${DKG}contentScopeVersion`, object: `"${GRAPH_KA_CONTENT_SCOPE_VERSION}"^^<${XSD}integer>`, graph: META },
+      { subject: UAL, predicate: `${DKG}assertionVersion`, object: `"1"^^<${XSD}integer>`, graph: META },
+      { subject: UAL, predicate: `${DKG}accessPolicy`, object: '"allowList"', graph: META },
+      { subject: UAL, predicate: `${DKG}allowedPeer`, object: '"peer-a"', graph: META },
+      { subject: UAL, predicate: `${DKG}publisherPeerId`, object: '"original-peer"', graph: META },
+      { subject: UAL, predicate: `${PROV}wasAttributedTo`, object: `did:dkg:agent:${AUTHOR}`, graph: META },
+    ]);
+  }
+
+  function message(
+    publicQuads: readonly Quad[],
+    privateQuads: readonly Quad[] = [],
+    overrides: Record<string, unknown> = {},
+  ): Uint8Array {
+    const privateMerkleRoot = computePrivateRootV10(privateQuads);
+    chainRoot = computeFlatKCRootV10(
+      publicQuads.map((quad) => ({ ...quad, graph: '' })),
+      privateMerkleRoot ? [privateMerkleRoot] : [],
+    );
+    return encodeKAUpdateRequest({
+      contextGraphId: CG,
+      batchId: KA_ID,
+      nquads: nquads(publicQuads, vmGraph),
+      manifest: [],
+      publisherPeerId: 'replay-peer',
+      publisherAddress: PUBLISHER,
+      txHash: `0x${'ab'.repeat(32)}`,
+      blockNumber: 20,
+      newMerkleRoot: chainRoot,
+      timestampMs: Date.now(),
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      kaUal: UAL,
+      assertionVersion: '2',
+      publicTripleCount: publicQuads.length,
+      ...(privateMerkleRoot ? { privateMerkleRoot } : {}),
+      privateTripleCount: privateQuads.length,
+      ...overrides,
+    });
+  }
+
+  it('atomically replaces the exact VM graph and preserves KA access metadata', async () => {
+    await seedPriorMetadata();
+    await store.insert([
+      { subject: 'urn:stale', predicate: 'urn:p:value', object: '"old"', graph: vmGraph },
+      { subject: 'urn:new:a', predicate: 'urn:p:value', object: '"a"', graph: swmGraph },
+    ]);
+    const publicQuads: Quad[] = [
+      { subject: 'urn:new:a', predicate: 'urn:p:value', object: '"a"', graph: '' },
+      { subject: 'urn:other:b', predicate: 'urn:p:value', object: '"b"', graph: '' },
+    ];
+    const privateQuads: Quad[] = [
+      { subject: 'urn:secret', predicate: 'urn:p:value', object: '"hidden"', graph: '' },
+    ];
+
+    await handler.handle(message(publicQuads, privateQuads), 'forwarding-peer');
+
+    expect(await store.countQuads(vmGraph)).toBe(2);
+    expect(await store.countQuads(swmGraph)).toBe(0);
+    const state = await store.query(
+      `ASK { GRAPH <${META}> {
+        <${UAL}> <${DKG}assertionVersion> "2"^^<${XSD}integer> ;
+          <${DKG}accessPolicy> "allowList" ;
+          <${DKG}allowedPeer> "peer-a" ;
+          <${DKG}publisherPeerId> "original-peer" ;
+          <${PROV}wasAttributedTo> <did:dkg:agent:${AUTHOR}> ;
+          <${DKG}status> "confirmed" .
+      } }`,
+    );
+    expect(state).toMatchObject({ type: 'boolean', value: true });
+    const legacyRoots = await store.query(
+      `ASK { GRAPH <${META}> { <${UAL}> <${DKG}rootEntity> ?root } }`,
+    );
+    expect(legacyRoots).toMatchObject({ type: 'boolean', value: false });
+  });
+
+  it('supports a fully private update with no public placeholder triple', async () => {
+    await seedPriorMetadata();
+    await store.insert([{
+      subject: 'urn:stale',
+      predicate: 'urn:p:value',
+      object: '"old"',
+      graph: vmGraph,
+    }]);
+    const privateQuads: Quad[] = [{
+      subject: 'urn:secret',
+      predicate: 'urn:p:value',
+      object: '"new"',
+      graph: '',
+    }];
+
+    await handler.handle(message([], privateQuads), 'forwarding-peer');
+
+    expect(await store.countQuads(vmGraph)).toBe(0);
+    const state = await store.query(
+      `ASK { GRAPH <${META}> {
+        <${UAL}> <${DKG}publicTripleCount> "0"^^<${XSD}integer> ;
+          <${DKG}privateTripleCount> "1"^^<${XSD}integer> ;
+          <${DKG}status> "confirmed" .
+      } }`,
+    );
+    expect(state).toMatchObject({ type: 'boolean', value: true });
+  });
+
+  it('rejects mixed legacy roots and a chain-inconsistent assertion version', async () => {
+    await seedPriorMetadata();
+    await store.insert([{
+      subject: 'urn:stale',
+      predicate: 'urn:p:value',
+      object: '"old"',
+      graph: vmGraph,
+    }]);
+    const update: Quad[] = [{
+      subject: 'urn:new',
+      predicate: 'urn:p:value',
+      object: '"new"',
+      graph: '',
+    }];
+
+    await handler.handle(message(update, [], {
+      manifest: [{ rootEntity: 'urn:legacy:root', privateTripleCount: 0 }],
+    }), 'forwarding-peer');
+    expect(await store.countQuads(vmGraph)).toBe(1);
+
+    chainRootCount = 3n;
+    await handler.handle(message(update), 'forwarding-peer');
+    expect(await store.countQuads(vmGraph)).toBe(1);
+  });
+
+  it('defers an update until authoritative graph metadata has synced', async () => {
+    const update: Quad[] = [{
+      subject: 'urn:new',
+      predicate: 'urn:p:value',
+      object: '"new"',
+      graph: '',
+    }];
+
+    await handler.handle(message(update), 'forwarding-peer');
+
+    expect(await store.countQuads(vmGraph)).toBe(0);
+  });
+
+  it('rejects a UAL from a different chain namespace', async () => {
+    await seedPriorMetadata();
+    const update: Quad[] = [{
+      subject: 'urn:new',
+      predicate: 'urn:p:value',
+      object: '"new"',
+      graph: '',
+    }];
+
+    await handler.handle(message(update, [], {
+      kaUal: `did:dkg:other:1/${AUTHOR}/7`,
+    }), 'forwarding-peer');
+
+    expect(await store.countQuads(vmGraph)).toBe(0);
+  });
+});

--- a/packages/publisher/test/ka-graph-update-handler.test.ts
+++ b/packages/publisher/test/ka-graph-update-handler.test.ts
@@ -13,6 +13,7 @@ import {
   UpdateHandler,
   computeFlatKCRootV10,
   computePrivateRootV10,
+  skolemizeKnowledgeAsset,
 } from '../src/index.js';
 
 const CG = 'rootless-update';
@@ -175,6 +176,49 @@ describe('UpdateHandler graph-scoped updates', () => {
       } }`,
     );
     expect(state).toMatchObject({ type: 'boolean', value: true });
+  });
+
+  it('materializes canonical blank-node skolems and rejects other reserved terms', async () => {
+    await seedPriorMetadata();
+    const canonical = await skolemizeKnowledgeAsset([{
+      subject: '_:blank',
+      predicate: 'urn:p:value',
+      object: '"canonical"',
+      graph: '',
+    }]);
+    expect(canonical[0]?.subject).toBe('urn:dkg:ka-skolem:c14n0');
+
+    await handler.handle(message(canonical), 'forwarding-peer');
+    expect(await store.query(
+      `ASK { GRAPH <${vmGraph}> { <urn:dkg:ka-skolem:c14n0> <urn:p:value> "canonical" } }`,
+    )).toMatchObject({ type: 'boolean', value: true });
+
+    store = new OxigraphStore();
+    const chain = {
+      chainId: 'otp:20430',
+      verifyKAUpdate: async () => ({
+        verified: true,
+        onChainMerkleRoot: chainRoot,
+        blockNumber: 20,
+        txIndex: 3,
+        merkleRootCount: 2n,
+      }),
+      getKAContextGraphId: async () => 42n,
+    } as unknown as ChainAdapter;
+    handler = new UpdateHandler(store, chain, events, {
+      knownBatchContextGraphs: new Map([[KA_ID.toString(), CG]]),
+      resolveOnChainCgId: async () => '42',
+    });
+    await seedPriorMetadata();
+    const malicious: Quad[] = [{
+      subject: 'urn:dkg:ka-skolem:attacker',
+      predicate: 'urn:p:value',
+      object: '"not-canonical"',
+      graph: '',
+    }];
+
+    await handler.handle(message(malicious), 'forwarding-peer');
+    expect(await store.countQuads(vmGraph)).toBe(0);
   });
 
   it('preserves owner-only access without minting a public policy row', async () => {

--- a/packages/publisher/test/ka-graph-update-handler.test.ts
+++ b/packages/publisher/test/ka-graph-update-handler.test.ts
@@ -63,12 +63,21 @@ describe('UpdateHandler graph-scoped updates', () => {
     });
   });
 
-  async function seedPriorMetadata(): Promise<void> {
+  async function seedPriorMetadata(options: {
+    accessPolicy?: 'public' | 'ownerOnly' | 'allowList';
+    subGraphName?: string;
+  } = {}): Promise<void> {
+    const accessPolicy = options.accessPolicy ?? 'allowList';
     await store.insert([
       { subject: UAL, predicate: `${DKG}contentScopeVersion`, object: `"${GRAPH_KA_CONTENT_SCOPE_VERSION}"^^<${XSD}integer>`, graph: META },
       { subject: UAL, predicate: `${DKG}assertionVersion`, object: `"1"^^<${XSD}integer>`, graph: META },
-      { subject: UAL, predicate: `${DKG}accessPolicy`, object: '"allowList"', graph: META },
-      { subject: UAL, predicate: `${DKG}allowedPeer`, object: '"peer-a"', graph: META },
+      { subject: UAL, predicate: `${DKG}accessPolicy`, object: `"${accessPolicy}"`, graph: META },
+      ...(accessPolicy === 'allowList'
+        ? [{ subject: UAL, predicate: `${DKG}allowedPeer`, object: '"peer-a"', graph: META }]
+        : []),
+      ...(options.subGraphName
+        ? [{ subject: UAL, predicate: `${DKG}subGraphName`, object: `"${options.subGraphName}"`, graph: META }]
+        : []),
       { subject: UAL, predicate: `${DKG}publisherPeerId`, object: '"original-peer"', graph: META },
       { subject: UAL, predicate: `${PROV}wasAttributedTo`, object: `did:dkg:agent:${AUTHOR}`, graph: META },
     ]);
@@ -166,6 +175,141 @@ describe('UpdateHandler graph-scoped updates', () => {
       } }`,
     );
     expect(state).toMatchObject({ type: 'boolean', value: true });
+  });
+
+  it('preserves owner-only access without minting a public policy row', async () => {
+    await seedPriorMetadata({ accessPolicy: 'ownerOnly' });
+    const update: Quad[] = [{
+      subject: 'urn:new', predicate: 'urn:p:value', object: '"new"', graph: '',
+    }];
+
+    await handler.handle(message(update), 'forwarding-peer');
+
+    const policies = await store.query(
+      `SELECT ?policy WHERE { GRAPH <${META}> { <${UAL}> <${DKG}accessPolicy> ?policy } }`,
+    );
+    expect(policies).toMatchObject({
+      type: 'bindings',
+      bindings: [{ policy: '"ownerOnly"' }],
+    });
+  });
+
+  it('rejects either direction of root/sub-graph identity movement', async () => {
+    const update: Quad[] = [{
+      subject: 'urn:new', predicate: 'urn:p:value', object: '"new"', graph: '',
+    }];
+    await seedPriorMetadata();
+    await store.insert([{
+      subject: 'urn:stale', predicate: 'urn:p:value', object: '"root"', graph: vmGraph,
+    }]);
+
+    const nestedVmGraph = knowledgeAssetLayerGraphUri(
+      CG,
+      MemoryLayer.VerifiableMemory,
+      scope,
+      'nested',
+    );
+    await handler.handle(message(update, [], {
+      subGraphName: 'nested',
+      nquads: nquads(update, nestedVmGraph),
+    }), 'forwarding-peer');
+    expect(await store.countQuads(vmGraph)).toBe(1);
+
+    store = new OxigraphStore();
+    const subScopeGraph = knowledgeAssetLayerGraphUri(
+      CG,
+      MemoryLayer.VerifiableMemory,
+      scope,
+      'nested',
+    );
+    const chain = {
+      chainId: 'otp:20430',
+      verifyKAUpdate: async () => ({
+        verified: true,
+        onChainMerkleRoot: chainRoot,
+        blockNumber: 20,
+        txIndex: 3,
+        merkleRootCount: 2n,
+      }),
+      getKAContextGraphId: async () => 42n,
+    } as unknown as ChainAdapter;
+    handler = new UpdateHandler(store, chain, events, {
+      knownBatchContextGraphs: new Map([[KA_ID.toString(), CG]]),
+      resolveOnChainCgId: async () => '42',
+    });
+    await seedPriorMetadata({ subGraphName: 'nested' });
+    await store.insert([{
+      subject: 'urn:stale', predicate: 'urn:p:value', object: '"sub"', graph: subScopeGraph,
+    }]);
+
+    await handler.handle(message(update), 'forwarding-peer');
+    expect(await store.countQuads(subScopeGraph)).toBe(1);
+  });
+
+  it('fails closed when the receipt root differs from the wire payload root', async () => {
+    await seedPriorMetadata();
+    await store.insert([{
+      subject: 'urn:stale', predicate: 'urn:p:value', object: '"old"', graph: vmGraph,
+    }]);
+    const update: Quad[] = [{
+      subject: 'urn:new', predicate: 'urn:p:value', object: '"new"', graph: '',
+    }];
+    const encoded = message(update);
+    chainRoot = new Uint8Array(32).fill(0xff);
+
+    await handler.handle(encoded, 'forwarding-peer');
+
+    expect(await store.countQuads(vmGraph)).toBe(1);
+    const old = await store.query(`ASK { GRAPH <${vmGraph}> { <urn:stale> ?p ?o } }`);
+    expect(old).toMatchObject({ type: 'boolean', value: true });
+  });
+
+  it('commits VM, metadata, and version atomically and replays after a failed transaction', async () => {
+    await seedPriorMetadata();
+    await store.insert([{
+      subject: 'urn:stale', predicate: 'urn:p:value', object: '"old"', graph: vmGraph,
+    }]);
+    const update: Quad[] = [{
+      subject: 'urn:new', predicate: 'urn:p:value', object: '"new"', graph: '',
+    }];
+    const encoded = message(update);
+    const realUpdate = store.update.bind(store);
+    let fail = true;
+    store.update = async (...args) => {
+      if (fail) {
+        fail = false;
+        throw new Error('injected atomic materialization failure');
+      }
+      return realUpdate(...args);
+    };
+
+    await handler.handle(encoded, 'forwarding-peer');
+    expect(await store.countQuads(vmGraph)).toBe(1);
+    expect(await store.query(
+      `ASK { GRAPH <${META}> { <${UAL}> <${DKG}assertionVersion> "1"^^<${XSD}integer> } }`,
+    )).toMatchObject({ type: 'boolean', value: true });
+
+    await handler.handle(encoded, 'forwarding-peer');
+    expect(await store.query(
+      `ASK { GRAPH <${vmGraph}> { <urn:new> <urn:p:value> "new" } }`,
+    )).toMatchObject({ type: 'boolean', value: true });
+    expect(await store.query(
+      `ASK { GRAPH <${META}> { <${UAL}> <${DKG}assertionVersion> "2"^^<${XSD}integer> } }`,
+    )).toMatchObject({ type: 'boolean', value: true });
+  });
+
+  it('rejects non-canonical receiver RDF before materialization', async () => {
+    await seedPriorMetadata();
+    const update: Quad[] = [{
+      subject: 'urn:new', predicate: 'urn:p:value', object: '"new"', graph: '',
+    }];
+    const wrongGraph = 'did:dkg:context-graph:attacker/_verifiable_memory';
+
+    await handler.handle(message(update, [], {
+      nquads: nquads(update, wrongGraph),
+    }), 'forwarding-peer');
+
+    expect(await store.countQuads(vmGraph)).toBe(0);
   });
 
   it('rejects mixed legacy roots and a chain-inconsistent assertion version', async () => {

--- a/packages/publisher/test/security-regressions.test.ts
+++ b/packages/publisher/test/security-regressions.test.ts
@@ -494,6 +494,16 @@ describe('EVMChainAdapter.verifyKAUpdate', () => {
     });
     expect(updateResult.status).toBe('confirmed');
 
+    // Verify the first update only after a later root exists. The adapter must
+    // read history at the receipt block; a latest-state read would report
+    // count=3 and make an otherwise-valid delayed gossip message look like
+    // assertion version 3 instead of 2.
+    const laterUpdate = await publisher.update(original.kaId, {
+      contextGraphId: CONTEXT_GRAPH,
+      quads: [q('urn:verify:root', 'http://schema.org/name', '"Later"')],
+    });
+    expect(laterUpdate.status).toBe('confirmed');
+
     const verification = await chain.verifyKAUpdate(
       updateResult.onChainResult!.txHash,
       original.kaId,
@@ -503,6 +513,7 @@ describe('EVMChainAdapter.verifyKAUpdate', () => {
     expect(verification.verified).toBe(true);
     expect(verification.onChainMerkleRoot).toEqual(new Uint8Array(updateResult.merkleRoot));
     expect(verification.blockNumber).toBe(updateResult.onChainResult!.blockNumber);
+    expect(verification.merkleRootCount).toBe(2n);
   });
 
   it('rejects verification with wrong txHash', async () => {

--- a/packages/publisher/test/storage-ack-handler.test.ts
+++ b/packages/publisher/test/storage-ack-handler.test.ts
@@ -934,6 +934,18 @@ describe('StorageACKHandler', () => {
       expect(recovered.toLowerCase()).toBe(coreWallet.address.toLowerCase());
     });
 
+    it('accepts zero assertion leaves because curated sampling uses the catalog tree', async () => {
+      const handler = await createHandler([]);
+      const response = await handler.handler(
+        curatedIntent({ merkleLeafCount: 0 }),
+        fakePeerId,
+      );
+      const ack = decodeStorageACK(response);
+
+      expect(isStorageACKDecline(ack)).toBe(false);
+      expect(ethers.hexlify(ack.merkleRoot)).toBe(ethers.hexlify(claimedRoot));
+    });
+
     it('DECLINEs CATALOG_ROOT_MISMATCH when the rebuilt root != the claimed catalogRoot', async () => {
       const handler = await createHandler([]);
       const wrongRoot = ethers.getBytes(ethers.keccak256(new TextEncoder().encode('wrong-catalog-root')));

--- a/packages/publisher/vitest.unit.config.ts
+++ b/packages/publisher/vitest.unit.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
       'test/ka-graph-publish-storage.test.ts',
       'test/ka-graph-update-ack.test.ts',
       'test/ka-graph-update-handler.test.ts',
+      'test/ka-graph-pull-from.test.ts',
       'test/agents-meta-bound.test.ts',
       'test/ack-collector.test.ts',
       'test/publish-lifecycle-logger.test.ts',

--- a/packages/publisher/vitest.unit.config.ts
+++ b/packages/publisher/vitest.unit.config.ts
@@ -23,6 +23,8 @@ export default defineConfig({
       'test/ka-graph-workspace-receiver.test.ts',
       'test/ka-graph-finalization-storage.test.ts',
       'test/ka-graph-publish-storage.test.ts',
+      'test/ka-graph-update-ack.test.ts',
+      'test/ka-graph-update-handler.test.ts',
       'test/agents-meta-bound.test.ts',
       'test/ack-collector.test.ts',
       'test/publish-lifecycle-logger.test.ts',


### PR DESCRIPTION
## Summary

- carry the complete V2 content envelope through update ACKs and KA-update gossip, with an empty legacy manifest
- verify UAL, kaId, assertion version, chain/context-graph binding, counts, private commitment, and exact SWM content before ACKing or materializing
- atomically replace the UAL-derived VM graph, preserve authoritative access metadata, and remove the consumed exact SWM graph
- support fully private curated updates without synthetic public placeholder triples
- verify delayed EVM updates against Merkle-root history at the receipt block instead of mutable latest state
- stop duplicating V2 content into the legacy per-context-graph partition while leaving legacy update behavior intact

## Validation

- `pnpm --filter @origintrail-official/dkg-agent... build` — passed
- focused publisher graph update/ACK suite — 54/54 passed
- core KA-update protobuf regression — 7/7 passed
- publisher full unit suite — 326/326 passed
- agent full unit suite — 830/830 passed
- core full unit suite — 1226/1226 passed
- chain full unit suite — 649 passed, 1 skipped
- real Hardhat delayed-update verification regression — passed

## Stack

Depends on #1716.