### PR TITLE
feat: route publishAsync through the rootless KA queue

### DIFF
--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -382,9 +382,7 @@ import {
   normalizePublishContextGraphId,
   isPublishAsyncQuadEnvelope,
   assertQuadArray,
-  partitionPublishAsyncQuads,
   signWithPrivateKey,
-  preSignedAttestationToLiftSeal,
   normalizeAgentDid,
   joinDelegationScope,
   normalizeSyncPhase,
@@ -1082,118 +1080,176 @@ export class PublishMethods extends DKGAgentBase {
     rejectOversizedRdfLiterals(publicQuads, 'publishAsync.publicQuads');
     rejectOversizedRdfLiterals(privateQuads, 'publishAsync.privateQuads');
 
-    const partitioned = partitionPublishAsyncQuads(publicQuads, privateQuads);
-    const gossipSigner = opts?.localOnly ? null : await this.resolveWorkspaceGossipSigningAgent(contextGraphId);
-    const { shareOperationId, message } = await this.publisher.writeToWorkspace(
+    if (opts?.transitionType !== undefined && opts.transitionType !== 'CREATE') {
+      throw new InvalidContentError(
+        'publishAsync creates one new atomic Knowledge Asset; use the KA update API for MUTATE or REVOKE',
+      );
+    }
+    if (opts?.priorVersion !== undefined) {
+      throw new InvalidContentError('publishAsync priorVersion is only valid for the legacy root-lift path');
+    }
+    if (opts?.namespace !== undefined || opts?.scope !== undefined || opts?.authority !== undefined) {
+      throw new InvalidContentError(
+        'publishAsync no longer accepts legacy root-lift namespace, scope, or authority metadata',
+      );
+    }
+    if (
+      this.chain.isV10Ready?.() !== true
+      || typeof this.chain.getEvmChainId !== 'function'
+      || typeof this.chain.getKnowledgeAssetsLifecycleAddress !== 'function'
+    ) {
+      throw Object.assign(
+        new Error('publishAsync requires a V10-capable chain so every queued KA has a sealed UAL identity'),
+        { code: SEAL_CAPABILITY_GAP_CODE },
+      );
+    }
+
+    const accessPolicy = opts?.accessPolicy
+      ?? (privateQuads.length > 0 ? 'ownerOnly' : 'public');
+    const allowedPeers = [...new Set(
+      (opts?.allowedPeers ?? []).map((peerId) => peerId.trim()).filter(Boolean),
+    )];
+    if (accessPolicy === 'allowList' && allowedPeers.length === 0) {
+      throw new InvalidContentError('publishAsync allowList policy requires allowedPeers');
+    }
+    if (accessPolicy !== 'allowList' && allowedPeers.length > 0) {
+      throw new InvalidContentError('publishAsync allowedPeers requires allowList policy');
+    }
+
+    const fallbackAuthor = opts?.preSignedAuthorAttestation === undefined
+      && opts?.authorAgentAddress === undefined
+      ? await this.publisher.publisherFallbackAuthorAddress()
+      : undefined;
+    const lifecycleAgentAddress = ethers.getAddress(
+      opts?.preSignedAuthorAttestation?.authorAddress
+        ?? opts?.authorAgentAddress
+        ?? fallbackAuthor
+        ?? (() => {
+          throw Object.assign(
+            new Error('publishAsync cannot create a rootless KA because no author signer is available'),
+            { code: SEAL_CAPABILITY_GAP_CODE },
+          );
+        })(),
+    );
+    const assertionName = `async-${randomUUID()}`;
+
+    // Reuse the named-KA lifecycle rather than maintaining a second async
+    // content model. Finalize canonicalizes the complete RDF set once, assigns
+    // the UAL, and materializes the exact WM graph; promote moves that graph to
+    // SWM and persists the immutable operation snapshot consumed by the queue.
+    await this.publisher.assertionCreate(
       contextGraphId,
-      partitioned.publicQuads,
+      assertionName,
+      lifecycleAgentAddress,
+      opts?.subGraphName,
+    );
+    if (publicQuads.length > 0) {
+      await this.publisher.assertionWrite(
+        contextGraphId,
+        assertionName,
+        lifecycleAgentAddress,
+        publicQuads,
+        opts?.subGraphName,
+      );
+    }
+    if (privateQuads.length > 0) {
+      await this.publisher.assertionWritePrivate(
+        contextGraphId,
+        assertionName,
+        lifecycleAgentAddress,
+        privateQuads,
+        opts?.subGraphName,
+      );
+    }
+
+    await this.assertionFinalize(
+      contextGraphId,
+      assertionName,
+      lifecycleAgentAddress,
       {
-        publisherPeerId: this.peerId,
-        operationCtx: ctx,
         subGraphName: opts?.subGraphName,
-        localOnly: opts?.localOnly,
-        senderAgentAddress: gossipSigner?.agentAddress,
+        ...(opts?.preSignedAuthorAttestation
+          ? {
+              preSignedAuthorAttestation: {
+                address: opts.preSignedAuthorAttestation.authorAddress,
+                expectedMerkleRoot: opts.preSignedAuthorAttestation.expectedMerkleRoot,
+                reservedKaId: opts.preSignedAuthorAttestation.reservedKaId,
+                signature: opts.preSignedAuthorAttestation.signature,
+              },
+              schemeVersion: opts.preSignedAuthorAttestation.schemeVersion,
+            }
+          : {}),
+        ...(opts?.authorAgentAddress
+          ? { authorAgentAddress: opts.authorAgentAddress }
+          : {}),
+        ...(opts?.authorSignTypedData
+          ? { authorSignTypedData: opts.authorSignTypedData }
+          : {}),
       },
     );
 
-    if (partitioned.privateQuadsByRoot.size > 0) {
-      const privateStore = new PrivateContentStore(this.store, new GraphManager(this.store));
-      for (const [rootEntity, rootPrivateQuads] of partitioned.privateQuadsByRoot) {
-        await privateStore.storePrivateTriplesForOperation(
-          contextGraphId,
-          shareOperationId,
-          rootEntity,
-          rootPrivateQuads,
-          opts?.subGraphName,
-        );
-      }
-    }
-
-    const liftRequestDraft = {
-      swmId: shareOperationId,
-      shareOperationId,
-      roots: partitioned.roots,
+    const gossipSigner = opts?.localOnly
+      ? null
+      : await this.resolveWorkspaceGossipSigningAgent(contextGraphId);
+    const confirmBeforeCommit = opts?.localOnly
+      ? undefined
+      : await this.buildCuratorAckConfirmer(contextGraphId, gossipSigner, {}, ctx);
+    const onChainContextGraphId = await this.getContextGraphOnChainId(contextGraphId) ?? undefined;
+    const trustedNonManifestCatalogTriples = await this.isPrivateContextGraph(contextGraphId)
+      ? generatedPrivateCatalogTripleKeys(contextGraphId)
+      : undefined;
+    const promoted = await this.publisher.assertionPromote(
       contextGraphId,
-      namespace: opts?.namespace ?? 'async-publish',
-      scope: opts?.scope ?? 'context-graph',
-      transitionType: opts?.transitionType ?? 'CREATE',
-      authority: opts?.authority ?? { type: 'owner', proofRef: `urn:dkg:publish-async:${shareOperationId}` },
-      priorVersion: opts?.priorVersion,
-      subGraphName: opts?.subGraphName,
-      accessPolicy: opts?.accessPolicy,
-      allowedPeers: opts?.allowedPeers,
-      entityProofs: opts?.entityProofs,
-      publishEpochs: opts?.publishEpochs,
-      // Stringify bigint for JSON-safe persistence; preserve `0n` (mode d).
-      publisherNodeIdentityIdOverride: opts?.publisherNodeIdentityIdOverride !== undefined
-        ? (opts.publisherNodeIdentityIdOverride.toString() as `${bigint}`)
-        : undefined,
-    } as const;
-
-    // OT-RFC-43 §F2 — bind the per-author reservedKaId into the async-lift seal so
-    // EPCIS/Kafka and other direct async-capture writers earn a real on-chain VM
-    // anchor (not just WM/SWM). Two sources:
-    //   • a caller-supplied preSignedAuthorAttestation carries its own attestation
-    //     and the slot it signed over — honour it, persisting its reservedKaId
-    //     (after a namespace sanity check so we never store a seal the mint would
-    //     reject with KaIdNamespaceMismatch);
-    //   • otherwise build the seal here via `buildAsyncLiftSeal`, which
-    //     allocates-before-signing in the resolved author's namespace.
-    // `buildAsyncLiftSeal` returns undefined (⇒ sealless lift, WM/SWM unaffected,
-    // on-chain anchor simply skipped) on non-V10 chains, off-chain CGs, noops, or
-    // when no allocator/author is available — preserving the prior graceful path.
-    // (A caller-supplied preSignedAuthorAttestation was namespace-checked up front,
-    // before workspace staging, so it can be threaded onto the seal as-is here.)
-    let seal: LiftRequestAuthorSeal | undefined;
-    if (opts?.preSignedAuthorAttestation) {
-      seal = preSignedAttestationToLiftSeal(opts.preSignedAuthorAttestation);
-    } else {
-      // `buildAsyncLiftSeal` degrades to `undefined` (sealless) for the expected
-      // non-mintable conditions (non-V10 / off-chain CG / noop / no allocator / no
-      // signer) and for an allocate failure. A *thrown* error is different and is
-      // handled by caller intent:
-      //   • IMPLICIT machine-capture path (no explicit author → publisher-fallback
-      //     signer; the EPCIS/Kafka shape): the WM/SWM write above is already
-      //     committed with no outer rollback, and the caller asked for a best-effort
-      //     capture, not a specific author's attestation. Degrade to a SEALLESS lift
-      //     (WM/SWM kept, on-chain anchor skipped) rather than orphan the staged
-      //     write — identical to the prior always-sealless async behaviour.
-      //   • EXPLICIT authorship request (custodial authorAgentAddress or a
-      //     self-sovereign authorSignTypedData callback): the caller specifically
-      //     asked for THAT author's attestation. Silently enqueuing an unauthored
-      //     sealless job and returning a captureID would report success without the
-      //     attestation ever being produced — so surface the failure instead.
-      const explicitAuthorshipRequested =
-        opts?.authorAgentAddress != null || opts?.authorSignTypedData != null;
-      try {
-        seal = await this.buildAsyncLiftSeal(
-          liftRequestDraft,
-          opts?.authorAgentAddress,
-          opts?.authorSignTypedData,
-        );
-      } catch (err) {
-        if (explicitAuthorshipRequested) throw err;
-        this.log.warn(
-          ctx,
-          `Async-lift seal build failed; lift stays sealless (WM/SWM committed, ` +
-            `on-chain VM anchor deferred): ${err instanceof Error ? err.message : String(err)}`,
-        );
-        seal = undefined;
-      }
+      assertionName,
+      lifecycleAgentAddress,
+      {
+        subGraphName: opts?.subGraphName,
+        publisherPeerId: this.node.peerId.toString(),
+        senderAgentAddress: gossipSigner?.agentAddress,
+        localOnly: opts?.localOnly === true,
+        accessPolicy,
+        allowedPeers,
+        trustedNonManifestCatalogTriples,
+        onChainContextGraphId,
+        confirmBeforeCommit,
+      },
+    );
+    if (!promoted.shareOperationId) {
+      throw new Error(`publishAsync did not produce an immutable SWM snapshot for ${assertionName}`);
     }
+    if (!opts?.localOnly && promoted.gossipMessage) {
+      await this.publishWorkspaceGossip(
+        contextGraphId,
+        promoted.gossipMessage,
+        ctx,
+        gossipSigner,
+        promoted.shareOperationId,
+      );
+    }
+    await this._stampSwmPointer(
+      contextGraphId,
+      assertionName,
+      lifecycleAgentAddress,
+      opts?.subGraphName,
+    );
 
+    const intent = await this.resolveFinalizedAssertionVmPublishIntent(
+      contextGraphId,
+      assertionName,
+      {
+        agentAddress: lifecycleAgentAddress,
+        subGraphName: opts?.subGraphName,
+        publishEpochs: opts?.publishEpochs,
+        accessPolicy,
+        allowedPeers,
+        entityProofs: opts?.entityProofs,
+        publisherNodeIdentityIdOverride: opts?.publisherNodeIdentityIdOverride,
+      },
+    );
     const asyncPublisher = new TripleStoreAsyncLiftPublisher(this.store, {
       publicSnapshotStore: this.publicSnapshotStore,
     });
-    const captureID = await asyncPublisher.lift({
-      ...liftRequestDraft,
-      ...(seal !== undefined ? { seal } : {}),
-    });
-
-    if (!opts?.localOnly) {
-      await this.publishWorkspaceGossip(contextGraphId, message, ctx, gossipSigner);
-    }
-
+    const captureID = await asyncPublisher.enqueueKnowledgeAssetVmPublish(intent);
     return { captureID };
   }
 
@@ -2189,6 +2245,9 @@ export class PublishMethods extends DKGAgentBase {
       subGraphName?: string;
       authorAgentAddress?: string;
       preSignedAuthorAttestation?: PreSignedAuthorAttestation;
+      authorSignTypedData?: (
+        typedData: AuthorAttestationTypedData,
+      ) => Promise<{ r: Uint8Array; vs: Uint8Array }>;
       schemeVersion?: number;
     },
   ): Promise<{
@@ -2211,12 +2270,15 @@ export class PublishMethods extends DKGAgentBase {
     eip712Digest: string;
   }> {
     if (
-      opts?.authorAgentAddress != null &&
       opts?.preSignedAuthorAttestation != null
+      && (opts.authorAgentAddress != null || opts.authorSignTypedData != null)
     ) {
       throw new Error(
-        'assertionFinalize: authorAgentAddress and preSignedAuthorAttestation are mutually exclusive',
+        'assertionFinalize: preSignedAuthorAttestation is mutually exclusive with authorAgentAddress / authorSignTypedData',
       );
+    }
+    if (opts?.authorSignTypedData != null && opts.authorAgentAddress == null) {
+      throw new Error('assertionFinalize: authorSignTypedData requires authorAgentAddress');
     }
 
     // 1. Resolve URIs.
@@ -2399,6 +2461,20 @@ export class PublishMethods extends DKGAgentBase {
       privateMerkleRoot ? [privateMerkleRoot] : [],
     );
     const publicTripleCount = normalizedKnowledgeAssetQuads.length;
+    const callerExpectedMerkleRoot = opts?.preSignedAuthorAttestation?.expectedMerkleRoot;
+    if (
+      callerExpectedMerkleRoot !== undefined
+      && (
+        callerExpectedMerkleRoot.length !== merkleRoot.length
+        || !callerExpectedMerkleRoot.every((byte, index) => byte === merkleRoot[index])
+      )
+    ) {
+      throw new Error(
+        `assertionFinalize: preSignedAuthorAttestation expectedMerkleRoot mismatch — ` +
+          `caller=${ethers.hexlify(callerExpectedMerkleRoot)}, ` +
+          `canonical=${ethers.hexlify(merkleRoot)}.`,
+      );
+    }
 
     // 4. Idempotency: if a seal already exists for this assertion,
     //    return it as-is when the merkleRoot matches. Mismatch means
@@ -2566,6 +2642,10 @@ export class PublishMethods extends DKGAgentBase {
     if (opts?.preSignedAuthorAttestation != null) {
       preSigned = opts.preSignedAuthorAttestation;
       authorAddress = preSigned.address;
+    } else if (opts?.authorSignTypedData != null) {
+      // Self-sovereign callback: the daemon builds the exact typed data after
+      // canonicalization and allocation, while the caller retains its key.
+      authorAddress = ethers.getAddress(opts.authorAgentAddress!);
     } else if (opts?.authorAgentAddress != null) {
       const mode = this.getLocalAgentMode(opts.authorAgentAddress);
       if (mode === undefined) {
@@ -2843,6 +2923,27 @@ export class PublishMethods extends DKGAgentBase {
       }
       r = preSigned.signature.r;
       vs = preSigned.signature.vs;
+    } else if (opts?.authorSignTypedData != null) {
+      const compact = await opts.authorSignTypedData(typedData);
+      const sig = ethers.Signature.from({
+        r: ethers.hexlify(compact.r),
+        yParityAndS: ethers.hexlify(compact.vs),
+      });
+      const isContractAuthor =
+        typeof this.chain.hasContractCode === 'function'
+          ? await this.chain.hasContractCode(authorAddress)
+          : false;
+      if (!isContractAuthor) {
+        const recovered = ethers.recoverAddress(eip712Digest, sig);
+        if (recovered.toLowerCase() !== authorAddress.toLowerCase()) {
+          throw new Error(
+            `assertionFinalize: authorSignTypedData signer mismatch — ` +
+              `signature recovers ${recovered} but address claims ${authorAddress}.`,
+          );
+        }
+      }
+      r = ethers.getBytes(sig.r);
+      vs = ethers.getBytes(sig.yParityAndS);
     } else if (signerPrivateKey) {
       const wallet = new ethers.Wallet(
         signerPrivateKey.startsWith('0x') ? signerPrivateKey : '0x' + signerPrivateKey,
@@ -3755,6 +3856,9 @@ export class PublishMethods extends DKGAgentBase {
       agentAddress?: string;
       publishEpochs?: number;
       clearSharedMemoryAfter?: boolean;
+      accessPolicy?: 'public' | 'ownerOnly' | 'allowList';
+      allowedPeers?: readonly string[];
+      entityProofs?: boolean;
       publisherNodeIdentityIdOverride?: bigint | `${bigint}`;
       publisherOverride?: DKGPublisher;
     },
@@ -3806,6 +3910,17 @@ export class PublishMethods extends DKGAgentBase {
       || seal.privateTripleCount === undefined
     ) {
       throw new Error(`Graph-scoped assertion seal for <${assertionUri}> is incomplete`);
+    }
+    const accessPolicy = opts?.accessPolicy
+      ?? (seal.privateTripleCount > 0 ? 'ownerOnly' : 'public');
+    const allowedPeers = [...new Set(
+      (opts?.allowedPeers ?? []).map((peerId) => peerId.trim()).filter(Boolean),
+    )];
+    if (accessPolicy === 'allowList' && allowedPeers.length === 0) {
+      throw new Error('Queued Knowledge Asset allowList policy requires allowedPeers');
+    }
+    if (accessPolicy !== 'allowList' && allowedPeers.length > 0) {
+      throw new Error('Queued Knowledge Asset allowedPeers requires allowList policy');
     }
     const latestPromote = [...history.events]
       .reverse()
@@ -3860,6 +3975,9 @@ export class PublishMethods extends DKGAgentBase {
         ? ethers.hexlify(seal.privateMerkleRoot).toLowerCase()
         : null,
       privateTripleCount: seal.privateTripleCount,
+      accessPolicy,
+      allowedPeers,
+      entityProofs: opts?.entityProofs ?? null,
       sealMerkleRoot: sealMerkleRoot.toLowerCase(),
       seal: queuedSeal,
       sealChainId: seal.chainId.toString(),
@@ -3891,6 +4009,9 @@ export class PublishMethods extends DKGAgentBase {
         ? { privateMerkleRoot: ethers.hexlify(seal.privateMerkleRoot) as `0x${string}` }
         : {}),
       privateTripleCount: seal.privateTripleCount,
+      accessPolicy,
+      ...(allowedPeers.length > 0 ? { allowedPeers } : {}),
+      ...(opts?.entityProofs !== undefined ? { entityProofs: opts.entityProofs } : {}),
       seal: queuedSeal,
       sealChainId: seal.chainId.toString() as `${bigint}`,
       sealKav10Address: ethers.getAddress(seal.kav10Address) as `0x${string}`,

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -9,7 +9,7 @@
  * `this: DKGAgent` so cross-calls resolve against the composed class.
  */
 
-import { createHash, randomUUID } from 'node:crypto';
+import { randomUUID } from 'node:crypto';
 import {
   DKGNode, ProtocolRouter, GossipSubManager, TypedEventBus, DKGEvent,
   LibP2PNetwork, PeerResolver, StubNetworkStateRegistry,
@@ -161,6 +161,10 @@ import {
 } from '@origintrail-official/dkg-query';
 import { DKGAgentWallet, type AgentWallet } from './agent-wallet.js';
 import { sharedMemoryScopeForFinalizedLifecycle } from './finalized-lifecycle-swm.js';
+import {
+  computeKnowledgeAssetVmPublishIntentKey,
+  type KnowledgeAssetVmPublishIntent,
+} from './knowledge-asset-vm-publish-intent.js';
 
 import { ProfileManager } from './profile-manager.js';
 import { DiscoveryClient, type SkillSearchOptions, type DiscoveredAgent, type DiscoveredOffering } from './discovery.js';
@@ -3886,6 +3890,7 @@ export class PublishMethods extends DKGAgentBase {
       publisherOverride?: DKGPublisher;
     },
   ): Promise<KnowledgeAssetVmPublishRequest> {
+    contextGraphId = normalizePublishContextGraphId(contextGraphId);
     const agentAddress = opts?.agentAddress ?? this.defaultAgentAddress ?? this.peerId;
     const publisher = opts?.publisherOverride ?? this.publisher;
     const history = await this.assertion.history(contextGraphId, name, {
@@ -4014,41 +4019,7 @@ export class PublishMethods extends DKGAgentBase {
     const publisherOverrideString = opts?.publisherNodeIdentityIdOverride !== undefined
       ? opts.publisherNodeIdentityIdOverride.toString() as `${bigint}`
       : undefined;
-    const canonicalIntent = {
-      contextGraphId,
-      name,
-      agentAddress,
-      subGraphName: opts?.subGraphName ?? null,
-      shareOperationId,
-      roots: [],
-      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
-      kaUal: seal.kaUal,
-      assertionVersion: seal.assertionVersion,
-      publicTripleCount: seal.publicTripleCount,
-      privateMerkleRoot: seal.privateMerkleRoot
-        ? ethers.hexlify(seal.privateMerkleRoot).toLowerCase()
-        : null,
-      privateTripleCount: seal.privateTripleCount,
-      accessPolicy,
-      allowedPeers,
-      entityProofs: opts?.entityProofs ?? null,
-      sealMerkleRoot: sealMerkleRoot.toLowerCase(),
-      seal: queuedSeal,
-      sealChainId: seal.chainId.toString(),
-      sealKav10Address: ethers.getAddress(seal.kav10Address),
-      sealFinalizedAtIso: seal.finalizedAtIso,
-      wmCurrentAssertion: history.wmCurrentAssertion ?? null,
-      swmCurrentAssertion: history.swmCurrentAssertion ?? null,
-      vmCurrentAssertion: history.vmCurrentAssertion ?? null,
-      kaNumber: history.kaNumber ?? null,
-      reservedUal: history.reservedUal ?? null,
-      publishEpochs: opts?.publishEpochs ?? null,
-      clearSharedMemoryAfter: opts?.clearSharedMemoryAfter ?? null,
-      publisherNodeIdentityIdOverride: publisherOverrideString ?? null,
-    };
-    const intentKey = `sha256:${createHash('sha256').update(JSON.stringify(canonicalIntent)).digest('hex')}`;
-
-    return {
+    const request: KnowledgeAssetVmPublishIntent = {
       contextGraphId,
       name,
       agentAddress,
@@ -4071,7 +4042,6 @@ export class PublishMethods extends DKGAgentBase {
       sealKav10Address: ethers.getAddress(seal.kav10Address) as `0x${string}`,
       sealFinalizedAtIso: seal.finalizedAtIso,
       sealMerkleRoot,
-      intentKey,
       ...(history.wmCurrentAssertion ? { wmCurrentAssertion: history.wmCurrentAssertion } : {}),
       ...(history.swmCurrentAssertion ? { swmCurrentAssertion: history.swmCurrentAssertion } : {}),
       ...(history.vmCurrentAssertion ? { vmCurrentAssertion: history.vmCurrentAssertion } : {}),
@@ -4080,6 +4050,10 @@ export class PublishMethods extends DKGAgentBase {
       ...(opts?.publishEpochs !== undefined ? { publishEpochs: opts.publishEpochs } : {}),
       ...(opts?.clearSharedMemoryAfter !== undefined ? { clearSharedMemoryAfter: opts.clearSharedMemoryAfter } : {}),
       ...(publisherOverrideString !== undefined ? { publisherNodeIdentityIdOverride: publisherOverrideString } : {}),
+    };
+    return {
+      ...request,
+      intentKey: computeKnowledgeAssetVmPublishIntentKey(request),
     };
   }
 

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -127,6 +127,7 @@ import {
   createKnowledgeAssetVmPublishSnapshotMetadata,
   createKnowledgeAssetVmPublishSnapshotRequest,
   resolveLiftWorkspaceSlice,
+  resolveKnowledgeAssetWorkspaceHead,
   validateLiftPublishPayload,
   subtractFinalizedExactQuads,
   TripleStoreAsyncLiftPublisher,
@@ -452,7 +453,7 @@ export function buildPrivateCatalogDefaultGraphQuads(cgDid: string, assertionUri
     .map((quad) => ({ ...quad, graph: '' }));
 }
 
-function prepareQueuedKnowledgeAssetVmPublishOptions(input: {
+export function prepareQueuedKnowledgeAssetVmPublishOptions(input: {
   contextGraphId: string;
   snapshotQuads: readonly Quad[];
   onChainContextGraphId?: string;
@@ -469,9 +470,13 @@ function prepareQueuedKnowledgeAssetVmPublishOptions(input: {
 > {
   const encryptionOptions = {
     encryptInlinePayload:
-      input.resolvedEncryptInlinePayload ?? input.queuedEncryptInlinePayload,
+      input.onChainContextGraphId
+        ? input.resolvedEncryptInlinePayload
+        : input.queuedEncryptInlinePayload,
     encryptInlineChunked:
-      input.resolvedEncryptInlineChunked ?? input.queuedEncryptInlineChunked,
+      input.onChainContextGraphId
+        ? input.resolvedEncryptInlineChunked
+        : input.queuedEncryptInlineChunked,
   };
   if (!input.onChainContextGraphId || !input.resolvedEncryptInlinePayload) {
     return { quads: [...input.snapshotQuads], ...encryptionOptions };
@@ -486,6 +491,15 @@ function prepareQueuedKnowledgeAssetVmPublishOptions(input: {
     ...encryptionOptions,
     trustedNonManifestCatalogTriples:
       preparedCatalog.trustedNonManifestCatalogTriples,
+  };
+}
+
+export function queuedKnowledgeAssetAccessEnvelope(
+  request: Pick<KnowledgeAssetVmPublishRequest, 'accessPolicy' | 'allowedPeers'>,
+): Pick<PublishOptions, 'accessPolicy' | 'allowedPeers'> {
+  return {
+    accessPolicy: request.accessPolicy,
+    allowedPeers: request.allowedPeers ? [...request.allowedPeers] : undefined,
   };
 }
 
@@ -1088,6 +1102,11 @@ export class PublishMethods extends DKGAgentBase {
     if (opts?.priorVersion !== undefined) {
       throw new InvalidContentError('publishAsync priorVersion is only valid for the legacy root-lift path');
     }
+    if (opts?.entityProofs === true) {
+      throw new InvalidContentError(
+        'publishAsync does not support entityProofs for graph-scoped Knowledge Assets',
+      );
+    }
     if (opts?.namespace !== undefined || opts?.scope !== undefined || opts?.authority !== undefined) {
       throw new InvalidContentError(
         'publishAsync no longer accepts legacy root-lift namespace, scope, or authority metadata',
@@ -1108,7 +1127,7 @@ export class PublishMethods extends DKGAgentBase {
       ?? (privateQuads.length > 0 ? 'ownerOnly' : 'public');
     const allowedPeers = [...new Set(
       (opts?.allowedPeers ?? []).map((peerId) => peerId.trim()).filter(Boolean),
-    )];
+    )].sort();
     if (accessPolicy === 'allowList' && allowedPeers.length === 0) {
       throw new InvalidContentError('publishAsync allowList policy requires allowedPeers');
     }
@@ -1752,6 +1771,8 @@ export class PublishMethods extends DKGAgentBase {
       publicTripleCount?: PublishOptions['publicTripleCount'];
       privateMerkleRoot?: PublishOptions['privateMerkleRoot'];
       privateTripleCount?: PublishOptions['privateTripleCount'];
+      accessPolicy?: PublishOptions['accessPolicy'];
+      allowedPeers?: PublishOptions['allowedPeers'];
     },
   ): Promise<PublishResult> {
     const ctx = opts?.operationCtx ?? createOperationContext('update');
@@ -1877,6 +1898,8 @@ export class PublishMethods extends DKGAgentBase {
       publicTripleCount: opts?.publicTripleCount,
       privateMerkleRoot: opts?.privateMerkleRoot,
       privateTripleCount: opts?.privateTripleCount,
+      accessPolicy: opts?.accessPolicy,
+      allowedPeers: opts?.allowedPeers,
       trustedNonManifestCatalogTriples:
         preparedUpdateCatalog?.trustedNonManifestCatalogTriples,
       v10UpdateACKProvider,
@@ -3911,16 +3934,8 @@ export class PublishMethods extends DKGAgentBase {
     ) {
       throw new Error(`Graph-scoped assertion seal for <${assertionUri}> is incomplete`);
     }
-    const accessPolicy = opts?.accessPolicy
-      ?? (seal.privateTripleCount > 0 ? 'ownerOnly' : 'public');
-    const allowedPeers = [...new Set(
-      (opts?.allowedPeers ?? []).map((peerId) => peerId.trim()).filter(Boolean),
-    )];
-    if (accessPolicy === 'allowList' && allowedPeers.length === 0) {
-      throw new Error('Queued Knowledge Asset allowList policy requires allowedPeers');
-    }
-    if (accessPolicy !== 'allowList' && allowedPeers.length > 0) {
-      throw new Error('Queued Knowledge Asset allowedPeers requires allowList policy');
+    if (opts?.entityProofs === true) {
+      throw new Error('Graph-scoped async publish does not support entityProofs');
     }
     const latestPromote = [...history.events]
       .reverse()
@@ -3931,6 +3946,45 @@ export class PublishMethods extends DKGAgentBase {
         new Error(
           `Cannot publish "${name}" asynchronously: the current SWM share is missing a shareOperationId. ` +
             `Re-share the asset through /api/knowledge-assets/${encodeURIComponent(name)}/swm/share before publishing.`,
+        ),
+        { code: 'PUBLISH_INTENT_STALE' },
+      );
+    }
+
+    const head = await resolveKnowledgeAssetWorkspaceHead({
+      store: this.store,
+      graphManager: new GraphManager(this.store),
+      contextGraphId,
+      kaUal: seal.kaUal,
+      subGraphName: opts?.subGraphName,
+    });
+    if (
+      !head
+      || head.shareOperationId !== shareOperationId
+      || head.assertionVersion !== seal.assertionVersion
+      || head.accessPolicy === undefined
+    ) {
+      throw Object.assign(
+        new Error(
+          `Cannot publish "${name}" asynchronously: the current SWM head does not match the sealed share operation. ` +
+            'Re-share the knowledge asset before publishing.',
+        ),
+        { code: 'PUBLISH_INTENT_STALE' },
+      );
+    }
+    const accessPolicy = head.accessPolicy;
+    const allowedPeers = [...new Set(head.allowedPeers.map((peerId) => peerId.trim()).filter(Boolean))].sort();
+    const explicitAllowedPeers = [...new Set(
+      (opts?.allowedPeers ?? []).map((peerId) => peerId.trim()).filter(Boolean),
+    )].sort();
+    if (
+      (opts?.accessPolicy !== undefined && opts.accessPolicy !== accessPolicy)
+      || (opts?.allowedPeers !== undefined
+        && JSON.stringify(explicitAllowedPeers) !== JSON.stringify(allowedPeers))
+    ) {
+      throw Object.assign(
+        new Error(
+          `Cannot publish "${name}" asynchronously: the requested access envelope does not match the immutable SWM share.`,
         ),
         { code: 'PUBLISH_INTENT_STALE' },
       );
@@ -4168,6 +4222,33 @@ export class PublishMethods extends DKGAgentBase {
       throw stale(
         `Knowledge asset VM publish intent for "${request.name}" changed after enqueue: ` +
           `shareOperationId is ${liveShareOperationId ?? 'none'}, queued shareOperationId was ${request.shareOperationId}.`,
+      );
+    }
+
+    const liveHead = await resolveKnowledgeAssetWorkspaceHead({
+      store: this.store,
+      graphManager: new GraphManager(this.store),
+      contextGraphId: request.contextGraphId,
+      kaUal: request.kaUal,
+      subGraphName: request.subGraphName,
+    });
+    const queuedAllowedPeers = [...new Set(
+      (request.allowedPeers ?? []).map((peerId) => peerId.trim()).filter(Boolean),
+    )].sort();
+    const liveAllowedPeers = [...new Set(
+      (liveHead?.allowedPeers ?? []).map((peerId) => peerId.trim()).filter(Boolean),
+    )].sort();
+    if (
+      !liveHead
+      || liveHead.shareOperationId !== request.shareOperationId
+      || liveHead.assertionVersion !== request.assertionVersion
+      || liveHead.accessPolicy === undefined
+      || liveHead.accessPolicy !== request.accessPolicy
+      || JSON.stringify(liveAllowedPeers) !== JSON.stringify(queuedAllowedPeers)
+    ) {
+      throw stale(
+        `Knowledge asset VM publish intent for "${request.name}" changed after enqueue: ` +
+          'the immutable SWM access envelope no longer matches the queued request.',
       );
     }
 
@@ -4604,6 +4685,7 @@ export class PublishMethods extends DKGAgentBase {
           publicTripleCount: seal.publicTripleCount,
           ...(snapshotPrivateRoot ? { privateMerkleRoot: snapshotPrivateRoot } : {}),
           privateTripleCount: seal.privateTripleCount,
+          ...queuedKnowledgeAssetAccessEnvelope(request),
         },
       );
 

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -71,6 +71,8 @@ import type {
  */
 export type PreSignedAuthorAttestation = {
   address: string;
+  /** Optional caller commitment checked against the canonicalized KA before sealing. */
+  expectedMerkleRoot?: Uint8Array;
   /**
    * OT-RFC-43 §F2 — the packed reservedKaId the self-sovereign author signed the
    * AuthorAttestation over `(uint160(address)<<96)|uint96(number)`. Required: the

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -2632,6 +2632,9 @@ export class DKGAgent extends DKGAgentBase {
           agentAddress?: string;
           authorAgentAddress?: string;
           preSignedAuthorAttestation?: PreSignedAuthorAttestation;
+          authorSignTypedData?: (
+            typedData: AuthorAttestationTypedData,
+          ) => Promise<{ r: Uint8Array; vs: Uint8Array }>;
           schemeVersion?: number;
           /**
            * #1116 — which layer holds the content to seal. `"wm"` (default)
@@ -2670,6 +2673,7 @@ export class DKGAgent extends DKGAgentBase {
             subGraphName: opts?.subGraphName,
             authorAgentAddress: opts?.authorAgentAddress,
             preSignedAuthorAttestation: opts?.preSignedAuthorAttestation,
+            authorSignTypedData: opts?.authorSignTypedData,
             schemeVersion: opts?.schemeVersion,
           });
         }

--- a/packages/agent/src/knowledge-asset-vm-publish-intent.ts
+++ b/packages/agent/src/knowledge-asset-vm-publish-intent.ts
@@ -1,0 +1,24 @@
+import { createHash } from 'node:crypto';
+import type { KnowledgeAssetVmPublishRequest } from '@origintrail-official/dkg-publisher';
+
+export type KnowledgeAssetVmPublishIntent = Omit<KnowledgeAssetVmPublishRequest, 'intentKey'>;
+
+/** Bind the queue deduplication key to the complete executable request. */
+export function computeKnowledgeAssetVmPublishIntentKey(
+  request: KnowledgeAssetVmPublishIntent,
+): string {
+  const canonical = JSON.stringify(stabilize(request));
+  return `sha256:${createHash('sha256').update(canonical).digest('hex')}`;
+}
+
+function stabilize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stabilize);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, entry]) => [key, stabilize(entry)]),
+    );
+  }
+  return value;
+}

--- a/packages/agent/test/publish-jsonld.test.ts
+++ b/packages/agent/test/publish-jsonld.test.ts
@@ -4,9 +4,27 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { DKGAgent, type DKGAgentConfig } from '../src/index.js';
-import { OxigraphStore, SharedMemoryLiteralBlobStore, type TripleStore } from '@origintrail-official/dkg-storage';
-import { TripleStoreAsyncLiftPublisher, type LiftJob, type LiftRequest } from '@origintrail-official/dkg-publisher';
-import { DKG_ONTOLOGY, SYSTEM_CONTEXT_GRAPHS, buildAuthorAttestationTypedData, contextGraphDataGraphUri } from '@origintrail-official/dkg-core';
+import {
+  GraphManager,
+  OxigraphStore,
+  PrivateContentStore,
+  SharedMemoryLiteralBlobStore,
+  type TripleStore,
+} from '@origintrail-official/dkg-storage';
+import {
+  TripleStoreAsyncLiftPublisher,
+  type KnowledgeAssetVmPublishRequest,
+  type LiftJob,
+} from '@origintrail-official/dkg-publisher';
+import {
+  DKG_ONTOLOGY,
+  MemoryLayer,
+  SYSTEM_CONTEXT_GRAPHS,
+  buildAuthorAttestationTypedData,
+  contextGraphDataGraphUri,
+  createGraphKnowledgeAssetScope,
+  knowledgeAssetLayerGraphUri,
+} from '@origintrail-official/dkg-core';
 import { createEVMAdapter, getSharedContext, createProvider, takeSnapshot, revertSnapshot, HARDHAT_KEYS } from '../../chain/test/evm-test-context.js';
 import { mintTokens } from '../../chain/test/hardhat-harness.js';
 import { ethers } from 'ethers';
@@ -65,12 +83,12 @@ afterEach(async () => {
   }
 });
 
-function expectRawLiftRequest(job: LiftJob | null): LiftRequest {
-  expect(job?.request.jobType).toBe('lift');
-  if (!job || job.request.jobType !== 'lift') {
-    throw new Error('Expected a raw lift job');
+function expectQueuedKaRequest(job: LiftJob | null): KnowledgeAssetVmPublishRequest {
+  expect(job?.request.jobType).toBe('knowledge-asset-vm-publish');
+  if (!job || job.request.jobType !== 'knowledge-asset-vm-publish') {
+    throw new Error('Expected a graph-scoped Knowledge Asset VM publish job');
   }
-  return job.request.lift;
+  return job.request.knowledgeAssetVmPublish;
 }
 
 describe('publishJsonLd', () => {
@@ -263,7 +281,7 @@ describe('publishJsonLd', () => {
     expect(result.status).toBe('confirmed');
   }, CHAIN_JSONLD_TIMEOUT_MS);
 
-  it('async private-only JSON-LD anchors the real private root and enqueues a Lift job', async () => {
+  it('async private-only JSON-LD enqueues one rootless KA and no root anchor', async () => {
     const { agent, store } = await createAgent('AsyncPrivateOnlyBot');
     await agent.createContextGraph({ id: 'async-priv-only', name: 'AsyncPrivateOnly', description: '' });
     await agent.registerContextGraph('async-priv-only');
@@ -284,33 +302,45 @@ describe('publishJsonLd', () => {
 
     const asyncPublisher = new TripleStoreAsyncLiftPublisher(store);
     const job = await asyncPublisher.getStatus(captureID);
-    const request = expectRawLiftRequest(job);
-    expect(request.roots).toEqual([root]);
+    const request = expectQueuedKaRequest(job);
+    expect(request.roots).toEqual([]);
+    expect(request.contentScopeVersion).toBe(2);
+    expect(request.kaUal).toMatch(/^did:dkg:[^/]+\/0x[0-9a-f]{40}\/\d+$/);
     expect(request.accessPolicy).toBe('allowList');
     expect(request.allowedPeers).toEqual(['peer-a']);
     // Keep this resilient to control-plane tuning (defaults changed in main).
     expect(job?.retries.maxRetries).toBeGreaterThan(0);
 
+    const scope = createGraphKnowledgeAssetScope(request.kaUal!, request.assertionVersion!);
+    const swmGraph = knowledgeAssetLayerGraphUri(
+      'async-priv-only',
+      MemoryLayer.SharedWorkingMemory,
+      scope,
+    );
     const publicAnchor = await store.query(
-      `ASK { GRAPH <did:dkg:context-graph:async-priv-only/_shared_memory> { <${root}> <http://dkg.io/ontology/privateDataAnchor> "true" } }`,
+      `ASK { GRAPH <${swmGraph}> { <${root}> <http://dkg.io/ontology/privateDataAnchor> "true" } }`,
     );
     expect(publicAnchor.type).toBe('boolean');
-    if (publicAnchor.type === 'boolean') expect(publicAnchor.value).toBe(true);
+    if (publicAnchor.type === 'boolean') expect(publicAnchor.value).toBe(false);
 
     const publicPayload = await store.query(
-      `ASK { GRAPH <did:dkg:context-graph:async-priv-only/_shared_memory> { <${root}> <http://schema.org/name> "Private Async" } }`,
+      `ASK { GRAPH <${swmGraph}> { <${root}> <http://schema.org/name> "Private Async" } }`,
     );
     expect(publicPayload.type).toBe('boolean');
     if (publicPayload.type === 'boolean') expect(publicPayload.value).toBe(false);
 
-    const privatePayload = await store.query(
-      `ASK { GRAPH <did:dkg:context-graph:async-priv-only/_private> { <${root}> <http://schema.org/name> "Private Async" } }`,
-    );
-    expect(privatePayload.type).toBe('boolean');
-    if (privatePayload.type === 'boolean') expect(privatePayload.value).toBe(false);
+    const privatePayload = await new PrivateContentStore(
+      store,
+      new GraphManager(store),
+    ).getKnowledgeAssetPrivateTriples('async-priv-only', scope);
+    expect(privatePayload.some(
+      (quad) => quad.subject === root
+        && quad.predicate === 'http://schema.org/name'
+        && quad.object === '"Private Async"',
+    )).toBe(true);
   }, CHAIN_JSONLD_TIMEOUT_MS);
 
-  it('async bare JSON-LD writes only an anchor in shared/private graphs before lift', async () => {
+  it('async bare JSON-LD keeps private data in the exact KA private graph', async () => {
     const { agent, store } = await createAgent('AsyncBarePrivateBot');
     await agent.createContextGraph({ id: 'async-bare-private', name: 'AsyncBarePrivate', description: '' });
     await agent.registerContextGraph('async-bare-private');
@@ -329,29 +359,38 @@ describe('publishJsonLd', () => {
 
     const asyncPublisher = new TripleStoreAsyncLiftPublisher(store);
     const job = await asyncPublisher.getStatus(captureID);
-    const request = expectRawLiftRequest(job);
-    expect(request.roots).toEqual([root]);
+    const request = expectQueuedKaRequest(job);
+    expect(request.roots).toEqual([]);
+    expect(request.contentScopeVersion).toBe(2);
     expect(request.accessPolicy).toBe('ownerOnly');
 
+    const scope = createGraphKnowledgeAssetScope(request.kaUal!, request.assertionVersion!);
+    const swmGraph = knowledgeAssetLayerGraphUri(
+      'async-bare-private',
+      MemoryLayer.SharedWorkingMemory,
+      scope,
+    );
     const publicAnchor = await store.query(
-      `ASK { GRAPH <did:dkg:context-graph:async-bare-private/_shared_memory> { <${root}> <http://dkg.io/ontology/privateDataAnchor> "true" } }`,
+      `ASK { GRAPH <${swmGraph}> { <${root}> <http://dkg.io/ontology/privateDataAnchor> "true" } }`,
     );
     expect(publicAnchor.type).toBe('boolean');
-    if (publicAnchor.type === 'boolean') expect(publicAnchor.value).toBe(true);
+    if (publicAnchor.type === 'boolean') expect(publicAnchor.value).toBe(false);
 
     const publicPayload = await store.query(
-      `ASK { GRAPH <did:dkg:context-graph:async-bare-private/_shared_memory> { <${root}> <http://schema.org/name> "Bare Async Private" } }`,
+      `ASK { GRAPH <${swmGraph}> { <${root}> <http://schema.org/name> "Bare Async Private" } }`,
     );
     expect(publicPayload.type).toBe('boolean');
     if (publicPayload.type === 'boolean') expect(publicPayload.value).toBe(false);
 
-    // Async lift stages private quads by operation; they are not materialized in
-    // `_private` until the lift pipeline executes.
-    const privatePayload = await store.query(
-      `ASK { GRAPH <did:dkg:context-graph:async-bare-private/_private> { <${root}> <http://schema.org/name> "Bare Async Private" } }`,
-    );
-    expect(privatePayload.type).toBe('boolean');
-    if (privatePayload.type === 'boolean') expect(privatePayload.value).toBe(false);
+    const privatePayload = await new PrivateContentStore(
+      store,
+      new GraphManager(store),
+    ).getKnowledgeAssetPrivateTriples('async-bare-private', scope);
+    expect(privatePayload.some(
+      (quad) => quad.subject === root
+        && quad.predicate === 'http://schema.org/name'
+        && quad.object === '"Bare Async Private"',
+    )).toBe(true);
   }, CHAIN_JSONLD_TIMEOUT_MS);
 
   // OT-RFC-43 §F2 — the async-lift seal now allocates + binds the per-author
@@ -384,18 +423,12 @@ describe('publishJsonLd', () => {
       },
     );
 
-    // Manually drive the same pipeline the publisher-runner runs in
-    // production: claim → validate → publish. We borrow the agent's
-    // own internal publisher so the chain adapter + wallets match
-    // what processed the request.
-    const internalPublisher = (agent as unknown as {
-      publisher: {
-        publish: (opts: unknown) => Promise<{ status: string; onChainResult?: { batchId: bigint } }>;
-      };
-    }).publisher;
+    // Manually drive the same named-KA queue handler used by the daemon.
     const runner = new TripleStoreAsyncLiftPublisher(store, {
-      publishExecutor: async ({ publishOptions }) => {
-        return internalPublisher.publish(publishOptions) as Promise<any>;
+      knowledgeAssetVmPublishHandler: {
+        preflight: ({ request }) => agent.preflightQueuedKnowledgeAssetVmPublishExecution(request),
+        execute: ({ request, publishOptions }) =>
+          agent.publishQueuedKnowledgeAssetVmPublish(request, publishOptions),
       },
     });
     const finalized = await runner.processNext(publisherAddress);
@@ -450,7 +483,7 @@ describe('publishJsonLd', () => {
 
     const asyncPublisher = new TripleStoreAsyncLiftPublisher(store);
     const job = await asyncPublisher.getStatus(captureID);
-    const seal = expectRawLiftRequest(job).seal;
+    const seal = expectQueuedKaRequest(job).seal;
     expect(seal).toBeDefined();
     expect(seal?.authorAddress.toLowerCase()).toBe(tenant.agentAddress.toLowerCase());
     expect(seal?.authorAddress.toLowerCase()).not.toBe(
@@ -559,7 +592,7 @@ describe('publishJsonLd', () => {
 
     const asyncPublisher = new TripleStoreAsyncLiftPublisher(store);
     const job = await asyncPublisher.getStatus(captureID);
-    const seal = expectRawLiftRequest(job).seal;
+    const seal = expectQueuedKaRequest(job).seal;
     expect(seal).toBeDefined();
     expect(seal?.merkleRoot).toMatch(/^0x[0-9a-f]{64}$/i);
     expect(seal?.authorAddress).toMatch(/^0x[0-9a-f]{40}$/i);
@@ -574,82 +607,68 @@ describe('publishJsonLd', () => {
     );
   }, CHAIN_JSONLD_TIMEOUT_MS);
 
-  it('async publish on a non-V10 chain enqueues without a seal (no on-chain publish to seal for)', async () => {
-    // Seal only built when chain is V10-ready AND CG has on-chain id. Non-V10 → publisher takes tentative-only path.
+  it('async publish fails closed on a non-V10 chain before enqueuing', async () => {
     const { agent, store } = await createAgent('AsyncSealNonV10Bot');
     await agent.createContextGraph({ id: 'async-seal-non-v10', name: 'AsyncSealNonV10', description: '' });
     await agent.registerContextGraph('async-seal-non-v10');
 
     (agent as unknown as { chain: { isV10Ready: () => boolean } }).chain.isV10Ready = () => false;
 
-    const { captureID } = await agent.publishAsync(
-      'did:dkg:context-graph:async-seal-non-v10',
-      {
-        public: {
-          '@context': 'http://schema.org/',
-          '@id': 'http://example.org/NonV10Entity',
-          '@type': 'Thing',
-          'name': 'Non-V10 Async',
+    await expect(
+      agent.publishAsync(
+        'did:dkg:context-graph:async-seal-non-v10',
+        {
+          public: {
+            '@context': 'http://schema.org/',
+            '@id': 'http://example.org/NonV10Entity',
+            '@type': 'Thing',
+            'name': 'Non-V10 Async',
+          },
         },
-      },
-      { localOnly: true },
-    );
+        { localOnly: true },
+      ),
+    ).rejects.toThrow(/requires a V10-capable chain/);
 
     const asyncPublisher = new TripleStoreAsyncLiftPublisher(store);
-    const job = await asyncPublisher.getStatus(captureID);
-    expect(expectRawLiftRequest(job).seal).toBeUndefined();
+    expect(await asyncPublisher.list()).toEqual([]);
   }, CHAIN_JSONLD_TIMEOUT_MS);
 
-  // OT-RFC-43 §F2 — backstop: the WM/SWM write is committed BEFORE seal-building and
-  // publishAsync has no outer rollback, so an unexpected throw inside buildAsyncLiftSeal
-  // (transient store read, slice/validation race, signer failure) must degrade to a
-  // SEALLESS lift — never orphan the staged capture or swallow the captureID.
-  it('async publish degrades to sealless (no orphaned write) when seal-building throws', async () => {
+  it('async publish fails closed without enqueuing when finalization throws', async () => {
     const { agent, store } = await createAgent('AsyncSealThrowBot');
     await agent.createContextGraph({ id: 'async-seal-throw', name: 'AsyncSealThrow', description: '' });
     await agent.registerContextGraph('async-seal-throw');
 
-    // Force the seal pipeline to throw, simulating a transient failure after the
-    // (already-committed) workspace write.
-    (agent as unknown as { buildAsyncLiftSeal: () => Promise<undefined> }).buildAsyncLiftSeal =
+    (agent as unknown as { assertionFinalize: (...args: unknown[]) => Promise<never> }).assertionFinalize =
       async () => {
-        throw new Error('simulated transient seal-build failure');
+        throw new Error('simulated finalization failure');
       };
 
-    const { captureID } = await agent.publishAsync(
-      'did:dkg:context-graph:async-seal-throw',
-      {
-        public: {
-          '@context': 'http://schema.org/',
-          '@id': 'http://example.org/ThrowEntity',
-          '@type': 'Thing',
-          'name': 'Throw',
+    await expect(
+      agent.publishAsync(
+        'did:dkg:context-graph:async-seal-throw',
+        {
+          public: {
+            '@context': 'http://schema.org/',
+            '@id': 'http://example.org/ThrowEntity',
+            '@type': 'Thing',
+            'name': 'Throw',
+          },
         },
-      },
-      { localOnly: true },
-    );
-    // The capture was still enqueued (NOT orphaned) and returned a usable captureID.
-    expect(captureID).toBeTruthy();
+        { localOnly: true },
+      ),
+    ).rejects.toThrow(/simulated finalization failure/);
 
     const asyncPublisher = new TripleStoreAsyncLiftPublisher(store);
-    const job = await asyncPublisher.getStatus(captureID);
-    expect(job).not.toBeNull();
-    // Sealless: the lift carries no seal, so the publisher stages WM/SWM without an
-    // on-chain VM anchor (exactly the prior always-sealless async behaviour).
-    expect(expectRawLiftRequest(job).seal).toBeUndefined();
+    expect(await asyncPublisher.list()).toEqual([]);
   }, CHAIN_JSONLD_TIMEOUT_MS);
 
-  // OT-RFC-43 §F2 — the sealless backstop is ONLY for the implicit machine-capture
-  // path. An EXPLICIT authorship request (custodial authorAgentAddress / self-sovereign
-  // callback) that fails to seal must surface — silently enqueuing an unauthored job
-  // and reporting success would hide that the requested attestation never happened.
-  it('async publish re-throws (does not silently go sealless) when an EXPLICIT author seal-build fails', async () => {
-    const { agent } = await createAgent('AsyncSealExplicitThrowBot');
+  it('async publish does not enqueue when an explicit-author finalization fails', async () => {
+    const { agent, store } = await createAgent('AsyncSealExplicitThrowBot');
     await agent.createContextGraph({ id: 'async-seal-explicit-throw', name: 'AsyncSealExplicitThrow', description: '' });
     await agent.registerContextGraph('async-seal-explicit-throw');
     const tenant = await agent.registerAgent('ExplicitTenant');
 
-    (agent as unknown as { buildAsyncLiftSeal: () => Promise<undefined> }).buildAsyncLiftSeal =
+    (agent as unknown as { assertionFinalize: (...args: unknown[]) => Promise<never> }).assertionFinalize =
       async () => {
         throw new Error('simulated signer failure');
       };
@@ -668,6 +687,9 @@ describe('publishJsonLd', () => {
         { localOnly: true, authorAgentAddress: tenant.agentAddress },
       ),
     ).rejects.toThrow(/simulated signer failure/);
+
+    const asyncPublisher = new TripleStoreAsyncLiftPublisher(store);
+    expect(await asyncPublisher.list()).toEqual([]);
   }, CHAIN_JSONLD_TIMEOUT_MS);
 
   // OT-RFC-43 §F2 — V10-ready + on-chain CG ⇒ the agent signs the canonical merkle
@@ -694,7 +716,7 @@ describe('publishJsonLd', () => {
 
     const asyncPublisher = new TripleStoreAsyncLiftPublisher(store);
     const job = await asyncPublisher.getStatus(captureID);
-    const request = expectRawLiftRequest(job);
+    const request = expectQueuedKaRequest(job);
     expect(request.seal).toBeDefined();
     expect(request.seal?.merkleRoot).toMatch(/^0x[0-9a-f]{64}$/i);
   }, CHAIN_JSONLD_TIMEOUT_MS);
@@ -720,7 +742,7 @@ describe('publishJsonLd', () => {
 
     const asyncPublisher = new TripleStoreAsyncLiftPublisher(store);
     const job = await asyncPublisher.getStatus(captureID);
-    expect(expectRawLiftRequest(job).seal).toBeDefined();
+    expect(expectQueuedKaRequest(job).seal).toBeDefined();
   }, CHAIN_JSONLD_TIMEOUT_MS);
 
   // OT-RFC-43 §F2 — disk-externalized public snapshots still resolve into the seal's
@@ -764,18 +786,18 @@ describe('publishJsonLd', () => {
 
     const asyncPublisher = new TripleStoreAsyncLiftPublisher(store);
     const job = await asyncPublisher.getStatus(captureID);
-    const request = expectRawLiftRequest(job);
+    const request = expectQueuedKaRequest(job);
     expect(request.seal).toBeDefined();
     expect(request.seal?.merkleRoot).toMatch(/^0x[0-9a-f]{64}$/i);
   }, CHAIN_JSONLD_TIMEOUT_MS);
 
-  it('async publish accepts preSignedAuthorAttestation and threads it byte-for-byte into LiftRequest.seal', async () => {
-    // Sync parity: caller pre-signs off-node, agent threads bytes verbatim. Publisher preflight validates at processNext.
+  it('async publish rejects a pre-signed attestation for a different canonical payload', async () => {
     const { agent, store } = await createAgent('AsyncSealPreSignedBot');
     await agent.createContextGraph({ id: 'async-seal-presigned', name: 'AsyncSealPreSigned', description: '' });
     await agent.registerContextGraph('async-seal-presigned');
 
-    // Arbitrary bytes — this test is passthrough wiring, not seal validity.
+    // A caller cannot enqueue arbitrary signature bytes against an unrelated
+    // merkle root: finalization binds the attestation to the canonical KA graph.
     const expectedMerkleRoot = new Uint8Array(32).fill(0xab);
     // Valid EIP-55 address (publishAsync getAddress-validates the attested author).
     const customAuthor = ethers.getAddress('0x' + 'ab'.repeat(20));
@@ -785,39 +807,32 @@ describe('publishJsonLd', () => {
     // (high 160 bits == author); publishAsync rejects it otherwise.
     const presignedReservedKaId = (BigInt(customAuthor) << 96n) | 7n;
 
-    const { captureID } = await agent.publishAsync(
-      'did:dkg:context-graph:async-seal-presigned',
-      {
-        public: {
-          '@context': 'http://schema.org/',
-          '@id': 'http://example.org/PreSignedEntity',
-          '@type': 'Thing',
-          'name': 'PreSigned',
+    await expect(
+      agent.publishAsync(
+        'did:dkg:context-graph:async-seal-presigned',
+        {
+          public: {
+            '@context': 'http://schema.org/',
+            '@id': 'http://example.org/PreSignedEntity',
+            '@type': 'Thing',
+            'name': 'PreSigned',
+          },
         },
-      },
-      {
-        localOnly: true,
-        preSignedAuthorAttestation: {
-          expectedMerkleRoot,
-          authorAddress: customAuthor,
-          signature: { r: sigR, vs: sigVs },
-          schemeVersion: 1,
-          reservedKaId: presignedReservedKaId,
+        {
+          localOnly: true,
+          preSignedAuthorAttestation: {
+            expectedMerkleRoot,
+            authorAddress: customAuthor,
+            signature: { r: sigR, vs: sigVs },
+            schemeVersion: 1,
+            reservedKaId: presignedReservedKaId,
+          },
         },
-      },
-    );
+      ),
+    ).rejects.toThrow(/expectedMerkleRoot mismatch/);
 
     const asyncPublisher = new TripleStoreAsyncLiftPublisher(store);
-    const job = await asyncPublisher.getStatus(captureID);
-    const seal = expectRawLiftRequest(job).seal;
-    expect(seal).toBeDefined();
-    expect(seal?.merkleRoot).toBe('0x' + 'ab'.repeat(32));
-    expect(seal?.authorAddress.toLowerCase()).toBe(customAuthor.toLowerCase());
-    expect(seal?.signature.r).toBe('0x' + 'bb'.repeat(32));
-    expect(seal?.signature.vs).toBe('0x' + 'cc'.repeat(32));
-    expect(seal?.schemeVersion).toBe(1);
-    // §F2 — the attested reservedKaId is threaded byte-for-byte onto the seal.
-    expect(seal?.reservedKaId).toBe(`${presignedReservedKaId}`);
+    expect(await asyncPublisher.list()).toEqual([]);
   }, CHAIN_JSONLD_TIMEOUT_MS);
 
   it('async publish rejects preSignedAuthorAttestation + authorAgentAddress as mutually exclusive', async () => {
@@ -906,7 +921,7 @@ describe('publishJsonLd', () => {
 
     const asyncPublisher = new TripleStoreAsyncLiftPublisher(store);
     const job = await asyncPublisher.getStatus(captureID);
-    const seal = expectRawLiftRequest(job).seal;
+    const seal = expectQueuedKaRequest(job).seal;
     expect(seal).toBeDefined();
     expect(seal?.authorAddress.toLowerCase()).toBe(selfSov.agentAddress.toLowerCase());
     // §F2 — reservedKaId is allocated in the self-sovereign author's namespace and
@@ -1017,16 +1032,12 @@ describe('publishJsonLd', () => {
       },
     );
 
-    // Drive processNext with the agent's own internal publisher so
-    // wallets + chain adapter match what enqueued the job.
-    const internalPublisher = (agent as unknown as {
-      publisher: {
-        publish: (opts: unknown) => Promise<{ status: string; onChainResult?: { batchId: bigint } }>;
-      };
-    }).publisher;
+    // Drive processNext through the same named-KA handler as production.
     const runner = new TripleStoreAsyncLiftPublisher(store, {
-      publishExecutor: async ({ publishOptions }) => {
-        return internalPublisher.publish(publishOptions) as Promise<any>;
+      knowledgeAssetVmPublishHandler: {
+        preflight: ({ request }) => agent.preflightQueuedKnowledgeAssetVmPublishExecution(request),
+        execute: ({ request, publishOptions }) =>
+          agent.publishQueuedKnowledgeAssetVmPublish(request, publishOptions),
       },
     });
     const finalized = await runner.processNext(publisherAddress);
@@ -1046,34 +1057,43 @@ describe('publishJsonLd', () => {
     expect(onChainAuthor.toLowerCase()).not.toBe(publisherAddress.toLowerCase());
   }, CHAIN_JSONLD_TIMEOUT_MS);
 
-  it('async publish threads opts.priorVersion into LiftRequest.priorVersion', async () => {
-    // `priorVersion` threads through enqueue unchanged for MUTATE/REVOKE transitions.
+  it('async publish rejects legacy transition metadata before enqueuing', async () => {
     const { agent, store } = await createAgent('AsyncPriorVerBot');
     await agent.createContextGraph({ id: 'async-priorver', name: 'AsyncPriorVer', description: '' });
     await agent.registerContextGraph('async-priorver');
 
-    const { captureID } = await agent.publishAsync(
-      'did:dkg:context-graph:async-priorver',
-      {
-        public: {
-          '@context': 'http://schema.org/',
-          '@id': 'http://example.org/PriorVerEntity',
-          '@type': 'Thing',
-          'name': 'PriorVer',
+    const content = {
+      public: {
+        '@context': 'http://schema.org/',
+        '@id': 'http://example.org/PriorVerEntity',
+        '@type': 'Thing',
+        'name': 'PriorVer',
+      },
+    };
+    await expect(
+      agent.publishAsync(
+        'did:dkg:context-graph:async-priorver',
+        content,
+        {
+          localOnly: true,
+          transitionType: 'MUTATE',
         },
-      },
-      {
-        localOnly: true,
-        transitionType: 'MUTATE',
-        priorVersion: 'did:dkg:mock:31337/0xabc/7',
-      },
-    );
+      ),
+    ).rejects.toThrow(/use the KA update API/);
+    await expect(
+      agent.publishAsync(
+        'did:dkg:context-graph:async-priorver',
+        content,
+        {
+          localOnly: true,
+          transitionType: 'CREATE',
+          priorVersion: 'did:dkg:mock:31337/0xabc/7',
+        },
+      ),
+    ).rejects.toThrow(/priorVersion is only valid for the legacy root-lift path/);
 
     const asyncPublisher = new TripleStoreAsyncLiftPublisher(store);
-    const job = await asyncPublisher.getStatus(captureID);
-    const request = expectRawLiftRequest(job);
-    expect(request.priorVersion).toBe('did:dkg:mock:31337/0xabc/7');
-    expect(request.transitionType).toBe('MUTATE');
+    expect(await asyncPublisher.list()).toEqual([]);
   }, CHAIN_JSONLD_TIMEOUT_MS);
 
   it('async publish threads opts.entityProofs into LiftRequest.entityProofs', async () => {
@@ -1100,7 +1120,7 @@ describe('publishJsonLd', () => {
 
     const asyncPublisher = new TripleStoreAsyncLiftPublisher(store);
     const job = await asyncPublisher.getStatus(captureID);
-    expect(expectRawLiftRequest(job).entityProofs).toBe(true);
+    expect(expectQueuedKaRequest(job).entityProofs).toBe(true);
   }, CHAIN_JSONLD_TIMEOUT_MS);
 
   it('async publish threads opts.publisherNodeIdentityIdOverride (bigint) into LiftRequest (stringified)', async () => {
@@ -1127,7 +1147,7 @@ describe('publishJsonLd', () => {
 
     const asyncPublisher = new TripleStoreAsyncLiftPublisher(store);
     const job = await asyncPublisher.getStatus(captureID);
-    expect(expectRawLiftRequest(job).publisherNodeIdentityIdOverride).toBe('42');
+    expect(expectQueuedKaRequest(job).publisherNodeIdentityIdOverride).toBe('42');
   }, CHAIN_JSONLD_TIMEOUT_MS);
 
   it('async publish preserves publisherNodeIdentityIdOverride === 0n (mode d "no attribution")', async () => {
@@ -1154,11 +1174,10 @@ describe('publishJsonLd', () => {
 
     const asyncPublisher = new TripleStoreAsyncLiftPublisher(store);
     const job = await asyncPublisher.getStatus(captureID);
-    expect(expectRawLiftRequest(job).publisherNodeIdentityIdOverride).toBe('0');
+    expect(expectQueuedKaRequest(job).publisherNodeIdentityIdOverride).toBe('0');
   }, CHAIN_JSONLD_TIMEOUT_MS);
 
-  it('async publish enqueues sealless when no signer is available (sync parity)', async () => {
-    // Chain-prereq failures downgrade to sealless enqueue. Publisher decides at processNext.
+  it('async publish fails closed without enqueuing when no signer is available', async () => {
     const { agent, store } = await createAgent('AsyncSealNoSigner');
     await agent.createContextGraph({ id: 'async-no-signer', name: 'AsyncNoSigner', description: '' });
     await agent.registerContextGraph('async-no-signer');
@@ -1168,22 +1187,23 @@ describe('publishJsonLd', () => {
     publisher.publisherFallbackAuthorAddress = async () => undefined;
 
     try {
-      const { captureID } = await agent.publishAsync(
-        'did:dkg:context-graph:async-no-signer',
-        {
-          public: {
-            '@context': 'http://schema.org/',
-            '@id': 'http://example.org/NoSignerEntity',
-            '@type': 'Thing',
-            'name': 'NoSigner',
+      await expect(
+        agent.publishAsync(
+          'did:dkg:context-graph:async-no-signer',
+          {
+            public: {
+              '@context': 'http://schema.org/',
+              '@id': 'http://example.org/NoSignerEntity',
+              '@type': 'Thing',
+              'name': 'NoSigner',
+            },
           },
-        },
-        { localOnly: true },
-      );
+          { localOnly: true },
+        ),
+      ).rejects.toThrow(/no author signer is available/);
 
       const asyncPublisher = new TripleStoreAsyncLiftPublisher(store);
-      const job = await asyncPublisher.getStatus(captureID);
-      expect(expectRawLiftRequest(job).seal).toBeUndefined();
+      expect(await asyncPublisher.list()).toEqual([]);
     } finally {
       publisher.publisherFallbackAuthorAddress = original;
     }
@@ -1241,8 +1261,7 @@ describe('publishJsonLd', () => {
     }
   }, CHAIN_JSONLD_TIMEOUT_MS);
 
-  it('async publish enqueues sealless when CG is not registered on-chain (sync parity)', async () => {
-    // CG without on-chain id → no seal, publisher goes tentative (matches sync `agent.publish`).
+  it('async publish seals a rootless KA even when its CG is not registered on-chain yet', async () => {
     const { agent, store } = await createAgent('AsyncNoOnChainBot');
     await agent.createContextGraph({ id: 'async-no-onchain', name: 'AsyncNoOnChain', description: '' });
     // Intentionally skip registerContextGraph so the CG has no on-chain id.
@@ -1262,12 +1281,13 @@ describe('publishJsonLd', () => {
 
     const asyncPublisher = new TripleStoreAsyncLiftPublisher(store);
     const job = await asyncPublisher.getStatus(captureID);
-    expect(expectRawLiftRequest(job).seal).toBeUndefined();
+    const request = expectQueuedKaRequest(job);
+    expect(request.seal).toBeDefined();
+    expect(request.contentScopeVersion).toBe(2);
+    expect(request.roots).toEqual([]);
   }, CHAIN_JSONLD_TIMEOUT_MS);
 
-  it('async publish seal reflects subtracted set when canonical root already confirmed (codex PR #455 #3)', async () => {
-    // Agent must mirror publisher's `subtractFinalizedExactQuads` so both compute the same merkle.
-    // Pre-populate confirmed state matching the canonical root; publishAsync same root → full overlap → seal undefined.
+  it('async publish does not subtract a new atomic KA against legacy root metadata', async () => {
     const { agent, store } = await createAgent('AsyncSubtractObserve');
     await agent.createContextGraph({ id: 'async-subtract-observe', name: 'AsyncSubtractObs', description: '' });
     await agent.registerContextGraph('async-subtract-observe');
@@ -1289,7 +1309,8 @@ describe('publishJsonLd', () => {
       { subject: canonical, predicate: 'http://example.org/p', object: '"hello"', graph: dataGraph },
     ]);
 
-    // publishAsync the same root/triple — full overlap → seal undefined.
+    // The submitted graph is a new KA even if an older root-addressed asset
+    // happens to contain an identical triple.
     const { captureID } = await agent.publishAsync(
       'async-subtract-observe',
       {
@@ -1301,11 +1322,10 @@ describe('publishJsonLd', () => {
 
     const asyncPublisher = new TripleStoreAsyncLiftPublisher(store);
     const job = await asyncPublisher.getStatus(captureID);
-    // Full overlap with confirmed state → buildAsyncLiftSeal returns
-    // undefined (short-circuit at `dkg-agent.ts` post-subtraction).
-    // If subtraction is removed from the agent pipeline, the seal
-    // would be present here.
-    expect(expectRawLiftRequest(job).seal).toBeUndefined();
+    const request = expectQueuedKaRequest(job);
+    expect(request.seal).toBeDefined();
+    expect(request.contentScopeVersion).toBe(2);
+    expect(request.roots).toEqual([]);
   }, CHAIN_JSONLD_TIMEOUT_MS);
 
   it('async publish records and resolves subGraphName for staged public and private data', async () => {
@@ -1336,8 +1356,10 @@ describe('publishJsonLd', () => {
 
     const asyncPublisher = new TripleStoreAsyncLiftPublisher(store);
     const job = await asyncPublisher.getStatus(captureID);
-    const request = expectRawLiftRequest(job);
+    const request = expectQueuedKaRequest(job);
     expect(request.subGraphName).toBe('research');
-    expect(request.roots).toContain(root);
+    expect(request.contentScopeVersion).toBe(2);
+    expect(request.roots).toEqual([]);
+    expect(request.accessPolicy).toBe('ownerOnly');
   }, CHAIN_JSONLD_TIMEOUT_MS);
 });

--- a/packages/agent/test/publish-jsonld.test.ts
+++ b/packages/agent/test/publish-jsonld.test.ts
@@ -297,7 +297,11 @@ describe('publishJsonLd', () => {
           'name': 'Private Async',
         },
       },
-      { localOnly: true, accessPolicy: 'allowList', allowedPeers: ['peer-a'] },
+      {
+        localOnly: true,
+        accessPolicy: 'allowList',
+        allowedPeers: [' peer-b ', 'peer-a', 'peer-b'],
+      },
     );
 
     const asyncPublisher = new TripleStoreAsyncLiftPublisher(store);
@@ -307,7 +311,19 @@ describe('publishJsonLd', () => {
     expect(request.contentScopeVersion).toBe(2);
     expect(request.kaUal).toMatch(/^did:dkg:[^/]+\/0x[0-9a-f]{40}\/\d+$/);
     expect(request.accessPolicy).toBe('allowList');
-    expect(request.allowedPeers).toEqual(['peer-a']);
+    expect(request.allowedPeers).toEqual(['peer-a', 'peer-b']);
+    const reResolved = await agent.resolveFinalizedAssertionVmPublishIntent(
+      'did:dkg:context-graph:async-priv-only',
+      request.name,
+      {
+        agentAddress: request.agentAddress,
+        accessPolicy: 'allowList',
+        allowedPeers: ['peer-b', 'peer-a'],
+      },
+    );
+    expect(reResolved.accessPolicy).toBe('allowList');
+    expect(reResolved.allowedPeers).toEqual(['peer-a', 'peer-b']);
+    expect(reResolved.intentKey).toBe(request.intentKey);
     // Keep this resilient to control-plane tuning (defaults changed in main).
     expect(job?.retries.maxRetries).toBeGreaterThan(0);
 
@@ -835,6 +851,84 @@ describe('publishJsonLd', () => {
     expect(await asyncPublisher.list()).toEqual([]);
   }, CHAIN_JSONLD_TIMEOUT_MS);
 
+  it('async publish accepts a valid off-node pre-signed author attestation unchanged', async () => {
+    const externalAuthor = ethers.Wallet.createRandom();
+    const content = {
+      public: {
+        '@context': 'http://schema.org/',
+        '@id': 'http://example.org/ValidPreSignedEntity',
+        '@type': 'Thing',
+        'name': 'Valid PreSigned',
+      },
+    };
+
+    // Produce the canonical seal through the callback signing path. Each test
+    // agent has a fresh deterministic KA allocator, so the second agent derives
+    // the same author-scoped UAL and can exercise the pre-signed input path.
+    const source = await createAgent('AsyncValidPreSignedSourceBot');
+    await source.agent.createContextGraph({
+      id: 'async-valid-presigned-source',
+      name: 'AsyncValidPreSignedSource',
+      description: '',
+    });
+    await source.agent.registerContextGraph('async-valid-presigned-source');
+    const sourceCapture = await source.agent.publishAsync(
+      'did:dkg:context-graph:async-valid-presigned-source',
+      content,
+      {
+        localOnly: true,
+        authorAgentAddress: externalAuthor.address,
+        authorSignTypedData: async (typedData) => {
+          const signature = ethers.Signature.from(await externalAuthor.signTypedData(
+            typedData.domain,
+            typedData.types,
+            typedData.message,
+          ));
+          return {
+            r: ethers.getBytes(signature.r),
+            vs: ethers.getBytes(signature.yParityAndS),
+          };
+        },
+      },
+    );
+    const sourceQueue = new TripleStoreAsyncLiftPublisher(source.store);
+    const sourceRequest = expectQueuedKaRequest(
+      await sourceQueue.getStatus(sourceCapture.captureID),
+    );
+
+    const target = await createAgent('AsyncValidPreSignedTargetBot');
+    await target.agent.createContextGraph({
+      id: 'async-valid-presigned-target',
+      name: 'AsyncValidPreSignedTarget',
+      description: '',
+    });
+    await target.agent.registerContextGraph('async-valid-presigned-target');
+    const targetCapture = await target.agent.publishAsync(
+      'did:dkg:context-graph:async-valid-presigned-target',
+      content,
+      {
+        localOnly: true,
+        preSignedAuthorAttestation: {
+          expectedMerkleRoot: ethers.getBytes(sourceRequest.seal.merkleRoot),
+          authorAddress: sourceRequest.seal.authorAddress,
+          signature: {
+            r: ethers.getBytes(sourceRequest.seal.signature.r),
+            vs: ethers.getBytes(sourceRequest.seal.signature.vs),
+          },
+          schemeVersion: sourceRequest.seal.schemeVersion,
+          reservedKaId: BigInt(sourceRequest.seal.reservedKaId!),
+        },
+      },
+    );
+    const targetQueue = new TripleStoreAsyncLiftPublisher(target.store);
+    const targetRequest = expectQueuedKaRequest(
+      await targetQueue.getStatus(targetCapture.captureID),
+    );
+
+    expect(targetRequest.seal).toEqual(sourceRequest.seal);
+    expect(targetRequest.seal.authorAddress).toBe(externalAuthor.address);
+  }, CHAIN_JSONLD_TIMEOUT_MS);
+
   it('async publish rejects preSignedAuthorAttestation + authorAgentAddress as mutually exclusive', async () => {
     // Sync parity: pick one signing path (caller-provided seal OR daemon custodial).
     const { agent } = await createAgent('AsyncSealMutexBot');
@@ -1096,31 +1190,31 @@ describe('publishJsonLd', () => {
     expect(await asyncPublisher.list()).toEqual([]);
   }, CHAIN_JSONLD_TIMEOUT_MS);
 
-  it('async publish threads opts.entityProofs into LiftRequest.entityProofs', async () => {
-    // V10 selective-disclosure flag persists through enqueue.
+  it('async publish rejects unsupported graph-scoped entity proofs before enqueue', async () => {
     const { agent, store } = await createAgent('AsyncEntityProofsBot');
     await agent.createContextGraph({ id: 'async-entity-proofs', name: 'AsyncEntityProofs', description: '' });
     await agent.registerContextGraph('async-entity-proofs');
 
-    const { captureID } = await agent.publishAsync(
-      'did:dkg:context-graph:async-entity-proofs',
-      {
-        public: {
-          '@context': 'http://schema.org/',
-          '@id': 'http://example.org/EntityProofsRoot',
-          '@type': 'Thing',
-          'name': 'EntityProofs',
+    await expect(
+      agent.publishAsync(
+        'did:dkg:context-graph:async-entity-proofs',
+        {
+          public: {
+            '@context': 'http://schema.org/',
+            '@id': 'http://example.org/EntityProofsRoot',
+            '@type': 'Thing',
+            'name': 'EntityProofs',
+          },
         },
-      },
-      {
-        localOnly: true,
-        entityProofs: true,
-      },
-    );
+        {
+          localOnly: true,
+          entityProofs: true,
+        },
+      ),
+    ).rejects.toThrow(/does not support entityProofs/);
 
     const asyncPublisher = new TripleStoreAsyncLiftPublisher(store);
-    const job = await asyncPublisher.getStatus(captureID);
-    expect(expectQueuedKaRequest(job).entityProofs).toBe(true);
+    expect(await asyncPublisher.list()).toEqual([]);
   }, CHAIN_JSONLD_TIMEOUT_MS);
 
   it('async publish threads opts.publisherNodeIdentityIdOverride (bigint) into LiftRequest (stringified)', async () => {

--- a/packages/agent/test/publish-jsonld.test.ts
+++ b/packages/agent/test/publish-jsonld.test.ts
@@ -1190,6 +1190,44 @@ describe('publishJsonLd', () => {
     expect(await asyncPublisher.list()).toEqual([]);
   }, CHAIN_JSONLD_TIMEOUT_MS);
 
+  it('async publish rejects invalid access envelopes before lifecycle mutation or enqueue', async () => {
+    const { agent, store } = await createAgent('AsyncInvalidAccessEnvelopeBot');
+    await agent.createContextGraph({
+      id: 'async-invalid-access-envelope',
+      name: 'AsyncInvalidAccessEnvelope',
+      description: '',
+    });
+    await agent.registerContextGraph('async-invalid-access-envelope');
+    const content = {
+      public: {
+        '@context': 'http://schema.org/',
+        '@id': 'http://example.org/InvalidAccessEnvelope',
+        '@type': 'Thing',
+        'name': 'Invalid access envelope',
+      },
+    };
+    const metadataBefore = await store.query(
+      'CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <did:dkg:context-graph:async-invalid-access-envelope/_meta> { ?s ?p ?o } }',
+    );
+
+    await expect(agent.publishAsync(
+      'did:dkg:context-graph:async-invalid-access-envelope',
+      content,
+      { localOnly: true, accessPolicy: 'allowList' },
+    )).rejects.toThrow(/allowList policy requires allowedPeers/);
+    await expect(agent.publishAsync(
+      'did:dkg:context-graph:async-invalid-access-envelope',
+      content,
+      { localOnly: true, accessPolicy: 'public', allowedPeers: ['peer-a'] },
+    )).rejects.toThrow(/allowedPeers requires allowList policy/);
+
+    const metadataAfter = await store.query(
+      'CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <did:dkg:context-graph:async-invalid-access-envelope/_meta> { ?s ?p ?o } }',
+    );
+    expect(metadataAfter).toEqual(metadataBefore);
+    expect(await new TripleStoreAsyncLiftPublisher(store).list()).toEqual([]);
+  }, CHAIN_JSONLD_TIMEOUT_MS);
+
   it('async publish rejects unsupported graph-scoped entity proofs before enqueue', async () => {
     const { agent, store } = await createAgent('AsyncEntityProofsBot');
     await agent.createContextGraph({ id: 'async-entity-proofs', name: 'AsyncEntityProofs', description: '' });

--- a/packages/agent/test/queued-publish-options.test.ts
+++ b/packages/agent/test/queued-publish-options.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  prepareQueuedKnowledgeAssetVmPublishOptions,
+  queuedKnowledgeAssetAccessEnvelope,
+} from '../src/dkg-agent-publish.js';
+
+describe('prepareQueuedKnowledgeAssetVmPublishOptions', () => {
+  const snapshotQuads = [{
+    subject: 'urn:test:asset',
+    predicate: 'http://schema.org/name',
+    object: '"public"',
+    graph: '',
+  }];
+
+  it('treats a live public policy result as authoritative over queued fail-closed callbacks', () => {
+    const queuedInline = vi.fn();
+    const queuedChunked = vi.fn();
+
+    const prepared = prepareQueuedKnowledgeAssetVmPublishOptions({
+      contextGraphId: 'public-cg',
+      snapshotQuads,
+      onChainContextGraphId: '7',
+      resolvedEncryptInlinePayload: undefined,
+      resolvedEncryptInlineChunked: undefined,
+      queuedEncryptInlinePayload: queuedInline,
+      queuedEncryptInlineChunked: queuedChunked,
+    });
+
+    expect(prepared.quads).toEqual(snapshotQuads);
+    expect(prepared.encryptInlinePayload).toBeUndefined();
+    expect(prepared.encryptInlineChunked).toBeUndefined();
+    expect(prepared.trustedNonManifestCatalogTriples).toBeUndefined();
+  });
+
+  it('retains queued fail-closed callbacks only when no live on-chain policy was resolved', () => {
+    const queuedInline = vi.fn();
+    const queuedChunked = vi.fn();
+
+    const prepared = prepareQueuedKnowledgeAssetVmPublishOptions({
+      contextGraphId: 'chainless-cg',
+      snapshotQuads,
+      resolvedEncryptInlinePayload: undefined,
+      resolvedEncryptInlineChunked: undefined,
+      queuedEncryptInlinePayload: queuedInline,
+      queuedEncryptInlineChunked: queuedChunked,
+    });
+
+    expect(prepared.encryptInlinePayload).toBe(queuedInline);
+    expect(prepared.encryptInlineChunked).toBe(queuedChunked);
+  });
+
+  it('preserves an owner-only envelope for the queued update entrypoint', () => {
+    expect(queuedKnowledgeAssetAccessEnvelope({ accessPolicy: 'ownerOnly' })).toEqual({
+      accessPolicy: 'ownerOnly',
+      allowedPeers: undefined,
+    });
+  });
+
+  it('copies the immutable allow-list for the queued update entrypoint', () => {
+    const allowedPeers = ['peer-a', 'peer-b'];
+    const envelope = queuedKnowledgeAssetAccessEnvelope({
+      accessPolicy: 'allowList',
+      allowedPeers,
+    });
+
+    expect(envelope).toEqual({ accessPolicy: 'allowList', allowedPeers });
+    expect(envelope.allowedPeers).not.toBe(allowedPeers);
+  });
+});

--- a/packages/agent/test/queued-publish-options.test.ts
+++ b/packages/agent/test/queued-publish-options.test.ts
@@ -3,6 +3,10 @@ import {
   prepareQueuedKnowledgeAssetVmPublishOptions,
   queuedKnowledgeAssetAccessEnvelope,
 } from '../src/dkg-agent-publish.js';
+import {
+  computeKnowledgeAssetVmPublishIntentKey,
+  type KnowledgeAssetVmPublishIntent,
+} from '../src/knowledge-asset-vm-publish-intent.js';
 
 describe('prepareQueuedKnowledgeAssetVmPublishOptions', () => {
   const snapshotQuads = [{
@@ -65,5 +69,96 @@ describe('prepareQueuedKnowledgeAssetVmPublishOptions', () => {
 
     expect(envelope).toEqual({ accessPolicy: 'allowList', allowedPeers });
     expect(envelope.allowedPeers).not.toBe(allowedPeers);
+  });
+});
+
+describe('computeKnowledgeAssetVmPublishIntentKey', () => {
+  const hex = (byte: string, count: number) => `0x${byte.repeat(count)}` as `0x${string}`;
+  const base: KnowledgeAssetVmPublishIntent = {
+    contextGraphId: 'cg-a',
+    name: 'asset-a',
+    agentAddress: '0x1111111111111111111111111111111111111111',
+    subGraphName: 'research',
+    shareOperationId: 'share-a',
+    roots: [],
+    contentScopeVersion: 2,
+    kaUal: 'did:dkg:mock:31337/0x1111111111111111111111111111111111111111/7',
+    assertionVersion: '1',
+    publicTripleCount: 2,
+    privateMerkleRoot: hex('11', 32),
+    privateTripleCount: 1,
+    accessPolicy: 'allowList',
+    allowedPeers: ['peer-a'],
+    entityProofs: false,
+    seal: {
+      merkleRoot: hex('22', 32),
+      authorAddress: hex('11', 20),
+      signature: { r: hex('33', 32), vs: hex('44', 32) },
+      schemeVersion: 1,
+      reservedKaId: '7',
+    },
+    sealChainId: '31337',
+    sealKav10Address: hex('55', 20),
+    sealFinalizedAtIso: '2026-07-15T00:00:00.000Z',
+    sealMerkleRoot: hex('22', 32),
+    wmCurrentAssertion: 'wm-a',
+    swmCurrentAssertion: 'swm-a',
+    vmCurrentAssertion: 'vm-a',
+    kaNumber: '7',
+    reservedUal: 'did:dkg:mock:31337/0x1111111111111111111111111111111111111111/7',
+    publishEpochs: 2,
+    clearSharedMemoryAfter: true,
+    publisherNodeIdentityIdOverride: '9',
+  };
+
+  it('binds every executable request field and ignores object insertion order', () => {
+    const baseKey = computeKnowledgeAssetVmPublishIntentKey(base);
+    const mutations: Array<[
+      string,
+      (request: KnowledgeAssetVmPublishIntent) => KnowledgeAssetVmPublishIntent,
+    ]> = [
+      ['contextGraphId', (v) => ({ ...v, contextGraphId: 'cg-b' })],
+      ['name', (v) => ({ ...v, name: 'asset-b' })],
+      ['agentAddress', (v) => ({ ...v, agentAddress: '0x2222222222222222222222222222222222222222' })],
+      ['subGraphName', (v) => ({ ...v, subGraphName: 'archive' })],
+      ['shareOperationId', (v) => ({ ...v, shareOperationId: 'share-b' })],
+      ['roots', (v) => ({ ...v, roots: ['urn:legacy:root'] })],
+      ['contentScopeVersion', (v) => ({ ...v, contentScopeVersion: 3 })],
+      ['kaUal', (v) => ({ ...v, kaUal: 'did:dkg:mock:31337/0x1111111111111111111111111111111111111111/8' })],
+      ['assertionVersion', (v) => ({ ...v, assertionVersion: '2' })],
+      ['publicTripleCount', (v) => ({ ...v, publicTripleCount: 3 })],
+      ['privateMerkleRoot', (v) => ({ ...v, privateMerkleRoot: hex('66', 32) })],
+      ['privateTripleCount', (v) => ({ ...v, privateTripleCount: 2 })],
+      ['accessPolicy', (v) => ({ ...v, accessPolicy: 'ownerOnly' })],
+      ['allowedPeers', (v) => ({ ...v, allowedPeers: ['peer-b'] })],
+      ['entityProofs', (v) => ({ ...v, entityProofs: true })],
+      ['seal.merkleRoot', (v) => ({ ...v, seal: { ...v.seal, merkleRoot: hex('77', 32) } })],
+      ['seal.authorAddress', (v) => ({ ...v, seal: { ...v.seal, authorAddress: hex('22', 20) } })],
+      ['seal.signature.r', (v) => ({ ...v, seal: { ...v.seal, signature: { ...v.seal.signature, r: hex('88', 32) } } })],
+      ['seal.signature.vs', (v) => ({ ...v, seal: { ...v.seal, signature: { ...v.seal.signature, vs: hex('99', 32) } } })],
+      ['seal.schemeVersion', (v) => ({ ...v, seal: { ...v.seal, schemeVersion: 2 } })],
+      ['seal.reservedKaId', (v) => ({ ...v, seal: { ...v.seal, reservedKaId: '8' } })],
+      ['sealChainId', (v) => ({ ...v, sealChainId: '1' })],
+      ['sealKav10Address', (v) => ({ ...v, sealKav10Address: hex('aa', 20) })],
+      ['sealFinalizedAtIso', (v) => ({ ...v, sealFinalizedAtIso: '2026-07-16T00:00:00.000Z' })],
+      ['sealMerkleRoot', (v) => ({ ...v, sealMerkleRoot: hex('bb', 32) })],
+      ['wmCurrentAssertion', (v) => ({ ...v, wmCurrentAssertion: 'wm-b' })],
+      ['swmCurrentAssertion', (v) => ({ ...v, swmCurrentAssertion: 'swm-b' })],
+      ['vmCurrentAssertion', (v) => ({ ...v, vmCurrentAssertion: 'vm-b' })],
+      ['kaNumber', (v) => ({ ...v, kaNumber: '8' })],
+      ['reservedUal', (v) => ({ ...v, reservedUal: 'did:dkg:mock:31337/0x1111111111111111111111111111111111111111/8' })],
+      ['publishEpochs', (v) => ({ ...v, publishEpochs: 3 })],
+      ['clearSharedMemoryAfter', (v) => ({ ...v, clearSharedMemoryAfter: false })],
+      ['publisherNodeIdentityIdOverride', (v) => ({ ...v, publisherNodeIdentityIdOverride: '10' })],
+    ];
+
+    for (const [field, mutate] of mutations) {
+      expect(computeKnowledgeAssetVmPublishIntentKey(mutate(base)), field).not.toBe(baseKey);
+    }
+
+    const reordered = Object.fromEntries(
+      Object.entries(base).reverse(),
+    ) as unknown as KnowledgeAssetVmPublishIntent;
+    expect(computeKnowledgeAssetVmPublishIntentKey(reordered)).toBe(baseKey);
   });
 });

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -67,6 +67,7 @@ export default defineConfig({
       "test/storage-ack-lifecycle-identity.test.ts",
       "test/v10-ack-provider-wiring.test.ts",
       "test/direct-rootless-publish.test.ts",
+      "test/queued-publish-options.test.ts",
       "test/agents-meta-policy.test.ts",
       "test/agents-meta-sync-wiring.test.ts",
       "test/network-identity-proof.test.ts",

--- a/packages/core/src/proto/workspace.ts
+++ b/packages/core/src/proto/workspace.ts
@@ -48,6 +48,8 @@ export const WorkspacePublishRequestSchema = new Type('WorkspacePublishRequest')
   .add(new Field('publicTripleCount', 15, 'uint32'))
   .add(new Field('privateMerkleRoot', 16, 'bytes'))
   .add(new Field('privateTripleCount', 17, 'uint32'))
+  .add(new Field('accessPolicy', 18, 'string'))
+  .add(new Field('allowedPeers', 19, 'string', 'repeated'))
   .add(WorkspaceManifestEntrySchema)
   .add(WorkspaceCASConditionSchema);
 
@@ -95,6 +97,10 @@ export interface WorkspacePublishRequestMsg {
   privateMerkleRoot?: Uint8Array;
   /** Number of private RDF triples committed by privateMerkleRoot. */
   privateTripleCount?: number;
+  /** Immutable graph-scoped access policy. */
+  accessPolicy?: 'public' | 'ownerOnly' | 'allowList';
+  /** Canonical peer allow-list when accessPolicy is allowList. */
+  allowedPeers?: string[];
 }
 
 export function encodeWorkspacePublishRequest(msg: WorkspacePublishRequestMsg): Uint8Array {

--- a/packages/core/test/proto-ka-content-scope.test.ts
+++ b/packages/core/test/proto-ka-content-scope.test.ts
@@ -51,12 +51,16 @@ describe('rootless KA graph scope wire contract', () => {
       publicTripleCount: 1_000,
       privateMerkleRoot: PRIVATE_ROOT,
       privateTripleCount: 11,
+      accessPolicy: 'allowList',
+      allowedPeers: ['12D3KooWReaderB', '12D3KooWReaderA'],
       subGraphName: 'updates',
     }));
 
     expect(decoded.kaUal).toBe(UAL);
     expect(decoded.manifest).toEqual([]);
     expect(decoded.subGraphName).toBe('updates');
+    expect(decoded.accessPolicy).toBe('allowList');
+    expect(decoded.allowedPeers).toEqual(['12D3KooWReaderB', '12D3KooWReaderA']);
     expectGraphScope(decoded);
   });
 

--- a/packages/publisher/src/async-lift-publish-options.ts
+++ b/packages/publisher/src/async-lift-publish-options.ts
@@ -1,6 +1,6 @@
 import { ethers } from 'ethers';
 import type { Quad } from '@origintrail-official/dkg-storage';
-import type { OperationContext } from '@origintrail-official/dkg-core';
+import { GRAPH_KA_CONTENT_SCOPE_VERSION, type OperationContext } from '@origintrail-official/dkg-core';
 import { MAX_PUBLISH_EPOCHS } from './publisher.js';
 import type {
   PhaseCallback,
@@ -172,6 +172,12 @@ export function mapLiftRequestToPublishOptions(input: LiftPublishMappingInput): 
 
   // Request flags (enqueue-time caller intent) win over resolved hints (per-process defaults).
   const entityProofs = input.request.entityProofs ?? input.resolved.entityProofs;
+  if (
+    input.request.contentScopeVersion === GRAPH_KA_CONTENT_SCOPE_VERSION
+    && entityProofs === true
+  ) {
+    throw new Error('Graph-scoped async publish does not support entityProofs');
+  }
   const publishEpochs = input.request.publishEpochs;
   if (publishEpochs !== undefined && (!Number.isSafeInteger(publishEpochs) || publishEpochs < 1 || publishEpochs > MAX_PUBLISH_EPOCHS)) {
     throw new Error(`Lift publish mapping requires request.publishEpochs to be a positive uint32 integer; got ${String(publishEpochs)}`);

--- a/packages/publisher/src/async-lift-publisher-impl.ts
+++ b/packages/publisher/src/async-lift-publisher-impl.ts
@@ -92,6 +92,9 @@ function assertGraphScopedLiftSnapshot(request: LiftPublishSnapshotRequest): voi
   if (request.roots.length !== 0) {
     throw new Error('Graph-scoped async publish must not contain root entities');
   }
+  if (request.entityProofs === true) {
+    throw new Error('Graph-scoped async publish does not support entityProofs');
+  }
   if (
     request.kaUal === undefined
     || request.assertionVersion === undefined

--- a/packages/publisher/src/async-lift-publisher-impl.ts
+++ b/packages/publisher/src/async-lift-publisher-impl.ts
@@ -119,6 +119,17 @@ function assertGraphScopedLiftSnapshot(request: LiftPublishSnapshotRequest): voi
   if (request.privateTripleCount === 0 && request.privateMerkleRoot !== undefined) {
     throw new Error('Graph-scoped async publish privateMerkleRoot requires private content');
   }
+  const accessPolicy = request.accessPolicy
+    ?? (request.privateTripleCount > 0 ? 'ownerOnly' : 'public');
+  const allowedPeers = [...new Set(
+    (request.allowedPeers ?? []).map((peerId) => peerId.trim()).filter(Boolean),
+  )];
+  if (accessPolicy === 'allowList' && allowedPeers.length === 0) {
+    throw new Error('Graph-scoped async publish allowList policy requires allowedPeers');
+  }
+  if (accessPolicy !== 'allowList' && allowedPeers.length > 0) {
+    throw new Error('Graph-scoped async publish allowedPeers requires allowList policy');
+  }
 }
 
 function resolveKnowledgeAssetVmPublishHandler(

--- a/packages/publisher/src/async-lift-publisher-utils.ts
+++ b/packages/publisher/src/async-lift-publisher-utils.ts
@@ -84,6 +84,15 @@ export function createKnowledgeAssetVmPublishSnapshotRequest(
     ...(request.privateTripleCount !== undefined
       ? { privateTripleCount: request.privateTripleCount }
       : {}),
+    ...(request.accessPolicy !== undefined
+      ? { accessPolicy: request.accessPolicy }
+      : {}),
+    ...(request.allowedPeers !== undefined
+      ? { allowedPeers: [...request.allowedPeers] }
+      : {}),
+    ...(request.entityProofs !== undefined
+      ? { entityProofs: request.entityProofs }
+      : {}),
     ...(request.subGraphName ? { subGraphName: request.subGraphName } : {}),
     ...(request.publishEpochs !== undefined ? { publishEpochs: request.publishEpochs } : {}),
     ...(request.publisherNodeIdentityIdOverride !== undefined
@@ -245,6 +254,9 @@ function parseKnowledgeAssetVmPublishRequest(value: unknown, path: string): Know
     ...optionalNumberField(record, 'publicTripleCount', path),
     ...optionalHexStringField(record, 'privateMerkleRoot', path),
     ...optionalNumberField(record, 'privateTripleCount', path),
+    ...optionalAccessPolicyField(record, 'accessPolicy', path),
+    ...optionalStringArrayField(record, 'allowedPeers', path),
+    ...optionalBooleanField(record, 'entityProofs', path),
     seal: parseSeal(record.seal, `${path}.seal`),
     sealChainId: expectBigIntString(record, 'sealChainId', path),
     sealKav10Address: expectHexString(record, 'sealKav10Address', path),

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -6738,6 +6738,11 @@ export class DKGPublisher implements Publisher {
       subGraphName?: string;
       publisherPeerId?: string;
       senderAgentAddress?: string;
+      /** Do not encrypt or emit a network-ready payload for a local capture. */
+      localOnly?: boolean;
+      /** Immutable access envelope persisted with the graph-scoped share. */
+      accessPolicy?: PublishOptions['accessPolicy'];
+      allowedPeers?: readonly string[];
       trustedNonManifestCatalogTriples?: PublishOptions['trustedNonManifestCatalogTriples'];
       onChainContextGraphId?: string | bigint;
       /**
@@ -6977,6 +6982,17 @@ export class DKGPublisher implements Publisher {
     );
     const normalizedQuads = normalizedParts.publicQuads;
     const normalizedPrivateQuads = normalizedParts.privateQuads;
+    const accessPolicy = opts?.accessPolicy
+      ?? (normalizedPrivateQuads.length > 0 ? 'ownerOnly' : 'public');
+    const allowedPeers = [...new Set(
+      (opts?.allowedPeers ?? []).map((peerId) => peerId.trim()).filter(Boolean),
+    )];
+    if (accessPolicy === 'allowList' && allowedPeers.length === 0) {
+      throw new Error('Graph-scoped assertion allowList policy requires allowedPeers');
+    }
+    if (accessPolicy !== 'allowList' && allowedPeers.length > 0) {
+      throw new Error('Graph-scoped assertion allowedPeers requires allowList policy');
+    }
     if (normalizedQuads.length !== seal.publicTripleCount) {
       throw new Error(
         `Graph-scoped assertion triple-count mismatch: seal=${seal.publicTripleCount}, ` +
@@ -7048,6 +7064,8 @@ export class DKGPublisher implements Publisher {
         publicTripleCount: normalizedQuads.length,
         ...(promotedPrivateRoot ? { privateMerkleRoot: promotedPrivateRoot } : {}),
         privateTripleCount: normalizedPrivateQuads.length,
+        accessPolicy,
+        allowedPeers,
       });
 
       // Wrap the plaintext publish-request in the encrypted envelope
@@ -7061,7 +7079,7 @@ export class DKGPublisher implements Publisher {
         contextGraphId,
         encoded,
         {
-          localOnly: false,
+          localOnly: opts?.localOnly === true,
           senderAgentAddress: opts.senderAgentAddress,
           operationId,
           shareOperationId: operationId,
@@ -7172,6 +7190,8 @@ export class DKGPublisher implements Publisher {
       ...(promotedPrivateRoot ? { privateMerkleRoot: promotedPrivateRoot } : {}),
       privateTripleCount: normalizedPrivateQuads.length,
       publisherPeerId: opts?.publisherPeerId,
+      accessPolicy,
+      allowedPeers,
       agentAddress: contentScope.agentAddress,
       subGraphName: opts?.subGraphName,
       timestamp: new Date(),

--- a/packages/publisher/src/lift-job-types.ts
+++ b/packages/publisher/src/lift-job-types.ts
@@ -58,6 +58,12 @@ export interface KnowledgeAssetVmPublishRequest {
   readonly privateMerkleRoot?: LiftJobHex;
   /** Exact private triple count committed by privateMerkleRoot. */
   readonly privateTripleCount?: number;
+  /** Immutable access policy captured with the queued SWM snapshot. */
+  readonly accessPolicy?: LiftAccessPolicy;
+  /** Canonical peer allow-list when accessPolicy is allowList. */
+  readonly allowedPeers?: readonly string[];
+  /** V10 selective-disclosure mode captured at enqueue. */
+  readonly entityProofs?: boolean;
   /** Author seal captured with the queued SWM share snapshot. */
   readonly seal: LiftRequestAuthorSeal;
   readonly sealChainId: LiftJobBigInt;

--- a/packages/publisher/src/workspace-handler.ts
+++ b/packages/publisher/src/workspace-handler.ts
@@ -1107,6 +1107,8 @@ export class SharedMemoryHandler {
         publicTripleCount,
         privateMerkleRoot,
         privateTripleCount,
+        accessPolicy: wireAccessPolicy,
+        allowedPeers: wireAllowedPeers,
       } = request;
       const shareOperationId = request.shareOperationId?.trim();
       const requestLifecycleFields: SharedMemoryLifecycleFields = {
@@ -1179,6 +1181,8 @@ export class SharedMemoryHandler {
       }
 
       let contentScope;
+      let graphAccessPolicy: 'public' | 'ownerOnly' | 'allowList';
+      let graphAllowedPeers: string[];
       try {
         contentScope = createGraphKnowledgeAssetScope(
           kaUal ?? '',
@@ -1222,6 +1226,23 @@ export class SharedMemoryHandler {
           throw new Error(
             'privateMerkleRoot requires a positive privateTripleCount',
           );
+        }
+        const normalizedWirePolicy = String(wireAccessPolicy ?? '').trim();
+        graphAccessPolicy = normalizedWirePolicy === ''
+          ? (privateCount > 0 ? 'ownerOnly' : 'public')
+          : normalizedWirePolicy === 'public'
+            || normalizedWirePolicy === 'ownerOnly'
+            || normalizedWirePolicy === 'allowList'
+            ? normalizedWirePolicy
+            : (() => { throw new Error(`invalid accessPolicy "${normalizedWirePolicy}"`); })();
+        graphAllowedPeers = [...new Set(
+          (wireAllowedPeers ?? []).map((peerId) => peerId.trim()).filter(Boolean),
+        )].sort();
+        if (graphAccessPolicy === 'allowList' && graphAllowedPeers.length === 0) {
+          throw new Error('allowList accessPolicy requires allowedPeers');
+        }
+        if (graphAccessPolicy !== 'allowList' && graphAllowedPeers.length > 0) {
+          throw new Error('allowedPeers requires allowList accessPolicy');
         }
       } catch (error) {
         const reason = `INVALID_KA_CONTENT_SCOPE: ${error instanceof Error ? error.message : String(error)}`;
@@ -1354,7 +1375,10 @@ export class SharedMemoryHandler {
               currentHead.publicTripleCount === (publicTripleCount ?? 0) &&
               currentHead.privateTripleCount === (privateTripleCount ?? 0) &&
               currentHead.privateMerkleRoot?.toLowerCase() === incomingPrivateRootHex &&
-              currentHead.assertionGraph === swmGraph;
+              currentHead.assertionGraph === swmGraph &&
+              (currentHead.accessPolicy
+                ?? (currentHead.privateTripleCount > 0 ? 'ownerOnly' : 'public')) === graphAccessPolicy &&
+              currentHead.allowedPeers.slice().sort().join('\u0000') === graphAllowedPeers.join('\u0000');
             if (sameAssertion) {
               // Exact replay: acknowledge idempotently without churning the
               // graph or immutable operation snapshot.
@@ -1436,6 +1460,8 @@ export class SharedMemoryHandler {
           privateMerkleRoot,
           privateTripleCount: privateTripleCount ?? 0,
           publisherPeerId,
+          accessPolicy: graphAccessPolicy,
+          allowedPeers: graphAllowedPeers,
           agentAddress: senderAgentAddress ?? contentScope.agentAddress,
           subGraphName,
           timestamp: operationTimestamp,

--- a/packages/publisher/test/async-lift-publish-options.test.ts
+++ b/packages/publisher/test/async-lift-publish-options.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { GRAPH_KA_CONTENT_SCOPE_VERSION } from '@origintrail-official/dkg-core';
 import { mapLiftRequestToPublishOptions, prepareAsyncPublishPayload, isFailClosedInlineEncrypt, type LiftPublishMappingInput } from '../src/async-lift-publish-options.js';
 
 describe('mapLiftRequestToPublishOptions', () => {
@@ -482,6 +483,26 @@ describe('mapLiftRequestToPublishOptions', () => {
     });
 
     expect(options.entityProofs).toBe(true);
+  });
+
+  it('rejects entity proofs for persisted graph-scoped jobs at mapping time', () => {
+    expect(() => mapLiftRequestToPublishOptions({
+      ...baseInput(),
+      request: {
+        ...baseInput().request,
+        roots: [],
+        contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+        kaUal: 'did:dkg:31337/0x1111111111111111111111111111111111111111/7',
+        assertionVersion: '1',
+        publicTripleCount: 1,
+        privateTripleCount: 0,
+        entityProofs: true,
+      },
+      resolved: {
+        ...baseInput().resolved,
+        publisherPeerId: '12D3KooWPublisher',
+      },
+    })).toThrow(/does not support entityProofs/);
   });
 
   it('forwards request.publishEpochs to PublishOptions', () => {

--- a/packages/publisher/test/async-lift-publisher.test.ts
+++ b/packages/publisher/test/async-lift-publisher.test.ts
@@ -1,7 +1,11 @@
 import { beforeAll, beforeEach, afterAll, describe, expect, it } from 'vitest';
 import { GraphManager, OxigraphStore, PrivateContentStore } from '@origintrail-official/dkg-storage';
 import { EVMChainAdapter } from '@origintrail-official/dkg-chain';
-import { TypedEventBus, generateEd25519Keypair } from '@origintrail-official/dkg-core';
+import {
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  TypedEventBus,
+  generateEd25519Keypair,
+} from '@origintrail-official/dkg-core';
 import { ethers } from 'ethers';
 import { createEVMAdapter, getSharedContext, createProvider, takeSnapshot, revertSnapshot, createTestContextGraph, HARDHAT_KEYS } from '../../chain/test/evm-test-context.js';
 import { mintTokens } from '../../chain/test/hardhat-harness.js';
@@ -13,6 +17,7 @@ import {
   QuorumUnmetError,
   TripleStoreAsyncLiftPublisher,
   createLiftJobFailureMetadata,
+  storeKnowledgeAssetOperationPublicQuads,
   type AsyncLiftPublisherConfig,
   type AsyncLiftPublisherRecoveryResult,
   type LiftRequest,
@@ -55,6 +60,7 @@ describe('TripleStoreAsyncLiftPublisher', () => {
   let _kav10Address: string;
   let _provider: ethers.JsonRpcProvider;
   const _author = new ethers.Wallet(HARDHAT_KEYS.CORE_OP);
+  const ROOTLESS_UAL = 'did:dkg:31337/0x1111111111111111111111111111111111111111/7';
 
   function makeTestPublisher(opts: ConstructorParameters<typeof DKGPublisher>[0]): DKGPublisher {
     // OT-RFC-43 Option-1: wire a KA-number allocator so the real EVM adapter
@@ -104,7 +110,12 @@ describe('TripleStoreAsyncLiftPublisher', () => {
       contextGraphId: 'music-social',
       name: 'albums',
       shareOperationId: 'share-op-1',
-      roots: ['urn:album:one', 'urn:album:two'],
+      roots: [],
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      kaUal: ROOTLESS_UAL,
+      assertionVersion: '1',
+      publicTripleCount: 2,
+      privateTripleCount: 0,
       seal: {
         merkleRoot: (`0x${'12'.repeat(32)}`) as `0x${string}`,
         authorAddress: authorAddress as `0x${string}`,
@@ -123,10 +134,27 @@ describe('TripleStoreAsyncLiftPublisher', () => {
       wmCurrentAssertion: '12'.repeat(32),
       swmCurrentAssertion: '12'.repeat(32),
       kaNumber: kaNumber.toString(),
-      reservedUal: 'did:dkg:31337/0x1111111111111111111111111111111111111111/7',
+      reservedUal: ROOTLESS_UAL,
     };
     return { ...base, ...overrides };
   };
+
+  async function stageRootlessSnapshot(shareOperationId: string): Promise<void> {
+    await storeKnowledgeAssetOperationPublicQuads({
+      store,
+      graphManager: new GraphManager(store),
+      contextGraphId: 'music-social',
+      shareOperationId,
+      kaUal: ROOTLESS_UAL,
+      assertionVersion: 1,
+      quads: [
+        { subject: 'urn:album:one', predicate: 'http://schema.org/name', object: '"One"', graph: '' },
+        { subject: 'urn:album:two', predicate: 'http://schema.org/name', object: '"Two"', graph: '' },
+      ],
+      publisherPeerId: 'peer-1',
+      accessPolicy: 'public',
+    });
+  }
 
   beforeEach(() => {
     store = new OxigraphStore();
@@ -274,19 +302,27 @@ describe('TripleStoreAsyncLiftPublisher', () => {
       publishEpochs: 3,
       clearSharedMemoryAfter: false,
       publisherNodeIdentityIdOverride: '42',
+      accessPolicy: 'allowList',
+      allowedPeers: ['peer-a', 'peer-b'],
+      entityProofs: true,
     }));
     const job = await publisher.getStatus(jobId);
 
     expect(jobId).toBe('job-1');
     expect(job?.status).toBe('accepted');
-    expect(job?.jobSlug).toBe('music-social/knowledge-assets/albums/vm-publish/share-op-1/one-two');
+    expect(job?.jobSlug).toBe('music-social/knowledge-assets/albums/vm-publish/share-op-1/no-roots');
     expect(job?.request.jobType).toBe('knowledge-asset-vm-publish');
     expect(job?.request.knowledgeAssetVmPublish).toEqual({
       contextGraphId: 'music-social',
       name: 'albums',
       subGraphName: 'research',
       shareOperationId: 'share-op-1',
-      roots: ['urn:album:one', 'urn:album:two'],
+      roots: [],
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      kaUal: ROOTLESS_UAL,
+      assertionVersion: '1',
+      publicTripleCount: 2,
+      privateTripleCount: 0,
       seal: {
         merkleRoot: `0x${'12'.repeat(32)}`,
         authorAddress: '0x1111111111111111111111111111111111111111',
@@ -305,7 +341,10 @@ describe('TripleStoreAsyncLiftPublisher', () => {
       wmCurrentAssertion: '12'.repeat(32),
       swmCurrentAssertion: '12'.repeat(32),
       kaNumber: '7',
-      reservedUal: 'did:dkg:31337/0x1111111111111111111111111111111111111111/7',
+      reservedUal: ROOTLESS_UAL,
+      accessPolicy: 'allowList',
+      allowedPeers: ['peer-a', 'peer-b'],
+      entityProofs: true,
       publishEpochs: 3,
       clearSharedMemoryAfter: false,
       publisherNodeIdentityIdOverride: '42',
@@ -393,11 +432,8 @@ describe('TripleStoreAsyncLiftPublisher', () => {
     expect(claimed?.jobId).toBe(jobId);
     await publisher.update(jobId, 'validated', {
       validation: {
-        canonicalRoots: ['urn:album:one', 'urn:album:two'],
-        canonicalRootMap: {
-          'urn:album:one': 'urn:album:one',
-          'urn:album:two': 'urn:album:two',
-        },
+        canonicalRoots: [],
+        canonicalRootMap: {},
         swmQuadCount: 2,
         authorityProofRef: 'urn:dkg:publish-async:share-op-1',
         transitionType: 'CREATE',
@@ -442,11 +478,8 @@ describe('TripleStoreAsyncLiftPublisher', () => {
     const jobId = await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
     await publisher.claimNext('wallet-1');
     const validation = {
-      canonicalRoots: ['urn:album:one', 'urn:album:two'],
-      canonicalRootMap: {
-        'urn:album:one': 'urn:album:one',
-        'urn:album:two': 'urn:album:two',
-      },
+      canonicalRoots: [],
+      canonicalRootMap: {},
       swmQuadCount: 2,
       authorityProofRef: 'urn:dkg:publish-async:share-op-1',
       transitionType: 'CREATE' as const,
@@ -496,21 +529,11 @@ describe('TripleStoreAsyncLiftPublisher', () => {
         },
       },
     });
-    const publisherContract: Publisher = makeTestPublisher({
-      store,
-      chain: createEVMAdapter(HARDHAT_KEYS.CORE_OP),
-      eventBus: new TypedEventBus(),
-      keypair: await generateEd25519Keypair(),
-      publisherPrivateKey: HARDHAT_KEYS.CORE_OP,
-      publisherNodeIdentityId: BigInt(getSharedContext().coreProfileId),
-    });
-    const share = await publisherContract.share('music-social', [
-      { subject: 'urn:album:one', predicate: 'http://schema.org/name', object: '"One"', graph: '' },
-      { subject: 'urn:album:two', predicate: 'http://schema.org/name', object: '"Two"', graph: '' },
-    ], { publisherPeerId: 'peer-1' });
+    const shareOperationId = 'rootless-execution-op';
+    await stageRootlessSnapshot(shareOperationId);
 
     const jobId = await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest({
-      shareOperationId: share.shareOperationId,
+      shareOperationId,
       clearSharedMemoryAfter: true,
     }));
     const processed = await publisher.processNext('wallet-1');
@@ -524,8 +547,13 @@ describe('TripleStoreAsyncLiftPublisher', () => {
         request: {
           contextGraphId: 'music-social',
           name: 'albums',
-          shareOperationId: share.shareOperationId,
-          roots: ['urn:album:one', 'urn:album:two'],
+          shareOperationId,
+          roots: [],
+          contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+          kaUal: ROOTLESS_UAL,
+          assertionVersion: '1',
+          publicTripleCount: 2,
+          privateTripleCount: 0,
           seal: {
             merkleRoot: `0x${'12'.repeat(32)}`,
             authorAddress: '0x1111111111111111111111111111111111111111',
@@ -543,11 +571,11 @@ describe('TripleStoreAsyncLiftPublisher', () => {
           wmCurrentAssertion: '12'.repeat(32),
           swmCurrentAssertion: '12'.repeat(32),
           kaNumber: '7',
-          reservedUal: 'did:dkg:31337/0x1111111111111111111111111111111111111111/7',
+          reservedUal: ROOTLESS_UAL,
           clearSharedMemoryAfter: true,
         },
         validation: {
-          canonicalRoots: ['urn:album:one', 'urn:album:two'],
+          canonicalRoots: [],
           swmQuadCount: 2,
           transitionType: 'CREATE',
         },
@@ -556,12 +584,13 @@ describe('TripleStoreAsyncLiftPublisher', () => {
         },
         publishOptions: {
           publisherPeerId: 'peer-1',
-          quads: [
+          quads: expect.arrayContaining([
             { subject: 'urn:album:one', predicate: 'http://schema.org/name', object: '"One"', graph: '' },
             { subject: 'urn:album:two', predicate: 'http://schema.org/name', object: '"Two"', graph: '' },
-          ],
+          ]),
         },
       });
+    expect((calls[0] as { publishOptions: { quads: unknown[] } }).publishOptions.quads).toHaveLength(2);
   });
 
   it('finalizes knowledge asset VM publish jobs as no-op when execution preflight says already published', async () => {
@@ -581,21 +610,11 @@ describe('TripleStoreAsyncLiftPublisher', () => {
         },
       },
     });
-    const publisherContract: Publisher = makeTestPublisher({
-      store,
-      chain: createEVMAdapter(HARDHAT_KEYS.CORE_OP),
-      eventBus: new TypedEventBus(),
-      keypair: await generateEd25519Keypair(),
-      publisherPrivateKey: HARDHAT_KEYS.CORE_OP,
-      publisherNodeIdentityId: BigInt(getSharedContext().coreProfileId),
-    });
-    const share = await publisherContract.share('music-social', [
-      { subject: 'urn:album:one', predicate: 'http://schema.org/name', object: '"One"', graph: '' },
-      { subject: 'urn:album:two', predicate: 'http://schema.org/name', object: '"Two"', graph: '' },
-    ], { publisherPeerId: 'peer-1' });
+    const shareOperationId = 'rootless-noop-op';
+    await stageRootlessSnapshot(shareOperationId);
 
     const jobId = await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest({
-      shareOperationId: share.shareOperationId,
+      shareOperationId,
     }));
     const processed = await publisher.processNext('wallet-1');
     const reloaded = await publisher.getStatus(jobId);
@@ -626,21 +645,11 @@ describe('TripleStoreAsyncLiftPublisher', () => {
         },
       },
     });
-    const publisherContract: Publisher = makeTestPublisher({
-      store,
-      chain: createEVMAdapter(HARDHAT_KEYS.CORE_OP),
-      eventBus: new TypedEventBus(),
-      keypair: await generateEd25519Keypair(),
-      publisherPrivateKey: HARDHAT_KEYS.CORE_OP,
-      publisherNodeIdentityId: BigInt(getSharedContext().coreProfileId),
-    });
-    const share = await publisherContract.share('music-social', [
-      { subject: 'urn:album:one', predicate: 'http://schema.org/name', object: '"One"', graph: '' },
-      { subject: 'urn:album:two', predicate: 'http://schema.org/name', object: '"Two"', graph: '' },
-    ], { publisherPeerId: 'peer-1' });
+    const shareOperationId = 'rootless-stale-op';
+    await stageRootlessSnapshot(shareOperationId);
 
     const jobId = await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest({
-      shareOperationId: share.shareOperationId,
+      shareOperationId,
     }));
     const processed = await publisher.processNext('wallet-1');
 
@@ -1795,7 +1804,7 @@ describe('TripleStoreAsyncLiftPublisher', () => {
     await publisher.claimNext('wallet-1');
     await publisher.update(jobId, 'validated', {
       validation: {
-        canonicalRoots: ['urn:album:one', 'urn:album:two'],
+        canonicalRoots: [],
         canonicalRootMap: {},
         swmQuadCount: 2,
         authorityProofRef: 'knowledge-asset-lifecycle',
@@ -1834,7 +1843,7 @@ describe('TripleStoreAsyncLiftPublisher', () => {
     await publisher.claimNext('wallet-1');
     await publisher.update(jobId, 'validated', {
       validation: {
-        canonicalRoots: ['urn:album:one', 'urn:album:two'],
+        canonicalRoots: [],
         canonicalRootMap: {},
         swmQuadCount: 2,
         authorityProofRef: 'knowledge-asset-lifecycle',

--- a/packages/publisher/test/async-lift-publisher.test.ts
+++ b/packages/publisher/test/async-lift-publisher.test.ts
@@ -304,7 +304,7 @@ describe('TripleStoreAsyncLiftPublisher', () => {
       publisherNodeIdentityIdOverride: '42',
       accessPolicy: 'allowList',
       allowedPeers: ['peer-a', 'peer-b'],
-      entityProofs: true,
+      entityProofs: false,
     }));
     const job = await publisher.getStatus(jobId);
 
@@ -344,7 +344,7 @@ describe('TripleStoreAsyncLiftPublisher', () => {
       reservedUal: ROOTLESS_UAL,
       accessPolicy: 'allowList',
       allowedPeers: ['peer-a', 'peer-b'],
-      entityProofs: true,
+      entityProofs: false,
       publishEpochs: 3,
       clearSharedMemoryAfter: false,
       publisherNodeIdentityIdOverride: '42',
@@ -352,6 +352,15 @@ describe('TripleStoreAsyncLiftPublisher', () => {
     expect((job?.request as any).scope).toBeUndefined();
     expect((job?.request as any).namespace).toBeUndefined();
     expect((job?.request as any).authority).toBeUndefined();
+  });
+
+  it('rejects unsupported entity proofs before persisting a graph-scoped job', async () => {
+    const publisher = createPublisher();
+
+    await expect(
+      publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest({ entityProofs: true })),
+    ).rejects.toThrow(/does not support entityProofs/);
+    expect(await publisher.list()).toEqual([]);
   });
 
   it('rejects duplicate active knowledge asset VM publish jobs', async () => {

--- a/packages/publisher/test/ka-graph-workspace-receiver.test.ts
+++ b/packages/publisher/test/ka-graph-workspace-receiver.test.ts
@@ -81,9 +81,12 @@ describe('SharedMemoryHandler graph-scoped KA receiver', () => {
     );
     expect(meta.type).toBe('quads');
     if (meta.type !== 'quads') throw new Error('expected metadata quads');
-    expect(meta.quads).toHaveLength(18);
+    expect(meta.quads).toHaveLength(19);
     expect(meta.quads.some((quad) => quad.predicate.endsWith('rootEntity'))).toBe(false);
     expect(meta.quads.some((quad) => quad.predicate.endsWith('workspaceOwner'))).toBe(false);
+    expect(meta.quads.some(
+      (quad) => quad.predicate.endsWith('accessPolicy') && quad.object === '"public"',
+    )).toBe(true);
     // The current-head fence points at the immutable operation, so the digest
     // and private commitment are stored only once.
     expect(meta.quads.filter((quad) => quad.predicate.endsWith('publicQuadsDigest'))).toHaveLength(1);
@@ -146,6 +149,45 @@ describe('SharedMemoryHandler graph-scoped KA receiver', () => {
     expect(stillCurrent.type).toBe('bindings');
     if (stillCurrent.type !== 'bindings') throw new Error('expected bindings');
     expect(stillCurrent.bindings).toEqual([{ s: 'urn:entity:2', o: '"two"' }]);
+  });
+
+  it('persists the access envelope and rejects same-version policy drift after restart', async () => {
+    const store = new OxigraphStore();
+    const handler = new SharedMemoryHandler(store, new TypedEventBus());
+    const request = v2Request({
+      accessPolicy: 'allowList',
+      allowedPeers: [' peer-b ', 'peer-a', 'peer-b'],
+    });
+    expect((await handler.handle(request, PEER_ID)).applied).toBe(true);
+
+    const metaGraph = new GraphManager(store).sharedMemoryMetaUri(CONTEXT_GRAPH);
+    const envelope = await store.query(
+      `SELECT ?policy ?peer WHERE { GRAPH <${metaGraph}> {
+        ?operation <http://dkg.io/ontology/shareOperationId> "rootless-op-1" ;
+          <http://dkg.io/ontology/accessPolicy> ?policy .
+        OPTIONAL { ?operation <http://dkg.io/ontology/allowedPeer> ?peer }
+      } } ORDER BY ?peer`,
+    );
+    expect(envelope.type).toBe('bindings');
+    if (envelope.type !== 'bindings') throw new Error('expected access-envelope bindings');
+    expect(envelope.bindings).toEqual([
+      { policy: '"allowList"', peer: '"peer-a"' },
+      { policy: '"allowList"', peer: '"peer-b"' },
+    ]);
+
+    const restarted = new SharedMemoryHandler(store, new TypedEventBus());
+    expect((await restarted.handle(v2Request({
+      accessPolicy: 'allowList',
+      allowedPeers: ['peer-a', 'peer-b'],
+    }), PEER_ID)).applied).toBe(true);
+
+    const drift = await restarted.handle(v2Request({
+      accessPolicy: 'ownerOnly',
+      allowedPeers: [],
+    }), PEER_ID);
+    expect(drift).toMatchObject({ applied: false, retryable: false });
+    if (drift.applied) throw new Error('expected policy-drift rejection');
+    expect(drift.reason).toContain('CONFLICTING_KA_ASSERTION_VERSION');
   });
 
   it('keeps one KA-level transport owner across assertion versions', async () => {

--- a/packages/publisher/test/lift-job-types.test.ts
+++ b/packages/publisher/test/lift-job-types.test.ts
@@ -30,6 +30,8 @@ import {
   normalizePersistedLiftJobRequest,
 } from '../src/async-lift-publisher-utils.js';
 
+const ROOTLESS_UAL = 'did:dkg:31337/0x1111111111111111111111111111111111111111/7';
+
 function rawJobRequest(request: RawLiftRequest): RawLiftJobRequest {
   return { jobType: 'lift', lift: request };
 }
@@ -68,7 +70,12 @@ function kaVmPublish(
     contextGraphId: 'music-social',
     name: 'albums',
     shareOperationId: 'op-1',
-    roots: ['urn:local:/rihana'],
+    roots: [],
+    contentScopeVersion: 2,
+    kaUal: ROOTLESS_UAL,
+    assertionVersion: '1',
+    publicTripleCount: 1,
+    privateTripleCount: 0,
     seal: seal(),
     sealChainId: '31337',
     sealKav10Address: '0x2222222222222222222222222222222222222222',
@@ -168,7 +175,11 @@ describe('LiftJob request and record types', () => {
   });
 
   it('models KA VM publish snapshot validation without raw-lift placeholder fields', () => {
-    const request = kaVmPublish();
+    const request = kaVmPublish({
+      accessPolicy: 'allowList',
+      allowedPeers: ['peer-a', 'peer-b'],
+      entityProofs: true,
+    });
 
     const snapshot = createKnowledgeAssetVmPublishSnapshotRequest(request);
     const metadata = createKnowledgeAssetVmPublishSnapshotMetadata(request);
@@ -178,7 +189,15 @@ describe('LiftJob request and record types', () => {
     expect(snapshot).toMatchObject({
       contextGraphId: 'music-social',
       shareOperationId: 'op-1',
-      roots: ['urn:local:/rihana'],
+      roots: [],
+      contentScopeVersion: 2,
+      kaUal: ROOTLESS_UAL,
+      assertionVersion: '1',
+      publicTripleCount: 1,
+      privateTripleCount: 0,
+      accessPolicy: 'allowList',
+      allowedPeers: ['peer-a', 'peer-b'],
+      entityProofs: true,
       seal: request.seal,
     });
     for (const rawOnlyField of ['jobType', 'swmId', 'namespace', 'scope', 'transitionType', 'authority']) {

--- a/packages/publisher/vitest.unit.config.ts
+++ b/packages/publisher/vitest.unit.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
       'test/async-lift-ka-broadcast-progress.test.ts',
       'test/async-lift-publish-options.test.ts',
       'test/async-promote-queue.test.ts',
+      'test/lift-job-types.test.ts',
       'test/multi-root-token-rows.test.ts',
       'test/promote-step-tag.test.ts',
       'test/ka-graph-skolemization.test.ts',


### PR DESCRIPTION
Stacked on #1718.

## Summary

- replaces the legacy raw-root `publishAsync` path with the named Knowledge Asset lifecycle, producing a sealed UAL/version and exact graph-scoped WM/SWM snapshot before enqueue
- carries private access policy, peer allow-lists, selective-disclosure mode, and canonical author attestation through the immutable queue snapshot and workspace wire contract
- adds caller-controlled typed-data signing, verifies pre-signed payload commitments, and fails closed for non-V10 or legacy mutation-shaped async requests instead of creating sealless root lifts
- makes workspace replay compare the immutable access envelope so a same-version policy drift is rejected

## Validation

- core, publisher, and agent TypeScript builds passed (including agent type tests)
- agent unit suite: 68 files / 836 tests passed
- publisher unit suite passed
- async queue integration suite: 44 / 44 tests passed
- rootless workspace proto and receiver regressions passed
- `git diff --check` passed

## Stack note

Review this after #1718; the next follow-up will quarantine/remove the remaining generic raw-lift entry points rather than expanding this PR.