### PR TITLE
chore(testnet): promote rootless sync recovery candidate

### DIFF
--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -292,6 +292,12 @@ import { resolveStorageAckLifecycleAssetUalFromLocalSwm } from './storage-ack-li
 const DEFAULT_MAX_REHYDRATED_SUBSCRIPTIONS = 64;
 /** Yield to the event loop every N activations so concurrent store work can interleave. */
 const REHYDRATE_THROTTLE_BATCH = 8;
+// A large rootless VM snapshot may need more than one graph-aligned fetch
+// window. Keep the post-approval bootstrap on the authenticated curator while
+// every round makes verified progress, instead of falling into a broad peer
+// scan and then waiting for an unrelated periodic reconciler. The cap is a
+// hard safety bound; the no-progress guard below is the normal termination.
+const MAX_POST_APPROVAL_CURATOR_SYNC_ROUNDS = 64;
 
 // type alias so listPendingJoinApprovalRetries() retains its old
 // public shape while it stubs out to []. PR-12 rebuilds the operator
@@ -5412,36 +5418,67 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           // authenticated this exact notification sender for this CG before
           // scheduling this method.
           await this.refreshMetaFromCurator(contextGraphId, curatorMetaRefreshOptions);
-          const result = await this.runCatchupOverPeers(contextGraphId, true, [curatorRemote]);
-          // A transient first meta read must not turn a successful payload/SWM
-          // transfer into a false-ready subscription. Retry once after the
-          // catchup and require a live metadata proof before declaring the
-          // curator-targeted bootstrap complete.
-          let hasAuthoritativeMeta = await this.hasConfirmedMetaState(contextGraphId)
-            .catch(() => false);
-          if (!hasAuthoritativeMeta) {
-            await this.refreshMetaFromCurator(contextGraphId, curatorMetaRefreshOptions);
-            hasAuthoritativeMeta = await this.hasConfirmedMetaState(contextGraphId)
+          let includeSharedMemory = true;
+          let totalDataSynced = 0;
+          let totalSharedMemorySynced = 0;
+          for (let round = 1; round <= MAX_POST_APPROVAL_CURATOR_SYNC_ROUNDS; round += 1) {
+            const result = await this.runCatchupOverPeers(
+              contextGraphId,
+              includeSharedMemory,
+              [curatorRemote],
+            );
+            totalDataSynced += result.dataSynced;
+            totalSharedMemorySynced += result.sharedMemorySynced;
+            if (result.sharedMemorySynced > 0) includeSharedMemory = false;
+
+            // A transient first meta read must not turn a successful payload/SWM
+            // transfer into a false-ready subscription. Retry once after each
+            // catchup round and require a live metadata proof before declaring
+            // the curator-targeted bootstrap complete.
+            let hasAuthoritativeMeta = await this.hasConfirmedMetaState(contextGraphId)
               .catch(() => false);
-          }
-          if (hasAuthoritativeMeta) {
-            await this.refreshMetaSyncedFlags([contextGraphId]);
-          }
-          if (result.peersSucceeded > 0 && hasAuthoritativeMeta) {
+            if (!hasAuthoritativeMeta) {
+              await this.refreshMetaFromCurator(contextGraphId, curatorMetaRefreshOptions);
+              hasAuthoritativeMeta = await this.hasConfirmedMetaState(contextGraphId)
+                .catch(() => false);
+            }
+            if (hasAuthoritativeMeta) {
+              await this.refreshMetaSyncedFlags([contextGraphId]);
+            }
+            if (result.peersSucceeded > 0 && hasAuthoritativeMeta) {
+              this.log.info(
+                ctx,
+                `Post-approval sync for "${contextGraphId}" from curator ${curatorShort} fetched ${totalDataSynced} data + ${totalSharedMemorySynced} SWM triples in ${round} round(s)`,
+              );
+              curatorTargetSucceeded = true;
+              break;
+            }
+
+            const madeVerifiedProgress = result.dataSynced > 0 || result.sharedMemorySynced > 0;
+            if (
+              result.denied
+              || !hasAuthoritativeMeta
+              || !madeVerifiedProgress
+              || round === MAX_POST_APPROVAL_CURATOR_SYNC_ROUNDS
+            ) {
+              if (result.peersSucceeded === 0) {
+                this.log.warn(
+                  ctx,
+                  `Post-approval sync for "${contextGraphId}" from curator ${curatorShort} produced no successful peer (denied=${result.denied}, progress=${madeVerifiedProgress}, round=${round}); falling back to broadcast catchup`,
+                );
+              } else {
+                this.log.warn(
+                  ctx,
+                  `Post-approval sync for "${contextGraphId}" transferred payload from curator ${curatorShort} but authoritative metadata is still absent; falling back to broadcast catchup`,
+                );
+              }
+              break;
+            }
+
             this.log.info(
               ctx,
-              `Post-approval sync for "${contextGraphId}" from curator ${curatorShort} fetched ${result.dataSynced} data + ${result.sharedMemorySynced} SWM triples`,
-            );
-            curatorTargetSucceeded = true;
-          } else if (result.peersSucceeded === 0) {
-            this.log.warn(
-              ctx,
-              `Post-approval sync for "${contextGraphId}" from curator ${curatorShort} produced no successful peer (denied=${result.denied}); falling back to broadcast catchup`,
-            );
-          } else {
-            this.log.warn(
-              ctx,
-              `Post-approval sync for "${contextGraphId}" transferred payload from curator ${curatorShort} but authoritative metadata is still absent; falling back to broadcast catchup`,
+              `Post-approval sync for "${contextGraphId}" made verified partial progress from curator ${curatorShort} `
+                + `(data=${result.dataSynced}, SWM=${result.sharedMemorySynced}, round=${round}); retrying curator directly`,
             );
           }
         } else {

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -4821,6 +4821,8 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     deferredBackpressure: number;
     dataSynced: number;
     sharedMemorySynced: number;
+    /** A selected peer completed a non-empty SWM snapshot without failure. */
+    sharedMemoryCompletedCleanly: boolean;
     /**
      * `true` iff at least one peer in this run explicitly denied the sync
      * by emitting a denial sentinel (`syncDenied` marker raised from
@@ -4999,6 +5001,8 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     deferredBackpressure: number;
     dataSynced: number;
     sharedMemorySynced: number;
+    /** A selected peer completed a non-empty SWM snapshot without failure. */
+    sharedMemoryCompletedCleanly: boolean;
     denied: boolean;
     deniedPeers: number;
     diagnostics: CatchupSyncDiagnostics;
@@ -5318,6 +5322,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       deferredBackpressure,
       dataSynced,
       sharedMemorySynced,
+      sharedMemoryCompletedCleanly,
       denied: accessDeniedPeers > 0,
       deniedPeers: accessDeniedPeers,
       diagnostics,
@@ -5429,7 +5434,11 @@ export class LifecycleSyncMethods extends DKGAgentBase {
             );
             totalDataSynced += result.dataSynced;
             totalSharedMemorySynced += result.sharedMemorySynced;
-            if (result.sharedMemorySynced > 0) includeSharedMemory = false;
+            // An insert count only proves partial progress: the SWM requester
+            // may have stored early pages before timing out. Stop requesting
+            // SWM only after this curator completed the plane cleanly; until
+            // then a durable-only success must not suppress SWM bootstrap.
+            if (result.sharedMemoryCompletedCleanly) includeSharedMemory = false;
 
             // A transient first meta read must not turn a successful payload/SWM
             // transfer into a false-ready subscription. Retry once after each

--- a/packages/agent/src/sync/durable-integrity.ts
+++ b/packages/agent/src/sync/durable-integrity.ts
@@ -108,6 +108,163 @@ export interface DurableIntegritySelection {
   logs: DurableIntegrityLogEntry[];
 }
 
+/**
+ * A safe, graph-aligned prefix from an incomplete rootless durable snapshot.
+ *
+ * Durable V2 responders order exact assertion graphs by Unicode code point and
+ * concatenate each complete graph into one stable row stream. A requester may
+ * therefore persist and checkpoint the leading *complete* graphs after a
+ * deadline, while discarding the final partial graph. Legacy/root-scoped or
+ * structurally-invalid metadata deliberately returns `null`: those layouts do
+ * not provide a safe graph boundary and retain the existing all-or-nothing
+ * verification behaviour.
+ */
+export interface BoundedGraphScopedDurableBatch {
+  /** Only rows belonging to complete assertion graphs in this fetch round. */
+  dataQuads: Quad[];
+  /** Exact graphs whose descriptors are in scope for this verification round. */
+  changedDataGraphs: string[];
+  /** Absolute responder row offset at the last complete graph boundary. */
+  safeNextOffset: number;
+  /** Number of positive-size assertion graphs completed in this round. */
+  completedGraphCount: number;
+}
+
+function compareUnicodeCodePoints(leftValue: string, rightValue: string): number {
+  const left = Array.from(leftValue);
+  const right = Array.from(rightValue);
+  const length = Math.min(left.length, right.length);
+  for (let index = 0; index < length; index++) {
+    const delta = left[index]!.codePointAt(0)! - right[index]!.codePointAt(0)!;
+    if (delta !== 0) return delta;
+  }
+  return left.length - right.length;
+}
+
+/**
+ * Project an incomplete/resumed full snapshot onto a safe V2 graph prefix.
+ *
+ * This mirrors the responder's `buildExactGraphPagePlan` ordering. The raw
+ * offset must start on a manifest boundary and the received rows must be a
+ * contiguous prefix of the remaining exact graphs. Any ambiguity fails closed
+ * by returning `null`, so callers cannot advance a cursor on attacker-shaped
+ * metadata or a mixed legacy/V2 snapshot.
+ */
+export function planBoundedGraphScopedDurableBatch(
+  dataQuads: readonly Quad[],
+  metaQuads: readonly Quad[],
+  resumedFromOffset: number,
+  rawNextOffset: number,
+  phaseCompleted: boolean,
+): BoundedGraphScopedDurableBatch | null {
+  if (
+    !Number.isSafeInteger(resumedFromOffset)
+    || resumedFromOffset < 0
+    || !Number.isSafeInteger(rawNextOffset)
+    || rawNextOffset < resumedFromOffset
+    || rawNextOffset - resumedFromOffset !== dataQuads.length
+    || metaQuads.length === 0
+  ) return null;
+
+  const metadata = indexIntegrityMetadata(dataQuads, metaQuads);
+  const parsed = readIntegrityMetadata(metadata, false);
+  if (
+    parsed.fatalUnscopedFailure
+    || parsed.invalidKcUals.size > 0
+    || parsed.candidates.length === 0
+    || parsed.candidates.some((candidate) => candidate.kind !== 'graph-scoped')
+  ) return null;
+
+  const descriptors = (parsed.candidates as GraphScopedCandidate[])
+    .map((candidate) => candidate.descriptor)
+    .sort((left, right) => compareUnicodeCodePoints(left.assertionGraph, right.assertionGraph));
+  const descriptorByGraph = new Map(
+    descriptors.map((descriptor) => [descriptor.assertionGraph, descriptor] as const),
+  );
+  if (descriptorByGraph.size !== descriptors.length) return null;
+
+  const observedCounts = new Map<string, number>();
+  for (const quad of dataQuads) {
+    if (!descriptorByGraph.has(quad.graph)) return null;
+    observedCounts.set(quad.graph, (observedCounts.get(quad.graph) ?? 0) + 1);
+  }
+
+  let manifestOffset = 0;
+  let reachedResumeBoundary = resumedFromOffset === 0;
+  let stoppedAtIncompleteGraph = false;
+  let safeNextOffset = resumedFromOffset;
+  let completedGraphCount = 0;
+  const completeGraphs = new Set<string>();
+  const completedPositiveGraphs: Array<{ graph: string; rowCount: number }> = [];
+
+  // Zero-public V2 assets have no responder rows, but their metadata envelope
+  // is independently verifiable. Keep them in scope on every bounded round;
+  // this is idempotent and avoids an offset ambiguity for zero-width entries.
+  for (const descriptor of descriptors) {
+    if (descriptor.publicTripleCount === 0) completeGraphs.add(descriptor.assertionGraph);
+  }
+
+  for (const descriptor of descriptors) {
+    const expected = descriptor.publicTripleCount;
+    if (expected === 0) continue;
+    const graphStart = manifestOffset;
+    const graphEnd = graphStart + expected;
+    if (!Number.isSafeInteger(graphEnd)) return null;
+    manifestOffset = graphEnd;
+
+    if (!reachedResumeBoundary) {
+      if (graphEnd <= resumedFromOffset) {
+        if ((observedCounts.get(descriptor.assertionGraph) ?? 0) !== 0) return null;
+        continue;
+      }
+      if (graphStart !== resumedFromOffset) return null;
+      reachedResumeBoundary = true;
+    }
+
+    const observed = observedCounts.get(descriptor.assertionGraph) ?? 0;
+    if (stoppedAtIncompleteGraph) {
+      if (observed !== 0) return null;
+      continue;
+    }
+    if (observed === expected) {
+      completeGraphs.add(descriptor.assertionGraph);
+      completedPositiveGraphs.push({
+        graph: descriptor.assertionGraph,
+        rowCount: expected,
+      });
+      safeNextOffset += expected;
+      completedGraphCount += 1;
+      continue;
+    }
+    if (observed < 0 || observed > expected) return null;
+    stoppedAtIncompleteGraph = true;
+  }
+
+  if (!reachedResumeBoundary || safeNextOffset > rawNextOffset) return null;
+
+  // A timed-out fetch can stop exactly on a graph boundary without receiving
+  // the terminal empty page. Do not checkpoint the final complete graph in
+  // that case: the next round must receive at least one verified data graph so
+  // its clean completion can serve as readiness evidence rather than an empty
+  // terminal probe after all useful rows were persisted by timed-out rounds.
+  if (!phaseCompleted && safeNextOffset === rawNextOffset && completedPositiveGraphs.length > 0) {
+    const replay = completedPositiveGraphs.pop()!;
+    completeGraphs.delete(replay.graph);
+    safeNextOffset -= replay.rowCount;
+    completedGraphCount -= 1;
+  }
+
+  const boundedData = dataQuads.filter((quad) => completeGraphs.has(quad.graph));
+  if (boundedData.length !== safeNextOffset - resumedFromOffset) return null;
+
+  return {
+    dataQuads: boundedData,
+    changedDataGraphs: [...completeGraphs],
+    safeNextOffset,
+    completedGraphCount,
+  };
+}
+
 interface GraphScopedDescriptor {
   ual: string;
   assertionGraph: string;

--- a/packages/agent/src/sync/durable-integrity.ts
+++ b/packages/agent/src/sync/durable-integrity.ts
@@ -21,6 +21,7 @@ const ASSERTION_VERSION = `${DKG_NS}assertionVersion`;
 const ASSERTION_GRAPH = `${DKG_NS}assertionGraph`;
 const CONTEXT_GRAPH = `${DKG_NS}contextGraph`;
 const BATCH_ID = `${DKG_NS}batchId`;
+const RESERVED_UAL = `${DKG_NS}reservedUal`;
 const PUBLIC_TRIPLE_COUNT = `${DKG_NS}publicTripleCount`;
 const PRIVATE_TRIPLE_COUNT = `${DKG_NS}privateTripleCount`;
 const PRIVATE_MERKLE_ROOT = `${DKG_NS}privateMerkleRoot`;
@@ -1129,7 +1130,16 @@ function isAuthenticatedSyncControl(
   // Admit only an exact copy of one verified descriptor's immutable scope;
   // a peer cannot use this path to introduce a different graph or version.
   const rows = metadata.metaBySubject.get(quad.subject) ?? [];
-  const owners = distinctObjects(rows, KA_UAL).map(stripLiteral);
+  // The immutable V2 descriptor is keyed directly by dkg:kaUal, while the
+  // named-KA lifecycle subject carries the same identity as dkg:reservedUal.
+  // Publishing re-points that lifecycle subject to the canonical VM graph;
+  // authenticate the repeated scope through either exact identity predicate.
+  // Combining them (rather than preferring one) makes conflicting peer input
+  // fail closed.
+  const owners = [...new Set([
+    ...distinctObjects(rows, KA_UAL),
+    ...distinctObjects(rows, RESERVED_UAL),
+  ].map(stripLiteral))];
   if (owners.length !== 1 || !authenticatedMetadataUals.has(owners[0]!)) return false;
   const descriptorRows = metadata.metaBySubject.get(owners[0]!) ?? [];
   try {

--- a/packages/agent/src/sync/requester/durable-sync.ts
+++ b/packages/agent/src/sync/requester/durable-sync.ts
@@ -4,6 +4,7 @@ import type { OperationContext } from '@origintrail-official/dkg-core';
 import type { Quad } from '@origintrail-official/dkg-storage';
 import type { PhaseCallback } from '@origintrail-official/dkg-publisher';
 import type { DurableBatchVerificationMode } from '../../sync-verify-worker.js';
+import { planBoundedGraphScopedDurableBatch } from '../durable-integrity.js';
 import { didSyncPeerRespond, isSyncBackoffWorthyError, isSyncPermanentRejection, isSyncTransportFailure } from '../error-tags.js';
 import { getSyncCheckpointKey } from '../checkpoint/state.js';
 import type { SyncPageResult } from './page-fetch.js';
@@ -240,16 +241,59 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
       const fetchDurationMs = Date.now() - fetchStartedAt;
       const isSystemContextGraph = (Object.values(SYSTEM_CONTEXT_GRAPHS) as string[]).includes(pid);
 
+      let effectiveDataResult = dataResult;
+      let dataForVerification = dataResult.quads;
+      let verificationMode: DurableBatchVerificationMode = sinceBatchId === undefined
+        ? { kind: 'fullSnapshot' }
+        : { kind: 'sinceBatchId', sinceBatchId };
+
+      // A rootless full snapshot is a deterministic concatenation of complete
+      // exact graphs. When the deadline cuts the final graph mid-page, verify
+      // and persist only the preceding complete graphs, then checkpoint their
+      // absolute row boundary. The partial graph is deliberately discarded and
+      // retried. This gives large V2 snapshots bounded memory and monotonic
+      // progress without weakening legacy/mixed-layout fail-closed behaviour.
+      if (
+        sinceBatchId === undefined
+        && !isSystemContextGraph
+        && (dataResult.timedOut || dataResult.resumedFromOffset > 0)
+      ) {
+        const bounded = planBoundedGraphScopedDurableBatch(
+          dataResult.quads,
+          metaResult.quads,
+          dataResult.resumedFromOffset,
+          dataResult.nextOffset,
+          dataResult.completed,
+        );
+        if (bounded) {
+          dataForVerification = bounded.dataQuads;
+          effectiveDataResult = {
+            ...dataResult,
+            quads: bounded.dataQuads,
+            nextOffset: bounded.safeNextOffset,
+          };
+          verificationMode = {
+            kind: 'changelogPage',
+            changedDataGraphs: bounded.changedDataGraphs,
+          };
+          logInfo(
+            ctx,
+            `Rootless durable progress for "${pid}": `
+              + `${bounded.completedGraphCount} complete graph(s), `
+              + `safe offset ${dataResult.resumedFromOffset}->${bounded.safeNextOffset} `
+              + `(raw ${dataResult.nextOffset})`,
+          );
+        }
+      }
+
       startPhase('verify');
       const verifyStartedAt = Date.now();
       const processed = await processDurableBatchInWorker(
-        dataResult.quads,
+        dataForVerification,
         metaResult.quads,
         ctx,
         isSystemContextGraph,
-        sinceBatchId === undefined
-          ? { kind: 'fullSnapshot' }
-          : { kind: 'sinceBatchId', sinceBatchId },
+        verificationMode,
       );
       endPhase();
       const verifyDurationMs = Date.now() - verifyStartedAt;
@@ -283,9 +327,9 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
           || sinceBatchId !== undefined
           || !batchVerifiedCleanly
           || processed.dataRejectedMissingMeta !== 0
-          || !dataResult.completed
-          || dataResult.timedOut
-          || dataResult.resumedFromOffset !== 0
+          || !effectiveDataResult.completed
+          || effectiveDataResult.timedOut
+          || effectiveDataResult.resumedFromOffset !== 0
           || (!skipAgentsMeta && (!metaResult.completed || metaResult.timedOut))
           || (!skipAgentsMeta && metaResult.resumedFromOffset !== 0)
         ) return;
@@ -337,11 +381,11 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
           countProgress: !metadataOnlyResponse,
           emptyPhase,
         });
-        recordPhaseOutcome(dataResult, {
+        recordPhaseOutcome(effectiveDataResult, {
           updateCheckpoint: updateDataCheckpoint,
           emptyPhase,
         });
-        if ((metaResult.timedOut || dataResult.timedOut) && shouldStopAfterBackoffWorthyFailure(pid, 'phase timeout')) {
+        if ((metaResult.timedOut || effectiveDataResult.timedOut) && shouldStopAfterBackoffWorthyFailure(pid, 'phase timeout')) {
           break;
         }
         continue;
@@ -361,9 +405,9 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
       }
       await notifyVerifiedFullSnapshot();
       recordPhaseOutcome(metaResult, { updateCheckpoint: updateMetaCheckpoint, countProgress: !metadataOnlyResponse });
-      recordPhaseOutcome(dataResult, { updateCheckpoint: updateDataCheckpoint });
+      recordPhaseOutcome(effectiveDataResult, { updateCheckpoint: updateDataCheckpoint });
       endPhase();
-      if ((metaResult.timedOut || dataResult.timedOut) && shouldStopAfterBackoffWorthyFailure(pid, 'phase timeout')) {
+      if ((metaResult.timedOut || effectiveDataResult.timedOut) && shouldStopAfterBackoffWorthyFailure(pid, 'phase timeout')) {
         break;
       }
       const storeDurationMs = Date.now() - storeStartedAt;

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -2924,6 +2924,12 @@ describe('runImmediatePostApprovalSync', () => {
       sharedMemorySynced: number;
       denied: boolean;
     };
+    runCatchupResults?: Array<{
+      peersSucceeded: number;
+      dataSynced: number;
+      sharedMemorySynced: number;
+      denied: boolean;
+    }>;
     runCatchupThrows?: Error;
     broadcastThrows?: Error;
     refreshMetaResults?: Array<boolean | Error>;
@@ -2990,14 +2996,16 @@ describe('runImmediatePostApprovalSync', () => {
         peers: peers.map((p) => p.toString()),
       });
       if (opts.runCatchupThrows) throw opts.runCatchupThrows;
+      const sequencedResult = opts.runCatchupResults?.[calls.runCatchupCalls.length - 1];
+      const configuredResult = sequencedResult ?? opts.runCatchupResult;
       return {
         connectedPeers: 1,
         syncCapablePeers: 1,
         peersTried: 1,
-        peersSucceeded: opts.runCatchupResult?.peersSucceeded ?? 0,
-        dataSynced: opts.runCatchupResult?.dataSynced ?? 0,
-        sharedMemorySynced: opts.runCatchupResult?.sharedMemorySynced ?? 0,
-        denied: opts.runCatchupResult?.denied ?? false,
+        peersSucceeded: configuredResult?.peersSucceeded ?? 0,
+        dataSynced: configuredResult?.dataSynced ?? 0,
+        sharedMemorySynced: configuredResult?.sharedMemorySynced ?? 0,
+        denied: configuredResult?.denied ?? false,
         diagnostics: { noProtocolPeers: 0 } as any,
       };
     };
@@ -3044,6 +3052,58 @@ describe('runImmediatePostApprovalSync', () => {
       peers: [CURATOR_PEER],
     });
     expect(calls.broadcastCalls).toHaveLength(0);
+  }, 15000);
+
+  it('retries curator directly while graph-aligned durable progress is increasing', async () => {
+    const result = await createTestAgent();
+    agent = result.agent;
+    await agent.start();
+
+    const calls = installStubs(agent, {
+      connectedPeers: [CURATOR_PEER],
+      runCatchupResults: [
+        { peersSucceeded: 0, dataSynced: 32_000, sharedMemorySynced: 50_000, denied: false },
+        { peersSucceeded: 1, dataSynced: 18_000, sharedMemorySynced: 0, denied: false },
+      ],
+    });
+    (agent as any).localApprovedAgentByCG.set(
+      'test-cg-bounded-progress',
+      agent.getDefaultAgentAddress()?.toLowerCase(),
+    );
+
+    await (agent as any).runImmediatePostApprovalSync('test-cg-bounded-progress', CURATOR_PEER);
+
+    expect(calls.runCatchupCalls).toEqual([
+      { cg: 'test-cg-bounded-progress', includeSwm: true, peers: [CURATOR_PEER] },
+      { cg: 'test-cg-bounded-progress', includeSwm: false, peers: [CURATOR_PEER] },
+    ]);
+    expect(calls.broadcastCalls).toHaveLength(0);
+  }, 15000);
+
+  it('stops curator-direct retries and falls back when a round makes no progress', async () => {
+    const result = await createTestAgent();
+    agent = result.agent;
+    await agent.start();
+
+    const calls = installStubs(agent, {
+      connectedPeers: [CURATOR_PEER],
+      runCatchupResults: [
+        { peersSucceeded: 0, dataSynced: 32_000, sharedMemorySynced: 50_000, denied: false },
+        { peersSucceeded: 0, dataSynced: 0, sharedMemorySynced: 0, denied: false },
+      ],
+    });
+    (agent as any).localApprovedAgentByCG.set(
+      'test-cg-no-progress',
+      agent.getDefaultAgentAddress()?.toLowerCase(),
+    );
+
+    await (agent as any).runImmediatePostApprovalSync('test-cg-no-progress', CURATOR_PEER);
+
+    expect(calls.runCatchupCalls).toHaveLength(2);
+    expect(calls.broadcastCalls).toEqual([{
+      cg: 'test-cg-no-progress',
+      includeSwm: true,
+    }]);
   }, 15000);
 
   it('falls back to broadcast when curator is not in connected peers after ensurePeerConnected', async () => {

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -2922,12 +2922,14 @@ describe('runImmediatePostApprovalSync', () => {
       peersSucceeded: number;
       dataSynced: number;
       sharedMemorySynced: number;
+      sharedMemoryCompletedCleanly?: boolean;
       denied: boolean;
     };
     runCatchupResults?: Array<{
       peersSucceeded: number;
       dataSynced: number;
       sharedMemorySynced: number;
+      sharedMemoryCompletedCleanly?: boolean;
       denied: boolean;
     }>;
     runCatchupThrows?: Error;
@@ -3005,6 +3007,8 @@ describe('runImmediatePostApprovalSync', () => {
         peersSucceeded: configuredResult?.peersSucceeded ?? 0,
         dataSynced: configuredResult?.dataSynced ?? 0,
         sharedMemorySynced: configuredResult?.sharedMemorySynced ?? 0,
+        sharedMemoryCompletedCleanly:
+          configuredResult?.sharedMemoryCompletedCleanly ?? false,
         denied: configuredResult?.denied ?? false,
         diagnostics: { noProtocolPeers: 0 } as any,
       };
@@ -3062,7 +3066,13 @@ describe('runImmediatePostApprovalSync', () => {
     const calls = installStubs(agent, {
       connectedPeers: [CURATOR_PEER],
       runCatchupResults: [
-        { peersSucceeded: 0, dataSynced: 32_000, sharedMemorySynced: 50_000, denied: false },
+        {
+          peersSucceeded: 0,
+          dataSynced: 32_000,
+          sharedMemorySynced: 50_000,
+          sharedMemoryCompletedCleanly: true,
+          denied: false,
+        },
         { peersSucceeded: 1, dataSynced: 18_000, sharedMemorySynced: 0, denied: false },
       ],
     });
@@ -3076,6 +3086,44 @@ describe('runImmediatePostApprovalSync', () => {
     expect(calls.runCatchupCalls).toEqual([
       { cg: 'test-cg-bounded-progress', includeSwm: true, peers: [CURATOR_PEER] },
       { cg: 'test-cg-bounded-progress', includeSwm: false, peers: [CURATOR_PEER] },
+    ]);
+    expect(calls.broadcastCalls).toHaveLength(0);
+  }, 15000);
+
+  it('keeps requesting SWM after partial inserts until the curator completes it cleanly', async () => {
+    const result = await createTestAgent();
+    agent = result.agent;
+    await agent.start();
+
+    const calls = installStubs(agent, {
+      connectedPeers: [CURATOR_PEER],
+      runCatchupResults: [
+        {
+          peersSucceeded: 0,
+          dataSynced: 32_000,
+          sharedMemorySynced: 50_000,
+          sharedMemoryCompletedCleanly: false,
+          denied: false,
+        },
+        {
+          peersSucceeded: 1,
+          dataSynced: 18_000,
+          sharedMemorySynced: 10_000,
+          sharedMemoryCompletedCleanly: true,
+          denied: false,
+        },
+      ],
+    });
+    (agent as any).localApprovedAgentByCG.set(
+      'test-cg-partial-swm',
+      agent.getDefaultAgentAddress()?.toLowerCase(),
+    );
+
+    await (agent as any).runImmediatePostApprovalSync('test-cg-partial-swm', CURATOR_PEER);
+
+    expect(calls.runCatchupCalls).toEqual([
+      { cg: 'test-cg-partial-swm', includeSwm: true, peers: [CURATOR_PEER] },
+      { cg: 'test-cg-partial-swm', includeSwm: true, peers: [CURATOR_PEER] },
     ]);
     expect(calls.broadcastCalls).toHaveLength(0);
   }, 15000);

--- a/packages/agent/test/rootless-durable-bounded-progress.test.ts
+++ b/packages/agent/test/rootless-durable-bounded-progress.test.ts
@@ -1,0 +1,283 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MemoryLayer,
+  createGraphKnowledgeAssetScope,
+  knowledgeAssetLayerGraphUri,
+  type OperationContext,
+} from '@origintrail-official/dkg-core';
+import {
+  computeFlatKCRootV10,
+  generateGraphKnowledgeAssetMetadata,
+} from '@origintrail-official/dkg-publisher';
+import type { Quad } from '@origintrail-official/dkg-storage';
+import {
+  planBoundedGraphScopedDurableBatch,
+} from '../src/sync/durable-integrity.js';
+import { runDurableSync } from '../src/sync/requester/durable-sync.js';
+import { processDurableBatchForWire } from '../src/sync-verify-worker-impl.js';
+import type {
+  DurableBatchVerificationMode,
+} from '../src/sync-verify-worker.js';
+import type { SyncPageResult } from '../src/sync/requester/page-fetch.js';
+
+const CONTEXT_GRAPH_ID = 'rootless-bounded-progress';
+const CONTEXT_GRAPH_URI = `did:dkg:context-graph:${CONTEXT_GRAPH_ID}`;
+const ctx = { operationId: 'bounded-rootless', operationName: 'sync' } as OperationContext;
+
+interface AssetFixture {
+  graph: string;
+  payload: Quad[];
+  meta: Quad[];
+}
+
+function asset(kaNumber: number, tripleCount = 4): AssetFixture {
+  const ual = `did:dkg:hardhat:31337/0x00000000000000000000000000000000000000ab/${kaNumber}`;
+  const scope = createGraphKnowledgeAssetScope(ual, '1');
+  const graph = knowledgeAssetLayerGraphUri(
+    CONTEXT_GRAPH_ID,
+    MemoryLayer.VerifiableMemory,
+    scope,
+  );
+  const payload = Array.from({ length: tripleCount }, (_, index): Quad => ({
+    subject: `urn:bounded:${kaNumber}:${index}`,
+    predicate: 'urn:bounded:value',
+    object: `"${index}"`,
+    graph,
+  }));
+  const meta = generateGraphKnowledgeAssetMetadata({
+    ual,
+    contextGraphId: CONTEXT_GRAPH_ID,
+    merkleRoot: computeFlatKCRootV10(payload, []),
+    publisherPeerId: 'publisher-peer',
+    accessPolicy: 'public',
+    timestamp: new Date(0),
+    assertionVersion: '1',
+    publicTripleCount: payload.length,
+    privateTripleCount: 0,
+    assertionGraph: graph,
+  }, 'tentative');
+  return { graph, payload, meta };
+}
+
+function orderedAssets(): AssetFixture[] {
+  return [asset(1), asset(2), asset(3)]
+    .sort((left, right) => left.graph.localeCompare(right.graph));
+}
+
+function pageResult(
+  phase: 'data' | 'meta',
+  overrides: Partial<SyncPageResult>,
+): SyncPageResult {
+  return {
+    quads: [],
+    bytesReceived: 0,
+    resumedFromOffset: 0,
+    nextOffset: 0,
+    checkpointKey: `${CONTEXT_GRAPH_ID}:${phase}`,
+    completed: true,
+    timedOut: false,
+    ...overrides,
+  };
+}
+
+function processBatch(
+  dataQuads: Quad[],
+  metaQuads: Quad[],
+  _ctx: OperationContext,
+  acceptUnverified: boolean,
+  mode: DurableBatchVerificationMode,
+) {
+  const wire = processDurableBatchForWire(dataQuads, metaQuads, acceptUnverified, mode);
+  return {
+    verifiedData: wire.verifiedDataIndexes.map((index) => dataQuads[index]!),
+    verifiedMeta: wire.verifiedMetaIndexes.map((index) => metaQuads[index]!),
+    verifiedGraphScopedDataGraphs: wire.verifiedGraphScopedDataGraphs,
+    droppedSyncControlTriples: wire.droppedSyncControlTriples,
+    verifiedPrivateOnlyResponses: wire.verifiedPrivateOnlyResponses,
+    totalFetchedDataQuads: wire.totalFetchedDataQuads,
+    totalFetchedMetaQuads: wire.totalFetchedMetaQuads,
+    rejectedKcs: wire.rejectedKcs,
+    emptyResponses: wire.emptyResponses,
+    metaOnlyResponses: wire.metaOnlyResponses,
+    dataRejectedMissingMeta: wire.dataRejectedMissingMeta,
+  };
+}
+
+describe('bounded rootless durable progress', () => {
+  it('projects a timed-out response to the last complete exact-graph boundary', () => {
+    const fixtures = orderedAssets();
+    const meta = fixtures.flatMap((entry) => entry.meta);
+    const rawData = [
+      ...fixtures[0]!.payload,
+      ...fixtures[1]!.payload,
+      ...fixtures[2]!.payload.slice(0, 2),
+    ];
+
+    const plan = planBoundedGraphScopedDurableBatch(
+      rawData,
+      meta,
+      0,
+      rawData.length,
+      false,
+    );
+
+    expect(plan).not.toBeNull();
+    expect(plan?.safeNextOffset).toBe(8);
+    expect(plan?.completedGraphCount).toBe(2);
+    expect(plan?.changedDataGraphs).toEqual([
+      fixtures[0]!.graph,
+      fixtures[1]!.graph,
+    ]);
+    expect(plan?.dataQuads).toEqual([
+      ...fixtures[0]!.payload,
+      ...fixtures[1]!.payload,
+    ]);
+  });
+
+  it('replays one complete graph when timeout lands exactly on a boundary', () => {
+    const fixtures = orderedAssets();
+    const meta = fixtures.flatMap((entry) => entry.meta);
+    const rawData = [
+      ...fixtures[0]!.payload,
+      ...fixtures[1]!.payload,
+    ];
+
+    const plan = planBoundedGraphScopedDurableBatch(
+      rawData,
+      meta,
+      0,
+      rawData.length,
+      false,
+    );
+
+    expect(plan?.safeNextOffset).toBe(4);
+    expect(plan?.completedGraphCount).toBe(1);
+    expect(plan?.dataQuads).toEqual(fixtures[0]!.payload);
+  });
+
+  it('stores the verified prefix and checkpoints only its safe row offset', async () => {
+    const fixtures = orderedAssets();
+    const meta = fixtures.flatMap((entry) => entry.meta);
+    const rawData = [
+      ...fixtures[0]!.payload,
+      ...fixtures[1]!.payload,
+      ...fixtures[2]!.payload.slice(0, 2),
+    ];
+    const inserted: Quad[][] = [];
+    const checkpoints: Array<[string, number]> = [];
+
+    const summary = await runDurableSync({
+      ctx,
+      remotePeerId: 'peer-a',
+      contextGraphIds: [CONTEXT_GRAPH_ID],
+      createContextGraphSyncDeadline: () => Date.now() + 60_000,
+      fetchSyncPages: async (
+        _ctx,
+        _peer,
+        _contextGraphId,
+        _includeSharedMemory,
+        phase,
+      ) => phase === 'meta'
+        ? pageResult('meta', {
+          quads: meta,
+          nextOffset: meta.length,
+        })
+        : pageResult('data', {
+          quads: rawData,
+          nextOffset: rawData.length,
+          completed: false,
+          timedOut: true,
+        }),
+      processDurableBatchInWorker: processBatch,
+      storeInsert: async (quads) => { inserted.push(quads); },
+      deleteCheckpoint: () => {},
+      setCheckpoint: (key, offset) => { checkpoints.push([key, offset]); },
+      logInfo: () => {},
+      logWarn: () => {},
+      logDebug: () => {},
+    });
+
+    expect(summary.rejectedKcs).toBe(0);
+    expect(summary.timedOutPhases).toBe(1);
+    expect(summary.insertedDataTriples).toBe(8);
+    expect(checkpoints).toContainEqual([`${CONTEXT_GRAPH_ID}:data`, 8]);
+    expect(inserted[0]).toEqual([
+      ...fixtures[0]!.payload,
+      ...fixtures[1]!.payload,
+    ]);
+    expect(inserted.flat().some((quad) => quad.graph === fixtures[2]!.graph)).toBe(false);
+  });
+
+  it('verifies the remaining suffix and cleanly completes a resumed snapshot', async () => {
+    const fixtures = orderedAssets();
+    const meta = fixtures.flatMap((entry) => entry.meta);
+    const suffix = fixtures[2]!.payload;
+    const inserted: Quad[][] = [];
+    const deleted: string[] = [];
+
+    const summary = await runDurableSync({
+      ctx,
+      remotePeerId: 'peer-a',
+      contextGraphIds: [CONTEXT_GRAPH_ID],
+      createContextGraphSyncDeadline: () => Date.now() + 60_000,
+      fetchSyncPages: async (
+        _ctx,
+        _peer,
+        _contextGraphId,
+        _includeSharedMemory,
+        phase,
+      ) => phase === 'meta'
+        ? pageResult('meta', {
+          quads: meta,
+          nextOffset: meta.length,
+        })
+        : pageResult('data', {
+          quads: suffix,
+          resumedFromOffset: 8,
+          nextOffset: 12,
+          completed: true,
+          timedOut: false,
+        }),
+      processDurableBatchInWorker: processBatch,
+      storeInsert: async (quads) => { inserted.push(quads); },
+      deleteCheckpoint: (key) => { deleted.push(key); },
+      setCheckpoint: () => {},
+      logInfo: () => {},
+      logWarn: () => {},
+      logDebug: () => {},
+    });
+
+    expect(summary.rejectedKcs).toBe(0);
+    expect(summary.timedOutPhases).toBe(0);
+    expect(summary.insertedDataTriples).toBe(4);
+    expect(summary.completedPhases).toBe(2);
+    expect(deleted).toContain(`${CONTEXT_GRAPH_ID}:data`);
+    expect(inserted[0]).toEqual(suffix);
+  });
+
+  it('fails closed for mixed legacy and graph-scoped metadata', () => {
+    const fixtures = orderedAssets();
+    const mixedMeta = [
+      ...fixtures.flatMap((entry) => entry.meta),
+      {
+        subject: 'did:dkg:legacy:1',
+        predicate: 'http://dkg.io/ontology/merkleRoot',
+        object: '"00"',
+        graph: `${CONTEXT_GRAPH_URI}/_meta`,
+      } as Quad,
+    ];
+    const rawData = [
+      ...fixtures[0]!.payload,
+      ...fixtures[1]!.payload,
+      ...fixtures[2]!.payload.slice(0, 2),
+    ];
+
+    expect(planBoundedGraphScopedDurableBatch(
+      rawData,
+      mixedMeta,
+      0,
+      rawData.length,
+      false,
+    )).toBeNull();
+  });
+});

--- a/packages/agent/test/sync-control-metadata-admission.test.ts
+++ b/packages/agent/test/sync-control-metadata-admission.test.ts
@@ -90,6 +90,83 @@ describe('durable sync control metadata admission', () => {
     ]);
   });
 
+  it('authenticates a named-KA lifecycle VM pointer through its reserved UAL', () => {
+    const scope = createGraphKnowledgeAssetScope(UAL, '1');
+    const assertionGraph = knowledgeAssetLayerGraphUri(
+      CONTEXT_GRAPH_ID,
+      MemoryLayer.VerifiableMemory,
+      scope,
+    );
+    const data = [quad('urn:verified:entity', 'urn:example:value', '"verified"', assertionGraph)];
+    const descriptor = generateGraphKnowledgeAssetMetadata({
+      ual: UAL,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      merkleRoot: computeFlatKCRootV10(data, []),
+      publisherPeerId: 'verified-publisher',
+      accessPolicy: 'public',
+      timestamp: new Date(0),
+      assertionVersion: '1',
+      publicTripleCount: data.length,
+      assertionGraph,
+    }, 'tentative');
+    const lifecycle = `urn:dkg:assertion:${CONTEXT_GRAPH_ID}:0x00000000000000000000000000000000000000AB:asset`;
+    const lifecycleRows = [
+      quad(lifecycle, `${DKG}contentScopeVersion`, integer(2n)),
+      quad(lifecycle, `${DKG}reservedUal`, `"${UAL}"`),
+      quad(lifecycle, `${DKG}assertionVersion`, integer(1n)),
+      quad(lifecycle, `${DKG}assertionGraph`, assertionGraph),
+      quad(lifecycle, `${DKG}state`, '"published"'),
+    ];
+    const meta = [...descriptor, ...lifecycleRows];
+
+    const selection = selectVerifiedDurableSyncQuads(data, meta, false);
+
+    expect(selection.rejected).toBe(0);
+    expect(selection.droppedSyncControlTriples).toBe(0);
+    expect(selection.metaIndexes.map((index) => meta[index]!)).toEqual(meta);
+  });
+
+  it('rejects lifecycle controls when kaUal and reservedUal identities conflict', () => {
+    const scope = createGraphKnowledgeAssetScope(UAL, '1');
+    const assertionGraph = knowledgeAssetLayerGraphUri(
+      CONTEXT_GRAPH_ID,
+      MemoryLayer.VerifiableMemory,
+      scope,
+    );
+    const data = [quad('urn:verified:entity', 'urn:example:value', '"verified"', assertionGraph)];
+    const descriptor = generateGraphKnowledgeAssetMetadata({
+      ual: UAL,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      merkleRoot: computeFlatKCRootV10(data, []),
+      publisherPeerId: 'verified-publisher',
+      accessPolicy: 'public',
+      timestamp: new Date(0),
+      assertionVersion: '1',
+      publicTripleCount: data.length,
+      assertionGraph,
+    }, 'tentative');
+    const lifecycle = 'urn:dkg:assertion:conflicting-owner';
+    const descriptiveRows = [
+      quad(lifecycle, `${DKG}contentScopeVersion`, integer(2n)),
+      quad(lifecycle, `${DKG}kaUal`, UAL),
+      quad(lifecycle, `${DKG}reservedUal`, `"${UAL_B}"`),
+    ];
+    const controlRows = [
+      quad(lifecycle, `${DKG}assertionVersion`, integer(1n)),
+      quad(lifecycle, `${DKG}assertionGraph`, assertionGraph),
+    ];
+    const meta = [...descriptor, ...descriptiveRows, ...controlRows];
+
+    const selection = selectVerifiedDurableSyncQuads(data, meta, false);
+
+    expect(selection.rejected).toBe(0);
+    expect(selection.droppedSyncControlTriples).toBe(2);
+    expect(selection.metaIndexes.map((index) => meta[index]!)).toEqual([
+      ...descriptor,
+      ...descriptiveRows,
+    ]);
+  });
+
   it('drops orphaned controls from an otherwise unverified system-graph page', () => {
     const subject = 'urn:system:unverified-control';
     const descriptive = quad(subject, `${DKG}status`, '"keep"');

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -56,6 +56,7 @@ export default defineConfig({
       "test/sync-backpressure.test.ts",
       "test/sync-requester-priority.test.ts",
       "test/sync-requester-progress.test.ts",
+      "test/rootless-durable-bounded-progress.test.ts",
       "test/swm-recovery.test.ts",
       "test/sync-responder-protection.test.ts",
       "test/sync-on-connect-retry.test.ts",

--- a/scripts/devnet-test-private-cg-membership-recovery.sh
+++ b/scripts/devnet-test-private-cg-membership-recovery.sh
@@ -214,6 +214,8 @@ TESTNET_MAX_ACCEPT_QUEUE="${TESTNET_MAX_ACCEPT_QUEUE:-128}"
 TESTNET_SERVICE="${TESTNET_SERVICE:-dkg-v9-node}"
 TESTNET_SSH_CONNECT_TIMEOUT="${TESTNET_SSH_CONNECT_TIMEOUT:-90}"
 INTEGRITY_PROGRESS_EVERY_KAS="${INTEGRITY_PROGRESS_EVERY_KAS:-10}"
+INTEGRITY_RATE_LIMIT_BACKOFF_S="${INTEGRITY_RATE_LIMIT_BACKOFF_S:-61}"
+INTEGRITY_RATE_LIMIT_MAX_RETRIES="${INTEGRITY_RATE_LIMIT_MAX_RETRIES:-3}"
 HEALTH_SAMPLE_EVERY_KAS="${HEALTH_SAMPLE_EVERY_KAS:-5}"
 HEALTH_SAMPLE_INTERVAL_S="${HEALTH_SAMPLE_INTERVAL_S:-15}"
 TESTNET_MAX_MEMORY_USED_PERCENT="${TESTNET_MAX_MEMORY_USED_PERCENT:-90}"
@@ -273,7 +275,9 @@ for numeric in \
   "$RECOVERY_TIMEOUT_S" "$POST_RESTART_TIMEOUT_S" \
   "$RECOVERY_EXACT_RECHECK_INTERVAL_S" \
   "$TESTNET_MAX_ACCEPT_QUEUE" "$TESTNET_SSH_CONNECT_TIMEOUT" \
-  "$INTEGRITY_PROGRESS_EVERY_KAS" "$HEALTH_SAMPLE_EVERY_KAS" \
+  "$INTEGRITY_PROGRESS_EVERY_KAS" \
+  "$INTEGRITY_RATE_LIMIT_BACKOFF_S" "$INTEGRITY_RATE_LIMIT_MAX_RETRIES" \
+  "$HEALTH_SAMPLE_EVERY_KAS" \
   "$HEALTH_SAMPLE_INTERVAL_S" "$TESTNET_MAX_MEMORY_USED_PERCENT" \
   "$TESTNET_MAX_LOAD_PER_CPU_PERCENT" \
   "$TESTNET_SATURATION_CONSECUTIVE_SAMPLES" \
@@ -286,6 +290,10 @@ for numeric in \
 done
 [ "$INTEGRITY_PROGRESS_EVERY_KAS" -ge 1 ] \
   || { echo "INTEGRITY_PROGRESS_EVERY_KAS must be at least 1." >&2; exit 2; }
+[ "$INTEGRITY_RATE_LIMIT_BACKOFF_S" -ge 1 ] \
+  || { echo "INTEGRITY_RATE_LIMIT_BACKOFF_S must be at least 1." >&2; exit 2; }
+[ "$INTEGRITY_RATE_LIMIT_MAX_RETRIES" -ge 1 ] \
+  || { echo "INTEGRITY_RATE_LIMIT_MAX_RETRIES must be at least 1." >&2; exit 2; }
 [ "$VM_PUBLISH_POLL_INTERVAL_S" -ge 1 ] \
   || { echo "VM_PUBLISH_POLL_INTERVAL_S must be at least 1." >&2; exit 2; }
 [ "$VM_PUBLISH_PROGRESS_EVERY_KAS" -ge 1 ] \
@@ -1233,6 +1241,40 @@ curl "${args[@]}"'
   fi
 }
 
+# Integrity certification deliberately performs exact, per-KA reads. Testnet
+# cores rate-limit API clients to a fixed one-minute window, so a valid run can
+# otherwise misread the JSON 429 response as an empty SPARQL result. Retry only
+# this read-only certification traffic; keep all state-changing API calls and
+# negative-path assertions on the original fail-fast semantics.
+integrity_api_call() {
+  local node="$1" method="$2" path="$3" data="${4:-}"
+  local response attempt=0
+  while [ "$attempt" -le "$INTEGRITY_RATE_LIMIT_MAX_RETRIES" ]; do
+    if ! response="$(api_call "$node" "$method" "$path" "$data")"; then
+      return 1
+    fi
+    case "$response" in
+      *"Too many requests"*)
+        if [ "$attempt" -ge "$INTEGRITY_RATE_LIMIT_MAX_RETRIES" ]; then
+          printf '%s' "$response"
+          return 1
+        fi
+        attempt=$((attempt + 1))
+        printf '%s node=%s method=%s path=%s attempt=%s backoff_s=%s\n' \
+          "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$node" "$method" "$path" \
+          "$attempt" "$INTEGRITY_RATE_LIMIT_BACKOFF_S" \
+          >> "$RUN_DIR/integrity-rate-limit-retries.log"
+        sleep "$INTEGRITY_RATE_LIMIT_BACKOFF_S"
+        ;;
+      *)
+        printf '%s' "$response"
+        return 0
+        ;;
+    esac
+  done
+  return 1
+}
+
 node_ready() {
   local node="$1" body
   body="$(API_TIMEOUT_OVERRIDE=5 api_call "$node" GET /api/status 2>/dev/null || true)"
@@ -1493,7 +1535,7 @@ integrity_head_query() {
       ...(process.env.LANE === "subgraph" ? { subGraphName: process.env.SUB } : {}),
     }));
   ')"
-  api_call "$node" POST /api/query "$body"
+  integrity_api_call "$node" POST /api/query "$body"
 }
 
 validate_integrity_head_response() {
@@ -1566,7 +1608,7 @@ integrity_data_query() {
       ...(process.env.LANE === "subgraph" ? { subGraphName: process.env.SUB } : {}),
     }));
   ')"
-  api_call "$node" POST /api/query "$body"
+  integrity_api_call "$node" POST /api/query "$body"
 }
 
 validate_integrity_data_response() {
@@ -1618,7 +1660,7 @@ vm_integrity_data_query() {
       ...(process.env.LANE === "subgraph" ? { subGraphName: process.env.SUB } : {}),
     }));
   ')"
-  api_call "$node" POST /api/query "$body"
+  integrity_api_call "$node" POST /api/query "$body"
 }
 
 validate_vm_descriptor() {
@@ -1904,7 +1946,7 @@ knowledge_asset_descriptor() {
   if [ "$lane" = "subgraph" ]; then
     path="$path&subGraphName=$(urlencode "$SUB_GRAPH_NAME")"
   fi
-  api_call "$node" GET "$path"
+  integrity_api_call "$node" GET "$path"
 }
 
 epoch_ms() {
@@ -2115,6 +2157,7 @@ vm_publish_progress() {
       const missing = [];
       const failed = [];
       let terminal = 0;
+      let retryEligible = 0;
       for (const row of tracked) {
         const job = byId.get(row.jobId);
         if (!job) {
@@ -2124,6 +2167,13 @@ vm_publish_progress() {
         counts[job.status] = (counts[job.status] || 0) + 1;
         if (job.status === "finalized" || job.status === "failed") terminal += 1;
         if (job.status === "failed") {
+          if (
+            job.failure?.retryable === true &&
+            job.failure?.resolution !== "retry_recovery" &&
+            Number(job.retries?.retryCount || 0) < Number(job.retries?.maxRetries || 0)
+          ) {
+            retryEligible += 1;
+          }
           failed.push({
             ordinal: row.ordinal,
             jobId: row.jobId,
@@ -2137,6 +2187,8 @@ vm_publish_progress() {
         terminal,
         finalized: counts.finalized || 0,
         failed: counts.failed || 0,
+        retryEligible,
+        globalFailed: jobs.filter(job => job.status === "failed").length,
         missing,
         statuses: counts,
         failures: failed,
@@ -2240,7 +2292,7 @@ record_vm_publish_manifest_row() {
 
 publish_seed_manifest_to_vm() {
   [ "$VM_PUBLISH_MODE" = "async-all" ] || return 0
-  local row jobs_response progress previous_progress="" start now
+  local row jobs_response progress previous_progress="" retry_response retry_count start now
   local enqueue_row job_id job descriptor vm_row ordinal
   VM_PUBLISH_STARTED_AT_MS="$(epoch_ms)"
   while IFS= read -r row; do
@@ -2258,6 +2310,24 @@ publish_seed_manifest_to_vm() {
     if [ "$progress" != "$previous_progress" ]; then
       log "VM publisher progress: $(json_get "$progress" terminal)/$VM_PLANNED_KA_COUNT terminal; statuses=$(json_get "$progress" statuses)"
       previous_progress="$progress"
+    fi
+    if [ "$(json_get "$progress" failed)" != "0" ] \
+      && [ "$(json_get "$progress" retryEligible)" = "$(json_get "$progress" failed)" ]; then
+      # Lift jobs intentionally expose retryable failures as a durable failed
+      # state plus an explicit retry control-plane action. Exercise that path
+      # instead of treating a transient all-RPC outage as terminal. The retry
+      # endpoint currently operates on every failed publisher job, so fail
+      # closed if this dedicated harness edge has any unrelated failed job.
+      [ "$(json_get "$progress" globalFailed)" = "$(json_get "$progress" failed)" ] \
+        || fail "refusing global publisher retry while unrelated failed jobs exist: $progress"
+      retry_response="$(api_call "$CURATOR_NODE" POST /api/publisher/retry '{"status":"failed"}' 2>/dev/null || true)"
+      retry_count="$(json_get "$retry_response" retried 2>/dev/null || true)"
+      [ -n "$retry_count" ] && [ "$retry_count" != "0" ] \
+        || fail "publisher declined retry for tracked retryable VM jobs: response=$retry_response progress=$progress"
+      log "VM publisher control plane requeued $retry_count retryable job(s)"
+      maybe_sample_node_health vm-publish-retry
+      sleep "$VM_PUBLISH_POLL_INTERVAL_S"
+      continue
     fi
     # A publisher status transition currently replaces its RDF row as a
     # delete followed by an insert. A concurrent list call can therefore miss
@@ -2437,6 +2507,46 @@ assert_fixed_list_state() {
     || fail "recovered CG does not report subscribed=true: $row"
   [ "$(json_get "$row" synced)" = "true" ] \
     || fail "recovered CG does not report synced=true: $row"
+}
+
+reactivate_joiner_subscription_if_dormant() {
+  local subscriptions state response body
+  subscriptions="$(integrity_api_call "$JOINER_NODE" GET /api/context-graph/subscriptions 2>/dev/null || true)"
+  state="$(printf '%s' "$subscriptions" | CG="$CG_ID" node -e '
+    let d = "";
+    process.stdin.on("data", c => d += c);
+    process.stdin.on("end", () => {
+      try {
+        const payload = JSON.parse(d);
+        const active = (payload.subscriptions || [])
+          .some(row => row?.contextGraphId === process.env.CG);
+        const dormant = (payload.rehydration?.dormantIds || [])
+          .includes(process.env.CG);
+        process.stdout.write(dormant ? "dormant" : active ? "active" : "absent");
+      } catch {
+        process.stdout.write("unreadable");
+      }
+    });
+  ')"
+  [ "$state" = "dormant" ] || return 0
+
+  # Testnet deliberately caps startup activation of non-hosted subscriptions
+  # to protect the store from a stale-backlog fan-out. Repeated harness runs
+  # can therefore leave this freshly verified CG persisted but dormant after
+  # restart. Explicit access is the documented reactivation path: exercise it
+  # and then let the normal recovery/durability assertions prove exact state.
+  save_artifact "post-restart-rehydration-before-reactivation.json" "$subscriptions"
+  body="$(CG="$CG_ID" node -e '
+    process.stdout.write(JSON.stringify({
+      contextGraphId: process.env.CG,
+      includeSharedMemory: true,
+    }));
+  ')"
+  response="$(api_call "$JOINER_NODE" POST /api/context-graph/subscribe "$body")"
+  save_artifact "post-restart-reactivation-response.json" "$response"
+  [ "$(json_get "$response" subscribed)" = "$CG_ID" ] \
+    || fail "joiner could not reactivate its persisted dormant subscription after restart: $response"
+  log "joiner reactivated the persisted CG after the configured startup subscription cap left it dormant"
 }
 
 snapshot_phase() {
@@ -3405,6 +3515,7 @@ wait_node_ready "$JOINER_NODE" 90 \
 JOINER_STOPPED=0
 
 if [ "$HARNESS_EXPECT" = "fixed" ]; then
+  reactivate_joiner_subscription_if_dormant
   wait_full_recovery "$POST_RESTART_TIMEOUT_S" \
     || { snapshot_phase post-restart-timeout; fail "fixed state did not survive/recover after joiner restart"; }
   assert_fixed_list_state


### PR DESCRIPTION
Promotes exact main candidate 54db3356cc1d82a9af1767e2cee5b6e02fc23f56 to testnet-canary after the full hotfixed 50 SWM + 50 VM private-CG autoApprove, late-join, integrity, restart, and resource gate passed. Includes bounded graph-safe rootless progress, verified VM lifecycle pointers, clean SWM retry handoff, and harness recovery hardening.\n\nAfter merge we will attest tree identity across main/testnet-canary and the four deployed nodes, then rerun the clean 50+50 gate before the mandatory 1,000+1,000 soak.