### PR TITLE
refactor(ka): make legacy SWM assets read-only

### DIFF
--- a/packages/adapter-hermes/hermes-plugin/__init__.py
+++ b/packages/adapter-hermes/hermes-plugin/__init__.py
@@ -2828,8 +2828,8 @@ def _validate_decimal_string_arg(value: Any, label: str) -> Tuple[Optional[str],
 # (cross-adapter parity invariant).
 SHARE_NOT_PUBLISH_READY_WARNING = (
     "Shared to SWM but NOT publish-ready (sealed:false). Legacy unsealed SWM "
-    "content is read-only; recreate or pull the asset into Working Memory, then "
-    "use an atomic full share before publishing."
+    "content is read-only; use the preserved Working Memory draft if available, "
+    "or recreate the knowledge asset, then use an atomic full share before publishing."
 )
 
 # #1116: a SUBSET share is publishReady:false too, but unlike a skip_seal full

--- a/packages/adapter-hermes/hermes-plugin/__init__.py
+++ b/packages/adapter-hermes/hermes-plugin/__init__.py
@@ -602,9 +602,9 @@ DKG_ASSERTION_FINALIZE_SCHEMA = {
         "(dkg_knowledge_asset_share with entities omitted or \"all\") auto-seals for you, so you "
         "only need to call this explicitly before sharing a SELECTIVE subset of entities, or to "
         "re-seal after editing a previously-sealed draft. Sealing works even if the context graph "
-        "is NOT yet registered on-chain (registration happens at publish). Pass layer=\"swm\" to "
-        "seal an asset already shared to SWM (e.g. shared with skip_seal) -- it recovers and seals "
-        "the SWM content without a delete-and-recreate. Author signing is node-side via "
+        "is NOT yet registered on-chain (registration happens at publish). The deprecated "
+        "layer=\"swm\" compatibility value is read-only and returns LEGACY_KA_READ_ONLY; recover "
+        "legacy content through Working Memory and an atomic full share instead. Author signing is node-side via "
         "author_agent_address; external-signer (pre-signed) attestation is a tracked follow-up, "
         "not exposed by the agent tools."
     ),
@@ -625,9 +625,8 @@ DKG_ASSERTION_FINALIZE_SCHEMA = {
                 "type": "string",
                 "enum": ["wm", "swm"],
                 "description": (
-                    "Which layer holds the content to seal. Default \"wm\" seals the open Working "
-                    "Memory draft. Pass \"swm\" to seal an asset already shared to SWM (recovers + "
-                    "seals the SWM content without delete-and-recreate)."
+                    "Default \"wm\" seals the open Working Memory draft. Deprecated \"swm\" is "
+                    "read-only and returns LEGACY_KA_READ_ONLY."
                 ),
             },
             "sub_graph_name": {"type": "string", "description": "Optional sub-graph name (must match write time)."},
@@ -673,9 +672,9 @@ DKG_ASSERTION_SHARE_SCHEMA = {
         "Share a knowledge asset (or selected root entities) from Working Memory into Shared "
         "Working Memory. A FULL share (omit `entities` or pass \"all\") SEALS BY DEFAULT and is "
         "then publish-ready -- follow with dkg_knowledge_asset_publish to mint it on-chain "
-        "(Verifiable Memory). Pass skip_seal=true to share WITHOUT sealing (an unsealed SWM share "
-        "-- seal it later with dkg_knowledge_asset_finalize, where layer=\"swm\" works after "
-        "sharing). If a default (sealing) share cannot seal it fails CLOSED (409, Working Memory "
+        "(Verifiable Memory). skip_seal=true is retained only for compatibility; an unsealed SWM "
+        "share cannot be finalized because legacy SWM writes are read-only. If a default "
+        "(sealing) share cannot seal it fails CLOSED (409, Working Memory "
         "preserved) and returns a recovery hint. For CUSTOM finalize options "
         "such as author_agent_address / scheme_version, call dkg_knowledge_asset_finalize "
         "EXPLICITLY first (the default seal cannot carry them). A SELECTIVE subset "
@@ -704,9 +703,9 @@ DKG_ASSERTION_SHARE_SCHEMA = {
             "skip_seal": {
                 "type": "boolean",
                 "description": (
-                    "Set true to share to SWM WITHOUT sealing (not publish-ready). Default (false) "
-                    "seals a full share so it is immediately publish-ready. Ignored for a subset "
-                    "share, which is never sealed."
+                    "Deprecated compatibility option. True shares to SWM without sealing, but "
+                    "legacy SWM is read-only and the result cannot be finalized. Default false "
+                    "atomically seals a full share."
                 ),
             },
             "sub_graph_name": {"type": "string", "description": "Optional sub-graph name."},
@@ -2823,29 +2822,30 @@ def _validate_decimal_string_arg(value: Any, label: str) -> Tuple[Optional[str],
 
 
 # #1116: the publishReady:false warning surfaced after a FULL share that opted
-# out of sealing (skip_seal=true) — a later finalize(layer:swm) DOES seal it.
+# out of sealing (skip_seal=true). Legacy SWM content is read-only, so recovery
+# must go through WM + atomic share.
 # Kept byte-identical across the MCP, OpenClaw, and Hermes adapters
 # (cross-adapter parity invariant).
 SHARE_NOT_PUBLISH_READY_WARNING = (
-    "Shared to SWM but NOT publish-ready (sealed:false). Seal it with "
-    "dkg_knowledge_asset_finalize (layer:swm works after sharing), then publish."
+    "Shared to SWM but NOT publish-ready (sealed:false). Legacy unsealed SWM "
+    "content is read-only; recreate or pull the asset into Working Memory, then "
+    "use an atomic full share before publishing."
 )
 
 # #1116: a SUBSET share is publishReady:false too, but unlike a skip_seal full
-# share it is NOT sealable — finalize(layer:swm) now REJECTS it with
-# SWM_SUBSET_NOT_SEALABLE. Surface the real recovery (full share / new asset)
+# share it is NOT sealable — legacy SWM finalize is read-only. Surface the real recovery (full share / new asset)
 # instead of the dead-end "seal it" advice. Byte-identical across all three
 # adapters (cross-adapter parity invariant).
 SHARE_SUBSET_NOT_PUBLISH_READY_WARNING = (
     "Shared a SUBSET to SWM for peer visibility. A subset is NOT sealable/"
-    "publishable (finalize layer:swm will reject it). To publish on-chain, share "
-    "the full asset (entities:\"all\"), or model this subset as its own knowledge asset."
+    "publishable. Legacy SWM finalize is read-only. To publish on-chain, share "
+    "the full asset atomically (entities:\"all\"), or model this subset as its own knowledge asset."
 )
 
 # #1116: a FULL share can come back sealed:true but publishReady:false when NOT
 # every sealed root reached SWM (promotedAllRoots false — e.g. foreign-owned roots
-# were skipped). The engine did NOT set the swmShareComplete marker, so
-# finalize(layer:swm) would REJECT — do NOT recommend it here. Re-sharing the full
+# were skipped). The engine did NOT set the swmShareComplete marker, and SWM is
+# read-only, so do NOT recommend finalizing it. Re-sharing the full
 # asset is the recovery. Byte-identical across all three adapters (cross-adapter
 # parity invariant).
 SHARE_INCOMPLETE_PROMOTE_WARNING = (
@@ -2890,15 +2890,14 @@ def _annotate_share_seal(result: Any, entities: Any = None) -> Any:
     is false, add a parity warning that branches on the ACTUAL outcome (three
     cases):
 
-      1. ``sealed:false`` + SUBSET (a non-empty specific list) → NOT sealable
-         (``finalize layer:swm`` rejects it with ``SWM_SUBSET_NOT_SEALABLE``);
+      1. ``sealed:false`` + SUBSET (a non-empty specific list) → NOT sealable;
          recover via a full share or a new asset.
-      2. ``sealed:false`` + FULL ("all"/omitted ``skip_seal``) → sealable later
-         (``finalize layer:swm`` works — the marker is set).
+      2. ``sealed:false`` + FULL ("all"/omitted ``skip_seal``) → recover through
+         Working Memory and an atomic full share.
       3. ``sealed:true`` + ``publishReady:false`` → an incomplete full promote
          (not every sealed root reached SWM, e.g. foreign-owned roots skipped). The
-         ``swmShareComplete`` marker is NOT set, so ``finalize layer:swm`` would
-         REJECT — re-share the full asset instead.
+         ``swmShareComplete`` marker is NOT set and SWM is read-only — re-share
+         the full asset instead.
 
     A default share that CANNOT seal fails CLOSED: the daemon returns 409
     ``UNSEALED_SHARE_BLOCKED`` with a ``recovery`` hint and Working Memory

--- a/packages/adapter-hermes/hermes-plugin/__init__.py
+++ b/packages/adapter-hermes/hermes-plugin/__init__.py
@@ -672,8 +672,9 @@ DKG_ASSERTION_SHARE_SCHEMA = {
         "Share a knowledge asset (or selected root entities) from Working Memory into Shared "
         "Working Memory. A FULL share (omit `entities` or pass \"all\") SEALS BY DEFAULT and is "
         "then publish-ready -- follow with dkg_knowledge_asset_publish to mint it on-chain "
-        "(Verifiable Memory). skip_seal=true is retained only for compatibility; an unsealed SWM "
-        "share cannot be finalized because legacy SWM writes are read-only. If a default "
+        "(Verifiable Memory). skip_seal=true is retained only for compatibility and is rejected "
+        "by graph-scoped daemons; omit it or pass false to perform the required atomic sealed "
+        "full share. If a default "
         "(sealing) share cannot seal it fails CLOSED (409, Working Memory "
         "preserved) and returns a recovery hint. For CUSTOM finalize options "
         "such as author_agent_address / scheme_version, call dkg_knowledge_asset_finalize "
@@ -703,9 +704,8 @@ DKG_ASSERTION_SHARE_SCHEMA = {
             "skip_seal": {
                 "type": "boolean",
                 "description": (
-                    "Deprecated compatibility option. True shares to SWM without sealing, but "
-                    "legacy SWM is read-only and the result cannot be finalized. Default false "
-                    "atomically seals a full share."
+                    "Deprecated compatibility option. Graph-scoped daemons reject true; omit it "
+                    "or pass false to atomically seal and share the complete asset."
                 ),
             },
             "sub_graph_name": {"type": "string", "description": "Optional sub-graph name."},

--- a/packages/adapter-hermes/hermes-plugin/client.py
+++ b/packages/adapter-hermes/hermes-plugin/client.py
@@ -535,8 +535,9 @@ class DKGClient:
                           skip_seal: Optional[bool] = None) -> Dict[str, Any]:
         """POST /api/knowledge-assets/{name}/swm/share — promote assertion to SWM.
 
-        A full share SEALS BY DEFAULT (publish-ready). ``skip_seal=True`` opts
-        out into an unsealed SWM share (camelCase ``skipSeal`` on the wire).
+        A full share SEALS BY DEFAULT (publish-ready). ``skip_seal=True`` is a
+        deprecated compatibility option that produces read-only, unsealed SWM
+        content which current daemons cannot finalize.
         """
         payload: Dict[str, Any] = {
             "contextGraphId": _normalize_context_graph_id(context_graph_id),
@@ -562,9 +563,9 @@ class DKGClient:
         omit it to let the daemon default the author to the request token's
         agent. The pre-signed attestation path is intentionally NOT exposed —
         Hermes relies on node-side signing, exactly like OpenClaw/MCP (no
-        client-side EIP-712, no raw preSignedAuthorAttestation). ``layer``
-        selects WHERE the content to seal lives: "wm" (default) seals the open
-        WM draft; "swm" seals an asset already shared to SWM.
+        client-side EIP-712, no raw preSignedAuthorAttestation). ``layer`` is
+        retained for mixed-version compatibility: "wm" seals the open draft;
+        current daemons reject deprecated "swm" with LEGACY_KA_READ_ONLY.
         """
         payload: Dict[str, Any] = {"contextGraphId": _normalize_context_graph_id(context_graph_id)}
         if sub_graph_name:

--- a/packages/adapter-hermes/pytests/test_lifecycle_tool_handlers.py
+++ b/packages/adapter-hermes/pytests/test_lifecycle_tool_handlers.py
@@ -141,21 +141,21 @@ def test_share_description_carries_subset_language(provider):
     assert "NOT publishable to Verifiable Memory" in share["description"]
 
 
-def test_share_description_softens_publish_ready_and_notes_finalize(provider):
+def test_share_description_marks_unsealed_swm_read_only(provider):
     # #1116 — a full share now SEALS BY DEFAULT (publish-ready). skip_seal=true
-    # opts out into an unsealed SWM share; a default share that cannot seal fails
-    # CLOSED (409, WM preserved) with a recovery hint. Finalize stays the explicit
-    # path for custom options and for sealing an already-shared asset (layer:swm).
+    # is retained only for compatibility and creates read-only SWM content; a
+    # default share that cannot seal fails CLOSED (409, WM preserved). Finalize
+    # stays the explicit WM path for custom options.
     share = next(s for s in provider.get_tool_schemas()
                  if s["name"] == "dkg_knowledge_asset_share")
     desc = share["description"]
     assert "SEALS BY DEFAULT" in desc
     assert "skip_seal=true" in desc
-    assert "WITHOUT sealing" in desc
+    assert "retained only for compatibility" in desc
+    assert "legacy SWM writes are read-only" in desc
     assert "fails CLOSED" in desc and "409" in desc
     assert "dkg_knowledge_asset_finalize EXPLICITLY first" in desc
-    # layer:swm note for sealing after sharing
-    assert "layer=\"swm\" works after" in desc
+    assert "layer=\"swm\" works after" not in desc
     # custom finalize options note is preserved
     assert "author_agent_address" in desc and "scheme_version" in desc
 
@@ -772,22 +772,22 @@ def test_create_name_description_aligns_to_validation(provider):
 
 # -- #1116 _annotate_share_seal helper (warning branch + recovery surfacing) ---
 
-def test_annotate_share_seal_full_skip_seal_warns_sealable(plugin_module):
-    # publishReady:false on a FULL share (entities None/"all") → the seal-it hint
-    # (finalize layer:swm DOES seal a skip_seal full share).
+def test_annotate_share_seal_full_skip_seal_warns_read_only(plugin_module):
+    # Legacy SWM is read-only, so direct recovery must not be recommended.
     f = plugin_module._annotate_share_seal
     out = f({"swmShared": True, "publishReady": False}, None)
     assert "NOT publish-ready (sealed:false)" in out["warning"]
-    assert "layer:swm works after sharing" in out["warning"]
+    assert "Legacy unsealed SWM content is read-only" in out["warning"]
+    assert "atomic full share" in out["warning"]
     assert "NOT sealable" not in out["warning"]
-    # "all" is also a full share → same sealable warning.
+    # "all" is also a full share → same read-only recovery warning.
     out_all = f({"swmShared": True, "publishReady": False}, "all")
-    assert "layer:swm works after sharing" in out_all["warning"]
+    assert "Legacy unsealed SWM content is read-only" in out_all["warning"]
 
 
 def test_annotate_share_seal_subset_warns_not_sealable(plugin_module):
     # publishReady:false on a SUBSET (non-empty list) → the not-sealable recovery
-    # (finalize layer:swm REJECTS a subset with SWM_SUBSET_NOT_SEALABLE).
+    # (legacy SWM finalize is read-only).
     f = plugin_module._annotate_share_seal
     out = f({"swmShared": True, "publishReady": False}, ["urn:a"])
     assert "A subset is NOT sealable/publishable" in out["warning"]
@@ -832,7 +832,7 @@ def test_annotate_share_seal_incomplete_full_promote_warns_no_finalize(plugin_mo
         assert "not all roots reached SWM" in out["warning"], ent
         assert "re-share the full asset" in out["warning"], ent
         # NOT the dead-end finalize layer:swm hint, NOT the subset hint.
-        assert "layer:swm works after sharing" not in out["warning"], ent
+        assert "recovers + seals" not in out["warning"], ent
         assert "NOT sealable" not in out["warning"], ent
 
 
@@ -928,9 +928,9 @@ def test_finalize_handler_forwards_layer_swm_to_client(provider):
 
 # -- #1116 share handler: publishReady:false warning end-to-end ------------
 
-def test_share_handler_full_skip_seal_warns_via_annotate(provider):
+def test_share_handler_full_skip_seal_warns_read_only_via_annotate(provider):
     # A FULL skip_seal share whose daemon reply is publishReady:false surfaces the
-    # sealable warning through the handler (parity with the helper test).
+    # read-only recovery warning through the handler (parity with the helper test).
     provider._client.promote_assertion = (  # type: ignore[assignment]
         lambda name, cg, entities, sub_graph_name=None, skip_seal=None: {
             "swmShared": True, "promotedCount": 2, "sealed": False, "publishReady": False,
@@ -939,7 +939,8 @@ def test_share_handler_full_skip_seal_warns_via_annotate(provider):
     out = json.loads(provider.handle_tool_call("dkg_knowledge_asset_share", {
         "context_graph_id": "cg1", "name": "ka", "skip_seal": True,
     }))
-    assert "layer:swm works after sharing" in out["warning"]
+    assert "Legacy unsealed SWM content is read-only" in out["warning"]
+    assert "atomic full share" in out["warning"]
 
 
 def test_share_handler_subset_warns_not_sealable_via_annotate(provider):
@@ -967,4 +968,4 @@ def test_share_handler_incomplete_full_promote_warns_via_annotate(provider):
     }))
     assert "not all roots reached SWM" in out["warning"]
     assert "re-share the full asset" in out["warning"]
-    assert "layer:swm works after sharing" not in out["warning"]
+    assert "recovers + seals" not in out["warning"]

--- a/packages/adapter-hermes/pytests/test_lifecycle_tool_handlers.py
+++ b/packages/adapter-hermes/pytests/test_lifecycle_tool_handlers.py
@@ -778,7 +778,10 @@ def test_annotate_share_seal_full_skip_seal_warns_read_only(plugin_module):
     out = f({"swmShared": True, "publishReady": False}, None)
     assert "NOT publish-ready (sealed:false)" in out["warning"]
     assert "Legacy unsealed SWM content is read-only" in out["warning"]
+    assert "preserved Working Memory draft" in out["warning"]
     assert "atomic full share" in out["warning"]
+    assert "pull the asset" not in out["warning"]
+    assert "pull-from" not in out["warning"]
     assert "NOT sealable" not in out["warning"]
     # "all" is also a full share → same read-only recovery warning.
     out_all = f({"swmShared": True, "publishReady": False}, "all")

--- a/packages/adapter-hermes/pytests/test_lifecycle_tool_handlers.py
+++ b/packages/adapter-hermes/pytests/test_lifecycle_tool_handlers.py
@@ -143,21 +143,24 @@ def test_share_description_carries_subset_language(provider):
 
 def test_share_description_marks_unsealed_swm_read_only(provider):
     # #1116 — a full share now SEALS BY DEFAULT (publish-ready). skip_seal=true
-    # is retained only for compatibility and creates read-only SWM content; a
-    # default share that cannot seal fails CLOSED (409, WM preserved). Finalize
-    # stays the explicit WM path for custom options.
+    # is retained only so older callers receive the graph-scoped daemon's clear
+    # rejection; it must not be advertised as a working unsealed share mode.
     share = next(s for s in provider.get_tool_schemas()
                  if s["name"] == "dkg_knowledge_asset_share")
     desc = share["description"]
     assert "SEALS BY DEFAULT" in desc
     assert "skip_seal=true" in desc
     assert "retained only for compatibility" in desc
-    assert "legacy SWM writes are read-only" in desc
+    assert "rejected by graph-scoped daemons" in desc
+    assert "unsealed SWM share" not in desc
     assert "fails CLOSED" in desc and "409" in desc
     assert "dkg_knowledge_asset_finalize EXPLICITLY first" in desc
     assert "layer=\"swm\" works after" not in desc
     # custom finalize options note is preserved
     assert "author_agent_address" in desc and "scheme_version" in desc
+    skip_desc = share["parameters"]["properties"]["skip_seal"]["description"]
+    assert "reject true" in skip_desc
+    assert "without sealing" not in skip_desc
 
 
 def test_publish_description_ual_middle_segment_is_contract_not_author(provider):

--- a/packages/adapter-openclaw/src/DkgNodePlugin.ts
+++ b/packages/adapter-openclaw/src/DkgNodePlugin.ts
@@ -115,8 +115,8 @@ import { buildMemoryTools } from './tools/memory-tools.js';
 // Legacy SWM content is read-only, so recovery must go through WM + atomic share.
 export const SHARE_NOT_PUBLISH_READY_WARNING =
   'Shared to SWM but NOT publish-ready (sealed:false). Legacy unsealed SWM ' +
-  'content is read-only; recreate or pull the asset into Working Memory, then ' +
-  'use an atomic full share before publishing.';
+  'content is read-only; use the preserved Working Memory draft if available, ' +
+  'or recreate the knowledge asset, then use an atomic full share before publishing.';
 
 // A SUBSET share is publishReady:false too, but unlike a skip_seal full share it
 // is NOT sealable — legacy SWM finalize is read-only.

--- a/packages/adapter-openclaw/src/DkgNodePlugin.ts
+++ b/packages/adapter-openclaw/src/DkgNodePlugin.ts
@@ -111,24 +111,25 @@ import { buildMemoryTools } from './tools/memory-tools.js';
 // canonical fixture at `tests/fixtures/share-seal-warnings.json`. Update the
 // fixture + all three adapters together; the parity tests flag any mismatch.
 
-// publishReady:false after a FULL share that opted out of sealing (skip_seal:true)
-// — a later finalize(layer:swm) DOES seal it.
+// publishReady:false after a FULL share that opted out of sealing (skip_seal:true).
+// Legacy SWM content is read-only, so recovery must go through WM + atomic share.
 export const SHARE_NOT_PUBLISH_READY_WARNING =
-  'Shared to SWM but NOT publish-ready (sealed:false). Seal it with ' +
-  'dkg_knowledge_asset_finalize (layer:swm works after sharing), then publish.';
+  'Shared to SWM but NOT publish-ready (sealed:false). Legacy unsealed SWM ' +
+  'content is read-only; recreate or pull the asset into Working Memory, then ' +
+  'use an atomic full share before publishing.';
 
 // A SUBSET share is publishReady:false too, but unlike a skip_seal full share it
-// is NOT sealable — finalize(layer:swm) now REJECTS it with SWM_SUBSET_NOT_SEALABLE.
+// is NOT sealable — legacy SWM finalize is read-only.
 // Surface the real recovery (full share / new asset) instead of "seal it".
 export const SHARE_SUBSET_NOT_PUBLISH_READY_WARNING =
   'Shared a SUBSET to SWM for peer visibility. A subset is NOT sealable/' +
-  'publishable (finalize layer:swm will reject it). To publish on-chain, share ' +
-  'the full asset (entities:"all"), or model this subset as its own knowledge asset.';
+  'publishable. Legacy SWM finalize is read-only. To publish on-chain, share ' +
+  'the full asset atomically (entities:"all"), or model this subset as its own knowledge asset.';
 
 // A FULL share can come back sealed:true but publishReady:false when NOT every
 // sealed root reached SWM (promotedAllRoots false — e.g. foreign-owned roots were
-// skipped). The engine did NOT set the swmShareComplete marker, so finalize(layer:
-// swm) would REJECT — do NOT recommend it here. Re-sharing the full asset recovers.
+// skipped). The engine did NOT set the swmShareComplete marker, and SWM is
+// read-only, so do NOT recommend finalizing it. Re-sharing the full asset recovers.
 export const SHARE_INCOMPLETE_PROMOTE_WARNING =
   'Sealed, but not all roots reached SWM (some roots may be owned by other ' +
   'agents) — not yet publishable; re-share the full asset so every sealed root ' +
@@ -138,9 +139,9 @@ export const SHARE_INCOMPLETE_PROMOTE_WARNING =
  * #1116: pick the not-publish-ready share warning from the share outcome. Returns
  * `undefined` when the share IS publish-ready (no warning). Precedence:
  *  1. sealed:true + publishReady:false → incomplete full promote (marker NOT set;
- *     finalize layer:swm would reject) → re-share the full asset.
+ *     SWM is read-only) → re-share the full asset.
  *  2. sealed:false + SUBSET → not sealable.
- *  3. sealed:false + FULL (skip_seal) → sealable later (finalize layer:swm works).
+ *  3. sealed:false + FULL (skip_seal) → recover through WM + atomic full share.
  * Duplicated byte-identical on MCP (TS) + Hermes (Python).
  */
 export function classifyShareWarning(outcome: {

--- a/packages/adapter-openclaw/src/dkg-client.ts
+++ b/packages/adapter-openclaw/src/dkg-client.ts
@@ -1225,8 +1225,8 @@ export class DkgDaemonClient {
       authorAgentAddress?: string;
       preSignedAuthorAttestation?: PreSignedAuthorAttestationPayload;
       schemeVersion?: number;
-      // #1116: "wm" (default) seals the open WM draft; "swm" seals an asset
-      // already shared to SWM (recover-without-recreate).
+      // #1116: retained for mixed-version wire compatibility. "wm" seals the
+      // draft; current daemons reject deprecated "swm" as read-only.
       layer?: 'wm' | 'swm';
     },
   ): Promise<{ merkleRoot: string; eip712Digest: string }> {

--- a/packages/adapter-openclaw/src/tools/assertion-tools.ts
+++ b/packages/adapter-openclaw/src/tools/assertion-tools.ts
@@ -103,9 +103,9 @@ export function buildAssertionTools(ctx: DkgToolHost): OpenClawTool[] {
         'subset parameter). A FULL share (dkg_knowledge_asset_share with entities omitted or "all") ' +
         'auto-seals for you, so you only need to call this explicitly before sharing a SELECTIVE subset of ' +
         'entities, or to re-seal after editing a previously-sealed draft. Sealing works even if the context ' +
-        'graph is NOT yet registered on-chain (registration happens at publish). Pass layer:"swm" to seal an ' +
-        'asset already shared to SWM (e.g. shared with skip_seal) — it recovers and seals the SWM content ' +
-        'without a delete-and-recreate. (External-signer / pre-signed ' +
+        'graph is NOT yet registered on-chain (registration happens at publish). The deprecated layer:"swm" ' +
+        'compatibility value is read-only and returns LEGACY_KA_READ_ONLY; recover legacy content through ' +
+        'Working Memory and an atomic full share instead. (External-signer / pre-signed ' +
         'attestation is a tracked follow-up and is not exposed by this tool — author with author_agent_address.)',
       parameters: {
         type: 'object',
@@ -123,9 +123,8 @@ export function buildAssertionTools(ctx: DkgToolHost): OpenClawTool[] {
             type: 'string',
             enum: ['wm', 'swm'],
             description:
-              'Which layer holds the content to seal. Default "wm" seals the open Working Memory draft. ' +
-              'Pass "swm" to seal an asset already shared to SWM (recovers + seals the SWM content without ' +
-              'delete-and-recreate).',
+              'Default "wm" seals the open Working Memory draft. Deprecated "swm" is read-only and ' +
+              'returns LEGACY_KA_READ_ONLY.',
           },
           sub_graph_name: { type: 'string', description: 'Must match the one used at write time.' },
         },
@@ -139,8 +138,8 @@ export function buildAssertionTools(ctx: DkgToolHost): OpenClawTool[] {
         'Step 4 of the canonical flow. Share a knowledge asset (or selected root entities) from Working ' +
         'Memory into Shared Working Memory. A FULL share (omit `entities` or pass "all") SEALS BY DEFAULT ' +
         'and is then publish-ready — follow it with dkg_knowledge_asset_publish to mint the asset on-chain ' +
-        '(Verifiable Memory). Pass skip_seal:true to share WITHOUT sealing (an unsealed SWM share — seal it ' +
-        'later with dkg_knowledge_asset_finalize, where layer:"swm" works after sharing). If a default ' +
+        '(Verifiable Memory). skip_seal:true is retained only for compatibility; an unsealed SWM share ' +
+        'cannot be finalized because legacy SWM writes are read-only. If a default ' +
         '(sealing) share cannot seal it fails CLOSED (409, Working Memory preserved) and returns a recovery ' +
         'hint. For custom finalize/attestation options — ' +
         'author_agent_address / scheme_version — call dkg_knowledge_asset_finalize EXPLICITLY first (the ' +
@@ -167,8 +166,8 @@ export function buildAssertionTools(ctx: DkgToolHost): OpenClawTool[] {
           skip_seal: {
             type: 'boolean',
             description:
-              'Set true to share to SWM WITHOUT sealing (not publish-ready). Default (false) seals a full ' +
-              'share so it is immediately publish-ready. Ignored for a subset share, which is never sealed.',
+              'Deprecated compatibility option. True shares to SWM without sealing, but legacy SWM is ' +
+              'read-only and the result cannot be finalized. Default false atomically seals a full share.',
           },
           sub_graph_name: { type: 'string', description: 'Must match the one used at write time.' },
         },

--- a/packages/adapter-openclaw/src/tools/assertion-tools.ts
+++ b/packages/adapter-openclaw/src/tools/assertion-tools.ts
@@ -138,8 +138,8 @@ export function buildAssertionTools(ctx: DkgToolHost): OpenClawTool[] {
         'Step 4 of the canonical flow. Share a knowledge asset (or selected root entities) from Working ' +
         'Memory into Shared Working Memory. A FULL share (omit `entities` or pass "all") SEALS BY DEFAULT ' +
         'and is then publish-ready — follow it with dkg_knowledge_asset_publish to mint the asset on-chain ' +
-        '(Verifiable Memory). skip_seal:true is retained only for compatibility; an unsealed SWM share ' +
-        'cannot be finalized because legacy SWM writes are read-only. If a default ' +
+        '(Verifiable Memory). skip_seal:true is retained only for compatibility and is rejected by ' +
+        'graph-scoped daemons; omit it or pass false to perform the required atomic sealed full share. If a default ' +
         '(sealing) share cannot seal it fails CLOSED (409, Working Memory preserved) and returns a recovery ' +
         'hint. For custom finalize/attestation options — ' +
         'author_agent_address / scheme_version — call dkg_knowledge_asset_finalize EXPLICITLY first (the ' +
@@ -166,8 +166,8 @@ export function buildAssertionTools(ctx: DkgToolHost): OpenClawTool[] {
           skip_seal: {
             type: 'boolean',
             description:
-              'Deprecated compatibility option. True shares to SWM without sealing, but legacy SWM is ' +
-              'read-only and the result cannot be finalized. Default false atomically seals a full share.',
+              'Deprecated compatibility option. Graph-scoped daemons reject true; omit it or pass false ' +
+              'to atomically seal and share the complete asset.',
           },
           sub_graph_name: { type: 'string', description: 'Must match the one used at write time.' },
         },

--- a/packages/adapter-openclaw/test/plugin.part-01.test.ts
+++ b/packages/adapter-openclaw/test/plugin.part-01.test.ts
@@ -957,16 +957,17 @@ describe("DkgNodePlugin", () => {
       expect(res.details?.error).toMatch(/skip_seal.*boolean/);
     });
 
-    it('dkg_knowledge_asset_share on a FULL share with publishReady:false emits the seal-it warning (#1116)', async () => {
+    it('dkg_knowledge_asset_share on a FULL share with publishReady:false directs recovery through WM (#1116)', async () => {
       const { byName } = setupPluginWithFetch({ swmShared: true, promotedCount: 2, sealed: false, publishReady: false });
       const res = await byName.get('dkg_knowledge_asset_share')!.execute('tc', {
         context_graph_id: 'ctx',
         name: 'notes',
         skip_seal: true,
       });
-      // A skip_seal FULL share IS sealable later → the "seal it with finalize" hint.
+      // Legacy SWM is read-only, so this must not recommend finalize(layer:swm).
       expect(res.details?.warning).toContain('NOT publish-ready (sealed:false)');
-      expect(res.details?.warning).toContain('layer:swm works after sharing');
+      expect(res.details?.warning).toContain('Legacy unsealed SWM content is read-only');
+      expect(res.details?.warning).toContain('atomic full share');
       expect(res.details?.warning).not.toContain('NOT sealable');
     });
 
@@ -977,7 +978,7 @@ describe("DkgNodePlugin", () => {
         name: 'notes',
         entities: ['urn:a'],
       });
-      // A subset is NOT sealable (finalize layer:swm rejects it) → the full-share /
+      // A subset is NOT sealable and SWM is read-only → the full-share /
       // new-asset recovery, NOT the dead-end "seal it" advice.
       expect(res.details?.warning).toContain('A subset is NOT sealable/publishable');
       expect(res.details?.warning).toContain('entities:"all"');
@@ -1005,7 +1006,7 @@ describe("DkgNodePlugin", () => {
       expect(res.details?.warning).toContain('not all roots reached SWM');
       expect(res.details?.warning).toContain('re-share the full asset');
       // Must NOT recommend the dead-end finalize layer:swm here (it would reject).
-      expect(res.details?.warning).not.toContain('layer:swm works after sharing');
+      expect(res.details?.warning).not.toContain('recovers + seals');
       expect(res.details?.warning).not.toContain('NOT sealable');
     });
 

--- a/packages/adapter-openclaw/test/plugin.part-04.test.ts
+++ b/packages/adapter-openclaw/test/plugin.part-04.test.ts
@@ -97,6 +97,12 @@ describe("DkgNodePlugin", () => {
       expect(share.description).toContain('dkg_knowledge_asset_publish');
       // #1116: a full share now SEALS BY DEFAULT (was "auto-seal best-effort").
       expect(share.description).toMatch(/seals by default/i);
+      expect(share.description).toContain('skip_seal:true');
+      expect(share.description).toMatch(/rejected by graph-scoped daemons/i);
+      expect(share.description).not.toMatch(/unsealed SWM share/i);
+      const skipSealDescription = (share.parameters as any).properties.skip_seal.description as string;
+      expect(skipSealDescription).toMatch(/reject true/i);
+      expect(skipSealDescription).not.toMatch(/without sealing/i);
       // §5 subset-vs-full language must be present.
       expect(share.description).toMatch(/NOT publishable to Verifiable Memory/i);
     });

--- a/packages/adapter-openclaw/test/share-warning-parity.test.ts
+++ b/packages/adapter-openclaw/test/share-warning-parity.test.ts
@@ -22,6 +22,8 @@ const fixture = JSON.parse(
 describe('#1116 share-warning parity (OpenClaw vs canonical fixture)', () => {
   it('SHARE_NOT_PUBLISH_READY_WARNING matches the fixture byte-for-byte', () => {
     expect(SHARE_NOT_PUBLISH_READY_WARNING).toBe(fixture.SHARE_NOT_PUBLISH_READY_WARNING);
+    expect(SHARE_NOT_PUBLISH_READY_WARNING).toContain('preserved Working Memory draft');
+    expect(SHARE_NOT_PUBLISH_READY_WARNING).not.toMatch(/pull(?:-|\s)from|pull the asset/i);
   });
 
   it('SHARE_SUBSET_NOT_PUBLISH_READY_WARNING matches the fixture byte-for-byte', () => {

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -2183,6 +2183,15 @@ export class PublishMethods extends DKGAgentBase {
           (err instanceof Error ? err.message : String(err)),
       );
     }
+    // Legacy root-scoped seals are readable only. Gate immediately after the
+    // durable scope is known, before querying WM/private content, injecting
+    // catalog rows, canonicalizing, or invoking any write-side engine path.
+    if (
+      existingSeal
+      && existingSeal.contentScopeVersion !== GRAPH_KA_CONTENT_SCOPE_VERSION
+    ) {
+      throw new LegacyKnowledgeAssetReadOnlyError();
+    }
     const privateStore = new PrivateContentStore(this.store, new GraphManager(this.store));
 
     // 2. Pull the assertion's quads. Refuse to finalize an empty
@@ -2317,9 +2326,6 @@ export class PublishMethods extends DKGAgentBase {
     //    the assertion was mutated since the previous finalize —
     //    refuse to overwrite silently.
     if (existingSeal) {
-      if (existingSeal.contentScopeVersion !== GRAPH_KA_CONTENT_SCOPE_VERSION) {
-        throw new LegacyKnowledgeAssetReadOnlyError();
-      }
       if (
         !existingSeal.kaUal ||
         !existingSeal.assertionVersion ||

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -86,6 +86,7 @@ import {
   SUBSCRIPTION_SOURCES,
   pickNetworkTunables,
   ENTITY_PRED_ALT,
+  LegacyKnowledgeAssetReadOnlyError,
 } from '@origintrail-official/dkg-core';
 import { GraphManager, PrivateContentStore, createTripleStore, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig } from '@origintrail-official/dkg-storage';
 import { EVMChainAdapter, NoChainAdapter, enrichEvmError, buildKnowledgeAssetUal, isContextGraphChainScanPartialError, type EVMAdapterConfig, type ChainAdapter, type ContextGraphOnChain, type ContextGraphChainScanOptions, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo } from '@origintrail-official/dkg-chain';
@@ -410,7 +411,6 @@ import {
   PublishMethods,
   SEAL_CAPABILITY_GAP_CODE,
 } from './dkg-agent-publish.js';
-import { placeFinalizedLifecycleSwm } from './finalized-lifecycle-swm.js';
 import { SwmHostModeMethods } from './dkg-agent-swm-host.js';
 import { ContextGraphMethods } from './dkg-agent-context-graph.js';
 import { ImportedArtifactMethods } from './imported-artifact.js';
@@ -2623,13 +2623,10 @@ export class DKGAgent extends DKGAgentBase {
           ) => Promise<{ r: Uint8Array; vs: Uint8Array }>;
           schemeVersion?: number;
           /**
-           * #1116 — which layer holds the content to seal. `"wm"` (default)
-           * finalizes the Working-Memory draft. `"swm"` seals an asset whose
-           * content is already in Shared Working Memory (e.g. after a
-           * `skipSeal` share, or an asset stuck unsealed under the old
-           * behavior): it reconstructs a transient WM draft from SWM, then
-           * finalizes — no delete-and-recreate. The asset stays in SWM and
-           * becomes publishable.
+           * @deprecated `"swm"` remains recognizable only so mixed-version
+           * callers get the stable `LEGACY_KA_READ_ONLY` error. New KAs are
+           * sealed in WM and shared atomically; existing root-scoped SWM assets
+           * are readable but cannot be reconstructed, resealed, or migrated.
            */
           layer?: 'wm' | 'swm';
         },
@@ -2643,102 +2640,16 @@ export class DKGAgent extends DKGAgentBase {
         eip712Digest: string;
       }> {
         const finalizeAgentAddress = opts?.agentAddress ?? agentAddress;
-        // #1116 seal-in-SWM: pull the asset's roots back out of SWM into a
-        // transient WM draft (reusing pull-from — incl. its seal-independent
-        // root resolution), run the ordinary finalize over that draft, then DROP
-        // the transient draft so the asset is left resident PURELY in SWM (with
-        // its fresh seal), not duplicated across WM+SWM. The seal is
-        // content-based, so it is valid for the SWM-resident content; the SWM
-        // copy itself is never modified. We reconstruct unconditionally
-        // (onConflict 'replace') so a stale WM draft never blocks the re-seal;
-        // pull-from now PRESERVES the dkg:rootEntity recovery rows across its
-        // clean-slate, so a finalize that fails here leaves the asset safely
-        // re-tryable (seal-in-SWM is atomic-on-failure).
-        if (opts?.layer !== 'swm') {
-          return agent.assertionFinalize(contextGraphId, name, finalizeAgentAddress, {
-            subGraphName: opts?.subGraphName,
-            authorAgentAddress: opts?.authorAgentAddress,
-            preSignedAuthorAttestation: opts?.preSignedAuthorAttestation,
-            authorSignTypedData: opts?.authorSignTypedData,
-            schemeVersion: opts?.schemeVersion,
-          });
+        if (opts?.layer === 'swm') {
+          throw new LegacyKnowledgeAssetReadOnlyError();
         }
-        // #1116 (review A1) — seal-in-SWM is publishable-by-construction: it
-        // reconstructs a WM draft from the promoted root rows, seals it, and
-        // leaves the asset resident in SWM ready to publish under the KA name.
-        // A SUBSET share also stamps those root rows but is SWM-ONLY (not
-        // publishable) — so guard on the full-share marker BEFORE the pull-from.
-        // Without this, a {A,B} KA only SUBSET-shared (A) could be sealed and
-        // published as a partial asset, breaking the subset-shares-aren't-
-        // publishable invariant.
-        const fullyShared = await agent.publisher.hasSwmShareComplete(
-          contextGraphId, name, finalizeAgentAddress, opts?.subGraphName,
-        );
-        if (!fullyShared) {
-          throw Object.assign(
-            new Error(
-              'Cannot seal-in-SWM: this asset was not fully shared to SWM — subset shares are not publishable. ' +
-                'Share the full asset (entities:"all") first, then finalize(layer:"swm").',
-            ),
-            { code: 'SWM_SUBSET_NOT_SEALABLE' },
-          );
-        }
-        // #1116 (round 9) — NO pre-clear of the seal here. Round 8 made the SWM
-        // pull resolve entities from the member rows (NOT seal.rootEntities), so a
-        // stale seal can no longer mis-scope the reconstruction; and
-        // assertionPullFrom's INTERNAL teardown clears the seal AFTER it validates
-        // the source is non-empty. A pre-clear ran BEFORE the pull and stranded the
-        // asset (seal gone, no fresh seal) if the pull threw PULL_FROM_EMPTY_SOURCE.
-        // Dropping it makes finalize(layer:"swm") atomic-on-failure: on a failed
-        // pull the prior seal survives and the asset stays re-tryable.
-        await agent.publisher.assertionPullFrom(contextGraphId, name, finalizeAgentAddress, 'swm', {
-          subGraphName: opts?.subGraphName,
-          onConflict: 'replace',
-        });
-        const swmSeal = await agent.assertionFinalize(contextGraphId, name, finalizeAgentAddress, {
+        return agent.assertionFinalize(contextGraphId, name, finalizeAgentAddress, {
           subGraphName: opts?.subGraphName,
           authorAgentAddress: opts?.authorAgentAddress,
           preSignedAuthorAttestation: opts?.preSignedAuthorAttestation,
+          authorSignTypedData: opts?.authorSignTypedData,
           schemeVersion: opts?.schemeVersion,
         });
-        // Upgraded full `skipSeal` shares may predate KA-number allocation and
-        // still live in the legacy SWM bucket. Finalize has now allocated the
-        // packed id bound by the seal; ensure that exact root closure also exists
-        // in its canonical named lifecycle before publish uses exact-scope reads.
-        // This is idempotent, so retrying after placement repairs the lifecycle
-        // pointer safely.
-        await placeFinalizedLifecycleSwm({
-          publisher: agent.publisher,
-          operationContext: createOperationContext('share'),
-          authorAddress: swmSeal.authorAddress,
-          packedKaId: swmSeal.reservedKaId,
-          contextGraphId,
-          assertionName: name,
-          assertionLifecycleAgentAddress: finalizeAgentAddress,
-          subGraphName: opts?.subGraphName,
-          rootEntities: swmSeal.rootEntities,
-        });
-        // #1116 FIX 2 — make the SWM-resident position observable. The original
-        // (possibly skipSeal) promote had no seal yet, so `_stampSwmPointer` ran a
-        // no-op then; now that the seal EXISTS, stamp dkg:swmCurrentAssertion to it
-        // so status reports "swm-shared". This must precede the WM-draft cleanup
-        // below, whose stale-WM-pointer retirement is gated on the SWM pointer
-        // being present (the content is genuinely SWM-resident).
-        await agent._stampSwmPointer(contextGraphId, name, finalizeAgentAddress, opts?.subGraphName);
-        // Best-effort: the seal (in _meta) and the SWM content are already
-        // durable, so a cleanup failure is harmless (it only leaves a sealed WM
-        // draft alongside SWM — which the finalize-after-edit guards still
-        // protect). Drop it so the post-condition is "purely in SWM".
-        try {
-          await agent.publisher.clearWmDraftDataGraph(contextGraphId, name, finalizeAgentAddress, opts?.subGraphName);
-        } catch (cleanupErr: any) {
-          agent.log.warn(
-            createOperationContext('share'),
-            `seal-in-SWM: WM-draft cleanup failed (asset is sealed and resident in SWM; ` +
-              `a harmless WM copy remains): ${cleanupErr?.message ?? String(cleanupErr)}`,
-          );
-        }
-        return swmSeal;
       },
 
       async history(contextGraphId: string, name: string, opts?: { agentAddress?: string; subGraphName?: string }): Promise<AssertionHistoryDescriptor | null> {

--- a/packages/agent/test/e2e-memory-layers.test.ts
+++ b/packages/agent/test/e2e-memory-layers.test.ts
@@ -1256,7 +1256,7 @@ describe('rootless graph-scoped KA lifecycle', () => {
     ).rejects.toMatchObject({ code: 'UNSEALED_SHARE_BLOCKED' });
     await expect(
       agent.assertion.finalize(CG_ID, name, { layer: 'swm' }),
-    ).rejects.toMatchObject({ code: 'SWM_SUBSET_NOT_SEALABLE' });
+    ).rejects.toMatchObject({ code: 'LEGACY_KA_READ_ONLY' });
 
     const wm = await agent.assertion.query(CG_ID, name);
     expect(wm).toHaveLength(1);
@@ -1447,8 +1447,8 @@ describe('rootless graph-scoped KA lifecycle', () => {
       agent.assertion.promote(CG_ID, name, { entities: [`${ENTITY_BASE}:a`] }),
     ).rejects.toMatchObject({ code: 'KA_ATOMIC_SHARE_REQUIRED' });
 
-    // 4. Seal-in-SWM is refused: the marker was cleared at discard AND on the
-    // subset share, so a partial asset can't be published under the KA name.
+    // 4. SWM reconstruction/resealing is refused unconditionally. Legacy
+    // root-scoped data remains readable but is never migrated by a write path.
     let thrown: any;
     try {
       await agent.assertion.finalize(CG_ID, name, { layer: 'swm' });
@@ -1456,7 +1456,7 @@ describe('rootless graph-scoped KA lifecycle', () => {
       thrown = e;
     }
     expect(thrown).toBeTruthy();
-    expect(thrown.code).toBe('SWM_SUBSET_NOT_SEALABLE');
+    expect(thrown.code).toBe('LEGACY_KA_READ_ONLY');
   }, 30_000);
 
   it('a rejected subset re-share preserves the prior sealed exact SWM version', async () => {
@@ -1699,10 +1699,9 @@ describe('rootless graph-scoped KA lifecycle', () => {
     expect((await agent.assertion.query(CG_ID, name)).map((quad) => quad.object).sort()).toEqual(['"A"', '"B"']);
   }, 40_000);
 
-  // (d) a CONFIRMED publish CLEARS the marker (step 3); a subsequent
-  // finalize(layer:swm) REJECTS (SWM_SUBSET_NOT_SEALABLE — the marker is gone)
-  // WITHOUT stranding the seal (the wrapper pre-clear is gone, step 4).
-  it('round 9 (d): confirmed publish clears the marker; a later finalize(layer:swm) rejects without stranding the seal', async () => {
+  // A confirmed publish clears the marker; a later legacy SWM-finalize request
+  // is read-only and cannot strand the surviving seal.
+  it('confirmed publish clears the marker; legacy SWM finalize rejects without stranding the seal', async () => {
     const agent = await createAgent('Round9PostPublishBot');
     await agent.createContextGraph({ id: CG_ID, name: 'Round9 PostPublish E2E' });
     await agent.registerContextGraph(CG_ID);
@@ -1719,20 +1718,18 @@ describe('rootless graph-scoped KA lifecycle', () => {
     // step 3: the confirmed publish consumed the SWM share → marker cleared.
     expect(await agent.publisher.hasSwmShareComplete(CG_ID, name, agent.defaultAgentAddress ?? agent.peerId)).toBe(false);
 
-    // A post-publish seal-in-SWM must REJECT (no live full share) and must NOT
-    // strand the seal (the published seal survives for VM ops).
+    // The deprecated write bridge must reject before touching the published seal.
     const sealBefore = await sealExists(agent, CG_ID, name);
     let thrown: any;
     try { await agent.assertion.finalize(CG_ID, name, { layer: 'swm' }); } catch (e) { thrown = e; }
     expect(thrown).toBeTruthy();
-    expect(thrown.code).toBe('SWM_SUBSET_NOT_SEALABLE');
+    expect(thrown.code).toBe('LEGACY_KA_READ_ONLY');
     expect(await sealExists(agent, CG_ID, name)).toBe(sealBefore); // seal not stranded
   }, 40_000);
 
-  // (e) finalize(layer:swm) whose SWM is EMPTY but the marker survived (simulate by
-  // clearing SWM after a full share) no longer strands the seal — the wrapper
-  // pre-clear is gone (step 4), so a PULL_FROM_EMPTY_SOURCE leaves the seal intact.
-  it('round 9 (e): finalize(layer:swm) on an empty-SWM (marker survived) does NOT strand the seal', async () => {
+  // Even inconsistent legacy metadata (empty SWM with a surviving marker) is
+  // never repaired through a write-side root migration; the seal stays intact.
+  it('legacy SWM finalize on empty SWM rejects read-only without stranding the seal', async () => {
     const agent = await createAgent('Round9NoStrandBot');
     await agent.createContextGraph({ id: CG_ID, name: 'Round9 NoStrand E2E' });
     await agent.registerContextGraph(CG_ID);
@@ -1749,12 +1746,11 @@ describe('rootless graph-scoped KA lifecycle', () => {
     // (without clearing the marker), mimicking a consumed/missing SWM slice.
     await agent.publisher.clearPublishedSwmRoots(CG_ID, [A], undefined, createOperationContext('publishFromSWM'));
 
-    // finalize(layer:swm) passes the marker gate, runs pull-from which finds an
-    // EMPTY source → PULL_FROM_EMPTY_SOURCE. The seal must SURVIVE (atomic-on-failure).
+    // Rejection happens before source inspection or mutation.
     let thrown: any;
     try { await agent.assertion.finalize(CG_ID, name, { layer: 'swm' }); } catch (e) { thrown = e; }
     expect(thrown).toBeTruthy();
-    expect(thrown.code).toBe('PULL_FROM_EMPTY_SOURCE');
+    expect(thrown.code).toBe('LEGACY_KA_READ_ONLY');
     expect(await sealExists(agent, CG_ID, name)).toBe(true); // NOT stranded (step 4)
   }, 40_000);
 

--- a/packages/agent/test/publish-finalized-agent-lane.test.ts
+++ b/packages/agent/test/publish-finalized-agent-lane.test.ts
@@ -326,6 +326,45 @@ describe('DKGAgent publishFromFinalizedAssertion agent lane', () => {
     expect(legacy).toMatchObject({ type: 'boolean', value: true });
   });
 
+  it('rejects a persisted legacy seal before inspecting an empty WM draft', async () => {
+    const store = new OxigraphStore();
+    const assertionUri = contextGraphAssertionUri(CG, AGENT_B, NAME);
+    await store.insert(buildAssertionSealQuads({
+      assertionUri,
+      metaGraph: contextGraphMetaUri(CG),
+      merkleRoot: MERKLE,
+      authorAddress: AGENT_B,
+      authorAttestationR: new Uint8Array(32).fill(1),
+      authorAttestationVS: new Uint8Array(32).fill(2),
+      authorSchemeVersion: 1,
+      chainId: 31337n,
+      kav10Address: AGENT_B,
+      reservedKaId: RESERVED_KA_ID,
+      finalizedAtIso: '2026-01-01T00:00:00.000Z',
+      rootEntities: [ROOT],
+    }) as Quad[]);
+
+    let wmReads = 0;
+    const agent = Object.create(DKGAgent.prototype) as any;
+    agent.store = store;
+    agent.log = makeLog();
+    agent.publisher = {
+      wmGraphUri: async () => 'urn:wm:legacy',
+      assertionQuery: async () => {
+        wmReads += 1;
+        return [];
+      },
+      assertionQueryPrivate: async () => {
+        wmReads += 1;
+        return [];
+      },
+    };
+
+    await expect(agent.assertionFinalize(CG, NAME, AGENT_B))
+      .rejects.toMatchObject({ code: 'LEGACY_KA_READ_ONLY' });
+    expect(wmReads).toBe(0);
+  });
+
   it('cleans only the finalized named lifecycle after a confirmed update', async () => {
     const store = new OxigraphStore();
     const assertionUri = contextGraphAssertionUri(CG, AGENT_B, NAME);

--- a/packages/agent/test/wm-multi-agent-isolation-extra.test.ts
+++ b/packages/agent/test/wm-multi-agent-isolation-extra.test.ts
@@ -280,7 +280,7 @@ describe('A-1: WM is per-agent — two agents co-hosted on one node', () => {
     expect(wm.some((q) => q.subject === 'urn:wm:bob:pull')).toBe(true);
   });
 
-  it('an unsealed SWM recovery cannot bypass the explicitly selected non-default agent lane', async () => {
+  it('legacy SWM recovery is read-only even on an explicitly selected non-default agent lane', async () => {
     const cgId = freshCgId('wm-assertion-swm-finalize-b');
     const assertionName = 'b-lane-swm-finalize';
     await node!.createContextGraph({ id: cgId, name: 'WM assertion SWM finalize B', description: '' });
@@ -304,7 +304,7 @@ describe('A-1: WM is per-agent — two agents co-hosted on one node', () => {
       agentAddress: agentB.agentAddress,
       authorAgentAddress: agentB.agentAddress,
     })).rejects.toMatchObject({
-      code: 'SWM_SUBSET_NOT_SEALABLE',
+      code: 'LEGACY_KA_READ_ONLY',
     });
     expect(await node!.publisher.assertionQuery(cgId, assertionName, agentB.agentAddress)).toHaveLength(1);
   });

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -255,7 +255,7 @@ modes auto-renewal can't recover from:
 | `dkg ka write <name> -c <cg> --input-file <rdf>` | Append RDF payload quads into WM |
 | `dkg ka import-file <name> -c <cg> --input-file <file>` | Import a document into WM through extraction |
 | `dkg ka extraction-status <name> -c <cg>` | Check document extraction status |
-| `dkg ka finalize <name> -c <cg> [--layer wm\|swm]` | Seal a WM draft, or seal SWM content with `--layer swm` |
+| `dkg ka finalize <name> -c <cg>` | Seal a WM draft; existing root-scoped SWM assets remain read-only |
 | `dkg ka share <name> -c <cg> [--entity <uri...>]` | Share finalized WM to Shared Working Memory |
 | `dkg ka share-async <name> -c <cg>` | Enqueue async WM-to-SWM share |
 | `dkg ka share-jobs [--context-graph-id <cg>]` | List async SWM share jobs |

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -707,6 +707,7 @@ export class ApiClient {
     name: string,
     options?: {
       subGraphName?: string;
+      /** @deprecated Only WM finalization is supported. `swm` fails read-only. */
       layer?: 'wm' | 'swm';
       authorAgentAddress?: string;
       preSignedAuthorAttestation?: PreSignedAuthorAttestationPayload;
@@ -717,6 +718,12 @@ export class ApiClient {
     // self-sign vs external-signer conflict client-side instead of relying on
     // the daemon, so every SDK surface enforces the same contract.
     assertExclusiveAuthorFields(options ?? {});
+    if (options?.layer === 'swm') {
+      throw Object.assign(
+        new Error('Legacy root-scoped Knowledge Assets are read-only'),
+        { code: 'LEGACY_KA_READ_ONLY' },
+      );
+    }
     return this.post(`/api/knowledge-assets/${encodeURIComponent(name)}/wm/finalize`, { contextGraphId, ...(options ?? {}) });
   }
 

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -4,6 +4,7 @@ import type {
   ContextGraphReconcileResult,
   RandomSamplingDisabledReason,
 } from '@origintrail-official/dkg-agent';
+import { LegacyKnowledgeAssetReadOnlyError } from '@origintrail-official/dkg-core';
 import { readApiPort, readPid, isProcessRunning, configExists, loadConfig } from './config.js';
 import { loadTokens } from './auth.js';
 import {
@@ -714,16 +715,13 @@ export class ApiClient {
       schemeVersion?: number;
     },
   ): Promise<{ merkleRoot: string; eip712Digest: string }> {
+    if (options?.layer === 'swm') {
+      throw new LegacyKnowledgeAssetReadOnlyError();
+    }
     // Mirror the mcp-dkg / openclaw / node-ui clients: reject the
     // self-sign vs external-signer conflict client-side instead of relying on
     // the daemon, so every SDK surface enforces the same contract.
     assertExclusiveAuthorFields(options ?? {});
-    if (options?.layer === 'swm') {
-      throw Object.assign(
-        new Error('Legacy root-scoped Knowledge Assets are read-only'),
-        { code: 'LEGACY_KA_READ_ONLY' },
-      );
-    }
     return this.post(`/api/knowledge-assets/${encodeURIComponent(name)}/wm/finalize`, { contextGraphId, ...(options ?? {}) });
   }
 

--- a/packages/cli/src/commands/knowledge-asset.ts
+++ b/packages/cli/src/commands/knowledge-asset.ts
@@ -1,4 +1,4 @@
-import { Command } from 'commander';
+import { Command, Option } from 'commander';
 import { toErrorMessage } from '@origintrail-official/dkg-core';
 import {
   ApiClient,
@@ -341,13 +341,19 @@ export function registerKnowledgeAssetCommand(program: Command): void {
   addFinalizeAuthorOptions(addSubGraphOption(addContextGraphOption(
     kaCmd
       .command('finalize <name>')
-      .description('Finalize/seal a Knowledge Asset from WM'),
+      .description('Finalize/seal a Knowledge Asset from WM')
+      .addOption(new Option('--layer <layer>').hideHelp()),
   )))
     .action(async (name: string, opts: ActionOpts) => runAction(async () => {
+      const layer = opts.layer === undefined ? undefined : String(opts.layer);
+      if (layer !== undefined && layer !== 'wm' && layer !== 'swm') {
+        throw new Error('--layer must be wm or swm');
+      }
       const authorOptions = parseFinalizeAuthorOptions(opts);
       const client = await ApiClient.connect();
       const result = await client.knowledgeAssetFinalize(requiredContextGraphId(opts), name, {
         ...(subGraphName(opts) ? { subGraphName: subGraphName(opts) } : {}),
+        ...(layer ? { layer } : {}),
         ...authorOptions,
       });
       console.log('Knowledge asset finalized:');

--- a/packages/cli/src/commands/knowledge-asset.ts
+++ b/packages/cli/src/commands/knowledge-asset.ts
@@ -341,19 +341,13 @@ export function registerKnowledgeAssetCommand(program: Command): void {
   addFinalizeAuthorOptions(addSubGraphOption(addContextGraphOption(
     kaCmd
       .command('finalize <name>')
-      .description('Finalize/seal a Knowledge Asset from WM, or from SWM with --layer swm')
-      .option('--layer <layer>', 'Layer to finalize: wm or swm (default: wm)'),
+      .description('Finalize/seal a Knowledge Asset from WM'),
   )))
     .action(async (name: string, opts: ActionOpts) => runAction(async () => {
-      const layer = opts.layer === undefined ? undefined : String(opts.layer);
-      if (layer !== undefined && layer !== 'wm' && layer !== 'swm') {
-        throw new Error('--layer must be wm or swm');
-      }
       const authorOptions = parseFinalizeAuthorOptions(opts);
       const client = await ApiClient.connect();
       const result = await client.knowledgeAssetFinalize(requiredContextGraphId(opts), name, {
         ...(subGraphName(opts) ? { subGraphName: subGraphName(opts) } : {}),
-        ...(layer ? { layer } : {}),
         ...authorOptions,
       });
       console.log('Knowledge asset finalized:');

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -74,7 +74,11 @@ import {
 } from "./shared-assertion-helpers.js";
 import { AsyncLiftJobConflictError, PromoteJobConflictError } from "@origintrail-official/dkg-publisher";
 import { deriveStatus } from "@origintrail-official/dkg-publisher";
-import { validateAssertionName, contextGraphAssertionUri } from "@origintrail-official/dkg-core";
+import {
+  LegacyKnowledgeAssetReadOnlyError,
+  validateAssertionName,
+  contextGraphAssertionUri,
+} from "@origintrail-official/dkg-core";
 import {
   formatFinalizedPublishOptionError,
   parseHttpFinalizedPublishOptions,
@@ -149,6 +153,11 @@ const FINALIZE_ONLY_CREATE_FIELDS = [
   "schemeVersion",
 ] as const;
 
+function respondLegacyKnowledgeAssetReadOnly(res: RequestContext["res"]): void {
+  const error = new LegacyKnowledgeAssetReadOnlyError();
+  jsonResponse(res, 409, { code: error.code, error: error.message });
+}
+
 /**
  * Translate engine/publisher errors on the WM/SWM mutation verbs into the same
  * HTTP status mapping the legacy `/api/assertion/*` routes use, so callers see
@@ -159,6 +168,13 @@ const FINALIZE_ONLY_CREATE_FIELDS = [
  * publish path, which never down-classified them).
  */
 function respondAssertionError(res: RequestContext["res"], e: any): void {
+  if (
+    e instanceof LegacyKnowledgeAssetReadOnlyError
+    || e?.code === "LEGACY_KA_READ_ONLY"
+  ) {
+    respondLegacyKnowledgeAssetReadOnly(res);
+    return;
+  }
   if (e?.code === "OVERSIZED_RDF_LITERAL") {
     jsonResponse(res, 400, oversizedRdfLiteralResponseBody(e));
     return;
@@ -320,10 +336,7 @@ export function resolveFinalizeOptions(
   // stable response for older clients that still send `layer:"swm"`, but never
   // invoke the legacy root-closure reconstruction/migration path.
   if (layer === "swm") {
-    jsonResponse(res, 409, {
-      code: "LEGACY_KA_READ_ONLY",
-      error: "Legacy root-scoped Knowledge Assets are read-only",
-    });
+    respondLegacyKnowledgeAssetReadOnly(res);
     return null;
   }
   if (layer != null && layer !== "wm") {

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -316,12 +316,18 @@ export function resolveFinalizeOptions(
     schemeVersion,
     layer,
   } = raw;
-  // #1116: optional `layer` selects WHERE the content to seal lives. "wm"
-  // (default) seals the Working-Memory draft; "swm" seals content already
-  // shared to SWM (reconstructs a transient WM draft from SWM, then finalizes)
-  // — mirrors the body-field `layer` precedent on pull-from.
-  if (layer != null && layer !== "wm" && layer !== "swm") {
-    jsonResponse(res, 400, { error: 'finalize "layer" must be "wm" or "swm" when supplied' });
+  // Rootless KAs are sealed in WM and shared atomically. Retain a deliberate,
+  // stable response for older clients that still send `layer:"swm"`, but never
+  // invoke the legacy root-closure reconstruction/migration path.
+  if (layer === "swm") {
+    jsonResponse(res, 409, {
+      code: "LEGACY_KA_READ_ONLY",
+      error: "Legacy root-scoped Knowledge Assets are read-only",
+    });
+    return null;
+  }
+  if (layer != null && layer !== "wm") {
+    jsonResponse(res, 400, { error: 'finalize "layer" must be "wm" when supplied' });
     return null;
   }
   if (authorAgentAddress != null && preSignedAuthorAttestation != null) {
@@ -383,7 +389,6 @@ export function resolveFinalizeOptions(
     ...(typeof effectiveAuthorAgentAddress === "string" ? { authorAgentAddress: effectiveAuthorAgentAddress } : {}),
     ...(resolvedPreSignedAttestation ? { preSignedAuthorAttestation: resolvedPreSignedAttestation } : {}),
     ...(schemeVersion != null ? { schemeVersion } : {}),
-    ...(layer === "swm" ? { layer } : {}),
   };
 }
 
@@ -1155,26 +1160,11 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
           finalizeOptions,
           writePreflightCallerAgentAddress,
         );
-        let seal;
-        try {
-          seal = await agent.assertion.finalize(contextGraphId, name, {
-            ...finalizeOptions,
-            ...finalizeStorageLane,
-          });
-        } catch (e: any) {
-          // #1116 (review A1): a finalize(layer:"swm") on an asset that was only
-          // SUBSET-shared is rejected — subset shares are SWM-only, not
-          // publishable. Map it to a 409 (parity with the swm/share
-          // UNSEALED_SHARE_BLOCKED mapping) carrying the recovery hint in the
-          // message; everything else propagates to the outer handler unchanged.
-          if (e?.code === "SWM_SUBSET_NOT_SEALABLE") {
-            return jsonResponse(res, 409, { code: "SWM_SUBSET_NOT_SEALABLE", error: e.message });
-          }
-          throw e;
-        }
-        // #1116: a layer:"swm" finalize touches SWM (it reconstructs a WM draft
-        // from SWM, then seals), so reflect both layers in the change event.
-        emitMemoryGraphChanged?.({ contextGraphId, layers: finalizeOptions.layer === "swm" ? ["wm", "swm"] : ["wm"], subGraphName, operation: "assertion_finalized", source: "api" });
+        const seal = await agent.assertion.finalize(contextGraphId, name, {
+          ...finalizeOptions,
+          ...finalizeStorageLane,
+        });
+        emitMemoryGraphChanged?.({ contextGraphId, layers: ["wm"], subGraphName, operation: "assertion_finalized", source: "api" });
         // Full seal payload (PR #971) — clients inspect the attestation.
         return jsonResponse(res, 200, {
           assertionUri: seal.assertionUri,

--- a/packages/cli/test/api-client.test.ts
+++ b/packages/cli/test/api-client.test.ts
@@ -1038,15 +1038,12 @@ describe('ApiClient — GitHub-shaped knowledge-assets SDK (OT-RFC-43 §10.5)', 
     expect(calls).toHaveLength(0);
   });
 
-  it('knowledgeAssetFinalize can target WM or SWM layer', async () => {
+  it('knowledgeAssetFinalize rejects the legacy SWM write bridge before HTTP serialization', async () => {
     const calls = track({ merkleRoot: '0xabc', eip712Digest: '0xdig' });
-    await client.knowledgeAssetFinalize('cg', 'f', { layer: 'swm', subGraphName: 'notes' });
-    expect(calls[0].url).toBe(`${base}/api/knowledge-assets/f/wm/finalize`);
-    expect(JSON.parse(calls[0].opts.body as string)).toMatchObject({
-      contextGraphId: 'cg',
-      layer: 'swm',
-      subGraphName: 'notes',
-    });
+    await expect(
+      client.knowledgeAssetFinalize('cg', 'f', { layer: 'swm', subGraphName: 'notes' }),
+    ).rejects.toMatchObject({ code: 'LEGACY_KA_READ_ONLY' });
+    expect(calls).toHaveLength(0);
   });
 
   it('knowledgeAssetShareAsync and share job helpers use lifecycle routes', async () => {

--- a/packages/cli/test/api-client.test.ts
+++ b/packages/cli/test/api-client.test.ts
@@ -1046,6 +1046,20 @@ describe('ApiClient — GitHub-shaped knowledge-assets SDK (OT-RFC-43 §10.5)', 
     expect(calls).toHaveLength(0);
   });
 
+  it('gives the legacy SWM read-only gate precedence over authorship validation', async () => {
+    const calls = track({ merkleRoot: '0xabc', eip712Digest: '0xdig' });
+    await expect(client.knowledgeAssetFinalize('cg', 'f', {
+      layer: 'swm',
+      authorAgentAddress: '0x1111111111111111111111111111111111111111',
+      preSignedAuthorAttestation: {
+        address: '0x2222222222222222222222222222222222222222',
+        reservedKaId: '1',
+        signature: { r: `0x${'22'.repeat(32)}`, vs: `0x${'33'.repeat(32)}` },
+      },
+    })).rejects.toMatchObject({ code: 'LEGACY_KA_READ_ONLY' });
+    expect(calls).toHaveLength(0);
+  });
+
   it('knowledgeAssetShareAsync and share job helpers use lifecycle routes', async () => {
     let calls = track({ jobId: 'share-job-1', state: 'queued' });
     await client.knowledgeAssetShareAsync('cg', 'f', {

--- a/packages/cli/test/knowledge-asset-cli-smoke.test.ts
+++ b/packages/cli/test/knowledge-asset-cli-smoke.test.ts
@@ -609,7 +609,9 @@ describe.sequential('knowledge-asset CLI smoke', () => {
     expect(createCall?.body.alsoPublishVm).toBeUndefined();
 
     await runCli(['knowledge-asset', 'write', 'paper', '-c', 'research', '--subject', 'urn:company:acme', '--predicate', 'http://schema.org/description', '--object', 'Logistics'], env);
-    await runCli(['ka', 'finalize', 'paper', '-c', 'research', '--layer', 'swm'], env);
+    await runCli(['ka', 'finalize', 'paper', '-c', 'research'], env);
+    await expect(runCli(['ka', 'finalize', 'paper', '-c', 'research', '--layer', 'swm'], env))
+      .rejects.toMatchObject({ stderr: expect.stringContaining("unknown option '--layer'") });
     await expect(runCli(['ka', 'share', 'paper', '-c', 'research', '--entity', 'urn:company:acme'], env))
       .rejects.toMatchObject({ stderr: expect.stringContaining("unknown option '--entity'") });
     await expect(runCli(['ka', 'share', 'paper', '-c', 'research', '--skip-seal'], env))
@@ -636,7 +638,7 @@ describe.sequential('knowledge-asset CLI smoke', () => {
         object: '"Logistics"',
       }),
     ]);
-    expect(calls.find((call) => call.url === '/api/knowledge-assets/paper/wm/finalize')?.body.layer).toBe('swm');
+    expect(calls.find((call) => call.url === '/api/knowledge-assets/paper/wm/finalize')?.body.layer).toBeUndefined();
     const shareCalls = calls.filter((call) => call.url === '/api/knowledge-assets/paper/swm/share');
     expect(shareCalls[0]?.body).toMatchObject({
       contextGraphId: 'research',

--- a/packages/cli/test/knowledge-asset-cli-smoke.test.ts
+++ b/packages/cli/test/knowledge-asset-cli-smoke.test.ts
@@ -610,8 +610,9 @@ describe.sequential('knowledge-asset CLI smoke', () => {
 
     await runCli(['knowledge-asset', 'write', 'paper', '-c', 'research', '--subject', 'urn:company:acme', '--predicate', 'http://schema.org/description', '--object', 'Logistics'], env);
     await runCli(['ka', 'finalize', 'paper', '-c', 'research'], env);
+    await runCli(['ka', 'finalize', 'paper', '-c', 'research', '--layer', 'wm'], env);
     await expect(runCli(['ka', 'finalize', 'paper', '-c', 'research', '--layer', 'swm'], env))
-      .rejects.toMatchObject({ stderr: expect.stringContaining("unknown option '--layer'") });
+      .rejects.toMatchObject({ stderr: expect.stringContaining('Legacy root-scoped Knowledge Assets are read-only') });
     await expect(runCli(['ka', 'share', 'paper', '-c', 'research', '--entity', 'urn:company:acme'], env))
       .rejects.toMatchObject({ stderr: expect.stringContaining("unknown option '--entity'") });
     await expect(runCli(['ka', 'share', 'paper', '-c', 'research', '--skip-seal'], env))
@@ -627,6 +628,8 @@ describe.sequential('knowledge-asset CLI smoke', () => {
 
     expect(calls.map((call) => call.url)).toContain('/api/knowledge-assets/paper/wm/write');
     expect(calls.map((call) => call.url)).toContain('/api/knowledge-assets/paper/wm/finalize');
+    expect(calls.filter((call) => call.url === '/api/knowledge-assets/paper/wm/finalize'))
+      .toHaveLength(2);
     expect(calls.map((call) => call.url)).toContain('/api/knowledge-assets/paper/swm/share');
     expect(calls.map((call) => call.url)).toContain('/api/knowledge-assets/paper/vm/publish');
     expect(calls.map((call) => call.url)).toContain('/api/knowledge-assets/paper/vm/publish-async');

--- a/packages/cli/test/knowledge-assets-1116-share-errors.test.ts
+++ b/packages/cli/test/knowledge-assets-1116-share-errors.test.ts
@@ -26,6 +26,7 @@ import type { DKGAgent } from '@origintrail-official/dkg-agent';
 import {
   generateEd25519Keypair,
   GRAPH_KA_CONTENT_SCOPE_VERSION,
+  LegacyKnowledgeAssetReadOnlyError,
   MAX_UINT72_DECIMAL,
 } from '@origintrail-official/dkg-core';
 import {
@@ -261,6 +262,21 @@ describe('#1116 share/seal route error mapping (fake agent)', () => {
     expect(res.body.code).toBe('LEGACY_KA_READ_ONLY');
     expect(String(res.body.error)).toContain('read-only');
     expect(finalizeCalls).toHaveLength(0);
+  });
+
+  it('wm/finalize maps a persisted legacy-scope engine rejection to structured 409', async () => {
+    await startWith({
+      finalize: async () => {
+        throw new LegacyKnowledgeAssetReadOnlyError();
+      },
+    });
+
+    const res = await post('wm/finalize', { contextGraphId: CG_ID, layer: 'wm' });
+    expect(res.status).toBe(409);
+    expect(res.body).toMatchObject({
+      code: 'LEGACY_KA_READ_ONLY',
+      error: 'Legacy root-scoped Knowledge Assets are read-only',
+    });
   });
 
   it('wm/finalize: uses the token-canonical storage lane and author when body author differs only by case', async () => {

--- a/packages/cli/test/knowledge-assets-1116-share-errors.test.ts
+++ b/packages/cli/test/knowledge-assets-1116-share-errors.test.ts
@@ -3,7 +3,7 @@
  * share contract, driven over real HTTP against `handleKnowledgeAssetsRoutes`
  * with a MINIMAL fake agent (same proven pattern as
  * `promote-route-not-persisted.test.ts`). The ENGINE outcomes (fail-closed +
- * WM-preserved + subset-not-sealable) are pinned at the agent e2e level
+ * WM-preserved + legacy-read-only) are pinned at the agent e2e level
  * (`packages/agent/test/e2e-memory-layers.test.ts`, #1116 block); this pins the
  * ROUTE's catch branches so the HTTP surface can't silently drift:
  *
@@ -12,8 +12,8 @@
  *     `{ code, error, recovery }`. The live-daemon suite explicitly can NOT
  *     reach this (it always has a signing key + V10 chain), so it's covered
  *     here with a fake agent.
- *   - wm/finalize (layer:swm): a subset-shared asset throws
- *     `code:'SWM_SUBSET_NOT_SEALABLE'` → route 409 `{ code, error }`.
+ *   - wm/finalize (layer:swm): the route rejects the retired write bridge with
+ *     `code:'LEGACY_KA_READ_ONLY'` before invoking the engine.
  */
 
 import { afterEach, describe, expect, it } from 'vitest';
@@ -247,31 +247,20 @@ describe('#1116 share/seal route error mapping (fake agent)', () => {
     expect(res.body.namedGraphs).toEqual(['urn:test:graph:one']);
   });
 
-  it('wm/finalize (layer:swm): forwards layer:"swm" to the engine AND maps SWM_SUBSET_NOT_SEALABLE → 409', async () => {
-    // Round 10 (reviewer 🟡): CAPTURE the finalize call args so we prove the route
-    // threaded `layer:"swm"` through resolveFinalizeOptions into
-    // agent.assertion.finalize — a fake that ignored its args would let a route
-    // that dropped `layer` (always finalizing WM) pass this test silently.
+  it('wm/finalize (layer:swm): rejects read-only before invoking the engine', async () => {
     const finalizeCalls: Array<{ contextGraphId: unknown; name: unknown; opts: any }> = [];
     await startWith({
       finalize: async (contextGraphId: unknown, name: unknown, opts: any) => {
         finalizeCalls.push({ contextGraphId, name, opts });
-        throw Object.assign(
-          new Error('Cannot seal-in-SWM: this asset was not fully shared to SWM — subset shares are not publishable. Share the full asset (entities:"all") first, then finalize(layer:"swm").'),
-          { code: 'SWM_SUBSET_NOT_SEALABLE' },
-        );
+        throw new Error('must not be called');
       },
     });
 
     const res = await post('wm/finalize', { contextGraphId: CG_ID, layer: 'swm' });
     expect(res.status).toBe(409);
-    expect(res.body.code).toBe('SWM_SUBSET_NOT_SEALABLE');
-    expect(String(res.body.error)).toContain('subset shares are not publishable');
-
-    // The route actually forwarded layer:"swm" (not dropped, not defaulted to WM).
-    expect(finalizeCalls.length).toBe(1);
-    expect(finalizeCalls[0]?.opts?.layer).toBe('swm');
-    expect(finalizeCalls[0]?.contextGraphId).toBe(CG_ID);
+    expect(res.body.code).toBe('LEGACY_KA_READ_ONLY');
+    expect(String(res.body.error)).toContain('read-only');
+    expect(finalizeCalls).toHaveLength(0);
   });
 
   it('wm/finalize: uses the token-canonical storage lane and author when body author differs only by case', async () => {

--- a/packages/mcp-dkg/src/client.ts
+++ b/packages/mcp-dkg/src/client.ts
@@ -1212,9 +1212,8 @@ export class DkgClient {
     authorAgentAddress?: string;
     preSignedAuthorAttestation?: PreSignedAuthorAttestationPayload;
     schemeVersion?: number;
-    // #1116: optional layer selects WHERE the content to seal lives. "wm"
-    // (default) seals the open WM draft; "swm" reconstructs a draft from an
-    // already-shared SWM asset and seals it (recover-without-recreate).
+    // #1116: retained for mixed-version wire compatibility. "wm" seals the open
+    // draft; current daemons reject deprecated "swm" with LEGACY_KA_READ_ONLY.
     layer?: 'wm' | 'swm';
   }): Promise<{ merkleRoot: string; eip712Digest: string }> {
     assertExclusiveAuthorFields(args);

--- a/packages/mcp-dkg/src/tools/assertions.ts
+++ b/packages/mcp-dkg/src/tools/assertions.ts
@@ -54,8 +54,8 @@ const formatError = (e: unknown): string =>
 // Legacy SWM content is read-only, so recovery must go through WM + atomic share.
 export const SHARE_NOT_PUBLISH_READY_WARNING =
   'Shared to SWM but NOT publish-ready (sealed:false). Legacy unsealed SWM ' +
-  'content is read-only; recreate or pull the asset into Working Memory, then ' +
-  'use an atomic full share before publishing.';
+  'content is read-only; use the preserved Working Memory draft if available, ' +
+  'or recreate the knowledge asset, then use an atomic full share before publishing.';
 
 // A SUBSET share is publishReady:false too, but unlike a skipSeal full share it is
 // NOT sealable — legacy SWM finalize is read-only.

--- a/packages/mcp-dkg/src/tools/assertions.ts
+++ b/packages/mcp-dkg/src/tools/assertions.ts
@@ -50,24 +50,25 @@ const formatError = (e: unknown): string =>
 // `tests/fixtures/share-seal-warnings.json`. Update the fixture + all three
 // adapters together; the parity tests flag any mismatch.
 
-// publishReady:false after a FULL share that opted out of sealing (skipSeal:true)
-// — a later finalize(layer:swm) DOES seal it.
+// publishReady:false after a FULL share that opted out of sealing (skipSeal:true).
+// Legacy SWM content is read-only, so recovery must go through WM + atomic share.
 export const SHARE_NOT_PUBLISH_READY_WARNING =
-  'Shared to SWM but NOT publish-ready (sealed:false). Seal it with ' +
-  'dkg_knowledge_asset_finalize (layer:swm works after sharing), then publish.';
+  'Shared to SWM but NOT publish-ready (sealed:false). Legacy unsealed SWM ' +
+  'content is read-only; recreate or pull the asset into Working Memory, then ' +
+  'use an atomic full share before publishing.';
 
 // A SUBSET share is publishReady:false too, but unlike a skipSeal full share it is
-// NOT sealable — finalize(layer:swm) now REJECTS it with SWM_SUBSET_NOT_SEALABLE.
+// NOT sealable — legacy SWM finalize is read-only.
 // Surface the real recovery (full share / new asset) instead of "seal it".
 export const SHARE_SUBSET_NOT_PUBLISH_READY_WARNING =
   'Shared a SUBSET to SWM for peer visibility. A subset is NOT sealable/' +
-  'publishable (finalize layer:swm will reject it). To publish on-chain, share ' +
-  'the full asset (entities:"all"), or model this subset as its own knowledge asset.';
+  'publishable. Legacy SWM finalize is read-only. To publish on-chain, share ' +
+  'the full asset atomically (entities:"all"), or model this subset as its own knowledge asset.';
 
 // A FULL share can come back sealed:true but publishReady:false when NOT every
 // sealed root reached SWM (promotedAllRoots false — e.g. foreign-owned roots were
-// skipped). The engine did NOT set the swmShareComplete marker, so finalize(layer:
-// swm) would REJECT — do NOT recommend it here. Re-sharing the full asset recovers.
+// skipped). The engine did NOT set the swmShareComplete marker, and SWM is
+// read-only, so do NOT recommend finalizing it. Re-sharing the full asset recovers.
 export const SHARE_INCOMPLETE_PROMOTE_WARNING =
   'Sealed, but not all roots reached SWM (some roots may be owned by other ' +
   'agents) — not yet publishable; re-share the full asset so every sealed root ' +
@@ -77,9 +78,9 @@ export const SHARE_INCOMPLETE_PROMOTE_WARNING =
  * #1116: pick the not-publish-ready share warning from the share outcome. Returns
  * `undefined` when the share IS publish-ready (no warning). Branch precedence:
  *  1. sealed:true + publishReady:false → incomplete full promote (marker NOT set;
- *     finalize layer:swm would reject) → re-share the full asset.
+ *     SWM is read-only) → re-share the full asset.
  *  2. sealed:false + SUBSET (a non-empty specific entity list) → not sealable.
- *  3. sealed:false + FULL (skipSeal) → sealable later (finalize layer:swm works).
+ *  3. sealed:false + FULL (skipSeal) → recover through WM + atomic full share.
  * Duplicated byte-identical on OpenClaw (TS) + Hermes (Python).
  */
 export function classifyShareWarning(outcome: {
@@ -444,9 +445,9 @@ export function registerAssertionTools(
         'call this explicitly before sharing a SELECTIVE subset of entities, or ' +
         'to re-seal after editing a previously-sealed draft. Sealing works even ' +
         'if the context graph is NOT yet registered on-chain (registration ' +
-        'happens at publish). Pass `layer:"swm"` to seal an asset already shared ' +
-        'to SWM (e.g. shared with `skipSeal:true`) — it recovers and seals the ' +
-        'SWM content without a delete-and-recreate. (External-signer / ' +
+        'happens at publish). The deprecated `layer:"swm"` compatibility value ' +
+        'is read-only and returns `LEGACY_KA_READ_ONLY`; recover legacy content ' +
+        'through Working Memory and an atomic full share instead. (External-signer / ' +
         'pre-signed attestation is a tracked follow-up and is not exposed by this ' +
         'tool — author with authorAgentAddress.)',
       inputSchema: {
@@ -461,15 +462,13 @@ export function registerAssertionTools(
         // CONTRACT §C: scheme_version is a POSITIVE integer (daemon >= 1) — zod
         // rejects 0 / negative / non-integer at the boundary as a tool error.
         schemeVersion: z.number().int().positive().optional().describe('Optional attestation scheme version (positive integer)'),
-        // #1116: `layer` selects WHERE the content to seal lives. Default "wm"
-        // seals the open WM draft; "swm" seals an asset already shared to SWM.
+        // #1116: retained for wire compatibility. Only WM is writable.
         layer: z
           .enum(['wm', 'swm'])
           .optional()
           .describe(
-            'Which layer holds the content to seal. Default "wm" seals the open ' +
-            'Working Memory draft. Pass "swm" to seal an asset already shared to ' +
-            'SWM (recovers + seals the SWM content without delete-and-recreate).',
+            'Default "wm" seals the open Working Memory draft. Deprecated ' +
+            '"swm" is read-only and returns LEGACY_KA_READ_ONLY.',
           ),
         projectId: z.string().optional().describe(`${EXISTING_CONTEXT_GRAPH_ID_DESCRIPTION} Defaults to .dkg/config.yaml.`),
         subGraphName: z.string().optional(),
@@ -516,9 +515,9 @@ export function registerAssertionTools(
         'Shared Working Memory so teammates see it. A FULL share (omit ' +
         '`entities` or pass "all") SEALS BY DEFAULT and is then publish-ready — ' +
         'follow it with dkg_knowledge_asset_publish to mint the asset on-chain ' +
-        '(Verifiable Memory). Pass `skipSeal:true` to share WITHOUT sealing (an ' +
-        'unsealed SWM share — seal it later with dkg_knowledge_asset_finalize, ' +
-        'where `layer:"swm"` works after sharing). If a default (sealing) share ' +
+        '(Verifiable Memory). `skipSeal:true` is retained only for compatibility; ' +
+        'an unsealed SWM share cannot be finalized because legacy SWM writes are ' +
+        'read-only. If a default (sealing) share ' +
         'cannot seal it fails CLOSED (409, Working Memory preserved) and returns ' +
         'a recovery hint. For custom finalize/attestation options — ' +
         'authorAgentAddress / schemeVersion — call dkg_knowledge_asset_finalize ' +

--- a/packages/mcp-dkg/src/tools/assertions.ts
+++ b/packages/mcp-dkg/src/tools/assertions.ts
@@ -515,9 +515,9 @@ export function registerAssertionTools(
         'Shared Working Memory so teammates see it. A FULL share (omit ' +
         '`entities` or pass "all") SEALS BY DEFAULT and is then publish-ready — ' +
         'follow it with dkg_knowledge_asset_publish to mint the asset on-chain ' +
-        '(Verifiable Memory). `skipSeal:true` is retained only for compatibility; ' +
-        'an unsealed SWM share cannot be finalized because legacy SWM writes are ' +
-        'read-only. If a default (sealing) share ' +
+        '(Verifiable Memory). `skipSeal:true` is retained only for compatibility ' +
+        'and is rejected by graph-scoped daemons; omit it or pass false to perform ' +
+        'the required atomic sealed full share. If a default (sealing) share ' +
         'cannot seal it fails CLOSED (409, Working Memory preserved) and returns ' +
         'a recovery hint. For custom finalize/attestation options — ' +
         'authorAgentAddress / schemeVersion — call dkg_knowledge_asset_finalize ' +
@@ -539,15 +539,14 @@ export function registerAssertionTools(
             'roots (seals by default + publish-ready). A subset (non-empty array) ' +
             'shares to SWM only and is NOT publishable to Verifiable Memory.',
           ),
-        // #1116: a full share SEALS BY DEFAULT. `skipSeal:true` opts out into an
-        // unsealed SWM share (not publish-ready until a later finalize).
+        // #1116: a full share SEALS BY DEFAULT. The field remains so old callers
+        // receive the daemon's explicit error for true instead of a schema error.
         skipSeal: z
           .boolean()
           .optional()
           .describe(
-            'Set true to share to SWM WITHOUT sealing (not publish-ready). ' +
-            'Default (false) seals a full share so it is immediately publish-ready. ' +
-            'Ignored for a subset share, which is never sealed.',
+            'Deprecated compatibility option. Graph-scoped daemons reject true; ' +
+            'omit it or pass false to atomically seal and share the complete asset.',
           ),
         projectId: z.string().optional().describe(`${EXISTING_CONTEXT_GRAPH_ID_DESCRIPTION} Defaults to .dkg/config.yaml.`),
         subGraphName: z.string().optional(),

--- a/packages/mcp-dkg/test/assertion-lifecycle.test.ts
+++ b/packages/mcp-dkg/test/assertion-lifecycle.test.ts
@@ -768,18 +768,19 @@ describe('rc.17 lifecycle verbs — finalize / publish / pull_from (parity with 
     expect(captured.skipSeal).toBe(true);
   });
 
-  it('share with publishReady:false on a FULL share emits the seal-it warning (#1116)', async () => {
+  it('share with publishReady:false on a FULL share directs recovery through WM (#1116)', async () => {
     const localClient = new FakeClient({
       knowledgeAssetShare: async () => ({ swmShared: true, promotedCount: 2, sealed: false, publishReady: false }),
     });
     const localServer = new FakeServer();
     registerAssertionTools(localServer.asMcpServer(), localClient.asDkgClient(), makeConfig());
 
-    // A skipSeal FULL share IS sealable later → the "seal it with finalize" hint.
+    // Legacy SWM is read-only, so this must not recommend finalize(layer:swm).
     const res = await localServer.call('dkg_knowledge_asset_share', { name: 'doc', skipSeal: true });
     expect(res.isError).toBeFalsy();
     expect(res.content[0].text).toContain('NOT publish-ready (sealed:false)');
-    expect(res.content[0].text).toContain('layer:swm works after sharing');
+    expect(res.content[0].text).toContain('Legacy unsealed SWM content is read-only');
+    expect(res.content[0].text).toContain('atomic full share');
     expect(res.content[0].text).not.toContain('NOT sealable');
   });
 
@@ -790,7 +791,7 @@ describe('rc.17 lifecycle verbs — finalize / publish / pull_from (parity with 
     const localServer = new FakeServer();
     registerAssertionTools(localServer.asMcpServer(), localClient.asDkgClient(), makeConfig());
 
-    // A subset is NOT sealable (finalize layer:swm rejects it) → full-share / new-asset recovery.
+    // A subset is NOT sealable and SWM is read-only → full-share / new-asset recovery.
     const res = await localServer.call('dkg_knowledge_asset_share', { name: 'doc', entities: ['urn:a'] });
     expect(res.isError).toBeFalsy();
     expect(res.content[0].text).toContain('A subset is NOT sealable/publishable');
@@ -812,7 +813,7 @@ describe('rc.17 lifecycle verbs — finalize / publish / pull_from (parity with 
     expect(res.content[0].text).toContain('not all roots reached SWM');
     expect(res.content[0].text).toContain('re-share the full asset');
     // Must NOT recommend the dead-end finalize layer:swm here (it would reject).
-    expect(res.content[0].text).not.toContain('layer:swm works after sharing');
+    expect(res.content[0].text).not.toContain('recovers + seals');
     expect(res.content[0].text).not.toContain('NOT sealable');
   });
 

--- a/packages/mcp-dkg/test/assertion-lifecycle.test.ts
+++ b/packages/mcp-dkg/test/assertion-lifecycle.test.ts
@@ -752,6 +752,17 @@ describe('rc.17 lifecycle verbs — finalize / publish / pull_from (parity with 
 
   // ── #1116 share seal: skipSeal forwarding + publishReady warning branch ──
 
+  it('advertises skipSeal:true as rejected compatibility input, not an unsealed share mode', () => {
+    const localServer = new FakeServer();
+    registerAssertionTools(localServer.asMcpServer(), client.asDkgClient(), makeConfig());
+    const share = localServer.get('dkg_knowledge_asset_share');
+    expect(share.config.description).toMatch(/skipSeal:true.*rejected by graph-scoped daemons/i);
+    expect(share.config.description).not.toMatch(/unsealed SWM share/i);
+    const skipSealDescription = share.config.inputSchema?.skipSeal?.description;
+    expect(skipSealDescription).toMatch(/reject true/i);
+    expect(skipSealDescription).not.toMatch(/without sealing/i);
+  });
+
   it('share forwards skipSeal:true to the client (#1116)', async () => {
     const captured: Record<string, unknown> = {};
     const localClient = new FakeClient({

--- a/packages/mcp-dkg/test/share-warning-parity.test.ts
+++ b/packages/mcp-dkg/test/share-warning-parity.test.ts
@@ -46,7 +46,7 @@ describe('#1116 share-warning parity (MCP vs canonical fixture)', () => {
     expect(classifyShareWarning({ sealed: false, publishReady: false, isSubset: true })).toBe(
       SHARE_SUBSET_NOT_PUBLISH_READY_WARNING,
     );
-    // sealed:false + full (skip_seal) → sealable later.
+    // sealed:false + full (skip_seal) → recover through WM + atomic full share.
     expect(classifyShareWarning({ sealed: false, publishReady: false, isSubset: false })).toBe(
       SHARE_NOT_PUBLISH_READY_WARNING,
     );

--- a/packages/mcp-dkg/test/share-warning-parity.test.ts
+++ b/packages/mcp-dkg/test/share-warning-parity.test.ts
@@ -22,6 +22,8 @@ const fixture = JSON.parse(
 describe('#1116 share-warning parity (MCP vs canonical fixture)', () => {
   it('SHARE_NOT_PUBLISH_READY_WARNING matches the fixture byte-for-byte', () => {
     expect(SHARE_NOT_PUBLISH_READY_WARNING).toBe(fixture.SHARE_NOT_PUBLISH_READY_WARNING);
+    expect(SHARE_NOT_PUBLISH_READY_WARNING).toContain('preserved Working Memory draft');
+    expect(SHARE_NOT_PUBLISH_READY_WARNING).not.toMatch(/pull(?:-|\s)from|pull the asset/i);
   });
 
   it('SHARE_SUBSET_NOT_PUBLISH_READY_WARNING matches the fixture byte-for-byte', () => {

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -897,31 +897,10 @@ export const knowledgeAssetPublish = (
 };
 
 /**
- * Thrown by `knowledgeAssetPublishWithSeal` when a SWM asset can't be sealed in
- * place because only a subset of it was shared (daemon `SWM_SUBSET_NOT_SEALABLE`).
- * The UI surfaces this as "share the full asset first" — it is NOT retried.
- */
-export class SwmSubsetNotSealableError extends Error {
-  constructor(message?: string) {
-    super(message ?? 'Share the full asset to Shared Memory before publishing.');
-    this.name = 'SwmSubsetNotSealableError';
-  }
-}
-
-/**
- * Publish a named SWM assertion to VM, sealing it in place first if the daemon
- * reports it isn't finalized (the #1116 / §4.4 catch→seal→retry contract).
- *
- * Normal path: by the time content reaches SWM it is sealed (seal-on-share is
- * the default), so the first `/vm/publish` succeeds. This is the robustness
- * safety net for the rare unsealed-in-SWM case:
- *   - `PUBLISH_NOT_FULL_SHARE` / `VM_PUBLISH_PRECONDITION` (409) → seal in place
- *     via `wm/finalize {layer:"swm"}`, then retry publish ONCE.
- *   - `SWM_SUBSET_NOT_SEALABLE` (409, on the seal) → throw
- *     `SwmSubsetNotSealableError` (caller tells the user to share the full
- *     asset); never loops.
- * `sealed` in the result tells the caller a seal step ran so it can surface
- * "sealing then publishing" instead of a silent skip.
+ * Publish a named, already-sealed SWM assertion to VM. Current graph-scoped
+ * KAs seal before atomic sharing; a publish precondition is surfaced directly
+ * so the UI never invokes the retired `finalize(layer:"swm")` write bridge or
+ * masks the original error with a second request.
  *
  * A daemon HTTP-207 partial publish (KA minted on-chain but the context-graph
  * binding failed) comes back as `res.ok`, so it is NOT thrown — the body
@@ -933,35 +912,7 @@ export async function knowledgeAssetPublishWithSeal(
   name: string,
   opts: { subGraphName?: string } & KnowledgeAssetFinalizedPublishOptions = {},
 ): Promise<Record<string, unknown> & { sealed?: boolean; contextGraphError?: string }> {
-  try {
-    return await knowledgeAssetPublish(contextGraphId, name, opts);
-  } catch (err: unknown) {
-    const code =
-      err instanceof HttpError && err.status === 409
-        ? (err.body as { code?: string } | undefined)?.code
-        : undefined;
-    if (code !== 'PUBLISH_NOT_FULL_SHARE' && code !== 'VM_PUBLISH_PRECONDITION') throw err;
-    // Unsealed in SWM — seal in place, then retry the publish once.
-    try {
-      await knowledgeAssetFinalize(contextGraphId, name, {
-        layer: 'swm',
-        ...(opts.subGraphName ? { subGraphName: opts.subGraphName } : {}),
-      });
-    } catch (sealErr: unknown) {
-      if (
-        sealErr instanceof HttpError &&
-        sealErr.status === 409 &&
-        (sealErr.body as { code?: string } | undefined)?.code === 'SWM_SUBSET_NOT_SEALABLE'
-      ) {
-        throw new SwmSubsetNotSealableError(
-          (sealErr.body as { error?: string } | undefined)?.error,
-        );
-      }
-      throw sealErr;
-    }
-    const result = await knowledgeAssetPublish(contextGraphId, name, opts);
-    return { ...result, sealed: true };
-  }
+  return knowledgeAssetPublish(contextGraphId, name, opts);
 }
 
 /**
@@ -1052,10 +1003,7 @@ export async function publishAssertionsToVm(
         }
       }
     } catch (err: unknown) {
-      const message =
-        err instanceof SwmSubsetNotSealableError
-          ? err.message
-          : (err as { message?: string })?.message ?? 'publish failed';
+      const message = (err as { message?: string })?.message ?? 'publish failed';
       failures.push({ name: a.name, ...(a.subGraph ? { subGraph: a.subGraph } : {}), error: message });
     }
   }

--- a/packages/node-ui/src/ui/views/MemoryLayerView.tsx
+++ b/packages/node-ui/src/ui/views/MemoryLayerView.tsx
@@ -664,7 +664,7 @@ export function PublishPanel({ contextGraphId, onPublished }: { contextGraphId: 
   }, [allSelected, allKeys]);
 
   // Publish a set of named SWM assertions, each as its own KA via the canonical
-  // /vm/publish (with the §4.4 catch→seal→retry safety net). We do NOT pre-
+  // /vm/publish from an already-sealed atomic share. We do NOT pre-
   // register the CG on-chain: the daemon's /vm/publish runs the local
   // preconditions FIRST and only auto-registers (preserving the stored publish
   // policy) on the `CG_NOT_REGISTERED` retry path — so a doomed publish never

--- a/packages/node-ui/src/ui/views/project/components/entities.tsx
+++ b/packages/node-ui/src/ui/views/project/components/entities.tsx
@@ -453,8 +453,8 @@ export function AssertionsList({ contextGraphId, layer, onComplete, scrollKey }:
         setResult(outcome.message);
       } else {
         // Publish THIS assertion as one Knowledge Asset (Design B, any entity
-        // count) via the shared knowledgeAssetPublishWithSeal wrapper — gets the
-        // seal-in-SWM retry + 207 partial-publish handling like the other CTAs.
+        // count) via the shared knowledgeAssetPublishWithSeal wrapper — requires
+        // an already-sealed atomic share and preserves 207 partial-publish handling.
         const res = await knowledgeAssetPublishWithSeal(contextGraphId, assertion.name, assertion.subGraph ? { subGraphName: assertion.subGraph } : {});
         setResult(
           res.contextGraphError

--- a/packages/node-ui/src/ui/views/project/components/ka.tsx
+++ b/packages/node-ui/src/ui/views/project/components/ka.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState, Suspense } from 'react';
 import { api } from '../../../api-wrapper.js';
-import { promoteAssertion, describePromoteResult, describePromoteError, knowledgeAssetPublishWithSeal, SwmSubsetNotSealableError, partialPublishWarning, PARTIAL_PUBLISH_STATUS_SUFFIX, type PromoteOutcome, type PublishResult } from '../../../api.js';
+import { promoteAssertion, describePromoteResult, describePromoteError, knowledgeAssetPublishWithSeal, partialPublishWarning, PARTIAL_PUBLISH_STATUS_SUFFIX, type PromoteOutcome, type PublishResult } from '../../../api.js';
 import { useMemoryEntities, canonicalEntityUri, isFirstClassEntity, type MemoryEntity, type Triple } from '../../../hooks/useMemoryEntities.js';
 import { decodeRdfStringLiteral } from '../../../../rdf-literal.js';
 import { useProjectProfileContext } from '../../../hooks/useProjectProfile.js';
@@ -176,7 +176,7 @@ export function VerifyOnDkgButton({
       } else {
         // Named-only publish (#1087): publish the entity's owning SWM assertion
         // as one Knowledge Asset via the canonical per-KA /vm/publish (with the
-        // §4.4 catch→seal→retry safety net). We do NOT pre-register the CG: the
+        // direct, already-sealed publish path). We do NOT pre-register the CG: the
         // daemon's /vm/publish checks the local preconditions first and only
         // auto-registers (with the stored publish policy) on its
         // `CG_NOT_REGISTERED` retry path, so a doomed publish never burns gas.
@@ -193,12 +193,10 @@ export function VerifyOnDkgButton({
     } catch (err: any) {
       // Issue #864 — `ASSERTION_NOT_PERSISTED` (HTTP 409) gets a
       // typed message that points the user at the re-import path
-      // instead of the raw backend error string. A subset-share that can't be
-      // sealed in place surfaces the "share the full asset first" hint.
+      // instead of the raw backend error string. Publish preconditions are
+      // surfaced directly.
       const typed = action.kind === 'promote' ? describePromoteError(assertionName, err) : null;
-      const message = err instanceof SwmSubsetNotSealableError
-        ? err.message
-        : (typed ? typed.message : (err?.message ?? 'Action failed'));
+      const message = typed ? typed.message : (err?.message ?? 'Action failed');
       setError(message);
     } finally {
       setBusy(false);
@@ -730,5 +728,4 @@ export function TrailEvent({
     </div>
   );
 }
-
 

--- a/packages/node-ui/test/context-graph-empty-stat-components.test.ts
+++ b/packages/node-ui/test/context-graph-empty-stat-components.test.ts
@@ -19,11 +19,8 @@ vi.mock('../src/ui/api.js', () => ({
   executeQuery: vi.fn(),
   writeProfileQueryCatalog: vi.fn(),
   fetchSubGraphs: vi.fn(async () => ({ subGraphs: [] })),
-  // ka.tsx (pulled in transitively via the components barrel) imports these —
-  // they must exist on the full mock or module-load fails. SwmSubsetNotSealableError
-  // is a real class because ka.tsx uses it in an `instanceof` check.
+  // ka.tsx (pulled in transitively via the components barrel) imports these.
   knowledgeAssetPublishWithSeal: vi.fn(),
-  SwmSubsetNotSealableError: class SwmSubsetNotSealableError extends Error {},
   partialPublishWarning: vi.fn(() => ''),
   PARTIAL_PUBLISH_STATUS_SUFFIX: 'binding incomplete',
 }));

--- a/packages/node-ui/test/context-graph-query-catalog.test.ts
+++ b/packages/node-ui/test/context-graph-query-catalog.test.ts
@@ -22,11 +22,8 @@ vi.mock('../src/ui/api.js', () => ({
   executeQuery: apiMocks.executeQuery,
   writeProfileQueryCatalog: apiMocks.writeProfileQueryCatalog,
   fetchSubGraphs: vi.fn(async () => ({ subGraphs: [] })),
-  // ka.tsx (pulled in transitively via the components barrel) imports these —
-  // they must exist on the full mock or module-load fails. SwmSubsetNotSealableError
-  // is a real class because ka.tsx uses it in an `instanceof` check.
+  // ka.tsx (pulled in transitively via the components barrel) imports these.
   knowledgeAssetPublishWithSeal: vi.fn(),
-  SwmSubsetNotSealableError: class SwmSubsetNotSealableError extends Error {},
   partialPublishWarning: vi.fn(() => ''),
   PARTIAL_PUBLISH_STATUS_SUFFIX: 'binding incomplete',
 }));

--- a/packages/node-ui/test/ka-verify-cta.test.ts
+++ b/packages/node-ui/test/ka-verify-cta.test.ts
@@ -28,7 +28,6 @@ vi.mock('../src/ui/api.js', () => ({
   describePromoteError: () => null,
   partialPublishWarning: () => '',
   PARTIAL_PUBLISH_STATUS_SUFFIX: 'binding incomplete',
-  SwmSubsetNotSealableError: class SwmSubsetNotSealableError extends Error {},
 }));
 
 // The profile context drives the CTA copy + the publish target.

--- a/packages/node-ui/test/ui-api-pure.test.ts
+++ b/packages/node-ui/test/ui-api-pure.test.ts
@@ -41,7 +41,6 @@ import {
   knowledgeAssetPublish,
   knowledgeAssetPublishWithSeal,
   publishAssertionsToVm,
-  SwmSubsetNotSealableError,
   partialPublishWarning,
   knowledgeAssetFinalize,
 } from '../src/ui/api.js';
@@ -51,9 +50,8 @@ let baseUrl: string;
 const requestLog: Array<{ url: string; method: string; body: string }> = [];
 let queryBindings: any[] = [];
 // Scripted per-call responses (status + body) for tests that need a non-200
-// reply, e.g. the knowledgeAssetPublishWithSeal recovery contract. Each entry
-// is consumed on first match (FIFO), so a test can sequence "first call 409,
-// next call 200". Cleared in beforeEach.
+// reply, e.g. a knowledgeAssetPublishWithSeal precondition. Each entry is
+// consumed on first match (FIFO). Cleared in beforeEach.
 type ResponseOverride = {
   match: (url: string, method: string, body: string) => boolean;
   status: number;
@@ -71,8 +69,7 @@ function startTestServer(): Promise<void> {
         const reqMethod = req.method ?? '';
         requestLog.push({ url: reqUrl, method: reqMethod, body });
 
-        // Scripted override (consumed on first match) — lets a test return a
-        // 409 then a 200 to exercise the catch→seal→retry path.
+        // Scripted override (consumed on first match).
         const ovIdx = responseOverrides.findIndex(o => o.match(reqUrl, reqMethod, body));
         if (ovIdx !== -1) {
           const [ov] = responseOverrides.splice(ovIdx, 1);
@@ -355,50 +352,29 @@ describe('UI API tests', () => {
       expect(requestLog.some(r => r.url.includes('/api/shared-memory/publish'))).toBe(false);
     });
 
-    it('knowledgeAssetPublishWithSeal seals in SWM (layer:swm + subGraphName) then retries on a VM_PUBLISH_PRECONDITION 409', async () => {
-      // VM_PUBLISH_PRECONDITION is the SEALABLE 409 — an unsealed full share. The
-      // wrapper seals in place (wm/finalize {layer:"swm"}, forwarding subGraphName) and
-      // retries the publish once. (A PUBLISH_NOT_FULL_SHARE 409 is NOT sealable: the
-      // full-share marker is missing, so finalize(layer:"swm") returns
-      // SWM_SUBSET_NOT_SEALABLE — that path is covered by the throws-no-retry test below.)
+    it('knowledgeAssetPublishWithSeal preserves VM_PUBLISH_PRECONDITION without invoking the retired SWM reseal bridge', async () => {
       responseOverrides.push({
         match: (url, method) => method === 'POST' && url.includes('/api/knowledge-assets/a/vm/publish'),
         status: 409,
         body: { code: 'VM_PUBLISH_PRECONDITION', error: 'is not finalized' },
       });
 
-      const res = await knowledgeAssetPublishWithSeal('cg-1', 'a', { subGraphName: 'sg' });
-
-      const finalize = requestLog.find(r => r.method === 'POST' && r.url.includes('/api/knowledge-assets/a/wm/finalize'));
-      expect(finalize, 'must seal in SWM after the 409').toBeTruthy();
-      expect(JSON.parse(finalize!.body).layer).toBe('swm');
-      expect(JSON.parse(finalize!.body).subGraphName).toBe('sg');
-      // Exactly two publish attempts: the failing one + the post-seal retry.
-      const publishCalls = requestLog.filter(r => r.method === 'POST' && r.url.includes('/vm/publish'));
-      expect(publishCalls).toHaveLength(2);
-      // `sealed` flag tells the caller a seal step ran (surface "sealing then publishing").
-      expect(res.sealed).toBe(true);
+      await expect(knowledgeAssetPublishWithSeal('cg-1', 'a', { subGraphName: 'sg' }))
+        .rejects.toMatchObject({ status: 409 });
+      expect(requestLog.filter(r => r.url.includes('/wm/finalize'))).toHaveLength(0);
+      expect(requestLog.filter(r => r.url.includes('/vm/publish'))).toHaveLength(1);
     });
 
-    it('knowledgeAssetPublishWithSeal throws SwmSubsetNotSealableError and does NOT retry on SWM_SUBSET_NOT_SEALABLE', async () => {
-      // Publish 409s as not-finalized, but the in-place seal is rejected because
-      // only a subset was shared — surface the typed error, never loop.
+    it('knowledgeAssetPublishWithSeal preserves PUBLISH_NOT_FULL_SHARE without retrying', async () => {
       responseOverrides.push({
         match: (url, method) => method === 'POST' && url.includes('/api/knowledge-assets/c/vm/publish'),
         status: 409,
         body: { code: 'PUBLISH_NOT_FULL_SHARE', error: 'requires a complete full share' },
       });
-      responseOverrides.push({
-        match: (url, method) => method === 'POST' && url.includes('/api/knowledge-assets/c/wm/finalize'),
-        status: 409,
-        body: { code: 'SWM_SUBSET_NOT_SEALABLE', error: 'share the full asset first' },
-      });
 
-      await expect(knowledgeAssetPublishWithSeal('cg-1', 'c')).rejects.toBeInstanceOf(SwmSubsetNotSealableError);
-
-      // The seal was attempted exactly once and the publish was NOT retried
-      // after the seal failed (one failing publish, no second attempt).
-      expect(requestLog.filter(r => r.method === 'POST' && r.url.includes('/api/knowledge-assets/c/wm/finalize'))).toHaveLength(1);
+      await expect(knowledgeAssetPublishWithSeal('cg-1', 'c'))
+        .rejects.toMatchObject({ status: 409 });
+      expect(requestLog.filter(r => r.url.includes('/wm/finalize'))).toHaveLength(0);
       expect(requestLog.filter(r => r.method === 'POST' && r.url.includes('/vm/publish'))).toHaveLength(1);
     });
 

--- a/tests/fixtures/share-seal-warnings.json
+++ b/tests/fixtures/share-seal-warnings.json
@@ -1,6 +1,6 @@
 {
   "_comment": "#1116 — canonical share-outcome warning strings. The MCP, OpenClaw, and Hermes adapters each keep their own copy of these three constants (no shared module: MCP deliberately has no dkg-core dependency, and creating a package is out of scope). Each adapter's test suite asserts its constants are byte-identical to these values, so drift is caught by a test, not a code comment. If you change a warning, update it HERE and in all three adapters; the parity tests will flag any mismatch.",
-  "SHARE_NOT_PUBLISH_READY_WARNING": "Shared to SWM but NOT publish-ready (sealed:false). Legacy unsealed SWM content is read-only; recreate or pull the asset into Working Memory, then use an atomic full share before publishing.",
+  "SHARE_NOT_PUBLISH_READY_WARNING": "Shared to SWM but NOT publish-ready (sealed:false). Legacy unsealed SWM content is read-only; use the preserved Working Memory draft if available, or recreate the knowledge asset, then use an atomic full share before publishing.",
   "SHARE_SUBSET_NOT_PUBLISH_READY_WARNING": "Shared a SUBSET to SWM for peer visibility. A subset is NOT sealable/publishable. Legacy SWM finalize is read-only. To publish on-chain, share the full asset atomically (entities:\"all\"), or model this subset as its own knowledge asset.",
   "SHARE_INCOMPLETE_PROMOTE_WARNING": "Sealed, but not all roots reached SWM (some roots may be owned by other agents) — not yet publishable; re-share the full asset so every sealed root is in SWM."
 }

--- a/tests/fixtures/share-seal-warnings.json
+++ b/tests/fixtures/share-seal-warnings.json
@@ -1,6 +1,6 @@
 {
   "_comment": "#1116 — canonical share-outcome warning strings. The MCP, OpenClaw, and Hermes adapters each keep their own copy of these three constants (no shared module: MCP deliberately has no dkg-core dependency, and creating a package is out of scope). Each adapter's test suite asserts its constants are byte-identical to these values, so drift is caught by a test, not a code comment. If you change a warning, update it HERE and in all three adapters; the parity tests will flag any mismatch.",
-  "SHARE_NOT_PUBLISH_READY_WARNING": "Shared to SWM but NOT publish-ready (sealed:false). Seal it with dkg_knowledge_asset_finalize (layer:swm works after sharing), then publish.",
-  "SHARE_SUBSET_NOT_PUBLISH_READY_WARNING": "Shared a SUBSET to SWM for peer visibility. A subset is NOT sealable/publishable (finalize layer:swm will reject it). To publish on-chain, share the full asset (entities:\"all\"), or model this subset as its own knowledge asset.",
+  "SHARE_NOT_PUBLISH_READY_WARNING": "Shared to SWM but NOT publish-ready (sealed:false). Legacy unsealed SWM content is read-only; recreate or pull the asset into Working Memory, then use an atomic full share before publishing.",
+  "SHARE_SUBSET_NOT_PUBLISH_READY_WARNING": "Shared a SUBSET to SWM for peer visibility. A subset is NOT sealable/publishable. Legacy SWM finalize is read-only. To publish on-chain, share the full asset atomically (entities:\"all\"), or model this subset as its own knowledge asset.",
   "SHARE_INCOMPLETE_PROMOTE_WARNING": "Sealed, but not all roots reached SWM (some roots may be owned by other agents) — not yet publishable; re-share the full asset so every sealed root is in SWM."
 }


### PR DESCRIPTION
## Summary

Retires the remaining write-side `finalize(layer:"swm")` bridge. New graph-scoped KAs are finalized in WM and shared atomically; existing root-scoped SWM assets remain readable, but older callers now receive stable `LEGACY_KA_READ_ONLY` before any transient-WM reconstruction, root-closure relocation, resealing, pointer update, or engine invocation. The CLI no longer exposes `--layer` on `ka finalize`; `ka pull-from --layer swm|vm` remains unchanged for the supported exact-graph edit loop.

## Stack

- Base: #1725 (`feat/rootless-ka-cli-atomic`)
- This is the fourth focused review unit in the rootless-KA stack.

## Validation

- Agent lifecycle + multi-agent isolation: 58 passed, 1 skipped, 0 failed
- CLI/daemon/API focused suites: 129 passed, 0 failed
- `pnpm --filter @origintrail-official/dkg-agent build`
- `pnpm --filter @origintrail-official/dkg build`

## Compatibility

The deprecated direct-agent/API `layer:"swm"` input remains recognizable so mixed-version callers fail deterministically with `LEGACY_KA_READ_ONLY`; it no longer performs a mutation. Legacy reads and normal SWM/VM pull-from remain supported.