### PR TITLE
fix(chain): add gas headroom to V10 writes

### DIFF
--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -187,6 +187,14 @@ export const RESOLVE_CONTRACT_ADDRESS_MEMO_TTL_MS = 30_000;
 
 const KA_HIGH_WATER_VIEW_SIGNATURE = 'getMaxKaNumberForAuthor(address)';
 
+// V10 publish/update execution cost can increase between eth_estimateGas and
+// mining when concurrent writes land first and advance shared contract state.
+// Base Sepolia Jenkins evidence showed three status=0 receipts consuming their
+// gas limits exactly while four nodes published into the same block. Keep this
+// headroom local to the shared V10 write path; unrelated contract writes retain
+// their existing gas policy.
+const V10_WRITE_GAS_LIMIT_BUFFER_BPS = 2_500;
+
 type IdentityIdCacheEntry = {
   identityId: bigint;
   ttlMs: number;
@@ -1513,6 +1521,7 @@ export class EVMChainAdapterBase {
           [methodParams],
           signer,
           `V10 ${method}`,
+          { gasLimitBufferBps: V10_WRITE_GAS_LIMIT_BUFFER_BPS },
         );
       } catch (err) {
         enrichEvmError(err);

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -4735,6 +4735,54 @@ const rawTooLowAllowanceRevert = () => {
 
 describe('populateAndSignV10WithAllowanceRecovery — shared publish/update recovery (#888/#896)', () => {
 
+  it('applies 25% gas headroom to every concurrent V10 publish preparation', async () => {
+    const { a } = makeRecoveryAdapter();
+    const signerA = new ethers.Wallet(DEPLOYER_PK);
+    const signerB = new ethers.Wallet(OTHER_PK);
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const populateAndSign = recorder(async (..._args: unknown[]) => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await Promise.resolve();
+      inFlight -= 1;
+      return { signedTx: '0xsigned', txHash: '0xhash' };
+    });
+    (a as any).populateAndSignAcrossProviders = populateAndSign;
+
+    await Promise.all([
+      (a as any).populateAndSignV10WithAllowanceRecovery(
+        signerA, {}, 'publish', {}, V10_KA_ADDRESS, 1n, 'label A',
+      ),
+      (a as any).populateAndSignV10WithAllowanceRecovery(
+        signerB, {}, 'publish', {}, V10_KA_ADDRESS, 1n, 'label B',
+      ),
+    ]);
+
+    expect(populateAndSign.calls).toHaveLength(2);
+    expect(maxInFlight).toBe(2);
+    for (const call of populateAndSign.calls) {
+      expect(call[4]).toBe('V10 publish');
+      expect(call[5]).toEqual({ gasLimitBufferBps: 2_500 });
+    }
+  });
+
+  it('applies the same 25% gas headroom to V10 update preparation', async () => {
+    const { a, signer } = makeRecoveryAdapter();
+    const populateAndSign = recorder(async (..._args: unknown[]) => (
+      { signedTx: '0xsigned', txHash: '0xhash' }
+    ));
+    (a as any).populateAndSignAcrossProviders = populateAndSign;
+
+    await (a as any).populateAndSignV10WithAllowanceRecovery(
+      signer, {}, 'update', {}, V10_KA_ADDRESS, 1n, 'label',
+    );
+
+    expect(populateAndSign.calls).toHaveLength(1);
+    expect(populateAndSign.calls[0][4]).toBe('V10 update');
+    expect(populateAndSign.calls[0][5]).toEqual({ gasLimitBufferBps: 2_500 });
+  });
+
   // The 🔴 fix: BOTH write paths recover from a pre-broadcast
   // `TooLowAllowance` revert, not just publish.
   it.each(['publish', 'update'] as const)(


### PR DESCRIPTION
## What changed

- Add 25% gas-limit headroom to V10 `publish` and `update` transaction preparation through the existing RPC-failover gas-estimation path.
- Keep the policy scoped to V10 knowledge-asset writes; unrelated contract writes, fees, nonce serialization, allowance recovery, and broadcast behavior are unchanged.
- Add regression coverage proving concurrent publish preparations and update preparations receive the buffer.

## Why

Base testnet Jenkins build 29 produced three `status=0` publish receipts in the same block. On-chain receipts showed that every failed transaction consumed exactly its full gas limit:

| Transaction | Gas limit | Gas used | Status |
| --- | ---: | ---: | ---: |
| `0x917b...f13e` | 703,770 | 703,770 | 0 |
| `0x9a9f...170e` | 735,848 | 735,848 | 0 |
| `0x7287...6f49` | 738,378 | 738,378 | 0 |

They were mined alongside another concurrent publish that succeeded with only about 3% gas headroom. This is the characteristic signature of the estimate becoming stale when another state-changing publish lands before mining, rather than a Jenkins harness failure.

Jenkins evidence: https://titan.dplcenter.xyz/view/V10%20Publish%20Tests/job/V10_Base_Testnet/29/console

## Verification

- `pnpm --filter @origintrail-official/dkg-chain run build`
- `pnpm --filter @origintrail-official/dkg-chain run test:unit -- --reporter=dot`
  - 29 test files passed
  - 653 tests passed, 1 pre-existing skip
- Focused V10 recovery/buffer regression: 10 passed

Unused gas is not charged, so the buffer raises the transaction ceiling without increasing normal execution gas consumption.
