### PR TITLE
fix(sync): recover rootless SWM from paged snapshots

### DIFF
--- a/packages/agent/src/sync/requester/shared-memory-sync.ts
+++ b/packages/agent/src/sync/requester/shared-memory-sync.ts
@@ -412,13 +412,16 @@ export async function syncPublicSnapshotsForMeta(params: {
     if (result.completed && (result.resumedFromOffset > 0 || result.nextOffset > result.resumedFromOffset)) {
       completedPhases += 1;
     }
-    if (result.nextOffset > result.resumedFromOffset) {
-      checkpointAdvances += 1;
-    }
-
     if (result.completed) params.deleteCheckpoint(result.checkpointKey);
     else {
-      params.setCheckpoint(result.checkpointKey, result.nextOffset);
+      // `fetchSyncPages` returns only the quads fetched during THIS call. We do
+      // not persist an unverified prefix, so resuming a snapshot at nextOffset
+      // would validate only the tail against the full digest/count and can never
+      // succeed. Restart this one immutable KA at offset zero on the next round;
+      // already completed snapshots remain cached and are skipped, preserving
+      // monotonic recovery progress across the CG without accepting a partial
+      // asset.
+      params.deleteCheckpoint(result.checkpointKey);
       return {
         bytesReceived,
         resumedPhases,

--- a/packages/agent/src/sync/requester/swm-recovery.ts
+++ b/packages/agent/src/sync/requester/swm-recovery.ts
@@ -27,9 +27,13 @@ import {
  * sync path's blind union (which corrupts a non-empty store — see
  * {@link applySwmRecovery}).
  *
- * It fetches the COMPLETE state across pages (each `fetchSyncPages` call loops
- * internally to completion-or-deadline), verifies it, then replaces each root
- * exactly once.
+ * It fetches the COMPLETE metadata state across pages, verifies it, then uses
+ * the narrowest safe recovery path:
+ *
+ * - graph-scoped KAs backed by immutable public snapshots are fetched and
+ *   verified one KA at a time, without scanning the aggregate SWM data graph;
+ * - legacy root-scoped KAs and graph-backed legacy snapshots retain the full
+ *   data-phase recovery below.
  *
  * A partial fetch (deadline) is NOT safe to apply, and is deliberately NOT
  * applied. Pagination is row-based, so a single root's rows (the root + its
@@ -167,22 +171,15 @@ export async function recoverContextGraphSwm(
   const wsGraph = contextGraphWorkspaceGraphUri(deps.contextGraphId);
   const wsMetaGraph = contextGraphWorkspaceMetaGraphUri(deps.contextGraphId);
 
-  // Meta first (its rootEntity list is what validates the data subjects), then data.
+  // Metadata is the recovery plan: it identifies both legacy roots and exact
+  // graph-scoped assets. Fetch it before deciding whether an aggregate SWM data
+  // scan is necessary.
   const meta = await fetchPhaseFully(deps, 'meta', wsMetaGraph);
-  const data = await fetchPhaseFully(deps, 'data', wsGraph);
-
-  // All-or-nothing gate (B10): a partial fetch may have cut a root mid-stream,
-  // so applying REPLACE over a prefix would truncate that root. If EITHER phase
-  // is incomplete, mutate nothing — not the data REPLACE, not the additive meta
-  // insert, not the ownership-cache hydration (hydrating roots we didn't write
-  // would desync the ownership map from the store) — and report `completed:
-  // false` so the caller retries. The checkpoint was already dropped above, so
-  // the retry re-accumulates the complete state from offset 0.
-  if (!meta.completed || !data.completed) {
+  if (!meta.completed) {
     deps.logInfo?.(
       deps.ctx,
-      `SWM recovery for "${deps.contextGraphId}" from ${deps.remotePeerId}: partial fetch ` +
-      `(meta ${meta.completed ? 'complete' : 'incomplete'}, data ${data.completed ? 'complete' : 'incomplete'}) — skipped, will retry`,
+      `SWM recovery for "${deps.contextGraphId}" from ${deps.remotePeerId}: ` +
+      'partial metadata fetch — skipped, will retry',
     );
     return {
       replacedRoots: 0,
@@ -217,6 +214,24 @@ export async function recoverContextGraphSwm(
     registeredSubGraphNames: recoveryRegistered,
     excludedSubGraphNames: excluded,
   });
+
+  // Classify legacy roots from metadata alone. The verifier does not need data
+  // rows to derive entityCreators, and this lets a rootless-only CG avoid the
+  // expensive aggregate `_shared_memory` query entirely. That query is both
+  // redundant (the immutable snapshot is the canonical source for an exact
+  // graph asset) and scales with every KA in the CG.
+  const metadataOnlyProcessed = await deps.processSharedMemoryBatch(
+    [], meta.quads, deps.contextGraphId, recoveryRegistered, excluded,
+  );
+  const hasLegacyRoots = metadataOnlyProcessed.entityCreators.length > 0;
+  const hasGraphBackedSnapshots = graphScopedDescriptors.some(
+    (descriptor) => descriptor.publicSnapshotGraph !== undefined,
+  );
+
+  // Fetch store-backed snapshots before any aggregate data scan. Each completed
+  // snapshot is persisted independently, so a deadline can make monotonic
+  // progress across retries while memory remains bounded to one KA rather than
+  // the complete context graph.
   if (graphScopedDescriptors.length > 0) {
     const activeGraphMeta = graphScopedDescriptors.flatMap((descriptor) => [
       ...descriptor.metadataQuads,
@@ -249,6 +264,33 @@ export async function recoverContextGraphSwm(
     }
   }
 
+  // Only legacy roots and old graph-backed snapshot rows require the aggregate
+  // data phase. New rootless KAs use immutable snapshot refs and never enter
+  // this path.
+  const needsAggregateData = hasLegacyRoots || hasGraphBackedSnapshots;
+  const data = needsAggregateData
+    ? await fetchPhaseFully(deps, 'data', wsGraph)
+    : { quads: [] as Quad[], completed: true };
+
+  // Legacy row pagination can cut a root (or a graph-backed snapshot) in the
+  // middle. Preserve the existing all-or-nothing gate for that compatibility
+  // path; store-backed exact assets above do not depend on it.
+  if (!data.completed) {
+    deps.logInfo?.(
+      deps.ctx,
+      `SWM recovery for "${deps.contextGraphId}" from ${deps.remotePeerId}: ` +
+      'partial legacy data fetch — skipped, will retry',
+    );
+    return {
+      replacedRoots: 0,
+      replacedGraphs: 0,
+      insertedDataQuads: 0,
+      insertedMetaQuads: 0,
+      droppedDataTriples: 0,
+      completed: false,
+    };
+  }
+
   // Rootless exact graphs and graph-backed immutable snapshots are verified
   // per KA below. Keep them out of the legacy rootEntity worker path so they
   // are not counted as invalid root subjects or inserted by union.
@@ -263,9 +305,11 @@ export async function recoverContextGraphSwm(
     (quad) => !graphScopedTransportGraphs.has(quad.graph),
   );
 
-  const processed = await deps.processSharedMemoryBatch(
-    legacyDataQuads, meta.quads, deps.contextGraphId, recoveryRegistered, excluded,
-  );
+  const processed = needsAggregateData
+    ? await deps.processSharedMemoryBatch(
+      legacyDataQuads, meta.quads, deps.contextGraphId, recoveryRegistered, excluded,
+    )
+    : metadataOnlyProcessed;
 
   await deps.ensureContextGraph(deps.contextGraphId);
 

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -588,11 +588,14 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
           if (!snapshotRef || !publicSnapshotStore) {
             return new TextEncoder().encode('');
           }
-          const snapshot = await raceAgainstAbort(publicSnapshotStore.getSnapshot(snapshotRef), signal);
-          if (!snapshot) {
-            return new TextEncoder().encode('');
-          }
-          const page = snapshot.slice(offset, offset + limit);
+          const page = publicSnapshotStore.getSnapshotPage
+            ? await raceAgainstAbort(
+              publicSnapshotStore.getSnapshotPage(snapshotRef, offset, limit, { signal }),
+              signal,
+            )
+            : (await raceAgainstAbort(publicSnapshotStore.getSnapshot(snapshotRef), signal))
+              ?.slice(offset, offset + limit);
+          if (!page) return new TextEncoder().encode('');
           if (page.length === 0) {
             return new TextEncoder().encode('');
           }

--- a/packages/agent/test/swm-recovery.test.ts
+++ b/packages/agent/test/swm-recovery.test.ts
@@ -34,6 +34,7 @@ const ctx: OperationContext = { operationId: 'test', operationName: 'sync' } as 
 const DKG = 'http://dkg.io/ontology/';
 const XSD_INTEGER = 'http://www.w3.org/2001/XMLSchema#integer';
 const UAL = 'did:dkg:hardhat:31337/0x00000000000000000000000000000000000000ab/7';
+const UAL_2 = 'did:dkg:hardhat:31337/0x00000000000000000000000000000000000000ab/8';
 
 class MemorySnapshotStore implements WorkspacePublicSnapshotStore {
   readonly snapshots = new Map<string, Quad[]>();
@@ -73,7 +74,10 @@ describe('recoverContextGraphSwm (fetch → verify → replace)', () => {
       processSharedMemoryBatch: async (dataQuads: Quad[], metaQuads: Quad[]) => ({
         verifiedData: dataQuads,
         verifiedMeta: metaQuads,
-        entityCreators: [...new Set(dataQuads.map((q) => q.subject))].map((entity) => ({
+        // Production derives the legacy recovery plan from rootEntity metadata,
+        // so it is available during the metadata-only classification call. This
+        // compact fixture models that plan from the declared source snapshot.
+        entityCreators: [...new Set(sourceData.map((q) => q.subject))].map((entity) => ({
           dataGraph: WS, entity, creator: 'peer-source',
         })),
         droppedDataTriples: 0,
@@ -188,6 +192,7 @@ describe('recoverContextGraphSwm (fetch → verify → replace)', () => {
     ]);
     const snapshotStore = new MemorySnapshotStore();
     let snapshotFetches = 0;
+    let dataFetches = 0;
 
     const result = await recoverContextGraphSwm({
       ctx,
@@ -202,6 +207,7 @@ describe('recoverContextGraphSwm (fetch → verify → replace)', () => {
           snapshotFetches += 1;
           return page(payload);
         }
+        dataFetches += 1;
         return page([]);
       },
       processSharedMemoryBatch: async (_dataQuads, metaQuads) => ({
@@ -225,6 +231,7 @@ describe('recoverContextGraphSwm (fetch → verify → replace)', () => {
       insertedMetaQuads: sourceMeta.length,
     });
     expect(snapshotFetches).toBe(1);
+    expect(dataFetches).toBe(0);
     const recovered = await store.query(
       `CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${assertionGraph}> { ?s ?p ?o } }`,
     );
@@ -232,6 +239,106 @@ describe('recoverContextGraphSwm (fetch → verify → replace)', () => {
     if (recovered.type === 'quads') {
       expect(recovered.quads.map(({ subject, predicate, object }) => ({ subject, predicate, object })))
         .toEqual(payload.map(({ subject, predicate, object }) => ({ subject, predicate, object })));
+    }
+  });
+
+  it('makes monotonic per-KA progress across a deadline without rescanning aggregate SWM data', async () => {
+    const store = new OxigraphStore();
+    stores.push(store);
+    const assets = [
+      {
+        ual: UAL,
+        operationId: 'rootless-recovery-page-1',
+        payload: [{ subject: 'urn:rootless:page:1', predicate: STATUS, object: '"one"', graph: '' }],
+      },
+      {
+        ual: UAL_2,
+        operationId: 'rootless-recovery-page-2',
+        payload: [{ subject: 'urn:rootless:page:2', predicate: STATUS, object: '"two"', graph: '' }],
+      },
+    ].map((asset) => {
+      const scope = createGraphKnowledgeAssetScope(asset.ual, 1);
+      const assertionGraph = knowledgeAssetLayerGraphUri(CG, MemoryLayer.SharedWorkingMemory, scope);
+      const digest = workspacePublicQuadsDigest(asset.payload);
+      const operationSubject = `urn:dkg:share:${CG}:${asset.operationId}`;
+      const headSubject = `${asset.ual}#dkg-swm-head`;
+      return {
+        ...asset,
+        assertionGraph,
+        digest,
+        meta: [
+          ...generateKnowledgeAssetShareMetadata({
+            shareOperationId: asset.operationId,
+            contextGraphId: CG,
+            kaUal: asset.ual,
+            assertionVersion: 1,
+            publicTripleCount: asset.payload.length,
+            privateTripleCount: 0,
+            publisherPeerId: 'peer-source',
+            timestamp: new Date(0),
+          }, WS_META),
+          { subject: operationSubject, predicate: `${DKG}publicQuadsDigest`, object: `"${digest}"`, graph: WS_META },
+          { subject: headSubject, predicate: `${DKG}contentScopeVersion`, object: `"${GRAPH_KA_CONTENT_SCOPE_VERSION}"^^<${XSD_INTEGER}>`, graph: WS_META },
+          { subject: headSubject, predicate: `${DKG}kaUal`, object: asset.ual, graph: WS_META },
+          { subject: headSubject, predicate: `${DKG}assertionVersion`, object: `"1"^^<${XSD_INTEGER}>`, graph: WS_META },
+          { subject: headSubject, predicate: `${DKG}assertionGraph`, object: assertionGraph, graph: WS_META },
+          { subject: headSubject, predicate: `${DKG}shareOperationId`, object: `"${asset.operationId}"`, graph: WS_META },
+        ] satisfies Quad[],
+      };
+    });
+    const sourceMeta = assets.flatMap((asset) => asset.meta);
+    const snapshotStore = new MemorySnapshotStore();
+    const snapshotFetches = new Map<string, number>();
+    let round = 1;
+    let dataFetches = 0;
+    const recover = () => recoverContextGraphSwm({
+      ctx,
+      remotePeerId: 'peer-source',
+      contextGraphId: CG,
+      deadline: Number.MAX_SAFE_INTEGER,
+      fetchSyncPages: async (
+        _c, _p, _cg, _inc, phase, _graph, _deadline, snapshotRef,
+      ): Promise<SyncPageResult> => {
+        if (phase === 'meta') return page(sourceMeta);
+        if (phase === 'data') {
+          dataFetches += 1;
+          throw new Error('rootless recovery must not request aggregate data');
+        }
+        const asset = assets.find((candidate) => candidate.digest === snapshotRef);
+        if (!asset) throw new Error(`Unexpected snapshot ref ${snapshotRef}`);
+        snapshotFetches.set(asset.digest, (snapshotFetches.get(asset.digest) ?? 0) + 1);
+        if (round === 1 && asset === assets[1]) {
+          return { ...page([], false), checkpointKey: `snapshot:${asset.digest}` };
+        }
+        return { ...page(asset.payload), checkpointKey: `snapshot:${asset.digest}` };
+      },
+      processSharedMemoryBatch: async (_dataQuads, metaQuads) => ({
+        verifiedData: [], verifiedMeta: metaQuads, entityCreators: [], droppedDataTriples: 0,
+      }),
+      store,
+      publicSnapshotStore: snapshotStore,
+      ensureContextGraph: async () => {},
+      setCheckpoint: () => {},
+      deleteCheckpoint: () => {},
+    });
+
+    const partial = await recover();
+    expect(partial.completed).toBe(false);
+    expect(partial.replacedGraphs).toBe(0);
+    await expect(snapshotStore.getSnapshot(assets[0]!.digest)).resolves.toEqual(assets[0]!.payload);
+    await expect(snapshotStore.getSnapshot(assets[1]!.digest)).resolves.toBeNull();
+
+    round = 2;
+    const completed = await recover();
+    expect(completed).toMatchObject({ completed: true, replacedGraphs: 2, insertedDataQuads: 2 });
+    expect(snapshotFetches.get(assets[0]!.digest)).toBe(1);
+    expect(snapshotFetches.get(assets[1]!.digest)).toBe(2);
+    expect(dataFetches).toBe(0);
+    for (const asset of assets) {
+      const result = await store.query(
+        `SELECT ?s ?p ?o WHERE { GRAPH <${asset.assertionGraph}> { ?s ?p ?o } }`,
+      );
+      expect(result.type === 'bindings' ? result.bindings : []).toHaveLength(asset.payload.length);
     }
   });
 

--- a/packages/agent/test/sync-requester-progress.test.ts
+++ b/packages/agent/test/sync-requester-progress.test.ts
@@ -829,7 +829,7 @@ describe('sync requester progress accounting', () => {
     expect(summary.checkpointAdvances).toBe(1);
   });
 
-  it('reports resume-capable shared-memory snapshot timeouts as checkpoint progress', async () => {
+  it('restarts incomplete shared-memory snapshots because their unverified prefix is not persisted', async () => {
     const setCheckpoint = recorder((_key: string, _offset: number) => {});
     const deleteCheckpoint = recorder((_key: string) => {});
     const storeInsert = recorder(async (_quads: Quad[]) => {});
@@ -897,10 +897,10 @@ describe('sync requester progress accounting', () => {
 
     expect(summary.failedPeers).toBe(0);
     expect(summary.timedOutPhases).toBe(1);
-    expect(summary.checkpointAdvances).toBe(1);
+    expect(summary.checkpointAdvances).toBe(0);
     expect(summary.insertedTriples).toBe(0);
-    expect(setCheckpoint.calls).toContainEqual(['large-swm:snapshot:snapshot-ref', 500]);
-    expect(deleteCheckpoint.calls).toEqual([]);
+    expect(setCheckpoint.calls).toEqual([]);
+    expect(deleteCheckpoint.calls).toContainEqual(['large-swm:snapshot:snapshot-ref']);
     expect(storeInsert.calls).toEqual([]);
     expect(ensureContextGraph.calls).toEqual([]);
   });
@@ -990,15 +990,15 @@ describe('sync requester progress accounting', () => {
 
     expect(summary.failedPeers).toBe(0);
     expect(summary.timedOutPhases).toBe(2);
-    expect(summary.checkpointAdvances).toBe(2);
+    expect(summary.checkpointAdvances).toBe(1);
     expect(summary.insertedDataTriples).toBe(1);
     expect(summary.insertedMetaTriples).toBe(0);
     expect(ensureContextGraph.calls).toContainEqual(['large-swm']);
     expect(storeInsert.calls).toHaveLength(1);
     expect(storeInsert.calls).toContainEqual([[dataQuad]]);
-    expect(setCheckpoint.calls).toContainEqual(['large-swm:snapshot:snapshot-ref', 500]);
+    expect(setCheckpoint.calls).not.toContainEqual(['large-swm:snapshot:snapshot-ref', expect.any(Number)]);
     expect(setCheckpoint.calls).toContainEqual(['large-swm:data', 7]);
     expect(setCheckpoint.calls).not.toContainEqual(['large-swm:meta', expect.any(Number)]);
-    expect(deleteCheckpoint.calls).toEqual([]);
+    expect(deleteCheckpoint.calls).toContainEqual(['large-swm:snapshot:snapshot-ref']);
   });
 });

--- a/packages/agent/test/sync-responder-log-volume.test.ts
+++ b/packages/agent/test/sync-responder-log-volume.test.ts
@@ -41,7 +41,10 @@ describe('sync responder page diagnostics', () => {
     ];
     const publicSnapshotStore: WorkspacePublicSnapshotStore = {
       putSnapshot: async () => ({ ref: 'snapshot-ref', byteLength: 0 }),
-      getSnapshot: async () => snapshotQuads,
+      getSnapshot: async () => {
+        throw new Error('paged responder must not materialize the complete snapshot');
+      },
+      getSnapshotPage: async (_ref, offset, limit) => snapshotQuads.slice(offset, offset + limit),
     };
     const debugMessages: string[] = [];
     const handler = registerTestSyncHandler(store, {

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -55,6 +55,7 @@ export default defineConfig({
       "test/sync-backpressure.test.ts",
       "test/sync-requester-priority.test.ts",
       "test/sync-requester-progress.test.ts",
+      "test/swm-recovery.test.ts",
       "test/sync-responder-protection.test.ts",
       "test/sync-on-connect-retry.test.ts",
       "test/sync-on-connect-churn.test.ts",

--- a/packages/publisher/src/workspace-snapshot-store.ts
+++ b/packages/publisher/src/workspace-snapshot-store.ts
@@ -1,6 +1,7 @@
-import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
+import { mkdir, open, readFile, rename, writeFile } from 'node:fs/promises';
 import { createHash } from 'node:crypto';
 import { dirname, join } from 'node:path';
+import { createInterface } from 'node:readline';
 import type { Quad } from '@origintrail-official/dkg-storage';
 
 export interface SharedMemoryPublicSnapshotStorageConfig {
@@ -14,6 +15,17 @@ export interface WorkspacePublicSnapshotStore {
     readonly quads: readonly Quad[];
   }): Promise<{ readonly ref: string; readonly byteLength: number }>;
   getSnapshot(ref: string): Promise<Quad[] | null>;
+  /**
+   * Read one immutable snapshot page without materializing the complete file.
+   * Optional for compatibility with custom/legacy stores; sync responders fall
+   * back to `getSnapshot().slice(...)` when it is not implemented.
+   */
+  getSnapshotPage?(
+    ref: string,
+    offset: number,
+    limit: number,
+    options?: { readonly signal?: AbortSignal },
+  ): Promise<Quad[] | null>;
 }
 
 export class FileWorkspacePublicSnapshotStore implements WorkspacePublicSnapshotStore {
@@ -53,6 +65,52 @@ export class FileWorkspacePublicSnapshotStore implements WorkspacePublicSnapshot
     }
 
     return parseWorkspacePublicSnapshotNQuads(raw, ref);
+  }
+
+  async getSnapshotPage(
+    ref: string,
+    offset: number,
+    limit: number,
+    options?: { readonly signal?: AbortSignal },
+  ): Promise<Quad[] | null> {
+    const safeOffset = Math.max(0, Math.floor(offset));
+    const safeLimit = Math.max(0, Math.floor(limit));
+    if (safeLimit === 0) return [];
+    const hash = snapshotHash(ref);
+    const nquadsPath = snapshotPath(this.directory, hash, 'nq');
+    let file: Awaited<ReturnType<typeof open>>;
+    try {
+      file = await open(nquadsPath, 'r');
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+      const legacy = await this.getLegacyJsonSnapshot(ref, hash);
+      return legacy?.slice(safeOffset, safeOffset + safeLimit) ?? null;
+    }
+
+    const input = file.createReadStream({
+      encoding: 'utf8',
+      autoClose: false,
+      signal: options?.signal,
+    });
+    const lines = createInterface({ input, crlfDelay: Infinity });
+    const page: Quad[] = [];
+    let row = 0;
+    try {
+      for await (const rawLine of lines) {
+        const line = rawLine.trim();
+        if (!line) continue;
+        if (row >= safeOffset) {
+          page.push(parseNQuadLine(line, ref, row));
+          if (page.length >= safeLimit) break;
+        }
+        row += 1;
+      }
+      return page;
+    } finally {
+      lines.close();
+      input.destroy();
+      await file.close().catch(() => {});
+    }
   }
 
   private async getLegacyJsonSnapshot(ref: string, hash: string): Promise<Quad[] | null> {

--- a/packages/publisher/test/async-lift-workspace.test.ts
+++ b/packages/publisher/test/async-lift-workspace.test.ts
@@ -66,6 +66,7 @@ describe('FileWorkspacePublicSnapshotStore', () => {
       );
 
       await expect(publicSnapshotStore.getSnapshot(SNAPSHOT_DIGEST)).resolves.toEqual(legacyQuads);
+      await expect(publicSnapshotStore.getSnapshotPage(SNAPSHOT_DIGEST, 0, 1)).resolves.toEqual(legacyQuads);
     } finally {
       await rm(snapshotDir, { recursive: true, force: true });
     }

--- a/packages/publisher/test/workspace-snapshot-store.test.ts
+++ b/packages/publisher/test/workspace-snapshot-store.test.ts
@@ -1,0 +1,33 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { FileWorkspacePublicSnapshotStore } from '../src/workspace-snapshot-store.js';
+
+const DIGEST = `sha256:${'b'.repeat(64)}`;
+
+describe('FileWorkspacePublicSnapshotStore paging', () => {
+  it('reads only the requested N-Quads page and returns an empty EOF page', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dkg-snapshot-page-'));
+    const store = new FileWorkspacePublicSnapshotStore(directory);
+    const quads = Array.from({ length: 205 }, (_, index) => ({
+      subject: `urn:snapshot:entity:${index.toString().padStart(3, '0')}`,
+      predicate: 'http://schema.org/value',
+      object: `"${index}"`,
+      graph: '',
+    }));
+
+    try {
+      await store.putSnapshot({ digest: DIGEST, quads });
+
+      await expect(store.getSnapshotPage(DIGEST, 64, 64))
+        .resolves.toEqual(quads.slice(64, 128));
+      await expect(store.getSnapshotPage(DIGEST, 192, 64))
+        .resolves.toEqual(quads.slice(192));
+      await expect(store.getSnapshotPage(DIGEST, quads.length, 64))
+        .resolves.toEqual([]);
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/publisher/vitest.unit.config.ts
+++ b/packages/publisher/vitest.unit.config.ts
@@ -38,6 +38,7 @@ export default defineConfig({
       'test/publish-lifecycle-logger.test.ts',
       'test/storage-ack-handler.test.ts',
       'test/swm-slice-ack-unbounded.test.ts',
+      'test/workspace-snapshot-store.test.ts',
     ],
     testTimeout: 60_000,
     maxWorkers: 1,


### PR DESCRIPTION
## Summary
- recover store-backed rootless SWM assets from their canonical per-KA snapshots without scanning the aggregate `_shared_memory` graph
- retain the aggregate data recovery path for legacy roots and graph-backed legacy snapshots
- serve file snapshots page-by-page and restart incomplete unverified snapshots safely

## Why
The 50 x 1,000-triple private-CG gate proved that the aggregate SWM data query can exceed the per-page transport deadline before returning offset zero, even though every new KA already has an immutable digest-addressed snapshot. This change uses that canonical per-KA source and bounds recovery memory to one KA/page.

## Verification
- publisher build
- agent build + type tests
- 29 focused publisher/agent tests, including legacy recovery, rootless no-aggregate-data recovery, deadline retry reuse, responder paging, and checkpoint safety