### PR TITLE
fix: testnet-canary test failures (parity, storage scheduler, update fail-closed) + triage

### DIFF
--- a/packages/chain/test/mock-adapter-parity.test.ts
+++ b/packages/chain/test/mock-adapter-parity.test.ts
@@ -281,6 +281,18 @@ const MOCK_EXEMPT_FROM_EVM = new Set<string>([
   // (the mock's getMaxKaNumberForAuthor is an in-memory scan, no providers).
   'queryKaCreatedPage',
   'queryEventLogsPage',
+  // EIP-1271 `isValidSignature(bytes32,bytes)` on-chain view call against a
+  // deployed smart-contract wallet. Its sole production caller
+  // (dkg-publisher.ts contract-author update authorization) is gated by
+  // `hasContractCode(author)`, which the mock hardcodes to false — so the
+  // contract-author branch is structurally unreachable on the mock. A `true`
+  // shim would be a false-accept on a security-sensitive auth path and a
+  // `false` shim would be dead code; a faithful impl would have to model
+  // deployed 1271 bytecode + the 0x1626ba7e magic value, which is out of the
+  // mock's remit. The two tests that exercise the contract-author branch stub
+  // both methods per-test. EVM-only — same family as the on-chain-derived
+  // helpers above.
+  'verifyContractSignature',
 ]);
 
 const NO_CHAIN_EXEMPT_FROM_EVM = new Set<string>([

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -4962,12 +4962,46 @@ export class DKGPublisher implements Publisher {
     const updateSeal = options.precomputedUpdateAttestation;
     const effectiveAuthorAddress = updateSeal.authorAddress;
     const effectiveSchemeVersion = updateSeal.schemeVersion;
-    await assertValidPrecomputedUpdateAttestation(
-      this.chain,
-      kaId,
-      kcMerkleRoot,
-      updateSeal,
-    );
+    try {
+      await assertValidPrecomputedUpdateAttestation(
+        this.chain,
+        kaId,
+        kcMerkleRoot,
+        updateSeal,
+      );
+    } catch (attestErr) {
+      // Fail-closed contract: update() returns {status:'failed'} and mutates
+      // nothing when the chain has no updatable KA. This pre-staging owner
+      // check reads chain-truth (getKnowledgeAssetOwner -> ownerOf) BEFORE the
+      // chain-submit try/catch below, so an update against a non-existent or
+      // expired KA reverts HERE and — before the rootless cutover moved this
+      // check ahead of staging — would escape update() as a throw instead of a
+      // failed result. Convert only that definitive "no updatable KA" class to
+      // a failed result; every authorization failure (wrong owner of an
+      // EXISTING KA -> KA_UPDATE_AUTHOR_NOT_OWNER, signer mismatch, or a
+      // missing-adapter-method config error) still throws, preserving the
+      // reject-unauthorized-before-staging semantics.
+      const errorName = enrichEvmError(attestErr)
+        ?? (attestErr as { revert?: { name?: string } })?.revert?.name;
+      const NO_UPDATABLE_KA = ['ERC721NonexistentToken', 'KnowledgeAssetExpired'];
+      if (!errorName || !NO_UPDATABLE_KA.includes(errorName)) {
+        throw attestErr;
+      }
+      this.log.warn(
+        ctx,
+        `V10 update rejected pre-staging (${errorName}) for kaId=${kaId}: no updatable KA on chain`,
+      );
+      onPhase?.('chain:submit', 'end');
+      onPhase?.('chain', 'end');
+      return {
+        kaId,
+        ual: graphUpdate?.scope.ual ?? await this.resolveKaUal(kaId),
+        merkleRoot: kcMerkleRoot,
+        kaManifest: manifestEntries,
+        status: 'failed',
+        publicQuads: allSkolemizedQuads,
+      };
+    }
 
     // P-1 review (iter-2): `chain:writeahead:start` fires from inside
     // the V10 adapter via `onBroadcast` — i.e. AFTER allowance +

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -284,6 +284,41 @@ export async function assertValidPrecomputedUpdateAttestation(
   }
 }
 
+/**
+ * Decode a chain rejection to its contract error name for update() failure
+ * classification. Prefers the adapter's `enrichEvmError` decode, falling back
+ * to an ethers-predecoded `revert.name`. Shared by update()'s pre-staging owner
+ * check and its chain-submit path so both classify rejections identically.
+ */
+function extractV10UpdateRejectionName(err: unknown): string | undefined {
+  return enrichEvmError(err) ?? (err as { revert?: { name?: string } })?.revert?.name;
+}
+
+/**
+ * Reverts the pre-staging owner check (`getKnowledgeAssetOwner` -> `ownerOf`)
+ * can surface that mean "there is no updatable KA on chain" — update() returns
+ * a failed result instead of throwing. Deliberately a strict subset of
+ * {@link V10_DEFINITIVE_UPDATE_ERRORS}: an authorization failure (wrong owner,
+ * bad signature) must still THROW before staging. Expiry/immutability are NOT
+ * here — those are submit-time reverts from `KnowledgeAssetsLifecycle`, never
+ * from the storage contract's `ownerOf`, so they cannot reach this check.
+ */
+const PRE_STAGING_NO_UPDATABLE_KA_ERRORS = ['ERC721NonexistentToken'];
+
+/**
+ * Definitive chain rejections at update submit — convert to a failed result
+ * rather than throw (by submit time the KA/authorship are already validated).
+ */
+const V10_DEFINITIVE_UPDATE_ERRORS = [
+  'NotKnowledgeAssetOwner',
+  'InvalidAuthorSignature',
+  'InvalidAuthorSignature1271',
+  'AuthorRequired',
+  'KnowledgeAssetExpired',
+  'CannotUpdateImmutableKnowledgeAsset',
+  'ExceededKnowledgeAssetBatchSize',
+];
+
 async function validateGraphScopedPayloadAgainstSeal(
   seal: AssertionSeal,
   publicQuads: readonly Quad[],
@@ -4962,6 +4997,17 @@ export class DKGPublisher implements Publisher {
     const updateSeal = options.precomputedUpdateAttestation;
     const effectiveAuthorAddress = updateSeal.authorAddress;
     const effectiveSchemeVersion = updateSeal.schemeVersion;
+    // Single source of truth for the "update rejected on chain" result shape,
+    // shared by the pre-staging owner check and the chain-submit path below so
+    // a definitive rejection returns one canonical failed PublishResult.
+    const buildFailedUpdateResult = async (): Promise<PublishResult> => ({
+      kaId,
+      ual: graphUpdate?.scope.ual ?? await this.resolveKaUal(kaId),
+      merkleRoot: kcMerkleRoot,
+      kaManifest: manifestEntries,
+      status: 'failed',
+      publicQuads: allSkolemizedQuads,
+    });
     try {
       await assertValidPrecomputedUpdateAttestation(
         this.chain,
@@ -4973,18 +5019,15 @@ export class DKGPublisher implements Publisher {
       // Fail-closed contract: update() returns {status:'failed'} and mutates
       // nothing when the chain has no updatable KA. This pre-staging owner
       // check reads chain-truth (getKnowledgeAssetOwner -> ownerOf) BEFORE the
-      // chain-submit try/catch below, so an update against a non-existent or
-      // expired KA reverts HERE and — before the rootless cutover moved this
-      // check ahead of staging — would escape update() as a throw instead of a
-      // failed result. Convert only that definitive "no updatable KA" class to
-      // a failed result; every authorization failure (wrong owner of an
-      // EXISTING KA -> KA_UPDATE_AUTHOR_NOT_OWNER, signer mismatch, or a
-      // missing-adapter-method config error) still throws, preserving the
-      // reject-unauthorized-before-staging semantics.
-      const errorName = enrichEvmError(attestErr)
-        ?? (attestErr as { revert?: { name?: string } })?.revert?.name;
-      const NO_UPDATABLE_KA = ['ERC721NonexistentToken', 'KnowledgeAssetExpired'];
-      if (!errorName || !NO_UPDATABLE_KA.includes(errorName)) {
+      // chain-submit try/catch below, so an update against a non-existent KA
+      // reverts HERE and — before the rootless cutover moved this check ahead
+      // of staging — would escape update() as a throw instead of a failed
+      // result. Convert only the definitive "no updatable KA" class to a failed
+      // result; every authorization failure (wrong owner of an EXISTING KA ->
+      // KA_UPDATE_AUTHOR_NOT_OWNER, signer mismatch, or a missing-adapter-method
+      // config error) still throws, preserving reject-unauthorized-before-staging.
+      const errorName = extractV10UpdateRejectionName(attestErr);
+      if (!errorName || !PRE_STAGING_NO_UPDATABLE_KA_ERRORS.includes(errorName)) {
         throw attestErr;
       }
       this.log.warn(
@@ -4993,14 +5036,7 @@ export class DKGPublisher implements Publisher {
       );
       onPhase?.('chain:submit', 'end');
       onPhase?.('chain', 'end');
-      return {
-        kaId,
-        ual: graphUpdate?.scope.ual ?? await this.resolveKaUal(kaId),
-        merkleRoot: kcMerkleRoot,
-        kaManifest: manifestEntries,
-        status: 'failed',
-        publicQuads: allSkolemizedQuads,
-      };
+      return buildFailedUpdateResult();
     }
 
     // P-1 review (iter-2): `chain:writeahead:start` fires from inside
@@ -5191,26 +5227,10 @@ export class DKGPublisher implements Publisher {
             onBroadcast: emitWriteAheadStart,
           });
         } catch (v10Err) {
-          const errorName = enrichEvmError(v10Err);
-          const V10_DEFINITIVE_ERRORS = [
-            'NotKnowledgeAssetOwner',
-            'InvalidAuthorSignature',
-            'InvalidAuthorSignature1271',
-            'AuthorRequired',
-            'KnowledgeAssetExpired',
-            'CannotUpdateImmutableKnowledgeAsset',
-            'ExceededKnowledgeAssetBatchSize',
-          ];
-          if (errorName && V10_DEFINITIVE_ERRORS.includes(errorName)) {
+          const errorName = extractV10UpdateRejectionName(v10Err);
+          if (errorName && V10_DEFINITIVE_UPDATE_ERRORS.includes(errorName)) {
             this.log.warn(ctx, `V10 update rejected (${errorName}): ${v10Err instanceof Error ? v10Err.message : String(v10Err)}`);
-            earlyReturn = {
-              kaId,
-              ual: graphUpdate?.scope.ual ?? await this.resolveKaUal(kaId),
-              merkleRoot: kcMerkleRoot,
-              kaManifest: manifestEntries,
-              status: 'failed',
-              publicQuads: allSkolemizedQuads,
-            };
+            earlyReturn = await buildFailedUpdateResult();
             txResult = { success: false, hash: '' };
           } else {
             // V9 legacy update fallback archived (issue 0004).
@@ -5233,14 +5253,7 @@ export class DKGPublisher implements Publisher {
     if (!txResult.success) {
       onPhase?.('chain:submit', 'end');
       onPhase?.('chain', 'end');
-      return {
-        kaId,
-        ual: graphUpdate?.scope.ual ?? await this.resolveKaUal(kaId),
-        merkleRoot: kcMerkleRoot,
-        kaManifest: manifestEntries,
-        status: 'failed',
-        publicQuads: allSkolemizedQuads,
-      };
+      return buildFailedUpdateResult();
     }
     let effectivePublisherAddress = coercePublisherAddress(txResult.publisherAddress);
     if (!effectivePublisherAddress && typeof this.chain.getLatestMerkleRootPublisher === 'function') {

--- a/packages/publisher/test/ka-update-submit-failure.test.ts
+++ b/packages/publisher/test/ka-update-submit-failure.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import { ethers } from 'ethers';
+import {
+  MockChainAdapter,
+  type TxResult,
+  type V10UpdateKAParams,
+} from '@origintrail-official/dkg-chain';
+import { TypedEventBus, generateEd25519Keypair } from '@origintrail-official/dkg-core';
+import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
+import { DKGPublisher } from '../src/dkg-publisher.js';
+import { buildUpdateSeal, mockSealCtx } from './_helpers/seal.js';
+
+// A definitive submit-time revert (KnowledgeAssetExpired / immutable / batch
+// size) surfaces from KnowledgeAssetsLifecycle at update SUBMIT — never from
+// the pre-staging ownerOf check — so update() must convert it to a failed
+// result (not throw, not mutate). These cases can't be reached with the shared
+// Hardhat harness without epoch time-travel, so drive the submit path with a
+// MockChainAdapter that passes the pre-staging owner check and then rejects the
+// broadcast. Mirrors the ProducerUpdateChain pattern in ka-graph-update-ack.
+
+const PRODUCER = new ethers.Wallet(
+  '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d',
+);
+const AUTHOR = PRODUCER.address;
+const KA_ID = (BigInt(AUTHOR) << 96n) | 7n;
+const CG_ID = '42';
+const DATA_GRAPH = `did:dkg:context-graph:${CG_ID}`;
+
+/** revert-shaped error whose `.name` `extractV10UpdateRejectionName` reads. */
+function revertError(name: string): Error {
+  return Object.assign(new Error(`execution reverted: ${name}`), {
+    revert: { name },
+  });
+}
+
+class SubmitRejectChain extends MockChainAdapter {
+  constructor(private readonly rejectWith: string) {
+    super('mock:31337', AUTHOR);
+  }
+
+  // Pre-staging owner check passes: the KA exists and the author owns it.
+  override async getKnowledgeAssetOwner(kaId: bigint): Promise<string> {
+    if (kaId === KA_ID) return ethers.getAddress(AUTHOR);
+    return super.getKnowledgeAssetOwner(kaId);
+  }
+
+  // Definitive rejection at submit.
+  override async updateKnowledgeCollectionV10(
+    _params: V10UpdateKAParams,
+  ): Promise<TxResult> {
+    throw revertError(this.rejectWith);
+  }
+}
+
+describe('publisher.update() definitive submit-rejection handling', () => {
+  async function update(rejectWith: string) {
+    const store = new OxigraphStore();
+    const publisher = new DKGPublisher({
+      store,
+      chain: new SubmitRejectChain(rejectWith),
+      eventBus: new TypedEventBus(),
+      keypair: await generateEd25519Keypair(),
+      publisherPrivateKey: PRODUCER.privateKey,
+      publisherNodeIdentityId: 1n,
+    });
+    const quads: Quad[] = [
+      { subject: 'urn:atomic', predicate: 'http://schema.org/name', object: '"v2"', graph: DATA_GRAPH },
+    ];
+    const precomputedUpdateAttestation = await buildUpdateSeal({
+      kaId: KA_ID,
+      quads,
+      author: PRODUCER,
+      ctx: mockSealCtx(),
+    });
+    return {
+      store,
+      result: () => publisher.update(KA_ID, {
+        contextGraphId: CG_ID,
+        quads,
+        precomputedUpdateAttestation,
+      }),
+    };
+  }
+
+  it('maps KnowledgeAssetExpired at submit to a failed result without mutating the store', async () => {
+    const { store, result } = await update('KnowledgeAssetExpired');
+    const res = await result();
+    expect(res.status).toBe('failed');
+    expect(res.onChainResult).toBeUndefined();
+    // No local write: the KA was rejected on chain, so nothing lands locally.
+    const rows = await store.query(
+      `SELECT ?o WHERE { GRAPH ?g { <urn:atomic> <http://schema.org/name> ?o } }`,
+    );
+    expect(rows.type === 'bindings' ? rows.bindings.length : -1).toBe(0);
+  });
+
+  it('maps CannotUpdateImmutableKnowledgeAsset at submit to a failed result', async () => {
+    const { result } = await update('CannotUpdateImmutableKnowledgeAsset');
+    const res = await result();
+    expect(res.status).toBe('failed');
+  });
+
+  it('rethrows a non-definitive submit rejection (teeth: only the definitive set is failed-mapped)', async () => {
+    const { result } = await update('SomeTransientChainHiccup');
+    await expect(result()).rejects.toThrow(/SomeTransientChainHiccup/);
+  });
+});

--- a/packages/publisher/test/security-regressions.test.ts
+++ b/packages/publisher/test/security-regressions.test.ts
@@ -724,8 +724,10 @@ describe('publisher.update() atomicity', () => {
       quads: [q('urn:atomic', 'http://schema.org/name', '"Original"')],
     });
 
-    // Attempt to update a non-existent batch — V10 catches KnowledgeAssetExpired
-    // as a definitive error and returns status: 'failed' (no throw, no store mutation)
+    // Attempt to update a non-existent batch. The pre-staging owner check
+    // (getKnowledgeAssetOwner -> ownerOf) reverts ERC721NonexistentToken, which
+    // update() maps to status: 'failed' (no throw, no store mutation). Expiry is
+    // a separate submit-time revert — see ka-update-submit-failure.test.ts.
     const failedUpdate = await publisher.update(999n, {
       contextGraphId: CONTEXT_GRAPH,
       quads: [q('urn:atomic', 'http://schema.org/name', '"Should not appear"')],

--- a/packages/publisher/vitest.unit.config.ts
+++ b/packages/publisher/vitest.unit.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     include: [
+      'test/ka-update-submit-failure.test.ts',
       'test/ack-peer-selection.test.ts',
       'test/trust-metadata.test.ts',
       'test/dkg-publisher-compat.test.ts',

--- a/packages/storage/test/graph-set-index-store.test.ts
+++ b/packages/storage/test/graph-set-index-store.test.ts
@@ -464,6 +464,13 @@ describe('GraphSetIndexStore', () => {
     const scheduler = new StorePriorityScheduler({
       maxConcurrent: 2,
       ackReservedSlots: 0,
+      // Pin the pre-health-lane 2-slot ordinary pool this scenario was designed
+      // around. Commit 4057c25df added DEFAULT_HEALTH_RESERVED_SLOTS=1, which would
+      // otherwise steal the 2nd of 2 slots and clamp normalReservedSlots to 0, so
+      // the normal read could not bypass the in-flight background seed. Production
+      // (DEFAULT_MAX_CONCURRENT=4) keeps a 2-slot ordinary pool, so the bypass
+      // invariant still holds there; only this contrived 2-slot config needs it.
+      healthReservedSlots: 0,
       normalReservedSlots: 1,
       backgroundReservedSlots: 0,
     });
@@ -545,6 +552,13 @@ describe('GraphSetIndexStore', () => {
     const scheduler = new StorePriorityScheduler({
       maxConcurrent: 2,
       ackReservedSlots: 0,
+      // Pin the pre-health-lane 2-slot ordinary pool this scenario was designed
+      // around. Commit 4057c25df added DEFAULT_HEALTH_RESERVED_SLOTS=1, which would
+      // otherwise steal the 2nd of 2 slots and clamp normalReservedSlots to 0, so
+      // the normal read could not bypass the in-flight background seed. Production
+      // (DEFAULT_MAX_CONCURRENT=4) keeps a 2-slot ordinary pool, so the bypass
+      // invariant still holds there; only this contrived 2-slot config needs it.
+      healthReservedSlots: 0,
       normalReservedSlots: 1,
       backgroundReservedSlots: 0,
     });


### PR DESCRIPTION
## Summary

`testnet-canary` has **46 failing tests across 19 files** — the first time the full Node/EVM lanes ran over the rootless-KA cutover delta (they only run advisory checks on canary-targeted PRs, so these accumulated undetected). This PR lands the **three clusters that are code-vs-test-decided, fixed, and locally verified**, and documents the full triage of the rest.

Every failure was diagnosed against `docs/rfcs/ka-graph-content-scope.md` with the rule: a test is **stale** only if it asserts a behavior the RFC *overturned* (root-membership metadata, per-root manifests, legacy-KA mutation, partial-subset state); it's a **code regression** if it asserts a behavior the RFC *preserves* (owner-only access, fail-closed update, discard idempotency, exact-graph replacement). Each verdict got an independent adversarial second pass — which changed or blocked several fixes (see "Deliberately not fixed here").

## Fixed and verified in this PR

| Commit | Cluster | Verdict | Verification |
|---|---|---|---|
| `verifyContractSignature` mock exemption | chain / mock-adapter-parity (1 test) | stale test | parity 15/15, full chain suite **652** |
| graph-set-index scheduler config | storage / graph-set-index-store (2 tests) | stale test | 37/37, **teeth-proven** (mutation re-reds), full storage suite **437** |
| update() non-existent-KA failed status | publisher / update-failed-status (3 tests) | **code regression** | ka-update 20/20, security-regressions 26/26, **teeth-proven**, publisher unit **414** |

Details:

1. **`test(chain): exempt verifyContractSignature`** — canary added the EIP-1271 method `verifyContractSignature` to `EVMChainAdapter`; `MockChainAdapter` lacks it and the CH-8 parity audit went red. It's a real-chain-only on-chain view call, structurally unreachable on the mock (`hasContractCode` returns false), and the two tests that exercise the contract-author branch stub both methods per-test — so the parity audit's own sanctioned exemption route is correct (a mock impl would be misleading dead code).

2. **`test(storage): pin pre-health-lane pool`** — canary's health lane (`DEFAULT_HEALTH_RESERVED_SLOTS=1`, commit 4057c25df) steals the 2nd of 2 slots in two tests' contrived `maxConcurrent:2` scheduler, clamping the normal lane so it can't bypass a background seed. Production (`maxConcurrent=4`) keeps a 2-slot ordinary pool, so the bypass invariant still holds; only the test config was stale. No assertion touched.

3. **`fix(publisher): return failed status when update() targets a non-existent KA`** — a **real regression**. The cutover moved the update authorization check ahead of staging, where `getKnowledgeAssetOwner` → `ownerOf` reverts for a non-existent/expired KA *before* the chain-submit try/catch, so `update()` threw instead of honoring the fail-closed contract (`{status:'failed'}`, no local mutation). Now only that definitive "no updatable KA" class becomes a failed result; every authorization failure (wrong owner → `KA_UPDATE_AUTHOR_NOT_OWNER`, signer mismatch) still throws.

## Deliberately NOT fixed here (need the design owner or the e2e harness)

The adversarial verify pass **blocked two "fixes"** that would have been wrong, and flagged others that need the CI e2e harness (2-node libp2p + hardhat, which is heavy/flaky locally and even throws `NoEligibleContextGraph`):

- **discard-after-promote** (`rootless-graph-lifecycle-e2e`, ~4 tests) — the initial diagnosis called the WM-mutable guard in `assertionDiscardUnlocked` an accidental paste, but the verify found commit 148c30626 **also shipped a deliberate test** (`draft-lifecycle.test.ts:2483` — "full lifecycle … rejects post-promote discard") asserting the *exact opposite*. So the codebase contains a genuine contradiction between the new guard and these e2e tests — a **design-intent decision for the rootless owner**, not a mechanical fix.
- **JSON-LD `assertion.write`** (`publish-jsonld-envelope`, 1 test) — the verify showed bare (non-envelope) JSON-LD → private/no-anchor is the *deliberate* rootless contract (a passing sibling test confirms it), so the proposed `defaultVisibility:'public'` code edit would mutate product code to satisfy a **stale test**. That test should be updated, not the code.
- **wm-promote-lifecycle** (`draft-lifecycle`, 6 tests) — adversarially confirmed a **real** promote-recovery regression (commit 11223763f broke the durable share-operation-id / WM-empty recovery preconditions in `assertionPromoteUnlocked`). Fix is understood but intricate; wanted a focused follow-up PR with hardhat verification rather than bundling.
- **publish-gossip** (`e2e-publish-protocol`, 4 tests) — a **real** cross-node regression: commit ee689fd58 rewrote the SWM-gossip *receiver* to require `contentScopeVersion===2` but the *sender* still emits the legacy shape, so peers receive nothing. Needs the 2-node libp2p harness to verify.
- **access-privacy** (`access-protocol` + `e2e-security`, 9 tests) — stale test setup: canary's trust-boundary gate (commit 6eff62110) now requires a CG root-registration marker the raw-publisher tests never seed (the same commit patched the sibling `access-verification.test.ts` but missed these). The marker is necessary but, for the real-publisher tests, not sufficient — the per-KA `…/context/n/_meta` metadata graph interacts with the filter's sub-graph exclusion in a way that needs a bit more investigation. The 2 collapsed-multi-root cases in the file are a clean marker-seed; the 6 real-publish cases need the deeper fix.
- **misc singletons** — mixed: `kafka-plugin-api.e2e` + `e2e-join` are real (heavy e2e); `host-mode-public-ingest`, `vm-reconcile-self-prime`, `workspace` are stale wire-fixture/scaffolding tests.

## Note on canary CI

`.github/workflows/ci.yml` `pull_request.branches` does not include `testnet-canary`, so this PR (and other canary-targeted PRs) run only advisory checks. The verifications above were run locally against the built packages and, where a chain was needed, the hardhat harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
