### PR TITLE
RFC-64: add bounded canonical JSON codec

### DIFF
--- a/packages/core/src/canonical-json.ts
+++ b/packages/core/src/canonical-json.ts
@@ -1,0 +1,484 @@
+/** RFC 8785 / I-JSON value accepted by the Track-2 control-object codec. */
+export type CanonicalJsonPrimitive = null | boolean | number | string;
+
+export type CanonicalJsonValue =
+  | CanonicalJsonPrimitive
+  | readonly CanonicalJsonValue[]
+  | { readonly [key: string]: CanonicalJsonValue };
+
+export interface CanonicalJsonOptions {
+  /** Hard input-byte ceiling. Callers should normally pass their object-type cap. */
+  maxBytes?: number;
+  /** Defensive nesting ceiling independent of JavaScript call-stack limits. */
+  maxDepth?: number;
+}
+
+export type StrictJsonParseOptions = CanonicalJsonOptions;
+
+export const MAX_CANONICAL_JSON_BYTES = 8 * 1024 * 1024;
+export const MAX_CANONICAL_JSON_DEPTH = 64;
+const UTF8 = new TextEncoder();
+// Preserve a leading BOM so the explicit wire-level rejection below can see it.
+const UTF8_FATAL = new TextDecoder('utf-8', { fatal: true, ignoreBOM: true });
+
+export class CanonicalJsonError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CanonicalJsonError';
+  }
+}
+
+/**
+ * Serialize one already parsed JSON value using RFC 8785 JCS.
+ *
+ * JavaScript's JSON number/string primitive serialization matches JCS; object keys
+ * are sorted by UTF-16 code units as required by RFC 8785 section 3.2.3. This
+ * implementation rejects values outside the I-JSON data model instead of silently
+ * dropping or coercing them like JSON.stringify does.
+ */
+export function canonicalizeJson(
+  value: CanonicalJsonValue,
+  options: CanonicalJsonOptions = {},
+): string {
+  const { maxBytes, maxDepth } = resolveLimits(options);
+  const ancestors = new Set<object>();
+  const writer = new BoundedJsonWriter(maxBytes);
+
+  const encode = (input: unknown, depth: number): void => {
+    if (depth > maxDepth) {
+      throw new CanonicalJsonError(`JSON nesting exceeds ${maxDepth}`);
+    }
+
+    if (input === null) {
+      writer.appendAscii('null');
+      return;
+    }
+
+    switch (typeof input) {
+      case 'boolean':
+        writer.appendAscii(input ? 'true' : 'false');
+        return;
+      case 'number': {
+        if (!Number.isFinite(input)) {
+          throw new CanonicalJsonError('JCS numbers must be finite IEEE-754 values');
+        }
+        writer.appendAscii(JSON.stringify(input));
+        return;
+      }
+      case 'string': {
+        writeCanonicalJsonString(input, writer, 'JSON string');
+        return;
+      }
+      case 'object':
+        break;
+      default:
+        throw new CanonicalJsonError(`Unsupported JSON value type: ${typeof input}`);
+    }
+
+    const object = input as object;
+    if (ancestors.has(object)) {
+      throw new CanonicalJsonError('Cyclic values are not JSON');
+    }
+    ancestors.add(object);
+
+    try {
+      if (Array.isArray(input)) {
+        assertJsonArrayShape(input);
+        writer.appendAscii('[');
+        for (let index = 0; index < input.length; index += 1) {
+          if (!Object.prototype.hasOwnProperty.call(input, index)) {
+            throw new CanonicalJsonError('Sparse arrays are not accepted');
+          }
+          if (index !== 0) writer.appendAscii(',');
+          encode(input[index], depth + 1);
+        }
+        writer.appendAscii(']');
+        return;
+      }
+
+      const prototype = Object.getPrototypeOf(input);
+      if (prototype !== Object.prototype && prototype !== null) {
+        throw new CanonicalJsonError('Only plain JSON objects are accepted');
+      }
+
+      const record = input as Record<string, unknown>;
+      assertJsonObjectShape(record);
+      const keys = Object.keys(record).sort();
+      writer.appendAscii('{');
+      for (let index = 0; index < keys.length; index += 1) {
+        if (index !== 0) writer.appendAscii(',');
+        const key = keys[index];
+        writeCanonicalJsonString(key, writer, 'JSON object key');
+        writer.appendAscii(':');
+        encode(record[key], depth + 1);
+      }
+      writer.appendAscii('}');
+    } finally {
+      ancestors.delete(object);
+    }
+  };
+
+  encode(value, 0);
+  return writer.finish();
+}
+
+export function canonicalizeJsonBytes(
+  value: CanonicalJsonValue,
+  options: CanonicalJsonOptions = {},
+): Uint8Array {
+  return UTF8.encode(canonicalizeJson(value, options));
+}
+
+/** Parse JSON while rejecting duplicate decoded keys, invalid UTF-8, and non-I-JSON values. */
+export function parseJsonStrict(
+  input: string | Uint8Array,
+  options: StrictJsonParseOptions = {},
+): CanonicalJsonValue {
+  const { maxBytes, maxDepth } = resolveLimits(options);
+
+  const byteLength = typeof input === 'string' ? UTF8.encode(input).byteLength : input.byteLength;
+  if (byteLength > maxBytes) {
+    throw new CanonicalJsonError(`JSON input exceeds ${maxBytes} bytes`);
+  }
+
+  let text: string;
+  try {
+    text = typeof input === 'string' ? input : UTF8_FATAL.decode(input);
+  } catch {
+    throw new CanonicalJsonError('JSON input is not valid UTF-8');
+  }
+  if (text.charCodeAt(0) === 0xfeff) {
+    throw new CanonicalJsonError('A UTF-8 BOM is not accepted');
+  }
+
+  const parser = new StrictJsonParser(text, maxDepth);
+  return parser.parse();
+}
+
+/** Parse one wire object and require that its bytes already equal RFC 8785 JCS. */
+export function parseCanonicalJson(
+  input: string | Uint8Array,
+  options: StrictJsonParseOptions = {},
+): CanonicalJsonValue {
+  const value = parseJsonStrict(input, options);
+  const text = typeof input === 'string' ? input : UTF8_FATAL.decode(input);
+  if (canonicalizeJson(value, options) !== text) {
+    throw new CanonicalJsonError('JSON bytes are valid but not RFC 8785 canonical');
+  }
+  return value;
+}
+
+function resolveLimits(options: CanonicalJsonOptions): {
+  maxBytes: number;
+  maxDepth: number;
+} {
+  const maxBytes = options.maxBytes ?? MAX_CANONICAL_JSON_BYTES;
+  const maxDepth = options.maxDepth ?? MAX_CANONICAL_JSON_DEPTH;
+  if (
+    !Number.isSafeInteger(maxBytes)
+    || maxBytes <= 0
+    || maxBytes > MAX_CANONICAL_JSON_BYTES
+  ) {
+    throw new CanonicalJsonError(
+      `maxBytes must be a positive safe integer no greater than ${MAX_CANONICAL_JSON_BYTES}`,
+    );
+  }
+  if (
+    !Number.isSafeInteger(maxDepth)
+    || maxDepth < 0
+    || maxDepth > MAX_CANONICAL_JSON_DEPTH
+  ) {
+    throw new CanonicalJsonError(
+      `maxDepth must be a non-negative safe integer no greater than ${MAX_CANONICAL_JSON_DEPTH}`,
+    );
+  }
+  return { maxBytes, maxDepth };
+}
+
+/**
+ * Bounded text sink used by the serializer. It coalesces small punctuation/number
+ * writes so a near-limit array does not allocate one JavaScript string per token.
+ */
+class BoundedJsonWriter {
+  private readonly chunks: string[] = [];
+  private pending = '';
+  private byteLength = 0;
+
+  constructor(private readonly maxBytes: number) {}
+
+  appendAscii(value: string): void {
+    this.appendMeasured(value, value.length);
+  }
+
+  appendUtf8(value: string): void {
+    this.appendMeasured(value, UTF8.encode(value).byteLength);
+  }
+
+  finish(): string {
+    if (this.pending.length > 0) {
+      this.chunks.push(this.pending);
+      this.pending = '';
+    }
+    return this.chunks.join('');
+  }
+
+  private appendMeasured(value: string, bytes: number): void {
+    if (this.byteLength + bytes > this.maxBytes) {
+      throw new CanonicalJsonError(`Canonical JSON exceeds ${this.maxBytes} bytes`);
+    }
+    this.byteLength += bytes;
+    this.pending += value;
+    if (this.pending.length >= 8192) {
+      this.chunks.push(this.pending);
+      this.pending = '';
+    }
+  }
+}
+
+/** Write one JCS string without first allocating an unbounded JSON.stringify result. */
+function writeCanonicalJsonString(
+  value: string,
+  writer: BoundedJsonWriter,
+  label: string,
+): void {
+  writer.appendAscii('"');
+  let rawStart = 0;
+  let index = 0;
+
+  const flushRaw = (end: number): void => {
+    // Keep TextEncoder allocations bounded even when the source string is enormous.
+    if (end > rawStart) writer.appendUtf8(value.slice(rawStart, end));
+    rawStart = end;
+  };
+
+  while (index < value.length) {
+    const unit = value.charCodeAt(index);
+    let escaped: string | undefined;
+    if (unit === 0x22) escaped = '\\"';
+    else if (unit === 0x5c) escaped = '\\\\';
+    else if (unit === 0x08) escaped = '\\b';
+    else if (unit === 0x09) escaped = '\\t';
+    else if (unit === 0x0a) escaped = '\\n';
+    else if (unit === 0x0c) escaped = '\\f';
+    else if (unit === 0x0d) escaped = '\\r';
+    else if (unit < 0x20) escaped = `\\u${unit.toString(16).padStart(4, '0')}`;
+
+    if (escaped !== undefined) {
+      flushRaw(index);
+      writer.appendAscii(escaped);
+      index += 1;
+      rawStart = index;
+      continue;
+    }
+
+    if (unit >= 0xd800 && unit <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+        throw new CanonicalJsonError(`${label} contains an unpaired high surrogate`);
+      }
+      index += 2;
+    } else if (unit >= 0xdc00 && unit <= 0xdfff) {
+      throw new CanonicalJsonError(`${label} contains an unpaired low surrogate`);
+    } else {
+      index += 1;
+    }
+
+    if (index - rawStart >= 4096) flushRaw(index);
+  }
+
+  flushRaw(value.length);
+  writer.appendAscii('"');
+}
+
+function assertUnicodeScalarString(value: string, label: string): void {
+  for (let index = 0; index < value.length; index += 1) {
+    const unit = value.charCodeAt(index);
+    if (unit >= 0xd800 && unit <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+        throw new CanonicalJsonError(`${label} contains an unpaired high surrogate`);
+      }
+      index += 1;
+    } else if (unit >= 0xdc00 && unit <= 0xdfff) {
+      throw new CanonicalJsonError(`${label} contains an unpaired low surrogate`);
+    }
+  }
+}
+
+class StrictJsonParser {
+  private index = 0;
+
+  constructor(
+    private readonly text: string,
+    private readonly maxDepth: number,
+  ) {}
+
+  parse(): CanonicalJsonValue {
+    this.skipWhitespace();
+    const value = this.parseValue(0);
+    this.skipWhitespace();
+    if (this.index !== this.text.length) this.fail('Unexpected trailing input');
+    return value;
+  }
+
+  private parseValue(depth: number): CanonicalJsonValue {
+    if (depth > this.maxDepth) this.fail(`JSON nesting exceeds ${this.maxDepth}`);
+    const char = this.text[this.index];
+    if (char === '"') return this.parseString();
+    if (char === '{') return this.parseObject(depth + 1);
+    if (char === '[') return this.parseArray(depth + 1);
+    if (char === 't') return this.parseLiteral('true', true);
+    if (char === 'f') return this.parseLiteral('false', false);
+    if (char === 'n') return this.parseLiteral('null', null);
+    if (char === '-' || (char >= '0' && char <= '9')) return this.parseNumber();
+    this.fail('Expected a JSON value');
+  }
+
+  private parseObject(depth: number): CanonicalJsonValue {
+    if (depth > this.maxDepth) this.fail(`JSON nesting exceeds ${this.maxDepth}`);
+    this.index += 1;
+    this.skipWhitespace();
+    const result: Record<string, CanonicalJsonValue> = Object.create(null) as Record<
+      string,
+      CanonicalJsonValue
+    >;
+    const seen = new Set<string>();
+    if (this.consume('}')) return result;
+
+    while (true) {
+      if (this.text[this.index] !== '"') this.fail('Expected an object key');
+      const key = this.parseString();
+      if (seen.has(key)) this.fail(`Duplicate object key ${JSON.stringify(key)}`);
+      seen.add(key);
+      this.skipWhitespace();
+      this.expect(':');
+      this.skipWhitespace();
+      result[key] = this.parseValue(depth);
+      this.skipWhitespace();
+      if (this.consume('}')) return result;
+      this.expect(',');
+      this.skipWhitespace();
+    }
+  }
+
+  private parseArray(depth: number): CanonicalJsonValue {
+    if (depth > this.maxDepth) this.fail(`JSON nesting exceeds ${this.maxDepth}`);
+    this.index += 1;
+    this.skipWhitespace();
+    const result: CanonicalJsonValue[] = [];
+    if (this.consume(']')) return result;
+
+    while (true) {
+      result.push(this.parseValue(depth));
+      this.skipWhitespace();
+      if (this.consume(']')) return result;
+      this.expect(',');
+      this.skipWhitespace();
+    }
+  }
+
+  private parseString(): string {
+    const start = this.index;
+    this.index += 1;
+    let escaped = false;
+    while (this.index < this.text.length) {
+      const code = this.text.charCodeAt(this.index);
+      if (!escaped && code === 0x22) {
+        this.index += 1;
+        const token = this.text.slice(start, this.index);
+        let value: string;
+        try {
+          value = JSON.parse(token) as string;
+        } catch {
+          this.fail('Invalid JSON string escape');
+        }
+        assertUnicodeScalarString(value, 'JSON string');
+        return value;
+      }
+      if (!escaped && code < 0x20) this.fail('Unescaped control character in string');
+      if (!escaped && code === 0x5c) {
+        escaped = true;
+      } else {
+        escaped = false;
+      }
+      this.index += 1;
+    }
+    this.fail('Unterminated JSON string');
+  }
+
+  private parseNumber(): number {
+    const rest = this.text.slice(this.index);
+    const match = /^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?/.exec(rest);
+    if (!match) this.fail('Invalid JSON number');
+    const token = match[0];
+    this.index += token.length;
+    const value = Number(token);
+    if (!Number.isFinite(value)) this.fail('JSON number is outside finite IEEE-754 range');
+    return value;
+  }
+
+  private parseLiteral<T extends CanonicalJsonPrimitive>(token: string, value: T): T {
+    if (!this.text.startsWith(token, this.index)) this.fail(`Expected ${token}`);
+    this.index += token.length;
+    return value;
+  }
+
+  private skipWhitespace(): void {
+    while (this.index < this.text.length) {
+      const char = this.text.charCodeAt(this.index);
+      if (char !== 0x20 && char !== 0x09 && char !== 0x0a && char !== 0x0d) return;
+      this.index += 1;
+    }
+  }
+
+  private consume(expected: string): boolean {
+    if (this.text[this.index] !== expected) return false;
+    this.index += 1;
+    return true;
+  }
+
+  private expect(expected: string): void {
+    if (!this.consume(expected)) this.fail(`Expected ${JSON.stringify(expected)}`);
+  }
+
+  private fail(message: string): never {
+    throw new CanonicalJsonError(`${message} at character ${this.index}`);
+  }
+}
+
+function assertJsonObjectShape(record: Record<string, unknown>): void {
+  for (const key of Reflect.ownKeys(record)) {
+    if (typeof key !== 'string') {
+      throw new CanonicalJsonError('JSON objects must not contain symbol properties');
+    }
+    const descriptor = Object.getOwnPropertyDescriptor(record, key);
+    if (!descriptor?.enumerable) {
+      throw new CanonicalJsonError('JSON objects must not contain non-enumerable properties');
+    }
+    if (!Object.prototype.hasOwnProperty.call(descriptor, 'value')) {
+      throw new CanonicalJsonError('JSON objects must not contain accessor properties');
+    }
+  }
+}
+
+function assertJsonArrayShape(array: readonly unknown[]): void {
+  for (const key of Reflect.ownKeys(array)) {
+    if (typeof key !== 'string') {
+      throw new CanonicalJsonError('JSON arrays must not contain symbol properties');
+    }
+    if (key === 'length') continue;
+    const index = Number(key);
+    if (!Number.isSafeInteger(index) || index < 0 || String(index) !== key || index >= array.length) {
+      throw new CanonicalJsonError('JSON arrays must not contain non-index properties');
+    }
+    const descriptor = Object.getOwnPropertyDescriptor(array, key);
+    if (
+      !descriptor?.enumerable
+      || !Object.prototype.hasOwnProperty.call(descriptor, 'value')
+    ) {
+      throw new CanonicalJsonError(
+        'JSON arrays must contain only enumerable data elements',
+      );
+    }
+  }
+}

--- a/packages/core/src/canonical-json.ts
+++ b/packages/core/src/canonical-json.ts
@@ -76,6 +76,12 @@ export function canonicalizeJson(
     }
 
     const object = input as object;
+    // Container depth is counted when entering the container, including when it
+    // is empty. This mirrors StrictJsonParser instead of relying on a recursive
+    // child visit to discover an over-limit empty object or array.
+    if (depth + 1 > maxDepth) {
+      throw new CanonicalJsonError(`JSON nesting exceeds ${maxDepth}`);
+    }
     if (ancestors.has(object)) {
       throw new CanonicalJsonError('Cyclic values are not JSON');
     }
@@ -407,13 +413,46 @@ class StrictJsonParser {
   }
 
   private parseNumber(): number {
-    const rest = this.text.slice(this.index);
-    const match = /^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?/.exec(rest);
-    if (!match) this.fail('Invalid JSON number');
-    const token = match[0];
-    this.index += token.length;
+    const start = this.index;
+
+    if (this.text[this.index] === '-') this.index += 1;
+
+    if (this.text[this.index] === '0') {
+      this.index += 1;
+    } else if (isDigitOneToNine(this.text[this.index])) {
+      this.index += 1;
+      while (isDigit(this.text[this.index])) this.index += 1;
+    } else {
+      this.fail('Invalid JSON number');
+    }
+
+    if (this.text[this.index] === '.') {
+      this.index += 1;
+      if (!isDigit(this.text[this.index])) this.fail('Invalid JSON number');
+      while (isDigit(this.text[this.index])) this.index += 1;
+    }
+
+    if (this.text[this.index] === 'e' || this.text[this.index] === 'E') {
+      this.index += 1;
+      if (this.text[this.index] === '+' || this.text[this.index] === '-') {
+        this.index += 1;
+      }
+      if (!isDigit(this.text[this.index])) this.fail('Invalid JSON number');
+      while (isDigit(this.text[this.index])) this.index += 1;
+    }
+
+    const token = this.text.slice(start, this.index);
     const value = Number(token);
     if (!Number.isFinite(value)) this.fail('JSON number is outside finite IEEE-754 range');
+
+    // A strict parse must not silently replace the supplied decimal value with
+    // another finite double. Compare the exact decimal value with the JCS/JSON
+    // rendering of the parsed double. This still accepts equivalent spellings
+    // such as 1.0 and 1e0, while rejecting unsafe integers, underflow, and
+    // non-canonical decimals that round to a different mathematical value.
+    if (!sameExactDecimalValue(token, JSON.stringify(value))) {
+      this.fail('JSON number loses information when converted to IEEE-754');
+    }
     return value;
   }
 
@@ -444,6 +483,89 @@ class StrictJsonParser {
   private fail(message: string): never {
     throw new CanonicalJsonError(`${message} at character ${this.index}`);
   }
+}
+
+interface NormalizedDecimal {
+  readonly negative: boolean;
+  readonly digits: string;
+  readonly exponent: number;
+}
+
+function sameExactDecimalValue(left: string, right: string): boolean {
+  const normalizedLeft = normalizeDecimalToken(left);
+  const normalizedRight = normalizeDecimalToken(right);
+  return normalizedLeft !== null
+    && normalizedRight !== null
+    && normalizedLeft.negative === normalizedRight.negative
+    && normalizedLeft.digits === normalizedRight.digits
+    && normalizedLeft.exponent === normalizedRight.exponent;
+}
+
+/** Normalize one already-tokenized JSON decimal as digits * 10^exponent. */
+function normalizeDecimalToken(token: string): NormalizedDecimal | null {
+  const match = /^(-)?([0-9]+)(?:\.([0-9]+))?(?:[eE]([+-]?[0-9]+))?$/.exec(token);
+  if (match === null) return null;
+
+  const integerDigits = match[2];
+  const fractionDigits = match[3] ?? '';
+  let digits = integerDigits + fractionDigits;
+
+  let firstNonZero = 0;
+  while (firstNonZero < digits.length && digits.charCodeAt(firstNonZero) === 0x30) {
+    firstNonZero += 1;
+  }
+  if (firstNonZero === digits.length) {
+    // All textual zero spellings, including -0 and large zero exponents,
+    // preserve the JSON numeric value zero.
+    return { negative: false, digits: '0', exponent: 0 };
+  }
+  digits = digits.slice(firstNonZero);
+
+  const explicitExponent = parseBoundedDecimalExponent(match[4]);
+  if (explicitExponent === null) return null;
+  let exponent = explicitExponent - fractionDigits.length;
+
+  let end = digits.length;
+  while (end > 1 && digits.charCodeAt(end - 1) === 0x30) {
+    end -= 1;
+    exponent += 1;
+  }
+
+  return {
+    negative: match[1] === '-',
+    digits: digits.slice(0, end),
+    exponent,
+  };
+}
+
+function parseBoundedDecimalExponent(raw: string | undefined): number | null {
+  if (raw === undefined) return 0;
+  let index = 0;
+  let sign = 1;
+  if (raw[index] === '+' || raw[index] === '-') {
+    if (raw[index] === '-') sign = -1;
+    index += 1;
+  }
+  while (raw.charCodeAt(index) === 0x30) index += 1;
+  const significant = raw.slice(index);
+  if (significant.length === 0) return 0;
+
+  // With an 8 MiB input ceiling, a finite nonzero token can need at most a
+  // seven-digit exponent to offset its coefficient length. A longer value
+  // cannot be made exact by the bounded fraction and is rejected without
+  // constructing an attacker-sized BigInt.
+  if (significant.length > 15) return null;
+  const magnitude = Number(significant);
+  if (!Number.isSafeInteger(magnitude)) return null;
+  return sign * magnitude;
+}
+
+function isDigit(value: string | undefined): boolean {
+  return value !== undefined && value >= '0' && value <= '9';
+}
+
+function isDigitOneToNine(value: string | undefined): boolean {
+  return value !== undefined && value >= '1' && value <= '9';
 }
 
 function assertJsonObjectShape(record: Record<string, unknown>): void {

--- a/packages/core/src/canonical-json.ts
+++ b/packages/core/src/canonical-json.ts
@@ -277,13 +277,13 @@ function writeCanonicalJsonString(
       continue;
     }
 
-    if (unit >= 0xd800 && unit <= 0xdbff) {
+    if (isHighSurrogate(unit)) {
       const next = value.charCodeAt(index + 1);
-      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+      if (!isLowSurrogate(next)) {
         throw new CanonicalJsonError(`${label} contains an unpaired high surrogate`);
       }
       index += 2;
-    } else if (unit >= 0xdc00 && unit <= 0xdfff) {
+    } else if (isLowSurrogate(unit)) {
       throw new CanonicalJsonError(`${label} contains an unpaired low surrogate`);
     } else {
       index += 1;
@@ -294,21 +294,6 @@ function writeCanonicalJsonString(
 
   flushRaw(value.length);
   writer.appendAscii('"');
-}
-
-function assertUnicodeScalarString(value: string, label: string): void {
-  for (let index = 0; index < value.length; index += 1) {
-    const unit = value.charCodeAt(index);
-    if (unit >= 0xd800 && unit <= 0xdbff) {
-      const next = value.charCodeAt(index + 1);
-      if (!(next >= 0xdc00 && next <= 0xdfff)) {
-        throw new CanonicalJsonError(`${label} contains an unpaired high surrogate`);
-      }
-      index += 1;
-    } else if (unit >= 0xdc00 && unit <= 0xdfff) {
-      throw new CanonicalJsonError(`${label} contains an unpaired low surrogate`);
-    }
-  }
 }
 
 class StrictJsonParser {
@@ -384,32 +369,124 @@ class StrictJsonParser {
   }
 
   private parseString(): string {
-    const start = this.index;
+    // Decode and validate the JSON string in this one path. Keeping the escape
+    // grammar and Unicode-scalar invariant together avoids relying on a second
+    // parser whose accepted boundary could drift from the local scanner.
     this.index += 1;
-    let escaped = false;
+    const chunks: string[] = [];
+    let parts: string[] = [];
+    let partsLength = 0;
+    let rawStart = this.index;
+    let pendingHighSurrogate: number | undefined;
+
+    const flushParts = (): void => {
+      if (parts.length === 0) return;
+      chunks.push(parts.join(''));
+      parts = [];
+      partsLength = 0;
+    };
+    const appendPart = (value: string): void => {
+      if (value.length === 0) return;
+      parts.push(value);
+      partsLength += value.length;
+      // Bound both the number of retained fragments and temporary join size for
+      // escape-heavy hostile strings while preserving the no-escape slice path.
+      if (partsLength >= 8192 || parts.length >= 1024) flushParts();
+    };
+    const flushRaw = (end: number): void => {
+      if (end > rawStart) appendPart(this.text.slice(rawStart, end));
+      rawStart = end;
+    };
+    const appendCodeUnit = (unit: number): void => {
+      if (pendingHighSurrogate !== undefined) {
+        if (!isLowSurrogate(unit)) {
+          this.fail('JSON string contains an unpaired high surrogate');
+        }
+        appendPart(String.fromCharCode(pendingHighSurrogate, unit));
+        pendingHighSurrogate = undefined;
+      } else if (isHighSurrogate(unit)) {
+        pendingHighSurrogate = unit;
+      } else if (isLowSurrogate(unit)) {
+        this.fail('JSON string contains an unpaired low surrogate');
+      } else {
+        appendPart(String.fromCharCode(unit));
+      }
+    };
+
     while (this.index < this.text.length) {
       const code = this.text.charCodeAt(this.index);
-      if (!escaped && code === 0x22) {
-        this.index += 1;
-        const token = this.text.slice(start, this.index);
-        let value: string;
-        try {
-          value = JSON.parse(token) as string;
-        } catch {
-          this.fail('Invalid JSON string escape');
+      if (code === 0x22) {
+        if (pendingHighSurrogate !== undefined) {
+          this.fail('JSON string contains an unpaired high surrogate');
         }
-        assertUnicodeScalarString(value, 'JSON string');
-        return value;
+        flushRaw(this.index);
+        this.index += 1;
+        flushParts();
+        return chunks.join('');
       }
-      if (!escaped && code < 0x20) this.fail('Unescaped control character in string');
-      if (!escaped && code === 0x5c) {
-        escaped = true;
-      } else {
-        escaped = false;
+
+      if (code < 0x20) this.fail('Unescaped control character in string');
+      if (code !== 0x5c) {
+        if (pendingHighSurrogate !== undefined) {
+          flushRaw(this.index);
+          appendCodeUnit(code);
+          this.index += 1;
+          rawStart = this.index;
+        } else if (isHighSurrogate(code)) {
+          const next = this.text.charCodeAt(this.index + 1);
+          if (isLowSurrogate(next)) {
+            this.index += 2;
+          } else {
+            flushRaw(this.index);
+            pendingHighSurrogate = code;
+            this.index += 1;
+            rawStart = this.index;
+          }
+        } else if (isLowSurrogate(code)) {
+          this.fail('JSON string contains an unpaired low surrogate');
+        } else {
+          this.index += 1;
+        }
+        continue;
       }
+
+      flushRaw(this.index);
       this.index += 1;
+      if (this.index >= this.text.length) this.fail('Unterminated JSON string');
+      const escape = this.text.charCodeAt(this.index);
+      this.index += 1;
+      if (escape === 0x22 || escape === 0x2f || escape === 0x5c) {
+        appendCodeUnit(escape);
+      } else if (escape === 0x62) {
+        appendCodeUnit(0x08);
+      } else if (escape === 0x66) {
+        appendCodeUnit(0x0c);
+      } else if (escape === 0x6e) {
+        appendCodeUnit(0x0a);
+      } else if (escape === 0x72) {
+        appendCodeUnit(0x0d);
+      } else if (escape === 0x74) {
+        appendCodeUnit(0x09);
+      } else if (escape === 0x75) {
+        appendCodeUnit(this.parseEscapedHexCodeUnit());
+      } else {
+        this.fail('Invalid JSON string escape');
+      }
+      rawStart = this.index;
     }
     this.fail('Unterminated JSON string');
+  }
+
+  private parseEscapedHexCodeUnit(): number {
+    if (this.index + 4 > this.text.length) this.fail('Truncated JSON unicode escape');
+    let value = 0;
+    for (let offset = 0; offset < 4; offset += 1) {
+      const nibble = hexNibble(this.text.charCodeAt(this.index + offset));
+      if (nibble < 0) this.fail('Invalid JSON unicode escape');
+      value = (value << 4) | nibble;
+    }
+    this.index += 4;
+    return value;
   }
 
   private parseNumber(): number {
@@ -566,6 +643,21 @@ function isDigit(value: string | undefined): boolean {
 
 function isDigitOneToNine(value: string | undefined): boolean {
   return value !== undefined && value >= '1' && value <= '9';
+}
+
+function isHighSurrogate(unit: number): boolean {
+  return unit >= 0xd800 && unit <= 0xdbff;
+}
+
+function isLowSurrogate(unit: number): boolean {
+  return unit >= 0xdc00 && unit <= 0xdfff;
+}
+
+function hexNibble(unit: number): number {
+  if (unit >= 0x30 && unit <= 0x39) return unit - 0x30;
+  if (unit >= 0x41 && unit <= 0x46) return unit - 0x41 + 10;
+  if (unit >= 0x61 && unit <= 0x66) return unit - 0x61 + 10;
+  return -1;
 }
 
 function assertJsonObjectShape(record: Record<string, unknown>): void {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,6 +13,7 @@ export * from './sparql-operation.js';
 export * from './publisher-extension.js';
 export * from './imported-artifact-bytes.js';
 export * from './imported-artifact-metadata.js';
+export * from './canonical-json.js';
 export * from './event-bus.js';
 export {
   Logger,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,7 +13,6 @@ export * from './sparql-operation.js';
 export * from './publisher-extension.js';
 export * from './imported-artifact-bytes.js';
 export * from './imported-artifact-metadata.js';
-export * from './canonical-json.js';
 export * from './event-bus.js';
 export {
   Logger,

--- a/packages/core/test/canonical-json.test.ts
+++ b/packages/core/test/canonical-json.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  CanonicalJsonError,
+  MAX_CANONICAL_JSON_BYTES,
+  MAX_CANONICAL_JSON_DEPTH,
+  canonicalizeJson,
+  parseCanonicalJson,
+  parseJsonStrict,
+  type CanonicalJsonValue,
+} from '../src/canonical-json.js';
+
+describe('RFC 8785 canonical JSON', () => {
+  it('matches the RFC 8785 section 3.2.2 canonicalization sample', () => {
+    const value = {
+      numbers: [333333333.33333329, 1e30, 4.5, 2e-3, 1e-27],
+      string: '\u20ac$\u000f\nA\'B"\\\\"/',
+      literals: [null, true, false],
+    };
+
+    expect(canonicalizeJson(value)).toBe(
+      '{"literals":[null,true,false],"numbers":[333333333.3333333,1e+30,4.5,0.002,1e-27],"string":"€$\\u000f\\nA\'B\\"\\\\\\\\\\"/"}',
+    );
+  });
+
+  it('sorts property names by UTF-16 code units rather than Unicode code points', () => {
+    expect(canonicalizeJson({ '\ue000': 'bmp', '\u{10000}': 'supplementary' })).toBe(
+      '{"𐀀":"supplementary","":"bmp"}',
+    );
+  });
+
+  it('matches the RFC 8785 Appendix B IEEE-754 number boundary vectors', () => {
+    const vectors: Array<[string, string]> = [
+      ['0000000000000000', '0'],
+      ['8000000000000000', '0'],
+      ['0000000000000001', '5e-324'],
+      ['8000000000000001', '-5e-324'],
+      ['7fefffffffffffff', '1.7976931348623157e+308'],
+      ['ffefffffffffffff', '-1.7976931348623157e+308'],
+      ['4340000000000000', '9007199254740992'],
+      ['c340000000000000', '-9007199254740992'],
+      ['4430000000000000', '295147905179352830000'],
+      ['44b52d02c7e14af5', '9.999999999999997e+22'],
+      ['44b52d02c7e14af6', '1e+23'],
+      ['44b52d02c7e14af7', '1.0000000000000001e+23'],
+      ['444b1ae4d6e2ef4e', '999999999999999700000'],
+      ['444b1ae4d6e2ef4f', '999999999999999900000'],
+      ['444b1ae4d6e2ef50', '1e+21'],
+      ['3eb0c6f7a0b5ed8c', '9.999999999999997e-7'],
+      ['3eb0c6f7a0b5ed8d', '0.000001'],
+      ['41b3de4355555553', '333333333.3333332'],
+      ['41b3de4355555554', '333333333.33333325'],
+      ['41b3de4355555555', '333333333.3333333'],
+      ['41b3de4355555556', '333333333.3333334'],
+      ['41b3de4355555557', '333333333.33333343'],
+      ['becbf647612f3696', '-0.0000033333333333333333'],
+      ['43143ff3c1cb0959', '1424953923781206.2'],
+    ];
+
+    for (const [bits, expected] of vectors) {
+      expect(canonicalizeJson(float64FromBits(bits)), bits).toBe(expected);
+    }
+    expect(() => canonicalizeJson(float64FromBits('7fffffffffffffff'))).toThrow(
+      /finite IEEE-754/,
+    );
+    expect(() => canonicalizeJson(float64FromBits('7ff0000000000000'))).toThrow(
+      /finite IEEE-754/,
+    );
+  });
+
+  it('parses canonical bytes and rejects merely valid, non-canonical JSON', () => {
+    expect(parseCanonicalJson('{"a":0,"b":[true,null]}')).toEqual({
+      a: 0,
+      b: [true, null],
+    });
+
+    for (const input of [
+      ' {"a":0,"b":[true,null]}',
+      '{"b":[true,null],"a":0}',
+      '{"a":-0,"b":[true,null]}',
+      '{"a":0.0,"b":[true,null]}',
+      '{"a":0,"b":[true,null]}\n',
+    ]) {
+      expect(() => parseCanonicalJson(input)).toThrow(/not RFC 8785 canonical/);
+    }
+  });
+
+  it('rejects duplicate decoded keys, including differently escaped spellings', () => {
+    expect(() => parseJsonStrict('{"a":1,"a":2}')).toThrow(/Duplicate object key/);
+    expect(() => parseJsonStrict(String.raw`{"a":1,"\u0061":2}`)).toThrow(
+      /Duplicate object key/,
+    );
+  });
+
+  it('rejects invalid UTF-8, a BOM, invalid grammar, and unpaired surrogates', () => {
+    expect(() => parseJsonStrict(new Uint8Array([0xc3, 0x28]))).toThrow(/not valid UTF-8/);
+    expect(() => parseJsonStrict(new Uint8Array([0xef, 0xbb, 0xbf, 0x6e, 0x75, 0x6c, 0x6c])))
+      .toThrow(/BOM/);
+
+    for (const input of ['01', '1.', '[1,]', '{"a":1,}', 'true false']) {
+      expect(() => parseJsonStrict(input)).toThrow(CanonicalJsonError);
+    }
+
+    expect(() => parseJsonStrict(String.raw`"\ud800"`)).toThrow(/unpaired high surrogate/);
+    expect(() => parseJsonStrict(String.raw`"\udc00"`)).toThrow(/unpaired low surrogate/);
+  });
+
+  it('enforces byte and nesting ceilings even for empty nested containers', () => {
+    expect(() => parseJsonStrict('{"a":1}', { maxBytes: 6 })).toThrow(/exceeds 6 bytes/);
+    expect(parseJsonStrict('{"a":1}', { maxDepth: 1 })).toEqual({ a: 1 });
+    expect(() => parseJsonStrict('{"a":{}}', { maxDepth: 1 })).toThrow(
+      /nesting exceeds 1/,
+    );
+    expect(() => parseJsonStrict('[[]]', { maxDepth: 1 })).toThrow(/nesting exceeds 1/);
+  });
+
+  it('enforces exact UTF-8 byte and protocol depth boundaries in both directions', () => {
+    expect(canonicalizeJson('é', { maxBytes: 4 })).toBe('"é"');
+    expect(parseCanonicalJson('"é"', { maxBytes: 4 })).toBe('é');
+    expect(() => canonicalizeJson('é', { maxBytes: 3 })).toThrow(/exceeds 3 bytes/);
+    expect(() => parseCanonicalJson('"é"', { maxBytes: 3 })).toThrow(
+      /exceeds 3 bytes/,
+    );
+
+    const atLimit = nestedArrayJson(MAX_CANONICAL_JSON_DEPTH);
+    expect(parseCanonicalJson(atLimit, { maxDepth: MAX_CANONICAL_JSON_DEPTH })).toBeTruthy();
+    expect(canonicalizeJson(parseJsonStrict(atLimit))).toBe(atLimit);
+    const overLimit = nestedArrayJson(MAX_CANONICAL_JSON_DEPTH + 1);
+    expect(() => parseCanonicalJson(overLimit)).toThrow(/nesting exceeds 64/);
+
+    expect(() => parseJsonStrict('null', {
+      maxBytes: MAX_CANONICAL_JSON_BYTES + 1,
+    })).toThrow(/no greater than/);
+    expect(() => parseJsonStrict('null', {
+      maxDepth: MAX_CANONICAL_JSON_DEPTH + 1,
+    })).toThrow(/no greater than/);
+  });
+
+  it('aborts bounded serialization while traversing an oversized JavaScript value', () => {
+    expect(() => canonicalizeJson({ payload: 'x'.repeat(128) }, { maxBytes: 32 })).toThrow(
+      /Canonical JSON exceeds 32 bytes/,
+    );
+  });
+
+  it('rejects JavaScript values that are not lossless plain JSON data', () => {
+    expect(() => canonicalizeJson(Number.NaN as unknown as CanonicalJsonValue)).toThrow(
+      /finite IEEE-754/,
+    );
+    expect(() => canonicalizeJson([1, , 3] as unknown as CanonicalJsonValue)).toThrow(
+      /Sparse arrays/,
+    );
+    expect(() => canonicalizeJson(new Date() as unknown as CanonicalJsonValue)).toThrow(
+      /plain JSON objects/,
+    );
+
+    const cyclic: Record<string, CanonicalJsonValue> = {};
+    cyclic.self = cyclic;
+    expect(() => canonicalizeJson(cyclic)).toThrow(/Cyclic values/);
+
+    const symbolObject = { a: 1 } as Record<PropertyKey, unknown>;
+    symbolObject[Symbol('hidden')] = 2;
+    expect(() => canonicalizeJson(symbolObject as CanonicalJsonValue)).toThrow(
+      /symbol properties/,
+    );
+
+    const accessorObject = {};
+    Object.defineProperty(accessorObject, 'a', { enumerable: true, get: () => 1 });
+    expect(() => canonicalizeJson(accessorObject as CanonicalJsonValue)).toThrow(
+      /accessor properties/,
+    );
+
+    const decoratedArray = [1] as unknown[] & { extra?: number };
+    decoratedArray.extra = 2;
+    expect(() => canonicalizeJson(decoratedArray as CanonicalJsonValue)).toThrow(
+      /non-index properties/,
+    );
+  });
+});
+
+function float64FromBits(hex: string): number {
+  const buffer = new ArrayBuffer(8);
+  const view = new DataView(buffer);
+  view.setBigUint64(0, BigInt(`0x${hex}`));
+  return view.getFloat64(0);
+}
+
+function nestedArrayJson(depth: number): string {
+  let value = '0';
+  for (let index = 0; index < depth; index += 1) value = `[${value}]`;
+  return value;
+}

--- a/packages/core/test/canonical-json.test.ts
+++ b/packages/core/test/canonical-json.test.ts
@@ -112,6 +112,26 @@ describe('RFC 8785 canonical JSON', () => {
       /nesting exceeds 1/,
     );
     expect(() => parseJsonStrict('[[]]', { maxDepth: 1 })).toThrow(/nesting exceeds 1/);
+    expect(() => canonicalizeJson({ a: {} }, { maxDepth: 1 })).toThrow(
+      /nesting exceeds 1/,
+    );
+    expect(() => canonicalizeJson([[]], { maxDepth: 1 })).toThrow(/nesting exceeds 1/);
+    expect(canonicalizeJson({ a: 1 }, { maxDepth: 1 })).toBe('{"a":1}');
+    expect(canonicalizeJson([1], { maxDepth: 1 })).toBe('[1]');
+    expect(() => canonicalizeJson({}, { maxDepth: 0 })).toThrow(/nesting exceeds 0/);
+    expect(() => parseJsonStrict('{}', { maxDepth: 0 })).toThrow(/nesting exceeds 0/);
+  });
+
+  it('rejects decimal tokens that silently change when converted to IEEE-754', () => {
+    expect(() => parseJsonStrict('9007199254740993')).toThrow(/loses information/);
+    expect(() => parseJsonStrict('1e-324')).toThrow(/loses information/);
+    expect(() => parseJsonStrict('0.10000000000000001')).toThrow(/loses information/);
+
+    expect(parseJsonStrict('9007199254740992')).toBe(9_007_199_254_740_992);
+    expect(parseJsonStrict('5e-324')).toBe(5e-324);
+    expect(parseJsonStrict('1.0')).toBe(1);
+    expect(parseJsonStrict('1e0')).toBe(1);
+    expect(parseJsonStrict('100000000000000000000000')).toBe(1e23);
   });
 
   it('enforces exact UTF-8 byte and protocol depth boundaries in both directions', () => {

--- a/packages/core/test/canonical-json.test.ts
+++ b/packages/core/test/canonical-json.test.ts
@@ -92,6 +92,30 @@ describe('RFC 8785 canonical JSON', () => {
     );
   });
 
+  it('decodes the complete JSON escape grammar in one Unicode-scalar path', () => {
+    expect(parseJsonStrict(
+      String.raw`["\"","\\","\/","\b","\f","\n","\r","\t","\u0061","\uD834\uDD1E"]`,
+    )).toEqual(['"', '\\', '/', '\b', '\f', '\n', '\r', '\t', 'a', '𝄞']);
+    expect(parseJsonStrict('"𝄞"')).toBe('𝄞');
+    // Preserve scalar semantics even when a direct JavaScript-string caller
+    // splits one pair across raw and escaped UTF-16 code units. Byte callers
+    // cannot carry the raw lone half because the UTF-8 decoder is fatal.
+    expect(parseJsonStrict(`"${'\ud834'}\\uDD1E"`)).toBe('𝄞');
+    expect(parseJsonStrict(`"\\uD834${'\udd1e'}"`)).toBe('𝄞');
+
+    for (const input of [
+      String.raw`"\uD834x"`,
+      String.raw`"\uD834\u0061"`,
+      String.raw`"\uDD1E"`,
+      String.raw`"\u12"`,
+      String.raw`"\u12xz"`,
+      String.raw`"\x61"`,
+      '"line\nbreak"',
+    ]) {
+      expect(() => parseJsonStrict(input), input).toThrow(CanonicalJsonError);
+    }
+  });
+
   it('rejects invalid UTF-8, a BOM, invalid grammar, and unpaired surrogates', () => {
     expect(() => parseJsonStrict(new Uint8Array([0xc3, 0x28]))).toThrow(/not valid UTF-8/);
     expect(() => parseJsonStrict(new Uint8Array([0xef, 0xbb, 0xbf, 0x6e, 0x75, 0x6c, 0x6c])))


### PR DESCRIPTION
## Summary

Introduces the dormant RFC-64 canonical JSON foundation used by signed sync control objects:

- strict RFC 8785/JCS serialization and canonical-wire decoding
- duplicate decoded-key, invalid UTF-8/BOM, unpaired-surrogate, non-I-JSON, accessor, sparse-array, and cyclic-value rejection
- bounded incremental serialization with 8 MiB hard output and depth ceilings
- RFC 8785 canonicalization and Appendix B numeric boundary vectors

This PR does not register a protocol, alter publication/sync behavior, or add persistence. It is the first independently reviewable implementation slice of [OT-RFC-64 Rev 4.7](https://github.com/OriginTrail/dkgv10-spec/pull/144).

## Validation

- core TypeScript build passes
- focused canonical JSON tests pass (10/10)
- the stacked combined core suite passes (84 files, 1,267 tests)
- `git diff --check` passes
