### PR TITLE
Make Base testnet remote-query checks deterministic

### DIFF
--- a/tests/publish/src/Base_Testnet.config.js
+++ b/tests/publish/src/Base_Testnet.config.js
@@ -7,6 +7,10 @@ export function getBaseTestnetPublishConfig(env = process.env) {
     blockchainName: 'v10:base:84532',
     // 'jenkins-publish-tests' is our public open-publish CG on Base Sepolia.
     contextGraphId: env.DKG_CONTEXT_GRAPH_ID || 'jenkins-publish-tests',
+    // Query Remote selects an arbitrary one of the other beacon nodes. Make
+    // that assertion valid by ensuring every possible receiver actively hosts
+    // and syncs the CG before any parallel publish stage starts.
+    remoteQuerySubscribeAll: true,
     // Jenkins may override the known-good default without changing this branch.
     fallbackUal: env.DKG_FALLBACK_UAL || BASE_TESTNET_FALLBACK_UAL,
     nodes: [

--- a/tests/publish/src/v10-publish-lib.js
+++ b/tests/publish/src/v10-publish-lib.js
@@ -209,6 +209,7 @@ export async function subscribeAndWait(
   nodeName,
   timeoutMs,
   pollIntervalMs = 3000,
+  allowedTerminalStatuses = [],
 ) {
   const deadline = Date.now() + timeoutMs;
   let last = null;
@@ -228,6 +229,13 @@ export async function subscribeAndWait(
     if (status === 'done') return res;
     if (['failed', 'error', 'denied', 'deferred', 'unreachable'].includes(status)) {
       const detail = res?.error ? `: ${res.error}` : '';
+      if (allowedTerminalStatuses.includes(status)) {
+        console.warn(
+          `⚠️ ${nodeName} historical catch-up reported ${status}${detail}; ` +
+          'the subscription is active, so continuing with fresh-publish Query Remote validation',
+        );
+        return res;
+      }
       throw new Error(`catch-up sync for "${contextGraphId}" on ${nodeName} reported ${status}${detail}`);
     }
     if (Date.now() > deadline) {
@@ -308,8 +316,24 @@ export function defineChainPublishSuite(config) {
         console.log(`🔗 Preparing all ${nodes.length} Query Remote receiver(s) for "${contextGraphId}"…`);
         await Promise.all(nodes.map(async (node) => {
           const client = makeNodeClient(node.hostname, node.token);
-          await subscribeAndWait(client, contextGraphId, node.name, CG_SUBSCRIBE_TIMEOUT_MS);
-          console.log(`✅ ${node.name} subscribed and synced for Query Remote`);
+          const catchup = await subscribeAndWait(
+            client,
+            contextGraphId,
+            node.name,
+            CG_SUBSCRIBE_TIMEOUT_MS,
+            3000,
+            // This suite measures reads of KAs published AFTER this barrier.
+            // A public node's subscription is already active when historical
+            // catch-up reports a transport/data-plane failure, so keep that as
+            // an explicit warning without suppressing the fresh-read canary.
+            ['failed', 'unreachable'],
+          );
+          const catchupStatus = catchup?.catchup?.status || catchup?.status;
+          console.log(
+            catchupStatus === 'done'
+              ? `✅ ${node.name} subscribed and synced for Query Remote`
+              : `✅ ${node.name} subscribed for fresh Query Remote (historical catch-up: ${catchupStatus})`,
+          );
         }));
       }
 

--- a/tests/publish/src/v10-publish-lib.js
+++ b/tests/publish/src/v10-publish-lib.js
@@ -261,7 +261,13 @@ const mean = (arr) => (arr.length > 0 ? arr.reduce((a, b) => a + b, 0) / arr.len
 // NODE_TO_TEST (env) selects which node this Jenkins stage runs.
 // ---------------------------------------------------------------------------
 export function defineChainPublishSuite(config) {
-  const { title, blockchainName, contextGraphId, nodes } = config;
+  const {
+    title,
+    blockchainName,
+    contextGraphId,
+    nodes,
+    remoteQuerySubscribeAll = false,
+  } = config;
   // Known-good, already-indexed UAL used to exercise the read paths when a
   // publish fails (no fresh UAL). Per-chain, overridable via DKG_FALLBACK_UAL.
   const FALLBACK_UAL = process.env.DKG_FALLBACK_UAL || config.fallbackUal || '';
@@ -278,6 +284,20 @@ export function defineChainPublishSuite(config) {
 
       console.log(`\nRunning test for node: ${nodesToRun.map((n) => n.name).join(', ')}`);
       console.log(`Blockchain: ${blockchainName} | Context graph: ${contextGraphId} | KAs per node: ${KA_COUNT}`);
+
+      // A remote query reads the selected peer's LOCAL VM; it does not initiate
+      // sync. Because this suite chooses an arbitrary receiver, every possible
+      // receiver must subscribe and finish catch-up first. Jenkins runs one
+      // process per node in parallel, so every process performs this idempotent
+      // barrier and none can publish before all four receivers are ready.
+      if (remoteQuerySubscribeAll) {
+        console.log(`🔗 Preparing all ${nodes.length} Query Remote receiver(s) for "${contextGraphId}"…`);
+        await Promise.all(nodes.map(async (node) => {
+          const client = makeNodeClient(node.hostname, node.token);
+          await subscribeAndWait(client, contextGraphId, node.name, CG_SUBSCRIBE_TIMEOUT_MS);
+          console.log(`✅ ${node.name} subscribed and synced for Query Remote`);
+        }));
+      }
 
       for (let currentIndex = 0; currentIndex < nodesToRun.length; currentIndex++) {
         const { name, hostname, token } = nodesToRun[currentIndex];
@@ -358,8 +378,10 @@ export function defineChainPublishSuite(config) {
         // publish into them (a public open-publish CG needs none of this). Auto-on
         // when the id is canonical ("<curator>/<slug>", contains '/') — bare public
         // names ('sports'/'foodie-network') skip it. V10_CG_SUBSCRIBE=true forces it.
-        const needsSubscribe = CG_SUBSCRIBE
-          || (typeof contextGraphId === 'string' && contextGraphId.includes('/'));
+        const needsSubscribe = !remoteQuerySubscribeAll && (
+          CG_SUBSCRIBE
+          || (typeof contextGraphId === 'string' && contextGraphId.includes('/'))
+        );
         if (needsSubscribe) {
           console.log(`🔗 ${name} subscribing to private CG "${contextGraphId}" (syncing from curator)…`);
           await subscribeAndWait(client, contextGraphId, name, CG_SUBSCRIBE_TIMEOUT_MS);

--- a/tests/publish/src/v10-publish-lib.js
+++ b/tests/publish/src/v10-publish-lib.js
@@ -265,6 +265,50 @@ function queryHasData(result) {
   return false;
 }
 
+// Query all protocol-backed candidate storage peers in parallel per retry
+// round and accept the first readable copy. A publish's availability contract
+// is backed by its StorageACK cores; requiring one unrelated random beacon to
+// hold the KA measured gossip luck instead of that contract.
+export async function queryAnyRemoteWithRetry(
+  client,
+  contextGraphId,
+  ual,
+  targets,
+  retries = READ_RETRIES,
+  retryDelayMs = READ_RETRY_MS,
+) {
+  let lastFailures = [];
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    const outcomes = await Promise.all(targets.map(async (target) => {
+      try {
+        const result = await withTimeout(
+          client.queryRemote(target.peerId, contextGraphId, {
+            lookupType: 'ENTITY_BY_UAL',
+            ual,
+          }),
+          'Query Remote (sync)',
+          target.name,
+        );
+        return { target, result };
+      } catch (error) {
+        return { target, error };
+      }
+    }));
+    const readable = outcomes.find((outcome) => queryHasData(outcome.result));
+    if (readable) return readable;
+
+    lastFailures = outcomes.map(({ target, error }) => (
+      `${target.name}: ${error instanceof Error ? error.message : 'no triples'}`
+    ));
+    if (attempt < retries) await sleep(retryDelayMs);
+  }
+
+  throw new Error(
+    `Query Remote (sync) found no readable copy of ${ual} across ` +
+    `${targets.length} storage candidate(s) — ${lastFailures.join('; ')}`,
+  );
+}
+
 // Resolve (and cache) a node's libp2p peerId via its public /api/status.
 const peerIdCache = new Map();
 async function getPeerId(node) {
@@ -431,6 +475,7 @@ export function defineChainPublishSuite(config) {
           const { quads, rootEntity } = buildQuads(name, i + 1);
 
           let ual = null;
+          let storageAckPeerIds = [];
           let step = 'publish';
 
           // ── 1. publish (mint to Verifiable Memory) ─────────────────────────
@@ -455,6 +500,9 @@ export function defineChainPublishSuite(config) {
             assert.ok(result.kaId !== undefined && result.kaId !== '0', `Publish response missing valid kaId (got ${result.kaId})`);
 
             ual = result.ual || null;
+            storageAckPeerIds = Array.isArray(result.storageAckPeerIds)
+              ? [...new Set(result.storageAckPeerIds.filter((peerId) => typeof peerId === 'string' && peerId.trim()).map((peerId) => peerId.trim()))]
+              : [];
             if (result.publisherAddress) publisherAddresses.add(result.publisherAddress);
             const kasCreated = Array.isArray(result.kas) ? result.kas.length : 'N/A';
             const txInfo = result.txHash ? ` | tx: ${result.txHash}` : '';
@@ -539,15 +587,34 @@ export function defineChainPublishSuite(config) {
             // single-node chain — no peer to sync-check against
             continue;
           }
-          const remoteNode = nodes[otherIndexes[Math.floor(Math.random() * otherIndexes.length)]];
           const remoteStart = Date.now();
           try {
             if (!readUal) throw new Error('Query Remote (sync): publish failed and no DKG_FALLBACK_UAL configured');
-            const remotePeerId = await getPeerId(remoteNode);
-            if (!remotePeerId) throw new Error(`Could not resolve peerId for ${remoteNode.name} (${remoteNode.hostname})`);
-            const result = await readWithRetry('Query Remote (sync)', remoteNode.name, () => client.queryRemote(remotePeerId, contextGraphId, { lookupType: 'ENTITY_BY_UAL', ual: readUal }));
-            assert.ok(queryHasData(result), `Query Remote (sync) returned no triples for ${readUal} from ${remoteNode.name}`);
-            console.log(`✅ Query Remote (sync) succeeded — ${remoteNode.name} has the KA (synced)`);
+            const targets = storageAckPeerIds.length > 0
+              ? storageAckPeerIds.map((peerId) => ({
+                  peerId,
+                  name: `StorageACK core …${peerId.slice(-8)}`,
+                }))
+              : (await Promise.all(otherIndexes.map(async (idx) => ({
+                  peerId: await getPeerId(nodes[idx]),
+                  name: nodes[idx].name,
+                })))).filter((target) => target.peerId);
+            if (targets.length === 0) {
+              throw new Error('Query Remote (sync) has no resolvable storage candidates');
+            }
+            const readable = await queryAnyRemoteWithRetry(
+              client,
+              contextGraphId,
+              readUal,
+              targets,
+            );
+            const targetKind = storageAckPeerIds.length > 0
+              ? 'acknowledged storage core'
+              : 'legacy beacon fallback';
+            console.log(
+              `✅ Query Remote (sync) succeeded — ${readable.target.name} has the KA ` +
+              `(${targetKind}; ${targets.length} candidate${targets.length === 1 ? '' : 's'})`,
+            );
             queryRemoteSuccess++;
             queryRemoteDurations.push(Date.now() - remoteStart);
           } catch (error) {

--- a/tests/publish/src/v10-publish-lib.js
+++ b/tests/publish/src/v10-publish-lib.js
@@ -191,40 +191,53 @@ export function makeNodeClient(baseUrl, token) {
         accessPolicy: opts.accessPolicy ?? 0,
         publishPolicy: opts.publishPolicy ?? 1,
       }).then((r) => r.data),
-    // subscribe to (and sync) a context graph this node does not host. Returns
-    // { subscribed, catchup: { status: queued|running|done, jobId } }. Re-calling
-    // returns the current catchup status, so it doubles as a poll.
+    // Subscribe to (and sync) a context graph this node does not host. The POST
+    // enqueues catch-up; status must be polled through the read-only endpoint so
+    // parallel Jenkins stages cannot keep re-queuing the same work.
     subscribe: (contextGraphId, includeSharedMemory = true) =>
       req('POST', '/api/context-graph/subscribe', { contextGraphId, includeSharedMemory }, { acceptStatuses: [200, 202] }).then((r) => r.data),
+    catchupStatus: (contextGraphId) =>
+      req('GET', `/api/sync/catchup-status?contextGraphId=${encodeURIComponent(contextGraphId)}`).then((r) => r.data),
   };
 }
 
 // Subscribe a node to a private CG and wait until its catch-up sync reports done
 // (or timeout). Idempotent: a node already synced returns done immediately.
-async function subscribeAndWait(client, contextGraphId, nodeName, timeoutMs) {
+export async function subscribeAndWait(
+  client,
+  contextGraphId,
+  nodeName,
+  timeoutMs,
+  pollIntervalMs = 3000,
+) {
   const deadline = Date.now() + timeoutMs;
   let last = null;
+  let res;
+  try {
+    res = await client.subscribe(contextGraphId);
+  } catch (error) {
+    throw new Error(`subscribe to "${contextGraphId}" on ${nodeName} failed: ${error.message}`);
+  }
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    let res;
-    try {
-      res = await client.subscribe(contextGraphId);
-    } catch (error) {
-      throw new Error(`subscribe to "${contextGraphId}" on ${nodeName} failed: ${error.message}`);
-    }
-    const status = res?.catchup?.status || 'unknown';
+    const status = res?.catchup?.status || res?.status || 'unknown';
     if (status !== last) {
       console.log(`   ↪ ${nodeName} subscribe/catchup: ${status}`);
       last = status;
     }
     if (status === 'done') return res;
-    if (status === 'failed' || status === 'error') {
+    if (['failed', 'error', 'denied', 'deferred', 'unreachable'].includes(status)) {
       throw new Error(`catch-up sync for "${contextGraphId}" on ${nodeName} reported ${status}`);
     }
     if (Date.now() > deadline) {
       throw new Error(`catch-up sync for "${contextGraphId}" on ${nodeName} did not finish within ${timeoutMs}ms (last status: ${status}) — is the curator node reachable on the DKG network?`);
     }
-    await sleep(3000);
+    await sleep(pollIntervalMs);
+    try {
+      res = await client.catchupStatus(contextGraphId);
+    } catch (error) {
+      throw new Error(`read catch-up status for "${contextGraphId}" on ${nodeName} failed: ${error.message}`);
+    }
   }
 }
 

--- a/tests/publish/src/v10-publish-lib.js
+++ b/tests/publish/src/v10-publish-lib.js
@@ -227,7 +227,8 @@ export async function subscribeAndWait(
     }
     if (status === 'done') return res;
     if (['failed', 'error', 'denied', 'deferred', 'unreachable'].includes(status)) {
-      throw new Error(`catch-up sync for "${contextGraphId}" on ${nodeName} reported ${status}`);
+      const detail = res?.error ? `: ${res.error}` : '';
+      throw new Error(`catch-up sync for "${contextGraphId}" on ${nodeName} reported ${status}${detail}`);
     }
     if (Date.now() > deadline) {
       throw new Error(`catch-up sync for "${contextGraphId}" on ${nodeName} did not finish within ${timeoutMs}ms (last status: ${status}) — is the curator node reachable on the DKG network?`);

--- a/tests/publish/test/catchup-polling.test.js
+++ b/tests/publish/test/catchup-polling.test.js
@@ -30,3 +30,19 @@ test('subscribeAndWait enqueues once and polls catch-up through the status endpo
   assert.equal(subscribeCalls, 1);
   assert.equal(statusCalls, 2);
 });
+
+test('subscribeAndWait includes the node catch-up error in a terminal failure', async () => {
+  const client = {
+    subscribe: async () => ({ catchup: { status: 'running', jobId: 'catchup-2' } }),
+    catchupStatus: async () => ({
+      status: 'failed',
+      jobId: 'catchup-2',
+      error: 'no sync-capable peers responded',
+    }),
+  };
+
+  await assert.rejects(
+    subscribeAndWait(client, 'jenkins-publish-tests', 'TestNode4', 1000, 0),
+    /reported failed: no sync-capable peers responded/,
+  );
+});

--- a/tests/publish/test/catchup-polling.test.js
+++ b/tests/publish/test/catchup-polling.test.js
@@ -1,7 +1,10 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { subscribeAndWait } from '../src/v10-publish-lib.js';
+import {
+  queryAnyRemoteWithRetry,
+  subscribeAndWait,
+} from '../src/v10-publish-lib.js';
 
 test('subscribeAndWait enqueues once and polls catch-up through the status endpoint', async () => {
   let subscribeCalls = 0;
@@ -66,4 +69,31 @@ test('subscribeAndWait can preserve a fresh-publish canary after historical catc
   );
 
   assert.equal(result.status, 'failed');
+});
+
+test('Query Remote succeeds when any acknowledged storage candidate serves the UAL', async () => {
+  const calls = [];
+  const client = {
+    queryRemote: async (peerId) => {
+      calls.push(peerId);
+      return peerId === 'ack-peer-2'
+        ? { status: 'OK', ntriples: '<urn:s> <urn:p> <urn:o> .' }
+        : { status: 'OK', ntriples: '' };
+    },
+  };
+
+  const readable = await queryAnyRemoteWithRetry(
+    client,
+    'jenkins-publish-tests',
+    'did:dkg:base:84532/0xabc/1',
+    [
+      { peerId: 'ack-peer-1', name: 'StorageACK core 1' },
+      { peerId: 'ack-peer-2', name: 'StorageACK core 2' },
+    ],
+    0,
+    0,
+  );
+
+  assert.equal(readable.target.peerId, 'ack-peer-2');
+  assert.deepEqual(calls.sort(), ['ack-peer-1', 'ack-peer-2']);
 });

--- a/tests/publish/test/catchup-polling.test.js
+++ b/tests/publish/test/catchup-polling.test.js
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { subscribeAndWait } from '../src/v10-publish-lib.js';
+
+test('subscribeAndWait enqueues once and polls catch-up through the status endpoint', async () => {
+  let subscribeCalls = 0;
+  let statusCalls = 0;
+  const statuses = ['running', 'done'];
+  const client = {
+    subscribe: async () => {
+      subscribeCalls++;
+      return { catchup: { status: 'queued', jobId: 'catchup-1' } };
+    },
+    catchupStatus: async () => {
+      statusCalls++;
+      return { status: statuses.shift(), jobId: 'catchup-1' };
+    },
+  };
+
+  const result = await subscribeAndWait(
+    client,
+    'jenkins-publish-tests',
+    'TestNode1',
+    1000,
+    0,
+  );
+
+  assert.equal(result.status, 'done');
+  assert.equal(subscribeCalls, 1);
+  assert.equal(statusCalls, 2);
+});

--- a/tests/publish/test/catchup-polling.test.js
+++ b/tests/publish/test/catchup-polling.test.js
@@ -46,3 +46,24 @@ test('subscribeAndWait includes the node catch-up error in a terminal failure', 
     /reported failed: no sync-capable peers responded/,
   );
 });
+
+test('subscribeAndWait can preserve a fresh-publish canary after historical catch-up fails', async () => {
+  const client = {
+    subscribe: async () => ({ subscribed: true, catchup: { status: 'running' } }),
+    catchupStatus: async () => ({
+      status: 'failed',
+      error: 'old staging data is not discoverable',
+    }),
+  };
+
+  const result = await subscribeAndWait(
+    client,
+    'jenkins-publish-tests',
+    'TestNode4',
+    1000,
+    0,
+    ['failed'],
+  );
+
+  assert.equal(result.status, 'failed');
+});

--- a/tests/publish/test/fallback-uals.test.js
+++ b/tests/publish/test/fallback-uals.test.js
@@ -14,6 +14,7 @@ test('Base testnet uses the known-good Base Sepolia UAL by default', () => {
   );
   assert.equal(config.blockchainName, 'v10:base:84532');
   assert.equal(config.fallbackUal, BASE_TESTNET_FALLBACK_UAL);
+  assert.equal(config.remoteQuerySubscribeAll, true);
   assert.match(config.fallbackUal, /^did:dkg:base:84532\//);
 });
 


### PR DESCRIPTION
## What changed

- Subscribe all Base testnet receiver nodes before publishing so Query Remote has an explicit hosting precondition.
- Enqueue catch-up once and poll the read-only status endpoint instead of repeatedly POSTing `/subscribe` and re-queuing the job.
- Keep historical catch-up failures visible while continuing the separate fresh-publish canary.
- Query the `storageAckPeerIds` returned by the publish API; older nodes fall back to checking every other configured beacon instead of one random peer.
- Add focused tests for catch-up polling, terminal diagnostics, and multi-candidate remote reads.

## Why

The old test chose one arbitrary beacon and assumed it held the KA. Query Remote only reads that peer's local VM and does not trigger synchronization, so this produced random false negatives and hid the actual StorageACK durability defect fixed by #1770.

## Live evidence

- Build #32 proved repeated POST polling re-queued catch-up until timeout.
- Builds #34-#36 showed TestNode4 had 21 connected peers, 18 sync-capable peers, and 18/18 transport successes, but zero clean data-plane completions.
- Build #39 used the corrected barrier and queried all three alternative beacons. Only 1/4 fresh publishes had any remotely readable copy, confirming the source fix is required.

## Validation

- `node --check tests/publish/src/v10-publish-lib.js`
- `npm --prefix tests/publish run test:config` - 6/6
- Jenkins smoke builds used one KA per node and did not write to Grafana.

This PR depends on #1770 for deterministic StorageACK-core targeting on upgraded nodes. After both PRs are merged and #1770 is deployed to the four Base testnet beacons, rerun the one-KA-per-node smoke and then the normal ten-KA job.
