### PR TITLE
chore(release): bump version set to 10.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to the DKG V10 node are documented here. The format is based
 
 ## [Unreleased]
 
+## [10.0.8] - 2026-07-17
+
+Durable-sync materialization hardening for large private Context Graphs. This release makes durable catch-up survive transport drops, responder restarts, and multi-million-quad snapshots without discarding verified work, and fixes the relay and dial paths that stalled fan-out under load. Validated by a 500-Knowledge-Asset private-CG late-join scale test on Gnosis mainnet (5,337,721 unique quads, exact per-graph digest verification). **No smart-contract changes — no deployment required** (no Solidity source, ABI, or deployment-registry changes since 10.0.7).
+
+### Fixed
+
+- **Durable sync survives transport drops without losing verified work** (#1775): a requester now retains its verified prefix and accepted-session checkpoints when a stream drops mid-transfer, resuming the same responder row list instead of restarting the snapshot. Responder sessions are persisted with their checkpoints, expired sessions rotate immediately, and store-fallback session expiry slides while a transfer makes progress.
+- **Snapshots beyond one million rows no longer fail integrity verification** (#1775): the responder clamped any requested cursor to 1,000,000, which silently replayed the row slice at the clamp boundary while the requester kept advancing — producing duplicates and failing manifest verification on any snapshot larger than the cap. Valid non-negative cursors are now accepted in full; exact-graph paging still bounds the response by returning an empty page past the plan.
+- **Durable settlement is serialized per graph** (#1775): concurrent settlement for the same graph no longer interleaves, and a catch-up round that fails against every peer surfaces the failure instead of reporting a silent no-op success.
+- **Catch-up honors its durable time budget** (#1775), and durable-only recovery is supported as a safe path.
+- **Rootless chain identities reconcile during sync** (#1775).
+- **Relay fan-out no longer stalls behind stale direct dials** (#1775): pooled messages reuse a live relay connection, and the dial path falls back to a live relay after a stale direct dial rather than blocking.
+
+### Changed
+
+- **Publisher wallet jobs run concurrently** (#1775): each configured wallet owns an independent nonce stream, so a cycle now dispatches one job per wallet in parallel and waits for all to settle. Adding publisher wallets now actually increases throughput. Errors propagate only after every wallet in the cycle settles.
+- **Rootless durable batches skip legacy partitioning** (#1775).
+- **Dashboard SQLite schema 29 → 30** (#1775): `sync_checkpoints` gains nullable `responder_session_id` and `responder_session_expires_at` columns, added idempotently on upgrade. The migration is additive, so rolling back to 10.0.7 is safe — the older schema guard ignores a newer database and leaves the extra columns in place.
+- **Release version set:** all workspace packages move together to 10.0.8.
+
+### Deployment
+
+- **No contract changes in this release.** No Solidity source, ABI, or mainnet/testnet deployment-registry files changed since 10.0.7; nodes can upgrade through the normal npm release path.
+
 ## [10.0.7] - 2026-07-16
 
 Rootless Knowledge Assets and production hardening for private Context Graphs. New Knowledge Assets are stored and synchronized by their canonical UAL-derived named graph without synthetic `rootEntity` triples; legacy V10 assets remain readable but are no longer rewritten through the legacy lifecycle. The release also completes private-CG auto-approval, late-join recovery, and scalable SWM/VM fan-out, including the fixes validated by the multi-network testnet harness. **No smart-contract changes — no deployment required** (no Solidity source, ABI, or deployment-registry changes since 10.0.6).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dkg-v10",
-  "version": "10.0.7",
+  "version": "10.0.8",
   "private": true,
   "packageManager": "pnpm@10.28.1",
   "dkgBuild": {

--- a/packages/adapter-elizaos/package.json
+++ b/packages/adapter-elizaos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-elizaos",
-  "version": "10.0.7",
+  "version": "10.0.8",
   "description": "ElizaOS plugin adapter — turns any ElizaOS agent into a DKG V10 node",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapter-hermes/package.json
+++ b/packages/adapter-hermes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-hermes",
-  "version": "10.0.7",
+  "version": "10.0.8",
   "description": "Hermes Agent adapter — connects Hermes AI agents to a DKG V10 node for verifiable shared memory",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapter-openclaw/package.json
+++ b/packages/adapter-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-openclaw",
-  "version": "10.0.7",
+  "version": "10.0.8",
   "description": "OpenClaw plugin adapter for connecting a DKG V10 node and chat bridge to an OpenClaw agent",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-agent",
-  "version": "10.0.7",
+  "version": "10.0.8",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/chain/package.json
+++ b/packages/chain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-chain",
-  "version": "10.0.7",
+  "version": "10.0.8",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg",
-  "version": "10.0.7",
+  "version": "10.0.8",
   "type": "module",
   "main": "dist/cli.js",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-core",
-  "version": "10.0.7",
+  "version": "10.0.8",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/epcis/package.json
+++ b/packages/epcis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-epcis",
-  "version": "10.0.7",
+  "version": "10.0.8",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/evm-module/package.json
+++ b/packages/evm-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-evm-module",
-  "version": "10.0.7",
+  "version": "10.0.8",
   "description": "DKG V10 smart contracts (forked from V8 dkg-evm-module)",
   "license": "Apache-2.0",
   "private": true,

--- a/packages/graph-viz/package.json
+++ b/packages/graph-viz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-graph-viz",
-  "version": "10.0.7",
+  "version": "10.0.8",
   "description": "RDF Knowledge Graph Visualizer — force-directed graph rendering with hexagonal nodes, declarative view configs, RDF-native data loading, and SPARQL-driven views",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/kafka-plugin/package.json
+++ b/packages/kafka-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/kafka-plugin",
-  "version": "10.0.7",
+  "version": "10.0.8",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mcp-dkg/package.json
+++ b/packages/mcp-dkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-mcp",
-  "version": "10.0.7",
+  "version": "10.0.8",
   "description": "MCP server that exposes the local DKG daemon (projects, sub-graphs, activity, chat) to Cursor, Claude Code, and any other MCP-aware coding assistant.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/network-sim/package.json
+++ b/packages/network-sim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-network-sim",
-  "version": "10.0.7",
+  "version": "10.0.8",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/node-ui/package.json
+++ b/packages/node-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-node-ui",
-  "version": "10.0.7",
+  "version": "10.0.8",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/okf/package.json
+++ b/packages/okf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-okf",
-  "version": "10.0.7",
+  "version": "10.0.8",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/publisher/package.json
+++ b/packages/publisher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-publisher",
-  "version": "10.0.7",
+  "version": "10.0.8",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-query",
-  "version": "10.0.7",
+  "version": "10.0.8",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/random-sampling/package.json
+++ b/packages/random-sampling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-random-sampling",
-  "version": "10.0.7",
+  "version": "10.0.8",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/rdf-utils/package.json
+++ b/packages/rdf-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-rdf-utils",
-  "version": "10.0.7",
+  "version": "10.0.8",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-storage",
-  "version": "10.0.7",
+  "version": "10.0.8",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Release-prep bump for **10.0.8**, per `RELEASE_PROCESS.md` §3. Moves the root package and all 20 `packages/*` workspaces to `10.0.8` in lockstep and adds the `CHANGELOG.md` entry.

This is the last gate before the comprehensive devnet run (§4) and the canary tag (§5). No functional changes — all 10.0.8 code landed via #1775.

## Changes

- **Version set → 10.0.8** (21 `package.json` files: root + 20 workspaces, including the two private ones so the publish graph stays aligned). Internal deps use `workspace:*`, so a partial bump would ship a skewed dependency graph.
- **`CHANGELOG.md`**: 10.0.8 entry — durable-sync materialization hardening, relay/dial fan-out fixes, publisher wallet concurrency, and the dashboard schema 29 → 30 note.

Version-only: `pnpm-lock.yaml` records third-party versions only and is untouched, so `pnpm install --frozen-lockfile` stays valid.

## Reviewer notes

- **Schema migration in this release.** Dashboard SQLite 29 → 30 adds nullable `responder_session_id` / `responder_session_expires_at` to `sync_checkpoints`. Rollback to 10.0.7 is safe: its guard is `if (version > SCHEMA_VERSION) return;`, so an older node ignores a v30 database and leaves the columns in place. Called out in the changelog.
- **No contract deployment needed.** No Solidity, ABI, or deployment-registry changes since `v10.0.7` — verified with `git diff --name-only v10.0.7..origin/main -- '*.sol' 'packages/evm-module/abi/*'` (empty).
- **Upgrade guide (§10) intentionally skipped** — 10.0.8 is fixes-only with no breaking builder-facing surface. Flag it if you disagree.

## Test Plan

- [x] `pnpm release:verify-versions --version 10.0.8` → passes, 21/21 package.json files at 10.0.8
- [x] `git diff --stat` → version-only, 21 insertions / 21 deletions across package.json files
- [x] `pnpm-lock.yaml` untouched
- [ ] CI green
- [ ] Comprehensive devnet suite on the resulting `main` commit (§4) — next gate, run after merge

## Related Issues

All 10.0.8 code landed via #1775. Validated by the mainnet 500-KA private-CG late-join scale test recorded in `docs/reports/mainnet-private-cg-scale500-20260717.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
