### PR TITLE
fix: prevent post-rollout store scan storms

### DIFF
--- a/packages/agent/src/finalization-handler.ts
+++ b/packages/agent/src/finalization-handler.ts
@@ -261,6 +261,20 @@ function finalizationSwmResultBudget(): SharedMemoryResultBudget {
   };
 }
 
+function finalizationAcceptancePolicyKey(
+  privateRoots: readonly Uint8Array[],
+  allowGeneratedCatalogFloor: boolean,
+): string {
+  const canonicalPrivateRoots = privateRoots
+    .map((root) => ethers.hexlify(root))
+    .sort()
+    .join('\u0001');
+  return [
+    canonicalPrivateRoots,
+    allowGeneratedCatalogFloor ? 'generated-catalog-floor' : 'strict-merkle',
+  ].join('\u0002');
+}
+
 type NegativeSnapshotMemoEntry = {
   /** Write generation for the CG's graph prefix observed BEFORE the scan. */
   writeGen: number;
@@ -1868,8 +1882,7 @@ export class FinalizationHandler {
       safeRoots.slice().sort().join('\u0001'),
       kaGraphBound ? `${kaGraphBound.agentAddress}:${kaGraphBound.startNumber}:${kaGraphBound.endNumber}` : '*',
       ethers.hexlify(expectedMerkleRoot),
-      privateRoots.map((root) => ethers.hexlify(root)).join('\u0001'),
-      allowGeneratedCatalogFloor ? 'generated-catalog-floor' : 'strict-merkle',
+      finalizationAcceptancePolicyKey(privateRoots, allowGeneratedCatalogFloor),
       String(writeGen ?? 'unknown'),
     ].join('\u0000');
     return this.runScanSingleFlight(key, async () => {

--- a/packages/agent/src/finalization-handler.ts
+++ b/packages/agent/src/finalization-handler.ts
@@ -476,23 +476,23 @@ export class FinalizationHandler {
       // unbounded read on empty-or-mismatch. All of the bound/widen policy — and the
       // reasoning for why it is safe — lives in storage's
       // `loadSharedMemorySliceWithKaBoundFallback`, which owns the widen.
+      const privateRoots = await this.getPrivateRootsFromMeta(
+        contextGraphId,
+        msg.rootEntities,
+        subGraphName,
+      );
+      const allowGeneratedCatalogFloor = await this.allowsGeneratedCatalogFloor(
+        contextGraphId,
+        ctxGraphId,
+      );
       const { quads: sharedMemoryQuads, matched: merkleMatchedQuads } = await this.loadFinalizationSwmSlice(
         contextGraphId,
         msg.rootEntities,
         subGraphName,
         swmKaBoundDisabled() ? undefined : deriveSwmKaGraphBound(startKAId, endKAId),
         msg.kcMerkleRoot,
-        async () => {
-          const privateRoots = await this.getPrivateRootsFromMeta(contextGraphId, msg.rootEntities, subGraphName);
-          const allowGeneratedCatalogFloor = await this.allowsGeneratedCatalogFloor(contextGraphId, ctxGraphId);
-          return (quads) => this.sharedMemoryQuadsMatchingMerkle(
-            contextGraphId,
-            quads,
-            privateRoots,
-            msg.kcMerkleRoot,
-            allowGeneratedCatalogFloor,
-          );
-        },
+        privateRoots,
+        allowGeneratedCatalogFloor,
       );
 
       if (sharedMemoryQuads.length > 0) {
@@ -1855,7 +1855,8 @@ export class FinalizationHandler {
     subGraphName: string | undefined,
     kaGraphBound: SwmKaGraphBound | undefined,
     expectedMerkleRoot: Uint8Array,
-    createAccept: () => Promise<(quads: Quad[]) => Quad[] | null>,
+    privateRoots: Uint8Array[],
+    allowGeneratedCatalogFloor: boolean,
   ): Promise<{ quads: Quad[]; matched: Quad[] | null }> {
     const safeRoots = rootEntities.filter(isSafeIri);
     if (safeRoots.length === 0) return { quads: [], matched: null };
@@ -1867,6 +1868,8 @@ export class FinalizationHandler {
       safeRoots.slice().sort().join('\u0001'),
       kaGraphBound ? `${kaGraphBound.agentAddress}:${kaGraphBound.startNumber}:${kaGraphBound.endNumber}` : '*',
       ethers.hexlify(expectedMerkleRoot),
+      privateRoots.map((root) => ethers.hexlify(root)).join('\u0001'),
+      allowGeneratedCatalogFloor ? 'generated-catalog-floor' : 'strict-merkle',
       String(writeGen ?? 'unknown'),
     ].join('\u0000');
     return this.runScanSingleFlight(key, async () => {
@@ -1881,7 +1884,13 @@ export class FinalizationHandler {
             widened: SWM_SLICE_SOURCE_WIDENED,
             unbounded: SWM_SLICE_SOURCE,
           },
-          createAccept,
+          createAccept: async () => (quads) => this.sharedMemoryQuadsMatchingMerkle(
+            contextGraphId,
+            quads,
+            privateRoots,
+            expectedMerkleRoot,
+            allowGeneratedCatalogFloor,
+          ),
           queryOptions: { priority: 'background' },
           resultBudget: finalizationSwmResultBudget(),
         },

--- a/packages/agent/src/sync/oversize-filter.ts
+++ b/packages/agent/src/sync/oversize-filter.ts
@@ -156,34 +156,57 @@ function buildSyncInsertUnits(quads: readonly Quad[]): SyncInsertUnit[] {
  * blank-node identity, so sync deliberately tombstones the complete component
  * and consumes the page instead of throwing before cursor advancement.
  */
-function quarantineOversizedBlankNodeComponents(quads: readonly Quad[]): OversizeFilterResult {
-  const kept: Quad[] = [];
-  const dropped: OversizeDrop[] = [];
-  for (const unit of buildSyncInsertUnits(quads)) {
+interface SyncInsertUnitFilterResult extends OversizeFilterResult {
+  keptUnits: SyncInsertUnit[];
+}
+
+function quarantineOversizedBlankNodeComponents(
+  units: readonly SyncInsertUnit[],
+): SyncInsertUnitFilterResult {
+  const oversizedUnits = new Set<SyncInsertUnit>();
+  const quarantinedVmGraphs = new Set<string>();
+  for (const unit of units) {
     if (
-      unit.blankNodeLabels.size > 0 &&
-      unit.estimatedBytes > SYNC_STORE_INSERT_BATCH_MAX_BYTES
-    ) {
+      unit.blankNodeLabels.size === 0 ||
+      unit.estimatedBytes <= SYNC_STORE_INSERT_BATCH_MAX_BYTES
+    ) continue;
+    oversizedUnits.add(unit);
+    for (const quad of unit.quads) {
+      if (isVerifiableMemoryGraph(quad.graph)) quarantinedVmGraphs.add(quad.graph!);
+    }
+  }
+
+  const keptUnits: SyncInsertUnit[] = [];
+  const dropped: OversizeDrop[] = [];
+  for (const unit of units) {
+    const touchesQuarantinedVmGraph = unit.quads.some(
+      (quad) => quad.graph !== undefined && quarantinedVmGraphs.has(quad.graph),
+    );
+    if (oversizedUnits.has(unit) || touchesQuarantinedVmGraph) {
       for (const quad of unit.quads) {
         dropped.push({
           quad,
           bytes: estimateSyncStoreInsertQuadBytes(quad),
-          kind: 'blank-node-component-quarantine',
+          kind: touchesQuarantinedVmGraph
+            ? 'vm-quarantine'
+            : 'blank-node-component-quarantine',
         });
       }
     } else {
-      kept.push(...unit.quads);
+      keptUnits.push(unit);
     }
   }
-  return { kept, dropped };
+  return {
+    keptUnits,
+    kept: keptUnits.flatMap((unit) => unit.quads),
+    dropped,
+  };
 }
 
 async function insertInBoundedBatches(
   insert: (quads: Quad[]) => Promise<void>,
-  quads: readonly Quad[],
+  units: readonly SyncInsertUnit[],
 ): Promise<void> {
-  const units = buildSyncInsertUnits(quads);
-
   let batch: Quad[] = [];
   let batchBytes = 0;
   for (const unit of units) {
@@ -329,13 +352,15 @@ export async function insertWithOversizeGuard(
 ): Promise<Quad[]> {
   const literalFilter = filterOversizedSyncQuads(quads);
   if (literalFilter.dropped.length > 0) hooks.recordDrops(literalFilter.dropped, seam);
-  const componentFilter = quarantineOversizedBlankNodeComponents(literalFilter.kept);
+  const componentFilter = quarantineOversizedBlankNodeComponents(
+    buildSyncInsertUnits(literalFilter.kept),
+  );
   if (componentFilter.dropped.length > 0) {
     hooks.recordDrops(componentFilter.dropped, `${seam}:blank-node-component-quarantine`);
   }
   if (componentFilter.kept.length === 0) return componentFilter.kept;
   try {
-    await insertInBoundedBatches(insert, componentFilter.kept);
+    await insertInBoundedBatches(insert, componentFilter.keptUnits);
     return componentFilter.kept;
   } catch (err) {
     if (!isOversizedRdfLiteralError(err)) throw err;
@@ -344,7 +369,7 @@ export async function insertWithOversizeGuard(
     hooks.recordDrops(backstop.dropped, `${seam}:store-reject`);
     if (backstop.kept.length === 0) return [];
     // Second oversize throw here propagates — no loop, loud failure.
-    await insertInBoundedBatches(insert, backstop.kept);
+    await insertInBoundedBatches(insert, buildSyncInsertUnits(backstop.kept));
     return backstop.kept;
   }
 }

--- a/packages/agent/src/sync/oversize-filter.ts
+++ b/packages/agent/src/sync/oversize-filter.ts
@@ -49,7 +49,10 @@ import {
   rdfLiteralTermMutf8ByteLength,
   isOversizedRdfLiteralError,
 } from '@origintrail-official/dkg-core';
-import type { Quad } from '@origintrail-official/dkg-storage';
+import {
+  partitionConnectedBlankNodeComponents,
+  type Quad,
+} from '@origintrail-official/dkg-storage';
 
 // Match `_shared_memory` / `_verifiable_memory` as a full path SEGMENT — the
 // bucket graph (`…/_shared_memory`) and its per-KA descendants
@@ -61,7 +64,11 @@ import type { Quad } from '@origintrail-official/dkg-storage';
 const SHARED_MEMORY_SEGMENT_RE = /\/_shared_memory(\/|$)/;
 const VERIFIABLE_MEMORY_SEGMENT_RE = /\/_verifiable_memory(\/|$)/;
 
-export type OversizeDropKind = 'oversize' | 'vm-quarantine' | 'store-reject';
+export type OversizeDropKind =
+  | 'oversize'
+  | 'vm-quarantine'
+  | 'store-reject'
+  | 'blank-node-component-quarantine';
 
 export interface OversizeDrop {
   quad: Quad;
@@ -83,21 +90,6 @@ export interface OversizeFilterResult {
 export const SYNC_STORE_INSERT_BATCH_MAX_BYTES = 8 * 1024 * 1024;
 
 const SYNC_STORE_INSERT_QUAD_SYNTAX_BYTES = 256;
-
-export class SyncInsertBlankNodeComponentTooLargeError extends Error {
-  constructor(
-    public readonly estimatedBytes: number,
-    public readonly maxBytes: number,
-    public readonly quadCount: number,
-    public readonly blankNodeCount: number,
-  ) {
-    super(
-      `Sync insert blank-node component is too large: estimated ${estimatedBytes} bytes ` +
-      `across ${quadCount} quads and ${blankNodeCount} blank nodes (max ${maxBytes} bytes)`,
-    );
-    this.name = 'SyncInsertBlankNodeComponentTooLargeError';
-  }
-}
 
 /**
  * Conservative cross-adapter serialized-size estimate. Generic SPARQL and
@@ -131,18 +123,9 @@ export function estimateSyncStoreInsertQuadBytes(quad: Quad): number {
   return bytes;
 }
 
-function quadBlankNodeLabels(quad: Quad): string[] {
-  const labels = new Set<string>();
-  for (const term of [quad.subject, quad.object, quad.graph]) {
-    if (term?.startsWith('_:')) labels.add(term);
-  }
-  return [...labels];
-}
-
 interface SyncInsertUnit {
   quads: Quad[];
   estimatedBytes: number;
-  firstIndex: number;
   blankNodeLabels: Set<string>;
 }
 
@@ -154,73 +137,45 @@ interface SyncInsertUnit {
  * graph even when the same label text appears in both calls.
  */
 function buildSyncInsertUnits(quads: readonly Quad[]): SyncInsertUnit[] {
-  const parents = quads.map((_, index) => index);
-  const ranks = quads.map(() => 0);
-  const labelsByQuad = quads.map(quadBlankNodeLabels);
-  const firstQuadByLabel = new Map<string, number>();
+  return partitionConnectedBlankNodeComponents(
+    quads,
+    (quad) => [quad.subject, quad.object, quad.graph],
+  ).map((component) => ({
+    quads: component.items,
+    estimatedBytes: component.items.reduce(
+      (total, quad) => total + estimateSyncStoreInsertQuadBytes(quad),
+      0,
+    ),
+    blankNodeLabels: component.blankNodeLabels,
+  }));
+}
 
-  const find = (index: number): number => {
-    let root = index;
-    while (parents[root] !== root) root = parents[root]!;
-    while (parents[index] !== index) {
-      const next = parents[index]!;
-      parents[index] = root;
-      index = next;
-    }
-    return root;
-  };
-
-  const union = (left: number, right: number): void => {
-    let leftRoot = find(left);
-    let rightRoot = find(right);
-    if (leftRoot === rightRoot) return;
-    if (ranks[leftRoot]! < ranks[rightRoot]!) [leftRoot, rightRoot] = [rightRoot, leftRoot];
-    parents[rightRoot] = leftRoot;
-    if (ranks[leftRoot] === ranks[rightRoot]) ranks[leftRoot]! += 1;
-  };
-
-  for (let index = 0; index < quads.length; index += 1) {
-    for (const label of labelsByQuad[index]!) {
-      const firstIndex = firstQuadByLabel.get(label);
-      if (firstIndex === undefined) firstQuadByLabel.set(label, index);
-      else union(index, firstIndex);
+/**
+ * Classify indivisible components before the first store mutation. A component
+ * larger than the adapter-neutral insert bound cannot be split without changing
+ * blank-node identity, so sync deliberately tombstones the complete component
+ * and consumes the page instead of throwing before cursor advancement.
+ */
+function quarantineOversizedBlankNodeComponents(quads: readonly Quad[]): OversizeFilterResult {
+  const kept: Quad[] = [];
+  const dropped: OversizeDrop[] = [];
+  for (const unit of buildSyncInsertUnits(quads)) {
+    if (
+      unit.blankNodeLabels.size > 0 &&
+      unit.estimatedBytes > SYNC_STORE_INSERT_BATCH_MAX_BYTES
+    ) {
+      for (const quad of unit.quads) {
+        dropped.push({
+          quad,
+          bytes: estimateSyncStoreInsertQuadBytes(quad),
+          kind: 'blank-node-component-quarantine',
+        });
+      }
+    } else {
+      kept.push(...unit.quads);
     }
   }
-
-  const componentUnits = new Map<number, SyncInsertUnit>();
-  const units: SyncInsertUnit[] = [];
-  for (let index = 0; index < quads.length; index += 1) {
-    const quad = quads[index]!;
-    const labels = labelsByQuad[index]!;
-    const estimatedBytes = estimateSyncStoreInsertQuadBytes(quad);
-    if (labels.length === 0) {
-      units.push({
-        quads: [quad],
-        estimatedBytes,
-        firstIndex: index,
-        blankNodeLabels: new Set(),
-      });
-      continue;
-    }
-
-    const root = find(index);
-    let unit = componentUnits.get(root);
-    if (!unit) {
-      unit = {
-        quads: [],
-        estimatedBytes: 0,
-        firstIndex: index,
-        blankNodeLabels: new Set(),
-      };
-      componentUnits.set(root, unit);
-      units.push(unit);
-    }
-    unit.quads.push(quad);
-    unit.estimatedBytes += estimatedBytes;
-    for (const label of labels) unit.blankNodeLabels.add(label);
-  }
-
-  return units.sort((left, right) => left.firstIndex - right.firstIndex);
+  return { kept, dropped };
 }
 
 async function insertInBoundedBatches(
@@ -228,23 +183,6 @@ async function insertInBoundedBatches(
   quads: readonly Quad[],
 ): Promise<void> {
   const units = buildSyncInsertUnits(quads);
-
-  // Validate every indivisible blank-node component before the first durable
-  // mutation. A too-large component cannot be split safely, and inserting
-  // earlier units before rejecting it would leave a needless partial apply.
-  for (const unit of units) {
-    if (
-      unit.blankNodeLabels.size > 0 &&
-      unit.estimatedBytes > SYNC_STORE_INSERT_BATCH_MAX_BYTES
-    ) {
-      throw new SyncInsertBlankNodeComponentTooLargeError(
-        unit.estimatedBytes,
-        SYNC_STORE_INSERT_BATCH_MAX_BYTES,
-        unit.quads.length,
-        unit.blankNodeLabels.size,
-      );
-    }
-  }
 
   let batch: Quad[] = [];
   let batchBytes = 0;
@@ -389,15 +327,19 @@ export async function insertWithOversizeGuard(
   hooks: OversizeGuardHooks,
   seam: string,
 ): Promise<Quad[]> {
-  const { kept, dropped } = filterOversizedSyncQuads(quads);
-  if (dropped.length > 0) hooks.recordDrops(dropped, seam);
-  if (kept.length === 0) return kept;
+  const literalFilter = filterOversizedSyncQuads(quads);
+  if (literalFilter.dropped.length > 0) hooks.recordDrops(literalFilter.dropped, seam);
+  const componentFilter = quarantineOversizedBlankNodeComponents(literalFilter.kept);
+  if (componentFilter.dropped.length > 0) {
+    hooks.recordDrops(componentFilter.dropped, `${seam}:blank-node-component-quarantine`);
+  }
+  if (componentFilter.kept.length === 0) return componentFilter.kept;
   try {
-    await insertInBoundedBatches(insert, kept);
-    return kept;
+    await insertInBoundedBatches(insert, componentFilter.kept);
+    return componentFilter.kept;
   } catch (err) {
     if (!isOversizedRdfLiteralError(err)) throw err;
-    const backstop = splitStoreRejectedQuads(kept);
+    const backstop = splitStoreRejectedQuads(componentFilter.kept);
     if (backstop.dropped.length === 0) throw err; // not size-explicable → real error
     hooks.recordDrops(backstop.dropped, `${seam}:store-reject`);
     if (backstop.kept.length === 0) return [];

--- a/packages/agent/src/sync/oversize-filter.ts
+++ b/packages/agent/src/sync/oversize-filter.ts
@@ -84,6 +84,21 @@ export const SYNC_STORE_INSERT_BATCH_MAX_BYTES = 8 * 1024 * 1024;
 
 const SYNC_STORE_INSERT_QUAD_SYNTAX_BYTES = 256;
 
+export class SyncInsertBlankNodeComponentTooLargeError extends Error {
+  constructor(
+    public readonly estimatedBytes: number,
+    public readonly maxBytes: number,
+    public readonly quadCount: number,
+    public readonly blankNodeCount: number,
+  ) {
+    super(
+      `Sync insert blank-node component is too large: estimated ${estimatedBytes} bytes ` +
+      `across ${quadCount} quads and ${blankNodeCount} blank nodes (max ${maxBytes} bytes)`,
+    );
+    this.name = 'SyncInsertBlankNodeComponentTooLargeError';
+  }
+}
+
 /**
  * Conservative cross-adapter serialized-size estimate. Generic SPARQL and
  * Oxigraph use UTF-8; Blazegraph ASCII-escapes non-ASCII code points, so use
@@ -116,21 +131,134 @@ export function estimateSyncStoreInsertQuadBytes(quad: Quad): number {
   return bytes;
 }
 
+function quadBlankNodeLabels(quad: Quad): string[] {
+  const labels = new Set<string>();
+  for (const term of [quad.subject, quad.object, quad.graph]) {
+    if (term?.startsWith('_:')) labels.add(term);
+  }
+  return [...labels];
+}
+
+interface SyncInsertUnit {
+  quads: Quad[];
+  estimatedBytes: number;
+  firstIndex: number;
+  blankNodeLabels: Set<string>;
+}
+
+/**
+ * Turn a quad stream into indivisible insert units. Ground quads remain
+ * independent, while quads connected through blank-node labels are grouped
+ * transitively. Blank-node labels are scoped to one RDF load/update operation,
+ * so splitting one component across insert calls changes the represented RDF
+ * graph even when the same label text appears in both calls.
+ */
+function buildSyncInsertUnits(quads: readonly Quad[]): SyncInsertUnit[] {
+  const parents = quads.map((_, index) => index);
+  const ranks = quads.map(() => 0);
+  const labelsByQuad = quads.map(quadBlankNodeLabels);
+  const firstQuadByLabel = new Map<string, number>();
+
+  const find = (index: number): number => {
+    let root = index;
+    while (parents[root] !== root) root = parents[root]!;
+    while (parents[index] !== index) {
+      const next = parents[index]!;
+      parents[index] = root;
+      index = next;
+    }
+    return root;
+  };
+
+  const union = (left: number, right: number): void => {
+    let leftRoot = find(left);
+    let rightRoot = find(right);
+    if (leftRoot === rightRoot) return;
+    if (ranks[leftRoot]! < ranks[rightRoot]!) [leftRoot, rightRoot] = [rightRoot, leftRoot];
+    parents[rightRoot] = leftRoot;
+    if (ranks[leftRoot] === ranks[rightRoot]) ranks[leftRoot]! += 1;
+  };
+
+  for (let index = 0; index < quads.length; index += 1) {
+    for (const label of labelsByQuad[index]!) {
+      const firstIndex = firstQuadByLabel.get(label);
+      if (firstIndex === undefined) firstQuadByLabel.set(label, index);
+      else union(index, firstIndex);
+    }
+  }
+
+  const componentUnits = new Map<number, SyncInsertUnit>();
+  const units: SyncInsertUnit[] = [];
+  for (let index = 0; index < quads.length; index += 1) {
+    const quad = quads[index]!;
+    const labels = labelsByQuad[index]!;
+    const estimatedBytes = estimateSyncStoreInsertQuadBytes(quad);
+    if (labels.length === 0) {
+      units.push({
+        quads: [quad],
+        estimatedBytes,
+        firstIndex: index,
+        blankNodeLabels: new Set(),
+      });
+      continue;
+    }
+
+    const root = find(index);
+    let unit = componentUnits.get(root);
+    if (!unit) {
+      unit = {
+        quads: [],
+        estimatedBytes: 0,
+        firstIndex: index,
+        blankNodeLabels: new Set(),
+      };
+      componentUnits.set(root, unit);
+      units.push(unit);
+    }
+    unit.quads.push(quad);
+    unit.estimatedBytes += estimatedBytes;
+    for (const label of labels) unit.blankNodeLabels.add(label);
+  }
+
+  return units.sort((left, right) => left.firstIndex - right.firstIndex);
+}
+
 async function insertInBoundedBatches(
   insert: (quads: Quad[]) => Promise<void>,
   quads: readonly Quad[],
 ): Promise<void> {
+  const units = buildSyncInsertUnits(quads);
+
+  // Validate every indivisible blank-node component before the first durable
+  // mutation. A too-large component cannot be split safely, and inserting
+  // earlier units before rejecting it would leave a needless partial apply.
+  for (const unit of units) {
+    if (
+      unit.blankNodeLabels.size > 0 &&
+      unit.estimatedBytes > SYNC_STORE_INSERT_BATCH_MAX_BYTES
+    ) {
+      throw new SyncInsertBlankNodeComponentTooLargeError(
+        unit.estimatedBytes,
+        SYNC_STORE_INSERT_BATCH_MAX_BYTES,
+        unit.quads.length,
+        unit.blankNodeLabels.size,
+      );
+    }
+  }
+
   let batch: Quad[] = [];
   let batchBytes = 0;
-  for (const quad of quads) {
-    const quadBytes = estimateSyncStoreInsertQuadBytes(quad);
-    if (batch.length > 0 && batchBytes + quadBytes > SYNC_STORE_INSERT_BATCH_MAX_BYTES) {
+  for (const unit of units) {
+    if (
+      batch.length > 0 &&
+      batchBytes + unit.estimatedBytes > SYNC_STORE_INSERT_BATCH_MAX_BYTES
+    ) {
       await insert(batch);
       batch = [];
       batchBytes = 0;
     }
-    batch.push(quad);
-    batchBytes += quadBytes;
+    batch.push(...unit.quads);
+    batchBytes += unit.estimatedBytes;
   }
   if (batch.length > 0) await insert(batch);
 }

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -2254,9 +2254,10 @@ function parseSparqlInteger(value: string | undefined): number {
  * graph; on a 1 GiB workspace that exceeded the 30s HTTP query timeout on every
  * page. This planner inverts the work with backend-neutral SPARQL 1.1:
  *
- *  1. Join each concrete graph to its fresh metadata roots by the root subject
- *     (an indexed lookup and a DKG workspace invariant: `rootEntity` names an
- *     entity present in the shared payload).
+ *  1. Join each concrete graph to its fresh metadata roots by either the root
+ *     subject or one of its generated descendants. Some valid closures contain
+ *     only generated rows, so requiring a direct root triple is not
+ *     set-equivalent to the canonical snapshot reader.
  *  2. Count the exact root closures per concrete graph without returning their
  *     large literal values.
  *  3. Cache only graph/root/count scalars for the responder session.
@@ -2299,7 +2300,14 @@ async function buildFreshSwmDataGraphPlan(
                 <${DKG_ROOT_ENTITY}> ?root .
             ${cutoffFilter}
           }
-          GRAPH <${assertSafeIri(graph)}> { ?root ?rootPredicate ?rootObject }
+          GRAPH <${assertSafeIri(graph)}> { ?candidateSubject ?rootPredicate ?rootObject }
+          FILTER(
+            ?candidateSubject = ?root
+            || STRSTARTS(
+              STR(?candidateSubject),
+              CONCAT(STR(?root), "/.well-known/genid/")
+            )
+          )
         }
       }`);
     const rootResult = await store.query(`

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -2312,6 +2312,7 @@ async function readFreshSwmDataRowsPageFromPlan(
       skip -= entry.rowCount;
       continue;
     }
+    // sparql-scan-allow: R3 -- exact-graph paging is bounded by the retained session plan row count
     const result = await store.query(`
       SELECT DISTINCT ?s ?p ?o WHERE {
         VALUES ?root { ${graphValues(entry.roots)} }

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -95,7 +95,12 @@ export interface FreshSwmDataGraphPlanMemo {
   get(
     key: string,
     load: () => Promise<FreshSwmDataGraphPlan>,
-    options?: { refresh?: boolean; requireExisting?: boolean; signal?: AbortSignal },
+    options?: {
+      refresh?: boolean;
+      refreshGeneration?: string;
+      requireExisting?: boolean;
+      signal?: AbortSignal;
+    },
   ): Promise<FreshSwmDataGraphPlan | null>;
 }
 
@@ -248,8 +253,15 @@ export function createResponderFreshSwmDataGraphPlanMemo(
   ttlMs = 10 * 60_000,
   maxEntries = 32,
 ): FreshSwmDataGraphPlanMemo {
-  const cached = new Map<string, { value: FreshSwmDataGraphPlan; cachedAt: number }>();
-  const inflight = new Map<string, Promise<FreshSwmDataGraphPlan>>();
+  const cached = new Map<string, {
+    value: FreshSwmDataGraphPlan;
+    cachedAt: number;
+    refreshGeneration?: string;
+  }>();
+  const inflight = new Map<string, {
+    promise: Promise<FreshSwmDataGraphPlan>;
+    refreshGeneration?: string;
+  }>();
   const prune = (now = Date.now()) => {
     for (const [key, entry] of cached) {
       if (now - entry.cachedAt >= ttlMs) cached.delete(key);
@@ -258,25 +270,57 @@ export function createResponderFreshSwmDataGraphPlanMemo(
   return {
     async get(key, load, options) {
       throwIfAborted(options?.signal);
+      const requestedGeneration = options?.refreshGeneration;
+      while (true) {
+        const pending = inflight.get(key);
+        if (!pending) break;
+        const supersedesPending = requestedGeneration !== undefined &&
+          requestedGeneration !== pending.refreshGeneration;
+        if (!supersedesPending) {
+          return raceAgainstAbort(pending.promise, options?.signal);
+        }
+        try {
+          await raceAgainstAbort(pending.promise, options?.signal);
+        } catch {
+          // A newer responder session owns an independent plan attempt. Do not
+          // inherit an older generation's load failure, but keep caller aborts.
+          throwIfAborted(options?.signal);
+        }
+      }
       const now = Date.now();
       prune(now);
-      const pending = inflight.get(key);
-      if (pending) return raceAgainstAbort(pending, options?.signal);
-      const existing = cached.get(key);
+      let existing = cached.get(key);
+      if (
+        existing &&
+        requestedGeneration !== undefined &&
+        existing.refreshGeneration !== requestedGeneration
+      ) {
+        cached.delete(key);
+        existing = undefined;
+      }
       if (!options?.refresh && existing) {
         cached.delete(key);
-        cached.set(key, { value: existing.value, cachedAt: now });
+        cached.set(key, { ...existing, cachedAt: now });
         return existing.value;
       }
       if (options?.requireExisting) return null;
       if (!existing && cached.size >= maxEntries) cached.delete(cached.keys().next().value!);
       const pendingLoad = load()
         .then((value) => {
-          cached.set(key, { value, cachedAt: Date.now() });
+          cached.set(key, {
+            value,
+            cachedAt: Date.now(),
+            refreshGeneration: requestedGeneration,
+          });
           return value;
         })
-        .finally(() => inflight.delete(key));
-      inflight.set(key, pendingLoad);
+        .finally(() => {
+          if (inflight.get(key)?.promise === pendingLoad) inflight.delete(key);
+        });
+      inflight.set(key, {
+        promise: pendingLoad,
+        refreshGeneration: requestedGeneration,
+      });
       return raceAgainstAbort(pendingLoad, options?.signal);
     },
   };
@@ -522,21 +566,22 @@ export async function readSwmDataPage(params: {
   }
 
   const loadStoreBoundedPage: StorePageLoader = async (offset, limit, signal) => {
-    const loadPlan = () => buildFreshSwmDataGraphPlan(
+    const loadPlan = (planSignal?: AbortSignal) => buildFreshSwmDataGraphPlan(
       params.store,
       dataGraphs,
       graphSet,
       candidateGraphsFor,
       params.cutoffIso!,
-      signal,
+      planSignal,
     );
     const plan = params.freshGraphPlanMemo && params.rowListCacheKey
-      ? await params.freshGraphPlanMemo.get(params.rowListCacheKey, loadPlan, {
+      ? await params.freshGraphPlanMemo.get(params.rowListCacheKey, () => loadPlan(), {
         refresh: offset === 0 ? params.refreshRowList : false,
+        refreshGeneration: params.refreshGeneration,
         requireExisting: offset > 0,
         signal,
       })
-      : await loadPlan();
+      : await loadPlan(signal);
     if (!plan) {
       throw new Error('Shared-memory data sync session graph plan expired before page completion');
     }

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -19,6 +19,7 @@ import {
 import { isSharedMemoryBucketDescendantDataGraph } from '../shared-memory-graphs.js';
 import type { SyncRow, SyncRowListMemo } from './snapshot-cache.js';
 import {
+  createGenerationAwareTtlSingleFlightMemo,
   SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_BYTES_ESTIMATE,
   SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_ROWS,
   SYNC_RESPONDER_SNAPSHOT_BUILD_PAGE_ROWS,
@@ -60,6 +61,11 @@ const PROV_GENERATED = 'http://www.w3.org/ns/prov#generated';
 const PROV_USED = 'http://www.w3.org/ns/prov#used';
 const DKG_JOIN_REQUEST_SUBJECT_PREFIX = 'did:dkg:join-request:';
 const COMPLETED_SYNC_RESPONDER_SESSION_GRACE_MS = 30_000;
+
+function rootClosureSparqlFilter(subjectVariable: string, rootVariable: string): string {
+  return `FILTER(sameTerm(${subjectVariable}, ${rootVariable}) || STRSTARTS(STR(${subjectVariable}), CONCAT(STR(${rootVariable}), "/.well-known/genid/")))`;
+}
+
 function syncResponderStoreOptions(signal: AbortSignal | undefined, source: string): QueryOptions {
   return { signal, priority: 'background', source };
 }
@@ -253,77 +259,7 @@ export function createResponderFreshSwmDataGraphPlanMemo(
   ttlMs = 10 * 60_000,
   maxEntries = 32,
 ): FreshSwmDataGraphPlanMemo {
-  const cached = new Map<string, {
-    value: FreshSwmDataGraphPlan;
-    cachedAt: number;
-    refreshGeneration?: string;
-  }>();
-  const inflight = new Map<string, {
-    promise: Promise<FreshSwmDataGraphPlan>;
-    refreshGeneration?: string;
-  }>();
-  const prune = (now = Date.now()) => {
-    for (const [key, entry] of cached) {
-      if (now - entry.cachedAt >= ttlMs) cached.delete(key);
-    }
-  };
-  return {
-    async get(key, load, options) {
-      throwIfAborted(options?.signal);
-      const requestedGeneration = options?.refreshGeneration;
-      while (true) {
-        const pending = inflight.get(key);
-        if (!pending) break;
-        const supersedesPending = requestedGeneration !== undefined &&
-          requestedGeneration !== pending.refreshGeneration;
-        if (!supersedesPending) {
-          return raceAgainstAbort(pending.promise, options?.signal);
-        }
-        try {
-          await raceAgainstAbort(pending.promise, options?.signal);
-        } catch {
-          // A newer responder session owns an independent plan attempt. Do not
-          // inherit an older generation's load failure, but keep caller aborts.
-          throwIfAborted(options?.signal);
-        }
-      }
-      const now = Date.now();
-      prune(now);
-      let existing = cached.get(key);
-      if (
-        existing &&
-        requestedGeneration !== undefined &&
-        existing.refreshGeneration !== requestedGeneration
-      ) {
-        cached.delete(key);
-        existing = undefined;
-      }
-      if (!options?.refresh && existing) {
-        cached.delete(key);
-        cached.set(key, { ...existing, cachedAt: now });
-        return existing.value;
-      }
-      if (options?.requireExisting) return null;
-      if (!existing && cached.size >= maxEntries) cached.delete(cached.keys().next().value!);
-      const pendingLoad = load()
-        .then((value) => {
-          cached.set(key, {
-            value,
-            cachedAt: Date.now(),
-            refreshGeneration: requestedGeneration,
-          });
-          return value;
-        })
-        .finally(() => {
-          if (inflight.get(key)?.promise === pendingLoad) inflight.delete(key);
-        });
-      inflight.set(key, {
-        promise: pendingLoad,
-        refreshGeneration: requestedGeneration,
-      });
-      return raceAgainstAbort(pendingLoad, options?.signal);
-    },
-  };
+  return createGenerationAwareTtlSingleFlightMemo<FreshSwmDataGraphPlan>(ttlMs, maxEntries);
 }
 
 /**
@@ -2301,13 +2237,7 @@ async function buildFreshSwmDataGraphPlan(
             ${cutoffFilter}
           }
           GRAPH <${assertSafeIri(graph)}> { ?candidateSubject ?rootPredicate ?rootObject }
-          FILTER(
-            ?candidateSubject = ?root
-            || STRSTARTS(
-              STR(?candidateSubject),
-              CONCAT(STR(?root), "/.well-known/genid/")
-            )
-          )
+          ${rootClosureSparqlFilter('?candidateSubject', '?root')}
         }
       }`);
     const rootResult = await store.query(`
@@ -2339,7 +2269,7 @@ async function buildFreshSwmDataGraphPlan(
             SELECT DISTINCT ?s ?p ?o WHERE {
               VALUES ?root { ${graphValues(roots)} }
               GRAPH <${assertSafeIri(graph)}> { ?s ?p ?o }
-              FILTER(?s = ?root || STRSTARTS(STR(?s), CONCAT(STR(?root), "/.well-known/genid/")))
+              ${rootClosureSparqlFilter('?s', '?root')}
             }
           }
         }
@@ -2386,7 +2316,7 @@ async function readFreshSwmDataRowsPageFromPlan(
       SELECT DISTINCT ?s ?p ?o WHERE {
         VALUES ?root { ${graphValues(entry.roots)} }
         GRAPH <${assertSafeIri(entry.graph)}> { ?s ?p ?o }
-        FILTER(?s = ?root || STRSTARTS(STR(?s), CONCAT(STR(?root), "/.well-known/genid/")))
+        ${rootClosureSparqlFilter('?s', '?root')}
       }
       ORDER BY ?s ?p ?o
       OFFSET ${skip}

--- a/packages/agent/src/sync/responder/snapshot-cache.ts
+++ b/packages/agent/src/sync/responder/snapshot-cache.ts
@@ -135,6 +135,136 @@ function raceAgainstAbort<T>(promise: Promise<T>, signal: AbortSignal | undefine
   });
 }
 
+interface GenerationAwareInflight<T> {
+  promise: Promise<T>;
+  refreshGeneration?: string;
+}
+
+const NO_COMPATIBLE_INFLIGHT = Symbol('no-compatible-inflight');
+
+/**
+ * Coalesce callers from the same responder-session generation while making a
+ * newer generation wait for, then supersede, an older in-flight load. Waiting
+ * is abortable per caller; the shared loader itself remains owner-independent.
+ */
+function awaitCompatibleGenerationInflight<T>(
+  getPending: () => GenerationAwareInflight<T> | undefined,
+  requestedGeneration: string | undefined,
+  signal: AbortSignal | undefined,
+): Promise<T | typeof NO_COMPATIBLE_INFLIGHT> | typeof NO_COMPATIBLE_INFLIGHT {
+  const firstPending = getPending();
+  if (!firstPending) return NO_COMPATIBLE_INFLIGHT;
+  const supersedesFirst = requestedGeneration !== undefined &&
+    requestedGeneration !== firstPending.refreshGeneration;
+  if (!supersedesFirst) return raceAgainstAbort(firstPending.promise, signal);
+
+  return (async () => {
+    let pending: GenerationAwareInflight<T> | undefined = firstPending;
+    while (pending) {
+      const supersedesPending = requestedGeneration !== undefined &&
+        requestedGeneration !== pending.refreshGeneration;
+      if (!supersedesPending) return raceAgainstAbort(pending.promise, signal);
+      try {
+        await raceAgainstAbort(pending.promise, signal);
+      } catch {
+        // A newer generation owns an independent attempt. Do not inherit an
+        // older load failure, but preserve the waiting caller's local abort.
+        throwIfAborted(signal);
+      }
+      pending = getPending();
+    }
+    return NO_COMPATIBLE_INFLIGHT;
+  })();
+}
+
+export interface GenerationAwareTtlSingleFlightMemo<T> {
+  get(
+    key: string,
+    load: () => Promise<T>,
+    options?: {
+      refresh?: boolean;
+      refreshGeneration?: string;
+      requireExisting?: boolean;
+      signal?: AbortSignal;
+    },
+  ): Promise<T | null>;
+}
+
+/**
+ * Small generation-aware TTL memo for responder plans and inventories. It
+ * centralizes the refresh/supersession protocol used by the row-snapshot memo
+ * without coupling scalar plan values to row retention budgets.
+ */
+export function createGenerationAwareTtlSingleFlightMemo<T>(
+  ttlMs: number,
+  maxEntries: number,
+): GenerationAwareTtlSingleFlightMemo<T> {
+  const cached = new Map<string, {
+    value: T;
+    cachedAt: number;
+    refreshGeneration?: string;
+  }>();
+  const inflight = new Map<string, GenerationAwareInflight<T>>();
+  const prune = (now = Date.now()) => {
+    for (const [key, entry] of cached) {
+      if (now - entry.cachedAt >= ttlMs) cached.delete(key);
+    }
+  };
+
+  return {
+    async get(key, load, options) {
+      throwIfAborted(options?.signal);
+      const requestedGeneration = options?.refreshGeneration;
+      const pendingResult = awaitCompatibleGenerationInflight(
+        () => inflight.get(key),
+        requestedGeneration,
+        options?.signal,
+      );
+      if (pendingResult !== NO_COMPATIBLE_INFLIGHT) {
+        const joined = await pendingResult;
+        if (joined !== NO_COMPATIBLE_INFLIGHT) return joined;
+      }
+
+      const now = Date.now();
+      prune(now);
+      let existing = cached.get(key);
+      if (
+        existing &&
+        requestedGeneration !== undefined &&
+        existing.refreshGeneration !== requestedGeneration
+      ) {
+        cached.delete(key);
+        existing = undefined;
+      }
+      if (!options?.refresh && existing) {
+        cached.delete(key);
+        cached.set(key, { ...existing, cachedAt: now });
+        return existing.value;
+      }
+      if (options?.requireExisting) return null;
+      if (!existing && cached.size >= maxEntries) cached.delete(cached.keys().next().value!);
+
+      const pendingLoad = load()
+        .then((value) => {
+          cached.set(key, {
+            value,
+            cachedAt: Date.now(),
+            refreshGeneration: requestedGeneration,
+          });
+          return value;
+        })
+        .finally(() => {
+          if (inflight.get(key)?.promise === pendingLoad) inflight.delete(key);
+        });
+      inflight.set(key, {
+        promise: pendingLoad,
+        refreshGeneration: requestedGeneration,
+      });
+      return raceAgainstAbort(pendingLoad, options?.signal);
+    },
+  };
+}
+
 /**
  * Session snapshot cache with coalesced loads, TTL expiry, immutable row-array
  * sharing, and optional process-wide retention budgeting. Returned arrays are
@@ -322,22 +452,14 @@ export function createResponderSyncRowListMemo(
       // written delegation). Wait for older loads to settle, then issue a new
       // store read. Re-check in a loop so concurrent refreshes serialize rather
       // than racing two writers against the same cache key.
-      while (true) {
-        const pending = inflight.get(key);
-        if (!pending) break;
-        const supersedesPending = options?.refreshGeneration !== undefined &&
-          options.refreshGeneration !== pending.refreshGeneration;
-        if (!supersedesPending) {
-          return raceAgainstAbort(pending.promise, options?.signal);
-        }
-        try {
-          await raceAgainstAbort(pending.promise, options?.signal);
-        } catch {
-          // A new session owns an independent attempt. An older session's
-          // query/budget failure must not be inherited, but caller abort still
-          // takes precedence.
-          throwIfAborted(options?.signal);
-        }
+      const pendingResult = awaitCompatibleGenerationInflight(
+        () => inflight.get(key),
+        options?.refreshGeneration,
+        options?.signal,
+      );
+      if (pendingResult !== NO_COMPATIBLE_INFLIGHT) {
+        const joined = await pendingResult;
+        if (joined !== NO_COMPATIBLE_INFLIGHT) return joined;
       }
 
       const now = Date.now();

--- a/packages/agent/src/sync/responder/snapshot-cache.ts
+++ b/packages/agent/src/sync/responder/snapshot-cache.ts
@@ -140,41 +140,59 @@ interface GenerationAwareInflight<T> {
   refreshGeneration?: string;
 }
 
-const NO_COMPATIBLE_INFLIGHT = Symbol('no-compatible-inflight');
+type GenerationInflightDecision<T> =
+  | { kind: 'claim' }
+  | { kind: 'wait'; result: Promise<GenerationInflightWaitResult<T>> };
+
+type GenerationInflightWaitResult<T> =
+  | { kind: 'joined'; value: T }
+  | { kind: 'retry' };
 
 /**
  * Coalesce callers from the same responder-session generation while making a
  * newer generation wait for, then supersede, an older in-flight load. Waiting
  * is abortable per caller; the shared loader itself remains owner-independent.
  */
-function awaitCompatibleGenerationInflight<T>(
+function decideGenerationInflight<T>(
   getPending: () => GenerationAwareInflight<T> | undefined,
   requestedGeneration: string | undefined,
   signal: AbortSignal | undefined,
-): Promise<T | typeof NO_COMPATIBLE_INFLIGHT> | typeof NO_COMPATIBLE_INFLIGHT {
+): GenerationInflightDecision<T> {
   const firstPending = getPending();
-  if (!firstPending) return NO_COMPATIBLE_INFLIGHT;
+  if (!firstPending) return { kind: 'claim' };
   const supersedesFirst = requestedGeneration !== undefined &&
     requestedGeneration !== firstPending.refreshGeneration;
-  if (!supersedesFirst) return raceAgainstAbort(firstPending.promise, signal);
+  if (!supersedesFirst) {
+    return {
+      kind: 'wait',
+      result: raceAgainstAbort(firstPending.promise, signal)
+        .then((value) => ({ kind: 'joined', value })),
+    };
+  }
 
-  return (async () => {
-    let pending: GenerationAwareInflight<T> | undefined = firstPending;
-    while (pending) {
-      const supersedesPending = requestedGeneration !== undefined &&
-        requestedGeneration !== pending.refreshGeneration;
-      if (!supersedesPending) return raceAgainstAbort(pending.promise, signal);
-      try {
-        await raceAgainstAbort(pending.promise, signal);
-      } catch {
-        // A newer generation owns an independent attempt. Do not inherit an
-        // older load failure, but preserve the waiting caller's local abort.
-        throwIfAborted(signal);
+  return {
+    kind: 'wait',
+    result: (async () => {
+      let pending: GenerationAwareInflight<T> | undefined = firstPending;
+      while (pending) {
+        const supersedesPending = requestedGeneration !== undefined &&
+          requestedGeneration !== pending.refreshGeneration;
+        if (!supersedesPending) {
+          const value = await raceAgainstAbort(pending.promise, signal);
+          return { kind: 'joined', value };
+        }
+        try {
+          await raceAgainstAbort(pending.promise, signal);
+        } catch {
+          // A newer generation owns an independent attempt. Do not inherit an
+          // older load failure, but preserve the waiting caller's local abort.
+          throwIfAborted(signal);
+        }
+        pending = getPending();
       }
-      pending = getPending();
-    }
-    return NO_COMPATIBLE_INFLIGHT;
-  })();
+      return { kind: 'retry' };
+    })(),
+  };
 }
 
 export interface GenerationAwareTtlSingleFlightMemo<T> {
@@ -216,14 +234,14 @@ export function createGenerationAwareTtlSingleFlightMemo<T>(
       throwIfAborted(options?.signal);
       const requestedGeneration = options?.refreshGeneration;
       while (true) {
-        const pendingResult = awaitCompatibleGenerationInflight(
+        const decision = decideGenerationInflight(
           () => inflight.get(key),
           requestedGeneration,
           options?.signal,
         );
-        if (pendingResult === NO_COMPATIBLE_INFLIGHT) break;
-        const joined = await pendingResult;
-        if (joined !== NO_COMPATIBLE_INFLIGHT) return joined;
+        if (decision.kind === 'claim') break;
+        const result = await decision.result;
+        if (result.kind === 'joined') return result.value;
         // Multiple callers for the same newer generation can all finish
         // waiting on the older load together. Re-enter the synchronous claim
         // path so the first installs the replacement and the rest join it.
@@ -457,14 +475,14 @@ export function createResponderSyncRowListMemo(
       // store read. Re-check in a loop so concurrent refreshes serialize rather
       // than racing two writers against the same cache key.
       while (true) {
-        const pendingResult = awaitCompatibleGenerationInflight(
+        const decision = decideGenerationInflight(
           () => inflight.get(key),
           options?.refreshGeneration,
           options?.signal,
         );
-        if (pendingResult === NO_COMPATIBLE_INFLIGHT) break;
-        const joined = await pendingResult;
-        if (joined !== NO_COMPATIBLE_INFLIGHT) return joined;
+        if (decision.kind === 'claim') break;
+        const result = await decision.result;
+        if (result.kind === 'joined') return result.value;
       }
 
       const now = Date.now();

--- a/packages/agent/src/sync/responder/snapshot-cache.ts
+++ b/packages/agent/src/sync/responder/snapshot-cache.ts
@@ -140,59 +140,55 @@ interface GenerationAwareInflight<T> {
   refreshGeneration?: string;
 }
 
-type GenerationInflightDecision<T> =
-  | { kind: 'claim' }
-  | { kind: 'wait'; result: Promise<GenerationInflightWaitResult<T>> };
-
-type GenerationInflightWaitResult<T> =
-  | { kind: 'joined'; value: T }
-  | { kind: 'retry' };
+type GenerationSingleFlightPreparation<T, R> =
+  | { kind: 'return'; value: R }
+  | { kind: 'load'; load: () => Promise<T> };
 
 /**
  * Coalesce callers from the same responder-session generation while making a
  * newer generation wait for, then supersede, an older in-flight load. Waiting
  * is abortable per caller; the shared loader itself remains owner-independent.
+ * The helper owns the complete wait/re-check/claim loop and installs the new
+ * promise before invoking its loader, so same-generation waiters cannot race
+ * independent replacement loads.
  */
-function decideGenerationInflight<T>(
-  getPending: () => GenerationAwareInflight<T> | undefined,
+async function runGenerationAwareSingleFlight<T, R>(
+  inflight: Map<string, GenerationAwareInflight<T>>,
+  key: string,
   requestedGeneration: string | undefined,
   signal: AbortSignal | undefined,
-): GenerationInflightDecision<T> {
-  const firstPending = getPending();
-  if (!firstPending) return { kind: 'claim' };
-  const supersedesFirst = requestedGeneration !== undefined &&
-    requestedGeneration !== firstPending.refreshGeneration;
-  if (!supersedesFirst) {
-    return {
-      kind: 'wait',
-      result: raceAgainstAbort(firstPending.promise, signal)
-        .then((value) => ({ kind: 'joined', value })),
-    };
-  }
-
-  return {
-    kind: 'wait',
-    result: (async () => {
-      let pending: GenerationAwareInflight<T> | undefined = firstPending;
-      while (pending) {
-        const supersedesPending = requestedGeneration !== undefined &&
-          requestedGeneration !== pending.refreshGeneration;
-        if (!supersedesPending) {
-          const value = await raceAgainstAbort(pending.promise, signal);
-          return { kind: 'joined', value };
-        }
-        try {
-          await raceAgainstAbort(pending.promise, signal);
-        } catch {
-          // A newer generation owns an independent attempt. Do not inherit an
-          // older load failure, but preserve the waiting caller's local abort.
-          throwIfAborted(signal);
-        }
-        pending = getPending();
+  prepare: () => GenerationSingleFlightPreparation<T, R>,
+  raceClaimedLoad = true,
+): Promise<T | R> {
+  while (true) {
+    const pending = inflight.get(key);
+    if (pending) {
+      const supersedesPending = requestedGeneration !== undefined &&
+        requestedGeneration !== pending.refreshGeneration;
+      if (!supersedesPending) return raceAgainstAbort(pending.promise, signal);
+      try {
+        await raceAgainstAbort(pending.promise, signal);
+      } catch {
+        // A newer generation owns an independent attempt. Do not inherit an
+        // older load failure, but preserve the waiting caller's local abort.
+        throwIfAborted(signal);
       }
-      return { kind: 'retry' };
-    })(),
-  };
+      continue;
+    }
+
+    const prepared = prepare();
+    if (prepared.kind === 'return') return prepared.value;
+    const promise = Promise.resolve().then(prepared.load);
+    const entry: GenerationAwareInflight<T> = {
+      promise,
+      refreshGeneration: requestedGeneration,
+    };
+    inflight.set(key, entry);
+    void promise.finally(() => {
+      if (inflight.get(key) === entry) inflight.delete(key);
+    }).catch(() => {});
+    return raceClaimedLoad ? raceAgainstAbort(promise, signal) : promise;
+  }
 }
 
 export interface GenerationAwareTtlSingleFlightMemo<T> {
@@ -233,56 +229,42 @@ export function createGenerationAwareTtlSingleFlightMemo<T>(
     async get(key, load, options) {
       throwIfAborted(options?.signal);
       const requestedGeneration = options?.refreshGeneration;
-      while (true) {
-        const decision = decideGenerationInflight(
-          () => inflight.get(key),
-          requestedGeneration,
-          options?.signal,
-        );
-        if (decision.kind === 'claim') break;
-        const result = await decision.result;
-        if (result.kind === 'joined') return result.value;
-        // Multiple callers for the same newer generation can all finish
-        // waiting on the older load together. Re-enter the synchronous claim
-        // path so the first installs the replacement and the rest join it.
-      }
+      return runGenerationAwareSingleFlight(
+        inflight,
+        key,
+        requestedGeneration,
+        options?.signal,
+        () => {
+          const now = Date.now();
+          prune(now);
+          let existing = cached.get(key);
+          if (
+            existing &&
+            requestedGeneration !== undefined &&
+            existing.refreshGeneration !== requestedGeneration
+          ) {
+            cached.delete(key);
+            existing = undefined;
+          }
+          if (!options?.refresh && existing) {
+            cached.delete(key);
+            cached.set(key, { ...existing, cachedAt: now });
+            return { kind: 'return', value: existing.value };
+          }
+          if (options?.requireExisting) return { kind: 'return', value: null };
+          if (!existing && cached.size >= maxEntries) cached.delete(cached.keys().next().value!);
 
-      const now = Date.now();
-      prune(now);
-      let existing = cached.get(key);
-      if (
-        existing &&
-        requestedGeneration !== undefined &&
-        existing.refreshGeneration !== requestedGeneration
-      ) {
-        cached.delete(key);
-        existing = undefined;
-      }
-      if (!options?.refresh && existing) {
-        cached.delete(key);
-        cached.set(key, { ...existing, cachedAt: now });
-        return existing.value;
-      }
-      if (options?.requireExisting) return null;
-      if (!existing && cached.size >= maxEntries) cached.delete(cached.keys().next().value!);
-
-      const pendingLoad = load()
-        .then((value) => {
-          cached.set(key, {
-            value,
-            cachedAt: Date.now(),
-            refreshGeneration: requestedGeneration,
-          });
-          return value;
-        })
-        .finally(() => {
-          if (inflight.get(key)?.promise === pendingLoad) inflight.delete(key);
-        });
-      inflight.set(key, {
-        promise: pendingLoad,
-        refreshGeneration: requestedGeneration,
-      });
-      return raceAgainstAbort(pendingLoad, options?.signal);
+          return { kind: 'load', load: async () => {
+            const value = await load();
+            cached.set(key, {
+              value,
+              cachedAt: Date.now(),
+              refreshGeneration: requestedGeneration,
+            });
+            return value;
+          } };
+        },
+      );
     },
   };
 }
@@ -472,121 +454,116 @@ export function createResponderSyncRowListMemo(
       // coalescing onto that in-flight promise would return the OLD row set to
       // the new session (the private-CG approval race can then omit the freshly
       // written delegation). Wait for older loads to settle, then issue a new
-      // store read. Re-check in a loop so concurrent refreshes serialize rather
-      // than racing two writers against the same cache key.
-      while (true) {
-        const decision = decideGenerationInflight(
-          () => inflight.get(key),
-          options?.refreshGeneration,
-          options?.signal,
-        );
-        if (decision.kind === 'claim') break;
-        const result = await decision.result;
-        if (result.kind === 'joined') return result.value;
-      }
-
-      const now = Date.now();
-      pruneExpired(now);
-      const requestedGeneration = options?.refreshGeneration;
-      const priorExpiry = expired.get(key);
-      if (priorExpiry) {
-        if (
-          options?.refresh ||
-          (requestedGeneration !== undefined &&
-            priorExpiry.refreshGeneration !== requestedGeneration)
-        ) deleteExpired(key);
-        else throw new Error('Durable data sync session snapshot expired before page completion');
-      }
-      const priorRejection = rejected.get(key);
-      if (priorRejection) {
-        if (
-          options?.refresh ||
-          (requestedGeneration !== undefined &&
-            priorRejection.refreshGeneration !== requestedGeneration)
-        ) deleteRejected(key);
-        else throw priorRejection.error;
-      }
-
-      let existing = cached.get(key);
-      if (
-        existing &&
-        requestedGeneration !== undefined &&
-        existing.refreshGeneration !== requestedGeneration
-      ) {
-        // prepareResponderSession installs a new token before its page-zero
-        // snapshot finishes. If that request aborts while waiting for an older
-        // generation, or its own refresh load fails, the older snapshot can
-        // remain retained. A same-token retry has refresh=false, so generation
-        // validation must also happen on cache hits rather than only while an
-        // in-flight load exists.
-        deleteCached(key, 'replaced');
-        existing = undefined;
-      }
-      if (!options?.refresh && existing && now - existing.cachedAt < ttlMs) {
-        const refreshed: CachedSnapshot = {
-          value: existing.value,
-          cachedAt: now,
-          cleanupTimer: scheduleCleanup(key, now, existing.refreshGeneration),
-          budgetEntryId: existing.budgetEntryId,
-          released: false,
-          refreshGeneration: existing.refreshGeneration,
-        };
-        clearTimeout(existing.cleanupTimer);
-        cached.delete(key);
-        cached.set(key, refreshed);
-        if (existing.budgetEntryId) memoOptions.budget?.touch(existing.budgetEntryId);
-        return existing.value;
-      }
-      if (options?.requireExisting) return null;
-      if (!cached.has(key) && cached.size + inflight.size >= maxEntries && !evictOneReleased()) {
-        throw new SyncRowSnapshotLimitError({
-          key,
-          maxEntries,
-          cachedEntries: cached.size,
-          inflightEntries: inflight.size,
-        });
-      }
-
-      const loadStartedAt = Date.now();
-      let loadOutcome: 'completed' | 'error' = 'completed';
-      recordSyncMemoryCheckpoint(memoOptions.phase, 'responder_snapshot_before_load');
-      const load = loadRows()
-        .then((rows) => {
-          // Loads are owner-independent and may finish after the first waiter
-          // aborts. Cache the complete result for surviving/coalesced waiters.
-          storeCached(key, rows, options?.refreshGeneration);
-          return rows;
-        })
-        .catch((error) => {
-          loadOutcome = 'error';
-          // A loader may reject before returning its array when a cheap store
-          // preflight or store-paged builder proves the full query would cross
-          // a response/heap safety bound. Remember intrinsic rejections exactly
-          // like storeCached() does, so later pages in this responder session go
-          // straight to bounded store paging instead of repeating the full load.
-          if (
-            error instanceof SyncRowSnapshotBudgetError &&
-            (error.reason === 'snapshot_rows' || error.reason === 'snapshot_bytes')
-          ) {
-            const stale = cached.get(key);
-            if (stale) deleteCached(key, 'replaced');
-            rememberRejected(key, error, options?.refreshGeneration);
+      // store read. The shared primitive owns the wait/re-check/claim loop.
+      const rows = await runGenerationAwareSingleFlight<
+        readonly SyncRow[],
+        readonly SyncRow[] | null
+      >(
+        inflight,
+        key,
+        options?.refreshGeneration,
+        options?.signal,
+        () => {
+          const now = Date.now();
+          pruneExpired(now);
+          const requestedGeneration = options?.refreshGeneration;
+          const priorExpiry = expired.get(key);
+          if (priorExpiry) {
+            if (
+              options?.refresh ||
+              (requestedGeneration !== undefined &&
+                priorExpiry.refreshGeneration !== requestedGeneration)
+            ) deleteExpired(key);
+            else throw new Error('Durable data sync session snapshot expired before page completion');
           }
-          throw error;
-        })
-        .finally(() => {
-          getMetrics().syncResponderSnapshotLoadDurationMs.record(
-            Date.now() - loadStartedAt,
-            { phase: memoOptions.phase, outcome: loadOutcome },
-          );
-          recordSyncMemoryCheckpoint(memoOptions.phase, 'responder_snapshot_after_load');
-          if (inflight.get(key)?.promise === load) inflight.delete(key);
-        });
-      inflight.set(key, {
-        promise: load,
-        refreshGeneration: options?.refreshGeneration,
-      });
-      const rows = await load;
+          const priorRejection = rejected.get(key);
+          if (priorRejection) {
+            if (
+              options?.refresh ||
+              (requestedGeneration !== undefined &&
+                priorRejection.refreshGeneration !== requestedGeneration)
+            ) deleteRejected(key);
+            else throw priorRejection.error;
+          }
+
+          let existing = cached.get(key);
+          if (
+            existing &&
+            requestedGeneration !== undefined &&
+            existing.refreshGeneration !== requestedGeneration
+          ) {
+            // prepareResponderSession installs a new token before its page-zero
+            // snapshot finishes. If that request aborts while waiting for an older
+            // generation, or its own refresh load fails, the older snapshot can
+            // remain retained. A same-token retry has refresh=false, so generation
+            // validation must also happen on cache hits rather than only while an
+            // in-flight load exists.
+            deleteCached(key, 'replaced');
+            existing = undefined;
+          }
+          if (!options?.refresh && existing && now - existing.cachedAt < ttlMs) {
+            const refreshed: CachedSnapshot = {
+              value: existing.value,
+              cachedAt: now,
+              cleanupTimer: scheduleCleanup(key, now, existing.refreshGeneration),
+              budgetEntryId: existing.budgetEntryId,
+              released: false,
+              refreshGeneration: existing.refreshGeneration,
+            };
+            clearTimeout(existing.cleanupTimer);
+            cached.delete(key);
+            cached.set(key, refreshed);
+            if (existing.budgetEntryId) memoOptions.budget?.touch(existing.budgetEntryId);
+            return { kind: 'return', value: existing.value };
+          }
+          if (options?.requireExisting) return { kind: 'return', value: null };
+          if (!cached.has(key) && cached.size + inflight.size >= maxEntries && !evictOneReleased()) {
+            throw new SyncRowSnapshotLimitError({
+              key,
+              maxEntries,
+              cachedEntries: cached.size,
+              inflightEntries: inflight.size,
+            });
+          }
+
+          return { kind: 'load', load: async () => {
+            const loadStartedAt = Date.now();
+            let loadOutcome: 'completed' | 'error' = 'completed';
+            recordSyncMemoryCheckpoint(memoOptions.phase, 'responder_snapshot_before_load');
+            try {
+              const loadedRows = await loadRows();
+              // Loads are owner-independent and may finish after the first waiter
+              // aborts. Cache the complete result for surviving/coalesced waiters.
+              storeCached(key, loadedRows, options?.refreshGeneration);
+              return loadedRows;
+            } catch (error) {
+              loadOutcome = 'error';
+              // A loader may reject before returning its array when a cheap store
+              // preflight or store-paged builder proves the full query would cross
+              // a response/heap safety bound. Remember intrinsic rejections exactly
+              // like storeCached() does, so later pages in this responder session go
+              // straight to bounded store paging instead of repeating the full load.
+              if (
+                error instanceof SyncRowSnapshotBudgetError &&
+                (error.reason === 'snapshot_rows' || error.reason === 'snapshot_bytes')
+              ) {
+                const stale = cached.get(key);
+                if (stale) deleteCached(key, 'replaced');
+                rememberRejected(key, error, options?.refreshGeneration);
+              }
+              throw error;
+            } finally {
+              getMetrics().syncResponderSnapshotLoadDurationMs.record(
+                Date.now() - loadStartedAt,
+                { phase: memoOptions.phase, outcome: loadOutcome },
+              );
+              recordSyncMemoryCheckpoint(memoOptions.phase, 'responder_snapshot_after_load');
+            }
+          } };
+        },
+        false,
+      );
+      if (rows === null) return null;
       if (options?.signal?.aborted) {
         const completed = cached.get(key);
         if (completed) {

--- a/packages/agent/src/sync/responder/snapshot-cache.ts
+++ b/packages/agent/src/sync/responder/snapshot-cache.ts
@@ -215,14 +215,18 @@ export function createGenerationAwareTtlSingleFlightMemo<T>(
     async get(key, load, options) {
       throwIfAborted(options?.signal);
       const requestedGeneration = options?.refreshGeneration;
-      const pendingResult = awaitCompatibleGenerationInflight(
-        () => inflight.get(key),
-        requestedGeneration,
-        options?.signal,
-      );
-      if (pendingResult !== NO_COMPATIBLE_INFLIGHT) {
+      while (true) {
+        const pendingResult = awaitCompatibleGenerationInflight(
+          () => inflight.get(key),
+          requestedGeneration,
+          options?.signal,
+        );
+        if (pendingResult === NO_COMPATIBLE_INFLIGHT) break;
         const joined = await pendingResult;
         if (joined !== NO_COMPATIBLE_INFLIGHT) return joined;
+        // Multiple callers for the same newer generation can all finish
+        // waiting on the older load together. Re-enter the synchronous claim
+        // path so the first installs the replacement and the rest join it.
       }
 
       const now = Date.now();
@@ -452,12 +456,13 @@ export function createResponderSyncRowListMemo(
       // written delegation). Wait for older loads to settle, then issue a new
       // store read. Re-check in a loop so concurrent refreshes serialize rather
       // than racing two writers against the same cache key.
-      const pendingResult = awaitCompatibleGenerationInflight(
-        () => inflight.get(key),
-        options?.refreshGeneration,
-        options?.signal,
-      );
-      if (pendingResult !== NO_COMPATIBLE_INFLIGHT) {
+      while (true) {
+        const pendingResult = awaitCompatibleGenerationInflight(
+          () => inflight.get(key),
+          options?.refreshGeneration,
+          options?.signal,
+        );
+        if (pendingResult === NO_COMPATIBLE_INFLIGHT) break;
         const joined = await pendingResult;
         if (joined !== NO_COMPATIBLE_INFLIGHT) return joined;
       }

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -804,6 +804,76 @@ describe('Phase D - VM reconcile damping', () => {
     expect(fetch.calls).toHaveLength(0);
   });
 
+  it('deletes an upgraded ops-based durable miss and scans a matching child graph', async () => {
+    const durable = new Map<string, VmReconcileNegativeRecord>();
+    const deleteDurable = recorder(async (key: string) => { durable.delete(key); });
+    const subscriptionStore: ContextGraphSubscriptionStore = {
+      loadAll: async () => [],
+      save: async () => undefined,
+      delete: async () => undefined,
+      loadVmReconcileNegative: async (key) => durable.get(key) ?? null,
+      saveVmReconcileNegative: async (record) => { durable.set(record.cacheKey, record); },
+      deleteVmReconcileNegative: deleteDurable,
+      deleteVmReconcileNegativesForContextGraph: async (cg) => {
+        for (const [key, record] of durable) if (record.localCgId === cg) durable.delete(key);
+      },
+    };
+    const localCgId = '66';
+    const onChainCgId = 66n;
+    const kaId = 9066n;
+    const entity = 'urn:fact:upgraded-child-graph';
+    const value = 'Payload found after discarding a stale durable miss';
+    const root = computeFlatKCRootV10(
+      [{ subject: entity, predicate: 'http://schema.org/name', object: `"${value}"`, graph: '' }],
+      [],
+    );
+    const internals = await boot(subscriptionStore);
+    registerUnmatchedKC(internals.chain, kaId, onChainCgId, bytesToHex(root));
+
+    const storageAddr = await internals.chain.getDKGKnowledgeAssetsAddress();
+    const ual = buildKnowledgeAssetUal(internals.chain.chainId, storageAddr, kaId);
+    const cacheKey = (internals as any).vmReconcileCacheKey(localCgId, ual, root);
+    const rootMetaGraph = contextGraphWorkspaceMetaGraphUri(localCgId);
+    const rootDataGraph = contextGraphWorkspaceGraphUri(localCgId);
+    durable.set(cacheKey, {
+      cacheKey,
+      localCgId,
+      failures: 1,
+      nextRetryAt: Date.now() + 60_000,
+      swmGen: `meta:${rootMetaGraph};data:${rootDataGraph};ops:1;opHash:legacy`,
+      candidateNamespaces: [{ metaGraph: rootMetaGraph, dataGraph: rootDataGraph }],
+      peerTopologyKey: await (internals as any).vmReconcilePeerTopologyKey(localCgId),
+    });
+
+    await insertWorkspaceOperationMeta(
+      internals.store,
+      rootMetaGraph,
+      'upgraded-child-graph',
+      entity,
+      '2035-01-01T00:00:00.000Z',
+    );
+    await internals.store.insert([{
+      subject: entity,
+      predicate: 'http://schema.org/name',
+      object: `"${value}"`,
+      graph: `${rootDataGraph}/0x0000000000000000000000000000000000000000/${kaId}`,
+    }]);
+
+    const originalQuery = internals.store.query.bind(internals.store);
+    let expensiveScans = 0;
+    (internals.store as any).query = recorder(async (sparql: string) => {
+      if (sparql.includes('SELECT ?op ?root WHERE')) expensiveScans++;
+      return originalQuery(sparql);
+    });
+    (internals as any).syncContextGraphFromConnectedPeers = recorder(async () => emptyCatchupStats());
+
+    await expect(internals.reconcileChainOrdinal(localCgId, onChainCgId, 0, undefined))
+      .resolves.toEqual({ status: 'reconciled', blockNumber: 0 });
+    expect(expensiveScans).toBeGreaterThan(0);
+    expect(deleteDurable.calls.some(([key]) => key === cacheKey)).toBe(true);
+    expect(durable.has(cacheKey)).toBe(false);
+  });
+
   it('rescans after restart when an incomplete operation payload appears only in a per-KA child graph', async () => {
     const durable = new Map<string, VmReconcileNegativeRecord>();
     const subscriptionStore: ContextGraphSubscriptionStore = {

--- a/packages/agent/test/finalization-reconcile-negative-memo.test.ts
+++ b/packages/agent/test/finalization-reconcile-negative-memo.test.ts
@@ -32,6 +32,16 @@ const wsMetaGraph = contextGraphWorkspaceMetaGraphUri(LOCAL_CG);
 const NAME_PRED = 'http://schema.org/name';
 const PRIVATE_ROOT_PRED = 'http://dkg.io/ontology/privateMerkleRoot';
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 /** Seed a local SWM snapshot for one KA and return its flat-KC merkle root. */
 async function seedSwmSnapshot(store: OxigraphStore, entity: string, value: string): Promise<Uint8Array> {
   await store.insert([
@@ -108,22 +118,73 @@ describe('#1609 — write-gen-gated negative memo (chain-reconcile backstop)', (
     const fh = new FinalizationHandler(store, new MockChainAdapter());
     const entity = 'urn:fact:finalization-singleflight';
     const merkleRoot = await seedSwmSnapshot(store, entity, 'shared value');
-    let acceptFactories = 0;
+    const queryGate = deferred<void>();
+    const originalQuery = store.query.bind(store);
+    let queryCalls = 0;
+    store.query = async (...args) => {
+      queryCalls += 1;
+      if (queryCalls === 1) await queryGate.promise;
+      return originalQuery(...args);
+    };
     const load = () => (fh as any).loadFinalizationSwmSlice(
       LOCAL_CG,
       [entity],
       undefined,
       undefined,
       merkleRoot,
-      async () => {
-        acceptFactories += 1;
-        return (quads: unknown[]) => quads;
-      },
+      [],
+      false,
     );
 
-    const [first, second] = await Promise.all([load(), load()]);
+    const firstLoad = load();
+    while (queryCalls === 0) await new Promise((resolve) => setTimeout(resolve, 0));
+    const secondLoad = load();
+    await Promise.resolve();
+    expect(queryCalls).toBe(1);
+    queryGate.resolve(undefined);
+    const [first, second] = await Promise.all([firstLoad, secondLoad]);
     expect(first.quads).toEqual(second.quads);
-    expect(acceptFactories).toBe(1);
+  });
+
+  it('does not coalesce finalization scans with different acceptance policies', async () => {
+    const store = new OxigraphStore();
+    const fh = new FinalizationHandler(store, new MockChainAdapter());
+    const entity = 'urn:fact:finalization-policy';
+    const merkleRoot = await seedSwmSnapshot(store, entity, 'shared value');
+    const queryGate = deferred<void>();
+    const originalQuery = store.query.bind(store);
+    let queryCalls = 0;
+    const singleFlightKeys: string[] = [];
+    const originalSingleFlight = (fh as any).runScanSingleFlight.bind(fh);
+    vi.spyOn(fh as any, 'runScanSingleFlight').mockImplementation(
+      (key: string, work: () => Promise<unknown>) => {
+        singleFlightKeys.push(key);
+        return originalSingleFlight(key, work);
+      },
+    );
+    store.query = async (...args) => {
+      queryCalls += 1;
+      if (queryCalls === 1) await queryGate.promise;
+      return originalQuery(...args);
+    };
+    const load = (allowGeneratedCatalogFloor: boolean) => (fh as any).loadFinalizationSwmSlice(
+      LOCAL_CG,
+      [entity],
+      undefined,
+      undefined,
+      merkleRoot,
+      [],
+      allowGeneratedCatalogFloor,
+    );
+
+    const strictLoad = load(false);
+    while (queryCalls === 0) await new Promise((resolve) => setTimeout(resolve, 0));
+    const floorLoad = load(true);
+    for (let i = 0; i < 3; i += 1) await Promise.resolve();
+    expect(singleFlightKeys).toHaveLength(2);
+    expect(singleFlightKeys[0]).not.toBe(singleFlightKeys[1]);
+    queryGate.resolve(undefined);
+    await Promise.all([strictLoad, floorLoad]);
   });
 
   it('single-flights concurrent equivalent never-match scans', async () => {

--- a/packages/agent/test/finalization-reconcile-negative-memo.test.ts
+++ b/packages/agent/test/finalization-reconcile-negative-memo.test.ts
@@ -146,6 +146,98 @@ describe('#1609 — write-gen-gated negative memo (chain-reconcile backstop)', (
     expect(first.quads).toEqual(second.quads);
   });
 
+  it('canonicalizes equivalent private-root sets in the finalization single-flight key', async () => {
+    const store = new OxigraphStore();
+    const fh = new FinalizationHandler(store, new MockChainAdapter());
+    const entity = 'urn:fact:finalization-private-root-order';
+    await seedSwmSnapshot(store, entity, 'shared value');
+    const privateA = Uint8Array.from({ length: 32 }, () => 0x11);
+    const privateB = Uint8Array.from({ length: 32 }, () => 0x22);
+    const merkleRoot = rootFor(entity, 'shared value', [privateA, privateB]);
+    const queryGate = deferred<void>();
+    const originalQuery = store.query.bind(store);
+    let queryCalls = 0;
+    const singleFlightKeys: string[] = [];
+    const originalSingleFlight = (fh as any).runScanSingleFlight.bind(fh);
+    vi.spyOn(fh as any, 'runScanSingleFlight').mockImplementation(
+      (key: string, work: () => Promise<unknown>) => {
+        singleFlightKeys.push(key);
+        return originalSingleFlight(key, work);
+      },
+    );
+    store.query = async (...args) => {
+      queryCalls += 1;
+      if (queryCalls === 1) await queryGate.promise;
+      return originalQuery(...args);
+    };
+    const load = (privateRoots: Uint8Array[]) => (fh as any).loadFinalizationSwmSlice(
+      LOCAL_CG,
+      [entity],
+      undefined,
+      undefined,
+      merkleRoot,
+      privateRoots,
+      false,
+    );
+
+    const firstLoad = load([privateA, privateB]);
+    while (queryCalls === 0) await new Promise((resolve) => setTimeout(resolve, 0));
+    const secondLoad = load([privateB, privateA]);
+    await Promise.resolve();
+
+    expect(singleFlightKeys).toHaveLength(2);
+    expect(singleFlightKeys[0]).toBe(singleFlightKeys[1]);
+    expect(queryCalls).toBe(1);
+    queryGate.resolve(undefined);
+    const [first, second] = await Promise.all([firstLoad, secondLoad]);
+    expect(first.quads).toEqual(second.quads);
+  });
+
+  it('keeps different private-root sets on separate finalization single flights', async () => {
+    const store = new OxigraphStore();
+    const fh = new FinalizationHandler(store, new MockChainAdapter());
+    const entity = 'urn:fact:finalization-private-root-policy';
+    await seedSwmSnapshot(store, entity, 'shared value');
+    const privateA = Uint8Array.from({ length: 32 }, () => 0x33);
+    const privateB = Uint8Array.from({ length: 32 }, () => 0x44);
+    const merkleRoot = rootFor(entity, 'shared value', [privateA]);
+    const queryGate = deferred<void>();
+    const originalQuery = store.query.bind(store);
+    let queryCalls = 0;
+    const singleFlightKeys: string[] = [];
+    const originalSingleFlight = (fh as any).runScanSingleFlight.bind(fh);
+    vi.spyOn(fh as any, 'runScanSingleFlight').mockImplementation(
+      (key: string, work: () => Promise<unknown>) => {
+        singleFlightKeys.push(key);
+        return originalSingleFlight(key, work);
+      },
+    );
+    store.query = async (...args) => {
+      queryCalls += 1;
+      if (queryCalls === 1) await queryGate.promise;
+      return originalQuery(...args);
+    };
+    const load = (privateRoots: Uint8Array[]) => (fh as any).loadFinalizationSwmSlice(
+      LOCAL_CG,
+      [entity],
+      undefined,
+      undefined,
+      merkleRoot,
+      privateRoots,
+      false,
+    );
+
+    const firstLoad = load([privateA]);
+    while (queryCalls === 0) await new Promise((resolve) => setTimeout(resolve, 0));
+    const secondLoad = load([privateB]);
+    while (queryCalls < 2) await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(singleFlightKeys).toHaveLength(2);
+    expect(singleFlightKeys[0]).not.toBe(singleFlightKeys[1]);
+    queryGate.resolve(undefined);
+    await Promise.all([firstLoad, secondLoad]);
+  });
+
   it('does not coalesce finalization scans with different acceptance policies', async () => {
     const store = new OxigraphStore();
     const fh = new FinalizationHandler(store, new MockChainAdapter());

--- a/packages/agent/test/oversize-filter.test.ts
+++ b/packages/agent/test/oversize-filter.test.ts
@@ -303,6 +303,33 @@ describe('insertWithOversizeGuard', () => {
     expect(drops.every(({ seam }) => seam === 'swm-sync:blank-node-component-quarantine')).toBe(true);
   });
 
+  it('quarantines the whole VM graph when one blank-node component is over-bound', async () => {
+    const { drops, hooks } = collect();
+    const validVm = quad(lit(10), VM_GRAPH, 'http://ex.org/valid-vm-metadata');
+    const otherGraph = quad(lit(10), DATA_GRAPH, 'http://ex.org/unrelated');
+    const detail = lit(50_000);
+    const component = [
+      quad('_:huge-vm-section', VM_GRAPH, 'http://ex.org/vm-doc'),
+      ...Array.from({ length: 170 }, (_, index) => ({
+        ...quad(detail, VM_GRAPH, '_:huge-vm-section'),
+        predicate: `http://ex.org/vm-detail-${index}`,
+      })),
+    ];
+    const batches: Quad[][] = [];
+
+    await expect(insertWithOversizeGuard(
+      async (batch) => { batches.push(batch); },
+      [validVm, ...component, otherGraph],
+      hooks,
+      'vm-sync',
+    )).resolves.toEqual([otherGraph]);
+
+    expect(batches).toEqual([[otherGraph]]);
+    expect(drops).toHaveLength(component.length + 1);
+    expect(drops.every(({ drop }) => drop.kind === 'vm-quarantine')).toBe(true);
+    expect(drops.map(({ drop }) => drop.quad)).toEqual([validVm, ...component]);
+  });
+
   it('rethrows an oversize error the split cannot explain (real store bug, loud failure)', async () => {
     const { hooks } = collect();
     const smallButRejected = quad(lit(10));

--- a/packages/agent/test/oversize-filter.test.ts
+++ b/packages/agent/test/oversize-filter.test.ts
@@ -239,6 +239,45 @@ describe('insertWithOversizeGuard', () => {
     }
   });
 
+  it('keeps a transitive blank-node chain in one insert call across a batch boundary', async () => {
+    const { hooks } = collect();
+    const detail = lit(50_000);
+    const chainedComponent = [
+      { ...quad('_:b', SWM_GRAPH, '_:a'), predicate: 'http://ex.org/next' },
+      { ...quad('_:c', SWM_GRAPH, '_:b'), predicate: 'http://ex.org/next' },
+      ...Array.from({ length: 90 }, (_, index) => ({
+        ...quad(detail, SWM_GRAPH, '_:c'),
+        predicate: `http://ex.org/chain-detail-${index}`,
+      })),
+    ];
+    const groundQuads = Array.from({ length: 100 }, (_, index) => ({
+      ...quad(detail, SWM_GRAPH, `http://ex.org/ground-${index}`),
+      predicate: `http://ex.org/ground-detail-${index}`,
+    }));
+    const input = chainedComponent.flatMap((componentQuad, index) => (
+      index < groundQuads.length ? [componentQuad, groundQuads[index]!] : [componentQuad]
+    ));
+    const batches: Quad[][] = [];
+
+    await insertWithOversizeGuard(
+      async (batch) => { batches.push(batch); },
+      input,
+      hooks,
+      'swm-sync',
+    );
+
+    expect(batches.length).toBeGreaterThan(1);
+    const chainBatches = batches.filter((batch) => batch.some((q) =>
+      ['_:a', '_:b', '_:c'].includes(q.subject) ||
+      ['_:a', '_:b', '_:c'].includes(q.object) ||
+      ['_:a', '_:b', '_:c'].includes(q.graph)));
+    expect(chainBatches).toHaveLength(1);
+    expect(chainBatches[0]!.filter((q) =>
+      ['_:a', '_:b', '_:c'].includes(q.subject) ||
+      ['_:a', '_:b', '_:c'].includes(q.object) ||
+      ['_:a', '_:b', '_:c'].includes(q.graph))).toHaveLength(chainedComponent.length);
+  });
+
   it('rejects an over-bound blank-node component before any insert mutation', async () => {
     const { hooks } = collect();
     const detail = lit(50_000);

--- a/packages/agent/test/oversize-filter.test.ts
+++ b/packages/agent/test/oversize-filter.test.ts
@@ -25,7 +25,6 @@ import {
   filterOversizedSyncQuads,
   insertWithOversizeGuard,
   splitStoreRejectedQuads,
-  SyncInsertBlankNodeComponentTooLargeError,
   SYNC_STORE_INSERT_BATCH_MAX_BYTES,
   type OversizeDrop,
 } from '../src/sync/oversize-filter.js';
@@ -278,8 +277,9 @@ describe('insertWithOversizeGuard', () => {
       ['_:a', '_:b', '_:c'].includes(q.graph))).toHaveLength(chainedComponent.length);
   });
 
-  it('rejects an over-bound blank-node component before any insert mutation', async () => {
-    const { hooks } = collect();
+  it('quarantines an over-bound blank-node component before inserting an earlier valid unit', async () => {
+    const { drops, hooks } = collect();
+    const valid = quad(lit(10), SWM_GRAPH, 'http://ex.org/valid');
     const detail = lit(50_000);
     const component = [
       quad('_:huge-section', SWM_GRAPH, 'http://ex.org/doc'),
@@ -292,12 +292,15 @@ describe('insertWithOversizeGuard', () => {
 
     await expect(insertWithOversizeGuard(
       async (batch) => { batches.push(batch); },
-      component,
+      [valid, ...component],
       hooks,
       'swm-sync',
-    )).rejects.toBeInstanceOf(SyncInsertBlankNodeComponentTooLargeError);
+    )).resolves.toEqual([valid]);
 
-    expect(batches).toEqual([]);
+    expect(batches).toEqual([[valid]]);
+    expect(drops).toHaveLength(component.length);
+    expect(drops.every(({ drop }) => drop.kind === 'blank-node-component-quarantine')).toBe(true);
+    expect(drops.every(({ seam }) => seam === 'swm-sync:blank-node-component-quarantine')).toBe(true);
   });
 
   it('rethrows an oversize error the split cannot explain (real store bug, loud failure)', async () => {
@@ -330,14 +333,18 @@ describe('runDurableSync — the poison-page retry-loop regression', () => {
   const goodA = quad(lit(10), DATA_GRAPH, 'http://ex.org/a');
   const goodB = quad(lit(10), DATA_GRAPH, 'http://ex.org/b');
 
-  function makeContext(storeInsert: (quads: Quad[]) => Promise<void>) {
+  function makeContext(
+    storeInsert: (quads: Quad[]) => Promise<void>,
+    dataQuads: Quad[] = [goodA, bad, goodB],
+  ) {
     const deletedCheckpoints: string[] = [];
     const setCheckpoints: Array<{ key: string; offset: number }> = [];
+    let dataFetchCalls = 0;
     const page = (phase: 'data' | 'meta'): SyncPageResult => ({
-      quads: phase === 'data' ? [goodA, bad, goodB] : [],
+      quads: phase === 'data' ? dataQuads : [],
       bytesReceived: 100,
       resumedFromOffset: 0,
-      nextOffset: 3,
+      nextOffset: dataQuads.length,
       checkpointKey: `cp|${phase}`,
       completed: true,
       timedOut: false,
@@ -345,12 +352,16 @@ describe('runDurableSync — the poison-page retry-loop regression', () => {
     return {
       deletedCheckpoints,
       setCheckpoints,
+      get dataFetchCalls() { return dataFetchCalls; },
       context: {
         ctx: createOperationContext('sync'),
         remotePeerId: 'peerR',
         contextGraphIds: ['agents'],
         createContextGraphSyncDeadline: () => Date.now() + 10_000,
-        fetchSyncPages: async (_c: unknown, _p: string, _cg: string, _swm: boolean, phase: 'data' | 'meta') => page(phase),
+        fetchSyncPages: async (_c: unknown, _p: string, _cg: string, _swm: boolean, phase: 'data' | 'meta') => {
+          if (phase === 'data') dataFetchCalls += 1;
+          return page(phase);
+        },
         processDurableBatchInWorker: async (dataQuads: Quad[], metaQuads: Quad[]) => ({
           verifiedData: dataQuads,
           verifiedMeta: metaQuads,
@@ -406,6 +417,41 @@ describe('runDurableSync — the poison-page retry-loop regression', () => {
       kind: 'oversize',
       seam: 'durable-sync',
       predicate: 'https://schema.org/description',
+    });
+  });
+
+  it('consumes a page containing an over-bound blank-node component instead of retrying it', async () => {
+    const valid = quad(lit(10), SWM_GRAPH, 'http://ex.org/valid-before-huge-component');
+    const detail = lit(50_000);
+    const component = [
+      quad('_:huge-section', SWM_GRAPH, 'http://ex.org/huge-doc'),
+      ...Array.from({ length: 170 }, (_, index) => ({
+        ...quad(detail, SWM_GRAPH, '_:huge-section'),
+        predicate: `http://ex.org/huge-detail-${index}`,
+      })),
+    ];
+    const stored: Quad[][] = [];
+    const tomb = new OversizeTombstoneLog({ logWarn: () => {} });
+    const guarded = async (quads: Quad[]) => {
+      await insertWithOversizeGuard(
+        async (kept) => { stored.push(kept); },
+        quads,
+        { recordDrops: (drops, seam) => tomb.record(drops, seam) },
+        'durable-sync',
+      );
+    };
+    const run = makeContext(guarded, [valid, ...component]);
+
+    const summary = await runDurableSync(run.context as never);
+
+    expect(summary.failedPhases).toBe(0);
+    expect(stored).toEqual([[valid]]);
+    expect(run.deletedCheckpoints).toEqual(expect.arrayContaining(['cp|meta', 'cp|data']));
+    expect(run.dataFetchCalls).toBe(1);
+    expect(tomb.size).toBe(component.length);
+    expect(tomb.list(component.length)[0]).toMatchObject({
+      kind: 'blank-node-component-quarantine',
+      seam: 'durable-sync:blank-node-component-quarantine',
     });
   });
 });

--- a/packages/agent/test/oversize-filter.test.ts
+++ b/packages/agent/test/oversize-filter.test.ts
@@ -25,6 +25,7 @@ import {
   filterOversizedSyncQuads,
   insertWithOversizeGuard,
   splitStoreRejectedQuads,
+  SyncInsertBlankNodeComponentTooLargeError,
   SYNC_STORE_INSERT_BATCH_MAX_BYTES,
   type OversizeDrop,
 } from '../src/sync/oversize-filter.js';
@@ -194,6 +195,70 @@ describe('insertWithOversizeGuard', () => {
       const bytes = batch.reduce((sum, q) => sum + estimateSyncStoreInsertQuadBytes(q), 0);
       expect(bytes).toBeLessThanOrEqual(SYNC_STORE_INSERT_BATCH_MAX_BYTES);
     }
+  });
+
+  it('keeps connected blank-node components within one bounded insert call', async () => {
+    const { hooks } = collect();
+    const detail = lit(50_000);
+    const componentA = [
+      quad('_:section-a', SWM_GRAPH, 'http://ex.org/doc-a'),
+      ...Array.from({ length: 90 }, (_, index) => ({
+        ...quad(detail, SWM_GRAPH, '_:section-a'),
+        predicate: `http://ex.org/a-${index}`,
+      })),
+    ];
+    const componentB = [
+      quad('_:section-b', SWM_GRAPH, 'http://ex.org/doc-b'),
+      ...Array.from({ length: 90 }, (_, index) => ({
+        ...quad(detail, SWM_GRAPH, '_:section-b'),
+        predicate: `http://ex.org/b-${index}`,
+      })),
+    ];
+    const input = componentA.flatMap((quadA, index) => (
+      index < componentB.length ? [quadA, componentB[index]!] : [quadA]
+    ));
+    const batches: Quad[][] = [];
+
+    await insertWithOversizeGuard(
+      async (batch) => { batches.push(batch); },
+      input,
+      hooks,
+      'swm-sync',
+    );
+
+    expect(batches).toHaveLength(2);
+    for (const label of ['_:section-a', '_:section-b']) {
+      const containingBatches = batches.filter((batch) => batch.some(
+        (q) => q.subject === label || q.object === label || q.graph === label,
+      ));
+      expect(containingBatches).toHaveLength(1);
+    }
+    for (const batch of batches) {
+      const bytes = batch.reduce((sum, q) => sum + estimateSyncStoreInsertQuadBytes(q), 0);
+      expect(bytes).toBeLessThanOrEqual(SYNC_STORE_INSERT_BATCH_MAX_BYTES);
+    }
+  });
+
+  it('rejects an over-bound blank-node component before any insert mutation', async () => {
+    const { hooks } = collect();
+    const detail = lit(50_000);
+    const component = [
+      quad('_:huge-section', SWM_GRAPH, 'http://ex.org/doc'),
+      ...Array.from({ length: 170 }, (_, index) => ({
+        ...quad(detail, SWM_GRAPH, '_:huge-section'),
+        predicate: `http://ex.org/detail-${index}`,
+      })),
+    ];
+    const batches: Quad[][] = [];
+
+    await expect(insertWithOversizeGuard(
+      async (batch) => { batches.push(batch); },
+      component,
+      hooks,
+      'swm-sync',
+    )).rejects.toBeInstanceOf(SyncInsertBlankNodeComponentTooLargeError);
+
+    expect(batches).toEqual([]);
   });
 
   it('rethrows an oversize error the split cannot explain (real store bug, loud failure)', async () => {

--- a/packages/agent/test/sync-responder-oversized-fallback.test.ts
+++ b/packages/agent/test/sync-responder-oversized-fallback.test.ts
@@ -195,6 +195,10 @@ describe('oversized responder fallback is store-bounded and set-equivalent', () 
       ...workspaceOpQuads(cgId, 'opA', 'urn:root:A', bucketAMeta, recent),
       { graph: bucketAData, subject: 'urn:root:A', predicate: `${DKG_NS}label`, object: '"A-root-row"' },
       { graph: bucketAData, subject: 'urn:root:A/.well-known/genid/child', predicate: `${DKG_NS}label`, object: '"A-skolem-row"' },
+      // bucket A: a recent root represented only by a generated descendant.
+      // The bounded planner must admit this closure without a direct root row.
+      ...workspaceOpQuads(cgId, 'opAgen', 'urn:root:Agenerated', bucketAMeta, recent),
+      { graph: bucketAData, subject: 'urn:root:Agenerated/.well-known/genid/child', predicate: `${DKG_NS}label`, object: '"A-generated-only-skolem-row"' },
       // bucket A: a STALE root (older than cutoff) whose row must be excluded
       ...workspaceOpQuads(cgId, 'opAold', 'urn:root:Aold', bucketAMeta, stale),
       { graph: bucketAData, subject: 'urn:root:Aold', predicate: `${DKG_NS}label`, object: '"A-stale-should-be-excluded"' },
@@ -243,6 +247,7 @@ describe('oversized responder fallback is store-bounded and set-equivalent', () 
     const joined = [...canonical].join('\n');
     expect(joined).toContain('"A-root-row"');
     expect(joined).toContain('"A-skolem-row"');
+    expect(joined).toContain('"A-generated-only-skolem-row"');
     expect(joined).toContain('"B-root-row"');
     expect(joined).not.toContain('A-stale-should-be-excluded');
     expect(joined).not.toContain('orphan-should-be-excluded');

--- a/packages/agent/test/sync-responder-snapshot-cache.test.ts
+++ b/packages/agent/test/sync-responder-snapshot-cache.test.ts
@@ -115,6 +115,33 @@ describe('sync responder snapshot budget defaults', () => {
 });
 
 describe('fresh SWM data graph-plan memo', () => {
+  it('coalesces concurrent loads from the same refresh generation', async () => {
+    const memo = createResponderFreshSwmDataGraphPlanMemo();
+    const gate = deferred<{ entries: []; totalRows: number }>();
+    let loads = 0;
+    const load = () => {
+      loads += 1;
+      return gate.promise;
+    };
+
+    const first = memo.get('peer/cg', load, {
+      refresh: true,
+      refreshGeneration: 'session-a',
+    });
+    const second = memo.get('peer/cg', load, {
+      refresh: true,
+      refreshGeneration: 'session-a',
+    });
+
+    await Promise.resolve();
+    expect(loads).toBe(1);
+    const plan = { entries: [] as [], totalRows: 2 };
+    gate.resolve(plan);
+    await expect(first).resolves.toBe(plan);
+    await expect(second).resolves.toBe(plan);
+    expect(loads).toBe(1);
+  });
+
   it('does not let a refreshed session join an older in-flight plan', async () => {
     const memo = createResponderFreshSwmDataGraphPlanMemo();
     const firstGate = deferred<{ entries: []; totalRows: number }>();

--- a/packages/agent/test/sync-responder-snapshot-cache.test.ts
+++ b/packages/agent/test/sync-responder-snapshot-cache.test.ts
@@ -4,7 +4,9 @@ import {
   createResponderFreshSwmDataGraphPlanMemo,
   createResponderSyncRowListMemo,
   readDurableMetaPage,
+  readSwmDataPage,
   SyncRowSnapshotLimitError,
+  type SyncRow,
   type SyncRowListMemo,
 } from '../src/sync/responder/graph-plan.js';
 import {
@@ -173,9 +175,128 @@ describe('fresh SWM data graph-plan memo', () => {
       requireExisting: true,
     })).resolves.toMatchObject({ totalRows: 2 });
   });
+
+  it('coalesces same-generation refreshes after they wait behind an older generation', async () => {
+    const memo = createResponderFreshSwmDataGraphPlanMemo();
+    const oldGate = deferred<{ entries: []; totalRows: number }>();
+    const newGate = deferred<{ entries: []; totalRows: number }>();
+    let newLoads = 0;
+    const loadNew = () => {
+      newLoads += 1;
+      return newGate.promise;
+    };
+
+    const oldRequest = memo.get('peer/cg', () => oldGate.promise, {
+      refresh: true,
+      refreshGeneration: 'session-a',
+    });
+    const firstNewRequest = memo.get('peer/cg', loadNew, {
+      refresh: true,
+      refreshGeneration: 'session-b',
+    });
+    const secondNewRequest = memo.get('peer/cg', loadNew, {
+      refresh: true,
+      refreshGeneration: 'session-b',
+    });
+
+    await Promise.resolve();
+    expect(newLoads).toBe(0);
+    oldGate.resolve({ entries: [], totalRows: 1 });
+    await expect(oldRequest).resolves.toMatchObject({ totalRows: 1 });
+    await vi.waitFor(() => expect(newLoads).toBe(1));
+
+    const newPlan = { entries: [] as [], totalRows: 2 };
+    newGate.resolve(newPlan);
+    await expect(firstNewRequest).resolves.toBe(newPlan);
+    await expect(secondNewRequest).resolves.toBe(newPlan);
+    expect(newLoads).toBe(1);
+  });
+
+  it('threads the session generation through the fresh SWM data call site', async () => {
+    const cg = 'generation-aware-call-site';
+    const dataGraph = `did:dkg:context-graph:${cg}/_shared_memory`;
+    const metaGraph = `${dataGraph}_meta`;
+    const oldRootQuery = deferred<{
+      type: 'bindings';
+      bindings: [];
+    }>();
+    let rootQueryLoads = 0;
+    const store = {
+      query: async (sparql: string) => {
+        if (!sparql.includes('SELECT DISTINCT ?g ?root')) {
+          throw new Error(`unexpected query: ${sparql}`);
+        }
+        rootQueryLoads += 1;
+        if (rootQueryLoads === 1) return oldRootQuery.promise;
+        return { type: 'bindings' as const, bindings: [] };
+      },
+    } as unknown as OxigraphStore;
+    const memo = createResponderFreshSwmDataGraphPlanMemo();
+    const request = (refreshGeneration: string) => readSwmDataPage({
+      store,
+      graphList: [dataGraph, metaGraph],
+      registeredSubGraphNames: [],
+      contextGraphId: cg,
+      cutoffIso: '2020-01-01T00:00:00.000Z',
+      offset: 0,
+      limit: 10,
+      rowListCacheKey: `${cg}:swm-data`,
+      refreshRowList: true,
+      refreshGeneration,
+      freshGraphPlanMemo: memo,
+    });
+
+    const oldRequest = request('session-a');
+    await vi.waitFor(() => expect(rootQueryLoads).toBe(1));
+    const newRequest = request('session-b');
+    await Promise.resolve();
+    expect(rootQueryLoads).toBe(1);
+
+    oldRootQuery.resolve({ type: 'bindings', bindings: [] });
+    await expect(oldRequest).resolves.toEqual([]);
+    await vi.waitFor(() => expect(rootQueryLoads).toBe(2));
+    await expect(newRequest).resolves.toEqual([]);
+  });
 });
 
 describe('sync responder snapshot cache and budget', () => {
+  it('coalesces same-generation snapshot reloads queued behind an older generation', async () => {
+    const memo = createResponderSyncRowListMemo(10_000);
+    const oldGate = deferred<readonly SyncRow[]>();
+    const newGate = deferred<readonly SyncRow[]>();
+    let newLoads = 0;
+    const loadNew = () => {
+      newLoads += 1;
+      return newGate.promise;
+    };
+    const oldRequest = memo.get('durable-meta:peer:cg', () => oldGate.promise, {
+      refresh: true,
+      refreshGeneration: 'session-a',
+    });
+    const firstNewRequest = memo.get('durable-meta:peer:cg', loadNew, {
+      refresh: true,
+      refreshGeneration: 'session-b',
+    });
+    const secondNewRequest = memo.get('durable-meta:peer:cg', loadNew, {
+      refresh: true,
+      refreshGeneration: 'session-b',
+    });
+
+    oldGate.resolve([]);
+    await expect(oldRequest).resolves.toEqual([]);
+    await vi.waitFor(() => expect(newLoads).toBe(1));
+    const freshRows: readonly SyncRow[] = [{
+      s: 'urn:memo:fresh',
+      p: `${DKG_NS}label`,
+      o: '"fresh"',
+      g: 'urn:memo:graph',
+    }];
+    newGate.resolve(freshRows);
+    await expect(firstNewRequest).resolves.toBe(freshRows);
+    await expect(secondNewRequest).resolves.toBe(freshRows);
+    expect(newLoads).toBe(1);
+  });
+
   it('reloads a new session after an older snapshot load is already in flight', async () => {
     const memo = createResponderSyncRowListMemo(10_000);
     const oldLoad = deferred<readonly {

--- a/packages/agent/test/sync-responder-snapshot-cache.test.ts
+++ b/packages/agent/test/sync-responder-snapshot-cache.test.ts
@@ -176,6 +176,35 @@ describe('fresh SWM data graph-plan memo', () => {
     })).resolves.toMatchObject({ totalRows: 2 });
   });
 
+  it('does not inherit an older generation plan failure', async () => {
+    const memo = createResponderFreshSwmDataGraphPlanMemo();
+    const oldGate = deferred<{ entries: []; totalRows: number }>();
+    const newGate = deferred<{ entries: []; totalRows: number }>();
+    let newLoads = 0;
+
+    const oldRequest = memo.get('peer/cg', () => oldGate.promise, {
+      refresh: true,
+      refreshGeneration: 'session-a',
+    });
+    const newRequest = memo.get('peer/cg', () => {
+      newLoads += 1;
+      return newGate.promise;
+    }, {
+      refresh: true,
+      refreshGeneration: 'session-b',
+    });
+
+    await Promise.resolve();
+    expect(newLoads).toBe(0);
+    oldGate.reject(new Error('older plan load failed'));
+    await expect(oldRequest).rejects.toThrow('older plan load failed');
+    await vi.waitFor(() => expect(newLoads).toBe(1));
+
+    const freshPlan = { entries: [] as [], totalRows: 2 };
+    newGate.resolve(freshPlan);
+    await expect(newRequest).resolves.toBe(freshPlan);
+  });
+
   it('coalesces same-generation refreshes after they wait behind an older generation', async () => {
     const memo = createResponderFreshSwmDataGraphPlanMemo();
     const oldGate = deferred<{ entries: []; totalRows: number }>();

--- a/packages/agent/test/sync-responder-snapshot-cache.test.ts
+++ b/packages/agent/test/sync-responder-snapshot-cache.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, it, expect, vi } from 'vitest';
 import { OxigraphStore } from '@origintrail-official/dkg-storage';
 import {
+  createResponderFreshSwmDataGraphPlanMemo,
   createResponderSyncRowListMemo,
   readDurableMetaPage,
   SyncRowSnapshotLimitError,
@@ -110,6 +111,40 @@ describe('sync responder snapshot budget defaults', () => {
     });
     expect(warnings).toHaveLength(3);
     expect(warnings[0]).toContain('DKG_SYNC_RESPONDER_GLOBAL_SNAPSHOT_ROW_LIMIT');
+  });
+});
+
+describe('fresh SWM data graph-plan memo', () => {
+  it('does not let a refreshed session join an older in-flight plan', async () => {
+    const memo = createResponderFreshSwmDataGraphPlanMemo();
+    const firstGate = deferred<{ entries: []; totalRows: number }>();
+    const secondGate = deferred<{ entries: []; totalRows: number }>();
+    let secondLoads = 0;
+
+    const first = memo.get('peer/cg', () => firstGate.promise, {
+      refresh: true,
+      refreshGeneration: 'session-a',
+    });
+    const second = memo.get('peer/cg', () => {
+      secondLoads += 1;
+      return secondGate.promise;
+    }, {
+      refresh: true,
+      refreshGeneration: 'session-b',
+    });
+
+    await Promise.resolve();
+    expect(secondLoads).toBe(0);
+    firstGate.resolve({ entries: [], totalRows: 1 });
+    await expect(first).resolves.toMatchObject({ totalRows: 1 });
+    while (secondLoads === 0) await new Promise((resolve) => setTimeout(resolve, 0));
+    secondGate.resolve({ entries: [], totalRows: 2 });
+    await expect(second).resolves.toMatchObject({ totalRows: 2 });
+
+    await expect(memo.get('peer/cg', async () => ({ entries: [], totalRows: 3 }), {
+      refreshGeneration: 'session-b',
+      requireExisting: true,
+    })).resolves.toMatchObject({ totalRows: 2 });
   });
 });
 

--- a/packages/cli/test/status-route-store-quads.test.ts
+++ b/packages/cli/test/status-route-store-quads.test.ts
@@ -33,7 +33,7 @@ function deferred<T>(): Deferred<T> {
   return { promise, resolve, reject };
 }
 
-async function startStatusServer(query: () => Promise<unknown>): Promise<{
+async function startStatusServer(query: (...args: unknown[]) => Promise<unknown>): Promise<{
   server: Server;
   baseUrl: string;
 }> {
@@ -131,9 +131,9 @@ describe('/api/status external-store quad count', () => {
   it('returns a pending cold count without waiting for the store refresh', async () => {
     const countResult = deferred<unknown>();
     const queryStarted = deferred<void>();
-    let queryCalls = 0;
-    const { server, baseUrl } = await startStatusServer(async () => {
-      queryCalls += 1;
+    const queryCalls: unknown[][] = [];
+    const { server, baseUrl } = await startStatusServer(async (...args: unknown[]) => {
+      queryCalls.push(args);
       queryStarted.resolve();
       return countResult.promise;
     });
@@ -165,7 +165,11 @@ describe('/api/status external-store quad count', () => {
         status: 200,
         body: { storeQuads: null, storeQuadsStatus: 'pending' },
       });
-      expect(queryCalls).toBe(1);
+      expect(queryCalls).toHaveLength(1);
+      expect(queryCalls[0]?.[1]).toEqual({
+        priority: 'health',
+        source: 'daemon.status.storeQuads',
+      });
     } finally {
       countResult.resolve({ type: 'bindings', bindings: [] });
       await closeServer(server);

--- a/packages/node-ui/test/db.test.ts
+++ b/packages/node-ui/test/db.test.ts
@@ -1165,6 +1165,52 @@ describe('DashboardDB — context graph subscriptions', () => {
 });
 
 describe('DashboardDB — durable VM reconcile negative cache', () => {
+  it('migrates an existing schema-28 database before durable cache use', () => {
+    const dbPath = join(dir, 'node-ui.db');
+    db.close();
+
+    const raw = new Database(dbPath);
+    raw.exec(`
+      DROP INDEX IF EXISTS idx_vm_reconcile_negative_cg;
+      DROP INDEX IF EXISTS idx_vm_reconcile_negative_retry;
+      DROP TABLE IF EXISTS vm_reconcile_negative_cache;
+    `);
+    raw.pragma('user_version = 28');
+    raw.close();
+
+    db = new DashboardDB({ dataDir: dir });
+    expect(db.db.pragma('user_version', { simple: true })).toBe(29);
+    const schemaObjects = (db.db.prepare(`
+      SELECT name FROM sqlite_master
+      WHERE name IN (
+        'vm_reconcile_negative_cache',
+        'idx_vm_reconcile_negative_cg',
+        'idx_vm_reconcile_negative_retry'
+      )
+      ORDER BY name
+    `).all() as Array<{ name: string }>).map((row) => row.name);
+    expect(schemaObjects).toEqual([
+      'idx_vm_reconcile_negative_cg',
+      'idx_vm_reconcile_negative_retry',
+      'vm_reconcile_negative_cache',
+    ]);
+
+    db.upsertVmReconcileNegative({
+      cache_key: 'migrated-cg\0ual#root',
+      context_graph_id: 'migrated-cg',
+      failures: 1,
+      next_retry_at: 42_000,
+      swm_gen: 'migrated-generation',
+      candidate_namespaces: '[]',
+      peer_topology_key: 'migrated-peers',
+      updated_at: 41_000,
+    });
+    expect(db.getVmReconcileNegative('migrated-cg\0ual#root')).toMatchObject({
+      context_graph_id: 'migrated-cg',
+      swm_gen: 'migrated-generation',
+    });
+  });
+
   it('round-trips and deletes restart-durable generation-gated misses', () => {
     db.upsertVmReconcileNegative({
       cache_key: 'cg\0ual#root',

--- a/packages/storage/src/adapters/sparql-http.ts
+++ b/packages/storage/src/adapters/sparql-http.ts
@@ -49,6 +49,10 @@ import {
 import { UnsupportedTripleStoreCapabilityError } from '../unsupported-capability-error.js';
 import { readResponseTextBounded } from '../http-response-limit.js';
 import {
+  isBlankNodeTerm,
+  partitionConnectedBlankNodeComponents,
+} from '../blank-node-components.js';
+import {
   assertQuadLiteralsMutf8Safe,
   getMetrics,
   JAVA_WRITE_UTF_MAX_BYTES,
@@ -808,53 +812,7 @@ function escapeString(s: string): string {
   return s.replace(/[\\"]/g, '\\$&');
 }
 
-/** True when an N-Quads term string denotes an RDF blank node (`_:label`). */
-export function isBlankNodeTerm(term: string): boolean {
-  return typeof term === 'string' && term.startsWith('_:');
-}
-
-/**
- * Partition blank-node-bearing quads into connected components: two quads are
- * connected when they share a blank-node label (directly or transitively). A
- * union-find over the blank-node labels does the grouping.
- *
- * Each component is later deleted as ONE `DELETE … WHERE …` so its shared
- * blank-node variables join correctly and any ground terms anchor the match.
- * Disjoint components must be emitted as SEPARATE statements: a single WHERE
- * holding two independent patterns is a cross-product, so if one pattern has
- * no match the whole row is empty and NOTHING is deleted — a silent
- * data-retention bug. Splitting by component avoids that.
- */
-function connectedBlankNodeComponents(quads: DKGQuad[]): DKGQuad[][] {
-  const parent = new Map<string, string>();
-  const add = (x: string) => { if (!parent.has(x)) parent.set(x, x); };
-  const find = (x: string): string => {
-    while (parent.get(x) !== x) {
-      parent.set(x, parent.get(parent.get(x)!)!); // path halving
-      x = parent.get(x)!;
-    }
-    return x;
-  };
-  const union = (a: string, b: string) => { parent.set(find(a), find(b)); };
-
-  for (const q of quads) {
-    const labels: string[] = [];
-    if (isBlankNodeTerm(q.subject)) labels.push(q.subject);
-    if (isBlankNodeTerm(q.object)) labels.push(q.object);
-    labels.forEach(add);
-    if (labels.length === 2) union(labels[0], labels[1]);
-  }
-
-  const groups = new Map<string, DKGQuad[]>();
-  for (const q of quads) {
-    const label = isBlankNodeTerm(q.subject) ? q.subject : q.object;
-    const root = find(label);
-    let arr = groups.get(root);
-    if (!arr) { arr = []; groups.set(root, arr); }
-    arr.push(q);
-  }
-  return [...groups.values()];
-}
+export { isBlankNodeTerm } from '../blank-node-components.js';
 
 /**
  * Build a spec-legal SPARQL Update that deletes exactly `quads`, including any
@@ -864,7 +822,7 @@ function connectedBlankNodeComponents(quads: DKGQuad[]): DKGQuad[][] {
  *  - Ground quads (no blank nodes) → a single `DELETE DATA { … }` block —
  *    exact and fast (identical to the legacy behaviour for the common case).
  *  - Blank-node quads → grouped into connected components ({@link
- *    connectedBlankNodeComponents}); each component becomes a
+ *    partitionConnectedBlankNodeComponents}); each component becomes a
  *    `DELETE { … } WHERE { … }` with every blank node rewritten to a fresh
  *    query variable. This is the only spec-legal way to remove existing
  *    blank-node structure over the SPARQL protocol (`DELETE DATA` forbids
@@ -910,7 +868,11 @@ export function buildBlankNodeSafeDelete(quads: DKGQuad[]): string | null {
       arr.push(q);
     }
     for (const [graph, list] of byGraph) {
-      for (const component of connectedBlankNodeComponents(list)) {
+      const components = partitionConnectedBlankNodeComponents(
+        list,
+        (q) => [q.subject, q.object],
+      );
+      for (const { items: component } of components) {
         const vars = new Map<string, string>();
         const render = (t: string): string => {
           if (!isBlankNodeTerm(t)) return formatTerm(t);

--- a/packages/storage/src/blank-node-components.ts
+++ b/packages/storage/src/blank-node-components.ts
@@ -1,0 +1,71 @@
+/** True when an N-Quads term string denotes an RDF blank node (`_:label`). */
+export function isBlankNodeTerm(term: string | undefined): term is string {
+  return typeof term === 'string' && term.startsWith('_:');
+}
+
+export interface ConnectedBlankNodeComponent<T> {
+  items: T[];
+  blankNodeLabels: Set<string>;
+  firstIndex: number;
+}
+
+/**
+ * Partition RDF-shaped items into stable, transitively connected blank-node
+ * components. Items without blank nodes remain independent singleton units.
+ *
+ * Callers choose which terms share one blank-node scope. For example, a
+ * graph-local SPARQL operation can pass subject/object after grouping by
+ * graph, while an N-Quads insert operation can also include the graph term.
+ */
+export function partitionConnectedBlankNodeComponents<T>(
+  items: readonly T[],
+  termsForItem: (item: T) => readonly (string | undefined)[],
+): ConnectedBlankNodeComponent<T>[] {
+  const parents = items.map((_, index) => index);
+  const ranks = items.map(() => 0);
+  const labelsByItem = items.map((item) => new Set(termsForItem(item).filter(isBlankNodeTerm)));
+  const firstItemByLabel = new Map<string, number>();
+
+  const find = (index: number): number => {
+    let root = index;
+    while (parents[root] !== root) root = parents[root]!;
+    while (parents[index] !== index) {
+      const next = parents[index]!;
+      parents[index] = root;
+      index = next;
+    }
+    return root;
+  };
+
+  const union = (left: number, right: number): void => {
+    let leftRoot = find(left);
+    let rightRoot = find(right);
+    if (leftRoot === rightRoot) return;
+    if (ranks[leftRoot]! < ranks[rightRoot]!) [leftRoot, rightRoot] = [rightRoot, leftRoot];
+    parents[rightRoot] = leftRoot;
+    if (ranks[leftRoot] === ranks[rightRoot]) ranks[leftRoot]! += 1;
+  };
+
+  for (let index = 0; index < items.length; index += 1) {
+    for (const label of labelsByItem[index]!) {
+      const firstIndex = firstItemByLabel.get(label);
+      if (firstIndex === undefined) firstItemByLabel.set(label, index);
+      else union(index, firstIndex);
+    }
+  }
+
+  const components = new Map<number, ConnectedBlankNodeComponent<T>>();
+  for (let index = 0; index < items.length; index += 1) {
+    const labels = labelsByItem[index]!;
+    const root = labels.size === 0 ? index : find(index);
+    let component = components.get(root);
+    if (!component) {
+      component = { items: [], blankNodeLabels: new Set(), firstIndex: index };
+      components.set(root, component);
+    }
+    component.items.push(items[index]!);
+    for (const label of labels) component.blankNodeLabels.add(label);
+  }
+
+  return [...components.values()].sort((left, right) => left.firstIndex - right.firstIndex);
+}

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -92,6 +92,11 @@ export {
 } from './bounded-rdf.js';
 export { StoreResponseTooLargeError } from './http-response-limit.js';
 export {
+  isBlankNodeTerm,
+  partitionConnectedBlankNodeComponents,
+  type ConnectedBlankNodeComponent,
+} from './blank-node-components.js';
+export {
   resolveGraphScopedOrLegacyMetadata,
   type GraphScopedOrLegacyMetadata,
 } from './graph-knowledge-asset-metadata-loader.js';

--- a/packages/storage/src/store-priority-scheduler.ts
+++ b/packages/storage/src/store-priority-scheduler.ts
@@ -84,7 +84,6 @@ interface NonAckLanePolicy {
 interface LegacyStorePrioritySchedulerArguments {
   argumentCount: number;
   ackReservedSlots?: number;
-  healthReservedSlots?: number;
   now?: () => number;
   backgroundReservedSlots?: number;
   queueLimits?: number | Partial<StorePriorityQueueLimits>;
@@ -251,7 +250,6 @@ export class StorePriorityScheduler {
     const options = normalizeStorePrioritySchedulerOptions(optionsOrMaxConcurrent, {
       argumentCount: arguments.length,
       ackReservedSlots: legacyAckReservedSlots,
-      healthReservedSlots: legacyHealthReservedSlots,
       now: legacyNow,
       backgroundReservedSlots: legacyBackgroundReservedSlots,
       queueLimits: legacyQueueLimits,

--- a/packages/storage/src/store-priority-scheduler.ts
+++ b/packages/storage/src/store-priority-scheduler.ts
@@ -84,6 +84,7 @@ interface NonAckLanePolicy {
 interface LegacyStorePrioritySchedulerArguments {
   argumentCount: number;
   ackReservedSlots?: number;
+  healthReservedSlots?: number;
   now?: () => number;
   backgroundReservedSlots?: number;
   queueLimits?: number | Partial<StorePriorityQueueLimits>;
@@ -250,6 +251,7 @@ export class StorePriorityScheduler {
     const options = normalizeStorePrioritySchedulerOptions(optionsOrMaxConcurrent, {
       argumentCount: arguments.length,
       ackReservedSlots: legacyAckReservedSlots,
+      healthReservedSlots: legacyHealthReservedSlots,
       now: legacyNow,
       backgroundReservedSlots: legacyBackgroundReservedSlots,
       queueLimits: legacyQueueLimits,

--- a/packages/storage/test/blank-node-components.test.ts
+++ b/packages/storage/test/blank-node-components.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isBlankNodeTerm,
+  partitionConnectedBlankNodeComponents,
+  type Quad,
+} from '../src/index.js';
+
+const quad = (subject: string, object: string, graph = 'urn:g'): Quad => ({
+  subject,
+  predicate: 'urn:p',
+  object,
+  graph,
+});
+
+describe('partitionConnectedBlankNodeComponents', () => {
+  it('groups shared labels transitively while preserving first-seen component order', () => {
+    const ground = quad('urn:ground', 'urn:value');
+    const first = quad('urn:a', '_:a');
+    const bridge = quad('_:a', '_:b');
+    const tail = quad('_:b', 'urn:tail');
+    const separate = quad('urn:c', '_:c');
+
+    const components = partitionConnectedBlankNodeComponents(
+      [ground, first, separate, bridge, tail],
+      (item) => [item.subject, item.object],
+    );
+
+    expect(components.map((component) => component.items)).toEqual([
+      [ground],
+      [first, bridge, tail],
+      [separate],
+    ]);
+    expect([...components[1]!.blankNodeLabels].sort()).toEqual(['_:a', '_:b']);
+  });
+
+  it('lets callers include or exclude graph-position blank nodes from the scope', () => {
+    const left = quad('urn:left', 'urn:value', '_:graph');
+    const right = quad('urn:right', 'urn:value', '_:graph');
+
+    expect(
+      partitionConnectedBlankNodeComponents([left, right], (item) => [
+        item.subject,
+        item.object,
+      ]),
+    ).toHaveLength(2);
+    expect(
+      partitionConnectedBlankNodeComponents([left, right], (item) => [
+        item.subject,
+        item.object,
+        item.graph,
+      ]),
+    ).toHaveLength(1);
+  });
+
+  it('recognizes only blank-node term strings', () => {
+    expect(isBlankNodeTerm('_:b0')).toBe(true);
+    expect(isBlankNodeTerm('urn:b0')).toBe(false);
+    expect(isBlankNodeTerm(undefined)).toBe(false);
+  });
+});

--- a/packages/storage/test/store-priority-scheduler.test.ts
+++ b/packages/storage/test/store-priority-scheduler.test.ts
@@ -192,6 +192,7 @@ describe('StorePriorityScheduler', () => {
       expect(scheduler.snapshot).toMatchObject({
         maxConcurrent: 2,
         ackReservedSlots: 0,
+        healthReservedSlots: 0,
         backgroundReservedSlots: 1,
         ackQueueLimit: 3,
         normalQueueLimit: 2,
@@ -260,6 +261,20 @@ describe('StorePriorityScheduler', () => {
       await Promise.allSettled(running);
       vi.useRealTimers();
     }
+  });
+
+  it('honors the deprecated seventh positional health reservation', () => {
+    const scheduler = new StorePriorityScheduler(
+      3,
+      1,
+      undefined,
+      0,
+      undefined,
+      1_000,
+      1,
+    );
+
+    expect(scheduler.snapshot.healthReservedSlots).toBe(1);
   });
 
   it('lets ACK work jump ahead of queued background work', async () => {


### PR DESCRIPTION
## Summary

- Coalesce equivalent finalization, reconciliation, and sync scans, and persist negative reconciliation memoization across restarts.
- Route Blazegraph and generic SPARQL HTTP work through a process-global priority scheduler with reserved ACK/health capacity and cancellation-aware slot ownership.
- Bound sync response, query, and ingest memory with frame-safe 64-row pages, a 64 MiB preflight threshold, graph/root/count paging plans, and 8 MiB insert batches.
- Stagger post-rollout reconciliation, add scan/scheduler telemetry, and use managed Oxigraph fallback for larger local devnets.

## Root cause

A rollout restarted several nodes close together, clearing process-local memo state. Startup finalization/reconciliation, sync, promotion, and health work then issued overlapping scans for the same context graphs. Timeouts retried while previous HTTP queries were still cleaning up. Unbounded `CONSTRUCT` and `Response.text()` paths amplified store and JavaScript memory pressure and could drive Oxigraph to its cgroup limit.

## Impact

Equivalent scans now join a single flight, background store work is globally bounded without starving ACK/health traffic, negative misses survive restarts with explicit invalidation, and oversized sync snapshots use bounded backend-neutral SPARQL 1.1 pages. The scheduling and bounded-scan protections apply to both Blazegraph and Oxigraph HTTP paths.

## Validation

- `pnpm --filter @origintrail-official/dkg-agent run build`
- Focused agent sync suite: 63/63 tests passed
- Storage adapter parity suite: 111/111 tests passed
- 200 MiB two-node Oxigraph devnet: exact 6,400/6,400 assets synchronized
- 1 GiB five-node update/restart simulation: exact 32,768/32,768 assets on all five nodes; node 5 retained data and peer identity through a managed Oxigraph restart
- `git diff --check`
- `bash -n scripts/devnet.sh`

## Caveats and rollout gate

- Live-volume tests used Oxigraph because Dockerized Blazegraph was unavailable; Blazegraph behavior is covered by adapter parity tests.
- A 30-minute, 10.3M-quad, 8 GiB-equivalent canary is still required before production rollout acceptance.

See `docs/active-now/oxigraph-cold-start-scan-storm.md` for the operational design and rollout guidance.
