### PR TITLE
refactor(publisher): harden rootless KA lifecycle

### DIFF
--- a/packages/cli/src/publisher-runner.ts
+++ b/packages/cli/src/publisher-runner.ts
@@ -434,6 +434,7 @@ async function createPublisherRuntimeFromBase(args: PublisherRuntimeBaseArgs): P
 
   const eventBus = new TypedEventBus();
   const wallets: ConfiguredPublisherWallet[] = [];
+  const writeLocks = new Map<string, Promise<void>>();
 
   for (const wallet of publisherWallets.wallets) {
     const chain = createPublisherWalletChain(args.chainBase, wallet.privateKey);
@@ -450,6 +451,7 @@ async function createPublisherRuntimeFromBase(args: PublisherRuntimeBaseArgs): P
         publisherNodeIdentityId: identityId,
         publisherPrivateKey: wallet.privateKey,
         publicSnapshotStore: args.publicSnapshotStore,
+        writeLocks,
       }),
     });
   }

--- a/packages/cli/test/publisher-runner-rpc-usage.test.ts
+++ b/packages/cli/test/publisher-runner-rpc-usage.test.ts
@@ -14,11 +14,28 @@ import { createServer, type Server } from 'node:http';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { generateEd25519Keypair } from '@origintrail-official/dkg-core';
 import { createTripleStore, type TripleStore } from '@origintrail-official/dkg-storage';
 import { rpcUsageWindowTotal } from '@origintrail-official/dkg-chain';
 import { createPublisherRuntimeFromAgent, type PublisherRuntime } from '../src/publisher-runner.js';
+
+const observedPublisherConfigs = vi.hoisted(
+  () => [] as Array<{ writeLocks?: Map<string, Promise<void>> }>,
+);
+
+vi.mock('@origintrail-official/dkg-publisher', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@origintrail-official/dkg-publisher')>();
+  return {
+    ...actual,
+    DKGPublisher: class ObservedDKGPublisher extends actual.DKGPublisher {
+      constructor(config: ConstructorParameters<typeof actual.DKGPublisher>[0]) {
+        observedPublisherConfigs.push(config);
+        super(config);
+      }
+    },
+  };
+});
 
 // Hardhat dev keys #0 and #1 — loopback only, never touch a real network.
 // TWO wallets so the merge across ALL per-wallet adapters is what's proven:
@@ -78,6 +95,7 @@ describe('publisher runtime drainRpcUsage — REAL runtime, real adapters, loopb
     await store?.close().catch(() => {});
     await loopback?.close().catch(() => {});
     if (dataDir) await rm(dataDir, { recursive: true, force: true });
+    observedPublisherConfigs.length = 0;
     runtime = null; store = null; loopback = null; dataDir = null;
   });
 
@@ -103,6 +121,9 @@ describe('publisher runtime drainRpcUsage — REAL runtime, real adapters, loopb
     // holds if EVERY adapter's tracker is merged (each wallet's identity
     // lookups bill separately).
     expect(runtime.walletIds).toHaveLength(WALLETS.length);
+    expect(observedPublisherConfigs).toHaveLength(WALLETS.length);
+    expect(observedPublisherConfigs.every((config) => config.writeLocks instanceof Map)).toBe(true);
+    expect(new Set(observedPublisherConfigs.map((config) => config.writeLocks)).size).toBe(1);
     const usage = runtime.drainRpcUsage();
     expect(usage).toBeDefined();
     expect(rpcUsageWindowTotal(usage!)).toBeGreaterThanOrEqual(2); // non-vacuous: both adapters made calls

--- a/packages/node-ui/e2e/helpers/devnet-publish.ts
+++ b/packages/node-ui/e2e/helpers/devnet-publish.ts
@@ -2,6 +2,7 @@
  * Devnet API helpers for Playwright e2e — WM → SWM → VM publish flows.
  * Mirrors patterns from `devnet/rich-scenario/automated.test.ts`.
  */
+import { contextGraphDataUri } from '@origintrail-official/dkg-core';
 import { devnetApiFetch, readDevnetNode } from './devnet.js';
 import { withSwmLock } from './swm-lock.js';
 
@@ -22,7 +23,7 @@ export const VM_SEED_SUBJECT_PREFIX = 'urn:e2e:ui:entity:';
 
 export function buildTestQuads(cgId: string, stamp: number, label: string): PublishQuads[] {
   const subject = `${VM_SEED_SUBJECT_PREFIX}${stamp}`;
-  const graph = `did:dkg:context-graph:${cgId}`;
+  const graph = contextGraphDataUri(cgId);
   return [
     {
       subject,
@@ -185,7 +186,7 @@ export async function createSubGraph(opts: {
   }
 }
 
-/** Quads targeting a NAMED sub-graph's data graph (`<cg>/<subGraph>`). */
+/** Quads targeting the canonical physical data graph for a named sub-graph. */
 export function buildSubGraphQuads(
   cgId: string,
   subGraphName: string,
@@ -193,7 +194,7 @@ export function buildSubGraphQuads(
   label: string,
 ): PublishQuads[] {
   const subject = `urn:e2e:ui:sg:${subGraphName}:${stamp}`;
-  const graph = `did:dkg:context-graph:${cgId}/${subGraphName}`;
+  const graph = contextGraphDataUri(cgId, subGraphName);
   return [
     {
       subject,

--- a/packages/node-ui/test/devnet-publish-helper.test.ts
+++ b/packages/node-ui/test/devnet-publish-helper.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { contextGraphDataUri } from '@origintrail-official/dkg-core';
+import { buildSubGraphQuads, buildTestQuads } from '../e2e/helpers/devnet-publish.js';
+
+describe('devnet publish fixture graph placement', () => {
+  it('uses canonical physical data graph URIs for root and named sub-graph seeds', () => {
+    expect(buildTestQuads('music-social', 1, 'root')).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ graph: contextGraphDataUri('music-social') }),
+      ]),
+    );
+    expect(buildSubGraphQuads('music-social', 'artists', 2, 'subgraph')).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ graph: contextGraphDataUri('music-social', 'artists') }),
+      ]),
+    );
+  });
+});

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -108,6 +108,45 @@ export {
 // member rows — cannot be sealed-in-SWM and published as a partial asset.
 const SWM_SHARE_COMPLETE_PRED = 'http://dkg.io/ontology/swmShareComplete';
 const SHARE_OPERATION_ID_PRED = 'http://dkg.io/ontology/shareOperationId';
+const PROMOTE_OPERATION_INTENT_PRED = 'http://dkg.io/ontology/promoteOperationIntent';
+
+type PromoteOperationIntent = {
+  version: 1;
+  operationId: string;
+  timestampMs: number;
+  publisherPeerId?: string;
+  confirmationRequired: boolean;
+  accessPolicy: 'public' | 'ownerOnly' | 'allowList';
+  allowedPeers: string[];
+};
+
+type AssertionPromoteOptions = {
+  entities?: string[] | 'all';
+  subGraphName?: string;
+  publisherPeerId?: string;
+  senderAgentAddress?: string;
+  /** Do not encrypt or emit a network-ready payload for a local capture. */
+  localOnly?: boolean;
+  /** Immutable access envelope persisted with the graph-scoped share. */
+  accessPolicy?: PublishOptions['accessPolicy'];
+  allowedPeers?: readonly string[];
+  trustedNonManifestCatalogTriples?: PublishOptions['trustedNonManifestCatalogTriples'];
+  onChainContextGraphId?: string | bigint;
+  /**
+   * Strict curator-ack gate (OT-RFC-49 curator-leader), same contract as
+   * `ShareOptions.confirmBeforeCommit`: called after the gossip message is
+   * built and BEFORE the WM→SWM mutation. `applied: false` aborts the promote
+   * (CuratorUnconfirmedError / CuratorRejectedError) leaving WM intact.
+   */
+  confirmBeforeCommit?: (message: Uint8Array) => Promise<{ applied: boolean; rejected?: boolean }>;
+};
+
+type AssertionPromoteResult = {
+  promotedCount: number;
+  gossipMessage?: Uint8Array;
+  promotedAllRoots: boolean;
+  shareOperationId?: string;
+};
 
 async function validateGraphScopedPayloadAgainstSeal(
   seal: AssertionSeal,
@@ -260,6 +299,33 @@ export interface DKGPublisherConfig {
    * the lifecycle subject; the history API returns `events: []` gracefully.
    */
   provenanceEvents?: boolean;
+}
+
+/**
+ * Publisher instances that target the same in-process store must serialize
+ * lifecycle mutations together. A per-instance default lets a writer race a
+ * promote in another publisher and disappear when promote drops the stale WM
+ * snapshot. Explicitly supplied locks still win so the agent can share its
+ * wider handler lock domain with the publisher.
+ */
+const STORE_WRITE_LOCKS = new WeakMap<TripleStore, Map<string, Promise<void>>>();
+
+function writeLocksForStore(
+  store: TripleStore,
+  suppliedLocks?: Map<string, Promise<void>>,
+): Map<string, Promise<void>> {
+  const existingLocks = STORE_WRITE_LOCKS.get(store);
+  if (existingLocks) {
+    if (suppliedLocks && suppliedLocks !== existingLocks) {
+      throw new Error(
+        'DKGPublisher instances sharing one TripleStore must share the same writeLocks map',
+      );
+    }
+    return existingLocks;
+  }
+  const locks = suppliedLocks ?? new Map();
+  STORE_WRITE_LOCKS.set(store, locks);
+  return locks;
 }
 
 export interface WorkspaceSenderKeyEncryptInput {
@@ -572,6 +638,56 @@ function stripOptionalLiteral(value: string | undefined): string | undefined {
   return value;
 }
 
+function parsePromoteOperationIntent(
+  rawValue: string,
+  expectedOperationId: string,
+): PromoteOperationIntent {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawValue);
+  } catch {
+    parsed = undefined;
+  }
+  const candidate = parsed as Partial<PromoteOperationIntent> | undefined;
+  const publisherPeerId = candidate?.publisherPeerId;
+  const allowedPeers = candidate?.allowedPeers;
+  const canonicalAllowedPeers = Array.isArray(allowedPeers)
+    ? [...new Set(allowedPeers.map((peer) => typeof peer === 'string' ? peer.trim() : ''))]
+        .filter(Boolean)
+        .sort()
+    : [];
+  const accessPolicy = candidate?.accessPolicy;
+  const valid = candidate?.version === 1
+    && candidate.operationId === expectedOperationId
+    && Number.isSafeInteger(candidate.timestampMs)
+    && Number(candidate.timestampMs) > 0
+    && (publisherPeerId === undefined
+      || (typeof publisherPeerId === 'string'
+        && publisherPeerId.length > 0
+        && publisherPeerId === publisherPeerId.trim()))
+    && typeof candidate.confirmationRequired === 'boolean'
+    && (accessPolicy === 'public' || accessPolicy === 'ownerOnly' || accessPolicy === 'allowList')
+    && Array.isArray(allowedPeers)
+    && allowedPeers.every((peer) => typeof peer === 'string')
+    && JSON.stringify(allowedPeers) === JSON.stringify(canonicalAllowedPeers)
+    && ((accessPolicy === 'allowList') === (canonicalAllowedPeers.length > 0));
+  if (!valid) {
+    throw Object.assign(
+      new Error(`Durable promote intent for operation ${expectedOperationId} is missing or corrupt`),
+      { code: 'KA_PROMOTE_OPERATION_INTENT_CORRUPT' },
+    );
+  }
+  return {
+    version: 1,
+    operationId: expectedOperationId,
+    timestampMs: candidate.timestampMs!,
+    ...(publisherPeerId ? { publisherPeerId } : {}),
+    confirmationRequired: candidate.confirmationRequired!,
+    accessPolicy,
+    allowedPeers: canonicalAllowedPeers,
+  };
+}
+
 function sameBigIntLiteral(left: string | bigint | undefined, right: string | bigint | undefined): boolean {
   if (left === undefined || right === undefined) return false;
   try {
@@ -787,7 +903,7 @@ export class DKGPublisher implements Publisher {
     this.privateStore = new PrivateContentStore(config.store, this.graphManager);
     this.sharedMemoryOwnedEntities = config.sharedMemoryOwnedEntities ?? new Map();
     this.knownBatchContextGraphs = config.knownBatchContextGraphs ?? new Map();
-    this.writeLocks = config.writeLocks ?? new Map();
+    this.writeLocks = writeLocksForStore(this.store, config.writeLocks);
     this.workspaceAgentRecipientResolver = config.workspaceAgentRecipientResolver;
     this.workspaceSenderKeyEncryptor = config.workspaceSenderKeyEncryptor;
     this.publicSnapshotStore = config.publicSnapshotStore;
@@ -1281,6 +1397,35 @@ export class DKGPublisher implements Publisher {
 
   private withWriteLocks<T>(keys: string[], fn: () => Promise<T>): Promise<T> {
     return withKeyedLocks(this.writeLocks, keys, fn);
+  }
+
+  private assertionLifecycleWriteLockKey(
+    contextGraphId: string,
+    name: string,
+    agentAddress: string,
+    subGraphName?: string,
+  ): string {
+    const normalizedAgentAddress = /^0x[0-9a-fA-F]{40}$/.test(agentAddress)
+      ? agentAddress.toLowerCase()
+      : agentAddress;
+    return `assertion-lifecycle:${JSON.stringify([
+      contextGraphId,
+      subGraphName ?? '',
+      normalizedAgentAddress,
+      name,
+    ])}`;
+  }
+
+  private withAssertionLifecycleWriteLock<T>(
+    contextGraphId: string,
+    name: string,
+    agentAddress: string,
+    subGraphName: string | undefined,
+    fn: () => Promise<T>,
+  ): Promise<T> {
+    return this.withWriteLocks([
+      this.assertionLifecycleWriteLockKey(contextGraphId, name, agentAddress, subGraphName),
+    ], fn);
   }
 
   /**
@@ -5657,6 +5802,21 @@ export class DKGPublisher implements Publisher {
     agentAddress: string,
     subGraphName?: string,
   ): Promise<void> {
+    return this.withAssertionLifecycleWriteLock(
+      contextGraphId,
+      name,
+      agentAddress,
+      subGraphName,
+      () => this.markSwmShareCompleteUnlocked(contextGraphId, name, agentAddress, subGraphName),
+    );
+  }
+
+  private async markSwmShareCompleteUnlocked(
+    contextGraphId: string,
+    name: string,
+    agentAddress: string,
+    subGraphName?: string,
+  ): Promise<void> {
     const metaGraph = contextGraphMetaUri(contextGraphId);
     const lifecycleUri = assertionLifecycleUri(contextGraphId, agentAddress, name, subGraphName);
     // Idempotent: drop any prior marker first, then insert exactly one.
@@ -5687,6 +5847,21 @@ export class DKGPublisher implements Publisher {
    * full-share path re-stamps it — it is only cleared when scope actually drops.
    */
   async clearSwmShareComplete(
+    contextGraphId: string,
+    name: string,
+    agentAddress: string,
+    subGraphName?: string,
+  ): Promise<void> {
+    return this.withAssertionLifecycleWriteLock(
+      contextGraphId,
+      name,
+      agentAddress,
+      subGraphName,
+      () => this.clearSwmShareCompleteUnlocked(contextGraphId, name, agentAddress, subGraphName),
+    );
+  }
+
+  private async clearSwmShareCompleteUnlocked(
     contextGraphId: string,
     name: string,
     agentAddress: string,
@@ -5735,6 +5910,29 @@ export class DKGPublisher implements Publisher {
    * atomic-on-failure (a failed pull no longer strands a previously-valid seal).
    */
   async clearAssertionSeal(
+    contextGraphId: string,
+    name: string,
+    agentAddress: string,
+    subGraphName?: string,
+  ): Promise<void> {
+    return this.withAssertionLifecycleWriteLock(
+      contextGraphId,
+      name,
+      agentAddress,
+      subGraphName,
+      async () => {
+        await this.assertNoUnfinishedAssertionPromote(
+          contextGraphId,
+          name,
+          agentAddress,
+          subGraphName,
+        );
+        await this.clearAssertionSealUnlocked(contextGraphId, name, agentAddress, subGraphName);
+      },
+    );
+  }
+
+  private async clearAssertionSealUnlocked(
     contextGraphId: string,
     name: string,
     agentAddress: string,
@@ -5894,6 +6092,178 @@ export class DKGPublisher implements Publisher {
     if (version !== String(GRAPH_KA_CONTENT_SCOPE_VERSION)) {
       throw new LegacyKnowledgeAssetReadOnlyError();
     }
+  }
+
+  /**
+   * A draft mutation is only valid while the lifecycle is exactly created/WM.
+   * The checks are separate and bounded so corrupt duplicate rows cannot form
+   * an unbounded Cartesian product in a recovery path.
+   */
+  private async assertWorkingMemoryLifecycleMutable(
+    contextGraphId: string,
+    name: string,
+    agentAddress: string,
+    subGraphName?: string,
+  ): Promise<void> {
+    const lifecycle = assertionLifecycleUri(contextGraphId, agentAddress, name, subGraphName);
+    const metaGraph = contextGraphMetaUri(contextGraphId);
+    const [stateResult, layerResult] = await Promise.all([
+      this.store.query(
+        `SELECT ?state WHERE { GRAPH <${assertSafeIri(metaGraph)}> {
+          <${assertSafeIri(lifecycle)}> <http://dkg.io/ontology/state> ?state
+        } } LIMIT 2`,
+      ),
+      this.store.query(
+        `SELECT ?layer WHERE { GRAPH <${assertSafeIri(metaGraph)}> {
+          <${assertSafeIri(lifecycle)}> <http://dkg.io/ontology/memoryLayer> ?layer
+        } } LIMIT 2`,
+      ),
+    ]);
+    const state = stateResult.type === 'bindings' && stateResult.bindings.length === 1
+      ? stripOptionalLiteral(stateResult.bindings[0]?.['state'])
+      : undefined;
+    const layer = layerResult.type === 'bindings' && layerResult.bindings.length === 1
+      ? stripOptionalLiteral(layerResult.bindings[0]?.['layer'])
+      : undefined;
+    if (state !== 'created' || layer !== MemoryLayer.WorkingMemory) {
+      throw Object.assign(
+        new Error(
+          `Assertion "${name}" is not an active Working Memory draft; reopen it before mutating it`,
+        ),
+        { code: 'KA_WM_LIFECYCLE_REQUIRED' },
+      );
+    }
+  }
+
+  /**
+   * Once an operation ID or immutable promote intent is durable, WM is frozen
+   * until promote either completes or receives a definitive rejection. This
+   * prevents a sequential write/discard from erasing the only state capable of
+   * repairing an acknowledgement whose outcome is still ambiguous.
+   */
+  private async assertNoUnfinishedAssertionPromote(
+    contextGraphId: string,
+    name: string,
+    agentAddress: string,
+    subGraphName?: string,
+  ): Promise<void> {
+    const lifecycle = assertionLifecycleUri(contextGraphId, agentAddress, name, subGraphName);
+    const metaGraph = contextGraphMetaUri(contextGraphId);
+    const [operationIdResult, intentResult, layerResult] = await Promise.all([
+      this.store.query(
+        `SELECT ?id WHERE { GRAPH <${assertSafeIri(metaGraph)}> {
+          <${assertSafeIri(lifecycle)}> <${SHARE_OPERATION_ID_PRED}> ?id
+        } } LIMIT 2`,
+      ),
+      this.store.query(
+        `ASK { GRAPH <${assertSafeIri(metaGraph)}> {
+          <${assertSafeIri(lifecycle)}> <${PROMOTE_OPERATION_INTENT_PRED}> ?intent
+        } }`,
+      ),
+      this.store.query(
+        `SELECT ?layer WHERE { GRAPH <${assertSafeIri(metaGraph)}> {
+          <${assertSafeIri(lifecycle)}> <http://dkg.io/ontology/memoryLayer> ?layer
+        } } LIMIT 2`,
+      ),
+    ]);
+    const operationIdBindings = operationIdResult.type === 'bindings'
+      ? operationIdResult.bindings
+      : undefined;
+    const hasOperationId = operationIdBindings === undefined || operationIdBindings.length > 0;
+    const hasIntent = intentResult.type !== 'boolean' || intentResult.value;
+    if (!hasOperationId && !hasIntent) return;
+
+    const layer = layerResult.type === 'bindings' && layerResult.bindings.length === 1
+      ? stripOptionalLiteral(layerResult.bindings[0]?.['layer'])
+      : undefined;
+    if (layer === MemoryLayer.VerifiableMemory) return;
+    if (layer === MemoryLayer.SharedWorkingMemory && operationIdBindings?.length === 1) {
+      const rawOperationId = operationIdBindings[0]?.['id'];
+      let operationId: string | undefined;
+      try {
+        const parsed: unknown = rawOperationId === undefined
+          ? undefined
+          : JSON.parse(rawOperationId);
+        operationId = typeof parsed === 'string' && parsed.length > 0 ? parsed : undefined;
+      } catch {
+        operationId = undefined;
+      }
+      const sealSubject = contextGraphAssertionUri(
+        contextGraphId,
+        agentAddress,
+        name,
+        subGraphName,
+      );
+      const sealResult = await this.store.query(
+        `CONSTRUCT { <${assertSafeIri(sealSubject)}> ?p ?o } WHERE {
+          GRAPH <${assertSafeIri(metaGraph)}> { <${assertSafeIri(sealSubject)}> ?p ?o }
+        }`,
+      );
+      const seal = parseAssertionSealQuads(
+        sealResult.type === 'quads' ? sealResult.quads : [],
+        sealSubject,
+      );
+      if (
+        operationId
+        && seal?.contentScopeVersion === GRAPH_KA_CONTENT_SCOPE_VERSION
+        && seal.kaUal
+        && seal.assertionVersion
+        && await this.hasSwmShareComplete(contextGraphId, name, agentAddress, subGraphName)
+        && await this.hasDurableAssertionPromoteTail(
+          contextGraphId,
+          operationId,
+          seal.kaUal,
+          seal.assertionVersion,
+          subGraphName,
+        )
+      ) {
+        return;
+      }
+    }
+    throw Object.assign(
+      new Error(
+        `Assertion "${name}" has an unfinished promote; retry assertionPromote before mutating its draft`,
+      ),
+      { code: 'KA_PROMOTE_RECOVERY_REQUIRED' },
+    );
+  }
+
+  private async hasDurableAssertionPromoteTail(
+    contextGraphId: string,
+    operationId: string,
+    kaUal: string,
+    assertionVersion: string | number | bigint,
+    subGraphName?: string,
+  ): Promise<boolean> {
+    const scope = createGraphKnowledgeAssetScope(kaUal, assertionVersion);
+    const workspaceMetaGraph = this.graphManager.sharedMemoryMetaUri(
+      contextGraphId,
+      subGraphName,
+    );
+    const operationSubject = `urn:dkg:share:${contextGraphId}:${operationId}`;
+    const headSubject = `${scope.ual}#dkg-swm-head`;
+    const assertionGraph = knowledgeAssetLayerGraphUri(
+      contextGraphId,
+      MemoryLayer.SharedWorkingMemory,
+      scope,
+      subGraphName,
+    );
+    const versionLiteral = `${JSON.stringify(scope.assertionVersion)}` +
+      '^^<http://www.w3.org/2001/XMLSchema#integer>';
+    const durableTail = await this.store.query(
+      `ASK { GRAPH <${assertSafeIri(workspaceMetaGraph)}> {
+        <${assertSafeIri(operationSubject)}> <http://dkg.io/ontology/shareOperationId> ${JSON.stringify(operationId)} ;
+          <http://dkg.io/ontology/publicQuadsDigest> ?digest ;
+          <http://dkg.io/ontology/publicQuadsCount> ?count ;
+          <http://dkg.io/ontology/kaUal> <${assertSafeIri(scope.ual)}> ;
+          <http://dkg.io/ontology/assertionVersion> ${versionLiteral} .
+        <${assertSafeIri(headSubject)}> <http://dkg.io/ontology/shareOperationId> ${JSON.stringify(operationId)} ;
+          <http://dkg.io/ontology/kaUal> <${assertSafeIri(scope.ual)}> ;
+          <http://dkg.io/ontology/assertionVersion> ${versionLiteral} ;
+          <http://dkg.io/ontology/assertionGraph> <${assertSafeIri(assertionGraph)}> .
+      } }`,
+    );
+    return durableTail.type === 'boolean' && durableTail.value;
   }
 
   /** Read a KA's allocated number (dkg:kaId) off its lifecycle URN, or null if not yet minted. */
@@ -6352,6 +6722,37 @@ export class DKGPublisher implements Publisher {
     subGraphName?: string,
     opts?: { allocateKaNumber?: () => Promise<{ number: bigint; reservedUal: string }> },
   ): Promise<string> {
+    DKGPublisher.validateOptionalSubGraph(subGraphName);
+    return this.withAssertionLifecycleWriteLock(
+      contextGraphId,
+      name,
+      agentAddress,
+      subGraphName,
+      async () => {
+        await this.assertNoUnfinishedAssertionPromote(
+          contextGraphId,
+          name,
+          agentAddress,
+          subGraphName,
+        );
+        return this.assertionCreateUnlocked(
+          contextGraphId,
+          name,
+          agentAddress,
+          subGraphName,
+          opts,
+        );
+      },
+    );
+  }
+
+  private async assertionCreateUnlocked(
+    contextGraphId: string,
+    name: string,
+    agentAddress: string,
+    subGraphName?: string,
+    opts?: { allocateKaNumber?: () => Promise<{ number: bigint; reservedUal: string }> },
+  ): Promise<string> {
     await this.ensureSubGraphRegistered(contextGraphId, subGraphName);
 
     // Clear any stale lifecycle data from a previous create/discard cycle
@@ -6490,20 +6891,54 @@ export class DKGPublisher implements Publisher {
     input: Quad[] | Array<{ subject: string; predicate: string; object: string }>,
     subGraphName?: string,
   ): Promise<void> {
-    // Reject protocol-reserved user data before any lifecycle/store read. This
-    // keeps the security boundary deterministic even when the addressed KA is
-    // legacy/read-only or does not exist.
-    rejectUserAuthoredProtocolMetadata(input.map((quad) => ({
+    // Keep the reserved-namespace security boundary ahead of lock and store
+    // access so invalid input fails deterministically even while this KA is busy.
+    const stableInput = input.map((quad) => ({ ...quad })) as typeof input;
+    rejectUserAuthoredProtocolMetadata(stableInput.map((quad) => ({
       subject: quad.subject,
       predicate: quad.predicate,
       object: quad.object,
       graph: 'graph' in quad ? String(quad.graph ?? '') : '',
     })));
+    return this.withAssertionLifecycleWriteLock(
+      contextGraphId,
+      name,
+      agentAddress,
+      subGraphName,
+      () => this.assertionWriteUnlocked(
+        contextGraphId,
+        name,
+        agentAddress,
+        stableInput,
+        subGraphName,
+      ),
+    );
+  }
+
+  private async assertionWriteUnlocked(
+    contextGraphId: string,
+    name: string,
+    agentAddress: string,
+    input: Quad[] | Array<{ subject: string; predicate: string; object: string }>,
+    subGraphName?: string,
+  ): Promise<void> {
     await this.ensureSubGraphRegistered(contextGraphId, subGraphName);
     await this.assertGraphScopedLifecycleWritable(
       contextGraphId,
       agentAddress,
       name,
+      subGraphName,
+    );
+    await this.assertNoUnfinishedAssertionPromote(
+      contextGraphId,
+      name,
+      agentAddress,
+      subGraphName,
+    );
+    await this.assertWorkingMemoryLifecycleMutable(
+      contextGraphId,
+      name,
+      agentAddress,
       subGraphName,
     );
     const graphUri = await this.wmGraphUri(contextGraphId, agentAddress, name, subGraphName);
@@ -6547,16 +6982,50 @@ export class DKGPublisher implements Publisher {
     input: Quad[],
     subGraphName?: string,
   ): Promise<void> {
-    // Private draft storage is triple-scoped and deliberately replaces the
-    // physical graph term. Reject RDF named-graph identity before that write so
-    // it cannot be silently erased and later sealed as a different dataset.
-    assertNoKnowledgeAssetPayloadNamedGraphs(input);
-    rejectUserAuthoredProtocolMetadata(input.map((quad) => ({ ...quad, graph: '' })));
+    // Private storage erases the physical graph term. Reject named-graph and
+    // reserved-namespace input before waiting on any lifecycle mutation.
+    const stableInput = input.map((quad) => ({ ...quad }));
+    assertNoKnowledgeAssetPayloadNamedGraphs(stableInput);
+    rejectUserAuthoredProtocolMetadata(stableInput.map((quad) => ({ ...quad, graph: '' })));
+    return this.withAssertionLifecycleWriteLock(
+      contextGraphId,
+      name,
+      agentAddress,
+      subGraphName,
+      () => this.assertionWritePrivateUnlocked(
+        contextGraphId,
+        name,
+        agentAddress,
+        stableInput,
+        subGraphName,
+      ),
+    );
+  }
+
+  private async assertionWritePrivateUnlocked(
+    contextGraphId: string,
+    name: string,
+    agentAddress: string,
+    input: Quad[],
+    subGraphName?: string,
+  ): Promise<void> {
     await this.ensureSubGraphRegistered(contextGraphId, subGraphName);
     await this.assertGraphScopedLifecycleWritable(
       contextGraphId,
       agentAddress,
       name,
+      subGraphName,
+    );
+    await this.assertNoUnfinishedAssertionPromote(
+      contextGraphId,
+      name,
+      agentAddress,
+      subGraphName,
+    );
+    await this.assertWorkingMemoryLifecycleMutable(
+      contextGraphId,
+      name,
+      agentAddress,
       subGraphName,
     );
     rejectOversizedRdfLiterals(input, 'assertionWritePrivate.quads');
@@ -6619,8 +7088,45 @@ export class DKGPublisher implements Publisher {
     kaUal: string;
     assertionVersion: string;
   }> {
+    const stableOpts = opts ? { ...opts } : undefined;
+    return this.withAssertionLifecycleWriteLock(
+      contextGraphId,
+      name,
+      agentAddress,
+      stableOpts?.subGraphName,
+      () => this.assertionPullFromUnlocked(
+        contextGraphId,
+        name,
+        agentAddress,
+        sourceLayer,
+        stableOpts,
+      ),
+    );
+  }
+
+  private async assertionPullFromUnlocked(
+    contextGraphId: string,
+    name: string,
+    agentAddress: string,
+    sourceLayer: 'swm' | 'vm',
+    opts?: { subGraphName?: string; onConflict?: 'reject' | 'replace' },
+  ): Promise<{
+    seeded: number;
+    seededPublic: number;
+    seededPrivate: number;
+    fromLayer: 'swm' | 'vm';
+    contentScopeVersion: number;
+    kaUal: string;
+    assertionVersion: string;
+  }> {
     const subGraphName = opts?.subGraphName;
     await this.ensureSubGraphRegistered(contextGraphId, subGraphName);
+    await this.assertNoUnfinishedAssertionPromote(
+      contextGraphId,
+      name,
+      agentAddress,
+      subGraphName,
+    );
     const metaGraph = contextGraphMetaUri(contextGraphId);
     const sealSubject = contextGraphAssertionUri(contextGraphId, agentAddress, name, subGraphName);
     const currentWmGraph = await this.wmGraphUri(
@@ -6730,8 +7236,8 @@ export class DKGPublisher implements Publisher {
         subGraphName,
       );
     }
-    await this.assertionCreate(contextGraphId, name, agentAddress, subGraphName);
-    await this.clearAssertionSeal(contextGraphId, name, agentAddress, subGraphName);
+    await this.assertionCreateUnlocked(contextGraphId, name, agentAddress, subGraphName);
+    await this.clearAssertionSealUnlocked(contextGraphId, name, agentAddress, subGraphName);
     // The source was already canonicalized and seal-verified. Re-materialize it
     // through the internal exact-graph primitive: public assertionWrite rightly
     // rejects protocol-owned c14n skolem IRIs as user input.
@@ -6764,27 +7270,36 @@ export class DKGPublisher implements Publisher {
     contextGraphId: string,
     name: string,
     agentAddress: string,
-    opts?: {
-      entities?: string[] | 'all';
-      subGraphName?: string;
-      publisherPeerId?: string;
-      senderAgentAddress?: string;
-      /** Do not encrypt or emit a network-ready payload for a local capture. */
-      localOnly?: boolean;
-      /** Immutable access envelope persisted with the graph-scoped share. */
-      accessPolicy?: PublishOptions['accessPolicy'];
-      allowedPeers?: readonly string[];
-      trustedNonManifestCatalogTriples?: PublishOptions['trustedNonManifestCatalogTriples'];
-      onChainContextGraphId?: string | bigint;
-      /**
-       * Strict curator-ack gate (OT-RFC-49 curator-leader), same contract as
-       * `ShareOptions.confirmBeforeCommit`: called after the gossip message is
-       * built and BEFORE the WM→SWM mutation. `applied: false` aborts the promote
-       * (CuratorUnconfirmedError / CuratorRejectedError) leaving WM intact.
-       */
-      confirmBeforeCommit?: (message: Uint8Array) => Promise<{ applied: boolean; rejected?: boolean }>;
-    },
-  ): Promise<{ promotedCount: number; gossipMessage?: Uint8Array; promotedAllRoots: boolean; shareOperationId?: string }> {
+    opts?: AssertionPromoteOptions,
+  ): Promise<AssertionPromoteResult> {
+    const stableOpts: AssertionPromoteOptions | undefined = opts
+      ? {
+          ...opts,
+          ...(Array.isArray(opts.entities) ? { entities: [...opts.entities] } : {}),
+          ...(opts.allowedPeers ? { allowedPeers: [...opts.allowedPeers] } : {}),
+          ...(opts.trustedNonManifestCatalogTriples
+            ? {
+                trustedNonManifestCatalogTriples:
+                  new Set(opts.trustedNonManifestCatalogTriples),
+              }
+            : {}),
+        }
+      : undefined;
+    return this.withAssertionLifecycleWriteLock(
+      contextGraphId,
+      name,
+      agentAddress,
+      stableOpts?.subGraphName,
+      () => this.assertionPromoteUnlocked(contextGraphId, name, agentAddress, stableOpts),
+    );
+  }
+
+  private async assertionPromoteUnlocked(
+    contextGraphId: string,
+    name: string,
+    agentAddress: string,
+    opts?: AssertionPromoteOptions,
+  ): Promise<AssertionPromoteResult> {
     // #1464 (PR1, diagnostic) — every awaited op below runs BEFORE the
     // `store.insert(swmQuads)` that actually lands the root in SWM. A masked
     // rejection here (typically a sparql-http read hitting the 30s
@@ -6882,19 +7397,11 @@ export class DKGPublisher implements Publisher {
     // are actually promoted; the MARKER is the cross-cutting invariant.)
     const promotingAllEntities = true;
     const lifecycleSubject = assertionLifecycleUri(contextGraphId, agentAddress, name, opts?.subGraphName);
-    const clearCurrentShareOperationId = async (): Promise<void> => {
-      await this.store.deleteByPattern({
-        graph: promoteMetaGraph,
-        subject: lifecycleSubject,
-        predicate: SHARE_OPERATION_ID_PRED,
-      });
-    };
     const maintainMarker = async (isFullCompletePromote: boolean): Promise<void> => {
       if (isFullCompletePromote) {
-        await this.markSwmShareComplete(contextGraphId, name, agentAddress, opts?.subGraphName);
+        await this.markSwmShareCompleteUnlocked(contextGraphId, name, agentAddress, opts?.subGraphName);
       } else {
-        await this.clearSwmShareComplete(contextGraphId, name, agentAddress, opts?.subGraphName);
-        await clearCurrentShareOperationId();
+        await this.clearSwmShareCompleteUnlocked(contextGraphId, name, agentAddress, opts?.subGraphName);
       }
     };
 
@@ -6902,24 +7409,46 @@ export class DKGPublisher implements Publisher {
       'assertionScopedQuads',
       () => this.assertionScopedQuads(graphUri),
     );
-    const lifecycleStateResult = await this.store.query(
-      `SELECT ?layer ?shareOperationId WHERE { GRAPH <${assertSafeIri(promoteMetaGraph)}> {
-        OPTIONAL {
-          <${assertSafeIri(lifecycleSubject)}> <http://dkg.io/ontology/memoryLayer> ?layer
-        }
-        OPTIONAL {
-          <${assertSafeIri(lifecycleSubject)}> <${SHARE_OPERATION_ID_PRED}> ?shareOperationId
-        }
-      } } LIMIT 1`,
+    const parsePlainLiteral = (raw: string | undefined, code: string): string | undefined => {
+      if (raw === undefined) return undefined;
+      try {
+        const value: unknown = JSON.parse(raw);
+        if (typeof value === 'string' && value.length > 0) return value;
+      } catch {
+        // Fall through to the typed corruption error below.
+      }
+      throw Object.assign(
+        new Error(`Graph-scoped assertion lifecycle <${lifecycleSubject}> contains malformed state`),
+        { code },
+      );
+    };
+    // Read the layer first. On empty-WM recovery the exact SWM graph must be
+    // validated and any stale completion marker cleared before operation
+    // metadata is parsed: corrupt IDs/intents must never leave a publishable
+    // marker exposed.
+    const layerResult = await this.store.query(
+      `SELECT ?layer WHERE { GRAPH <${assertSafeIri(promoteMetaGraph)}> {
+        <${assertSafeIri(lifecycleSubject)}> <http://dkg.io/ontology/memoryLayer> ?layer
+      } } LIMIT 2`,
     );
-    const lifecycleState = lifecycleStateResult.type === 'bindings'
-      ? lifecycleStateResult.bindings[0]
-      : undefined;
-    const lifecycleLayer = stripOptionalLiteral(lifecycleState?.['layer']);
-    const durableShareOperationId = stripOptionalLiteral(
-      lifecycleState?.['shareOperationId'],
+    if (layerResult.type !== 'bindings') {
+      throw Object.assign(
+        new Error(`Graph-scoped assertion lifecycle <${lifecycleSubject}> could not be read safely`),
+        { code: 'KA_LIFECYCLE_STATE_CORRUPT' },
+      );
+    }
+    if (layerResult.bindings.length > 1) {
+      throw Object.assign(
+        new Error(`Graph-scoped assertion lifecycle <${lifecycleSubject}> has conflicting memory layers`),
+        { code: 'KA_LIFECYCLE_LAYER_CONFLICT' },
+      );
+    }
+    const lifecycleLayer = parsePlainLiteral(
+      layerResult.bindings[0]?.['layer'],
+      'KA_LIFECYCLE_LAYER_CORRUPT',
     );
     let resumingCommittedSwm = false;
+    let preserveLegacyCompletionMarker = false;
     if (assertionQuads.length === 0) {
       if (lifecycleLayer === MemoryLayer.VerifiableMemory) {
         // A confirmed publish consumes SWM and leaves WM empty. A stale retry
@@ -6976,10 +7505,130 @@ export class DKGPublisher implements Publisher {
           await maintainMarker(false);
           throw error;
         }
+        // A marker inherited from an older commit ordering is not proof that
+        // the immutable operation snapshot and monotonic head are durable.
+        // Clear it immediately after the exact SWM payload validates, before
+        // parsing any fallible operation metadata. The sole exception is a
+        // completed pre-intent promotion: those rows have a durable operation
+        // ID, snapshot, head, and marker but no promoteOperationIntent. Keep
+        // that already-published state readable as a non-mutating no-op once
+        // its complete durable tail is verified below; it cannot be replayed
+        // because its original wire timestamp is unavailable.
+        if (hasCompletionMarker) {
+          const intentPresence = await this.store.query(
+            `ASK { GRAPH <${assertSafeIri(promoteMetaGraph)}> {
+              <${assertSafeIri(lifecycleSubject)}> <${PROMOTE_OPERATION_INTENT_PRED}> ?intent
+            } }`,
+          );
+          if (intentPresence.type !== 'boolean') {
+            await maintainMarker(false);
+            throw Object.assign(
+              new Error(`Graph-scoped assertion lifecycle <${lifecycleSubject}> could not be read safely`),
+              { code: 'KA_LIFECYCLE_STATE_CORRUPT' },
+            );
+          }
+          preserveLegacyCompletionMarker = !intentPresence.value;
+        }
+        if (!preserveLegacyCompletionMarker) await maintainMarker(false);
         assertionQuads = existingSwmQuads;
         resumingCommittedSwm = true;
       }
     }
+
+    // Keep the operation cardinality checks separate and bounded. Combining
+    // OPTIONALs creates a Cartesian product on corrupt rows — precisely the
+    // sort of recovery path that should not double as an accidental OOM test.
+    const [operationIdResult, promoteIntentResult] = await Promise.all([
+      this.store.query(
+        `SELECT ?shareOperationId WHERE { GRAPH <${assertSafeIri(promoteMetaGraph)}> {
+          <${assertSafeIri(lifecycleSubject)}> <${SHARE_OPERATION_ID_PRED}> ?shareOperationId
+        } } LIMIT 2`,
+      ),
+      this.store.query(
+        `SELECT ?promoteIntent WHERE { GRAPH <${assertSafeIri(promoteMetaGraph)}> {
+          <${assertSafeIri(lifecycleSubject)}> <${PROMOTE_OPERATION_INTENT_PRED}> ?promoteIntent
+        } } LIMIT 2`,
+      ),
+    ]);
+    if (preserveLegacyCompletionMarker) {
+      if (
+        operationIdResult.type === 'bindings'
+        && operationIdResult.bindings.length === 1
+        && promoteIntentResult.type === 'bindings'
+        && promoteIntentResult.bindings.length === 0
+      ) {
+        let legacyOperationId: string | undefined;
+        try {
+          legacyOperationId = parsePlainLiteral(
+            operationIdResult.bindings[0]?.['shareOperationId'],
+            'KA_SHARE_OPERATION_ID_CORRUPT',
+          );
+        } catch (error) {
+          await maintainMarker(false);
+          throw error;
+        }
+        if (
+          legacyOperationId
+          && await this.hasDurableAssertionPromoteTail(
+            contextGraphId,
+            legacyOperationId,
+            contentScope.ual,
+            contentScope.assertionVersion,
+            opts?.subGraphName,
+          )
+        ) {
+          return {
+            promotedCount: 0,
+            promotedAllRoots: false,
+            shareOperationId: legacyOperationId,
+          };
+        }
+      }
+      // The shape was not a complete legacy commit. Remove the stale marker
+      // before the normal conflict/corruption path reports the exact reason.
+      await maintainMarker(false);
+    }
+    if (operationIdResult.type !== 'bindings' || promoteIntentResult.type !== 'bindings') {
+      throw Object.assign(
+        new Error(`Graph-scoped assertion lifecycle <${lifecycleSubject}> could not be read safely`),
+        { code: 'KA_LIFECYCLE_STATE_CORRUPT' },
+      );
+    }
+    if (operationIdResult.bindings.length > 1) {
+      throw Object.assign(
+        new Error(
+          `Graph-scoped assertion lifecycle <${lifecycleSubject}> has conflicting durable share operation IDs`,
+        ),
+        { code: 'KA_SHARE_OPERATION_ID_CONFLICT' },
+      );
+    }
+    if (promoteIntentResult.bindings.length > 1) {
+      throw Object.assign(
+        new Error(
+          `Graph-scoped assertion lifecycle <${lifecycleSubject}> has conflicting durable promote intent`,
+        ),
+        { code: 'KA_PROMOTE_OPERATION_INTENT_CONFLICT' },
+      );
+    }
+    const durableShareOperationId = parsePlainLiteral(
+      operationIdResult.bindings[0]?.['shareOperationId'],
+      'KA_SHARE_OPERATION_ID_CORRUPT',
+    );
+    const durablePromoteIntentValue = parsePlainLiteral(
+      promoteIntentResult.bindings[0]?.['promoteIntent'],
+      'KA_PROMOTE_OPERATION_INTENT_CORRUPT',
+    );
+    if (!durableShareOperationId && durablePromoteIntentValue) {
+      throw Object.assign(
+        new Error(
+          `Graph-scoped assertion lifecycle <${lifecycleSubject}> has promote intent without an operation ID`,
+        ),
+        { code: 'KA_PROMOTE_OPERATION_INTENT_CONFLICT' },
+      );
+    }
+    const durablePromoteIntent = durablePromoteIntentValue && durableShareOperationId
+      ? parsePromoteOperationIntent(durablePromoteIntentValue, durableShareOperationId)
+      : undefined;
     if (assertionQuads.length === 0 && immutablePrivateQuads.length === 0) {
       await maintainMarker(false);
       throw Object.assign(
@@ -7073,9 +7722,8 @@ export class DKGPublisher implements Publisher {
       );
     }
 
-    const operationId = resumingCommittedSwm && durableShareOperationId
-      ? durableShareOperationId
-      : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+    const operationId = durableShareOperationId
+      ?? `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
 
     // Canonicalize both partitions together so blank-node labels stay stable
     // across the public/private boundary and validate the complete sealed KA.
@@ -7094,22 +7742,68 @@ export class DKGPublisher implements Publisher {
     const normalizedQuads = validatedPayload.normalizedPublicQuads;
     const normalizedPrivateQuads = validatedPayload.normalizedPrivateQuads;
     const promotedPrivateRoot = validatedPayload.privateMerkleRoot;
-    const accessPolicy = opts?.accessPolicy
+    // A prior completed version may leave its marker intentionally preserved
+    // while a new WM draft is prepared. Once this exact new payload validates,
+    // retire that old proof before any encoding, confirmation, or other
+    // fallible work. Only the final commit tail may expose completion again.
+    await maintainMarker(false);
+    const requestedAccessPolicy = opts?.accessPolicy
       ?? (normalizedPrivateQuads.length > 0 ? 'ownerOnly' : 'public');
-    const allowedPeers = [...new Set(
+    const requestedAllowedPeers = [...new Set(
       (opts?.allowedPeers ?? []).map((peerId) => peerId.trim()).filter(Boolean),
-    )];
-    if (accessPolicy === 'allowList' && allowedPeers.length === 0) {
-      throw new Error('Graph-scoped assertion allowList policy requires allowedPeers');
+    )].sort();
+    if (!durableShareOperationId) {
+      if (requestedAccessPolicy === 'allowList' && requestedAllowedPeers.length === 0) {
+        throw new Error('Graph-scoped assertion allowList policy requires allowedPeers');
+      }
+      if (requestedAccessPolicy !== 'allowList' && requestedAllowedPeers.length > 0) {
+        throw new Error('Graph-scoped assertion allowedPeers requires allowList policy');
+      }
     }
-    if (accessPolicy !== 'allowList' && allowedPeers.length > 0) {
-      throw new Error('Graph-scoped assertion allowedPeers requires allowList policy');
+
+    if (!durablePromoteIntent && durableShareOperationId) {
+      // Older partial commits persisted the ID but not the exact timestamp and
+      // access envelope used on the wire. Reconstructing those fields from the
+      // later operation record can change a replay under the same ID, so this
+      // state is deliberately query/export-only until explicitly reconciled.
+      throw Object.assign(
+        new Error(
+          `Durable share operation ${durableShareOperationId} has no immutable promote intent and cannot be replayed safely`,
+        ),
+        { code: 'KA_PROMOTE_OPERATION_INTENT_MISSING' },
+      );
+    }
+
+    const operationIntent: PromoteOperationIntent = durablePromoteIntent ?? {
+      version: 1,
+      operationId,
+      timestampMs: Date.now(),
+      ...(opts?.publisherPeerId?.trim() ? { publisherPeerId: opts.publisherPeerId.trim() } : {}),
+      confirmationRequired: opts?.confirmBeforeCommit !== undefined,
+      accessPolicy: requestedAccessPolicy,
+      allowedPeers: requestedAllowedPeers,
+    };
+    const accessPolicy = operationIntent.accessPolicy;
+    const allowedPeers = operationIntent.allowedPeers;
+    const operationTimestamp = new Date(operationIntent.timestampMs);
+    if (opts?.confirmBeforeCommit && !operationIntent.publisherPeerId) {
+      throw Object.assign(
+        new Error('Curator-confirmed promote requires a publisherPeerId before claiming an operation ID'),
+        { code: 'KA_PROMOTE_PUBLISHER_PEER_REQUIRED' },
+      );
+    }
+    if (operationIntent.confirmationRequired && !opts?.confirmBeforeCommit) {
+      throw Object.assign(
+        new Error('This durable promote operation requires curator confirmation on every retry'),
+        { code: 'KA_PROMOTE_CONFIRMATION_REQUIRED' },
+      );
     }
     // Pre-encode gossip message and enforce size limit BEFORE any destructive
     // mutations, so oversized promotions are rejected cleanly while the
     // assertion is still intact in WM.
     let gossipMessage: Uint8Array | undefined;
-    if (opts?.publisherPeerId) {
+    const operationPublisherPeerId = operationIntent.publisherPeerId;
+    if (operationPublisherPeerId) {
       const dataGraph = this.graphManager.dataGraphUri(contextGraphId);
       const nquadsStr = normalizedQuads
         .map(
@@ -7117,16 +7811,16 @@ export class DKGPublisher implements Publisher {
             `<${q.subject}> <${q.predicate}> ${q.object.startsWith('"') ? q.object : `<${q.object}>`} <${dataGraph}> .`,
         )
         .join('\n');
-      const timestampMs = Date.now();
+      const timestampMs = operationIntent.timestampMs;
       const encoded = encodeWorkspacePublishRequest({
         contextGraphId: contextGraphId,
         nquads: new TextEncoder().encode(nquadsStr),
         manifest: [],
-        publisherPeerId: opts.publisherPeerId,
+        publisherPeerId: operationPublisherPeerId,
         shareOperationId: operationId,
         timestampMs,
         operationId,
-        subGraphName: opts.subGraphName,
+        subGraphName: opts?.subGraphName,
         agentAddress: contentScope.agentAddress,
         kaNumber: contentScope.kaNumber,
         contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
@@ -7151,15 +7845,12 @@ export class DKGPublisher implements Publisher {
         encoded,
         {
           localOnly: opts?.localOnly === true,
-          senderAgentAddress: opts.senderAgentAddress,
+          senderAgentAddress: opts?.senderAgentAddress,
           operationId,
           shareOperationId: operationId,
           timestampMs,
-          subGraphName: opts.subGraphName,
-          // Non-null: guarded by the enclosing `if (opts?.publisherPeerId)`. The
-          // tagPromoteStep thunk runs synchronously in-tick, but TS widens the
-          // narrowing across the closure boundary.
-          publisherPeerId: opts.publisherPeerId!,
+          subGraphName: opts?.subGraphName,
+          publisherPeerId: operationPublisherPeerId,
         },
       ));
 
@@ -7178,30 +7869,86 @@ export class DKGPublisher implements Publisher {
       gossipMessage = wrapped;
     }
 
+    // Persist the ID and its immutable envelope in one store call before any
+    // external confirmer can apply it. Every retry reuses these exact fields;
+    // one operation ID can never quietly acquire a new timestamp or policy.
+    const serializedOperationIntent = JSON.stringify(operationIntent);
+    const operationIdQuad: Quad = {
+      subject: lifecycleSubject,
+      predicate: SHARE_OPERATION_ID_PRED,
+      object: `"${operationId}"`,
+      graph: promoteMetaGraph,
+    };
+    const operationIntentQuad: Quad = {
+      subject: lifecycleSubject,
+      predicate: PROMOTE_OPERATION_INTENT_PRED,
+      object: JSON.stringify(serializedOperationIntent),
+      graph: promoteMetaGraph,
+    };
+    if (!durableShareOperationId) {
+      await this.store.insert([operationIdQuad, operationIntentQuad]);
+
+      // The in-memory lifecycle lock is deliberately instance-local. Re-read
+      // the claim after insertion so two daemon processes sharing one store
+      // cannot both pass an empty-state check and confirm different IDs. This
+      // is a conservative compare-after-insert: a collision may make both
+      // callers withdraw, but it can never let both escape externally.
+      const [claimedIdsResult, claimedIntentsResult] = await Promise.all([
+        this.store.query(
+          `SELECT ?id WHERE { GRAPH <${assertSafeIri(promoteMetaGraph)}> {
+            <${assertSafeIri(lifecycleSubject)}> <${SHARE_OPERATION_ID_PRED}> ?id
+          } } LIMIT 2`,
+        ),
+        this.store.query(
+          `SELECT ?intent WHERE { GRAPH <${assertSafeIri(promoteMetaGraph)}> {
+            <${assertSafeIri(lifecycleSubject)}> <${PROMOTE_OPERATION_INTENT_PRED}> ?intent
+          } } LIMIT 2`,
+        ),
+      ]);
+      const claimedId = claimedIdsResult.type === 'bindings'
+        && claimedIdsResult.bindings.length === 1
+        ? parsePlainLiteral(claimedIdsResult.bindings[0]?.['id'], 'KA_SHARE_OPERATION_ID_CORRUPT')
+        : undefined;
+      const claimedIntent = claimedIntentsResult.type === 'bindings'
+        && claimedIntentsResult.bindings.length === 1
+        ? parsePlainLiteral(
+            claimedIntentsResult.bindings[0]?.['intent'],
+            'KA_PROMOTE_OPERATION_INTENT_CORRUPT',
+          )
+        : undefined;
+      if (claimedId !== operationId || claimedIntent !== serializedOperationIntent) {
+        await this.store.delete([operationIdQuad, operationIntentQuad]);
+        throw Object.assign(
+          new Error(`A different promote operation already claimed assertion "${name}"`),
+          { code: 'KA_SHARE_OPERATION_ID_CONFLICT' },
+        );
+      }
+    }
+
     // Strict curator-ack gate (OT-RFC-49 curator-leader) for the WM→SWM promote
     // path — the same confirm-before-commit seam as `_shareImpl`, here between the
     // gossip-message build (above) and the SWM mutation (below). A non-confirmation
-    // aborts the promote with NO SWM mutation, leaving WM intact for retry. NB:
-    // unlike share()/_shareImpl this method holds no per-CG write lock, so the gate
-    // guarantees confirm-before-persist but not cross-write serialization —
-    // acceptable, since concurrent promotes of one assertion are not a supported
-    // pattern and the silent-loss property is confirm-or-abort. Fail closed if the
-    // message is somehow absent (cannot confirm what we cannot send).
+    // aborts the promote with NO SWM mutation, leaving WM intact for retry. The
+    // per-KA promote lock stays held across confirmation and the complete local
+    // commit, so concurrent callers cannot expose two operation IDs for one
+    // UAL/version. Fail closed if the message is somehow absent (cannot confirm
+    // what we cannot send).
     if (opts?.confirmBeforeCommit) {
       if (!gossipMessage) throw new CuratorUnconfirmedError(contextGraphId);
       const confirmation = await opts.confirmBeforeCommit(gossipMessage);
       if (!confirmation.applied) {
-        if (confirmation.rejected) throw new CuratorRejectedError(contextGraphId);
+        if (confirmation.rejected) {
+          // A definitive rejection proves the curator did not apply this
+          // provisional operation, so a corrected fresh-WM retry may claim a
+          // new ID. An ID that existed at method entry is never removed: an
+          // earlier ambiguous confirmation may already have applied it.
+          if (!durableShareOperationId) {
+            await this.store.delete([operationIdQuad, operationIntentQuad]);
+          }
+          throw new CuratorRejectedError(contextGraphId);
+        }
         throw new CuratorUnconfirmedError(contextGraphId);
       }
-    }
-
-    // A marker from an older interrupted ordering is not a completion proof:
-    // the immutable operation snapshot/head may still be missing. Clear it only
-    // after any required curator confirmation, then re-stamp it at the very end
-    // of the repaired commit tail.
-    if (resumingCommittedSwm) {
-      await maintainMarker(false);
     }
 
     // The UAL-derived graph is the ownership boundary. Replace the complete
@@ -7230,7 +7977,6 @@ export class DKGPublisher implements Publisher {
     }]);
     const promotedAllRoots = true; // compatibility return name; v2 has no roots.
     const isFullCompletePromote = true;
-    await clearCurrentShareOperationId();
     await this.store.deleteByPattern({ graph: promoteMetaGraph, subject: lifecycleSubject, predicate: DKG_ROOT_ENTITY_LEGACY });
     await this.store.deleteByPattern({ graph: promoteMetaGraph, subject: lifecycleSubject, predicate: DKG_ENTITY });
 
@@ -7243,7 +7989,7 @@ export class DKGPublisher implements Publisher {
       kaNumber: BigInt(contentScope.kaNumber),
       shareOperationId: operationId,
       rootEntities: [],
-      timestamp: new Date(),
+      timestamp: operationTimestamp,
     }, { provenanceEvents: this.provenanceEvents });
     await this.store.delete(promoted.delete);
     await this.store.insert(promoted.insert);
@@ -7258,12 +8004,12 @@ export class DKGPublisher implements Publisher {
       quads: swmQuads,
       ...(promotedPrivateRoot ? { privateMerkleRoot: promotedPrivateRoot } : {}),
       privateTripleCount: normalizedPrivateQuads.length,
-      publisherPeerId: opts?.publisherPeerId,
+      publisherPeerId: operationIntent.publisherPeerId,
       accessPolicy,
       allowedPeers,
       agentAddress: contentScope.agentAddress,
       subGraphName: opts?.subGraphName,
-      timestamp: new Date(),
+      timestamp: operationTimestamp,
       publicSnapshotStore: this.publicSnapshotStore,
     });
     // The originator does not receive its own GossipSub message, so it must
@@ -7296,12 +8042,44 @@ export class DKGPublisher implements Publisher {
     };
   }
 
-  async assertionDiscard(contextGraphId: string, name: string, agentAddress: string, subGraphName?: string): Promise<void> {
+  async assertionDiscard(
+    contextGraphId: string,
+    name: string,
+    agentAddress: string,
+    subGraphName?: string,
+  ): Promise<void> {
+    return this.withAssertionLifecycleWriteLock(
+      contextGraphId,
+      name,
+      agentAddress,
+      subGraphName,
+      () => this.assertionDiscardUnlocked(contextGraphId, name, agentAddress, subGraphName),
+    );
+  }
+
+  private async assertionDiscardUnlocked(
+    contextGraphId: string,
+    name: string,
+    agentAddress: string,
+    subGraphName?: string,
+  ): Promise<void> {
     DKGPublisher.validateOptionalSubGraph(subGraphName);
     await this.assertGraphScopedLifecycleWritable(
       contextGraphId,
       agentAddress,
       name,
+      subGraphName,
+    );
+    await this.assertNoUnfinishedAssertionPromote(
+      contextGraphId,
+      name,
+      agentAddress,
+      subGraphName,
+    );
+    await this.assertWorkingMemoryLifecycleMutable(
+      contextGraphId,
+      name,
+      agentAddress,
       subGraphName,
     );
     const graphUri = await this.wmGraphUri(contextGraphId, agentAddress, name, subGraphName);
@@ -7408,7 +8186,7 @@ export class DKGPublisher implements Publisher {
       // `seal.rootEntities` first, drive a discard → recreate → re-share →
       // seal-in-SWM reconstruction from the STALE roots. A discarded
       // (non-published) asset must leave NO seal.
-      await this.clearAssertionSeal(contextGraphId, name, agentAddress, subGraphName);
+      await this.clearAssertionSealUnlocked(contextGraphId, name, agentAddress, subGraphName);
     }
     await this.dropAssertionScopedGraphs(graphUri);
     await this.privateStore.deleteKnowledgeAssetPrivateDraft(
@@ -7443,6 +8221,29 @@ export class DKGPublisher implements Publisher {
    * `dkg:kaId`, and `dkg:swmCurrentAssertion`/`dkg:vmCurrentAssertion`.
    */
   async clearWmDraftDataGraph(
+    contextGraphId: string,
+    name: string,
+    agentAddress: string,
+    subGraphName?: string,
+  ): Promise<void> {
+    return this.withAssertionLifecycleWriteLock(
+      contextGraphId,
+      name,
+      agentAddress,
+      subGraphName,
+      async () => {
+        await this.assertNoUnfinishedAssertionPromote(
+          contextGraphId,
+          name,
+          agentAddress,
+          subGraphName,
+        );
+        await this.clearWmDraftDataGraphUnlocked(contextGraphId, name, agentAddress, subGraphName);
+      },
+    );
+  }
+
+  private async clearWmDraftDataGraphUnlocked(
     contextGraphId: string,
     name: string,
     agentAddress: string,

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -2,10 +2,12 @@ import type { NamedKnowledgeAssetGraphIdentity, Quad, SharedMemoryGraphScope, Tr
 import type { ChainAdapter, OnChainPublishResult, AddBatchToContextGraphParams } from '@origintrail-official/dkg-chain';
 import { enrichEvmError } from '@origintrail-official/dkg-chain';
 import type { EventBus, GraphKnowledgeAssetScope, OperationContext } from '@origintrail-official/dkg-core';
-import { DKGEvent, Logger, createOperationContext, sha256, encodeWorkspacePublishRequest, encodeEncryptedWorkspacePayload, encryptWorkspacePayload, contextGraphDataUri, contextGraphDataGraphUri, contextGraphMetaUri, contextGraphAssertionUri, contextGraphLayerUri, MemoryLayer, assertionLifecycleUri, contextGraphSubGraphUri, contextGraphSubGraphMetaUri, SYSTEM_CONTEXT_GRAPHS, validateSubGraphName, isSafeIri, assertSafeIri, assertSafeRdfTerm, assertQuadLiteralsMutf8Safe, DKG_GOSSIP_MAX_MESSAGE_BYTES, SwmGossipPayloadTooLargeError, STORAGE_ACK_MAX_STAGING_BYTES, type Ed25519Keypair, buildAuthorAttestationTypedData, buildUpdateAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1, TrustLevel, TRUST_LEVEL_PREDICATE, assertNoUserAuthoredTrustLevelQuads, buildTrustLevelQuads, isTrustLevelQuad, isSwmMerkleExcludedQuad, WORKSPACE_OWNER_PREDICATE, DKG_ENTITY, DKG_ROOT_ENTITY_LEGACY, ENTITY_PRED_ALT, parseAssertionSealQuads, ASSERTION_SEAL_PREDICATES, sharedMemoryReadBothFilter, DKG_ONTOLOGY, GRAPH_KA_CONTENT_SCOPE_VERSION, LegacyKnowledgeAssetReadOnlyError, createGraphKnowledgeAssetScope, knowledgeAssetLayerGraphUri } from '@origintrail-official/dkg-core';
+import type { AssertionSeal } from '@origintrail-official/dkg-core';
+import { DKGEvent, Logger, createOperationContext, sha256, encodeWorkspacePublishRequest, encodeEncryptedWorkspacePayload, encryptWorkspacePayload, contextGraphDataUri, contextGraphDataGraphUri, contextGraphMetaUri, contextGraphAssertionUri, contextGraphLayerUri, MemoryLayer, assertionLifecycleUri, contextGraphSubGraphUri, contextGraphSubGraphMetaUri, SYSTEM_CONTEXT_GRAPHS, validateSubGraphName, isSafeIri, assertSafeIri, assertSafeRdfTerm, assertQuadLiteralsMutf8Safe, DKG_GOSSIP_MAX_MESSAGE_BYTES, SwmGossipPayloadTooLargeError, STORAGE_ACK_MAX_STAGING_BYTES, type Ed25519Keypair, buildAuthorAttestationTypedData, buildUpdateAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1, TrustLevel, TRUST_LEVEL_PREDICATE, assertNoUserAuthoredTrustLevelQuads, buildTrustLevelQuads, isTrustLevelQuad, isSwmMerkleExcludedQuad, WORKSPACE_OWNER_PREDICATE, DKG_ENTITY, DKG_ROOT_ENTITY_LEGACY, ENTITY_PRED_ALT, parseAssertionSealQuads, ASSERTION_SEAL_PREDICATES, DKG_ONTOLOGY, GRAPH_KA_CONTENT_SCOPE_VERSION, LegacyKnowledgeAssetReadOnlyError, createGraphKnowledgeAssetScope, knowledgeAssetLayerGraphUri } from '@origintrail-official/dkg-core';
 import { GraphManager, PrivateContentStore, loadSharedMemoryQuadsForScope, loadSelectedSharedMemoryQuads, migrateSharedMemoryRootClosureToNamedLifecycle, resolveSharedMemoryScopeGraphs, tryReplaceGraphAtomically, type NamedLifecycleSharedMemoryMigrationResult } from '@origintrail-official/dkg-storage';
 import { DEFAULT_PUBLISH_EPOCHS, MAX_PUBLISH_EPOCHS, type Publisher, type PublishOptions, type PublishResult, type KAManifestEntry, type PhaseCallback, type V10CoreNodeACK, type V10ACKProviderParams, type V10ACKProviderObject, type LegacyV10ACKProvider } from './publisher.js';
 import { assertNoUserAuthoredKnowledgeAssetSkolemTerms, skolemizeByEntity, skolemizeKnowledgeAsset, skolemizeKnowledgeAssetParts } from './auto-partition.js';
+import { assertNoKnowledgeAssetPayloadNamedGraphs } from './knowledge-asset-graph-policy.js';
 import { withKeyedLocks } from './keyed-lock.js';
 import { tagPromoteStep } from './promote-step-tag.js';
 import { canonicalPublishPayload } from './canonical-publish-payload.js';
@@ -106,6 +108,67 @@ export {
 // member rows — cannot be sealed-in-SWM and published as a partial asset.
 const SWM_SHARE_COMPLETE_PRED = 'http://dkg.io/ontology/swmShareComplete';
 const SHARE_OPERATION_ID_PRED = 'http://dkg.io/ontology/shareOperationId';
+
+async function validateGraphScopedPayloadAgainstSeal(
+  seal: AssertionSeal,
+  publicQuads: readonly Quad[],
+  privateQuads: readonly Quad[],
+  sourceLabel: string,
+): Promise<{
+  normalizedPublicQuads: Quad[];
+  normalizedPrivateQuads: Quad[];
+  privateMerkleRoot: Uint8Array | undefined;
+}> {
+  assertNoKnowledgeAssetPayloadNamedGraphs(publicQuads, privateQuads);
+  const normalizedParts = await skolemizeKnowledgeAssetParts(
+    [...publicQuads],
+    [...privateQuads],
+    { allowCanonicalSkolemTerms: true },
+  );
+  const normalizedPublicQuads = normalizedParts.publicQuads;
+  const normalizedPrivateQuads = normalizedParts.privateQuads;
+  if (normalizedPublicQuads.length !== seal.publicTripleCount) {
+    throw new Error(
+      `Graph-scoped assertion triple-count mismatch: seal=${seal.publicTripleCount}, `
+      + `${sourceLabel}=${normalizedPublicQuads.length}`,
+    );
+  }
+  if (normalizedPrivateQuads.length !== seal.privateTripleCount) {
+    throw new Error(
+      `Graph-scoped assertion private triple-count mismatch: seal=${seal.privateTripleCount}, `
+      + `private-store=${normalizedPrivateQuads.length}`,
+    );
+  }
+  const privateMerkleRoot = computePrivateRoot(normalizedPrivateQuads);
+  const privateRootMatches = seal.privateMerkleRoot === undefined
+    ? privateMerkleRoot === undefined
+    : privateMerkleRoot !== undefined
+      && seal.privateMerkleRoot.length === privateMerkleRoot.length
+      && seal.privateMerkleRoot.every((byte, index) => byte === privateMerkleRoot[index]);
+  if (!privateRootMatches) {
+    throw new Error(
+      `Graph-scoped assertion private Merkle mismatch: seal=${seal.privateMerkleRoot
+        ? ethers.hexlify(seal.privateMerkleRoot)
+        : '(none)'}, private-store=${privateMerkleRoot
+        ? ethers.hexlify(privateMerkleRoot)
+        : '(none)'}`,
+    );
+  }
+  const merkleRoot = computeFlatKCRoot(
+    normalizedPublicQuads,
+    privateMerkleRoot ? [privateMerkleRoot] : [],
+  );
+  if (
+    merkleRoot.length !== seal.merkleRoot.length
+    || !merkleRoot.every((byte, index) => byte === seal.merkleRoot[index])
+  ) {
+    throw new Error(
+      `Graph-scoped assertion Merkle mismatch: seal=${ethers.hexlify(seal.merkleRoot)}, `
+      + `${sourceLabel}=${ethers.hexlify(merkleRoot)}`,
+    );
+  }
+  return { normalizedPublicQuads, normalizedPrivateQuads, privateMerkleRoot };
+}
 
 async function listGraphFamily(store: TripleStore, rootGraph: string): Promise<string[]> {
   const graphs = await listGraphsByPrefix(store, `${rootGraph}/`);
@@ -6314,15 +6377,6 @@ export class DKGPublisher implements Publisher {
       `${A2_DKG}contentScopeVersion`,
       `${A2_DKG}assertionVersion`,
       'http://www.w3.org/ns/prov#wasRevisionOf',
-      // #1116: the promote-stamped member rows (dkg:rootEntity / dkg:entity) are
-      // the SEAL-INDEPENDENT recovery source readPromotedRootEntities uses. Pull-from
-      // (the seal-in-SWM reconstruction path) MUST preserve them across this
-      // clean-slate, otherwise a finalize that fails AFTER the re-seed would leave
-      // the asset with neither a seal nor the member rows — stranding the very asset
-      // seal-in-SWM exists to rescue (a non-atomic recovery). Keeping them makes
-      // finalize layer=swm safely retryable.
-      `${A2_DKG}rootEntity`,
-      `${A2_DKG}entity`,
       // #1116 (review A1): the full-SWM-share marker that gates finalize(layer:"swm").
       // pull-from's clean-slate (the seal-in-SWM reconstruction) MUST preserve it,
       // or a finalize that fails after the re-seed would strip the marker and make
@@ -6493,6 +6547,10 @@ export class DKGPublisher implements Publisher {
     input: Quad[],
     subGraphName?: string,
   ): Promise<void> {
+    // Private draft storage is triple-scoped and deliberately replaces the
+    // physical graph term. Reject RDF named-graph identity before that write so
+    // it cannot be silently erased and later sealed as a different dataset.
+    assertNoKnowledgeAssetPayloadNamedGraphs(input);
     rejectUserAuthoredProtocolMetadata(input.map((quad) => ({ ...quad, graph: '' })));
     await this.ensureSubGraphRegistered(contextGraphId, subGraphName);
     await this.assertGraphScopedLifecycleWritable(
@@ -6538,18 +6596,13 @@ export class DKGPublisher implements Publisher {
   }
 
   /**
-   * OT-RFC-43 §10.5.3 — `wm/pull-from`: seed a fresh WM draft from this file's
-   * current SWM or VM state (the `git checkout origin/<branch>` equivalent).
+   * Re-open one sealed rootless KA from its exact SWM or VM graph.
    *
-   * WM is the only writable surface; to edit content that already lives in SWM
-   * or VM you pull it into a new WM draft, edit, then re-share / re-publish.
-   * The file's entity set is read from the assertion seal (on the lifecycle
-   * URN); the source layer's quads for those entities (+ their skolemized
-   * children) are gathered and written into a fresh WM draft.
-   *
-   * `onConflict` applies only when the WM draft already holds content:
-   *   - 'reject' (default): throw `WM_DRAFT_CONFLICT` — the caller decides.
-   *   - 'replace': discard the open draft, then seed fresh (git force-checkout).
+   * V2 never reconstructs content from root/member rows or scans a shared
+   * bucket. The seal's (UAL, assertionVersion) tuple resolves one physical
+   * source graph, and the complete public/private payload is verified against
+   * that seal before any existing draft is removed. Legacy KAs remain readable
+   * through query/export surfaces but cannot enter this mutation path.
    */
   async assertionPullFrom(
     contextGraphId: string,
@@ -6557,26 +6610,85 @@ export class DKGPublisher implements Publisher {
     agentAddress: string,
     sourceLayer: 'swm' | 'vm',
     opts?: { subGraphName?: string; onConflict?: 'reject' | 'replace' },
-  ): Promise<{ seeded: number; fromLayer: 'swm' | 'vm'; entities: number }> {
+  ): Promise<{
+    seeded: number;
+    seededPublic: number;
+    seededPrivate: number;
+    fromLayer: 'swm' | 'vm';
+    contentScopeVersion: number;
+    kaUal: string;
+    assertionVersion: string;
+  }> {
     const subGraphName = opts?.subGraphName;
-    // PR #972/a6740ac: ensure the (sub)graph is registered so a sub-scoped VM
-    // pull can resolve its data graph below (was a pure name-format validation).
     await this.ensureSubGraphRegistered(contextGraphId, subGraphName);
-    const wmGraph = await this.wmGraphUri(contextGraphId, agentAddress, name, subGraphName);
     const metaGraph = contextGraphMetaUri(contextGraphId);
-    const sourceGraph = sourceLayer === 'swm'
-      ? this.graphManager.sharedMemoryUri(contextGraphId, subGraphName)
-      // PR #972/a6740ac: a sub-scoped VM pull reads the SUBGRAPH's data graph,
-      // not the root data graph (mirrors the SWM branch's subGraphName handling).
-      : subGraphName
-        ? this.graphManager.subGraphUri(contextGraphId, subGraphName)
-        : this.graphManager.dataGraphUri(contextGraphId);
+    const sealSubject = contextGraphAssertionUri(contextGraphId, agentAddress, name, subGraphName);
+    const currentWmGraph = await this.wmGraphUri(
+      contextGraphId,
+      agentAddress,
+      name,
+      subGraphName,
+    );
+    const candidateSealSubjects = currentWmGraph === sealSubject
+      ? [sealSubject]
+      : [sealSubject, currentWmGraph];
+    let seal: AssertionSeal | undefined;
+    for (const candidate of candidateSealSubjects) {
+      const sealResult = await this.store.query(
+        `CONSTRUCT { <${candidate}> ?p ?o } WHERE {
+          GRAPH <${metaGraph}> { <${candidate}> ?p ?o }
+        }`,
+      );
+      seal = parseAssertionSealQuads(
+        sealResult.type === 'quads' ? sealResult.quads : [],
+        candidate,
+      );
+      if (seal) break;
+    }
+    if (!seal) {
+      throw Object.assign(
+        new Error(
+          `Cannot pull "${name}" from ${sourceLayer.toUpperCase()}: rootless mutation requires a finalized v2 assertion seal`,
+        ),
+        { code: 'UNSEALED_PULL_FROM_BLOCKED' },
+      );
+    }
+    if (seal.contentScopeVersion !== GRAPH_KA_CONTENT_SCOPE_VERSION) {
+      throw new LegacyKnowledgeAssetReadOnlyError();
+    }
+    if (
+      !seal.kaUal
+      || !seal.assertionVersion
+      || seal.publicTripleCount === undefined
+      || seal.privateTripleCount === undefined
+    ) {
+      throw new Error(`Graph-scoped assertion seal for <${sealSubject}> is incomplete`);
+    }
 
-    // onConflict: refuse to clobber a dirty WM draft unless told to replace it.
-    // NB: the actual DROP happens only AFTER the source is validated non-empty
-    // (below) — PR #972/335e8d8: dropping first could destroy an open draft when
-    // the pull turns out to have no source quads.
-    const hasDraft = await this.assertionScopedHasQuads(wmGraph);
+    const scope = createGraphKnowledgeAssetScope(seal.kaUal, seal.assertionVersion);
+    const wmGraph = knowledgeAssetLayerGraphUri(
+      contextGraphId,
+      MemoryLayer.WorkingMemory,
+      scope,
+      subGraphName,
+    );
+    const sourceGraph = knowledgeAssetLayerGraphUri(
+      contextGraphId,
+      sourceLayer === 'swm'
+        ? MemoryLayer.SharedWorkingMemory
+        : MemoryLayer.VerifiableMemory,
+      scope,
+      subGraphName,
+    );
+
+    const publicDraftExists = await this.assertionScopedHasQuads(wmGraph);
+    const privateDraft = await this.privateStore.getKnowledgeAssetPrivateDraftTriples(
+      contextGraphId,
+      agentAddress,
+      name,
+      subGraphName,
+    );
+    const hasDraft = publicDraftExists || privateDraft.length > 0;
     if (hasDraft && (opts?.onConflict ?? 'reject') === 'reject') {
       throw Object.assign(
         new Error(`A WM draft already exists for "${name}" in context graph "${contextGraphId}"; pass onConflict:"replace" to overwrite it.`),
@@ -6584,149 +6696,68 @@ export class DKGPublisher implements Publisher {
       );
     }
 
-    // Resolve the file's member entities from the SEAL. PR #972/335e8d8: the
-    // seal is stamped at finalize under the assertion-graph URI
-    // (`contextGraphAssertionUri`) in the meta graph — NOT under the
-    // lifecycle URN. The prior code read `assertionLifecycleUri`, a
-    // different subject, so the lookup found nothing and pull-from failed for
-    // EVERY finalized assertion.
-    //
-    // #1094: the same class of bug, second occurrence. `wmGraphUri()` only
-    // equals `contextGraphAssertionUri` BEFORE a kaId is minted; finalize
-    // stamps `dkg:kaId`, after which `wmGraphUri()` resolves to the numbered
-    // per-KA layer URI (`…/_working_memory/<addr>/<n>`). Reading the seal
-    // under `wmGraph` therefore failed for every finalized-AND-minted
-    // assertion — exactly the population pull-from exists for. The seal's
-    // canonical subject is the name-keyed assertion URI; check it first and
-    // keep the wmGraph subject as a legacy fallback (they coincide pre-mint).
-    const sealSubject = contextGraphAssertionUri(contextGraphId, agentAddress, name, subGraphName);
-    let sealRes = await this.store.query(
-      `CONSTRUCT { <${sealSubject}> ?p ?o } WHERE { GRAPH <${metaGraph}> { <${sealSubject}> ?p ?o } }`,
+    const sourcePublicQuads = (await this.assertionScopedQuads(sourceGraph)).filter(
+      (quad) => !isSwmMerkleExcludedQuad(quad),
     );
-    let seal = parseAssertionSealQuads(sealRes.type === 'quads' ? sealRes.quads : [], sealSubject);
-    if (!seal && wmGraph !== sealSubject) {
-      sealRes = await this.store.query(
-        `CONSTRUCT { <${wmGraph}> ?p ?o } WHERE { GRAPH <${metaGraph}> { <${wmGraph}> ?p ?o } }`,
-      );
-      seal = parseAssertionSealQuads(sealRes.type === 'quads' ? sealRes.quads : [], wmGraph);
-    }
-    // #1116: a seal is no longer required to pull from SWM. When the asset was
-    // shared UNSEALED (a `skipSeal` share, or an asset stuck unsealed under the
-    // old auto-finalize-swallow behavior), fall back to the member entities
-    // stamped on the lifecycle URN by every promote
-    // (`generateAssertionPromotedMetadata`, predicate dkg:rootEntity) — recorded
-    // independent of any seal. This is what lets seal-in-SWM (finalize
-    // layer=swm) and recovery reconstruct the WM draft without first finalizing.
-    // VM pulls still require the seal (VM content is keyed by the published
-    // roots, which only the seal records).
-    // #1116 (review A1, rounds 5/7/8) — the SWM reconstruction is the ROOT of the
-    // subset-publishability bypass, and the guard MUST live here at the single
-    // publisher chokepoint so EVERY caller is covered (the finalize(layer:"swm")
-    // wrapper AND the direct wm/pull-from route + a plain finalize).
-    //
-    // Crucially, an SWM pull must NEVER trust the seal's rootEntities for scope:
-    // a stale FULL seal survives a SUBSET re-share (a subset share never
-    // re-seals, and `create` without a discard does not clear the seal — it lives
-    // on the name-keyed assertion URI, outside the lifecycle-URN clean-slate). If
-    // we read that stale seal it would short-circuit the subset gate below and let
-    // the direct route reconstruct + publish a superseded/partial asset under the
-    // KA name (round-8 live repro). So for SWM we ALWAYS resolve from the
-    // promote-stamped member rows, gated on the full-share completeness marker —
-    // the seal is rebuilt at the next finalize anyway (and torn down below). VM
-    // pulls still use the seal (VM content is keyed by the published roots, which
-    // only the seal records).
-    let entities: string[];
-    if (sourceLayer === 'swm') {
-      const promotedRoots = await this.readPromotedRootEntities(contextGraphId, agentAddress, name, subGraphName);
-      if (promotedRoots.length > 0) {
-        const fullyShared = await this.hasSwmShareComplete(contextGraphId, name, agentAddress, subGraphName);
-        if (!fullyShared) {
-          throw Object.assign(
-            new Error(
-              `"${name}" in context graph "${contextGraphId}" was only shared to SWM as a SUBSET — `
-              + `reconstructing or sealing it would publish a partial asset under the KA name. `
-              + `Share the full asset (entities:"all") before sealing in SWM.`,
-            ),
-            { code: 'SWM_SUBSET_NOT_SEALABLE' },
-          );
-        }
-      }
-      entities = promotedRoots;
-    } else {
-      entities = seal?.rootEntities ?? [];
-    }
-    if (entities.length === 0) {
-      throw new Error(
-        `No member entities for "${name}" in context graph "${contextGraphId}" — pull-from `
-        + `requires either a finalized assertion (its seal records the members) or a prior `
-        + `promote to SWM (which stamps the members on the lifecycle record). Found neither.`,
-      );
-    }
-
-    // Gather the source-layer quads scoped to the entity set + skolem children
-    // (same filter the publish gather / RS prover use), minus trust/ownership
-    // bookkeeping that never belongs in a working draft.
-    const values = entities.map((e) => `<${e}>`).join(' ');
-    // #1094: a per-KA `vm/publish` writes the canonical quads into the
-    // numbered per-KA VM graph `…/_verifiable_memory/{author}/{number}`
-    // (see SUBSTRATE-2 in dkg-agent-publish.ts) and, for on-chain CGs,
-    // into the per-on-chain-id partition `…/context/{ctxGraphId}` — NOT
-    // (only) the bare data graph this branch used to read. Pulling from
-    // "vm" therefore came back empty for exactly the published KAs the
-    // edit loop exists for. Scan the data graph PLUS both VM-side graph
-    // families; CONSTRUCT output is a set, so overlapping copies dedup.
-    const vmBase = subGraphName
-      ? `did:dkg:context-graph:${contextGraphId}/${subGraphName}`
-      : `did:dkg:context-graph:${contextGraphId}`;
-    const vmGraphFilter =
-      `FILTER(STR(?g) = "${sourceGraph}" ` +
-      `|| STRSTARTS(STR(?g), "${vmBase}/_verifiable_memory/") ` +
-      `|| STRSTARTS(STR(?g), "did:dkg:context-graph:${contextGraphId}/context/"))`;
-    // Per-KA SWM: when pulling from SWM the source spans the per-KA prefix, not one bucket.
-    const sourcePattern = sourceLayer === 'swm'
-      ? `GRAPH ?g { VALUES ?root { ${values} } ?s ?p ?o . FILTER(?s = ?root || STRSTARTS(STR(?s), CONCAT(STR(?root), "/.well-known/genid/"))) } ${sharedMemoryReadBothFilter(sourceGraph)}`
-      : `GRAPH ?g { VALUES ?root { ${values} } ?s ?p ?o . FILTER(?s = ?root || STRSTARTS(STR(?s), CONCAT(STR(?root), "/.well-known/genid/"))) } ${vmGraphFilter}`;
-    const gather = await this.store.query(
-      `CONSTRUCT { ?s ?p ?o } WHERE { ${sourcePattern} }`,
+    const sourcePrivateQuads = await this.privateStore.getKnowledgeAssetPrivateTriples(
+      contextGraphId,
+      scope,
+      subGraphName,
     );
-    const gathered = gather.type === 'quads'
-      ? gather.quads.filter((q) => !isSwmMerkleExcludedQuad(q))
-      : [];
-
-    // Validate the source has content BEFORE touching the draft (PR #972/335e8d8:
-    // a drop-before-validate could destroy an open WM draft when the source
-    // turned out empty — e.g. pulling from a layer the file was never shared to).
-    if (gathered.length === 0) {
+    if (sourcePublicQuads.length === 0 && sourcePrivateQuads.length === 0) {
       throw Object.assign(
         new Error(
-          `No ${sourceLayer.toUpperCase()} quads found for "${name}" in context graph "${contextGraphId}" `
-          + `using the assertion seal's ${entities.length} root entit${entities.length === 1 ? 'y' : 'ies'}; `
-          + `WM draft was not modified.`,
+          `No exact ${sourceLayer.toUpperCase()} content found for sealed KA ${scope.ual} assertion ${scope.assertionVersion}; WM draft was not modified.`,
         ),
         { code: 'PULL_FROM_EMPTY_SOURCE' },
       );
     }
+    const validated = await validateGraphScopedPayloadAgainstSeal(
+      seal,
+      sourcePublicQuads,
+      sourcePrivateQuads,
+      `${sourceLayer}-memory`,
+    );
 
-    // Source validated — now (re)open a fresh WM draft (clears stale
-    // lifecycle/seal) and seed it.
+    // The complete source has been validated. Only now is replace allowed to
+    // remove a dirty public or private draft.
     if (hasDraft) {
-      await this.dropAssertionScopedGraphs(wmGraph); // 'replace' — git force-checkout, after source validation
+      await this.dropAssertionScopedGraphs(wmGraph);
+      await this.privateStore.deleteKnowledgeAssetPrivateDraft(
+        contextGraphId,
+        agentAddress,
+        name,
+        subGraphName,
+      );
     }
     await this.assertionCreate(contextGraphId, name, agentAddress, subGraphName);
-    // #1094: `assertionCreate`'s clean-slate wipe only covers subjects under
-    // the lifecycle URN — the SEAL lives under the name-keyed assertion URI
-    // (and pre-mint legacy seals under the numbered WM URI), so it survived
-    // every pull-from. The next `wm/finalize` of the edited draft then hit
-    // "already finalized with a different merkleRoot" and the edit loop was
-    // permanently wedged. Pull-from re-opens the draft for editing, so the
-    // stale seal MUST go (it is rebuilt — same reservedKaId, preserved by
-    // assertionCreate's A2 carry-over — at the next finalize). Reuse the single
-    // clearAssertionSeal helper so the seal subject/predicate set has one source
-    // of truth (sealSubject == the helper's name-keyed assertion URI; wmGraph is
-    // re-resolved identically).
     await this.clearAssertionSeal(contextGraphId, name, agentAddress, subGraphName);
-    await this.assertionWrite(contextGraphId, name, agentAddress, gathered, subGraphName);
-    return { seeded: gathered.length, fromLayer: sourceLayer, entities: entities.length };
+    // The source was already canonicalized and seal-verified. Re-materialize it
+    // through the internal exact-graph primitive: public assertionWrite rightly
+    // rejects protocol-owned c14n skolem IRIs as user input.
+    await this.replaceExactKnowledgeAssetGraph(
+      wmGraph,
+      validated.normalizedPublicQuads,
+      'Knowledge Asset pull-from',
+    );
+    if (validated.normalizedPrivateQuads.length > 0) {
+      await this.privateStore.storeKnowledgeAssetPrivateDraftTriples(
+        contextGraphId,
+        agentAddress,
+        name,
+        validated.normalizedPrivateQuads,
+        subGraphName,
+      );
+    }
+    return {
+      seeded: validated.normalizedPublicQuads.length + validated.normalizedPrivateQuads.length,
+      seededPublic: validated.normalizedPublicQuads.length,
+      seededPrivate: validated.normalizedPrivateQuads.length,
+      fromLayer: sourceLayer,
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      kaUal: scope.ual,
+      assertionVersion: scope.assertionVersion,
+    };
   }
 
   async assertionPromote(
@@ -6832,6 +6863,12 @@ export class DKGPublisher implements Publisher {
       contentScope,
       opts?.subGraphName,
     );
+    const vmGraphUri = knowledgeAssetLayerGraphUri(
+      contextGraphId,
+      MemoryLayer.VerifiableMemory,
+      contentScope,
+      opts?.subGraphName,
+    );
 
     // #1116 (round 10) — the swmShareComplete marker MUST be maintained on EVERY
     // return path of assertionPromote, not just the success tail. A non-full share
@@ -6861,7 +6898,88 @@ export class DKGPublisher implements Publisher {
       }
     };
 
-    const assertionQuads = await tagPromoteStep('assertionScopedQuads', () => this.assertionScopedQuads(graphUri));
+    let assertionQuads = await tagPromoteStep(
+      'assertionScopedQuads',
+      () => this.assertionScopedQuads(graphUri),
+    );
+    const lifecycleStateResult = await this.store.query(
+      `SELECT ?layer ?shareOperationId WHERE { GRAPH <${assertSafeIri(promoteMetaGraph)}> {
+        OPTIONAL {
+          <${assertSafeIri(lifecycleSubject)}> <http://dkg.io/ontology/memoryLayer> ?layer
+        }
+        OPTIONAL {
+          <${assertSafeIri(lifecycleSubject)}> <${SHARE_OPERATION_ID_PRED}> ?shareOperationId
+        }
+      } } LIMIT 1`,
+    );
+    const lifecycleState = lifecycleStateResult.type === 'bindings'
+      ? lifecycleStateResult.bindings[0]
+      : undefined;
+    const lifecycleLayer = stripOptionalLiteral(lifecycleState?.['layer']);
+    const durableShareOperationId = stripOptionalLiteral(
+      lifecycleState?.['shareOperationId'],
+    );
+    let resumingCommittedSwm = false;
+    if (assertionQuads.length === 0) {
+      if (lifecycleLayer === MemoryLayer.VerifiableMemory) {
+        // A confirmed publish consumes SWM and leaves WM empty. A stale retry
+        // must be a non-mutating no-op, but only after the exact VM graph and
+        // immutable private partition still validate against the persisted seal.
+        // This retains the old idempotency guarantee without trusting legacy
+        // extraction markers or reconstructing scope from RDF subjects.
+        const existingVmQuads = (await this.assertionScopedQuads(vmGraphUri)).filter(
+          (quad) => !isReservedSubject(quad.subject) && !isTrustLevelQuad(quad),
+        );
+        const existingPrivateQuads = immutablePrivateQuads.filter(
+          (quad) => !isReservedSubject(quad.subject) && !isTrustLevelQuad(quad),
+        );
+        await validateGraphScopedPayloadAgainstSeal(
+          seal,
+          existingVmQuads,
+          existingPrivateQuads,
+          'verifiable-memory',
+        );
+        await maintainMarker(false);
+        return { promotedCount: 0, promotedAllRoots: false };
+      }
+
+      const existingSwmQuads = (await this.assertionScopedQuads(swmGraphUri)).filter(
+        (quad) => !isReservedSubject(quad.subject) && !isTrustLevelQuad(quad),
+      );
+      const hasCompletionMarker = await this.hasSwmShareComplete(
+        contextGraphId,
+        name,
+        agentAddress,
+        opts?.subGraphName,
+      );
+      if (
+        hasCompletionMarker
+        || lifecycleLayer === MemoryLayer.SharedWorkingMemory
+        || existingSwmQuads.length > 0
+      ) {
+        // A completed promote deliberately removes WM. A crash can also land
+        // the exact SWM graph before the lifecycle, operation snapshot, head,
+        // or completion marker. Validate the complete sealed payload and then
+        // run the idempotent commit tail again so a retry repairs every durable
+        // record and returns gossip for replay instead of merely saying no-op.
+        const existingPrivateQuads = immutablePrivateQuads.filter(
+          (quad) => !isReservedSubject(quad.subject) && !isTrustLevelQuad(quad),
+        );
+        try {
+          await validateGraphScopedPayloadAgainstSeal(
+            seal,
+            existingSwmQuads,
+            existingPrivateQuads,
+            'shared-memory',
+          );
+        } catch (error) {
+          await maintainMarker(false);
+          throw error;
+        }
+        assertionQuads = existingSwmQuads;
+        resumingCommittedSwm = true;
+      }
+    }
     if (assertionQuads.length === 0 && immutablePrivateQuads.length === 0) {
       await maintainMarker(false);
       throw Object.assign(
@@ -6955,33 +7073,27 @@ export class DKGPublisher implements Publisher {
       );
     }
 
-    const namedGraphs = [...new Set(quadsToPromote
-      .map((q) => q.graph)
-      .filter((graph): graph is string => typeof graph === 'string' && graph.length > 0))];
-    if (namedGraphs.length > 0) {
-      await maintainMarker(false);
-      throw Object.assign(
-        new Error(
-          'Knowledge Asset contains RDF named-graph quads, but SWM share and VM publish do not yet preserve original graph identity. '
-          + 'Rewrite the payload into the default graph before sharing, or keep the KA in WM until graph-preserving SWM/VM semantics are implemented.',
-        ),
-        { code: 'KA_NAMED_GRAPH_SHARE_UNSUPPORTED', namedGraphs },
-      );
-    }
-
-    const operationId = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+    const operationId = resumingCommittedSwm && durableShareOperationId
+      ? durableShareOperationId
+      : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
 
     // Canonicalize both partitions together so blank-node labels stay stable
     // across the public/private boundary and validate the complete sealed KA.
-    const normalizedParts = await skolemizeKnowledgeAssetParts(
-      quadsToPromote,
-      privateQuadsToPromote,
-      {
-      allowCanonicalSkolemTerms: true,
-      },
-    );
-    const normalizedQuads = normalizedParts.publicQuads;
-    const normalizedPrivateQuads = normalizedParts.privateQuads;
+    let validatedPayload: Awaited<ReturnType<typeof validateGraphScopedPayloadAgainstSeal>>;
+    try {
+      validatedPayload = await validateGraphScopedPayloadAgainstSeal(
+        seal,
+        quadsToPromote,
+        privateQuadsToPromote,
+        'working-memory',
+      );
+    } catch (error) {
+      await maintainMarker(false);
+      throw error;
+    }
+    const normalizedQuads = validatedPayload.normalizedPublicQuads;
+    const normalizedPrivateQuads = validatedPayload.normalizedPrivateQuads;
+    const promotedPrivateRoot = validatedPayload.privateMerkleRoot;
     const accessPolicy = opts?.accessPolicy
       ?? (normalizedPrivateQuads.length > 0 ? 'ownerOnly' : 'public');
     const allowedPeers = [...new Set(
@@ -6993,47 +7105,6 @@ export class DKGPublisher implements Publisher {
     if (accessPolicy !== 'allowList' && allowedPeers.length > 0) {
       throw new Error('Graph-scoped assertion allowedPeers requires allowList policy');
     }
-    if (normalizedQuads.length !== seal.publicTripleCount) {
-      throw new Error(
-        `Graph-scoped assertion triple-count mismatch: seal=${seal.publicTripleCount}, ` +
-        `working-memory=${normalizedQuads.length}`,
-      );
-    }
-    if (normalizedPrivateQuads.length !== seal.privateTripleCount) {
-      throw new Error(
-        `Graph-scoped assertion private triple-count mismatch: seal=${seal.privateTripleCount}, ` +
-        `private-store=${normalizedPrivateQuads.length}`,
-      );
-    }
-    const promotedPrivateRoot = computePrivateRoot(normalizedPrivateQuads);
-    const privateRootMatches = seal.privateMerkleRoot === undefined
-      ? promotedPrivateRoot === undefined
-      : promotedPrivateRoot !== undefined
-        && seal.privateMerkleRoot.length === promotedPrivateRoot.length
-        && seal.privateMerkleRoot.every((byte, index) => byte === promotedPrivateRoot[index]);
-    if (!privateRootMatches) {
-      throw new Error(
-        `Graph-scoped assertion private Merkle mismatch: seal=${seal.privateMerkleRoot
-          ? ethers.hexlify(seal.privateMerkleRoot)
-          : '(none)'}, private-store=${promotedPrivateRoot
-          ? ethers.hexlify(promotedPrivateRoot)
-          : '(none)'}`,
-      );
-    }
-    const promotedMerkleRoot = computeFlatKCRoot(
-      normalizedQuads,
-      promotedPrivateRoot ? [promotedPrivateRoot] : [],
-    );
-    if (
-      promotedMerkleRoot.length !== seal.merkleRoot.length ||
-      !promotedMerkleRoot.every((byte, index) => byte === seal.merkleRoot[index])
-    ) {
-      throw new Error(
-        `Graph-scoped assertion Merkle mismatch: seal=${ethers.hexlify(seal.merkleRoot)}, ` +
-        `working-memory=${ethers.hexlify(promotedMerkleRoot)}`,
-      );
-    }
-
     // Pre-encode gossip message and enforce size limit BEFORE any destructive
     // mutations, so oversized promotions are rejected cleanly while the
     // assertion is still intact in WM.
@@ -7125,6 +7196,14 @@ export class DKGPublisher implements Publisher {
       }
     }
 
+    // A marker from an older interrupted ordering is not a completion proof:
+    // the immutable operation snapshot/head may still be missing. Clear it only
+    // after any required curator confirmation, then re-stamp it at the very end
+    // of the repaired commit tail.
+    if (resumingCommittedSwm) {
+      await maintainMarker(false);
+    }
+
     // The UAL-derived graph is the ownership boundary. Replace the complete
     // graph; never inspect, claim, skip, or delete individual RDF subjects.
     const swmQuads = normalizedQuads.map((q) => ({ ...q, graph: swmGraphUri }));
@@ -7169,16 +7248,6 @@ export class DKGPublisher implements Publisher {
     await this.store.delete(promoted.delete);
     await this.store.insert(promoted.insert);
 
-    // #1116 (round 9/10) — CO-LOCATE the swmShareComplete marker with the
-    // member-row REPLACE above, at the single publisher chokepoint, via the same
-    // `maintainMarker` helper every early-return uses. The marker and the member
-    // rows MUST stay in lockstep: the marker says "the member rows describe a
-    // complete full share". A FULL-COMPLETE promote (entities:"all" + no foreign
-    // root skipped) SETS it; any other promote (subset/foreign-skipped) CLEARS it.
-    // Doing it in the publisher (not the agent wrapper) keeps the invariant for
-    // EVERY caller of the public assertionPromote — no desync on a direct caller.
-    await maintainMarker(isFullCompletePromote);
-
     await storeKnowledgeAssetOperationPublicQuads({
       store: this.store,
       graphManager: this.graphManager,
@@ -7211,8 +7280,16 @@ export class DKGPublisher implements Publisher {
       subGraphName: opts?.subGraphName,
     });
 
+    // This is the final commit record. It is intentionally written only after
+    // the exact SWM graph, lifecycle operation id, immutable operation snapshot,
+    // and monotonic KA head are durable. A retry that sees any earlier partial
+    // state repairs the tail above before this marker can become visible.
+    await maintainMarker(isFullCompletePromote);
+
     return {
-      promotedCount: swmQuads.length + normalizedPrivateQuads.length,
+      promotedCount: resumingCommittedSwm
+        ? 0
+        : swmQuads.length + normalizedPrivateQuads.length,
       gossipMessage,
       promotedAllRoots,
       shareOperationId: operationId,

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -276,7 +276,10 @@ export interface DKGPublisherConfig {
   sharedMemoryOwnedEntities?: Map<string, Map<string, string>>;
   /** Shared batch→context graph binding map. Pass to UpdateHandler so it uses trusted local bindings. */
   knownBatchContextGraphs?: Map<string, string>;
-  /** Shared write lock map. Pass to SharedMemoryHandler so gossip writes serialize against CAS writes. */
+  /**
+   * Explicit lifecycle write-lock domain. Publishers and handlers that mutate
+   * the same store must receive the same map from their application factory.
+   */
   writeLocks?: Map<string, Promise<void>>;
   /** Resolves DKG-agent public encryption keys for private/agent-gated remote SWM gossip. */
   workspaceAgentRecipientResolver?: WorkspaceAgentRecipientResolver;
@@ -299,33 +302,6 @@ export interface DKGPublisherConfig {
    * the lifecycle subject; the history API returns `events: []` gracefully.
    */
   provenanceEvents?: boolean;
-}
-
-/**
- * Publisher instances that target the same in-process store must serialize
- * lifecycle mutations together. A per-instance default lets a writer race a
- * promote in another publisher and disappear when promote drops the stale WM
- * snapshot. Explicitly supplied locks still win so the agent can share its
- * wider handler lock domain with the publisher.
- */
-const STORE_WRITE_LOCKS = new WeakMap<TripleStore, Map<string, Promise<void>>>();
-
-function writeLocksForStore(
-  store: TripleStore,
-  suppliedLocks?: Map<string, Promise<void>>,
-): Map<string, Promise<void>> {
-  const existingLocks = STORE_WRITE_LOCKS.get(store);
-  if (existingLocks) {
-    if (suppliedLocks && suppliedLocks !== existingLocks) {
-      throw new Error(
-        'DKGPublisher instances sharing one TripleStore must share the same writeLocks map',
-      );
-    }
-    return existingLocks;
-  }
-  const locks = suppliedLocks ?? new Map();
-  STORE_WRITE_LOCKS.set(store, locks);
-  return locks;
 }
 
 export interface WorkspaceSenderKeyEncryptInput {
@@ -903,7 +879,7 @@ export class DKGPublisher implements Publisher {
     this.privateStore = new PrivateContentStore(config.store, this.graphManager);
     this.sharedMemoryOwnedEntities = config.sharedMemoryOwnedEntities ?? new Map();
     this.knownBatchContextGraphs = config.knownBatchContextGraphs ?? new Map();
-    this.writeLocks = writeLocksForStore(this.store, config.writeLocks);
+    this.writeLocks = config.writeLocks ?? new Map();
     this.workspaceAgentRecipientResolver = config.workspaceAgentRecipientResolver;
     this.workspaceSenderKeyEncryptor = config.workspaceSenderKeyEncryptor;
     this.publicSnapshotStore = config.publicSnapshotStore;

--- a/packages/publisher/src/index.ts
+++ b/packages/publisher/src/index.ts
@@ -9,6 +9,7 @@ export {
   autoPartition,
   type SkolemizedKnowledgeAssetParts,
 } from './auto-partition.js';
+export { assertNoKnowledgeAssetPayloadNamedGraphs } from './knowledge-asset-graph-policy.js';
 export {
   ASSERTION_NAMED_GRAPH_PREFIX,
   assertionOriginalGraph,

--- a/packages/publisher/src/knowledge-asset-graph-policy.ts
+++ b/packages/publisher/src/knowledge-asset-graph-policy.ts
@@ -1,0 +1,33 @@
+import type { Quad } from '@origintrail-official/dkg-storage';
+
+/**
+ * Rootless KAs currently have one RDF dataset scope: the default graph inside
+ * their exact physical per-KA graph. A non-empty quad graph term is therefore
+ * user-authored RDF named-graph identity, not storage placement metadata.
+ *
+ * Canonicalization deliberately operates on the RDF triple set and would erase
+ * that graph term. Reject it before hashing or materialization so two identical
+ * SPOs in different named graphs cannot collapse into a seal that no longer
+ * represents the submitted dataset. Physical DKG graph terms are normalized to
+ * the default graph by assertionWrite before this boundary.
+ */
+export function assertNoKnowledgeAssetPayloadNamedGraphs(
+  ...partitions: ReadonlyArray<ReadonlyArray<Quad>>
+): void {
+  const namedGraphs = [...new Set(
+    partitions
+      .flatMap((quads) => quads)
+      .map((quad) => quad.graph)
+      .filter((graph): graph is string => typeof graph === 'string' && graph.length > 0),
+  )];
+
+  if (namedGraphs.length === 0) return;
+
+  throw Object.assign(
+    new Error(
+      'Knowledge Asset contains RDF named-graph quads, but SWM share and VM publish do not yet preserve original graph identity. '
+      + 'Rewrite the payload into the default graph before sharing, or keep the KA in WM until graph-preserving SWM/VM semantics are implemented.',
+    ),
+    { code: 'KA_NAMED_GRAPH_SHARE_UNSUPPORTED', namedGraphs },
+  );
+}

--- a/packages/publisher/test/_helpers/rootless-lifecycle.ts
+++ b/packages/publisher/test/_helpers/rootless-lifecycle.ts
@@ -1,0 +1,264 @@
+import { ethers } from 'ethers';
+import {
+  ASSERTION_SEAL_PREDICATES,
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  MemoryLayer,
+  assertionLifecycleUri,
+  buildAssertionSealQuads,
+  contextGraphAssertionUri,
+  contextGraphMetaUri,
+  createGraphKnowledgeAssetScope,
+  isTrustLevelQuad,
+  knowledgeAssetLayerGraphUri,
+} from '@origintrail-official/dkg-core';
+import {
+  GraphManager,
+  PrivateContentStore,
+  type OxigraphStore,
+  type Quad,
+} from '@origintrail-official/dkg-storage';
+import {
+  computeFlatKCRootV10,
+  computePrivateRootV10,
+  assertNoKnowledgeAssetPayloadNamedGraphs,
+  skolemizeKnowledgeAssetParts,
+} from '../../src/index.js';
+import type { DKGPublisher } from '../../src/dkg-publisher.js';
+
+const DKG = 'http://dkg.io/ontology/';
+const XSD_INTEGER = '<http://www.w3.org/2001/XMLSchema#integer>';
+const RESERVED_PREFIXES = ['urn:dkg:file:', 'urn:dkg:extraction:'];
+
+function stripStoredTerm(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) return undefined;
+  const literal = /^"(.*)"(?:\^\^<[^>]+>)?$/.exec(trimmed);
+  if (literal) return literal[1];
+  const iri = /^<([^>]+)>$/.exec(trimmed);
+  return iri?.[1] ?? trimmed;
+}
+
+function fixtureNumber(contextGraphId: string, agentAddress: string, name: string): bigint {
+  let hash = 0x811c9dc5;
+  for (const byte of new TextEncoder().encode(`${contextGraphId}\0${agentAddress}\0${name}`)) {
+    hash ^= byte;
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return BigInt((hash >>> 0) + 1);
+}
+
+function isProtocolMetadata(quad: Quad): boolean {
+  const subject = quad.subject.toLowerCase();
+  return RESERVED_PREFIXES.some((prefix) => subject.startsWith(prefix))
+    || isTrustLevelQuad(quad);
+}
+
+/**
+ * Publisher-unit equivalent of agent.assertion.finalize(). It deliberately
+ * uses the same canonicalization, exact UAL graph, Merkle construction, seal
+ * shape, lifecycle identity, and cleanup order; only the signature bytes are
+ * inert because publisher lifecycle tests do not submit this seal on-chain.
+ */
+export async function finalizeRootlessAssertionForTest(params: {
+  publisher: DKGPublisher;
+  store: OxigraphStore;
+  contextGraphId: string;
+  name: string;
+  agentAddress: string;
+  subGraphName?: string;
+  assertionVersion?: string | number | bigint;
+}): Promise<{
+  kaUal: string;
+  assertionVersion: string;
+  graphUri: string;
+  sharedGraphUri: string;
+  publicQuads: Quad[];
+  privateQuads: Quad[];
+}> {
+  const {
+    publisher,
+    store,
+    contextGraphId,
+    name,
+    subGraphName,
+  } = params;
+  // Direct publisher tests intentionally exercise callers that have not passed
+  // through the agent's checksum normalization. Address lifecycle graphs by the
+  // exact value used at assertionCreate, while keeping the signed author and UAL
+  // identity canonical.
+  const lifecycleAgentAddress = params.agentAddress;
+  const authorAddress = ethers.getAddress(params.agentAddress);
+  const assertionUri = contextGraphAssertionUri(
+    contextGraphId,
+    lifecycleAgentAddress,
+    name,
+    subGraphName,
+  );
+  const lifecycleUri = assertionLifecycleUri(
+    contextGraphId,
+    lifecycleAgentAddress,
+    name,
+    subGraphName,
+  );
+  const metaGraph = contextGraphMetaUri(contextGraphId);
+  const sourceGraphUri = await publisher.wmGraphUri(
+    contextGraphId,
+    lifecycleAgentAddress,
+    name,
+    subGraphName,
+  );
+  const rawPublic = (await publisher.assertionQuery(
+    contextGraphId,
+    name,
+    lifecycleAgentAddress,
+    subGraphName,
+  )).filter((quad) => !isProtocolMetadata(quad));
+  const rawPrivate = (await publisher.assertionQueryPrivate(
+    contextGraphId,
+    name,
+    lifecycleAgentAddress,
+    subGraphName,
+  )).filter((quad) => !isProtocolMetadata(quad));
+  if (rawPublic.length === 0 && rawPrivate.length === 0) {
+    throw new Error(`Cannot finalize empty test assertion ${name}`);
+  }
+
+  assertNoKnowledgeAssetPayloadNamedGraphs(rawPublic, rawPrivate);
+
+  const normalized = await skolemizeKnowledgeAssetParts(rawPublic, rawPrivate, {
+    allowCanonicalSkolemTerms: true,
+  });
+  const privateMerkleRoot = computePrivateRootV10(normalized.privateQuads);
+  const merkleRoot = computeFlatKCRootV10(
+    normalized.publicQuads,
+    privateMerkleRoot ? [privateMerkleRoot] : [],
+  );
+
+  const identity = await store.query(
+    `SELECT ?n ?u ?v WHERE { GRAPH <${metaGraph}> { ` +
+      `OPTIONAL { <${lifecycleUri}> <${DKG}kaId> ?n } ` +
+      `OPTIONAL { <${lifecycleUri}> <${DKG}reservedUal> ?u } ` +
+      `OPTIONAL { <${lifecycleUri}> <${DKG}assertionVersion> ?v } } } LIMIT 1`,
+  );
+  const row = identity.type === 'bindings' ? identity.bindings[0] : undefined;
+  const storedNumber = stripStoredTerm(row?.['n']);
+  const kaNumber = storedNumber !== undefined
+    ? BigInt(storedNumber)
+    : fixtureNumber(contextGraphId, lifecycleAgentAddress, name);
+  const storedUal = stripStoredTerm(row?.['u']);
+  const kaUal = storedUal
+    ?? `did:dkg:31337/${authorAddress.toLowerCase()}/${kaNumber}`;
+  const assertionVersion = String(
+    params.assertionVersion
+      ?? stripStoredTerm(row?.['v'])
+      ?? '1',
+  );
+  const scope = createGraphKnowledgeAssetScope(kaUal, assertionVersion);
+  const reservedKaId = (BigInt(authorAddress) << 96n) | kaNumber;
+
+  const graphUri = await publisher.materializeCanonicalWorkingMemory(
+    contextGraphId,
+    scope.ual,
+    scope.assertionVersion,
+    normalized.publicQuads,
+    subGraphName,
+  );
+  const sharedGraphUri = knowledgeAssetLayerGraphUri(
+    contextGraphId,
+    MemoryLayer.SharedWorkingMemory,
+    scope,
+    subGraphName,
+  );
+  const privateStore = new PrivateContentStore(store, new GraphManager(store));
+  await privateStore.replaceKnowledgeAssetPrivateTriples(
+    contextGraphId,
+    scope,
+    normalized.privateQuads,
+    subGraphName,
+  );
+
+  for (const predicate of Object.values(ASSERTION_SEAL_PREDICATES)) {
+    await store.deleteByPattern({ graph: metaGraph, subject: assertionUri, predicate });
+  }
+  const sealQuads = buildAssertionSealQuads({
+    assertionUri,
+    metaGraph,
+    merkleRoot,
+    authorAddress,
+    authorAttestationR: new Uint8Array(32).fill(1),
+    authorAttestationVS: new Uint8Array(32).fill(2),
+    authorSchemeVersion: 1,
+    chainId: 31337n,
+    kav10Address: '0x0000000000000000000000000000000000000001',
+    reservedKaId,
+    finalizedAtIso: new Date(0).toISOString(),
+    contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+    kaUal: scope.ual,
+    assertionVersion: scope.assertionVersion,
+    publicTripleCount: normalized.publicQuads.length,
+    ...(privateMerkleRoot ? { privateMerkleRoot } : {}),
+    privateTripleCount: normalized.privateQuads.length,
+  });
+  const merkleHex = ethers.hexlify(merkleRoot).slice(2);
+  await store.deleteByPattern({
+    graph: metaGraph,
+    subject: lifecycleUri,
+    predicate: ASSERTION_SEAL_PREDICATES.ASSERTION_VERSION,
+  });
+  await store.insert([
+    ...sealQuads,
+    {
+      subject: lifecycleUri,
+      predicate: `${DKG}kaId`,
+      object: `"${kaNumber}"^^${XSD_INTEGER}`,
+      graph: metaGraph,
+    },
+    {
+      subject: lifecycleUri,
+      predicate: `${DKG}reservedUal`,
+      object: `"${scope.ual}"`,
+      graph: metaGraph,
+    },
+    {
+      subject: lifecycleUri,
+      predicate: ASSERTION_SEAL_PREDICATES.CONTENT_SCOPE_VERSION,
+      object: `"${GRAPH_KA_CONTENT_SCOPE_VERSION}"^^${XSD_INTEGER}`,
+      graph: metaGraph,
+    },
+    {
+      subject: lifecycleUri,
+      predicate: ASSERTION_SEAL_PREDICATES.ASSERTION_VERSION,
+      object: `"${scope.assertionVersion}"^^${XSD_INTEGER}`,
+      graph: metaGraph,
+    },
+    {
+      subject: lifecycleUri,
+      predicate: `${DKG}wmCurrentAssertion`,
+      object: `"${merkleHex}"`,
+      graph: metaGraph,
+    },
+  ]);
+  await publisher.cleanupCanonicalWorkingMemorySources(
+    contextGraphId,
+    name,
+    lifecycleAgentAddress,
+    graphUri,
+    [sourceGraphUri],
+    subGraphName,
+  );
+  await privateStore.deleteKnowledgeAssetPrivateDraft(
+    contextGraphId,
+    lifecycleAgentAddress,
+    name,
+    subGraphName,
+  );
+
+  return {
+    kaUal: scope.ual,
+    assertionVersion: scope.assertionVersion,
+    graphUri,
+    sharedGraphUri,
+    publicQuads: normalized.publicQuads,
+    privateQuads: normalized.privateQuads,
+  };
+}

--- a/packages/publisher/test/_helpers/rootless-workspace.ts
+++ b/packages/publisher/test/_helpers/rootless-workspace.ts
@@ -1,0 +1,108 @@
+import {
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  createGraphKnowledgeAssetScope,
+  decodeWorkspacePublishRequest,
+  encodeWorkspacePublishRequest,
+  knowledgeAssetLayerGraphUri,
+  MemoryLayer,
+  type WorkspacePublishRequestMsg,
+} from '@origintrail-official/dkg-core';
+import { parseSimpleNQuads } from '../../src/publish-handler.js';
+
+const DEFAULT_AGENT = '0x0000000000000000000000000000000000000001';
+
+/**
+ * Stable, non-cryptographic fixture number. Reusing an operation id reuses the
+ * same KA identity, while unrelated test messages do not accidentally collide.
+ */
+function fixtureKaNumber(contextGraphId: string, identityHint: string): string {
+  let hash = 0x811c9dc5;
+  for (const byte of new TextEncoder().encode(`${contextGraphId}\0${identityHint}`)) {
+    hash ^= byte;
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return String((hash >>> 0) + 1);
+}
+
+export type RootlessWorkspaceRequest = Omit<
+  WorkspacePublishRequestMsg,
+  | 'manifest'
+  | 'contentScopeVersion'
+  | 'publicTripleCount'
+  | 'privateTripleCount'
+> & {
+  manifest?: WorkspacePublishRequestMsg['manifest'];
+  contentScopeVersion?: number;
+  publicTripleCount?: number;
+  privateTripleCount?: number;
+};
+
+/** Encode a complete graph-scoped KA envelope for receiver-focused tests. */
+export function encodeRootlessWorkspaceRequest(
+  input: RootlessWorkspaceRequest,
+): Uint8Array {
+  const agentAddress = input.agentAddress?.trim() || DEFAULT_AGENT;
+  const parsedQuads = parseSimpleNQuads(new TextDecoder().decode(input.nquads));
+  // Most receiver fixtures model one KA over one stable subject. The subject is
+  // only a deterministic test-id hint; it is never emitted as root metadata or
+  // used by production content selection.
+  const identityHint = parsedQuads[0]?.subject || input.shareOperationId;
+  const kaNumber = input.kaNumber?.trim()
+    || fixtureKaNumber(input.contextGraphId, identityHint);
+  const kaUal = input.kaUal?.trim()
+    || `did:dkg:31337/${agentAddress.toLowerCase()}/${kaNumber}`;
+  const scope = createGraphKnowledgeAssetScope(
+    kaUal,
+    input.assertionVersion?.trim() || '1',
+  );
+  if (scope.agentAddress.toLowerCase() !== agentAddress.toLowerCase()) {
+    throw new Error(
+      `Fixture agent ${agentAddress} does not match KA UAL agent ${scope.agentAddress}`,
+    );
+  }
+  if (scope.kaNumber !== kaNumber) {
+    throw new Error(
+      `Fixture KA number ${kaNumber} does not match KA UAL number ${scope.kaNumber}`,
+    );
+  }
+  const publicTripleCount = input.publicTripleCount
+    ?? parsedQuads.length;
+
+  return encodeWorkspacePublishRequest({
+    ...input,
+    manifest: [],
+    agentAddress,
+    kaNumber,
+    contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+    kaUal: scope.ual,
+    assertionVersion: scope.assertionVersion,
+    publicTripleCount,
+    privateTripleCount: input.privateTripleCount ?? 0,
+  });
+}
+
+export function rootlessSharedMemoryGraphFromWire(payload: Uint8Array): string {
+  const request = decodeWorkspacePublishRequest(payload);
+  return rootlessSharedMemoryGraph(
+    request.contextGraphId,
+    request,
+    request.subGraphName,
+  );
+}
+
+export function rootlessSharedMemoryGraph(
+  contextGraphId: string,
+  request: Pick<WorkspacePublishRequestMsg, 'kaUal' | 'assertionVersion'>,
+  subGraphName?: string,
+): string {
+  const scope = createGraphKnowledgeAssetScope(
+    request.kaUal ?? '',
+    request.assertionVersion ?? '',
+  );
+  return knowledgeAssetLayerGraphUri(
+    contextGraphId,
+    MemoryLayer.SharedWorkingMemory,
+    scope,
+    subGraphName,
+  );
+}

--- a/packages/publisher/test/assertion-pull-from.test.ts
+++ b/packages/publisher/test/assertion-pull-from.test.ts
@@ -116,7 +116,6 @@ describe('rootless assertionPullFrom', () => {
       q('urn:e:legacy-decoy', SCHEMA, '"Legacy bucket decoy"', LEGACY_SWM_GRAPH),
       q(lifecycle, `${DKG}rootEntity`, ENTITY_1, meta),
     ]);
-    await publisher.clearSwmShareComplete(CG, NAME, AGENT);
 
     const result = await publisher.assertionPullFrom(CG, NAME, AGENT, 'swm');
 
@@ -140,9 +139,38 @@ describe('rootless assertionPullFrom', () => {
     if (staleRoots.type === 'bindings') expect(staleRoots.bindings).toHaveLength(0);
   });
 
+  it('blocks a destructive pull until a marker-less promote tail is repaired', async () => {
+    const { publisher, store } = await makePublisher();
+    const finalized = await seedShared(publisher, store);
+    await publisher.clearSwmShareComplete(CG, NAME, AGENT);
+
+    await expect(
+      publisher.assertionPullFrom(CG, NAME, AGENT, 'swm'),
+    ).rejects.toMatchObject({ code: 'KA_PROMOTE_RECOVERY_REQUIRED' });
+    expect(await store.hasGraph(finalized.sharedGraphUri)).toBe(true);
+    expect(await publisher.assertionQuery(CG, NAME, AGENT)).toEqual([]);
+  });
+
+  it('snapshots pull options before waiting for its lifecycle lock', async () => {
+    const { publisher, store } = await makePublisher();
+    const finalized = await seedShared(publisher, store);
+    const options: NonNullable<Parameters<DKGPublisher['assertionPullFrom']>[4]> = {
+      onConflict: 'replace',
+    };
+
+    const pull = publisher.assertionPullFrom(CG, NAME, AGENT, 'swm', options);
+    options.subGraphName = 'mutated-after-lock-selection';
+
+    await expect(pull).resolves.toMatchObject({
+      seeded: finalized.publicQuads.length,
+      fromLayer: 'swm',
+    });
+  });
+
   it('rejects a dirty public WM draft by default', async () => {
     const { publisher, store } = await makePublisher();
     await seedShared(publisher, store);
+    await publisher.assertionCreate(CG, NAME, AGENT);
     await publisher.assertionWrite(CG, NAME, AGENT, [
       q('urn:e:local', SCHEMA, '"Local edit"'),
     ]);
@@ -158,6 +186,7 @@ describe('rootless assertionPullFrom', () => {
   it('treats a private-only dirty WM draft as a conflict', async () => {
     const { publisher, store } = await makePublisher();
     await seedShared(publisher, store);
+    await publisher.assertionCreate(CG, NAME, AGENT);
     await publisher.assertionWritePrivate(CG, NAME, AGENT, [
       q('urn:e:private-local', 'urn:predicate:secret', '"Local secret"'),
     ]);
@@ -174,6 +203,7 @@ describe('rootless assertionPullFrom', () => {
       publicQuads: [q(ENTITY_2, SCHEMA, '"Bob from SWM"')],
     });
     const localNamedGraph = 'urn:test:graph:stale-local';
+    await publisher.assertionCreate(CG, NAME, AGENT);
     const wmGraph = await publisher.wmGraphUri(CG, AGENT, NAME);
     const scopedLocalGraph = assertionScopedGraphUri(wmGraph, localNamedGraph);
     await publisher.assertionWrite(CG, NAME, AGENT, [
@@ -204,6 +234,7 @@ describe('rootless assertionPullFrom', () => {
   it('validates a missing source before replacing the dirty draft', async () => {
     const { publisher, store } = await makePublisher();
     const finalized = await seedShared(publisher, store);
+    await publisher.assertionCreate(CG, NAME, AGENT);
     await publisher.assertionWrite(CG, NAME, AGENT, [
       q('urn:e:precious-local', SCHEMA, '"Precious local edit"'),
     ]);
@@ -220,6 +251,7 @@ describe('rootless assertionPullFrom', () => {
   it('rejects a tampered exact source and preserves the dirty draft', async () => {
     const { publisher, store } = await makePublisher();
     const finalized = await seedShared(publisher, store);
+    await publisher.assertionCreate(CG, NAME, AGENT);
     await publisher.assertionWrite(CG, NAME, AGENT, [
       q('urn:e:precious-local', SCHEMA, '"Precious local edit"'),
     ]);
@@ -238,6 +270,7 @@ describe('rootless assertionPullFrom', () => {
   it('rejects named-graph identity injected into the exact source before replacement', async () => {
     const { publisher, store } = await makePublisher();
     const finalized = await seedShared(publisher, store);
+    await publisher.assertionCreate(CG, NAME, AGENT);
     await publisher.assertionWrite(CG, NAME, AGENT, [
       q('urn:e:precious-local', SCHEMA, '"Precious local edit"'),
     ]);

--- a/packages/publisher/test/assertion-pull-from.test.ts
+++ b/packages/publisher/test/assertion-pull-from.test.ts
@@ -1,31 +1,32 @@
 import { describe, expect, it } from 'vitest';
 import { NoChainAdapter } from '@origintrail-official/dkg-chain';
 import {
+  ASSERTION_SEAL_PREDICATES,
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  MemoryLayer,
   TypedEventBus,
-  generateEd25519Keypair,
-  buildAssertionSealQuads,
-  contextGraphMetaUri,
-  contextGraphAssertionUri,
   assertionLifecycleUri,
+  buildAssertionSealQuads,
+  contextGraphAssertionUri,
+  contextGraphMetaUri,
+  createGraphKnowledgeAssetScope,
+  generateEd25519Keypair,
+  knowledgeAssetLayerGraphUri,
 } from '@origintrail-official/dkg-core';
 import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
 import { DKGPublisher, assertionScopedGraphUri } from '../src/index.js';
-
-// OT-RFC-43 §10.5.3 — `wm/pull-from` seeds a fresh WM draft from the file's
-// current SWM/VM state. These are store-backed (real OxigraphStore) so the
-// entity-scoped gather + onConflict behavior is exercised end to end.
+import { finalizeRootlessAssertionForTest } from './_helpers/rootless-lifecycle.js';
 
 const CG = 'pull-from-test';
 const AGENT = '0x00000000000000000000000000000000000000a1';
 const NAME = 'meeting-notes';
-const SWM_GRAPH = `did:dkg:context-graph:${CG}/_shared_memory`;
+const LEGACY_SWM_GRAPH = `did:dkg:context-graph:${CG}/_shared_memory`;
+const LEGACY_DATA_GRAPH = `did:dkg:context-graph:${CG}`;
 const SCHEMA = 'http://schema.org/name';
 const DKG = 'http://dkg.io/ontology/';
-
 const ENTITY_1 = 'urn:e:alice';
 const ENTITY_2 = 'urn:e:bob';
-const SKOLEM_1 = `${ENTITY_1}/.well-known/genid/n1`;
-const OTHER_FILE_ENTITY = 'urn:e:carol-other-file';
+const ENTITY_3 = 'urn:e:carol';
 
 async function makePublisher() {
   const store = new OxigraphStore();
@@ -38,18 +39,50 @@ async function makePublisher() {
   return { publisher, store };
 }
 
-function q(subject: string, predicate: string, object: string, graph: string): Quad {
+function q(subject: string, predicate: string, object: string, graph = ''): Quad {
   return { subject, predicate, object, graph };
 }
 
-/**
- * Seal: build a REAL assertion seal under the assertion-graph URI
- * (`contextGraphAssertionUri`) in `_meta`, exactly as `finalize` does — this is
- * where `assertionPullFrom` reads it via `parseAssertionSealQuads`
- * (PR #972/335e8d8). The previous helper wrote a bare `assertionRootEntity` on
- * the lifecycle URN, which only matched the old (buggy) read.
- */
-function sealEntities(entities: string[]): Quad[] {
+function key(quad: Quad): string {
+  return JSON.stringify([quad.subject, quad.predicate, quad.object]);
+}
+
+async function seedShared(
+  publisher: DKGPublisher,
+  store: OxigraphStore,
+  options: {
+    publicQuads?: Quad[];
+    privateQuads?: Quad[];
+    name?: string;
+    agentAddress?: string;
+  } = {},
+) {
+  const name = options.name ?? NAME;
+  const agentAddress = options.agentAddress ?? AGENT;
+  const publicQuads = options.publicQuads ?? [
+    q(ENTITY_1, SCHEMA, '"Alice"'),
+    q(ENTITY_2, SCHEMA, '"Bob"'),
+  ];
+  const privateQuads = options.privateQuads ?? [];
+  await publisher.assertionCreate(CG, name, agentAddress);
+  if (publicQuads.length > 0) {
+    await publisher.assertionWrite(CG, name, agentAddress, publicQuads);
+  }
+  if (privateQuads.length > 0) {
+    await publisher.assertionWritePrivate(CG, name, agentAddress, privateQuads);
+  }
+  const finalized = await finalizeRootlessAssertionForTest({
+    publisher,
+    store,
+    contextGraphId: CG,
+    name,
+    agentAddress,
+  });
+  await publisher.assertionPromote(CG, name, agentAddress);
+  return finalized;
+}
+
+function legacySeal(rootEntities: string[]): Quad[] {
   return buildAssertionSealQuads({
     assertionUri: contextGraphAssertionUri(CG, AGENT, NAME),
     metaGraph: contextGraphMetaUri(CG),
@@ -60,509 +93,293 @@ function sealEntities(entities: string[]): Quad[] {
     authorSchemeVersion: 1,
     chainId: 31337n,
     kav10Address: AGENT,
-    // §F2 — the seal now carries the packed reservedKaId
-    // (uint160(author) << 96 | number). This test only consumes the seal's
-    // rootEntities for scoping, so number=1 is sufficient. AGENT is already a
-    // 20-byte hex literal, so BigInt() packs it without ethers.
     reservedKaId: (BigInt(AGENT) << 96n) | 1n,
     finalizedAtIso: '2026-01-01T00:00:00.000Z',
-    rootEntities: entities,
+    rootEntities,
   }) as Quad[];
 }
 
-async function wmQuads(store: OxigraphStore): Promise<Quad[]> {
-  const wm = contextGraphAssertionUri(CG, AGENT, NAME);
-  const r = await store.query(`CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${wm}> { ?s ?p ?o } }`);
-  return r.type === 'quads' ? r.quads : [];
-}
-
-describe('assertionPullFrom (OT-RFC-43 §10.5.3 wm/pull-from)', () => {
-  it('seeds a WM draft from SWM, scoped to the file\'s sealed entities (+ skolem children)', async () => {
+describe('rootless assertionPullFrom', () => {
+  it('re-opens the complete exact SWM graph and ignores bucket and root-row decoys', async () => {
     const { publisher, store } = await makePublisher();
-    const lifecycleUri = assertionLifecycleUri(CG, AGENT, NAME);
-    const metaGraph = contextGraphMetaUri(CG);
-    await store.insert([
-      // this file's entities in SWM
-      q(ENTITY_1, SCHEMA, '"Alice"', SWM_GRAPH),
-      q(SKOLEM_1, SCHEMA, '"Alice detail"', SWM_GRAPH),
-      q(ENTITY_2, SCHEMA, '"Bob"', SWM_GRAPH),
-      // trust/ownership bookkeeping that must NOT land in the draft
-      q(ENTITY_1, `${DKG}workspaceOwner`, '"peer-a"', SWM_GRAPH),
-      // a DIFFERENT file's entity co-resident in the same SWM graph
-      q(OTHER_FILE_ENTITY, SCHEMA, '"Carol"', SWM_GRAPH),
-      ...sealEntities([ENTITY_1, ENTITY_2]),
-      // #1116 (round 8): an SWM pull resolves scope from the promote-stamped
-      // member rows + the full-share marker, NOT the seal (a stale seal must
-      // never short-circuit the subset gate). Represent a legitimately-finalized
-      // FULL share by stamping the member rows for the sealed set.
-      q(lifecycleUri, `${DKG}rootEntity`, ENTITY_1, metaGraph),
-      q(lifecycleUri, `${DKG}rootEntity`, ENTITY_2, metaGraph),
-    ]);
-    await publisher.markSwmShareComplete(CG, NAME, AGENT);
-
-    const result = await publisher.assertionPullFrom(CG, NAME, AGENT, 'swm');
-    expect(result.fromLayer).toBe('swm');
-    expect(result.entities).toBe(2);
-
-    const draft = await wmQuads(store);
-    const subjects = new Set(draft.map((d) => d.subject));
-    // the file's entities + skolem child are present...
-    expect(subjects.has(ENTITY_1)).toBe(true);
-    expect(subjects.has(SKOLEM_1)).toBe(true);
-    expect(subjects.has(ENTITY_2)).toBe(true);
-    // ...the co-resident other-file entity is NOT pulled in...
-    expect(subjects.has(OTHER_FILE_ENTITY)).toBe(false);
-    // ...and the workspaceOwner bookkeeping is filtered out.
-    expect(draft.some((d) => d.predicate === `${DKG}workspaceOwner`)).toBe(false);
-  });
-
-  it('rejects with WM_DRAFT_CONFLICT when a draft already exists (default onConflict)', async () => {
-    const { publisher, store } = await makePublisher();
-    await store.insert([q(ENTITY_1, SCHEMA, '"Alice"', SWM_GRAPH), ...sealEntities([ENTITY_1])]);
-    // open + dirty a WM draft
-    await publisher.assertionWrite(CG, NAME, AGENT, [{ subject: ENTITY_1, predicate: SCHEMA, object: '"local edit"' }]);
-
-    const err = await publisher.assertionPullFrom(CG, NAME, AGENT, 'swm').catch((e) => e);
-    expect(err).toBeInstanceOf(Error);
-    expect((err as any).code).toBe('WM_DRAFT_CONFLICT');
-  });
-
-  it('onConflict:"replace" overwrites a dirty draft with the source layer', async () => {
-    const { publisher, store } = await makePublisher();
-    await store.insert([
-      q(ENTITY_2, SCHEMA, '"Bob from SWM"', SWM_GRAPH),
-      ...sealEntities([ENTITY_2]),
-      // #1116 (round 8): SWM scope comes from the member rows + marker, not the seal.
-      q(assertionLifecycleUri(CG, AGENT, NAME), `${DKG}rootEntity`, ENTITY_2, contextGraphMetaUri(CG)),
-    ]);
-    await publisher.markSwmShareComplete(CG, NAME, AGENT);
-    await publisher.assertionWrite(CG, NAME, AGENT, [{ subject: ENTITY_1, predicate: SCHEMA, object: '"stale local"' }]);
-
-    const result = await publisher.assertionPullFrom(CG, NAME, AGENT, 'swm', { onConflict: 'replace' });
-    expect(result.fromLayer).toBe('swm');
-
-    const draft = await wmQuads(store);
-    const subjects = new Set(draft.map((d) => d.subject));
-    expect(subjects.has(ENTITY_2)).toBe(true);   // the SWM content
-    expect(subjects.has(ENTITY_1)).toBe(false);  // the stale local edit is gone
-  });
-
-  it('rejects named-graph-only dirty drafts with WM_DRAFT_CONFLICT', async () => {
-    const { publisher, store } = await makePublisher();
-    const localGraph = 'urn:test:graph:pull-from-local-only';
-    const wmGraph = contextGraphAssertionUri(CG, AGENT, NAME);
-    const scopedLocalGraph = assertionScopedGraphUri(wmGraph, localGraph);
-    await store.insert([
-      q(ENTITY_2, SCHEMA, '"Bob from SWM"', SWM_GRAPH),
-      q(assertionLifecycleUri(CG, AGENT, NAME), `${DKG}rootEntity`, ENTITY_2, contextGraphMetaUri(CG)),
-    ]);
-    await publisher.markSwmShareComplete(CG, NAME, AGENT);
-    await publisher.assertionWrite(CG, NAME, AGENT, [{
-      subject: ENTITY_1,
-      predicate: SCHEMA,
-      object: '"local named edit"',
-      graph: localGraph,
-    }]);
-
-    const err = await publisher.assertionPullFrom(CG, NAME, AGENT, 'swm').catch((e) => e);
-
-    expect(err).toBeInstanceOf(Error);
-    expect((err as any).code).toBe('WM_DRAFT_CONFLICT');
-    expect(await store.listGraphs()).toContain(scopedLocalGraph);
-    expect(await publisher.assertionQuery(CG, NAME, AGENT)).toEqual([
-      expect.objectContaining({ subject: ENTITY_1, graph: localGraph }),
-    ]);
-  });
-
-  it('onConflict:"replace" removes named-graph-only dirty draft children', async () => {
-    const { publisher, store } = await makePublisher();
-    const localGraph = 'urn:test:graph:pull-from-stale-child';
-    const wmGraph = contextGraphAssertionUri(CG, AGENT, NAME);
-    const scopedLocalGraph = assertionScopedGraphUri(wmGraph, localGraph);
-    await store.insert([
-      q(ENTITY_2, SCHEMA, '"Bob from SWM"', SWM_GRAPH),
-      q(assertionLifecycleUri(CG, AGENT, NAME), `${DKG}rootEntity`, ENTITY_2, contextGraphMetaUri(CG)),
-    ]);
-    await publisher.markSwmShareComplete(CG, NAME, AGENT);
-    await publisher.assertionWrite(CG, NAME, AGENT, [{
-      subject: ENTITY_1,
-      predicate: SCHEMA,
-      object: '"stale named local"',
-      graph: localGraph,
-    }]);
-    expect(await store.listGraphs()).toContain(scopedLocalGraph);
-
-    const result = await publisher.assertionPullFrom(CG, NAME, AGENT, 'swm', { onConflict: 'replace' });
-
-    expect(result.fromLayer).toBe('swm');
-    expect(await store.listGraphs()).not.toContain(scopedLocalGraph);
-    const draft = await publisher.assertionQuery(CG, NAME, AGENT);
-    expect(draft).toEqual(expect.arrayContaining([
-      expect.objectContaining({ subject: ENTITY_2, object: '"Bob from SWM"', graph: '' }),
-    ]));
-    expect(draft.some((quad) => quad.subject === ENTITY_1 || quad.graph === localGraph)).toBe(false);
-  });
-
-  it('validates the source BEFORE dropping — an empty-source replace pull preserves the dirty draft (PR #972/335e8d8)', async () => {
-    const { publisher, store } = await makePublisher();
-    // Finalized FULL share whose member entity has NO quads in SWM (e.g. never
-    // shared there), plus a dirty WM draft holding a precious local edit. The
-    // member row + marker represent the full-share scope; the gather finds
-    // nothing in SWM, so the pull rejects with PULL_FROM_EMPTY_SOURCE BEFORE any
-    // drop. #1116 (round 8): SWM scope is the member rows, not the seal.
-    await store.insert([
-      ...sealEntities([ENTITY_1]), // note: no ENTITY_1 quads in SWM_GRAPH
-      q(assertionLifecycleUri(CG, AGENT, NAME), `${DKG}rootEntity`, ENTITY_1, contextGraphMetaUri(CG)),
-    ]);
-    await publisher.markSwmShareComplete(CG, NAME, AGENT);
-    await publisher.assertionWrite(CG, NAME, AGENT, [{ subject: ENTITY_1, predicate: SCHEMA, object: '"precious local edit"' }]);
-
-    const err = await publisher.assertionPullFrom(CG, NAME, AGENT, 'swm', { onConflict: 'replace' }).catch((e) => e);
-    expect(err).toBeInstanceOf(Error);
-    expect((err as any).code).toBe('PULL_FROM_EMPTY_SOURCE');
-
-    // The draft must be UNTOUCHED — the empty pull validated the source before
-    // any drop, so the precious local edit survives.
-    const draft = await wmQuads(store);
-    expect(draft.some((d) => d.subject === ENTITY_1 && d.object === '"precious local edit"')).toBe(true);
-  });
-
-  it('throws when the file has neither a seal nor a prior promote (no member entities)', async () => {
-    const { publisher, store } = await makePublisher();
-    await store.insert([q(ENTITY_1, SCHEMA, '"Alice"', SWM_GRAPH)]); // no seal, no promoted rows
-    const err = await publisher.assertionPullFrom(CG, NAME, AGENT, 'swm').catch((e) => e);
-    expect(err).toBeInstanceOf(Error);
-    expect((err as Error).message).toMatch(/requires either a finalized assertion.*or a prior promote/i);
-  });
-
-  // #1116: seal-INDEPENDENT pull-from. An asset shared UNSEALED (a skipSeal
-  // share, or stuck unsealed under the old behavior) records its member
-  // entities on the lifecycle URN (dkg:rootEntity) even with no seal —
-  // pull-from falls back to those so seal-in-SWM / recovery can reconstruct the
-  // WM draft without first finalizing.
-  it('seeds a WM draft from SWM via the promoted member entities when there is NO seal', async () => {
-    const { publisher, store } = await makePublisher();
-    await store.insert([
-      q(ENTITY_1, SCHEMA, '"Alice"', SWM_GRAPH),
-      q(SKOLEM_1, SCHEMA, '"Alice detail"', SWM_GRAPH),
-      // NO seal — instead the promote-stamped member row on the lifecycle URN:
-      q(assertionLifecycleUri(CG, AGENT, NAME), `${DKG}rootEntity`, ENTITY_1, contextGraphMetaUri(CG)),
-    ]);
-    // #1116 (round 5): the seal-less SWM reconstruction now requires the
-    // full-share marker (else it's a SUBSET share, not publishable). A real
-    // skipSeal FULL share stamps it via promote(); set it here to represent
-    // that legitimate full-share state.
-    await publisher.markSwmShareComplete(CG, NAME, AGENT);
-    const result = await publisher.assertionPullFrom(CG, NAME, AGENT, 'swm');
-    expect(result.fromLayer).toBe('swm');
-    expect(result.entities).toBe(1);
-    const subjects = new Set((await wmQuads(store)).map((d) => d.subject));
-    expect(subjects.has(ENTITY_1)).toBe(true);
-    expect(subjects.has(SKOLEM_1)).toBe(true);
-  });
-
-  // #1116 atomicity: a pull-from re-opens the WM draft via `assertionCreate`,
-  // whose clean-slate WIPES every row under the lifecycle URN before re-seeding.
-  // The promote-stamped member rows (dkg:rootEntity) are the SEAL-INDEPENDENT
-  // recovery source pull-from falls back to — so they MUST survive that wipe, or
-  // a SECOND pull-from (and seal-in-SWM recovery in general) would lose the
-  // members and fail. #1116 added dkg:rootEntity to assertionCreate's
-  // A2_PRESERVE_PREDS carry-over; this guards that.
-  it('#1116: dkg:rootEntity rows on the lifecycle URN SURVIVE a replace pull-from (a second pull still finds the members)', async () => {
-    const { publisher, store } = await makePublisher();
-    const lifecycleUri = assertionLifecycleUri(CG, AGENT, NAME);
-    const metaGraph = contextGraphMetaUri(CG);
-
-    // Unsealed, promote-stamped asset: SWM content + the dkg:rootEntity member
-    // row on the lifecycle URN, NO seal — exactly what seal-in-SWM consumes.
-    await store.insert([
-      q(ENTITY_1, SCHEMA, '"Alice"', SWM_GRAPH),
-      q(SKOLEM_1, SCHEMA, '"Alice detail"', SWM_GRAPH),
-      q(lifecycleUri, `${DKG}rootEntity`, ENTITY_1, metaGraph),
-    ]);
-    // #1116 (round 5): a real FULL skipSeal share stamps the full-share marker
-    // (it survives assertionCreate's clean-slate via A2_PRESERVE), so the
-    // seal-less reconstruction is allowed; mark it to represent that state.
-    await publisher.markSwmShareComplete(CG, NAME, AGENT);
-
-    // Mirror readPromotedRootEntities: the seal-independent member lookup.
-    const readRoots = async (): Promise<string[]> => {
-      const r = await store.query(
-        `SELECT ?root WHERE { GRAPH <${metaGraph}> { <${lifecycleUri}> <${DKG}rootEntity> ?root } }`,
-      );
-      return r.type === 'bindings' ? r.bindings.map((b) => String(b['root'])) : [];
-    };
-
-    // First pull-from succeeds via the rootEntity fallback...
-    const first = await publisher.assertionPullFrom(CG, NAME, AGENT, 'swm', { onConflict: 'replace' });
-    expect(first.entities).toBe(1);
-    // ...and the row survived assertionCreate's clean-slate (it routes through
-    // the A2_PRESERVE_PREDS carry-over).
-    expect(await readRoots()).toContain(ENTITY_1);
-
-    // The crux: a SECOND replace pull-from still resolves the member — only
-    // possible if the dkg:rootEntity row was preserved across the first pull's
-    // clean-slate. Pre-#1116 (row wiped) this threw "No member entities".
-    const second = await publisher.assertionPullFrom(CG, NAME, AGENT, 'swm', { onConflict: 'replace' });
-    expect(second.entities).toBe(1);
-    expect(await readRoots()).toContain(ENTITY_1);
-
-    // And the reconstructed draft still holds the member + its skolem child.
-    const subjects = new Set((await wmQuads(store)).map((d) => d.subject));
-    expect(subjects.has(ENTITY_1)).toBe(true);
-    expect(subjects.has(SKOLEM_1)).toBe(true);
-  });
-
-  // #1116 (review A1): the swmShareComplete marker gates finalize(layer:"swm").
-  // seal-in-SWM runs a replace pull-from (assertionCreate clean-slate) BEFORE
-  // sealing — so the marker MUST survive that wipe (it was added to
-  // A2_PRESERVE_PREDS), otherwise a finalize that fails after the re-seed would
-  // strip the marker and make an already-fully-shared asset un-sealable.
-  it('#1116: swmShareComplete marker SURVIVES a replace pull-from (A2 preserve)', async () => {
-    const { publisher, store } = await makePublisher();
-    const lifecycleUri = assertionLifecycleUri(CG, AGENT, NAME);
-    const metaGraph = contextGraphMetaUri(CG);
-
-    // Fully-shared (marker present) + the seal-independent member row, NO seal —
-    // exactly the state seal-in-SWM reconstructs from.
-    await publisher.markSwmShareComplete(CG, NAME, AGENT);
-    await store.insert([
-      q(ENTITY_1, SCHEMA, '"Alice"', SWM_GRAPH),
-      q(lifecycleUri, `${DKG}rootEntity`, ENTITY_1, metaGraph),
-    ]);
-    expect(await publisher.hasSwmShareComplete(CG, NAME, AGENT)).toBe(true);
-
-    // The replace pull-from re-opens the WM draft via assertionCreate's clean
-    // slate; the marker must carry over.
-    const result = await publisher.assertionPullFrom(CG, NAME, AGENT, 'swm', { onConflict: 'replace' });
-    expect(result.entities).toBe(1);
-    expect(await publisher.hasSwmShareComplete(CG, NAME, AGENT)).toBe(true);
-
-    // markSwmShareComplete is idempotent — re-marking leaves exactly one row.
-    await publisher.markSwmShareComplete(CG, NAME, AGENT);
-    const rows = await store.query(
-      `SELECT ?o WHERE { GRAPH <${metaGraph}> { <${lifecycleUri}> <${DKG}swmShareComplete> ?o } }`,
-    );
-    expect(rows.type === 'bindings' && rows.bindings.length).toBe(1);
-  });
-
-  // #1116 (round 5): the marker MUST be cleared on discard — otherwise the
-  // A2_PRESERVE carry-over re-arms it on a recreate, and a full-share → discard
-  // → recreate → subset-share cycle would keep a stale marker and let
-  // finalize(layer:"swm") publish a partial asset under the KA name.
-  it('#1116: hasSwmShareComplete is FALSE after assertionDiscard (marker cleared)', async () => {
-    const { publisher } = await makePublisher();
-
-    // Open a WM draft, then fully-share (mark complete) — the state a full share
-    // leaves behind.
-    await publisher.assertionWrite(CG, NAME, AGENT, [
-      { subject: ENTITY_1, predicate: SCHEMA, object: '"Alice"' },
-    ]);
-    await publisher.markSwmShareComplete(CG, NAME, AGENT);
-    expect(await publisher.hasSwmShareComplete(CG, NAME, AGENT)).toBe(true);
-
-    // Discard MUST clear the marker.
-    await publisher.assertionDiscard(CG, NAME, AGENT);
-    expect(await publisher.hasSwmShareComplete(CG, NAME, AGENT)).toBe(false);
-  });
-
-  it('#1116: hasSwmShareComplete stays FALSE after discard + recreate (no stale re-arm)', async () => {
-    const { publisher } = await makePublisher();
-
-    await publisher.assertionWrite(CG, NAME, AGENT, [
-      { subject: ENTITY_1, predicate: SCHEMA, object: '"Alice"' },
-    ]);
-    await publisher.markSwmShareComplete(CG, NAME, AGENT);
-    await publisher.assertionDiscard(CG, NAME, AGENT);
-
-    // Recreate on the same name — assertionCreate's A2_PRESERVE clean-slate must
-    // NOT resurrect a marker that discard cleared (it was already gone, so there
-    // is nothing to preserve). The recreated draft is un-marked: a later seal-in-
-    // SWM must re-prove completeness.
-    await publisher.assertionCreate(CG, NAME, AGENT);
-    expect(await publisher.hasSwmShareComplete(CG, NAME, AGENT)).toBe(false);
-  });
-
-  // #1116 (round 5): the subset-publishability bypass is closed at the ROOT —
-  // the seal-less SWM reconstruction. A SUBSET share stamps dkg:rootEntity rows
-  // but NOT the full-share marker, so reconstructing/sealing it (reachable via
-  // the wm/pull-from route + a plain finalize, which bypasses the finalize(
-  // layer:"swm") wrapper guard) must be refused with SWM_SUBSET_NOT_SEALABLE.
-  it('#1116: seal-less SWM pull-from REJECTS a subset-only asset (no full-share marker)', async () => {
-    const { publisher, store } = await makePublisher();
-    const lifecycleUri = assertionLifecycleUri(CG, AGENT, NAME);
-    const metaGraph = contextGraphMetaUri(CG);
-
-    // SUBSET-shared, unsealed: SWM content + the promoted member row, but NO
-    // swmShareComplete marker (a subset share never sets it).
-    await store.insert([
-      q(ENTITY_1, SCHEMA, '"Alice"', SWM_GRAPH),
-      q(lifecycleUri, `${DKG}rootEntity`, ENTITY_1, metaGraph),
-    ]);
-    expect(await publisher.hasSwmShareComplete(CG, NAME, AGENT)).toBe(false);
-
-    const err = await publisher
-      .assertionPullFrom(CG, NAME, AGENT, 'swm')
-      .catch((e) => e);
-    expect((err as any).code).toBe('SWM_SUBSET_NOT_SEALABLE');
-  });
-
-  // ── round 7: lifecycle-URN member-row staleness (append-only bug) ──
-  // The member rows (dkg:rootEntity) are the seal-less reconstruction source.
-  // generateAssertionPromotedMetadata only INSERTs them (never deletes prior),
-  // and they survive discard+recreate via A2_PRESERVE — so without round-7 they
-  // accumulate a stale UNION and the seal-less reconstruction seals a SUPERSET.
-
-  // Read the lifecycle-URN member roots exactly as readPromotedRootEntities does.
-  async function readMemberRoots(store: OxigraphStore): Promise<Set<string>> {
-    const lifecycleUri = assertionLifecycleUri(CG, AGENT, NAME);
-    const metaGraph = contextGraphMetaUri(CG);
-    const r = await store.query(
-      `SELECT DISTINCT ?root WHERE { GRAPH <${metaGraph}> { <${lifecycleUri}> (<${DKG}rootEntity>|<${DKG}entity>) ?root } }`,
-    );
-    const out = new Set<string>();
-    if (r.type === 'bindings') for (const b of r.bindings) if (b['root']) out.add(String(b['root']));
-    return out;
-  }
-
-  it('#1116 (round 7): member rows are CLEARED after assertionDiscard (no VM version)', async () => {
-    const { publisher, store } = await makePublisher();
-    const lifecycleUri = assertionLifecycleUri(CG, AGENT, NAME);
-    const metaGraph = contextGraphMetaUri(CG);
-
-    // A promoted (unsealed) asset: SWM content + the promote-stamped member rows.
-    await publisher.assertionWrite(CG, NAME, AGENT, [
-      { subject: ENTITY_1, predicate: SCHEMA, object: '"Alice"' },
-    ]);
-    await store.insert([
-      q(lifecycleUri, `${DKG}rootEntity`, ENTITY_1, metaGraph),
-      q(lifecycleUri, `${DKG}rootEntity`, ENTITY_2, metaGraph),
-    ]);
-    expect((await readMemberRoots(store)).size).toBe(2);
-
-    // Discard a NON-published asset → membership is gone (nothing to reconstruct).
-    await publisher.assertionDiscard(CG, NAME, AGENT);
-    expect((await readMemberRoots(store)).size).toBe(0);
-  });
-
-  it('#1116 (round 7): a stale member row does NOT survive discard+recreate into a new draft', async () => {
-    const { publisher, store } = await makePublisher();
-    const lifecycleUri = assertionLifecycleUri(CG, AGENT, NAME);
-    const metaGraph = contextGraphMetaUri(CG);
-
-    await publisher.assertionWrite(CG, NAME, AGENT, [
-      { subject: ENTITY_1, predicate: SCHEMA, object: '"Alice"' },
-    ]);
-    await store.insert([q(lifecycleUri, `${DKG}rootEntity`, ENTITY_1, metaGraph)]);
-    await publisher.assertionDiscard(CG, NAME, AGENT);
-    // Recreate the SAME name: A2_PRESERVE must NOT carry the member row that
-    // discard cleared (the round-7 stale-superset bug starts here).
-    await publisher.assertionCreate(CG, NAME, AGENT);
-    expect((await readMemberRoots(store)).size).toBe(0);
-  });
-
-  it('#1116 (round 7): a FULL-COMPLETE promote REPLACES the member rows (drops a stale prior root)', async () => {
-    const { publisher, store } = await makePublisher();
-    const lifecycleUri = assertionLifecycleUri(CG, AGENT, NAME);
-    const metaGraph = contextGraphMetaUri(CG);
-
-    // Pre-seed a STALE member row for a root NOT in the current draft (e.g. left
-    // over from a prior full share {A, OTHER} that A2_PRESERVE carried across a
-    // recreate).
-    await store.insert([q(lifecycleUri, `${DKG}rootEntity`, OTHER_FILE_ENTITY, metaGraph)]);
-
-    // Current draft holds A and B; a FULL promote (entities:"all", no skip) is the
-    // authoritative current set → member rows must become EXACTLY {A, B}, not the
-    // union {A, B, OTHER}.
-    await publisher.assertionWrite(CG, NAME, AGENT, [
-      { subject: ENTITY_1, predicate: SCHEMA, object: '"Alice"' },
-      { subject: ENTITY_2, predicate: SCHEMA, object: '"Bob"' },
-    ]);
-    const res = await publisher.assertionPromote(CG, NAME, AGENT, { publisherPeerId: 'peer-self' });
-    expect(res.promotedAllRoots).toBe(true);
-
-    const rows = await readMemberRoots(store);
-    expect(rows.has(ENTITY_1)).toBe(true);
-    expect(rows.has(ENTITY_2)).toBe(true);
-    // The stale prior root is GONE — replaced, not appended.
-    expect(rows.has(OTHER_FILE_ENTITY)).toBe(false);
-    expect(rows.size).toBe(2);
-  });
-
-  // #1116 (round 8): the subset gate must hold even when a STALE FULL seal exists.
-  // A subset re-share never re-seals, and `create` without discard doesn't clear
-  // the seal (it lives on the name-keyed assertion URI, outside the lifecycle-URN
-  // clean-slate) — so an SWM pull that trusts the seal's rootEntities would short-
-  // circuit the gate and reconstruct/publish the superseded FULL set. The fix
-  // resolves SWM scope ALWAYS from the marker-gated member rows, never the seal.
-  // This pins it: stale seal {A,B} + member rows {A,B} + marker CLEARED (the
-  // subset-reshare state) → the SWM pull must REJECT, NOT trust the seal.
-  it('#1116 (round 8): a STALE full seal does NOT bypass the subset gate on an SWM pull', async () => {
-    const { publisher, store } = await makePublisher();
-    const lifecycleUri = assertionLifecycleUri(CG, AGENT, NAME);
-    const metaGraph = contextGraphMetaUri(CG);
-
-    await store.insert([
-      // SWM content for both entities (a prior full share left them here)...
-      q(ENTITY_1, SCHEMA, '"Alice"', SWM_GRAPH),
-      q(ENTITY_2, SCHEMA, '"Bob"', SWM_GRAPH),
-      // ...a STALE FULL seal over {A, B} (a subset re-share never re-sealed it)...
-      ...sealEntities([ENTITY_1, ENTITY_2]),
-      // ...and the promote-stamped member rows {A, B}.
-      q(lifecycleUri, `${DKG}rootEntity`, ENTITY_1, metaGraph),
-      q(lifecycleUri, `${DKG}rootEntity`, ENTITY_2, metaGraph),
-    ]);
-    // The marker is CLEARED — this is the post-subset-reshare state (round 6
-    // clears it on a subset share). The member rows still exist (subset append),
-    // but the asset is NOT a publishable full share.
-    expect(await publisher.hasSwmShareComplete(CG, NAME, AGENT)).toBe(false);
-
-    // Pre-round-8 the seal's rootEntities short-circuited scope and the pull
-    // SUCCEEDED, reconstructing the stale full {A, B}. Now it must REJECT.
-    const err = await publisher
-      .assertionPullFrom(CG, NAME, AGENT, 'swm', { onConflict: 'replace' })
-      .catch((e) => e);
-    expect((err as any).code).toBe('SWM_SUBSET_NOT_SEALABLE');
-  });
-
-  // #1116 (round 10): assertionPromote must maintain the swmShareComplete marker
-  // on EVERY return path — including the EARLY RETURN where a subset selection
-  // filters to ZERO promotable quads (the `quadsToPromote.length === 0` exit).
-  // Pre-fix that path returned BEFORE the marker maintenance, so a prior FULL
-  // share's marker SURVIVED a later zero-quad subset share, and finalize(layer:
-  // "swm")/pull-from then passed its gate against the OLD SWM contents.
-  it('#1116 (round 10): a zero-quad SUBSET share (early return) CLEARS a stale full-share marker', async () => {
-    const { publisher, store } = await makePublisher();
-
-    // 1. FULL share {A, B} — sets the marker, stamps member rows {A, B}, empties WM.
-    await publisher.assertionWrite(CG, NAME, AGENT, [
-      { subject: ENTITY_1, predicate: SCHEMA, object: '"Alice"' },
-      { subject: ENTITY_2, predicate: SCHEMA, object: '"Bob"' },
-    ]);
-    const full = await publisher.assertionPromote(CG, NAME, AGENT, { publisherPeerId: 'peer-self' });
-    expect(full.promotedAllRoots).toBe(true);
-    expect(await publisher.hasSwmShareComplete(CG, NAME, AGENT)).toBe(true);
-
-    // 2. Re-write a fresh WM draft, then SUBSET-share a selection that matches NONE
-    //    of the current draft's subjects → the selective filter empties
-    //    quadsToPromote → the early `length === 0` return path fires.
-    await publisher.assertionWrite(CG, NAME, AGENT, [
-      { subject: ENTITY_1, predicate: SCHEMA, object: '"Alice v2"' },
-      { subject: ENTITY_2, predicate: SCHEMA, object: '"Bob v2"' },
-    ]);
-    const zeroQuadSubset = await publisher.assertionPromote(CG, NAME, AGENT, {
-      entities: [OTHER_FILE_ENTITY], // not present in the draft → zero quads promoted
-      publisherPeerId: 'peer-self',
+    const finalized = await seedShared(publisher, store, {
+      publicQuads: [
+        q(ENTITY_1, 'urn:predicate:detail', '_:detail'),
+        q('_:detail', SCHEMA, '"Alice detail"'),
+        q(ENTITY_2, SCHEMA, '"Bob"'),
+        q(ENTITY_3, SCHEMA, '"Carol in the same KA"'),
+      ],
     });
-    expect(zeroQuadSubset.promotedCount).toBe(0); // confirms the early-return path
+    const lifecycle = assertionLifecycleUri(CG, AGENT, NAME);
+    const meta = contextGraphMetaUri(CG);
+    await store.insert([
+      q('urn:e:legacy-decoy', SCHEMA, '"Legacy bucket decoy"', LEGACY_SWM_GRAPH),
+      q(lifecycle, `${DKG}rootEntity`, ENTITY_1, meta),
+    ]);
+    await publisher.clearSwmShareComplete(CG, NAME, AGENT);
 
-    // 3. The stale full-share marker MUST be cleared (round 10 fix).
-    expect(await publisher.hasSwmShareComplete(CG, NAME, AGENT)).toBe(false);
+    const result = await publisher.assertionPullFrom(CG, NAME, AGENT, 'swm');
 
-    // 4. And the SWM pull / seal-in-SWM source now REJECTS (marker gone).
-    const err = await publisher
-      .assertionPullFrom(CG, NAME, AGENT, 'swm', { onConflict: 'replace' })
-      .catch((e) => e);
-    expect((err as any).code).toBe('SWM_SUBSET_NOT_SEALABLE');
+    expect(result).toMatchObject({
+      seeded: finalized.publicQuads.length,
+      seededPublic: finalized.publicQuads.length,
+      seededPrivate: 0,
+      fromLayer: 'swm',
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      kaUal: finalized.kaUal,
+      assertionVersion: finalized.assertionVersion,
+    });
+    expect(result).not.toHaveProperty('entities');
+    const draft = await publisher.assertionQuery(CG, NAME, AGENT);
+    expect(new Set(draft.map(key))).toEqual(new Set(finalized.publicQuads.map(key)));
+    expect(draft.some((quad) => quad.subject === 'urn:e:legacy-decoy')).toBe(false);
+    const staleRoots = await store.query(
+      `SELECT ?root WHERE { GRAPH <${meta}> { <${lifecycle}> <${DKG}rootEntity> ?root } }`,
+    );
+    expect(staleRoots.type).toBe('bindings');
+    if (staleRoots.type === 'bindings') expect(staleRoots.bindings).toHaveLength(0);
+  });
+
+  it('rejects a dirty public WM draft by default', async () => {
+    const { publisher, store } = await makePublisher();
+    await seedShared(publisher, store);
+    await publisher.assertionWrite(CG, NAME, AGENT, [
+      q('urn:e:local', SCHEMA, '"Local edit"'),
+    ]);
+
+    await expect(publisher.assertionPullFrom(CG, NAME, AGENT, 'swm')).rejects.toMatchObject({
+      code: 'WM_DRAFT_CONFLICT',
+    });
+    expect(await publisher.assertionQuery(CG, NAME, AGENT)).toEqual([
+      expect.objectContaining({ subject: 'urn:e:local' }),
+    ]);
+  });
+
+  it('treats a private-only dirty WM draft as a conflict', async () => {
+    const { publisher, store } = await makePublisher();
+    await seedShared(publisher, store);
+    await publisher.assertionWritePrivate(CG, NAME, AGENT, [
+      q('urn:e:private-local', 'urn:predicate:secret', '"Local secret"'),
+    ]);
+
+    await expect(publisher.assertionPullFrom(CG, NAME, AGENT, 'swm')).rejects.toMatchObject({
+      code: 'WM_DRAFT_CONFLICT',
+    });
+    expect(await publisher.assertionQueryPrivate(CG, NAME, AGENT)).toHaveLength(1);
+  });
+
+  it('onConflict replace removes public named-graph and private draft residue', async () => {
+    const { publisher, store } = await makePublisher();
+    const finalized = await seedShared(publisher, store, {
+      publicQuads: [q(ENTITY_2, SCHEMA, '"Bob from SWM"')],
+    });
+    const localNamedGraph = 'urn:test:graph:stale-local';
+    const wmGraph = await publisher.wmGraphUri(CG, AGENT, NAME);
+    const scopedLocalGraph = assertionScopedGraphUri(wmGraph, localNamedGraph);
+    await publisher.assertionWrite(CG, NAME, AGENT, [
+      q(ENTITY_1, SCHEMA, '"Stale named local"', localNamedGraph),
+    ]);
+    await publisher.assertionWritePrivate(CG, NAME, AGENT, [
+      q('urn:e:private-local', 'urn:predicate:secret', '"Stale private local"'),
+    ]);
+    expect(await store.listGraphs()).toContain(scopedLocalGraph);
+
+    const result = await publisher.assertionPullFrom(
+      CG,
+      NAME,
+      AGENT,
+      'swm',
+      { onConflict: 'replace' },
+    );
+
+    expect(result.seededPublic).toBe(1);
+    expect(await store.listGraphs()).not.toContain(scopedLocalGraph);
+    expect(await publisher.assertionQuery(CG, NAME, AGENT)).toEqual([
+      expect.objectContaining({ subject: ENTITY_2, object: '"Bob from SWM"', graph: '' }),
+    ]);
+    expect(await publisher.assertionQueryPrivate(CG, NAME, AGENT)).toEqual([]);
+    expect(await store.hasGraph(finalized.sharedGraphUri)).toBe(true);
+  });
+
+  it('validates a missing source before replacing the dirty draft', async () => {
+    const { publisher, store } = await makePublisher();
+    const finalized = await seedShared(publisher, store);
+    await publisher.assertionWrite(CG, NAME, AGENT, [
+      q('urn:e:precious-local', SCHEMA, '"Precious local edit"'),
+    ]);
+    await store.dropGraph(finalized.sharedGraphUri);
+
+    await expect(
+      publisher.assertionPullFrom(CG, NAME, AGENT, 'swm', { onConflict: 'replace' }),
+    ).rejects.toMatchObject({ code: 'PULL_FROM_EMPTY_SOURCE' });
+    expect(await publisher.assertionQuery(CG, NAME, AGENT)).toEqual([
+      expect.objectContaining({ subject: 'urn:e:precious-local' }),
+    ]);
+  });
+
+  it('rejects a tampered exact source and preserves the dirty draft', async () => {
+    const { publisher, store } = await makePublisher();
+    const finalized = await seedShared(publisher, store);
+    await publisher.assertionWrite(CG, NAME, AGENT, [
+      q('urn:e:precious-local', SCHEMA, '"Precious local edit"'),
+    ]);
+    await store.insert([
+      q('urn:e:tampered', SCHEMA, '"Injected"', finalized.sharedGraphUri),
+    ]);
+
+    await expect(
+      publisher.assertionPullFrom(CG, NAME, AGENT, 'swm', { onConflict: 'replace' }),
+    ).rejects.toThrow(/triple-count mismatch/);
+    expect(await publisher.assertionQuery(CG, NAME, AGENT)).toEqual([
+      expect.objectContaining({ subject: 'urn:e:precious-local' }),
+    ]);
+  });
+
+  it('rejects named-graph identity injected into the exact source before replacement', async () => {
+    const { publisher, store } = await makePublisher();
+    const finalized = await seedShared(publisher, store);
+    await publisher.assertionWrite(CG, NAME, AGENT, [
+      q('urn:e:precious-local', SCHEMA, '"Precious local edit"'),
+    ]);
+    const tamperedNamedGraph = assertionScopedGraphUri(
+      finalized.sharedGraphUri,
+      'urn:test:graph:injected',
+    );
+    await store.insert([
+      q(ENTITY_1, SCHEMA, '"Alice"', tamperedNamedGraph),
+    ]);
+
+    await expect(
+      publisher.assertionPullFrom(CG, NAME, AGENT, 'swm', { onConflict: 'replace' }),
+    ).rejects.toMatchObject({ code: 'KA_NAMED_GRAPH_SHARE_UNSUPPORTED' });
+    expect(await publisher.assertionQuery(CG, NAME, AGENT)).toEqual([
+      expect.objectContaining({ subject: 'urn:e:precious-local' }),
+    ]);
+  });
+
+  it('does not reconstruct an unsealed asset from legacy member rows or a completion marker', async () => {
+    const { publisher, store } = await makePublisher();
+    await publisher.assertionCreate(CG, NAME, AGENT);
+    const lifecycle = assertionLifecycleUri(CG, AGENT, NAME);
+    await store.insert([
+      q(ENTITY_1, SCHEMA, '"Legacy content"', LEGACY_SWM_GRAPH),
+      q(lifecycle, `${DKG}rootEntity`, ENTITY_1, contextGraphMetaUri(CG)),
+    ]);
+    await publisher.markSwmShareComplete(CG, NAME, AGENT);
+
+    await expect(publisher.assertionPullFrom(CG, NAME, AGENT, 'swm')).rejects.toMatchObject({
+      code: 'UNSEALED_PULL_FROM_BLOCKED',
+    });
+  });
+
+  it('keeps legacy root-scoped KAs read-only', async () => {
+    const { publisher, store } = await makePublisher();
+    await store.insert([
+      q(ENTITY_1, SCHEMA, '"Legacy content"', LEGACY_SWM_GRAPH),
+      ...legacySeal([ENTITY_1]),
+    ]);
+
+    await expect(publisher.assertionPullFrom(CG, NAME, AGENT, 'swm')).rejects.toMatchObject({
+      code: 'LEGACY_KA_READ_ONLY',
+    });
+  });
+
+  it('re-opens both public and private partitions from the same sealed scope', async () => {
+    const { publisher, store } = await makePublisher();
+    const finalized = await seedShared(publisher, store, {
+      publicQuads: [q(ENTITY_1, SCHEMA, '"Public"')],
+      privateQuads: [
+        q(ENTITY_1, 'urn:predicate:secret', '"Private"'),
+        q(ENTITY_2, 'urn:predicate:secret', '"Second private"'),
+      ],
+    });
+
+    const result = await publisher.assertionPullFrom(CG, NAME, AGENT, 'swm');
+
+    expect(result).toMatchObject({
+      seeded: 3,
+      seededPublic: 1,
+      seededPrivate: 2,
+    });
+    expect(new Set((await publisher.assertionQuery(CG, NAME, AGENT)).map(key)))
+      .toEqual(new Set(finalized.publicQuads.map(key)));
+    expect(new Set((await publisher.assertionQueryPrivate(CG, NAME, AGENT)).map(key)))
+      .toEqual(new Set(finalized.privateQuads.map(key)));
+  });
+
+  it('re-opens a fully private KA without inventing a public root', async () => {
+    const { publisher, store } = await makePublisher();
+    const finalized = await seedShared(publisher, store, {
+      publicQuads: [],
+      privateQuads: [q(ENTITY_1, 'urn:predicate:secret', '"Private only"')],
+    });
+
+    const result = await publisher.assertionPullFrom(CG, NAME, AGENT, 'swm');
+
+    expect(result).toMatchObject({ seeded: 1, seededPublic: 0, seededPrivate: 1 });
+    expect(await publisher.assertionQuery(CG, NAME, AGENT)).toEqual([]);
+    expect(new Set((await publisher.assertionQueryPrivate(CG, NAME, AGENT)).map(key)))
+      .toEqual(new Set(finalized.privateQuads.map(key)));
+  });
+
+  it('reads only the UAL-derived VM graph, never broad VM or data-graph decoys', async () => {
+    const { publisher, store } = await makePublisher();
+    const finalized = await seedShared(publisher, store, {
+      publicQuads: [q(ENTITY_1, SCHEMA, '"Canonical VM content"')],
+    });
+    const scope = createGraphKnowledgeAssetScope(
+      finalized.kaUal,
+      finalized.assertionVersion,
+    );
+    const vmGraph = knowledgeAssetLayerGraphUri(
+      CG,
+      MemoryLayer.VerifiableMemory,
+      scope,
+    );
+    await store.insert(finalized.publicQuads.map((quad) => ({ ...quad, graph: vmGraph })));
+    await store.insert([
+      q('urn:e:vm-decoy', SCHEMA, '"Bare data graph decoy"', LEGACY_DATA_GRAPH),
+      q('urn:e:vm-family-decoy', SCHEMA, '"Other VM decoy"', `${LEGACY_DATA_GRAPH}/_verifiable_memory/0x00000000000000000000000000000000000000ff/99`),
+    ]);
+    await store.dropGraph(finalized.sharedGraphUri);
+
+    const result = await publisher.assertionPullFrom(CG, NAME, AGENT, 'vm');
+
+    expect(result).toMatchObject({ fromLayer: 'vm', seededPublic: 1 });
+    const draft = await publisher.assertionQuery(CG, NAME, AGENT);
+    expect(draft).toEqual([
+      expect.objectContaining({ subject: ENTITY_1, object: '"Canonical VM content"' }),
+    ]);
+    expect(draft.some((quad) => quad.subject.includes('decoy'))).toBe(false);
+  });
+
+  it('clears the old seal, retains UAL identity, and permits a new assertion version', async () => {
+    const { publisher, store } = await makePublisher();
+    const first = await seedShared(publisher, store);
+
+    await publisher.assertionPullFrom(CG, NAME, AGENT, 'swm');
+    const sealSubject = contextGraphAssertionUri(CG, AGENT, NAME);
+    const meta = contextGraphMetaUri(CG);
+    const sealed = await store.query(
+      `ASK { GRAPH <${meta}> {
+        <${sealSubject}> <${ASSERTION_SEAL_PREDICATES.ASSERTION_MERKLE_ROOT}> ?root
+      } }`,
+    );
+    expect(sealed.type === 'boolean' && sealed.value).toBe(false);
+    await publisher.assertionWrite(CG, NAME, AGENT, [
+      q('urn:e:new-version', SCHEMA, '"Version two"'),
+    ]);
+    const second = await finalizeRootlessAssertionForTest({
+      publisher,
+      store,
+      contextGraphId: CG,
+      name: NAME,
+      agentAddress: AGENT,
+      assertionVersion: 2,
+    });
+
+    expect(second.kaUal).toBe(first.kaUal);
+    expect(second.assertionVersion).toBe('2');
+    expect(second.publicQuads.some((quad) => quad.subject === 'urn:e:new-version')).toBe(true);
   });
 });

--- a/packages/publisher/test/dkg-publisher.test.ts
+++ b/packages/publisher/test/dkg-publisher.test.ts
@@ -15,6 +15,7 @@ import { mintTokens } from '../../chain/test/hardhat-harness.js';
 import { buildSeal, buildUpdateSeal, wrapPublisherForTest } from './_helpers/seal.js';
 import { makeHardhatReceiverACKProvider } from './_helpers/acks.js';
 import { makeTestKaAllocator } from './_helpers/ka-allocator.js';
+import { finalizeRootlessAssertionForTest } from './_helpers/rootless-lifecycle.js';
 import type { V10ACKProvider } from '../src/publisher.js';
 
 let CONTEXT_GRAPH: string;
@@ -445,6 +446,11 @@ describe('DKGPublisher', () => {
     });
 
     it('allows a user-authored assertionWrite with a non-reserved subject', async () => {
+      await publisher.assertionCreate(
+        CONTEXT_GRAPH,
+        'user-allowed',
+        TEST_PUBLISHER_ADDRESS,
+      );
       await expect(
         publisher.assertionWrite(CONTEXT_GRAPH, 'user-allowed', TEST_PUBLISHER_ADDRESS, [
           { subject: 'urn:note:my-doc', predicate: 'http://schema.org/name', object: '"allowed"' },
@@ -645,7 +651,11 @@ describe('DKGPublisher', () => {
       // functionally-equivalent but differently-shaped check
       // (e.g., a Set lookup or a regex), this test still passes
       // as long as the behaviour is correct.
-      const dataGraph = `did:dkg:context-graph:${CONTEXT_GRAPH}/assertion/${TEST_PUBLISHER_ADDRESS}/bug35-ssot`;
+      const dataGraph = await publisher.assertionCreate(
+        CONTEXT_GRAPH,
+        'bug35-ssot',
+        TEST_PUBLISHER_ADDRESS,
+      );
       const reservedQuads: Quad[] = RESERVED_SUBJECT_PREFIXES.map((prefix, i) => ({
         subject: `${prefix}synthetic-${i}`,
         predicate: 'http://schema.org/name',
@@ -680,6 +690,13 @@ describe('DKGPublisher', () => {
           throw err;
         }
       }
+      const finalized = await finalizeRootlessAssertionForTest({
+        publisher,
+        store,
+        contextGraphId: CONTEXT_GRAPH,
+        name: 'bug35-ssot',
+        agentAddress: TEST_PUBLISHER_ADDRESS,
+      });
       const result = await publisher.assertionPromote(
         CONTEXT_GRAPH,
         'bug35-ssot',
@@ -689,7 +706,7 @@ describe('DKGPublisher', () => {
       // directly, but we can query the SWM graph post-promote and
       // assert that none of the reserved subjects landed there.
       expect(result.promotedCount).toBeGreaterThan(0);
-      const swmGraph = `did:dkg:context-graph:${CONTEXT_GRAPH}/_shared_memory`;
+      const swmGraph = finalized.graphUri.replace('/_working_memory/', '/_shared_memory/');
       const swmCheck = await store.query(
         `ASK { GRAPH <${swmGraph}> { ?s ?p ?o . FILTER(${RESERVED_SUBJECT_PREFIXES.map(p => `STRSTARTS(STR(?s), "${p}")`).join(' || ')}) } }`,
       );
@@ -781,7 +798,11 @@ describe('DKGPublisher', () => {
         // the daemon's import-file handler does). Then promote and
         // verify the uppercase variants are filtered out along with
         // the lowercase canonical form.
-        const dataGraph = `did:dkg:context-graph:${CONTEXT_GRAPH}/assertion/${TEST_PUBLISHER_ADDRESS}/bug41-promote`;
+        const dataGraph = await publisher.assertionCreate(
+          CONTEXT_GRAPH,
+          'bug41-promote',
+          TEST_PUBLISHER_ADDRESS,
+        );
         const mixedCaseReserved: Quad[] = [
           { subject: 'URN:dkg:file:keccak256:upper', predicate: 'http://schema.org/name', object: '"upper-reserved"', graph: dataGraph },
           { subject: 'urn:DKG:extraction:caseNID', predicate: 'http://schema.org/name', object: '"nid-reserved"', graph: dataGraph },
@@ -802,6 +823,14 @@ describe('DKGPublisher', () => {
           }
         }
 
+        const finalized = await finalizeRootlessAssertionForTest({
+          publisher,
+          store,
+          contextGraphId: CONTEXT_GRAPH,
+          name: 'bug41-promote',
+          agentAddress: TEST_PUBLISHER_ADDRESS,
+        });
+
         const result = await publisher.assertionPromote(
           CONTEXT_GRAPH,
           'bug41-promote',
@@ -809,7 +838,7 @@ describe('DKGPublisher', () => {
         );
         expect(result.promotedCount).toBeGreaterThan(0);
 
-        const swmGraph = `did:dkg:context-graph:${CONTEXT_GRAPH}/_shared_memory`;
+        const swmGraph = finalized.graphUri.replace('/_working_memory/', '/_shared_memory/');
         // Use a SPARQL ASK that matches ANY case of the reserved
         // prefixes (LCASE both sides of the comparison).
         const swmCheck = await store.query(

--- a/packages/publisher/test/draft-lifecycle.test.ts
+++ b/packages/publisher/test/draft-lifecycle.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
-import { EVMChainAdapter } from '@origintrail-official/dkg-chain';
+import { GraphManager, OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
 import {
   DKG_GOSSIP_MAX_MESSAGE_BYTES,
   TypedEventBus,
@@ -8,20 +7,21 @@ import {
   contextGraphAssertionUri,
   contextGraphDataUri,
   contextGraphMetaUri,
-  contextGraphSharedMemoryUri,
   contextGraphLayerUri,
   MemoryLayer,
   assertionLifecycleUri,
 } from '@origintrail-official/dkg-core';
 import {
   DKGPublisher,
-  AssertionNotPersistedError,
   assertionScopedGraphUri,
   generatedPrivateCatalogFloorQuads,
   generatedPrivateCatalogTripleKeys,
+  resolveKnowledgeAssetOperationPublicQuads,
+  resolveKnowledgeAssetWorkspaceHead,
 } from '../src/index.js';
 import { ethers } from 'ethers';
 import { createEVMAdapter, getSharedContext, HARDHAT_KEYS } from '../../chain/test/evm-test-context.js';
+import { finalizeRootlessAssertionForTest } from './_helpers/rootless-lifecycle.js';
 
 const CG_ID = 'test-assertion-cg';
 const SWM_GRAPH = `did:dkg:context-graph:${CG_ID}/_shared_memory`;
@@ -101,6 +101,23 @@ function localAllowedAgentQuad(): Quad {
 describe('Working Memory Assertion Lifecycle', () => {
   let store: OxigraphStore;
   let publisher: DKGPublisher;
+
+  const finalizeAssertion = (
+    name = ASSERTION_NAME,
+    agentAddress = AGENT,
+    options: {
+      contextGraphId?: string;
+      subGraphName?: string;
+      publisher?: DKGPublisher;
+    } = {},
+  ) => finalizeRootlessAssertionForTest({
+    publisher: options.publisher ?? publisher,
+    store,
+    contextGraphId: options.contextGraphId ?? CG_ID,
+    name,
+    agentAddress,
+    subGraphName: options.subGraphName,
+  });
 
   beforeEach(async () => {
     store = new OxigraphStore();
@@ -258,7 +275,7 @@ describe('Working Memory Assertion Lifecycle', () => {
       expect.objectContaining({ graph: 'urn:test:graph:one' }),
       expect.objectContaining({ graph: 'urn:test:graph:two' }),
     ]));
-    await expect(publisher.assertionPromote(CG_ID, name, AGENT)).rejects.toMatchObject({
+    await expect(finalizeAssertion(name)).rejects.toMatchObject({
       code: 'KA_NAMED_GRAPH_SHARE_UNSUPPORTED',
       namedGraphs: ['urn:test:graph:one', 'urn:test:graph:two'],
     });
@@ -288,6 +305,7 @@ describe('Working Memory Assertion Lifecycle', () => {
         graph: '',
       }),
     ]);
+    await finalizeAssertion(name);
     const promoted = await publisher.assertionPromote(CG_ID, name, AGENT);
     expect(promoted.promotedCount).toBe(1);
   });
@@ -311,7 +329,7 @@ describe('Working Memory Assertion Lifecycle', () => {
         graph: namedGraph,
       }),
     ]);
-    await expect(publisher.assertionPromote(CG_ID, name, AGENT)).rejects.toMatchObject({
+    await expect(finalizeAssertion(name)).rejects.toMatchObject({
       code: 'KA_NAMED_GRAPH_SHARE_UNSUPPORTED',
       namedGraphs: [namedGraph],
     });
@@ -366,6 +384,7 @@ describe('Working Memory Assertion Lifecycle', () => {
     await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
     await publisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT, TRIPLES);
 
+    const finalized = await finalizeAssertion();
     const result = await publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT);
     expect(result.promotedCount).toBe(3);
 
@@ -373,7 +392,7 @@ describe('Working Memory Assertion Lifecycle', () => {
     expect(assertionQuads.length).toBe(0);
 
     const swmResult = await store.query(
-      `SELECT ?s ?p ?o WHERE { GRAPH <${SWM_GRAPH}> { ?s ?p ?o } }`,
+      `SELECT ?s ?p ?o WHERE { GRAPH <${finalized.sharedGraphUri}> { ?s ?p ?o } }`,
     );
     expect(swmResult.type).toBe('bindings');
     if (swmResult.type === 'bindings') {
@@ -391,7 +410,8 @@ describe('Working Memory Assertion Lifecycle', () => {
       { subject: '_:child', predicate: 'http://schema.org/name', object: '"Child"' },
     ]);
 
-    const wmGraph = contextGraphAssertionUri(CG_ID, AGENT, name);
+    const finalized = await finalizeAssertion(name);
+    const wmGraph = finalized.graphUri;
     const dropped: string[] = [];
     const wmShapeDeletes: Quad[][] = [];
     const realDropGraph = store.dropGraph.bind(store);
@@ -413,26 +433,30 @@ describe('Working Memory Assertion Lifecycle', () => {
     expect(await publisher.assertionQuery(CG_ID, name, AGENT)).toHaveLength(0);
   });
 
-  it('full promote keeps the precise-delete path when reserved rows must survive in WM', async () => {
+  it('finalize excludes reserved WM bookkeeping so full promote drops the exact KA graph', async () => {
     const name = 'reserved-row-promote';
     await publisher.assertionCreate(CG_ID, name, AGENT);
     await publisher.assertionWrite(CG_ID, name, AGENT, [
       { subject: 'urn:test:root', predicate: 'http://schema.org/name', object: '"Root"' },
     ]);
 
-    const wmGraph = contextGraphAssertionUri(CG_ID, AGENT, name);
+    const sourceWmGraph = contextGraphAssertionUri(CG_ID, AGENT, name);
     // The import-file handler writes `urn:dkg:file:` / `urn:dkg:extraction:`
-    // descriptor + provenance rows straight into the WM assertion graph. They
-    // are reserved, so they are filtered out of the SWM payload and must stay
-    // behind in WM. Only the length equality in `consumesEntireAssertion` stops
-    // the graph-drop fast path from taking them with it, so pin it: without that
-    // term this promote would silently destroy every imported file's bookkeeping.
+    // descriptor + provenance rows straight into the mutable WM assertion
+    // graph. Rootless finalization filters them before sealing and relocates
+    // only the exact user RDF set into the canonical UAL-derived WM graph.
     await store.insert([{
       subject: 'urn:dkg:file:report-descriptor',
       predicate: 'http://schema.org/name',
       object: '"report.pdf"',
-      graph: wmGraph,
+      graph: sourceWmGraph,
     }]);
+
+    const finalized = await finalizeAssertion(name);
+    const wmGraph = finalized.graphUri;
+    expect(finalized.publicQuads.map((quad) => quad.subject))
+      .not.toContain('urn:dkg:file:report-descriptor');
+    expect(await store.hasGraph(sourceWmGraph)).toBe(false);
 
     const dropped: string[] = [];
     const wmShapeDeletes: Quad[][] = [];
@@ -449,41 +473,37 @@ describe('Working Memory Assertion Lifecycle', () => {
 
     await publisher.assertionPromote(CG_ID, name, AGENT);
 
-    // The fast path must NOT engage: the reserved row is not consumed.
-    expect(dropped).not.toContain(wmGraph);
-    expect(wmShapeDeletes.length).toBeGreaterThan(0);
-
-    const remaining = await publisher.assertionQuery(CG_ID, name, AGENT);
-    expect(remaining.map((quad) => quad.subject))
-      .toContain('urn:dkg:file:report-descriptor');
-    // ...and the user-authored quad it accompanied really was promoted away.
-    expect(remaining.map((quad) => quad.subject)).not.toContain('urn:test:root');
+    expect(dropped).toContain(wmGraph);
+    expect(wmShapeDeletes).toHaveLength(0);
+    expect(await publisher.assertionQuery(CG_ID, name, AGENT)).toHaveLength(0);
   });
 
-  it('promote strips generated private-CG catalog floor from SWM and WM when trusted', async () => {
+  it('promote retains trusted generated private-CG catalog floor in the exact sealed SWM graph', async () => {
     const name = 'private-catalog-promote';
     const cgDid = contextGraphDataUri(CG_ID);
+    const catalogFloor = generatedPrivateCatalogFloorQuads(CG_ID);
     await publisher.assertionCreate(CG_ID, name, AGENT);
     await publisher.assertionWrite(CG_ID, name, AGENT, [
       { subject: 'urn:test:entity:catalog-content', predicate: 'http://schema.org/name', object: '"Content"' },
-      ...generatedPrivateCatalogFloorQuads(CG_ID),
+      ...catalogFloor,
     ]);
     await store.insert([onChainIdQuad('1')]);
     (publisher as any).chain.getContextGraphAccessPolicy = async () => 1;
     (publisher as any).chain.getContextGraphNameHash = async () => ethers.keccak256(ethers.toUtf8Bytes(CG_ID));
 
+    const finalized = await finalizeAssertion(name);
     const result = await publisher.assertionPromote(CG_ID, name, AGENT, {
       publisherPeerId: PEER,
       trustedNonManifestCatalogTriples: generatedPrivateCatalogTripleKeys(CG_ID),
       onChainContextGraphId: '1',
     });
 
-    expect(result.promotedCount).toBe(1);
+    expect(result.promotedCount).toBe(1 + catalogFloor.length);
     const swmCatalog = await store.query(
-      `SELECT ?p ?o WHERE { GRAPH <${SWM_GRAPH}> { <${cgDid}> ?p ?o } }`,
+      `SELECT ?p ?o WHERE { GRAPH <${finalized.sharedGraphUri}> { <${cgDid}> ?p ?o } }`,
     );
     expect(swmCatalog.type).toBe('bindings');
-    if (swmCatalog.type === 'bindings') expect(swmCatalog.bindings).toHaveLength(0);
+    if (swmCatalog.type === 'bindings') expect(swmCatalog.bindings).toHaveLength(catalogFloor.length);
 
     const remaining = await publisher.assertionQuery(CG_ID, name, AGENT);
     expect(remaining).toHaveLength(0);
@@ -496,6 +516,7 @@ describe('Working Memory Assertion Lifecycle', () => {
       { subject: 'urn:test:entity:catalog-content', predicate: 'http://schema.org/name', object: '"Content"' },
       ...generatedPrivateCatalogFloorQuads(CG_ID),
     ]);
+    await finalizeAssertion(name);
 
     await expect(
       publisher.assertionPromote(CG_ID, name, AGENT, {
@@ -505,27 +526,29 @@ describe('Working Memory Assertion Lifecycle', () => {
     ).rejects.toThrow(/trustedNonManifestCatalogTriples is only allowed/);
   });
 
-  it('promote strips finalized private-CG catalog floor for local private CGs before first registration', async () => {
+  it('promote retains finalized private-CG catalog floor for local private CGs before first registration', async () => {
     const name = 'private-catalog-promote-local-private';
     const cgDid = contextGraphDataUri(CG_ID);
+    const catalogFloor = generatedPrivateCatalogFloorQuads(CG_ID);
     await store.insert([localPrivateContextGraphQuad()]);
     await publisher.assertionCreate(CG_ID, name, AGENT);
     await publisher.assertionWrite(CG_ID, name, AGENT, [
       { subject: 'urn:test:entity:catalog-content', predicate: 'http://schema.org/name', object: '"Content"' },
-      ...generatedPrivateCatalogFloorQuads(CG_ID),
+      ...catalogFloor,
     ]);
 
+    const finalized = await finalizeAssertion(name);
     const result = await publisher.assertionPromote(CG_ID, name, AGENT, {
       publisherPeerId: PEER,
       trustedNonManifestCatalogTriples: generatedPrivateCatalogTripleKeys(CG_ID),
     });
 
-    expect(result.promotedCount).toBe(1);
+    expect(result.promotedCount).toBe(1 + catalogFloor.length);
     const swmCatalog = await store.query(
-      `SELECT ?p ?o WHERE { GRAPH <${SWM_GRAPH}> { <${cgDid}> ?p ?o } }`,
+      `SELECT ?p ?o WHERE { GRAPH <${finalized.sharedGraphUri}> { <${cgDid}> ?p ?o } }`,
     );
     expect(swmCatalog.type).toBe('bindings');
-    if (swmCatalog.type === 'bindings') expect(swmCatalog.bindings).toHaveLength(0);
+    if (swmCatalog.type === 'bindings') expect(swmCatalog.bindings).toHaveLength(catalogFloor.length);
   });
 
   it('rejects generated private-CG catalog floor stripping with a borrowed private on-chain id', async () => {
@@ -538,6 +561,7 @@ describe('Working Memory Assertion Lifecycle', () => {
     await store.insert([onChainIdQuad('2')]);
     (publisher as any).chain.getContextGraphAccessPolicy = async () => 1;
     (publisher as any).chain.getContextGraphNameHash = async () => null;
+    await finalizeAssertion(name);
 
     await expect(
       publisher.assertionPromote(CG_ID, name, AGENT, {
@@ -558,6 +582,7 @@ describe('Working Memory Assertion Lifecycle', () => {
       { subject: 'urn:test:entity:catalog-content', predicate: 'http://schema.org/name', object: '"Content"' },
       ...generatedPrivateCatalogFloorQuads(CG_ID),
     ]);
+    await finalizeAssertion(name);
 
     await expect(
       publisher.assertionPromote(CG_ID, name, AGENT, {
@@ -575,6 +600,7 @@ describe('Working Memory Assertion Lifecycle', () => {
       { subject: 'urn:test:entity:catalog-content', predicate: 'http://schema.org/name', object: '"Content"' },
       ...generatedPrivateCatalogFloorQuads(CG_ID),
     ]);
+    await finalizeAssertion(name);
 
     await expect(
       publisher.assertionPromote(CG_ID, name, AGENT, {
@@ -584,13 +610,7 @@ describe('Working Memory Assertion Lifecycle', () => {
     ).rejects.toThrow(/trustedNonManifestCatalogTriples is only allowed/);
   });
 
-  // Issue #864 — when the assertion data graph is empty but `_meta` says
-  // an extraction completed with N > 0 triples, the legacy
-  // `{ promotedCount: 0 }` return hid the inconsistency behind a
-  // misleading "Promoted 0 triples" toast. The publisher now throws
-  // `AssertionNotPersistedError` so the daemon route can map it to a
-  // 409 with an actionable hint.
-  it('promote throws AssertionNotPersistedError when _meta says extraction completed but data graph is empty', async () => {
+  it('blocks an unsealed empty draft even when legacy extraction metadata claims content', async () => {
     await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
 
     // Simulate the post-import-file state: extraction metadata landed in
@@ -615,36 +635,17 @@ describe('Working Memory Assertion Lifecycle', () => {
       },
     ]);
 
-    await expect(
-      publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT),
-    ).rejects.toBeInstanceOf(AssertionNotPersistedError);
-
-    // Re-run to capture the structured fields the daemon route reads
-    // when building its 409 response body.
-    try {
-      await publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT);
-      throw new Error('expected promote to throw');
-    } catch (err: unknown) {
-      expect(err).toBeInstanceOf(AssertionNotPersistedError);
-      const typed = err as AssertionNotPersistedError;
-      expect(typed.code).toBe('ASSERTION_NOT_PERSISTED');
-      expect(typed.contextGraphId).toBe(CG_ID);
-      expect(typed.assertionGraph).toBe(graphUri);
-      expect(typed.expectedTripleCount).toBe(49);
-    }
+    await expect(publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT)).rejects.toMatchObject({
+      code: 'UNSEALED_SHARE_BLOCKED',
+    });
   });
 
-  // Issue #864 — guard the legitimate empty-promote path. When there's
-  // no extraction metadata in `_meta` at all, an empty data graph is a
-  // perfectly valid no-op (e.g. a `create` with no subsequent `write`,
-  // or a re-promote of an already-promoted assertion). The publisher
-  // must keep returning `{ promotedCount: 0 }` instead of throwing, so
-  // existing polling/retry call-sites don't regress.
-  it('promote returns { promotedCount: 0 } when data graph is empty and _meta has no extraction record', async () => {
+  it('blocks an unsealed empty draft when no extraction metadata exists', async () => {
     await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
 
-    const result = await publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT);
-    expect(result.promotedCount).toBe(0);
+    await expect(publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT)).rejects.toMatchObject({
+      code: 'UNSEALED_SHARE_BLOCKED',
+    });
   });
 
   // Codex review on #898 — `assertionPromote` empties the assertion
@@ -656,7 +657,7 @@ describe('Working Memory Assertion Lifecycle', () => {
   // successful promote was misclassified as ASSERTION_NOT_PERSISTED.
   // The lifecycle marker is flipped to "SWM" by `assertionPromote`, so
   // the second promote must short-circuit cleanly to a no-op.
-  it('promote is a no-op (no AssertionNotPersistedError) when re-running after a successful promote', async () => {
+  it('promote is idempotent only while the already-shared exact graph still matches its seal', async () => {
     await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
     await publisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT, TRIPLES);
 
@@ -681,19 +682,89 @@ describe('Working Memory Assertion Lifecycle', () => {
       },
     ]);
 
+    const finalized = await finalizeAssertion();
     const first = await publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT, { publisherPeerId: PEER });
     expect(first.promotedCount).toBeGreaterThan(0);
 
     // Stale second click — must be a harmless no-op, not an error.
     const second = await publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT, { publisherPeerId: PEER });
     expect(second.promotedCount).toBe(0);
+    expect(second.shareOperationId).toBe(first.shareOperationId);
+    expect(second.gossipMessage).toBeInstanceOf(Uint8Array);
+    expect(await publisher.hasSwmShareComplete(CG_ID, ASSERTION_NAME, AGENT)).toBe(true);
+
+    await store.insert([{
+      subject: 'urn:test:tampered',
+      predicate: 'http://schema.org/name',
+      object: '"Tampered"',
+      graph: finalized.sharedGraphUri,
+    }]);
+    await expect(
+      publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT, { publisherPeerId: PEER }),
+    ).rejects.toThrow(/triple-count mismatch/);
+    expect(await publisher.hasSwmShareComplete(CG_ID, ASSERTION_NAME, AGENT)).toBe(false);
   });
 
-  // Issue #864 — same shape as the previous test but exercises the
-  // partial-metadata case: status present, count = 0 → not an
-  // inconsistency, still a legitimate no-op (e.g. a Phase-1 file with
-  // no extractable structural content).
-  it('promote returns { promotedCount: 0 } when _meta says completed but structuralTripleCount is 0', async () => {
+  it('repairs an interrupted exact-SWM commit before exposing the completion marker', async () => {
+    await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
+    await publisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT, TRIPLES);
+    const finalized = await finalizeAssertion();
+
+    const insert = store.insert.bind(store);
+    let interrupted = false;
+    store.insert = async (quads) => {
+      if (
+        !interrupted
+        && quads.some((quad) => quad.graph.includes('/_shared_memory_snapshots/') && quad.graph.endsWith('/ka'))
+      ) {
+        interrupted = true;
+        throw new Error('injected operation snapshot failure');
+      }
+      return insert(quads);
+    };
+    try {
+      await expect(
+        publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT, { publisherPeerId: PEER }),
+      ).rejects.toThrow('injected operation snapshot failure');
+    } finally {
+      store.insert = insert;
+    }
+
+    expect(interrupted).toBe(true);
+    expect(await publisher.hasSwmShareComplete(CG_ID, ASSERTION_NAME, AGENT)).toBe(false);
+    expect(await store.hasGraph(finalized.sharedGraphUri)).toBe(true);
+
+    const repaired = await publisher.assertionPromote(
+      CG_ID,
+      ASSERTION_NAME,
+      AGENT,
+      { publisherPeerId: PEER },
+    );
+    expect(repaired.promotedCount).toBe(0);
+    expect(repaired.shareOperationId).toBeTruthy();
+    expect(repaired.gossipMessage).toBeInstanceOf(Uint8Array);
+    expect(await publisher.hasSwmShareComplete(CG_ID, ASSERTION_NAME, AGENT)).toBe(true);
+
+    const graphManager = new GraphManager(store);
+    const snapshot = await resolveKnowledgeAssetOperationPublicQuads({
+      store,
+      graphManager,
+      contextGraphId: CG_ID,
+      shareOperationId: repaired.shareOperationId!,
+      kaUal: finalized.kaUal,
+      assertionVersion: finalized.assertionVersion,
+    });
+    expect(snapshot.quads).toHaveLength(finalized.publicQuads.length);
+    const head = await resolveKnowledgeAssetWorkspaceHead({
+      store,
+      graphManager,
+      contextGraphId: CG_ID,
+      kaUal: finalized.kaUal,
+    });
+    expect(head?.shareOperationId).toBe(repaired.shareOperationId);
+  });
+
+  it('blocks an unsealed empty draft when legacy structuralTripleCount is zero', async () => {
     await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
     const graphUri = contextGraphAssertionUri(CG_ID, AGENT, ASSERTION_NAME);
     const metaGraph = contextGraphMetaUri(CG_ID);
@@ -712,11 +783,12 @@ describe('Working Memory Assertion Lifecycle', () => {
       },
     ]);
 
-    const result = await publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT);
-    expect(result.promotedCount).toBe(0);
+    await expect(publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT)).rejects.toMatchObject({
+      code: 'UNSEALED_SHARE_BLOCKED',
+    });
   });
 
-  it('durable SWM ownership skips (advisory) cross-author promote after publisher restart with empty map', async () => {
+  it('keeps cross-author KAs with the same RDF subject isolated after publisher restart', async () => {
     const root = 'urn:test:entity:restart-owned';
     const firstAssertion = 'restart-owner-a';
     const secondAssertion = 'restart-owner-b';
@@ -725,6 +797,7 @@ describe('Working Memory Assertion Lifecycle', () => {
     await publisher.assertionWrite(CG_ID, firstAssertion, AGENT, [
       { subject: root, predicate: 'http://schema.org/name', object: '"Original"' },
     ]);
+    const firstFinalized = await finalizeAssertion(firstAssertion);
     await publisher.assertionPromote(CG_ID, firstAssertion, AGENT, { publisherPeerId: PEER });
 
     const ownerBefore = await store.query(
@@ -732,7 +805,7 @@ describe('Working Memory Assertion Lifecycle', () => {
     );
     expect(ownerBefore.type).toBe('bindings');
     if (ownerBefore.type === 'bindings') {
-      expect(ownerBefore.bindings.map((row) => row['creator'])).toEqual([`"${PEER}"`]);
+      expect(ownerBefore.bindings).toHaveLength(0);
     }
 
     const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
@@ -751,29 +824,33 @@ describe('Working Memory Assertion Lifecycle', () => {
     await restartedPublisher.assertionWrite(CG_ID, secondAssertion, AGENT_B, [
       { subject: root, predicate: 'http://schema.org/name', object: '"Overwritten"' },
     ]);
-
-    // OT-RFC-46 §17.4 / rc.17 D6: a cross-author promote is no longer REJECTED — the
-    // foreign-owned root is skipped (workspaceOwner is now advisory, not a hard gate).
-    // Under the still-bucket SWM the skip preserves the owner's data (no clobber); the
-    // assertions below confirm SWM content and ownership are unchanged. Once SWM is
-    // per-KA (rc.17b) the co-claim coexists in its own graph instead of being skipped.
+    const secondFinalized = await finalizeAssertion(secondAssertion, AGENT_B, {
+      publisher: restartedPublisher,
+    });
     const promoteResult = await restartedPublisher.assertionPromote(
       CG_ID,
       secondAssertion,
       AGENT_B,
       { publisherPeerId: PEER_B },
     );
-    expect(promoteResult.promotedCount).toBe(0);
+    expect(promoteResult.promotedCount).toBe(1);
 
     const remaining = await restartedPublisher.assertionQuery(CG_ID, secondAssertion, AGENT_B);
-    expect(remaining).toHaveLength(1);
+    expect(remaining).toHaveLength(0);
 
-    const swmAfter = await store.query(
-      `SELECT ?o WHERE { GRAPH <${SWM_GRAPH}> { <${root}> <http://schema.org/name> ?o } }`,
+    const firstSwm = await store.query(
+      `SELECT ?o WHERE { GRAPH <${firstFinalized.sharedGraphUri}> { <${root}> <http://schema.org/name> ?o } }`,
     );
-    expect(swmAfter.type).toBe('bindings');
-    if (swmAfter.type === 'bindings') {
-      expect(swmAfter.bindings.map((row) => row['o'])).toEqual(['"Original"']);
+    expect(firstSwm.type).toBe('bindings');
+    if (firstSwm.type === 'bindings') {
+      expect(firstSwm.bindings.map((row) => row['o'])).toEqual(['"Original"']);
+    }
+    const secondSwm = await store.query(
+      `SELECT ?o WHERE { GRAPH <${secondFinalized.sharedGraphUri}> { <${root}> <http://schema.org/name> ?o } }`,
+    );
+    expect(secondSwm.type).toBe('bindings');
+    if (secondSwm.type === 'bindings') {
+      expect(secondSwm.bindings.map((row) => row['o'])).toEqual(['"Overwritten"']);
     }
 
     const ownerAfter = await store.query(
@@ -781,11 +858,11 @@ describe('Working Memory Assertion Lifecycle', () => {
     );
     expect(ownerAfter.type).toBe('bindings');
     if (ownerAfter.type === 'bindings') {
-      expect(ownerAfter.bindings.map((row) => row['creator'])).toEqual([`"${PEER}"`]);
+      expect(ownerAfter.bindings).toHaveLength(0);
     }
   });
 
-  it('durable SWM ownership allows owner promote after publisher restart with empty map', async () => {
+  it('does not use publisherPeerId as ownership for distinct graph-scoped KAs', async () => {
     const root = 'urn:test:entity:restart-owned-upsert';
     const firstAssertion = 'restart-owner-upsert-a';
     const secondAssertion = 'restart-owner-upsert-b';
@@ -794,6 +871,7 @@ describe('Working Memory Assertion Lifecycle', () => {
     await publisher.assertionWrite(CG_ID, firstAssertion, AGENT, [
       { subject: root, predicate: 'http://schema.org/name', object: '"Original"' },
     ]);
+    const firstFinalized = await finalizeAssertion(firstAssertion);
     await publisher.assertionPromote(CG_ID, firstAssertion, AGENT, { publisherPeerId: PEER });
 
     const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
@@ -812,6 +890,9 @@ describe('Working Memory Assertion Lifecycle', () => {
     await restartedPublisher.assertionWrite(CG_ID, secondAssertion, AGENT_B, [
       { subject: root, predicate: 'http://schema.org/name', object: '"Updated"' },
     ]);
+    const secondFinalized = await finalizeAssertion(secondAssertion, AGENT_B, {
+      publisher: restartedPublisher,
+    });
 
     const result = await restartedPublisher.assertionPromote(CG_ID, secondAssertion, AGENT_B, {
       publisherPeerId: PEER,
@@ -821,12 +902,19 @@ describe('Working Memory Assertion Lifecycle', () => {
     const remaining = await restartedPublisher.assertionQuery(CG_ID, secondAssertion, AGENT_B);
     expect(remaining).toHaveLength(0);
 
-    const swmAfter = await store.query(
-      `SELECT ?o WHERE { GRAPH <${SWM_GRAPH}> { <${root}> <http://schema.org/name> ?o } }`,
+    const firstSwm = await store.query(
+      `SELECT ?o WHERE { GRAPH <${firstFinalized.sharedGraphUri}> { <${root}> <http://schema.org/name> ?o } }`,
     );
-    expect(swmAfter.type).toBe('bindings');
-    if (swmAfter.type === 'bindings') {
-      expect(swmAfter.bindings.map((row) => row['o'])).toEqual(['"Updated"']);
+    expect(firstSwm.type).toBe('bindings');
+    if (firstSwm.type === 'bindings') {
+      expect(firstSwm.bindings.map((row) => row['o'])).toEqual(['"Original"']);
+    }
+    const secondSwm = await store.query(
+      `SELECT ?o WHERE { GRAPH <${secondFinalized.sharedGraphUri}> { <${root}> <http://schema.org/name> ?o } }`,
+    );
+    expect(secondSwm.type).toBe('bindings');
+    if (secondSwm.type === 'bindings') {
+      expect(secondSwm.bindings.map((row) => row['o'])).toEqual(['"Updated"']);
     }
 
     const ownerAfter = await store.query(
@@ -834,11 +922,11 @@ describe('Working Memory Assertion Lifecycle', () => {
     );
     expect(ownerAfter.type).toBe('bindings');
     if (ownerAfter.type === 'bindings') {
-      expect(ownerAfter.bindings.map((row) => row['creator'])).toEqual([`"${PEER}"`]);
+      expect(ownerAfter.bindings).toHaveLength(0);
     }
   });
 
-  it('durable SWM ownership collapses conflicts before owner promote after restart', async () => {
+  it('ignores legacy per-root ownership conflicts during graph-scoped promote', async () => {
     const root = 'urn:test:entity:restart-owned-conflict';
     const firstAssertion = 'restart-owner-conflict-a';
     const secondAssertion = 'restart-owner-conflict-b';
@@ -848,9 +936,16 @@ describe('Working Memory Assertion Lifecycle', () => {
     await publisher.assertionWrite(CG_ID, firstAssertion, AGENT, [
       { subject: root, predicate: 'http://schema.org/name', object: '"Original"' },
     ]);
+    const firstFinalized = await finalizeAssertion(firstAssertion);
     await publisher.assertionPromote(CG_ID, firstAssertion, AGENT, { publisherPeerId: PEER });
 
     await store.insert([
+      {
+        subject: root,
+        predicate: 'http://dkg.io/ontology/workspaceOwner',
+        object: `"${PEER}"`,
+        graph: SWM_META_GRAPH,
+      },
       {
         subject: root,
         predicate: 'http://dkg.io/ontology/workspaceOwner',
@@ -887,18 +982,36 @@ describe('Working Memory Assertion Lifecycle', () => {
     await restartedPublisher.assertionWrite(CG_ID, secondAssertion, AGENT_B, [
       { subject: root, predicate: 'http://schema.org/name', object: '"Effective owner update"' },
     ]);
+    const secondFinalized = await finalizeAssertion(secondAssertion, AGENT_B, {
+      publisher: restartedPublisher,
+    });
 
     const result = await restartedPublisher.assertionPromote(CG_ID, secondAssertion, AGENT_B, {
       publisherPeerId: PEER,
     });
     expect(result.promotedCount).toBe(1);
 
-    const swmAfter = await store.query(
-      `SELECT ?o WHERE { GRAPH <${SWM_GRAPH}> { <${root}> <http://schema.org/name> ?o } }`,
+    const firstSwm = await store.query(
+      `SELECT ?o WHERE { GRAPH <${firstFinalized.sharedGraphUri}> { <${root}> <http://schema.org/name> ?o } }`,
     );
-    expect(swmAfter.type).toBe('bindings');
-    if (swmAfter.type === 'bindings') {
-      expect(swmAfter.bindings.map((row) => row['o'])).toEqual(['"Effective owner update"']);
+    expect(firstSwm.type).toBe('bindings');
+    if (firstSwm.type === 'bindings') {
+      expect(firstSwm.bindings.map((row) => row['o'])).toEqual(['"Original"']);
+    }
+    const secondSwm = await store.query(
+      `SELECT ?o WHERE { GRAPH <${secondFinalized.sharedGraphUri}> { <${root}> <http://schema.org/name> ?o } }`,
+    );
+    expect(secondSwm.type).toBe('bindings');
+    if (secondSwm.type === 'bindings') {
+      expect(secondSwm.bindings.map((row) => row['o'])).toEqual(['"Effective owner update"']);
+    }
+    const legacyOwners = await store.query(
+      `SELECT ?creator WHERE { GRAPH <${SWM_META_GRAPH}> { <${root}> <http://dkg.io/ontology/workspaceOwner> ?creator } }`,
+    );
+    expect(legacyOwners.type).toBe('bindings');
+    if (legacyOwners.type === 'bindings') {
+      expect(new Set(legacyOwners.bindings.map((row) => row['creator'])))
+        .toEqual(new Set([`"${PEER}"`, `"${PEER_B}"`]));
     }
   });
 
@@ -906,6 +1019,7 @@ describe('Working Memory Assertion Lifecycle', () => {
     await publisher.assertionCreate(CG_ID, 'large-promote', AGENT);
     const quads = largePayloadQuads('large-promote', 2 * 1024 * 1024);
     await publisher.assertionWrite(CG_ID, 'large-promote', AGENT, quads);
+    await finalizeAssertion('large-promote');
 
     const result = await publisher.assertionPromote(CG_ID, 'large-promote', AGENT, {
       publisherPeerId: PEER,
@@ -921,6 +1035,7 @@ describe('Working Memory Assertion Lifecycle', () => {
     await publisher.assertionCreate(CG_ID, 'too-large-promote', AGENT);
     const quads = largePayloadQuads('too-large-promote', DKG_GOSSIP_MAX_MESSAGE_BYTES + 1024 * 1024);
     await publisher.assertionWrite(CG_ID, 'too-large-promote', AGENT, quads);
+    const finalized = await finalizeAssertion('too-large-promote');
 
     await expect(
       publisher.assertionPromote(CG_ID, 'too-large-promote', AGENT, { publisherPeerId: PEER }),
@@ -930,7 +1045,7 @@ describe('Working Memory Assertion Lifecycle', () => {
     expect(assertionQuads.length).toBe(quads.length);
 
     const swmResult = await store.query(
-      `SELECT ?o WHERE { GRAPH <${SWM_GRAPH}> { <urn:test:entity:too-large-promote:0> <http://schema.org/description> ?o } }`,
+      `SELECT ?o WHERE { GRAPH <${finalized.sharedGraphUri}> { <urn:test:entity:too-large-promote:0> <http://schema.org/description> ?o } }`,
     );
     expect(swmResult.type).toBe('bindings');
     if (swmResult.type === 'bindings') {
@@ -938,18 +1053,16 @@ describe('Working Memory Assertion Lifecycle', () => {
     }
   });
 
-  it('promote with entity filter only moves selected entities', async () => {
+  it('rejects entity-filtered sharing because a graph-scoped KA is atomic', async () => {
     await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
     await publisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT, TRIPLES);
 
-    const result = await publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT, {
+    await expect(publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT, {
       entities: ['urn:test:entity:alice'],
-    });
-    expect(result.promotedCount).toBe(2);
+    })).rejects.toMatchObject({ code: 'KA_ATOMIC_SHARE_REQUIRED' });
 
     const remaining = await publisher.assertionQuery(CG_ID, ASSERTION_NAME, AGENT);
-    expect(remaining.length).toBe(1);
-    expect(remaining[0].subject).toBe('urn:test:entity:bob');
+    expect(remaining).toHaveLength(TRIPLES.length);
 
     const swmResult = await store.query(
       `SELECT ?s WHERE { GRAPH <${SWM_GRAPH}> { ?s ?p ?o } }`,
@@ -957,12 +1070,12 @@ describe('Working Memory Assertion Lifecycle', () => {
     expect(swmResult.type).toBe('bindings');
     if (swmResult.type === 'bindings') {
       const swmSubjects = new Set(swmResult.bindings.map((b) => b['s']));
-      expect(swmSubjects.has('urn:test:entity:alice')).toBe(true);
+      expect(swmSubjects.has('urn:test:entity:alice')).toBe(false);
       expect(swmSubjects.has('urn:test:entity:bob')).toBe(false);
     }
   });
 
-  it('promote with entity filter ignores unrelated named-graph draft content', async () => {
+  it('rejects entity-filtered sharing before touching mixed default/named-graph drafts', async () => {
     const name = 'subset-default-with-local-named-graph';
     const localNamedGraph = 'urn:test:graph:local-only';
     await publisher.assertionCreate(CG_ID, name, AGENT);
@@ -976,17 +1089,20 @@ describe('Working Memory Assertion Lifecycle', () => {
       },
     ]);
 
-    const result = await publisher.assertionPromote(CG_ID, name, AGENT, {
+    await expect(publisher.assertionPromote(CG_ID, name, AGENT, {
       entities: ['urn:test:entity:selected'],
-    });
-    expect(result.promotedCount).toBe(1);
+    })).rejects.toMatchObject({ code: 'KA_ATOMIC_SHARE_REQUIRED' });
 
-    expect(await publisher.assertionQuery(CG_ID, name, AGENT)).toEqual([
+    expect(await publisher.assertionQuery(CG_ID, name, AGENT)).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        subject: 'urn:test:entity:selected',
+        graph: '',
+      }),
       expect.objectContaining({
         subject: 'urn:test:entity:local-only',
         graph: localNamedGraph,
       }),
-    ]);
+    ]));
 
     const swmResult = await store.query(
       `SELECT ?s WHERE { GRAPH <${SWM_GRAPH}> { ?s ?p ?o } }`,
@@ -994,7 +1110,7 @@ describe('Working Memory Assertion Lifecycle', () => {
     expect(swmResult.type).toBe('bindings');
     if (swmResult.type === 'bindings') {
       const swmSubjects = new Set(swmResult.bindings.map((b) => b['s']));
-      expect(swmSubjects.has('urn:test:entity:selected')).toBe(true);
+      expect(swmSubjects.has('urn:test:entity:selected')).toBe(false);
       expect(swmSubjects.has('urn:test:entity:local-only')).toBe(false);
     }
   });
@@ -1028,16 +1144,18 @@ describe('Working Memory Assertion Lifecycle', () => {
     expect(agentBQuads[0].subject).toBe('urn:test:bob');
   });
 
-  it('promote on empty assertion returns 0', async () => {
+  it('blocks promote on an unsealed empty assertion', async () => {
     await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
-    const result = await publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT);
-    expect(result.promotedCount).toBe(0);
+    await expect(publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT)).rejects.toMatchObject({
+      code: 'UNSEALED_SHARE_BLOCKED',
+    });
   });
 
   it('RFC ka-metadata-trim P3.4: promote writes NO ShareTransition record', async () => {
     const SWM_META = `did:dkg:context-graph:${CG_ID}/_shared_memory_meta`;
     await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
     await publisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT, TRIPLES);
+    await finalizeAssertion();
     await publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT);
 
     const result = await store.query(
@@ -1449,13 +1567,14 @@ describe('Working Memory Assertion Lifecycle', () => {
     let quads = await publisher.assertionQuery(CG_ID, ASSERTION_NAME, AGENT);
     expect(quads.length).toBe(3);
 
+    const finalized = await finalizeAssertion();
     await publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT);
 
     quads = await publisher.assertionQuery(CG_ID, ASSERTION_NAME, AGENT);
     expect(quads.length).toBe(0);
 
     const swmResult = await store.query(
-      `SELECT (COUNT(*) AS ?c) WHERE { GRAPH <${SWM_GRAPH}> { ?s ?p ?o } }`,
+      `SELECT (COUNT(*) AS ?c) WHERE { GRAPH <${finalized.sharedGraphUri}> { ?s ?p ?o } }`,
     );
     expect(swmResult.type).toBe('bindings');
     if (swmResult.type === 'bindings') {
@@ -1472,6 +1591,15 @@ describe('Working Memory Assertion sub-graph registration check', () => {
   const SG_NAME = 'code';
   let store: OxigraphStore;
   let publisher: DKGPublisher;
+
+  const finalizeSubGraphAssertion = () => finalizeRootlessAssertionForTest({
+    publisher,
+    store,
+    contextGraphId: SG_CG_ID,
+    name: ASSERTION_NAME,
+    agentAddress: AGENT,
+    subGraphName: SG_NAME,
+  });
 
   beforeEach(async () => {
     store = new OxigraphStore();
@@ -1549,7 +1677,7 @@ describe('Working Memory Assertion sub-graph registration check', () => {
     ).rejects.toThrow(/Sub-graph "code" has not been registered/);
   });
 
-  it('assertionQuery and assertionDiscard still work for legacy unregistered sub-graph graphs', async () => {
+  it('keeps legacy unregistered sub-graph graphs readable but rejects discard mutation', async () => {
     const graphUri = contextGraphAssertionUri(SG_CG_ID, AGENT, ASSERTION_NAME, SG_NAME);
     await store.createGraph(graphUri);
     await store.insert(TRIPLES.map((triple) => ({ ...triple, graph: graphUri })));
@@ -1557,9 +1685,11 @@ describe('Working Memory Assertion sub-graph registration check', () => {
     const quads = await publisher.assertionQuery(SG_CG_ID, ASSERTION_NAME, AGENT, SG_NAME);
     expect(quads.length).toBe(3);
 
-    await publisher.assertionDiscard(SG_CG_ID, ASSERTION_NAME, AGENT, SG_NAME);
+    await expect(
+      publisher.assertionDiscard(SG_CG_ID, ASSERTION_NAME, AGENT, SG_NAME),
+    ).rejects.toMatchObject({ code: 'LEGACY_KA_READ_ONLY' });
     const afterDiscard = await publisher.assertionQuery(SG_CG_ID, ASSERTION_NAME, AGENT, SG_NAME);
-    expect(afterDiscard.length).toBe(0);
+    expect(afterDiscard.length).toBe(3);
   });
 
   it('assertion ops succeed after the sub-graph is registered', async () => {
@@ -1578,12 +1708,11 @@ describe('Working Memory Assertion sub-graph registration check', () => {
   });
 
   it('assertionPromote routes promoted triples into the registered sub-graph shared memory', async () => {
-    const swmGraph = contextGraphSharedMemoryUri(SG_CG_ID, SG_NAME);
-
     await registerSubGraph();
     await publisher.assertionCreate(SG_CG_ID, ASSERTION_NAME, AGENT, SG_NAME);
     await publisher.assertionWrite(SG_CG_ID, ASSERTION_NAME, AGENT, TRIPLES, SG_NAME);
 
+    const finalized = await finalizeSubGraphAssertion();
     const result = await publisher.assertionPromote(SG_CG_ID, ASSERTION_NAME, AGENT, { subGraphName: SG_NAME });
     expect(result.promotedCount).toBe(3);
 
@@ -1591,7 +1720,7 @@ describe('Working Memory Assertion sub-graph registration check', () => {
     expect(assertionQuads.length).toBe(0);
 
     const swmResult = await store.query(
-      `SELECT ?s ?p ?o WHERE { GRAPH <${swmGraph}> { ?s ?p ?o } }`,
+      `SELECT ?s ?p ?o WHERE { GRAPH <${finalized.sharedGraphUri}> { ?s ?p ?o } }`,
     );
     expect(swmResult.type).toBe('bindings');
     if (swmResult.type === 'bindings') {
@@ -1618,6 +1747,14 @@ describe('Assertion Lifecycle Provenance (Event-Sourced, PROV-O)', () => {
   const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
   let store: OxigraphStore;
   let publisher: DKGPublisher;
+
+  const finalizeAssertion = () => finalizeRootlessAssertionForTest({
+    publisher,
+    store,
+    contextGraphId: CG_ID,
+    name: ASSERTION_NAME,
+    agentAddress: AGENT,
+  });
 
   beforeEach(async () => {
     store = new OxigraphStore();
@@ -1721,6 +1858,7 @@ describe('Assertion Lifecycle Provenance (Event-Sourced, PROV-O)', () => {
   it('promote updates state to "promoted" and memoryLayer to "SWM"', async () => {
     await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
     await publisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT, TRIPLES);
+    await finalizeAssertion();
     await publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT);
 
     expect(await queryLifecycleState()).toBe('promoted');
@@ -1730,6 +1868,7 @@ describe('Assertion Lifecycle Provenance (Event-Sourced, PROV-O)', () => {
   it('promote appends an AssertionPromoted event (WM → SWM)', async () => {
     await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
     await publisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT, TRIPLES);
+    await finalizeAssertion();
     await publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT);
 
     const events = await queryEvents();
@@ -1739,9 +1878,10 @@ describe('Assertion Lifecycle Provenance (Event-Sourced, PROV-O)', () => {
     expect(events[1].toLayer).toBe('SWM');
   });
 
-  it('promote records shareOperationId on the event; member entities on the stable lifecycle subject', async () => {
+  it('promote records shareOperationId without root-entity member metadata', async () => {
     await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
     await publisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT, TRIPLES);
+    await finalizeAssertion();
     await publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT);
 
     const uri = assertionLifecycleUri(CG_ID, AGENT, ASSERTION_NAME);
@@ -1755,9 +1895,8 @@ describe('Assertion Lifecycle Provenance (Event-Sourced, PROV-O)', () => {
         `SELECT ?opId WHERE { GRAPH <${META_GRAPH}> { <${eventUri}> <${DKG}shareOperationId> ?opId } } LIMIT 1`,
       );
       expect(opResult.type === 'bindings' && opResult.bindings.length).toBeGreaterThan(0);
-      // RFC ka-metadata-trim Phase 2: the event node no longer duplicates
-      // the member list — the SUBSTRATE-1 stamp on the stable lifecycle
-      // subject is the canonical member index (read-both for old rows).
+      // Rootless V2 keeps neither event-level nor lifecycle-level root member
+      // rows; the UAL-derived exact graph is the complete membership boundary.
       const eventEntityResult = await store.query(
         `SELECT ?entity WHERE { GRAPH <${META_GRAPH}> { <${eventUri}> <${DKG}rootEntity> ?entity } }`,
       );
@@ -1769,7 +1908,7 @@ describe('Assertion Lifecycle Provenance (Event-Sourced, PROV-O)', () => {
       );
       expect(subjectEntityResult.type).toBe('bindings');
       if (subjectEntityResult.type === 'bindings') {
-        expect(subjectEntityResult.bindings.length).toBeGreaterThanOrEqual(2);
+        expect(subjectEntityResult.bindings).toHaveLength(0);
       }
     }
   });
@@ -1796,6 +1935,7 @@ describe('Assertion Lifecycle Provenance (Event-Sourced, PROV-O)', () => {
   it('lifecycle record persists in _meta even after assertion graph is emptied', async () => {
     await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
     await publisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT, TRIPLES);
+    await finalizeAssertion();
     await publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT);
 
     const assertionQuads = await publisher.assertionQuery(CG_ID, ASSERTION_NAME, AGENT);
@@ -1821,6 +1961,7 @@ describe('Assertion Lifecycle Provenance (Event-Sourced, PROV-O)', () => {
     await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT_B);
 
     await publisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT, TRIPLES);
+    await finalizeAssertion();
     await publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT);
 
     expect(await queryLifecycleState()).toBe('promoted');

--- a/packages/publisher/test/draft-lifecycle.test.ts
+++ b/packages/publisher/test/draft-lifecycle.test.ts
@@ -194,17 +194,22 @@ describe('Working Memory Assertion Lifecycle', () => {
     publisher = await createPublisher();
   });
 
-  it('uses one canonical write-lock domain per store', async () => {
-    const isolatedStore = new OxigraphStore();
+  it('keeps lifecycle lock domains explicit regardless of construction order', async () => {
+    const defaultFirstStore = new OxigraphStore();
     const suppliedLocks = new Map<string, Promise<void>>();
-    const configuredPublisher = await createPublisher(suppliedLocks, isolatedStore);
-    const defaultPublisher = await createPublisher(undefined, isolatedStore);
+    const defaultFirst = await createPublisher(undefined, defaultFirstStore);
+    const configuredSecond = await createPublisher(suppliedLocks, defaultFirstStore);
 
-    expect(configuredPublisher.writeLocks).toBe(suppliedLocks);
-    expect(defaultPublisher.writeLocks).toBe(suppliedLocks);
-    await expect(
-      createPublisher(new Map<string, Promise<void>>(), isolatedStore),
-    ).rejects.toThrow('must share the same writeLocks map');
+    expect(defaultFirst.writeLocks).not.toBe(suppliedLocks);
+    expect(configuredSecond.writeLocks).toBe(suppliedLocks);
+
+    const configuredFirstStore = new OxigraphStore();
+    const configuredFirst = await createPublisher(suppliedLocks, configuredFirstStore);
+    const defaultSecond = await createPublisher(undefined, configuredFirstStore);
+
+    expect(configuredFirst.writeLocks).toBe(suppliedLocks);
+    expect(defaultSecond.writeLocks).not.toBe(suppliedLocks);
+    expect(defaultSecond.writeLocks).not.toBe(defaultFirst.writeLocks);
   });
 
   it('create returns the correct assertion graph URI', async () => {
@@ -989,11 +994,13 @@ describe('Working Memory Assertion Lifecycle', () => {
     expect(await publisher.assertionQuery(CG_ID, ASSERTION_NAME, AGENT)).toEqual([]);
   });
 
-  it('serializes lifecycle mutations across publishers sharing one store', async () => {
+  it('serializes lifecycle mutations across publishers given one explicit lock domain', async () => {
+    const sharedLocks = new Map<string, Promise<void>>();
+    publisher = await createPublisher(sharedLocks);
     await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
     await publisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT, TRIPLES);
     await finalizeAssertion();
-    const otherPublisher = await createPublisher();
+    const otherPublisher = await createPublisher(sharedLocks);
 
     let releaseConfirmation!: () => void;
     const confirmationReleased = new Promise<void>((resolve) => {
@@ -2642,6 +2649,33 @@ describe('Working Memory Assertion sub-graph registration check', () => {
     if (swmResult.type === 'bindings') {
       expect(swmResult.bindings.length).toBe(3);
     }
+  });
+
+  it('normalizes canonical sub-graph placement input before finalization and promote', async () => {
+    await registerSubGraph();
+    await publisher.assertionCreate(SG_CG_ID, ASSERTION_NAME, AGENT, SG_NAME);
+    await publisher.assertionWrite(SG_CG_ID, ASSERTION_NAME, AGENT, [{
+      subject: 'urn:test:entity:canonical-subgraph-input',
+      predicate: 'http://www.w3.org/2000/01/rdf-schema#label',
+      object: '"Canonical subgraph input"',
+      graph: contextGraphDataUri(SG_CG_ID, SG_NAME),
+    }], SG_NAME);
+
+    expect(await publisher.assertionQuery(SG_CG_ID, ASSERTION_NAME, AGENT, SG_NAME)).toEqual([
+      expect.objectContaining({
+        subject: 'urn:test:entity:canonical-subgraph-input',
+        graph: '',
+      }),
+    ]);
+    const finalized = await finalizeSubGraphAssertion();
+    await expect(
+      publisher.assertionPromote(SG_CG_ID, ASSERTION_NAME, AGENT, { subGraphName: SG_NAME }),
+    ).resolves.toMatchObject({ promotedCount: 1 });
+    const promoted = await store.query(
+      `ASK { GRAPH <${finalized.sharedGraphUri}> { `
+      + '<urn:test:entity:canonical-subgraph-input> ?p ?o } }',
+    );
+    expect(promoted).toEqual({ type: 'boolean', value: true });
   });
 
   it('assertion ops without a sub-graph name still work (guard is opt-in)', async () => {

--- a/packages/publisher/test/draft-lifecycle.test.ts
+++ b/packages/publisher/test/draft-lifecycle.test.ts
@@ -9,7 +9,11 @@ import {
   contextGraphMetaUri,
   contextGraphLayerUri,
   MemoryLayer,
+  ASSERTION_SEAL_PREDICATES,
   assertionLifecycleUri,
+  createGraphKnowledgeAssetScope,
+  knowledgeAssetLayerGraphUri,
+  decodeWorkspacePublishRequest,
 } from '@origintrail-official/dkg-core';
 import {
   DKGPublisher,
@@ -36,6 +40,8 @@ const AGENT_B = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
 const PEER = '12D3KooWPromoteBoundary';
 const PEER_B = '12D3KooWPromoteBoundaryB';
 const ASSERTION_NAME = 'my-assertion';
+const SHARE_OPERATION_ID_PREDICATE = 'http://dkg.io/ontology/shareOperationId';
+const PROMOTE_OPERATION_INTENT_PREDICATE = 'http://dkg.io/ontology/promoteOperationIntent';
 
 const TRIPLES = [
   { subject: 'urn:test:entity:alice', predicate: 'http://schema.org/name', object: '"Alice"' },
@@ -102,6 +108,23 @@ describe('Working Memory Assertion Lifecycle', () => {
   let store: OxigraphStore;
   let publisher: DKGPublisher;
 
+  const createPublisher = async (
+    writeLocks?: Map<string, Promise<void>>,
+    publisherStore: OxigraphStore = store,
+  ): Promise<DKGPublisher> => {
+    const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
+    const keypair = await generateEd25519Keypair();
+    return new DKGPublisher({
+      store: publisherStore,
+      chain,
+      eventBus: new TypedEventBus(),
+      keypair,
+      publisherPrivateKey: HARDHAT_KEYS.CORE_OP,
+      publisherNodeIdentityId: BigInt(getSharedContext().coreProfileId),
+      ...(writeLocks ? { writeLocks } : {}),
+    });
+  };
+
   const finalizeAssertion = (
     name = ASSERTION_NAME,
     agentAddress = AGENT,
@@ -119,18 +142,69 @@ describe('Working Memory Assertion Lifecycle', () => {
     subGraphName: options.subGraphName,
   });
 
+  const readShareOperationId = async (
+    name = ASSERTION_NAME,
+    agentAddress = AGENT,
+  ): Promise<string | undefined> => {
+    const lifecycle = assertionLifecycleUri(CG_ID, agentAddress, name);
+    const metaGraph = contextGraphMetaUri(CG_ID);
+    const result = await store.query(
+      `SELECT ?id WHERE { GRAPH <${metaGraph}> { ` +
+        `<${lifecycle}> <${SHARE_OPERATION_ID_PREDICATE}> ?id } } LIMIT 1`,
+    );
+    const object = result.type === 'bindings' ? result.bindings[0]?.['id'] : undefined;
+    return object?.match(/^"(.*)"$/)?.[1] ?? object;
+  };
+
+  const hasPromoteOperationIntent = async (): Promise<boolean> => {
+    const lifecycle = assertionLifecycleUri(CG_ID, AGENT, ASSERTION_NAME);
+    const result = await store.query(
+      `ASK { GRAPH <${contextGraphMetaUri(CG_ID)}> { ` +
+        `<${lifecycle}> <${PROMOTE_OPERATION_INTENT_PREDICATE}> ?intent } }`,
+    );
+    return result.type === 'boolean' && result.value;
+  };
+
+  const withInjectedOperationSnapshotFailure = async <T>(
+    operation: () => Promise<T>,
+  ): Promise<T> => {
+    const insert = store.insert.bind(store);
+    let injected = false;
+    store.insert = async (quads) => {
+      if (
+        !injected
+        && quads.some((quad) =>
+          quad.graph.includes('/_shared_memory_snapshots/') && quad.graph.endsWith('/ka'))
+      ) {
+        injected = true;
+        throw new Error('injected operation snapshot failure');
+      }
+      return insert(quads);
+    };
+    try {
+      return await operation();
+    } finally {
+      store.insert = insert;
+      if (!injected) throw new Error('operation snapshot failure injection was not reached');
+    }
+  };
+
   beforeEach(async () => {
     store = new OxigraphStore();
-    const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
-    const keypair = await generateEd25519Keypair();
-    publisher = new DKGPublisher({
-      store,
-      chain,
-      eventBus: new TypedEventBus(),
-      keypair,
-      publisherPrivateKey: HARDHAT_KEYS.CORE_OP,
-      publisherNodeIdentityId: BigInt(getSharedContext().coreProfileId),
-    });
+    publisher = await createPublisher();
+  });
+
+  it('uses one canonical write-lock domain per store', async () => {
+    const isolatedStore = new OxigraphStore();
+    const suppliedLocks = new Map<string, Promise<void>>();
+    const configuredPublisher = await createPublisher(suppliedLocks, isolatedStore);
+    const defaultPublisher = await createPublisher(undefined, isolatedStore);
+
+    expect(configuredPublisher.writeLocks).toBe(suppliedLocks);
+    expect(defaultPublisher.writeLocks).toBe(suppliedLocks);
+    await expect(
+      createPublisher(new Map<string, Promise<void>>(), isolatedStore),
+    ).rejects.toThrow('must share the same writeLocks map');
   });
 
   it('create returns the correct assertion graph URI', async () => {
@@ -333,6 +407,34 @@ describe('Working Memory Assertion Lifecycle', () => {
       code: 'KA_NAMED_GRAPH_SHARE_UNSUPPORTED',
       namedGraphs: [namedGraph],
     });
+  });
+
+  it('rejects private named-graph writes before leaving draft residue', async () => {
+    const name = 'private-named-graph';
+    await publisher.assertionCreate(CG_ID, name, AGENT);
+
+    await expect(
+      publisher.assertionWritePrivate(CG_ID, name, AGENT, [{
+        subject: 'urn:test:entity:private',
+        predicate: 'http://schema.org/name',
+        object: '"Private"',
+        graph: 'urn:test:graph:private',
+      }]),
+    ).rejects.toMatchObject({
+      code: 'KA_NAMED_GRAPH_SHARE_UNSUPPORTED',
+      namedGraphs: ['urn:test:graph:private'],
+    });
+    expect(await publisher.assertionQueryPrivate(CG_ID, name, AGENT)).toEqual([]);
+
+    await publisher.assertionWritePrivate(CG_ID, name, AGENT, [{
+      subject: 'urn:test:entity:private',
+      predicate: 'http://schema.org/name',
+      object: '"Private"',
+      graph: '',
+    }]);
+    expect(await publisher.assertionQueryPrivate(CG_ID, name, AGENT)).toEqual([
+      expect.objectContaining({ subject: 'urn:test:entity:private', graph: '' }),
+    ]);
   });
 
   it('discard removes KA-scoped named graph draft content', async () => {
@@ -705,34 +807,795 @@ describe('Working Memory Assertion Lifecycle', () => {
     expect(await publisher.hasSwmShareComplete(CG_ID, ASSERTION_NAME, AGENT)).toBe(false);
   });
 
-  it('repairs an interrupted exact-SWM commit before exposing the completion marker', async () => {
+  it('validates the exact VM graph before treating a stale promote as a no-op', async () => {
+    await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
+    await publisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT, TRIPLES);
+    const finalized = await finalizeAssertion();
+    await publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT, { publisherPeerId: PEER });
+
+    const vmGraph = knowledgeAssetLayerGraphUri(
+      CG_ID,
+      MemoryLayer.VerifiableMemory,
+      createGraphKnowledgeAssetScope(finalized.kaUal, finalized.assertionVersion),
+    );
+    await store.insert(finalized.publicQuads.map((quad) => ({ ...quad, graph: vmGraph })));
+    await store.dropGraph(finalized.sharedGraphUri);
+    const lifecycle = assertionLifecycleUri(CG_ID, AGENT, ASSERTION_NAME);
+    const metaGraph = contextGraphMetaUri(CG_ID);
+    const memoryLayerPredicate = 'http://dkg.io/ontology/memoryLayer';
+    await store.deleteByPattern({ graph: metaGraph, subject: lifecycle, predicate: memoryLayerPredicate });
+    await store.insert([{
+      subject: lifecycle,
+      predicate: memoryLayerPredicate,
+      object: `"${MemoryLayer.VerifiableMemory}"`,
+      graph: metaGraph,
+    }]);
+
+    await expect(
+      publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT, { publisherPeerId: PEER }),
+    ).resolves.toMatchObject({ promotedCount: 0, promotedAllRoots: false });
+
+    await store.delete([{ ...finalized.publicQuads[0]!, graph: vmGraph }]);
+    await store.insert([{
+      subject: 'urn:test:tampered-vm',
+      predicate: 'http://schema.org/name',
+      object: '"Tampered"',
+      graph: vmGraph,
+    }]);
+    await expect(
+      publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT, { publisherPeerId: PEER }),
+    ).rejects.toThrow(/Merkle mismatch/);
+  });
+
+  it('persists the share operation ID before curator confirmation can escape locally', async () => {
     await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
     await publisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT, TRIPLES);
     const finalized = await finalizeAssertion();
 
+    let confirmedOperationId: string | undefined;
+    const replaceGraph = store.replaceGraph.bind(store);
+    let crashedAfterConfirmation = false;
+    store.replaceGraph = async (graph, quads) => {
+      if (!crashedAfterConfirmation && graph === finalized.sharedGraphUri) {
+        crashedAfterConfirmation = true;
+        throw new Error('injected post-confirmation local crash');
+      }
+      return replaceGraph(graph, quads);
+    };
+    try {
+      await expect(
+        publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT, {
+          publisherPeerId: PEER,
+          confirmBeforeCommit: async () => {
+            confirmedOperationId = await readShareOperationId();
+            return { applied: true };
+          },
+        }),
+      ).rejects.toThrow('injected post-confirmation local crash');
+    } finally {
+      store.replaceGraph = replaceGraph;
+    }
+
+    expect(crashedAfterConfirmation).toBe(true);
+    expect(confirmedOperationId).toBeTruthy();
+    expect(await readShareOperationId()).toBe(confirmedOperationId);
+    const repaired = await publisher.assertionPromote(
+      CG_ID,
+      ASSERTION_NAME,
+      AGENT,
+      {
+        publisherPeerId: PEER,
+        confirmBeforeCommit: async () => ({ applied: true }),
+      },
+    );
+    expect(repaired.shareOperationId).toBe(confirmedOperationId);
+  });
+
+  it('serializes concurrent promotes onto one durable share operation ID', async () => {
+    await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
+    await publisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT, TRIPLES);
+    await finalizeAssertion();
+
+    let confirmationCalls = 0;
+    let activeConfirmations = 0;
+    let maxActiveConfirmations = 0;
+    let releaseFirstConfirmation!: () => void;
+    const firstConfirmationReleased = new Promise<void>((resolve) => {
+      releaseFirstConfirmation = resolve;
+    });
+    let signalFirstConfirmation!: () => void;
+    const firstConfirmationStarted = new Promise<void>((resolve) => {
+      signalFirstConfirmation = resolve;
+    });
+    const confirmBeforeCommit = async (): Promise<{ applied: boolean }> => {
+      confirmationCalls += 1;
+      const call = confirmationCalls;
+      activeConfirmations += 1;
+      maxActiveConfirmations = Math.max(maxActiveConfirmations, activeConfirmations);
+      if (call === 1) {
+        signalFirstConfirmation();
+        await firstConfirmationReleased;
+      }
+      activeConfirmations -= 1;
+      return { applied: true };
+    };
+
+    const firstPromote = publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT, {
+      publisherPeerId: PEER,
+      confirmBeforeCommit,
+    });
+    await firstConfirmationStarted;
+    const secondOptions: NonNullable<Parameters<DKGPublisher['assertionPromote']>[3]> = {
+      publisherPeerId: PEER,
+      confirmBeforeCommit,
+    };
+    const secondPromote = publisher.assertionPromote(
+      CG_ID,
+      ASSERTION_NAME,
+      AGENT,
+      secondOptions,
+    );
+    secondOptions.subGraphName = 'mutated-after-lock-selection';
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(confirmationCalls).toBe(1);
+    releaseFirstConfirmation();
+    const [first, second] = await Promise.all([firstPromote, secondPromote]);
+
+    expect(maxActiveConfirmations).toBe(1);
+    expect(confirmationCalls).toBe(2);
+    expect(first.shareOperationId).toBeTruthy();
+    expect(second.shareOperationId).toBe(first.shareOperationId);
+    expect(await readShareOperationId()).toBe(first.shareOperationId);
+  });
+
+  it('rejects a draft write queued behind a completed promote', async () => {
+    await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
+    await publisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT, TRIPLES);
+    await finalizeAssertion();
+
+    let releaseConfirmation!: () => void;
+    const confirmationReleased = new Promise<void>((resolve) => {
+      releaseConfirmation = resolve;
+    });
+    let signalConfirmationStarted!: () => void;
+    const confirmationStarted = new Promise<void>((resolve) => {
+      signalConfirmationStarted = resolve;
+    });
+    const promote = publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT, {
+      publisherPeerId: PEER,
+      confirmBeforeCommit: async () => {
+        signalConfirmationStarted();
+        await confirmationReleased;
+        return { applied: true };
+      },
+    });
+    await confirmationStarted;
+
+    const lateQuad = {
+      subject: 'urn:test:entity:late-draft',
+      predicate: 'http://schema.org/name',
+      object: '"Late draft"',
+    };
+    const write = publisher.assertionWrite(
+      CG_ID,
+      ASSERTION_NAME,
+      AGENT,
+      [lateQuad],
+    );
+
+    releaseConfirmation();
+    await expect(promote).resolves.toMatchObject({ promotedCount: TRIPLES.length });
+    await expect(write).rejects.toMatchObject({ code: 'KA_WM_LIFECYCLE_REQUIRED' });
+    expect(await publisher.assertionQuery(CG_ID, ASSERTION_NAME, AGENT)).toEqual([]);
+  });
+
+  it('serializes lifecycle mutations across publishers sharing one store', async () => {
+    await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
+    await publisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT, TRIPLES);
+    await finalizeAssertion();
+    const otherPublisher = await createPublisher();
+
+    let releaseConfirmation!: () => void;
+    const confirmationReleased = new Promise<void>((resolve) => {
+      releaseConfirmation = resolve;
+    });
+    let signalConfirmationStarted!: () => void;
+    const confirmationStarted = new Promise<void>((resolve) => {
+      signalConfirmationStarted = resolve;
+    });
+    const promote = publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT, {
+      publisherPeerId: PEER,
+      confirmBeforeCommit: async () => {
+        signalConfirmationStarted();
+        await confirmationReleased;
+        return { applied: true };
+      },
+    });
+    await confirmationStarted;
+
+    const write = otherPublisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT, [{
+      subject: 'urn:test:entity:cross-instance-late-write',
+      predicate: 'http://schema.org/name',
+      object: '"Cross-instance late write"',
+    }]);
+    releaseConfirmation();
+
+    await expect(promote).resolves.toMatchObject({ promotedCount: TRIPLES.length });
+    await expect(write).rejects.toMatchObject({ code: 'KA_WM_LIFECYCLE_REQUIRED' });
+    expect(await otherPublisher.assertionQuery(CG_ID, ASSERTION_NAME, AGENT)).toEqual([]);
+  });
+
+  it('freezes every destructive draft mutation while promote recovery is ambiguous', async () => {
+    await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
+    await publisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT, TRIPLES);
+    const finalized = await finalizeAssertion();
+
+    await expect(
+      publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT, {
+        publisherPeerId: PEER,
+        confirmBeforeCommit: async () => {
+          expect(await publisher.hasSwmShareComplete(
+            CG_ID,
+            ASSERTION_NAME,
+            AGENT,
+          )).toBe(false);
+          return { applied: false };
+        },
+      }),
+    ).rejects.toMatchObject({ name: 'CuratorUnconfirmedError' });
+    const operationId = await readShareOperationId();
+    expect(operationId).toBeTruthy();
+    const sealSubject = contextGraphAssertionUri(CG_ID, AGENT, ASSERTION_NAME);
+    const sealBefore = await store.query(
+      `ASK { GRAPH <${contextGraphMetaUri(CG_ID)}> { ` +
+        `<${sealSubject}> <${ASSERTION_SEAL_PREDICATES.ASSERTION_MERKLE_ROOT}> ?root } }`,
+    );
+    expect(sealBefore).toEqual({ type: 'boolean', value: true });
+
+    const expectedRecoveryError = { code: 'KA_PROMOTE_RECOVERY_REQUIRED' };
+    await expect(
+      publisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT, [TRIPLES[0]!]),
+    ).rejects.toMatchObject(expectedRecoveryError);
+    await expect(
+      publisher.assertionWritePrivate(CG_ID, ASSERTION_NAME, AGENT, [{ ...TRIPLES[0]!, graph: '' }]),
+    ).rejects.toMatchObject(expectedRecoveryError);
+    await expect(
+      publisher.assertionDiscard(CG_ID, ASSERTION_NAME, AGENT),
+    ).rejects.toMatchObject(expectedRecoveryError);
+    await expect(
+      publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT),
+    ).rejects.toMatchObject(expectedRecoveryError);
+    await expect(
+      publisher.assertionPullFrom(CG_ID, ASSERTION_NAME, AGENT, 'swm'),
+    ).rejects.toMatchObject(expectedRecoveryError);
+    await expect(
+      publisher.clearAssertionSeal(CG_ID, ASSERTION_NAME, AGENT),
+    ).rejects.toMatchObject(expectedRecoveryError);
+    await expect(
+      publisher.clearWmDraftDataGraph(CG_ID, ASSERTION_NAME, AGENT),
+    ).rejects.toMatchObject(expectedRecoveryError);
+
+    expect(await readShareOperationId()).toBe(operationId);
+    expect(await hasPromoteOperationIntent()).toBe(true);
+    const remainingPublic = await publisher.assertionQuery(CG_ID, ASSERTION_NAME, AGENT);
+    expect(remainingPublic).toHaveLength(finalized.publicQuads.length);
+    expect(remainingPublic).toEqual(
+      expect.arrayContaining(finalized.publicQuads.map((quad) => expect.objectContaining(quad))),
+    );
+    expect(await publisher.assertionQueryPrivate(CG_ID, ASSERTION_NAME, AGENT)).toEqual([]);
+    expect(await store.query(
+      `ASK { GRAPH <${contextGraphMetaUri(CG_ID)}> { ` +
+        `<${sealSubject}> <${ASSERTION_SEAL_PREDICATES.ASSERTION_MERKLE_ROOT}> ?root } }`,
+    )).toEqual(sealBefore);
+  });
+
+  it('snapshots caller-owned private quads before waiting for the lifecycle lock', async () => {
+    await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
+    await publisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT, TRIPLES);
+    await finalizeAssertion();
+
+    let releaseConfirmation!: () => void;
+    const confirmationReleased = new Promise<void>((resolve) => {
+      releaseConfirmation = resolve;
+    });
+    let signalConfirmationStarted!: () => void;
+    const confirmationStarted = new Promise<void>((resolve) => {
+      signalConfirmationStarted = resolve;
+    });
+    const promote = publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT, {
+      publisherPeerId: PEER,
+      confirmBeforeCommit: async () => {
+        signalConfirmationStarted();
+        await confirmationReleased;
+        return { applied: false, rejected: true };
+      },
+    });
+    await confirmationStarted;
+
+    const input: Quad[] = [{
+      subject: 'urn:test:private:stable',
+      predicate: 'http://schema.org/name',
+      object: '"Stable"',
+      graph: '',
+    }];
+    const write = publisher.assertionWritePrivate(CG_ID, ASSERTION_NAME, AGENT, input);
+    input[0]!.subject = 'urn:dkg:file:mutated-after-validation';
+    input[0]!.graph = 'urn:test:named-after-validation';
+    releaseConfirmation();
+
+    await expect(promote).rejects.toMatchObject({ name: 'CuratorRejectedError' });
+    await expect(write).resolves.toBeUndefined();
+    expect(await publisher.assertionQueryPrivate(CG_ID, ASSERTION_NAME, AGENT)).toEqual([
+      expect.objectContaining({ subject: 'urn:test:private:stable', graph: '' }),
+    ]);
+  });
+
+  it('rejects curator confirmation without a publisher peer before claiming an ID', async () => {
+    await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
+    await publisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT, TRIPLES);
+    await finalizeAssertion();
+
+    let confirmationCalls = 0;
+    await expect(
+      publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT, {
+        confirmBeforeCommit: async () => {
+          confirmationCalls += 1;
+          return { applied: true };
+        },
+      }),
+    ).rejects.toMatchObject({ code: 'KA_PROMOTE_PUBLISHER_PEER_REQUIRED' });
+
+    expect(confirmationCalls).toBe(0);
+    expect(await readShareOperationId()).toBeUndefined();
+    expect(await hasPromoteOperationIntent()).toBe(false);
+    expect(await publisher.assertionQuery(CG_ID, ASSERTION_NAME, AGENT)).not.toHaveLength(0);
+  });
+
+  it('retires the prior completion marker before confirming a reopened draft', async () => {
+    await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
+    await publisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT, TRIPLES);
+    await finalizeAssertion();
+    await publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT, { publisherPeerId: PEER });
+    expect(await publisher.hasSwmShareComplete(CG_ID, ASSERTION_NAME, AGENT)).toBe(true);
+
+    await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
+    await publisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT, [{
+      subject: 'urn:test:entity:new-version',
+      predicate: 'http://schema.org/name',
+      object: '"New version"',
+    }]);
+    await finalizeAssertion();
+    await expect(
+      publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT, {
+        publisherPeerId: PEER,
+        confirmBeforeCommit: async () => {
+          expect(await publisher.hasSwmShareComplete(
+            CG_ID,
+            ASSERTION_NAME,
+            AGENT,
+          )).toBe(false);
+          return { applied: false };
+        },
+      }),
+    ).rejects.toMatchObject({ name: 'CuratorUnconfirmedError' });
+
+    expect(await publisher.hasSwmShareComplete(CG_ID, ASSERTION_NAME, AGENT)).toBe(false);
+    expect(await readShareOperationId()).toBeTruthy();
+  });
+
+  it('allows at most one cross-instance promote claim to reach confirmation', async () => {
+    await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
+    await publisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT, TRIPLES);
+    await finalizeAssertion();
+    // Distinct store object identities model independent processes while both
+    // proxies still delegate to the same backend. Same-store publisher objects
+    // cannot silently split their lock domain (tested above).
+    const independentStoreView = (): OxigraphStore => new Proxy(store, {
+      get(target, property) {
+        const value: unknown = Reflect.get(target, property, target);
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    });
+    const firstClaimPublisher = await createPublisher(undefined, independentStoreView());
+    const otherPublisher = await createPublisher(undefined, independentStoreView());
+
     const insert = store.insert.bind(store);
-    let interrupted = false;
-    store.insert = async (quads) => {
+    const query = store.query.bind(store);
+    let initialClaimReads = 0;
+    let releaseInitialReads!: () => void;
+    const bothInitialReadsFinished = new Promise<void>((resolve) => {
+      releaseInitialReads = resolve;
+    });
+    let claimInsertions = 0;
+    let releaseClaims!: () => void;
+    const bothClaimsInserted = new Promise<void>((resolve) => {
+      releaseClaims = resolve;
+    });
+    store.query = async (sparql) => {
+      const result = await query(sparql);
       if (
-        !interrupted
-        && quads.some((quad) => quad.graph.includes('/_shared_memory_snapshots/') && quad.graph.endsWith('/ka'))
+        sparql.includes('SELECT ?shareOperationId')
+        && sparql.includes(SHARE_OPERATION_ID_PREDICATE)
       ) {
-        interrupted = true;
-        throw new Error('injected operation snapshot failure');
+        initialClaimReads += 1;
+        if (initialClaimReads === 2) releaseInitialReads();
+        await bothInitialReadsFinished;
+      }
+      return result;
+    };
+    store.insert = async (quads) => {
+      const isPromoteClaim = quads.some((quad) => quad.predicate === SHARE_OPERATION_ID_PREDICATE)
+        && quads.some((quad) => quad.predicate === PROMOTE_OPERATION_INTENT_PREDICATE);
+      await insert(quads);
+      if (isPromoteClaim) {
+        claimInsertions += 1;
+        if (claimInsertions === 2) releaseClaims();
+        await bothClaimsInserted;
+      }
+    };
+    let confirmationCalls = 0;
+    try {
+      const settled = await Promise.allSettled([
+        firstClaimPublisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT, {
+          publisherPeerId: PEER,
+          confirmBeforeCommit: async () => {
+            confirmationCalls += 1;
+            return { applied: true };
+          },
+        }),
+        otherPublisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT, {
+          publisherPeerId: PEER_B,
+          confirmBeforeCommit: async () => {
+            confirmationCalls += 1;
+            return { applied: true };
+          },
+        }),
+      ]);
+      expect(settled.filter((result) => result.status === 'fulfilled').length).toBeLessThanOrEqual(1);
+      expect(settled.filter((result) => result.status === 'rejected').length).toBeGreaterThanOrEqual(1);
+      for (const rejected of settled.filter((result) => result.status === 'rejected')) {
+        expect(rejected).toMatchObject({ reason: { code: 'KA_SHARE_OPERATION_ID_CONFLICT' } });
+      }
+    } finally {
+      store.insert = insert;
+      store.query = query;
+    }
+    expect(confirmationCalls).toBeLessThanOrEqual(1);
+    const ids = await store.query(
+      `SELECT ?id WHERE { GRAPH <${contextGraphMetaUri(CG_ID)}> { ` +
+        `<${assertionLifecycleUri(CG_ID, AGENT, ASSERTION_NAME)}> ` +
+        `<${SHARE_OPERATION_ID_PREDICATE}> ?id } } LIMIT 2`,
+    );
+    expect(ids.type === 'bindings' ? ids.bindings : []).toHaveLength(confirmationCalls);
+    const intents = await store.query(
+      `SELECT ?intent WHERE { GRAPH <${contextGraphMetaUri(CG_ID)}> { ` +
+        `<${assertionLifecycleUri(CG_ID, AGENT, ASSERTION_NAME)}> ` +
+        `<${PROMOTE_OPERATION_INTENT_PREDICATE}> ?intent } } LIMIT 2`,
+    );
+    expect(intents.type === 'bindings' ? intents.bindings : []).toHaveLength(confirmationCalls);
+  });
+
+  it('keeps a completed legacy promotion readable without replaying it', async () => {
+    await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
+    await publisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT, TRIPLES);
+    await finalizeAssertion();
+    const promoted = await publisher.assertionPromote(
+      CG_ID,
+      ASSERTION_NAME,
+      AGENT,
+      { publisherPeerId: PEER },
+    );
+    expect(promoted.shareOperationId).toBeTruthy();
+    expect(await publisher.hasSwmShareComplete(CG_ID, ASSERTION_NAME, AGENT)).toBe(true);
+
+    await store.deleteByPattern({
+      graph: contextGraphMetaUri(CG_ID),
+      subject: assertionLifecycleUri(CG_ID, AGENT, ASSERTION_NAME),
+      predicate: PROMOTE_OPERATION_INTENT_PREDICATE,
+    });
+    let confirmationCalls = 0;
+    const retried = await publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT, {
+      publisherPeerId: PEER_B,
+      confirmBeforeCommit: async () => {
+        confirmationCalls += 1;
+        return { applied: true };
+      },
+    });
+
+    expect(retried).toMatchObject({
+      promotedCount: 0,
+      promotedAllRoots: false,
+      shareOperationId: promoted.shareOperationId,
+    });
+    expect(retried.gossipMessage).toBeUndefined();
+    expect(confirmationCalls).toBe(0);
+    expect(await publisher.hasSwmShareComplete(CG_ID, ASSERTION_NAME, AGENT)).toBe(true);
+  });
+
+  it('fails closed when a legacy durable operation ID has no immutable intent', async () => {
+    await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
+    await publisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT, TRIPLES);
+    await finalizeAssertion();
+    await expect(withInjectedOperationSnapshotFailure(() => publisher.assertionPromote(
+      CG_ID,
+      ASSERTION_NAME,
+      AGENT,
+      { publisherPeerId: PEER },
+    ))).rejects.toThrow('injected operation snapshot failure');
+
+    const lifecycle = assertionLifecycleUri(CG_ID, AGENT, ASSERTION_NAME);
+    await store.deleteByPattern({
+      graph: contextGraphMetaUri(CG_ID),
+      subject: lifecycle,
+      predicate: PROMOTE_OPERATION_INTENT_PREDICATE,
+    });
+    await expect(
+      publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT, { publisherPeerId: PEER }),
+    ).rejects.toMatchObject({ code: 'KA_PROMOTE_OPERATION_INTENT_MISSING' });
+    expect(await readShareOperationId()).toBeTruthy();
+    expect(await publisher.hasSwmShareComplete(CG_ID, ASSERTION_NAME, AGENT)).toBe(false);
+  });
+
+  it('clears a stale completion marker before rejecting corrupt recovery intent', async () => {
+    await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
+    await publisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT, TRIPLES);
+    await finalizeAssertion();
+    await expect(withInjectedOperationSnapshotFailure(() => publisher.assertionPromote(
+      CG_ID,
+      ASSERTION_NAME,
+      AGENT,
+      { publisherPeerId: PEER },
+    ))).rejects.toThrow('injected operation snapshot failure');
+
+    const lifecycle = assertionLifecycleUri(CG_ID, AGENT, ASSERTION_NAME);
+    const metaGraph = contextGraphMetaUri(CG_ID);
+    await publisher.markSwmShareComplete(CG_ID, ASSERTION_NAME, AGENT);
+    await store.deleteByPattern({
+      graph: metaGraph,
+      subject: lifecycle,
+      predicate: PROMOTE_OPERATION_INTENT_PREDICATE,
+    });
+    await store.insert([{
+      graph: metaGraph,
+      subject: lifecycle,
+      predicate: PROMOTE_OPERATION_INTENT_PREDICATE,
+      object: '"not-json"',
+    }]);
+
+    await expect(
+      publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT, { publisherPeerId: PEER }),
+    ).rejects.toMatchObject({ code: 'KA_PROMOTE_OPERATION_INTENT_CORRUPT' });
+    expect(await publisher.hasSwmShareComplete(CG_ID, ASSERTION_NAME, AGENT)).toBe(false);
+  });
+
+  it('releases a provisional share operation ID after definitive curator rejection', async () => {
+    await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
+    await publisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT, TRIPLES);
+    await finalizeAssertion();
+
+    let rejectedOperationId: string | undefined;
+    await expect(
+      publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT, {
+        publisherPeerId: PEER,
+        confirmBeforeCommit: async () => {
+          rejectedOperationId = await readShareOperationId();
+          return { applied: false, rejected: true };
+        },
+      }),
+    ).rejects.toMatchObject({ name: 'CuratorRejectedError' });
+
+    expect(rejectedOperationId).toBeTruthy();
+    expect(await readShareOperationId()).toBeUndefined();
+    expect(await hasPromoteOperationIntent()).toBe(false);
+    const retried = await publisher.assertionPromote(
+      CG_ID,
+      ASSERTION_NAME,
+      AGENT,
+      { publisherPeerId: PEER },
+    );
+    expect(retried.shareOperationId).toBeTruthy();
+    expect(retried.shareOperationId).not.toBe(rejectedOperationId);
+  });
+
+  it('retains a durable share operation ID when a later retry is rejected', async () => {
+    await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
+    await publisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT, TRIPLES);
+    await finalizeAssertion();
+
+    await expect(
+      publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT, {
+        publisherPeerId: PEER,
+        confirmBeforeCommit: async () => ({ applied: false }),
+      }),
+    ).rejects.toMatchObject({ name: 'CuratorUnconfirmedError' });
+    const durableOperationId = await readShareOperationId();
+    expect(durableOperationId).toBeTruthy();
+
+    await expect(
+      publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT, {
+        publisherPeerId: PEER,
+        confirmBeforeCommit: async () => ({ applied: false, rejected: true }),
+      }),
+    ).rejects.toMatchObject({ name: 'CuratorRejectedError' });
+    expect(await readShareOperationId()).toBe(durableOperationId);
+
+    await expect(
+      publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT, { publisherPeerId: PEER }),
+    ).rejects.toMatchObject({ code: 'KA_PROMOTE_CONFIRMATION_REQUIRED' });
+    const repaired = await publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT, {
+      publisherPeerId: PEER,
+      confirmBeforeCommit: async () => ({ applied: true }),
+    });
+    expect(repaired.shareOperationId).toBe(durableOperationId);
+  });
+
+  it('reuses the immutable promote envelope across ambiguous retries', async () => {
+    await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
+    await publisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT, TRIPLES);
+    await finalizeAssertion();
+
+    let firstMessage: Uint8Array | undefined;
+    await expect(
+      publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT, {
+        publisherPeerId: PEER,
+        accessPolicy: 'allowList',
+        allowedPeers: [PEER_B, PEER],
+        confirmBeforeCommit: async (message) => {
+          firstMessage = message;
+          return { applied: false };
+        },
+      }),
+    ).rejects.toMatchObject({ name: 'CuratorUnconfirmedError' });
+
+    let retryMessage: Uint8Array | undefined;
+    await expect(
+      publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT, {
+        publisherPeerId: PEER_B,
+        accessPolicy: 'public',
+        confirmBeforeCommit: async (message) => {
+          retryMessage = message;
+          return { applied: false };
+        },
+      }),
+    ).rejects.toMatchObject({ name: 'CuratorUnconfirmedError' });
+
+    expect(firstMessage).toBeDefined();
+    expect(retryMessage).toBeDefined();
+    const first = decodeWorkspacePublishRequest(firstMessage!);
+    const retry = decodeWorkspacePublishRequest(retryMessage!);
+    expect(retry.shareOperationId).toBe(first.shareOperationId);
+    expect(retry.operationId).toBe(first.operationId);
+    expect(String(retry.timestampMs)).toBe(String(first.timestampMs));
+    expect(retry.publisherPeerId).toBe(PEER);
+    expect(retry.accessPolicy).toBe('allowList');
+    expect(retry.allowedPeers).toEqual([PEER, PEER_B].sort());
+  });
+
+  it('fails closed when a lifecycle contains conflicting share operation IDs', async () => {
+    await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
+    await publisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT, TRIPLES);
+    const finalized = await finalizeAssertion();
+
+    await expect(
+      publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT, {
+        publisherPeerId: PEER,
+        confirmBeforeCommit: async () => ({ applied: false }),
+      }),
+    ).rejects.toMatchObject({ name: 'CuratorUnconfirmedError' });
+    const firstOperationId = await readShareOperationId();
+    expect(firstOperationId).toBeTruthy();
+
+    const lifecycle = assertionLifecycleUri(CG_ID, AGENT, ASSERTION_NAME);
+    await store.insert([{
+      subject: lifecycle,
+      predicate: SHARE_OPERATION_ID_PREDICATE,
+      object: '"conflicting-operation-id"',
+      graph: contextGraphMetaUri(CG_ID),
+    }]);
+
+    let confirmationCalled = false;
+    await expect(
+      publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT, {
+        publisherPeerId: PEER,
+        confirmBeforeCommit: async () => {
+          confirmationCalled = true;
+          return { applied: true };
+        },
+      }),
+    ).rejects.toMatchObject({ code: 'KA_SHARE_OPERATION_ID_CONFLICT' });
+    expect(confirmationCalled).toBe(false);
+    expect(await publisher.assertionQuery(CG_ID, ASSERTION_NAME, AGENT)).toHaveLength(TRIPLES.length);
+    const swmExists = await store.query(
+      `ASK { GRAPH <${finalized.sharedGraphUri}> { ?s ?p ?o } }`,
+    );
+    expect(swmExists).toEqual({ type: 'boolean', value: false });
+    const ids = await store.query(
+      `SELECT ?id WHERE { GRAPH <${contextGraphMetaUri(CG_ID)}> { ` +
+        `<${lifecycle}> <${SHARE_OPERATION_ID_PREDICATE}> ?id } }`,
+    );
+    expect(ids.type === 'bindings' ? ids.bindings : []).toHaveLength(2);
+  });
+
+  it('clears an inherited completion marker before fallible SWM repair work', async () => {
+    await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
+    await publisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT, TRIPLES);
+    await finalizeAssertion();
+
+    await expect(
+      withInjectedOperationSnapshotFailure(() =>
+        publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT, { publisherPeerId: PEER }),
+      ),
+    ).rejects.toThrow('injected operation snapshot failure');
+    await publisher.markSwmShareComplete(CG_ID, ASSERTION_NAME, AGENT);
+
+    await expect(
+      withInjectedOperationSnapshotFailure(() =>
+        publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT, { publisherPeerId: PEER }),
+      ),
+    ).rejects.toThrow('injected operation snapshot failure');
+    expect(await publisher.hasSwmShareComplete(CG_ID, ASSERTION_NAME, AGENT)).toBe(false);
+  });
+
+  it('preserves the durable share operation ID across an interrupted SWM repair', async () => {
+    await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
+    await publisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT, TRIPLES);
+    await finalizeAssertion();
+
+    const lifecycle = assertionLifecycleUri(CG_ID, AGENT, ASSERTION_NAME);
+    const insert = store.insert.bind(store);
+    await expect(
+      withInjectedOperationSnapshotFailure(() =>
+        publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT, { publisherPeerId: PEER }),
+      ),
+    ).rejects.toThrow('injected operation snapshot failure');
+    const durableOperationId = await readShareOperationId();
+    expect(durableOperationId).toBeTruthy();
+
+    store.insert = async (quads) => {
+      if (quads.some((quad) =>
+        quad.subject === lifecycle && quad.predicate === SHARE_OPERATION_ID_PREDICATE)) {
+        throw new Error('injected lifecycle repair failure');
       }
       return insert(quads);
     };
     try {
       await expect(
         publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT, { publisherPeerId: PEER }),
-      ).rejects.toThrow('injected operation snapshot failure');
+      ).rejects.toThrow('injected lifecycle repair failure');
     } finally {
       store.insert = insert;
     }
+    expect(await readShareOperationId()).toBe(durableOperationId);
 
-    expect(interrupted).toBe(true);
+    const repaired = await publisher.assertionPromote(
+      CG_ID,
+      ASSERTION_NAME,
+      AGENT,
+      { publisherPeerId: PEER },
+    );
+    expect(repaired.shareOperationId).toBe(durableOperationId);
+  });
+
+  it('repairs an interrupted exact-SWM commit before exposing the completion marker', async () => {
+    await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
+    await publisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT, TRIPLES);
+    const finalized = await finalizeAssertion();
+
+    await expect(
+      withInjectedOperationSnapshotFailure(() =>
+        publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT, { publisherPeerId: PEER }),
+      ),
+    ).rejects.toThrow('injected operation snapshot failure');
+
     expect(await publisher.hasSwmShareComplete(CG_ID, ASSERTION_NAME, AGENT)).toBe(false);
     expect(await store.hasGraph(finalized.sharedGraphUri)).toBe(true);
+
+    // A marker written before the immutable snapshot/head tail is not proof of
+    // completion. Destructive mutation must still force promote recovery.
+    await publisher.markSwmShareComplete(CG_ID, ASSERTION_NAME, AGENT);
+    await expect(
+      publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT),
+    ).rejects.toMatchObject({ code: 'KA_PROMOTE_RECOVERY_REQUIRED' });
 
     const repaired = await publisher.assertionPromote(
       CG_ID,
@@ -762,6 +1625,49 @@ describe('Working Memory Assertion Lifecycle', () => {
       kaUal: finalized.kaUal,
     });
     expect(head?.shareOperationId).toBe(repaired.shareOperationId);
+  });
+
+  it('does not borrow another KA tail to release a corrupt recovery claim', async () => {
+    const completedName = 'completed-tail-owner';
+    await publisher.assertionCreate(CG_ID, completedName, AGENT);
+    await publisher.assertionWrite(CG_ID, completedName, AGENT, [{
+      subject: 'urn:test:entity:completed-tail-owner',
+      predicate: 'http://schema.org/name',
+      object: '"Completed tail owner"',
+    }]);
+    await finalizeAssertion(completedName);
+    await publisher.assertionPromote(CG_ID, completedName, AGENT, { publisherPeerId: PEER });
+    const completedOperationId = await readShareOperationId(completedName);
+    expect(completedOperationId).toBeTruthy();
+
+    await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
+    await publisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT, TRIPLES);
+    await finalizeAssertion();
+    await expect(
+      withInjectedOperationSnapshotFailure(() =>
+        publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT, { publisherPeerId: PEER }),
+      ),
+    ).rejects.toThrow('injected operation snapshot failure');
+
+    const lifecycle = assertionLifecycleUri(CG_ID, AGENT, ASSERTION_NAME);
+    const metaGraph = contextGraphMetaUri(CG_ID);
+    await store.deleteByPattern({
+      graph: metaGraph,
+      subject: lifecycle,
+      predicate: SHARE_OPERATION_ID_PREDICATE,
+    });
+    await store.insert([{
+      graph: metaGraph,
+      subject: lifecycle,
+      predicate: SHARE_OPERATION_ID_PREDICATE,
+      object: JSON.stringify(completedOperationId),
+    }]);
+    await publisher.markSwmShareComplete(CG_ID, ASSERTION_NAME, AGENT);
+
+    await expect(
+      publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT),
+    ).rejects.toMatchObject({ code: 'KA_PROMOTE_RECOVERY_REQUIRED' });
+    expect(await readShareOperationId()).toBe(completedOperationId);
   });
 
   it('blocks an unsealed empty draft when legacy structuralTripleCount is zero', async () => {
@@ -1560,7 +2466,7 @@ describe('Working Memory Assertion Lifecycle', () => {
     }
   });
 
-  it('full lifecycle: create → write → promote → verify SWM → discard', async () => {
+  it('full lifecycle preserves promoted SWM and rejects post-promote discard', async () => {
     await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
     await publisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT, TRIPLES);
 
@@ -1582,7 +2488,17 @@ describe('Working Memory Assertion Lifecycle', () => {
       expect(count).toBe(3);
     }
 
-    await publisher.assertionDiscard(CG_ID, ASSERTION_NAME, AGENT);
+    await expect(
+      publisher.assertionDiscard(CG_ID, ASSERTION_NAME, AGENT),
+    ).rejects.toMatchObject({ code: 'KA_WM_LIFECYCLE_REQUIRED' });
+    const preservedSwm = await store.query(
+      `SELECT (COUNT(*) AS ?c) WHERE { GRAPH <${finalized.sharedGraphUri}> { ?s ?p ?o } }`,
+    );
+    expect(preservedSwm.type).toBe('bindings');
+    if (preservedSwm.type === 'bindings') {
+      const count = Number(String(preservedSwm.bindings[0]?.['c'] ?? '0').match(/\d+/)?.[0] ?? 0);
+      expect(count).toBe(3);
+    }
   });
 });
 

--- a/packages/publisher/test/phase-sequences.test.ts
+++ b/packages/publisher/test/phase-sequences.test.ts
@@ -11,7 +11,6 @@ import {
   TypedEventBus,
   generateEd25519Keypair,
   createOperationContext,
-  encodeWorkspacePublishRequest,
 } from '@origintrail-official/dkg-core';
 import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
 import { EVMChainAdapter } from '@origintrail-official/dkg-chain';
@@ -24,6 +23,7 @@ import { mintTokens } from '../../chain/test/hardhat-harness.js';
 import { wrapPublisherForTest } from './_helpers/seal.js';
 import { makeTestKaAllocator } from './_helpers/ka-allocator.js';
 import { hardhatACKProvider } from './_helpers/acks.js';
+import { encodeRootlessWorkspaceRequest } from './_helpers/rootless-workspace.js';
 
 let CONTEXT_GRAPH: string;
 let _kav10Address: string;
@@ -275,15 +275,14 @@ describe('Phase-sequence contracts', () => {
 
     const quads = [q(ENTITY, 'http://schema.org/name', '"WS draft"')];
     const nquads = quads
-      .map(t => `<${t.subject}> <${t.predicate}> ${t.object} .`)
+      .map(t => `<${t.subject}> <${t.predicate}> ${t.object} <${t.graph}> .`)
       .join('\n');
 
-    const msg = encodeWorkspacePublishRequest({
+    const msg = encodeRootlessWorkspaceRequest({
       shareOperationId: 'ws-test-001',
       contextGraphId: CONTEXT_GRAPH,
       publisherPeerId: '12D3KooWTest',
       nquads: new TextEncoder().encode(nquads),
-      manifest: [{ rootEntity: ENTITY }],
       timestampMs: Date.now(),
     });
 

--- a/packages/publisher/test/security-regressions.test.ts
+++ b/packages/publisher/test/security-regressions.test.ts
@@ -5,7 +5,7 @@
 import { describe, it, expect, beforeEach, beforeAll, afterAll, afterEach } from 'vitest';
 import { OxigraphStore, type Quad, GraphManager } from '@origintrail-official/dkg-storage';
 import { EVMChainAdapter, NoChainAdapter } from '@origintrail-official/dkg-chain';
-import { TypedEventBus, encodeKAUpdateRequest, encodeWorkspacePublishRequest } from '@origintrail-official/dkg-core';
+import { TypedEventBus, encodeKAUpdateRequest } from '@origintrail-official/dkg-core';
 import { generateEd25519Keypair } from '@origintrail-official/dkg-core';
 import {
   DKGPublisher,
@@ -19,6 +19,10 @@ import { mintTokens } from '../../chain/test/hardhat-harness.js';
 import { wrapPublisherForTest } from './_helpers/seal.js';
 import { makeTestKaAllocator } from './_helpers/ka-allocator.js';
 import { hardhatACKProvider } from './_helpers/acks.js';
+import {
+  encodeRootlessWorkspaceRequest,
+  rootlessSharedMemoryGraphFromWire,
+} from './_helpers/rootless-workspace.js';
 
 let CONTEXT_GRAPH: string;
 let _kav10Address: string;
@@ -175,20 +179,18 @@ describe('Prefix deletion safety', () => {
     it('gossip upsert of urn:x:foo does NOT delete urn:x:foobar triples', async () => {
       const peerId = '12D3KooWPrefixTest';
 
-      const msg1 = encodeWorkspacePublishRequest({
+      const msg1 = encodeRootlessWorkspaceRequest({
         contextGraphId: CONTEXT_GRAPH,
         nquads: new TextEncoder().encode(`<urn:x:foo> <http://schema.org/name> "Foo" <${DATA_GRAPH}> .`),
-        manifest: [{ rootEntity: 'urn:x:foo', privateTripleCount: 0 }],
         publisherPeerId: peerId,
         shareOperationId: 'ws-prefix-1',
         timestampMs: Date.now(),
       });
       await handler.handle(msg1, peerId);
 
-      const msg2 = encodeWorkspacePublishRequest({
+      const msg2 = encodeRootlessWorkspaceRequest({
         contextGraphId: CONTEXT_GRAPH,
         nquads: new TextEncoder().encode(`<urn:x:foobar> <http://schema.org/name> "Foobar" <${DATA_GRAPH}> .`),
-        manifest: [{ rootEntity: 'urn:x:foobar', privateTripleCount: 0 }],
         publisherPeerId: peerId,
         shareOperationId: 'ws-prefix-2',
         timestampMs: Date.now(),
@@ -196,18 +198,17 @@ describe('Prefix deletion safety', () => {
       await handler.handle(msg2, peerId);
 
       // Upsert urn:x:foo
-      const msg3 = encodeWorkspacePublishRequest({
+      const msg3 = encodeRootlessWorkspaceRequest({
         contextGraphId: CONTEXT_GRAPH,
         nquads: new TextEncoder().encode(`<urn:x:foo> <http://schema.org/name> "Foo Updated" <${DATA_GRAPH}> .`),
-        manifest: [{ rootEntity: 'urn:x:foo', privateTripleCount: 0 }],
         publisherPeerId: peerId,
         shareOperationId: 'ws-prefix-3',
+        assertionVersion: '2',
         timestampMs: Date.now(),
       });
       await handler.handle(msg3, peerId);
 
-      const gm = new GraphManager(store);
-      const wsGraph = gm.workspaceGraphUri(CONTEXT_GRAPH);
+      const wsGraph = rootlessSharedMemoryGraphFromWire(msg2);
 
       const foobarResult = await store.query(
         `SELECT ?o WHERE { GRAPH <${wsGraph}> { <urn:x:foobar> <http://schema.org/name> ?o } }`,
@@ -801,10 +802,9 @@ describe('Workspace peerId spoofing', () => {
     const victimPeerId = '12D3KooWVictim';
     const attackerPeerId = '12D3KooWAttacker';
 
-    const msg = encodeWorkspacePublishRequest({
+    const msg = encodeRootlessWorkspaceRequest({
       contextGraphId: CONTEXT_GRAPH,
       nquads: new TextEncoder().encode(`<urn:spoof> <http://schema.org/name> "Spoofed" <${DATA_GRAPH}> .`),
-      manifest: [{ rootEntity: 'urn:spoof', privateTripleCount: 0 }],
       publisherPeerId: victimPeerId,
       shareOperationId: 'ws-spoof-1',
       timestampMs: Date.now(),
@@ -812,8 +812,7 @@ describe('Workspace peerId spoofing', () => {
 
     await handler.handle(msg, attackerPeerId);
 
-    const gm = new GraphManager(store);
-    const wsGraph = gm.workspaceGraphUri(CONTEXT_GRAPH);
+    const wsGraph = rootlessSharedMemoryGraphFromWire(msg);
     const result = await store.query(
       `ASK { GRAPH <${wsGraph}> { <urn:spoof> ?p ?o } }`,
     );
@@ -826,10 +825,9 @@ describe('Workspace peerId spoofing', () => {
   it('accepts message where publisherPeerId matches fromPeerId', async () => {
     const peerId = '12D3KooWLegit';
 
-    const msg = encodeWorkspacePublishRequest({
+    const msg = encodeRootlessWorkspaceRequest({
       contextGraphId: CONTEXT_GRAPH,
       nquads: new TextEncoder().encode(`<urn:legit> <http://schema.org/name> "Legit" <${DATA_GRAPH}> .`),
-      manifest: [{ rootEntity: 'urn:legit', privateTripleCount: 0 }],
       publisherPeerId: peerId,
       shareOperationId: 'ws-legit-1',
       timestampMs: Date.now(),
@@ -837,8 +835,7 @@ describe('Workspace peerId spoofing', () => {
 
     await handler.handle(msg, peerId);
 
-    const gm = new GraphManager(store);
-    const wsGraph = gm.workspaceGraphUri(CONTEXT_GRAPH);
+    const wsGraph = rootlessSharedMemoryGraphFromWire(msg);
     const result = await store.query(
       `SELECT ?o WHERE { GRAPH <${wsGraph}> { <urn:legit> <http://schema.org/name> ?o } }`,
     );

--- a/packages/publisher/test/workspace-handler-agent-gate.test.ts
+++ b/packages/publisher/test/workspace-handler-agent-gate.test.ts
@@ -11,7 +11,6 @@ import {
   decodeWorkspacePublishRequest,
   encodeEncryptedWorkspacePayload,
   encodeGossipEnvelope,
-  encodeWorkspacePublishRequest,
   encryptWorkspacePayload,
   generateWorkspaceRecipientEncryptionKey,
   GOSSIP_ENVELOPE_VERSION,
@@ -20,6 +19,7 @@ import {
   type WorkspaceRecipientEncryptionKey,
 } from '@origintrail-official/dkg-core';
 import { SharedMemoryHandler } from '../src/index.js';
+import { encodeRootlessWorkspaceRequest } from './_helpers/rootless-workspace.js';
 
 const CONTEXT_GRAPH_ID = 'workspace-handler-agent-gate';
 const DATA_GRAPH = contextGraphDataUri(CONTEXT_GRAPH_ID);
@@ -34,12 +34,11 @@ let workspaceOwned: Map<string, Map<string, string>>;
 let handler: SharedMemoryHandler;
 
 function workspaceMessage(name: string, operationId: string): Uint8Array {
-  return encodeWorkspacePublishRequest({
+  return encodeRootlessWorkspaceRequest({
     contextGraphId: CONTEXT_GRAPH_ID,
     nquads: new TextEncoder().encode(
       `<${ENTITY}> <http://schema.org/name> "${name}" <${DATA_GRAPH}> .`,
     ),
-    manifest: [{ rootEntity: ENTITY, privateTripleCount: 0 }],
     publisherPeerId: PEER_ID,
     shareOperationId: operationId,
     timestampMs: Date.now(),
@@ -135,7 +134,8 @@ async function insertPrivateAccessPolicy(graph: string): Promise<void> {
 
 async function expectStoredName(name: string): Promise<void> {
   const result = await store.query(
-    `SELECT ?o WHERE { GRAPH <${WORKSPACE_GRAPH}> { <${ENTITY}> <http://schema.org/name> ?o } }`,
+    `SELECT ?o WHERE { GRAPH ?g { <${ENTITY}> <http://schema.org/name> ?o } ` +
+      `FILTER(STRSTARTS(STR(?g), "${WORKSPACE_GRAPH}/")) }`,
   );
   expect(result.type).toBe('bindings');
   if (result.type === 'bindings') {
@@ -146,7 +146,8 @@ async function expectStoredName(name: string): Promise<void> {
 
 async function expectWorkspaceEmpty(): Promise<void> {
   const result = await store.query(
-    `ASK { GRAPH <${WORKSPACE_GRAPH}> { <${ENTITY}> ?p ?o } }`,
+    `ASK { GRAPH ?g { <${ENTITY}> ?p ?o } ` +
+      `FILTER(STRSTARTS(STR(?g), "${WORKSPACE_GRAPH}/")) }`,
   );
   expect(result.type).toBe('boolean');
   if (result.type === 'boolean') {
@@ -163,11 +164,17 @@ describe('SharedMemoryHandler agent-gated gossip', () => {
     });
   });
 
-  it('accepts legacy raw SWM gossip for open context graphs with no policy or allowlist', async () => {
-    await handler.handle(workspaceMessage('Raw Open', 'ws-agent-gate-raw-open'), PEER_ID);
+  it('accepts unsigned V2 SWM gossip for open context graphs with no policy or allowlist', async () => {
+    const outcome = await handler.handle(
+      workspaceMessage('Raw Open', 'ws-agent-gate-raw-open'),
+      PEER_ID,
+    );
 
+    expect(outcome.applied).toBe(true);
     await expectStoredName('Raw Open');
-    expect(workspaceOwned.get(CONTEXT_GRAPH_ID)?.get(ENTITY)).toBe(PEER_ID);
+    // Graph-scoped KAs retain transport ownership in durable KA metadata, not
+    // in the legacy per-root in-memory ownership map.
+    expect(workspaceOwned.get(CONTEXT_GRAPH_ID)?.get(ENTITY)).toBeUndefined();
   });
 
   // GH #1124 (otReviewAgent #1239) — PUBLIC-CG host-catchup forgery gate.

--- a/packages/publisher/test/workspace-handler-trusted-replay.test.ts
+++ b/packages/publisher/test/workspace-handler-trusted-replay.test.ts
@@ -11,7 +11,6 @@ import {
   decodeWorkspacePublishRequest,
   encodeEncryptedWorkspacePayload,
   encodeGossipEnvelope,
-  encodeWorkspacePublishRequest,
   encryptWorkspacePayload,
   generateWorkspaceRecipientEncryptionKey,
   GOSSIP_ENVELOPE_VERSION,
@@ -19,6 +18,7 @@ import {
   type WorkspaceRecipientEncryptionKey,
 } from '@origintrail-official/dkg-core';
 import { SharedMemoryHandler } from '../src/index.js';
+import { encodeRootlessWorkspaceRequest } from './_helpers/rootless-workspace.js';
 
 // Coverage for the `trustedReplay` option on
 // SharedMemoryHandler.handle() — the bypass that lets LU-6
@@ -64,12 +64,11 @@ let store: OxigraphStore;
 let workspaceOwned: Map<string, Map<string, string>>;
 
 function workspaceMessage(name: string, operationId: string, cgId = CONTEXT_GRAPH_ID): Uint8Array {
-  return encodeWorkspacePublishRequest({
+  return encodeRootlessWorkspaceRequest({
     contextGraphId: cgId,
     nquads: new TextEncoder().encode(
       `<${ENTITY}> <http://schema.org/name> "${name}" <${contextGraphDataUri(cgId)}> .`,
     ),
-    manifest: [{ rootEntity: ENTITY, privateTripleCount: 0 }],
     publisherPeerId: PUBLISHER_PEER_ID,
     shareOperationId: operationId,
     timestampMs: Date.now(),
@@ -169,7 +168,8 @@ async function insertPrivateAccessPolicy(): Promise<void> {
 
 async function expectStoredName(name: string): Promise<void> {
   const result = await store.query(
-    `SELECT ?o WHERE { GRAPH <${WORKSPACE_GRAPH}> { <${ENTITY}> <http://schema.org/name> ?o } }`,
+    `SELECT ?o WHERE { GRAPH ?g { <${ENTITY}> <http://schema.org/name> ?o } ` +
+      `FILTER(STRSTARTS(STR(?g), "${WORKSPACE_GRAPH}/")) }`,
   );
   expect(result.type).toBe('bindings');
   if (result.type === 'bindings') {
@@ -180,7 +180,8 @@ async function expectStoredName(name: string): Promise<void> {
 
 async function expectWorkspaceEmpty(): Promise<void> {
   const result = await store.query(
-    `ASK { GRAPH <${WORKSPACE_GRAPH}> { <${ENTITY}> ?p ?o } }`,
+    `ASK { GRAPH ?g { <${ENTITY}> ?p ?o } ` +
+      `FILTER(STRSTARTS(STR(?g), "${WORKSPACE_GRAPH}/")) }`,
   );
   expect(result.type).toBe('boolean');
   if (result.type === 'boolean') {

--- a/packages/publisher/test/workspace.test.ts
+++ b/packages/publisher/test/workspace.test.ts
@@ -5,7 +5,7 @@ import { EVMChainAdapter } from '@origintrail-official/dkg-chain';
 import {
   TypedEventBus,
   generateEd25519Keypair,
-  encodeWorkspacePublishRequest,
+  decodeWorkspacePublishRequest,
   encodeGossipEnvelope,
   encodeEncryptedWorkspacePayload,
   encryptWorkspacePayload,
@@ -20,6 +20,7 @@ import {
   DKGPublisher,
   SharedMemoryHandler,
   StaleWriteError,
+  resolveKnowledgeAssetWorkspaceHead,
   type ShareOptions,
   type ConditionalShareOptions,
 } from '../src/index.js';
@@ -29,6 +30,10 @@ import { mintTokens } from '../../chain/test/hardhat-harness.js';
 import { wrapPublisherForTest, buildSeal } from './_helpers/seal.js';
 import { makeHardhatReceiverACKProvider } from './_helpers/acks.js';
 import { makeTestKaAllocator } from './_helpers/ka-allocator.js';
+import {
+  encodeRootlessWorkspaceRequest,
+  rootlessSharedMemoryGraphFromWire,
+} from './_helpers/rootless-workspace.js';
 import type { V10ACKProvider, V10ACKProviderParams } from '../src/publisher.js';
 
 // RC11 / PR1: in-memory 3-of-N ACK provider that signs the V10 ACK
@@ -598,7 +603,7 @@ describe('Workspace: publishFromSharedMemory', () => {
   it('throws when workspace is empty for selection', async () => {
     await expect(
       publisher.publishFromSharedMemory(CONTEXT_GRAPH, 'all'),
-    ).rejects.toThrow(/No quads in shared memory/);
+    ).rejects.toThrow(/No public or private quads/);
   });
 
   it('escapes backslash and double-quote in rootEntity filter (SPARQL injection prevention)', async () => {
@@ -918,12 +923,10 @@ describe('SharedMemoryHandler', () => {
   });
 
   it('stores valid workspace message to workspace and workspace_meta', async () => {
-    const { encodeWorkspacePublishRequest } = await import('@origintrail-official/dkg-core');
     const nquads = `<${ENTITY}> <http://schema.org/name> "Handler Test" <${DATA_GRAPH}> .`;
-    const msg = encodeWorkspacePublishRequest({
+    const msg = encodeRootlessWorkspaceRequest({
       contextGraphId: CONTEXT_GRAPH,
       nquads: new TextEncoder().encode(nquads),
-      manifest: [{ rootEntity: ENTITY, privateTripleCount: 0 }],
       publisherPeerId: '12D3KooWPeer',
       shareOperationId: 'ws-handler-1',
       timestampMs: Date.now(),
@@ -931,9 +934,7 @@ describe('SharedMemoryHandler', () => {
 
     await handler.handle(msg, '12D3KooWPeer');
 
-    const gm = new GraphManager(store);
-    await gm.ensureContextGraph(CONTEXT_GRAPH);
-    const wsGraph = gm.workspaceGraphUri(CONTEXT_GRAPH);
+    const wsGraph = rootlessSharedMemoryGraphFromWire(msg);
     const result = await store.query(
       `SELECT ?o WHERE { GRAPH <${wsGraph}> { <${ENTITY}> <http://schema.org/name> ?o } }`,
     );
@@ -942,7 +943,7 @@ describe('SharedMemoryHandler', () => {
       expect(result.bindings.length).toBe(1);
       expect(result.bindings[0]['o']).toBe('"Handler Test"');
     }
-    expect(workspaceOwned.get(CONTEXT_GRAPH)?.has(ENTITY)).toBe(true);
+    expect(workspaceOwned.get(CONTEXT_GRAPH)?.has(ENTITY)).not.toBe(true);
   });
 
   it('notifies context-graph meta invalidation after SWM sub-graph auto-registration', async () => {
@@ -954,11 +955,10 @@ describe('SharedMemoryHandler', () => {
     const subGraphName = 'tasks';
     const subGraphGraph = `${DATA_GRAPH}/${subGraphName}`;
     const nquads = `<${ENTITY}> <http://schema.org/name> "SubGraph Handler Test" <${DATA_GRAPH}> .`;
-    const msg = encodeWorkspacePublishRequest({
+    const msg = encodeRootlessWorkspaceRequest({
       contextGraphId: CONTEXT_GRAPH,
       subGraphName,
       nquads: new TextEncoder().encode(nquads),
-      manifest: [{ rootEntity: ENTITY, privateTripleCount: 0 }],
       publisherPeerId: '12D3KooWPeer',
       shareOperationId: 'ws-handler-subgraph-dirty',
       timestampMs: Date.now(),
@@ -988,10 +988,9 @@ describe('SharedMemoryHandler', () => {
     }]);
 
     const nquads = `<${ENTITY}> <http://schema.org/name> "Unsigned" <${DATA_GRAPH}> .`;
-    const msg = encodeWorkspacePublishRequest({
+    const msg = encodeRootlessWorkspaceRequest({
       contextGraphId: CONTEXT_GRAPH,
       nquads: new TextEncoder().encode(nquads),
-      manifest: [{ rootEntity: ENTITY, privateTripleCount: 0 }],
       publisherPeerId: '12D3KooWPeer',
       shareOperationId: 'ws-unsigned-agent-gate',
       timestampMs: Date.now(),
@@ -1019,10 +1018,9 @@ describe('SharedMemoryHandler', () => {
     }]);
 
     const nquads = `<${ENTITY}> <http://schema.org/name> "Malformed Gate" <${DATA_GRAPH}> .`;
-    const msg = encodeWorkspacePublishRequest({
+    const msg = encodeRootlessWorkspaceRequest({
       contextGraphId: CONTEXT_GRAPH,
       nquads: new TextEncoder().encode(nquads),
-      manifest: [{ rootEntity: ENTITY, privateTripleCount: 0 }],
       publisherPeerId: '12D3KooWPeer',
       shareOperationId: 'ws-malformed-agent-gate',
       timestampMs: Date.now(),
@@ -1059,10 +1057,9 @@ describe('SharedMemoryHandler', () => {
     const nquads = `<${ENTITY}> <http://schema.org/name> "Signed" <${DATA_GRAPH}> .`;
     const timestampMs = Date.now();
     const shareOperationId = 'ws-signed-agent-gate';
-    const raw = encodeWorkspacePublishRequest({
+    const raw = encodeRootlessWorkspaceRequest({
       contextGraphId: CONTEXT_GRAPH,
       nquads: new TextEncoder().encode(nquads),
-      manifest: [{ rootEntity: ENTITY, privateTripleCount: 0 }],
       publisherPeerId: '12D3KooWPeer',
       shareOperationId,
       timestampMs,
@@ -1079,10 +1076,9 @@ describe('SharedMemoryHandler', () => {
 
     await handler.handle(msg, '12D3KooWPeer');
 
-    const gm = new GraphManager(store);
-    await gm.ensureContextGraph(CONTEXT_GRAPH);
+    const wsGraph = rootlessSharedMemoryGraphFromWire(raw);
     const result = await store.query(
-      `SELECT ?o WHERE { GRAPH <${gm.workspaceGraphUri(CONTEXT_GRAPH)}> { <${ENTITY}> <http://schema.org/name> ?o } }`,
+      `SELECT ?o WHERE { GRAPH <${wsGraph}> { <${ENTITY}> <http://schema.org/name> ?o } }`,
     );
     expect(result.type).toBe('bindings');
     if (result.type === 'bindings') {
@@ -1105,10 +1101,9 @@ describe('SharedMemoryHandler', () => {
     }]);
 
     const nquads = `<${ENTITY}> <http://schema.org/name> "Denied" <${DATA_GRAPH}> .`;
-    const raw = encodeWorkspacePublishRequest({
+    const raw = encodeRootlessWorkspaceRequest({
       contextGraphId: CONTEXT_GRAPH,
       nquads: new TextEncoder().encode(nquads),
-      manifest: [{ rootEntity: ENTITY, privateTripleCount: 0 }],
       publisherPeerId: '12D3KooWPeer',
       shareOperationId: 'ws-denied-agent-gate',
       timestampMs: Date.now(),
@@ -1128,60 +1123,54 @@ describe('SharedMemoryHandler', () => {
     }
   });
 
-  it('rejects message when rootEntity was created by a different peer (Rule 4)', async () => {
-    const { encodeWorkspacePublishRequest } = await import('@origintrail-official/dkg-core');
+  it('does not consult legacy per-root ownership for a graph-scoped KA', async () => {
     workspaceOwned.set(CONTEXT_GRAPH, new Map([[ENTITY, 'otherPeer']]));
 
     const nquads = `<${ENTITY}> <http://schema.org/name> "Duplicate" <${DATA_GRAPH}> .`;
-    const msg = encodeWorkspacePublishRequest({
+    const msg = encodeRootlessWorkspaceRequest({
       contextGraphId: CONTEXT_GRAPH,
       nquads: new TextEncoder().encode(nquads),
-      manifest: [{ rootEntity: ENTITY, privateTripleCount: 0 }],
       publisherPeerId: '12D3KooWPeer',
       shareOperationId: 'ws-dup',
       timestampMs: Date.now(),
     });
 
-    await handler.handle(msg, '12D3KooWPeer');
+    const outcome = await handler.handle(msg, '12D3KooWPeer');
 
-    const gm = new GraphManager(store);
-    await gm.ensureContextGraph(CONTEXT_GRAPH);
-    const wsGraph = gm.workspaceGraphUri(CONTEXT_GRAPH);
+    const wsGraph = rootlessSharedMemoryGraphFromWire(msg);
     const askResult = await store.query(
       `ASK { GRAPH <${wsGraph}> { <${ENTITY}> ?p ?o } }`,
     );
+    expect(outcome.applied).toBe(true);
     expect(askResult.type).toBe('boolean');
     if (askResult.type === 'boolean') {
-      expect(askResult.value).toBe(false);
+      expect(askResult.value).toBe(true);
     }
   });
 
   it('allows same creator to upsert via gossip handler', async () => {
-    const { encodeWorkspacePublishRequest } = await import('@origintrail-official/dkg-core');
     const peerId = '12D3KooWSameCreator';
 
-    const msg1 = encodeWorkspacePublishRequest({
+    const msg1 = encodeRootlessWorkspaceRequest({
       contextGraphId: CONTEXT_GRAPH,
       nquads: new TextEncoder().encode(`<${ENTITY}> <http://schema.org/name> "Original" <${DATA_GRAPH}> .`),
-      manifest: [{ rootEntity: ENTITY, privateTripleCount: 0 }],
       publisherPeerId: peerId,
       shareOperationId: 'ws-1',
       timestampMs: Date.now(),
     });
     await handler.handle(msg1, peerId);
 
-    const msg2 = encodeWorkspacePublishRequest({
+    const msg2 = encodeRootlessWorkspaceRequest({
       contextGraphId: CONTEXT_GRAPH,
       nquads: new TextEncoder().encode(`<${ENTITY}> <http://schema.org/name> "Updated" <${DATA_GRAPH}> .`),
-      manifest: [{ rootEntity: ENTITY, privateTripleCount: 0 }],
       publisherPeerId: peerId,
       shareOperationId: 'ws-2',
+      assertionVersion: '2',
       timestampMs: Date.now(),
     });
     await handler.handle(msg2, peerId);
 
-    const gm = new GraphManager(store);
-    const wsGraph = gm.workspaceGraphUri(CONTEXT_GRAPH);
+    const wsGraph = rootlessSharedMemoryGraphFromWire(msg2);
     const result = await store.query(
       `SELECT ?o WHERE { GRAPH <${wsGraph}> { <${ENTITY}> <http://schema.org/name> ?o } }`,
     );
@@ -1192,14 +1181,12 @@ describe('SharedMemoryHandler', () => {
     }
   });
 
-  it('persists ownership triples and does not duplicate on same-creator upsert', async () => {
-    const { encodeWorkspacePublishRequest } = await import('@origintrail-official/dkg-core');
+  it('persists one durable KA-level transport owner across assertion versions', async () => {
     const peerId = '12D3KooWOwner';
 
-    const msg1 = encodeWorkspacePublishRequest({
+    const msg1 = encodeRootlessWorkspaceRequest({
       contextGraphId: CONTEXT_GRAPH,
       nquads: new TextEncoder().encode(`<${ENTITY}> <http://schema.org/name> "First" <${DATA_GRAPH}> .`),
-      manifest: [{ rootEntity: ENTITY, privateTripleCount: 0 }],
       publisherPeerId: peerId,
       shareOperationId: 'ws-own-1',
       timestampMs: Date.now(),
@@ -1207,34 +1194,35 @@ describe('SharedMemoryHandler', () => {
     await handler.handle(msg1, peerId);
 
     const gm = new GraphManager(store);
-    const wsMetaGraph = gm.workspaceMetaGraphUri(CONTEXT_GRAPH);
-    const afterFirst = await store.query(
-      `SELECT ?creator WHERE { GRAPH <${wsMetaGraph}> { <${ENTITY}> <http://dkg.io/ontology/workspaceOwner> ?creator } }`,
-    );
-    expect(afterFirst.type).toBe('bindings');
-    if (afterFirst.type === 'bindings') {
-      expect(afterFirst.bindings.length).toBe(1);
-      expect(afterFirst.bindings[0]['creator']).toBe(`"${peerId}"`);
-    }
+    const firstRequest = decodeWorkspacePublishRequest(msg1);
+    const afterFirst = await resolveKnowledgeAssetWorkspaceHead({
+      store,
+      graphManager: gm,
+      contextGraphId: CONTEXT_GRAPH,
+      kaUal: firstRequest.kaUal ?? '',
+    });
+    expect(afterFirst?.publisherPeerId).toBe(peerId);
 
-    const msg2 = encodeWorkspacePublishRequest({
+    const msg2 = encodeRootlessWorkspaceRequest({
       contextGraphId: CONTEXT_GRAPH,
       nquads: new TextEncoder().encode(`<${ENTITY}> <http://schema.org/name> "Updated" <${DATA_GRAPH}> .`),
-      manifest: [{ rootEntity: ENTITY, privateTripleCount: 0 }],
       publisherPeerId: peerId,
       shareOperationId: 'ws-own-2',
+      assertionVersion: '2',
       timestampMs: Date.now(),
     });
     await handler.handle(msg2, peerId);
 
-    const afterSecond = await store.query(
-      `SELECT ?creator WHERE { GRAPH <${wsMetaGraph}> { <${ENTITY}> <http://dkg.io/ontology/workspaceOwner> ?creator } }`,
-    );
-    expect(afterSecond.type).toBe('bindings');
-    if (afterSecond.type === 'bindings') {
-      expect(afterSecond.bindings.length).toBe(1);
-      expect(afterSecond.bindings[0]['creator']).toBe(`"${peerId}"`);
-    }
+    const afterSecond = await resolveKnowledgeAssetWorkspaceHead({
+      store,
+      graphManager: gm,
+      contextGraphId: CONTEXT_GRAPH,
+      kaUal: firstRequest.kaUal ?? '',
+    });
+    expect(afterSecond).toMatchObject({
+      assertionVersion: '2',
+      publisherPeerId: peerId,
+    });
   });
 });
 
@@ -1257,10 +1245,9 @@ describe('SharedMemoryHandler.handle outcome (rc.9 PR-C codex R3)', () => {
 
   it('successful apply returns { applied: true } with metadata for PR-D ack-quorum tracking', async () => {
     const nquads = `<${ENTITY}> <http://schema.org/name> "Applied" <${DATA_GRAPH}> .`;
-    const msg = encodeWorkspacePublishRequest({
+    const msg = encodeRootlessWorkspaceRequest({
       contextGraphId: CONTEXT_GRAPH,
       nquads: new TextEncoder().encode(nquads),
-      manifest: [{ rootEntity: ENTITY, privateTripleCount: 0 }],
       publisherPeerId: '12D3KooWPeerR3',
       shareOperationId: 'op-applied',
       timestampMs: Date.now(),
@@ -1281,6 +1268,7 @@ describe('SharedMemoryHandler.handle outcome (rc.9 PR-C codex R3)', () => {
     // assertions need the new field.
     expect(outcome).toEqual({
       applied: true,
+      assetUal: expect.stringMatching(/^did:dkg:/),
       cgId: CONTEXT_GRAPH,
       shareOperationId: 'op-applied',
       publisherPeerId: '12D3KooWPeerR3',
@@ -1290,10 +1278,9 @@ describe('SharedMemoryHandler.handle outcome (rc.9 PR-C codex R3)', () => {
 
   it('permanent rejection (publisherPeerId / fromPeerId mismatch) returns { applied: false, retryable: false }', async () => {
     const nquads = `<${ENTITY}> <http://schema.org/name> "PubMismatch" <${DATA_GRAPH}> .`;
-    const msg = encodeWorkspacePublishRequest({
+    const msg = encodeRootlessWorkspaceRequest({
       contextGraphId: CONTEXT_GRAPH,
       nquads: new TextEncoder().encode(nquads),
-      manifest: [{ rootEntity: ENTITY, privateTripleCount: 0 }],
       publisherPeerId: '12D3KooWClaimedPublisher',
       shareOperationId: 'op-pub-mismatch',
       timestampMs: Date.now(),
@@ -1320,10 +1307,9 @@ describe('SharedMemoryHandler.handle outcome (rc.9 PR-C codex R3)', () => {
     // withWriteLocksRejection = 'cas' → outcome should be
     // retryable.
     const nquads = `<${ENTITY}> <http://schema.org/name> "CASRetry" <${DATA_GRAPH}> .`;
-    const msg = encodeWorkspacePublishRequest({
+    const msg = encodeRootlessWorkspaceRequest({
       contextGraphId: CONTEXT_GRAPH,
       nquads: new TextEncoder().encode(nquads),
-      manifest: [{ rootEntity: ENTITY, privateTripleCount: 0 }],
       publisherPeerId: '12D3KooWPeerR4',
       shareOperationId: 'op-cas-retryable',
       timestampMs: Date.now(),
@@ -1384,10 +1370,9 @@ describe('SharedMemoryHandler.handle outcome (rc.9 PR-C codex R3)', () => {
     const throwingHandler = new SharedMemoryHandler(throwingStore, new TypedEventBus(), {});
 
     const nquads = `<${ENTITY}> <http://schema.org/name> "WillThrow" <${DATA_GRAPH}> .`;
-    const msg = encodeWorkspacePublishRequest({
+    const msg = encodeRootlessWorkspaceRequest({
       contextGraphId: CONTEXT_GRAPH,
       nquads: new TextEncoder().encode(nquads),
-      manifest: [{ rootEntity: ENTITY, privateTripleCount: 0 }],
       publisherPeerId: '12D3KooWPeerR3',
       shareOperationId: 'op-retryable',
       timestampMs: Date.now(),
@@ -1417,10 +1402,9 @@ describe('SharedMemoryHandler: redundant-apply counter (rc.9 PR-A)', () => {
 
   it('does not count first delivery of a (cgId, shareOpId) pair', async () => {
     const nquads = `<${ENTITY}> <http://schema.org/name> "First" <${DATA_GRAPH}> .`;
-    const msg = encodeWorkspacePublishRequest({
+    const msg = encodeRootlessWorkspaceRequest({
       contextGraphId: CONTEXT_GRAPH,
       nquads: new TextEncoder().encode(nquads),
-      manifest: [{ rootEntity: ENTITY, privateTripleCount: 0 }],
       publisherPeerId: '12D3KooWPeer',
       shareOperationId: 'first-only',
       timestampMs: Date.now(),
@@ -1433,10 +1417,9 @@ describe('SharedMemoryHandler: redundant-apply counter (rc.9 PR-A)', () => {
 
   it('counts each subsequent delivery of the same (cgId, shareOpId) within TTL', async () => {
     const nquads = `<${ENTITY}> <http://schema.org/name> "Twice" <${DATA_GRAPH}> .`;
-    const msg = encodeWorkspacePublishRequest({
+    const msg = encodeRootlessWorkspaceRequest({
       contextGraphId: CONTEXT_GRAPH,
       nquads: new TextEncoder().encode(nquads),
-      manifest: [{ rootEntity: ENTITY, privateTripleCount: 0 }],
       publisherPeerId: '12D3KooWPeer',
       shareOperationId: 'dup-op',
       timestampMs: Date.now(),
@@ -1458,18 +1441,16 @@ describe('SharedMemoryHandler: redundant-apply counter (rc.9 PR-A)', () => {
     const otherCg = `${CONTEXT_GRAPH}-second`;
     const otherDataGraph = `did:dkg:context-graph:${otherCg}`;
 
-    const msgA = encodeWorkspacePublishRequest({
+    const msgA = encodeRootlessWorkspaceRequest({
       contextGraphId: CONTEXT_GRAPH,
       nquads: new TextEncoder().encode(`<${ENTITY}> <http://schema.org/name> "A" <${DATA_GRAPH}> .`),
-      manifest: [{ rootEntity: ENTITY, privateTripleCount: 0 }],
       publisherPeerId: '12D3KooWPeer',
       shareOperationId: 'op-a',
       timestampMs: Date.now(),
     });
-    const msgB = encodeWorkspacePublishRequest({
+    const msgB = encodeRootlessWorkspaceRequest({
       contextGraphId: otherCg,
       nquads: new TextEncoder().encode(`<${ENTITY}> <http://schema.org/name> "B" <${otherDataGraph}> .`),
-      manifest: [{ rootEntity: ENTITY, privateTripleCount: 0 }],
       publisherPeerId: '12D3KooWPeer',
       shareOperationId: 'op-b',
       timestampMs: Date.now(),
@@ -1498,10 +1479,9 @@ describe('SharedMemoryHandler: redundant-apply counter (rc.9 PR-A)', () => {
       now: () => nowMs,
     });
 
-    const msg = encodeWorkspacePublishRequest({
+    const msg = encodeRootlessWorkspaceRequest({
       contextGraphId: CONTEXT_GRAPH,
       nquads: new TextEncoder().encode(`<${ENTITY}> <http://schema.org/name> "TTL" <${DATA_GRAPH}> .`),
-      manifest: [{ rootEntity: ENTITY, privateTripleCount: 0 }],
       publisherPeerId: '12D3KooWPeer',
       shareOperationId: 'op-ttl',
       timestampMs: nowMs,
@@ -1516,10 +1496,9 @@ describe('SharedMemoryHandler: redundant-apply counter (rc.9 PR-A)', () => {
 
   it('still applies the second delivery (no behavior change — measurement only)', async () => {
     const nquads = `<${ENTITY}> <http://schema.org/name> "Applied" <${DATA_GRAPH}> .`;
-    const msg = encodeWorkspacePublishRequest({
+    const msg = encodeRootlessWorkspaceRequest({
       contextGraphId: CONTEXT_GRAPH,
       nquads: new TextEncoder().encode(nquads),
-      manifest: [{ rootEntity: ENTITY, privateTripleCount: 0 }],
       publisherPeerId: '12D3KooWPeer',
       shareOperationId: 'op-applied-twice',
       timestampMs: Date.now(),
@@ -1528,9 +1507,7 @@ describe('SharedMemoryHandler: redundant-apply counter (rc.9 PR-A)', () => {
     await handler.handle(msg, '12D3KooWPeer');
     await handler.handle(msg, '12D3KooWPeer');
 
-    const gm = new GraphManager(store);
-    await gm.ensureContextGraph(CONTEXT_GRAPH);
-    const wsGraph = gm.workspaceGraphUri(CONTEXT_GRAPH);
+    const wsGraph = rootlessSharedMemoryGraphFromWire(msg);
     const result = await store.query(
       `SELECT ?o WHERE { GRAPH <${wsGraph}> { <${ENTITY}> <http://schema.org/name> ?o } }`,
     );
@@ -1556,10 +1533,9 @@ describe('SharedMemoryHandler: redundant-apply counter (rc.9 PR-A)', () => {
   // Codex review on PR #570 caught the early-bump.
   it('does NOT count a duplicated rejected delivery (R1: rejected messages skipped)', async () => {
     const nquads = `<${ENTITY}> <http://schema.org/name> "Bad" <${DATA_GRAPH}> .`;
-    const badMsg = encodeWorkspacePublishRequest({
+    const badMsg = encodeRootlessWorkspaceRequest({
       contextGraphId: CONTEXT_GRAPH,
       nquads: new TextEncoder().encode(nquads),
-      manifest: [{ rootEntity: ENTITY, privateTripleCount: 0 }],
       publisherPeerId: '12D3KooWPeer',
       shareOperationId: 'op-rejected',
       timestampMs: Date.now(),
@@ -1578,10 +1554,9 @@ describe('SharedMemoryHandler: redundant-apply counter (rc.9 PR-A)', () => {
 
   it('does NOT count a duplicated delivery whose publisherPeerId disagrees with the sender (R1: rejected messages skipped)', async () => {
     const nquads = `<${ENTITY}> <http://schema.org/name> "Spoofed" <${DATA_GRAPH}> .`;
-    const spoofedMsg = encodeWorkspacePublishRequest({
+    const spoofedMsg = encodeRootlessWorkspaceRequest({
       contextGraphId: CONTEXT_GRAPH,
       nquads: new TextEncoder().encode(nquads),
-      manifest: [{ rootEntity: ENTITY, privateTripleCount: 0 }],
       // Claims to be from Peer-A but `handle()` receives it from
       // Peer-Other → rejected at the publisherPeerId check.
       publisherPeerId: '12D3KooWPeer-A',
@@ -1970,15 +1945,13 @@ describe('SharedMemoryHandler: CAS gossip enforcement', () => {
   });
 
   it('rejects CAS conditions with SPARQL injection in subject', async () => {
-    const { encodeWorkspacePublishRequest } = await import('@origintrail-official/dkg-core');
     const peerId = '12D3KooWPeer';
     const safeEntity = 'urn:test:safe-entity';
     const nquads = `<${safeEntity}> <http://schema.org/name> "Test" <${DATA_GRAPH}> .`;
 
-    const msg = encodeWorkspacePublishRequest({
+    const msg = encodeRootlessWorkspaceRequest({
       contextGraphId: CONTEXT_GRAPH,
       nquads: new TextEncoder().encode(nquads),
-      manifest: [{ rootEntity: safeEntity, privateTripleCount: 0 }],
       publisherPeerId: peerId,
       shareOperationId: 'ws-inject-1',
       timestampMs: Date.now(),
@@ -2002,15 +1975,13 @@ describe('SharedMemoryHandler: CAS gossip enforcement', () => {
   });
 
   it('rejects CAS conditions with SPARQL injection in expectedValue', async () => {
-    const { encodeWorkspacePublishRequest } = await import('@origintrail-official/dkg-core');
     const peerId = '12D3KooWPeer';
     const safeEntity = 'urn:test:safe-entity2';
 
     // First write so the entity exists
-    const setupMsg = encodeWorkspacePublishRequest({
+    const setupMsg = encodeRootlessWorkspaceRequest({
       contextGraphId: CONTEXT_GRAPH,
       nquads: new TextEncoder().encode(`<${safeEntity}> <http://schema.org/name> "Setup" <${DATA_GRAPH}> .`),
-      manifest: [{ rootEntity: safeEntity, privateTripleCount: 0 }],
       publisherPeerId: peerId,
       shareOperationId: 'ws-setup',
       timestampMs: Date.now(),
@@ -2018,12 +1989,12 @@ describe('SharedMemoryHandler: CAS gossip enforcement', () => {
     await handler.handle(setupMsg, peerId);
 
     const nquads = `<${safeEntity}> <http://schema.org/name> "Updated" <${DATA_GRAPH}> .`;
-    const msg = encodeWorkspacePublishRequest({
+    const msg = encodeRootlessWorkspaceRequest({
       contextGraphId: CONTEXT_GRAPH,
       nquads: new TextEncoder().encode(nquads),
-      manifest: [{ rootEntity: safeEntity, privateTripleCount: 0 }],
       publisherPeerId: peerId,
       shareOperationId: 'ws-inject-2',
+      assertionVersion: '2',
       timestampMs: Date.now(),
       casConditions: [{
         subject: safeEntity,
@@ -2035,8 +2006,7 @@ describe('SharedMemoryHandler: CAS gossip enforcement', () => {
 
     await handler.handle(msg, peerId);
 
-    const gm = new GraphManager(store);
-    const wsGraph = gm.workspaceGraphUri(CONTEXT_GRAPH);
+    const wsGraph = rootlessSharedMemoryGraphFromWire(setupMsg);
     const result = await store.query(
       `SELECT ?o WHERE { GRAPH <${wsGraph}> { <${safeEntity}> <http://schema.org/name> ?o } }`,
     );
@@ -2048,26 +2018,24 @@ describe('SharedMemoryHandler: CAS gossip enforcement', () => {
   });
 
   it('accepts valid CAS conditions and enforces them', async () => {
-    const { encodeWorkspacePublishRequest } = await import('@origintrail-official/dkg-core');
     const peerId = '12D3KooWPeer';
     const entity = 'urn:test:cas-valid';
 
-    const setupMsg = encodeWorkspacePublishRequest({
+    const setupMsg = encodeRootlessWorkspaceRequest({
       contextGraphId: CONTEXT_GRAPH,
       nquads: new TextEncoder().encode(`<${entity}> <http://example.org/status> "recruiting" <${DATA_GRAPH}> .`),
-      manifest: [{ rootEntity: entity, privateTripleCount: 0 }],
       publisherPeerId: peerId,
       shareOperationId: 'ws-cas-setup',
       timestampMs: Date.now(),
     });
     await handler.handle(setupMsg, peerId);
 
-    const updateMsg = encodeWorkspacePublishRequest({
+    const updateMsg = encodeRootlessWorkspaceRequest({
       contextGraphId: CONTEXT_GRAPH,
       nquads: new TextEncoder().encode(`<${entity}> <http://example.org/status> "traveling" <${DATA_GRAPH}> .`),
-      manifest: [{ rootEntity: entity, privateTripleCount: 0 }],
       publisherPeerId: peerId,
       shareOperationId: 'ws-cas-update',
+      assertionVersion: '2',
       timestampMs: Date.now(),
       casConditions: [{
         subject: entity,
@@ -2078,8 +2046,7 @@ describe('SharedMemoryHandler: CAS gossip enforcement', () => {
     });
     await handler.handle(updateMsg, peerId);
 
-    const gm = new GraphManager(store);
-    const wsGraph = gm.workspaceGraphUri(CONTEXT_GRAPH);
+    const wsGraph = rootlessSharedMemoryGraphFromWire(updateMsg);
     const result = await store.query(
       `SELECT ?o WHERE { GRAPH <${wsGraph}> { <${entity}> <http://example.org/status> ?o } }`,
     );
@@ -2091,26 +2058,24 @@ describe('SharedMemoryHandler: CAS gossip enforcement', () => {
   });
 
   it('rejects write when CAS condition value mismatches', async () => {
-    const { encodeWorkspacePublishRequest } = await import('@origintrail-official/dkg-core');
     const peerId = '12D3KooWPeer';
     const entity = 'urn:test:cas-mismatch';
 
-    const setupMsg = encodeWorkspacePublishRequest({
+    const setupMsg = encodeRootlessWorkspaceRequest({
       contextGraphId: CONTEXT_GRAPH,
       nquads: new TextEncoder().encode(`<${entity}> <http://example.org/status> "traveling" <${DATA_GRAPH}> .`),
-      manifest: [{ rootEntity: entity, privateTripleCount: 0 }],
       publisherPeerId: peerId,
       shareOperationId: 'ws-mismatch-setup',
       timestampMs: Date.now(),
     });
     await handler.handle(setupMsg, peerId);
 
-    const updateMsg = encodeWorkspacePublishRequest({
+    const updateMsg = encodeRootlessWorkspaceRequest({
       contextGraphId: CONTEXT_GRAPH,
       nquads: new TextEncoder().encode(`<${entity}> <http://example.org/status> "arrived" <${DATA_GRAPH}> .`),
-      manifest: [{ rootEntity: entity, privateTripleCount: 0 }],
       publisherPeerId: peerId,
       shareOperationId: 'ws-mismatch-update',
+      assertionVersion: '2',
       timestampMs: Date.now(),
       casConditions: [{
         subject: entity,
@@ -2121,8 +2086,7 @@ describe('SharedMemoryHandler: CAS gossip enforcement', () => {
     });
     await handler.handle(updateMsg, peerId);
 
-    const gm = new GraphManager(store);
-    const wsGraph = gm.workspaceGraphUri(CONTEXT_GRAPH);
+    const wsGraph = rootlessSharedMemoryGraphFromWire(setupMsg);
     const result = await store.query(
       `SELECT ?o WHERE { GRAPH <${wsGraph}> { <${entity}> <http://example.org/status> ?o } }`,
     );
@@ -2134,14 +2098,12 @@ describe('SharedMemoryHandler: CAS gossip enforcement', () => {
   });
 
   it('expectAbsent: allows write when triple does not exist', async () => {
-    const { encodeWorkspacePublishRequest } = await import('@origintrail-official/dkg-core');
     const peerId = '12D3KooWPeer';
     const entity = 'urn:test:absent-pass';
 
-    const msg = encodeWorkspacePublishRequest({
+    const msg = encodeRootlessWorkspaceRequest({
       contextGraphId: CONTEXT_GRAPH,
       nquads: new TextEncoder().encode(`<${entity}> <http://example.org/status> "recruiting" <${DATA_GRAPH}> .`),
-      manifest: [{ rootEntity: entity, privateTripleCount: 0 }],
       publisherPeerId: peerId,
       shareOperationId: 'ws-absent-pass',
       timestampMs: Date.now(),
@@ -2154,8 +2116,7 @@ describe('SharedMemoryHandler: CAS gossip enforcement', () => {
     });
     await handler.handle(msg, peerId);
 
-    const gm = new GraphManager(store);
-    const wsGraph = gm.workspaceGraphUri(CONTEXT_GRAPH);
+    const wsGraph = rootlessSharedMemoryGraphFromWire(msg);
     const result = await store.query(
       `ASK { GRAPH <${wsGraph}> { <${entity}> <http://example.org/status> ?o } }`,
     );
@@ -2164,26 +2125,24 @@ describe('SharedMemoryHandler: CAS gossip enforcement', () => {
   });
 
   it('expectAbsent: rejects write when triple already exists', async () => {
-    const { encodeWorkspacePublishRequest } = await import('@origintrail-official/dkg-core');
     const peerId = '12D3KooWPeer';
     const entity = 'urn:test:absent-fail';
 
-    const setupMsg = encodeWorkspacePublishRequest({
+    const setupMsg = encodeRootlessWorkspaceRequest({
       contextGraphId: CONTEXT_GRAPH,
       nquads: new TextEncoder().encode(`<${entity}> <http://example.org/status> "recruiting" <${DATA_GRAPH}> .`),
-      manifest: [{ rootEntity: entity, privateTripleCount: 0 }],
       publisherPeerId: peerId,
       shareOperationId: 'ws-absent-setup',
       timestampMs: Date.now(),
     });
     await handler.handle(setupMsg, peerId);
 
-    const updateMsg = encodeWorkspacePublishRequest({
+    const updateMsg = encodeRootlessWorkspaceRequest({
       contextGraphId: CONTEXT_GRAPH,
       nquads: new TextEncoder().encode(`<${entity}> <http://example.org/status> "traveling" <${DATA_GRAPH}> .`),
-      manifest: [{ rootEntity: entity, privateTripleCount: 0 }],
       publisherPeerId: peerId,
       shareOperationId: 'ws-absent-reject',
+      assertionVersion: '2',
       timestampMs: Date.now(),
       casConditions: [{
         subject: entity,
@@ -2194,8 +2153,7 @@ describe('SharedMemoryHandler: CAS gossip enforcement', () => {
     });
     await handler.handle(updateMsg, peerId);
 
-    const gm = new GraphManager(store);
-    const wsGraph = gm.workspaceGraphUri(CONTEXT_GRAPH);
+    const wsGraph = rootlessSharedMemoryGraphFromWire(setupMsg);
     const result = await store.query(
       `SELECT ?o WHERE { GRAPH <${wsGraph}> { <${entity}> <http://example.org/status> ?o } }`,
     );
@@ -2207,26 +2165,24 @@ describe('SharedMemoryHandler: CAS gossip enforcement', () => {
   });
 
   it('rejects non-absent CAS condition with empty expectedValue (protobuf default)', async () => {
-    const { encodeWorkspacePublishRequest } = await import('@origintrail-official/dkg-core');
     const peerId = '12D3KooWPeer';
     const entity = 'urn:test:empty-expected';
 
-    const setupMsg = encodeWorkspacePublishRequest({
+    const setupMsg = encodeRootlessWorkspaceRequest({
       contextGraphId: CONTEXT_GRAPH,
       nquads: new TextEncoder().encode(`<${entity}> <http://schema.org/name> "Setup" <${DATA_GRAPH}> .`),
-      manifest: [{ rootEntity: entity, privateTripleCount: 0 }],
       publisherPeerId: peerId,
       shareOperationId: 'ws-empty-setup',
       timestampMs: Date.now(),
     });
     await handler.handle(setupMsg, peerId);
 
-    const updateMsg = encodeWorkspacePublishRequest({
+    const updateMsg = encodeRootlessWorkspaceRequest({
       contextGraphId: CONTEXT_GRAPH,
       nquads: new TextEncoder().encode(`<${entity}> <http://schema.org/name> "Updated" <${DATA_GRAPH}> .`),
-      manifest: [{ rootEntity: entity, privateTripleCount: 0 }],
       publisherPeerId: peerId,
       shareOperationId: 'ws-empty-update',
+      assertionVersion: '2',
       timestampMs: Date.now(),
       casConditions: [{
         subject: entity,
@@ -2237,8 +2193,7 @@ describe('SharedMemoryHandler: CAS gossip enforcement', () => {
     });
     await handler.handle(updateMsg, peerId);
 
-    const gm = new GraphManager(store);
-    const wsGraph = gm.workspaceGraphUri(CONTEXT_GRAPH);
+    const wsGraph = rootlessSharedMemoryGraphFromWire(setupMsg);
     const result = await store.query(
       `SELECT ?o WHERE { GRAPH <${wsGraph}> { <${entity}> <http://schema.org/name> ?o } }`,
     );
@@ -2533,15 +2488,13 @@ describe('SharedMemoryHandler: CAS edge cases', () => {
   });
 
   it('rejects CAS conditions with SPARQL injection in predicate', async () => {
-    const { encodeWorkspacePublishRequest } = await import('@origintrail-official/dkg-core');
     const peerId = '12D3KooWPeer';
     const entity = 'urn:test:inject-pred';
     const nquads = `<${entity}> <http://schema.org/name> "Test" <${DATA_GRAPH}> .`;
 
-    const msg = encodeWorkspacePublishRequest({
+    const msg = encodeRootlessWorkspaceRequest({
       contextGraphId: CONTEXT_GRAPH,
       nquads: new TextEncoder().encode(nquads),
-      manifest: [{ rootEntity: entity, privateTripleCount: 0 }],
       publisherPeerId: peerId,
       shareOperationId: 'ws-inject-pred',
       timestampMs: Date.now(),
@@ -2565,27 +2518,29 @@ describe('SharedMemoryHandler: CAS edge cases', () => {
   });
 
   it('cross-subject CAS: condition on subject A, write targets subject B — lock covers both', async () => {
-    const { encodeWorkspacePublishRequest } = await import('@origintrail-official/dkg-core');
     const peerId = '12D3KooWPeer';
     const subjectA = 'urn:test:lock-a';
     const subjectB = 'urn:test:lock-b';
 
-    const setupA = encodeWorkspacePublishRequest({
+    const setupA = encodeRootlessWorkspaceRequest({
       contextGraphId: CONTEXT_GRAPH,
       nquads: new TextEncoder().encode(`<${subjectA}> <http://example.org/status> "active" <${DATA_GRAPH}> .`),
-      manifest: [{ rootEntity: subjectA, privateTripleCount: 0 }],
       publisherPeerId: peerId,
       shareOperationId: 'ws-lock-setup-a',
       timestampMs: Date.now(),
     });
     await handler.handle(setupA, peerId);
+    const setupScope = decodeWorkspacePublishRequest(setupA);
 
-    const writeB = encodeWorkspacePublishRequest({
+    const writeB = encodeRootlessWorkspaceRequest({
       contextGraphId: CONTEXT_GRAPH,
       nquads: new TextEncoder().encode(`<${subjectB}> <http://example.org/name> "Created conditionally" <${DATA_GRAPH}> .`),
-      manifest: [{ rootEntity: subjectB, privateTripleCount: 0 }],
       publisherPeerId: peerId,
       shareOperationId: 'ws-lock-write-b',
+      agentAddress: setupScope.agentAddress,
+      kaNumber: setupScope.kaNumber,
+      kaUal: setupScope.kaUal,
+      assertionVersion: '2',
       timestampMs: Date.now(),
       casConditions: [{
         subject: subjectA,
@@ -2596,8 +2551,7 @@ describe('SharedMemoryHandler: CAS edge cases', () => {
     });
     await handler.handle(writeB, peerId);
 
-    const gm = new GraphManager(store);
-    const wsGraph = gm.workspaceGraphUri(CONTEXT_GRAPH);
+    const wsGraph = rootlessSharedMemoryGraphFromWire(writeB);
     const result = await store.query(
       `ASK { GRAPH <${wsGraph}> { <${subjectB}> <http://example.org/name> ?o } }`,
     );
@@ -2606,27 +2560,29 @@ describe('SharedMemoryHandler: CAS edge cases', () => {
   });
 
   it('cross-subject CAS: rejects when condition on subject A fails', async () => {
-    const { encodeWorkspacePublishRequest } = await import('@origintrail-official/dkg-core');
     const peerId = '12D3KooWPeer';
     const subjectA = 'urn:test:lock-a2';
     const subjectB = 'urn:test:lock-b2';
 
-    const setupA = encodeWorkspacePublishRequest({
+    const setupA = encodeRootlessWorkspaceRequest({
       contextGraphId: CONTEXT_GRAPH,
       nquads: new TextEncoder().encode(`<${subjectA}> <http://example.org/status> "inactive" <${DATA_GRAPH}> .`),
-      manifest: [{ rootEntity: subjectA, privateTripleCount: 0 }],
       publisherPeerId: peerId,
       shareOperationId: 'ws-lock-setup-a2',
       timestampMs: Date.now(),
     });
     await handler.handle(setupA, peerId);
+    const setupScope = decodeWorkspacePublishRequest(setupA);
 
-    const writeB = encodeWorkspacePublishRequest({
+    const writeB = encodeRootlessWorkspaceRequest({
       contextGraphId: CONTEXT_GRAPH,
       nquads: new TextEncoder().encode(`<${subjectB}> <http://example.org/name> "Should not appear" <${DATA_GRAPH}> .`),
-      manifest: [{ rootEntity: subjectB, privateTripleCount: 0 }],
       publisherPeerId: peerId,
       shareOperationId: 'ws-lock-write-b2',
+      agentAddress: setupScope.agentAddress,
+      kaNumber: setupScope.kaNumber,
+      kaUal: setupScope.kaUal,
+      assertionVersion: '2',
       timestampMs: Date.now(),
       casConditions: [{
         subject: subjectA,
@@ -2637,8 +2593,7 @@ describe('SharedMemoryHandler: CAS edge cases', () => {
     });
     await handler.handle(writeB, peerId);
 
-    const gm = new GraphManager(store);
-    const wsGraph = gm.workspaceGraphUri(CONTEXT_GRAPH);
+    const wsGraph = rootlessSharedMemoryGraphFromWire(setupA);
     const result = await store.query(
       `ASK { GRAPH <${wsGraph}> { <${subjectB}> ?p ?o } }`,
     );
@@ -2647,29 +2602,27 @@ describe('SharedMemoryHandler: CAS edge cases', () => {
   });
 
   it('multiple gossip CAS conditions: rejects if any single condition fails', async () => {
-    const { encodeWorkspacePublishRequest } = await import('@origintrail-official/dkg-core');
     const peerId = '12D3KooWPeer';
     const entity = 'urn:test:multi-cond';
 
-    const setup = encodeWorkspacePublishRequest({
+    const setup = encodeRootlessWorkspaceRequest({
       contextGraphId: CONTEXT_GRAPH,
       nquads: new TextEncoder().encode(
         `<${entity}> <http://example.org/status> "recruiting" <${DATA_GRAPH}> .\n` +
         `<${entity}> <http://example.org/turn> "5"^^<http://www.w3.org/2001/XMLSchema#integer> <${DATA_GRAPH}> .`,
       ),
-      manifest: [{ rootEntity: entity, privateTripleCount: 0 }],
       publisherPeerId: peerId,
       shareOperationId: 'ws-multi-setup',
       timestampMs: Date.now(),
     });
     await handler.handle(setup, peerId);
 
-    const update = encodeWorkspacePublishRequest({
+    const update = encodeRootlessWorkspaceRequest({
       contextGraphId: CONTEXT_GRAPH,
       nquads: new TextEncoder().encode(`<${entity}> <http://example.org/status> "traveling" <${DATA_GRAPH}> .`),
-      manifest: [{ rootEntity: entity, privateTripleCount: 0 }],
       publisherPeerId: peerId,
       shareOperationId: 'ws-multi-update',
+      assertionVersion: '2',
       timestampMs: Date.now(),
       casConditions: [
         { subject: entity, predicate: 'http://example.org/status', expectedValue: '"recruiting"', expectAbsent: false },
@@ -2678,8 +2631,7 @@ describe('SharedMemoryHandler: CAS edge cases', () => {
     });
     await handler.handle(update, peerId);
 
-    const gm = new GraphManager(store);
-    const wsGraph = gm.workspaceGraphUri(CONTEXT_GRAPH);
+    const wsGraph = rootlessSharedMemoryGraphFromWire(setup);
     const result = await store.query(
       `SELECT ?o WHERE { GRAPH <${wsGraph}> { <${entity}> <http://example.org/status> ?o } }`,
     );
@@ -2691,30 +2643,28 @@ describe('SharedMemoryHandler: CAS edge cases', () => {
   });
 
   it('gossip CAS with typed literal (xsd:integer) succeeds when match', async () => {
-    const { encodeWorkspacePublishRequest } = await import('@origintrail-official/dkg-core');
     const peerId = '12D3KooWPeer';
     const entity = 'urn:test:typed-lit';
 
-    const setup = encodeWorkspacePublishRequest({
+    const setup = encodeRootlessWorkspaceRequest({
       contextGraphId: CONTEXT_GRAPH,
       nquads: new TextEncoder().encode(
         `<${entity}> <http://example.org/turn> "1"^^<http://www.w3.org/2001/XMLSchema#integer> <${DATA_GRAPH}> .`,
       ),
-      manifest: [{ rootEntity: entity, privateTripleCount: 0 }],
       publisherPeerId: peerId,
       shareOperationId: 'ws-typed-setup',
       timestampMs: Date.now(),
     });
     await handler.handle(setup, peerId);
 
-    const update = encodeWorkspacePublishRequest({
+    const update = encodeRootlessWorkspaceRequest({
       contextGraphId: CONTEXT_GRAPH,
       nquads: new TextEncoder().encode(
         `<${entity}> <http://example.org/turn> "2"^^<http://www.w3.org/2001/XMLSchema#integer> <${DATA_GRAPH}> .`,
       ),
-      manifest: [{ rootEntity: entity, privateTripleCount: 0 }],
       publisherPeerId: peerId,
       shareOperationId: 'ws-typed-update',
+      assertionVersion: '2',
       timestampMs: Date.now(),
       casConditions: [{
         subject: entity,
@@ -2725,8 +2675,7 @@ describe('SharedMemoryHandler: CAS edge cases', () => {
     });
     await handler.handle(update, peerId);
 
-    const gm = new GraphManager(store);
-    const wsGraph = gm.workspaceGraphUri(CONTEXT_GRAPH);
+    const wsGraph = rootlessSharedMemoryGraphFromWire(update);
     const result = await store.query(
       `SELECT ?o WHERE { GRAPH <${wsGraph}> { <${entity}> <http://example.org/turn> ?o } }`,
     );


### PR DESCRIPTION
## Summary

- enforce exact graph-scoped pull-from and promotion for new rootless Knowledge Assets
- reject payload RDF named graphs before canonicalization can erase their dataset identity
- make interrupted WM to SWM commits repair the exact graph, immutable operation snapshot, monotonic head, and completion marker before returning success
- replay the durable share operation and gossip payload on retry so a post-commit response loss cannot strand peer synchronization
- replace root-oriented publisher fixtures with reusable rootless lifecycle and workspace helpers

## Compatibility

Legacy root-scoped KAs remain readable, but their mutation path stays quarantined. New graph-scoped writes require a complete v2 seal and operate on the exact UAL plus assertion-version graph.

## Validation

- `pnpm --filter @origintrail-official/dkg-publisher build`
- publisher Vitest matrix: 400 suites, 1,567 passed, 6 skipped, 0 failed
- injected crash regression proves the completion marker stays absent until operation snapshot and head repair finish

Stacked on #1722.