### PR TITLE
feat: publish rootless KAs through direct protocols

### DIFF
--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -1584,6 +1584,7 @@ export class PublishMethods extends DKGAgentBase {
     await this.broadcastPublish(contextGraphId, result, ctx, {
       accessPolicy: opts?.accessPolicy,
       allowedPeers: opts?.allowedPeers,
+      curated: preparedCatalog !== undefined,
     });
     onPhase?.('broadcast', 'end');
     this.log.info(ctx, `Publish complete — status=${result.status} kaId=${result.kaId}`);

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -1426,6 +1426,19 @@ export class PublishMethods extends DKGAgentBase {
       ? { aeadBindingContextGraphId: onChainId }
       : undefined;
 
+    // Every new on-chain KA uses the V2 atomic content model. Curated CGs
+    // include their deterministic public catalog floor in that same asset;
+    // the exact trust-key set is passed to the publisher for policy checks.
+    const graphScopedDirectPublish = onChainId != null
+      && this.chain.isV10Ready?.() === true
+      && typeof this.chain.getEvmChainId === 'function'
+      && typeof this.chain.getKnowledgeAssetsLifecycleAddress === 'function';
+    const preparedCatalog = graphScopedDirectPublish
+      && await this.isPrivateContextGraph(contextGraphId)
+      ? replaceCatalogPartitionWithGeneratedPrivateFloor(contextGraphId, quads)
+      : undefined;
+    const publishQuads = preparedCatalog?.quads ?? quads;
+
     // RFC-001 §9.x — sign-at-creation. The publisher refuses on-chain
     // publishes without a `precomputedAttestation`, so the agent
     // mints one here at the publish boundary using the publisher
@@ -1449,7 +1462,7 @@ export class PublishMethods extends DKGAgentBase {
       try {
         precomputedAttestation = await this._buildPrecomputedAttestationForSelection(
           contextGraphId,
-          quads,
+          publishQuads,
           {
             targetOnChainCgId: onChainId,
             // Round 4 review §11 — propagate privateQuads so the
@@ -1459,16 +1472,51 @@ export class PublishMethods extends DKGAgentBase {
             // with private content silently downgrades to tentative on
             // the publisher's `expectedMerkleRoot` guard).
             privateQuads,
+            graphScoped: graphScopedDirectPublish,
           },
         );
       } catch (err) {
-        this.log.warn(
+        this.log.error(
           ctx,
-          `Inline seal mint failed; on-chain publish will fall back to tentative: ${
+          `Inline rootless seal preparation failed: ${
             err instanceof Error ? err.message : String(err)
           }`,
         );
+        throw err;
       }
+    }
+
+    let graphScopeOptions: Pick<
+      PublishOptions,
+      | 'contentScopeVersion'
+      | 'kaUal'
+      | 'assertionVersion'
+      | 'publicTripleCount'
+      | 'privateMerkleRoot'
+      | 'privateTripleCount'
+    > = {};
+    if (graphScopedDirectPublish) {
+      if (!precomputedAttestation) {
+        throw new Error('Rootless direct publish requires a precomputed author attestation');
+      }
+      const canonical = await skolemizeKnowledgeAssetParts(publishQuads, privateQuads ?? []);
+      const privateMerkleRoot = computePrivateRoot(canonical.privateQuads);
+      const authorAddress = ethers.getAddress(precomputedAttestation.authorAddress).toLowerCase();
+      const reservedKaId = precomputedAttestation.reservedKaId;
+      if ((reservedKaId >> 96n) !== BigInt(authorAddress)) {
+        throw new Error(
+          `Rootless direct publish reserved kaId ${reservedKaId} is outside author ${authorAddress}'s namespace`,
+        );
+      }
+      const kaNumber = reservedKaId & ((1n << 96n) - 1n);
+      graphScopeOptions = {
+        contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+        kaUal: `did:dkg:${this.chain.chainId}/${authorAddress}/${kaNumber}`,
+        assertionVersion: '1',
+        publicTripleCount: canonical.publicQuads.length,
+        ...(privateMerkleRoot ? { privateMerkleRoot } : {}),
+        privateTripleCount: canonical.privateQuads.length,
+      };
     }
 
     // OT-RFC-38 / LU-5 — curated CG ACK payloads ship as AEAD ciphertext
@@ -1504,7 +1552,7 @@ export class PublishMethods extends DKGAgentBase {
 
     const result = await this.publisher.publish({
       contextGraphId,
-      quads,
+      quads: publishQuads,
       privateQuads,
       publisherPeerId: this.peerId,
       accessPolicy: opts?.accessPolicy,
@@ -1518,6 +1566,9 @@ export class PublishMethods extends DKGAgentBase {
       publishContextGraphId: onChainId ?? undefined,
       publishEpochs: opts?.publishEpochs,
       precomputedAttestation,
+      trustedNonManifestCatalogTriples:
+        preparedCatalog?.trustedNonManifestCatalogTriples,
+      ...graphScopeOptions,
       encryptInlinePayload,
       encryptInlineChunked,
     });
@@ -1530,7 +1581,10 @@ export class PublishMethods extends DKGAgentBase {
 
     onPhase?.('broadcast', 'start');
     this.log.info(ctx, `Local publish complete, broadcasting to peers`);
-    await this.broadcastPublish(contextGraphId, result, ctx);
+    await this.broadcastPublish(contextGraphId, result, ctx, {
+      accessPolicy: opts?.accessPolicy,
+      allowedPeers: opts?.allowedPeers,
+    });
     onPhase?.('broadcast', 'end');
     this.log.info(ctx, `Publish complete — status=${result.status} kaId=${result.kaId}`);
 
@@ -2968,6 +3022,8 @@ export class PublishMethods extends DKGAgentBase {
        * matches what the publisher will recompute.
        */
       privateQuads?: Quad[];
+      /** Compute the V2 one-asset commitment instead of legacy per-root commitments. */
+      graphScoped?: boolean;
     },
   ): Promise<PublishOptions['precomputedAttestation']> {
     if (
@@ -2989,15 +3045,26 @@ export class PublishMethods extends DKGAgentBase {
     }
 
     const privateQuads = opts?.privateQuads ?? [];
-    const trustedCatalogOnChainId = opts?.targetOnChainCgId ?? await this.getContextGraphOnChainId(contextGraphId);
-    const canonical = canonicalPublishPayload(
-      quads,
-      privateQuads,
-      trustedCatalogOnChainId != null && (await this.isPrivateContextGraph(contextGraphId))
-        ? { trustedNonManifestCatalogTriples: generatedPrivateCatalogTripleKeys(contextGraphId) }
-        : undefined,
-    );
-    const merkleRoot = canonical.kcMerkleRoot;
+    let merkleRoot: Uint8Array;
+    if (opts?.graphScoped) {
+      const canonical = await skolemizeKnowledgeAssetParts(quads, privateQuads);
+      const privateRoot = computePrivateRoot(canonical.privateQuads);
+      merkleRoot = computeFlatKCRoot(
+        canonical.publicQuads,
+        privateRoot ? [privateRoot] : [],
+      );
+    } else {
+      const trustedCatalogOnChainId = opts?.targetOnChainCgId
+        ?? await this.getContextGraphOnChainId(contextGraphId);
+      const canonical = canonicalPublishPayload(
+        quads,
+        privateQuads,
+        trustedCatalogOnChainId != null && (await this.isPrivateContextGraph(contextGraphId))
+          ? { trustedNonManifestCatalogTriples: generatedPrivateCatalogTripleKeys(contextGraphId) }
+          : undefined,
+      );
+      merkleRoot = canonical.kcMerkleRoot;
+    }
 
     const chainId = await this.chain.getEvmChainId();
     const kav10Address = await this.chain.getKnowledgeAssetsLifecycleAddress();
@@ -4626,6 +4693,8 @@ export class PublishMethods extends DKGAgentBase {
         publicTripleCount: seal.publicTripleCount,
         ...(snapshotPrivateRoot ? { privateMerkleRoot: snapshotPrivateRoot } : {}),
         privateTripleCount: seal.privateTripleCount,
+        accessPolicy: result.accessPolicy ?? 'ownerOnly',
+        allowedPeers: result.allowedPeers ?? [],
       };
       const topic = contextGraphFinalizationTopic(request.contextGraphId);
       try {
@@ -5739,6 +5808,8 @@ export class PublishMethods extends DKGAgentBase {
                 ? { privateMerkleRoot: options.privateMerkleRoot }
                 : {}),
               privateTripleCount: options.privateTripleCount ?? 0,
+              accessPolicy: result.accessPolicy ?? 'ownerOnly',
+              allowedPeers: result.allowedPeers ?? [],
             }
           : {}),
       };

--- a/packages/agent/src/dkg-agent-swm-substrate.ts
+++ b/packages/agent/src/dkg-agent-swm-substrate.ts
@@ -903,6 +903,7 @@ export class SwmSubstrateMethods extends DKGAgentBase {
           recordDiscoveredContextGraph: (id, next) => { this.recordDiscoveredContextGraph(id, next); },
           hasConfirmedMetaState: (id) => this.hasConfirmedMetaState(id),
           getCgMeta: (id) => this.getCgMeta(id),
+          getContextGraphOnChainId: (id) => this.getContextGraphOnChainId(id),
           markCgMetaDirtyFromQuads: (quads) => { this.contextGraphMetaProjection.markDirtyFromQuads(quads); },
           persistContextGraphSubscription: (id) => this.persistContextGraphSubscriptionState(id),
         },

--- a/packages/agent/src/dkg-agent-swm-substrate.ts
+++ b/packages/agent/src/dkg-agent-swm-substrate.ts
@@ -454,9 +454,9 @@ export class SwmSubstrateMethods extends DKGAgentBase {
 
     const finalizationTopic = contextGraphFinalizationTopic(contextGraphId);
     this.gossip.subscribe(finalizationTopic);
-    this.gossip.onMessage(finalizationTopic, async (_topic, data) => {
+    this.gossip.onMessage(finalizationTopic, async (_topic, data, from) => {
       const fh = this.getOrCreateFinalizationHandler();
-      await fh.handleFinalizationMessage(data, contextGraphId);
+      await fh.handleFinalizationMessage(data, contextGraphId, from);
     });
   }
 

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -11,6 +11,9 @@ import {
   contextGraphDataUri, contextGraphMetaUri, assertionLifecycleUri, contextGraphAssertionUri,
   deriveCuratorDidFromCgId,
   MemoryLayer,
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  createGraphKnowledgeAssetScope,
+  knowledgeAssetLayerGraphUri,
   computeACKDigest,
   encodePublishRequest,
   encodeKAUpdateRequest,
@@ -2053,6 +2056,14 @@ export class DKGAgent extends DKGAgentBase {
         subGraphName: params.subGraphName,
         merkleLeafCount: params.merkleLeafCount,
         assetUal: params.assetUal,
+        contentScopeVersion: params.contentScopeVersion,
+        kaUal: params.kaUal,
+        assertionVersion: params.assertionVersion,
+        publicTripleCount: params.publicTripleCount,
+        privateMerkleRoot: params.privateMerkleRoot,
+        privateTripleCount: params.privateTripleCount,
+        accessPolicy: params.accessPolicy,
+        allowedPeers: params.allowedPeers,
         ackMode: params.ackMode,
       });
       return result.acks;
@@ -2226,26 +2237,55 @@ export class DKGAgent extends DKGAgentBase {
     };
   }
 
-  async broadcastPublish(contextGraphId: string, result: PublishResult, ctx: OperationContext): Promise<void> {
+  async broadcastPublish(
+    contextGraphId: string,
+    result: PublishResult,
+    ctx: OperationContext,
+    policy?: {
+      accessPolicy?: 'public' | 'ownerOnly' | 'allowList';
+      allowedPeers?: string[];
+    },
+  ): Promise<void> {
     // Use the public quads from the publish result to avoid leaking private
     // triples that are stored in the same data graph.
     const publicQuads = result.publicQuads ?? [];
+    const isGraphScoped = result.contentScopeVersion === GRAPH_KA_CONTENT_SCOPE_VERSION;
+    const graphScope = isGraphScoped
+      ? createGraphKnowledgeAssetScope(result.ual, result.assertionVersion ?? '')
+      : undefined;
+    const exactGraph = graphScope
+      ? knowledgeAssetLayerGraphUri(
+          contextGraphId,
+          MemoryLayer.VerifiableMemory,
+          graphScope,
+          result.subGraphName,
+        )
+      : undefined;
     const ntriples = publicQuads.map(q => {
       const obj = q.object.startsWith('"') ? q.object : `<${q.object}>`;
-      return `<${q.subject}> <${q.predicate}> ${obj} .`;
+      return exactGraph
+        ? `<${q.subject}> <${q.predicate}> ${obj} <${exactGraph}> .`
+        : `<${q.subject}> <${q.predicate}> ${obj} .`;
     }).join('\n');
+
+    const accessPolicy = result.accessPolicy
+      ?? policy?.accessPolicy
+      ?? ((result.privateTripleCount ?? 0) > 0 ? 'ownerOnly' : 'public');
+    const allowedPeers = result.allowedPeers ?? policy?.allowedPeers ?? [];
 
     const onChain = result.onChainResult;
     const msg = encodePublishRequest({
       ual: result.ual,
       nquads: new TextEncoder().encode(ntriples),
       contextGraphId: contextGraphId,
-      kas: result.kaManifest.map(ka => ({
-        tokenId: ka.tokenId,
-        rootEntity: ka.rootEntity,
-        privateMerkleRoot: ka.privateMerkleRoot ?? new Uint8Array(0),
-        privateTripleCount: ka.privateTripleCount ?? 0,
-      })),
+      kas: isGraphScoped
+        ? []
+        : result.kaManifest.map(ka => ({
+            tokenId: ka.tokenId,
+            rootEntity: ka.rootEntity,
+            privateMerkleRoot: ka.privateMerkleRoot ?? new Uint8Array(0),
+            privateTripleCount: ka.privateTripleCount ?? 0,
+          })),
       publisherIdentity: this.wallet.keypair.publicKey,
       publisherAddress: onChain?.publisherAddress ?? '',
       startKAId: onChain?.startKAId ?? 0n,
@@ -2257,6 +2297,19 @@ export class DKGAgent extends DKGAgentBase {
       blockNumber: onChain?.blockNumber ?? 0,
       operationId: ctx.operationId,
       subGraphName: result.subGraphName,
+      ...(graphScope
+        ? {
+            contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+            assertionVersion: graphScope.assertionVersion,
+            publicTripleCount: result.publicTripleCount ?? 0,
+            ...(result.privateMerkleRoot
+              ? { privateMerkleRoot: result.privateMerkleRoot }
+              : {}),
+            privateTripleCount: result.privateTripleCount ?? 0,
+            accessPolicy,
+            allowedPeers,
+          }
+        : {}),
     });
 
     const topic = contextGraphPublishTopic(contextGraphId);

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -2244,12 +2244,22 @@ export class DKGAgent extends DKGAgentBase {
     policy?: {
       accessPolicy?: 'public' | 'ownerOnly' | 'allowList';
       allowedPeers?: string[];
+      /** Curated assertions stay on encrypted member channels. */
+      curated?: boolean;
     },
   ): Promise<void> {
     // Use the public quads from the publish result to avoid leaking private
     // triples that are stored in the same data graph.
     const publicQuads = result.publicQuads ?? [];
     const isGraphScoped = result.contentScopeVersion === GRAPH_KA_CONTENT_SCOPE_VERSION;
+    if (isGraphScoped && policy?.curated) {
+      this.log.info(
+        ctx,
+        `Skipping ordinary publish gossip for curated graph-scoped KA ${result.ual}; ` +
+          'the assertion is distributed only through encrypted member channels',
+      );
+      return;
+    }
     const graphScope = isGraphScoped
       ? createGraphKnowledgeAssetScope(result.ual, result.assertionVersion ?? '')
       : undefined;

--- a/packages/agent/src/finalization-handler.ts
+++ b/packages/agent/src/finalization-handler.ts
@@ -223,7 +223,11 @@ export class FinalizationHandler {
     this.lifecycle = new FinalizationLifecycleLogger(this.log, lifecycleLogOptions);
   }
 
-  async handleFinalizationMessage(data: Uint8Array, contextGraphId: string): Promise<void> {
+  async handleFinalizationMessage(
+    data: Uint8Array,
+    contextGraphId: string,
+    sourcePeerId?: string,
+  ): Promise<void> {
     let ctx = createOperationContext('gossip');
     let decodedMsg: FinalizationMessageMsg | undefined;
     let resolvedTargetContextGraphId: string | undefined;
@@ -355,6 +359,7 @@ export class FinalizationHandler {
           ctxGraphId,
           subGraphName,
           blockNumber,
+          sourcePeerId,
           ctx,
         });
         if (graphOutcome === 'applied' || graphOutcome === 'already-confirmed') {
@@ -606,6 +611,7 @@ export class FinalizationHandler {
     ctxGraphId?: string;
     subGraphName?: string;
     blockNumber: number;
+    sourcePeerId?: string;
     ctx: OperationContext;
   }): Promise<'applied' | 'already-confirmed' | 'deferred'> {
     const {
@@ -614,6 +620,7 @@ export class FinalizationHandler {
       ctxGraphId,
       subGraphName,
       blockNumber,
+      sourcePeerId,
       ctx,
     } = input;
     if (msg.rootEntities.length !== 0) {
@@ -655,6 +662,21 @@ export class FinalizationHandler {
       || (privateTripleCount === 0 && privateMerkleRoot !== undefined)
     ) {
       this.log.warn(ctx, `Finalization: invalid graph-scoped content envelope for ${scope.ual}, ignoring`);
+      return 'deferred';
+    }
+    const rawAllowedPeers = msg.allowedPeers ?? [];
+    const allowedPeers = [...new Set(rawAllowedPeers.map((peer) => peer.trim()).filter(Boolean))];
+    const wireAccessPolicy = msg.accessPolicy || undefined;
+    if (
+      (wireAccessPolicy !== undefined
+        && wireAccessPolicy !== 'public'
+        && wireAccessPolicy !== 'ownerOnly'
+        && wireAccessPolicy !== 'allowList')
+      || allowedPeers.length !== rawAllowedPeers.length
+      || (wireAccessPolicy === 'allowList' && allowedPeers.length === 0)
+      || (wireAccessPolicy !== 'allowList' && allowedPeers.length > 0)
+    ) {
+      this.log.warn(ctx, `Finalization: invalid graph-scoped access envelope for ${scope.ual}`);
       return 'deferred';
     }
 
@@ -731,6 +753,16 @@ export class FinalizationHandler {
       this.log.warn(ctx, `Finalization: no matching graph-scoped SWM head for ${scope.ual}`);
       return 'deferred';
     }
+    const trustedWireAccess = wireAccessPolicy !== undefined
+      && sourcePeerId !== undefined
+      && sourcePeerId === head.publisherPeerId;
+    if (wireAccessPolicy !== undefined && !trustedWireAccess) {
+      this.log.warn(
+        ctx,
+        `Finalization: ignoring untrusted access envelope for ${scope.ual}; ` +
+          `source=${sourcePeerId ?? '(missing)'} owner=${head.publisherPeerId}`,
+      );
+    }
 
     const swmResult = await this.store.query(
       `CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${assertSafeIri(swmGraph)}> { ?s ?p ?o } }`,
@@ -787,6 +819,12 @@ export class FinalizationHandler {
         blockNumber,
         txIndex: verified.txIndex ?? 0,
       },
+      accessPolicy: head.accessPolicy ?? (trustedWireAccess ? wireAccessPolicy : undefined),
+      allowedPeers: head.accessPolicy
+        ? head.allowedPeers
+        : trustedWireAccess
+          ? allowedPeers
+          : [],
       subGraphName,
       source: 'finalization',
       ctx,
@@ -974,6 +1012,8 @@ export class FinalizationHandler {
     batchId: bigint;
     authorAddress?: string;
     materializedVersion: MaterializedVersion;
+    accessPolicy?: 'public' | 'ownerOnly' | 'allowList';
+    allowedPeers?: string[];
     subGraphName?: string;
     source: 'finalization' | 'chain-reconcile';
     ctx: OperationContext;
@@ -991,6 +1031,8 @@ export class FinalizationHandler {
       batchId,
       authorAddress,
       materializedVersion,
+      accessPolicy: requestedAccessPolicy,
+      allowedPeers: requestedAllowedPeers = [],
       subGraphName,
       source,
       ctx,
@@ -1010,6 +1052,16 @@ export class FinalizationHandler {
       subGraphName,
     );
     const metaGraph = contextGraphMetaUri(contextGraphId);
+    const effectiveAccessPolicy = requestedAccessPolicy
+      ?? head.accessPolicy
+      ?? 'ownerOnly';
+    const effectiveAllowedPeers = effectiveAccessPolicy === 'allowList'
+      ? (requestedAccessPolicy ? requestedAllowedPeers : head.allowedPeers)
+      : [];
+    const safeAccessPolicy = effectiveAccessPolicy === 'allowList'
+      && effectiveAllowedPeers.length === 0
+      ? 'ownerOnly'
+      : effectiveAccessPolicy;
 
     const outcome = await withMaterializationLock(metaGraph, scope.ual, async () => {
       if (!(await shouldApplyMaterialization(
@@ -1056,7 +1108,10 @@ export class FinalizationHandler {
           contextGraphId,
           merkleRoot: computedMerkleRoot,
           publisherPeerId: head.publisherPeerId,
-          accessPolicy: privateTripleCount > 0 ? 'ownerOnly' : 'public',
+          accessPolicy: safeAccessPolicy,
+          ...(safeAccessPolicy === 'allowList'
+            ? { allowedPeers: effectiveAllowedPeers }
+            : {}),
           timestamp: new Date(),
           subGraphName,
           ...(authorAddress ? { authorAddress } : {}),

--- a/packages/agent/src/gossip-publish-handler.ts
+++ b/packages/agent/src/gossip-publish-handler.ts
@@ -21,6 +21,8 @@ import {
   computeTripleHashV10 as computeTripleHash, computeFlatKCRootV10 as computeFlatKCRoot, skolemizeByEntity,
   generateTentativeMetadata, getTentativeStatusQuad, getConfirmedStatusQuad,
   generateGraphKnowledgeAssetMetadata,
+  resolveKnowledgeAssetWorkspaceHead,
+  workspacePublicQuadsDigest,
   shouldApplyMaterialization,
   withMaterializationLock,
   writeMaterializedVersion,
@@ -150,6 +152,8 @@ export interface GossipPublishHandlerCallbacks {
    */
   hasConfirmedMetaState?: (id: string) => Promise<boolean>;
   getCgMeta?: (id: string) => Promise<ContextGraphMetaRecord>;
+  /** Resolve the topic Context Graph to its authoritative on-chain id. */
+  getContextGraphOnChainId?: (id: string) => Promise<string | null>;
   markCgMetaDirtyFromQuads?: (quads: readonly Quad[]) => void;
   persistContextGraphSubscription?: (id: string) => void;
   onPhase?: GossipPhaseCallback;
@@ -495,6 +499,56 @@ export class GossipPublishHandler {
         const blockNumber = protoToNumber(request.blockNumber ?? 0);
         const startKAId = protoToBigInt(request.startKAId ?? 0);
         const endKAId = protoToBigInt(request.endKAId ?? 0);
+        const graphManager = new GraphManager(this.store);
+        let workspaceHead;
+        try {
+          workspaceHead = await resolveKnowledgeAssetWorkspaceHead({
+            store: this.store,
+            graphManager,
+            contextGraphId: request.contextGraphId,
+            kaUal: graphPublish.scope.ual,
+            subGraphName,
+          });
+        } catch (err) {
+          this.log.warn(
+            ctx,
+            `Gossip rejected corrupt graph-scoped SWM head for ${graphPublish.scope.ual}: ` +
+              `${err instanceof Error ? err.message : String(err)}`,
+          );
+          return;
+        }
+        const privateMerkleRoot = graphPublish.privateMerkleRoot
+          ? ethers.hexlify(graphPublish.privateMerkleRoot).toLowerCase()
+          : undefined;
+        const publicDigest = workspacePublicQuadsDigest(
+          normalized.map((quad) => ({ ...quad, graph: '' })),
+        );
+        if (
+          !workspaceHead
+          || workspaceHead.assertionVersion !== graphPublish.scope.assertionVersion
+          || workspaceHead.publicTripleCount !== graphPublish.publicTripleCount
+          || workspaceHead.publicQuadsDigest !== publicDigest
+          || workspaceHead.privateTripleCount !== graphPublish.privateTripleCount
+          || workspaceHead.privateMerkleRoot?.toLowerCase() !== privateMerkleRoot
+          || workspaceHead.accessPolicy === undefined
+        ) {
+          this.log.warn(
+            ctx,
+            `Gossip deferred graph-scoped publish ${graphPublish.scope.ual}: ` +
+              'no matching durable StorageACK workspace head',
+          );
+          return;
+        }
+        if (
+          graphPublish.accessPolicy !== workspaceHead.accessPolicy
+          || graphPublish.allowedPeers.join('\0') !== workspaceHead.allowedPeers.join('\0')
+          || (fromPeerId !== undefined && fromPeerId !== workspaceHead.publisherPeerId)
+        ) {
+          this.log.warn(
+            ctx,
+            `Gossip ignored untrusted graph-scoped access provenance for ${graphPublish.scope.ual}`,
+          );
+        }
         let verified = false;
         if (txHash && blockNumber > 0 && request.publisherAddress) {
           phase?.('chain-verify', 'start');
@@ -506,6 +560,7 @@ export class GossipPublishHandler {
             startKAId,
             endKAId,
             ctx,
+            request.contextGraphId,
           );
           phase?.('chain-verify', 'end');
         }
@@ -515,10 +570,10 @@ export class GossipPublishHandler {
             ual: graphPublish.scope.ual,
             contextGraphId: request.contextGraphId,
             merkleRoot,
-            publisherPeerId: fromPeerId ?? request.publisherAddress ?? 'unknown',
-            accessPolicy: graphPublish.accessPolicy,
-            ...(graphPublish.accessPolicy === 'allowList'
-              ? { allowedPeers: graphPublish.allowedPeers }
+            publisherPeerId: workspaceHead.publisherPeerId,
+            accessPolicy: workspaceHead.accessPolicy,
+            ...(workspaceHead.accessPolicy === 'allowList'
+              ? { allowedPeers: workspaceHead.allowedPeers }
               : {}),
             timestamp: new Date(),
             subGraphName,
@@ -733,6 +788,7 @@ export class GossipPublishHandler {
     expectedStartKAId: bigint,
     expectedEndKAId: bigint,
     ctx: OperationContext,
+    expectedContextGraphId?: string,
   ): Promise<boolean> {
     if (!this.chain || this.chain.chainId === 'none') return false;
 
@@ -742,6 +798,31 @@ export class GossipPublishHandler {
     }
 
     try {
+      if (expectedContextGraphId !== undefined) {
+        if (
+          typeof this.chain.getKAContextGraphId !== 'function'
+          || !this.callbacks.getContextGraphOnChainId
+        ) {
+          this.log.warn(ctx, 'Gossip verification rejected: Context Graph binding oracle unavailable');
+          return false;
+        }
+        const expectedOnChainId = await this.callbacks.getContextGraphOnChainId(
+          expectedContextGraphId,
+        );
+        if (expectedOnChainId === null) {
+          this.log.warn(ctx, `Gossip verification rejected: Context Graph ${expectedContextGraphId} is not registered`);
+          return false;
+        }
+        const actualOnChainId = await this.chain.getKAContextGraphId(expectedStartKAId);
+        if (actualOnChainId !== BigInt(expectedOnChainId)) {
+          this.log.warn(
+            ctx,
+            `Gossip verification rejected: KA ${expectedStartKAId} belongs to Context Graph ` +
+              `${actualOnChainId}, not ${expectedOnChainId}`,
+          );
+          return false;
+        }
+      }
       const filter: EventFilter = {
         eventTypes: ['KnowledgeBatchCreated', 'KCCreated'],
         fromBlock: blockNumber,

--- a/packages/agent/src/gossip-publish-handler.ts
+++ b/packages/agent/src/gossip-publish-handler.ts
@@ -4,13 +4,26 @@ import {
   isSafeIri, assertSafeIri, validateSubGraphName, validateContextGraphId,
   contextGraphSubGraphUri,
   contextGraphMetaGraphUri, contextGraphDataGraphUri,
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  createGraphKnowledgeAssetScope,
+  knowledgeAssetLayerGraphUri,
+  MemoryLayer,
   type OperationContext,
 } from '@origintrail-official/dkg-core';
-import { GraphManager, type TripleStore, type Quad } from '@origintrail-official/dkg-storage';
+import {
+  GraphManager,
+  tryReplaceGraphAtomically,
+  type TripleStore,
+  type Quad,
+} from '@origintrail-official/dkg-storage';
 import { type ChainAdapter, type EventFilter } from '@origintrail-official/dkg-chain';
 import {
   computeTripleHashV10 as computeTripleHash, computeFlatKCRootV10 as computeFlatKCRoot, skolemizeByEntity,
   generateTentativeMetadata, getTentativeStatusQuad, getConfirmedStatusQuad,
+  generateGraphKnowledgeAssetMetadata,
+  shouldApplyMaterialization,
+  withMaterializationLock,
+  writeMaterializedVersion,
   validatePublishRequest, parseSimpleNQuads, generateSubGraphRegistration,
   type KAMetadata,
 } from '@origintrail-official/dkg-publisher';
@@ -19,6 +32,99 @@ import type { ContextGraphMetaRecord } from './context-graph-meta-projection.js'
 import type { ContextGraphDiscoveryMetadata, ContextGraphSub } from './dkg-agent-types.js';
 
 export type GossipPhaseCallback = (phase: string, status: 'start' | 'end') => void;
+
+interface GraphScopedPublishRequest {
+  scope: ReturnType<typeof createGraphKnowledgeAssetScope>;
+  publicTripleCount: number;
+  privateTripleCount: number;
+  privateMerkleRoot?: Uint8Array;
+  accessPolicy: 'public' | 'ownerOnly' | 'allowList';
+  allowedPeers: string[];
+}
+
+function resolveGraphScopedPublishRequest(
+  request: ReturnType<typeof decodePublishRequest>,
+): GraphScopedPublishRequest | undefined {
+  const privateMerkleRoot = request.privateMerkleRoot?.length
+    ? new Uint8Array(request.privateMerkleRoot)
+    : undefined;
+  const hasGraphField =
+    (request.contentScopeVersion ?? 0) !== 0
+    || Boolean(request.assertionVersion)
+    || (request.publicTripleCount ?? 0) > 0
+    || privateMerkleRoot !== undefined
+    || (request.privateTripleCount ?? 0) > 0
+    || Boolean(request.accessPolicy)
+    || (request.allowedPeers?.length ?? 0) > 0;
+  if (!hasGraphField) return undefined;
+  if (request.contentScopeVersion !== GRAPH_KA_CONTENT_SCOPE_VERSION) {
+    throw new Error(
+      `Graph-scoped gossip requires contentScopeVersion=${GRAPH_KA_CONTENT_SCOPE_VERSION}`,
+    );
+  }
+  if (!request.ual) {
+    throw new Error('Graph-scoped gossip requires a UAL');
+  }
+  if (!request.assertionVersion || request.kas.length !== 0) {
+    throw new Error('Graph-scoped gossip requires assertionVersion and no legacy KA manifest');
+  }
+  const scope = createGraphKnowledgeAssetScope(request.ual, request.assertionVersion);
+  if (
+    scope.ual !== request.ual
+    || scope.assertionVersion !== '1'
+    || !request.chainId
+    || scope.chainId !== request.chainId
+  ) {
+    throw new Error('Graph-scoped gossip has a non-canonical initial KA scope');
+  }
+  const kaNumber = BigInt(scope.kaNumber);
+  if (kaNumber >= (1n << 96n)) {
+    throw new Error('Graph-scoped gossip KA number exceeds the 96-bit author namespace');
+  }
+  const packedKaId = (BigInt(scope.agentAddress) << 96n) | kaNumber;
+  const startKAId = protoToBigInt(request.startKAId ?? 0);
+  const endKAId = protoToBigInt(request.endKAId ?? 0);
+  if (startKAId !== packedKaId || endKAId !== packedKaId) {
+    throw new Error(
+      `Graph-scoped gossip UAL-derived kaId ${packedKaId} does not match ` +
+        `published range ${startKAId}..${endKAId}`,
+    );
+  }
+  const publicTripleCount = request.publicTripleCount ?? 0;
+  const privateTripleCount = request.privateTripleCount ?? 0;
+  if (
+    !Number.isSafeInteger(publicTripleCount)
+    || publicTripleCount < 0
+    || !Number.isSafeInteger(privateTripleCount)
+    || privateTripleCount < 0
+    || (publicTripleCount === 0 && privateTripleCount === 0)
+    || (privateTripleCount > 0 && privateMerkleRoot?.length !== 32)
+    || (privateTripleCount === 0 && privateMerkleRoot !== undefined)
+  ) {
+    throw new Error('Graph-scoped gossip has an invalid content envelope');
+  }
+  const accessPolicy = request.accessPolicy;
+  if (accessPolicy !== 'public' && accessPolicy !== 'ownerOnly' && accessPolicy !== 'allowList') {
+    throw new Error(`Graph-scoped gossip has invalid accessPolicy: ${accessPolicy || '(empty)'}`);
+  }
+  const rawAllowedPeers = request.allowedPeers ?? [];
+  const allowedPeers = [...new Set(rawAllowedPeers.map((peer) => peer.trim()).filter(Boolean))];
+  if (
+    allowedPeers.length !== rawAllowedPeers.length
+    || (accessPolicy === 'allowList' && allowedPeers.length === 0)
+    || (accessPolicy !== 'allowList' && allowedPeers.length > 0)
+  ) {
+    throw new Error('Graph-scoped gossip has an invalid access-policy peer envelope');
+  }
+  return {
+    scope,
+    publicTripleCount,
+    privateTripleCount,
+    ...(privateMerkleRoot ? { privateMerkleRoot } : {}),
+    accessPolicy,
+    allowedPeers,
+  };
+}
 
 export interface GossipPublishHandlerCallbacks {
   contextGraphExists: (id: string) => Promise<boolean>;
@@ -151,6 +257,7 @@ export class GossipPublishHandler {
 
       const nquadsStr = new TextDecoder().decode(request.nquads);
       const quads = parseSimpleNQuads(nquadsStr);
+      const graphPublish = resolveGraphScopedPublishRequest(request);
 
       if (quads.length === 0 && !request.ual) {
         this.log.warn(ctx, 'Gossip: empty broadcast with no UAL, ignoring');
@@ -173,19 +280,42 @@ export class GossipPublishHandler {
         await graphManager.ensureSubGraph(request.contextGraphId, subGraphName);
       }
 
-      const dataGraph = subGraphName
-        ? contextGraphSubGraphUri(request.contextGraphId, subGraphName)
-        : graphManager.dataGraphUri(request.contextGraphId);
+      const dataGraph = graphPublish
+        ? knowledgeAssetLayerGraphUri(
+            request.contextGraphId,
+            MemoryLayer.VerifiableMemory,
+            graphPublish.scope,
+            subGraphName,
+          )
+        : subGraphName
+          ? contextGraphSubGraphUri(request.contextGraphId, subGraphName)
+          : graphManager.dataGraphUri(request.contextGraphId);
       // Drop any _meta quads from gossip — _meta state (allowlists, registration
       // status, curator) is security-critical and must only propagate via the
       // authenticated sync protocol, not unauthenticated gossip.
       // Match both raw `/_meta` suffix and common percent-encoded variants.
       // Avoid decodeURIComponent which throws on malformed encoding.
-      const filteredQuads = quads.filter(q => {
-        const g = q.graph;
-        return !g.endsWith('/_meta') && !g.endsWith('%2F_meta') && !g.endsWith('%2f_meta');
-      });
-      let normalized = filteredQuads.map(q => ({ ...q, graph: dataGraph }));
+      let normalized: Quad[];
+      if (graphPublish) {
+        if (quads.some((quad) => quad.graph !== dataGraph)) {
+          throw new Error(
+            `Graph-scoped gossip payload must target only its UAL-derived VM graph ${dataGraph}`,
+          );
+        }
+        if (quads.length !== graphPublish.publicTripleCount) {
+          throw new Error(
+            `Graph-scoped gossip public triple count mismatch ` +
+              `(wire=${graphPublish.publicTripleCount}, parsed=${quads.length})`,
+          );
+        }
+        normalized = quads.map((quad) => ({ ...quad, graph: dataGraph }));
+      } else {
+        const filteredQuads = quads.filter(q => {
+          const g = q.graph;
+          return !g.endsWith('/_meta') && !g.endsWith('%2F_meta') && !g.endsWith('%2f_meta');
+        });
+        normalized = filteredQuads.map(q => ({ ...q, graph: dataGraph }));
+      }
 
       // When receiving ontology-topic broadcasts, skip context graph definition
       // triples for context graphs we already have locally. This prevents duplicate
@@ -296,7 +426,7 @@ export class GossipPublishHandler {
       // broadcasts (no UAL or no KAs) bypass validation.
       phase?.('validate', 'start');
       let isReplay = false;
-      if (request.ual && request.kas?.length > 0) {
+      if (!graphPublish && request.ual && request.kas?.length > 0) {
         const manifest = request.kas.map(ka => ({
           tokenId: 0n,
           rootEntity: ka.rootEntity,
@@ -353,6 +483,143 @@ export class GossipPublishHandler {
           this.callbacks.markCgMetaDirtyFromQuads?.(regQuads);
           this.log.info(ctx, `Auto-registered sub-graph "${subGraphName}" in context graph "${request.contextGraphId}" from gossip`);
         }
+      }
+
+      if (graphPublish) {
+        phase?.('store', 'start');
+        const privateRoots = graphPublish.privateMerkleRoot
+          ? [graphPublish.privateMerkleRoot]
+          : [];
+        const merkleRoot = computeFlatKCRoot(normalized, privateRoots);
+        const txHash = request.txHash ?? '';
+        const blockNumber = protoToNumber(request.blockNumber ?? 0);
+        const startKAId = protoToBigInt(request.startKAId ?? 0);
+        const endKAId = protoToBigInt(request.endKAId ?? 0);
+        let verified = false;
+        if (txHash && blockNumber > 0 && request.publisherAddress) {
+          phase?.('chain-verify', 'start');
+          verified = await this.verifyGossipOnChain(
+            txHash,
+            blockNumber,
+            merkleRoot,
+            request.publisherAddress,
+            startKAId,
+            endKAId,
+            ctx,
+          );
+          phase?.('chain-verify', 'end');
+        }
+
+        const metadata = generateGraphKnowledgeAssetMetadata(
+          {
+            ual: graphPublish.scope.ual,
+            contextGraphId: request.contextGraphId,
+            merkleRoot,
+            publisherPeerId: fromPeerId ?? request.publisherAddress ?? 'unknown',
+            accessPolicy: graphPublish.accessPolicy,
+            ...(graphPublish.accessPolicy === 'allowList'
+              ? { allowedPeers: graphPublish.allowedPeers }
+              : {}),
+            timestamp: new Date(),
+            subGraphName,
+            authorAddress: graphPublish.scope.agentAddress,
+            assertionVersion: graphPublish.scope.assertionVersion,
+            publicTripleCount: graphPublish.publicTripleCount,
+            privateTripleCount: graphPublish.privateTripleCount,
+            ...(graphPublish.privateMerkleRoot
+              ? { privateMerkleRoot: graphPublish.privateMerkleRoot }
+              : {}),
+            assertionGraph: dataGraph,
+          },
+          verified ? 'confirmed' : 'tentative',
+          verified
+            ? {
+                txHash,
+                blockNumber,
+                blockTimestamp: Math.floor(Date.now() / 1000),
+                publisherAddress: request.publisherAddress,
+                batchId: startKAId,
+                chainId: request.chainId,
+              }
+            : undefined,
+        );
+        const metaGraph = contextGraphMetaGraphUri(request.contextGraphId);
+        const incomingVersion = {
+          blockNumber: verified ? blockNumber : 0,
+          txIndex: 0,
+        };
+        const outcome = await withMaterializationLock(
+          metaGraph,
+          graphPublish.scope.ual,
+          async () => {
+            if (!verified) {
+              const confirmed = await this.store.query(
+                `ASK { GRAPH <${assertSafeIri(metaGraph)}> { ` +
+                  `<${assertSafeIri(graphPublish.scope.ual)}> ` +
+                  `<http://dkg.io/ontology/status> "confirmed" } }`,
+              );
+              if (confirmed.type === 'boolean' && confirmed.value) {
+                return 'stale' as const;
+              }
+            }
+            if (!(await shouldApplyMaterialization(
+              this.store,
+              metaGraph,
+              graphPublish.scope.ual,
+              incomingVersion,
+            ))) {
+              return 'stale' as const;
+            }
+            const replaced = await tryReplaceGraphAtomically(
+              this.store,
+              dataGraph,
+              normalized,
+              { source: 'agent.gossipPublish.graphScopedReplace' },
+            );
+            if (!replaced) {
+              throw Object.assign(
+                new Error('Graph-scoped gossip requires atomic TripleStore.replaceGraph support'),
+                { code: 'VM_ATOMIC_REPLACE_UNSUPPORTED' },
+              );
+            }
+            await this.store.deleteByPattern({
+              graph: metaGraph,
+              subject: graphPublish.scope.ual,
+            });
+            await this.store.insert(metadata);
+            await writeMaterializedVersion(
+              this.store,
+              metaGraph,
+              graphPublish.scope.ual,
+              incomingVersion,
+            );
+            if (verified) {
+              const swmGraph = knowledgeAssetLayerGraphUri(
+                request.contextGraphId,
+                MemoryLayer.SharedWorkingMemory,
+                graphPublish.scope,
+                subGraphName,
+              );
+              await this.store.dropGraph(swmGraph);
+            }
+            return 'applied' as const;
+          },
+        );
+        phase?.('store', 'end');
+        if (outcome === 'stale') {
+          this.log.info(
+            ctx,
+            `Skipped stale graph-scoped publish gossip for ${graphPublish.scope.ual}`,
+          );
+          return;
+        }
+        this.callbacks.markCgMetaDirtyFromQuads?.(metadata);
+        this.log.info(
+          ctx,
+          `Graph-scoped publish ${graphPublish.scope.ual} stored as ` +
+            `${verified ? 'confirmed' : 'tentative'} (${normalized.length} public triples)`,
+        );
+        return;
       }
 
       phase?.('store', 'start');

--- a/packages/agent/test/direct-rootless-publish.test.ts
+++ b/packages/agent/test/direct-rootless-publish.test.ts
@@ -11,8 +11,15 @@ import {
   knowledgeAssetLayerGraphUri,
 } from '@origintrail-official/dkg-core';
 import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
-import type { PublishOptions, PublishResult } from '@origintrail-official/dkg-publisher';
+import {
+  computeFlatKCRootV10,
+  computePrivateRootV10,
+  skolemizeKnowledgeAssetParts,
+  type PublishOptions,
+  type PublishResult,
+} from '@origintrail-official/dkg-publisher';
 import { DKGAgent } from '../src/index.js';
+import { makeTestKaNumberAllocator } from './_helpers/ka-allocator.js';
 
 const AUTHOR = '0x70997970c51812dc3a010c7d01b50e0d17dc79c8';
 const KA_NUMBER = 7n;
@@ -31,6 +38,7 @@ describe('direct rootless agent publish entrypoint', () => {
       name: 'DirectRootlessPublish',
       store: new OxigraphStore(),
       chainAdapter: new MockChainAdapter('mock:31337', AUTHOR),
+      kaNumberAllocator: makeTestKaNumberAllocator(),
       nodeRole: 'edge',
       skills: [],
     });
@@ -45,23 +53,19 @@ describe('direct rootless agent publish entrypoint', () => {
     internals._resolveEncryptInlinePayload = vi.fn(async () => undefined);
     internals._resolveEncryptInlineChunked = vi.fn(async () => undefined);
     internals.emitPublicProjectionAfterPublish = vi.fn(async () => undefined);
-    internals._buildPrecomputedAttestationForSelection = vi.fn(async () => ({
-      expectedMerkleRoot: new Uint8Array(32).fill(0x11),
-      authorAddress: AUTHOR,
-      signatureR: new Uint8Array(32).fill(0x22),
-      signatureVs: new Uint8Array(32).fill(0x33),
-      schemeVersion: 1,
-      reservedKaId: RESERVED_KA_ID,
-    }));
-
     let capturedOptions: PublishOptions | undefined;
     const fakePublisher = {
+      publisherFallbackAuthorAddress: vi.fn(async () => AUTHOR),
+      signAuthorAttestationAsPublisher: vi.fn(async () => ({
+        r: new Uint8Array(32).fill(0x22),
+        vs: new Uint8Array(32).fill(0x33),
+      })),
       publish: vi.fn(async (options: PublishOptions): Promise<PublishResult> => {
         capturedOptions = options;
         return {
-          kaId: RESERVED_KA_ID,
+          kaId: options.precomputedAttestation!.reservedKaId!,
           ual: options.kaUal!,
-          merkleRoot: new Uint8Array(32).fill(0x11),
+          merkleRoot: options.precomputedAttestation!.expectedMerkleRoot,
           kaManifest: [],
           status: 'confirmed',
           publicQuads: options.quads,
@@ -106,7 +110,7 @@ describe('direct rootless agent publish entrypoint', () => {
     expect(capturedOptions).toBeDefined();
     expect(capturedOptions).toMatchObject({
       contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
-      kaUal: `did:dkg:mock:31337/${AUTHOR}/${KA_NUMBER}`,
+      kaUal: `did:dkg:mock:31337/${AUTHOR}/0`,
       assertionVersion: '1',
       privateTripleCount: 1,
       accessPolicy: 'ownerOnly',
@@ -122,11 +126,16 @@ describe('direct rootless agent publish entrypoint', () => {
       quad.subject === 'did:dkg:context-graph:ontology'
       && quad.predicate === 'http://purl.org/dc/terms/accessRights'
     )).toBe(true);
-    expect(internals._buildPrecomputedAttestationForSelection).toHaveBeenCalledWith(
-      SYSTEM_CONTEXT_GRAPHS.ONTOLOGY,
-      expect.arrayContaining(capturedOptions!.quads),
-      expect.objectContaining({ graphScoped: true, privateQuads }),
+    const canonical = await skolemizeKnowledgeAssetParts(capturedOptions!.quads, privateQuads);
+    const expectedPrivateRoot = computePrivateRootV10(canonical.privateQuads);
+    const expectedMerkleRoot = computeFlatKCRootV10(
+      canonical.publicQuads,
+      expectedPrivateRoot ? [expectedPrivateRoot] : [],
     );
+    expect(ethers.hexlify(capturedOptions!.precomputedAttestation!.expectedMerkleRoot))
+      .toBe(ethers.hexlify(expectedMerkleRoot));
+    expect(capturedOptions!.precomputedAttestation!.reservedKaId)
+      .toBe(BigInt(AUTHOR) << 96n);
     expect(broadcastPublish).toHaveBeenCalledWith(
       SYSTEM_CONTEXT_GRAPHS.ONTOLOGY,
       expect.objectContaining({
@@ -134,8 +143,46 @@ describe('direct rootless agent publish entrypoint', () => {
         kaManifest: [],
       }),
       expect.any(Object),
-      { accessPolicy: 'ownerOnly', allowedPeers: undefined },
+      { accessPolicy: 'ownerOnly', allowedPeers: undefined, curated: true },
     );
+  });
+
+  it('never sends curated graph-scoped assertion plaintext on the ordinary publish topic', async () => {
+    agent = await DKGAgent.create({
+      name: 'CuratedRootlessBroadcast',
+      store: new OxigraphStore(),
+      chainAdapter: new MockChainAdapter('mock:31337', AUTHOR),
+      nodeRole: 'edge',
+      skills: [],
+    });
+    const internals = agent as unknown as Record<string, any>;
+    const publish = vi.fn(async () => undefined);
+    internals.gossip = { publish };
+
+    await internals.broadcastPublish(
+      '42',
+      {
+        kaId: RESERVED_KA_ID,
+        ual: `did:dkg:mock:31337/${AUTHOR}/${KA_NUMBER}`,
+        merkleRoot: new Uint8Array(32),
+        kaManifest: [],
+        status: 'confirmed',
+        publicQuads: [{
+          subject: 'urn:curated:secret',
+          predicate: 'urn:p:value',
+          object: '"must-not-leak"',
+          graph: '',
+        }],
+        contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+        assertionVersion: '1',
+        publicTripleCount: 1,
+        privateTripleCount: 0,
+      },
+      createOperationContext('publish'),
+      { accessPolicy: 'ownerOnly', curated: true },
+    );
+
+    expect(publish).not.toHaveBeenCalled();
   });
 
   it('broadcasts the exact UAL-derived graph and no legacy root manifest', async () => {

--- a/packages/agent/test/direct-rootless-publish.test.ts
+++ b/packages/agent/test/direct-rootless-publish.test.ts
@@ -1,0 +1,210 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ethers } from 'ethers';
+import { MockChainAdapter } from '@origintrail-official/dkg-chain';
+import {
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  MemoryLayer,
+  SYSTEM_CONTEXT_GRAPHS,
+  createGraphKnowledgeAssetScope,
+  createOperationContext,
+  decodePublishRequest,
+  knowledgeAssetLayerGraphUri,
+} from '@origintrail-official/dkg-core';
+import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
+import type { PublishOptions, PublishResult } from '@origintrail-official/dkg-publisher';
+import { DKGAgent } from '../src/index.js';
+
+const AUTHOR = '0x70997970c51812dc3a010c7d01b50e0d17dc79c8';
+const KA_NUMBER = 7n;
+const RESERVED_KA_ID = (BigInt(AUTHOR) << 96n) | KA_NUMBER;
+
+describe('direct rootless agent publish entrypoint', () => {
+  let agent: DKGAgent | undefined;
+
+  afterEach(async () => {
+    await agent?.stop().catch(() => undefined);
+    agent = undefined;
+  });
+
+  it('passes one complete V2 graph envelope into the publisher and broadcast', async () => {
+    agent = await DKGAgent.create({
+      name: 'DirectRootlessPublish',
+      store: new OxigraphStore(),
+      chainAdapter: new MockChainAdapter('mock:31337', AUTHOR),
+      nodeRole: 'edge',
+      skills: [],
+    });
+    const internals = agent as unknown as Record<string, any>;
+    Object.defineProperty(agent, 'peerId', {
+      value: '12D3KooWRootlessPublisher',
+      configurable: true,
+    });
+    internals.getContextGraphOnChainId = vi.fn(async () => '42');
+    internals.isPrivateContextGraph = vi.fn(async () => true);
+    internals.createV10ACKProvider = vi.fn(() => undefined);
+    internals._resolveEncryptInlinePayload = vi.fn(async () => undefined);
+    internals._resolveEncryptInlineChunked = vi.fn(async () => undefined);
+    internals.emitPublicProjectionAfterPublish = vi.fn(async () => undefined);
+    internals._buildPrecomputedAttestationForSelection = vi.fn(async () => ({
+      expectedMerkleRoot: new Uint8Array(32).fill(0x11),
+      authorAddress: AUTHOR,
+      signatureR: new Uint8Array(32).fill(0x22),
+      signatureVs: new Uint8Array(32).fill(0x33),
+      schemeVersion: 1,
+      reservedKaId: RESERVED_KA_ID,
+    }));
+
+    let capturedOptions: PublishOptions | undefined;
+    const fakePublisher = {
+      publish: vi.fn(async (options: PublishOptions): Promise<PublishResult> => {
+        capturedOptions = options;
+        return {
+          kaId: RESERVED_KA_ID,
+          ual: options.kaUal!,
+          merkleRoot: new Uint8Array(32).fill(0x11),
+          kaManifest: [],
+          status: 'confirmed',
+          publicQuads: options.quads,
+          contentScopeVersion: options.contentScopeVersion,
+          assertionVersion: String(options.assertionVersion),
+          publicTripleCount: options.publicTripleCount,
+          privateMerkleRoot: options.privateMerkleRoot,
+          privateTripleCount: options.privateTripleCount,
+          accessPolicy: options.accessPolicy ?? 'ownerOnly',
+          allowedPeers: options.allowedPeers ?? [],
+        };
+      }),
+    };
+    Object.defineProperty(agent, 'publisher', {
+      value: fakePublisher,
+      writable: true,
+      configurable: true,
+    });
+    const broadcastPublish = vi.fn(async () => undefined);
+    internals.broadcastPublish = broadcastPublish;
+
+    const publicQuads: Quad[] = [{
+      subject: 'urn:private:asset',
+      predicate: 'urn:p:value',
+      object: '"public projection"',
+      graph: '',
+    }];
+    const privateQuads: Quad[] = [{
+      subject: 'urn:private:asset',
+      predicate: 'urn:p:secret',
+      object: '"hidden"',
+      graph: '',
+    }];
+    const result = await internals._publish(
+      SYSTEM_CONTEXT_GRAPHS.ONTOLOGY,
+      publicQuads,
+      privateQuads,
+      { accessPolicy: 'ownerOnly', onChainContextGraphId: '42' },
+    );
+
+    expect(result.status).toBe('confirmed');
+    expect(capturedOptions).toBeDefined();
+    expect(capturedOptions).toMatchObject({
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      kaUal: `did:dkg:mock:31337/${AUTHOR}/${KA_NUMBER}`,
+      assertionVersion: '1',
+      privateTripleCount: 1,
+      accessPolicy: 'ownerOnly',
+      publishContextGraphId: '42',
+    });
+    // A curated direct publish replaces any caller-provided catalog partition
+    // with the deterministic four-triple public floor inside this same KA.
+    expect(capturedOptions!.quads).toHaveLength(5);
+    expect(capturedOptions!.publicTripleCount).toBe(5);
+    expect(capturedOptions!.privateMerkleRoot).toHaveLength(32);
+    expect(capturedOptions!.trustedNonManifestCatalogTriples).toHaveLength(4);
+    expect(capturedOptions!.quads.some((quad) =>
+      quad.subject === 'did:dkg:context-graph:ontology'
+      && quad.predicate === 'http://purl.org/dc/terms/accessRights'
+    )).toBe(true);
+    expect(internals._buildPrecomputedAttestationForSelection).toHaveBeenCalledWith(
+      SYSTEM_CONTEXT_GRAPHS.ONTOLOGY,
+      expect.arrayContaining(capturedOptions!.quads),
+      expect.objectContaining({ graphScoped: true, privateQuads }),
+    );
+    expect(broadcastPublish).toHaveBeenCalledWith(
+      SYSTEM_CONTEXT_GRAPHS.ONTOLOGY,
+      expect.objectContaining({
+        contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+        kaManifest: [],
+      }),
+      expect.any(Object),
+      { accessPolicy: 'ownerOnly', allowedPeers: undefined },
+    );
+  });
+
+  it('broadcasts the exact UAL-derived graph and no legacy root manifest', async () => {
+    agent = await DKGAgent.create({
+      name: 'RootlessBroadcastWire',
+      store: new OxigraphStore(),
+      chainAdapter: new MockChainAdapter('mock:31337', AUTHOR),
+      nodeRole: 'edge',
+      skills: [],
+    });
+    const internals = agent as unknown as Record<string, any>;
+    let wire: Uint8Array | undefined;
+    internals.gossip = {
+      publish: vi.fn(async (_topic: string, data: Uint8Array) => {
+        wire = data;
+      }),
+    };
+    const ual = `did:dkg:mock:31337/${AUTHOR}/${KA_NUMBER}`;
+    const scope = createGraphKnowledgeAssetScope(ual, 1);
+    const expectedGraph = knowledgeAssetLayerGraphUri(
+      '42',
+      MemoryLayer.VerifiableMemory,
+      scope,
+    );
+    await internals.broadcastPublish(
+      '42',
+      {
+        kaId: RESERVED_KA_ID,
+        ual,
+        merkleRoot: new Uint8Array(32).fill(0x11),
+        kaManifest: [],
+        status: 'confirmed',
+        publicQuads: [{
+          subject: 'urn:rootless:subject',
+          predicate: 'urn:rootless:predicate',
+          object: '"value"',
+          graph: 'urn:ignored:placement',
+        }],
+        contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+        assertionVersion: '1',
+        publicTripleCount: 1,
+        privateTripleCount: 0,
+        accessPolicy: 'allowList',
+        allowedPeers: ['12D3KooWReader'],
+        onChainResult: {
+          batchId: RESERVED_KA_ID,
+          kaId: RESERVED_KA_ID,
+          startKAId: RESERVED_KA_ID,
+          endKAId: RESERVED_KA_ID,
+          txHash: `0x${'11'.repeat(32)}`,
+          blockNumber: 12,
+          blockTimestamp: 1,
+          publisherAddress: AUTHOR,
+        },
+      },
+      createOperationContext('publish'),
+    );
+
+    expect(wire).toBeDefined();
+    const decoded = decodePublishRequest(wire!);
+    expect(decoded.kas).toEqual([]);
+    expect(decoded.contentScopeVersion).toBe(GRAPH_KA_CONTENT_SCOPE_VERSION);
+    expect(decoded.assertionVersion).toBe('1');
+    expect(decoded.publicTripleCount).toBe(1);
+    expect(decoded.privateTripleCount).toBe(0);
+    expect(decoded.accessPolicy).toBe('allowList');
+    expect(decoded.allowedPeers).toEqual(['12D3KooWReader']);
+    expect(new TextDecoder().decode(decoded.nquads)).toBe(
+      `<urn:rootless:subject> <urn:rootless:predicate> "value" <${expectedGraph}> .`,
+    );
+  });
+});

--- a/packages/agent/test/e2e-chain.test.ts
+++ b/packages/agent/test/e2e-chain.test.ts
@@ -6,6 +6,10 @@ import { EVMChainAdapter } from '@origintrail-official/dkg-chain';
 import {
   buildUpdateAuthorAttestationTypedData,
   AUTHOR_SCHEME_VERSION_V1,
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  MemoryLayer,
+  createGraphKnowledgeAssetScope,
+  knowledgeAssetLayerGraphUri,
   type PrecomputedUpdateAttestation,
 } from '@origintrail-official/dkg-core';
 import {
@@ -217,13 +221,17 @@ describe('E2E: DKGAgent with real blockchain', () => {
 
     const result = await agents[0].publish(CONTEXT_GRAPH_ID, quads);
     expect(result).toBeDefined();
-    expect(result.kaManifest).toBeDefined();
-    expect(result.kaManifest.length).toBeGreaterThan(0);
+    expect(result.kaManifest).toEqual([]);
+    expect(result.contentScopeVersion).toBe(GRAPH_KA_CONTENT_SCOPE_VERSION);
+    expect(result.assertionVersion).toBe('1');
     expect(result.status).toBe('confirmed');
     expect(result.onChainResult).toBeDefined();
     expect(result.onChainResult!.txHash).toMatch(/^0x[0-9a-f]{64}$/);
     expect(result.onChainResult!.batchId).toBeGreaterThan(0n);
-    expect(result.ual).toContain('did:dkg:evm:31337/');
+    const scope = createGraphKnowledgeAssetScope(result.ual, result.assertionVersion!);
+    expect(scope.ual).toBe(result.ual);
+    expect((BigInt(scope.agentAddress) << 96n) | BigInt(scope.kaNumber))
+      .toBe(result.onChainResult!.batchId);
     firstPublishBatchId = result.onChainResult!.batchId;
   }, 60_000);
 
@@ -348,7 +356,11 @@ describe('E2E: DKGAgent with real blockchain', () => {
 
     const result = await agents[0].publish(secondCG, quads);
     expect(result).toBeDefined();
-    expect(result.kaManifest.length).toBeGreaterThan(0);
+    expect(result.kaManifest).toEqual([]);
+    expect(result.contentScopeVersion).toBe(GRAPH_KA_CONTENT_SCOPE_VERSION);
+    const scope = createGraphKnowledgeAssetScope(result.ual, result.assertionVersion!);
+    expect((BigInt(scope.agentAddress) << 96n) | BigInt(scope.kaNumber))
+      .toBe(result.onChainResult!.batchId);
     expect(result.status).toBe('confirmed');
     expect(result.onChainResult).toBeDefined();
 
@@ -364,9 +376,8 @@ describe('E2E: DKGAgent with real blockchain', () => {
 
   // -------------------------------------------------------------------------
   // Multi-entity publish — OT-RFC-44 / Design B.
-  // Direct agent.publish now routes multi-root payloads as one KA with multiple
-  // member entities. The on-chain publish still uses knowledgeAssetsAmount=1;
-  // the manifest keeps per-root compatibility token IDs for UAL suffix callers.
+  // Direct agent.publish routes the whole payload as one graph-scoped KA. RDF
+  // subjects stay data and never become compatibility token rows.
   // -------------------------------------------------------------------------
 
   it('publishes multi-root payloads through agent.publish as one Knowledge Asset', async () => {
@@ -390,8 +401,22 @@ describe('E2E: DKGAgent with real blockchain', () => {
 
     expect(result.status).toBe('confirmed');
     expect(result.onChainResult).toBeDefined();
-    expect(new Set(result.kaManifest.map((m) => m.rootEntity))).toEqual(new Set(entities));
-    expect(new Set(result.kaManifest.map((m) => String(m.tokenId)))).toEqual(new Set(['1', '2', '3']));
+    expect(result.kaManifest).toEqual([]);
+    expect(result.contentScopeVersion).toBe(GRAPH_KA_CONTENT_SCOPE_VERSION);
+    const scope = createGraphKnowledgeAssetScope(result.ual, result.assertionVersion!);
+    const exactGraph = knowledgeAssetLayerGraphUri(
+      CONTEXT_GRAPH_ID,
+      MemoryLayer.VerifiableMemory,
+      scope,
+    );
+    const exact = await (agents[0] as unknown as { store: {
+      query: (sparql: string) => Promise<{ type: string; bindings?: Record<string, string>[] }>;
+    } }).store.query(
+      `SELECT ?s ?p ?o WHERE { GRAPH <${exactGraph}> { ?s ?p ?o } }`,
+    );
+    expect(exact.type).toBe('bindings');
+    expect(exact.bindings).toHaveLength(6);
+    expect(new Set(exact.bindings!.map((binding) => binding.s))).toEqual(new Set(entities));
   }, 30_000);
 
   // -------------------------------------------------------------------------

--- a/packages/agent/test/gossip-publish-handler.test.ts
+++ b/packages/agent/test/gossip-publish-handler.test.ts
@@ -3,6 +3,10 @@ import {
   encodePublishRequest,
   DKG_ONTOLOGY,
   SYSTEM_CONTEXT_GRAPHS,
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  MemoryLayer,
+  createGraphKnowledgeAssetScope,
+  knowledgeAssetLayerGraphUri,
 } from '@origintrail-official/dkg-core';
 import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
 import { GossipPublishHandler } from '../src/gossip-publish-handler.js';
@@ -64,6 +68,122 @@ function createHandler(store?: OxigraphStore, callbacks?: Partial<{
 }
 
 describe('GossipPublishHandler', () => {
+  it('materializes a graph-scoped KA into one exact VM graph without root metadata', async () => {
+    const { store, handler } = createHandler();
+    const author = '0x70997970c51812dc3a010c7d01b50e0d17dc79c8';
+    const kaNumber = 41n;
+    const packedKaId = (BigInt(author) << 96n) | kaNumber;
+    const ual = `did:dkg:base:8453/${author}/${kaNumber}`;
+    const scope = createGraphKnowledgeAssetScope(ual, 1);
+    const vmGraph = knowledgeAssetLayerGraphUri(
+      CONTEXT_GRAPH,
+      MemoryLayer.VerifiableMemory,
+      scope,
+    );
+    const data = encodePublishRequest({
+      ual,
+      nquads: new TextEncoder().encode(
+        `<urn:rootless:subject> <urn:rootless:predicate> "value" <${vmGraph}> .`,
+      ),
+      contextGraphId: CONTEXT_GRAPH,
+      kas: [],
+      publisherIdentity: new Uint8Array(32),
+      publisherAddress: author,
+      startKAId: packedKaId,
+      endKAId: packedKaId,
+      chainId: 'base:8453',
+      publisherSignatureR: new Uint8Array(0),
+      publisherSignatureVs: new Uint8Array(0),
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      assertionVersion: '1',
+      publicTripleCount: 1,
+      privateTripleCount: 0,
+      accessPolicy: 'public',
+      allowedPeers: [],
+    });
+
+    await handler.handlePublishMessage(data, CONTEXT_GRAPH, undefined, '12D3KooWPublisher');
+
+    expect(await store.countQuads(vmGraph)).toBe(1);
+    const rootGraph = `did:dkg:context-graph:${CONTEXT_GRAPH}`;
+    expect(await store.countQuads(rootGraph)).toBe(0);
+    const metaGraph = `${rootGraph}/_meta`;
+    const metadata = await store.query(
+      `CONSTRUCT { <${ual}> ?p ?o } WHERE { GRAPH <${metaGraph}> { <${ual}> ?p ?o } }`,
+    );
+    expect(metadata.type).toBe('quads');
+    if (metadata.type !== 'quads') throw new Error('expected graph-scoped metadata');
+    expect(metadata.quads.some((quad) => quad.predicate.endsWith('rootEntity'))).toBe(false);
+    expect(metadata.quads.some((quad) => quad.predicate.endsWith('tokenId'))).toBe(false);
+    expect(metadata.quads).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        predicate: 'http://dkg.io/ontology/assertionGraph',
+        object: vmGraph,
+      }),
+      expect.objectContaining({
+        predicate: 'http://dkg.io/ontology/contentScopeVersion',
+      }),
+    ]));
+
+    await store.deleteByPattern({
+      graph: metaGraph,
+      subject: ual,
+      predicate: 'http://dkg.io/ontology/status',
+    });
+    await store.insert([{
+      subject: ual,
+      predicate: 'http://dkg.io/ontology/status',
+      object: '"confirmed"',
+      graph: metaGraph,
+    }]);
+    await handler.handlePublishMessage(data, CONTEXT_GRAPH, undefined, '12D3KooWPublisher');
+    const statusAfterReplay = await store.query(
+      `SELECT ?status WHERE { GRAPH <${metaGraph}> { ` +
+        `<${ual}> <http://dkg.io/ontology/status> ?status } }`,
+    );
+    expect(statusAfterReplay.type).toBe('bindings');
+    expect(statusAfterReplay.type === 'bindings'
+      ? statusAfterReplay.bindings[0]?.status
+      : undefined).toBe('"confirmed"');
+  });
+
+  it('rejects a graph-scoped KA whose payload targets a non-derived graph', async () => {
+    const { store, handler } = createHandler();
+    const author = '0x70997970c51812dc3a010c7d01b50e0d17dc79c8';
+    const packedKaId = (BigInt(author) << 96n) | 42n;
+    const ual = `did:dkg:base:8453/${author}/42`;
+    const scope = createGraphKnowledgeAssetScope(ual, 1);
+    const vmGraph = knowledgeAssetLayerGraphUri(
+      CONTEXT_GRAPH,
+      MemoryLayer.VerifiableMemory,
+      scope,
+    );
+    const data = encodePublishRequest({
+      ual,
+      nquads: new TextEncoder().encode(
+        '<urn:rootless:subject> <urn:rootless:predicate> "value" <urn:forged:graph> .',
+      ),
+      contextGraphId: CONTEXT_GRAPH,
+      kas: [],
+      publisherIdentity: new Uint8Array(32),
+      publisherAddress: author,
+      startKAId: packedKaId,
+      endKAId: packedKaId,
+      chainId: 'base:8453',
+      publisherSignatureR: new Uint8Array(0),
+      publisherSignatureVs: new Uint8Array(0),
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      assertionVersion: '1',
+      publicTripleCount: 1,
+      privateTripleCount: 0,
+      accessPolicy: 'public',
+    });
+
+    await handler.handlePublishMessage(data, CONTEXT_GRAPH, undefined, '12D3KooWPublisher');
+
+    expect(await store.countQuads(vmGraph)).toBe(0);
+  });
+
   it('processes a valid publish message and inserts quads into store', async () => {
     const { store, handler } = createHandler();
 

--- a/packages/agent/test/gossip-publish-handler.test.ts
+++ b/packages/agent/test/gossip-publish-handler.test.ts
@@ -6,9 +6,16 @@ import {
   GRAPH_KA_CONTENT_SCOPE_VERSION,
   MemoryLayer,
   createGraphKnowledgeAssetScope,
+  createOperationContext,
   knowledgeAssetLayerGraphUri,
 } from '@origintrail-official/dkg-core';
 import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
+import { GraphManager } from '@origintrail-official/dkg-storage';
+import type { ChainAdapter } from '@origintrail-official/dkg-chain';
+import {
+  storeKnowledgeAssetOperationPublicQuads,
+  storeKnowledgeAssetWorkspaceHead,
+} from '@origintrail-official/dkg-publisher';
 import { GossipPublishHandler } from '../src/gossip-publish-handler.js';
 import type { ContextGraphDiscoveryMetadata, ContextGraphSub } from '../src/index.js';
 
@@ -40,6 +47,7 @@ function createHandler(store?: OxigraphStore, callbacks?: Partial<{
   getContextGraphOwner: (id: string) => Promise<string | null>;
   setContextGraphSubscription: (id: string, next: ContextGraphSub) => void;
   recordDiscoveredContextGraph: (id: string, metadata: ContextGraphDiscoveryMetadata) => void;
+  getContextGraphOnChainId: (id: string) => Promise<string | null>;
 }>) {
   const s = store ?? new OxigraphStore();
   const subscriptions = new Map<string, ContextGraphSub>();
@@ -62,6 +70,9 @@ function createHandler(store?: OxigraphStore, callbacks?: Partial<{
             metaSynced: false,
           });
         }),
+        ...(callbacks?.getContextGraphOnChainId
+          ? { getContextGraphOnChainId: callbacks.getContextGraphOnChainId }
+          : {}),
       },
     ),
   };
@@ -80,6 +91,33 @@ describe('GossipPublishHandler', () => {
       MemoryLayer.VerifiableMemory,
       scope,
     );
+    const publicQuads: Quad[] = [{
+      subject: 'urn:rootless:subject',
+      predicate: 'urn:rootless:predicate',
+      object: '"value"',
+      graph: '',
+    }];
+    const graphManager = new GraphManager(store);
+    await storeKnowledgeAssetOperationPublicQuads({
+      store,
+      graphManager,
+      contextGraphId: CONTEXT_GRAPH,
+      shareOperationId: 'gossip-head',
+      kaUal: ual,
+      assertionVersion: '1',
+      quads: publicQuads,
+      privateTripleCount: 0,
+      publisherPeerId: '12D3KooWPublisher',
+      accessPolicy: 'public',
+    });
+    await storeKnowledgeAssetWorkspaceHead({
+      store,
+      graphManager,
+      contextGraphId: CONTEXT_GRAPH,
+      shareOperationId: 'gossip-head',
+      kaUal: ual,
+      assertionVersion: '1',
+    });
     const data = encodePublishRequest({
       ual,
       nquads: new TextEncoder().encode(
@@ -145,6 +183,118 @@ describe('GossipPublishHandler', () => {
     expect(statusAfterReplay.type === 'bindings'
       ? statusAfterReplay.bindings[0]?.status
       : undefined).toBe('"confirmed"');
+  });
+
+  it('uses durable owner and allow-list metadata instead of relay-supplied values', async () => {
+    const { store, handler } = createHandler();
+    const author = '0x70997970c51812dc3a010c7d01b50e0d17dc79c8';
+    const kaNumber = 43n;
+    const packedKaId = (BigInt(author) << 96n) | kaNumber;
+    const ual = `did:dkg:base:8453/${author}/${kaNumber}`;
+    const scope = createGraphKnowledgeAssetScope(ual, 1);
+    const vmGraph = knowledgeAssetLayerGraphUri(
+      CONTEXT_GRAPH,
+      MemoryLayer.VerifiableMemory,
+      scope,
+    );
+    const publicQuads: Quad[] = [{
+      subject: 'urn:rootless:trusted',
+      predicate: 'urn:rootless:predicate',
+      object: '"value"',
+      graph: '',
+    }];
+    const graphManager = new GraphManager(store);
+    await storeKnowledgeAssetOperationPublicQuads({
+      store,
+      graphManager,
+      contextGraphId: CONTEXT_GRAPH,
+      shareOperationId: 'trusted-access-head',
+      kaUal: ual,
+      assertionVersion: '1',
+      quads: publicQuads,
+      privateTripleCount: 0,
+      publisherPeerId: '12D3KooWDurableOwner',
+      accessPolicy: 'allowList',
+      allowedPeers: ['12D3KooWTrustedReader'],
+    });
+    await storeKnowledgeAssetWorkspaceHead({
+      store,
+      graphManager,
+      contextGraphId: CONTEXT_GRAPH,
+      shareOperationId: 'trusted-access-head',
+      kaUal: ual,
+      assertionVersion: '1',
+    });
+    const data = encodePublishRequest({
+      ual,
+      nquads: new TextEncoder().encode(
+        `<urn:rootless:trusted> <urn:rootless:predicate> "value" <${vmGraph}> .`,
+      ),
+      contextGraphId: CONTEXT_GRAPH,
+      kas: [],
+      publisherIdentity: new Uint8Array(32),
+      publisherAddress: author,
+      startKAId: packedKaId,
+      endKAId: packedKaId,
+      chainId: 'base:8453',
+      publisherSignatureR: new Uint8Array(0),
+      publisherSignatureVs: new Uint8Array(0),
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      assertionVersion: '1',
+      publicTripleCount: 1,
+      privateTripleCount: 0,
+      accessPolicy: 'allowList',
+      allowedPeers: ['12D3KooWAttacker'],
+    });
+
+    await handler.handlePublishMessage(data, CONTEXT_GRAPH, undefined, '12D3KooWRelay');
+
+    const metaGraph = `did:dkg:context-graph:${CONTEXT_GRAPH}/_meta`;
+    const durable = await store.query(
+      `ASK { GRAPH <${metaGraph}> { <${ual}> ` +
+        `<http://dkg.io/ontology/publisherPeerId> "12D3KooWDurableOwner" ; ` +
+        `<http://dkg.io/ontology/accessPolicy> "allowList" ; ` +
+        `<http://dkg.io/ontology/allowedPeer> "12D3KooWTrustedReader" . } }`,
+    );
+    expect(durable).toMatchObject({ type: 'boolean', value: true });
+    const attacker = await store.query(
+      `ASK { GRAPH <${metaGraph}> { <${ual}> ` +
+        `<http://dkg.io/ontology/allowedPeer> "12D3KooWAttacker" } }`,
+    );
+    expect(attacker).toMatchObject({ type: 'boolean', value: false });
+  });
+
+  it('fails on-chain verification when the KA belongs to another Context Graph', async () => {
+    const chain = {
+      chainId: 'base:8453',
+      getKAContextGraphId: async () => 8n,
+      async *listenForEvents() {
+        throw new Error('event scan must not run after a binding mismatch');
+      },
+    } as unknown as ChainAdapter;
+    const handler = new GossipPublishHandler(
+      new OxigraphStore(),
+      chain,
+      new Map(),
+      {
+        contextGraphExists: async () => true,
+        getContextGraphOwner: async () => null,
+        getContextGraphOnChainId: async () => '7',
+      },
+    );
+    const verified = await (handler as unknown as {
+      verifyGossipOnChain: (...args: unknown[]) => Promise<boolean>;
+    }).verifyGossipOnChain(
+      `0x${'11'.repeat(32)}`,
+      10,
+      new Uint8Array(32),
+      '0x1111111111111111111111111111111111111111',
+      1n,
+      1n,
+      createOperationContext('test'),
+      CONTEXT_GRAPH,
+    );
+    expect(verified).toBe(false);
   });
 
   it('rejects a graph-scoped KA whose payload targets a non-derived graph', async () => {

--- a/packages/agent/test/ka-graph-finalization-handler.test.ts
+++ b/packages/agent/test/ka-graph-finalization-handler.test.ts
@@ -135,7 +135,11 @@ describe('graph-scoped finalization handler', () => {
   it('atomically replaces the exact VM graph and emits constant-size rootless metadata', async () => {
     const { message, swmGraph, vmGraph } = await stageGraph();
 
-    await handler.handleFinalizationMessage(encodeFinalizationMessage(message), CG);
+    await handler.handleFinalizationMessage(encodeFinalizationMessage({
+      ...message,
+      accessPolicy: 'allowList',
+      allowedPeers: ['12D3KooWReader'],
+    }), CG, '12D3KooWPublisher');
 
     expect(await store.countQuads(vmGraph)).toBe(2);
     expect(await store.countQuads(swmGraph)).toBe(0);
@@ -167,8 +171,13 @@ describe('graph-scoped finalization handler', () => {
       count: '"2"^^<http://www.w3.org/2001/XMLSchema#integer>',
       privateCount: '"1"^^<http://www.w3.org/2001/XMLSchema#integer>',
       graph: vmGraph,
-      policy: '"ownerOnly"',
+      policy: '"allowList"',
     });
+    const allowedPeer = await store.query(
+      `ASK { GRAPH <${metaGraph}> { <${UAL}> ` +
+        `<http://dkg.io/ontology/allowedPeer> "12D3KooWReader" } }`,
+    );
+    expect(allowedPeer).toMatchObject({ type: 'boolean', value: true });
     const legacyRoots = await store.query(
       `ASK { GRAPH <${metaGraph}> { ?s <http://dkg.io/ontology/rootEntity> ?root } }`,
     );

--- a/packages/agent/test/ka-graph-finalization-handler.test.ts
+++ b/packages/agent/test/ka-graph-finalization-handler.test.ts
@@ -47,7 +47,10 @@ describe('graph-scoped finalization handler', () => {
     });
   });
 
-  async function stageGraph(): Promise<{
+  async function stageGraph(durableAccess?: {
+    accessPolicy: 'ownerOnly' | 'allowList';
+    allowedPeers?: string[];
+  }): Promise<{
     message: FinalizationMessageMsg;
     swmGraph: string;
     vmGraph: string;
@@ -95,6 +98,8 @@ describe('graph-scoped finalization handler', () => {
       privateMerkleRoot,
       privateTripleCount: privateQuads.length,
       publisherPeerId: '12D3KooWPublisher',
+      accessPolicy: durableAccess?.accessPolicy,
+      allowedPeers: durableAccess?.allowedPeers,
     });
     await storeKnowledgeAssetWorkspaceHead({
       store,
@@ -254,6 +259,31 @@ describe('graph-scoped finalization handler', () => {
       } }`,
     );
     expect(metadata).toMatchObject({ type: 'boolean', value: true });
+  });
+
+  it('ignores an access envelope supplied by a relay that is not the durable owner', async () => {
+    const { message } = await stageGraph({ accessPolicy: 'ownerOnly' });
+
+    await handler.handleFinalizationMessage(encodeFinalizationMessage({
+      ...message,
+      accessPolicy: 'allowList',
+      allowedPeers: ['12D3KooWAttacker'],
+    }), CG, '12D3KooWUntrustedRelay');
+
+    const metaGraph = `did:dkg:context-graph:${CG}/_meta`;
+    const policy = await store.query(
+      `SELECT ?policy WHERE { GRAPH <${metaGraph}> { <${UAL}> ` +
+        `<http://dkg.io/ontology/accessPolicy> ?policy } }`,
+    );
+    expect(policy).toMatchObject({
+      type: 'bindings',
+      bindings: [{ policy: '"ownerOnly"' }],
+    });
+    const attacker = await store.query(
+      `ASK { GRAPH <${metaGraph}> { <${UAL}> ` +
+        `<http://dkg.io/ontology/allowedPeer> "12D3KooWAttacker" } }`,
+    );
+    expect(attacker).toMatchObject({ type: 'boolean', value: false });
   });
 
   it('keeps the old VM graph and remains retryable when the atomic swap fails', async () => {

--- a/packages/agent/test/v10-ack-provider-wiring.test.ts
+++ b/packages/agent/test/v10-ack-provider-wiring.test.ts
@@ -337,6 +337,51 @@ describe('DKGAgent.createV10ACKProvider — structured ACK verifier wiring (PR #
     })).rejects.toThrow('zero is valid only for curated encrypted updates');
   });
 
+  it('forwards the complete graph-scoped publish envelope into ACK collection', async () => {
+    const boot = await bootProviderAgent();
+    agent = boot.agent;
+    const publishProvider = boot.internals.createV10ACKProvider('test-cg') as V10ACKProviderObject;
+    const root = new Uint8Array(32).fill(0x44);
+    const privateRoot = new Uint8Array(32).fill(0x55);
+    const kaUal = 'did:dkg:mock:31337/0x1111111111111111111111111111111111111111/7';
+
+    await expect(publishProvider({
+      merkleRoot: root,
+      contextGraphId: '42',
+      kaCount: 1,
+      rootEntities: [],
+      publicByteSize: 100n,
+      merkleLeafCount: 4,
+      contentScopeVersion: 2,
+      kaUal,
+      assertionVersion: '1',
+      publicTripleCount: 4,
+      privateMerkleRoot: privateRoot,
+      privateTripleCount: 9,
+      accessPolicy: 'ownerOnly',
+      allowedPeers: [],
+      stagingQuads: new Uint8Array([1]),
+      ackMode: {
+        kind: 'curated-catalog',
+        catalogCommitment: { catalogRoot: root, catalogLeafCount: 4 },
+      },
+    })).resolves.toEqual([]);
+
+    expect(capturedPublishCollectParams).toHaveLength(1);
+    expect(capturedPublishCollectParams[0]).toMatchObject({
+      rootEntities: [],
+      contentScopeVersion: 2,
+      kaUal,
+      assertionVersion: '1',
+      publicTripleCount: 4,
+      privateTripleCount: 9,
+      accessPolicy: 'ownerOnly',
+      allowedPeers: [],
+    });
+    expect((capturedPublishCollectParams[0] as { privateMerkleRoot: Uint8Array }).privateMerkleRoot)
+      .toBe(privateRoot);
+  });
+
   it('passes ackSendTimeoutMs through publish and update ACK provider sendP2P closures', async () => {
     const boot = await bootProviderAgent({ ackSendTimeoutMs: 60_000 });
     agent = boot.agent;

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -66,6 +66,7 @@ export default defineConfig({
       "test/ka-lifecycle-asset-ual-timeout.test.ts",
       "test/storage-ack-lifecycle-identity.test.ts",
       "test/v10-ack-provider-wiring.test.ts",
+      "test/direct-rootless-publish.test.ts",
       "test/agents-meta-policy.test.ts",
       "test/agents-meta-sync-wiring.test.ts",
       "test/network-identity-proof.test.ts",

--- a/packages/core/src/proto/finalization.ts
+++ b/packages/core/src/proto/finalization.ts
@@ -94,7 +94,9 @@ export const FinalizationMessageSchema = new Type('FinalizationMessage')
   .add(new Field('assertionVersion', 19, 'string'))
   .add(new Field('publicTripleCount', 20, 'uint32'))
   .add(new Field('privateMerkleRoot', 21, 'bytes'))
-  .add(new Field('privateTripleCount', 22, 'uint32'));
+  .add(new Field('privateTripleCount', 22, 'uint32'))
+  .add(new Field('accessPolicy', 23, 'string'))
+  .add(new Field('allowedPeers', 24, 'string', 'repeated'));
 
 type Long = { low: number; high: number; unsigned: boolean };
 
@@ -164,6 +166,10 @@ export interface FinalizationMessageMsg {
   privateMerkleRoot?: Uint8Array;
   /** Number of private RDF triples committed by privateMerkleRoot. */
   privateTripleCount?: number;
+  /** Rootless KA query policy retained by receiving replicas. */
+  accessPolicy?: 'public' | 'ownerOnly' | 'allowList';
+  /** Exact peer allow-list when accessPolicy is allowList. */
+  allowedPeers?: string[];
 }
 
 const MAX_UINT64 = (1n << 64n) - 1n;

--- a/packages/core/src/proto/publish-intent.ts
+++ b/packages/core/src/proto/publish-intent.ts
@@ -101,7 +101,9 @@ export const PublishIntentSchema = new Type('PublishIntent')
   .add(new Field('assertionVersion', 23, 'string'))
   .add(new Field('publicTripleCount', 24, 'uint32'))
   .add(new Field('privateMerkleRoot', 25, 'bytes'))
-  .add(new Field('privateTripleCount', 26, 'uint32'));
+  .add(new Field('privateTripleCount', 26, 'uint32'))
+  .add(new Field('accessPolicy', 27, 'string'))
+  .add(new Field('allowedPeers', 28, 'string', 'repeated'));
 
 type Long = { low: number; high: number; unsigned: boolean };
 
@@ -223,6 +225,10 @@ export interface PublishIntentMsg {
   privateMerkleRoot?: Uint8Array;
   /** Number of private RDF triples committed by privateMerkleRoot. */
   privateTripleCount?: number;
+  /** Rootless KA query policy retained across ACK-backed replication. */
+  accessPolicy?: 'public' | 'ownerOnly' | 'allowList';
+  /** Exact peer allow-list when accessPolicy is allowList. */
+  allowedPeers?: string[];
 }
 
 /** Sent in `ackProtocolVersion` for LU-11 chunked ACKs. */

--- a/packages/core/src/proto/publish.ts
+++ b/packages/core/src/proto/publish.ts
@@ -42,6 +42,8 @@ export const PublishRequestSchema = new Type('PublishRequest')
   .add(new Field('publicTripleCount', 18, 'uint32'))
   .add(new Field('privateMerkleRoot', 19, 'bytes'))
   .add(new Field('privateTripleCount', 20, 'uint32'))
+  .add(new Field('accessPolicy', 21, 'string'))
+  .add(new Field('allowedPeers', 22, 'string', 'repeated'))
   .add(KAManifestEntrySchema);
 
 export const PublishAckSchema = new Type('PublishAck')
@@ -90,6 +92,10 @@ export interface PublishRequestMsg {
   privateMerkleRoot?: Uint8Array;
   /** Number of private RDF triples committed by privateMerkleRoot. */
   privateTripleCount?: number;
+  /** KA-level access policy carried by graph-scoped writers. */
+  accessPolicy?: 'public' | 'ownerOnly' | 'allowList';
+  /** Exact allow-list retained when accessPolicy is allowList. */
+  allowedPeers?: string[];
 }
 
 export interface PublishAckMsg {

--- a/packages/core/test/proto-ka-content-scope.test.ts
+++ b/packages/core/test/proto-ka-content-scope.test.ts
@@ -76,11 +76,15 @@ describe('rootless KA graph scope wire contract', () => {
       publicTripleCount: 1_000,
       privateMerkleRoot: PRIVATE_ROOT,
       privateTripleCount: 11,
+      accessPolicy: 'allowList',
+      allowedPeers: ['12D3KooWReader'],
     }));
 
     expect(decoded.kaUal).toBe(UAL);
     expect(decoded.rootEntities).toEqual([]);
     expect(decoded.privateMerkleRoots).toEqual([]);
+    expect(decoded.accessPolicy).toBe('allowList');
+    expect(decoded.allowedPeers).toEqual(['12D3KooWReader']);
     expectGraphScope(decoded);
   });
 
@@ -102,10 +106,14 @@ describe('rootless KA graph scope wire contract', () => {
       publicTripleCount: 1_000,
       privateMerkleRoot: PRIVATE_ROOT,
       privateTripleCount: 11,
+      accessPolicy: 'ownerOnly',
+      allowedPeers: [],
     }));
 
     expect(decoded.ual).toBe(UAL);
     expect(decoded.rootEntities).toEqual([]);
+    expect(decoded.accessPolicy).toBe('ownerOnly');
+    expect(decoded.allowedPeers).toEqual([]);
     expectGraphScope(decoded);
   });
 
@@ -122,6 +130,8 @@ describe('rootless KA graph scope wire contract', () => {
       chainId: 'base:8453',
       publisherSignatureR: new Uint8Array(32),
       publisherSignatureVs: new Uint8Array(32),
+      accessPolicy: 'allowList',
+      allowedPeers: ['12D3KooWOne', '12D3KooWTwo'],
       contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
       assertionVersion: '2',
       publicTripleCount: 1_000,
@@ -132,6 +142,8 @@ describe('rootless KA graph scope wire contract', () => {
     expect(decoded.ual).toBe(UAL);
     expect(decoded.kas).toEqual([]);
     expectGraphScope(decoded);
+    expect(decoded.accessPolicy).toBe('allowList');
+    expect(decoded.allowedPeers).toEqual(['12D3KooWOne', '12D3KooWTwo']);
   });
 
   it('round-trips one KA scope through update gossip', () => {

--- a/packages/publisher/src/access-handler.ts
+++ b/packages/publisher/src/access-handler.ts
@@ -7,6 +7,8 @@ import {
   assertSafeIri,
   GRAPH_KA_CONTENT_SCOPE_VERSION,
   createGraphKnowledgeAssetScope,
+  knowledgeAssetLayerGraphUri,
+  MemoryLayer,
   validateSubGraphName,
 } from '@origintrail-official/dkg-core';
 import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
@@ -240,7 +242,11 @@ export class AccessHandler {
     return null;
   }
 
-  /** Resolve V2 metadata through the durable StorageACK head, never VM wire rows. */
+  /**
+   * Resolve replicated V2 metadata through the durable StorageACK head. Direct
+   * publishes do not have a StorageACK workspace, so they fall back to the
+   * complete confirmed metadata written by the local publish transaction.
+   */
   private async queryGraphScopedKAMeta(kaUal: string): Promise<KAMeta | null> {
     const safeUal = assertSafeIri(kaUal);
     const candidates = await this.store.query(
@@ -256,7 +262,9 @@ export class AccessHandler {
         }
       }`,
     );
-    if (candidates.type !== 'bindings' || candidates.bindings.length === 0) return null;
+    if (candidates.type !== 'bindings' || candidates.bindings.length === 0) {
+      return this.queryConfirmedGraphScopedKAMeta(kaUal);
+    }
 
     const distinct = new Map<string, { contextGraphId: string; assertionVersion: string; subGraphName?: string }>();
     for (const binding of candidates.bindings) {
@@ -309,6 +317,131 @@ export class AccessHandler {
       accessPolicy: head.accessPolicy,
       publisherPeerId: head.publisherPeerId,
       allowedPeers: head.allowedPeers,
+    };
+  }
+
+  /**
+   * Resolve the originator's direct-publish metadata without weakening the
+   * durable-head rule for replicated SWM data. Every value must come from the
+   * canonical context-graph metadata graph, be confirmed, and describe the
+   * exact assertion-version VM graph whose private bag will be served.
+   */
+  private async queryConfirmedGraphScopedKAMeta(kaUal: string): Promise<KAMeta | null> {
+    const safeUal = assertSafeIri(kaUal);
+    const result = await this.store.query(
+      `SELECT ?metaGraph ?contextGraph ?assertionVersion ?assertionGraph
+              ?publicTripleCount ?privateTripleCount ?privateMerkleRoot
+              ?accessPolicy ?publisherPeerId ?subGraphName ?allowedPeer WHERE {
+        GRAPH ?metaGraph {
+          <${safeUal}> <${DKG_NS}contentScopeVersion> "${GRAPH_KA_CONTENT_SCOPE_VERSION}"^^<http://www.w3.org/2001/XMLSchema#integer> ;
+            <${DKG_NS}kaUal> <${safeUal}> ;
+            <${DKG_NS}status> "confirmed" ;
+            <${DKG_NS}contextGraph> ?contextGraph ;
+            <${DKG_NS}assertionVersion> ?assertionVersion ;
+            <${DKG_NS}assertionGraph> ?assertionGraph ;
+            <${DKG_NS}publicTripleCount> ?publicTripleCount ;
+            <${DKG_NS}privateTripleCount> ?privateTripleCount ;
+            <${DKG_NS}privateMerkleRoot> ?privateMerkleRoot ;
+            <${DKG_NS}accessPolicy> ?accessPolicy ;
+            <${DKG_NS}publisherPeerId> ?publisherPeerId .
+          OPTIONAL { <${safeUal}> <${DKG_NS}subGraphName> ?subGraphName }
+          OPTIONAL { <${safeUal}> <${DKG_NS}allowedPeer> ?allowedPeer }
+        }
+      }`,
+    );
+    if (result.type !== 'bindings' || result.bindings.length === 0) return null;
+
+    const values = (key: string): string[] => [...new Set(
+      result.bindings
+        .map((row) => row[key])
+        .filter((value): value is string => value !== undefined)
+        .map(stripLiteral),
+    )];
+    const requiredSingleton = (key: string): string => {
+      const found = values(key);
+      if (found.length !== 1 || found[0].length === 0) {
+        throw new Error(`Corrupt confirmed graph-scoped access metadata: ${key}`);
+      }
+      return found[0];
+    };
+    const optionalSingleton = (key: string): string | undefined => {
+      const found = values(key);
+      if (found.length > 1) {
+        throw new Error(`Corrupt confirmed graph-scoped access metadata: ${key}`);
+      }
+      return found[0];
+    };
+
+    const contextGraph = requiredSingleton('contextGraph');
+    const contextGraphPrefix = 'did:dkg:context-graph:';
+    const contextGraphId = contextGraph.startsWith(contextGraphPrefix)
+      ? contextGraph.slice(contextGraphPrefix.length)
+      : '';
+    if (
+      !contextGraphId
+      || requiredSingleton('metaGraph') !== `${contextGraph}/_meta`
+    ) {
+      throw new Error('Corrupt confirmed graph-scoped access metadata: contextGraph');
+    }
+
+    const assertionVersion = requiredSingleton('assertionVersion');
+    const publicTripleCount = requiredSingleton('publicTripleCount');
+    const privateTripleCountLiteral = requiredSingleton('privateTripleCount');
+    if (
+      !/^[1-9][0-9]*$/.test(assertionVersion)
+      || !/^(?:0|[1-9][0-9]*)$/.test(publicTripleCount)
+      || !/^[1-9][0-9]*$/.test(privateTripleCountLiteral)
+    ) {
+      throw new Error('Corrupt confirmed graph-scoped access metadata: content counts');
+    }
+    const publicTripleCountNumber = Number(publicTripleCount);
+    const privateTripleCount = Number(privateTripleCountLiteral);
+    if (
+      !Number.isSafeInteger(publicTripleCountNumber)
+      || !Number.isSafeInteger(privateTripleCount)
+    ) {
+      throw new Error('Corrupt confirmed graph-scoped access metadata: content counts');
+    }
+
+    const subGraphName = optionalSingleton('subGraphName');
+    if (subGraphName && !validateSubGraphName(subGraphName).valid) {
+      throw new Error('Corrupt confirmed graph-scoped access metadata: subGraphName');
+    }
+    const graphScope = createGraphKnowledgeAssetScope(kaUal, assertionVersion);
+    const expectedAssertionGraph = knowledgeAssetLayerGraphUri(
+      contextGraphId,
+      MemoryLayer.VerifiableMemory,
+      graphScope,
+      subGraphName,
+    );
+    if (requiredSingleton('assertionGraph') !== expectedAssertionGraph) {
+      throw new Error('Corrupt confirmed graph-scoped access metadata: assertionGraph');
+    }
+
+    const accessPolicy = requiredSingleton('accessPolicy');
+    if (!isAccessPolicy(accessPolicy)) {
+      throw new Error('Corrupt confirmed graph-scoped access metadata: accessPolicy');
+    }
+    const allowedPeers = values('allowedPeer');
+    if (
+      allowedPeers.some((peer) => peer.length === 0 || peer.trim() !== peer)
+      || (accessPolicy === 'allowList' && allowedPeers.length === 0)
+      || (accessPolicy !== 'allowList' && allowedPeers.length > 0)
+    ) {
+      throw new Error('Corrupt confirmed graph-scoped access metadata: allowedPeer');
+    }
+
+    return {
+      rootEntity: '',
+      rootEntities: [],
+      contextGraphId,
+      ...(subGraphName ? { subGraphName } : {}),
+      graphScope,
+      privateMerkleRoot: hexToBytes(requiredSingleton('privateMerkleRoot')),
+      privateTripleCount,
+      accessPolicy,
+      publisherPeerId: requiredSingleton('publisherPeerId'),
+      allowedPeers,
     };
   }
 

--- a/packages/publisher/src/access-handler.ts
+++ b/packages/publisher/src/access-handler.ts
@@ -5,10 +5,14 @@ import {
   encodeAccessResponse,
   ed25519Verify,
   assertSafeIri,
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  createGraphKnowledgeAssetScope,
+  validateSubGraphName,
 } from '@origintrail-official/dkg-core';
-import type { TripleStore } from '@origintrail-official/dkg-storage';
+import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
 import { GraphManager, PrivateContentStore } from '@origintrail-official/dkg-storage';
 import { computePrivateRootV10 as computePrivateRoot } from './merkle.js';
+import { resolveKnowledgeAssetWorkspaceHead } from './workspace-resolution.js';
 
 const DKG_NS = 'http://dkg.io/ontology/';
 
@@ -32,6 +36,7 @@ interface KAMeta {
   hasInvalidExplicitPolicy?: boolean;
   publisherPeerId?: string;
   allowedPeers?: string[];
+  graphScope?: ReturnType<typeof createGraphKnowledgeAssetScope>;
 }
 
 /**
@@ -90,15 +95,25 @@ export class AccessHandler {
       // Single-root KAs (and legacy `<ual>/<n>` requests, inherently 1:1)
       // are unchanged.
       let servedRootEntity = meta.rootEntity;
+      let privateQuads: Quad[] | undefined;
       let hasPrivate = false;
-      for (const root of meta.rootEntities) {
-        if (
-          this.privateStore.hasPrivateTriples(meta.contextGraphId, root, meta.subGraphName) ||
-          (await this.privateStore.hasPrivateTriplesInStore(meta.contextGraphId, root, meta.subGraphName))
-        ) {
-          servedRootEntity = root;
-          hasPrivate = true;
-          break;
+      if (meta.graphScope) {
+        privateQuads = await this.privateStore.getKnowledgeAssetPrivateTriples(
+          meta.contextGraphId,
+          meta.graphScope,
+          meta.subGraphName,
+        );
+        hasPrivate = privateQuads.length > 0;
+      } else {
+        for (const root of meta.rootEntities) {
+          if (
+            this.privateStore.hasPrivateTriples(meta.contextGraphId, root, meta.subGraphName) ||
+            (await this.privateStore.hasPrivateTriplesInStore(meta.contextGraphId, root, meta.subGraphName))
+          ) {
+            servedRootEntity = root;
+            hasPrivate = true;
+            break;
+          }
         }
       }
 
@@ -157,16 +172,27 @@ export class AccessHandler {
         }
       }
 
-      const privateQuads = await this.privateStore.getPrivateTriples(
+      privateQuads ??= await this.privateStore.getPrivateTriples(
         meta.contextGraphId,
         servedRootEntity,
         meta.subGraphName,
       );
 
+      if (meta.graphScope && meta.privateMerkleRoot) {
+        const actualPrivateRoot = computePrivateRoot(privateQuads);
+        if (
+          !actualPrivateRoot
+          || toHex(actualPrivateRoot) !== toHex(meta.privateMerkleRoot)
+        ) {
+          return this.deny('Private content does not match the durable KA commitment');
+        }
+      }
+
       const nquads = privateQuads
         .map(
-          (q) =>
-            `<${q.subject}> <${q.predicate}> ${q.object} <${q.graph}> .`,
+          (q) => q.graph
+            ? `<${q.subject}> <${q.predicate}> ${q.object} <${q.graph}> .`
+            : `<${q.subject}> <${q.predicate}> ${q.object} .`,
         )
         .join('\n');
 
@@ -199,6 +225,8 @@ export class AccessHandler {
   }
 
   private async lookupKAMeta(kaUal: string): Promise<KAMeta | null> {
+    const graphScoped = await this.queryGraphScopedKAMeta(kaUal);
+    if (graphScoped) return graphScoped;
     const direct = await this.queryKAMeta(kaUal);
     if (direct) return direct;
     // Read-both (RFC ka-metadata-trim P3.1): older requesters address private
@@ -210,6 +238,78 @@ export class AccessHandler {
       return this.queryKAMeta(legacyToken[1]);
     }
     return null;
+  }
+
+  /** Resolve V2 metadata through the durable StorageACK head, never VM wire rows. */
+  private async queryGraphScopedKAMeta(kaUal: string): Promise<KAMeta | null> {
+    const safeUal = assertSafeIri(kaUal);
+    const candidates = await this.store.query(
+      `SELECT ?contextGraphId ?assertionVersion ?subGraphName WHERE {
+        GRAPH ?g {
+          ?head <${DKG_NS}contentScopeVersion> "${GRAPH_KA_CONTENT_SCOPE_VERSION}"^^<http://www.w3.org/2001/XMLSchema#integer> ;
+            <${DKG_NS}kaUal> <${safeUal}> ;
+            <${DKG_NS}assertionVersion> ?assertionVersion ;
+            <${DKG_NS}shareOperationId> ?shareOperationId .
+          ?operation <${DKG_NS}shareOperationId> ?shareOperationId ;
+            <${DKG_NS}contextGraphId> ?contextGraphId .
+          OPTIONAL { ?operation <${DKG_NS}subGraphName> ?subGraphName }
+        }
+      }`,
+    );
+    if (candidates.type !== 'bindings' || candidates.bindings.length === 0) return null;
+
+    const distinct = new Map<string, { contextGraphId: string; assertionVersion: string; subGraphName?: string }>();
+    for (const binding of candidates.bindings) {
+      const contextGraphId = stripLiteral(binding['contextGraphId'] ?? '').trim();
+      const assertionVersion = stripLiteral(binding['assertionVersion'] ?? '').trim();
+      const subGraphName = binding['subGraphName']
+        ? stripLiteral(binding['subGraphName']).trim()
+        : undefined;
+      if (!contextGraphId || !/^[1-9][0-9]*$/.test(assertionVersion)) {
+        throw new Error('Corrupt graph-scoped access metadata');
+      }
+      if (subGraphName && !validateSubGraphName(subGraphName).valid) {
+        throw new Error('Corrupt graph-scoped access sub-graph metadata');
+      }
+      distinct.set(`${contextGraphId}\0${assertionVersion}\0${subGraphName ?? ''}`, {
+        contextGraphId,
+        assertionVersion,
+        ...(subGraphName ? { subGraphName } : {}),
+      });
+    }
+    if (distinct.size !== 1) {
+      throw new Error('Ambiguous graph-scoped access metadata');
+    }
+    const candidate = [...distinct.values()][0];
+    const head = await resolveKnowledgeAssetWorkspaceHead({
+      store: this.store,
+      graphManager: this.graphManager,
+      contextGraphId: candidate.contextGraphId,
+      kaUal,
+      subGraphName: candidate.subGraphName,
+    });
+    if (
+      !head
+      || head.assertionVersion !== candidate.assertionVersion
+      || head.privateTripleCount <= 0
+      || !head.privateMerkleRoot
+      || !head.accessPolicy
+    ) {
+      throw new Error('Incomplete graph-scoped access metadata');
+    }
+    const graphScope = createGraphKnowledgeAssetScope(kaUal, head.assertionVersion);
+    return {
+      rootEntity: '',
+      rootEntities: [],
+      contextGraphId: candidate.contextGraphId,
+      subGraphName: candidate.subGraphName,
+      graphScope,
+      privateMerkleRoot: hexToBytes(head.privateMerkleRoot),
+      privateTripleCount: head.privateTripleCount,
+      accessPolicy: head.accessPolicy,
+      publisherPeerId: head.publisherPeerId,
+      allowedPeers: head.allowedPeers,
+    };
   }
 
   private async queryKAMeta(kaUal: string): Promise<KAMeta | null> {
@@ -355,6 +455,12 @@ function toHex(bytes: Uint8Array): string {
   return Array.from(bytes)
     .map((b) => b.toString(16).padStart(2, '0'))
     .join('');
+}
+
+function hexToBytes(value: string): Uint8Array {
+  const hex = value.replace(/^0x/, '');
+  if (!/^[0-9a-f]{64}$/i.test(hex)) throw new Error('Invalid private Merkle root');
+  return Uint8Array.from(hex.match(/.{2}/g)!.map((pair) => Number.parseInt(pair, 16)));
 }
 
 function stripLiteral(s: string): string {

--- a/packages/publisher/src/ack-collector.ts
+++ b/packages/publisher/src/ack-collector.ts
@@ -12,6 +12,8 @@ import {
   STORAGE_ACK_DECLINE_CODES,
   boundedDeclineCodeLabel,
   isSubscriptionSource,
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  createGraphKnowledgeAssetScope,
   withSpan,
   getMetrics,
   type PublishIntentMsg,
@@ -119,6 +121,15 @@ export interface ACKCollectorParams {
   merkleLeafCount: number;
   /** Canonical KA UAL for publisher-local lifecycle context. Not sent on the PublishIntent wire. */
   assetUal?: string;
+  /** Complete rootless-KA envelope; omitted together for legacy intents. */
+  contentScopeVersion?: number;
+  kaUal?: string;
+  assertionVersion?: string;
+  publicTripleCount?: number;
+  privateMerkleRoot?: Uint8Array;
+  privateTripleCount?: number;
+  accessPolicy?: 'public' | 'ownerOnly' | 'allowList';
+  allowedPeers?: string[];
   ackMode?: V10ACKMode;
 }
 
@@ -301,6 +312,14 @@ export class ACKCollector {
         `ACK collection failed: V10 publish requires exactly one Knowledge Asset (kaCount=1); got ${params.kaCount}`,
       );
     }
+    const isGraphScoped = params.contentScopeVersion !== undefined
+      || params.kaUal !== undefined
+      || params.assertionVersion !== undefined
+      || params.publicTripleCount !== undefined
+      || params.privateMerkleRoot !== undefined
+      || params.privateTripleCount !== undefined
+      || params.accessPolicy !== undefined
+      || params.allowedPeers !== undefined;
     const privateMerkleRoots = ackMode.kind === 'folded-private'
       ? ackMode.privateMerkleRoots
       : [];
@@ -317,6 +336,64 @@ export class ACKCollector {
     }
     if (ackMode.kind === 'folded-private' && privateMerkleRoots.length === 0) {
       throw new Error('ACK collection failed: folded-private ACK mode requires at least one privateMerkleRoot');
+    }
+    if (isGraphScoped) {
+      if (
+        params.contentScopeVersion !== GRAPH_KA_CONTENT_SCOPE_VERSION
+        || !params.kaUal
+        || !params.assertionVersion
+        || params.publicTripleCount === undefined
+        || params.privateTripleCount === undefined
+      ) {
+        throw new Error('ACK collection failed: graph-scoped publish requires a complete content envelope');
+      }
+      const allowedPeers = params.allowedPeers ?? [];
+      if (
+        (params.accessPolicy !== 'public'
+          && params.accessPolicy !== 'ownerOnly'
+          && params.accessPolicy !== 'allowList')
+        || new Set(allowedPeers).size !== allowedPeers.length
+        || allowedPeers.some((peer) => peer.trim() !== peer || peer.length === 0)
+        || (params.accessPolicy === 'allowList' && allowedPeers.length === 0)
+        || (params.accessPolicy !== 'allowList' && allowedPeers.length > 0)
+      ) {
+        throw new Error('ACK collection failed: graph-scoped publish has an invalid access envelope');
+      }
+      if (params.rootEntities.length !== 0) {
+        throw new Error('ACK collection failed: graph-scoped publish must not carry rootEntities');
+      }
+      if (privateMerkleRoots.length > 1) {
+        throw new Error('ACK collection failed: graph-scoped publish supports one KA-level private commitment');
+      }
+      const graphScope = createGraphKnowledgeAssetScope(params.kaUal, params.assertionVersion);
+      if (graphScope.ual !== params.kaUal || graphScope.assertionVersion !== '1') {
+        throw new Error('ACK collection failed: graph-scoped publish requires a canonical version-1 UAL');
+      }
+      if (
+        !Number.isSafeInteger(params.publicTripleCount)
+        || params.publicTripleCount < 0
+        || !Number.isSafeInteger(params.privateTripleCount)
+        || params.privateTripleCount < 0
+        || (params.publicTripleCount === 0 && params.privateTripleCount === 0)
+        || (params.privateTripleCount > 0 && params.privateMerkleRoot?.length !== 32)
+        || (params.privateTripleCount === 0 && params.privateMerkleRoot !== undefined)
+      ) {
+        throw new Error('ACK collection failed: graph-scoped publish has an invalid content envelope');
+      }
+      if (
+        params.privateMerkleRoot
+        && ackMode.kind === 'folded-private'
+        && (privateMerkleRoots.length !== 1
+          || !privateMerkleRoots[0].every((byte, index) => byte === params.privateMerkleRoot![index]))
+      ) {
+        throw new Error('ACK collection failed: graph-scoped private commitment differs from ACK mode');
+      }
+      if (
+        (params.privateMerkleRoot === undefined && privateMerkleRoots.length > 0)
+        || (params.privateMerkleRoot !== undefined && ackMode.kind === 'public')
+      ) {
+        throw new Error('ACK collection failed: graph-scoped ACK mode carries an undeclared private commitment');
+      }
     }
     for (const [idx, root] of privateMerkleRoots.entries()) {
       if (root.length !== 32) {
@@ -363,7 +440,7 @@ export class ACKCollector {
     // the V2 storage-ack protocol. This makes mixed-version clusters fail at
     // protocol/capability selection instead of dialing V1-only cores that would
     // ignore field 20 and sign/decline against a public-only root.
-    const ackProtocolId = privateMerkleRoots.length > 0
+    const ackProtocolId = privateMerkleRoots.length > 0 || isGraphScoped
       ? PROTOCOL_STORAGE_ACK_V2
       : PROTOCOL_STORAGE_ACK;
     const p2pMsg: PublishIntentMsg = {
@@ -386,8 +463,17 @@ export class ACKCollector {
       catalogRoot: catalogCommitment?.catalogRoot,
       catalogLeafCount: catalogCommitment?.catalogLeafCount,
       privateMerkleRoots: privateMerkleRoots.length > 0
+        && !isGraphScoped
         ? [...privateMerkleRoots]
         : undefined,
+      contentScopeVersion: params.contentScopeVersion,
+      kaUal: params.kaUal,
+      assertionVersion: params.assertionVersion,
+      publicTripleCount: params.publicTripleCount,
+      privateMerkleRoot: params.privateMerkleRoot,
+      privateTripleCount: params.privateTripleCount,
+      accessPolicy: params.accessPolicy,
+      allowedPeers: params.allowedPeers,
     };
     const intentBytes = encodePublishIntent(p2pMsg);
 

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -253,6 +253,13 @@ async function invokeV10ACKProvider(
     return (provider as V10ACKProviderObject)(params);
   }
 
+  if (params.contentScopeVersion === GRAPH_KA_CONTENT_SCOPE_VERSION) {
+    throw new Error(
+      'Graph-scoped V10 ACK collection requires object-form v10ACKProvider ' +
+      'so the complete content and access envelopes reach ACK replicas.',
+    );
+  }
+
   if (params.ackMode.kind === 'folded-private') {
     throw new Error(
       'Folded-private V10 ACK collection requires object-form v10ACKProvider ' +
@@ -2577,7 +2584,7 @@ export class DKGPublisher implements Publisher {
     // `useCuratedCatalog` gates the inline-catalog ACK path (cores rebuild the
     // catalog root from the inline plaintext and DECLINE on mismatch).
     const useCuratedCatalog = useEncryptedInline && catalogCommitment !== undefined;
-    if (useEncryptedInline && privateRoots.length > 0) {
+    if (useEncryptedInline && privateRoots.length > 0 && !graphPublish) {
       throw new Error(
         'Encrypted inline publishes with privateQuads are not supported by the current V10 ACK model. ' +
         'The publisher can collect either curated-catalog ACKs or folded-private public-CG ACKs, ' +
@@ -2796,6 +2803,18 @@ export class DKGPublisher implements Publisher {
           subGraphName: options.subGraphName,
           merkleLeafCount: kcMerkleLeafCount,
           assetUal,
+          ...(graphPublish
+            ? {
+                contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+                kaUal: graphPublish.scope.ual,
+                assertionVersion: graphPublish.scope.assertionVersion,
+                publicTripleCount: graphPublish.publicTripleCount,
+                ...(privateRoots[0] ? { privateMerkleRoot: privateRoots[0] } : {}),
+                privateTripleCount: graphPublish.privateTripleCount,
+                accessPolicy: effectiveAccessPolicy,
+                allowedPeers: [...normalizedAllowedPeers],
+              }
+            : {}),
         };
         const lifecycleAckMode = useCuratedCatalog
           ? 'curated_catalog'
@@ -3730,6 +3749,17 @@ export class DKGPublisher implements Publisher {
       v10ACKs,
       v10Origin: usedV10Path,
       subGraphName: options.subGraphName,
+      ...(graphPublish
+        ? {
+            contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+            assertionVersion: graphPublish.scope.assertionVersion,
+            publicTripleCount: graphPublish.publicTripleCount,
+            ...(privateRoots[0] ? { privateMerkleRoot: privateRoots[0] } : {}),
+            privateTripleCount: graphPublish.privateTripleCount,
+            accessPolicy: effectiveAccessPolicy,
+            allowedPeers: [...normalizedAllowedPeers],
+          }
+        : {}),
     };
     lifecycle.emit('finalization', 'complete', {
       metadata: {

--- a/packages/publisher/src/metadata.ts
+++ b/packages/publisher/src/metadata.ts
@@ -592,6 +592,8 @@ export interface KnowledgeAssetShareMetadata {
   /** Number of private triples committed by privateMerkleRoot. */
   privateTripleCount?: number;
   publisherPeerId: string;
+  accessPolicy?: 'public' | 'ownerOnly' | 'allowList';
+  allowedPeers?: readonly string[];
   agentAddress?: string;
   timestamp: Date;
   subGraphName?: string;
@@ -626,6 +628,15 @@ export function generateKnowledgeAssetShareMetadata(
   if (meta.publicTripleCount === 0 && privateTripleCount === 0) {
     throw new Error('Graph-scoped KA share cannot contain zero public and zero private triples');
   }
+  const rawAllowedPeers = meta.allowedPeers ?? [];
+  const allowedPeers = [...new Set(rawAllowedPeers.map((peer) => peer.trim()).filter(Boolean))];
+  if (
+    allowedPeers.length !== rawAllowedPeers.length
+    || (meta.accessPolicy === 'allowList' && allowedPeers.length === 0)
+    || (meta.accessPolicy !== 'allowList' && allowedPeers.length > 0)
+  ) {
+    throw new Error('Graph-scoped KA share has an invalid access-policy peer envelope');
+  }
   const subject = `urn:dkg:share:${meta.contextGraphId}:${meta.shareOperationId}`;
   const quads = [
     mq(subject, `${RDF}type`, `${DKG}WorkspaceOperation`, swmMetaGraph),
@@ -649,6 +660,12 @@ export function generateKnowledgeAssetShareMetadata(
     quads.push(
       mq(subject, `${DKG}privateMerkleRoot`, lit(`0x${toHex(privateMerkleRoot)}`), swmMetaGraph),
     );
+  }
+  if (meta.accessPolicy) {
+    quads.push(mq(subject, `${DKG}accessPolicy`, lit(meta.accessPolicy), swmMetaGraph));
+    for (const peer of allowedPeers) {
+      quads.push(mq(subject, `${DKG}allowedPeer`, lit(peer), swmMetaGraph));
+    }
   }
   if (meta.subGraphName) {
     quads.push(mq(subject, `${DKG}subGraphName`, lit(meta.subGraphName), swmMetaGraph));

--- a/packages/publisher/src/publish-handler.ts
+++ b/packages/publisher/src/publish-handler.ts
@@ -1,5 +1,5 @@
 import type { TripleStore, Quad } from '@origintrail-official/dkg-storage';
-import { GraphManager } from '@origintrail-official/dkg-storage';
+import { GraphManager, tryReplaceGraphAtomically } from '@origintrail-official/dkg-storage';
 import type { EventBus, StreamHandler, OperationContext } from '@origintrail-official/dkg-core';
 import {
   DKGEvent,
@@ -9,6 +9,11 @@ import {
   createOperationContext,
   assertSafeIri,
   assertNoUserAuthoredTrustLevelQuads,
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  MemoryLayer,
+  createGraphKnowledgeAssetScope,
+  knowledgeAssetLayerGraphUri,
+  validateSubGraphName,
   type PublishRequestMsg,
 } from '@origintrail-official/dkg-core';
 import type { ChainAdapter } from '@origintrail-official/dkg-chain';
@@ -19,6 +24,10 @@ import {
   generateTentativeMetadata,
   getTentativeStatusQuad,
   getConfirmedStatusQuad,
+  generateGraphKnowledgeAssetMetadata,
+  shouldApplyMaterialization,
+  withMaterializationLock,
+  writeMaterializedVersion,
   type KAMetadata,
 } from './metadata.js';
 import { insertBoundedAgentRegistryMeta } from './agent-registry-meta-retention.js';
@@ -39,6 +48,111 @@ interface PendingPublish {
   rootEntities: string[];
   createdAt: number;
   restoredFromJournal: boolean;
+  graphScoped?: {
+    assertionVersion: string;
+    vmGraph: string;
+    swmGraph: string;
+    subGraphName?: string;
+  };
+}
+
+interface GraphScopedPublishRequest {
+  scope: ReturnType<typeof createGraphKnowledgeAssetScope>;
+  publicTripleCount: number;
+  privateTripleCount: number;
+  privateMerkleRoot?: Uint8Array;
+  accessPolicy: 'public' | 'ownerOnly' | 'allowList';
+  allowedPeers: string[];
+  subGraphName?: string;
+}
+
+function resolveGraphScopedPublishRequest(
+  request: PublishRequestMsg,
+): GraphScopedPublishRequest | undefined {
+  const privateMerkleRoot = request.privateMerkleRoot?.length
+    ? new Uint8Array(request.privateMerkleRoot)
+    : undefined;
+  const hasGraphField =
+    (request.contentScopeVersion ?? 0) !== 0
+    || Boolean(request.assertionVersion)
+    || (request.publicTripleCount ?? 0) > 0
+    || privateMerkleRoot !== undefined
+    || (request.privateTripleCount ?? 0) > 0
+    || Boolean(request.accessPolicy)
+    || (request.allowedPeers?.length ?? 0) > 0;
+  if (!hasGraphField) return undefined;
+  if (request.contentScopeVersion !== GRAPH_KA_CONTENT_SCOPE_VERSION) {
+    throw new Error(
+      `Graph-scoped publish requires contentScopeVersion=${GRAPH_KA_CONTENT_SCOPE_VERSION}`,
+    );
+  }
+  if (!request.ual || !request.assertionVersion || request.kas.length !== 0) {
+    throw new Error('Graph-scoped publish requires a UAL, assertionVersion, and no legacy manifest');
+  }
+  const scope = createGraphKnowledgeAssetScope(request.ual, request.assertionVersion);
+  if (
+    scope.ual !== request.ual
+    || scope.assertionVersion !== '1'
+    || !request.chainId
+    || scope.chainId !== request.chainId
+  ) {
+    throw new Error('Graph-scoped publish has a non-canonical initial KA scope');
+  }
+  const kaNumber = BigInt(scope.kaNumber);
+  if (kaNumber >= (1n << 96n)) {
+    throw new Error('Graph-scoped publish KA number exceeds the 96-bit author namespace');
+  }
+  const packedKaId = (BigInt(scope.agentAddress) << 96n) | kaNumber;
+  const startKAId = protoToBigInt(request.startKAId);
+  const endKAId = protoToBigInt(request.endKAId);
+  if (startKAId !== packedKaId || endKAId !== packedKaId) {
+    throw new Error(
+      `Graph-scoped publish UAL-derived kaId ${packedKaId} does not match ` +
+        `published range ${startKAId}..${endKAId}`,
+    );
+  }
+  const publicTripleCount = request.publicTripleCount ?? 0;
+  const privateTripleCount = request.privateTripleCount ?? 0;
+  if (
+    !Number.isSafeInteger(publicTripleCount)
+    || publicTripleCount < 0
+    || !Number.isSafeInteger(privateTripleCount)
+    || privateTripleCount < 0
+    || (publicTripleCount === 0 && privateTripleCount === 0)
+    || (privateTripleCount > 0 && privateMerkleRoot?.length !== 32)
+    || (privateTripleCount === 0 && privateMerkleRoot !== undefined)
+  ) {
+    throw new Error('Graph-scoped publish has an invalid content envelope');
+  }
+  const accessPolicy = request.accessPolicy;
+  if (accessPolicy !== 'public' && accessPolicy !== 'ownerOnly' && accessPolicy !== 'allowList') {
+    throw new Error(`Graph-scoped publish has invalid accessPolicy: ${accessPolicy || '(empty)'}`);
+  }
+  const rawAllowedPeers = request.allowedPeers ?? [];
+  const allowedPeers = [...new Set(rawAllowedPeers.map((peer) => peer.trim()).filter(Boolean))];
+  if (
+    allowedPeers.length !== rawAllowedPeers.length
+    || (accessPolicy === 'allowList' && allowedPeers.length === 0)
+    || (accessPolicy !== 'allowList' && allowedPeers.length > 0)
+  ) {
+    throw new Error('Graph-scoped publish has an invalid access-policy peer envelope');
+  }
+  const subGraphName = request.subGraphName || undefined;
+  if (subGraphName) {
+    const validation = validateSubGraphName(subGraphName);
+    if (!validation.valid) {
+      throw new Error(`Graph-scoped publish has invalid subGraphName: ${validation.reason}`);
+    }
+  }
+  return {
+    scope,
+    publicTripleCount,
+    privateTripleCount,
+    ...(privateMerkleRoot ? { privateMerkleRoot } : {}),
+    accessPolicy,
+    allowedPeers,
+    ...(subGraphName ? { subGraphName } : {}),
+  };
 }
 
 /**
@@ -185,16 +299,33 @@ export class PublishHandler {
     this.log.info(opCtx, `Confirmed publish for ${ual}`);
     clearTimeout(pending.timeout);
 
-    // Promote in graph: remove tentative status, add confirmed (clean model: either tentative or confirmed, never both)
+    // Promote in graph: remove tentative status, add confirmed (clean model:
+    // either tentative or confirmed, never both). Rootless receivers share the
+    // same per-UAL lock as gossip/finalization so a same-version retry cannot
+    // race this transition and immediately downgrade the confirmed metadata.
     try {
-      await this.store.delete([getTentativeStatusQuad(ual, pending.contextGraphId)]);
-      await this.store.insert([getConfirmedStatusQuad(ual, pending.contextGraphId)]);
+      const promoteStatus = async () => {
+        await this.store.delete([getTentativeStatusQuad(ual, pending.contextGraphId)]);
+        await this.store.insert([getConfirmedStatusQuad(ual, pending.contextGraphId)]);
+      };
+      if (pending.graphScoped) {
+        await withMaterializationLock(
+          this.graphManager.metaGraphUri(pending.contextGraphId),
+          ual,
+          promoteStatus,
+        );
+      } else {
+        await promoteStatus();
+      }
     } catch (err) {
       this.log.error(opCtx, `Failed to promote tentative→confirmed in store: ${err instanceof Error ? err.message : String(err)}`);
     }
 
     // SWM cleanup (spec §9.0.5): delete published triples from _shared_memory
     try {
+      if (pending.graphScoped) {
+        await this.store.dropGraph(pending.graphScoped.swmGraph);
+      } else {
       const swmGraph = this.graphManager.sharedMemoryUri(pending.contextGraphId);
       const swmMetaGraph = this.graphManager.sharedMemoryMetaUri(pending.contextGraphId);
       // Uniform layout: span the per-KA …/_shared_memory/{addr}/{number} graphs + the bucket.
@@ -211,6 +342,7 @@ export class PublishHandler {
         await this.store.deleteByPattern({
           graph: swmMetaGraph, subject: rootEntity, predicate: 'http://dkg.io/ontology/workspaceOwner',
         });
+      }
       }
     } catch (swmErr) {
       this.log.warn(opCtx, `SWM cleanup after confirm failed: ${swmErr instanceof Error ? swmErr.message : String(swmErr)}`);
@@ -235,6 +367,10 @@ export class PublishHandler {
       const nquadsStr = new TextDecoder().decode(request.nquads);
       const quads = parseSimpleNQuads(nquadsStr);
       assertNoUserAuthoredTrustLevelQuads(quads);
+      const graphPublish = resolveGraphScopedPublishRequest(request);
+      if (graphPublish) {
+        return this.handleGraphScopedPublish(request, graphPublish, quads, fromPeerId, ctx);
+      }
 
       const manifest = request.kas.map((ka) => ({
         tokenId: protoToBigInt(ka.tokenId),
@@ -391,6 +527,191 @@ export class PublishHandler {
     }
   }
 
+  private async handleGraphScopedPublish(
+    request: PublishRequestMsg,
+    graphPublish: GraphScopedPublishRequest,
+    quads: Quad[],
+    fromPeerId: string,
+    ctx: OperationContext,
+  ): Promise<Uint8Array> {
+    if (graphPublish.subGraphName) {
+      await this.graphManager.ensureSubGraph(request.contextGraphId, graphPublish.subGraphName);
+    }
+    const vmGraph = knowledgeAssetLayerGraphUri(
+      request.contextGraphId,
+      MemoryLayer.VerifiableMemory,
+      graphPublish.scope,
+      graphPublish.subGraphName,
+    );
+    const swmGraph = knowledgeAssetLayerGraphUri(
+      request.contextGraphId,
+      MemoryLayer.SharedWorkingMemory,
+      graphPublish.scope,
+      graphPublish.subGraphName,
+    );
+    if (quads.some((quad) => quad.graph !== vmGraph)) {
+      return this.rejectAck(
+        `Graph-scoped publish payload must target only its UAL-derived VM graph ${vmGraph}`,
+      );
+    }
+    if (quads.length !== graphPublish.publicTripleCount) {
+      return this.rejectAck(
+        `Graph-scoped publish public triple count mismatch ` +
+          `(wire=${graphPublish.publicTripleCount}, parsed=${quads.length})`,
+      );
+    }
+    const normalized = quads.map((quad) => ({ ...quad, graph: vmGraph }));
+    const computedMerkleRoot = computeFlatKCRoot(
+      normalized,
+      graphPublish.privateMerkleRoot ? [graphPublish.privateMerkleRoot] : [],
+    );
+    const metadataQuads = generateGraphKnowledgeAssetMetadata(
+      {
+        ual: graphPublish.scope.ual,
+        contextGraphId: request.contextGraphId,
+        merkleRoot: computedMerkleRoot,
+        publisherPeerId: fromPeerId,
+        accessPolicy: graphPublish.accessPolicy,
+        ...(graphPublish.accessPolicy === 'allowList'
+          ? { allowedPeers: graphPublish.allowedPeers }
+          : {}),
+        timestamp: new Date(),
+        subGraphName: graphPublish.subGraphName,
+        authorAddress: graphPublish.scope.agentAddress,
+        assertionVersion: graphPublish.scope.assertionVersion,
+        publicTripleCount: graphPublish.publicTripleCount,
+        privateTripleCount: graphPublish.privateTripleCount,
+        ...(graphPublish.privateMerkleRoot
+          ? { privateMerkleRoot: graphPublish.privateMerkleRoot }
+          : {}),
+        assertionGraph: vmGraph,
+      },
+      'tentative',
+    );
+    const metaGraph = this.graphManager.metaGraphUri(request.contextGraphId);
+    const applyOutcome = await withMaterializationLock(
+      metaGraph,
+      graphPublish.scope.ual,
+      async () => {
+        if (await this.isPublishConfirmed(graphPublish.scope.ual, request.contextGraphId)) {
+          return 'confirmed' as const;
+        }
+        const existingPending = this.pendingPublishes.get(graphPublish.scope.ual);
+        if (existingPending) {
+          const exactReplay =
+            ethers.hexlify(existingPending.expectedMerkleRoot) === ethers.hexlify(computedMerkleRoot)
+            && existingPending.expectedPublisherAddress.toLowerCase()
+              === (request.publisherAddress ?? '').toLowerCase()
+            && existingPending.expectedStartKAId === protoToBigInt(request.startKAId)
+            && existingPending.expectedEndKAId === protoToBigInt(request.endKAId)
+            && existingPending.expectedChainId === request.chainId;
+          return exactReplay ? 'replay' as const : 'conflict' as const;
+        }
+        if (!(await shouldApplyMaterialization(
+          this.store,
+          metaGraph,
+          graphPublish.scope.ual,
+          { blockNumber: 0, txIndex: 0 },
+        ))) {
+          return 'stale' as const;
+        }
+        const replaced = await tryReplaceGraphAtomically(
+          this.store,
+          vmGraph,
+          normalized,
+          { source: 'publisher.publishHandler.graphScopedReplace' },
+        );
+        if (!replaced) {
+          throw Object.assign(
+            new Error('Graph-scoped publish requires atomic TripleStore.replaceGraph support'),
+            { code: 'VM_ATOMIC_REPLACE_UNSUPPORTED' },
+          );
+        }
+        await this.store.deleteByPattern({ graph: metaGraph, subject: graphPublish.scope.ual });
+        await this.store.insert(metadataQuads);
+        await writeMaterializedVersion(
+          this.store,
+          metaGraph,
+          graphPublish.scope.ual,
+          { blockNumber: 0, txIndex: 0 },
+        );
+        const timeout = setTimeout(
+          () => this.expireTentativePublish(
+            graphPublish.scope.ual,
+            request.contextGraphId,
+            normalized,
+            metadataQuads,
+          ),
+          PublishHandler.TENTATIVE_TIMEOUT_MS,
+        );
+        const startKAId = protoToBigInt(request.startKAId);
+        const endKAId = protoToBigInt(request.endKAId);
+        this.pendingPublishes.set(graphPublish.scope.ual, {
+          ual: graphPublish.scope.ual,
+          contextGraphId: request.contextGraphId,
+          dataQuads: normalized,
+          metadataQuads,
+          timeout,
+          expectedPublisherAddress: request.publisherAddress ?? '',
+          expectedMerkleRoot: computedMerkleRoot,
+          expectedStartKAId: startKAId,
+          expectedEndKAId: endKAId,
+          expectedChainId: request.chainId,
+          rootEntities: [],
+          createdAt: Date.now(),
+          restoredFromJournal: false,
+          graphScoped: {
+            assertionVersion: graphPublish.scope.assertionVersion,
+            vmGraph,
+            swmGraph,
+            subGraphName: graphPublish.subGraphName,
+          },
+        });
+        this.persistJournal();
+        return 'applied' as const;
+      },
+    );
+    if (applyOutcome === 'confirmed') {
+      return this.rejectAck(`Graph-scoped KA ${graphPublish.scope.ual} is already confirmed`);
+    }
+    if (applyOutcome === 'conflict') {
+      return this.rejectAck(
+        `Graph-scoped KA ${graphPublish.scope.ual} already has a conflicting tentative publish`,
+      );
+    }
+    if (applyOutcome === 'stale') {
+      return this.rejectAck(`A newer assertion is already materialized for ${graphPublish.scope.ual}`);
+    }
+    if (applyOutcome === 'applied') {
+      this.eventBus.emit(DKGEvent.KC_PUBLISHED, {
+        ual: graphPublish.scope.ual,
+        from: fromPeerId,
+        contextGraphId: request.contextGraphId,
+        subGraphName: graphPublish.subGraphName,
+        tripleCount: normalized.length,
+      });
+    }
+    const publicByteSize = request.nquads.length;
+    const { signatureR, signatureVs } = await this.signMerkleRootAndByteSize(
+      computedMerkleRoot,
+      publicByteSize,
+    );
+    this.log.info(
+      ctx,
+      `${applyOutcome === 'replay' ? 'Replayed' : 'Stored'} graph-scoped publish ` +
+        `${graphPublish.scope.ual} as tentative and sending ACK`,
+    );
+    return encodePublishAck({
+      merkleRoot: computedMerkleRoot,
+      identityId: this.nodeIdentityId ? Number(this.nodeIdentityId) : 0,
+      signatureR,
+      signatureVs,
+      accepted: true,
+      rejectionReason: '',
+      publicByteSize,
+    });
+  }
+
   /**
    * Sign (merkleRoot, publicByteSize) so the attested byte size is binding on-chain; token amount is enforced from it.
    * Must match contract: ECDSA.toEthSignedMessageHash(keccak256(abi.encodePacked(merkleRoot, publicByteSize))).
@@ -463,6 +784,13 @@ export class PublishHandler {
         expectedEndKAId: p.expectedEndKAId.toString(),
         expectedChainId: p.expectedChainId,
         rootEntities: p.rootEntities,
+        ...(p.graphScoped
+          ? {
+              contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+              assertionVersion: p.graphScoped.assertionVersion,
+              subGraphName: p.graphScoped.subGraphName,
+            }
+          : {}),
         createdAt: p.createdAt,
       });
     }
@@ -535,6 +863,30 @@ export class PublishHandler {
         rootEntities: entry.rootEntities ?? [],
         createdAt: entry.createdAt,
         restoredFromJournal: true,
+        ...(entry.contentScopeVersion === GRAPH_KA_CONTENT_SCOPE_VERSION
+          && entry.assertionVersion
+          ? (() => {
+              const scope = createGraphKnowledgeAssetScope(entry.ual, entry.assertionVersion!);
+              return {
+                graphScoped: {
+                  assertionVersion: scope.assertionVersion,
+                  vmGraph: knowledgeAssetLayerGraphUri(
+                    entry.contextGraphId,
+                    MemoryLayer.VerifiableMemory,
+                    scope,
+                    entry.subGraphName,
+                  ),
+                  swmGraph: knowledgeAssetLayerGraphUri(
+                    entry.contextGraphId,
+                    MemoryLayer.SharedWorkingMemory,
+                    scope,
+                    entry.subGraphName,
+                  ),
+                  subGraphName: entry.subGraphName,
+                },
+              };
+            })()
+          : {}),
       });
       restored++;
     }
@@ -561,11 +913,16 @@ export class PublishHandler {
           this.log.info(ctx, `Restored publish already confirmed, skipping cleanup: ${ual}`);
           return;
         }
-        const dataGraph = this.graphManager.dataGraphUri(pending.contextGraphId);
         const metaGraph = this.graphManager.metaGraphUri(pending.contextGraphId);
-        for (const rootEntity of pending.rootEntities) {
-          await this.store.deleteByPattern({ graph: dataGraph, subject: rootEntity });
-          await this.store.deleteBySubjectPrefix(dataGraph, rootEntity + '/.well-known/genid/');
+        if (pending.graphScoped) {
+          await this.store.dropGraph(pending.graphScoped.vmGraph);
+          await this.store.dropGraph(pending.graphScoped.swmGraph);
+        } else {
+          const dataGraph = this.graphManager.dataGraphUri(pending.contextGraphId);
+          for (const rootEntity of pending.rootEntities) {
+            await this.store.deleteByPattern({ graph: dataGraph, subject: rootEntity });
+            await this.store.deleteBySubjectPrefix(dataGraph, rootEntity + '/.well-known/genid/');
+          }
         }
         await this.store.deleteBySubjectPrefix(metaGraph, ual);
         await this.store.delete([getTentativeStatusQuad(ual, pending.contextGraphId)]);

--- a/packages/publisher/src/publish-handler.ts
+++ b/packages/publisher/src/publish-handler.ts
@@ -834,10 +834,48 @@ export class PublishHandler {
       let merkleRoot: Uint8Array;
       let startKAId: bigint;
       let endKAId: bigint;
+      let graphScoped: PendingPublish['graphScoped'];
       try {
         merkleRoot = ethers.getBytes(entry.expectedMerkleRoot);
         startKAId = BigInt(entry.expectedStartKAId);
         endKAId = BigInt(entry.expectedEndKAId);
+        const hasGraphFields = entry.contentScopeVersion !== undefined
+          || entry.assertionVersion !== undefined
+          || entry.subGraphName !== undefined;
+        if (hasGraphFields) {
+          if (
+            entry.contentScopeVersion !== GRAPH_KA_CONTENT_SCOPE_VERSION
+            || !entry.assertionVersion
+          ) {
+            throw new Error('Incomplete graph-scoped journal entry');
+          }
+          if (entry.subGraphName) {
+            const validation = validateSubGraphName(entry.subGraphName);
+            if (!validation.valid) {
+              throw new Error(`Invalid graph-scoped journal subGraphName: ${validation.reason}`);
+            }
+          }
+          const scope = createGraphKnowledgeAssetScope(entry.ual, entry.assertionVersion);
+          if (scope.ual !== entry.ual) {
+            throw new Error('Non-canonical graph-scoped journal UAL');
+          }
+          graphScoped = {
+            assertionVersion: scope.assertionVersion,
+            vmGraph: knowledgeAssetLayerGraphUri(
+              entry.contextGraphId,
+              MemoryLayer.VerifiableMemory,
+              scope,
+              entry.subGraphName,
+            ),
+            swmGraph: knowledgeAssetLayerGraphUri(
+              entry.contextGraphId,
+              MemoryLayer.SharedWorkingMemory,
+              scope,
+              entry.subGraphName,
+            ),
+            subGraphName: entry.subGraphName,
+          };
+        }
       } catch (parseErr) {
         this.log.warn(ctx, `Skipping malformed journal entry ${entry.ual}: ${parseErr instanceof Error ? parseErr.message : String(parseErr)}`);
         skippedInvalid++;
@@ -863,30 +901,7 @@ export class PublishHandler {
         rootEntities: entry.rootEntities ?? [],
         createdAt: entry.createdAt,
         restoredFromJournal: true,
-        ...(entry.contentScopeVersion === GRAPH_KA_CONTENT_SCOPE_VERSION
-          && entry.assertionVersion
-          ? (() => {
-              const scope = createGraphKnowledgeAssetScope(entry.ual, entry.assertionVersion!);
-              return {
-                graphScoped: {
-                  assertionVersion: scope.assertionVersion,
-                  vmGraph: knowledgeAssetLayerGraphUri(
-                    entry.contextGraphId,
-                    MemoryLayer.VerifiableMemory,
-                    scope,
-                    entry.subGraphName,
-                  ),
-                  swmGraph: knowledgeAssetLayerGraphUri(
-                    entry.contextGraphId,
-                    MemoryLayer.SharedWorkingMemory,
-                    scope,
-                    entry.subGraphName,
-                  ),
-                  subGraphName: entry.subGraphName,
-                },
-              };
-            })()
-          : {}),
+        ...(graphScoped ? { graphScoped } : {}),
       });
       restored++;
     }

--- a/packages/publisher/src/publish-journal.ts
+++ b/packages/publisher/src/publish-journal.ts
@@ -15,6 +15,10 @@ export interface JournalEntry {
   expectedChainId: string;
   /** Root entity IRIs from the KA manifest, used for cleanup on expiry */
   rootEntities?: string[];
+  /** Complete V2 graph scope for rootless tentative cleanup after restart. */
+  contentScopeVersion?: number;
+  assertionVersion?: string;
+  subGraphName?: string;
   createdAt: number;
 }
 

--- a/packages/publisher/src/publisher.ts
+++ b/packages/publisher/src/publisher.ts
@@ -88,6 +88,15 @@ export interface V10ACKProviderBaseParams {
   merkleLeafCount: number;
   /** Canonical KA UAL used by receiver-side lifecycle logs. */
   assetUal?: string;
+  /** Complete rootless-KA content envelope; omitted together for legacy ACKs. */
+  contentScopeVersion?: number;
+  kaUal?: string;
+  assertionVersion?: string;
+  publicTripleCount?: number;
+  privateMerkleRoot?: Uint8Array;
+  privateTripleCount?: number;
+  accessPolicy?: 'public' | 'ownerOnly' | 'allowList';
+  allowedPeers?: string[];
 }
 
 export type V10ACKProviderParams =
@@ -457,6 +466,15 @@ export interface PublishResult {
   v10Origin?: boolean;
   /** Sub-graph the data was published into (for gossip propagation). */
   subGraphName?: string;
+  /** Complete rootless-KA content envelope; omitted together for legacy results. */
+  contentScopeVersion?: number;
+  assertionVersion?: string;
+  publicTripleCount?: number;
+  privateMerkleRoot?: Uint8Array;
+  privateTripleCount?: number;
+  /** Effective access envelope persisted for graph-scoped KAs. */
+  accessPolicy?: 'public' | 'ownerOnly' | 'allowList';
+  allowedPeers?: string[];
 }
 
 export interface Publisher {

--- a/packages/publisher/src/storage-ack-handler.ts
+++ b/packages/publisher/src/storage-ack-handler.ts
@@ -1,5 +1,7 @@
 import {
+  GraphManager,
   loadSelectedSharedMemoryQuads,
+  tryReplaceGraphAtomically,
   type SharedMemoryReadSelection,
   type TripleStore,
   type Quad,
@@ -48,9 +50,93 @@ import {
 } from './merkle.js';
 import { parseSimpleNQuads } from './publish-handler.js';
 import { replaceCatalogQuads } from './catalog-persistence.js';
+import { generateKnowledgeAssetShareMetadata } from './metadata.js';
+import { storeKnowledgeAssetWorkspaceHead } from './workspace-resolution.js';
+import { workspacePublicQuadsDigest } from './workspace-snapshot-store.js';
 import { ethers } from 'ethers';
 
 type PeerId = { toString(): string };
+
+type GraphScopedPublishIntent = {
+  scope: ReturnType<typeof createGraphKnowledgeAssetScope>;
+  publicTripleCount: number;
+  privateTripleCount: number;
+  privateMerkleRoot?: Uint8Array;
+  accessPolicy: 'public' | 'ownerOnly' | 'allowList';
+  allowedPeers: string[];
+  subGraphName?: string;
+};
+
+function resolveGraphScopedPublishIntent(
+  intent: PublishIntentMsg,
+): GraphScopedPublishIntent | undefined {
+  const privateMerkleRoot = intent.privateMerkleRoot?.length
+    ? new Uint8Array(intent.privateMerkleRoot)
+    : undefined;
+  const hasGraphField =
+    (intent.contentScopeVersion ?? 0) !== 0
+    || Boolean(intent.kaUal)
+    || Boolean(intent.assertionVersion)
+    || (intent.publicTripleCount ?? 0) > 0
+    || privateMerkleRoot !== undefined
+    || (intent.privateTripleCount ?? 0) > 0;
+  if (!hasGraphField) return undefined;
+  if (intent.contentScopeVersion !== GRAPH_KA_CONTENT_SCOPE_VERSION) {
+    throw new Error(
+      `StorageACK: graph-scoped publish requires contentScopeVersion=${GRAPH_KA_CONTENT_SCOPE_VERSION}`,
+    );
+  }
+  if (!intent.kaUal || !intent.assertionVersion) {
+    throw new Error('StorageACK: graph-scoped publish requires kaUal and assertionVersion');
+  }
+  if ((intent.rootEntities?.length ?? 0) !== 0 || (intent.privateMerkleRoots?.length ?? 0) !== 0) {
+    throw new Error('StorageACK: graph-scoped publish must not carry legacy root commitments');
+  }
+  const publicTripleCount = intent.publicTripleCount ?? 0;
+  const privateTripleCount = intent.privateTripleCount ?? 0;
+  if (
+    !Number.isSafeInteger(publicTripleCount)
+    || publicTripleCount < 0
+    || !Number.isSafeInteger(privateTripleCount)
+    || privateTripleCount < 0
+    || (publicTripleCount === 0 && privateTripleCount === 0)
+    || (privateTripleCount > 0 && privateMerkleRoot?.length !== 32)
+    || (privateTripleCount === 0 && privateMerkleRoot !== undefined)
+  ) {
+    throw new Error('StorageACK: graph-scoped publish has an invalid content envelope');
+  }
+  const scope = createGraphKnowledgeAssetScope(intent.kaUal, intent.assertionVersion);
+  if (scope.ual !== intent.kaUal || scope.assertionVersion !== '1') {
+    throw new Error('StorageACK: graph-scoped publish requires a canonical version-1 UAL');
+  }
+  const accessPolicy = intent.accessPolicy;
+  const rawAllowedPeers = intent.allowedPeers ?? [];
+  const allowedPeers = [...new Set(rawAllowedPeers.map((peer) => peer.trim()).filter(Boolean))];
+  if (
+    (accessPolicy !== 'public' && accessPolicy !== 'ownerOnly' && accessPolicy !== 'allowList')
+    || allowedPeers.length !== rawAllowedPeers.length
+    || (accessPolicy === 'allowList' && allowedPeers.length === 0)
+    || (accessPolicy !== 'allowList' && allowedPeers.length > 0)
+  ) {
+    throw new Error('StorageACK: graph-scoped publish has an invalid access envelope');
+  }
+  const subGraphName = intent.subGraphName || undefined;
+  if (subGraphName) {
+    const validation = validateSubGraphName(subGraphName);
+    if (!validation.valid) {
+      throw new Error(`StorageACK: invalid graph-scoped subGraphName: ${validation.reason}`);
+    }
+  }
+  return {
+    scope,
+    publicTripleCount,
+    privateTripleCount,
+    ...(privateMerkleRoot ? { privateMerkleRoot } : {}),
+    accessPolicy,
+    allowedPeers,
+    ...(subGraphName ? { subGraphName } : {}),
+  };
+}
 
 type GraphScopedUpdateIntent = {
   scope: ReturnType<typeof createGraphKnowledgeAssetScope>;
@@ -534,12 +620,14 @@ export const DEFAULT_ACK_HANDLER_DEADLINE_MS =
  */
 export class StorageACKHandler {
   private store: TripleStore;
+  private readonly graphManager: GraphManager;
   private config: StorageACKHandlerConfig;
   private eventBus: EventBus;
   private readonly log = new Logger('StorageACKHandler');
 
   constructor(store: TripleStore, config: StorageACKHandlerConfig, eventBus: EventBus) {
     this.store = store;
+    this.graphManager = new GraphManager(store);
     this.config = config;
     this.eventBus = eventBus;
   }
@@ -757,6 +845,107 @@ export class StorageACKHandler {
   }
 
   /**
+   * Persist a verified rootless assertion as one exact SWM graph plus the
+   * constant-size workspace head needed by finalization and chain reconcile.
+   *
+   * StorageACK durability is not satisfied by the data graph alone: without
+   * the head, a core that does not subscribe to the CG's live publish topic
+   * cannot bind those triples back to the UAL after the chain event lands.
+   * The operation id is content-derived, so ACK retries replace the same
+   * metadata rows instead of growing one record per attempt.
+   */
+  private async persistGraphScopedWorkspaceOrDecline(
+    cgId: string,
+    swmGraphId: string,
+    swmGraphUri: string,
+    graphPublish: GraphScopedPublishIntent,
+    parsed: Quad[],
+    publisherPeerId: string,
+    merkleRoot: Uint8Array,
+    replaceGraph: boolean,
+    signal?: AbortSignal,
+  ): Promise<{ ok: true } | { ok: false; decline: Uint8Array }> {
+    assertPersistQuadTermsSafe(parsed);
+    const normalized = parsed.map((quad) => ({ ...quad, graph: swmGraphUri }));
+    const operationId = `storage-ack-${ethers.hexlify(merkleRoot).slice(2)}`;
+    const metaGraph = this.graphManager.sharedMemoryMetaUri(
+      swmGraphId,
+      graphPublish.subGraphName,
+    );
+    const publicDigest = workspacePublicQuadsDigest(
+      normalized.map((quad) => ({ ...quad, graph: '' })),
+    );
+    const metadata = generateKnowledgeAssetShareMetadata(
+      {
+        shareOperationId: operationId,
+        contextGraphId: swmGraphId,
+        kaUal: graphPublish.scope.ual,
+        assertionVersion: graphPublish.scope.assertionVersion,
+        publicTripleCount: normalized.length,
+        ...(graphPublish.privateMerkleRoot
+          ? { privateMerkleRoot: graphPublish.privateMerkleRoot }
+          : {}),
+        privateTripleCount: graphPublish.privateTripleCount,
+        publisherPeerId: publisherPeerId.trim() || 'unknown',
+        accessPolicy: graphPublish.accessPolicy,
+        allowedPeers: graphPublish.allowedPeers,
+        agentAddress: graphPublish.scope.agentAddress,
+        subGraphName: graphPublish.subGraphName,
+        timestamp: new Date(),
+      },
+      metaGraph,
+    );
+    const operationSubject = metadata[0]?.subject;
+    if (!operationSubject) {
+      throw new Error('StorageACK: graph-scoped workspace metadata is empty');
+    }
+    metadata.push({
+      subject: operationSubject,
+      predicate: 'http://dkg.io/ontology/publicQuadsDigest',
+      object: `"${publicDigest}"`,
+      graph: metaGraph,
+    });
+
+    const result = await this.runStoreOpOrDecline(cgId, async () => {
+      if (replaceGraph) {
+        const replaced = await tryReplaceGraphAtomically(
+          this.store,
+          swmGraphUri,
+          normalized,
+          ackStoreOptions('storage-ack.persistGraphScoped.replaceGraph', signal),
+        );
+        if (!replaced) {
+          throw Object.assign(
+            new Error('Graph-scoped StorageACK requires atomic TripleStore.replaceGraph support'),
+            { code: 'SWM_ATOMIC_REPLACE_UNSUPPORTED' },
+          );
+        }
+      }
+      await this.store.deleteByPattern(
+        { graph: metaGraph, subject: operationSubject },
+        ackStoreOptions('storage-ack.persistGraphScoped.deleteOperationMeta', signal),
+      );
+      await this.store.insert(
+        metadata,
+        ackStoreOptions('storage-ack.persistGraphScoped.insertOperationMeta', signal),
+      );
+      await storeKnowledgeAssetWorkspaceHead({
+        store: this.store,
+        graphManager: this.graphManager,
+        contextGraphId: swmGraphId,
+        kaUal: graphPublish.scope.ual,
+        assertionVersion: graphPublish.scope.assertionVersion,
+        shareOperationId: operationId,
+        subGraphName: graphPublish.subGraphName,
+      });
+      await this.store.flush?.(
+        ackStoreOptions('storage-ack.persistGraphScoped.flush', signal),
+      );
+    }, signal);
+    return result.ok ? { ok: true } : result;
+  }
+
+  /**
    * Load SWM quads for the recompute, translating a store outage into the
    * transient decline. `loadSWMQuads` tags ONLY the storage loader's store/index
    * throws as `StoreUnavailableError`; its `assertSafeIri` guards throw
@@ -950,7 +1139,7 @@ export class StorageACKHandler {
    */
   private handlePublishIntent = async (
     data: Uint8Array,
-    _peerId: PeerId,
+    peerId: PeerId,
     signal?: AbortSignal,
   ): Promise<Uint8Array> => {
     if (this.config.nodeRole !== 'core') {
@@ -958,6 +1147,7 @@ export class StorageACKHandler {
     }
 
     const intent = decodePublishIntent(data);
+    const graphPublish = resolveGraphScopedPublishIntent(intent);
     // `cgId` is the TARGET on-chain numeric id used by the ACK digest and
     // the publishDirect tx. `swmGraphId` (optional, from the remap flow)
     // is the SOURCE graph where data lives in SWM. When absent, fall back
@@ -966,9 +1156,11 @@ export class StorageACKHandler {
     const swmGraphId = intent.swmGraphId && intent.swmGraphId.length > 0
       ? intent.swmGraphId
       : cgId;
-    const subGraphName = intent.subGraphName && intent.subGraphName.length > 0
-      ? intent.subGraphName
-      : undefined;
+    const subGraphName = graphPublish?.subGraphName ?? (
+      intent.subGraphName && intent.subGraphName.length > 0
+        ? intent.subGraphName
+        : undefined
+    );
     const merkleRoot = intent.merkleRoot instanceof Uint8Array
       ? intent.merkleRoot
       : new Uint8Array(intent.merkleRoot);
@@ -980,7 +1172,17 @@ export class StorageACKHandler {
       );
     }
 
-    const swmGraphUri = this.config.contextGraphSharedMemoryUri(swmGraphId, subGraphName);
+    const contentPrivateRoots = graphPublish?.privateMerkleRoot
+      ? [graphPublish.privateMerkleRoot]
+      : privateMerkleRoots;
+    const swmGraphUri = graphPublish
+      ? knowledgeAssetLayerGraphUri(
+          swmGraphId,
+          MemoryLayer.SharedWorkingMemory,
+          graphPublish.scope,
+          subGraphName,
+        )
+      : this.config.contextGraphSharedMemoryUri(swmGraphId, subGraphName);
 
     let swmQuads: Quad[];
 
@@ -1127,6 +1329,14 @@ export class StorageACKHandler {
           `curated PublishIntent.merkleLeafCount must be a non-negative integer; got ${claimedLeafCount}`,
         );
       }
+      if (graphPublish && claimedLeafCount === 0 && graphPublish.publicTripleCount !== 0) {
+        return this.encodeDecline(
+          cgId,
+          STORAGE_ACK_DECLINE_CODES.MERKLE_MISMATCH_IN_SWM,
+          `curated graph-scoped PublishIntent claims zero Merkle leaves for ` +
+            `${graphPublish.publicTripleCount} public triples`,
+        );
+      }
 
       const intentEpochs = (typeof intent.epochs === 'number' && intent.epochs > 0) ? intent.epochs : 1;
       const intentTokenAmount = intent.tokenAmountStr ? BigInt(intent.tokenAmountStr) : 0n;
@@ -1248,7 +1458,13 @@ export class StorageACKHandler {
         }
       }
 
-      const inMemoryRoot = computeFlatKCRoot(parsed, privateMerkleRoots);
+      if (graphPublish && parsed.length !== graphPublish.publicTripleCount) {
+        throw new Error(
+          `StorageACK: graph-scoped public triple count mismatch ` +
+            `(intent=${graphPublish.publicTripleCount}, inline=${parsed.length})`,
+        );
+      }
+      const inMemoryRoot = computeFlatKCRoot(parsed, contentPrivateRoots);
       if (!bytesEqual(inMemoryRoot, merkleRoot)) {
         throw new Error(
           `Merkle root mismatch (inline quads): publisher=${ethers.hexlify(merkleRoot).slice(0, 18)}..., ` +
@@ -1265,16 +1481,32 @@ export class StorageACKHandler {
       // transient decline instead of resetting the stream — the durability
       // invariant is why we CANNOT sign anyway, so the publisher re-sends
       // once the store worker is back rather than bucketing us as no_response.
-      const stagingGraphUri = `${swmGraphUri}/staging/${ethers.hexlify(merkleRoot).slice(2, 18)}`;
-      const persistedStaging = await this.persistStagingOrDecline(cgId, stagingGraphUri, parsed, signal);
+      const stagingGraphUri = graphPublish
+        ? swmGraphUri
+        : `${swmGraphUri}/staging/${ethers.hexlify(merkleRoot).slice(2, 18)}`;
+      const persistedStaging = graphPublish
+        ? await this.persistGraphScopedWorkspaceOrDecline(
+            cgId,
+            swmGraphId,
+            swmGraphUri,
+            graphPublish,
+            parsed,
+            peerId.toString(),
+            merkleRoot,
+            true,
+            signal,
+          )
+        : await this.persistStagingOrDecline(cgId, stagingGraphUri, parsed, signal);
       if (!persistedStaging.ok) return persistedStaging.decline;
       swmQuads = parsed;
 
       // Schedule cleanup: remove staging graph after 10 minutes.
       // Finalization may promote data to LTM before this fires.
-      setTimeout(async () => {
-        try { await this.store.dropGraph(stagingGraphUri); } catch { /* ignore */ }
-      }, 10 * 60 * 1000);
+      if (!graphPublish) {
+        setTimeout(async () => {
+          try { await this.store.dropGraph(stagingGraphUri); } catch { /* ignore */ }
+        }, 10 * 60 * 1000);
+      }
     } else {
       // Fallback: data should already be in SWM (publishFromSharedMemory path).
       // Both the "no data" and "data but wrong merkle root" cases below are
@@ -1289,11 +1521,20 @@ export class StorageACKHandler {
       // the handler and reset the stream. `loadSWMOrDecline` translates a
       // store-op failure (and ONLY that — assertSafeIri malformed-request
       // throws still propagate + reset) into the transient decline.
-      const loadedSWM = await this.loadSWMOrDecline(cgId, swmGraphUri, intent.rootEntities, signal);
-      if (!loadedSWM.ok) return loadedSWM.decline;
-      swmQuads = loadedSWM.quads;
+      if (graphPublish?.publicTripleCount === 0) {
+        swmQuads = [];
+      } else {
+        const loadedSWM = await this.loadSWMOrDecline(
+          cgId,
+          swmGraphUri,
+          graphPublish ? [] : intent.rootEntities,
+          signal,
+        );
+        if (!loadedSWM.ok) return loadedSWM.decline;
+        swmQuads = loadedSWM.quads;
+      }
 
-      if (swmQuads.length === 0) {
+      if (swmQuads.length === 0 && !graphPublish) {
         return this.encodeDecline(
           cgId,
           STORAGE_ACK_DECLINE_CODES.NO_DATA_IN_SWM,
@@ -1302,7 +1543,15 @@ export class StorageACKHandler {
         );
       }
 
-      const recomputedRoot = computeFlatKCRoot(swmQuads, privateMerkleRoots);
+      if (graphPublish && swmQuads.length !== graphPublish.publicTripleCount) {
+        return this.encodeDecline(
+          cgId,
+          STORAGE_ACK_DECLINE_CODES.MERKLE_MISMATCH_IN_SWM,
+          `StorageACK: graph-scoped public triple count mismatch ` +
+            `(intent=${graphPublish.publicTripleCount}, local=${swmQuads.length})`,
+        );
+      }
+      const recomputedRoot = computeFlatKCRoot(swmQuads, contentPrivateRoots);
       if (!bytesEqual(recomputedRoot, merkleRoot)) {
         return this.encodeDecline(
           cgId,
@@ -1311,6 +1560,20 @@ export class StorageACKHandler {
           `local=${ethers.hexlify(recomputedRoot).slice(0, 18)}... ` +
           `(${swmQuads.length} triples in SWM)`,
         );
+      }
+      if (graphPublish) {
+        const persistedWorkspace = await this.persistGraphScopedWorkspaceOrDecline(
+          cgId,
+          swmGraphId,
+          swmGraphUri,
+          graphPublish,
+          swmQuads,
+          peerId.toString(),
+          merkleRoot,
+          false,
+          signal,
+        );
+        if (!persistedWorkspace.ok) return persistedWorkspace.decline;
       }
     }
 
@@ -1418,8 +1681,8 @@ export class StorageACKHandler {
       ? BigInt(intent.tokenAmountStr)
       : 0n;
 
-    const verifiedLeafCount = computeFlatKCMerkleLeafCountV10(swmQuads, privateMerkleRoots);
-    if (verifiedLeafCount === 0) {
+    const verifiedLeafCount = computeFlatKCMerkleLeafCountV10(swmQuads, contentPrivateRoots);
+    if (verifiedLeafCount === 0 && !graphPublish?.privateMerkleRoot) {
       throw new Error(
         'StorageACK: empty Knowledge Asset payload (zero V10 Merkle leaves after sort+dedupe) — refusing ACK',
       );

--- a/packages/publisher/src/storage-ack-handler.ts
+++ b/packages/publisher/src/storage-ack-handler.ts
@@ -851,8 +851,8 @@ export class StorageACKHandler {
    * StorageACK durability is not satisfied by the data graph alone: without
    * the head, a core that does not subscribe to the CG's live publish topic
    * cannot bind those triples back to the UAL after the chain event lands.
-   * The operation id is content-derived, so ACK retries replace the same
-   * metadata rows instead of growing one record per attempt.
+   * The operation id binds asset identity, version, and content, so ACK retries
+   * replace the same metadata rows without aliasing identical-content KAs.
    */
   private async persistGraphScopedWorkspaceOrDecline(
     cgId: string,
@@ -867,7 +867,11 @@ export class StorageACKHandler {
   ): Promise<{ ok: true } | { ok: false; decline: Uint8Array }> {
     assertPersistQuadTermsSafe(parsed);
     const normalized = parsed.map((quad) => ({ ...quad, graph: swmGraphUri }));
-    const operationId = `storage-ack-${ethers.hexlify(merkleRoot).slice(2)}`;
+    const operationId = `storage-ack-${ethers.keccak256(ethers.toUtf8Bytes([
+      graphPublish.scope.ual,
+      graphPublish.scope.assertionVersion,
+      ethers.hexlify(merkleRoot),
+    ].join('\0'))).slice(2)}`;
     const metaGraph = this.graphManager.sharedMemoryMetaUri(
       swmGraphId,
       graphPublish.subGraphName,

--- a/packages/publisher/src/workspace-resolution.ts
+++ b/packages/publisher/src/workspace-resolution.ts
@@ -66,6 +66,8 @@ export interface KnowledgeAssetWorkspaceHead {
   readonly shareOperationId: string;
   /** Transport owner retained at KA granularity; replaces per-subject ownership rows. */
   readonly publisherPeerId: string;
+  readonly accessPolicy?: 'public' | 'ownerOnly' | 'allowList';
+  readonly allowedPeers: string[];
 }
 
 /**
@@ -88,7 +90,7 @@ export async function resolveKnowledgeAssetWorkspaceHead(params: {
   );
   const subject = workspaceKnowledgeAssetHeadSubject(scope.ual);
   const result = await params.store.query(
-    `SELECT ?scopeVersion ?kaUal ?assertionVersion ?assertionGraph ?shareOperationId ?operation ?operationUal ?operationVersion ?digest ?publicCount ?privateRoot ?privateCount ?publisherPeerId WHERE {
+    `SELECT ?scopeVersion ?kaUal ?assertionVersion ?assertionGraph ?shareOperationId ?operation ?operationUal ?operationVersion ?digest ?publicCount ?privateRoot ?privateCount ?publisherPeerId ?accessPolicy WHERE {
       GRAPH <${assertSafeIri(metaGraph)}> {
         <${assertSafeIri(subject)}> <${DKG}contentScopeVersion> ?scopeVersion ;
           <${DKG}kaUal> ?kaUal ;
@@ -103,6 +105,7 @@ export async function resolveKnowledgeAssetWorkspaceHead(params: {
           <${DKG}privateTripleCount> ?privateCount ;
           <${DKG}publisherPeerId> ?publisherPeerId .
         OPTIONAL { ?operation <${DKG}privateMerkleRoot> ?privateRoot }
+        OPTIONAL { ?operation <${DKG}accessPolicy> ?accessPolicy }
       }
     } LIMIT 1`,
   );
@@ -134,6 +137,12 @@ export async function resolveKnowledgeAssetWorkspaceHead(params: {
   const privateMerkleRoot = stripLiteral(row?.['privateRoot'])?.trim();
   const shareOperationId = stripLiteral(row?.['shareOperationId'])?.trim() ?? '';
   const publisherPeerId = stripLiteral(row?.['publisherPeerId'])?.trim() ?? '';
+  const rawAccessPolicy = stripLiteral(row?.['accessPolicy'])?.trim();
+  const accessPolicy = rawAccessPolicy === 'public'
+    || rawAccessPolicy === 'ownerOnly'
+    || rawAccessPolicy === 'allowList'
+    ? rawAccessPolicy
+    : undefined;
   const expectedOperationSubject = shareOperationId
     ? workspaceOperationSubject(params.contextGraphId, shareOperationId)
     : '';
@@ -150,8 +159,24 @@ export async function resolveKnowledgeAssetWorkspaceHead(params: {
     operationVersion.toString() !== actualScope.assertionVersion ||
     (privateTripleCount > 0 && !/^0x[0-9a-f]{64}$/i.test(privateMerkleRoot ?? '')) ||
     (privateTripleCount === 0 && privateMerkleRoot !== undefined)
+    || (rawAccessPolicy !== undefined && accessPolicy === undefined)
   ) {
     throw new Error(`Corrupt graph-scoped SWM head for ${scope.ual}: incomplete commitment metadata`);
+  }
+  const peersResult = await params.store.query(
+    `SELECT ?peer WHERE { GRAPH <${assertSafeIri(metaGraph)}> { ` +
+      `<${assertSafeIri(expectedOperationSubject)}> <${DKG}allowedPeer> ?peer } }`,
+  );
+  const allowedPeers = peersResult.type === 'bindings'
+    ? [...new Set(peersResult.bindings
+        .map((binding) => stripLiteral(binding['peer'])?.trim())
+        .filter((peer): peer is string => Boolean(peer)))]
+    : [];
+  if (
+    (accessPolicy === 'allowList' && allowedPeers.length === 0)
+    || (accessPolicy !== 'allowList' && allowedPeers.length > 0)
+  ) {
+    throw new Error(`Corrupt graph-scoped SWM head for ${scope.ual}: invalid access envelope`);
   }
   return {
     kaUal: actualScope.ual,
@@ -163,6 +188,8 @@ export async function resolveKnowledgeAssetWorkspaceHead(params: {
     privateTripleCount,
     shareOperationId,
     publisherPeerId,
+    ...(accessPolicy ? { accessPolicy } : {}),
+    allowedPeers,
   };
 }
 
@@ -352,6 +379,8 @@ export async function storeKnowledgeAssetOperationPublicQuads(params: {
   privateMerkleRoot?: Uint8Array;
   privateTripleCount?: number;
   publisherPeerId?: string;
+  accessPolicy?: 'public' | 'ownerOnly' | 'allowList';
+  allowedPeers?: readonly string[];
   agentAddress?: string;
   subGraphName?: string;
   timestamp?: Date;
@@ -400,6 +429,8 @@ export async function storeKnowledgeAssetOperationPublicQuads(params: {
       privateMerkleRoot: params.privateMerkleRoot,
       privateTripleCount: params.privateTripleCount,
       publisherPeerId,
+      accessPolicy: params.accessPolicy,
+      allowedPeers: params.allowedPeers,
       agentAddress: params.agentAddress?.trim() || undefined,
       timestamp,
       subGraphName,

--- a/packages/publisher/test/access-verification.test.ts
+++ b/packages/publisher/test/access-verification.test.ts
@@ -18,9 +18,12 @@ import {
   decodeAccessRequest,
   decodeAccessResponse,
   createGraphKnowledgeAssetScope,
+  knowledgeAssetLayerGraphUri,
+  MemoryLayer,
 } from '@origintrail-official/dkg-core';
 import { OxigraphStore, GraphManager, PrivateContentStore, type Quad } from '@origintrail-official/dkg-storage';
 import { AccessHandler } from '../src/access-handler.js';
+import { generateGraphKnowledgeAssetMetadata } from '../src/metadata.js';
 import { computePrivateRootV10 } from '../src/merkle.js';
 import {
   storeKnowledgeAssetOperationPublicQuads,
@@ -400,6 +403,79 @@ describe('graph-scoped private access', () => {
     expect(response.granted).toBe(true);
     expect(new TextDecoder().decode(response.nquads)).toContain('exact-version-secret');
     expect(toHex(response.privateMerkleRoot)).toBe(toHex(privateMerkleRoot));
+  });
+
+  it('serves a direct confirmed allow-list publish without a StorageACK workspace head', async () => {
+    const store = new OxigraphStore();
+    const graphManager = new GraphManager(store);
+    const privateStore = new PrivateContentStore(store, graphManager);
+    const ual = 'did:dkg:mock:31337/0x2222222222222222222222222222222222222222/10';
+    const scope = createGraphKnowledgeAssetScope(ual, 1);
+    const privateQuads: Quad[] = [{
+      subject: 'urn:direct:private',
+      predicate: 'urn:p:secret',
+      object: '"direct-only-secret"',
+      graph: '',
+    }];
+    const privateMerkleRoot = computePrivateRootV10(privateQuads)!;
+    await privateStore.replaceKnowledgeAssetPrivateTriples(
+      CONTEXT_GRAPH,
+      scope,
+      privateQuads,
+    );
+    await store.insert(generateGraphKnowledgeAssetMetadata({
+      ual,
+      contextGraphId: CONTEXT_GRAPH,
+      merkleRoot: privateMerkleRoot,
+      publisherPeerId: 'owner-peer',
+      accessPolicy: 'allowList',
+      allowedPeers: ['reader-peer'],
+      timestamp: new Date(0),
+      assertionVersion: scope.assertionVersion,
+      publicTripleCount: 0,
+      privateTripleCount: privateQuads.length,
+      privateMerkleRoot,
+      assertionGraph: knowledgeAssetLayerGraphUri(
+        CONTEXT_GRAPH,
+        MemoryLayer.VerifiableMemory,
+        scope,
+      ),
+    }, 'confirmed', {
+      txHash: `0x${'11'.repeat(32)}`,
+      blockNumber: 1,
+      blockTimestamp: 1,
+      publisherAddress: '0x2222222222222222222222222222222222222222',
+      batchId: 10n,
+      chainId: 'mock:31337',
+    }));
+
+    const handler = new AccessHandler(store, new TypedEventBus());
+    const denied = decodeAccessResponse(await handler.handler(encodeAccessRequest({
+      kaUal: ual,
+      requesterPeerId: 'intruder-peer',
+      paymentProof: new Uint8Array(0),
+      requesterSignature: new Uint8Array(0),
+    }), 'intruder-peer' as any));
+    expect(denied.granted).toBe(false);
+    expect(denied.rejectionReason).toContain('not on allow list');
+
+    const keypair = await generateEd25519Keypair();
+    const paymentProof = new Uint8Array(0);
+    const signature = await ed25519Sign(
+      new TextEncoder().encode(ual + toHex(paymentProof)),
+      keypair.secretKey,
+    );
+    const granted = decodeAccessResponse(await handler.handler(encodeAccessRequest({
+      kaUal: ual,
+      requesterPeerId: 'reader-peer',
+      paymentProof,
+      requesterSignature: signature,
+      requesterPublicKey: keypair.publicKey,
+    }), 'reader-peer' as any));
+
+    expect(granted.granted).toBe(true);
+    expect(new TextDecoder().decode(granted.nquads)).toContain('direct-only-secret');
+    expect(toHex(granted.privateMerkleRoot)).toBe(toHex(privateMerkleRoot));
   });
 });
 

--- a/packages/publisher/test/access-verification.test.ts
+++ b/packages/publisher/test/access-verification.test.ts
@@ -17,9 +17,15 @@ import {
   encodeAccessRequest,
   decodeAccessRequest,
   decodeAccessResponse,
+  createGraphKnowledgeAssetScope,
 } from '@origintrail-official/dkg-core';
-import { OxigraphStore, GraphManager, type Quad } from '@origintrail-official/dkg-storage';
+import { OxigraphStore, GraphManager, PrivateContentStore, type Quad } from '@origintrail-official/dkg-storage';
 import { AccessHandler } from '../src/access-handler.js';
+import { computePrivateRootV10 } from '../src/merkle.js';
+import {
+  storeKnowledgeAssetOperationPublicQuads,
+  storeKnowledgeAssetWorkspaceHead,
+} from '../src/workspace-resolution.js';
 
 const CONTEXT_GRAPH = 'test-access-verify';
 const META_GRAPH = `did:dkg:context-graph:${CONTEXT_GRAPH}/_meta`;
@@ -337,6 +343,63 @@ describe('I-005: Access handler signature verification', () => {
 
     expect(res.granted).toBe(false);
     expect(res.rejectionReason).toContain('allow list missing or empty');
+  });
+});
+
+describe('graph-scoped private access', () => {
+  it('serves the exact assertion-version private graph through its durable head', async () => {
+    const store = new OxigraphStore();
+    const graphManager = new GraphManager(store);
+    const privateStore = new PrivateContentStore(store, graphManager);
+    const ual = 'did:dkg:mock:31337/0x1111111111111111111111111111111111111111/9';
+    const scope = createGraphKnowledgeAssetScope(ual, 1);
+    const privateQuads: Quad[] = [{
+      subject: 'urn:rootless:private',
+      predicate: 'urn:p:secret',
+      object: '"exact-version-secret"',
+      graph: '',
+    }];
+    const privateMerkleRoot = computePrivateRootV10(privateQuads)!;
+    await privateStore.replaceKnowledgeAssetPrivateTriples(
+      CONTEXT_GRAPH,
+      scope,
+      privateQuads,
+    );
+    await storeKnowledgeAssetOperationPublicQuads({
+      store,
+      graphManager,
+      contextGraphId: CONTEXT_GRAPH,
+      shareOperationId: 'graph-access-share',
+      kaUal: ual,
+      assertionVersion: scope.assertionVersion,
+      quads: [],
+      privateMerkleRoot,
+      privateTripleCount: privateQuads.length,
+      publisherPeerId: 'owner-peer',
+      accessPolicy: 'public',
+    });
+    await storeKnowledgeAssetWorkspaceHead({
+      store,
+      graphManager,
+      contextGraphId: CONTEXT_GRAPH,
+      shareOperationId: 'graph-access-share',
+      kaUal: ual,
+      assertionVersion: scope.assertionVersion,
+    });
+
+    const request = encodeAccessRequest({
+      kaUal: ual,
+      requesterPeerId: 'reader-peer',
+      paymentProof: new Uint8Array(0),
+      requesterSignature: new Uint8Array(0),
+    });
+    const response = decodeAccessResponse(
+      await new AccessHandler(store, new TypedEventBus()).handler(request, 'reader-peer' as any),
+    );
+
+    expect(response.granted).toBe(true);
+    expect(new TextDecoder().decode(response.nquads)).toContain('exact-version-secret');
+    expect(toHex(response.privateMerkleRoot)).toBe(toHex(privateMerkleRoot));
   });
 });
 

--- a/packages/publisher/test/ka-graph-publish-ack.test.ts
+++ b/packages/publisher/test/ka-graph-publish-ack.test.ts
@@ -62,6 +62,80 @@ function byteSizeFloor(quads: readonly Pick<Quad, 'subject' | 'predicate' | 'obj
 }
 
 describe('graph-scoped publish storage ACKs', () => {
+  it('keeps identical-content KAs in distinct durable workspace operations', async () => {
+    const store = new OxigraphStore();
+    const handler = new StorageACKHandler(
+      store,
+      handlerConfig(ethers.Wallet.createRandom(), false),
+      new TypedEventBus(),
+    );
+    const secondUal = `did:dkg:otp:20430/${AUTHOR}/8`;
+
+    for (const ual of [UAL, secondUal]) {
+      const scope = createGraphKnowledgeAssetScope(ual, 1);
+      const swmGraph = knowledgeAssetLayerGraphUri(
+        CONTEXT_GRAPH_ID,
+        MemoryLayer.SharedWorkingMemory,
+        scope,
+      );
+      const quads: Quad[] = [{
+        subject: 'urn:asset:same',
+        predicate: 'urn:p:value',
+        object: '"same"',
+        graph: swmGraph,
+      }];
+      await store.insert(quads);
+      const merkleRoot = computeFlatKCRootV10(quads, []);
+      const deps: ACKCollectorDeps = {
+        gossipPublish: async () => {},
+        sendP2P: async (_peerId, _protocol, data) => handler.handler(data, PEER),
+        getConnectedCorePeers: () => ['core-1'],
+        verifyIdentity: async () => true,
+        log: () => {},
+      };
+      const result = await new ACKCollector(deps).collect({
+        merkleRoot,
+        contextGraphId: BigInt(CONTEXT_GRAPH_ID),
+        contextGraphIdStr: CONTEXT_GRAPH_ID,
+        publisherPeerId: 'publisher-peer',
+        publicByteSize: BigInt(byteSizeFloor(quads)),
+        isPrivate: false,
+        kaCount: 1,
+        rootEntities: [],
+        chainId: 31337n,
+        kav10Address: KAV10,
+        requiredACKs: 1,
+        merkleLeafCount: computeFlatKCMerkleLeafCountV10(quads, []),
+        contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+        kaUal: ual,
+        assertionVersion: '1',
+        publicTripleCount: quads.length,
+        privateTripleCount: 0,
+        accessPolicy: 'public',
+        allowedPeers: [],
+        ackMode: { kind: 'public' },
+      });
+      expect(result.acks).toHaveLength(1);
+    }
+
+    const graphManager = new GraphManager(store);
+    const firstHead = await resolveKnowledgeAssetWorkspaceHead({
+      store,
+      graphManager,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      kaUal: UAL,
+    });
+    const secondHead = await resolveKnowledgeAssetWorkspaceHead({
+      store,
+      graphManager,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      kaUal: secondUal,
+    });
+    expect(firstHead?.kaUal).toBe(UAL);
+    expect(secondHead?.kaUal).toBe(secondUal);
+    expect(firstHead?.shareOperationId).not.toBe(secondHead?.shareOperationId);
+  });
+
   it('collects over V2 from only the exact per-KA SWM graph', async () => {
     const store = new OxigraphStore();
     const quads: Quad[] = [

--- a/packages/publisher/test/ka-graph-publish-ack.test.ts
+++ b/packages/publisher/test/ka-graph-publish-ack.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it } from 'vitest';
+import { ethers } from 'ethers';
+import {
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  MemoryLayer,
+  PROTOCOL_STORAGE_ACK_V2,
+  TypedEventBus,
+  computeCatalogRoot,
+  contextGraphCatalogUri,
+  createGraphKnowledgeAssetScope,
+  decodePublishIntent,
+  knowledgeAssetLayerGraphUri,
+} from '@origintrail-official/dkg-core';
+import { GraphManager, OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
+import { ACKCollector, type ACKCollectorDeps } from '../src/ack-collector.js';
+import {
+  StorageACKHandler,
+  type StorageACKHandlerConfig,
+} from '../src/storage-ack-handler.js';
+import { resolveKnowledgeAssetWorkspaceHead } from '../src/workspace-resolution.js';
+import {
+  computeFlatKCMerkleLeafCountV10,
+  computeFlatKCRootV10,
+} from '../src/merkle.js';
+
+const CONTEXT_GRAPH_ID = '42';
+const AUTHOR = '0x1111111111111111111111111111111111111111';
+const UAL = `did:dkg:otp:20430/${AUTHOR}/7`;
+const SCOPE = createGraphKnowledgeAssetScope(UAL, 1);
+const SWM_GRAPH = knowledgeAssetLayerGraphUri(
+  CONTEXT_GRAPH_ID,
+  MemoryLayer.SharedWorkingMemory,
+  SCOPE,
+);
+const KAV10 = '0x000000000000000000000000000000000000c10a';
+const PRIVATE_ROOT = ethers.getBytes(
+  ethers.keccak256(ethers.toUtf8Bytes('rootless-private-publish')),
+);
+const PEER = { toString: () => 'publisher-peer' };
+
+function handlerConfig(wallet: ethers.Wallet, curated: boolean): StorageACKHandlerConfig {
+  return {
+    nodeRole: 'core',
+    nodeIdentityId: 17n,
+    signerWallet: wallet,
+    contextGraphSharedMemoryUri: (cgId: string) =>
+      `did:dkg:context-graph:${cgId}/_shared_memory`,
+    chainId: 31337n,
+    kav10Address: KAV10,
+    isCgCurated: async () => curated,
+  };
+}
+
+function byteSizeFloor(quads: readonly Pick<Quad, 'subject' | 'predicate' | 'object'>[]): number {
+  return quads.reduce(
+    (sum, quad) => sum
+      + Buffer.byteLength(quad.subject, 'utf8')
+      + Buffer.byteLength(quad.predicate, 'utf8')
+      + Buffer.byteLength(quad.object, 'utf8'),
+    0,
+  );
+}
+
+describe('graph-scoped publish storage ACKs', () => {
+  it('collects over V2 from only the exact per-KA SWM graph', async () => {
+    const store = new OxigraphStore();
+    const quads: Quad[] = [
+      { subject: 'urn:asset:a', predicate: 'urn:p:value', object: '"a"', graph: SWM_GRAPH },
+      { subject: 'urn:asset:b', predicate: 'urn:p:value', object: '"b"', graph: SWM_GRAPH },
+    ];
+    await store.insert([
+      ...quads,
+      {
+        subject: 'urn:legacy:poison',
+        predicate: 'urn:p:value',
+        object: '"wrong"',
+        graph: `did:dkg:context-graph:${CONTEXT_GRAPH_ID}/_shared_memory`,
+      },
+    ]);
+    const handler = new StorageACKHandler(
+      store,
+      handlerConfig(ethers.Wallet.createRandom(), false),
+      new TypedEventBus(),
+    );
+    const merkleRoot = computeFlatKCRootV10(quads, []);
+    let capturedIntent: ReturnType<typeof decodePublishIntent> | undefined;
+    let capturedProtocol: string | undefined;
+    const deps: ACKCollectorDeps = {
+      gossipPublish: async () => {},
+      sendP2P: async (_peerId, protocol, data) => {
+        capturedProtocol = protocol;
+        capturedIntent = decodePublishIntent(data);
+        return handler.handler(data, PEER);
+      },
+      getConnectedCorePeers: () => ['core-1'],
+      verifyIdentity: async () => true,
+      log: () => {},
+    };
+
+    const result = await new ACKCollector(deps).collect({
+      merkleRoot,
+      contextGraphId: BigInt(CONTEXT_GRAPH_ID),
+      contextGraphIdStr: CONTEXT_GRAPH_ID,
+      publisherPeerId: 'publisher-peer',
+      publicByteSize: BigInt(Math.max(1, byteSizeFloor(quads))),
+      isPrivate: false,
+      kaCount: 1,
+      rootEntities: [],
+      chainId: 31337n,
+      kav10Address: KAV10,
+      requiredACKs: 1,
+      merkleLeafCount: computeFlatKCMerkleLeafCountV10(quads, []),
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      kaUal: UAL,
+      assertionVersion: '1',
+      publicTripleCount: quads.length,
+      privateTripleCount: 0,
+      accessPolicy: 'allowList',
+      allowedPeers: ['12D3KooWReader'],
+      ackMode: { kind: 'public' },
+    });
+
+    expect(result.acks).toHaveLength(1);
+    expect(capturedProtocol).toBe(PROTOCOL_STORAGE_ACK_V2);
+    expect(capturedIntent?.rootEntities).toEqual([]);
+    expect(capturedIntent?.privateMerkleRoots).toEqual([]);
+    expect(capturedIntent?.kaUal).toBe(UAL);
+    expect(capturedIntent?.publicTripleCount).toBe(quads.length);
+    const head = await resolveKnowledgeAssetWorkspaceHead({
+      store,
+      graphManager: new GraphManager(store),
+      contextGraphId: CONTEXT_GRAPH_ID,
+      kaUal: UAL,
+    });
+    expect(head).toMatchObject({
+      kaUal: UAL,
+      assertionVersion: '1',
+      assertionGraph: SWM_GRAPH,
+      publicTripleCount: quads.length,
+      privateTripleCount: 0,
+      publisherPeerId: 'publisher-peer',
+      accessPolicy: 'allowList',
+      allowedPeers: ['12D3KooWReader'],
+    });
+  });
+
+  it('collects a curated publish with one KA-level private commitment and no root manifest', async () => {
+    const store = new OxigraphStore();
+    const handler = new StorageACKHandler(
+      store,
+      handlerConfig(ethers.Wallet.createRandom(), true),
+      new TypedEventBus(),
+    );
+    const catalogTriples = [{
+      subject: `did:dkg:context-graph:${CONTEXT_GRAPH_ID}`,
+      predicate: 'http://purl.org/dc/terms/identifier',
+      object: `"did:dkg:context-graph:${CONTEXT_GRAPH_ID}"`,
+    }];
+    const catalog = computeCatalogRoot(catalogTriples);
+    const stagingQuads = new TextEncoder().encode(
+      catalogTriples.map((quad) =>
+        `<${quad.subject}> <${quad.predicate}> ${quad.object} .`,
+      ).join('\n'),
+    );
+    const publicQuads: Quad[] = catalogTriples.map((quad) => ({
+      ...quad,
+      graph: SWM_GRAPH,
+    }));
+    const merkleRoot = computeFlatKCRootV10(publicQuads, [PRIVATE_ROOT]);
+    let capturedIntent: ReturnType<typeof decodePublishIntent> | undefined;
+    const deps: ACKCollectorDeps = {
+      gossipPublish: async () => {},
+      sendP2P: async (_peerId, protocol, data) => {
+        expect(protocol).toBe(PROTOCOL_STORAGE_ACK_V2);
+        capturedIntent = decodePublishIntent(data);
+        return handler.handler(data, PEER);
+      },
+      getConnectedCorePeers: () => ['core-1'],
+      verifyIdentity: async () => true,
+      log: () => {},
+    };
+
+    const result = await new ACKCollector(deps).collect({
+      merkleRoot,
+      contextGraphId: BigInt(CONTEXT_GRAPH_ID),
+      contextGraphIdStr: CONTEXT_GRAPH_ID,
+      publisherPeerId: 'publisher-peer',
+      publicByteSize: BigInt(stagingQuads.length),
+      isPrivate: true,
+      kaCount: 1,
+      rootEntities: [],
+      chainId: 31337n,
+      kav10Address: KAV10,
+      requiredACKs: 1,
+      stagingQuads,
+      merkleLeafCount: computeFlatKCMerkleLeafCountV10(publicQuads, [PRIVATE_ROOT]),
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      kaUal: UAL,
+      assertionVersion: '1',
+      publicTripleCount: publicQuads.length,
+      privateMerkleRoot: PRIVATE_ROOT,
+      privateTripleCount: 9,
+      accessPolicy: 'ownerOnly',
+      allowedPeers: [],
+      ackMode: {
+        kind: 'curated-catalog',
+        catalogCommitment: {
+          catalogRoot: catalog.root,
+          catalogLeafCount: catalog.leafCount,
+        },
+      },
+    });
+
+    expect(result.acks).toHaveLength(1);
+    expect(capturedIntent?.rootEntities).toEqual([]);
+    expect(capturedIntent?.privateMerkleRoots).toEqual([]);
+    expect(ethers.hexlify(capturedIntent!.privateMerkleRoot!)).toBe(
+      ethers.hexlify(PRIVATE_ROOT),
+    );
+    expect(await store.countQuads(contextGraphCatalogUri(CONTEXT_GRAPH_ID))).toBe(
+      publicQuads.length,
+    );
+    // A storage core that is not a curated-CG member must retain only the
+    // independently verified public catalog. The protected assertion reaches
+    // members through encrypted gossip/sync and must never be mislabeled as a
+    // complete exact SWM graph on this core.
+    expect(await store.countQuads(SWM_GRAPH)).toBe(0);
+  });
+});

--- a/packages/publisher/test/ka-graph-publish-handler.test.ts
+++ b/packages/publisher/test/ka-graph-publish-handler.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+import {
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  MemoryLayer,
+  TypedEventBus,
+  createGraphKnowledgeAssetScope,
+  decodePublishAck,
+  encodePublishRequest,
+  knowledgeAssetLayerGraphUri,
+} from '@origintrail-official/dkg-core';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import { PublishHandler } from '../src/publish-handler.js';
+
+const CONTEXT_GRAPH = '42';
+const CHAIN_ID = 'otp:20430';
+const AUTHOR = '0x1111111111111111111111111111111111111111';
+const KA_NUMBER = 7n;
+const KA_ID = (BigInt(AUTHOR) << 96n) | KA_NUMBER;
+const UAL = `did:dkg:${CHAIN_ID}/${AUTHOR}/${KA_NUMBER}`;
+const SCOPE = createGraphKnowledgeAssetScope(UAL, 1);
+const VM_GRAPH = knowledgeAssetLayerGraphUri(
+  CONTEXT_GRAPH,
+  MemoryLayer.VerifiableMemory,
+  SCOPE,
+);
+const SWM_GRAPH = knowledgeAssetLayerGraphUri(
+  CONTEXT_GRAPH,
+  MemoryLayer.SharedWorkingMemory,
+  SCOPE,
+);
+const PEER = { toString: () => '12D3KooWPublisher' };
+
+function request(graph = VM_GRAPH): Uint8Array {
+  return encodePublishRequest({
+    ual: UAL,
+    nquads: new TextEncoder().encode(
+      `<urn:asset:subject> <urn:asset:predicate> "value" <${graph}> .`,
+    ),
+    contextGraphId: CONTEXT_GRAPH,
+    kas: [],
+    publisherIdentity: new Uint8Array(32),
+    publisherAddress: AUTHOR,
+    startKAId: KA_ID,
+    endKAId: KA_ID,
+    chainId: CHAIN_ID,
+    publisherSignatureR: new Uint8Array(0),
+    publisherSignatureVs: new Uint8Array(0),
+    contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+    assertionVersion: '1',
+    publicTripleCount: 1,
+    privateTripleCount: 0,
+    accessPolicy: 'allowList',
+    allowedPeers: ['12D3KooWReader'],
+  });
+}
+
+describe('PublishHandler graph-scoped protocol', () => {
+  it('stores one exact tentative VM graph, confirms it, and drops exact SWM', async () => {
+    const store = new OxigraphStore();
+    const handler = new PublishHandler(store, new TypedEventBus());
+
+    const ack = decodePublishAck(await handler.handler(request(), PEER));
+
+    expect(ack.accepted).toBe(true);
+    expect(await store.countQuads(VM_GRAPH)).toBe(1);
+    expect(await store.countQuads(`did:dkg:context-graph:${CONTEXT_GRAPH}`)).toBe(0);
+    const metaGraph = `did:dkg:context-graph:${CONTEXT_GRAPH}/_meta`;
+    const metadata = await store.query(
+      `CONSTRUCT { <${UAL}> ?p ?o } WHERE { GRAPH <${metaGraph}> { <${UAL}> ?p ?o } }`,
+    );
+    expect(metadata.type).toBe('quads');
+    if (metadata.type !== 'quads') throw new Error('expected graph-scoped metadata');
+    expect(metadata.quads.some((quad) => quad.predicate.endsWith('rootEntity'))).toBe(false);
+    expect(metadata.quads.some((quad) => quad.predicate.endsWith('tokenId'))).toBe(false);
+    expect(metadata.quads).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        predicate: 'http://dkg.io/ontology/accessPolicy',
+        object: '"allowList"',
+      }),
+      expect.objectContaining({
+        predicate: 'http://dkg.io/ontology/allowedPeer',
+        object: '"12D3KooWReader"',
+      }),
+    ]));
+
+    await store.insert([{
+      subject: 'urn:asset:subject',
+      predicate: 'urn:asset:predicate',
+      object: '"value"',
+      graph: SWM_GRAPH,
+    }]);
+    const confirmed = await handler.confirmPublish(UAL, {
+      publisherAddress: AUTHOR,
+      merkleRoot: new Uint8Array(ack.merkleRoot),
+      startKAId: KA_ID,
+      endKAId: KA_ID,
+    });
+
+    expect(confirmed).toBe(true);
+    expect(await store.countQuads(SWM_GRAPH)).toBe(0);
+    const status = await store.query(
+      `SELECT ?status WHERE { GRAPH <${metaGraph}> { <${UAL}> <http://dkg.io/ontology/status> ?status } }`,
+    );
+    expect(status.type).toBe('bindings');
+    expect(status.type === 'bindings' ? status.bindings[0]?.status : undefined).toBe('"confirmed"');
+
+    const replayAck = decodePublishAck(await handler.handler(request(), PEER));
+    expect(replayAck.accepted).toBe(false);
+    expect(replayAck.rejectionReason).toContain('already confirmed');
+    expect(await store.countQuads(VM_GRAPH)).toBe(1);
+    const statusAfterReplay = await store.query(
+      `SELECT ?status WHERE { GRAPH <${metaGraph}> { <${UAL}> <http://dkg.io/ontology/status> ?status } }`,
+    );
+    expect(statusAfterReplay.type).toBe('bindings');
+    expect(statusAfterReplay.type === 'bindings'
+      ? statusAfterReplay.bindings[0]?.status
+      : undefined).toBe('"confirmed"');
+  });
+
+  it('rejects graph-scoped protocol data aimed at a forged graph', async () => {
+    const store = new OxigraphStore();
+    const handler = new PublishHandler(store, new TypedEventBus());
+
+    const ack = decodePublishAck(await handler.handler(request('urn:forged:graph'), PEER));
+
+    expect(ack.accepted).toBe(false);
+    expect(ack.rejectionReason).toContain('UAL-derived VM graph');
+    expect(await store.countQuads(VM_GRAPH)).toBe(0);
+  });
+});

--- a/packages/publisher/test/publish-handler-journal.test.ts
+++ b/packages/publisher/test/publish-handler-journal.test.ts
@@ -1,20 +1,27 @@
 /**
  * PublishHandler journal restore / expiry paths (tentative publish persistence).
  */
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { ethers } from 'ethers';
+import {
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  MemoryLayer,
+  createGraphKnowledgeAssetScope,
+  knowledgeAssetLayerGraphUri,
+} from '@origintrail-official/dkg-core';
 import { PublishHandler } from '../src/publish-handler.js';
 import type { JournalEntry } from '../src/publish-journal.js';
 
 const TENTATIVE_MS = 60 * 60 * 1000;
 
-function makeStore() {
+function makeStore(droppedGraphs?: string[]) {
   return {
     query: async () => ({ type: 'bindings' as const, bindings: [] }),
     insert: async () => {},
     delete: async () => {},
     deleteByPattern: async () => 0,
     deleteBySubjectPrefix: async () => 0,
+    dropGraph: async (graph: string) => { droppedGraphs?.push(graph); },
   };
 }
 
@@ -63,6 +70,61 @@ describe('PublishHandler.restorePendingPublishes', () => {
     const h = new PublishHandler(store as any, bus, { journal: journal as any });
     const n = await h.restorePendingPublishes();
     expect(n).toBe(1);
+    expect(h.hasPendingPublishes).toBe(true);
+  });
+
+  it('restores graph-scoped identity and expires the exact VM and SWM graphs', async () => {
+    vi.useFakeTimers();
+    try {
+      const droppedGraphs: string[] = [];
+      store = makeStore(droppedGraphs);
+      const entry = baseEntry({
+        contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+        assertionVersion: '3',
+        subGraphName: 'research',
+      });
+      const journal = {
+        load: async () => [entry],
+        save: async () => {},
+      };
+      const h = new PublishHandler(store as any, bus, { journal: journal as any });
+
+      expect(await h.restorePendingPublishes()).toBe(1);
+      await (h as any).expireRestoredPublish(entry.ual);
+
+      const scope = createGraphKnowledgeAssetScope(entry.ual, '3');
+      expect(droppedGraphs).toEqual([
+        knowledgeAssetLayerGraphUri(
+          entry.contextGraphId,
+          MemoryLayer.VerifiableMemory,
+          scope,
+          'research',
+        ),
+        knowledgeAssetLayerGraphUri(
+          entry.contextGraphId,
+          MemoryLayer.SharedWorkingMemory,
+          scope,
+          'research',
+        ),
+      ]);
+      expect(h.hasPendingPublishes).toBe(false);
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
+  });
+
+  it('skips a malformed graph-scoped entry without aborting later restores', async () => {
+    const journal = {
+      load: async () => [
+        baseEntry({ assertionVersion: '1' }),
+        baseEntry(),
+      ],
+      save: async () => {},
+    };
+    const h = new PublishHandler(store as any, bus, { journal: journal as any });
+
+    expect(await h.restorePendingPublishes()).toBe(1);
     expect(h.hasPendingPublishes).toBe(true);
   });
 

--- a/packages/publisher/vitest.unit.config.ts
+++ b/packages/publisher/vitest.unit.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
       'test/async-lift-publish-options.test.ts',
       'test/async-promote-queue.test.ts',
       'test/multi-root-token-rows.test.ts',
+      'test/access-verification.test.ts',
       'test/promote-step-tag.test.ts',
       'test/ka-graph-skolemization.test.ts',
       'test/ka-graph-workspace-snapshot.test.ts',

--- a/packages/publisher/vitest.unit.config.ts
+++ b/packages/publisher/vitest.unit.config.ts
@@ -23,6 +23,8 @@ export default defineConfig({
       'test/ka-graph-workspace-receiver.test.ts',
       'test/ka-graph-finalization-storage.test.ts',
       'test/ka-graph-publish-storage.test.ts',
+      'test/ka-graph-publish-ack.test.ts',
+      'test/ka-graph-publish-handler.test.ts',
       'test/ka-graph-update-ack.test.ts',
       'test/ka-graph-update-handler.test.ts',
       'test/agents-meta-bound.test.ts',


### PR DESCRIPTION
## Summary

- Routes direct V10 publishes through the graph-scoped rootless V2 envelope and targets only the UAL-derived VM graph.
- Validates ACK, P2P publish, gossip, finalization, and replay paths against the exact per-KA graph; persists a durable SWM workspace head for chain reconciliation.
- Propagates public, owner-only, and allow-list access policy through authenticated protocol boundaries, preferring durable ACK state and failing closed when recovery provenance is unavailable.
- Keeps legacy root-scoped KAs read-only and rejects mixed root plus graph envelopes; curated private-CG cores retain only the public catalog commitment rather than plaintext private content.

## Validation

- Core protocol scope tests: 7 passed.
- Publisher unit suite: 29 files, 330 tests passed.
- Agent unit suite: 68 files, 836 tests passed.
- Core, publisher, and agent builds passed.
- git diff --check passed.

## Stack

Depends on #1717. This is the direct protocol and ACK boundary milestone in the rootless-KA stack.