### PR TITLE
fix(sync): page rootless snapshots by exact graph

### DIFF
--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -85,6 +85,24 @@ export interface FreshSwmDataGraphPlanMemo {
   ): Promise<FreshSwmDataGraphPlan | null>;
 }
 
+interface ExactGraphPagePlanEntry {
+  graph: string;
+  rowCount: number;
+}
+
+interface ExactGraphPagePlan {
+  entries: readonly ExactGraphPagePlanEntry[];
+  totalRows: number;
+}
+
+export interface ExactGraphPagePlanMemo {
+  get(
+    key: string,
+    load: () => Promise<ExactGraphPagePlan>,
+    options?: { refresh?: boolean; requireExisting?: boolean; signal?: AbortSignal },
+  ): Promise<ExactGraphPagePlan | null>;
+}
+
 interface RowListCache {
   memo: SyncRowListMemo;
   key: string;
@@ -196,6 +214,51 @@ export function createResponderFreshSwmDataGraphPlanMemo(
 ): FreshSwmDataGraphPlanMemo {
   const cached = new Map<string, { value: FreshSwmDataGraphPlan; cachedAt: number }>();
   const inflight = new Map<string, Promise<FreshSwmDataGraphPlan>>();
+  const prune = (now = Date.now()) => {
+    for (const [key, entry] of cached) {
+      if (now - entry.cachedAt >= ttlMs) cached.delete(key);
+    }
+  };
+  return {
+    async get(key, load, options) {
+      throwIfAborted(options?.signal);
+      const now = Date.now();
+      prune(now);
+      const pending = inflight.get(key);
+      if (pending) return raceAgainstAbort(pending, options?.signal);
+      const existing = cached.get(key);
+      if (!options?.refresh && existing) {
+        cached.delete(key);
+        cached.set(key, { value: existing.value, cachedAt: now });
+        return existing.value;
+      }
+      if (options?.requireExisting) return null;
+      if (!existing && cached.size >= maxEntries) cached.delete(cached.keys().next().value!);
+      const pendingLoad = load()
+        .then((value) => {
+          cached.set(key, { value, cachedAt: Date.now() });
+          return value;
+        })
+        .finally(() => inflight.delete(key));
+      inflight.set(key, pendingLoad);
+      return raceAgainstAbort(pendingLoad, options?.signal);
+    },
+  };
+}
+
+/**
+ * Session-scoped inventory for ordinary durable/SWM graph paging. The memo
+ * stores only exact graph IRIs and their row counts. Payload rows remain in the
+ * triple store and each page addresses one concrete graph at a time, avoiding
+ * the global `VALUES ?g ... ORDER BY ?g ?s ?p ?o OFFSET ...` scan that grows
+ * super-linearly on large stores.
+ */
+export function createResponderExactGraphPagePlanMemo(
+  ttlMs = 10 * 60_000,
+  maxEntries = 32,
+): ExactGraphPagePlanMemo {
+  const cached = new Map<string, { value: ExactGraphPagePlan; cachedAt: number }>();
+  const inflight = new Map<string, Promise<ExactGraphPagePlan>>();
   const prune = (now = Date.now()) => {
     for (const [key, entry] of cached) {
       if (now - entry.cachedAt >= ttlMs) cached.delete(key);
@@ -378,6 +441,7 @@ export async function readSwmDataPage(params: {
   refreshRowList?: boolean;
   refreshGeneration?: string;
   freshGraphPlanMemo?: FreshSwmDataGraphPlanMemo;
+  exactGraphPlanMemo?: ExactGraphPagePlanMemo;
 }): Promise<SyncRow[]> {
   const dataGraphs = swmGraphsForRegisteredSubGraphs(params.contextGraphId, params.registeredSubGraphNames, false);
   const graphSet = new Set(params.graphList);
@@ -404,6 +468,7 @@ export async function readSwmDataPage(params: {
       async () => true,
       cache,
       params.signal,
+      params.exactGraphPlanMemo,
     );
   }
 
@@ -660,6 +725,7 @@ export async function readDurableDataPage(params: {
   rowListCacheScope?: string;
   refreshRowList?: boolean;
   refreshGeneration?: string;
+  exactGraphPlanMemo?: ExactGraphPagePlanMemo;
 }): Promise<SyncRow[]> {
   // Admission context (candidate exclusions + RFC-49 `isAdmitted`) — extracted to
   // a module factory so `readChangelogDeltaPage` reuses it verbatim. Behaviour
@@ -684,6 +750,7 @@ export async function readDurableDataPage(params: {
         }
         : undefined,
       params.signal,
+      params.exactGraphPlanMemo,
     );
   }
 
@@ -748,41 +815,110 @@ async function readPagedRowsAcrossGraphs(
   isAdmitted: (graph: string) => Promise<boolean>,
   cache?: RowListCache,
   signal?: AbortSignal,
+  planMemo?: ExactGraphPagePlanMemo,
 ): Promise<SyncRow[]> {
+  // A small snapshot is first assembled into the row cache. If that build
+  // crosses its cap, readResponderRowsPage immediately retries page zero via
+  // the store-bounded path. Consume the explicit session refresh only once so
+  // that fallback reuses the exact graph/count plan instead of counting every
+  // graph twice.
+  let planRefreshPending = cache?.refresh === true;
+  const loadPage: StorePageLoader = async (pageOffset, pageLimit, pageSignal) => {
+    const loadPlan = () => buildExactGraphPagePlan(
+      store,
+      graphs,
+      isAdmitted,
+      pageSignal,
+    );
+    const refreshPlan = pageOffset === 0 && planRefreshPending;
+    if (refreshPlan) planRefreshPending = false;
+    const plan = planMemo && cache
+      ? await planMemo.get(cache.key, loadPlan, {
+        refresh: refreshPlan,
+        requireExisting: pageOffset > 0,
+        signal: pageSignal,
+      })
+      : await loadPlan();
+    if (!plan) {
+      throw new Error('Sync session exact-graph plan expired before page completion');
+    }
+    return readRowsPageFromExactGraphPlan(store, plan, pageOffset, pageLimit, pageSignal);
+  };
   return readResponderRowsPage(
     cache && {
       ...cache,
       expiredMessage: cache.expiredMessage ?? 'Durable data sync session snapshot expired before page completion',
     },
-    (pageOffset, pageLimit, pageSignal) => readPagedRowsAcrossGraphsStoreBounded(
-      store,
-      graphs,
-      pageOffset,
-      pageLimit,
-      isAdmitted,
-      pageSignal,
-    ),
+    loadPage,
     offset,
     limit,
     signal,
   );
 }
 
-async function readPagedRowsAcrossGraphsStoreBounded(
+async function buildExactGraphPagePlan(
   store: TripleStore,
   graphs: readonly string[],
-  offset: number,
-  limit: number,
   isAdmitted: (graph: string) => Promise<boolean>,
   signal?: AbortSignal,
-): Promise<SyncRow[]> {
-  const admittedGraphs: string[] = [];
-  for (const graph of graphs) {
+): Promise<ExactGraphPagePlan> {
+  const entries: ExactGraphPagePlanEntry[] = [];
+  for (const graph of dedupeStrings(graphs).sort(compareCodePoint)) {
+    throwIfAborted(signal);
     if (!(await isAdmitted(graph))) continue;
-    admittedGraphs.push(graph);
+    const rowCount = await store.countQuads(
+      graph,
+      syncResponderStoreOptions(signal, 'sync.responder.countExactGraphRows'),
+    );
+    if (rowCount > 0) entries.push({ graph, rowCount });
   }
+  return {
+    entries,
+    totalRows: entries.reduce((sum, entry) => sum + entry.rowCount, 0),
+  };
+}
 
-  return readRowsPageAcrossGraphs(store, admittedGraphs, offset, limit, signal);
+async function readRowsPageFromExactGraphPlan(
+  store: TripleStore,
+  plan: ExactGraphPagePlan,
+  offset: number,
+  limit: number,
+  signal?: AbortSignal,
+): Promise<SyncRow[]> {
+  let skip = Math.max(0, Math.floor(offset));
+  let remaining = Math.max(0, Math.floor(limit));
+  if (remaining === 0 || skip >= plan.totalRows) return [];
+  const rows: SyncRow[] = [];
+  for (const entry of plan.entries) {
+    if (skip >= entry.rowCount) {
+      skip -= entry.rowCount;
+      continue;
+    }
+    const result = await store.query(`
+      SELECT ?s ?p ?o WHERE {
+        GRAPH <${assertSafeIri(entry.graph)}> { ?s ?p ?o }
+      }
+      ORDER BY ?s ?p ?o
+      OFFSET ${skip}
+      LIMIT ${remaining}
+    `, syncResponderStoreOptions(signal, 'sync.responder.readExactGraphRowsPage'));
+    let added = 0;
+    if (result.type === 'bindings') {
+      for (const row of result.bindings) {
+        const s = row['s'];
+        const p = row['p'];
+        const o = row['o'];
+        if (s && p && o) {
+          rows.push({ s, p, o, g: entry.graph });
+          added += 1;
+        }
+      }
+    }
+    remaining -= added;
+    if (remaining <= 0) break;
+    skip = 0;
+  }
+  return rows;
 }
 
 async function readPagedDurableDeltaRowsAcrossGraphs(
@@ -834,16 +970,17 @@ function isPerSnapshotBudgetError(error: unknown): error is SyncRowSnapshotBudge
  * retryable limit and the requester retries once other sessions drain.
  *
  * KNOWN LIMITATION (tracked as follow-up): the store-bounded fallback pages via
- * `OFFSET`, which — unlike a retained session snapshot — is NOT stable if the
- * graph mutates between two page requests of the same session (a row inserted
- * before the current offset can shift the window, duplicating or skipping a
- * row). This is inherent to any non-cached fallback and pre-dates the meta/SWM
- * work (durable-data already paged this way). It is bounded in blast radius:
+ * a per-exact-graph `OFFSET`, which — unlike a retained session snapshot — is
+ * NOT stable if that exact graph mutates between two page requests of the same
+ * session (a row inserted before the current offset can shift the window,
+ * duplicating or skipping a row). New graph-scoped KAs are immutable for one
+ * assertion version, so this caveat is limited to legacy mutable graph shapes.
+ * It is bounded in blast radius:
  * durable data is Merkle-verified end-to-end, so an inconsistent assembly fails
  * verification and the requester restarts the phase (churn, not silent
  * corruption); it only bites an oversized AND concurrently-mutating context
- * graph. The durable fix is a stable keyset/seek cursor for the fallback (page
- * on `(g,s,p,o) > lastKey` instead of `OFFSET`); see the PR follow-up list.
+ * graph. The durable legacy fix is a stable keyset/seek cursor within the exact
+ * graph; the global cross-graph sort/offset is deliberately no longer used.
  */
 type StorePageLoader = (
   offset: number,
@@ -1159,32 +1296,6 @@ async function readRowsAcrossGraphsExcludingSubjectPrefix(
     .map((row) => ({ s: row['s'], p: row['p'], o: row['o'], g: row['g'] }))
     .filter((row) => row.s && row.p && row.o && row.g)
     .sort(compareRows);
-}
-
-async function readRowsPageAcrossGraphs(
-  store: TripleStore,
-  graphs: readonly string[],
-  offset: number,
-  limit: number,
-  signal?: AbortSignal,
-): Promise<SyncRow[]> {
-  const safeOffset = Math.max(0, Math.floor(offset));
-  const safeLimit = Math.max(0, Math.floor(limit));
-  const values = graphValues(graphs);
-  if (safeLimit === 0 || !values) return [];
-  const res = await store.query(`
-    SELECT ?g ?s ?p ?o WHERE {
-      VALUES ?g { ${values} }
-      GRAPH ?g { ?s ?p ?o }
-    }
-    ORDER BY ?g ?s ?p ?o
-    OFFSET ${safeOffset}
-    LIMIT ${safeLimit}
-  `, syncResponderStoreOptions(signal, 'sync.responder.readRowsPageAcrossGraphs'));
-  if (res.type !== 'bindings') return [];
-  return res.bindings
-    .map((row) => ({ s: row['s'], p: row['p'], o: row['o'], g: row['g'] }))
-    .filter((row) => row.s && row.p && row.o && row.g);
 }
 
 async function readSwmMetaRows(

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -14,6 +14,7 @@ import type { SyncRequestEnvelope } from '../auth/request-build.js';
 import { DURABLE_DATA_SYNC_SESSION_TTL_MS } from '../durable-session.js';
 import {
   createResponderGraphListMemo,
+  createResponderExactGraphPagePlanMemo,
   createResponderFreshSwmDataGraphPlanMemo,
   createResponderSyncRowListMemo,
   createResponderSubGraphRegistrationMemo,
@@ -438,6 +439,14 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
     DURABLE_DATA_SYNC_SESSION_TTL_MS,
     SYNC_RESPONDER_SHARED_MEMORY_SNAPSHOT_LIMIT,
   );
+  const durableDataExactGraphPlanMemo = createResponderExactGraphPagePlanMemo(
+    DURABLE_DATA_SYNC_SESSION_TTL_MS,
+    SYNC_RESPONDER_DURABLE_DATA_SNAPSHOT_LIMIT,
+  );
+  const swmDataExactGraphPlanMemo = createResponderExactGraphPagePlanMemo(
+    DURABLE_DATA_SYNC_SESSION_TTL_MS,
+    SYNC_RESPONDER_SHARED_MEMORY_SNAPSHOT_LIMIT,
+  );
   const syncSessionTokens = new Map<string, SyncSessionTokenEntry>();
   const subGraphRegistrationMemo = createResponderSubGraphRegistrationMemo(store);
   const swmAdmissionMemo = createResponderSwmAdmissionMemo(store);
@@ -673,6 +682,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
             refreshRowList: session?.refreshRowList,
             refreshGeneration: session?.refreshGeneration,
             freshGraphPlanMemo: freshSwmDataGraphPlanMemo,
+            exactGraphPlanMemo: swmDataExactGraphPlanMemo,
           });
           const queryDurationMs = Date.now() - queryStartedAt;
           const serializeStartedAt = Date.now();
@@ -759,6 +769,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
           rowListCacheScope: session ? peerId : undefined,
           refreshRowList: session?.refreshRowList,
           refreshGeneration: session?.refreshGeneration,
+          exactGraphPlanMemo: durableDataExactGraphPlanMemo,
         });
         const queryDurationMs = Date.now() - queryStartedAt;
         const serializeStartedAt = Date.now();

--- a/packages/agent/test/encrypt-inline-policy.test.ts
+++ b/packages/agent/test/encrypt-inline-policy.test.ts
@@ -607,7 +607,16 @@ describe('DKGAgent.update inline encryption routing', () => {
         error: recorder(() => undefined),
         debug: recorder(() => undefined),
       },
-      chain: { chainId },
+      chain: {
+        chainId,
+        getEvmChainId: recorder(async () => 31337n),
+        getKnowledgeAssetsLifecycleAddress: recorder(
+          async () => '0x2222222222222222222222222222222222222222',
+        ),
+        hasContractCode: recorder(async () => true),
+        verifyContractSignature: recorder(async () => true),
+        getKnowledgeAssetOwner: recorder(async () => author),
+      },
       getContextGraphOnChainId: recorder(async () => '42'),
       createV10UpdateACKProvider: recorder(() => undefined),
       node: { peerId: { toString: () => 'peer-1' } },
@@ -927,11 +936,12 @@ describe('DKGAgent.publishQueuedKnowledgeAssetVmPublish inline encryption routin
   });
 
   it('does not trust or append a catalog floor for a private local-only queued publish', async () => {
-    const realInline = recorder(async (plaintext: Uint8Array) => plaintext);
+    const liveResolverInline = recorder(async (plaintext: Uint8Array) => plaintext);
+    const queuedInline = recorder(async (plaintext: Uint8Array) => plaintext);
     const { agentLike, publisherPublish } = makeQueuedAgentHarness({
       peerId: 'did:dkg:agent:queued-private-local',
       ual: 'did:dkg:local/queued-private-local',
-      encryptInlinePayload: realInline,
+      encryptInlinePayload: liveResolverInline,
     });
     const originalQuads = [{
       subject: 'urn:test:queued-private-local',
@@ -950,14 +960,20 @@ describe('DKGAgent.publishQueuedKnowledgeAssetVmPublish inline encryption routin
     await (DKGAgent.prototype as any).publishQueuedKnowledgeAssetVmPublish.call(
       agentLike,
       request,
-      { contextGraphId: request.contextGraphId, quads: originalQuads },
+      {
+        contextGraphId: request.contextGraphId,
+        quads: originalQuads,
+        encryptInlinePayload: queuedInline,
+      },
     );
 
     expect(publisherPublish.calls.at(-1)?.[0]).toMatchObject({
       quads: originalQuads,
-      encryptInlinePayload: realInline,
+      encryptInlinePayload: queuedInline,
       onChainContextGraphId: undefined,
     });
+    expect(publisherPublish.calls.at(-1)?.[0].encryptInlinePayload)
+      .not.toBe(liveResolverInline);
     expect(publisherPublish.calls.at(-1)?.[0]).not.toHaveProperty(
       'trustedNonManifestCatalogTriples',
     );

--- a/packages/agent/test/sync-responder-concurrent-interleaving.test.ts
+++ b/packages/agent/test/sync-responder-concurrent-interleaving.test.ts
@@ -470,7 +470,7 @@ describe('sync responder pagination interleaving', () => {
     expect(lineGraphsFromNquads(out)).toEqual(new Set([cgPrefix, fallbackGraph]));
   });
 
-  it('builds a reusable durable-data snapshot only from ordered bounded store pages', async () => {
+  it('builds a reusable durable-data snapshot from exact-graph bounded pages', async () => {
     const store = new OxigraphStore();
     const cgId = 'single-query-durable-fallback';
     const cgPrefix = `did:dkg:context-graph:${cgId}`;
@@ -481,18 +481,28 @@ describe('sync responder pagination interleaving', () => {
     ]);
 
     const originalQuery = store.query.bind(store);
-    let globalRowLoads = 0;
+    let exactGraphRowLoads = 0;
+    let exactGraphCounts = 0;
+    const originalCountQuads = store.countQuads.bind(store);
+    store.countQuads = async (graph, options) => {
+      if (graph === cgPrefix || graph === fallbackGraph) exactGraphCounts++;
+      return originalCountQuads(graph, options);
+    };
     store.query = (async (sparql: string) => {
       const normalized = sparql.replace(/\s+/g, ' ').trim();
-      if (normalized.includes('COUNT(*)')) {
-        throw new Error(`durable fallback should not count per graph: ${normalized}`);
-      }
       if (
         /^SELECT \?g \?s \?p \?o WHERE \{/.test(normalized) &&
-        normalized.includes(`VALUES ?g { <${cgPrefix}> <${fallbackGraph}>`)
+        normalized.includes('VALUES ?g') &&
+        normalized.includes('ORDER BY ?g ?s ?p ?o')
       ) {
-        globalRowLoads++;
-        expect(normalized).toContain('ORDER BY ?g ?s ?p ?o');
+        throw new Error(`durable fallback must not globally sort graph rows: ${normalized}`);
+      }
+      if (
+        /^SELECT \?s \?p \?o WHERE \{/.test(normalized) &&
+        (normalized.includes(`GRAPH <${cgPrefix}>`) || normalized.includes(`GRAPH <${fallbackGraph}>`))
+      ) {
+        exactGraphRowLoads++;
+        expect(normalized).toContain('ORDER BY ?s ?p ?o');
         expect(normalized).toContain('OFFSET 0');
         expect(normalized).toMatch(/LIMIT \d+$/);
       }
@@ -517,7 +527,8 @@ describe('sync responder pagination interleaving', () => {
       syncSessionId: 'cache-session',
     });
 
-    expect(globalRowLoads).toBe(1);
+    expect(exactGraphCounts).toBe(2);
+    expect(exactGraphRowLoads).toBe(2);
     expect(first).toContain('"row-000"');
     expect(first).not.toContain('"row-001"');
     expect(second).toContain('"row-001"');

--- a/packages/agent/test/sync-responder-large-graph-stack-overflow.test.ts
+++ b/packages/agent/test/sync-responder-large-graph-stack-overflow.test.ts
@@ -34,7 +34,19 @@ describe('sync responder tolerates a shared-memory graph larger than the spread 
 
     const store = {
       async query(sparql: string) {
-        if (sparql.includes('SELECT DISTINCT ?g ?s ?p ?o')) {
+        if (sparql.includes('SELECT DISTINCT ?g ?root')) {
+          return {
+            type: 'bindings' as const,
+            bindings: [{ g: dataGraph, root }],
+          };
+        }
+        if (sparql.includes('SELECT ?g ?count')) {
+          return {
+            type: 'bindings' as const,
+            bindings: [{ g: dataGraph, count: String(rowCount) }],
+          };
+        }
+        if (sparql.includes('SELECT DISTINCT ?s ?p ?o')) {
           const offset = Number(/OFFSET (\d+)/.exec(sparql)?.[1] ?? 0);
           const limit = Number(/LIMIT (\d+)/.exec(sparql)?.[1] ?? rowCount);
           return {

--- a/packages/agent/test/sync-responder-oversized-fallback.test.ts
+++ b/packages/agent/test/sync-responder-oversized-fallback.test.ts
@@ -320,19 +320,20 @@ describe('oversized responder fallback is store-bounded and set-equivalent', () 
   });
 });
 
-/** Assert the durable-data fallback issued a bounded ORDER BY/OFFSET/LIMIT page query. */
+/** Assert the durable-data fallback addressed one exact graph per bounded page query. */
 function watchBoundedDataPageQuery(store: OxigraphStore, graph: string) {
   const originalQuery = store.query.bind(store);
   let observed = 0;
   store.query = (async (sparql: string) => {
     const normalized = sparql.replace(/\s+/g, ' ').trim();
     if (
-      /^SELECT \?g \?s \?p \?o WHERE \{/.test(normalized) &&
-      normalized.includes(`<${graph}>`) &&
-      normalized.includes('ORDER BY ?g ?s ?p ?o') &&
+      /^SELECT \?s \?p \?o WHERE \{/.test(normalized) &&
+      normalized.includes(`GRAPH <${graph}>`) &&
+      normalized.includes('ORDER BY ?s ?p ?o') &&
       /OFFSET \d+/.test(normalized) &&
       /LIMIT \d+/.test(normalized)
     ) {
+      expect(normalized).not.toContain('VALUES ?g');
       observed += 1;
     }
     return originalQuery(sparql);

--- a/packages/agent/test/sync-responder-protection.test.ts
+++ b/packages/agent/test/sync-responder-protection.test.ts
@@ -27,7 +27,10 @@ function baseStore(overrides: Partial<TripleStore> = {}): TripleStore {
     dropGraph: async () => {},
     listGraphs: async () => [],
     deleteBySubjectPrefix: async () => 0,
-    countQuads: async () => 0,
+    // Exact-graph responder paging inventories a listed graph before issuing
+    // its bounded row query. Tests that expose a graph therefore model one row
+    // by default so their query gates still exercise responder admission.
+    countQuads: async (graph) => graph ? 1 : 0,
     close: async () => {},
     ...overrides,
   };

--- a/packages/agent/test/sync-responder-rootless-perf.test.ts
+++ b/packages/agent/test/sync-responder-rootless-perf.test.ts
@@ -1,0 +1,176 @@
+import { performance } from 'node:perf_hooks';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  MemoryLayer,
+  contextGraphLayerUri,
+} from '@origintrail-official/dkg-core';
+import {
+  SparqlHttpStore,
+  type Quad,
+  type TripleStore,
+} from '@origintrail-official/dkg-storage';
+import {
+  DKG_NS,
+  linesFromNquads,
+  registerTestSyncHandler,
+  type CapturedSyncHandler,
+} from './_helpers/sync-responder.js';
+
+const describePerf = process.env.DKG_SYNC_RESPONDER_ROOTLESS_PERF === '1'
+  ? describe
+  : describe.skip;
+
+const RUN_ID = (
+  process.env.DKG_SYNC_RESPONDER_ROOTLESS_PERF_RUN_ID?.trim()
+  || `${process.pid}-${Date.now().toString(36)}`
+).replace(/[^A-Za-z0-9_-]/g, '-');
+const CG_ID = `rootless-perf-${RUN_ID}`;
+const AGENT_ADDRESS = '0x00000000000000000000000000000000000000ab';
+const KA_COUNT = 50;
+const ROWS_PER_KA = 1_000;
+const TOTAL_ROWS = KA_COUNT * ROWS_PER_KA;
+const PAGE_SIZE = 500;
+const SESSION_ID = `rootless-perf-session-${RUN_ID}`;
+const DEFAULT_SYNC_BUDGET_MS = 30_000;
+
+function syncBudgetMs(): number {
+  const configured = Number(process.env.DKG_SYNC_RESPONDER_ROOTLESS_PERF_BUDGET_MS);
+  return Number.isFinite(configured) && configured > 0
+    ? configured
+    : DEFAULT_SYNC_BUDGET_MS;
+}
+
+function createPerfStore(): TripleStore {
+  const queryEndpoint = process.env.DKG_SYNC_RESPONDER_PERF_QUERY_ENDPOINT?.trim();
+  if (!queryEndpoint) {
+    throw new Error(
+      'DKG_SYNC_RESPONDER_ROOTLESS_PERF=1 requires ' +
+      'DKG_SYNC_RESPONDER_PERF_QUERY_ENDPOINT pointing at an oxigraph-server /query endpoint',
+    );
+  }
+  const timeout = Number(process.env.DKG_SYNC_RESPONDER_PERF_TIMEOUT_MS ?? 180_000);
+  return new SparqlHttpStore({
+    queryEndpoint,
+    updateEndpoint: process.env.DKG_SYNC_RESPONDER_PERF_UPDATE_ENDPOINT?.trim()
+      || queryEndpoint.replace(/\/query\/?$/, '/update'),
+    timeout: Number.isFinite(timeout) && timeout > 0 ? timeout : 180_000,
+    managedByDkg: true,
+  });
+}
+
+function graphForKa(index: number): string {
+  return contextGraphLayerUri(
+    CG_ID,
+    MemoryLayer.VerifiableMemory,
+    AGENT_ADDRESS,
+    index + 1,
+  );
+}
+
+describePerf('rootless exact-graph sync responder perf guard', () => {
+  let store: TripleStore;
+  let cap: CapturedSyncHandler;
+  const seededGraphs: string[] = [];
+  let exactGraphCounts = 0;
+  let exactGraphPageQueries = 0;
+  let largestExactGraphOffset = 0;
+
+  beforeAll(async () => {
+    store = createPerfStore();
+    const originalCountQuads = store.countQuads.bind(store);
+    store.countQuads = async (graph, options) => {
+      if (graph?.includes('/_verifiable_memory/')) exactGraphCounts += 1;
+      return originalCountQuads(graph, options);
+    };
+
+    const originalQuery = store.query.bind(store);
+    store.query = async (sparql, options) => {
+      const normalized = sparql.replace(/\s+/g, ' ').trim();
+      if (
+        normalized.startsWith('SELECT ?g ?s ?p ?o WHERE {')
+        && normalized.includes('VALUES ?g')
+        && normalized.includes('ORDER BY ?g ?s ?p ?o')
+      ) {
+        throw new Error(`rootless sync issued a global cross-graph page query: ${normalized}`);
+      }
+      if (
+        normalized.startsWith('SELECT ?s ?p ?o WHERE {')
+        && normalized.includes('/_verifiable_memory/')
+        && normalized.includes('ORDER BY ?s ?p ?o')
+      ) {
+        exactGraphPageQueries += 1;
+        const offset = Number(/OFFSET (\d+)/.exec(normalized)?.[1] ?? 0);
+        largestExactGraphOffset = Math.max(largestExactGraphOffset, offset);
+      }
+      return originalQuery(sparql, options);
+    };
+
+    let batch: Quad[] = [];
+    const flush = async () => {
+      if (batch.length === 0) return;
+      await store.insert(batch);
+      batch = [];
+    };
+    for (let ka = 0; ka < KA_COUNT; ka += 1) {
+      const graph = graphForKa(ka);
+      seededGraphs.push(graph);
+      for (let row = 0; row < ROWS_PER_KA; row += 1) {
+        const suffix = row.toString().padStart(4, '0');
+        batch.push({
+          graph,
+          subject: `urn:rootless:perf:${ka.toString().padStart(2, '0')}:${suffix}`,
+          predicate: `${DKG_NS}label`,
+          object: `"rootless-${ka}-${suffix}"`,
+        });
+        if (batch.length >= 10_000) await flush();
+      }
+    }
+    for (let index = 0; index < 100; index += 1) {
+      const graph = `did:dkg:context-graph:rootless-perf-decoy-${RUN_ID}-${index}`;
+      seededGraphs.push(graph);
+      batch.push({
+        graph,
+        subject: `urn:rootless:decoy:${index}`,
+        predicate: `${DKG_NS}label`,
+        object: '"decoy"',
+      });
+    }
+    await flush();
+
+    cap = registerTestSyncHandler(store, { syncPageSize: PAGE_SIZE });
+  }, 180_000);
+
+  afterAll(async () => {
+    if (!store) return;
+    for (const graph of seededGraphs) {
+      await store.dropGraph(graph).catch(() => undefined);
+    }
+    await store.close();
+  }, 60_000);
+
+  it('syncs 50 immutable 1,000-triple KAs without a store-wide sort or deep offset', async () => {
+    const lines = new Set<string>();
+    const startedAt = performance.now();
+    for (let offset = 0; offset < TOTAL_ROWS; offset += PAGE_SIZE) {
+      const page = await cap.invoke({
+        contextGraphId: CG_ID,
+        includeSharedMemory: false,
+        phase: 'data',
+        offset,
+        limit: PAGE_SIZE,
+        syncSessionId: SESSION_ID,
+      });
+      const pageLines = linesFromNquads(page);
+      expect(pageLines, `offset ${offset}`).toHaveLength(PAGE_SIZE);
+      for (const line of pageLines) lines.add(line);
+    }
+    const elapsedMs = performance.now() - startedAt;
+
+    expect(lines.size).toBe(TOTAL_ROWS);
+    expect(exactGraphCounts).toBe(KA_COUNT);
+    expect(exactGraphPageQueries).toBeGreaterThanOrEqual(KA_COUNT * 2);
+    expect(largestExactGraphOffset).toBeLessThan(ROWS_PER_KA);
+    expect(elapsedMs, `rootless exact-graph sync took ${elapsedMs.toFixed(1)}ms`)
+      .toBeLessThan(syncBudgetMs());
+  }, 120_000);
+});


### PR DESCRIPTION
## Summary

- replaces the full durable and non-TTL SWM global `VALUES ?g ... ORDER BY ?g ?s ?p ?o OFFSET ...` fallback with a session-scoped inventory of exact graph IRIs and row counts
- pages one concrete named graph at a time and reuses the tiny plan across the 10k-row snapshot cap and all later frames
- keeps payload rows in the triple store, prevents deep store-wide offsets, and fails if a later page has lost its original session plan
- adds regression coverage plus an opt-in real Oxigraph 0.5.8 guard for 50 immutable KAs x 1,000 triples
- refreshes two stale privacy test fixtures already failing on the canary base; this is test-only and preserves the new immutable queued-callback rule

## Why

The canary saturation query was a cross-graph four-term sort with a large global OFFSET. A real Oxigraph 0.5.8 reproduction remained CPU-bound after both the native timeout and client abort. Exact per-KA graph reads avoid that query plan entirely.

## Validation

- agent build and type tests pass
- real Oxigraph 0.5.8: 50 KAs x 1,000 triples, 50,000 unique rows, no global cross-graph sort, maximum exact-graph offset below 1,000; full response walk 2.31 seconds
- focused responder suites: 119 passed, 3 opt-in performance cases skipped
- rootless privacy, recovery, finalization, membership, SWM snapshot and admission group: 80 passed
- full agent unit suite: 1,022 passed
