### PR TITLE
fix(ka): close rootless recovery blockers

### DIFF
--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -4081,6 +4081,16 @@ export class LifecycleSyncMethods extends DKGAgentBase {
   ): Promise<DurableSyncResult> {
     // `did:dkg:*` public triples anchor a `dkg:merkleRoot` literal in their meta graph.
     const MERKLE_ROOT_PREDICATE = 'http://dkg.io/ontology/merkleRoot';
+    const INTEGRITY_META_PREDICATES = new Set([
+      MERKLE_ROOT_PREDICATE,
+      'http://dkg.io/ontology/contentScopeVersion',
+      'http://dkg.io/ontology/kaUal',
+      'http://dkg.io/ontology/assertionVersion',
+      'http://dkg.io/ontology/assertionGraph',
+      'http://dkg.io/ontology/publicTripleCount',
+      'http://dkg.io/ontology/privateTripleCount',
+      'http://dkg.io/ontology/privateMerkleRoot',
+    ]);
     let insertedDataTriples = 0;
     let insertedMetaTriples = 0;
     let result = emptyDurableSyncResult(); // folds every resync's legacy DurableSyncResult
@@ -4133,6 +4143,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         const metaRecs = page.records.filter((r) => r.op === 'upsert' && r.graph.endsWith('/_meta') && !isForeignGraph(r.graph));
         const recordQuadCountByGraph = new Map<string, number>();
         const metaGraphsWithRoot = new Set<string>();
+        const integrityMetaGraphs = new Set<string>();
         const dataQuads: Quad[] = [];
         const metaQuads: Quad[] = [];
         for (const rec of dataRecs) {
@@ -4146,6 +4157,12 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           recordQuadCountByGraph.set(rec.graph, quads.length);
           // A meta graph can bind data only if it actually carries a merkle root.
           if (quads.some((q) => q.predicate === MERKLE_ROOT_PREDICATE)) metaGraphsWithRoot.add(rec.graph);
+          // Any V2 integrity field makes the whole metadata record fail-closed.
+          // In particular, contentScopeVersion without merkleRoot is malformed,
+          // not harmless configuration that the cursor may acknowledge.
+          if (quads.some((q) => INTEGRITY_META_PREDICATES.has(q.predicate))) {
+            integrityMetaGraphs.add(rec.graph);
+          }
         }
         // Merkle-verify data against meta (same worker path legacy sync uses).
         const processed = await this.processDurableBatchInWorker(dataQuads, metaQuads, ctx, acceptUnverified);
@@ -4180,6 +4197,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           verifiedByGraph,
           recordQuadCountByGraph,
           metaGraphsWithRoot,
+          integrityMetaGraphs,
           merkleBoundDataGraphs,
           batchVerifiedCleanly: processed.rejectedKcs === 0 && processed.dataRejectedMissingMeta === 0,
         });

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -149,6 +149,7 @@ import {
   type SignedAgentDelegation,
 } from './auth/agent-delegation.js';
 import { SyncVerifyWorker } from './sync-verify-worker.js';
+import { classifyDurableMetaGraph } from './sync/durable-integrity.js';
 import { bindRandomSampling, type RandomSamplingHandle, type RandomSamplingStatus } from './random-sampling-bind.js';
 import { connectToMultiaddr, ensurePeerConnected as ensurePeerConnectedAtom, primeCatchupConnections as primeCatchupConnectionsAtom } from './p2p/peer-connect.js';
 import { Messenger, type SloProtocolStats } from './p2p/messenger.js';
@@ -4079,18 +4080,6 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     remotePeerId: string,
     contextGraphId: string,
   ): Promise<DurableSyncResult> {
-    // `did:dkg:*` public triples anchor a `dkg:merkleRoot` literal in their meta graph.
-    const MERKLE_ROOT_PREDICATE = 'http://dkg.io/ontology/merkleRoot';
-    const INTEGRITY_META_PREDICATES = new Set([
-      MERKLE_ROOT_PREDICATE,
-      'http://dkg.io/ontology/contentScopeVersion',
-      'http://dkg.io/ontology/kaUal',
-      'http://dkg.io/ontology/assertionVersion',
-      'http://dkg.io/ontology/assertionGraph',
-      'http://dkg.io/ontology/publicTripleCount',
-      'http://dkg.io/ontology/privateTripleCount',
-      'http://dkg.io/ontology/privateMerkleRoot',
-    ]);
     let insertedDataTriples = 0;
     let insertedMetaTriples = 0;
     let result = emptyDurableSyncResult(); // folds every resync's legacy DurableSyncResult
@@ -4155,14 +4144,13 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           const { quads } = await worker.parseAndFilter(rec.quads ?? '', rec.graph, contextGraphId);
           metaQuads.push(...quads);
           recordQuadCountByGraph.set(rec.graph, quads.length);
-          // A meta graph can bind data only if it actually carries a merkle root.
-          if (quads.some((q) => q.predicate === MERKLE_ROOT_PREDICATE)) metaGraphsWithRoot.add(rec.graph);
-          // Any V2 integrity field makes the whole metadata record fail-closed.
+          const classification = classifyDurableMetaGraph(quads);
+          // A meta graph can bind data only if it actually carries a Merkle root.
+          if (classification.hasMerkleRoot) metaGraphsWithRoot.add(rec.graph);
+          // Any V2 integrity field makes the whole metadata record fail closed.
           // In particular, contentScopeVersion without merkleRoot is malformed,
           // not harmless configuration that the cursor may acknowledge.
-          if (quads.some((q) => INTEGRITY_META_PREDICATES.has(q.predicate))) {
-            integrityMetaGraphs.add(rec.graph);
-          }
+          if (classification.hasIntegrityEnvelope) integrityMetaGraphs.add(rec.graph);
         }
         // Merkle-verify data against meta (same worker path legacy sync uses).
         const processed = await this.processDurableBatchInWorker(dataQuads, metaQuads, ctx, acceptUnverified);

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -133,6 +133,7 @@ import {
   skolemizeKnowledgeAsset,
   skolemizeKnowledgeAssetParts,
   assertNoKnowledgeAssetPayloadNamedGraphs,
+  assertValidPrecomputedUpdateAttestation,
   isReservedSubject,
   canonicalPublishPayload,
   generatedPrivateCatalogTripleKeys,
@@ -173,6 +174,7 @@ import {
 } from '@origintrail-official/dkg-query';
 import { DKGAgentWallet, type AgentWallet } from './agent-wallet.js';
 import { sharedMemoryScopeForFinalizedLifecycle } from './finalized-lifecycle-scope.js';
+import { RootlessUpdateError, type RootlessUpdateErrorCode } from './rootless-update-error.js';
 
 import { ProfileManager } from './profile-manager.js';
 import { DiscoveryClient, type SkillSearchOptions, type DiscoveredAgent, type DiscoveredOffering } from './discovery.js';
@@ -441,8 +443,8 @@ export const SEAL_CAPABILITY_GAP_CODE = 'SEAL_CAPABILITY_GAP';
 const ROOTLESS_UPDATE_DKG_NS = 'http://dkg.io/ontology/';
 const ROOTLESS_UPDATE_XSD_INTEGER = 'http://www.w3.org/2001/XMLSchema#integer';
 
-function rootlessUpdateError(code: string, message: string): Error {
-  return Object.assign(new Error(message), { code });
+function rootlessUpdateError(code: RootlessUpdateErrorCode, message: string): Error {
+  return new RootlessUpdateError(code, message);
 }
 
 function distinctMetadataObjects(
@@ -1825,6 +1827,17 @@ export class PublishMethods extends DKGAgentBase {
           `update payload yielded ${ethers.hexlify(canonicalMerkleRoot)}.`,
       );
     }
+
+    // Authentication is a rejectable publisher precondition, so run the
+    // publisher-owned verifier before replacing either private content or the
+    // canonical SWM graph. The publisher repeats the same check immediately
+    // before chain submission as defense in depth.
+    await assertValidPrecomputedUpdateAttestation(
+      this.chain,
+      kaId,
+      canonicalMerkleRoot,
+      opts.precomputedUpdateAttestation,
+    );
 
     const updateScope = await resolveDirectRootlessUpdateScope(
       this,

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -105,7 +105,20 @@ import {
   assertQuadLiteralsMutf8Safe,
 } from '@origintrail-official/dkg-core';
 import { SpanStatusCode } from '@opentelemetry/api';
-import { GraphManager, PrivateContentStore, createTripleStore, loadSharedMemoryQuadsForScope, canonicalSharedMemoryScopeWriteGraph, type SharedMemoryGraphScope, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig } from '@origintrail-official/dkg-storage';
+import {
+  GraphManager,
+  PrivateContentStore,
+  createTripleStore,
+  loadSharedMemoryQuadsForScope,
+  canonicalSharedMemoryScopeWriteGraph,
+  resolveSharedMemoryScopeGraphs,
+  tryReplaceGraphAtomically,
+  type SharedMemoryGraphScope,
+  type TripleStore,
+  type TripleStoreConfig,
+  type Quad,
+  type LargeLiteralStorageConfig,
+} from '@origintrail-official/dkg-storage';
 import { EVMChainAdapter, NoChainAdapter, enrichEvmError, buildKnowledgeAssetUal, type EVMAdapterConfig, type ChainAdapter, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo } from '@origintrail-official/dkg-chain';
 import {
   DKGPublisher, PublishHandler, SharedMemoryHandler, UpdateHandler, ChainEventPoller, AccessHandler, AccessClient,
@@ -124,7 +137,6 @@ import {
   canonicalPublishPayload,
   generatedPrivateCatalogTripleKeys,
   appendMissingGeneratedPrivateCatalogFloor,
-  replaceCatalogPartitionWithGeneratedPrivateFloor,
   createKnowledgeAssetVmPublishSnapshotMetadata,
   createKnowledgeAssetVmPublishSnapshotRequest,
   resolveLiftWorkspaceSlice,
@@ -426,6 +438,148 @@ import type { DKGAgent } from './dkg-agent.js';
  */
 export const SEAL_CAPABILITY_GAP_CODE = 'SEAL_CAPABILITY_GAP';
 
+const ROOTLESS_UPDATE_DKG_NS = 'http://dkg.io/ontology/';
+const ROOTLESS_UPDATE_XSD_INTEGER = 'http://www.w3.org/2001/XMLSchema#integer';
+
+function rootlessUpdateError(code: string, message: string): Error {
+  return Object.assign(new Error(message), { code });
+}
+
+function distinctMetadataObjects(
+  rows: readonly Quad[],
+  predicate: string,
+): string[] {
+  return [...new Set(
+    rows
+      .filter((quad) => quad.predicate === predicate)
+      .map((quad) => stripLiteral(quad.object)),
+  )];
+}
+
+/**
+ * Resolve the next mutation scope from durable, confirmed V2 metadata.
+ *
+ * A packed kaId is not sufficient by itself: an old root-scoped token can
+ * also be represented as a bigint. Requiring the exact UAL subject plus its V2
+ * marker prevents `/api/update` from silently converting a legacy KA into a
+ * mutable graph-scoped one. Missing local metadata also fails closed; callers
+ * must sync the KA before they can safely replace its exact graph.
+ */
+async function resolveDirectRootlessUpdateScope(
+  agent: DKGAgent,
+  chainId: string,
+  kaId: bigint,
+  contextGraphId: string,
+  subGraphName?: string,
+): Promise<ReturnType<typeof createGraphKnowledgeAssetScope>> {
+  if (kaId <= 0n || kaId >= (1n << 256n)) {
+    throw rootlessUpdateError(
+      'ROOTLESS_UPDATE_INVALID_KA_ID',
+      `Rootless update requires a positive uint256 kaId, got ${kaId.toString()}`,
+    );
+  }
+
+  const authorBits = kaId >> 96n;
+  const kaNumber = kaId & ((1n << 96n) - 1n);
+  const authorAddress = `0x${authorBits.toString(16).padStart(40, '0')}`;
+  const expectedUal = `did:dkg:${chainId}/${authorAddress}/${kaNumber.toString()}`;
+  const currentScope = createGraphKnowledgeAssetScope(expectedUal, 1);
+  const metaGraph = assertSafeIri(contextGraphMetaUri(contextGraphId));
+  const safeUal = assertSafeIri(currentScope.ual);
+  const result = await agent.store.query(
+    `CONSTRUCT { <${safeUal}> ?p ?o } WHERE { `
+      + `GRAPH <${metaGraph}> { <${safeUal}> ?p ?o } }`,
+  );
+  const rows = result.type === 'quads' ? result.quads : [];
+
+  if (rows.length === 0) {
+    const byBatch = await agent.store.query(
+      `SELECT ?ual ?scope WHERE { GRAPH <${metaGraph}> { `
+        + `?ual <${ROOTLESS_UPDATE_DKG_NS}batchId> "${kaId.toString()}"^^<${ROOTLESS_UPDATE_XSD_INTEGER}> . `
+        + `OPTIONAL { ?ual <${ROOTLESS_UPDATE_DKG_NS}contentScopeVersion> ?scope } `
+        + `} } LIMIT 2`,
+    );
+    if (byBatch.type === 'bindings' && byBatch.bindings.length > 0) {
+      throw new LegacyKnowledgeAssetReadOnlyError();
+    }
+    throw rootlessUpdateError(
+      'ROOTLESS_KA_NOT_MATERIALIZED',
+      `Rootless KA ${currentScope.ual} is not materialized in context graph "${contextGraphId}"; `
+        + 'sync the confirmed KA before updating it',
+    );
+  }
+
+  const requireSingle = (predicate: string, field: string): string => {
+    const values = distinctMetadataObjects(rows, `${ROOTLESS_UPDATE_DKG_NS}${predicate}`);
+    if (values.length !== 1) {
+      throw rootlessUpdateError(
+        'ROOTLESS_UPDATE_TARGET_CORRUPT',
+        `Rootless update target ${currentScope.ual} has ${values.length === 0 ? 'missing' : 'ambiguous'} ${field} metadata`,
+      );
+    }
+    return values[0]!;
+  };
+
+  const scopeVersion = requireSingle('contentScopeVersion', 'contentScopeVersion');
+  if (scopeVersion !== String(GRAPH_KA_CONTENT_SCOPE_VERSION)) {
+    throw new LegacyKnowledgeAssetReadOnlyError();
+  }
+  const metadataUal = requireSingle('kaUal', 'kaUal');
+  if (metadataUal !== currentScope.ual) {
+    throw rootlessUpdateError(
+      'ROOTLESS_UPDATE_TARGET_CORRUPT',
+      `Rootless update target kaUal mismatch: expected ${currentScope.ual}, found ${metadataUal}`,
+    );
+  }
+  const batchId = requireSingle('batchId', 'batchId');
+  if (!/^\d+$/.test(batchId) || BigInt(batchId) !== kaId) {
+    throw rootlessUpdateError(
+      'ROOTLESS_UPDATE_TARGET_CORRUPT',
+      `Rootless update target batchId mismatch: expected ${kaId.toString()}, found ${batchId}`,
+    );
+  }
+  const status = requireSingle('status', 'status');
+  if (status !== 'confirmed') {
+    throw rootlessUpdateError(
+      'ROOTLESS_UPDATE_TARGET_NOT_CONFIRMED',
+      `Rootless update target ${currentScope.ual} is ${status || 'unconfirmed'}; only confirmed KAs can be updated`,
+    );
+  }
+  const metadataContextGraph = requireSingle('contextGraph', 'contextGraph');
+  const expectedContextGraph = contextGraphDataUri(contextGraphId);
+  if (metadataContextGraph !== expectedContextGraph) {
+    throw rootlessUpdateError(
+      'ROOTLESS_UPDATE_TARGET_CORRUPT',
+      `Rootless update target contextGraph mismatch: expected ${expectedContextGraph}, found ${metadataContextGraph}`,
+    );
+  }
+  const rawCurrentVersion = requireSingle('assertionVersion', 'assertionVersion');
+  if (!/^\d+$/.test(rawCurrentVersion) || BigInt(rawCurrentVersion) < 1n) {
+    throw rootlessUpdateError(
+      'ROOTLESS_UPDATE_TARGET_CORRUPT',
+      `Rootless update target has invalid assertionVersion ${rawCurrentVersion}`,
+    );
+  }
+  const expectedAssertionGraph = knowledgeAssetLayerGraphUri(
+    contextGraphId,
+    MemoryLayer.VerifiableMemory,
+    createGraphKnowledgeAssetScope(currentScope.ual, rawCurrentVersion),
+    subGraphName,
+  );
+  const assertionGraph = requireSingle('assertionGraph', 'assertionGraph');
+  if (assertionGraph !== expectedAssertionGraph) {
+    throw rootlessUpdateError(
+      'ROOTLESS_UPDATE_TARGET_CORRUPT',
+      `Rootless update target assertionGraph mismatch: expected ${expectedAssertionGraph}, found ${assertionGraph}`,
+    );
+  }
+
+  return createGraphKnowledgeAssetScope(
+    currentScope.ual,
+    BigInt(rawCurrentVersion) + 1n,
+  );
+}
+
 export type ResolveCuratedChainKeyContextOptions = {
   /**
    * Binding-only id for AEAD associated data. This value must never affect
@@ -476,15 +630,14 @@ function prepareQueuedKnowledgeAssetVmPublishOptions(input: {
     return { quads: [...input.snapshotQuads], ...encryptionOptions };
   }
 
-  const preparedCatalog = appendMissingGeneratedPrivateCatalogFloor(
-    input.contextGraphId,
-    input.snapshotQuads,
-  );
   return {
-    quads: preparedCatalog.quads,
+    // The snapshot is already the immutable V2 KA payload. Catalog proof
+    // material travels as a detached trusted capability and is generated by
+    // the publisher; never append it to a queued snapshot.
+    quads: [...input.snapshotQuads],
     ...encryptionOptions,
     trustedNonManifestCatalogTriples:
-      preparedCatalog.trustedNonManifestCatalogTriples,
+      generatedPrivateCatalogTripleKeys(input.contextGraphId),
   };
 }
 
@@ -505,6 +658,50 @@ function recordPublishOutcome(
   const attrs = { outcome, source, ...(chainId ? { chain_id: chainId } : {}) };
   getMetrics().publishTotal.add(1, attrs);
   getMetrics().publishDuration.record(Date.now() - startedAt, attrs);
+}
+
+// Only finalized-assertion / durable-queue replay paths may submit payloads
+// that already contain our canonical `urn:dkg:ka-skolem:c14nN` terms. The
+// symbol is module-private so a public `agent.update(...)` caller cannot opt
+// into the retry allowance and author protocol-reserved skolem IRIs.
+const INTERNAL_ROOTLESS_UPDATE_ORIGIN = Symbol('dkg-agent:internal-rootless-update-origin');
+
+// Serialize the full "validate current V2 head -> stage exact SWM replacement
+// -> submit update" sequence per KA. Without this, two concurrent HTTP calls
+// for the same packed id could overwrite the shared-memory graph between each
+// other's attestation check and publisher reload. Unrelated KAs remain fully
+// parallel and settled promises are removed from the map.
+const rootlessUpdateLocks = new Map<string, Promise<unknown>>();
+
+async function withRootlessUpdateLock<T>(
+  contextGraphId: string,
+  kaId: bigint,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const key = `${contextGraphId}\u0000${kaId.toString()}`;
+  const previous = rootlessUpdateLocks.get(key);
+  const work = (async () => {
+    if (previous) {
+      try {
+        await previous;
+      } catch {
+        // The previous caller observes its own failure; the next retry must
+        // still be allowed to converge the exact staged graph.
+      }
+    }
+    return fn();
+  })();
+  rootlessUpdateLocks.set(key, work);
+  try {
+    return await work;
+  } finally {
+    if (rootlessUpdateLocks.get(key) === work) rootlessUpdateLocks.delete(key);
+  }
+}
+
+function bytesEqual(left: Uint8Array | undefined, right: Uint8Array | undefined): boolean {
+  if (left === undefined || right === undefined) return left === right;
+  return left.length === right.length && left.every((byte, index) => byte === right[index]);
 }
 
 export class PublishMethods extends DKGAgentBase {
@@ -1193,10 +1390,6 @@ export class PublishMethods extends DKGAgentBase {
     const confirmBeforeCommit = opts?.localOnly
       ? undefined
       : await this.buildCuratorAckConfirmer(contextGraphId, gossipSigner, {}, ctx);
-    const onChainContextGraphId = await this.getContextGraphOnChainId(contextGraphId) ?? undefined;
-    const trustedNonManifestCatalogTriples = await this.isPrivateContextGraph(contextGraphId)
-      ? generatedPrivateCatalogTripleKeys(contextGraphId)
-      : undefined;
     const promoted = await this.publisher.assertionPromote(
       contextGraphId,
       assertionName,
@@ -1208,8 +1401,6 @@ export class PublishMethods extends DKGAgentBase {
         localOnly: opts?.localOnly === true,
         accessPolicy,
         allowedPeers,
-        trustedNonManifestCatalogTriples,
-        onChainContextGraphId,
         confirmBeforeCommit,
       },
     );
@@ -1310,18 +1501,24 @@ export class PublishMethods extends DKGAgentBase {
       ? { aeadBindingContextGraphId: onChainId }
       : undefined;
 
-    // Every new on-chain KA uses the V2 atomic content model. Curated CGs
-    // include their deterministic public catalog floor in that same asset;
-    // the exact trust-key set is passed to the publisher for policy checks.
+    // Every new on-chain KA uses the V2 atomic content model. Curated CGs pass
+    // only the exact generated-floor capability to the publisher, which builds
+    // the independent catalog commitment without changing the submitted KA.
     const graphScopedDirectPublish = onChainId != null
       && this.chain.isV10Ready?.() === true
       && typeof this.chain.getEvmChainId === 'function'
       && typeof this.chain.getKnowledgeAssetsLifecycleAddress === 'function';
-    const preparedCatalog = graphScopedDirectPublish
+    if (graphScopedDirectPublish) {
+      // V2 commits one RDF triple set. A caller-authored named graph would be
+      // discarded when the protocol places those triples in its UAL-derived
+      // WM/SWM/VM graph, so reject it instead of signing ambiguous content.
+      assertNoKnowledgeAssetPayloadNamedGraphs(quads, privateQuads ?? []);
+    }
+    const trustedNonManifestCatalogTriples = graphScopedDirectPublish
       && await this.isPrivateContextGraph(contextGraphId)
-      ? replaceCatalogPartitionWithGeneratedPrivateFloor(contextGraphId, quads)
+      ? generatedPrivateCatalogTripleKeys(contextGraphId)
       : undefined;
-    const publishQuads = preparedCatalog?.quads ?? quads;
+    const publishQuads = quads;
 
     // RFC-001 §9.x — sign-at-creation. The publisher refuses on-chain
     // publishes without a `precomputedAttestation`, so the agent
@@ -1451,7 +1648,7 @@ export class PublishMethods extends DKGAgentBase {
       publishEpochs: opts?.publishEpochs,
       precomputedAttestation,
       trustedNonManifestCatalogTriples:
-        preparedCatalog?.trustedNonManifestCatalogTriples,
+        trustedNonManifestCatalogTriples,
       ...graphScopeOptions,
       encryptInlinePayload,
       encryptInlineChunked,
@@ -1580,13 +1777,165 @@ export class PublishMethods extends DKGAgentBase {
       publicTripleCount?: PublishOptions['publicTripleCount'];
       privateMerkleRoot?: PublishOptions['privateMerkleRoot'];
       privateTripleCount?: PublishOptions['privateTripleCount'];
+      [INTERNAL_ROOTLESS_UPDATE_ORIGIN]?: true;
     },
   ): Promise<PublishResult> {
+    return withRootlessUpdateLock(contextGraphId, kaId, async () => {
     const ctx = opts?.operationCtx ?? createOperationContext('update');
     const onPhase = opts?.onPhase;
     this.log.info(ctx, `Starting update of kaId=${kaId} in context graph "${contextGraphId}" with ${quads.length} triples`);
     rejectOversizedRdfLiterals(quads, 'agent.update.quads');
     rejectOversizedRdfLiterals(privateQuads, 'agent.update.privateQuads');
+
+    if (!opts?.precomputedUpdateAttestation) {
+      throw new Error(
+        'Update rejected: on-chain update requires precomputedUpdateAttestation. ' +
+          'Sign UpdateAuthorAttestation(kaId, newMerkleRoot, authorAddress) off-band and pass the seal in this call.',
+      );
+    }
+    if (kaId <= 0n || kaId >= (1n << 256n)) {
+      throw new Error(`Invalid graph-scoped kaId ${kaId.toString()}: expected a positive uint256`);
+    }
+
+    const submittedPrivateQuads = privateQuads ?? [];
+    assertNoKnowledgeAssetPayloadNamedGraphs(quads, submittedPrivateQuads);
+    const canonicalParts = await skolemizeKnowledgeAssetParts(
+      quads,
+      submittedPrivateQuads,
+      {
+        allowCanonicalSkolemTerms:
+          opts?.[INTERNAL_ROOTLESS_UPDATE_ORIGIN] === true,
+      },
+    );
+    if (canonicalParts.publicQuads.length === 0 && canonicalParts.privateQuads.length === 0) {
+      throw new Error('Graph-scoped Knowledge Asset update cannot be empty');
+    }
+    const canonicalPrivateMerkleRoot = computePrivateRoot(canonicalParts.privateQuads);
+    const canonicalMerkleRoot = computeFlatKCRoot(
+      canonicalParts.publicQuads,
+      canonicalPrivateMerkleRoot ? [canonicalPrivateMerkleRoot] : [],
+    );
+    if (!bytesEqual(
+      opts.precomputedUpdateAttestation.expectedNewMerkleRoot,
+      canonicalMerkleRoot,
+    )) {
+      throw new Error(
+        `precomputedUpdateAttestation.expectedNewMerkleRoot mismatch: seal expects ` +
+          `${ethers.hexlify(opts.precomputedUpdateAttestation.expectedNewMerkleRoot)} but canonical ` +
+          `update payload yielded ${ethers.hexlify(canonicalMerkleRoot)}.`,
+      );
+    }
+
+    const updateScope = await resolveDirectRootlessUpdateScope(
+      this,
+      this.chain.chainId,
+      kaId,
+      contextGraphId,
+      opts?.subGraphName,
+    );
+    // The UAL remains namespaced by the original mint author encoded in kaId,
+    // while update authority follows ERC-721 ownership. After a KA transfer
+    // these addresses intentionally differ; the publisher verifies the signed
+    // attestation and the contract enforces ownerOf(kaId) == authorAddress.
+    const nextAssertionVersion = updateScope.assertionVersion;
+    if (
+      opts.contentScopeVersion !== undefined
+      && opts.contentScopeVersion !== GRAPH_KA_CONTENT_SCOPE_VERSION
+    ) {
+      if (opts.contentScopeVersion === 0 || opts.contentScopeVersion === 1) {
+        throw new LegacyKnowledgeAssetReadOnlyError();
+      }
+      throw new Error(`Unsupported KA content scope version ${opts.contentScopeVersion}`);
+    }
+    if (opts.kaUal !== undefined && createGraphKnowledgeAssetScope(
+      opts.kaUal,
+      nextAssertionVersion,
+    ).ual !== updateScope.ual) {
+      throw new Error(
+        `Graph-scoped update UAL ${opts.kaUal} does not match target ${updateScope.ual}`,
+      );
+    }
+    if (
+      opts.assertionVersion !== undefined
+      && BigInt(opts.assertionVersion) !== BigInt(nextAssertionVersion)
+    ) {
+      throw new Error(
+        `Graph-scoped update assertionVersion ${String(opts.assertionVersion)} must advance ` +
+          `the durable current version to ${nextAssertionVersion}`,
+      );
+    }
+    if (
+      opts.publicTripleCount !== undefined
+      && opts.publicTripleCount !== canonicalParts.publicQuads.length
+    ) {
+      throw new Error(
+        `Graph-scoped update public triple count mismatch: envelope=${opts.publicTripleCount}, ` +
+          `canonical=${canonicalParts.publicQuads.length}`,
+      );
+    }
+    if (
+      opts.privateTripleCount !== undefined
+      && opts.privateTripleCount !== canonicalParts.privateQuads.length
+    ) {
+      throw new Error(
+        `Graph-scoped update private triple count mismatch: envelope=${opts.privateTripleCount}, ` +
+          `canonical=${canonicalParts.privateQuads.length}`,
+      );
+    }
+    if (
+      opts.privateMerkleRoot !== undefined
+      && !bytesEqual(opts.privateMerkleRoot, canonicalPrivateMerkleRoot)
+    ) {
+      throw new Error('Graph-scoped update private Merkle root does not match canonical private content');
+    }
+
+    // Direct HTTP/SDK updates and finalized-assertion updates converge through
+    // the same trusted SWM boundary. Stage the immutable private version first
+    // (it cannot overwrite the previous commitment), then atomically replace
+    // the stable public SWM graph and remove historical checksum aliases before
+    // the publisher reloads it. Any failure remains retryable and cannot touch
+    // verifiable memory or the chain.
+    const updateSharedMemoryScope: SharedMemoryGraphScope = {
+      kind: 'named-lifecycle',
+      identity: {
+        agentAddress: updateScope.agentAddress,
+        kaNumber: BigInt(updateScope.kaNumber),
+      },
+    };
+    const graphManager = new GraphManager(this.store);
+    const swmBucket = graphManager.sharedMemoryUri(contextGraphId, opts?.subGraphName);
+    const canonicalSwmGraph = canonicalSharedMemoryScopeWriteGraph(
+      swmBucket,
+      updateSharedMemoryScope,
+    );
+    const priorSwmGraphs = await resolveSharedMemoryScopeGraphs(
+      this.store,
+      swmBucket,
+      updateSharedMemoryScope,
+    );
+    const updatePrivateStore = new PrivateContentStore(this.store, graphManager);
+    await updatePrivateStore.replaceKnowledgeAssetPrivateTriples(
+      contextGraphId,
+      updateScope,
+      canonicalParts.privateQuads,
+      opts?.subGraphName,
+    );
+    const replacedSwm = await tryReplaceGraphAtomically(
+      this.store,
+      canonicalSwmGraph,
+      canonicalParts.publicQuads.map((quad) => ({ ...quad, graph: canonicalSwmGraph })),
+    );
+    if (!replacedSwm) {
+      throw Object.assign(
+        new Error(
+          `Graph-scoped update requires atomic SWM replacement at ${canonicalSwmGraph}`,
+        ),
+        { code: 'ATOMIC_GRAPH_REPLACE_UNSUPPORTED', graphUri: canonicalSwmGraph },
+      );
+    }
+    for (const graph of priorSwmGraphs) {
+      if (graph !== canonicalSwmGraph) await this.store.dropGraph(graph);
+    }
     // GH #842: thread the on-chain cgId so the publisher can promote the update
     // payload into the per-cgId partition the RS prover reads. Without it,
     // updated KAs stay unprovable (data-corrupted / leaf-count-mismatch).
@@ -1659,54 +2008,33 @@ export class PublishMethods extends DKGAgentBase {
         )
       : undefined;
 
-    // A2: USER DECISION (a) — deterministic floor RE-PROJECTION (not read-and-
-    // merge). For a curated update, the public `_catalog` floor MUST be in the
-    // quads handed to the publisher so `partitionCatalogQuads` can lift it back
-    // out, commit a non-zero `newCatalogRoot`, and satisfy the on-chain
-    // `CuratedCGRequiresCatalogCommitment` gate — even for a metadata-only
-    // update (Open Decision #2: every curated update re-commits the floor).
-    // The update analogue of `_ensureCuratedCatalogInSwm`: route through the
-    // SAME publisher-boundary preparation helper so the generated quads and
-    // exact trust allow-list are byte-identical across publish and update.
-    // STRIP-THEN-APPEND: drop any catalog quads the caller's
-    // payload already carries (the from-SWM `publishFromFinalizedAssertion`
-    // path at 3213 can re-load a previously-injected floor) so the floor is
-    // never duplicated, then append exactly the fresh projection. The graph
-    // is cosmetic — `partitionCatalogQuads` matches on subject (the CG DID)
-    // and the catalog root excludes the graph term — so we stamp the canonical
-    // CG-DID data graph for clarity. Public updates skip this block entirely (no
-    // floor, no hook) and are unchanged on a HEALTHY chain. NB: update() now
-    // resolves the access policy unconditionally (~:1442), exactly as the publish
-    // path always has — so under a DEGRADED / stale policy probe a public update
-    // fails closed (throws) consistently with publish, where the OLD update path
-    // would have proceeded. Fail-closed, never a leak; see PR #1208 notes.
-    const preparedUpdateCatalog = isCuratedUpdate && updateOnChainId != null
-      ? replaceCatalogPartitionWithGeneratedPrivateFloor(
-          contextGraphId,
-          quads,
-          contextGraphDataUri(contextGraphId),
-        )
+    // Curated V2 updates re-commit the deterministic catalog floor only as a
+    // detached trusted capability. The exact staged KA graph stays untouched.
+    // There is intentionally no legacy root-scoped mutation fallback here.
+    const trustedUpdateCatalogTriples = isCuratedUpdate && updateOnChainId != null
+      ? generatedPrivateCatalogTripleKeys(contextGraphId)
       : undefined;
-    const updateQuads = preparedUpdateCatalog?.quads ?? quads;
 
     const publisher = opts?.publisherOverride ?? this.publisher;
     const publisherUpdateOptions = {
       contextGraphId,
-      privateQuads,
+      privateQuads: canonicalParts.privateQuads,
       publisherPeerId: this.node.peerId.toString(),
       publishContextGraphId: updateOnChainId ?? undefined,
       operationCtx: ctx,
       onPhase,
       subGraphName: opts?.subGraphName,
-      precomputedUpdateAttestation: opts?.precomputedUpdateAttestation,
-      contentScopeVersion: opts?.contentScopeVersion,
-      kaUal: opts?.kaUal,
-      assertionVersion: opts?.assertionVersion,
-      publicTripleCount: opts?.publicTripleCount,
-      privateMerkleRoot: opts?.privateMerkleRoot,
-      privateTripleCount: opts?.privateTripleCount,
+      precomputedUpdateAttestation: opts.precomputedUpdateAttestation,
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      kaUal: updateScope.ual,
+      assertionVersion: updateScope.assertionVersion,
+      publicTripleCount: canonicalParts.publicQuads.length,
+      ...(canonicalPrivateMerkleRoot
+        ? { privateMerkleRoot: canonicalPrivateMerkleRoot }
+        : {}),
+      privateTripleCount: canonicalParts.privateQuads.length,
       trustedNonManifestCatalogTriples:
-        preparedUpdateCatalog?.trustedNonManifestCatalogTriples,
+        trustedUpdateCatalogTriples,
       v10UpdateACKProvider,
       // Curated → wire the single-blob AEAD hook so the producer's
       // `useEncryptedInlineUpdate` gate fires (catalog commit). Public →
@@ -1716,26 +2044,21 @@ export class PublishMethods extends DKGAgentBase {
       // private payload out to CG members (member distribution). Public → undefined.
       encryptInlineChunked: updateEncryptInlineChunked,
     };
-    const result = opts?.contentScopeVersion === GRAPH_KA_CONTENT_SCOPE_VERSION
-      ? await publisher.updateKnowledgeAssetFromSharedMemory(kaId, publisherUpdateOptions)
-      : await publisher.update(kaId, { ...publisherUpdateOptions, quads: updateQuads });
+    const result = await publisher.updateKnowledgeAssetFromSharedMemory(
+      kaId,
+      publisherUpdateOptions,
+    );
     this.log.info(ctx, `Update complete — status=${result.status}`);
 
     onPhase?.('broadcast', 'start');
     if (result.onChainResult && result.publicQuads) {
       try {
-        const isGraphUpdate = opts?.contentScopeVersion === GRAPH_KA_CONTENT_SCOPE_VERSION;
-        const graphScope = isGraphUpdate
-          ? createGraphKnowledgeAssetScope(opts?.kaUal ?? '', opts?.assertionVersion ?? '')
-          : undefined;
-        const dataGraph = graphScope
-          ? knowledgeAssetLayerGraphUri(
-              contextGraphId,
-              MemoryLayer.VerifiableMemory,
-              graphScope,
-              opts?.subGraphName,
-            )
-          : `did:dkg:context-graph:${contextGraphId}`;
+        const dataGraph = knowledgeAssetLayerGraphUri(
+          contextGraphId,
+          MemoryLayer.VerifiableMemory,
+          updateScope,
+          opts?.subGraphName,
+        );
         const nquadsStr = result.publicQuads
           .map((q) => `<${q.subject}> <${q.predicate}> ${q.object.startsWith('"') ? q.object : `<${q.object}>`} <${dataGraph}> .`)
           .join('\n');
@@ -1744,13 +2067,7 @@ export class PublishMethods extends DKGAgentBase {
           contextGraphId: contextGraphId,
           batchId: kaId,
           nquads: nquadsBytes,
-          manifest: graphScope
-            ? []
-            : result.kaManifest.map((m) => ({
-                rootEntity: m.rootEntity,
-                privateMerkleRoot: m.privateMerkleRoot,
-                privateTripleCount: m.privateTripleCount ?? 0,
-              })),
+          manifest: [],
           publisherPeerId: this.node.peerId.toString(),
           publisherAddress: result.onChainResult.publisherAddress,
           txHash: result.onChainResult.txHash,
@@ -1758,19 +2075,15 @@ export class PublishMethods extends DKGAgentBase {
           newMerkleRoot: result.merkleRoot,
           timestampMs: Date.now(),
           operationId: ctx.operationId,
-          ...(graphScope
-            ? {
-                contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
-                kaUal: graphScope.ual,
-                assertionVersion: graphScope.assertionVersion,
-                publicTripleCount: opts?.publicTripleCount ?? 0,
-                ...(opts?.privateMerkleRoot
-                  ? { privateMerkleRoot: opts.privateMerkleRoot }
-                  : {}),
-                privateTripleCount: opts?.privateTripleCount ?? 0,
-                subGraphName: opts?.subGraphName,
-              }
+          contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+          kaUal: updateScope.ual,
+          assertionVersion: updateScope.assertionVersion,
+          publicTripleCount: canonicalParts.publicQuads.length,
+          ...(canonicalPrivateMerkleRoot
+            ? { privateMerkleRoot: canonicalPrivateMerkleRoot }
             : {}),
+          privateTripleCount: canonicalParts.privateQuads.length,
+          subGraphName: opts?.subGraphName,
         });
         const topic = contextGraphUpdateTopic(contextGraphId);
         await this.gossip.publish(topic, message);
@@ -1782,6 +2095,7 @@ export class PublishMethods extends DKGAgentBase {
     onPhase?.('broadcast', 'end');
 
     return result;
+    });
   }
 
   /**
@@ -2252,30 +2566,11 @@ export class PublishMethods extends DKGAgentBase {
     // private draft quads preserve their graph terms too.
     assertNoKnowledgeAssetPayloadNamedGraphs(userQuads, userPrivateQuads);
 
-    // B6 — inject the public DCAT catalog entry for a PRIVATE CG ONLY AFTER the
-    // "≥1 real user-authored quad" contract has been validated against
-    // `userQuads` above, so a catalog-only assertion can never finalize.
-    // The entry rides in the CG's OWN merkle root as a public KA whose subject
-    // is the context-graph DID (`contextGraphDataUri(contextGraphId)` ===
-    // `did:dkg:context-graph:<contextGraphId>`), the SAME subject open-serve
-    // reads from `<source-cg>/_catalog`. Persisted to the WM graph so
-    // promote/reload carry it; the publish-path partition keeps it out of the
-    // ciphertext and routes it to the public `_catalog` sink. The catalog quads
-    // are appended to `quads` (the merkle input) so the root the seal commits
-    // matches the root the publisher recomputes after reloading WM (which then
-    // includes the catalog) — the leaf hash is over (subject, predicate, object)
-    // only, so the placeholder `graph` here does not affect the root.
-    // Idempotent across re-finalize: identical quads dedupe in the WM store.
+    // The V2 seal commits exactly the canonical submitted RDF. Private-CG
+    // catalog proof material is generated later at the publish boundary and
+    // committed through the independent catalogRoot/catalogLeafCount fields;
+    // it must never enter WM, this seal, or the per-KA graph.
     const quads = [...userQuads];
-    const trustedGeneratedCatalogTriples = (await this.isPrivateContextGraph(contextGraphId))
-      ? generatedPrivateCatalogTripleKeys(contextGraphId)
-      : undefined;
-    if (trustedGeneratedCatalogTriples) {
-      const cgDid = contextGraphDataUri(contextGraphId);
-      const catalogQuads = buildPrivateCatalogDefaultGraphQuads(cgDid, assertionUri);
-      await this.publisher.assertionWrite(contextGraphId, name, agentAddress, catalogQuads, opts?.subGraphName);
-      quads.push(...catalogQuads);
-    }
 
     // 3. Canonicalize the COMPLETE RDF set once at KA scope. Subjects are data,
     // not partitions: 1,000 distinct subjects still produce one asset, one
@@ -4440,6 +4735,7 @@ export class PublishMethods extends DKGAgentBase {
           publicTripleCount: seal.publicTripleCount,
           ...(snapshotPrivateRoot ? { privateMerkleRoot: snapshotPrivateRoot } : {}),
           privateTripleCount: seal.privateTripleCount,
+          [INTERNAL_ROOTLESS_UPDATE_ORIGIN]: true,
         },
       );
 
@@ -4519,20 +4815,17 @@ export class PublishMethods extends DKGAgentBase {
         undefined,
         publishBindingOptions,
       );
-      // #1670 — finalized private assertions seal the deterministic public
-      // catalog floor, but assertionPromote deliberately keeps that synthetic
-      // root out of the per-user-root immutable share snapshot. The synchronous
-      // named-KA path reconstructs the floor in SWM before publishing; queued
-      // execution must do the same from deterministic inputs. Without it the
-      // publisher has no catalog commitment/staging bytes, so cores fall back to
-      // their (intentionally absent) curated SWM copy and decline NO_DATA_IN_SWM.
+      // #1670 — finalized V2 private assertions seal only the exact submitted
+      // RDF. Queued execution must still supply the deterministic catalog
+      // capability so the publisher can build independent catalog commitment
+      // and staging bytes; it must not append those rows to the snapshot.
       //
       // The queued preparation boundary requires both a verified on-chain CG binding
       // and a live curated-policy encryption result. That keeps local-only and
       // public CGs untouched and prevents queued mapper placeholders from
-      // manufacturing trusted catalog triples. The shared preparation boundary performs exact-key
-      // de-duplication for legacy snapshots and returns the trust allow-list
-      // with the quads so queued/update/sync paths cannot drift independently.
+      // manufacturing trusted catalog triples. The shared preparation boundary
+      // returns the unchanged snapshot and exact trust allow-list together so
+      // queued/update/sync paths cannot drift independently.
       const queuedPublishPreparation = prepareQueuedKnowledgeAssetVmPublishOptions({
         contextGraphId: request.contextGraphId,
         snapshotQuads,
@@ -4962,6 +5255,7 @@ export class PublishMethods extends DKGAgentBase {
           publicTripleCount: seal.publicTripleCount,
           ...(privateMerkleRoot ? { privateMerkleRoot } : {}),
           privateTripleCount: seal.privateTripleCount,
+          [INTERNAL_ROOTLESS_UPDATE_ORIGIN]: true,
         },
       );
 
@@ -5403,18 +5697,17 @@ export class PublishMethods extends DKGAgentBase {
   }
 
   /**
-   * OT-RFC-49 — ensure a curated CG's public `_catalog` floor projection is in
-   * the SWM before a from-SWM publish that bypassed `assertionFinalize`.
+   * OT-RFC-49 legacy compatibility — ensure a curated CG's public `_catalog`
+   * floor is in SWM for an arbitrary root-selected combined-model publish.
    *
-   * Mirrors the finalize-path injection (`assertionFinalize`): the catalog
-   * subject is `contextGraphDataUri(contextGraphId)` — the EXACT subject the
-   * publisher's `partitionCatalogQuads` matches — and the floor quads come from
-   * the SAME preparation helper as queued publish and update, so the committed
-   * catalog and exact trust allow-list cannot drift across those paths.
+   * New graph-scoped KAs never call this helper: they keep the catalog detached
+   * from WM/SWM and derive its proof material at the publisher boundary. This
+   * remains only for legacy selection-based publishes whose author seal and KC
+   * root intentionally use the historical combined model.
    *
     * IDEMPOTENT: repeated insertion dedupes in the store/V10 Merkle path because
     * the floor is deterministic, so `catalogLeafCount` stays stable across
-    * finalize-path and direct from-SWM publishes.
+    * repeated legacy selection publishes.
    *
    * Returns a possibly-extended `selection`: for a `{rootEntities}` publish the
    * CG-DID catalog subject is appended so it is in scope for BOTH the author seal
@@ -5568,23 +5861,17 @@ export class PublishMethods extends DKGAgentBase {
 
     const v10ACKProvider = this.createV10ACKProvider(contextGraphId);
 
-    // OT-RFC-49 — inject the public `_catalog` projection for a curated CG
-    // publishing from raw SWM through the internal substrate shortcut that did
-    // NOT go through `assertionFinalize` — which is what
-    // normally injects the catalog. Without it the reloaded payload carries no
-    // catalog, the on-chain catalog commitment stays zero, and the core ACK
-    // falls back to SWM-lookup and DECLINEs `NO_DATA_IN_SWM`. Run BEFORE the
-    // author seal below so the attestation's merkleRoot covers the catalog, and
-    // idempotent so a finalize-path publish (where the catalog is already in SWM)
-    // is unaffected. Gated on an on-chain id so a local-only publish gets nothing
-    // spurious. Returns a possibly-extended selection so the CG-DID catalog
-    // subject is in scope for a `{rootEntities}` publish too (the seal-read and
-    // the publisher reload scope identically).
+    // OT-RFC-49 catalog handling differs by content model. Legacy arbitrary
+    // SWM selections retain their combined-model floor injection. A V2 named
+    // lifecycle carries only the trusted floor capability: the publisher
+    // derives a detached catalog commitment without altering the exact KA
+    // graph or its author seal.
+    const graphScopedPublish = options?.contentScopeVersion === GRAPH_KA_CONTENT_SCOPE_VERSION;
     const hasGeneratedPrivateCatalog = onChainId != null && (await this.isPrivateContextGraph(contextGraphId));
     const trustedNonManifestCatalogTriples = hasGeneratedPrivateCatalog
       ? generatedPrivateCatalogTripleKeys(contextGraphId)
       : undefined;
-    if (hasGeneratedPrivateCatalog) {
+    if (hasGeneratedPrivateCatalog && !graphScopedPublish) {
       selection = await this._ensureCuratedCatalogInSwm(
         contextGraphId,
         selection,
@@ -5629,6 +5916,7 @@ export class PublishMethods extends DKGAgentBase {
             ...(options?.schemeVersion !== undefined
               ? { schemeVersion: options.schemeVersion }
               : {}),
+            graphScoped: graphScopedPublish,
           },
         );
       }

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -134,6 +134,8 @@ import {
   skolemizeKnowledgeAssetParts,
   assertNoKnowledgeAssetPayloadNamedGraphs,
   assertValidPrecomputedUpdateAttestation,
+  storeKnowledgeAssetOperationPublicQuads,
+  storeKnowledgeAssetWorkspaceHead,
   isReservedSubject,
   canonicalPublishPayload,
   generatedPrivateCatalogTripleKeys,
@@ -1949,6 +1951,40 @@ export class PublishMethods extends DKGAgentBase {
     for (const graph of priorSwmGraphs) {
       if (graph !== canonicalSwmGraph) await this.store.dropGraph(graph);
     }
+
+    // Persist the exact update snapshot and monotonic SWM head before the
+    // publisher can cross the chain write-ahead boundary. If the process dies
+    // after the transaction lands but before local VM materialization, chain
+    // reconciliation can now resolve the staged version, counts, private
+    // commitment, publisher, and immutable public payload without guessing.
+    const updateOperationId = ctx.operationId;
+    await storeKnowledgeAssetOperationPublicQuads({
+      store: this.store,
+      graphManager,
+      contextGraphId,
+      shareOperationId: updateOperationId,
+      kaUal: updateScope.ual,
+      assertionVersion: updateScope.assertionVersion,
+      quads: canonicalParts.publicQuads,
+      ...(canonicalPrivateMerkleRoot
+        ? { privateMerkleRoot: canonicalPrivateMerkleRoot }
+        : {}),
+      privateTripleCount: canonicalParts.privateQuads.length,
+      publisherPeerId: this.node.peerId.toString(),
+      agentAddress: updateScope.agentAddress,
+      subGraphName: opts?.subGraphName,
+      timestamp: new Date(),
+      publicSnapshotStore: this.publicSnapshotStore,
+    });
+    await storeKnowledgeAssetWorkspaceHead({
+      store: this.store,
+      graphManager,
+      contextGraphId,
+      kaUal: updateScope.ual,
+      assertionVersion: updateScope.assertionVersion,
+      shareOperationId: updateOperationId,
+      subGraphName: opts?.subGraphName,
+    });
     // GH #842: thread the on-chain cgId so the publisher can promote the update
     // payload into the per-cgId partition the RS prover reads. Without it,
     // updated KAs stay unprovable (data-corrupted / leaf-count-mismatch).

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -1839,6 +1839,7 @@ export class PublishMethods extends DKGAgentBase {
       kaId,
       canonicalMerkleRoot,
       opts.precomputedUpdateAttestation,
+      { requireLocalAuthorization: true },
     );
 
     const updateScope = await resolveDirectRootlessUpdateScope(

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -98,7 +98,6 @@ import {
   resolveWorkspaceAgentRecipients,
   computeTripleHashV10 as computeTripleHash, computeFlatKCRootV10 as computeFlatKCRoot, skolemizeByEntity, isReservedSubject, computePrivateRootV10 as computePrivateRoot,
   canonicalPublishPayload,
-  generatedPrivateCatalogTripleKeys,
   resolveLiftWorkspaceSlice,
   validateLiftPublishPayload,
   subtractFinalizedExactQuads,
@@ -2538,11 +2537,6 @@ export class DKGAgent extends DKGAgentBase {
           { awaitCuratorAck: opts?.awaitCuratorAck, curatorAckTimeoutMs: opts?.curatorAckTimeoutMs },
           createOperationContext('share'),
         );
-        const trustedCatalogOnChainContextGraphId = await agent.getContextGraphOnChainId(contextGraphId) ?? undefined;
-        const isPrivateContextGraph = await agent.isPrivateContextGraph(contextGraphId);
-        const trustedNonManifestCatalogTriples = isPrivateContextGraph
-          ? generatedPrivateCatalogTripleKeys(contextGraphId)
-          : undefined;
         const { promotedCount, gossipMessage, promotedAllRoots, shareOperationId } = await agent.publisher.assertionPromote(
           contextGraphId, name, promoteAgentAddress,
           {
@@ -2550,8 +2544,6 @@ export class DKGAgent extends DKGAgentBase {
             ...(opts?.subGraphName !== undefined ? { subGraphName: opts.subGraphName } : {}),
             publisherPeerId: agent.node.peerId.toString(),
             senderAgentAddress: gossipSigner?.agentAddress,
-            trustedNonManifestCatalogTriples,
-            onChainContextGraphId: trustedCatalogOnChainContextGraphId,
             confirmBeforeCommit,
           },
         );

--- a/packages/agent/src/finalization-handler.ts
+++ b/packages/agent/src/finalization-handler.ts
@@ -958,8 +958,28 @@ export class FinalizationHandler {
         // A confirmed publish may have committed the exact VM graph and drained
         // SWM before the named lifecycle/receipt write survived a crash. Chain
         // binding plus the exact graph's seal root is sufficient immutable proof;
-        // recovery may repair metadata without requiring the consumed SWM copy.
-        this.log.info(ctx, `Chain-reconcile: exact VM graph already matches ${ual}; repairing metadata only`);
+        // repair the metadata through the same idempotent materialization path.
+        // Passing the verified VM payload back through the atomic replace is safe
+        // and avoids a second, subtly different metadata writer.
+        const outcome = await this.applyVerifiedGraphScopedFinalization({
+          contextGraphId,
+          scope,
+          swmQuads: vmQuads,
+          head,
+          privateMerkleRoot,
+          computedMerkleRoot: computedVmMerkleRoot,
+          publisherAddress,
+          txHash: '',
+          blockNumber: versionBlock,
+          batchId: kaId,
+          authorAddress,
+          materializedVersion: { blockNumber: versionBlock, txIndex: 0 },
+          subGraphName,
+          source: 'chain-reconcile',
+          ctx,
+        });
+        if (outcome === 'stale') return 'stale-target';
+        this.log.info(ctx, `Chain-reconcile: exact VM graph already matches ${ual}; repaired metadata`);
         return 'already-confirmed';
       }
     }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -148,6 +148,12 @@ export {
   type VerifyMemberAttestationResult,
 } from './swm/member-attestation.js';
 export {
+  ROOTLESS_UPDATE_ERROR_CODES,
+  RootlessUpdateError,
+  isRootlessUpdateError,
+  type RootlessUpdateErrorCode,
+} from './rootless-update-error.js';
+export {
   ContextGraphNotFoundError,
   InvalidContentError,
   StaleSenderKeyTargetError,

--- a/packages/agent/src/rootless-update-error.ts
+++ b/packages/agent/src/rootless-update-error.ts
@@ -1,0 +1,29 @@
+export const ROOTLESS_UPDATE_ERROR_CODES = [
+  'ROOTLESS_UPDATE_INVALID_KA_ID',
+  'ROOTLESS_KA_NOT_MATERIALIZED',
+  'ROOTLESS_UPDATE_TARGET_CORRUPT',
+  'ROOTLESS_UPDATE_TARGET_NOT_CONFIRMED',
+] as const;
+
+export type RootlessUpdateErrorCode = typeof ROOTLESS_UPDATE_ERROR_CODES[number];
+
+const ROOTLESS_UPDATE_ERROR_CODE_SET: ReadonlySet<string> = new Set(
+  ROOTLESS_UPDATE_ERROR_CODES,
+);
+
+export class RootlessUpdateError extends Error {
+  readonly code: RootlessUpdateErrorCode;
+
+  constructor(code: RootlessUpdateErrorCode, message: string) {
+    super(message);
+    this.name = 'RootlessUpdateError';
+    this.code = code;
+  }
+}
+
+/** Closed structural guard for errors crossing the agent/CLI package boundary. */
+export function isRootlessUpdateError(error: unknown): error is RootlessUpdateError {
+  if (!(error instanceof Error)) return false;
+  const code = Reflect.get(error, 'code');
+  return typeof code === 'string' && ROOTLESS_UPDATE_ERROR_CODE_SET.has(code);
+}

--- a/packages/agent/src/sync/durable-integrity.ts
+++ b/packages/agent/src/sync/durable-integrity.ts
@@ -33,7 +33,7 @@ const SKOLEM_SUFFIX = '/.well-known/genid/';
  * changelog cursor planning must fail closed when any one of these fields is
  * present, even when a malformed record is missing its Merkle root.
  */
-const DURABLE_INTEGRITY_META_PREDICATES: ReadonlySet<string> = new Set([
+export const DURABLE_INTEGRITY_META_PREDICATES = [
   MERKLE_ROOT,
   CONTENT_SCOPE_VERSION,
   KA_UAL,
@@ -42,7 +42,11 @@ const DURABLE_INTEGRITY_META_PREDICATES: ReadonlySet<string> = new Set([
   PUBLIC_TRIPLE_COUNT,
   PRIVATE_TRIPLE_COUNT,
   PRIVATE_MERKLE_ROOT,
-]);
+] as const;
+
+const DURABLE_INTEGRITY_META_PREDICATE_SET: ReadonlySet<string> = new Set(
+  DURABLE_INTEGRITY_META_PREDICATES,
+);
 
 export interface DurableMetaGraphClassification {
   hasMerkleRoot: boolean;
@@ -57,7 +61,7 @@ export function classifyDurableMetaGraph(
   let hasIntegrityEnvelope = false;
   for (const quad of quads) {
     if (quad.predicate === MERKLE_ROOT) hasMerkleRoot = true;
-    if (DURABLE_INTEGRITY_META_PREDICATES.has(quad.predicate)) {
+    if (DURABLE_INTEGRITY_META_PREDICATE_SET.has(quad.predicate)) {
       hasIntegrityEnvelope = true;
     }
     if (hasMerkleRoot && hasIntegrityEnvelope) break;

--- a/packages/agent/src/sync/durable-integrity.ts
+++ b/packages/agent/src/sync/durable-integrity.ts
@@ -27,6 +27,44 @@ const ROOT_ENTITY = `${DKG_NS}rootEntity`;
 const PART_OF = `${DKG_NS}partOf`;
 const SKOLEM_SUFFIX = '/.well-known/genid/';
 
+/**
+ * Predicates that make a durable metadata record part of a KA integrity
+ * envelope. Keep this list beside the verifier that interprets the envelope:
+ * changelog cursor planning must fail closed when any one of these fields is
+ * present, even when a malformed record is missing its Merkle root.
+ */
+const DURABLE_INTEGRITY_META_PREDICATES: ReadonlySet<string> = new Set([
+  MERKLE_ROOT,
+  CONTENT_SCOPE_VERSION,
+  KA_UAL,
+  ASSERTION_VERSION,
+  ASSERTION_GRAPH,
+  PUBLIC_TRIPLE_COUNT,
+  PRIVATE_TRIPLE_COUNT,
+  PRIVATE_MERKLE_ROOT,
+]);
+
+export interface DurableMetaGraphClassification {
+  hasMerkleRoot: boolean;
+  hasIntegrityEnvelope: boolean;
+}
+
+/** Classify a parsed durable metadata record using the verifier's predicates. */
+export function classifyDurableMetaGraph(
+  quads: readonly Quad[],
+): DurableMetaGraphClassification {
+  let hasMerkleRoot = false;
+  let hasIntegrityEnvelope = false;
+  for (const quad of quads) {
+    if (quad.predicate === MERKLE_ROOT) hasMerkleRoot = true;
+    if (DURABLE_INTEGRITY_META_PREDICATES.has(quad.predicate)) {
+      hasIntegrityEnvelope = true;
+    }
+    if (hasMerkleRoot && hasIntegrityEnvelope) break;
+  }
+  return { hasMerkleRoot, hasIntegrityEnvelope };
+}
+
 export interface DurableIntegrityLogEntry {
   level: 'debug' | 'warn';
   message: string;

--- a/packages/agent/src/sync/requester/changelog-sync.ts
+++ b/packages/agent/src/sync/requester/changelog-sync.ts
@@ -47,6 +47,8 @@ export function planPageApply(params: {
   recordQuadCountByGraph: Map<string, number>;
   /** Legacy sibling meta-graph URIs present in-page that carry a `dkg:merkleRoot`. */
   metaGraphsWithRoot: Set<string>;
+  /** Meta graphs containing V2 integrity fields that must never be partially acknowledged. */
+  integrityMetaGraphs: Set<string>;
   /** Exact V2 assertion graphs bound by verified graph-scoped metadata in THIS page. */
   merkleBoundDataGraphs: Set<string>;
   /** processDurableBatch rejected nothing this page (rejectedKcs===0 && dataRejectedMissingMeta===0). */
@@ -87,12 +89,15 @@ export function planPageApply(params: {
     if (rec.graph.endsWith('/_meta')) {
       const parsedCount = params.recordQuadCountByGraph.get(rec.graph) ?? 0;
       const verifiedCount = params.verifiedByGraph.get(rec.graph)?.length ?? 0;
-      // A merkle-bearing metadata snapshot is shared by every KA in the CG.
+      // An integrity-bearing metadata snapshot is shared by every KA in the CG.
       // Never REPLACE it with the verifier's partial subset: that would erase
-      // rejected KA metadata and then advance beyond it. Plain CG config
-      // metadata (no merkle roots) retains the established trusted-anchor path.
+      // rejected KA metadata and then advance beyond it. This includes malformed
+      // V2 rows whose contentScopeVersion/identity envelope survived parsing but
+      // whose merkleRoot is absent: the verifier rejects those rows, so keying
+      // this guard only on merkleRoot would silently acknowledge the rejection.
+      // Plain CG config metadata retains the established trusted-anchor path.
       if (
-        params.metaGraphsWithRoot.has(rec.graph)
+        params.integrityMetaGraphs.has(rec.graph)
         && (!params.batchVerifiedCleanly || verifiedCount !== parsedCount)
       ) {
         deferred = true;

--- a/packages/agent/test/changelog-requester.test.ts
+++ b/packages/agent/test/changelog-requester.test.ts
@@ -7,6 +7,7 @@ import {
   encodeChangelogResponse, decodeChangelogRequest, decodeChangelogResponse,
   type ChangelogDeltaRecord, type ChangelogSyncRequest, type ChangelogSyncResponse,
 } from '../src/sync/changelog/wire.js';
+import { classifyDurableMetaGraph } from '../src/sync/durable-integrity.js';
 
 const qd = (graph: string, n: number): Quad => ({ subject: `s${n}`, predicate: 'p', object: `o${n}`, graph });
 
@@ -18,7 +19,16 @@ const qd = (graph: string, n: number): Quad => ({ subject: `s${n}`, predicate: '
  * unless `noRoot` (a rootless meta cannot bind data), and to integrityMetaGraphs unless
  * explicitly marked as plain configuration.
  */
-function buildPage(specs: Array<{ seq: number; graph: string; op?: 'upsert' | 'drop'; count?: number; verified?: number; noRoot?: boolean; noIntegrity?: boolean }>) {
+function buildPage(specs: Array<{
+  seq: number;
+  graph: string;
+  op?: 'upsert' | 'drop';
+  count?: number;
+  verified?: number;
+  noRoot?: boolean;
+  noIntegrity?: boolean;
+  parsedQuads?: Quad[];
+}>) {
   const records: ChangelogDeltaRecord[] = [];
   const verifiedByGraph = new Map<string, Quad[]>();
   const recordQuadCountByGraph = new Map<string, number>();
@@ -27,13 +37,23 @@ function buildPage(specs: Array<{ seq: number; graph: string; op?: 'upsert' | 'd
   for (const s of specs) {
     const op = s.op ?? 'upsert';
     if (op === 'drop') { records.push({ seq: s.seq, graph: s.graph, op }); continue; }
-    const count = s.count ?? 1;
+    const parsedQuads = s.parsedQuads;
+    const count = s.count ?? parsedQuads?.length ?? 1;
     const verified = s.verified ?? count;
     records.push({ seq: s.seq, graph: s.graph, op, quads: `nq:${s.graph}` });
     recordQuadCountByGraph.set(s.graph, count);
-    verifiedByGraph.set(s.graph, Array.from({ length: verified }, (_, i) => qd(s.graph, i)));
-    if (s.graph.endsWith('/_meta') && !s.noRoot) metaGraphsWithRoot.add(s.graph);
-    if (s.graph.endsWith('/_meta') && !s.noIntegrity) integrityMetaGraphs.add(s.graph);
+    const recordQuads = parsedQuads ?? Array.from({ length: count }, (_, i) => qd(s.graph, i));
+    verifiedByGraph.set(s.graph, recordQuads.slice(0, verified));
+    if (s.graph.endsWith('/_meta')) {
+      if (parsedQuads) {
+        const classification = classifyDurableMetaGraph(parsedQuads);
+        if (classification.hasMerkleRoot) metaGraphsWithRoot.add(s.graph);
+        if (classification.hasIntegrityEnvelope) integrityMetaGraphs.add(s.graph);
+      } else {
+        if (!s.noRoot) metaGraphsWithRoot.add(s.graph);
+        if (!s.noIntegrity) integrityMetaGraphs.add(s.graph);
+      }
+    }
   }
   return { records, verifiedByGraph, recordQuadCountByGraph, metaGraphsWithRoot, integrityMetaGraphs };
 }
@@ -98,13 +118,42 @@ describe('planPageApply — verified-apply planner', () => {
 
   it('does not acknowledge rejected V2 metadata when its merkle root is missing', () => {
     const topMeta = 'did:dkg:context-graph:cg/_meta';
+    const subject = 'did:dkg:31337/0x00000000000000000000000000000000000000aa/7';
     const page = buildPage([
-      { seq: 7, graph: topMeta, count: 4, verified: 1, noRoot: true },
+      {
+        seq: 7,
+        graph: topMeta,
+        verified: 0,
+        parsedQuads: [{
+          subject,
+          predicate: 'http://dkg.io/ontology/contentScopeVersion',
+          object: '"2"^^<http://www.w3.org/2001/XMLSchema#integer>',
+          graph: topMeta,
+        }],
+      },
     ]);
     const p = plan(page, { nextSeq: 7, priorSeq: 6, batchClean: false });
     expect(p.deferred).toBe(true);
     expect(p.ops).toEqual([]);
     expect(p.advanceTo).toBe(6);
+  });
+
+  it('classifies ordinary CG metadata as non-integrity configuration', () => {
+    const topMeta = 'did:dkg:context-graph:cg/_meta';
+    const page = buildPage([{
+      seq: 7,
+      graph: topMeta,
+      parsedQuads: [{
+        subject: 'did:dkg:context-graph:cg',
+        predicate: 'http://schema.org/name',
+        object: '"Context graph"',
+        graph: topMeta,
+      }],
+    }]);
+    const p = plan(page, { nextSeq: 7, priorSeq: 6 });
+    expect(p.deferred).toBe(false);
+    expect(p.ops.map((op) => op.graph)).toEqual([topMeta]);
+    expect(p.advanceTo).toBe(7);
   });
 
   it('accepts a rootless exact graph bound by verified top-level V2 metadata', () => {

--- a/packages/agent/test/changelog-requester.test.ts
+++ b/packages/agent/test/changelog-requester.test.ts
@@ -15,13 +15,15 @@ const qd = (graph: string, n: number): Quad => ({ subject: `s${n}`, predicate: '
 /**
  * Build records + the verify maps planPageApply consumes. Each spec is a graph with `count`
  * parsed quads of which `verified` survived; a meta graph is added to metaGraphsWithRoot
- * unless `noRoot` (a rootless meta cannot bind data).
+ * unless `noRoot` (a rootless meta cannot bind data), and to integrityMetaGraphs unless
+ * explicitly marked as plain configuration.
  */
-function buildPage(specs: Array<{ seq: number; graph: string; op?: 'upsert' | 'drop'; count?: number; verified?: number; noRoot?: boolean }>) {
+function buildPage(specs: Array<{ seq: number; graph: string; op?: 'upsert' | 'drop'; count?: number; verified?: number; noRoot?: boolean; noIntegrity?: boolean }>) {
   const records: ChangelogDeltaRecord[] = [];
   const verifiedByGraph = new Map<string, Quad[]>();
   const recordQuadCountByGraph = new Map<string, number>();
   const metaGraphsWithRoot = new Set<string>();
+  const integrityMetaGraphs = new Set<string>();
   for (const s of specs) {
     const op = s.op ?? 'upsert';
     if (op === 'drop') { records.push({ seq: s.seq, graph: s.graph, op }); continue; }
@@ -31,8 +33,9 @@ function buildPage(specs: Array<{ seq: number; graph: string; op?: 'upsert' | 'd
     recordQuadCountByGraph.set(s.graph, count);
     verifiedByGraph.set(s.graph, Array.from({ length: verified }, (_, i) => qd(s.graph, i)));
     if (s.graph.endsWith('/_meta') && !s.noRoot) metaGraphsWithRoot.add(s.graph);
+    if (s.graph.endsWith('/_meta') && !s.noIntegrity) integrityMetaGraphs.add(s.graph);
   }
-  return { records, verifiedByGraph, recordQuadCountByGraph, metaGraphsWithRoot };
+  return { records, verifiedByGraph, recordQuadCountByGraph, metaGraphsWithRoot, integrityMetaGraphs };
 }
 
 const plan = (page: ReturnType<typeof buildPage>, extra: { nextSeq: number; priorSeq?: number; isForeign?: (g: string) => boolean; batchClean?: boolean; merkleBoundDataGraphs?: Set<string> }) =>
@@ -44,6 +47,7 @@ const plan = (page: ReturnType<typeof buildPage>, extra: { nextSeq: number; prio
     verifiedByGraph: page.verifiedByGraph,
     recordQuadCountByGraph: page.recordQuadCountByGraph,
     metaGraphsWithRoot: page.metaGraphsWithRoot,
+    integrityMetaGraphs: page.integrityMetaGraphs,
     merkleBoundDataGraphs: extra.merkleBoundDataGraphs ?? new Set(),
     batchVerifiedCleanly: extra.batchClean ?? true,
   });
@@ -90,6 +94,17 @@ describe('planPageApply — verified-apply planner', () => {
     expect(p.deferred).toBe(true);
     expect(p.ops).toEqual([]);
     expect(p.advanceTo).toBe(1);
+  });
+
+  it('does not acknowledge rejected V2 metadata when its merkle root is missing', () => {
+    const topMeta = 'did:dkg:context-graph:cg/_meta';
+    const page = buildPage([
+      { seq: 7, graph: topMeta, count: 4, verified: 1, noRoot: true },
+    ]);
+    const p = plan(page, { nextSeq: 7, priorSeq: 6, batchClean: false });
+    expect(p.deferred).toBe(true);
+    expect(p.ops).toEqual([]);
+    expect(p.advanceTo).toBe(6);
   });
 
   it('accepts a rootless exact graph bound by verified top-level V2 metadata', () => {

--- a/packages/agent/test/changelog-requester.test.ts
+++ b/packages/agent/test/changelog-requester.test.ts
@@ -7,7 +7,10 @@ import {
   encodeChangelogResponse, decodeChangelogRequest, decodeChangelogResponse,
   type ChangelogDeltaRecord, type ChangelogSyncRequest, type ChangelogSyncResponse,
 } from '../src/sync/changelog/wire.js';
-import { classifyDurableMetaGraph } from '../src/sync/durable-integrity.js';
+import {
+  DURABLE_INTEGRITY_META_PREDICATES,
+  classifyDurableMetaGraph,
+} from '../src/sync/durable-integrity.js';
 
 const qd = (graph: string, n: number): Quad => ({ subject: `s${n}`, predicate: 'p', object: `o${n}`, graph });
 
@@ -116,7 +119,9 @@ describe('planPageApply — verified-apply planner', () => {
     expect(p.advanceTo).toBe(1);
   });
 
-  it('does not acknowledge rejected V2 metadata when its merkle root is missing', () => {
+  it.each(DURABLE_INTEGRITY_META_PREDICATES.filter(
+    (predicate) => predicate !== 'http://dkg.io/ontology/merkleRoot',
+  ))('does not acknowledge rejected V2 metadata containing %s without a merkle root', (predicate) => {
     const topMeta = 'did:dkg:context-graph:cg/_meta';
     const subject = 'did:dkg:31337/0x00000000000000000000000000000000000000aa/7';
     const page = buildPage([
@@ -126,7 +131,7 @@ describe('planPageApply — verified-apply planner', () => {
         verified: 0,
         parsedQuads: [{
           subject,
-          predicate: 'http://dkg.io/ontology/contentScopeVersion',
+          predicate,
           object: '"2"^^<http://www.w3.org/2001/XMLSchema#integer>',
           graph: topMeta,
         }],
@@ -137,6 +142,18 @@ describe('planPageApply — verified-apply planner', () => {
     expect(p.ops).toEqual([]);
     expect(p.advanceTo).toBe(6);
   });
+
+  it.each(DURABLE_INTEGRITY_META_PREDICATES)(
+    'classifies %s as part of the durable integrity envelope',
+    (predicate) => {
+      expect(classifyDurableMetaGraph([{
+        subject: 'urn:ka',
+        predicate,
+        object: '"value"',
+        graph: 'urn:meta',
+      }]).hasIntegrityEnvelope).toBe(true);
+    },
+  );
 
   it('classifies ordinary CG metadata as non-integrity configuration', () => {
     const topMeta = 'did:dkg:context-graph:cg/_meta';

--- a/packages/agent/test/combined-catalog-baseline.e2e.test.ts
+++ b/packages/agent/test/combined-catalog-baseline.e2e.test.ts
@@ -1,14 +1,14 @@
 /**
- * combined-model BASELINE (pre-catalog-injection) — curated e2e.
+ * detached-catalog rootless baseline — curated e2e.
  *
  * The first end-to-end curated/private-CG VM publish on the devnet, via the
  * PRODUCT path (write -> promote -> publishFromFinalizedAssertion). Uses the
  * pre-staked genesis core nodes for the ACK quorum (lowered to 1), so the
  * curated `nodeExists` signer check passes.
  *
- * Baseline invariant: a private CG publishing N data entities yields a manifest
- * with exactly N data roots. The public DCAT catalog floor is still committed in
- * the KC Merkle root and served from `_catalog`, but it is not a user KA root.
+ * Baseline invariant: a private CG publishing N submitted triples yields one
+ * exact graph-scoped KA with N VM triples and an empty legacy root manifest.
+ * The public DCAT floor is committed independently and served from `_catalog`.
  */
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { mkdtempSync } from 'node:fs';
@@ -16,6 +16,11 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { makeTestKaNumberAllocator } from './_helpers/ka-allocator.js';
 import { DKGAgent } from '../src/index.js';
+import {
+  MemoryLayer,
+  createGraphKnowledgeAssetScope,
+  knowledgeAssetLayerGraphUri,
+} from '@origintrail-official/dkg-core';
 import {
   spawnHardhatEnv, killHardhat, setMinimumRequiredSignatures, HARDHAT_KEYS, type HardhatContext,
 } from '../../chain/test/hardhat-harness.js';
@@ -31,7 +36,7 @@ function chainConfig(opKey: string, adminKey: string) {
 // store the curated ciphertext chunks and declines the ACK (MISSING_CIPHERTEXT_CHUNKS).
 const mkDataDir = (name: string) => mkdtempSync(join(tmpdir(), `rfc49-${name}-`));
 
-describe('baseline — curated CG product-path publish (pre-catalog)', () => {
+describe('baseline — curated CG rootless publish with detached catalog', () => {
   let publisher: DKGAgent;
   let curator: string;
 
@@ -63,7 +68,7 @@ describe('baseline — curated CG product-path publish (pre-catalog)', () => {
     killHardhat(ctx);
   });
 
-  it('a private CG publishes via the product path and yields exactly N data KAs', async () => {
+  it('a private CG publishes exact KAs while retaining a public catalog commitment', async () => {
     const CG = 'rfc49-baseline-private';
     await publisher.createContextGraph({ id: CG, name: 'RFC49 Baseline Private', accessPolicy: 1, callerAgentAddress: curator });
     await publisher.registerContextGraph(CG, { callerAgentAddress: curator });
@@ -73,22 +78,23 @@ describe('baseline — curated CG product-path publish (pre-catalog)', () => {
     await publisher.assertion.write(CG, name, [
       { subject: 'urn:acme:shipment/SH-42', predicate: 'urn:acme:product', object: '"P-9"' },
     ]);
-    // Explicit finalize = the daemon product path (POST /vm/publish does
-    // assertion.finalize then publishFromFinalizedAssertion). The catalog
-    // injection lives in assertionFinalize and is re-injected as generated
-    // catalog material at publish time, without becoming a manifest root.
-    await publisher.assertion.finalize(CG, name);
-    await publisher.assertion.promote(CG, name);
+    const finalized: any = await publisher.assertion.finalize(CG, name);
+    expect(finalized.publicTripleCount).toBe(1);
+    const promoted = await publisher.assertion.promote(CG, name);
+    expect(promoted.promotedCount).toBe(1);
 
     const pub: any = await publisher.publishFromFinalizedAssertion(CG, name);
 
     expect(pub.status).toBe('confirmed');
-    // combined model: the private publish carries only data roots in the KA
-    // manifest. The generated catalog floor is committed in the CG's Merkle root
-    // and public _catalog graph, but not sealed as a Rule-4-colliding root.
-    expect(pub.kaManifest.length).toBe(1);
-    const roots = pub.kaManifest.map((m: any) => String(m.rootEntity ?? m.entity ?? m.subject ?? ''));
-    expect(roots).toEqual(['urn:acme:shipment/SH-42']);
+    expect(pub.kaManifest).toEqual([]);
+    expect(pub.publicQuads).toHaveLength(1);
+    expect(pub.publicQuads[0]).toMatchObject({ subject: 'urn:acme:shipment/SH-42' });
+    const vmGraph = knowledgeAssetLayerGraphUri(
+      CG,
+      MemoryLayer.VerifiableMemory,
+      createGraphKnowledgeAssetScope(pub.ual, pub.assertionVersion ?? '1'),
+    );
+    expect(await (publisher as any).store.countQuads(vmGraph)).toBe(1);
 
     // The catalog entry persists PLAINTEXT in the public _catalog graph — a
     // queryable, standards-compliant DCAT dataset record (NOT encrypted, unlike
@@ -111,15 +117,22 @@ describe('baseline — curated CG product-path publish (pre-catalog)', () => {
     await publisher.assertion.write(CG, secondName, [
       { subject: 'urn:acme:shipment/SH-43', predicate: 'urn:acme:product', object: '"P-10"' },
     ]);
-    await publisher.assertion.finalize(CG, secondName);
-    await publisher.assertion.promote(CG, secondName);
+    const secondFinalized: any = await publisher.assertion.finalize(CG, secondName);
+    expect(secondFinalized.publicTripleCount).toBe(1);
+    const secondPromoted = await publisher.assertion.promote(CG, secondName);
+    expect(secondPromoted.promotedCount).toBe(1);
 
     const secondPub: any = await publisher.publishFromFinalizedAssertion(CG, secondName);
     expect(secondPub.status).toBe('confirmed');
-    expect(secondPub.kaManifest.length).toBe(1);
-    const secondRoots = secondPub.kaManifest.map((m: any) => String(m.rootEntity ?? m.entity ?? m.subject ?? ''));
-    expect(secondRoots).toEqual(['urn:acme:shipment/SH-43']);
-    expect(secondRoots).not.toContain(cgUal);
+    expect(secondPub.kaManifest).toEqual([]);
+    expect(secondPub.publicQuads).toHaveLength(1);
+    expect(secondPub.publicQuads[0]).toMatchObject({ subject: 'urn:acme:shipment/SH-43' });
+    const secondVmGraph = knowledgeAssetLayerGraphUri(
+      CG,
+      MemoryLayer.VerifiableMemory,
+      createGraphKnowledgeAssetScope(secondPub.ual, secondPub.assertionVersion ?? '1'),
+    );
+    expect(await (publisher as any).store.countQuads(secondVmGraph)).toBe(1);
 
     const postSecondCatalog: any = await (publisher as any).store.query(
       `SELECT ?p ?o WHERE { GRAPH <${catalogGraph}> { <${cgUal}> ?p ?o } }`,

--- a/packages/agent/test/direct-rootless-publish.test.ts
+++ b/packages/agent/test/direct-rootless-publish.test.ts
@@ -26,6 +26,34 @@ describe('direct rootless agent publish entrypoint', () => {
     agent = undefined;
   });
 
+  it('rejects caller-authored named graphs before signing a V2 publish', async () => {
+    agent = await DKGAgent.create({
+      name: 'RootlessNamedGraphGuard',
+      store: new OxigraphStore(),
+      chainAdapter: new MockChainAdapter('mock:31337', AUTHOR),
+      nodeRole: 'edge',
+      skills: [],
+    });
+    const internals = agent as unknown as Record<string, any>;
+    internals.getContextGraphOnChainId = vi.fn(async () => '42');
+    internals._buildPrecomputedAttestationForSelection = vi.fn(async () => {
+      throw new Error('named-graph payload must be rejected before signing');
+    });
+
+    await expect(internals._publish(
+      SYSTEM_CONTEXT_GRAPHS.ONTOLOGY,
+      [{
+        subject: 'urn:named:asset',
+        predicate: 'urn:p:value',
+        object: '"value"',
+        graph: 'urn:user:named-graph',
+      }],
+      [],
+      { onChainContextGraphId: '42' },
+    )).rejects.toMatchObject({ code: 'KA_NAMED_GRAPH_SHARE_UNSUPPORTED' });
+    expect(internals._buildPrecomputedAttestationForSelection).not.toHaveBeenCalled();
+  });
+
   it('passes one complete V2 graph envelope into the publisher and broadcast', async () => {
     agent = await DKGAgent.create({
       name: 'DirectRootlessPublish',
@@ -112,16 +140,16 @@ describe('direct rootless agent publish entrypoint', () => {
       accessPolicy: 'ownerOnly',
       publishContextGraphId: '42',
     });
-    // A curated direct publish replaces any caller-provided catalog partition
-    // with the deterministic four-triple public floor inside this same KA.
-    expect(capturedOptions!.quads).toHaveLength(5);
-    expect(capturedOptions!.publicTripleCount).toBe(5);
+    // The submitted canonical RDF remains the complete atomic KA. The trusted
+    // four-key capability produces a separate catalog commitment downstream.
+    expect(capturedOptions!.quads).toEqual(publicQuads);
+    expect(capturedOptions!.publicTripleCount).toBe(1);
     expect(capturedOptions!.privateMerkleRoot).toHaveLength(32);
     expect(capturedOptions!.trustedNonManifestCatalogTriples).toHaveLength(4);
     expect(capturedOptions!.quads.some((quad) =>
       quad.subject === 'did:dkg:context-graph:ontology'
       && quad.predicate === 'http://purl.org/dc/terms/accessRights'
-    )).toBe(true);
+    )).toBe(false);
     expect(internals._buildPrecomputedAttestationForSelection).toHaveBeenCalledWith(
       SYSTEM_CONTEXT_GRAPHS.ONTOLOGY,
       expect.arrayContaining(capturedOptions!.quads),

--- a/packages/agent/test/e2e-chain.test.ts
+++ b/packages/agent/test/e2e-chain.test.ts
@@ -9,9 +9,9 @@ import {
   type PrecomputedUpdateAttestation,
 } from '@origintrail-official/dkg-core';
 import {
-  autoPartition,
   computeFlatKCRootV10,
   computePrivateRootV10,
+  skolemizeKnowledgeAssetParts,
 } from '../../publisher/src/index.js';
 import type { Quad } from '@origintrail-official/dkg-storage';
 import {
@@ -42,20 +42,15 @@ async function buildUpdateSeal(opts: {
   provider: ethers.JsonRpcProvider;
   kav10Address: string;
 }): Promise<PrecomputedUpdateAttestation> {
-  const kaMap = autoPartition(opts.quads);
-  const allPublic = [...kaMap.values()].flat();
-  const privateRoots: Uint8Array[] = [];
-  for (const rootEntity of kaMap.keys()) {
-    const entityPrivateQuads = (opts.privateQuads ?? []).filter(
-      (q) =>
-        q.subject === rootEntity ||
-        q.subject.startsWith(rootEntity + '/.well-known/genid/'),
-    );
-    if (entityPrivateQuads.length === 0) continue;
-    const root = computePrivateRootV10(entityPrivateQuads);
-    if (root) privateRoots.push(root);
-  }
-  const newMerkleRoot = computeFlatKCRootV10(allPublic, privateRoots);
+  const canonical = await skolemizeKnowledgeAssetParts(
+    opts.quads,
+    opts.privateQuads ?? [],
+  );
+  const privateRoot = computePrivateRootV10(canonical.privateQuads);
+  const newMerkleRoot = computeFlatKCRootV10(
+    canonical.publicQuads,
+    privateRoot ? [privateRoot] : [],
+  );
   const chainId = await opts.provider.getNetwork().then((n) => n.chainId);
   const td = buildUpdateAuthorAttestationTypedData({
     chainId: BigInt(chainId),
@@ -205,20 +200,19 @@ describe('E2E: DKGAgent with real blockchain', () => {
         subject: 'did:dkg:test:Alice',
         predicate: 'http://schema.org/name',
         object: '"Alice"',
-        graph: `did:dkg:context-graph:${CONTEXT_GRAPH_ID}`,
+        graph: '',
       },
       {
         subject: 'did:dkg:test:Alice',
         predicate: 'http://schema.org/knows',
         object: 'did:dkg:test:Bob',
-        graph: `did:dkg:context-graph:${CONTEXT_GRAPH_ID}`,
+        graph: '',
       },
     ];
 
     const result = await agents[0].publish(CONTEXT_GRAPH_ID, quads);
     expect(result).toBeDefined();
-    expect(result.kaManifest).toBeDefined();
-    expect(result.kaManifest.length).toBeGreaterThan(0);
+    expect(result.kaManifest).toEqual([]);
     expect(result.status).toBe('confirmed');
     expect(result.onChainResult).toBeDefined();
     expect(result.onChainResult!.txHash).toMatch(/^0x[0-9a-f]{64}$/);
@@ -262,7 +256,10 @@ describe('E2E: DKGAgent with real blockchain', () => {
         subject: 'did:dkg:test:Alice',
         predicate: 'http://schema.org/name',
         object: '"Alice Updated"',
-        graph: `did:dkg:context-graph:${CONTEXT_GRAPH_ID}`,
+        // V2 KAs commit one exact RDF triple set. The DKG-owned VM graph is
+        // derived from the UAL; it is storage placement, not a caller-authored
+        // RDF named graph.
+        graph: '',
       },
     ];
 
@@ -336,19 +333,20 @@ describe('E2E: DKGAgent with real blockchain', () => {
         subject: 'did:dkg:test:Dave',
         predicate: 'http://schema.org/name',
         object: '"Dave"',
-        graph: `did:dkg:context-graph:${secondCG}`,
+        graph: '',
       },
       {
         subject: 'did:dkg:test:Dave',
         predicate: 'http://schema.org/jobTitle',
         object: '"Researcher"',
-        graph: `did:dkg:context-graph:${secondCG}`,
+        graph: '',
       },
     ];
 
     const result = await agents[0].publish(secondCG, quads);
     expect(result).toBeDefined();
-    expect(result.kaManifest.length).toBeGreaterThan(0);
+    expect(result.kaManifest).toEqual([]);
+    expect(result.publicTripleCount).toBe(quads.length);
     expect(result.status).toBe('confirmed');
     expect(result.onChainResult).toBeDefined();
 
@@ -363,10 +361,9 @@ describe('E2E: DKGAgent with real blockchain', () => {
   }, 60_000);
 
   // -------------------------------------------------------------------------
-  // Multi-entity publish — OT-RFC-44 / Design B.
-  // Direct agent.publish now routes multi-root payloads as one KA with multiple
-  // member entities. The on-chain publish still uses knowledgeAssetsAmount=1;
-  // the manifest keeps per-root compatibility token IDs for UAL suffix callers.
+  // Multi-entity publish — rootless V2.
+  // Subjects are data, not KA partitions: direct agent.publish commits the
+  // complete six-triple set as one KA and emits no legacy root manifest.
   // -------------------------------------------------------------------------
 
   it('publishes multi-root payloads through agent.publish as one Knowledge Asset', async () => {
@@ -376,13 +373,13 @@ describe('E2E: DKGAgent with real blockchain', () => {
         subject: e,
         predicate: 'http://schema.org/name',
         object: `"${e.split(':').pop()}"`,
-        graph: `did:dkg:context-graph:${CONTEXT_GRAPH_ID}`,
+        graph: '',
       },
       {
         subject: e,
         predicate: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
         object: 'http://schema.org/Thing',
-        graph: `did:dkg:context-graph:${CONTEXT_GRAPH_ID}`,
+        graph: '',
       },
     ]);
 
@@ -390,8 +387,8 @@ describe('E2E: DKGAgent with real blockchain', () => {
 
     expect(result.status).toBe('confirmed');
     expect(result.onChainResult).toBeDefined();
-    expect(new Set(result.kaManifest.map((m) => m.rootEntity))).toEqual(new Set(entities));
-    expect(new Set(result.kaManifest.map((m) => String(m.tokenId)))).toEqual(new Set(['1', '2', '3']));
+    expect(result.kaManifest).toEqual([]);
+    expect(result.publicTripleCount).toBe(quads.length);
   }, 30_000);
 
   // -------------------------------------------------------------------------
@@ -425,7 +422,7 @@ describe('E2E: DKGAgent with real blockchain', () => {
         subject: 'did:dkg:test:GossipEntity',
         predicate: 'http://schema.org/name',
         object: '"GossipTest"',
-        graph: `did:dkg:context-graph:${gossipCG}`,
+        graph: '',
       },
     ];
 

--- a/packages/agent/test/encrypt-inline-policy.test.ts
+++ b/packages/agent/test/encrypt-inline-policy.test.ts
@@ -607,7 +607,16 @@ describe('DKGAgent.update inline encryption routing', () => {
         error: recorder(() => undefined),
         debug: recorder(() => undefined),
       },
-      chain: { chainId },
+      chain: {
+        chainId,
+        getEvmChainId: recorder(async () => 31337n),
+        getKnowledgeAssetsLifecycleAddress: recorder(
+          async () => '0x2222222222222222222222222222222222222222',
+        ),
+        getKnowledgeAssetOwner: recorder(async () => author),
+        hasContractCode: recorder(async () => true),
+        verifyContractSignature: recorder(async () => true),
+      },
       getContextGraphOnChainId: recorder(async () => '42'),
       createV10UpdateACKProvider: recorder(() => undefined),
       node: { peerId: { toString: () => 'peer-1' } },

--- a/packages/agent/test/encrypt-inline-policy.test.ts
+++ b/packages/agent/test/encrypt-inline-policy.test.ts
@@ -13,16 +13,25 @@ import {
   ciphertextChunkStoreGraph,
   ciphertextChunkStoreSubject,
   CIPHERTEXT_CHUNK_PREDICATE,
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  MemoryLayer,
+  contextGraphDataUri,
+  contextGraphMetaUri,
+  createGraphKnowledgeAssetScope,
   decodeStorageACK,
   decryptV10PublishPayload,
   encodePublishIntent,
   isStorageACKDecline,
+  knowledgeAssetLayerGraphUri,
 } from '@origintrail-official/dkg-core';
 import {
   StorageACKHandler,
   catalogTripleKey,
+  computeFlatKCRootV10,
+  computePrivateRootV10,
   generatedPrivateCatalogFloorQuads,
   generatedPrivateCatalogTripleKeys,
+  skolemizeKnowledgeAssetParts,
   type KnowledgeAssetVmPublishRequest,
 } from '@origintrail-official/dkg-publisher';
 import { DKGAgent } from '../src/dkg-agent.js';
@@ -491,7 +500,7 @@ describe('DKGAgent._publish inline encryption routing', () => {
       encryptInlinePayload,
       encryptInlineChunked,
     }));
-    expect(publishArgs).not.toHaveProperty('trustedNonManifestCatalogTriples');
+    expect(publishArgs.trustedNonManifestCatalogTriples).toBeUndefined();
   });
 
   it('keeps caller-supplied mismatched onChainContextGraphId as an explicit policy target', async () => {
@@ -553,6 +562,33 @@ describe('DKGAgent._publish inline encryption routing', () => {
 
 describe('DKGAgent.update inline encryption routing', () => {
   it('passes derived update on-chain id as binding-only while preserving publisher target', async () => {
+    const store = new OxigraphStore();
+    const chainId = 'mock:31337';
+    const author = '0x1111111111111111111111111111111111111111';
+    const kaNumber = 123n;
+    const kaId = (BigInt(author) << 96n) | kaNumber;
+    const ual = `did:dkg:${chainId}/${author}/${kaNumber.toString()}`;
+    const currentScope = createGraphKnowledgeAssetScope(ual, 1);
+    const metaGraph = contextGraphMetaUri('private-cg');
+    const assertionGraph = knowledgeAssetLayerGraphUri(
+      'private-cg',
+      MemoryLayer.VerifiableMemory,
+      currentScope,
+    );
+    const dkg = 'http://dkg.io/ontology/';
+    const xsdInteger = 'http://www.w3.org/2001/XMLSchema#integer';
+    await store.insert([
+      { subject: ual, predicate: `${dkg}contentScopeVersion`, object: `"${GRAPH_KA_CONTENT_SCOPE_VERSION}"^^<${xsdInteger}>`, graph: metaGraph },
+      { subject: ual, predicate: `${dkg}kaUal`, object: ual, graph: metaGraph },
+      { subject: ual, predicate: `${dkg}assertionVersion`, object: `"1"^^<${xsdInteger}>`, graph: metaGraph },
+      { subject: ual, predicate: `${dkg}batchId`, object: `"${kaId.toString()}"^^<${xsdInteger}>`, graph: metaGraph },
+      { subject: ual, predicate: `${dkg}status`, object: '"confirmed"', graph: metaGraph },
+      { subject: ual, predicate: `${dkg}contextGraph`, object: contextGraphDataUri('private-cg'), graph: metaGraph },
+      { subject: ual, predicate: `${dkg}assertionGraph`, object: assertionGraph, graph: metaGraph },
+    ]);
+    const updateQuads = [{ subject: 'urn:update:subject', predicate: 'urn:update:predicate', object: '"o"', graph: '' }];
+    const canonical = await skolemizeKnowledgeAssetParts(updateQuads, []);
+    const updateRoot = computeFlatKCRootV10(canonical.publicQuads, []);
     const updateEncryptInlinePayload = async (plaintext: Uint8Array) => plaintext;
     const updateEncryptInlineChunked = async () => ({
       ciphertextChunksRoot: new Uint8Array(32),
@@ -564,17 +600,19 @@ describe('DKGAgent.update inline encryption routing', () => {
       status: 'confirmed',
     }));
     const agentLike = {
+      store,
       log: {
         info: recorder(() => undefined),
         warn: recorder(() => undefined),
         error: recorder(() => undefined),
         debug: recorder(() => undefined),
       },
+      chain: { chainId },
       getContextGraphOnChainId: recorder(async () => '42'),
       createV10UpdateACKProvider: recorder(() => undefined),
       node: { peerId: { toString: () => 'peer-1' } },
       publisher: {
-        update: publisherUpdate,
+        updateKnowledgeAssetFromSharedMemory: publisherUpdate,
       },
       _resolveEncryptInlinePayload: recorder(async () => updateEncryptInlinePayload),
       _resolveEncryptInlineChunked: recorder(async () => updateEncryptInlineChunked),
@@ -582,9 +620,18 @@ describe('DKGAgent.update inline encryption routing', () => {
 
     await (DKGAgent.prototype as any).update.call(
       agentLike,
-      123n,
+      kaId,
       'private-cg',
-      [{ subject: 's', predicate: 'p', object: '"o"', graph: 'g' }],
+      updateQuads,
+      [],
+      {
+        precomputedUpdateAttestation: {
+          expectedNewMerkleRoot: updateRoot,
+          authorAddress: author,
+          signature: { r: new Uint8Array(32), vs: new Uint8Array(32) },
+          schemeVersion: 1,
+        },
+      },
     );
 
     expect(agentLike._resolveEncryptInlinePayload.calls.at(-1)).toEqual([
@@ -602,7 +649,7 @@ describe('DKGAgent.update inline encryption routing', () => {
       { aeadBindingContextGraphId: '42' },
     ]);
     expect(publisherUpdate.calls.at(-1)).toEqual([
-      123n,
+      kaId,
       expect.objectContaining({
         publishContextGraphId: '42',
         encryptInlinePayload: updateEncryptInlinePayload,
@@ -749,41 +796,55 @@ function makeQueuedAgentHarness(options: {
   return { agentLike, publisherPublish };
 }
 
-function makeQueuedPublishRequest(options: {
+async function makeQueuedPublishRequest(options: {
   contextGraphId: string;
   name: string;
   shareOperationId: string;
-  root: string;
   intentByte: string;
-  reservedKaId?: `${bigint}`;
-}): KnowledgeAssetVmPublishRequest {
+  quads: Array<{ subject: string; predicate: string; object: string; graph: string }>;
+  privateQuads?: Array<{ subject: string; predicate: string; object: string; graph: string }>;
+}): Promise<KnowledgeAssetVmPublishRequest> {
+  const canonical = await skolemizeKnowledgeAssetParts(
+    options.quads.map((quad) => ({ ...quad, graph: '' })),
+    (options.privateQuads ?? []).map((quad) => ({ ...quad, graph: '' })),
+  );
+  const privateRoot = computePrivateRootV10(canonical.privateQuads);
+  const merkleRoot = ethers.hexlify(computeFlatKCRootV10(
+    canonical.publicQuads,
+    privateRoot ? [privateRoot] : [],
+  ));
+  const packedKaId = (BigInt(QUEUED_TEST_AUTHOR) << 96n) | 1n;
   return {
     contextGraphId: options.contextGraphId,
     name: options.name,
     shareOperationId: options.shareOperationId,
-    roots: [options.root],
+    roots: [],
     seal: {
-      merkleRoot: `0x${'12'.repeat(32)}`,
+      merkleRoot,
       authorAddress: QUEUED_TEST_AUTHOR,
       signature: {
         r: `0x${'34'.repeat(32)}`,
         vs: `0x${'56'.repeat(32)}`,
       },
       schemeVersion: 1,
-      ...(options.reservedKaId === undefined
-        ? {}
-        : { reservedKaId: options.reservedKaId }),
+      reservedKaId: packedKaId.toString() as `${bigint}`,
     },
     sealChainId: '31337',
     sealKav10Address: QUEUED_TEST_LIFECYCLE,
     sealFinalizedAtIso: '2026-01-01T00:00:00.000Z',
-    sealMerkleRoot: `0x${'12'.repeat(32)}`,
+    sealMerkleRoot: merkleRoot,
     intentKey: `sha256:${options.intentByte.repeat(32)}`,
+    contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+    kaUal: `did:dkg:mock:31337/${QUEUED_TEST_AUTHOR}/1`,
+    assertionVersion: '1',
+    publicTripleCount: canonical.publicQuads.length,
+    ...(privateRoot ? { privateMerkleRoot: ethers.hexlify(privateRoot) } : {}),
+    privateTripleCount: canonical.privateQuads.length,
   };
 }
 
 describe('DKGAgent.publishQueuedKnowledgeAssetVmPublish inline encryption routing', () => {
-  it('reconstructs the curated catalog floor and lets real encryption override placeholders', async () => {
+  it('keeps the V2 snapshot exact while passing a detached catalog capability', async () => {
     const realInline = recorder(async (plaintext: Uint8Array) => new Uint8Array([...plaintext, 0xaa]));
     const realChunked = recorder(async () => ({
       ciphertextChunksRoot: ethers.getBytes(ethers.id('queued-real-chunk-root')),
@@ -809,30 +870,28 @@ describe('DKGAgent.publishQueuedKnowledgeAssetVmPublish inline encryption routin
       encryptInlinePayload: realInline,
       encryptInlineChunked: realChunked,
     });
-    const request = makeQueuedPublishRequest({
+    const generatedFloor = generatedPrivateCatalogFloorQuads('private-cg');
+    const legacyFloorQuad = { ...generatedFloor[0], graph: 'urn:legacy:catalog' };
+    const snapshotQuads = [
+      {
+        subject: 'urn:test:queued-private',
+        predicate: 'http://schema.org/name',
+        object: '"Queued Private"',
+        graph: '',
+      },
+      legacyFloorQuad,
+    ];
+    const request = await makeQueuedPublishRequest({
       contextGraphId: 'private-cg',
       name: 'queued-private-ka',
       shareOperationId: 'share-op-1',
-      root: 'urn:test:queued-private',
       intentByte: 'ab',
-      reservedKaId: (
-        (BigInt(QUEUED_TEST_AUTHOR) << 96n) | 1n
-      ).toString() as `${bigint}`,
+      quads: snapshotQuads,
     });
-    const generatedFloor = generatedPrivateCatalogFloorQuads('private-cg');
-    const legacyFloorQuad = { ...generatedFloor[0], graph: 'urn:legacy:catalog' };
 
     await (DKGAgent.prototype as any).publishQueuedKnowledgeAssetVmPublish.call(agentLike, request, {
       contextGraphId: request.contextGraphId,
-      quads: [
-        {
-          subject: 'urn:test:queued-private',
-          predicate: 'http://schema.org/name',
-          object: '"Queued Private"',
-          graph: '',
-        },
-        legacyFloorQuad,
-      ],
+      quads: snapshotQuads,
       encryptInlinePayload: failClosedInline,
       encryptInlineChunked: failClosedChunked,
     });
@@ -858,10 +917,11 @@ describe('DKGAgent.publishQueuedKnowledgeAssetVmPublish inline encryption routin
       trustedNonManifestCatalogTriples: generatedPrivateCatalogTripleKeys('private-cg'),
     });
     const publishedQuads = publisherPublish.calls.at(-1)?.[0].quads;
+    expect(publishedQuads).toHaveLength(2);
     expect(publishedQuads).toContainEqual({ ...legacyFloorQuad, graph: '' });
-    for (const key of generatedPrivateCatalogTripleKeys('private-cg')) {
-      expect(publishedQuads.filter((quad: any) => catalogTripleKey(quad) === key)).toHaveLength(1);
-    }
+    expect([...generatedPrivateCatalogTripleKeys('private-cg')].filter((key) =>
+      publishedQuads.some((quad: any) => catalogTripleKey(quad) === key),
+    )).toHaveLength(1);
     expect(publisherPublish.calls.at(-1)?.[0].encryptInlinePayload).not.toBe(failClosedInline);
     expect(publisherPublish.calls.at(-1)?.[0].encryptInlineChunked).not.toBe(failClosedChunked);
   });
@@ -873,19 +933,19 @@ describe('DKGAgent.publishQueuedKnowledgeAssetVmPublish inline encryption routin
       ual: 'did:dkg:local/queued-private-local',
       encryptInlinePayload: realInline,
     });
-    const request = makeQueuedPublishRequest({
-      contextGraphId: 'private-local-cg',
-      name: 'queued-private-local-ka',
-      shareOperationId: 'share-op-private-local',
-      root: 'urn:test:queued-private-local',
-      intentByte: 'cd',
-    });
     const originalQuads = [{
       subject: 'urn:test:queued-private-local',
       predicate: 'http://schema.org/name',
       object: '"Queued Private Local"',
       graph: '',
     }];
+    const request = await makeQueuedPublishRequest({
+      contextGraphId: 'private-local-cg',
+      name: 'queued-private-local-ka',
+      shareOperationId: 'share-op-private-local',
+      intentByte: 'cd',
+      quads: originalQuads,
+    });
 
     await (DKGAgent.prototype as any).publishQueuedKnowledgeAssetVmPublish.call(
       agentLike,
@@ -914,19 +974,19 @@ describe('DKGAgent.publishQueuedKnowledgeAssetVmPublish inline encryption routin
       peerId: 'did:dkg:agent:queued-placeholder',
       ual: 'did:dkg:local/queued-placeholder',
     });
-    const request = makeQueuedPublishRequest({
-      contextGraphId: 'public-cg',
-      name: 'queued-public-ka',
-      shareOperationId: 'share-op-placeholder',
-      root: 'urn:test:queued-public',
-      intentByte: 'ef',
-    });
     const originalQuads = [{
       subject: 'urn:test:queued-public',
       predicate: 'http://schema.org/name',
       object: '"Queued Public"',
       graph: '',
     }];
+    const request = await makeQueuedPublishRequest({
+      contextGraphId: 'public-cg',
+      name: 'queued-public-ka',
+      shareOperationId: 'share-op-placeholder',
+      intentByte: 'ef',
+      quads: originalQuads,
+    });
 
     await (DKGAgent.prototype as any).publishQueuedKnowledgeAssetVmPublish.call(
       agentLike,
@@ -956,23 +1016,23 @@ describe('DKGAgent.publishQueuedKnowledgeAssetVmPublish inline encryption routin
       },
       onChainContextGraphId: null,
     });
-    const request = makeQueuedPublishRequest({
+    const queuedBindingQuads = [{
+      subject: 'urn:test:queued-binding',
+      predicate: 'http://schema.org/name',
+      object: '"Queued Binding"',
+      graph: '',
+    }];
+    const request = await makeQueuedPublishRequest({
       contextGraphId: 'memory-layers-e2e',
       name: 'queued-binding-ka',
       shareOperationId: 'share-op-1',
-      root: 'urn:test:queued-binding',
       intentByte: 'cd',
-      reservedKaId: '1',
+      quads: queuedBindingQuads,
     });
 
     await (DKGAgent.prototype as any).publishQueuedKnowledgeAssetVmPublish.call(agentLike, request, {
       contextGraphId: request.contextGraphId,
-      quads: [{
-        subject: 'urn:test:queued-binding',
-        predicate: 'http://schema.org/name',
-        object: '"Queued Binding"',
-        graph: '',
-      }],
+      quads: queuedBindingQuads,
       publishContextGraphId: '42',
     });
 
@@ -1012,25 +1072,25 @@ describe('DKGAgent.publishQueuedKnowledgeAssetVmPublish inline encryption routin
       },
       onChainContextGraphId: null,
     });
-    const request = makeQueuedPublishRequest({
+    const unregisteredQuads = [{
+      subject: 'urn:test:queued-unregistered',
+      predicate: 'http://schema.org/name',
+      object: '"Queued Unregistered"',
+      graph: '',
+    }];
+    const request = await makeQueuedPublishRequest({
       contextGraphId: 'unregistered-product-cg',
       name: 'queued-unregistered-ka',
       shareOperationId: 'share-op-1',
-      root: 'urn:test:queued-unregistered',
       intentByte: 'de',
-      reservedKaId: '1',
+      quads: unregisteredQuads,
     });
 
     let thrown: any;
     try {
       await (DKGAgent.prototype as any).publishQueuedKnowledgeAssetVmPublish.call(agentLike, request, {
         contextGraphId: request.contextGraphId,
-        quads: [{
-          subject: 'urn:test:queued-unregistered',
-          predicate: 'http://schema.org/name',
-          object: '"Queued Unregistered"',
-          graph: '',
-        }],
+        quads: unregisteredQuads,
       });
     } catch (err) {
       thrown = err;

--- a/packages/agent/test/ka-graph-finalization-handler.test.ts
+++ b/packages/agent/test/ka-graph-finalization-handler.test.ts
@@ -314,6 +314,7 @@ describe('graph-scoped finalization handler', () => {
 
   it('repairs rootless metadata after VM content committed but metadata did not', async () => {
     const { message, swmGraph, vmGraph } = await stageGraph();
+    if (!message.privateMerkleRoot) throw new Error('expected private commitment');
     const swmResult = await store.query(
       `CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${swmGraph}> { ?s ?p ?o } }`,
     );
@@ -352,6 +353,8 @@ describe('graph-scoped finalization handler', () => {
         <${UAL}> <http://dkg.io/ontology/contentScopeVersion> "2"^^<http://www.w3.org/2001/XMLSchema#integer> ;
           <http://dkg.io/ontology/assertionVersion> "1"^^<http://www.w3.org/2001/XMLSchema#integer> ;
           <http://dkg.io/ontology/assertionGraph> <${vmGraph}> ;
+          <http://dkg.io/ontology/privateTripleCount> "1"^^<http://www.w3.org/2001/XMLSchema#integer> ;
+          <http://dkg.io/ontology/privateMerkleRoot> "${Buffer.from(message.privateMerkleRoot).toString('hex')}" ;
           <http://dkg.io/ontology/status> "confirmed" ;
           <http://dkg.io/ontology/materializedVersion> "123:0" .
       } }`,

--- a/packages/agent/test/ka-graph-finalization-handler.test.ts
+++ b/packages/agent/test/ka-graph-finalization-handler.test.ts
@@ -312,6 +312,53 @@ describe('graph-scoped finalization handler', () => {
     expect(await store.countQuads(swmGraph)).toBe(0);
   });
 
+  it('repairs rootless metadata after VM content committed but metadata did not', async () => {
+    const { message, swmGraph, vmGraph } = await stageGraph();
+    const swmResult = await store.query(
+      `CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${swmGraph}> { ?s ?p ?o } }`,
+    );
+    if (swmResult.type !== 'quads') throw new Error('expected staged SWM quads');
+    await store.dropGraph(vmGraph);
+    await store.insert(swmResult.quads.map((quad) => ({ ...quad, graph: vmGraph })));
+    await store.dropGraph(swmGraph);
+    const metaGraph = `did:dkg:context-graph:${CG}/_meta`;
+    await store.deleteByPattern({ graph: metaGraph, subject: UAL });
+
+    const internals = handler as unknown as {
+      verifyChainCgBinding: (kaId: bigint, cgId: string) => Promise<boolean>;
+      findSwmSnapshotForMerkleRoot: () => Promise<never>;
+    };
+    internals.verifyChainCgBinding = async () => true;
+    internals.findSwmSnapshotForMerkleRoot = async () => {
+      throw new Error('legacy root scan must not run for VM metadata recovery');
+    };
+
+    const outcome = await handler.handleChainReconciledKC({
+      contextGraphId: CG,
+      onChainCgId: '42',
+      ual: UAL,
+      merkleRoot: message.kcMerkleRoot,
+      publisherAddress: PUBLISHER,
+      kaId: PACKED_KA_ID,
+      versionBlock: 123,
+      authorAddress: AUTHOR,
+    }, createOperationContext('system'));
+
+    expect(outcome).toBe('already-confirmed');
+    expect(await store.countQuads(vmGraph)).toBe(2);
+    expect(await store.countQuads(swmGraph)).toBe(0);
+    const repaired = await store.query(
+      `ASK { GRAPH <${metaGraph}> {
+        <${UAL}> <http://dkg.io/ontology/contentScopeVersion> "2"^^<http://www.w3.org/2001/XMLSchema#integer> ;
+          <http://dkg.io/ontology/assertionVersion> "1"^^<http://www.w3.org/2001/XMLSchema#integer> ;
+          <http://dkg.io/ontology/assertionGraph> <${vmGraph}> ;
+          <http://dkg.io/ontology/status> "confirmed" ;
+          <http://dkg.io/ontology/materializedVersion> "123:0" .
+      } }`,
+    );
+    expect(repaired).toMatchObject({ type: 'boolean', value: true });
+  });
+
   it('does not let an older confirmed assertion mask reconciliation of a newer chain root', async () => {
     const first = await stageGraph();
     await handler.handleFinalizationMessage(encodeFinalizationMessage(first.message), CG);

--- a/packages/agent/test/publish-finalized-agent-lane.test.ts
+++ b/packages/agent/test/publish-finalized-agent-lane.test.ts
@@ -90,7 +90,7 @@ describe('DKGAgent publishFromFinalizedAssertion agent lane', () => {
       .toThrow(/not in author .* namespace/);
   });
 
-  it('injects the curated catalog floor into the exact named lifecycle graph', async () => {
+  it('keeps the legacy catalog-in-SWM helper scoped to the selected lifecycle graph', async () => {
     const store = new OxigraphStore();
     const agent = Object.create(DKGAgent.prototype) as any;
     agent.store = store;

--- a/packages/agent/test/rfc49-catalog-parity.e2e.test.ts
+++ b/packages/agent/test/rfc49-catalog-parity.e2e.test.ts
@@ -38,21 +38,17 @@ import {
 import {
   computeCatalogRoot,
   contextGraphCatalogUri,
-  contextGraphDataUri,
-  partitionCatalogQuads,
+  createGraphKnowledgeAssetScope,
+  knowledgeAssetLayerGraphUri,
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  MemoryLayer,
   buildUpdateAuthorAttestationTypedData,
   AUTHOR_SCHEME_VERSION_V1,
   type PrecomputedUpdateAttestation,
 } from '@origintrail-official/dkg-core';
-// The curated-UPDATE leg signs its precomputedUpdateAttestation over the SAME
-// floor-injected quads the producer's update() recomputes from, so it imports
-// the exact floor builder the feature uses (deterministic from the CG DID) plus
-// the matching V10 merkle/partition helpers.
-import { buildPublicProjection } from '../src/context-graph-public-projection.js';
 import {
-  autoPartition,
   computeFlatKCRootV10,
-  computePrivateRootV10,
+  skolemizeKnowledgeAsset,
   TripleStoreAsyncLiftPublisher,
 } from '../../publisher/src/index.js';
 import type { Quad } from '@origintrail-official/dkg-storage';
@@ -87,37 +83,18 @@ function numericCgIdFromCatalogGraph(graphUri: string): bigint | null {
 /**
  * Build a `precomputedUpdateAttestation` for a curated UPDATE.
  *
- * A V10 update requires a caller-supplied attestation over the NEW merkle root
- * (the agent's `update()` never auto-mints one). For a CURATED CG the producer's
- * `update()` RE-INJECTS the deterministic public `_catalog` floor into the
- * payload BEFORE computing the on-chain merkle (dkg-agent-publish.ts: the
- * `isCuratedUpdate` branch — `partitionCatalogQuads` + `buildPublicProjection`
- * → `[...nonCatalog, ...floor]`), then hard-checks
- * `precomputedUpdateAttestation.expectedNewMerkleRoot === kcMerkleRoot`. So this
- * seal MUST commit to the merkle over the POST-floor-injection quads — we mirror
- * the producer's injection here with the SAME builder (deterministic floor) so
- * the two roots agree by construction. Graph term and order are irrelevant: the
- * V10 triple hash excludes the graph and the tree sorts+dedupes its leaves.
+ * A V10 update requires a caller-supplied attestation over the NEW atomic KA
+ * Merkle root. The curated catalog floor is committed independently and is not
+ * part of this author seal or the exact per-KA graph.
  */
 async function buildCuratedUpdateSeal(opts: {
   kaId: bigint;
-  contextGraphId: string;
   newQuads: Quad[];
   author: Wallet;
   provider: ethers.JsonRpcProvider;
   kav10Address: string;
 }): Promise<PrecomputedUpdateAttestation> {
-  const cgDid = contextGraphDataUri(opts.contextGraphId);
-  // Mirror dkg-agent-publish.ts update()'s curated floor injection EXACTLY.
-  const { otherQuads: nonCatalogQuads } = partitionCatalogQuads(opts.newQuads, cgDid);
-  const catalogFloor = buildPublicProjection({ ual: cgDid, accessPolicy: 'private', graph: cgDid });
-  const injected: Quad[] = [...nonCatalogQuads, ...catalogFloor];
-
-  // Mirror publisher.update()'s merkle recompute (skolemize === autoPartition,
-  // computeFlatKCRootV10 over the flattened public quads + per-entity private
-  // roots). The UPDATE leg below ships no private quads, so privateRoots is [].
-  const kaMap = autoPartition(injected);
-  const allPublic = [...kaMap.values()].flat();
+  const allPublic = await skolemizeKnowledgeAsset(opts.newQuads);
   const newMerkleRoot = computeFlatKCRootV10(allPublic, []);
 
   const chainId = await opts.provider.getNetwork().then((n) => n.chainId);
@@ -179,14 +156,33 @@ describe('OT-RFC-49 WS-D — catalog producer↔extractor↔chain parity', () =>
     await publisher.assertion.write(CG, name, [
       { subject: 'urn:acme:shipment/SH-42', predicate: 'urn:acme:product', object: '"P-9"' },
     ]);
-    await publisher.assertion.finalize(CG, name);
-    await publisher.assertion.promote(CG, name);
+    const finalized: any = await publisher.assertion.finalize(CG, name);
+    expect(finalized.publicTripleCount).toBe(1);
+    const promoted = await publisher.assertion.promote(CG, name);
+    expect(promoted.promotedCount).toBe(1);
 
     const pub: any = await publisher.publishFromFinalizedAssertion(CG, name);
 
     // A confirmed publish, with the ACK supplied by the REMOTE ackCore, is free
     // proof that producer/collector/handler agree on the catalog ACK digest.
     expect(pub.status).toBe('confirmed');
+    expect(pub.kaManifest).toEqual([]);
+    expect(pub.publicQuads).toHaveLength(1);
+    expect(pub.publicQuads[0]).toMatchObject({
+      subject: 'urn:acme:shipment/SH-42',
+      predicate: 'urn:acme:product',
+      object: '"P-9"',
+    });
+    const vmGraph = knowledgeAssetLayerGraphUri(
+      CG,
+      MemoryLayer.VerifiableMemory,
+      createGraphKnowledgeAssetScope(pub.ual, pub.assertionVersion ?? '1'),
+    );
+    expect(await (publisher as any).store.countQuads(vmGraph)).toBe(1);
+    const leakedCatalog = await (publisher as any).store.query(
+      `ASK { GRAPH <${vmGraph}> { <did:dkg:context-graph:${CG}> ?p ?o } }`,
+    );
+    expect(leakedCatalog).toMatchObject({ type: 'boolean', value: false });
     const kaId: bigint = pub.kaId;
     expect(typeof kaId).toBe('bigint');
 
@@ -364,17 +360,47 @@ describe('OT-RFC-49 WS-D — catalog producer↔extractor↔chain parity', () =>
     ];
     const precomputedUpdateAttestation = await buildCuratedUpdateSeal({
       kaId,
-      contextGraphId: CG,
       newQuads,
       author,
       provider: ctx.provider,
       kav10Address: await chain.getKnowledgeAssetsLifecycleAddress(),
     });
 
-    const upd: any = await publisher.update(kaId, CG, newQuads, [], { precomputedUpdateAttestation });
+    // V2 updates consume one immutable version-scoped SWM graph; callers do
+    // not get to substitute an arbitrary inline bag after the author seal is
+    // created. Stage the exact assertionVersion=2 payload at that boundary.
+    const updateScope = createGraphKnowledgeAssetScope(pub.ual, '2');
+    const updateSwmGraph = knowledgeAssetLayerGraphUri(
+      CG,
+      MemoryLayer.SharedWorkingMemory,
+      updateScope,
+    );
+    await (publisher as any).store.insert(
+      newQuads.map((quad) => ({ ...quad, graph: updateSwmGraph })),
+    );
+
+    const upd: any = await publisher.update(kaId, CG, newQuads, [], {
+      precomputedUpdateAttestation,
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      kaUal: pub.ual,
+      assertionVersion: '2',
+      publicTripleCount: newQuads.length,
+      privateTripleCount: 0,
+    });
     expect(upd.status, 'curated update must CONFIRM (no CuratedCGRequiresCatalogCommitment revert)').toBe('confirmed');
     // The update targets — and re-confirms — the SAME on-chain KA as the publish.
     expect(upd.kaId).toBe(kaId);
+    expect(upd.publicQuads).toHaveLength(newQuads.length);
+    const updateVmGraph = knowledgeAssetLayerGraphUri(
+      CG,
+      MemoryLayer.VerifiableMemory,
+      updateScope,
+    );
+    expect(await (publisher as any).store.countQuads(updateVmGraph)).toBe(newQuads.length);
+    const updateCatalogLeak = await (publisher as any).store.query(
+      `ASK { GRAPH <${updateVmGraph}> { <did:dkg:context-graph:${CG}> ?p ?o } }`,
+    );
+    expect(updateCatalogLeak).toMatchObject({ type: 'boolean', value: false });
 
     // ── on-chain: catalog still committed, non-zero, EQUALS the publish baseline. ──
     // The catalog is the stable public floor — a curated update RE-COMMITS the

--- a/packages/agent/test/rootless-update-boundary.test.ts
+++ b/packages/agent/test/rootless-update-boundary.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
+  AUTHOR_SCHEME_VERSION_V1,
   GRAPH_KA_CONTENT_SCOPE_VERSION,
   MemoryLayer,
+  buildUpdateAuthorAttestationTypedData,
   contextGraphDataUri,
   contextGraphMetaUri,
   createGraphKnowledgeAssetScope,
@@ -21,12 +23,21 @@ import {
   computePrivateRootV10,
   skolemizeKnowledgeAssetParts,
 } from '@origintrail-official/dkg-publisher';
+import { ethers } from 'ethers';
 import { PublishMethods } from '../src/dkg-agent-publish.js';
 
 const CG = 'rootless-update-boundary';
 const CHAIN_ID = 'mock:31337';
 const ORIGINAL_AUTHOR = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
-const CURRENT_OWNER = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const EVM_CHAIN_ID = 31337n;
+const KAV_ADDRESS = '0x1111111111111111111111111111111111111111';
+const CURRENT_OWNER_WALLET = new ethers.Wallet(
+  '0x59c6995e998f97a5a0044976f7d4b21ddc10b15f2b79366a0a69c3fcf4e7f5c2',
+);
+const ATTACKER_WALLET = new ethers.Wallet(
+  '0x8b3a350cf5c34c9194ca3a545d05a0f4f70e6fb072cf5f77b905d8b317f2f3d0',
+);
+const CURRENT_OWNER = CURRENT_OWNER_WALLET.address;
 const KA_NUMBER = 7n;
 const KA_ID = (BigInt(ORIGINAL_AUTHOR) << 96n) | KA_NUMBER;
 const UAL = `did:dkg:${CHAIN_ID}/${ORIGINAL_AUTHOR}/${KA_NUMBER.toString()}`;
@@ -64,24 +75,39 @@ async function seedConfirmedRootlessHead(store: OxigraphStore): Promise<void> {
 async function updateAttestation(
   publicQuads: Quad[],
   privateQuads: Quad[] = [],
-  authorAddress = CURRENT_OWNER,
+  signer = CURRENT_OWNER_WALLET,
+  authorAddress = signer.address,
 ) {
   const canonical = await skolemizeKnowledgeAssetParts(publicQuads, privateQuads);
   const privateRoot = computePrivateRootV10(canonical.privateQuads);
+  const expectedNewMerkleRoot = computeFlatKCRootV10(
+    canonical.publicQuads,
+    privateRoot ? [privateRoot] : [],
+  );
+  const typedData = buildUpdateAuthorAttestationTypedData({
+    chainId: EVM_CHAIN_ID,
+    kav10Address: KAV_ADDRESS,
+    kaId: KA_ID,
+    newMerkleRoot: expectedNewMerkleRoot,
+    authorAddress,
+    schemeVersion: AUTHOR_SCHEME_VERSION_V1,
+  });
+  const signed = ethers.Signature.from(await signer.signTypedData(
+    typedData.domain,
+    typedData.types,
+    typedData.message,
+  ));
   return {
     canonical,
     privateRoot,
     attestation: {
-      expectedNewMerkleRoot: computeFlatKCRootV10(
-        canonical.publicQuads,
-        privateRoot ? [privateRoot] : [],
-      ),
+      expectedNewMerkleRoot,
       authorAddress,
       signature: {
-        r: new Uint8Array(32),
-        vs: new Uint8Array(32),
+        r: ethers.getBytes(signed.r),
+        vs: ethers.getBytes(signed.yParityAndS),
       },
-      schemeVersion: 1,
+      schemeVersion: AUTHOR_SCHEME_VERSION_V1,
     },
   };
 }
@@ -92,7 +118,12 @@ function makeAgentLike(
 ) {
   return {
     store,
-    chain: { chainId: CHAIN_ID },
+    chain: {
+      chainId: CHAIN_ID,
+      getEvmChainId: async () => EVM_CHAIN_ID,
+      getKnowledgeAssetsLifecycleAddress: async () => KAV_ADDRESS,
+      hasContractCode: async () => false,
+    },
     log: {
       info: () => undefined,
       warn: () => undefined,
@@ -121,7 +152,6 @@ describe('DKGAgent rootless update boundary', () => {
     const { canonical, privateRoot, attestation } = await updateAttestation(
       publicQuads,
       privateQuads,
-      CURRENT_OWNER,
     );
 
     const graphManager = new GraphManager(store);
@@ -229,6 +259,133 @@ describe('DKGAgent rootless update boundary', () => {
       .getKnowledgeAssetPrivateTriples(CG, createGraphKnowledgeAssetScope(UAL, 2)))
       .toEqual([]);
     expect(publisherCalls).toBe(0);
+  });
+
+  it('rejects an invalid update signer before replacing existing SWM or private state', async () => {
+    const store = new OxigraphStore();
+    await seedConfirmedRootlessHead(store);
+    const replacementPublic = [q('urn:update:new', 'urn:value', '"replacement"')];
+    const replacementPrivate = [q('urn:update:secret', 'urn:value', '"replacement-secret"')];
+    const { attestation } = await updateAttestation(
+      replacementPublic,
+      replacementPrivate,
+      ATTACKER_WALLET,
+      CURRENT_OWNER,
+    );
+
+    const graphManager = new GraphManager(store);
+    const swmBucket = graphManager.sharedMemoryUri(CG);
+    const swmScope: SharedMemoryGraphScope = {
+      kind: 'named-lifecycle',
+      identity: { agentAddress: ORIGINAL_AUTHOR, kaNumber: KA_NUMBER },
+    };
+    const canonicalSwm = canonicalSharedMemoryScopeWriteGraph(swmBucket, swmScope);
+    const priorPublic = [q('urn:update:prior', 'urn:value', '"prior"', canonicalSwm)];
+    await store.insert(priorPublic);
+    const privateStore = new PrivateContentStore(store, graphManager);
+    const nextScope = createGraphKnowledgeAssetScope(UAL, 2);
+    const priorPrivate = [q('urn:update:prior-secret', 'urn:value', '"prior-secret"')];
+    await privateStore.replaceKnowledgeAssetPrivateTriples(CG, nextScope, priorPrivate);
+
+    let publisherCalls = 0;
+    const agent = makeAgentLike(store, async () => {
+      publisherCalls += 1;
+      throw new Error('publisher must not be called');
+    });
+
+    await expect((PublishMethods.prototype as any).update.call(
+      agent,
+      KA_ID,
+      CG,
+      replacementPublic,
+      replacementPrivate,
+      { precomputedUpdateAttestation: attestation },
+    )).rejects.toThrow(/signer mismatch/);
+
+    const persistedPublic = await loadSharedMemoryQuadsForScope(
+      store,
+      swmBucket,
+      'all',
+      swmScope,
+    );
+    expect(persistedPublic.map(({ graph: _graph, ...quad }) => quad)).toEqual(
+      priorPublic.map(({ graph: _graph, ...quad }) => quad),
+    );
+    expect(await privateStore.getKnowledgeAssetPrivateTriples(CG, nextScope))
+      .toEqual(priorPrivate);
+    expect(publisherCalls).toBe(0);
+  });
+
+  it('serializes same-KA updates so each publisher call reads its own staged graph', async () => {
+    const store = new OxigraphStore();
+    await seedConfirmedRootlessHead(store);
+    const publicA = [q('urn:update:a', 'urn:value', '"A"')];
+    const publicB = [q('urn:update:b', 'urn:value', '"B"')];
+    const signedA = await updateAttestation(publicA);
+    const signedB = await updateAttestation(publicB);
+    const graphManager = new GraphManager(store);
+    const swmBucket = graphManager.sharedMemoryUri(CG);
+    const swmScope: SharedMemoryGraphScope = {
+      kind: 'named-lifecycle',
+      identity: { agentAddress: ORIGINAL_AUTHOR, kaNumber: KA_NUMBER },
+    };
+
+    let releaseFirst!: () => void;
+    const holdFirst = new Promise<void>((resolve) => { releaseFirst = resolve; });
+    let firstPublisherEntered!: () => void;
+    const firstEntered = new Promise<void>((resolve) => { firstPublisherEntered = resolve; });
+    const stagedByCall: Quad[][] = [];
+    const agent = makeAgentLike(store, async (kaId) => {
+      const staged = await loadSharedMemoryQuadsForScope(
+        store,
+        swmBucket,
+        'all',
+        swmScope,
+      );
+      stagedByCall.push(staged.map(({ graph: _graph, ...quad }) => quad));
+      if (stagedByCall.length === 1) {
+        firstPublisherEntered();
+        await holdFirst;
+      }
+      return {
+        kaId,
+        ual: UAL,
+        merkleRoot: stagedByCall.length === 1
+          ? signedA.attestation.expectedNewMerkleRoot
+          : signedB.attestation.expectedNewMerkleRoot,
+        kaManifest: [],
+        status: 'tentative',
+        publicQuads: staged,
+      };
+    });
+
+    const first = (PublishMethods.prototype as any).update.call(
+      agent,
+      KA_ID,
+      CG,
+      publicA,
+      [],
+      { precomputedUpdateAttestation: signedA.attestation },
+    );
+    await firstEntered;
+    const second = (PublishMethods.prototype as any).update.call(
+      agent,
+      KA_ID,
+      CG,
+      publicB,
+      [],
+      { precomputedUpdateAttestation: signedB.attestation },
+    );
+
+    await new Promise<void>((resolve) => { setTimeout(resolve, 0); });
+    expect(stagedByCall).toHaveLength(1);
+    releaseFirst();
+    await Promise.all([first, second]);
+
+    expect(stagedByCall).toEqual([
+      signedA.canonical.publicQuads.map(({ graph: _graph, ...quad }) => quad),
+      signedB.canonical.publicQuads.map(({ graph: _graph, ...quad }) => quad),
+    ]);
   });
 
   it('stages a fully private update without inventing a public placeholder', async () => {

--- a/packages/agent/test/rootless-update-boundary.test.ts
+++ b/packages/agent/test/rootless-update-boundary.test.ts
@@ -1,0 +1,327 @@
+import { describe, expect, it } from 'vitest';
+import {
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  MemoryLayer,
+  contextGraphDataUri,
+  contextGraphMetaUri,
+  createGraphKnowledgeAssetScope,
+  knowledgeAssetLayerGraphUri,
+} from '@origintrail-official/dkg-core';
+import {
+  GraphManager,
+  OxigraphStore,
+  PrivateContentStore,
+  canonicalSharedMemoryScopeWriteGraph,
+  loadSharedMemoryQuadsForScope,
+  type Quad,
+  type SharedMemoryGraphScope,
+} from '@origintrail-official/dkg-storage';
+import {
+  computeFlatKCRootV10,
+  computePrivateRootV10,
+  skolemizeKnowledgeAssetParts,
+} from '@origintrail-official/dkg-publisher';
+import { PublishMethods } from '../src/dkg-agent-publish.js';
+
+const CG = 'rootless-update-boundary';
+const CHAIN_ID = 'mock:31337';
+const ORIGINAL_AUTHOR = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const CURRENT_OWNER = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const KA_NUMBER = 7n;
+const KA_ID = (BigInt(ORIGINAL_AUTHOR) << 96n) | KA_NUMBER;
+const UAL = `did:dkg:${CHAIN_ID}/${ORIGINAL_AUTHOR}/${KA_NUMBER.toString()}`;
+const DKG = 'http://dkg.io/ontology/';
+const XSD_INTEGER = 'http://www.w3.org/2001/XMLSchema#integer';
+
+function int(value: bigint | number): string {
+  return `"${value.toString()}"^^<${XSD_INTEGER}>`;
+}
+
+function q(subject: string, predicate: string, object: string, graph = ''): Quad {
+  return { subject, predicate, object, graph };
+}
+
+async function seedConfirmedRootlessHead(store: OxigraphStore): Promise<void> {
+  const scope = createGraphKnowledgeAssetScope(UAL, 1);
+  const metaGraph = contextGraphMetaUri(CG);
+  const vmGraph = knowledgeAssetLayerGraphUri(
+    CG,
+    MemoryLayer.VerifiableMemory,
+    scope,
+  );
+  await store.insert([
+    q(UAL, `${DKG}contentScopeVersion`, int(GRAPH_KA_CONTENT_SCOPE_VERSION), metaGraph),
+    q(UAL, `${DKG}kaUal`, UAL, metaGraph),
+    q(UAL, `${DKG}assertionVersion`, int(1), metaGraph),
+    q(UAL, `${DKG}batchId`, int(KA_ID), metaGraph),
+    q(UAL, `${DKG}status`, '"confirmed"', metaGraph),
+    q(UAL, `${DKG}contextGraph`, contextGraphDataUri(CG), metaGraph),
+    q(UAL, `${DKG}assertionGraph`, vmGraph, metaGraph),
+    q('urn:old:vm', 'urn:value', '"one"', vmGraph),
+  ]);
+}
+
+async function updateAttestation(
+  publicQuads: Quad[],
+  privateQuads: Quad[] = [],
+  authorAddress = CURRENT_OWNER,
+) {
+  const canonical = await skolemizeKnowledgeAssetParts(publicQuads, privateQuads);
+  const privateRoot = computePrivateRootV10(canonical.privateQuads);
+  return {
+    canonical,
+    privateRoot,
+    attestation: {
+      expectedNewMerkleRoot: computeFlatKCRootV10(
+        canonical.publicQuads,
+        privateRoot ? [privateRoot] : [],
+      ),
+      authorAddress,
+      signature: {
+        r: new Uint8Array(32),
+        vs: new Uint8Array(32),
+      },
+      schemeVersion: 1,
+    },
+  };
+}
+
+function makeAgentLike(
+  store: OxigraphStore,
+  onPublisherUpdate: (kaId: bigint, options: Record<string, any>) => Promise<any>,
+) {
+  return {
+    store,
+    chain: { chainId: CHAIN_ID },
+    log: {
+      info: () => undefined,
+      warn: () => undefined,
+      error: () => undefined,
+      debug: () => undefined,
+    },
+    node: { peerId: { toString: () => 'peer-rootless-update' } },
+    publisher: { updateKnowledgeAssetFromSharedMemory: onPublisherUpdate },
+    getContextGraphOnChainId: async () => null,
+    createV10UpdateACKProvider: () => undefined,
+    _resolveEncryptInlinePayload: async () => undefined,
+    _resolveEncryptInlineChunked: async () => undefined,
+    gossip: { publish: async () => undefined },
+  } as any;
+}
+
+describe('DKGAgent rootless update boundary', () => {
+  it('stages one exact SWM graph, versions private content, and permits a transferred owner', async () => {
+    const store = new OxigraphStore();
+    await seedConfirmedRootlessHead(store);
+    const publicQuads = [
+      q('urn:update:asset', 'urn:hasPart', '_:part'),
+      q('_:part', 'urn:value', '"two"'),
+    ];
+    const privateQuads = [q('_:secret', 'urn:secret', '"classified"')];
+    const { canonical, privateRoot, attestation } = await updateAttestation(
+      publicQuads,
+      privateQuads,
+      CURRENT_OWNER,
+    );
+
+    const graphManager = new GraphManager(store);
+    const swmBucket = graphManager.sharedMemoryUri(CG);
+    const scope: SharedMemoryGraphScope = {
+      kind: 'named-lifecycle',
+      identity: { agentAddress: ORIGINAL_AUTHOR, kaNumber: KA_NUMBER },
+    };
+    const canonicalSwm = canonicalSharedMemoryScopeWriteGraph(swmBucket, scope);
+    const historicalAlias = `${swmBucket}/0x${ORIGINAL_AUTHOR.slice(2).toUpperCase()}/${KA_NUMBER.toString()}`;
+    await store.insert([q('urn:stale', 'urn:value', '"stale"', historicalAlias)]);
+
+    let publisherCalls = 0;
+    const agent = makeAgentLike(store, async (kaId, options) => {
+      publisherCalls += 1;
+      expect(kaId).toBe(KA_ID);
+      expect(options).toMatchObject({
+        contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+        kaUal: UAL,
+        assertionVersion: '2',
+        publicTripleCount: canonical.publicQuads.length,
+        privateTripleCount: canonical.privateQuads.length,
+      });
+      expect(options.privateMerkleRoot).toEqual(privateRoot);
+
+      const staged = await loadSharedMemoryQuadsForScope(
+        store,
+        swmBucket,
+        'all',
+        scope,
+      );
+      expect(staged.map(({ graph: _graph, ...quad }) => quad)).toEqual(
+        canonical.publicQuads.map(({ graph: _graph, ...quad }) => quad),
+      );
+      return {
+        kaId,
+        ual: UAL,
+        merkleRoot: attestation.expectedNewMerkleRoot,
+        kaManifest: [],
+        status: 'tentative',
+        publicQuads: staged,
+      };
+    });
+
+    const result = await (PublishMethods.prototype as any).update.call(
+      agent,
+      KA_ID,
+      CG,
+      publicQuads,
+      privateQuads,
+      { precomputedUpdateAttestation: attestation },
+    );
+
+    expect(result.status).toBe('tentative');
+    expect(publisherCalls).toBe(1);
+    expect(await store.countQuads(canonicalSwm)).toBe(canonical.publicQuads.length);
+    expect(await store.countQuads(historicalAlias)).toBe(0);
+    const privateStore = new PrivateContentStore(store, graphManager);
+    expect(await privateStore.getKnowledgeAssetPrivateTriples(
+      CG,
+      createGraphKnowledgeAssetScope(UAL, 2),
+    )).toEqual(canonical.privateQuads);
+
+    // Staging an update must not mutate the current VM graph before the
+    // publisher/chain confirms it.
+    const currentVm = knowledgeAssetLayerGraphUri(
+      CG,
+      MemoryLayer.VerifiableMemory,
+      createGraphKnowledgeAssetScope(UAL, 1),
+    );
+    expect(await store.countQuads(currentVm)).toBe(1);
+  });
+
+  it('rejects an attestation-root mismatch before touching SWM or private storage', async () => {
+    const store = new OxigraphStore();
+    await seedConfirmedRootlessHead(store);
+    const publicQuads = [q('urn:update:asset', 'urn:value', '"two"')];
+    const { attestation } = await updateAttestation(publicQuads);
+    attestation.expectedNewMerkleRoot = new Uint8Array(32).fill(0xff);
+    let publisherCalls = 0;
+    const agent = makeAgentLike(store, async () => {
+      publisherCalls += 1;
+      throw new Error('publisher must not be called');
+    });
+
+    await expect((PublishMethods.prototype as any).update.call(
+      agent,
+      KA_ID,
+      CG,
+      publicQuads,
+      [],
+      { precomputedUpdateAttestation: attestation },
+    )).rejects.toThrow(/expectedNewMerkleRoot mismatch/);
+
+    const graphManager = new GraphManager(store);
+    const swmScope: SharedMemoryGraphScope = {
+      kind: 'named-lifecycle',
+      identity: { agentAddress: ORIGINAL_AUTHOR, kaNumber: KA_NUMBER },
+    };
+    expect(await store.countQuads(canonicalSharedMemoryScopeWriteGraph(
+      graphManager.sharedMemoryUri(CG),
+      swmScope,
+    ))).toBe(0);
+    expect(await new PrivateContentStore(store, graphManager)
+      .getKnowledgeAssetPrivateTriples(CG, createGraphKnowledgeAssetScope(UAL, 2)))
+      .toEqual([]);
+    expect(publisherCalls).toBe(0);
+  });
+
+  it('stages a fully private update without inventing a public placeholder', async () => {
+    const store = new OxigraphStore();
+    await seedConfirmedRootlessHead(store);
+    const privateQuads = [q('urn:private:only', 'urn:secret', '"updated"')];
+    const { canonical, privateRoot, attestation } = await updateAttestation([], privateQuads);
+    let publisherCalls = 0;
+    const agent = makeAgentLike(store, async (kaId, options) => {
+      publisherCalls += 1;
+      expect(kaId).toBe(KA_ID);
+      expect(options.publicTripleCount).toBe(0);
+      expect(options.privateTripleCount).toBe(canonical.privateQuads.length);
+      expect(options.privateMerkleRoot).toEqual(privateRoot);
+      expect(options.privateQuads).toEqual(canonical.privateQuads);
+      return {
+        kaId,
+        ual: UAL,
+        merkleRoot: attestation.expectedNewMerkleRoot,
+        kaManifest: [],
+        status: 'tentative',
+        publicQuads: [],
+      };
+    });
+
+    await (PublishMethods.prototype as any).update.call(
+      agent,
+      KA_ID,
+      CG,
+      [],
+      privateQuads,
+      { precomputedUpdateAttestation: attestation },
+    );
+
+    expect(publisherCalls).toBe(1);
+    const scope = createGraphKnowledgeAssetScope(UAL, 2);
+    const graphManager = new GraphManager(store);
+    const swmScope: SharedMemoryGraphScope = {
+      kind: 'named-lifecycle',
+      identity: { agentAddress: ORIGINAL_AUTHOR, kaNumber: KA_NUMBER },
+    };
+    expect(await store.countQuads(canonicalSharedMemoryScopeWriteGraph(
+      graphManager.sharedMemoryUri(CG),
+      swmScope,
+    ))).toBe(0);
+    expect(await new PrivateContentStore(store, graphManager)
+      .getKnowledgeAssetPrivateTriples(CG, scope)).toEqual(canonical.privateQuads);
+  });
+
+  it('requires the confirmed V2 head to be locally materialized', async () => {
+    const store = new OxigraphStore();
+    const publicQuads = [q('urn:update:asset', 'urn:value', '"two"')];
+    const { attestation } = await updateAttestation(publicQuads);
+    let publisherCalls = 0;
+    const agent = makeAgentLike(store, async () => {
+      publisherCalls += 1;
+      throw new Error('publisher must not be called');
+    });
+
+    await expect((PublishMethods.prototype as any).update.call(
+      agent,
+      KA_ID,
+      CG,
+      publicQuads,
+      [],
+      { precomputedUpdateAttestation: attestation },
+    )).rejects.toMatchObject({ code: 'ROOTLESS_KA_NOT_MATERIALIZED' });
+    expect(publisherCalls).toBe(0);
+  });
+
+  it('keeps an existing root-scoped KA read-only instead of synthesizing a V2 target', async () => {
+    const store = new OxigraphStore();
+    const legacyUal = 'did:dkg:legacy/0xcccccccccccccccccccccccccccccccccccccccc/1';
+    await store.insert([
+      q(legacyUal, `${DKG}batchId`, int(KA_ID), contextGraphMetaUri(CG)),
+      q(legacyUal, `${DKG}status`, '"confirmed"', contextGraphMetaUri(CG)),
+    ]);
+    const publicQuads = [q('urn:update:asset', 'urn:value', '"two"')];
+    const { attestation } = await updateAttestation(publicQuads);
+    let publisherCalls = 0;
+    const agent = makeAgentLike(store, async () => {
+      publisherCalls += 1;
+      throw new Error('publisher must not be called');
+    });
+
+    await expect((PublishMethods.prototype as any).update.call(
+      agent,
+      KA_ID,
+      CG,
+      publicQuads,
+      [],
+      { precomputedUpdateAttestation: attestation },
+    )).rejects.toMatchObject({ code: 'LEGACY_KA_READ_ONLY' });
+    expect(publisherCalls).toBe(0);
+  });
+});

--- a/packages/agent/test/rootless-update-boundary.test.ts
+++ b/packages/agent/test/rootless-update-boundary.test.ts
@@ -21,6 +21,8 @@ import {
 import {
   computeFlatKCRootV10,
   computePrivateRootV10,
+  resolveKnowledgeAssetOperationPublicQuads,
+  resolveKnowledgeAssetWorkspaceHead,
   skolemizeKnowledgeAssetParts,
 } from '@origintrail-official/dkg-publisher';
 import { ethers } from 'ethers';
@@ -115,6 +117,7 @@ async function updateAttestation(
 function makeAgentLike(
   store: OxigraphStore,
   onPublisherUpdate: (kaId: bigint, options: Record<string, any>) => Promise<any>,
+  currentOwner = CURRENT_OWNER,
 ) {
   return {
     store,
@@ -122,6 +125,7 @@ function makeAgentLike(
       chainId: CHAIN_ID,
       getEvmChainId: async () => EVM_CHAIN_ID,
       getKnowledgeAssetsLifecycleAddress: async () => KAV_ADDRESS,
+      getKnowledgeAssetOwner: async () => currentOwner,
       hasContractCode: async () => false,
     },
     log: {
@@ -313,6 +317,166 @@ describe('DKGAgent rootless update boundary', () => {
     );
     expect(await privateStore.getKnowledgeAssetPrivateTriples(CG, nextScope))
       .toEqual(priorPrivate);
+    expect(publisherCalls).toBe(0);
+  });
+
+  it('rejects an invalid EIP-1271 update signature before durable staging', async () => {
+    const store = new OxigraphStore();
+    await seedConfirmedRootlessHead(store);
+    const publicQuads = [q('urn:update:contract', 'urn:value', '"replacement"')];
+    const { attestation } = await updateAttestation(publicQuads);
+    let publisherCalls = 0;
+    const agent = makeAgentLike(store, async () => {
+      publisherCalls += 1;
+      throw new Error('publisher must not be called');
+    });
+    agent.chain.hasContractCode = async () => true;
+    agent.chain.verifyContractSignature = async () => false;
+
+    await expect((PublishMethods.prototype as any).update.call(
+      agent,
+      KA_ID,
+      CG,
+      publicQuads,
+      [],
+      { precomputedUpdateAttestation: attestation },
+    )).rejects.toThrow(/contract signature is invalid/);
+
+    const graphManager = new GraphManager(store);
+    const swmScope: SharedMemoryGraphScope = {
+      kind: 'named-lifecycle',
+      identity: { agentAddress: ORIGINAL_AUTHOR, kaNumber: KA_NUMBER },
+    };
+    expect(await store.countQuads(canonicalSharedMemoryScopeWriteGraph(
+      graphManager.sharedMemoryUri(CG),
+      swmScope,
+    ))).toBe(0);
+    expect(publisherCalls).toBe(0);
+  });
+
+  it('rejects a valid non-owner attestation before replacing existing SWM or private state', async () => {
+    const store = new OxigraphStore();
+    await seedConfirmedRootlessHead(store);
+    const replacementPublic = [q('urn:update:new', 'urn:value', '"replacement"')];
+    const replacementPrivate = [q('urn:update:secret', 'urn:value', '"replacement-secret"')];
+    const { attestation } = await updateAttestation(
+      replacementPublic,
+      replacementPrivate,
+      ATTACKER_WALLET,
+    );
+
+    const graphManager = new GraphManager(store);
+    const swmBucket = graphManager.sharedMemoryUri(CG);
+    const swmScope: SharedMemoryGraphScope = {
+      kind: 'named-lifecycle',
+      identity: { agentAddress: ORIGINAL_AUTHOR, kaNumber: KA_NUMBER },
+    };
+    const canonicalSwm = canonicalSharedMemoryScopeWriteGraph(swmBucket, swmScope);
+    const priorPublic = [q('urn:update:prior', 'urn:value', '"prior"', canonicalSwm)];
+    await store.insert(priorPublic);
+    const privateStore = new PrivateContentStore(store, graphManager);
+    const nextScope = createGraphKnowledgeAssetScope(UAL, 2);
+    const priorPrivate = [q('urn:update:prior-secret', 'urn:value', '"prior-secret"')];
+    await privateStore.replaceKnowledgeAssetPrivateTriples(CG, nextScope, priorPrivate);
+
+    let publisherCalls = 0;
+    const agent = makeAgentLike(store, async () => {
+      publisherCalls += 1;
+      throw new Error('publisher must not be called');
+    });
+
+    await expect((PublishMethods.prototype as any).update.call(
+      agent,
+      KA_ID,
+      CG,
+      replacementPublic,
+      replacementPrivate,
+      { precomputedUpdateAttestation: attestation },
+    )).rejects.toMatchObject({ code: 'KA_UPDATE_AUTHOR_NOT_OWNER' });
+
+    const persistedPublic = await loadSharedMemoryQuadsForScope(
+      store,
+      swmBucket,
+      'all',
+      swmScope,
+    );
+    expect(persistedPublic.map(({ graph: _graph, ...quad }) => quad)).toEqual(
+      priorPublic.map(({ graph: _graph, ...quad }) => quad),
+    );
+    expect(await privateStore.getKnowledgeAssetPrivateTriples(CG, nextScope))
+      .toEqual(priorPrivate);
+    expect(publisherCalls).toBe(0);
+  });
+
+  it('persists an exact update snapshot and head before publisher chain write-ahead', async () => {
+    const store = new OxigraphStore();
+    await seedConfirmedRootlessHead(store);
+    const publicQuads = [q('urn:update:recover', 'urn:value', '"recoverable"')];
+    const privateQuads = [q('urn:update:recover-secret', 'urn:value', '"private"')];
+    const { canonical, privateRoot, attestation } = await updateAttestation(
+      publicQuads,
+      privateQuads,
+    );
+    const agent = makeAgentLike(store, async () => {
+      throw new Error('simulated crash after chain write-ahead');
+    });
+
+    await expect((PublishMethods.prototype as any).update.call(
+      agent,
+      KA_ID,
+      CG,
+      publicQuads,
+      privateQuads,
+      { precomputedUpdateAttestation: attestation },
+    )).rejects.toThrow('simulated crash after chain write-ahead');
+
+    const graphManager = new GraphManager(store);
+    const head = await resolveKnowledgeAssetWorkspaceHead({
+      store,
+      graphManager,
+      contextGraphId: CG,
+      kaUal: UAL,
+    });
+    expect(head).toMatchObject({
+      kaUal: UAL,
+      assertionVersion: '2',
+      publicTripleCount: canonical.publicQuads.length,
+      privateTripleCount: canonical.privateQuads.length,
+      publisherPeerId: 'peer-rootless-update',
+    });
+    expect(head?.privateMerkleRoot?.toLowerCase()).toBe(
+      privateRoot ? ethers.hexlify(privateRoot).toLowerCase() : undefined,
+    );
+    const snapshot = await resolveKnowledgeAssetOperationPublicQuads({
+      store,
+      graphManager,
+      contextGraphId: CG,
+      shareOperationId: head!.shareOperationId,
+      kaUal: UAL,
+      assertionVersion: 2,
+    });
+    expect(snapshot.quads).toEqual(canonical.publicQuads);
+  });
+
+  it('rejects caller-authored named graphs before staging or publisher side effects', async () => {
+    const store = new OxigraphStore();
+    await seedConfirmedRootlessHead(store);
+    const plain = [q('urn:update:named', 'urn:value', '"blocked"')];
+    const { attestation } = await updateAttestation(plain);
+    let publisherCalls = 0;
+    const agent = makeAgentLike(store, async () => {
+      publisherCalls += 1;
+      throw new Error('publisher must not be called');
+    });
+
+    await expect((PublishMethods.prototype as any).update.call(
+      agent,
+      KA_ID,
+      CG,
+      [q('urn:update:named', 'urn:value', '"blocked"', 'urn:user:graph')],
+      [],
+      { precomputedUpdateAttestation: attestation },
+    )).rejects.toMatchObject({ code: 'KA_NAMED_GRAPH_SHARE_UNSUPPORTED' });
     expect(publisherCalls).toBe(0);
   });
 

--- a/packages/agent/test/rootless-update-boundary.test.ts
+++ b/packages/agent/test/rootless-update-boundary.test.ts
@@ -40,6 +40,7 @@ const ATTACKER_WALLET = new ethers.Wallet(
   '0x8b3a350cf5c34c9194ca3a545d05a0f4f70e6fb072cf5f77b905d8b317f2f3d0',
 );
 const CURRENT_OWNER = CURRENT_OWNER_WALLET.address;
+const CONTRACT_OWNER = '0x2222222222222222222222222222222222222222';
 const KA_NUMBER = 7n;
 const KA_ID = (BigInt(ORIGINAL_AUTHOR) << 96n) | KA_NUMBER;
 const UAL = `did:dkg:${CHAIN_ID}/${ORIGINAL_AUTHOR}/${KA_NUMBER.toString()}`;
@@ -352,6 +353,74 @@ describe('DKGAgent rootless update boundary', () => {
       swmScope,
     ))).toBe(0);
     expect(publisherCalls).toBe(0);
+  });
+
+  it('accepts a valid EIP-1271 owner signature and forwards the exact digest before staging', async () => {
+    const store = new OxigraphStore();
+    await seedConfirmedRootlessHead(store);
+    const publicQuads = [q('urn:update:contract-valid', 'urn:value', '"replacement"')];
+    const { canonical, attestation } = await updateAttestation(
+      publicQuads,
+      [],
+      CURRENT_OWNER_WALLET,
+      CONTRACT_OWNER,
+    );
+    const typedData = buildUpdateAuthorAttestationTypedData({
+      chainId: EVM_CHAIN_ID,
+      kav10Address: KAV_ADDRESS,
+      kaId: KA_ID,
+      newMerkleRoot: attestation.expectedNewMerkleRoot,
+      authorAddress: CONTRACT_OWNER,
+      schemeVersion: AUTHOR_SCHEME_VERSION_V1,
+    });
+    const expectedDigest = ethers.TypedDataEncoder.hash(
+      typedData.domain,
+      typedData.types,
+      typedData.message,
+    );
+    const expectedSignature = ethers.Signature.from({
+      r: ethers.hexlify(attestation.signature.r),
+      yParityAndS: ethers.hexlify(attestation.signature.vs),
+    }).serialized;
+    const contractVerificationCalls: Array<{
+      address: string;
+      digest: string;
+      signature: string;
+    }> = [];
+    let publisherCalls = 0;
+    const agent = makeAgentLike(store, async (kaId) => {
+      publisherCalls += 1;
+      return {
+        kaId,
+        ual: UAL,
+        merkleRoot: attestation.expectedNewMerkleRoot,
+        kaManifest: [],
+        status: 'tentative',
+        publicQuads: canonical.publicQuads,
+      };
+    }, CONTRACT_OWNER);
+    agent.chain.hasContractCode = async () => true;
+    agent.chain.verifyContractSignature = async (address: string, digest: string, signature: string) => {
+      contractVerificationCalls.push({ address, digest, signature });
+      return true;
+    };
+
+    const result = await (PublishMethods.prototype as any).update.call(
+      agent,
+      KA_ID,
+      CG,
+      publicQuads,
+      [],
+      { precomputedUpdateAttestation: attestation },
+    );
+
+    expect(result.status).toBe('tentative');
+    expect(publisherCalls).toBe(1);
+    expect(contractVerificationCalls).toEqual([{
+      address: CONTRACT_OWNER,
+      digest: expectedDigest,
+      signature: expectedSignature,
+    }]);
   });
 
   it('rejects a valid non-owner attestation before replacing existing SWM or private state', async () => {

--- a/packages/agent/test/rootless-update-error.test.ts
+++ b/packages/agent/test/rootless-update-error.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ROOTLESS_UPDATE_ERROR_CODES,
+  RootlessUpdateError,
+  isRootlessUpdateError,
+} from '../src/rootless-update-error.js';
+
+describe('rootless update error contract', () => {
+  it.each(ROOTLESS_UPDATE_ERROR_CODES)('recognizes the declared code %s', (code) => {
+    const error = new RootlessUpdateError(code, 'rejected');
+    expect(isRootlessUpdateError(error)).toBe(true);
+    expect(error.code).toBe(code);
+  });
+
+  it('does not classify an unknown ROOTLESS-prefixed failure as caller input', () => {
+    expect(isRootlessUpdateError(Object.assign(
+      new Error('internal storage failure'),
+      { code: 'ROOTLESS_STORAGE_CORRUPTION' },
+    ))).toBe(false);
+  });
+});

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -69,6 +69,8 @@ export default defineConfig({
       "test/v10-ack-provider-wiring.test.ts",
       "test/direct-rootless-publish.test.ts",
       "test/rootless-update-boundary.test.ts",
+      "test/rootless-update-error.test.ts",
+      "test/changelog-requester.test.ts",
       "test/encrypt-inline-policy.test.ts",
       "test/agents-meta-policy.test.ts",
       "test/agents-meta-sync-wiring.test.ts",

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -68,6 +68,8 @@ export default defineConfig({
       "test/storage-ack-lifecycle-identity.test.ts",
       "test/v10-ack-provider-wiring.test.ts",
       "test/direct-rootless-publish.test.ts",
+      "test/rootless-update-boundary.test.ts",
+      "test/encrypt-inline-policy.test.ts",
       "test/agents-meta-policy.test.ts",
       "test/agents-meta-sync-wiring.test.ts",
       "test/network-identity-proof.test.ts",

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -1242,6 +1242,17 @@ export interface ChainAdapter {
    */
   hasContractCode?(address: string): Promise<boolean>;
 
+  /**
+   * Verify an EIP-1271 signature for a contract-backed author. Update
+   * preparation uses this before durable staging; omitting the capability for
+   * an address with code makes that preparation fail closed.
+   */
+  verifyContractSignature?(
+    address: string,
+    digest: string,
+    signature: string,
+  ): Promise<boolean>;
+
   // On-Chain Context Graphs (ContextGraphs contract)
   createOnChainContextGraph?(params: CreateOnChainContextGraphParams): Promise<CreateOnChainContextGraphResult>;
   verify?(params: VerifyParams): Promise<TxResult>;
@@ -1276,6 +1287,13 @@ export interface ChainAdapter {
 
   /** Deployed `DKGKnowledgeAssets` (or legacy `KnowledgeCollectionStorage`) address. */
   getDKGKnowledgeAssetsAddress?(): Promise<string>;
+
+  /**
+   * Live ERC-721 owner of a V10 Knowledge Asset. Update preparation requires
+   * this capability before it may replace durable local SWM/private staging;
+   * adapters that cannot resolve ownership must fail that preparation closed.
+   */
+  getKnowledgeAssetOwner?(kaId: bigint): Promise<string>;
 
   /** Read minimumRequiredSignatures from ParametersStorage. Used by ACKCollector. */
   getMinimumRequiredSignatures?(): Promise<number>;

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -2753,6 +2753,21 @@ export class EVMChainAdapterBase {
     return this.contracts.knowledgeAssetStorage.target as string;
   }
 
+  async getKnowledgeAssetOwner(kaId: bigint): Promise<string> {
+    await this.init();
+    const storage = this.contracts.knowledgeAssetStorage;
+    if (!storage) {
+      throw new Error('DKGKnowledgeAssets not deployed on this chain.');
+    }
+    const owner = await this.readContract<string>(
+      storage,
+      'DKGKnowledgeAssets.ownerOf',
+      'ownerOf',
+      kaId,
+    );
+    return ethers.getAddress(owner);
+  }
+
   /**
    * OT-RFC-43 Option 1 — highest per-author KA `number` already minted on chain,
    * or `-1n` if `author` never minted. Backs the allocator's cold-start
@@ -3342,6 +3357,30 @@ export class EVMChainAdapterBase {
     try {
       const code = await this.readProvider('hasContractCode getCode', (p) => p.getCode(address));
       return code !== undefined && code !== null && code !== '0x' && code.length > 2;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyContractSignature(
+    address: string,
+    digest: string,
+    signature: string,
+  ): Promise<boolean> {
+    const wallet = new Contract(
+      ethers.getAddress(address),
+      ['function isValidSignature(bytes32,bytes) view returns (bytes4)'],
+      this.signer,
+    );
+    try {
+      const magic = await this.readContract<string>(
+        wallet,
+        'IERC1271.isValidSignature',
+        'isValidSignature',
+        digest,
+        signature,
+      );
+      return magic.toLowerCase() === '0x1626ba7e';
     } catch {
       return false;
     }

--- a/packages/chain/src/mock-adapter.ts
+++ b/packages/chain/src/mock-adapter.ts
@@ -306,6 +306,14 @@ export class MockChainAdapter implements ChainAdapter {
     return 1n;
   }
 
+  async getKnowledgeAssetOwner(kaId: bigint): Promise<string> {
+    const collection = this.collections.get(kaId);
+    if (!collection || collection.authorAddress === ethers.ZeroAddress) {
+      throw new Error(`Mock Knowledge Asset ${kaId.toString()} does not exist`);
+    }
+    return ethers.getAddress(collection.authorAddress);
+  }
+
   async verifyPublisherOwnsRange(
     publisherAddress: string,
     startKAId: bigint,

--- a/packages/chain/src/no-chain-adapter.ts
+++ b/packages/chain/src/no-chain-adapter.ts
@@ -42,6 +42,7 @@ export class NoChainAdapter implements ChainAdapter {
   async isOperationalWalletRegistered(_identityId: bigint, _address: string): Promise<boolean> { return false; }
   async getKnowledgeAssetsLifecycleAddress(): Promise<string> { noChain(); }
   async getEvmChainId(): Promise<bigint> { noChain(); }
+  async getKnowledgeAssetOwner(_kaId: bigint): Promise<string> { noChain(); }
   async getPublishingConvictionAccountOwner(_accountId: bigint): Promise<string> { noChain(); }
   // The 7 #519 PCA write+read methods are OMITTED on purpose: they are
   // optional on ChainAdapter, so the DKGAgent facade's `typeof guard`

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -729,12 +729,6 @@ export class ApiClient {
     // self-sign vs external-signer conflict client-side instead of relying on
     // the daemon, so every SDK surface enforces the same contract.
     assertExclusiveAuthorFields(options ?? {});
-    if (options?.layer === 'swm') {
-      throw Object.assign(
-        new Error('Legacy root-scoped Knowledge Assets are read-only'),
-        { code: 'LEGACY_KA_READ_ONLY' },
-      );
-    }
     const wireOptions = { ...(options ?? {}) };
     delete wireOptions.layer;
     return this.post(`/api/knowledge-assets/${encodeURIComponent(name)}/wm/finalize`, { contextGraphId, ...wireOptions });

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -724,7 +724,9 @@ export class ApiClient {
         { code: 'LEGACY_KA_READ_ONLY' },
       );
     }
-    return this.post(`/api/knowledge-assets/${encodeURIComponent(name)}/wm/finalize`, { contextGraphId, ...(options ?? {}) });
+    const wireOptions = { ...(options ?? {}) };
+    delete wireOptions.layer;
+    return this.post(`/api/knowledge-assets/${encodeURIComponent(name)}/wm/finalize`, { contextGraphId, ...wireOptions });
   }
 
   /** Discard the WM draft. */

--- a/packages/cli/src/commands/knowledge-asset.ts
+++ b/packages/cli/src/commands/knowledge-asset.ts
@@ -350,10 +350,6 @@ export function registerKnowledgeAssetCommand(program: Command): void {
         throw new Error('--layer must be wm or swm');
       }
       const authorOptions = parseFinalizeAuthorOptions(opts);
-      const layer = opts.layer === undefined ? undefined : String(opts.layer);
-      if (layer !== undefined && layer !== 'wm' && layer !== 'swm') {
-        throw new Error('--layer must be wm or swm');
-      }
       const client = await ApiClient.connect();
       const result = await client.knowledgeAssetFinalize(requiredContextGraphId(opts), name, {
         ...(subGraphName(opts) ? { subGraphName: subGraphName(opts) } : {}),

--- a/packages/cli/src/commands/knowledge-asset.ts
+++ b/packages/cli/src/commands/knowledge-asset.ts
@@ -341,13 +341,19 @@ export function registerKnowledgeAssetCommand(program: Command): void {
   addFinalizeAuthorOptions(addSubGraphOption(addContextGraphOption(
     kaCmd
       .command('finalize <name>')
-      .description('Finalize/seal a Knowledge Asset from WM'),
+      .description('Finalize/seal a Knowledge Asset from WM')
+      .option('--layer <layer>', 'Deprecated compatibility option: wm (swm is read-only)'),
   )))
     .action(async (name: string, opts: ActionOpts) => runAction(async () => {
       const authorOptions = parseFinalizeAuthorOptions(opts);
+      const layer = opts.layer === undefined ? undefined : String(opts.layer);
+      if (layer !== undefined && layer !== 'wm' && layer !== 'swm') {
+        throw new Error('--layer must be wm or swm');
+      }
       const client = await ApiClient.connect();
       const result = await client.knowledgeAssetFinalize(requiredContextGraphId(opts), name, {
         ...(subGraphName(opts) ? { subGraphName: subGraphName(opts) } : {}),
+        ...(layer ? { layer } : {}),
         ...authorOptions,
       });
       console.log('Knowledge asset finalized:');

--- a/packages/cli/src/daemon/routes/agent-chat.ts
+++ b/packages/cli/src/daemon/routes/agent-chat.ts
@@ -1087,6 +1087,9 @@ export async function handleAgentChatRoutes(ctx: RequestContext): Promise<void> 
       if (errorCode === "KA_NAMED_GRAPH_SHARE_UNSUPPORTED") {
         return jsonResponse(res, 400, { error: message });
       }
+      if (errorCode === "KA_UPDATE_AUTHOR_NOT_OWNER") {
+        return jsonResponse(res, 403, { error: message, code: "KA_UPDATE_AUTHOR_NOT_OWNER" });
+      }
       if (errorCode === "LEGACY_KA_READ_ONLY") {
         return jsonResponse(res, 409, { error: message, code: "LEGACY_KA_READ_ONLY" });
       }

--- a/packages/cli/src/daemon/routes/agent-chat.ts
+++ b/packages/cli/src/daemon/routes/agent-chat.ts
@@ -953,11 +953,19 @@ export async function handleAgentChatRoutes(ctx: RequestContext): Promise<void> 
     return jsonResponse(res, 200, { connected: true });
   }
 
-  // POST /api/update  { kaId, contextGraphId, quads, privateQuads?, precomputedUpdateAttestation? }
+  // POST /api/update  { kaId, contextGraphId, quads?, privateQuads?, precomputedUpdateAttestation? }
   if (req.method === "POST" && path === "/api/update") {
     const body = await readBody(req);
     const parsed = JSON.parse(body);
-    const { kaId, quads, privateQuads } = parsed;
+    const { kaId } = parsed;
+    if (parsed.quads !== undefined && !Array.isArray(parsed.quads)) {
+      return jsonResponse(res, 400, { error: '"quads" must be an array when provided' });
+    }
+    if (parsed.privateQuads !== undefined && !Array.isArray(parsed.privateQuads)) {
+      return jsonResponse(res, 400, { error: '"privateQuads" must be an array when provided' });
+    }
+    const quads = Array.isArray(parsed.quads) ? parsed.quads : [];
+    const privateQuads = Array.isArray(parsed.privateQuads) ? parsed.privateQuads : [];
     const contextGraphId = parsed.contextGraphId;
     const precomputedUpdateAttestation = parsePrecomputedUpdateAttestation(
       parsed.precomputedUpdateAttestation,
@@ -975,9 +983,9 @@ export async function handleAgentChatRoutes(ctx: RequestContext): Promise<void> 
     )) {
       return;
     }
-    if (!kaId || !contextGraphId || !quads?.length) {
+    if (!kaId || !contextGraphId || (quads.length === 0 && privateQuads.length === 0)) {
       return jsonResponse(res, 400, {
-        error: 'Missing "kaId", "contextGraphId", or "quads"',
+        error: 'Missing "kaId", "contextGraphId", or update content in "quads"/"privateQuads"',
       });
     }
     let kcIdBigInt: bigint;
@@ -1060,6 +1068,15 @@ export async function handleAgentChatRoutes(ctx: RequestContext): Promise<void> 
       const message = err instanceof Error ? err.message : String(err);
       if ((err as any)?.code === "OVERSIZED_RDF_LITERAL") {
         return jsonResponse(res, 400, oversizedRdfLiteralResponseBody(err));
+      }
+      if ((err as any)?.code === "KA_NAMED_GRAPH_SHARE_UNSUPPORTED") {
+        return jsonResponse(res, 400, { error: message });
+      }
+      if ((err as any)?.code === "LEGACY_KA_READ_ONLY") {
+        return jsonResponse(res, 409, { error: message, code: "LEGACY_KA_READ_ONLY" });
+      }
+      if (String((err as any)?.code ?? '').startsWith("ROOTLESS_")) {
+        return jsonResponse(res, 422, { error: message, code: (err as any).code });
       }
       if (message.includes('precomputedUpdateAttestation')) {
         return jsonResponse(res, 422, { error: message });

--- a/packages/cli/src/daemon/routes/agent-chat.ts
+++ b/packages/cli/src/daemon/routes/agent-chat.ts
@@ -56,7 +56,12 @@ const daemonRequire = createRequire(import.meta.url);
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
 import { enrichEvmError, MockChainAdapter } from '@origintrail-official/dkg-chain';
-import { DKGAgent, loadOpWallets } from '@origintrail-official/dkg-agent';
+import {
+  DKGAgent,
+  isRootlessUpdateError,
+  loadOpWallets,
+  type RootlessUpdateErrorCode,
+} from '@origintrail-official/dkg-agent';
 import { computeNetworkId, createOperationContext, DKGEvent, Logger, PayloadTooLargeError, GET_VIEWS, TrustLevel, validateSubGraphName, validateAssertionName, validateContextGraphId, isSafeIri, assertSafeIri, sparqlIri, contextGraphSharedMemoryUri, contextGraphAssertionUri, contextGraphMetaUri } from '@origintrail-official/dkg-core';
 import { findReservedSubjectPrefix, isSkolemizedUri } from '@origintrail-official/dkg-publisher';
 import {
@@ -69,6 +74,13 @@ import {
   LlmClient,
   type MetricsSource,
 } from "@origintrail-official/dkg-node-ui";
+
+const ROOTLESS_UPDATE_HTTP_STATUS = {
+  ROOTLESS_UPDATE_INVALID_KA_ID: 422,
+  ROOTLESS_KA_NOT_MATERIALIZED: 422,
+  ROOTLESS_UPDATE_TARGET_CORRUPT: 422,
+  ROOTLESS_UPDATE_TARGET_NOT_CONFIRMED: 422,
+} as const satisfies Record<RootlessUpdateErrorCode, number>;
 import {
   loadConfig,
   saveConfig,
@@ -1066,17 +1078,23 @@ export async function handleAgentChatRoutes(ctx: RequestContext): Promise<void> 
       // those to 422 (Unprocessable Entity) so the API surfaces a proper 4xx
       // instead of letting it bubble to the generic 500 handler.
       const message = err instanceof Error ? err.message : String(err);
-      if ((err as any)?.code === "OVERSIZED_RDF_LITERAL") {
+      const errorCode = typeof err === 'object' && err !== null
+        ? Reflect.get(err, 'code')
+        : undefined;
+      if (errorCode === "OVERSIZED_RDF_LITERAL") {
         return jsonResponse(res, 400, oversizedRdfLiteralResponseBody(err));
       }
-      if ((err as any)?.code === "KA_NAMED_GRAPH_SHARE_UNSUPPORTED") {
+      if (errorCode === "KA_NAMED_GRAPH_SHARE_UNSUPPORTED") {
         return jsonResponse(res, 400, { error: message });
       }
-      if ((err as any)?.code === "LEGACY_KA_READ_ONLY") {
+      if (errorCode === "LEGACY_KA_READ_ONLY") {
         return jsonResponse(res, 409, { error: message, code: "LEGACY_KA_READ_ONLY" });
       }
-      if (String((err as any)?.code ?? '').startsWith("ROOTLESS_")) {
-        return jsonResponse(res, 422, { error: message, code: (err as any).code });
+      if (isRootlessUpdateError(err)) {
+        return jsonResponse(res, ROOTLESS_UPDATE_HTTP_STATUS[err.code], {
+          error: message,
+          code: err.code,
+        });
       }
       if (message.includes('precomputedUpdateAttestation')) {
         return jsonResponse(res, 422, { error: message });

--- a/packages/cli/test/agent-chat-update-route.test.ts
+++ b/packages/cli/test/agent-chat-update-route.test.ts
@@ -205,6 +205,22 @@ describe('POST /api/update — kaId + attestation contract (KC→KA), real daemo
     expect(res.body.error).toMatch(/precomputedUpdateAttestation/);
   });
 
+  it('accepts private-only update content at the HTTP boundary', async () => {
+    const res = await postJson(daemon, '/api/update', {
+      kaId: '7',
+      contextGraphId: CG,
+      privateQuads: [{
+        subject: 'urn:private:only',
+        predicate: 'http://schema.org/value',
+        object: '"updated"',
+      }],
+    });
+    // Reaching the attestation precondition proves the route did not reject a
+    // valid fully-private replacement merely because `quads` is empty.
+    expect(res.status).toBe(422);
+    expect(res.body.error).toMatch(/precomputedUpdateAttestation/);
+  });
+
   it('maps an expectedNewMerkleRoot mismatch in the seal to 422 (real recompute guard)', async () => {
     // A present, structurally-valid seal whose expectedNewMerkleRoot does not
     // match the root the daemon recomputes from the real KA state is a caller

--- a/packages/cli/test/knowledge-asset-cli-smoke.test.ts
+++ b/packages/cli/test/knowledge-asset-cli-smoke.test.ts
@@ -610,8 +610,9 @@ describe.sequential('knowledge-asset CLI smoke', () => {
 
     await runCli(['knowledge-asset', 'write', 'paper', '-c', 'research', '--subject', 'urn:company:acme', '--predicate', 'http://schema.org/description', '--object', 'Logistics'], env);
     await runCli(['ka', 'finalize', 'paper', '-c', 'research'], env);
+    await runCli(['ka', 'finalize', 'paper', '-c', 'research', '--layer', 'wm'], env);
     await expect(runCli(['ka', 'finalize', 'paper', '-c', 'research', '--layer', 'swm'], env))
-      .rejects.toMatchObject({ stderr: expect.stringContaining("unknown option '--layer'") });
+      .rejects.toMatchObject({ stderr: expect.stringContaining('Legacy root-scoped Knowledge Assets are read-only') });
     await expect(runCli(['ka', 'share', 'paper', '-c', 'research', '--entity', 'urn:company:acme'], env))
       .rejects.toMatchObject({ stderr: expect.stringContaining("unknown option '--entity'") });
     await expect(runCli(['ka', 'share', 'paper', '-c', 'research', '--skip-seal'], env))
@@ -638,7 +639,9 @@ describe.sequential('knowledge-asset CLI smoke', () => {
         object: '"Logistics"',
       }),
     ]);
-    expect(calls.find((call) => call.url === '/api/knowledge-assets/paper/wm/finalize')?.body.layer).toBeUndefined();
+    const finalizeCalls = calls.filter((call) => call.url === '/api/knowledge-assets/paper/wm/finalize');
+    expect(finalizeCalls).toHaveLength(2);
+    expect(finalizeCalls.every((call) => call.body.layer === undefined)).toBe(true);
     const shareCalls = calls.filter((call) => call.url === '/api/knowledge-assets/paper/swm/share');
     expect(shareCalls[0]?.body).toMatchObject({
       contextGraphId: 'research',

--- a/packages/mcp-dkg/src/tools/assertions.ts
+++ b/packages/mcp-dkg/src/tools/assertions.ts
@@ -450,7 +450,7 @@ export function registerAssertionTools(
         // CONTRACT §C: scheme_version is a POSITIVE integer (daemon >= 1) — zod
         // rejects 0 / negative / non-integer at the boundary as a tool error.
         schemeVersion: z.number().int().positive().optional().describe('Optional attestation scheme version (positive integer)'),
-        layer: z.never().optional().describe('Retired: only Working Memory finalization is supported.'),
+        layer: z.literal('wm').optional().describe('Deprecated compatibility alias; only Working Memory finalization is supported.'),
         projectId: z.string().optional().describe(`${EXISTING_CONTEXT_GRAPH_ID_DESCRIPTION} Defaults to .dkg/config.yaml.`),
         subGraphName: z.string().optional(),
       },
@@ -502,8 +502,8 @@ export function registerAssertionTools(
         'EXPLICITLY first (the default seal cannot carry them).',
       inputSchema: {
         name: z.string().describe('Existing knowledge asset name'),
-        entities: z.never().optional().describe('Retired: Knowledge Assets are shared atomically.'),
-        skipSeal: z.never().optional().describe('Retired: Knowledge Assets are always sealed before sharing.'),
+        entities: z.literal('all').optional().describe('Deprecated compatibility sentinel; the complete Knowledge Asset is always shared.'),
+        skipSeal: z.literal(false).optional().describe('Deprecated compatibility sentinel; Knowledge Assets are always sealed before sharing.'),
         projectId: z.string().optional().describe(`${EXISTING_CONTEXT_GRAPH_ID_DESCRIPTION} Defaults to .dkg/config.yaml.`),
         subGraphName: z.string().optional(),
       },

--- a/packages/mcp-dkg/test/assertion-lifecycle.test.ts
+++ b/packages/mcp-dkg/test/assertion-lifecycle.test.ts
@@ -337,7 +337,7 @@ describe('assertion CRUD quintet — round-trip with @en literal preservation', 
     })).rejects.toThrow();
   });
 
-  it('share rejects the retired "all" sentinel instead of widening scope silently', async () => {
+  it('share accepts harmless legacy defaults and omits them from the client call', async () => {
     const captured: Record<string, unknown> = {};
     const localClient = new FakeClient({
       knowledgeAssetShare: async (args) => {
@@ -348,10 +348,15 @@ describe('assertion CRUD quintet — round-trip with @en literal preservation', 
     const localServer = new FakeServer();
     registerAssertionTools(localServer.asMcpServer(), localClient.asDkgClient(), makeConfig());
 
-    await expect(
-      localServer.call('dkg_knowledge_asset_share', { name: 'doc', entities: 'all' }),
-    ).rejects.toThrow();
-    expect(captured).toEqual({});
+    const result = await localServer.call('dkg_knowledge_asset_share', {
+      name: 'doc',
+      entities: 'all',
+      skipSeal: false,
+    });
+    expect(result.isError).toBeFalsy();
+    expect(captured).toMatchObject({ name: 'doc', contextGraphId: 'test-cg' });
+    expect(captured).not.toHaveProperty('entities');
+    expect(captured).not.toHaveProperty('skipSeal');
   });
 
   it('share rejects root-selection arrays before invoking the client', async () => {
@@ -817,7 +822,27 @@ describe('rc.17 lifecycle verbs — finalize / publish / pull_from (parity with 
     expect(res.content[0].text).toMatch(/Failed to share knowledge asset/);
   });
 
-  it('finalize rejects the retired layer field before invoking the client', async () => {
+  it('finalize accepts the harmless legacy WM layer and omits it from the client call', async () => {
+    const captured: Record<string, unknown> = {};
+    const localClient = new FakeClient({
+      knowledgeAssetFinalize: async (args) => {
+        Object.assign(captured, args);
+        return { merkleRoot: '0xroot', eip712Digest: '0xdig', authorAddress: '0xtoken' };
+      },
+    });
+    const localServer = new FakeServer();
+    registerAssertionTools(localServer.asMcpServer(), localClient.asDkgClient(), makeConfig());
+
+    const result = await localServer.call('dkg_knowledge_asset_finalize', {
+      name: 'doc',
+      layer: 'wm',
+    });
+    expect(result.isError).toBeFalsy();
+    expect(captured).toMatchObject({ name: 'doc', contextGraphId: 'test-cg' });
+    expect(captured).not.toHaveProperty('layer');
+  });
+
+  it('finalize rejects the retired SWM layer before invoking the client', async () => {
     const captured: Record<string, unknown> = {};
     const localClient = new FakeClient({
       knowledgeAssetFinalize: async (args) => {

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -1396,7 +1396,7 @@ export async function listAssertions(
 export const promoteAssertion = (
   contextGraphId: string,
   assertionName: string,
-  optionsOrLegacyEntities: { subGraphName?: string } | string | string[] = {},
+  optionsOrLegacyEntities: { subGraphName?: string } | string | string[] | undefined = {},
   legacySubGraphName?: string,
 ) => {
   if (Array.isArray(optionsOrLegacyEntities)) {
@@ -1412,7 +1412,7 @@ export const promoteAssertion = (
   const subGraphName =
     typeof optionsOrLegacyEntities === 'string'
       ? legacySubGraphName
-      : optionsOrLegacyEntities.subGraphName;
+      : optionsOrLegacyEntities?.subGraphName ?? legacySubGraphName;
   return post<{ promotedCount: number; sealed: boolean; publishReady: boolean }>(
     `/api/knowledge-assets/${encodeURIComponent(assertionName)}/swm/share`,
     {

--- a/packages/node-ui/test/ui-api-pure.test.ts
+++ b/packages/node-ui/test/ui-api-pure.test.ts
@@ -606,6 +606,13 @@ describe('UI API tests', () => {
       });
 
       requestLog.length = 0;
+      await promoteAssertion('cg-1', 'legacy-undefined', undefined, 'sg-placeholder');
+      expect(JSON.parse(requestLog[0]?.body ?? '{}')).toEqual({
+        contextGraphId: 'cg-1',
+        subGraphName: 'sg-placeholder',
+      });
+
+      requestLog.length = 0;
       expect(() => promoteAssertion('cg-1', 'asset', ['urn:root'])).toThrow(
         'root-entity selection is not supported',
       );

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -3,7 +3,7 @@ import type { ChainAdapter, OnChainPublishResult, AddBatchToContextGraphParams }
 import { enrichEvmError } from '@origintrail-official/dkg-chain';
 import type { EventBus, GraphKnowledgeAssetScope, OperationContext } from '@origintrail-official/dkg-core';
 import type { AssertionSeal } from '@origintrail-official/dkg-core';
-import { DKGEvent, Logger, createOperationContext, sha256, encodeWorkspacePublishRequest, encodeEncryptedWorkspacePayload, encryptWorkspacePayload, contextGraphDataUri, contextGraphDataGraphUri, contextGraphMetaUri, contextGraphAssertionUri, contextGraphLayerUri, MemoryLayer, assertionLifecycleUri, contextGraphSubGraphUri, contextGraphSubGraphMetaUri, SYSTEM_CONTEXT_GRAPHS, validateSubGraphName, isSafeIri, assertSafeIri, assertSafeRdfTerm, assertQuadLiteralsMutf8Safe, DKG_GOSSIP_MAX_MESSAGE_BYTES, SwmGossipPayloadTooLargeError, STORAGE_ACK_MAX_STAGING_BYTES, type Ed25519Keypair, buildAuthorAttestationTypedData, buildUpdateAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1, TrustLevel, TRUST_LEVEL_PREDICATE, assertNoUserAuthoredTrustLevelQuads, buildTrustLevelQuads, isTrustLevelQuad, isSwmMerkleExcludedQuad, WORKSPACE_OWNER_PREDICATE, DKG_ENTITY, DKG_ROOT_ENTITY_LEGACY, ENTITY_PRED_ALT, parseAssertionSealQuads, ASSERTION_SEAL_PREDICATES, DKG_ONTOLOGY, GRAPH_KA_CONTENT_SCOPE_VERSION, LegacyKnowledgeAssetReadOnlyError, createGraphKnowledgeAssetScope, knowledgeAssetLayerGraphUri } from '@origintrail-official/dkg-core';
+import { DKGEvent, Logger, createOperationContext, sha256, encodeWorkspacePublishRequest, encodeEncryptedWorkspacePayload, encryptWorkspacePayload, contextGraphDataUri, contextGraphDataGraphUri, contextGraphMetaUri, contextGraphPrivateUri, contextGraphAssertionUri, contextGraphLayerUri, MemoryLayer, assertionLifecycleUri, contextGraphSubGraphUri, contextGraphSubGraphMetaUri, contextGraphSubGraphPrivateUri, SYSTEM_CONTEXT_GRAPHS, validateSubGraphName, isSafeIri, assertSafeIri, assertSafeRdfTerm, assertQuadLiteralsMutf8Safe, DKG_GOSSIP_MAX_MESSAGE_BYTES, SwmGossipPayloadTooLargeError, STORAGE_ACK_MAX_STAGING_BYTES, type Ed25519Keypair, buildAuthorAttestationTypedData, buildUpdateAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1, TrustLevel, TRUST_LEVEL_PREDICATE, assertNoUserAuthoredTrustLevelQuads, buildTrustLevelQuads, isTrustLevelQuad, isSwmMerkleExcludedQuad, WORKSPACE_OWNER_PREDICATE, DKG_ENTITY, DKG_ROOT_ENTITY_LEGACY, ENTITY_PRED_ALT, parseAssertionSealQuads, ASSERTION_SEAL_PREDICATES, DKG_ONTOLOGY, GRAPH_KA_CONTENT_SCOPE_VERSION, LegacyKnowledgeAssetReadOnlyError, createGraphKnowledgeAssetScope, knowledgeAssetLayerGraphUri } from '@origintrail-official/dkg-core';
 import { GraphManager, PrivateContentStore, loadSharedMemoryQuadsForScope, loadSelectedSharedMemoryQuads, resolveSharedMemoryScopeGraphs, tryReplaceGraphAtomically } from '@origintrail-official/dkg-storage';
 import { DEFAULT_PUBLISH_EPOCHS, MAX_PUBLISH_EPOCHS, type Publisher, type PublishOptions, type PublishResult, type KAManifestEntry, type PhaseCallback, type V10CoreNodeACK, type V10ACKProviderParams, type V10ACKProviderObject, type LegacyV10ACKProvider } from './publisher.js';
 import { assertNoUserAuthoredKnowledgeAssetSkolemTerms, skolemizeByEntity, skolemizeKnowledgeAsset, skolemizeKnowledgeAssetParts } from './auto-partition.js';
@@ -61,6 +61,7 @@ import {
   type OnChainProvenance,
 } from './metadata.js';
 import {
+  resolveKnowledgeAssetWorkspaceHead,
   storeKnowledgeAssetOperationPublicQuads,
   storeKnowledgeAssetWorkspaceHead,
   storeWorkspaceOperationPublicQuads,
@@ -5708,16 +5709,14 @@ export class DKGPublisher implements Publisher {
    * lives on a DIFFERENT subject than the lifecycle URN, so the create/discard
    * clean-slates that key on the lifecycle URN don't reach it.
    *
-   * Callers: `assertionDiscard` (drops the seal when a non-published draft is
-   * discarded) and `assertionPullFrom` (re-opens a draft for editing, so the
-   * stale seal must go — it is rebuilt at the next finalize with the same
-   * reservedKaId via assertionCreate's A2 carry-over).
+   * Caller: `assertionDiscard`, when neither durable VM state nor an exact
+   * graph-scoped SWM head still needs a recovery commitment.
    *
    * NOTE (#1116 round 8+): finalize(layer="swm") does NOT pre-clear the seal.
    * The SWM pull resolves scope from the marker-gated promoted member rows —
-   * never `seal.rootEntities` — and `assertionPullFrom` does its own seal
-   * teardown only AFTER validating a non-empty source, which keeps the operation
-   * atomic-on-failure (a failed pull no longer strands a previously-valid seal).
+   * never `seal.rootEntities`. Pull-from archives the last finalized seal under
+   * a recovery-only subject before clearing the active draft seal, so editing is
+   * still enabled without letting a crash or discard strand durable SWM/VM data.
    */
   async clearAssertionSeal(
     contextGraphId: string,
@@ -5725,14 +5724,160 @@ export class DKGPublisher implements Publisher {
     agentAddress: string,
     subGraphName?: string,
   ): Promise<void> {
-    const metaGraph = contextGraphMetaUri(contextGraphId);
+    await this.clearActiveAssertionSeal(contextGraphId, name, agentAddress, subGraphName);
+    const recoveryGraph = this.assertionRecoverySealGraph(contextGraphId, subGraphName);
+    const recoverySubject = this.assertionRecoverySealSubject(
+      contextGraphId,
+      name,
+      agentAddress,
+      subGraphName,
+    );
+    for (const predicate of Object.values(ASSERTION_SEAL_PREDICATES)) {
+      await this.store.deleteByPattern({ graph: recoveryGraph, subject: recoverySubject, predicate });
+    }
+  }
+
+  private assertionRecoverySealGraph(
+    contextGraphId: string,
+    subGraphName?: string,
+  ): string {
+    return subGraphName
+      ? contextGraphSubGraphPrivateUri(contextGraphId, subGraphName)
+      : contextGraphPrivateUri(contextGraphId);
+  }
+
+  private assertionRecoverySealSubject(
+    contextGraphId: string,
+    name: string,
+    agentAddress: string,
+    subGraphName?: string,
+  ): string {
+    return `${contextGraphAssertionUri(
+      contextGraphId,
+      agentAddress,
+      name,
+      subGraphName,
+    )}/_recovery_seal`;
+  }
+
+  private async activeAssertionSealSubjects(
+    contextGraphId: string,
+    name: string,
+    agentAddress: string,
+    subGraphName?: string,
+  ): Promise<string[]> {
     const nameKeyed = contextGraphAssertionUri(contextGraphId, agentAddress, name, subGraphName);
-    const wmGraph = await this.wmGraphUri(contextGraphId, agentAddress, name, subGraphName);
-    for (const sealSubj of new Set([nameKeyed, wmGraph])) {
-      for (const pred of Object.values(ASSERTION_SEAL_PREDICATES)) {
-        await this.store.deleteByPattern({ graph: metaGraph, subject: sealSubj, predicate: pred });
+    const currentWmGraph = await this.wmGraphUri(
+      contextGraphId,
+      agentAddress,
+      name,
+      subGraphName,
+    );
+    return [...new Set([nameKeyed, currentWmGraph])];
+  }
+
+  private async clearActiveAssertionSeal(
+    contextGraphId: string,
+    name: string,
+    agentAddress: string,
+    subGraphName?: string,
+  ): Promise<void> {
+    const metaGraph = contextGraphMetaUri(contextGraphId);
+    for (const subject of await this.activeAssertionSealSubjects(
+      contextGraphId,
+      name,
+      agentAddress,
+      subGraphName,
+    )) {
+      for (const predicate of Object.values(ASSERTION_SEAL_PREDICATES)) {
+        await this.store.deleteByPattern({ graph: metaGraph, subject, predicate });
       }
     }
+  }
+
+  private async loadAssertionSeals(
+    contextGraphId: string,
+    name: string,
+    agentAddress: string,
+    subGraphName?: string,
+  ): Promise<Array<{ seal: AssertionSeal; subject: string; quads: Quad[] }>> {
+    const metaGraph = contextGraphMetaUri(contextGraphId);
+    const recoveryGraph = this.assertionRecoverySealGraph(contextGraphId, subGraphName);
+    const recoverySubject = this.assertionRecoverySealSubject(
+      contextGraphId,
+      name,
+      agentAddress,
+      subGraphName,
+    );
+    const candidates: Array<{ subject: string; graph: string }> = [
+      ...(await this.activeAssertionSealSubjects(contextGraphId, name, agentAddress, subGraphName))
+        .map((subject) => ({ subject, graph: metaGraph })),
+      { subject: recoverySubject, graph: recoveryGraph },
+    ];
+    const loaded: Array<{ seal: AssertionSeal; subject: string; quads: Quad[] }> = [];
+    const seen = new Set<string>();
+    for (const { subject, graph } of candidates) {
+      const key = `${graph}\0${subject}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      const result = await this.store.query(
+        `CONSTRUCT { <${subject}> ?p ?o } WHERE {
+          GRAPH <${graph}> { <${subject}> ?p ?o }
+        }`,
+      );
+      const quads = result.type === 'quads' ? result.quads : [];
+      try {
+        const seal = parseAssertionSealQuads(quads, subject);
+        if (seal) loaded.push({ seal, subject, quads });
+      } catch {
+        // A complete recovery archive may coexist with a torn active-seal
+        // deletion after a crash. Ignore only the unusable candidate; the
+        // source payload is still verified against whichever complete seal wins.
+      }
+    }
+    return loaded;
+  }
+
+  private async loadAssertionSeal(
+    contextGraphId: string,
+    name: string,
+    agentAddress: string,
+    subGraphName?: string,
+  ): Promise<{ seal: AssertionSeal; subject: string; quads: Quad[] } | undefined> {
+    return (await this.loadAssertionSeals(
+      contextGraphId,
+      name,
+      agentAddress,
+      subGraphName,
+    ))[0];
+  }
+
+  /** Copy a verified active seal to a recovery-only subject before unlocking WM. */
+  private async archiveAssertionSeal(
+    contextGraphId: string,
+    name: string,
+    agentAddress: string,
+    loaded: { seal: AssertionSeal; subject: string; quads: Quad[] },
+    subGraphName?: string,
+  ): Promise<Quad[]> {
+    const recoveryGraph = this.assertionRecoverySealGraph(contextGraphId, subGraphName);
+    const recoverySubject = this.assertionRecoverySealSubject(
+      contextGraphId,
+      name,
+      agentAddress,
+      subGraphName,
+    );
+    const sealPredicates = new Set<string>(Object.values(ASSERTION_SEAL_PREDICATES));
+    const recoveryQuads = loaded.quads
+      .filter((quad) => sealPredicates.has(quad.predicate))
+      .map((quad) => ({ ...quad, subject: recoverySubject, graph: recoveryGraph }));
+    if (loaded.subject !== recoverySubject) {
+      for (const predicate of sealPredicates) {
+        await this.store.deleteByPattern({ graph: recoveryGraph, subject: recoverySubject, predicate });
+      }
+      await this.store.insert(recoveryQuads);
+    }
+    return recoveryQuads;
   }
 
   // ── Working Memory Assertion Operations (spec §6) ───────────────────
@@ -6523,30 +6668,14 @@ export class DKGPublisher implements Publisher {
   }> {
     const subGraphName = opts?.subGraphName;
     await this.ensureSubGraphRegistered(contextGraphId, subGraphName);
-    const metaGraph = contextGraphMetaUri(contextGraphId);
     const sealSubject = contextGraphAssertionUri(contextGraphId, agentAddress, name, subGraphName);
-    const currentWmGraph = await this.wmGraphUri(
+    const loadedSeal = await this.loadAssertionSeal(
       contextGraphId,
-      agentAddress,
       name,
+      agentAddress,
       subGraphName,
     );
-    const candidateSealSubjects = currentWmGraph === sealSubject
-      ? [sealSubject]
-      : [sealSubject, currentWmGraph];
-    let seal: AssertionSeal | undefined;
-    for (const candidate of candidateSealSubjects) {
-      const sealResult = await this.store.query(
-        `CONSTRUCT { <${candidate}> ?p ?o } WHERE {
-          GRAPH <${metaGraph}> { <${candidate}> ?p ?o }
-        }`,
-      );
-      seal = parseAssertionSealQuads(
-        sealResult.type === 'quads' ? sealResult.quads : [],
-        candidate,
-      );
-      if (seal) break;
-    }
+    const seal = loadedSeal?.seal;
     if (!seal) {
       throw Object.assign(
         new Error(
@@ -6621,6 +6750,20 @@ export class DKGPublisher implements Publisher {
       `${sourceLayer}-memory`,
     );
 
+    // Archive the verified recovery commitment before unlocking the active
+    // draft seal. Finalization must see no active seal so a sanctioned edit can
+    // create the next assertion version, while pull/discard recovery can still
+    // verify the last durable SWM/VM copy after a crash.
+    if (!loadedSeal) throw new Error('Assertion seal disappeared during pull-from');
+    await this.archiveAssertionSeal(
+      contextGraphId,
+      name,
+      agentAddress,
+      loadedSeal,
+      subGraphName,
+    );
+    await this.clearActiveAssertionSeal(contextGraphId, name, agentAddress, subGraphName);
+
     // The complete source has been validated. Only now is replace allowed to
     // remove a dirty public or private draft.
     if (hasDraft) {
@@ -6633,7 +6776,6 @@ export class DKGPublisher implements Publisher {
       );
     }
     await this.assertionCreate(contextGraphId, name, agentAddress, subGraphName);
-    await this.clearAssertionSeal(contextGraphId, name, agentAddress, subGraphName);
     // The source was already canonicalized and seal-verified. Re-materialize it
     // through the internal exact-graph primitive: public assertionWrite rightly
     // rejects protocol-owned c14n skolem IRIs as user input.
@@ -7255,6 +7397,42 @@ export class DKGPublisher implements Publisher {
       `ASK { GRAPH <${cgMetaGraphForDiscard}> { <${lifecycleSubject}> <${VM_CURRENT_ASSERTION_PRED}> ?vm } }`,
     );
     const hasVmVersion = vmPointerRes.type === 'boolean' && vmPointerRes.value === true;
+    let preserveSwmRecoverySeal = false;
+    if (!hasVmVersion) {
+      const loadedSeals = await this.loadAssertionSeals(
+        contextGraphId,
+        name,
+        agentAddress,
+        subGraphName,
+      );
+      for (const loadedSeal of loadedSeals) {
+        const seal = loadedSeal.seal;
+        if (
+          seal.contentScopeVersion !== GRAPH_KA_CONTENT_SCOPE_VERSION
+          || !seal.kaUal
+          || !seal.assertionVersion
+        ) continue;
+        const head = await resolveKnowledgeAssetWorkspaceHead({
+          store: this.store,
+          graphManager: this.graphManager,
+          contextGraphId,
+          kaUal: seal.kaUal,
+          subGraphName,
+        });
+        preserveSwmRecoverySeal = head?.kaUal === seal.kaUal
+          && head.assertionVersion === seal.assertionVersion;
+        if (preserveSwmRecoverySeal) {
+          await this.archiveAssertionSeal(
+            contextGraphId,
+            name,
+            agentAddress,
+            loadedSeal,
+            subGraphName,
+          );
+          break;
+        }
+      }
+    }
     if (hasVmVersion) {
       const DKG_STATE_PRED = 'http://dkg.io/ontology/state';
       const PROV_INVALIDATED = 'http://www.w3.org/ns/prov#wasInvalidatedBy';
@@ -7301,16 +7479,16 @@ export class DKGPublisher implements Publisher {
     if (!hasVmVersion) {
       await this.store.deleteByPattern({ graph: metaGraph, subject: lifecycleSubject, predicate: DKG_ROOT_ENTITY_LEGACY });
       await this.store.deleteByPattern({ graph: metaGraph, subject: lifecycleSubject, predicate: DKG_ENTITY });
-      // #1116 (round 7) — CLEAR the assertion SEAL too, via the single
-      // `clearAssertionSeal` helper (one source of truth for the seal
-      // subject/predicate set — a critical lifecycle invariant). The seal is keyed
-      // by the name-keyed assertion URI / numbered WM URI, a DIFFERENT subject than
-      // the lifecycle URN the `_meta` cleanup above deletes — so a seal from a prior
-      // FULL share would SURVIVE discard and, since pull-from reads
-      // `seal.rootEntities` first, drive a discard → recreate → re-share →
-      // seal-in-SWM reconstruction from the STALE roots. A discarded
-      // (non-published) asset must leave NO seal.
-      await this.clearAssertionSeal(contextGraphId, name, agentAddress, subGraphName);
+    }
+    // A never-shared draft has no durable source and must lose its seal. An
+    // exact graph-scoped SWM head, however, is immutable recovery state just
+    // like VM: retain its matching v2 seal so a later pull can reopen it.
+    if (!hasVmVersion) {
+      if (preserveSwmRecoverySeal) {
+        await this.clearActiveAssertionSeal(contextGraphId, name, agentAddress, subGraphName);
+      } else {
+        await this.clearAssertionSeal(contextGraphId, name, agentAddress, subGraphName);
+      }
     }
     await this.dropAssertionScopedGraphs(graphUri);
     await this.privateStore.deleteKnowledgeAssetPrivateDraft(

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -138,6 +138,70 @@ function resolveCatalogProofMaterial(
   };
 }
 
+/**
+ * Verify the off-band owner authorization before any update payload is staged.
+ *
+ * Both the agent's direct-update boundary and the publisher's final chain
+ * submission call this helper. Keeping the verification here prevents the two
+ * layers from drifting while allowing callers to reject an unauthorized update
+ * before replacing local SWM or private state.
+ */
+export async function assertValidPrecomputedUpdateAttestation(
+  chain: ChainAdapter,
+  kaId: bigint,
+  merkleRoot: Uint8Array,
+  updateSeal: NonNullable<PublishOptions['precomputedUpdateAttestation']>,
+): Promise<void> {
+  const expected = updateSeal.expectedNewMerkleRoot;
+  if (
+    expected.length !== merkleRoot.length
+    || !expected.every((byte, index) => byte === merkleRoot[index])
+  ) {
+    throw new Error(
+      `precomputedUpdateAttestation.expectedNewMerkleRoot mismatch: seal expects ${ethers.hexlify(expected)} `
+      + `but update-time recompute yielded ${ethers.hexlify(merkleRoot)}.`,
+    );
+  }
+
+  const v10ChainId = await chain.getEvmChainId?.();
+  const v10KavAddress = await chain.getKnowledgeAssetsLifecycleAddress?.();
+  if (v10ChainId === undefined || !v10KavAddress) {
+    throw new Error(
+      'V10 update requires getEvmChainId() and getKnowledgeAssetsLifecycleAddress() on the chain adapter.',
+    );
+  }
+
+  const updateAuthorTyped = buildUpdateAuthorAttestationTypedData({
+    chainId: v10ChainId,
+    kav10Address: v10KavAddress,
+    kaId,
+    newMerkleRoot: merkleRoot,
+    authorAddress: updateSeal.authorAddress,
+    schemeVersion: updateSeal.schemeVersion,
+  });
+  const signature = ethers.Signature.from({
+    r: ethers.hexlify(updateSeal.signature.r),
+    yParityAndS: ethers.hexlify(updateSeal.signature.vs),
+  });
+  const digest = ethers.TypedDataEncoder.hash(
+    updateAuthorTyped.domain,
+    updateAuthorTyped.types,
+    updateAuthorTyped.message,
+  );
+  const isContractAuthor = typeof chain.hasContractCode === 'function'
+    ? await chain.hasContractCode(updateSeal.authorAddress)
+    : false;
+  if (isContractAuthor) return;
+
+  const recovered = ethers.recoverAddress(digest, signature);
+  if (recovered.toLowerCase() !== updateSeal.authorAddress.toLowerCase()) {
+    throw new Error(
+      `precomputedUpdateAttestation signer mismatch: recovers ${recovered} `
+      + `but claims ${updateSeal.authorAddress}.`,
+    );
+  }
+}
+
 async function validateGraphScopedPayloadAgainstSeal(
   seal: AssertionSeal,
   publicQuads: readonly Quad[],
@@ -4548,53 +4612,12 @@ export class DKGPublisher implements Publisher {
     const updateSeal = options.precomputedUpdateAttestation;
     const effectiveAuthorAddress = updateSeal.authorAddress;
     const effectiveSchemeVersion = updateSeal.schemeVersion;
-    {
-      const expected = updateSeal.expectedNewMerkleRoot;
-      if (expected.length !== kcMerkleRoot.length || !expected.every((b, i) => b === kcMerkleRoot[i])) {
-        throw new Error(
-          `precomputedUpdateAttestation.expectedNewMerkleRoot mismatch: seal expects ${ethers.hexlify(expected)} ` +
-          `but update-time recompute yielded ${ethers.hexlify(kcMerkleRoot)}.`,
-        );
-      }
-    }
-    const v10ChainId = await this.chain.getEvmChainId?.();
-    const v10KavAddress = await this.chain.getKnowledgeAssetsLifecycleAddress?.();
-    if (v10ChainId === undefined || !v10KavAddress) {
-      throw new Error(
-        'V10 update requires getEvmChainId() and getKnowledgeAssetsLifecycleAddress() on the chain adapter.',
-      );
-    }
-    const updateAuthorTyped = buildUpdateAuthorAttestationTypedData({
-      chainId: v10ChainId,
-      kav10Address: v10KavAddress,
-      kaId: kaId,
-      newMerkleRoot: kcMerkleRoot,
-      authorAddress: effectiveAuthorAddress,
-      schemeVersion: effectiveSchemeVersion,
-    });
-    {
-      const sig = ethers.Signature.from({
-        r: ethers.hexlify(updateSeal.signature.r),
-        yParityAndS: ethers.hexlify(updateSeal.signature.vs),
-      });
-      const digest = ethers.TypedDataEncoder.hash(
-        updateAuthorTyped.domain,
-        updateAuthorTyped.types,
-        updateAuthorTyped.message,
-      );
-      const isContractAuthor =
-        typeof this.chain.hasContractCode === 'function'
-          ? await this.chain.hasContractCode(effectiveAuthorAddress)
-          : false;
-      if (!isContractAuthor) {
-        const recovered = ethers.recoverAddress(digest, sig);
-        if (recovered.toLowerCase() !== effectiveAuthorAddress.toLowerCase()) {
-          throw new Error(
-            `precomputedUpdateAttestation signer mismatch: recovers ${recovered} but claims ${effectiveAuthorAddress}.`,
-          );
-        }
-      }
-    }
+    await assertValidPrecomputedUpdateAttestation(
+      this.chain,
+      kaId,
+      kcMerkleRoot,
+      updateSeal,
+    );
 
     // P-1 review (iter-2): `chain:writeahead:start` fires from inside
     // the V10 adapter via `onBroadcast` — i.e. AFTER allowance +

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -14,7 +14,7 @@ import { canonicalPublishPayload } from './canonical-publish-payload.js';
 import {
   assertTrustedCatalogTriplesAreGeneratedFloor,
   catalogTripleKey,
-  replaceCatalogPartitionWithGeneratedPrivateFloor,
+  generatedPrivateCatalogFloorQuads,
   splitTrustedGeneratedCatalogRootMap,
   trustedCatalogTripleKeySet,
 } from './catalog-trust.js';
@@ -109,6 +109,34 @@ export {
 // member rows — cannot be sealed-in-SWM and published as a partial asset.
 const SWM_SHARE_COMPLETE_PRED = 'http://dkg.io/ontology/swmShareComplete';
 const SHARE_OPERATION_ID_PRED = 'http://dkg.io/ontology/shareOperationId';
+
+/**
+ * Resolve the public catalog proof material independently from a V2 KA's
+ * canonical RDF payload.
+ *
+ * Legacy root-scoped publishes retain the combined-model partition: catalog
+ * rows already present in the payload stay committed by the KC root. A
+ * graph-scoped KA is different: every submitted triple is atomic asset data,
+ * including a user-authored triple whose subject happens to be the CG DID.
+ * Its protocol-owned private-CG floor is therefore generated into a detached
+ * catalog commitment and must never be removed from, or appended to, the KA.
+ */
+function resolveCatalogProofMaterial(
+  quads: readonly Quad[],
+  contextGraphId: string,
+  graphScoped: boolean,
+  trustedKeys: PublishOptions['trustedNonManifestCatalogTriples'],
+): { catalogQuads: Quad[]; otherQuads: Quad[] } {
+  if (!graphScoped) {
+    return partitionCatalogQuads(quads, contextGraphDataUri(contextGraphId));
+  }
+  return {
+    catalogQuads: trustedCatalogTripleKeySet(trustedKeys).size > 0
+      ? generatedPrivateCatalogFloorQuads(contextGraphId)
+      : [],
+    otherQuads: [...quads],
+  };
+}
 
 async function validateGraphScopedPayloadAgainstSeal(
   seal: AssertionSeal,
@@ -2295,6 +2323,7 @@ export class DKGPublisher implements Publisher {
     let allSkolemizedQuads: Quad[];
     let privateRoots: Uint8Array[];
     if (graphPublish) {
+      assertNoKnowledgeAssetPayloadNamedGraphs(quads, privateQuads);
       const canonicalParts = await skolemizeKnowledgeAssetParts(quads, privateQuads, {
         allowCanonicalSkolemTerms: isInternalOrigin(options),
       });
@@ -2508,16 +2537,18 @@ export class DKGPublisher implements Publisher {
     const publicNquadsBytes = new TextEncoder().encode(nquadsStr);
     const publicByteSize = BigInt(publicNquadsBytes.length);
 
-    // the public DCAT catalog entry rides in the KC merkle root
-    // (kcMerkleRoot, above, covers it) AND is the OT-RFC-49 curated random-
-    // sampling commitment (catalogRoot, below). It MUST NOT be encrypted: feed
-    // only the non-catalog (private data) quads to the MEMBER encryptor. No-op
-    // for public CGs and any private CG without a catalog entry (catalogQuads
-    // empty ⇒ encryptableNquadsStr === nquadsStr).
-    // Identity-based partition: the ONLY catalog subject is this CG's canonical
-    // DID (round-3 SECURITY). A forged `rdf:type dkg:PrivateContextGraph` on a
-    // user entity no longer routes that entity into the plaintext `_catalog`.
-    const { catalogQuads, otherQuads } = partitionCatalogQuads(allSkolemizedQuads, contextGraphDataUri(contextGraphId));
+    // Legacy payloads retain the combined catalog model. V2 graph-scoped KAs
+    // use a detached protocol-owned floor: their KC Merkle root and exact
+    // publicTripleCount cover only the submitted canonical RDF, while the
+    // independent catalogRoot/catalogLeafCount pair commits the generated
+    // public floor. This also prevents a user-authored CG-DID triple from being
+    // stripped out of the atomic KA or leaked into the plaintext catalog.
+    const { catalogQuads, otherQuads } = resolveCatalogProofMaterial(
+      allSkolemizedQuads,
+      contextGraphId,
+      graphPublish !== undefined,
+      options.trustedNonManifestCatalogTriples,
+    );
     const encryptableNquadsStr = catalogQuads.length === 0
       ? nquadsStr
       : otherQuads
@@ -3952,7 +3983,7 @@ export class DKGPublisher implements Publisher {
         kaNumber: BigInt(descriptor.scope.kaNumber),
       },
     };
-    let quads = await loadSharedMemoryQuadsForScope(
+    const quads = await loadSharedMemoryQuadsForScope(
       this.store,
       swmBucket,
       'all',
@@ -3962,19 +3993,13 @@ export class DKGPublisher implements Publisher {
     const hasTrustedCatalogTriples =
       trustedCatalogTripleKeySet(options.trustedNonManifestCatalogTriples).size > 0;
     if (hasTrustedCatalogTriples) {
-      // Curated updates refresh the deterministic public catalog floor. The
-      // trusted entrypoint still sources all user content from the exact SWM
-      // graph; only the four validated protocol-owned catalog triples are
-      // replaced here, so callers cannot smuggle arbitrary RDF around that
-      // boundary. `update()` re-validates the exact key set below.
+      // Validate the capability here, but do not mutate the exact SWM payload.
+      // `update()` derives the detached catalog commitment from this trusted
+      // marker after separately canonicalizing the submitted KA graph.
       assertTrustedCatalogTriplesAreGeneratedFloor(
         options.contextGraphId,
         options.trustedNonManifestCatalogTriples,
       );
-      quads = replaceCatalogPartitionWithGeneratedPrivateFloor(
-        options.contextGraphId,
-        quads,
-      ).quads;
     }
     if (quads.length === 0 && (options.privateQuads?.length ?? 0) === 0) {
       throw new Error(
@@ -4096,6 +4121,7 @@ export class DKGPublisher implements Publisher {
     let allSkolemizedQuads: Quad[];
     let updatePrivateRoots: Uint8Array[];
     if (graphUpdate) {
+      assertNoKnowledgeAssetPayloadNamedGraphs(quads, privateQuads);
       const canonicalParts = await skolemizeKnowledgeAssetParts(quads, privateQuads, {
         allowCanonicalSkolemTerms: isInternalOrigin(options),
       });
@@ -4400,7 +4426,12 @@ export class DKGPublisher implements Publisher {
     // DID, so a forged `rdf:type dkg:PrivateContextGraph` cannot route a user
     // entity into the plaintext `_catalog`.
     const { catalogQuads: updateCatalogQuads, otherQuads: updateOtherQuads } =
-      partitionCatalogQuads(allSkolemizedQuads, contextGraphDataUri(contextGraphId));
+      resolveCatalogProofMaterial(
+        allSkolemizedQuads,
+        contextGraphId,
+        graphUpdate !== undefined,
+        options.trustedNonManifestCatalogTriples,
+      );
     // Non-catalog plaintext fed to the MEMBER encryptor (graph term retained,
     // mirror 2031-2038). No-op for public updates / curated updates with no
     // catalog entry (then encryptableUpdateNquadsStr === updateNquadsStr).
@@ -5795,6 +5826,49 @@ export class DKGPublisher implements Publisher {
     }
   }
 
+  /**
+   * Discard may run while a confirmed VM version and a newly-finalized draft
+   * coexist. Retain an active seal only when it is the seal for that confirmed
+   * VM head; every other active seal belongs to the draft being discarded.
+   * Recovery seals live in the private partition and are deliberately untouched.
+   */
+  private async clearActiveAssertionSealsNotMatchingMerkle(
+    contextGraphId: string,
+    name: string,
+    agentAddress: string,
+    confirmedVmMerkleHex: string,
+    subGraphName?: string,
+  ): Promise<void> {
+    const metaGraph = contextGraphMetaUri(contextGraphId);
+    const expected = confirmedVmMerkleHex.replace(/^0x/i, '').toLowerCase();
+    for (const subject of await this.activeAssertionSealSubjects(
+      contextGraphId,
+      name,
+      agentAddress,
+      subGraphName,
+    )) {
+      const result = await this.store.query(
+        `CONSTRUCT { <${subject}> ?p ?o } WHERE {
+          GRAPH <${metaGraph}> { <${subject}> ?p ?o }
+        }`,
+      );
+      const quads = result.type === 'quads' ? result.quads : [];
+      let matchesConfirmedVm = false;
+      try {
+        const seal = parseAssertionSealQuads(quads, subject);
+        matchesConfirmedVm = seal !== undefined
+          && ethers.hexlify(seal.merkleRoot).slice(2).toLowerCase() === expected;
+      } catch {
+        // A torn or mixed active seal cannot describe the confirmed VM head and
+        // must not outrank the complete recovery archive on the next pull.
+      }
+      if (matchesConfirmedVm) continue;
+      for (const predicate of Object.values(ASSERTION_SEAL_PREDICATES)) {
+        await this.store.deleteByPattern({ graph: metaGraph, subject, predicate });
+      }
+    }
+  }
+
   private async loadAssertionSeals(
     contextGraphId: string,
     name: string,
@@ -5836,20 +5910,6 @@ export class DKGPublisher implements Publisher {
       }
     }
     return loaded;
-  }
-
-  private async loadAssertionSeal(
-    contextGraphId: string,
-    name: string,
-    agentAddress: string,
-    subGraphName?: string,
-  ): Promise<{ seal: AssertionSeal; subject: string; quads: Quad[] } | undefined> {
-    return (await this.loadAssertionSeals(
-      contextGraphId,
-      name,
-      agentAddress,
-      subGraphName,
-    ))[0];
   }
 
   /** Copy a verified active seal to a recovery-only subject before unlocking WM. */
@@ -6669,14 +6729,13 @@ export class DKGPublisher implements Publisher {
     const subGraphName = opts?.subGraphName;
     await this.ensureSubGraphRegistered(contextGraphId, subGraphName);
     const sealSubject = contextGraphAssertionUri(contextGraphId, agentAddress, name, subGraphName);
-    const loadedSeal = await this.loadAssertionSeal(
+    const loadedSeals = await this.loadAssertionSeals(
       contextGraphId,
       name,
       agentAddress,
       subGraphName,
     );
-    const seal = loadedSeal?.seal;
-    if (!seal) {
+    if (loadedSeals.length === 0) {
       throw Object.assign(
         new Error(
           `Cannot pull "${name}" from ${sourceLayer.toUpperCase()}: rootless mutation requires a finalized v2 assertion seal`,
@@ -6684,30 +6743,89 @@ export class DKGPublisher implements Publisher {
         { code: 'UNSEALED_PULL_FROM_BLOCKED' },
       );
     }
-    if (seal.contentScopeVersion !== GRAPH_KA_CONTENT_SCOPE_VERSION) {
-      throw new LegacyKnowledgeAssetReadOnlyError();
-    }
-    if (
-      !seal.kaUal
-      || !seal.assertionVersion
-      || seal.publicTripleCount === undefined
-      || seal.privateTripleCount === undefined
-    ) {
-      throw new Error(`Graph-scoped assertion seal for <${sealSubject}> is incomplete`);
+
+    let selectedSeal: typeof loadedSeals[number] | undefined;
+    let selectedScope: GraphKnowledgeAssetScope | undefined;
+    let validated: Awaited<ReturnType<typeof validateGraphScopedPayloadAgainstSeal>> | undefined;
+    let candidateError: unknown;
+    let sawLegacySeal = false;
+
+    // Active and recovery seals may legitimately coexist while an edit is
+    // open. Validate candidates against the requested exact source graph in
+    // priority order; a discarded/torn active seal must never shadow the last
+    // complete VM/SWM recovery commitment.
+    for (const loadedSeal of loadedSeals) {
+      const seal = loadedSeal.seal;
+      if (seal.contentScopeVersion !== GRAPH_KA_CONTENT_SCOPE_VERSION) {
+        sawLegacySeal = true;
+        continue;
+      }
+      if (
+        !seal.kaUal
+        || !seal.assertionVersion
+        || seal.publicTripleCount === undefined
+        || seal.privateTripleCount === undefined
+      ) {
+        candidateError = new Error(`Graph-scoped assertion seal for <${sealSubject}> is incomplete`);
+        continue;
+      }
+
+      try {
+        const scope = createGraphKnowledgeAssetScope(seal.kaUal, seal.assertionVersion);
+        const sourceGraph = knowledgeAssetLayerGraphUri(
+          contextGraphId,
+          sourceLayer === 'swm'
+            ? MemoryLayer.SharedWorkingMemory
+            : MemoryLayer.VerifiableMemory,
+          scope,
+          subGraphName,
+        );
+        const sourcePublicQuads = (await this.assertionScopedQuads(sourceGraph)).filter(
+          (quad) => !isSwmMerkleExcludedQuad(quad),
+        );
+        const sourcePrivateQuads = await this.privateStore.getKnowledgeAssetPrivateTriples(
+          contextGraphId,
+          scope,
+          subGraphName,
+        );
+        if (sourcePublicQuads.length === 0 && sourcePrivateQuads.length === 0) {
+          throw Object.assign(
+            new Error(
+              `No exact ${sourceLayer.toUpperCase()} content found for sealed KA ${scope.ual} assertion ${scope.assertionVersion}; WM draft was not modified.`,
+            ),
+            { code: 'PULL_FROM_EMPTY_SOURCE' },
+          );
+        }
+        const candidatePayload = await validateGraphScopedPayloadAgainstSeal(
+          seal,
+          sourcePublicQuads,
+          sourcePrivateQuads,
+          `${sourceLayer}-memory`,
+        );
+        selectedSeal = loadedSeal;
+        selectedScope = scope;
+        validated = candidatePayload;
+        break;
+      } catch (error) {
+        candidateError = error;
+      }
     }
 
-    const scope = createGraphKnowledgeAssetScope(seal.kaUal, seal.assertionVersion);
+    if (!selectedSeal || !selectedScope || !validated) {
+      if (candidateError) throw candidateError;
+      if (sawLegacySeal) throw new LegacyKnowledgeAssetReadOnlyError();
+      throw Object.assign(
+        new Error(
+          `Cannot pull "${name}" from ${sourceLayer.toUpperCase()}: no complete v2 assertion seal matches the exact source graph`,
+        ),
+        { code: 'UNSEALED_PULL_FROM_BLOCKED' },
+      );
+    }
+
+    const scope = selectedScope;
     const wmGraph = knowledgeAssetLayerGraphUri(
       contextGraphId,
       MemoryLayer.WorkingMemory,
-      scope,
-      subGraphName,
-    );
-    const sourceGraph = knowledgeAssetLayerGraphUri(
-      contextGraphId,
-      sourceLayer === 'swm'
-        ? MemoryLayer.SharedWorkingMemory
-        : MemoryLayer.VerifiableMemory,
       scope,
       subGraphName,
     );
@@ -6727,39 +6845,15 @@ export class DKGPublisher implements Publisher {
       );
     }
 
-    const sourcePublicQuads = (await this.assertionScopedQuads(sourceGraph)).filter(
-      (quad) => !isSwmMerkleExcludedQuad(quad),
-    );
-    const sourcePrivateQuads = await this.privateStore.getKnowledgeAssetPrivateTriples(
-      contextGraphId,
-      scope,
-      subGraphName,
-    );
-    if (sourcePublicQuads.length === 0 && sourcePrivateQuads.length === 0) {
-      throw Object.assign(
-        new Error(
-          `No exact ${sourceLayer.toUpperCase()} content found for sealed KA ${scope.ual} assertion ${scope.assertionVersion}; WM draft was not modified.`,
-        ),
-        { code: 'PULL_FROM_EMPTY_SOURCE' },
-      );
-    }
-    const validated = await validateGraphScopedPayloadAgainstSeal(
-      seal,
-      sourcePublicQuads,
-      sourcePrivateQuads,
-      `${sourceLayer}-memory`,
-    );
-
     // Archive the verified recovery commitment before unlocking the active
     // draft seal. Finalization must see no active seal so a sanctioned edit can
     // create the next assertion version, while pull/discard recovery can still
     // verify the last durable SWM/VM copy after a crash.
-    if (!loadedSeal) throw new Error('Assertion seal disappeared during pull-from');
     await this.archiveAssertionSeal(
       contextGraphId,
       name,
       agentAddress,
-      loadedSeal,
+      selectedSeal,
       subGraphName,
     );
     await this.clearActiveAssertionSeal(contextGraphId, name, agentAddress, subGraphName);
@@ -7394,9 +7488,14 @@ export class DKGPublisher implements Publisher {
     const lifecycleSubject = assertionLifecycleUri(contextGraphId, agentAddress, name, subGraphName);
     const cgMetaGraphForDiscard = contextGraphMetaUri(contextGraphId);
     const vmPointerRes = await this.store.query(
-      `ASK { GRAPH <${cgMetaGraphForDiscard}> { <${lifecycleSubject}> <${VM_CURRENT_ASSERTION_PRED}> ?vm } }`,
+      `SELECT ?vm WHERE { GRAPH <${cgMetaGraphForDiscard}> {
+        <${lifecycleSubject}> <${VM_CURRENT_ASSERTION_PRED}> ?vm
+      } } LIMIT 1`,
     );
-    const hasVmVersion = vmPointerRes.type === 'boolean' && vmPointerRes.value === true;
+    const confirmedVmMerkleHex = stripSparqlLiteral(
+      vmPointerRes.type === 'bindings' ? vmPointerRes.bindings[0]?.['vm'] : undefined,
+    )?.replace(/^0x/i, '').toLowerCase();
+    const hasVmVersion = confirmedVmMerkleHex !== undefined;
     let preserveSwmRecoverySeal = false;
     if (!hasVmVersion) {
       const loadedSeals = await this.loadAssertionSeals(
@@ -7434,6 +7533,17 @@ export class DKGPublisher implements Publisher {
       }
     }
     if (hasVmVersion) {
+      // A newly-finalized edit has an active seal even though the VM pointer
+      // still identifies the prior confirmed assertion. Discard that draft
+      // seal now; retain only an active seal that actually matches VM. The
+      // archived recovery seal for the confirmed version remains untouched.
+      await this.clearActiveAssertionSealsNotMatchingMerkle(
+        contextGraphId,
+        name,
+        agentAddress,
+        confirmedVmMerkleHex,
+        subGraphName,
+      );
       const DKG_STATE_PRED = 'http://dkg.io/ontology/state';
       const PROV_INVALIDATED = 'http://www.w3.org/ns/prov#wasInvalidatedBy';
       discarded.insert = discarded.insert.filter(

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -191,13 +191,51 @@ export async function assertValidPrecomputedUpdateAttestation(
   const isContractAuthor = typeof chain.hasContractCode === 'function'
     ? await chain.hasContractCode(updateSeal.authorAddress)
     : false;
-  if (isContractAuthor) return;
+  if (isContractAuthor) {
+    if (typeof chain.verifyContractSignature !== 'function') {
+      throw new Error(
+        'V10 contract-author update authorization requires verifyContractSignature() on the chain adapter.',
+      );
+    }
+    const valid = await chain.verifyContractSignature(
+      updateSeal.authorAddress,
+      digest,
+      signature.serialized,
+    );
+    if (!valid) {
+      throw new Error(
+        `precomputedUpdateAttestation contract signature is invalid for ${updateSeal.authorAddress}.`,
+      );
+    }
+  } else {
+    const recovered = ethers.recoverAddress(digest, signature);
+    if (recovered.toLowerCase() !== updateSeal.authorAddress.toLowerCase()) {
+      throw new Error(
+        `precomputedUpdateAttestation signer mismatch: recovers ${recovered} `
+        + `but claims ${updateSeal.authorAddress}.`,
+      );
+    }
+  }
 
-  const recovered = ethers.recoverAddress(digest, signature);
-  if (recovered.toLowerCase() !== updateSeal.authorAddress.toLowerCase()) {
+  if (typeof chain.getKnowledgeAssetOwner !== 'function') {
     throw new Error(
-      `precomputedUpdateAttestation signer mismatch: recovers ${recovered} `
-      + `but claims ${updateSeal.authorAddress}.`,
+      'V10 update authorization requires getKnowledgeAssetOwner() on the chain adapter.',
+    );
+  }
+  const currentOwner = ethers.getAddress(await chain.getKnowledgeAssetOwner(kaId));
+  const claimedAuthor = ethers.getAddress(updateSeal.authorAddress);
+  if (currentOwner !== claimedAuthor) {
+    throw Object.assign(
+      new Error(
+        `precomputedUpdateAttestation author ${claimedAuthor} is not the current owner `
+        + `${currentOwner} of Knowledge Asset ${kaId.toString()}.`,
+      ),
+      {
+        code: 'KA_UPDATE_AUTHOR_NOT_OWNER',
+        kaId: kaId.toString(),
+        currentOwner,
+        authorAddress: claimedAuthor,
+      },
     );
   }
 }

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -142,15 +142,17 @@ function resolveCatalogProofMaterial(
  * Verify the off-band owner authorization before any update payload is staged.
  *
  * Both the agent's direct-update boundary and the publisher's final chain
- * submission call this helper. Keeping the verification here prevents the two
- * layers from drifting while allowing callers to reject an unauthorized update
- * before replacing local SWM or private state.
+ * submission call this helper. The agent requires every local authorization
+ * capability because it is about to mutate durable staging. Direct publisher
+ * callers may use older/custom adapters without the optional pre-read methods;
+ * in that case the on-chain update remains the final authorization boundary.
  */
 export async function assertValidPrecomputedUpdateAttestation(
   chain: ChainAdapter,
   kaId: bigint,
   merkleRoot: Uint8Array,
   updateSeal: NonNullable<PublishOptions['precomputedUpdateAttestation']>,
+  options: { requireLocalAuthorization?: boolean } = {},
 ): Promise<void> {
   const expected = updateSeal.expectedNewMerkleRoot;
   if (
@@ -193,19 +195,22 @@ export async function assertValidPrecomputedUpdateAttestation(
     : false;
   if (isContractAuthor) {
     if (typeof chain.verifyContractSignature !== 'function') {
-      throw new Error(
-        'V10 contract-author update authorization requires verifyContractSignature() on the chain adapter.',
+      if (options.requireLocalAuthorization) {
+        throw new Error(
+          'V10 contract-author update authorization requires verifyContractSignature() on the chain adapter.',
+        );
+      }
+    } else {
+      const valid = await chain.verifyContractSignature(
+        updateSeal.authorAddress,
+        digest,
+        signature.serialized,
       );
-    }
-    const valid = await chain.verifyContractSignature(
-      updateSeal.authorAddress,
-      digest,
-      signature.serialized,
-    );
-    if (!valid) {
-      throw new Error(
-        `precomputedUpdateAttestation contract signature is invalid for ${updateSeal.authorAddress}.`,
-      );
+      if (!valid) {
+        throw new Error(
+          `precomputedUpdateAttestation contract signature is invalid for ${updateSeal.authorAddress}.`,
+        );
+      }
     }
   } else {
     const recovered = ethers.recoverAddress(digest, signature);
@@ -218,9 +223,12 @@ export async function assertValidPrecomputedUpdateAttestation(
   }
 
   if (typeof chain.getKnowledgeAssetOwner !== 'function') {
-    throw new Error(
-      'V10 update authorization requires getKnowledgeAssetOwner() on the chain adapter.',
-    );
+    if (options.requireLocalAuthorization) {
+      throw new Error(
+        'V10 update authorization requires getKnowledgeAssetOwner() on the chain adapter.',
+      );
+    }
+    return;
   }
   const currentOwner = ethers.getAddress(await chain.getKnowledgeAssetOwner(kaId));
   const claimedAuthor = ethers.getAddress(updateSeal.authorAddress);

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -126,6 +126,7 @@ function resolveCatalogProofMaterial(
   contextGraphId: string,
   graphScoped: boolean,
   trustedKeys: PublishOptions['trustedNonManifestCatalogTriples'],
+  memberDataGraph: string,
 ): { catalogQuads: Quad[]; otherQuads: Quad[] } {
   if (!graphScoped) {
     return partitionCatalogQuads(quads, contextGraphDataUri(contextGraphId));
@@ -134,7 +135,11 @@ function resolveCatalogProofMaterial(
     catalogQuads: trustedCatalogTripleKeySet(trustedKeys).size > 0
       ? generatedPrivateCatalogFloorQuads(contextGraphId)
       : [],
-    otherQuads: [...quads],
+    // Graph-scoped canonicalization deliberately hashes graph-less triples,
+    // but the same payload is later serialized as N-Quads for member-side
+    // encryption. Stamp the exact per-KA VM graph here so that serialization
+    // cannot emit the invalid empty graph IRI `<>`.
+    otherQuads: quads.map((quad) => ({ ...quad, graph: memberDataGraph })),
   };
 }
 
@@ -2641,7 +2646,7 @@ export class DKGPublisher implements Publisher {
     const nquadsStr = allSkolemizedQuads
       .map(
         (q) =>
-          `<${q.subject}> <${q.predicate}> ${q.object.startsWith('"') ? q.object : `<${q.object}>`} <${q.graph}> .`,
+          `<${q.subject}> <${q.predicate}> ${q.object.startsWith('"') ? q.object : `<${q.object}>`} <${q.graph || dataGraph}> .`,
       )
       .join('\n');
     const publicNquadsBytes = new TextEncoder().encode(nquadsStr);
@@ -2658,6 +2663,7 @@ export class DKGPublisher implements Publisher {
       contextGraphId,
       graphPublish !== undefined,
       options.trustedNonManifestCatalogTriples,
+      dataGraph,
     );
     const encryptableNquadsStr = catalogQuads.length === 0
       ? nquadsStr
@@ -4541,6 +4547,7 @@ export class DKGPublisher implements Publisher {
         contextGraphId,
         graphUpdate !== undefined,
         options.trustedNonManifestCatalogTriples,
+        dataGraph,
       );
     // Non-catalog plaintext fed to the MEMBER encryptor (graph term retained,
     // mirror 2031-2038). No-op for public updates / curated updates with no

--- a/packages/publisher/src/index.ts
+++ b/packages/publisher/src/index.ts
@@ -75,6 +75,7 @@ export {
   MultiRootPublishNotAtomicError,
   CuratorUnconfirmedError,
   CuratorRejectedError,
+  assertValidPrecomputedUpdateAttestation,
   type DKGPublisherConfig,
   type WorkspaceSenderKeyEncryptInput,
   type WorkspaceSenderKeyEncryptor,

--- a/packages/publisher/src/publisher.ts
+++ b/packages/publisher/src/publisher.ts
@@ -277,9 +277,11 @@ export interface PublishOptions {
    */
   onChainContextGraphId?: string | bigint;
   /**
-   * Internal/private-CG catalog path: exact generated catalog triples that ride
-   * in the KC Merkle root but are not user KA manifest roots. Public callers
-   * should not set this for arbitrary metadata.
+   * Internal/private-CG catalog capability: the exact deterministic floor keys.
+   * Legacy publishes use them to recognize combined-model catalog rows. V2
+   * graph-scoped publishes use them to derive a detached catalog commitment;
+   * the generated floor is never appended to the atomic KA graph or KC root.
+   * Public callers must not set this for arbitrary metadata.
    */
   trustedNonManifestCatalogTriples?: TrustedCatalogTripleKeys;
   /**

--- a/packages/publisher/test/assertion-pull-from.test.ts
+++ b/packages/publisher/test/assertion-pull-from.test.ts
@@ -375,6 +375,67 @@ describe('rootless assertionPullFrom', () => {
     expect(draft.some((quad) => quad.subject.includes('decoy'))).toBe(false);
   });
 
+  it('recovers confirmed VM v1 after finalizing and discarding an unpublished v2 edit', async () => {
+    const { publisher, store } = await makePublisher();
+    const v1 = await seedShared(publisher, store, {
+      publicQuads: [q(ENTITY_1, SCHEMA, '"Confirmed version one"')],
+    });
+    const v1Scope = createGraphKnowledgeAssetScope(v1.kaUal, v1.assertionVersion);
+    const vmGraph = knowledgeAssetLayerGraphUri(
+      CG,
+      MemoryLayer.VerifiableMemory,
+      v1Scope,
+    );
+    await store.insert(v1.publicQuads.map((quad) => ({ ...quad, graph: vmGraph })));
+
+    const sealSubject = contextGraphAssertionUri(CG, AGENT, NAME);
+    const metaGraph = contextGraphMetaUri(CG);
+    const rootResult = await store.query(
+      `SELECT ?root WHERE { GRAPH <${metaGraph}> {
+        <${sealSubject}> <${ASSERTION_SEAL_PREDICATES.ASSERTION_MERKLE_ROOT}> ?root
+      } } LIMIT 1`,
+    );
+    const rootTerm = rootResult.type === 'bindings'
+      ? rootResult.bindings[0]?.['root']
+      : undefined;
+    const confirmedRoot = rootTerm
+      ?.replace(/^"/, '')
+      .replace(/"(\^\^<[^>]+>)?$/, '');
+    expect(confirmedRoot).toBeTruthy();
+    const lifecycle = assertionLifecycleUri(CG, AGENT, NAME);
+    await store.insert([
+      q(lifecycle, `${DKG}vmCurrentAssertion`, `"${confirmedRoot}"`, metaGraph),
+    ]);
+
+    // Pulling v1 archives its seal and unlocks an editable WM draft.
+    await publisher.assertionPullFrom(CG, NAME, AGENT, 'vm');
+    await publisher.assertionWrite(CG, NAME, AGENT, [
+      q(ENTITY_2, SCHEMA, '"Unpublished version two"'),
+    ]);
+    const v2 = await finalizeRootlessAssertionForTest({
+      publisher,
+      store,
+      contextGraphId: CG,
+      name: NAME,
+      agentAddress: AGENT,
+      assertionVersion: 2,
+    });
+    expect(v2.publicQuads).toHaveLength(2);
+
+    await publisher.assertionDiscard(CG, NAME, AGENT);
+    const reopened = await publisher.assertionPullFrom(CG, NAME, AGENT, 'vm');
+
+    expect(reopened).toMatchObject({
+      kaUal: v1.kaUal,
+      assertionVersion: v1.assertionVersion,
+      seededPublic: v1.publicQuads.length,
+    });
+    expect(new Set((await publisher.assertionQuery(CG, NAME, AGENT)).map(key)))
+      .toEqual(new Set(v1.publicQuads.map(key)));
+    expect((await publisher.assertionQuery(CG, NAME, AGENT))
+      .some((quad) => quad.object === '"Unpublished version two"')).toBe(false);
+  });
+
   it('retains a durable SWM recovery seal across pull and draft discard', async () => {
     const { publisher, store } = await makePublisher();
     const finalized = await seedShared(publisher, store);

--- a/packages/publisher/test/assertion-pull-from.test.ts
+++ b/packages/publisher/test/assertion-pull-from.test.ts
@@ -9,6 +9,7 @@ import {
   buildAssertionSealQuads,
   contextGraphAssertionUri,
   contextGraphMetaUri,
+  contextGraphPrivateUri,
   createGraphKnowledgeAssetScope,
   generateEd25519Keypair,
   knowledgeAssetLayerGraphUri,
@@ -353,7 +354,24 @@ describe('rootless assertionPullFrom', () => {
     expect(draft.some((quad) => quad.subject.includes('decoy'))).toBe(false);
   });
 
-  it('clears the old seal, retains UAL identity, and permits a new assertion version', async () => {
+  it('retains a durable SWM recovery seal across pull and draft discard', async () => {
+    const { publisher, store } = await makePublisher();
+    const finalized = await seedShared(publisher, store);
+
+    await publisher.assertionPullFrom(CG, NAME, AGENT, 'swm');
+    await publisher.assertionDiscard(CG, NAME, AGENT);
+    const reopened = await publisher.assertionPullFrom(CG, NAME, AGENT, 'swm');
+
+    expect(reopened).toMatchObject({
+      kaUal: finalized.kaUal,
+      assertionVersion: finalized.assertionVersion,
+      seededPublic: finalized.publicQuads.length,
+    });
+    expect(new Set((await publisher.assertionQuery(CG, NAME, AGENT)).map(key)))
+      .toEqual(new Set(finalized.publicQuads.map(key)));
+  });
+
+  it('archives the source seal while leaving the active draft unlocked for re-finalization', async () => {
     const { publisher, store } = await makePublisher();
     const first = await seedShared(publisher, store);
 
@@ -366,6 +384,19 @@ describe('rootless assertionPullFrom', () => {
       } }`,
     );
     expect(sealed.type === 'boolean' && sealed.value).toBe(false);
+    const recoverySubject = `${sealSubject}/_recovery_seal`;
+    const recoverySeal = await store.query(
+      `ASK { GRAPH <${contextGraphPrivateUri(CG)}> {
+        <${recoverySubject}> <${ASSERTION_SEAL_PREDICATES.ASSERTION_MERKLE_ROOT}> ?root
+      } }`,
+    );
+    expect(recoverySeal).toMatchObject({ type: 'boolean', value: true });
+    const leakedRecoverySeal = await store.query(
+      `ASK { GRAPH <${meta}> {
+        <${recoverySubject}> <${ASSERTION_SEAL_PREDICATES.ASSERTION_MERKLE_ROOT}> ?root
+      } }`,
+    );
+    expect(leakedRecoverySeal).toMatchObject({ type: 'boolean', value: false });
     await publisher.assertionWrite(CG, NAME, AGENT, [
       q('urn:e:new-version', SCHEMA, '"Version two"'),
     ]);

--- a/packages/publisher/test/assertion-pull-from.test.ts
+++ b/packages/publisher/test/assertion-pull-from.test.ts
@@ -453,6 +453,29 @@ describe('rootless assertionPullFrom', () => {
       .toEqual(new Set(finalized.publicQuads.map(key)));
   });
 
+  it('retains private commitments and content across SWM pull, discard, and reopen', async () => {
+    const { publisher, store } = await makePublisher();
+    const finalized = await seedShared(publisher, store, {
+      publicQuads: [q(ENTITY_1, SCHEMA, '"Public recovery content"')],
+      privateQuads: [
+        q(ENTITY_1, 'urn:predicate:secret', '"Private recovery content"'),
+        q(ENTITY_2, 'urn:predicate:secret', '"Second private recovery content"'),
+      ],
+    });
+
+    await publisher.assertionPullFrom(CG, NAME, AGENT, 'swm');
+    await publisher.assertionDiscard(CG, NAME, AGENT);
+    const reopened = await publisher.assertionPullFrom(CG, NAME, AGENT, 'swm');
+
+    expect(reopened).toMatchObject({
+      kaUal: finalized.kaUal,
+      assertionVersion: finalized.assertionVersion,
+      seededPrivate: finalized.privateQuads.length,
+    });
+    expect(new Set((await publisher.assertionQueryPrivate(CG, NAME, AGENT)).map(key)))
+      .toEqual(new Set(finalized.privateQuads.map(key)));
+  });
+
   it('keeps a sub-graph recovery seal inside its private partition across pull and discard', async () => {
     const { publisher, store } = await makePublisher();
     const subGraphName = 'code';

--- a/packages/publisher/test/assertion-pull-from.test.ts
+++ b/packages/publisher/test/assertion-pull-from.test.ts
@@ -10,6 +10,8 @@ import {
   contextGraphAssertionUri,
   contextGraphMetaUri,
   contextGraphPrivateUri,
+  contextGraphSubGraphPrivateUri,
+  contextGraphSubGraphUri,
   createGraphKnowledgeAssetScope,
   generateEd25519Keypair,
   knowledgeAssetLayerGraphUri,
@@ -56,21 +58,23 @@ async function seedShared(
     privateQuads?: Quad[];
     name?: string;
     agentAddress?: string;
+    subGraphName?: string;
   } = {},
 ) {
   const name = options.name ?? NAME;
   const agentAddress = options.agentAddress ?? AGENT;
+  const subGraphName = options.subGraphName;
   const publicQuads = options.publicQuads ?? [
     q(ENTITY_1, SCHEMA, '"Alice"'),
     q(ENTITY_2, SCHEMA, '"Bob"'),
   ];
   const privateQuads = options.privateQuads ?? [];
-  await publisher.assertionCreate(CG, name, agentAddress);
+  await publisher.assertionCreate(CG, name, agentAddress, subGraphName);
   if (publicQuads.length > 0) {
-    await publisher.assertionWrite(CG, name, agentAddress, publicQuads);
+    await publisher.assertionWrite(CG, name, agentAddress, publicQuads, subGraphName);
   }
   if (privateQuads.length > 0) {
-    await publisher.assertionWritePrivate(CG, name, agentAddress, privateQuads);
+    await publisher.assertionWritePrivate(CG, name, agentAddress, privateQuads, subGraphName);
   }
   const finalized = await finalizeRootlessAssertionForTest({
     publisher,
@@ -78,9 +82,26 @@ async function seedShared(
     contextGraphId: CG,
     name,
     agentAddress,
+    subGraphName,
   });
-  await publisher.assertionPromote(CG, name, agentAddress);
+  await publisher.assertionPromote(CG, name, agentAddress, { subGraphName });
   return finalized;
+}
+
+async function registerSubGraph(store: OxigraphStore, subGraphName: string): Promise<void> {
+  const metaGraph = contextGraphMetaUri(CG);
+  const subGraphUri = contextGraphSubGraphUri(CG, subGraphName);
+  await store.createGraph(metaGraph);
+  await store.insert([
+    q(
+      subGraphUri,
+      'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
+      'http://dkg.io/ontology/SubGraph',
+      metaGraph,
+    ),
+    q(subGraphUri, 'http://schema.org/name', `"${subGraphName}"`, metaGraph),
+    q(subGraphUri, `${DKG}createdBy`, 'did:dkg:agent:test-agent', metaGraph),
+  ]);
 }
 
 function legacySeal(rootEntities: string[]): Quad[] {
@@ -369,6 +390,58 @@ describe('rootless assertionPullFrom', () => {
     });
     expect(new Set((await publisher.assertionQuery(CG, NAME, AGENT)).map(key)))
       .toEqual(new Set(finalized.publicQuads.map(key)));
+  });
+
+  it('keeps a sub-graph recovery seal inside its private partition across pull and discard', async () => {
+    const { publisher, store } = await makePublisher();
+    const subGraphName = 'code';
+    await registerSubGraph(store, subGraphName);
+    const finalized = await seedShared(publisher, store, {
+      subGraphName,
+      publicQuads: [q(ENTITY_1, SCHEMA, '"Sub-graph content"')],
+    });
+
+    await publisher.assertionPullFrom(CG, NAME, AGENT, 'swm', { subGraphName });
+    await publisher.assertionDiscard(CG, NAME, AGENT, subGraphName);
+    const reopened = await publisher.assertionPullFrom(
+      CG,
+      NAME,
+      AGENT,
+      'swm',
+      { subGraphName },
+    );
+
+    expect(reopened).toMatchObject({
+      kaUal: finalized.kaUal,
+      assertionVersion: finalized.assertionVersion,
+      seededPublic: finalized.publicQuads.length,
+    });
+    expect(new Set((await publisher.assertionQuery(CG, NAME, AGENT, subGraphName)).map(key)))
+      .toEqual(new Set(finalized.publicQuads.map(key)));
+
+    const sealSubject = contextGraphAssertionUri(CG, AGENT, NAME, subGraphName);
+    const recoverySubject = `${sealSubject}/_recovery_seal`;
+    const recoveryPredicate = ASSERTION_SEAL_PREDICATES.ASSERTION_MERKLE_ROOT;
+    const subGraphPrivate = await store.query(
+      `ASK { GRAPH <${contextGraphSubGraphPrivateUri(CG, subGraphName)}> {
+        <${recoverySubject}> <${recoveryPredicate}> ?root
+      } }`,
+    );
+    expect(subGraphPrivate).toMatchObject({ type: 'boolean', value: true });
+
+    const leakedToRootPrivate = await store.query(
+      `ASK { GRAPH <${contextGraphPrivateUri(CG)}> {
+        <${recoverySubject}> <${recoveryPredicate}> ?root
+      } }`,
+    );
+    expect(leakedToRootPrivate).toMatchObject({ type: 'boolean', value: false });
+
+    const leakedToRootMeta = await store.query(
+      `ASK { GRAPH <${contextGraphMetaUri(CG)}> {
+        <${recoverySubject}> <${recoveryPredicate}> ?root
+      } }`,
+    );
+    expect(leakedToRootMeta).toMatchObject({ type: 'boolean', value: false });
   });
 
   it('archives the source seal while leaving the active draft unlocked for re-finalization', async () => {

--- a/packages/publisher/test/ka-graph-publish-storage.test.ts
+++ b/packages/publisher/test/ka-graph-publish-storage.test.ts
@@ -21,7 +21,7 @@ const AUTHOR = '0x70997970c51812dc3a010c7d01b50e0d17dc79c8';
 const UAL = `did:dkg:base:8453/${AUTHOR}/41`;
 
 function quad(subject: string, predicate: string, object: string): Quad {
-  return { subject, predicate, object, graph: 'urn:input:placement-is-flattened' };
+  return { subject, predicate, object, graph: '' };
 }
 
 describe('graph-scoped KA publish storage', () => {
@@ -222,7 +222,7 @@ describe('graph-scoped KA publish storage', () => {
     )).toEqual(canonicalReplacement);
   });
 
-  it('refreshes only the deterministic curated catalog floor on a trusted SWM update', async () => {
+  it('keeps the deterministic curated catalog floor out of a trusted SWM update graph', async () => {
     const initial = await publisher.publish({
       contextGraphId: CONTEXT_GRAPH,
       quads: [quad('urn:curated:data', 'urn:predicate:value', '"old"')],
@@ -242,12 +242,12 @@ describe('graph-scoped KA publish storage', () => {
       graph: swmGraph,
     }]);
 
-    await publisher.updateKnowledgeAssetFromSharedMemory(initial.kaId, {
+    const updated = await publisher.updateKnowledgeAssetFromSharedMemory(initial.kaId, {
       contextGraphId: CONTEXT_GRAPH,
       contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
       kaUal: UAL,
       assertionVersion: 2,
-      publicTripleCount: 5,
+      publicTripleCount: 1,
       privateTripleCount: 0,
       trustedNonManifestCatalogTriples:
         generatedPrivateCatalogTripleKeys(CONTEXT_GRAPH),
@@ -258,7 +258,14 @@ describe('graph-scoped KA publish storage', () => {
       MemoryLayer.VerifiableMemory,
       scope,
     );
-    expect(await store.countQuads(vmGraph)).toBe(5);
+    expect(updated.publicQuads).toEqual([
+      expect.objectContaining({
+        subject: 'urn:curated:data',
+        predicate: 'urn:predicate:value',
+        object: '"new"',
+      }),
+    ]);
+    expect(await store.countQuads(vmGraph)).toBe(1);
     const catalogRows = await store.query(
       `SELECT ?p ?o WHERE { GRAPH <${vmGraph}> {
          <did:dkg:context-graph:${CONTEXT_GRAPH}> ?p ?o
@@ -266,10 +273,24 @@ describe('graph-scoped KA publish storage', () => {
     );
     expect(catalogRows.type).toBe('bindings');
     if (catalogRows.type !== 'bindings') throw new Error('expected catalog bindings');
-    expect(catalogRows.bindings).toHaveLength(4);
+    expect(catalogRows.bindings).toHaveLength(0);
   });
 
   it('rejects legacy and incomplete mutation envelopes before writing', async () => {
+    await expect(
+      publisher.publish({
+        contextGraphId: CONTEXT_GRAPH,
+        quads: [{
+          ...quad('urn:named', 'urn:predicate:value', '"named"'),
+          graph: 'urn:user:named-graph',
+        }],
+        contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+        kaUal: UAL,
+        assertionVersion: 1,
+        publicTripleCount: 1,
+      }),
+    ).rejects.toMatchObject({ code: 'KA_NAMED_GRAPH_SHARE_UNSUPPORTED' });
+
     await expect(
       publisher.publish({
         contextGraphId: CONTEXT_GRAPH,

--- a/packages/publisher/test/publisher-no-random-wallet.test.ts
+++ b/packages/publisher/test/publisher-no-random-wallet.test.ts
@@ -711,6 +711,10 @@ class AdapterManagedUpdateChain implements ChainAdapter {
     return '0x000000000000000000000000000000000000c10a';
   }
 
+  async getKnowledgeAssetOwner(_kaId: bigint): Promise<string> {
+    return _SEAL_WALLET.address;
+  }
+
   async updateKnowledgeCollectionV10(params: V10UpdateKAParams): Promise<TxResult> {
     this.capturedPublisherAddress = params.publisherAddress;
     this.capturedPublisherNodeIdentityId = params.publisherNodeIdentityId;

--- a/packages/publisher/test/publisher-no-random-wallet.test.ts
+++ b/packages/publisher/test/publisher-no-random-wallet.test.ts
@@ -25,11 +25,22 @@
  */
 import { describe, it, expect, vi } from 'vitest';
 import { DKGPublisher } from '../src/dkg-publisher.js';
+import {
+  generatedPrivateCatalogTripleKeys,
+  parseSimpleNQuads,
+} from '../src/index.js';
 import { PublisherPlanner } from '../src/publisher-planning.js';
 import { DEFAULT_PUBLISH_EPOCHS, type V10ACKProvider, type V10ACKProviderParams } from '../src/publisher.js';
 import { generateConfirmedFullMetadata } from '../src/metadata.js';
 import { OxigraphStore } from '@origintrail-official/dkg-storage';
-import { TypedEventBus, generateEd25519Keypair } from '@origintrail-official/dkg-core';
+import {
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  MemoryLayer,
+  TypedEventBus,
+  createGraphKnowledgeAssetScope,
+  generateEd25519Keypair,
+  knowledgeAssetLayerGraphUri,
+} from '@origintrail-official/dkg-core';
 import {
   MockChainAdapter,
   type ChainAdapter,
@@ -40,7 +51,13 @@ import {
   type V10UpdateKAParams,
 } from '@origintrail-official/dkg-chain';
 import { ethers } from 'ethers';
-import { wrapPublisherForTest, mockSealCtx, updateSealed } from './_helpers/seal.js';
+import {
+  buildSeal,
+  buildUpdateSeal,
+  wrapPublisherForTest,
+  mockSealCtx,
+  updateSealed,
+} from './_helpers/seal.js';
 import { mockChainStubACKProvider } from './_helpers/acks.js';
 
 // Greenfield (PR #815): the confirmed UAL embeds the DKGKnowledgeAssets
@@ -1603,6 +1620,110 @@ describe('DKGPublisher: no random publisher wallet without explicit key', () => 
 
     expect(encryptInlineChunked).not.toHaveBeenCalled();
     expect(ackProvider).not.toHaveBeenCalled();
+  });
+
+  it('sends valid graph-scoped N-Quads to member encryption for curated publish and update', async () => {
+    const wallet = new ethers.Wallet(TEST_KEY);
+    const chain = new CatalogPlanningChain(wallet);
+    (chain as unknown as { getContextGraphAccessPolicy: () => Promise<number> })
+      .getContextGraphAccessPolicy = async () => 1;
+    const publisher = await makeEpochPublisher(chain, wallet);
+    const store = (publisher as unknown as { store: OxigraphStore }).store;
+    const contextGraphId = '1';
+    const publishQuad = {
+      subject: 'urn:test:graph-scoped-member-payload',
+      predicate: 'http://schema.org/name',
+      object: '"published"',
+      graph: '',
+    };
+    const publishSeal = await buildSeal({
+      quads: [publishQuad],
+      author: wallet,
+      contextGraphId,
+      ctx: mockSealCtx(),
+    });
+    const kaId = publishSeal.reservedKaId!;
+    const kaNumber = kaId & ((1n << 96n) - 1n);
+    const ual = `did:dkg:mock:31337/${wallet.address}/${kaNumber}`;
+    const scopeV1 = createGraphKnowledgeAssetScope(ual, 1);
+    const swmGraph = knowledgeAssetLayerGraphUri(
+      contextGraphId,
+      MemoryLayer.SharedWorkingMemory,
+      scopeV1,
+    );
+    await store.insert([{ ...publishQuad, graph: swmGraph }]);
+
+    const capturedPlaintexts: Uint8Array[] = [];
+    const encryptInlineChunked = async ({ plaintextNquads }: { plaintextNquads: Uint8Array }) => {
+      capturedPlaintexts.push(plaintextNquads);
+      return {
+        ciphertextChunksRoot: new Uint8Array(32),
+        ciphertextChunkCount: 1,
+        totalCiphertextBytes: plaintextNquads.length,
+      };
+    };
+    const encryptInlinePayload = async (plaintext: Uint8Array) => plaintext;
+    const catalogKeys = generatedPrivateCatalogTripleKeys(contextGraphId);
+
+    const published = await publisher.publishFromSharedMemory(contextGraphId, 'all', {
+      onChainContextGraphId: contextGraphId,
+      sharedMemoryScope: {
+        kind: 'named-lifecycle',
+        identity: { agentAddress: wallet.address, kaNumber },
+      },
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      kaUal: ual,
+      assertionVersion: 1,
+      publicTripleCount: 1,
+      privateTripleCount: 0,
+      trustedNonManifestCatalogTriples: catalogKeys,
+      precomputedAttestation: publishSeal,
+      encryptInlinePayload,
+      encryptInlineChunked,
+    });
+    expect(published.status).toBe('confirmed');
+    expect(capturedPlaintexts).toHaveLength(1);
+    const publishVmGraph = knowledgeAssetLayerGraphUri(
+      contextGraphId,
+      MemoryLayer.VerifiableMemory,
+      scopeV1,
+    );
+    expect(parseSimpleNQuads(new TextDecoder().decode(capturedPlaintexts[0]))).toEqual([
+      { ...publishQuad, graph: publishVmGraph },
+    ]);
+
+    const updateQuad = { ...publishQuad, object: '"updated"' };
+    await store.replaceGraph?.(swmGraph, [{ ...updateQuad, graph: swmGraph }]);
+    const updateSeal = await buildUpdateSeal({
+      kaId,
+      quads: [updateQuad],
+      author: wallet,
+      ctx: mockSealCtx(),
+    });
+    const updated = await publisher.updateKnowledgeAssetFromSharedMemory(kaId, {
+      contextGraphId,
+      publishContextGraphId: contextGraphId,
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      kaUal: ual,
+      assertionVersion: 2,
+      publicTripleCount: 1,
+      privateTripleCount: 0,
+      trustedNonManifestCatalogTriples: catalogKeys,
+      precomputedUpdateAttestation: updateSeal,
+      encryptInlinePayload,
+      encryptInlineChunked,
+      v10ACKProvider: mockChainStubACKProvider(),
+    });
+    expect(updated.status).toBe('confirmed');
+    expect(capturedPlaintexts).toHaveLength(2);
+    const updateVmGraph = knowledgeAssetLayerGraphUri(
+      contextGraphId,
+      MemoryLayer.VerifiableMemory,
+      createGraphKnowledgeAssetScope(ual, 2),
+    );
+    expect(parseSimpleNQuads(new TextDecoder().decode(capturedPlaintexts[1]))).toEqual([
+      { ...updateQuad, graph: updateVmGraph },
+    ]);
   });
 
   it('prices curated publishes from the exact public catalog bytes across plan, ACK, and tx', async () => {

--- a/packages/publisher/test/publisher-no-random-wallet.test.ts
+++ b/packages/publisher/test/publisher-no-random-wallet.test.ts
@@ -711,10 +711,6 @@ class AdapterManagedUpdateChain implements ChainAdapter {
     return '0x000000000000000000000000000000000000c10a';
   }
 
-  async getKnowledgeAssetOwner(_kaId: bigint): Promise<string> {
-    return _SEAL_WALLET.address;
-  }
-
   async updateKnowledgeCollectionV10(params: V10UpdateKAParams): Promise<TxResult> {
     this.capturedPublisherAddress = params.publisherAddress;
     this.capturedPublisherNodeIdentityId = params.publisherNodeIdentityId;
@@ -1939,10 +1935,11 @@ describe('DKGPublisher: no random publisher wallet without explicit key', () => 
     expect(updated.onChainResult?.publisherAddress.toLowerCase()).toBe(wallet.address.toLowerCase());
   });
 
-  it('lets adapter-managed updates select their signer without local address discovery', async () => {
+  it('lets adapter-managed updates without owner lookup rely on chain authorization', async () => {
     const keypair = await generateEd25519Keypair();
     const wallet = new ethers.Wallet(TEST_KEY);
     const chain = new AdapterManagedUpdateChain(wallet.address);
+    expect((chain as ChainAdapter).getKnowledgeAssetOwner).toBeUndefined();
     const publisher = new DKGPublisher({
       store: new OxigraphStore(),
       chain,

--- a/packages/publisher/vitest.unit.config.ts
+++ b/packages/publisher/vitest.unit.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
       'test/ka-graph-publish-storage.test.ts',
       'test/ka-graph-publish-ack.test.ts',
       'test/ka-graph-publish-handler.test.ts',
+      'test/assertion-pull-from.test.ts',
       'test/ka-graph-update-ack.test.ts',
       'test/ka-graph-update-handler.test.ts',
       'test/agents-meta-bound.test.ts',


### PR DESCRIPTION
Closes the correctness and compatibility blockers found across the rootless KA review stack before testnet validation.

- prevents changelog cursors from acknowledging rejected V2 integrity metadata
- preserves pull-from recovery through crashes and draft discard using a local-only recovery seal
- repairs missing graph-scoped metadata when exact VM content already committed
- restores harmless legacy CLI, MCP, and Node UI call compatibility without restoring root-subset writes

Validation:
- all affected TypeScript builds pass
- agent focused tests: 31 passed
- publisher pull/recovery tests: 14 passed
- publisher unit suite: 338 passed
- MCP assertion lifecycle: 56 passed
- Node UI pure API: 59 passed
- CLI lifecycle smoke: 13 passed