### PR TITLE
fix(sync): bound rootless VM manifests and private auth reads

### DIFF
--- a/packages/agent/src/context-graph-meta-projection.ts
+++ b/packages/agent/src/context-graph-meta-projection.ts
@@ -20,6 +20,14 @@ export interface ContextGraphSubGraphMeta {
   description?: string;
 }
 
+export interface ContextGraphDelegationMeta {
+  uri: string;
+  agents: string[];
+  allowedPeers: string[];
+  allowedKeys: string[];
+  expiresAtValues: string[];
+}
+
 export interface ContextGraphMetaRecord {
   id: string;
   uri: string;
@@ -38,6 +46,7 @@ export interface ContextGraphMetaRecord {
   participantAgents: string[];
   participantIdentityIds: string[];
   revokedAgents: string[];
+  delegations: ContextGraphDelegationMeta[];
   onChainId?: string;
   subGraphs: ContextGraphSubGraphMeta[];
   hasAgentGate: boolean;
@@ -98,6 +107,13 @@ const SUB_GRAPH_META_PREDICATES = new Set([
   `${LEGACY_DKG_NS}createdAt`,
   `${DKG_NS}authorizedWriter`,
   `${LEGACY_DKG_NS}authorizedWriter`,
+]);
+
+const DELEGATION_META_PREDICATES = new Set<string>([
+  DKG_ONTOLOGY.DKG_DELEGATION_AGENT,
+  DKG_ONTOLOGY.DKG_ALLOWED_DELEGATEE_PEER,
+  DKG_ONTOLOGY.DKG_ALLOWED_DELEGATEE_KEY,
+  DKG_ONTOLOGY.DKG_DELEGATION_EXPIRES_AT,
 ]);
 
 // OT-RFC-49 §5.9: the public `_catalog` graph is a CG's discoverable face and may
@@ -310,6 +326,7 @@ export class ContextGraphMetaProjection {
       participantAgents: [],
       participantIdentityIds: [],
       revokedAgents: [],
+      delegations: [],
       subGraphs: [],
       hasAgentGate: false,
       hasPeerGate: false,
@@ -324,12 +341,69 @@ export class ContextGraphMetaProjection {
     await this.loadContextGraphFacts(agentsGraph, uri, record, options);
     await this.loadContextGraphFacts(catalogGraph, uri, record, options, CATALOG_META_PREDICATES);
     await this.loadContextGraphFacts(ontologyGraph, uri, record, options);
+    record.delegations = await this.loadDelegations(contextGraphId, options);
     record.subGraphs = await this.loadSubGraphs(contextGraphId, options);
 
     record.hasAgentGate = record.allowedAgents.length > 0 || record.participantAgents.length > 0;
     record.hasPeerGate = record.allowedPeers.length > 0;
     record.hasLegacyParticipantGate = record.participantIdentityIds.length > 0;
     return record;
+  }
+
+  private async loadDelegations(
+    contextGraphId: string,
+    options: QueryOptions,
+  ): Promise<ContextGraphDelegationMeta[]> {
+    const metaGraph = contextGraphMetaGraphUri(contextGraphId);
+    const result = await this.store.query(
+      `SELECT ?delegation ?predicate ?object WHERE {
+        GRAPH <${metaGraph}> {
+          ?delegation <${DKG_ONTOLOGY.DKG_DELEGATION_AGENT}> ?delegatedAgent .
+          ?delegation ?predicate ?object .
+          VALUES ?predicate {
+            <${DKG_ONTOLOGY.DKG_DELEGATION_AGENT}>
+            <${DKG_ONTOLOGY.DKG_ALLOWED_DELEGATEE_PEER}>
+            <${DKG_ONTOLOGY.DKG_ALLOWED_DELEGATEE_KEY}>
+            <${DKG_ONTOLOGY.DKG_DELEGATION_EXPIRES_AT}>
+          }
+        }
+      }`,
+      options,
+    );
+    if (result.type !== 'bindings') return [];
+
+    const byUri = new Map<string, ContextGraphDelegationMeta>();
+    for (const row of result.bindings) {
+      const delegation = typeof row['delegation'] === 'string' ? stripTerm(row['delegation']) : '';
+      const predicate = typeof row['predicate'] === 'string' ? strip(row['predicate']) : '';
+      const object = typeof row['object'] === 'string' ? stripTerm(row['object']) : '';
+      if (!delegation || !predicate || !object) continue;
+      const current = byUri.get(delegation) ?? {
+        uri: delegation,
+        agents: [],
+        allowedPeers: [],
+        allowedKeys: [],
+        expiresAtValues: [],
+      };
+      switch (predicate) {
+        case DKG_ONTOLOGY.DKG_DELEGATION_AGENT:
+          pushUniqueCaseInsensitive(current.agents, object);
+          break;
+        case DKG_ONTOLOGY.DKG_ALLOWED_DELEGATEE_PEER:
+          pushUnique(current.allowedPeers, object);
+          break;
+        case DKG_ONTOLOGY.DKG_ALLOWED_DELEGATEE_KEY:
+          pushUniqueCaseInsensitive(current.allowedKeys, object);
+          break;
+        case DKG_ONTOLOGY.DKG_DELEGATION_EXPIRES_AT:
+          pushUnique(current.expiresAtValues, object);
+          break;
+        default:
+          break;
+      }
+      byUri.set(delegation, current);
+    }
+    return [...byUri.values()];
   }
 
   private async loadContextGraphFacts(
@@ -495,6 +569,13 @@ export class ContextGraphMetaProjection {
         return metaContextGraphId;
       }
 
+      if (
+        subject.startsWith(`did:dkg:agent-delegation:${metaContextGraphId}:`) &&
+        DELEGATION_META_PREDICATES.has(predicate)
+      ) {
+        return metaContextGraphId;
+      }
+
       if (!subject.startsWith(`${contextGraphUri}/`)) return null;
       if (!SUB_GRAPH_META_PREDICATES.has(predicate)) return null;
       if (predicate === DKG_ONTOLOGY.RDF_TYPE && !SUB_GRAPH_TYPE_URIS.has(object)) return null;
@@ -587,6 +668,13 @@ function cloneMetaRecord(record: ContextGraphMetaRecord): ContextGraphMetaRecord
     participantAgents: [...record.participantAgents],
     participantIdentityIds: [...record.participantIdentityIds],
     revokedAgents: [...record.revokedAgents],
+    delegations: record.delegations.map((delegation) => ({
+      ...delegation,
+      agents: [...delegation.agents],
+      allowedPeers: [...delegation.allowedPeers],
+      allowedKeys: [...delegation.allowedKeys],
+      expiresAtValues: [...delegation.expiresAtValues],
+    })),
     subGraphs: record.subGraphs.map((subGraph) => ({ ...subGraph })),
   };
 }

--- a/packages/agent/src/dkg-agent-crypto.ts
+++ b/packages/agent/src/dkg-agent-crypto.ts
@@ -378,8 +378,45 @@ import {
 } from './dkg-agent-swm-state.js';
 import { DKGAgentBase } from './dkg-agent-base.js';
 import type { DKGAgent } from './dkg-agent.js';
+import type { ContextGraphMetaRecord } from './context-graph-meta-projection.js';
 
 const KA_LIFECYCLE_ASSET_UAL_RESOLVE_TIMEOUT_MS = 50;
+
+function delegationIsCurrentlyActive(expiresAtValues: readonly string[], nowMs: number): boolean {
+  if (expiresAtValues.length === 0) return true;
+  return expiresAtValues.some((value) => {
+    const expiresAt = Number(value);
+    return !Number.isFinite(expiresAt) || expiresAt <= 0 || expiresAt >= nowMs;
+  });
+}
+
+function collectProjectedDelegatees(
+  meta: ContextGraphMetaRecord,
+  field: 'allowedPeers' | 'allowedKeys',
+  normalizeValue: (value: string) => string,
+): Map<string, string[]> {
+  const members = new Set(
+    [...meta.allowedAgents, ...meta.participantAgents].map((agent) => agent.toLowerCase()),
+  );
+  const revoked = new Set(meta.revokedAgents.map((agent) => agent.toLowerCase()));
+  const out = new Map<string, string[]>();
+  const nowMs = Date.now();
+
+  for (const delegation of meta.delegations) {
+    if (!delegationIsCurrentlyActive(delegation.expiresAtValues, nowMs)) continue;
+    for (const rawAgent of delegation.agents) {
+      const agent = rawAgent.toLowerCase();
+      if (!agent || !members.has(agent) || revoked.has(agent)) continue;
+      const values = out.get(agent) ?? [];
+      for (const rawValue of delegation[field]) {
+        const value = normalizeValue(rawValue);
+        if (value && !values.includes(value)) values.push(value);
+      }
+      if (values.length > 0) out.set(agent, values);
+    }
+  }
+  return out;
+}
 
 export class WorkspaceCryptoMethods extends DKGAgentBase {
   getWorkspaceGossipSigningAgent(this: DKGAgent): (AgentKeyRecord & { privateKey: string }) | null {
@@ -526,53 +563,8 @@ export class WorkspaceCryptoMethods extends DKGAgentBase {
     contextGraphId: string,
     options: { signal?: AbortSignal } = {},
   ): Promise<Map<string, string[]>> {
-    const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
-    const cgEntity = contextGraphDataGraphUri(contextGraphId);
-    // SELECT also returns `expiresAtMs` so we can filter expired rows in
-    // JS — pushing the FILTER into SPARQL would force a string→long
-    // cast that not every store backend handles uniformly.
-    // PR #448 review (round 4): without this, an approved delegation
-    // remained authorised forever even after `expiresAtMs` had passed.
-    // `approveJoinRequest()` re-validates expiry only at approval time;
-    // sync auth never checked it again, turning `expiresAtMs` into a
-    // one-time admission gate instead of an ongoing constraint.
-    const result = await this.store.query(
-      `SELECT ?agent ?peer ?expiresAt WHERE {
-        GRAPH <${cgMetaGraph}> {
-          ?d <${DKG_ONTOLOGY.DKG_DELEGATION_AGENT}> ?agent ;
-             <${DKG_ONTOLOGY.DKG_ALLOWED_DELEGATEE_PEER}> ?peer .
-          <${cgEntity}> (<${DKG_ONTOLOGY.DKG_ALLOWED_AGENT}>|<${DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT}>) ?memberAgent .
-          FILTER(LCASE(STR(?agent)) = LCASE(STR(?memberAgent)))
-          FILTER NOT EXISTS {
-            <${cgEntity}> <${DKG_ONTOLOGY.DKG_REVOKED_AGENT}> ?revokedAgent .
-            FILTER(LCASE(STR(?agent)) = LCASE(STR(?revokedAgent)))
-          }
-          OPTIONAL { ?d <${DKG_ONTOLOGY.DKG_DELEGATION_EXPIRES_AT}> ?expiresAt }
-        }
-      }`,
-      { signal: options.signal },
-    );
-    const out = new Map<string, string[]>();
-    if (result.type !== 'bindings') return out;
-    const strip = (raw: unknown): string => {
-      if (typeof raw !== 'string') return '';
-      return raw.replace(/^"/, '').replace(/"(@[a-zA-Z-]+|\^\^<[^>]+>)?$/, '');
-    };
-    const nowMs = Date.now();
-    for (const row of result.bindings) {
-      const agent = strip(row['agent']).toLowerCase();
-      const peer = strip(row['peer']);
-      if (!agent || !peer) continue;
-      const expiresStr = strip(row['expiresAt']);
-      if (expiresStr) {
-        const expiresAt = Number(expiresStr);
-        if (Number.isFinite(expiresAt) && expiresAt > 0 && expiresAt < nowMs) continue;
-      }
-      const list = out.get(agent) ?? [];
-      if (!list.includes(peer)) list.push(peer);
-      out.set(agent, list);
-    }
-    return out;
+    const meta = await this.getCgMeta(contextGraphId, { signal: options.signal });
+    return collectProjectedDelegatees(meta, 'allowedPeers', (value) => value);
   }
 
   /**
@@ -588,45 +580,8 @@ export class WorkspaceCryptoMethods extends DKGAgentBase {
     contextGraphId: string,
     options: { signal?: AbortSignal } = {},
   ): Promise<Map<string, string[]>> {
-    const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
-    const cgEntity = contextGraphDataGraphUri(contextGraphId);
-    const result = await this.store.query(
-      `SELECT ?agent ?key ?expiresAt WHERE {
-        GRAPH <${cgMetaGraph}> {
-          ?d <${DKG_ONTOLOGY.DKG_DELEGATION_AGENT}> ?agent ;
-             <${DKG_ONTOLOGY.DKG_ALLOWED_DELEGATEE_KEY}> ?key .
-          <${cgEntity}> (<${DKG_ONTOLOGY.DKG_ALLOWED_AGENT}>|<${DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT}>) ?memberAgent .
-          FILTER(LCASE(STR(?agent)) = LCASE(STR(?memberAgent)))
-          FILTER NOT EXISTS {
-            <${cgEntity}> <${DKG_ONTOLOGY.DKG_REVOKED_AGENT}> ?revokedAgent .
-            FILTER(LCASE(STR(?agent)) = LCASE(STR(?revokedAgent)))
-          }
-          OPTIONAL { ?d <${DKG_ONTOLOGY.DKG_DELEGATION_EXPIRES_AT}> ?expiresAt }
-        }
-      }`,
-      { signal: options.signal },
-    );
-    const out = new Map<string, string[]>();
-    if (result.type !== 'bindings') return out;
-    const strip = (raw: unknown): string => {
-      if (typeof raw !== 'string') return '';
-      return raw.replace(/^"/, '').replace(/"(@[a-zA-Z-]+|\^\^<[^>]+>)?$/, '');
-    };
-    const nowMs = Date.now();
-    for (const row of result.bindings) {
-      const agent = strip(row['agent']).toLowerCase();
-      const key = strip(row['key']).toLowerCase();
-      if (!agent || !key) continue;
-      const expiresStr = strip(row['expiresAt']);
-      if (expiresStr) {
-        const expiresAt = Number(expiresStr);
-        if (Number.isFinite(expiresAt) && expiresAt > 0 && expiresAt < nowMs) continue;
-      }
-      const list = out.get(agent) ?? [];
-      if (!list.includes(key)) list.push(key);
-      out.set(agent, list);
-    }
-    return out;
+    const meta = await this.getCgMeta(contextGraphId, { signal: options.signal });
+    return collectProjectedDelegatees(meta, 'allowedKeys', (value) => value.toLowerCase());
   }
 
   hasLocalAgentInGate(this: DKGAgent, agentGateAddresses: readonly string[]): boolean {

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -6,8 +6,16 @@ import {
   sparqlString,
   validateSubGraphName,
   contextGraphCatalogUri,
+  createGraphKnowledgeAssetScope,
+  knowledgeAssetLayerGraphUri,
 } from '@origintrail-official/dkg-core';
-import type { QueryOptions, TripleStore, ChangelogReader, ChangeOp } from '@origintrail-official/dkg-storage';
+import {
+  StoreResponseTooLargeError,
+  type QueryOptions,
+  type TripleStore,
+  type ChangelogReader,
+  type ChangeOp,
+} from '@origintrail-official/dkg-storage';
 import { isSharedMemoryBucketDescendantDataGraph } from '../shared-memory-graphs.js';
 import type { SyncRow, SyncRowListMemo } from './snapshot-cache.js';
 import {
@@ -39,6 +47,11 @@ const DKG_SHARE_OPERATION_ID = `${DKG}shareOperationId`;
 const DKG_ASSERTION_GRAPH = `${DKG}assertionGraph`;
 const DKG_ASSERTION_NAME = `${DKG}assertionName`;
 const DKG_MEMORY_LAYER = `${DKG}memoryLayer`;
+const DKG_CONTEXT_GRAPH = `${DKG}contextGraph`;
+const DKG_PUBLIC_TRIPLE_COUNT = `${DKG}publicTripleCount`;
+const DKG_PRIVATE_TRIPLE_COUNT = `${DKG}privateTripleCount`;
+const DKG_STATUS = `${DKG}status`;
+const DKG_SUB_GRAPH_NAME = `${DKG}subGraphName`;
 const DKG_PART_OF = `${DKG}partOf`;
 const DKG_BATCH_ID = `${DKG}batchId`;
 const SCHEMA_NAME = 'http://schema.org/name';
@@ -90,9 +103,31 @@ interface ExactGraphPagePlanEntry {
   rowCount: number;
 }
 
+interface ConfirmedGraphScopedVmManifestEntry extends ExactGraphPagePlanEntry {
+  ual: string;
+}
+
+interface GraphScopedVmManifest {
+  confirmedEntries: readonly ConfirmedGraphScopedVmManifestEntry[];
+  confirmedGraphs: ReadonlySet<string>;
+  /** Complete V2 descriptors in any lifecycle state, used to reject tentative VM payloads. */
+  knownGraphs: ReadonlySet<string>;
+}
+
 interface ExactGraphPagePlan {
   entries: readonly ExactGraphPagePlanEntry[];
   totalRows: number;
+  /** At most one exact graph is retained while an oversized phase is framed. */
+  activeGraphRows?: {
+    graph: string;
+    rows: readonly SyncRow[];
+  };
+  activeGraphRowsLoad?: {
+    graph: string;
+    promise: Promise<readonly SyncRow[] | null>;
+  };
+  /** Graphs that exceeded the bounded local snapshot and require ordered paging. */
+  pagedGraphs: Set<string>;
 }
 
 export interface ExactGraphPagePlanMemo {
@@ -542,6 +577,14 @@ export async function readDurableMetaPage(params: {
     params.offset,
     params.limit,
     params.signal,
+    cache
+      ? () => readBoundedDurableMetaSnapshot(
+        params.store,
+        params.contextGraphId,
+        params.registeredSubGraphNames,
+        cache,
+      )
+      : undefined,
   );
 }
 
@@ -551,9 +594,273 @@ export async function readDurableMetaPage(params: {
 const DEFAULT_CHANGELOG_PAGE_BYTES = 4 * 1024 * 1024;
 
 /**
+ * Read the constant-size V2 control rows that already form a per-KA manifest.
+ *
+ * The payload graph and its row count are authenticated again by the requester,
+ * but deriving the responder plan from these rows removes three store-wide or
+ * per-graph discovery operations from the normal rootless path: graph-family
+ * enumeration as authority, child-prefix probing after the reserved VM segment,
+ * and COUNT(*)/countQuads for every KA. The query is deliberately one exact
+ * metadata graph, standard SPARQL 1.1, unordered, row/response bounded, and
+ * backend-neutral.
+ */
+async function readGraphScopedVmManifest(
+  store: TripleStore,
+  contextGraphId: string,
+  signal?: AbortSignal,
+): Promise<GraphScopedVmManifest> {
+  const metaGraph = contextGraphMetaGraphUri(contextGraphId);
+  const contextGraph = contextGraphDataGraphUri(contextGraphId);
+  const maxRows = SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_ROWS;
+  const readBoundedBindings = async (
+    sparql: string,
+    operation: string,
+  ): Promise<Array<Record<string, string>>> => {
+    let result;
+    try {
+      result = await store.query(sparql, {
+        ...syncResponderStoreOptions(signal, operation),
+        maxResponseBytes: snapshotResponseByteLimit(
+          SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_BYTES_ESTIMATE,
+        ),
+      });
+    } catch (error) {
+      if (!(error instanceof StoreResponseTooLargeError)) throw error;
+      throw snapshotBudgetError({
+        key: `durable-v2-manifest:${contextGraphId}`,
+        reason: 'snapshot_bytes',
+        rows: 0,
+        bytesEstimate: typeof error.actualBytes === 'bigint'
+          ? Number(error.actualBytes > BigInt(Number.MAX_SAFE_INTEGER)
+            ? BigInt(Number.MAX_SAFE_INTEGER)
+            : error.actualBytes)
+          : error.actualBytes,
+        limit: SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_BYTES_ESTIMATE,
+      });
+    }
+    if (result.type !== 'bindings') return [];
+    if (result.bindings.length > maxRows) {
+      throw snapshotBudgetError({
+        key: `durable-v2-manifest:${contextGraphId}`,
+        reason: 'snapshot_rows',
+        rows: result.bindings.length,
+        bytesEstimate: 0,
+        limit: maxRows,
+      });
+    }
+    return result.bindings;
+  };
+
+  // Read every scope marker independently of the complete descriptor join.
+  // Without this pass, a partially written V2 descriptor would be absent from
+  // the join below and its payload graph could incorrectly fall through the
+  // legacy compatibility lane.
+  const markerBindings = await readBoundedBindings(`
+    SELECT ?ual ?scopeVersion WHERE {
+      GRAPH <${assertSafeIri(metaGraph)}> {
+        ?ual <${DKG_CONTENT_SCOPE_VERSION}> ?scopeVersion .
+      }
+    }
+    LIMIT ${maxRows + 1}
+  `, 'sync.responder.readGraphScopedVmManifestMarkers');
+  const scopeVersionsByUal = new Map<string, Set<string>>();
+  for (const row of markerBindings) {
+    const ual = row['ual'];
+    const rawVersion = row['scopeVersion'];
+    if (!ual || !rawVersion) continue;
+    const versions = scopeVersionsByUal.get(ual) ?? new Set<string>();
+    versions.add(stripLiteral(rawVersion));
+    scopeVersionsByUal.set(ual, versions);
+  }
+  const currentV2Uals = new Set<string>();
+  for (const [ual, versions] of scopeVersionsByUal) {
+    if (versions.size !== 1) {
+      throw new Error(`Rootless sync manifest ${ual} has ambiguous scopeVersion`);
+    }
+    const decoded = [...versions][0]!;
+    if (!/^-?\d+$/.test(decoded)) {
+      throw new Error(`Rootless sync manifest ${ual} has invalid scopeVersion: ${decoded}`);
+    }
+    const version = BigInt(decoded);
+    if (version < 0n || version.toString() !== decoded) {
+      throw new Error(`Rootless sync manifest ${ual} has non-canonical scopeVersion: ${decoded}`);
+    }
+    if (version === 0n || version === 1n) continue;
+    if (version !== BigInt(GRAPH_KA_CONTENT_SCOPE_VERSION)) {
+      throw new Error(`Rootless sync manifest ${ual} has unsupported contentScopeVersion ${decoded}`);
+    }
+    currentV2Uals.add(ual);
+  }
+
+  const bindings = await readBoundedBindings(`
+      SELECT ?ual ?scopeVersion ?kaUal ?assertionVersion ?assertionGraph
+             ?contextGraph ?publicTripleCount ?privateTripleCount ?status ?subGraphName
+      WHERE {
+        GRAPH <${assertSafeIri(metaGraph)}> {
+          ?ual <${DKG_CONTENT_SCOPE_VERSION}> ?scopeVersion ;
+               <${DKG_KA_UAL}> ?kaUal ;
+               <${DKG_ASSERTION_VERSION}> ?assertionVersion ;
+               <${DKG_ASSERTION_GRAPH}> ?assertionGraph ;
+               <${DKG_CONTEXT_GRAPH}> ?contextGraph ;
+               <${DKG_PUBLIC_TRIPLE_COUNT}> ?publicTripleCount ;
+               <${DKG_PRIVATE_TRIPLE_COUNT}> ?privateTripleCount ;
+               <${DKG_STATUS}> ?status .
+          OPTIONAL { ?ual <${DKG_SUB_GRAPH_NAME}> ?subGraphName }
+        }
+      }
+      LIMIT ${maxRows + 1}
+  `, 'sync.responder.readGraphScopedVmManifest');
+
+  type ManifestField =
+    | 'scopeVersion'
+    | 'kaUal'
+    | 'assertionVersion'
+    | 'assertionGraph'
+    | 'contextGraph'
+    | 'publicTripleCount'
+    | 'privateTripleCount'
+    | 'status'
+    | 'subGraphName';
+  const fields: readonly ManifestField[] = [
+    'scopeVersion',
+    'kaUal',
+    'assertionVersion',
+    'assertionGraph',
+    'contextGraph',
+    'publicTripleCount',
+    'privateTripleCount',
+    'status',
+    'subGraphName',
+  ];
+  const byUal = new Map<string, Map<ManifestField, Set<string>>>();
+  for (const row of bindings) {
+    const ual = row['ual'];
+    if (!ual) continue;
+    const values = byUal.get(ual) ?? new Map<ManifestField, Set<string>>();
+    for (const field of fields) {
+      const value = row[field];
+      if (!value) continue;
+      const set = values.get(field) ?? new Set<string>();
+      set.add(value);
+      values.set(field, set);
+    }
+    byUal.set(ual, values);
+  }
+  for (const ual of currentV2Uals) {
+    if (!byUal.has(ual)) {
+      throw new Error(`Rootless sync manifest ${ual} has an incomplete V2 descriptor`);
+    }
+  }
+
+  const confirmedEntries: ConfirmedGraphScopedVmManifestEntry[] = [];
+  const knownGraphs = new Set<string>();
+  const graphOwners = new Map<string, string>();
+  for (const [ual, values] of byUal) {
+    if (!currentV2Uals.has(ual)) continue;
+    const requireSingle = (field: ManifestField): string => {
+      const candidates = [...(values.get(field) ?? [])];
+      if (candidates.length !== 1) {
+        throw new Error(
+          `Rootless sync manifest ${ual} has ${candidates.length === 0 ? 'missing' : 'ambiguous'} ${field}`,
+        );
+      }
+      return candidates[0]!;
+    };
+    const optionalSingle = (field: ManifestField): string | undefined => {
+      const candidates = [...(values.get(field) ?? [])];
+      if (candidates.length > 1) {
+        throw new Error(`Rootless sync manifest ${ual} has ambiguous ${field}`);
+      }
+      return candidates[0];
+    };
+    const parseCanonicalInteger = (field: ManifestField, minimum: bigint): bigint => {
+      const decoded = stripLiteral(requireSingle(field));
+      if (!/^-?\d+$/.test(decoded)) {
+        throw new Error(`Rootless sync manifest ${ual} has invalid ${field}: ${decoded}`);
+      }
+      const value = BigInt(decoded);
+      if (value < minimum || value.toString() !== decoded) {
+        throw new Error(`Rootless sync manifest ${ual} has non-canonical ${field}: ${decoded}`);
+      }
+      return value;
+    };
+
+    const scopeVersion = parseCanonicalInteger('scopeVersion', 0n);
+    if (scopeVersion !== BigInt(GRAPH_KA_CONTENT_SCOPE_VERSION)) {
+      throw new Error(`Rootless sync manifest ${ual} changed scopeVersion during projection`);
+    }
+    const metadataUal = requireSingle('kaUal');
+    if (metadataUal !== ual) {
+      throw new Error(`Rootless sync manifest UAL mismatch: subject ${ual}, kaUal ${metadataUal}`);
+    }
+    const assertionVersion = parseCanonicalInteger('assertionVersion', 1n);
+    const scope = createGraphKnowledgeAssetScope(ual, assertionVersion);
+    if (scope.ual !== ual) {
+      throw new Error(`Rootless sync manifest contains non-canonical UAL ${ual}`);
+    }
+    if (requireSingle('contextGraph') !== contextGraph) {
+      throw new Error(`Rootless sync manifest ${ual} points outside context graph ${contextGraphId}`);
+    }
+    const rawSubGraphName = optionalSingle('subGraphName');
+    const subGraphName = rawSubGraphName === undefined
+      ? undefined
+      : stripLiteral(rawSubGraphName);
+    if (subGraphName !== undefined && !validateSubGraphName(subGraphName).valid) {
+      throw new Error(`Rootless sync manifest ${ual} has invalid subGraphName ${subGraphName}`);
+    }
+    const expectedGraph = knowledgeAssetLayerGraphUri(
+      contextGraphId,
+      MemoryLayer.VerifiableMemory,
+      scope,
+      subGraphName,
+    );
+    const assertionGraph = requireSingle('assertionGraph');
+    if (assertionGraph !== expectedGraph) {
+      throw new Error(
+        `Rootless sync manifest ${ual} assertionGraph mismatch: expected ${expectedGraph}, found ${assertionGraph}`,
+      );
+    }
+    const publicCount = parseCanonicalInteger('publicTripleCount', 0n);
+    const privateCount = parseCanonicalInteger('privateTripleCount', 0n);
+    if (publicCount > BigInt(Number.MAX_SAFE_INTEGER) || privateCount > BigInt(Number.MAX_SAFE_INTEGER)) {
+      throw new Error(`Rootless sync manifest ${ual} has an unsafe triple count`);
+    }
+    if (publicCount === 0n && privateCount === 0n) {
+      throw new Error(`Rootless sync manifest ${ual} describes an empty asset`);
+    }
+    const owner = graphOwners.get(assertionGraph);
+    if (owner && owner !== ual) {
+      throw new Error(`Rootless sync graph ${assertionGraph} has multiple UAL owners`);
+    }
+    graphOwners.set(assertionGraph, ual);
+    knownGraphs.add(assertionGraph);
+
+    const statuses = new Set(
+      [...(values.get('status') ?? [])].map((status) => stripLiteral(status)),
+    );
+    if (statuses.size !== 1) {
+      throw new Error(`Rootless sync manifest ${ual} has ambiguous status metadata`);
+    }
+    if (!statuses.has('confirmed')) continue;
+    confirmedEntries.push({
+      ual,
+      graph: assertionGraph,
+      rowCount: Number(publicCount),
+    });
+  }
+  confirmedEntries.sort((a, b) => compareCodePoint(a.graph, b.graph));
+  return {
+    confirmedEntries,
+    confirmedGraphs: new Set(confirmedEntries.map((entry) => entry.graph)),
+    knownGraphs,
+  };
+}
+
+/**
  * The per-CG admission boundary shared by the durable-data phase and the
  * changelog delta lane: the candidate-graph exclusions (wrong CG / top or
- * first-level subgraph `_meta` / `/_shared_memory*` / `/_private`) and the
+ * first-level subgraph `_meta` / transient WM / `/_shared_memory*` /
+ * `/_private`) and the
  * RFC-49 `isAdmitted` gate
  * (assertion-graph membership + child-CG descendant rejection). `assertionGraphs`
  * is memoised per invocation, matching the original inline closure.
@@ -566,7 +873,10 @@ function createAdmissionContext(
   // serves data AND meta in ONE delta stream, so it must INCLUDE topMeta —
   // otherwise a public CG routed to changelog-only never converges its top-level
   // metadata (OT-RFC-59 review 🔴 3594). SWM (own phase) and `/_private` stay out.
-  opts: { includeTopMeta?: boolean } = {},
+  opts: {
+    includeTopMeta?: boolean;
+    graphScopedVmManifest?: GraphScopedVmManifest;
+  } = {},
 ): {
   cgPrefix: string;
   topMetaGraph: string;
@@ -587,17 +897,27 @@ function createAdmissionContext(
       ? graph.slice(cgPrefix.length + 1)
       : '';
     if (relative.split('/').length === 2 && relative.endsWith('/_meta')) return false;
-    // SWM graphs are the dedicated SWM phase's exclusive domain; `/_private` is
-    // never durable-served (see readDurableDataPage's original inline note).
-    if (graph.includes('/_shared_memory')) return false;
-    return !graph.includes('/_private');
+    const segments = relative.split('/').filter(Boolean);
+    // Working memory is transient and has no durable metadata anchor (the
+    // durable-meta phase deliberately excludes memoryLayer=WM). Serving an
+    // orphan or abandoned WM graph here therefore creates unverifiable payload
+    // and, on real stores, can sort millions of unrelated draft rows. SWM has a
+    // dedicated phase and private graphs are never served by durable sync.
+    if (segments.includes('_working_memory')) return false;
+    if (segments.includes('_shared_memory') || segments.includes('_shared_memory_meta')) return false;
+    return !segments.includes('_private');
   };
   let assertionGraphs: Set<string> | null = null;
   const isAdmitted = (signal?: AbortSignal) => async (graph: string): Promise<boolean> => {
+    const graphWithoutMeta = graph.endsWith('/_meta')
+      ? graph.slice(0, -'/_meta'.length)
+      : graph;
+    if (opts.graphScopedVmManifest?.knownGraphs.has(graphWithoutMeta)) {
+      if (!opts.graphScopedVmManifest.confirmedGraphs.has(graphWithoutMeta)) return false;
+    }
     if (graph.includes('/assertion/')) {
       assertionGraphs ??= await readAdmittedAssertionGraphs(store, contextGraphId, signal);
-      const assertionGraph = graph.endsWith('/_meta') ? graph.slice(0, -'/_meta'.length) : graph;
-      if (!assertionGraphs.has(assertionGraph)) return false;
+      if (!assertionGraphs.has(graphWithoutMeta)) return false;
     }
     return !(await isDescendantOfKnownChildContextGraph(store, cgPrefix, graph, signal));
   };
@@ -652,8 +972,15 @@ export async function readChangelogDeltaPage(params: {
   // DATA phase — it INCLUDES the top-level `_meta` graph (the requester applies meta
   // as a trusted anchor, legacy-parity), so a changelog-only public CG converges its
   // top-level metadata rather than silently skipping it.
+  const graphScopedVmManifest = await readGraphScopedVmManifest(
+    params.store,
+    params.contextGraphId,
+    params.signal,
+  );
   const { isCandidateGraph, isAdmitted } = createAdmissionContext(
-    params.store, params.contextGraphId, { includeTopMeta: true },
+    params.store,
+    params.contextGraphId,
+    { includeTopMeta: true, graphScopedVmManifest },
   );
   const lastOp = new Map<string, { seq: number; op: ChangeOp }>();
   for (const r of raw) {
@@ -727,32 +1054,81 @@ export async function readDurableDataPage(params: {
   refreshGeneration?: string;
   exactGraphPlanMemo?: ExactGraphPagePlanMemo;
 }): Promise<SyncRow[]> {
-  // Admission context (candidate exclusions + RFC-49 `isAdmitted`) — extracted to
-  // a module factory so `readChangelogDeltaPage` reuses it verbatim. Behaviour
-  // here is byte-identical to the previous inline closures.
-  const { cgPrefix, topMetaGraph, isCandidateGraph, isAdmitted } =
-    createAdmissionContext(params.store, params.contextGraphId);
-  const candidateGraphs = params.graphList.filter(isCandidateGraph).sort(compareCodePoint);
+  const cache = params.rowListMemo
+    ? {
+      memo: params.rowListMemo,
+      key: durableDataRowListCacheKey(
+        params.rowListCacheScope ?? 'default',
+        params.contextGraphId,
+        params.sinceBatchId,
+      ),
+      refresh: params.refreshRowList,
+      refreshGeneration: params.refreshGeneration,
+    }
+    : undefined;
 
   if (params.sinceBatchId == null) {
-    return readPagedRowsAcrossGraphs(
+    return readPagedRowsFromExactGraphPlanLoader(
       params.store,
-      candidateGraphs,
       params.offset,
       params.limit,
-      isAdmitted(params.rowListMemo ? undefined : params.signal),
-      params.rowListMemo
-        ? {
-          memo: params.rowListMemo,
-          key: durableDataRowListCacheKey(params.rowListCacheScope ?? 'default', params.contextGraphId, params.sinceBatchId),
-          refresh: params.refreshRowList,
-          refreshGeneration: params.refreshGeneration,
-        }
-        : undefined,
+      cache,
       params.signal,
       params.exactGraphPlanMemo,
+      async (planSignal) => {
+        const manifest = await readGraphScopedVmManifest(
+          params.store,
+          params.contextGraphId,
+          planSignal,
+        );
+        const { isCandidateGraph, isAdmitted } = createAdmissionContext(
+          params.store,
+          params.contextGraphId,
+          { graphScopedVmManifest: manifest },
+        );
+        // A just-committed exact graph may precede a stale external graph-list
+        // cache. Include every confirmed non-empty manifest graph explicitly;
+        // the count-vs-read invariant below will fail closed if its payload is
+        // absent or raced. The legacy list remains only as the compatibility
+        // source for pre-V2 graphs and non-KA durable partitions.
+        const candidateGraphs = dedupeStrings([
+          ...params.graphList.filter(isCandidateGraph),
+          ...manifest.confirmedEntries
+            .filter((entry) => entry.rowCount > 0)
+            .map((entry) => entry.graph),
+        ]).sort(compareCodePoint);
+        const knownRowCounts = new Map(
+          manifest.confirmedEntries.map((entry) => [entry.graph, entry.rowCount]),
+        );
+        return buildExactGraphPagePlan(
+          params.store,
+          candidateGraphs,
+          isAdmitted(params.rowListMemo ? undefined : planSignal),
+          planSignal,
+          knownRowCounts,
+        );
+      },
     );
   }
+
+  // The batch-id lane is legacy compatibility. Still load the V2 manifest for
+  // admission so tentative V2 graphs cannot fall through as legacy payload;
+  // OT-RFC-59 changelog is the scalable incremental lane for rootless KAs.
+  const manifest = await readGraphScopedVmManifest(
+    params.store,
+    params.contextGraphId,
+    params.signal,
+  );
+  const { cgPrefix, topMetaGraph, isCandidateGraph, isAdmitted } =
+    createAdmissionContext(params.store, params.contextGraphId, {
+      graphScopedVmManifest: manifest,
+    });
+  const candidateGraphs = dedupeStrings([
+    ...params.graphList.filter(isCandidateGraph),
+    ...manifest.confirmedEntries
+      .filter((entry) => entry.rowCount > 0)
+      .map((entry) => entry.graph),
+  ]).sort(compareCodePoint);
 
   const graphs: string[] = [];
   const isAdmittedForRequest = isAdmitted(params.signal);
@@ -773,14 +1149,7 @@ export async function readDurableDataPage(params: {
     params.sinceBatchId,
     params.offset,
     params.limit,
-    params.rowListMemo
-      ? {
-        memo: params.rowListMemo,
-        key: durableDataRowListCacheKey(params.rowListCacheScope ?? 'default', params.contextGraphId, params.sinceBatchId),
-        refresh: params.refreshRowList,
-        refreshGeneration: params.refreshGeneration,
-      }
-      : undefined,
+    cache,
     params.signal,
   );
 }
@@ -816,6 +1185,33 @@ async function readPagedRowsAcrossGraphs(
   cache?: RowListCache,
   signal?: AbortSignal,
   planMemo?: ExactGraphPagePlanMemo,
+  knownRowCounts?: ReadonlyMap<string, number>,
+): Promise<SyncRow[]> {
+  return readPagedRowsFromExactGraphPlanLoader(
+    store,
+    offset,
+    limit,
+    cache,
+    signal,
+    planMemo,
+    (planSignal) => buildExactGraphPagePlan(
+      store,
+      graphs,
+      isAdmitted,
+      planSignal,
+      knownRowCounts,
+    ),
+  );
+}
+
+async function readPagedRowsFromExactGraphPlanLoader(
+  store: TripleStore,
+  offset: number,
+  limit: number,
+  cache: RowListCache | undefined,
+  signal: AbortSignal | undefined,
+  planMemo: ExactGraphPagePlanMemo | undefined,
+  loadExactGraphPlan: (signal?: AbortSignal) => Promise<ExactGraphPagePlan>,
 ): Promise<SyncRow[]> {
   // A small snapshot is first assembled into the row cache. If that build
   // crosses its cap, readResponderRowsPage immediately retries page zero via
@@ -823,13 +1219,16 @@ async function readPagedRowsAcrossGraphs(
   // that fallback reuses the exact graph/count plan instead of counting every
   // graph twice.
   let planRefreshPending = cache?.refresh === true;
-  const loadPage: StorePageLoader = async (pageOffset, pageLimit, pageSignal) => {
-    const loadPlan = () => buildExactGraphPagePlan(
-      store,
-      graphs,
-      isAdmitted,
-      pageSignal,
-    );
+  const rowSnapshotLimits = cache?.memo.snapshotLoadLimits ?? {
+    maxRows: SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_ROWS,
+    maxBytesEstimate: SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_BYTES_ESTIMATE,
+    pageRows: SYNC_RESPONDER_SNAPSHOT_BUILD_PAGE_ROWS,
+  };
+  const getPlan = async (
+    pageOffset: number,
+    pageSignal: AbortSignal | undefined,
+  ): Promise<ExactGraphPagePlan> => {
+    const loadPlan = () => loadExactGraphPlan(pageSignal);
     const refreshPlan = pageOffset === 0 && planRefreshPending;
     if (refreshPlan) planRefreshPending = false;
     const plan = planMemo && cache
@@ -842,7 +1241,18 @@ async function readPagedRowsAcrossGraphs(
     if (!plan) {
       throw new Error('Sync session exact-graph plan expired before page completion');
     }
-    return readRowsPageFromExactGraphPlan(store, plan, pageOffset, pageLimit, pageSignal);
+    return plan;
+  };
+  const loadPage: StorePageLoader = async (pageOffset, pageLimit, pageSignal) => {
+    const plan = await getPlan(pageOffset, pageSignal);
+    return readRowsPageFromExactGraphPlan(
+      store,
+      plan,
+      pageOffset,
+      pageLimit,
+      rowSnapshotLimits,
+      pageSignal,
+    );
   };
   return readResponderRowsPage(
     cache && {
@@ -853,6 +1263,14 @@ async function readPagedRowsAcrossGraphs(
     offset,
     limit,
     signal,
+    cache
+      ? async () => readExactGraphPlanSnapshot(
+        store,
+        await getPlan(0, undefined),
+        cache,
+        rowSnapshotLimits,
+      )
+      : undefined,
   );
 }
 
@@ -861,12 +1279,13 @@ async function buildExactGraphPagePlan(
   graphs: readonly string[],
   isAdmitted: (graph: string) => Promise<boolean>,
   signal?: AbortSignal,
+  knownRowCounts?: ReadonlyMap<string, number>,
 ): Promise<ExactGraphPagePlan> {
   const entries: ExactGraphPagePlanEntry[] = [];
   for (const graph of dedupeStrings(graphs).sort(compareCodePoint)) {
     throwIfAborted(signal);
     if (!(await isAdmitted(graph))) continue;
-    const rowCount = await store.countQuads(
+    const rowCount = knownRowCounts?.get(graph) ?? await store.countQuads(
       graph,
       syncResponderStoreOptions(signal, 'sync.responder.countExactGraphRows'),
     );
@@ -875,7 +1294,146 @@ async function buildExactGraphPagePlan(
   return {
     entries,
     totalRows: entries.reduce((sum, entry) => sum + entry.rowCount, 0),
+    pagedGraphs: new Set<string>(),
   };
+}
+
+interface ExactGraphSnapshotLimits {
+  maxRows: number;
+  maxBytesEstimate: number;
+}
+
+function snapshotResponseByteLimit(maxBytesEstimate: number): number {
+  // SPARQL JSON adds field names and escaping around each RDF term. Bound the
+  // transport body independently while leaving enough headroom for that wire
+  // overhead. HTTP adapters enforce this before parsing; embedded adapters are
+  // still bounded by the row LIMIT below.
+  return Math.max(
+    1,
+    Math.min(Number.MAX_SAFE_INTEGER, Math.floor(maxBytesEstimate) * 2),
+  );
+}
+
+function snapshotBudgetError(params: {
+  key: string;
+  reason: 'snapshot_rows' | 'snapshot_bytes';
+  rows: number;
+  bytesEstimate: number;
+  limit: number;
+}): SyncRowSnapshotBudgetError {
+  return new SyncRowSnapshotBudgetError(params);
+}
+
+async function loadExactGraphRowsSnapshot(
+  store: TripleStore,
+  plan: ExactGraphPagePlan,
+  entry: ExactGraphPagePlanEntry,
+  limits: ExactGraphSnapshotLimits,
+  signal?: AbortSignal,
+): Promise<readonly SyncRow[] | null> {
+  if (entry.rowCount > limits.maxRows || plan.pagedGraphs.has(entry.graph)) return null;
+  if (plan.activeGraphRows?.graph === entry.graph) return plan.activeGraphRows.rows;
+  if (plan.activeGraphRowsLoad?.graph === entry.graph) {
+    return raceAgainstAbort(plan.activeGraphRowsLoad.promise, signal);
+  }
+
+  const load = (async (): Promise<readonly SyncRow[] | null> => {
+    try {
+      const result = await store.query(`
+        SELECT ?s ?p ?o WHERE {
+          GRAPH <${assertSafeIri(entry.graph)}> { ?s ?p ?o }
+        }
+        LIMIT ${limits.maxRows + 1}
+      `, {
+        ...syncResponderStoreOptions(undefined, 'sync.responder.readExactGraphSnapshot'),
+        maxResponseBytes: snapshotResponseByteLimit(limits.maxBytesEstimate),
+      });
+      if (result.type !== 'bindings') return [];
+      const rows: SyncRow[] = [];
+      let bytesEstimate = 0;
+      for (const row of result.bindings) {
+        const s = row['s'];
+        const p = row['p'];
+        const o = row['o'];
+        if (!s || !p || !o) continue;
+        const nextBytes = bytesEstimate + estimateStringRowHeapBytes(s, p, o, entry.graph);
+        if (rows.length + 1 > limits.maxRows || nextBytes > limits.maxBytesEstimate) {
+          plan.pagedGraphs.add(entry.graph);
+          return null;
+        }
+        rows.push({ s, p, o, g: entry.graph });
+        bytesEstimate = nextBytes;
+      }
+      // The plan count and payload must describe one immutable graph snapshot.
+      // A mismatch means the graph changed between COUNT and SELECT; fail the
+      // session rather than silently skipping or duplicating rows.
+      if (rows.length !== entry.rowCount) {
+        throw new Error(
+          `Sync exact-graph plan changed while reading ${entry.graph}: ` +
+          `expected ${entry.rowCount} rows, found ${rows.length}`,
+        );
+      }
+      rows.sort(compareRows);
+      plan.activeGraphRows = { graph: entry.graph, rows };
+      return rows;
+    } catch (error) {
+      if (error instanceof StoreResponseTooLargeError) {
+        plan.pagedGraphs.add(entry.graph);
+        return null;
+      }
+      throw error;
+    }
+  })().finally(() => {
+    if (plan.activeGraphRowsLoad?.promise === load) plan.activeGraphRowsLoad = undefined;
+  });
+  plan.activeGraphRowsLoad = { graph: entry.graph, promise: load };
+  return raceAgainstAbort(load, signal);
+}
+
+async function readExactGraphPlanSnapshot(
+  store: TripleStore,
+  plan: ExactGraphPagePlan,
+  cache: RowListCache,
+  limits: ExactGraphSnapshotLimits,
+): Promise<readonly SyncRow[]> {
+  if (plan.totalRows > limits.maxRows) {
+    throw snapshotBudgetError({
+      key: cache.key,
+      reason: 'snapshot_rows',
+      rows: plan.totalRows,
+      bytesEstimate: 0,
+      limit: limits.maxRows,
+    });
+  }
+  const rows: SyncRow[] = [];
+  let bytesEstimate = 0;
+  for (const entry of plan.entries) {
+    const graphRows = await loadExactGraphRowsSnapshot(store, plan, entry, limits);
+    if (!graphRows) {
+      throw snapshotBudgetError({
+        key: cache.key,
+        reason: 'snapshot_bytes',
+        rows: rows.length,
+        bytesEstimate: limits.maxBytesEstimate + 1,
+        limit: limits.maxBytesEstimate,
+      });
+    }
+    for (const row of graphRows) {
+      const nextBytes = bytesEstimate + estimateStringRowHeapBytes(row.s, row.p, row.o, row.g);
+      if (nextBytes > limits.maxBytesEstimate) {
+        throw snapshotBudgetError({
+          key: cache.key,
+          reason: 'snapshot_bytes',
+          rows: rows.length + 1,
+          bytesEstimate: nextBytes,
+          limit: limits.maxBytesEstimate,
+        });
+      }
+      rows.push(row);
+      bytesEstimate = nextBytes;
+    }
+  }
+  return rows.sort(compareRows);
 }
 
 async function readRowsPageFromExactGraphPlan(
@@ -883,6 +1441,7 @@ async function readRowsPageFromExactGraphPlan(
   plan: ExactGraphPagePlan,
   offset: number,
   limit: number,
+  snapshotLimits: ExactGraphSnapshotLimits,
   signal?: AbortSignal,
 ): Promise<SyncRow[]> {
   let skip = Math.max(0, Math.floor(offset));
@@ -894,23 +1453,39 @@ async function readRowsPageFromExactGraphPlan(
       skip -= entry.rowCount;
       continue;
     }
-    const result = await store.query(`
-      SELECT ?s ?p ?o WHERE {
-        GRAPH <${assertSafeIri(entry.graph)}> { ?s ?p ?o }
-      }
-      ORDER BY ?s ?p ?o
-      OFFSET ${skip}
-      LIMIT ${remaining}
-    `, syncResponderStoreOptions(signal, 'sync.responder.readExactGraphRowsPage'));
     let added = 0;
-    if (result.type === 'bindings') {
-      for (const row of result.bindings) {
-        const s = row['s'];
-        const p = row['p'];
-        const o = row['o'];
-        if (s && p && o) {
-          rows.push({ s, p, o, g: entry.graph });
-          added += 1;
+    const graphRows = await loadExactGraphRowsSnapshot(
+      store,
+      plan,
+      entry,
+      snapshotLimits,
+      signal,
+    );
+    if (graphRows) {
+      const page = graphRows.slice(skip, skip + remaining);
+      rows.push(...page);
+      added = page.length;
+    } else {
+      const result = await store.query(`
+        SELECT ?s ?p ?o WHERE {
+          GRAPH <${assertSafeIri(entry.graph)}> { ?s ?p ?o }
+        }
+        ORDER BY ?s ?p ?o
+        OFFSET ${skip}
+        LIMIT ${remaining}
+      `, {
+        ...syncResponderStoreOptions(signal, 'sync.responder.readExactGraphRowsPage'),
+        maxResponseBytes: snapshotResponseByteLimit(snapshotLimits.maxBytesEstimate),
+      });
+      if (result.type === 'bindings') {
+        for (const row of result.bindings) {
+          const s = row['s'];
+          const p = row['p'];
+          const o = row['o'];
+          if (s && p && o) {
+            rows.push({ s, p, o, g: entry.graph });
+            added += 1;
+          }
         }
       }
     }
@@ -1047,6 +1622,7 @@ async function readResponderRowsPage(
   offset: number,
   limit: number,
   signal?: AbortSignal,
+  loadSnapshot?: () => Promise<readonly SyncRow[]>,
 ): Promise<SyncRow[]> {
   const safeOffset = Math.max(0, Math.floor(offset));
   const safeLimit = Math.max(0, Math.floor(limit));
@@ -1055,7 +1631,7 @@ async function readResponderRowsPage(
   try {
     return await readCachedRowsPage(
       cache,
-      () => loadStorePagedSnapshot(cache, loadStoreBoundedPage),
+      loadSnapshot ?? (() => loadStorePagedSnapshot(cache, loadStoreBoundedPage)),
       safeOffset,
       safeLimit,
       signal,
@@ -1201,6 +1777,22 @@ async function isDescendantOfKnownChildContextGraph(
   const remainder = graph.slice(cgPrefix.length + 1);
   const segments = remainder.split('/').filter(Boolean);
   if (isParentOwnedReservedGraphSegments(segments)) return false;
+
+  // A KA layer segment is a namespace boundary, not a possible child-CG name.
+  // Only prefixes BEFORE it can own the graph. The previous generic walk also
+  // ASKed the full graph and every publisher/KA-id suffix (including the full
+  // graph twice), multiplying a 50-KA bootstrap into roughly 200 pointless
+  // metadata probes. Top-level VM therefore needs zero ASK calls; a VM under a
+  // named subgraph needs only the one ownership check for that subgraph prefix.
+  const vmBoundary = segments.indexOf('_verifiable_memory');
+  if (vmBoundary >= 0) {
+    let possibleChild = cgPrefix;
+    for (let index = 0; index < vmBoundary; index++) {
+      possibleChild = `${possibleChild}/${segments[index]}`;
+      if (await isKnownContextGraph(store, possibleChild, signal)) return true;
+    }
+    return false;
+  }
   if (await isKnownContextGraph(store, graph, signal)) return true;
   if (graph.endsWith('/_meta')) {
     const graphOwner = graph.slice(0, -'/_meta'.length);
@@ -1616,7 +2208,9 @@ async function readFreshSwmRoots(
 function buildDurableMetaRowsQuery(
   contextGraphId: string,
   registeredSubGraphNames: readonly string[],
-  page?: { offset: number; limit: number },
+  window?:
+    | { kind: 'page'; offset: number; limit: number }
+    | { kind: 'snapshot'; limit: number },
 ): string {
   const metaGraph = contextGraphMetaGraphUri(contextGraphId);
   const cgEntity = contextGraphDataGraphUri(contextGraphId);
@@ -1629,9 +2223,12 @@ function buildDurableMetaRowsQuery(
   const registeredSubGraphClause = registeredSubGraphSubjects.length
     ? `|| ?s IN (${registeredSubGraphSubjects.join(', ')})`
     : '';
-  const pagination = page
-    ? `\n    OFFSET ${Math.max(0, Math.floor(page.offset))}\n    LIMIT ${Math.max(0, Math.floor(page.limit))}`
-    : '';
+  const pagination = window?.kind === 'page'
+    ? `\n    ORDER BY ?g ?s ?p ?o\n    OFFSET ${Math.max(0, Math.floor(window.offset))}` +
+      `\n    LIMIT ${Math.max(0, Math.floor(window.limit))}`
+    : window?.kind === 'snapshot'
+      ? `\n    LIMIT ${Math.max(0, Math.floor(window.limit))}`
+      : '';
   return `
     SELECT ?g ?s ?p ?o WHERE {
       VALUES ?g { <${assertSafeIri(metaGraph)}> }
@@ -1642,6 +2239,14 @@ function buildDurableMetaRowsQuery(
         || ${activeDelegationSubjectExpression}
         ${registeredSubGraphClause}
         || STRSTARTS(STR(?s), "did:dkg:activity:")
+        || EXISTS {
+             GRAPH ?g {
+               ?s <${DKG_CONTENT_SCOPE_VERSION}> ?scopeVersion ;
+                  <${DKG_STATUS}> ${sparqlString('confirmed')} .
+             }
+             FILTER(STR(?scopeVersion) = ${sparqlString(String(GRAPH_KA_CONTENT_SCOPE_VERSION))})
+             FILTER(REGEX(STR(?s), "^did:dkg:[^/]+/0x[0-9A-Fa-f]{40}/[0-9]+$"))
+           }
         || EXISTS { GRAPH ?g { ?s <${DKG_MEMORY_LAYER}> ?ml } ${notWorking} }
         || EXISTS { GRAPH ?g { ?agLifecycle <${DKG_ASSERTION_GRAPH}> ?s ; <${DKG_MEMORY_LAYER}> ?ml } ${notWorking} }
         || EXISTS {
@@ -1659,7 +2264,7 @@ function buildDurableMetaRowsQuery(
            )
       )
     }
-    ORDER BY ?g ?s ?p ?o${pagination}
+    ${pagination}
   `;
 }
 
@@ -1667,22 +2272,30 @@ async function queryDurableMetaRows(
   store: TripleStore,
   contextGraphId: string,
   registeredSubGraphNames: readonly string[],
-  page: { offset: number; limit: number } | undefined,
+  window:
+    | { kind: 'page'; offset: number; limit: number }
+    | { kind: 'snapshot'; limit: number; maxResponseBytes: number }
+    | undefined,
   signal?: AbortSignal,
 ): Promise<SyncRow[]> {
-  if (page && Math.max(0, Math.floor(page.limit)) === 0) return [];
+  if (window && Math.max(0, Math.floor(window.limit)) === 0) return [];
   const res = await store.query(
-    buildDurableMetaRowsQuery(contextGraphId, registeredSubGraphNames, page),
-    syncResponderStoreOptions(
-      signal,
-      page ? 'sync.responder.readDurableMetaRowsPage' : 'sync.responder.readDurableMetaRows',
-    ),
+    buildDurableMetaRowsQuery(contextGraphId, registeredSubGraphNames, window),
+    {
+      ...syncResponderStoreOptions(
+        signal,
+        window?.kind === 'page'
+          ? 'sync.responder.readDurableMetaRowsPage'
+          : 'sync.responder.readDurableMetaRowsSnapshot',
+      ),
+      ...(window?.kind === 'snapshot' ? { maxResponseBytes: window.maxResponseBytes } : {}),
+    },
   );
   if (res.type !== 'bindings') return [];
   const rows = res.bindings
     .map((row) => ({ s: row['s'], p: row['p'], o: row['o'], g: row['g'] }))
     .filter((row) => row.s && row.p && row.o && row.g);
-  return page ? rows : rows.sort(compareRows);
+  return window?.kind === 'page' ? rows : rows.sort(compareRows);
 }
 
 /**
@@ -1703,6 +2316,196 @@ async function readDurableMetaRows(
     undefined,
     signal,
   );
+}
+
+async function readBoundedDurableMetaSnapshot(
+  store: TripleStore,
+  contextGraphId: string,
+  registeredSubGraphNames: readonly string[],
+  cache: RowListCache,
+): Promise<readonly SyncRow[]> {
+  const limits = cache.memo.snapshotLoadLimits ?? {
+    maxRows: SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_ROWS,
+    maxBytesEstimate: SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_BYTES_ESTIMATE,
+    pageRows: SYNC_RESPONDER_SNAPSHOT_BUILD_PAGE_ROWS,
+  };
+  const metaGraph = contextGraphMetaGraphUri(contextGraphId);
+  let rawRows: SyncRow[];
+  try {
+    const result = await store.query(`
+      SELECT ?s ?p ?o WHERE {
+        GRAPH <${assertSafeIri(metaGraph)}> { ?s ?p ?o }
+      }
+      LIMIT ${limits.maxRows + 1}
+    `, {
+      ...syncResponderStoreOptions(undefined, 'sync.responder.readDurableMetaGraphSnapshot'),
+      maxResponseBytes: snapshotResponseByteLimit(limits.maxBytesEstimate),
+    });
+    rawRows = result.type === 'bindings'
+      ? result.bindings
+        .map((row) => ({ s: row['s'], p: row['p'], o: row['o'], g: metaGraph }))
+        .filter((row): row is SyncRow => Boolean(row.s && row.p && row.o))
+      : [];
+  } catch (error) {
+    if (!(error instanceof StoreResponseTooLargeError)) throw error;
+    const actualBytes = typeof error.actualBytes === 'bigint'
+      ? Number(error.actualBytes > BigInt(Number.MAX_SAFE_INTEGER)
+        ? BigInt(Number.MAX_SAFE_INTEGER)
+        : error.actualBytes)
+      : error.actualBytes;
+    throw snapshotBudgetError({
+      key: cache.key,
+      reason: 'snapshot_bytes',
+      rows: 0,
+      bytesEstimate: actualBytes,
+      limit: limits.maxBytesEstimate,
+    });
+  }
+  if (rawRows.length > limits.maxRows) {
+    throw snapshotBudgetError({
+      key: cache.key,
+      reason: 'snapshot_rows',
+      rows: rawRows.length,
+      bytesEstimate: 0,
+      limit: limits.maxRows,
+    });
+  }
+  let bytesEstimate = 0;
+  for (const row of rawRows) {
+    bytesEstimate += estimateStringRowHeapBytes(row.s, row.p, row.o, row.g);
+    if (bytesEstimate > limits.maxBytesEstimate) {
+      throw snapshotBudgetError({
+        key: cache.key,
+        reason: 'snapshot_bytes',
+        rows: rawRows.length,
+        bytesEstimate,
+        limit: limits.maxBytesEstimate,
+      });
+    }
+  }
+  return filterDurableMetaSnapshotRows(
+    rawRows,
+    contextGraphId,
+    registeredSubGraphNames,
+  );
+}
+
+/**
+ * Canonical durable-meta admission over one already-bounded exact graph.
+ *
+ * This is deliberately the in-process twin of buildDurableMetaRowsQuery's
+ * oversized fallback predicate. Executing the nested EXISTS expression in the
+ * store caused both Oxigraph and Blazegraph planners to rescan/sort the same
+ * metadata graph for every frame. Reading that one graph once and building
+ * subject indexes is O(meta rows), backend-neutral, and retains the exact
+ * privacy boundary. sync-responder-oversized-fallback.test.ts proves set
+ * equivalence between this path and the SPARQL fallback across every branch.
+ */
+function filterDurableMetaSnapshotRows(
+  rows: readonly SyncRow[],
+  contextGraphId: string,
+  registeredSubGraphNames: readonly string[],
+): SyncRow[] {
+  const cgEntity = contextGraphDataGraphUri(contextGraphId);
+  const registeredSubjects = new Set(
+    dedupeStrings(registeredSubGraphNames)
+      .filter((name) => validateSubGraphName(name).valid)
+      .map((name) => `${cgEntity}/${name}`),
+  );
+  const bySubject = new Map<string, SyncRow[]>();
+  for (const row of rows) {
+    const bucket = bySubject.get(row.s) ?? [];
+    bucket.push(row);
+    bySubject.set(row.s, bucket);
+  }
+  const objects = (subject: string, predicate: string): string[] =>
+    (bySubject.get(subject) ?? [])
+      .filter((row) => row.p === predicate)
+      .map((row) => row.o);
+  const lowerStringValues = (subject: string, predicates: readonly string[]): Set<string> =>
+    new Set(predicates.flatMap((predicate) => objects(subject, predicate))
+      .map((value) => stripLiteral(value).toLowerCase()));
+
+  const nonWorkingSubjects = new Set<string>();
+  for (const [subject] of bySubject) {
+    if (objects(subject, DKG_MEMORY_LAYER).some(
+      (layer) => stripLiteral(layer) !== MemoryLayer.WorkingMemory,
+    )) nonWorkingSubjects.add(subject);
+  }
+
+  const admitted = new Set<string>([cgEntity, ...registeredSubjects]);
+  for (const subject of nonWorkingSubjects) admitted.add(subject);
+
+  // Rootless V2 descriptors live directly on the deterministic UAL and do not
+  // carry the legacy lifecycle memoryLayer predicate. Admit confirmed V2
+  // descriptor rows explicitly; tentative rows remain workspace-local. The
+  // requester performs the complete descriptor, graph-URI, count and Merkle
+  // validation, so a malformed confirmed marker is visible and fails closed
+  // instead of silently falling through as harmless configuration metadata.
+  for (const [subject] of bySubject) {
+    if (!/^did:dkg:[^/]+\/0x[0-9A-Fa-f]{40}\/[0-9]+$/.test(subject)) continue;
+    const versions = objects(subject, DKG_CONTENT_SCOPE_VERSION).map(stripLiteral);
+    const statuses = objects(subject, DKG_STATUS).map(stripLiteral);
+    if (
+      versions.includes(String(GRAPH_KA_CONTENT_SCOPE_VERSION)) &&
+      statuses.includes('confirmed')
+    ) admitted.add(subject);
+  }
+
+  const members = lowerStringValues(cgEntity, [
+    DKG_ONTOLOGY.DKG_ALLOWED_AGENT,
+    DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT,
+  ]);
+  const revoked = lowerStringValues(cgEntity, [DKG_ONTOLOGY.DKG_REVOKED_AGENT]);
+  const delegationPrefix = `did:dkg:agent-delegation:${contextGraphId}:`;
+  for (const [subject] of bySubject) {
+    if (subject.startsWith('did:dkg:activity:')) admitted.add(subject);
+    if (!subject.startsWith(delegationPrefix)) continue;
+    const delegatedAgents = objects(subject, DKG_ONTOLOGY.DKG_DELEGATION_AGENT)
+      .map((value) => stripLiteral(value).toLowerCase());
+    if (delegatedAgents.some((agent) => members.has(agent) && !revoked.has(agent))) {
+      admitted.add(subject);
+    }
+  }
+
+  const assertionNames = new Set<string>();
+  for (const lifecycle of nonWorkingSubjects) {
+    for (const graph of objects(lifecycle, DKG_ASSERTION_GRAPH)) admitted.add(graph);
+    for (const rawName of objects(lifecycle, DKG_ASSERTION_NAME)) {
+      const name = stripLiteral(rawName);
+      if (name) assertionNames.add(name);
+    }
+  }
+  const assertionNamesByTail = new Map<string, string[]>();
+  for (const name of assertionNames) {
+    const tail = name.slice(name.lastIndexOf('/') + 1);
+    const names = assertionNamesByTail.get(tail) ?? [];
+    names.push(name);
+    assertionNamesByTail.set(tail, names);
+  }
+
+  for (const [subject, subjectRows] of bySubject) {
+    if (subjectRows.some((row) =>
+      (row.p === PROV_GENERATED || row.p === PROV_USED) && nonWorkingSubjects.has(row.o),
+    )) admitted.add(subject);
+    if (subject.includes('/assertion/')) {
+      const tail = subject.slice(subject.lastIndexOf('/') + 1);
+      if ((assertionNamesByTail.get(tail) ?? []).some(
+        (name) => subject.endsWith(`/${name}`),
+      )) admitted.add(subject);
+    }
+  }
+
+  return rows
+    .filter((row) =>
+      admitted.has(row.s) &&
+      !(isIriTerm(row.s) && row.s.startsWith(DKG_JOIN_REQUEST_SUBJECT_PREFIX)),
+    )
+    .sort(compareRows);
+}
+
+function isIriTerm(term: string): boolean {
+  return !term.startsWith('_:') && !term.startsWith('"');
 }
 
 /**
@@ -1734,7 +2537,7 @@ async function readDurableMetaRowsPage(
     store,
     contextGraphId,
     registeredSubGraphNames,
-    { offset: safeOffset, limit: safeLimit },
+    { kind: 'page', offset: safeOffset, limit: safeLimit },
     signal,
   );
 }

--- a/packages/agent/src/sync/responder/snapshot-cache.ts
+++ b/packages/agent/src/sync/responder/snapshot-cache.ts
@@ -20,7 +20,10 @@ export type SyncRow = Readonly<{ s: string; p: string; o: string; g: string }>;
  * They bound temporary materialization even when an operator configures a very
  * large cache. Larger phases use direct store paging instead of being cached.
  */
-export const SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_ROWS = 10_000;
+// Keep the ordinary 50 x 1,000-triple release gate on the snapshot path. The
+// byte ceiling remains the primary heap bound, so raising the row ceiling does
+// not permit a large-literal snapshot to exceed 32 MiB of estimated row data.
+export const SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_ROWS = 64_000;
 export const SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_BYTES_ESTIMATE = 32 * 1024 * 1024;
 export const SYNC_RESPONDER_SNAPSHOT_BUILD_PAGE_ROWS = 500;
 

--- a/packages/agent/test/sync-responder-concurrent-interleaving.test.ts
+++ b/packages/agent/test/sync-responder-concurrent-interleaving.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, describe, it, expect, vi } from 'vitest';
 import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
 import {
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  MemoryLayer,
+  createGraphKnowledgeAssetScope,
+  knowledgeAssetLayerGraphUri,
+} from '@origintrail-official/dkg-core';
+import {
   createResponderGraphListMemo,
   createResponderSubGraphRegistrationMemo,
 } from '../src/sync/responder/graph-plan.js';
@@ -20,6 +26,47 @@ function q(graph: string, index: number): Quad {
     predicate: `${DKG_NS}label`,
     object: `"row-${index.toString().padStart(3, '0')}"`,
   };
+}
+
+function graphScopedVmMeta(params: {
+  cgId: string;
+  ual: string;
+  assertionVersion?: number;
+  publicTripleCount: number;
+  status: 'tentative' | 'confirmed';
+  subGraphName?: string;
+}): { graph: string; quads: Quad[] } {
+  const assertionVersion = params.assertionVersion ?? 1;
+  const scope = createGraphKnowledgeAssetScope(params.ual, assertionVersion);
+  const graph = knowledgeAssetLayerGraphUri(
+    params.cgId,
+    MemoryLayer.VerifiableMemory,
+    scope,
+    params.subGraphName,
+  );
+  const meta = `did:dkg:context-graph:${params.cgId}/_meta`;
+  const int = (value: number) =>
+    `"${value}"^^<http://www.w3.org/2001/XMLSchema#integer>`;
+  const quads: Quad[] = [
+    { graph: meta, subject: params.ual, predicate: `${DKG_NS}contentScopeVersion`, object: int(GRAPH_KA_CONTENT_SCOPE_VERSION) },
+    { graph: meta, subject: params.ual, predicate: `${DKG_NS}kaUal`, object: params.ual },
+    { graph: meta, subject: params.ual, predicate: `${DKG_NS}assertionVersion`, object: int(assertionVersion) },
+    { graph: meta, subject: params.ual, predicate: `${DKG_NS}assertionGraph`, object: graph },
+    { graph: meta, subject: params.ual, predicate: `${DKG_NS}contextGraph`, object: `did:dkg:context-graph:${params.cgId}` },
+    { graph: meta, subject: params.ual, predicate: `${DKG_NS}publicTripleCount`, object: int(params.publicTripleCount) },
+    { graph: meta, subject: params.ual, predicate: `${DKG_NS}privateTripleCount`, object: int(0) },
+    { graph: meta, subject: params.ual, predicate: `${DKG_NS}status`, object: `"${params.status}"` },
+    { graph: meta, subject: params.ual, predicate: `${DKG_NS}merkleRoot`, object: '"0x0000000000000000000000000000000000000000000000000000000000000000"' },
+  ];
+  if (params.subGraphName) {
+    quads.push({
+      graph: meta,
+      subject: params.ual,
+      predicate: `${DKG_NS}subGraphName`,
+      object: `"${params.subGraphName}"`,
+    });
+  }
+  return { graph, quads };
 }
 
 function deferred<T>() {
@@ -73,7 +120,177 @@ function watchBoundedPageQuery(
   };
 }
 
+function watchBoundedExactGraphSnapshot(store: OxigraphStore, graph: string) {
+  const originalQuery = store.query.bind(store);
+  let observedSnapshotQueries = 0;
+  store.query = (async (sparql: string) => {
+    const normalized = sparql.replace(/\s+/g, ' ').trim();
+    const isTargetSnapshot = /^SELECT \?s \?p \?o WHERE \{/.test(normalized) &&
+      normalized.includes(`GRAPH <${graph}>`) &&
+      !normalized.includes('ORDER BY') &&
+      !normalized.includes('OFFSET');
+    if (isTargetSnapshot) {
+      observedSnapshotQueries++;
+      expect(normalized).toMatch(/LIMIT \d+$/);
+    }
+    return originalQuery(sparql);
+  }) as OxigraphStore['query'];
+  return {
+    assertObserved() {
+      expect(observedSnapshotQueries).toBeGreaterThan(0);
+    },
+  };
+}
+
 describe('sync responder pagination interleaving', () => {
+  it('uses confirmed V2 metadata as the exact VM manifest and omits tentative V2 payloads', async () => {
+    const store = new OxigraphStore();
+    const cgId = 'rootless-v2-manifest';
+    const confirmed = graphScopedVmMeta({
+      cgId,
+      ual: 'did:dkg:base:8453/0x00000000000000000000000000000000000000ab/7',
+      publicTripleCount: 3,
+      status: 'confirmed',
+    });
+    const tentative = graphScopedVmMeta({
+      cgId,
+      ual: 'did:dkg:base:8453/0x00000000000000000000000000000000000000ab/8',
+      publicTripleCount: 2,
+      status: 'tentative',
+    });
+    await store.insert([
+      ...confirmed.quads,
+      ...tentative.quads,
+      q(confirmed.graph, 0),
+      q(confirmed.graph, 1),
+      q(confirmed.graph, 2),
+      q(tentative.graph, 3),
+      q(tentative.graph, 4),
+    ]);
+
+    const originalCount = store.countQuads.bind(store);
+    let confirmedCountCalls = 0;
+    store.countQuads = async (graph, options) => {
+      if (graph === confirmed.graph) {
+        confirmedCountCalls += 1;
+        throw new Error('confirmed V2 graph must use manifest publicTripleCount');
+      }
+      return originalCount(graph, options);
+    };
+    const originalQuery = store.query.bind(store);
+    let vmChildProbeQueries = 0;
+    store.query = (async (sparql: string, options?: Parameters<OxigraphStore['query']>[1]) => {
+      const normalized = sparql.replace(/\s+/g, ' ');
+      if (normalized.includes('ASK') && normalized.includes('_verifiable_memory')) {
+        vmChildProbeQueries += 1;
+      }
+      return originalQuery(sparql, options);
+    }) as OxigraphStore['query'];
+
+    const cap = registerTestSyncHandler(store, { syncPageSize: 10 });
+    const base = {
+      contextGraphId: cgId,
+      includeSharedMemory: false,
+      limit: 10,
+    } as const;
+    const data = await cap.invoke({
+      ...base,
+      phase: 'data',
+      offset: 0,
+      syncSessionId: 'rootless-v2-data',
+    });
+    const meta = await cap.invoke({
+      ...base,
+      phase: 'meta',
+      offset: 0,
+      syncSessionId: 'rootless-v2-meta',
+    });
+
+    expect(linesFromNquads(data)).toHaveLength(3);
+    expect(data).toContain(confirmed.graph);
+    expect(data).not.toContain(tentative.graph);
+    expect(meta).toContain(confirmed.quads[0]!.subject);
+    expect(meta).toContain('contentScopeVersion');
+    expect(meta).not.toContain(tentative.quads[0]!.subject);
+    expect(confirmedCountCalls).toBe(0);
+    expect(vmChildProbeQueries).toBe(0);
+  });
+
+  it('fails closed when a confirmed V2 manifest count disagrees with its exact graph', async () => {
+    const store = new OxigraphStore();
+    const cgId = 'rootless-v2-count-race';
+    const manifest = graphScopedVmMeta({
+      cgId,
+      ual: 'did:dkg:base:8453/0x00000000000000000000000000000000000000ac/9',
+      publicTripleCount: 2,
+      status: 'confirmed',
+    });
+    await store.insert([...manifest.quads, q(manifest.graph, 0)]);
+    const cap = registerTestSyncHandler(store, { syncPageSize: 10 });
+
+    await expect(cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: false,
+      phase: 'data',
+      offset: 0,
+      limit: 10,
+      syncSessionId: 'rootless-v2-count-race',
+    })).rejects.toThrow(/expected 2 rows, found 1/);
+  });
+
+  it('fails closed instead of treating an incomplete V2 descriptor as legacy data', async () => {
+    const store = new OxigraphStore();
+    const cgId = 'rootless-v2-incomplete-manifest';
+    const manifest = graphScopedVmMeta({
+      cgId,
+      ual: 'did:dkg:base:8453/0x00000000000000000000000000000000000000ad/10',
+      publicTripleCount: 1,
+      status: 'confirmed',
+    });
+    await store.insert([
+      ...manifest.quads.filter((quad) => quad.predicate !== `${DKG_NS}status`),
+      q(manifest.graph, 0),
+    ]);
+    const cap = registerTestSyncHandler(store, { syncPageSize: 10 });
+
+    await expect(cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: false,
+      phase: 'data',
+      offset: 0,
+      limit: 10,
+      syncSessionId: 'rootless-v2-incomplete-manifest',
+    })).rejects.toThrow(/incomplete V2 descriptor/);
+  });
+
+  it('fails closed on a future graph-scoped content version', async () => {
+    const store = new OxigraphStore();
+    const cgId = 'rootless-v2-future-manifest';
+    const manifest = graphScopedVmMeta({
+      cgId,
+      ual: 'did:dkg:base:8453/0x00000000000000000000000000000000000000ae/11',
+      publicTripleCount: 1,
+      status: 'confirmed',
+    });
+    const futureVersion = '"3"^^<http://www.w3.org/2001/XMLSchema#integer>';
+    await store.insert([
+      ...manifest.quads.map((quad) => quad.predicate === `${DKG_NS}contentScopeVersion`
+        ? { ...quad, object: futureVersion }
+        : quad),
+      q(manifest.graph, 0),
+    ]);
+    const cap = registerTestSyncHandler(store, { syncPageSize: 10 });
+
+    await expect(cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: false,
+      phase: 'data',
+      offset: 0,
+      limit: 10,
+      syncSessionId: 'rootless-v2-future-manifest',
+    })).rejects.toThrow(/unsupported contentScopeVersion 3/);
+  });
+
   it('returns an exact no-gap/no-duplicate union across overlapping durable-data page loops', async () => {
     const store = new OxigraphStore();
     const cgId = 'interleave-cg';
@@ -306,13 +523,13 @@ describe('sync responder pagination interleaving', () => {
     expect(joined).not.toContain('"delta-1"');
   });
 
-  it('uses bounded store-side paging for deep SWM data pages without TTL', async () => {
+  it('uses one bounded unordered exact-graph snapshot for deep SWM pages without TTL', async () => {
     const store = new OxigraphStore();
     const cgId = 'bounded-swm';
     const swmGraph = `did:dkg:context-graph:${cgId}/_shared_memory`;
     await store.insert(Array.from({ length: 100 }, (_, index) => q(swmGraph, index)));
 
-    const probe = watchBoundedPageQuery(store, swmGraph, 90, 5);
+    const probe = watchBoundedExactGraphSnapshot(store, swmGraph);
     const cap = registerTestSyncHandler(store, { sharedMemoryTtlMs: 0, syncPageSize: 5 });
     const out = await cap.invoke({
       contextGraphId: cgId,
@@ -470,7 +687,7 @@ describe('sync responder pagination interleaving', () => {
     expect(lineGraphsFromNquads(out)).toEqual(new Set([cgPrefix, fallbackGraph]));
   });
 
-  it('builds a reusable durable-data snapshot from exact-graph bounded pages', async () => {
+  it('builds a reusable durable-data snapshot from bounded unordered exact-graph reads', async () => {
     const store = new OxigraphStore();
     const cgId = 'single-query-durable-fallback';
     const cgPrefix = `did:dkg:context-graph:${cgId}`;
@@ -502,8 +719,8 @@ describe('sync responder pagination interleaving', () => {
         (normalized.includes(`GRAPH <${cgPrefix}>`) || normalized.includes(`GRAPH <${fallbackGraph}>`))
       ) {
         exactGraphRowLoads++;
-        expect(normalized).toContain('ORDER BY ?s ?p ?o');
-        expect(normalized).toContain('OFFSET 0');
+        expect(normalized).not.toContain('ORDER BY');
+        expect(normalized).not.toContain('OFFSET');
         expect(normalized).toMatch(/LIMIT \d+$/);
       }
       return originalQuery(sparql);
@@ -533,6 +750,45 @@ describe('sync responder pagination interleaving', () => {
     expect(first).not.toContain('"row-001"');
     expect(second).toContain('"row-001"');
     expect(second).not.toContain('"row-000"');
+  });
+
+  it('never admits transient working-memory graphs into durable data sync', async () => {
+    const store = new OxigraphStore();
+    const cgId = 'exclude-transient-working-memory';
+    const cgPrefix = `did:dkg:context-graph:${cgId}`;
+    const durableGraph = `${cgPrefix}/context/1`;
+    const orphanWorkingGraph = `${cgPrefix}/_working_memory/0xabc/271`;
+    await store.insert([
+      q(durableGraph, 1),
+      ...Array.from({ length: 100 }, (_, index) => q(orphanWorkingGraph, 1000 + index)),
+    ]);
+
+    const originalCountQuads = store.countQuads.bind(store);
+    store.countQuads = async (graph, options) => {
+      if (graph === orphanWorkingGraph) {
+        throw new Error('durable sync must reject WM before count/query planning');
+      }
+      return originalCountQuads(graph, options);
+    };
+    const originalQuery = store.query.bind(store);
+    store.query = (async (sparql: string, options?: Parameters<OxigraphStore['query']>[1]) => {
+      expect(sparql).not.toContain(`GRAPH <${orphanWorkingGraph}>`);
+      return originalQuery(sparql, options);
+    }) as OxigraphStore['query'];
+
+    const cap = registerTestSyncHandler(store, { syncPageSize: 10 });
+    const out = await cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: false,
+      phase: 'data',
+      offset: 0,
+      limit: 10,
+      syncSessionId: 'wm-exclusion',
+    });
+
+    expect(out).toContain('"row-001"');
+    expect(out).not.toContain('"row-1000"');
+    expect(lineGraphsFromNquads(out)).toEqual(new Set([durableGraph]));
   });
 
   it('refreshes full durable-data snapshots on page zero for the same peer', async () => {

--- a/packages/agent/test/sync-responder-oversized-fallback.test.ts
+++ b/packages/agent/test/sync-responder-oversized-fallback.test.ts
@@ -56,6 +56,8 @@ describe('oversized responder fallback is store-bounded and set-equivalent', () 
     const activeDelegation = `did:dkg:agent-delegation:${cgId}:0xactive`;
     const orphanedDelegation = `did:dkg:agent-delegation:${cgId}:0xorphaned`;
     const revokedDelegation = `did:dkg:agent-delegation:${cgId}:0xrevoked`;
+    const confirmedV2 = 'did:dkg:base:8453/0x00000000000000000000000000000000000000ab/7';
+    const tentativeV2 = 'did:dkg:base:8453/0x00000000000000000000000000000000000000ab/8';
 
     const quads: Quad[] = [
       // A: the CG entity subject
@@ -92,6 +94,14 @@ describe('oversized responder fallback is store-bounded and set-equivalent', () 
       { graph: meta, subject: 'urn:event:used', predicate: 'http://www.w3.org/ns/prov#used', object: 'urn:lc:vm' },
       // H: an /assertion/ subject ending with a non-working lifecycle's assertion name
       { graph: meta, subject: `${cgEntity}/assertion/0xabc/myassert`, predicate: `${DKG_NS}label`, object: '"assertion-name-hit"' },
+      // I: rootless descriptors do not carry legacy memoryLayer. Confirmed V2
+      // metadata is durable; tentative V2 metadata remains workspace-local.
+      { graph: meta, subject: confirmedV2, predicate: `${DKG_NS}contentScopeVersion`, object: '"2"^^<http://www.w3.org/2001/XMLSchema#integer>' },
+      { graph: meta, subject: confirmedV2, predicate: `${DKG_NS}status`, object: '"confirmed"' },
+      { graph: meta, subject: confirmedV2, predicate: `${DKG_NS}label`, object: '"confirmed-v2-row"' },
+      { graph: meta, subject: tentativeV2, predicate: `${DKG_NS}contentScopeVersion`, object: '"2"^^<http://www.w3.org/2001/XMLSchema#integer>' },
+      { graph: meta, subject: tentativeV2, predicate: `${DKG_NS}status`, object: '"tentative"' },
+      { graph: meta, subject: tentativeV2, predicate: `${DKG_NS}label`, object: '"tentative-v2-row"' },
 
       // ---- negatives that MUST be excluded by both paths ----
       // working-only lifecycle, matches no other branch
@@ -153,6 +163,8 @@ describe('oversized responder fallback is store-bounded and set-equivalent', () 
     expect(has('urn:event:gen')).toBe(true); // G generated
     expect(has('urn:event:used')).toBe(true); // G used
     expect(has(`${cgEntity}/assertion/0xabc/myassert`)).toBe(true); // H
+    expect(has(confirmedV2)).toBe(true); // I confirmed V2
+    expect(has(tentativeV2)).toBe(false);
     // negatives
     expect([...canonical].join('\n')).not.toContain('noise-should-be-excluded');
     expect([...canonical].join('\n')).not.toContain('working-name-should-be-excluded');

--- a/packages/agent/test/sync-responder-rootless-perf.test.ts
+++ b/packages/agent/test/sync-responder-rootless-perf.test.ts
@@ -1,8 +1,12 @@
 import { performance } from 'node:perf_hooks';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import {
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
   MemoryLayer,
-  contextGraphLayerUri,
+  createGraphKnowledgeAssetScope,
+  contextGraphDataGraphUri,
+  contextGraphMetaGraphUri,
+  knowledgeAssetLayerGraphUri,
 } from '@origintrail-official/dkg-core';
 import {
   SparqlHttpStore,
@@ -45,7 +49,7 @@ function createPerfStore(): TripleStore {
   if (!queryEndpoint) {
     throw new Error(
       'DKG_SYNC_RESPONDER_ROOTLESS_PERF=1 requires ' +
-      'DKG_SYNC_RESPONDER_PERF_QUERY_ENDPOINT pointing at an oxigraph-server /query endpoint',
+      'DKG_SYNC_RESPONDER_PERF_QUERY_ENDPOINT pointing at a SPARQL 1.1 query endpoint',
     );
   }
   const timeout = Number(process.env.DKG_SYNC_RESPONDER_PERF_TIMEOUT_MS ?? 180_000);
@@ -59,12 +63,32 @@ function createPerfStore(): TripleStore {
 }
 
 function graphForKa(index: number): string {
-  return contextGraphLayerUri(
+  return knowledgeAssetLayerGraphUri(
     CG_ID,
     MemoryLayer.VerifiableMemory,
-    AGENT_ADDRESS,
-    index + 1,
+    createGraphKnowledgeAssetScope(ualForKa(index), 1),
   );
+}
+
+function ualForKa(index: number): string {
+  return `did:dkg:base:8453/${AGENT_ADDRESS}/${index + 1}`;
+}
+
+function manifestQuadsForKa(index: number, graph: string): Quad[] {
+  const ual = ualForKa(index);
+  const meta = contextGraphMetaGraphUri(CG_ID);
+  const integer = (value: number) =>
+    `"${value}"^^<http://www.w3.org/2001/XMLSchema#integer>`;
+  return [
+    { graph: meta, subject: ual, predicate: `${DKG_NS}contentScopeVersion`, object: integer(GRAPH_KA_CONTENT_SCOPE_VERSION) },
+    { graph: meta, subject: ual, predicate: `${DKG_NS}kaUal`, object: ual },
+    { graph: meta, subject: ual, predicate: `${DKG_NS}assertionVersion`, object: integer(1) },
+    { graph: meta, subject: ual, predicate: `${DKG_NS}assertionGraph`, object: graph },
+    { graph: meta, subject: ual, predicate: `${DKG_NS}contextGraph`, object: contextGraphDataGraphUri(CG_ID) },
+    { graph: meta, subject: ual, predicate: `${DKG_NS}publicTripleCount`, object: integer(ROWS_PER_KA) },
+    { graph: meta, subject: ual, predicate: `${DKG_NS}privateTripleCount`, object: integer(0) },
+    { graph: meta, subject: ual, predicate: `${DKG_NS}status`, object: '"confirmed"' },
+  ];
 }
 
 describePerf('rootless exact-graph sync responder perf guard', () => {
@@ -72,6 +96,7 @@ describePerf('rootless exact-graph sync responder perf guard', () => {
   let cap: CapturedSyncHandler;
   const seededGraphs: string[] = [];
   let exactGraphCounts = 0;
+  let exactGraphSnapshotQueries = 0;
   let exactGraphPageQueries = 0;
   let largestExactGraphOffset = 0;
 
@@ -96,6 +121,14 @@ describePerf('rootless exact-graph sync responder perf guard', () => {
       if (
         normalized.startsWith('SELECT ?s ?p ?o WHERE {')
         && normalized.includes('/_verifiable_memory/')
+        && !normalized.includes('ORDER BY')
+        && !normalized.includes('OFFSET')
+      ) {
+        exactGraphSnapshotQueries += 1;
+      }
+      if (
+        normalized.startsWith('SELECT ?s ?p ?o WHERE {')
+        && normalized.includes('/_verifiable_memory/')
         && normalized.includes('ORDER BY ?s ?p ?o')
       ) {
         exactGraphPageQueries += 1;
@@ -114,6 +147,7 @@ describePerf('rootless exact-graph sync responder perf guard', () => {
     for (let ka = 0; ka < KA_COUNT; ka += 1) {
       const graph = graphForKa(ka);
       seededGraphs.push(graph);
+      batch.push(...manifestQuadsForKa(ka, graph));
       for (let row = 0; row < ROWS_PER_KA; row += 1) {
         const suffix = row.toString().padStart(4, '0');
         batch.push({
@@ -125,6 +159,7 @@ describePerf('rootless exact-graph sync responder perf guard', () => {
         if (batch.length >= 10_000) await flush();
       }
     }
+    seededGraphs.push(contextGraphMetaGraphUri(CG_ID));
     for (let index = 0; index < 100; index += 1) {
       const graph = `did:dkg:context-graph:rootless-perf-decoy-${RUN_ID}-${index}`;
       seededGraphs.push(graph);
@@ -148,7 +183,7 @@ describePerf('rootless exact-graph sync responder perf guard', () => {
     await store.close();
   }, 60_000);
 
-  it('syncs 50 immutable 1,000-triple KAs without a store-wide sort or deep offset', async () => {
+  it('syncs 50 manifest-backed immutable 1,000-triple KAs without counts, sorting, or offsets', async () => {
     const lines = new Set<string>();
     const startedAt = performance.now();
     for (let offset = 0; offset < TOTAL_ROWS; offset += PAGE_SIZE) {
@@ -167,9 +202,10 @@ describePerf('rootless exact-graph sync responder perf guard', () => {
     const elapsedMs = performance.now() - startedAt;
 
     expect(lines.size).toBe(TOTAL_ROWS);
-    expect(exactGraphCounts).toBe(KA_COUNT);
-    expect(exactGraphPageQueries).toBeGreaterThanOrEqual(KA_COUNT * 2);
-    expect(largestExactGraphOffset).toBeLessThan(ROWS_PER_KA);
+    expect(exactGraphCounts).toBe(0);
+    expect(exactGraphSnapshotQueries).toBe(KA_COUNT);
+    expect(exactGraphPageQueries).toBe(0);
+    expect(largestExactGraphOffset).toBe(0);
     expect(elapsedMs, `rootless exact-graph sync took ${elapsedMs.toFixed(1)}ms`)
       .toBeLessThan(syncBudgetMs());
   }, 120_000);

--- a/packages/agent/test/workspace-crypto-delegatee-filter.test.ts
+++ b/packages/agent/test/workspace-crypto-delegatee-filter.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ethers } from 'ethers';
 import { MockChainAdapter } from '@origintrail-official/dkg-chain';
 import {
@@ -28,14 +28,17 @@ describe('workspace crypto delegatee authorization lookups', () => {
     const participantAgent = ethers.Wallet.createRandom().address;
     const orphanedAgent = ethers.Wallet.createRandom().address;
     const revokedAgent = ethers.Wallet.createRandom().address;
+    const expiredAgent = ethers.Wallet.createRandom().address;
     const allowedKey = ethers.Wallet.createRandom().address;
     const participantKey = ethers.Wallet.createRandom().address;
     const orphanedKey = ethers.Wallet.createRandom().address;
     const revokedKey = ethers.Wallet.createRandom().address;
+    const expiredKey = ethers.Wallet.createRandom().address;
     const allowedPeer = '12D3KooWAllowedDelegatee';
     const participantPeer = '12D3KooWParticipantDelegatee';
     const orphanedPeer = '12D3KooWOrphanedDelegatee';
     const revokedPeer = '12D3KooWRevokedDelegatee';
+    const expiredPeer = '12D3KooWExpiredDelegatee';
     const delegationSubject = (principal: string) =>
       `did:dkg:agent-delegation:${contextGraphId}:${principal.toLowerCase()}`;
     const delegationQuads = (principal: string, peer: string, key: string) => [{
@@ -77,6 +80,12 @@ describe('workspace crypto delegatee authorization lookups', () => {
       {
         graph: metaGraph,
         subject: cgEntity,
+        predicate: DKG_ONTOLOGY.DKG_ALLOWED_AGENT,
+        object: `"${expiredAgent}"`,
+      },
+      {
+        graph: metaGraph,
+        subject: cgEntity,
         predicate: DKG_ONTOLOGY.DKG_REVOKED_AGENT,
         object: `"${revokedAgent.toLowerCase()}"`,
       },
@@ -84,11 +93,21 @@ describe('workspace crypto delegatee authorization lookups', () => {
       ...delegationQuads(participantAgent, participantPeer, participantKey),
       ...delegationQuads(orphanedAgent, orphanedPeer, orphanedKey),
       ...delegationQuads(revokedAgent, revokedPeer, revokedKey),
+      ...delegationQuads(expiredAgent, expiredPeer, expiredKey),
+      {
+        graph: metaGraph,
+        subject: delegationSubject(expiredAgent),
+        predicate: DKG_ONTOLOGY.DKG_DELEGATION_EXPIRES_AT,
+        object: `"${Date.now() - 1}"`,
+      },
     ]);
 
+    const querySpy = vi.spyOn(agent.store, 'query');
     const peers = await (agent as any).getContextGraphAllowedDelegateePeers(contextGraphId);
+    const queriesAfterProjectionBuild = querySpy.mock.calls.length;
     const keys = await (agent as any).getContextGraphAllowedDelegateeKeys(contextGraphId);
 
+    expect(querySpy.mock.calls.length).toBe(queriesAfterProjectionBuild);
     expect(peers.size).toBe(2);
     expect(keys.size).toBe(2);
     expect(peers.get(allowedAgent.toLowerCase())).toEqual([allowedPeer]);
@@ -99,5 +118,21 @@ describe('workspace crypto delegatee authorization lookups', () => {
     expect(peers.has(revokedAgent.toLowerCase())).toBe(false);
     expect(keys.has(orphanedAgent.toLowerCase())).toBe(false);
     expect(keys.has(revokedAgent.toLowerCase())).toBe(false);
+    expect(peers.has(expiredAgent.toLowerCase())).toBe(false);
+    expect(keys.has(expiredAgent.toLowerCase())).toBe(false);
+
+    const refreshedPeer = '12D3KooWRefreshedDelegatee';
+    await agent.store.insert([{
+      graph: metaGraph,
+      subject: delegationSubject(allowedAgent),
+      predicate: DKG_ONTOLOGY.DKG_ALLOWED_DELEGATEE_PEER,
+      object: `"${refreshedPeer}"`,
+    }]);
+    const refreshedPeers = await (agent as any).getContextGraphAllowedDelegateePeers(contextGraphId);
+    expect(querySpy.mock.calls.length).toBeGreaterThan(queriesAfterProjectionBuild);
+    expect(refreshedPeers.get(allowedAgent.toLowerCase())).toHaveLength(2);
+    expect(refreshedPeers.get(allowedAgent.toLowerCase())).toEqual(
+      expect.arrayContaining([allowedPeer, refreshedPeer]),
+    );
   });
 });


### PR DESCRIPTION
## Summary

- build rootless VM bootstrap plans from confirmed V2 control metadata, deriving exact immutable graphs and row counts without per-KA `countQuads`
- fail closed for tentative, incomplete, ambiguous, count-mismatched, or future-version V2 descriptors while keeping legacy reads isolated
- exclude transient WM graphs and remove redundant VM child-prefix probes
- use bounded unordered exact-graph snapshots for normal KAs, retaining portable ordered paging only as the oversized fallback
- collapse durable `_meta` admission into one bounded exact-graph read and cache private delegation facts in the write-invalidated CG projection instead of querying them twice per sync page
- add a backend-neutral 50 x 1,000 triple rootless VM performance gate

## Validation

- agent build + type tests: pass
- focused sync/auth/membership tests: 59/59 pass after rebase
- additional integrity/worker/auth suites: 78/78 pass
- Oxigraph real SPARQL endpoint: 50,000/50,000 unique triples, zero counts, zero ordered/offset page queries, ~1.08s sync
- Blazegraph real SPARQL endpoint: same assertions, ~1.58s sync

Based on `testnet-canary` after #1742 (`5dc417317`).