### PR TITLE
Fix remote reads from StorageACK cores

### DIFF
--- a/packages/agent/src/finalization-handler.ts
+++ b/packages/agent/src/finalization-handler.ts
@@ -2620,7 +2620,12 @@ export class FinalizationHandler {
     // reuse the memoized root only when the op's current content still hashes to the
     // same cheap digest; any content change flips the digest → full recompute → the
     // op is re-evaluated and re-stamped. No op can be stranded by a stale stamp.
-    type OpMemo = { roots: string[]; memoRoot?: string; memoDigest?: string };
+    type OpMemo = {
+      roots: string[];
+      privateRoots: Uint8Array[];
+      memoRoot?: string;
+      memoDigest?: string;
+    };
     const opsBySubject = new Map<string, OpMemo>();
     try {
       const memoPatterns = useStampIndex
@@ -2638,7 +2643,7 @@ export class FinalizationHandler {
           const op = typeof row['op'] === 'string' ? row['op'].replace(/^<(.*)>$/, '$1') : '';
           const root = typeof row['root'] === 'string' ? row['root'].replace(/^<(.*)>$/, '$1') : '';
           if (!op || !isSafeIri(root)) continue;
-          const memo = opsBySubject.get(op) ?? { roots: [] };
+          const memo = opsBySubject.get(op) ?? { roots: [], privateRoots: [] };
           if (!memo.roots.includes(root)) memo.roots.push(root);
           if (memo.memoRoot === undefined && typeof row['memoRoot'] === 'string') {
             memo.memoRoot = row['memoRoot'].replace(/^"(.*)".*$/, '$1');
@@ -2647,6 +2652,30 @@ export class FinalizationHandler {
             memo.memoDigest = row['memoDigest'].replace(/^"(.*)".*$/, '$1');
           }
           opsBySubject.set(op, memo);
+        }
+      }
+
+      // Folded-private legacy ACK snapshots attach their private roots to the
+      // operation, rather than to a reusable entity. Keep this as a separate
+      // lookup so the established operation-enumeration query remains stable
+      // for store adapters and instrumentation that identify the full scan.
+      const privateResult = await this.store.query(`SELECT ?op ?privateRoot WHERE {
+        GRAPH <${assertSafeIri(wsMetaGraph)}> {
+          ?op <${DKG_NS}privateMerkleRoot> ?privateRoot .
+        }
+      }`);
+      if (privateResult.type === 'bindings') {
+        for (const row of privateResult.bindings) {
+          const op = typeof row['op'] === 'string' ? row['op'].replace(/^<(.*)>$/, '$1') : '';
+          const memo = opsBySubject.get(op);
+          const privateRoot = this.privateMerkleRootFromBinding(row['privateRoot']);
+          if (
+            memo
+            && privateRoot
+            && !memo.privateRoots.some((existing) => equalBytes(existing, privateRoot))
+          ) {
+            memo.privateRoots.push(privateRoot);
+          }
         }
       }
     } catch { /* SWM meta may not exist yet */ }
@@ -2666,7 +2695,9 @@ export class FinalizationHandler {
       const roots = memo.roots;
       const sharedMemoryQuads = await this.getSharedMemoryQuadsForRoots(contextGraphId, roots, subGraphName);
       if (sharedMemoryQuads.length === 0) continue;
-      const privateRoots = await this.getPrivateRootsFromMeta(contextGraphId, roots, subGraphName);
+      const privateRoots = memo.privateRoots.length > 0
+        ? memo.privateRoots
+        : await this.getPrivateRootsFromMeta(contextGraphId, roots, subGraphName);
       if (useStampIndex) {
         const digest = this.swmContentDigest(sharedMemoryQuads, privateRoots);
         let computedHex: string;
@@ -2764,7 +2795,7 @@ export class FinalizationHandler {
     subGraphName?: string,
   ): Promise<{ rootEntities: string[]; sharedMemoryQuads: Quad[] } | null> {
     const targetHex = ethers.hexlify(merkleRoot);
-    const rootsByOp = new Map<string, string[]>();
+    const snapshotsByOp = new Map<string, { roots: string[]; privateRoots: Uint8Array[] }>();
     try {
       const result = await this.store.query(`SELECT ?op ?root WHERE {
         GRAPH <${assertSafeIri(wsMetaGraph)}> {
@@ -2777,17 +2808,41 @@ export class FinalizationHandler {
           const op = typeof row['op'] === 'string' ? row['op'].replace(/^<(.*)>$/, '$1') : '';
           const root = typeof row['root'] === 'string' ? row['root'].replace(/^<(.*)>$/, '$1') : '';
           if (!op || !isSafeIri(root)) continue;
-          const list = rootsByOp.get(op) ?? [];
-          list.push(root);
-          rootsByOp.set(op, list);
+          const snapshot = snapshotsByOp.get(op) ?? { roots: [], privateRoots: [] };
+          if (!snapshot.roots.includes(root)) snapshot.roots.push(root);
+          snapshotsByOp.set(op, snapshot);
+        }
+      }
+
+      const privateResult = await this.store.query(`SELECT ?op ?privateRoot WHERE {
+        GRAPH <${assertSafeIri(wsMetaGraph)}> {
+          ?op <${SWM_SNAPSHOT_MERKLE_ROOT_PREDICATE}> "${targetHex}" .
+          ?op <${DKG_NS}privateMerkleRoot> ?privateRoot .
+        }
+      }`);
+      if (privateResult.type === 'bindings') {
+        for (const row of privateResult.bindings) {
+          const op = typeof row['op'] === 'string' ? row['op'].replace(/^<(.*)>$/, '$1') : '';
+          const snapshot = snapshotsByOp.get(op);
+          const privateRoot = this.privateMerkleRootFromBinding(row['privateRoot']);
+          if (
+            snapshot
+            && privateRoot
+            && !snapshot.privateRoots.some((existing) => equalBytes(existing, privateRoot))
+          ) {
+            snapshot.privateRoots.push(privateRoot);
+          }
         }
       }
     } catch { return null; }
 
-    for (const [op, roots] of rootsByOp) {
+    for (const [op, snapshot] of snapshotsByOp) {
+      const { roots } = snapshot;
       const sharedMemoryQuads = await this.getSharedMemoryQuadsForRoots(contextGraphId, roots, subGraphName);
       if (sharedMemoryQuads.length > 0) {
-        const privateRoots = await this.getPrivateRootsFromMeta(contextGraphId, roots, subGraphName);
+        const privateRoots = snapshot.privateRoots.length > 0
+          ? snapshot.privateRoots
+          : await this.getPrivateRootsFromMeta(contextGraphId, roots, subGraphName);
         if (this.verifyMerkleMatch(sharedMemoryQuads, privateRoots, merkleRoot)) {
           return { rootEntities: roots, sharedMemoryQuads };
         }
@@ -2800,6 +2855,13 @@ export class FinalizationHandler {
       } catch { /* best-effort self-heal */ }
     }
     return null;
+  }
+
+  private privateMerkleRootFromBinding(value: unknown): Uint8Array | null {
+    if (typeof value !== 'string') return null;
+    const hex = value.replace(/^"(.*)".*$/, '$1').replace(/^0x/, '');
+    if (!/^[0-9a-fA-F]{64}$/.test(hex)) return null;
+    return ethers.getBytes(`0x${hex}`);
   }
 
   private async verifyOnChain(

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -34,15 +34,24 @@ function recorder<A extends unknown[], R>(impl: (...args: A) => R) {
   };
   return Object.assign(fn, { calls });
 }
-import { computeFlatKCRootV10 } from '@origintrail-official/dkg-publisher';
+import {
+  computeFlatKCRootV10,
+  computeFlatKCMerkleLeafCountV10,
+  StorageACKHandler,
+} from '@origintrail-official/dkg-publisher';
 import {
   DKG_ONTOLOGY,
   SYSTEM_CONTEXT_GRAPHS,
+  TypedEventBus,
   contextGraphDataGraphUri,
   contextGraphWorkspaceGraphUri,
   contextGraphWorkspaceMetaGraphUri,
+  decodeStorageACK,
+  encodePublishIntent,
+  isStorageACKDecline,
 } from '@origintrail-official/dkg-core';
 import { GraphManager, type TripleStore } from '@origintrail-official/dkg-storage';
+import { ethers } from 'ethers';
 import type {
   ReplicationEvent,
   ContextGraphSubscriptionRecord,
@@ -1910,7 +1919,7 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     expect(sources).toEqual(['periodic', 'live', 'manual']);
   });
 
-  it('a host-only reconcile promotes the missed KA to VM and emits core-fill', async () => {
+  it('an unsubscribed StorageACK signer promotes its durable snapshot to VM and emits core-fill', async () => {
     const captured: ReplicationEvent[] = [];
     const chain = new MockChainAdapter();
     agent = await DKGAgent.create({
@@ -1926,10 +1935,46 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
       publishPolicy: 1,
     });
     const localCgId = ON_CHAIN_CG.toString();
-    // The Core already has the SWM snapshot locally (simulating a pull from
-    // another Core), but never member-subscribed — it only hosts the CG.
-    const root = await seedSwmSnapshot(internals.store, localCgId, 'urn:fact:monday', 'Monday fun fact');
-    const { ethers } = await import('ethers');
+
+    // Exercise the real legacy inline StorageACK receiver path. This core is
+    // deliberately NOT member-subscribed: the ACK itself is what creates its
+    // durable storage obligation and discoverable SWM snapshot.
+    const publicQuads = [{
+      subject: 'urn:fact:monday',
+      predicate: 'http://schema.org/name',
+      object: '"Monday fun fact"',
+      graph: '',
+    }];
+    const root = computeFlatKCRootV10(publicQuads, []);
+    const stagingQuads = new TextEncoder().encode(
+      '<urn:fact:monday> <http://schema.org/name> "Monday fun fact" .',
+    );
+    const ackHandler = new StorageACKHandler(internals.store, {
+      nodeRole: 'core',
+      nodeIdentityId: 42n,
+      signerWallet: ethers.Wallet.createRandom(),
+      contextGraphSharedMemoryUri: contextGraphWorkspaceGraphUri,
+      chainId: await chain.getEvmChainId(),
+      kav10Address: await chain.getKnowledgeAssetsLifecycleAddress(),
+      ackHandlerDeadlineMs: 0,
+      isSignerRegistered: async () => true,
+      isCgCurated: async () => false,
+    }, new TypedEventBus());
+    const ack = decodeStorageACK(await ackHandler.handler(encodePublishIntent({
+      merkleRoot: root,
+      contextGraphId: localCgId,
+      publisherPeerId: 'publisher-peer',
+      publicByteSize: stagingQuads.length,
+      isPrivate: false,
+      kaCount: 1,
+      rootEntities: ['urn:fact:monday'],
+      stagingQuads,
+      epochs: 1,
+      tokenAmountStr: '1',
+      merkleLeafCount: computeFlatKCMerkleLeafCountV10(publicQuads, []),
+    }), { toString: () => 'publisher-peer' }));
+    expect(isStorageACKDecline(ack)).toBe(false);
+
     chain.__registerKC({ kaId: 4242n, contextGraphId: ON_CHAIN_CG, merkleRootHex: ethers.hexlify(root), chunks: [] });
 
     await internals.recordCoreHostedPublicCg(localCgId);

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -89,6 +89,8 @@ export interface KnowledgeAssetCreateResponse {
   swmShared?: boolean;
   promotedCount?: number;
   publishReady?: boolean;
+  /** Core peers whose StorageACKs backed a confirmed VM publish. */
+  storageAckPeerIds?: string[];
   errors?: KnowledgeAssetLifecycleError[];
   [key: string]: unknown;
 }

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -940,6 +940,24 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
           result.kaId = pub?.kaId;
           result.ual = pub?.ual;
           result.txHash = pub?.onChainResult?.txHash;
+          const storageAckPeerIds = [
+            ...new Set(
+              (Array.isArray(pub?.v10ACKs) ? pub.v10ACKs : [])
+                .map((ack: unknown) => (
+                  ack && typeof ack === 'object' && typeof (ack as { peerId?: unknown }).peerId === 'string'
+                    ? (ack as { peerId: string }).peerId.trim()
+                    : ''
+                ))
+                .filter(Boolean),
+            ),
+          ];
+          if (storageAckPeerIds.length > 0) {
+            // Query Remote must validate the protocol's actual durability
+            // guarantee: an ACK-signing core stored this KA. Expose only peer
+            // IDs (never signatures) so callers can read from those exact
+            // storage cores instead of guessing an unrelated random peer.
+            result.storageAckPeerIds = storageAckPeerIds;
+          }
           if (pub?.onChainResult?.convictionCostCovered) {
             result.convictionCostCovered = pub.onChainResult.convictionCostCovered;
           }

--- a/packages/cli/test/knowledge-assets-1116-share-errors.test.ts
+++ b/packages/cli/test/knowledge-assets-1116-share-errors.test.ts
@@ -1179,6 +1179,11 @@ describe('#1116 share/seal route error mapping (fake agent)', () => {
               status: 'confirmed',
               ual: 'did:dkg:test/1/44',
               kaId: '44',
+              v10ACKs: [
+                { peerId: '12D3KooWStorageCore1' },
+                { peerId: '12D3KooWStorageCore1' },
+                { peerId: '12D3KooWStorageCore2' },
+              ],
               seal: { authorAddress: tokenAgentAddress },
             };
           },
@@ -1204,6 +1209,10 @@ describe('#1116 share/seal route error mapping (fake agent)', () => {
 
       expect(res.status).toBe(201);
       expect(res.body.status).toBe('vm-confirmed');
+      expect(res.body.storageAckPeerIds).toEqual([
+        '12D3KooWStorageCore1',
+        '12D3KooWStorageCore2',
+      ]);
       expect(seenOpts).toHaveLength(1);
       expect(seenOpts[0]).toMatchObject({
         agentAddress: tokenAgentAddress,

--- a/packages/publisher/src/storage-ack-handler.ts
+++ b/packages/publisher/src/storage-ack-handler.ts
@@ -29,6 +29,7 @@ import {
   computePublishACKDigest,
   computeUpdateACKDigest,
   assertSafeIri,
+  isSafeIri,
   assertSafeRdfTerm,
   STORAGE_ACK_DECLINE_CODES,
   DEFAULT_SEND_TIMEOUT_MS,
@@ -57,6 +58,11 @@ import { validateKnowledgeAssetPublishRequest } from './validation.js';
 import { ethers } from 'ethers';
 
 type PeerId = { toString(): string };
+
+const LEGACY_ACK_SNAPSHOT_MERKLE_ROOT_PREDICATE =
+  'http://dkg.io/ontology/snapshotMerkleRoot';
+const LEGACY_ACK_ROOT_ENTITY_PREDICATE = 'http://dkg.io/ontology/rootEntity';
+const LEGACY_ACK_PRIVATE_ROOT_PREDICATE = 'http://dkg.io/ontology/privateMerkleRoot';
 
 type GraphScopedPublishIntent = {
   scope: ReturnType<typeof createGraphKnowledgeAssetScope>;
@@ -813,33 +819,99 @@ export class StorageACKHandler {
   }
 
   /**
-   * Persist merkle-verified inline quads to a scoped staging graph before the
-   * ACK is signed (crash-safety durability invariant: an on-chain KC implies
-   * at least one core stored the data, so a failed persist MUST decline rather
-   * than sign anyway). `dropGraph` (idempotent replace) then `insert`.
+   * Persist a legacy (pre graph-scoped-intent) public ACK payload as a durable,
+   * discoverable SWM snapshot before signing.
+   *
+   * The old implementation put these quads under `/staging/<root-prefix>` and
+   * deleted them after ten minutes. SWM readers intentionally exclude staging
+   * graphs, so an ACK-signing core that was not also a member subscriber could
+   * never match the chain root, promote the KA, or answer ENTITY_BY_UAL. That
+   * violated the StorageACK durability contract even though the bytes had been
+   * written successfully.
+   *
+   * Keep the payload under a normal SWM child graph and add the minimal legacy
+   * WorkspaceOperation index (`rootEntity` + authoritative snapshot root) used
+   * by the chain reconciler. The full root is part of both identifiers, making
+   * retries idempotent and avoiding truncated-prefix collisions. Data remains
+   * in SWM after VM promotion so this storage core can serve later catch-up.
    */
-  private async persistStagingOrDecline(
+  private async persistLegacyAckSnapshotOrDecline(
     cgId: string,
-    stagingGraphUri: string,
+    swmGraphId: string,
+    swmGraphUri: string,
+    merkleRoot: Uint8Array,
     parsed: Quad[],
+    rootEntities: string[],
+    privateMerkleRoots: Uint8Array[],
+    subGraphName?: string,
     signal?: AbortSignal,
   ): Promise<{ ok: true } | { ok: false; decline: Uint8Array }> {
     // Malformed terms are a bad request, not a store outage — validate BEFORE
     // the store wrapper so they reset the stream instead of being mislabeled
     // as a transient decline (see assertPersistQuadTermsSafe).
     assertPersistQuadTermsSafe(parsed);
+    const rootHex = ethers.hexlify(merkleRoot);
+    const snapshotGraphUri = `${swmGraphUri}/storage-ack/${rootHex.slice(2)}`;
+    const operationSubject = `urn:dkg:storage-ack:${rootHex.slice(2)}`;
+    const metaGraphUri = this.graphManager.sharedMemoryMetaUri(swmGraphId, subGraphName);
+    assertSafeIri(snapshotGraphUri);
+    assertSafeIri(operationSubject);
+    assertSafeIri(metaGraphUri);
+
+    const uniqueRoots = [...new Set(rootEntities)].filter(isSafeIri);
+    if (uniqueRoots.length === 0) {
+      throw new Error('StorageACK: legacy inline payload has no recoverable root entities');
+    }
+    const metadata: Quad[] = uniqueRoots.map((rootEntity) => ({
+      subject: operationSubject,
+      predicate: LEGACY_ACK_ROOT_ENTITY_PREDICATE,
+      object: rootEntity,
+      graph: metaGraphUri,
+    }));
+    metadata.push({
+      subject: operationSubject,
+      predicate: LEGACY_ACK_SNAPSHOT_MERKLE_ROOT_PREDICATE,
+      object: `"${rootHex}"`,
+      graph: metaGraphUri,
+    });
+    // Legacy folded-private intents carry an unordered bag of private roots.
+    // Store the bag on this operation, not on an entity that may be reused by
+    // later KAs. The reconciler prefers operation-scoped roots and falls back
+    // to historical entity-scoped metadata for old snapshots.
+    for (const privateRoot of privateMerkleRoots) {
+      metadata.push({
+        subject: operationSubject,
+        predicate: LEGACY_ACK_PRIVATE_ROOT_PREDICATE,
+        object: `"${ethers.hexlify(privateRoot)}"`,
+        graph: metaGraphUri,
+      });
+    }
+
     const result = await this.runStoreOpOrDecline(cgId, async () => {
       await this.store.dropGraph(
-        stagingGraphUri,
-        ackStoreOptions('storage-ack.persistStaging.dropGraph', signal),
+        snapshotGraphUri,
+        ackStoreOptions('storage-ack.persistLegacySnapshot.dropGraph', signal),
       );
-      const graphedQuads = parsed.map((q) => ({ ...q, graph: stagingGraphUri }));
-      await this.store.insert(graphedQuads, ackStoreOptions('storage-ack.persistStaging.insert', signal));
+      const graphedQuads = parsed.map((q) => ({ ...q, graph: snapshotGraphUri }));
+      await this.store.insert(
+        graphedQuads,
+        ackStoreOptions('storage-ack.persistLegacySnapshot.insertData', signal),
+      );
+      await this.store.deleteByPattern(
+        { graph: metaGraphUri, subject: operationSubject },
+        ackStoreOptions('storage-ack.persistLegacySnapshot.deleteMeta', signal),
+      );
+      await this.store.insert(
+        metadata,
+        ackStoreOptions('storage-ack.persistLegacySnapshot.insertMeta', signal),
+      );
       // Durability boundary: the ACK we are about to sign asserts this data is
       // stored, and a worker respawn can recover from a snapshot that predates
       // the debounced flush — so force it durable before signing. A flush
       // failure stays inside the wrapper → transient decline (never sign).
-      await this.store.flush?.(ackStoreOptions('storage-ack.persistStaging.flush', signal));
+      await this.store.flush?.(
+        ackStoreOptions('storage-ack.persistLegacySnapshot.flush', signal),
+      );
     }, signal);
     return result.ok ? { ok: true } : result;
   }
@@ -1477,18 +1549,14 @@ export class StorageACKHandler {
         );
       }
 
-      // Root verified — persist to a scoped staging graph so the data is
-      // durable before we sign the ACK (crash safety: on-chain KC implies
-      // at least one core node stored the data). The staging graph is keyed
-      // by merkle root prefix and cleaned up during finalization. A store
+      // Root verified — persist a discoverable graph-scoped or legacy SWM
+      // snapshot so the data is durable before we sign the ACK (crash safety:
+      // on-chain KC implies at least one core node stored the data). A store
       // outage during the apply (closed / restarting worker) returns the
       // transient decline instead of resetting the stream — the durability
       // invariant is why we CANNOT sign anyway, so the publisher re-sends
       // once the store worker is back rather than bucketing us as no_response.
-      const stagingGraphUri = graphPublish
-        ? swmGraphUri
-        : `${swmGraphUri}/staging/${ethers.hexlify(merkleRoot).slice(2, 18)}`;
-      const persistedStaging = graphPublish
+      const persistedSnapshot = graphPublish
         ? await this.persistGraphScopedWorkspaceOrDecline(
             cgId,
             swmGraphId,
@@ -1500,17 +1568,19 @@ export class StorageACKHandler {
             true,
             signal,
           )
-        : await this.persistStagingOrDecline(cgId, stagingGraphUri, parsed, signal);
-      if (!persistedStaging.ok) return persistedStaging.decline;
+        : await this.persistLegacyAckSnapshotOrDecline(
+            cgId,
+            swmGraphId,
+            swmGraphUri,
+            merkleRoot,
+            parsed,
+            [...rootSubjects],
+            privateMerkleRoots,
+            subGraphName,
+            signal,
+          );
+      if (!persistedSnapshot.ok) return persistedSnapshot.decline;
       swmQuads = parsed;
-
-      // Schedule cleanup: remove staging graph after 10 minutes.
-      // Finalization may promote data to LTM before this fires.
-      if (!graphPublish) {
-        setTimeout(async () => {
-          try { await this.store.dropGraph(stagingGraphUri); } catch { /* ignore */ }
-        }, 10 * 60 * 1000);
-      }
     } else {
       // Fallback: data should already be in SWM (publishFromSharedMemory path).
       // Both the "no data" and "data but wrong merkle root" cases below are

--- a/packages/publisher/test/storage-ack-handler.test.ts
+++ b/packages/publisher/test/storage-ack-handler.test.ts
@@ -160,6 +160,60 @@ describe('StorageACKHandler', () => {
     expect(recovered.toLowerCase()).toBe(coreWallet.address.toLowerCase());
   });
 
+  it('keeps a legacy inline ACK payload discoverable for host-only chain reconciliation', async () => {
+    const inlineQuads: Quad[] = [
+      makeQuad('urn:entity:ack-root', 'urn:p', 'urn:o1', 'urn:publisher:source'),
+      makeQuad('urn:entity:ack-root', 'urn:p', 'urn:o2', 'urn:publisher:source'),
+    ];
+    const inlineRoot = computeFlatKCRoot(inlineQuads, []);
+    const inlineLeafCount = computeFlatKCMerkleLeafCountV10(inlineQuads, []);
+    const stagingQuads = new TextEncoder().encode(
+      inlineQuads
+        .map((q) => `<${q.subject}> <${q.predicate}> <${q.object}> <${q.graph}> .`)
+        .join('\n'),
+    );
+    const handler = await createHandler([]);
+
+    const response = await handler.handler(encodePublishIntent({
+      merkleRoot: inlineRoot,
+      contextGraphId,
+      publisherPeerId: 'publisher-0',
+      publicByteSize: stagingQuads.length,
+      isPrivate: false,
+      kaCount: 1,
+      // Exercise the compatibility fallback used by the named-KA publisher
+      // that exposed the live testnet failure: infer top-level roots from data.
+      rootEntities: [],
+      epochs: 1,
+      tokenAmountStr: '1000',
+      merkleLeafCount: inlineLeafCount,
+      stagingQuads,
+    }), fakePeerId);
+
+    expect(isStorageACKDecline(decodeStorageACK(response))).toBe(false);
+
+    const store = (handler as unknown as { store: TripleStore }).store;
+    const rootHex = ethers.hexlify(inlineRoot);
+    const expectedDataGraph =
+      `did:dkg:context-graph:${contextGraphId}/_shared_memory/storage-ack/${rootHex.slice(2)}`;
+    const graphs = await store.listGraphs();
+    expect(graphs).toContain(expectedDataGraph);
+    expect(graphs.some((graph) => graph.includes('/staging/'))).toBe(false);
+
+    const storedData = await store.query(
+      `CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${expectedDataGraph}> { ?s ?p ?o } }`,
+    );
+    expect(storedData.type).toBe('quads');
+    if (storedData.type === 'quads') expect(storedData.quads).toHaveLength(2);
+
+    const metaGraph = `did:dkg:context-graph:${contextGraphId}/_shared_memory_meta`;
+    const indexed = await store.query(`ASK { GRAPH <${metaGraph}> {
+      ?op <http://dkg.io/ontology/rootEntity> <urn:entity:ack-root> ;
+          <http://dkg.io/ontology/snapshotMerkleRoot> "${rootHex}" .
+    } }`);
+    expect(indexed).toEqual({ type: 'boolean', value: true });
+  });
+
   it('does not emit a canonical lifecycle assetUal from an unverified PublishIntent field', async () => {
     const handler = await createHandler(swmQuads, {
       ackHandlerDeadlineMs: 0,

--- a/packages/publisher/test/storage-ack-priority-lane.test.ts
+++ b/packages/publisher/test/storage-ack-priority-lane.test.ts
@@ -256,7 +256,7 @@ describe('StorageACKHandler priority store lane', () => {
     expect(onDecline).toHaveBeenCalledOnce();
   });
 
-  it('passes ACK priority options through inline staging writes and flushes', async () => {
+  it('passes ACK priority options through durable inline snapshot writes and flushes', async () => {
     const scheduler = new StorePriorityScheduler({ maxConcurrent: 2, ackReservedSlots: 1 });
     const events: string[] = [];
     const store = new PriorityLaneStore(scheduler, events);
@@ -268,9 +268,11 @@ describe('StorageACKHandler priority store lane', () => {
     expect(isStorageACKDecline(decoded)).toBe(false);
     expect(store.ackQueries).toBe(0);
     expect(store.writeCalls.map((call) => call.source)).toEqual([
-      'storage-ack.persistStaging.dropGraph',
-      'storage-ack.persistStaging.insert',
-      'storage-ack.persistStaging.flush',
+      'storage-ack.persistLegacySnapshot.dropGraph',
+      'storage-ack.persistLegacySnapshot.insertData',
+      'storage-ack.persistLegacySnapshot.deleteMeta',
+      'storage-ack.persistLegacySnapshot.insertMeta',
+      'storage-ack.persistLegacySnapshot.flush',
     ]);
     expect(store.writeCalls.every((call) => call.priority === 'ack')).toBe(true);
 

--- a/packages/publisher/test/v10-ack-edge-cases.test.ts
+++ b/packages/publisher/test/v10-ack-edge-cases.test.ts
@@ -691,7 +691,7 @@ describe('StorageACKHandler inline verification', () => {
     expect(store.query.calls).toHaveLength(0);
   });
 
-  it('persists inline quads to staging graph before signing (crash safety)', async () => {
+  it('persists inline quads to a durable ACK snapshot before signing', async () => {
     const store = createRecordingStore();
     const handler = new StorageACKHandler(store, createConfig(), makeEventBus() as any);
 
@@ -713,7 +713,8 @@ describe('StorageACKHandler inline verification', () => {
     expect(store.dropGraph.calls.length).toBeGreaterThan(0);
     expect(store.insert.calls.length).toBeGreaterThan(0);
     const insertedQuads = store.insert.calls[0][0];
-    expect(insertedQuads[0].graph).toContain('/staging/');
+    expect(insertedQuads[0].graph).toContain('/_shared_memory/storage-ack/');
+    expect(insertedQuads[0].graph).not.toContain('/staging/');
     expect(store.query.calls).toHaveLength(0);
   });
 

--- a/packages/publisher/test/v10-protocol-operations.test.ts
+++ b/packages/publisher/test/v10-protocol-operations.test.ts
@@ -1018,7 +1018,7 @@ describe('V10 StorageACKHandler round-trip', () => {
       .rejects.toThrow('exceeds');
   });
 
-  it('persists inline quads to staging graph before signing (crash safety)', async () => {
+  it('persists inline quads to a durable ACK snapshot before signing', async () => {
     const store = createRecordingStore([]);
     const handler = createHandler(store);
 
@@ -1043,7 +1043,8 @@ describe('V10 StorageACKHandler round-trip', () => {
     expect(store._insertCalls.length).toBeGreaterThan(0);
     const insertedQuads = store._insertCalls[0][0] as any[];
     expect(insertedQuads.length).toBeGreaterThan(0);
-    expect(insertedQuads[0].graph).toContain('/staging/');
+    expect(insertedQuads[0].graph).toContain('/_shared_memory/storage-ack/');
+    expect(insertedQuads[0].graph).not.toContain('/staging/');
   });
 
   it('uint64 overflow check for nodeIdentityId > 2^64', async () => {


### PR DESCRIPTION
## What changed

- Persist legacy inline StorageACK payloads in a durable, discoverable SWM child graph instead of a temporary `/staging/` graph.
- Index the snapshot root, root entities, and operation-scoped private roots so chain reconciliation can promote the acknowledged KA into VM.
- Keep acknowledged snapshots available for later catch-up instead of deleting them after ten minutes.
- Return `storageAckPeerIds` from the atomic publish API so Query Remote can validate the cores that actually signed the storage commitment.
- Add regressions covering persistence, host-only reconciliation, VM promotion, and the API target list.

## Root cause

The receiver wrote verified ACK data under `/staging/<root-prefix>`. SWM discovery intentionally excludes staging graphs, and the graph was deleted after ten minutes. An unsubscribed core could therefore sign a StorageACK but never reconcile, promote, or serve that UAL remotely.

## Evidence

Base testnet Jenkins build #39 subscribed all four beacons and queried all three alternative beacons per published KA. Only 1 of 4 fresh KAs had any readable remote copy, proving this is not a random-peer or timing-only test issue. TestNode4 catch-up also showed 18/18 sync-capable peers responding at transport level but zero clean data-plane completions.

## Validation

- `DKG_SKIP_EVM_BUILD=1 pnpm run build:packages` - 22/22 packages
- Publisher StorageACK tests - 40/40
- Agent core-fill/reconciliation tests - 58/58
- CLI knowledge-assets route tests - 41/41
- Publisher, agent, and CLI TypeScript builds passed

The four Base testnet beacons are still running commit `4bae1e58`; this PR must be deployed there before the live remote-query rate can be expected to reach 100%.
