### PR TITLE
refactor(adapters): enforce atomic KA sharing

### DIFF
--- a/packages/adapter-hermes/hermes-plugin/__init__.py
+++ b/packages/adapter-hermes/hermes-plugin/__init__.py
@@ -597,14 +597,10 @@ DKG_ASSERTION_FINALIZE_SCHEMA = {
     "name": "dkg_knowledge_asset_finalize",
     "description": (
         "Step 3 of the canonical flow. Seal a knowledge asset's Working Memory draft -- computes "
-        "the merkle root and signs the EIP-712 AuthorAttestation node-side. Finalize always seals "
-        "the WHOLE draft (there is no subset parameter). A FULL share "
-        "(dkg_knowledge_asset_share with entities omitted or \"all\") auto-seals for you, so you "
-        "only need to call this explicitly before sharing a SELECTIVE subset of entities, or to "
-        "re-seal after editing a previously-sealed draft. Sealing works even if the context graph "
-        "is NOT yet registered on-chain (registration happens at publish). Pass layer=\"swm\" to "
-        "seal an asset already shared to SWM (e.g. shared with skip_seal) -- it recovers and seals "
-        "the SWM content without a delete-and-recreate. Author signing is node-side via "
+        "the merkle root and signs the EIP-712 AuthorAttestation node-side. Finalize seals the "
+        "complete WM draft. The share step also seals automatically; call finalize explicitly for "
+        "custom authorship options or after editing. Sealing works before on-chain registration. "
+        "Existing root-scoped SWM assets are read-only. Author signing is node-side via "
         "author_agent_address; external-signer (pre-signed) attestation is a tracked follow-up, "
         "not exposed by the agent tools."
     ),
@@ -621,15 +617,6 @@ DKG_ASSERTION_FINALIZE_SCHEMA = {
                 ),
             },
             "scheme_version": {"type": "integer", "minimum": 1, "description": "Optional attestation scheme version."},
-            "layer": {
-                "type": "string",
-                "enum": ["wm", "swm"],
-                "description": (
-                    "Which layer holds the content to seal. Default \"wm\" seals the open Working "
-                    "Memory draft. Pass \"swm\" to seal an asset already shared to SWM (recovers + "
-                    "seals the SWM content without delete-and-recreate)."
-                ),
-            },
             "sub_graph_name": {"type": "string", "description": "Optional sub-graph name (must match write time)."},
         },
         "required": ["context_graph_id", "name"],
@@ -670,45 +657,19 @@ DKG_ASSERTION_SHARE_SCHEMA = {
     "name": "dkg_knowledge_asset_share",
     "description": (
         "Step 4 of the canonical flow (create -> write -> finalize -> share -> publish). "
-        "Share a knowledge asset (or selected root entities) from Working Memory into Shared "
-        "Working Memory. A FULL share (omit `entities` or pass \"all\") SEALS BY DEFAULT and is "
-        "then publish-ready -- follow with dkg_knowledge_asset_publish to mint it on-chain "
-        "(Verifiable Memory). Pass skip_seal=true to share WITHOUT sealing (an unsealed SWM share "
-        "-- seal it later with dkg_knowledge_asset_finalize, where layer=\"swm\" works after "
-        "sharing). If a default (sealing) share cannot seal it fails CLOSED (409, Working Memory "
+        "Atomically seal and share the complete Knowledge Asset triple set from Working Memory "
+        "into Shared Working Memory. Root-entity subsets and unsealed shares are unsupported. "
+        "A successful share is publish-ready; follow with dkg_knowledge_asset_publish. If sealing "
+        "or complete transfer fails, the operation fails CLOSED (Working Memory "
         "preserved) and returns a recovery hint. For CUSTOM finalize options "
         "such as author_agent_address / scheme_version, call dkg_knowledge_asset_finalize "
-        "EXPLICITLY first (the default seal cannot carry them). A SELECTIVE subset "
-        "(`entities` set to a proper subset) shares to SWM ONLY for peer visibility, is NOT "
-        "sealed, and is NOT publishable to Verifiable Memory: dkg_knowledge_asset_publish "
-        "reconstructs the seal's full root set and rejects a truncated SWM with a merkleRoot "
-        "mismatch. To publish on-chain, share the full asset (or model the subset as its own "
-        "knowledge asset)."
+        "EXPLICITLY first (the default seal cannot carry them)."
     ),
     "parameters": {
         "type": "object",
         "properties": {
             "context_graph_id": {"type": "string", "description": TARGET_CONTEXT_GRAPH_DESCRIPTION},
             "name": {"type": "string", "description": "Knowledge asset name to share."},
-            "entities": {
-                "anyOf": [
-                    {"type": "string", "enum": ["all"]},
-                    {"type": "array", "items": {"type": "string"}},
-                ],
-                "description": (
-                    "Optional: \"all\" (or omitted) shares every root entity (default, seals by "
-                    "default + publish-ready); a non-empty array of root entity URIs shares only "
-                    "that subset to SWM (NOT sealed, NOT publishable to Verifiable Memory)."
-                ),
-            },
-            "skip_seal": {
-                "type": "boolean",
-                "description": (
-                    "Set true to share to SWM WITHOUT sealing (not publish-ready). Default (false) "
-                    "seals a full share so it is immediately publish-ready. Ignored for a subset "
-                    "share, which is never sealed."
-                ),
-            },
             "sub_graph_name": {"type": "string", "description": "Optional sub-graph name."},
         },
         "required": ["context_graph_id", "name"],
@@ -798,7 +759,7 @@ DKG_ASSERTION_QUERY_SCHEMA = {
     "name": "dkg_knowledge_asset_query",
     "description": (
         "Dump every quad from one knowledge asset's WORKING MEMORY DRAFT. Reads the WM draft "
-        "ONLY: a FULL share (dkg_knowledge_asset_share with entities omitted or \"all\") empties "
+        "ONLY: an atomic dkg_knowledge_asset_share empties "
         "the WM draft, so a query AFTER sharing returns 0 quads. Query the draft BEFORE sharing "
         "(e.g. to inspect deterministic import quads before semantic enrichment); to inspect "
         "shared content after a share, use dkg_query with view \"shared-working-memory\". "
@@ -1179,7 +1140,7 @@ class DKGMemoryProvider(MemoryProvider):
             "  dkg_knowledge_asset_import_artifact_resolve - Optional metadata re-check for imported attachments\n"
             "\n"
             "COLLABORATION WORKFLOW:\n"
-            "  dkg_knowledge_asset_share — Share a named knowledge asset's entities to Shared Working Memory (team-visible, free; full share seals by default)\n"
+            "  dkg_knowledge_asset_share — Atomically seal and share a complete named Knowledge Asset to Shared Working Memory (team-visible, free)\n"
             f"{publish_guidance}"
             "  dkg_wallet_balances — Check TRAC balance BEFORE publishing\n"
             "\n"
@@ -1984,39 +1945,19 @@ class DKGMemoryProvider(MemoryProvider):
             return tool_error("context_graph_id is required.")
         if not name:
             return tool_error("name is required.")
-        # entities accepts "all" | string[] | omitted (CONTRACT §B). "all" and
-        # omitted are both a full share; pass either straight through. Reject an
-        # empty array fast (the daemon would 400 it as empty SWM selection) and
-        # do NOT coerce "all" -> [] or omitted -> "all".
         entities = args.get("entities")
-        if entities is not None:
-            if isinstance(entities, str):
-                if entities.strip() != "all":
-                    return tool_error('entities must be "all", a non-empty array of strings, or omitted.')
-                entities = "all"
-            elif isinstance(entities, list):
-                if not entities or not all(isinstance(e, str) and e.strip() for e in entities):
-                    return tool_error('entities must be "all", a non-empty array of strings, or omitted.')
-                # Normalize to the stripped values (Codex #1079:2157) — the
-                # validation strips each entity but the UNSTRIPPED list was being
-                # forwarded, so " urn:a " reached the daemon with surrounding
-                # whitespace and resolved to the wrong / no root entity.
-                entities = [str(e).strip() for e in entities]
-            else:
-                return tool_error('entities must be "all", a non-empty array of strings, or omitted.')
-        # #1116: a full share SEALS BY DEFAULT; skip_seal=true shares unsealed.
-        # Present-but-invalid is a tool error, never a silent default.
+        if isinstance(entities, list):
+            return tool_error("Knowledge Assets are shared atomically; root-entity selection is not supported.")
+        if entities is not None and entities != "all":
+            return tool_error("entities is retired; omit it to share the complete Knowledge Asset.")
         skip_seal = args.get("skip_seal")
-        if skip_seal is not None and not isinstance(skip_seal, bool):
-            return tool_error("skip_seal must be a boolean.")
+        if skip_seal is True:
+            return tool_error("Knowledge Assets are always sealed before sharing.")
+        if skip_seal is not None and skip_seal is not False:
+            return tool_error("skip_seal must be a boolean when supplied.")
         result = self._client.promote_assertion(
-            name, cg, entities, _first_text(args, "sub_graph_name"), skip_seal=skip_seal)
-        # #1116: surface the seal outcome. A 409 UNSEALED_SHARE_BLOCKED (default
-        # seal failed, WM preserved) is returned by the client as the parsed body
-        # dict — surface its recovery hint; otherwise add the publishReady:false
-        # warning when the share is not publish-ready. Pass the parsed `entities`
-        # so the warning branches subset (not sealable) vs full skip_seal (sealable).
-        return json.dumps(_annotate_share_seal(result, entities))
+            name, cg, None, _first_text(args, "sub_graph_name"), skip_seal=None)
+        return json.dumps(_annotate_share_seal(result, None))
 
     def _handle_assertion_finalize(self, args: Dict[str, Any]) -> str:
         if self._offline:
@@ -2031,26 +1972,18 @@ class DKGMemoryProvider(MemoryProvider):
             return tool_error(error)
         author = _first_text(args, "author_agent_address")
         author = _normalize_wm_agent_address(author) if author else None
-        # #1116: optional `layer` selects WHERE the content to seal lives. Default
-        # (omitted/null) seals the open WM draft; "swm" seals an asset already
-        # shared to SWM. Validate args.get("layer") DIRECTLY (NOT via _first_text,
-        # which coerces any non-string to "" → an absent/omitted layer): a PRESENT
-        # non-string (True / a list / a number) or a string outside {wm,swm} is a
-        # tool error, never a silent fall-through to the default WM seal.
         layer_raw = args.get("layer")
-        if layer_raw is None:
-            layer = None
-        elif layer_raw in ("wm", "swm"):
-            layer = layer_raw
-        else:
-            return tool_error('layer must be "wm" or "swm".')
+        if layer_raw == "swm":
+            return tool_error("Legacy root-scoped Knowledge Assets are read-only.")
+        if layer_raw is not None and layer_raw != "wm":
+            return tool_error("Only Working Memory finalization is supported.")
         return json.dumps(self._client.finalize_assertion(
             name,
             cg,
             sub_graph_name=_first_text(args, "sub_graph_name"),
             author_agent_address=author,
             scheme_version=scheme_version,
-            layer=layer,
+            layer="wm" if layer_raw == "wm" else None,
         ))
 
     def _handle_assertion_publish(self, args: Dict[str, Any]) -> str:
@@ -2822,36 +2755,28 @@ def _validate_decimal_string_arg(value: Any, label: str) -> Tuple[Optional[str],
     return None, f"{label} must be a non-negative integer (decimal string)."
 
 
-# #1116: the publishReady:false warning surfaced after a FULL share that opted
-# out of sealing (skip_seal=true) — a later finalize(layer:swm) DOES seal it.
-# Kept byte-identical across the MCP, OpenClaw, and Hermes adapters
+# Defensive mixed-version warning for a non-ready atomic share. Kept
+# byte-identical across the MCP, OpenClaw, and Hermes adapters
 # (cross-adapter parity invariant).
 SHARE_NOT_PUBLISH_READY_WARNING = (
-    "Shared to SWM but NOT publish-ready (sealed:false). Seal it with "
-    "dkg_knowledge_asset_finalize (layer:swm works after sharing), then publish."
+    "The atomic SWM share did not become publish-ready (sealed:false). Keep the "
+    "Working Memory draft and retry the complete Knowledge Asset share; do not publish it."
 )
 
-# #1116: a SUBSET share is publishReady:false too, but unlike a skip_seal full
-# share it is NOT sealable — finalize(layer:swm) now REJECTS it with
-# SWM_SUBSET_NOT_SEALABLE. Surface the real recovery (full share / new asset)
-# instead of the dead-end "seal it" advice. Byte-identical across all three
+# Defensive mixed-version classification for a legacy partial-share outcome.
+# Byte-identical across all three
 # adapters (cross-adapter parity invariant).
 SHARE_SUBSET_NOT_PUBLISH_READY_WARNING = (
-    "Shared a SUBSET to SWM for peer visibility. A subset is NOT sealable/"
-    "publishable (finalize layer:swm will reject it). To publish on-chain, share "
-    "the full asset (entities:\"all\"), or model this subset as its own knowledge asset."
+    "A legacy partial-share outcome was reported. Root-scoped subsets are read-only "
+    "and not publishable; model the intended data as its own Knowledge Asset and share it atomically."
 )
 
-# #1116: a FULL share can come back sealed:true but publishReady:false when NOT
-# every sealed root reached SWM (promotedAllRoots false — e.g. foreign-owned roots
-# were skipped). The engine did NOT set the swmShareComplete marker, so
-# finalize(layer:swm) would REJECT — do NOT recommend it here. Re-sharing the full
-# asset is the recovery. Byte-identical across all three adapters (cross-adapter
+# A sealed atomic share can still report incomplete delivery; retry from WM.
+# Byte-identical across all three adapters (cross-adapter
 # parity invariant).
 SHARE_INCOMPLETE_PROMOTE_WARNING = (
-    "Sealed, but not all roots reached SWM (some roots may be owned by other "
-    "agents) — not yet publishable; re-share the full asset so every sealed root "
-    "is in SWM."
+    "The complete sealed Knowledge Asset did not reach SWM and is not publish-ready; "
+    "keep the Working Memory draft and retry the atomic share."
 )
 
 
@@ -2887,18 +2812,10 @@ def _annotate_share_seal(result: Any, entities: Any = None) -> Any:
 
     On a default (sealing) share the daemon returns
     ``{ swmShared, promotedCount, sealed, publishReady }``. When ``publishReady``
-    is false, add a parity warning that branches on the ACTUAL outcome (three
-    cases):
-
-      1. ``sealed:false`` + SUBSET (a non-empty specific list) → NOT sealable
-         (``finalize layer:swm`` rejects it with ``SWM_SUBSET_NOT_SEALABLE``);
-         recover via a full share or a new asset.
-      2. ``sealed:false`` + FULL ("all"/omitted ``skip_seal``) → sealable later
-         (``finalize layer:swm`` works — the marker is set).
-      3. ``sealed:true`` + ``publishReady:false`` → an incomplete full promote
-         (not every sealed root reached SWM, e.g. foreign-owned roots skipped). The
-         ``swmShareComplete`` marker is NOT set, so ``finalize layer:swm`` would
-         REJECT — re-share the full asset instead.
+    is false, add a parity warning that branches on the ACTUAL outcome: an
+    incomplete sealed atomic delivery, a defensive legacy-subset response, or
+    an unsealed atomic response. None of these is repaired by mutating SWM;
+    callers retry the complete share from Working Memory.
 
     A default share that CANNOT seal fails CLOSED: the daemon returns 409
     ``UNSEALED_SHARE_BLOCKED`` with a ``recovery`` hint and Working Memory

--- a/packages/adapter-hermes/hermes-plugin/__init__.py
+++ b/packages/adapter-hermes/hermes-plugin/__init__.py
@@ -2779,6 +2779,11 @@ SHARE_INCOMPLETE_PROMOTE_WARNING = (
     "keep the Working Memory draft and retry the atomic share."
 )
 
+ATOMIC_SHARE_SIGNING_RECOVERY = (
+    "Resolve the local signing capability, then retry the complete atomic "
+    "Knowledge Asset share from Working Memory."
+)
+
 
 def _create_swm_share_error(result: Any, also_share_swm: bool) -> Optional[str]:
     """Return the share-failure tail when a create one-shot's opt-in SWM share failed.
@@ -2819,17 +2824,14 @@ def _annotate_share_seal(result: Any, entities: Any = None) -> Any:
 
     A default share that CANNOT seal fails CLOSED: the daemon returns 409
     ``UNSEALED_SHARE_BLOCKED`` with a ``recovery`` hint and Working Memory
-    preserved; ``client._post`` surfaces that body as a dict, so re-raise the
-    recovery text as the tool error (parity with MCP/OpenClaw, which return only
-    the recovery string). Anything else passes through untouched.
+    preserved; older daemons may recommend retired skip-seal/SWM-write modes,
+    so replace that hint with the supported atomic recovery. Anything else
+    passes through untouched.
     """
     if not isinstance(result, dict):
         return result
     if result.get("code") == "UNSEALED_SHARE_BLOCKED":
-        recovery = result.get("recovery")
-        if isinstance(recovery, str) and recovery:
-            return {"error": recovery}
-        return result
+        return {"error": ATOMIC_SHARE_SIGNING_RECOVERY}
     if result.get("publishReady") is False:
         if result.get("sealed") is True:
             warning = SHARE_INCOMPLETE_PROMOTE_WARNING

--- a/packages/adapter-hermes/hermes-plugin/client.py
+++ b/packages/adapter-hermes/hermes-plugin/client.py
@@ -576,8 +576,6 @@ class DKGClient:
             payload["authorAgentAddress"] = author_agent_address
         if scheme_version is not None:
             payload["schemeVersion"] = scheme_version
-        if layer == "wm":
-            payload["layer"] = layer
         return self._post(f"/api/knowledge-assets/{quote(assertion_name, safe='')}/wm/finalize", payload)
 
     def publish_finalized_assertion(self, assertion_name: str, context_graph_id: str,

--- a/packages/adapter-hermes/hermes-plugin/client.py
+++ b/packages/adapter-hermes/hermes-plugin/client.py
@@ -533,20 +533,20 @@ class DKGClient:
                           entities: Optional[Any] = None,
                           sub_graph_name: Optional[str] = None,
                           skip_seal: Optional[bool] = None) -> Dict[str, Any]:
-        """POST /api/knowledge-assets/{name}/swm/share — promote assertion to SWM.
-
-        A full share SEALS BY DEFAULT (publish-ready). ``skip_seal=True`` opts
-        out into an unsealed SWM share (camelCase ``skipSeal`` on the wire).
-        """
+        """Atomically seal and share a complete Knowledge Asset to SWM."""
+        if isinstance(entities, list):
+            raise ValueError("Knowledge Assets are shared atomically; root-entity selection is not supported")
+        if entities is not None and entities != "all":
+            raise ValueError("Knowledge Assets are shared atomically; omit entities to share the complete asset")
+        if skip_seal is True:
+            raise ValueError("Knowledge Assets are always sealed before sharing")
+        if skip_seal is not None and skip_seal is not False:
+            raise TypeError("skip_seal must be false or omitted")
         payload: Dict[str, Any] = {
             "contextGraphId": _normalize_context_graph_id(context_graph_id),
         }
-        if entities is not None:
-            payload["entities"] = entities
         if sub_graph_name:
             payload["subGraphName"] = sub_graph_name
-        if skip_seal is not None:
-            payload["skipSeal"] = skip_seal
         return self._post(f"/api/knowledge-assets/{quote(assertion_name, safe='')}/swm/share", payload)
 
     def finalize_assertion(self, assertion_name: str, context_graph_id: str,
@@ -562,10 +562,13 @@ class DKGClient:
         omit it to let the daemon default the author to the request token's
         agent. The pre-signed attestation path is intentionally NOT exposed —
         Hermes relies on node-side signing, exactly like OpenClaw/MCP (no
-        client-side EIP-712, no raw preSignedAuthorAttestation). ``layer``
-        selects WHERE the content to seal lives: "wm" (default) seals the open
-        WM draft; "swm" seals an asset already shared to SWM.
+        client-side EIP-712, no raw preSignedAuthorAttestation). Existing
+        root-scoped SWM assets are read-only.
         """
+        if layer == "swm":
+            raise ValueError("Legacy root-scoped Knowledge Assets are read-only")
+        if layer is not None and layer != "wm":
+            raise ValueError("Only Working Memory finalization is supported")
         payload: Dict[str, Any] = {"contextGraphId": _normalize_context_graph_id(context_graph_id)}
         if sub_graph_name:
             payload["subGraphName"] = sub_graph_name
@@ -573,7 +576,7 @@ class DKGClient:
             payload["authorAgentAddress"] = author_agent_address
         if scheme_version is not None:
             payload["schemeVersion"] = scheme_version
-        if layer is not None:
+        if layer == "wm":
             payload["layer"] = layer
         return self._post(f"/api/knowledge-assets/{quote(assertion_name, safe='')}/wm/finalize", payload)
 

--- a/packages/adapter-hermes/pytests/test_lifecycle_client_methods.py
+++ b/packages/adapter-hermes/pytests/test_lifecycle_client_methods.py
@@ -66,6 +66,13 @@ def test_finalize_omits_layer_when_none(recording_client):
     assert "layer" not in body
 
 
+def test_finalize_accepts_wm_but_omits_layer_from_wire(recording_client):
+    client = recording_client
+    client.finalize_assertion("k", "cg1", layer="wm")
+    _, body = client.posts[-1]
+    assert body == {"contextGraphId": "cg1"}
+
+
 def test_finalize_rejects_non_wm_layer_before_http(recording_client):
     client = recording_client
     before = len(client.posts)

--- a/packages/adapter-hermes/pytests/test_lifecycle_client_methods.py
+++ b/packages/adapter-hermes/pytests/test_lifecycle_client_methods.py
@@ -7,6 +7,8 @@ daemon — only the request body / path the client builds is asserted.
 
 from __future__ import annotations
 
+import pytest
+
 
 # -- finalize_assertion -----------------------------------------------------
 
@@ -49,14 +51,12 @@ def test_finalize_url_encodes_name(recording_client):
     assert path == "/api/knowledge-assets/a%20b/wm/finalize"
 
 
-def test_finalize_puts_layer_swm_in_body(recording_client):
-    # #1116 — the `layer` field must reach the wire (the FakeClient handler tests
-    # only prove the tool→client arg pass-through; this pins the actual POST body).
+def test_finalize_rejects_layer_swm_before_http(recording_client):
     client = recording_client
-    client.finalize_assertion("k", "cg1", layer="swm")
-    path, body = client.posts[-1]
-    assert path == "/api/knowledge-assets/k/wm/finalize"
-    assert body == {"contextGraphId": "cg1", "layer": "swm"}
+    before = len(client.posts)
+    with pytest.raises(ValueError, match="read-only"):
+        client.finalize_assertion("k", "cg1", layer="swm")
+    assert len(client.posts) == before
 
 
 def test_finalize_omits_layer_when_none(recording_client):
@@ -66,15 +66,22 @@ def test_finalize_omits_layer_when_none(recording_client):
     assert "layer" not in body
 
 
+def test_finalize_rejects_non_wm_layer_before_http(recording_client):
+    client = recording_client
+    before = len(client.posts)
+    with pytest.raises(ValueError, match="Working Memory"):
+        client.finalize_assertion("k", "cg1", layer="vm")
+    assert len(client.posts) == before
+
+
 # -- promote_assertion (swm/share) ------------------------------------------
 
-def test_promote_puts_skip_seal_in_body(recording_client):
-    # #1116 — `skip_seal=True` must reach the wire as camelCase `skipSeal:true`.
+def test_promote_rejects_skip_seal_before_http(recording_client):
     client = recording_client
-    client.promote_assertion("k", "cg1", None, skip_seal=True)
-    path, body = client.posts[-1]
-    assert path == "/api/knowledge-assets/k/swm/share"
-    assert body == {"contextGraphId": "cg1", "skipSeal": True}
+    before = len(client.posts)
+    with pytest.raises(ValueError, match="always sealed"):
+        client.promote_assertion("k", "cg1", None, skip_seal=True)
+    assert len(client.posts) == before
 
 
 def test_promote_omits_skip_seal_when_none(recording_client):
@@ -86,11 +93,29 @@ def test_promote_omits_skip_seal_when_none(recording_client):
     assert "entities" not in body
 
 
-def test_promote_forwards_entities_and_skip_seal_together(recording_client):
+def test_promote_accepts_legacy_all_but_serializes_no_scope_fields(recording_client):
     client = recording_client
     client.promote_assertion("k", "cg1", "all", skip_seal=False)
     _, body = client.posts[-1]
-    assert body == {"contextGraphId": "cg1", "entities": "all", "skipSeal": False}
+    assert body == {"contextGraphId": "cg1"}
+
+
+def test_promote_rejects_root_selection_before_http(recording_client):
+    client = recording_client
+    before = len(client.posts)
+    with pytest.raises(ValueError, match="shared atomically"):
+        client.promote_assertion("k", "cg1", ["urn:a"])
+    assert len(client.posts) == before
+
+
+def test_promote_rejects_malformed_legacy_values_before_http(recording_client):
+    client = recording_client
+    before = len(client.posts)
+    with pytest.raises(ValueError, match="shared atomically"):
+        client.promote_assertion("k", "cg1", "urn:not-all")
+    with pytest.raises(TypeError, match="false or omitted"):
+        client.promote_assertion("k", "cg1", None, skip_seal="yes")
+    assert len(client.posts) == before
 
 
 # -- publish_finalized_assertion --------------------------------------------

--- a/packages/adapter-hermes/pytests/test_lifecycle_tool_handlers.py
+++ b/packages/adapter-hermes/pytests/test_lifecycle_tool_handlers.py
@@ -135,29 +135,23 @@ def test_prompt_advertises_publish_only_when_allowed(provider):
     }
 
 
-def test_share_description_carries_subset_language(provider):
+def test_share_description_carries_atomic_scope(provider):
     share = next(s for s in provider.get_tool_schemas()
                  if s["name"] == "dkg_knowledge_asset_share")
-    assert "NOT publishable to Verifiable Memory" in share["description"]
+    assert "Atomically seal and share the complete Knowledge Asset triple set" in share["description"]
+    assert "Root-entity subsets and unsealed shares are unsupported" in share["description"]
 
 
-def test_share_description_softens_publish_ready_and_notes_finalize(provider):
-    # #1116 — a full share now SEALS BY DEFAULT (publish-ready). skip_seal=true
-    # opts out into an unsealed SWM share; a default share that cannot seal fails
-    # CLOSED (409, WM preserved) with a recovery hint. Finalize stays the explicit
-    # path for custom options and for sealing an already-shared asset (layer:swm).
+def test_share_description_exposes_only_atomic_publish_ready_flow(provider):
     share = next(s for s in provider.get_tool_schemas()
                  if s["name"] == "dkg_knowledge_asset_share")
     desc = share["description"]
-    assert "SEALS BY DEFAULT" in desc
-    assert "skip_seal=true" in desc
-    assert "WITHOUT sealing" in desc
-    assert "fails CLOSED" in desc and "409" in desc
+    assert "successful share is publish-ready" in desc
+    assert "fails CLOSED" in desc
     assert "dkg_knowledge_asset_finalize EXPLICITLY first" in desc
-    # layer:swm note for sealing after sharing
-    assert "layer=\"swm\" works after" in desc
-    # custom finalize options note is preserved
     assert "author_agent_address" in desc and "scheme_version" in desc
+    assert "skip_seal" not in desc
+    assert "layer=\"swm\"" not in desc
 
 
 def test_publish_description_ual_middle_segment_is_contract_not_author(provider):
@@ -176,30 +170,32 @@ def test_publish_description_ual_middle_segment_is_contract_not_author(provider)
     assert "authorAddress" in desc and "seal author" in desc
 
 
-# -- B: entities accepts "all" | string[] | omitted -------------------------
+# -- Atomic KA scope ---------------------------------------------------------
 
 def test_share_entities_all_passes_through(provider):
     provider.handle_tool_call("dkg_knowledge_asset_share", {
         "context_graph_id": "cg1", "name": "ka", "entities": "all",
     })
-    assert provider._client.calls[-1][3] == "all"
+    assert provider._client.calls[-1][3] is None
 
 
-def test_share_entities_array_passes_through(provider):
-    provider.handle_tool_call("dkg_knowledge_asset_share", {
+def test_share_entities_array_is_rejected(provider):
+    before = len(provider._client.calls)
+    out = json.loads(provider.handle_tool_call("dkg_knowledge_asset_share", {
         "context_graph_id": "cg1", "name": "ka", "entities": ["urn:a", "urn:b"],
-    })
-    assert provider._client.calls[-1][3] == ["urn:a", "urn:b"]
+    }))
+    assert "shared atomically" in out["error"]
+    assert len(provider._client.calls) == before
 
 
-def test_share_entities_array_is_stripped_before_promote(provider):
-    # FIX K (#1079:2157): each entity is validated with .strip() but the
-    # UNSTRIPPED list was forwarded — " urn:a " must reach the daemon stripped.
-    provider.handle_tool_call("dkg_knowledge_asset_share", {
+def test_share_entities_array_never_widens_to_complete_share(provider):
+    before = len(provider._client.calls)
+    out = json.loads(provider.handle_tool_call("dkg_knowledge_asset_share", {
         "context_graph_id": "cg1", "name": "ka",
         "entities": [" urn:a ", "urn:b\t", "  urn:c"],
-    })
-    assert provider._client.calls[-1][3] == ["urn:a", "urn:b", "urn:c"]
+    }))
+    assert "shared atomically" in out["error"]
+    assert len(provider._client.calls) == before
 
 
 def test_share_entities_omitted_is_none_not_coerced(provider):
@@ -215,7 +211,7 @@ def test_share_entities_empty_array_rejected(provider):
     out = json.loads(provider.handle_tool_call("dkg_knowledge_asset_share", {
         "context_graph_id": "cg1", "name": "ka", "entities": [],
     }))
-    assert "error" in out and '"all"' in out["error"]
+    assert "shared atomically" in out["error"]
     assert len(provider._client.calls) == before  # never reached the wire
 
 
@@ -226,10 +222,11 @@ def test_share_entities_bad_string_rejected(provider):
     assert "error" in out
 
 
-def test_share_schema_entities_is_union(provider):
+def test_share_schema_omits_legacy_scope_fields(provider):
     share = next(s for s in provider.get_tool_schemas()
                  if s["name"] == "dkg_knowledge_asset_share")
-    assert "anyOf" in share["parameters"]["properties"]["entities"]
+    assert "entities" not in share["parameters"]["properties"]
+    assert "skip_seal" not in share["parameters"]["properties"]
 
 
 # -- E: no pre-signed reference; finalize follow-up note ---------------------
@@ -772,27 +769,21 @@ def test_create_name_description_aligns_to_validation(provider):
 
 # -- #1116 _annotate_share_seal helper (warning branch + recovery surfacing) ---
 
-def test_annotate_share_seal_full_skip_seal_warns_sealable(plugin_module):
-    # publishReady:false on a FULL share (entities None/"all") → the seal-it hint
-    # (finalize layer:swm DOES seal a skip_seal full share).
+def test_annotate_share_seal_non_ready_warns_atomic_retry(plugin_module):
     f = plugin_module._annotate_share_seal
     out = f({"swmShared": True, "publishReady": False}, None)
-    assert "NOT publish-ready (sealed:false)" in out["warning"]
-    assert "layer:swm works after sharing" in out["warning"]
-    assert "NOT sealable" not in out["warning"]
-    # "all" is also a full share → same sealable warning.
+    assert "did not become publish-ready (sealed:false)" in out["warning"]
+    assert "retry the complete Knowledge Asset share" in out["warning"]
     out_all = f({"swmShared": True, "publishReady": False}, "all")
-    assert "layer:swm works after sharing" in out_all["warning"]
+    assert "retry the complete Knowledge Asset share" in out_all["warning"]
 
 
 def test_annotate_share_seal_subset_warns_not_sealable(plugin_module):
-    # publishReady:false on a SUBSET (non-empty list) → the not-sealable recovery
-    # (finalize layer:swm REJECTS a subset with SWM_SUBSET_NOT_SEALABLE).
+    # Defensive handling for a mixed-version daemon that reports a legacy subset.
     f = plugin_module._annotate_share_seal
     out = f({"swmShared": True, "publishReady": False}, ["urn:a"])
-    assert "A subset is NOT sealable/publishable" in out["warning"]
-    assert 'entities:"all"' in out["warning"]
-    assert "Seal it with" not in out["warning"]
+    assert "legacy partial-share outcome" in out["warning"]
+    assert "share it atomically" in out["warning"]
 
 
 def test_create_swm_share_error_flags_207_share_failure(plugin_module):
@@ -829,11 +820,8 @@ def test_annotate_share_seal_incomplete_full_promote_warns_no_finalize(plugin_mo
     f = plugin_module._annotate_share_seal
     for ent in (None, "all", ["urn:a"]):
         out = f({"swmShared": True, "sealed": True, "publishReady": False}, ent)
-        assert "not all roots reached SWM" in out["warning"], ent
-        assert "re-share the full asset" in out["warning"], ent
-        # NOT the dead-end finalize layer:swm hint, NOT the subset hint.
-        assert "layer:swm works after sharing" not in out["warning"], ent
-        assert "NOT sealable" not in out["warning"], ent
+        assert "complete sealed Knowledge Asset did not reach SWM" in out["warning"], ent
+        assert "retry the atomic share" in out["warning"], ent
 
 
 def test_annotate_share_seal_blocked_surfaces_recovery(plugin_module):
@@ -861,35 +849,35 @@ def test_annotate_share_seal_publish_ready_and_non_dict_pass_through(plugin_modu
     assert f("x", None) == "x"
 
 
-# -- #1116 share handler: skip_seal validation + wire forwarding -----------
+# -- Atomic share handler boundary ------------------------------------------
 
 def test_share_handler_rejects_non_boolean_skip_seal(provider):
     before = len(provider._client.calls)
     out = json.loads(provider.handle_tool_call("dkg_knowledge_asset_share", {
         "context_graph_id": "cg1", "name": "ka", "skip_seal": "yes",
     }))
-    assert out["error"] == "skip_seal must be a boolean."
+    assert out["error"] == "skip_seal must be a boolean when supplied."
     # invalid value never reached the wire
     assert len(provider._client.calls) == before
 
 
-def test_share_handler_forwards_skip_seal_true_to_client(provider):
-    provider.handle_tool_call("dkg_knowledge_asset_share", {
+def test_share_handler_rejects_skip_seal_true(provider):
+    before = len(provider._client.calls)
+    out = json.loads(provider.handle_tool_call("dkg_knowledge_asset_share", {
         "context_graph_id": "cg1", "name": "ka", "skip_seal": True,
-    })
-    # promote_assertion records ("share", name, cg, entities, sub_graph_name, skip_seal)
-    assert provider._client.calls[-1][0] == "share"
-    assert provider._client.calls[-1][5] is True
+    }))
+    assert "always sealed" in out["error"]
+    assert len(provider._client.calls) == before
 
 
-# -- #1116 finalize handler: layer validation + wire forwarding ------------
+# -- WM-only finalize boundary ----------------------------------------------
 
 def test_finalize_handler_rejects_invalid_layer(provider):
     before = len(provider._client.calls)
     out = json.loads(provider.handle_tool_call("dkg_knowledge_asset_finalize", {
         "context_graph_id": "cg1", "name": "ka", "layer": "bogus",
     }))
-    assert out["error"] == 'layer must be "wm" or "swm".'
+    assert out["error"] == "Only Working Memory finalization is supported."
     assert len(provider._client.calls) == before
 
 
@@ -904,7 +892,7 @@ def test_finalize_handler_rejects_non_string_layer(provider, bad):
     out = json.loads(provider.handle_tool_call("dkg_knowledge_asset_finalize", {
         "context_graph_id": "cg1", "name": "ka", "layer": bad,
     }))
-    assert out["error"] == 'layer must be "wm" or "swm".', (bad, out)
+    assert out["error"] == "Only Working Memory finalization is supported.", (bad, out)
     assert len(provider._client.calls) == before, bad  # nothing on the wire
 
 
@@ -917,41 +905,36 @@ def test_finalize_handler_omitted_layer_defaults_to_none(provider):
     assert provider._client.calls[-1][6] is None
 
 
-def test_finalize_handler_forwards_layer_swm_to_client(provider):
-    provider.handle_tool_call("dkg_knowledge_asset_finalize", {
+def test_finalize_handler_rejects_layer_swm_read_only(provider):
+    before = len(provider._client.calls)
+    out = json.loads(provider.handle_tool_call("dkg_knowledge_asset_finalize", {
         "context_graph_id": "cg1", "name": "ka", "layer": "swm",
-    })
-    # finalize records ("finalize", name, cg, sub_graph_name, author, scheme_version, layer)
-    assert provider._client.calls[-1][0] == "finalize"
-    assert provider._client.calls[-1][6] == "swm"
+    }))
+    assert "read-only" in out["error"]
+    assert len(provider._client.calls) == before
 
 
 # -- #1116 share handler: publishReady:false warning end-to-end ------------
 
-def test_share_handler_full_skip_seal_warns_via_annotate(provider):
-    # A FULL skip_seal share whose daemon reply is publishReady:false surfaces the
-    # sealable warning through the handler (parity with the helper test).
+def test_share_handler_non_ready_warns_atomic_retry(provider):
     provider._client.promote_assertion = (  # type: ignore[assignment]
         lambda name, cg, entities, sub_graph_name=None, skip_seal=None: {
             "swmShared": True, "promotedCount": 2, "sealed": False, "publishReady": False,
         }
     )
     out = json.loads(provider.handle_tool_call("dkg_knowledge_asset_share", {
-        "context_graph_id": "cg1", "name": "ka", "skip_seal": True,
+        "context_graph_id": "cg1", "name": "ka",
     }))
-    assert "layer:swm works after sharing" in out["warning"]
+    assert "retry the complete Knowledge Asset share" in out["warning"]
 
 
-def test_share_handler_subset_warns_not_sealable_via_annotate(provider):
-    provider._client.promote_assertion = (  # type: ignore[assignment]
-        lambda name, cg, entities, sub_graph_name=None, skip_seal=None: {
-            "swmShared": True, "promotedCount": 1, "sealed": False, "publishReady": False,
-        }
-    )
+def test_share_handler_rejects_subset_without_widening(provider):
+    before = len(provider._client.calls)
     out = json.loads(provider.handle_tool_call("dkg_knowledge_asset_share", {
         "context_graph_id": "cg1", "name": "ka", "entities": ["urn:a"],
     }))
-    assert "A subset is NOT sealable/publishable" in out["warning"]
+    assert "shared atomically" in out["error"]
+    assert len(provider._client.calls) == before
 
 
 def test_share_handler_incomplete_full_promote_warns_via_annotate(provider):
@@ -965,6 +948,5 @@ def test_share_handler_incomplete_full_promote_warns_via_annotate(provider):
     out = json.loads(provider.handle_tool_call("dkg_knowledge_asset_share", {
         "context_graph_id": "cg1", "name": "ka",
     }))
-    assert "not all roots reached SWM" in out["warning"]
-    assert "re-share the full asset" in out["warning"]
-    assert "layer:swm works after sharing" not in out["warning"]
+    assert "complete sealed Knowledge Asset did not reach SWM" in out["warning"]
+    assert "retry the atomic share" in out["warning"]

--- a/packages/adapter-hermes/pytests/test_lifecycle_tool_handlers.py
+++ b/packages/adapter-hermes/pytests/test_lifecycle_tool_handlers.py
@@ -824,19 +824,19 @@ def test_annotate_share_seal_incomplete_full_promote_warns_no_finalize(plugin_mo
         assert "retry the atomic share" in out["warning"], ent
 
 
-def test_annotate_share_seal_blocked_surfaces_recovery(plugin_module):
-    # A 409 UNSEALED_SHARE_BLOCKED body (returned by the client as a dict) →
-    # surface the recovery verbatim as {error: recovery}.
+def test_annotate_share_seal_blocked_normalizes_legacy_recovery(plugin_module):
+    # Older daemons recommend retired skip-seal/SWM writes; replace that hint.
     f = plugin_module._annotate_share_seal
     out = f({"code": "UNSEALED_SHARE_BLOCKED", "recovery": "pass skip_seal=true"})
-    assert out == {"error": "pass skip_seal=true"}
+    assert "Resolve the local signing capability" in out["error"]
+    assert "atomic Knowledge Asset share" in out["error"]
+    assert "skip_seal" not in out["error"]
 
 
-def test_annotate_share_seal_blocked_without_recovery_passes_through(plugin_module):
-    # blocked but no recovery hint → pass the raw body through untouched.
+def test_annotate_share_seal_blocked_without_recovery_uses_atomic_guidance(plugin_module):
     f = plugin_module._annotate_share_seal
-    body = {"code": "UNSEALED_SHARE_BLOCKED"}
-    assert f(body) == body
+    out = f({"code": "UNSEALED_SHARE_BLOCKED"})
+    assert "atomic Knowledge Asset share" in out["error"]
 
 
 def test_annotate_share_seal_publish_ready_and_non_dict_pass_through(plugin_module):

--- a/packages/adapter-openclaw/src/DkgNodePlugin.ts
+++ b/packages/adapter-openclaw/src/DkgNodePlugin.ts
@@ -111,36 +111,27 @@ import { buildMemoryTools } from './tools/memory-tools.js';
 // canonical fixture at `tests/fixtures/share-seal-warnings.json`. Update the
 // fixture + all three adapters together; the parity tests flag any mismatch.
 
-// publishReady:false after a FULL share that opted out of sealing (skip_seal:true)
-// — a later finalize(layer:swm) DOES seal it.
+// Defensive mixed-version warning for a non-ready atomic share.
 export const SHARE_NOT_PUBLISH_READY_WARNING =
-  'Shared to SWM but NOT publish-ready (sealed:false). Seal it with ' +
-  'dkg_knowledge_asset_finalize (layer:swm works after sharing), then publish.';
+  'The atomic SWM share did not become publish-ready (sealed:false). Keep the ' +
+  'Working Memory draft and retry the complete Knowledge Asset share; do not publish it.';
 
-// A SUBSET share is publishReady:false too, but unlike a skip_seal full share it
-// is NOT sealable — finalize(layer:swm) now REJECTS it with SWM_SUBSET_NOT_SEALABLE.
-// Surface the real recovery (full share / new asset) instead of "seal it".
+// Defensive mixed-version classification for a legacy partial-share outcome.
 export const SHARE_SUBSET_NOT_PUBLISH_READY_WARNING =
-  'Shared a SUBSET to SWM for peer visibility. A subset is NOT sealable/' +
-  'publishable (finalize layer:swm will reject it). To publish on-chain, share ' +
-  'the full asset (entities:"all"), or model this subset as its own knowledge asset.';
+  'A legacy partial-share outcome was reported. Root-scoped subsets are read-only ' +
+  'and not publishable; model the intended data as its own Knowledge Asset and share it atomically.';
 
-// A FULL share can come back sealed:true but publishReady:false when NOT every
-// sealed root reached SWM (promotedAllRoots false — e.g. foreign-owned roots were
-// skipped). The engine did NOT set the swmShareComplete marker, so finalize(layer:
-// swm) would REJECT — do NOT recommend it here. Re-sharing the full asset recovers.
+// A sealed atomic share can still report incomplete delivery; retry from WM.
 export const SHARE_INCOMPLETE_PROMOTE_WARNING =
-  'Sealed, but not all roots reached SWM (some roots may be owned by other ' +
-  'agents) — not yet publishable; re-share the full asset so every sealed root ' +
-  'is in SWM.';
+  'The complete sealed Knowledge Asset did not reach SWM and is not publish-ready; ' +
+  'keep the Working Memory draft and retry the atomic share.';
 
 /**
  * #1116: pick the not-publish-ready share warning from the share outcome. Returns
  * `undefined` when the share IS publish-ready (no warning). Precedence:
- *  1. sealed:true + publishReady:false → incomplete full promote (marker NOT set;
- *     finalize layer:swm would reject) → re-share the full asset.
- *  2. sealed:false + SUBSET → not sealable.
- *  3. sealed:false + FULL (skip_seal) → sealable later (finalize layer:swm works).
+ *  1. sealed:true + publishReady:false → incomplete atomic delivery.
+ *  2. sealed:false + legacy subset response → legacy read-only warning.
+ *  3. sealed:false + atomic response → retry the complete share from WM.
  * Duplicated byte-identical on MCP (TS) + Hermes (Python).
  */
 export function classifyShareWarning(outcome: {
@@ -3593,6 +3584,12 @@ export class DkgNodePlugin {
       const name = String(args.name ?? '').trim();
       if (!contextGraphId) return this.error('"context_graph_id" is required.');
       if (!name) return this.error('"name" is required.');
+      if (args.layer === 'swm') {
+        return this.error('Legacy root-scoped Knowledge Assets are read-only.');
+      }
+      if (args.layer !== undefined && args.layer !== 'wm') {
+        return this.error('Only Working Memory finalization is supported.');
+      }
       const subGraphName = args.sub_graph_name ? String(args.sub_graph_name) : undefined;
       const authorAgentAddress = args.author_agent_address ? String(args.author_agent_address) : undefined;
       // CONTRACT §C: present-but-invalid is a tool error, never silent-default.
@@ -3605,20 +3602,6 @@ export class DkgNodePlugin {
         }
         schemeVersion = raw;
       }
-      // #1116: optional `layer` selects WHERE the content to seal lives. Default
-      // (omitted) seals the open WM draft; "swm" seals an asset already shared to
-      // SWM. Present-but-invalid is a tool error, never a silent default. Check
-      // `typeof === 'string'` BEFORE trimming/enum-checking — `String(args.layer)`
-      // would coerce a non-string like ['swm'] to "swm" and FORWARD it (parity
-      // with the Hermes direct-validation fix; not a String() coercion bypass).
-      let layer: 'wm' | 'swm' | undefined;
-      if (args.layer !== undefined) {
-        const raw = typeof args.layer === 'string' ? args.layer.trim() : args.layer;
-        if (raw !== 'wm' && raw !== 'swm') {
-          return this.error('"layer" must be "wm" or "swm".');
-        }
-        layer = raw;
-      }
       // Seal the WHOLE WM draft (CONTRACT §1 Stage3 — there is no subset scope on
       // finalize). The author defaults to the request token's agent when
       // `author_agent_address` is omitted; pre-signed attestations are not surfaced
@@ -3627,7 +3610,6 @@ export class DkgNodePlugin {
         subGraphName,
         authorAgentAddress,
         schemeVersion,
-        layer,
       });
       return this.json(result);
     } catch (err: any) {
@@ -3641,51 +3623,25 @@ export class DkgNodePlugin {
       const name = String(args.name ?? '').trim();
       if (!contextGraphId) return this.error('"context_graph_id" is required.');
       if (!name) return this.error('"name" is required.');
+      if (Array.isArray(args.entities)) {
+        return this.error('Knowledge Assets are shared atomically; root-entity selection is not supported.');
+      }
+      if (args.entities !== undefined && args.entities !== 'all') {
+        return this.error('"entities" is retired; omit it to share the complete Knowledge Asset.');
+      }
+      if (args.skip_seal === true) {
+        return this.error('Knowledge Assets are always sealed before sharing.');
+      }
+      if (args.skip_seal !== undefined && args.skip_seal !== false) {
+        return this.error('"skip_seal" must be a boolean when supplied.');
+      }
       const subGraphName = args.sub_graph_name ? String(args.sub_graph_name) : undefined;
-      // CONTRACT §B: `entities` accepts "all" | string[] | omitted. Omitted ⇒
-      // undefined (daemon defaults to a full share); the "all" string sentinel is
-      // passed through unchanged (the daemon reads parsed.entities and treats
-      // "all" as a full share). A non-empty string[] passes through as the subset.
-      // An empty array is rejected client-side (the daemon REST 400s "all"→[] /
-      // empty selections) — fail fast with a clear message, never coerce.
-      let entities: string[] | 'all' | undefined;
-      const raw = args.entities;
-      if (raw === undefined || raw === null) {
-        entities = undefined;
-      } else if (raw === 'all') {
-        entities = 'all';
-      } else if (Array.isArray(raw) && raw.length > 0 && raw.every((e) => typeof e === 'string')) {
-        // FIX K: trim each root-entity URI before forwarding — a whitespace-padded
-        // entity (" urn:a ") would otherwise reach the daemon with the spaces and
-        // resolve to the wrong (or no) root. Parity with Hermes.
-        entities = raw.map((e) => String(e).trim());
-      } else {
-        return this.error('"entities" must be omitted, the string "all", or a non-empty array of root entity URIs.');
-      }
-      // #1116: a full share SEALS BY DEFAULT; `skip_seal:true` shares unsealed.
-      // Present-but-invalid is a tool error, never a silent default.
-      let skipSeal: boolean | undefined;
-      if (args.skip_seal !== undefined) {
-        if (typeof args.skip_seal !== 'boolean') {
-          return this.error('"skip_seal" must be a boolean.');
-        }
-        skipSeal = args.skip_seal;
-      }
-      // WM → SWM. The KA `swm/share` route is the same engine call
-      // (`agent.assertion.promote`) the legacy promote used.
       const result = await this.client.knowledgeAssetShare(contextGraphId, name, {
-        entities,
         subGraphName,
-        skipSeal,
       });
-      // #1116: surface the seal outcome. `sealed`/`publishReady` flow through the
-      // JSON; ALSO add the explicit warning when the share is NOT publish-ready.
-      // classifyShareWarning picks the right of the three warnings from
-      // {sealed, publishReady, isSubset}. A subset is a non-empty specific array
-      // (an empty array was rejected above; "all"/undefined is a full share).
       const seal = result as { publishReady?: boolean; sealed?: boolean };
       const warning = result
-        ? classifyShareWarning({ sealed: seal.sealed, publishReady: seal.publishReady, isSubset: Array.isArray(entities) })
+        ? classifyShareWarning({ sealed: seal.sealed, publishReady: seal.publishReady, isSubset: false })
         : undefined;
       if (warning) {
         return this.json({ ...result, warning });

--- a/packages/adapter-openclaw/src/DkgNodePlugin.ts
+++ b/packages/adapter-openclaw/src/DkgNodePlugin.ts
@@ -126,6 +126,10 @@ export const SHARE_INCOMPLETE_PROMOTE_WARNING =
   'The complete sealed Knowledge Asset did not reach SWM and is not publish-ready; ' +
   'keep the Working Memory draft and retry the atomic share.';
 
+export const ATOMIC_SHARE_SIGNING_RECOVERY =
+  'Resolve the local signing capability, then retry the complete atomic ' +
+  'Knowledge Asset share from Working Memory.';
+
 /**
  * #1116: pick the not-publish-ready share warning from the share outcome. Returns
  * `undefined` when the share IS publish-ready (no warning). Precedence:
@@ -146,8 +150,8 @@ export function classifyShareWarning(outcome: {
 }
 
 /**
- * #1116: extract the daemon's recovery hint from a 409 UNSEALED_SHARE_BLOCKED
- * share failure. The DkgDaemonClient throws a typed {@link DkgDaemonHttpError}
+ * #1116: normalize a 409 UNSEALED_SHARE_BLOCKED share failure to the
+ * supported atomic recovery. The DkgDaemonClient throws a typed {@link DkgDaemonHttpError}
  * carrying the response `status` and parsed JSON `body`, so branch structurally
  * on the status + body code (no JSON-from-message parsing). Returns undefined
  * for any other error (caller falls back to the generic daemonError).
@@ -159,9 +163,9 @@ function extractUnsealedShareRecovery(err: unknown): string | undefined {
     typeof err.body === 'object' &&
     err.body !== null
   ) {
-    const body = err.body as { code?: string; recovery?: string };
-    if (body.code === 'UNSEALED_SHARE_BLOCKED' && typeof body.recovery === 'string' && body.recovery) {
-      return body.recovery;
+    const body = err.body as { code?: string };
+    if (body.code === 'UNSEALED_SHARE_BLOCKED') {
+      return ATOMIC_SHARE_SIGNING_RECOVERY;
     }
   }
   return undefined;
@@ -3650,8 +3654,8 @@ export class DkgNodePlugin {
     } catch (err: any) {
       // #1116: a default (sealing) share that cannot seal fails CLOSED — the
       // daemon returns 409 UNSEALED_SHARE_BLOCKED with a recovery hint and WM
-      // preserved. The client throws an Error whose message carries the response
-      // body; surface the recovery text verbatim when present.
+      // preserved. Normalize old-daemon hints that recommend retired
+      // skipSeal/SWM-write modes to the supported atomic recovery.
       const recovery = extractUnsealedShareRecovery(err);
       if (recovery) return this.error(recovery);
       return this.daemonError(err);

--- a/packages/adapter-openclaw/src/dkg-client.ts
+++ b/packages/adapter-openclaw/src/dkg-client.ts
@@ -561,19 +561,24 @@ export class DkgDaemonClient {
     });
   }
 
-  /**
-   * Promote a Working Memory assertion (or a subset of its root entities) to
-   * Shared Working Memory. `entities` defaults to `"all"` server-side when
-   * omitted; callers can pin specific root entity URIs via an array.
-   */
+  /** Atomically seal and share a complete Working Memory Knowledge Asset. */
   async promoteAssertion(
     contextGraphId: string,
     name: string,
-    opts?: { entities?: string[] | 'all'; subGraphName?: string },
+    opts?: { /** @deprecated Root selection is unsupported. */ entities?: string[] | 'all'; subGraphName?: string },
   ): Promise<Record<string, unknown>> {
+    if (Array.isArray(opts?.entities)) {
+      throw Object.assign(new Error('Knowledge Assets are shared atomically; root-entity selection is not supported'), {
+        code: 'KA_ATOMIC_SHARE_REQUIRED',
+      });
+    }
+    if (opts?.entities !== undefined && opts.entities !== 'all') {
+      throw Object.assign(new Error('Knowledge Assets are shared atomically; omit entities to share the complete asset'), {
+        code: 'KA_ATOMIC_SHARE_REQUIRED',
+      });
+    }
     return this.post(`/api/knowledge-assets/${encodeURIComponent(name)}/swm/share`, {
       contextGraphId: normalizeContextGraphId(contextGraphId),
-      entities: opts?.entities,
       subGraphName: opts?.subGraphName,
     });
   }
@@ -1225,12 +1230,19 @@ export class DkgDaemonClient {
       authorAgentAddress?: string;
       preSignedAuthorAttestation?: PreSignedAuthorAttestationPayload;
       schemeVersion?: number;
-      // #1116: "wm" (default) seals the open WM draft; "swm" seals an asset
-      // already shared to SWM (recover-without-recreate).
+      /** @deprecated Only WM finalization is supported. `swm` fails read-only. */
       layer?: 'wm' | 'swm';
     },
   ): Promise<{ merkleRoot: string; eip712Digest: string }> {
     assertExclusiveAuthorFields(opts ?? {});
+    if (opts?.layer === 'swm') {
+      throw Object.assign(new Error('Legacy root-scoped Knowledge Assets are read-only'), {
+        code: 'LEGACY_KA_READ_ONLY',
+      });
+    }
+    if (opts?.layer !== undefined && opts.layer !== 'wm') {
+      throw new TypeError('Only Working Memory finalization is supported');
+    }
     return this.post(`/api/knowledge-assets/${encodeURIComponent(name)}/wm/finalize`, {
       contextGraphId: normalizeContextGraphId(contextGraphId),
       ...(opts ?? {}),
@@ -1267,8 +1279,32 @@ export class DkgDaemonClient {
   async knowledgeAssetShare(
     contextGraphId: string,
     name: string,
-    opts?: { subGraphName?: string; entities?: string[] | 'all'; skipSeal?: boolean },
+    opts?: {
+      subGraphName?: string;
+      /** @deprecated Root selection is unsupported. */
+      entities?: string[] | 'all';
+      /** @deprecated Unsealed shares are unsupported. */
+      skipSeal?: boolean;
+    },
   ): Promise<{ swmShared: boolean; promotedCount: number; sealed: boolean; publishReady: boolean }> {
+    if (Array.isArray(opts?.entities)) {
+      throw Object.assign(new Error('Knowledge Assets are shared atomically; root-entity selection is not supported'), {
+        code: 'KA_ATOMIC_SHARE_REQUIRED',
+      });
+    }
+    if (opts?.entities !== undefined && opts.entities !== 'all') {
+      throw Object.assign(new Error('Knowledge Assets are shared atomically; omit entities to share the complete asset'), {
+        code: 'KA_ATOMIC_SHARE_REQUIRED',
+      });
+    }
+    if (opts?.skipSeal === true) {
+      throw Object.assign(new Error('Knowledge Assets are always sealed before sharing'), {
+        code: 'UNSEALED_SHARE_BLOCKED',
+      });
+    }
+    if (opts?.skipSeal !== undefined && opts.skipSeal !== false) {
+      throw new TypeError('skipSeal must be false or omitted');
+    }
     // Only include the optional fields when actually set -- don't spread the whole
     // opts object (which would carry `entities: undefined` / `subGraphName:
     // undefined` keys). Parity with MCP's knowledgeAssetShare body construction.
@@ -1276,9 +1312,6 @@ export class DkgDaemonClient {
       contextGraphId: normalizeContextGraphId(contextGraphId),
     };
     if (opts?.subGraphName) body.subGraphName = opts.subGraphName;
-    if (opts?.entities !== undefined) body.entities = opts.entities;
-    // #1116: a full share SEALS BY DEFAULT; `skipSeal:true` shares unsealed.
-    if (opts?.skipSeal !== undefined) body.skipSeal = opts.skipSeal;
     return this.post(`/api/knowledge-assets/${encodeURIComponent(name)}/swm/share`, body);
   }
 

--- a/packages/adapter-openclaw/src/dkg-client.ts
+++ b/packages/adapter-openclaw/src/dkg-client.ts
@@ -1243,10 +1243,16 @@ export class DkgDaemonClient {
     if (opts?.layer !== undefined && opts.layer !== 'wm') {
       throw new TypeError('Only Working Memory finalization is supported');
     }
-    return this.post(`/api/knowledge-assets/${encodeURIComponent(name)}/wm/finalize`, {
+    const body: Record<string, unknown> = {
       contextGraphId: normalizeContextGraphId(contextGraphId),
-      ...(opts ?? {}),
-    });
+    };
+    if (opts?.subGraphName) body.subGraphName = opts.subGraphName;
+    if (opts?.authorAgentAddress) body.authorAgentAddress = opts.authorAgentAddress;
+    if (opts?.preSignedAuthorAttestation) {
+      body.preSignedAuthorAttestation = opts.preSignedAuthorAttestation;
+    }
+    if (opts?.schemeVersion !== undefined) body.schemeVersion = opts.schemeVersion;
+    return this.post(`/api/knowledge-assets/${encodeURIComponent(name)}/wm/finalize`, body);
   }
 
   /** Discard the open WM draft (git checkout -- .). */

--- a/packages/adapter-openclaw/src/tools/assertion-tools.ts
+++ b/packages/adapter-openclaw/src/tools/assertion-tools.ts
@@ -99,13 +99,10 @@ export function buildAssertionTools(ctx: DkgToolHost): OpenClawTool[] {
       name: 'dkg_knowledge_asset_finalize',
       description:
         'Step 3 of the canonical flow. Seal a knowledge asset\'s Working Memory draft — computes the merkle ' +
-        'root and signs the EIP-712 AuthorAttestation. Finalize always seals the WHOLE draft (there is no ' +
-        'subset parameter). A FULL share (dkg_knowledge_asset_share with entities omitted or "all") ' +
-        'auto-seals for you, so you only need to call this explicitly before sharing a SELECTIVE subset of ' +
-        'entities, or to re-seal after editing a previously-sealed draft. Sealing works even if the context ' +
-        'graph is NOT yet registered on-chain (registration happens at publish). Pass layer:"swm" to seal an ' +
-        'asset already shared to SWM (e.g. shared with skip_seal) — it recovers and seals the SWM content ' +
-        'without a delete-and-recreate. (External-signer / pre-signed ' +
+        'root and signs the EIP-712 AuthorAttestation. Finalize always seals the complete WM draft. The ' +
+        'share step also seals automatically; call finalize explicitly for custom authorship options or ' +
+        'after editing. Sealing works before on-chain registration. Existing root-scoped SWM assets are ' +
+        'read-only. (External-signer / pre-signed ' +
         'attestation is a tracked follow-up and is not exposed by this tool — author with author_agent_address.)',
       parameters: {
         type: 'object',
@@ -119,14 +116,6 @@ export function buildAssertionTools(ctx: DkgToolHost): OpenClawTool[] {
               'request token\'s agent.',
           },
           scheme_version: { type: 'integer', description: 'Optional attestation scheme version.' },
-          layer: {
-            type: 'string',
-            enum: ['wm', 'swm'],
-            description:
-              'Which layer holds the content to seal. Default "wm" seals the open Working Memory draft. ' +
-              'Pass "swm" to seal an asset already shared to SWM (recovers + seals the SWM content without ' +
-              'delete-and-recreate).',
-          },
           sub_graph_name: { type: 'string', description: 'Must match the one used at write time.' },
         },
         required: ['context_graph_id', 'name'],
@@ -136,40 +125,18 @@ export function buildAssertionTools(ctx: DkgToolHost): OpenClawTool[] {
     {
       name: 'dkg_knowledge_asset_share',
       description:
-        'Step 4 of the canonical flow. Share a knowledge asset (or selected root entities) from Working ' +
-        'Memory into Shared Working Memory. A FULL share (omit `entities` or pass "all") SEALS BY DEFAULT ' +
-        'and is then publish-ready — follow it with dkg_knowledge_asset_publish to mint the asset on-chain ' +
-        '(Verifiable Memory). Pass skip_seal:true to share WITHOUT sealing (an unsealed SWM share — seal it ' +
-        'later with dkg_knowledge_asset_finalize, where layer:"swm" works after sharing). If a default ' +
-        '(sealing) share cannot seal it fails CLOSED (409, Working Memory preserved) and returns a recovery ' +
+        'Step 4 of the canonical flow. Atomically seal and share the complete Knowledge Asset triple set ' +
+        'from Working Memory into Shared Working Memory. Root-entity subsets and unsealed shares are not ' +
+        'supported. A successful share is publish-ready; follow it with dkg_knowledge_asset_publish. If ' +
+        'sealing or complete transfer fails, the operation fails CLOSED (Working Memory preserved) with a recovery ' +
         'hint. For custom finalize/attestation options — ' +
         'author_agent_address / scheme_version — call dkg_knowledge_asset_finalize EXPLICITLY first (the ' +
-        'default seal cannot carry them). A SELECTIVE subset ' +
-        '(`entities` set to a proper subset) shares ' +
-        'to SWM ONLY for peer visibility, is NOT sealed, and is NOT publishable to Verifiable Memory: ' +
-        'dkg_knowledge_asset_publish reconstructs the seal\'s full root set and rejects a truncated SWM with ' +
-        'a merkleRoot mismatch. To publish on-chain, share the full asset (or model the subset as its own ' +
-        'knowledge asset).',
+        'default seal cannot carry them).',
       parameters: {
         type: 'object',
         properties: {
           context_graph_id: { type: 'string', description: `Target context graph. ${EXISTING_CONTEXT_GRAPH_ID_DESCRIPTION}` },
           name: { type: 'string', description: 'Knowledge asset name to share.' },
-          entities: {
-            type: ['string', 'array'],
-            items: { type: 'string', description: 'Root entity URI.' },
-            description:
-              'Root entities to share. Omit (or pass the string "all") to share every root entity (full share, ' +
-              'seals by default + publish-ready). Provide a non-empty array of URIs that already exist in the asset to ' +
-              'share a subset — a subset shares to SWM only and is NOT publishable to Verifiable Memory. The only ' +
-              'accepted string value is "all".',
-          },
-          skip_seal: {
-            type: 'boolean',
-            description:
-              'Set true to share to SWM WITHOUT sealing (not publish-ready). Default (false) seals a full ' +
-              'share so it is immediately publish-ready. Ignored for a subset share, which is never sealed.',
-          },
           sub_graph_name: { type: 'string', description: 'Must match the one used at write time.' },
         },
         required: ['context_graph_id', 'name'],
@@ -292,7 +259,7 @@ export function buildAssertionTools(ctx: DkgToolHost): OpenClawTool[] {
       name: 'dkg_knowledge_asset_query',
       description:
         'Dump every triple in a knowledge asset\'s Working Memory DRAFT (the un-shared working copy) as ' +
-        '`{ quads, count }`. Query it BEFORE sharing: a FULL share empties the WM draft, so a query after ' +
+        '`{ quads, count }`. Query it BEFORE sharing: an atomic share empties the WM draft, so a query after ' +
         'sharing returns 0 quads. To inspect already-shared content use dkg_query with view ' +
         '"shared-working-memory" (or "verifiable-memory" once published). NOT a SPARQL endpoint — use ' +
         'dkg_query for ad-hoc SPARQL.',

--- a/packages/adapter-openclaw/test/dkg-client.test.ts
+++ b/packages/adapter-openclaw/test/dkg-client.test.ts
@@ -1058,6 +1058,18 @@ describe('DkgDaemonClient', () => {
       expect(url(1)).toBe('http://localhost:9200/api/knowledge-assets/f/vm/publish');
     });
 
+    it('knowledgeAssetShare rejects retired modes before HTTP and omits safe legacy defaults', async () => {
+      await expect(client.knowledgeAssetShare('cg-1', 'f', { entities: ['urn:x'] }))
+        .rejects.toMatchObject({ code: 'KA_ATOMIC_SHARE_REQUIRED' });
+      await expect(client.knowledgeAssetShare('cg-1', 'f', { skipSeal: true }))
+        .rejects.toMatchObject({ code: 'UNSEALED_SHARE_BLOCKED' });
+      expect(fetchCalls).toHaveLength(0);
+
+      ok({ swmShared: true, promotedCount: 1, sealed: true, publishReady: true });
+      await client.knowledgeAssetShare('cg-1', 'f', { entities: 'all', skipSeal: false });
+      expect(body()).toEqual({ contextGraphId: 'cg-1' });
+    });
+
     it('knowledgeAssetPublish nests finalized-publish controls under `options`', async () => {
       ok({ ual: 'did:dkg:x' });
       await client.knowledgeAssetPublish('cg-1', 'f', {
@@ -1128,6 +1140,16 @@ describe('DkgDaemonClient', () => {
         preSignedAuthorAttestation: { address: '0xauthor', reservedKaId: '1', signature: { r: '0xr', vs: '0xvs' } },
       })).rejects.toThrow('authorAgentAddress and preSignedAuthorAttestation are mutually exclusive');
       expect(fetchCalls).toHaveLength(0);
+    });
+
+    it('knowledgeAssetFinalize rejects SWM before HTTP and omits neutral layer:wm', async () => {
+      await expect(client.knowledgeAssetFinalize('cg-1', 'f', { layer: 'swm' }))
+        .rejects.toMatchObject({ code: 'LEGACY_KA_READ_ONLY' });
+      expect(fetchCalls).toHaveLength(0);
+
+      ok({ merkleRoot: '0xroot', eip712Digest: '0xdig' });
+      await client.knowledgeAssetFinalize('cg-1', 'f', { layer: 'wm' });
+      expect(body()).toEqual({ contextGraphId: 'cg-1' });
     });
 
     it('createKnowledgeAsset rejects mutually exclusive authorship fields before HTTP serialization', async () => {

--- a/packages/adapter-openclaw/test/dkg-client.test.ts
+++ b/packages/adapter-openclaw/test/dkg-client.test.ts
@@ -408,11 +408,10 @@ describe('DkgDaemonClient', () => {
   // destructure, plus URL-encodes the assertion name.
   // ---------------------------------------------------------------------------
 
-  it('promoteAssertion hits /api/knowledge-assets/:name/swm/share with camelCase body', async () => {
+  it('promoteAssertion atomically shares without root selectors', async () => {
     fetchResponses.push(new Response(JSON.stringify({ swmShared: true, promotedCount: 1 }), { status: 200 }));
 
     await client.promoteAssertion('ctx', 'chat-turns', {
-      entities: ['urn:a', 'urn:b'],
       subGraphName: 'protocols',
     });
 
@@ -422,9 +421,18 @@ describe('DkgDaemonClient', () => {
     const body = JSON.parse(opts?.body as string);
     expect(body).toEqual({
       contextGraphId: 'ctx',
-      entities: ['urn:a', 'urn:b'],
       subGraphName: 'protocols',
     });
+  });
+
+  it('promoteAssertion rejects root selection before HTTP', async () => {
+    await expect(
+      client.promoteAssertion('ctx', 'chat-turns', { entities: ['urn:a'] }),
+    ).rejects.toMatchObject({ code: 'KA_ATOMIC_SHARE_REQUIRED' });
+    await expect(
+      client.promoteAssertion('ctx', 'chat-turns', { entities: 'urn:not-all' as any }),
+    ).rejects.toMatchObject({ code: 'KA_ATOMIC_SHARE_REQUIRED' });
+    expect(fetchCalls).toHaveLength(0);
   });
 
   it('promoteAssertion URL-encodes assertion names containing slashes or spaces', async () => {

--- a/packages/adapter-openclaw/test/plugin.part-01.test.ts
+++ b/packages/adapter-openclaw/test/plugin.part-01.test.ts
@@ -994,7 +994,7 @@ describe("DkgNodePlugin", () => {
       expect(res.details?.warning).toContain('retry the atomic share');
     });
 
-    it('dkg_knowledge_asset_share surfaces a 409 UNSEALED_SHARE_BLOCKED recovery verbatim (#1116)', async () => {
+    it('dkg_knowledge_asset_share replaces obsolete 409 recovery with atomic guidance (#1116)', async () => {
       const recovery = 'No local signing key; pass skip_seal:true to share unsealed.';
       const fetchMock = vi.fn(async () =>
         new Response(JSON.stringify({ code: 'UNSEALED_SHARE_BLOCKED', recovery }), {
@@ -1011,8 +1011,9 @@ describe("DkgNodePlugin", () => {
         context_graph_id: 'ctx',
         name: 'notes',
       });
-      // The handler surfaces the daemon's recovery hint verbatim as the tool error.
-      expect(res.details?.error).toBe(recovery);
+      expect(res.details?.error).toContain('Resolve the local signing capability');
+      expect(res.details?.error).toContain('atomic Knowledge Asset share');
+      expect(res.details?.error).not.toContain('skip_seal');
     });
 
     it('dkg_knowledge_asset_share falls back to the generic error for a non-matching 409 (#1116)', async () => {

--- a/packages/adapter-openclaw/test/plugin.part-01.test.ts
+++ b/packages/adapter-openclaw/test/plugin.part-01.test.ts
@@ -864,25 +864,21 @@ describe("DkgNodePlugin", () => {
     });
 
 
-    it('dkg_knowledge_asset_share forwards snake_case → camelCase body and accepts the "all" sentinel (CONTRACT §B)', async () => {
+    it('dkg_knowledge_asset_share sends only the atomic KA scope and rejects root selection', async () => {
       const { fetchMock, byName } = setupPluginWithFetch({ promoted: 1 });
       await byName.get('dkg_knowledge_asset_share')!.execute('tc', {
         context_graph_id: 'ctx',
         name: 'notes',
-        entities: ['urn:root-1', 'urn:root-2'],
         sub_graph_name: 'protocols',
       });
       const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
       expect(url).toBe('http://localhost:9200/api/knowledge-assets/notes/swm/share');
       expect(JSON.parse(init.body as string)).toEqual({
         contextGraphId: 'ctx',
-        entities: ['urn:root-1', 'urn:root-2'],
         subGraphName: 'protocols',
       });
 
-      // CONTRACT §B: the "all" string sentinel is accepted and passed through to
-      // the wire unchanged (the daemon reads parsed.entities and treats "all" as a
-      // full share). It is NOT coerced to [] or omitted.
+      // Compatibility-only "all" is accepted but never serialized.
       fetchMock.mockClear();
       await byName.get('dkg_knowledge_asset_share')!.execute('tc', {
         context_graph_id: 'ctx',
@@ -893,11 +889,10 @@ describe("DkgNodePlugin", () => {
       const [, allInit] = fetchMock.mock.calls[0] as [string, RequestInit];
       expect(JSON.parse(allInit.body as string)).toEqual({
         contextGraphId: 'ctx',
-        entities: 'all',
       });
 
-      // An empty array is still rejected client-side (fail fast — the daemon would
-      // 400 it anyway).
+      // Any array is rejected before HTTP so an old subset request can never
+      // silently widen into a complete-KA share.
       fetchMock.mockClear();
       const bad = await byName.get('dkg_knowledge_asset_share')!.execute('tc', {
         context_graph_id: 'ctx',
@@ -905,18 +900,18 @@ describe("DkgNodePlugin", () => {
         entities: [],
       });
       expect(fetchMock).not.toHaveBeenCalled();
-      expect(bad.content[0].text).toContain('entities');
+      expect(bad.content[0].text).toContain('shared atomically');
     });
 
-    it('dkg_knowledge_asset_share trims whitespace from each entity URI before the wire (FIX K)', async () => {
+    it('dkg_knowledge_asset_share rejects root-selection arrays before the wire', async () => {
       const { fetchMock, byName } = setupPluginWithFetch({ promoted: 1 });
-      await byName.get('dkg_knowledge_asset_share')!.execute('tc', {
+      const res = await byName.get('dkg_knowledge_asset_share')!.execute('tc', {
         context_graph_id: 'ctx',
         name: 'notes',
         entities: [' urn:root-1 ', '\turn:root-2\n'],
       });
-      const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
-      expect(JSON.parse(init.body as string).entities).toEqual(['urn:root-1', 'urn:root-2']);
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(res.details?.error).toContain('shared atomically');
     });
 
 
@@ -932,18 +927,17 @@ describe("DkgNodePlugin", () => {
     });
 
 
-    // ── #1116 share seal: skip_seal forwarding + publishReady warning branch ──
+    // ── Atomic-share boundary + defensive mixed-version warnings ──
 
-    it('dkg_knowledge_asset_share forwards skip_seal:true as skipSeal on the wire (#1116)', async () => {
+    it('dkg_knowledge_asset_share rejects skip_seal:true before the wire', async () => {
       const { fetchMock, byName } = setupPluginWithFetch({ swmShared: true, promotedCount: 1, sealed: false, publishReady: false });
-      await byName.get('dkg_knowledge_asset_share')!.execute('tc', {
+      const res = await byName.get('dkg_knowledge_asset_share')!.execute('tc', {
         context_graph_id: 'ctx',
         name: 'notes',
         skip_seal: true,
       });
-      const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
-      expect(url).toBe('http://localhost:9200/api/knowledge-assets/notes/swm/share');
-      expect(JSON.parse(init.body as string).skipSeal).toBe(true);
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(res.details?.error).toContain('always sealed');
     });
 
     it('dkg_knowledge_asset_share rejects a non-boolean skip_seal at the boundary (#1116)', async () => {
@@ -957,31 +951,25 @@ describe("DkgNodePlugin", () => {
       expect(res.details?.error).toMatch(/skip_seal.*boolean/);
     });
 
-    it('dkg_knowledge_asset_share on a FULL share with publishReady:false emits the seal-it warning (#1116)', async () => {
+    it('dkg_knowledge_asset_share with publishReady:false emits the atomic retry warning', async () => {
       const { byName } = setupPluginWithFetch({ swmShared: true, promotedCount: 2, sealed: false, publishReady: false });
       const res = await byName.get('dkg_knowledge_asset_share')!.execute('tc', {
         context_graph_id: 'ctx',
         name: 'notes',
-        skip_seal: true,
       });
-      // A skip_seal FULL share IS sealable later → the "seal it with finalize" hint.
-      expect(res.details?.warning).toContain('NOT publish-ready (sealed:false)');
-      expect(res.details?.warning).toContain('layer:swm works after sharing');
-      expect(res.details?.warning).not.toContain('NOT sealable');
+      expect(res.details?.warning).toContain('did not become publish-ready (sealed:false)');
+      expect(res.details?.warning).toContain('retry the complete Knowledge Asset share');
     });
 
-    it('dkg_knowledge_asset_share on a SUBSET with publishReady:false emits the not-sealable warning (#1116)', async () => {
-      const { byName } = setupPluginWithFetch({ swmShared: true, promotedCount: 1, sealed: false, publishReady: false });
+    it('dkg_knowledge_asset_share rejects a legacy subset request without widening it', async () => {
+      const { fetchMock, byName } = setupPluginWithFetch({ swmShared: true, promotedCount: 1, sealed: false, publishReady: false });
       const res = await byName.get('dkg_knowledge_asset_share')!.execute('tc', {
         context_graph_id: 'ctx',
         name: 'notes',
         entities: ['urn:a'],
       });
-      // A subset is NOT sealable (finalize layer:swm rejects it) → the full-share /
-      // new-asset recovery, NOT the dead-end "seal it" advice.
-      expect(res.details?.warning).toContain('A subset is NOT sealable/publishable');
-      expect(res.details?.warning).toContain('entities:"all"');
-      expect(res.details?.warning).not.toContain('Seal it with');
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(res.details?.error).toContain('shared atomically');
     });
 
     it('dkg_knowledge_asset_share with publishReady:true emits NO warning (#1116)', async () => {
@@ -1002,11 +990,8 @@ describe("DkgNodePlugin", () => {
         context_graph_id: 'ctx',
         name: 'notes',
       });
-      expect(res.details?.warning).toContain('not all roots reached SWM');
-      expect(res.details?.warning).toContain('re-share the full asset');
-      // Must NOT recommend the dead-end finalize layer:swm here (it would reject).
-      expect(res.details?.warning).not.toContain('layer:swm works after sharing');
-      expect(res.details?.warning).not.toContain('NOT sealable');
+      expect(res.details?.warning).toContain('complete sealed Knowledge Asset did not reach SWM');
+      expect(res.details?.warning).toContain('retry the atomic share');
     });
 
     it('dkg_knowledge_asset_share surfaces a 409 UNSEALED_SHARE_BLOCKED recovery verbatim (#1116)', async () => {
@@ -1053,16 +1038,15 @@ describe("DkgNodePlugin", () => {
 
     // ── #1116 finalize layer ──────────────────────────────────────────────
 
-    it('dkg_knowledge_asset_finalize forwards layer:"swm" on the wire (#1116)', async () => {
+    it('dkg_knowledge_asset_finalize rejects legacy SWM finalization before the wire', async () => {
       const { fetchMock, byName } = setupPluginWithFetch({ merkleRoot: '0xroot', eip712Digest: '0xdig' });
-      await byName.get('dkg_knowledge_asset_finalize')!.execute('tc', {
+      const res = await byName.get('dkg_knowledge_asset_finalize')!.execute('tc', {
         context_graph_id: 'ctx',
         name: 'notes',
         layer: 'swm',
       });
-      const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
-      expect(url).toBe('http://localhost:9200/api/knowledge-assets/notes/wm/finalize');
-      expect(JSON.parse(init.body as string).layer).toBe('swm');
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(res.details?.error).toContain('read-only');
     });
 
     it('dkg_knowledge_asset_finalize rejects an invalid layer at the boundary (#1116)', async () => {
@@ -1073,7 +1057,7 @@ describe("DkgNodePlugin", () => {
         layer: 'vm',
       });
       expect(fetchMock).not.toHaveBeenCalled();
-      expect(res.details?.error).toMatch(/layer.*"wm".*"swm"/);
+      expect(res.details?.error).toContain('Only Working Memory finalization');
     });
 
     it('dkg_knowledge_asset_finalize rejects a NON-STRING layer, nothing on the wire (#1116)', async () => {
@@ -1088,7 +1072,7 @@ describe("DkgNodePlugin", () => {
           layer: bad as never,
         });
         expect(fetchMock, `layer: ${JSON.stringify(bad)}`).not.toHaveBeenCalled();
-        expect(res.details?.error).toMatch(/layer.*"wm".*"swm"/);
+        expect(res.details?.error).toContain('Only Working Memory finalization');
       }
     });
 

--- a/packages/adapter-openclaw/test/plugin.part-04.test.ts
+++ b/packages/adapter-openclaw/test/plugin.part-04.test.ts
@@ -83,7 +83,7 @@ describe("DkgNodePlugin", () => {
       // rc.17 (CONTRACT §2 promote→share, §1 Stage5) + #1116: a FULL share now
       // SEALS BY DEFAULT and is publish-ready via the per-KA
       // dkg_knowledge_asset_publish. The share description must steer the agent
-      // to it and explain the subset-is-not-publishable rule (§5).
+      // to it and make the atomic scope explicit.
       const plugin = new DkgNodePlugin();
       const tools: OpenClawTool[] = [];
       plugin.register({
@@ -95,10 +95,8 @@ describe("DkgNodePlugin", () => {
       });
       const share = tools.find((t) => t.name === 'dkg_knowledge_asset_share')!;
       expect(share.description).toContain('dkg_knowledge_asset_publish');
-      // #1116: a full share now SEALS BY DEFAULT (was "auto-seal best-effort").
-      expect(share.description).toMatch(/seals by default/i);
-      // §5 subset-vs-full language must be present.
-      expect(share.description).toMatch(/NOT publishable to Verifiable Memory/i);
+      expect(share.description).toMatch(/atomically seal and share the complete Knowledge Asset/i);
+      expect(share.description).toMatch(/Root-entity subsets and unsealed shares are not supported/i);
     });
 
 

--- a/packages/adapter-openclaw/test/share-warning-parity.test.ts
+++ b/packages/adapter-openclaw/test/share-warning-parity.test.ts
@@ -22,7 +22,7 @@ const fixture = JSON.parse(
 describe('#1116 share-warning parity (OpenClaw vs canonical fixture)', () => {
   it('SHARE_NOT_PUBLISH_READY_WARNING matches the fixture byte-for-byte', () => {
     expect(SHARE_NOT_PUBLISH_READY_WARNING).toBe(fixture.SHARE_NOT_PUBLISH_READY_WARNING);
-    expect(SHARE_NOT_PUBLISH_READY_WARNING).toContain('preserved Working Memory draft');
+    expect(SHARE_NOT_PUBLISH_READY_WARNING).toContain('Keep the Working Memory draft');
     expect(SHARE_NOT_PUBLISH_READY_WARNING).not.toMatch(/pull(?:-|\s)from|pull the asset/i);
   });
 

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -1259,10 +1259,11 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
           emitMemoryGraphChanged?.({ contextGraphId, layers: ["wm", "swm"], subGraphName, operation: "assertion_promoted", source: "api", counts: { triples: share.promotedCount } });
           recordActivityAndNotify(ctx, { contextGraphId, kind: "promoted", actorAgentAddress: requestAgentAddress, subGraphName, tripleCount: share.promotedCount });
         }
-        // #1116: ownership conflicts are advisory skips. A zero-row outcome is
-        // still HTTP 200, but it did not create an SWM share and must not report
-        // the pre-share WM seal as a sealed share.
-        const swmShared = share.promotedCount > 0;
+        // A durable idempotent replay returns zero newly-promoted rows together
+        // with the original shareOperationId. That is an already-completed share,
+        // not an ownership skip, so preserve its sealed/publish-ready status.
+        const durableReplay = share.promotedCount === 0 && Boolean(share.shareOperationId);
+        const swmShared = share.promotedCount > 0 || durableReplay;
         return jsonResponse(res, 200, {
           swmShared,
           promotedCount: share.promotedCount,

--- a/packages/cli/test/knowledge-assets-1116-share-errors.test.ts
+++ b/packages/cli/test/knowledge-assets-1116-share-errors.test.ts
@@ -230,7 +230,7 @@ describe('#1116 share/seal route error mapping (fake agent)', () => {
 
   it('swm/share preserves sealed publish-ready status for a durable replay', async () => {
     await startWith({
-      promote: async () => ({
+      shareWholeKnowledgeAsset: async () => ({
         promotedCount: 0,
         sealed: true,
         publishReady: true,

--- a/packages/cli/test/knowledge-assets-1116-share-errors.test.ts
+++ b/packages/cli/test/knowledge-assets-1116-share-errors.test.ts
@@ -227,6 +227,27 @@ describe('#1116 share/seal route error mapping (fake agent)', () => {
     expect(String(res.body.recovery)).toContain('retry');
   });
 
+  it('swm/share preserves sealed publish-ready status for a durable replay', async () => {
+    await startWith({
+      promote: async () => ({
+        promotedCount: 0,
+        sealed: true,
+        publishReady: true,
+        shareOperationId: 'existing-share-operation',
+      }),
+    });
+
+    const res = await post('swm/share', { contextGraphId: CG_ID });
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      swmShared: true,
+      promotedCount: 0,
+      sealed: true,
+      publishReady: true,
+      shareOperationId: 'existing-share-operation',
+    });
+  });
+
   it('swm/share: KA_NAMED_GRAPH_SHARE_UNSUPPORTED → 409 { code, error, namedGraphs }', async () => {
     await startWith({
       promote: async () => {

--- a/packages/mcp-dkg/README.md
+++ b/packages/mcp-dkg/README.md
@@ -179,7 +179,7 @@ The lifecycle tool family that lets agents stage memory, seal it, share it, publ
 | `dkg_knowledge_asset_create` | 1 | Create an empty Working Memory assertion graph (knowledge asset). Idempotent — duplicate names land as `alreadyExists: true`. Name validation matches the daemon's `validateAssertionName`: any IRI-safe name up to 256 chars (no `/`, no whitespace, no `` <>"{}|^`\ `` characters), and not a reserved B3 KA id — NOT restricted to a lowercase-hyphen slug. |
 | `dkg_knowledge_asset_write` | 2 | Append RDF quads into an existing WM assertion. Set-merge — duplicates collapse. To replace, call `dkg_knowledge_asset_discard` first or mint a unique name. |
 | `dkg_knowledge_asset_finalize` | 3 | **Seal** the WM draft (the "git commit"): compute the merkleRoot over the whole assertion, build + sign an EIP-712 AuthorAttestation, stamp the seal. Returns `merkleRoot`, `authorAddress`, `schemeVersion`, `chainId`, `kav10Address`, `eip712Digest`. Seals the entire draft — no subset parameter. |
-| `dkg_knowledge_asset_share` | 4 | Share a WM assertion (or specific root entities) from private WM to Shared Working Memory so teammates see it (formerly "promote"). Omit `entities` for a full share, which auto-seals best-effort; a subset share is SWM-only and not publishable to VM as a subset. |
+| `dkg_knowledge_asset_share` | 4 | Atomically seal and share the complete KA triple set from private WM to Shared Working Memory. Root-entity subsets and unsealed shares are unsupported. |
 | `dkg_knowledge_asset_publish` | 5 | **Mint / update on chain** (the sealed assertion → Verifiable Memory). Takes no selector (the seal commits the whole assertion). Returns the **UAL** + `kaId` + `txHash` — see "The canonical round-trip" below. |
 | `dkg_knowledge_asset_pull_from` | edit-loop | Seed a fresh WM draft from the current SWM or VM state (the "git checkout"). Body `{ layer: "swm" \| "vm", onConflict?: "reject" \| "replace" }`; `409 WM_DRAFT_CONFLICT` on a dirty draft unless `replace`. |
 | `dkg_knowledge_asset_discard` | rollback | Discard a WM assertion without sharing it. Idempotent — no-op on a missing assertion. Use before re-writing an assertion whose name you want to keep stable. |
@@ -218,7 +218,7 @@ Lifted from the repo-root README's [DKG V10 as agent memory quickstart](../../RE
 2. `dkg_knowledge_asset_write` with one or more quads (additive set-merge).
 3. `dkg_memory_search` with a keyword from the write — the just-written triple comes back from the WM layer with `trustWeight` set.
 4. *(optional)* `dkg_knowledge_asset_finalize` to **seal** the draft (the EIP-712 "git commit" — note: this is the rc.17 *seal* verb, distinct from the on-chain mint in step 6).
-5. *(optional)* `dkg_knowledge_asset_share` to advance the lifecycle to SWM and gossip to peers (a full share auto-seals best-effort, so step 4 can be skipped for the common case).
+5. *(optional)* `dkg_knowledge_asset_share` to atomically seal, advance the complete KA to SWM, and gossip it to peers (step 4 can be skipped when the default authorship options are sufficient).
 6. *(optional)* `dkg_knowledge_asset_publish` to **mint on chain** (costs TRAC + gas, clears SWM). The response carries the asset's **UAL** (`did:dkg:<chainId>/<addr>/<number>`) plus `kaId` and `txHash` — store the UAL to reference the asset later.
 
 For ad-hoc filtering or non-text-search queries, `dkg_query` is the lower-level SPARQL surface. To put fresh quads on chain, author them as a named knowledge asset and publish through the lifecycle (`create → write → finalize → share → publish`).

--- a/packages/mcp-dkg/hooks/capture-chat.mjs
+++ b/packages/mcp-dkg/hooks/capture-chat.mjs
@@ -36,7 +36,7 @@
  *    on stdout.
  * 2. CANONICAL DKG OPS. Writes go through the existing
  *    `POST /api/knowledge-assets/<name>/wm/write` (JSON triples) and
- *    promotes through `POST /api/knowledge-assets/<name>/swm/share`,
+ *    shares atomically through `POST /api/knowledge-assets/<name>/swm/share`,
  *    matching every other seeding script in the repo.
  * 3. NO PROMPT INJECTION. Per the V10 retirement of sugared writes
  *    (#18) and the dropped agent-instruction protocol (#21), this hook
@@ -418,11 +418,10 @@ async function writeTriples(cfg, triples, assertionName = cfg.assertion) {
   });
 }
 
-async function promoteEntities(cfg, entities, assertionName = cfg.assertion) {
+export async function shareAssertionAtomically(cfg, assertionName = cfg.assertion) {
   return postJson(cfg.api, `/api/knowledge-assets/${encodeURIComponent(assertionName)}/swm/share`, cfg.token, {
     contextGraphId: cfg.project,
     subGraphName: cfg.subGraph,
-    entities,
   });
 }
 
@@ -610,10 +609,9 @@ async function handleAfterAgentResponse(cfg, payload) {
     state.pendingTurnIndex = null;
     if (bootstrapSession) state.sessionWritten = true;
     if (await shouldPromote(cfg, state)) {
-      // Promote both the session and the individual turn so the team
-      // sees the turn immediately and the aggregate Session is kept
-      // in SWM.
-      await promoteEntities(cfg, [turn, state.sessionUri], turnAssertion).catch((e) => log(`promote turn: ${e.message}`));
+      // Each assertion contains the complete turn and session payload, so share
+      // that Knowledge Asset atomically; entity arrays are a retired subset mode.
+      await shareAssertionAtomically(cfg, turnAssertion).catch((e) => log(`share turn: ${e.message}`));
     } else if (cfg.autoShare) {
       log(`auto-share skipped: session ${sessionKey} is private`);
     }

--- a/packages/mcp-dkg/src/client.ts
+++ b/packages/mcp-dkg/src/client.ts
@@ -665,6 +665,25 @@ export class DkgClient {
   }
 
   /**
+   * @deprecated Use {@link knowledgeAssetShare}. Knowledge Assets now share
+   * atomically; omitted/`"all"` scope remains a compatibility alias, while a
+   * legacy entity subset is rejected by the canonical share boundary.
+   */
+  async promoteAssertion(args: {
+    contextGraphId: string;
+    assertionName: string;
+    subGraphName?: string;
+    entities?: string[] | 'all';
+  }): Promise<void> {
+    await this.knowledgeAssetShare({
+      contextGraphId: args.contextGraphId,
+      name: args.assertionName,
+      ...(args.subGraphName ? { subGraphName: args.subGraphName } : {}),
+      ...(args.entities !== undefined ? { entities: args.entities } : {}),
+    });
+  }
+
+  /**
    * Create an empty Working Memory assertion graph (idempotent — duplicate
    * names land as `alreadyExists: true` rather than throwing). The
    * canonical write flow is `createAssertion` → `writeAssertion` →

--- a/packages/mcp-dkg/src/client.ts
+++ b/packages/mcp-dkg/src/client.ts
@@ -664,30 +664,11 @@ export class DkgClient {
     );
   }
 
-  /** Promote specific entity URIs from WM → SWM. */
-  async promoteAssertion(args: {
-    contextGraphId: string;
-    assertionName: string;
-    subGraphName?: string;
-    entities: string[];
-  }): Promise<void> {
-    const body: Record<string, unknown> = {
-      contextGraphId: normalizeContextGraphId(args.contextGraphId),
-      entities: args.entities,
-    };
-    if (args.subGraphName) body.subGraphName = args.subGraphName;
-    await this.request(
-      'POST',
-      `/api/knowledge-assets/${encodeURIComponent(args.assertionName)}/swm/share`,
-      body,
-    );
-  }
-
   /**
    * Create an empty Working Memory assertion graph (idempotent — duplicate
    * names land as `alreadyExists: true` rather than throwing). The
    * canonical write flow is `createAssertion` → `writeAssertion` →
-   * `promoteAssertion` (or `discardAssertion` to roll back).
+   * `knowledgeAssetShare` (or `discardAssertion` to roll back).
    */
   async createAssertion(args: {
     contextGraphId: string;
@@ -1233,7 +1214,6 @@ export class DkgClient {
       body.preSignedAuthorAttestation = args.preSignedAuthorAttestation;
     }
     if (args.schemeVersion !== undefined) body.schemeVersion = args.schemeVersion;
-    if (args.layer !== undefined) body.layer = args.layer;
     return this.request<{ merkleRoot: string; eip712Digest: string }>(
       'POST',
       `/api/knowledge-assets/${encodeURIComponent(args.name)}/wm/finalize`,

--- a/packages/mcp-dkg/src/client.ts
+++ b/packages/mcp-dkg/src/client.ts
@@ -1212,12 +1212,18 @@ export class DkgClient {
     authorAgentAddress?: string;
     preSignedAuthorAttestation?: PreSignedAuthorAttestationPayload;
     schemeVersion?: number;
-    // #1116: optional layer selects WHERE the content to seal lives. "wm"
-    // (default) seals the open WM draft; "swm" reconstructs a draft from an
-    // already-shared SWM asset and seals it (recover-without-recreate).
+    /** @deprecated Only WM finalization is supported. `swm` fails read-only. */
     layer?: 'wm' | 'swm';
   }): Promise<{ merkleRoot: string; eip712Digest: string }> {
     assertExclusiveAuthorFields(args);
+    if (args.layer === 'swm') {
+      throw Object.assign(new Error('Legacy root-scoped Knowledge Assets are read-only'), {
+        code: 'LEGACY_KA_READ_ONLY',
+      });
+    }
+    if (args.layer !== undefined && args.layer !== 'wm') {
+      throw new TypeError('Only Working Memory finalization is supported');
+    }
     const body: Record<string, unknown> = {
       contextGraphId: normalizeContextGraphId(args.contextGraphId),
     };
@@ -1278,18 +1284,33 @@ export class DkgClient {
     contextGraphId: string;
     name: string;
     subGraphName?: string;
+    /** @deprecated Knowledge Assets are shared atomically. */
     entities?: string[] | 'all';
-    // #1116: a full share SEALS BY DEFAULT (publish-ready). `skipSeal:true`
-    // opts out into an unsealed SWM share. A subset share is SWM-only and is
-    // never sealed regardless of this flag.
+    /** @deprecated Unsealed Knowledge Asset shares are unsupported. */
     skipSeal?: boolean;
   }): Promise<{ swmShared: boolean; promotedCount: number; sealed: boolean; publishReady: boolean }> {
+    if (Array.isArray(args.entities)) {
+      throw Object.assign(new Error('Knowledge Assets are shared atomically; root-entity selection is not supported'), {
+        code: 'KA_ATOMIC_SHARE_REQUIRED',
+      });
+    }
+    if (args.entities !== undefined && args.entities !== 'all') {
+      throw Object.assign(new Error('Knowledge Assets are shared atomically; omit entities to share the complete asset'), {
+        code: 'KA_ATOMIC_SHARE_REQUIRED',
+      });
+    }
+    if (args.skipSeal === true) {
+      throw Object.assign(new Error('Knowledge Assets are always sealed before sharing'), {
+        code: 'UNSEALED_SHARE_BLOCKED',
+      });
+    }
+    if (args.skipSeal !== undefined && args.skipSeal !== false) {
+      throw new TypeError('skipSeal must be false or omitted');
+    }
     const body: Record<string, unknown> = {
       contextGraphId: normalizeContextGraphId(args.contextGraphId),
     };
     if (args.subGraphName) body.subGraphName = args.subGraphName;
-    if (args.entities !== undefined) body.entities = args.entities;
-    if (args.skipSeal !== undefined) body.skipSeal = args.skipSeal;
     return this.request<{ swmShared: boolean; promotedCount: number; sealed: boolean; publishReady: boolean }>(
       'POST',
       `/api/knowledge-assets/${encodeURIComponent(args.name)}/swm/share`,

--- a/packages/mcp-dkg/src/manifest/publish.ts
+++ b/packages/mcp-dkg/src/manifest/publish.ts
@@ -288,15 +288,15 @@ export async function publishManifest(
   });
 
   if (opts.autoShare !== false) {
-    try {
-      await opts.client.promoteAssertion({
-        contextGraphId: opts.contextGraphId,
-        assertionName: assertion,
-        subGraphName: 'meta',
-        entities: [mUri, ...Object.values(templateUris)],
-      });
-    } catch {
-      // Promote failure is non-fatal; manifest is in WM and can be promoted later.
+    const share = await opts.client.knowledgeAssetShare({
+      contextGraphId: opts.contextGraphId,
+      name: assertion,
+      subGraphName: 'meta',
+    });
+    if (!share.swmShared || !share.sealed || !share.publishReady) {
+      throw new Error(
+        'Manifest atomic share did not reach SWM as sealed and publish-ready',
+      );
     }
   }
 

--- a/packages/mcp-dkg/src/tools/assertions.ts
+++ b/packages/mcp-dkg/src/tools/assertions.ts
@@ -50,36 +50,29 @@ const formatError = (e: unknown): string =>
 // `tests/fixtures/share-seal-warnings.json`. Update the fixture + all three
 // adapters together; the parity tests flag any mismatch.
 
-// publishReady:false after a FULL share that opted out of sealing (skipSeal:true)
-// — a later finalize(layer:swm) DOES seal it.
+// Defensive warnings for mixed-version daemon replies. New clients only issue
+// atomic, sealed full-KA shares, but an older daemon may still report one of the
+// historical non-publish-ready outcomes.
 export const SHARE_NOT_PUBLISH_READY_WARNING =
-  'Shared to SWM but NOT publish-ready (sealed:false). Seal it with ' +
-  'dkg_knowledge_asset_finalize (layer:swm works after sharing), then publish.';
+  'The atomic SWM share did not become publish-ready (sealed:false). Keep the ' +
+  'Working Memory draft and retry the complete Knowledge Asset share; do not publish it.';
 
-// A SUBSET share is publishReady:false too, but unlike a skipSeal full share it is
-// NOT sealable — finalize(layer:swm) now REJECTS it with SWM_SUBSET_NOT_SEALABLE.
-// Surface the real recovery (full share / new asset) instead of "seal it".
+// Defensive mixed-version classification for a legacy partial-share outcome.
 export const SHARE_SUBSET_NOT_PUBLISH_READY_WARNING =
-  'Shared a SUBSET to SWM for peer visibility. A subset is NOT sealable/' +
-  'publishable (finalize layer:swm will reject it). To publish on-chain, share ' +
-  'the full asset (entities:"all"), or model this subset as its own knowledge asset.';
+  'A legacy partial-share outcome was reported. Root-scoped subsets are read-only ' +
+  'and not publishable; model the intended data as its own Knowledge Asset and share it atomically.';
 
-// A FULL share can come back sealed:true but publishReady:false when NOT every
-// sealed root reached SWM (promotedAllRoots false — e.g. foreign-owned roots were
-// skipped). The engine did NOT set the swmShareComplete marker, so finalize(layer:
-// swm) would REJECT — do NOT recommend it here. Re-sharing the full asset recovers.
+// A sealed atomic share can still report incomplete delivery; retry from WM.
 export const SHARE_INCOMPLETE_PROMOTE_WARNING =
-  'Sealed, but not all roots reached SWM (some roots may be owned by other ' +
-  'agents) — not yet publishable; re-share the full asset so every sealed root ' +
-  'is in SWM.';
+  'The complete sealed Knowledge Asset did not reach SWM and is not publish-ready; ' +
+  'keep the Working Memory draft and retry the atomic share.';
 
 /**
  * #1116: pick the not-publish-ready share warning from the share outcome. Returns
  * `undefined` when the share IS publish-ready (no warning). Branch precedence:
- *  1. sealed:true + publishReady:false → incomplete full promote (marker NOT set;
- *     finalize layer:swm would reject) → re-share the full asset.
- *  2. sealed:false + SUBSET (a non-empty specific entity list) → not sealable.
- *  3. sealed:false + FULL (skipSeal) → sealable later (finalize layer:swm works).
+ *  1. sealed:true + publishReady:false → incomplete atomic delivery.
+ *  2. sealed:false + legacy subset response → legacy read-only warning.
+ *  3. sealed:false + atomic response → retry the complete share from WM.
  * Duplicated byte-identical on OpenClaw (TS) + Hermes (Python).
  */
 export function classifyShareWarning(outcome: {
@@ -438,15 +431,11 @@ export function registerAssertionTools(
       description:
         'Step 3 of the canonical write flow: seal a knowledge asset\'s Working ' +
         'Memory draft — computes the merkle root and signs the EIP-712 ' +
-        'AuthorAttestation. Finalize always seals the WHOLE draft (there is no ' +
-        'subset parameter). A FULL share (dkg_knowledge_asset_share with ' +
-        '`entities` omitted or "all") auto-seals for you, so you only need to ' +
-        'call this explicitly before sharing a SELECTIVE subset of entities, or ' +
-        'to re-seal after editing a previously-sealed draft. Sealing works even ' +
+        'AuthorAttestation. Finalize always seals the WHOLE draft. The share ' +
+        'step also seals automatically, so call this explicitly when custom ' +
+        'authorship options are needed or after editing a previously-sealed draft. Sealing works even ' +
         'if the context graph is NOT yet registered on-chain (registration ' +
-        'happens at publish). Pass `layer:"swm"` to seal an asset already shared ' +
-        'to SWM (e.g. shared with `skipSeal:true`) — it recovers and seals the ' +
-        'SWM content without a delete-and-recreate. (External-signer / ' +
+        'happens at publish). Existing root-scoped SWM assets are read-only. (External-signer / ' +
         'pre-signed attestation is a tracked follow-up and is not exposed by this ' +
         'tool — author with authorAgentAddress.)',
       inputSchema: {
@@ -461,21 +450,12 @@ export function registerAssertionTools(
         // CONTRACT §C: scheme_version is a POSITIVE integer (daemon >= 1) — zod
         // rejects 0 / negative / non-integer at the boundary as a tool error.
         schemeVersion: z.number().int().positive().optional().describe('Optional attestation scheme version (positive integer)'),
-        // #1116: `layer` selects WHERE the content to seal lives. Default "wm"
-        // seals the open WM draft; "swm" seals an asset already shared to SWM.
-        layer: z
-          .enum(['wm', 'swm'])
-          .optional()
-          .describe(
-            'Which layer holds the content to seal. Default "wm" seals the open ' +
-            'Working Memory draft. Pass "swm" to seal an asset already shared to ' +
-            'SWM (recovers + seals the SWM content without delete-and-recreate).',
-          ),
+        layer: z.never().optional().describe('Retired: only Working Memory finalization is supported.'),
         projectId: z.string().optional().describe(`${EXISTING_CONTEXT_GRAPH_ID_DESCRIPTION} Defaults to .dkg/config.yaml.`),
         subGraphName: z.string().optional(),
       },
     },
-    async ({ name, authorAgentAddress, schemeVersion, layer, projectId, subGraphName }): Promise<ToolResult> => {
+    async ({ name, authorAgentAddress, schemeVersion, projectId, subGraphName }): Promise<ToolResult> => {
       const pid = resolveProject(projectId, config);
       if (!pid) return projectErr();
       try {
@@ -490,7 +470,6 @@ export function registerAssertionTools(
           subGraphName,
           authorAgentAddress,
           schemeVersion,
-          layer,
         });
         return ok(
           `Finalized (sealed) knowledge asset '${name}' (project '${pid}'):\n\n\`\`\`json\n${JSON.stringify(
@@ -511,99 +490,46 @@ export function registerAssertionTools(
     {
       title: 'Share Knowledge Asset to SWM',
       description:
-        'Step 4 of the canonical write flow: share a knowledge asset (or ' +
-        'specific root entities within it) from private Working Memory to ' +
-        'Shared Working Memory so teammates see it. A FULL share (omit ' +
-        '`entities` or pass "all") SEALS BY DEFAULT and is then publish-ready — ' +
+        'Step 4 of the canonical write flow: atomically seal and share the complete ' +
+        'knowledge asset from private Working Memory to Shared Working Memory. ' +
+        'The exact submitted triple set is the asset boundary; root-entity subset ' +
+        'selection and unsealed shares are not supported. A successful share is publish-ready — ' +
         'follow it with dkg_knowledge_asset_publish to mint the asset on-chain ' +
-        '(Verifiable Memory). Pass `skipSeal:true` to share WITHOUT sealing (an ' +
-        'unsealed SWM share — seal it later with dkg_knowledge_asset_finalize, ' +
-        'where `layer:"swm"` works after sharing). If a default (sealing) share ' +
-        'cannot seal it fails CLOSED (409, Working Memory preserved) and returns ' +
+        '(Verifiable Memory). If sealing or the complete transfer fails, the ' +
+        'operation fails CLOSED (Working Memory preserved) and returns ' +
         'a recovery hint. For custom finalize/attestation options — ' +
         'authorAgentAddress / schemeVersion — call dkg_knowledge_asset_finalize ' +
-        'EXPLICITLY first (the default seal cannot carry them). A SELECTIVE ' +
-        'subset (`entities` set to a proper subset) shares to SWM ONLY for peer ' +
-        'visibility, is NOT sealed, and is NOT publishable to Verifiable Memory: ' +
-        'dkg_knowledge_asset_publish reconstructs the seal\'s full root set and ' +
-        'rejects a truncated SWM with a merkleRoot mismatch. To publish on-chain, ' +
-        'share the full asset (or model the subset as its own knowledge asset).',
+        'EXPLICITLY first (the default seal cannot carry them).',
       inputSchema: {
         name: z.string().describe('Existing knowledge asset name'),
-        // CONTRACT §B: accept "all" | string[] | omitted. The daemon reads
-        // parsed.entities and treats "all"/omitted as a full share.
-        entities: z
-          .union([z.literal('all'), z.array(z.string())])
-          .optional()
-          .describe(
-            'Root entities to share. Omit (or pass the string "all") to share all ' +
-            'roots (seals by default + publish-ready). A subset (non-empty array) ' +
-            'shares to SWM only and is NOT publishable to Verifiable Memory.',
-          ),
-        // #1116: a full share SEALS BY DEFAULT. `skipSeal:true` opts out into an
-        // unsealed SWM share (not publish-ready until a later finalize).
-        skipSeal: z
-          .boolean()
-          .optional()
-          .describe(
-            'Set true to share to SWM WITHOUT sealing (not publish-ready). ' +
-            'Default (false) seals a full share so it is immediately publish-ready. ' +
-            'Ignored for a subset share, which is never sealed.',
-          ),
+        entities: z.never().optional().describe('Retired: Knowledge Assets are shared atomically.'),
+        skipSeal: z.never().optional().describe('Retired: Knowledge Assets are always sealed before sharing.'),
         projectId: z.string().optional().describe(`${EXISTING_CONTEXT_GRAPH_ID_DESCRIPTION} Defaults to .dkg/config.yaml.`),
         subGraphName: z.string().optional(),
       },
     },
-    async ({ name, entities, skipSeal, projectId, subGraphName }): Promise<ToolResult> => {
+    async ({ name, projectId, subGraphName }): Promise<ToolResult> => {
       const pid = resolveProject(projectId, config);
       if (!pid) return projectErr();
-      // CONTRACT §B: "all" | string[] | omitted. Pass "all" / omitted through as a
-      // full share (omitted ⇒ undefined ⇒ daemon default); a non-empty array is the
-      // subset. An empty array is rejected client-side (the daemon would 400 it) —
-      // fail fast, never coerce to "all" or omit.
-      if (Array.isArray(entities) && entities.length === 0) {
-        return errResult(
-          '"entities" must be omitted, the string "all", or a non-empty array of root entity URIs.',
-        );
-      }
-      // FIX K: trim each root-entity URI before forwarding — a whitespace-padded
-      // entity (" urn:a ") would otherwise reach the daemon with the spaces and
-      // resolve to the wrong (or no) root. Parity with Hermes.
-      const trimmedEntities = Array.isArray(entities) ? entities.map((e) => String(e).trim()) : entities;
       try {
-        // WM → SWM. The KA `swm/share` route is the same engine call
-        // (`agent.assertion.promote`) the legacy promote used; omit `entities`
-        // to share every root (the route's default), pass "all", or pass a subset.
         const result = await client.knowledgeAssetShare({
           contextGraphId: pid,
           name,
           subGraphName,
-          entities: trimmedEntities,
-          skipSeal,
         });
-        // A subset is a non-empty specific array (an empty array was rejected
-        // above; "all"/omitted is a full share). Reused for both the scope label
-        // and the not-publish-ready warning classification.
-        const isSubset = Array.isArray(entities);
-        const scope = isSubset
-          ? `${entities.length} entit${entities.length === 1 ? 'y' : 'ies'}`
-          : 'all root entities';
-        // #1116: surface the seal outcome. A full share seals by default
-        // (publishReady:true); when NOT publish-ready, classifyShareWarning picks
-        // the right of the three warnings from {sealed, publishReady, isSubset}.
         const warning = classifyShareWarning({
           sealed: result.sealed,
           publishReady: result.publishReady,
-          isSubset,
+          isSubset: false,
         });
         if (warning) {
           return ok(
-            `Shared ${scope} from knowledge asset '${name}' (project '${pid}') to SWM. ` +
+            `Atomic share for knowledge asset '${name}' (project '${pid}') did not complete. ` +
             `${warning}`,
           );
         }
         return ok(
-          `Shared ${scope} from knowledge asset '${name}' (project '${pid}') to SWM ` +
+          `Shared complete knowledge asset '${name}' (project '${pid}') to SWM ` +
           `(sealed:true, publish-ready).`,
         );
       } catch (e) {
@@ -857,7 +783,7 @@ export function registerAssertionTools(
       title: 'Dump Knowledge Asset Quads',
       description:
         'Return every quad in a knowledge asset\'s Working Memory DRAFT (the ' +
-        'un-shared working copy). Query it BEFORE sharing: a FULL share empties ' +
+        'un-shared working copy). Query it BEFORE sharing: an atomic share empties ' +
         'the WM draft, so a query after sharing returns 0 quads. To inspect ' +
         'already-shared content use `dkg_query` with `view: ' +
         '"shared-working-memory"` (or `"verifiable-memory"` once published). Not ' +

--- a/packages/mcp-dkg/src/tools/assertions.ts
+++ b/packages/mcp-dkg/src/tools/assertions.ts
@@ -67,6 +67,10 @@ export const SHARE_INCOMPLETE_PROMOTE_WARNING =
   'The complete sealed Knowledge Asset did not reach SWM and is not publish-ready; ' +
   'keep the Working Memory draft and retry the atomic share.';
 
+export const ATOMIC_SHARE_SIGNING_RECOVERY =
+  'Resolve the local signing capability, then retry the complete atomic ' +
+  'Knowledge Asset share from Working Memory.';
+
 /**
  * #1116: pick the not-publish-ready share warning from the share outcome. Returns
  * `undefined` when the share IS publish-ready (no warning). Branch precedence:
@@ -450,7 +454,7 @@ export function registerAssertionTools(
         // CONTRACT §C: scheme_version is a POSITIVE integer (daemon >= 1) — zod
         // rejects 0 / negative / non-integer at the boundary as a tool error.
         schemeVersion: z.number().int().positive().optional().describe('Optional attestation scheme version (positive integer)'),
-        layer: z.never().optional().describe('Retired: only Working Memory finalization is supported.'),
+        layer: z.literal('wm').optional().describe('Deprecated no-op compatibility value; omitted on the wire.'),
         projectId: z.string().optional().describe(`${EXISTING_CONTEXT_GRAPH_ID_DESCRIPTION} Defaults to .dkg/config.yaml.`),
         subGraphName: z.string().optional(),
       },
@@ -502,8 +506,8 @@ export function registerAssertionTools(
         'EXPLICITLY first (the default seal cannot carry them).',
       inputSchema: {
         name: z.string().describe('Existing knowledge asset name'),
-        entities: z.never().optional().describe('Retired: Knowledge Assets are shared atomically.'),
-        skipSeal: z.never().optional().describe('Retired: Knowledge Assets are always sealed before sharing.'),
+        entities: z.literal('all').optional().describe('Deprecated no-op compatibility value; omitted on the wire.'),
+        skipSeal: z.literal(false).optional().describe('Deprecated no-op compatibility value; omitted on the wire.'),
         projectId: z.string().optional().describe(`${EXISTING_CONTEXT_GRAPH_ID_DESCRIPTION} Defaults to .dkg/config.yaml.`),
         subGraphName: z.string().optional(),
       },
@@ -535,11 +539,12 @@ export function registerAssertionTools(
       } catch (e) {
         // #1116: a default (sealing) share that cannot seal fails CLOSED — the
         // daemon returns 409 UNSEALED_SHARE_BLOCKED with a recovery hint and WM
-        // preserved. Surface the recovery text verbatim so the agent can act.
+        // preserved. Older daemons recommend retired skipSeal/SWM-write modes;
+        // replace that hint with the only recovery supported by this client.
         if (e instanceof DkgHttpError && e.status === 409) {
-          const body = e.body as { code?: string; recovery?: string } | undefined;
-          if (body?.code === 'UNSEALED_SHARE_BLOCKED' && body.recovery) {
-            return errResult(body.recovery);
+          const body = e.body as { code?: string } | undefined;
+          if (body?.code === 'UNSEALED_SHARE_BLOCKED') {
+            return errResult(ATOMIC_SHARE_SIGNING_RECOVERY);
           }
         }
         return errResult(`Failed to share knowledge asset: ${formatError(e)}`);

--- a/packages/mcp-dkg/test/assertion-lifecycle.test.ts
+++ b/packages/mcp-dkg/test/assertion-lifecycle.test.ts
@@ -337,7 +337,7 @@ describe('assertion CRUD quintet — round-trip with @en literal preservation', 
     })).rejects.toThrow();
   });
 
-  it('share rejects the retired "all" sentinel instead of widening scope silently', async () => {
+  it('share accepts safe legacy defaults but omits them from the client call', async () => {
     const captured: Record<string, unknown> = {};
     const localClient = new FakeClient({
       knowledgeAssetShare: async (args) => {
@@ -348,10 +348,13 @@ describe('assertion CRUD quintet — round-trip with @en literal preservation', 
     const localServer = new FakeServer();
     registerAssertionTools(localServer.asMcpServer(), localClient.asDkgClient(), makeConfig());
 
-    await expect(
-      localServer.call('dkg_knowledge_asset_share', { name: 'doc', entities: 'all' }),
-    ).rejects.toThrow();
-    expect(captured).toEqual({});
+    const result = await localServer.call('dkg_knowledge_asset_share', {
+      name: 'doc', entities: 'all', skipSeal: false,
+    });
+    expect(result.isError).toBeFalsy();
+    expect(captured).toMatchObject({ contextGraphId: 'test-cg', name: 'doc' });
+    expect(captured).not.toHaveProperty('entities');
+    expect(captured).not.toHaveProperty('skipSeal');
   });
 
   it('share rejects root-selection arrays before invoking the client', async () => {
@@ -787,7 +790,7 @@ describe('rc.17 lifecycle verbs — finalize / publish / pull_from (parity with 
     expect(res.content[0].text).not.toContain('NOT publish-ready');
   });
 
-  it('share surfaces a 409 UNSEALED_SHARE_BLOCKED recovery verbatim (#1116)', async () => {
+  it('share replaces obsolete UNSEALED_SHARE_BLOCKED recovery with atomic guidance (#1116)', async () => {
     const recovery = 'No local signing key; pass skipSeal:true to share unsealed.';
     const localClient = new FakeClient({
       knowledgeAssetShare: async () => {
@@ -799,8 +802,9 @@ describe('rc.17 lifecycle verbs — finalize / publish / pull_from (parity with 
 
     const res = await localServer.call('dkg_knowledge_asset_share', { name: 'doc' });
     expect(res.isError).toBe(true);
-    // The handler surfaces the daemon's recovery hint verbatim as the tool error.
-    expect(res.content[0].text).toBe(recovery);
+    expect(res.content[0].text).toContain('Resolve the local signing capability');
+    expect(res.content[0].text).toContain('atomic Knowledge Asset share');
+    expect(res.content[0].text).not.toContain('skipSeal');
   });
 
   it('share falls back to the generic error for a non-matching 409 (#1116)', async () => {
@@ -832,6 +836,23 @@ describe('rc.17 lifecycle verbs — finalize / publish / pull_from (parity with 
       localServer.call('dkg_knowledge_asset_finalize', { name: 'doc', layer: 'swm' }),
     ).rejects.toThrow();
     expect(captured).toEqual({});
+  });
+
+  it('finalize accepts legacy layer:wm but omits it from the client call', async () => {
+    const captured: Record<string, unknown> = {};
+    const localClient = new FakeClient({
+      knowledgeAssetFinalize: async (args) => {
+        Object.assign(captured, args);
+        return { merkleRoot: '0xroot', eip712Digest: '0xdig', authorAddress: '0xtoken' };
+      },
+    });
+    const localServer = new FakeServer();
+    registerAssertionTools(localServer.asMcpServer(), localClient.asDkgClient(), makeConfig());
+
+    const result = await localServer.call('dkg_knowledge_asset_finalize', { name: 'doc', layer: 'wm' });
+    expect(result.isError).toBeFalsy();
+    expect(captured).toMatchObject({ contextGraphId: 'test-cg', name: 'doc' });
+    expect(captured).not.toHaveProperty('layer');
   });
 
   it('finalize rejects an invalid layer at the schema boundary (wm|swm enum) (#1116)', async () => {

--- a/packages/mcp-dkg/test/assertion-lifecycle.test.ts
+++ b/packages/mcp-dkg/test/assertion-lifecycle.test.ts
@@ -156,12 +156,9 @@ describe('assertion CRUD quintet — round-trip with @en literal preservation', 
     // Object stored verbatim — language-tagged literal is preserved in WM.
     expect(cellBeforeShare!.quads[0].object).toBe(langTagged);
 
-    const shared = await server.call('dkg_knowledge_asset_share', {
-      name: 'session-2026',
-      entities: ['urn:x:1'],
-    });
+    const shared = await server.call('dkg_knowledge_asset_share', { name: 'session-2026' });
     expect(shared.isError).toBeFalsy();
-    expect(shared.content[0].text).toMatch(/Shared 1 entity/);
+    expect(shared.content[0].text).toMatch(/Shared complete knowledge asset/);
 
     // After sharing `urn:x:1`, BOTH quads (both have subject `urn:x:1`) move
     // WM → SWM and are deleted from the WM draft — so a post-share WM query
@@ -329,21 +326,18 @@ describe('assertion CRUD quintet — round-trip with @en literal preservation', 
     ).rejects.toThrow();
   });
 
-  it('share rejects an empty entities array (must be omitted or non-empty)', async () => {
+  it('share rejects the retired entities field', async () => {
     await server.call('dkg_knowledge_asset_create', { name: 'rollback' });
     await server.call('dkg_knowledge_asset_write', {
       name: 'rollback',
       quads: [{ subject: 'urn:r', predicate: 'urn:p', object: '"v"' }],
     });
-    const result = await server.call('dkg_knowledge_asset_share', {
-      name: 'rollback',
-      entities: [],
-    });
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toMatch(/non-empty array/);
+    await expect(server.call('dkg_knowledge_asset_share', {
+      name: 'rollback', entities: [],
+    })).rejects.toThrow();
   });
 
-  it('share accepts the "all" sentinel and passes it through unchanged (CONTRACT §B)', async () => {
+  it('share rejects the retired "all" sentinel instead of widening scope silently', async () => {
     const captured: Record<string, unknown> = {};
     const localClient = new FakeClient({
       knowledgeAssetShare: async (args) => {
@@ -354,13 +348,13 @@ describe('assertion CRUD quintet — round-trip with @en literal preservation', 
     const localServer = new FakeServer();
     registerAssertionTools(localServer.asMcpServer(), localClient.asDkgClient(), makeConfig());
 
-    const res = await localServer.call('dkg_knowledge_asset_share', { name: 'doc', entities: 'all' });
-    expect(res.isError).toBeFalsy();
-    // CONTRACT §B: "all" is forwarded verbatim (NOT coerced to [] or omitted).
-    expect(captured.entities).toBe('all');
+    await expect(
+      localServer.call('dkg_knowledge_asset_share', { name: 'doc', entities: 'all' }),
+    ).rejects.toThrow();
+    expect(captured).toEqual({});
   });
 
-  it('share trims whitespace from each entity URI before forwarding (FIX K)', async () => {
+  it('share rejects root-selection arrays before invoking the client', async () => {
     const captured: Record<string, unknown> = {};
     const localClient = new FakeClient({
       knowledgeAssetShare: async (args) => {
@@ -371,13 +365,11 @@ describe('assertion CRUD quintet — round-trip with @en literal preservation', 
     const localServer = new FakeServer();
     registerAssertionTools(localServer.asMcpServer(), localClient.asDkgClient(), makeConfig());
 
-    const res = await localServer.call('dkg_knowledge_asset_share', {
+    await expect(localServer.call('dkg_knowledge_asset_share', {
       name: 'doc',
       entities: [' urn:root-1 ', '\turn:root-2\n'],
-    });
-    expect(res.isError).toBeFalsy();
-    // A whitespace-padded entity must reach the daemon trimmed (else wrong root).
-    expect(captured.entities).toEqual(['urn:root-1', 'urn:root-2']);
+    })).rejects.toThrow();
+    expect(captured).toEqual({});
   });
 
   it('discard marks the assertion discarded; subsequent writes fail', async () => {
@@ -706,10 +698,7 @@ describe('rc.17 lifecycle verbs — finalize / publish / pull_from (parity with 
     expect(res.content[0].text).toContain('WM_DRAFT_CONFLICT');
   });
 
-  // The crux of CONTRACT §5 (H2): a SUBSET share is NOT auto-sealed, so
-  // publish 409s; a FULL share (or an explicit finalize) seals and publish
-  // succeeds. This models the seal-before-publish invariant.
-  it('subset share → publish FAILS (not finalized); full share → publish SUCCEEDS', async () => {
+  it('atomic share seals the complete KA and makes it publishable', async () => {
     await server.call('dkg_knowledge_asset_create', { name: 'multi' });
     await server.call('dkg_knowledge_asset_write', {
       name: 'multi',
@@ -718,16 +707,6 @@ describe('rc.17 lifecycle verbs — finalize / publish / pull_from (parity with 
         { subject: 'urn:b', predicate: 'urn:p', object: '"b"' },
       ],
     });
-    // SUBSET share — SWM-only, NOT auto-sealed.
-    const subset = await server.call('dkg_knowledge_asset_share', { name: 'multi', entities: ['urn:a'] });
-    expect(subset.isError).toBeFalsy();
-    expect(client.assertions.get('test-cg::multi')!.finalized).toBe(false);
-
-    const failed = await server.call('dkg_knowledge_asset_publish', { name: 'multi' });
-    expect(failed.isError).toBe(true);
-    expect(failed.content[0].text).toContain('VM_PUBLISH_PRECONDITION');
-
-    // FULL share auto-seals → publish now succeeds and returns the UAL.
     const full = await server.call('dkg_knowledge_asset_share', { name: 'multi' });
     expect(full.isError).toBeFalsy();
     expect(client.assertions.get('test-cg::multi')!.finalized).toBe(true);
@@ -737,22 +716,22 @@ describe('rc.17 lifecycle verbs — finalize / publish / pull_from (parity with 
     expect(ok.content[0].text).toContain('"ual"');
   });
 
-  it('explicit finalize before a subset share also makes publish succeed', async () => {
+  it('explicit finalize before atomic share also makes publish succeed', async () => {
     await server.call('dkg_knowledge_asset_create', { name: 'sealed' });
     await server.call('dkg_knowledge_asset_write', {
       name: 'sealed',
       quads: [{ subject: 'urn:a', predicate: 'urn:p', object: '"a"' }],
     });
     await server.call('dkg_knowledge_asset_finalize', { name: 'sealed' });
-    await server.call('dkg_knowledge_asset_share', { name: 'sealed', entities: ['urn:a'] });
+    await server.call('dkg_knowledge_asset_share', { name: 'sealed' });
     const res = await server.call('dkg_knowledge_asset_publish', { name: 'sealed' });
     expect(res.isError).toBeFalsy();
     expect(res.content[0].text).toContain('"ual"');
   });
 
-  // ── #1116 share seal: skipSeal forwarding + publishReady warning branch ──
+  // ── Atomic-share boundary + defensive mixed-version warnings ──
 
-  it('share forwards skipSeal:true to the client (#1116)', async () => {
+  it('share rejects skipSeal before invoking the client', async () => {
     const captured: Record<string, unknown> = {};
     const localClient = new FakeClient({
       knowledgeAssetShare: async (args) => {
@@ -763,44 +742,26 @@ describe('rc.17 lifecycle verbs — finalize / publish / pull_from (parity with 
     const localServer = new FakeServer();
     registerAssertionTools(localServer.asMcpServer(), localClient.asDkgClient(), makeConfig());
 
-    const res = await localServer.call('dkg_knowledge_asset_share', { name: 'doc', skipSeal: true });
-    expect(res.isError).toBeFalsy();
-    expect(captured.skipSeal).toBe(true);
+    await expect(
+      localServer.call('dkg_knowledge_asset_share', { name: 'doc', skipSeal: true }),
+    ).rejects.toThrow();
+    expect(captured).toEqual({});
   });
 
-  it('share with publishReady:false on a FULL share emits the seal-it warning (#1116)', async () => {
+  it('share with publishReady:false emits an atomic retry warning', async () => {
     const localClient = new FakeClient({
       knowledgeAssetShare: async () => ({ swmShared: true, promotedCount: 2, sealed: false, publishReady: false }),
     });
     const localServer = new FakeServer();
     registerAssertionTools(localServer.asMcpServer(), localClient.asDkgClient(), makeConfig());
 
-    // A skipSeal FULL share IS sealable later → the "seal it with finalize" hint.
-    const res = await localServer.call('dkg_knowledge_asset_share', { name: 'doc', skipSeal: true });
+    const res = await localServer.call('dkg_knowledge_asset_share', { name: 'doc' });
     expect(res.isError).toBeFalsy();
-    expect(res.content[0].text).toContain('NOT publish-ready (sealed:false)');
-    expect(res.content[0].text).toContain('layer:swm works after sharing');
-    expect(res.content[0].text).not.toContain('NOT sealable');
+    expect(res.content[0].text).toContain('did not become publish-ready (sealed:false)');
+    expect(res.content[0].text).toContain('retry the complete Knowledge Asset share');
   });
 
-  it('share with publishReady:false on a SUBSET emits the not-sealable warning (#1116)', async () => {
-    const localClient = new FakeClient({
-      knowledgeAssetShare: async () => ({ swmShared: true, promotedCount: 1, sealed: false, publishReady: false }),
-    });
-    const localServer = new FakeServer();
-    registerAssertionTools(localServer.asMcpServer(), localClient.asDkgClient(), makeConfig());
-
-    // A subset is NOT sealable (finalize layer:swm rejects it) → full-share / new-asset recovery.
-    const res = await localServer.call('dkg_knowledge_asset_share', { name: 'doc', entities: ['urn:a'] });
-    expect(res.isError).toBeFalsy();
-    expect(res.content[0].text).toContain('A subset is NOT sealable/publishable');
-    expect(res.content[0].text).toContain('entities:"all"');
-    expect(res.content[0].text).not.toContain('Seal it with');
-  });
-
-  it('share with sealed:true + publishReady:false (incomplete full promote) warns NOT to finalize layer:swm (#1116)', async () => {
-    // A FULL share that sealed but did NOT promote every root (foreign-owned roots
-    // skipped) → swmShareComplete marker NOT set → finalize layer:swm would REJECT.
+  it('share with sealed:true + publishReady:false emits the incomplete atomic warning', async () => {
     const localClient = new FakeClient({
       knowledgeAssetShare: async () => ({ swmShared: true, promotedCount: 1, sealed: true, publishReady: false }),
     });
@@ -809,11 +770,8 @@ describe('rc.17 lifecycle verbs — finalize / publish / pull_from (parity with 
 
     const res = await localServer.call('dkg_knowledge_asset_share', { name: 'doc' });
     expect(res.isError).toBeFalsy();
-    expect(res.content[0].text).toContain('not all roots reached SWM');
-    expect(res.content[0].text).toContain('re-share the full asset');
-    // Must NOT recommend the dead-end finalize layer:swm here (it would reject).
-    expect(res.content[0].text).not.toContain('layer:swm works after sharing');
-    expect(res.content[0].text).not.toContain('NOT sealable');
+    expect(res.content[0].text).toContain('complete sealed Knowledge Asset did not reach SWM');
+    expect(res.content[0].text).toContain('retry the atomic share');
   });
 
   it('share with publishReady:true emits NO warning, reports sealed + publish-ready (#1116)', async () => {
@@ -859,7 +817,7 @@ describe('rc.17 lifecycle verbs — finalize / publish / pull_from (parity with 
     expect(res.content[0].text).toMatch(/Failed to share knowledge asset/);
   });
 
-  it('finalize forwards layer:"swm" to the client (#1116)', async () => {
+  it('finalize rejects the retired layer field before invoking the client', async () => {
     const captured: Record<string, unknown> = {};
     const localClient = new FakeClient({
       knowledgeAssetFinalize: async (args) => {
@@ -870,9 +828,10 @@ describe('rc.17 lifecycle verbs — finalize / publish / pull_from (parity with 
     const localServer = new FakeServer();
     registerAssertionTools(localServer.asMcpServer(), localClient.asDkgClient(), makeConfig());
 
-    const res = await localServer.call('dkg_knowledge_asset_finalize', { name: 'doc', layer: 'swm' });
-    expect(res.isError).toBeFalsy();
-    expect(captured.layer).toBe('swm');
+    await expect(
+      localServer.call('dkg_knowledge_asset_finalize', { name: 'doc', layer: 'swm' }),
+    ).rejects.toThrow();
+    expect(captured).toEqual({});
   });
 
   it('finalize rejects an invalid layer at the schema boundary (wm|swm enum) (#1116)', async () => {

--- a/packages/mcp-dkg/test/capture-chat-atomic-share.test.ts
+++ b/packages/mcp-dkg/test/capture-chat-atomic-share.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { shareAssertionAtomically } from '../hooks/capture-chat.mjs';
+
+describe('capture-chat atomic sharing', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('shares the complete per-turn assertion without a retired entities selector', async () => {
+    const fetcher = vi.fn(async (_url: string, init?: RequestInit) =>
+      new Response(JSON.stringify({
+        swmShared: true,
+        promotedCount: 7,
+        sealed: true,
+        publishReady: true,
+        shareOperationId: 'turn-share-1',
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } }));
+    vi.stubGlobal('fetch', fetcher);
+
+    const result = await shareAssertionAtomically({
+      api: 'http://127.0.0.1:9200',
+      project: 'team-cg',
+      subGraph: 'chat',
+      token: 'secret',
+    }, 'chat-session-turn-1');
+
+    expect(result).toMatchObject({ swmShared: true, sealed: true, publishReady: true });
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    const [url, init] = fetcher.mock.calls[0];
+    expect(url).toBe('http://127.0.0.1:9200/api/knowledge-assets/chat-session-turn-1/swm/share');
+    expect(JSON.parse(String(init?.body))).toEqual({
+      contextGraphId: 'team-cg',
+      subGraphName: 'chat',
+    });
+  });
+});

--- a/packages/mcp-dkg/test/knowledge-assets-client.test.ts
+++ b/packages/mcp-dkg/test/knowledge-assets-client.test.ts
@@ -200,6 +200,32 @@ describe('DkgClient knowledge-assets — publish/finalize option serialization',
     expect(calls[0].body).not.toHaveProperty('entities');
   });
 
+  it('keeps promoteAssertion as a deprecated alias for complete atomic sharing', async () => {
+    const { client, calls } = makeClient();
+    await client.promoteAssertion({
+      contextGraphId: 'cg-1', assertionName: 'legacy', subGraphName: 'sg', entities: 'all',
+    });
+    await client.promoteAssertion({ contextGraphId: 'cg-1', assertionName: 'legacy-default' });
+
+    expect(calls).toHaveLength(2);
+    expect(calls[0]).toEqual({
+      url: expect.stringContaining('/api/knowledge-assets/legacy/swm/share'),
+      body: { contextGraphId: 'cg-1', subGraphName: 'sg' },
+    });
+    expect(calls[1]).toEqual({
+      url: expect.stringContaining('/api/knowledge-assets/legacy-default/swm/share'),
+      body: { contextGraphId: 'cg-1' },
+    });
+  });
+
+  it('makes legacy promoteAssertion subsets fail through the atomic share guard before HTTP', async () => {
+    const { client, calls } = makeClient();
+    await expect(client.promoteAssertion({
+      contextGraphId: 'cg-1', assertionName: 'legacy', entities: ['urn:x'],
+    })).rejects.toMatchObject({ code: 'KA_ATOMIC_SHARE_REQUIRED' });
+    expect(calls).toHaveLength(0);
+  });
+
   it('createKnowledgeAsset translates an alsoPublishVm options object', async () => {
     const { client, calls } = makeClient();
     await client.createKnowledgeAsset({

--- a/packages/mcp-dkg/test/knowledge-assets-client.test.ts
+++ b/packages/mcp-dkg/test/knowledge-assets-client.test.ts
@@ -150,13 +150,12 @@ describe('DkgClient knowledge-assets — publish/finalize option serialization',
     expect(calls).toHaveLength(0);
   });
 
-  // #1116 — the `layer` field must reach the wire (FakeClient tests only prove the
-  // tool→client arg pass-through; this pins the actual POST body).
-  it('knowledgeAssetFinalize puts layer:"swm" in the POST body', async () => {
+  it('knowledgeAssetFinalize rejects the retired SWM write bridge before HTTP', async () => {
     const { client, calls } = makeClient();
-    await client.knowledgeAssetFinalize({ contextGraphId: 'cg-1', name: 'f', layer: 'swm' });
-    expect(calls[0].url).toContain('/api/knowledge-assets/f/wm/finalize');
-    expect(calls[0].body).toMatchObject({ contextGraphId: 'cg-1', layer: 'swm' });
+    await expect(
+      client.knowledgeAssetFinalize({ contextGraphId: 'cg-1', name: 'f', layer: 'swm' }),
+    ).rejects.toMatchObject({ code: 'LEGACY_KA_READ_ONLY' });
+    expect(calls).toHaveLength(0);
   });
 
   it('knowledgeAssetFinalize omits the layer key when not passed', async () => {
@@ -165,15 +164,27 @@ describe('DkgClient knowledge-assets — publish/finalize option serialization',
     expect(calls[0].body).not.toHaveProperty('layer');
   });
 
-  // #1116 — the `skipSeal` field must reach the wire.
-  it('knowledgeAssetShare puts skipSeal:true in the POST body', async () => {
+  it('knowledgeAssetShare rejects unsealed sharing before HTTP', async () => {
     const { client, calls } = makeClient();
-    await client.knowledgeAssetShare({ contextGraphId: 'cg-1', name: 'f', skipSeal: true });
-    expect(calls[0].url).toContain('/api/knowledge-assets/f/swm/share');
-    expect(calls[0].body).toMatchObject({ contextGraphId: 'cg-1', skipSeal: true });
+    await expect(
+      client.knowledgeAssetShare({ contextGraphId: 'cg-1', name: 'f', skipSeal: true }),
+    ).rejects.toMatchObject({ code: 'UNSEALED_SHARE_BLOCKED' });
+    expect(calls).toHaveLength(0);
   });
 
-  it('knowledgeAssetShare omits skipSeal (and entities) when not passed', async () => {
+  it('knowledgeAssetShare rejects root selection and emits no legacy fields for atomic share', async () => {
+    const rejected = makeClient();
+    await expect(
+      rejected.client.knowledgeAssetShare({ contextGraphId: 'cg-1', name: 'f', entities: ['urn:x'] }),
+    ).rejects.toMatchObject({ code: 'KA_ATOMIC_SHARE_REQUIRED' });
+    await expect(
+      rejected.client.knowledgeAssetShare({ contextGraphId: 'cg-1', name: 'f', entities: 'urn:not-all' as any }),
+    ).rejects.toMatchObject({ code: 'KA_ATOMIC_SHARE_REQUIRED' });
+    await expect(
+      rejected.client.knowledgeAssetShare({ contextGraphId: 'cg-1', name: 'f', skipSeal: 'yes' as any }),
+    ).rejects.toThrow('skipSeal must be false or omitted');
+    expect(rejected.calls).toHaveLength(0);
+
     const { client, calls } = makeClient();
     await client.knowledgeAssetShare({ contextGraphId: 'cg-1', name: 'f' });
     expect(calls[0].body).toEqual({ contextGraphId: 'cg-1' });

--- a/packages/mcp-dkg/test/knowledge-assets-client.test.ts
+++ b/packages/mcp-dkg/test/knowledge-assets-client.test.ts
@@ -164,6 +164,12 @@ describe('DkgClient knowledge-assets — publish/finalize option serialization',
     expect(calls[0].body).not.toHaveProperty('layer');
   });
 
+  it('knowledgeAssetFinalize accepts legacy layer:wm but omits it from the wire', async () => {
+    const { client, calls } = makeClient();
+    await client.knowledgeAssetFinalize({ contextGraphId: 'cg-1', name: 'f', layer: 'wm' });
+    expect(calls[0].body).toEqual({ contextGraphId: 'cg-1' });
+  });
+
   it('knowledgeAssetShare rejects unsealed sharing before HTTP', async () => {
     const { client, calls } = makeClient();
     await expect(
@@ -186,7 +192,9 @@ describe('DkgClient knowledge-assets — publish/finalize option serialization',
     expect(rejected.calls).toHaveLength(0);
 
     const { client, calls } = makeClient();
-    await client.knowledgeAssetShare({ contextGraphId: 'cg-1', name: 'f' });
+    await client.knowledgeAssetShare({
+      contextGraphId: 'cg-1', name: 'f', entities: 'all', skipSeal: false,
+    });
     expect(calls[0].body).toEqual({ contextGraphId: 'cg-1' });
     expect(calls[0].body).not.toHaveProperty('skipSeal');
     expect(calls[0].body).not.toHaveProperty('entities');

--- a/packages/mcp-dkg/test/manifest-atomic-share.test.ts
+++ b/packages/mcp-dkg/test/manifest-atomic-share.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { DkgClient } from '../src/client.js';
+import { publishManifest } from '../src/manifest/publish.js';
+import { makeConfig } from './harness.js';
+
+function makeClient(shareResponse: Record<string, unknown>) {
+  const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+  const client = new DkgClient({
+    config: makeConfig(),
+    fetcher: (async (url, init) => {
+      const body = JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>;
+      calls.push({ url: String(url), body });
+      const payload = String(url).endsWith('/swm/share') ? shareResponse : {};
+      return new Response(JSON.stringify(payload), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }) as typeof fetch,
+  });
+  return { client, calls };
+}
+
+const manifestInput = {
+  contextGraphId: 'team-cg',
+  network: 'testnet' as const,
+  supportedTools: ['claude-code'] as const,
+  publisherAgentUri: 'did:dkg:agent:publisher',
+  templates: {
+    agentsMd: { encodingFormat: 'text/markdown', text: '# Agent rules' },
+  },
+};
+
+describe('manifest publishing atomic share', () => {
+  it('reports success only after the complete manifest reaches SWM', async () => {
+    const { client, calls } = makeClient({
+      swmShared: true,
+      promotedCount: 0,
+      sealed: true,
+      publishReady: true,
+      shareOperationId: 'manifest-share-1',
+    });
+
+    const result = await publishManifest({ ...manifestInput, client });
+    expect(result.tripleCount).toBeGreaterThan(0);
+    const share = calls.find((call) => call.url.endsWith('/project-manifest/swm/share'));
+    expect(share?.body).toEqual({ contextGraphId: 'team-cg', subGraphName: 'meta' });
+    expect(share?.body).not.toHaveProperty('entities');
+  });
+
+  it('fails instead of reporting success when the atomic share is incomplete', async () => {
+    const { client } = makeClient({
+      swmShared: false,
+      promotedCount: 0,
+      sealed: false,
+      publishReady: false,
+    });
+
+    await expect(publishManifest({ ...manifestInput, client }))
+      .rejects.toThrow('Manifest atomic share did not reach SWM');
+  });
+});

--- a/packages/mcp-dkg/test/share-warning-parity.test.ts
+++ b/packages/mcp-dkg/test/share-warning-parity.test.ts
@@ -22,7 +22,7 @@ const fixture = JSON.parse(
 describe('#1116 share-warning parity (MCP vs canonical fixture)', () => {
   it('SHARE_NOT_PUBLISH_READY_WARNING matches the fixture byte-for-byte', () => {
     expect(SHARE_NOT_PUBLISH_READY_WARNING).toBe(fixture.SHARE_NOT_PUBLISH_READY_WARNING);
-    expect(SHARE_NOT_PUBLISH_READY_WARNING).toContain('preserved Working Memory draft');
+    expect(SHARE_NOT_PUBLISH_READY_WARNING).toContain('Keep the Working Memory draft');
     expect(SHARE_NOT_PUBLISH_READY_WARNING).not.toMatch(/pull(?:-|\s)from|pull the asset/i);
   });
 

--- a/tests/fixtures/share-seal-warnings.json
+++ b/tests/fixtures/share-seal-warnings.json
@@ -1,6 +1,6 @@
 {
   "_comment": "#1116 — canonical share-outcome warning strings. The MCP, OpenClaw, and Hermes adapters each keep their own copy of these three constants (no shared module: MCP deliberately has no dkg-core dependency, and creating a package is out of scope). Each adapter's test suite asserts its constants are byte-identical to these values, so drift is caught by a test, not a code comment. If you change a warning, update it HERE and in all three adapters; the parity tests will flag any mismatch.",
-  "SHARE_NOT_PUBLISH_READY_WARNING": "Shared to SWM but NOT publish-ready (sealed:false). Seal it with dkg_knowledge_asset_finalize (layer:swm works after sharing), then publish.",
-  "SHARE_SUBSET_NOT_PUBLISH_READY_WARNING": "Shared a SUBSET to SWM for peer visibility. A subset is NOT sealable/publishable (finalize layer:swm will reject it). To publish on-chain, share the full asset (entities:\"all\"), or model this subset as its own knowledge asset.",
-  "SHARE_INCOMPLETE_PROMOTE_WARNING": "Sealed, but not all roots reached SWM (some roots may be owned by other agents) — not yet publishable; re-share the full asset so every sealed root is in SWM."
+  "SHARE_NOT_PUBLISH_READY_WARNING": "The atomic SWM share did not become publish-ready (sealed:false). Keep the Working Memory draft and retry the complete Knowledge Asset share; do not publish it.",
+  "SHARE_SUBSET_NOT_PUBLISH_READY_WARNING": "A legacy partial-share outcome was reported. Root-scoped subsets are read-only and not publishable; model the intended data as its own Knowledge Asset and share it atomically.",
+  "SHARE_INCOMPLETE_PROMOTE_WARNING": "The complete sealed Knowledge Asset did not reach SWM and is not publish-ready; keep the Working Memory draft and retry the atomic share."
 }


### PR DESCRIPTION
## Summary

- make MCP, OpenClaw, and Hermes expose complete Knowledge Asset sharing as the only supported write path
- reject legacy root-entity subsets, unsealed shares, and SWM finalization before they reach the daemon
- preserve compatibility-only neutral values such as `entities: "all"`, `skipSeal: false`, and `layer: "wm"` without serializing legacy write controls
- keep SWM and VM `pull-from` reads intact and update mixed-version recovery warnings
- prevent old callers from being silently widened into a complete atomic share

## Validation

- `pnpm --filter @origintrail-official/dkg-mcp build`
- `pnpm --filter @origintrail-official/dkg-adapter-openclaw build`
- `pnpm --filter @origintrail-official/dkg-adapter-hermes build`
- MCP: 331/331 tests passed
- OpenClaw: 1,097/1,097 tests passed
- Hermes TypeScript: 92/92 tests passed
- Hermes Python: 148/148 tests passed

## Stack

This PR is stacked on #1726 and should be reviewed after that layer.