### PR TITLE
fix(publish): let a curator VM-publish a member-shared rootless KA (#1778)

### DIFF
--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -4193,6 +4193,13 @@ export class PublishMethods extends DKGAgentBase {
     },
   ): Promise<KnowledgeAssetVmPublishRequest> {
     const agentAddress = await this.resolveFinalizedAssertionPublishAuthor(contextGraphId, name, opts);
+    // GH#1778 — the ENQUEUING caller (token holder for the route path, or an
+    // explicit author selector for a direct caller), persisted alongside the
+    // resolved author so the async worker stamps the CG curator with the caller
+    // (matching the sync lane), NOT the resolved member author. Left undefined
+    // for a tokenless enqueue so `stampAddressCurator` falls back to the node
+    // default — again exactly as the sync lane does.
+    const callerAgentAddress = opts?.callerAgentAddress ?? opts?.agentAddress;
     const publisher = opts?.publisherOverride ?? this.publisher;
     const history = await this.assertion.history(contextGraphId, name, {
       agentAddress,
@@ -4355,6 +4362,11 @@ export class PublishMethods extends DKGAgentBase {
       contextGraphId,
       name,
       agentAddress,
+      // GH#1778 — carried for caller-scoped async execution (CG-register curator
+      // stamp). Deliberately NOT part of canonicalIntent/intentKey above: the
+      // caller must not fork job dedup, so deduped jobs share one caller (the
+      // first enqueuer), matching the sync lane's first-writer-wins registration.
+      ...(callerAgentAddress ? { callerAgentAddress } : {}),
       ...(opts?.subGraphName ? { subGraphName: opts.subGraphName } : {}),
       shareOperationId,
       roots: [],

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -20,7 +20,6 @@ import {
   contextGraphSharedMemoryUri,
   contextGraphVerifiableMemoryUri, contextGraphVerifiableMemoryMetaUri,
   contextGraphDataUri, contextGraphMetaUri, assertionLifecycleUri, contextGraphAssertionUri,
-  parseContextGraphAssertionUri,
   contextGraphCatalogUri,
   contextGraphLayerUri,
   deriveCuratorDidFromCgId,
@@ -47,8 +46,6 @@ import {
   parseAssertionSealQuads, type AssertionSeal,
   ASSERTION_SEAL_PREDICATES,
   GRAPH_KA_CONTENT_SCOPE_VERSION,
-  validateAssertionName,
-  knowledgeAssetAgentAddressesEqual,
   LegacyKnowledgeAssetReadOnlyError,
   createGraphKnowledgeAssetScope,
   knowledgeAssetLayerGraphUri,
@@ -183,6 +180,7 @@ import {
 } from '@origintrail-official/dkg-query';
 import { DKGAgentWallet, type AgentWallet } from './agent-wallet.js';
 import { sharedMemoryScopeForFinalizedLifecycle } from './finalized-lifecycle-scope.js';
+import { resolveFinalizedAssertionAuthor } from './finalized-assertion-author.js';
 import { RootlessUpdateError, type RootlessUpdateErrorCode } from './rootless-update-error.js';
 
 import { ProfileManager } from './profile-manager.js';
@@ -4101,29 +4099,12 @@ export class PublishMethods extends DKGAgentBase {
   }
 
   /**
-   * GH#1778 — resolve the AUTHOR of a named assertion for VM publish.
-   *
-   * A curator publishes a member-shared rootless KA it did NOT author: the
-   * seal lives in the curator's `_meta` under the member's author coordinate
-   * (`.../assertion/<member>/<name>`), delivered by durable `_meta` sync. The
-   * publish routes, however, only carry the CALLER's token address (a
-   * body-supplied author is deliberately 400-rejected — "the seal already
-   * encodes the author"). So the author must be recovered from stored state,
-   * never from the caller's claim.
-   *
-   * Enumerates the sealed assertion subjects for this (cg, name, subGraph) in
-   * the local `_meta` graph and applies the resolution rule agreed for #1778:
-   *   1. if the CALLER authored a KA of this name → return the caller's own
-   *      (stored-case) address — byte-identical to today's self-publish;
-   *   2. else if exactly one other author has it → return that author;
-   *   3. else if several other authors have it → throw
-   *      `AMBIGUOUS_ASSERTION_AUTHOR` with the candidate list;
-   *   4. else (none finalized) → return `undefined`, so the caller falls back
-   *      to its own address and the existing "is not finalized" error stands.
-   *
-   * The returned address is the EXACT case stored on the seal subject, so the
-   * downstream `contextGraphAssertionUri(...)` re-read hits the same subject
-   * (`contextGraphAssertionUri` does not canonicalise address case).
+   * GH#1778 — resolve the AUTHOR of a named assertion for VM publish, when the
+   * caller may not be the author (a curator publishing a member-shared rootless
+   * KA whose seal was delivered under the member's coordinate by durable sync).
+   * Thin delegate to {@link resolveFinalizedAssertionAuthor}, which owns the
+   * store/URI/EVM lookup so it lives beside the coordinate helpers rather than
+   * in this publish mixin. See that function for the full resolution rule.
    */
   async resolveAssertionAuthor(this: DKGAgent,
     contextGraphId: string,
@@ -4131,60 +4112,12 @@ export class PublishMethods extends DKGAgentBase {
     subGraphName?: string,
     callerAgentAddress?: string,
   ): Promise<string | undefined> {
-    if (!validateAssertionName(name).valid) return undefined;
-    const metaGraph = assertSafeIri(contextGraphMetaUri(contextGraphId));
-    // The seal subject is the author's own assertion coordinate. Bracket the
-    // author segment with an exact prefix + `/<name>` suffix; `name` cannot
-    // contain `/` (validateAssertionName), so STRENDS cannot cross a segment.
-    const prefix = subGraphName
-      ? `did:dkg:context-graph:${contextGraphId}/${subGraphName}/assertion/`
-      : `did:dkg:context-graph:${contextGraphId}/assertion/`;
-    const suffix = `/${name}`;
-    const result = await this.store.query(
-      `SELECT DISTINCT ?s WHERE {
-        GRAPH <${metaGraph}> {
-          ?s <${ASSERTION_SEAL_PREDICATES.ASSERTION_MERKLE_ROOT}> ?root .
-          FILTER(STRSTARTS(STR(?s), "${escapeSparqlLiteral(prefix)}"))
-          FILTER(STRENDS(STR(?s), "${escapeSparqlLiteral(suffix)}"))
-        }
-      }`,
-    );
-    const subjects = result.type === 'bindings'
-      ? result.bindings.map((b) => b.s).filter((s): s is string => typeof s === 'string' && s.length > 0)
-      : [];
-    // Map each seal subject back to its exact-case author segment via the shared
-    // core parser, re-validating cg/subGraph/name (the FILTER already fences the
-    // shape; this keeps a malformed `_meta` row from becoming a publish author).
-    const candidates: string[] = [];
-    for (const subject of subjects) {
-      const coord = parseContextGraphAssertionUri(subject);
-      if (!coord
-        || coord.contextGraphId !== contextGraphId
-        || coord.subGraphName !== subGraphName
-        || coord.name !== name
-        || !/^0x[0-9a-fA-F]{40}$/.test(coord.agentAddress)) continue;
-      candidates.push(coord.agentAddress);
-    }
-    if (candidates.length === 0) return undefined;
-    // 1. Prefer the caller's own KA (preserves today's self-publish exactly).
-    if (callerAgentAddress) {
-      const own = candidates.find((a) => knowledgeAssetAgentAddressesEqual(a, callerAgentAddress));
-      if (own) return own;
-    }
-    // Distinct authors, case-insensitive (guards the known mixed-case _meta hazard).
-    const distinct: string[] = [];
-    for (const author of candidates) {
-      if (!distinct.some((a) => knowledgeAssetAgentAddressesEqual(a, author))) distinct.push(author);
-    }
-    if (distinct.length === 1) return distinct[0];
-    throw Object.assign(
-      new Error(
-        `Cannot publish "${name}" in context graph "${contextGraphId}": ` +
-          `${distinct.length} authors have a knowledge asset with this name. ` +
-          `Publish is unambiguous only for a single author.`,
-      ),
-      { code: 'AMBIGUOUS_ASSERTION_AUTHOR', candidates: distinct },
-    );
+    return resolveFinalizedAssertionAuthor(this.store, {
+      contextGraphId,
+      name,
+      subGraphName,
+      callerAgentAddress,
+    });
   }
 
   /**
@@ -4206,6 +4139,18 @@ export class PublishMethods extends DKGAgentBase {
     name: string,
     opts?: { subGraphName?: string; agentAddress?: string; callerAgentAddress?: string },
   ): Promise<string> {
+    // The two identity fields are mutually exclusive modes: `agentAddress` is an
+    // authoritative author selector, `callerAgentAddress` a resolution hint.
+    // Reject supplying both so the contract is enforced, not just documented.
+    if (opts?.agentAddress && opts?.callerAgentAddress) {
+      throw Object.assign(
+        new Error(
+          'agentAddress (authoritative author selector) and callerAgentAddress ' +
+            '(resolution hint) are mutually exclusive on a VM publish',
+        ),
+        { code: 'PUBLISH_AUTHOR_SELECTION_CONFLICT' },
+      );
+    }
     if (opts?.agentAddress) return opts.agentAddress;
     const callerHint = opts?.callerAgentAddress ?? this.defaultAgentAddress ?? this.peerId;
     return (await this.resolveAssertionAuthor(

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -46,6 +46,8 @@ import {
   parseAssertionSealQuads, type AssertionSeal,
   ASSERTION_SEAL_PREDICATES,
   GRAPH_KA_CONTENT_SCOPE_VERSION,
+  validateAssertionName,
+  knowledgeAssetAgentAddressesEqual,
   LegacyKnowledgeAssetReadOnlyError,
   createGraphKnowledgeAssetScope,
   knowledgeAssetLayerGraphUri,
@@ -4098,6 +4100,90 @@ export class PublishMethods extends DKGAgentBase {
   }
 
   /**
+   * GH#1778 — resolve the AUTHOR of a named assertion for VM publish.
+   *
+   * A curator publishes a member-shared rootless KA it did NOT author: the
+   * seal lives in the curator's `_meta` under the member's author coordinate
+   * (`.../assertion/<member>/<name>`), delivered by durable `_meta` sync. The
+   * publish routes, however, only carry the CALLER's token address (a
+   * body-supplied author is deliberately 400-rejected — "the seal already
+   * encodes the author"). So the author must be recovered from stored state,
+   * never from the caller's claim.
+   *
+   * Enumerates the sealed assertion subjects for this (cg, name, subGraph) in
+   * the local `_meta` graph and applies the resolution rule agreed for #1778:
+   *   1. if the CALLER authored a KA of this name → return the caller's own
+   *      (stored-case) address — byte-identical to today's self-publish;
+   *   2. else if exactly one other author has it → return that author;
+   *   3. else if several other authors have it → throw
+   *      `AMBIGUOUS_ASSERTION_AUTHOR` with the candidate list;
+   *   4. else (none finalized) → return `undefined`, so the caller falls back
+   *      to its own address and the existing "is not finalized" error stands.
+   *
+   * The returned address is the EXACT case stored on the seal subject, so the
+   * downstream `contextGraphAssertionUri(...)` re-read hits the same subject
+   * (`contextGraphAssertionUri` does not canonicalise address case).
+   */
+  async resolveAssertionAuthor(this: DKGAgent,
+    contextGraphId: string,
+    name: string,
+    subGraphName?: string,
+    callerAgentAddress?: string,
+  ): Promise<string | undefined> {
+    if (!validateAssertionName(name).valid) return undefined;
+    const metaGraph = assertSafeIri(contextGraphMetaUri(contextGraphId));
+    // The seal subject is the author's own assertion coordinate. Bracket the
+    // author segment with an exact prefix + `/<name>` suffix; `name` cannot
+    // contain `/` (validateAssertionName), so STRENDS cannot cross a segment.
+    const prefix = subGraphName
+      ? `did:dkg:context-graph:${contextGraphId}/${subGraphName}/assertion/`
+      : `did:dkg:context-graph:${contextGraphId}/assertion/`;
+    const suffix = `/${name}`;
+    const result = await this.store.query(
+      `SELECT DISTINCT ?s WHERE {
+        GRAPH <${metaGraph}> {
+          ?s <${ASSERTION_SEAL_PREDICATES.ASSERTION_MERKLE_ROOT}> ?root .
+          FILTER(STRSTARTS(STR(?s), "${escapeSparqlLiteral(prefix)}"))
+          FILTER(STRENDS(STR(?s), "${escapeSparqlLiteral(suffix)}"))
+        }
+      }`,
+    );
+    const subjects = result.type === 'bindings'
+      ? result.bindings.map((b) => b.s).filter((s): s is string => typeof s === 'string' && s.length > 0)
+      : [];
+    // Map each seal subject back to its exact-case author segment, and reject
+    // any subject whose author segment is not a well-formed 0x address (the
+    // FILTER prefix/suffix already fence the shape, but keep it defensive so a
+    // malformed `_meta` row cannot become a publish author).
+    const candidates: string[] = [];
+    for (const subject of subjects) {
+      if (!subject.startsWith(prefix) || !subject.endsWith(suffix)) continue;
+      const author = subject.slice(prefix.length, subject.length - suffix.length);
+      if (/^0x[0-9a-fA-F]{40}$/.test(author)) candidates.push(author);
+    }
+    if (candidates.length === 0) return undefined;
+    // 1. Prefer the caller's own KA (preserves today's self-publish exactly).
+    if (callerAgentAddress) {
+      const own = candidates.find((a) => knowledgeAssetAgentAddressesEqual(a, callerAgentAddress));
+      if (own) return own;
+    }
+    // Distinct authors, case-insensitive (guards the known mixed-case _meta hazard).
+    const distinct: string[] = [];
+    for (const author of candidates) {
+      if (!distinct.some((a) => knowledgeAssetAgentAddressesEqual(a, author))) distinct.push(author);
+    }
+    if (distinct.length === 1) return distinct[0];
+    throw Object.assign(
+      new Error(
+        `Cannot publish "${name}" in context graph "${contextGraphId}": ` +
+          `${distinct.length} authors have a knowledge asset with this name. ` +
+          `Publish is unambiguous only for a single author.`,
+      ),
+      { code: 'AMBIGUOUS_ASSERTION_AUTHOR', candidates: distinct },
+    );
+  }
+
+  /**
    * RFC-001 §9.x — publish a previously-finalized assertion to the
    * verifiable-memory chain.
    *
@@ -4129,7 +4215,16 @@ export class PublishMethods extends DKGAgentBase {
       publisherOverride?: DKGPublisher;
     },
   ): Promise<KnowledgeAssetVmPublishRequest> {
-    const agentAddress = opts?.agentAddress ?? this.defaultAgentAddress ?? this.peerId;
+    // GH#1778 — resolve the KA author from stored `_meta` (a curator publishes
+    // a member-authored share; the caller's token address is not the author).
+    // The caller hint is the EFFECTIVE publish identity (token → default agent →
+    // peer), so a node that also self-authored this name still prefers its OWN
+    // KA on the tokenless path; falls back to that same identity when nothing is
+    // finalized, preserving the existing "is not finalized"/self-publish behaviour.
+    const callerAgentAddress = opts?.agentAddress ?? this.defaultAgentAddress ?? this.peerId;
+    const agentAddress = (await this.resolveAssertionAuthor(
+      contextGraphId, name, opts?.subGraphName, callerAgentAddress,
+    )) ?? callerAgentAddress;
     const publisher = opts?.publisherOverride ?? this.publisher;
     const history = await this.assertion.history(contextGraphId, name, {
       agentAddress,
@@ -5342,7 +5437,16 @@ export class PublishMethods extends DKGAgentBase {
       publisherOverride?: DKGPublisher;
     },
   ): Promise<PublishResult & { assertionUri: string; seal: AssertionSeal }> {
-    const agentAddress = opts?.agentAddress ?? this.defaultAgentAddress ?? this.peerId;
+    // GH#1778 — resolve the KA author from stored `_meta` (a curator publishes
+    // a member-authored share; the caller's token address is not the author).
+    // The caller hint is the EFFECTIVE publish identity (token → default agent →
+    // peer), so a node that also self-authored this name still prefers its OWN
+    // KA on the tokenless path; falls back to that same identity when nothing is
+    // finalized, preserving the existing "is not finalized"/self-publish behaviour.
+    const callerAgentAddress = opts?.agentAddress ?? this.defaultAgentAddress ?? this.peerId;
+    const agentAddress = (await this.resolveAssertionAuthor(
+      contextGraphId, name, opts?.subGraphName, callerAgentAddress,
+    )) ?? callerAgentAddress;
     const publisher = opts?.publisherOverride ?? this.publisher;
     const assertionUri = contextGraphAssertionUri(
       contextGraphId,

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -4193,10 +4193,6 @@ export class PublishMethods extends DKGAgentBase {
     },
   ): Promise<KnowledgeAssetVmPublishRequest> {
     const agentAddress = await this.resolveFinalizedAssertionPublishAuthor(contextGraphId, name, opts);
-    // GH#1778 — carry the CALLER identity separately from the resolved author,
-    // so the async job registers an unregistered CG under the operator's own
-    // identity (not the KA author's). Mirrors the effective publish identity.
-    const callerAgentAddress = opts?.callerAgentAddress ?? opts?.agentAddress ?? this.defaultAgentAddress ?? this.peerId;
     const publisher = opts?.publisherOverride ?? this.publisher;
     const history = await this.assertion.history(contextGraphId, name, {
       agentAddress,
@@ -4359,9 +4355,6 @@ export class PublishMethods extends DKGAgentBase {
       contextGraphId,
       name,
       agentAddress,
-      // GH#1778 — NOT in canonicalIntent/intentKey (caller must not fork job
-      // identity/dedup); carried only for caller-scoped async execution.
-      ...(callerAgentAddress ? { callerAgentAddress } : {}),
       ...(opts?.subGraphName ? { subGraphName: opts.subGraphName } : {}),
       shareOperationId,
       roots: [],

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -20,6 +20,7 @@ import {
   contextGraphSharedMemoryUri,
   contextGraphVerifiableMemoryUri, contextGraphVerifiableMemoryMetaUri,
   contextGraphDataUri, contextGraphMetaUri, assertionLifecycleUri, contextGraphAssertionUri,
+  parseContextGraphAssertionUri,
   contextGraphCatalogUri,
   contextGraphLayerUri,
   deriveCuratorDidFromCgId,
@@ -4151,15 +4152,18 @@ export class PublishMethods extends DKGAgentBase {
     const subjects = result.type === 'bindings'
       ? result.bindings.map((b) => b.s).filter((s): s is string => typeof s === 'string' && s.length > 0)
       : [];
-    // Map each seal subject back to its exact-case author segment, and reject
-    // any subject whose author segment is not a well-formed 0x address (the
-    // FILTER prefix/suffix already fence the shape, but keep it defensive so a
-    // malformed `_meta` row cannot become a publish author).
+    // Map each seal subject back to its exact-case author segment via the shared
+    // core parser, re-validating cg/subGraph/name (the FILTER already fences the
+    // shape; this keeps a malformed `_meta` row from becoming a publish author).
     const candidates: string[] = [];
     for (const subject of subjects) {
-      if (!subject.startsWith(prefix) || !subject.endsWith(suffix)) continue;
-      const author = subject.slice(prefix.length, subject.length - suffix.length);
-      if (/^0x[0-9a-fA-F]{40}$/.test(author)) candidates.push(author);
+      const coord = parseContextGraphAssertionUri(subject);
+      if (!coord
+        || coord.contextGraphId !== contextGraphId
+        || coord.subGraphName !== subGraphName
+        || coord.name !== name
+        || !/^0x[0-9a-fA-F]{40}$/.test(coord.agentAddress)) continue;
+      candidates.push(coord.agentAddress);
     }
     if (candidates.length === 0) return undefined;
     // 1. Prefer the caller's own KA (preserves today's self-publish exactly).
@@ -4181,6 +4185,32 @@ export class PublishMethods extends DKGAgentBase {
       ),
       { code: 'AMBIGUOUS_ASSERTION_AUTHOR', candidates: distinct },
     );
+  }
+
+  /**
+   * GH#1778 — pick the author identity for a VM publish, shared by both the
+   * sync and async publish entry points so their policy cannot drift.
+   *
+   * `opts.agentAddress` is an AUTHORITATIVE author selector for direct
+   * programmatic callers: when set, exactly that author is published and it is
+   * NEVER silently substituted by a different same-named author (a mismatch
+   * simply falls through to the existing "is not finalized"). The daemon
+   * publish routes instead pass `opts.callerAgentAddress` (the token/caller
+   * identity) and leave the author to be resolved from stored `_meta` — that is
+   * the curator-publishes-a-member-KA flow. With neither, the effective node
+   * identity (default agent → peer) is the caller hint, and resolution prefers
+   * the node's OWN same-named KA before any resident foreign seal.
+   */
+  async resolveFinalizedAssertionPublishAuthor(this: DKGAgent,
+    contextGraphId: string,
+    name: string,
+    opts?: { subGraphName?: string; agentAddress?: string; callerAgentAddress?: string },
+  ): Promise<string> {
+    if (opts?.agentAddress) return opts.agentAddress;
+    const callerHint = opts?.callerAgentAddress ?? this.defaultAgentAddress ?? this.peerId;
+    return (await this.resolveAssertionAuthor(
+      contextGraphId, name, opts?.subGraphName, callerHint,
+    )) ?? callerHint;
   }
 
   /**
@@ -4206,6 +4236,8 @@ export class PublishMethods extends DKGAgentBase {
     opts?: {
       subGraphName?: string;
       agentAddress?: string;
+      /** GH#1778 — token/caller identity hint (routes); NOT an author selector. */
+      callerAgentAddress?: string;
       publishEpochs?: number;
       clearSharedMemoryAfter?: boolean;
       accessPolicy?: 'public' | 'ownerOnly' | 'allowList';
@@ -4215,16 +4247,7 @@ export class PublishMethods extends DKGAgentBase {
       publisherOverride?: DKGPublisher;
     },
   ): Promise<KnowledgeAssetVmPublishRequest> {
-    // GH#1778 — resolve the KA author from stored `_meta` (a curator publishes
-    // a member-authored share; the caller's token address is not the author).
-    // The caller hint is the EFFECTIVE publish identity (token → default agent →
-    // peer), so a node that also self-authored this name still prefers its OWN
-    // KA on the tokenless path; falls back to that same identity when nothing is
-    // finalized, preserving the existing "is not finalized"/self-publish behaviour.
-    const callerAgentAddress = opts?.agentAddress ?? this.defaultAgentAddress ?? this.peerId;
-    const agentAddress = (await this.resolveAssertionAuthor(
-      contextGraphId, name, opts?.subGraphName, callerAgentAddress,
-    )) ?? callerAgentAddress;
+    const agentAddress = await this.resolveFinalizedAssertionPublishAuthor(contextGraphId, name, opts);
     const publisher = opts?.publisherOverride ?? this.publisher;
     const history = await this.assertion.history(contextGraphId, name, {
       agentAddress,
@@ -5429,6 +5452,8 @@ export class PublishMethods extends DKGAgentBase {
     opts?: {
       subGraphName?: string;
       agentAddress?: string;
+      /** GH#1778 — token/caller identity hint (routes); NOT an author selector. */
+      callerAgentAddress?: string;
       operationCtx?: OperationContext;
       onPhase?: PhaseCallback;
       publisherNodeIdentityIdOverride?: bigint;
@@ -5437,16 +5462,7 @@ export class PublishMethods extends DKGAgentBase {
       publisherOverride?: DKGPublisher;
     },
   ): Promise<PublishResult & { assertionUri: string; seal: AssertionSeal }> {
-    // GH#1778 — resolve the KA author from stored `_meta` (a curator publishes
-    // a member-authored share; the caller's token address is not the author).
-    // The caller hint is the EFFECTIVE publish identity (token → default agent →
-    // peer), so a node that also self-authored this name still prefers its OWN
-    // KA on the tokenless path; falls back to that same identity when nothing is
-    // finalized, preserving the existing "is not finalized"/self-publish behaviour.
-    const callerAgentAddress = opts?.agentAddress ?? this.defaultAgentAddress ?? this.peerId;
-    const agentAddress = (await this.resolveAssertionAuthor(
-      contextGraphId, name, opts?.subGraphName, callerAgentAddress,
-    )) ?? callerAgentAddress;
+    const agentAddress = await this.resolveFinalizedAssertionPublishAuthor(contextGraphId, name, opts);
     const publisher = opts?.publisherOverride ?? this.publisher;
     const assertionUri = contextGraphAssertionUri(
       contextGraphId,

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -4193,6 +4193,10 @@ export class PublishMethods extends DKGAgentBase {
     },
   ): Promise<KnowledgeAssetVmPublishRequest> {
     const agentAddress = await this.resolveFinalizedAssertionPublishAuthor(contextGraphId, name, opts);
+    // GH#1778 — carry the CALLER identity separately from the resolved author,
+    // so the async job registers an unregistered CG under the operator's own
+    // identity (not the KA author's). Mirrors the effective publish identity.
+    const callerAgentAddress = opts?.callerAgentAddress ?? opts?.agentAddress ?? this.defaultAgentAddress ?? this.peerId;
     const publisher = opts?.publisherOverride ?? this.publisher;
     const history = await this.assertion.history(contextGraphId, name, {
       agentAddress,
@@ -4355,6 +4359,9 @@ export class PublishMethods extends DKGAgentBase {
       contextGraphId,
       name,
       agentAddress,
+      // GH#1778 — NOT in canonicalIntent/intentKey (caller must not fork job
+      // identity/dedup); carried only for caller-scoped async execution.
+      ...(callerAgentAddress ? { callerAgentAddress } : {}),
       ...(opts?.subGraphName ? { subGraphName: opts.subGraphName } : {}),
       shareOperationId,
       roots: [],

--- a/packages/agent/src/finalized-assertion-author.ts
+++ b/packages/agent/src/finalized-assertion-author.ts
@@ -1,0 +1,106 @@
+import {
+  ASSERTION_SEAL_PREDICATES,
+  assertSafeIri,
+  contextGraphMetaUri,
+  escapeSparqlLiteral,
+  knowledgeAssetAgentAddressesEqual,
+  parseContextGraphAssertionUri,
+  validateAssertionName,
+} from '@origintrail-official/dkg-core';
+
+/** Minimal structural view of the store this resolver needs. */
+export interface AssertionAuthorQueryStore {
+  query(sparql: string): Promise<{ type: string; bindings?: ReadonlyArray<Record<string, string>> }>;
+}
+
+export interface ResolveFinalizedAssertionAuthorParams {
+  contextGraphId: string;
+  name: string;
+  subGraphName?: string;
+  /**
+   * The effective caller identity (VM publish routes pass the token holder;
+   * direct callers may omit it). NOT an author selector — see
+   * `resolveFinalizedAssertionPublishAuthor` for the selector-vs-hint split.
+   */
+  callerAgentAddress?: string;
+}
+
+/**
+ * GH#1778 — resolve the AUTHOR of a named, finalized assertion from the local
+ * `_meta` graph, for a VM publish where the caller may not be the author (a
+ * curator publishing a member-shared rootless KA). Kept in a focused module,
+ * not the large publish mixin, so the store/URI/EVM lookup lives beside the
+ * coordinate helpers it depends on.
+ *
+ * Resolution order:
+ *   1. if the caller authored a KA of this name → the caller's own (stored-case)
+ *      address, so self-publish is byte-identical to before;
+ *   2. else if exactly one other author has it → that author;
+ *   3. else if several other authors have it → throw `AMBIGUOUS_ASSERTION_AUTHOR`
+ *      with the candidate list;
+ *   4. else (none finalized) → `undefined`, so the caller falls back to its own
+ *      address and the existing "is not finalized" error stands.
+ *
+ * The returned address is the EXACT case stored on the seal subject, so a
+ * downstream `contextGraphAssertionUri(...)` re-read hits the same subject
+ * (`contextGraphAssertionUri` does not canonicalise address case).
+ */
+export async function resolveFinalizedAssertionAuthor(
+  store: AssertionAuthorQueryStore,
+  { contextGraphId, name, subGraphName, callerAgentAddress }: ResolveFinalizedAssertionAuthorParams,
+): Promise<string | undefined> {
+  if (!validateAssertionName(name).valid) return undefined;
+  const metaGraph = assertSafeIri(contextGraphMetaUri(contextGraphId));
+  // The seal subject is the author's own assertion coordinate. Bracket the
+  // author segment with an exact prefix + `/<name>` suffix; `name` cannot
+  // contain `/` (validateAssertionName), so STRENDS cannot cross a segment. The
+  // prefix carries the full contextGraphId verbatim, so a slash-containing cg id
+  // is matched correctly server-side.
+  const prefix = subGraphName
+    ? `did:dkg:context-graph:${contextGraphId}/${subGraphName}/assertion/`
+    : `did:dkg:context-graph:${contextGraphId}/assertion/`;
+  const suffix = `/${name}`;
+  const result = await store.query(
+    `SELECT DISTINCT ?s WHERE {
+      GRAPH <${metaGraph}> {
+        ?s <${ASSERTION_SEAL_PREDICATES.ASSERTION_MERKLE_ROOT}> ?root .
+        FILTER(STRSTARTS(STR(?s), "${escapeSparqlLiteral(prefix)}"))
+        FILTER(STRENDS(STR(?s), "${escapeSparqlLiteral(suffix)}"))
+      }
+    }`,
+  );
+  const subjects = result.type === 'bindings'
+    ? (result.bindings ?? []).map((b) => b.s).filter((s): s is string => typeof s === 'string' && s.length > 0)
+    : [];
+  // Map each seal subject back to its exact-case author segment via the shared
+  // core parser, re-validating scope/name. `scope` is compared as a whole so a
+  // slash-containing contextGraphId is preserved (the parser cannot split cg
+  // from subGraph, and must not try).
+  const expectedScope = subGraphName ? `${contextGraphId}/${subGraphName}` : contextGraphId;
+  const candidates: string[] = [];
+  for (const subject of subjects) {
+    const coord = parseContextGraphAssertionUri(subject);
+    if (!coord || coord.scope !== expectedScope || coord.name !== name) continue;
+    candidates.push(coord.agentAddress);
+  }
+  if (candidates.length === 0) return undefined;
+  // 1. Prefer the caller's own KA (preserves today's self-publish exactly).
+  if (callerAgentAddress) {
+    const own = candidates.find((a) => knowledgeAssetAgentAddressesEqual(a, callerAgentAddress));
+    if (own) return own;
+  }
+  // Distinct authors, case-insensitive (guards the known mixed-case _meta hazard).
+  const distinct: string[] = [];
+  for (const author of candidates) {
+    if (!distinct.some((a) => knowledgeAssetAgentAddressesEqual(a, author))) distinct.push(author);
+  }
+  if (distinct.length === 1) return distinct[0];
+  throw Object.assign(
+    new Error(
+      `Cannot publish "${name}" in context graph "${contextGraphId}": ` +
+        `${distinct.length} authors have a knowledge asset with this name. ` +
+        `Publish is unambiguous only for a single author.`,
+    ),
+    { code: 'AMBIGUOUS_ASSERTION_AUTHOR', candidates: distinct },
+  );
+}

--- a/packages/agent/src/finalized-assertion-author.ts
+++ b/packages/agent/src/finalized-assertion-author.ts
@@ -1,13 +1,11 @@
 import {
   ASSERTION_SEAL_PREDICATES,
-  GRAPH_KA_CONTENT_SCOPE_VERSION,
   assertSafeIri,
   contextGraphAssertionQueryBounds,
   contextGraphMetaUri,
   escapeSparqlLiteral,
   knowledgeAssetAgentAddressesEqual,
-  parseAssertionSealQuads,
-  parseContextGraphAssertionUri,
+  parseGraphScopedAssertionSealCandidate,
   validateAssertionName,
 } from '@origintrail-official/dkg-core';
 
@@ -86,21 +84,18 @@ export async function resolveFinalizedAssertionAuthor(
       else rowsBySubject.set(quad.subject, [quad]);
     }
   }
-  // Admit only subjects whose rows parse as a COMPLETE graph-scoped v2 seal —
-  // the exact check publish performs — so a resolved author is always
-  // publishable and a partial/corrupt subject is treated as not-finalized.
+  // Admit only subjects that are a complete, self-consistent graph-scoped seal —
+  // the SAME canonical definition durable-sync uses (`parseGraphScopedAssertionSealCandidate`):
+  // a partial/corrupt subject, or a complete seal whose `authorAddress`/`kaUal`
+  // disagree with its `/assertion/<addr>/…` coordinate, is NOT a publish
+  // candidate (it is treated as not-finalized rather than silently trusted).
   const candidates: string[] = [];
   for (const [subject, rows] of rowsBySubject) {
-    const coord = parseContextGraphAssertionUri(subject);
-    if (!coord || coord.scope !== expectedScope || coord.name !== name) continue;
-    let seal;
-    try {
-      seal = parseAssertionSealQuads(rows, subject);
-    } catch {
-      continue; // partial/corrupt seal — not a publish candidate
-    }
-    if (!seal || seal.contentScopeVersion !== GRAPH_KA_CONTENT_SCOPE_VERSION) continue;
-    candidates.push(coord.agentAddress);
+    const candidate = parseGraphScopedAssertionSealCandidate(rows, subject);
+    if (!candidate
+      || candidate.coordinate.scope !== expectedScope
+      || candidate.coordinate.name !== name) continue;
+    candidates.push(candidate.coordinate.agentAddress);
   }
   if (candidates.length === 0) return undefined;
   // 1. Prefer the caller's own KA (preserves today's self-publish exactly).

--- a/packages/agent/src/finalized-assertion-author.ts
+++ b/packages/agent/src/finalized-assertion-author.ts
@@ -1,6 +1,7 @@
 import {
   ASSERTION_SEAL_PREDICATES,
   assertSafeIri,
+  contextGraphAssertionQueryBounds,
   contextGraphMetaUri,
   escapeSparqlLiteral,
   knowledgeAssetAgentAddressesEqual,
@@ -51,15 +52,12 @@ export async function resolveFinalizedAssertionAuthor(
 ): Promise<string | undefined> {
   if (!validateAssertionName(name).valid) return undefined;
   const metaGraph = assertSafeIri(contextGraphMetaUri(contextGraphId));
-  // The seal subject is the author's own assertion coordinate. Bracket the
-  // author segment with an exact prefix + `/<name>` suffix; `name` cannot
-  // contain `/` (validateAssertionName), so STRENDS cannot cross a segment. The
-  // prefix carries the full contextGraphId verbatim, so a slash-containing cg id
-  // is matched correctly server-side.
-  const prefix = subGraphName
-    ? `did:dkg:context-graph:${contextGraphId}/${subGraphName}/assertion/`
-    : `did:dkg:context-graph:${contextGraphId}/assertion/`;
-  const suffix = `/${name}`;
+  // Bound the query by the canonical assertion-coordinate grammar (the core
+  // helper owns the URI layout; `name` cannot contain `/`, so the suffix cannot
+  // cross a segment, and the prefix carries a slash-containing cg id verbatim).
+  const { scope: expectedScope, prefix, suffix } = contextGraphAssertionQueryBounds(
+    contextGraphId, name, subGraphName,
+  );
   const result = await store.query(
     `SELECT DISTINCT ?s WHERE {
       GRAPH <${metaGraph}> {
@@ -73,10 +71,7 @@ export async function resolveFinalizedAssertionAuthor(
     ? (result.bindings ?? []).map((b) => b.s).filter((s): s is string => typeof s === 'string' && s.length > 0)
     : [];
   // Map each seal subject back to its exact-case author segment via the shared
-  // core parser, re-validating scope/name. `scope` is compared as a whole so a
-  // slash-containing contextGraphId is preserved (the parser cannot split cg
-  // from subGraph, and must not try).
-  const expectedScope = subGraphName ? `${contextGraphId}/${subGraphName}` : contextGraphId;
+  // core parser, re-validating scope/name against the query bounds.
   const candidates: string[] = [];
   for (const subject of subjects) {
     const coord = parseContextGraphAssertionUri(subject);

--- a/packages/agent/src/finalized-assertion-author.ts
+++ b/packages/agent/src/finalized-assertion-author.ts
@@ -1,17 +1,21 @@
 import {
   ASSERTION_SEAL_PREDICATES,
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
   assertSafeIri,
   contextGraphAssertionQueryBounds,
   contextGraphMetaUri,
   escapeSparqlLiteral,
   knowledgeAssetAgentAddressesEqual,
+  parseAssertionSealQuads,
   parseContextGraphAssertionUri,
   validateAssertionName,
 } from '@origintrail-official/dkg-core';
 
+type SealQuad = { subject: string; predicate: string; object: string };
+
 /** Minimal structural view of the store this resolver needs. */
 export interface AssertionAuthorQueryStore {
-  query(sparql: string): Promise<{ type: string; bindings?: ReadonlyArray<Record<string, string>> }>;
+  query(sparql: string): Promise<{ type: string; quads?: ReadonlyArray<SealQuad> }>;
 }
 
 export interface ResolveFinalizedAssertionAuthorParams {
@@ -58,24 +62,44 @@ export async function resolveFinalizedAssertionAuthor(
   const { scope: expectedScope, prefix, suffix } = contextGraphAssertionQueryBounds(
     contextGraphId, name, subGraphName,
   );
+  // Fetch the FULL `_meta` rows of every subject at this name coordinate that
+  // carries a Merkle root, so each candidate can be validated against a complete
+  // seal before it influences selection. `assertionMerkleRoot` alone is NOT
+  // proof of a publishable assertion — durable `_meta` may hold stale/partial
+  // rows or unauthenticated fragments, and counting those would either false-409
+  // a legitimate publish or select an unusable author (GH#1778 review).
   const result = await store.query(
-    `SELECT DISTINCT ?s WHERE {
+    `CONSTRUCT { ?s ?p ?o } WHERE {
       GRAPH <${metaGraph}> {
         ?s <${ASSERTION_SEAL_PREDICATES.ASSERTION_MERKLE_ROOT}> ?root .
+        ?s ?p ?o .
         FILTER(STRSTARTS(STR(?s), "${escapeSparqlLiteral(prefix)}"))
         FILTER(STRENDS(STR(?s), "${escapeSparqlLiteral(suffix)}"))
       }
     }`,
   );
-  const subjects = result.type === 'bindings'
-    ? (result.bindings ?? []).map((b) => b.s).filter((s): s is string => typeof s === 'string' && s.length > 0)
-    : [];
-  // Map each seal subject back to its exact-case author segment via the shared
-  // core parser, re-validating scope/name against the query bounds.
+  const rowsBySubject = new Map<string, SealQuad[]>();
+  if (result.type === 'quads') {
+    for (const quad of result.quads ?? []) {
+      const rows = rowsBySubject.get(quad.subject);
+      if (rows) rows.push(quad);
+      else rowsBySubject.set(quad.subject, [quad]);
+    }
+  }
+  // Admit only subjects whose rows parse as a COMPLETE graph-scoped v2 seal —
+  // the exact check publish performs — so a resolved author is always
+  // publishable and a partial/corrupt subject is treated as not-finalized.
   const candidates: string[] = [];
-  for (const subject of subjects) {
+  for (const [subject, rows] of rowsBySubject) {
     const coord = parseContextGraphAssertionUri(subject);
     if (!coord || coord.scope !== expectedScope || coord.name !== name) continue;
+    let seal;
+    try {
+      seal = parseAssertionSealQuads(rows, subject);
+    } catch {
+      continue; // partial/corrupt seal — not a publish candidate
+    }
+    if (!seal || seal.contentScopeVersion !== GRAPH_KA_CONTENT_SCOPE_VERSION) continue;
     candidates.push(coord.agentAddress);
   }
   if (candidates.length === 0) return undefined;

--- a/packages/agent/src/finalized-assertion-author.ts
+++ b/packages/agent/src/finalized-assertion-author.ts
@@ -13,7 +13,11 @@ type SealQuad = { subject: string; predicate: string; object: string };
 
 /** Minimal structural view of the store this resolver needs. */
 export interface AssertionAuthorQueryStore {
-  query(sparql: string): Promise<{ type: string; quads?: ReadonlyArray<SealQuad> }>;
+  query(sparql: string): Promise<{
+    type: string;
+    bindings?: ReadonlyArray<Record<string, string>>;
+    quads?: ReadonlyArray<SealQuad>;
+  }>;
 }
 
 export interface ResolveFinalizedAssertionAuthorParams {
@@ -60,37 +64,42 @@ export async function resolveFinalizedAssertionAuthor(
   const { scope: expectedScope, prefix, suffix } = contextGraphAssertionQueryBounds(
     contextGraphId, name, subGraphName,
   );
-  // Fetch the FULL `_meta` rows of every subject at this name coordinate that
-  // carries a Merkle root, so each candidate can be validated against a complete
-  // seal before it influences selection. `assertionMerkleRoot` alone is NOT
-  // proof of a publishable assertion — durable `_meta` may hold stale/partial
-  // rows or unauthenticated fragments, and counting those would either false-409
-  // a legitimate publish or select an unusable author (GH#1778 review).
-  const result = await store.query(
-    `CONSTRUCT { ?s ?p ?o } WHERE {
+  // Phase 1 — find the candidate seal subject(s) at this name coordinate. This
+  // is a bound-predicate lookup fenced by the exact coordinate prefix/suffix
+  // (NOT an all-variable `?s ?p ?o` scan of the growing `_meta` graph), and the
+  // result is the ~1 subject finalized under this name.
+  const subjectsResult = await store.query(
+    `SELECT DISTINCT ?s WHERE {
       GRAPH <${metaGraph}> {
         ?s <${ASSERTION_SEAL_PREDICATES.ASSERTION_MERKLE_ROOT}> ?root .
-        ?s ?p ?o .
         FILTER(STRSTARTS(STR(?s), "${escapeSparqlLiteral(prefix)}"))
         FILTER(STRENDS(STR(?s), "${escapeSparqlLiteral(suffix)}"))
       }
     }`,
   );
-  const rowsBySubject = new Map<string, SealQuad[]>();
-  if (result.type === 'quads') {
-    for (const quad of result.quads ?? []) {
-      const rows = rowsBySubject.get(quad.subject);
-      if (rows) rows.push(quad);
-      else rowsBySubject.set(quad.subject, [quad]);
-    }
-  }
-  // Admit only subjects that are a complete, self-consistent graph-scoped seal —
-  // the SAME canonical definition durable-sync uses (`parseGraphScopedAssertionSealCandidate`):
-  // a partial/corrupt subject, or a complete seal whose `authorAddress`/`kaUal`
-  // disagree with its `/assertion/<addr>/…` coordinate, is NOT a publish
-  // candidate (it is treated as not-finalized rather than silently trusted).
+  const subjects = subjectsResult.type === 'bindings'
+    ? (subjectsResult.bindings ?? []).map((b) => b.s).filter((s): s is string => typeof s === 'string' && s.length > 0)
+    : [];
+
+  // Phase 2 — read each candidate's rows by EXACT subject (a bounded per-subject
+  // read, not a graph scan) and admit only a complete, self-consistent
+  // graph-scoped seal — the SAME canonical definition durable-sync uses
+  // (`parseGraphScopedAssertionSealCandidate`). `assertionMerkleRoot` alone is
+  // NOT proof of a publishable assertion: a partial/corrupt subject, or a
+  // complete seal whose `authorAddress`/`kaUal` disagree with its
+  // `/assertion/<addr>/…` coordinate, is treated as not-finalized (GH#1778 review).
   const candidates: string[] = [];
-  for (const [subject, rows] of rowsBySubject) {
+  for (const subject of subjects) {
+    let safeSubject: string;
+    try {
+      safeSubject = assertSafeIri(subject);
+    } catch {
+      continue; // unsafe/corrupt subject IRI — cannot be a valid candidate
+    }
+    const rowsResult = await store.query(
+      `CONSTRUCT { <${safeSubject}> ?p ?o } WHERE { GRAPH <${metaGraph}> { <${safeSubject}> ?p ?o } }`,
+    );
+    const rows = rowsResult.type === 'quads' ? (rowsResult.quads ?? []) : [];
     const candidate = parseGraphScopedAssertionSealCandidate(rows, subject);
     if (!candidate
       || candidate.coordinate.scope !== expectedScope

--- a/packages/agent/src/sync/durable-integrity.ts
+++ b/packages/agent/src/sync/durable-integrity.ts
@@ -3,6 +3,7 @@ import {
   MemoryLayer,
   createGraphKnowledgeAssetScope,
   knowledgeAssetLayerGraphUri,
+  parseContextGraphAssertionUri,
   parseDeterministicKnowledgeAssetUal,
   validateSubGraphName,
 } from '@origintrail-official/dkg-core';
@@ -1196,8 +1197,11 @@ function isSelfConsistentGraphSeal(
     if (parseDeterministicKnowledgeAssetUal(kaUals[0]!).agentAddress.toLowerCase() !== author) {
       return false;
     }
-    const coordinate = /\/assertion\/(0x[0-9a-fA-F]{40})\/[^/]+$/.exec(subject);
-    return coordinate !== null && coordinate[1]!.toLowerCase() === author;
+    // The seal must sit at its own author's assertion coordinate.
+    const coordinate = parseContextGraphAssertionUri(subject);
+    return coordinate !== undefined
+      && /^0x[0-9a-fA-F]{40}$/.test(coordinate.agentAddress)
+      && coordinate.agentAddress.toLowerCase() === author;
   } catch {
     return false;
   }

--- a/packages/agent/src/sync/durable-integrity.ts
+++ b/packages/agent/src/sync/durable-integrity.ts
@@ -15,6 +15,8 @@ import { appendInPlace } from './append-in-place.js';
 
 const DKG_NS = 'http://dkg.io/ontology/';
 const MERKLE_ROOT = `${DKG_NS}merkleRoot`;
+const ASSERTION_MERKLE_ROOT = `${DKG_NS}assertionMerkleRoot`;
+const AUTHOR_ADDRESS = `${DKG_NS}authorAddress`;
 const CONTENT_SCOPE_VERSION = `${DKG_NS}contentScopeVersion`;
 const KA_UAL = `${DKG_NS}kaUal`;
 const ASSERTION_VERSION = `${DKG_NS}assertionVersion`;
@@ -1153,6 +1155,54 @@ function selectSystemOverrideMetadataIndexes(
   return { indexes, droppedControls };
 }
 
+/**
+ * GH#1778 — a graph-scoped author seal (subject carries `dkg:assertionMerkleRoot`)
+ * is descriptive author metadata, NOT a delta/routing control. Its 13 sibling
+ * quads (Merkle root, EIP-712 attestation, `dkg:kaUal`, triple counts) already
+ * sync unauthenticated through the descriptive path, and the seal's authenticity
+ * is established at PUBLISH time (`parseAssertionSealQuads` + a Merkle recompute
+ * against the signed root), not here. Only `dkg:assertionVersion` collides with
+ * the sync-control set, so for a not-yet-published KA (no on-chain UAL
+ * descriptor to authenticate against) it was being stripped — leaving 13/14
+ * quads and making `parseAssertionSealQuads` throw "Partial graph-scoped
+ * assertion seal", i.e. the KA is unpublishable.
+ *
+ * Admit `dkg:assertionVersion` only for a self-consistent seal rooted at its own
+ * author coordinate: the subject carries a v2 seal whose single `dkg:kaUal`
+ * author equals its single `dkg:authorAddress` and the `.../assertion/<addr>/…`
+ * path segment. A peer that forges a version value gains nothing the sibling
+ * quads didn't already allow — a tampered version derives the wrong graph scope
+ * and fails closed at publish on the Merkle recheck.
+ */
+function isSelfConsistentGraphSeal(
+  subject: string,
+  metadata: IntegrityMetadataIndex,
+): boolean {
+  const rows = metadata.metaBySubject.get(subject) ?? [];
+  if (!rows.some((row) => row.predicate === ASSERTION_MERKLE_ROOT)) return false;
+  try {
+    const scopeVersions = distinctObjects(rows, CONTENT_SCOPE_VERSION)
+      .map((value) => parseInteger(value, 'contentScopeVersion'));
+    if (scopeVersions.length !== 1
+      || scopeVersions[0] !== BigInt(GRAPH_KA_CONTENT_SCOPE_VERSION)) {
+      return false;
+    }
+    const kaUals = [...new Set(distinctObjects(rows, KA_UAL)
+      .map((value) => stripLiteral(value).replace(/^<(.*)>$/, '$1')))];
+    if (kaUals.length !== 1) return false;
+    const authors = [...new Set(distinctObjects(rows, AUTHOR_ADDRESS).map(stripLiteral))];
+    if (authors.length !== 1) return false;
+    const author = authors[0]!.toLowerCase();
+    if (parseDeterministicKnowledgeAssetUal(kaUals[0]!).agentAddress.toLowerCase() !== author) {
+      return false;
+    }
+    const coordinate = /\/assertion\/(0x[0-9a-fA-F]{40})\/[^/]+$/.exec(subject);
+    return coordinate !== null && coordinate[1]!.toLowerCase() === author;
+  } catch {
+    return false;
+  }
+}
+
 function isAuthenticatedSyncControl(
   quad: Quad,
   metadata: IntegrityMetadataIndex,
@@ -1160,6 +1210,10 @@ function isAuthenticatedSyncControl(
   kaToKc: ReadonlyMap<string, string>,
 ): boolean {
   if (authenticatedMetadataUals.has(quad.subject)) return true;
+  if (quad.predicate === ASSERTION_VERSION
+    && isSelfConsistentGraphSeal(quad.subject, metadata)) {
+    return true;
+  }
   const legacyOwner = kaToKc.get(quad.subject);
   if (legacyOwner && authenticatedMetadataUals.has(legacyOwner)) return true;
   if (quad.predicate === BATCH_ID) return false;

--- a/packages/agent/src/sync/durable-integrity.ts
+++ b/packages/agent/src/sync/durable-integrity.ts
@@ -1109,6 +1109,12 @@ function selectAdmittedMetadataIndexes(
       continue;
     }
 
+    // A self-consistent graph-seal assertionVersion is descriptive metadata,
+    // not a sync control — admit it via the descriptive path.
+    if (isGraphSealDescriptiveVersion(quad, metadata)) {
+      indexes.push(index);
+      continue;
+    }
     if (DURABLE_SYNC_CONTROL_PREDICATE_SET.has(quad.predicate)) {
       if (isAuthenticatedSyncControl(
         quad,
@@ -1139,6 +1145,7 @@ function selectSystemOverrideMetadataIndexes(
     const quad = metaQuads[index]!;
     if (
       DURABLE_SYNC_CONTROL_PREDICATE_SET.has(quad.predicate)
+      && !isGraphSealDescriptiveVersion(quad, metadata)
       && !isAuthenticatedSyncControl(
         quad,
         metadata,
@@ -1155,29 +1162,27 @@ function selectSystemOverrideMetadataIndexes(
 }
 
 /**
- * GH#1778 — a graph-scoped author seal (subject carries `dkg:assertionMerkleRoot`)
- * is descriptive author metadata, NOT a delta/routing control. Its 13 sibling
- * quads (Merkle root, EIP-712 attestation, `dkg:kaUal`, triple counts) already
- * sync unauthenticated through the descriptive path, and the seal's authenticity
- * is established at PUBLISH time (`parseAssertionSealQuads` + a Merkle recompute
- * against the signed root), not here. Only `dkg:assertionVersion` collides with
- * the sync-control set, so for a not-yet-published KA (no on-chain UAL
- * descriptor to authenticate against) it was being stripped — leaving 13/14
- * quads and making `parseAssertionSealQuads` throw "Partial graph-scoped
- * assertion seal", i.e. the KA is unpublishable.
+ * GH#1778 — classify a `dkg:assertionVersion` row as DESCRIPTIVE author-seal
+ * metadata rather than a delta/routing control. A graph-scoped author seal
+ * (subject carries `dkg:assertionMerkleRoot`) is descriptive: its 13 sibling
+ * quads (Merkle root, EIP-712 attestation, `dkg:kaUal`, counts) already sync
+ * unauthenticated, and the seal's authenticity is established at PUBLISH time
+ * (`parseAssertionSealQuads` + a Merkle recompute), not here. Only
+ * `dkg:assertionVersion` collides with the sync-control set, so for a
+ * not-yet-published KA it was being stripped — leaving 13/14 quads and making
+ * `parseAssertionSealQuads` throw "Partial graph-scoped assertion seal".
  *
- * The self-consistency check (v2 seal whose kaUal author == authorAddress ==
- * `.../assertion/<addr>/…` coordinate) lives in core beside the seal vocabulary
- * (`graphScopedSealAuthor`) so this integrity layer does not re-declare seal
- * predicates. A peer that forges a version value gains nothing the sibling quads
- * didn't already allow — a tampered version derives the wrong graph scope and
- * fails closed at publish on the Merkle recheck.
+ * Classifying it here (via the core `graphScopedSealAuthor` self-consistency
+ * check — v2 seal whose kaUal author == authorAddress == `.../assertion/<addr>/…`
+ * coordinate) keeps the control-authentication abstraction honest: the seal
+ * field follows the descriptive path instead of being smuggled through
+ * `isAuthenticatedSyncControl` as an "authenticated control". A peer that forges
+ * a version value gains nothing the sibling quads didn't already allow — a
+ * tampered version derives the wrong graph scope and fails closed at publish.
  */
-function isSelfConsistentGraphSeal(
-  subject: string,
-  metadata: IntegrityMetadataIndex,
-): boolean {
-  return graphScopedSealAuthor(metadata.metaBySubject.get(subject) ?? [], subject) !== undefined;
+function isGraphSealDescriptiveVersion(quad: Quad, metadata: IntegrityMetadataIndex): boolean {
+  return quad.predicate === ASSERTION_VERSION
+    && graphScopedSealAuthor(metadata.metaBySubject.get(quad.subject) ?? [], quad.subject) !== undefined;
 }
 
 function isAuthenticatedSyncControl(
@@ -1187,10 +1192,6 @@ function isAuthenticatedSyncControl(
   kaToKc: ReadonlyMap<string, string>,
 ): boolean {
   if (authenticatedMetadataUals.has(quad.subject)) return true;
-  if (quad.predicate === ASSERTION_VERSION
-    && isSelfConsistentGraphSeal(quad.subject, metadata)) {
-    return true;
-  }
   const legacyOwner = kaToKc.get(quad.subject);
   if (legacyOwner && authenticatedMetadataUals.has(legacyOwner)) return true;
   if (quad.predicate === BATCH_ID) return false;

--- a/packages/agent/src/sync/durable-integrity.ts
+++ b/packages/agent/src/sync/durable-integrity.ts
@@ -2,7 +2,7 @@ import {
   GRAPH_KA_CONTENT_SCOPE_VERSION,
   MemoryLayer,
   createGraphKnowledgeAssetScope,
-  isSelfConsistentGraphScopedAssertionSeal,
+  parseGraphScopedAssertionSealCandidate,
   knowledgeAssetLayerGraphUri,
   parseDeterministicKnowledgeAssetUal,
   validateSubGraphName,
@@ -1172,17 +1172,19 @@ function selectSystemOverrideMetadataIndexes(
  * not-yet-published KA it was being stripped — leaving 13/14 quads and making
  * `parseAssertionSealQuads` throw "Partial graph-scoped assertion seal".
  *
- * Classifying it here (via the core `isSelfConsistentGraphScopedAssertionSeal` self-consistency
- * check — v2 seal whose kaUal author == authorAddress == `.../assertion/<addr>/…`
- * coordinate) keeps the control-authentication abstraction honest: the seal
- * field follows the descriptive path instead of being smuggled through
- * `isAuthenticatedSyncControl` as an "authenticated control". A peer that forges
- * a version value gains nothing the sibling quads didn't already allow — a
- * tampered version derives the wrong graph scope and fails closed at publish.
+ * Classifying it here (via the core `parseGraphScopedAssertionSealCandidate`
+ * check — the SAME canonical "publishable graph-scoped seal" definition VM
+ * publish uses: complete v2 seal whose kaUal author == authorAddress ==
+ * `.../assertion/<addr>/…` coordinate, single-valued identity fields) keeps the
+ * control-authentication abstraction honest: the seal field follows the
+ * descriptive path instead of being smuggled through `isAuthenticatedSyncControl`
+ * as an "authenticated control". A peer that forges a version value gains nothing
+ * the sibling quads didn't already allow — a tampered version derives the wrong
+ * graph scope and fails closed at publish.
  */
 function isGraphSealDescriptiveVersion(quad: Quad, metadata: IntegrityMetadataIndex): boolean {
   return quad.predicate === ASSERTION_VERSION
-    && isSelfConsistentGraphScopedAssertionSeal(metadata.metaBySubject.get(quad.subject) ?? [], quad.subject);
+    && parseGraphScopedAssertionSealCandidate(metadata.metaBySubject.get(quad.subject) ?? [], quad.subject) !== undefined;
 }
 
 function isAuthenticatedSyncControl(

--- a/packages/agent/src/sync/durable-integrity.ts
+++ b/packages/agent/src/sync/durable-integrity.ts
@@ -2,7 +2,7 @@ import {
   GRAPH_KA_CONTENT_SCOPE_VERSION,
   MemoryLayer,
   createGraphKnowledgeAssetScope,
-  graphScopedSealAuthor,
+  isSelfConsistentGraphScopedAssertionSeal,
   knowledgeAssetLayerGraphUri,
   parseDeterministicKnowledgeAssetUal,
   validateSubGraphName,
@@ -1172,7 +1172,7 @@ function selectSystemOverrideMetadataIndexes(
  * not-yet-published KA it was being stripped — leaving 13/14 quads and making
  * `parseAssertionSealQuads` throw "Partial graph-scoped assertion seal".
  *
- * Classifying it here (via the core `graphScopedSealAuthor` self-consistency
+ * Classifying it here (via the core `isSelfConsistentGraphScopedAssertionSeal` self-consistency
  * check — v2 seal whose kaUal author == authorAddress == `.../assertion/<addr>/…`
  * coordinate) keeps the control-authentication abstraction honest: the seal
  * field follows the descriptive path instead of being smuggled through
@@ -1182,7 +1182,7 @@ function selectSystemOverrideMetadataIndexes(
  */
 function isGraphSealDescriptiveVersion(quad: Quad, metadata: IntegrityMetadataIndex): boolean {
   return quad.predicate === ASSERTION_VERSION
-    && graphScopedSealAuthor(metadata.metaBySubject.get(quad.subject) ?? [], quad.subject) !== undefined;
+    && isSelfConsistentGraphScopedAssertionSeal(metadata.metaBySubject.get(quad.subject) ?? [], quad.subject);
 }
 
 function isAuthenticatedSyncControl(

--- a/packages/agent/src/sync/durable-integrity.ts
+++ b/packages/agent/src/sync/durable-integrity.ts
@@ -2,8 +2,8 @@ import {
   GRAPH_KA_CONTENT_SCOPE_VERSION,
   MemoryLayer,
   createGraphKnowledgeAssetScope,
+  graphScopedSealAuthor,
   knowledgeAssetLayerGraphUri,
-  parseContextGraphAssertionUri,
   parseDeterministicKnowledgeAssetUal,
   validateSubGraphName,
 } from '@origintrail-official/dkg-core';
@@ -16,8 +16,6 @@ import { appendInPlace } from './append-in-place.js';
 
 const DKG_NS = 'http://dkg.io/ontology/';
 const MERKLE_ROOT = `${DKG_NS}merkleRoot`;
-const ASSERTION_MERKLE_ROOT = `${DKG_NS}assertionMerkleRoot`;
-const AUTHOR_ADDRESS = `${DKG_NS}authorAddress`;
 const CONTENT_SCOPE_VERSION = `${DKG_NS}contentScopeVersion`;
 const KA_UAL = `${DKG_NS}kaUal`;
 const ASSERTION_VERSION = `${DKG_NS}assertionVersion`;
@@ -1168,43 +1166,18 @@ function selectSystemOverrideMetadataIndexes(
  * quads and making `parseAssertionSealQuads` throw "Partial graph-scoped
  * assertion seal", i.e. the KA is unpublishable.
  *
- * Admit `dkg:assertionVersion` only for a self-consistent seal rooted at its own
- * author coordinate: the subject carries a v2 seal whose single `dkg:kaUal`
- * author equals its single `dkg:authorAddress` and the `.../assertion/<addr>/…`
- * path segment. A peer that forges a version value gains nothing the sibling
- * quads didn't already allow — a tampered version derives the wrong graph scope
- * and fails closed at publish on the Merkle recheck.
+ * The self-consistency check (v2 seal whose kaUal author == authorAddress ==
+ * `.../assertion/<addr>/…` coordinate) lives in core beside the seal vocabulary
+ * (`graphScopedSealAuthor`) so this integrity layer does not re-declare seal
+ * predicates. A peer that forges a version value gains nothing the sibling quads
+ * didn't already allow — a tampered version derives the wrong graph scope and
+ * fails closed at publish on the Merkle recheck.
  */
 function isSelfConsistentGraphSeal(
   subject: string,
   metadata: IntegrityMetadataIndex,
 ): boolean {
-  const rows = metadata.metaBySubject.get(subject) ?? [];
-  if (!rows.some((row) => row.predicate === ASSERTION_MERKLE_ROOT)) return false;
-  try {
-    const scopeVersions = distinctObjects(rows, CONTENT_SCOPE_VERSION)
-      .map((value) => parseInteger(value, 'contentScopeVersion'));
-    if (scopeVersions.length !== 1
-      || scopeVersions[0] !== BigInt(GRAPH_KA_CONTENT_SCOPE_VERSION)) {
-      return false;
-    }
-    const kaUals = [...new Set(distinctObjects(rows, KA_UAL)
-      .map((value) => stripLiteral(value).replace(/^<(.*)>$/, '$1')))];
-    if (kaUals.length !== 1) return false;
-    const authors = [...new Set(distinctObjects(rows, AUTHOR_ADDRESS).map(stripLiteral))];
-    if (authors.length !== 1) return false;
-    const author = authors[0]!.toLowerCase();
-    if (parseDeterministicKnowledgeAssetUal(kaUals[0]!).agentAddress.toLowerCase() !== author) {
-      return false;
-    }
-    // The seal must sit at its own author's assertion coordinate.
-    const coordinate = parseContextGraphAssertionUri(subject);
-    return coordinate !== undefined
-      && /^0x[0-9a-fA-F]{40}$/.test(coordinate.agentAddress)
-      && coordinate.agentAddress.toLowerCase() === author;
-  } catch {
-    return false;
-  }
+  return graphScopedSealAuthor(metadata.metaBySubject.get(subject) ?? [], subject) !== undefined;
 }
 
 function isAuthenticatedSyncControl(

--- a/packages/agent/test/durable-integrity-seal-assertion-version.test.ts
+++ b/packages/agent/test/durable-integrity-seal-assertion-version.test.ts
@@ -172,4 +172,22 @@ describe('GH#1778 durable-sync retains the seal assertionVersion', () => {
     expect(kept.filter((q) => q.subject === ASSERTION_URI).length).toBe(seal.length);
     expect(kept.some((q) => q.subject === orphan)).toBe(false);
   });
+
+  it('drops the seal assertionVersion when a `merkleRoot` quad is planted on the subject (adversarial, fail-closed)', () => {
+    // A malicious CG member appends a bare `dkg:merkleRoot` (NOT `assertionMerkleRoot`)
+    // to the victim's seal subject, routing ALL its rows into the descriptor
+    // branch, where the subject is rejected as a malformed KA descriptor and the
+    // descriptive-version classifier never runs. Documents the current
+    // fail-closed behaviour: the seal is not admitted (so it cannot mis-publish),
+    // at the cost of that seal becoming unsyncable until a clean batch heals it.
+    const seal = buildSeal();
+    const plantedMerkleRoot: Quad = {
+      subject: ASSERTION_URI,
+      predicate: 'http://dkg.io/ontology/merkleRoot',
+      object: `"${'00'.repeat(32)}"^^<http://www.w3.org/2001/XMLSchema#hexBinary>`,
+      graph: META_GRAPH,
+    };
+    const kept = keptMeta([...seal, plantedMerkleRoot], { kind: 'fullSnapshot' }).filter((q) => q.subject === ASSERTION_URI);
+    expect(kept.some((q) => q.predicate === ASSERTION_SEAL_PREDICATES.ASSERTION_VERSION)).toBe(false);
+  });
 });

--- a/packages/agent/test/durable-integrity-seal-assertion-version.test.ts
+++ b/packages/agent/test/durable-integrity-seal-assertion-version.test.ts
@@ -84,6 +84,14 @@ describe('GH#1778 durable-sync retains the seal assertionVersion', () => {
     });
   }
 
+  it('keeps assertionVersion for a self-consistent SUB-GRAPH seal', () => {
+    const subUri = contextGraphAssertionUri(CG, AUTHOR, NAME, 'wing-a');
+    const seal = buildSeal({ assertionUri: subUri });
+    const kept = keptMeta(seal, { kind: 'fullSnapshot' }).filter((q) => q.subject === subUri);
+    expect(kept).toHaveLength(seal.length);
+    expect(() => parseAssertionSealQuads(kept, subUri)).not.toThrow();
+  });
+
   it('drops assertionVersion on a non-seal subject (no assertionMerkleRoot) — unchanged fail-closed behaviour', () => {
     const foreign: Quad = {
       subject: `did:dkg:context-graph:${CG}/assertion/${AUTHOR}/other`,

--- a/packages/agent/test/durable-integrity-seal-assertion-version.test.ts
+++ b/packages/agent/test/durable-integrity-seal-assertion-version.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildAssertionSealQuads,
+  contextGraphAssertionUri,
+  contextGraphMetaUri,
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  ASSERTION_SEAL_PREDICATES,
+} from '@origintrail-official/dkg-core';
+import { parseAssertionSealQuads } from '@origintrail-official/dkg-core';
+import type { Quad } from '@origintrail-official/dkg-storage';
+import { selectVerifiedDurableSyncQuads } from '../src/sync/durable-integrity.js';
+
+/**
+ * GH#1778 — a graph-scoped author seal shared member->curator reaches the
+ * curator over the durable `_meta` sync lane. The seal subject carries
+ * `dkg:assertionVersion`, which collides with the durable sync-control
+ * predicate set; for a not-yet-published KA (no on-chain UAL descriptor to
+ * authenticate against) it used to be stripped, leaving 13/14 quads and making
+ * `parseAssertionSealQuads` throw "Partial graph-scoped assertion seal".
+ *
+ * These tests pin: (1) a self-consistent seal keeps ALL 14 quads and parses,
+ * in both snapshot and delta modes; (2) the admission is fail-closed — a
+ * forged version on a subject that is not a self-consistent seal rooted at its
+ * own author coordinate is still dropped.
+ */
+
+const CG = 'construction';
+const AUTHOR = '0xA32f1cc125401B55911678847426759094055B2d';
+const NAME = 'justTriplets';
+const META_GRAPH = contextGraphMetaUri(CG);
+const ASSERTION_URI = contextGraphAssertionUri(CG, AUTHOR, NAME);
+const KA_UAL = `did:dkg:84532/${AUTHOR.toLowerCase()}/7`;
+const RESERVED_KA_ID = (BigInt(AUTHOR) << 96n) | 7n;
+
+function buildSeal(overrides?: {
+  assertionUri?: string;
+  authorAddress?: string;
+  kaUal?: string;
+  reservedKaId?: bigint;
+  contentScopeVersion?: 1 | 2;
+}): Quad[] {
+  return buildAssertionSealQuads({
+    assertionUri: overrides?.assertionUri ?? ASSERTION_URI,
+    metaGraph: META_GRAPH,
+    merkleRoot: new Uint8Array(32).fill(0xab),
+    authorAddress: overrides?.authorAddress ?? AUTHOR,
+    authorAttestationR: new Uint8Array(32).fill(0x11),
+    authorAttestationVS: new Uint8Array(32).fill(0x22),
+    authorSchemeVersion: 1,
+    chainId: 84532n,
+    kav10Address: '0x1234567890123456789012345678901234567890',
+    reservedKaId: overrides?.reservedKaId ?? RESERVED_KA_ID,
+    finalizedAtIso: '2026-01-01T00:00:00.000Z',
+    contentScopeVersion: (overrides?.contentScopeVersion ?? GRAPH_KA_CONTENT_SCOPE_VERSION) as typeof GRAPH_KA_CONTENT_SCOPE_VERSION,
+    kaUal: overrides?.kaUal ?? KA_UAL,
+    assertionVersion: 1n,
+    publicTripleCount: 3,
+    privateTripleCount: 0,
+  }) as Quad[];
+}
+
+function keptMeta(metaQuads: Quad[], mode: { kind: 'fullSnapshot' } | { kind: 'sinceBatchId'; sinceBatchId: bigint }): Quad[] {
+  const sel = selectVerifiedDurableSyncQuads([], metaQuads, false, mode);
+  return sel.metaIndexes.map((i) => metaQuads[i]!);
+}
+
+const MODES: Array<{ kind: 'fullSnapshot' } | { kind: 'sinceBatchId'; sinceBatchId: bigint }> = [
+  { kind: 'fullSnapshot' },
+  { kind: 'sinceBatchId', sinceBatchId: 0n },
+];
+
+describe('GH#1778 durable-sync retains the seal assertionVersion', () => {
+  for (const mode of MODES) {
+    it(`keeps all 14 seal quads and parses (mode=${mode.kind})`, () => {
+      const seal = buildSeal();
+      const kept = keptMeta(seal, mode).filter((q) => q.subject === ASSERTION_URI);
+      expect(kept).toHaveLength(seal.length);
+      expect(kept.some((q) => q.predicate === ASSERTION_SEAL_PREDICATES.ASSERTION_VERSION)).toBe(true);
+      // The whole point: the seal now parses at the author subject.
+      expect(() => parseAssertionSealQuads(kept, ASSERTION_URI)).not.toThrow();
+      const parsed = parseAssertionSealQuads(kept, ASSERTION_URI);
+      expect(parsed?.contentScopeVersion).toBe(GRAPH_KA_CONTENT_SCOPE_VERSION);
+      expect(parsed?.assertionVersion).toBe('1');
+    });
+  }
+
+  it('drops assertionVersion on a non-seal subject (no assertionMerkleRoot) — unchanged fail-closed behaviour', () => {
+    const foreign: Quad = {
+      subject: `did:dkg:context-graph:${CG}/assertion/${AUTHOR}/other`,
+      predicate: ASSERTION_SEAL_PREDICATES.ASSERTION_VERSION,
+      object: '"9"^^<http://www.w3.org/2001/XMLSchema#integer>',
+      graph: META_GRAPH,
+    };
+    const kept = keptMeta([foreign], { kind: 'fullSnapshot' });
+    expect(kept).toHaveLength(0);
+  });
+
+  it('drops assertionVersion when the seal author disagrees with the kaUal author (fail-closed)', () => {
+    // Seal at AUTHOR's coordinate but kaUal names a DIFFERENT author.
+    const mismatched = buildSeal({ kaUal: `did:dkg:84532/0x${'cd'.repeat(20)}/7` });
+    const kept = keptMeta(mismatched, { kind: 'fullSnapshot' }).filter((q) => q.subject === ASSERTION_URI);
+    expect(kept.some((q) => q.predicate === ASSERTION_SEAL_PREDICATES.ASSERTION_VERSION)).toBe(false);
+    // The rest of the seal still flows (descriptive), so parse throws "partial".
+    expect(() => parseAssertionSealQuads(kept, ASSERTION_URI)).toThrow(/Partial graph-scoped assertion seal/);
+  });
+
+  it('drops assertionVersion when the seal subject is planted at a foreign author coordinate (fail-closed)', () => {
+    // A valid, self-consistent seal for AUTHOR/KA_UAL, but planted under a
+    // DIFFERENT address segment in the subject URI (a "wrong place" attack).
+    const victim = `0x${'ee'.repeat(20)}`;
+    const plantedUri = contextGraphAssertionUri(CG, victim, NAME);
+    const planted = buildSeal({ assertionUri: plantedUri });
+    const kept = keptMeta(planted, { kind: 'fullSnapshot' }).filter((q) => q.subject === plantedUri);
+    expect(kept.some((q) => q.predicate === ASSERTION_SEAL_PREDICATES.ASSERTION_VERSION)).toBe(false);
+  });
+});

--- a/packages/agent/test/durable-integrity-seal-assertion-version.test.ts
+++ b/packages/agent/test/durable-integrity-seal-assertion-version.test.ts
@@ -135,4 +135,41 @@ describe('GH#1778 durable-sync retains the seal assertionVersion', () => {
     const kept = keptMeta(planted, { kind: 'fullSnapshot' }).filter((q) => q.subject === plantedUri);
     expect(kept.some((q) => q.predicate === ASSERTION_SEAL_PREDICATES.ASSERTION_VERSION)).toBe(false);
   });
+
+  it('drops ALL assertionVersion rows when the seal carries two conflicting versions (fail-closed)', () => {
+    // The admitted field itself must be single-valued: a peer that appends a
+    // second, conflicting assertionVersion must not have either row admitted
+    // (else the full parser's last-writer-wins could pick the tampered value).
+    const seal = buildSeal();
+    const forkedVersion: Quad = {
+      subject: ASSERTION_URI,
+      predicate: ASSERTION_SEAL_PREDICATES.ASSERTION_VERSION,
+      object: '"999"^^<http://www.w3.org/2001/XMLSchema#integer>',
+      graph: META_GRAPH,
+    };
+    const kept = keptMeta([...seal, forkedVersion], { kind: 'fullSnapshot' }).filter((q) => q.subject === ASSERTION_URI);
+    expect(kept.some((q) => q.predicate === ASSERTION_SEAL_PREDICATES.ASSERTION_VERSION)).toBe(false);
+    expect(() => parseAssertionSealQuads(kept, ASSERTION_URI)).toThrow(/Partial graph-scoped assertion seal/);
+  });
+
+  it('retains the seal assertionVersion on the system-override path (acceptUnverified) while dropping orphan controls', () => {
+    // acceptUnverified=true + a rejected/orphan control routes selection through
+    // selectSystemOverrideMetadataIndexes; the seal-version classifier must apply
+    // there too, so the self-consistent seal keeps assertionVersion while an
+    // unrelated orphan control is still dropped.
+    const seal = buildSeal();
+    const orphan = 'urn:system:orphan-control';
+    const orphanVersion: Quad = {
+      subject: orphan,
+      predicate: ASSERTION_SEAL_PREDICATES.ASSERTION_VERSION,
+      object: '"999"^^<http://www.w3.org/2001/XMLSchema#integer>',
+      graph: META_GRAPH,
+    };
+    const meta = [...seal, orphanVersion];
+    const selection = selectVerifiedDurableSyncQuads([], meta, true);
+    const kept = selection.metaIndexes.map((i) => meta[i]!);
+    // Seal's assertionVersion survives (descriptive); the orphan's is dropped.
+    expect(kept.filter((q) => q.subject === ASSERTION_URI).length).toBe(seal.length);
+    expect(kept.some((q) => q.subject === orphan)).toBe(false);
+  });
 });

--- a/packages/agent/test/durable-integrity-seal-assertion-version.test.ts
+++ b/packages/agent/test/durable-integrity-seal-assertion-version.test.ts
@@ -103,6 +103,20 @@ describe('GH#1778 durable-sync retains the seal assertionVersion', () => {
     expect(kept).toHaveLength(0);
   });
 
+  it('drops assertionVersion when a peer supplies two conflicting kaUal values (ambiguity fails closed)', () => {
+    // A second, different kaUal on the same seal subject must not be silently
+    // collapsed (last-writer-wins) — admission requires exactly one identity.
+    const seal = buildSeal();
+    const forkedKaUal: Quad = {
+      subject: ASSERTION_URI,
+      predicate: ASSERTION_SEAL_PREDICATES.KA_UAL,
+      object: `<did:dkg:84532/0x${'cd'.repeat(20)}/7>`,
+      graph: META_GRAPH,
+    };
+    const kept = keptMeta([...seal, forkedKaUal], { kind: 'fullSnapshot' }).filter((q) => q.subject === ASSERTION_URI);
+    expect(kept.some((q) => q.predicate === ASSERTION_SEAL_PREDICATES.ASSERTION_VERSION)).toBe(false);
+  });
+
   it('drops assertionVersion when the seal author disagrees with the kaUal author (fail-closed)', () => {
     // Seal at AUTHOR's coordinate but kaUal names a DIFFERENT author.
     const mismatched = buildSeal({ kaUal: `did:dkg:84532/0x${'cd'.repeat(20)}/7` });

--- a/packages/agent/test/publish-finalized-agent-lane.test.ts
+++ b/packages/agent/test/publish-finalized-agent-lane.test.ts
@@ -175,7 +175,12 @@ describe('DKGAgent publishFromFinalizedAssertion agent lane', () => {
       };
     };
 
-    await expect(agent.publishFromFinalizedAssertion(CG, NAME)).rejects.toThrow(/is not finalized/);
+    // GH#1778 — a genuinely absent name still yields "is not finalized":
+    // resolveAssertionAuthor finds no seal, returns undefined, and the caller
+    // falls back to its own address. (Before #1778, publishing NAME itself
+    // without an explicit agentAddress failed here; it now auto-resolves the
+    // sole author AGENT_B — covered by publish-foreign-author-resolution.test.ts.)
+    await expect(agent.publishFromFinalizedAssertion(CG, 'no-such-name')).rejects.toThrow(/is not finalized/);
 
     const result = await agent.publishFromFinalizedAssertion(CG, NAME, {
       agentAddress: AGENT_B,

--- a/packages/agent/test/publish-foreign-author-resolution.test.ts
+++ b/packages/agent/test/publish-foreign-author-resolution.test.ts
@@ -149,14 +149,16 @@ describe('GH#1778 resolveAssertionAuthor', () => {
     expect(await agent.resolveAssertionAuthor(slashCg, NAME, undefined, CURATOR)).toBe(MEMBER);
   });
 
-  it('does not cross-match a name that is a suffix of another', async () => {
+  it('does not cross-match a name that is a suffix of another (different authors make it observable)', async () => {
+    // MEMBER authors 'asset'; OTHER authors 'myasset' (which ends with 'asset').
+    // Anchored `/asset` suffix + exact-name check must resolve MEMBER alone. An
+    // UNANCHORED suffix match would pull OTHER in and make 'asset' ambiguous —
+    // so an accidental regression changes the observable result (throws) instead
+    // of silently passing.
     const store = new OxigraphStore();
-    await store.insert([...sealFor(MEMBER, 'triplets'), ...sealFor(MEMBER, 'justTriplets')]);
+    await store.insert([...sealFor(MEMBER, 'asset'), ...sealFor(OTHER, 'myasset')]);
     const agent = stubAgent(store, CURATOR);
-    // 'triplets' must not match '.../justTriplets' (segment-anchored suffix).
-    expect(await agent.resolveAssertionAuthor(CG, 'triplets', undefined, CURATOR)).toBe(MEMBER);
-    const kaUri = contextGraphAssertionUri(CG, MEMBER, 'triplets');
-    expect(kaUri.endsWith('/triplets')).toBe(true);
+    expect(await agent.resolveAssertionAuthor(CG, 'asset', undefined, CURATOR)).toBe(MEMBER);
   });
 });
 

--- a/packages/agent/test/publish-foreign-author-resolution.test.ts
+++ b/packages/agent/test/publish-foreign-author-resolution.test.ts
@@ -34,10 +34,10 @@ const PUBLIC_QUAD: Quad = {
 };
 const MERKLE = computeFlatKCRootV10([PUBLIC_QUAD], []);
 
-function sealFor(author: string, name = NAME): Quad[] {
+function sealAt(cg: string, author: string, name = NAME, subGraphName?: string): Quad[] {
   return buildAssertionSealQuads({
-    assertionUri: contextGraphAssertionUri(CG, author, name),
-    metaGraph: contextGraphMetaUri(CG),
+    assertionUri: contextGraphAssertionUri(cg, author, name, subGraphName),
+    metaGraph: contextGraphMetaUri(cg),
     merkleRoot: MERKLE,
     authorAddress: author,
     authorAttestationR: new Uint8Array(32).fill(1),
@@ -53,6 +53,10 @@ function sealFor(author: string, name = NAME): Quad[] {
     publicTripleCount: 1,
     privateTripleCount: 0,
   }) as Quad[];
+}
+
+function sealFor(author: string, name = NAME): Quad[] {
+  return sealAt(CG, author, name);
 }
 
 function makeLog() {
@@ -123,6 +127,28 @@ describe('GH#1778 resolveAssertionAuthor', () => {
     expect(await agent.resolveAssertionAuthor(CG, 'no-such-name', undefined, CURATOR)).toBeUndefined();
   });
 
+  it('resolves the subgraph member and does NOT fall back to a same-named root seal', async () => {
+    // Member seal in sub-graph 'wing-a' AND a same-named root seal by a different
+    // author as a guard: the requested sub-graph scope must resolve the wing-a
+    // member, never the root author.
+    const store = new OxigraphStore();
+    await store.insert([...sealAt(CG, MEMBER, NAME, 'wing-a'), ...sealAt(CG, OTHER, NAME)]);
+    const agent = stubAgent(store, CURATOR);
+    expect(await agent.resolveAssertionAuthor(CG, NAME, 'wing-a', CURATOR)).toBe(MEMBER);
+    // ...and the root scope resolves the root author, not the wing-a member.
+    expect(await agent.resolveAssertionAuthor(CG, NAME, undefined, CURATOR)).toBe(OTHER);
+  });
+
+  it('resolves a foreign author for a slash-containing (wallet-scoped) context graph id', async () => {
+    // GH#1778 review: validateContextGraphId permits '/'. The from-the-right
+    // parser must not mis-split the cg id into a subgraph.
+    const slashCg = `0x${'11'.repeat(20)}/project`;
+    const store = new OxigraphStore();
+    await store.insert(sealAt(slashCg, MEMBER, NAME));
+    const agent = stubAgent(store, CURATOR);
+    expect(await agent.resolveAssertionAuthor(slashCg, NAME, undefined, CURATOR)).toBe(MEMBER);
+  });
+
   it('does not cross-match a name that is a suffix of another', async () => {
     const store = new OxigraphStore();
     await store.insert([...sealFor(MEMBER, 'triplets'), ...sealFor(MEMBER, 'justTriplets')]);
@@ -160,6 +186,15 @@ describe('GH#1778 an explicit agentAddress is an authoritative author selector',
     expect(await agent.resolveFinalizedAssertionPublishAuthor(CG, NAME, { agentAddress: OTHER })).toBe(OTHER);
     // A caller hint (no explicit selector) resolves the sole member author.
     expect(await agent.resolveFinalizedAssertionPublishAuthor(CG, NAME, { callerAgentAddress: CURATOR })).toBe(MEMBER);
+  });
+
+  it('rejects supplying both agentAddress (selector) and callerAgentAddress (hint)', async () => {
+    const store = new OxigraphStore();
+    await store.insert(sealFor(MEMBER));
+    const agent = stubAgent(store, CURATOR);
+    await expect(
+      agent.resolveFinalizedAssertionPublishAuthor(CG, NAME, { agentAddress: OTHER, callerAgentAddress: CURATOR }),
+    ).rejects.toMatchObject({ code: 'PUBLISH_AUTHOR_SELECTION_CONFLICT' });
   });
 });
 

--- a/packages/agent/test/publish-foreign-author-resolution.test.ts
+++ b/packages/agent/test/publish-foreign-author-resolution.test.ts
@@ -4,6 +4,7 @@ import {
   contextGraphAssertionUri,
   contextGraphSharedMemoryUri,
   contextGraphMetaUri,
+  ASSERTION_SEAL_PREDICATES,
   GRAPH_KA_CONTENT_SCOPE_VERSION,
 } from '@origintrail-official/dkg-core';
 import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
@@ -147,6 +148,32 @@ describe('GH#1778 resolveAssertionAuthor', () => {
     await store.insert(sealAt(slashCg, MEMBER, NAME));
     const agent = stubAgent(store, CURATOR);
     expect(await agent.resolveAssertionAuthor(slashCg, NAME, undefined, CURATOR)).toBe(MEMBER);
+  });
+
+  // A subject with ONLY dkg:assertionMerkleRoot (a stale/partial/peer-supplied
+  // fragment) must NOT count as a publishable author candidate.
+  function partialSealOnly(author: string, name = NAME): Quad {
+    return {
+      subject: contextGraphAssertionUri(CG, author, name),
+      predicate: ASSERTION_SEAL_PREDICATES.ASSERTION_MERKLE_ROOT,
+      object: `"${'ab'.repeat(32)}"^^<http://www.w3.org/2001/XMLSchema#hexBinary>`,
+      graph: contextGraphMetaUri(CG),
+    };
+  }
+
+  it('does NOT count a partial (merkleRoot-only) subject — resolves the sole complete seal', async () => {
+    const store = new OxigraphStore();
+    await store.insert([...sealFor(MEMBER), partialSealOnly(OTHER)]);
+    const agent = stubAgent(store, CURATOR);
+    // The partial OTHER subject must not create false ambiguity.
+    expect(await agent.resolveAssertionAuthor(CG, NAME, undefined, CURATOR)).toBe(MEMBER);
+  });
+
+  it('treats a partial-only name as not finalized (returns undefined, no unusable author)', async () => {
+    const store = new OxigraphStore();
+    await store.insert([partialSealOnly(OTHER)]);
+    const agent = stubAgent(store, CURATOR);
+    expect(await agent.resolveAssertionAuthor(CG, NAME, undefined, CURATOR)).toBeUndefined();
   });
 
   it('does not cross-match a name that is a suffix of another (different authors make it observable)', async () => {

--- a/packages/agent/test/publish-foreign-author-resolution.test.ts
+++ b/packages/agent/test/publish-foreign-author-resolution.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildAssertionSealQuads,
+  contextGraphAssertionUri,
+  contextGraphSharedMemoryUri,
+  contextGraphMetaUri,
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+} from '@origintrail-official/dkg-core';
+import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
+import { computeFlatKCRootV10 } from '@origintrail-official/dkg-publisher';
+import { DKGAgent } from '../src/dkg-agent.js';
+
+/**
+ * GH#1778 — a curator publishes a rootless named KA authored by a MEMBER and
+ * received over SWM. The seal lives in the curator's `_meta` under the member's
+ * author coordinate. Publish routes carry only the caller's (curator's) token
+ * address, so the author must be resolved from stored `_meta`, never claimed by
+ * the caller. These tests pin `resolveAssertionAuthor` and the end-to-end
+ * auto-resolution in `publishFromFinalizedAssertion`.
+ */
+
+const CG = 'construction';
+const MEMBER = '0xA32f1cc125401B55911678847426759094055B2d';
+const CURATOR = `0x${'11'.repeat(20)}`;
+const OTHER = `0x${'22'.repeat(20)}`;
+const NAME = 'justTriplets';
+const KA_UAL = `did:dkg:hardhat:31337/${MEMBER}/7`;
+const RESERVED_KA_ID = (BigInt(MEMBER) << 96n) | 7n;
+const PUBLIC_QUAD: Quad = {
+  subject: 'urn:justTriplets:subject1',
+  predicate: 'urn:justTriplets:predicate1',
+  object: '"value1"',
+  graph: '',
+};
+const MERKLE = computeFlatKCRootV10([PUBLIC_QUAD], []);
+
+function sealFor(author: string, name = NAME): Quad[] {
+  return buildAssertionSealQuads({
+    assertionUri: contextGraphAssertionUri(CG, author, name),
+    metaGraph: contextGraphMetaUri(CG),
+    merkleRoot: MERKLE,
+    authorAddress: author,
+    authorAttestationR: new Uint8Array(32).fill(1),
+    authorAttestationVS: new Uint8Array(32).fill(2),
+    authorSchemeVersion: 1,
+    chainId: 31337n,
+    kav10Address: '0x1234567890123456789012345678901234567890',
+    reservedKaId: (BigInt(author) << 96n) | 7n,
+    finalizedAtIso: '2026-01-01T00:00:00.000Z',
+    contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+    kaUal: `did:dkg:hardhat:31337/${author}/7`,
+    assertionVersion: 1,
+    publicTripleCount: 1,
+    privateTripleCount: 0,
+  }) as Quad[];
+}
+
+function makeLog() {
+  return { debug() {}, info() {}, warn() {}, error() {} };
+}
+
+function stubAgent(store: OxigraphStore, defaultAgentAddress: string) {
+  const agent = Object.create(DKGAgent.prototype) as any;
+  agent.store = store;
+  agent.log = makeLog();
+  agent.defaultAgentAddress = defaultAgentAddress;
+  Object.defineProperty(agent, 'peerId', {
+    value: '12D3KooWQz2bQbQueABKRSjV9koF8VYsXk5TdCsUmPf5zAEZg3q6',
+    configurable: true,
+  });
+  return agent;
+}
+
+describe('GH#1778 resolveAssertionAuthor', () => {
+  it('resolves the sole (member) author when the caller (curator) is not the author', async () => {
+    const store = new OxigraphStore();
+    await store.insert(sealFor(MEMBER));
+    const agent = stubAgent(store, CURATOR);
+    const resolved = await agent.resolveAssertionAuthor(CG, NAME, undefined, CURATOR);
+    expect(resolved).toBe(MEMBER); // exact stored (checksum) case
+  });
+
+  it('prefers the caller when the caller is one of several authors (self-publish unchanged)', async () => {
+    const store = new OxigraphStore();
+    await store.insert([...sealFor(MEMBER), ...sealFor(CURATOR)]);
+    const agent = stubAgent(store, CURATOR);
+    const resolved = await agent.resolveAssertionAuthor(CG, NAME, undefined, CURATOR);
+    expect(resolved).toBe(CURATOR);
+  });
+
+  it('throws AMBIGUOUS_ASSERTION_AUTHOR when several non-caller authors share the name', async () => {
+    const store = new OxigraphStore();
+    await store.insert([...sealFor(MEMBER), ...sealFor(OTHER)]);
+    const agent = stubAgent(store, CURATOR);
+    await expect(agent.resolveAssertionAuthor(CG, NAME, undefined, CURATOR)).rejects.toMatchObject({
+      code: 'AMBIGUOUS_ASSERTION_AUTHOR',
+    });
+    try {
+      await agent.resolveAssertionAuthor(CG, NAME, undefined, CURATOR);
+    } catch (e: any) {
+      expect(e.candidates).toHaveLength(2);
+    }
+  });
+
+  it('tokenless self-publish still prefers the node\'s OWN KA when a same-named member seal is also resident', async () => {
+    // The node's default identity (CURATOR) self-authored NAME, and it also
+    // curates MEMBER's same-named KA (both seals resident). A tokenless publish
+    // passes no explicit agentAddress; the caller hint must be the effective
+    // identity so the node still self-publishes its own KA (no false 409).
+    const store = new OxigraphStore();
+    await store.insert([...sealFor(CURATOR), ...sealFor(MEMBER)]);
+    const agent = stubAgent(store, CURATOR);
+    // Simulate the effective-identity caller hint the publish sites now pass.
+    const effectiveCaller = CURATOR; // opts?.agentAddress ?? defaultAgentAddress
+    const resolved = await agent.resolveAssertionAuthor(CG, NAME, undefined, effectiveCaller);
+    expect(resolved).toBe(CURATOR);
+  });
+
+  it('returns undefined when no author has finalized this name', async () => {
+    const store = new OxigraphStore();
+    await store.insert(sealFor(MEMBER));
+    const agent = stubAgent(store, CURATOR);
+    expect(await agent.resolveAssertionAuthor(CG, 'no-such-name', undefined, CURATOR)).toBeUndefined();
+  });
+
+  it('does not cross-match a name that is a suffix of another', async () => {
+    const store = new OxigraphStore();
+    await store.insert([...sealFor(MEMBER, 'triplets'), ...sealFor(MEMBER, 'justTriplets')]);
+    const agent = stubAgent(store, CURATOR);
+    // 'triplets' must not match '.../justTriplets' (segment-anchored suffix).
+    expect(await agent.resolveAssertionAuthor(CG, 'triplets', undefined, CURATOR)).toBe(MEMBER);
+    const kaUri = contextGraphAssertionUri(CG, MEMBER, 'triplets');
+    expect(kaUri.endsWith('/triplets')).toBe(true);
+  });
+});
+
+describe('GH#1778 publishFromFinalizedAssertion auto-resolves the member author', () => {
+  it('a curator publishing a member-authored KA (no agentAddress) reaches the member seal', async () => {
+    const store = new OxigraphStore();
+    const assertionUri = contextGraphAssertionUri(CG, MEMBER, NAME);
+    const exactGraph = `${contextGraphSharedMemoryUri(CG)}/${MEMBER}/7`;
+    await store.insert([
+      ...sealFor(MEMBER),
+      { ...PUBLIC_QUAD, graph: exactGraph },
+    ]);
+
+    const publishCalls: Array<{ contextGraphId: string; selection: any; opts: any }> = [];
+    const markerCalls: Array<{ agentAddress: string }> = [];
+    const agent = stubAgent(store, CURATOR); // curator is NOT the author
+    agent.chain = {};
+    agent.publisher = {
+      hasSwmShareComplete: async (_cg: string, _n: string, agentAddress: string) => {
+        markerCalls.push({ agentAddress });
+        return agentAddress === MEMBER;
+      },
+      clearSwmShareComplete: async () => {},
+      clearRemainingSharedMemory: async () => {},
+    };
+    agent.publishFromSharedMemory = async (contextGraphId: string, selection: any, opts: any) => {
+      publishCalls.push({ contextGraphId, selection, opts });
+      return {
+        kaId: RESERVED_KA_ID,
+        ual: 'did:dkg:test/31337/7',
+        merkleRoot: MERKLE,
+        kaManifest: [],
+        status: 'confirmed',
+        publicQuads: [],
+      };
+    };
+
+    // No agentAddress passed — the curator (default) is not the author. Before
+    // #1778 this threw "is not finalized"; now it resolves MEMBER.
+    const result = await agent.publishFromFinalizedAssertion(CG, NAME);
+    expect(result.assertionUri).toBe(assertionUri);
+    expect(markerCalls.every((c) => c.agentAddress === MEMBER)).toBe(true);
+    expect(publishCalls).toHaveLength(1);
+    // The forwarded seal carries the MEMBER's attestation (never re-signed by
+    // the curator). kaUal is canonicalised to lowercase by the scope helper.
+    expect(publishCalls[0]?.opts).toMatchObject({
+      kaUal: KA_UAL.toLowerCase(),
+      precomputedAttestation: { authorAddress: MEMBER, reservedKaId: RESERVED_KA_ID },
+    });
+  });
+});

--- a/packages/agent/test/publish-foreign-author-resolution.test.ts
+++ b/packages/agent/test/publish-foreign-author-resolution.test.ts
@@ -134,6 +134,57 @@ describe('GH#1778 resolveAssertionAuthor', () => {
   });
 });
 
+describe('GH#1778 an explicit agentAddress is an authoritative author selector', () => {
+  it('does NOT substitute a different sole resident author when an explicit agentAddress is requested', async () => {
+    // Only MEMBER has a seal for NAME. A direct caller explicitly requesting
+    // OTHER (an author selector, e.g. a programmatic caller) must FAIL as
+    // not-finalized — never silently publish MEMBER's same-named KA.
+    const store = new OxigraphStore();
+    await store.insert(sealFor(MEMBER));
+    const agent = stubAgent(store, CURATOR);
+    agent.chain = {};
+    agent.publisher = {
+      hasSwmShareComplete: async () => true,
+      clearSwmShareComplete: async () => {},
+      clearRemainingSharedMemory: async () => {},
+    };
+    await expect(agent.publishFromFinalizedAssertion(CG, NAME, { agentAddress: OTHER }))
+      .rejects.toThrow(/is not finalized/);
+  });
+
+  it('resolveFinalizedAssertionPublishAuthor returns an explicit agentAddress verbatim', async () => {
+    const store = new OxigraphStore();
+    await store.insert(sealFor(MEMBER));
+    const agent = stubAgent(store, CURATOR);
+    // Explicit selector wins over resolution, even when MEMBER is the sole seal.
+    expect(await agent.resolveFinalizedAssertionPublishAuthor(CG, NAME, { agentAddress: OTHER })).toBe(OTHER);
+    // A caller hint (no explicit selector) resolves the sole member author.
+    expect(await agent.resolveFinalizedAssertionPublishAuthor(CG, NAME, { callerAgentAddress: CURATOR })).toBe(MEMBER);
+  });
+});
+
+describe('GH#1778 resolveFinalizedAssertionVmPublishIntent (async) auto-resolves the member author', () => {
+  it('resolves the member author from _meta when the caller (curator) is not the author', async () => {
+    const store = new OxigraphStore();
+    await store.insert(sealFor(MEMBER));
+    const agent = stubAgent(store, CURATOR); // curator is NOT the author
+    let historyAgent: string | undefined;
+    Object.defineProperty(agent, 'assertion', {
+      value: {
+        history: async (_cg: string, _n: string, o: { agentAddress: string }) => {
+          historyAgent = o.agentAddress;
+          return null; // force the early exit after author resolution
+        },
+      },
+      configurable: true,
+    });
+    await expect(agent.resolveFinalizedAssertionVmPublishIntent(CG, NAME))
+      .rejects.toThrow(/is not finalized or does not exist/);
+    // The async intent path resolved the MEMBER author before touching history.
+    expect(historyAgent).toBe(MEMBER);
+  });
+});
+
 describe('GH#1778 publishFromFinalizedAssertion auto-resolves the member author', () => {
   it('a curator publishing a member-authored KA (no agentAddress) reaches the member seal', async () => {
     const store = new OxigraphStore();

--- a/packages/agent/test/publish-foreign-author-resolution.test.ts
+++ b/packages/agent/test/publish-foreign-author-resolution.test.ts
@@ -176,6 +176,47 @@ describe('GH#1778 resolveAssertionAuthor', () => {
     expect(await agent.resolveAssertionAuthor(CG, NAME, undefined, CURATOR)).toBeUndefined();
   });
 
+  // A complete seal at MEMBER's coordinate but whose authorAddress/kaUal name a
+  // DIFFERENT author must NOT be trusted from the URI — the resolver reads the
+  // author from the seal identity, not the subject alone.
+  function mismatchedSeal(coordAuthor: string, sealAuthor: string, name = NAME): Quad[] {
+    return buildAssertionSealQuads({
+      assertionUri: contextGraphAssertionUri(CG, coordAuthor, name),
+      metaGraph: contextGraphMetaUri(CG),
+      merkleRoot: MERKLE,
+      authorAddress: sealAuthor,
+      authorAttestationR: new Uint8Array(32).fill(1),
+      authorAttestationVS: new Uint8Array(32).fill(2),
+      authorSchemeVersion: 1,
+      chainId: 31337n,
+      kav10Address: '0x1234567890123456789012345678901234567890',
+      reservedKaId: (BigInt(sealAuthor) << 96n) | 7n,
+      finalizedAtIso: '2026-01-01T00:00:00.000Z',
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      kaUal: `did:dkg:hardhat:31337/${sealAuthor}/7`,
+      assertionVersion: 1,
+      publicTripleCount: 1,
+      privateTripleCount: 0,
+    }) as Quad[];
+  }
+
+  it('ignores a complete seal whose authorAddress/kaUal disagree with the subject coordinate', async () => {
+    const store = new OxigraphStore();
+    // Subject coordinate = MEMBER, but the seal names OTHER.
+    await store.insert(mismatchedSeal(MEMBER, OTHER));
+    const agent = stubAgent(store, CURATOR);
+    // Neither MEMBER (URI) nor OTHER (seal) is resolved — the subject is not a
+    // self-consistent candidate, so it is treated as not finalized.
+    expect(await agent.resolveAssertionAuthor(CG, NAME, undefined, CURATOR)).toBeUndefined();
+  });
+
+  it('resolves the aligned seal and ignores a coordinate-mismatched one at the same name', async () => {
+    const store = new OxigraphStore();
+    await store.insert([...sealFor(MEMBER), ...mismatchedSeal(OTHER, `0x${'33'.repeat(20)}`)]);
+    const agent = stubAgent(store, CURATOR);
+    expect(await agent.resolveAssertionAuthor(CG, NAME, undefined, CURATOR)).toBe(MEMBER);
+  });
+
   it('does not cross-match a name that is a suffix of another (different authors make it observable)', async () => {
     // MEMBER authors 'asset'; OTHER authors 'myasset' (which ends with 'asset').
     // Anchored `/asset` suffix + exact-name check must resolve MEMBER alone. An

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -19,6 +19,8 @@ export default defineConfig({
       "test/generic-sql-source.test.ts",
       "test/imported-artifact.test.ts",
       "test/publish-finalized-agent-lane.test.ts",
+      "test/publish-foreign-author-resolution.test.ts",
+      "test/durable-integrity-seal-assertion-version.test.ts",
       "test/promote-async-default-agent.test.ts",
       "test/query-min-trust-alias.test.ts",
       "test/sync-envelope-cursor.test.ts",

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -886,12 +886,14 @@ export function createKnowledgeAssetVmPublishHandler(agent: DKGAgent): Knowledge
       ) {
         throw firstErr;
       }
-      // GH#1778 — register the CG under the CALLER (operator/token) identity,
-      // not the resolved KA author (request.agentAddress may be a member the
-      // curator is publishing for). Fall back to agentAddress for older intents
-      // that predate callerAgentAddress (author == caller on the self-publish path).
-      const registrationAgentAddress =
-        request.callerAgentAddress ?? request.agentAddress ?? agent.getDefaultAgentAddress();
+      // GH#1778 — auto-register the CG under the NODE's own operational identity,
+      // NOT the persisted request's author/caller. The async worker is the node
+      // processing its queue: `request.agentAddress` is the resolved KA author (a
+      // member the curator is publishing for), and different callers of the same
+      // resolved author/name share one deduped job — so keying registration on
+      // the request identity would register under a member, or under whichever
+      // caller enqueued first. The node identity is well-defined and collapse-proof.
+      const registrationAgentAddress = agent.getDefaultAgentAddress();
       await agent.ensureRegisteredForPublish(request.contextGraphId, {
         ...(registrationAgentAddress ? { callerAgentAddress: registrationAgentAddress } : {}),
       });

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -886,9 +886,14 @@ export function createKnowledgeAssetVmPublishHandler(agent: DKGAgent): Knowledge
       ) {
         throw firstErr;
       }
-      const defaultAgentAddress = request.agentAddress ?? agent.getDefaultAgentAddress();
+      // GH#1778 — register the CG under the CALLER (operator/token) identity,
+      // not the resolved KA author (request.agentAddress may be a member the
+      // curator is publishing for). Fall back to agentAddress for older intents
+      // that predate callerAgentAddress (author == caller on the self-publish path).
+      const registrationAgentAddress =
+        request.callerAgentAddress ?? request.agentAddress ?? agent.getDefaultAgentAddress();
       await agent.ensureRegisteredForPublish(request.contextGraphId, {
-        ...(defaultAgentAddress ? { callerAgentAddress: defaultAgentAddress } : {}),
+        ...(registrationAgentAddress ? { callerAgentAddress: registrationAgentAddress } : {}),
       });
       return await agent.publishQueuedKnowledgeAssetVmPublish(
         request,

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -886,19 +886,19 @@ export function createKnowledgeAssetVmPublishHandler(agent: DKGAgent): Knowledge
       ) {
         throw firstErr;
       }
-      // GH#1778 — auto-register the CG under the NODE's own operational identity,
-      // NOT the persisted request's author/caller. The async worker is the node
-      // processing its queue: `request.agentAddress` is the resolved KA author (a
-      // member the curator is publishing for), and different callers of the same
-      // resolved author/name share one deduped job — so keying registration on
-      // the request identity would register under a member, or under whichever
-      // caller enqueued first. The node identity is well-defined and collapse-proof.
-      // Fall back to the request author ONLY when the node has no default identity
-      // (a degenerate deployment) so a self-authored publish — where author ==
-      // caller — still has an EVM registration actor, as it did before this change.
-      const registrationAgentAddress = agent.getDefaultAgentAddress() ?? request.agentAddress;
+      // GH#1778 — auto-register the CG under the ENQUEUING CALLER (the token
+      // holder / operator who requested the publish), stamped as the CG curator by
+      // `stampAddressCurator`. This matches the synchronous `vm/publish` lane
+      // (`knowledge-assets.ts` passes `callerAgentAddress: requestAgentAddress`), so
+      // the same CG gets the same curator regardless of which lane registers it.
+      // NOT `request.agentAddress` (the resolved KA author — a member the curator
+      // is publishing for). When the caller was not captured (tokenless enqueue /
+      // pre-#1778 job), `stampAddressCurator` falls back to the node's default
+      // identity — again exactly as the sync lane does when `requestAgentAddress`
+      // is undefined. Deduped jobs stamp under the first enqueuer's caller, which
+      // is the same first-writer-wins the sync lane already has.
       await agent.ensureRegisteredForPublish(request.contextGraphId, {
-        ...(registrationAgentAddress ? { callerAgentAddress: registrationAgentAddress } : {}),
+        ...(request.callerAgentAddress ? { callerAgentAddress: request.callerAgentAddress } : {}),
       });
       return await agent.publishQueuedKnowledgeAssetVmPublish(
         request,

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -893,7 +893,10 @@ export function createKnowledgeAssetVmPublishHandler(agent: DKGAgent): Knowledge
       // resolved author/name share one deduped job — so keying registration on
       // the request identity would register under a member, or under whichever
       // caller enqueued first. The node identity is well-defined and collapse-proof.
-      const registrationAgentAddress = agent.getDefaultAgentAddress();
+      // Fall back to the request author ONLY when the node has no default identity
+      // (a degenerate deployment) so a self-authored publish — where author ==
+      // caller — still has an EVM registration actor, as it did before this change.
+      const registrationAgentAddress = agent.getDefaultAgentAddress() ?? request.agentAddress;
       await agent.ensureRegisteredForPublish(request.contextGraphId, {
         ...(registrationAgentAddress ? { callerAgentAddress: registrationAgentAddress } : {}),
       });

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -166,6 +166,22 @@ const FINALIZE_ONLY_CREATE_FIELDS = [
  * carry "Invalid"/"Unsafe" text and must stay 500 (parity with the legacy
  * publish path, which never down-classified them).
  */
+/**
+ * GH#1778 — shared 409 mapping for the ambiguous-author VM-publish error, used
+ * by both `vm/publish` and `vm/publish-async` so the `{ code, error, candidates }`
+ * response shape cannot drift between the two routes. Returns `true` (and writes
+ * the response) when it handled the error, `false` otherwise.
+ */
+function respondAmbiguousAssertionAuthor(res: RequestContext["res"], e: any): boolean {
+  if (e?.code !== "AMBIGUOUS_ASSERTION_AUTHOR") return false;
+  jsonResponse(res, 409, {
+    code: "AMBIGUOUS_ASSERTION_AUTHOR",
+    error: e.message ?? String(e),
+    candidates: e.candidates ?? [],
+  });
+  return true;
+}
+
 function respondAssertionError(res: RequestContext["res"], e: any): void {
   if (e?.code === "OVERSIZED_RDF_LITERAL") {
     jsonResponse(res, 400, oversizedRdfLiteralResponseBody(e));
@@ -433,6 +449,16 @@ function resolveAuthorAgentAddressFromFinalizeOptions(
 
 function scopedTokenStorageLane(agentAddress?: string): { agentAddress?: string } {
   return agentAddress ? { agentAddress } : {};
+}
+
+/**
+ * GH#1778 — the VM-publish caller hint. The token holder is the CALLER, not
+ * necessarily the KA author, so it is passed as `callerAgentAddress` (a
+ * resolution hint), never as `agentAddress` (an authoritative author selector).
+ * Centralised so both publish routes construct the same option.
+ */
+function publishCallerHintLane(agentAddress?: string): { callerAgentAddress?: string } {
+  return agentAddress ? { callerAgentAddress: agentAddress } : {};
 }
 
 function resolveBatchRejectionReporterIdentity(
@@ -1395,10 +1421,7 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
         const publishOptions = opts;
         const intent = await agent.resolveFinalizedAssertionVmPublishIntent(contextGraphId, name, {
           ...(subGraphName ? { subGraphName } : {}),
-          // GH#1778 — the token holder is the CALLER, not necessarily the author.
-          // Pass it as a caller hint so a curator resolves the member author from
-          // stored _meta; an explicit author selector would suppress that.
-          ...(writePreflightCallerAgentAddress ? { callerAgentAddress: writePreflightCallerAgentAddress } : {}),
+          ...publishCallerHintLane(writePreflightCallerAgentAddress),
           ...(publishOptions.publishEpochs !== undefined ? { publishEpochs: publishOptions.publishEpochs } : {}),
           ...(publishOptions.clearSharedMemoryAfter !== undefined
             ? { clearSharedMemoryAfter: publishOptions.clearSharedMemoryAfter }
@@ -1436,9 +1459,7 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
         }
         // GH#1778 — several authors share this KA name; the caller must
         // disambiguate. Surface the candidate authors so the UI/CLI can pick.
-        if (err?.code === "AMBIGUOUS_ASSERTION_AUTHOR") {
-          return jsonResponse(res, 409, { code: err.code, error: err.message ?? String(err), candidates: err.candidates ?? [] });
-        }
+        if (respondAmbiguousAssertionAuthor(res, err)) return;
         if (
           err.message?.includes("required") ||
           err.message?.includes("Invalid") ||
@@ -1471,12 +1492,7 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
         // transparently register and retry (idempotent). All other errors
         // propagate to the precondition/500 mapping below unchanged.
         let pub: FinalizedPublishResult;
-        // GH#1778 — the token holder is the CALLER, not necessarily the author.
-        // Pass it as a caller hint (not an author selector) so a curator resolves
-        // the member author from stored _meta rather than looking under its own.
-        const publishStorageLane = writePreflightCallerAgentAddress
-          ? { callerAgentAddress: writePreflightCallerAgentAddress }
-          : {};
+        const publishStorageLane = publishCallerHintLane(writePreflightCallerAgentAddress);
         try {
           pub = await agent.publishFromFinalizedAssertion(contextGraphId, name, { subGraphName, ...opts, ...publishStorageLane });
         } catch (firstErr: any) {
@@ -1542,9 +1558,7 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
         }
         // GH#1778 — several authors share this KA name; the caller must
         // disambiguate. Surface the candidate authors so the UI/CLI can pick.
-        if (e?.code === "AMBIGUOUS_ASSERTION_AUTHOR") {
-          return jsonResponse(res, 409, { code: e.code, error: msg, candidates: e.candidates ?? [] });
-        }
+        if (respondAmbiguousAssertionAuthor(res, e)) return;
         // Funded-wallet selection found no operational wallet holding the
         // gas + TRAC a publish needs. This is a user-actionable funding
         // condition (4xx), not a server/on-chain bug. Classification + body are

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -158,15 +158,6 @@ const FINALIZE_ONLY_CREATE_FIELDS = [
 ] as const;
 
 /**
- * Translate engine/publisher errors on the WM/SWM mutation verbs into the same
- * HTTP status mapping the legacy `/api/assertion/*` routes use, so callers see
- * 400 for their own mistakes (missing assertion, unsafe/reserved IRI) and 409
- * for the "_meta says completed but the data graph is empty" case — instead of
- * a blanket 500. NOT applied to vm/publish: on-chain/storage failures there can
- * carry "Invalid"/"Unsafe" text and must stay 500 (parity with the legacy
- * publish path, which never down-classified them).
- */
-/**
  * GH#1778 — shared 409 mapping for the ambiguous-author VM-publish error, used
  * by both `vm/publish` and `vm/publish-async` so the `{ code, error, candidates }`
  * response shape cannot drift between the two routes. Returns `true` (and writes
@@ -182,6 +173,15 @@ function respondAmbiguousAssertionAuthor(res: RequestContext["res"], e: any): bo
   return true;
 }
 
+/**
+ * Translate engine/publisher errors on the WM/SWM mutation verbs into the same
+ * HTTP status mapping the legacy `/api/assertion/*` routes use, so callers see
+ * 400 for their own mistakes (missing assertion, unsafe/reserved IRI) and 409
+ * for the "_meta says completed but the data graph is empty" case — instead of
+ * a blanket 500. NOT applied to vm/publish: on-chain/storage failures there can
+ * carry "Invalid"/"Unsafe" text and must stay 500 (parity with the legacy
+ * publish path, which never down-classified them).
+ */
 function respondAssertionError(res: RequestContext["res"], e: any): void {
   if (e?.code === "OVERSIZED_RDF_LITERAL") {
     jsonResponse(res, 400, oversizedRdfLiteralResponseBody(e));

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -1431,6 +1431,11 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
         if (err?.code === "PUBLISH_NOT_FULL_SHARE" || err?.code === "PUBLISH_INTENT_STALE") {
           return jsonResponse(res, 409, { code: err.code, error: err.message ?? String(err) });
         }
+        // GH#1778 — several authors share this KA name; the caller must
+        // disambiguate. Surface the candidate authors so the UI/CLI can pick.
+        if (err?.code === "AMBIGUOUS_ASSERTION_AUTHOR") {
+          return jsonResponse(res, 409, { code: err.code, error: err.message ?? String(err), candidates: err.candidates ?? [] });
+        }
         if (
           err.message?.includes("required") ||
           err.message?.includes("Invalid") ||
@@ -1526,6 +1531,11 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
         // caller precondition; map it to the same 409 (code-first).
         if (e?.code === "PUBLISH_NOT_FULL_SHARE" || /is not finalized/.test(msg) || /No quads in shared memory/.test(msg) || /has no private payload/.test(msg)) {
           return jsonResponse(res, 409, { code: e?.code === "PUBLISH_NOT_FULL_SHARE" ? "PUBLISH_NOT_FULL_SHARE" : "VM_PUBLISH_PRECONDITION", error: msg });
+        }
+        // GH#1778 — several authors share this KA name; the caller must
+        // disambiguate. Surface the candidate authors so the UI/CLI can pick.
+        if (e?.code === "AMBIGUOUS_ASSERTION_AUTHOR") {
+          return jsonResponse(res, 409, { code: e.code, error: msg, candidates: e.candidates ?? [] });
         }
         // Funded-wallet selection found no operational wallet holding the
         // gas + TRAC a publish needs. This is a user-actionable funding

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -1395,7 +1395,10 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
         const publishOptions = opts;
         const intent = await agent.resolveFinalizedAssertionVmPublishIntent(contextGraphId, name, {
           ...(subGraphName ? { subGraphName } : {}),
-          ...(writePreflightCallerAgentAddress ? { agentAddress: writePreflightCallerAgentAddress } : {}),
+          // GH#1778 — the token holder is the CALLER, not necessarily the author.
+          // Pass it as a caller hint so a curator resolves the member author from
+          // stored _meta; an explicit author selector would suppress that.
+          ...(writePreflightCallerAgentAddress ? { callerAgentAddress: writePreflightCallerAgentAddress } : {}),
           ...(publishOptions.publishEpochs !== undefined ? { publishEpochs: publishOptions.publishEpochs } : {}),
           ...(publishOptions.clearSharedMemoryAfter !== undefined
             ? { clearSharedMemoryAfter: publishOptions.clearSharedMemoryAfter }
@@ -1468,7 +1471,12 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
         // transparently register and retry (idempotent). All other errors
         // propagate to the precondition/500 mapping below unchanged.
         let pub: FinalizedPublishResult;
-        const publishStorageLane = scopedTokenStorageLane(writePreflightCallerAgentAddress);
+        // GH#1778 — the token holder is the CALLER, not necessarily the author.
+        // Pass it as a caller hint (not an author selector) so a curator resolves
+        // the member author from stored _meta rather than looking under its own.
+        const publishStorageLane = writePreflightCallerAgentAddress
+          ? { callerAgentAddress: writePreflightCallerAgentAddress }
+          : {};
         try {
           pub = await agent.publishFromFinalizedAssertion(contextGraphId, name, { subGraphName, ...opts, ...publishStorageLane });
         } catch (firstErr: any) {

--- a/packages/cli/test/async-vm-publish-registration.test.ts
+++ b/packages/cli/test/async-vm-publish-registration.test.ts
@@ -3,14 +3,15 @@ import { createKnowledgeAssetVmPublishHandler } from '../src/daemon/lifecycle.js
 
 /**
  * GH#1778 — a curator async-publishes a member-authored KA. The queued intent's
- * `agentAddress` is the resolved AUTHOR (the member), but CG auto-registration on
- * `CG_NOT_REGISTERED` must use the CALLER (the operator/token holder) carried in
- * `callerAgentAddress`, not the author. Before the fix, registration used the
- * member author and could register under / authorize the wrong identity.
+ * `agentAddress` is the resolved AUTHOR (the member). CG auto-registration on
+ * `CG_NOT_REGISTERED` must use the NODE's own operational identity, NOT the
+ * request's author (a member) — and it must be independent of the request
+ * identity so that different callers of the same deduped job cannot collapse
+ * onto one caller's registration actor.
  */
 
-const CURATOR = `0x${'11'.repeat(20)}`;
-const MEMBER = `0x${'22'.repeat(20)}`;
+const NODE = `0x${'11'.repeat(20)}`; // the node's own default identity
+const MEMBER = `0x${'22'.repeat(20)}`; // resolved KA author (not the registrant)
 const CG = 'construction';
 
 function makeMockAgent(registrationCalls: Array<Record<string, unknown> | undefined>) {
@@ -27,36 +28,22 @@ function makeMockAgent(registrationCalls: Array<Record<string, unknown> | undefi
       registrationCalls.push(opts);
     },
     getDefaultAgentAddress() {
-      return CURATOR;
+      return NODE;
     },
   } as any;
 }
 
 describe('GH#1778 async VM publish CG auto-registration', () => {
-  it('registers under the caller (curator), not the resolved member author', async () => {
+  it('registers under the node identity, not the resolved member author', async () => {
     const registrationCalls: Array<Record<string, unknown> | undefined> = [];
     const handler = createKnowledgeAssetVmPublishHandler(makeMockAgent(registrationCalls));
 
-    const request: any = {
-      contextGraphId: CG,
-      name: 'report',
-      agentAddress: MEMBER, // resolved AUTHOR
-      callerAgentAddress: CURATOR, // token/caller identity
-    };
+    // The intent's agentAddress is the resolved AUTHOR (member); registration
+    // must not use it, and must not depend on any per-request caller identity.
+    const request: any = { contextGraphId: CG, name: 'report', agentAddress: MEMBER };
     const result = await handler.execute({ request, publishOptions: {}, publisher: undefined } as any);
 
     expect(result.status).toBe('confirmed');
-    expect(registrationCalls).toHaveLength(1);
-    expect(registrationCalls[0]).toEqual({ callerAgentAddress: CURATOR });
-  });
-
-  it('falls back to agentAddress for an older intent without callerAgentAddress', async () => {
-    const registrationCalls: Array<Record<string, unknown> | undefined> = [];
-    const handler = createKnowledgeAssetVmPublishHandler(makeMockAgent(registrationCalls));
-
-    const request: any = { contextGraphId: CG, name: 'report', agentAddress: MEMBER };
-    await handler.execute({ request, publishOptions: {}, publisher: undefined } as any);
-
-    expect(registrationCalls[0]).toEqual({ callerAgentAddress: MEMBER });
+    expect(registrationCalls).toEqual([{ callerAgentAddress: NODE }]);
   });
 });

--- a/packages/cli/test/async-vm-publish-registration.test.ts
+++ b/packages/cli/test/async-vm-publish-registration.test.ts
@@ -14,7 +14,10 @@ const NODE = `0x${'11'.repeat(20)}`; // the node's own default identity
 const MEMBER = `0x${'22'.repeat(20)}`; // resolved KA author (not the registrant)
 const CG = 'construction';
 
-function makeMockAgent(registrationCalls: Array<Record<string, unknown> | undefined>) {
+function makeMockAgent(
+  registrationCalls: Array<Record<string, unknown> | undefined>,
+  defaultAgentAddress: string | undefined,
+) {
   let attempts = 0;
   return {
     async publishQueuedKnowledgeAssetVmPublish() {
@@ -28,7 +31,7 @@ function makeMockAgent(registrationCalls: Array<Record<string, unknown> | undefi
       registrationCalls.push(opts);
     },
     getDefaultAgentAddress() {
-      return NODE;
+      return defaultAgentAddress;
     },
   } as any;
 }
@@ -36,7 +39,7 @@ function makeMockAgent(registrationCalls: Array<Record<string, unknown> | undefi
 describe('GH#1778 async VM publish CG auto-registration', () => {
   it('registers under the node identity, not the resolved member author', async () => {
     const registrationCalls: Array<Record<string, unknown> | undefined> = [];
-    const handler = createKnowledgeAssetVmPublishHandler(makeMockAgent(registrationCalls));
+    const handler = createKnowledgeAssetVmPublishHandler(makeMockAgent(registrationCalls, NODE));
 
     // The intent's agentAddress is the resolved AUTHOR (member); registration
     // must not use it, and must not depend on any per-request caller identity.
@@ -45,5 +48,18 @@ describe('GH#1778 async VM publish CG auto-registration', () => {
 
     expect(result.status).toBe('confirmed');
     expect(registrationCalls).toEqual([{ callerAgentAddress: NODE }]);
+  });
+
+  it('falls back to the request author when the node has no default identity', async () => {
+    // Degenerate deployment: no node default. A self-authored publish (author ==
+    // caller) must still supply an EVM registration actor rather than register
+    // with no address at all.
+    const registrationCalls: Array<Record<string, unknown> | undefined> = [];
+    const handler = createKnowledgeAssetVmPublishHandler(makeMockAgent(registrationCalls, undefined));
+
+    const request: any = { contextGraphId: CG, name: 'report', agentAddress: MEMBER };
+    await handler.execute({ request, publishOptions: {}, publisher: undefined } as any);
+
+    expect(registrationCalls).toEqual([{ callerAgentAddress: MEMBER }]);
   });
 });

--- a/packages/cli/test/async-vm-publish-registration.test.ts
+++ b/packages/cli/test/async-vm-publish-registration.test.ts
@@ -4,20 +4,18 @@ import { createKnowledgeAssetVmPublishHandler } from '../src/daemon/lifecycle.js
 /**
  * GH#1778 — a curator async-publishes a member-authored KA. The queued intent's
  * `agentAddress` is the resolved AUTHOR (the member). CG auto-registration on
- * `CG_NOT_REGISTERED` must use the NODE's own operational identity, NOT the
- * request's author (a member) — and it must be independent of the request
- * identity so that different callers of the same deduped job cannot collapse
- * onto one caller's registration actor.
+ * `CG_NOT_REGISTERED` must stamp the CG curator with the ENQUEUING CALLER
+ * (`callerAgentAddress`, the operator who requested the publish) — matching the
+ * synchronous `vm/publish` lane — NOT the resolved member author. When the
+ * request carries no caller, registration passes no caller and the agent's
+ * `stampAddressCurator` falls back to the node default (again, as sync does).
  */
 
-const NODE = `0x${'11'.repeat(20)}`; // the node's own default identity
-const MEMBER = `0x${'22'.repeat(20)}`; // resolved KA author (not the registrant)
+const CALLER = `0x${'11'.repeat(20)}`; // operator / token holder that enqueued
+const MEMBER = `0x${'22'.repeat(20)}`; // resolved KA author (must NOT be the registrant)
 const CG = 'construction';
 
-function makeMockAgent(
-  registrationCalls: Array<Record<string, unknown> | undefined>,
-  defaultAgentAddress: string | undefined,
-) {
+function makeMockAgent(registrationCalls: Array<Record<string, unknown> | undefined>) {
   let attempts = 0;
   return {
     async publishQueuedKnowledgeAssetVmPublish() {
@@ -30,36 +28,31 @@ function makeMockAgent(
     async ensureRegisteredForPublish(_cg: string, opts?: Record<string, unknown>) {
       registrationCalls.push(opts);
     },
-    getDefaultAgentAddress() {
-      return defaultAgentAddress;
-    },
   } as any;
 }
 
 describe('GH#1778 async VM publish CG auto-registration', () => {
-  it('registers under the node identity, not the resolved member author', async () => {
+  it('registers under the enqueuing caller, not the resolved member author', async () => {
     const registrationCalls: Array<Record<string, unknown> | undefined> = [];
-    const handler = createKnowledgeAssetVmPublishHandler(makeMockAgent(registrationCalls, NODE));
+    const handler = createKnowledgeAssetVmPublishHandler(makeMockAgent(registrationCalls));
 
-    // The intent's agentAddress is the resolved AUTHOR (member); registration
-    // must not use it, and must not depend on any per-request caller identity.
-    const request: any = { contextGraphId: CG, name: 'report', agentAddress: MEMBER };
+    const request: any = { contextGraphId: CG, name: 'report', agentAddress: MEMBER, callerAgentAddress: CALLER };
     const result = await handler.execute({ request, publishOptions: {}, publisher: undefined } as any);
 
     expect(result.status).toBe('confirmed');
-    expect(registrationCalls).toEqual([{ callerAgentAddress: NODE }]);
+    expect(registrationCalls).toEqual([{ callerAgentAddress: CALLER }]);
   });
 
-  it('falls back to the request author when the node has no default identity', async () => {
-    // Degenerate deployment: no node default. A self-authored publish (author ==
-    // caller) must still supply an EVM registration actor rather than register
-    // with no address at all.
+  it('passes no caller when the request has none (defers to the node-default curator stamp)', async () => {
     const registrationCalls: Array<Record<string, unknown> | undefined> = [];
-    const handler = createKnowledgeAssetVmPublishHandler(makeMockAgent(registrationCalls, undefined));
+    const handler = createKnowledgeAssetVmPublishHandler(makeMockAgent(registrationCalls));
 
+    // No callerAgentAddress (tokenless / pre-#1778 job). Registration must NOT
+    // fall back to the resolved member author — it passes nothing, and the real
+    // stampAddressCurator falls back to the node default (as the sync lane does).
     const request: any = { contextGraphId: CG, name: 'report', agentAddress: MEMBER };
     await handler.execute({ request, publishOptions: {}, publisher: undefined } as any);
 
-    expect(registrationCalls).toEqual([{ callerAgentAddress: MEMBER }]);
+    expect(registrationCalls).toEqual([{}]);
   });
 });

--- a/packages/cli/test/async-vm-publish-registration.test.ts
+++ b/packages/cli/test/async-vm-publish-registration.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { createKnowledgeAssetVmPublishHandler } from '../src/daemon/lifecycle.js';
+
+/**
+ * GH#1778 — a curator async-publishes a member-authored KA. The queued intent's
+ * `agentAddress` is the resolved AUTHOR (the member), but CG auto-registration on
+ * `CG_NOT_REGISTERED` must use the CALLER (the operator/token holder) carried in
+ * `callerAgentAddress`, not the author. Before the fix, registration used the
+ * member author and could register under / authorize the wrong identity.
+ */
+
+const CURATOR = `0x${'11'.repeat(20)}`;
+const MEMBER = `0x${'22'.repeat(20)}`;
+const CG = 'construction';
+
+function makeMockAgent(registrationCalls: Array<Record<string, unknown> | undefined>) {
+  let attempts = 0;
+  return {
+    async publishQueuedKnowledgeAssetVmPublish() {
+      attempts += 1;
+      if (attempts === 1) {
+        throw Object.assign(new Error('context graph not registered on-chain'), { code: 'CG_NOT_REGISTERED' });
+      }
+      return { status: 'confirmed', ual: 'did:dkg:test/1/7', kaId: '7' };
+    },
+    async ensureRegisteredForPublish(_cg: string, opts?: Record<string, unknown>) {
+      registrationCalls.push(opts);
+    },
+    getDefaultAgentAddress() {
+      return CURATOR;
+    },
+  } as any;
+}
+
+describe('GH#1778 async VM publish CG auto-registration', () => {
+  it('registers under the caller (curator), not the resolved member author', async () => {
+    const registrationCalls: Array<Record<string, unknown> | undefined> = [];
+    const handler = createKnowledgeAssetVmPublishHandler(makeMockAgent(registrationCalls));
+
+    const request: any = {
+      contextGraphId: CG,
+      name: 'report',
+      agentAddress: MEMBER, // resolved AUTHOR
+      callerAgentAddress: CURATOR, // token/caller identity
+    };
+    const result = await handler.execute({ request, publishOptions: {}, publisher: undefined } as any);
+
+    expect(result.status).toBe('confirmed');
+    expect(registrationCalls).toHaveLength(1);
+    expect(registrationCalls[0]).toEqual({ callerAgentAddress: CURATOR });
+  });
+
+  it('falls back to agentAddress for an older intent without callerAgentAddress', async () => {
+    const registrationCalls: Array<Record<string, unknown> | undefined> = [];
+    const handler = createKnowledgeAssetVmPublishHandler(makeMockAgent(registrationCalls));
+
+    const request: any = { contextGraphId: CG, name: 'report', agentAddress: MEMBER };
+    await handler.execute({ request, publishOptions: {}, publisher: undefined } as any);
+
+    expect(registrationCalls[0]).toEqual({ callerAgentAddress: MEMBER });
+  });
+});

--- a/packages/cli/test/knowledge-assets-1116-share-errors.test.ts
+++ b/packages/cli/test/knowledge-assets-1116-share-errors.test.ts
@@ -445,6 +445,39 @@ describe('#1116 share/seal route error mapping (fake agent)', () => {
     expect(enqueueCalls).toBe(0);
   });
 
+  // GH#1778 — the disambiguation error surfaces as a 409 with the candidate
+  // author list so UI/CLI consumers can pick an author.
+  const AMBIGUOUS_AUTHORS = [
+    '0xA32f1cc125401B55911678847426759094055B2d',
+    '0x2222222222222222222222222222222222222222',
+  ];
+  function throwAmbiguousAuthor(): never {
+    throw Object.assign(
+      new Error('2 authors have a knowledge asset with this name'),
+      { code: 'AMBIGUOUS_ASSERTION_AUTHOR', candidates: AMBIGUOUS_AUTHORS },
+    );
+  }
+
+  it('vm/publish-async: AMBIGUOUS_ASSERTION_AUTHOR → 409 { code, candidates }', async () => {
+    await startWith({}, {
+      resolveFinalizedAssertionVmPublishIntent: async () => throwAmbiguousAuthor(),
+    });
+    const res = await post('vm/publish-async', { contextGraphId: CG_ID });
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe('AMBIGUOUS_ASSERTION_AUTHOR');
+    expect(res.body.candidates).toEqual(AMBIGUOUS_AUTHORS);
+  });
+
+  it('vm/publish: AMBIGUOUS_ASSERTION_AUTHOR → 409 { code, candidates }', async () => {
+    await startWith({}, {
+      publishFromFinalizedAssertion: async () => throwAmbiguousAuthor(),
+    });
+    const res = await post('vm/publish', { contextGraphId: CG_ID });
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe('AMBIGUOUS_ASSERTION_AUTHOR');
+    expect(res.body.candidates).toEqual(AMBIGUOUS_AUTHORS);
+  });
+
   it('vm/publish-async rejects before persisting when no runtime can claim jobs', async () => {
     let resolved = 0;
     let enqueued = 0;
@@ -796,7 +829,9 @@ describe('#1116 share/seal route error mapping (fake agent)', () => {
         return {
           contextGraphId: CG_ID,
           name: ASSERTION_NAME,
-          agentAddress: opts.agentAddress,
+          // GH#1778 — the route forwards the token as a CALLER hint; the author
+          // is resolved from that (here the caller IS the author).
+          agentAddress: opts.callerAgentAddress,
           shareOperationId: 'share-token-agent',
           roots: ['urn:test:token-agent-root'],
           seal: {
@@ -830,7 +865,7 @@ describe('#1116 share/seal route error mapping (fake agent)', () => {
     expect(res.status).toBe(202);
     expect(res.body.jobId).toBe('job-token-agent');
     expect(seenResolveOptions).toHaveLength(1);
-    expect(seenResolveOptions[0]).toMatchObject({ agentAddress: tokenAgentAddress });
+    expect(seenResolveOptions[0]).toMatchObject({ callerAgentAddress: tokenAgentAddress });
     expect(enqueuedIntents[0]).toMatchObject({ agentAddress: tokenAgentAddress });
   });
 
@@ -1478,7 +1513,7 @@ describe('#1116 share/seal route error mapping (fake agent)', () => {
       expect(createCalls).toHaveLength(0);
     });
 
-    it('passes the token-scoped storage lane into finalized publish calls', async () => {
+    it('passes the token caller hint into finalized publish calls', async () => {
       const token = 'agent-token-a';
       const tokenAgentAddress = `0x${'ab'.repeat(20)}`;
       const seenOpts: unknown[] = [];
@@ -1506,7 +1541,7 @@ describe('#1116 share/seal route error mapping (fake agent)', () => {
       expect(res.status).toBe(200);
       expect(res.body.storageAckPeerIds).toEqual(['12D3KooWStorageCore3']);
       expect(seenOpts).toHaveLength(1);
-      expect(seenOpts[0]).toMatchObject({ agentAddress: tokenAgentAddress });
+      expect(seenOpts[0]).toMatchObject({ callerAgentAddress: tokenAgentAddress });
     });
 
     it('standalone vm/publish accepts uint72 publisher identity overrides into publish options', async () => {

--- a/packages/cli/test/knowledge-assets-1116-share-errors.test.ts
+++ b/packages/cli/test/knowledge-assets-1116-share-errors.test.ts
@@ -1009,7 +1009,9 @@ describe('#1116 share/seal route error mapping (fake agent)', () => {
     const intent = {
       contextGraphId: CG_ID,
       name: ASSERTION_NAME,
+      // agentAddress = resolved AUTHOR; callerAgentAddress = enqueuing operator.
       agentAddress: '0x00000000000000000000000000000000000000b2',
+      callerAgentAddress: '0x00000000000000000000000000000000000000c3',
       shareOperationId: rootless.shareOperationId,
       roots: [],
       contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
@@ -1093,11 +1095,10 @@ describe('#1116 share/seal route error mapping (fake agent)', () => {
       expect(processed?.status).toBe('finalized');
       expect(calls).toEqual([
         'publish#1',
-        // GH#1778 — CG auto-registration uses the NODE's own identity
-        // (getDefaultAgentAddress = ...a1), NOT the intent's resolved author
-        // (agentAddress = ...b2), so a member-authored curator publish registers
-        // under the operator and cannot collapse onto another caller's identity.
-        'register:0x00000000000000000000000000000000000000a1',
+        // GH#1778 — CG auto-registration stamps the curator with the ENQUEUING
+        // CALLER (callerAgentAddress = ...c3), matching the sync vm/publish lane,
+        // NOT the intent's resolved author (agentAddress = ...b2).
+        'register:0x00000000000000000000000000000000000000c3',
         'publish#2',
       ]);
       expect(publishAttempts).toBe(2);

--- a/packages/cli/test/knowledge-assets-1116-share-errors.test.ts
+++ b/packages/cli/test/knowledge-assets-1116-share-errors.test.ts
@@ -1093,7 +1093,11 @@ describe('#1116 share/seal route error mapping (fake agent)', () => {
       expect(processed?.status).toBe('finalized');
       expect(calls).toEqual([
         'publish#1',
-        'register:0x00000000000000000000000000000000000000b2',
+        // GH#1778 — CG auto-registration uses the NODE's own identity
+        // (getDefaultAgentAddress = ...a1), NOT the intent's resolved author
+        // (agentAddress = ...b2), so a member-authored curator publish registers
+        // under the operator and cannot collapse onto another caller's identity.
+        'register:0x00000000000000000000000000000000000000a1',
         'publish#2',
       ]);
       expect(publishAttempts).toBe(2);

--- a/packages/cli/vitest.unit.config.ts
+++ b/packages/cli/vitest.unit.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
       ? ['test/daemon-http-behavior-extra.test.ts']
       : [
           'test/api-client.test.ts',
+          'test/async-vm-publish-registration.test.ts',
           'test/agent-connect-routes.test.ts',
           'test/preferred-relays.test.ts',
           'test/reconcile-503-mapping.test.ts',

--- a/packages/core/src/assertion-seal.ts
+++ b/packages/core/src/assertion-seal.ts
@@ -395,12 +395,6 @@ export interface AssertionSeal {
 }
 
 /**
- * Parse a `_meta` quad slice (already filtered to subject =
- * assertionUri) into a typed seal record. Returns `undefined` when
- * the assertion has not been finalized (no merkle root present).
- * Throws on partial seals — those signal store corruption.
- */
-/**
  * The single low-level seal-field collector, shared by
  * {@link parseAssertionSealQuads} and {@link parseGraphScopedAssertionSealCandidate}. Filters to
  * `subject === assertionUri`, normalises/validates root-entity IRIs, and returns
@@ -443,6 +437,12 @@ function collectSealFieldObjects(
   return { fields, rootEntities };
 }
 
+/**
+ * Parse a `_meta` quad slice (already filtered to subject =
+ * assertionUri) into a typed seal record. Returns `undefined` when
+ * the assertion has not been finalized (no merkle root present).
+ * Throws on partial seals — those signal store corruption.
+ */
 export function parseAssertionSealQuads(
   quads: ReadonlyArray<{ subject: string; predicate: string; object: string }>,
   assertionUri: string,

--- a/packages/core/src/assertion-seal.ts
+++ b/packages/core/src/assertion-seal.ts
@@ -129,8 +129,10 @@ function hexBinaryLexical(hex: string): string {
  * Caller supplies the resolved `assertionUri` (subject), the `_meta`
  * graph URI for the context graph (typically
  * `contextGraphMetaUri(contextGraphId)`), and the seal payload.
- * Every quad is pinned to the `metaGraph` so the gossip layer
- * propagates them with the rest of `_meta`.
+ * Every quad is pinned to the `metaGraph`. NOTE: the seal does NOT ride
+ * SWM live gossip (that path force-rewrites quads onto the KA's data graph
+ * and never carried seal fields); its peer-to-peer transport is the durable
+ * `_meta` sync lane. See GH#1778.
  */
 interface AssertionSealBuildBaseArgs {
   assertionUri: string;

--- a/packages/core/src/assertion-seal.ts
+++ b/packages/core/src/assertion-seal.ts
@@ -402,7 +402,7 @@ export interface AssertionSeal {
  */
 /**
  * The single low-level seal-field collector, shared by
- * {@link parseAssertionSealQuads} and {@link graphScopedSealAuthor}. Filters to
+ * {@link parseAssertionSealQuads} and {@link isSelfConsistentGraphScopedAssertionSeal}. Filters to
  * `subject === assertionUri`, normalises/validates root-entity IRIs, and returns
  * every non-root-entity object grouped by predicate WITH MULTIPLICITY preserved
  * — so each caller applies its own cardinality policy (the full parser takes the
@@ -601,58 +601,59 @@ export function parseAssertionSealQuads(
 }
 
 /**
- * GH#1778 — durable-sync admission helper. Given a subject's `_meta` rows,
- * return the seal author address when they form a *self-consistent graph-scoped
- * author seal rooted at the subject's own author coordinate*, else `undefined`.
- *
- * Lives beside {@link ASSERTION_SEAL_PREDICATES} and {@link parseAssertionSealQuads}
- * so the durable-sync integrity layer does not re-declare seal predicate names
- * or re-implement seal-shape parsing. Deliberately lighter than
- * `parseAssertionSealQuads` (it never throws and only inspects the identity
- * fields) because it runs on peer-supplied rows during selection: it decides
- * whether the seal's `dkg:assertionVersion` control predicate may be admitted.
- * The seal's ultimate integrity is still enforced at publish time (the Merkle
+ * GH#1778 — durable-sync admission predicate. Returns `true` when a subject's
+ * `_meta` rows form a *self-consistent graph-scoped author seal rooted at the
+ * subject's own author coordinate*, so the durable-sync integrity layer may
+ * treat the seal's `dkg:assertionVersion` row as descriptive metadata rather
+ * than an authenticated control. This is a narrow admission policy, not a
+ * general author extractor — but it lives beside {@link ASSERTION_SEAL_PREDICATES}
+ * and {@link parseAssertionSealQuads} so the integrity layer does not re-declare
+ * seal predicate names or re-implement seal-shape parsing. Deliberately lighter
+ * than `parseAssertionSealQuads` (never throws, inspects only identity fields);
+ * the seal's ultimate integrity is still enforced at publish time (the Merkle
  * recompute against the author-signed root).
  *
  * Self-consistent means: the subject carries the author-signed
  * `assertionMerkleRoot`; content scope is graph-scoped v2; there is exactly one
- * `kaUal` and one `authorAddress`; and the `kaUal` author, the `authorAddress`,
- * and the `/assertion/<addr>/…` subject coordinate all agree (case-folded).
+ * distinct `kaUal`, `authorAddress`, AND `assertionVersion` (fail-closed on any
+ * conflicting/duplicate value, so a tampered version cannot be admitted); and
+ * the `kaUal` author, the `authorAddress`, and the `/assertion/<addr>/…` subject
+ * coordinate all agree (case-folded).
  */
-export function graphScopedSealAuthor(
+export function isSelfConsistentGraphScopedAssertionSeal(
   rows: ReadonlyArray<{ subject: string; predicate: string; object: string }>,
   subject: string,
-): string | undefined {
+): boolean {
   try {
     const { fields } = collectSealFieldObjects(rows, subject);
-    // Admission is fail-closed on ambiguity: an identity predicate present with
-    // anything other than exactly one DISTINCT value is treated as absent, so a
-    // peer that supplies two conflicting kaUal/authorAddress values can never be
-    // silently collapsed to one (unlike the full parser's last-writer-wins).
+    // Fail closed on ambiguity: an identity predicate present with anything
+    // other than exactly one DISTINCT value is treated as absent, so a peer that
+    // supplies two conflicting kaUal/authorAddress/assertionVersion values can
+    // never be silently collapsed to one (unlike the full parser's last-writer).
     const exactlyOne = (predicate: string): string | undefined => {
       const distinct = [...new Set(fields.get(predicate) ?? [])];
       return distinct.length === 1 ? distinct[0] : undefined;
     };
-    if (!fields.has(ASSERTION_SEAL_PREDICATES.ASSERTION_MERKLE_ROOT)) return undefined;
+    if (!fields.has(ASSERTION_SEAL_PREDICATES.ASSERTION_MERKLE_ROOT)) return false;
     const scopeVersion = exactlyOne(ASSERTION_SEAL_PREDICATES.CONTENT_SCOPE_VERSION);
     if (scopeVersion === undefined
       || integerLiteralToValue(scopeVersion) !== BigInt(GRAPH_KA_CONTENT_SCOPE_VERSION)) {
-      return undefined;
+      return false;
     }
+    // The admitted field itself must be single-valued — a subject with two
+    // conflicting assertionVersion rows is rejected outright (the 🔴 this guards).
+    if (exactlyOne(ASSERTION_SEAL_PREDICATES.ASSERTION_VERSION) === undefined) return false;
     const kaUalObject = exactlyOne(ASSERTION_SEAL_PREDICATES.KA_UAL);
     const authorObject = exactlyOne(ASSERTION_SEAL_PREDICATES.AUTHOR_ADDRESS);
-    if (kaUalObject === undefined || authorObject === undefined) return undefined;
+    if (kaUalObject === undefined || authorObject === undefined) return false;
     const author = stringLiteralToValue(authorObject);
     const ualAuthor = parseDeterministicKnowledgeAssetUal(iriObjectToValue(kaUalObject)).agentAddress;
     const coordinate = parseContextGraphAssertionUri(subject);
-    if (!coordinate) return undefined;
+    if (!coordinate) return false;
     const lc = author.toLowerCase();
-    if (ualAuthor.toLowerCase() !== lc || coordinate.agentAddress.toLowerCase() !== lc) {
-      return undefined;
-    }
-    return author;
+    return ualAuthor.toLowerCase() === lc && coordinate.agentAddress.toLowerCase() === lc;
   } catch {
-    return undefined;
+    return false;
   }
 }
 

--- a/packages/core/src/assertion-seal.ts
+++ b/packages/core/src/assertion-seal.ts
@@ -400,11 +400,20 @@ export interface AssertionSeal {
  * the assertion has not been finalized (no merkle root present).
  * Throws on partial seals — those signal store corruption.
  */
-export function parseAssertionSealQuads(
+/**
+ * The single low-level seal-field collector, shared by
+ * {@link parseAssertionSealQuads} and {@link graphScopedSealAuthor}. Filters to
+ * `subject === assertionUri`, normalises/validates root-entity IRIs, and returns
+ * every non-root-entity object grouped by predicate WITH MULTIPLICITY preserved
+ * — so each caller applies its own cardinality policy (the full parser takes the
+ * last value; durable admission requires exactly one and fails closed on
+ * ambiguity). Throws only on an unsafe root-entity IRI (store corruption).
+ */
+function collectSealFieldObjects(
   quads: ReadonlyArray<{ subject: string; predicate: string; object: string }>,
   assertionUri: string,
-): AssertionSeal | undefined {
-  const seen = new Map<string, string>();
+): { fields: Map<string, string[]>; rootEntities: string[] } {
+  const fields = new Map<string, string[]>();
   const rootEntities: string[] = [];
   for (const q of quads) {
     if (q.subject !== assertionUri) continue;
@@ -427,8 +436,22 @@ export function parseAssertionSealQuads(
       rootEntities.push(root);
       continue;
     }
-    seen.set(q.predicate, q.object);
+    const existing = fields.get(q.predicate);
+    if (existing) existing.push(q.object);
+    else fields.set(q.predicate, [q.object]);
   }
+  return { fields, rootEntities };
+}
+
+export function parseAssertionSealQuads(
+  quads: ReadonlyArray<{ subject: string; predicate: string; object: string }>,
+  assertionUri: string,
+): AssertionSeal | undefined {
+  const { fields, rootEntities } = collectSealFieldObjects(quads, assertionUri);
+  // Full parse keeps last-writer-wins for a repeated predicate (historical
+  // behaviour): collapse each predicate's objects to its last value.
+  const seen = new Map<string, string>();
+  for (const [predicate, objects] of fields) seen.set(predicate, objects[objects.length - 1]!);
   if (!seen.has(ASSERTION_SEAL_PREDICATES.ASSERTION_MERKLE_ROOT)) return undefined;
 
   const required = [
@@ -600,28 +623,27 @@ export function graphScopedSealAuthor(
   rows: ReadonlyArray<{ subject: string; predicate: string; object: string }>,
   subject: string,
 ): string | undefined {
-  const own = rows.filter((q) => q.subject === subject);
-  // Admission policy is fail-closed on ambiguity: read DISTINCT objects for each
-  // identity predicate and require exactly one (NOT last-writer-wins — a peer
-  // that supplies two conflicting kaUal/authorAddress values must not be
-  // silently collapsed to one). Reuses the canonical seal vocabulary + literal
-  // decoders rather than re-declaring them.
-  const distinctObjectsOf = (predicate: string): string[] =>
-    [...new Set(own.filter((q) => q.predicate === predicate).map((q) => q.object))];
-  if (!own.some((q) => q.predicate === ASSERTION_SEAL_PREDICATES.ASSERTION_MERKLE_ROOT)) {
-    return undefined;
-  }
   try {
-    const scopeVersions = distinctObjectsOf(ASSERTION_SEAL_PREDICATES.CONTENT_SCOPE_VERSION);
-    if (scopeVersions.length !== 1
-      || integerLiteralToValue(scopeVersions[0]!) !== BigInt(GRAPH_KA_CONTENT_SCOPE_VERSION)) {
+    const { fields } = collectSealFieldObjects(rows, subject);
+    // Admission is fail-closed on ambiguity: an identity predicate present with
+    // anything other than exactly one DISTINCT value is treated as absent, so a
+    // peer that supplies two conflicting kaUal/authorAddress values can never be
+    // silently collapsed to one (unlike the full parser's last-writer-wins).
+    const exactlyOne = (predicate: string): string | undefined => {
+      const distinct = [...new Set(fields.get(predicate) ?? [])];
+      return distinct.length === 1 ? distinct[0] : undefined;
+    };
+    if (!fields.has(ASSERTION_SEAL_PREDICATES.ASSERTION_MERKLE_ROOT)) return undefined;
+    const scopeVersion = exactlyOne(ASSERTION_SEAL_PREDICATES.CONTENT_SCOPE_VERSION);
+    if (scopeVersion === undefined
+      || integerLiteralToValue(scopeVersion) !== BigInt(GRAPH_KA_CONTENT_SCOPE_VERSION)) {
       return undefined;
     }
-    const kaUals = distinctObjectsOf(ASSERTION_SEAL_PREDICATES.KA_UAL);
-    const authors = distinctObjectsOf(ASSERTION_SEAL_PREDICATES.AUTHOR_ADDRESS);
-    if (kaUals.length !== 1 || authors.length !== 1) return undefined;
-    const author = stringLiteralToValue(authors[0]!);
-    const ualAuthor = parseDeterministicKnowledgeAssetUal(iriObjectToValue(kaUals[0]!)).agentAddress;
+    const kaUalObject = exactlyOne(ASSERTION_SEAL_PREDICATES.KA_UAL);
+    const authorObject = exactlyOne(ASSERTION_SEAL_PREDICATES.AUTHOR_ADDRESS);
+    if (kaUalObject === undefined || authorObject === undefined) return undefined;
+    const author = stringLiteralToValue(authorObject);
+    const ualAuthor = parseDeterministicKnowledgeAssetUal(iriObjectToValue(kaUalObject)).agentAddress;
     const coordinate = parseContextGraphAssertionUri(subject);
     if (!coordinate) return undefined;
     const lc = author.toLowerCase();

--- a/packages/core/src/assertion-seal.ts
+++ b/packages/core/src/assertion-seal.ts
@@ -400,18 +400,10 @@ export interface AssertionSeal {
  * the assertion has not been finalized (no merkle root present).
  * Throws on partial seals — those signal store corruption.
  */
-/**
- * Collect a `_meta` quad slice (filtered to `subject === assertionUri`) into a
- * predicate→object map plus the multi-valued root-entity list. The SINGLE seal
- * field collector, shared by {@link parseAssertionSealQuads} (full validation)
- * and {@link graphScopedSealAuthor} (durable-sync admission), so both interpret
- * the seal vocabulary from one place with the same last-writer-wins semantics.
- * Throws only on an unsafe root-entity IRI (store corruption).
- */
-function collectAssertionSealFields(
+export function parseAssertionSealQuads(
   quads: ReadonlyArray<{ subject: string; predicate: string; object: string }>,
   assertionUri: string,
-): { seen: Map<string, string>; rootEntities: string[] } {
+): AssertionSeal | undefined {
   const seen = new Map<string, string>();
   const rootEntities: string[] = [];
   for (const q of quads) {
@@ -437,14 +429,6 @@ function collectAssertionSealFields(
     }
     seen.set(q.predicate, q.object);
   }
-  return { seen, rootEntities };
-}
-
-export function parseAssertionSealQuads(
-  quads: ReadonlyArray<{ subject: string; predicate: string; object: string }>,
-  assertionUri: string,
-): AssertionSeal | undefined {
-  const { seen, rootEntities } = collectAssertionSealFields(quads, assertionUri);
   if (!seen.has(ASSERTION_SEAL_PREDICATES.ASSERTION_MERKLE_ROOT)) return undefined;
 
   const required = [
@@ -616,19 +600,28 @@ export function graphScopedSealAuthor(
   rows: ReadonlyArray<{ subject: string; predicate: string; object: string }>,
   subject: string,
 ): string | undefined {
+  const own = rows.filter((q) => q.subject === subject);
+  // Admission policy is fail-closed on ambiguity: read DISTINCT objects for each
+  // identity predicate and require exactly one (NOT last-writer-wins — a peer
+  // that supplies two conflicting kaUal/authorAddress values must not be
+  // silently collapsed to one). Reuses the canonical seal vocabulary + literal
+  // decoders rather than re-declaring them.
+  const distinctObjectsOf = (predicate: string): string[] =>
+    [...new Set(own.filter((q) => q.predicate === predicate).map((q) => q.object))];
+  if (!own.some((q) => q.predicate === ASSERTION_SEAL_PREDICATES.ASSERTION_MERKLE_ROOT)) {
+    return undefined;
+  }
   try {
-    const { seen } = collectAssertionSealFields(rows, subject);
-    if (!seen.has(ASSERTION_SEAL_PREDICATES.ASSERTION_MERKLE_ROOT)) return undefined;
-    const scopeVersion = seen.get(ASSERTION_SEAL_PREDICATES.CONTENT_SCOPE_VERSION);
-    if (scopeVersion === undefined
-      || integerLiteralToValue(scopeVersion) !== BigInt(GRAPH_KA_CONTENT_SCOPE_VERSION)) {
+    const scopeVersions = distinctObjectsOf(ASSERTION_SEAL_PREDICATES.CONTENT_SCOPE_VERSION);
+    if (scopeVersions.length !== 1
+      || integerLiteralToValue(scopeVersions[0]!) !== BigInt(GRAPH_KA_CONTENT_SCOPE_VERSION)) {
       return undefined;
     }
-    const kaUalObject = seen.get(ASSERTION_SEAL_PREDICATES.KA_UAL);
-    const authorObject = seen.get(ASSERTION_SEAL_PREDICATES.AUTHOR_ADDRESS);
-    if (kaUalObject === undefined || authorObject === undefined) return undefined;
-    const author = stringLiteralToValue(authorObject);
-    const ualAuthor = parseDeterministicKnowledgeAssetUal(iriObjectToValue(kaUalObject)).agentAddress;
+    const kaUals = distinctObjectsOf(ASSERTION_SEAL_PREDICATES.KA_UAL);
+    const authors = distinctObjectsOf(ASSERTION_SEAL_PREDICATES.AUTHOR_ADDRESS);
+    if (kaUals.length !== 1 || authors.length !== 1) return undefined;
+    const author = stringLiteralToValue(authors[0]!);
+    const ualAuthor = parseDeterministicKnowledgeAssetUal(iriObjectToValue(kaUals[0]!)).agentAddress;
     const coordinate = parseContextGraphAssertionUri(subject);
     if (!coordinate) return undefined;
     const lc = author.toLowerCase();

--- a/packages/core/src/assertion-seal.ts
+++ b/packages/core/src/assertion-seal.ts
@@ -25,7 +25,9 @@ import {
   GRAPH_KA_CONTENT_SCOPE_VERSION,
   LEGACY_ROOT_CONTENT_SCOPE_VERSION,
   createGraphKnowledgeAssetScope,
+  parseDeterministicKnowledgeAssetUal,
 } from './ka-content-scope.js';
+import { parseContextGraphAssertionUri } from './constants.js';
 
 const ONT = 'http://dkg.io/ontology/';
 
@@ -573,6 +575,59 @@ export function parseAssertionSealQuads(
     ...(privateTripleCount !== undefined ? { privateTripleCount } : {}),
     rootEntities,
   };
+}
+
+/**
+ * GH#1778 — durable-sync admission helper. Given a subject's `_meta` rows,
+ * return the seal author address when they form a *self-consistent graph-scoped
+ * author seal rooted at the subject's own author coordinate*, else `undefined`.
+ *
+ * Lives beside {@link ASSERTION_SEAL_PREDICATES} and {@link parseAssertionSealQuads}
+ * so the durable-sync integrity layer does not re-declare seal predicate names
+ * or re-implement seal-shape parsing. Deliberately lighter than
+ * `parseAssertionSealQuads` (it never throws and only inspects the identity
+ * fields) because it runs on peer-supplied rows during selection: it decides
+ * whether the seal's `dkg:assertionVersion` control predicate may be admitted.
+ * The seal's ultimate integrity is still enforced at publish time (the Merkle
+ * recompute against the author-signed root).
+ *
+ * Self-consistent means: the subject carries the author-signed
+ * `assertionMerkleRoot`; content scope is graph-scoped v2; there is exactly one
+ * `kaUal` and one `authorAddress`; and the `kaUal` author, the `authorAddress`,
+ * and the `/assertion/<addr>/…` subject coordinate all agree (case-folded).
+ */
+export function graphScopedSealAuthor(
+  rows: ReadonlyArray<{ subject: string; predicate: string; object: string }>,
+  subject: string,
+): string | undefined {
+  const own = rows.filter((q) => q.subject === subject);
+  const objectsOf = (predicate: string): string[] =>
+    [...new Set(own.filter((q) => q.predicate === predicate).map((q) => q.object))];
+
+  if (!own.some((q) => q.predicate === ASSERTION_SEAL_PREDICATES.ASSERTION_MERKLE_ROOT)) {
+    return undefined;
+  }
+  try {
+    const scopeVersions = objectsOf(ASSERTION_SEAL_PREDICATES.CONTENT_SCOPE_VERSION);
+    if (scopeVersions.length !== 1
+      || integerLiteralToValue(scopeVersions[0]!) !== BigInt(GRAPH_KA_CONTENT_SCOPE_VERSION)) {
+      return undefined;
+    }
+    const kaUals = objectsOf(ASSERTION_SEAL_PREDICATES.KA_UAL);
+    const authors = objectsOf(ASSERTION_SEAL_PREDICATES.AUTHOR_ADDRESS);
+    if (kaUals.length !== 1 || authors.length !== 1) return undefined;
+    const author = stringLiteralToValue(authors[0]!);
+    const ualAuthor = parseDeterministicKnowledgeAssetUal(iriObjectToValue(kaUals[0]!)).agentAddress;
+    const coordinate = parseContextGraphAssertionUri(subject);
+    if (!coordinate) return undefined;
+    const lc = author.toLowerCase();
+    if (ualAuthor.toLowerCase() !== lc || coordinate.agentAddress.toLowerCase() !== lc) {
+      return undefined;
+    }
+    return author;
+  } catch {
+    return undefined;
+  }
 }
 
 // ── literal helpers ─────────────────────────────────────────────

--- a/packages/core/src/assertion-seal.ts
+++ b/packages/core/src/assertion-seal.ts
@@ -402,7 +402,7 @@ export interface AssertionSeal {
  */
 /**
  * The single low-level seal-field collector, shared by
- * {@link parseAssertionSealQuads} and {@link isSelfConsistentGraphScopedAssertionSeal}. Filters to
+ * {@link parseAssertionSealQuads} and {@link parseGraphScopedAssertionSealCandidate}. Filters to
  * `subject === assertionUri`, normalises/validates root-entity IRIs, and returns
  * every non-root-entity object grouped by predicate WITH MULTIPLICITY preserved
  * — so each caller applies its own cardinality policy (the full parser takes the
@@ -600,60 +600,66 @@ export function parseAssertionSealQuads(
   };
 }
 
+/** A validated, publishable graph-scoped author seal candidate + its coordinate. */
+export interface GraphScopedAssertionSealCandidate {
+  seal: AssertionSeal;
+  coordinate: { scope: string; agentAddress: string; name: string };
+}
+
 /**
- * GH#1778 — durable-sync admission predicate. Returns `true` when a subject's
- * `_meta` rows form a *self-consistent graph-scoped author seal rooted at the
- * subject's own author coordinate*, so the durable-sync integrity layer may
- * treat the seal's `dkg:assertionVersion` row as descriptive metadata rather
- * than an authenticated control. This is a narrow admission policy, not a
- * general author extractor — but it lives beside {@link ASSERTION_SEAL_PREDICATES}
- * and {@link parseAssertionSealQuads} so the integrity layer does not re-declare
- * seal predicate names or re-implement seal-shape parsing. Deliberately lighter
- * than `parseAssertionSealQuads` (never throws, inspects only identity fields);
- * the seal's ultimate integrity is still enforced at publish time (the Merkle
- * recompute against the author-signed root).
+ * GH#1778 — the SINGLE canonical definition of a "publishable graph-scoped
+ * author seal", shared by VM-publish author resolution and durable-sync
+ * admission so the two never drift. Returns the parsed seal + its subject
+ * coordinate iff a subject's `_meta` rows form a complete, self-consistent
+ * graph-scoped v2 seal rooted at its own author coordinate; otherwise
+ * `undefined` (never throws — safe on peer-supplied rows during selection).
  *
- * Self-consistent means: the subject carries the author-signed
- * `assertionMerkleRoot`; content scope is graph-scoped v2; there is exactly one
- * distinct `kaUal`, `authorAddress`, AND `assertionVersion` (fail-closed on any
- * conflicting/duplicate value, so a tampered version cannot be admitted); and
- * the `kaUal` author, the `authorAddress`, and the `/assertion/<addr>/…` subject
- * coordinate all agree (case-folded).
+ * A row set qualifies only when ALL of the following hold:
+ *  - the identity/version predicates (`assertionMerkleRoot`, `contentScopeVersion`,
+ *    `kaUal`, `authorAddress`, `assertionVersion`) each have exactly ONE distinct
+ *    value — fail-closed on conflicting/duplicate rows, so a peer cannot rely on
+ *    the full parser's last-writer-wins to slip a tampered value through;
+ *  - `parseAssertionSealQuads` accepts it as a COMPLETE seal (all required fields
+ *    present — the exact check publish performs), and it is graph-scoped v2;
+ *  - the subject `/assertion/<addr>/…` coordinate, the seal's `authorAddress`, and
+ *    the `kaUal` author all agree (case-folded) — a seal that names a different
+ *    author than its subject URI is rejected, not silently trusted.
  */
-export function isSelfConsistentGraphScopedAssertionSeal(
+export function parseGraphScopedAssertionSealCandidate(
   rows: ReadonlyArray<{ subject: string; predicate: string; object: string }>,
   subject: string,
-): boolean {
+): GraphScopedAssertionSealCandidate | undefined {
   try {
     const { fields } = collectSealFieldObjects(rows, subject);
-    // Fail closed on ambiguity: an identity predicate present with anything
-    // other than exactly one DISTINCT value is treated as absent, so a peer that
-    // supplies two conflicting kaUal/authorAddress/assertionVersion values can
-    // never be silently collapsed to one (unlike the full parser's last-writer).
-    const exactlyOne = (predicate: string): string | undefined => {
-      const distinct = [...new Set(fields.get(predicate) ?? [])];
-      return distinct.length === 1 ? distinct[0] : undefined;
-    };
-    if (!fields.has(ASSERTION_SEAL_PREDICATES.ASSERTION_MERKLE_ROOT)) return false;
-    const scopeVersion = exactlyOne(ASSERTION_SEAL_PREDICATES.CONTENT_SCOPE_VERSION);
-    if (scopeVersion === undefined
-      || integerLiteralToValue(scopeVersion) !== BigInt(GRAPH_KA_CONTENT_SCOPE_VERSION)) {
-      return false;
+    // Fail closed on ambiguity BEFORE the last-writer-wins full parse: any
+    // identity/version predicate present with more than one distinct value is
+    // rejected outright.
+    for (const predicate of [
+      ASSERTION_SEAL_PREDICATES.ASSERTION_MERKLE_ROOT,
+      ASSERTION_SEAL_PREDICATES.CONTENT_SCOPE_VERSION,
+      ASSERTION_SEAL_PREDICATES.KA_UAL,
+      ASSERTION_SEAL_PREDICATES.AUTHOR_ADDRESS,
+      ASSERTION_SEAL_PREDICATES.ASSERTION_VERSION,
+    ]) {
+      if (new Set(fields.get(predicate) ?? []).size > 1) return undefined;
     }
-    // The admitted field itself must be single-valued — a subject with two
-    // conflicting assertionVersion rows is rejected outright (the 🔴 this guards).
-    if (exactlyOne(ASSERTION_SEAL_PREDICATES.ASSERTION_VERSION) === undefined) return false;
-    const kaUalObject = exactlyOne(ASSERTION_SEAL_PREDICATES.KA_UAL);
-    const authorObject = exactlyOne(ASSERTION_SEAL_PREDICATES.AUTHOR_ADDRESS);
-    if (kaUalObject === undefined || authorObject === undefined) return false;
-    const author = stringLiteralToValue(authorObject);
-    const ualAuthor = parseDeterministicKnowledgeAssetUal(iriObjectToValue(kaUalObject)).agentAddress;
+    const seal = parseAssertionSealQuads(rows, subject);
+    if (!seal
+      || seal.contentScopeVersion !== GRAPH_KA_CONTENT_SCOPE_VERSION
+      || !seal.kaUal) {
+      return undefined;
+    }
     const coordinate = parseContextGraphAssertionUri(subject);
-    if (!coordinate) return false;
-    const lc = author.toLowerCase();
-    return ualAuthor.toLowerCase() === lc && coordinate.agentAddress.toLowerCase() === lc;
+    if (!coordinate) return undefined;
+    // Identity alignment: subject-coordinate author == seal author == kaUal author.
+    const sealAuthor = seal.authorAddress.toLowerCase();
+    const ualAuthor = parseDeterministicKnowledgeAssetUal(seal.kaUal).agentAddress.toLowerCase();
+    if (coordinate.agentAddress.toLowerCase() !== sealAuthor || ualAuthor !== sealAuthor) {
+      return undefined;
+    }
+    return { seal, coordinate };
   } catch {
-    return false;
+    return undefined;
   }
 }
 

--- a/packages/core/src/assertion-seal.ts
+++ b/packages/core/src/assertion-seal.ts
@@ -400,10 +400,18 @@ export interface AssertionSeal {
  * the assertion has not been finalized (no merkle root present).
  * Throws on partial seals — those signal store corruption.
  */
-export function parseAssertionSealQuads(
+/**
+ * Collect a `_meta` quad slice (filtered to `subject === assertionUri`) into a
+ * predicate→object map plus the multi-valued root-entity list. The SINGLE seal
+ * field collector, shared by {@link parseAssertionSealQuads} (full validation)
+ * and {@link graphScopedSealAuthor} (durable-sync admission), so both interpret
+ * the seal vocabulary from one place with the same last-writer-wins semantics.
+ * Throws only on an unsafe root-entity IRI (store corruption).
+ */
+function collectAssertionSealFields(
   quads: ReadonlyArray<{ subject: string; predicate: string; object: string }>,
   assertionUri: string,
-): AssertionSeal | undefined {
+): { seen: Map<string, string>; rootEntities: string[] } {
   const seen = new Map<string, string>();
   const rootEntities: string[] = [];
   for (const q of quads) {
@@ -429,6 +437,14 @@ export function parseAssertionSealQuads(
     }
     seen.set(q.predicate, q.object);
   }
+  return { seen, rootEntities };
+}
+
+export function parseAssertionSealQuads(
+  quads: ReadonlyArray<{ subject: string; predicate: string; object: string }>,
+  assertionUri: string,
+): AssertionSeal | undefined {
+  const { seen, rootEntities } = collectAssertionSealFields(quads, assertionUri);
   if (!seen.has(ASSERTION_SEAL_PREDICATES.ASSERTION_MERKLE_ROOT)) return undefined;
 
   const required = [
@@ -600,24 +616,19 @@ export function graphScopedSealAuthor(
   rows: ReadonlyArray<{ subject: string; predicate: string; object: string }>,
   subject: string,
 ): string | undefined {
-  const own = rows.filter((q) => q.subject === subject);
-  const objectsOf = (predicate: string): string[] =>
-    [...new Set(own.filter((q) => q.predicate === predicate).map((q) => q.object))];
-
-  if (!own.some((q) => q.predicate === ASSERTION_SEAL_PREDICATES.ASSERTION_MERKLE_ROOT)) {
-    return undefined;
-  }
   try {
-    const scopeVersions = objectsOf(ASSERTION_SEAL_PREDICATES.CONTENT_SCOPE_VERSION);
-    if (scopeVersions.length !== 1
-      || integerLiteralToValue(scopeVersions[0]!) !== BigInt(GRAPH_KA_CONTENT_SCOPE_VERSION)) {
+    const { seen } = collectAssertionSealFields(rows, subject);
+    if (!seen.has(ASSERTION_SEAL_PREDICATES.ASSERTION_MERKLE_ROOT)) return undefined;
+    const scopeVersion = seen.get(ASSERTION_SEAL_PREDICATES.CONTENT_SCOPE_VERSION);
+    if (scopeVersion === undefined
+      || integerLiteralToValue(scopeVersion) !== BigInt(GRAPH_KA_CONTENT_SCOPE_VERSION)) {
       return undefined;
     }
-    const kaUals = objectsOf(ASSERTION_SEAL_PREDICATES.KA_UAL);
-    const authors = objectsOf(ASSERTION_SEAL_PREDICATES.AUTHOR_ADDRESS);
-    if (kaUals.length !== 1 || authors.length !== 1) return undefined;
-    const author = stringLiteralToValue(authors[0]!);
-    const ualAuthor = parseDeterministicKnowledgeAssetUal(iriObjectToValue(kaUals[0]!)).agentAddress;
+    const kaUalObject = seen.get(ASSERTION_SEAL_PREDICATES.KA_UAL);
+    const authorObject = seen.get(ASSERTION_SEAL_PREDICATES.AUTHOR_ADDRESS);
+    if (kaUalObject === undefined || authorObject === undefined) return undefined;
+    const author = stringLiteralToValue(authorObject);
+    const ualAuthor = parseDeterministicKnowledgeAssetUal(iriObjectToValue(kaUalObject)).agentAddress;
     const coordinate = parseContextGraphAssertionUri(subject);
     if (!coordinate) return undefined;
     const lc = author.toLowerCase();

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -369,6 +369,28 @@ export function parseContextGraphAssertionUri(subject: string): {
   return { scope, agentAddress, name };
 }
 
+/**
+ * Query bounds for locating the assertion-coordinate subjects of one
+ * `(contextGraphId, name[, subGraphName])` in `_meta`, derived from the same
+ * grammar as {@link contextGraphAssertionUri} so callers do not re-encode the
+ * URI layout. `prefix`/`suffix` bound a `STRSTARTS`/`STRENDS` filter (the prefix
+ * carries the full context-graph id verbatim, so a slash-containing id matches
+ * correctly); `scope` is what a matched subject's {@link parseContextGraphAssertionUri}
+ * `scope` must equal (see that function for why cg and subGraph are not split).
+ */
+export function contextGraphAssertionQueryBounds(
+  contextGraphId: string,
+  name: string,
+  subGraphName?: string,
+): { scope: string; prefix: string; suffix: string } {
+  const scope = subGraphName ? `${contextGraphId}/${subGraphName}` : contextGraphId;
+  return {
+    scope,
+    prefix: `did:dkg:context-graph:${scope}/assertion/`,
+    suffix: `/${name}`,
+  };
+}
+
 /** Canonical identity segment used by all new per-KA memory-layer writes. */
 export function canonicalKnowledgeAssetAgentAddress(agentAddress: string): string {
   // Non-EVM legacy identities (notably peer IDs) remain byte-for-byte stable.

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -331,6 +331,32 @@ export function contextGraphAssertionUri(contextGraphId: string, agentAddress: s
   return `did:dkg:context-graph:${contextGraphId}/assertion/${agentAddress}/${name}`;
 }
 
+/**
+ * Inverse of {@link contextGraphAssertionUri}: parse an assertion-coordinate
+ * subject `did:dkg:context-graph:<cg>[/<sub>]/assertion/<addr>/<name>` back into
+ * its parts, or `undefined` when the shape does not match. Centralises the URI
+ * layout so consumers (VM-publish author resolution, durable-sync seal identity)
+ * do not each re-derive it with bespoke slicing/regex. `contextGraphId`,
+ * `subGraphName`, and `name` cannot contain `/`, so segment counting is exact.
+ */
+export function parseContextGraphAssertionUri(subject: string): {
+  contextGraphId: string;
+  subGraphName?: string;
+  agentAddress: string;
+  name: string;
+} | undefined {
+  const PREFIX = 'did:dkg:context-graph:';
+  if (!subject.startsWith(PREFIX)) return undefined;
+  const parts = subject.slice(PREFIX.length).split('/');
+  if (parts.length === 4 && parts[1] === 'assertion' && parts[0] && parts[2] && parts[3]) {
+    return { contextGraphId: parts[0], agentAddress: parts[2], name: parts[3] };
+  }
+  if (parts.length === 5 && parts[2] === 'assertion' && parts[0] && parts[1] && parts[3] && parts[4]) {
+    return { contextGraphId: parts[0], subGraphName: parts[1], agentAddress: parts[3], name: parts[4] };
+  }
+  return undefined;
+}
+
 /** Canonical identity segment used by all new per-KA memory-layer writes. */
 export function canonicalKnowledgeAssetAgentAddress(agentAddress: string): string {
   // Non-EVM legacy identities (notably peer IDs) remain byte-for-byte stable.

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -332,29 +332,41 @@ export function contextGraphAssertionUri(contextGraphId: string, agentAddress: s
 }
 
 /**
- * Inverse of {@link contextGraphAssertionUri}: parse an assertion-coordinate
- * subject `did:dkg:context-graph:<cg>[/<sub>]/assertion/<addr>/<name>` back into
- * its parts, or `undefined` when the shape does not match. Centralises the URI
- * layout so consumers (VM-publish author resolution, durable-sync seal identity)
- * do not each re-derive it with bespoke slicing/regex. `contextGraphId`,
- * `subGraphName`, and `name` cannot contain `/`, so segment counting is exact.
+ * Inverse of {@link contextGraphAssertionUri}: split an assertion-coordinate
+ * subject `did:dkg:context-graph:<scope>/assertion/<addr>/<name>` into its
+ * cryptographic coordinate, or `undefined` when the shape does not match.
+ * Centralises the URI layout so consumers (VM-publish author resolution,
+ * durable-sync seal identity) do not re-derive it with bespoke slicing/regex.
+ *
+ * Anchored on the `/assertion/<addr>/<name>` suffix from the RIGHT so it is
+ * robust to slash-containing context-graph IDs (which {@link validateContextGraphId}
+ * permits, e.g. wallet-scoped `0xabc…/project`). `scope` is the raw
+ * `contextGraphId` OR `contextGraphId/<subGraphName>` and is deliberately NOT
+ * split: a context-graph ID may itself contain `/`, so it cannot be separated
+ * from an optional sub-graph name by the URI alone. Callers that know the
+ * expected context graph compare `scope` to
+ * `subGraphName ? contextGraphId + "/" + subGraphName : contextGraphId`.
+ * `subGraphName` and `name` cannot contain `/`, so the suffix is unambiguous;
+ * `agentAddress` is validated as a 0x EVM address.
  */
 export function parseContextGraphAssertionUri(subject: string): {
-  contextGraphId: string;
-  subGraphName?: string;
+  scope: string;
   agentAddress: string;
   name: string;
 } | undefined {
   const PREFIX = 'did:dkg:context-graph:';
   if (!subject.startsWith(PREFIX)) return undefined;
   const parts = subject.slice(PREFIX.length).split('/');
-  if (parts.length === 4 && parts[1] === 'assertion' && parts[0] && parts[2] && parts[3]) {
-    return { contextGraphId: parts[0], agentAddress: parts[2], name: parts[3] };
-  }
-  if (parts.length === 5 && parts[2] === 'assertion' && parts[0] && parts[1] && parts[3] && parts[4]) {
-    return { contextGraphId: parts[0], subGraphName: parts[1], agentAddress: parts[3], name: parts[4] };
-  }
-  return undefined;
+  // Minimum shape: <scope(>=1)>/assertion/<addr>/<name> → at least 4 segments.
+  if (parts.length < 4) return undefined;
+  const name = parts[parts.length - 1]!;
+  const agentAddress = parts[parts.length - 2]!;
+  const sentinel = parts[parts.length - 3]!;
+  if (sentinel !== 'assertion' || name.length === 0) return undefined;
+  if (!/^0x[0-9a-fA-F]{40}$/.test(agentAddress)) return undefined;
+  const scope = parts.slice(0, parts.length - 3).join('/');
+  if (scope.length === 0) return undefined;
+  return { scope, agentAddress, name };
 }
 
 /** Canonical identity segment used by all new per-KA memory-layer writes. */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -296,7 +296,8 @@ export {
   buildAssertionSealQuads,
   buildAssertionPublishReceiptQuads,
   parseAssertionSealQuads,
-  isSelfConsistentGraphScopedAssertionSeal,
+  parseGraphScopedAssertionSealCandidate,
+  type GraphScopedAssertionSealCandidate,
   type AssertionSealBuildArgs,
   type AssertionSeal,
 } from './assertion-seal.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -296,7 +296,7 @@ export {
   buildAssertionSealQuads,
   buildAssertionPublishReceiptQuads,
   parseAssertionSealQuads,
-  graphScopedSealAuthor,
+  isSelfConsistentGraphScopedAssertionSeal,
   type AssertionSealBuildArgs,
   type AssertionSeal,
 } from './assertion-seal.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -296,6 +296,7 @@ export {
   buildAssertionSealQuads,
   buildAssertionPublishReceiptQuads,
   parseAssertionSealQuads,
+  graphScopedSealAuthor,
   type AssertionSealBuildArgs,
   type AssertionSeal,
 } from './assertion-seal.js';

--- a/packages/core/test/constants.test.ts
+++ b/packages/core/test/constants.test.ts
@@ -24,31 +24,63 @@ import { createOperationContext } from '../src/logger.js';
 
 describe('parseContextGraphAssertionUri (inverse of contextGraphAssertionUri)', () => {
   const ADDR = '0xA32f1cc125401B55911678847426759094055B2d';
+  // Wallet-scoped context graph IDs may contain '/' (validateContextGraphId allows it).
+  const SLASH_CG = '0x1111111111111111111111111111111111111111/project';
 
-  it('round-trips the no-subgraph coordinate', () => {
+  it('round-trips the no-subgraph coordinate (scope = contextGraphId)', () => {
     const uri = contextGraphAssertionUri('construction', ADDR, 'justTriplets');
     expect(parseContextGraphAssertionUri(uri)).toEqual({
-      contextGraphId: 'construction',
+      scope: 'construction',
       agentAddress: ADDR,
       name: 'justTriplets',
     });
   });
 
-  it('round-trips the sub-graph coordinate', () => {
+  it('round-trips the sub-graph coordinate (scope = contextGraphId/subGraphName)', () => {
     const uri = contextGraphAssertionUri('construction', ADDR, 'justTriplets', 'wing-a');
     expect(parseContextGraphAssertionUri(uri)).toEqual({
-      contextGraphId: 'construction',
-      subGraphName: 'wing-a',
+      scope: 'construction/wing-a',
       agentAddress: ADDR,
       name: 'justTriplets',
     });
   });
 
-  it('returns undefined for non-assertion or malformed subjects', () => {
+  it('preserves a slash-containing contextGraphId (GH#1778 review) — no subgraph', () => {
+    const uri = contextGraphAssertionUri(SLASH_CG, ADDR, 'asset');
+    // The whole cg id (incl. its slash) is the scope; it is NOT mis-split into a subgraph.
+    expect(parseContextGraphAssertionUri(uri)).toEqual({
+      scope: SLASH_CG,
+      agentAddress: ADDR,
+      name: 'asset',
+    });
+  });
+
+  it('preserves a slash-containing contextGraphId with a subGraphName', () => {
+    const uri = contextGraphAssertionUri(SLASH_CG, ADDR, 'asset', 'wing-a');
+    expect(parseContextGraphAssertionUri(uri)).toEqual({
+      scope: `${SLASH_CG}/wing-a`,
+      agentAddress: ADDR,
+      name: 'asset',
+    });
+  });
+
+  it('anchors on the rightmost assertion coordinate even when the scope contains one', () => {
+    const trickyCg = `weird/assertion/${ADDR}/inner`;
+    const uri = contextGraphAssertionUri(trickyCg, ADDR, 'asset');
+    expect(parseContextGraphAssertionUri(uri)).toEqual({
+      scope: trickyCg,
+      agentAddress: ADDR,
+      name: 'asset',
+    });
+  });
+
+  it('returns undefined for non-assertion, malformed, or non-0x-author subjects', () => {
     expect(parseContextGraphAssertionUri('did:dkg:context-graph:construction/_meta')).toBeUndefined();
     expect(parseContextGraphAssertionUri(`did:dkg:context-graph:construction/_shared_memory/${ADDR}/7`)).toBeUndefined();
     expect(parseContextGraphAssertionUri('did:dkg:gnosis:100/0xabc/7')).toBeUndefined();
     expect(parseContextGraphAssertionUri('urn:dkg:assertion:construction:0xabc:name')).toBeUndefined();
+    // author segment is not a 0x40 address
+    expect(parseContextGraphAssertionUri('did:dkg:context-graph:construction/assertion/notanaddr/asset')).toBeUndefined();
   });
 });
 

--- a/packages/core/test/constants.test.ts
+++ b/packages/core/test/constants.test.ts
@@ -7,6 +7,8 @@ import {
   contextGraphSessionsTopic,
   contextGraphPublishTopic,
   contextGraphWorkspaceTopic,
+  contextGraphAssertionUri,
+  parseContextGraphAssertionUri,
   DHT_PROTOCOL,
   validateContextGraphId,
   validateNewContextGraphId,
@@ -19,6 +21,36 @@ import {
   wireTopicForNetwork,
 } from '../src/constants.js';
 import { createOperationContext } from '../src/logger.js';
+
+describe('parseContextGraphAssertionUri (inverse of contextGraphAssertionUri)', () => {
+  const ADDR = '0xA32f1cc125401B55911678847426759094055B2d';
+
+  it('round-trips the no-subgraph coordinate', () => {
+    const uri = contextGraphAssertionUri('construction', ADDR, 'justTriplets');
+    expect(parseContextGraphAssertionUri(uri)).toEqual({
+      contextGraphId: 'construction',
+      agentAddress: ADDR,
+      name: 'justTriplets',
+    });
+  });
+
+  it('round-trips the sub-graph coordinate', () => {
+    const uri = contextGraphAssertionUri('construction', ADDR, 'justTriplets', 'wing-a');
+    expect(parseContextGraphAssertionUri(uri)).toEqual({
+      contextGraphId: 'construction',
+      subGraphName: 'wing-a',
+      agentAddress: ADDR,
+      name: 'justTriplets',
+    });
+  });
+
+  it('returns undefined for non-assertion or malformed subjects', () => {
+    expect(parseContextGraphAssertionUri('did:dkg:context-graph:construction/_meta')).toBeUndefined();
+    expect(parseContextGraphAssertionUri(`did:dkg:context-graph:construction/_shared_memory/${ADDR}/7`)).toBeUndefined();
+    expect(parseContextGraphAssertionUri('did:dkg:gnosis:100/0xabc/7')).toBeUndefined();
+    expect(parseContextGraphAssertionUri('urn:dkg:assertion:construction:0xabc:name')).toBeUndefined();
+  });
+});
 
 describe('context graph topic helpers (V10)', () => {
   it('contextGraphFinalizationTopic matches deprecated contextGraphPublishTopic', () => {

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -1103,9 +1103,11 @@ export interface AssertionInfo {
  * the single `/_shared_memory` graph, so the assertion graph itself becomes
  * empty and the WM-style listing returns nothing. The authoring node's
  * `_meta` graph also records full lifecycle entities (`dkg:state`,
- * `dkg:memoryLayer`, `prov:Activity` events), but `_meta` is NOT replicated
- * between peers — only the context graph's data graphs and the
- * `_shared_memory_meta` partitions propagate over sync.
+ * `dkg:memoryLayer`, `prov:Activity` events). NOTE: `_meta` rows for a shared
+ * (non-WM) assertion DO replicate to peers over the durable `_meta` sync lane —
+ * that is how a curator learns a member-shared KA's name and seal (see GH#1778).
+ * The context graph's data graphs and `_shared_memory_meta` partitions also
+ * propagate over sync.
  *
  * What DOES land on every replica is one `dkg:ShareTransition` entity per
  * promote, authored by `generateShareTransitionMetadata()` in

--- a/packages/publisher/src/async-lift-publisher-utils.ts
+++ b/packages/publisher/src/async-lift-publisher-utils.ts
@@ -245,10 +245,6 @@ function parseKnowledgeAssetVmPublishRequest(value: unknown, path: string): Know
     contextGraphId: expectString(record, 'contextGraphId', path),
     name: expectString(record, 'name', path),
     ...optionalStringField(record, 'agentAddress', path),
-    // GH#1778 — the caller identity must survive the persisted-job round-trip,
-    // or CG auto-registration in the async worker falls back to the resolved
-    // author (a member) instead of the operator who enqueued the publish.
-    ...optionalStringField(record, 'callerAgentAddress', path),
     ...optionalStringField(record, 'subGraphName', path),
     shareOperationId: expectString(record, 'shareOperationId', path),
     roots: expectStringArray(record, 'roots', path),

--- a/packages/publisher/src/async-lift-publisher-utils.ts
+++ b/packages/publisher/src/async-lift-publisher-utils.ts
@@ -245,6 +245,10 @@ function parseKnowledgeAssetVmPublishRequest(value: unknown, path: string): Know
     contextGraphId: expectString(record, 'contextGraphId', path),
     name: expectString(record, 'name', path),
     ...optionalStringField(record, 'agentAddress', path),
+    // GH#1778 — the enqueuing caller must survive the persisted-job round-trip so
+    // the async worker stamps the CG curator with the operator who requested the
+    // publish (consistent with the sync lane), not the resolved KA author.
+    ...optionalStringField(record, 'callerAgentAddress', path),
     ...optionalStringField(record, 'subGraphName', path),
     shareOperationId: expectString(record, 'shareOperationId', path),
     roots: expectStringArray(record, 'roots', path),

--- a/packages/publisher/src/async-lift-publisher-utils.ts
+++ b/packages/publisher/src/async-lift-publisher-utils.ts
@@ -245,6 +245,10 @@ function parseKnowledgeAssetVmPublishRequest(value: unknown, path: string): Know
     contextGraphId: expectString(record, 'contextGraphId', path),
     name: expectString(record, 'name', path),
     ...optionalStringField(record, 'agentAddress', path),
+    // GH#1778 — the caller identity must survive the persisted-job round-trip,
+    // or CG auto-registration in the async worker falls back to the resolved
+    // author (a member) instead of the operator who enqueued the publish.
+    ...optionalStringField(record, 'callerAgentAddress', path),
     ...optionalStringField(record, 'subGraphName', path),
     shareOperationId: expectString(record, 'shareOperationId', path),
     roots: expectStringArray(record, 'roots', path),

--- a/packages/publisher/src/lift-job-types.ts
+++ b/packages/publisher/src/lift-job-types.ts
@@ -44,6 +44,15 @@ export interface KnowledgeAssetVmPublishRequest {
   readonly name: string;
   /** Resolved assertion AUTHOR (may differ from the caller — GH#1778 curator publish). */
   readonly agentAddress?: string;
+  /**
+   * Enqueuing CALLER identity (token holder / operator), distinct from the
+   * resolved author (GH#1778). Used to stamp the CG curator on `CG_NOT_REGISTERED`
+   * auto-registration, matching the synchronous `vm/publish` lane — the async
+   * worker registers under the caller who requested the publish, not the KA
+   * author and not the node's default. Absent → registration falls back to the
+   * node default inside `stampAddressCurator`, exactly as the sync lane does.
+   */
+  readonly callerAgentAddress?: string;
   readonly subGraphName?: string;
   readonly shareOperationId: string;
   readonly roots: readonly string[];

--- a/packages/publisher/src/lift-job-types.ts
+++ b/packages/publisher/src/lift-job-types.ts
@@ -44,13 +44,6 @@ export interface KnowledgeAssetVmPublishRequest {
   readonly name: string;
   /** Resolved assertion AUTHOR (may differ from the caller — GH#1778 curator publish). */
   readonly agentAddress?: string;
-  /**
-   * Token/caller identity that enqueued this publish (GH#1778). Distinct from
-   * `agentAddress` (the resolved author): used for caller-scoped decisions on
-   * the async job, notably CG auto-registration on `CG_NOT_REGISTERED`, which
-   * must register under the operator's own identity, not the KA author's.
-   */
-  readonly callerAgentAddress?: string;
   readonly subGraphName?: string;
   readonly shareOperationId: string;
   readonly roots: readonly string[];

--- a/packages/publisher/src/lift-job-types.ts
+++ b/packages/publisher/src/lift-job-types.ts
@@ -42,7 +42,15 @@ export interface LiftRequestAuthorSeal {
 export interface KnowledgeAssetVmPublishRequest {
   readonly contextGraphId: string;
   readonly name: string;
+  /** Resolved assertion AUTHOR (may differ from the caller — GH#1778 curator publish). */
   readonly agentAddress?: string;
+  /**
+   * Token/caller identity that enqueued this publish (GH#1778). Distinct from
+   * `agentAddress` (the resolved author): used for caller-scoped decisions on
+   * the async job, notably CG auto-registration on `CG_NOT_REGISTERED`, which
+   * must register under the operator's own identity, not the KA author's.
+   */
+  readonly callerAgentAddress?: string;
   readonly subGraphName?: string;
   readonly shareOperationId: string;
   readonly roots: readonly string[];

--- a/packages/publisher/test/async-lift-publisher.test.ts
+++ b/packages/publisher/test/async-lift-publisher.test.ts
@@ -416,24 +416,6 @@ describe('TripleStoreAsyncLiftPublisher', () => {
     });
   });
 
-  it('preserves callerAgentAddress across the persisted queue round-trip (GH#1778)', async () => {
-    // The caller identity (curator) is distinct from the resolved author
-    // (member). It must survive the strict persisted-job parser, or the async
-    // worker's CG auto-registration falls back to the author instead of the
-    // operator who enqueued the publish.
-    const publisher = createPublisher();
-    const member = `0x${'22'.repeat(20)}`;
-    const curator = `0x${'11'.repeat(20)}`;
-    const job = await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest({
-      agentAddress: member,
-      callerAgentAddress: curator,
-      subGraphName: 'research',
-    }));
-    const persisted = (await publisher.getStatus(job))?.request.knowledgeAssetVmPublish;
-    expect(persisted?.agentAddress).toBe(member);
-    expect(persisted?.callerAgentAddress).toBe(curator);
-  });
-
   it('scopes active knowledge asset VM publish duplicate detection by agent address', async () => {
     const publisher = createPublisher();
     const agentA = `0x${'aa'.repeat(20)}`;

--- a/packages/publisher/test/async-lift-publisher.test.ts
+++ b/packages/publisher/test/async-lift-publisher.test.ts
@@ -416,6 +416,24 @@ describe('TripleStoreAsyncLiftPublisher', () => {
     });
   });
 
+  it('preserves callerAgentAddress across the persisted queue round-trip (GH#1778)', async () => {
+    // The enqueuing caller (curator) is distinct from the resolved author
+    // (member) and must survive the strict persisted-job parser, or the async
+    // worker's CG auto-registration loses the operator identity it stamps the
+    // curator with.
+    const publisher = createPublisher();
+    const member = `0x${'22'.repeat(20)}`;
+    const curator = `0x${'11'.repeat(20)}`;
+    const job = await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest({
+      agentAddress: member,
+      callerAgentAddress: curator,
+      subGraphName: 'research',
+    }));
+    const persisted = (await publisher.getStatus(job))?.request.knowledgeAssetVmPublish;
+    expect(persisted?.agentAddress).toBe(member);
+    expect(persisted?.callerAgentAddress).toBe(curator);
+  });
+
   it('scopes active knowledge asset VM publish duplicate detection by agent address', async () => {
     const publisher = createPublisher();
     const agentA = `0x${'aa'.repeat(20)}`;

--- a/packages/publisher/test/async-lift-publisher.test.ts
+++ b/packages/publisher/test/async-lift-publisher.test.ts
@@ -416,6 +416,24 @@ describe('TripleStoreAsyncLiftPublisher', () => {
     });
   });
 
+  it('preserves callerAgentAddress across the persisted queue round-trip (GH#1778)', async () => {
+    // The caller identity (curator) is distinct from the resolved author
+    // (member). It must survive the strict persisted-job parser, or the async
+    // worker's CG auto-registration falls back to the author instead of the
+    // operator who enqueued the publish.
+    const publisher = createPublisher();
+    const member = `0x${'22'.repeat(20)}`;
+    const curator = `0x${'11'.repeat(20)}`;
+    const job = await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest({
+      agentAddress: member,
+      callerAgentAddress: curator,
+      subGraphName: 'research',
+    }));
+    const persisted = (await publisher.getStatus(job))?.request.knowledgeAssetVmPublish;
+    expect(persisted?.agentAddress).toBe(member);
+    expect(persisted?.callerAgentAddress).toBe(curator);
+  });
+
   it('scopes active knowledge asset VM publish duplicate detection by agent address', async () => {
     const publisher = createPublisher();
     const agentA = `0x${'aa'.repeat(20)}`;


### PR DESCRIPTION
## Summary

Fixes #1778. A sealed **rootless named KA** shared member → curator over SWM is reported "unsealed" on the curator and cannot be published to VM.

The issue proposed adding the assertion seal to the SWM wire protobuf. Deep investigation — including **executing the real durable-sync and seal modules** against a genuine `buildAssertionSealQuads` output — showed that framing is wrong: **the seal has never ridden SWM gossip in any version**, so there is nothing to restore there, and no wire/protobuf change (the "metadata complexity" we wanted to avoid) is needed. The seal already reaches the curator over the durable `_meta` sync lane. The real failure is **two stacked off-chain defects**:

### Defect A — publish looked up the seal under the wrong author
`publishFromFinalizedAssertion` / `resolveFinalizedAssertionVmPublishIntent` built the seal-lookup URI from the **caller's** (curator's) address. The member's seal sits at `…/assertion/<member>/<name>`; publish queried `…/assertion/<curator>/<name>`, found zero quads, and `parseAssertionSealQuads` returned `undefined` → the literal `"is not finalized"` error → HTTP 409, surfaced in the UI as "unsealed". (This fired first and *masked* Defect B.)

**Fix:** `resolveAssertionAuthor()` resolves the author from the local `_meta` graph:
1. prefer the caller's own KA of that name (self-publish is byte-identical to before — the caller hint is the *effective* publish identity, so the tokenless path is covered too);
2. else the sole other author;
3. else `409 AMBIGUOUS_ASSERTION_AUTHOR` with the candidate list;
4. else `undefined` → unchanged `"is not finalized"`.

No route/UI/CLI signature change; the existing `400` gate ("author cannot be supplied on `vm/publish` — the seal already encodes the author") stays and is now honored.

### Defect B — durable sync stripped one seal predicate
The durable-sync integrity filter treats `dkg:assertionVersion` as a routing-control predicate and dropped it from a **not-yet-published** seal subject (no on-chain UAL descriptor to authenticate against). The seal arrived as **13/14 quads** and `parseAssertionSealQuads` threw *"Partial graph-scoped assertion seal … missing assertionVersion"* — surfacing as a 500 the moment Defect A is fixed.

**Fix:** admit `assertionVersion` for a **self-consistent seal subject** — one that carries `assertionMerkleRoot`, `contentScopeVersion=2`, and a single `kaUal` whose author equals the single `authorAddress` *and* the `/assertion/<addr>/` path segment. The seal's other 13 quads already sync unauthenticated; the real integrity boundary is the **publish-time Merkle recompute** against the author-signed root, which stays authoritative. The existing UAL-descriptor authentication path is untouched.

## Why this is the right shape

- **No wire, protobuf, ACK, or receiver changes.** The receiver still writes no context-graph `_meta`. `WorkspacePublishRequest` is untouched.
- **On-chain flow is supported.** `KnowledgeAssetsLifecycle` recovers the author from the EIP-712 attestation and never compares it to `msg.sender`; curator-pays / member-authors is a first-class flow. The publisher forwards the member's attestation verbatim (never re-signs).
- **Fail-closed.** Ambiguity → 409; a forged/mismatched seal is rejected at sync (adversarial tests) or at publish (Merkle recheck).

## Tests

- `durable-integrity-seal-assertion-version.test.ts` — seal retains all 14 quads and parses (snapshot + delta modes); adversarial rejections (non-seal subject, kaUal/author mismatch, planted-at-foreign-coordinate).
- `publish-foreign-author-resolution.test.ts` — sole-author resolution, prefer-caller self-publish, tokenless self-vs-foreign collision, `AMBIGUOUS_ASSERTION_AUTHOR`, absent name, suffix-name safety, and end-to-end `publishFromFinalizedAssertion` forwarding the member's attestation.
- Updated `publish-finalized-agent-lane.test.ts` to reflect the intended behavior change (no-`agentAddress` now auto-resolves the sole author).
- Full agent unit suite green (**1116 tests**); CLI knowledge-assets route tests green (41).

## Test plan

- [x] `pnpm -C packages/agent test:unit` (1116 pass)
- [x] `pnpm -C packages/cli test:unit` knowledge-assets routes (41 pass)
- [x] Executed the real durable-sync module: **14/14** seal quads survive after the fix (was 13/14)
- [ ] CI: full route suite (`knowledge-assets-route.test.ts`, Hardhat-backed — not runnable on Windows)
- [ ] Two-node devnet share → curator-publish (recommend before release)

> Note on already-shared KAs: Defect A alone unblocks them once their seal has synced. The curator must also be an authorized publisher on-chain for the CG (`isAuthorizedPublisher`) — an operational precondition, not a code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
