### PR TITLE
RFC-64: add opaque KA bundle framing

### DIFF
--- a/packages/core/src/ka-bundle-v1.ts
+++ b/packages/core/src/ka-bundle-v1.ts
@@ -1,0 +1,250 @@
+import { sha256 } from '@noble/hashes/sha2.js';
+
+import {
+  MAX_KA_TRANSFER_BYTES_V1,
+  MIN_KA_TRANSFER_BYTES_V1,
+} from './ka-transfer-descriptor.js';
+import type { Digest32V1 } from './sync-wire-scalars.js';
+
+export const KA_BUNDLE_PROJECTION_DIGEST_DOMAIN_V1 = 'dkg-ka-projection-v1\n' as const;
+export const KA_BUNDLE_BLOB_DIGEST_DOMAIN_V1 = 'dkg-ka-transfer-v1\n' as const;
+export const KA_BUNDLE_U64_PREFIX_BYTES_V1 = 8;
+export const MIN_KA_BUNDLE_BYTES_V1 = MIN_KA_TRANSFER_BYTES_V1;
+export const MAX_KA_BUNDLE_BYTES_V1 = MAX_KA_TRANSFER_BYTES_V1;
+
+const MAX_U64 = 18_446_744_073_709_551_615n;
+const UTF8 = new TextEncoder();
+const PROJECTION_DIGEST_DOMAIN_BYTES = UTF8.encode(KA_BUNDLE_PROJECTION_DIGEST_DOMAIN_V1);
+const BLOB_DIGEST_DOMAIN_BYTES = UTF8.encode(KA_BUNDLE_BLOB_DIGEST_DOMAIN_V1);
+
+export type KaBundleV1ErrorCode =
+  | 'bundle-byte-length'
+  | 'bundle-truncated'
+  | 'bundle-length-overflow'
+  | 'bundle-trailing-bytes';
+
+export class KaBundleV1Error extends Error {
+  constructor(
+    readonly code: KaBundleV1ErrorCode,
+    message: string,
+  ) {
+    super(`[${code}] ${message}`);
+    this.name = 'KaBundleV1Error';
+  }
+}
+
+export interface EncodedOpaqueKaBundleV1 {
+  /** Exact `u64be(projection length) || projection || u64be(seal length) || seal`. */
+  readonly bundleBytes: Uint8Array;
+  readonly projectionDigest: Digest32V1;
+  readonly blobDigest: Digest32V1;
+}
+
+export interface DecodedOpaqueKaBundleV1 {
+  /**
+   * Borrowed zero-copy view into the received bundle. It carries no RDF semantic
+   * claim and is valid only while the caller leaves the input bytes unchanged.
+   */
+  readonly projectionBytes: Uint8Array;
+  /**
+   * Borrowed zero-copy view into the received bundle. It carries no seal semantic
+   * claim and must be copied or ownership-pinned before asynchronous retention.
+   */
+  readonly sealBytes: Uint8Array;
+  readonly projectionDigest: Digest32V1;
+  readonly blobDigest: Digest32V1;
+}
+
+/**
+ * Validate the exact v1 component-length arithmetic without allocating a bundle.
+ * Inputs are bigint so no candidate u64 ever passes through binary floating point.
+ */
+export function calculateOpaqueKaBundleByteLengthV1(
+  projectionByteLength: bigint,
+  sealByteLength: bigint,
+): bigint {
+  assertU64Length(projectionByteLength, 'projectionByteLength');
+  assertU64Length(sealByteLength, 'sealByteLength');
+
+  const payloadLimit = MAX_KA_BUNDLE_BYTES_V1 - MIN_KA_BUNDLE_BYTES_V1;
+  if (
+    projectionByteLength > payloadLimit
+    || sealByteLength > payloadLimit - projectionByteLength
+  ) {
+    fail(
+      'bundle-length-overflow',
+      `component lengths exceed the ${MAX_KA_BUNDLE_BYTES_V1}-byte v1 bundle limit`,
+    );
+  }
+
+  const totalByteLength = MIN_KA_BUNDLE_BYTES_V1
+    + projectionByteLength
+    + sealByteLength;
+  // Keep the complete-length gate shared with the decoder and advertised-length
+  // admission path even though the component checks above already prove this bound.
+  assertOpaqueKaBundleByteLengthV1(totalByteLength);
+  return totalByteLength;
+}
+
+/** Validate an advertised/received complete bundle length before any payload work. */
+export function assertOpaqueKaBundleByteLengthV1(totalByteLength: bigint): void {
+  if (
+    typeof totalByteLength !== 'bigint'
+    || totalByteLength < MIN_KA_BUNDLE_BYTES_V1
+    || totalByteLength > MAX_KA_BUNDLE_BYTES_V1
+  ) {
+    fail(
+      'bundle-byte-length',
+      `bundle length must be ${MIN_KA_BUNDLE_BYTES_V1}-${MAX_KA_BUNDLE_BYTES_V1} bytes`,
+    );
+  }
+}
+
+/**
+ * Frame two opaque byte strings and compute both RFC-64 digests incrementally.
+ * This function does not validate RDF, a structured root, or an author seal.
+ */
+export function encodeOpaqueKaBundleV1(
+  projectionBytes: Uint8Array,
+  sealBytes: Uint8Array,
+): EncodedOpaqueKaBundleV1 {
+  assertUint8Array(projectionBytes, 'projectionBytes');
+  assertUint8Array(sealBytes, 'sealBytes');
+
+  const projectionByteLength = BigInt(projectionBytes.byteLength);
+  const sealByteLength = BigInt(sealBytes.byteLength);
+  const totalByteLength = calculateOpaqueKaBundleByteLengthV1(
+    projectionByteLength,
+    sealByteLength,
+  );
+
+  // The protocol ceiling is 1 GiB, so the checked bigint is exactly representable.
+  const bundleBytes = new Uint8Array(Number(totalByteLength));
+  const projectionPrefix = encodeU64Be(projectionByteLength);
+  const sealPrefix = encodeU64Be(sealByteLength);
+  let cursor = 0;
+  bundleBytes.set(projectionPrefix, cursor);
+  cursor += KA_BUNDLE_U64_PREFIX_BYTES_V1;
+  bundleBytes.set(projectionBytes, cursor);
+  cursor += projectionBytes.byteLength;
+  bundleBytes.set(sealPrefix, cursor);
+  cursor += KA_BUNDLE_U64_PREFIX_BYTES_V1;
+  bundleBytes.set(sealBytes, cursor);
+
+  const finalizedProjectionBytes = bundleBytes.subarray(
+    KA_BUNDLE_U64_PREFIX_BYTES_V1,
+    KA_BUNDLE_U64_PREFIX_BYTES_V1 + projectionBytes.byteLength,
+  );
+
+  return {
+    bundleBytes,
+    projectionDigest: digestToLowerHex(
+      PROJECTION_DIGEST_DOMAIN_BYTES,
+      finalizedProjectionBytes,
+    ),
+    blobDigest: digestToLowerHex(BLOB_DIGEST_DOMAIN_BYTES, bundleBytes),
+  };
+}
+
+/**
+ * Strictly decode one complete frame. Component bytes are returned as zero-copy views;
+ * all framing checks finish before either digest is updated.
+ */
+export function decodeOpaqueKaBundleV1(bundleBytes: Uint8Array): DecodedOpaqueKaBundleV1 {
+  assertUint8Array(bundleBytes, 'bundleBytes');
+
+  const receivedByteLength = BigInt(bundleBytes.byteLength);
+  assertOpaqueKaBundleByteLengthV1(receivedByteLength);
+
+  const projectionByteLength = decodeU64Be(bundleBytes, 0);
+  // This shared arithmetic check distinguishes an impossible v1 declaration from a
+  // merely truncated received frame, without converting an unchecked u64 to number.
+  const minimumWithProjection = calculateOpaqueKaBundleByteLengthV1(
+    projectionByteLength,
+    0n,
+  );
+  if (minimumWithProjection > receivedByteLength) {
+    fail('bundle-truncated', 'projection payload or seal-length prefix is truncated');
+  }
+
+  const projectionStart = KA_BUNDLE_U64_PREFIX_BYTES_V1;
+  const projectionEnd = projectionStart + Number(projectionByteLength);
+  const sealByteLength = decodeU64Be(bundleBytes, projectionEnd);
+  const expectedByteLength = calculateOpaqueKaBundleByteLengthV1(
+    projectionByteLength,
+    sealByteLength,
+  );
+
+  if (expectedByteLength > receivedByteLength) {
+    fail('bundle-truncated', 'seal payload is truncated');
+  }
+  if (expectedByteLength < receivedByteLength) {
+    fail('bundle-trailing-bytes', 'bundle contains bytes after the declared seal payload');
+  }
+
+  const sealStart = projectionEnd + KA_BUNDLE_U64_PREFIX_BYTES_V1;
+  const sealEnd = sealStart + Number(sealByteLength);
+  const projectionBytes = bundleBytes.subarray(projectionStart, projectionEnd);
+  const sealBytes = bundleBytes.subarray(sealStart, sealEnd);
+
+  return {
+    projectionBytes,
+    sealBytes,
+    projectionDigest: digestToLowerHex(PROJECTION_DIGEST_DOMAIN_BYTES, projectionBytes),
+    blobDigest: digestToLowerHex(BLOB_DIGEST_DOMAIN_BYTES, bundleBytes),
+  };
+}
+
+function assertU64Length(value: bigint, label: string): void {
+  if (typeof value !== 'bigint' || value < 0n || value > MAX_U64) {
+    fail('bundle-length-overflow', `${label} is not an unsigned 64-bit length`);
+  }
+}
+
+function assertUint8Array(value: unknown, label: string): asserts value is Uint8Array {
+  if (!(value instanceof Uint8Array)) {
+    throw new TypeError(`${label} must be a Uint8Array`);
+  }
+  if (!(value.buffer instanceof ArrayBuffer)) {
+    throw new TypeError(`${label} must not use shared backing memory`);
+  }
+  if ((value.buffer as ArrayBuffer & { readonly resizable?: boolean }).resizable === true) {
+    throw new TypeError(`${label} must not use resizable backing memory`);
+  }
+}
+
+function encodeU64Be(value: bigint): Uint8Array {
+  assertU64Length(value, 'u64be value');
+  const encoded = new Uint8Array(KA_BUNDLE_U64_PREFIX_BYTES_V1);
+  let remaining = value;
+  for (let index = encoded.length - 1; index >= 0; index -= 1) {
+    encoded[index] = Number(remaining & 0xffn);
+    remaining >>= 8n;
+  }
+  return encoded;
+}
+
+function decodeU64Be(bytes: Uint8Array, offset: number): bigint {
+  if (offset < 0 || offset + KA_BUNDLE_U64_PREFIX_BYTES_V1 > bytes.byteLength) {
+    fail('bundle-truncated', 'u64be length prefix is truncated');
+  }
+  let value = 0n;
+  for (let index = offset; index < offset + KA_BUNDLE_U64_PREFIX_BYTES_V1; index += 1) {
+    value = (value << 8n) | BigInt(bytes[index]);
+  }
+  return value;
+}
+
+function digestToLowerHex(domain: Uint8Array, ...chunks: readonly Uint8Array[]): Digest32V1 {
+  const hasher = sha256.create();
+  hasher.update(domain);
+  for (const chunk of chunks) hasher.update(chunk);
+  const digest = hasher.digest();
+  let result = '0x';
+  for (const byte of digest) result += byte.toString(16).padStart(2, '0');
+  return result;
+}
+
+function fail(code: KaBundleV1ErrorCode, message: string): never {
+  throw new KaBundleV1Error(code, message);
+}

--- a/packages/core/src/ka-bundle-v1.ts
+++ b/packages/core/src/ka-bundle-v1.ts
@@ -4,7 +4,10 @@ import {
   MAX_KA_TRANSFER_BYTES_V1,
   MIN_KA_TRANSFER_BYTES_V1,
 } from './ka-transfer-descriptor.js';
-import type { Digest32V1 } from './sync-wire-scalars.js';
+import {
+  assertCanonicalDigest,
+  type Digest32V1,
+} from './sync-wire-scalars.js';
 
 export const KA_BUNDLE_PROJECTION_DIGEST_DOMAIN_V1 = 'dkg-ka-projection-v1\n' as const;
 export const KA_BUNDLE_BLOB_DIGEST_DOMAIN_V1 = 'dkg-ka-transfer-v1\n' as const;
@@ -242,6 +245,7 @@ function digestToLowerHex(domain: Uint8Array, ...chunks: readonly Uint8Array[]):
   const digest = hasher.digest();
   let result = '0x';
   for (const byte of digest) result += byte.toString(16).padStart(2, '0');
+  assertCanonicalDigest(result);
   return result;
 }
 

--- a/packages/core/test/ka-bundle-v1.test.ts
+++ b/packages/core/test/ka-bundle-v1.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  MAX_KA_BUNDLE_BYTES_V1,
+  assertOpaqueKaBundleByteLengthV1,
+  calculateOpaqueKaBundleByteLengthV1,
+  decodeOpaqueKaBundleV1,
+  encodeOpaqueKaBundleV1,
+  type KaBundleV1ErrorCode,
+} from '../src/ka-bundle-v1.js';
+
+const EMPTY_EMPTY_BUNDLE = '00000000000000000000000000000000';
+const EMPTY_PROJECTION_DIGEST =
+  '0x4d798c66290f2feed54b20ad25eab62df38360cab298332be5e6d921ad1b5f3c';
+const EMPTY_EMPTY_BLOB_DIGEST =
+  '0x83bb2c1cb5e6d45dd63f06f085d1167f0a8b8b504be1117b839c479f1546ea18';
+
+const A_BC_BUNDLE = '00000000000000016100000000000000026263';
+const A_PROJECTION_DIGEST =
+  '0xdae61dbbf6d5ff323951a573fda1ec18a51c77a00811a4574adc2639e0ed72cb';
+const A_BC_BLOB_DIGEST =
+  '0xd632761c3a93b54f7e84ec45934bec3eb4a32508f50e8d37927f7dff0e52f17c';
+
+describe('RFC-64 dormant opaque KA bundle framing', () => {
+  it('matches the exact empty-empty conformance vector', () => {
+    const encoded = encodeOpaqueKaBundleV1(new Uint8Array(), new Uint8Array());
+    expect(lowerHex(encoded.bundleBytes)).toBe(EMPTY_EMPTY_BUNDLE);
+    expect(encoded.projectionDigest).toBe(EMPTY_PROJECTION_DIGEST);
+    expect(encoded.blobDigest).toBe(EMPTY_EMPTY_BLOB_DIGEST);
+
+    const decoded = decodeOpaqueKaBundleV1(fromHex(EMPTY_EMPTY_BUNDLE));
+    expect(decoded.projectionBytes).toEqual(new Uint8Array());
+    expect(decoded.sealBytes).toEqual(new Uint8Array());
+    expect(decoded.projectionDigest).toBe(EMPTY_PROJECTION_DIGEST);
+    expect(decoded.blobDigest).toBe(EMPTY_EMPTY_BLOB_DIGEST);
+  });
+
+  it('matches the exact a-bc conformance vector in network byte order', () => {
+    const encoded = encodeOpaqueKaBundleV1(fromHex('61'), fromHex('6263'));
+    expect(lowerHex(encoded.bundleBytes)).toBe(A_BC_BUNDLE);
+    expect(encoded.projectionDigest).toBe(A_PROJECTION_DIGEST);
+    expect(encoded.blobDigest).toBe(A_BC_BLOB_DIGEST);
+
+    const decoded = decodeOpaqueKaBundleV1(fromHex(A_BC_BUNDLE));
+    expect(lowerHex(decoded.projectionBytes)).toBe('61');
+    expect(lowerHex(decoded.sealBytes)).toBe('6263');
+    expect(decoded.projectionDigest).toBe(A_PROJECTION_DIGEST);
+    expect(decoded.blobDigest).toBe(A_BC_BLOB_DIGEST);
+  });
+
+  it('returns zero-copy component views from a decoded bundle', () => {
+    const bundle = fromHex(A_BC_BUNDLE);
+    const decoded = decodeOpaqueKaBundleV1(bundle);
+    expect(decoded.projectionBytes.buffer).toBe(bundle.buffer);
+    expect(decoded.sealBytes.buffer).toBe(bundle.buffer);
+    expect(decoded.projectionBytes.byteOffset).toBe(bundle.byteOffset + 8);
+    expect(decoded.sealBytes.byteOffset).toBe(bundle.byteOffset + 17);
+  });
+
+  it('rejects shared backing memory before copying, parsing, or hashing', () => {
+    const sharedProjection = new Uint8Array(new SharedArrayBuffer(1));
+    sharedProjection[0] = 0x61;
+    const sharedBundle = new Uint8Array(new SharedArrayBuffer(16));
+
+    expect(() => encodeOpaqueKaBundleV1(sharedProjection, new Uint8Array()))
+      .toThrow(/shared backing memory/);
+    expect(() => decodeOpaqueKaBundleV1(sharedBundle)).toThrow(/shared backing memory/);
+  });
+
+  it('rejects resizable ArrayBuffer views when the runtime supports them', () => {
+    const ResizableArrayBuffer = ArrayBuffer as unknown as new (
+      byteLength: number,
+      options: { maxByteLength: number },
+    ) => ArrayBuffer;
+    let backing: ArrayBuffer;
+    try {
+      backing = new ResizableArrayBuffer(16, { maxByteLength: 32 });
+    } catch {
+      return;
+    }
+    if ((backing as ArrayBuffer & { readonly resizable?: boolean }).resizable !== true) return;
+    expect(() => decodeOpaqueKaBundleV1(new Uint8Array(backing)))
+      .toThrow(/resizable backing memory/);
+  });
+
+  it('validates maximum arithmetic without allocating a 1 GiB fixture', () => {
+    expect(calculateOpaqueKaBundleByteLengthV1(1_073_741_808n, 0n)).toBe(
+      MAX_KA_BUNDLE_BYTES_V1,
+    );
+    expectFailureCode(
+      () => calculateOpaqueKaBundleByteLengthV1(1_073_741_809n, 0n),
+      'bundle-length-overflow',
+    );
+    expectFailureCode(
+      () => calculateOpaqueKaBundleByteLengthV1(1_073_741_808n, 1n),
+      'bundle-length-overflow',
+    );
+  });
+
+  it('rejects total lengths outside 16..1 GiB before frame parsing', () => {
+    expectFailureCode(
+      () => assertOpaqueKaBundleByteLengthV1(15n),
+      'bundle-byte-length',
+    );
+    expectFailureCode(
+      () => assertOpaqueKaBundleByteLengthV1(1_073_741_825n),
+      'bundle-byte-length',
+    );
+    expectFailureCode(
+      () => decodeOpaqueKaBundleV1(new Uint8Array(15)),
+      'bundle-byte-length',
+    );
+    expectFailureCode(
+      () => decodeOpaqueKaBundleV1(new Uint8Array(7)),
+      'bundle-byte-length',
+    );
+  });
+
+  it('rejects truncated projection and seal payloads', () => {
+    // projection length 1, but no projection byte plus complete second prefix
+    expectFailureCode(
+      () => decodeOpaqueKaBundleV1(fromHex(
+        '00000000000000010000000000000000',
+      )),
+      'bundle-truncated',
+    );
+
+    // empty projection, declared one-byte seal, no seal payload
+    expectFailureCode(
+      () => decodeOpaqueKaBundleV1(fromHex(
+        '00000000000000000000000000000001',
+      )),
+      'bundle-truncated',
+    );
+  });
+
+  it('rejects projection and seal u64 declarations outside the v1 total bound', () => {
+    expectFailureCode(
+      () => decodeOpaqueKaBundleV1(fromHex(
+        'ffffffffffffffff0000000000000000',
+      )),
+      'bundle-length-overflow',
+    );
+    expectFailureCode(
+      () => decodeOpaqueKaBundleV1(fromHex(
+        '0000000000000000ffffffffffffffff',
+      )),
+      'bundle-length-overflow',
+    );
+  });
+
+  it('rejects trailing bytes and never treats them as a second record', () => {
+    expectFailureCode(
+      () => decodeOpaqueKaBundleV1(fromHex(`${EMPTY_EMPTY_BUNDLE}00`)),
+      'bundle-trailing-bytes',
+    );
+    expectFailureCode(
+      () => decodeOpaqueKaBundleV1(fromHex(
+        `${EMPTY_EMPTY_BUNDLE}${EMPTY_EMPTY_BUNDLE}`,
+      )),
+      'bundle-trailing-bytes',
+    );
+  });
+
+  it('never reinterprets a little-endian projection length', () => {
+    expectFailureCode(
+      () => decodeOpaqueKaBundleV1(fromHex(
+        '01000000000000006100000000000000026263',
+      )),
+      'bundle-length-overflow',
+    );
+  });
+
+  it('rejects non-u64 and negative component arithmetic inputs', () => {
+    expectFailureCode(
+      () => calculateOpaqueKaBundleByteLengthV1(-1n, 0n),
+      'bundle-length-overflow',
+    );
+    expectFailureCode(
+      () => calculateOpaqueKaBundleByteLengthV1(18_446_744_073_709_551_616n, 0n),
+      'bundle-length-overflow',
+    );
+  });
+});
+
+function expectFailureCode(operation: () => unknown, expected: KaBundleV1ErrorCode): void {
+  try {
+    operation();
+  } catch (error) {
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error & { code?: unknown }).code).toBe(expected);
+    return;
+  }
+  throw new Error(`expected operation to fail with ${expected}`);
+}
+
+function fromHex(hex: string): Uint8Array {
+  if (hex.length % 2 !== 0 || !/^[0-9a-f]*$/.test(hex)) throw new Error('invalid test hex');
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let index = 0; index < bytes.length; index += 1) {
+    bytes[index] = Number.parseInt(hex.slice(index * 2, index * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+function lowerHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
+}

--- a/packages/core/test/ka-bundle-v1.test.ts
+++ b/packages/core/test/ka-bundle-v1.test.ts
@@ -60,9 +60,13 @@ describe('RFC-64 dormant opaque KA bundle framing', () => {
   it('rejects shared backing memory before copying, parsing, or hashing', () => {
     const sharedProjection = new Uint8Array(new SharedArrayBuffer(1));
     sharedProjection[0] = 0x61;
+    const sharedSeal = new Uint8Array(new SharedArrayBuffer(1));
+    sharedSeal[0] = 0x62;
     const sharedBundle = new Uint8Array(new SharedArrayBuffer(16));
 
     expect(() => encodeOpaqueKaBundleV1(sharedProjection, new Uint8Array()))
+      .toThrow(/shared backing memory/);
+    expect(() => encodeOpaqueKaBundleV1(new Uint8Array(), sharedSeal))
       .toThrow(/shared backing memory/);
     expect(() => decodeOpaqueKaBundleV1(sharedBundle)).toThrow(/shared backing memory/);
   });
@@ -79,6 +83,10 @@ describe('RFC-64 dormant opaque KA bundle framing', () => {
       return;
     }
     if ((backing as ArrayBuffer & { readonly resizable?: boolean }).resizable !== true) return;
+    expect(() => encodeOpaqueKaBundleV1(new Uint8Array(backing), new Uint8Array()))
+      .toThrow(/resizable backing memory/);
+    expect(() => encodeOpaqueKaBundleV1(new Uint8Array(), new Uint8Array(backing)))
+      .toThrow(/resizable backing memory/);
     expect(() => decodeOpaqueKaBundleV1(new Uint8Array(backing)))
       .toThrow(/resizable backing memory/);
   });


### PR DESCRIPTION
## Summary

Adds the dormant, store-agnostic RFC-64 opaque KA bundle codec:

- exact `u64be(projection length) || projection || u64be(seal length) || seal` framing
- projection and whole-bundle digest computation with frozen domains
- strict 16-byte to 1 GiB bounds and overflow/truncation/trailing-byte rejection
- zero-copy decode views with explicit ownership semantics
- rejection of shared or resizable backing memory to keep digest results race-free
- exact conformance vectors and hostile-frame tests

This is a stacked PR based on #1791. It does not activate networking, persistence, RDF interpretation, or runtime synchronization.

## Verification

- `pnpm --filter @origintrail-official/dkg-rdf-utils build`
- `pnpm --filter @origintrail-official/dkg-core build`
- focused RFC-64 stack: 79/79 passed
- complete core suite: 87 files, 1,314 tests passed