### PR TITLE
ci: restore independent Solidity path gating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: OriginTrail/dkg
-          ref: e5f8165fdc246ed5458849256ce886b776c56320
+          ref: aba17f2e66cf48a6cd6dc06c567e1e8bd77bfb8d
           persist-credentials: false
           path: trusted-ci
           sparse-checkout: |
@@ -138,6 +138,10 @@ jobs:
             --sample-key "${SAMPLE_KEY}" \
             --github-output "${GITHUB_OUTPUT}" \
             --summary "${GITHUB_STEP_SUMMARY}"
+          if ! grep -Eq '^abi_freshness=(true|false)$' "${GITHUB_OUTPUT}"; then
+            echo "::error::Trusted CI controller did not emit abi_freshness"
+            exit 1
+          fi
       # Package README files are documentation for routing purposes, but they
       # are also npm metadata. Candidate code runs only after the trusted plan
       # has finalized its outputs, so it cannot influence test selection.
@@ -1398,7 +1402,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: OriginTrail/dkg
-          ref: e5f8165fdc246ed5458849256ce886b776c56320
+          ref: aba17f2e66cf48a6cd6dc06c567e1e8bd77bfb8d
           persist-credentials: false
           path: trusted-ci
           sparse-checkout: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: OriginTrail/dkg
-          ref: 342e811260dd320f96140cc10f128ee4a54732a3
+          ref: e5f8165fdc246ed5458849256ce886b776c56320
           persist-credentials: false
           path: trusted-ci
           sparse-checkout: |
@@ -1396,7 +1396,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: OriginTrail/dkg
-          ref: 342e811260dd320f96140cc10f128ee4a54732a3
+          ref: e5f8165fdc246ed5458849256ce886b776c56320
           persist-credentials: false
           path: trusted-ci
           sparse-checkout: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 # Trigger rules:
 #   * pull_request : fail-closed delta plan for fast iteration. Label changes
 #                    retrigger the workflow so `ci:full` is an override.
-#   * merge_group : every Node/EVM lane against the exact pre-merge candidate.
+#   * merge_group : full CI against the exact pre-merge candidate.
 #   * protected push / manual dispatch : full CI safety net.
 #   * No `push` trigger on feature branches (e.g. `test/**`). When a PR
 #     is open, the `pull_request` event already covers every new commit;
@@ -42,9 +42,10 @@ jobs:
   # ------------------------------------------------------------------
   # Produce one fail-closed test plan for every workflow in this repository.
   # PRs run the affected package lane plus declared downstream consumers.
-  # Protected pushes and manual runs select every lane. Merge queue candidates,
-  # global/unknown changes, package manifests, large changes, and `ci:full` run
-  # every Node/EVM lane; Solidity retains its independent PR path gate.
+  # Protected pushes, manual runs, and merge queue candidates select every
+  # lane. Global/unknown changes, package manifests, large changes, and
+  # `ci:full` run every Node/EVM lane; Solidity retains its independent PR
+  # path gate.
   # ------------------------------------------------------------------
   changes:
     name: Plan CI delta
@@ -85,7 +86,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: OriginTrail/dkg
-          ref: 29158635894980100917e2a3fd2233ac45e7d16f
+          ref: 342e811260dd320f96140cc10f128ee4a54732a3
           persist-credentials: false
           path: trusted-ci
           sparse-checkout: |
@@ -1017,8 +1018,8 @@ jobs:
   #   - PR + contract changes    : 4-way sharded hardhat test, no
   #                                coverage (~5-6 min per shard in
   #                                parallel; previously ~20 min single).
-  #   - merge queue candidate    : no duplicate Solidity run; contract PRs
-  #                                already ran this suite before entering it.
+  #   - merge queue candidate    : same sharded suite against the exact
+  #                                combined commit that is about to land.
   #   - push (main / v10-rc / …) : full coverage + ratchet safety net,
   #                                single job (coverage reports don't
   #                                compose across shards, so we keep
@@ -1029,9 +1030,9 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    # PR lane only — sharded 4 ways. Protected pushes and manual runs use the
-    # separate coverage+ratchet job below; merge queue does not duplicate it.
-    if: github.event_name == 'pull_request' && needs.changes.outputs.contracts == 'true'
+    # Candidate lane — sharded 4 ways. Protected pushes and manual runs use the
+    # separate coverage+ratchet job below.
+    if: (github.event_name == 'pull_request' || github.event_name == 'merge_group') && needs.changes.outputs.contracts == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -1395,7 +1396,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: OriginTrail/dkg
-          ref: 29158635894980100917e2a3fd2233ac45e7d16f
+          ref: 342e811260dd320f96140cc10f128ee4a54732a3
           persist-credentials: false
           path: trusted-ci
           sparse-checkout: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,6 @@ jobs:
     outputs:
       full_ci: ${{ steps.plan.outputs.full_ci }}
       run_node: ${{ steps.plan.outputs.run_node }}
-      abi_freshness: ${{ steps.plan.outputs.abi_freshness }}
       tornado_core: ${{ steps.plan.outputs.tornado_core }}
       tornado_blazegraph: ${{ steps.plan.outputs.tornado_blazegraph }}
       tornado_publisher: ${{ steps.plan.outputs.tornado_publisher }}
@@ -87,7 +86,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: OriginTrail/dkg
-          ref: aba17f2e66cf48a6cd6dc06c567e1e8bd77bfb8d
+          ref: c441bd6766ace67e331c0dfc6e22cb1325a6e1f6
           persist-credentials: false
           path: trusted-ci
           sparse-checkout: |
@@ -138,10 +137,6 @@ jobs:
             --sample-key "${SAMPLE_KEY}" \
             --github-output "${GITHUB_OUTPUT}" \
             --summary "${GITHUB_STEP_SUMMARY}"
-          if ! grep -Eq '^abi_freshness=(true|false)$' "${GITHUB_OUTPUT}"; then
-            echo "::error::Trusted CI controller did not emit abi_freshness"
-            exit 1
-          fi
       # Package README files are documentation for routing purposes, but they
       # are also npm metadata. Candidate code runs only after the trusted plan
       # has finalized its outputs, so it cannot influence test selection.
@@ -946,17 +941,18 @@ jobs:
   #
   # This job catches the only way that contract can break: a contributor
   # changes a `.sol` file and forgets to commit the regenerated ABIs.
-  # Runs when contract/compiler inputs or committed ABI files change. Solidity
-  # test relevance stays independent, so ABI-only PRs pay for this gate but
-  # not the four Hardhat shards. On failure prints an explicit
-  # remediation command so the fix is one copy-paste away.
+  # The controller changes in this PR are not trusted until they land on the
+  # protected default branch. During that first rollout phase, run this cheap
+  # gate unconditionally instead of pinning workflows to candidate history.
+  # A follow-up may rotate the immutable controller and restore path selection.
+  # On failure prints an explicit remediation command so the fix is one
+  # copy-paste away.
   # ------------------------------------------------------------------
   abi-freshness:
     name: "Tornado: ABI freshness (committed abi/ vs hardhat compile)"
     needs: changes
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: needs.changes.outputs.abi_freshness == 'true'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -1402,7 +1398,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: OriginTrail/dkg
-          ref: aba17f2e66cf48a6cd6dc06c567e1e8bd77bfb8d
+          ref: c441bd6766ace67e331c0dfc6e22cb1325a6e1f6
           persist-credentials: false
           path: trusted-ci
           sparse-checkout: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 # Trigger rules:
 #   * pull_request : fail-closed delta plan for fast iteration. Label changes
 #                    retrigger the workflow so `ci:full` is an override.
-#   * merge_group : full CI against the exact pre-merge candidate.
+#   * merge_group : every Node/EVM lane against the exact pre-merge candidate.
 #   * protected push / manual dispatch : full CI safety net.
 #   * No `push` trigger on feature branches (e.g. `test/**`). When a PR
 #     is open, the `pull_request` event already covers every new commit;
@@ -42,8 +42,9 @@ jobs:
   # ------------------------------------------------------------------
   # Produce one fail-closed test plan for every workflow in this repository.
   # PRs run the affected package lane plus declared downstream consumers.
-  # Protected pushes, merge queue candidates, manual runs, global/unknown
-  # changes, package manifests, large changes, and `ci:full` run everything.
+  # Protected pushes and manual runs select every lane. Merge queue candidates,
+  # global/unknown changes, package manifests, large changes, and `ci:full` run
+  # every Node/EVM lane; Solidity retains its independent PR path gate.
   # ------------------------------------------------------------------
   changes:
     name: Plan CI delta
@@ -84,7 +85,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: OriginTrail/dkg
-          ref: c441bd6766ace67e331c0dfc6e22cb1325a6e1f6
+          ref: 29158635894980100917e2a3fd2233ac45e7d16f
           persist-credentials: false
           path: trusted-ci
           sparse-checkout: |
@@ -1016,8 +1017,8 @@ jobs:
   #   - PR + contract changes    : 4-way sharded hardhat test, no
   #                                coverage (~5-6 min per shard in
   #                                parallel; previously ~20 min single).
-  #   - merge queue candidate    : same sharded full test suite as a PR,
-  #                                keeping the pre-merge critical path short.
+  #   - merge queue candidate    : no duplicate Solidity run; contract PRs
+  #                                already ran this suite before entering it.
   #   - push (main / v10-rc / …) : full coverage + ratchet safety net,
   #                                single job (coverage reports don't
   #                                compose across shards, so we keep
@@ -1028,9 +1029,9 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    # Candidate lane only — sharded 4 ways. Protected pushes and manual runs
-    # use the separate coverage+ratchet job below.
-    if: (github.event_name == 'pull_request' || github.event_name == 'merge_group') && needs.changes.outputs.contracts == 'true'
+    # PR lane only — sharded 4 ways. Protected pushes and manual runs use the
+    # separate coverage+ratchet job below; merge queue does not duplicate it.
+    if: github.event_name == 'pull_request' && needs.changes.outputs.contracts == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -1394,7 +1395,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: OriginTrail/dkg
-          ref: c441bd6766ace67e331c0dfc6e22cb1325a6e1f6
+          ref: 29158635894980100917e2a3fd2233ac45e7d16f
           persist-credentials: false
           path: trusted-ci
           sparse-checkout: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
     outputs:
       full_ci: ${{ steps.plan.outputs.full_ci }}
       run_node: ${{ steps.plan.outputs.run_node }}
+      abi_freshness: ${{ steps.plan.outputs.abi_freshness }}
       tornado_core: ${{ steps.plan.outputs.tornado_core }}
       tornado_blazegraph: ${{ steps.plan.outputs.tornado_blazegraph }}
       tornado_publisher: ${{ steps.plan.outputs.tornado_publisher }}
@@ -941,8 +942,9 @@ jobs:
   #
   # This job catches the only way that contract can break: a contributor
   # changes a `.sol` file and forgets to commit the regenerated ABIs.
-  # Runs only when `changes.outputs.contracts == 'true'` so PRs that
-  # don't touch contracts pay zero cost. On failure prints an explicit
+  # Runs when contract/compiler inputs or committed ABI files change. Solidity
+  # test relevance stays independent, so ABI-only PRs pay for this gate but
+  # not the four Hardhat shards. On failure prints an explicit
   # remediation command so the fix is one copy-paste away.
   # ------------------------------------------------------------------
   abi-freshness:
@@ -950,7 +952,7 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: needs.changes.outputs.contracts == 'true'
+    if: needs.changes.outputs.abi_freshness == 'true'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/evm-integration.yml
+++ b/.github/workflows/evm-integration.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: OriginTrail/dkg
-          ref: aba17f2e66cf48a6cd6dc06c567e1e8bd77bfb8d
+          ref: c441bd6766ace67e331c0dfc6e22cb1325a6e1f6
           persist-credentials: false
           path: trusted-ci
           sparse-checkout: |
@@ -147,7 +147,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: OriginTrail/dkg
-          ref: aba17f2e66cf48a6cd6dc06c567e1e8bd77bfb8d
+          ref: c441bd6766ace67e331c0dfc6e22cb1325a6e1f6
           persist-credentials: false
           path: trusted-ci
           sparse-checkout: |

--- a/.github/workflows/evm-integration.yml
+++ b/.github/workflows/evm-integration.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: OriginTrail/dkg
-          ref: 29158635894980100917e2a3fd2233ac45e7d16f
+          ref: 342e811260dd320f96140cc10f128ee4a54732a3
           persist-credentials: false
           path: trusted-ci
           sparse-checkout: |
@@ -147,7 +147,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: OriginTrail/dkg
-          ref: 29158635894980100917e2a3fd2233ac45e7d16f
+          ref: 342e811260dd320f96140cc10f128ee4a54732a3
           persist-credentials: false
           path: trusted-ci
           sparse-checkout: |

--- a/.github/workflows/evm-integration.yml
+++ b/.github/workflows/evm-integration.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: OriginTrail/dkg
-          ref: 342e811260dd320f96140cc10f128ee4a54732a3
+          ref: e5f8165fdc246ed5458849256ce886b776c56320
           persist-credentials: false
           path: trusted-ci
           sparse-checkout: |
@@ -147,7 +147,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: OriginTrail/dkg
-          ref: 342e811260dd320f96140cc10f128ee4a54732a3
+          ref: e5f8165fdc246ed5458849256ce886b776c56320
           persist-credentials: false
           path: trusted-ci
           sparse-checkout: |

--- a/.github/workflows/evm-integration.yml
+++ b/.github/workflows/evm-integration.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: OriginTrail/dkg
-          ref: e5f8165fdc246ed5458849256ce886b776c56320
+          ref: aba17f2e66cf48a6cd6dc06c567e1e8bd77bfb8d
           persist-credentials: false
           path: trusted-ci
           sparse-checkout: |
@@ -147,7 +147,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: OriginTrail/dkg
-          ref: e5f8165fdc246ed5458849256ce886b776c56320
+          ref: aba17f2e66cf48a6cd6dc06c567e1e8bd77bfb8d
           persist-credentials: false
           path: trusted-ci
           sparse-checkout: |

--- a/.github/workflows/evm-integration.yml
+++ b/.github/workflows/evm-integration.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: OriginTrail/dkg
-          ref: c441bd6766ace67e331c0dfc6e22cb1325a6e1f6
+          ref: 29158635894980100917e2a3fd2233ac45e7d16f
           persist-credentials: false
           path: trusted-ci
           sparse-checkout: |
@@ -147,7 +147,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: OriginTrail/dkg
-          ref: c441bd6766ace67e331c0dfc6e22cb1325a6e1f6
+          ref: 29158635894980100917e2a3fd2233ac45e7d16f
           persist-credentials: false
           path: trusted-ci
           sparse-checkout: |

--- a/docs/ci-delta-policy.md
+++ b/docs/ci-delta-policy.md
@@ -6,9 +6,10 @@ Use affected-lane CI for pull-request feedback, then run every Node/EVM lane
 against the exact merge candidate in GitHub's merge queue. Keep full CI on
 protected-branch pushes and manual dispatches. Solidity remains independently
 path-gated on pull requests: contract-relevant PRs run the four Hardhat shards,
-while protected pushes run the full coverage ratchet after merge. Do not add a
-`develop` branch solely for CI: that would postpone integration failures and
-collect unrelated changes into a large `develop -> main` batch.
+merge candidates rerun them against the exact combined commit, and protected
+pushes run the full coverage ratchet after merge. Do not add a `develop` branch
+solely for CI: that would postpone integration failures and collect unrelated
+changes into a large `develop -> main` batch.
 
 The delta planner is deliberately conservative. It selects the changed
 workspace's owning lane plus known downstream consumers, and falls back to full
@@ -28,7 +29,7 @@ CI whenever it cannot prove that a smaller plan is safe.
 | More than 100 production files or at least 4 workspaces | Full CI |
 | PR with `ci:full` label | Full Node/EVM CI; Solidity remains path-gated |
 | Deterministic 5% PR audit sample | Full Node/EVM CI; Solidity remains path-gated |
-| Merge queue | Every Node/EVM lane; no duplicate Solidity run |
+| Merge queue | Every Node/EVM lane plus sharded Solidity on the exact candidate |
 | Protected-branch push or manual dispatch | Full CI, including Solidity coverage |
 
 The planner reads `git diff --name-status -z`, so spaces and other shell-hostile
@@ -47,10 +48,9 @@ file names cannot alter the decision. Its routing table lives in
 - Unknown inputs fail closed to full CI instead of silently receiving no tests.
 - `CI gate` and `EVM integration gate` are always present. They fail when a
   selected job was accidentally skipped, failed, or was cancelled.
-- The merge queue tests every Node/EVM lane against the exact combined commit
-  before it lands. Contract-relevant PRs have already run the sharded Solidity
-  suite, and protected-branch Solidity coverage remains the post-merge safety
-  net.
+- The merge queue tests every Node/EVM lane and the sharded Solidity suite
+  against the exact combined commit before it lands. Protected-branch Solidity
+  coverage remains the post-merge safety net.
 - Five percent of PR commits run full CI even when delta would be possible. This
   continuously audits the routing model and exposes a missing dependency edge.
 - The routing tests enumerate all package/demo workspaces with a `test` script.

--- a/docs/ci-delta-policy.md
+++ b/docs/ci-delta-policy.md
@@ -48,6 +48,19 @@ file names cannot alter the decision. Its routing table lives in
 - Unknown inputs fail closed to full CI instead of silently receiving no tests.
 - `CI gate` and `EVM integration gate` are always present. They fail when a
   selected job was accidentally skipped, failed, or was cancelled.
+- CI controller changes use a two-phase rollout. The controller implementation
+  lands first while every workflow remains pinned to an immutable SHA already
+  present on protected `main`. Only a follow-up PR may rotate that pin to the
+  landed controller. During this rollout, ABI freshness runs unconditionally,
+  so candidate code cannot suppress it by choosing its own planner.
+
+  Before any follow-up rotates the pin, fetch protected `main` and require this
+  command to exit zero for the proposed immutable SHA:
+
+  ```sh
+  git fetch origin main
+  git merge-base --is-ancestor <controller-sha> origin/main
+  ```
 - The merge queue tests every Node/EVM lane and the sharded Solidity suite
   against the exact combined commit before it lands. Protected-branch Solidity
   coverage remains the post-merge safety net.

--- a/docs/ci-delta-policy.md
+++ b/docs/ci-delta-policy.md
@@ -2,11 +2,13 @@
 
 ## Decision
 
-Use affected-lane CI for pull-request feedback, then run full CI against the
-exact merge candidate in GitHub's merge queue. Keep full CI on protected-branch
-pushes and manual dispatches. Do not add a `develop` branch solely for CI: that
-would postpone integration failures and collect unrelated changes into a large
-`develop -> main` batch.
+Use affected-lane CI for pull-request feedback, then run every Node/EVM lane
+against the exact merge candidate in GitHub's merge queue. Keep full CI on
+protected-branch pushes and manual dispatches. Solidity remains independently
+path-gated on pull requests: contract-relevant PRs run the four Hardhat shards,
+while protected pushes run the full coverage ratchet after merge. Do not add a
+`develop` branch solely for CI: that would postpone integration failures and
+collect unrelated changes into a large `develop -> main` batch.
 
 The delta planner is deliberately conservative. It selects the changed
 workspace's owning lane plus known downstream consumers, and falls back to full
@@ -19,14 +21,15 @@ CI whenever it cannot prove that a smaller plan is safe.
 | Pull request, known workspace | Owning lane plus declared downstream unit/integration lanes |
 | Documentation only | Planner and aggregate gates only |
 | `core` / `rdf-utils` | All downstream Node and real-EVM lanes |
-| `evm-module` | Full CI, including Solidity |
-| Root dependency/build config, workflow, planner, or generic scripts | Full CI |
+| `evm-module` | Full Node/EVM CI; Solidity only for the established contract-relevant paths |
+| Root dependency/build config, workflow, planner, or generic scripts | Full Node/EVM CI; Solidity only when its independent path filter matches |
 | Any workspace `package.json` | Full CI because the base and head dependency graphs may differ |
 | Rename, copy, deletion, unknown path, or no diff | Full CI |
 | More than 100 production files or at least 4 workspaces | Full CI |
-| PR with `ci:full` label | Full CI |
-| Deterministic 5% PR audit sample | Full CI |
-| Merge queue, protected-branch push, or manual dispatch | Full CI |
+| PR with `ci:full` label | Full Node/EVM CI; Solidity remains path-gated |
+| Deterministic 5% PR audit sample | Full Node/EVM CI; Solidity remains path-gated |
+| Merge queue | Every Node/EVM lane; no duplicate Solidity run |
+| Protected-branch push or manual dispatch | Full CI, including Solidity coverage |
 
 The planner reads `git diff --name-status -z`, so spaces and other shell-hostile
 file names cannot alter the decision. Its routing table lives in
@@ -44,8 +47,10 @@ file names cannot alter the decision. Its routing table lives in
 - Unknown inputs fail closed to full CI instead of silently receiving no tests.
 - `CI gate` and `EVM integration gate` are always present. They fail when a
   selected job was accidentally skipped, failed, or was cancelled.
-- Full merge-queue CI tests the exact combined commit before it lands. Full
-  protected-branch CI remains a second safety net after merge.
+- The merge queue tests every Node/EVM lane against the exact combined commit
+  before it lands. Contract-relevant PRs have already run the sharded Solidity
+  suite, and protected-branch Solidity coverage remains the post-merge safety
+  net.
 - Five percent of PR commits run full CI even when delta would be possible. This
   continuously audits the routing model and exposes a missing dependency edge.
 - The routing tests enumerate all package/demo workspaces with a `test` script.
@@ -60,8 +65,9 @@ correctness gate.
 ## Required repository settings
 
 Delta selection is **default-off**. Until the repository variable
-`CI_DELTA_ENABLED` is exactly `true`, PRs deliberately receive full CI. Activate
-it only after all safeguards below are configured:
+`CI_DELTA_ENABLED` is exactly `true`, PRs deliberately receive full Node/EVM CI.
+The independent Solidity path gate still applies. Activate delta only after all
+safeguards below are configured:
 
 1. Create the `ci:full` label.
 2. Enable GitHub merge queue for `main`.

--- a/scripts/lib/__tests__/ci-delta.test.mjs
+++ b/scripts/lib/__tests__/ci-delta.test.mjs
@@ -77,6 +77,21 @@ test('unknown PR diffs fail closed with Solidity selected and enforced', () => {
   assert.deepEqual(selectedLanes(plan), CI_LANES);
   assert.match(plan.reasons.join('\n'), /failing closed/);
 
+  for (const [name, overridePlan] of [
+    ['ci:full', pullRequestPlan([], { labels: ['ci:full'] })],
+    ['audit sample', pullRequestPlan([], { sampleKey: '00000000ffffffff' })],
+    ['delta disabled', planCi({
+      eventName: 'pull_request_delta_disabled',
+      changeEntries: [],
+    })],
+  ]) {
+    assert.equal(overridePlan.mode, 'full', name);
+    assert.equal(overridePlan.lanes.contracts, true, name);
+    assert.equal(overridePlan.abiFreshnessRelevant, true, name);
+    assert.deepEqual(selectedLanes(overridePlan), CI_LANES, name);
+    assert.match(overridePlan.reasons.join('\n'), /failing closed/, name);
+  }
+
   const needs = {
     changes: { result: 'success' },
     build: { result: 'success' },

--- a/scripts/lib/__tests__/ci-delta.test.mjs
+++ b/scripts/lib/__tests__/ci-delta.test.mjs
@@ -22,7 +22,7 @@ import {
 } from '../ci-results.mjs';
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
-const TRUSTED_CI_CONTROLLER_SHA = '29158635894980100917e2a3fd2233ac45e7d16f';
+const TRUSTED_CI_CONTROLLER_SHA = '342e811260dd320f96140cc10f128ee4a54732a3';
 const NON_SOLIDITY_LANES = CI_LANES.filter((lane) => lane !== 'contracts');
 
 function change(filePath, status = 'M') {
@@ -505,14 +505,9 @@ test('every planner output is wired to a real workflow job and omitted tests sta
   assert.ok(workflow.includes("needs.changes.outputs.contracts == 'true'"));
   assert.ok(
     workflow.includes(
-      "if: github.event_name == 'pull_request' && needs.changes.outputs.contracts == 'true'",
+      "if: (github.event_name == 'pull_request' || github.event_name == 'merge_group') && needs.changes.outputs.contracts == 'true'",
     ),
-    'the sharded Solidity suite must run only on contract-relevant pull requests',
-  );
-  assert.equal(
-    workflow.includes("github.event_name == 'merge_group') && needs.changes.outputs.contracts"),
-    false,
-    'merge queue must not duplicate the Solidity suite already run on the pull request',
+    'the sharded Solidity suite must protect contract PRs and exact merge candidates',
   );
   assert.ok(
     workflow.includes('run: node candidate/scripts/check-npm-metadata.mjs'),

--- a/scripts/lib/__tests__/ci-delta.test.mjs
+++ b/scripts/lib/__tests__/ci-delta.test.mjs
@@ -23,6 +23,7 @@ import {
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
 const TRUSTED_CI_CONTROLLER_SHA = 'c441bd6766ace67e331c0dfc6e22cb1325a6e1f6';
+const NON_SOLIDITY_LANES = CI_LANES.filter((lane) => lane !== 'contracts');
 
 function change(filePath, status = 'M') {
   return { status, paths: [filePath] };
@@ -49,7 +50,7 @@ test('parses NUL-delimited git name-status output without shell-splitting file n
   ]);
 });
 
-test('push, merge queue, manual, and explicit label plans are always full', () => {
+test('non-PR events run every lane while full-PR overrides preserve the Solidity gate', () => {
   for (const eventName of ['push', 'merge_group', 'workflow_dispatch']) {
     const plan = planCi({ eventName });
     assert.equal(plan.fullCi, true, eventName);
@@ -59,6 +60,8 @@ test('push, merge queue, manual, and explicit label plans are always full', () =
 
   const labeled = pullRequestPlan([change('CHANGELOG.md')], { labels: ['ci:full'] });
   assert.equal(labeled.fullCi, true);
+  assert.deepEqual(selectedLanes(labeled), NON_SOLIDITY_LANES);
+  assert.deepEqual(labeled.evmScopes, EVM_SCOPES);
 });
 
 test('five percent of PR SHAs are deterministic full-CI audit samples', () => {
@@ -66,8 +69,65 @@ test('five percent of PR SHAs are deterministic full-CI audit samples', () => {
   const normal = pullRequestPlan([change('CHANGELOG.md')], { sampleKey: 'ffffffffffffffff' });
   assert.equal(sampled.auditSampled, true);
   assert.equal(sampled.fullCi, true);
+  assert.deepEqual(selectedLanes(sampled), NON_SOLIDITY_LANES);
   assert.equal(normal.auditSampled, false);
   assert.equal(normal.fullCi, false);
+});
+
+test('full PR plans preserve the pre-delta Solidity path filter', () => {
+  const solidityRelevantPaths = [
+    'packages/evm-module/contracts/KnowledgeAssets.sol',
+    'packages/evm-module/test/KnowledgeAssets.test.ts',
+    'packages/evm-module/deploy/001_deploy.ts',
+    'packages/evm-module/scripts/export-abi.ts',
+    'packages/evm-module/hardhat.config.ts',
+    'packages/evm-module/hardhat.node.config.ts',
+    'packages/evm-module/package.json',
+    'packages/evm-module/slither.config.json',
+    'packages/evm-module/.solhint.json',
+    'packages/evm-module/.solhintignore',
+    'packages/evm-module/aderyn.toml',
+    'package.json',
+    'pnpm-lock.yaml',
+    'pnpm-workspace.yaml',
+    '.github/workflows/ci.yml',
+  ];
+
+  for (const filePath of solidityRelevantPaths) {
+    const plan = pullRequestPlan([change(filePath)], { labels: ['ci:full'] });
+    assert.equal(plan.mode, 'full', filePath);
+    assert.equal(plan.lanes.contracts, true, filePath);
+  }
+
+  const nonSolidityPaths = [
+    'packages/evm-module/abi/KnowledgeAssets.json',
+    'packages/evm-module/hardhat/config.ts',
+    'packages/agent/package.json',
+    '.github/workflows/evm-integration.yml',
+    'scripts/ci/plan-ci.mjs',
+  ];
+  for (const filePath of nonSolidityPaths) {
+    const plan = pullRequestPlan([change(filePath)], { labels: ['ci:full'] });
+    assert.equal(plan.mode, 'full', filePath);
+    assert.equal(plan.lanes.contracts, false, filePath);
+    assert.deepEqual(selectedLanes(plan), NON_SOLIDITY_LANES, filePath);
+  }
+});
+
+test('the delta rollback switch still path-gates Solidity on pull requests', () => {
+  const nonContract = planCi({
+    eventName: 'pull_request_delta_disabled',
+    changeEntries: [change('packages/agent/src/index.ts')],
+  });
+  assert.equal(nonContract.mode, 'full');
+  assert.deepEqual(selectedLanes(nonContract), NON_SOLIDITY_LANES);
+  assert.deepEqual(nonContract.evmScopes, EVM_SCOPES);
+
+  const contract = planCi({
+    eventName: 'pull_request_delta_disabled',
+    changeEntries: [change('packages/evm-module/contracts/KnowledgeAssets.sol')],
+  });
+  assert.deepEqual(selectedLanes(contract), CI_LANES);
 });
 
 test('documentation-only PRs select no test lane or shared build', () => {
@@ -159,7 +219,7 @@ test('highest-risk, global, unknown, manifest, large, and ambiguous changes fail
   assert.equal(hugePlan.changedFiles.length, 200, 'GitHub output must stay bounded');
 });
 
-test('workflow, planner, and aggregate-gate changes always force every CI lane', () => {
+test('control-plane changes force full Node/EVM CI without overriding the Solidity gate', () => {
   const controlPlanePaths = [
     '.github/workflows/ci.yml',
     '.github/workflows/evm-integration.yml',
@@ -176,7 +236,11 @@ test('workflow, planner, and aggregate-gate changes always force every CI lane',
     assert.equal(plan.mode, 'full', filePath);
     assert.equal(plan.fullCi, true, filePath);
     assert.equal(plan.runNode, true, filePath);
-    assert.deepEqual(selectedLanes(plan), CI_LANES, filePath);
+    assert.deepEqual(
+      selectedLanes(plan),
+      filePath === '.github/workflows/ci.yml' ? CI_LANES : NON_SOLIDITY_LANES,
+      filePath,
+    );
     assert.deepEqual(plan.evmScopes, EVM_SCOPES, filePath);
   }
 });
@@ -365,7 +429,7 @@ test('trusted planner and gates reject the all-skipped candidate-control attack'
   assert.equal(planner.status, 0, planner.stderr);
   const plan = JSON.parse(planner.stdout);
   assert.equal(plan.mode, 'full');
-  assert.deepEqual(selectedLanes(plan), CI_LANES);
+  assert.deepEqual(selectedLanes(plan), NON_SOLIDITY_LANES);
   assert.deepEqual(plan.evmScopes, EVM_SCOPES);
 
   const primaryNeeds = {
@@ -518,6 +582,29 @@ test('aggregate gates reject failed or accidentally skipped selected jobs', () =
   needs['kosava-supporting'].result = 'skipped';
   assert.match(validatePrimaryResults({ eventName: 'pull_request', plan, needs }).join('\n'), /selected/);
 
+  const fullNonContract = pullRequestPlan(
+    [change('scripts/unrelated-maintenance.mjs')],
+    { labels: ['ci:full'] },
+  );
+  const fullNonContractNeeds = {
+    changes: { result: 'success' },
+    build: { result: 'success' },
+    'abi-freshness': { result: 'skipped' },
+    solidity: { result: 'skipped' },
+    'solidity-coverage': { result: 'skipped' },
+    'tornado-static-analysis': { result: 'skipped' },
+    'evm-node-test-artifacts': { result: 'success' },
+    'evm-devnet-test-artifacts': { result: 'success' },
+    ...Object.fromEntries(
+      Object.values(PRIMARY_LANE_JOBS).map((job) => [job, { result: 'success' }]),
+    ),
+  };
+  assert.deepEqual(validatePrimaryResults({
+    eventName: 'pull_request',
+    plan: fullNonContract,
+    needs: fullNonContractNeeds,
+  }), []);
+
   const evmPlan = pullRequestPlan([change('packages/agent/src/index.ts')]);
   assert.deepEqual(validateEvmResults({
     eventName: 'pull_request',
@@ -562,7 +649,7 @@ test('aggregate gate accepts the full-push and docs-only job shapes', () => {
   );
 
   const mergeNeeds = structuredClone(fullNeeds);
-  mergeNeeds.solidity.result = 'success';
+  mergeNeeds.solidity.result = 'skipped';
   mergeNeeds['solidity-coverage'].result = 'skipped';
   assert.deepEqual(validatePrimaryResults({
     eventName: 'merge_group',

--- a/scripts/lib/__tests__/ci-delta.test.mjs
+++ b/scripts/lib/__tests__/ci-delta.test.mjs
@@ -33,6 +33,15 @@ function change(filePath, status = 'M') {
   return { status, paths: [filePath] };
 }
 
+function workflowJobBlock(workflow, jobName) {
+  const marker = `  ${jobName}:\n`;
+  const start = workflow.indexOf(marker);
+  assert.notEqual(start, -1, `workflow must define ${jobName}`);
+  const remainder = workflow.slice(start + marker.length);
+  const nextJob = remainder.search(/^  [a-zA-Z0-9_-]+:\n/m);
+  return nextJob === -1 ? remainder : remainder.slice(0, nextJob);
+}
+
 function pullRequestPlan(changeEntries, overrides = {}) {
   return planCi({
     eventName: 'pull_request',
@@ -476,10 +485,11 @@ test('workflows execute the planner and aggregate gates from one immutable trust
     /ref: aba17f2e66cf48a6cd6dc06c567e1e8bd77bfb8d/,
     'the trusted controller must not point into candidate-only history',
   );
+  const abiFreshnessJob = workflowJobBlock(primaryWorkflow, 'abi-freshness');
   assert.doesNotMatch(
-    primaryWorkflow,
-    /if: needs\.changes\.outputs\.abi_freshness == 'true'/,
-    'ABI freshness must run conservatively until the new controller is protected',
+    abiFreshnessJob,
+    /^    if:/m,
+    'ABI freshness must have no job-level condition until the new controller is protected',
   );
   assert.ok(
     primaryWorkflow.indexOf('run: node candidate/scripts/check-npm-metadata.mjs')
@@ -575,11 +585,7 @@ test('every planner output is wired to a real workflow job and omitted tests sta
     );
   }
   assert.ok(workflow.includes("needs.changes.outputs.contracts == 'true'"));
-  assert.doesNotMatch(
-    workflow,
-    /if: needs\.changes\.outputs\.abi_freshness == 'true'/,
-    'the first rollout phase must not depend on output from an untrusted controller update',
-  );
+  assert.doesNotMatch(workflowJobBlock(workflow, 'abi-freshness'), /^    if:/m);
   assert.ok(
     workflow.includes(
       "if: (github.event_name == 'pull_request' || github.event_name == 'merge_group') && needs.changes.outputs.contracts == 'true'",

--- a/scripts/lib/__tests__/ci-delta.test.mjs
+++ b/scripts/lib/__tests__/ci-delta.test.mjs
@@ -8,6 +8,7 @@ import { fileURLToPath } from 'node:url';
 import {
   CI_LANES,
   EVM_SCOPES,
+  NODE_EVM_LANES,
   WORKSPACE_OWNING_EVM_SCOPES,
   WORKSPACE_OWNING_LANES,
   WORKSPACE_RULES,
@@ -62,6 +63,37 @@ test('non-PR events run every lane while full-PR overrides preserve the Solidity
   assert.equal(labeled.fullCi, true);
   assert.deepEqual(selectedLanes(labeled), NON_SOLIDITY_LANES);
   assert.deepEqual(labeled.evmScopes, EVM_SCOPES);
+  assert.equal(labeled.solidityRelevant, false);
+  assert.deepEqual(NODE_EVM_LANES, NON_SOLIDITY_LANES);
+});
+
+test('unknown PR diffs fail closed with Solidity selected and enforced', () => {
+  const plan = pullRequestPlan([]);
+  assert.equal(plan.mode, 'full');
+  assert.equal(plan.fullCi, true);
+  assert.equal(plan.solidityRelevant, true);
+  assert.deepEqual(selectedLanes(plan), CI_LANES);
+  assert.match(plan.reasons.join('\n'), /failing closed/);
+
+  const needs = {
+    changes: { result: 'success' },
+    build: { result: 'success' },
+    'abi-freshness': { result: 'success' },
+    solidity: { result: 'skipped' },
+    'solidity-coverage': { result: 'skipped' },
+    'tornado-static-analysis': { result: 'success' },
+    'evm-node-test-artifacts': { result: 'success' },
+    'evm-devnet-test-artifacts': { result: 'success' },
+    ...Object.fromEntries(
+      Object.values(PRIMARY_LANE_JOBS).map((job) => [job, { result: 'success' }]),
+    ),
+  };
+  assert.match(
+    validatePrimaryResults({ eventName: 'pull_request', plan, needs }).join('\n'),
+    /solidity was selected but ended with skipped/,
+  );
+  needs.solidity.result = 'success';
+  assert.deepEqual(validatePrimaryResults({ eventName: 'pull_request', plan, needs }), []);
 });
 
 test('five percent of PR SHAs are deterministic full-CI audit samples', () => {
@@ -577,6 +609,7 @@ test('GitHub outputs are booleans plus compact JSON matrices', () => {
   const gatePlan = JSON.parse(outputs.plan_json);
   assert.equal(gatePlan.mode, 'delta');
   assert.equal(gatePlan.lanes.kosava_supporting, true);
+  assert.equal(gatePlan.solidityRelevant, false);
   assert.equal('changedFiles' in gatePlan, false);
   assert.equal('reasons' in gatePlan, false);
 });

--- a/scripts/lib/__tests__/ci-delta.test.mjs
+++ b/scripts/lib/__tests__/ci-delta.test.mjs
@@ -23,7 +23,10 @@ import {
 } from '../ci-results.mjs';
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
-const TRUSTED_CI_CONTROLLER_SHA = 'aba17f2e66cf48a6cd6dc06c567e1e8bd77bfb8d';
+// This SHA predates the candidate branch and is already reachable from the
+// protected default branch. Controller updates in this PR need a second,
+// post-merge pin-rotation PR before workflows may execute them.
+const TRUSTED_CI_CONTROLLER_SHA = 'c441bd6766ace67e331c0dfc6e22cb1325a6e1f6';
 const NON_SOLIDITY_LANES = CI_LANES.filter((lane) => lane !== 'contracts');
 
 function change(filePath, status = 'M') {
@@ -468,10 +471,15 @@ test('workflows execute the planner and aggregate gates from one immutable trust
   }
 
   const primaryWorkflow = workflows.get('primary');
-  assert.match(
+  assert.doesNotMatch(
     primaryWorkflow,
-    /grep -Eq '\^abi_freshness=\(true\|false\)\$'/,
-    'the primary planner must fail closed when the pinned controller omits abi_freshness',
+    /ref: aba17f2e66cf48a6cd6dc06c567e1e8bd77bfb8d/,
+    'the trusted controller must not point into candidate-only history',
+  );
+  assert.doesNotMatch(
+    primaryWorkflow,
+    /if: needs\.changes\.outputs\.abi_freshness == 'true'/,
+    'ABI freshness must run conservatively until the new controller is protected',
   );
   assert.ok(
     primaryWorkflow.indexOf('run: node candidate/scripts/check-npm-metadata.mjs')
@@ -567,7 +575,11 @@ test('every planner output is wired to a real workflow job and omitted tests sta
     );
   }
   assert.ok(workflow.includes("needs.changes.outputs.contracts == 'true'"));
-  assert.ok(workflow.includes("needs.changes.outputs.abi_freshness == 'true'"));
+  assert.doesNotMatch(
+    workflow,
+    /if: needs\.changes\.outputs\.abi_freshness == 'true'/,
+    'the first rollout phase must not depend on output from an untrusted controller update',
+  );
   assert.ok(
     workflow.includes(
       "if: (github.event_name == 'pull_request' || github.event_name == 'merge_group') && needs.changes.outputs.contracts == 'true'",

--- a/scripts/lib/__tests__/ci-delta.test.mjs
+++ b/scripts/lib/__tests__/ci-delta.test.mjs
@@ -23,7 +23,7 @@ import {
 } from '../ci-results.mjs';
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
-const TRUSTED_CI_CONTROLLER_SHA = '342e811260dd320f96140cc10f128ee4a54732a3';
+const TRUSTED_CI_CONTROLLER_SHA = 'e5f8165fdc246ed5458849256ce886b776c56320';
 const NON_SOLIDITY_LANES = CI_LANES.filter((lane) => lane !== 'contracts');
 
 function change(filePath, status = 'M') {

--- a/scripts/lib/__tests__/ci-delta.test.mjs
+++ b/scripts/lib/__tests__/ci-delta.test.mjs
@@ -63,7 +63,8 @@ test('non-PR events run every lane while full-PR overrides preserve the Solidity
   assert.equal(labeled.fullCi, true);
   assert.deepEqual(selectedLanes(labeled), NON_SOLIDITY_LANES);
   assert.deepEqual(labeled.evmScopes, EVM_SCOPES);
-  assert.equal(labeled.solidityRelevant, false);
+  assert.equal(labeled.lanes.contracts, false);
+  assert.equal(labeled.abiFreshnessRelevant, false);
   assert.deepEqual(NODE_EVM_LANES, NON_SOLIDITY_LANES);
 });
 
@@ -71,7 +72,8 @@ test('unknown PR diffs fail closed with Solidity selected and enforced', () => {
   const plan = pullRequestPlan([]);
   assert.equal(plan.mode, 'full');
   assert.equal(plan.fullCi, true);
-  assert.equal(plan.solidityRelevant, true);
+  assert.equal(plan.lanes.contracts, true);
+  assert.equal(plan.abiFreshnessRelevant, true);
   assert.deepEqual(selectedLanes(plan), CI_LANES);
   assert.match(plan.reasons.join('\n'), /failing closed/);
 
@@ -135,15 +137,24 @@ test('full PR plans preserve legacy Solidity paths and cover Hardhat support cod
   ]);
   assert.equal(hardhatSupport.mode, 'full');
   assert.equal(hardhatSupport.lanes.contracts, true);
+  assert.equal(hardhatSupport.abiFreshnessRelevant, true);
 
   for (const filePath of solidityRelevantPaths) {
     const plan = pullRequestPlan([change(filePath)], { labels: ['ci:full'] });
     assert.equal(plan.mode, 'full', filePath);
     assert.equal(plan.lanes.contracts, true, filePath);
+    assert.equal(plan.abiFreshnessRelevant, true, filePath);
   }
 
+  const abiOnly = pullRequestPlan([
+    change('packages/evm-module/abi/KnowledgeAssets.json'),
+  ]);
+  assert.equal(abiOnly.mode, 'full');
+  assert.equal(abiOnly.lanes.contracts, false);
+  assert.equal(abiOnly.abiFreshnessRelevant, true);
+  assert.deepEqual(selectedLanes(abiOnly), NON_SOLIDITY_LANES);
+
   const nonSolidityPaths = [
-    'packages/evm-module/abi/KnowledgeAssets.json',
     'packages/evm-module/README.md',
     'packages/evm-module/docs/greenfield-ka-ual.md',
     'packages/agent/package.json',
@@ -154,6 +165,7 @@ test('full PR plans preserve legacy Solidity paths and cover Hardhat support cod
     const plan = pullRequestPlan([change(filePath)], { labels: ['ci:full'] });
     assert.equal(plan.mode, 'full', filePath);
     assert.equal(plan.lanes.contracts, false, filePath);
+    assert.equal(plan.abiFreshnessRelevant, false, filePath);
     assert.deepEqual(selectedLanes(plan), NON_SOLIDITY_LANES, filePath);
   }
 });
@@ -535,6 +547,7 @@ test('every planner output is wired to a real workflow job and omitted tests sta
     );
   }
   assert.ok(workflow.includes("needs.changes.outputs.contracts == 'true'"));
+  assert.ok(workflow.includes("needs.changes.outputs.abi_freshness == 'true'"));
   assert.ok(
     workflow.includes(
       "if: (github.event_name == 'pull_request' || github.event_name == 'merge_group') && needs.changes.outputs.contracts == 'true'",
@@ -609,7 +622,9 @@ test('GitHub outputs are booleans plus compact JSON matrices', () => {
   const gatePlan = JSON.parse(outputs.plan_json);
   assert.equal(gatePlan.mode, 'delta');
   assert.equal(gatePlan.lanes.kosava_supporting, true);
-  assert.equal(gatePlan.solidityRelevant, false);
+  assert.equal(gatePlan.lanes.contracts, false);
+  assert.equal(gatePlan.abiFreshnessRelevant, false);
+  assert.equal('solidityRelevant' in gatePlan, false);
   assert.equal('changedFiles' in gatePlan, false);
   assert.equal('reasons' in gatePlan, false);
 });
@@ -655,6 +670,26 @@ test('aggregate gates reject failed or accidentally skipped selected jobs', () =
     plan: fullNonContract,
     needs: fullNonContractNeeds,
   }), []);
+
+  const abiOnly = pullRequestPlan([
+    change('packages/evm-module/abi/KnowledgeAssets.json'),
+  ]);
+  const abiOnlyNeeds = structuredClone(fullNonContractNeeds);
+  abiOnlyNeeds['abi-freshness'].result = 'success';
+  assert.deepEqual(validatePrimaryResults({
+    eventName: 'pull_request',
+    plan: abiOnly,
+    needs: abiOnlyNeeds,
+  }), []);
+  abiOnlyNeeds['abi-freshness'].result = 'skipped';
+  assert.match(
+    validatePrimaryResults({
+      eventName: 'pull_request',
+      plan: abiOnly,
+      needs: abiOnlyNeeds,
+    }).join('\n'),
+    /abi-freshness was selected but ended with skipped/,
+  );
 
   const evmPlan = pullRequestPlan([change('packages/agent/src/index.ts')]);
   assert.deepEqual(validateEvmResults({

--- a/scripts/lib/__tests__/ci-delta.test.mjs
+++ b/scripts/lib/__tests__/ci-delta.test.mjs
@@ -74,7 +74,7 @@ test('five percent of PR SHAs are deterministic full-CI audit samples', () => {
   assert.equal(normal.fullCi, false);
 });
 
-test('full PR plans preserve the pre-delta Solidity path filter', () => {
+test('full PR plans preserve legacy Solidity paths and cover Hardhat support code', () => {
   const solidityRelevantPaths = [
     'packages/evm-module/contracts/KnowledgeAssets.sol',
     'packages/evm-module/test/KnowledgeAssets.test.ts',
@@ -91,7 +91,18 @@ test('full PR plans preserve the pre-delta Solidity path filter', () => {
     'pnpm-lock.yaml',
     'pnpm-workspace.yaml',
     '.github/workflows/ci.yml',
+    'packages/evm-module/utils/helpers.ts',
+    'packages/evm-module/utils/network.ts',
+    'packages/evm-module/tasks/send_neuro.ts',
+    'packages/evm-module/tsconfig.json',
+    'packages/evm-module/deployments/parameters.json',
   ];
+
+  const hardhatSupport = pullRequestPlan([
+    change('packages/evm-module/utils/helpers.ts'),
+  ]);
+  assert.equal(hardhatSupport.mode, 'full');
+  assert.equal(hardhatSupport.lanes.contracts, true);
 
   for (const filePath of solidityRelevantPaths) {
     const plan = pullRequestPlan([change(filePath)], { labels: ['ci:full'] });
@@ -101,7 +112,8 @@ test('full PR plans preserve the pre-delta Solidity path filter', () => {
 
   const nonSolidityPaths = [
     'packages/evm-module/abi/KnowledgeAssets.json',
-    'packages/evm-module/hardhat/config.ts',
+    'packages/evm-module/README.md',
+    'packages/evm-module/docs/greenfield-ka-ual.md',
     'packages/agent/package.json',
     '.github/workflows/evm-integration.yml',
     'scripts/ci/plan-ci.mjs',
@@ -660,8 +672,14 @@ test('aggregate gate accepts the full-push and docs-only job shapes', () => {
   );
 
   const mergeNeeds = structuredClone(fullNeeds);
-  mergeNeeds.solidity.result = 'skipped';
   mergeNeeds['solidity-coverage'].result = 'skipped';
+  assert.match(validatePrimaryResults({
+    eventName: 'merge_group',
+    plan: full,
+    needs: mergeNeeds,
+  }).join('\n'), /solidity was selected but ended with skipped/);
+
+  mergeNeeds.solidity.result = 'success';
   assert.deepEqual(validatePrimaryResults({
     eventName: 'merge_group',
     plan: full,

--- a/scripts/lib/__tests__/ci-delta.test.mjs
+++ b/scripts/lib/__tests__/ci-delta.test.mjs
@@ -23,7 +23,7 @@ import {
 } from '../ci-results.mjs';
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
-const TRUSTED_CI_CONTROLLER_SHA = 'e5f8165fdc246ed5458849256ce886b776c56320';
+const TRUSTED_CI_CONTROLLER_SHA = 'aba17f2e66cf48a6cd6dc06c567e1e8bd77bfb8d';
 const NON_SOLIDITY_LANES = CI_LANES.filter((lane) => lane !== 'contracts');
 
 function change(filePath, status = 'M') {
@@ -453,6 +453,11 @@ test('workflows execute the planner and aggregate gates from one immutable trust
   }
 
   const primaryWorkflow = workflows.get('primary');
+  assert.match(
+    primaryWorkflow,
+    /grep -Eq '\^abi_freshness=\(true\|false\)\$'/,
+    'the primary planner must fail closed when the pinned controller omits abi_freshness',
+  );
   assert.ok(
     primaryWorkflow.indexOf('run: node candidate/scripts/check-npm-metadata.mjs')
       > primaryWorkflow.indexOf('node trusted-ci/scripts/ci/plan-ci.mjs'),
@@ -627,6 +632,12 @@ test('GitHub outputs are booleans plus compact JSON matrices', () => {
   assert.equal('solidityRelevant' in gatePlan, false);
   assert.equal('changedFiles' in gatePlan, false);
   assert.equal('reasons' in gatePlan, false);
+
+  const abiOnlyOutputs = githubOutputsForPlan(pullRequestPlan([
+    change('packages/evm-module/abi/KnowledgeAssets.json'),
+  ]));
+  assert.equal(abiOnlyOutputs.abi_freshness, 'true');
+  assert.equal(abiOnlyOutputs.contracts, 'false');
 });
 
 test('aggregate gates reject failed or accidentally skipped selected jobs', () => {

--- a/scripts/lib/__tests__/ci-delta.test.mjs
+++ b/scripts/lib/__tests__/ci-delta.test.mjs
@@ -22,7 +22,7 @@ import {
 } from '../ci-results.mjs';
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
-const TRUSTED_CI_CONTROLLER_SHA = 'c441bd6766ace67e331c0dfc6e22cb1325a6e1f6';
+const TRUSTED_CI_CONTROLLER_SHA = '29158635894980100917e2a3fd2233ac45e7d16f';
 const NON_SOLIDITY_LANES = CI_LANES.filter((lane) => lane !== 'contracts');
 
 function change(filePath, status = 'M') {
@@ -491,6 +491,17 @@ test('every planner output is wired to a real workflow job and omitted tests sta
     );
   }
   assert.ok(workflow.includes("needs.changes.outputs.contracts == 'true'"));
+  assert.ok(
+    workflow.includes(
+      "if: github.event_name == 'pull_request' && needs.changes.outputs.contracts == 'true'",
+    ),
+    'the sharded Solidity suite must run only on contract-relevant pull requests',
+  );
+  assert.equal(
+    workflow.includes("github.event_name == 'merge_group') && needs.changes.outputs.contracts"),
+    false,
+    'merge queue must not duplicate the Solidity suite already run on the pull request',
+  );
   assert.ok(
     workflow.includes('run: node candidate/scripts/check-npm-metadata.mjs'),
     'docs-only package README changes must retain the npm metadata gate',

--- a/scripts/lib/ci-delta.mjs
+++ b/scripts/lib/ci-delta.mjs
@@ -261,6 +261,11 @@ function isSolidityRelevantPath(filePath) {
     && !isDocumentationOnlyPath(filePath);
 }
 
+function isAbiFreshnessRelevantPath(filePath) {
+  return isSolidityRelevantPath(filePath)
+    || /^packages\/evm-module\/abi\/.*\.json$/i.test(filePath);
+}
+
 const BLAZEGRAPH_ARM64_PATHS = new Set([
   'blazegraph-image.json',
   'packages/cli/blazegraph-image-metadata.cjs',
@@ -286,16 +291,17 @@ function fullPlan({
   reasons,
   changedFiles = [],
   auditSampled = false,
-  solidityRelevant = true,
+  contracts = true,
+  abiFreshnessRelevant = true,
 }) {
   const lanes = Object.fromEntries(NODE_EVM_LANES.map((lane) => [lane, true]));
-  lanes.contracts = solidityRelevant;
+  lanes.contracts = contracts;
   return {
     mode: 'full',
     fullCi: true,
     auditSampled,
     runNode: true,
-    solidityRelevant,
+    abiFreshnessRelevant,
     lanes,
     evmScopes: [...EVM_SCOPES],
     changedFileCount: changedFiles.length,
@@ -309,7 +315,8 @@ function knownDiffPullRequestFullPlan(reasons, changedFiles = [], auditSampled =
     reasons,
     changedFiles,
     auditSampled,
-    solidityRelevant: changedFiles.some(isSolidityRelevantPath),
+    contracts: changedFiles.some(isSolidityRelevantPath),
+    abiFreshnessRelevant: changedFiles.some(isAbiFreshnessRelevantPath),
   });
 }
 
@@ -449,7 +456,8 @@ export function planCi({
     return fullPlan({
       reasons: ['No changed files were reported; failing closed'],
       changedFiles,
-      solidityRelevant: true,
+      contracts: true,
+      abiFreshnessRelevant: true,
     });
   }
 
@@ -468,7 +476,7 @@ export function planCi({
       fullCi: false,
       auditSampled: false,
       runNode: false,
-      solidityRelevant: false,
+      abiFreshnessRelevant: false,
       lanes: emptyLanes(),
       evmScopes: [],
       changedFileCount: changedFiles.length,
@@ -545,7 +553,7 @@ export function planCi({
     fullCi: false,
     auditSampled: false,
     runNode,
-    solidityRelevant: lanes.contracts,
+    abiFreshnessRelevant: false,
     lanes,
     evmScopes: EVM_SCOPES.filter((scope) => evmScopes.has(scope)),
     changedFileCount: changedFiles.length,
@@ -559,13 +567,14 @@ export function githubOutputsForPlan(plan) {
     mode: plan.mode,
     fullCi: plan.fullCi,
     runNode: plan.runNode,
-    solidityRelevant: plan.solidityRelevant,
+    abiFreshnessRelevant: plan.abiFreshnessRelevant,
     lanes: plan.lanes,
     evmScopes: plan.evmScopes,
   };
   return {
     full_ci: String(plan.fullCi),
     run_node: String(plan.runNode),
+    abi_freshness: String(plan.abiFreshnessRelevant),
     ...Object.fromEntries(CI_LANES.map((lane) => [lane, String(plan.lanes[lane])])),
     evm_matrix: JSON.stringify(plan.evmScopes),
     plan_json: JSON.stringify(gatePlan),

--- a/scripts/lib/ci-delta.mjs
+++ b/scripts/lib/ci-delta.mjs
@@ -287,37 +287,38 @@ function emptyLanes() {
   return Object.fromEntries(CI_LANES.map((lane) => [lane, false]));
 }
 
+function classifySolidityRelevance(eventName, changedFiles, diffKnown) {
+  const isPullRequest = eventName === 'pull_request'
+    || eventName === 'pull_request_delta_disabled';
+  if (!isPullRequest || !diffKnown) {
+    return { contracts: true, abiFreshnessRelevant: true };
+  }
+  return {
+    contracts: changedFiles.some(isSolidityRelevantPath),
+    abiFreshnessRelevant: changedFiles.some(isAbiFreshnessRelevantPath),
+  };
+}
+
 function fullPlan({
   reasons,
+  solidityRelevance,
   changedFiles = [],
   auditSampled = false,
-  contracts = true,
-  abiFreshnessRelevant = true,
 }) {
   const lanes = Object.fromEntries(NODE_EVM_LANES.map((lane) => [lane, true]));
-  lanes.contracts = contracts;
+  lanes.contracts = solidityRelevance.contracts;
   return {
     mode: 'full',
     fullCi: true,
     auditSampled,
     runNode: true,
-    abiFreshnessRelevant,
+    abiFreshnessRelevant: solidityRelevance.abiFreshnessRelevant,
     lanes,
     evmScopes: [...EVM_SCOPES],
     changedFileCount: changedFiles.length,
     changedFiles: changedFiles.slice(0, MAX_REPORTED_FILES),
     reasons,
   };
-}
-
-function knownDiffPullRequestFullPlan(reasons, changedFiles = [], auditSampled = false) {
-  return fullPlan({
-    reasons,
-    changedFiles,
-    auditSampled,
-    contracts: changedFiles.some(isSolidityRelevantPath),
-    abiFreshnessRelevant: changedFiles.some(isAbiFreshnessRelevantPath),
-  });
 }
 
 function normalizePath(filePath) {
@@ -425,52 +426,42 @@ export function planCi({
 } = {}) {
   const changedFiles = [...new Set(changeEntries.flatMap((entry) => entry.paths).map(normalizePath))];
   const isPullRequest = eventName === 'pull_request' || eventName === 'pull_request_delta_disabled';
+  const diffKnown = !isPullRequest || (changeEntries.length > 0 && changedFiles.length > 0);
+  const solidityRelevance = classifySolidityRelevance(eventName, changedFiles, diffKnown);
+  const fullForCurrentDiff = (reasons, auditSampled = false) => fullPlan({
+    reasons,
+    solidityRelevance,
+    changedFiles,
+    auditSampled,
+  });
 
   if (!isPullRequest) {
-    return fullPlan({
-      reasons: [`${eventName || 'unknown'} events always run full CI`],
-      changedFiles,
-    });
+    return fullForCurrentDiff([`${eventName || 'unknown'} events always run full CI`]);
   }
 
   // Missing diff data is the highest-risk input and must win over every PR
   // override. Labels, audit sampling, and the delta rollback switch may force
   // a known diff to full CI, but they cannot infer that Solidity is irrelevant
   // when GitHub reported no changed files at all.
-  if (changeEntries.length === 0 || changedFiles.length === 0) {
-    return fullPlan({
-      reasons: ['No changed files were reported; failing closed'],
-      changedFiles,
-      contracts: true,
-      abiFreshnessRelevant: true,
-    });
+  if (!diffKnown) {
+    return fullForCurrentDiff(['No changed files were reported; failing closed']);
   }
 
   if (eventName === 'pull_request_delta_disabled') {
-    return knownDiffPullRequestFullPlan(
-      ['PR delta routing is disabled; running full CI'],
-      changedFiles,
-    );
+    return fullForCurrentDiff(['PR delta routing is disabled; running full CI']);
   }
 
   if (labels.includes('ci:full')) {
-    return knownDiffPullRequestFullPlan(['PR has the ci:full override label'], changedFiles);
+    return fullForCurrentDiff(['PR has the ci:full override label']);
   }
 
   if (isAuditSample(sampleKey, auditPercentage)) {
-    return knownDiffPullRequestFullPlan(
-      [`${auditPercentage}% deterministic audit sample`],
-      changedFiles,
-      true,
-    );
+    return fullForCurrentDiff([`${auditPercentage}% deterministic audit sample`], true);
   }
 
   const riskyChange = changeEntries.find(({ status }) => ['D', 'R', 'C', 'T', 'U', 'X', 'B'].includes(status[0]));
   if (riskyChange) {
-    return knownDiffPullRequestFullPlan(
-      [`Git change status ${riskyChange.status} cannot be narrowed safely`],
-      changedFiles,
-    );
+    return fullForCurrentDiff([`Git change status ${riskyChange.status} cannot be narrowed safely`]);
   }
 
   const productionFiles = changedFiles.filter((filePath) => !isDocumentationOnlyPath(filePath));
@@ -480,7 +471,7 @@ export function planCi({
       fullCi: false,
       auditSampled: false,
       runNode: false,
-      abiFreshnessRelevant: false,
+      abiFreshnessRelevant: solidityRelevance.abiFreshnessRelevant,
       lanes: emptyLanes(),
       evmScopes: [],
       changedFileCount: changedFiles.length,
@@ -490,27 +481,22 @@ export function planCi({
   }
 
   if (productionFiles.length > 100) {
-    return knownDiffPullRequestFullPlan(
-      [`Large PR (${productionFiles.length} non-documentation files)`],
-      changedFiles,
-    );
+    return fullForCurrentDiff([`Large PR (${productionFiles.length} non-documentation files)`]);
   }
 
   const touchedWorkspaces = new Set(productionFiles.map(workspaceForPath).filter(Boolean));
   if (touchedWorkspaces.size >= 4) {
-    return knownDiffPullRequestFullPlan(
-      [`Cross-cutting PR (${touchedWorkspaces.size} production workspaces)`],
-      changedFiles,
-    );
+    return fullForCurrentDiff([`Cross-cutting PR (${touchedWorkspaces.size} production workspaces)`]);
   }
 
   const lanes = emptyLanes();
   const evmScopes = new Set();
   const reasons = [];
+  lanes.contracts = solidityRelevance.contracts;
 
   for (const filePath of productionFiles) {
     if (isGlobalFullPath(filePath)) {
-      return knownDiffPullRequestFullPlan([`Global CI input changed: ${filePath}`], changedFiles);
+      return fullForCurrentDiff([`Global CI input changed: ${filePath}`]);
     }
 
     const blazegraphProvisioningChange = isBlazegraphArm64Path(filePath);
@@ -523,19 +509,16 @@ export function planCi({
     const workspace = workspaceForPath(filePath);
     if (!workspace) {
       if (blazegraphProvisioningChange) continue;
-      return knownDiffPullRequestFullPlan([`Unclassified path changed: ${filePath}`], changedFiles);
+      return fullForCurrentDiff([`Unclassified path changed: ${filePath}`]);
     }
 
     if (filePath === `${workspace}/package.json`) {
-      return knownDiffPullRequestFullPlan(
-        [`Workspace dependency manifest changed: ${filePath}`],
-        changedFiles,
-      );
+      return fullForCurrentDiff([`Workspace dependency manifest changed: ${filePath}`]);
     }
 
     const rule = WORKSPACE_RULES[workspace];
     if (rule.forceFull) {
-      return knownDiffPullRequestFullPlan([`Highest-risk workspace changed: ${workspace}`], changedFiles);
+      return fullForCurrentDiff([`Highest-risk workspace changed: ${workspace}`]);
     }
 
     for (const lane of rule.lanes) lanes[lane] = true;
@@ -546,10 +529,7 @@ export function planCi({
   const deduplicatedReasons = [...new Set(reasons)];
   const runNode = NODE_LANES.some((lane) => lanes[lane]);
   if (!runNode && !lanes.bura_blazegraph_arm64 && !lanes.contracts && evmScopes.size === 0) {
-    return knownDiffPullRequestFullPlan(
-      ['Planner selected no lane for a production change; failing closed'],
-      changedFiles,
-    );
+    return fullForCurrentDiff(['Planner selected no lane for a production change; failing closed']);
   }
 
   return {
@@ -557,7 +537,7 @@ export function planCi({
     fullCi: false,
     auditSampled: false,
     runNode,
-    abiFreshnessRelevant: false,
+    abiFreshnessRelevant: solidityRelevance.abiFreshnessRelevant,
     lanes,
     evmScopes: EVM_SCOPES.filter((scope) => evmScopes.has(scope)),
     changedFileCount: changedFiles.length,

--- a/scripts/lib/ci-delta.mjs
+++ b/scripts/lib/ci-delta.mjs
@@ -223,6 +223,29 @@ const GLOBAL_FULL_PATHS = new Set([
   'vitest.evm-integration.ts',
 ]);
 
+// Preserve the independent Solidity gate that existed before delta CI. A PR
+// can be promoted to full Node/EVM CI for many reasons (audit sample, label,
+// unknown path, disabled rollout) without making a four-shard Hardhat run
+// relevant. These paths intentionally mirror the former dorny/paths-filter
+// allowlist in .github/workflows/ci.yml.
+const SOLIDITY_RELEVANT_PATHS = new Set([
+  'packages/evm-module/package.json',
+  'packages/evm-module/slither.config.json',
+  'packages/evm-module/.solhint.json',
+  'packages/evm-module/.solhintignore',
+  'packages/evm-module/aderyn.toml',
+  'package.json',
+  'pnpm-lock.yaml',
+  'pnpm-workspace.yaml',
+  '.github/workflows/ci.yml',
+]);
+
+function isSolidityRelevantPath(filePath) {
+  return SOLIDITY_RELEVANT_PATHS.has(filePath)
+    || /^packages\/evm-module\/(?:contracts|test|deploy|scripts)\//.test(filePath)
+    || /^packages\/evm-module\/hardhat\.[^/]+$/.test(filePath);
+}
+
 const BLAZEGRAPH_ARM64_PATHS = new Set([
   'blazegraph-image.json',
   'packages/cli/blazegraph-image-metadata.cjs',
@@ -244,18 +267,29 @@ function emptyLanes() {
   return Object.fromEntries(CI_LANES.map((lane) => [lane, false]));
 }
 
-function fullPlan(reasons, changedFiles = [], auditSampled = false) {
+function fullPlan(reasons, changedFiles = [], auditSampled = false, contracts = true) {
+  const lanes = Object.fromEntries(CI_LANES.map((lane) => [lane, true]));
+  lanes.contracts = contracts;
   return {
     mode: 'full',
     fullCi: true,
     auditSampled,
     runNode: true,
-    lanes: Object.fromEntries(CI_LANES.map((lane) => [lane, true])),
+    lanes,
     evmScopes: [...EVM_SCOPES],
     changedFileCount: changedFiles.length,
     changedFiles: changedFiles.slice(0, MAX_REPORTED_FILES),
     reasons,
   };
+}
+
+function fullPullRequestPlan(reasons, changedFiles = [], auditSampled = false) {
+  return fullPlan(
+    reasons,
+    changedFiles,
+    auditSampled,
+    changedFiles.some(isSolidityRelevantPath),
+  );
 }
 
 function normalizePath(filePath) {
@@ -362,26 +396,34 @@ export function planCi({
   auditPercentage = 5,
 } = {}) {
   const changedFiles = [...new Set(changeEntries.flatMap((entry) => entry.paths).map(normalizePath))];
+  const isPullRequest = eventName === 'pull_request' || eventName === 'pull_request_delta_disabled';
 
-  if (eventName !== 'pull_request') {
+  if (!isPullRequest) {
     return fullPlan([`${eventName || 'unknown'} events always run full CI`], changedFiles);
   }
 
+  if (eventName === 'pull_request_delta_disabled') {
+    return fullPullRequestPlan(['PR delta routing is disabled; running full CI'], changedFiles);
+  }
+
   if (labels.includes('ci:full')) {
-    return fullPlan(['PR has the ci:full override label'], changedFiles);
+    return fullPullRequestPlan(['PR has the ci:full override label'], changedFiles);
   }
 
   if (isAuditSample(sampleKey, auditPercentage)) {
-    return fullPlan([`${auditPercentage}% deterministic audit sample`], changedFiles, true);
+    return fullPullRequestPlan([`${auditPercentage}% deterministic audit sample`], changedFiles, true);
   }
 
   if (changeEntries.length === 0 || changedFiles.length === 0) {
-    return fullPlan(['No changed files were reported; failing closed'], changedFiles);
+    return fullPullRequestPlan(['No changed files were reported; failing closed'], changedFiles);
   }
 
   const riskyChange = changeEntries.find(({ status }) => ['D', 'R', 'C', 'T', 'U', 'X', 'B'].includes(status[0]));
   if (riskyChange) {
-    return fullPlan([`Git change status ${riskyChange.status} cannot be narrowed safely`], changedFiles);
+    return fullPullRequestPlan(
+      [`Git change status ${riskyChange.status} cannot be narrowed safely`],
+      changedFiles,
+    );
   }
 
   const productionFiles = changedFiles.filter((filePath) => !isDocumentationOnlyPath(filePath));
@@ -400,12 +442,18 @@ export function planCi({
   }
 
   if (productionFiles.length > 100) {
-    return fullPlan([`Large PR (${productionFiles.length} non-documentation files)`], changedFiles);
+    return fullPullRequestPlan(
+      [`Large PR (${productionFiles.length} non-documentation files)`],
+      changedFiles,
+    );
   }
 
   const touchedWorkspaces = new Set(productionFiles.map(workspaceForPath).filter(Boolean));
   if (touchedWorkspaces.size >= 4) {
-    return fullPlan([`Cross-cutting PR (${touchedWorkspaces.size} production workspaces)`], changedFiles);
+    return fullPullRequestPlan(
+      [`Cross-cutting PR (${touchedWorkspaces.size} production workspaces)`],
+      changedFiles,
+    );
   }
 
   const lanes = emptyLanes();
@@ -414,7 +462,7 @@ export function planCi({
 
   for (const filePath of productionFiles) {
     if (isGlobalFullPath(filePath)) {
-      return fullPlan([`Global CI input changed: ${filePath}`], changedFiles);
+      return fullPullRequestPlan([`Global CI input changed: ${filePath}`], changedFiles);
     }
 
     const blazegraphProvisioningChange = isBlazegraphArm64Path(filePath);
@@ -427,16 +475,19 @@ export function planCi({
     const workspace = workspaceForPath(filePath);
     if (!workspace) {
       if (blazegraphProvisioningChange) continue;
-      return fullPlan([`Unclassified path changed: ${filePath}`], changedFiles);
+      return fullPullRequestPlan([`Unclassified path changed: ${filePath}`], changedFiles);
     }
 
     if (filePath === `${workspace}/package.json`) {
-      return fullPlan([`Workspace dependency manifest changed: ${filePath}`], changedFiles);
+      return fullPullRequestPlan(
+        [`Workspace dependency manifest changed: ${filePath}`],
+        changedFiles,
+      );
     }
 
     const rule = WORKSPACE_RULES[workspace];
     if (rule.forceFull) {
-      return fullPlan([`Highest-risk workspace changed: ${workspace}`], changedFiles);
+      return fullPullRequestPlan([`Highest-risk workspace changed: ${workspace}`], changedFiles);
     }
 
     for (const lane of rule.lanes) lanes[lane] = true;
@@ -447,7 +498,10 @@ export function planCi({
   const deduplicatedReasons = [...new Set(reasons)];
   const runNode = NODE_LANES.some((lane) => lanes[lane]);
   if (!runNode && !lanes.bura_blazegraph_arm64 && !lanes.contracts && evmScopes.size === 0) {
-    return fullPlan(['Planner selected no lane for a production change; failing closed'], changedFiles);
+    return fullPullRequestPlan(
+      ['Planner selected no lane for a production change; failing closed'],
+      changedFiles,
+    );
   }
 
   return {

--- a/scripts/lib/ci-delta.mjs
+++ b/scripts/lib/ci-delta.mjs
@@ -1,4 +1,4 @@
-export const CI_LANES = Object.freeze([
+export const NODE_EVM_LANES = Object.freeze([
   'tornado_core',
   'tornado_blazegraph',
   'tornado_publisher',
@@ -10,8 +10,11 @@ export const CI_LANES = Object.freeze([
   'kosava_node_ui_e2e',
   'kosava_supporting',
   'kosava_hardhat_plugins',
-  'contracts',
 ]);
+
+// `contracts` remains a workflow output for compatibility, but Solidity is an
+// independent relevance gate rather than part of the Node/EVM "full" profile.
+export const CI_LANES = Object.freeze([...NODE_EVM_LANES, 'contracts']);
 
 export const EVM_SCOPES = Object.freeze(['chain', 'publisher', 'agent']);
 
@@ -272,21 +275,27 @@ function isBlazegraphArm64Path(filePath) {
     || /^packages\/cli\/(?:src|test)\/.*blazegraph.*\.(?:[cm]?[jt]s|json)$/i.test(filePath);
 }
 
-const NODE_LANES = CI_LANES.filter((lane) => lane !== 'contracts' && lane !== 'bura_blazegraph_arm64');
+const NODE_LANES = NODE_EVM_LANES.filter((lane) => lane !== 'bura_blazegraph_arm64');
 const MAX_REPORTED_FILES = 200;
 
 function emptyLanes() {
   return Object.fromEntries(CI_LANES.map((lane) => [lane, false]));
 }
 
-function fullPlan(reasons, changedFiles = [], auditSampled = false, contracts = true) {
-  const lanes = Object.fromEntries(CI_LANES.map((lane) => [lane, true]));
-  lanes.contracts = contracts;
+function fullPlan({
+  reasons,
+  changedFiles = [],
+  auditSampled = false,
+  solidityRelevant = true,
+}) {
+  const lanes = Object.fromEntries(NODE_EVM_LANES.map((lane) => [lane, true]));
+  lanes.contracts = solidityRelevant;
   return {
     mode: 'full',
     fullCi: true,
     auditSampled,
     runNode: true,
+    solidityRelevant,
     lanes,
     evmScopes: [...EVM_SCOPES],
     changedFileCount: changedFiles.length,
@@ -295,13 +304,13 @@ function fullPlan(reasons, changedFiles = [], auditSampled = false, contracts = 
   };
 }
 
-function fullPullRequestPlan(reasons, changedFiles = [], auditSampled = false) {
-  return fullPlan(
+function knownDiffPullRequestFullPlan(reasons, changedFiles = [], auditSampled = false) {
+  return fullPlan({
     reasons,
     changedFiles,
     auditSampled,
-    changedFiles.some(isSolidityRelevantPath),
-  );
+    solidityRelevant: changedFiles.some(isSolidityRelevantPath),
+  });
 }
 
 function normalizePath(filePath) {
@@ -411,28 +420,42 @@ export function planCi({
   const isPullRequest = eventName === 'pull_request' || eventName === 'pull_request_delta_disabled';
 
   if (!isPullRequest) {
-    return fullPlan([`${eventName || 'unknown'} events always run full CI`], changedFiles);
+    return fullPlan({
+      reasons: [`${eventName || 'unknown'} events always run full CI`],
+      changedFiles,
+    });
   }
 
   if (eventName === 'pull_request_delta_disabled') {
-    return fullPullRequestPlan(['PR delta routing is disabled; running full CI'], changedFiles);
+    return knownDiffPullRequestFullPlan(
+      ['PR delta routing is disabled; running full CI'],
+      changedFiles,
+    );
   }
 
   if (labels.includes('ci:full')) {
-    return fullPullRequestPlan(['PR has the ci:full override label'], changedFiles);
+    return knownDiffPullRequestFullPlan(['PR has the ci:full override label'], changedFiles);
   }
 
   if (isAuditSample(sampleKey, auditPercentage)) {
-    return fullPullRequestPlan([`${auditPercentage}% deterministic audit sample`], changedFiles, true);
+    return knownDiffPullRequestFullPlan(
+      [`${auditPercentage}% deterministic audit sample`],
+      changedFiles,
+      true,
+    );
   }
 
   if (changeEntries.length === 0 || changedFiles.length === 0) {
-    return fullPullRequestPlan(['No changed files were reported; failing closed'], changedFiles);
+    return fullPlan({
+      reasons: ['No changed files were reported; failing closed'],
+      changedFiles,
+      solidityRelevant: true,
+    });
   }
 
   const riskyChange = changeEntries.find(({ status }) => ['D', 'R', 'C', 'T', 'U', 'X', 'B'].includes(status[0]));
   if (riskyChange) {
-    return fullPullRequestPlan(
+    return knownDiffPullRequestFullPlan(
       [`Git change status ${riskyChange.status} cannot be narrowed safely`],
       changedFiles,
     );
@@ -445,6 +468,7 @@ export function planCi({
       fullCi: false,
       auditSampled: false,
       runNode: false,
+      solidityRelevant: false,
       lanes: emptyLanes(),
       evmScopes: [],
       changedFileCount: changedFiles.length,
@@ -454,7 +478,7 @@ export function planCi({
   }
 
   if (productionFiles.length > 100) {
-    return fullPullRequestPlan(
+    return knownDiffPullRequestFullPlan(
       [`Large PR (${productionFiles.length} non-documentation files)`],
       changedFiles,
     );
@@ -462,7 +486,7 @@ export function planCi({
 
   const touchedWorkspaces = new Set(productionFiles.map(workspaceForPath).filter(Boolean));
   if (touchedWorkspaces.size >= 4) {
-    return fullPullRequestPlan(
+    return knownDiffPullRequestFullPlan(
       [`Cross-cutting PR (${touchedWorkspaces.size} production workspaces)`],
       changedFiles,
     );
@@ -474,7 +498,7 @@ export function planCi({
 
   for (const filePath of productionFiles) {
     if (isGlobalFullPath(filePath)) {
-      return fullPullRequestPlan([`Global CI input changed: ${filePath}`], changedFiles);
+      return knownDiffPullRequestFullPlan([`Global CI input changed: ${filePath}`], changedFiles);
     }
 
     const blazegraphProvisioningChange = isBlazegraphArm64Path(filePath);
@@ -487,11 +511,11 @@ export function planCi({
     const workspace = workspaceForPath(filePath);
     if (!workspace) {
       if (blazegraphProvisioningChange) continue;
-      return fullPullRequestPlan([`Unclassified path changed: ${filePath}`], changedFiles);
+      return knownDiffPullRequestFullPlan([`Unclassified path changed: ${filePath}`], changedFiles);
     }
 
     if (filePath === `${workspace}/package.json`) {
-      return fullPullRequestPlan(
+      return knownDiffPullRequestFullPlan(
         [`Workspace dependency manifest changed: ${filePath}`],
         changedFiles,
       );
@@ -499,7 +523,7 @@ export function planCi({
 
     const rule = WORKSPACE_RULES[workspace];
     if (rule.forceFull) {
-      return fullPullRequestPlan([`Highest-risk workspace changed: ${workspace}`], changedFiles);
+      return knownDiffPullRequestFullPlan([`Highest-risk workspace changed: ${workspace}`], changedFiles);
     }
 
     for (const lane of rule.lanes) lanes[lane] = true;
@@ -510,7 +534,7 @@ export function planCi({
   const deduplicatedReasons = [...new Set(reasons)];
   const runNode = NODE_LANES.some((lane) => lanes[lane]);
   if (!runNode && !lanes.bura_blazegraph_arm64 && !lanes.contracts && evmScopes.size === 0) {
-    return fullPullRequestPlan(
+    return knownDiffPullRequestFullPlan(
       ['Planner selected no lane for a production change; failing closed'],
       changedFiles,
     );
@@ -521,6 +545,7 @@ export function planCi({
     fullCi: false,
     auditSampled: false,
     runNode,
+    solidityRelevant: lanes.contracts,
     lanes,
     evmScopes: EVM_SCOPES.filter((scope) => evmScopes.has(scope)),
     changedFileCount: changedFiles.length,
@@ -534,6 +559,7 @@ export function githubOutputsForPlan(plan) {
     mode: plan.mode,
     fullCi: plan.fullCi,
     runNode: plan.runNode,
+    solidityRelevant: plan.solidityRelevant,
     lanes: plan.lanes,
     evmScopes: plan.evmScopes,
   };

--- a/scripts/lib/ci-delta.mjs
+++ b/scripts/lib/ci-delta.mjs
@@ -223,11 +223,11 @@ const GLOBAL_FULL_PATHS = new Set([
   'vitest.evm-integration.ts',
 ]);
 
-// Preserve the independent Solidity gate that existed before delta CI. A PR
-// can be promoted to full Node/EVM CI for many reasons (audit sample, label,
-// unknown path, disabled rollout) without making a four-shard Hardhat run
-// relevant. These paths intentionally mirror the former dorny/paths-filter
-// allowlist in .github/workflows/ci.yml.
+// Preserve the independent Solidity gate that existed before delta CI, while
+// also covering Hardhat-loaded support code that the former paths-filter
+// missed. A PR can be promoted to full Node/EVM CI for many reasons without
+// making a four-shard Hardhat run relevant, but any production input inside
+// evm-module can affect compilation, deployment, or the test environment.
 const SOLIDITY_RELEVANT_PATHS = new Set([
   'packages/evm-module/package.json',
   'packages/evm-module/slither.config.json',
@@ -241,9 +241,21 @@ const SOLIDITY_RELEVANT_PATHS = new Set([
 ]);
 
 function isSolidityRelevantPath(filePath) {
-  return SOLIDITY_RELEVANT_PATHS.has(filePath)
+  if (
+    SOLIDITY_RELEVANT_PATHS.has(filePath)
     || /^packages\/evm-module\/(?:contracts|test|deploy|scripts)\//.test(filePath)
-    || /^packages\/evm-module\/hardhat\.[^/]+$/.test(filePath);
+    || /^packages\/evm-module\/hardhat\.[^/]+$/.test(filePath)
+  ) {
+    return true;
+  }
+
+  if (!filePath.startsWith('packages/evm-module/')) return false;
+
+  // Committed ABIs are runtime inputs for Node/EVM integration lanes, but they
+  // do not alter Hardhat compile/test behavior. Package documentation is also
+  // intentionally excluded unless it lives under a legacy matched directory.
+  return !filePath.startsWith('packages/evm-module/abi/')
+    && !isDocumentationOnlyPath(filePath);
 }
 
 const BLAZEGRAPH_ARM64_PATHS = new Set([

--- a/scripts/lib/ci-delta.mjs
+++ b/scripts/lib/ci-delta.mjs
@@ -433,6 +433,19 @@ export function planCi({
     });
   }
 
+  // Missing diff data is the highest-risk input and must win over every PR
+  // override. Labels, audit sampling, and the delta rollback switch may force
+  // a known diff to full CI, but they cannot infer that Solidity is irrelevant
+  // when GitHub reported no changed files at all.
+  if (changeEntries.length === 0 || changedFiles.length === 0) {
+    return fullPlan({
+      reasons: ['No changed files were reported; failing closed'],
+      changedFiles,
+      contracts: true,
+      abiFreshnessRelevant: true,
+    });
+  }
+
   if (eventName === 'pull_request_delta_disabled') {
     return knownDiffPullRequestFullPlan(
       ['PR delta routing is disabled; running full CI'],
@@ -450,15 +463,6 @@ export function planCi({
       changedFiles,
       true,
     );
-  }
-
-  if (changeEntries.length === 0 || changedFiles.length === 0) {
-    return fullPlan({
-      reasons: ['No changed files were reported; failing closed'],
-      changedFiles,
-      contracts: true,
-      abiFreshnessRelevant: true,
-    });
   }
 
   const riskyChange = changeEntries.find(({ status }) => ['D', 'R', 'C', 'T', 'U', 'X', 'B'].includes(status[0]));

--- a/scripts/lib/ci-results.mjs
+++ b/scripts/lib/ci-results.mjs
@@ -1,4 +1,4 @@
-import { CI_LANES, EVM_SCOPES } from './ci-delta.mjs';
+import { CI_LANES, EVM_SCOPES, NODE_EVM_LANES } from './ci-delta.mjs';
 
 export const PRIMARY_LANE_JOBS = Object.freeze({
   tornado_core: 'tornado-core',
@@ -39,8 +39,15 @@ function checkPlanShape(plan, eventName, errors) {
   if (!['full', 'delta', 'docs-only'].includes(plan.mode)) {
     errors.push(`CI plan has invalid mode ${plan.mode}`);
   }
-  if (typeof plan.fullCi !== 'boolean' || typeof plan.runNode !== 'boolean') {
-    errors.push('CI plan fullCi/runNode flags must be booleans');
+  if (
+    typeof plan.fullCi !== 'boolean'
+    || typeof plan.runNode !== 'boolean'
+    || typeof plan.solidityRelevant !== 'boolean'
+  ) {
+    errors.push('CI plan fullCi/runNode/solidityRelevant flags must be booleans');
+  }
+  if (plan.lanes?.contracts !== plan.solidityRelevant) {
+    errors.push('CI plan contracts output must match solidityRelevant');
   }
   for (const lane of CI_LANES) {
     if (typeof plan.lanes?.[lane] !== 'boolean') {
@@ -55,11 +62,8 @@ function checkPlanShape(plan, eventName, errors) {
     errors.push('CI plan has an invalid EVM scope matrix');
   }
   if (plan.mode === 'full') {
-    const requiredFullLanes = eventName === 'pull_request'
-      ? CI_LANES.filter((lane) => lane !== 'contracts')
-      : CI_LANES;
-    if (!plan.fullCi || requiredFullLanes.some((lane) => plan.lanes?.[lane] !== true)) {
-      errors.push('Full CI mode must select every required lane');
+    if (!plan.fullCi || NODE_EVM_LANES.some((lane) => plan.lanes?.[lane] !== true)) {
+      errors.push('Full CI mode must select every Node/EVM lane');
     }
     if (EVM_SCOPES.some((scope) => !plan.evmScopes?.includes(scope))) {
       errors.push('Full CI mode must select every EVM scope');
@@ -96,7 +100,7 @@ export function validatePrimaryResults({ eventName, plan, needs }) {
     requireSuccess(needs, job, Boolean(plan.lanes?.[lane]), errors);
   }
 
-  const contracts = Boolean(plan.lanes?.contracts);
+  const contracts = Boolean(plan.solidityRelevant);
   requireSuccess(needs, 'abi-freshness', contracts, errors);
   const candidateEvent = eventName === 'pull_request' || eventName === 'merge_group';
   requireSuccess(needs, 'solidity', candidateEvent && contracts, errors);

--- a/scripts/lib/ci-results.mjs
+++ b/scripts/lib/ci-results.mjs
@@ -98,11 +98,12 @@ export function validatePrimaryResults({ eventName, plan, needs }) {
 
   const contracts = Boolean(plan.lanes?.contracts);
   requireSuccess(needs, 'abi-freshness', contracts, errors);
-  requireSuccess(needs, 'solidity', eventName === 'pull_request' && contracts, errors);
+  const candidateEvent = eventName === 'pull_request' || eventName === 'merge_group';
+  requireSuccess(needs, 'solidity', candidateEvent && contracts, errors);
   requireSuccess(
     needs,
     'solidity-coverage',
-    eventName !== 'pull_request' && eventName !== 'merge_group',
+    !candidateEvent,
     errors,
   );
   requireSuccess(

--- a/scripts/lib/ci-results.mjs
+++ b/scripts/lib/ci-results.mjs
@@ -42,12 +42,12 @@ function checkPlanShape(plan, eventName, errors) {
   if (
     typeof plan.fullCi !== 'boolean'
     || typeof plan.runNode !== 'boolean'
-    || typeof plan.solidityRelevant !== 'boolean'
+    || typeof plan.abiFreshnessRelevant !== 'boolean'
   ) {
-    errors.push('CI plan fullCi/runNode/solidityRelevant flags must be booleans');
+    errors.push('CI plan fullCi/runNode/abiFreshnessRelevant flags must be booleans');
   }
-  if (plan.lanes?.contracts !== plan.solidityRelevant) {
-    errors.push('CI plan contracts output must match solidityRelevant');
+  if (plan.lanes?.contracts && !plan.abiFreshnessRelevant) {
+    errors.push('CI plan cannot select Solidity without ABI freshness');
   }
   for (const lane of CI_LANES) {
     if (typeof plan.lanes?.[lane] !== 'boolean') {
@@ -100,8 +100,8 @@ export function validatePrimaryResults({ eventName, plan, needs }) {
     requireSuccess(needs, job, Boolean(plan.lanes?.[lane]), errors);
   }
 
-  const contracts = Boolean(plan.solidityRelevant);
-  requireSuccess(needs, 'abi-freshness', contracts, errors);
+  const contracts = Boolean(plan.lanes?.contracts);
+  requireSuccess(needs, 'abi-freshness', Boolean(plan.abiFreshnessRelevant), errors);
   const candidateEvent = eventName === 'pull_request' || eventName === 'merge_group';
   requireSuccess(needs, 'solidity', candidateEvent && contracts, errors);
   requireSuccess(

--- a/scripts/lib/ci-results.mjs
+++ b/scripts/lib/ci-results.mjs
@@ -55,8 +55,11 @@ function checkPlanShape(plan, eventName, errors) {
     errors.push('CI plan has an invalid EVM scope matrix');
   }
   if (plan.mode === 'full') {
-    if (!plan.fullCi || CI_LANES.some((lane) => plan.lanes?.[lane] !== true)) {
-      errors.push('Full CI mode must select every lane');
+    const requiredFullLanes = eventName === 'pull_request'
+      ? CI_LANES.filter((lane) => lane !== 'contracts')
+      : CI_LANES;
+    if (!plan.fullCi || requiredFullLanes.some((lane) => plan.lanes?.[lane] !== true)) {
+      errors.push('Full CI mode must select every required lane');
     }
     if (EVM_SCOPES.some((scope) => !plan.evmScopes?.includes(scope))) {
       errors.push('Full CI mode must select every EVM scope');
@@ -95,9 +98,13 @@ export function validatePrimaryResults({ eventName, plan, needs }) {
 
   const contracts = Boolean(plan.lanes?.contracts);
   requireSuccess(needs, 'abi-freshness', contracts, errors);
-  const candidateEvent = eventName === 'pull_request' || eventName === 'merge_group';
-  requireSuccess(needs, 'solidity', candidateEvent && contracts, errors);
-  requireSuccess(needs, 'solidity-coverage', !candidateEvent, errors);
+  requireSuccess(needs, 'solidity', eventName === 'pull_request' && contracts, errors);
+  requireSuccess(
+    needs,
+    'solidity-coverage',
+    eventName !== 'pull_request' && eventName !== 'merge_group',
+    errors,
+  );
   requireSuccess(
     needs,
     'tornado-static-analysis',


### PR DESCRIPTION
## Summary

- Restore the Solidity path filter that existed before PR #1687, independently of delta or full Node/EVM routing.
- Keep full Node/EVM coverage for labels, audit samples, risky diffs, disabled delta mode, merge queue, pushes, and manual runs.
- Run sharded Solidity tests only for contract-relevant pull requests, avoid duplicating them in merge queue, and retain full Solidity coverage on protected pushes/manual runs.
- Keep planner and aggregate-gate decisions pinned to the reviewed controller commit.

## Why

The delta planner currently sets every lane true whenever a pull request falls back to full CI. That makes non-contract pull requests run all four Solidity shards even though the previous workflow kept Solidity behind a separate contract-path filter.

## Verification

- pnpm test:scripts: 92/92 passed
- DKG_SKIP_EVM_BUILD=1 pnpm run build:packages: passed
- actionlint .github/workflows/ci.yml .github/workflows/evm-integration.yml: passed
- git diff --check: passed

This pull request changes .github/workflows/ci.yml, which is intentionally part of the legacy contract-relevant filter, so its own PR run should include Solidity once.