### PR TITLE
chore(release): DKG 10.0.7 rootless private-CG sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,34 @@ All notable changes to the DKG V10 node are documented here. The format is based
 
 ## [Unreleased]
 
+## [10.0.7] - 2026-07-16
+
+Rootless Knowledge Assets and production hardening for private Context Graphs. New Knowledge Assets are stored and synchronized by their canonical UAL-derived named graph without synthetic `rootEntity` triples; legacy V10 assets remain readable but are no longer rewritten through the legacy lifecycle. The release also completes private-CG auto-approval, late-join recovery, and scalable SWM/VM fan-out, including the fixes validated by the multi-network testnet harness. **No smart-contract changes — no deployment required** (no Solidity source, ABI, or deployment-registry changes since 10.0.6).
+
+### Added
+
+- **Rootless, graph-scoped Knowledge Assets:** publish, update, finalize, query, Random Sampling, and recovery now use the canonical UAL-derived graph as the asset boundary. Blank-node input is canonicalized deterministically, lifecycle metadata is stored separately, and legacy assets retain read compatibility without remaining on the new write path.
+- **Private Context Graph enrollment controls:** owners can opt a private Context Graph into bounded automatic approval of authenticated join requests, while requester identity, membership, privacy, and curator-local control records remain fail-closed.
+- **Realistic private-CG recovery gates:** local and testnet harnesses cover live receivers, mid-run and cold late joiners, unauthorized negative nodes, SWM and VM payloads, exact manifest integrity, and resource sampling across independent network paths.
+
 ### Fixed
 
 - **PCA agents can register PCA-backed Context Graphs:** the agent, CLI/API, and MCP surfaces now match the deployed contract by allowing either the PCA owner or a wallet registered to that exact PCA to register a curated Context Graph. Eligible registrations consume a quota-backed deposit waiver instead of requiring a separate liquid-TRAC deposit; exact-account authorization and Context Graph NFT ownership alignment remain fail-closed.
+- **Private SWM and VM late-join recovery:** graph-scoped manifests, authenticated sync controls, exact-graph reads, lifecycle pointers, queued VM intent, and private access evidence survive restart and catch-up without leaking private data or accepting unverified control metadata.
+- **Bounded sync makes durable progress:** recovery retains verified prefixes across truncated responses, retries while progress advances, tolerates a bounded flat round, and only declares a snapshot complete after exact integrity verification.
+- **Large snapshots no longer crawl one tiny page at a time:** responder pages are constrained by both frame and byte budgets, requester page size adapts to the transport, and successive pages reuse a framed sync stream with a safe fallback to the prior single-request protocol.
+- **Relay fan-out capacity matches large KA transfer:** the default relayed-circuit byte allowance is raised from 16 MiB to 256 MiB, avoiding deterministic stream termination during realistic private-CG synchronization while preserving the circuit duration and concurrency bounds.
+- **Join and discovery startup races:** profile readiness gates enrollment, durable discovery metadata survives restart, false relay quarantine is avoided, and repeated connect/catch-up work remains bounded.
+- **Graph-scoped publish and update safety:** chain identity, ownership, access-control metadata, immutable snapshot integrity, crash recovery, and update authorization are checked before materialization or promotion.
+
+### Changed
+
+- **Sync work is graph-addressed and backend-agnostic:** scalable paths enumerate candidate UALs from bounded metadata and fetch individual named graphs with SPARQL 1.1-compatible queries, avoiding store-wide ordered/offset scans and preserving Oxigraph/Blazegraph portability.
+- **Release version set:** all workspace packages move together to 10.0.7, including `@origintrail-official/dkg-rdf-utils`.
+
+### Deployment
+
+- **No contract changes in this release.** No Solidity source, ABI, or mainnet/testnet deployment-registry files changed since 10.0.6; nodes can upgrade through the normal npm release path.
 
 ## [10.0.6] - 2026-07-13
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dkg-v10",
-  "version": "10.0.6",
+  "version": "10.0.7",
   "private": true,
   "packageManager": "pnpm@10.28.1",
   "dkgBuild": {

--- a/packages/adapter-elizaos/package.json
+++ b/packages/adapter-elizaos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-elizaos",
-  "version": "10.0.6",
+  "version": "10.0.7",
   "description": "ElizaOS plugin adapter — turns any ElizaOS agent into a DKG V10 node",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapter-hermes/package.json
+++ b/packages/adapter-hermes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-hermes",
-  "version": "10.0.6",
+  "version": "10.0.7",
   "description": "Hermes Agent adapter — connects Hermes AI agents to a DKG V10 node for verifiable shared memory",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapter-openclaw/package.json
+++ b/packages/adapter-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-openclaw",
-  "version": "10.0.6",
+  "version": "10.0.7",
   "description": "OpenClaw plugin adapter for connecting a DKG V10 node and chat bridge to an OpenClaw agent",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-agent",
-  "version": "10.0.6",
+  "version": "10.0.7",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -1167,6 +1167,13 @@ export class DKGAgentBase {
    */
   protected publishProfileTail: Promise<unknown> = Promise.resolve();
   /**
+   * Coalesces startup and first-join profile readiness checks. The regular
+   * publish tail serializes writes, but without this promise two concurrent
+   * readiness callers could still queue duplicate profile KAs while neither
+   * has observed the first result yet.
+   */
+  protected ensureProfilePublishedInFlight?: Promise<void>;
+  /**
    * OT-RFC-38 / LU-6 Phase B — sliding-window rate-limiter applied
    * to pre-registration (beacon-discovered) ciphertext writes.
    * Bounds the freemium-tier abuse vector: any wallet can broadcast

--- a/packages/agent/src/dkg-agent-cg-resolve.ts
+++ b/packages/agent/src/dkg-agent-cg-resolve.ts
@@ -281,6 +281,8 @@ import {
 } from './dkg-agent-utils.js';
 import {
   PRIVATE_DATA_ANCHOR,
+  SYNC_BYTE_BUDGET_MAX_ROWS,
+  SYNC_BYTE_BUDGET_PAGE_MODE,
   SYNC_PAGE_SIZE,
   SYNC_PAGE_RETRY_ATTEMPTS,
   SYNC_TOTAL_TIMEOUT_MS,
@@ -941,6 +943,14 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
         snapshotRef: typeof parsed.snapshotRef === 'string' ? parsed.snapshotRef : undefined,
         authPurpose: typeof parsed.authPurpose === 'string' ? parsed.authPurpose : undefined,
         authSelector: typeof parsed.authSelector === 'string' ? parsed.authSelector : undefined,
+        pageMode: parsed.pageMode === SYNC_BYTE_BUDGET_PAGE_MODE
+          ? SYNC_BYTE_BUDGET_PAGE_MODE
+          : undefined,
+        pageRowsHint: parsed.pageMode === SYNC_BYTE_BUDGET_PAGE_MODE &&
+          Number.isSafeInteger(parsed.pageRowsHint) &&
+          Number(parsed.pageRowsHint) > SYNC_PAGE_SIZE
+          ? Math.min(Number(parsed.pageRowsHint), SYNC_BYTE_BUDGET_MAX_ROWS)
+          : undefined,
         targetPeerId: parsed.targetPeerId,
         requesterPeerId: parsed.requesterPeerId,
         requestId: parsed.requestId,

--- a/packages/agent/src/dkg-agent-constants.ts
+++ b/packages/agent/src/dkg-agent-constants.ts
@@ -17,8 +17,8 @@ import {
 export const PRIVATE_DATA_ANCHOR = 'http://dkg.io/ontology/privateDataAnchor';
 
 // ── Sync ──────────────────────────────────────────────────────────────
-/** Legacy responder-side maximum accepted row limit. Keep at 500 so a new
- * responder remains compatible with requesters from an older rolling node. */
+/** Legacy signed responder-side maximum accepted row limit. Keep at 500 so a
+ * new responder remains compatible with requesters from an older rolling node. */
 export const SYNC_PAGE_SIZE = 500;
 /**
  * Requester page size derived from the wire frame cap, not only row count.
@@ -28,11 +28,14 @@ export const SYNC_PAGE_SIZE = 500;
  * tripped ProtocolRouter's 10 MiB read limit before page parsing. Reserve six
  * MiB for subjects, predicates, graph IRIs, N-Quads syntax, and framing; the
  * remaining four MiB admits 64 maximum-sized literal rows. That value remains
- * the retry floor for pathological payloads. Normal RDF rows are far smaller,
- * so request 256 rows first and let the requester halve the limit on transport
- * retries (256 -> 128 -> 64). New requesters work with old responders because
- * `limit` was already part of the wire request; keeping SYNC_PAGE_SIZE above
- * unchanged preserves old-requester compatibility.
+ * the retry floor for pathological payloads.
+ *
+ * Upgraded authenticated peers negotiate a byte-budgeted page through
+ * additive unsigned hints. The signed `limit` stays capped at the legacy 500,
+ * so an old responder authenticates the request and simply returns 500 rows;
+ * a new responder may return up to the row hint but serializes only a bounded
+ * response body. EOF-only pagination makes both responses unambiguous. A
+ * transport failure retries at the conservative 64-row floor.
  */
 export const SYNC_RESPONSE_FRAME_HEADROOM_BYTES = 6 * 1024 * 1024;
 export const SYNC_REQUEST_SAFE_PAGE_SIZE = Math.max(
@@ -42,10 +45,14 @@ export const SYNC_REQUEST_SAFE_PAGE_SIZE = Math.max(
     JAVA_WRITE_UTF_MAX_BYTES,
   ),
 );
-export const SYNC_REQUEST_PAGE_SIZE = Math.min(
-  SYNC_PAGE_SIZE,
-  Math.max(SYNC_REQUEST_SAFE_PAGE_SIZE, 256),
-);
+/** Additive wire capability understood by upgraded authenticated responders. */
+export const SYNC_BYTE_BUDGET_PAGE_MODE = 'byte-budget-v1' as const;
+/** Maximum rows a responder may materialize for one byte-budgeted durable page. */
+export const SYNC_BYTE_BUDGET_MAX_ROWS = 8_192;
+/** Target serialized body. Six MiB of the 10 MiB router cap remains as headroom. */
+export const SYNC_BYTE_BUDGET_RESPONSE_BYTES = DEFAULT_MAX_READ_BYTES - SYNC_RESPONSE_FRAME_HEADROOM_BYTES;
+/** Throughput-oriented requested row hint; the signed legacy limit remains 500. */
+export const SYNC_REQUEST_PAGE_SIZE = SYNC_BYTE_BUDGET_MAX_ROWS;
 export const SYNC_PAGE_RETRY_ATTEMPTS = 3;
 export const SYNC_TOTAL_TIMEOUT_MS = 120_000;
 /** Per-page timeout for sync when we have budget (relay links can be slow). */

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -239,7 +239,11 @@ import {
   runOrderedContextGraphSyncs,
   type ContextGraphSyncWork,
 } from './sync/requester/ordered-sync.js';
-import { recoverContextGraphSwm, type RecoverContextGraphSwmResult } from './sync/requester/swm-recovery.js';
+import {
+  recoverContextGraphSwm,
+  recoverContextGraphSwmWithProgressRetries,
+  type RecoverContextGraphSwmResult,
+} from './sync/requester/swm-recovery.js';
 import { buildSyncRequestEnvelope, type SyncPhase } from './sync/auth/request-build.js';
 import { authorizePrivateSyncRequest } from './sync/auth/request-authorize.js';
 import {
@@ -833,6 +837,8 @@ function emptySwmRecoveryResult(): RecoverContextGraphSwmResult {
     insertedDataQuads: 0,
     insertedMetaQuads: 0,
     droppedDataTriples: 0,
+    readySnapshots: 0,
+    totalSnapshots: 0,
     completed: true,
   };
 }
@@ -4705,7 +4711,16 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           operationId: `swm-recovery:${contextGraphId}:${remotePeerId.slice(-8)}`,
           run: async (): Promise<SharedMemorySyncResult> => {
             try {
-              const recovered = await recoverPrivateContextGraph(contextGraphId);
+              const recovered = await recoverContextGraphSwmWithProgressRetries({
+                recover: () => recoverPrivateContextGraph(contextGraphId),
+                onRetry: ({ completedRound, readySnapshots, totalSnapshots }) => {
+                  this.log.info(
+                    ctx,
+                    `Continuing private SWM recovery for "${contextGraphId}" from ${remotePeerId.slice(-8)} `
+                    + `after round ${completedRound}: snapshots=${readySnapshots}/${totalSnapshots}`,
+                  );
+                },
+              });
               const result = emptySharedMemorySyncResult();
               result.insertedDataTriples = recovered.insertedDataQuads;
               result.insertedMetaTriples = recovered.insertedMetaQuads;

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -12,7 +12,7 @@ import { createHash } from 'node:crypto';
 import {
   DKGNode, ProtocolRouter, GossipSubManager, TypedEventBus, DKGEvent,
   LibP2PNetwork, PeerResolver, StubNetworkStateRegistry,
-  PROTOCOL_ACCESS, PROTOCOL_PUBLISH, PROTOCOL_SYNC, PROTOCOL_SYNC_CHANGELOG, PROTOCOL_QUERY_REMOTE, PROTOCOL_STORAGE_ACK, PROTOCOL_STORAGE_ACK_V2, PROTOCOL_STORAGE_UPDATE_ACK, PROTOCOL_STORAGE_UPDATE_ACK_V2, PROTOCOL_GET_CIPHERTEXT_CHUNK, PROTOCOL_VERIFY_PROPOSAL, PROTOCOL_JOIN_REQUEST,
+  PROTOCOL_ACCESS, PROTOCOL_PUBLISH, PROTOCOL_SYNC, PROTOCOL_SYNC_POOLED, PROTOCOL_SYNC_CHANGELOG, PROTOCOL_QUERY_REMOTE, PROTOCOL_STORAGE_ACK, PROTOCOL_STORAGE_ACK_V2, PROTOCOL_STORAGE_UPDATE_ACK, PROTOCOL_STORAGE_UPDATE_ACK_V2, PROTOCOL_GET_CIPHERTEXT_CHUNK, PROTOCOL_VERIFY_PROPOSAL, PROTOCOL_JOIN_REQUEST,
   PROTOCOL_NETWORK_IDENTITY,
   PROTOCOL_SWM_SENDER_KEY, PROTOCOL_SWM_UPDATE, PROTOCOL_SWM_SHARE_ACK, PROTOCOL_SWM_HOST_CATCHUP, PROTOCOL_MESSAGE,
   contextGraphPublishTopic, contextGraphWorkspaceTopic, contextGraphAppTopic, contextGraphUpdateTopic, contextGraphFinalizationTopic,
@@ -696,6 +696,7 @@ interface RecoverContextGraphSwmFromPeerDependencies {
   fetchSyncPages: RecoverContextGraphSwmOptions['fetchSyncPages'];
   processSharedMemoryBatch: RecoverContextGraphSwmOptions['processSharedMemoryBatch'];
   publicSnapshotStore?: WorkspacePublicSnapshotStore;
+  isGraphAssetMaterialized: NonNullable<RecoverContextGraphSwmOptions['isGraphAssetMaterialized']>;
   recordDrops: OversizeGuardHooks['recordDrops'];
   invalidateListContextGraphsCache: () => void;
   markMetaProjectionDirty: (quads: Quad[]) => void;
@@ -2085,6 +2086,18 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       configuredPriorities: configuredPriorityCounts,
       snapshotLocalClamped: snapshotPolicy.localRowsClamped || snapshotPolicy.localBytesEstimateClamped,
     })}`);
+    // Keep one framed sync stream (and therefore its circuit-relay connection)
+    // alive across page requests. Old peers do not advertise this wire id and
+    // transparently fall back to PROTOCOL_SYNC. Set DKG_POOLED_SYNC=0 only as
+    // an emergency rollback; the hot path is enabled by default.
+    if (process.env.DKG_POOLED_SYNC !== '0') {
+      this.router.enablePooling(PROTOCOL_SYNC, {
+        protocolId: PROTOCOL_SYNC_POOLED,
+        keepaliveIntervalMs: 10_000,
+        idleTimeoutMs: 5 * 60_000,
+      });
+      this.log.info(ctx, `[sync] pooled wire variant ${PROTOCOL_SYNC_POOLED} enabled`);
+    }
     registerSyncHandler({
       register: (protocol, handler) =>
         this.router.register(protocol, (data, peerIdObj, options) => handler(data, peerIdObj.toString(), options)),
@@ -4589,6 +4602,19 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         processSharedMemoryBatch: (data, meta, cgId, registered, excluded) =>
           this.getOrCreateSyncVerifyWorker().processSharedMemoryBatch(data, meta, cgId, registered, excluded),
         publicSnapshotStore: this.publicSnapshotStore,
+        isGraphAssetMaterialized: async (asset) => {
+          const result = await this.store.query(
+            `ASK { GRAPH <${assertSafeIri(asset.metaGraph)}> { ` +
+              `<${assertSafeIri(asset.headSubject)}> ` +
+              `<http://dkg.io/ontology/assertionGraph> ` +
+              `<${assertSafeIri(asset.assertionGraph)}> . } }`,
+            {
+              priority: 'background',
+              source: 'agent.swmRecovery.isGraphAssetMaterialized',
+            },
+          );
+          return result.type === 'boolean' && result.value;
+        },
         recordDrops: (drops, seam) => this.oversizeTombstoneLog.record(drops, seam),
         invalidateListContextGraphsCache: () => this.invalidateListContextGraphsCache(),
         markMetaProjectionDirty: (quads) => this.contextGraphMetaProjection.markDirtyFromQuads(quads),
@@ -4810,6 +4836,19 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           processSharedMemoryBatch: (data, meta, cgId, registered, excluded) =>
             this.getOrCreateSyncVerifyWorker().processSharedMemoryBatch(data, meta, cgId, registered, excluded),
           publicSnapshotStore: this.publicSnapshotStore,
+          isGraphAssetMaterialized: async (asset) => {
+            const result = await this.store.query(
+              `ASK { GRAPH <${assertSafeIri(asset.metaGraph)}> { ` +
+                `<${assertSafeIri(asset.headSubject)}> ` +
+                `<http://dkg.io/ontology/assertionGraph> ` +
+                `<${assertSafeIri(asset.assertionGraph)}> . } }`,
+              {
+                priority: 'background',
+                source: 'agent.swmRecovery.isGraphAssetMaterialized',
+              },
+            );
+            return result.type === 'boolean' && result.value;
+          },
           recordDrops: (drops, seam) => this.oversizeTombstoneLog.record(drops, seam),
           invalidateListContextGraphsCache: () => this.invalidateListContextGraphsCache(),
           markMetaProjectionDirty: (quads) => this.contextGraphMetaProjection.markDirtyFromQuads(quads),
@@ -7052,6 +7091,7 @@ async function runRecoverContextGraphSwmFromPeer(
     fetchSyncPages: dependencies.fetchSyncPages,
     processSharedMemoryBatch: dependencies.processSharedMemoryBatch,
     publicSnapshotStore: dependencies.publicSnapshotStore,
+    isGraphAssetMaterialized: dependencies.isGraphAssetMaterialized,
     // SwmRecoveryStore: invalidate the list cache + mark the meta projection
     // dirty on insert (parity with runSharedMemorySync's
     // insertSyncedQuadsAndInvalidateListCache); deletes pass through to the store.

--- a/packages/agent/src/dkg-agent-registry.ts
+++ b/packages/agent/src/dkg-agent-registry.ts
@@ -418,6 +418,29 @@ function parseExplicitConnectTarget(multiaddress: string, admissionEnabled: bool
 }
 
 export class AgentRegistryMethods extends DKGAgentBase {
+  async ensureProfilePublished(this: DKGAgent): Promise<void> {
+    if (this.profileManager.profileKcId !== null) return;
+    if (this.ensureProfilePublishedInFlight) {
+      return this.ensureProfilePublishedInFlight;
+    }
+
+    let tracked: Promise<void>;
+    const publish = (async () => {
+      // Re-check inside the coalesced operation in case another serialized
+      // publisher completed between the fast-path check and this turn.
+      if (this.profileManager.profileKcId === null) {
+        await this.publishProfile();
+      }
+    })();
+    tracked = publish.finally(() => {
+      if (this.ensureProfilePublishedInFlight === tracked) {
+        this.ensureProfilePublishedInFlight = undefined;
+      }
+    });
+    this.ensureProfilePublishedInFlight = tracked;
+    return tracked;
+  }
+
   async publishProfile(this: DKGAgent): Promise<PublishResult> {
     // Tail-chain serialization: every caller waits for the prior
     // `publishProfile()` to settle (success or failure) before

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -156,6 +156,13 @@ export interface SyncRequestEnvelope {
   snapshotRef?: string;
   authPurpose?: string;
   authSelector?: string;
+  /**
+   * Additive unsigned response-shaping capability. The authenticated legacy
+   * `limit` remains capped at 500; upgraded responders may honor this hint only
+   * under their own hard row/byte caps. Kept in lockstep with request-build.ts.
+   */
+  pageMode?: 'byte-budget-v1';
+  pageRowsHint?: number;
   targetPeerId?: string;
   requesterPeerId?: string;
   requestId?: string;

--- a/packages/agent/src/sync/auth/request-build.ts
+++ b/packages/agent/src/sync/auth/request-build.ts
@@ -1,4 +1,9 @@
 import { ethers } from 'ethers';
+import {
+  SYNC_BYTE_BUDGET_MAX_ROWS,
+  SYNC_BYTE_BUDGET_PAGE_MODE,
+  SYNC_PAGE_SIZE,
+} from '../../dkg-agent-constants.js';
 
 // 'catalog' (§7) — the public facet open-serve: served to ANYONE
 // without the allowlist gate, bounded to exactly the `_catalog` named graph.
@@ -28,6 +33,16 @@ export interface SyncRequestEnvelope {
   snapshotRef?: string;
   authPurpose?: string;
   authSelector?: string;
+  /**
+   * Additive, UNSIGNED response-shaping capability. The signed `limit` remains
+   * at or below the legacy 500-row cap, so old responders can authenticate and
+   * serve the request unchanged. New responders may honor `pageRowsHint`, but
+   * only under their own hard row and byte caps. This cannot expand the caller's
+   * authorization scope; it only changes how much already-authorized durable
+   * data is returned in one response.
+   */
+  pageMode?: typeof SYNC_BYTE_BUDGET_PAGE_MODE;
+  pageRowsHint?: number;
   /**
    * Phase C — optional, UNSIGNED delta-sync hint. When set, the responder
    * returns only Knowledge Assets whose KC `dkg:batchId` is strictly greater
@@ -154,6 +169,11 @@ export async function buildSyncRequestEnvelope(params: BuildSyncRequestParams): 
     throw new Error(`Cannot build agent-signed sync request for "${contextGraphId}": forced agent signing requires an authenticated envelope`);
   }
 
+  const requestedLimit = Number.isSafeInteger(limit)
+    ? Math.max(1, Math.min(limit, SYNC_BYTE_BUDGET_MAX_ROWS))
+    : SYNC_PAGE_SIZE;
+  const useByteBudgetPage = !includeSharedMemory && phase === 'data' && requestedLimit > SYNC_PAGE_SIZE;
+
   if (!needsAuth) {
     const prefix = includeSharedMemory ? `workspace:${contextGraphId}` : contextGraphId;
     const phaseSuffix = phase === 'meta'
@@ -171,13 +191,17 @@ export async function buildSyncRequestEnvelope(params: BuildSyncRequestParams): 
     // Trailing keyed tokens are additive; old responders ignore the extra parts.
     const sessionSuffix = syncSessionId ? `|session|${syncSessionId}` : '';
     const sinceSuffix = sinceBatchId ? `|since|${sinceBatchId}` : '';
-    return new TextEncoder().encode(`${prefix}|${offset}|${limit}${phaseSuffix}${sessionSuffix}${sinceSuffix}`);
+    return new TextEncoder().encode(`${prefix}|${offset}|${requestedLimit}${phaseSuffix}${sessionSuffix}${sinceSuffix}`);
   }
 
   const request: SyncRequestEnvelope = {
     contextGraphId,
     offset,
-    limit,
+    // Keep this signed field within the legacy cap. An old responder clamps to
+    // the same value before verifying the digest, so rolling upgrades remain
+    // wire-compatible even when the additive hint below asks a new responder
+    // for a larger byte-bounded page.
+    limit: Math.min(requestedLimit, SYNC_PAGE_SIZE),
     includeSharedMemory,
     targetPeerId,
     requesterPeerId,
@@ -217,6 +241,10 @@ export async function buildSyncRequestEnvelope(params: BuildSyncRequestParams): 
   // authorization; only narrows the responder's result set).
   if (syncSessionId) request.syncSessionId = syncSessionId;
   if (sinceBatchId) request.sinceBatchId = sinceBatchId;
+  if (useByteBudgetPage) {
+    request.pageMode = SYNC_BYTE_BUDGET_PAGE_MODE;
+    request.pageRowsHint = requestedLimit;
+  }
   // R9: unsigned recovery marker (only ever escalates strictness — see field
   // docs). The responder authorizes against the recovered signer, not this flag.
   if (recovery) request.recovery = true;

--- a/packages/agent/src/sync/durable-integrity.ts
+++ b/packages/agent/src/sync/durable-integrity.ts
@@ -130,6 +130,8 @@ export interface BoundedGraphScopedDurableBatch {
   safeNextOffset: number;
   /** Number of positive-size assertion graphs completed in this round. */
   completedGraphCount: number;
+  /** Total public rows declared by the verified graph-scoped manifest. */
+  manifestRowCount: number;
 }
 
 function compareUnicodeCodePoints(leftValue: string, rightValue: string): number {
@@ -264,6 +266,7 @@ export function planBoundedGraphScopedDurableBatch(
     changedDataGraphs: [...completeGraphs],
     safeNextOffset,
     completedGraphCount,
+    manifestRowCount: manifestOffset,
   };
 }
 

--- a/packages/agent/src/sync/requester/durable-sync.ts
+++ b/packages/agent/src/sync/requester/durable-sync.ts
@@ -292,15 +292,17 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
         : { kind: 'sinceBatchId', sinceBatchId };
 
       // A rootless full snapshot is a deterministic concatenation of complete
-      // exact graphs. When the deadline cuts the final graph mid-page, verify
-      // and persist only the preceding complete graphs, then checkpoint their
-      // absolute row boundary. The partial graph is deliberately discarded and
-      // retried. This gives large V2 snapshots bounded memory and monotonic
-      // progress without weakening legacy/mixed-layout fail-closed behaviour.
+      // exact graphs. Always compare a graph-scoped response with its verified
+      // metadata manifest: a relayed stream can close cleanly after a prefix
+      // and surface `completed=true` even though later graphs never arrived.
+      // Verify and persist only complete leading graphs, checkpoint their
+      // absolute row boundary, and call the phase complete only at the manifest
+      // total. A partial final graph is deliberately discarded and retried.
+      // This gives large V2 snapshots bounded memory and monotonic progress
+      // without weakening legacy/mixed-layout fail-closed behaviour.
       if (
         sinceBatchId === undefined
         && !isSystemContextGraph
-        && (dataResult.timedOut || dataResult.resumedFromOffset > 0)
       ) {
         const bounded = planBoundedGraphScopedDurableBatch(
           dataResult.quads,
@@ -315,6 +317,8 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
             ...dataResult,
             quads: bounded.dataQuads,
             nextOffset: bounded.safeNextOffset,
+            completed: dataResult.completed
+              && bounded.safeNextOffset === bounded.manifestRowCount,
           };
           verificationMode = {
             kind: 'changelogPage',
@@ -325,7 +329,7 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
             `Rootless durable progress for "${pid}": `
               + `${bounded.completedGraphCount} complete graph(s), `
               + `safe offset ${dataResult.resumedFromOffset}->${bounded.safeNextOffset} `
-              + `(raw ${dataResult.nextOffset})`,
+              + `of ${bounded.manifestRowCount} (raw ${dataResult.nextOffset})`,
           );
         }
       }

--- a/packages/agent/src/sync/requester/page-fetch.ts
+++ b/packages/agent/src/sync/requester/page-fetch.ts
@@ -244,6 +244,7 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
   const usesByteBudgetPagination = syncPageSize > SYNC_PAGE_SIZE;
   let activePageSize = syncPageSize;
   let successfulPageSize = syncPageSize;
+  let consecutiveSuccessfulPages = 0;
   const syncSessionId = usesPageSession
     ? (savedResponderSession?.syncSessionId ?? createResponderSessionId(includeSharedMemory, phase))
     : undefined;
@@ -301,14 +302,14 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
         onRetry: (attempt, delay, err) => {
           const priorPageSize = activePageSize;
           if (activePageSize > safePageSize) {
-            // A failed multi-thousand-row response should not spend two more
-            // attempts walking down through still-large pages. Drop directly
-            // to the proven frame-safe floor. Legacy-sized callers retain the
-            // historical halving behaviour used by mixed-version tests.
-            activePageSize = usesByteBudgetPagination
-              ? safePageSize
-              : Math.max(safePageSize, Math.floor(activePageSize / 2));
+            // Adapt to the actual path capacity instead of falling all the way
+            // from 8192 rows to the 64-row emergency floor. A lossy relay can
+            // often carry 1k-4k rows reliably; halving finds that stable point
+            // within the existing retry budget without turning the remainder
+            // of the phase into hundreds of tiny round trips.
+            activePageSize = Math.max(safePageSize, Math.floor(activePageSize / 2));
           }
+          consecutiveSuccessfulPages = 0;
           const pageSizeNote = activePageSize < priorPageSize
             ? `; reducing page size ${priorPageSize}->${activePageSize}`
             : '';
@@ -362,10 +363,19 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
 
       appendInPlace(allQuads, parsed.quads);
       offset += parsed.totalQuads;
-      // One conservative retry must not throttle the rest of a healthy phase.
-      // The next request returns to the byte-budget hint; if it fails again the
-      // same bounded fallback applies independently.
-      if (usesByteBudgetPagination) activePageSize = syncPageSize;
+      // Keep the size that actually crossed the path. Probe upward only after
+      // three consecutive successful pages, and at most double at a time.
+      // This avoids the old 8192 -> 64 -> 8192 oscillation where every useful
+      // page paid for a doomed large request and its timeout first.
+      if (usesByteBudgetPagination && activePageSize < syncPageSize) {
+        consecutiveSuccessfulPages += 1;
+        if (consecutiveSuccessfulPages >= 3) {
+          activePageSize = Math.min(syncPageSize, activePageSize * 2);
+          consecutiveSuccessfulPages = 0;
+        }
+      } else {
+        consecutiveSuccessfulPages = 0;
+      }
 
       if (debugSyncProgress) {
         logInfo(

--- a/packages/agent/src/sync/requester/page-fetch.ts
+++ b/packages/agent/src/sync/requester/page-fetch.ts
@@ -16,7 +16,10 @@ import {
 import {
   createRequesterPhaseTelemetry,
 } from '../memory-telemetry.js';
-import { SYNC_REQUEST_SAFE_PAGE_SIZE } from '../../dkg-agent-constants.js';
+import {
+  SYNC_PAGE_SIZE,
+  SYNC_REQUEST_SAFE_PAGE_SIZE,
+} from '../../dkg-agent-constants.js';
 
 const MAX_UNFINISHED_SYNC_RESPONDER_SESSIONS = 4096;
 type UnfinishedSyncResponderSession = {
@@ -238,6 +241,7 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
   // A transient failure merely makes the remainder of this phase conservative;
   // it never changes offsets or responder-session identity.
   const safePageSize = Math.min(syncPageSize, SYNC_REQUEST_SAFE_PAGE_SIZE);
+  const usesByteBudgetPagination = syncPageSize > SYNC_PAGE_SIZE;
   let activePageSize = syncPageSize;
   let successfulPageSize = syncPageSize;
   const syncSessionId = usesPageSession
@@ -297,7 +301,13 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
         onRetry: (attempt, delay, err) => {
           const priorPageSize = activePageSize;
           if (activePageSize > safePageSize) {
-            activePageSize = Math.max(safePageSize, Math.floor(activePageSize / 2));
+            // A failed multi-thousand-row response should not spend two more
+            // attempts walking down through still-large pages. Drop directly
+            // to the proven frame-safe floor. Legacy-sized callers retain the
+            // historical halving behaviour used by mixed-version tests.
+            activePageSize = usesByteBudgetPagination
+              ? safePageSize
+              : Math.max(safePageSize, Math.floor(activePageSize / 2));
           }
           const pageSizeNote = activePageSize < priorPageSize
             ? `; reducing page size ${priorPageSize}->${activePageSize}`
@@ -352,6 +362,10 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
 
       appendInPlace(allQuads, parsed.quads);
       offset += parsed.totalQuads;
+      // One conservative retry must not throttle the rest of a healthy phase.
+      // The next request returns to the byte-budget hint; if it fails again the
+      // same bounded fallback applies independently.
+      if (usesByteBudgetPagination) activePageSize = syncPageSize;
 
       if (debugSyncProgress) {
         logInfo(
@@ -359,7 +373,11 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
           `Sync progress for "${contextGraphId}" ${includeSharedMemory ? 'shared-memory' : 'durable'} ${phase}: transferred=${allQuads.length} bytes=${bytesReceived} offset=${offset}`,
         );
       }
-      if (parsed.totalQuads < successfulPageSize) break;
+      // A new responder may deliberately return a short prefix to stay inside
+      // its byte budget, while an old responder returns at most its legacy
+      // 500-row cap. Therefore short pages are not EOF in negotiated mode; an
+      // explicit empty response is. Legacy pagination keeps the old shortcut.
+      if (!usesByteBudgetPagination && parsed.totalQuads < successfulPageSize) break;
     }
   } catch (err) {
     const denied = (err as Error & { syncDenied?: boolean }).syncDenied === true;

--- a/packages/agent/src/sync/requester/shared-memory-sync.ts
+++ b/packages/agent/src/sync/requester/shared-memory-sync.ts
@@ -361,6 +361,15 @@ export async function syncPublicSnapshotsForMeta(params: {
   fetchSyncPages: SharedMemorySyncContext['fetchSyncPages'];
   deleteCheckpoint: (key: string) => void;
   setCheckpoint: (key: string, offset: number) => void;
+  /**
+   * Optional recovery hook invoked only after the complete immutable snapshot
+   * has passed its signed digest/count check. Callers may make that one KA
+   * visible immediately; an unverified prefix never reaches this hook.
+   */
+  onSnapshotReady?: (
+    snapshot: PublicSnapshotMetadata,
+    source: 'cache' | 'network',
+  ) => Promise<void>;
 }): Promise<{
   bytesReceived: number;
   resumedPhases: number;
@@ -400,6 +409,7 @@ export async function syncPublicSnapshotsForMeta(params: {
   let readySnapshots = 0;
   for (const snapshot of snapshots) {
     if (await hasValidSnapshot(params.publicSnapshotStore, snapshot)) {
+      await params.onSnapshotReady?.(snapshot, 'cache');
       readySnapshots += 1;
       continue;
     }
@@ -468,6 +478,7 @@ export async function syncPublicSnapshotsForMeta(params: {
       );
     }
     await params.publicSnapshotStore.putSnapshot({ digest: snapshot.digest, quads: snapshotQuads });
+    await params.onSnapshotReady?.(snapshot, 'network');
     completedPhases += 1;
     readySnapshots += 1;
   }

--- a/packages/agent/src/sync/requester/shared-memory-sync.ts
+++ b/packages/agent/src/sync/requester/shared-memory-sync.ts
@@ -417,9 +417,6 @@ export async function syncPublicSnapshotsForMeta(params: {
     bytesReceived += result.bytesReceived;
     resumedPhases += result.resumedFromOffset > 0 ? 1 : 0;
     timedOutPhases += result.timedOut ? 1 : 0;
-    if (result.completed && (result.resumedFromOffset > 0 || result.nextOffset > result.resumedFromOffset)) {
-      completedPhases += 1;
-    }
     if (result.completed) params.deleteCheckpoint(result.checkpointKey);
     else {
       // `fetchSyncPages` returns only the quads fetched during THIS call. We do
@@ -443,6 +440,26 @@ export async function syncPublicSnapshotsForMeta(params: {
     }
 
     const snapshotQuads = result.quads.map((quad) => ({ ...quad, graph: '' }));
+    if (snapshotQuads.length < snapshot.count) {
+      // A relayed stream can terminate cleanly after returning a prefix. The
+      // requester then sees `completed=true`, but the signed metadata gives us
+      // an authoritative expected count and proves that this is incomplete,
+      // not corrupt. Never cache or apply the prefix; retry it from offset zero
+      // in a later bounded recovery round. Equal-count digest mismatches remain
+      // fatal below so a complete but tampered snapshot is never softened into
+      // a transport retry.
+      params.deleteCheckpoint(result.checkpointKey);
+      return {
+        bytesReceived,
+        resumedPhases,
+        timedOutPhases,
+        completedPhases,
+        checkpointAdvances,
+        readySnapshots,
+        totalSnapshots: snapshots.length,
+        completed: false,
+      };
+    }
     const actualDigest = workspacePublicQuadsDigest(snapshotQuads);
     if (actualDigest !== snapshot.digest || snapshotQuads.length !== snapshot.count) {
       throw new Error(
@@ -451,6 +468,7 @@ export async function syncPublicSnapshotsForMeta(params: {
       );
     }
     await params.publicSnapshotStore.putSnapshot({ digest: snapshot.digest, quads: snapshotQuads });
+    completedPhases += 1;
     readySnapshots += 1;
   }
 

--- a/packages/agent/src/sync/requester/shared-memory-sync.ts
+++ b/packages/agent/src/sync/requester/shared-memory-sync.ts
@@ -367,6 +367,10 @@ export async function syncPublicSnapshotsForMeta(params: {
   timedOutPhases: number;
   completedPhases: number;
   checkpointAdvances: number;
+  /** Immutable snapshot refs already valid locally or fetched in this round. */
+  readySnapshots: number;
+  /** Total immutable snapshot refs declared by the verified SWM metadata. */
+  totalSnapshots: number;
   completed: boolean;
 }> {
   const snapshots = collectPublicSnapshotMetadata(params.metaQuads);
@@ -377,6 +381,8 @@ export async function syncPublicSnapshotsForMeta(params: {
       timedOutPhases: 0,
       completedPhases: 0,
       checkpointAdvances: 0,
+      readySnapshots: 0,
+      totalSnapshots: 0,
       completed: true,
     };
   }
@@ -391,8 +397,10 @@ export async function syncPublicSnapshotsForMeta(params: {
   let timedOutPhases = 0;
   let completedPhases = 0;
   let checkpointAdvances = 0;
+  let readySnapshots = 0;
   for (const snapshot of snapshots) {
     if (await hasValidSnapshot(params.publicSnapshotStore, snapshot)) {
+      readySnapshots += 1;
       continue;
     }
 
@@ -428,6 +436,8 @@ export async function syncPublicSnapshotsForMeta(params: {
         timedOutPhases,
         completedPhases,
         checkpointAdvances,
+        readySnapshots,
+        totalSnapshots: snapshots.length,
         completed: false,
       };
     }
@@ -441,6 +451,7 @@ export async function syncPublicSnapshotsForMeta(params: {
       );
     }
     await params.publicSnapshotStore.putSnapshot({ digest: snapshot.digest, quads: snapshotQuads });
+    readySnapshots += 1;
   }
 
   return {
@@ -449,6 +460,8 @@ export async function syncPublicSnapshotsForMeta(params: {
     timedOutPhases,
     completedPhases,
     checkpointAdvances,
+    readySnapshots,
+    totalSnapshots: snapshots.length,
     completed: true,
   };
 }

--- a/packages/agent/src/sync/requester/shared-memory-sync.ts
+++ b/packages/agent/src/sync/requester/shared-memory-sync.ts
@@ -242,6 +242,12 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       summary.checkpointAdvances += snapshotSync.checkpointAdvances;
       const snapshotDurationMs = Date.now() - snapshotStartedAt;
       if (!snapshotSync.completed) {
+        // The responder was reachable, but the snapshot phase did not produce
+        // a complete, verified snapshot. Preserve any verified data prefix
+        // below, while keeping the overall sync result non-successful so the
+        // lifecycle scheduler retries instead of stamping this peer as caught
+        // up with dangling/missing public snapshot state.
+        summary.failedPhases += 1;
         if (validWsQuads.length > 0) {
           await ensureContextGraph(pid);
           await storeInsert(validWsQuads);

--- a/packages/agent/src/sync/requester/swm-recovery.ts
+++ b/packages/agent/src/sync/requester/swm-recovery.ts
@@ -136,6 +136,7 @@ export interface RecoverContextGraphSwmResult {
 }
 
 export const DEFAULT_PRIVATE_SWM_RECOVERY_MAX_ROUNDS = 6;
+export const ABSOLUTE_PRIVATE_SWM_RECOVERY_MAX_ROUNDS = 24;
 
 /**
  * Repeat an authoritative private-SWM recovery while its immutable snapshot
@@ -147,8 +148,13 @@ export const DEFAULT_PRIVATE_SWM_RECOVERY_MAX_ROUNDS = 6;
  * same catch-up job without weakening the all-or-nothing graph apply gate.
  *
  * One no-progress retry is allowed for a transient transport failure. Two
- * consecutive results with the same ready count stop the driver, and the hard
- * round cap prevents an arbitrarily large CG from monopolising a worker.
+ * consecutive results with the same ready count stop the driver. For the
+ * default policy, the first verified metadata response expands the six-round
+ * floor to at most one round per declared immutable snapshot plus a two-round
+ * transport cushion, bounded by an absolute ceiling. That lets a finite CG
+ * finish when a lossy relay yields only one new verified snapshot per round,
+ * without allowing an arbitrarily large CG to monopolise a worker. An explicit
+ * `maxRounds` remains authoritative for callers and tests.
  */
 export async function recoverContextGraphSwmWithProgressRetries(params: {
   readonly recover: () => Promise<RecoverContextGraphSwmResult>;
@@ -159,10 +165,10 @@ export async function recoverContextGraphSwmWithProgressRetries(params: {
     readonly totalSnapshots: number;
   }) => void;
 }): Promise<RecoverContextGraphSwmResult> {
-  const maxRounds = Math.max(
-    1,
-    Math.floor(params.maxRounds ?? DEFAULT_PRIVATE_SWM_RECOVERY_MAX_ROUNDS),
-  );
+  const explicitMaxRounds = params.maxRounds === undefined
+    ? undefined
+    : Math.max(1, Math.floor(params.maxRounds));
+  let maxRounds = explicitMaxRounds ?? DEFAULT_PRIVATE_SWM_RECOVERY_MAX_ROUNDS;
   let previousReadySnapshots = -1;
   let consecutiveNoProgressRounds = 0;
   let result: RecoverContextGraphSwmResult | undefined;
@@ -170,6 +176,13 @@ export async function recoverContextGraphSwmWithProgressRetries(params: {
   for (let round = 1; round <= maxRounds; round += 1) {
     result = await params.recover();
     if (result.completed) return result;
+
+    if (explicitMaxRounds === undefined && Number.isSafeInteger(result.totalSnapshots)) {
+      maxRounds = Math.min(
+        ABSOLUTE_PRIVATE_SWM_RECOVERY_MAX_ROUNDS,
+        Math.max(maxRounds, result.totalSnapshots + 2),
+      );
+    }
 
     const madeProgress = result.readySnapshots > previousReadySnapshots;
     consecutiveNoProgressRounds = madeProgress ? 0 : consecutiveNoProgressRounds + 1;

--- a/packages/agent/src/sync/requester/swm-recovery.ts
+++ b/packages/agent/src/sync/requester/swm-recovery.ts
@@ -146,9 +146,9 @@ export const DEFAULT_PRIVATE_SWM_RECOVERY_MAX_ROUNDS = 6;
  * reconnect/reconciler tick. This bounded driver consumes that progress in the
  * same catch-up job without weakening the all-or-nothing graph apply gate.
  *
- * One no-progress retry is allowed for a transient first-round transport
- * failure. A second result with the same ready count stops immediately, and the
- * hard round cap prevents an arbitrarily large CG from monopolising a worker.
+ * One no-progress retry is allowed for a transient transport failure. Two
+ * consecutive results with the same ready count stop the driver, and the hard
+ * round cap prevents an arbitrarily large CG from monopolising a worker.
  */
 export async function recoverContextGraphSwmWithProgressRetries(params: {
   readonly recover: () => Promise<RecoverContextGraphSwmResult>;
@@ -164,6 +164,7 @@ export async function recoverContextGraphSwmWithProgressRetries(params: {
     Math.floor(params.maxRounds ?? DEFAULT_PRIVATE_SWM_RECOVERY_MAX_ROUNDS),
   );
   let previousReadySnapshots = -1;
+  let consecutiveNoProgressRounds = 0;
   let result: RecoverContextGraphSwmResult | undefined;
 
   for (let round = 1; round <= maxRounds; round += 1) {
@@ -171,7 +172,8 @@ export async function recoverContextGraphSwmWithProgressRetries(params: {
     if (result.completed) return result;
 
     const madeProgress = result.readySnapshots > previousReadySnapshots;
-    if (round >= maxRounds || !madeProgress) return result;
+    consecutiveNoProgressRounds = madeProgress ? 0 : consecutiveNoProgressRounds + 1;
+    if (round >= maxRounds || consecutiveNoProgressRounds >= 2) return result;
 
     previousReadySnapshots = result.readySnapshots;
     params.onRetry?.({

--- a/packages/agent/src/sync/requester/swm-recovery.ts
+++ b/packages/agent/src/sync/requester/swm-recovery.ts
@@ -127,8 +127,62 @@ export interface RecoverContextGraphSwmResult {
   readonly insertedDataQuads: number;
   readonly insertedMetaQuads: number;
   readonly droppedDataTriples: number;
+  /** Verified immutable snapshot refs ready in the local cache after this round. */
+  readonly readySnapshots: number;
+  /** Total immutable snapshot refs declared by the recovered SWM metadata. */
+  readonly totalSnapshots: number;
   /** false if a phase hit the deadline without completing — partial, safe to retry. */
   readonly completed: boolean;
+}
+
+export const DEFAULT_PRIVATE_SWM_RECOVERY_MAX_ROUNDS = 6;
+
+/**
+ * Repeat an authoritative private-SWM recovery while its immutable snapshot
+ * cache is making monotonic progress. A single recovery round is deliberately
+ * deadline-bounded; large rootless CGs can therefore finish several verified
+ * KAs and time out before the final one. Treating that first timeout as a
+ * terminal subscribe failure strands the safe cached progress until a later
+ * reconnect/reconciler tick. This bounded driver consumes that progress in the
+ * same catch-up job without weakening the all-or-nothing graph apply gate.
+ *
+ * One no-progress retry is allowed for a transient first-round transport
+ * failure. A second result with the same ready count stops immediately, and the
+ * hard round cap prevents an arbitrarily large CG from monopolising a worker.
+ */
+export async function recoverContextGraphSwmWithProgressRetries(params: {
+  readonly recover: () => Promise<RecoverContextGraphSwmResult>;
+  readonly maxRounds?: number;
+  readonly onRetry?: (progress: {
+    readonly completedRound: number;
+    readonly readySnapshots: number;
+    readonly totalSnapshots: number;
+  }) => void;
+}): Promise<RecoverContextGraphSwmResult> {
+  const maxRounds = Math.max(
+    1,
+    Math.floor(params.maxRounds ?? DEFAULT_PRIVATE_SWM_RECOVERY_MAX_ROUNDS),
+  );
+  let previousReadySnapshots = -1;
+  let result: RecoverContextGraphSwmResult | undefined;
+
+  for (let round = 1; round <= maxRounds; round += 1) {
+    result = await params.recover();
+    if (result.completed) return result;
+
+    const madeProgress = result.readySnapshots > previousReadySnapshots;
+    if (round >= maxRounds || !madeProgress) return result;
+
+    previousReadySnapshots = result.readySnapshots;
+    params.onRetry?.({
+      completedRound: round,
+      readySnapshots: result.readySnapshots,
+      totalSnapshots: result.totalSnapshots,
+    });
+  }
+
+  // The loop always executes at least once because maxRounds is clamped to 1.
+  return result!;
 }
 
 const DEFAULT_MAX_PAGES_PER_PHASE = 1000;
@@ -187,6 +241,8 @@ export async function recoverContextGraphSwm(
       insertedDataQuads: 0,
       insertedMetaQuads: 0,
       droppedDataTriples: 0,
+      readySnapshots: 0,
+      totalSnapshots: 0,
       completed: false,
     };
   }
@@ -227,6 +283,7 @@ export async function recoverContextGraphSwm(
   const hasGraphBackedSnapshots = graphScopedDescriptors.some(
     (descriptor) => descriptor.publicSnapshotGraph !== undefined,
   );
+  let snapshotProgress = { readySnapshots: 0, totalSnapshots: 0 };
 
   // Fetch store-backed snapshots before any aggregate data scan. Each completed
   // snapshot is persisted independently, so a deadline can make monotonic
@@ -247,6 +304,10 @@ export async function recoverContextGraphSwm(
       deleteCheckpoint: deps.deleteCheckpoint,
       setCheckpoint: deps.setCheckpoint,
     });
+    snapshotProgress = {
+      readySnapshots: snapshotSync.readySnapshots,
+      totalSnapshots: snapshotSync.totalSnapshots,
+    };
     if (!snapshotSync.completed) {
       deps.logInfo?.(
         deps.ctx,
@@ -259,6 +320,7 @@ export async function recoverContextGraphSwm(
         insertedDataQuads: 0,
         insertedMetaQuads: 0,
         droppedDataTriples: 0,
+        ...snapshotProgress,
         completed: false,
       };
     }
@@ -287,6 +349,7 @@ export async function recoverContextGraphSwm(
       insertedDataQuads: 0,
       insertedMetaQuads: 0,
       droppedDataTriples: 0,
+      ...snapshotProgress,
       completed: false,
     };
   }
@@ -376,6 +439,7 @@ export async function recoverContextGraphSwm(
     insertedDataQuads: applied.insertedQuads + insertedGraphQuads,
     insertedMetaQuads: processed.verifiedMeta.length,
     droppedDataTriples: processed.droppedDataTriples,
+    ...snapshotProgress,
     completed: true,
   };
 }

--- a/packages/agent/src/sync/requester/swm-recovery.ts
+++ b/packages/agent/src/sync/requester/swm-recovery.ts
@@ -35,18 +35,15 @@ import {
  * - legacy root-scoped KAs and graph-backed legacy snapshots retain the full
  *   data-phase recovery below.
  *
- * A partial fetch (deadline) is NOT safe to apply, and is deliberately NOT
- * applied. Pagination is row-based, so a single root's rows (the root + its
- * skolemized children + every predicate) can straddle the last fetched page: a
- * deadline can cut a root mid-stream. REPLACE-ing such a root would clear it and
- * reinsert only the fetched prefix, truncating the entity until a later retry —
- * the same corruption the per-root REPLACE exists to prevent. So recovery is
- * all-or-nothing: we apply ONLY when BOTH phases fetched to completion; on a
- * partial fetch we mutate the store not at all, drop the mid-stream checkpoint
- * so the retry re-accumulates from offset 0, and return `completed: false` for
- * the caller to retry. (Per-root completeness is not cheaply recoverable here —
- * `entityCreators` is a set derived from possibly-truncated rows, so the
- * truncated tail root can't be singled out; all-or-nothing is the correct gate.)
+ * A partial legacy-root fetch (deadline) is NOT safe to apply. Pagination is
+ * row-based, so a root's rows can straddle the last fetched page; replacing it
+ * with that prefix would truncate the entity. Legacy recovery therefore stays
+ * all-or-nothing and restarts from offset zero after a partial response.
+ *
+ * Exact rootless KAs are different: each immutable snapshot carries its own
+ * signed count and digest. A complete verified KA can be atomically
+ * materialized immediately while the next KA is still downloading. An
+ * incomplete snapshot remains invisible and is retried from zero.
  *
  * This is deliberately separate from `runSharedMemorySync` so the shared
  * incremental path (cold-start / public / top-up, where union is correct) is
@@ -104,6 +101,10 @@ export interface RecoverContextGraphSwmDeps {
   readonly replaceMetaForGraphAssets?: (
     assets: readonly GraphScopedSwmRecoveryDescriptor[],
   ) => Promise<void>;
+  /** True when this exact graph asset was already committed by an earlier round. */
+  readonly isGraphAssetMaterialized?: (
+    asset: GraphScopedSwmRecoveryDescriptor,
+  ) => Promise<boolean>;
   readonly ensureContextGraph: (contextGraphId: string) => Promise<void>;
   readonly setCheckpoint: (key: string, offset: number) => void;
   readonly deleteCheckpoint: (key: string) => void;
@@ -299,6 +300,64 @@ export async function recoverContextGraphSwm(
     (descriptor) => descriptor.publicSnapshotGraph !== undefined,
   );
   let snapshotProgress = { readySnapshots: 0, totalSnapshots: 0 };
+  const incrementallyReadyGraphs = new Set<string>();
+  let incrementallyReplacedGraphs = 0;
+  let incrementallyInsertedDataQuads = 0;
+  let incrementallyInsertedMetaQuads = 0;
+
+  const snapshotDescriptorsByRef = new Map<string, GraphScopedSwmRecoveryDescriptor[]>();
+  for (const descriptor of graphScopedDescriptors) {
+    if (!descriptor.publicSnapshotRef) continue;
+    const descriptors = snapshotDescriptorsByRef.get(descriptor.publicSnapshotRef) ?? [];
+    descriptors.push(descriptor);
+    snapshotDescriptorsByRef.set(descriptor.publicSnapshotRef, descriptors);
+  }
+  const quadKey = (quad: Quad): string =>
+    `${quad.graph}\u0000${quad.subject}\u0000${quad.predicate}\u0000${quad.object}`;
+  const verifiedMetaKeys = new Set(metadataOnlyProcessed.verifiedMeta.map(quadKey));
+  let contextGraphEnsured = false;
+
+  const materializeReadySnapshot = async (snapshotRef: string): Promise<void> => {
+    for (const descriptor of snapshotDescriptorsByRef.get(snapshotRef) ?? []) {
+      const graphKey = `${descriptor.metaGraph}\u0000${descriptor.assertionGraph}`;
+      if (incrementallyReadyGraphs.has(graphKey)) continue;
+      if (await deps.isGraphAssetMaterialized?.(descriptor)) {
+        incrementallyReadyGraphs.add(graphKey);
+        continue;
+      }
+
+      const verifiedAssetMeta = descriptor.metadataQuads.filter((quad) => verifiedMetaKeys.has(quadKey(quad)));
+      if (verifiedAssetMeta.length !== descriptor.metadataQuads.length) {
+        throw new Error(`Verified SWM metadata is incomplete for ${descriptor.kaUal}`);
+      }
+      const asset = await materializeGraphScopedSwmRecoveryAsset({
+        descriptor,
+        fetchedDataQuads: [],
+        publicSnapshotStore: deps.publicSnapshotStore,
+      });
+      if (!contextGraphEnsured) {
+        await deps.ensureContextGraph(deps.contextGraphId);
+        contextGraphEnsured = true;
+      }
+      // The graph replacement completes before its metadata marker is written.
+      // A crash between the two therefore retries idempotently; it can never
+      // advertise a head whose graph was only partially transferred.
+      await deps.store.replaceGraph(asset.assertionGraph, [...asset.quads]);
+      await deps.replaceMetaForGraphAssets?.([descriptor]);
+      if (verifiedAssetMeta.length > 0) {
+        await deps.store.insert([...verifiedAssetMeta]);
+      }
+      incrementallyReadyGraphs.add(graphKey);
+      incrementallyReplacedGraphs += 1;
+      incrementallyInsertedDataQuads += asset.quads.length;
+      incrementallyInsertedMetaQuads += verifiedAssetMeta.length;
+      deps.logInfo?.(
+        deps.ctx,
+        `SWM recovery for "${deps.contextGraphId}": committed verified snapshot ${snapshotRef} ` +
+        `as ${descriptor.assertionGraph} (${asset.quads.length} triples)`,
+      );
+    }
+  };
 
   // Fetch store-backed snapshots before any aggregate data scan. Each completed
   // snapshot is persisted independently, so a deadline can make monotonic
@@ -318,6 +377,7 @@ export async function recoverContextGraphSwm(
       fetchSyncPages: deps.fetchSyncPages,
       deleteCheckpoint: deps.deleteCheckpoint,
       setCheckpoint: deps.setCheckpoint,
+      onSnapshotReady: (snapshot) => materializeReadySnapshot(snapshot.ref),
     });
     snapshotProgress = {
       readySnapshots: snapshotSync.readySnapshots,
@@ -331,9 +391,9 @@ export async function recoverContextGraphSwm(
       );
       return {
         replacedRoots: 0,
-        replacedGraphs: 0,
-        insertedDataQuads: 0,
-        insertedMetaQuads: 0,
+        replacedGraphs: incrementallyReplacedGraphs,
+        insertedDataQuads: incrementallyInsertedDataQuads,
+        insertedMetaQuads: incrementallyInsertedMetaQuads,
         droppedDataTriples: 0,
         ...snapshotProgress,
         completed: false,
@@ -360,9 +420,9 @@ export async function recoverContextGraphSwm(
     );
     return {
       replacedRoots: 0,
-      replacedGraphs: 0,
-      insertedDataQuads: 0,
-      insertedMetaQuads: 0,
+      replacedGraphs: incrementallyReplacedGraphs,
+      insertedDataQuads: incrementallyInsertedDataQuads,
+      insertedMetaQuads: incrementallyInsertedMetaQuads,
       droppedDataTriples: 0,
       ...snapshotProgress,
       completed: false,
@@ -400,6 +460,12 @@ export async function recoverContextGraphSwm(
   let replacedGraphs = 0;
   let insertedGraphQuads = 0;
   for (const descriptor of graphScopedDescriptors) {
+    const graphKey = `${descriptor.metaGraph}\u0000${descriptor.assertionGraph}`;
+    if (incrementallyReadyGraphs.has(graphKey)) {
+      replacedGraphs += 1;
+      insertedGraphQuads += descriptor.publicQuadsCount;
+      continue;
+    }
     const asset = await materializeGraphScopedSwmRecoveryAsset({
       descriptor,
       fetchedDataQuads: data.quads,

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -145,6 +145,8 @@ interface RowListCache {
   refresh?: boolean;
   refreshGeneration?: string;
   expiredMessage?: string;
+  /** Byte-budget pages may serialize only a prefix of a short row slice. */
+  releaseOnShortPage?: boolean;
 }
 
 export function createResponderGraphListMemo(
@@ -415,10 +417,39 @@ export function compareRows(a: SyncRow, b: SyncRow): number {
   );
 }
 
+function serializeResponderRow(row: SyncRow): string {
+  return `${formatTerm(row.s)} <${assertSafeIri(row.p)}> ${formatTerm(row.o)} <${assertSafeIri(row.g)}> .`;
+}
+
 export function serializeResponderRows(rows: readonly SyncRow[]): string {
-  return rows.map((row) =>
-    `${formatTerm(row.s)} <${assertSafeIri(row.p)}> ${formatTerm(row.o)} <${assertSafeIri(row.g)}> .`,
-  ).join('\n');
+  return rows.map(serializeResponderRow).join('\n');
+}
+
+/**
+ * Serialize the largest prefix that fits the negotiated response target.
+ * Pagination advances by the number of N-Quads actually parsed by the
+ * requester, so returning a prefix is cursor-safe. Always emit one row when a
+ * non-empty input contains an unexpectedly oversized row; that guarantees
+ * forward progress and leaves the transport's existing hard frame limit as the
+ * final safety boundary for that pathological single row.
+ */
+export function serializeResponderRowsWithinByteBudget(
+  rows: readonly SyncRow[],
+  maxBytes: number,
+): string {
+  const safeMaxBytes = Math.max(1, Math.floor(maxBytes));
+  const encoder = new TextEncoder();
+  const page: string[] = [];
+  let bytes = 0;
+  for (const row of rows) {
+    const serialized = serializeResponderRow(row);
+    const rowBytes = encoder.encode(serialized).byteLength + (page.length > 0 ? 1 : 0);
+    if (page.length > 0 && bytes + rowBytes > safeMaxBytes) break;
+    page.push(serialized);
+    bytes += rowBytes;
+    if (bytes >= safeMaxBytes) break;
+  }
+  return page.join('\n');
 }
 
 export async function readSwmMetaPage(params: {
@@ -1071,6 +1102,8 @@ export async function readDurableDataPage(params: {
   refreshRowList?: boolean;
   refreshGeneration?: string;
   exactGraphPlanMemo?: ExactGraphPagePlanMemo;
+  /** Keep the immutable row snapshot until an explicit empty-page EOF. */
+  releaseCacheOnShortPage?: boolean;
 }): Promise<SyncRow[]> {
   const cache = params.rowListMemo
     ? {
@@ -1082,6 +1115,7 @@ export async function readDurableDataPage(params: {
       ),
       refresh: params.refreshRowList,
       refreshGeneration: params.refreshGeneration,
+      releaseOnShortPage: params.releaseCacheOnShortPage,
     }
     : undefined;
 
@@ -1693,7 +1727,7 @@ async function readCachedRowsPage(
   // page allocates only that page's backing array, never a shallow copy of the
   // complete snapshot first.
   const page = rows.slice(safeOffset, safeOffset + safeLimit);
-  if (page.length < safeLimit) {
+  if (page.length === 0 || (cache.releaseOnShortPage !== false && page.length < safeLimit)) {
     cache.memo.release(cache.key, { graceMs: COMPLETED_SYNC_RESPONDER_SESSION_GRACE_MS });
   }
   return page;

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -7,6 +7,11 @@ import {
 } from '@origintrail-official/dkg-core';
 import type { TripleStore } from '@origintrail-official/dkg-storage';
 import {
+  SYNC_BYTE_BUDGET_MAX_ROWS,
+  SYNC_BYTE_BUDGET_PAGE_MODE,
+  SYNC_BYTE_BUDGET_RESPONSE_BYTES,
+} from '../../dkg-agent-constants.js';
+import {
   serializeWorkspacePublicSnapshotQuads,
   type WorkspacePublicSnapshotStore,
 } from '@origintrail-official/dkg-publisher';
@@ -25,6 +30,7 @@ import {
   readSwmDataPage,
   readSwmMetaPage,
   serializeResponderRows,
+  serializeResponderRowsWithinByteBudget,
   SyncRowSnapshotLimitError,
 } from './graph-plan.js';
 import {
@@ -523,6 +529,15 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
     const phase = request.phase ?? 'data';
     const isWorkspace = request.includeSharedMemory;
     const contextGraphId = request.contextGraphId;
+    const hintedPageRows = typeof request.pageRowsHint === 'number' &&
+      Number.isSafeInteger(request.pageRowsHint)
+      ? Math.max(1, Math.min(request.pageRowsHint, SYNC_BYTE_BUDGET_MAX_ROWS))
+      : 0;
+    const usesByteBudgetPage = !isWorkspace &&
+      phase === 'data' &&
+      request.pageMode === SYNC_BYTE_BUDGET_PAGE_MODE &&
+      hintedPageRows > limit;
+    const durableDataLimit = usesByteBudgetPage ? hintedPageRows : limit;
     if (!contextGraphId || typeof contextGraphId !== 'string') {
       // Count this early return too — it short-circuits before limiter.run, so
       // without this it would never reach the syncResponseTotal{ok}/{error}
@@ -763,17 +778,23 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
           contextGraphId,
           sinceBatchId,
           offset,
-          limit,
+          limit: durableDataLimit,
           signal,
           rowListMemo: session ? durableDataRowsMemo : undefined,
           rowListCacheScope: session ? peerId : undefined,
           refreshRowList: session?.refreshRowList,
           refreshGeneration: session?.refreshGeneration,
           exactGraphPlanMemo: durableDataExactGraphPlanMemo,
+          // A byte-bounded response may contain only a prefix of the row slice
+          // loaded above. Do not release the immutable session snapshot merely
+          // because that slice was short; the explicit empty request is EOF.
+          releaseCacheOnShortPage: !usesByteBudgetPage,
         });
         const queryDurationMs = Date.now() - queryStartedAt;
         const serializeStartedAt = Date.now();
-        const serialized = serializeResponderRows(rows);
+        const serialized = usesByteBudgetPage
+          ? serializeResponderRowsWithinByteBudget(rows, SYNC_BYTE_BUDGET_RESPONSE_BYTES)
+          : serializeResponderRows(rows);
         if (serialized) nquads.push(serialized);
         const serializeDurationMs = Date.now() - serializeStartedAt;
         logFirstPageDetail(() => `Sync responder durable data for "${contextGraphId}": auth=${authDurationMs}ms query=${queryDurationMs}ms serialize=${serializeDurationMs}ms`);

--- a/packages/agent/test/rootless-durable-bounded-progress.test.ts
+++ b/packages/agent/test/rootless-durable-bounded-progress.test.ts
@@ -123,6 +123,7 @@ describe('bounded rootless durable progress', () => {
 
     expect(plan).not.toBeNull();
     expect(plan?.safeNextOffset).toBe(8);
+    expect(plan?.manifestRowCount).toBe(12);
     expect(plan?.completedGraphCount).toBe(2);
     expect(plan?.changedDataGraphs).toEqual([
       fixtures[0]!.graph,
@@ -213,6 +214,58 @@ describe('bounded rootless durable progress', () => {
     expect(materialized.flatMap((entry) => entry.dataQuads)
       .some((quad) => quad.graph === fixtures[2]!.graph)).toBe(false);
     expect(inserted.flat().some((quad) => fixtures.some((entry) => entry.graph === quad.graph))).toBe(false);
+  });
+
+  it('checkpoints a cleanly-closed rootless prefix instead of replaying it from zero', async () => {
+    const fixtures = orderedAssets();
+    const meta = fixtures.flatMap((entry) => entry.meta);
+    const cleanPrefix = fixtures[0]!.payload;
+    const materialized: Array<{ dataQuads: Quad[] }> = [];
+    const checkpoints: Array<[string, number]> = [];
+    const deleted: string[] = [];
+
+    const summary = await runDurableSync({
+      ctx,
+      remotePeerId: 'peer-a',
+      contextGraphIds: [CONTEXT_GRAPH_ID],
+      createContextGraphSyncDeadline: () => Date.now() + 60_000,
+      fetchSyncPages: async (
+        _ctx,
+        _peer,
+        _contextGraphId,
+        _includeSharedMemory,
+        phase,
+      ) => phase === 'meta'
+        ? pageResult('meta', {
+          quads: meta,
+          nextOffset: meta.length,
+        })
+        : pageResult('data', {
+          quads: cleanPrefix,
+          nextOffset: cleanPrefix.length,
+          completed: true,
+          timedOut: false,
+        }),
+      processDurableBatchInWorker: processBatch,
+      storeInsert: async () => {},
+      storeGraphScopedAsset: async (entry) => {
+        materialized.push(entry);
+        return 'applied';
+      },
+      deleteCheckpoint: (key) => { deleted.push(key); },
+      setCheckpoint: (key, offset) => { checkpoints.push([key, offset]); },
+      logInfo: () => {},
+      logWarn: () => {},
+      logDebug: () => {},
+    });
+
+    expect(summary.rejectedKcs).toBe(0);
+    expect(summary.timedOutPhases).toBe(0);
+    expect(summary.insertedDataTriples).toBe(cleanPrefix.length);
+    expect(summary.completedPhases).toBe(1);
+    expect(checkpoints).toContainEqual([`${CONTEXT_GRAPH_ID}:data`, cleanPrefix.length]);
+    expect(deleted).not.toContain(`${CONTEXT_GRAPH_ID}:data`);
+    expect(materialized.flatMap((entry) => entry.dataQuads)).toEqual(cleanPrefix);
   });
 
   it('verifies the remaining suffix and cleanly completes a resumed snapshot', async () => {

--- a/packages/agent/test/swm-publish-profile-mutex.test.ts
+++ b/packages/agent/test/swm-publish-profile-mutex.test.ts
@@ -111,6 +111,33 @@ describe('DKGAgent.publishProfile — tail-chain mutex serialization (PR #700 ro
     expect(results.map((r) => (r as { callId: number }).callId)).toEqual([0, 1, 2, 3, 4]);
   });
 
+  it('coalesces concurrent first-profile readiness checks into one publish', async () => {
+    const boot = await bootAgent();
+    agent = boot.agent;
+    let publishes = 0;
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    (agent as unknown as { publishProfile: () => Promise<unknown> }).publishProfile = async () => {
+      publishes++;
+      await gate;
+      return { ok: true };
+    };
+
+    const readiness = [
+      agent.ensureProfilePublished(),
+      agent.ensureProfilePublished(),
+      agent.ensureProfilePublished(),
+    ];
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    expect(publishes).toBe(1);
+
+    release();
+    await expect(Promise.all(readiness)).resolves.toHaveLength(3);
+    expect(publishes).toBe(1);
+  });
+
   it('error isolation: a failing publishProfileImpl does not poison the tail for subsequent callers', async () => {
     // Pinned by the explicit `.catch(swallow)` in the mutex body.
     // Without that, a single rejected publish would wedge every

--- a/packages/agent/test/swm-recovery.test.ts
+++ b/packages/agent/test/swm-recovery.test.ts
@@ -16,6 +16,7 @@ import {
 } from '@origintrail-official/dkg-publisher';
 import type { Quad } from '@origintrail-official/dkg-storage';
 import type { SyncPageResult } from '../src/sync/requester/page-fetch.js';
+import { syncPublicSnapshotsForMeta } from '../src/sync/requester/shared-memory-sync.js';
 import {
   recoverContextGraphSwm,
   recoverContextGraphSwmWithProgressRetries,
@@ -125,6 +126,46 @@ describe('recoverContextGraphSwmWithProgressRetries', () => {
 
     expect(result).toMatchObject({ completed: false, readySnapshots: 3, totalSnapshots: 100 });
     expect(calls).toBe(3);
+  });
+});
+
+describe('syncPublicSnapshotsForMeta', () => {
+  it('retries a cleanly-closed short snapshot response without caching its prefix', async () => {
+    const expected: Quad[] = [
+      { subject: 'urn:snapshot:a', predicate: STATUS, object: '"one"', graph: '' },
+      { subject: 'urn:snapshot:b', predicate: STATUS, object: '"two"', graph: '' },
+    ];
+    const digest = workspacePublicQuadsDigest(expected);
+    const snapshotSubject = 'urn:dkg:share:short-snapshot';
+    const snapshotStore = new MemorySnapshotStore();
+    let deletedCheckpoints = 0;
+
+    const result = await syncPublicSnapshotsForMeta({
+      ctx,
+      remotePeerId: 'peer-source',
+      contextGraphId: CG,
+      deadline: Number.MAX_SAFE_INTEGER,
+      metaQuads: [
+        { subject: snapshotSubject, predicate: `${DKG}publicQuadsDigest`, object: `"${digest}"`, graph: WS_META },
+        { subject: snapshotSubject, predicate: `${DKG}publicQuadsCount`, object: `"${expected.length}"^^<${XSD_INTEGER}>`, graph: WS_META },
+      ],
+      publicSnapshotStore: snapshotStore,
+      fetchSyncPages: async () => ({
+        ...page([expected[0]!]),
+        checkpointKey: `snapshot:${digest}`,
+      }),
+      deleteCheckpoint: () => { deletedCheckpoints += 1; },
+      setCheckpoint: () => {},
+    });
+
+    expect(result).toMatchObject({
+      completed: false,
+      readySnapshots: 0,
+      totalSnapshots: 1,
+      completedPhases: 0,
+    });
+    expect(deletedCheckpoints).toBeGreaterThan(0);
+    await expect(snapshotStore.getSnapshot(digest)).resolves.toBeNull();
   });
 });
 const UAL = 'did:dkg:hardhat:31337/0x00000000000000000000000000000000000000ab/7';

--- a/packages/agent/test/swm-recovery.test.ts
+++ b/packages/agent/test/swm-recovery.test.ts
@@ -16,7 +16,11 @@ import {
 } from '@origintrail-official/dkg-publisher';
 import type { Quad } from '@origintrail-official/dkg-storage';
 import type { SyncPageResult } from '../src/sync/requester/page-fetch.js';
-import { recoverContextGraphSwm } from '../src/sync/requester/swm-recovery.js';
+import {
+  recoverContextGraphSwm,
+  recoverContextGraphSwmWithProgressRetries,
+  type RecoverContextGraphSwmResult,
+} from '../src/sync/requester/swm-recovery.js';
 
 /**
  * integration. `recoverContextGraphSwm` fetches a CG's
@@ -33,6 +37,74 @@ const STATUS = 'http://schema.org/status';
 const ctx: OperationContext = { operationId: 'test', operationName: 'sync' } as never;
 const DKG = 'http://dkg.io/ontology/';
 const XSD_INTEGER = 'http://www.w3.org/2001/XMLSchema#integer';
+
+function recoveryResult(
+  readySnapshots: number,
+  totalSnapshots: number,
+  completed = false,
+): RecoverContextGraphSwmResult {
+  return {
+    replacedRoots: 0,
+    replacedGraphs: completed ? totalSnapshots : 0,
+    insertedDataQuads: completed ? totalSnapshots : 0,
+    insertedMetaQuads: completed ? totalSnapshots : 0,
+    droppedDataTriples: 0,
+    readySnapshots,
+    totalSnapshots,
+    completed,
+  };
+}
+
+describe('recoverContextGraphSwmWithProgressRetries', () => {
+  it('consumes monotonic immutable-snapshot progress inside one bounded catch-up job', async () => {
+    const outcomes = [
+      recoveryResult(5, 20),
+      recoveryResult(10, 20),
+      recoveryResult(15, 20),
+      recoveryResult(20, 20, true),
+    ];
+    const retries: string[] = [];
+    let calls = 0;
+
+    const result = await recoverContextGraphSwmWithProgressRetries({
+      recover: async () => outcomes[calls++]!,
+      onRetry: ({ completedRound, readySnapshots, totalSnapshots }) => {
+        retries.push(`${completedRound}:${readySnapshots}/${totalSnapshots}`);
+      },
+    });
+
+    expect(result).toMatchObject({ completed: true, readySnapshots: 20, totalSnapshots: 20 });
+    expect(calls).toBe(4);
+    expect(retries).toEqual(['1:5/20', '2:10/20', '3:15/20']);
+  });
+
+  it('stops after one transient retry when snapshot progress is flat', async () => {
+    let calls = 0;
+    const result = await recoverContextGraphSwmWithProgressRetries({
+      recover: async () => {
+        calls += 1;
+        return recoveryResult(0, 20);
+      },
+    });
+
+    expect(result.completed).toBe(false);
+    expect(calls).toBe(2);
+  });
+
+  it('honours the hard recovery-round cap while progress continues', async () => {
+    let calls = 0;
+    const result = await recoverContextGraphSwmWithProgressRetries({
+      maxRounds: 3,
+      recover: async () => {
+        calls += 1;
+        return recoveryResult(calls, 100);
+      },
+    });
+
+    expect(result).toMatchObject({ completed: false, readySnapshots: 3, totalSnapshots: 100 });
+    expect(calls).toBe(3);
+  });
+});
 const UAL = 'did:dkg:hardhat:31337/0x00000000000000000000000000000000000000ab/7';
 const UAL_2 = 'did:dkg:hardhat:31337/0x00000000000000000000000000000000000000ab/8';
 

--- a/packages/agent/test/swm-recovery.test.ts
+++ b/packages/agent/test/swm-recovery.test.ts
@@ -485,9 +485,17 @@ describe('recoverContextGraphSwm (fetch → verify → replace)', () => {
 
     const partial = await recover();
     expect(partial.completed).toBe(false);
-    expect(partial.replacedGraphs).toBe(0);
+    expect(partial.replacedGraphs).toBe(1);
     await expect(snapshotStore.getSnapshot(assets[0]!.digest)).resolves.toEqual(assets[0]!.payload);
     await expect(snapshotStore.getSnapshot(assets[1]!.digest)).resolves.toBeNull();
+    const firstVisible = await store.query(
+      `SELECT ?s ?p ?o WHERE { GRAPH <${assets[0]!.assertionGraph}> { ?s ?p ?o } }`,
+    );
+    const secondStillHidden = await store.query(
+      `SELECT ?s ?p ?o WHERE { GRAPH <${assets[1]!.assertionGraph}> { ?s ?p ?o } }`,
+    );
+    expect(firstVisible.type === 'bindings' ? firstVisible.bindings : []).toHaveLength(1);
+    expect(secondStillHidden.type === 'bindings' ? secondStillHidden.bindings : []).toHaveLength(0);
 
     round = 2;
     const completed = await recover();

--- a/packages/agent/test/swm-recovery.test.ts
+++ b/packages/agent/test/swm-recovery.test.ts
@@ -88,7 +88,29 @@ describe('recoverContextGraphSwmWithProgressRetries', () => {
     });
 
     expect(result.completed).toBe(false);
-    expect(calls).toBe(2);
+    expect(calls).toBe(3);
+  });
+
+  it('continues after one flat transport window when snapshot progress resumes', async () => {
+    const outcomes = [
+      recoveryResult(5, 20),
+      recoveryResult(5, 20),
+      recoveryResult(10, 20),
+      recoveryResult(20, 20, true),
+    ];
+    const retries: string[] = [];
+    let calls = 0;
+
+    const result = await recoverContextGraphSwmWithProgressRetries({
+      recover: async () => outcomes[calls++]!,
+      onRetry: ({ completedRound, readySnapshots, totalSnapshots }) => {
+        retries.push(`${completedRound}:${readySnapshots}/${totalSnapshots}`);
+      },
+    });
+
+    expect(result).toMatchObject({ completed: true, readySnapshots: 20, totalSnapshots: 20 });
+    expect(calls).toBe(4);
+    expect(retries).toEqual(['1:5/20', '2:5/20', '3:10/20']);
   });
 
   it('honours the hard recovery-round cap while progress continues', async () => {

--- a/packages/agent/test/swm-recovery.test.ts
+++ b/packages/agent/test/swm-recovery.test.ts
@@ -114,6 +114,32 @@ describe('recoverContextGraphSwmWithProgressRetries', () => {
     expect(retries).toEqual(['1:5/20', '2:5/20', '3:10/20']);
   });
 
+  it('extends the default cap while declared snapshots keep making progress', async () => {
+    let calls = 0;
+    const result = await recoverContextGraphSwmWithProgressRetries({
+      recover: async () => {
+        calls += 1;
+        return recoveryResult(calls, 20, calls === 20);
+      },
+    });
+
+    expect(result).toMatchObject({ completed: true, readySnapshots: 20, totalSnapshots: 20 });
+    expect(calls).toBe(20);
+  });
+
+  it('keeps snapshot-aware progress retries under an absolute ceiling', async () => {
+    let calls = 0;
+    const result = await recoverContextGraphSwmWithProgressRetries({
+      recover: async () => {
+        calls += 1;
+        return recoveryResult(calls, 100);
+      },
+    });
+
+    expect(result).toMatchObject({ completed: false, readySnapshots: 24, totalSnapshots: 100 });
+    expect(calls).toBe(24);
+  });
+
   it('honours the hard recovery-round cap while progress continues', async () => {
     let calls = 0;
     const result = await recoverContextGraphSwmWithProgressRetries({

--- a/packages/agent/test/swm-snapshot-sync.test.ts
+++ b/packages/agent/test/swm-snapshot-sync.test.ts
@@ -111,15 +111,24 @@ describe('SWM snapshot catch-up sync', () => {
     installSharedMemorySyncMock(nodeB, nodeA, sourceSnapshots, { omitSnapshots: true });
 
     const detailed = await (nodeB as unknown as {
-      syncSharedMemoryFromPeerDetailed(peerId: string, contextGraphIds: string[]): Promise<{ failedPeers: number; failedPhases: number; insertedTriples: number }>;
+      syncSharedMemoryFromPeerDetailed(peerId: string, contextGraphIds: string[]): Promise<{
+        failedPeers: number;
+        failedPhases: number;
+        completedPhases: number;
+        insertedDataTriples: number;
+        insertedMetaTriples: number;
+        insertedTriples: number;
+      }>;
     }).syncSharedMemoryFromPeerDetailed(REMOTE_PEER, [CONTEXT_GRAPH]);
-    // The peer is reachable and responds; only its snapshot phase fails the
-    // digest/count check. That is a phase failure (failedPhases), not a peer
-    // reachability failure (failedPeers) — but it still suppresses the
-    // success-stamp/backoff via the lifecycle success-gate.
+    // The peer is reachable and its verified data phase can be retained, but
+    // the immutable snapshot is incomplete. Keep the snapshot phase failed so
+    // lifecycle readiness retries, while never making its metadata visible.
     expect(detailed.failedPeers).toBe(0);
     expect(detailed.failedPhases).toBe(1);
-    expect(detailed.insertedTriples).toBe(0);
+    expect(detailed.completedPhases).toBe(1);
+    expect(detailed.insertedDataTriples).toBe(1);
+    expect(detailed.insertedMetaTriples).toBe(0);
+    expect(detailed.insertedTriples).toBe(1);
 
     const metaGraph = contextGraphWorkspaceMetaGraphUri(CONTEXT_GRAPH);
     // RFC ka-metadata-trim Phase 2: the snapshot pointer is the digest row

--- a/packages/agent/test/sync-byte-budget-pages.test.ts
+++ b/packages/agent/test/sync-byte-budget-pages.test.ts
@@ -103,6 +103,53 @@ describe('byte-budget sync pagination', () => {
     expect(result.completed).toBe(true);
   });
 
+  it('keeps a successful fallback size sticky and probes upward gradually', async () => {
+    const requestedSizes: number[] = [];
+    let sends = 0;
+    const result = await fetchSyncPages({
+      ctx: makeCtx(),
+      remotePeerId: REMOTE_PEER_ID,
+      contextGraphId: CG_ID,
+      includeSharedMemory: true,
+      phase: 'snapshot',
+      graphUri: '',
+      snapshotRef: 'snapshot-ref',
+      deadline: Date.now() + 15_000,
+      syncPageTimeoutMs: 5_000,
+      syncRouterAttempts: 1,
+      syncPageRetryAttempts: 2,
+      syncPageSize: SYNC_REQUEST_PAGE_SIZE,
+      syncDeniedResponse: '#DENIED',
+      debugSyncProgress: false,
+      protocolSync: '/dkg/test/sync',
+      checkpointStore: new MemorySyncCheckpointStore(),
+      buildSyncRequest: async (_cg, _offset, limit) => {
+        requestedSizes.push(limit);
+        return new TextEncoder().encode('request');
+      },
+      parseAndFilter: async () => ({ quads: [], totalQuads: 100 }),
+      send: async () => {
+        sends += 1;
+        if (sends === 1) throw new Error('relay stream reset');
+        return sends <= 4
+          ? new TextEncoder().encode('<urn:s> <urn:p> <urn:o> <urn:g> .')
+          : new Uint8Array();
+      },
+      logWarn: noopLog,
+      logInfo: noopLog,
+      logDebug: noopLog,
+    });
+
+    expect(requestedSizes).toEqual([
+      SYNC_REQUEST_PAGE_SIZE,
+      SYNC_REQUEST_PAGE_SIZE / 2,
+      SYNC_REQUEST_PAGE_SIZE / 2,
+      SYNC_REQUEST_PAGE_SIZE / 2,
+      SYNC_REQUEST_PAGE_SIZE,
+    ]);
+    expect(result.completed).toBe(true);
+  });
+
   it('serializes a UTF-8-correct prefix inside the response target', () => {
     const rows: SyncRow[] = Array.from({ length: 20 }, (_, i) => ({
       s: `urn:subject:${i}`,

--- a/packages/agent/test/sync-byte-budget-pages.test.ts
+++ b/packages/agent/test/sync-byte-budget-pages.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest';
+import { ethers } from 'ethers';
+import type { OperationContext } from '@origintrail-official/dkg-core';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import {
+  SYNC_BYTE_BUDGET_PAGE_MODE,
+  SYNC_PAGE_SIZE,
+  SYNC_REQUEST_PAGE_SIZE,
+  SYNC_REQUEST_SAFE_PAGE_SIZE,
+} from '../src/dkg-agent-constants.js';
+import { buildSyncRequestEnvelope } from '../src/sync/auth/request-build.js';
+import { MemorySyncCheckpointStore } from '../src/sync/checkpoint/state.js';
+import { fetchSyncPages } from '../src/sync/requester/page-fetch.js';
+import {
+  serializeResponderRowsWithinByteBudget,
+  type SyncRow,
+} from '../src/sync/responder/graph-plan.js';
+import {
+  linesFromNquads,
+  registerTestSyncHandler,
+} from './_helpers/sync-responder.js';
+
+const CG_ID = 'byte-budget-cg';
+const REMOTE_PEER_ID = '12D3KooWByteBudgetRemote';
+const LOCAL_PEER_ID = '12D3KooWByteBudgetLocal';
+
+function makeCtx(): OperationContext {
+  return { kind: 'system', id: 'byte-budget-test', startedAt: Date.now() } as never;
+}
+
+function noopLog(): void {}
+
+describe('byte-budget sync pagination', () => {
+  it('keeps the authenticated legacy limit signed while adding the larger hint', async () => {
+    const wallet = ethers.Wallet.createRandom();
+    const signedLimits: number[] = [];
+    const encoded = await buildSyncRequestEnvelope({
+      contextGraphId: CG_ID,
+      offset: 0,
+      limit: SYNC_REQUEST_PAGE_SIZE,
+      includeSharedMemory: false,
+      targetPeerId: REMOTE_PEER_ID,
+      requesterPeerId: LOCAL_PEER_ID,
+      phase: 'data',
+      needsAuth: true,
+      computeSyncDigest: (_cg, _offset, limit) => {
+        signedLimits.push(limit);
+        return new Uint8Array(32);
+      },
+      getIdentityId: async () => 0n,
+      claimedAgentAddress: wallet.address,
+      claimedAgentPrivateKey: wallet.privateKey,
+    });
+
+    const request = JSON.parse(new TextDecoder().decode(encoded));
+    expect(signedLimits).toEqual([SYNC_PAGE_SIZE]);
+    expect(request.limit).toBe(SYNC_PAGE_SIZE);
+    expect(request.pageMode).toBe(SYNC_BYTE_BUDGET_PAGE_MODE);
+    expect(request.pageRowsHint).toBe(SYNC_REQUEST_PAGE_SIZE);
+    expect(request.requesterSignatureR).toMatch(/^0x/);
+  });
+
+  it('continues after an old responder returns a short legacy page', async () => {
+    const requested: Array<{ offset: number; limit: number }> = [];
+    let sends = 0;
+    const result = await fetchSyncPages({
+      ctx: makeCtx(),
+      remotePeerId: REMOTE_PEER_ID,
+      contextGraphId: CG_ID,
+      includeSharedMemory: false,
+      phase: 'data',
+      graphUri: `did:dkg:context-graph:${CG_ID}`,
+      deadline: Date.now() + 10_000,
+      syncPageTimeoutMs: 2_000,
+      syncRouterAttempts: 1,
+      syncPageRetryAttempts: 1,
+      syncPageSize: SYNC_REQUEST_PAGE_SIZE,
+      syncDeniedResponse: '#DENIED',
+      debugSyncProgress: false,
+      protocolSync: '/dkg/test/sync',
+      checkpointStore: new MemorySyncCheckpointStore(),
+      buildSyncRequest: async (_cg, offset, limit) => {
+        requested.push({ offset, limit });
+        return new TextEncoder().encode('request');
+      },
+      parseAndFilter: async () => ({ quads: [], totalQuads: SYNC_PAGE_SIZE }),
+      send: async () => {
+        sends += 1;
+        return sends === 1
+          ? new TextEncoder().encode('<urn:s> <urn:p> <urn:o> <urn:g> .')
+          : new Uint8Array();
+      },
+      logWarn: noopLog,
+      logInfo: noopLog,
+      logDebug: noopLog,
+    });
+
+    expect(requested).toEqual([
+      { offset: 0, limit: SYNC_REQUEST_PAGE_SIZE },
+      { offset: SYNC_PAGE_SIZE, limit: SYNC_REQUEST_PAGE_SIZE },
+    ]);
+    expect(result.nextOffset).toBe(SYNC_PAGE_SIZE);
+    expect(result.completed).toBe(true);
+  });
+
+  it('serializes a UTF-8-correct prefix inside the response target', () => {
+    const rows: SyncRow[] = Array.from({ length: 20 }, (_, i) => ({
+      s: `urn:subject:${i}`,
+      p: 'urn:predicate',
+      o: `"${'🚀'.repeat(40)}-${i}"`,
+      g: 'urn:graph',
+    }));
+    const budget = 600;
+    const serialized = serializeResponderRowsWithinByteBudget(rows, budget);
+    const bytes = new TextEncoder().encode(serialized).byteLength;
+    expect(linesFromNquads(serialized).length).toBeGreaterThan(0);
+    expect(linesFromNquads(serialized).length).toBeLessThan(rows.length);
+    expect(bytes).toBeLessThanOrEqual(budget);
+  });
+
+  it('lets an upgraded responder exceed 500 rows while legacy requests remain capped', async () => {
+    const store = new OxigraphStore();
+    const graph = `did:dkg:context-graph:${CG_ID}/context/1`;
+    await store.insert(Array.from({ length: 1_200 }, (_, i) => ({
+      graph,
+      subject: `urn:subject:${i.toString().padStart(4, '0')}`,
+      predicate: 'urn:predicate',
+      object: `"value-${i}"`,
+    })));
+    const cap = registerTestSyncHandler(store, { syncPageSize: SYNC_PAGE_SIZE });
+
+    const legacy = await cap.invoke({
+      contextGraphId: CG_ID,
+      offset: 0,
+      limit: SYNC_PAGE_SIZE,
+      includeSharedMemory: false,
+      phase: 'data',
+      syncSessionId: 'legacy-session',
+    });
+    expect(linesFromNquads(legacy)).toHaveLength(SYNC_PAGE_SIZE);
+
+    const upgraded = await cap.invoke({
+      contextGraphId: CG_ID,
+      offset: 0,
+      limit: SYNC_PAGE_SIZE,
+      includeSharedMemory: false,
+      phase: 'data',
+      syncSessionId: 'byte-budget-session',
+      pageMode: SYNC_BYTE_BUDGET_PAGE_MODE,
+      pageRowsHint: SYNC_REQUEST_PAGE_SIZE,
+    });
+    expect(linesFromNquads(upgraded)).toHaveLength(1_200);
+
+    await store.close();
+  });
+
+  it('retains the 64-row transport fallback floor', () => {
+    expect(SYNC_REQUEST_SAFE_PAGE_SIZE).toBe(64);
+  });
+});

--- a/packages/agent/test/sync-on-connect-churn.test.ts
+++ b/packages/agent/test/sync-on-connect-churn.test.ts
@@ -237,6 +237,8 @@ describe('sync-on-connect churn gates', () => {
       insertedDataQuads: 0,
       insertedMetaQuads: 0,
       droppedDataTriples: 0,
+      readySnapshots: 0,
+      totalSnapshots: 0,
       completed: true,
     });
   });

--- a/packages/agent/test/sync-page-frame-budget.test.ts
+++ b/packages/agent/test/sync-page-frame-budget.test.ts
@@ -4,6 +4,8 @@ import {
   JAVA_WRITE_UTF_MAX_BYTES,
 } from '@origintrail-official/dkg-core';
 import {
+  SYNC_BYTE_BUDGET_MAX_ROWS,
+  SYNC_BYTE_BUDGET_RESPONSE_BYTES,
   SYNC_PAGE_SIZE,
   SYNC_REQUEST_PAGE_SIZE,
   SYNC_REQUEST_SAFE_PAGE_SIZE,
@@ -21,13 +23,14 @@ function encodedPageBytes(rows: number, literalBytes: number): number {
 
 describe('sync requester transport frame budget', () => {
   it('keeps the adaptive retry floor below the protocol read cap', () => {
-    expect(SYNC_REQUEST_PAGE_SIZE).toBe(256);
+    expect(SYNC_REQUEST_PAGE_SIZE).toBe(8_192);
+    expect(SYNC_REQUEST_PAGE_SIZE).toBe(SYNC_BYTE_BUDGET_MAX_ROWS);
     expect(SYNC_REQUEST_SAFE_PAGE_SIZE).toBe(64);
     expect(SYNC_RESPONSE_FRAME_HEADROOM_BYTES).toBe(6 * 1024 * 1024);
+    expect(SYNC_BYTE_BUDGET_RESPONSE_BYTES).toBe(4 * 1024 * 1024);
+    expect(SYNC_BYTE_BUDGET_RESPONSE_BYTES).toBeLessThan(DEFAULT_MAX_READ_BYTES);
     expect(encodedPageBytes(SYNC_REQUEST_SAFE_PAGE_SIZE, JAVA_WRITE_UTF_MAX_BYTES))
       .toBeLessThan(DEFAULT_MAX_READ_BYTES);
-    expect(encodedPageBytes(SYNC_REQUEST_PAGE_SIZE, JAVA_WRITE_UTF_MAX_BYTES))
-      .toBeGreaterThan(DEFAULT_MAX_READ_BYTES);
   });
 
   it('reproduces why the legacy 500-row request cannot carry large literals', () => {

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -61,6 +61,7 @@ export default defineConfig({
       "test/sync-requester-progress.test.ts",
       "test/rootless-durable-bounded-progress.test.ts",
       "test/swm-recovery.test.ts",
+      "test/swm-snapshot-sync.test.ts",
       "test/sync-responder-protection.test.ts",
       "test/sync-on-connect-retry.test.ts",
       "test/sync-on-connect-churn.test.ts",

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -51,6 +51,7 @@ export default defineConfig({
       "test/sync-responder-oversized-fallback.test.ts",
       "test/sync-responder-large-graph-stack-overflow.test.ts",
       "test/sync-page-frame-budget.test.ts",
+      "test/sync-byte-budget-pages.test.ts",
       "test/sync-append-in-place.test.ts",
       "test/sync-memory-metrics.test.ts",
       "test/sync-responder-metrics.test.ts",

--- a/packages/chain/package.json
+++ b/packages/chain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-chain",
-  "version": "10.0.6",
+  "version": "10.0.7",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg",
-  "version": "10.0.6",
+  "version": "10.0.7",
   "type": "module",
   "main": "dist/cli.js",
   "bin": {

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -2201,7 +2201,7 @@ export async function runDaemonInner(
   const publisherChainBase = runtimeEvmChainConfig;
   const startPostApiPublishing = () => {
     const profileTimer = setTimeout(() => {
-      void agent.publishProfile().catch((err: any) => {
+      void agent.ensureProfilePublished().catch((err: any) => {
         log(`Agent profile publish failed: ${err?.message ?? String(err)}`);
       });
     }, 0);

--- a/packages/cli/src/daemon/routes/context-graph.ts
+++ b/packages/cli/src/daemon/routes/context-graph.ts
@@ -1059,6 +1059,20 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
           error: 'Missing curatorPeerId. Invite codes must include the curator peer id (V10 format: "<cgId>\\n<peerId>"). Ask the curator to share an updated invite code.',
         });
       }
+      try {
+        // Auto-approval is deliberately fail-closed when the curator cannot
+        // resolve an active encryption key. A cold joiner must therefore make
+        // its agent profile visible before sending the signed request instead
+        // of relying on the periodic profile heartbeat (which may be minutes
+        // away after a transient startup publish failure).
+        await agent.ensureProfilePublished();
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return jsonResponse(res, 503, {
+          error: 'Agent profile is not ready; join request was not sent.',
+          cause: msg,
+        });
+      }
       const result = await agent.forwardJoinRequest(contextGraphId, delegation, agentName, curatorPeerId);
       if (result.delivered === 0) {
         // Surface per-peer errors so the joiner can see WHY (curator

--- a/packages/cli/test/context-graph-join-request-route.test.ts
+++ b/packages/cli/test/context-graph-join-request-route.test.ts
@@ -2,6 +2,56 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createServer, type Server } from 'node:http';
 import { handleContextGraphRoutes } from '../src/daemon/routes/context-graph.js';
 
+async function startRouteServer(agent: Record<string, unknown>): Promise<Server> {
+  const server = createServer(async (req, res) => {
+    const url = new URL(req.url ?? '/', 'http://127.0.0.1');
+    await handleContextGraphRoutes({
+      req,
+      res,
+      agent,
+      publisherControl: {},
+      publisherRuntime: null,
+      config: {},
+      startedAt: Date.now(),
+      dashDb: {},
+      opWallets: {},
+      network: {},
+      tracker: {},
+      memoryManager: {},
+      bridgeAuthToken: undefined,
+      nodeVersion: 'test',
+      nodeCommit: 'test',
+      catchupTracker: { jobs: new Map(), latestByContextGraph: new Map() },
+      extractionRegistry: {},
+      fileStore: {},
+      extractionStatus: new Map(),
+      assertionImportLocks: new Map(),
+      vectorStore: {},
+      embeddingProvider: null,
+      validTokens: new Set(),
+      apiHost: '127.0.0.1',
+      apiPortRef: { value: 0 },
+      routePlugins: [],
+      url,
+      path: url.pathname,
+      requestToken: undefined,
+      requestAgentAddress: undefined,
+    } as any);
+    if (!res.writableEnded) {
+      res.writeHead(404, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ error: 'not found' }));
+    }
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  return server;
+}
+
+function routeUrl(server: Server, contextGraphId: string): string {
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('route test server did not bind');
+  return `http://127.0.0.1:${address.port}/api/context-graph/${encodeURIComponent(contextGraphId)}/request-join`;
+}
+
 describe('POST /api/context-graph/{id}/request-join', () => {
   let server: Server | undefined;
 
@@ -107,5 +157,85 @@ describe('POST /api/context-graph/{id}/request-join', () => {
       'expired-repair-joiner',
       peerId,
     );
+  });
+
+  it('publishes a cold joiner profile before forwarding the signed request', async () => {
+    const contextGraphId = 'private-cold-join';
+    const curatorPeerId = '12D3KooWColdJoinCurator';
+    const callOrder: string[] = [];
+    const ensureProfilePublished = vi.fn(async () => {
+      callOrder.push('profile');
+    });
+    const forwardJoinRequest = vi.fn(async () => {
+      callOrder.push('join');
+      return { delivered: 1, errors: [], autoApproved: true };
+    });
+    const agent = {
+      peerId: '12D3KooWColdJoiner',
+      isCuratorOf: vi.fn().mockResolvedValue(false),
+      ensureProfilePublished,
+      forwardJoinRequest,
+      resolveAgentByToken: () => undefined,
+    };
+    const delegation = {
+      agentAddress: '0x3333333333333333333333333333333333333333',
+      scope: `join:test:${contextGraphId}`,
+      issuedAtMs: Date.now(),
+      delegateePeerId: agent.peerId,
+      signature: `0x${'22'.repeat(65)}`,
+    };
+
+    server = await startRouteServer(agent);
+    const response = await fetch(routeUrl(server, contextGraphId), {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ delegation, curatorPeerId, agentName: 'cold-joiner' }),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      status: 'approved',
+      autoApproved: true,
+    });
+    expect(callOrder).toEqual(['profile', 'join']);
+  });
+
+  it('fails closed and does not forward when the cold profile cannot publish', async () => {
+    const contextGraphId = 'private-profile-unavailable';
+    const ensureProfilePublished = vi.fn().mockRejectedValue(new Error('registry unavailable'));
+    const forwardJoinRequest = vi.fn();
+    const agent = {
+      peerId: '12D3KooWColdJoiner',
+      isCuratorOf: vi.fn().mockResolvedValue(false),
+      ensureProfilePublished,
+      forwardJoinRequest,
+      resolveAgentByToken: () => undefined,
+    };
+    const delegation = {
+      agentAddress: '0x4444444444444444444444444444444444444444',
+      scope: `join:test:${contextGraphId}`,
+      issuedAtMs: Date.now(),
+      delegateePeerId: agent.peerId,
+      signature: `0x${'33'.repeat(65)}`,
+    };
+
+    server = await startRouteServer(agent);
+    const response = await fetch(routeUrl(server, contextGraphId), {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        delegation,
+        curatorPeerId: '12D3KooWColdJoinCurator',
+        agentName: 'cold-joiner',
+      }),
+    });
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toMatchObject({
+      error: 'Agent profile is not ready; join request was not sent.',
+      cause: 'registry unavailable',
+    });
+    expect(forwardJoinRequest).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-core",
-  "version": "10.0.6",
+  "version": "10.0.7",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -23,6 +23,10 @@ export const PROTOCOL_DISCOVER = '/dkg/10.0.0/discover';
 // (sync is a self-healing catch-up net, so the brief mixed-version
 // window during auto-update is no-data-loss).
 export const PROTOCOL_SYNC = '/dkg/10.0.2/sync';
+// Framed, long-lived transport overlay for PROTOCOL_SYNC. The logical request
+// and response bytes are unchanged; the distinct wire id lets upgraded peers
+// negotiate stream reuse while older peers cleanly fall back to one-shot sync.
+export const PROTOCOL_SYNC_POOLED = '/dkg/10.0.3/sync';
 // OT-RFC-59 changelog read-lane — a SEPARATE protocol id, not a field on
 // PROTOCOL_SYNC: the legacy sync response is bare N-Quads with no envelope, so a
 // structured (era, headSeq, nextSeq, records) head cannot ride the existing

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -1792,6 +1792,10 @@ export class DKGNode {
             relayPeerId: relayPath.relayPeerId,
             remotePeerId: pid,
             durationMs,
+            // libp2p's connection:close event carries no reliable failure
+            // reason. A one-shot DKG request/response relay circuit normally
+            // closes in <1s, so duration alone must never poison the route.
+            confirmedFailure: false,
           });
           if (result.enteredQuarantine) {
             console.warn(

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -1150,7 +1150,13 @@ export class DKGNode {
           // 2h) so operators tuning relay behaviour see the value
           // here instead of having to grep upstream.
           reservationTtl: RELAY_RESERVATION_TTL_MS,
-          defaultDataLimit: BigInt(1 << 24),
+          // Durable graph syncs regularly exceed the previous 16 MiB
+          // per-circuit ceiling. Hitting that ceiling resets an otherwise
+          // healthy relayed connection mid-page and forces the requester to
+          // retry from its last safe graph checkpoint. Raising the forwarding
+          // allowance does not pre-allocate memory; it only permits a circuit
+          // to carry a realistic multi-KA catch-up before its 30-minute limit.
+          defaultDataLimit: BigInt(256 * 1024 * 1024),
         },
       });
       // Route the ulimit log emission to the appropriate console sink

--- a/packages/core/src/protocol-router.ts
+++ b/packages/core/src/protocol-router.ts
@@ -638,7 +638,7 @@ export class ProtocolRouter {
     // is exhausted.
     const overlay = this.pooledByLogical.get(protocolId);
     const memoizedVariant = this.peerWireVariantFor(peerIdStr, protocolId);
-    if (!singleUsePayload && overlay && memoizedVariant !== 'one-shot') {
+    if (overlay && memoizedVariant !== 'one-shot') {
       try {
         const remainingForPool = Math.max(0, timeoutMs - (Date.now() - overallStartedAt));
         const response = await overlay.pool.send(peerIdStr, data, {
@@ -664,6 +664,15 @@ export class ProtocolRouter {
           // variant. Pin to one-shot for future sends; fall through
           // to existing single-path / multi-path logic below.
           this.memoizePeerWire(peerIdStr, protocolId, 'one-shot');
+        } else if (singleUsePayload) {
+          // The authenticated sync envelope is single-use. A pooled request is
+          // itself one wire attempt, but after any ambiguous transport failure
+          // we MUST NOT fall through and replay those bytes on a one-shot
+          // stream. Bubble to sync's outer retry, which rebuilds a fresh signed
+          // envelope before trying again. Protocol-unsupported is the one safe
+          // fallback above: multistream negotiation fails before payload bytes
+          // are written.
+          throw err;
         } else if (memoizedVariant === 'pooled') {
           // Peer is KNOWN to speak the pooled wire (we've delivered
           // on it before). This is a transient failure on the held

--- a/packages/core/src/relay-flap-guard.ts
+++ b/packages/core/src/relay-flap-guard.ts
@@ -99,9 +99,24 @@ export class RelayFlapGuard {
     relayPeerId: string;
     remotePeerId: string;
     durationMs: number;
+    /**
+     * A short-lived relay circuit is not, by itself, a failure: normal DKG
+     * request/response streams routinely open and close in well under a
+     * second. Callers must have an independent failure signal before a close
+     * can contribute to quarantine.
+     */
+    confirmedFailure: boolean;
     now?: number;
   }): RelayFlapCloseResult {
     const now = input.now ?? Date.now();
+    if (!input.confirmedFailure) {
+      return {
+        shortClose: false,
+        shortCloseCount: 0,
+        enteredQuarantine: false,
+        cleared: false,
+      };
+    }
     if (input.durationMs >= this.options.stableCloseMs) {
       return {
         shortClose: false,

--- a/packages/core/test/protocol-router.test.ts
+++ b/packages/core/test/protocol-router.test.ts
@@ -929,7 +929,7 @@ describe('ProtocolRouter', () => {
       expect(resolveCalls).toBe(3);
     });
 
-    it('uses one one-shot attempt for a single-use payload and skips pooling', async () => {
+    it('uses one pooled attempt for a single-use payload without replaying it', async () => {
       let resolveCalls = 0;
       let dialCalls = 0;
       let poolCalls = 0;
@@ -952,18 +952,43 @@ describe('ProtocolRouter', () => {
         },
       });
 
-      await expect(
-        router.send(
-          FAKE_PEER_ID,
-          protocolId,
-          new Uint8Array([1, 2, 3]),
-          { timeoutMs: 5_000, payloadReuse: 'single-use' },
-        ),
-      ).rejects.toThrow(/timeout/);
+      await expect(router.send(
+        FAKE_PEER_ID,
+        protocolId,
+        new Uint8Array([1, 2, 3]),
+        { timeoutMs: 5_000, payloadReuse: 'single-use' },
+      )).resolves.toEqual(new Uint8Array([0xFF]));
 
-      expect(poolCalls).toBe(0);
-      expect(dialCalls).toBe(1);
-      expect(resolveCalls).toBe(1);
+      expect(poolCalls).toBe(1);
+      expect(dialCalls).toBe(0);
+      expect(resolveCalls).toBe(0);
+    });
+
+    it('never replays a single-use payload after an ambiguous pooled failure', async () => {
+      let dialCalls = 0;
+      const protocolId = '/dkg/test/single-use/1.0.0';
+      const router = makeRouter({
+        onResolve: () => undefined,
+        dialBehavior: async () => {
+          dialCalls += 1;
+          return makeStubStream(new Uint8Array([0xFF])) as any;
+        },
+      });
+      (router as any).pooledByLogical.set(protocolId, {
+        logicalProtocolId: protocolId,
+        wireProtocolId: '/dkg/test/single-use-pooled/1.0.0',
+        pool: {
+          send: async () => { throw new Error('pooled stream reset after write'); },
+        },
+      });
+
+      await expect(router.send(
+        FAKE_PEER_ID,
+        protocolId,
+        new Uint8Array([1, 2, 3]),
+        { timeoutMs: 5_000, payloadReuse: 'single-use' },
+      )).rejects.toThrow(/pooled stream reset/);
+      expect(dialCalls).toBe(0);
     });
 
     it('rejects multi-path fan-out for a single-use payload before any wire attempt', async () => {

--- a/packages/core/test/relay-flap-guard.test.ts
+++ b/packages/core/test/relay-flap-guard.test.ts
@@ -19,12 +19,30 @@ function guard(): RelayFlapGuard {
 }
 
 function recordShortBurst(g: RelayFlapGuard, relayPeerId = RELAY_A, remotePeerId = REMOTE_A): void {
-  expect(g.recordRelayedClose({ relayPeerId, remotePeerId, durationMs: 50, now: 0 }).enteredQuarantine).toBe(false);
-  expect(g.recordRelayedClose({ relayPeerId, remotePeerId, durationMs: 50, now: 10 }).enteredQuarantine).toBe(false);
-  expect(g.recordRelayedClose({ relayPeerId, remotePeerId, durationMs: 50, now: 20 }).enteredQuarantine).toBe(true);
+  expect(g.recordRelayedClose({ relayPeerId, remotePeerId, durationMs: 50, confirmedFailure: true, now: 0 }).enteredQuarantine).toBe(false);
+  expect(g.recordRelayedClose({ relayPeerId, remotePeerId, durationMs: 50, confirmedFailure: true, now: 10 }).enteredQuarantine).toBe(false);
+  expect(g.recordRelayedClose({ relayPeerId, remotePeerId, durationMs: 50, confirmedFailure: true, now: 20 }).enteredQuarantine).toBe(true);
 }
 
 describe('RelayFlapGuard', () => {
+  it('does not treat normal short-lived request/response circuits as relay failures', () => {
+    const g = guard();
+
+    for (let i = 0; i < 20; i++) {
+      const result = g.recordRelayedClose({
+        relayPeerId: RELAY_A,
+        remotePeerId: REMOTE_A,
+        durationMs: 25,
+        confirmedFailure: false,
+        now: i * 10,
+      });
+      expect(result.enteredQuarantine).toBe(false);
+    }
+
+    expect(g.getPairState(RELAY_A, REMOTE_A, 250)).toBeUndefined();
+    expect(g.checkRelayedConnection({ relayPeerId: RELAY_A, remotePeerId: REMOTE_A, now: 250 }).deny).toBe(false);
+  });
+
   it('quarantines the exact relay/remote pair after repeated short relayed closes', () => {
     const g = guard();
     recordShortBurst(g);
@@ -41,8 +59,8 @@ describe('RelayFlapGuard', () => {
 
   it('does not quarantine below the short-close threshold', () => {
     const g = guard();
-    g.recordRelayedClose({ relayPeerId: RELAY_A, remotePeerId: REMOTE_A, durationMs: 50, now: 0 });
-    g.recordRelayedClose({ relayPeerId: RELAY_A, remotePeerId: REMOTE_A, durationMs: 50, now: 10 });
+    g.recordRelayedClose({ relayPeerId: RELAY_A, remotePeerId: REMOTE_A, durationMs: 50, confirmedFailure: true, now: 0 });
+    g.recordRelayedClose({ relayPeerId: RELAY_A, remotePeerId: REMOTE_A, durationMs: 50, confirmedFailure: true, now: 10 });
 
     expect(g.checkRelayedConnection({ relayPeerId: RELAY_A, remotePeerId: REMOTE_A, now: 20 }).deny).toBe(false);
     expect(g.getPairState(RELAY_A, REMOTE_A, 20)?.shortCloseCount).toBe(2);
@@ -50,10 +68,10 @@ describe('RelayFlapGuard', () => {
 
   it('does not quarantine long-lived relayed closes and clears prior penalty', () => {
     const g = guard();
-    g.recordRelayedClose({ relayPeerId: RELAY_A, remotePeerId: REMOTE_A, durationMs: 50, now: 0 });
-    g.recordRelayedClose({ relayPeerId: RELAY_A, remotePeerId: REMOTE_A, durationMs: 50, now: 10 });
+    g.recordRelayedClose({ relayPeerId: RELAY_A, remotePeerId: REMOTE_A, durationMs: 50, confirmedFailure: true, now: 0 });
+    g.recordRelayedClose({ relayPeerId: RELAY_A, remotePeerId: REMOTE_A, durationMs: 50, confirmedFailure: true, now: 10 });
 
-    const result = g.recordRelayedClose({ relayPeerId: RELAY_A, remotePeerId: REMOTE_A, durationMs: 1_000, now: 20 });
+    const result = g.recordRelayedClose({ relayPeerId: RELAY_A, remotePeerId: REMOTE_A, durationMs: 1_000, confirmedFailure: true, now: 20 });
     expect(result.cleared).toBe(true);
     expect(g.getPairState(RELAY_A, REMOTE_A, 20)).toBeUndefined();
   });
@@ -98,9 +116,9 @@ describe('RelayFlapGuard', () => {
     // first two must be pruned, so the late one is the only in-window close and
     // never reaches the quarantine threshold (a regression that stops pruning
     // would let three closes across a >window span trip quarantine).
-    expect(g.recordRelayedClose({ relayPeerId: RELAY_A, remotePeerId: REMOTE_A, durationMs: 50, now: 0 }).enteredQuarantine).toBe(false);
-    expect(g.recordRelayedClose({ relayPeerId: RELAY_A, remotePeerId: REMOTE_A, durationMs: 50, now: 10 }).enteredQuarantine).toBe(false);
-    const late = g.recordRelayedClose({ relayPeerId: RELAY_A, remotePeerId: REMOTE_A, durationMs: 50, now: 1_100 });
+    expect(g.recordRelayedClose({ relayPeerId: RELAY_A, remotePeerId: REMOTE_A, durationMs: 50, confirmedFailure: true, now: 0 }).enteredQuarantine).toBe(false);
+    expect(g.recordRelayedClose({ relayPeerId: RELAY_A, remotePeerId: REMOTE_A, durationMs: 50, confirmedFailure: true, now: 10 }).enteredQuarantine).toBe(false);
+    const late = g.recordRelayedClose({ relayPeerId: RELAY_A, remotePeerId: REMOTE_A, durationMs: 50, confirmedFailure: true, now: 1_100 });
     expect(late.enteredQuarantine).toBe(false);
     expect(late.shortCloseCount).toBe(1);
     expect(g.checkRelayedConnection({ relayPeerId: RELAY_A, remotePeerId: REMOTE_A, now: 1_100 }).deny).toBe(false);
@@ -132,10 +150,10 @@ describe('buildRelayFlapConnectionGater (libp2p wiring)', () => {
       stableCloseMs: 60_000,
     });
     const now = Date.now();
-    g.recordRelayedClose({ relayPeerId: RELAY_A, remotePeerId: REMOTE_A, durationMs: 50, now });
-    g.recordRelayedClose({ relayPeerId: RELAY_A, remotePeerId: REMOTE_A, durationMs: 50, now: now + 10 });
+    g.recordRelayedClose({ relayPeerId: RELAY_A, remotePeerId: REMOTE_A, durationMs: 50, confirmedFailure: true, now });
+    g.recordRelayedClose({ relayPeerId: RELAY_A, remotePeerId: REMOTE_A, durationMs: 50, confirmedFailure: true, now: now + 10 });
     expect(
-      g.recordRelayedClose({ relayPeerId: RELAY_A, remotePeerId: REMOTE_A, durationMs: 50, now: now + 20 }).enteredQuarantine,
+      g.recordRelayedClose({ relayPeerId: RELAY_A, remotePeerId: REMOTE_A, durationMs: 50, confirmedFailure: true, now: now + 20 }).enteredQuarantine,
     ).toBe(true);
 
     const gater = buildRelayFlapConnectionGater(g);

--- a/packages/epcis/package.json
+++ b/packages/epcis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-epcis",
-  "version": "10.0.6",
+  "version": "10.0.7",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/evm-module/package.json
+++ b/packages/evm-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-evm-module",
-  "version": "10.0.6",
+  "version": "10.0.7",
   "description": "DKG V10 smart contracts (forked from V8 dkg-evm-module)",
   "license": "Apache-2.0",
   "private": true,

--- a/packages/graph-viz/package.json
+++ b/packages/graph-viz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-graph-viz",
-  "version": "10.0.6",
+  "version": "10.0.7",
   "description": "RDF Knowledge Graph Visualizer — force-directed graph rendering with hexagonal nodes, declarative view configs, RDF-native data loading, and SPARQL-driven views",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/kafka-plugin/package.json
+++ b/packages/kafka-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/kafka-plugin",
-  "version": "10.0.6",
+  "version": "10.0.7",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mcp-dkg/package.json
+++ b/packages/mcp-dkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-mcp",
-  "version": "10.0.6",
+  "version": "10.0.7",
   "description": "MCP server that exposes the local DKG daemon (projects, sub-graphs, activity, chat) to Cursor, Claude Code, and any other MCP-aware coding assistant.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/network-sim/package.json
+++ b/packages/network-sim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-network-sim",
-  "version": "10.0.6",
+  "version": "10.0.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/node-ui/package.json
+++ b/packages/node-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-node-ui",
-  "version": "10.0.6",
+  "version": "10.0.7",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/okf/package.json
+++ b/packages/okf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-okf",
-  "version": "10.0.6",
+  "version": "10.0.7",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/publisher/package.json
+++ b/packages/publisher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-publisher",
-  "version": "10.0.6",
+  "version": "10.0.7",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-query",
-  "version": "10.0.6",
+  "version": "10.0.7",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/random-sampling/package.json
+++ b/packages/random-sampling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-random-sampling",
-  "version": "10.0.6",
+  "version": "10.0.7",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/rdf-utils/package.json
+++ b/packages/rdf-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-rdf-utils",
-  "version": "10.0.6",
+  "version": "10.0.7",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-storage",
-  "version": "10.0.6",
+  "version": "10.0.7",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

- lands the eight recovery and transport hotfixes validated during the multi-network private-CG fan-out test
- completes bounded SWM/VM late-join sync, byte-budgeted adaptive pages, verified-prefix resume, framed stream reuse, and the 256 MiB relay circuit allowance
- cuts the monorepo package set at 10.0.7 and documents the rootless Knowledge Asset release

## Validation

- hotfix range applies exactly onto current main with no conflict-driven changes
- 20 SWM + 20 VM exact-manifest fan-out completed after the relay/transport fixes: 505,666 verified quads total
- complete 17-package CLI runtime dependency build passed, including agent type tests
- focused regressions passed: agent 44, core 73, CLI 3
- release version gate passed: 21 manifests at 10.0.7
- release pack gate passed with CLI network/project/build/Blazegraph assets
- npm registry preflight confirms 10.0.7 is unused for all 18 publishable packages

## Deployment

No Solidity source, ABI, or deployment-registry changes since v10.0.6; no contract deployment is required.