### PR TITLE
Expose StorageACK peers for reliable remote queries

### DIFF
--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -89,6 +89,8 @@ export interface KnowledgeAssetCreateResponse {
   swmShared?: boolean;
   promotedCount?: number;
   publishReady?: boolean;
+  /** Core peers whose StorageACKs backed a confirmed VM publish. */
+  storageAckPeerIds?: string[];
   errors?: KnowledgeAssetLifecycleError[];
   [key: string]: unknown;
 }
@@ -125,6 +127,8 @@ export interface KnowledgeAssetPublishResponse {
   ual?: string;
   txHash?: string;
   status?: string;
+  /** Core peers whose StorageACKs backed a confirmed VM publish. */
+  storageAckPeerIds?: string[];
   error?: string;
   errors?: KnowledgeAssetLifecycleError[];
   contextGraphError?: unknown;
@@ -938,6 +942,7 @@ export class ApiClient {
     kas: Array<{ tokenId: string; rootEntity: string }>;
     txHash?: string;
     blockNumber?: number;
+    storageAckPeerIds?: string[];
     contextGraphError?: string;
   }> {
     return this.knowledgeAssetPublish(contextGraphId, assertionName, options) as Promise<{
@@ -949,6 +954,7 @@ export class ApiClient {
       kas: Array<{ tokenId: string; rootEntity: string }>;
       txHash?: string;
       blockNumber?: number;
+      storageAckPeerIds?: string[];
       contextGraphError?: string;
     }>;
   }

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -80,8 +80,16 @@ import {
   parseHttpFinalizedPublishOptions,
   type NormalizedFinalizedPublishOptions,
 } from "../../finalized-publish-options.js";
+import { storageAckPeerIdsFromPublishResult } from "./storage-ack-peers.js";
 
 const PREFIX = "/api/knowledge-assets";
+type FinalizedPublishResult = Awaited<
+  ReturnType<RequestContext["agent"]["publishFromFinalizedAssertion"]>
+> & {
+  /** Backward-compatible response aliases still accepted by the HTTP route. */
+  authorAddress?: string;
+  kas?: unknown[];
+};
 
 // Decode + validate a `:name` path segment (parity with the legacy routes,
 // which `safeDecodeURIComponent` then `validateAssertionName` every name). A
@@ -932,7 +940,7 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
       }
       if (alsoPublishVm === true || (typeof alsoPublishVm === "object" && alsoPublishVm !== null)) {
         try {
-          const pub: any = await agent.publishFromFinalizedAssertion(resolvedContextGraphId, name, {
+          const pub: FinalizedPublishResult = await agent.publishFromFinalizedAssertion(resolvedContextGraphId, name, {
             subGraphName,
             ...alsoPublishVmOptions,
             ...atomicAuthorLane,
@@ -940,6 +948,10 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
           result.kaId = pub?.kaId;
           result.ual = pub?.ual;
           result.txHash = pub?.onChainResult?.txHash;
+          const storageAckPeerIds = storageAckPeerIdsFromPublishResult(pub);
+          if (storageAckPeerIds.length > 0) {
+            result.storageAckPeerIds = storageAckPeerIds;
+          }
           if (pub?.onChainResult?.convictionCostCovered) {
             result.convictionCostCovered = pub.onChainResult.convictionCostCovered;
           }
@@ -1450,7 +1462,7 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
         // first; ONLY if the sole remaining blocker is an unregistered CG do we
         // transparently register and retry (idempotent). All other errors
         // propagate to the precondition/500 mapping below unchanged.
-        let pub: any;
+        let pub: FinalizedPublishResult;
         const publishStorageLane = scopedTokenStorageLane(writePreflightCallerAgentAddress);
         try {
           pub = await agent.publishFromFinalizedAssertion(contextGraphId, name, { subGraphName, ...opts, ...publishStorageLane });
@@ -1477,6 +1489,7 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
           recordActivityAndNotify(ctx, { contextGraphId, kind: "published", actorAgentAddress: pub?.seal?.authorAddress ?? pub?.authorAddress ?? requestAgentAddress, subGraphName });
         }
         recordPcaDiscount(ctx, contextGraphId, pub?.onChainResult);
+        const storageAckPeerIds = storageAckPeerIdsFromPublishResult(pub);
         // Full publish payload (PR #971) so clients can reconcile sealed↔minted.
         return jsonResponse(res, httpStatus, {
           kaId: pub?.kaId,
@@ -1492,6 +1505,7 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
           ...(pub?.onChainResult?.blockNumber !== undefined ? { blockNumber: pub.onChainResult.blockNumber } : {}),
           ...(pub?.onChainResult?.convictionCostCovered ? { convictionCostCovered: pub.onChainResult.convictionCostCovered } : {}),
           ...(typeof pub?.contextGraphError === "string" ? { contextGraphError: pub.contextGraphError } : {}),
+          ...(storageAckPeerIds.length > 0 ? { storageAckPeerIds } : {}),
           ...(reason ? { error: reason } : {}),
         });
       } catch (e: any) {

--- a/packages/cli/src/daemon/routes/storage-ack-peers.ts
+++ b/packages/cli/src/daemon/routes/storage-ack-peers.ts
@@ -1,0 +1,21 @@
+import type { PublishResult } from '@origintrail-official/dkg-publisher';
+
+type StorageAckPublishResult = Pick<PublishResult, 'status' | 'v10ACKs'>;
+
+/**
+ * Return the distinct Core peer IDs that actually backed a confirmed publish.
+ * Signatures and node identities intentionally stay inside the daemon.
+ */
+export function storageAckPeerIdsFromPublishResult(
+  result: StorageAckPublishResult | null | undefined,
+): string[] {
+  if (result?.status !== 'confirmed') return [];
+
+  return [
+    ...new Set(
+      (result.v10ACKs ?? [])
+        .map(({ peerId }) => (typeof peerId === 'string' ? peerId.trim() : ''))
+        .filter(Boolean),
+    ),
+  ];
+}

--- a/packages/cli/test/knowledge-assets-1116-share-errors.test.ts
+++ b/packages/cli/test/knowledge-assets-1116-share-errors.test.ts
@@ -1179,6 +1179,11 @@ describe('#1116 share/seal route error mapping (fake agent)', () => {
               status: 'confirmed',
               ual: 'did:dkg:test/1/44',
               kaId: '44',
+              v10ACKs: [
+                { peerId: ' 12D3KooWStorageCore1 ' },
+                { peerId: '12D3KooWStorageCore1' },
+                { peerId: '12D3KooWStorageCore2' },
+              ],
               seal: { authorAddress: tokenAgentAddress },
             };
           },
@@ -1204,6 +1209,10 @@ describe('#1116 share/seal route error mapping (fake agent)', () => {
 
       expect(res.status).toBe(201);
       expect(res.body.status).toBe('vm-confirmed');
+      expect(res.body.storageAckPeerIds).toEqual([
+        '12D3KooWStorageCore1',
+        '12D3KooWStorageCore2',
+      ]);
       expect(seenOpts).toHaveLength(1);
       expect(seenOpts[0]).toMatchObject({
         agentAddress: tokenAgentAddress,
@@ -1484,6 +1493,7 @@ describe('#1116 share/seal route error mapping (fake agent)', () => {
               status: 'confirmed',
               ual: 'did:dkg:test/1/43',
               kaId: '43',
+              v10ACKs: [{ peerId: '12D3KooWStorageCore3' }],
               seal: { authorAddress: tokenAgentAddress },
             };
           },
@@ -1494,6 +1504,7 @@ describe('#1116 share/seal route error mapping (fake agent)', () => {
       const res = await post('vm/publish', { contextGraphId: CG_ID });
 
       expect(res.status).toBe(200);
+      expect(res.body.storageAckPeerIds).toEqual(['12D3KooWStorageCore3']);
       expect(seenOpts).toHaveLength(1);
       expect(seenOpts[0]).toMatchObject({ agentAddress: tokenAgentAddress });
     });

--- a/packages/cli/test/storage-ack-peers.test.ts
+++ b/packages/cli/test/storage-ack-peers.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { storageAckPeerIdsFromPublishResult } from '../src/daemon/routes/storage-ack-peers.js';
+
+describe('storageAckPeerIdsFromPublishResult', () => {
+  it('returns trimmed, distinct peer IDs for a confirmed publish', () => {
+    expect(storageAckPeerIdsFromPublishResult({
+      status: 'confirmed',
+      v10ACKs: [
+        { peerId: ' peer-a ' },
+        { peerId: 'peer-a' },
+        { peerId: ' ' },
+        { peerId: 'peer-b' },
+      ],
+    })).toEqual(['peer-a', 'peer-b']);
+  });
+
+  it('does not expose ACK targets for an unconfirmed publish', () => {
+    expect(storageAckPeerIdsFromPublishResult({
+      status: 'tentative',
+      v10ACKs: [{ peerId: 'peer-a' }],
+    })).toEqual([]);
+  });
+
+  it('returns an empty list when ACKs are absent', () => {
+    expect(storageAckPeerIdsFromPublishResult({ status: 'confirmed' })).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What changed

- Add a typed helper that returns only the distinct Core peer IDs whose StorageACKs backed a confirmed publish.
- Expose `storageAckPeerIds` from both atomic Knowledge Asset creation and standalone VM publish responses, and add the field to the API client types.
- Add focused route and helper regressions for confirmed-only exposure, trimming, de-duplication, and both publish surfaces.

## Why

The publish harness could not identify the cores that actually signed the storage commitment, so Query Remote had to guess unrelated peers. That could fail even when the durability contract worked, or pass without verifying an ACK signer.

This supersedes #1770 with a smaller approach: current `main` already persists rootless graph-scoped ACK snapshots through the canonical workspace metadata path, so this PR does not change StorageACK persistence, finalization, contracts, transactions, or legacy data retention.

The long-lived `test/publish` branch is updated at commit `c20884f75` to query only returned ACK peers after a fresh confirmed publish and fail closed when the API field is absent; fallback UAL reads remain available only after publish failure.

## Validation

- `DKG_SKIP_EVM_BUILD=1 pnpm run build:packages` — 22/22 build tasks passed
- `pnpm exec vitest run test/storage-ack-peers.test.ts test/knowledge-assets-1116-share-errors.test.ts` — 44/44 tests passed
- `npm run test:config` in `tests/publish` — 13/13 tests passed
