### PR TITLE
testnet: integrate rootless VM and sync correctness fixes

### DIFF
--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -4232,8 +4232,16 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     result.insertedDataTriples += insertedDataTriples;
     result.insertedMetaTriples += insertedMetaTriples;
     result.insertedTriples += insertedDataTriples + insertedMetaTriples;
+    const changelogComplete = outcome.kind === 'delta'
+      || (outcome.kind === 'resync' && outcome.complete);
+    if (!changelogComplete) {
+      // A legacy fallback may have completed its own fetch phases while the
+      // changelog drop remains unauthoritative. Preserve inserted progress,
+      // but do not surface those phase completions as CG readiness evidence.
+      result.completedPhases = 0;
+    }
     if (
-      outcome.kind !== 'denied'
+      changelogComplete
       && result.timedOutPhases === 0
       && result.failedPhases === 0
       && result.failedPeers === 0

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -227,7 +227,7 @@ import { fetchSyncPages, type SyncPageResult } from './sync/requester/page-fetch
 import { insertWithOversizeGuard, type OversizeGuardHooks } from './sync/oversize-filter.js';
 import { runOversizeSweep } from './sync/oversize-sweep.js';
 import { getSyncCheckpointKey } from './sync/checkpoint/state.js';
-import { runDurableSync } from './sync/requester/durable-sync.js';
+import { runDurableSync, type VerifiedFullSnapshot } from './sync/requester/durable-sync.js';
 import { resolveSyncAgentsMeta, shouldWithholdAgentsDurableMeta } from './sync/agents-meta-policy.js';
 import { runSharedMemorySync, sharedMemoryOwnershipKeyFromGraph } from './sync/requester/shared-memory-sync.js';
 import {
@@ -4000,6 +4000,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     onAccessDenied?: (contextGraphId: string) => void,
     sinceBatchIdFor?: (contextGraphId: string) => string | undefined,
     stopOnBackoffWorthyFailure?: boolean,
+    onVerifiedFullSnapshot?: (snapshot: VerifiedFullSnapshot) => Promise<void>,
   ): Promise<DurableSyncResult> {
     const syncAgentsMeta = resolveSyncAgentsMeta(this.config.syncAgentsMeta, process.env.DKG_SYNC_AGENTS_META);
     return runDurableSync({
@@ -4010,7 +4011,30 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       onAccessDenied,
       syncAgentsMeta,
       createContextGraphSyncDeadline: () => this.createContextGraphSyncDeadline(remainingContextGraphs),
-      fetchSyncPages: this.fetchSyncPages.bind(this),
+      fetchSyncPages: (
+        opCtx,
+        peerId,
+        cgId,
+        includeSharedMemory,
+        phase,
+        graphUri,
+        deadline,
+        snapshotRef,
+        sinceBatchId,
+      ) => this.fetchSyncPages(
+        opCtx,
+        peerId,
+        cgId,
+        includeSharedMemory,
+        phase,
+        graphUri,
+        deadline,
+        snapshotRef,
+        sinceBatchId,
+        undefined,
+        undefined,
+        onVerifiedFullSnapshot !== undefined,
+      ),
       sinceBatchIdFor,
       stopOnBackoffWorthyFailure,
       processDurableBatchInWorker: this.processDurableBatchInWorker.bind(this),
@@ -4018,6 +4042,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         priority: 'background',
         source: 'agent.durableSync.storeInsert',
       }),
+      onVerifiedFullSnapshot,
       deleteCheckpoint: (key) => this.syncCheckpoints.delete(key),
       setCheckpoint: (key, offset) => this.syncCheckpoints.set(key, offset),
       logInfo: (opCtx, message) => this.log.info(opCtx, message),
@@ -4135,7 +4160,27 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       // Resync = the legacy verified lane for just this CG (no re-entry into the changelog
       // branch). Fold its result in, and report completeness so the driver only advances
       // the cursor to headSeq when the resync verifiably fetched everything below it.
-      runResync: async () => {
+      runResync: async (dropCandidates) => {
+        const pendingDrops = [...new Set(dropCandidates)].filter((graph) => !isForeignGraph(graph));
+        let dropsReconciled = pendingDrops.length === 0;
+        let curatorAuthoritative = false;
+        if (pendingDrops.length > 0) {
+          const curator = await this.resolveCuratorPeerIdsForCg(contextGraphId);
+          // Merkle verification authenticates returned KAs, not snapshot completeness.
+          // Only the uniquely resolved structural curator may make absence authoritative;
+          // legacy triples and ambiguous/mismatched registry entries fail closed.
+          curatorAuthoritative = !curator.curatorIsLocal
+            && !curator.legacyTripleResolved
+            && curator.peerIds.length === 1
+            && curator.peerIds[0] === remotePeerId;
+          if (!curatorAuthoritative) {
+            this.log.warn(
+              ctx,
+              `Leaving ${pendingDrops.length} changelog drop(s) pending for CG ${contextGraphId}: `
+              + `peer ${remotePeerId.slice(-8)} is not the uniquely resolved structural curator`,
+            );
+          }
+        }
         const r = await this.runLegacyDurableSyncForContextGraph(
           ctx,
           remotePeerId,
@@ -4144,9 +4189,26 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           undefined,
           undefined,
           undefined,
+          undefined,
+          curatorAuthoritative ? async (snapshot) => {
+            let reconciled = true;
+            for (const graph of pendingDrops) {
+              const metadataGraph = graph.endsWith('/_meta');
+              if (metadataGraph && !snapshot.metaFetched) {
+                reconciled = false;
+                continue;
+              }
+              const present = metadataGraph
+                ? snapshot.verifiedMetaGraphs.has(graph)
+                : snapshot.verifiedDataGraphs.has(graph);
+              if (!present) await this.store.dropGraph(graph);
+            }
+            dropsReconciled = reconciled;
+          } : undefined,
         );
         result = mergeDurableSyncResults(result, r);
-        const complete = r.timedOutPhases === 0 && r.failedPhases === 0
+        const complete = dropsReconciled
+          && r.timedOutPhases === 0 && r.failedPhases === 0
           && r.failedPeers === 0 && r.dataRejectedMissingMeta === 0
           && r.rejectedKcs === 0;
         return { complete, insertedTriples: r.insertedTriples };

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -450,6 +450,16 @@ function rootlessUpdateError(code: RootlessUpdateErrorCode, message: string): Er
   return new RootlessUpdateError(code, message);
 }
 
+function latestShareOperationId(history: {
+  events: readonly AssertionEvent[];
+  currentShareOperationId?: string;
+}): string | undefined {
+  const promoted = [...history.events]
+    .reverse()
+    .find((event) => event.type === 'promoted' && event.shareOperationId);
+  return promoted?.shareOperationId?.trim() || history.currentShareOperationId?.trim() || undefined;
+}
+
 function distinctMetadataObjects(
   rows: readonly Quad[],
   predicate: string,
@@ -4152,10 +4162,7 @@ export class PublishMethods extends DKGAgentBase {
     if (opts?.entityProofs === true) {
       throw new Error('Graph-scoped async publish does not support entityProofs');
     }
-    const latestPromote = [...history.events]
-      .reverse()
-      .find((event) => event.type === 'promoted' && event.shareOperationId);
-    const shareOperationId = latestPromote?.shareOperationId?.trim() ?? history.currentShareOperationId?.trim();
+    const shareOperationId = latestShareOperationId(history);
     if (!shareOperationId) {
       throw Object.assign(
         new Error(
@@ -4432,7 +4439,13 @@ export class PublishMethods extends DKGAgentBase {
       );
     }
 
-    const liveShareOperationId = history.currentShareOperationId?.trim();
+    // Completed graph-scoped promotions intentionally consume the temporary
+    // lifecycle-level operation row. The durable operation identity remains
+    // on the canonical promoted event and immutable SWM head. Read the same
+    // metadata shapes used when the intent was enqueued so a valid queued job
+    // cannot become stale merely because redundant lifecycle metadata was
+    // trimmed after the promote commit.
+    const liveShareOperationId = latestShareOperationId(history);
     if (!liveShareOperationId || liveShareOperationId !== request.shareOperationId.trim()) {
       throw stale(
         `Knowledge asset VM publish intent for "${request.name}" changed after enqueue: ` +

--- a/packages/agent/src/sync/requester/changelog-sync.ts
+++ b/packages/agent/src/sync/requester/changelog-sync.ts
@@ -196,10 +196,9 @@ export interface ChangelogSyncDeps {
   logWarn?(message: string): void;
 }
 
-export interface ChangelogSyncOutcome {
-  kind: 'delta' | 'resync' | 'denied';
-  applied: number;
-}
+export type ChangelogSyncOutcome =
+  | { kind: 'delta' | 'denied'; applied: number }
+  | { kind: 'resync'; applied: number; complete: boolean };
 
 /** After this many consecutive no-forward-progress rounds, fall back to a full resync. */
 const RESYNC_AFTER_STALLED_ROUNDS = 3;
@@ -238,7 +237,7 @@ export async function runChangelogSync(deps: ChangelogSyncDeps): Promise<Changel
       // Only jump the cursor to headSeq if the resync verifiably fetched everything < headSeq;
       // otherwise leave it (still first-contact / behind) so the next cycle retries — no gap.
       if (rr.complete) deps.setCursor(resp.era, resp.headSeq);
-      return { kind: 'resync', applied };
+      return { kind: 'resync', applied, complete: rr.complete };
     }
 
     // delta — verified apply of the page (store writes commit inside applyPage).
@@ -258,7 +257,7 @@ export async function runChangelogSync(deps: ChangelogSyncDeps): Promise<Changel
         const rr = await deps.runResync();
         applied += rr.insertedTriples;
         if (rr.complete) deps.setCursor(resp.era, resp.headSeq);
-        return { kind: 'resync', applied };
+        return { kind: 'resync', applied, complete: rr.complete };
       }
     }
 

--- a/packages/agent/src/sync/requester/changelog-sync.ts
+++ b/packages/agent/src/sync/requester/changelog-sync.ts
@@ -191,8 +191,12 @@ export interface ChangelogSyncDeps {
   applyPage(page: {
     era: string; headSeq: number; nextSeq: number; priorSeq: number; records: ChangelogDeltaRecord[];
   }): Promise<{ advanceTo: number; applied: number; deferred: boolean }>;
-  /** Bootstrap this CG via the legacy full/durable lane (resync fallback + stall backstop). */
-  runResync(): Promise<ResyncOutcome>;
+  /**
+   * Bootstrap this CG via the legacy full/durable lane (resync fallback + stall backstop).
+   * `dropCandidates` are exact in-scope graphs whose unauthenticated changelog markers
+   * caused the stall. The full snapshot must reconcile them before returning `complete`.
+   */
+  runResync(dropCandidates: readonly string[]): Promise<ResyncOutcome>;
   logWarn?(message: string): void;
 }
 
@@ -232,7 +236,7 @@ export async function runChangelogSync(deps: ChangelogSyncDeps): Promise<Changel
     if (resp.kind === 'denied') return { kind: 'denied', applied };
 
     if (resp.kind === 'resync') {
-      const rr = await deps.runResync();
+      const rr = await deps.runResync([]);
       applied += rr.insertedTriples;
       // Only jump the cursor to headSeq if the resync verifiably fetched everything < headSeq;
       // otherwise leave it (still first-contact / behind) so the next cycle retries — no gap.
@@ -254,7 +258,9 @@ export async function runChangelogSync(deps: ChangelogSyncDeps): Promise<Changel
       // genuinely-missing meta (or an in-lane-unverifiable graph) can't wedge the CG.
       if (++stalledRounds >= RESYNC_AFTER_STALLED_ROUNDS) {
         deps.logWarn?.(`changelog sync stalled ${stalledRounds} rounds at seq ${priorSeq}; resyncing`);
-        const rr = await deps.runResync();
+        const rr = await deps.runResync(
+          resp.records.filter((record) => record.op === 'drop').map((record) => record.graph),
+        );
         applied += rr.insertedTriples;
         if (rr.complete) deps.setCursor(resp.era, resp.headSeq);
         return { kind: 'resync', applied, complete: rr.complete };

--- a/packages/agent/src/sync/requester/durable-sync.ts
+++ b/packages/agent/src/sync/requester/durable-sync.ts
@@ -32,6 +32,15 @@ export interface DurableSyncSummary {
   deferredBackpressure: number;
 }
 
+/** Graph inventory from one clean, complete legacy full snapshot. */
+export interface VerifiedFullSnapshot {
+  contextGraphId: string;
+  verifiedDataGraphs: ReadonlySet<string>;
+  verifiedMetaGraphs: ReadonlySet<string>;
+  /** False only when this CG's metadata phase was intentionally disabled. */
+  metaFetched: boolean;
+}
+
 interface DurableSyncContext {
   ctx: OperationContext;
   remotePeerId: string;
@@ -76,6 +85,7 @@ interface DurableSyncContext {
   ) => Promise<{
     verifiedData: Quad[];
     verifiedMeta: Quad[];
+    verifiedGraphScopedDataGraphs?: string[];
     totalFetchedDataQuads: number;
     totalFetchedMetaQuads: number;
     rejectedKcs: number;
@@ -85,6 +95,8 @@ interface DurableSyncContext {
     dataRejectedMissingMeta: number;
   }>;
   storeInsert: (quads: Quad[]) => Promise<void>;
+  /** Runs after verified snapshot writes and before phase checkpoints advance. */
+  onVerifiedFullSnapshot?: (snapshot: VerifiedFullSnapshot) => Promise<void>;
   deleteCheckpoint: (key: string) => void;
   setCheckpoint: (key: string, offset: number) => void;
   logInfo: (ctx: OperationContext, message: string) => void;
@@ -106,6 +118,7 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
     stopOnBackoffWorthyFailure = false,
     processDurableBatchInWorker,
     storeInsert,
+    onVerifiedFullSnapshot,
     deleteCheckpoint,
     setCheckpoint,
     logInfo,
@@ -263,6 +276,31 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
         summary.rejectedKcs += processed.rejectedKcs;
       }
 
+      const notifyVerifiedFullSnapshot = async (): Promise<void> => {
+        if (
+          !onVerifiedFullSnapshot
+          || sinceBatchId !== undefined
+          || !batchVerifiedCleanly
+          || processed.dataRejectedMissingMeta !== 0
+          || !dataResult.completed
+          || dataResult.timedOut
+          || dataResult.resumedFromOffset !== 0
+          || (!skipAgentsMeta && (!metaResult.completed || metaResult.timedOut))
+          || (!skipAgentsMeta && metaResult.resumedFromOffset !== 0)
+        ) return;
+
+        const verifiedDataGraphs = new Set(processed.verifiedData.map((quad) => quad.graph));
+        for (const graph of processed.verifiedGraphScopedDataGraphs ?? []) {
+          verifiedDataGraphs.add(graph);
+        }
+        await onVerifiedFullSnapshot({
+          contextGraphId: pid,
+          verifiedDataGraphs,
+          verifiedMetaGraphs: new Set(processed.verifiedMeta.map((quad) => quad.graph)),
+          metaFetched: !skipAgentsMeta,
+        });
+      };
+
       const metadataOnlyResponse = processed.metaOnlyResponses > 0;
       const updateMetaCheckpoint = batchVerifiedCleanly
         && processed.dataRejectedMissingMeta === 0
@@ -277,6 +315,7 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
         processed.dataRejectedMissingMeta > 0 ||
         (processed.verifiedData.length === 0 && processed.verifiedMeta.length === 0 && processed.metaOnlyResponses > 0)
       ) {
+        await notifyVerifiedFullSnapshot();
         // The verifier reports an empty batch only when both fetched phase
         // payloads are empty. Record each phase independently: a completed
         // zero-offset phase is a real clean-empty response, while a sibling
@@ -309,6 +348,7 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
         summary.insertedTriples += processed.verifiedMeta.length;
         summary.insertedMetaTriples += processed.verifiedMeta.length;
       }
+      await notifyVerifiedFullSnapshot();
       recordPhaseOutcome(metaResult, { updateCheckpoint: updateMetaCheckpoint, countProgress: !metadataOnlyResponse });
       recordPhaseOutcome(dataResult, { updateCheckpoint: updateDataCheckpoint });
       endPhase();

--- a/packages/agent/test/changelog-requester.test.ts
+++ b/packages/agent/test/changelog-requester.test.ts
@@ -356,7 +356,7 @@ describe('runChangelogSync — driver loop', () => {
       async () => ({ complete: true, insertedTriples: 42 }),
     );
     const out = await runChangelogSync(h.deps);
-    expect(out).toEqual({ kind: 'resync', applied: 42 });
+    expect(out).toEqual({ kind: 'resync', applied: 42, complete: true });
     expect(h.resyncs()).toBe(1);
     expect(h.cursor()).toEqual({ era: 'e2', seq: 9 });
   });
@@ -368,7 +368,7 @@ describe('runChangelogSync — driver loop', () => {
       async () => ({ complete: false, insertedTriples: 5 }),
     );
     const out = await runChangelogSync(h.deps);
-    expect(out).toEqual({ kind: 'resync', applied: 5 });
+    expect(out).toEqual({ kind: 'resync', applied: 5, complete: false });
     expect(h.cursor()).toBeUndefined(); // cursor left untouched — next cycle retries the resync
   });
 
@@ -406,6 +406,159 @@ describe('runChangelogSync — driver loop', () => {
   });
 });
 
+describe('changelog drop resync reconciliation', () => {
+  it('removes only graphs absent from the complete verified snapshot before advancing the cursor', async () => {
+    const presentGraph = 'did:dkg:context-graph:cg/_verifiable_memory/0xabc/8';
+    const staleGraph = 'did:dkg:context-graph:cg/_verifiable_memory/0xabc/9';
+    const response = encodeChangelogResponse(delta(9, 9, [
+      { seq: 8, graph: presentGraph, op: 'drop' },
+      { seq: 9, graph: staleGraph, op: 'drop' },
+    ]));
+    let cursor: { era: string; seq: number } | undefined;
+    const dropped: string[] = [];
+    const forceFreshSessionFlags: boolean[] = [];
+    const agent = {
+      config: { syncAgentsMeta: true },
+      changelogCursors: {
+        get: () => cursor,
+        set: (_peer: string, _cg: string, era: string, seq: number) => { cursor = { era, seq }; },
+      },
+      messenger: { sendToPeer: async () => response },
+      node: { stopSignal: null },
+      createContextGraphSyncDeadline: () => Date.now() + 60_000,
+      fetchSyncPages: async (
+        _ctx: unknown,
+        _peer: string,
+        contextGraphId: string,
+        _includeSharedMemory: boolean,
+        phase: string,
+        _graphUri: string,
+        _deadline: number,
+        _snapshotRef?: string,
+        _sinceBatchId?: string,
+        _signal?: AbortSignal,
+        _recovery?: boolean,
+        forceFreshSession?: boolean,
+      ) => {
+        forceFreshSessionFlags.push(forceFreshSession === true);
+        return {
+          quads: [], bytesReceived: 0, resumedFromOffset: 0, nextOffset: 0,
+          checkpointKey: `${contextGraphId}:${phase}`, completed: true, timedOut: false,
+        };
+      },
+      syncCheckpoints: new Map(),
+      insertSyncedQuadsAndInvalidateListCache: async () => {},
+      getOrCreateSyncVerifyWorker: () => ({
+        parseAndFilter: async () => ({ quads: [] }),
+      }),
+      processDurableBatchInWorker: async (
+        _data: Quad[], _meta: Quad[], _ctx: unknown, _accept: boolean,
+        mode: { kind: string },
+      ) => mode.kind === 'fullSnapshot'
+        ? {
+            verifiedData: [qd(presentGraph, 1)], verifiedMeta: [],
+            verifiedGraphScopedDataGraphs: [], totalFetchedDataQuads: 1,
+            totalFetchedMetaQuads: 0, rejectedKcs: 0, emptyResponses: 0,
+            metaOnlyResponses: 0, verifiedPrivateOnlyResponses: 0,
+            dataRejectedMissingMeta: 0,
+          }
+        : {
+            verifiedData: [], verifiedMeta: [], verifiedGraphScopedDataGraphs: [],
+            totalFetchedDataQuads: 0, totalFetchedMetaQuads: 0, rejectedKcs: 0,
+            emptyResponses: 1, metaOnlyResponses: 0, verifiedPrivateOnlyResponses: 0,
+            dataRejectedMissingMeta: 0,
+          },
+      runLegacyDurableSyncForContextGraph:
+        LifecycleSyncMethods.prototype.runLegacyDurableSyncForContextGraph,
+      resolveCuratorPeerIdsForCg: async () => ({
+        peerIds: ['peer'], curatorIsLocal: false, legacyTripleResolved: false,
+      }),
+      store: { dropGraph: async (graph: string) => { dropped.push(graph); } },
+      log: { info: () => {}, warn: () => {}, debug: () => {} },
+    };
+
+    await (LifecycleSyncMethods.prototype.runChangelogSyncForCg as any).call(
+      agent,
+      { kind: 'system', id: 'test', startedAt: 0 },
+      'peer',
+      'cg',
+    );
+
+    expect(dropped).toEqual([staleGraph]);
+    expect(forceFreshSessionFlags).toEqual([true, true]);
+    expect(cursor).toEqual({ era: 'e1', seq: 9 });
+  });
+
+  it('keeps the graph and cursor pending when the responder is not the unique structural curator', async () => {
+    const staleGraph = 'did:dkg:context-graph:cg/_verifiable_memory/0xabc/9';
+    const response = encodeChangelogResponse(delta(9, 9, [
+      { seq: 9, graph: staleGraph, op: 'drop' },
+    ]));
+    let cursor: { era: string; seq: number } | undefined;
+    const dropped: string[] = [];
+    const forceFreshSessionFlags: boolean[] = [];
+    const agent = {
+      config: { syncAgentsMeta: true },
+      changelogCursors: {
+        get: () => cursor,
+        set: (_peer: string, _cg: string, era: string, seq: number) => { cursor = { era, seq }; },
+      },
+      messenger: { sendToPeer: async () => response },
+      node: { stopSignal: null },
+      createContextGraphSyncDeadline: () => Date.now() + 60_000,
+      fetchSyncPages: async (
+        _ctx: unknown,
+        _peer: string,
+        contextGraphId: string,
+        _includeSharedMemory: boolean,
+        phase: string,
+        _graphUri: string,
+        _deadline: number,
+        _snapshotRef?: string,
+        _sinceBatchId?: string,
+        _signal?: AbortSignal,
+        _recovery?: boolean,
+        forceFreshSession?: boolean,
+      ) => {
+        forceFreshSessionFlags.push(forceFreshSession === true);
+        return {
+          quads: [], bytesReceived: 0, resumedFromOffset: 0, nextOffset: 1,
+          checkpointKey: `${contextGraphId}:${phase}`, completed: true, timedOut: false,
+        };
+      },
+      syncCheckpoints: new Map(),
+      insertSyncedQuadsAndInvalidateListCache: async () => {},
+      getOrCreateSyncVerifyWorker: () => ({ parseAndFilter: async () => ({ quads: [] }) }),
+      processDurableBatchInWorker: async () => ({
+        verifiedData: [qd('did:dkg:context-graph:cg/_verifiable_memory/0xabc/8', 1)],
+        verifiedMeta: [], verifiedGraphScopedDataGraphs: [],
+        totalFetchedDataQuads: 1, totalFetchedMetaQuads: 0, rejectedKcs: 0,
+        emptyResponses: 0, metaOnlyResponses: 0, verifiedPrivateOnlyResponses: 0,
+        dataRejectedMissingMeta: 0,
+      }),
+      runLegacyDurableSyncForContextGraph:
+        LifecycleSyncMethods.prototype.runLegacyDurableSyncForContextGraph,
+      resolveCuratorPeerIdsForCg: async () => ({
+        peerIds: ['different-peer'], curatorIsLocal: false, legacyTripleResolved: false,
+      }),
+      store: { dropGraph: async (graph: string) => { dropped.push(graph); } },
+      log: { info: () => {}, warn: () => {}, debug: () => {} },
+    };
+
+    const result = await (LifecycleSyncMethods.prototype.runChangelogSyncForCg as any).call(
+      agent,
+      { kind: 'system', id: 'test', startedAt: 0 },
+      'peer',
+      'cg',
+    );
+
+    expect(dropped).toEqual([]);
+    expect(forceFreshSessionFlags).toEqual([false, false]);
+    expect(cursor).toEqual({ era: 'e1', seq: 8 });
+    expect(result.insertedDataTriples).toBe(1);
+    expect(result.completedPhases).toBe(0);
+  });
+});
 // ── decodeChangelogResponse cursor invariants (wire hardening) ──────────────
 
 describe('decodeChangelogResponse cursor invariants', () => {

--- a/packages/agent/test/changelog-requester.test.ts
+++ b/packages/agent/test/changelog-requester.test.ts
@@ -11,6 +11,7 @@ import {
   DURABLE_INTEGRITY_META_PREDICATES,
   classifyDurableMetaGraph,
 } from '../src/sync/durable-integrity.js';
+import { LifecycleSyncMethods } from '../src/dkg-agent-lifecycle.js';
 
 const qd = (graph: string, n: number): Quad => ({ subject: `s${n}`, predicate: 'p', object: `o${n}`, graph });
 

--- a/packages/agent/test/changelog-requester.test.ts
+++ b/packages/agent/test/changelog-requester.test.ts
@@ -309,7 +309,7 @@ describe('planPageApply — verified-apply planner', () => {
 function loopHarness(
   responses: ChangelogSyncResponse[],
   applyPage: ChangelogSyncDeps['applyPage'],
-  resync: () => Promise<ResyncOutcome> = async () => ({ complete: true, insertedTriples: 0 }),
+  resync: (dropCandidates: readonly string[]) => Promise<ResyncOutcome> = async () => ({ complete: true, insertedTriples: 0 }),
 ) {
   let cursor: { era: string; seq: number } | undefined;
   const requests: ChangelogSyncRequest[] = [];
@@ -325,7 +325,7 @@ function loopHarness(
       return encodeChangelogResponse(r);
     },
     applyPage,
-    runResync: async () => { resyncs += 1; return resync(); },
+    runResync: async (dropCandidates) => { resyncs += 1; return resync(dropCandidates); },
     logWarn: () => {},
   };
   return { deps, requests, resyncs: () => resyncs, cursor: () => cursor };

--- a/packages/agent/test/e2e-memory-layers.test.ts
+++ b/packages/agent/test/e2e-memory-layers.test.ts
@@ -548,6 +548,21 @@ describe('rootless graph-scoped KA lifecycle', () => {
     const intent = await agent.resolveFinalizedAssertionVmPublishIntent(CG_ID, name);
     expect(intent.shareOperationId).toBe(share.shareOperationId);
 
+    // Rootless metadata trimming consumes the lifecycle-level operation row
+    // once the immutable SWM snapshot and head are durable. The promoted
+    // event remains the canonical lifecycle reference. Revalidation must read
+    // that same shape instead of rejecting an otherwise unchanged queued job.
+    const author = agent.defaultAgentAddress ?? agent.peerId;
+    await (agent as any).store.deleteByPattern({
+      graph: contextGraphMetaUri(CG_ID),
+      subject: assertionLifecycleUri(CG_ID, author, name),
+      predicate: 'http://dkg.io/ontology/shareOperationId',
+    });
+    const trimmedHistory = await agent.assertion.history(CG_ID, name);
+    expect(trimmedHistory?.currentShareOperationId).toBeUndefined();
+    expect(trimmedHistory?.events.find((event) => event.type === 'promoted')?.shareOperationId)
+      .toBe(share.shareOperationId);
+
     await (agent as any).publisher.clearPublishedSwmRoots(
       CG_ID,
       [...intent.roots],

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -165,6 +165,7 @@ function resolveCatalogProofMaterial(
   contextGraphId: string,
   graphScoped: boolean,
   trustedKeys: PublishOptions['trustedNonManifestCatalogTriples'],
+  memberDataGraph: string,
 ): { catalogQuads: Quad[]; otherQuads: Quad[] } {
   if (!graphScoped) {
     return partitionCatalogQuads(quads, contextGraphDataUri(contextGraphId));
@@ -173,7 +174,11 @@ function resolveCatalogProofMaterial(
     catalogQuads: trustedCatalogTripleKeySet(trustedKeys).size > 0
       ? generatedPrivateCatalogFloorQuads(contextGraphId)
       : [],
-    otherQuads: [...quads],
+    // Graph-scoped canonicalization deliberately hashes graph-less triples,
+    // but the same payload is later serialized as N-Quads for member-side
+    // encryption. Stamp the exact per-KA VM graph here so that serialization
+    // cannot emit the invalid empty graph IRI `<>`.
+    otherQuads: quads.map((quad) => ({ ...quad, graph: memberDataGraph })),
   };
 }
 
@@ -2779,7 +2784,7 @@ export class DKGPublisher implements Publisher {
     const nquadsStr = allSkolemizedQuads
       .map(
         (q) =>
-          `<${q.subject}> <${q.predicate}> ${q.object.startsWith('"') ? q.object : `<${q.object}>`} <${q.graph}> .`,
+          `<${q.subject}> <${q.predicate}> ${q.object.startsWith('"') ? q.object : `<${q.object}>`} <${q.graph || dataGraph}> .`,
       )
       .join('\n');
     const publicNquadsBytes = new TextEncoder().encode(nquadsStr);
@@ -2796,6 +2801,7 @@ export class DKGPublisher implements Publisher {
       contextGraphId,
       graphPublish !== undefined,
       options.trustedNonManifestCatalogTriples,
+      dataGraph,
     );
     const encryptableNquadsStr = catalogQuads.length === 0
       ? nquadsStr
@@ -4809,6 +4815,7 @@ export class DKGPublisher implements Publisher {
         contextGraphId,
         graphUpdate !== undefined,
         options.trustedNonManifestCatalogTriples,
+        dataGraph,
       );
     // Non-catalog plaintext fed to the MEMBER encryptor (graph term retained,
     // mirror 2031-2038). No-op for public updates / curated updates with no

--- a/packages/publisher/src/storage-ack-handler.ts
+++ b/packages/publisher/src/storage-ack-handler.ts
@@ -1834,6 +1834,14 @@ export class StorageACKHandler {
           subGraphName,
         )
       : this.config.contextGraphSharedMemoryUri(swmGraphId, subGraphName);
+    const inlineVmGraphUri = graphUpdate
+      ? knowledgeAssetLayerGraphUri(
+          swmGraphId,
+          MemoryLayer.VerifiableMemory,
+          graphUpdate.scope,
+          subGraphName,
+        )
+      : undefined;
 
     // Verify the new Merkle root the same way the publish path does:
     // recompute over the updated quads and compare to the publisher's
@@ -1998,7 +2006,13 @@ export class StorageACKHandler {
         inlineByteLength === undefined
           ? publicQuads.map((quad) => ({ ...quad, graph: swmGraphUri }))
           : publicQuads,
-        swmGraphUri,
+        // Inline public graph updates are emitted by DKGPublisher from its
+        // materialized per-KA VM graph. Only the no-inline fallback loads the
+        // source per-KA SWM graph. Keeping these provenance-specific graph
+        // expectations separate prevents every ordinary public update from
+        // being declined while still rejecting a payload stamped for an
+        // unrelated graph.
+        inlineByteLength === undefined ? swmGraphUri : inlineVmGraphUri!,
         graphUpdate.publicTripleCount,
       );
       if (!validation.valid) {

--- a/packages/publisher/test/ka-graph-update-ack.test.ts
+++ b/packages/publisher/test/ka-graph-update-ack.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import { ethers } from 'ethers';
 import {
+  MockChainAdapter,
+  NoChainAdapter,
+  type TxResult,
+  type V10UpdateKAParams,
+} from '@origintrail-official/dkg-chain';
+import {
   computeCatalogRoot,
   GRAPH_KA_CONTENT_SCOPE_VERSION,
   MemoryLayer,
@@ -10,11 +16,13 @@ import {
   createGraphKnowledgeAssetScope,
   decodeStorageACK,
   encodeUpdateIntent,
+  generateEd25519Keypair,
   isStorageACKDecline,
   knowledgeAssetLayerGraphUri,
 } from '@origintrail-official/dkg-core';
 import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
 import { ACKCollector, type ACKCollectorDeps } from '../src/ack-collector.js';
+import { DKGPublisher } from '../src/dkg-publisher.js';
 import {
   StorageACKHandler,
   type StorageACKHandlerConfig,
@@ -23,13 +31,22 @@ import {
   computeFlatKCMerkleLeafCountV10,
   computeFlatKCRootV10,
 } from '../src/merkle.js';
+import { buildUpdateSeal, mockSealCtx } from './_helpers/seal.js';
 
 const TARGET_CG_ID = '42';
 const SOURCE_CG_ID = 'private-rootless-cg';
-const AUTHOR = '0x1111111111111111111111111111111111111111';
+const PRODUCER_WALLET = new ethers.Wallet(
+  '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d',
+);
+const AUTHOR = PRODUCER_WALLET.address.toLowerCase();
 const UAL = `did:dkg:otp:20430/${AUTHOR}/7`;
 const KA_ID = (BigInt(AUTHOR) << 96n) | 7n;
 const SCOPE = createGraphKnowledgeAssetScope(UAL, 2);
+const EXACT_VM_GRAPH = knowledgeAssetLayerGraphUri(
+  SOURCE_CG_ID,
+  MemoryLayer.VerifiableMemory,
+  SCOPE,
+);
 const EXACT_SWM_GRAPH = knowledgeAssetLayerGraphUri(
   SOURCE_CG_ID,
   MemoryLayer.SharedWorkingMemory,
@@ -40,6 +57,36 @@ const PRIVATE_ROOT = ethers.getBytes(
   ethers.keccak256(ethers.toUtf8Bytes('rootless-private-update')),
 );
 const PEER = { toString: () => 'publisher-peer' };
+const UPDATE_TX_HASH = `0x${'42'.padStart(64, '0')}`;
+
+class ProducerUpdateChain extends MockChainAdapter {
+  constructor() {
+    super('mock:31337', AUTHOR);
+  }
+
+  async getUpdateAckDigestFields() {
+    return {
+      contextGraphId: BigInt(TARGET_CG_ID),
+      preUpdateMerkleRootCount: 1n,
+      newTokenAmount: 1000n,
+      mintAmount: 0n,
+      burnTokenIds: [],
+    };
+  }
+
+  override async updateKnowledgeCollectionV10(
+    params: V10UpdateKAParams,
+  ): Promise<TxResult> {
+    await params.onBroadcast?.({ txHash: UPDATE_TX_HASH });
+    return {
+      success: true,
+      hash: UPDATE_TX_HASH,
+      blockNumber: 2,
+      txIndex: 0,
+      publisherAddress: AUTHOR,
+    };
+  }
+}
 
 function config(wallet: ethers.Wallet, curated = false): StorageACKHandlerConfig {
   return {
@@ -102,6 +149,100 @@ function intent(
 }
 
 describe('StorageACKHandler graph-scoped updates', () => {
+  it('accepts the inline VM payload emitted by a public graph-update producer', async () => {
+    const store = new OxigraphStore();
+    const publisher = new DKGPublisher({
+      store,
+      chain: new NoChainAdapter(),
+      eventBus: new TypedEventBus(),
+      keypair: await generateEd25519Keypair(),
+      publisherAddress: AUTHOR,
+    });
+    const initial = await publisher.publish({
+      contextGraphId: SOURCE_CG_ID,
+      quads: [{
+        subject: 'urn:entity:producer',
+        predicate: 'urn:p:value',
+        object: '"v1"',
+        graph: 'urn:input:is-restamped',
+      }],
+      publisherPeerId: 'publisher-peer',
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      kaUal: UAL,
+      assertionVersion: 1,
+      publicTripleCount: 1,
+      privateTripleCount: 0,
+    });
+    expect(initial.kaId).toBe(KA_ID);
+
+    const updatedSWMQuad: Quad = {
+      subject: 'urn:entity:producer',
+      predicate: 'urn:p:value',
+      object: '"v2"',
+      graph: EXACT_SWM_GRAPH,
+    };
+    await store.insert([updatedSWMQuad]);
+
+    const chain = new ProducerUpdateChain();
+    chain.__registerKC({
+      kaId: KA_ID,
+      contextGraphId: BigInt(TARGET_CG_ID),
+      merkleRootHex: ethers.hexlify(initial.merkleRoot),
+      chunks: [],
+      merkleLeafCount: 1,
+      publisherAddress: AUTHOR,
+    });
+    (publisher as unknown as { chain: ProducerUpdateChain }).chain = chain;
+
+    const handler = new StorageACKHandler(
+      new OxigraphStore(),
+      config(ethers.Wallet.createRandom()),
+      new TypedEventBus(),
+    );
+    const deps: ACKCollectorDeps = {
+      gossipPublish: async () => {},
+      sendP2P: async (_peerId, _protocol, data) => handler.updateHandler(data, PEER),
+      getConnectedCorePeers: () => ['core-1'],
+      verifyIdentity: async () => true,
+      log: () => {},
+    };
+    const collector = new ACKCollector(deps);
+    let producedStagingQuads: Uint8Array | undefined;
+    const updateSeal = await buildUpdateSeal({
+      kaId: KA_ID,
+      quads: [{ ...updatedSWMQuad, graph: '' }],
+      author: PRODUCER_WALLET,
+      ctx: mockSealCtx(),
+    });
+
+    const result = await publisher.updateKnowledgeAssetFromSharedMemory(KA_ID, {
+      contextGraphId: SOURCE_CG_ID,
+      publishContextGraphId: TARGET_CG_ID,
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      kaUal: UAL,
+      assertionVersion: 2,
+      publicTripleCount: 1,
+      privateTripleCount: 0,
+      precomputedUpdateAttestation: updateSeal,
+      v10UpdateACKProvider: async (params) => {
+        producedStagingQuads = params.stagingQuads;
+        const collected = await collector.collectUpdate({
+          ...params,
+          contextGraphId: BigInt(params.contextGraphId),
+          chainId: 31337n,
+          kav10Address: '0x000000000000000000000000000000000000c10a',
+          publisherPeerId: 'publisher-peer',
+          requiredACKs: 1,
+        });
+        return collected.acks;
+      },
+    });
+
+    expect(result.status).toBe('confirmed');
+    expect(new TextDecoder().decode(producedStagingQuads)).toContain(`<${EXACT_VM_GRAPH}>`);
+    expect(new TextDecoder().decode(producedStagingQuads)).not.toContain(`<${EXACT_SWM_GRAPH}>`);
+  });
+
   it('verifies a public-plus-private update from only its exact per-KA SWM graph', async () => {
     const store = new OxigraphStore();
     const quads: Quad[] = [

--- a/packages/publisher/test/ka-graph-update-ack.test.ts
+++ b/packages/publisher/test/ka-graph-update-ack.test.ts
@@ -64,6 +64,11 @@ class ProducerUpdateChain extends MockChainAdapter {
     super('otp:20430', AUTHOR);
   }
 
+  override async getKnowledgeAssetOwner(kaId: bigint): Promise<string> {
+    if (kaId === KA_ID) return AUTHOR;
+    return super.getKnowledgeAssetOwner(kaId);
+  }
+
   async getUpdateAckDigestFields() {
     return {
       contextGraphId: BigInt(TARGET_CG_ID),

--- a/packages/publisher/test/ka-graph-update-ack.test.ts
+++ b/packages/publisher/test/ka-graph-update-ack.test.ts
@@ -61,7 +61,7 @@ const UPDATE_TX_HASH = `0x${'42'.padStart(64, '0')}`;
 
 class ProducerUpdateChain extends MockChainAdapter {
   constructor() {
-    super('mock:31337', AUTHOR);
+    super('otp:20430', AUTHOR);
   }
 
   async getUpdateAckDigestFields() {
@@ -164,7 +164,7 @@ describe('StorageACKHandler graph-scoped updates', () => {
         subject: 'urn:entity:producer',
         predicate: 'urn:p:value',
         object: '"v1"',
-        graph: 'urn:input:is-restamped',
+        graph: '',
       }],
       publisherPeerId: 'publisher-peer',
       contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,

--- a/packages/publisher/test/publisher-no-random-wallet.test.ts
+++ b/packages/publisher/test/publisher-no-random-wallet.test.ts
@@ -25,11 +25,22 @@
  */
 import { describe, it, expect, vi } from 'vitest';
 import { DKGPublisher } from '../src/dkg-publisher.js';
+import {
+  generatedPrivateCatalogTripleKeys,
+  parseSimpleNQuads,
+} from '../src/index.js';
 import { PublisherPlanner } from '../src/publisher-planning.js';
 import { DEFAULT_PUBLISH_EPOCHS, type V10ACKProvider, type V10ACKProviderParams } from '../src/publisher.js';
 import { generateConfirmedFullMetadata } from '../src/metadata.js';
 import { OxigraphStore } from '@origintrail-official/dkg-storage';
-import { TypedEventBus, generateEd25519Keypair } from '@origintrail-official/dkg-core';
+import {
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  MemoryLayer,
+  TypedEventBus,
+  createGraphKnowledgeAssetScope,
+  generateEd25519Keypair,
+  knowledgeAssetLayerGraphUri,
+} from '@origintrail-official/dkg-core';
 import {
   MockChainAdapter,
   type ChainAdapter,
@@ -40,7 +51,13 @@ import {
   type V10UpdateKAParams,
 } from '@origintrail-official/dkg-chain';
 import { ethers } from 'ethers';
-import { wrapPublisherForTest, mockSealCtx, updateSealed } from './_helpers/seal.js';
+import {
+  buildSeal,
+  buildUpdateSeal,
+  wrapPublisherForTest,
+  mockSealCtx,
+  updateSealed,
+} from './_helpers/seal.js';
 import { mockChainStubACKProvider } from './_helpers/acks.js';
 
 // Greenfield (PR #815): the confirmed UAL embeds the DKGKnowledgeAssets
@@ -1607,6 +1624,110 @@ describe('DKGPublisher: no random publisher wallet without explicit key', () => 
 
     expect(encryptInlineChunked).not.toHaveBeenCalled();
     expect(ackProvider).not.toHaveBeenCalled();
+  });
+
+  it('sends valid graph-scoped N-Quads to member encryption for curated publish and update', async () => {
+    const wallet = new ethers.Wallet(TEST_KEY);
+    const chain = new CatalogPlanningChain(wallet);
+    (chain as unknown as { getContextGraphAccessPolicy: () => Promise<number> })
+      .getContextGraphAccessPolicy = async () => 1;
+    const publisher = await makeEpochPublisher(chain, wallet);
+    const store = (publisher as unknown as { store: OxigraphStore }).store;
+    const contextGraphId = '1';
+    const publishQuad = {
+      subject: 'urn:test:graph-scoped-member-payload',
+      predicate: 'http://schema.org/name',
+      object: '"published"',
+      graph: '',
+    };
+    const publishSeal = await buildSeal({
+      quads: [publishQuad],
+      author: wallet,
+      contextGraphId,
+      ctx: mockSealCtx(),
+    });
+    const kaId = publishSeal.reservedKaId!;
+    const kaNumber = kaId & ((1n << 96n) - 1n);
+    const ual = `did:dkg:mock:31337/${wallet.address}/${kaNumber}`;
+    const scopeV1 = createGraphKnowledgeAssetScope(ual, 1);
+    const swmGraph = knowledgeAssetLayerGraphUri(
+      contextGraphId,
+      MemoryLayer.SharedWorkingMemory,
+      scopeV1,
+    );
+    await store.insert([{ ...publishQuad, graph: swmGraph }]);
+
+    const capturedPlaintexts: Uint8Array[] = [];
+    const encryptInlineChunked = async ({ plaintextNquads }: { plaintextNquads: Uint8Array }) => {
+      capturedPlaintexts.push(plaintextNquads);
+      return {
+        ciphertextChunksRoot: new Uint8Array(32),
+        ciphertextChunkCount: 1,
+        totalCiphertextBytes: plaintextNquads.length,
+      };
+    };
+    const encryptInlinePayload = async (plaintext: Uint8Array) => plaintext;
+    const catalogKeys = generatedPrivateCatalogTripleKeys(contextGraphId);
+
+    const published = await publisher.publishFromSharedMemory(contextGraphId, 'all', {
+      onChainContextGraphId: contextGraphId,
+      sharedMemoryScope: {
+        kind: 'named-lifecycle',
+        identity: { agentAddress: wallet.address, kaNumber },
+      },
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      kaUal: ual,
+      assertionVersion: 1,
+      publicTripleCount: 1,
+      privateTripleCount: 0,
+      trustedNonManifestCatalogTriples: catalogKeys,
+      precomputedAttestation: publishSeal,
+      encryptInlinePayload,
+      encryptInlineChunked,
+    });
+    expect(published.status).toBe('confirmed');
+    expect(capturedPlaintexts).toHaveLength(1);
+    const publishVmGraph = knowledgeAssetLayerGraphUri(
+      contextGraphId,
+      MemoryLayer.VerifiableMemory,
+      scopeV1,
+    );
+    expect(parseSimpleNQuads(new TextDecoder().decode(capturedPlaintexts[0]))).toEqual([
+      { ...publishQuad, graph: publishVmGraph },
+    ]);
+
+    const updateQuad = { ...publishQuad, object: '"updated"' };
+    await store.replaceGraph?.(swmGraph, [{ ...updateQuad, graph: swmGraph }]);
+    const updateSeal = await buildUpdateSeal({
+      kaId,
+      quads: [updateQuad],
+      author: wallet,
+      ctx: mockSealCtx(),
+    });
+    const updated = await publisher.updateKnowledgeAssetFromSharedMemory(kaId, {
+      contextGraphId,
+      publishContextGraphId: contextGraphId,
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      kaUal: ual,
+      assertionVersion: 2,
+      publicTripleCount: 1,
+      privateTripleCount: 0,
+      trustedNonManifestCatalogTriples: catalogKeys,
+      precomputedUpdateAttestation: updateSeal,
+      encryptInlinePayload,
+      encryptInlineChunked,
+      v10ACKProvider: mockChainStubACKProvider(),
+    });
+    expect(updated.status).toBe('confirmed');
+    expect(capturedPlaintexts).toHaveLength(2);
+    const updateVmGraph = knowledgeAssetLayerGraphUri(
+      contextGraphId,
+      MemoryLayer.VerifiableMemory,
+      createGraphKnowledgeAssetScope(ual, 2),
+    );
+    expect(parseSimpleNQuads(new TextDecoder().decode(capturedPlaintexts[1]))).toEqual([
+      { ...updateQuad, graph: updateVmGraph },
+    ]);
   });
 
   it('prices curated publishes from the exact public catalog bytes across plan, ACK, and tx', async () => {


### PR DESCRIPTION
This canary integration fixes the deterministic async VM failure found by the 50 x 1,000-triple private-CG gate: queued jobs now revalidate shareOperationId from the canonical promoted lifecycle event after temporary metadata has been trimmed. It also incorporates three already-green post-cut correctness fixes that apply cleanly to the deployed candidate: graph-scoped encrypted payload stamping, public graph-update ACK provenance, and coherent deferred/incomplete changelog readiness handling. Older SWM recovery patches are intentionally excluded because PR #1738 supersedes them; broader conflicting read/recovery changes remain on their original PRs.

Validation:
- agent and publisher builds
- 45 changelog requester tests
- 9 graph-update ACK tests
- curated encrypted graph-scoped payload regression
- queued async VM end-to-end regression after lifecycle metadata trim
- diff check clean

Live failure addressed: all 50 VM jobs previously stopped before chain submission with publish_intent_stale because enqueue read the promoted event while execution read only the consumed lifecycle row.