### PR TITLE
fix(random-sampling): pin RS proof content per period (mid-period update no longer misses a proof) [#1716]

### DIFF
--- a/packages/random-sampling/src/prover.ts
+++ b/packages/random-sampling/src/prover.ts
@@ -115,6 +115,27 @@ export class RandomSamplingProver {
   private readonly log: ProverLogger;
   private inflight: Promise<TickOutcome> | null = null;
 
+  /**
+   * Proof material pinned for the active proof period. The prover already pins
+   * the challenge root / leaf-count / curation branch at issuance (WS-B Trap 1),
+   * but the CONTENT was re-read live on every retry — so a mid-period UPDATE to
+   * the sampled KA (typically surfacing on a submit retry after a transient tx
+   * failure) turned an already-valid proof into a `data-corrupted` miss. Once a
+   * proof verifies against the pinned root we keep it and reuse it for the rest
+   * of the period. Keyed by the full challenge identity so a new period never
+   * reuses stale material. In-memory only — a restart mid-period re-extracts,
+   * same as before (restart + mid-period-update + this exact sampled KA is
+   * vanishingly rare).
+   */
+  private pinnedProofMaterial?: {
+    epoch: bigint;
+    periodStartBlock: bigint;
+    kaId: bigint;
+    chunkId: bigint;
+    expectedRoot: Uint8Array;
+    material: Awaited<ReturnType<ProofBuilder['build']>>;
+  };
+
   constructor(deps: RandomSamplingProverDeps) {
     this.chain = deps.chain;
     this.store = deps.store;
@@ -185,6 +206,44 @@ export class RandomSamplingProver {
     }
     const periodEndBlock = existing.activeProofPeriodStartBlock + duration;
     return BigInt(currentBlock) >= periodEndBlock;
+  }
+
+  /** Reuse the proof material already verified for this exact challenge, if any. */
+  private pinnedMaterialFor(
+    periodKey: PeriodKey,
+    kaId: bigint,
+    chunkId: bigint,
+    expectedRoot: Uint8Array,
+  ): Awaited<ReturnType<ProofBuilder['build']>> | undefined {
+    const p = this.pinnedProofMaterial;
+    if (
+      p
+      && p.epoch === periodKey.epoch
+      && p.periodStartBlock === periodKey.periodStartBlock
+      && p.kaId === kaId
+      && p.chunkId === chunkId
+      && uint8ArrayEquals(p.expectedRoot, expectedRoot)
+    ) {
+      return p.material;
+    }
+    return undefined;
+  }
+
+  private pinProofMaterial(
+    periodKey: PeriodKey,
+    kaId: bigint,
+    chunkId: bigint,
+    expectedRoot: Uint8Array,
+    material: Awaited<ReturnType<ProofBuilder['build']>>,
+  ): void {
+    this.pinnedProofMaterial = {
+      epoch: periodKey.epoch,
+      periodStartBlock: periodKey.periodStartBlock,
+      kaId,
+      chunkId,
+      expectedRoot,
+      material,
+    };
   }
 
   private async tickImpl(): Promise<TickOutcome> {
@@ -453,7 +512,24 @@ export class RandomSamplingProver {
       material = await this.builder.build(req);
     } catch (err) {
       const reason = mapBuilderError(err);
-      if (reason) {
+      if (!reason) throw err;
+      // Content changed under us mid-period: an UPDATE to the sampled KA flips
+      // the live root, so a freshly-extracted proof no longer matches the
+      // challenge root. That root is PINNED on the challenge, so if we already
+      // built a proof that verified against it earlier this period, reuse it
+      // instead of missing an honest proof — this rescues the common
+      // submit-retry-after-update path. Otherwise the content genuinely does
+      // not match the pinned commitment: skip as before.
+      const pinned = this.pinnedMaterialFor(periodKey, kaId, chunkId, expectedRoot);
+      if (pinned) {
+        this.log.info('rs.tick.pinned-material-reused', {
+          kaId: kaId.toString(),
+          cgId: cgId.toString(),
+          periodStart: periodKey.periodStartBlock.toString(),
+          reason,
+        });
+        material = pinned;
+      } else {
         const e = err as any;
         this.log.error('rs.tick.data-corrupted', {
           kaId: kaId.toString(),
@@ -478,8 +554,10 @@ export class RandomSamplingProver {
         );
         return { kind: 'data-corrupted', kaId, cgId, reason };
       }
-      throw err;
     }
+    // Pin the verified material so a mid-period update (surfacing here on a
+    // submit retry) reuses it rather than re-extracting stale content.
+    this.pinProofMaterial(periodKey, kaId, chunkId, expectedRoot, material);
 
     await this.wal.append(
       makeWalEntry(periodKey, 'built', {
@@ -556,4 +634,12 @@ function mapBuilderError(err: unknown): 'root-mismatch' | 'leaf-count-mismatch' 
   if (err instanceof V10ProofLeafCountMismatchError) return 'leaf-count-mismatch';
   if (err instanceof V10ProofChunkOutOfRangeError) return 'leaf-count-mismatch';
   return null;
+}
+
+function uint8ArrayEquals(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i += 1) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
 }

--- a/packages/random-sampling/src/prover.ts
+++ b/packages/random-sampling/src/prover.ts
@@ -572,6 +572,7 @@ export class RandomSamplingProver {
       txResult = await this.chain.submitProof(material.content, material.proof);
     } catch (err) {
       if (err instanceof ChallengeNoLongerActiveError) {
+        this.pinnedProofMaterial = undefined;
         this.log.warn('rs.tick.submit-stale', {
           kaId: kaId.toString(),
           cgId: cgId.toString(),
@@ -588,6 +589,11 @@ export class RandomSamplingProver {
         return { kind: 'submit-stale' };
       }
       if (err instanceof MerkleRootMismatchError) {
+        // This material was deterministically rejected by the on-chain
+        // verifier. Never retain it for the exception-path retry fallback: a
+        // later live-content mismatch must not resubmit proof bytes the chain
+        // already proved invalid.
+        this.pinnedProofMaterial = undefined;
         // The chain says the root we built does not match the on-chain
         // commitment. We already verified it locally, so this is
         // either (a) a race against an UPDATE that flipped the root,

--- a/packages/random-sampling/test/prover.test.ts
+++ b/packages/random-sampling/test/prover.test.ts
@@ -16,6 +16,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   ChallengeNoLongerActiveError,
+  MerkleRootMismatchError,
   NoEligibleContextGraphError,
   NoEligibleKnowledgeCollectionError,
   type ChainAdapter,
@@ -259,7 +260,10 @@ describe('RandomSamplingProver — mid-period update (content pinning)', () => {
     const dataGraph = contextGraphDataUri(`cg-${fixture.cgId}`, fixture.cgId.toString());
 
     let submitCalls = 0;
-    const submitProof = vi.fn(async () => {
+    const submitProof = vi.fn(async (
+      _content: Uint8Array,
+      _proof: Uint8Array[],
+    ) => {
       submitCalls += 1;
       if (submitCalls === 1) throw new Error('transient submit failure');
       return { hash: '0xretry', blockNumber: 1002, success: true };
@@ -307,6 +311,75 @@ describe('RandomSamplingProver — mid-period update (content pinning)', () => {
     const outcome = await prover.tick();
     expect(outcome).toMatchObject({ kind: 'submitted', txHash: '0xretry' });
     expect(submitProof).toHaveBeenCalledTimes(2);
+    const [firstContent, firstProof] = submitProof.mock.calls[0]!;
+    const [retryContent, retryProof] = submitProof.mock.calls[1]!;
+    expect(retryContent).toEqual(firstContent);
+    expect(retryProof).toEqual(firstProof);
+    expect(new TextDecoder().decode(retryContent)).not.toContain('MUTATED');
+    await prover.close();
+  });
+
+  it('does not reuse material after the chain deterministically rejects it', async () => {
+    const fixture: KCFixture = {
+      cgId: 12n,
+      kaId: 8n,
+      ual: 'did:dkg:hardhat:31337/0xpub/8',
+      rootEntities: ['urn:e:1', 'urn:e:2', 'urn:e:3'],
+      publicTriples: [
+        { subject: 'urn:e:1', predicate: 'urn:p:k', object: '"a"' },
+        { subject: 'urn:e:2', predicate: 'urn:p:k', object: '"b"' },
+        { subject: 'urn:e:3', predicate: 'urn:p:k', object: '"c"' },
+      ],
+    };
+    const { root, leafCount } = await seedKC(store, fixture);
+    const dataGraph = contextGraphDataUri(`cg-${fixture.cgId}`, fixture.cgId.toString());
+    const submitProof = vi.fn(async (
+      _content: Uint8Array,
+      _proof: Uint8Array[],
+    ) => {
+      throw new MerkleRootMismatchError('0xbad', '0xexpected');
+    });
+    const challenge = makeChallenge({
+      knowledgeAssetId: fixture.kaId,
+      chunkId: 1n,
+      challengeRoot: root,
+      challengeLeafCount: BigInt(leafCount),
+      activeProofPeriodStartBlock: 1000n,
+      solved: false,
+    });
+    const chain = makeChain({
+      status: { activeProofPeriodStartBlock: 1000n, isValid: true },
+      challengeForNode: challenge,
+      createChallenge: async () => ({
+        challenge,
+        contextGraphId: fixture.cgId,
+        hash: '0xchallenge',
+        blockNumber: 1000,
+        success: true,
+      }),
+      expectedRoot: root,
+      expectedLeafCount: leafCount,
+      cgIdForKc: fixture.cgId,
+      submitProof,
+    });
+    const prover = new RandomSamplingProver({ chain, store, identityId: IDENTITY_ID });
+
+    await expect(prover.tick()).resolves.toMatchObject({
+      kind: 'data-corrupted',
+      reason: 'root-mismatch',
+    });
+    await store.delete([
+      { subject: 'urn:e:1', predicate: 'urn:p:k', object: '"a"', graph: dataGraph },
+    ]);
+    await store.insert([
+      { subject: 'urn:e:1', predicate: 'urn:p:k', object: '"MUTATED"', graph: dataGraph },
+    ]);
+
+    await expect(prover.tick()).resolves.toMatchObject({
+      kind: 'data-corrupted',
+      reason: 'root-mismatch',
+    });
+    expect(submitProof).toHaveBeenCalledTimes(1);
     await prover.close();
   });
 });

--- a/packages/random-sampling/test/prover.test.ts
+++ b/packages/random-sampling/test/prover.test.ts
@@ -231,6 +231,86 @@ describe('RandomSamplingProver — happy path', () => {
   });
 });
 
+describe('RandomSamplingProver — mid-period update (content pinning)', () => {
+  let store: OxigraphStore;
+  beforeEach(() => {
+    store = new OxigraphStore();
+  });
+
+  it('reuses the proof it already verified when an update flips the live root before a submit retry', async () => {
+    // #1716: the challenge pins root/leaf-count at issuance, but the CONTENT
+    // was re-read live on every retry. First tick builds a valid proof against
+    // the pinned root, then the submit fails transiently. A mid-period UPDATE
+    // then changes the sampled KA's content (new live root). Without the
+    // content pin, the retry re-extracts, fails root-mismatch, and misses an
+    // honest proof. With it, the retry reuses the already-verified material.
+    const fixture: KCFixture = {
+      cgId: 11n,
+      kaId: 7n,
+      ual: 'did:dkg:hardhat:31337/0xpub/7',
+      rootEntities: ['urn:e:1', 'urn:e:2', 'urn:e:3'],
+      publicTriples: [
+        { subject: 'urn:e:1', predicate: 'urn:p:k', object: '"a"' },
+        { subject: 'urn:e:2', predicate: 'urn:p:k', object: '"b"' },
+        { subject: 'urn:e:3', predicate: 'urn:p:k', object: '"c"' },
+      ],
+    };
+    const { root, leafCount } = await seedKC(store, fixture);
+    const dataGraph = contextGraphDataUri(`cg-${fixture.cgId}`, fixture.cgId.toString());
+
+    let submitCalls = 0;
+    const submitProof = vi.fn(async () => {
+      submitCalls += 1;
+      if (submitCalls === 1) throw new Error('transient submit failure');
+      return { hash: '0xretry', blockNumber: 1002, success: true };
+    });
+    const challenge = makeChallenge({
+      knowledgeAssetId: fixture.kaId,
+      chunkId: 1n,
+      challengeRoot: root,
+      challengeLeafCount: BigInt(leafCount),
+      activeProofPeriodStartBlock: 1000n,
+      solved: false,
+    });
+    const chain = makeChain({
+      status: { activeProofPeriodStartBlock: 1000n, isValid: true },
+      challengeForNode: challenge,
+      createChallenge: async () => ({
+        challenge,
+        contextGraphId: fixture.cgId,
+        hash: '0xchallenge',
+        blockNumber: 1000,
+        success: true,
+      }),
+      expectedRoot: root,
+      expectedLeafCount: leafCount,
+      cgIdForKc: fixture.cgId,
+      submitProof,
+    });
+    const prover = new RandomSamplingProver({ chain, store, identityId: IDENTITY_ID });
+
+    // Tick 1: builds + verifies the proof (pins it), then the submit throws.
+    await expect(prover.tick()).rejects.toThrow('transient submit failure');
+    expect(submitProof).toHaveBeenCalledTimes(1);
+
+    // A mid-period UPDATE mutates the sampled KA's content → new live root,
+    // while the on-chain challenge stays pinned to the original root.
+    await store.delete([
+      { subject: 'urn:e:1', predicate: 'urn:p:k', object: '"a"', graph: dataGraph },
+    ]);
+    await store.insert([
+      { subject: 'urn:e:1', predicate: 'urn:p:k', object: '"MUTATED"', graph: dataGraph },
+    ]);
+
+    // Tick 2: a fresh extract no longer matches the pinned root, but the prover
+    // submits the material it already verified this period instead of missing.
+    const outcome = await prover.tick();
+    expect(outcome).toMatchObject({ kind: 'submitted', txHash: '0xretry' });
+    expect(submitProof).toHaveBeenCalledTimes(2);
+    await prover.close();
+  });
+});
+
 describe('RandomSamplingProver — curated catalog (OT-RFC-49 WS-C)', () => {
   let store: OxigraphStore;
   beforeEach(() => {


### PR DESCRIPTION
## #1716 — pin RS proof content per period (mid-period update no longer misses a proof)

**The bug.** The prover already pins the challenge root/leaf-count/curation branch at issuance (WS-B Trap 1) so a mid-period on-chain update can't fail an honest proof — but it still re-read the **content** live from the store on every retry. The VM graph is version-agnostic and an update destructively replaces it (`DROP SILENT GRAPH`), so if the sampled KA is updated between challenge issuance and proof submission — most often surfacing on a **submit retry after a transient tx failure** — the retry re-extracts the new content, fails the local root check against the pinned `challengeRoot`, and drops the period as `data-corrupted`. That's a missed proof (reward loss) for content the node verifiably held. Bounded/self-recovering (next period draws against the new root), but real.

**The fix (node-only).** I earlier mis-classified this as needing a contract change; it doesn't. The challenge already carries the pinned root, so the node has everything it needs — it just no longer *has* the matching content after an update. Extend the existing "pin at issuance" contract to the content: once the built material verifies against the pinned root, cache it for the period (keyed by the full challenge identity) and reuse it if a later rebuild fails because the live content moved under us.

**Why this shape** (low-complexity / high-quality / scales):
- Prover-local — no coupling to the update/materialization path, no new storage graphs, no GC of retained graphs.
- Scales — one in-memory cache entry, replaced each period (constant). Zero storage growth (unlike per-version graph retention).
- Consistent with the code's own philosophy (it already pins root/count the same way).
- **Residual & caveat:** closes the practical window (submit-retry-after-update). The remaining `period-start -> first-extract` sliver (an update landing before the prover's first extract) is only fully closed by immutable per-version assertion graphs — a larger storage-model refactor, out of scope for this low-severity, self-recovering issue. In-memory only: a restart mid-period re-extracts (same as before).

**Test.** Regression drives tick1 (build + pin, transient submit failure) → mutate the sampled KA's content → tick2 (fresh build root-mismatch → reuse pinned material → submit). It fails without the pin. Full `random-sampling` suite green (87 tests).
