### PR TITLE
RFC-64: add signed control object envelopes

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,7 @@ export * from './publisher-extension.js';
 export * from './imported-artifact-bytes.js';
 export * from './imported-artifact-metadata.js';
 export * from './canonical-json.js';
+export * from './sync-control-object.js';
 export * from './event-bus.js';
 export {
   Logger,

--- a/packages/core/src/sync-control-object.ts
+++ b/packages/core/src/sync-control-object.ts
@@ -321,7 +321,7 @@ function assertUnsignedControlEnvelopeFields(
       throw new Error('Control-object type is outside the canonical string bounds');
     }
   }
-  if (/[ -]/u.test(envelope.objectType)) {
+  if (/[\u0000-\u001f\u007f]/u.test(envelope.objectType)) {
     throw new Error('Control-object type is outside the canonical string bounds');
   }
   if (!CONTROL_OBJECT_SIGNATURE_SUITES.includes(envelope.signatureSuite)) {

--- a/packages/core/src/sync-control-object.ts
+++ b/packages/core/src/sync-control-object.ts
@@ -34,19 +34,42 @@ export type ControlObjectSignatureEvidence =
       readonly contractAddress: string;
     };
 
-export interface UnsignedControlEnvelopeV1<Payload extends CanonicalJsonValue = CanonicalJsonValue> {
+interface ControlEnvelopeBaseV1<Payload extends CanonicalJsonValue> {
   readonly objectType: string;
   readonly payload: Payload;
-  readonly signatureSuite: ControlObjectSignatureSuite;
   readonly issuer: string;
-  readonly signatureEvidence: ControlObjectSignatureEvidence;
 }
 
-export interface SignedControlEnvelopeV1<Payload extends CanonicalJsonValue = CanonicalJsonValue>
-  extends UnsignedControlEnvelopeV1<Payload> {
+export interface Eip191UnsignedControlEnvelopeV1<
+  Payload extends CanonicalJsonValue = CanonicalJsonValue,
+> extends ControlEnvelopeBaseV1<Payload> {
+  readonly signatureSuite: 'eip191-personal-sign-digest-v1';
+  readonly signatureEvidence: { readonly kind: 'none' };
+}
+
+export interface Eip1271UnsignedControlEnvelopeV1<
+  Payload extends CanonicalJsonValue = CanonicalJsonValue,
+> extends ControlEnvelopeBaseV1<Payload> {
+  readonly signatureSuite: 'eip1271-current-finalized-v1';
+  readonly signatureEvidence: {
+    readonly kind: 'eip1271-current-finalized';
+    readonly chainId: string;
+    readonly contractAddress: string;
+  };
+}
+
+export type UnsignedControlEnvelopeV1<
+  Payload extends CanonicalJsonValue = CanonicalJsonValue,
+> = Eip191UnsignedControlEnvelopeV1<Payload> | Eip1271UnsignedControlEnvelopeV1<Payload>;
+
+interface SignedControlEnvelopeFieldsV1 {
   readonly objectDigest: string;
   readonly signature: string;
 }
+
+export type SignedControlEnvelopeV1<
+  Payload extends CanonicalJsonValue = CanonicalJsonValue,
+> = UnsignedControlEnvelopeV1<Payload> & SignedControlEnvelopeFieldsV1;
 
 export interface ControlObjectSignatureVariantV1 {
   readonly objectDigest: string;
@@ -60,6 +83,7 @@ const SIGNATURE_VARIANT_DOMAIN_BYTES = UTF8.encode(CONTROL_SIGNATURE_VARIANT_DIG
 const EVM_ADDRESS = /^0x[0-9a-f]{40}$/;
 const LOWER_HEX_BYTES = /^0x(?:[0-9a-f]{2})+$/;
 const CANONICAL_UNSIGNED_DECIMAL = /^(?:0|[1-9][0-9]*)$/;
+const MAX_U256 = (1n << 256n) - 1n;
 
 /**
  * Return the exact RFC-64 unsigned-envelope bytes used by every digest/signature
@@ -135,7 +159,14 @@ export function parseCanonicalUnsignedControlEnvelope(
 export function assertSignedControlEnvelope(
   envelope: SignedControlEnvelopeV1,
 ): void {
-  validateSignedControlEnvelope(envelope, true);
+  validateSignedControlEnvelope(envelope);
+}
+
+/** Return the exact bounded canonical bytes of a complete signed envelope. */
+export function canonicalizeSignedControlEnvelopeBytes(
+  envelope: SignedControlEnvelopeV1,
+): Uint8Array {
+  return validateSignedControlEnvelope(envelope);
 }
 
 /** Strictly decode and validate a canonical signed wire envelope. */
@@ -148,7 +179,7 @@ export function parseCanonicalSignedControlEnvelope(
     throw new Error('Signed control-object envelope must be a plain JSON object');
   }
   const envelope = parsed as unknown as SignedControlEnvelopeV1;
-  validateSignedControlEnvelope(envelope, false);
+  validateSignedControlEnvelope(envelope);
   return envelope;
 }
 
@@ -220,7 +251,7 @@ export function parseCanonicalControlSignatureVariant(
   return variant;
 }
 
-export function assertCanonicalEvmAddress(value: string, label = 'address'): void {
+function assertCanonicalEvmAddress(value: string, label = 'address'): void {
   if (typeof value !== 'string' || !EVM_ADDRESS.test(value)) {
     throw new Error(`${label} must be a lowercase 20-byte 0x EVM address`);
   }
@@ -229,7 +260,7 @@ export function assertCanonicalEvmAddress(value: string, label = 'address'): voi
   }
 }
 
-export function bytesToLowerHex(bytes: Uint8Array): string {
+function bytesToLowerHex(bytes: Uint8Array): string {
   let result = '0x';
   for (const byte of bytes) result += byte.toString(16).padStart(2, '0');
   return result;
@@ -237,8 +268,7 @@ export function bytesToLowerHex(bytes: Uint8Array): string {
 
 function validateSignedControlEnvelope(
   envelope: SignedControlEnvelopeV1,
-  enforceSignedSize: boolean,
-): void {
+): Uint8Array {
   if (!isPlainRecord(envelope)) {
     throw new Error('Signed control-object envelope must be a plain JSON object');
   }
@@ -257,17 +287,15 @@ function validateSignedControlEnvelope(
   assertCanonicalDigest(envelope.objectDigest, 'objectDigest');
   assertSignatureForSuite(envelope.signature, envelope.signatureSuite);
   const canonicalUnsigned = canonicalizeUnsignedControlEnvelopeBytesAfterFields(unsigned);
-  if (
-    enforceSignedSize
-    && canonicalUnsigned.byteLength + signedEnvelopeAdditionalBytes(envelope)
-      > MAX_CONTROL_OBJECT_BYTES
-  ) {
-    throw new Error(`Signed control-object envelope exceeds ${MAX_CONTROL_OBJECT_BYTES} bytes`);
-  }
+  const canonicalSigned = canonicalizeJsonBytes(toCanonicalSignedEnvelope(envelope), {
+    maxBytes: MAX_CONTROL_OBJECT_BYTES,
+    maxDepth: MAX_CONTROL_OBJECT_DEPTH,
+  });
   const expectedDigest = bytesToLowerHex(digestWithDomain(DOMAIN_BYTES, canonicalUnsigned));
   if (envelope.objectDigest !== expectedDigest) {
     throw new Error(`Control-object digest mismatch: expected ${expectedDigest}`);
   }
+  return canonicalSigned;
 }
 
 function assertUnsignedControlEnvelopeFields(
@@ -321,9 +349,11 @@ function assertUnsignedControlEnvelopeFields(
     }
     if (
       typeof envelope.signatureEvidence.chainId !== 'string'
+      || envelope.signatureEvidence.chainId.length > 78
       || !CANONICAL_UNSIGNED_DECIMAL.test(envelope.signatureEvidence.chainId)
+      || BigInt(envelope.signatureEvidence.chainId) > MAX_U256
     ) {
-      throw new Error('EIP-1271 chainId must be a canonical unsigned decimal string');
+      throw new Error('EIP-1271 chainId must be a canonical unsigned decimal u256 string');
     }
     assertCanonicalEvmAddress(
       envelope.signatureEvidence.contractAddress,
@@ -391,6 +421,15 @@ function assertCanonicalHexBytes(
 function extractUnsignedEnvelope(
   envelope: SignedControlEnvelopeV1,
 ): UnsignedControlEnvelopeV1 {
+  if (envelope.signatureSuite === 'eip191-personal-sign-digest-v1') {
+    return {
+      issuer: envelope.issuer,
+      objectType: envelope.objectType,
+      payload: envelope.payload,
+      signatureEvidence: envelope.signatureEvidence,
+      signatureSuite: envelope.signatureSuite,
+    };
+  }
   return {
     issuer: envelope.issuer,
     objectType: envelope.objectType,
@@ -420,15 +459,18 @@ function toCanonicalUnsignedEnvelope(
   };
 }
 
-function signedEnvelopeAdditionalBytes(
+function toCanonicalSignedEnvelope(
   envelope: SignedControlEnvelopeV1,
-): number {
-  // The signed form adds exactly two comma-delimited ASCII fields to the already
-  // non-empty unsigned object. Sorting changes placement, never byte length.
-  return (
-    1 + '"objectDigest":'.length + envelope.objectDigest.length + 2
-    + 1 + '"signature":'.length + envelope.signature.length + 2
-  );
+): CanonicalJsonValue {
+  const unsigned = toCanonicalUnsignedEnvelope(envelope) as Record<
+    string,
+    CanonicalJsonValue
+  >;
+  return {
+    ...unsigned,
+    objectDigest: envelope.objectDigest,
+    signature: envelope.signature,
+  };
 }
 
 function digestWithDomain(domain: Uint8Array, payload: Uint8Array): Uint8Array {

--- a/packages/core/src/sync-control-object.ts
+++ b/packages/core/src/sync-control-object.ts
@@ -496,9 +496,12 @@ function assertExactKeys(
     throw new Error(`${label} must not contain symbol properties`);
   }
   const strings = actual as string[];
+  // Sort both sides so the helper is a true exact-key validator and does not
+  // silently depend on each call site pre-sorting `expected`.
+  const sortedExpected = [...expected].sort();
   if (
     strings.length !== expected.length
-    || [...strings].sort().some((key, index) => key !== expected[index])
+    || [...strings].sort().some((key, index) => key !== sortedExpected[index])
   ) {
     throw new Error(`${label} has unknown or missing fields`);
   }

--- a/packages/core/src/sync-control-object.ts
+++ b/packages/core/src/sync-control-object.ts
@@ -1,0 +1,469 @@
+import { sha256 } from '@noble/hashes/sha2.js';
+
+import {
+  MAX_CANONICAL_JSON_BYTES,
+  MAX_CANONICAL_JSON_DEPTH,
+  canonicalizeJsonBytes,
+  parseCanonicalJson,
+  type CanonicalJsonValue,
+  type StrictJsonParseOptions,
+} from './canonical-json.js';
+
+export const CONTROL_OBJECT_DIGEST_DOMAIN = 'dkg-control-object-v1\n' as const;
+export const CONTROL_SIGNATURE_VARIANT_DIGEST_DOMAIN =
+  'dkg-control-signature-variant-v1\n' as const;
+export const MAX_CONTROL_OBJECT_BYTES = MAX_CANONICAL_JSON_BYTES;
+export const MAX_CONTROL_OBJECT_DEPTH = MAX_CANONICAL_JSON_DEPTH;
+export const EIP191_SIGNATURE_BYTES = 65;
+export const MAX_EIP1271_SIGNATURE_BYTES = 4096;
+export const MAX_CONTROL_SIGNATURE_VARIANT_BYTES = 16 * 1024;
+
+export const CONTROL_OBJECT_SIGNATURE_SUITES = [
+  'eip191-personal-sign-digest-v1',
+  'eip1271-current-finalized-v1',
+] as const;
+
+export type ControlObjectSignatureSuite = (typeof CONTROL_OBJECT_SIGNATURE_SUITES)[number];
+
+export type ControlObjectSignatureEvidence =
+  | { readonly kind: 'none' }
+  | {
+      readonly kind: 'eip1271-current-finalized';
+      /** Canonical unsigned decimal integer; JSON numbers are not used for chain IDs. */
+      readonly chainId: string;
+      readonly contractAddress: string;
+    };
+
+export interface UnsignedControlEnvelopeV1<Payload extends CanonicalJsonValue = CanonicalJsonValue> {
+  readonly objectType: string;
+  readonly payload: Payload;
+  readonly signatureSuite: ControlObjectSignatureSuite;
+  readonly issuer: string;
+  readonly signatureEvidence: ControlObjectSignatureEvidence;
+}
+
+export interface SignedControlEnvelopeV1<Payload extends CanonicalJsonValue = CanonicalJsonValue>
+  extends UnsignedControlEnvelopeV1<Payload> {
+  readonly objectDigest: string;
+  readonly signature: string;
+}
+
+export interface ControlObjectSignatureVariantV1 {
+  readonly objectDigest: string;
+  readonly signatureVariantDigest: string;
+  readonly signature: string;
+}
+
+const UTF8 = new TextEncoder();
+const DOMAIN_BYTES = UTF8.encode(CONTROL_OBJECT_DIGEST_DOMAIN);
+const SIGNATURE_VARIANT_DOMAIN_BYTES = UTF8.encode(CONTROL_SIGNATURE_VARIANT_DIGEST_DOMAIN);
+const EVM_ADDRESS = /^0x[0-9a-f]{40}$/;
+const LOWER_HEX_BYTES = /^0x(?:[0-9a-f]{2})+$/;
+const CANONICAL_UNSIGNED_DECIMAL = /^(?:0|[1-9][0-9]*)$/;
+
+/**
+ * Return the exact RFC-64 unsigned-envelope bytes used by every digest/signature
+ * implementation. Validation and bounded serialization happen in the same traversal.
+ */
+export function canonicalizeUnsignedControlEnvelopeBytes(
+  envelope: UnsignedControlEnvelopeV1,
+): Uint8Array {
+  assertUnsignedControlEnvelopeFields(envelope);
+  return canonicalizeUnsignedControlEnvelopeBytesAfterFields(envelope);
+}
+
+function canonicalizeUnsignedControlEnvelopeBytesAfterFields(
+  envelope: UnsignedControlEnvelopeV1,
+): Uint8Array {
+  return canonicalizeJsonBytes(toCanonicalUnsignedEnvelope(envelope), {
+    maxBytes: MAX_CONTROL_OBJECT_BYTES,
+    maxDepth: MAX_CONTROL_OBJECT_DEPTH,
+  });
+}
+
+/** Compute the raw 32-byte Track-2 object digest over the exact unsigned envelope. */
+export function computeControlObjectDigest(
+  envelope: UnsignedControlEnvelopeV1,
+): Uint8Array {
+  return digestWithDomain(DOMAIN_BYTES, canonicalizeUnsignedControlEnvelopeBytes(envelope));
+}
+
+export function computeControlObjectDigestHex(
+  envelope: UnsignedControlEnvelopeV1,
+): string {
+  return bytesToLowerHex(computeControlObjectDigest(envelope));
+}
+
+export function assertControlObjectDigest(
+  envelope: UnsignedControlEnvelopeV1,
+  claimedDigest: string,
+): void {
+  assertCanonicalDigest(claimedDigest, 'objectDigest');
+  const expected = computeControlObjectDigestHex(envelope);
+  if (claimedDigest !== expected) {
+    throw new Error(`Control-object digest mismatch: expected ${expected}`);
+  }
+}
+
+/** Validate an in-memory unsigned envelope, including the generic byte/depth caps. */
+export function assertUnsignedControlEnvelope(
+  envelope: UnsignedControlEnvelopeV1,
+): void {
+  canonicalizeUnsignedControlEnvelopeBytes(envelope);
+}
+
+/**
+ * Decode a received unsigned envelope. Wire bytes must already be canonical JCS;
+ * the returned object has exactly the five unsigned-envelope fields.
+ */
+export function parseCanonicalUnsignedControlEnvelope(
+  input: string | Uint8Array,
+  options: StrictJsonParseOptions = {},
+): UnsignedControlEnvelopeV1 {
+  const parsed = parseCanonicalJson(input, options);
+  if (!isPlainRecord(parsed)) {
+    throw new Error('Control-object envelope must be a plain JSON object');
+  }
+  const envelope = parsed as unknown as UnsignedControlEnvelopeV1;
+  // parseCanonicalJson already enforced I-JSON, the caller's lower cap, and the
+  // protocol hard caps. Only schema/evidence constraints remain here.
+  assertUnsignedControlEnvelopeFields(envelope);
+  return envelope;
+}
+
+/** Validate a complete signed wire envelope without performing authority verification. */
+export function assertSignedControlEnvelope(
+  envelope: SignedControlEnvelopeV1,
+): void {
+  validateSignedControlEnvelope(envelope, true);
+}
+
+/** Strictly decode and validate a canonical signed wire envelope. */
+export function parseCanonicalSignedControlEnvelope(
+  input: string | Uint8Array,
+  options: StrictJsonParseOptions = {},
+): SignedControlEnvelopeV1 {
+  const parsed = parseCanonicalJson(input, options);
+  if (!isPlainRecord(parsed)) {
+    throw new Error('Signed control-object envelope must be a plain JSON object');
+  }
+  const envelope = parsed as unknown as SignedControlEnvelopeV1;
+  validateSignedControlEnvelope(envelope, false);
+  return envelope;
+}
+
+/** Compute the RFC-64 detached-signature record digest. */
+export function computeControlSignatureVariantDigest(
+  objectDigest: string,
+  signature: string,
+): Uint8Array {
+  assertCanonicalDigest(objectDigest, 'objectDigest');
+  assertCanonicalHexBytes(
+    signature,
+    'signature',
+    1,
+    MAX_EIP1271_SIGNATURE_BYTES,
+  );
+  const canonicalVariant = canonicalizeJsonBytes({ objectDigest, signature }, {
+    maxBytes: MAX_CONTROL_OBJECT_BYTES,
+    maxDepth: MAX_CONTROL_OBJECT_DEPTH,
+  });
+  return digestWithDomain(SIGNATURE_VARIANT_DOMAIN_BYTES, canonicalVariant);
+}
+
+export function computeControlSignatureVariantDigestHex(
+  objectDigest: string,
+  signature: string,
+): string {
+  return bytesToLowerHex(computeControlSignatureVariantDigest(objectDigest, signature));
+}
+
+export function assertControlSignatureVariantDigest(
+  objectDigest: string,
+  signature: string,
+  claimedDigest: string,
+): void {
+  assertCanonicalDigest(claimedDigest, 'signatureVariantDigest');
+  const expected = computeControlSignatureVariantDigestHex(objectDigest, signature);
+  if (claimedDigest !== expected) {
+    throw new Error(`Control signature-variant digest mismatch: expected ${expected}`);
+  }
+}
+
+/** Strictly decode the normalized detached-signature record defined by RFC-64. */
+export function parseCanonicalControlSignatureVariant(
+  input: string | Uint8Array,
+  options: StrictJsonParseOptions = {},
+): ControlObjectSignatureVariantV1 {
+  const parsed = parseCanonicalJson(input, {
+    ...options,
+    maxBytes: Math.min(
+      options.maxBytes ?? MAX_CONTROL_SIGNATURE_VARIANT_BYTES,
+      MAX_CONTROL_SIGNATURE_VARIANT_BYTES,
+    ),
+    maxDepth: Math.min(options.maxDepth ?? 1, 1),
+  });
+  if (!isPlainRecord(parsed)) {
+    throw new Error('Control signature variant must be a plain JSON object');
+  }
+  assertExactKeys(
+    parsed,
+    ['objectDigest', 'signature', 'signatureVariantDigest'],
+    'control signature variant',
+  );
+  const variant = parsed as unknown as ControlObjectSignatureVariantV1;
+  assertControlSignatureVariantDigest(
+    variant.objectDigest,
+    variant.signature,
+    variant.signatureVariantDigest,
+  );
+  return variant;
+}
+
+export function assertCanonicalEvmAddress(value: string, label = 'address'): void {
+  if (typeof value !== 'string' || !EVM_ADDRESS.test(value)) {
+    throw new Error(`${label} must be a lowercase 20-byte 0x EVM address`);
+  }
+  if (value === '0x0000000000000000000000000000000000000000') {
+    throw new Error(`${label} must not be the zero address`);
+  }
+}
+
+export function bytesToLowerHex(bytes: Uint8Array): string {
+  let result = '0x';
+  for (const byte of bytes) result += byte.toString(16).padStart(2, '0');
+  return result;
+}
+
+function validateSignedControlEnvelope(
+  envelope: SignedControlEnvelopeV1,
+  enforceSignedSize: boolean,
+): void {
+  if (!isPlainRecord(envelope)) {
+    throw new Error('Signed control-object envelope must be a plain JSON object');
+  }
+  assertExactKeys(envelope, [
+    'issuer',
+    'objectDigest',
+    'objectType',
+    'payload',
+    'signature',
+    'signatureEvidence',
+    'signatureSuite',
+  ], 'signed control-object envelope');
+
+  const unsigned = extractUnsignedEnvelope(envelope);
+  assertUnsignedControlEnvelopeFields(unsigned);
+  assertCanonicalDigest(envelope.objectDigest, 'objectDigest');
+  assertSignatureForSuite(envelope.signature, envelope.signatureSuite);
+  const canonicalUnsigned = canonicalizeUnsignedControlEnvelopeBytesAfterFields(unsigned);
+  if (
+    enforceSignedSize
+    && canonicalUnsigned.byteLength + signedEnvelopeAdditionalBytes(envelope)
+      > MAX_CONTROL_OBJECT_BYTES
+  ) {
+    throw new Error(`Signed control-object envelope exceeds ${MAX_CONTROL_OBJECT_BYTES} bytes`);
+  }
+  const expectedDigest = bytesToLowerHex(digestWithDomain(DOMAIN_BYTES, canonicalUnsigned));
+  if (envelope.objectDigest !== expectedDigest) {
+    throw new Error(`Control-object digest mismatch: expected ${expectedDigest}`);
+  }
+}
+
+function assertUnsignedControlEnvelopeFields(
+  envelope: UnsignedControlEnvelopeV1,
+): void {
+  if (!isPlainRecord(envelope)) {
+    throw new Error('Control-object envelope must be a plain JSON object');
+  }
+  assertExactKeys(envelope, [
+    'issuer',
+    'objectType',
+    'payload',
+    'signatureEvidence',
+    'signatureSuite',
+  ], 'control-object envelope');
+  if (typeof envelope.objectType !== 'string' || envelope.objectType.length === 0) {
+    throw new Error('Control-object type must be a non-empty string');
+  }
+  let objectTypeScalars = 0;
+  for (const _scalar of envelope.objectType) {
+    objectTypeScalars += 1;
+    if (objectTypeScalars > 128) {
+      throw new Error('Control-object type is outside the canonical string bounds');
+    }
+  }
+  if (/[ -]/u.test(envelope.objectType)) {
+    throw new Error('Control-object type is outside the canonical string bounds');
+  }
+  if (!CONTROL_OBJECT_SIGNATURE_SUITES.includes(envelope.signatureSuite)) {
+    throw new Error(`Unsupported control-object signature suite: ${String(envelope.signatureSuite)}`);
+  }
+  assertCanonicalEvmAddress(envelope.issuer, 'issuer');
+
+  if (!isPlainRecord(envelope.signatureEvidence)) {
+    throw new Error('Control-object signature evidence must be a plain JSON object');
+  }
+
+  if (envelope.signatureSuite === 'eip191-personal-sign-digest-v1') {
+    assertExactKeys(envelope.signatureEvidence, ['kind'], 'EIP-191 signature evidence');
+    if (envelope.signatureEvidence.kind !== 'none') {
+      throw new Error('EIP-191 control objects require signatureEvidence.kind=none');
+    }
+  } else {
+    assertExactKeys(
+      envelope.signatureEvidence,
+      ['chainId', 'contractAddress', 'kind'],
+      'EIP-1271 signature evidence',
+    );
+    if (envelope.signatureEvidence.kind !== 'eip1271-current-finalized') {
+      throw new Error('EIP-1271 control objects require current-finalized evidence');
+    }
+    if (
+      typeof envelope.signatureEvidence.chainId !== 'string'
+      || !CANONICAL_UNSIGNED_DECIMAL.test(envelope.signatureEvidence.chainId)
+    ) {
+      throw new Error('EIP-1271 chainId must be a canonical unsigned decimal string');
+    }
+    assertCanonicalEvmAddress(
+      envelope.signatureEvidence.contractAddress,
+      'signatureEvidence.contractAddress',
+    );
+    if (envelope.signatureEvidence.contractAddress !== envelope.issuer) {
+      throw new Error('EIP-1271 evidence contract must equal the envelope issuer');
+    }
+  }
+}
+
+function assertSignatureForSuite(
+  signature: string,
+  suite: ControlObjectSignatureSuite,
+): void {
+  if (suite === 'eip191-personal-sign-digest-v1') {
+    assertCanonicalHexBytes(
+      signature,
+      'EIP-191 signature',
+      EIP191_SIGNATURE_BYTES,
+      EIP191_SIGNATURE_BYTES,
+    );
+    return;
+  }
+  assertCanonicalHexBytes(
+    signature,
+    'EIP-1271 signature',
+    1,
+    MAX_EIP1271_SIGNATURE_BYTES,
+  );
+}
+
+function assertCanonicalDigest(value: string, label: string): void {
+  if (
+    typeof value !== 'string'
+    || value.length !== 66
+    || !/^0x[0-9a-f]{64}$/.test(value)
+  ) {
+    throw new Error(`${label} must be a lowercase 32-byte 0x digest`);
+  }
+}
+
+function assertCanonicalHexBytes(
+  value: string,
+  label: string,
+  minBytes: number,
+  maxBytes: number,
+): void {
+  if (typeof value !== 'string' || !value.startsWith('0x')) {
+    throw new Error(`${label} must be lowercase 0x-prefixed bytes`);
+  }
+  const hexLength = value.length - 2;
+  if (
+    hexLength % 2 !== 0
+    || hexLength < minBytes * 2
+    || hexLength > maxBytes * 2
+    || !LOWER_HEX_BYTES.test(value)
+  ) {
+    throw new Error(
+      `${label} must be ${minBytes === maxBytes ? `${minBytes}` : `${minBytes}-${maxBytes}`} lowercase bytes`,
+    );
+  }
+}
+
+function extractUnsignedEnvelope(
+  envelope: SignedControlEnvelopeV1,
+): UnsignedControlEnvelopeV1 {
+  return {
+    issuer: envelope.issuer,
+    objectType: envelope.objectType,
+    payload: envelope.payload,
+    signatureEvidence: envelope.signatureEvidence,
+    signatureSuite: envelope.signatureSuite,
+  };
+}
+
+function toCanonicalUnsignedEnvelope(
+  envelope: UnsignedControlEnvelopeV1,
+): CanonicalJsonValue {
+  const evidence: CanonicalJsonValue = envelope.signatureEvidence.kind === 'none'
+    ? { kind: 'none' }
+    : {
+        chainId: envelope.signatureEvidence.chainId,
+        contractAddress: envelope.signatureEvidence.contractAddress,
+        kind: 'eip1271-current-finalized',
+      };
+
+  return {
+    issuer: envelope.issuer,
+    objectType: envelope.objectType,
+    payload: envelope.payload,
+    signatureEvidence: evidence,
+    signatureSuite: envelope.signatureSuite,
+  };
+}
+
+function signedEnvelopeAdditionalBytes(
+  envelope: SignedControlEnvelopeV1,
+): number {
+  // The signed form adds exactly two comma-delimited ASCII fields to the already
+  // non-empty unsigned object. Sorting changes placement, never byte length.
+  return (
+    1 + '"objectDigest":'.length + envelope.objectDigest.length + 2
+    + 1 + '"signature":'.length + envelope.signature.length + 2
+  );
+}
+
+function digestWithDomain(domain: Uint8Array, payload: Uint8Array): Uint8Array {
+  const preimage = new Uint8Array(domain.length + payload.length);
+  preimage.set(domain);
+  preimage.set(payload, domain.length);
+  return sha256(preimage);
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function assertExactKeys(
+  record: Record<string, unknown>,
+  expected: readonly string[],
+  label: string,
+): void {
+  const actual = Reflect.ownKeys(record);
+  if (actual.some((key) => typeof key !== 'string')) {
+    throw new Error(`${label} must not contain symbol properties`);
+  }
+  const strings = actual as string[];
+  if (
+    strings.length !== expected.length
+    || [...strings].sort().some((key, index) => key !== expected[index])
+  ) {
+    throw new Error(`${label} has unknown or missing fields`);
+  }
+  for (const key of strings) {
+    const descriptor = Object.getOwnPropertyDescriptor(record, key);
+    if (!descriptor?.enumerable || !Object.prototype.hasOwnProperty.call(descriptor, 'value')) {
+      throw new Error(`${label} fields must be enumerable data properties`);
+    }
+  }
+}

--- a/packages/core/test/sync-control-object.test.ts
+++ b/packages/core/test/sync-control-object.test.ts
@@ -1,0 +1,330 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  MAX_CONTROL_OBJECT_BYTES,
+  MAX_EIP1271_SIGNATURE_BYTES,
+  assertControlObjectDigest,
+  assertSignedControlEnvelope,
+  assertUnsignedControlEnvelope,
+  canonicalizeUnsignedControlEnvelopeBytes,
+  computeControlObjectDigestHex,
+  computeControlSignatureVariantDigestHex,
+  parseCanonicalControlSignatureVariant,
+  parseCanonicalSignedControlEnvelope,
+  parseCanonicalUnsignedControlEnvelope,
+  type SignedControlEnvelopeV1,
+  type UnsignedControlEnvelopeV1,
+} from '../src/sync-control-object.js';
+
+const CG_ID = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/threat-intel';
+const EOA_ISSUER = '0x1111111111111111111111111111111111111111';
+const SAFE_ISSUER = '0x2222222222222222222222222222222222222222';
+const EOA_DIGEST = '0xf76fc6928b271be4cdd13b2e463a8f303af95b84be619c6aea0fad1ab8259da3';
+const SAFE_DIGEST = '0xbaa5433cc34c3b621c556c408b1b290382cbd97f2fa99e2df714439f819bc072';
+const EOA_SIGNATURE = `0x${'11'.repeat(65)}`;
+
+// Normative bytes generated independently with Python hashlib over these literal
+// UTF-8 fixtures. Do not regenerate expected values from the implementation under test.
+const EOA_CANONICAL_UNSIGNED =
+  '{"issuer":"0x1111111111111111111111111111111111111111","objectType":"ContextGraphPolicyV1","payload":{"accessPolicy":"invite-only","contextGraphId":"0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/threat-intel","era":"0","networkId":"otp:2043","publishPolicy":"curated","version":"1"},"signatureEvidence":{"kind":"none"},"signatureSuite":"eip191-personal-sign-digest-v1"}';
+const SAFE_CANONICAL_UNSIGNED =
+  '{"issuer":"0x2222222222222222222222222222222222222222","objectType":"ContextGraphCheckpointV1","payload":{"authorityEpoch":"7","checkpointVersion":"42","contextGraphId":"0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/threat-intel","networkId":"otp:2043"},"signatureEvidence":{"chainId":"2043","contractAddress":"0x2222222222222222222222222222222222222222","kind":"eip1271-current-finalized"},"signatureSuite":"eip1271-current-finalized-v1"}';
+const EOA_CANONICAL_SIGNED =
+  '{"issuer":"0x1111111111111111111111111111111111111111","objectDigest":"0xf76fc6928b271be4cdd13b2e463a8f303af95b84be619c6aea0fad1ab8259da3","objectType":"ContextGraphPolicyV1","payload":{"accessPolicy":"invite-only","contextGraphId":"0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/threat-intel","era":"0","networkId":"otp:2043","publishPolicy":"curated","version":"1"},"signature":"0x1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111","signatureEvidence":{"kind":"none"},"signatureSuite":"eip191-personal-sign-digest-v1"}';
+const EOA_SIGNATURE_VARIANT_DIGEST =
+  '0x4ee07bedb94b7050086d75012344b1fc0b883ded2b36b7b0f987d1235b360509';
+const EOA_CANONICAL_SIGNATURE_VARIANT =
+  '{"objectDigest":"0xf76fc6928b271be4cdd13b2e463a8f303af95b84be619c6aea0fad1ab8259da3","signature":"0x1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111","signatureVariantDigest":"0x4ee07bedb94b7050086d75012344b1fc0b883ded2b36b7b0f987d1235b360509"}';
+
+const EOA_VECTOR: UnsignedControlEnvelopeV1 = {
+  objectType: 'ContextGraphPolicyV1',
+  payload: {
+    accessPolicy: 'invite-only',
+    contextGraphId: CG_ID,
+    era: '0',
+    networkId: 'otp:2043',
+    publishPolicy: 'curated',
+    version: '1',
+  },
+  signatureSuite: 'eip191-personal-sign-digest-v1',
+  issuer: EOA_ISSUER,
+  signatureEvidence: { kind: 'none' },
+};
+
+const SAFE_VECTOR: UnsignedControlEnvelopeV1 = {
+  objectType: 'ContextGraphCheckpointV1',
+  payload: {
+    authorityEpoch: '7',
+    checkpointVersion: '42',
+    contextGraphId: CG_ID,
+    networkId: 'otp:2043',
+  },
+  signatureSuite: 'eip1271-current-finalized-v1',
+  issuer: SAFE_ISSUER,
+  signatureEvidence: {
+    kind: 'eip1271-current-finalized',
+    chainId: '2043',
+    contractAddress: SAFE_ISSUER,
+  },
+};
+
+const EOA_SIGNED: SignedControlEnvelopeV1 = {
+  ...EOA_VECTOR,
+  objectDigest: EOA_DIGEST,
+  signature: EOA_SIGNATURE,
+};
+
+const SAFE_SIGNED: SignedControlEnvelopeV1 = {
+  ...SAFE_VECTOR,
+  objectDigest: SAFE_DIGEST,
+  signature: '0x1234',
+};
+
+describe('Track-2 control-object envelopes', () => {
+  it('pins the exact EIP-191 canonical preimage and domain-separated SHA-256 vector', () => {
+    expect(new TextDecoder().decode(canonicalizeUnsignedControlEnvelopeBytes(EOA_VECTOR)))
+      .toBe(EOA_CANONICAL_UNSIGNED);
+    expect(computeControlObjectDigestHex(EOA_VECTOR)).toBe(
+      EOA_DIGEST,
+    );
+  });
+
+  it('pins the exact EIP-1271 canonical preimage and domain-separated SHA-256 vector', () => {
+    expect(new TextDecoder().decode(canonicalizeUnsignedControlEnvelopeBytes(SAFE_VECTOR)))
+      .toBe(SAFE_CANONICAL_UNSIGNED);
+    expect(computeControlObjectDigestHex(SAFE_VECTOR)).toBe(
+      SAFE_DIGEST,
+    );
+  });
+
+  it('strictly decodes only canonical unsigned envelopes with the exact field set', () => {
+    expect(parseCanonicalUnsignedControlEnvelope(EOA_CANONICAL_UNSIGNED)).toMatchObject({
+      objectType: 'ContextGraphPolicyV1',
+      issuer: EOA_ISSUER,
+    });
+    expect(() => parseCanonicalUnsignedControlEnvelope(` ${EOA_CANONICAL_UNSIGNED}`)).toThrow(
+      /not RFC 8785 canonical/,
+    );
+    const unknownField = `${EOA_CANONICAL_UNSIGNED.slice(0, -1)},"unknown":true}`;
+    expect(() => parseCanonicalUnsignedControlEnvelope(unknownField)).toThrow(
+      /unknown or missing fields/,
+    );
+  });
+
+  it('strictly decodes and validates canonical EIP-191 and EIP-1271 signed envelopes', () => {
+    expect(parseCanonicalSignedControlEnvelope(EOA_CANONICAL_SIGNED)).toMatchObject({
+      objectDigest: EOA_DIGEST,
+      signature: EOA_SIGNATURE,
+    });
+    expect(() => assertSignedControlEnvelope(EOA_SIGNED)).not.toThrow();
+    expect(() => assertSignedControlEnvelope(SAFE_SIGNED)).not.toThrow();
+    expect(() => parseCanonicalSignedControlEnvelope(` ${EOA_CANONICAL_SIGNED}`)).toThrow(
+      /not RFC 8785 canonical/,
+    );
+  });
+
+  it('pins and strictly decodes the detached signature-variant digest', () => {
+    expect(computeControlSignatureVariantDigestHex(EOA_DIGEST, EOA_SIGNATURE)).toBe(
+      EOA_SIGNATURE_VARIANT_DIGEST,
+    );
+    expect(parseCanonicalControlSignatureVariant(EOA_CANONICAL_SIGNATURE_VARIANT))
+      .toEqual({
+        objectDigest: EOA_DIGEST,
+        signature: EOA_SIGNATURE,
+        signatureVariantDigest: EOA_SIGNATURE_VARIANT_DIGEST,
+      });
+  });
+
+  it('is independent of JavaScript insertion order and verifies exact claims', () => {
+    const reordered = {
+      signatureEvidence: { kind: 'none' },
+      issuer: EOA_ISSUER,
+      signatureSuite: 'eip191-personal-sign-digest-v1',
+      payload: {
+        version: '1',
+        publishPolicy: 'curated',
+        networkId: 'otp:2043',
+        era: '0',
+        contextGraphId: CG_ID,
+        accessPolicy: 'invite-only',
+      },
+      objectType: 'ContextGraphPolicyV1',
+    } satisfies UnsignedControlEnvelopeV1;
+
+    const digest = computeControlObjectDigestHex(EOA_VECTOR);
+    expect(computeControlObjectDigestHex(reordered)).toBe(digest);
+    expect(() => assertControlObjectDigest(reordered, digest)).not.toThrow();
+    expect(() => assertControlObjectDigest(reordered, `0x${'00'.repeat(32)}`)).toThrow(
+      /digest mismatch/,
+    );
+  });
+
+  it('fails closed on suite/evidence substitution', () => {
+    expect(() => assertUnsignedControlEnvelope({
+      ...EOA_VECTOR,
+      signatureEvidence: {
+        kind: 'eip1271-current-finalized',
+        chainId: '2043',
+        contractAddress: EOA_ISSUER,
+      },
+    })).toThrow(/EIP-191 signature evidence|unknown or missing fields/);
+
+    expect(() => assertUnsignedControlEnvelope({
+      ...SAFE_VECTOR,
+      signatureEvidence: { kind: 'none' },
+    })).toThrow(/EIP-1271 signature evidence|unknown or missing fields/);
+  });
+
+  it.each(['01', '+1', '-1', '1.0', '1e3', ''])('rejects non-canonical chainId %j', (chainId) => {
+    expect(() => assertUnsignedControlEnvelope({
+      ...SAFE_VECTOR,
+      signatureEvidence: { ...SAFE_VECTOR.signatureEvidence, chainId },
+    })).toThrow(/canonical unsigned decimal/);
+  });
+
+  it('rejects a non-string chain ID and evidence for a different contract', () => {
+    expect(() => assertUnsignedControlEnvelope({
+      ...SAFE_VECTOR,
+      signatureEvidence: {
+        ...SAFE_VECTOR.signatureEvidence,
+        chainId: 2043 as unknown as string,
+      },
+    })).toThrow(/canonical unsigned decimal/);
+
+    expect(() => assertUnsignedControlEnvelope({
+      ...SAFE_VECTOR,
+      signatureEvidence: {
+        ...SAFE_VECTOR.signatureEvidence,
+        contractAddress: EOA_ISSUER,
+      },
+    })).toThrow(/must equal the envelope issuer/);
+  });
+
+  it('rejects non-canonical and zero EVM issuers', () => {
+    expect(() => assertUnsignedControlEnvelope({
+      ...EOA_VECTOR,
+      issuer: '0x111111111111111111111111111111111111111A',
+    })).toThrow(/lowercase 20-byte/);
+    expect(() => assertUnsignedControlEnvelope({
+      ...EOA_VECTOR,
+      issuer: `0x${'00'.repeat(20)}`,
+    })).toThrow(/zero address/);
+  });
+
+  it('rejects malformed, non-canonical, and mismatched signed-envelope digests', () => {
+    expect(() => assertSignedControlEnvelope({
+      ...EOA_SIGNED,
+      objectDigest: `0x${'00'.repeat(32)}`,
+    })).toThrow(/digest mismatch/);
+    expect(() => assertSignedControlEnvelope({
+      ...EOA_SIGNED,
+      objectDigest: `0x${'AA'.repeat(32)}`,
+    })).toThrow(/lowercase 32-byte/);
+
+    const signedWithUnknown = `${EOA_CANONICAL_SIGNED.slice(0, -1)},"unknown":true}`;
+    expect(() => parseCanonicalSignedControlEnvelope(signedWithUnknown)).toThrow(
+      /unknown or missing fields/,
+    );
+  });
+
+  it('enforces exact EIP-191 and bounded EIP-1271 signature encodings', () => {
+    expect(() => assertSignedControlEnvelope({
+      ...EOA_SIGNED,
+      signature: `0x${'11'.repeat(64)}`,
+    })).toThrow(/65 lowercase bytes/);
+    expect(() => assertSignedControlEnvelope({
+      ...EOA_SIGNED,
+      signature: `0x${'AA'.repeat(65)}`,
+    })).toThrow(/65 lowercase bytes/);
+    expect(() => assertSignedControlEnvelope({
+      ...SAFE_SIGNED,
+      signature: '0x',
+    })).toThrow(/1-4096 lowercase bytes/);
+    expect(() => assertSignedControlEnvelope({
+      ...SAFE_SIGNED,
+      signature: '0xabc',
+    })).toThrow(/1-4096 lowercase bytes/);
+    expect(() => assertSignedControlEnvelope({
+      ...SAFE_SIGNED,
+      signature: `0x${'aa'.repeat(MAX_EIP1271_SIGNATURE_BYTES + 1)}`,
+    })).toThrow(/1-4096 lowercase bytes/);
+    expect(() => assertSignedControlEnvelope({
+      ...SAFE_SIGNED,
+      signature: `0x${'aa'.repeat(MAX_EIP1271_SIGNATURE_BYTES)}`,
+    })).not.toThrow();
+  });
+
+  it('measures the object-type limit in Unicode scalar values', () => {
+    expect(() => assertUnsignedControlEnvelope({
+      ...EOA_VECTOR,
+      objectType: '🚀'.repeat(128),
+    })).not.toThrow();
+    expect(() => assertUnsignedControlEnvelope({
+      ...EOA_VECTOR,
+      objectType: '🚀'.repeat(129),
+    })).toThrow(/canonical string bounds/);
+  });
+
+  it('rejects unknown, missing, accessor, and symbol envelope/evidence fields', () => {
+    expect(() => assertUnsignedControlEnvelope({
+      ...EOA_VECTOR,
+      extra: true,
+    } as unknown as UnsignedControlEnvelopeV1)).toThrow(/unknown or missing fields/);
+
+    const missing = { ...EOA_VECTOR } as Partial<UnsignedControlEnvelopeV1>;
+    delete missing.payload;
+    expect(() => assertUnsignedControlEnvelope(missing as UnsignedControlEnvelopeV1)).toThrow(
+      /unknown or missing fields/,
+    );
+
+    const evidenceWithExtra = {
+      kind: 'none',
+      staleBlock: '7',
+    } as unknown as UnsignedControlEnvelopeV1['signatureEvidence'];
+    expect(() => assertUnsignedControlEnvelope({
+      ...EOA_VECTOR,
+      signatureEvidence: evidenceWithExtra,
+    })).toThrow(/unknown or missing fields/);
+
+    const accessor = { ...EOA_VECTOR };
+    Object.defineProperty(accessor, 'issuer', { enumerable: true, get: () => EOA_ISSUER });
+    expect(() => assertUnsignedControlEnvelope(accessor)).toThrow(/enumerable data properties/);
+
+    const symbolEnvelope = { ...EOA_VECTOR } as UnsignedControlEnvelopeV1 & Record<symbol, true>;
+    symbolEnvelope[Symbol('hidden')] = true;
+    expect(() => assertUnsignedControlEnvelope(symbolEnvelope)).toThrow(/symbol properties/);
+  });
+
+  it('rejects non-I-JSON payloads before computing a digest', () => {
+    const payload = { value: Number.POSITIVE_INFINITY } as unknown as UnsignedControlEnvelopeV1['payload'];
+    expect(() => computeControlObjectDigestHex({ ...EOA_VECTOR, payload })).toThrow(
+      /finite IEEE-754/,
+    );
+  });
+
+  it('fails oversized in-memory envelopes during bounded traversal', () => {
+    const payload = {
+      blob: 'x'.repeat(MAX_CONTROL_OBJECT_BYTES),
+    } as UnsignedControlEnvelopeV1['payload'];
+    expect(() => computeControlObjectDigestHex({ ...EOA_VECTOR, payload })).toThrow(
+      /Canonical JSON exceeds/,
+    );
+  });
+
+  it('rejects malformed or mismatched detached signature variants', () => {
+    const mismatched = EOA_CANONICAL_SIGNATURE_VARIANT.replace(
+      EOA_SIGNATURE_VARIANT_DIGEST,
+      `0x${'00'.repeat(32)}`,
+    );
+    expect(() => parseCanonicalControlSignatureVariant(mismatched)).toThrow(
+      /digest mismatch/,
+    );
+    const uppercaseSignature = EOA_CANONICAL_SIGNATURE_VARIANT.replace(
+      EOA_SIGNATURE,
+      `0x${'AA'.repeat(65)}`,
+    );
+    expect(() => parseCanonicalControlSignatureVariant(uppercaseSignature)).toThrow(
+      /lowercase bytes/,
+    );
+  });
+});

--- a/packages/core/test/sync-control-object.test.ts
+++ b/packages/core/test/sync-control-object.test.ts
@@ -6,6 +6,7 @@ import {
   assertControlObjectDigest,
   assertSignedControlEnvelope,
   assertUnsignedControlEnvelope,
+  canonicalizeSignedControlEnvelopeBytes,
   canonicalizeUnsignedControlEnvelopeBytes,
   computeControlObjectDigestHex,
   computeControlSignatureVariantDigestHex,
@@ -112,6 +113,8 @@ describe('Track-2 control-object envelopes', () => {
   });
 
   it('strictly decodes and validates canonical EIP-191 and EIP-1271 signed envelopes', () => {
+    expect(new TextDecoder().decode(canonicalizeSignedControlEnvelopeBytes(EOA_SIGNED)))
+      .toBe(EOA_CANONICAL_SIGNED);
     expect(parseCanonicalSignedControlEnvelope(EOA_CANONICAL_SIGNED)).toMatchObject({
       objectDigest: EOA_DIGEST,
       signature: EOA_SIGNATURE,
@@ -198,6 +201,25 @@ describe('Track-2 control-object envelopes', () => {
         contractAddress: EOA_ISSUER,
       },
     })).toThrow(/must equal the envelope issuer/);
+  });
+
+  it('enforces the full unsigned 256-bit chainId boundary before BigInt conversion', () => {
+    const maxU256 = ((1n << 256n) - 1n).toString();
+    expect(() => assertUnsignedControlEnvelope({
+      ...SAFE_VECTOR,
+      signatureEvidence: { ...SAFE_VECTOR.signatureEvidence, chainId: maxU256 },
+    })).not.toThrow();
+    expect(() => assertUnsignedControlEnvelope({
+      ...SAFE_VECTOR,
+      signatureEvidence: {
+        ...SAFE_VECTOR.signatureEvidence,
+        chainId: (1n << 256n).toString(),
+      },
+    })).toThrow(/u256/);
+    expect(() => assertUnsignedControlEnvelope({
+      ...SAFE_VECTOR,
+      signatureEvidence: { ...SAFE_VECTOR.signatureEvidence, chainId: '9'.repeat(100_000) },
+    })).toThrow(/u256/);
   });
 
   it('rejects non-canonical and zero EVM issuers', () => {
@@ -309,6 +331,48 @@ describe('Track-2 control-object envelopes', () => {
     expect(() => computeControlObjectDigestHex({ ...EOA_VECTOR, payload })).toThrow(
       /Canonical JSON exceeds/,
     );
+  });
+
+  it('enforces the complete signed-envelope byte ceiling through canonical serialization', () => {
+    const emptyPayloadEnvelope: UnsignedControlEnvelopeV1 = {
+      ...EOA_VECTOR,
+      payload: { blob: '' },
+    };
+    const unsignedBaseBytes = canonicalizeUnsignedControlEnvelopeBytes(
+      emptyPayloadEnvelope,
+    ).byteLength;
+    const unsignedAtLimit: UnsignedControlEnvelopeV1 = {
+      ...emptyPayloadEnvelope,
+      payload: { blob: 'x'.repeat(MAX_CONTROL_OBJECT_BYTES - unsignedBaseBytes) },
+    };
+    expect(canonicalizeUnsignedControlEnvelopeBytes(unsignedAtLimit)).toHaveLength(
+      MAX_CONTROL_OBJECT_BYTES,
+    );
+    expect(() => assertSignedControlEnvelope({
+      ...unsignedAtLimit,
+      objectDigest: computeControlObjectDigestHex(unsignedAtLimit),
+      signature: EOA_SIGNATURE,
+    })).toThrow(/Canonical JSON exceeds/);
+
+    const emptySigned: SignedControlEnvelopeV1 = {
+      ...emptyPayloadEnvelope,
+      objectDigest: computeControlObjectDigestHex(emptyPayloadEnvelope),
+      signature: EOA_SIGNATURE,
+    };
+    const signedBaseBytes = canonicalizeSignedControlEnvelopeBytes(emptySigned).byteLength;
+    const signedAtLimitUnsigned: UnsignedControlEnvelopeV1 = {
+      ...emptyPayloadEnvelope,
+      payload: { blob: 'x'.repeat(MAX_CONTROL_OBJECT_BYTES - signedBaseBytes) },
+    };
+    const signedAtLimit: SignedControlEnvelopeV1 = {
+      ...signedAtLimitUnsigned,
+      objectDigest: computeControlObjectDigestHex(signedAtLimitUnsigned),
+      signature: EOA_SIGNATURE,
+    };
+    expect(canonicalizeSignedControlEnvelopeBytes(signedAtLimit)).toHaveLength(
+      MAX_CONTROL_OBJECT_BYTES,
+    );
+    expect(() => assertSignedControlEnvelope(signedAtLimit)).not.toThrow();
   });
 
   it('rejects malformed or mismatched detached signature variants', () => {

--- a/packages/core/test/sync-control-object.test.ts
+++ b/packages/core/test/sync-control-object.test.ts
@@ -390,5 +390,16 @@ describe('Track-2 control-object envelopes', () => {
     expect(() => parseCanonicalControlSignatureVariant(uppercaseSignature)).toThrow(
       /lowercase bytes/,
     );
+    // Exact-key contract: an extra field in canonical (sorted) position passes
+    // canonicalization but must be rejected by the exact-key check.
+    const withExtraField = `${EOA_CANONICAL_SIGNATURE_VARIANT.slice(0, -1)},"unknown":"metadata"}`;
+    expect(() => parseCanonicalControlSignatureVariant(withExtraField)).toThrow(
+      /unknown or missing fields/,
+    );
+    // Variant parser limits: maxDepth 1 rejects nesting, and the 16 KiB byte cap
+    // rejects an over-cap canonical input before materialization.
+    expect(() => parseCanonicalControlSignatureVariant('{"a":{"b":1}}')).toThrow(/nesting/);
+    const oversizedVariant = `{"a":"${'x'.repeat(16 * 1024)}"}`;
+    expect(() => parseCanonicalControlSignatureVariant(oversizedVariant)).toThrow();
   });
 });


### PR DESCRIPTION
## Summary

Builds the dormant RFC-64 signed control-object envelope codec on the bounded JCS layer from the preceding PR:

- exact unsigned and signed envelope schemas with strict canonical decoding
- domain-separated SHA-256 object digests and detached signature-variant digests
- exact EIP-191 and bounded EIP-1271 signature/evidence encodings
- lowercase digest/address rules, exact field sets, and in-memory byte/depth enforcement
- literal canonical preimages and independently generated digest/rejection vectors

This PR performs structural and digest validation only. It does not verify signer authority, call EIP-1271, register networking, write storage, or activate reconciliation. It is stacked on the canonical JSON PR and will be retargeted to `main` after that dependency lands. Specification: [OT-RFC-64 Rev 4.7](https://github.com/OriginTrail/dkgv10-spec/pull/144).

## Validation

- core TypeScript build passes
- focused codec tests pass (32/32 across both stacked slices)
- full core suite passes (84 files, 1,267 tests)
- `git diff --check` passes
