### PR TITLE
Fix Markdown KA visibility after SWM sharing

### DIFF
--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -2543,7 +2543,17 @@ export class DKGAgent extends DKGAgentBase {
         );
         if (gossipMessage) {
           try {
-            await agent.publishWorkspaceGossip(contextGraphId, gossipMessage, createOperationContext('share'), gossipSigner);
+            // Preserve the immutable operation id through the fan-out seam.
+            // Direct share() already does this; assertion promotion previously
+            // dropped it, so receiver acknowledgements/watchdog retries could
+            // not be correlated for imported (including Markdown) KAs.
+            await agent.publishWorkspaceGossip(
+              contextGraphId,
+              gossipMessage,
+              createOperationContext('share'),
+              gossipSigner,
+              shareOperationId,
+            );
           } catch (err: any) {
             agent.log.warn(createOperationContext('share'), `Promote gossip failed (local SWM committed): ${err?.message ?? err}`);
           }

--- a/packages/agent/test/e2e-assertion-lifecycle.test.ts
+++ b/packages/agent/test/e2e-assertion-lifecycle.test.ts
@@ -11,7 +11,7 @@
  * 8. Sub-graph assertions — assertion lifecycle within a sub-graph
  * 9. Two-node promote gossip — promoted data replicates via gossip
  */
-import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest';
 import { makeTestKaNumberAllocator } from "./_helpers/ka-allocator.js";
 import { DKGAgent } from '../src/index.js';
 import { createEVMAdapter, getSharedContext, createProvider, takeSnapshot, revertSnapshot, HARDHAT_KEYS } from '../../chain/test/evm-test-context.js';
@@ -200,7 +200,7 @@ describe('Assertion lifecycle with sub-graphs', () => {
 });
 
 describe('Assertion promote gossip (2 nodes)', () => {
-  it('promoted data replicates to connected peer via gossip', async () => {
+  it('a rootless Markdown-shaped KA replicates to the connected peer with its entities intact', async () => {
     const nodeA = await DKGAgent.create({
       kaNumberAllocator: makeTestKaNumberAllocator(),
       name: 'PromoteGossipA',
@@ -235,18 +235,40 @@ describe('Assertion promote gossip (2 nodes)', () => {
     nodeB.subscribeToContextGraph(CG_ID);
     await sleep(500);
 
+    const markdownRoot = 'did:dkg:context-graph:assertion-e2e/assertion/0xauthor/readme.md';
+    // The Markdown extractor emits section blank nodes. Finalization owns the
+    // conversion into the protocol-reserved urn:dkg:ka-skolem namespace.
+    const markdownSection = '_:section-safety';
+    const markdownFile = 'urn:dkg:file:keccak256:abc';
     await nodeA.assertion.create(CG_ID, 'gossip-draft');
     await nodeA.assertion.write(CG_ID, 'gossip-draft', [
-      { subject: 'urn:gossip:item', predicate: 'http://schema.org/name', object: '"Gossiped via promote"' },
+      { subject: markdownRoot, predicate: 'http://schema.org/name', object: '"Construction notes"' },
+      { subject: markdownRoot, predicate: 'http://dkg.io/ontology/sourceContentType', object: '"text/markdown"' },
+      { subject: markdownRoot, predicate: 'http://dkg.io/ontology/sourceFile', object: markdownFile },
+      { subject: markdownRoot, predicate: 'http://dkg.io/ontology/markdownForm', object: markdownFile },
+      { subject: markdownRoot, predicate: 'http://dkg.io/ontology/rootEntity', object: markdownRoot },
+      { subject: markdownRoot, predicate: 'http://dkg.io/ontology/hasSection', object: markdownSection },
+      { subject: markdownSection, predicate: 'http://schema.org/name', object: '"Safety"' },
     ]);
 
-    await nodeA.assertion.promote(CG_ID, 'gossip-draft');
+    const publishWorkspaceGossip = vi.spyOn(nodeA, 'publishWorkspaceGossip');
+    const promoted = await nodeA.assertion.promote(CG_ID, 'gossip-draft');
+    expect(promoted.shareOperationId).toBeTruthy();
+    const publishCall = publishWorkspaceGossip.mock.calls[0];
+    expect(publishCall?.[0]).toBe(CG_ID);
+    expect(publishCall?.[1]).toBeInstanceOf(Uint8Array);
+    expect(publishCall?.[4]).toBe(promoted.shareOperationId);
 
     const deadline = Date.now() + 15_000;
     let bindings: any[] = [];
     while (Date.now() < deadline) {
       const result = await nodeB.query(
-        'SELECT ?name WHERE { <urn:gossip:item> <http://schema.org/name> ?name }',
+        `SELECT ?title ?contentType ?sectionName WHERE {
+          <${markdownRoot}> <http://schema.org/name> ?title ;
+            <http://dkg.io/ontology/sourceContentType> ?contentType ;
+            <http://dkg.io/ontology/hasSection> ?section .
+          ?section <http://schema.org/name> ?sectionName .
+        }`,
         { contextGraphId: CG_ID, graphSuffix: '_shared_memory' },
       );
       bindings = result.bindings;
@@ -254,6 +276,8 @@ describe('Assertion promote gossip (2 nodes)', () => {
       await sleep(500);
     }
     expect(bindings.length).toBe(1);
-    expect(bindings[0]?.['name']).toBe('"Gossiped via promote"');
+    expect(bindings[0]?.['title']).toBe('"Construction notes"');
+    expect(bindings[0]?.['contentType']).toBe('"text/markdown"');
+    expect(bindings[0]?.['sectionName']).toBe('"Safety"');
   }, 20_000);
 });

--- a/packages/agent/test/e2e-memory-layers.test.ts
+++ b/packages/agent/test/e2e-memory-layers.test.ts
@@ -19,6 +19,7 @@ import { buildKnowledgeAssetUal } from '@origintrail-official/dkg-chain';
 import { ethers } from 'ethers';
 import { TripleStoreAsyncLiftPublisher } from '@origintrail-official/dkg-publisher';
 import { installHardhatACKProvider } from './_helpers/v10-acks.js';
+import { extractFromMarkdown } from '../../cli/src/extraction/markdown-extractor.js';
 import {
   assertionLifecycleUri,
   contextGraphMetaUri,
@@ -2130,7 +2131,7 @@ describe('WM → SWM gossip → VM (2 nodes)', () => {
     return lastResult;
   }
 
-  it('A drafts in WM → promotes to SWM → gossips to B → publishes → B finalizes', async () => {
+  it('an imported Markdown KA survives WM → SWM gossip → VM on a second node', async () => {
     const sharedChain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
     const nodeA = await DKGAgent.create({
       kaNumberAllocator: makeTestKaNumberAllocator(),
@@ -2164,42 +2165,99 @@ describe('WM → SWM gossip → VM (2 nodes)', () => {
     nodeB.subscribeToContextGraph(CG_ID);
     await sleep(1500);
 
-    // Step 1: A creates assertion in WM
-    await nodeA.assertion.create(CG_ID, 'two-node-draft');
-    await nodeA.assertion.write(CG_ID, 'two-node-draft', [
-      { subject: `${ENTITY_BASE}:two-node`, predicate: 'http://schema.org/name', object: '"Two Node Entity"' },
+    // Step 1: use the production Markdown extractor, including the blank-node
+    // section hierarchy that originally made imported KAs appear empty on the
+    // receiving node. The two daemon-owned linkage rows below are written by
+    // the real import-file route alongside this extractor output.
+    const assertionName = 'two-node-markdown';
+    const assertionUri = contextGraphAssertionUri(
+      CG_ID,
+      nodeA.defaultAgentAddress ?? nodeA.peerId,
+      assertionName,
+    );
+    const fileUri = `urn:dkg:file:keccak256:${'a'.repeat(64)}`;
+    const extracted = extractFromMarkdown({
+      markdown: [
+        '---',
+        'type: Report',
+        'title: Construction safety notes',
+        'status: approved',
+        '---',
+        '',
+        '# Construction safety notes',
+        '',
+        'Shared with [[Site Alpha]] and tagged #safety.',
+        '',
+        '## Equipment',
+        '',
+        'Inspect lifting equipment.',
+        '',
+        '### Cranes',
+        '',
+        'Check every crane before use.',
+      ].join('\n'),
+      agentDid: `did:dkg:agent:${nodeA.defaultAgentAddress ?? nodeA.peerId}`,
+      documentIri: assertionUri,
+      sourceFileIri: fileUri,
+    });
+    expect(extracted.triples.some((quad) => quad.subject.startsWith('_:dkg-md-section-'))).toBe(true);
+
+    await nodeA.assertion.create(CG_ID, assertionName);
+    await nodeA.assertion.write(CG_ID, assertionName, [
+      ...extracted.triples,
+      ...extracted.sourceFileLinkage,
+      {
+        subject: extracted.subjectIri,
+        predicate: 'http://dkg.io/ontology/sourceContentType',
+        object: '"text/markdown"',
+      },
+      {
+        subject: extracted.subjectIri,
+        predicate: 'http://dkg.io/ontology/markdownForm',
+        object: fileUri,
+      },
     ]);
 
     // Step 2: A promotes to SWM (gossips to B)
-    await nodeA.assertion.promote(CG_ID, 'two-node-draft');
+    await nodeA.assertion.promote(CG_ID, assertionName);
 
-    // Step 3: B receives via gossip
+    const receiverMarkdownQuery = `SELECT ?title ?contentType ?section ?sectionName WHERE {
+      <${assertionUri}> <http://schema.org/name> ?title ;
+        <http://dkg.io/ontology/sourceContentType> ?contentType ;
+        <http://dkg.io/ontology/hasSection> ?section .
+      ?section <http://schema.org/name> ?sectionName .
+    }`;
+
+    // Step 3: B receives the document and its canonicalized section entity via gossip.
     const bSwm = await pollUntil(
       () => nodeB.query(
-        `SELECT ?name WHERE { <${ENTITY_BASE}:two-node> <http://schema.org/name> ?name }`,
+        receiverMarkdownQuery,
         { contextGraphId: CG_ID, graphSuffix: '_shared_memory' },
       ),
       (b) => b.length > 0,
       15_000,
     );
     expect(bSwm.length).toBe(1);
-    expect(bSwm[0]?.['name']).toBe('"Two Node Entity"');
+    expect(bSwm[0]).toMatchObject({
+      title: '"Construction safety notes"',
+      contentType: '"text/markdown"',
+      sectionName: '"Equipment"',
+    });
+    expect(bSwm[0]?.['section']).toMatch(/^urn:dkg:ka-skolem:c14n\d+$/);
 
     // Step 4: A publishes from SWM → chain
     const pubResult = await nodeA.publishFromSharedMemory(CG_ID, 'all');
     expect(pubResult.status).toBe('confirmed');
 
-    // Step 5: B receives finalization → promotes to data graph
+    // Step 5: B receives finalization and exposes the same document/entity
+    // relationship from VM, proving publication does not lose Markdown content.
     const bData = await pollUntil(
-      () => nodeB.query(
-        `SELECT ?name WHERE { <${ENTITY_BASE}:two-node> <http://schema.org/name> ?name }`,
-        CG_ID,
-      ),
+      () => nodeB.query(receiverMarkdownQuery, CG_ID),
       (b) => b.length > 0,
       20_000,
     );
     expect(bData.length).toBe(1);
-    expect(bData[0]?.['name']).toBe('"Two Node Entity"');
+    expect(bData[0]).toEqual(bSwm[0]);
   }, 60_000);
 });
 

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -1451,11 +1451,14 @@ export const promoteAssertion = (
       code: 'KA_ATOMIC_SHARE_REQUIRED',
     });
   }
-  const subGraphName =
+  const options: AtomicShareOptions =
     optionsOrLegacyEntities === undefined || typeof optionsOrLegacyEntities === 'string'
-      ? legacySubGraphName
-      : optionsOrLegacyEntities.subGraphName ?? legacySubGraphName;
-  return knowledgeAssetShare(contextGraphId, assertionName, { subGraphName });
+      ? { subGraphName: legacySubGraphName }
+      : {
+          ...optionsOrLegacyEntities,
+          subGraphName: optionsOrLegacyEntities.subGraphName ?? legacySubGraphName,
+        };
+  return knowledgeAssetShare(contextGraphId, assertionName, options);
 };
 
 // Issue #864 — central UI translator for `promoteAssertion` outcomes so

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -886,6 +886,12 @@ export const knowledgeAssetPullFrom = (
 
 export interface AtomicShareOptions {
   subGraphName?: string;
+  /**
+   * Require a private context graph's curator to apply the complete KA before
+   * the UI reports that it reached Shared Working Memory. Defaults to true for
+   * interactive UI shares; public context graphs ignore the gate.
+   */
+  awaitCuratorAck?: boolean;
 }
 
 type LegacyAtomicShareOptions = AtomicShareOptions & {
@@ -920,7 +926,16 @@ function normalizeAtomicShareOptions(raw: AtomicShareOptions): AtomicShareOption
   if (opts.skipSeal !== undefined && opts.skipSeal !== false) {
     throw new TypeError('skipSeal must be false or omitted');
   }
-  return opts.subGraphName ? { subGraphName: opts.subGraphName } : {};
+  if (opts.awaitCuratorAck !== undefined && typeof opts.awaitCuratorAck !== 'boolean') {
+    throw new TypeError('awaitCuratorAck must be a boolean when supplied');
+  }
+  return {
+    ...(opts.subGraphName ? { subGraphName: opts.subGraphName } : {}),
+    // The synchronous UI flow must not turn a local-only SWM commit into a
+    // success toast. For private CGs this waits for the curator's applied ACK;
+    // for public CGs the daemon treats the flag as a no-op.
+    awaitCuratorAck: opts.awaitCuratorAck ?? true,
+  };
 }
 
 /** Atomically seal and share the complete WM Knowledge Asset to SWM. */
@@ -935,6 +950,7 @@ export const knowledgeAssetShare = (
     {
       contextGraphId: normalizeContextGraphId(contextGraphId),
       ...(opts.subGraphName ? { subGraphName: opts.subGraphName } : {}),
+      awaitCuratorAck: opts.awaitCuratorAck,
     },
   );
 };

--- a/packages/node-ui/test/build-entities-triple-count.test.ts
+++ b/packages/node-ui/test/build-entities-triple-count.test.ts
@@ -273,4 +273,30 @@ describe('buildEntities — MemoryEntity.tripleCount', () => {
     expect(isFirstClassEntity(sectionEntity!)).toBe(true);
     expect(sectionEntity?.properties.get('http://schema.org/description')).toEqual(['see /.well-known/genid/a']);
   });
+
+  it('renders a rootless Markdown KA received in Shared Working Memory as document and section entities', () => {
+    const root = 'did:dkg:context-graph:construction/assertion/0xauthor/readme.md';
+    const section = 'urn:dkg:ka-skolem:c14n0';
+    const file = 'urn:dkg:file:keccak256:abc';
+    const entities = buildEntities([
+      triple(root, 'http://schema.org/name', '"Construction notes"', 'shared'),
+      triple(root, 'http://dkg.io/ontology/sourceContentType', '"text/markdown"', 'shared'),
+      triple(root, 'http://dkg.io/ontology/sourceFile', file, 'shared'),
+      triple(root, 'http://dkg.io/ontology/markdownForm', file, 'shared'),
+      triple(root, 'http://dkg.io/ontology/rootEntity', root, 'shared'),
+      triple(root, 'http://dkg.io/ontology/hasSection', section, 'shared'),
+      triple(section, 'http://schema.org/name', '"Safety"', 'shared'),
+    ]);
+
+    const rootEntity = entities.get(root);
+    const sectionEntity = entities.get(section);
+    expect(rootEntity).toBeDefined();
+    expect(rootEntity?.trustLevel).toBe('shared');
+    expect(rootEntity?.properties.get('http://dkg.io/ontology/sourceContentType')).toEqual(['text/markdown']);
+    expect(rootEntity?.tripleCount).toBe(6);
+    expect(isFirstClassEntity(rootEntity!)).toBe(true);
+    expect(sectionEntity).toBeDefined();
+    expect(sectionEntity?.trustLevel).toBe('shared');
+    expect(isFirstClassEntity(sectionEntity!)).toBe(true);
+  });
 });

--- a/packages/node-ui/test/ui-api-pure.test.ts
+++ b/packages/node-ui/test/ui-api-pure.test.ts
@@ -584,7 +584,11 @@ describe('UI API tests', () => {
         entities: 'all', // compatibility-only neutral value
       } as any);
       const call = requestLog.find(r => r.url.includes('/api/knowledge-assets/asset/swm/share'));
-      expect(JSON.parse(call?.body ?? '{}')).toEqual({ contextGraphId: 'cg-1', subGraphName: 'sg' });
+      expect(JSON.parse(call?.body ?? '{}')).toEqual({
+        contextGraphId: 'cg-1',
+        subGraphName: 'sg',
+        awaitCuratorAck: true,
+      });
 
       requestLog.length = 0;
       expect(() =>
@@ -601,13 +605,18 @@ describe('UI API tests', () => {
     it('promoteAssertion shares the complete owning KA and never silently widens a legacy subset', async () => {
       await promoteAssertion('cg-1', 'asset', { subGraphName: 'sg' });
       const call = requestLog.find(r => r.url.includes('/api/knowledge-assets/asset/swm/share'));
-      expect(JSON.parse(call?.body ?? '{}')).toEqual({ contextGraphId: 'cg-1', subGraphName: 'sg' });
+      expect(JSON.parse(call?.body ?? '{}')).toEqual({
+        contextGraphId: 'cg-1',
+        subGraphName: 'sg',
+        awaitCuratorAck: true,
+      });
 
       requestLog.length = 0;
       await promoteAssertion('cg-1', 'legacy-caller', 'all', 'sg-legacy');
       expect(JSON.parse(requestLog[0]?.body ?? '{}')).toEqual({
         contextGraphId: 'cg-1',
         subGraphName: 'sg-legacy',
+        awaitCuratorAck: true,
       });
 
       requestLog.length = 0;
@@ -615,6 +624,7 @@ describe('UI API tests', () => {
       expect(JSON.parse(requestLog[0]?.body ?? '{}')).toEqual({
         contextGraphId: 'cg-1',
         subGraphName: 'sg-from-fourth-arg',
+        awaitCuratorAck: true,
       });
 
       requestLog.length = 0;

--- a/packages/node-ui/test/ui-api-pure.test.ts
+++ b/packages/node-ui/test/ui-api-pure.test.ts
@@ -602,6 +602,24 @@ describe('UI API tests', () => {
       expect(requestLog).toHaveLength(0);
     });
 
+    it('knowledgeAssetShare preserves an explicit curator-ACK opt-out and rejects invalid values', async () => {
+      await knowledgeAssetShare('cg-1', 'asset', {
+        subGraphName: 'sg',
+        awaitCuratorAck: false,
+      });
+      expect(JSON.parse(requestLog[0]?.body ?? '{}')).toEqual({
+        contextGraphId: 'cg-1',
+        subGraphName: 'sg',
+        awaitCuratorAck: false,
+      });
+
+      requestLog.length = 0;
+      expect(() =>
+        knowledgeAssetShare('cg-1', 'asset', { awaitCuratorAck: 'false' } as any),
+      ).toThrow('awaitCuratorAck must be a boolean');
+      expect(requestLog).toHaveLength(0);
+    });
+
     it('promoteAssertion shares the complete owning KA and never silently widens a legacy subset', async () => {
       await promoteAssertion('cg-1', 'asset', { subGraphName: 'sg' });
       const call = requestLog.find(r => r.url.includes('/api/knowledge-assets/asset/swm/share'));
@@ -609,6 +627,17 @@ describe('UI API tests', () => {
         contextGraphId: 'cg-1',
         subGraphName: 'sg',
         awaitCuratorAck: true,
+      });
+
+      requestLog.length = 0;
+      await promoteAssertion('cg-1', 'explicit-opt-out', {
+        subGraphName: 'sg-no-ack',
+        awaitCuratorAck: false,
+      });
+      expect(JSON.parse(requestLog[0]?.body ?? '{}')).toEqual({
+        contextGraphId: 'cg-1',
+        subGraphName: 'sg-no-ack',
+        awaitCuratorAck: false,
       });
 
       requestLog.length = 0;

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -27,7 +27,10 @@ import {
   computeFlatKCRootV10 as computeFlatKCRoot,
   computeFlatKCMerkleLeafCountV10,
 } from './merkle.js';
-import { validateKnowledgeAssetPublishRequest, validatePublishRequest } from './validation.js';
+import {
+  validateCanonicalGraphScopedKnowledgeAssetPayload,
+  validatePublishRequest,
+} from './validation.js';
 import { isFailClosedInlineEncrypt } from './async-lift-publish-options.js';
 import {
   assertionOriginalGraph,
@@ -2695,11 +2698,10 @@ export class DKGPublisher implements Publisher {
         graphPublish.scope,
         options.subGraphName,
       );
-      const validation = validateKnowledgeAssetPublishRequest(
+      const validation = validateCanonicalGraphScopedKnowledgeAssetPayload(
         allSkolemizedQuads.map((quad) => ({ ...quad, graph: vmGraph })),
         vmGraph,
         graphPublish.publicTripleCount,
-        { allowCanonicalSkolemTerms: true },
       );
       if (!validation.valid) {
         throw new Error(`Validation failed: ${validation.errors.join('; ')}`);
@@ -4640,11 +4642,10 @@ export class DKGPublisher implements Publisher {
       });
       allSkolemizedQuads = canonicalParts.publicQuads;
       canonicalPrivateQuads = canonicalParts.privateQuads;
-      const validation = validateKnowledgeAssetPublishRequest(
+      const validation = validateCanonicalGraphScopedKnowledgeAssetPayload(
         allSkolemizedQuads.map((quad) => ({ ...quad, graph: dataGraph })),
         dataGraph,
         graphUpdate.publicTripleCount,
-        { allowCanonicalSkolemTerms: true },
       );
       if (!validation.valid) {
         throw new Error(`Validation failed: ${validation.errors.join('; ')}`);

--- a/packages/publisher/src/index.ts
+++ b/packages/publisher/src/index.ts
@@ -69,7 +69,12 @@ export {
   computeKARootV10,
   computeKCRootV10,
 } from './merkle.js';
-export { validatePublishRequest, type ValidationResult, type ValidationOptions } from './validation.js';
+export {
+  validatePublishRequest,
+  validateCanonicalGraphScopedKnowledgeAssetPayload,
+  type ValidationResult,
+  type ValidationOptions,
+} from './validation.js';
 export { generateKCMetadata, generateTentativeMetadata, generateConfirmedFullMetadata, generateGraphKnowledgeAssetMetadata, replaceLocallyTrustedKnowledgeAssetControls, readLocallyTrustedKnowledgeAssetControls, readConfirmedGraphKnowledgeAssetMetadataEnvelope, buildDeterministicTokenRows, compareRootIris, getTentativeStatusQuad, getConfirmedStatusQuad, generateOwnershipQuads, generateShareMetadata, generateWorkspaceMetadata, generateKnowledgeAssetShareMetadata, generateSubGraphRegistration, subGraphDeregistrationSparql, subGraphDiscoverySparql, subGraphWritersSparql, toHex, resolveUalByBatchId, updateMetaMerkleRoot, promoteUpdatedKaToPerCgId, restateKaPartition, restateLabelGraphForUpdate, readMaterializedVersion, shouldApplyMaterialization, writeMaterializedVersion, materializedVersionQuad, withMaterializationLock, compareMaterializedVersion, type MaterializedVersion, generateAssertionCreatedMetadata, generateAssertionPromotedMetadata, generateAssertionUpdatedMetadata, generateAssertionDiscardedMetadata, assertionStateQuad, assertionLayerQuad, deriveStatus, assertionLayerPointerQuad, stampLayerPointerSparql, type LifecycleMetadataOptions, WM_CURRENT_ASSERTION_PRED, SWM_CURRENT_ASSERTION_PRED, VM_CURRENT_ASSERTION_PRED, KA_ID_PRED, RESERVED_UAL_PRED, PROV_WAS_REVISION_OF, type KaStatus, type StatusPointers, type KCMetadata, type KAMetadata, type GraphKnowledgeAssetMetadata, type ConfirmedGraphKnowledgeAssetMetadataEnvelope, type ConfirmedGraphKnowledgeAssetMetadataRead, type OnChainProvenance, type ShareMetadata, type WorkspaceMetadata, type KnowledgeAssetShareMetadata, type SubGraphRegistration, type AssertionCreatedMeta, type AssertionPromotedMeta, type AssertionUpdatedMeta, type AssertionDiscardedMeta } from './metadata.js';
 export { pruneSupersededAgentRegistryMeta, insertBoundedAgentRegistryMeta } from './agent-registry-meta-retention.js';
 export {

--- a/packages/publisher/src/storage-ack-handler.ts
+++ b/packages/publisher/src/storage-ack-handler.ts
@@ -53,7 +53,7 @@ import { replaceCatalogQuads } from './catalog-persistence.js';
 import { generateKnowledgeAssetShareMetadata } from './metadata.js';
 import { storeKnowledgeAssetWorkspaceHead } from './workspace-resolution.js';
 import { workspacePublicQuadsDigest } from './workspace-snapshot-store.js';
-import { validateKnowledgeAssetPublishRequest } from './validation.js';
+import { validateCanonicalGraphScopedKnowledgeAssetPayload } from './validation.js';
 import { ethers } from 'ethers';
 
 type PeerId = { toString(): string };
@@ -2002,7 +2002,7 @@ export class StorageACKHandler {
             `intent=${graphUpdate.publicTripleCount}, local=${publicQuads.length}`,
         );
       }
-      const validation = validateKnowledgeAssetPublishRequest(
+      const validation = validateCanonicalGraphScopedKnowledgeAssetPayload(
         inlineByteLength === undefined
           ? publicQuads.map((quad) => ({ ...quad, graph: swmGraphUri }))
           : publicQuads,
@@ -2014,11 +2014,6 @@ export class StorageACKHandler {
         // unrelated graph.
         inlineByteLength === undefined ? swmGraphUri : inlineVmGraphUri!,
         graphUpdate.publicTripleCount,
-        // ACK verification operates on a canonical graph-scoped payload. The
-        // exact c14n form is legitimate protocol output (for example Markdown
-        // section nodes); the validator still rejects arbitrary/private uses
-        // of the reserved namespace before signing an ACK.
-        { allowCanonicalSkolemTerms: true },
       );
       if (!validation.valid) {
         return this.encodeDecline(

--- a/packages/publisher/src/storage-ack-handler.ts
+++ b/packages/publisher/src/storage-ack-handler.ts
@@ -2014,6 +2014,11 @@ export class StorageACKHandler {
         // unrelated graph.
         inlineByteLength === undefined ? swmGraphUri : inlineVmGraphUri!,
         graphUpdate.publicTripleCount,
+        // ACK verification operates on a canonical graph-scoped payload. The
+        // exact c14n form is legitimate protocol output (for example Markdown
+        // section nodes); the validator still rejects arbitrary/private uses
+        // of the reserved namespace before signing an ACK.
+        { allowCanonicalSkolemTerms: true },
       );
       if (!validation.valid) {
         return this.encodeDecline(

--- a/packages/publisher/src/update-handler.ts
+++ b/packages/publisher/src/update-handler.ts
@@ -620,6 +620,10 @@ export class UpdateHandler {
       parsed,
       vmGraph,
       graphUpdate.publicTripleCount,
+      // The chain-verified graph update contains the sender's already
+      // canonicalized KA. This is required for blank-node-backed structures
+      // such as Markdown sections; non-canonical reserved terms remain denied.
+      { allowCanonicalSkolemTerms: true },
     );
     if (!validation.valid) {
       this.log.warn(

--- a/packages/publisher/src/update-handler.ts
+++ b/packages/publisher/src/update-handler.ts
@@ -24,7 +24,7 @@ import {
 import { decodeKAUpdateRequest } from '@origintrail-official/dkg-core';
 import { parseSimpleNQuads } from './publish-handler.js';
 import { skolemizeByEntity } from './auto-partition.js';
-import { validateKnowledgeAssetPublishRequest } from './validation.js';
+import { validateCanonicalGraphScopedKnowledgeAssetPayload } from './validation.js';
 import { computeTripleHashV10 as computeTripleHash, computeFlatKCRootV10 as computeFlatKCRoot } from './merkle.js';
 import {
   promoteUpdatedKaToPerCgId,
@@ -616,14 +616,10 @@ export class UpdateHandler {
       graphUpdate.subGraphName,
     );
     const metaGraph = contextGraphMetaUri(request.contextGraphId);
-    const validation = validateKnowledgeAssetPublishRequest(
+    const validation = validateCanonicalGraphScopedKnowledgeAssetPayload(
       parsed,
       vmGraph,
       graphUpdate.publicTripleCount,
-      // The chain-verified graph update contains the sender's already
-      // canonicalized KA. This is required for blank-node-backed structures
-      // such as Markdown sections; non-canonical reserved terms remain denied.
-      { allowCanonicalSkolemTerms: true },
     );
     if (!validation.valid) {
       this.log.warn(

--- a/packages/publisher/src/validation.ts
+++ b/packages/publisher/src/validation.ts
@@ -106,6 +106,29 @@ export function validateKnowledgeAssetPublishRequest(
   return { valid: errors.length === 0, errors };
 }
 
+/**
+ * Validate a canonical graph-scoped KA at a trusted protocol boundary.
+ *
+ * Graph-scoped senders canonicalize Markdown and other RDF blank nodes before
+ * transmission, so exact public `urn:dkg:ka-skolem:c14nN` terms are standard
+ * wire data. User-authored input should continue to use the strict validator
+ * above; this named policy keeps receiver/update/ACK call sites consistent
+ * while still rejecting blank nodes and every private, forged, predicate, or
+ * graph use of the reserved namespace.
+ */
+export function validateCanonicalGraphScopedKnowledgeAssetPayload(
+  nquads: readonly Quad[],
+  expectedGraph: string,
+  publicTripleCount: number,
+): ValidationResult {
+  return validateKnowledgeAssetPublishRequest(
+    nquads,
+    expectedGraph,
+    publicTripleCount,
+    { allowCanonicalSkolemTerms: true },
+  );
+}
+
 function isForbiddenKnowledgeAssetSkolemTerm(
   term: string,
   options: { allowCanonicalSkolemTerms?: boolean },

--- a/packages/publisher/src/workspace-handler.ts
+++ b/packages/publisher/src/workspace-handler.ts
@@ -1319,6 +1319,12 @@ export class SharedMemoryHandler {
           quads,
           expectedWireGraph,
           publicTripleCount ?? 0,
+          // Graph-scoped senders canonicalize blank nodes before putting the
+          // complete KA on the wire. Markdown section nodes therefore arrive
+          // as exact protocol-owned c14n IRIs, never as blank nodes. Keep the
+          // narrow canonical form valid here while the validator continues to
+          // reject every other use of the reserved namespace.
+          { allowCanonicalSkolemTerms: true },
         );
         if (!validation.valid) {
           const reason = validation.errors.join('; ');

--- a/packages/publisher/src/workspace-handler.ts
+++ b/packages/publisher/src/workspace-handler.ts
@@ -25,7 +25,7 @@ import {
 } from '@origintrail-official/dkg-core';
 import type { EncryptedWorkspacePayloadMsg, GossipEnvelopeMsg, OperationContext, SwmSenderKeyMessageMsg, WorkspaceCASConditionMsg, WorkspacePublishRequestMsg, WorkspaceRecipientEncryptionKey } from '@origintrail-official/dkg-core';
 import { ethers } from 'ethers';
-import { validateKnowledgeAssetPublishRequest } from './validation.js';
+import { validateCanonicalGraphScopedKnowledgeAssetPayload } from './validation.js';
 import { withKeyedLocks } from './keyed-lock.js';
 import { generateSubGraphRegistration } from './metadata.js';
 import { parseSimpleNQuads } from './publish-handler.js';
@@ -1315,16 +1315,10 @@ export class SharedMemoryHandler {
       onPhase?.('store', 'start');
       const applied = await this.withWriteLocks(lockKeys, async (): Promise<boolean> => {
         onPhase?.('validate', 'start');
-        const validation = validateKnowledgeAssetPublishRequest(
+        const validation = validateCanonicalGraphScopedKnowledgeAssetPayload(
           quads,
           expectedWireGraph,
           publicTripleCount ?? 0,
-          // Graph-scoped senders canonicalize blank nodes before putting the
-          // complete KA on the wire. Markdown section nodes therefore arrive
-          // as exact protocol-owned c14n IRIs, never as blank nodes. Keep the
-          // narrow canonical form valid here while the validator continues to
-          // reject every other use of the reserved namespace.
-          { allowCanonicalSkolemTerms: true },
         );
         if (!validation.valid) {
           const reason = validation.errors.join('; ');

--- a/packages/publisher/test/ka-graph-update-ack.test.ts
+++ b/packages/publisher/test/ka-graph-update-ack.test.ts
@@ -417,6 +417,35 @@ describe('StorageACKHandler graph-scoped updates', () => {
     expect(ack.declineMessage).toContain('newMerkleLeafCount mismatch');
   });
 
+  it('ACKs canonical Markdown section entities from the exact SWM graph', async () => {
+    const store = new OxigraphStore();
+    const section = 'urn:dkg:ka-skolem:c14n0';
+    const quads: Quad[] = [
+      {
+        subject: 'urn:document:construction-notes',
+        predicate: 'http://dkg.io/ontology/hasSection',
+        object: section,
+        graph: EXACT_SWM_GRAPH,
+      },
+      {
+        subject: section,
+        predicate: 'http://schema.org/name',
+        object: '"Safety"',
+        graph: EXACT_SWM_GRAPH,
+      },
+    ];
+    await store.insert(quads);
+    const handler = new StorageACKHandler(
+      store,
+      config(ethers.Wallet.createRandom()),
+      new TypedEventBus(),
+    );
+
+    const ack = decodeStorageACK(await handler.updateHandler(intent(quads, 0), PEER));
+
+    expect(isStorageACKDecline(ack)).toBe(false);
+  });
+
   it('keeps a legacy sub-graph update on the legacy handler', async () => {
     const quad: Quad = {
       subject: 'urn:legacy:entity',
@@ -450,9 +479,9 @@ describe('StorageACKHandler graph-scoped updates', () => {
     expect(isStorageACKDecline(ack)).toBe(false);
   });
 
-  it('declines reserved skolem terms received over the graph-scoped ACK protocol', async () => {
+  it('declines non-canonical reserved skolem terms over the graph-scoped ACK protocol', async () => {
     const malicious: Quad[] = [{
-      subject: 'urn:dkg:ka-skolem:c14n0',
+      subject: 'urn:dkg:ka-skolem:attacker',
       predicate: 'urn:p:value',
       object: '"attacker-authored"',
       graph: EXACT_SWM_GRAPH,

--- a/packages/publisher/test/ka-graph-update-handler.test.ts
+++ b/packages/publisher/test/ka-graph-update-handler.test.ts
@@ -149,6 +149,39 @@ describe('UpdateHandler graph-scoped updates', () => {
     expect(legacyRoots).toMatchObject({ type: 'boolean', value: false });
   });
 
+  it('materializes canonical Markdown section entities from a verified update', async () => {
+    await seedPriorMetadata();
+    const document = 'urn:document:construction-notes';
+    const section = 'urn:dkg:ka-skolem:c14n0';
+    const publicQuads: Quad[] = [
+      {
+        subject: document,
+        predicate: 'http://dkg.io/ontology/hasSection',
+        object: section,
+        graph: '',
+      },
+      {
+        subject: section,
+        predicate: 'http://schema.org/name',
+        object: '"Safety"',
+        graph: '',
+      },
+    ];
+
+    await handler.handle(message(publicQuads), 'forwarding-peer');
+
+    const rows = await store.query(
+      `SELECT ?section ?name WHERE { GRAPH <${vmGraph}> {
+        <${document}> <http://dkg.io/ontology/hasSection> ?section .
+        ?section <http://schema.org/name> ?name .
+      } }`,
+    );
+    expect(rows).toMatchObject({
+      type: 'bindings',
+      bindings: [{ section, name: '"Safety"' }],
+    });
+  });
+
   it('supports a fully private update with no public placeholder triple', async () => {
     await seedPriorMetadata();
     await store.insert([{

--- a/packages/publisher/test/ka-graph-workspace-receiver.test.ts
+++ b/packages/publisher/test/ka-graph-workspace-receiver.test.ts
@@ -92,6 +92,41 @@ describe('SharedMemoryHandler graph-scoped KA receiver', () => {
     expect(meta.quads.filter((quad) => quad.predicate.endsWith('publicQuadsDigest'))).toHaveLength(1);
   });
 
+  it('stores canonical Markdown section entities received over SWM', async () => {
+    const store = new OxigraphStore();
+    const handler = new SharedMemoryHandler(store, new TypedEventBus());
+    const document = 'urn:document:construction-notes';
+    const section = 'urn:dkg:ka-skolem:c14n0';
+    const lines = [
+      `<${document}> <http://dkg.io/ontology/hasSection> <${section}> <${DATA_GRAPH}> .`,
+      `<${section}> <http://schema.org/name> "Safety" <${DATA_GRAPH}> .`,
+    ].join('\n');
+
+    const outcome = await handler.handle(v2Request({
+      nquads: new TextEncoder().encode(lines),
+      publicTripleCount: 2,
+      shareOperationId: 'rootless-markdown-op',
+    }), PEER_ID);
+
+    expect(outcome.applied).toBe(true);
+    if (!outcome.applied) throw new Error(outcome.reason);
+    const swmGraph = knowledgeAssetLayerGraphUri(
+      CONTEXT_GRAPH,
+      MemoryLayer.SharedWorkingMemory,
+      createGraphKnowledgeAssetScope(UAL, 1),
+    );
+    const rows = await store.query(
+      `SELECT ?section ?name WHERE { GRAPH <${swmGraph}> {
+        <${document}> <http://dkg.io/ontology/hasSection> ?section .
+        ?section <http://schema.org/name> ?name .
+      } }`,
+    );
+    expect(rows).toMatchObject({
+      type: 'bindings',
+      bindings: [{ section, name: '"Safety"' }],
+    });
+  });
+
   it('replaces the whole KA graph without leaving prior subjects behind', async () => {
     const store = new OxigraphStore();
     const handler = new SharedMemoryHandler(store, new TypedEventBus());
@@ -335,6 +370,15 @@ describe('SharedMemoryHandler graph-scoped KA receiver', () => {
           ),
         },
         'blank-node subject',
+      ],
+      [
+        'forged-skolem',
+        {
+          nquads: new TextEncoder().encode(
+            `<urn:dkg:ka-skolem:attacker> <urn:predicate:value> "forged" <${DATA_GRAPH}> .`,
+          ),
+        },
+        'reserved KA skolem namespace',
       ],
       [
         'private',

--- a/packages/publisher/test/validation.test.ts
+++ b/packages/publisher/test/validation.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { validatePublishRequest } from '../src/validation.js';
+import {
+  validateCanonicalGraphScopedKnowledgeAssetPayload,
+  validateKnowledgeAssetPublishRequest,
+  validatePublishRequest,
+} from '../src/validation.js';
 import type { KAManifestEntry } from '../src/publisher.js';
 import type { Quad } from '@origintrail-official/dkg-storage';
 
@@ -91,5 +95,40 @@ describe('validatePublishRequest', () => {
     const r = validatePublishRequest(nquads, manifest(root), P, new Set());
     expect(r.valid).toBe(false);
     expect(r.errors.some((e) => e.includes('Rule 5'))).toBe(true);
+  });
+});
+
+describe('canonical graph-scoped KA validation policy', () => {
+  const publicCanonical = 'urn:dkg:ka-skolem:c14n0';
+
+  it('accepts exact public canonical Markdown section terms only at the named wire boundary', () => {
+    const canonical = [quad(
+      'urn:document:1',
+      'http://dkg.io/ontology/hasSection',
+      publicCanonical,
+    ), quad(
+      publicCanonical,
+      'http://schema.org/name',
+      '"Safety"',
+    )];
+
+    expect(validateKnowledgeAssetPublishRequest(canonical, G, 2).valid).toBe(false);
+    expect(validateCanonicalGraphScopedKnowledgeAssetPayload(canonical, G, 2)).toEqual({
+      valid: true,
+      errors: [],
+    });
+  });
+
+  it.each<[string, Quad]>([
+    ['private canonical subject', quad('urn:dkg:ka-skolem:private:c14n0', 'urn:p', '"x"')],
+    ['private canonical object', quad('urn:s', 'urn:p', 'urn:dkg:ka-skolem:private:c14n0')],
+    ['forged reserved subject', quad('urn:dkg:ka-skolem:attacker', 'urn:p', '"x"')],
+    ['reserved predicate', quad('urn:s', publicCanonical, '"x"')],
+    ['reserved graph', quad('urn:s', 'urn:p', '"x"', publicCanonical)],
+    ['blank-node subject', quad('_:section', 'urn:p', '"x"')],
+    ['blank-node object', quad('urn:s', 'urn:p', '_:section')],
+  ])('rejects %s', (_label, malicious) => {
+    const result = validateCanonicalGraphScopedKnowledgeAssetPayload([malicious], G, 1);
+    expect(result.valid).toBe(false);
   });
 });

--- a/packages/publisher/test/workspace-handler-trusted-replay.test.ts
+++ b/packages/publisher/test/workspace-handler-trusted-replay.test.ts
@@ -63,12 +63,15 @@ const HOST_PEER_ID = '12D3KooWHostPeer';
 let store: OxigraphStore;
 let workspaceOwned: Map<string, Map<string, string>>;
 
-function workspaceMessage(name: string, operationId: string, cgId = CONTEXT_GRAPH_ID): Uint8Array {
+function workspaceMessage(
+  name: string,
+  operationId: string,
+  cgId = CONTEXT_GRAPH_ID,
+  nquads = `<${ENTITY}> <http://schema.org/name> "${name}" <${contextGraphDataUri(cgId)}> .`,
+): Uint8Array {
   return encodeRootlessWorkspaceRequest({
     contextGraphId: cgId,
-    nquads: new TextEncoder().encode(
-      `<${ENTITY}> <http://schema.org/name> "${name}" <${contextGraphDataUri(cgId)}> .`,
-    ),
+    nquads: new TextEncoder().encode(nquads),
     publisherPeerId: PUBLISHER_PEER_ID,
     shareOperationId: operationId,
     timestampMs: Date.now(),
@@ -224,6 +227,46 @@ describe('SharedMemoryHandler trustedReplay (LU-6 host-catchup)', () => {
       expect(outcome.publisherPeerId).toBe(PUBLISHER_PEER_ID);
     }
     await expectStoredName('Trusted Replay Valid');
+  });
+
+  it('replays canonical Markdown section entities during host catch-up', async () => {
+    const allowed = ethers.Wallet.createRandom();
+    const recipientKey = recipientKeyFor(allowed.address);
+    const handler = makeHandler({ allowedAgentAddress: allowed.address, recipientKey });
+    await insertPrivateAccessPolicy();
+    await insertAgentGate(DKG_ONTOLOGY.DKG_ALLOWED_AGENT, allowed.address);
+    await insertPeerGate(PUBLISHER_PEER_ID);
+
+    // A restarted member receives this durable host replay after the original
+    // Markdown blank node has already been canonicalized by the publisher.
+    // This is the same reserved section form used by live SWM delivery.
+    const section = 'urn:dkg:ka-skolem:c14n0';
+    const graph = contextGraphDataUri(CONTEXT_GRAPH_ID);
+    const raw = workspaceMessage(
+      'Markdown replay',
+      'ws-trusted-replay-markdown',
+      CONTEXT_GRAPH_ID,
+      [
+        `<${ENTITY}> <http://dkg.io/ontology/hasSection> <${section}> <${graph}> .`,
+        `<${section}> <http://schema.org/name> "Recovered section" <${graph}> .`,
+      ].join('\n'),
+    );
+    const encrypted = await encryptForCg(allowed.address, raw, recipientKey);
+    const wire = await signWorkspaceMessage(allowed, encrypted);
+
+    const outcome = await handler.handle(wire, HOST_PEER_ID, undefined, { trustedReplay: true });
+
+    expect(outcome.applied).toBe(true);
+    if (outcome.applied) expect(outcome.insertedTriples).toBe(2);
+    const result = await store.query(
+      `SELECT ?sectionName WHERE { GRAPH ?g { <${ENTITY}> <http://dkg.io/ontology/hasSection> ?section . ` +
+        `?section <http://schema.org/name> ?sectionName } ` +
+        `FILTER(STRSTARTS(STR(?g), "${WORKSPACE_GRAPH}/")) }`,
+    );
+    expect(result.type).toBe('bindings');
+    if (result.type === 'bindings') {
+      expect(result.bindings).toEqual([{ sectionName: '"Recovered section"' }]);
+    }
   });
 
   it('rejects the same wire bytes without trustedReplay (publisher mismatch + allowlist)', async () => {


### PR DESCRIPTION
## What changed

- Accept exact protocol-generated canonical skolem identifiers at trusted graph-scoped SWM, update, and Storage ACK boundaries while continuing to reject blank nodes and every non-canonical/private use of the reserved namespace.
- Preserve the share operation ID during assertion promotion so receiver ACKs and retries correlate with the imported KA.
- Make interactive UI sharing wait for a private context graph curator to apply the KA before reporting success.
- Add Markdown-specific receiver, two-node replication, update, ACK, and UI entity regressions.

## Root cause

Markdown headings are imported as blank-node section entities and correctly canonicalized during finalization to identifiers such as urn:dkg:ka-skolem:c14n0. The receiving SWM validator treated those protocol-generated identifiers as user-authored reserved terms, rejected all content triples, and left only operation/assertion metadata, which made the KA appear in Assertions while Entities and Triples were empty on peers.

## Validation

- 30/30 focused publisher receiver, update, and Storage ACK tests passed.
- 7/7 assertion lifecycle tests passed, including a real two-node Markdown-shaped SWM replication where the receiver stored and queried all document and section entities.
- 76/76 focused node UI API/entity rendering tests passed.
- 54/54 Markdown extraction tests and 16/16 Markdown import integration tests passed.
- 9/9 graph-scoped publish-storage tests passed, including blank-node canonicalization and VM materialization.
- Publisher, agent, and node UI builds passed with all 11 dependency tasks successful.
- git diff --check passed.

## Security boundary

The exception is limited to the exact lowercase urn:dkg:ka-skolem:c14n<number> form on already-canonical graph-scoped protocol payloads. User-authored blank nodes, arbitrary reserved identifiers, private skolem identifiers in public content, graph mismatches, count mismatches, Merkle mismatches, and publisher/version conflicts remain fail-closed.
