### PR TITLE
feat: add rootless KA query and private access parity

### DIFF
--- a/packages/agent/src/dkg-agent-cg-registry.ts
+++ b/packages/agent/src/dkg-agent-cg-registry.ts
@@ -1044,6 +1044,7 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
     }
 
     const gm = new GraphManager(this.store);
+    gm.assertNewContextGraphId(opts.id);
     const contextGraphUri = contextGraphDataGraphUri(opts.id);
     const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
     const cgMetaGraph = contextGraphMetaGraphUri(opts.id);
@@ -1089,7 +1090,7 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
 
     await this.store.insert(quads);
     this.contextGraphMetaProjection.markDirtyFromQuads(quads);
-    await gm.ensureContextGraph(opts.id);
+    await gm.ensureNewContextGraph(opts.id);
 
     this.subscribeToContextGraph(opts.id);
     this.setContextGraphSubscription(opts.id, {

--- a/packages/agent/src/dkg-agent-context-graph.ts
+++ b/packages/agent/src/dkg-agent-context-graph.ts
@@ -92,7 +92,6 @@ import {
   SUBSCRIPTION_SOURCES,
   pickNetworkTunables,
   assertRdfLiteralMutf8Safe,
-  validateNewContextGraphId,
 } from '@origintrail-official/dkg-core';
 import { GraphManager, PrivateContentStore, createTripleStore, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig } from '@origintrail-official/dkg-storage';
 import { EVMChainAdapter, NoChainAdapter, enrichEvmError, buildKnowledgeAssetUal, type EVMAdapterConfig, type ChainAdapter, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo } from '@origintrail-official/dkg-chain';
@@ -431,10 +430,8 @@ export class ContextGraphMethods extends DKGAgentBase {
     callerAgentAddress?: string;
   }): Promise<void> {
     const ctx = createOperationContext('system');
-    const idValidation = validateNewContextGraphId(opts.id);
-    if (!idValidation.valid) {
-      throw new Error(`Invalid context graph ID: ${idValidation.reason}`);
-    }
+    const gm = new GraphManager(this.store);
+    gm.assertNewContextGraphId(opts.id);
     // OT-RFC-56 §4.6: name/description land as raw literals in a
     // network-replicated graph — enforce the protocol limit before ANY
     // side effect (see ensureContextGraphLocal for the incident context).
@@ -446,7 +443,6 @@ export class ContextGraphMethods extends DKGAgentBase {
         label: 'contextGraph.description', subject: opts.id, predicate: DKG_ONTOLOGY.SCHEMA_DESCRIPTION,
       });
     }
-    const gm = new GraphManager(this.store);
     const contextGraphUri = `did:dkg:context-graph:${opts.id}`;
     const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
     const cgMetaGraph = contextGraphMetaGraphUri(opts.id);
@@ -684,7 +680,7 @@ export class ContextGraphMethods extends DKGAgentBase {
     await this.store.insert(quads);
     this.invalidateListContextGraphsCache();
     this.contextGraphMetaProjection.markDirtyFromQuads(quads);
-    await gm.ensureContextGraph(opts.id);
+    await gm.ensureNewContextGraph(opts.id);
 
     // Force the triple-store flush BEFORE the SQLite caches are written.
     // Without this, a daemon crash within 50ms of the insert would lose the
@@ -881,10 +877,7 @@ export class ContextGraphMethods extends DKGAgentBase {
     strictEoaCuratorMatch?: boolean;
   }): Promise<{ onChainId: string; txHash?: string }> {
     const ctx = createOperationContext('system');
-    const idValidation = validateNewContextGraphId(id);
-    if (!idValidation.valid) {
-      throw new Error(`Invalid context graph ID: ${idValidation.reason}`);
-    }
+    new GraphManager(this.store).assertNewContextGraphId(id);
 
     if (opts?.revealOnChain === true) {
       this.log.warn(

--- a/packages/agent/src/dkg-agent-context-graph.ts
+++ b/packages/agent/src/dkg-agent-context-graph.ts
@@ -92,6 +92,7 @@ import {
   SUBSCRIPTION_SOURCES,
   pickNetworkTunables,
   assertRdfLiteralMutf8Safe,
+  validateNewContextGraphId,
 } from '@origintrail-official/dkg-core';
 import { GraphManager, PrivateContentStore, createTripleStore, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig } from '@origintrail-official/dkg-storage';
 import { EVMChainAdapter, NoChainAdapter, enrichEvmError, buildKnowledgeAssetUal, type EVMAdapterConfig, type ChainAdapter, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo } from '@origintrail-official/dkg-chain';
@@ -430,6 +431,10 @@ export class ContextGraphMethods extends DKGAgentBase {
     callerAgentAddress?: string;
   }): Promise<void> {
     const ctx = createOperationContext('system');
+    const idValidation = validateNewContextGraphId(opts.id);
+    if (!idValidation.valid) {
+      throw new Error(`Invalid context graph ID: ${idValidation.reason}`);
+    }
     // OT-RFC-56 §4.6: name/description land as raw literals in a
     // network-replicated graph — enforce the protocol limit before ANY
     // side effect (see ensureContextGraphLocal for the incident context).
@@ -876,6 +881,10 @@ export class ContextGraphMethods extends DKGAgentBase {
     strictEoaCuratorMatch?: boolean;
   }): Promise<{ onChainId: string; txHash?: string }> {
     const ctx = createOperationContext('system');
+    const idValidation = validateNewContextGraphId(id);
+    if (!idValidation.valid) {
+      throw new Error(`Invalid context graph ID: ${idValidation.reason}`);
+    }
 
     if (opts?.revealOnChain === true) {
       this.log.warn(

--- a/packages/agent/test/cg-registration-oversize-guard.test.ts
+++ b/packages/agent/test/cg-registration-oversize-guard.test.ts
@@ -27,20 +27,6 @@ describe('createContextGraph oversize-description guard', () => {
     skills: [],
   });
 
-  it('rejects new context graph IDs that alias structural storage partitions', async () => {
-    const store = new OxigraphStore();
-    agent = await makeAgent(store);
-
-    await expect(
-      agent.createContextGraph({ id: 'victim/_meta', name: 'Namespace collision' }),
-    ).rejects.toThrow(/reserved storage partition/);
-
-    const result = await store.query(
-      'SELECT ?p WHERE { GRAPH ?g { <did:dkg:context-graph:victim/_meta> ?p ?o } }',
-    );
-    expect(result.type === 'bindings' && result.bindings).toHaveLength(0);
-  });
-
   it('rejects an oversized description with OVERSIZED_RDF_LITERAL, writing nothing', async () => {
     const store = new OxigraphStore();
     agent = await makeAgent(store);

--- a/packages/agent/test/cg-registration-oversize-guard.test.ts
+++ b/packages/agent/test/cg-registration-oversize-guard.test.ts
@@ -27,6 +27,20 @@ describe('createContextGraph oversize-description guard', () => {
     skills: [],
   });
 
+  it('rejects new context graph IDs that alias structural storage partitions', async () => {
+    const store = new OxigraphStore();
+    agent = await makeAgent(store);
+
+    await expect(
+      agent.createContextGraph({ id: 'victim/_meta', name: 'Namespace collision' }),
+    ).rejects.toThrow(/reserved storage partition/);
+
+    const result = await store.query(
+      'SELECT ?p WHERE { GRAPH ?g { <did:dkg:context-graph:victim/_meta> ?p ?o } }',
+    );
+    expect(result.type === 'bindings' && result.bindings).toHaveLength(0);
+  });
+
   it('rejects an oversized description with OVERSIZED_RDF_LITERAL, writing nothing', async () => {
     const store = new OxigraphStore();
     agent = await makeAgent(store);

--- a/packages/agent/test/context-graph-id-validation.test.ts
+++ b/packages/agent/test/context-graph-id-validation.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DKGAgent } from '../src/index.js';
+import {
+  DKG_ONTOLOGY,
+  contextGraphMetaUri,
+} from '@origintrail-official/dkg-core';
+import {
+  MockChainAdapter,
+  NoChainAdapter,
+  type ChainAdapter,
+} from '@origintrail-official/dkg-chain';
+import {
+  GraphManager,
+  OxigraphStore,
+} from '@origintrail-official/dkg-storage';
+
+describe('context graph ID validation', () => {
+  let agent: DKGAgent | undefined;
+
+  afterEach(async () => {
+    await agent?.stop().catch(() => {});
+    agent = undefined;
+  });
+
+  const makeAgent = async (
+    store: OxigraphStore,
+    chainAdapter: ChainAdapter = new NoChainAdapter(),
+  ) => DKGAgent.create({
+    name: 'ContextGraphIdGuardNode',
+    listenPort: 0,
+    listenHost: '127.0.0.1',
+    store,
+    chainAdapter,
+    nodeRole: 'core',
+    skills: [],
+  });
+
+  it('rejects new context graph IDs that alias structural storage partitions', async () => {
+    const store = new OxigraphStore();
+    agent = await makeAgent(store);
+
+    await expect(
+      agent.createContextGraph({ id: 'victim/_meta', name: 'Namespace collision' }),
+    ).rejects.toThrow(/reserved storage partition/);
+
+    const result = await store.query(
+      'SELECT ?p WHERE { GRAPH ?g { <did:dkg:context-graph:victim/_meta> ?p ?o } }',
+    );
+    expect(result.type === 'bindings' && result.bindings).toHaveLength(0);
+  });
+
+  it('rejects direct registration of a pre-existing reserved ID before chain access', async () => {
+    const store = new OxigraphStore();
+    const id = 'victim/_meta';
+    await new GraphManager(store).ensureContextGraph(id);
+    await store.insert([{
+      subject: `did:dkg:context-graph:${id}`,
+      predicate: DKG_ONTOLOGY.RDF_TYPE,
+      object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH,
+      graph: contextGraphMetaUri(id),
+    }]);
+    const chain = new MockChainAdapter('mock:31337');
+    const createOnChainContextGraph = vi.spyOn(chain, 'createOnChainContextGraph');
+    agent = await makeAgent(store, chain);
+
+    await expect(agent.registerContextGraph(id))
+      .rejects.toThrow(/reserved storage partition/);
+    expect(createOnChainContextGraph).not.toHaveBeenCalled();
+  });
+});

--- a/packages/agent/test/context-graph-id-validation.test.ts
+++ b/packages/agent/test/context-graph-id-validation.test.ts
@@ -49,6 +49,21 @@ describe('context graph ID validation', () => {
     expect(result.type === 'bindings' && result.bindings).toHaveLength(0);
   });
 
+  it('rejects fresh local bootstrap IDs before inserting registration metadata', async () => {
+    const store = new OxigraphStore();
+    agent = await makeAgent(store);
+
+    await expect(agent.ensureContextGraphLocal({
+      id: 'victim/_meta',
+      name: 'Namespace collision',
+    })).rejects.toThrow(/reserved storage partition/);
+
+    const result = await store.query(
+      'SELECT ?p WHERE { GRAPH ?g { <did:dkg:context-graph:victim/_meta> ?p ?o } }',
+    );
+    expect(result.type === 'bindings' && result.bindings).toHaveLength(0);
+  });
+
   it('rejects direct registration of a pre-existing reserved ID before chain access', async () => {
     const store = new OxigraphStore();
     const id = 'victim/_meta';

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -37,6 +37,7 @@ export default defineConfig({
       "test/swm-late-joiner-deferred-gossip.test.ts",
       "test/oversize-filter.test.ts",
       "test/cg-registration-oversize-guard.test.ts",
+      "test/context-graph-id-validation.test.ts",
       "test/sync-responder-concurrent-interleaving.test.ts",
       "test/durable-meta-admission.test.ts",
       "test/sync-responder-log-volume.test.ts",

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -510,6 +510,21 @@ export function validateContextGraphId(id: string): { valid: boolean; reason?: s
   if (!id || id.length === 0) return { valid: false, reason: 'Context graph ID cannot be empty' };
   if (id.length > 256) return { valid: false, reason: 'Context graph ID exceeds 256 characters' };
   if (!/^[\w:/.@\-]+$/.test(id)) return { valid: false, reason: 'Context graph ID contains disallowed characters (allowed: alphanumeric, _, :, /, ., @, -)' };
+  return { valid: true };
+}
+
+/**
+ * Validate a newly-created context graph ID against the storage namespace.
+ *
+ * Existing stores may contain IDs that predate the reserved-partition rule,
+ * so read/sync paths intentionally keep using {@link validateContextGraphId}.
+ * New roots must not claim a path segment used by a structural graph such as
+ * `_meta`, otherwise their payload graph can alias another root's control
+ * plane.
+ */
+export function validateNewContextGraphId(id: string): { valid: boolean; reason?: string } {
+  const validation = validateContextGraphId(id);
+  if (!validation.valid) return validation;
   const reservedSegment = id.split('/').find((segment) => segment.startsWith('_'));
   if (reservedSegment) {
     return {

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -510,6 +510,13 @@ export function validateContextGraphId(id: string): { valid: boolean; reason?: s
   if (!id || id.length === 0) return { valid: false, reason: 'Context graph ID cannot be empty' };
   if (id.length > 256) return { valid: false, reason: 'Context graph ID exceeds 256 characters' };
   if (!/^[\w:/.@\-]+$/.test(id)) return { valid: false, reason: 'Context graph ID contains disallowed characters (allowed: alphanumeric, _, :, /, ., @, -)' };
+  const reservedSegment = id.split('/').find((segment) => segment.startsWith('_'));
+  if (reservedSegment) {
+    return {
+      valid: false,
+      reason: `Context graph ID contains reserved storage partition segment "${reservedSegment}"`,
+    };
+  }
   return { valid: true };
 }
 

--- a/packages/core/src/graph-knowledge-asset-metadata.ts
+++ b/packages/core/src/graph-knowledge-asset-metadata.ts
@@ -2,6 +2,7 @@ import {
   parseRdfLiteralTerm,
 } from '@origintrail-official/dkg-rdf-utils';
 import {
+  contextGraphDataUri,
   contextGraphMetaUri,
   validateContextGraphId,
   validateSubGraphName,
@@ -18,6 +19,21 @@ import { assertSafeIri, isSafeIri } from './sparql-safe.js';
 const DKG = 'http://dkg.io/ontology/';
 const PROV = 'http://www.w3.org/ns/prov#';
 const CONTEXT_GRAPH_PREFIX = 'did:dkg:context-graph:';
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+const SYSTEM_ONTOLOGY_GRAPH = contextGraphDataUri('ontology');
+const SYSTEM_AGENTS_GRAPH = contextGraphDataUri('agents');
+const ROOT_CONTEXT_GRAPH_TYPES = [
+  'https://dkg.network/ontology#ContextGraph',
+  'http://dkg.io/ontology/ContextGraph',
+] as const;
+const SUB_GRAPH_TYPES = [
+  'https://dkg.network/ontology#SubGraph',
+  'http://dkg.io/ontology/SubGraph',
+] as const;
+const PARENT_CONTEXT_GRAPH_PREDICATES = [
+  'https://dkg.network/ontology#parentContextGraph',
+  'http://dkg.io/ontology/parentContextGraph',
+] as const;
 
 const METADATA_PREDICATES = {
   scopeVersion: `${DKG}contentScopeVersion`,
@@ -107,6 +123,83 @@ export type GraphKnowledgeAssetMetadataParseResult =
   | { readonly kind: 'graph'; readonly metadata: ParsedGraphKnowledgeAssetMetadata };
 
 /**
+ * Require a context-graph subject to be declared in an authoritative root
+ * registry. Open roots are registered in the system ontology graph; curated
+ * roots keep the same declaration in their own control-plane metadata graph.
+ * Payload and named-subgraph graphs are deliberately excluded.
+ */
+export function buildTrustedRootContextGraphRegistrationFilter(
+  contextGraphVariable: string,
+  metadataGraphVariable: string,
+): string {
+  const variablePattern = /^\?[A-Za-z_][A-Za-z0-9_]*$/;
+  if (!variablePattern.test(contextGraphVariable) || !variablePattern.test(metadataGraphVariable)) {
+    throw new Error('Trusted context-graph registration filter requires SPARQL variables');
+  }
+  const rootTypes = ROOT_CONTEXT_GRAPH_TYPES.map((iri) => `<${iri}>`).join(' ');
+  const subGraphTypes = SUB_GRAPH_TYPES.map((iri) => `<${iri}>`).join(' ');
+  const parentPredicates = PARENT_CONTEXT_GRAPH_PREDICATES
+    .map((iri) => `<${iri}>`)
+    .join(' ');
+  const rootRegistryGraphs = `<${SYSTEM_ONTOLOGY_GRAPH}> <${SYSTEM_AGENTS_GRAPH}>`;
+  return `FILTER EXISTS {
+      VALUES ?_dkgRootContextGraphType { ${rootTypes} }
+      VALUES ?_dkgRootRegistryGraph { ${rootRegistryGraphs} }
+      {
+        GRAPH ?_dkgRootRegistryGraph {
+          ${contextGraphVariable} <${RDF_TYPE}> ?_dkgRootContextGraphType .
+        }
+      }
+      UNION
+      {
+        GRAPH ${metadataGraphVariable} {
+          ${contextGraphVariable} <${RDF_TYPE}> ?_dkgRootContextGraphType .
+        }
+      }
+    }
+    FILTER NOT EXISTS {
+      GRAPH ?_dkgParentMetaGraph {
+        ${contextGraphVariable} <${RDF_TYPE}> ?_dkgSubGraphType .
+        ${contextGraphVariable} ?_dkgParentPredicate ?_dkgParentContextGraph .
+      }
+      VALUES ?_dkgSubGraphType { ${subGraphTypes} }
+      VALUES ?_dkgParentPredicate { ${parentPredicates} }
+      FILTER(
+        STR(?_dkgParentMetaGraph) = CONCAT(STR(?_dkgParentContextGraph), "/_meta")
+      )
+      VALUES ?_dkgParentRootType { ${rootTypes} }
+      VALUES ?_dkgParentRegistryGraph { ${rootRegistryGraphs} }
+      {
+        GRAPH ?_dkgParentRegistryGraph {
+          ?_dkgParentContextGraph <${RDF_TYPE}> ?_dkgParentRootType .
+        }
+      }
+      UNION
+      {
+        GRAPH ?_dkgParentMetaGraph {
+          ?_dkgParentContextGraph <${RDF_TYPE}> ?_dkgParentRootType .
+        }
+      }
+    }
+    FILTER NOT EXISTS {
+      VALUES ?_dkgAliasRootType { ${rootTypes} }
+      VALUES ?_dkgAliasRegistryGraph { ${rootRegistryGraphs} }
+      {
+        GRAPH ?_dkgAliasRegistryGraph {
+          ${metadataGraphVariable} <${RDF_TYPE}> ?_dkgAliasRootType .
+        }
+      }
+      UNION
+      {
+        GRAPH ?_dkgAliasMetaGraph {
+          ${metadataGraphVariable} <${RDF_TYPE}> ?_dkgAliasRootType .
+        }
+        FILTER(STR(?_dkgAliasMetaGraph) = CONCAT(STR(${metadataGraphVariable}), "/_meta"))
+      }
+    }`;
+}
+
+/**
  * Build the one canonical graph-scoped metadata lookup.
  *
  * Rows are deliberately vertical (`predicate`, `value`) instead of a group of
@@ -131,11 +224,10 @@ export function buildGraphKnowledgeAssetMetadataQuery(ual: string): string {
       FILTER EXISTS {
         <${safeUal}> <${METADATA_PREDICATES.scopeVersion}> ?_scopeMarker .
       }
+      <${safeUal}> <${METADATA_PREDICATES.contextGraph}> ?_contextGraph .
     }
-    FILTER(
-      STRSTARTS(STR(?g), "${CONTEXT_GRAPH_PREFIX}") &&
-      STRENDS(STR(?g), "/_meta")
-    )
+    FILTER(STR(?g) = CONCAT(STR(?_contextGraph), "/_meta"))
+    ${buildTrustedRootContextGraphRegistrationFilter('?_contextGraph', '?g')}
   }`;
 }
 

--- a/packages/core/src/graph-knowledge-asset-metadata.ts
+++ b/packages/core/src/graph-knowledge-asset-metadata.ts
@@ -224,9 +224,9 @@ export function buildGraphKnowledgeAssetMetadataQuery(ual: string): string {
       FILTER EXISTS {
         <${safeUal}> <${METADATA_PREDICATES.scopeVersion}> ?_scopeMarker .
       }
-      <${safeUal}> <${METADATA_PREDICATES.contextGraph}> ?_contextGraph .
     }
-    FILTER(STR(?g) = CONCAT(STR(?_contextGraph), "/_meta"))
+    FILTER(STRENDS(STR(?g), "/_meta"))
+    BIND(IRI(SUBSTR(STR(?g), 1, STRLEN(STR(?g)) - 6)) AS ?_contextGraph)
     ${buildTrustedRootContextGraphRegistrationFilter('?_contextGraph', '?g')}
   }`;
 }

--- a/packages/core/src/graph-knowledge-asset-metadata.ts
+++ b/packages/core/src/graph-knowledge-asset-metadata.ts
@@ -128,7 +128,7 @@ export type GraphKnowledgeAssetMetadataParseResult =
  * roots keep the same declaration in their own control-plane metadata graph.
  * Payload and named-subgraph graphs are deliberately excluded.
  */
-export function buildTrustedRootContextGraphRegistrationFilter(
+function buildTrustedRootContextGraphRegistrationFilter(
   contextGraphVariable: string,
   metadataGraphVariable: string,
 ): string {
@@ -228,6 +228,57 @@ export function buildGraphKnowledgeAssetMetadataQuery(ual: string): string {
     }
     FILTER(STR(?g) = CONCAT(STR(?_contextGraph), "/_meta"))
     ${buildTrustedRootContextGraphRegistrationFilter('?_contextGraph', '?g')}
+  }`;
+}
+
+/** Build the complete trusted legacy metadata lookup used by query reads. */
+export function buildLegacyKnowledgeAssetMetadataQuery(ual: string): string {
+  const safeUal = assertSafeIri(ual);
+  return `SELECT ?ka ?rootEntity ?ctxGraph ?sgName WHERE {
+    GRAPH ?g {
+      {
+        ?ka <${DKG}rootEntity> ?rootEntity .
+        ?ka <${DKG}partOf> <${safeUal}> .
+      }
+      UNION
+      {
+        <${safeUal}> <${DKG}rootEntity> ?rootEntity .
+        BIND(<${safeUal}> AS ?ka)
+      }
+      <${safeUal}> <${DKG}contextGraph> ?ctxGraph .
+      OPTIONAL { <${safeUal}> <${DKG}subGraphName> ?sgName }
+      BIND(CONCAT(STR(?ctxGraph), "/_meta") AS ?expectedMetaGraph)
+      FILTER(STR(?g) = ?expectedMetaGraph)
+    }
+    ${buildTrustedRootContextGraphRegistrationFilter('?ctxGraph', '?g')}
+  } ORDER BY ?ka`;
+}
+
+/** Build the complete trusted legacy metadata lookup used by private access. */
+export function buildLegacyKnowledgeAssetAccessMetadataQuery(ual: string): string {
+  const safeUal = assertSafeIri(ual);
+  return `SELECT ?rootEntity ?contextGraph ?kc ?privateMerkleRoot ?privateTripleCount ?accessPolicy ?publisherPeerId ?attributedTo ?sgName WHERE {
+    GRAPH ?g {
+      {
+        <${safeUal}> <${DKG}rootEntity> ?rootEntity .
+        <${safeUal}> <${DKG}partOf> ?kc .
+      }
+      UNION
+      {
+        <${safeUal}> <${DKG}rootEntity> ?rootEntity .
+        BIND(<${safeUal}> AS ?kc)
+      }
+      ?kc <${DKG}contextGraph> ?contextGraph .
+      OPTIONAL { <${safeUal}> <${DKG}privateMerkleRoot> ?privateMerkleRoot }
+      OPTIONAL { <${safeUal}> <${DKG}privateTripleCount> ?privateTripleCount }
+      OPTIONAL { ?kc <${DKG}accessPolicy> ?accessPolicy }
+      OPTIONAL { ?kc <${DKG}publisherPeerId> ?publisherPeerId }
+      OPTIONAL { ?kc <${PROV}wasAttributedTo> ?attributedTo }
+      OPTIONAL { ?kc <${DKG}subGraphName> ?sgName }
+      BIND(CONCAT(STR(?contextGraph), "/_meta") AS ?expectedMetaGraph)
+      FILTER(STR(?g) = ?expectedMetaGraph)
+    }
+    ${buildTrustedRootContextGraphRegistrationFilter('?contextGraph', '?g')}
   }`;
 }
 

--- a/packages/core/src/graph-knowledge-asset-metadata.ts
+++ b/packages/core/src/graph-knowledge-asset-metadata.ts
@@ -1,0 +1,457 @@
+import {
+  parseRdfLiteralTerm,
+} from '@origintrail-official/dkg-rdf-utils';
+import {
+  contextGraphMetaUri,
+  validateContextGraphId,
+  validateSubGraphName,
+} from './constants.js';
+import {
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  createGraphKnowledgeAssetScope,
+  knowledgeAssetLayerGraphUri,
+  type GraphKnowledgeAssetScope,
+} from './ka-content-scope.js';
+import { MemoryLayer } from './memory-model.js';
+import { assertSafeIri, isSafeIri } from './sparql-safe.js';
+
+const DKG = 'http://dkg.io/ontology/';
+const PROV = 'http://www.w3.org/ns/prov#';
+const CONTEXT_GRAPH_PREFIX = 'did:dkg:context-graph:';
+
+const METADATA_PREDICATES = {
+  scopeVersion: `${DKG}contentScopeVersion`,
+  kaUal: `${DKG}kaUal`,
+  assertionVersion: `${DKG}assertionVersion`,
+  assertionGraph: `${DKG}assertionGraph`,
+  contextGraph: `${DKG}contextGraph`,
+  publicTripleCount: `${DKG}publicTripleCount`,
+  privateTripleCount: `${DKG}privateTripleCount`,
+  privateMerkleRoot: `${DKG}privateMerkleRoot`,
+  accessPolicy: `${DKG}accessPolicy`,
+  publisherPeerId: `${DKG}publisherPeerId`,
+  attributedTo: `${PROV}wasAttributedTo`,
+  sgName: `${DKG}subGraphName`,
+  allowedPeer: `${DKG}allowedPeer`,
+} as const;
+
+type MetadataField = keyof typeof METADATA_PREDICATES;
+type ParsedField = MetadataField | 'g';
+
+const METADATA_FIELDS = Object.keys(METADATA_PREDICATES) as MetadataField[];
+const FIELD_BY_PREDICATE = new Map<string, MetadataField>(
+  METADATA_FIELDS.map((field) => [METADATA_PREDICATES[field], field]),
+);
+
+/** One vertical property/value row returned by the canonical metadata query. */
+export interface GraphKnowledgeAssetMetadataPropertyBinding {
+  readonly g: string;
+  readonly predicate: string;
+  readonly value: string;
+}
+
+/**
+ * Compatibility shape for already-projected binding fixtures/callers. The
+ * canonical query uses property/value rows so multi-valued fields cannot form
+ * an OPTIONAL cross-product, but the parser accepts this shape as well.
+ */
+export interface GraphKnowledgeAssetMetadataProjectedBinding {
+  readonly g?: string;
+  readonly predicate?: never;
+  readonly value?: never;
+  readonly scopeVersion?: string;
+  readonly kaUal?: string;
+  readonly assertionVersion?: string;
+  readonly assertionGraph?: string;
+  readonly contextGraph?: string;
+  readonly publicTripleCount?: string;
+  readonly privateTripleCount?: string;
+  readonly privateMerkleRoot?: string;
+  readonly accessPolicy?: string;
+  readonly publisherPeerId?: string;
+  readonly attributedTo?: string;
+  readonly sgName?: string;
+  readonly allowedPeer?: string;
+}
+
+export type GraphKnowledgeAssetMetadataBinding =
+  | GraphKnowledgeAssetMetadataPropertyBinding
+  | GraphKnowledgeAssetMetadataProjectedBinding
+  | Readonly<Record<string, string | undefined>>;
+
+export type GraphKnowledgeAssetAccessPolicy = 'public' | 'ownerOnly' | 'allowList';
+
+/** Canonical, validated graph-scoped KA control-plane metadata. */
+export interface ParsedGraphKnowledgeAssetMetadata {
+  readonly contentScopeVersion: typeof GRAPH_KA_CONTENT_SCOPE_VERSION;
+  readonly scope: GraphKnowledgeAssetScope;
+  readonly ual: string;
+  readonly assertionVersion: string;
+  readonly assertionGraph: string;
+  readonly metadataGraph: string;
+  readonly contextGraphUri: string;
+  readonly contextGraphId: string;
+  readonly subGraphName?: string;
+  readonly publicTripleCount: number;
+  readonly privateTripleCount: number;
+  readonly privateMerkleRoot?: Uint8Array;
+  readonly accessPolicy?: GraphKnowledgeAssetAccessPolicy;
+  readonly publisherPeerId?: string;
+  readonly attributedTo?: string;
+  readonly allowedPeers: readonly string[];
+}
+
+export type GraphKnowledgeAssetMetadataParseResult =
+  | { readonly kind: 'absent' }
+  | { readonly kind: 'legacy' }
+  | { readonly kind: 'graph'; readonly metadata: ParsedGraphKnowledgeAssetMetadata };
+
+/**
+ * Build the one canonical graph-scoped metadata lookup.
+ *
+ * Rows are deliberately vertical (`predicate`, `value`) instead of a group of
+ * OPTIONAL columns. A KA with several allowed peers therefore stays linear in
+ * its metadata size rather than multiplying every optional value together.
+ * The graph-name filter is independent of the metadata payload: an incomplete
+ * V2 marker in a trusted `/_meta` graph remains visible and fails in the parser,
+ * while marker triples authored inside KA payload graphs are ignored.
+ */
+export function buildGraphKnowledgeAssetMetadataQuery(ual: string): string {
+  const safeUal = assertSafeIri(ual);
+  const predicates = METADATA_FIELDS
+    .map((field) => `<${METADATA_PREDICATES[field]}>`)
+    .join('\n      ');
+
+  return `SELECT ?g ?predicate ?value WHERE {
+    GRAPH ?g {
+      <${safeUal}> ?predicate ?value .
+      VALUES ?predicate {
+        ${predicates}
+      }
+      FILTER EXISTS {
+        <${safeUal}> <${METADATA_PREDICATES.scopeVersion}> ?_scopeMarker .
+      }
+    }
+    FILTER(
+      STRSTARTS(STR(?g), "${CONTEXT_GRAPH_PREFIX}") &&
+      STRENDS(STR(?g), "/_meta")
+    )
+  }`;
+}
+
+/**
+ * Parse graph-scoped KA bindings without allowing malformed V2 metadata to
+ * fall through to the legacy reader.
+ */
+export function parseGraphKnowledgeAssetMetadataBindings(
+  ual: string,
+  rows: readonly GraphKnowledgeAssetMetadataBinding[],
+): GraphKnowledgeAssetMetadataParseResult {
+  if (rows.length === 0) return { kind: 'absent' };
+
+  const valuesByField = pivotBindings(ual, rows);
+  const values = (field: ParsedField): string[] => [
+    ...(valuesByField.get(field) ?? []),
+  ];
+  const requireSingle = (field: ParsedField): string => {
+    const candidates = values(field);
+    if (candidates.length !== 1) {
+      throw new Error(
+        `Graph-scoped KA ${ual} has ${candidates.length === 0 ? 'missing' : 'ambiguous'} ${field} metadata`,
+      );
+    }
+    return candidates[0] as string;
+  };
+  const optionalSingle = (field: MetadataField): string | undefined => {
+    const candidates = values(field);
+    if (candidates.length > 1) {
+      throw new Error(`Graph-scoped KA ${ual} has ambiguous ${field} metadata`);
+    }
+    return candidates[0];
+  };
+
+  const rawScopeVersions = values('scopeVersion');
+  if (rawScopeVersions.length === 0) {
+    throw new Error(`Graph-scoped KA ${ual} has missing contentScopeVersion metadata`);
+  }
+  if (rawScopeVersions.length !== 1) {
+    throw new Error(`Graph-scoped KA ${ual} has ambiguous contentScopeVersion metadata`);
+  }
+  const scopeVersion = parseInteger(
+    ual,
+    rawScopeVersions[0] as string,
+    'contentScopeVersion',
+  );
+  if (scopeVersion === 0n || scopeVersion === 1n) return { kind: 'legacy' };
+  if (scopeVersion !== BigInt(GRAPH_KA_CONTENT_SCOPE_VERSION)) {
+    throw new Error(`Unsupported KA contentScopeVersion: ${scopeVersion}`);
+  }
+
+  const metadataGraph = requireIri(ual, requireSingle('g'), 'metadata graph');
+  const metadataUal = requireIri(ual, requireSingle('kaUal'), 'kaUal');
+  if (metadataUal !== ual) {
+    throw new Error(
+      `Graph-scoped KA metadata UAL mismatch: requested ${ual}, found ${metadataUal}`,
+    );
+  }
+
+  const assertionVersionRaw = decodeBindingValue(
+    ual,
+    requireSingle('assertionVersion'),
+    'assertionVersion',
+  );
+  const assertionVersion = parseInteger(
+    ual,
+    requireSingle('assertionVersion'),
+    'assertionVersion',
+  ).toString();
+  if (assertionVersionRaw !== assertionVersion) {
+    throw new Error(
+      `Graph-scoped KA ${ual} has non-canonical assertionVersion: ${assertionVersionRaw}`,
+    );
+  }
+  const scope = createGraphKnowledgeAssetScope(metadataUal, assertionVersion);
+  if (scope.ual !== metadataUal) {
+    throw new Error(
+      `Graph-scoped KA metadata has non-canonical kaUal: ${metadataUal}`,
+    );
+  }
+
+  const contextGraphUri = requireIri(
+    ual,
+    requireSingle('contextGraph'),
+    'contextGraph',
+  );
+  if (!contextGraphUri.startsWith(CONTEXT_GRAPH_PREFIX)) {
+    throw new Error(
+      `Graph-scoped KA ${ual} has invalid contextGraph metadata: ${contextGraphUri}`,
+    );
+  }
+  const contextGraphId = contextGraphUri.slice(CONTEXT_GRAPH_PREFIX.length);
+  const contextGraphValidation = validateContextGraphId(contextGraphId);
+  if (!contextGraphValidation.valid) {
+    throw new Error(
+      `Graph-scoped KA ${ual} has invalid contextGraph metadata: ${contextGraphValidation.reason}`,
+    );
+  }
+  const expectedMetaGraph = contextGraphMetaUri(contextGraphId);
+  if (metadataGraph !== expectedMetaGraph) {
+    throw new Error(
+      `Graph-scoped KA ${ual} metadata graph mismatch: ` +
+        `expected ${expectedMetaGraph}, found ${metadataGraph}`,
+    );
+  }
+
+  const rawSubGraphName = optionalSingle('sgName');
+  const subGraphName = rawSubGraphName === undefined
+    ? undefined
+    : decodeBindingValue(ual, rawSubGraphName, 'subGraphName');
+  if (subGraphName !== undefined) {
+    const validation = validateSubGraphName(subGraphName);
+    if (!validation.valid) {
+      throw new Error(
+        `Graph-scoped KA ${ual} has invalid subGraphName: ${validation.reason}`,
+      );
+    }
+  }
+
+  const expectedAssertionGraph = knowledgeAssetLayerGraphUri(
+    contextGraphId,
+    MemoryLayer.VerifiableMemory,
+    scope,
+    subGraphName,
+  );
+  const assertionGraph = requireIri(
+    ual,
+    requireSingle('assertionGraph'),
+    'assertionGraph',
+  );
+  if (assertionGraph !== expectedAssertionGraph) {
+    throw new Error(
+      `Graph-scoped KA ${ual} assertionGraph mismatch: ` +
+        `expected ${expectedAssertionGraph}, found ${assertionGraph}`,
+    );
+  }
+
+  const publicTripleCount = parseSafeCount(
+    ual,
+    requireSingle('publicTripleCount'),
+    'publicTripleCount',
+  );
+  const privateTripleCount = parseSafeCount(
+    ual,
+    requireSingle('privateTripleCount'),
+    'privateTripleCount',
+  );
+  if (publicTripleCount === 0 && privateTripleCount === 0) {
+    throw new Error(`Graph-scoped KA ${ual} metadata cannot describe an empty asset`);
+  }
+
+  const privateRootCandidates = values('privateMerkleRoot');
+  if (privateTripleCount > 0 && privateRootCandidates.length !== 1) {
+    throw new Error(
+      `Graph-scoped KA ${ual} requires exactly one privateMerkleRoot for private content`,
+    );
+  }
+  if (privateTripleCount === 0 && privateRootCandidates.length !== 0) {
+    throw new Error(
+      `Graph-scoped KA ${ual} has a privateMerkleRoot without private content`,
+    );
+  }
+  const privateMerkleRoot = privateRootCandidates[0] === undefined
+    ? undefined
+    : decodeHexBytes32(ual, privateRootCandidates[0]);
+
+  const accessPolicy = decodeAccessPolicy(ual, optionalSingle('accessPolicy'));
+  const publisherPeerId = decodeOptionalValue(
+    ual,
+    optionalSingle('publisherPeerId'),
+    'publisherPeerId',
+  );
+  const attributedTo = decodeOptionalValue(
+    ual,
+    optionalSingle('attributedTo'),
+    'attributedTo',
+  );
+  const allowedPeers = [
+    ...new Set(
+      values('allowedPeer').map((raw) =>
+        decodeBindingValue(ual, raw, 'allowedPeer')),
+    ),
+  ];
+
+  return {
+    kind: 'graph',
+    metadata: {
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      scope,
+      ual: scope.ual,
+      assertionVersion: scope.assertionVersion,
+      assertionGraph,
+      metadataGraph,
+      contextGraphUri,
+      contextGraphId,
+      subGraphName,
+      publicTripleCount,
+      privateTripleCount,
+      privateMerkleRoot,
+      accessPolicy,
+      publisherPeerId,
+      attributedTo,
+      allowedPeers,
+    },
+  };
+}
+
+function pivotBindings(
+  ual: string,
+  rows: readonly GraphKnowledgeAssetMetadataBinding[],
+): Map<ParsedField, Set<string>> {
+  const result = new Map<ParsedField, Set<string>>();
+  const add = (field: ParsedField, value: string): void => {
+    const existing = result.get(field);
+    if (existing) {
+      existing.add(value);
+    } else {
+      result.set(field, new Set([value]));
+    }
+  };
+
+  for (const row of rows) {
+    if (row.g !== undefined) add('g', row.g);
+
+    if ('predicate' in row || 'value' in row) {
+      if (typeof row.predicate !== 'string' || typeof row.value !== 'string') {
+        throw new Error(`Graph-scoped KA ${ual} has malformed property/value metadata`);
+      }
+      const field = FIELD_BY_PREDICATE.get(row.predicate);
+      if (!field) {
+        throw new Error(
+          `Graph-scoped KA ${ual} has unexpected metadata predicate: ${row.predicate}`,
+        );
+      }
+      add(field, row.value);
+      continue;
+    }
+
+    for (const field of METADATA_FIELDS) {
+      const value = row[field];
+      if (value !== undefined) add(field, value);
+    }
+  }
+
+  return result;
+}
+
+function decodeBindingValue(ual: string, raw: string, field: string): string {
+  if (raw.length === 0) {
+    throw new Error(`Graph-scoped KA ${ual} has invalid ${field}: (empty)`);
+  }
+  if (!raw.startsWith('"')) return raw;
+
+  const literal = parseRdfLiteralTerm(raw);
+  if (!literal) {
+    throw new Error(`Graph-scoped KA ${ual} has invalid ${field}: ${raw}`);
+  }
+  return literal.value;
+}
+
+function parseInteger(ual: string, raw: string, field: string): bigint {
+  const value = decodeBindingValue(ual, raw, field);
+  if (!/^-?\d+$/.test(value)) {
+    throw new Error(`Graph-scoped KA ${ual} has invalid ${field}: ${raw}`);
+  }
+  return BigInt(value);
+}
+
+function parseSafeCount(ual: string, raw: string, field: string): number {
+  const value = parseInteger(ual, raw, field);
+  if (value < 0n || value > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new Error(`Graph-scoped KA ${ual} has invalid ${field}: ${value}`);
+  }
+  return Number(value);
+}
+
+function requireIri(ual: string, raw: string, field: string): string {
+  if (!isSafeIri(raw)) {
+    throw new Error(`Graph-scoped KA ${ual} has invalid ${field}: ${raw}`);
+  }
+  return raw;
+}
+
+function decodeHexBytes32(ual: string, raw: string): Uint8Array {
+  const decoded = decodeBindingValue(ual, raw, 'privateMerkleRoot');
+  const hex = decoded.replace(/^0x/i, '');
+  if (!/^[0-9a-fA-F]{64}$/.test(hex)) {
+    throw new Error(
+      `Graph-scoped KA ${ual} privateMerkleRoot must be exactly 32 bytes of hexadecimal data`,
+    );
+  }
+  const pairs = hex.match(/.{2}/g);
+  if (!pairs || pairs.length !== 32) {
+    throw new Error(
+      `Graph-scoped KA ${ual} privateMerkleRoot must be exactly 32 bytes of hexadecimal data`,
+    );
+  }
+  return Uint8Array.from(pairs.map((pair) => Number.parseInt(pair, 16)));
+}
+
+function decodeAccessPolicy(
+  ual: string,
+  raw: string | undefined,
+): GraphKnowledgeAssetAccessPolicy | undefined {
+  if (raw === undefined) return undefined;
+  const value = decodeBindingValue(ual, raw, 'accessPolicy');
+  if (value !== 'public' && value !== 'ownerOnly' && value !== 'allowList') {
+    throw new Error(`Graph-scoped KA ${ual} has invalid accessPolicy: ${value}`);
+  }
+  return value;
+}
+
+function decodeOptionalValue(
+  ual: string,
+  raw: string | undefined,
+  field: string,
+): string | undefined {
+  return raw === undefined ? undefined : decodeBindingValue(ual, raw, field);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,6 +7,7 @@ export * from './catalog.js';
 export { parseDotenvValue } from './dotenv.js';
 export * from './memory-model.js';
 export * from './ka-content-scope.js';
+export * from './graph-knowledge-asset-metadata.js';
 export * from './trust.js';
 export * from './sparql-operation.js';
 export * from './publisher-extension.js';

--- a/packages/core/test/constants.test.ts
+++ b/packages/core/test/constants.test.ts
@@ -159,6 +159,17 @@ describe('validateContextGraphId', () => {
     expect(validateContextGraphId('user@domain').valid).toBe(true);
   });
 
+  it('rejects path segments reserved for storage partitions', () => {
+    for (const id of [
+      'victim/_meta',
+      'victim/_private',
+      'victim/_shared_memory',
+      'victim/_future-partition',
+    ]) {
+      expect(validateContextGraphId(id)).toMatchObject({ valid: false });
+    }
+  });
+
   it('rejects IDs exceeding 256 chars', () => {
     expect(validateContextGraphId('a'.repeat(257)).valid).toBe(false);
     expect(validateContextGraphId('a'.repeat(256)).valid).toBe(true);

--- a/packages/core/test/constants.test.ts
+++ b/packages/core/test/constants.test.ts
@@ -9,6 +9,7 @@ import {
   contextGraphWorkspaceTopic,
   DHT_PROTOCOL,
   validateContextGraphId,
+  validateNewContextGraphId,
   validateSubGraphName,
   validateAssertionName,
   deriveCuratorDidFromCgId,
@@ -159,14 +160,15 @@ describe('validateContextGraphId', () => {
     expect(validateContextGraphId('user@domain').valid).toBe(true);
   });
 
-  it('rejects path segments reserved for storage partitions', () => {
+  it('reserves structural partition segments for new IDs without breaking legacy reads', () => {
     for (const id of [
       'victim/_meta',
       'victim/_private',
       'victim/_shared_memory',
       'victim/_future-partition',
     ]) {
-      expect(validateContextGraphId(id)).toMatchObject({ valid: false });
+      expect(validateContextGraphId(id)).toEqual({ valid: true });
+      expect(validateNewContextGraphId(id)).toMatchObject({ valid: false });
     }
   });
 

--- a/packages/publisher/src/access-handler.ts
+++ b/packages/publisher/src/access-handler.ts
@@ -1,12 +1,21 @@
-import type { StreamHandler, EventBus } from '@origintrail-official/dkg-core';
+import type {
+  StreamHandler,
+  EventBus,
+  GraphKnowledgeAssetScope,
+} from '@origintrail-official/dkg-core';
 import {
   DKGEvent,
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  MemoryLayer,
+  createGraphKnowledgeAssetScope,
   decodeAccessRequest,
   encodeAccessResponse,
   ed25519Verify,
   assertSafeIri,
+  knowledgeAssetLayerGraphUri,
+  validateSubGraphName,
 } from '@origintrail-official/dkg-core';
-import type { TripleStore } from '@origintrail-official/dkg-storage';
+import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
 import { GraphManager, PrivateContentStore } from '@origintrail-official/dkg-storage';
 import { computePrivateRootV10 as computePrivateRoot } from './merkle.js';
 
@@ -14,16 +23,7 @@ const DKG_NS = 'http://dkg.io/ontology/';
 
 export type AccessPolicy = 'public' | 'ownerOnly' | 'allowList';
 
-interface KAMeta {
-  rootEntity: string;
-  /**
-   * ALL distinct member roots bound by the meta query (binding order).
-   * On the collapsed multi-root shape (RFC ka-metadata-trim P3.1) a bare-UAL
-   * request cannot name a member, so the handler scans these for the first
-   * root that actually has a private bag instead of denying on an
-   * engine-arbitrary first binding (Codex review "multi-root-access").
-   */
-  rootEntities: string[];
+interface KAMetaBase {
   contextGraphId: string;
   subGraphName?: string;
   privateMerkleRoot?: Uint8Array;
@@ -33,6 +33,29 @@ interface KAMeta {
   publisherPeerId?: string;
   allowedPeers?: string[];
 }
+
+interface GraphScopedKAMeta extends KAMetaBase {
+  contentScopeVersion: typeof GRAPH_KA_CONTENT_SCOPE_VERSION;
+  scope: GraphKnowledgeAssetScope;
+  privateTripleCount: number;
+  rootEntities: [];
+  rootEntity?: never;
+}
+
+interface LegacyRootKAMeta extends KAMetaBase {
+  contentScopeVersion: 1;
+  rootEntity: string;
+  /**
+   * ALL distinct member roots bound by the meta query (binding order).
+   * On the collapsed multi-root shape (RFC ka-metadata-trim P3.1) a bare-UAL
+   * request cannot name a member, so the handler scans these for the first
+   * root that actually has a private bag instead of denying on an
+   * engine-arbitrary first binding (Codex review "multi-root-access").
+   */
+  rootEntities: string[];
+}
+
+type KAMeta = GraphScopedKAMeta | LegacyRootKAMeta;
 
 /**
  * Handles incoming /dkg/access/1.0.0 requests on the publisher node.
@@ -80,25 +103,28 @@ export class AccessHandler {
         return this.deny('Access denied: invalid access policy metadata');
       }
 
-      // Codex review "multi-root-access" hardening: on the collapsed
-      // multi-root shape, SPARQL binding order is unspecified — the first
-      // bound root may have no private bag even though another member does
-      // (bags are stored strictly per root). Serve the FIRST member root
-      // that actually has a bag; the ambiguous-pairing guard below already
-      // forces the attested privateMerkleRoot to be recomputed over the
-      // served triples, so the attestation always matches what is sent.
-      // Single-root KAs (and legacy `<ual>/<n>` requests, inherently 1:1)
-      // are unchanged.
-      let servedRootEntity = meta.rootEntity;
-      let hasPrivate = false;
-      for (const root of meta.rootEntities) {
-        if (
-          this.privateStore.hasPrivateTriples(meta.contextGraphId, root, meta.subGraphName) ||
-          (await this.privateStore.hasPrivateTriplesInStore(meta.contextGraphId, root, meta.subGraphName))
-        ) {
-          servedRootEntity = root;
-          hasPrivate = true;
-          break;
+      let servedRootEntity: string | undefined;
+      let hasPrivate: boolean;
+      if (meta.contentScopeVersion === GRAPH_KA_CONTENT_SCOPE_VERSION) {
+        // V2 metadata commits the complete private payload as one exact
+        // `(UAL, assertionVersion)` graph. Do not infer membership from RDF
+        // subjects and do not touch the legacy shared private bucket.
+        hasPrivate = (meta.privateTripleCount ?? 0) > 0;
+      } else {
+        // Existing collapsed multi-root KAs have one private bag per root and
+        // no reliable root-to-private-root pairing. Preserve their read-only
+        // lookup by selecting the first member whose legacy bag exists.
+        servedRootEntity = meta.rootEntity;
+        hasPrivate = false;
+        for (const root of meta.rootEntities) {
+          if (
+            this.privateStore.hasPrivateTriples(meta.contextGraphId, root, meta.subGraphName) ||
+            (await this.privateStore.hasPrivateTriplesInStore(meta.contextGraphId, root, meta.subGraphName))
+          ) {
+            servedRootEntity = root;
+            hasPrivate = true;
+            break;
+          }
         }
       }
 
@@ -157,17 +183,37 @@ export class AccessHandler {
         }
       }
 
-      const privateQuads = await this.privateStore.getPrivateTriples(
-        meta.contextGraphId,
-        servedRootEntity,
-        meta.subGraphName,
-      );
+      let privateQuads: Quad[];
+      if (meta.contentScopeVersion === GRAPH_KA_CONTENT_SCOPE_VERSION) {
+        privateQuads = await this.privateStore.getKnowledgeAssetPrivateTriples(
+          meta.contextGraphId,
+          meta.scope,
+          meta.subGraphName,
+        );
+        if (privateQuads.length !== meta.privateTripleCount) {
+          return this.deny(
+            `Private KA integrity check failed: metadata declares ${meta.privateTripleCount} triples, ` +
+              `found ${privateQuads.length}`,
+          );
+        }
+        const computedPrivateRoot = computePrivateRoot(privateQuads);
+        if (
+          !computedPrivateRoot
+          || !meta.privateMerkleRoot
+          || !bytesEqual(computedPrivateRoot, meta.privateMerkleRoot)
+        ) {
+          return this.deny('Private KA integrity check failed: Merkle root mismatch');
+        }
+      } else {
+        privateQuads = await this.privateStore.getPrivateTriples(
+          meta.contextGraphId,
+          servedRootEntity!,
+          meta.subGraphName,
+        );
+      }
 
       const nquads = privateQuads
-        .map(
-          (q) =>
-            `<${q.subject}> <${q.predicate}> ${q.object} <${q.graph}> .`,
-        )
+        .map((q) => serializeAccessQuad(q))
         .join('\n');
 
       // Compute real privateMerkleRoot from the actual triples
@@ -199,7 +245,10 @@ export class AccessHandler {
   }
 
   private async lookupKAMeta(kaUal: string): Promise<KAMeta | null> {
-    const direct = await this.queryKAMeta(kaUal);
+    const graphScoped = await this.queryGraphScopedKAMeta(kaUal);
+    if (graphScoped) return graphScoped;
+
+    const direct = await this.queryLegacyKAMeta(kaUal);
     if (direct) return direct;
     // Read-both (RFC ka-metadata-trim P3.1): older requesters address private
     // content by the legacy token row `<ual>/<n>`; the collapsed shape keys
@@ -207,12 +256,188 @@ export class AccessHandler {
     // old-client requests keep resolving against new-shape stores.
     const legacyToken = /^(.+)\/\d+$/.exec(kaUal);
     if (legacyToken && legacyToken[1]) {
-      return this.queryKAMeta(legacyToken[1]);
+      return this.queryLegacyKAMeta(legacyToken[1]);
     }
     return null;
   }
 
-  private async queryKAMeta(kaUal: string): Promise<KAMeta | null> {
+  private async queryGraphScopedKAMeta(
+    kaUal: string,
+  ): Promise<GraphScopedKAMeta | null> {
+    const safeUal = assertSafeIri(kaUal);
+    const result = await this.store.query(
+      `SELECT ?g ?scopeVersion ?kaUal ?assertionVersion ?assertionGraph ?contextGraph ` +
+        `?privateMerkleRoot ?privateTripleCount ?accessPolicy ?publisherPeerId ` +
+        `?attributedTo ?sgName ?allowedPeer WHERE {
+        GRAPH ?g {
+          <${safeUal}> <${DKG_NS}contentScopeVersion> ?scopeVersion .
+          OPTIONAL { <${safeUal}> <${DKG_NS}kaUal> ?kaUal }
+          OPTIONAL { <${safeUal}> <${DKG_NS}assertionVersion> ?assertionVersion }
+          OPTIONAL { <${safeUal}> <${DKG_NS}assertionGraph> ?assertionGraph }
+          OPTIONAL { <${safeUal}> <${DKG_NS}contextGraph> ?contextGraph }
+          OPTIONAL { <${safeUal}> <${DKG_NS}privateMerkleRoot> ?privateMerkleRoot }
+          OPTIONAL { <${safeUal}> <${DKG_NS}privateTripleCount> ?privateTripleCount }
+          OPTIONAL { <${safeUal}> <${DKG_NS}accessPolicy> ?accessPolicy }
+          OPTIONAL { <${safeUal}> <${DKG_NS}publisherPeerId> ?publisherPeerId }
+          OPTIONAL { <${safeUal}> <http://www.w3.org/ns/prov#wasAttributedTo> ?attributedTo }
+          OPTIONAL { <${safeUal}> <${DKG_NS}subGraphName> ?sgName }
+          OPTIONAL { <${safeUal}> <${DKG_NS}allowedPeer> ?allowedPeer }
+        }
+      }`,
+    );
+    if (result.type !== 'bindings' || result.bindings.length === 0) return null;
+
+    const values = (field: string): string[] => [
+      ...new Set(
+        result.bindings
+          .map((row) => row[field])
+          .filter((value): value is string => typeof value === 'string' && value.length > 0),
+      ),
+    ];
+    const requireSingle = (field: string): string => {
+      const candidates = values(field);
+      if (candidates.length !== 1) {
+        throw new Error(
+          `Graph-scoped KA ${kaUal} has ${candidates.length === 0 ? 'missing' : 'ambiguous'} ${field} metadata`,
+        );
+      }
+      return candidates[0] as string;
+    };
+    const optionalSingle = (field: string): string | undefined => {
+      const candidates = values(field);
+      if (candidates.length > 1) {
+        throw new Error(`Graph-scoped KA ${kaUal} has ambiguous ${field} metadata`);
+      }
+      return candidates[0];
+    };
+    const parseInteger = (raw: string, field: string): bigint => {
+      const value = stripLiteral(raw);
+      if (!/^-?\d+$/.test(value)) {
+        throw new Error(`Graph-scoped KA ${kaUal} has invalid ${field}: ${raw}`);
+      }
+      return BigInt(value);
+    };
+
+    const scopeVersions = values('scopeVersion').map((raw) =>
+      parseInteger(raw, 'contentScopeVersion'),
+    );
+    const uniqueScopeVersions = [...new Set(scopeVersions.map(String))];
+    if (uniqueScopeVersions.length !== 1) {
+      throw new Error(`Graph-scoped KA ${kaUal} has ambiguous contentScopeVersion metadata`);
+    }
+    const scopeVersion = BigInt(uniqueScopeVersions[0] as string);
+    if (scopeVersion === 1n) return null;
+    if (scopeVersion !== BigInt(GRAPH_KA_CONTENT_SCOPE_VERSION)) {
+      throw new Error(`Unsupported KA contentScopeVersion: ${scopeVersion}`);
+    }
+
+    const metadataUal = requireSingle('kaUal');
+    if (metadataUal !== safeUal) {
+      throw new Error(`Graph-scoped KA metadata UAL mismatch: requested ${safeUal}, found ${metadataUal}`);
+    }
+
+    const contextGraphUri = requireSingle('contextGraph');
+    const contextGraphPrefix = 'did:dkg:context-graph:';
+    if (!contextGraphUri.startsWith(contextGraphPrefix)) {
+      throw new Error(`Graph-scoped KA ${kaUal} has invalid contextGraph metadata`);
+    }
+    const contextGraphId = contextGraphUri.slice(contextGraphPrefix.length);
+    if (!contextGraphId) {
+      throw new Error(`Graph-scoped KA ${kaUal} has an empty context graph id`);
+    }
+    const expectedMetaGraph = `${contextGraphUri}/_meta`;
+    const metadataGraph = requireSingle('g');
+    if (metadataGraph !== expectedMetaGraph) {
+      throw new Error(
+        `Graph-scoped KA ${kaUal} metadata graph mismatch: expected ${expectedMetaGraph}, found ${metadataGraph}`,
+      );
+    }
+
+    const subGraphNameRaw = optionalSingle('sgName');
+    const subGraphName = subGraphNameRaw === undefined
+      ? undefined
+      : stripLiteral(subGraphNameRaw);
+    if (subGraphName !== undefined) {
+      const validation = validateSubGraphName(subGraphName);
+      if (!validation.valid) {
+        throw new Error(
+          `Graph-scoped KA ${kaUal} has invalid subGraphName: ${validation.reason}`,
+        );
+      }
+    }
+
+    const assertionVersion = parseInteger(
+      requireSingle('assertionVersion'),
+      'assertionVersion',
+    ).toString();
+    const scope = createGraphKnowledgeAssetScope(safeUal, assertionVersion);
+    const expectedAssertionGraph = knowledgeAssetLayerGraphUri(
+      contextGraphId,
+      MemoryLayer.VerifiableMemory,
+      scope,
+      subGraphName,
+    );
+    const assertionGraph = requireSingle('assertionGraph');
+    if (assertionGraph !== expectedAssertionGraph) {
+      throw new Error(
+        `Graph-scoped KA ${kaUal} assertionGraph mismatch: ` +
+          `expected ${expectedAssertionGraph}, found ${assertionGraph}`,
+      );
+    }
+
+    const privateTripleCountBig = parseInteger(
+      requireSingle('privateTripleCount'),
+      'privateTripleCount',
+    );
+    if (
+      privateTripleCountBig < 0n
+      || privateTripleCountBig > BigInt(Number.MAX_SAFE_INTEGER)
+    ) {
+      throw new Error(
+        `Graph-scoped KA ${kaUal} has invalid privateTripleCount: ${privateTripleCountBig}`,
+      );
+    }
+    const privateTripleCount = Number(privateTripleCountBig);
+    const privateRootRaw = optionalSingle('privateMerkleRoot');
+    if (privateTripleCount > 0 && privateRootRaw === undefined) {
+      throw new Error(`Graph-scoped KA ${kaUal} is missing privateMerkleRoot metadata`);
+    }
+    if (privateTripleCount === 0 && privateRootRaw !== undefined) {
+      throw new Error(`Graph-scoped KA ${kaUal} has a privateMerkleRoot without private content`);
+    }
+    const privateMerkleRoot = privateRootRaw === undefined
+      ? undefined
+      : decodeHexBytes32(privateRootRaw, `Graph-scoped KA ${kaUal} privateMerkleRoot`);
+
+    const rawPolicy = optionalSingle('accessPolicy');
+    const parsedPolicy = rawPolicy === undefined ? undefined : stripLiteral(rawPolicy);
+    const accessPolicy = isAccessPolicy(parsedPolicy) ? parsedPolicy : undefined;
+    const hasInvalidExplicitPolicy = parsedPolicy !== undefined && !isAccessPolicy(parsedPolicy);
+    const publisherPeerIdRaw = optionalSingle('publisherPeerId');
+    const attributedToRaw = optionalSingle('attributedTo');
+    const publisherPeerId = publisherPeerIdRaw !== undefined
+      ? stripLiteral(publisherPeerIdRaw)
+      : attributedToRaw !== undefined
+        ? stripLiteral(attributedToRaw)
+        : undefined;
+    const allowedPeers = values('allowedPeer').map(stripLiteral);
+
+    return {
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      scope,
+      rootEntities: [],
+      contextGraphId,
+      subGraphName,
+      privateMerkleRoot,
+      privateTripleCount,
+      accessPolicy,
+      hasInvalidExplicitPolicy,
+      publisherPeerId,
+      allowedPeers,
+    };
+  }
+
+  private async queryLegacyKAMeta(kaUal: string): Promise<LegacyRootKAMeta | null> {
     const safeUal = assertSafeIri(kaUal);
     // Read-both (RFC ka-metadata-trim P3.1): the collapsed shape has NO
     // `<ual>/<n>` token row — the UAL subject itself carries the entity pair
@@ -323,6 +548,7 @@ export class AccessHandler {
         : undefined;
 
     return {
+      contentScopeVersion: 1,
       rootEntity,
       rootEntities: [...distinctRoots],
       contextGraphId,
@@ -362,6 +588,24 @@ function stripLiteral(s: string): string {
   const match = s.match(/^"(.*)"(\^\^.*|@.*)?$/);
   if (match) return match[1];
   return s;
+}
+
+function decodeHexBytes32(raw: string, field: string): Uint8Array {
+  const hex = stripLiteral(raw).replace(/^0x/i, '');
+  if (!/^[0-9a-f]{64}$/i.test(hex)) {
+    throw new Error(`${field} must be exactly 32 bytes of hexadecimal data`);
+  }
+  return Uint8Array.from(hex.match(/.{2}/g)!.map((pair) => Number.parseInt(pair, 16)));
+}
+
+function bytesEqual(left: Uint8Array, right: Uint8Array): boolean {
+  return left.length === right.length && left.every((byte, index) => byte === right[index]);
+}
+
+function serializeAccessQuad(quad: Quad): string {
+  const subject = quad.subject.startsWith('_:') ? quad.subject : `<${quad.subject}>`;
+  const graph = quad.graph ? ` <${quad.graph}>` : '';
+  return `${subject} <${quad.predicate}> ${quad.object}${graph} .`;
 }
 
 function isAccessPolicy(value: string | undefined): value is AccessPolicy {

--- a/packages/publisher/src/access-handler.ts
+++ b/packages/publisher/src/access-handler.ts
@@ -7,6 +7,7 @@ import {
   DKGEvent,
   GRAPH_KA_CONTENT_SCOPE_VERSION,
   buildGraphKnowledgeAssetMetadataQuery,
+  buildTrustedRootContextGraphRegistrationFilter,
   decodeAccessRequest,
   encodeAccessResponse,
   ed25519Verify,
@@ -354,6 +355,7 @@ export class AccessHandler {
           BIND(CONCAT(STR(?contextGraph), '/_meta') AS ?expectedMetaGraph)
           FILTER(STR(?g) = ?expectedMetaGraph)
         }
+        ${buildTrustedRootContextGraphRegistrationFilter('?contextGraph', '?g')}
       }`,
     );
 

--- a/packages/publisher/src/access-handler.ts
+++ b/packages/publisher/src/access-handler.ts
@@ -279,7 +279,8 @@ export class AccessHandler {
 
   private async lookupKAMeta(kaUal: string): Promise<KAMeta | null> {
     const legacyAliasBase = legacyTokenAliasBase(kaUal);
-    const canonicalUal = legacyAliasBase ?? kaUal;
+    const graphScopedAliasBase = canonicalDeterministicUal(legacyAliasBase);
+    const canonicalUal = graphScopedAliasBase ?? kaUal;
     // A token-form legacy alias must not bypass a V2 marker on the canonical
     // bare UAL. Resolve the canonical control plane before either legacy path.
     const resolved = await resolveGraphScopedOrLegacyMetadata(
@@ -300,7 +301,7 @@ export class AccessHandler {
       // Numeric token suffixes are a legacy compatibility address only.
       // A V2 asset has one canonical UAL; detect its marker above so an alias
       // cannot fall through, but never serve graph-scoped data through it.
-      if (legacyAliasBase) return null;
+      if (graphScopedAliasBase) return null;
       return this.graphScopedKAMeta(resolved.metadata);
     }
     return resolved.kind === 'legacy' ? resolved.metadata : null;
@@ -465,14 +466,21 @@ function isAccessPolicy(value: string | undefined): value is AccessPolicy {
 }
 
 function legacyTokenAliasBase(kaUal: string): string | undefined {
-  const match = /^(.+)\/\d+$/.exec(kaUal);
-  const candidate = match?.[1];
-  if (!candidate) return undefined;
   try {
-    return parseDeterministicKnowledgeAssetUal(candidate).ual;
+    parseDeterministicKnowledgeAssetUal(kaUal);
+    return undefined;
   } catch {
-    // A canonical bare UAL also ends in digits. Its prefix is not itself a
-    // deterministic KA UAL, so it must never be stripped as a token alias.
+    // Continue: non-deterministic legacy UALs may still carry a token suffix.
+  }
+  const match = /^(.+)\/\d+$/.exec(kaUal);
+  return match?.[1];
+}
+
+function canonicalDeterministicUal(ual: string | undefined): string | undefined {
+  if (!ual) return undefined;
+  try {
+    return parseDeterministicKnowledgeAssetUal(ual).ual;
+  } catch {
     return undefined;
   }
 }

--- a/packages/publisher/src/access-handler.ts
+++ b/packages/publisher/src/access-handler.ts
@@ -6,14 +6,13 @@ import type {
 import {
   DKGEvent,
   GRAPH_KA_CONTENT_SCOPE_VERSION,
-  buildGraphKnowledgeAssetMetadataQuery,
-  buildTrustedRootContextGraphRegistrationFilter,
+  buildLegacyKnowledgeAssetAccessMetadataQuery,
   decodeAccessRequest,
   encodeAccessResponse,
   ed25519Verify,
   assertSafeIri,
   parseDeterministicKnowledgeAssetUal,
-  parseGraphKnowledgeAssetMetadataBindings,
+  type ParsedGraphKnowledgeAssetMetadata,
 } from '@origintrail-official/dkg-core';
 import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
 import {
@@ -21,6 +20,7 @@ import {
   GraphManager,
   PrivateContentStore,
   quadsToNQuads,
+  resolveGraphScopedOrLegacyMetadata,
 } from '@origintrail-official/dkg-storage';
 import { computePrivateRootV10 as computePrivateRoot } from './merkle.js';
 
@@ -282,35 +282,29 @@ export class AccessHandler {
     const canonicalUal = legacyAliasBase ?? kaUal;
     // A token-form legacy alias must not bypass a V2 marker on the canonical
     // bare UAL. Resolve the canonical control plane before either legacy path.
-    const graphScoped = await this.queryGraphScopedKAMeta(canonicalUal);
-    if (graphScoped) return graphScoped;
-
-    const direct = await this.queryLegacyKAMeta(kaUal);
-    if (direct) return direct;
-    // Read-both (RFC ka-metadata-trim P3.1): older requesters address private
-    // content by the legacy token row `<ual>/<n>`; the collapsed shape keys
-    // everything on the bare UAL. Strip a numeric suffix and retry once so
-    // old-client requests keep resolving against new-shape stores.
-    if (legacyAliasBase) {
-      return this.queryLegacyKAMeta(legacyAliasBase);
+    const resolved = await resolveGraphScopedOrLegacyMetadata(
+      this.store,
+      canonicalUal,
+      async () => {
+        const direct = await this.queryLegacyKAMeta(kaUal);
+        if (direct) return direct;
+        // Read-both (RFC ka-metadata-trim P3.1): older requesters address
+        // private content by `<ual>/<n>`. Retry the canonical bare UAL once.
+        return legacyAliasBase
+          ? this.queryLegacyKAMeta(legacyAliasBase)
+          : null;
+      },
+      { source: 'publisher.access.metadata' },
+    );
+    if (resolved.kind === 'graph') {
+      return this.graphScopedKAMeta(resolved.metadata);
     }
-    return null;
+    return resolved.kind === 'legacy' ? resolved.metadata : null;
   }
 
-  private async queryGraphScopedKAMeta(
-    kaUal: string,
-  ): Promise<GraphScopedKAMeta | null> {
-    const safeUal = assertSafeIri(kaUal);
-    const result = await this.store.query(
-      buildGraphKnowledgeAssetMetadataQuery(safeUal),
-    );
-    const parsed = parseGraphKnowledgeAssetMetadataBindings(
-      safeUal,
-      result.type === 'bindings' ? result.bindings : [],
-    );
-    if (parsed.kind !== 'graph') return null;
-    const metadata = parsed.metadata;
-
+  private graphScopedKAMeta(
+    metadata: ParsedGraphKnowledgeAssetMetadata,
+  ): GraphScopedKAMeta {
     return {
       contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
       scope: metadata.scope,
@@ -334,29 +328,7 @@ export class AccessHandler {
     // keeps legacy `<ual>/<n>` lookups (old clients / old-shape replica rows)
     // resolving.
     const result = await this.store.query(
-      `SELECT ?rootEntity ?contextGraph ?kc ?privateMerkleRoot ?privateTripleCount ?accessPolicy ?publisherPeerId ?attributedTo ?sgName WHERE {
-        GRAPH ?g {
-          {
-            <${safeUal}> <${DKG_NS}rootEntity> ?rootEntity .
-            <${safeUal}> <${DKG_NS}partOf> ?kc .
-          }
-          UNION
-          {
-            <${safeUal}> <${DKG_NS}rootEntity> ?rootEntity .
-            BIND(<${safeUal}> AS ?kc)
-          }
-          ?kc <${DKG_NS}contextGraph> ?contextGraph .
-          OPTIONAL { <${safeUal}> <${DKG_NS}privateMerkleRoot> ?privateMerkleRoot }
-          OPTIONAL { <${safeUal}> <${DKG_NS}privateTripleCount> ?privateTripleCount }
-          OPTIONAL { ?kc <${DKG_NS}accessPolicy> ?accessPolicy }
-          OPTIONAL { ?kc <${DKG_NS}publisherPeerId> ?publisherPeerId }
-          OPTIONAL { ?kc <http://www.w3.org/ns/prov#wasAttributedTo> ?attributedTo }
-          OPTIONAL { ?kc <${DKG_NS}subGraphName> ?sgName }
-          BIND(CONCAT(STR(?contextGraph), '/_meta') AS ?expectedMetaGraph)
-          FILTER(STR(?g) = ?expectedMetaGraph)
-        }
-        ${buildTrustedRootContextGraphRegistrationFilter('?contextGraph', '?g')}
-      }`,
+      buildLegacyKnowledgeAssetAccessMetadataQuery(safeUal),
     );
 
     if (result.type !== 'bindings' || result.bindings.length === 0) {

--- a/packages/publisher/src/access-handler.ts
+++ b/packages/publisher/src/access-handler.ts
@@ -6,17 +6,21 @@ import type {
 import {
   DKGEvent,
   GRAPH_KA_CONTENT_SCOPE_VERSION,
-  MemoryLayer,
-  createGraphKnowledgeAssetScope,
+  buildGraphKnowledgeAssetMetadataQuery,
   decodeAccessRequest,
   encodeAccessResponse,
   ed25519Verify,
   assertSafeIri,
-  knowledgeAssetLayerGraphUri,
-  validateSubGraphName,
+  parseDeterministicKnowledgeAssetUal,
+  parseGraphKnowledgeAssetMetadataBindings,
 } from '@origintrail-official/dkg-core';
 import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
-import { GraphManager, PrivateContentStore } from '@origintrail-official/dkg-storage';
+import {
+  ExactGraphReadError,
+  GraphManager,
+  PrivateContentStore,
+  quadsToNQuads,
+} from '@origintrail-official/dkg-storage';
 import { computePrivateRootV10 as computePrivateRoot } from './merkle.js';
 
 const DKG_NS = 'http://dkg.io/ontology/';
@@ -56,6 +60,13 @@ interface LegacyRootKAMeta extends KAMetaBase {
 }
 
 type KAMeta = GraphScopedKAMeta | LegacyRootKAMeta;
+
+interface PrivatePayload {
+  quads: Quad[];
+  privateMerkleRoot: Uint8Array;
+}
+
+type PrivatePayloadLoader = () => Promise<PrivatePayload>;
 
 /**
  * Handles incoming /dkg/access/1.0.0 requests on the publisher node.
@@ -103,36 +114,12 @@ export class AccessHandler {
         return this.deny('Access denied: invalid access policy metadata');
       }
 
-      let servedRootEntity: string | undefined;
-      let hasPrivate: boolean;
-      if (meta.contentScopeVersion === GRAPH_KA_CONTENT_SCOPE_VERSION) {
-        // V2 metadata commits the complete private payload as one exact
-        // `(UAL, assertionVersion)` graph. Do not infer membership from RDF
-        // subjects and do not touch the legacy shared private bucket.
-        hasPrivate = (meta.privateTripleCount ?? 0) > 0;
-      } else {
-        // Existing collapsed multi-root KAs have one private bag per root and
-        // no reliable root-to-private-root pairing. Preserve their read-only
-        // lookup by selecting the first member whose legacy bag exists.
-        servedRootEntity = meta.rootEntity;
-        hasPrivate = false;
-        for (const root of meta.rootEntities) {
-          if (
-            this.privateStore.hasPrivateTriples(meta.contextGraphId, root, meta.subGraphName) ||
-            (await this.privateStore.hasPrivateTriplesInStore(meta.contextGraphId, root, meta.subGraphName))
-          ) {
-            servedRootEntity = root;
-            hasPrivate = true;
-            break;
-          }
-        }
-      }
-
-      if (!hasPrivate) {
+      const loadPrivatePayload = await this.preparePrivatePayload(meta);
+      if (!loadPrivatePayload) {
         return this.deny('No private triples available for this KA');
       }
 
-      const effectivePolicy = this.resolveAccessPolicy(meta, hasPrivate);
+      const effectivePolicy = this.resolveAccessPolicy(meta, true);
 
       // Enforce access policy (cheap peerId checks first, before expensive crypto)
       if (effectivePolicy === 'ownerOnly') {
@@ -183,47 +170,8 @@ export class AccessHandler {
         }
       }
 
-      let privateQuads: Quad[];
-      if (meta.contentScopeVersion === GRAPH_KA_CONTENT_SCOPE_VERSION) {
-        privateQuads = await this.privateStore.getKnowledgeAssetPrivateTriples(
-          meta.contextGraphId,
-          meta.scope,
-          meta.subGraphName,
-        );
-        if (privateQuads.length !== meta.privateTripleCount) {
-          return this.deny(
-            `Private KA integrity check failed: metadata declares ${meta.privateTripleCount} triples, ` +
-              `found ${privateQuads.length}`,
-          );
-        }
-        const computedPrivateRoot = computePrivateRoot(privateQuads);
-        if (
-          !computedPrivateRoot
-          || !meta.privateMerkleRoot
-          || !bytesEqual(computedPrivateRoot, meta.privateMerkleRoot)
-        ) {
-          return this.deny('Private KA integrity check failed: Merkle root mismatch');
-        }
-      } else {
-        privateQuads = await this.privateStore.getPrivateTriples(
-          meta.contextGraphId,
-          servedRootEntity!,
-          meta.subGraphName,
-        );
-      }
-
-      const nquads = privateQuads
-        .map((q) => serializeAccessQuad(q))
-        .join('\n');
-
-      // Compute real privateMerkleRoot from the actual triples
-      let privateMerkleRoot = new Uint8Array(32) as Uint8Array<ArrayBuffer>;
-      if (meta.privateMerkleRoot) {
-        privateMerkleRoot = Uint8Array.from(meta.privateMerkleRoot);
-      } else if (privateQuads.length > 0) {
-        const root = computePrivateRoot(privateQuads);
-        if (root) privateMerkleRoot = Uint8Array.from(root);
-      }
+      const { quads: privateQuads, privateMerkleRoot } = await loadPrivatePayload();
+      const nquads = quadsToNQuads(privateQuads);
 
       this.eventBus.emit(DKGEvent.ACCESS_RESPONSE, {
         kaUal: request.kaUal,
@@ -244,8 +192,96 @@ export class AccessHandler {
     }
   }
 
+  /**
+   * Resolve the private payload location before policy checks, but defer the
+   * bounded graph read and Merkle work until after the requester is allowed.
+   */
+  private async preparePrivatePayload(meta: KAMeta): Promise<PrivatePayloadLoader | null> {
+    if (meta.contentScopeVersion === GRAPH_KA_CONTENT_SCOPE_VERSION) {
+      if (meta.privateTripleCount <= 0) return null;
+
+      return async () => {
+        let quads: Quad[];
+        try {
+          quads = await this.privateStore.getKnowledgeAssetPrivateTriples(
+            meta.contextGraphId,
+            meta.scope,
+            meta.subGraphName,
+            {
+              expectedQuadCount: meta.privateTripleCount,
+              queryOptions: { source: 'publisher.access' },
+            },
+          );
+        } catch (error) {
+          if (
+            error instanceof ExactGraphReadError
+            && error.code === 'QUAD_COUNT_MISMATCH'
+          ) {
+            throw new Error(
+              `Private KA integrity check failed: metadata declares ${meta.privateTripleCount} triples, `
+                + `found ${error.actual ?? 'an unknown count'}`,
+            );
+          }
+          throw error;
+        }
+
+        const computedPrivateRoot = computePrivateRoot(quads);
+        if (
+          !computedPrivateRoot
+          || !meta.privateMerkleRoot
+          || !bytesEqual(computedPrivateRoot, meta.privateMerkleRoot)
+        ) {
+          throw new Error('Private KA integrity check failed: Merkle root mismatch');
+        }
+        return {
+          quads,
+          privateMerkleRoot: Uint8Array.from(meta.privateMerkleRoot),
+        };
+      };
+    }
+
+    // Existing collapsed multi-root KAs have one private bag per root and no
+    // reliable root-to-private-root pairing. Preserve read-only lookup by
+    // selecting the first member whose legacy bag exists.
+    let servedRootEntity: string | undefined;
+    for (const root of meta.rootEntities) {
+      if (
+        this.privateStore.hasPrivateTriples(meta.contextGraphId, root, meta.subGraphName)
+        || await this.privateStore.hasPrivateTriplesInStore(
+          meta.contextGraphId,
+          root,
+          meta.subGraphName,
+        )
+      ) {
+        servedRootEntity = root;
+        break;
+      }
+    }
+    if (!servedRootEntity) return null;
+
+    return async () => {
+      const quads = await this.privateStore.getPrivateTriples(
+        meta.contextGraphId,
+        servedRootEntity,
+        meta.subGraphName,
+      );
+      let privateMerkleRoot = meta.privateMerkleRoot
+        ? Uint8Array.from(meta.privateMerkleRoot)
+        : new Uint8Array(32);
+      if (!meta.privateMerkleRoot && quads.length > 0) {
+        const computed = computePrivateRoot(quads);
+        if (computed) privateMerkleRoot = Uint8Array.from(computed);
+      }
+      return { quads, privateMerkleRoot };
+    };
+  }
+
   private async lookupKAMeta(kaUal: string): Promise<KAMeta | null> {
-    const graphScoped = await this.queryGraphScopedKAMeta(kaUal);
+    const legacyAliasBase = legacyTokenAliasBase(kaUal);
+    const canonicalUal = legacyAliasBase ?? kaUal;
+    // A token-form legacy alias must not bypass a V2 marker on the canonical
+    // bare UAL. Resolve the canonical control plane before either legacy path.
+    const graphScoped = await this.queryGraphScopedKAMeta(canonicalUal);
     if (graphScoped) return graphScoped;
 
     const direct = await this.queryLegacyKAMeta(kaUal);
@@ -254,9 +290,8 @@ export class AccessHandler {
     // content by the legacy token row `<ual>/<n>`; the collapsed shape keys
     // everything on the bare UAL. Strip a numeric suffix and retry once so
     // old-client requests keep resolving against new-shape stores.
-    const legacyToken = /^(.+)\/\d+$/.exec(kaUal);
-    if (legacyToken && legacyToken[1]) {
-      return this.queryLegacyKAMeta(legacyToken[1]);
+    if (legacyAliasBase) {
+      return this.queryLegacyKAMeta(legacyAliasBase);
     }
     return null;
   }
@@ -266,174 +301,27 @@ export class AccessHandler {
   ): Promise<GraphScopedKAMeta | null> {
     const safeUal = assertSafeIri(kaUal);
     const result = await this.store.query(
-      `SELECT ?g ?scopeVersion ?kaUal ?assertionVersion ?assertionGraph ?contextGraph ` +
-        `?privateMerkleRoot ?privateTripleCount ?accessPolicy ?publisherPeerId ` +
-        `?attributedTo ?sgName ?allowedPeer WHERE {
-        GRAPH ?g {
-          <${safeUal}> <${DKG_NS}contentScopeVersion> ?scopeVersion .
-          OPTIONAL { <${safeUal}> <${DKG_NS}kaUal> ?kaUal }
-          OPTIONAL { <${safeUal}> <${DKG_NS}assertionVersion> ?assertionVersion }
-          OPTIONAL { <${safeUal}> <${DKG_NS}assertionGraph> ?assertionGraph }
-          OPTIONAL { <${safeUal}> <${DKG_NS}contextGraph> ?contextGraph }
-          OPTIONAL { <${safeUal}> <${DKG_NS}privateMerkleRoot> ?privateMerkleRoot }
-          OPTIONAL { <${safeUal}> <${DKG_NS}privateTripleCount> ?privateTripleCount }
-          OPTIONAL { <${safeUal}> <${DKG_NS}accessPolicy> ?accessPolicy }
-          OPTIONAL { <${safeUal}> <${DKG_NS}publisherPeerId> ?publisherPeerId }
-          OPTIONAL { <${safeUal}> <http://www.w3.org/ns/prov#wasAttributedTo> ?attributedTo }
-          OPTIONAL { <${safeUal}> <${DKG_NS}subGraphName> ?sgName }
-          OPTIONAL { <${safeUal}> <${DKG_NS}allowedPeer> ?allowedPeer }
-        }
-      }`,
+      buildGraphKnowledgeAssetMetadataQuery(safeUal),
     );
-    if (result.type !== 'bindings' || result.bindings.length === 0) return null;
-
-    const values = (field: string): string[] => [
-      ...new Set(
-        result.bindings
-          .map((row) => row[field])
-          .filter((value): value is string => typeof value === 'string' && value.length > 0),
-      ),
-    ];
-    const requireSingle = (field: string): string => {
-      const candidates = values(field);
-      if (candidates.length !== 1) {
-        throw new Error(
-          `Graph-scoped KA ${kaUal} has ${candidates.length === 0 ? 'missing' : 'ambiguous'} ${field} metadata`,
-        );
-      }
-      return candidates[0] as string;
-    };
-    const optionalSingle = (field: string): string | undefined => {
-      const candidates = values(field);
-      if (candidates.length > 1) {
-        throw new Error(`Graph-scoped KA ${kaUal} has ambiguous ${field} metadata`);
-      }
-      return candidates[0];
-    };
-    const parseInteger = (raw: string, field: string): bigint => {
-      const value = stripLiteral(raw);
-      if (!/^-?\d+$/.test(value)) {
-        throw new Error(`Graph-scoped KA ${kaUal} has invalid ${field}: ${raw}`);
-      }
-      return BigInt(value);
-    };
-
-    const scopeVersions = values('scopeVersion').map((raw) =>
-      parseInteger(raw, 'contentScopeVersion'),
+    const parsed = parseGraphKnowledgeAssetMetadataBindings(
+      safeUal,
+      result.type === 'bindings' ? result.bindings : [],
     );
-    const uniqueScopeVersions = [...new Set(scopeVersions.map(String))];
-    if (uniqueScopeVersions.length !== 1) {
-      throw new Error(`Graph-scoped KA ${kaUal} has ambiguous contentScopeVersion metadata`);
-    }
-    const scopeVersion = BigInt(uniqueScopeVersions[0] as string);
-    if (scopeVersion === 1n) return null;
-    if (scopeVersion !== BigInt(GRAPH_KA_CONTENT_SCOPE_VERSION)) {
-      throw new Error(`Unsupported KA contentScopeVersion: ${scopeVersion}`);
-    }
-
-    const metadataUal = requireSingle('kaUal');
-    if (metadataUal !== safeUal) {
-      throw new Error(`Graph-scoped KA metadata UAL mismatch: requested ${safeUal}, found ${metadataUal}`);
-    }
-
-    const contextGraphUri = requireSingle('contextGraph');
-    const contextGraphPrefix = 'did:dkg:context-graph:';
-    if (!contextGraphUri.startsWith(contextGraphPrefix)) {
-      throw new Error(`Graph-scoped KA ${kaUal} has invalid contextGraph metadata`);
-    }
-    const contextGraphId = contextGraphUri.slice(contextGraphPrefix.length);
-    if (!contextGraphId) {
-      throw new Error(`Graph-scoped KA ${kaUal} has an empty context graph id`);
-    }
-    const expectedMetaGraph = `${contextGraphUri}/_meta`;
-    const metadataGraph = requireSingle('g');
-    if (metadataGraph !== expectedMetaGraph) {
-      throw new Error(
-        `Graph-scoped KA ${kaUal} metadata graph mismatch: expected ${expectedMetaGraph}, found ${metadataGraph}`,
-      );
-    }
-
-    const subGraphNameRaw = optionalSingle('sgName');
-    const subGraphName = subGraphNameRaw === undefined
-      ? undefined
-      : stripLiteral(subGraphNameRaw);
-    if (subGraphName !== undefined) {
-      const validation = validateSubGraphName(subGraphName);
-      if (!validation.valid) {
-        throw new Error(
-          `Graph-scoped KA ${kaUal} has invalid subGraphName: ${validation.reason}`,
-        );
-      }
-    }
-
-    const assertionVersion = parseInteger(
-      requireSingle('assertionVersion'),
-      'assertionVersion',
-    ).toString();
-    const scope = createGraphKnowledgeAssetScope(safeUal, assertionVersion);
-    const expectedAssertionGraph = knowledgeAssetLayerGraphUri(
-      contextGraphId,
-      MemoryLayer.VerifiableMemory,
-      scope,
-      subGraphName,
-    );
-    const assertionGraph = requireSingle('assertionGraph');
-    if (assertionGraph !== expectedAssertionGraph) {
-      throw new Error(
-        `Graph-scoped KA ${kaUal} assertionGraph mismatch: ` +
-          `expected ${expectedAssertionGraph}, found ${assertionGraph}`,
-      );
-    }
-
-    const privateTripleCountBig = parseInteger(
-      requireSingle('privateTripleCount'),
-      'privateTripleCount',
-    );
-    if (
-      privateTripleCountBig < 0n
-      || privateTripleCountBig > BigInt(Number.MAX_SAFE_INTEGER)
-    ) {
-      throw new Error(
-        `Graph-scoped KA ${kaUal} has invalid privateTripleCount: ${privateTripleCountBig}`,
-      );
-    }
-    const privateTripleCount = Number(privateTripleCountBig);
-    const privateRootRaw = optionalSingle('privateMerkleRoot');
-    if (privateTripleCount > 0 && privateRootRaw === undefined) {
-      throw new Error(`Graph-scoped KA ${kaUal} is missing privateMerkleRoot metadata`);
-    }
-    if (privateTripleCount === 0 && privateRootRaw !== undefined) {
-      throw new Error(`Graph-scoped KA ${kaUal} has a privateMerkleRoot without private content`);
-    }
-    const privateMerkleRoot = privateRootRaw === undefined
-      ? undefined
-      : decodeHexBytes32(privateRootRaw, `Graph-scoped KA ${kaUal} privateMerkleRoot`);
-
-    const rawPolicy = optionalSingle('accessPolicy');
-    const parsedPolicy = rawPolicy === undefined ? undefined : stripLiteral(rawPolicy);
-    const accessPolicy = isAccessPolicy(parsedPolicy) ? parsedPolicy : undefined;
-    const hasInvalidExplicitPolicy = parsedPolicy !== undefined && !isAccessPolicy(parsedPolicy);
-    const publisherPeerIdRaw = optionalSingle('publisherPeerId');
-    const attributedToRaw = optionalSingle('attributedTo');
-    const publisherPeerId = publisherPeerIdRaw !== undefined
-      ? stripLiteral(publisherPeerIdRaw)
-      : attributedToRaw !== undefined
-        ? stripLiteral(attributedToRaw)
-        : undefined;
-    const allowedPeers = values('allowedPeer').map(stripLiteral);
+    if (parsed.kind !== 'graph') return null;
+    const metadata = parsed.metadata;
 
     return {
       contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
-      scope,
+      scope: metadata.scope,
       rootEntities: [],
-      contextGraphId,
-      subGraphName,
-      privateMerkleRoot,
-      privateTripleCount,
-      accessPolicy,
-      hasInvalidExplicitPolicy,
-      publisherPeerId,
-      allowedPeers,
+      contextGraphId: metadata.contextGraphId,
+      subGraphName: metadata.subGraphName,
+      privateMerkleRoot: metadata.privateMerkleRoot,
+      privateTripleCount: metadata.privateTripleCount,
+      accessPolicy: metadata.accessPolicy,
+      hasInvalidExplicitPolicy: false,
+      publisherPeerId: metadata.publisherPeerId ?? metadata.attributedTo,
+      allowedPeers: [...metadata.allowedPeers],
     };
   }
 
@@ -590,24 +478,24 @@ function stripLiteral(s: string): string {
   return s;
 }
 
-function decodeHexBytes32(raw: string, field: string): Uint8Array {
-  const hex = stripLiteral(raw).replace(/^0x/i, '');
-  if (!/^[0-9a-f]{64}$/i.test(hex)) {
-    throw new Error(`${field} must be exactly 32 bytes of hexadecimal data`);
-  }
-  return Uint8Array.from(hex.match(/.{2}/g)!.map((pair) => Number.parseInt(pair, 16)));
-}
-
 function bytesEqual(left: Uint8Array, right: Uint8Array): boolean {
   return left.length === right.length && left.every((byte, index) => byte === right[index]);
 }
 
-function serializeAccessQuad(quad: Quad): string {
-  const subject = quad.subject.startsWith('_:') ? quad.subject : `<${quad.subject}>`;
-  const graph = quad.graph ? ` <${quad.graph}>` : '';
-  return `${subject} <${quad.predicate}> ${quad.object}${graph} .`;
-}
-
 function isAccessPolicy(value: string | undefined): value is AccessPolicy {
   return value === 'public' || value === 'ownerOnly' || value === 'allowList';
+}
+
+function legacyTokenAliasBase(kaUal: string): string | undefined {
+  const match = /^(.+)\/\d+$/.exec(kaUal);
+  const candidate = match?.[1];
+  if (!candidate) return undefined;
+  try {
+    parseDeterministicKnowledgeAssetUal(candidate);
+    return candidate;
+  } catch {
+    // A canonical bare UAL also ends in digits. Its prefix is not itself a
+    // deterministic KA UAL, so it must never be stripped as a token alias.
+    return undefined;
+  }
 }

--- a/packages/publisher/src/access-handler.ts
+++ b/packages/publisher/src/access-handler.ts
@@ -297,6 +297,10 @@ export class AccessHandler {
       { source: 'publisher.access.metadata' },
     );
     if (resolved.kind === 'graph') {
+      // Numeric token suffixes are a legacy compatibility address only.
+      // A V2 asset has one canonical UAL; detect its marker above so an alias
+      // cannot fall through, but never serve graph-scoped data through it.
+      if (legacyAliasBase) return null;
       return this.graphScopedKAMeta(resolved.metadata);
     }
     return resolved.kind === 'legacy' ? resolved.metadata : null;

--- a/packages/publisher/src/access-handler.ts
+++ b/packages/publisher/src/access-handler.ts
@@ -491,8 +491,7 @@ function legacyTokenAliasBase(kaUal: string): string | undefined {
   const candidate = match?.[1];
   if (!candidate) return undefined;
   try {
-    parseDeterministicKnowledgeAssetUal(candidate);
-    return candidate;
+    return parseDeterministicKnowledgeAssetUal(candidate).ual;
   } catch {
     // A canonical bare UAL also ends in digits. Its prefix is not itself a
     // deterministic KA UAL, so it must never be stripped as a token alias.

--- a/packages/publisher/test/access-verification.test.ts
+++ b/packages/publisher/test/access-verification.test.ts
@@ -22,6 +22,7 @@ import { OxigraphStore, GraphManager, type Quad } from '@origintrail-official/dk
 import { AccessHandler } from '../src/access-handler.js';
 
 const CONTEXT_GRAPH = 'test-access-verify';
+const CONTEXT_GRAPH_URI = `did:dkg:context-graph:${CONTEXT_GRAPH}`;
 const META_GRAPH = `did:dkg:context-graph:${CONTEXT_GRAPH}/_meta`;
 const PRIVATE_GRAPH = `did:dkg:context-graph:${CONTEXT_GRAPH}/_private`;
 const DKG = 'http://dkg.io/ontology/';
@@ -48,9 +49,15 @@ async function setupStoreWithPolicy(
 
   // KA metadata in meta graph
   await store.insert([
+    mq(
+      CONTEXT_GRAPH_URI,
+      'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
+      'https://dkg.network/ontology#ContextGraph',
+      META_GRAPH,
+    ),
     mq(KA_UAL, `${DKG}rootEntity`, ENTITY, META_GRAPH),
     mq(KA_UAL, `${DKG}partOf`, KC_UAL, META_GRAPH),
-    mq(KC_UAL, `${DKG}contextGraph`, `did:dkg:context-graph:${CONTEXT_GRAPH}`, META_GRAPH),
+    mq(KC_UAL, `${DKG}contextGraph`, CONTEXT_GRAPH_URI, META_GRAPH),
     mq(KC_UAL, `${DKG}accessPolicy`, lit(policy), META_GRAPH),
     mq(KC_UAL, `${DKG}status`, lit('confirmed'), META_GRAPH),
   ]);

--- a/packages/publisher/test/multi-root-token-rows.test.ts
+++ b/packages/publisher/test/multi-root-token-rows.test.ts
@@ -44,6 +44,13 @@ const ROOT_B = 'urn:test:tokenrows:beta';
 const PRIV_A = new Uint8Array(32).fill(0xaa);
 const PRIV_B = new Uint8Array(32).fill(0xbb);
 
+const rootContextGraphRegistration = (): Quad => ({
+  subject: `did:dkg:context-graph:${CG}`,
+  predicate: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
+  object: 'https://dkg.network/ontology#ContextGraph',
+  graph: META,
+});
+
 function kaEntry(rootEntity: string, tokenId: bigint, privateMerkleRoot?: Uint8Array): KAMetadata {
   return {
     rootEntity,
@@ -113,10 +120,13 @@ describe('generateKCMetadata — conditional collapse', () => {
 describe('AccessHandler on the dual (multi-root) shape', () => {
   async function seedDualShapeStore(): Promise<OxigraphStore> {
     const store = new OxigraphStore();
-    await store.insert(generateKCMetadata(kcMeta(), [
-      kaEntry(ROOT_A, 1n, PRIV_A),
-      kaEntry(ROOT_B, 2n, PRIV_B),
-    ]));
+    await store.insert([
+      rootContextGraphRegistration(),
+      ...generateKCMetadata(kcMeta(), [
+        kaEntry(ROOT_A, 1n, PRIV_A),
+        kaEntry(ROOT_B, 2n, PRIV_B),
+      ]),
+    ]);
     await store.insert([
       { subject: ROOT_A, predicate: 'http://ex.org/secretA', object: '"alpha-secret"', graph: PRIVATE },
       { subject: ROOT_B, predicate: 'http://ex.org/secretB', object: '"beta-secret"', graph: PRIVATE },
@@ -146,6 +156,7 @@ describe('AccessHandler hardening on already-written collapsed multi-root stores
     // private bag exists ONLY for ROOT_B. Pre-hardening, an engine that
     // bound ROOT_A first denied "No private triples available".
     await store.insert([
+      rootContextGraphRegistration(),
       { subject: UAL, predicate: `${DKG_NS}rootEntity`, object: ROOT_A, graph: META },
       { subject: UAL, predicate: `${DKG_NS}rootEntity`, object: ROOT_B, graph: META },
       { subject: UAL, predicate: `${DKG_NS}privateMerkleRoot`, object: `"${toHex(PRIV_B)}"`, graph: META },

--- a/packages/publisher/test/rootless-access.test.ts
+++ b/packages/publisher/test/rootless-access.test.ts
@@ -499,6 +499,59 @@ describe('rootless graph-scoped private access', () => {
     expect(new TextDecoder().decode(response.nquads)).not.toContain('must-not-leak');
   });
 
+  it('quarantines aliased private rows behind a marker-only V2 envelope', async () => {
+    const store = new OxigraphStore();
+    const legacyRoot = 'urn:legacy:marker-only-alias-poison';
+    const aliasedUal = UAL.replace(
+      '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+      '0x70997970C51812DC3A010C7D01B50E0D17DC79C8',
+    );
+    await store.insert([
+      rootContextGraphRegistration(),
+      {
+        subject: UAL,
+        predicate: `${DKG}contentScopeVersion`,
+        object: `"2"^^<${XSD_INTEGER}>`,
+        graph: META_GRAPH,
+      },
+      {
+        subject: aliasedUal,
+        predicate: `${DKG}rootEntity`,
+        object: legacyRoot,
+        graph: META_GRAPH,
+      },
+      {
+        subject: aliasedUal,
+        predicate: `${DKG}contextGraph`,
+        object: CONTEXT_GRAPH_URI,
+        graph: META_GRAPH,
+      },
+      {
+        subject: aliasedUal,
+        predicate: `${DKG}accessPolicy`,
+        object: '"public"',
+        graph: META_GRAPH,
+      },
+      {
+        subject: legacyRoot,
+        predicate: 'urn:p',
+        object: '"must-not-leak-through-marker-only-alias"',
+        graph: `${CONTEXT_GRAPH_URI}/_private`,
+      },
+    ]);
+
+    const response = await request(
+      new AccessHandler(store, new TypedEventBus()),
+      aliasedUal,
+    );
+
+    expect(response.granted).toBe(false);
+    expect(response.rejectionReason).toContain('missing kaUal metadata');
+    expect(new TextDecoder().decode(response.nquads)).not.toContain(
+      'must-not-leak-through-marker-only-alias',
+    );
+  });
+
   it('canonicalizes and rechecks a legacy token alias before serving stale private data', async () => {
     const store = new OxigraphStore();
     const legacyRoot = 'urn:legacy:alias-poison';

--- a/packages/publisher/test/rootless-access.test.ts
+++ b/packages/publisher/test/rootless-access.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MemoryLayer,
+  TypedEventBus,
+  createGraphKnowledgeAssetScope,
+  decodeAccessResponse,
+  encodeAccessRequest,
+  generateEd25519Keypair,
+  knowledgeAssetLayerGraphUri,
+} from '@origintrail-official/dkg-core';
+import {
+  GraphManager,
+  OxigraphStore,
+  PrivateContentStore,
+  type Quad,
+} from '@origintrail-official/dkg-storage';
+import { AccessClient, type AccessSendSurface } from '../src/access-client.js';
+import { AccessHandler } from '../src/access-handler.js';
+import { generateGraphKnowledgeAssetMetadata } from '../src/metadata.js';
+import { computePrivateRootV10 } from '../src/merkle.js';
+
+const CONTEXT_GRAPH = 'rootless-access';
+const CONTEXT_GRAPH_URI = `did:dkg:context-graph:${CONTEXT_GRAPH}`;
+const META_GRAPH = `${CONTEXT_GRAPH_URI}/_meta`;
+const UAL = 'did:dkg:base:8453/0x70997970c51812dc3a010c7d01b50e0d17dc79c8/41';
+const DKG = 'http://dkg.io/ontology/';
+const XSD_INTEGER = 'http://www.w3.org/2001/XMLSchema#integer';
+
+function quad(subject: string, predicate: string, object: string): Quad {
+  return { subject, predicate, object, graph: '' };
+}
+
+function request(handler: AccessHandler, kaUal = UAL) {
+  const payload = encodeAccessRequest({
+    kaUal,
+    requesterPeerId: 'requester-peer',
+    paymentProof: new Uint8Array(0),
+    requesterSignature: new Uint8Array(0),
+  });
+  return handler.handler(payload, 'requester-peer' as never).then(decodeAccessResponse);
+}
+
+function loopback(handler: AccessHandler): AccessSendSurface {
+  return {
+    async sendReliable(_peerId, _protocolId, payload) {
+      return {
+        delivered: true,
+        response: await handler.handler(payload, 'requester-peer' as never),
+        attempts: 1,
+        messageId: 'rootless-access-test',
+      };
+    },
+  };
+}
+
+async function seedRootlessPrivateKA(options: {
+  assertionVersion?: string;
+  payload?: Quad[];
+  metadataPrivateTripleCount?: number;
+  metadataPrivateRoot?: Uint8Array;
+  metadataAssertionGraph?: string;
+  subGraphName?: string;
+} = {}) {
+  const assertionVersion = options.assertionVersion ?? '1';
+  const payload = options.payload ?? [
+    quad('urn:secret:alpha', 'urn:predicate:value', '"alpha"'),
+    quad('urn:disconnected:beta', 'urn:predicate:value', '"beta"'),
+  ];
+  const store = new OxigraphStore();
+  const graphManager = new GraphManager(store);
+  await graphManager.ensureContextGraph(CONTEXT_GRAPH);
+  const privateStore = new PrivateContentStore(store, graphManager);
+  const scope = createGraphKnowledgeAssetScope(UAL, assertionVersion);
+  await privateStore.replaceKnowledgeAssetPrivateTriples(
+    CONTEXT_GRAPH,
+    scope,
+    payload,
+    options.subGraphName,
+  );
+  const privateRoot = options.metadataPrivateRoot
+    ?? computePrivateRootV10(payload)!;
+  const assertionGraph = options.metadataAssertionGraph
+    ?? knowledgeAssetLayerGraphUri(
+      CONTEXT_GRAPH,
+      MemoryLayer.VerifiableMemory,
+      scope,
+      options.subGraphName,
+    );
+  await store.insert(generateGraphKnowledgeAssetMetadata(
+    {
+      ual: UAL,
+      contextGraphId: CONTEXT_GRAPH,
+      merkleRoot: new Uint8Array(32).fill(7),
+      publisherPeerId: 'publisher-peer',
+      accessPolicy: 'public',
+      timestamp: new Date(0),
+      assertionVersion,
+      publicTripleCount: 0,
+      privateTripleCount: options.metadataPrivateTripleCount ?? payload.length,
+      privateMerkleRoot: privateRoot,
+      assertionGraph,
+      subGraphName: options.subGraphName,
+    },
+    'tentative',
+  ));
+  return { store, privateStore, scope, payload, privateRoot };
+}
+
+describe('rootless graph-scoped private access', () => {
+  it('serves the complete exact private graph by bare UAL and verifies end to end', async () => {
+    const { store, payload, privateRoot } = await seedRootlessPrivateKA();
+    const handler = new AccessHandler(store, new TypedEventBus());
+    const keypair = await generateEd25519Keypair();
+    const client = new AccessClient(loopback(handler), keypair, 'requester-peer');
+
+    const result = await client.requestAccess('publisher-peer', UAL);
+
+    expect(result.granted).toBe(true);
+    expect(result.verified).toBe(true);
+    expect(result.quads).toHaveLength(payload.length);
+    expect(new Set(result.quads.map((entry) => entry.subject))).toEqual(
+      new Set(payload.map((entry) => entry.subject)),
+    );
+    expect(result.quads.every((entry) => entry.graph === '')).toBe(true);
+    expect(Array.from(result.privateMerkleRoot ?? [])).toEqual(Array.from(privateRoot));
+  });
+
+  it('selects the metadata assertion version and never leaks an older private graph', async () => {
+    const currentPayload = [quad('urn:secret:current', 'urn:p', '"version-two"')];
+    const { store, privateStore } = await seedRootlessPrivateKA({
+      assertionVersion: '2',
+      payload: currentPayload,
+    });
+    await privateStore.replaceKnowledgeAssetPrivateTriples(
+      CONTEXT_GRAPH,
+      createGraphKnowledgeAssetScope(UAL, '1'),
+      [quad('urn:secret:stale', 'urn:p', '"version-one"')],
+    );
+
+    const response = await request(new AccessHandler(store, new TypedEventBus()));
+    const body = new TextDecoder().decode(response.nquads);
+
+    expect(response.granted).toBe(true);
+    expect(body).toContain('version-two');
+    expect(body).not.toContain('version-one');
+  });
+
+  it('fails closed when the exact private graph count differs from metadata', async () => {
+    const { store } = await seedRootlessPrivateKA({ metadataPrivateTripleCount: 1 });
+
+    const response = await request(new AccessHandler(store, new TypedEventBus()));
+
+    expect(response.granted).toBe(false);
+    expect(response.rejectionReason).toContain('integrity check failed');
+    expect(response.rejectionReason).toContain('declares 1 triples, found 2');
+  });
+
+  it('fails closed when the private payload does not match its committed Merkle root', async () => {
+    const { store } = await seedRootlessPrivateKA({
+      metadataPrivateRoot: new Uint8Array(32).fill(9),
+    });
+
+    const response = await request(new AccessHandler(store, new TypedEventBus()));
+
+    expect(response.granted).toBe(false);
+    expect(response.rejectionReason).toContain('Merkle root mismatch');
+  });
+
+  it('rejects metadata that points away from the UAL-derived VM graph', async () => {
+    const { store } = await seedRootlessPrivateKA({
+      metadataAssertionGraph: `${CONTEXT_GRAPH_URI}/_verifiable_memory/attacker/41`,
+    });
+
+    const response = await request(new AccessHandler(store, new TypedEventBus()));
+
+    expect(response.granted).toBe(false);
+    expect(response.rejectionReason).toContain('assertionGraph mismatch');
+  });
+
+  it('never falls back to a legacy root bag after seeing an incomplete V2 marker', async () => {
+    const store = new OxigraphStore();
+    const legacyRoot = 'urn:legacy:poison';
+    await store.insert([
+      {
+        subject: UAL,
+        predicate: `${DKG}contentScopeVersion`,
+        object: `"2"^^<${XSD_INTEGER}>`,
+        graph: META_GRAPH,
+      },
+      {
+        subject: UAL,
+        predicate: `${DKG}contextGraph`,
+        object: CONTEXT_GRAPH_URI,
+        graph: META_GRAPH,
+      },
+      {
+        subject: UAL,
+        predicate: `${DKG}rootEntity`,
+        object: legacyRoot,
+        graph: META_GRAPH,
+      },
+      {
+        subject: UAL,
+        predicate: `${DKG}accessPolicy`,
+        object: '"public"',
+        graph: META_GRAPH,
+      },
+      {
+        subject: legacyRoot,
+        predicate: 'urn:p',
+        object: '"must-not-leak"',
+        graph: `${CONTEXT_GRAPH_URI}/_private`,
+      },
+    ]);
+
+    const response = await request(new AccessHandler(store, new TypedEventBus()));
+
+    expect(response.granted).toBe(false);
+    expect(response.rejectionReason).toContain('missing kaUal metadata');
+    expect(new TextDecoder().decode(response.nquads)).not.toContain('must-not-leak');
+  });
+});

--- a/packages/publisher/test/rootless-access.test.ts
+++ b/packages/publisher/test/rootless-access.test.ts
@@ -264,6 +264,48 @@ describe('rootless graph-scoped private access', () => {
     expect(response.rejectionReason).toContain('assertionGraph mismatch');
   });
 
+  it('treats persisted content-scope version zero as a legacy private read', async () => {
+    const store = new OxigraphStore();
+    const legacyRoot = 'urn:legacy:version-zero';
+    await store.insert([
+      {
+        subject: UAL,
+        predicate: `${DKG}contentScopeVersion`,
+        object: `"0"^^<${XSD_INTEGER}>`,
+        graph: META_GRAPH,
+      },
+      {
+        subject: UAL,
+        predicate: `${DKG}rootEntity`,
+        object: legacyRoot,
+        graph: META_GRAPH,
+      },
+      {
+        subject: UAL,
+        predicate: `${DKG}contextGraph`,
+        object: CONTEXT_GRAPH_URI,
+        graph: META_GRAPH,
+      },
+      {
+        subject: UAL,
+        predicate: `${DKG}accessPolicy`,
+        object: '"public"',
+        graph: META_GRAPH,
+      },
+      {
+        subject: legacyRoot,
+        predicate: 'urn:p',
+        object: '"legacy-zero"',
+        graph: `${CONTEXT_GRAPH_URI}/_private`,
+      },
+    ]);
+
+    const response = await request(new AccessHandler(store, new TypedEventBus()));
+
+    expect(response.granted).toBe(true);
+    expect(new TextDecoder().decode(response.nquads)).toContain('legacy-zero');
+  });
+
   it('never falls back to a legacy root bag after seeing an incomplete V2 marker', async () => {
     const store = new OxigraphStore();
     const legacyRoot = 'urn:legacy:poison';

--- a/packages/publisher/test/rootless-access.test.ts
+++ b/packages/publisher/test/rootless-access.test.ts
@@ -25,9 +25,20 @@ const META_GRAPH = `${CONTEXT_GRAPH_URI}/_meta`;
 const UAL = 'did:dkg:base:8453/0x70997970c51812dc3a010c7d01b50e0d17dc79c8/41';
 const DKG = 'http://dkg.io/ontology/';
 const XSD_INTEGER = 'http://www.w3.org/2001/XMLSchema#integer';
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+const DKG_CONTEXT_GRAPH = 'https://dkg.network/ontology#ContextGraph';
 
 function quad(subject: string, predicate: string, object: string): Quad {
   return { subject, predicate, object, graph: '' };
+}
+
+function rootContextGraphRegistration(): Quad {
+  return {
+    subject: CONTEXT_GRAPH_URI,
+    predicate: RDF_TYPE,
+    object: DKG_CONTEXT_GRAPH,
+    graph: META_GRAPH,
+  };
 }
 
 function request(handler: AccessHandler, kaUal = UAL, peerId = 'requester-peer') {
@@ -107,6 +118,7 @@ async function seedRootlessPrivateKA(options: {
     },
     'tentative',
   ));
+  await store.insert([rootContextGraphRegistration()]);
   return { store, privateStore, scope, payload, privateRoot };
 }
 
@@ -127,6 +139,21 @@ describe('rootless graph-scoped private access', () => {
     );
     expect(result.quads.every((entry) => entry.graph === '')).toBe(true);
     expect(Array.from(result.privateMerkleRoot ?? [])).toEqual(Array.from(privateRoot));
+  });
+
+  it('denies private access when the metadata partition is also a registered legacy root', async () => {
+    const { store } = await seedRootlessPrivateKA();
+    await store.insert([{
+      subject: META_GRAPH,
+      predicate: RDF_TYPE,
+      object: DKG_CONTEXT_GRAPH,
+      graph: `${META_GRAPH}/_meta`,
+    }]);
+
+    const response = await request(new AccessHandler(store, new TypedEventBus()));
+
+    expect(response.granted).toBe(false);
+    expect(response.rejectionReason).toContain('KA not found');
   });
 
   it('selects the metadata assertion version and never leaks an older private graph', async () => {
@@ -268,6 +295,7 @@ describe('rootless graph-scoped private access', () => {
     const store = new OxigraphStore();
     const legacyRoot = 'urn:legacy:version-zero';
     await store.insert([
+      rootContextGraphRegistration(),
       {
         subject: UAL,
         predicate: `${DKG}contentScopeVersion`,
@@ -310,6 +338,7 @@ describe('rootless graph-scoped private access', () => {
     const store = new OxigraphStore();
     const legacyRoot = 'urn:legacy:poison';
     await store.insert([
+      rootContextGraphRegistration(),
       {
         subject: UAL,
         predicate: `${DKG}contentScopeVersion`,
@@ -357,6 +386,7 @@ describe('rootless graph-scoped private access', () => {
       '0x70997970C51812DC3A010C7D01B50E0D17DC79C8',
     );
     await store.insert([
+      rootContextGraphRegistration(),
       {
         subject: UAL,
         predicate: `${DKG}contentScopeVersion`,

--- a/packages/publisher/test/rootless-access.test.ts
+++ b/packages/publisher/test/rootless-access.test.ts
@@ -141,6 +141,27 @@ describe('rootless graph-scoped private access', () => {
     expect(Array.from(result.privateMerkleRoot ?? [])).toEqual(Array.from(privateRoot));
   });
 
+  it.each([
+    [
+      'checksum-cased',
+      UAL.replace(
+        '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+        '0x70997970C51812DC3A010C7D01B50E0D17DC79C8',
+      ),
+    ],
+    ['leading-zero', UAL.replace(/\/41$/, '/00041')],
+  ])('canonicalizes %s deterministic UAL aliases before graph metadata resolution', async (_kind, alias) => {
+    const { store } = await seedRootlessPrivateKA();
+
+    const response = await request(
+      new AccessHandler(store, new TypedEventBus()),
+      alias,
+    );
+
+    expect(response.granted).toBe(true);
+    expect(new TextDecoder().decode(response.nquads)).toContain('urn:secret:alpha');
+  });
+
   it('denies token aliases for graph-scoped private access', async () => {
     const { store } = await seedRootlessPrivateKA();
 

--- a/packages/publisher/test/rootless-access.test.ts
+++ b/packages/publisher/test/rootless-access.test.ts
@@ -221,6 +221,47 @@ describe('rootless graph-scoped private access', () => {
     expect(new TextDecoder().decode(response.nquads)).toContain('legacy-token-data');
   });
 
+  it('keeps collapsed non-deterministic legacy UALs readable through token aliases', async () => {
+    const store = new OxigraphStore();
+    const legacyUal = 'did:dkg:test/1/42';
+    const legacyRoot = 'urn:legacy:collapsed-token-alias';
+    await store.insert([
+      rootContextGraphRegistration(),
+      {
+        subject: legacyUal,
+        predicate: `${DKG}rootEntity`,
+        object: legacyRoot,
+        graph: META_GRAPH,
+      },
+      {
+        subject: legacyUal,
+        predicate: `${DKG}contextGraph`,
+        object: CONTEXT_GRAPH_URI,
+        graph: META_GRAPH,
+      },
+      {
+        subject: legacyUal,
+        predicate: `${DKG}accessPolicy`,
+        object: '"public"',
+        graph: META_GRAPH,
+      },
+      {
+        subject: legacyRoot,
+        predicate: 'urn:p',
+        object: '"legacy-collapsed-data"',
+        graph: `${CONTEXT_GRAPH_URI}/_private`,
+      },
+    ]);
+
+    const response = await request(
+      new AccessHandler(store, new TypedEventBus()),
+      `${legacyUal}/1`,
+    );
+
+    expect(response.granted).toBe(true);
+    expect(new TextDecoder().decode(response.nquads)).toContain('legacy-collapsed-data');
+  });
+
   it('denies private access when the metadata partition is also a registered legacy root', async () => {
     const { store } = await seedRootlessPrivateKA();
     await store.insert([{

--- a/packages/publisher/test/rootless-access.test.ts
+++ b/packages/publisher/test/rootless-access.test.ts
@@ -349,9 +349,13 @@ describe('rootless graph-scoped private access', () => {
     expect(new TextDecoder().decode(response.nquads)).not.toContain('must-not-leak');
   });
 
-  it('rechecks the canonical UAL before a legacy token alias can expose stale private data', async () => {
+  it('canonicalizes and rechecks a legacy token alias before serving stale private data', async () => {
     const store = new OxigraphStore();
     const legacyRoot = 'urn:legacy:alias-poison';
+    const aliasedUal = UAL.replace(
+      '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+      '0x70997970C51812DC3A010C7D01B50E0D17DC79C8',
+    );
     await store.insert([
       {
         subject: UAL,
@@ -366,19 +370,25 @@ describe('rootless graph-scoped private access', () => {
         graph: META_GRAPH,
       },
       {
-        subject: `${UAL}/1`,
+        subject: `${aliasedUal}/1`,
         predicate: `${DKG}rootEntity`,
         object: legacyRoot,
         graph: META_GRAPH,
       },
       {
-        subject: `${UAL}/1`,
+        subject: `${aliasedUal}/1`,
         predicate: `${DKG}partOf`,
-        object: UAL,
+        object: aliasedUal,
         graph: META_GRAPH,
       },
       {
-        subject: UAL,
+        subject: aliasedUal,
+        predicate: `${DKG}contextGraph`,
+        object: CONTEXT_GRAPH_URI,
+        graph: META_GRAPH,
+      },
+      {
+        subject: aliasedUal,
         predicate: `${DKG}accessPolicy`,
         object: '"public"',
         graph: META_GRAPH,
@@ -391,7 +401,10 @@ describe('rootless graph-scoped private access', () => {
       },
     ]);
 
-    const response = await request(new AccessHandler(store, new TypedEventBus()), `${UAL}/1`);
+    const response = await request(
+      new AccessHandler(store, new TypedEventBus()),
+      `${aliasedUal}/1`,
+    );
 
     expect(response.granted).toBe(false);
     expect(response.rejectionReason).toContain('missing kaUal metadata');

--- a/packages/publisher/test/rootless-access.test.ts
+++ b/packages/publisher/test/rootless-access.test.ts
@@ -30,14 +30,14 @@ function quad(subject: string, predicate: string, object: string): Quad {
   return { subject, predicate, object, graph: '' };
 }
 
-function request(handler: AccessHandler, kaUal = UAL) {
+function request(handler: AccessHandler, kaUal = UAL, peerId = 'requester-peer') {
   const payload = encodeAccessRequest({
     kaUal,
-    requesterPeerId: 'requester-peer',
+    requesterPeerId: peerId,
     paymentProof: new Uint8Array(0),
     requesterSignature: new Uint8Array(0),
   });
-  return handler.handler(payload, 'requester-peer' as never).then(decodeAccessResponse);
+  return handler.handler(payload, peerId as never).then(decodeAccessResponse);
 }
 
 function loopback(handler: AccessHandler): AccessSendSurface {
@@ -60,6 +60,9 @@ async function seedRootlessPrivateKA(options: {
   metadataPrivateRoot?: Uint8Array;
   metadataAssertionGraph?: string;
   subGraphName?: string;
+  accessPolicy?: 'public' | 'ownerOnly' | 'allowList';
+  publisherPeerId?: string;
+  allowedPeers?: string[];
 } = {}) {
   const assertionVersion = options.assertionVersion ?? '1';
   const payload = options.payload ?? [
@@ -91,8 +94,9 @@ async function seedRootlessPrivateKA(options: {
       ual: UAL,
       contextGraphId: CONTEXT_GRAPH,
       merkleRoot: new Uint8Array(32).fill(7),
-      publisherPeerId: 'publisher-peer',
-      accessPolicy: 'public',
+      publisherPeerId: options.publisherPeerId ?? 'publisher-peer',
+      accessPolicy: options.accessPolicy ?? 'public',
+      allowedPeers: options.allowedPeers,
       timestamp: new Date(0),
       assertionVersion,
       publicTripleCount: 0,
@@ -143,6 +147,89 @@ describe('rootless graph-scoped private access', () => {
     expect(response.granted).toBe(true);
     expect(body).toContain('version-two');
     expect(body).not.toContain('version-one');
+  });
+
+  it('routes a named subgraph to its exact private graph without leaking the root graph', async () => {
+    const namedPayload = [quad('urn:secret:named', 'urn:p', 'urn:object:named')];
+    const { store, privateStore, scope } = await seedRootlessPrivateKA({
+      subGraphName: 'updates',
+      payload: namedPayload,
+    });
+    await privateStore.replaceKnowledgeAssetPrivateTriples(
+      CONTEXT_GRAPH,
+      scope,
+      [quad('urn:secret:root-decoy', 'urn:p', '"must-not-leak"')],
+    );
+
+    const response = await request(new AccessHandler(store, new TypedEventBus()));
+    const body = new TextDecoder().decode(response.nquads);
+
+    expect(response.granted).toBe(true);
+    expect(body).toContain('<urn:object:named>');
+    expect(body).not.toContain('root-decoy');
+    expect(body).not.toContain('must-not-leak');
+  });
+
+  it('enforces graph-scoped allow lists for both authorized and unauthorized peers', async () => {
+    const { store } = await seedRootlessPrivateKA({
+      accessPolicy: 'allowList',
+      allowedPeers: ['requester-peer'],
+    });
+    const handler = new AccessHandler(store, new TypedEventBus());
+    const keypair = await generateEd25519Keypair();
+    const client = new AccessClient(loopback(handler), keypair, 'requester-peer');
+
+    const allowed = await client.requestAccess('publisher-peer', UAL);
+    const denied = await request(handler, UAL, 'outsider-peer');
+
+    expect(allowed.granted).toBe(true);
+    expect(allowed.verified).toBe(true);
+    expect(denied.granted).toBe(false);
+    expect(denied.rejectionReason).toContain('not on allow list');
+  });
+
+  it('reads a large exact private graph in bounded ordered pages', async () => {
+    const payload = Array.from({ length: 257 }, (_, index) =>
+      quad(`urn:secret:${index.toString().padStart(3, '0')}`, 'urn:p', `"${index}"`));
+    const { store } = await seedRootlessPrivateKA({ payload });
+    const queries: string[] = [];
+    const originalQuery = store.query.bind(store);
+    store.query = async (...args) => {
+      queries.push(args[0]);
+      return originalQuery(...args);
+    };
+
+    const response = await request(new AccessHandler(store, new TypedEventBus()));
+    const pageQueries = queries.filter((sparql) => sparql.includes('ORDER BY ?s ?p ?o'));
+
+    expect(response.granted).toBe(true);
+    expect(pageQueries).toHaveLength(2);
+    expect(pageQueries[0]).toMatch(/LIMIT 256\s+OFFSET 0/);
+    expect(pageQueries[1]).toMatch(/LIMIT 2\s+OFFSET 256/);
+  });
+
+  it('rejects an oversized declared private graph before materializing payload rows', async () => {
+    const { store } = await seedRootlessPrivateKA({ metadataPrivateTripleCount: 100_001 });
+
+    const response = await request(new AccessHandler(store, new TypedEventBus()));
+
+    expect(response.granted).toBe(false);
+    expect(response.rejectionReason).toContain('exceeds quad limit');
+  });
+
+  it('ignores a victim scope marker stored in another KA payload graph', async () => {
+    const { store } = await seedRootlessPrivateKA();
+    await store.insert([{
+      subject: UAL,
+      predicate: `${DKG}contentScopeVersion`,
+      object: `"2"^^<${XSD_INTEGER}>`,
+      graph: 'urn:attacker:other-ka-payload',
+    }]);
+
+    const response = await request(new AccessHandler(store, new TypedEventBus()));
+
+    expect(response.granted).toBe(true);
+    expect(new TextDecoder().decode(response.nquads)).toContain('urn:secret:alpha');
   });
 
   it('fails closed when the exact private graph count differs from metadata', async () => {
@@ -218,5 +305,54 @@ describe('rootless graph-scoped private access', () => {
     expect(response.granted).toBe(false);
     expect(response.rejectionReason).toContain('missing kaUal metadata');
     expect(new TextDecoder().decode(response.nquads)).not.toContain('must-not-leak');
+  });
+
+  it('rechecks the canonical UAL before a legacy token alias can expose stale private data', async () => {
+    const store = new OxigraphStore();
+    const legacyRoot = 'urn:legacy:alias-poison';
+    await store.insert([
+      {
+        subject: UAL,
+        predicate: `${DKG}contentScopeVersion`,
+        object: `"2"^^<${XSD_INTEGER}>`,
+        graph: META_GRAPH,
+      },
+      {
+        subject: UAL,
+        predicate: `${DKG}contextGraph`,
+        object: CONTEXT_GRAPH_URI,
+        graph: META_GRAPH,
+      },
+      {
+        subject: `${UAL}/1`,
+        predicate: `${DKG}rootEntity`,
+        object: legacyRoot,
+        graph: META_GRAPH,
+      },
+      {
+        subject: `${UAL}/1`,
+        predicate: `${DKG}partOf`,
+        object: UAL,
+        graph: META_GRAPH,
+      },
+      {
+        subject: UAL,
+        predicate: `${DKG}accessPolicy`,
+        object: '"public"',
+        graph: META_GRAPH,
+      },
+      {
+        subject: legacyRoot,
+        predicate: 'urn:p',
+        object: '"must-not-leak-through-alias"',
+        graph: `${CONTEXT_GRAPH_URI}/_private`,
+      },
+    ]);
+
+    const response = await request(new AccessHandler(store, new TypedEventBus()), `${UAL}/1`);
+
+    expect(response.granted).toBe(false);
+    expect(response.rejectionReason).toContain('missing kaUal metadata');
+    expect(new TextDecoder().decode(response.nquads)).not.toContain('must-not-leak-through-alias');
   });
 });

--- a/packages/publisher/test/rootless-access.test.ts
+++ b/packages/publisher/test/rootless-access.test.ts
@@ -141,6 +141,65 @@ describe('rootless graph-scoped private access', () => {
     expect(Array.from(result.privateMerkleRoot ?? [])).toEqual(Array.from(privateRoot));
   });
 
+  it('denies token aliases for graph-scoped private access', async () => {
+    const { store } = await seedRootlessPrivateKA();
+
+    const response = await request(
+      new AccessHandler(store, new TypedEventBus()),
+      `${UAL}/999`,
+    );
+
+    expect(response.granted).toBe(false);
+    expect(response.rejectionReason).toContain('KA not found');
+    expect(new TextDecoder().decode(response.nquads)).not.toContain('urn:secret:alpha');
+  });
+
+  it('keeps token aliases readable for legacy private metadata', async () => {
+    const store = new OxigraphStore();
+    const legacyRoot = 'urn:legacy:token-alias';
+    await store.insert([
+      rootContextGraphRegistration(),
+      {
+        subject: `${UAL}/1`,
+        predicate: `${DKG}rootEntity`,
+        object: legacyRoot,
+        graph: META_GRAPH,
+      },
+      {
+        subject: `${UAL}/1`,
+        predicate: `${DKG}partOf`,
+        object: UAL,
+        graph: META_GRAPH,
+      },
+      {
+        subject: UAL,
+        predicate: `${DKG}contextGraph`,
+        object: CONTEXT_GRAPH_URI,
+        graph: META_GRAPH,
+      },
+      {
+        subject: UAL,
+        predicate: `${DKG}accessPolicy`,
+        object: '"public"',
+        graph: META_GRAPH,
+      },
+      {
+        subject: legacyRoot,
+        predicate: 'urn:p',
+        object: '"legacy-token-data"',
+        graph: `${CONTEXT_GRAPH_URI}/_private`,
+      },
+    ]);
+
+    const response = await request(
+      new AccessHandler(store, new TypedEventBus()),
+      `${UAL}/1`,
+    );
+
+    expect(response.granted).toBe(true);
+    expect(new TextDecoder().decode(response.nquads)).toContain('legacy-token-data');
+  });
+
   it('denies private access when the metadata partition is also a registered legacy root', async () => {
     const { store } = await seedRootlessPrivateKA();
     await store.insert([{

--- a/packages/publisher/vitest.unit.config.ts
+++ b/packages/publisher/vitest.unit.config.ts
@@ -28,6 +28,8 @@ export default defineConfig({
       'test/ka-graph-publish-handler.test.ts',
       'test/ka-graph-update-ack.test.ts',
       'test/ka-graph-update-handler.test.ts',
+      'test/rootless-access.test.ts',
+      'test/access-verification.test.ts',
       'test/agents-meta-bound.test.ts',
       'test/ack-collector.test.ts',
       'test/publish-lifecycle-logger.test.ts',

--- a/packages/query/src/dkg-query-engine.ts
+++ b/packages/query/src/dkg-query-engine.ts
@@ -1,9 +1,13 @@
 import type { TripleStore, Quad, QueryResult as StoreQueryResult } from '@origintrail-official/dkg-storage';
-import { GraphManager } from '@origintrail-official/dkg-storage';
+import {
+  ExactGraphReadError,
+  GraphManager,
+  readExactGraphPaged,
+} from '@origintrail-official/dkg-storage';
 import type {
   QueryResult,
   QueryOptions,
-  QueryEngine,
+  GraphAwareQueryEngine,
   ResolvedGraphKnowledgeAsset,
   ResolvedKnowledgeAsset,
   ResolvedLegacyKnowledgeAsset,
@@ -21,8 +25,8 @@ import {
   TrustLevel,
   TRUST_LEVEL_PREDICATE,
   GRAPH_KA_CONTENT_SCOPE_VERSION,
-  createGraphKnowledgeAssetScope,
-  knowledgeAssetLayerGraphUri,
+  buildGraphKnowledgeAssetMetadataQuery,
+  parseGraphKnowledgeAssetMetadataBindings,
 } from '@origintrail-official/dkg-core';
 import {
   validateReadOnlySparql,
@@ -250,7 +254,7 @@ export function resolveViewGraphs(
  * Isolation). All data must arrive via protocol messages (publish, access,
  * sync) before it can be queried here.
  */
-export class DKGQueryEngine implements QueryEngine {
+export class DKGQueryEngine implements GraphAwareQueryEngine {
   private readonly store: TripleStore;
   private readonly graphManager: GraphManager;
   // Collapse the dashboard's parallel WM/SWM/VM count scans without retaining
@@ -941,7 +945,17 @@ export class DKGQueryEngine implements QueryEngine {
     return { bindings: [] };
   }
 
-  async resolveKA(ual: string): Promise<ResolvedKnowledgeAsset> {
+  async resolveKA(ual: string): Promise<ResolvedLegacyKnowledgeAsset> {
+    const resolved = await this.resolveKnowledgeAsset(ual);
+    if (resolved.contentScopeVersion === GRAPH_KA_CONTENT_SCOPE_VERSION) {
+      throw new Error(
+        'Graph-scoped Knowledge Assets do not have root entities; use resolveKnowledgeAsset()',
+      );
+    }
+    return resolved;
+  }
+
+  async resolveKnowledgeAsset(ual: string): Promise<ResolvedKnowledgeAsset> {
     const safeUal = assertSafeIri(ual);
     const graphScoped = await this.resolveGraphScopedKA(safeUal);
     if (graphScoped) return graphScoped;
@@ -951,175 +965,45 @@ export class DKGQueryEngine implements QueryEngine {
   private async resolveGraphScopedKA(
     ual: string,
   ): Promise<ResolvedGraphKnowledgeAsset | null> {
-    const DKG = 'http://dkg.io/ontology/';
     const metaResult = await this.store.query(
-      `SELECT ?g ?scopeVersion ?kaUal ?assertionVersion ?assertionGraph ?ctxGraph ?publicTripleCount ?sgName WHERE {
-        GRAPH ?g {
-          <${ual}> <${DKG}contentScopeVersion> ?scopeVersion .
-          OPTIONAL { <${ual}> <${DKG}kaUal> ?kaUal }
-          OPTIONAL { <${ual}> <${DKG}assertionVersion> ?assertionVersion }
-          OPTIONAL { <${ual}> <${DKG}assertionGraph> ?assertionGraph }
-          OPTIONAL { <${ual}> <${DKG}contextGraph> ?ctxGraph }
-          OPTIONAL { <${ual}> <${DKG}publicTripleCount> ?publicTripleCount }
-          OPTIONAL { <${ual}> <${DKG}subGraphName> ?sgName }
-        }
-      }`,
+      buildGraphKnowledgeAssetMetadataQuery(ual),
     );
+    const parsed = parseGraphKnowledgeAssetMetadataBindings(
+      ual,
+      metaResult.type === 'bindings' ? metaResult.bindings : [],
+    );
+    if (parsed.kind !== 'graph') return null;
+    const metadata = parsed.metadata;
+    const expectedGraph = metadata.assertionGraph;
 
-    if (metaResult.type !== 'bindings' || metaResult.bindings.length === 0) return null;
-    const parseInteger = (value: string | undefined, field: string): bigint => {
-      const match = value?.match(/^"(-?\d+)"/) ?? value?.match(/^(-?\d+)$/);
-      if (!match) {
-        throw new Error(`Graph-scoped KA ${ual} has invalid ${field}: ${value ?? '(missing)'}`);
-      }
-      return BigInt(match[1] as string);
-    };
-    const scopeVersions = [
-      ...new Set(
-        metaResult.bindings.map((row) =>
-          parseInteger(row['scopeVersion'], 'contentScopeVersion').toString(),
-        ),
-      ),
-    ];
-    if (scopeVersions.length !== 1) {
-      throw new Error(`Graph-scoped KA ${ual} has ambiguous contentScopeVersion metadata`);
-    }
-    const scopeVersion = BigInt(scopeVersions[0] as string);
-    if (scopeVersion === 1n) return null;
-    if (scopeVersion !== BigInt(GRAPH_KA_CONTENT_SCOPE_VERSION)) {
-      throw new Error(`Unsupported KA contentScopeVersion: ${scopeVersion}`);
-    }
-    const graphRows = metaResult.bindings;
-
-    const values = (field: string): string[] => [
-      ...new Set(
-        graphRows
-          .map((row) => row[field])
-          .filter((value): value is string => typeof value === 'string' && value.length > 0),
-      ),
-    ];
-    const requireSingle = (field: string): string => {
-      const candidates = values(field);
-      if (candidates.length !== 1) {
+    let quads: Quad[];
+    try {
+      quads = await readExactGraphPaged(this.store, expectedGraph, {
+        expectedQuadCount: metadata.publicTripleCount,
+        queryOptions: { source: 'query.resolveKnowledgeAsset' },
+      });
+    } catch (error) {
+      if (error instanceof ExactGraphReadError && error.code === 'QUAD_COUNT_MISMATCH') {
         throw new Error(
-          `Graph-scoped KA ${ual} has ${candidates.length === 0 ? 'missing' : 'ambiguous'} ${field} metadata`,
+          `Graph-scoped KA ${ual} graph integrity mismatch: metadata declares ` +
+            `${metadata.publicTripleCount} public triples, found ${error.actual ?? 'an unknown count'}`,
         );
       }
-      return candidates[0] as string;
-    };
-    const decodeLiteral = (value: string, field: string): string => {
-      if (!value.startsWith('"')) return value;
-      const end = value.lastIndexOf('"');
-      if (end <= 0) {
-        throw new Error(`Graph-scoped KA ${ual} has invalid ${field}: ${value}`);
-      }
-      try {
-        return JSON.parse(value.slice(0, end + 1)) as string;
-      } catch {
-        throw new Error(`Graph-scoped KA ${ual} has invalid ${field}: ${value}`);
-      }
-    };
-
-    const metadataUal = requireSingle('kaUal');
-    if (metadataUal !== ual) {
-      throw new Error(`Graph-scoped KA metadata UAL mismatch: requested ${ual}, found ${metadataUal}`);
+      throw error;
     }
-    const assertionVersion = parseInteger(
-      requireSingle('assertionVersion'),
-      'assertionVersion',
-    ).toString();
-    const publicTripleCountBig = parseInteger(
-      requireSingle('publicTripleCount'),
-      'publicTripleCount',
-    );
-    if (
-      publicTripleCountBig < 0n
-      || publicTripleCountBig > BigInt(Number.MAX_SAFE_INTEGER)
-    ) {
+    if (quads.length !== metadata.publicTripleCount) {
       throw new Error(
-        `Graph-scoped KA ${ual} has invalid publicTripleCount: ${publicTripleCountBig}`,
-      );
-    }
-    const publicTripleCount = Number(publicTripleCountBig);
-
-    const contextGraphUri = requireSingle('ctxGraph');
-    const contextGraphPrefix = 'did:dkg:context-graph:';
-    if (!contextGraphUri.startsWith(contextGraphPrefix)) {
-      throw new Error(
-        `Graph-scoped KA ${ual} has invalid contextGraph metadata: ${contextGraphUri}`,
-      );
-    }
-    const contextGraphId = contextGraphUri.slice(contextGraphPrefix.length);
-    if (!contextGraphId) {
-      throw new Error(`Graph-scoped KA ${ual} has an empty context graph id`);
-    }
-    const expectedMetaGraph = `${contextGraphUri}/_meta`;
-    const metadataGraph = requireSingle('g');
-    if (metadataGraph !== expectedMetaGraph) {
-      throw new Error(
-        `Graph-scoped KA ${ual} metadata graph mismatch: ` +
-          `expected ${expectedMetaGraph}, found ${metadataGraph}`,
-      );
-    }
-
-    const subGraphValues = values('sgName').map((value) =>
-      decodeLiteral(value, 'subGraphName'),
-    );
-    const uniqueSubGraphs = [...new Set(subGraphValues)];
-    if (uniqueSubGraphs.length > 1) {
-      throw new Error(`Graph-scoped KA ${ual} has ambiguous subGraphName metadata`);
-    }
-    const subGraphName = uniqueSubGraphs[0];
-    if (subGraphName !== undefined) {
-      const validation = validateSubGraphName(subGraphName);
-      if (!validation.valid) {
-        throw new Error(
-          `Graph-scoped KA ${ual} has invalid subGraphName: ${validation.reason}`,
-        );
-      }
-    }
-
-    const scope = createGraphKnowledgeAssetScope(ual, assertionVersion);
-    const expectedGraph = knowledgeAssetLayerGraphUri(
-      contextGraphId,
-      MemoryLayer.VerifiableMemory,
-      scope,
-      subGraphName,
-    );
-    const assertionGraph = requireSingle('assertionGraph');
-    if (assertionGraph !== expectedGraph) {
-      throw new Error(
-        `Graph-scoped KA ${ual} assertionGraph mismatch: expected ${expectedGraph}, found ${assertionGraph}`,
-      );
-    }
-
-    const dataResult = await this.store.query(
-      `SELECT ?s ?p ?o WHERE {
-        GRAPH <${assertSafeIri(expectedGraph)}> { ?s ?p ?o }
-      }`,
-    );
-    const quads: Quad[] =
-      dataResult.type === 'bindings'
-        ? dataResult.bindings.map((row) => ({
-            subject: row['s'],
-            predicate: row['p'],
-            object: row['o'],
-            graph: expectedGraph,
-          }))
-        : [];
-    if (quads.length !== publicTripleCount) {
-      throw new Error(
-        `Graph-scoped KA ${ual} graph integrity mismatch: metadata declares ${publicTripleCount} public triples, found ${quads.length}`,
+        `Graph-scoped KA ${ual} graph integrity mismatch: metadata declares ${metadata.publicTripleCount} public triples, found ${quads.length}`,
       );
     }
 
     return {
-      ual: scope.ual,
+      ual: metadata.scope.ual,
       contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
-      assertionVersion: scope.assertionVersion,
+      assertionVersion: metadata.scope.assertionVersion,
       assertionGraph: expectedGraph,
       rootEntities: [],
-      contextGraphId,
+      contextGraphId: metadata.contextGraphId,
       quads,
     };
   }
@@ -1143,6 +1027,8 @@ export class DKGQueryEngine implements QueryEngine {
           }
           <${ual}> <http://dkg.io/ontology/contextGraph> ?ctxGraph .
           OPTIONAL { <${ual}> <http://dkg.io/ontology/subGraphName> ?sgName }
+          BIND(CONCAT(STR(?ctxGraph), "/_meta") AS ?expectedMetaGraph)
+          FILTER(STR(?g) = ?expectedMetaGraph)
         }
       } ORDER BY ?ka`,
     );

--- a/packages/query/src/dkg-query-engine.ts
+++ b/packages/query/src/dkg-query-engine.ts
@@ -3,6 +3,7 @@ import {
   ExactGraphReadError,
   GraphManager,
   readExactGraphPaged,
+  resolveGraphScopedOrLegacyMetadata,
 } from '@origintrail-official/dkg-storage';
 import type {
   QueryResult,
@@ -25,9 +26,8 @@ import {
   TrustLevel,
   TRUST_LEVEL_PREDICATE,
   GRAPH_KA_CONTENT_SCOPE_VERSION,
-  buildGraphKnowledgeAssetMetadataQuery,
-  buildTrustedRootContextGraphRegistrationFilter,
-  parseGraphKnowledgeAssetMetadataBindings,
+  buildLegacyKnowledgeAssetMetadataQuery,
+  type ParsedGraphKnowledgeAssetMetadata,
 } from '@origintrail-official/dkg-core';
 import {
   validateReadOnlySparql,
@@ -958,23 +958,23 @@ export class DKGQueryEngine implements GraphAwareQueryEngine {
 
   async resolveKnowledgeAsset(ual: string): Promise<ResolvedKnowledgeAsset> {
     const safeUal = assertSafeIri(ual);
-    const graphScoped = await this.resolveGraphScopedKA(safeUal);
-    if (graphScoped) return graphScoped;
-    return this.resolveLegacyRootScopedKA(safeUal);
+    const resolved = await resolveGraphScopedOrLegacyMetadata(
+      this.store,
+      safeUal,
+      () => this.resolveLegacyRootScopedKA(safeUal),
+      { source: 'query.resolveKnowledgeAsset.metadata' },
+    );
+    if (resolved.kind === 'graph') {
+      return this.resolveGraphScopedKA(safeUal, resolved.metadata);
+    }
+    if (resolved.kind === 'legacy') return resolved.metadata;
+    throw new Error(`KA not found for UAL: ${safeUal}`);
   }
 
   private async resolveGraphScopedKA(
     ual: string,
-  ): Promise<ResolvedGraphKnowledgeAsset | null> {
-    const metaResult = await this.store.query(
-      buildGraphKnowledgeAssetMetadataQuery(ual),
-    );
-    const parsed = parseGraphKnowledgeAssetMetadataBindings(
-      ual,
-      metaResult.type === 'bindings' ? metaResult.bindings : [],
-    );
-    if (parsed.kind !== 'graph') return null;
-    const metadata = parsed.metadata;
+    metadata: ParsedGraphKnowledgeAssetMetadata,
+  ): Promise<ResolvedGraphKnowledgeAsset> {
     const expectedGraph = metadata.assertionGraph;
 
     let quads: Quad[];
@@ -1015,24 +1015,7 @@ export class DKGQueryEngine implements GraphAwareQueryEngine {
     // Existing V10 metadata can use either token-row + partOf membership or
     // the collapsed UAL-subject rootEntity form. This path is read-only.
     const metaResult = await this.store.query(
-      `SELECT ?ka ?rootEntity ?ctxGraph ?sgName WHERE {
-        GRAPH ?g {
-          {
-            ?ka <http://dkg.io/ontology/rootEntity> ?rootEntity .
-            ?ka <http://dkg.io/ontology/partOf> <${ual}> .
-          }
-          UNION
-          {
-            <${ual}> <http://dkg.io/ontology/rootEntity> ?rootEntity .
-            BIND(<${ual}> AS ?ka)
-          }
-          <${ual}> <http://dkg.io/ontology/contextGraph> ?ctxGraph .
-          OPTIONAL { <${ual}> <http://dkg.io/ontology/subGraphName> ?sgName }
-          BIND(CONCAT(STR(?ctxGraph), "/_meta") AS ?expectedMetaGraph)
-          FILTER(STR(?g) = ?expectedMetaGraph)
-        }
-        ${buildTrustedRootContextGraphRegistrationFilter('?ctxGraph', '?g')}
-      } ORDER BY ?ka`,
+      buildLegacyKnowledgeAssetMetadataQuery(ual),
     );
 
     if (metaResult.type !== 'bindings' || metaResult.bindings.length === 0) {

--- a/packages/query/src/dkg-query-engine.ts
+++ b/packages/query/src/dkg-query-engine.ts
@@ -26,6 +26,7 @@ import {
   TRUST_LEVEL_PREDICATE,
   GRAPH_KA_CONTENT_SCOPE_VERSION,
   buildGraphKnowledgeAssetMetadataQuery,
+  buildTrustedRootContextGraphRegistrationFilter,
   parseGraphKnowledgeAssetMetadataBindings,
 } from '@origintrail-official/dkg-core';
 import {
@@ -1030,6 +1031,7 @@ export class DKGQueryEngine implements GraphAwareQueryEngine {
           BIND(CONCAT(STR(?ctxGraph), "/_meta") AS ?expectedMetaGraph)
           FILTER(STR(?g) = ?expectedMetaGraph)
         }
+        ${buildTrustedRootContextGraphRegistrationFilter('?ctxGraph', '?g')}
       } ORDER BY ?ka`,
     );
 

--- a/packages/query/src/dkg-query-engine.ts
+++ b/packages/query/src/dkg-query-engine.ts
@@ -1,6 +1,13 @@
 import type { TripleStore, Quad, QueryResult as StoreQueryResult } from '@origintrail-official/dkg-storage';
 import { GraphManager } from '@origintrail-official/dkg-storage';
-import type { QueryResult, QueryOptions, QueryEngine } from './query-engine.js';
+import type {
+  QueryResult,
+  QueryOptions,
+  QueryEngine,
+  ResolvedGraphKnowledgeAsset,
+  ResolvedKnowledgeAsset,
+  ResolvedLegacyKnowledgeAsset,
+} from './query-engine.js';
 import {
   contextGraphDataUri, contextGraphSharedMemoryUri, contextGraphVerifiableMemoryUri, contextGraphAssertionUri, contextGraphLayerUri, MemoryLayer,
   contextGraphLayerUriCandidates, contextGraphLayerPrefixCandidates,
@@ -13,6 +20,9 @@ import {
   REMOVED_VIEWS,
   TrustLevel,
   TRUST_LEVEL_PREDICATE,
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  createGraphKnowledgeAssetScope,
+  knowledgeAssetLayerGraphUri,
 } from '@origintrail-official/dkg-core';
 import {
   validateReadOnlySparql,
@@ -931,33 +941,208 @@ export class DKGQueryEngine implements QueryEngine {
     return { bindings: [] };
   }
 
-  async resolveKA(ual: string): Promise<{
-    rootEntity: string;
-    rootEntities: string[];
-    contextGraphId: string;
-    quads: Quad[];
-  }> {
-    // Look up KA metadata across all meta graphs, including subGraphName if recorded.
-    // Design B (OT-RFC-44): one KA can hold MULTIPLE rootEntities, so collect
-    // every `?ka <rootEntity>` binding (not just bindings[0]) — PR #968 salvage.
-    // Read-both (RFC ka-metadata-trim P3.1): the collapsed shape carries
-    // `dkg:rootEntity` directly on the UAL subject (no `<ual>/<n>` token rows,
-    // no `dkg:partOf`); legacy-shape rows synced from older nodes still use
-    // the token-row + partOf form, so both branches are queried.
+  async resolveKA(ual: string): Promise<ResolvedKnowledgeAsset> {
+    const safeUal = assertSafeIri(ual);
+    const graphScoped = await this.resolveGraphScopedKA(safeUal);
+    if (graphScoped) return graphScoped;
+    return this.resolveLegacyRootScopedKA(safeUal);
+  }
+
+  private async resolveGraphScopedKA(
+    ual: string,
+  ): Promise<ResolvedGraphKnowledgeAsset | null> {
+    const DKG = 'http://dkg.io/ontology/';
+    const metaResult = await this.store.query(
+      `SELECT ?g ?scopeVersion ?kaUal ?assertionVersion ?assertionGraph ?ctxGraph ?publicTripleCount ?sgName WHERE {
+        GRAPH ?g {
+          <${ual}> <${DKG}contentScopeVersion> ?scopeVersion .
+          OPTIONAL { <${ual}> <${DKG}kaUal> ?kaUal }
+          OPTIONAL { <${ual}> <${DKG}assertionVersion> ?assertionVersion }
+          OPTIONAL { <${ual}> <${DKG}assertionGraph> ?assertionGraph }
+          OPTIONAL { <${ual}> <${DKG}contextGraph> ?ctxGraph }
+          OPTIONAL { <${ual}> <${DKG}publicTripleCount> ?publicTripleCount }
+          OPTIONAL { <${ual}> <${DKG}subGraphName> ?sgName }
+        }
+      }`,
+    );
+
+    if (metaResult.type !== 'bindings' || metaResult.bindings.length === 0) return null;
+    const parseInteger = (value: string | undefined, field: string): bigint => {
+      const match = value?.match(/^"(-?\d+)"/) ?? value?.match(/^(-?\d+)$/);
+      if (!match) {
+        throw new Error(`Graph-scoped KA ${ual} has invalid ${field}: ${value ?? '(missing)'}`);
+      }
+      return BigInt(match[1] as string);
+    };
+    const scopeVersions = [
+      ...new Set(
+        metaResult.bindings.map((row) =>
+          parseInteger(row['scopeVersion'], 'contentScopeVersion').toString(),
+        ),
+      ),
+    ];
+    if (scopeVersions.length !== 1) {
+      throw new Error(`Graph-scoped KA ${ual} has ambiguous contentScopeVersion metadata`);
+    }
+    const scopeVersion = BigInt(scopeVersions[0] as string);
+    if (scopeVersion === 1n) return null;
+    if (scopeVersion !== BigInt(GRAPH_KA_CONTENT_SCOPE_VERSION)) {
+      throw new Error(`Unsupported KA contentScopeVersion: ${scopeVersion}`);
+    }
+    const graphRows = metaResult.bindings;
+
+    const values = (field: string): string[] => [
+      ...new Set(
+        graphRows
+          .map((row) => row[field])
+          .filter((value): value is string => typeof value === 'string' && value.length > 0),
+      ),
+    ];
+    const requireSingle = (field: string): string => {
+      const candidates = values(field);
+      if (candidates.length !== 1) {
+        throw new Error(
+          `Graph-scoped KA ${ual} has ${candidates.length === 0 ? 'missing' : 'ambiguous'} ${field} metadata`,
+        );
+      }
+      return candidates[0] as string;
+    };
+    const decodeLiteral = (value: string, field: string): string => {
+      if (!value.startsWith('"')) return value;
+      const end = value.lastIndexOf('"');
+      if (end <= 0) {
+        throw new Error(`Graph-scoped KA ${ual} has invalid ${field}: ${value}`);
+      }
+      try {
+        return JSON.parse(value.slice(0, end + 1)) as string;
+      } catch {
+        throw new Error(`Graph-scoped KA ${ual} has invalid ${field}: ${value}`);
+      }
+    };
+
+    const metadataUal = requireSingle('kaUal');
+    if (metadataUal !== ual) {
+      throw new Error(`Graph-scoped KA metadata UAL mismatch: requested ${ual}, found ${metadataUal}`);
+    }
+    const assertionVersion = parseInteger(
+      requireSingle('assertionVersion'),
+      'assertionVersion',
+    ).toString();
+    const publicTripleCountBig = parseInteger(
+      requireSingle('publicTripleCount'),
+      'publicTripleCount',
+    );
+    if (
+      publicTripleCountBig < 0n
+      || publicTripleCountBig > BigInt(Number.MAX_SAFE_INTEGER)
+    ) {
+      throw new Error(
+        `Graph-scoped KA ${ual} has invalid publicTripleCount: ${publicTripleCountBig}`,
+      );
+    }
+    const publicTripleCount = Number(publicTripleCountBig);
+
+    const contextGraphUri = requireSingle('ctxGraph');
+    const contextGraphPrefix = 'did:dkg:context-graph:';
+    if (!contextGraphUri.startsWith(contextGraphPrefix)) {
+      throw new Error(
+        `Graph-scoped KA ${ual} has invalid contextGraph metadata: ${contextGraphUri}`,
+      );
+    }
+    const contextGraphId = contextGraphUri.slice(contextGraphPrefix.length);
+    if (!contextGraphId) {
+      throw new Error(`Graph-scoped KA ${ual} has an empty context graph id`);
+    }
+    const expectedMetaGraph = `${contextGraphUri}/_meta`;
+    const metadataGraph = requireSingle('g');
+    if (metadataGraph !== expectedMetaGraph) {
+      throw new Error(
+        `Graph-scoped KA ${ual} metadata graph mismatch: ` +
+          `expected ${expectedMetaGraph}, found ${metadataGraph}`,
+      );
+    }
+
+    const subGraphValues = values('sgName').map((value) =>
+      decodeLiteral(value, 'subGraphName'),
+    );
+    const uniqueSubGraphs = [...new Set(subGraphValues)];
+    if (uniqueSubGraphs.length > 1) {
+      throw new Error(`Graph-scoped KA ${ual} has ambiguous subGraphName metadata`);
+    }
+    const subGraphName = uniqueSubGraphs[0];
+    if (subGraphName !== undefined) {
+      const validation = validateSubGraphName(subGraphName);
+      if (!validation.valid) {
+        throw new Error(
+          `Graph-scoped KA ${ual} has invalid subGraphName: ${validation.reason}`,
+        );
+      }
+    }
+
+    const scope = createGraphKnowledgeAssetScope(ual, assertionVersion);
+    const expectedGraph = knowledgeAssetLayerGraphUri(
+      contextGraphId,
+      MemoryLayer.VerifiableMemory,
+      scope,
+      subGraphName,
+    );
+    const assertionGraph = requireSingle('assertionGraph');
+    if (assertionGraph !== expectedGraph) {
+      throw new Error(
+        `Graph-scoped KA ${ual} assertionGraph mismatch: expected ${expectedGraph}, found ${assertionGraph}`,
+      );
+    }
+
+    const dataResult = await this.store.query(
+      `SELECT ?s ?p ?o WHERE {
+        GRAPH <${assertSafeIri(expectedGraph)}> { ?s ?p ?o }
+      }`,
+    );
+    const quads: Quad[] =
+      dataResult.type === 'bindings'
+        ? dataResult.bindings.map((row) => ({
+            subject: row['s'],
+            predicate: row['p'],
+            object: row['o'],
+            graph: expectedGraph,
+          }))
+        : [];
+    if (quads.length !== publicTripleCount) {
+      throw new Error(
+        `Graph-scoped KA ${ual} graph integrity mismatch: metadata declares ${publicTripleCount} public triples, found ${quads.length}`,
+      );
+    }
+
+    return {
+      ual: scope.ual,
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      assertionVersion: scope.assertionVersion,
+      assertionGraph: expectedGraph,
+      rootEntities: [],
+      contextGraphId,
+      quads,
+    };
+  }
+
+  private async resolveLegacyRootScopedKA(
+    ual: string,
+  ): Promise<ResolvedLegacyKnowledgeAsset> {
+    // Existing V10 metadata can use either token-row + partOf membership or
+    // the collapsed UAL-subject rootEntity form. This path is read-only.
     const metaResult = await this.store.query(
       `SELECT ?ka ?rootEntity ?ctxGraph ?sgName WHERE {
         GRAPH ?g {
           {
             ?ka <http://dkg.io/ontology/rootEntity> ?rootEntity .
-            ?ka <http://dkg.io/ontology/partOf> <${assertSafeIri(ual)}> .
+            ?ka <http://dkg.io/ontology/partOf> <${ual}> .
           }
           UNION
           {
-            <${assertSafeIri(ual)}> <http://dkg.io/ontology/rootEntity> ?rootEntity .
-            BIND(<${assertSafeIri(ual)}> AS ?ka)
+            <${ual}> <http://dkg.io/ontology/rootEntity> ?rootEntity .
+            BIND(<${ual}> AS ?ka)
           }
-          <${assertSafeIri(ual)}> <http://dkg.io/ontology/contextGraph> ?ctxGraph .
-          OPTIONAL { <${assertSafeIri(ual)}> <http://dkg.io/ontology/subGraphName> ?sgName }
+          <${ual}> <http://dkg.io/ontology/contextGraph> ?ctxGraph .
+          OPTIONAL { <${ual}> <http://dkg.io/ontology/subGraphName> ?sgName }
         }
       } ORDER BY ?ka`,
     );
@@ -976,10 +1161,24 @@ export class DKGQueryEngine implements QueryEngine {
     if (rootEntities.length === 0) {
       throw new Error(`KA not found for UAL: ${ual}`);
     }
-    const rootEntity = rootEntities[0];
-    const contextGraphUri = metaResult.bindings[0]['ctxGraph'];
-    const contextGraphId = contextGraphUri.replace('did:dkg:context-graph:', '');
-    const sgNameRaw = metaResult.bindings[0]['sgName'];
+    const rootEntity = rootEntities[0] as string;
+    const contextGraphUris = [
+      ...new Set(
+        metaResult.bindings
+          .map((row) => row['ctxGraph'])
+          .filter((value): value is string => typeof value === 'string' && value.length > 0),
+      ),
+    ];
+    if (contextGraphUris.length !== 1) {
+      throw new Error(`Legacy KA ${ual} has ambiguous contextGraph metadata`);
+    }
+    const contextGraphPrefix = 'did:dkg:context-graph:';
+    const contextGraphUri = contextGraphUris[0] as string;
+    if (!contextGraphUri.startsWith(contextGraphPrefix)) {
+      throw new Error(`Legacy KA ${ual} has invalid contextGraph metadata`);
+    }
+    const contextGraphId = contextGraphUri.slice(contextGraphPrefix.length);
+    const sgNameRaw = metaResult.bindings[0]?.['sgName'];
     const subGraphName = sgNameRaw ? sgNameRaw.replace(/^"(.*)".*$/, '$1') : undefined;
 
     const dataGraph = subGraphName
@@ -993,7 +1192,6 @@ export class DKGQueryEngine implements QueryEngine {
       )
       .join(' || ');
 
-    // Fetch all triples for every KA member root from the correct data graph.
     const dataResult = await this.store.query(
       `SELECT ?s ?p ?o WHERE {
         GRAPH <${assertSafeIri(dataGraph)}> {
@@ -1013,9 +1211,15 @@ export class DKGQueryEngine implements QueryEngine {
           }))
         : [];
 
-    return { rootEntity, rootEntities, contextGraphId, quads };
+    return {
+      ual,
+      contentScopeVersion: 1,
+      rootEntity,
+      rootEntities,
+      contextGraphId,
+      quads,
+    };
   }
-
   /**
    * Execute a query across all locally-stored context graphs.
    */

--- a/packages/query/src/query-engine.ts
+++ b/packages/query/src/query-engine.ts
@@ -86,7 +86,35 @@ export interface QueryOptions {
   _minTrust?: TrustLevel;
 }
 
+export interface ResolvedKnowledgeAssetBase {
+  ual: string;
+  contextGraphId: string;
+  quads: Quad[];
+}
+
+/** Current V10 KA model: one exact graph identified by UAL + assertion version. */
+export interface ResolvedGraphKnowledgeAsset extends ResolvedKnowledgeAssetBase {
+  contentScopeVersion: 2;
+  assertionVersion: string;
+  assertionGraph: string;
+  rootEntities: [];
+  rootEntity?: never;
+}
+
+/** Existing V10 root-scoped KAs remain queryable but are never writable. */
+export interface ResolvedLegacyKnowledgeAsset extends ResolvedKnowledgeAssetBase {
+  contentScopeVersion: 1;
+  rootEntity: string;
+  rootEntities: string[];
+  assertionVersion?: never;
+  assertionGraph?: never;
+}
+
+export type ResolvedKnowledgeAsset =
+  | ResolvedGraphKnowledgeAsset
+  | ResolvedLegacyKnowledgeAsset;
+
 export interface QueryEngine {
   query(sparql: string, options?: QueryOptions): Promise<QueryResult>;
-  resolveKA(ual: string): Promise<{ rootEntity: string; rootEntities: string[]; contextGraphId: string; quads: Quad[] }>;
+  resolveKA(ual: string): Promise<ResolvedKnowledgeAsset>;
 }

--- a/packages/query/src/query-engine.ts
+++ b/packages/query/src/query-engine.ts
@@ -92,6 +92,14 @@ export interface ResolvedKnowledgeAssetBase {
   quads: Quad[];
 }
 
+/** The original public result contract of {@link QueryEngine.resolveKA}. */
+export interface LegacyResolveKAResult {
+  rootEntity: string;
+  rootEntities: string[];
+  contextGraphId: string;
+  quads: Quad[];
+}
+
 /** Current V10 KA model: one exact graph identified by UAL + assertion version. */
 export interface ResolvedGraphKnowledgeAsset extends ResolvedKnowledgeAssetBase {
   contentScopeVersion: 2;
@@ -102,7 +110,8 @@ export interface ResolvedGraphKnowledgeAsset extends ResolvedKnowledgeAssetBase 
 }
 
 /** Existing V10 root-scoped KAs remain queryable but are never writable. */
-export interface ResolvedLegacyKnowledgeAsset extends ResolvedKnowledgeAssetBase {
+export interface ResolvedLegacyKnowledgeAsset
+  extends ResolvedKnowledgeAssetBase, LegacyResolveKAResult {
   contentScopeVersion: 1;
   rootEntity: string;
   rootEntities: string[];
@@ -116,5 +125,19 @@ export type ResolvedKnowledgeAsset =
 
 export interface QueryEngine {
   query(sparql: string, options?: QueryOptions): Promise<QueryResult>;
-  resolveKA(ual: string): Promise<ResolvedKnowledgeAsset>;
+  /**
+   * Backwards-compatible legacy resolver. Its required root fields remain
+   * source-compatible with callers published before graph-scoped KAs existed.
+   */
+  resolveKA(ual: string): Promise<LegacyResolveKAResult>;
+  /**
+   * Graph-aware resolver for current callers. Optional so third-party
+   * QueryEngine implementations are not broken by the additive API.
+   */
+  resolveKnowledgeAsset?(ual: string): Promise<ResolvedKnowledgeAsset>;
+}
+
+/** Query engine surface for callers that understand graph-scoped KAs. */
+export interface GraphAwareQueryEngine extends QueryEngine {
+  resolveKnowledgeAsset(ual: string): Promise<ResolvedKnowledgeAsset>;
 }

--- a/packages/query/src/query-handler.ts
+++ b/packages/query/src/query-handler.ts
@@ -285,7 +285,9 @@ export class QueryHandler {
     }
 
     try {
-      const resolved = await this.queryEngine.resolveKA(ual);
+      const resolved = this.queryEngine.resolveKnowledgeAsset
+        ? await this.queryEngine.resolveKnowledgeAsset(ual)
+        : await this.queryEngine.resolveKA(ual);
       // PR #1107 review (🔴): enforce the RESOLVED context graph's access
       // policy — config entry first (operator override), then the #1105
       // on-chain public resolver. Pre-fix, UAL lookups bypassed per-CG

--- a/packages/query/src/query-handler.ts
+++ b/packages/query/src/query-handler.ts
@@ -1,5 +1,6 @@
 import type { PeerId } from '@origintrail-official/dkg-core';
 import { contextGraphDataUri, assertSafeIri, escapeSparqlLiteral } from '@origintrail-official/dkg-core';
+import { quadsToNQuads } from '@origintrail-official/dkg-storage';
 import { stripLiteralsAndComments } from './sparql-utils.js';
 import { validateReadOnlySparql } from './sparql-guard.js';
 import type { DKGQueryEngine } from './dkg-query-engine.js';
@@ -296,9 +297,9 @@ export class QueryHandler {
       // any other public CG existed on the node.
       const denied = await this.checkContextGraphAccess('ENTITY_BY_UAL', resolved.contextGraphId, peerId);
       if (denied) return { ...denied, operationId: opId };
-      const ntriples = resolved.quads
-        .map(q => `<${q.subject}> <${q.predicate}> ${formatObject(q.object)} .`)
-        .join('\n');
+      const ntriples = quadsToNQuads(
+        resolved.quads.map((quad) => ({ ...quad, graph: '' })),
+      );
 
       return {
         operationId: opId,

--- a/packages/query/test/query-engine.test.ts
+++ b/packages/query/test/query-engine.test.ts
@@ -256,6 +256,27 @@ describe('DKGQueryEngine', () => {
       expect(result.quads.some((quad) => quad.predicate === 'urn:predicate:decoy')).toBe(false);
     });
 
+    it('resolves a leading-zero deterministic UAL alias to the canonical graph', async () => {
+      const alias = UAL.replace(/\/7$/, '/0007');
+      const scope = createGraphKnowledgeAssetScope(UAL, '1');
+      const vmGraph = knowledgeAssetLayerGraphUri(
+        CONTEXT_GRAPH,
+        MemoryLayer.VerifiableMemory,
+        scope,
+      );
+      await store.insert([
+        q('urn:asset:canonical', 'urn:p', '"canonical"', vmGraph),
+        ...graphScopedMetadata(UAL, '1', vmGraph, 1),
+      ]);
+
+      const result = await engine.resolveKnowledgeAsset(alias);
+
+      expect(result.ual).toBe(UAL);
+      expect(result.quads).toEqual([
+        q('urn:asset:canonical', 'urn:p', '"canonical"', vmGraph),
+      ]);
+    });
+
     it('ignores scope markers stored in another KA payload graph', async () => {
       const scope = createGraphKnowledgeAssetScope(UAL, '1');
       const vmGraph = knowledgeAssetLayerGraphUri(

--- a/packages/query/test/query-engine.test.ts
+++ b/packages/query/test/query-engine.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
+import {
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  MemoryLayer,
+  createGraphKnowledgeAssetScope,
+  knowledgeAssetLayerGraphUri,
+} from '@origintrail-official/dkg-core';
 import { DKGQueryEngine } from '../src/dkg-query-engine.js';
 import { validateReadOnlySparql } from '../src/sparql-guard.js';
 
@@ -20,6 +26,8 @@ const DKG_CONTEXT_GRAPH = 'https://dkg.network/ontology#ContextGraph';
 const DKG_REGISTRATION_STATUS = 'https://dkg.network/ontology#registrationStatus';
 const SCHEMA_NAME = 'http://schema.org/name';
 const COUNT_NAME = 'http://example.com/countName';
+const DKG = 'http://dkg.io/ontology/';
+const XSD_INTEGER = 'http://www.w3.org/2001/XMLSchema#integer';
 
 function q(s: string, p: string, o: string, g = GRAPH): Quad {
   return { subject: s, predicate: p, object: o, graph: g };
@@ -36,6 +44,32 @@ function subGraphRegistration(name: string): Quad[] {
 
 function assertionGraphRegistration(graph: string, name: string): Quad {
   return q(`urn:dkg:assertion:${name}`, DKG_ASSERTION_GRAPH, graph, META);
+}
+
+function graphScopedMetadata(
+  ual: string,
+  assertionVersion: string,
+  assertionGraph: string,
+  publicTripleCount: number,
+  subGraphName?: string,
+  metadataGraph = META,
+): Quad[] {
+  return [
+    q(
+      ual,
+      `${DKG}contentScopeVersion`,
+      `"${GRAPH_KA_CONTENT_SCOPE_VERSION}"^^<${XSD_INTEGER}>`,
+      metadataGraph,
+    ),
+    q(ual, `${DKG}kaUal`, ual, metadataGraph),
+    q(ual, `${DKG}assertionVersion`, `"${assertionVersion}"^^<${XSD_INTEGER}>`, metadataGraph),
+    q(ual, `${DKG}publicTripleCount`, `"${publicTripleCount}"^^<${XSD_INTEGER}>`, metadataGraph),
+    q(ual, `${DKG}assertionGraph`, assertionGraph, metadataGraph),
+    q(ual, `${DKG}contextGraph`, GRAPH, metadataGraph),
+    ...(subGraphName
+      ? [q(ual, `${DKG}subGraphName`, JSON.stringify(subGraphName), metadataGraph)]
+      : []),
+  ];
 }
 
 describe('DKGQueryEngine', () => {
@@ -100,6 +134,8 @@ describe('DKGQueryEngine', () => {
     ]);
 
     const result = await engine.resolveKA(ual);
+    expect(result.contentScopeVersion).toBe(1);
+    expect(result.ual).toBe(ual);
     expect(result.rootEntity).toBe(ENTITY);
     expect(result.rootEntities).toEqual([ENTITY]);
     expect(result.contextGraphId).toBe(CONTEXT_GRAPH);
@@ -122,6 +158,7 @@ describe('DKGQueryEngine', () => {
     ]);
 
     const result = await engine.resolveKA(ual);
+    expect(result.contentScopeVersion).toBe(1);
     // Pre-#968 this returned only bindings[0]; now every member root is read.
     expect(result.rootEntities).toEqual([ENTITY, ENTITY_2]);
     expect(result.rootEntity).toBe(ENTITY); // backward-compat: first member root
@@ -129,6 +166,147 @@ describe('DKGQueryEngine', () => {
     expect(subjects).toContain(ENTITY);
     expect(subjects).toContain(ENTITY_2);
     expect(subjects).toContain(`${ENTITY_2}/.well-known/genid/o1`);
+  });
+
+  describe('graph-scoped resolveKA', () => {
+    const UAL = 'did:dkg:31337/0x1111111111111111111111111111111111111111/7';
+
+    it('loads the complete exact VM graph without root metadata or subject-prefix filtering', async () => {
+      const scope = createGraphKnowledgeAssetScope(UAL, '1');
+      const vmGraph = knowledgeAssetLayerGraphUri(
+        CONTEXT_GRAPH,
+        MemoryLayer.VerifiableMemory,
+        scope,
+      );
+      const payload = [
+        q('urn:asset:alpha', 'urn:predicate:name', '"Alpha"', vmGraph),
+        q('urn:unconnected:beta', 'urn:predicate:name', '"Beta"', vmGraph),
+        q('urn:unconnected:gamma', 'urn:predicate:value', '"disconnected payload"', vmGraph),
+      ];
+      await store.insert([
+        ...payload,
+        ...graphScopedMetadata(UAL, '1', vmGraph, payload.length),
+        q('urn:asset:alpha', 'urn:predicate:decoy', '"outside exact graph"', GRAPH),
+      ]);
+
+      const result = await engine.resolveKA(UAL);
+
+      expect(result.contentScopeVersion).toBe(GRAPH_KA_CONTENT_SCOPE_VERSION);
+      if (result.contentScopeVersion !== GRAPH_KA_CONTENT_SCOPE_VERSION) {
+        throw new Error('Expected graph-scoped KA');
+      }
+      expect(result.ual).toBe(UAL);
+      expect(result.assertionVersion).toBe('1');
+      expect(result.assertionGraph).toBe(vmGraph);
+      expect(result.rootEntities).toEqual([]);
+      expect(result.quads).toHaveLength(payload.length);
+      expect(new Set(result.quads.map((quad) => quad.subject))).toEqual(
+        new Set(payload.map((quad) => quad.subject)),
+      );
+      expect(result.quads.every((quad) => quad.graph === vmGraph)).toBe(true);
+      expect(result.quads.some((quad) => quad.predicate === 'urn:predicate:decoy')).toBe(false);
+    });
+
+    it('derives the versioned VM graph inside the registered subgraph', async () => {
+      const assertionVersion = '2';
+      const subGraphName = 'updates';
+      const scope = createGraphKnowledgeAssetScope(UAL, assertionVersion);
+      const vmGraph = knowledgeAssetLayerGraphUri(
+        CONTEXT_GRAPH,
+        MemoryLayer.VerifiableMemory,
+        scope,
+        subGraphName,
+      );
+      await store.insert([
+        q('urn:update:subject', 'urn:update:predicate', '"v2"', vmGraph),
+        ...graphScopedMetadata(UAL, assertionVersion, vmGraph, 1, subGraphName),
+      ]);
+
+      const result = await engine.resolveKA(UAL);
+
+      expect(result.contentScopeVersion).toBe(GRAPH_KA_CONTENT_SCOPE_VERSION);
+      if (result.contentScopeVersion !== GRAPH_KA_CONTENT_SCOPE_VERSION) {
+        throw new Error('Expected graph-scoped KA');
+      }
+      expect(result.assertionVersion).toBe(assertionVersion);
+      expect(result.assertionGraph).toBe(vmGraph);
+      expect(result.quads).toEqual([
+        q('urn:update:subject', 'urn:update:predicate', '"v2"', vmGraph),
+      ]);
+    });
+
+    it('fails closed when metadata points away from the UAL-derived exact graph', async () => {
+      const scope = createGraphKnowledgeAssetScope(UAL, '1');
+      const vmGraph = knowledgeAssetLayerGraphUri(
+        CONTEXT_GRAPH,
+        MemoryLayer.VerifiableMemory,
+        scope,
+      );
+      const attackerGraph = `${GRAPH}/_verifiable_memory/attacker/7`;
+      await store.insert([
+        q('urn:expected', 'urn:p', '"expected"', vmGraph),
+        q('urn:attacker', 'urn:p', '"attacker"', attackerGraph),
+        ...graphScopedMetadata(UAL, '1', attackerGraph, 1),
+      ]);
+
+      await expect(engine.resolveKA(UAL)).rejects.toThrow(/assertionGraph mismatch/);
+    });
+
+    it('fails closed when the exact graph count differs from committed metadata', async () => {
+      const scope = createGraphKnowledgeAssetScope(UAL, '1');
+      const vmGraph = knowledgeAssetLayerGraphUri(
+        CONTEXT_GRAPH,
+        MemoryLayer.VerifiableMemory,
+        scope,
+      );
+      await store.insert([
+        q('urn:only', 'urn:p', '"one"', vmGraph),
+        ...graphScopedMetadata(UAL, '1', vmGraph, 2),
+      ]);
+
+      await expect(engine.resolveKA(UAL)).rejects.toThrow(/graph integrity mismatch/);
+    });
+
+    it('does not fall back to legacy resolution when a V2 marker has incomplete metadata', async () => {
+      await store.insert([
+        q(
+          UAL,
+          `${DKG}contentScopeVersion`,
+          `"${GRAPH_KA_CONTENT_SCOPE_VERSION}"^^<${XSD_INTEGER}>`,
+          META,
+        ),
+        q(UAL, `${DKG}contextGraph`, GRAPH, META),
+        q(UAL, `${DKG}rootEntity`, ENTITY, META),
+      ]);
+
+      await expect(engine.resolveKA(UAL)).rejects.toThrow(/missing kaUal metadata/);
+    });
+
+    it('rejects graph-scoped metadata written outside the context graph meta partition', async () => {
+      const scope = createGraphKnowledgeAssetScope(UAL, '1');
+      const vmGraph = knowledgeAssetLayerGraphUri(
+        CONTEXT_GRAPH,
+        MemoryLayer.VerifiableMemory,
+        scope,
+      );
+      const poisonedMetaGraph = 'urn:attacker:metadata';
+      await store.insert([
+        q('urn:asset', 'urn:p', '"value"', vmGraph),
+        ...graphScopedMetadata(UAL, '1', vmGraph, 1, undefined, poisonedMetaGraph),
+      ]);
+
+      await expect(engine.resolveKA(UAL)).rejects.toThrow(/metadata graph mismatch/);
+    });
+
+    it('does not hide a malformed scope marker behind the legacy fallback', async () => {
+      await store.insert([
+        q(UAL, `${DKG}contentScopeVersion`, '"not-an-integer"', META),
+        q(UAL, `${DKG}contextGraph`, GRAPH, META),
+        q(UAL, `${DKG}rootEntity`, ENTITY, META),
+      ]);
+
+      await expect(engine.resolveKA(UAL)).rejects.toThrow(/invalid contentScopeVersion/);
+    });
   });
 
   it('throws on unknown UAL', async () => {

--- a/packages/query/test/query-engine.test.ts
+++ b/packages/query/test/query-engine.test.ts
@@ -22,6 +22,7 @@ function recorder<A extends unknown[], R>(impl: (...args: A) => R) {
 const CONTEXT_GRAPH = 'agent-registry';
 const GRAPH = `did:dkg:context-graph:${CONTEXT_GRAPH}`;
 const META = `${GRAPH}/_meta`;
+const ONTOLOGY_GRAPH = 'did:dkg:context-graph:ontology';
 const ENTITY = 'did:dkg:agent:QmImageBot';
 const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
 const DKG_SUB_GRAPH = 'http://dkg.io/ontology/SubGraph';
@@ -41,6 +42,7 @@ function subGraphRegistration(name: string): Quad[] {
   const subGraphUri = `${GRAPH}/${name}`;
   return [
     q(subGraphUri, RDF_TYPE, DKG_SUB_GRAPH, META),
+    q(subGraphUri, `${DKG}parentContextGraph`, GRAPH, META),
     q(subGraphUri, SCHEMA_NAME, `"${name}"`, META),
     q(subGraphUri, 'http://dkg.io/ontology/createdBy', 'did:dkg:agent:test', META),
   ];
@@ -92,6 +94,7 @@ describe('DKGQueryEngine', () => {
 
     // Seed data
     await store.insert([
+      q(GRAPH, RDF_TYPE, DKG_CONTEXT_GRAPH, ONTOLOGY_GRAPH),
       q(ENTITY, 'http://schema.org/name', '"ImageBot"'),
       q(ENTITY, 'http://schema.org/description', '"Analyzes images"'),
       q(
@@ -276,6 +279,125 @@ describe('DKGQueryEngine', () => {
       expect(result.quads).toEqual([
         q('urn:asset:trusted', 'urn:p', '"trusted"', vmGraph),
       ]);
+    });
+
+    it.each([
+      ['current', 'https://dkg.network/ontology#'],
+      ['legacy', 'http://dkg.io/ontology/'],
+    ])('rejects a %s named-subgraph meta graph impersonating a registered root', async (_label, namespace) => {
+      const nestedContextGraphId = `${CONTEXT_GRAPH}/updates`;
+      const nestedContextGraphUri = `did:dkg:context-graph:${nestedContextGraphId}`;
+      const poisonedMetaGraph = `${nestedContextGraphUri}/_meta`;
+      const scope = createGraphKnowledgeAssetScope(UAL, '1');
+      const vmGraph = knowledgeAssetLayerGraphUri(
+        nestedContextGraphId,
+        MemoryLayer.VerifiableMemory,
+        scope,
+      );
+      const poisonedMetadata = graphScopedMetadata(
+        UAL,
+        '1',
+        vmGraph,
+        1,
+        undefined,
+        poisonedMetaGraph,
+      ).map((entry) => entry.predicate === `${DKG}contextGraph`
+        ? { ...entry, object: nestedContextGraphUri }
+        : entry);
+      await store.insert([
+        q(nestedContextGraphUri, RDF_TYPE, `${namespace}SubGraph`, META),
+        q(nestedContextGraphUri, `${namespace}parentContextGraph`, GRAPH, META),
+        q(nestedContextGraphUri, RDF_TYPE, DKG_CONTEXT_GRAPH, poisonedMetaGraph),
+        q('urn:poisoned:asset', 'urn:p', '"must-not-resolve"', vmGraph),
+        ...poisonedMetadata,
+      ]);
+
+      await expect(engine.resolveKnowledgeAsset(UAL)).rejects.toThrow(/KA not found/);
+    });
+
+    it('accepts the genesis agents root registration from the agents data graph', async () => {
+      const agentsContextGraphId = 'agents';
+      const agentsContextGraphUri = 'did:dkg:context-graph:agents';
+      const agentsMetaGraph = `${agentsContextGraphUri}/_meta`;
+      const scope = createGraphKnowledgeAssetScope(UAL, '1');
+      const vmGraph = knowledgeAssetLayerGraphUri(
+        agentsContextGraphId,
+        MemoryLayer.VerifiableMemory,
+        scope,
+      );
+      const metadata = graphScopedMetadata(
+        UAL,
+        '1',
+        vmGraph,
+        1,
+        undefined,
+        agentsMetaGraph,
+      ).map((entry) => entry.predicate === `${DKG}contextGraph`
+        ? { ...entry, object: agentsContextGraphUri }
+        : entry);
+      await store.insert([
+        q(agentsContextGraphUri, RDF_TYPE, DKG_CONTEXT_GRAPH, agentsContextGraphUri),
+        q('urn:agents-root:asset', 'urn:p', '"trusted"', vmGraph),
+        ...metadata,
+      ]);
+
+      const result = await engine.resolveKnowledgeAsset(UAL);
+
+      expect(result.contextGraphId).toBe(agentsContextGraphId);
+      expect(result.quads).toEqual([
+        q('urn:agents-root:asset', 'urn:p', '"trusted"', vmGraph),
+      ]);
+    });
+
+    it('accepts an independently registered slash-shaped wallet root', async () => {
+      const walletContextGraphId = '0x2222222222222222222222222222222222222222/project';
+      const walletContextGraphUri = `did:dkg:context-graph:${walletContextGraphId}`;
+      const walletMetaGraph = `${walletContextGraphUri}/_meta`;
+      const scope = createGraphKnowledgeAssetScope(UAL, '1');
+      const vmGraph = knowledgeAssetLayerGraphUri(
+        walletContextGraphId,
+        MemoryLayer.VerifiableMemory,
+        scope,
+      );
+      const metadata = graphScopedMetadata(
+        UAL,
+        '1',
+        vmGraph,
+        1,
+        undefined,
+        walletMetaGraph,
+      ).map((entry) => entry.predicate === `${DKG}contextGraph`
+        ? { ...entry, object: walletContextGraphUri }
+        : entry);
+      await store.insert([
+        q(walletContextGraphUri, RDF_TYPE, DKG_CONTEXT_GRAPH, walletMetaGraph),
+        q('urn:wallet-root:asset', 'urn:p', '"trusted"', vmGraph),
+        ...metadata,
+      ]);
+
+      const result = await engine.resolveKnowledgeAsset(UAL);
+
+      expect(result.contextGraphId).toBe(walletContextGraphId);
+      expect(result.quads).toEqual([
+        q('urn:wallet-root:asset', 'urn:p', '"trusted"', vmGraph),
+      ]);
+    });
+
+    it('rejects metadata when its partition is also a registered legacy root payload graph', async () => {
+      const aliasMetaGraph = `${META}/_meta`;
+      const scope = createGraphKnowledgeAssetScope(UAL, '1');
+      const vmGraph = knowledgeAssetLayerGraphUri(
+        CONTEXT_GRAPH,
+        MemoryLayer.VerifiableMemory,
+        scope,
+      );
+      await store.insert([
+        q(META, RDF_TYPE, DKG_CONTEXT_GRAPH, aliasMetaGraph),
+        q('urn:poisoned:legacy-asset', 'urn:p', '"must-not-resolve"', vmGraph),
+        ...graphScopedMetadata(UAL, '1', vmGraph, 1),
+      ]);
+
+      await expect(engine.resolveKnowledgeAsset(UAL)).rejects.toThrow(/KA not found/);
     });
 
     it('pages exact-graph reads before materializing the resolved payload', async () => {

--- a/packages/query/test/query-engine.test.ts
+++ b/packages/query/test/query-engine.test.ts
@@ -277,6 +277,28 @@ describe('DKGQueryEngine', () => {
       ]);
     });
 
+    it('quarantines aliased legacy rows behind a marker-only V2 envelope', async () => {
+      const canonicalUal = 'did:dkg:31337/0xabcdefabcdefabcdefabcdefabcdefabcdefabcd/9';
+      const aliasedUal = canonicalUal.replace(
+        '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
+        '0xABCDEFABCDEFABCDEFABCDEFABCDEFABCDEFABCD',
+      );
+      await store.insert([
+        q(
+          canonicalUal,
+          `${DKG}contentScopeVersion`,
+          `"${GRAPH_KA_CONTENT_SCOPE_VERSION}"^^<${XSD_INTEGER}>`,
+          META,
+        ),
+        q(aliasedUal, `${DKG}rootEntity`, ENTITY, META),
+        q(aliasedUal, `${DKG}contextGraph`, GRAPH, META),
+      ]);
+
+      await expect(engine.resolveKnowledgeAsset(aliasedUal)).rejects.toThrow(
+        /missing kaUal metadata/,
+      );
+    });
+
     it('ignores scope markers stored in another KA payload graph', async () => {
       const scope = createGraphKnowledgeAssetScope(UAL, '1');
       const vmGraph = knowledgeAssetLayerGraphUri(

--- a/packages/query/test/query-engine.test.ts
+++ b/packages/query/test/query-engine.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, expectTypeOf } from 'vitest';
 import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
 import {
   GRAPH_KA_CONTENT_SCOPE_VERSION,
@@ -7,6 +7,10 @@ import {
   knowledgeAssetLayerGraphUri,
 } from '@origintrail-official/dkg-core';
 import { DKGQueryEngine } from '../src/dkg-query-engine.js';
+import type {
+  LegacyResolveKAResult,
+  QueryEngine,
+} from '../src/query-engine.js';
 import { validateReadOnlySparql } from '../src/sparql-guard.js';
 
 function recorder<A extends unknown[], R>(impl: (...args: A) => R) {
@@ -53,6 +57,8 @@ function graphScopedMetadata(
   publicTripleCount: number,
   subGraphName?: string,
   metadataGraph = META,
+  privateTripleCount = 0,
+  privateMerkleRoot?: string,
 ): Quad[] {
   return [
     q(
@@ -64,8 +70,12 @@ function graphScopedMetadata(
     q(ual, `${DKG}kaUal`, ual, metadataGraph),
     q(ual, `${DKG}assertionVersion`, `"${assertionVersion}"^^<${XSD_INTEGER}>`, metadataGraph),
     q(ual, `${DKG}publicTripleCount`, `"${publicTripleCount}"^^<${XSD_INTEGER}>`, metadataGraph),
+    q(ual, `${DKG}privateTripleCount`, `"${privateTripleCount}"^^<${XSD_INTEGER}>`, metadataGraph),
     q(ual, `${DKG}assertionGraph`, assertionGraph, metadataGraph),
     q(ual, `${DKG}contextGraph`, GRAPH, metadataGraph),
+    ...(privateMerkleRoot
+      ? [q(ual, `${DKG}privateMerkleRoot`, JSON.stringify(privateMerkleRoot), metadataGraph)]
+      : []),
     ...(subGraphName
       ? [q(ual, `${DKG}subGraphName`, JSON.stringify(subGraphName), metadataGraph)]
       : []),
@@ -168,7 +178,42 @@ describe('DKGQueryEngine', () => {
     expect(subjects).toContain(`${ENTITY_2}/.well-known/genid/o1`);
   });
 
-  describe('graph-scoped resolveKA', () => {
+  it('treats persisted content-scope version zero as a legacy read', async () => {
+    const ual = 'did:dkg:mock:31337/43';
+    await store.insert([
+      q(ual, `${DKG}contentScopeVersion`, `"0"^^<${XSD_INTEGER}>`, META),
+      q(ual, `${DKG}rootEntity`, ENTITY, META),
+      q(ual, `${DKG}contextGraph`, GRAPH, META),
+    ]);
+
+    const result = await engine.resolveKA(ual);
+
+    expect(result.rootEntity).toBe(ENTITY);
+    expect(result.rootEntities).toEqual([ENTITY]);
+  });
+
+  it('ignores legacy control rows stored in an RDF payload graph', async () => {
+    const ual = 'did:dkg:mock:31337/44';
+    const attackerRoot = 'urn:attacker:root';
+    const payloadGraph = 'urn:attacker:payload';
+    await store.insert([
+      q(ual, `${DKG}rootEntity`, ENTITY, META),
+      q(ual, `${DKG}contextGraph`, GRAPH, META),
+      q(ual, `${DKG}rootEntity`, attackerRoot, payloadGraph),
+      q(ual, `${DKG}contextGraph`, GRAPH, payloadGraph),
+    ]);
+
+    const result = await engine.resolveKA(ual);
+
+    expect(result.rootEntities).toEqual([ENTITY]);
+  });
+
+  it('keeps the published resolveKA result root-compatible for legacy consumers', () => {
+    expectTypeOf<QueryEngine['resolveKA']>()
+      .returns.resolves.toEqualTypeOf<LegacyResolveKAResult>();
+  });
+
+  describe('graph-scoped resolveKnowledgeAsset', () => {
     const UAL = 'did:dkg:31337/0x1111111111111111111111111111111111111111/7';
 
     it('loads the complete exact VM graph without root metadata or subject-prefix filtering', async () => {
@@ -189,7 +234,8 @@ describe('DKGQueryEngine', () => {
         q('urn:asset:alpha', 'urn:predicate:decoy', '"outside exact graph"', GRAPH),
       ]);
 
-      const result = await engine.resolveKA(UAL);
+      await expect(engine.resolveKA(UAL)).rejects.toThrow(/resolveKnowledgeAsset/);
+      const result = await engine.resolveKnowledgeAsset(UAL);
 
       expect(result.contentScopeVersion).toBe(GRAPH_KA_CONTENT_SCOPE_VERSION);
       if (result.contentScopeVersion !== GRAPH_KA_CONTENT_SCOPE_VERSION) {
@@ -207,6 +253,76 @@ describe('DKGQueryEngine', () => {
       expect(result.quads.some((quad) => quad.predicate === 'urn:predicate:decoy')).toBe(false);
     });
 
+    it('ignores scope markers stored in another KA payload graph', async () => {
+      const scope = createGraphKnowledgeAssetScope(UAL, '1');
+      const vmGraph = knowledgeAssetLayerGraphUri(
+        CONTEXT_GRAPH,
+        MemoryLayer.VerifiableMemory,
+        scope,
+      );
+      await store.insert([
+        q('urn:asset:trusted', 'urn:p', '"trusted"', vmGraph),
+        ...graphScopedMetadata(UAL, '1', vmGraph, 1),
+        q(
+          UAL,
+          `${DKG}contentScopeVersion`,
+          `"${GRAPH_KA_CONTENT_SCOPE_VERSION}"^^<${XSD_INTEGER}>`,
+          'urn:attacker:other-ka-payload',
+        ),
+      ]);
+
+      const result = await engine.resolveKnowledgeAsset(UAL);
+
+      expect(result.quads).toEqual([
+        q('urn:asset:trusted', 'urn:p', '"trusted"', vmGraph),
+      ]);
+    });
+
+    it('pages exact-graph reads before materializing the resolved payload', async () => {
+      const scope = createGraphKnowledgeAssetScope(UAL, '1');
+      const vmGraph = knowledgeAssetLayerGraphUri(
+        CONTEXT_GRAPH,
+        MemoryLayer.VerifiableMemory,
+        scope,
+      );
+      const payload = Array.from({ length: 257 }, (_, index) =>
+        q(`urn:paged:${index.toString().padStart(3, '0')}`, 'urn:p', `"${index}"`, vmGraph));
+      await store.insert([
+        ...payload,
+        ...graphScopedMetadata(UAL, '1', vmGraph, payload.length),
+      ]);
+      const trackedQuery = recorder(store.query.bind(store));
+      store.query = trackedQuery;
+
+      const result = await engine.resolveKnowledgeAsset(UAL);
+
+      expect(result.quads).toHaveLength(payload.length);
+      const exactReads = trackedQuery.calls
+        .map(([sparql]) => sparql)
+        .filter((sparql) =>
+          sparql.includes(`GRAPH <${vmGraph}>`) && sparql.includes('ORDER BY ?s ?p ?o'));
+      const exactCounts = trackedQuery.calls
+        .map(([sparql]) => sparql)
+        .filter((sparql) =>
+          sparql.includes(`GRAPH <${vmGraph}>`) && sparql.includes('COUNT(*)'));
+      expect(exactReads).toHaveLength(2);
+      expect(exactCounts).toHaveLength(2);
+      expect(exactReads[0]).toMatch(/LIMIT 256\s+OFFSET 0/);
+      expect(exactReads[1]).toMatch(/LIMIT 2\s+OFFSET 256/);
+    });
+
+    it('rejects a declared exact graph that exceeds the cumulative quad budget', async () => {
+      const scope = createGraphKnowledgeAssetScope(UAL, '1');
+      const vmGraph = knowledgeAssetLayerGraphUri(
+        CONTEXT_GRAPH,
+        MemoryLayer.VerifiableMemory,
+        scope,
+      );
+      await store.insert(graphScopedMetadata(UAL, '1', vmGraph, 100_001));
+
+      await expect(engine.resolveKnowledgeAsset(UAL)).rejects.toThrow(/exceeds quad limit/);
+    });
+
     it('derives the versioned VM graph inside the registered subgraph', async () => {
       const assertionVersion = '2';
       const subGraphName = 'updates';
@@ -222,7 +338,7 @@ describe('DKGQueryEngine', () => {
         ...graphScopedMetadata(UAL, assertionVersion, vmGraph, 1, subGraphName),
       ]);
 
-      const result = await engine.resolveKA(UAL);
+      const result = await engine.resolveKnowledgeAsset(UAL);
 
       expect(result.contentScopeVersion).toBe(GRAPH_KA_CONTENT_SCOPE_VERSION);
       if (result.contentScopeVersion !== GRAPH_KA_CONTENT_SCOPE_VERSION) {
@@ -249,7 +365,7 @@ describe('DKGQueryEngine', () => {
         ...graphScopedMetadata(UAL, '1', attackerGraph, 1),
       ]);
 
-      await expect(engine.resolveKA(UAL)).rejects.toThrow(/assertionGraph mismatch/);
+      await expect(engine.resolveKnowledgeAsset(UAL)).rejects.toThrow(/assertionGraph mismatch/);
     });
 
     it('fails closed when the exact graph count differs from committed metadata', async () => {
@@ -264,7 +380,7 @@ describe('DKGQueryEngine', () => {
         ...graphScopedMetadata(UAL, '1', vmGraph, 2),
       ]);
 
-      await expect(engine.resolveKA(UAL)).rejects.toThrow(/graph integrity mismatch/);
+      await expect(engine.resolveKnowledgeAsset(UAL)).rejects.toThrow(/graph integrity mismatch/);
     });
 
     it('does not fall back to legacy resolution when a V2 marker has incomplete metadata', async () => {
@@ -279,10 +395,88 @@ describe('DKGQueryEngine', () => {
         q(UAL, `${DKG}rootEntity`, ENTITY, META),
       ]);
 
-      await expect(engine.resolveKA(UAL)).rejects.toThrow(/missing kaUal metadata/);
+      await expect(engine.resolveKnowledgeAsset(UAL)).rejects.toThrow(/missing kaUal metadata/);
     });
 
-    it('rejects graph-scoped metadata written outside the context graph meta partition', async () => {
+    it('rejects V2 metadata that omits the private triple count', async () => {
+      const scope = createGraphKnowledgeAssetScope(UAL, '1');
+      const vmGraph = knowledgeAssetLayerGraphUri(
+        CONTEXT_GRAPH,
+        MemoryLayer.VerifiableMemory,
+        scope,
+      );
+      const metadata = graphScopedMetadata(UAL, '1', vmGraph, 1)
+        .filter((entry) => entry.predicate !== `${DKG}privateTripleCount`);
+      await store.insert([
+        q('urn:asset', 'urn:p', '"value"', vmGraph),
+        ...metadata,
+      ]);
+
+      await expect(engine.resolveKnowledgeAsset(UAL)).rejects.toThrow(
+        /missing privateTripleCount metadata/,
+      );
+    });
+
+    it('rejects an empty V2 count envelope', async () => {
+      const scope = createGraphKnowledgeAssetScope(UAL, '1');
+      const vmGraph = knowledgeAssetLayerGraphUri(
+        CONTEXT_GRAPH,
+        MemoryLayer.VerifiableMemory,
+        scope,
+      );
+      await store.insert(graphScopedMetadata(UAL, '1', vmGraph, 0));
+
+      await expect(engine.resolveKnowledgeAsset(UAL)).rejects.toThrow(/empty asset/);
+    });
+
+    it('requires a private commitment exactly when the V2 private count is positive', async () => {
+      const scope = createGraphKnowledgeAssetScope(UAL, '1');
+      const vmGraph = knowledgeAssetLayerGraphUri(
+        CONTEXT_GRAPH,
+        MemoryLayer.VerifiableMemory,
+        scope,
+      );
+      await store.insert(graphScopedMetadata(UAL, '1', vmGraph, 0, undefined, META, 1));
+
+      await expect(engine.resolveKnowledgeAsset(UAL)).rejects.toThrow(
+        /requires exactly one privateMerkleRoot/,
+      );
+    });
+
+    it('rejects a V2 private commitment when the private count is zero', async () => {
+      const scope = createGraphKnowledgeAssetScope(UAL, '1');
+      const vmGraph = knowledgeAssetLayerGraphUri(
+        CONTEXT_GRAPH,
+        MemoryLayer.VerifiableMemory,
+        scope,
+      );
+      await store.insert(
+        graphScopedMetadata(UAL, '1', vmGraph, 1, undefined, META, 0, 'ab'.repeat(32)),
+      );
+      await store.insert([q('urn:asset', 'urn:p', '"value"', vmGraph)]);
+
+      await expect(engine.resolveKnowledgeAsset(UAL)).rejects.toThrow(
+        /privateMerkleRoot without private content/,
+      );
+    });
+
+    it('accepts a legitimate private-only V2 envelope without materializing public quads', async () => {
+      const scope = createGraphKnowledgeAssetScope(UAL, '1');
+      const vmGraph = knowledgeAssetLayerGraphUri(
+        CONTEXT_GRAPH,
+        MemoryLayer.VerifiableMemory,
+        scope,
+      );
+      await store.insert(
+        graphScopedMetadata(UAL, '1', vmGraph, 0, undefined, META, 1, 'cd'.repeat(32)),
+      );
+
+      const result = await engine.resolveKnowledgeAsset(UAL);
+
+      expect(result.quads).toEqual([]);
+    });
+
+    it('does not treat graph-scoped metadata outside a trusted meta partition as control data', async () => {
       const scope = createGraphKnowledgeAssetScope(UAL, '1');
       const vmGraph = knowledgeAssetLayerGraphUri(
         CONTEXT_GRAPH,
@@ -295,7 +489,7 @@ describe('DKGQueryEngine', () => {
         ...graphScopedMetadata(UAL, '1', vmGraph, 1, undefined, poisonedMetaGraph),
       ]);
 
-      await expect(engine.resolveKA(UAL)).rejects.toThrow(/metadata graph mismatch/);
+      await expect(engine.resolveKnowledgeAsset(UAL)).rejects.toThrow(/KA not found/);
     });
 
     it('does not hide a malformed scope marker behind the legacy fallback', async () => {
@@ -305,7 +499,7 @@ describe('DKGQueryEngine', () => {
         q(UAL, `${DKG}rootEntity`, ENTITY, META),
       ]);
 
-      await expect(engine.resolveKA(UAL)).rejects.toThrow(/invalid contentScopeVersion/);
+      await expect(engine.resolveKnowledgeAsset(UAL)).rejects.toThrow(/invalid contentScopeVersion/);
     });
   });
 

--- a/packages/query/test/query-handler.test.ts
+++ b/packages/query/test/query-handler.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
+import {
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  MemoryLayer,
+  createGraphKnowledgeAssetScope,
+  knowledgeAssetLayerGraphUri,
+} from '@origintrail-official/dkg-core';
 import { DKGQueryEngine } from '../src/dkg-query-engine.js';
 import { QueryHandler } from '../src/query-handler.js';
 import type { QueryRequest, QueryAccessConfig } from '../src/query-types.js';
@@ -11,6 +17,9 @@ const ENTITY_B = 'did:dkg:entity:bob';
 const SCHEMA_NAME = 'https://schema.org/name';
 const SCHEMA_PERSON = 'https://schema.org/Person';
 const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+const DKG = 'http://dkg.io/ontology/';
+const XSD_INTEGER = 'http://www.w3.org/2001/XMLSchema#integer';
+const DKG_CONTEXT_GRAPH = 'https://dkg.network/ontology#ContextGraph';
 
 function q(s: string, p: string, o: string, g = GRAPH): Quad {
   return { subject: s, predicate: p, object: o, graph: g };
@@ -355,6 +364,40 @@ describe('QueryHandler', () => {
   });
 
   describe('ENTITY_BY_UAL lookup', () => {
+    it('serves graph-scoped assets through the graph-aware resolver', async () => {
+      const ual = 'did:dkg:31337/0x1111111111111111111111111111111111111111/7';
+      const assertionVersion = '1';
+      const scope = createGraphKnowledgeAssetScope(ual, assertionVersion);
+      const assertionGraph = knowledgeAssetLayerGraphUri(
+        CONTEXT_GRAPH,
+        MemoryLayer.VerifiableMemory,
+        scope,
+      );
+      const metadataGraph = `${GRAPH}/_meta`;
+      const payloadSubject = 'urn:asset:graph-aware';
+      await store.insert([
+        q(GRAPH, RDF_TYPE, DKG_CONTEXT_GRAPH, 'did:dkg:context-graph:ontology'),
+        q(payloadSubject, SCHEMA_NAME, '"Graph aware"', assertionGraph),
+        q(ual, `${DKG}contentScopeVersion`, `"${GRAPH_KA_CONTENT_SCOPE_VERSION}"^^<${XSD_INTEGER}>`, metadataGraph),
+        q(ual, `${DKG}kaUal`, ual, metadataGraph),
+        q(ual, `${DKG}assertionVersion`, `"${assertionVersion}"^^<${XSD_INTEGER}>`, metadataGraph),
+        q(ual, `${DKG}publicTripleCount`, `"1"^^<${XSD_INTEGER}>`, metadataGraph),
+        q(ual, `${DKG}privateTripleCount`, `"0"^^<${XSD_INTEGER}>`, metadataGraph),
+        q(ual, `${DKG}assertionGraph`, assertionGraph, metadataGraph),
+        q(ual, `${DKG}contextGraph`, GRAPH, metadataGraph),
+      ]);
+      const handler = new QueryHandler(engine, { defaultPolicy: 'public' });
+
+      const response = await handler.handle(
+        makeRequest({ lookupType: 'ENTITY_BY_UAL', contextGraphId: undefined, ual }),
+        'peer-1',
+      );
+
+      expect(response.status).toBe('OK');
+      expect(response.resultCount).toBe(1);
+      expect(response.ntriples).toContain(payloadSubject);
+    });
+
     it('returns error when ual is missing', async () => {
       const handler = new QueryHandler(engine, { defaultPolicy: 'public' });
 

--- a/packages/query/test/query-handler.test.ts
+++ b/packages/query/test/query-handler.test.ts
@@ -374,14 +374,16 @@ describe('QueryHandler', () => {
         scope,
       );
       const metadataGraph = `${GRAPH}/_meta`;
-      const payloadSubject = 'urn:asset:graph-aware';
+      const blankSubject = '_:graph-aware';
+      const blankObject = '_:related';
       await store.insert([
         q(GRAPH, RDF_TYPE, DKG_CONTEXT_GRAPH, 'did:dkg:context-graph:ontology'),
-        q(payloadSubject, SCHEMA_NAME, '"Graph aware"', assertionGraph),
+        q(blankSubject, SCHEMA_NAME, '"Graph aware"', assertionGraph),
+        q('urn:asset:iri', 'urn:related', blankObject, assertionGraph),
         q(ual, `${DKG}contentScopeVersion`, `"${GRAPH_KA_CONTENT_SCOPE_VERSION}"^^<${XSD_INTEGER}>`, metadataGraph),
         q(ual, `${DKG}kaUal`, ual, metadataGraph),
         q(ual, `${DKG}assertionVersion`, `"${assertionVersion}"^^<${XSD_INTEGER}>`, metadataGraph),
-        q(ual, `${DKG}publicTripleCount`, `"1"^^<${XSD_INTEGER}>`, metadataGraph),
+        q(ual, `${DKG}publicTripleCount`, `"2"^^<${XSD_INTEGER}>`, metadataGraph),
         q(ual, `${DKG}privateTripleCount`, `"0"^^<${XSD_INTEGER}>`, metadataGraph),
         q(ual, `${DKG}assertionGraph`, assertionGraph, metadataGraph),
         q(ual, `${DKG}contextGraph`, GRAPH, metadataGraph),
@@ -394,8 +396,14 @@ describe('QueryHandler', () => {
       );
 
       expect(response.status).toBe('OK');
-      expect(response.resultCount).toBe(1);
-      expect(response.ntriples).toContain(payloadSubject);
+      expect(response.resultCount).toBe(2);
+      expect(response.ntriples).toMatch(
+        /^_:[A-Za-z0-9]+ <https:\/\/schema\.org\/name> "Graph aware" \.$/m,
+      );
+      expect(response.ntriples).toMatch(
+        /^<urn:asset:iri> <urn:related> _:[A-Za-z0-9]+ \.$/m,
+      );
+      expect(response.ntriples).not.toContain('<_:');
     });
 
     it('returns error when ual is missing', async () => {

--- a/packages/storage/src/adapters/blazegraph.ts
+++ b/packages/storage/src/adapters/blazegraph.ts
@@ -26,6 +26,7 @@ import {
   isAtomicGraphReplaceStagingGraph,
 } from '../atomic-graph-replace.js';
 import { quadToNQuad } from '../bounded-rdf.js';
+import { readResponseTextBounded } from '../http-response-limit.js';
 
 export const DEFAULT_BLAZEGRAPH_OPERATION_TIMEOUT_MS = 30_000;
 
@@ -367,7 +368,7 @@ export class BlazegraphStore implements TripleStore {
       const isConstruct = upper.startsWith('CONSTRUCT') || upper.startsWith('DESCRIBE');
 
       if (isConstruct) {
-        return this.queryConstruct(trimmed, deadline);
+        return this.queryConstruct(trimmed, deadline, options);
       }
 
       // Direct POST (W3C SPARQL 1.1 Protocol): send the query as the raw
@@ -388,13 +389,20 @@ export class BlazegraphStore implements TripleStore {
         signal: deadline.signal,
       }));
       if (!res.ok) {
-        const text = await deadline.waitFor(res.text().catch(() => ''));
+        const text = await deadline.waitFor((options?.maxResponseBytes === undefined
+          ? res.text()
+          : readResponseTextBounded(res, options.maxResponseBytes)
+        ).catch(() => ''));
         throw new Error(`Blazegraph query failed (${res.status}): ${text.slice(0, 300)}`);
       }
 
-      const json = await deadline.waitFor(
-        res.json() as Promise<AdapterSparqlJsonSelectResponse | BlazeAskResponse>,
-      );
+      const json = options?.maxResponseBytes === undefined
+        ? await deadline.waitFor(
+            res.json() as Promise<AdapterSparqlJsonSelectResponse | BlazeAskResponse>,
+          )
+        : JSON.parse(await deadline.waitFor(
+            readResponseTextBounded(res, options.maxResponseBytes),
+          )) as AdapterSparqlJsonSelectResponse | BlazeAskResponse;
 
       if (isAsk || 'boolean' in json) {
         return { type: 'boolean', value: (json as BlazeAskResponse).boolean } satisfies AskResult;
@@ -408,6 +416,7 @@ export class BlazegraphStore implements TripleStore {
   private async queryConstruct(
     sparql: string,
     deadline: StoreOperationDeadline,
+    options?: TripleStoreQueryOptions,
   ): Promise<ConstructResult> {
     const res = await deadline.waitFor(fetch(this.url, {
       method: 'POST',
@@ -419,10 +428,15 @@ export class BlazegraphStore implements TripleStore {
       signal: deadline.signal,
     }));
     if (!res.ok) {
-      const text = await deadline.waitFor(res.text().catch(() => ''));
+      const text = await deadline.waitFor((options?.maxResponseBytes === undefined
+        ? res.text()
+        : readResponseTextBounded(res, options.maxResponseBytes)
+      ).catch(() => ''));
       throw new Error(`Blazegraph construct failed (${res.status}): ${text.slice(0, 300)}`);
     }
-    const text = await deadline.waitFor(res.text());
+    const text = await deadline.waitFor(options?.maxResponseBytes === undefined
+      ? res.text()
+      : readResponseTextBounded(res, options.maxResponseBytes));
     const quads = parseNQuadsText(text);
     deadline.check();
     return { type: 'quads', quads };

--- a/packages/storage/src/adapters/blazegraph.ts
+++ b/packages/storage/src/adapters/blazegraph.ts
@@ -25,6 +25,7 @@ import {
   buildAtomicGraphReplaceUpdate,
   isAtomicGraphReplaceStagingGraph,
 } from '../atomic-graph-replace.js';
+import { quadToNQuad } from '../bounded-rdf.js';
 
 export const DEFAULT_BLAZEGRAPH_OPERATION_TIMEOUT_MS = 30_000;
 
@@ -534,14 +535,6 @@ interface BlazeAskResponse {
 // =====================================================================
 // N-Quad serialisation / parsing helpers (shared with oxigraph adapter)
 // =====================================================================
-
-function quadToNQuad(q: DKGQuad): string {
-  const s = formatTerm(q.subject);
-  const p = `<${q.predicate}>`;
-  const o = formatTerm(q.object);
-  const g = q.graph ? ` <${q.graph}>` : '';
-  return `${s} ${p} ${o}${g} .`;
-}
 
 /**
  * N-Quads serializer for Blazegraph's bulk-insert wire format: a standard

--- a/packages/storage/src/adapters/oxigraph.ts
+++ b/packages/storage/src/adapters/oxigraph.ts
@@ -23,6 +23,7 @@ import {
   buildAtomicGraphReplaceUpdate,
   isAtomicGraphReplaceStagingGraph,
 } from '../atomic-graph-replace.js';
+import { quadsToNQuads } from '../bounded-rdf.js';
 import { assertQuadLiteralsMutf8Safe, JAVA_WRITE_UTF_MAX_BYTES } from '@origintrail-official/dkg-core';
 
 // SWM DATA segment (bucket `…/_shared_memory` + per-KA `…/_shared_memory/{author}/{n}`),
@@ -228,7 +229,7 @@ export class OxigraphStore implements TripleStore {
         label: 'OxigraphStore.insert',
       });
     }
-    const nquads = quads.map(quadToNQuad).join('\n') + '\n';
+    const nquads = `${quadsToNQuads(quads)}\n`;
     this.store.load(nquads, { format: 'application/n-quads' });
     this.scheduleFlush();
     this.writeGen.recordGraphWrites(new Set(quads.map((q) => q.graph || '')));
@@ -469,27 +470,6 @@ function throwIfAborted(signal: AbortSignal | undefined): void {
   if (!signal?.aborted) return;
   const reason = signal.reason;
   throw reason instanceof Error ? reason : new Error(String(reason ?? 'aborted'));
-}
-
-function quadToNQuad(q: DKGQuad): string {
-  const s = formatTerm(q.subject);
-  const p = `<${q.predicate}>`;
-  const o = formatTerm(q.object);
-  const g = q.graph ? ` <${q.graph}>` : '';
-  return `${s} ${p} ${o}${g} .`;
-}
-
-function formatTerm(term: string): string {
-  if (term.startsWith('"')) {
-    // Wrap bare datatype IRIs in angle brackets: "val"^^http://... → "val"^^<http://...>
-    // Anchored to closing quote to avoid matching ^^ inside string content.
-    const m = term.match(/^("(?:[^"\\]|\\.)*")\^\^(?!<)(.+)$/);
-    if (m) return `${m[1]}^^<${m[2]}>`;
-    return term;
-  }
-  if (term.startsWith('_:')) return term;
-  if (term.startsWith('<')) return term;
-  return `<${term}>`;
 }
 
 function parseTerm(term: string): oxigraph.NamedNode | oxigraph.Literal | oxigraph.BlankNode {

--- a/packages/storage/src/adapters/sparql-http.ts
+++ b/packages/storage/src/adapters/sparql-http.ts
@@ -45,6 +45,7 @@ import {
   buildAtomicGraphReplaceUpdate,
   isAtomicGraphReplaceStagingGraph,
 } from '../atomic-graph-replace.js';
+import { readResponseTextBounded } from '../http-response-limit.js';
 import { assertQuadLiteralsMutf8Safe, JAVA_WRITE_UTF_MAX_BYTES } from '@origintrail-official/dkg-core';
 import { createHash } from 'node:crypto';
 import { performance } from 'node:perf_hooks';
@@ -462,11 +463,18 @@ export class SparqlHttpStore implements TripleStore {
 
         const res = await this.postQuery(trimmed, 'application/sparql-results+json', options);
         if (!res.ok) {
-          const text = await res.text().catch(() => '');
+          const text = await (options?.maxResponseBytes === undefined
+            ? res.text()
+            : readResponseTextBounded(res, options.maxResponseBytes)
+          ).catch(() => '');
           throw new Error(`SPARQL HTTP query failed (${res.status}): ${text.slice(0, 300)}`);
         }
 
-        const json = (await res.json()) as AdapterSparqlJsonSelectResponse | W3CAskResponse;
+        const json = options?.maxResponseBytes === undefined
+          ? await res.json() as AdapterSparqlJsonSelectResponse | W3CAskResponse
+          : JSON.parse(
+              await readResponseTextBounded(res, options.maxResponseBytes),
+            ) as AdapterSparqlJsonSelectResponse | W3CAskResponse;
 
         if (isAsk || 'boolean' in json) {
           return { type: 'boolean', value: (json as W3CAskResponse).boolean } satisfies AskResult;
@@ -488,10 +496,15 @@ export class SparqlHttpStore implements TripleStore {
   private async queryConstruct(sparql: string, options?: SparqlHttpQueryOptions): Promise<ConstructResult> {
     const res = await this.postQuery(sparql, 'application/n-quads, text/n-quads', options);
     if (!res.ok) {
-      const text = await res.text().catch(() => '');
+      const text = await (options?.maxResponseBytes === undefined
+        ? res.text()
+        : readResponseTextBounded(res, options.maxResponseBytes)
+      ).catch(() => '');
       throw new Error(`SPARQL HTTP construct failed (${res.status}): ${text.slice(0, 300)}`);
     }
-    const text = await res.text();
+    const text = options?.maxResponseBytes === undefined
+      ? await res.text()
+      : await readResponseTextBounded(res, options.maxResponseBytes);
     const quads = parseNQuadsText(text);
     return { type: 'quads', quads };
   }

--- a/packages/storage/src/bounded-rdf.ts
+++ b/packages/storage/src/bounded-rdf.ts
@@ -1,0 +1,347 @@
+import {
+  DEFAULT_MAX_READ_BYTES,
+  assertSafeIri,
+} from '@origintrail-official/dkg-core';
+import type {
+  Quad,
+  QueryOptions,
+  TripleStore,
+} from './triple-store.js';
+
+const DEFAULT_EXACT_GRAPH_PAGE_SIZE = 256;
+const DEFAULT_EXACT_GRAPH_MAX_QUADS = 100_000;
+const DEFAULT_EXACT_GRAPH_MAX_NQUADS_BYTES = DEFAULT_MAX_READ_BYTES - 1024;
+const UTF8_ENCODER = new TextEncoder();
+
+export interface ReadExactGraphPagedOptions {
+  expectedQuadCount: number;
+  pageSize?: number;
+  maxQuadCount?: number;
+  maxNQuadsBytes?: number;
+  outputGraph?: string;
+  queryOptions?: QueryOptions;
+}
+
+type ReadExactGraphPagedWithDiscoveredCountOptions = Omit<
+  ReadExactGraphPagedOptions,
+  'expectedQuadCount'
+>;
+
+export type ExactGraphReadErrorKind = 'limit' | 'integrity';
+
+export type ExactGraphReadErrorCode =
+  | 'QUAD_COUNT_LIMIT_EXCEEDED'
+  | 'NQUADS_BYTE_LIMIT_EXCEEDED'
+  | 'QUAD_COUNT_MISMATCH'
+  | 'INVALID_QUERY_RESULT';
+
+/** A machine-classifiable failure from a bounded exact-graph read. */
+export class ExactGraphReadError extends Error {
+  readonly kind: ExactGraphReadErrorKind;
+  readonly code: ExactGraphReadErrorCode;
+  readonly graphIri: string;
+  readonly expected?: number;
+  readonly actual?: number | bigint;
+  readonly limit?: number;
+
+  constructor(params: {
+    kind: ExactGraphReadErrorKind;
+    code: ExactGraphReadErrorCode;
+    graphIri: string;
+    message: string;
+    expected?: number;
+    actual?: number | bigint;
+    limit?: number;
+  }) {
+    super(params.message);
+    this.name = 'ExactGraphReadError';
+    this.kind = params.kind;
+    this.code = params.code;
+    this.graphIri = params.graphIri;
+    this.expected = params.expected;
+    this.actual = params.actual;
+    this.limit = params.limit;
+  }
+}
+
+/** Render one storage {@link Quad} as a canonical N-Quads line. */
+export function quadToNQuad(quad: Quad): string {
+  const graph = quad.graph ? ` ${termToNQuad(quad.graph)}` : '';
+  return `${termToNQuad(quad.subject)} ${iriToNQuad(quad.predicate)} ${termToNQuad(quad.object)}${graph} .`;
+}
+
+/** Render storage quads as newline-delimited N-Quads without a trailing newline. */
+export function quadsToNQuads(quads: readonly Quad[]): string {
+  return quads.map(quadToNQuad).join('\n');
+}
+
+/**
+ * Read one exact named graph in deterministic pages.
+ *
+ * The returned graph term is caller-selectable because private access serves
+ * graphless N-Quads while sync/query callers retain the source named graph.
+ */
+export async function readExactGraphPaged(
+  store: TripleStore,
+  graphIri: string,
+  options: ReadExactGraphPagedOptions,
+): Promise<Quad[]> {
+  return readExactGraphPagedInternal(store, graphIri, options);
+}
+
+/** Internal compatibility path for callers that do not yet own a trusted count. */
+export async function readExactGraphPagedWithDiscoveredCount(
+  store: TripleStore,
+  graphIri: string,
+  options: ReadExactGraphPagedWithDiscoveredCountOptions = {},
+): Promise<Quad[]> {
+  return readExactGraphPagedInternal(store, graphIri, options);
+}
+
+async function readExactGraphPagedInternal(
+  store: TripleStore,
+  graphIri: string,
+  options: ReadExactGraphPagedOptions | ReadExactGraphPagedWithDiscoveredCountOptions,
+): Promise<Quad[]> {
+  const graph = assertSafeIri(graphIri);
+  const requestedPageSize = positiveSafeInteger(
+    options.pageSize ?? DEFAULT_EXACT_GRAPH_PAGE_SIZE,
+    'pageSize',
+  );
+  // The adapter materializes one whole SELECT result before this function can
+  // inspect its byte size. Keep that unavoidable transient page hard-bounded.
+  const pageSize = Math.min(requestedPageSize, DEFAULT_EXACT_GRAPH_PAGE_SIZE);
+  const maxQuadCount = nonNegativeSafeInteger(
+    options.maxQuadCount ?? DEFAULT_EXACT_GRAPH_MAX_QUADS,
+    'maxQuadCount',
+  );
+  const maxNQuadsBytes = nonNegativeSafeInteger(
+    options.maxNQuadsBytes ?? DEFAULT_EXACT_GRAPH_MAX_NQUADS_BYTES,
+    'maxNQuadsBytes',
+  );
+  const configuredExpectedQuadCount = 'expectedQuadCount' in options
+    ? nonNegativeSafeInteger(options.expectedQuadCount, 'expectedQuadCount')
+    : undefined;
+  if (
+    configuredExpectedQuadCount !== undefined
+    && configuredExpectedQuadCount > maxQuadCount
+  ) {
+    throw new ExactGraphReadError({
+      kind: 'limit',
+      code: 'QUAD_COUNT_LIMIT_EXCEEDED',
+      graphIri: graph,
+      message: `Exact graph read exceeds quad limit: expected ${configuredExpectedQuadCount}, limit ${maxQuadCount}`,
+      actual: configuredExpectedQuadCount,
+      limit: maxQuadCount,
+    });
+  }
+
+  const preflightQuadCount = await queryExactGraphCount(
+    store,
+    graph,
+    maxQuadCount,
+    options.queryOptions,
+  );
+  const expectedQuadCount = configuredExpectedQuadCount ?? preflightQuadCount;
+  if (
+    configuredExpectedQuadCount !== undefined
+    && preflightQuadCount !== configuredExpectedQuadCount
+  ) {
+    throw quadCountMismatch(graph, configuredExpectedQuadCount, preflightQuadCount);
+  }
+
+  const quads: Quad[] = [];
+  const seenNQuadLines = new Set<string>();
+  let nquadsBytes = 0;
+  let offset = 0;
+  for (;;) {
+    const remainingWithOverflowSentinel = expectedQuadCount - quads.length + 1;
+    const pageLimit = Math.min(pageSize, remainingWithOverflowSentinel);
+    const result = await store.query(
+      `SELECT ?s ?p ?o WHERE {
+        GRAPH <${graph}> { ?s ?p ?o }
+      }
+      ORDER BY ?s ?p ?o
+      LIMIT ${pageLimit}
+      OFFSET ${offset}`,
+      options.queryOptions,
+    );
+    if (result.type !== 'bindings') {
+      throw invalidQueryResult(graph, 'Exact graph read expected SELECT bindings');
+    }
+    if (!Array.isArray(result.bindings)) {
+      throw invalidQueryResult(graph, 'Exact graph read bindings are not an array');
+    }
+    if (result.bindings.length > pageLimit) {
+      throw invalidQueryResult(
+        graph,
+        `Exact graph read page exceeded LIMIT ${pageLimit}: found ${result.bindings.length} bindings`,
+      );
+    }
+    for (const rawRow of result.bindings) {
+      if (typeof rawRow !== 'object' || rawRow === null) {
+        throw invalidQueryResult(graph, 'Exact graph read received an invalid binding');
+      }
+      const row = rawRow as Record<string, unknown>;
+      const subject = row['s'];
+      const predicate = row['p'];
+      const object = row['o'];
+      if (
+        typeof subject !== 'string'
+        || typeof predicate !== 'string'
+        || typeof object !== 'string'
+      ) {
+        throw invalidQueryResult(graph, 'Exact graph read received an incomplete binding');
+      }
+      const quad: Quad = {
+        subject,
+        predicate,
+        object,
+        graph: options.outputGraph ?? graph,
+      };
+      const nquadLine = quadToNQuad(quad);
+      if (seenNQuadLines.has(nquadLine)) {
+        throw invalidQueryResult(
+          graph,
+          'Exact graph read received a duplicate triple across ordered pages',
+        );
+      }
+      seenNQuadLines.add(nquadLine);
+      nquadsBytes +=
+        (quads.length === 0 ? 0 : 1) +
+        UTF8_ENCODER.encode(nquadLine).byteLength;
+      if (nquadsBytes > maxNQuadsBytes) {
+        throw new ExactGraphReadError({
+          kind: 'limit',
+          code: 'NQUADS_BYTE_LIMIT_EXCEEDED',
+          graphIri: graph,
+          message: `Exact graph read exceeds N-Quads byte limit: found ${nquadsBytes}, limit ${maxNQuadsBytes}`,
+          actual: nquadsBytes,
+          limit: maxNQuadsBytes,
+        });
+      }
+      quads.push(quad);
+    }
+    if (quads.length > expectedQuadCount) {
+      throw quadCountMismatch(graph, expectedQuadCount, quads.length);
+    }
+    if (result.bindings.length < pageLimit) break;
+    offset += pageLimit;
+  }
+
+  if (quads.length !== expectedQuadCount) {
+    throw quadCountMismatch(graph, expectedQuadCount, quads.length);
+  }
+  const postflightQuadCount = await queryExactGraphCount(
+    store,
+    graph,
+    maxQuadCount,
+    options.queryOptions,
+  );
+  if (postflightQuadCount !== expectedQuadCount) {
+    throw quadCountMismatch(graph, expectedQuadCount, postflightQuadCount);
+  }
+  return quads;
+}
+
+function termToNQuad(term: string): string {
+  if (term.startsWith('"')) return normalizeBareLiteralDatatype(term);
+  if (term.startsWith('_:')) return term;
+  return iriToNQuad(term);
+}
+
+function iriToNQuad(iri: string): string {
+  return iri.startsWith('<') && iri.endsWith('>') ? iri : `<${iri}>`;
+}
+
+function normalizeBareLiteralDatatype(term: string): string {
+  const bareDatatype = term.match(/^("(?:[^"\\]|\\.)*")\^\^(?!<)(.+)$/);
+  return bareDatatype
+    ? `${bareDatatype[1]}^^${iriToNQuad(bareDatatype[2])}`
+    : term;
+}
+
+function nonNegativeSafeInteger(value: number, field: string): number {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new RangeError(`${field} must be a non-negative safe integer`);
+  }
+  return value;
+}
+
+function positiveSafeInteger(value: number, field: string): number {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new RangeError(`${field} must be a positive safe integer`);
+  }
+  return value;
+}
+
+function quadCountMismatch(
+  graphIri: string,
+  expected: number,
+  actual: number,
+): ExactGraphReadError {
+  return new ExactGraphReadError({
+    kind: 'integrity',
+    code: 'QUAD_COUNT_MISMATCH',
+    graphIri,
+    message: `Exact graph read count mismatch: expected ${expected}, found ${actual}`,
+    expected,
+    actual,
+  });
+}
+
+function invalidQueryResult(graphIri: string, message: string): ExactGraphReadError {
+  return new ExactGraphReadError({
+    kind: 'integrity',
+    code: 'INVALID_QUERY_RESULT',
+    graphIri,
+    message,
+  });
+}
+
+async function queryExactGraphCount(
+  store: TripleStore,
+  graphIri: string,
+  maxQuadCount: number,
+  queryOptions: QueryOptions | undefined,
+): Promise<number> {
+  const result = await store.query(
+    `SELECT (COUNT(*) AS ?count) WHERE {
+      GRAPH <${graphIri}> { ?s ?p ?o }
+    }`,
+    queryOptions,
+  );
+  if (
+    result.type !== 'bindings'
+    || !Array.isArray(result.bindings)
+    || result.bindings.length !== 1
+  ) {
+    throw invalidQueryResult(graphIri, 'Exact graph count expected one SELECT binding');
+  }
+  const row: unknown = result.bindings[0];
+  if (typeof row !== 'object' || row === null) {
+    throw invalidQueryResult(graphIri, 'Exact graph count received an invalid binding');
+  }
+  const raw = (row as Record<string, unknown>)['count'];
+  if (typeof raw !== 'string') {
+    throw invalidQueryResult(graphIri, 'Exact graph count binding is not a string');
+  }
+  const match = raw.match(/^(?:([0-9]+)|"([0-9]+)"(?:\^\^<[^>]+>)?)$/);
+  const digits = match?.[1] ?? match?.[2];
+  if (digits === undefined) {
+    throw invalidQueryResult(graphIri, `Exact graph count is not a non-negative integer: ${raw}`);
+  }
+  const count = BigInt(digits);
+  if (count > BigInt(maxQuadCount)) {
+    const actual = count <= BigInt(Number.MAX_SAFE_INTEGER) ? Number(count) : count;
+    throw new ExactGraphReadError({
+      kind: 'limit',
+      code: 'QUAD_COUNT_LIMIT_EXCEEDED',
+      graphIri,
+      message: `Exact graph read exceeds quad limit: found ${count}, limit ${maxQuadCount}`,
+      actual,
+      limit: maxQuadCount,
+    });
+  }
+  return Number(count);
+}

--- a/packages/storage/src/bounded-rdf.ts
+++ b/packages/storage/src/bounded-rdf.ts
@@ -119,6 +119,15 @@ async function readExactGraphPagedInternal(
     options.maxNQuadsBytes ?? DEFAULT_EXACT_GRAPH_MAX_NQUADS_BYTES,
     'maxNQuadsBytes',
   );
+  const maxPageResponseBytes = Math.min(
+    options.queryOptions?.maxResponseBytes ?? DEFAULT_MAX_READ_BYTES,
+    DEFAULT_MAX_READ_BYTES,
+    Math.max(64 * 1024, maxNQuadsBytes + 64 * 1024),
+  );
+  const boundedQueryOptions: QueryOptions = {
+    ...options.queryOptions,
+    maxResponseBytes: maxPageResponseBytes,
+  };
   const configuredExpectedQuadCount = 'expectedQuadCount' in options
     ? nonNegativeSafeInteger(options.expectedQuadCount, 'expectedQuadCount')
     : undefined;
@@ -140,7 +149,7 @@ async function readExactGraphPagedInternal(
     store,
     graph,
     maxQuadCount,
-    options.queryOptions,
+    boundedQueryOptions,
   );
   const expectedQuadCount = configuredExpectedQuadCount ?? preflightQuadCount;
   if (
@@ -164,7 +173,7 @@ async function readExactGraphPagedInternal(
       ORDER BY ?s ?p ?o
       LIMIT ${pageLimit}
       OFFSET ${offset}`,
-      options.queryOptions,
+      boundedQueryOptions,
     );
     if (result.type !== 'bindings') {
       throw invalidQueryResult(graph, 'Exact graph read expected SELECT bindings');
@@ -236,7 +245,7 @@ async function readExactGraphPagedInternal(
     store,
     graph,
     maxQuadCount,
-    options.queryOptions,
+    boundedQueryOptions,
   );
   if (postflightQuadCount !== expectedQuadCount) {
     throw quadCountMismatch(graph, expectedQuadCount, postflightQuadCount);

--- a/packages/storage/src/bounded-rdf.ts
+++ b/packages/storage/src/bounded-rdf.ts
@@ -162,6 +162,99 @@ async function readExactGraphPagedInternal(
   const quads: Quad[] = [];
   const seenNQuadLines = new Set<string>();
   let nquadsBytes = 0;
+  const appendQuad = (subject: string, predicate: string, object: string): void => {
+    const quad: Quad = {
+      subject,
+      predicate,
+      object,
+      graph: options.outputGraph ?? graph,
+    };
+    const nquadLine = quadToNQuad(quad);
+    if (seenNQuadLines.has(nquadLine)) {
+      throw invalidQueryResult(
+        graph,
+        'Exact graph read received a duplicate triple',
+      );
+    }
+    seenNQuadLines.add(nquadLine);
+    nquadsBytes +=
+      (quads.length === 0 ? 0 : 1) +
+      UTF8_ENCODER.encode(nquadLine).byteLength;
+    if (nquadsBytes > maxNQuadsBytes) {
+      throw new ExactGraphReadError({
+        kind: 'limit',
+        code: 'NQUADS_BYTE_LIMIT_EXCEEDED',
+        graphIri: graph,
+        message: `Exact graph read exceeds N-Quads byte limit: found ${nquadsBytes}, limit ${maxNQuadsBytes}`,
+        actual: nquadsBytes,
+        limit: maxNQuadsBytes,
+      });
+    }
+    quads.push(quad);
+  };
+  const verifyPostflightCount = async (): Promise<void> => {
+    const postflightQuadCount = await queryExactGraphCount(
+      store,
+      graph,
+      maxQuadCount,
+      boundedQueryOptions,
+    );
+    if (postflightQuadCount !== expectedQuadCount) {
+      throw quadCountMismatch(graph, expectedQuadCount, postflightQuadCount);
+    }
+  };
+  const readBlankNodeGraph = async (): Promise<Quad[]> => {
+    const maxSingleDocumentQuadCount = Math.min(
+      maxQuadCount,
+      DEFAULT_EXACT_GRAPH_PAGE_SIZE,
+    );
+    if (expectedQuadCount > maxSingleDocumentQuadCount) {
+      throw new ExactGraphReadError({
+        kind: 'limit',
+        code: 'QUAD_COUNT_LIMIT_EXCEEDED',
+        graphIri: graph,
+        message: `Exact blank-node graph read exceeds the single-document quad limit: expected ${expectedQuadCount}, limit ${maxSingleDocumentQuadCount}`,
+        actual: expectedQuadCount,
+        limit: maxSingleDocumentQuadCount,
+      });
+    }
+    quads.length = 0;
+    seenNQuadLines.clear();
+    nquadsBytes = 0;
+    const result = await store.query(
+      `CONSTRUCT { ?s ?p ?o } WHERE {
+        GRAPH <${graph}> { ?s ?p ?o }
+      }
+      LIMIT ${expectedQuadCount + 1}`,
+      boundedQueryOptions,
+    );
+    if (result.type !== 'quads' || !Array.isArray(result.quads)) {
+      throw invalidQueryResult(graph, 'Exact blank-node graph read expected CONSTRUCT quads');
+    }
+    for (const rawQuad of result.quads) {
+      if (typeof rawQuad !== 'object' || rawQuad === null) {
+        throw invalidQueryResult(graph, 'Exact blank-node graph read received an invalid quad');
+      }
+      const { subject, predicate, object } = rawQuad as Partial<Quad>;
+      if (
+        typeof subject !== 'string'
+        || typeof predicate !== 'string'
+        || typeof object !== 'string'
+      ) {
+        throw invalidQueryResult(graph, 'Exact blank-node graph read received an incomplete quad');
+      }
+      appendQuad(subject, predicate, object);
+      if (quads.length > expectedQuadCount) {
+        throw quadCountMismatch(graph, expectedQuadCount, quads.length);
+      }
+    }
+    if (quads.length !== expectedQuadCount) {
+      throw quadCountMismatch(graph, expectedQuadCount, quads.length);
+    }
+    await verifyPostflightCount();
+    return quads;
+  };
+
   let offset = 0;
   for (;;) {
     const remainingWithOverflowSentinel = expectedQuadCount - quads.length + 1;
@@ -202,34 +295,10 @@ async function readExactGraphPagedInternal(
       ) {
         throw invalidQueryResult(graph, 'Exact graph read received an incomplete binding');
       }
-      const quad: Quad = {
-        subject,
-        predicate,
-        object,
-        graph: options.outputGraph ?? graph,
-      };
-      const nquadLine = quadToNQuad(quad);
-      if (seenNQuadLines.has(nquadLine)) {
-        throw invalidQueryResult(
-          graph,
-          'Exact graph read received a duplicate triple across ordered pages',
-        );
+      if (subject.startsWith('_:') || object.startsWith('_:')) {
+        return readBlankNodeGraph();
       }
-      seenNQuadLines.add(nquadLine);
-      nquadsBytes +=
-        (quads.length === 0 ? 0 : 1) +
-        UTF8_ENCODER.encode(nquadLine).byteLength;
-      if (nquadsBytes > maxNQuadsBytes) {
-        throw new ExactGraphReadError({
-          kind: 'limit',
-          code: 'NQUADS_BYTE_LIMIT_EXCEEDED',
-          graphIri: graph,
-          message: `Exact graph read exceeds N-Quads byte limit: found ${nquadsBytes}, limit ${maxNQuadsBytes}`,
-          actual: nquadsBytes,
-          limit: maxNQuadsBytes,
-        });
-      }
-      quads.push(quad);
+      appendQuad(subject, predicate, object);
     }
     if (quads.length > expectedQuadCount) {
       throw quadCountMismatch(graph, expectedQuadCount, quads.length);
@@ -241,15 +310,7 @@ async function readExactGraphPagedInternal(
   if (quads.length !== expectedQuadCount) {
     throw quadCountMismatch(graph, expectedQuadCount, quads.length);
   }
-  const postflightQuadCount = await queryExactGraphCount(
-    store,
-    graph,
-    maxQuadCount,
-    boundedQueryOptions,
-  );
-  if (postflightQuadCount !== expectedQuadCount) {
-    throw quadCountMismatch(graph, expectedQuadCount, postflightQuadCount);
-  }
+  await verifyPostflightCount();
   return quads;
 }
 

--- a/packages/storage/src/graph-knowledge-asset-metadata-loader.ts
+++ b/packages/storage/src/graph-knowledge-asset-metadata-loader.ts
@@ -1,6 +1,7 @@
 import {
   buildGraphKnowledgeAssetMetadataQuery,
   parseGraphKnowledgeAssetMetadataBindings,
+  parseDeterministicKnowledgeAssetUal,
   type ParsedGraphKnowledgeAssetMetadata,
 } from '@origintrail-official/dkg-core';
 import type { QueryOptions, TripleStore } from './triple-store.js';
@@ -23,12 +24,18 @@ export async function resolveGraphScopedOrLegacyMetadata<TLegacy>(
   loadLegacyMetadata: () => Promise<TLegacy | null>,
   queryOptions?: QueryOptions,
 ): Promise<GraphScopedOrLegacyMetadata<TLegacy>> {
+  let graphScopedUal = ual;
+  try {
+    graphScopedUal = parseDeterministicKnowledgeAssetUal(ual).ual;
+  } catch {
+    // Non-deterministic identifiers remain eligible for legacy read-both.
+  }
   const result = await store.query(
-    buildGraphKnowledgeAssetMetadataQuery(ual),
+    buildGraphKnowledgeAssetMetadataQuery(graphScopedUal),
     queryOptions,
   );
   const parsed = parseGraphKnowledgeAssetMetadataBindings(
-    ual,
+    graphScopedUal,
     result.type === 'bindings' ? result.bindings : [],
   );
   if (parsed.kind === 'graph') return parsed;

--- a/packages/storage/src/graph-knowledge-asset-metadata-loader.ts
+++ b/packages/storage/src/graph-knowledge-asset-metadata-loader.ts
@@ -1,0 +1,40 @@
+import {
+  buildGraphKnowledgeAssetMetadataQuery,
+  parseGraphKnowledgeAssetMetadataBindings,
+  type ParsedGraphKnowledgeAssetMetadata,
+} from '@origintrail-official/dkg-core';
+import type { QueryOptions, TripleStore } from './triple-store.js';
+
+export type GraphScopedOrLegacyMetadata<TLegacy> =
+  | { readonly kind: 'graph'; readonly metadata: ParsedGraphKnowledgeAssetMetadata }
+  | { readonly kind: 'legacy'; readonly metadata: TLegacy }
+  | { readonly kind: 'absent' };
+
+/**
+ * Resolve graph-scoped control metadata before attempting a legacy lookup.
+ *
+ * This is the canonical fail-closed ordering shared by query and private
+ * access: malformed V2 metadata throws, while absent or explicitly legacy
+ * metadata delegates exactly once to the caller-specific legacy reader.
+ */
+export async function resolveGraphScopedOrLegacyMetadata<TLegacy>(
+  store: Pick<TripleStore, 'query'>,
+  ual: string,
+  loadLegacyMetadata: () => Promise<TLegacy | null>,
+  queryOptions?: QueryOptions,
+): Promise<GraphScopedOrLegacyMetadata<TLegacy>> {
+  const result = await store.query(
+    buildGraphKnowledgeAssetMetadataQuery(ual),
+    queryOptions,
+  );
+  const parsed = parseGraphKnowledgeAssetMetadataBindings(
+    ual,
+    result.type === 'bindings' ? result.bindings : [],
+  );
+  if (parsed.kind === 'graph') return parsed;
+
+  const legacyMetadata = await loadLegacyMetadata();
+  return legacyMetadata === null
+    ? { kind: 'absent' }
+    : { kind: 'legacy', metadata: legacyMetadata };
+}

--- a/packages/storage/src/graph-manager.ts
+++ b/packages/storage/src/graph-manager.ts
@@ -14,6 +14,7 @@ import {
   contextGraphCatalogUri,
   canonicalKnowledgeAssetGraphIdentitySuffix,
   knowledgeAssetAgentAddressesEqual,
+  validateContextGraphId,
   isSafeIri,
   assertSafeIri,
   sparqlString,
@@ -805,6 +806,10 @@ export class ContextGraphManager {
   }
 
   async ensureContextGraph(contextGraphId: string): Promise<void> {
+    const validation = validateContextGraphId(contextGraphId);
+    if (!validation.valid) {
+      throw new Error(`Invalid context graph ID: ${validation.reason}`);
+    }
     if (this.ensuredContextGraphs.has(contextGraphId)) return;
     await this.store.createGraph(this.dataGraphUri(contextGraphId));
     await this.store.createGraph(this.metaGraphUri(contextGraphId));

--- a/packages/storage/src/graph-manager.ts
+++ b/packages/storage/src/graph-manager.ts
@@ -17,6 +17,7 @@ import {
   isSafeIri,
   assertSafeIri,
   sparqlString,
+  validateNewContextGraphId,
 } from '@origintrail-official/dkg-core';
 
 const CG_PREFIX = 'did:dkg:context-graph:';
@@ -802,6 +803,23 @@ export class ContextGraphManager {
     await this.store.createGraph(this.subGraphPrivateUri(contextGraphId, subGraphName));
     await this.store.createGraph(contextGraphSharedMemoryUri(contextGraphId, subGraphName));
     await this.store.createGraph(contextGraphSharedMemoryMetaUri(contextGraphId, subGraphName));
+  }
+
+  /** Reject an ID that would alias one of the storage-owned partitions. */
+  assertNewContextGraphId(contextGraphId: string): void {
+    const validation = validateNewContextGraphId(contextGraphId);
+    if (!validation.valid) {
+      throw new Error(`Invalid context graph ID: ${validation.reason}`);
+    }
+  }
+
+  /**
+   * Create the storage partitions for a newly-authored context graph.
+   * Existing read and sync paths intentionally keep using ensureContextGraph.
+   */
+  async ensureNewContextGraph(contextGraphId: string): Promise<void> {
+    this.assertNewContextGraphId(contextGraphId);
+    await this.ensureContextGraph(contextGraphId);
   }
 
   async ensureContextGraph(contextGraphId: string): Promise<void> {

--- a/packages/storage/src/graph-manager.ts
+++ b/packages/storage/src/graph-manager.ts
@@ -14,7 +14,6 @@ import {
   contextGraphCatalogUri,
   canonicalKnowledgeAssetGraphIdentitySuffix,
   knowledgeAssetAgentAddressesEqual,
-  validateContextGraphId,
   isSafeIri,
   assertSafeIri,
   sparqlString,
@@ -806,10 +805,6 @@ export class ContextGraphManager {
   }
 
   async ensureContextGraph(contextGraphId: string): Promise<void> {
-    const validation = validateContextGraphId(contextGraphId);
-    if (!validation.valid) {
-      throw new Error(`Invalid context graph ID: ${validation.reason}`);
-    }
     if (this.ensuredContextGraphs.has(contextGraphId)) return;
     await this.store.createGraph(this.dataGraphUri(contextGraphId));
     await this.store.createGraph(this.metaGraphUri(contextGraphId));

--- a/packages/storage/src/http-response-limit.ts
+++ b/packages/storage/src/http-response-limit.ts
@@ -1,0 +1,57 @@
+export class StoreResponseTooLargeError extends Error {
+  readonly code = 'STORE_RESPONSE_TOO_LARGE';
+  readonly maxBytes: number;
+  readonly actualBytes: number | bigint;
+
+  constructor(maxBytes: number, actualBytes: number | bigint) {
+    super(`Triple-store response exceeds byte limit: found ${actualBytes}, limit ${maxBytes}`);
+    this.name = 'StoreResponseTooLargeError';
+    this.maxBytes = maxBytes;
+    this.actualBytes = actualBytes;
+  }
+}
+
+/** Read a fetch response body without ever buffering more than `maxBytes`. */
+export async function readResponseTextBounded(
+  response: Response,
+  maxBytes: number,
+): Promise<string> {
+  if (!Number.isSafeInteger(maxBytes) || maxBytes < 0) {
+    throw new RangeError('maxResponseBytes must be a non-negative safe integer');
+  }
+
+  const contentLength = response.headers.get('content-length');
+  if (contentLength && /^\d+$/.test(contentLength)) {
+    const declaredBytes = BigInt(contentLength);
+    if (declaredBytes > BigInt(maxBytes)) {
+      throw new StoreResponseTooLargeError(maxBytes, declaredBytes);
+    }
+  }
+
+  if (!response.body) return '';
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      totalBytes += value.byteLength;
+      if (totalBytes > maxBytes) {
+        await reader.cancel().catch(() => undefined);
+        throw new StoreResponseTooLargeError(maxBytes, totalBytes);
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const body = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(body);
+}

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -85,6 +85,7 @@ export {
   type ExactGraphReadErrorKind,
   type ReadExactGraphPagedOptions,
 } from './bounded-rdf.js';
+export { StoreResponseTooLargeError } from './http-response-limit.js';
 
 export { OxigraphStore } from './adapters/oxigraph.js';
 export { OxigraphWorkerStore } from './adapters/oxigraph-worker.js';

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -86,6 +86,10 @@ export {
   type ReadExactGraphPagedOptions,
 } from './bounded-rdf.js';
 export { StoreResponseTooLargeError } from './http-response-limit.js';
+export {
+  resolveGraphScopedOrLegacyMetadata,
+  type GraphScopedOrLegacyMetadata,
+} from './graph-knowledge-asset-metadata-loader.js';
 
 export { OxigraphStore } from './adapters/oxigraph.js';
 export { OxigraphWorkerStore } from './adapters/oxigraph-worker.js';

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -76,6 +76,15 @@ export {
   asGraphWriteGenSource,
   type GraphWriteGenSource,
 } from './graph-write-gen.js';
+export {
+  ExactGraphReadError,
+  quadToNQuad,
+  quadsToNQuads,
+  readExactGraphPaged,
+  type ExactGraphReadErrorCode,
+  type ExactGraphReadErrorKind,
+  type ReadExactGraphPagedOptions,
+} from './bounded-rdf.js';
 
 export { OxigraphStore } from './adapters/oxigraph.js';
 export { OxigraphWorkerStore } from './adapters/oxigraph-worker.js';
@@ -115,7 +124,10 @@ export {
   type SwmSliceSourceTags,
   type LoadSharedMemorySliceWithKaBoundFallbackOptions,
 } from './graph-manager.js';
-export { PrivateContentStore } from './private-store.js';
+export {
+  PrivateContentStore,
+  type KnowledgeAssetPrivateReadOptions,
+} from './private-store.js';
 
 // Side-effect: register built-in adapters
 import './adapters/oxigraph.js';

--- a/packages/storage/src/private-store.ts
+++ b/packages/storage/src/private-store.ts
@@ -9,6 +9,17 @@ import {
 } from '@origintrail-official/dkg-core';
 import { tryReplaceGraphAtomically, type TripleStore, type Quad } from './triple-store.js';
 import type { ContextGraphManager } from './graph-manager.js';
+import {
+  readExactGraphPaged,
+  readExactGraphPagedWithDiscoveredCount,
+  type ReadExactGraphPagedOptions,
+} from './bounded-rdf.js';
+
+export interface KnowledgeAssetPrivateReadOptions
+  extends Omit<ReadExactGraphPagedOptions, 'expectedQuadCount' | 'outputGraph'> {
+  /** Trusted metadata count. When omitted, the store's current count is used. */
+  expectedQuadCount?: number;
+}
 
 /**
  * GH #1078 — predicate used for the per-(cg,root[,sub]) "current verifiable
@@ -297,13 +308,20 @@ export class PrivateContentStore {
     contextGraphId: string,
     scope: GraphKnowledgeAssetScope,
     subGraphName?: string,
+    readOptions?: KnowledgeAssetPrivateReadOptions,
   ): Promise<Quad[]> {
     const graphUri = this.knowledgeAssetPrivateGraphUri(contextGraphId, scope, subGraphName);
-    const result = await this.store.query(
-      `CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${graphUri}> { ?s ?p ?o } }`,
-    );
-    if (result.type !== 'quads') return [];
-    return result.quads.map((quad) => ({ ...quad, graph: '' }));
+    if (readOptions?.expectedQuadCount !== undefined) {
+      return readExactGraphPaged(this.store, graphUri, {
+        ...readOptions,
+        expectedQuadCount: readOptions.expectedQuadCount,
+        outputGraph: '',
+      });
+    }
+    return readExactGraphPagedWithDiscoveredCount(this.store, graphUri, {
+      ...readOptions,
+      outputGraph: '',
+    });
   }
 
   async deleteKnowledgeAssetPrivateTriples(

--- a/packages/storage/src/triple-store.ts
+++ b/packages/storage/src/triple-store.ts
@@ -72,6 +72,11 @@ export interface QueryOptions {
    * dispatching or after returning from their blocking native call.
    */
   signal?: AbortSignal;
+  /**
+   * Optional pre-parse cap for remote response bodies. HTTP adapters stream
+   * and reject above this bound before JSON/N-Quads materialization.
+   */
+  maxResponseBytes?: number;
 }
 
 export type TripleStoreQueryOptions = QueryOptions;

--- a/packages/storage/test/bounded-rdf.test.ts
+++ b/packages/storage/test/bounded-rdf.test.ts
@@ -358,4 +358,31 @@ describe('bounded HTTP query responses', () => {
       globalThis.fetch = originalFetch;
     }
   });
+
+  it.each([
+    ['SPARQL HTTP', 'CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }', () => new SparqlHttpStore({ queryEndpoint: 'http://store.test/query' })],
+    ['SPARQL HTTP', 'DESCRIBE <urn:test:subject>', () => new SparqlHttpStore({ queryEndpoint: 'http://store.test/query' })],
+    ['Blazegraph', 'CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }', () => new BlazegraphStore('http://store.test/query')],
+    ['Blazegraph', 'DESCRIBE <urn:test:subject>', () => new BlazegraphStore('http://store.test/query')],
+  ])('rejects an oversized %s N-Quads response for %s before parsing', async (_name, sparql, makeStore) => {
+    const originalFetch = globalThis.fetch;
+    // Deliberately malformed: parsing before enforcing the byte limit would
+    // surface an RDF parser error instead of STORE_RESPONSE_TOO_LARGE.
+    const body = `<urn:test:s> <urn:test:p> "unterminated-${'x'.repeat(256)}`;
+    globalThis.fetch = (async () => new Response(body, {
+      status: 200,
+      headers: { 'Content-Type': 'application/n-quads' },
+    })) as typeof fetch;
+
+    try {
+      const store = makeStore();
+      await expect(store.query(sparql, { maxResponseBytes: 64 }))
+        .rejects.toMatchObject({
+          code: 'STORE_RESPONSE_TOO_LARGE',
+          maxBytes: 64,
+        });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 });

--- a/packages/storage/test/bounded-rdf.test.ts
+++ b/packages/storage/test/bounded-rdf.test.ts
@@ -164,7 +164,7 @@ describe('readExactGraphPaged', () => {
     const rows = [
       { s: 'urn:test:s1', p: 'urn:test:p', o: 'urn:test:o1' },
       { s: 'urn:test:s2', p: 'urn:test:p', o: '"literal"' },
-      { s: '_:s3', p: 'urn:test:p', o: '_:o3' },
+      { s: 'urn:test:s3', p: 'urn:test:p', o: 'urn:test:o3' },
     ];
     const store = {
       query: async (sparql: string, options?: QueryOptions): Promise<QueryResult> => {
@@ -202,6 +202,88 @@ describe('readExactGraphPaged', () => {
       expect(options?.maxResponseBytes).toBeGreaterThan(0);
       expect(options?.maxResponseBytes).toBeLessThanOrEqual(10 * 1024 * 1024);
     }
+  });
+
+  it('preserves blank-node relationships in one bounded result document', async () => {
+    const graph = 'urn:test:paged-blank-node-graph';
+    const store = {
+      query: async (sparql: string): Promise<QueryResult> => {
+        if (sparql.includes('COUNT(*)')) {
+          return { type: 'bindings', bindings: [{ count: '"2"' }] };
+        }
+        if (sparql.includes('CONSTRUCT')) {
+          expect(sparql).toContain('LIMIT 3');
+          return {
+            type: 'quads',
+            quads: [
+              { subject: 'urn:root', predicate: 'urn:child', object: '_:stable', graph: '' },
+              { subject: '_:stable', predicate: 'urn:name', object: '"child"', graph: '' },
+            ],
+          };
+        }
+        const offset = Number(sparql.match(/OFFSET (\d+)/)?.[1] ?? 0);
+        return {
+          type: 'bindings',
+          bindings: offset === 0
+            ? [{ s: 'urn:root', p: 'urn:child', o: '_:page-one' }]
+            : offset === 1
+              ? [{ s: '_:page-two', p: 'urn:name', o: '"child"' }]
+              : [],
+        };
+      },
+    } as Pick<TripleStore, 'query'> as TripleStore;
+
+    await expect(readExactGraphPaged(store, graph, {
+      expectedQuadCount: 2,
+      pageSize: 1,
+      outputGraph: 'urn:test:rewritten-blank-node-graph',
+    })).resolves.toEqual([
+      {
+        subject: 'urn:root',
+        predicate: 'urn:child',
+        object: '_:stable',
+        graph: 'urn:test:rewritten-blank-node-graph',
+      },
+      {
+        subject: '_:stable',
+        predicate: 'urn:name',
+        object: '"child"',
+        graph: 'urn:test:rewritten-blank-node-graph',
+      },
+    ]);
+  });
+
+  it('fails closed before materializing an oversized blank-node graph', async () => {
+    const graph = 'urn:test:oversized-blank-node-graph';
+    let constructCalled = false;
+    const store = {
+      query: async (sparql: string): Promise<QueryResult> => {
+        if (sparql.includes('COUNT(*)')) {
+          return { type: 'bindings', bindings: [{ count: '"257"' }] };
+        }
+        if (sparql.includes('CONSTRUCT')) {
+          constructCalled = true;
+          return { type: 'quads', quads: [] };
+        }
+        return {
+          type: 'bindings',
+          bindings: [{ s: '_:page-local', p: 'urn:p', o: '"value"' }],
+        };
+      },
+    } as Pick<TripleStore, 'query'> as TripleStore;
+
+    const error = await readExactGraphPaged(store, graph, {
+      expectedQuadCount: 257,
+    }).catch((cause: unknown) => cause);
+
+    expect(error).toBeInstanceOf(ExactGraphReadError);
+    expect(error).toMatchObject({
+      kind: 'limit',
+      code: 'QUAD_COUNT_LIMIT_EXCEEDED',
+      actual: 257,
+      limit: 256,
+    });
+    expect(constructCalled).toBe(false);
   });
 
   it('fails with a typed limit error before materializing an oversized graph', async () => {

--- a/packages/storage/test/bounded-rdf.test.ts
+++ b/packages/storage/test/bounded-rdf.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
+  BlazegraphStore,
   ExactGraphReadError,
+  SparqlHttpStore,
   quadToNQuad,
   quadsToNQuads,
   readExactGraphPaged,
@@ -194,12 +196,12 @@ describe('readExactGraphPaged', () => {
     expect(queries).toHaveLength(2);
     expect(queries[0]).toMatch(/ORDER BY \?s \?p \?o\s+LIMIT 2\s+OFFSET 0/);
     expect(queries[1]).toMatch(/ORDER BY \?s \?p \?o\s+LIMIT 2\s+OFFSET 2/);
-    expect(seenOptions).toEqual([
-      queryOptions,
-      queryOptions,
-      queryOptions,
-      queryOptions,
-    ]);
+    expect(seenOptions).toHaveLength(4);
+    for (const options of seenOptions) {
+      expect(options).toMatchObject(queryOptions);
+      expect(options?.maxResponseBytes).toBeGreaterThan(0);
+      expect(options?.maxResponseBytes).toBeLessThanOrEqual(10 * 1024 * 1024);
+    }
   });
 
   it('fails with a typed limit error before materializing an oversized graph', async () => {
@@ -323,5 +325,37 @@ describe('readExactGraphPaged', () => {
       code: 'INVALID_QUERY_RESULT',
       graphIri: graph,
     });
+  });
+});
+
+describe('bounded HTTP query responses', () => {
+  it.each([
+    ['SPARQL HTTP', () => new SparqlHttpStore({ queryEndpoint: 'http://store.test/query' })],
+    ['Blazegraph', () => new BlazegraphStore('http://store.test/query')],
+  ])('rejects an oversized %s SELECT response before JSON materialization', async (_name, makeStore) => {
+    const originalFetch = globalThis.fetch;
+    const body = JSON.stringify({
+      head: { vars: ['o'] },
+      results: {
+        bindings: [{ o: { type: 'literal', value: 'x'.repeat(256) } }],
+      },
+    });
+    globalThis.fetch = (async () => new Response(body, {
+      status: 200,
+      headers: { 'Content-Type': 'application/sparql-results+json' },
+    })) as typeof fetch;
+
+    try {
+      const store = makeStore();
+      await expect(store.query(
+        'SELECT ?o WHERE { ?s ?p ?o }',
+        { maxResponseBytes: 64 },
+      )).rejects.toMatchObject({
+        code: 'STORE_RESPONSE_TOO_LARGE',
+        maxBytes: 64,
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });

--- a/packages/storage/test/bounded-rdf.test.ts
+++ b/packages/storage/test/bounded-rdf.test.ts
@@ -1,0 +1,327 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ExactGraphReadError,
+  quadToNQuad,
+  quadsToNQuads,
+  readExactGraphPaged,
+  type Quad,
+  type QueryOptions,
+  type QueryResult,
+  type TripleStore,
+} from '../src/index.js';
+
+describe('canonical storage N-Quads serialization', () => {
+  it('formats every Quad term shape at the public storage seam', () => {
+    const quads: Quad[] = [
+      {
+        subject: 'urn:test:iri-subject',
+        predicate: 'urn:test:predicate',
+        object: 'urn:test:iri-object',
+        graph: '',
+      },
+      {
+        subject: 'urn:test:typed-subject',
+        predicate: 'urn:test:predicate',
+        object: '"value"^^urn:test:datatype',
+        graph: 'urn:test:named-graph',
+      },
+      {
+        subject: '_:subject',
+        predicate: 'urn:test:predicate',
+        object: '_:object',
+        graph: 'urn:test:named-graph',
+      },
+    ];
+
+    expect(quadToNQuad(quads[0])).toBe(
+      '<urn:test:iri-subject> <urn:test:predicate> <urn:test:iri-object> .',
+    );
+    expect(quadsToNQuads(quads)).toBe(
+      '<urn:test:iri-subject> <urn:test:predicate> <urn:test:iri-object> .\n' +
+        '<urn:test:typed-subject> <urn:test:predicate> "value"^^<urn:test:datatype> <urn:test:named-graph> .\n' +
+        '_:subject <urn:test:predicate> _:object <urn:test:named-graph> .',
+    );
+  });
+});
+
+describe('readExactGraphPaged', () => {
+  it('uses a server-side COUNT instead of a materializing store count', async () => {
+    const graph = 'urn:test:server-count';
+    const store = {
+      countQuads: async () => {
+        throw new Error('materializing countQuads must not run');
+      },
+      query: async (sparql: string): Promise<QueryResult> => {
+        if (sparql.includes('COUNT(*)')) {
+          return {
+            type: 'bindings',
+            bindings: [{ count: '"1"^^<http://www.w3.org/2001/XMLSchema#integer>' }],
+          };
+        }
+        return {
+          type: 'bindings',
+          bindings: [{ s: 'urn:s', p: 'urn:p', o: 'urn:o' }],
+        };
+      },
+    } as Pick<TripleStore, 'countQuads' | 'query'> as TripleStore;
+
+    await expect(readExactGraphPaged(store, graph, {
+      expectedQuadCount: 1,
+    })).resolves.toEqual([
+      { subject: 'urn:s', predicate: 'urn:p', object: 'urn:o', graph },
+    ]);
+  });
+
+  it('rechecks the exact graph count after the final page', async () => {
+    const graph = 'urn:test:postflight-count';
+    let countQueries = 0;
+    const store = {
+      query: async (sparql: string): Promise<QueryResult> => {
+        if (sparql.includes('COUNT(*)')) {
+          countQueries++;
+          return {
+            type: 'bindings',
+            bindings: [{ count: `"${countQueries}"` }],
+          };
+        }
+        return {
+          type: 'bindings',
+          bindings: [{ s: 'urn:s', p: 'urn:p', o: 'urn:o' }],
+        };
+      },
+    } as Pick<TripleStore, 'query'> as TripleStore;
+
+    const error = await readExactGraphPaged(store, graph, {
+      expectedQuadCount: 1,
+    }).catch((cause: unknown) => cause);
+
+    expect(error).toBeInstanceOf(ExactGraphReadError);
+    expect(error).toMatchObject({
+      kind: 'integrity',
+      code: 'QUAD_COUNT_MISMATCH',
+      expected: 1,
+      actual: 2,
+    });
+  });
+
+  it('never sends a caller-sized unbounded page to the store', async () => {
+    const graph = 'urn:test:bounded-page-size';
+    let pageQuery = '';
+    const store = {
+      query: async (sparql: string): Promise<QueryResult> => {
+        if (sparql.includes('COUNT(*)')) {
+          return { type: 'bindings', bindings: [{ count: '"5000"' }] };
+        }
+        pageQuery = sparql;
+        return { type: 'bindings', bindings: [] };
+      },
+    } as Pick<TripleStore, 'query'> as TripleStore;
+
+    await readExactGraphPaged(store, graph, {
+      expectedQuadCount: 5000,
+      pageSize: Number.MAX_SAFE_INTEGER,
+    }).catch(() => undefined);
+
+    expect(pageQuery).toMatch(/LIMIT 256\s+OFFSET 0/);
+  });
+
+  it('rejects duplicate triples returned across OFFSET pages', async () => {
+    const graph = 'urn:test:duplicate-pages';
+    const store = {
+      query: async (sparql: string): Promise<QueryResult> => {
+        if (sparql.includes('COUNT(*)')) {
+          return { type: 'bindings', bindings: [{ count: '"2"' }] };
+        }
+        const offset = Number(sparql.match(/OFFSET (\d+)/)?.[1] ?? 0);
+        return {
+          type: 'bindings',
+          bindings: offset < 2
+            ? [{ s: 'urn:s', p: 'urn:p', o: 'urn:o' }]
+            : [],
+        };
+      },
+    } as Pick<TripleStore, 'query'> as TripleStore;
+
+    await expect(readExactGraphPaged(store, graph, {
+      expectedQuadCount: 2,
+      pageSize: 1,
+    })).rejects.toMatchObject({
+      kind: 'integrity',
+      code: 'INVALID_QUERY_RESULT',
+    });
+  });
+
+  it('reads one exact named graph in stable ordered pages', async () => {
+    const graph = 'urn:test:exact-graph';
+    const queryOptions: QueryOptions = {
+      source: 'bounded-rdf-test',
+      priority: 'background',
+    };
+    const queries: string[] = [];
+    const seenOptions: Array<QueryOptions | undefined> = [];
+    const rows = [
+      { s: 'urn:test:s1', p: 'urn:test:p', o: 'urn:test:o1' },
+      { s: 'urn:test:s2', p: 'urn:test:p', o: '"literal"' },
+      { s: '_:s3', p: 'urn:test:p', o: '_:o3' },
+    ];
+    const store = {
+      query: async (sparql: string, options?: QueryOptions): Promise<QueryResult> => {
+        seenOptions.push(options);
+        if (sparql.includes('COUNT(*)')) {
+          return { type: 'bindings', bindings: [{ count: '"3"' }] };
+        }
+        queries.push(sparql);
+        const offset = Number(sparql.match(/OFFSET (\d+)/)?.[1] ?? 0);
+        return {
+          type: 'bindings',
+          bindings: rows.slice(offset, offset + 2),
+        };
+      },
+    } as Pick<TripleStore, 'query'> as TripleStore;
+
+    await expect(
+      readExactGraphPaged(store, graph, {
+        expectedQuadCount: 3,
+        pageSize: 2,
+        queryOptions,
+      }),
+    ).resolves.toEqual(rows.map((row) => ({
+      subject: row.s,
+      predicate: row.p,
+      object: row.o,
+      graph,
+    })));
+    expect(queries).toHaveLength(2);
+    expect(queries[0]).toMatch(/ORDER BY \?s \?p \?o\s+LIMIT 2\s+OFFSET 0/);
+    expect(queries[1]).toMatch(/ORDER BY \?s \?p \?o\s+LIMIT 2\s+OFFSET 2/);
+    expect(seenOptions).toEqual([
+      queryOptions,
+      queryOptions,
+      queryOptions,
+      queryOptions,
+    ]);
+  });
+
+  it('fails with a typed limit error before materializing an oversized graph', async () => {
+    const graph = 'urn:test:oversized-graph';
+    const store = {
+      query: async (): Promise<QueryResult> => ({
+        type: 'bindings',
+        bindings: [{ count: '"2"' }],
+      }),
+    } as Pick<TripleStore, 'query'> as TripleStore;
+
+    const error = await readExactGraphPaged(store, graph, {
+      expectedQuadCount: 1,
+      maxQuadCount: 1,
+    }).catch((cause: unknown) => cause);
+
+    expect(error).toBeInstanceOf(ExactGraphReadError);
+    expect(error).toMatchObject({
+      kind: 'limit',
+      code: 'QUAD_COUNT_LIMIT_EXCEEDED',
+      graphIri: graph,
+      actual: 2,
+      limit: 1,
+    });
+  });
+
+  it('enforces the cumulative N-Quads budget in UTF-8 bytes', async () => {
+    const graph = 'urn:test:utf8-graph';
+    const store = {
+      query: async (sparql: string): Promise<QueryResult> => sparql.includes('COUNT(*)')
+        ? { type: 'bindings', bindings: [{ count: '"1"' }] }
+        : {
+            type: 'bindings',
+            bindings: [{ s: 'urn:s', p: 'urn:p', o: '"😀"' }],
+          },
+    } as Pick<TripleStore, 'query'> as TripleStore;
+
+    const error = await readExactGraphPaged(store, graph, {
+      expectedQuadCount: 1,
+      maxNQuadsBytes: 22,
+      outputGraph: '',
+    }).catch((cause: unknown) => cause);
+
+    expect(error).toBeInstanceOf(ExactGraphReadError);
+    expect(error).toMatchObject({
+      kind: 'limit',
+      code: 'NQUADS_BYTE_LIMIT_EXCEEDED',
+      graphIri: graph,
+      actual: 24,
+      limit: 22,
+    });
+  });
+
+  it('fails with a typed integrity error when the final page count is not exact', async () => {
+    const graph = 'urn:test:changing-graph';
+    const store = {
+      query: async (sparql: string): Promise<QueryResult> => sparql.includes('COUNT(*)')
+        ? { type: 'bindings', bindings: [{ count: '"2"' }] }
+        : {
+            type: 'bindings',
+            bindings: [{ s: 'urn:s', p: 'urn:p', o: 'urn:o' }],
+          },
+    } as Pick<TripleStore, 'query'> as TripleStore;
+
+    const error = await readExactGraphPaged(store, graph, {
+      expectedQuadCount: 2,
+      pageSize: 2,
+    }).catch((cause: unknown) => cause);
+
+    expect(error).toBeInstanceOf(ExactGraphReadError);
+    expect(error).toMatchObject({
+      kind: 'integrity',
+      code: 'QUAD_COUNT_MISMATCH',
+      graphIri: graph,
+      expected: 2,
+      actual: 1,
+    });
+  });
+
+  it('classifies a non-SELECT store response as an integrity failure', async () => {
+    const graph = 'urn:test:wrong-result-shape';
+    const store = {
+      query: async (sparql: string): Promise<QueryResult> => sparql.includes('COUNT(*)')
+        ? { type: 'bindings', bindings: [{ count: '"1"' }] }
+        : { type: 'quads', quads: [] },
+    } as Pick<TripleStore, 'query'> as TripleStore;
+
+    const error = await readExactGraphPaged(store, graph, {
+      expectedQuadCount: 1,
+    }).catch((cause: unknown) => cause);
+
+    expect(error).toBeInstanceOf(ExactGraphReadError);
+    expect(error).toMatchObject({
+      kind: 'integrity',
+      code: 'INVALID_QUERY_RESULT',
+      graphIri: graph,
+    });
+  });
+
+  it('classifies malformed runtime bindings as an integrity failure', async () => {
+    const graph = 'urn:test:malformed-bindings';
+    const store = {
+      query: async (sparql: string): Promise<QueryResult> => {
+        if (sparql.includes('COUNT(*)')) {
+          return { type: 'bindings', bindings: [{ count: '"1"' }] };
+        }
+        return {
+          type: 'bindings',
+          bindings: [null],
+        } as unknown as QueryResult;
+      },
+    } as Pick<TripleStore, 'query'> as TripleStore;
+
+    const error = await readExactGraphPaged(store, graph, {
+      expectedQuadCount: 1,
+    }).catch((cause: unknown) => cause);
+
+    expect(error).toBeInstanceOf(ExactGraphReadError);
+    expect(error).toMatchObject({
+      kind: 'integrity',
+      code: 'INVALID_QUERY_RESULT',
+      graphIri: graph,
+    });
+  });
+});

--- a/packages/storage/test/graph-knowledge-asset-metadata-loader.test.ts
+++ b/packages/storage/test/graph-knowledge-asset-metadata-loader.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  resolveGraphScopedOrLegacyMetadata,
+  type QueryResult,
+  type TripleStore,
+} from '../src/index.js';
+
+const UAL = 'did:dkg:31337/0x1111111111111111111111111111111111111111/7';
+const META = 'did:dkg:context-graph:test/_meta';
+
+describe('graph-scoped-first metadata resolution', () => {
+  it('loads graph-scoped metadata before invoking the legacy fallback', async () => {
+    const order: string[] = [];
+    const store = {
+      query: vi.fn(async (): Promise<QueryResult> => {
+        order.push('graph');
+        return { type: 'bindings', bindings: [] };
+      }),
+    } as Pick<TripleStore, 'query'> as TripleStore;
+    const loadLegacy = vi.fn(async () => {
+      order.push('legacy');
+      return { rootEntity: 'urn:legacy:root' };
+    });
+
+    const result = await resolveGraphScopedOrLegacyMetadata(
+      store,
+      UAL,
+      loadLegacy,
+    );
+
+    expect(order).toEqual(['graph', 'legacy']);
+    expect(result).toEqual({
+      kind: 'legacy',
+      metadata: { rootEntity: 'urn:legacy:root' },
+    });
+  });
+
+  it('fails closed on an incomplete V2 marker without invoking legacy lookup', async () => {
+    const store = {
+      query: vi.fn(async (): Promise<QueryResult> => ({
+        type: 'bindings',
+        bindings: [
+          {
+            g: META,
+            predicate: 'http://dkg.io/ontology/contentScopeVersion',
+            value: '"2"^^<http://www.w3.org/2001/XMLSchema#integer>',
+          },
+          {
+            g: META,
+            predicate: 'http://dkg.io/ontology/contextGraph',
+            value: 'did:dkg:context-graph:test',
+          },
+        ],
+      })),
+    } as Pick<TripleStore, 'query'> as TripleStore;
+    const loadLegacy = vi.fn(async () => ({ rootEntity: 'must-not-load' }));
+
+    await expect(resolveGraphScopedOrLegacyMetadata(store, UAL, loadLegacy))
+      .rejects.toThrow(/missing kaUal metadata/);
+    expect(loadLegacy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/storage/test/graph-manager-context-graph-id.test.ts
+++ b/packages/storage/test/graph-manager-context-graph-id.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { GraphManager, OxigraphStore } from '../src/index.js';
+
+describe('new context-graph storage boundary', () => {
+  it('rejects structural partition aliases before creating any graph', async () => {
+    const store = new OxigraphStore();
+    const manager = new GraphManager(store);
+
+    await expect(manager.ensureNewContextGraph('victim/_meta'))
+      .rejects.toThrow(/reserved storage partition/);
+
+    await expect(store.listGraphs()).resolves.toEqual([]);
+  });
+
+  it('keeps the legacy ensure path available for existing read and sync callers', async () => {
+    const store = new OxigraphStore();
+    const manager = new GraphManager(store);
+
+    await expect(manager.ensureContextGraph('legacy/_meta')).resolves.toBeUndefined();
+  });
+});

--- a/packages/storage/test/ka-graph-private-store.test.ts
+++ b/packages/storage/test/ka-graph-private-store.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { createGraphKnowledgeAssetScope } from '@origintrail-official/dkg-core';
 import {
+  ExactGraphReadError,
   GraphManager,
   OxigraphStore,
   PrivateContentStore,
@@ -81,5 +82,47 @@ describe('graph-scoped private content', () => {
     await expect(
       privateStore.getKnowledgeAssetPrivateTriples(CONTEXT_GRAPH, scope),
     ).resolves.toEqual([quad('urn:private:new', '"new"')]);
+  });
+
+  it('fails closed when an optional exact-read count does not match', async () => {
+    const scope = createGraphKnowledgeAssetScope(UAL, 4);
+    await privateStore.replaceKnowledgeAssetPrivateTriples(
+      CONTEXT_GRAPH,
+      scope,
+      [quad('urn:private:only', '"only"')],
+    );
+
+    const error = await privateStore.getKnowledgeAssetPrivateTriples(
+      CONTEXT_GRAPH,
+      scope,
+      undefined,
+      { expectedQuadCount: 2, pageSize: 1 },
+    ).catch((cause: unknown) => cause);
+
+    expect(error).toBeInstanceOf(ExactGraphReadError);
+    expect(error).toMatchObject({
+      kind: 'integrity',
+      code: 'QUAD_COUNT_MISMATCH',
+      expected: 2,
+      actual: 1,
+    });
+  });
+
+  it('discovers the count without materializing the private graph', async () => {
+    const scope = createGraphKnowledgeAssetScope(UAL, 5);
+    const payload = [quad('urn:private:bounded', '"bounded"')];
+    await privateStore.replaceKnowledgeAssetPrivateTriples(
+      CONTEXT_GRAPH,
+      scope,
+      payload,
+    );
+    store.countQuads = async () => {
+      throw new Error('materializing countQuads must not run');
+    };
+
+    await expect(privateStore.getKnowledgeAssetPrivateTriples(
+      CONTEXT_GRAPH,
+      scope,
+    )).resolves.toEqual(payload);
   });
 });

--- a/packages/storage/test/ka-graph-private-store.test.ts
+++ b/packages/storage/test/ka-graph-private-store.test.ts
@@ -29,6 +29,17 @@ describe('graph-scoped private content', () => {
     privateStore = new PrivateContentStore(store, new GraphManager(store));
   });
 
+  it('rejects context graph IDs that alias structural storage partitions', async () => {
+    const graphManager = new GraphManager(store);
+
+    await expect(graphManager.ensureContextGraph('victim/_meta')).rejects.toThrow(
+      /reserved storage partition/,
+    );
+    await expect(store.listGraphs()).resolves.not.toContain(
+      'did:dkg:context-graph:victim/_meta',
+    );
+  });
+
   it('keys exact private payloads by both UAL and assertion version', async () => {
     const first = createGraphKnowledgeAssetScope(UAL, 1);
     const second = createGraphKnowledgeAssetScope(UAL, 2);

--- a/packages/storage/test/ka-graph-private-store.test.ts
+++ b/packages/storage/test/ka-graph-private-store.test.ts
@@ -29,17 +29,6 @@ describe('graph-scoped private content', () => {
     privateStore = new PrivateContentStore(store, new GraphManager(store));
   });
 
-  it('rejects context graph IDs that alias structural storage partitions', async () => {
-    const graphManager = new GraphManager(store);
-
-    await expect(graphManager.ensureContextGraph('victim/_meta')).rejects.toThrow(
-      /reserved storage partition/,
-    );
-    await expect(store.listGraphs()).resolves.not.toContain(
-      'did:dkg:context-graph:victim/_meta',
-    );
-  });
-
   it('keys exact private payloads by both UAL and assertion version', async () => {
     const first = createGraphKnowledgeAssetScope(UAL, 1);
     const second = createGraphKnowledgeAssetScope(UAL, 2);


### PR DESCRIPTION
## Summary

- resolves graph-scoped KAs from the V2 content-scope marker and loads the complete exact UAL + assertion-version VM graph without root filtering
- fails closed on malformed, ambiguous, misplaced, or graph-pointer/count-mismatched V2 metadata while preserving read-only legacy root resolution
- serves rootless private content from its exact versioned private graph and verifies both triple count and the committed private Merkle root before returning data
- prevents incomplete V2 metadata from falling back into legacy root buckets

## Verification

- `@origintrail-official/dkg-query`: 12 files, 304 tests passed
- focused publisher access coverage: 4 files, 41 tests passed
- query, publisher, agent (including type tests), and CLI builds passed
- `git diff --check` passed

## Stack note

This PR is stacked on #1720. The full publisher suite currently inherits 86 failures across legacy mutation fixtures from the #1720 head; a clean detached run at that exact parent reproduced the representative `workspace.test.ts` result (21 failures, 64 passes), confirming they are not introduced here. Those fixtures will be converted to V2 graph scope in a dedicated stacked follow-up before integration.