### PR TITLE
Keep test/publish synced with main

### DIFF
--- a/.github/workflows/sync-test-publish.yml
+++ b/.github/workflows/sync-test-publish.yml
@@ -1,0 +1,45 @@
+name: Sync test/publish with main
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '17 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: sync-test-publish-with-main
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Merge main into test/publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out test/publish
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: test/publish
+          fetch-depth: 0
+
+      - name: Merge and push latest main
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git fetch origin main:refs/remotes/origin/main
+
+          if git merge-base --is-ancestor origin/main HEAD; then
+            echo 'test/publish already contains the latest main commit.'
+            exit 0
+          fi
+
+          git merge --no-edit origin/main
+          git push origin HEAD:test/publish

--- a/.github/workflows/sync-test-publish.yml
+++ b/.github/workflows/sync-test-publish.yml
@@ -8,8 +8,7 @@ on:
     - cron: '17 * * * *'
   workflow_dispatch:
 
-permissions:
-  contents: write
+permissions: {}
 
 concurrency:
   group: sync-test-publish-with-main
@@ -20,15 +19,20 @@ jobs:
     name: Merge main into test/publish
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: write
     steps:
       - name: Check out test/publish
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: test/publish
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Merge and push latest main
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
@@ -42,4 +46,5 @@ jobs:
           fi
 
           git merge --no-edit origin/main
+          gh auth setup-git
           git push origin HEAD:test/publish


### PR DESCRIPTION
## Summary
- merge `main` into `test/publish` whenever `main` changes
- retry the sync hourly and support manual runs
- use a normal merge and fail on conflicts instead of force-pushing test changes

The workflow must live on the default branch for GitHub scheduled triggers to run. After this PR is merged, the same sync run will copy the workflow into `test/publish` too.

## Validation
- `actionlint .github/workflows/sync-test-publish.yml`
- YAML parse check
- conflict-free merge simulation against the current `test/publish` head