### PR TITLE
fix: two missing rootless-KA mainnet blockers (bare-UAL quarantine bypass + update materialization race)

### DIFF
--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -4589,71 +4589,100 @@ export class DKGPublisher implements Publisher {
       if (graphUpdate) {
         const labelMeta = options.targetMetaGraphUri
           ?? this.graphManager.metaGraphUri(contextGraphId);
-        const inherited = await this.readGraphKnowledgeAssetIdentity(
-          labelMeta,
-          graphUpdate.scope.ual,
-        );
-        if (inherited.subGraphName !== options.subGraphName) {
-          throw new Error(
-            `Graph-scoped KA update cannot move ${graphUpdate.scope.ual} from ` +
-              `${inherited.subGraphName ?? '(root)'} to ${options.subGraphName ?? '(root)'}`,
-          );
-        }
-        await this.replaceExactKnowledgeAssetGraph(
-          dataGraph,
-          allSkolemizedQuads,
-          'Graph-scoped KA update',
-        );
-        await this.privateStore.replaceKnowledgeAssetPrivateTriples(
-          contextGraphId,
-          graphUpdate.scope,
-          canonicalPrivateQuads,
-          options.subGraphName,
-        );
-        // 🔴 PR #1712 review (3586192289): the converge below replaces the
-        // KA's entire access row set, so passing raw update options here let
-        // an update that omitted `accessPolicy` rewrite a private KA to the
-        // metadata generator's 'public' default (and its owner to 'unknown'),
-        // silently exposing its private triples. `graphUpdateAccess` resolves
-        // explicit option → existing stored row → publish()'s private-content
-        // default, with publish()'s option validation applied.
-        const metadata = generateGraphKnowledgeAssetMetadata(
-          {
-            ual: graphUpdate.scope.ual,
-            contextGraphId,
-            merkleRoot: kcMerkleRoot,
-            publisherPeerId: graphUpdateAccess!.publisherPeerId,
-            accessPolicy: graphUpdateAccess!.accessPolicy,
-            allowedPeers: graphUpdateAccess!.allowedPeers.length > 0
-              ? graphUpdateAccess!.allowedPeers
-              : undefined,
-            timestamp: new Date(),
-            subGraphName: inherited.subGraphName,
-            authorAddress: inherited.authorAddress,
-            assertionVersion: graphUpdate.scope.assertionVersion,
-            publicTripleCount: graphUpdate.publicTripleCount,
-            privateTripleCount: graphUpdate.privateTripleCount,
-            ...(updatePrivateRoots[0]
-              ? { privateMerkleRoot: updatePrivateRoots[0] }
-              : {}),
-            assertionGraph: dataGraph,
-          },
-          provenance ? 'confirmed' : 'tentative',
-          provenance,
-        );
-        await this.convergeKnowledgeAssetMetadataRows(
-          labelMeta,
-          graphUpdate.scope.ual,
-          metadata,
-        );
-        if (version) {
-          await writeMaterializedVersion(
-            this.store,
+        // GH#842 last-writer-wins + atomicity. Serialise the whole exact-graph
+        // replace + private replace + metadata converge + version stamp under
+        // the per-KA materialization lock, and skip a stale (lower chain
+        // version) re-run — exactly like the publish-promote path (~4182) and
+        // the legacy update restate. Without this the graph-scoped update was
+        // the only materialising writer with no lock and no version gate: two
+        // racing updates could interleave their multi-step replace, and a late
+        // v2 could overwrite a materialised v3's data graph and delete v3's
+        // metadata rows via the converge, leaving the node permanently serving
+        // the superseded assertion with no self-heal (cross-node divergence).
+        await withMaterializationLock(labelMeta, graphUpdate.scope.ual, async () => {
+          // Gate only on a confirmed run (one that carries a chain version); the
+          // tentative local write has none and is the current-version write.
+          if (
+            version
+            && !(await shouldApplyMaterialization(
+              this.store,
+              labelMeta,
+              graphUpdate.scope.ual,
+              version,
+            ))
+          ) {
+            this.log.info(
+              ctx,
+              `Graph-scoped update: skipped ${graphUpdate.scope.ual} — a newer materialisation is present`,
+            );
+            return;
+          }
+          const inherited = await this.readGraphKnowledgeAssetIdentity(
             labelMeta,
             graphUpdate.scope.ual,
-            version,
           );
-        }
+          if (inherited.subGraphName !== options.subGraphName) {
+            throw new Error(
+              `Graph-scoped KA update cannot move ${graphUpdate.scope.ual} from ` +
+                `${inherited.subGraphName ?? '(root)'} to ${options.subGraphName ?? '(root)'}`,
+            );
+          }
+          await this.replaceExactKnowledgeAssetGraph(
+            dataGraph,
+            allSkolemizedQuads,
+            'Graph-scoped KA update',
+          );
+          await this.privateStore.replaceKnowledgeAssetPrivateTriples(
+            contextGraphId,
+            graphUpdate.scope,
+            canonicalPrivateQuads,
+            options.subGraphName,
+          );
+          // 🔴 PR #1712 review (3586192289): the converge below replaces the
+          // KA's entire access row set, so passing raw update options here let
+          // an update that omitted `accessPolicy` rewrite a private KA to the
+          // metadata generator's 'public' default (and its owner to 'unknown'),
+          // silently exposing its private triples. `graphUpdateAccess` resolves
+          // explicit option → existing stored row → publish()'s private-content
+          // default, with publish()'s option validation applied.
+          const metadata = generateGraphKnowledgeAssetMetadata(
+            {
+              ual: graphUpdate.scope.ual,
+              contextGraphId,
+              merkleRoot: kcMerkleRoot,
+              publisherPeerId: graphUpdateAccess!.publisherPeerId,
+              accessPolicy: graphUpdateAccess!.accessPolicy,
+              allowedPeers: graphUpdateAccess!.allowedPeers.length > 0
+                ? graphUpdateAccess!.allowedPeers
+                : undefined,
+              timestamp: new Date(),
+              subGraphName: inherited.subGraphName,
+              authorAddress: inherited.authorAddress,
+              assertionVersion: graphUpdate.scope.assertionVersion,
+              publicTripleCount: graphUpdate.publicTripleCount,
+              privateTripleCount: graphUpdate.privateTripleCount,
+              ...(updatePrivateRoots[0]
+                ? { privateMerkleRoot: updatePrivateRoots[0] }
+                : {}),
+              assertionGraph: dataGraph,
+            },
+            provenance ? 'confirmed' : 'tentative',
+            provenance,
+          );
+          await this.convergeKnowledgeAssetMetadataRows(
+            labelMeta,
+            graphUpdate.scope.ual,
+            metadata,
+          );
+          if (version) {
+            await writeMaterializedVersion(
+              this.store,
+              labelMeta,
+              graphUpdate.scope.ual,
+              version,
+            );
+          }
+        });
         onPhase?.('store', 'end');
         return;
       }

--- a/packages/storage/src/graph-knowledge-asset-metadata-loader.ts
+++ b/packages/storage/src/graph-knowledge-asset-metadata-loader.ts
@@ -1,6 +1,7 @@
 import {
   buildGraphKnowledgeAssetMetadataQuery,
   parseGraphKnowledgeAssetMetadataBindings,
+  parseDeterministicKnowledgeAssetUal,
   type ParsedGraphKnowledgeAssetMetadata,
 } from '@origintrail-official/dkg-core';
 import type { QueryOptions, TripleStore } from './triple-store.js';
@@ -23,12 +24,25 @@ export async function resolveGraphScopedOrLegacyMetadata<TLegacy>(
   loadLegacyMetadata: () => Promise<TLegacy | null>,
   queryOptions?: QueryOptions,
 ): Promise<GraphScopedOrLegacyMetadata<TLegacy>> {
+  // Canonicalize a bare deterministic UAL before the V2 marker lookup. V2
+  // markers are stored under the canonical form (lowercase author address,
+  // BigInt-normalized KA number), so a checksum-cased or leading-zero variant
+  // — what ethers-based clients emit — would otherwise miss its own marker and
+  // fall through to the legacy reader, serving quarantined legacy rows and the
+  // private bag under the legacy access policy. Non-deterministic identifiers
+  // stay eligible for legacy read-both.
+  let graphScopedUal = ual;
+  try {
+    graphScopedUal = parseDeterministicKnowledgeAssetUal(ual).ual;
+  } catch {
+    // Non-deterministic identifiers remain eligible for legacy read-both.
+  }
   const result = await store.query(
-    buildGraphKnowledgeAssetMetadataQuery(ual),
+    buildGraphKnowledgeAssetMetadataQuery(graphScopedUal),
     queryOptions,
   );
   const parsed = parseGraphKnowledgeAssetMetadataBindings(
-    ual,
+    graphScopedUal,
     result.type === 'bindings' ? result.bindings : [],
   );
   if (parsed.kind === 'graph') return parsed;

--- a/packages/storage/test/graph-knowledge-asset-metadata-loader.test.ts
+++ b/packages/storage/test/graph-knowledge-asset-metadata-loader.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
+  buildGraphKnowledgeAssetMetadataQuery,
+  parseDeterministicKnowledgeAssetUal,
+} from '@origintrail-official/dkg-core';
+import {
   resolveGraphScopedOrLegacyMetadata,
   type QueryResult,
   type TripleStore,
@@ -33,6 +37,32 @@ describe('graph-scoped-first metadata resolution', () => {
       kind: 'legacy',
       metadata: { rootEntity: 'urn:legacy:root' },
     });
+  });
+
+  it('canonicalizes a bare non-canonical UAL before the V2 marker lookup', async () => {
+    // A leading-zero KA number (like a checksum-cased address) is a valid but
+    // non-canonical alias of the same asset. V2 markers are stored under the
+    // canonical form, so the marker lookup MUST query the canonical UAL — else
+    // the alias misses its own marker and falls through to the legacy reader,
+    // serving quarantined legacy rows / the private bag under the legacy access
+    // policy. Regression: this fails if the raw input is queried verbatim.
+    const ALIAS_UAL = 'did:dkg:31337/0x1111111111111111111111111111111111111111/007';
+    const canonicalUal = parseDeterministicKnowledgeAssetUal(ALIAS_UAL).ual;
+    expect(canonicalUal).toBe(UAL); // /007 normalizes to /7
+
+    const captured: string[] = [];
+    const store = {
+      query: vi.fn(async (q: string): Promise<QueryResult> => {
+        captured.push(q);
+        return { type: 'bindings', bindings: [] };
+      }),
+    } as Pick<TripleStore, 'query'> as TripleStore;
+    const loadLegacy = vi.fn(async () => null);
+
+    await resolveGraphScopedOrLegacyMetadata(store, ALIAS_UAL, loadLegacy);
+
+    expect(captured[0]).toBe(buildGraphKnowledgeAssetMetadataQuery(canonicalUal));
+    expect(captured[0]).not.toContain('/007'); // never queried the raw alias
   });
 
   it('fails closed on an incomplete V2 marker without invoking legacy lookup', async () => {


### PR DESCRIPTION
## Two missing rootless-KA mainnet blockers, fixed against `testnet-canary`

Part of a critical-bug audit of the rootless-KA stack re-baselined against `testnet-canary` (the branch merging to main). This PR fixes the two confirmed-missing blockers that have surgical, low-risk fixes. Four other confirmed-missing blockers need deeper/owner-led work and are listed below with precise locations, not fixed here.

### Fixed

**1. `fix(storage)`: canonicalize bare UAL before the V2 marker lookup** — `graph-knowledge-asset-metadata-loader.ts`
`resolveGraphScopedOrLegacyMetadata` queried the V2 control-plane marker with the caller's raw UAL. V2 markers are stored under the canonical form (lowercase author address, BigInt-normalized KA number), so a checksum-cased address or a leading-zero KA number — the forms ethers-based clients emit — missed its own marker and fell through to the legacy reader, **serving quarantined legacy rows and the private bag under the legacy access policy** (a privacy bypass). This is the bare-alias equivalent of the token-alias (`<ual>/<n>`) quarantine bypass already fixed. Both the publisher access path and the query engine share this resolver, so both are covered. Regression test asserts the marker query uses the canonical UAL and fails on the raw alias.

**2. `fix(publisher)`: lock + version-gate graph-scoped KA update materialization** — `dkg-publisher.ts` (graph-scoped branch of `storeUpdatedQuads`)
This was the only materializing writer with neither `withMaterializationLock` nor a `shouldApplyMaterialization` last-writer-wins gate (the publish-promote path ~4182 and the legacy update restate both have them). Two updates racing on one KA could interleave their multi-step replace, and a late lower-version update could overwrite a materialized newer assertion's VM graph and delete its metadata rows via the converge → **the node permanently serves the superseded assertion, diverging from chain and in-order peers, no self-heal**. Wrapped the sequence in the lock + stale-version skip, mirroring the canonical pattern at ~4182. Deadlock-verified (inner helpers don't self-lock; no caller holds the lock). Existing graph-scoped update suites (`ka-graph-publish-storage` 7/7, `ka-graph-update-handler` 10/10) pass unchanged. Follow-up: a dedicated producer-side stale-version race regression test (MockChainAdapter with controlled block/txIndex) should be added.

### Confirmed FIXED already in `testnet-canary` (no action)
- Update-ACK inline layer mismatch (`inlineVmGraphUri`).
- v2 queued-publish crash recovery (full re-implementation; verified end-to-end incl. head-write ordering).

### Confirmed MISSING in `testnet-canary` — NOT fixed here (need owner-led / deeper work)
- **Scoped-`_meta` finalization** (`finalization-handler.ts` `applyVerifiedGraphScopedFinalization`, single-arg `contextGraphMetaUri`): a receiver-finalized graph-scoped KA writes confirmed meta only to the label `_meta`, never the scoped `.../context/<cgId>/_meta` the RS extractor reads → the node fails RS challenges for content it holds. Fix is an additive scoped dual-write that must mirror the publisher's writer byte-for-byte (the scoped `_meta` is synced, so a wrong shape trades RS-invisibility for cross-node divergence). Entangled with the RS-extractor rootless read; land together.
- **RS challenge-version pinning** (`ka-extractor.ts` + `update-handler.ts` destructive version-agnostic replace): no content-version pin and no per-version retention, so an update landing between challenge issuance and proof submission makes an honest proof fail (per-incident reward loss). Needs an on-chain challenge version field + per-version assertion retention — contract-level; the other half of the same "updates destroy the challenged assertion" problem as the scoped-`_meta` item.
- **Durable sync applies verified v2 data insert-only** (`durable-sync.ts` store phase; `changelog-sync.ts:90-108` blanket-defers any `/_meta` page): the source *replaces* the version-agnostic exact graph on update, but the requester inserts → first v2 update makes a replica's exact graph v1∪v2 and its `_meta` accumulate both versions' merkleRoot → downstream verifier throws "ambiguous merkleRoot" → CG unsyncable from that replica. Harder blocker (data corruption / CG-wide unsyncability via the routine resync path). Fix: `replaceGraph` each verified graph-scoped data graph + per-subject `_meta` descriptor replacement, or teach `planPageApply` to apply a per-subject verified V2 descriptor rather than blanket-defer.
- **Peer-metadata expands the SWM subgraph admission list** (`swm-recovery.ts:200-206`): recovery unions peer-discovered subgraph names into the lane-admission gate (`sync-verify-worker-impl.ts:257`), so a dishonest-but-authorized CG member can get the requester to REPLACE-apply rows into a lane it never registered locally (isolation breach; only a partial mitigation present). Fix: restrict to local registrations / gate discovered names against an authoritative local source.
