### PR TITLE
refactor(node-ui): share Knowledge Assets atomically

### DIFF
--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -831,14 +831,19 @@ export const knowledgeAssetFinalize = (
     authorAgentAddress?: string;
     preSignedAuthorAttestation?: PreSignedAuthorAttestationPayload;
     schemeVersion?: number;
-    // #1116 — `layer:"swm"` seals content already shared to SWM (the daemon
-    // reconstructs a transient WM draft from SWM, finalizes, drops the draft);
-    // default ("wm") seals the open Working-Memory draft. Lets a publish path
-    // seal an unsealed-in-SWM asset in place before retrying /vm/publish.
+    /** @deprecated Only Working Memory finalization is supported. */
     layer?: 'wm' | 'swm';
   } = {},
 ) => {
   assertExclusiveAuthorFields(opts);
+  if (opts.layer === 'swm') {
+    throw Object.assign(new Error('Legacy root-scoped Knowledge Assets are read-only'), {
+      code: 'LEGACY_KA_READ_ONLY',
+    });
+  }
+  if (opts.layer !== undefined && opts.layer !== 'wm') {
+    throw new TypeError('Only Working Memory finalization is supported');
+  }
   return post<{ merkleRoot: string; eip712Digest: string }>(
     `/api/knowledge-assets/${encodeURIComponent(name)}/wm/finalize`,
     { contextGraphId: normalizeContextGraphId(contextGraphId), ...opts },
@@ -868,16 +873,44 @@ export const knowledgeAssetPullFrom = (
     { contextGraphId: normalizeContextGraphId(contextGraphId), layer, ...opts },
   );
 
-/** Advance the SWM pointer (WM → SWM; git push origin <branch>). */
+/** Atomically seal and share the complete WM Knowledge Asset to SWM. */
 export const knowledgeAssetShare = (
   contextGraphId: string,
   name: string,
-  opts: { subGraphName?: string; entities?: string[] | 'all' } = {},
-) =>
-  post<{ swmShared: boolean; promotedCount: number }>(
+  opts: {
+    subGraphName?: string;
+    /** @deprecated Knowledge Assets are shared atomically. */
+    entities?: string[] | 'all';
+    /** @deprecated Unsealed Knowledge Asset shares are unsupported. */
+    skipSeal?: boolean;
+  } = {},
+) => {
+  if (Array.isArray(opts.entities)) {
+    throw Object.assign(new Error('Knowledge Assets are shared atomically; root-entity selection is not supported'), {
+      code: 'KA_ATOMIC_SHARE_REQUIRED',
+    });
+  }
+  if (opts.entities !== undefined && opts.entities !== 'all') {
+    throw Object.assign(new Error('Knowledge Assets are shared atomically; omit entities to share the complete asset'), {
+      code: 'KA_ATOMIC_SHARE_REQUIRED',
+    });
+  }
+  if (opts.skipSeal === true) {
+    throw Object.assign(new Error('Knowledge Assets are always sealed before sharing'), {
+      code: 'UNSEALED_SHARE_BLOCKED',
+    });
+  }
+  if (opts.skipSeal !== undefined && opts.skipSeal !== false) {
+    throw new TypeError('skipSeal must be false or omitted');
+  }
+  return post<{ swmShared: boolean; promotedCount: number; sealed: boolean; publishReady: boolean }>(
     `/api/knowledge-assets/${encodeURIComponent(name)}/swm/share`,
-    { contextGraphId: normalizeContextGraphId(contextGraphId), ...opts },
+    {
+      contextGraphId: normalizeContextGraphId(contextGraphId),
+      ...(opts.subGraphName ? { subGraphName: opts.subGraphName } : {}),
+    },
   );
+};
 
 /** Publish to VM — mint or update on chain (git push origin main). */
 export const knowledgeAssetPublish = (
@@ -897,71 +930,23 @@ export const knowledgeAssetPublish = (
 };
 
 /**
- * Thrown by `knowledgeAssetPublishWithSeal` when a SWM asset can't be sealed in
- * place because only a subset of it was shared (daemon `SWM_SUBSET_NOT_SEALABLE`).
- * The UI surfaces this as "share the full asset first" — it is NOT retried.
- */
-export class SwmSubsetNotSealableError extends Error {
-  constructor(message?: string) {
-    super(message ?? 'Share the full asset to Shared Memory before publishing.');
-    this.name = 'SwmSubsetNotSealableError';
-  }
-}
-
-/**
- * Publish a named SWM assertion to VM, sealing it in place first if the daemon
- * reports it isn't finalized (the #1116 / §4.4 catch→seal→retry contract).
- *
- * Normal path: by the time content reaches SWM it is sealed (seal-on-share is
- * the default), so the first `/vm/publish` succeeds. This is the robustness
- * safety net for the rare unsealed-in-SWM case:
- *   - `PUBLISH_NOT_FULL_SHARE` / `VM_PUBLISH_PRECONDITION` (409) → seal in place
- *     via `wm/finalize {layer:"swm"}`, then retry publish ONCE.
- *   - `SWM_SUBSET_NOT_SEALABLE` (409, on the seal) → throw
- *     `SwmSubsetNotSealableError` (caller tells the user to share the full
- *     asset); never loops.
- * `sealed` in the result tells the caller a seal step ran so it can surface
- * "sealing then publishing" instead of a silent skip.
+ * Publish a named, already-sealed SWM Knowledge Asset to VM.
  *
  * A daemon HTTP-207 partial publish (KA minted on-chain but the context-graph
  * binding failed) comes back as `res.ok`, so it is NOT thrown — the body
  * carries `contextGraphError`. Callers MUST check that field and surface a
  * partial/warning state rather than treating it as a clean success.
+ *
+ * The historical function name is retained for UI source compatibility. It no
+ * longer finalizes or mutates SWM: legacy root-scoped SWM assets are read-only,
+ * and a publish precondition is surfaced to the caller without retrying.
  */
 export async function knowledgeAssetPublishWithSeal(
   contextGraphId: string,
   name: string,
   opts: { subGraphName?: string } & KnowledgeAssetFinalizedPublishOptions = {},
-): Promise<Record<string, unknown> & { sealed?: boolean; contextGraphError?: string }> {
-  try {
-    return await knowledgeAssetPublish(contextGraphId, name, opts);
-  } catch (err: unknown) {
-    const code =
-      err instanceof HttpError && err.status === 409
-        ? (err.body as { code?: string } | undefined)?.code
-        : undefined;
-    if (code !== 'PUBLISH_NOT_FULL_SHARE' && code !== 'VM_PUBLISH_PRECONDITION') throw err;
-    // Unsealed in SWM — seal in place, then retry the publish once.
-    try {
-      await knowledgeAssetFinalize(contextGraphId, name, {
-        layer: 'swm',
-        ...(opts.subGraphName ? { subGraphName: opts.subGraphName } : {}),
-      });
-    } catch (sealErr: unknown) {
-      if (
-        sealErr instanceof HttpError &&
-        sealErr.status === 409 &&
-        (sealErr.body as { code?: string } | undefined)?.code === 'SWM_SUBSET_NOT_SEALABLE'
-      ) {
-        throw new SwmSubsetNotSealableError(
-          (sealErr.body as { error?: string } | undefined)?.error,
-        );
-      }
-      throw sealErr;
-    }
-    const result = await knowledgeAssetPublish(contextGraphId, name, opts);
-    return { ...result, sealed: true };
-  }
+): Promise<Record<string, unknown> & { contextGraphError?: string }> {
+  return knowledgeAssetPublish(contextGraphId, name, opts);
 }
 
 /**
@@ -971,7 +956,6 @@ export async function knowledgeAssetPublishWithSeal(
 export interface BatchPublishResult {
   published: number;
   total: number;
-  sealed: number;        // how many needed an in-place seal before publishing
   partial: number;       // how many minted on-chain but failed the CG binding (207)
   partialError?: string; // a sample contextGraphError detail (the first 207's reason)
   // Every per-KA failure (not just the last), so callers can report the count + the
@@ -988,7 +972,7 @@ export interface BatchPublishResult {
 
 /**
  * Publish each named SWM assertion to Verifiable Memory through
- * `knowledgeAssetPublishWithSeal` (seal-in-SWM retry + 207 partial handling), aggregating
+ * `knowledgeAssetPublishWithSeal` (direct publish + 207 partial handling), aggregating
  * into ONE `BatchPublishResult`. The canonical batch-publish loop reused by every CTA
  * (MemoryLayerView / entities / layer-widgets) so the partial-detail, sample, and per-KA
  * error accounting cannot drift between them. Per-KA failures are collected into
@@ -999,7 +983,6 @@ export async function publishAssertionsToVm(
   items: Array<{ name: string; subGraph?: string }>,
 ): Promise<BatchPublishResult> {
   let published = 0;
-  let sealed = 0;
   let partial = 0;
   let firstPartialError: string | undefined;
   const failures: BatchPublishResult['failures'] = [];
@@ -1024,7 +1007,6 @@ export async function publishAssertionsToVm(
         a.subGraph ? { subGraphName: a.subGraph } : {},
       );
       published += 1;
-      if (res.sealed) sealed += 1;
       // PR #972 — a 207 partial: minted on-chain but the CG binding failed.
       if (res.contextGraphError) {
         partial += 1;
@@ -1052,10 +1034,7 @@ export async function publishAssertionsToVm(
         }
       }
     } catch (err: unknown) {
-      const message =
-        err instanceof SwmSubsetNotSealableError
-          ? err.message
-          : (err as { message?: string })?.message ?? 'publish failed';
+      const message = (err as { message?: string })?.message ?? 'publish failed';
       failures.push({ name: a.name, ...(a.subGraph ? { subGraph: a.subGraph } : {}), error: message });
     }
   }
@@ -1069,7 +1048,7 @@ export async function publishAssertionsToVm(
         drawnFromTopUp: aggDrawnTopUp.toString(),
       }
     : undefined;
-  return { published, total: items.length, sealed, partial, partialError: firstPartialError, failures, sample, convictionCostCovered };
+  return { published, total: items.length, partial, partialError: firstPartialError, failures, sample, convictionCostCovered };
 }
 
 // --- Assertions (WM objects) ---
@@ -1406,27 +1385,42 @@ export async function listAssertions(
 }
 
 /**
- * Promote an assertion from WM to SWM.
+ * Atomically seal and share a complete assertion from WM to SWM.
  *
- * PR #710 fix — `subGraphName` is the third part of the daemon's
- * lookup key alongside `(contextGraphId, assertionName)`. Without
- * it, promoting a sub-graph-scoped assertion either 404s or
- * silently promotes a same-named root-bucket assertion. The
- * daemon route already accepts the field
- * (`packages/cli/src/daemon/routes/assertion.ts:820-823`); only
- * spread it when supplied so root-bucket promotes keep the prior
- * wire shape.
+ * `subGraphName` is part of the daemon lookup key alongside
+ * `(contextGraphId, assertionName)`, so callers must preserve it for
+ * sub-graph-scoped assets. The legacy positional `"all"` form remains a
+ * neutral compatibility input, but root-entity arrays are rejected before
+ * any request so an old subset caller can never be silently widened.
  */
 export const promoteAssertion = (
   contextGraphId: string,
   assertionName: string,
-  entities: string | string[] = 'all',
-  subGraphName?: string,
-) =>
-  post<{ promotedCount: number }>(
+  optionsOrLegacyEntities: { subGraphName?: string } | string | string[] = {},
+  legacySubGraphName?: string,
+) => {
+  if (Array.isArray(optionsOrLegacyEntities)) {
+    throw Object.assign(new Error('Knowledge Assets are shared atomically; root-entity selection is not supported'), {
+      code: 'KA_ATOMIC_SHARE_REQUIRED',
+    });
+  }
+  if (typeof optionsOrLegacyEntities === 'string' && optionsOrLegacyEntities !== 'all') {
+    throw Object.assign(new Error('Knowledge Assets are shared atomically; omit entities to share the complete asset'), {
+      code: 'KA_ATOMIC_SHARE_REQUIRED',
+    });
+  }
+  const subGraphName =
+    typeof optionsOrLegacyEntities === 'string'
+      ? legacySubGraphName
+      : optionsOrLegacyEntities.subGraphName;
+  return post<{ promotedCount: number; sealed: boolean; publishReady: boolean }>(
     `/api/knowledge-assets/${encodeURIComponent(assertionName)}/swm/share`,
-    { contextGraphId, entities, ...(subGraphName ? { subGraphName } : {}) },
+    {
+      contextGraphId: normalizeContextGraphId(contextGraphId),
+      ...(subGraphName ? { subGraphName } : {}),
+    },
   );
+};
 
 // Issue #864 — central UI translator for `promoteAssertion` outcomes so
 // every call-site speaks the same language. Two shapes get massaged

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -822,31 +822,42 @@ export const knowledgeAssetWrite = (
     { contextGraphId: normalizeContextGraphId(contextGraphId), quads, ...opts },
   );
 
+export interface KnowledgeAssetFinalizeOptions {
+  subGraphName?: string;
+  authorAgentAddress?: string;
+  preSignedAuthorAttestation?: PreSignedAuthorAttestationPayload;
+  schemeVersion?: number;
+  /** Deprecated neutral compatibility value; never serialized. */
+  layer?: 'wm';
+}
+
 /** Seal the WM draft — computes the merkle root + signs the seal (git commit). */
 export const knowledgeAssetFinalize = (
   contextGraphId: string,
   name: string,
-  opts: {
-    subGraphName?: string;
-    authorAgentAddress?: string;
-    preSignedAuthorAttestation?: PreSignedAuthorAttestationPayload;
-    schemeVersion?: number;
-    /** @deprecated Only Working Memory finalization is supported. */
-    layer?: 'wm' | 'swm';
-  } = {},
+  opts: KnowledgeAssetFinalizeOptions = {},
 ) => {
   assertExclusiveAuthorFields(opts);
-  if (opts.layer === 'swm') {
+  const legacyLayer = (opts as { layer?: unknown }).layer;
+  if (legacyLayer === 'swm') {
     throw Object.assign(new Error('Legacy root-scoped Knowledge Assets are read-only'), {
       code: 'LEGACY_KA_READ_ONLY',
     });
   }
-  if (opts.layer !== undefined && opts.layer !== 'wm') {
+  if (legacyLayer !== undefined && legacyLayer !== 'wm') {
     throw new TypeError('Only Working Memory finalization is supported');
   }
   return post<{ merkleRoot: string; eip712Digest: string }>(
     `/api/knowledge-assets/${encodeURIComponent(name)}/wm/finalize`,
-    { contextGraphId: normalizeContextGraphId(contextGraphId), ...opts },
+    {
+      contextGraphId: normalizeContextGraphId(contextGraphId),
+      ...(opts.subGraphName ? { subGraphName: opts.subGraphName } : {}),
+      ...(opts.authorAgentAddress ? { authorAgentAddress: opts.authorAgentAddress } : {}),
+      ...(opts.preSignedAuthorAttestation
+        ? { preSignedAuthorAttestation: opts.preSignedAuthorAttestation }
+        : {}),
+      ...(opts.schemeVersion !== undefined ? { schemeVersion: opts.schemeVersion } : {}),
+    },
   );
 };
 
@@ -873,18 +884,24 @@ export const knowledgeAssetPullFrom = (
     { contextGraphId: normalizeContextGraphId(contextGraphId), layer, ...opts },
   );
 
-/** Atomically seal and share the complete WM Knowledge Asset to SWM. */
-export const knowledgeAssetShare = (
-  contextGraphId: string,
-  name: string,
-  opts: {
-    subGraphName?: string;
-    /** @deprecated Knowledge Assets are shared atomically. */
-    entities?: string[] | 'all';
-    /** @deprecated Unsealed Knowledge Asset shares are unsupported. */
-    skipSeal?: boolean;
-  } = {},
-) => {
+export interface AtomicShareOptions {
+  subGraphName?: string;
+}
+
+type LegacyAtomicShareOptions = AtomicShareOptions & {
+  entities?: string[] | 'all';
+  skipSeal?: boolean;
+};
+
+export interface AtomicShareResult {
+  swmShared: boolean;
+  promotedCount: number;
+  sealed: boolean;
+  publishReady: boolean;
+}
+
+function normalizeAtomicShareOptions(raw: AtomicShareOptions): AtomicShareOptions {
+  const opts = raw as LegacyAtomicShareOptions;
   if (Array.isArray(opts.entities)) {
     throw Object.assign(new Error('Knowledge Assets are shared atomically; root-entity selection is not supported'), {
       code: 'KA_ATOMIC_SHARE_REQUIRED',
@@ -903,7 +920,17 @@ export const knowledgeAssetShare = (
   if (opts.skipSeal !== undefined && opts.skipSeal !== false) {
     throw new TypeError('skipSeal must be false or omitted');
   }
-  return post<{ swmShared: boolean; promotedCount: number; sealed: boolean; publishReady: boolean }>(
+  return opts.subGraphName ? { subGraphName: opts.subGraphName } : {};
+}
+
+/** Atomically seal and share the complete WM Knowledge Asset to SWM. */
+export const knowledgeAssetShare = (
+  contextGraphId: string,
+  name: string,
+  rawOptions: AtomicShareOptions = {},
+) => {
+  const opts = normalizeAtomicShareOptions(rawOptions);
+  return post<AtomicShareResult>(
     `/api/knowledge-assets/${encodeURIComponent(name)}/swm/share`,
     {
       contextGraphId: normalizeContextGraphId(contextGraphId),
@@ -913,13 +940,15 @@ export const knowledgeAssetShare = (
 };
 
 /** Publish to VM — mint or update on chain (git push origin main). */
+export type KnowledgeAssetPublishResult = Record<string, unknown> & { contextGraphError?: string };
+
 export const knowledgeAssetPublish = (
   contextGraphId: string,
   name: string,
   opts: { subGraphName?: string } & KnowledgeAssetFinalizedPublishOptions = {},
 ) => {
   const publishOptions = finalizedPublishOptionsPayload(opts, ['subGraphName']);
-  return post<Record<string, unknown>>(
+  return post<KnowledgeAssetPublishResult>(
     `/api/knowledge-assets/${encodeURIComponent(name)}/vm/publish`,
     {
       contextGraphId: normalizeContextGraphId(contextGraphId),
@@ -941,13 +970,8 @@ export const knowledgeAssetPublish = (
  * longer finalizes or mutates SWM: legacy root-scoped SWM assets are read-only,
  * and a publish precondition is surfaced to the caller without retrying.
  */
-export async function knowledgeAssetPublishWithSeal(
-  contextGraphId: string,
-  name: string,
-  opts: { subGraphName?: string } & KnowledgeAssetFinalizedPublishOptions = {},
-): Promise<Record<string, unknown> & { contextGraphError?: string }> {
-  return knowledgeAssetPublish(contextGraphId, name, opts);
-}
+/** @deprecated Use `knowledgeAssetPublish`; retained only as an external source alias. */
+export const knowledgeAssetPublishWithSeal = knowledgeAssetPublish;
 
 /**
  * Aggregate result of a batch SWM→VM publish. Shared so every batch-publish CTA reports
@@ -972,7 +996,7 @@ export interface BatchPublishResult {
 
 /**
  * Publish each named SWM assertion to Verifiable Memory through
- * `knowledgeAssetPublishWithSeal` (direct publish + 207 partial handling), aggregating
+ * `knowledgeAssetPublish` (direct publish + 207 partial handling), aggregating
  * into ONE `BatchPublishResult`. The canonical batch-publish loop reused by every CTA
  * (MemoryLayerView / entities / layer-widgets) so the partial-detail, sample, and per-KA
  * error accounting cannot drift between them. Per-KA failures are collected into
@@ -1001,7 +1025,7 @@ export async function publishAssertionsToVm(
   let sameCoveredEpoch = true;
   for (const a of items) {
     try {
-      const res = await knowledgeAssetPublishWithSeal(
+      const res = await knowledgeAssetPublish(
         contextGraphId,
         a.name,
         a.subGraph ? { subGraphName: a.subGraph } : {},
@@ -1385,6 +1409,8 @@ export async function listAssertions(
 }
 
 /**
+ * @deprecated Use `knowledgeAssetShare`; retained as a positional compatibility adapter.
+ *
  * Atomically seal and share a complete assertion from WM to SWM.
  *
  * `subGraphName` is part of the daemon lookup key alongside
@@ -1396,7 +1422,7 @@ export async function listAssertions(
 export const promoteAssertion = (
   contextGraphId: string,
   assertionName: string,
-  optionsOrLegacyEntities: { subGraphName?: string } | string | string[] = {},
+  optionsOrLegacyEntities?: AtomicShareOptions | string | string[],
   legacySubGraphName?: string,
 ) => {
   if (Array.isArray(optionsOrLegacyEntities)) {
@@ -1410,16 +1436,10 @@ export const promoteAssertion = (
     });
   }
   const subGraphName =
-    typeof optionsOrLegacyEntities === 'string'
+    optionsOrLegacyEntities === undefined || typeof optionsOrLegacyEntities === 'string'
       ? legacySubGraphName
       : optionsOrLegacyEntities.subGraphName;
-  return post<{ promotedCount: number; sealed: boolean; publishReady: boolean }>(
-    `/api/knowledge-assets/${encodeURIComponent(assertionName)}/swm/share`,
-    {
-      contextGraphId: normalizeContextGraphId(contextGraphId),
-      ...(subGraphName ? { subGraphName } : {}),
-    },
-  );
+  return knowledgeAssetShare(contextGraphId, assertionName, { subGraphName });
 };
 
 // Issue #864 — central UI translator for `promoteAssertion` outcomes so
@@ -1452,12 +1472,12 @@ export function describePromoteResult(
     return {
       kind: 'success',
       promotedCount: res.promotedCount,
-      message: `Promoted ${res.promotedCount} triple${res.promotedCount === 1 ? '' : 's'} from ${assertionName} to Shared Working Memory.`,
+      message: `Shared the complete Knowledge Asset ${assertionName} to Shared Working Memory (${res.promotedCount} triple${res.promotedCount === 1 ? '' : 's'}).`,
     };
   }
   return {
     kind: 'noop',
-    message: `${assertionName} had no triples to promote. It may already be in Shared Working Memory, or the extracted content is still being committed — refresh and try again.`,
+    message: `${assertionName} was not newly shared. Its complete Knowledge Asset may already be in Shared Working Memory, or its content is still being committed — refresh and try again.`,
   };
 }
 
@@ -1473,14 +1493,11 @@ export function describePromoteError(
       hint?: string;
     } | undefined;
     if (body?.code === 'SWM_GOSSIP_PAYLOAD_TOO_LARGE') {
-      const hint = typeof body.hint === 'string' && body.hint.length > 0
-        ? body.hint
-        : 'Promote fewer entities per call or split the assertion into smaller root-entity batches.';
       return {
         kind: 'payload-too-large',
         actualBytes: typeof body.actualBytes === 'number' ? body.actualBytes : undefined,
         limitBytes: typeof body.limitBytes === 'number' ? body.limitBytes : undefined,
-        message: `${assertionName} is too large to promote to Shared Working Memory. ${hint}`,
+        message: `${assertionName} is too large to share atomically. Split its content into smaller Knowledge Assets before sharing.`,
       };
     }
   }

--- a/packages/node-ui/src/ui/hooks/useProjectProfile.ts
+++ b/packages/node-ui/src/ui/hooks/useProjectProfile.ts
@@ -37,8 +37,8 @@ export interface SubGraphBinding {
   timelinePredicate?: string;
   /**
    * Name of the WM assertion this sub-graph's importer writes into.
-   * Needed by the verify-on-DKG flow to promote a single entity WM -> SWM
-   * (the promote API takes an assertion name, not just a URI).
+   * Needed by the verify-on-DKG flow to share the entity's complete owning
+   * Knowledge Asset from WM to SWM (the API is keyed by assertion name).
    */
   sourceAssertion?: string;
 }

--- a/packages/node-ui/src/ui/lib/ontologyInstall.ts
+++ b/packages/node-ui/src/ui/lib/ontologyInstall.ts
@@ -149,15 +149,18 @@ export async function installOntology(
     quads,
   });
 
-  // Auto-promote so other subscribed nodes (and their agents) see it.
-  try {
-    await post('/api/knowledge-assets/project-ontology/swm/share', {
-      contextGraphId,
-      subGraphName: 'meta',
-      entities: [ontologyUri, guideUri],
-    });
-  } catch {
-    // Promote failure is non-fatal — agent on this node can still use it.
+  // Atomically seal and share the complete ontology KA so subscribed peers see
+  // it. Installation must not report success when SWM delivery failed.
+  const share = await post<{
+    swmShared?: boolean;
+    sealed?: boolean;
+    publishReady?: boolean;
+  }>('/api/knowledge-assets/project-ontology/swm/share', {
+    contextGraphId,
+    subGraphName: 'meta',
+  });
+  if (!share.swmShared || !share.sealed || !share.publishReady) {
+    throw new Error('Project ontology atomic share did not reach Shared Working Memory');
   }
 
   return { ontologyUri, guideUri, tripleCount: quads.length };

--- a/packages/node-ui/src/ui/views/MemoryLayerView.tsx
+++ b/packages/node-ui/src/ui/views/MemoryLayerView.tsx
@@ -475,7 +475,11 @@ function AssertionList({ contextGraphId, onPromoted }: { contextGraphId: string;
       // PR #710 Fix A — thread `subGraph` so the daemon's
       // `(cg, name, subGraph)` lookup hits the right partition;
       // mirrors the AssertionsList fix in components.tsx.
-      const res = await promoteAssertion(contextGraphId, assertion.name, 'all', assertion.subGraph);
+      const res = await promoteAssertion(
+        contextGraphId,
+        assertion.name,
+        assertion.subGraph ? { subGraphName: assertion.subGraph } : {},
+      );
       const outcome = describePromoteResult(assertion.name, res);
       setPromoteResult({
         message: outcome.message + (assertion.subGraph ? ` (in ${assertion.subGraph})` : ''),
@@ -513,7 +517,11 @@ function AssertionList({ contextGraphId, onPromoted }: { contextGraphId: string;
       for (const a of assertions) {
         currentAssertion = a.name;
         // PR #710 — see comment on the single-row handler above.
-        const res = await promoteAssertion(contextGraphId, a.name, 'all', a.subGraph);
+        const res = await promoteAssertion(
+          contextGraphId,
+          a.name,
+          a.subGraph ? { subGraphName: a.subGraph } : {},
+        );
         totalPromoted += res.promotedCount;
         if (res.promotedCount === 0) noopCount += 1;
       }
@@ -664,7 +672,7 @@ export function PublishPanel({ contextGraphId, onPublished }: { contextGraphId: 
   }, [allSelected, allKeys]);
 
   // Publish a set of named SWM assertions, each as its own KA via the canonical
-  // /vm/publish (with the §4.4 catch→seal→retry safety net). We do NOT pre-
+  // /vm/publish (direct and fail-closed). We do NOT pre-
   // register the CG on-chain: the daemon's /vm/publish runs the local
   // preconditions FIRST and only auto-registers (preserving the stored publish
   // policy) on the `CG_NOT_REGISTERED` retry path — so a doomed publish never
@@ -780,7 +788,7 @@ export function PublishPanel({ contextGraphId, onPublished }: { contextGraphId: 
       </div>
 
       {publishResult && (() => {
-        const { published, total, sealed, partial, partialError, failures, sample, convictionCostCovered } = publishResult;
+        const { published, total, partial, partialError, failures, sample, convictionCostCovered } = publishResult;
         // "Clean" only when every asset published AND none came back as a 207
         // partial (minted on-chain but the CG binding failed).
         const allOk = published === total && published > 0 && partial === 0;
@@ -792,11 +800,6 @@ export function PublishPanel({ contextGraphId, onPublished }: { contextGraphId: 
                 ? `Published ${published} of ${total} knowledge asset${total === 1 ? '' : 's'} to Verifiable Memory`
                 : 'NOT published to Verifiable Memory'}
             </div>
-            {sealed > 0 && (
-              <div className="v10-publish-result-details" style={{ marginBottom: 6 }}>
-                {sealed} asset{sealed === 1 ? ' was' : 's were'} sealed in Shared Memory before publishing.
-              </div>
-            )}
             {partial > 0 && (
               <div className="v10-publish-result-details" style={{ marginBottom: 6 }}>
                 ⚠ {partial} asset{partial === 1 ? '' : 's'}: {partialPublishWarning(partialError)}

--- a/packages/node-ui/src/ui/views/MemoryLayerView.tsx
+++ b/packages/node-ui/src/ui/views/MemoryLayerView.tsx
@@ -505,7 +505,6 @@ function AssertionList({ contextGraphId, onPromoted }: { contextGraphId: string;
     setPromoting('__all__');
     setPromoteResult(null);
     setPromoteError(null);
-    let totalPromoted = 0;
     let noopCount = 0;
     // Issue #864 (Codex review on #874) — capture the in-flight
     // assertion name so a mid-loop failure surfaces "<name>: …"
@@ -522,15 +521,15 @@ function AssertionList({ contextGraphId, onPromoted }: { contextGraphId: string;
           a.name,
           a.subGraph ? { subGraphName: a.subGraph } : {},
         );
-        totalPromoted += res.promotedCount;
         if (res.promotedCount === 0) noopCount += 1;
       }
-      const tail = noopCount > 0 ? ` (${noopCount} assertion${noopCount === 1 ? '' : 's'} had nothing to promote)` : '';
+      const sharedCount = assertions.length - noopCount;
+      const tail = noopCount > 0 ? ` (${noopCount} already shared or still committing)` : '';
       setPromoteResult({
-        message: totalPromoted > 0
-          ? `Promoted ${totalPromoted} triple${totalPromoted === 1 ? '' : 's'} across ${assertions.length} assertion${assertions.length === 1 ? '' : 's'}.${tail}`
-          : `No triples were promoted — every assertion was already in Shared Working Memory or its content has not been committed yet.`,
-        kind: totalPromoted > 0 ? 'success' : 'noop',
+        message: sharedCount > 0
+          ? `Shared ${sharedCount} complete Knowledge Asset${sharedCount === 1 ? '' : 's'} to Shared Working Memory${tail}.`
+          : 'No Knowledge Assets were newly shared — all were already in Shared Working Memory or still committing.',
+        kind: sharedCount > 0 ? 'success' : 'noop',
       });
       refresh();
       onPromoted();
@@ -558,7 +557,7 @@ function AssertionList({ contextGraphId, onPromoted }: { contextGraphId: string;
           disabled={promoting !== null}
           onClick={handlePromoteAll}
         >
-          {promoting === '__all__' ? 'Promoting...' : 'Promote All → SWM'}
+          {promoting === '__all__' ? 'Sharing...' : 'Share Complete KAs → SWM'}
         </button>
       </div>
       <div className="v10-assertion-items">
@@ -592,7 +591,7 @@ function AssertionList({ contextGraphId, onPromoted }: { contextGraphId: string;
               className="v10-btn-promote"
               disabled={promoting !== null}
               onClick={() => handlePromote(a)}
-              title="Copy these triples to Shared Working Memory"
+              title="Share this complete Knowledge Asset to Shared Working Memory"
             >
               {promoting === a.graphUri ? 'Promoting...' : '→ SWM'}
             </button>

--- a/packages/node-ui/src/ui/views/project/components/entities.tsx
+++ b/packages/node-ui/src/ui/views/project/components/entities.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from 'react';
 import { useFetch } from '../../../hooks.js';
 import { encodeDocTabId, resolveDocRef } from '../../../lib/doc-tab-id.js';
 import { truncateMiddle } from '../../../lib/truncate.js';
-import { listAssertions, promoteAssertion, describePromoteResult, describePromoteError, knowledgeAssetPublishWithSeal, publishAssertionsToVm, partialPublishWarning, fetchAssertionUals, type AssertionInfo } from '../../../api.js';
+import { listAssertions, promoteAssertion, describePromoteResult, describePromoteError, knowledgeAssetPublish, publishAssertionsToVm, partialPublishWarning, fetchAssertionUals, type AssertionInfo } from '../../../api.js';
 import { useMemoryEntities, type TrustLevel, type MemoryEntity, type Triple } from '../../../hooks/useMemoryEntities.js';
 import { useProjectProfileContext } from '../../../hooks/useProjectProfile.js';
 import { useAgentsContext } from '../../../hooks/useAgents.js';
@@ -446,9 +446,8 @@ export function AssertionsList({ contextGraphId, layer, onComplete, scrollKey }:
         setResult(outcome.message);
       } else {
         // Publish THIS assertion as one Knowledge Asset (Design B, any entity
-        // count) via the shared knowledgeAssetPublishWithSeal wrapper — direct,
-        // fail-closed publishing with 207 partial-publish handling like the other CTAs.
-        const res = await knowledgeAssetPublishWithSeal(contextGraphId, assertion.name, assertion.subGraph ? { subGraphName: assertion.subGraph } : {});
+        // count) via the direct canonical publish API, preserving 207 partial handling.
+        const res = await knowledgeAssetPublish(contextGraphId, assertion.name, assertion.subGraph ? { subGraphName: assertion.subGraph } : {});
         setResult(
           res.contextGraphError
             ? `Published ${assertion.name} on-chain — ⚠ ${partialPublishWarning(res.contextGraphError)}`
@@ -479,7 +478,6 @@ export function AssertionsList({ contextGraphId, layer, onComplete, scrollKey }:
       // off-chain, and /vm/publish registers-then-
       // mints only after preconditions pass.
       if (layer === 'wm') {
-        let total = 0;
         let noopCount = 0;
         for (const a of assertions) {
           currentAssertion = a.name;
@@ -489,16 +487,16 @@ export function AssertionsList({ contextGraphId, layer, onComplete, scrollKey }:
             a.name,
             a.subGraph ? { subGraphName: a.subGraph } : {},
           );
-          total += res.promotedCount;
           if (res.promotedCount === 0) noopCount += 1;
         }
         // Issue #864 — distinguish "some moved, some no-ops" from
         // "literally nothing moved" so the user gets the truth.
-        if (total > 0) {
-          const tail = noopCount > 0 ? ` (${noopCount} had nothing to promote)` : '';
-          setResult(`Promoted ${total} triples across ${assertions.length} assertion${assertions.length !== 1 ? 's' : ''}${tail}`);
+        const sharedCount = assertions.length - noopCount;
+        if (sharedCount > 0) {
+          const tail = noopCount > 0 ? ` (${noopCount} already shared or still committing)` : '';
+          setResult(`Shared ${sharedCount} complete Knowledge Asset${sharedCount !== 1 ? 's' : ''}${tail}`);
         } else {
-          setResult('No triples were promoted — every assertion was already in Shared Memory or its content is still being committed.');
+          setResult('No Knowledge Assets were newly shared — all were already in Shared Memory or still committing.');
         }
       } else {
         // Publish each shared assertion as its own Knowledge Asset (Design B) via the
@@ -555,8 +553,8 @@ export function AssertionsList({ contextGraphId, layer, onComplete, scrollKey }:
     );
   }
 
-  const actionLabel = layer === 'wm' ? 'Promote → Shared' : 'Publish to VM';
-  const actionAllLabel = layer === 'wm' ? 'Promote All → Shared' : 'Publish all to Verifiable Memory';
+  const actionLabel = layer === 'wm' ? 'Share Complete KA → Shared' : 'Publish to VM';
+  const actionAllLabel = layer === 'wm' ? 'Share Complete KAs → Shared' : 'Publish all to Verifiable Memory';
 
   return (
     <div style={scrollRootStyle} data-cg-scroll-key={scrollKey}>

--- a/packages/node-ui/src/ui/views/project/components/entities.tsx
+++ b/packages/node-ui/src/ui/views/project/components/entities.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from 'react';
 import { useFetch } from '../../../hooks.js';
 import { encodeDocTabId, resolveDocRef } from '../../../lib/doc-tab-id.js';
 import { truncateMiddle } from '../../../lib/truncate.js';
-import { listAssertions, promoteAssertion, describePromoteResult, describePromoteError, knowledgeAssetFinalize, knowledgeAssetPublishWithSeal, publishAssertionsToVm, partialPublishWarning, fetchAssertionUals, type AssertionInfo } from '../../../api.js';
+import { listAssertions, promoteAssertion, describePromoteResult, describePromoteError, knowledgeAssetPublishWithSeal, publishAssertionsToVm, partialPublishWarning, fetchAssertionUals, type AssertionInfo } from '../../../api.js';
 import { useMemoryEntities, type TrustLevel, type MemoryEntity, type Triple } from '../../../hooks/useMemoryEntities.js';
 import { useProjectProfileContext } from '../../../hooks/useProjectProfile.js';
 import { useAgentsContext } from '../../../hooks/useAgents.js';
@@ -344,7 +344,7 @@ export function VerifiableMemoryHeroBanner({ entities, tripleCount, contextGraph
           tone="vm"
           icon={LAYER_CONFIG.vm.icon}
           title="No Knowledge Assets yet."
-          description="Publish entities from Shared Working Memory to verify them on-chain."
+          description="Publish complete Knowledge Assets from Shared Working Memory to verify them on-chain."
         />
       </div>
     );
@@ -425,27 +425,20 @@ export function AssertionsList({ contextGraphId, layer, onComplete, scrollKey }:
     setResult(null);
     setError(null);
     try {
-      // VM is the on-chain layer; finalize/publish need the CG registered, so
-      // auto-register transparently first.
-      // No client-side CG pre-registration: the seal is CG-independent (#1116 —
-      // finalize works on an unregistered CG with no chain write), WM→SWM promote is
-      // off-chain, and /vm/publish owns register-then-mint (it registers ONLY after
+      // No client-side CG pre-registration: atomic WM→SWM sharing is off-chain,
+      // and /vm/publish owns register-then-mint (it registers ONLY after
       // publish preconditions pass, so a doomed publish never burns registration gas).
       if (layer === 'wm') {
-        // Seal the draft before sharing — promote moves content out of WM and a
-        // later vm/publish requires a finalized assertion, so finalize must run
-        // here. Tolerate already-sealed / nothing-to-seal.
-        try {
-          await knowledgeAssetFinalize(contextGraphId, assertion.name, assertion.subGraph ? { subGraphName: assertion.subGraph } : {});
-        } catch (e: any) {
-          const m = String(e?.message ?? '');
-          if (!/already|finaliz|sealed|promoted|no quads|reserved/i.test(m)) throw e;
-        }
+        // The share route seals and transfers the complete KA atomically.
         // PR #710 Fix A — sub-graph slug threads into the daemon's
         // `(cg, name, subGraph)` lookup so a row clicked from a
         // sub-graph partition resolves to that partition's
         // assertion, not a same-named root one.
-        const res = await promoteAssertion(contextGraphId, assertion.name, 'all', assertion.subGraph);
+        const res = await promoteAssertion(
+          contextGraphId,
+          assertion.name,
+          assertion.subGraph ? { subGraphName: assertion.subGraph } : {},
+        );
         // Issue #864 — fan the promote response through the central
         // describe helper so 0-count returns get an actionable hint
         // instead of the misleading "Promoted 0 triples" toast.
@@ -453,8 +446,8 @@ export function AssertionsList({ contextGraphId, layer, onComplete, scrollKey }:
         setResult(outcome.message);
       } else {
         // Publish THIS assertion as one Knowledge Asset (Design B, any entity
-        // count) via the shared knowledgeAssetPublishWithSeal wrapper — gets the
-        // seal-in-SWM retry + 207 partial-publish handling like the other CTAs.
+        // count) via the shared knowledgeAssetPublishWithSeal wrapper — direct,
+        // fail-closed publishing with 207 partial-publish handling like the other CTAs.
         const res = await knowledgeAssetPublishWithSeal(contextGraphId, assertion.name, assertion.subGraph ? { subGraphName: assertion.subGraph } : {});
         setResult(
           res.contextGraphError
@@ -482,22 +475,20 @@ export function AssertionsList({ contextGraphId, layer, onComplete, scrollKey }:
     // "selected assertion …".
     let currentAssertion: string | null = null;
     try {
-      // No client-side CG pre-registration (see handleAction): the seal is
-      // CG-independent (#1116), promote is off-chain, and /vm/publish registers-then-
+      // No client-side CG pre-registration (see handleAction): atomic sharing is
+      // off-chain, and /vm/publish registers-then-
       // mints only after preconditions pass.
       if (layer === 'wm') {
         let total = 0;
         let noopCount = 0;
         for (const a of assertions) {
           currentAssertion = a.name;
-          try {
-            await knowledgeAssetFinalize(contextGraphId, a.name, a.subGraph ? { subGraphName: a.subGraph } : {});
-          } catch (e: any) {
-            const m = String(e?.message ?? '');
-            if (!/already|finaliz|sealed|promoted|no quads|reserved/i.test(m)) throw e;
-          }
           // PR #710 — see comment on the single-row handler above.
-          const res = await promoteAssertion(contextGraphId, a.name, 'all', a.subGraph);
+          const res = await promoteAssertion(
+            contextGraphId,
+            a.name,
+            a.subGraph ? { subGraphName: a.subGraph } : {},
+          );
           total += res.promotedCount;
           if (res.promotedCount === 0) noopCount += 1;
         }
@@ -511,7 +502,7 @@ export function AssertionsList({ contextGraphId, layer, onComplete, scrollKey }:
         }
       } else {
         // Publish each shared assertion as its own Knowledge Asset (Design B) via the
-        // shared batch loop (api.ts publishAssertionsToVm) — seal-retry + 207 partial
+        // shared batch loop (api.ts publishAssertionsToVm) — fail-closed direct publish + 207 partial
         // handling, uniform with the other batch-publish CTAs (carries the partial detail).
         const r = await publishAssertionsToVm(contextGraphId, assertions);
         if (r.published > 0) {

--- a/packages/node-ui/src/ui/views/project/components/ka.tsx
+++ b/packages/node-ui/src/ui/views/project/components/ka.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState, Suspense } from 'react';
 import { api } from '../../../api-wrapper.js';
-import { promoteAssertion, describePromoteResult, describePromoteError, knowledgeAssetPublishWithSeal, partialPublishWarning, PARTIAL_PUBLISH_STATUS_SUFFIX, type PromoteOutcome, type PublishResult } from '../../../api.js';
+import { promoteAssertion, describePromoteResult, describePromoteError, knowledgeAssetPublish, partialPublishWarning, PARTIAL_PUBLISH_STATUS_SUFFIX, type PromoteOutcome, type PublishResult } from '../../../api.js';
 import { useMemoryEntities, canonicalEntityUri, isFirstClassEntity, type MemoryEntity, type Triple } from '../../../hooks/useMemoryEntities.js';
 import { decodeRdfStringLiteral } from '../../../../rdf-literal.js';
 import { useProjectProfileContext } from '../../../hooks/useProjectProfile.js';
@@ -54,7 +54,7 @@ export function SubGraphBadge({
 // ─── Verify on DKG CTA ───────────────────────────────────────
 // Two-step progression driven by the profile:
 //   WM  -> SWM  : promoteAssertion(sourceAssertion)                ("Propose…")
-//   SWM -> VM   : knowledgeAssetPublishWithSeal(sourceAssertion)   ("Ratify…")
+//   SWM -> VM   : knowledgeAssetPublish(sourceAssertion)           ("Ratify…")
 // The SWM→VM step publishes the entity's owning NAMED assertion as one
 // Knowledge Asset via the canonical per-KA /vm/publish (named-only, #1087).
 // Labels, hints and the promote-path assertion name all come from the
@@ -136,7 +136,7 @@ export function VerifyOnDkgButton({
     : {
         kind: 'publish' as const,
         label:    binding.publishLabel ?? 'Verify on DKG',
-        hint:     binding.publishHint  ?? 'Anchors this entity on-chain.',
+        hint:     binding.publishHint  ?? 'Publishes the complete owning Knowledge Asset on-chain.',
         busyCopy: 'Anchoring…',
         // Named-only publish (#1087): /vm/publish is keyed by a named SWM
         // assertion. We publish the entity's owning assertion (its
@@ -177,7 +177,7 @@ export function VerifyOnDkgButton({
         // `CG_NOT_REGISTERED` retry path, so a doomed publish never burns gas.
         // The CTA is disabled above when no sourceAssertion resolves, so
         // `sgBinding.sourceAssertion` is present here.
-        const r = await knowledgeAssetPublishWithSeal(
+        const r = await knowledgeAssetPublish(
           contextGraphId,
           sgBinding!.binding.sourceAssertion!,
           sgBinding!.subGraph ? { subGraphName: sgBinding!.subGraph } : {},

--- a/packages/node-ui/src/ui/views/project/components/ka.tsx
+++ b/packages/node-ui/src/ui/views/project/components/ka.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState, Suspense } from 'react';
 import { api } from '../../../api-wrapper.js';
-import { promoteAssertion, describePromoteResult, describePromoteError, knowledgeAssetPublishWithSeal, SwmSubsetNotSealableError, partialPublishWarning, PARTIAL_PUBLISH_STATUS_SUFFIX, type PromoteOutcome, type PublishResult } from '../../../api.js';
+import { promoteAssertion, describePromoteResult, describePromoteError, knowledgeAssetPublishWithSeal, partialPublishWarning, PARTIAL_PUBLISH_STATUS_SUFFIX, type PromoteOutcome, type PublishResult } from '../../../api.js';
 import { useMemoryEntities, canonicalEntityUri, isFirstClassEntity, type MemoryEntity, type Triple } from '../../../hooks/useMemoryEntities.js';
 import { decodeRdfStringLiteral } from '../../../../rdf-literal.js';
 import { useProjectProfileContext } from '../../../hooks/useProjectProfile.js';
@@ -53,7 +53,7 @@ export function SubGraphBadge({
 
 // ─── Verify on DKG CTA ───────────────────────────────────────
 // Two-step progression driven by the profile:
-//   WM  -> SWM  : promoteAssertion(sourceAssertion, [uri])         ("Propose…")
+//   WM  -> SWM  : promoteAssertion(sourceAssertion)                ("Propose…")
 //   SWM -> VM   : knowledgeAssetPublishWithSeal(sourceAssertion)   ("Ratify…")
 // The SWM→VM step publishes the entity's owning NAMED assertion as one
 // Knowledge Asset via the canonical per-KA /vm/publish (named-only, #1087).
@@ -126,7 +126,7 @@ export function VerifyOnDkgButton({
     ? {
         kind: 'promote' as const,
         label:    binding.promoteLabel ?? 'Promote to Shared Memory',
-        hint:     binding.promoteHint  ?? 'Shares this entity with the team.',
+        hint:     binding.promoteHint  ?? 'Shares the complete owning Knowledge Asset with the team.',
         busyCopy: 'Sharing…',
         disabled: !sgBinding?.binding.sourceAssertion,
         disabledReason: !sgBinding?.binding.sourceAssertion
@@ -157,17 +157,13 @@ export function VerifyOnDkgButton({
     const assertionName = sgBinding?.binding.sourceAssertion ?? 'assertion';
     try {
       if (action.kind === 'promote') {
-        // PR #710 — `sgBinding.sourceAssertion` is itself
-        // sub-graph-scoped (the binding came from a SubGraphBinding
-        // for slug `sgBinding.subGraph`), so we thread that slug as
-        // the 4th arg. Without it the daemon's `(cg, name, subGraph)`
-        // lookup falls back to the root-bucket assertion of the same
-        // name (404 or wrong-target).
+        // Share the entity's complete owning Knowledge Asset. The sub-graph
+        // slug is part of the daemon lookup key, so it must travel with the
+        // source assertion; root-entity subset selection is intentionally gone.
         const r = await promoteAssertion(
           contextGraphId,
           sgBinding!.binding.sourceAssertion!,
-          [entity.uri],
-          sgBinding!.subGraph,
+          sgBinding!.subGraph ? { subGraphName: sgBinding!.subGraph } : {},
         );
         // Issue #864 — fan the promote response through the central
         // describe helper so 0-count returns get an actionable hint
@@ -175,9 +171,8 @@ export function VerifyOnDkgButton({
         setResult(describePromoteResult(assertionName, r));
       } else {
         // Named-only publish (#1087): publish the entity's owning SWM assertion
-        // as one Knowledge Asset via the canonical per-KA /vm/publish (with the
-        // §4.4 catch→seal→retry safety net). We do NOT pre-register the CG: the
-        // daemon's /vm/publish checks the local preconditions first and only
+        // as one Knowledge Asset via the canonical per-KA /vm/publish. We do
+        // NOT pre-register the CG: the daemon checks local preconditions first and only
         // auto-registers (with the stored publish policy) on its
         // `CG_NOT_REGISTERED` retry path, so a doomed publish never burns gas.
         // The CTA is disabled above when no sourceAssertion resolves, so
@@ -193,12 +188,9 @@ export function VerifyOnDkgButton({
     } catch (err: any) {
       // Issue #864 — `ASSERTION_NOT_PERSISTED` (HTTP 409) gets a
       // typed message that points the user at the re-import path
-      // instead of the raw backend error string. A subset-share that can't be
-      // sealed in place surfaces the "share the full asset first" hint.
+      // instead of the raw backend error string.
       const typed = action.kind === 'promote' ? describePromoteError(assertionName, err) : null;
-      const message = err instanceof SwmSubsetNotSealableError
-        ? err.message
-        : (typed ? typed.message : (err?.message ?? 'Action failed'));
+      const message = typed ? typed.message : (err?.message ?? 'Action failed');
       setError(message);
     } finally {
       setBusy(false);
@@ -730,5 +722,3 @@ export function TrailEvent({
     </div>
   );
 }
-
-

--- a/packages/node-ui/src/ui/views/project/components/layer-widgets.tsx
+++ b/packages/node-ui/src/ui/views/project/components/layer-widgets.tsx
@@ -191,7 +191,6 @@ export function PromoteWidget({ count, contextGraphId, onComplete, onResult }: L
         // The share route seals and transfers each complete KA atomically. It is
         // off-chain, so no client-side CG pre-registration is needed.
         const assertions = await listAssertions(contextGraphId, 'wm');
-        let promoted = 0;
         let noopCount = 0;
         for (const a of assertions) {
           currentAssertion = a.name;
@@ -202,16 +201,16 @@ export function PromoteWidget({ count, contextGraphId, onComplete, onResult }: L
             a.name,
             a.subGraph ? { subGraphName: a.subGraph } : {},
           );
-          promoted += res.promotedCount;
           if (res.promotedCount === 0) noopCount += 1;
         }
         // Issue #864 — flag the "nothing was actually moved" case so users on the bulk-promote
         // widget aren't lied to by a "Promoted 0 triples" success toast.
-        if (promoted > 0) {
-          const tail = noopCount > 0 ? ` (${noopCount} had nothing to promote)` : '';
-          return `Promoted ${promoted} triple${promoted !== 1 ? 's' : ''} to Shared Memory${tail}`;
+        const sharedCount = assertions.length - noopCount;
+        if (sharedCount > 0) {
+          const tail = noopCount > 0 ? ` (${noopCount} already shared or still committing)` : '';
+          return `Shared ${sharedCount} complete Knowledge Asset${sharedCount !== 1 ? 's' : ''} to Shared Memory${tail}`;
         }
-        return 'No triples were promoted — every assertion was already in Shared Memory or its content is still being committed.';
+        return 'No Knowledge Assets were newly shared — all were already in Shared Memory or still committing.';
       },
       (err: any) => {
         const typed = describePromoteError(currentAssertion ?? 'an assertion', err);
@@ -226,9 +225,9 @@ export function PromoteWidget({ count, contextGraphId, onComplete, onResult }: L
 
   return (
     <LayerActionShell
-      title="Promote"
-      footnote={`Moves ${noun} from this layer to Shared Working Memory.`}
-      context={<>{count} {noun} in this layer can be promoted to Shared Working Memory for collaborative review.</>}
+      title="Share complete Knowledge Assets"
+      footnote="Shares each complete owning Knowledge Asset atomically to Shared Working Memory."
+      context={<>The displayed {noun} will be shared through their complete owning Knowledge Assets for collaborative review.</>}
       result={result}
       error={error}
     >
@@ -239,7 +238,7 @@ export function PromoteWidget({ count, contextGraphId, onComplete, onResult }: L
         disabled={busy}
         onClick={promote}
       >
-        {busy ? '...' : '✓ Promote All → Shared'}
+        {busy ? '...' : '✓ Share Complete KAs → Shared'}
       </button>
     </LayerActionShell>
   );

--- a/packages/node-ui/src/ui/views/project/components/layer-widgets.tsx
+++ b/packages/node-ui/src/ui/views/project/components/layer-widgets.tsx
@@ -1,6 +1,6 @@
 import React, { useId, useMemo, useState, useCallback } from 'react';
 import type { ReactNode } from 'react';
-import { listAssertions, promoteAssertion, describePromoteError, knowledgeAssetFinalize, publishAssertionsToVm, partialPublishWarning, type ConvictionCostCovered } from '../../../api.js';
+import { listAssertions, promoteAssertion, describePromoteError, publishAssertionsToVm, partialPublishWarning, type ConvictionCostCovered } from '../../../api.js';
 import type { MemoryEntity } from '../../../hooks/useMemoryEntities.js';
 import { useProjectProfileContext } from '../../../hooks/useProjectProfile.js';
 import { LAYER_CONFIG, entityMeta, layerNoun } from '../helpers.js';
@@ -188,26 +188,20 @@ export function PromoteWidget({ count, contextGraphId, onComplete, onResult }: L
     let currentAssertion: string | null = null;
     void run(
       async () => {
-        // Seal each draft before sharing — promote moves content OUT of Working Memory, after
-        // which it can no longer be finalized, and a later vm/publish requires a finalized
-        // assertion. The seal is CG-independent (#1116) and promote is off-chain, so no
-        // client-side CG pre-registration is needed. (See OT-RFC-44 Design B.)
+        // The share route seals and transfers each complete KA atomically. It is
+        // off-chain, so no client-side CG pre-registration is needed.
         const assertions = await listAssertions(contextGraphId, 'wm');
         let promoted = 0;
         let noopCount = 0;
         for (const a of assertions) {
           currentAssertion = a.name;
-          // Seal the draft first; tolerate already-sealed / nothing-to-seal so re-runs and
-          // empty drafts don't abort the batch (surface real errors).
-          try {
-            await knowledgeAssetFinalize(contextGraphId, a.name, a.subGraph ? { subGraphName: a.subGraph } : {});
-          } catch (e: any) {
-            const m = String(e?.message ?? '');
-            if (!/already|finaliz|sealed|promoted|no quads|reserved/i.test(m)) throw e;
-          }
           // PR #710 — thread `subGraph` so sub-graph-scoped assertions hit the correct
           // daemon lookup key `(cg, name, subGraph)`.
-          const res = await promoteAssertion(contextGraphId, a.name, 'all', a.subGraph);
+          const res = await promoteAssertion(
+            contextGraphId,
+            a.name,
+            a.subGraph ? { subGraphName: a.subGraph } : {},
+          );
           promoted += res.promotedCount;
           if (res.promotedCount === 0) noopCount += 1;
         }
@@ -376,8 +370,8 @@ export function LayerWidgetStrip({ layer, entities, entityCount, tripleCount, co
             layer === 'wm'
               ? 'Import data or chat with agents to populate Working Memory.'
               : layer === 'swm'
-                ? 'Promote entities from Working Memory to share them with the team.'
-                : 'Publish entities from Shared Working Memory to verify them on-chain.'
+                ? 'Seal and share complete Knowledge Assets from Working Memory with the team.'
+                : 'Publish complete Knowledge Assets from Shared Working Memory to verify them on-chain.'
           }
         />
       </div>

--- a/packages/node-ui/test/context-graph-empty-stat-components.test.ts
+++ b/packages/node-ui/test/context-graph-empty-stat-components.test.ts
@@ -20,10 +20,8 @@ vi.mock('../src/ui/api.js', () => ({
   writeProfileQueryCatalog: vi.fn(),
   fetchSubGraphs: vi.fn(async () => ({ subGraphs: [] })),
   // ka.tsx (pulled in transitively via the components barrel) imports these —
-  // they must exist on the full mock or module-load fails. SwmSubsetNotSealableError
-  // is a real class because ka.tsx uses it in an `instanceof` check.
+  // they must exist on the full mock or module-load fails.
   knowledgeAssetPublishWithSeal: vi.fn(),
-  SwmSubsetNotSealableError: class SwmSubsetNotSealableError extends Error {},
   partialPublishWarning: vi.fn(() => ''),
   PARTIAL_PUBLISH_STATUS_SUFFIX: 'binding incomplete',
 }));

--- a/packages/node-ui/test/context-graph-empty-stat-components.test.ts
+++ b/packages/node-ui/test/context-graph-empty-stat-components.test.ts
@@ -21,7 +21,7 @@ vi.mock('../src/ui/api.js', () => ({
   fetchSubGraphs: vi.fn(async () => ({ subGraphs: [] })),
   // ka.tsx (pulled in transitively via the components barrel) imports these —
   // they must exist on the full mock or module-load fails.
-  knowledgeAssetPublishWithSeal: vi.fn(),
+  knowledgeAssetPublish: vi.fn(),
   partialPublishWarning: vi.fn(() => ''),
   PARTIAL_PUBLISH_STATUS_SUFFIX: 'binding incomplete',
 }));

--- a/packages/node-ui/test/context-graph-query-catalog.test.ts
+++ b/packages/node-ui/test/context-graph-query-catalog.test.ts
@@ -23,10 +23,8 @@ vi.mock('../src/ui/api.js', () => ({
   writeProfileQueryCatalog: apiMocks.writeProfileQueryCatalog,
   fetchSubGraphs: vi.fn(async () => ({ subGraphs: [] })),
   // ka.tsx (pulled in transitively via the components barrel) imports these —
-  // they must exist on the full mock or module-load fails. SwmSubsetNotSealableError
-  // is a real class because ka.tsx uses it in an `instanceof` check.
+  // they must exist on the full mock or module-load fails.
   knowledgeAssetPublishWithSeal: vi.fn(),
-  SwmSubsetNotSealableError: class SwmSubsetNotSealableError extends Error {},
   partialPublishWarning: vi.fn(() => ''),
   PARTIAL_PUBLISH_STATUS_SUFFIX: 'binding incomplete',
 }));

--- a/packages/node-ui/test/context-graph-query-catalog.test.ts
+++ b/packages/node-ui/test/context-graph-query-catalog.test.ts
@@ -24,7 +24,7 @@ vi.mock('../src/ui/api.js', () => ({
   fetchSubGraphs: vi.fn(async () => ({ subGraphs: [] })),
   // ka.tsx (pulled in transitively via the components barrel) imports these —
   // they must exist on the full mock or module-load fails.
-  knowledgeAssetPublishWithSeal: vi.fn(),
+  knowledgeAssetPublish: vi.fn(),
   partialPublishWarning: vi.fn(() => ''),
   PARTIAL_PUBLISH_STATUS_SUFFIX: 'binding incomplete',
 }));

--- a/packages/node-ui/test/ka-verify-cta.test.ts
+++ b/packages/node-ui/test/ka-verify-cta.test.ts
@@ -4,7 +4,9 @@
 // (VerifyOnDkgButton in ka.tsx). #1087 changed the SWM→VM publish action from
 // root-entity publishing to NAMED knowledge-asset publishing via the canonical
 // per-KA /vm/publish, and added a disabled state for entities that are not part
-// of a named SWM asset. These tests pin: (1) the publish CTA calls
+// of a named SWM asset. The rootless-KA cutover also makes the WM→SWM action
+// share the complete owning assertion instead of one entity. These tests pin:
+// (1) the publish CTA calls
 // knowledgeAssetPublishWithSeal with the entity's owning `sourceAssertion` AND
 // its `subGraphName` (so a future change can't drop the slug or publish the
 // wrong assertion), and (2) a shared entity with no named source assertion
@@ -28,7 +30,6 @@ vi.mock('../src/ui/api.js', () => ({
   describePromoteError: () => null,
   partialPublishWarning: () => '',
   PARTIAL_PUBLISH_STATUS_SUFFIX: 'binding incomplete',
-  SwmSubsetNotSealableError: class SwmSubsetNotSealableError extends Error {},
 }));
 
 // The profile context drives the CTA copy + the publish target.
@@ -68,6 +69,7 @@ async function flush(): Promise<void> {
 
 // A 'shared'-layer entity that lives in sub-graph 'sg1'.
 const sharedEntity = { trustLevel: 'shared', types: ['ex:Character'], subGraphs: ['sg1'], uri: 'urn:e:hero' } as any;
+const workingEntity = { ...sharedEntity, trustLevel: 'working' } as any;
 
 beforeEach(() => {
   apiMocks.knowledgeAssetPublishWithSeal.mockReset();
@@ -78,6 +80,30 @@ beforeEach(() => {
 afterEach(() => { document.body.innerHTML = ''; });
 
 describe('VerifyOnDkgButton — entity-level SWM→VM publish CTA (#1087 named-KA)', () => {
+  it('shares the complete owning KA from WM without sending a root-entity subset', async () => {
+    profileRef.current = {
+      forType: () => ({ promoteLabel: 'Submit for review' }),
+      forSubGraph: (s: string) => (s === 'sg1' ? { sourceAssertion: 'character-sheet' } : null),
+    };
+    apiMocks.promoteAssertion.mockResolvedValue({ promotedCount: 12 });
+    const { container, unmount } = await render(
+      React.createElement(VerifyOnDkgButton, { entity: workingEntity, contextGraphId: 'cg-1', onVerified: vi.fn() }),
+    );
+    await flush();
+
+    const btn = container.querySelector('button.v10-ka-verify-btn') as HTMLButtonElement;
+    await act(async () => { btn.click(); });
+    await flush();
+
+    expect(apiMocks.promoteAssertion).toHaveBeenCalledWith(
+      'cg-1',
+      'character-sheet',
+      { subGraphName: 'sg1' },
+    );
+    expect(apiMocks.promoteAssertion.mock.calls[0]).not.toContain('urn:e:hero');
+    await unmount();
+  });
+
   it("publishes the entity's owning NAMED assertion via knowledgeAssetPublishWithSeal, threading its subGraphName", async () => {
     profileRef.current = {
       forType: () => ({ publishLabel: 'Publish as canon', publishHint: 'Anchors on-chain.' }),

--- a/packages/node-ui/test/ka-verify-cta.test.ts
+++ b/packages/node-ui/test/ka-verify-cta.test.ts
@@ -7,7 +7,7 @@
 // of a named SWM asset. The rootless-KA cutover also makes the WM→SWM action
 // share the complete owning assertion instead of one entity. These tests pin:
 // (1) the publish CTA calls
-// knowledgeAssetPublishWithSeal with the entity's owning `sourceAssertion` AND
+// knowledgeAssetPublish with the entity's owning `sourceAssertion` AND
 // its `subGraphName` (so a future change can't drop the slug or publish the
 // wrong assertion), and (2) a shared entity with no named source assertion
 // disables the CTA rather than publishing the wrong thing.
@@ -19,13 +19,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
 
 const apiMocks = vi.hoisted(() => ({
-  knowledgeAssetPublishWithSeal: vi.fn(),
+  knowledgeAssetPublish: vi.fn(),
   promoteAssertion: vi.fn(),
 }));
 
 vi.mock('../src/ui/api.js', () => ({
   promoteAssertion: apiMocks.promoteAssertion,
-  knowledgeAssetPublishWithSeal: apiMocks.knowledgeAssetPublishWithSeal,
+  knowledgeAssetPublish: apiMocks.knowledgeAssetPublish,
   describePromoteResult: (_n: string, r: unknown) => r,
   describePromoteError: () => null,
   partialPublishWarning: () => '',
@@ -72,8 +72,8 @@ const sharedEntity = { trustLevel: 'shared', types: ['ex:Character'], subGraphs:
 const workingEntity = { ...sharedEntity, trustLevel: 'working' } as any;
 
 beforeEach(() => {
-  apiMocks.knowledgeAssetPublishWithSeal.mockReset();
-  apiMocks.knowledgeAssetPublishWithSeal.mockResolvedValue({ status: 'confirmed', txHash: '0xtx', kaId: '1' });
+  apiMocks.knowledgeAssetPublish.mockReset();
+  apiMocks.knowledgeAssetPublish.mockResolvedValue({ status: 'confirmed', txHash: '0xtx', kaId: '1' });
   apiMocks.promoteAssertion.mockReset();
   profileRef.current = null;
 });
@@ -104,7 +104,7 @@ describe('VerifyOnDkgButton — entity-level SWM→VM publish CTA (#1087 named-K
     await unmount();
   });
 
-  it("publishes the entity's owning NAMED assertion via knowledgeAssetPublishWithSeal, threading its subGraphName", async () => {
+  it("publishes the entity's owning NAMED assertion via knowledgeAssetPublish, threading its subGraphName", async () => {
     profileRef.current = {
       forType: () => ({ publishLabel: 'Publish as canon', publishHint: 'Anchors on-chain.' }),
       forSubGraph: (s: string) => (s === 'sg1' ? { sourceAssertion: 'character-sheet' } : null),
@@ -124,8 +124,8 @@ describe('VerifyOnDkgButton — entity-level SWM→VM publish CTA (#1087 named-K
 
     // The named-KA publish contract: publish the OWNING sourceAssertion, not the
     // raw entity URI, and thread the sub-graph slug so the daemon keys (cg,name,subGraph).
-    expect(apiMocks.knowledgeAssetPublishWithSeal).toHaveBeenCalledTimes(1);
-    expect(apiMocks.knowledgeAssetPublishWithSeal).toHaveBeenCalledWith('cg-1', 'character-sheet', { subGraphName: 'sg1' });
+    expect(apiMocks.knowledgeAssetPublish).toHaveBeenCalledTimes(1);
+    expect(apiMocks.knowledgeAssetPublish).toHaveBeenCalledWith('cg-1', 'character-sheet', { subGraphName: 'sg1' });
     await unmount();
   });
 
@@ -142,7 +142,7 @@ describe('VerifyOnDkgButton — entity-level SWM→VM publish CTA (#1087 named-K
     const btn = container.querySelector('button.v10-ka-verify-btn') as HTMLButtonElement;
     expect(btn?.disabled, 'CTA disabled without a named source assertion').toBe(true);
     expect(container.textContent).toContain('not part of a named Shared-Memory asset');
-    expect(apiMocks.knowledgeAssetPublishWithSeal).not.toHaveBeenCalled();
+    expect(apiMocks.knowledgeAssetPublish).not.toHaveBeenCalled();
     await unmount();
   });
 });

--- a/packages/node-ui/test/layer-widgets-publish.test.ts
+++ b/packages/node-ui/test/layer-widgets-publish.test.ts
@@ -71,7 +71,7 @@ afterEach(() => { document.body.innerHTML = ''; });
 describe('PublishVmWidget — B8 confirmed discount badge (#1365 r3)', () => {
   it('renders the badge from the BATCH convictionCostCovered even when the clean sample has none', async () => {
     apiMocks.publishAssertionsToVm.mockResolvedValue({
-      published: 1, total: 1, sealed: 0, partial: 0, failures: [],
+      published: 1, total: 1, partial: 0, failures: [],
       sample: { status: 'confirmed', txHash: '0xtx', kaId: '0xka' }, // clean, NO discount on the sample
       convictionCostCovered: { accountId: '7', epoch: 1284, baseCost: '1000', discountedCost: '700', drawnFromEpoch: '700', drawnFromTopUp: '0' },
     });
@@ -89,7 +89,7 @@ describe('PublishVmWidget — B8 confirmed discount badge (#1365 r3)', () => {
 
   it('renders NO badge when the batch drew no discount (degrade-hidden #9)', async () => {
     apiMocks.publishAssertionsToVm.mockResolvedValue({
-      published: 1, total: 1, sealed: 0, partial: 0, failures: [],
+      published: 1, total: 1, partial: 0, failures: [],
       sample: { status: 'confirmed', txHash: '0xtx', kaId: '0xka' },
       // no convictionCostCovered on the batch
     });
@@ -271,21 +271,19 @@ describe('PromoteWidget — promote flow (#1382)', () => {
   const clickPromote = async (c: HTMLElement) =>
     act(async () => { (c.querySelector('[data-testid="widget-promote-all-btn"]') as HTMLButtonElement).click(); });
 
-  it('seals (finalize) each draft BEFORE promoting, threading subGraph through both calls', async () => {
+  it('uses one atomic share per draft and threads subGraph without a separate finalize call', async () => {
     const order: string[] = [];
     apiMocks.listAssertions.mockResolvedValue([{ name: 'a1', subGraph: 'sg1' }]);
-    apiMocks.knowledgeAssetFinalize.mockImplementation(async () => { order.push('finalize'); });
+    apiMocks.knowledgeAssetFinalize.mockRejectedValue(new Error('redundant finalize must not run'));
     apiMocks.promoteAssertion.mockImplementation(async () => { order.push('promote'); return { promotedCount: 3 }; });
     const { container, unmount } = await render(
       React.createElement(PromoteWidget, { count: 1, contextGraphId: 'cg' }),
     );
     await clickPromote(container);
-    for (let i = 0; i < 30 && order.length < 2; i++) await flush();
-    // finalize precedes promote for the draft (a dropped seal would fail this).
-    expect(order).toEqual(['finalize', 'promote']);
-    // subGraph threaded through BOTH calls (a dropped passthrough would fail this).
-    expect(apiMocks.knowledgeAssetFinalize).toHaveBeenCalledWith('cg', 'a1', { subGraphName: 'sg1' });
-    expect(apiMocks.promoteAssertion).toHaveBeenCalledWith('cg', 'a1', 'all', 'sg1');
+    for (let i = 0; i < 30 && order.length < 1; i++) await flush();
+    expect(order).toEqual(['promote']);
+    expect(apiMocks.knowledgeAssetFinalize).not.toHaveBeenCalled();
+    expect(apiMocks.promoteAssertion).toHaveBeenCalledWith('cg', 'a1', { subGraphName: 'sg1' });
     expect(container.querySelector('[data-testid="layer-action-result"]')?.textContent).toContain('Promoted 3 triples to Shared Memory');
     await unmount();
   });
@@ -350,7 +348,7 @@ describe('LayerWidgetStrip — action-result survives the widget unmount (OVzK3)
   });
 
   it('keeps the "Published N knowledge assets" feedback after publish empties the swm layer', async () => {
-    apiMocks.publishAssertionsToVm.mockResolvedValue({ published: 2, total: 2, sealed: 0, partial: 0, failures: [] });
+    apiMocks.publishAssertionsToVm.mockResolvedValue({ published: 2, total: 2, partial: 0, failures: [] });
     const { container, unmount } = await render(React.createElement(StripHarness, { layer: 'swm' }));
     expect(container.querySelector('[data-testid="widget-publish-vm-btn"]')).toBeTruthy();
     await clickBtn(container, 'widget-publish-vm-btn');

--- a/packages/node-ui/test/layer-widgets-publish.test.ts
+++ b/packages/node-ui/test/layer-widgets-publish.test.ts
@@ -284,14 +284,14 @@ describe('PromoteWidget — promote flow (#1382)', () => {
     expect(order).toEqual(['promote']);
     expect(apiMocks.knowledgeAssetFinalize).not.toHaveBeenCalled();
     expect(apiMocks.promoteAssertion).toHaveBeenCalledWith('cg', 'a1', { subGraphName: 'sg1' });
-    expect(container.querySelector('[data-testid="layer-action-result"]')?.textContent).toContain('Promoted 3 triples to Shared Memory');
+    expect(container.querySelector('[data-testid="layer-action-result"]')?.textContent).toContain('Shared 1 complete Knowledge Asset to Shared Memory');
     await unmount();
   });
 
   // #1464 — THE MASK: a THROWN promote must render under a DISTINCT `layer-action-error` testid,
   // never the success `layer-action-result`. Before this split both shared one testid, so the
   // devnet e2e (which reads `layer-action-result` testid-agnostically and only rejects the literal
-  // "No triples were promoted" no-op string) mistook an "✕ Promote failed…" banner for a
+  // no-op result string) mistook an "✕ Promote failed…" banner for a
   // successful promote — then the SWM count stayed 0 and the throw was misdiagnosed as a silent
   // migration gap (#1464). Deterministic; fails before the testid split (the error was queryable
   // under layer-action-result), passes after.
@@ -334,7 +334,7 @@ describe('LayerWidgetStrip — action-result survives the widget unmount (OVzK3)
   const clickBtn = async (c: HTMLElement, testid: string) =>
     act(async () => { (c.querySelector(`[data-testid="${testid}"]`) as HTMLButtonElement).click(); });
 
-  it('keeps the "Promoted N triples" feedback after promote empties the wm layer', async () => {
+  it('keeps the complete-KA share feedback after share empties the wm layer', async () => {
     apiMocks.promoteAssertion.mockResolvedValue({ promotedCount: 3 });
     const { container, unmount } = await render(React.createElement(StripHarness, { layer: 'wm' }));
     expect(container.querySelector('[data-testid="widget-promote-all-btn"]')).toBeTruthy();
@@ -343,7 +343,7 @@ describe('LayerWidgetStrip — action-result survives the widget unmount (OVzK3)
     // The layer emptied → the action widget unmounted…
     expect(container.querySelector('[data-testid="widget-promote-all-btn"]')).toBeNull();
     // …but the lifted outcome persists in the strip's own state.
-    expect(container.querySelector('[data-testid="layer-action-result"]')?.textContent).toContain('Promoted 3 triples to Shared Memory');
+    expect(container.querySelector('[data-testid="layer-action-result"]')?.textContent).toContain('Shared 1 complete Knowledge Asset to Shared Memory');
     await unmount();
   });
 

--- a/packages/node-ui/test/memory-layer-publish-panel.test.ts
+++ b/packages/node-ui/test/memory-layer-publish-panel.test.ts
@@ -76,7 +76,7 @@ const ASSERTIONS = [
 ];
 
 const cleanResult = {
-  published: 2, total: 2, sealed: 0, partial: 0, failures: [],
+  published: 2, total: 2, partial: 0, failures: [],
   sample: { status: 'confirmed', txHash: '0xtx', kaId: '0xka' },
 };
 
@@ -163,7 +163,7 @@ describe('MemoryLayerView PublishPanel (SWM → VM)', () => {
 
   it('renders a WARNING (not a clean success) + the contextGraphError detail on a 207 partial', async () => {
     apiMocks.publishAssertionsToVm.mockResolvedValue({
-      published: 1, total: 1, sealed: 0, partial: 1, partialError: 'binding failed', failures: [],
+      published: 1, total: 1, partial: 1, partialError: 'binding failed', failures: [],
       sample: { status: 'confirmed', txHash: '0xtx', kaId: '0xka', contextGraphError: 'binding failed' },
     });
     const { container, unmount } = await render(
@@ -189,7 +189,7 @@ describe('MemoryLayerView PublishPanel (SWM → VM)', () => {
   // guard: a CLEAN non-discount sample alongside a batch-level discount must still render.
   it('B8 — renders the discount badge from the BATCH field even when the clean sample has no discount', async () => {
     apiMocks.publishAssertionsToVm.mockResolvedValue({
-      published: 2, total: 2, sealed: 0, partial: 0, failures: [],
+      published: 2, total: 2, partial: 0, failures: [],
       // The headline sample is a clean, NON-discount item (the mixed-batch trap)…
       sample: { status: 'confirmed', txHash: '0xtx', kaId: '0xka' },
       // …but the batch DID draw a discount on another item → badge must render it.
@@ -220,10 +220,10 @@ describe('MemoryLayerView PublishPanel (SWM → VM)', () => {
     await unmount();
   });
 
-  it('surfaces a per-KA failure (subset-not-sealable) via failures[] without crashing', async () => {
+  it('surfaces a fail-closed per-KA publish precondition via failures[] without crashing', async () => {
     apiMocks.publishAssertionsToVm.mockResolvedValue({
-      published: 0, total: 1, sealed: 0, partial: 0,
-      failures: [{ name: 'beta', error: 'Share the full asset to Shared Memory before publishing.' }],
+      published: 0, total: 1, partial: 0,
+      failures: [{ name: 'beta', error: 'Knowledge Asset is not publish-ready.' }],
       sample: null,
     });
     const { container, unmount } = await render(
@@ -235,7 +235,7 @@ describe('MemoryLayerView PublishPanel (SWM → VM)', () => {
 
     const card = container.querySelector('.v10-publish-result-card');
     expect(card, 'panel renders a result card rather than crashing').toBeTruthy();
-    expect(container.textContent).toContain('Share the full asset');
+    expect(container.textContent).toContain('Knowledge Asset is not publish-ready');
     await unmount();
   });
 });

--- a/packages/node-ui/test/ontology-install.test.ts
+++ b/packages/node-ui/test/ontology-install.test.ts
@@ -29,10 +29,12 @@ function isDaemonAcceptedObjectTerm(value: string): boolean {
 describe('installOntology', () => {
   let originalFetch: typeof globalThis.fetch | undefined;
   let calls: FetchCall[];
+  let failAtomicShare: boolean;
 
   beforeEach(() => {
     originalFetch = globalThis.fetch;
     calls = [];
+    failAtomicShare = false;
     globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const path = String(input);
       const body = init?.body ? JSON.parse(String(init.body)) : {};
@@ -50,6 +52,28 @@ describe('installOntology', () => {
             headers: { 'Content-Type': 'application/json' },
           });
         }
+      }
+
+      if (path.endsWith('/swm/share')) {
+        if ('entities' in body || 'skipSeal' in body) {
+          return new Response(JSON.stringify({
+            code: 'KA_ATOMIC_SHARE_REQUIRED',
+            error: 'Knowledge Assets are shared atomically',
+          }), { status: 409, headers: { 'Content-Type': 'application/json' } });
+        }
+        if (failAtomicShare) {
+          return new Response(JSON.stringify({ error: 'peer delivery failed' }), {
+            status: 503,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        return new Response(JSON.stringify({
+          swmShared: true,
+          promotedCount: 21,
+          sealed: true,
+          publishReady: true,
+          shareOperationId: 'ontology-share-1',
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
       }
 
       return new Response(JSON.stringify({ ok: true }), {
@@ -85,5 +109,15 @@ describe('installOntology', () => {
     expect(writtenObjects).not.toEqual(expect.arrayContaining([
       expect.stringMatching(/^<[^>]+>$/),
     ]));
+
+    const shareCall = calls.find((call) => call.path.endsWith('/swm/share'));
+    expect(shareCall?.body).toEqual({ contextGraphId, subGraphName: 'meta' });
+    expect(shareCall?.body).not.toHaveProperty('entities');
+  });
+
+  it('propagates atomic share failure instead of reporting a local-only install as successful', async () => {
+    failAtomicShare = true;
+    await expect(installOntology('team-cg', 'pkm')).rejects.toThrow('peer delivery failed');
+    expect(calls.some((call) => call.path.endsWith('/swm/share'))).toBe(true);
   });
 });

--- a/packages/node-ui/test/promote-outcome-helpers.test.ts
+++ b/packages/node-ui/test/promote-outcome-helpers.test.ts
@@ -20,12 +20,13 @@ import {
  * silently re-break that CTA.
  */
 describe('describePromoteResult', () => {
-  it('returns kind="success" with a positive triple count message when promotedCount > 0', () => {
+  it('returns kind="success" with complete-KA scope and the affected triple count', () => {
     const out = describePromoteResult('character-sheet', { promotedCount: 7 });
     expect(out.kind).toBe('success');
     if (out.kind !== 'success') return;
     expect(out.promotedCount).toBe(7);
-    expect(out.message).toContain('Promoted 7 triples');
+    expect(out.message).toContain('Shared the complete Knowledge Asset');
+    expect(out.message).toContain('(7 triples)');
     expect(out.message).toContain('character-sheet');
   });
 
@@ -36,14 +37,14 @@ describe('describePromoteResult', () => {
     // The CTA now renders `outcome.message` verbatim instead of the
     // misleading "✓ 0 triples now in Shared Memory" toast.
     expect(out.message).toContain('character-sheet');
-    expect(out.message.toLowerCase()).toContain('no triples');
+    expect(out.message).toContain('not newly shared');
   });
 
   it('uses singular "triple" when promotedCount === 1', () => {
     const out = describePromoteResult('character-sheet', { promotedCount: 1 });
     expect(out.kind).toBe('success');
     if (out.kind !== 'success') return;
-    expect(out.message).toContain('Promoted 1 triple ');
+    expect(out.message).toContain('(1 triple)');
     expect(out.message).not.toContain('1 triples');
   });
 });
@@ -97,7 +98,7 @@ describe('describePromoteError', () => {
     expect(out.limitBytes).toBe(10 * 1024 * 1024);
     expect(out.message).toContain('skills-catalog-0001');
     expect(out.message.toLowerCase()).toContain('too large');
-    expect(out.message.toLowerCase()).toContain('fewer entities');
+    expect(out.message.toLowerCase()).toContain('smaller knowledge assets');
   });
 
   it('returns null for non-HttpError throwables (network errors, generic Error)', () => {

--- a/packages/node-ui/test/ui-api-pure.test.ts
+++ b/packages/node-ui/test/ui-api-pure.test.ts
@@ -568,27 +568,32 @@ describe('UI API tests', () => {
 
     it('knowledgeAssetFinalize rejects legacy SWM finalization before POSTing', () => {
       expect(() =>
-        knowledgeAssetFinalize('cg-1', 'legacy', { layer: 'swm' }),
+        knowledgeAssetFinalize('cg-1', 'legacy', { layer: 'swm' } as any),
       ).toThrow('Legacy root-scoped Knowledge Assets are read-only');
       expect(requestLog).toHaveLength(0);
+    });
+
+    it('knowledgeAssetFinalize accepts neutral layer:wm but omits it from the wire', async () => {
+      await knowledgeAssetFinalize('cg-1', 'asset', { layer: 'wm' });
+      expect(JSON.parse(requestLog[0]?.body ?? '{}')).toEqual({ contextGraphId: 'cg-1' });
     });
 
     it('knowledgeAssetShare sends only atomic scope and rejects root-entity subsets before POSTing', async () => {
       await knowledgeAssetShare('cg-1', 'asset', {
         subGraphName: 'sg',
         entities: 'all', // compatibility-only neutral value
-      });
+      } as any);
       const call = requestLog.find(r => r.url.includes('/api/knowledge-assets/asset/swm/share'));
       expect(JSON.parse(call?.body ?? '{}')).toEqual({ contextGraphId: 'cg-1', subGraphName: 'sg' });
 
       requestLog.length = 0;
       expect(() =>
-        knowledgeAssetShare('cg-1', 'asset', { entities: ['urn:root'] }),
+        knowledgeAssetShare('cg-1', 'asset', { entities: ['urn:root'] } as any),
       ).toThrow('root-entity selection is not supported');
       expect(requestLog).toHaveLength(0);
 
       expect(() =>
-        knowledgeAssetShare('cg-1', 'asset', { skipSeal: true }),
+        knowledgeAssetShare('cg-1', 'asset', { skipSeal: true } as any),
       ).toThrow('always sealed before sharing');
       expect(requestLog).toHaveLength(0);
     });
@@ -603,6 +608,13 @@ describe('UI API tests', () => {
       expect(JSON.parse(requestLog[0]?.body ?? '{}')).toEqual({
         contextGraphId: 'cg-1',
         subGraphName: 'sg-legacy',
+      });
+
+      requestLog.length = 0;
+      await promoteAssertion('cg-1', 'undefined-placeholder', undefined, 'sg-from-fourth-arg');
+      expect(JSON.parse(requestLog[0]?.body ?? '{}')).toEqual({
+        contextGraphId: 'cg-1',
+        subGraphName: 'sg-from-fourth-arg',
       });
 
       requestLog.length = 0;

--- a/packages/node-ui/test/ui-api-pure.test.ts
+++ b/packages/node-ui/test/ui-api-pure.test.ts
@@ -41,9 +41,9 @@ import {
   knowledgeAssetPublish,
   knowledgeAssetPublishWithSeal,
   publishAssertionsToVm,
-  SwmSubsetNotSealableError,
   partialPublishWarning,
   knowledgeAssetFinalize,
+  knowledgeAssetShare,
 } from '../src/ui/api.js';
 
 let server: Server;
@@ -51,9 +51,8 @@ let baseUrl: string;
 const requestLog: Array<{ url: string; method: string; body: string }> = [];
 let queryBindings: any[] = [];
 // Scripted per-call responses (status + body) for tests that need a non-200
-// reply, e.g. the knowledgeAssetPublishWithSeal recovery contract. Each entry
-// is consumed on first match (FIFO), so a test can sequence "first call 409,
-// next call 200". Cleared in beforeEach.
+// reply, e.g. a fail-closed publish precondition. Each entry is consumed on
+// first match (FIFO). Cleared in beforeEach.
 type ResponseOverride = {
   match: (url: string, method: string, body: string) => boolean;
   status: number;
@@ -72,7 +71,7 @@ function startTestServer(): Promise<void> {
         requestLog.push({ url: reqUrl, method: reqMethod, body });
 
         // Scripted override (consumed on first match) — lets a test return a
-        // 409 then a 200 to exercise the catch→seal→retry path.
+        // specific failure or partial-success response.
         const ovIdx = responseOverrides.findIndex(o => o.match(reqUrl, reqMethod, body));
         if (ovIdx !== -1) {
           const [ov] = responseOverrides.splice(ovIdx, 1);
@@ -355,51 +354,23 @@ describe('UI API tests', () => {
       expect(requestLog.some(r => r.url.includes('/api/shared-memory/publish'))).toBe(false);
     });
 
-    it('knowledgeAssetPublishWithSeal seals in SWM (layer:swm + subGraphName) then retries on a VM_PUBLISH_PRECONDITION 409', async () => {
-      // VM_PUBLISH_PRECONDITION is the SEALABLE 409 — an unsealed full share. The
-      // wrapper seals in place (wm/finalize {layer:"swm"}, forwarding subGraphName) and
-      // retries the publish once. (A PUBLISH_NOT_FULL_SHARE 409 is NOT sealable: the
-      // full-share marker is missing, so finalize(layer:"swm") returns
-      // SWM_SUBSET_NOT_SEALABLE — that path is covered by the throws-no-retry test below.)
+    it('knowledgeAssetPublishWithSeal surfaces a VM_PUBLISH_PRECONDITION without mutating SWM or retrying', async () => {
       responseOverrides.push({
         match: (url, method) => method === 'POST' && url.includes('/api/knowledge-assets/a/vm/publish'),
         status: 409,
         body: { code: 'VM_PUBLISH_PRECONDITION', error: 'is not finalized' },
       });
 
-      const res = await knowledgeAssetPublishWithSeal('cg-1', 'a', { subGraphName: 'sg' });
+      await expect(
+        knowledgeAssetPublishWithSeal('cg-1', 'a', { subGraphName: 'sg' }),
+      ).rejects.toMatchObject({
+        status: 409,
+        body: { code: 'VM_PUBLISH_PRECONDITION' },
+      });
 
-      const finalize = requestLog.find(r => r.method === 'POST' && r.url.includes('/api/knowledge-assets/a/wm/finalize'));
-      expect(finalize, 'must seal in SWM after the 409').toBeTruthy();
-      expect(JSON.parse(finalize!.body).layer).toBe('swm');
-      expect(JSON.parse(finalize!.body).subGraphName).toBe('sg');
-      // Exactly two publish attempts: the failing one + the post-seal retry.
+      expect(requestLog.some(r => r.url.includes('/wm/finalize'))).toBe(false);
       const publishCalls = requestLog.filter(r => r.method === 'POST' && r.url.includes('/vm/publish'));
-      expect(publishCalls).toHaveLength(2);
-      // `sealed` flag tells the caller a seal step ran (surface "sealing then publishing").
-      expect(res.sealed).toBe(true);
-    });
-
-    it('knowledgeAssetPublishWithSeal throws SwmSubsetNotSealableError and does NOT retry on SWM_SUBSET_NOT_SEALABLE', async () => {
-      // Publish 409s as not-finalized, but the in-place seal is rejected because
-      // only a subset was shared — surface the typed error, never loop.
-      responseOverrides.push({
-        match: (url, method) => method === 'POST' && url.includes('/api/knowledge-assets/c/vm/publish'),
-        status: 409,
-        body: { code: 'PUBLISH_NOT_FULL_SHARE', error: 'requires a complete full share' },
-      });
-      responseOverrides.push({
-        match: (url, method) => method === 'POST' && url.includes('/api/knowledge-assets/c/wm/finalize'),
-        status: 409,
-        body: { code: 'SWM_SUBSET_NOT_SEALABLE', error: 'share the full asset first' },
-      });
-
-      await expect(knowledgeAssetPublishWithSeal('cg-1', 'c')).rejects.toBeInstanceOf(SwmSubsetNotSealableError);
-
-      // The seal was attempted exactly once and the publish was NOT retried
-      // after the seal failed (one failing publish, no second attempt).
-      expect(requestLog.filter(r => r.method === 'POST' && r.url.includes('/api/knowledge-assets/c/wm/finalize'))).toHaveLength(1);
-      expect(requestLog.filter(r => r.method === 'POST' && r.url.includes('/vm/publish'))).toHaveLength(1);
+      expect(publishCalls).toHaveLength(1);
     });
 
     it('knowledgeAssetPublishWithSeal surfaces a 207 partial publish (contextGraphError) without throwing', async () => {
@@ -418,7 +389,7 @@ describe('UI API tests', () => {
       expect(res.status).toBe('confirmed');
       expect(res.txHash).toBe('0xdeadbeef');
       expect(res.contextGraphError).toBe('binding failed');
-      // No seal/retry — a 207 is not a 409 precondition.
+      // A 207 is returned directly without any SWM mutation.
       expect(requestLog.some(r => r.url.includes('/wm/finalize'))).toBe(false);
       expect(requestLog.filter(r => r.method === 'POST' && r.url.includes('/vm/publish'))).toHaveLength(1);
     });
@@ -592,6 +563,52 @@ describe('UI API tests', () => {
           preSignedAuthorAttestation: { address: '0xauthor', signature: { r: '0xr', vs: '0xvs' } },
         }),
       ).toThrow('authorAgentAddress and preSignedAuthorAttestation are mutually exclusive');
+      expect(requestLog).toHaveLength(0);
+    });
+
+    it('knowledgeAssetFinalize rejects legacy SWM finalization before POSTing', () => {
+      expect(() =>
+        knowledgeAssetFinalize('cg-1', 'legacy', { layer: 'swm' }),
+      ).toThrow('Legacy root-scoped Knowledge Assets are read-only');
+      expect(requestLog).toHaveLength(0);
+    });
+
+    it('knowledgeAssetShare sends only atomic scope and rejects root-entity subsets before POSTing', async () => {
+      await knowledgeAssetShare('cg-1', 'asset', {
+        subGraphName: 'sg',
+        entities: 'all', // compatibility-only neutral value
+      });
+      const call = requestLog.find(r => r.url.includes('/api/knowledge-assets/asset/swm/share'));
+      expect(JSON.parse(call?.body ?? '{}')).toEqual({ contextGraphId: 'cg-1', subGraphName: 'sg' });
+
+      requestLog.length = 0;
+      expect(() =>
+        knowledgeAssetShare('cg-1', 'asset', { entities: ['urn:root'] }),
+      ).toThrow('root-entity selection is not supported');
+      expect(requestLog).toHaveLength(0);
+
+      expect(() =>
+        knowledgeAssetShare('cg-1', 'asset', { skipSeal: true }),
+      ).toThrow('always sealed before sharing');
+      expect(requestLog).toHaveLength(0);
+    });
+
+    it('promoteAssertion shares the complete owning KA and never silently widens a legacy subset', async () => {
+      await promoteAssertion('cg-1', 'asset', { subGraphName: 'sg' });
+      const call = requestLog.find(r => r.url.includes('/api/knowledge-assets/asset/swm/share'));
+      expect(JSON.parse(call?.body ?? '{}')).toEqual({ contextGraphId: 'cg-1', subGraphName: 'sg' });
+
+      requestLog.length = 0;
+      await promoteAssertion('cg-1', 'legacy-caller', 'all', 'sg-legacy');
+      expect(JSON.parse(requestLog[0]?.body ?? '{}')).toEqual({
+        contextGraphId: 'cg-1',
+        subGraphName: 'sg-legacy',
+      });
+
+      requestLog.length = 0;
+      expect(() => promoteAssertion('cg-1', 'asset', ['urn:root'])).toThrow(
+        'root-entity selection is not supported',
+      );
       expect(requestLog).toHaveLength(0);
     });
 

--- a/packages/node-ui/test/vm-hero-banner.test.ts
+++ b/packages/node-ui/test/vm-hero-banner.test.ts
@@ -87,7 +87,7 @@ describe('VerifiableMemoryHeroBanner', () => {
     expect(container.textContent).toContain('Verifiable Memory');
     expect(container.textContent).toContain('Nothing published yet');
     expect(container.textContent).toContain('No Knowledge Assets yet.');
-    expect(container.textContent).toContain('Publish entities from Shared Working Memory');
+    expect(container.textContent).toContain('Publish complete Knowledge Assets from Shared Working Memory');
     expect(container.querySelectorAll('.v10-vm-hero-stat')).toHaveLength(0);
 
     await unmount();


### PR DESCRIPTION
## Summary

- make every Node UI WM to SWM action seal and share the complete owning Knowledge Asset atomically
- remove root-entity subset selection and redundant pre-share finalize calls from entity, assertion, and batch actions
- make legacy SWM finalization read-only and reject subset or unsealed share inputs before HTTP
- stop mutating SWM and retrying when VM publish reports a precondition; publish is now direct and fail-closed
- remove the historical SWM seal-recovery result counter and update user-facing copy to describe complete Knowledge Assets
- retain compatibility-only `entities: "all"` and the old helper name without serializing legacy write controls

## Validation

- `pnpm --filter @origintrail-official/dkg-node-ui build:full`
- Node UI: 151 test files passed
- Node UI: 2,160 tests passed, 38 skipped
- `git diff --check`

## Stack

This PR is stacked on #1727 and should be reviewed after that layer.