### PR TITLE
fix(sync): recover graph-scoped SWM assets exactly

### DIFF
--- a/packages/agent/src/dkg-agent-cg-resolve.ts
+++ b/packages/agent/src/dkg-agent-cg-resolve.ts
@@ -939,6 +939,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
         includeSharedMemory: parsed.includeSharedMemory ?? false,
         phase: normalizeSyncPhase(parsed.phase),
         snapshotRef: typeof parsed.snapshotRef === 'string' ? parsed.snapshotRef : undefined,
+        snapshotGraph: typeof parsed.snapshotGraph === 'string' ? parsed.snapshotGraph : undefined,
         authPurpose: typeof parsed.authPurpose === 'string' ? parsed.authPurpose : undefined,
         authSelector: typeof parsed.authSelector === 'string' ? parsed.authSelector : undefined,
         targetPeerId: parsed.targetPeerId,
@@ -1079,6 +1080,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
     sinceBatchId?: string,
     syncSessionId?: string,
     recovery?: boolean,
+    snapshotGraph?: string,
   ): Promise<Uint8Array> {
     // Policy-read uncertainty must not abort bootstrap or downgrade it to the
     // public pipe encoding. Treat an unreadable policy as private; catalog is
@@ -1123,6 +1125,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       requesterPeerId: this.peerId,
       phase,
       snapshotRef,
+      snapshotGraph,
       // Phase C: only forwarded for the durable DATA phase — SWM has no
       // `dkg:batchId` (pre-chain) and meta must never be narrowed. The hint
       // is gap-safe only when it comes from a CONTIGUOUS watermark, so it is

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -482,6 +482,7 @@ function syncPageFetchCoalescingKey(params: {
   graphUri: string;
   deadline: number;
   snapshotRef?: string;
+  snapshotGraph?: string;
   sinceBatchId?: string;
   recovery?: boolean;
   forceFreshSession?: boolean;
@@ -494,6 +495,7 @@ function syncPageFetchCoalescingKey(params: {
     params.graphUri,
     params.deadline,
     params.snapshotRef ?? null,
+    params.snapshotGraph ?? null,
     params.sinceBatchId ?? null,
     params.recovery === true,
     params.forceFreshSession === true,
@@ -4249,6 +4251,9 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     // Authoritative snapshot callers must rotate the responder session even
     // when an unfinished offset-zero requester session is still cached.
     forceFreshSession?: boolean,
+    // Explicit target for graph-backed SWM snapshots. Kept separate from
+    // content-addressed snapshotRef while legacy URI-shaped refs remain readable.
+    snapshotGraph?: string,
   ): Promise<SyncPageResult> {
     const coalescingKey = syncPageFetchCoalescingKey({
       remotePeerId,
@@ -4258,6 +4263,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       graphUri,
       deadline,
       snapshotRef,
+      snapshotGraph,
       sinceBatchId,
       recovery,
       forceFreshSession,
@@ -4295,6 +4301,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       phase,
       graphUri,
       snapshotRef,
+      snapshotGraph,
       sinceBatchId,
       deadline,
       recovery,
@@ -4323,7 +4330,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       buildSyncRequest: this.buildSyncRequest.bind(this),
       parseAndFilter: (nquadsText, targetGraphUri, targetContextGraphId) => {
         if (phase === 'snapshot') {
-          const quads = parseWorkspacePublicSnapshotNQuads(nquadsText, snapshotRef ?? 'unknown');
+          const quads = parseWorkspacePublicSnapshotNQuads(nquadsText, snapshotRef ?? snapshotGraph ?? 'unknown');
           return Promise.resolve({ quads, totalQuads: quads.length });
         }
         return this.getOrCreateSyncVerifyWorker().parseAndFilter(nquadsText, targetGraphUri, targetContextGraphId);
@@ -4451,8 +4458,8 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         store: this.store,
         listSubGraphs: (id) => this.listSubGraphs(id),
         createContextGraphSyncDeadline: (remaining) => this.createContextGraphSyncDeadline(remaining),
-        fetchSyncPages: (ctx2, peerId, cgId, includeSharedMemory, phase, graphUri, deadline, snapshotRef) =>
-          this.fetchSyncPages(ctx2, peerId, cgId, includeSharedMemory, phase, graphUri, deadline, snapshotRef, undefined, undefined, true),
+        fetchSyncPages: (ctx2, peerId, cgId, includeSharedMemory, phase, graphUri, deadline, snapshotRef, snapshotGraph) =>
+          this.fetchSyncPages(ctx2, peerId, cgId, includeSharedMemory, phase, graphUri, deadline, snapshotRef, undefined, undefined, true, undefined, snapshotGraph),
         processSharedMemoryBatch: (data, meta, cgId, registered, excluded) =>
           this.getOrCreateSyncVerifyWorker().processSharedMemoryBatch(data, meta, cgId, registered, excluded),
         publicSnapshotStore: this.publicSnapshotStore,
@@ -4663,8 +4670,8 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           store: this.store,
           listSubGraphs: (id) => this.listSubGraphs(id),
           createContextGraphSyncDeadline: (remaining) => this.createContextGraphSyncDeadline(remaining),
-          fetchSyncPages: (ctx2, peerId, cgId, includeSharedMemory, phase, graphUri, deadline, snapshotRef) =>
-            this.fetchSyncPages(ctx2, peerId, cgId, includeSharedMemory, phase, graphUri, deadline, snapshotRef, undefined, undefined, true),
+          fetchSyncPages: (ctx2, peerId, cgId, includeSharedMemory, phase, graphUri, deadline, snapshotRef, snapshotGraph) =>
+            this.fetchSyncPages(ctx2, peerId, cgId, includeSharedMemory, phase, graphUri, deadline, snapshotRef, undefined, undefined, true, undefined, snapshotGraph),
           processSharedMemoryBatch: (data, meta, cgId, registered, excluded) =>
             this.getOrCreateSyncVerifyWorker().processSharedMemoryBatch(data, meta, cgId, registered, excluded),
           publicSnapshotStore: this.publicSnapshotStore,

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -96,7 +96,7 @@ import {
   SUBSCRIPTION_SOURCES,
   pickNetworkTunables,
 } from '@origintrail-official/dkg-core';
-import { GraphManager, PrivateContentStore, createTripleStore, asChangelogReader, type ChangelogReader, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig } from '@origintrail-official/dkg-storage';
+import { GraphManager, PrivateContentStore, createTripleStore, asChangelogReader, tryReplaceGraphAtomically, type ChangelogReader, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig } from '@origintrail-official/dkg-storage';
 import { readChangelogDeltaPage } from './sync/responder/graph-plan.js';
 import { decodeChangelogRequest, encodeChangelogResponse } from './sync/changelog/wire.js';
 import { runChangelogSync, planPageApply } from './sync/requester/changelog-sync.js';
@@ -675,6 +675,7 @@ interface RecoverContextGraphSwmFromPeerDependencies {
   createContextGraphSyncDeadline: (remainingContextGraphs: number) => number;
   fetchSyncPages: RecoverContextGraphSwmOptions['fetchSyncPages'];
   processSharedMemoryBatch: RecoverContextGraphSwmOptions['processSharedMemoryBatch'];
+  publicSnapshotStore?: WorkspacePublicSnapshotStore;
   recordDrops: OversizeGuardHooks['recordDrops'];
   invalidateListContextGraphsCache: () => void;
   markMetaProjectionDirty: (quads: Quad[]) => void;
@@ -809,6 +810,7 @@ function mergeSharedMemorySyncResults(
 function emptySwmRecoveryResult(): RecoverContextGraphSwmResult {
   return {
     replacedRoots: 0,
+    replacedGraphs: 0,
     insertedDataQuads: 0,
     insertedMetaQuads: 0,
     droppedDataTriples: 0,
@@ -4448,10 +4450,11 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         store: this.store,
         listSubGraphs: (id) => this.listSubGraphs(id),
         createContextGraphSyncDeadline: (remaining) => this.createContextGraphSyncDeadline(remaining),
-        fetchSyncPages: (ctx2, peerId, cgId, includeSharedMemory, phase, graphUri, deadline) =>
-          this.fetchSyncPages(ctx2, peerId, cgId, includeSharedMemory, phase, graphUri, deadline, undefined, undefined, undefined, true),
+        fetchSyncPages: (ctx2, peerId, cgId, includeSharedMemory, phase, graphUri, deadline, snapshotRef) =>
+          this.fetchSyncPages(ctx2, peerId, cgId, includeSharedMemory, phase, graphUri, deadline, snapshotRef, undefined, undefined, true),
         processSharedMemoryBatch: (data, meta, cgId, registered, excluded) =>
           this.getOrCreateSyncVerifyWorker().processSharedMemoryBatch(data, meta, cgId, registered, excluded),
+        publicSnapshotStore: this.publicSnapshotStore,
         recordDrops: (drops, seam) => this.oversizeTombstoneLog.record(drops, seam),
         invalidateListContextGraphsCache: () => this.invalidateListContextGraphsCache(),
         markMetaProjectionDirty: (quads) => this.contextGraphMetaProjection.markDirtyFromQuads(quads),
@@ -4659,10 +4662,11 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           store: this.store,
           listSubGraphs: (id) => this.listSubGraphs(id),
           createContextGraphSyncDeadline: (remaining) => this.createContextGraphSyncDeadline(remaining),
-          fetchSyncPages: (ctx2, peerId, cgId, includeSharedMemory, phase, graphUri, deadline) =>
-            this.fetchSyncPages(ctx2, peerId, cgId, includeSharedMemory, phase, graphUri, deadline, undefined, undefined, undefined, true),
+          fetchSyncPages: (ctx2, peerId, cgId, includeSharedMemory, phase, graphUri, deadline, snapshotRef) =>
+            this.fetchSyncPages(ctx2, peerId, cgId, includeSharedMemory, phase, graphUri, deadline, snapshotRef, undefined, undefined, true),
           processSharedMemoryBatch: (data, meta, cgId, registered, excluded) =>
             this.getOrCreateSyncVerifyWorker().processSharedMemoryBatch(data, meta, cgId, registered, excluded),
+          publicSnapshotStore: this.publicSnapshotStore,
           recordDrops: (drops, seam) => this.oversizeTombstoneLog.record(drops, seam),
           invalidateListContextGraphsCache: () => this.invalidateListContextGraphsCache(),
           markMetaProjectionDirty: (quads) => this.contextGraphMetaProjection.markDirtyFromQuads(quads),
@@ -6729,6 +6733,7 @@ async function runRecoverContextGraphSwmFromPeer(
     // responder gates via the strict members-only `isMemberRecoveryAuthorized`).
     fetchSyncPages: dependencies.fetchSyncPages,
     processSharedMemoryBatch: dependencies.processSharedMemoryBatch,
+    publicSnapshotStore: dependencies.publicSnapshotStore,
     // SwmRecoveryStore: invalidate the list cache + mark the meta projection
     // dirty on insert (parity with runSharedMemorySync's
     // insertSyncedQuadsAndInvalidateListCache); deletes pass through to the store.
@@ -6748,6 +6753,24 @@ async function runRecoverContextGraphSwmFromPeer(
           dependencies.invalidateListContextGraphsCache();
           dependencies.markMetaProjectionDirty(inserted);
         }
+      },
+      replaceGraph: async (graph, quads) => {
+        const replaced = await tryReplaceGraphAtomically(
+          dependencies.store,
+          graph,
+          quads,
+          {
+            priority: 'background',
+            source: 'agent.swmRecovery.graphScopedReplace',
+          },
+        );
+        if (!replaced) {
+          throw Object.assign(
+            new Error('Graph-scoped SWM recovery requires atomic TripleStore.replaceGraph() support'),
+            { code: 'SWM_ATOMIC_REPLACE_UNSUPPORTED' },
+          );
+        }
+        dependencies.invalidateListContextGraphsCache();
       },
       deleteByPattern: (pattern) => dependencies.store.deleteByPattern(pattern, {
         priority: 'background',
@@ -6811,6 +6834,43 @@ async function runRecoverContextGraphSwmFromPeer(
               );
             }
           }
+        }
+      }
+    },
+    replaceMetaForGraphAssets: async (assets) => {
+      for (const asset of assets) {
+        const linkedOperations = await dependencies.store.query(
+          `SELECT DISTINCT ?op WHERE { GRAPH <${assertSafeIri(asset.metaGraph)}> { ` +
+            `<${assertSafeIri(asset.headSubject)}> <http://dkg.io/ontology/shareOperationId> ?shareId . ` +
+            `?op <http://dkg.io/ontology/shareOperationId> ?shareId ; ` +
+            `<http://dkg.io/ontology/kaUal> <${assertSafeIri(asset.kaUal)}> . } }`,
+          {
+            priority: 'background',
+            source: 'agent.swmRecovery.replaceMetaForGraphAssets.findOperations',
+          },
+        );
+        const operationSubjects = new Set<string>([asset.operationSubject]);
+        if (linkedOperations.type === 'bindings') {
+          for (const row of linkedOperations.bindings) {
+            const operation = row['op'];
+            if (operation) operationSubjects.add(operation);
+          }
+        }
+        await dependencies.store.deleteByPattern(
+          { graph: asset.metaGraph, subject: asset.headSubject },
+          {
+            priority: 'background',
+            source: 'agent.swmRecovery.replaceMetaForGraphAssets.deleteHead',
+          },
+        );
+        for (const operationSubject of operationSubjects) {
+          await dependencies.store.deleteByPattern(
+            { graph: asset.metaGraph, subject: operationSubject },
+            {
+              priority: 'background',
+              source: 'agent.swmRecovery.replaceMetaForGraphAssets.deleteOperation',
+            },
+          );
         }
       }
     },

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -231,7 +231,7 @@ import {
   type ContextGraphSyncWork,
 } from './sync/requester/ordered-sync.js';
 import { recoverContextGraphSwm, type RecoverContextGraphSwmResult } from './sync/requester/swm-recovery.js';
-import { replaceGraphScopedSwmRecoveryMetadata } from './sync/requester/graph-scoped-swm-meta-replace.js';
+import { deletePriorGraphScopedSwmRecoveryMetadata } from './sync/requester/graph-scoped-swm-meta-replace.js';
 import { buildSyncRequestEnvelope, type SyncPhase } from './sync/auth/request-build.js';
 import { authorizePrivateSyncRequest } from './sync/auth/request-authorize.js';
 import {
@@ -6839,7 +6839,7 @@ async function runRecoverContextGraphSwmFromPeer(
       }
     },
     replaceMetaForGraphAssets: (assets) =>
-      replaceGraphScopedSwmRecoveryMetadata(dependencies.store, assets),
+      deletePriorGraphScopedSwmRecoveryMetadata(dependencies.store, assets),
     ensureContextGraph: async (cgId) => {
       const graphManager = new GraphManager(dependencies.store);
       await graphManager.ensureContextGraph(cgId);

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -231,6 +231,7 @@ import {
   type ContextGraphSyncWork,
 } from './sync/requester/ordered-sync.js';
 import { recoverContextGraphSwm, type RecoverContextGraphSwmResult } from './sync/requester/swm-recovery.js';
+import { replaceGraphScopedSwmRecoveryMetadata } from './sync/requester/graph-scoped-swm-meta-replace.js';
 import { buildSyncRequestEnvelope, type SyncPhase } from './sync/auth/request-build.js';
 import { authorizePrivateSyncRequest } from './sync/auth/request-authorize.js';
 import {
@@ -6837,43 +6838,8 @@ async function runRecoverContextGraphSwmFromPeer(
         }
       }
     },
-    replaceMetaForGraphAssets: async (assets) => {
-      for (const asset of assets) {
-        const linkedOperations = await dependencies.store.query(
-          `SELECT DISTINCT ?op WHERE { GRAPH <${assertSafeIri(asset.metaGraph)}> { ` +
-            `<${assertSafeIri(asset.headSubject)}> <http://dkg.io/ontology/shareOperationId> ?shareId . ` +
-            `?op <http://dkg.io/ontology/shareOperationId> ?shareId ; ` +
-            `<http://dkg.io/ontology/kaUal> <${assertSafeIri(asset.kaUal)}> . } }`,
-          {
-            priority: 'background',
-            source: 'agent.swmRecovery.replaceMetaForGraphAssets.findOperations',
-          },
-        );
-        const operationSubjects = new Set<string>([asset.operationSubject]);
-        if (linkedOperations.type === 'bindings') {
-          for (const row of linkedOperations.bindings) {
-            const operation = row['op'];
-            if (operation) operationSubjects.add(operation);
-          }
-        }
-        await dependencies.store.deleteByPattern(
-          { graph: asset.metaGraph, subject: asset.headSubject },
-          {
-            priority: 'background',
-            source: 'agent.swmRecovery.replaceMetaForGraphAssets.deleteHead',
-          },
-        );
-        for (const operationSubject of operationSubjects) {
-          await dependencies.store.deleteByPattern(
-            { graph: asset.metaGraph, subject: operationSubject },
-            {
-              priority: 'background',
-              source: 'agent.swmRecovery.replaceMetaForGraphAssets.deleteOperation',
-            },
-          );
-        }
-      }
-    },
+    replaceMetaForGraphAssets: (assets) =>
+      replaceGraphScopedSwmRecoveryMetadata(dependencies.store, assets),
     ensureContextGraph: async (cgId) => {
       const graphManager = new GraphManager(dependencies.store);
       await graphManager.ensureContextGraph(cgId);

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -154,6 +154,8 @@ export interface SyncRequestEnvelope {
   includeSharedMemory: boolean;
   phase?: SyncPhase;
   snapshotRef?: string;
+  /** Explicit graph-backed snapshot target; kept in lockstep with request-build.ts. */
+  snapshotGraph?: string;
   authPurpose?: string;
   authSelector?: string;
   targetPeerId?: string;

--- a/packages/agent/src/sync/auth/request-build.ts
+++ b/packages/agent/src/sync/auth/request-build.ts
@@ -26,6 +26,8 @@ export interface SyncRequestEnvelope {
   requesterSignatureVS?: string;
   phase?: SyncPhase;
   snapshotRef?: string;
+  /** Explicit graph-backed snapshot target. `snapshotRef` remains the store-ref field. */
+  snapshotGraph?: string;
   authPurpose?: string;
   authSelector?: string;
   /**
@@ -70,6 +72,7 @@ interface BuildSyncRequestParams {
   requesterPeerId: string;
   phase?: SyncPhase;
   snapshotRef?: string;
+  snapshotGraph?: string;
   authPurpose?: string;
   authSelector?: string;
   sinceBatchId?: string;
@@ -129,6 +132,7 @@ export async function buildSyncRequestEnvelope(params: BuildSyncRequestParams): 
     requesterPeerId,
     phase,
     snapshotRef,
+    snapshotGraph,
     authPurpose,
     authSelector,
     sinceBatchId,
@@ -159,7 +163,7 @@ export async function buildSyncRequestEnvelope(params: BuildSyncRequestParams): 
     const phaseSuffix = phase === 'meta'
       ? '|meta'
       : phase === 'snapshot'
-        ? `|snapshot|${snapshotRef ?? ''}`
+        ? `|snapshot|${snapshotGraph ?? snapshotRef ?? ''}`
         : phase === 'catalog'
           // The public `_catalog` facet (§7) is open-served unauthenticated, so
           // it rides THIS text form. Emit the phase token in parts[3] (same slot
@@ -186,6 +190,7 @@ export async function buildSyncRequestEnvelope(params: BuildSyncRequestParams): 
   };
   if (phase) request.phase = phase;
   if (snapshotRef) request.snapshotRef = snapshotRef;
+  if (snapshotGraph) request.snapshotGraph = snapshotGraph;
   if (authPurpose) request.authPurpose = authPurpose;
   if (authSelector) request.authSelector = authSelector;
   // Phase C: set AFTER digest computation below — it is intentionally outside

--- a/packages/agent/src/sync/durable-integrity.ts
+++ b/packages/agent/src/sync/durable-integrity.ts
@@ -3,6 +3,7 @@ import {
   MemoryLayer,
   createGraphKnowledgeAssetScope,
   knowledgeAssetLayerGraphUri,
+  parseDeterministicKnowledgeAssetUal,
   validateSubGraphName,
 } from '@origintrail-official/dkg-core';
 import {
@@ -61,7 +62,10 @@ export function classifyDurableMetaGraph(
   let hasIntegrityEnvelope = false;
   for (const quad of quads) {
     if (quad.predicate === MERKLE_ROOT) hasMerkleRoot = true;
-    if (DURABLE_INTEGRITY_META_PREDICATE_SET.has(quad.predicate)) {
+    if (
+      DURABLE_INTEGRITY_META_PREDICATE_SET.has(quad.predicate)
+      && (quad.predicate === MERKLE_ROOT || isDeterministicKaMetadataSubject(quad.subject))
+    ) {
       hasIntegrityEnvelope = true;
     }
     if (hasMerkleRoot && hasIntegrityEnvelope) break;
@@ -143,7 +147,12 @@ export function selectVerifiedDurableSyncQuads(
   const markerSubjects = new Set<string>();
   for (const quad of metaQuads) {
     if (quad.predicate === MERKLE_ROOT) merkleSubjects.add(quad.subject);
-    if (quad.predicate === CONTENT_SCOPE_VERSION) markerSubjects.add(quad.subject);
+    if (
+      quad.predicate === CONTENT_SCOPE_VERSION
+      && isDeterministicKaMetadataSubject(quad.subject)
+    ) {
+      markerSubjects.add(quad.subject);
+    }
   }
 
   if (merkleSubjects.size === 0 && markerSubjects.size === 0) {
@@ -431,6 +440,27 @@ export function selectVerifiedDurableSyncQuads(
   }
 
   return { dataIndexes, metaIndexes, rejected, verifiedZeroPublicAssets, logs };
+}
+
+/**
+ * Durable V2 KA descriptors live on the deterministic UAL subject itself.
+ * Lifecycle, seal and SWM operation rows deliberately repeat scope fields on
+ * other subjects; treating those rows as KA descriptors makes an otherwise
+ * valid sync batch fail for lacking `dkg:merkleRoot`.
+ *
+ * Keep syntactically deterministic-but-noncanonical UALs in the candidate set
+ * so they still fail closed in `parseGraphScopedDescriptor` instead of being
+ * mistaken for harmless configuration metadata.
+ */
+function isDeterministicKaMetadataSubject(subject: string): boolean {
+  if (!/^did:dkg:[^/]+\/0x[0-9a-fA-F]{40}\/[0-9]+$/.test(subject)) return false;
+  try {
+    parseDeterministicKnowledgeAssetUal(subject);
+  } catch {
+    // Shape matched, so this is a malformed KA descriptor and must remain in
+    // the integrity envelope for the verifier to reject.
+  }
+  return true;
 }
 
 function parseGraphScopedDescriptor(ual: string, rows: readonly Quad[]): GraphScopedDescriptor {

--- a/packages/agent/src/sync/durable-integrity.ts
+++ b/packages/agent/src/sync/durable-integrity.ts
@@ -64,7 +64,10 @@ export function classifyDurableMetaGraph(
     if (quad.predicate === MERKLE_ROOT) hasMerkleRoot = true;
     if (
       DURABLE_INTEGRITY_META_PREDICATE_SET.has(quad.predicate)
-      && (quad.predicate === MERKLE_ROOT || isDeterministicKaMetadataSubject(quad.subject))
+      && (
+        quad.predicate === MERKLE_ROOT
+        || !isInternalNonKaMetadataSubject(quad.subject)
+      )
     ) {
       hasIntegrityEnvelope = true;
     }
@@ -461,6 +464,17 @@ function isDeterministicKaMetadataSubject(subject: string): boolean {
     // the integrity envelope for the verifier to reject.
   }
   return true;
+}
+
+/**
+ * DKG lifecycle, seal, and workspace-operation rows may repeat V2 scope
+ * predicates without being KA integrity descriptors. Exclude those known DKG
+ * subjects while keeping unknown/external subjects fail-closed, as required by
+ * changelog admission when a malformed envelope has no Merkle root.
+ */
+function isInternalNonKaMetadataSubject(subject: string): boolean {
+  if (isDeterministicKaMetadataSubject(subject)) return false;
+  return subject.startsWith('did:dkg:') || subject.startsWith('urn:dkg:');
 }
 
 function parseGraphScopedDescriptor(ual: string, rows: readonly Quad[]): GraphScopedDescriptor {

--- a/packages/agent/src/sync/graph-scoped-swm-recovery.ts
+++ b/packages/agent/src/sync/graph-scoped-swm-recovery.ts
@@ -309,10 +309,19 @@ export async function materializeGraphScopedSwmRecoveryAsset(params: {
       .filter((quad) => quad.graph === descriptor.publicSnapshotGraph)
       .map((quad) => ({ ...quad, graph: '' }));
   } else {
-    if (!params.publicSnapshotStore || !descriptor.publicSnapshotRef) {
-      throw new Error(`Graph-scoped SWM recovery requires a public snapshot store for ${descriptor.kaUal}`);
+    const inline = params.fetchedDataQuads
+      .filter((quad) => quad.graph === descriptor.assertionGraph)
+      .map((quad) => ({ ...quad, graph: '' }));
+    if (inline.length > 0 || descriptor.publicQuadsCount === 0) {
+      raw = inline;
+    } else {
+      if (!params.publicSnapshotStore || !descriptor.publicSnapshotRef) {
+        throw new Error(
+          `Graph-scoped SWM recovery has neither inline data nor a public snapshot store for ${descriptor.kaUal}`,
+        );
+      }
+      raw = await params.publicSnapshotStore.getSnapshot(descriptor.publicSnapshotRef);
     }
-    raw = await params.publicSnapshotStore.getSnapshot(descriptor.publicSnapshotRef);
   }
   if (!raw) {
     throw new Error(`Graph-scoped SWM snapshot is missing for ${descriptor.kaUal}`);

--- a/packages/agent/src/sync/graph-scoped-swm-recovery.ts
+++ b/packages/agent/src/sync/graph-scoped-swm-recovery.ts
@@ -10,6 +10,16 @@ import {
   type WorkspacePublicSnapshotStore,
 } from '@origintrail-official/dkg-publisher';
 import type { Quad } from '@origintrail-official/dkg-storage';
+import { stripLiteral } from '../dkg-agent-utils.js';
+import {
+  distinctRdfObjects,
+  optionalRdfLiteral,
+  optionalRdfObject,
+  requireRdfLiteral,
+  requireRdfObject,
+  requireRdfPositiveIntegerString,
+  requireRdfSafeInteger,
+} from './rdf-metadata.js';
 
 const DKG = 'http://dkg.io/ontology/';
 const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
@@ -147,12 +157,12 @@ export function parseGraphScopedSwmRecoveryDescriptors(params: {
     }
 
     const kaUalFromHead = headSubject.slice(0, -HEAD_SUFFIX.length);
-    const scopeVersion = requireSafeInteger(headRows, CONTENT_SCOPE_VERSION, 'contentScopeVersion');
+    const scopeVersion = requireRdfSafeInteger(headRows, CONTENT_SCOPE_VERSION, 'contentScopeVersion');
     if (scopeVersion !== GRAPH_KA_CONTENT_SCOPE_VERSION) {
       throw new Error(`Graph-scoped SWM head ${headSubject} has unsupported contentScopeVersion ${scopeVersion}`);
     }
-    const kaUal = requireSingle(headRows, KA_UAL, 'kaUal');
-    const assertionVersion = requirePositiveInteger(headRows, ASSERTION_VERSION, 'assertionVersion');
+    const kaUal = requireRdfObject(headRows, KA_UAL, 'kaUal');
+    const assertionVersion = requireRdfPositiveIntegerString(headRows, ASSERTION_VERSION, 'assertionVersion');
     const scope = createGraphKnowledgeAssetScope(kaUal, assertionVersion);
     if (scope.ual !== kaUal || scope.ual !== kaUalFromHead) {
       throw new Error(`Graph-scoped SWM head ${headSubject} has a non-canonical or mismatched kaUal`);
@@ -165,7 +175,7 @@ export function parseGraphScopedSwmRecoveryDescriptors(params: {
       scope,
       subGraphName,
     );
-    const assertionGraph = requireSingle(headRows, ASSERTION_GRAPH, 'assertionGraph');
+    const assertionGraph = requireRdfObject(headRows, ASSERTION_GRAPH, 'assertionGraph');
     if (assertionGraph !== expectedAssertionGraph) {
       throw new Error(
         `Graph-scoped SWM head ${headSubject} assertionGraph mismatch: ` +
@@ -173,7 +183,7 @@ export function parseGraphScopedSwmRecoveryDescriptors(params: {
       );
     }
 
-    const shareOperationId = requireLiteral(headRows, SHARE_OPERATION_ID, 'shareOperationId').trim();
+    const shareOperationId = requireRdfLiteral(headRows, SHARE_OPERATION_ID, 'shareOperationId').trim();
     if (!shareOperationId) throw new Error(`Graph-scoped SWM head ${headSubject} has an empty shareOperationId`);
     const operationSubject = `urn:dkg:share:${params.contextGraphId}:${shareOperationId}`;
     const operationRows = byGraphAndSubject.get(`${metaGraph}\u0000${operationSubject}`) ?? [];
@@ -188,7 +198,7 @@ export function parseGraphScopedSwmRecoveryDescriptors(params: {
       subGraphName,
     });
 
-    const publicQuadsDigest = requireLiteral(
+    const publicQuadsDigest = requireRdfLiteral(
       operationRows,
       PUBLIC_QUADS_DIGEST,
       'publicQuadsDigest',
@@ -196,7 +206,7 @@ export function parseGraphScopedSwmRecoveryDescriptors(params: {
     if (!/^sha256:[0-9a-f]{64}$/.test(publicQuadsDigest)) {
       throw new Error(`Graph-scoped SWM operation ${operationSubject} has an invalid publicQuadsDigest`);
     }
-    const publicQuadsCount = requireSafeInteger(
+    const publicQuadsCount = requireRdfSafeInteger(
       operationRows,
       PUBLIC_QUADS_COUNT,
       'publicQuadsCount',
@@ -204,7 +214,7 @@ export function parseGraphScopedSwmRecoveryDescriptors(params: {
     if (publicQuadsCount < 0) {
       throw new Error(`Graph-scoped SWM operation ${operationSubject} has a negative publicQuadsCount`);
     }
-    const privateTripleCount = requireSafeInteger(
+    const privateTripleCount = requireRdfSafeInteger(
       operationRows,
       PRIVATE_TRIPLE_COUNT,
       'privateTripleCount',
@@ -212,7 +222,7 @@ export function parseGraphScopedSwmRecoveryDescriptors(params: {
     if (privateTripleCount < 0 || (privateTripleCount === 0 && publicQuadsCount === 0)) {
       throw new Error(`Graph-scoped SWM operation ${operationSubject} has invalid public/private counts`);
     }
-    const privateRoot = optionalSingle(operationRows, PRIVATE_MERKLE_ROOT, 'privateMerkleRoot');
+    const privateRoot = optionalRdfObject(operationRows, PRIVATE_MERKLE_ROOT, 'privateMerkleRoot');
     if (
       (privateTripleCount > 0 && !/^0x[0-9a-fA-F]{64}$/.test(stripLiteral(privateRoot ?? '')))
       || (privateTripleCount === 0 && privateRoot !== undefined)
@@ -220,12 +230,12 @@ export function parseGraphScopedSwmRecoveryDescriptors(params: {
       throw new Error(`Graph-scoped SWM operation ${operationSubject} has an invalid private commitment`);
     }
 
-    const publicSnapshotGraph = optionalSingle(
+    const publicSnapshotGraph = optionalRdfObject(
       operationRows,
       PUBLIC_SNAPSHOT_GRAPH,
       'publicSnapshotGraph',
     );
-    const explicitSnapshotRef = optionalLiteral(
+    const explicitSnapshotRef = optionalRdfLiteral(
       operationRows,
       PUBLIC_SNAPSHOT_REF,
       'publicSnapshotRef',
@@ -253,7 +263,7 @@ export function parseGraphScopedSwmRecoveryDescriptors(params: {
       throw new Error(`Graph-scoped SWM operation ${operationSubject} has an invalid publicSnapshotRef`);
     }
 
-    const publisherPeerId = requireLiteral(operationRows, PUBLISHER_PEER_ID, 'publisherPeerId').trim();
+    const publisherPeerId = requireRdfLiteral(operationRows, PUBLISHER_PEER_ID, 'publisherPeerId').trim();
     if (!publisherPeerId) {
       throw new Error(`Graph-scoped SWM operation ${operationSubject} has an empty publisherPeerId`);
     }
@@ -342,31 +352,31 @@ function validateOperationRows(params: {
   if (!rows.some((row) => row.predicate === RDF_TYPE && row.object === WORKSPACE_OPERATION)) {
     throw new Error(`Graph-scoped SWM operation ${params.operationSubject} is missing its type`);
   }
-  requireSingle(rows, PUBLISHED_AT, 'publishedAt');
-  if (requireSafeInteger(rows, CONTENT_SCOPE_VERSION, 'contentScopeVersion') !== GRAPH_KA_CONTENT_SCOPE_VERSION) {
+  requireRdfObject(rows, PUBLISHED_AT, 'publishedAt');
+  if (requireRdfSafeInteger(rows, CONTENT_SCOPE_VERSION, 'contentScopeVersion') !== GRAPH_KA_CONTENT_SCOPE_VERSION) {
     throw new Error(`Graph-scoped SWM operation ${params.operationSubject} has an invalid scope version`);
   }
-  if (requireLiteral(rows, CONTEXT_GRAPH_ID, 'contextGraphId') !== params.contextGraphId) {
+  if (requireRdfLiteral(rows, CONTEXT_GRAPH_ID, 'contextGraphId') !== params.contextGraphId) {
     throw new Error(`Graph-scoped SWM operation ${params.operationSubject} has a contextGraphId mismatch`);
   }
-  if (requireLiteral(rows, SHARE_OPERATION_ID, 'shareOperationId') !== params.shareOperationId) {
+  if (requireRdfLiteral(rows, SHARE_OPERATION_ID, 'shareOperationId') !== params.shareOperationId) {
     throw new Error(`Graph-scoped SWM operation ${params.operationSubject} has a shareOperationId mismatch`);
   }
-  if (requireSingle(rows, KA_UAL, 'kaUal') !== params.kaUal) {
+  if (requireRdfObject(rows, KA_UAL, 'kaUal') !== params.kaUal) {
     throw new Error(`Graph-scoped SWM operation ${params.operationSubject} has a kaUal mismatch`);
   }
-  if (requirePositiveInteger(rows, ASSERTION_VERSION, 'assertionVersion') !== params.assertionVersion) {
+  if (requireRdfPositiveIntegerString(rows, ASSERTION_VERSION, 'assertionVersion') !== params.assertionVersion) {
     throw new Error(`Graph-scoped SWM operation ${params.operationSubject} has an assertionVersion mismatch`);
   }
-  const operationSubGraph = optionalLiteral(rows, SUB_GRAPH_NAME, 'subGraphName')?.trim();
+  const operationSubGraph = optionalRdfLiteral(rows, SUB_GRAPH_NAME, 'subGraphName')?.trim();
   if (operationSubGraph !== params.subGraphName) {
     throw new Error(`Graph-scoped SWM operation ${params.operationSubject} has a subGraphName mismatch`);
   }
-  const accessPolicy = optionalLiteral(rows, ACCESS_POLICY, 'accessPolicy')?.trim();
+  const accessPolicy = optionalRdfLiteral(rows, ACCESS_POLICY, 'accessPolicy')?.trim();
   if (accessPolicy && !['public', 'ownerOnly', 'allowList'].includes(accessPolicy)) {
     throw new Error(`Graph-scoped SWM operation ${params.operationSubject} has an invalid accessPolicy`);
   }
-  const allowedPeers = distinctObjects(rows, ALLOWED_PEER).map(stripLiteral).filter(Boolean);
+  const allowedPeers = distinctRdfObjects(rows, ALLOWED_PEER, { stripLiterals: true }).filter(Boolean);
   if (
     (accessPolicy === 'allowList' && allowedPeers.length === 0)
     || (accessPolicy !== 'allowList' && allowedPeers.length > 0)
@@ -434,58 +444,4 @@ function groupByGraphAndSubject(quads: readonly Quad[]): Map<string, Quad[]> {
     else grouped.set(key, [quad]);
   }
   return grouped;
-}
-
-function distinctObjects(rows: readonly Quad[], predicate: string): string[] {
-  return [...new Set(rows.filter((row) => row.predicate === predicate).map((row) => row.object))];
-}
-
-function requireSingle(rows: readonly Quad[], predicate: string, field: string): string {
-  const values = distinctObjects(rows, predicate);
-  if (values.length !== 1) {
-    throw new Error(`${values.length === 0 ? 'missing' : 'ambiguous'} ${field}`);
-  }
-  return values[0]!;
-}
-
-function optionalSingle(rows: readonly Quad[], predicate: string, field: string): string | undefined {
-  const values = distinctObjects(rows, predicate);
-  if (values.length > 1) throw new Error(`ambiguous ${field}`);
-  return values[0];
-}
-
-function requireLiteral(rows: readonly Quad[], predicate: string, field: string): string {
-  return stripLiteral(requireSingle(rows, predicate, field));
-}
-
-function optionalLiteral(rows: readonly Quad[], predicate: string, field: string): string | undefined {
-  const value = optionalSingle(rows, predicate, field);
-  return value === undefined ? undefined : stripLiteral(value);
-}
-
-function requireSafeInteger(rows: readonly Quad[], predicate: string, field: string): number {
-  const raw = stripLiteral(requireSingle(rows, predicate, field));
-  if (!/^-?[0-9]+$/.test(raw)) throw new Error(`invalid ${field}`);
-  const parsed = Number(raw);
-  if (!Number.isSafeInteger(parsed)) throw new Error(`unsafe ${field}`);
-  return parsed;
-}
-
-function requirePositiveInteger(rows: readonly Quad[], predicate: string, field: string): string {
-  const raw = stripLiteral(requireSingle(rows, predicate, field));
-  if (!/^[0-9]+$/.test(raw)) throw new Error(`invalid ${field}`);
-  const parsed = BigInt(raw);
-  if (parsed < 1n) throw new Error(`${field} must be positive`);
-  return parsed.toString();
-}
-
-function stripLiteral(value: string): string {
-  const match = value.match(/^"((?:[^"\\]|\\.)*)"(?:@[-A-Za-z0-9]+|\^\^<[^>]+>)?$/);
-  if (!match) return value;
-  return match[1]!
-    .replace(/\\n/g, '\n')
-    .replace(/\\r/g, '\r')
-    .replace(/\\t/g, '\t')
-    .replace(/\\"/g, '"')
-    .replace(/\\\\/g, '\\');
 }

--- a/packages/agent/src/sync/graph-scoped-swm-recovery.ts
+++ b/packages/agent/src/sync/graph-scoped-swm-recovery.ts
@@ -34,6 +34,41 @@ const ALLOWED_PEER = `${DKG}allowedPeer`;
 const SUB_GRAPH_NAME = `${DKG}subGraphName`;
 const HEAD_SUFFIX = '#dkg-swm-head';
 
+/** Canonical responder pattern binding an untimestamped active head to its operation timestamp. */
+export function graphScopedSwmHeadFreshnessPattern(): string {
+  return `
+            ?s <${CONTENT_SCOPE_VERSION}> ${GRAPH_KA_CONTENT_SCOPE_VERSION} ;
+               <${KA_UAL}> ?headUal ;
+               <${ASSERTION_VERSION}> ?headVersion ;
+               <${SHARE_OPERATION_ID}> ?shareId .
+            ?headOperation <${RDF_TYPE}> <${WORKSPACE_OPERATION}> ;
+               <${CONTENT_SCOPE_VERSION}> ${GRAPH_KA_CONTENT_SCOPE_VERSION} ;
+               <${KA_UAL}> ?headUal ;
+               <${ASSERTION_VERSION}> ?headVersion ;
+               <${SHARE_OPERATION_ID}> ?shareId ;
+               <${PUBLISHED_AT}> ?ts .`;
+}
+
+/** Restrict graph-backed snapshot reads to the requested CG and admitted SWM lane. */
+export function isGraphScopedSwmSnapshotGraph(params: {
+  readonly contextGraphId: string;
+  readonly snapshotGraph: string;
+  readonly registeredSubGraphNames?: readonly string[];
+}): boolean {
+  const contextGraphComponent = encodeURIComponent(params.contextGraphId);
+  const prefix = `did:dkg:context-graph:${contextGraphComponent}/_shared_memory_snapshots/`;
+  if (!params.snapshotGraph.startsWith(prefix)) return false;
+  const parts = params.snapshotGraph.slice(prefix.length).split('/');
+  if (parts.length !== 3 || parts[2] !== 'ka' || !isCanonicalEncodedComponent(parts[1]!)) {
+    return false;
+  }
+  const admittedLaneComponents = new Set([
+    '_',
+    ...(params.registeredSubGraphNames ?? []).map(encodeURIComponent),
+  ]);
+  return admittedLaneComponents.has(parts[0]!);
+}
+
 export interface GraphScopedSwmRecoveryDescriptor {
   readonly metaGraph: string;
   readonly headSubject: string;
@@ -379,6 +414,15 @@ function knowledgeAssetSnapshotGraph(
 ): string {
   const parts = [contextGraphId, subGraphName ?? '_', shareOperationId].map(encodeURIComponent);
   return `did:dkg:context-graph:${parts[0]}/_shared_memory_snapshots/${parts[1]}/${parts[2]}/ka`;
+}
+
+function isCanonicalEncodedComponent(value: string): boolean {
+  if (!value) return false;
+  try {
+    return encodeURIComponent(decodeURIComponent(value)) === value;
+  } catch {
+    return false;
+  }
 }
 
 function groupByGraphAndSubject(quads: readonly Quad[]): Map<string, Quad[]> {

--- a/packages/agent/src/sync/graph-scoped-swm-recovery.ts
+++ b/packages/agent/src/sync/graph-scoped-swm-recovery.ts
@@ -1,0 +1,447 @@
+import {
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  MemoryLayer,
+  createGraphKnowledgeAssetScope,
+  knowledgeAssetLayerGraphUri,
+  validateSubGraphName,
+} from '@origintrail-official/dkg-core';
+import {
+  workspacePublicQuadsDigest,
+  type WorkspacePublicSnapshotStore,
+} from '@origintrail-official/dkg-publisher';
+import type { Quad } from '@origintrail-official/dkg-storage';
+
+const DKG = 'http://dkg.io/ontology/';
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+const WORKSPACE_OPERATION = `${DKG}WorkspaceOperation`;
+
+const CONTENT_SCOPE_VERSION = `${DKG}contentScopeVersion`;
+const KA_UAL = `${DKG}kaUal`;
+const ASSERTION_VERSION = `${DKG}assertionVersion`;
+const ASSERTION_GRAPH = `${DKG}assertionGraph`;
+const SHARE_OPERATION_ID = `${DKG}shareOperationId`;
+const CONTEXT_GRAPH_ID = `${DKG}contextGraphId`;
+const PUBLIC_QUADS_DIGEST = `${DKG}publicQuadsDigest`;
+const PUBLIC_QUADS_COUNT = `${DKG}publicQuadsCount`;
+const PUBLIC_SNAPSHOT_REF = `${DKG}publicSnapshotRef`;
+const PUBLIC_SNAPSHOT_GRAPH = `${DKG}publicSnapshotGraph`;
+const PRIVATE_TRIPLE_COUNT = `${DKG}privateTripleCount`;
+const PRIVATE_MERKLE_ROOT = `${DKG}privateMerkleRoot`;
+const PUBLISHER_PEER_ID = `${DKG}publisherPeerId`;
+const PUBLISHED_AT = `${DKG}publishedAt`;
+const ACCESS_POLICY = `${DKG}accessPolicy`;
+const ALLOWED_PEER = `${DKG}allowedPeer`;
+const SUB_GRAPH_NAME = `${DKG}subGraphName`;
+const HEAD_SUFFIX = '#dkg-swm-head';
+
+export interface GraphScopedSwmRecoveryDescriptor {
+  readonly metaGraph: string;
+  readonly headSubject: string;
+  readonly operationSubject: string;
+  readonly kaUal: string;
+  readonly assertionVersion: string;
+  readonly assertionGraph: string;
+  readonly shareOperationId: string;
+  readonly publicQuadsDigest: string;
+  readonly publicQuadsCount: number;
+  readonly publicSnapshotRef?: string;
+  readonly publicSnapshotGraph?: string;
+  readonly publisherPeerId: string;
+  readonly subGraphName?: string;
+  /** Only the active head and its referenced operation, for snapshot fetch. */
+  readonly metadataQuads: readonly Quad[];
+}
+
+export interface MaterializedGraphScopedSwmRecoveryAsset
+  extends GraphScopedSwmRecoveryDescriptor {
+  readonly quads: readonly Quad[];
+}
+
+/**
+ * Recoveries run immediately after admission, before the durable subgraph
+ * registration projection is guaranteed to have landed locally. The
+ * authenticated responder has already filtered SWM lanes to its registered
+ * subgraphs, so bootstrap syntactically valid lane names from the response and
+ * retain the local known-child exclusion as the final collision guard.
+ */
+export function discoverSwmRecoverySubGraphNames(params: {
+  readonly contextGraphId: string;
+  readonly metaQuads: readonly Quad[];
+  readonly excludedSubGraphNames?: readonly string[];
+}): string[] {
+  const prefix = `did:dkg:context-graph:${params.contextGraphId}/`;
+  const suffix = '/_shared_memory_meta';
+  const excluded = new Set(params.excludedSubGraphNames ?? []);
+  const names = new Set<string>();
+  for (const quad of params.metaQuads) {
+    const graph = quad.graph;
+    if (!graph.startsWith(prefix) || !graph.endsWith(suffix)) continue;
+    const name = graph.slice(prefix.length, -suffix.length);
+    if (!name || excluded.has(name) || !validateSubGraphName(name).valid) continue;
+    names.add(name);
+  }
+  return [...names].sort();
+}
+
+/**
+ * Parse and validate the active graph-scoped SWM heads in a complete recovery
+ * metadata snapshot. Every accepted descriptor is bound to one deterministic
+ * UAL/version graph and one same-graph WorkspaceOperation commitment.
+ */
+export function parseGraphScopedSwmRecoveryDescriptors(params: {
+  readonly contextGraphId: string;
+  readonly metaQuads: readonly Quad[];
+  readonly registeredSubGraphNames?: readonly string[];
+  readonly excludedSubGraphNames?: readonly string[];
+}): GraphScopedSwmRecoveryDescriptor[] {
+  const allowedMetaGraphs = allowedWorkspaceMetaGraphs(
+    params.contextGraphId,
+    params.registeredSubGraphNames,
+    params.excludedSubGraphNames,
+  );
+  const byGraphAndSubject = groupByGraphAndSubject(params.metaQuads);
+  const descriptors: GraphScopedSwmRecoveryDescriptor[] = [];
+
+  for (const [key, headRows] of byGraphAndSubject) {
+    const separator = key.indexOf('\u0000');
+    const metaGraph = key.slice(0, separator);
+    const headSubject = key.slice(separator + 1);
+    if (!headSubject.endsWith(HEAD_SUFFIX)) continue;
+    if (!allowedMetaGraphs.has(metaGraph)) {
+      throw new Error(`Graph-scoped SWM head ${headSubject} is in an unregistered metadata graph ${metaGraph}`);
+    }
+
+    const kaUalFromHead = headSubject.slice(0, -HEAD_SUFFIX.length);
+    const scopeVersion = requireSafeInteger(headRows, CONTENT_SCOPE_VERSION, 'contentScopeVersion');
+    if (scopeVersion !== GRAPH_KA_CONTENT_SCOPE_VERSION) {
+      throw new Error(`Graph-scoped SWM head ${headSubject} has unsupported contentScopeVersion ${scopeVersion}`);
+    }
+    const kaUal = requireSingle(headRows, KA_UAL, 'kaUal');
+    const assertionVersion = requirePositiveInteger(headRows, ASSERTION_VERSION, 'assertionVersion');
+    const scope = createGraphKnowledgeAssetScope(kaUal, assertionVersion);
+    if (scope.ual !== kaUal || scope.ual !== kaUalFromHead) {
+      throw new Error(`Graph-scoped SWM head ${headSubject} has a non-canonical or mismatched kaUal`);
+    }
+
+    const subGraphName = subGraphForMetaGraph(params.contextGraphId, metaGraph);
+    const expectedAssertionGraph = knowledgeAssetLayerGraphUri(
+      params.contextGraphId,
+      MemoryLayer.SharedWorkingMemory,
+      scope,
+      subGraphName,
+    );
+    const assertionGraph = requireSingle(headRows, ASSERTION_GRAPH, 'assertionGraph');
+    if (assertionGraph !== expectedAssertionGraph) {
+      throw new Error(
+        `Graph-scoped SWM head ${headSubject} assertionGraph mismatch: ` +
+        `expected ${expectedAssertionGraph}, found ${assertionGraph}`,
+      );
+    }
+
+    const shareOperationId = requireLiteral(headRows, SHARE_OPERATION_ID, 'shareOperationId').trim();
+    if (!shareOperationId) throw new Error(`Graph-scoped SWM head ${headSubject} has an empty shareOperationId`);
+    const operationSubject = `urn:dkg:share:${params.contextGraphId}:${shareOperationId}`;
+    const operationRows = byGraphAndSubject.get(`${metaGraph}\u0000${operationSubject}`) ?? [];
+    validateOperationRows({
+      rows: operationRows,
+      contextGraphId: params.contextGraphId,
+      metaGraph,
+      operationSubject,
+      shareOperationId,
+      kaUal: scope.ual,
+      assertionVersion: scope.assertionVersion,
+      subGraphName,
+    });
+
+    const publicQuadsDigest = requireLiteral(
+      operationRows,
+      PUBLIC_QUADS_DIGEST,
+      'publicQuadsDigest',
+    ).trim().toLowerCase();
+    if (!/^sha256:[0-9a-f]{64}$/.test(publicQuadsDigest)) {
+      throw new Error(`Graph-scoped SWM operation ${operationSubject} has an invalid publicQuadsDigest`);
+    }
+    const publicQuadsCount = requireSafeInteger(
+      operationRows,
+      PUBLIC_QUADS_COUNT,
+      'publicQuadsCount',
+    );
+    if (publicQuadsCount < 0) {
+      throw new Error(`Graph-scoped SWM operation ${operationSubject} has a negative publicQuadsCount`);
+    }
+    const privateTripleCount = requireSafeInteger(
+      operationRows,
+      PRIVATE_TRIPLE_COUNT,
+      'privateTripleCount',
+    );
+    if (privateTripleCount < 0 || (privateTripleCount === 0 && publicQuadsCount === 0)) {
+      throw new Error(`Graph-scoped SWM operation ${operationSubject} has invalid public/private counts`);
+    }
+    const privateRoot = optionalSingle(operationRows, PRIVATE_MERKLE_ROOT, 'privateMerkleRoot');
+    if (
+      (privateTripleCount > 0 && !/^0x[0-9a-fA-F]{64}$/.test(stripLiteral(privateRoot ?? '')))
+      || (privateTripleCount === 0 && privateRoot !== undefined)
+    ) {
+      throw new Error(`Graph-scoped SWM operation ${operationSubject} has an invalid private commitment`);
+    }
+
+    const publicSnapshotGraph = optionalSingle(
+      operationRows,
+      PUBLIC_SNAPSHOT_GRAPH,
+      'publicSnapshotGraph',
+    );
+    const explicitSnapshotRef = optionalLiteral(
+      operationRows,
+      PUBLIC_SNAPSHOT_REF,
+      'publicSnapshotRef',
+    )?.trim();
+    if (publicSnapshotGraph && explicitSnapshotRef) {
+      throw new Error(`Graph-scoped SWM operation ${operationSubject} has two public snapshot locations`);
+    }
+    if (publicSnapshotGraph) {
+      const expectedSnapshotGraph = knowledgeAssetSnapshotGraph(
+        params.contextGraphId,
+        shareOperationId,
+        subGraphName,
+      );
+      if (publicSnapshotGraph !== expectedSnapshotGraph) {
+        throw new Error(
+          `Graph-scoped SWM operation ${operationSubject} snapshot graph mismatch: ` +
+          `expected ${expectedSnapshotGraph}, found ${publicSnapshotGraph}`,
+        );
+      }
+    }
+    const publicSnapshotRef = publicSnapshotGraph
+      ? undefined
+      : (explicitSnapshotRef || publicQuadsDigest);
+    if (publicSnapshotRef && !/^sha256:[0-9a-f]{64}$/i.test(publicSnapshotRef)) {
+      throw new Error(`Graph-scoped SWM operation ${operationSubject} has an invalid publicSnapshotRef`);
+    }
+
+    const publisherPeerId = requireLiteral(operationRows, PUBLISHER_PEER_ID, 'publisherPeerId').trim();
+    if (!publisherPeerId) {
+      throw new Error(`Graph-scoped SWM operation ${operationSubject} has an empty publisherPeerId`);
+    }
+    descriptors.push({
+      metaGraph,
+      headSubject,
+      operationSubject,
+      kaUal: scope.ual,
+      assertionVersion: scope.assertionVersion,
+      assertionGraph,
+      shareOperationId,
+      publicQuadsDigest,
+      publicQuadsCount,
+      ...(publicSnapshotRef ? { publicSnapshotRef } : {}),
+      ...(publicSnapshotGraph ? { publicSnapshotGraph } : {}),
+      publisherPeerId,
+      ...(subGraphName ? { subGraphName } : {}),
+      metadataQuads: [...headRows, ...operationRows],
+    });
+  }
+
+  const assertionOwners = new Map<string, string>();
+  for (const descriptor of descriptors) {
+    const owner = assertionOwners.get(descriptor.assertionGraph);
+    if (owner && owner !== descriptor.kaUal) {
+      throw new Error(`Graph-scoped SWM assertion graph ${descriptor.assertionGraph} has multiple UAL owners`);
+    }
+    assertionOwners.set(descriptor.assertionGraph, descriptor.kaUal);
+  }
+  return descriptors;
+}
+
+/** Load and re-verify one immutable snapshot, then stamp its exact SWM graph. */
+export async function materializeGraphScopedSwmRecoveryAsset(params: {
+  readonly descriptor: GraphScopedSwmRecoveryDescriptor;
+  readonly fetchedDataQuads: readonly Quad[];
+  readonly publicSnapshotStore?: WorkspacePublicSnapshotStore;
+}): Promise<MaterializedGraphScopedSwmRecoveryAsset> {
+  const descriptor = params.descriptor;
+  let raw: Quad[] | null;
+  if (descriptor.publicSnapshotGraph) {
+    raw = params.fetchedDataQuads
+      .filter((quad) => quad.graph === descriptor.publicSnapshotGraph)
+      .map((quad) => ({ ...quad, graph: '' }));
+  } else {
+    if (!params.publicSnapshotStore || !descriptor.publicSnapshotRef) {
+      throw new Error(`Graph-scoped SWM recovery requires a public snapshot store for ${descriptor.kaUal}`);
+    }
+    raw = await params.publicSnapshotStore.getSnapshot(descriptor.publicSnapshotRef);
+  }
+  if (!raw) {
+    throw new Error(`Graph-scoped SWM snapshot is missing for ${descriptor.kaUal}`);
+  }
+  const normalized = raw.map((quad) => ({ ...quad, graph: '' }));
+  const actualDigest = workspacePublicQuadsDigest(normalized);
+  if (
+    normalized.length !== descriptor.publicQuadsCount
+    || actualDigest !== descriptor.publicQuadsDigest
+  ) {
+    throw new Error(
+      `Graph-scoped SWM snapshot failed integrity for ${descriptor.kaUal}: ` +
+      `expected ${descriptor.publicQuadsDigest}/${descriptor.publicQuadsCount}, ` +
+      `got ${actualDigest}/${normalized.length}`,
+    );
+  }
+  return {
+    ...descriptor,
+    quads: normalized.map((quad) => ({ ...quad, graph: descriptor.assertionGraph })),
+  };
+}
+
+function validateOperationRows(params: {
+  rows: readonly Quad[];
+  contextGraphId: string;
+  metaGraph: string;
+  operationSubject: string;
+  shareOperationId: string;
+  kaUal: string;
+  assertionVersion: string;
+  subGraphName?: string;
+}): void {
+  const rows = params.rows;
+  if (rows.length === 0) {
+    throw new Error(`Graph-scoped SWM head references missing operation ${params.operationSubject}`);
+  }
+  if (!rows.some((row) => row.predicate === RDF_TYPE && row.object === WORKSPACE_OPERATION)) {
+    throw new Error(`Graph-scoped SWM operation ${params.operationSubject} is missing its type`);
+  }
+  requireSingle(rows, PUBLISHED_AT, 'publishedAt');
+  if (requireSafeInteger(rows, CONTENT_SCOPE_VERSION, 'contentScopeVersion') !== GRAPH_KA_CONTENT_SCOPE_VERSION) {
+    throw new Error(`Graph-scoped SWM operation ${params.operationSubject} has an invalid scope version`);
+  }
+  if (requireLiteral(rows, CONTEXT_GRAPH_ID, 'contextGraphId') !== params.contextGraphId) {
+    throw new Error(`Graph-scoped SWM operation ${params.operationSubject} has a contextGraphId mismatch`);
+  }
+  if (requireLiteral(rows, SHARE_OPERATION_ID, 'shareOperationId') !== params.shareOperationId) {
+    throw new Error(`Graph-scoped SWM operation ${params.operationSubject} has a shareOperationId mismatch`);
+  }
+  if (requireSingle(rows, KA_UAL, 'kaUal') !== params.kaUal) {
+    throw new Error(`Graph-scoped SWM operation ${params.operationSubject} has a kaUal mismatch`);
+  }
+  if (requirePositiveInteger(rows, ASSERTION_VERSION, 'assertionVersion') !== params.assertionVersion) {
+    throw new Error(`Graph-scoped SWM operation ${params.operationSubject} has an assertionVersion mismatch`);
+  }
+  const operationSubGraph = optionalLiteral(rows, SUB_GRAPH_NAME, 'subGraphName')?.trim();
+  if (operationSubGraph !== params.subGraphName) {
+    throw new Error(`Graph-scoped SWM operation ${params.operationSubject} has a subGraphName mismatch`);
+  }
+  const accessPolicy = optionalLiteral(rows, ACCESS_POLICY, 'accessPolicy')?.trim();
+  if (accessPolicy && !['public', 'ownerOnly', 'allowList'].includes(accessPolicy)) {
+    throw new Error(`Graph-scoped SWM operation ${params.operationSubject} has an invalid accessPolicy`);
+  }
+  const allowedPeers = distinctObjects(rows, ALLOWED_PEER).map(stripLiteral).filter(Boolean);
+  if (
+    (accessPolicy === 'allowList' && allowedPeers.length === 0)
+    || (accessPolicy !== 'allowList' && allowedPeers.length > 0)
+  ) {
+    throw new Error(`Graph-scoped SWM operation ${params.operationSubject} has an invalid access envelope`);
+  }
+  for (const row of rows) {
+    if (row.graph !== params.metaGraph || row.subject !== params.operationSubject) {
+      throw new Error(`Graph-scoped SWM operation ${params.operationSubject} is not graph-local`);
+    }
+  }
+}
+
+function allowedWorkspaceMetaGraphs(
+  contextGraphId: string,
+  registeredSubGraphNames: readonly string[] | undefined,
+  excludedSubGraphNames: readonly string[] | undefined,
+): Set<string> {
+  const prefix = `did:dkg:context-graph:${contextGraphId}`;
+  const allowed = new Set<string>([`${prefix}/_shared_memory_meta`]);
+  const excluded = new Set(excludedSubGraphNames ?? []);
+  for (const name of registeredSubGraphNames ?? []) {
+    if (excluded.has(name) || !validateSubGraphName(name).valid) continue;
+    allowed.add(`${prefix}/${name}/_shared_memory_meta`);
+  }
+  return allowed;
+}
+
+function subGraphForMetaGraph(contextGraphId: string, metaGraph: string): string | undefined {
+  const root = `did:dkg:context-graph:${contextGraphId}/_shared_memory_meta`;
+  if (metaGraph === root) return undefined;
+  const prefix = `did:dkg:context-graph:${contextGraphId}/`;
+  const suffix = '/_shared_memory_meta';
+  const name = metaGraph.slice(prefix.length, -suffix.length);
+  if (!validateSubGraphName(name).valid) {
+    throw new Error(`Invalid graph-scoped SWM subgraph metadata graph ${metaGraph}`);
+  }
+  return name;
+}
+
+function knowledgeAssetSnapshotGraph(
+  contextGraphId: string,
+  shareOperationId: string,
+  subGraphName?: string,
+): string {
+  const parts = [contextGraphId, subGraphName ?? '_', shareOperationId].map(encodeURIComponent);
+  return `did:dkg:context-graph:${parts[0]}/_shared_memory_snapshots/${parts[1]}/${parts[2]}/ka`;
+}
+
+function groupByGraphAndSubject(quads: readonly Quad[]): Map<string, Quad[]> {
+  const grouped = new Map<string, Quad[]>();
+  for (const quad of quads) {
+    const key = `${quad.graph}\u0000${quad.subject}`;
+    const rows = grouped.get(key);
+    if (rows) rows.push(quad);
+    else grouped.set(key, [quad]);
+  }
+  return grouped;
+}
+
+function distinctObjects(rows: readonly Quad[], predicate: string): string[] {
+  return [...new Set(rows.filter((row) => row.predicate === predicate).map((row) => row.object))];
+}
+
+function requireSingle(rows: readonly Quad[], predicate: string, field: string): string {
+  const values = distinctObjects(rows, predicate);
+  if (values.length !== 1) {
+    throw new Error(`${values.length === 0 ? 'missing' : 'ambiguous'} ${field}`);
+  }
+  return values[0]!;
+}
+
+function optionalSingle(rows: readonly Quad[], predicate: string, field: string): string | undefined {
+  const values = distinctObjects(rows, predicate);
+  if (values.length > 1) throw new Error(`ambiguous ${field}`);
+  return values[0];
+}
+
+function requireLiteral(rows: readonly Quad[], predicate: string, field: string): string {
+  return stripLiteral(requireSingle(rows, predicate, field));
+}
+
+function optionalLiteral(rows: readonly Quad[], predicate: string, field: string): string | undefined {
+  const value = optionalSingle(rows, predicate, field);
+  return value === undefined ? undefined : stripLiteral(value);
+}
+
+function requireSafeInteger(rows: readonly Quad[], predicate: string, field: string): number {
+  const raw = stripLiteral(requireSingle(rows, predicate, field));
+  if (!/^-?[0-9]+$/.test(raw)) throw new Error(`invalid ${field}`);
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed)) throw new Error(`unsafe ${field}`);
+  return parsed;
+}
+
+function requirePositiveInteger(rows: readonly Quad[], predicate: string, field: string): string {
+  const raw = stripLiteral(requireSingle(rows, predicate, field));
+  if (!/^[0-9]+$/.test(raw)) throw new Error(`invalid ${field}`);
+  const parsed = BigInt(raw);
+  if (parsed < 1n) throw new Error(`${field} must be positive`);
+  return parsed.toString();
+}
+
+function stripLiteral(value: string): string {
+  const match = value.match(/^"((?:[^"\\]|\\.)*)"(?:@[-A-Za-z0-9]+|\^\^<[^>]+>)?$/);
+  if (!match) return value;
+  return match[1]!
+    .replace(/\\n/g, '\n')
+    .replace(/\\r/g, '\r')
+    .replace(/\\t/g, '\t')
+    .replace(/\\"/g, '"')
+    .replace(/\\\\/g, '\\');
+}

--- a/packages/agent/src/sync/rdf-metadata.ts
+++ b/packages/agent/src/sync/rdf-metadata.ts
@@ -1,0 +1,77 @@
+import type { Quad } from '@origintrail-official/dkg-storage';
+import { stripLiteral } from '../dkg-agent-utils.js';
+
+/** Canonical low-level RDF metadata reads shared by sync descriptor parsers. */
+export function distinctRdfObjects(
+  rows: readonly Quad[],
+  predicate: string,
+  options?: { readonly stripLiterals?: boolean },
+): string[] {
+  const values = rows
+    .filter((row) => row.predicate === predicate)
+    .map((row) => options?.stripLiterals ? stripLiteral(row.object) : row.object);
+  return [...new Set(values)];
+}
+
+export function requireRdfObject(
+  rows: readonly Quad[],
+  predicate: string,
+  field: string,
+): string {
+  const values = distinctRdfObjects(rows, predicate);
+  if (values.length !== 1) {
+    throw new Error(`${values.length === 0 ? 'missing' : 'ambiguous'} ${field}`);
+  }
+  return values[0]!;
+}
+
+export function optionalRdfObject(
+  rows: readonly Quad[],
+  predicate: string,
+  field: string,
+): string | undefined {
+  const values = distinctRdfObjects(rows, predicate);
+  if (values.length > 1) throw new Error(`ambiguous ${field}`);
+  return values[0];
+}
+
+export function requireRdfLiteral(
+  rows: readonly Quad[],
+  predicate: string,
+  field: string,
+): string {
+  return stripLiteral(requireRdfObject(rows, predicate, field));
+}
+
+export function optionalRdfLiteral(
+  rows: readonly Quad[],
+  predicate: string,
+  field: string,
+): string | undefined {
+  const value = optionalRdfObject(rows, predicate, field);
+  return value === undefined ? undefined : stripLiteral(value);
+}
+
+export function requireRdfSafeInteger(
+  rows: readonly Quad[],
+  predicate: string,
+  field: string,
+): number {
+  const raw = requireRdfLiteral(rows, predicate, field);
+  if (!/^-?[0-9]+$/.test(raw)) throw new Error(`invalid ${field}`);
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed)) throw new Error(`unsafe ${field}`);
+  return parsed;
+}
+
+export function requireRdfPositiveIntegerString(
+  rows: readonly Quad[],
+  predicate: string,
+  field: string,
+): string {
+  const raw = requireRdfLiteral(rows, predicate, field);
+  if (!/^[0-9]+$/.test(raw)) throw new Error(`invalid ${field}`);
+  const parsed = BigInt(raw);
+  if (parsed < 1n) throw new Error(`${field} must be positive`);
+  return parsed.toString();
+}

--- a/packages/agent/src/sync/requester/graph-scoped-swm-meta-replace.ts
+++ b/packages/agent/src/sync/requester/graph-scoped-swm-meta-replace.ts
@@ -1,0 +1,49 @@
+import { assertSafeIri } from '@origintrail-official/dkg-core';
+import type { TripleStore } from '@origintrail-official/dkg-storage';
+import type { GraphScopedSwmRecoveryDescriptor } from '../graph-scoped-swm-recovery.js';
+
+/**
+ * Remove the prior active head and every linked operation before inserting the
+ * verified graph-scoped recovery metadata. Keeping this beside the recovery
+ * model makes data and metadata replacement one explicit store invariant.
+ */
+export async function replaceGraphScopedSwmRecoveryMetadata(
+  store: TripleStore,
+  assets: readonly GraphScopedSwmRecoveryDescriptor[],
+): Promise<void> {
+  for (const asset of assets) {
+    const linkedOperations = await store.query(
+      `SELECT DISTINCT ?op WHERE { GRAPH <${assertSafeIri(asset.metaGraph)}> { ` +
+        `<${assertSafeIri(asset.headSubject)}> <http://dkg.io/ontology/shareOperationId> ?shareId . ` +
+        `?op <http://dkg.io/ontology/shareOperationId> ?shareId ; ` +
+        `<http://dkg.io/ontology/kaUal> <${assertSafeIri(asset.kaUal)}> . } }`,
+      {
+        priority: 'background',
+        source: 'agent.swmRecovery.replaceGraphMeta.findOperations',
+      },
+    );
+    const operationSubjects = new Set<string>([asset.operationSubject]);
+    if (linkedOperations.type === 'bindings') {
+      for (const row of linkedOperations.bindings) {
+        const operation = row['op'];
+        if (operation) operationSubjects.add(operation);
+      }
+    }
+    await store.deleteByPattern(
+      { graph: asset.metaGraph, subject: asset.headSubject },
+      {
+        priority: 'background',
+        source: 'agent.swmRecovery.replaceGraphMeta.deleteHead',
+      },
+    );
+    for (const operationSubject of operationSubjects) {
+      await store.deleteByPattern(
+        { graph: asset.metaGraph, subject: operationSubject },
+        {
+          priority: 'background',
+          source: 'agent.swmRecovery.replaceGraphMeta.deleteOperation',
+        },
+      );
+    }
+  }
+}

--- a/packages/agent/src/sync/requester/graph-scoped-swm-meta-replace.ts
+++ b/packages/agent/src/sync/requester/graph-scoped-swm-meta-replace.ts
@@ -7,7 +7,7 @@ import type { GraphScopedSwmRecoveryDescriptor } from '../graph-scoped-swm-recov
  * verified graph-scoped recovery metadata. Keeping this beside the recovery
  * model makes data and metadata replacement one explicit store invariant.
  */
-export async function replaceGraphScopedSwmRecoveryMetadata(
+export async function deletePriorGraphScopedSwmRecoveryMetadata(
   store: TripleStore,
   assets: readonly GraphScopedSwmRecoveryDescriptor[],
 ): Promise<void> {

--- a/packages/agent/src/sync/requester/page-fetch.ts
+++ b/packages/agent/src/sync/requester/page-fetch.ts
@@ -77,6 +77,7 @@ interface FetchSyncPagesParams {
   phase: SyncPhase;
   graphUri: string;
   snapshotRef?: string;
+  snapshotGraph?: string;
   deadline: number;
   syncPageTimeoutMs: number;
   syncRouterAttempts: number;
@@ -114,7 +115,7 @@ interface FetchSyncPagesParams {
    * members-only `isMemberRecoveryAuthorized`). Default false ⇒ normal sync.
    */
   recovery?: boolean;
-  buildSyncRequest: (contextGraphId: string, offset: number, limit: number, includeSharedMemory: boolean, remotePeerId: string, phase?: SyncPhase, snapshotRef?: string, sinceBatchId?: string, syncSessionId?: string, recovery?: boolean) => Promise<Uint8Array>;
+  buildSyncRequest: (contextGraphId: string, offset: number, limit: number, includeSharedMemory: boolean, remotePeerId: string, phase?: SyncPhase, snapshotRef?: string, sinceBatchId?: string, syncSessionId?: string, recovery?: boolean, snapshotGraph?: string) => Promise<Uint8Array>;
   /**
    * Phase C — optional, gap-safe delta-sync high-water mark. Forwarded to the
    * responder for the durable DATA phase so it returns only KAs with
@@ -184,6 +185,7 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
     phase,
     graphUri,
     snapshotRef,
+    snapshotGraph,
     deadline,
     syncPageTimeoutMs,
     syncRouterAttempts,
@@ -273,7 +275,7 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
         // full rationale (codex review on #569 follow-ups #1, #4-#8).
         requestFactory: async () => {
           throwIfAborted(signal);
-          const request = await buildSyncRequest(contextGraphId, curOffset, syncPageSize, includeSharedMemory, remotePeerId, phase, snapshotRef, sinceBatchId, syncSessionId, recovery);
+          const request = await buildSyncRequest(contextGraphId, curOffset, syncPageSize, includeSharedMemory, remotePeerId, phase, snapshotRef, sinceBatchId, syncSessionId, recovery, snapshotGraph);
           throwIfAborted(signal);
           return request;
         },

--- a/packages/agent/src/sync/requester/shared-memory-sync.ts
+++ b/packages/agent/src/sync/requester/shared-memory-sync.ts
@@ -345,13 +345,13 @@ export function sharedMemoryOwnershipKeyFromGraph(contextGraphId: string, dataGr
   return `${contextGraphId}\0${subGraphName}`;
 }
 
-interface PublicSnapshotMetadata {
+export interface PublicSnapshotMetadata {
   ref: string;
   digest: string;
   count: number;
 }
 
-async function syncPublicSnapshotsForMeta(params: {
+export async function syncPublicSnapshotsForMeta(params: {
   ctx: OperationContext;
   remotePeerId: string;
   contextGraphId: string;
@@ -450,7 +450,7 @@ async function syncPublicSnapshotsForMeta(params: {
   };
 }
 
-function collectPublicSnapshotMetadata(metaQuads: readonly Quad[]): PublicSnapshotMetadata[] {
+export function collectPublicSnapshotMetadata(metaQuads: readonly Quad[]): PublicSnapshotMetadata[] {
   const bySubject = new Map<string, { ref?: string; digest?: string; count?: number; hasSnapshotGraph?: boolean }>();
   for (const quad of metaQuads) {
     if (

--- a/packages/agent/src/sync/requester/swm-recovery-apply.ts
+++ b/packages/agent/src/sync/requester/swm-recovery-apply.ts
@@ -26,8 +26,6 @@ import type { Quad } from '@origintrail-official/dkg-storage';
 /** The subset of the triple store this apply needs. */
 export interface SwmRecoveryStore {
   insert(quads: Quad[]): Promise<unknown>;
-  /** Atomic complete-graph replacement required by graph-scoped recovery. */
-  replaceGraph(graph: string, quads: Quad[]): Promise<unknown>;
   deleteByPattern(pattern: { graph: string; subject: string }): Promise<unknown>;
   deleteBySubjectPrefix(graph: string, prefix: string): Promise<unknown>;
 }

--- a/packages/agent/src/sync/requester/swm-recovery-apply.ts
+++ b/packages/agent/src/sync/requester/swm-recovery-apply.ts
@@ -26,6 +26,8 @@ import type { Quad } from '@origintrail-official/dkg-storage';
 /** The subset of the triple store this apply needs. */
 export interface SwmRecoveryStore {
   insert(quads: Quad[]): Promise<unknown>;
+  /** Atomic complete-graph replacement required by graph-scoped recovery. */
+  replaceGraph(graph: string, quads: Quad[]): Promise<unknown>;
   deleteByPattern(pattern: { graph: string; subject: string }): Promise<unknown>;
   deleteBySubjectPrefix(graph: string, prefix: string): Promise<unknown>;
 }

--- a/packages/agent/src/sync/requester/swm-recovery.ts
+++ b/packages/agent/src/sync/requester/swm-recovery.ts
@@ -79,6 +79,7 @@ export interface RecoverContextGraphSwmDeps {
     graphUri: string,
     deadline: number,
     snapshotRef?: string,
+    snapshotGraph?: string,
   ) => Promise<SyncPageResult>;
   readonly processSharedMemoryBatch: (
     wsDataQuads: Quad[],
@@ -202,6 +203,7 @@ async function fetchGraphBackedSnapshotQuads(
       'snapshot',
       descriptor.publicSnapshotGraph,
       deps.deadline,
+      descriptor.publicSnapshotGraph,
       descriptor.publicSnapshotGraph,
     );
     // Recovery has no durable cross-invocation snapshot accumulator. A resumed
@@ -346,6 +348,17 @@ export async function recoverContextGraphSwm(
     legacyDataQuads, meta.quads, deps.contextGraphId, registered, excluded,
   );
 
+  // Graph-scoped descriptor metadata has already passed its dedicated,
+  // graph-local validation above. Keep it out of the legacy verifier's remote
+  // lane admission (which must remain limited to locally registered
+  // subgraphs), then merge it back into the final metadata apply set. Without
+  // this split, a bootstrapped subgraph recovers its exact data graph but loses
+  // the active head and WorkspaceOperation rows needed to resolve it later.
+  const verifiedMeta = distinctQuads([
+    ...processed.verifiedMeta,
+    ...graphScopedDescriptors.flatMap((descriptor) => descriptor.metadataQuads),
+  ]);
+
   // Build the complete exact-graph apply plan before the first store mutation.
   // A corrupt graph-scoped snapshot must not leave already-replaced legacy
   // roots or an earlier exact graph behind.
@@ -391,8 +404,8 @@ export async function recoverContextGraphSwm(
   if (graphScopedDescriptors.length > 0) {
     await deps.replaceMetaForGraphAssets(graphScopedDescriptors);
   }
-  if (processed.verifiedMeta.length > 0) {
-    await deps.store.insert([...processed.verifiedMeta]);
+  if (verifiedMeta.length > 0) {
+    await deps.store.insert(verifiedMeta);
   }
 
   // R2 — hydrate the Rule-4 ownership cache for the recovered roots (parity with
@@ -415,15 +428,27 @@ export async function recoverContextGraphSwm(
     deps.ctx,
     `SWM recovery for "${deps.contextGraphId}" from ${deps.remotePeerId}: replaced ${applied.replacedRoots} roots, ` +
     `${replacedGraphs} exact graphs, ${applied.insertedQuads + insertedGraphQuads} data + ` +
-    `${processed.verifiedMeta.length} meta triples`,
+    `${verifiedMeta.length} meta triples`,
   );
 
   return {
     replacedRoots: applied.replacedRoots,
     replacedGraphs,
     insertedDataQuads: applied.insertedQuads + insertedGraphQuads,
-    insertedMetaQuads: processed.verifiedMeta.length,
+    insertedMetaQuads: verifiedMeta.length,
     droppedDataTriples: processed.droppedDataTriples,
     completed: true,
   };
+}
+
+function distinctQuads(quads: readonly Quad[]): Quad[] {
+  const seen = new Set<string>();
+  const result: Quad[] = [];
+  for (const quad of quads) {
+    const key = `${quad.graph}\u0000${quad.subject}\u0000${quad.predicate}\u0000${quad.object}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(quad);
+  }
+  return result;
 }

--- a/packages/agent/src/sync/requester/swm-recovery.ts
+++ b/packages/agent/src/sync/requester/swm-recovery.ts
@@ -18,6 +18,7 @@ import {
   materializeGraphScopedSwmRecoveryAsset,
   parseGraphScopedSwmRecoveryDescriptors,
   type GraphScopedSwmRecoveryDescriptor,
+  type MaterializedGraphScopedSwmRecoveryAsset,
 } from '../graph-scoped-swm-recovery.js';
 
 /**
@@ -96,8 +97,8 @@ export interface RecoverContextGraphSwmDeps {
     roots: readonly { readonly entity: string }[],
     metaGraphs: readonly string[],
   ) => Promise<void>;
-  /** Replace the active head/operation rows for each exact graph asset. */
-  readonly replaceMetaForGraphAssets?: (
+  /** Required metadata half of exact graph replacement. */
+  readonly replaceMetaForGraphAssets: (
     assets: readonly GraphScopedSwmRecoveryDescriptor[],
   ) => Promise<void>;
   readonly ensureContextGraph: (contextGraphId: string) => Promise<void>;
@@ -159,6 +160,52 @@ async function fetchPhaseFully(
   // list) and rebuild the COMPLETE state before the apply gate can pass.
   if (lastCheckpointKey !== undefined) deps.deleteCheckpoint(lastCheckpointKey);
   return { quads: all, completed: false };
+}
+
+async function fetchGraphBackedSnapshotQuads(
+  deps: RecoverContextGraphSwmDeps,
+  descriptors: readonly GraphScopedSwmRecoveryDescriptor[],
+  fetchedDataQuads: readonly Quad[],
+): Promise<{ quads: Quad[]; completed: boolean }> {
+  const quads: Quad[] = [];
+  for (const descriptor of descriptors) {
+    if (!descriptor.publicSnapshotGraph) continue;
+    try {
+      // Rolling responders may already carry immutable snapshot graphs in the
+      // SWM data phase. Accept a complete integrity-checked copy without a
+      // redundant snapshot RPC; partial/corrupt copies fall through to the
+      // authenticated exact-graph fetch below.
+      await materializeGraphScopedSwmRecoveryAsset({
+        descriptor,
+        fetchedDataQuads,
+      });
+      continue;
+    } catch {
+      // Fetch the canonical graph explicitly and validate the combined plan
+      // before any store mutation.
+    }
+    const result = await deps.fetchSyncPages(
+      deps.ctx,
+      deps.remotePeerId,
+      deps.contextGraphId,
+      true,
+      'snapshot',
+      descriptor.publicSnapshotGraph,
+      deps.deadline,
+      descriptor.publicSnapshotGraph,
+    );
+    // Recovery has no durable cross-invocation snapshot accumulator. A resumed
+    // or incomplete page would be only a suffix, so discard its checkpoint and
+    // force the next attempt to verify the complete immutable graph from zero.
+    deps.deleteCheckpoint(result.checkpointKey);
+    if (!result.completed || result.resumedFromOffset > 0) {
+      return { quads: [], completed: false };
+    }
+    for (const quad of result.quads) {
+      quads.push({ ...quad, graph: descriptor.publicSnapshotGraph });
+    }
+  }
+  return { quads, completed: true };
 }
 
 export async function recoverContextGraphSwm(
@@ -249,6 +296,27 @@ export async function recoverContextGraphSwm(
     }
   }
 
+  const graphBackedSnapshots = await fetchGraphBackedSnapshotQuads(
+    deps,
+    graphScopedDescriptors,
+    data.quads,
+  );
+  if (!graphBackedSnapshots.completed) {
+    deps.logInfo?.(
+      deps.ctx,
+      `SWM recovery for "${deps.contextGraphId}" from ${deps.remotePeerId}: ` +
+      'graph-backed public snapshot fetch incomplete — skipped, will retry',
+    );
+    return {
+      replacedRoots: 0,
+      replacedGraphs: 0,
+      insertedDataQuads: 0,
+      insertedMetaQuads: 0,
+      droppedDataTriples: 0,
+      completed: false,
+    };
+  }
+
   // Rootless exact graphs and graph-backed immutable snapshots are verified
   // per KA below. Keep them out of the legacy rootEntity worker path so they
   // are not counted as invalid root subjects or inserted by union.
@@ -267,6 +335,19 @@ export async function recoverContextGraphSwm(
     legacyDataQuads, meta.quads, deps.contextGraphId, recoveryRegistered, excluded,
   );
 
+  // Build the complete exact-graph apply plan before the first store mutation.
+  // A corrupt graph-scoped snapshot must not leave already-replaced legacy
+  // roots or an earlier exact graph behind.
+  const graphScopedAssets: MaterializedGraphScopedSwmRecoveryAsset[] = [];
+  const graphSnapshotQuads = [...data.quads, ...graphBackedSnapshots.quads];
+  for (const descriptor of graphScopedDescriptors) {
+    graphScopedAssets.push(await materializeGraphScopedSwmRecoveryAsset({
+      descriptor,
+      fetchedDataQuads: graphSnapshotQuads,
+      publicSnapshotStore: deps.publicSnapshotStore,
+    }));
+  }
+
   await deps.ensureContextGraph(deps.contextGraphId);
 
   // REPLACE per root (the recovery fix), applied over the COMPLETE fetched state.
@@ -277,12 +358,7 @@ export async function recoverContextGraphSwm(
   });
   let replacedGraphs = 0;
   let insertedGraphQuads = 0;
-  for (const descriptor of graphScopedDescriptors) {
-    const asset = await materializeGraphScopedSwmRecoveryAsset({
-      descriptor,
-      fetchedDataQuads: data.quads,
-      publicSnapshotStore: deps.publicSnapshotStore,
-    });
+  for (const asset of graphScopedAssets) {
     await deps.store.replaceGraph(asset.assertionGraph, [...asset.quads]);
     replacedGraphs += 1;
     insertedGraphQuads += asset.quads.length;
@@ -297,7 +373,7 @@ export async function recoverContextGraphSwm(
     await deps.replaceMetaForRoots?.(processed.entityCreators, metaGraphs);
   }
   if (graphScopedDescriptors.length > 0) {
-    await deps.replaceMetaForGraphAssets?.(graphScopedDescriptors);
+    await deps.replaceMetaForGraphAssets(graphScopedDescriptors);
   }
   if (processed.verifiedMeta.length > 0) {
     await deps.store.insert([...processed.verifiedMeta]);

--- a/packages/agent/src/sync/requester/swm-recovery.ts
+++ b/packages/agent/src/sync/requester/swm-recovery.ts
@@ -59,6 +59,11 @@ interface ProcessedSwmBatch {
   readonly droppedDataTriples: number;
 }
 
+interface GraphScopedSwmRecoveryStore extends SwmRecoveryStore {
+  /** Atomic complete-graph replacement required only by graph-scoped recovery. */
+  replaceGraph(graph: string, quads: Quad[]): Promise<unknown>;
+}
+
 export interface RecoverContextGraphSwmDeps {
   readonly ctx: OperationContext;
   readonly remotePeerId: string;
@@ -82,7 +87,7 @@ export interface RecoverContextGraphSwmDeps {
     registeredSubGraphNames?: readonly string[],
     excludedSubGraphNames?: readonly string[],
   ) => Promise<ProcessedSwmBatch>;
-  readonly store: SwmRecoveryStore;
+  readonly store: GraphScopedSwmRecoveryStore;
   readonly publicSnapshotStore?: WorkspacePublicSnapshotStore;
   /**
    * REPLACE (not append) the SWM meta for each recovered root, BEFORE the fresh
@@ -166,8 +171,13 @@ async function fetchGraphBackedSnapshotQuads(
   deps: RecoverContextGraphSwmDeps,
   descriptors: readonly GraphScopedSwmRecoveryDescriptor[],
   fetchedDataQuads: readonly Quad[],
-): Promise<{ quads: Quad[]; completed: boolean }> {
+): Promise<{
+  quads: Quad[];
+  completed: boolean;
+  explicitlyFetchedGraphs: ReadonlySet<string>;
+}> {
   const quads: Quad[] = [];
+  const explicitlyFetchedGraphs = new Set<string>();
   for (const descriptor of descriptors) {
     if (!descriptor.publicSnapshotGraph) continue;
     try {
@@ -181,8 +191,8 @@ async function fetchGraphBackedSnapshotQuads(
       });
       continue;
     } catch {
-      // Fetch the canonical graph explicitly and validate the combined plan
-      // before any store mutation.
+      // Fetch the canonical graph explicitly. The caller replaces, rather
+      // than combines, any rejected data-phase copy before validation.
     }
     const result = await deps.fetchSyncPages(
       deps.ctx,
@@ -199,13 +209,14 @@ async function fetchGraphBackedSnapshotQuads(
     // force the next attempt to verify the complete immutable graph from zero.
     deps.deleteCheckpoint(result.checkpointKey);
     if (!result.completed || result.resumedFromOffset > 0) {
-      return { quads: [], completed: false };
+      return { quads: [], completed: false, explicitlyFetchedGraphs };
     }
+    explicitlyFetchedGraphs.add(descriptor.publicSnapshotGraph);
     for (const quad of result.quads) {
       quads.push({ ...quad, graph: descriptor.publicSnapshotGraph });
     }
   }
-  return { quads, completed: true };
+  return { quads, completed: true, explicitlyFetchedGraphs };
 }
 
 export async function recoverContextGraphSwm(
@@ -247,7 +258,7 @@ export async function recoverContextGraphSwm(
   const excluded = deps.getExcludedSubGraphNames
     ? await deps.getExcludedSubGraphNames(deps.contextGraphId)
     : undefined;
-  const recoveryRegistered = [
+  const graphScopedRecoveryRegistered = [
     ...new Set([
       ...(registered ?? []),
       ...discoverSwmRecoverySubGraphNames({
@@ -261,7 +272,7 @@ export async function recoverContextGraphSwm(
   const graphScopedDescriptors = parseGraphScopedSwmRecoveryDescriptors({
     contextGraphId: deps.contextGraphId,
     metaQuads: meta.quads,
-    registeredSubGraphNames: recoveryRegistered,
+    registeredSubGraphNames: graphScopedRecoveryRegistered,
     excludedSubGraphNames: excluded,
   });
   if (graphScopedDescriptors.length > 0) {
@@ -332,14 +343,19 @@ export async function recoverContextGraphSwm(
   );
 
   const processed = await deps.processSharedMemoryBatch(
-    legacyDataQuads, meta.quads, deps.contextGraphId, recoveryRegistered, excluded,
+    legacyDataQuads, meta.quads, deps.contextGraphId, registered, excluded,
   );
 
   // Build the complete exact-graph apply plan before the first store mutation.
   // A corrupt graph-scoped snapshot must not leave already-replaced legacy
   // roots or an earlier exact graph behind.
   const graphScopedAssets: MaterializedGraphScopedSwmRecoveryAsset[] = [];
-  const graphSnapshotQuads = [...data.quads, ...graphBackedSnapshots.quads];
+  const graphSnapshotQuads = [
+    ...data.quads.filter(
+      (quad) => !graphBackedSnapshots.explicitlyFetchedGraphs.has(quad.graph),
+    ),
+    ...graphBackedSnapshots.quads,
+  ];
   for (const descriptor of graphScopedDescriptors) {
     graphScopedAssets.push(await materializeGraphScopedSwmRecoveryAsset({
       descriptor,

--- a/packages/agent/src/sync/requester/swm-recovery.ts
+++ b/packages/agent/src/sync/requester/swm-recovery.ts
@@ -278,9 +278,21 @@ export async function recoverContextGraphSwm(
     excludedSubGraphNames: excluded,
   });
   if (graphScopedDescriptors.length > 0) {
-    const activeGraphMeta = graphScopedDescriptors.flatMap((descriptor) => [
-      ...descriptor.metadataQuads,
-    ]);
+    const inlineGraphScopedAssets = new Set(
+      graphScopedDescriptors
+        .filter((descriptor) => (
+          descriptor.publicQuadsCount === 0
+          || data.quads.some((quad) => quad.graph === descriptor.assertionGraph)
+        ))
+        .map((descriptor) => descriptor.operationSubject),
+    );
+    // Digest-only graph-scoped rows can carry their immutable payload inline
+    // in the exact assertion graph. Do not route those rows through the
+    // snapshot-store synchronizer: the data phase already brought the payload
+    // needed for the same digest/count verification performed below.
+    const activeGraphMeta = graphScopedDescriptors
+      .filter((descriptor) => !inlineGraphScopedAssets.has(descriptor.operationSubject))
+      .flatMap((descriptor) => [...descriptor.metadataQuads]);
     const snapshotSync = await syncPublicSnapshotsForMeta({
       ctx: deps.ctx,
       remotePeerId: deps.remotePeerId,

--- a/packages/agent/src/sync/requester/swm-recovery.ts
+++ b/packages/agent/src/sync/requester/swm-recovery.ts
@@ -1,13 +1,24 @@
 import type { Quad } from '@origintrail-official/dkg-storage';
+import type { WorkspacePublicSnapshotStore } from '@origintrail-official/dkg-publisher';
 import {
   contextGraphWorkspaceGraphUri,
   contextGraphWorkspaceMetaGraphUri,
   type OperationContext,
 } from '@origintrail-official/dkg-core';
 import type { SyncPageResult } from './page-fetch.js';
+import type { SyncPhase } from '../auth/request-build.js';
 import { applySwmRecovery, type SwmRecoveryStore } from './swm-recovery-apply.js';
-import { sharedMemoryOwnershipKeyFromGraph } from './shared-memory-sync.js';
+import {
+  sharedMemoryOwnershipKeyFromGraph,
+  syncPublicSnapshotsForMeta,
+} from './shared-memory-sync.js';
 import { appendInPlace } from '../append-in-place.js';
+import {
+  discoverSwmRecoverySubGraphNames,
+  materializeGraphScopedSwmRecoveryAsset,
+  parseGraphScopedSwmRecoveryDescriptors,
+  type GraphScopedSwmRecoveryDescriptor,
+} from '../graph-scoped-swm-recovery.js';
 
 /**
  * recovery entry point. Recovers a CG's
@@ -58,9 +69,10 @@ export interface RecoverContextGraphSwmDeps {
     remotePeerId: string,
     contextGraphId: string,
     includeSharedMemory: boolean,
-    phase: RecoverableSyncPhase,
+    phase: SyncPhase,
     graphUri: string,
     deadline: number,
+    snapshotRef?: string,
   ) => Promise<SyncPageResult>;
   readonly processSharedMemoryBatch: (
     wsDataQuads: Quad[],
@@ -70,6 +82,7 @@ export interface RecoverContextGraphSwmDeps {
     excludedSubGraphNames?: readonly string[],
   ) => Promise<ProcessedSwmBatch>;
   readonly store: SwmRecoveryStore;
+  readonly publicSnapshotStore?: WorkspacePublicSnapshotStore;
   /**
    * REPLACE (not append) the SWM meta for each recovered root, BEFORE the fresh
    * `verifiedMeta` is inserted. `applySwmRecovery` REPLACEs the root DATA, but
@@ -82,6 +95,10 @@ export interface RecoverContextGraphSwmDeps {
   readonly replaceMetaForRoots?: (
     roots: readonly { readonly entity: string }[],
     metaGraphs: readonly string[],
+  ) => Promise<void>;
+  /** Replace the active head/operation rows for each exact graph asset. */
+  readonly replaceMetaForGraphAssets?: (
+    assets: readonly GraphScopedSwmRecoveryDescriptor[],
   ) => Promise<void>;
   readonly ensureContextGraph: (contextGraphId: string) => Promise<void>;
   readonly setCheckpoint: (key: string, offset: number) => void;
@@ -102,6 +119,7 @@ export interface RecoverContextGraphSwmDeps {
 
 export interface RecoverContextGraphSwmResult {
   readonly replacedRoots: number;
+  readonly replacedGraphs: number;
   readonly insertedDataQuads: number;
   readonly insertedMetaQuads: number;
   readonly droppedDataTriples: number;
@@ -168,6 +186,7 @@ export async function recoverContextGraphSwm(
     );
     return {
       replacedRoots: 0,
+      replacedGraphs: 0,
       insertedDataQuads: 0,
       insertedMetaQuads: 0,
       droppedDataTriples: 0,
@@ -181,9 +200,71 @@ export async function recoverContextGraphSwm(
   const excluded = deps.getExcludedSubGraphNames
     ? await deps.getExcludedSubGraphNames(deps.contextGraphId)
     : undefined;
+  const recoveryRegistered = [
+    ...new Set([
+      ...(registered ?? []),
+      ...discoverSwmRecoverySubGraphNames({
+        contextGraphId: deps.contextGraphId,
+        metaQuads: meta.quads,
+        excludedSubGraphNames: excluded,
+      }),
+    ]),
+  ];
+
+  const graphScopedDescriptors = parseGraphScopedSwmRecoveryDescriptors({
+    contextGraphId: deps.contextGraphId,
+    metaQuads: meta.quads,
+    registeredSubGraphNames: recoveryRegistered,
+    excludedSubGraphNames: excluded,
+  });
+  if (graphScopedDescriptors.length > 0) {
+    const activeGraphMeta = graphScopedDescriptors.flatMap((descriptor) => [
+      ...descriptor.metadataQuads,
+    ]);
+    const snapshotSync = await syncPublicSnapshotsForMeta({
+      ctx: deps.ctx,
+      remotePeerId: deps.remotePeerId,
+      contextGraphId: deps.contextGraphId,
+      deadline: deps.deadline,
+      metaQuads: activeGraphMeta,
+      publicSnapshotStore: deps.publicSnapshotStore,
+      fetchSyncPages: deps.fetchSyncPages,
+      deleteCheckpoint: deps.deleteCheckpoint,
+      setCheckpoint: deps.setCheckpoint,
+    });
+    if (!snapshotSync.completed) {
+      deps.logInfo?.(
+        deps.ctx,
+        `SWM recovery for "${deps.contextGraphId}" from ${deps.remotePeerId}: ` +
+        'graph-scoped public snapshot fetch incomplete — skipped, will retry',
+      );
+      return {
+        replacedRoots: 0,
+        replacedGraphs: 0,
+        insertedDataQuads: 0,
+        insertedMetaQuads: 0,
+        droppedDataTriples: 0,
+        completed: false,
+      };
+    }
+  }
+
+  // Rootless exact graphs and graph-backed immutable snapshots are verified
+  // per KA below. Keep them out of the legacy rootEntity worker path so they
+  // are not counted as invalid root subjects or inserted by union.
+  const graphScopedTransportGraphs = new Set<string>();
+  for (const descriptor of graphScopedDescriptors) {
+    graphScopedTransportGraphs.add(descriptor.assertionGraph);
+    if (descriptor.publicSnapshotGraph) {
+      graphScopedTransportGraphs.add(descriptor.publicSnapshotGraph);
+    }
+  }
+  const legacyDataQuads = data.quads.filter(
+    (quad) => !graphScopedTransportGraphs.has(quad.graph),
+  );
 
   const processed = await deps.processSharedMemoryBatch(
-    data.quads, meta.quads, deps.contextGraphId, registered, excluded,
+    legacyDataQuads, meta.quads, deps.contextGraphId, recoveryRegistered, excluded,
   );
 
   await deps.ensureContextGraph(deps.contextGraphId);
@@ -194,6 +275,18 @@ export async function recoverContextGraphSwm(
     verifiedData: processed.verifiedData,
     roots: processed.entityCreators,
   });
+  let replacedGraphs = 0;
+  let insertedGraphQuads = 0;
+  for (const descriptor of graphScopedDescriptors) {
+    const asset = await materializeGraphScopedSwmRecoveryAsset({
+      descriptor,
+      fetchedDataQuads: data.quads,
+      publicSnapshotStore: deps.publicSnapshotStore,
+    });
+    await deps.store.replaceGraph(asset.assertionGraph, [...asset.quads]);
+    replacedGraphs += 1;
+    insertedGraphQuads += asset.quads.length;
+  }
   // Codex high: REPLACE the SWM meta for each recovered root (the data was
   // REPLACEd above; the meta must be too). Otherwise a stale WorkspaceOperation
   // pointing at the root survives and the TTL sweep later deletes the
@@ -202,6 +295,9 @@ export async function recoverContextGraphSwm(
   if (processed.entityCreators.length > 0) {
     const metaGraphs = [...new Set(processed.verifiedMeta.map((q) => q.graph))];
     await deps.replaceMetaForRoots?.(processed.entityCreators, metaGraphs);
+  }
+  if (graphScopedDescriptors.length > 0) {
+    await deps.replaceMetaForGraphAssets?.(graphScopedDescriptors);
   }
   if (processed.verifiedMeta.length > 0) {
     await deps.store.insert([...processed.verifiedMeta]);
@@ -226,12 +322,14 @@ export async function recoverContextGraphSwm(
   deps.logInfo?.(
     deps.ctx,
     `SWM recovery for "${deps.contextGraphId}" from ${deps.remotePeerId}: replaced ${applied.replacedRoots} roots, ` +
-    `${applied.insertedQuads} data + ${processed.verifiedMeta.length} meta triples`,
+    `${replacedGraphs} exact graphs, ${applied.insertedQuads + insertedGraphQuads} data + ` +
+    `${processed.verifiedMeta.length} meta triples`,
   );
 
   return {
     replacedRoots: applied.replacedRoots,
-    insertedDataQuads: applied.insertedQuads,
+    replacedGraphs,
+    insertedDataQuads: applied.insertedQuads + insertedGraphQuads,
     insertedMetaQuads: processed.verifiedMeta.length,
     droppedDataTriples: processed.droppedDataTriples,
     completed: true,

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -1,5 +1,6 @@
 import {
   DKG_ONTOLOGY,
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
   MemoryLayer,
   assertSafeIri,
   sparqlString,
@@ -31,6 +32,10 @@ const DKG_SUB_GRAPH = `${DKG}SubGraph`;
 const DKG_WORKSPACE_OPERATION = `${DKG}WorkspaceOperation`;
 const DKG_PUBLISHED_AT = `${DKG}publishedAt`;
 const DKG_ROOT_ENTITY = `${DKG}rootEntity`;
+const DKG_CONTENT_SCOPE_VERSION = `${DKG}contentScopeVersion`;
+const DKG_KA_UAL = `${DKG}kaUal`;
+const DKG_ASSERTION_VERSION = `${DKG}assertionVersion`;
+const DKG_SHARE_OPERATION_ID = `${DKG}shareOperationId`;
 const DKG_ASSERTION_GRAPH = `${DKG}assertionGraph`;
 const DKG_ASSERTION_NAME = `${DKG}assertionName`;
 const DKG_MEMORY_LAYER = `${DKG}memoryLayer`;
@@ -397,8 +402,9 @@ const DEFAULT_CHANGELOG_PAGE_BYTES = 4 * 1024 * 1024;
 
 /**
  * The per-CG admission boundary shared by the durable-data phase and the
- * changelog delta lane: the candidate-graph exclusions (wrong CG / top `_meta` /
- * `/_shared_memory*` / `/_private`) and the RFC-49 `isAdmitted` gate
+ * changelog delta lane: the candidate-graph exclusions (wrong CG / top or
+ * first-level subgraph `_meta` / `/_shared_memory*` / `/_private`) and the
+ * RFC-49 `isAdmitted` gate
  * (assertion-graph membership + child-CG descendant rejection). `assertionGraphs`
  * is memoised per invocation, matching the original inline closure.
  */
@@ -422,6 +428,15 @@ function createAdmissionContext(
   const isCandidateGraph = (graph: string): boolean => {
     if (graph !== cgPrefix && !graph.startsWith(`${cgPrefix}/`)) return false;
     if (!opts.includeTopMeta && graph === topMetaGraph) return false;
+    // `<cg>/<subGraph>/_meta` is protocol control metadata for the subgraph
+    // itself (for example local migration markers).  It is not KA payload and
+    // must not enter the durable-data integrity verifier.  Keep deeper
+    // `.../_meta` graphs admitted: assertion and partition metadata are
+    // integrity-bearing durable material served alongside their data graph.
+    const relative = graph.startsWith(`${cgPrefix}/`)
+      ? graph.slice(cgPrefix.length + 1)
+      : '';
+    if (relative.split('/').length === 2 && relative.endsWith('/_meta')) return false;
     // SWM graphs are the dedicated SWM phase's exclusive domain; `/_private` is
     // never durable-served (see readDurableDataPage's original inline note).
     if (graph.includes('/_shared_memory')) return false;
@@ -1134,7 +1149,24 @@ async function readSwmMetaRowsPage(
           ?s ?p ?o .
           ${cutoffIso
             ? `
-          ?s <${DKG_PUBLISHED_AT}> ?ts .
+          {
+            ?s <${DKG_PUBLISHED_AT}> ?ts .
+          } UNION {
+            # Graph-scoped SWM heads are current-state pointers and therefore
+            # intentionally have no independent publishedAt row. Bind them to
+            # the timestamped WorkspaceOperation they select so TTL recovery
+            # receives the head plus its immutable commitment atomically.
+            ?s <${DKG_CONTENT_SCOPE_VERSION}> ${GRAPH_KA_CONTENT_SCOPE_VERSION} ;
+               <${DKG_KA_UAL}> ?headUal ;
+               <${DKG_ASSERTION_VERSION}> ?headVersion ;
+               <${DKG_SHARE_OPERATION_ID}> ?shareId .
+            ?headOperation <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_WORKSPACE_OPERATION}> ;
+               <${DKG_CONTENT_SCOPE_VERSION}> ${GRAPH_KA_CONTENT_SCOPE_VERSION} ;
+               <${DKG_KA_UAL}> ?headUal ;
+               <${DKG_ASSERTION_VERSION}> ?headVersion ;
+               <${DKG_SHARE_OPERATION_ID}> ?shareId ;
+               <${DKG_PUBLISHED_AT}> ?ts .
+          }
           FILTER(?ts >= ${sparqlString(cutoffIso)}^^<http://www.w3.org/2001/XMLSchema#dateTime>)`
             : ''}
         }

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -1,6 +1,5 @@
 import {
   DKG_ONTOLOGY,
-  GRAPH_KA_CONTENT_SCOPE_VERSION,
   MemoryLayer,
   assertSafeIri,
   sparqlString,
@@ -19,6 +18,10 @@ import { SyncRowSnapshotBudgetError } from './snapshot-budget.js';
 import { estimateStringRowHeapBytes } from '../memory-telemetry.js';
 import type { ChangelogSyncResponse, ChangelogDeltaRecord } from '../changelog/wire.js';
 import { durableMetaDelegationSubjectAdmissionExpression } from './durable-meta-admission.js';
+import {
+  graphScopedSwmHeadFreshnessPattern,
+  isGraphScopedSwmSnapshotGraph,
+} from '../graph-scoped-swm-recovery.js';
 
 export {
   createResponderSyncRowListMemo,
@@ -32,10 +35,6 @@ const DKG_SUB_GRAPH = `${DKG}SubGraph`;
 const DKG_WORKSPACE_OPERATION = `${DKG}WorkspaceOperation`;
 const DKG_PUBLISHED_AT = `${DKG}publishedAt`;
 const DKG_ROOT_ENTITY = `${DKG}rootEntity`;
-const DKG_CONTENT_SCOPE_VERSION = `${DKG}contentScopeVersion`;
-const DKG_KA_UAL = `${DKG}kaUal`;
-const DKG_ASSERTION_VERSION = `${DKG}assertionVersion`;
-const DKG_SHARE_OPERATION_ID = `${DKG}shareOperationId`;
 const DKG_ASSERTION_GRAPH = `${DKG}assertionGraph`;
 const DKG_ASSERTION_NAME = `${DKG}assertionName`;
 const DKG_MEMORY_LAYER = `${DKG}memoryLayer`;
@@ -352,6 +351,35 @@ export async function readSwmDataPage(params: {
       limit,
       signal,
     ),
+    params.offset,
+    params.limit,
+    params.signal,
+  );
+}
+
+export async function readGraphBackedSwmSnapshotPage(params: {
+  store: TripleStore;
+  graphList: readonly string[];
+  registeredSubGraphNames: readonly string[];
+  contextGraphId: string;
+  snapshotGraph: string;
+  offset: number;
+  limit: number;
+  signal?: AbortSignal;
+}): Promise<SyncRow[]> {
+  if (
+    !params.graphList.includes(params.snapshotGraph)
+    || !isGraphScopedSwmSnapshotGraph({
+      contextGraphId: params.contextGraphId,
+      snapshotGraph: params.snapshotGraph,
+      registeredSubGraphNames: params.registeredSubGraphNames,
+    })
+  ) {
+    return [];
+  }
+  return readRowsPageAcrossGraphs(
+    params.store,
+    [params.snapshotGraph],
     params.offset,
     params.limit,
     params.signal,
@@ -1156,16 +1184,7 @@ async function readSwmMetaRowsPage(
             # intentionally have no independent publishedAt row. Bind them to
             # the timestamped WorkspaceOperation they select so TTL recovery
             # receives the head plus its immutable commitment atomically.
-            ?s <${DKG_CONTENT_SCOPE_VERSION}> ${GRAPH_KA_CONTENT_SCOPE_VERSION} ;
-               <${DKG_KA_UAL}> ?headUal ;
-               <${DKG_ASSERTION_VERSION}> ?headVersion ;
-               <${DKG_SHARE_OPERATION_ID}> ?shareId .
-            ?headOperation <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_WORKSPACE_OPERATION}> ;
-               <${DKG_CONTENT_SCOPE_VERSION}> ${GRAPH_KA_CONTENT_SCOPE_VERSION} ;
-               <${DKG_KA_UAL}> ?headUal ;
-               <${DKG_ASSERTION_VERSION}> ?headVersion ;
-               <${DKG_SHARE_OPERATION_ID}> ?shareId ;
-               <${DKG_PUBLISHED_AT}> ?ts .
+            ${graphScopedSwmHeadFreshnessPattern()}
           }
           FILTER(?ts >= ${sparqlString(cutoffIso)}^^<http://www.w3.org/2001/XMLSchema#dateTime>)`
             : ''}

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -5,7 +5,7 @@ import {
   getMetrics,
   type OperationContext,
 } from '@origintrail-official/dkg-core';
-import type { TripleStore } from '@origintrail-official/dkg-storage';
+import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
 import {
   serializeWorkspacePublicSnapshotQuads,
   type WorkspacePublicSnapshotStore,
@@ -20,6 +20,7 @@ import {
   readCatalogPage,
   readDurableDataPage,
   readDurableMetaPage,
+  readGraphBackedSwmSnapshotPage,
   readSwmDataPage,
   readSwmMetaPage,
   serializeResponderRows,
@@ -580,19 +581,41 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
         const cutoff = sharedMemoryTtlMs > 0 ? new Date(Date.now() - sharedMemoryTtlMs).toISOString() : null;
         if (phase === 'snapshot') {
           const snapshotRef = request.snapshotRef?.trim();
-          if (!snapshotRef || !publicSnapshotStore) {
+          if (!snapshotRef) {
             return new TextEncoder().encode('');
           }
-          const snapshot = await raceAgainstAbort(publicSnapshotStore.getSnapshot(snapshotRef), signal);
-          if (!snapshot) {
+          let snapshot: Quad[];
+          if (snapshotRef.startsWith('did:dkg:context-graph:')) {
+            const rows = await readGraphBackedSwmSnapshotPage({
+              store,
+              graphList: await graphListMemo.get({ refresh: offset === 0, signal }),
+              registeredSubGraphNames: await swmAdmissionMemo.get(
+                contextGraphId,
+                { refresh: offset === 0, signal },
+              ),
+              contextGraphId,
+              snapshotGraph: snapshotRef,
+              offset,
+              limit,
+              signal,
+            });
+            snapshot = rows.map((row) => ({
+              subject: row.s,
+              predicate: row.p,
+              object: row.o,
+              graph: '',
+            }));
+          } else {
+            if (!publicSnapshotStore) return new TextEncoder().encode('');
+            const stored = await raceAgainstAbort(publicSnapshotStore.getSnapshot(snapshotRef), signal);
+            if (!stored) return new TextEncoder().encode('');
+            snapshot = stored.slice(offset, offset + limit);
+          }
+          if (snapshot.length === 0) {
             return new TextEncoder().encode('');
           }
-          const page = snapshot.slice(offset, offset + limit);
-          if (page.length === 0) {
-            return new TextEncoder().encode('');
-          }
-          nquads.push(serializeWorkspacePublicSnapshotQuads(page).trimEnd());
-          logFirstPageDetail(() => `Sync responder SWM snapshot for "${contextGraphId}" ref=${snapshotRef}: auth=${authDurationMs}ms quads=${page.length}`);
+          nquads.push(serializeWorkspacePublicSnapshotQuads(snapshot).trimEnd());
+          logFirstPageDetail(() => `Sync responder SWM snapshot for "${contextGraphId}" ref=${snapshotRef}: auth=${authDurationMs}ms quads=${snapshot.length}`);
         } else if (phase === 'meta') {
           const queryStartedAt = Date.now();
           const session = prepareResponderSession(

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -11,6 +11,7 @@ import {
   type WorkspacePublicSnapshotStore,
 } from '@origintrail-official/dkg-publisher';
 import type { SyncRequestEnvelope } from '../auth/request-build.js';
+import { parseSnapshotTarget } from '../snapshot-target.js';
 import { DURABLE_DATA_SYNC_SESSION_TTL_MS } from '../durable-session.js';
 import {
   createResponderGraphListMemo,
@@ -580,12 +581,12 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
       if (isWorkspace) {
         const cutoff = sharedMemoryTtlMs > 0 ? new Date(Date.now() - sharedMemoryTtlMs).toISOString() : null;
         if (phase === 'snapshot') {
-          const snapshotRef = request.snapshotRef?.trim();
-          if (!snapshotRef) {
+          const snapshotTarget = parseSnapshotTarget(request);
+          if (!snapshotTarget) {
             return new TextEncoder().encode('');
           }
           let snapshot: Quad[];
-          if (snapshotRef.startsWith('did:dkg:context-graph:')) {
+          if (snapshotTarget.kind === 'graphBacked') {
             const rows = await readGraphBackedSwmSnapshotPage({
               store,
               graphList: await graphListMemo.get({ refresh: offset === 0, signal }),
@@ -594,7 +595,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
                 { refresh: offset === 0, signal },
               ),
               contextGraphId,
-              snapshotGraph: snapshotRef,
+              snapshotGraph: snapshotTarget.graph,
               offset,
               limit,
               signal,
@@ -607,7 +608,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
             }));
           } else {
             if (!publicSnapshotStore) return new TextEncoder().encode('');
-            const stored = await raceAgainstAbort(publicSnapshotStore.getSnapshot(snapshotRef), signal);
+            const stored = await raceAgainstAbort(publicSnapshotStore.getSnapshot(snapshotTarget.ref), signal);
             if (!stored) return new TextEncoder().encode('');
             snapshot = stored.slice(offset, offset + limit);
           }
@@ -615,7 +616,10 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
             return new TextEncoder().encode('');
           }
           nquads.push(serializeWorkspacePublicSnapshotQuads(snapshot).trimEnd());
-          logFirstPageDetail(() => `Sync responder SWM snapshot for "${contextGraphId}" ref=${snapshotRef}: auth=${authDurationMs}ms quads=${snapshot.length}`);
+          const targetLabel = snapshotTarget.kind === 'graphBacked'
+            ? `graph=${snapshotTarget.graph}`
+            : `ref=${snapshotTarget.ref}`;
+          logFirstPageDetail(() => `Sync responder SWM snapshot for "${contextGraphId}" ${targetLabel}: auth=${authDurationMs}ms quads=${snapshot.length}`);
         } else if (phase === 'meta') {
           const queryStartedAt = Date.now();
           const session = prepareResponderSession(

--- a/packages/agent/src/sync/snapshot-target.ts
+++ b/packages/agent/src/sync/snapshot-target.ts
@@ -1,0 +1,27 @@
+export type SnapshotTarget =
+  | { readonly kind: 'storeRef'; readonly ref: string }
+  | { readonly kind: 'graphBacked'; readonly graph: string };
+
+const GRAPH_BACKED_SNAPSHOT_PREFIX = 'did:dkg:context-graph:';
+
+/**
+ * Parse snapshot intent once at the request boundary. `snapshotGraph` is the
+ * explicit current wire field; URI-shaped `snapshotRef` remains accepted for
+ * rolling compatibility with older graph-backed requesters.
+ */
+export function parseSnapshotTarget(input: {
+  readonly snapshotRef?: string;
+  readonly snapshotGraph?: string;
+}): SnapshotTarget | undefined {
+  const snapshotRef = input.snapshotRef?.trim();
+  const snapshotGraph = input.snapshotGraph?.trim();
+  if (snapshotGraph) {
+    if (snapshotRef && snapshotRef !== snapshotGraph) return undefined;
+    return { kind: 'graphBacked', graph: snapshotGraph };
+  }
+  if (!snapshotRef) return undefined;
+  if (snapshotRef.startsWith(GRAPH_BACKED_SNAPSHOT_PREFIX)) {
+    return { kind: 'graphBacked', graph: snapshotRef };
+  }
+  return { kind: 'storeRef', ref: snapshotRef };
+}

--- a/packages/agent/test/changelog-requester.test.ts
+++ b/packages/agent/test/changelog-requester.test.ts
@@ -173,6 +173,27 @@ describe('planPageApply — verified-apply planner', () => {
     expect(p.advanceTo).toBe(7);
   });
 
+  it('classifies lifecycle scope fields as non-integrity metadata', () => {
+    const topMeta = 'did:dkg:context-graph:cg/_meta';
+    const lifecycle = 'did:dkg:31337/0x00000000000000000000000000000000000000aa/7/assertion/1';
+    const classification = classifyDurableMetaGraph([
+      {
+        subject: lifecycle,
+        predicate: 'http://dkg.io/ontology/contentScopeVersion',
+        object: '"2"^^<http://www.w3.org/2001/XMLSchema#integer>',
+        graph: topMeta,
+      },
+      {
+        subject: lifecycle,
+        predicate: 'http://dkg.io/ontology/assertionGraph',
+        object: 'did:dkg:context-graph:cg/_verifiable_memory/0xabc/7',
+        graph: topMeta,
+      },
+    ]);
+
+    expect(classification).toEqual({ hasMerkleRoot: false, hasIntegrityEnvelope: false });
+  });
+
   it('accepts a rootless exact graph bound by verified top-level V2 metadata', () => {
     const graph = 'did:dkg:context-graph:cg/_verifiable_memory/0xabc/7';
     const topMeta = 'did:dkg:context-graph:cg/_meta';

--- a/packages/agent/test/snapshot-target.test.ts
+++ b/packages/agent/test/snapshot-target.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { parseSnapshotTarget } from '../src/sync/snapshot-target.js';
+
+const GRAPH = 'did:dkg:context-graph:cg/_shared_memory_snapshots/_/op/ka';
+
+describe('parseSnapshotTarget', () => {
+  it('uses the explicit graph-backed target', () => {
+    expect(parseSnapshotTarget({ snapshotGraph: GRAPH })).toEqual({
+      kind: 'graphBacked',
+      graph: GRAPH,
+    });
+  });
+
+  it('keeps content-addressed snapshot refs distinct from graph targets', () => {
+    expect(parseSnapshotTarget({ snapshotRef: 'sha256:abc' })).toEqual({
+      kind: 'storeRef',
+      ref: 'sha256:abc',
+    });
+  });
+
+  it('accepts legacy URI-shaped snapshot refs during rolling upgrades', () => {
+    expect(parseSnapshotTarget({ snapshotRef: GRAPH })).toEqual({
+      kind: 'graphBacked',
+      graph: GRAPH,
+    });
+  });
+
+  it('rejects conflicting explicit and legacy targets', () => {
+    expect(parseSnapshotTarget({
+      snapshotGraph: GRAPH,
+      snapshotRef: 'sha256:different',
+    })).toBeUndefined();
+  });
+});

--- a/packages/agent/test/swm-recovery.test.ts
+++ b/packages/agent/test/swm-recovery.test.ts
@@ -18,6 +18,7 @@ import type { Quad } from '@origintrail-official/dkg-storage';
 import type { SyncPageResult } from '../src/sync/requester/page-fetch.js';
 import { recoverContextGraphSwm } from '../src/sync/requester/swm-recovery.js';
 import { deletePriorGraphScopedSwmRecoveryMetadata } from '../src/sync/requester/graph-scoped-swm-meta-replace.js';
+import { SyncVerifyWorker } from '../src/sync-verify-worker.js';
 
 /**
  * integration. `recoverContextGraphSwm` fetches a CG's
@@ -35,6 +36,7 @@ const ctx: OperationContext = { operationId: 'test', operationName: 'sync' } as 
 const DKG = 'http://dkg.io/ontology/';
 const XSD_INTEGER = 'http://www.w3.org/2001/XMLSchema#integer';
 const UAL = 'did:dkg:hardhat:31337/0x00000000000000000000000000000000000000ab/7';
+const SECOND_UAL = 'did:dkg:hardhat:31337/0x00000000000000000000000000000000000000ab/8';
 
 class MemorySnapshotStore implements WorkspacePublicSnapshotStore {
   readonly snapshots = new Map<string, Quad[]>();
@@ -52,6 +54,51 @@ class MemorySnapshotStore implements WorkspacePublicSnapshotStore {
 function page(quads: Quad[], completed = true): SyncPageResult {
   return { quads, bytesReceived: 0, resumedFromOffset: 0, nextOffset: quads.length, checkpointKey: 'k', completed };
 }
+
+function graphBackedFixture(params: {
+  ual: string;
+  operationId: string;
+  payload: Quad[];
+  subGraphName?: string;
+}) {
+  const scope = createGraphKnowledgeAssetScope(params.ual, 1);
+  const metaGraph = params.subGraphName
+    ? `did:dkg:context-graph:${CG}/${params.subGraphName}/_shared_memory_meta`
+    : WS_META;
+  const assertionGraph = knowledgeAssetLayerGraphUri(
+    CG,
+    MemoryLayer.SharedWorkingMemory,
+    scope,
+    params.subGraphName,
+  );
+  const operationSubject = `urn:dkg:share:${CG}:${params.operationId}`;
+  const headSubject = `${params.ual}#dkg-swm-head`;
+  const snapshotGraph =
+    `did:dkg:context-graph:${encodeURIComponent(CG)}/_shared_memory_snapshots/` +
+    `${encodeURIComponent(params.subGraphName ?? '_')}/${encodeURIComponent(params.operationId)}/ka`;
+  const meta: Quad[] = [
+    ...generateKnowledgeAssetShareMetadata({
+      shareOperationId: params.operationId,
+      contextGraphId: CG,
+      kaUal: params.ual,
+      assertionVersion: 1,
+      publicTripleCount: params.payload.length,
+      privateTripleCount: 0,
+      publisherPeerId: 'peer-source',
+      timestamp: new Date(0),
+      ...(params.subGraphName ? { subGraphName: params.subGraphName } : {}),
+    }, metaGraph),
+    { subject: operationSubject, predicate: `${DKG}publicQuadsDigest`, object: `"${workspacePublicQuadsDigest(params.payload)}"`, graph: metaGraph },
+    { subject: operationSubject, predicate: `${DKG}publicSnapshotGraph`, object: snapshotGraph, graph: metaGraph },
+    { subject: headSubject, predicate: `${DKG}contentScopeVersion`, object: `"${GRAPH_KA_CONTENT_SCOPE_VERSION}"^^<${XSD_INTEGER}>`, graph: metaGraph },
+    { subject: headSubject, predicate: `${DKG}kaUal`, object: params.ual, graph: metaGraph },
+    { subject: headSubject, predicate: `${DKG}assertionVersion`, object: `"1"^^<${XSD_INTEGER}>`, graph: metaGraph },
+    { subject: headSubject, predicate: `${DKG}assertionGraph`, object: assertionGraph, graph: metaGraph },
+    { subject: headSubject, predicate: `${DKG}shareOperationId`, object: `"${params.operationId}"`, graph: metaGraph },
+  ];
+  return { assertionGraph, headSubject, meta, metaGraph, operationSubject, snapshotGraph };
+}
+
 async function statusValues(store: OxigraphStore): Promise<string[]> {
   const r = await store.query(`SELECT ?o WHERE { GRAPH <${WS}> { <${SUBJ}> <${STATUS}> ?o } }`);
   return r.type === 'bindings' ? r.bindings.map((b) => b['o']) : [];
@@ -59,7 +106,13 @@ async function statusValues(store: OxigraphStore): Promise<string[]> {
 
 describe('recoverContextGraphSwm (fetch → verify → replace)', () => {
   const stores: OxigraphStore[] = [];
-  afterEach(async () => { await Promise.all(stores.splice(0).map((s) => s.close().catch(() => {}))); });
+  const workers: SyncVerifyWorker[] = [];
+  afterEach(async () => {
+    await Promise.all([
+      ...stores.splice(0).map((s) => s.close().catch(() => {})),
+      ...workers.splice(0).map((worker) => worker.close().catch(() => {})),
+    ]);
+  });
 
   function makeDeps(store: OxigraphStore, sourceData: Quad[], sourceMeta: Quad[] = []) {
     return {
@@ -445,6 +498,8 @@ describe('recoverContextGraphSwm (fetch → verify → replace)', () => {
       { subject: headSubject, predicate: `${DKG}shareOperationId`, object: `"${operationId}"`, graph: subMetaGraph },
     ];
     let verifierRegistered: readonly string[] | undefined;
+    const verifier = new SyncVerifyWorker();
+    workers.push(verifier);
 
     const result = await recoverContextGraphSwm({
       ctx,
@@ -463,14 +518,15 @@ describe('recoverContextGraphSwm (fetch → verify → replace)', () => {
         }
         return page(payload);
       },
-      processSharedMemoryBatch: async (_dataQuads, metaQuads, _cg, registered) => {
+      processSharedMemoryBatch: async (dataQuads, metaQuads, cgId, registered, excluded) => {
         verifierRegistered = registered;
-        return {
-          verifiedData: [],
-          verifiedMeta: metaQuads,
-          entityCreators: [],
-          droppedDataTriples: 1,
-        };
+        return verifier.processSharedMemoryBatch(
+          dataQuads,
+          metaQuads,
+          cgId,
+          registered,
+          excluded,
+        );
       },
       store,
       replaceMetaForGraphAssets: async () => {},
@@ -487,6 +543,134 @@ describe('recoverContextGraphSwm (fetch → verify → replace)', () => {
     );
     expect(recovered.type === 'bindings' ? recovered.bindings.map((row) => row['o']) : [])
       .toEqual(['"recovered"']);
+    const recoveredHead = await store.query(
+      `SELECT ?shareId WHERE { GRAPH <${subMetaGraph}> { <${headSubject}> <${DKG}shareOperationId> ?shareId } }`,
+    );
+    expect(recoveredHead.type === 'bindings'
+      ? recoveredHead.bindings.map((row) => row['shareId'])
+      : []).toEqual([`"${operationId}"`]);
+    const recoveredOperation = await store.query(
+      `SELECT ?digest WHERE { GRAPH <${subMetaGraph}> { <${operationSubject}> <${DKG}publicQuadsDigest> ?digest } }`,
+    );
+    expect(recoveredOperation.type === 'bindings'
+      ? recoveredOperation.bindings.map((row) => row['digest'])
+      : []).toEqual([`"${workspacePublicQuadsDigest(payload)}"`]);
+  });
+
+  it('does not mutate exact or legacy data when a graph-backed snapshot is incomplete', async () => {
+    const store = new OxigraphStore();
+    stores.push(store);
+    const payload: Quad[] = [
+      { subject: 'urn:rootless:partial', predicate: STATUS, object: '"fresh"', graph: '' },
+    ];
+    const fixture = graphBackedFixture({
+      ual: UAL,
+      operationId: 'rootless-partial-op',
+      payload,
+    });
+    await store.insert([
+      { subject: 'urn:rootless:partial', predicate: STATUS, object: '"stale-safe"', graph: fixture.assertionGraph },
+      { subject: SUBJ, predicate: STATUS, object: '"legacy-stale-safe"', graph: WS },
+    ]);
+    const deletedCheckpoints: string[] = [];
+
+    const result = await recoverContextGraphSwm({
+      ctx,
+      remotePeerId: 'peer-source',
+      contextGraphId: CG,
+      deadline: Number.MAX_SAFE_INTEGER,
+      fetchSyncPages: async (_c, _p, _cg, _inc, phase): Promise<SyncPageResult> => {
+        if (phase === 'meta') return page(fixture.meta);
+        if (phase === 'data') {
+          return page([{ subject: SUBJ, predicate: STATUS, object: '"legacy-new"', graph: WS }]);
+        }
+        return { ...page(payload, false), resumedFromOffset: 0, nextOffset: 1 };
+      },
+      processSharedMemoryBatch: async (dataQuads, metaQuads) => ({
+        verifiedData: dataQuads,
+        verifiedMeta: metaQuads,
+        entityCreators: [{ dataGraph: WS, entity: SUBJ, creator: 'peer-source' }],
+        droppedDataTriples: 0,
+      }),
+      store,
+      replaceMetaForGraphAssets: async () => {},
+      ensureContextGraph: async () => {},
+      setCheckpoint: () => {},
+      deleteCheckpoint: (key) => { deletedCheckpoints.push(key); },
+    });
+
+    expect(result).toMatchObject({ completed: false, replacedRoots: 0, replacedGraphs: 0 });
+    expect(deletedCheckpoints).toContain('k');
+    const exact = await store.query(
+      `SELECT ?o WHERE { GRAPH <${fixture.assertionGraph}> { <urn:rootless:partial> <${STATUS}> ?o } }`,
+    );
+    expect(exact.type === 'bindings' ? exact.bindings.map((row) => row['o']) : [])
+      .toEqual(['"stale-safe"']);
+    expect(await statusValues(store)).toEqual(['"legacy-stale-safe"']);
+  });
+
+  it('verifies every graph-scoped asset before mutating the first asset or legacy roots', async () => {
+    const store = new OxigraphStore();
+    stores.push(store);
+    const firstPayload: Quad[] = [
+      { subject: 'urn:rootless:first', predicate: STATUS, object: '"first-fresh"', graph: '' },
+    ];
+    const secondPayload: Quad[] = [
+      { subject: 'urn:rootless:second', predicate: STATUS, object: '"second-fresh"', graph: '' },
+    ];
+    const first = graphBackedFixture({
+      ual: UAL,
+      operationId: 'rootless-first-op',
+      payload: firstPayload,
+    });
+    const second = graphBackedFixture({
+      ual: SECOND_UAL,
+      operationId: 'rootless-second-op',
+      payload: secondPayload,
+    });
+    await store.insert([
+      { subject: 'urn:rootless:first', predicate: STATUS, object: '"first-stale-safe"', graph: first.assertionGraph },
+      { subject: 'urn:rootless:second', predicate: STATUS, object: '"second-stale-safe"', graph: second.assertionGraph },
+      { subject: SUBJ, predicate: STATUS, object: '"legacy-stale-safe"', graph: WS },
+    ]);
+
+    await expect(recoverContextGraphSwm({
+      ctx,
+      remotePeerId: 'peer-source',
+      contextGraphId: CG,
+      deadline: Number.MAX_SAFE_INTEGER,
+      fetchSyncPages: async (_c, _p, _cg, _inc, phase, graphUri): Promise<SyncPageResult> => {
+        if (phase === 'meta') return page([...first.meta, ...second.meta]);
+        if (phase === 'data') {
+          return page([{ subject: SUBJ, predicate: STATUS, object: '"legacy-new"', graph: WS }]);
+        }
+        if (graphUri === first.snapshotGraph) return page(firstPayload);
+        return page([{ ...secondPayload[0]!, object: '"second-corrupt"' }]);
+      },
+      processSharedMemoryBatch: async (dataQuads, metaQuads) => ({
+        verifiedData: dataQuads,
+        verifiedMeta: metaQuads,
+        entityCreators: [{ dataGraph: WS, entity: SUBJ, creator: 'peer-source' }],
+        droppedDataTriples: 0,
+      }),
+      store,
+      replaceMetaForGraphAssets: async () => {},
+      ensureContextGraph: async () => {},
+      setCheckpoint: () => {},
+      deleteCheckpoint: () => {},
+    })).rejects.toThrow('failed integrity');
+
+    const firstAfter = await store.query(
+      `SELECT ?o WHERE { GRAPH <${first.assertionGraph}> { <urn:rootless:first> <${STATUS}> ?o } }`,
+    );
+    expect(firstAfter.type === 'bindings' ? firstAfter.bindings.map((row) => row['o']) : [])
+      .toEqual(['"first-stale-safe"']);
+    const secondAfter = await store.query(
+      `SELECT ?o WHERE { GRAPH <${second.assertionGraph}> { <urn:rootless:second> <${STATUS}> ?o } }`,
+    );
+    expect(secondAfter.type === 'bindings' ? secondAfter.bindings.map((row) => row['o']) : [])
+      .toEqual(['"second-stale-safe"']);
+    expect(await statusValues(store)).toEqual(['"legacy-stale-safe"']);
   });
 
   it('rejects a corrupt rootless snapshot before replacing the existing exact graph', async () => {

--- a/packages/agent/test/swm-recovery.test.ts
+++ b/packages/agent/test/swm-recovery.test.ts
@@ -17,7 +17,7 @@ import {
 import type { Quad } from '@origintrail-official/dkg-storage';
 import type { SyncPageResult } from '../src/sync/requester/page-fetch.js';
 import { recoverContextGraphSwm } from '../src/sync/requester/swm-recovery.js';
-import { replaceGraphScopedSwmRecoveryMetadata } from '../src/sync/requester/graph-scoped-swm-meta-replace.js';
+import { deletePriorGraphScopedSwmRecoveryMetadata } from '../src/sync/requester/graph-scoped-swm-meta-replace.js';
 
 /**
  * integration. `recoverContextGraphSwm` fetches a CG's
@@ -221,7 +221,7 @@ describe('recoverContextGraphSwm (fetch → verify → replace)', () => {
       store,
       publicSnapshotStore: snapshotStore,
       replaceMetaForGraphAssets: (assets) =>
-        replaceGraphScopedSwmRecoveryMetadata(store, assets),
+        deletePriorGraphScopedSwmRecoveryMetadata(store, assets),
       ensureContextGraph: async () => {},
       setCheckpoint: () => {},
       deleteCheckpoint: () => {},
@@ -358,6 +358,135 @@ describe('recoverContextGraphSwm (fetch → verify → replace)', () => {
     });
     expect(dataCarried).toMatchObject({ completed: true, replacedGraphs: 1 });
     expect(redundantSnapshotFetches).toBe(0);
+
+    const fallbackStore = new OxigraphStore();
+    stores.push(fallbackStore);
+    let fallbackSnapshotFetches = 0;
+    const fallback = await recoverContextGraphSwm({
+      ctx,
+      remotePeerId: 'peer-source',
+      contextGraphId: CG,
+      deadline: Number.MAX_SAFE_INTEGER,
+      fetchSyncPages: async (_c, _p, _cg, _inc, phase) => {
+        if (phase === 'meta') return page(sourceMeta);
+        if (phase === 'data') {
+          return page([{
+            subject: payload[0].subject,
+            predicate: payload[0].predicate,
+            object: '"tampered-data-phase-copy"',
+            graph: snapshotGraph,
+          }]);
+        }
+        fallbackSnapshotFetches += 1;
+        return page(payload);
+      },
+      processSharedMemoryBatch: async (dataQuads, metaQuads) => ({
+        verifiedData: dataQuads,
+        verifiedMeta: metaQuads,
+        entityCreators: [],
+        droppedDataTriples: 0,
+      }),
+      store: fallbackStore,
+      replaceMetaForGraphAssets: async () => {},
+      ensureContextGraph: async () => {},
+      setCheckpoint: () => {},
+      deleteCheckpoint: () => {},
+    });
+    expect(fallback).toMatchObject({ completed: true, replacedGraphs: 1 });
+    expect(fallbackSnapshotFetches).toBe(1);
+    const fallbackRecovered = await fallbackStore.query(
+      `SELECT ?o WHERE { GRAPH <${assertionGraph}> { <urn:rootless:graph-backed> <${STATUS}> ?o } }`,
+    );
+    expect(fallbackRecovered.type === 'bindings'
+      ? fallbackRecovered.bindings.map((row) => row['o'])
+      : []).toEqual(['"recovered"']);
+  });
+
+  it('bootstraps graph-scoped subgraphs without admitting remote legacy lanes', async () => {
+    const store = new OxigraphStore();
+    stores.push(store);
+    const subGraphName = 'ai-tools';
+    const subMetaGraph = `did:dkg:context-graph:${CG}/${subGraphName}/_shared_memory_meta`;
+    const subDataGraph = `did:dkg:context-graph:${CG}/${subGraphName}/_shared_memory`;
+    const scope = createGraphKnowledgeAssetScope(UAL, 1);
+    const assertionGraph = knowledgeAssetLayerGraphUri(
+      CG,
+      MemoryLayer.SharedWorkingMemory,
+      scope,
+      subGraphName,
+    );
+    const operationId = 'rootless-subgraph-op';
+    const operationSubject = `urn:dkg:share:${CG}:${operationId}`;
+    const headSubject = `${UAL}#dkg-swm-head`;
+    const snapshotGraph =
+      `did:dkg:context-graph:${encodeURIComponent(CG)}/_shared_memory_snapshots/` +
+      `${encodeURIComponent(subGraphName)}/${encodeURIComponent(operationId)}/ka`;
+    const payload: Quad[] = [
+      { subject: 'urn:rootless:subgraph', predicate: STATUS, object: '"recovered"', graph: '' },
+    ];
+    const sourceMeta: Quad[] = [
+      ...generateKnowledgeAssetShareMetadata({
+        shareOperationId: operationId,
+        contextGraphId: CG,
+        kaUal: UAL,
+        assertionVersion: 1,
+        publicTripleCount: payload.length,
+        privateTripleCount: 0,
+        publisherPeerId: 'peer-source',
+        timestamp: new Date(0),
+        subGraphName,
+      }, subMetaGraph),
+      { subject: operationSubject, predicate: `${DKG}publicQuadsDigest`, object: `"${workspacePublicQuadsDigest(payload)}"`, graph: subMetaGraph },
+      { subject: operationSubject, predicate: `${DKG}publicSnapshotGraph`, object: snapshotGraph, graph: subMetaGraph },
+      { subject: headSubject, predicate: `${DKG}contentScopeVersion`, object: `"${GRAPH_KA_CONTENT_SCOPE_VERSION}"^^<${XSD_INTEGER}>`, graph: subMetaGraph },
+      { subject: headSubject, predicate: `${DKG}kaUal`, object: UAL, graph: subMetaGraph },
+      { subject: headSubject, predicate: `${DKG}assertionVersion`, object: '"1"^^<http://www.w3.org/2001/XMLSchema#integer>', graph: subMetaGraph },
+      { subject: headSubject, predicate: `${DKG}assertionGraph`, object: assertionGraph, graph: subMetaGraph },
+      { subject: headSubject, predicate: `${DKG}shareOperationId`, object: `"${operationId}"`, graph: subMetaGraph },
+    ];
+    let verifierRegistered: readonly string[] | undefined;
+
+    const result = await recoverContextGraphSwm({
+      ctx,
+      remotePeerId: 'peer-source',
+      contextGraphId: CG,
+      deadline: Number.MAX_SAFE_INTEGER,
+      fetchSyncPages: async (_c, _p, _cg, _inc, phase) => {
+        if (phase === 'meta') return page(sourceMeta);
+        if (phase === 'data') {
+          return page([{
+            subject: 'urn:remote:legacy',
+            predicate: STATUS,
+            object: '"must-not-be-admitted"',
+            graph: subDataGraph,
+          }]);
+        }
+        return page(payload);
+      },
+      processSharedMemoryBatch: async (_dataQuads, metaQuads, _cg, registered) => {
+        verifierRegistered = registered;
+        return {
+          verifiedData: [],
+          verifiedMeta: metaQuads,
+          entityCreators: [],
+          droppedDataTriples: 1,
+        };
+      },
+      store,
+      replaceMetaForGraphAssets: async () => {},
+      ensureContextGraph: async () => {},
+      setCheckpoint: () => {},
+      deleteCheckpoint: () => {},
+      getRegisteredSubGraphNames: async () => [],
+    });
+
+    expect(verifierRegistered).toEqual([]);
+    expect(result).toMatchObject({ completed: true, replacedGraphs: 1, droppedDataTriples: 1 });
+    const recovered = await store.query(
+      `SELECT ?o WHERE { GRAPH <${assertionGraph}> { <urn:rootless:subgraph> <${STATUS}> ?o } }`,
+    );
+    expect(recovered.type === 'bindings' ? recovered.bindings.map((row) => row['o']) : [])
+      .toEqual(['"recovered"']);
   });
 
   it('rejects a corrupt rootless snapshot before replacing the existing exact graph', async () => {

--- a/packages/agent/test/swm-recovery.test.ts
+++ b/packages/agent/test/swm-recovery.test.ts
@@ -17,6 +17,7 @@ import {
 import type { Quad } from '@origintrail-official/dkg-storage';
 import type { SyncPageResult } from '../src/sync/requester/page-fetch.js';
 import { recoverContextGraphSwm } from '../src/sync/requester/swm-recovery.js';
+import { replaceGraphScopedSwmRecoveryMetadata } from '../src/sync/requester/graph-scoped-swm-meta-replace.js';
 
 /**
  * integration. `recoverContextGraphSwm` fetches a CG's
@@ -79,6 +80,7 @@ describe('recoverContextGraphSwm (fetch → verify → replace)', () => {
         droppedDataTriples: 0,
       }),
       store,
+      replaceMetaForGraphAssets: async () => {},
       ensureContextGraph: async () => {},
       setCheckpoint: () => {},
       deleteCheckpoint: () => {},
@@ -159,6 +161,8 @@ describe('recoverContextGraphSwm (fetch → verify → replace)', () => {
     const operationId = 'rootless-recovery-op';
     const operationSubject = `urn:dkg:share:${CG}:${operationId}`;
     const headSubject = `${UAL}#dkg-swm-head`;
+    const staleOperationId = 'rootless-stale-op';
+    const staleOperationSubject = `urn:dkg:share:${CG}:${staleOperationId}`;
     const payload: Quad[] = [
       { subject: 'urn:rootless:a', predicate: STATUS, object: '"v2"', graph: '' },
       { subject: 'urn:rootless:disconnected', predicate: 'urn:p', object: '"kept"', graph: '' },
@@ -185,6 +189,10 @@ describe('recoverContextGraphSwm (fetch → verify → replace)', () => {
     await store.insert([
       { subject: 'urn:rootless:a', predicate: STATUS, object: '"stale"', graph: assertionGraph },
       { subject: 'urn:rootless:old', predicate: 'urn:p', object: '"must-disappear"', graph: assertionGraph },
+      { subject: headSubject, predicate: `${DKG}shareOperationId`, object: `"${staleOperationId}"`, graph: WS_META },
+      { subject: staleOperationSubject, predicate: `${DKG}shareOperationId`, object: `"${staleOperationId}"`, graph: WS_META },
+      { subject: staleOperationSubject, predicate: `${DKG}kaUal`, object: UAL, graph: WS_META },
+      { subject: staleOperationSubject, predicate: 'urn:stale:marker', object: '"remove-me"', graph: WS_META },
     ]);
     const snapshotStore = new MemorySnapshotStore();
     let snapshotFetches = 0;
@@ -212,6 +220,8 @@ describe('recoverContextGraphSwm (fetch → verify → replace)', () => {
       }),
       store,
       publicSnapshotStore: snapshotStore,
+      replaceMetaForGraphAssets: (assets) =>
+        replaceGraphScopedSwmRecoveryMetadata(store, assets),
       ensureContextGraph: async () => {},
       setCheckpoint: () => {},
       deleteCheckpoint: () => {},
@@ -233,6 +243,121 @@ describe('recoverContextGraphSwm (fetch → verify → replace)', () => {
       expect(recovered.quads.map(({ subject, predicate, object }) => ({ subject, predicate, object })))
         .toEqual(payload.map(({ subject, predicate, object }) => ({ subject, predicate, object })));
     }
+    const staleMeta = await store.query(
+      `SELECT ?p WHERE { GRAPH <${WS_META}> { <${staleOperationSubject}> ?p ?o } }`,
+    );
+    expect(staleMeta.type === 'bindings' ? staleMeta.bindings : []).toEqual([]);
+    const activeHead = await store.query(
+      `SELECT ?shareId WHERE { GRAPH <${WS_META}> { <${headSubject}> <${DKG}shareOperationId> ?shareId } }`,
+    );
+    expect(activeHead.type === 'bindings'
+      ? activeHead.bindings.map((row) => row['shareId'])
+      : []).toEqual([`"${operationId}"`]);
+  });
+
+  it('fetches and recovers a graph-backed rootless snapshot without a snapshot store', async () => {
+    const store = new OxigraphStore();
+    stores.push(store);
+    const scope = createGraphKnowledgeAssetScope(UAL, 1);
+    const assertionGraph = knowledgeAssetLayerGraphUri(
+      CG,
+      MemoryLayer.SharedWorkingMemory,
+      scope,
+    );
+    const operationId = 'rootless-graph-backed-op';
+    const operationSubject = `urn:dkg:share:${CG}:${operationId}`;
+    const headSubject = `${UAL}#dkg-swm-head`;
+    const snapshotGraph =
+      `did:dkg:context-graph:${encodeURIComponent(CG)}/_shared_memory_snapshots/_/` +
+      `${encodeURIComponent(operationId)}/ka`;
+    const payload: Quad[] = [
+      { subject: 'urn:rootless:graph-backed', predicate: STATUS, object: '"recovered"', graph: '' },
+    ];
+    const sourceMeta: Quad[] = [
+      ...generateKnowledgeAssetShareMetadata({
+        shareOperationId: operationId,
+        contextGraphId: CG,
+        kaUal: UAL,
+        assertionVersion: 1,
+        publicTripleCount: payload.length,
+        privateTripleCount: 0,
+        publisherPeerId: 'peer-source',
+        timestamp: new Date(0),
+      }, WS_META),
+      { subject: operationSubject, predicate: `${DKG}publicQuadsDigest`, object: `"${workspacePublicQuadsDigest(payload)}"`, graph: WS_META },
+      { subject: operationSubject, predicate: `${DKG}publicSnapshotGraph`, object: snapshotGraph, graph: WS_META },
+      { subject: headSubject, predicate: `${DKG}contentScopeVersion`, object: `"${GRAPH_KA_CONTENT_SCOPE_VERSION}"^^<${XSD_INTEGER}>`, graph: WS_META },
+      { subject: headSubject, predicate: `${DKG}kaUal`, object: UAL, graph: WS_META },
+      { subject: headSubject, predicate: `${DKG}assertionVersion`, object: '"1"^^<http://www.w3.org/2001/XMLSchema#integer>', graph: WS_META },
+      { subject: headSubject, predicate: `${DKG}assertionGraph`, object: assertionGraph, graph: WS_META },
+      { subject: headSubject, predicate: `${DKG}shareOperationId`, object: `"${operationId}"`, graph: WS_META },
+    ];
+    let graphSnapshotFetches = 0;
+
+    const result = await recoverContextGraphSwm({
+      ctx,
+      remotePeerId: 'peer-source',
+      contextGraphId: CG,
+      deadline: Number.MAX_SAFE_INTEGER,
+      fetchSyncPages: async (_c, _p, _cg, _inc, phase, graphUri, _deadline, snapshotRef) => {
+        if (phase === 'meta') return page(sourceMeta);
+        if (phase === 'snapshot') {
+          graphSnapshotFetches += 1;
+          expect(graphUri).toBe(snapshotGraph);
+          expect(snapshotRef).toBe(snapshotGraph);
+          return page(payload);
+        }
+        return page([]);
+      },
+      processSharedMemoryBatch: async (_dataQuads, metaQuads) => ({
+        verifiedData: [], verifiedMeta: metaQuads, entityCreators: [], droppedDataTriples: 0,
+      }),
+      store,
+      replaceMetaForGraphAssets: async () => {},
+      ensureContextGraph: async () => {},
+      setCheckpoint: () => {},
+      deleteCheckpoint: () => {},
+    });
+
+    expect(result).toMatchObject({ completed: true, replacedGraphs: 1, insertedDataQuads: 1 });
+    expect(graphSnapshotFetches).toBe(1);
+    const recovered = await store.query(
+      `SELECT ?o WHERE { GRAPH <${assertionGraph}> { <urn:rootless:graph-backed> <${STATUS}> ?o } }`,
+    );
+    expect(recovered.type === 'bindings'
+      ? recovered.bindings.map((row) => row['o'])
+      : []).toEqual(['"recovered"']);
+
+    const dataCarriedStore = new OxigraphStore();
+    stores.push(dataCarriedStore);
+    let redundantSnapshotFetches = 0;
+    const dataCarried = await recoverContextGraphSwm({
+      ctx,
+      remotePeerId: 'peer-source',
+      contextGraphId: CG,
+      deadline: Number.MAX_SAFE_INTEGER,
+      fetchSyncPages: async (_c, _p, _cg, _inc, phase) => {
+        if (phase === 'meta') return page(sourceMeta);
+        if (phase === 'data') {
+          return page(payload.map((quad) => ({ ...quad, graph: snapshotGraph })));
+        }
+        redundantSnapshotFetches += 1;
+        return page(payload);
+      },
+      processSharedMemoryBatch: async (dataQuads, metaQuads) => ({
+        verifiedData: dataQuads,
+        verifiedMeta: metaQuads,
+        entityCreators: [],
+        droppedDataTriples: 0,
+      }),
+      store: dataCarriedStore,
+      replaceMetaForGraphAssets: async () => {},
+      ensureContextGraph: async () => {},
+      setCheckpoint: () => {},
+      deleteCheckpoint: () => {},
+    });
+    expect(dataCarried).toMatchObject({ completed: true, replacedGraphs: 1 });
+    expect(redundantSnapshotFetches).toBe(0);
   });
 
   it('rejects a corrupt rootless snapshot before replacing the existing exact graph', async () => {
@@ -262,7 +387,10 @@ describe('recoverContextGraphSwm (fetch → verify → replace)', () => {
       { subject: headSubject, predicate: `${DKG}assertionGraph`, object: assertionGraph, graph: WS_META },
       { subject: headSubject, predicate: `${DKG}shareOperationId`, object: `"${operationId}"`, graph: WS_META },
     ];
-    await store.insert([{ subject: 'urn:rootless:a', predicate: STATUS, object: '"stale-safe"', graph: assertionGraph }]);
+    await store.insert([
+      { subject: 'urn:rootless:a', predicate: STATUS, object: '"stale-safe"', graph: assertionGraph },
+      { subject: SUBJ, predicate: STATUS, object: '"legacy-stale-safe"', graph: WS },
+    ]);
 
     await expect(recoverContextGraphSwm({
       ctx,
@@ -274,13 +402,17 @@ describe('recoverContextGraphSwm (fetch → verify → replace)', () => {
         if (phase === 'snapshot') {
           return page([{ subject: 'urn:rootless:a', predicate: STATUS, object: '"tampered"', graph: '' }]);
         }
-        return page([]);
+        return page([{ subject: SUBJ, predicate: STATUS, object: '"legacy-new"', graph: WS }]);
       },
-      processSharedMemoryBatch: async (_dataQuads, metaQuads) => ({
-        verifiedData: [], verifiedMeta: metaQuads, entityCreators: [], droppedDataTriples: 0,
+      processSharedMemoryBatch: async (dataQuads, metaQuads) => ({
+        verifiedData: dataQuads,
+        verifiedMeta: metaQuads,
+        entityCreators: [{ dataGraph: WS, entity: SUBJ, creator: 'peer-source' }],
+        droppedDataTriples: 0,
       }),
       store,
       publicSnapshotStore: new MemorySnapshotStore(),
+      replaceMetaForGraphAssets: async () => {},
       ensureContextGraph: async () => {},
       setCheckpoint: () => {},
       deleteCheckpoint: () => {},
@@ -290,5 +422,6 @@ describe('recoverContextGraphSwm (fetch → verify → replace)', () => {
       `SELECT ?o WHERE { GRAPH <${assertionGraph}> { <urn:rootless:a> <${STATUS}> ?o } }`,
     );
     expect(stale.type === 'bindings' ? stale.bindings.map((row) => row['o']) : []).toEqual(['"stale-safe"']);
+    expect(await statusValues(store)).toEqual(['"legacy-stale-safe"']);
   });
 });

--- a/packages/agent/test/swm-recovery.test.ts
+++ b/packages/agent/test/swm-recovery.test.ts
@@ -455,6 +455,58 @@ describe('recoverContextGraphSwm (fetch → verify → replace)', () => {
       : []).toEqual(['"recovered"']);
   });
 
+  it('recovers digest-only graph-scoped data inline from its exact assertion graph', async () => {
+    const store = new OxigraphStore();
+    stores.push(store);
+    const payload: Quad[] = [
+      { subject: 'urn:rootless:inline', predicate: STATUS, object: '"recovered"', graph: '' },
+    ];
+    const fixture = graphBackedFixture({
+      ual: UAL,
+      operationId: 'rootless-inline-op',
+      payload,
+    });
+    const digestOnlyMeta = fixture.meta.filter(
+      (quad) => quad.predicate !== `${DKG}publicSnapshotGraph`,
+    );
+    let snapshotFetches = 0;
+
+    const result = await recoverContextGraphSwm({
+      ctx,
+      remotePeerId: 'peer-source',
+      contextGraphId: CG,
+      deadline: Number.MAX_SAFE_INTEGER,
+      fetchSyncPages: async (_c, _p, _cg, _inc, phase) => {
+        if (phase === 'meta') return page(digestOnlyMeta);
+        if (phase === 'data') {
+          return page(payload.map((quad) => ({ ...quad, graph: fixture.assertionGraph })));
+        }
+        snapshotFetches += 1;
+        return page([]);
+      },
+      processSharedMemoryBatch: async (dataQuads, metaQuads) => ({
+        verifiedData: dataQuads,
+        verifiedMeta: metaQuads,
+        entityCreators: [],
+        droppedDataTriples: 0,
+      }),
+      store,
+      replaceMetaForGraphAssets: async () => {},
+      ensureContextGraph: async () => {},
+      setCheckpoint: () => {},
+      deleteCheckpoint: () => {},
+    });
+
+    expect(result).toMatchObject({ completed: true, replacedGraphs: 1, insertedDataQuads: 1 });
+    expect(snapshotFetches).toBe(0);
+    const recovered = await store.query(
+      `SELECT ?o WHERE { GRAPH <${fixture.assertionGraph}> { <urn:rootless:inline> <${STATUS}> ?o } }`,
+    );
+    expect(recovered.type === 'bindings'
+      ? recovered.bindings.map((row) => row['o'])
+      : []).toEqual(['"recovered"']);
+  });
+
   it('bootstraps graph-scoped subgraphs without admitting remote legacy lanes', async () => {
     const store = new OxigraphStore();
     stores.push(store);

--- a/packages/agent/test/swm-recovery.test.ts
+++ b/packages/agent/test/swm-recovery.test.ts
@@ -1,10 +1,19 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { OxigraphStore } from '@origintrail-official/dkg-storage';
 import {
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  MemoryLayer,
+  createGraphKnowledgeAssetScope,
   contextGraphWorkspaceGraphUri,
   contextGraphWorkspaceMetaGraphUri,
+  knowledgeAssetLayerGraphUri,
   type OperationContext,
 } from '@origintrail-official/dkg-core';
+import {
+  generateKnowledgeAssetShareMetadata,
+  workspacePublicQuadsDigest,
+  type WorkspacePublicSnapshotStore,
+} from '@origintrail-official/dkg-publisher';
 import type { Quad } from '@origintrail-official/dkg-storage';
 import type { SyncPageResult } from '../src/sync/requester/page-fetch.js';
 import { recoverContextGraphSwm } from '../src/sync/requester/swm-recovery.js';
@@ -22,6 +31,22 @@ const WS_META = contextGraphWorkspaceMetaGraphUri(CG);
 const SUBJ = 'urn:ws00r:shipment';
 const STATUS = 'http://schema.org/status';
 const ctx: OperationContext = { operationId: 'test', operationName: 'sync' } as never;
+const DKG = 'http://dkg.io/ontology/';
+const XSD_INTEGER = 'http://www.w3.org/2001/XMLSchema#integer';
+const UAL = 'did:dkg:hardhat:31337/0x00000000000000000000000000000000000000ab/7';
+
+class MemorySnapshotStore implements WorkspacePublicSnapshotStore {
+  readonly snapshots = new Map<string, Quad[]>();
+
+  async putSnapshot(input: { readonly digest: string; readonly quads: readonly Quad[] }) {
+    this.snapshots.set(input.digest, input.quads.map((quad) => ({ ...quad })));
+    return { ref: input.digest, byteLength: 0 };
+  }
+
+  async getSnapshot(ref: string): Promise<Quad[] | null> {
+    return this.snapshots.get(ref)?.map((quad) => ({ ...quad })) ?? null;
+  }
+}
 
 function page(quads: Quad[], completed = true): SyncPageResult {
   return { quads, bytesReceived: 0, resumedFromOffset: 0, nextOffset: quads.length, checkpointKey: 'k', completed };
@@ -120,5 +145,150 @@ describe('recoverContextGraphSwm (fetch → verify → replace)', () => {
     expect(result.replacedRoots).toBe(0);
     // incomplete fetch → no mutation at all; the prior v1 is untouched (no truncation, no partial replace)
     expect(await statusValues(store)).toEqual(['"v1"']);
+  });
+
+  it('recovers a rootless KA snapshot into its exact UAL-derived SWM graph', async () => {
+    const store = new OxigraphStore();
+    stores.push(store);
+    const scope = createGraphKnowledgeAssetScope(UAL, 1);
+    const assertionGraph = knowledgeAssetLayerGraphUri(
+      CG,
+      MemoryLayer.SharedWorkingMemory,
+      scope,
+    );
+    const operationId = 'rootless-recovery-op';
+    const operationSubject = `urn:dkg:share:${CG}:${operationId}`;
+    const headSubject = `${UAL}#dkg-swm-head`;
+    const payload: Quad[] = [
+      { subject: 'urn:rootless:a', predicate: STATUS, object: '"v2"', graph: '' },
+      { subject: 'urn:rootless:disconnected', predicate: 'urn:p', object: '"kept"', graph: '' },
+    ];
+    const digest = workspacePublicQuadsDigest(payload);
+    const sourceMeta: Quad[] = [
+      ...generateKnowledgeAssetShareMetadata({
+        shareOperationId: operationId,
+        contextGraphId: CG,
+        kaUal: UAL,
+        assertionVersion: 1,
+        publicTripleCount: payload.length,
+        privateTripleCount: 0,
+        publisherPeerId: 'peer-source',
+        timestamp: new Date(0),
+      }, WS_META),
+      { subject: operationSubject, predicate: `${DKG}publicQuadsDigest`, object: `"${digest}"`, graph: WS_META },
+      { subject: headSubject, predicate: `${DKG}contentScopeVersion`, object: `"${GRAPH_KA_CONTENT_SCOPE_VERSION}"^^<${XSD_INTEGER}>`, graph: WS_META },
+      { subject: headSubject, predicate: `${DKG}kaUal`, object: UAL, graph: WS_META },
+      { subject: headSubject, predicate: `${DKG}assertionVersion`, object: `"1"^^<${XSD_INTEGER}>`, graph: WS_META },
+      { subject: headSubject, predicate: `${DKG}assertionGraph`, object: assertionGraph, graph: WS_META },
+      { subject: headSubject, predicate: `${DKG}shareOperationId`, object: `"${operationId}"`, graph: WS_META },
+    ];
+    await store.insert([
+      { subject: 'urn:rootless:a', predicate: STATUS, object: '"stale"', graph: assertionGraph },
+      { subject: 'urn:rootless:old', predicate: 'urn:p', object: '"must-disappear"', graph: assertionGraph },
+    ]);
+    const snapshotStore = new MemorySnapshotStore();
+    let snapshotFetches = 0;
+
+    const result = await recoverContextGraphSwm({
+      ctx,
+      remotePeerId: 'peer-source',
+      contextGraphId: CG,
+      deadline: Number.MAX_SAFE_INTEGER,
+      fetchSyncPages: async (
+        _c, _p, _cg, _inc, phase,
+      ): Promise<SyncPageResult> => {
+        if (phase === 'meta') return page(sourceMeta);
+        if (phase === 'snapshot') {
+          snapshotFetches += 1;
+          return page(payload);
+        }
+        return page([]);
+      },
+      processSharedMemoryBatch: async (_dataQuads, metaQuads) => ({
+        verifiedData: [],
+        verifiedMeta: metaQuads,
+        entityCreators: [],
+        droppedDataTriples: 0,
+      }),
+      store,
+      publicSnapshotStore: snapshotStore,
+      ensureContextGraph: async () => {},
+      setCheckpoint: () => {},
+      deleteCheckpoint: () => {},
+    });
+
+    expect(result).toMatchObject({
+      completed: true,
+      replacedRoots: 0,
+      replacedGraphs: 1,
+      insertedDataQuads: payload.length,
+      insertedMetaQuads: sourceMeta.length,
+    });
+    expect(snapshotFetches).toBe(1);
+    const recovered = await store.query(
+      `CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${assertionGraph}> { ?s ?p ?o } }`,
+    );
+    expect(recovered.type).toBe('quads');
+    if (recovered.type === 'quads') {
+      expect(recovered.quads.map(({ subject, predicate, object }) => ({ subject, predicate, object })))
+        .toEqual(payload.map(({ subject, predicate, object }) => ({ subject, predicate, object })));
+    }
+  });
+
+  it('rejects a corrupt rootless snapshot before replacing the existing exact graph', async () => {
+    const store = new OxigraphStore();
+    stores.push(store);
+    const scope = createGraphKnowledgeAssetScope(UAL, 1);
+    const assertionGraph = knowledgeAssetLayerGraphUri(CG, MemoryLayer.SharedWorkingMemory, scope);
+    const operationId = 'rootless-corrupt-op';
+    const operationSubject = `urn:dkg:share:${CG}:${operationId}`;
+    const headSubject = `${UAL}#dkg-swm-head`;
+    const committed: Quad[] = [{ subject: 'urn:rootless:a', predicate: STATUS, object: '"good"', graph: '' }];
+    const sourceMeta: Quad[] = [
+      ...generateKnowledgeAssetShareMetadata({
+        shareOperationId: operationId,
+        contextGraphId: CG,
+        kaUal: UAL,
+        assertionVersion: 1,
+        publicTripleCount: committed.length,
+        privateTripleCount: 0,
+        publisherPeerId: 'peer-source',
+        timestamp: new Date(0),
+      }, WS_META),
+      { subject: operationSubject, predicate: `${DKG}publicQuadsDigest`, object: `"${workspacePublicQuadsDigest(committed)}"`, graph: WS_META },
+      { subject: headSubject, predicate: `${DKG}contentScopeVersion`, object: `"2"^^<${XSD_INTEGER}>`, graph: WS_META },
+      { subject: headSubject, predicate: `${DKG}kaUal`, object: UAL, graph: WS_META },
+      { subject: headSubject, predicate: `${DKG}assertionVersion`, object: `"1"^^<${XSD_INTEGER}>`, graph: WS_META },
+      { subject: headSubject, predicate: `${DKG}assertionGraph`, object: assertionGraph, graph: WS_META },
+      { subject: headSubject, predicate: `${DKG}shareOperationId`, object: `"${operationId}"`, graph: WS_META },
+    ];
+    await store.insert([{ subject: 'urn:rootless:a', predicate: STATUS, object: '"stale-safe"', graph: assertionGraph }]);
+
+    await expect(recoverContextGraphSwm({
+      ctx,
+      remotePeerId: 'peer-source',
+      contextGraphId: CG,
+      deadline: Number.MAX_SAFE_INTEGER,
+      fetchSyncPages: async (_c, _p, _cg, _inc, phase): Promise<SyncPageResult> => {
+        if (phase === 'meta') return page(sourceMeta);
+        if (phase === 'snapshot') {
+          return page([{ subject: 'urn:rootless:a', predicate: STATUS, object: '"tampered"', graph: '' }]);
+        }
+        return page([]);
+      },
+      processSharedMemoryBatch: async (_dataQuads, metaQuads) => ({
+        verifiedData: [], verifiedMeta: metaQuads, entityCreators: [], droppedDataTriples: 0,
+      }),
+      store,
+      publicSnapshotStore: new MemorySnapshotStore(),
+      ensureContextGraph: async () => {},
+      setCheckpoint: () => {},
+      deleteCheckpoint: () => {},
+    })).rejects.toThrow('failed digest/count validation');
+
+    const stale = await store.query(
+      `SELECT ?o WHERE { GRAPH <${assertionGraph}> { <urn:rootless:a> <${STATUS}> ?o } }`,
+    );
+    expect(stale.type === 'bindings' ? stale.bindings.map((row) => row['o']) : []).toEqual(['"stale-safe"']);
   });
 });

--- a/packages/agent/test/sync-on-connect-churn.test.ts
+++ b/packages/agent/test/sync-on-connect-churn.test.ts
@@ -233,6 +233,7 @@ describe('sync-on-connect churn gates', () => {
     const recovery = await (agent as any).recoverContextGraphSwmFromPeer(PEER_A, 'cg-a');
     expect(recovery).toEqual({
       replacedRoots: 0,
+      replacedGraphs: 0,
       insertedDataQuads: 0,
       insertedMetaQuads: 0,
       droppedDataTriples: 0,

--- a/packages/agent/test/sync-responder-admission-parity.test.ts
+++ b/packages/agent/test/sync-responder-admission-parity.test.ts
@@ -99,6 +99,7 @@ describe('sync responder graph admission planner', () => {
     const canonicalData = cgPrefix;
     const perCgData = `${cgPrefix}/context/1`;
     const perCgMeta = `${cgPrefix}/context/1/_meta`;
+    const subGraphControlMeta = `${cgPrefix}/ai-tools/_meta`;
     const privateGraph = `${cgPrefix}/_private/secret`;
     const wmAssertion = `${cgPrefix}/assertion/0xabc/wm-draft`;
     const vmAssertion = `${cgPrefix}/assertion/0xabc/vm-final`;
@@ -111,6 +112,7 @@ describe('sync responder graph admission planner', () => {
       q(cgMeta, cgPrefix, `${DKG_NS}createdAt`, '"2026-06-01T00:00:00Z"'),
       q(perCgData, 'urn:per-cg:data', 'http://schema.org/name', '"per-cg-data"'),
       q(perCgMeta, 'urn:per-cg:meta', `${DKG_NS}merkleRoot`, '"per-cg-meta"'),
+      q(subGraphControlMeta, 'urn:dkg:migration:swm-attr-agent-did', `${DKG_NS}appliedAt`, '"local-control-row"'),
       q(privateGraph, 'urn:private:data', 'http://schema.org/name', '"private-leak"'),
       q(wmAssertion, 'urn:assertion:wm', 'http://schema.org/name', '"wm-assertion-leak"'),
       q(vmAssertion, 'urn:assertion:vm', 'http://schema.org/name', '"vm-assertion"'),
@@ -135,6 +137,7 @@ describe('sync responder graph admission planner', () => {
     expect(graphs.has(canonicalData)).toBe(true);
     expect(graphs.has(perCgData)).toBe(true);
     expect(graphs.has(perCgMeta)).toBe(true);
+    expect(graphs.has(subGraphControlMeta)).toBe(false);
     expect(graphs.has(vmAssertion)).toBe(true);
     expect(graphs.has(cgMeta)).toBe(false);
     expect(graphs.has(privateGraph)).toBe(false);
@@ -144,6 +147,7 @@ describe('sync responder graph admission planner', () => {
     expect(out).not.toContain('"wm-assertion-leak"');
     expect(out).not.toContain('"private-leak"');
     expect(out).not.toContain('"child-leak"');
+    expect(out).not.toContain('"local-control-row"');
   });
 
   it('keeps parent durable partitions when a child CG has a reserved partition name', async () => {

--- a/packages/agent/test/sync-responder-swm-subgraphs.test.ts
+++ b/packages/agent/test/sync-responder-swm-subgraphs.test.ts
@@ -410,6 +410,64 @@ describe('sync responder workspace branch — sub-graph SWM coverage', () => {
     });
   });
 
+  it('serves an exact graph-backed rootless snapshot without a snapshot store', async () => {
+    const storeSnapshot = new OxigraphStore();
+    const snapshotGraph =
+      `${CG_PREFIX}/_shared_memory_snapshots/_/graph-backed-op/ka`;
+    const unregisteredSubGraphSnapshot =
+      `${CG_PREFIX}/_shared_memory_snapshots/${OTHER_SUB}/graph-backed-op/ka`;
+    await storeSnapshot.insert([
+      {
+        graph: snapshotGraph,
+        subject: 'urn:rootless:snapshot',
+        predicate: 'http://schema.org/status',
+        object: '"graph-backed"',
+      },
+      {
+        graph: unregisteredSubGraphSnapshot,
+        subject: 'urn:rootless:private-subgraph',
+        predicate: 'http://schema.org/status',
+        object: '"must-not-leak"',
+      },
+    ]);
+    const capSnapshot = captureHandler();
+    registerSyncHandler({
+      register: capSnapshot.register,
+      protocolSync: '/origintrail/dkg/sync/1.0.0',
+      syncDeniedResponse: 'sync-denied',
+      syncPageSize: 5000,
+      sharedMemoryTtlMs: 0,
+      store: storeSnapshot,
+      peerId: 'self-peer',
+      parseSyncRequest: (data) => JSON.parse(new TextDecoder().decode(data)) as SyncRequestEnvelope,
+      authorizeSyncRequest: async () => true,
+      logWarn: noopLog,
+      logDebug: noopLog,
+    });
+
+    const out = await capSnapshot.invoke({
+      contextGraphId: CG_ID,
+      offset: 0,
+      limit: 5000,
+      includeSharedMemory: true,
+      phase: 'snapshot',
+      snapshotRef: snapshotGraph,
+    });
+    expect(out).toContain('"graph-backed"');
+    expect(out).not.toContain(snapshotGraph);
+
+    const denied = await capSnapshot.invoke({
+      contextGraphId: CG_ID,
+      offset: 0,
+      limit: 5000,
+      includeSharedMemory: true,
+      phase: 'snapshot',
+      snapshotRef: unregisteredSubGraphSnapshot,
+    });
+    expect(denied).toBe('');
+    await storeSnapshot.close();
+  });
+
   // Codex review on #885 — URI shape alone is NOT a sufficient CG
   // boundary because `validateContextGraphId` permits `/` in the CG
   // ID (wallet-scoped IDs do, e.g. `0xabc/project`). For a request on

--- a/packages/agent/test/sync-responder-swm-subgraphs.test.ts
+++ b/packages/agent/test/sync-responder-swm-subgraphs.test.ts
@@ -414,6 +414,8 @@ describe('sync responder workspace branch — sub-graph SWM coverage', () => {
     const storeSnapshot = new OxigraphStore();
     const snapshotGraph =
       `${CG_PREFIX}/_shared_memory_snapshots/_/graph-backed-op/ka`;
+    const registeredSubGraphSnapshot =
+      `${CG_PREFIX}/_shared_memory_snapshots/${SUB_NAME}/graph-backed-op/ka`;
     const unregisteredSubGraphSnapshot =
       `${CG_PREFIX}/_shared_memory_snapshots/${OTHER_SUB}/graph-backed-op/ka`;
     await storeSnapshot.insert([
@@ -430,11 +432,18 @@ describe('sync responder workspace branch — sub-graph SWM coverage', () => {
         object: '"graph-backed-b"',
       },
       {
+        graph: registeredSubGraphSnapshot,
+        subject: 'urn:rootless:registered-subgraph',
+        predicate: 'http://schema.org/status',
+        object: '"registered-subgraph-snapshot"',
+      },
+      {
         graph: unregisteredSubGraphSnapshot,
         subject: 'urn:rootless:private-subgraph',
         predicate: 'http://schema.org/status',
         object: '"must-not-leak"',
       },
+      ...subGraphRegistrationQuads(CG_ID, SUB_NAME),
     ]);
     const capSnapshot = captureHandler();
     registerSyncHandler({
@@ -457,7 +466,7 @@ describe('sync responder workspace branch — sub-graph SWM coverage', () => {
       limit: 1,
       includeSharedMemory: true,
       phase: 'snapshot',
-      snapshotRef: snapshotGraph,
+      snapshotGraph,
     });
     const secondPage = await capSnapshot.invoke({
       contextGraphId: CG_ID,
@@ -465,7 +474,7 @@ describe('sync responder workspace branch — sub-graph SWM coverage', () => {
       limit: 1,
       includeSharedMemory: true,
       phase: 'snapshot',
-      snapshotRef: snapshotGraph,
+      snapshotGraph,
     });
     expect(firstPage.trim().split('\n')).toHaveLength(1);
     expect(secondPage.trim().split('\n')).toHaveLength(1);
@@ -475,13 +484,35 @@ describe('sync responder workspace branch — sub-graph SWM coverage', () => {
     expect(firstPage).not.toContain(snapshotGraph);
     expect(secondPage).not.toContain(snapshotGraph);
 
+    const registered = await capSnapshot.invoke({
+      contextGraphId: CG_ID,
+      offset: 0,
+      limit: 5000,
+      includeSharedMemory: true,
+      phase: 'snapshot',
+      snapshotGraph: registeredSubGraphSnapshot,
+    });
+    expect(registered).toContain('"registered-subgraph-snapshot"');
+
+    // Rolling compatibility: old requesters encoded graph-backed intent in
+    // snapshotRef. The centralized target parser keeps accepting that form.
+    const legacy = await capSnapshot.invoke({
+      contextGraphId: CG_ID,
+      offset: 0,
+      limit: 1,
+      includeSharedMemory: true,
+      phase: 'snapshot',
+      snapshotRef: snapshotGraph,
+    });
+    expect(legacy).not.toBe('');
+
     const denied = await capSnapshot.invoke({
       contextGraphId: CG_ID,
       offset: 0,
       limit: 5000,
       includeSharedMemory: true,
       phase: 'snapshot',
-      snapshotRef: unregisteredSubGraphSnapshot,
+      snapshotGraph: unregisteredSubGraphSnapshot,
     });
     expect(denied).toBe('');
     await storeSnapshot.close();

--- a/packages/agent/test/sync-responder-swm-subgraphs.test.ts
+++ b/packages/agent/test/sync-responder-swm-subgraphs.test.ts
@@ -351,6 +351,65 @@ describe('sync responder workspace branch — sub-graph SWM coverage', () => {
     });
   });
 
+  describe('phase=meta (TTL on, graph-scoped heads)', () => {
+    it('serves an untimestamped rootless head when its selected operation is fresh', async () => {
+      const storeTtl = new OxigraphStore();
+      const freshIso = new Date(Date.now() - 1_000).toISOString();
+      const staleIso = new Date(Date.now() - 10_000).toISOString();
+      const freshUal = 'did:dkg:hardhat:31337/0x00000000000000000000000000000000000000ab/7';
+      const staleUal = 'did:dkg:hardhat:31337/0x00000000000000000000000000000000000000ab/8';
+      const graphScopedRows = (ual: string, opId: string, timestamp: string) => {
+        const op = `urn:dkg:share:${CG_ID}:${opId}`;
+        const head = `${ual}#dkg-swm-head`;
+        return [
+          { graph: ROOT_SWM_META, subject: op, predicate: RDF_TYPE, object: `${DKG_NS}WorkspaceOperation` },
+          { graph: ROOT_SWM_META, subject: op, predicate: `${DKG_NS}publishedAt`, object: `"${timestamp}"^^<http://www.w3.org/2001/XMLSchema#dateTime>` },
+          { graph: ROOT_SWM_META, subject: op, predicate: `${DKG_NS}shareOperationId`, object: `"${opId}"` },
+          { graph: ROOT_SWM_META, subject: op, predicate: `${DKG_NS}contentScopeVersion`, object: '"2"^^<http://www.w3.org/2001/XMLSchema#integer>' },
+          { graph: ROOT_SWM_META, subject: op, predicate: `${DKG_NS}kaUal`, object: ual },
+          { graph: ROOT_SWM_META, subject: op, predicate: `${DKG_NS}assertionVersion`, object: '"1"^^<http://www.w3.org/2001/XMLSchema#integer>' },
+          { graph: ROOT_SWM_META, subject: head, predicate: `${DKG_NS}contentScopeVersion`, object: '"2"^^<http://www.w3.org/2001/XMLSchema#integer>' },
+          { graph: ROOT_SWM_META, subject: head, predicate: `${DKG_NS}kaUal`, object: ual },
+          { graph: ROOT_SWM_META, subject: head, predicate: `${DKG_NS}assertionVersion`, object: '"1"^^<http://www.w3.org/2001/XMLSchema#integer>' },
+          { graph: ROOT_SWM_META, subject: head, predicate: `${DKG_NS}shareOperationId`, object: `"${opId}"` },
+          { graph: ROOT_SWM_META, subject: head, predicate: `${DKG_NS}assertionGraph`, object: `${ROOT_SWM}/0x00000000000000000000000000000000000000ab/${ual.endsWith('/7') ? '7' : '8'}` },
+        ];
+      };
+      await storeTtl.insert([
+        ...graphScopedRows(freshUal, 'fresh-rootless', freshIso),
+        ...graphScopedRows(staleUal, 'stale-rootless', staleIso),
+      ]);
+      const capTtl = captureHandler();
+      registerSyncHandler({
+        register: capTtl.register,
+        protocolSync: '/origintrail/dkg/sync/1.0.0',
+        syncDeniedResponse: 'sync-denied',
+        syncPageSize: 5000,
+        sharedMemoryTtlMs: 5_000,
+        store: storeTtl,
+        peerId: 'self-peer',
+        parseSyncRequest: (data) => JSON.parse(new TextDecoder().decode(data)) as SyncRequestEnvelope,
+        authorizeSyncRequest: async () => true,
+        logWarn: noopLog,
+        logDebug: noopLog,
+      });
+
+      const out = await capTtl.invoke({
+        contextGraphId: CG_ID,
+        offset: 0,
+        limit: 5000,
+        includeSharedMemory: true,
+        phase: 'meta',
+      });
+
+      expect(out).toContain(`${freshUal}#dkg-swm-head`);
+      expect(out).toContain('urn:dkg:share:devnet-test:fresh-rootless');
+      expect(out).not.toContain(`${staleUal}#dkg-swm-head`);
+      expect(out).not.toContain('urn:dkg:share:devnet-test:stale-rootless');
+      await storeTtl.close();
+    });
+  });
+
   // Codex review on #885 — URI shape alone is NOT a sufficient CG
   // boundary because `validateContextGraphId` permits `/` in the CG
   // ID (wallet-scoped IDs do, e.g. `0xabc/project`). For a request on

--- a/packages/agent/test/sync-responder-swm-subgraphs.test.ts
+++ b/packages/agent/test/sync-responder-swm-subgraphs.test.ts
@@ -421,7 +421,13 @@ describe('sync responder workspace branch — sub-graph SWM coverage', () => {
         graph: snapshotGraph,
         subject: 'urn:rootless:snapshot',
         predicate: 'http://schema.org/status',
-        object: '"graph-backed"',
+        object: '"graph-backed-a"',
+      },
+      {
+        graph: snapshotGraph,
+        subject: 'urn:rootless:snapshot-2',
+        predicate: 'http://schema.org/status',
+        object: '"graph-backed-b"',
       },
       {
         graph: unregisteredSubGraphSnapshot,
@@ -445,16 +451,29 @@ describe('sync responder workspace branch — sub-graph SWM coverage', () => {
       logDebug: noopLog,
     });
 
-    const out = await capSnapshot.invoke({
+    const firstPage = await capSnapshot.invoke({
       contextGraphId: CG_ID,
       offset: 0,
-      limit: 5000,
+      limit: 1,
       includeSharedMemory: true,
       phase: 'snapshot',
       snapshotRef: snapshotGraph,
     });
-    expect(out).toContain('"graph-backed"');
-    expect(out).not.toContain(snapshotGraph);
+    const secondPage = await capSnapshot.invoke({
+      contextGraphId: CG_ID,
+      offset: 1,
+      limit: 1,
+      includeSharedMemory: true,
+      phase: 'snapshot',
+      snapshotRef: snapshotGraph,
+    });
+    expect(firstPage.trim().split('\n')).toHaveLength(1);
+    expect(secondPage.trim().split('\n')).toHaveLength(1);
+    expect(firstPage).not.toBe(secondPage);
+    expect(`${firstPage}\n${secondPage}`).toContain('"graph-backed-a"');
+    expect(`${firstPage}\n${secondPage}`).toContain('"graph-backed-b"');
+    expect(firstPage).not.toContain(snapshotGraph);
+    expect(secondPage).not.toContain(snapshotGraph);
 
     const denied = await capSnapshot.invoke({
       contextGraphId: CG_ID,

--- a/packages/agent/test/sync-verify-rootless.test.ts
+++ b/packages/agent/test/sync-verify-rootless.test.ts
@@ -98,6 +98,24 @@ describe('verifySyncedData — rootless graph scope', () => {
     expect(meta.some((entry) => entry.predicate === `${DKG}rootEntity`)).toBe(false);
   });
 
+  it('does not mistake lifecycle scope rows for a second incomplete KA descriptor', () => {
+    const generated = fixture();
+    const lifecycle = `${UAL}/assertion/1`;
+    const lifecycleRows = [
+      quad(lifecycle, `${DKG}contentScopeVersion`, `"2"^^<${XSD_INTEGER}>`, META),
+      quad(lifecycle, `${DKG}kaUal`, UAL, META),
+      quad(lifecycle, `${DKG}assertionVersion`, `"1"^^<${XSD_INTEGER}>`, META),
+      quad(lifecycle, `${DKG}assertionGraph`, generated.assertionGraph, META),
+    ];
+
+    const result = verifyBoth(generated.payload, [...generated.meta, ...lifecycleRows]);
+
+    expect(result.rejected).toBe(0);
+    expect(result.data).toEqual(generated.payload);
+    expect(result.meta).toEqual([...generated.meta, ...lifecycleRows]);
+    expect(result.logs.some(({ message }) => message.includes('missing merkleRoot'))).toBe(false);
+  });
+
   it('rejects a Merkle mismatch by exact graph while retaining unrelated data', () => {
     const { payload, meta, assertionGraph } = fixture({
       merkleRoot: new Uint8Array(32).fill(9),


### PR DESCRIPTION
## Summary
- recover V2 graph-scoped SWM assets from immutable, digest-checked snapshots into their exact UAL/version-derived named graphs
- replace each recovered graph atomically and replace its active head/operation metadata
- keep lifecycle and seal scope rows out of the durable KA descriptor classifier
- include active graph-scoped heads in TTL recovery and keep first-level subgraph control metadata out of the durable data lane
- preserve the legacy root-based recovery path for legacy assets

## Runtime failure closed
A newly admitted private-CG member received the rootless WorkspaceOperation rows but not the active head, then treated a local subgraph migration marker as KA data and rejected the lifecycle metadata batch. The member could not reach a fully synced state even though the immutable snapshots were available.

## Verification
- focused sync/recovery suites: 72/72 passed
- full workspace build: passed
- clean six-node mixed-backend smoke: autoApprove plus late join, 2/2 exact KAs recovered and persisted across restart
- local load gate: 50/50 KAs, 1,000 triples each, 50,000/50,000 triples recovered
- per-KA digest/count/graph integrity: 50/50 before and after joiner restart
- operation success: 50/50
- health audit: no daemon or Oxigraph crash, OOM, or sustained queue/memory/load saturation

Artifacts are retained locally under `.harness-artifacts/private-cg-membership-recovery-20260715T084633Z-62808-devnet-fixed-auto`.

## Stack
Depends on #1730. The load-harness commits will be proposed as the next stacked PR so this production fix remains independently reviewable.