### PR TITLE
feat(core): add RFC-64 KA chunk tree

### DIFF
--- a/packages/core/src/ka-chunk-tree.ts
+++ b/packages/core/src/ka-chunk-tree.ts
@@ -1,0 +1,170 @@
+import { sha256 } from '@noble/hashes/sha2.js';
+
+import {
+  KA_TRANSFER_CHUNK_SIZE_BYTES_V1,
+  MAX_KA_TRANSFER_BYTES_V1,
+  MAX_KA_TRANSFER_CHUNKS_V1,
+  MIN_KA_TRANSFER_BYTES_V1,
+} from './ka-transfer-descriptor.js';
+import {
+  assertCanonicalDigest,
+  type Digest32V1,
+} from './sync-wire-scalars.js';
+
+export const KA_CHUNK_LEAF_DIGEST_DOMAIN_V1 = 'dkg-ka-chunk-leaf-v1\n' as const;
+export const KA_CHUNK_NODE_DIGEST_DOMAIN_V1 = 'dkg-ka-chunk-node-v1\n' as const;
+export const KA_CHUNK_ODD_DIGEST_DOMAIN_V1 = 'dkg-ka-chunk-odd-v1\n' as const;
+export const KA_CHUNK_EMPTY_DIGEST_DOMAIN_V1 = 'dkg-ka-chunk-empty-v1\n' as const;
+
+const UTF8 = new TextEncoder();
+const LEAF_DOMAIN_BYTES = UTF8.encode(KA_CHUNK_LEAF_DIGEST_DOMAIN_V1);
+const NODE_DOMAIN_BYTES = UTF8.encode(KA_CHUNK_NODE_DIGEST_DOMAIN_V1);
+const ODD_DOMAIN_BYTES = UTF8.encode(KA_CHUNK_ODD_DIGEST_DOMAIN_V1);
+const EMPTY_DOMAIN_BYTES = UTF8.encode(KA_CHUNK_EMPTY_DIGEST_DOMAIN_V1);
+const U64_BYTES = 8;
+
+export type KaChunkTreeV1ErrorCode =
+  | 'chunk-tree-byte-length'
+  | 'chunk-index'
+  | 'chunk-byte-length'
+  | 'chunk-count';
+
+export class KaChunkTreeV1Error extends Error {
+  constructor(
+    readonly code: KaChunkTreeV1ErrorCode,
+    message: string,
+  ) {
+    super(`[${code}] ${message}`);
+    this.name = 'KaChunkTreeV1Error';
+  }
+}
+
+/**
+ * Compute the exact index- and length-bound RFC-64 leaf digest for one non-empty
+ * transfer chunk. This is a dormant structural primitive; it makes no RDF or seal claim.
+ */
+export function computeKaChunkLeafDigestV1(
+  chunkIndex: bigint,
+  chunkBytes: Uint8Array,
+): Digest32V1 {
+  assertOwnedFixedUint8Array(chunkBytes, 'chunkBytes');
+  if (
+    typeof chunkIndex !== 'bigint'
+    || chunkIndex < 0n
+    || chunkIndex >= MAX_KA_TRANSFER_CHUNKS_V1
+  ) {
+    fail(
+      'chunk-index',
+      `chunkIndex must be in 0..${MAX_KA_TRANSFER_CHUNKS_V1 - 1n}`,
+    );
+  }
+  const byteLength = BigInt(chunkBytes.byteLength);
+  if (byteLength < 1n || byteLength > KA_TRANSFER_CHUNK_SIZE_BYTES_V1) {
+    fail(
+      'chunk-byte-length',
+      `chunk length must be in 1..${KA_TRANSFER_CHUNK_SIZE_BYTES_V1}`,
+    );
+  }
+  return digestBytesToLowerHex(computeLeafDigestBytes(chunkIndex, chunkBytes));
+}
+
+function computeLeafDigestBytes(chunkIndex: bigint, chunkBytes: Uint8Array): Uint8Array {
+  return digestBytes(
+    LEAF_DOMAIN_BYTES,
+    encodeU64Be(chunkIndex),
+    encodeU64Be(BigInt(chunkBytes.byteLength)),
+    chunkBytes,
+  );
+}
+
+/**
+ * Compute the canonical root for one complete transfer blob. Chunks are the exact
+ * consecutive 256 KiB slices of `bundleBytes`; only the final chunk may be shorter.
+ */
+export function computeKaChunkTreeRootV1(bundleBytes: Uint8Array): Digest32V1 {
+  assertOwnedFixedUint8Array(bundleBytes, 'bundleBytes');
+  const byteLength = BigInt(bundleBytes.byteLength);
+  if (byteLength < MIN_KA_TRANSFER_BYTES_V1 || byteLength > MAX_KA_TRANSFER_BYTES_V1) {
+    fail(
+      'chunk-tree-byte-length',
+      `bundle length must be ${MIN_KA_TRANSFER_BYTES_V1}-${MAX_KA_TRANSFER_BYTES_V1} bytes`,
+    );
+  }
+
+  const chunkCount = ((byteLength - 1n) / KA_TRANSFER_CHUNK_SIZE_BYTES_V1) + 1n;
+  if (chunkCount < 1n || chunkCount > MAX_KA_TRANSFER_CHUNKS_V1) {
+    fail('chunk-count', `chunk count must be in 1..${MAX_KA_TRANSFER_CHUNKS_V1}`);
+  }
+
+  const chunkSize = Number(KA_TRANSFER_CHUNK_SIZE_BYTES_V1);
+  let level: Uint8Array[] = [];
+  for (let index = 0; index < Number(chunkCount); index += 1) {
+    const start = index * chunkSize;
+    const end = Math.min(start + chunkSize, bundleBytes.byteLength);
+    const chunkBytes = bundleBytes.subarray(start, end);
+    // The complete bundle bounds above prove the index and chunk-length domains.
+    level.push(computeLeafDigestBytes(BigInt(index), chunkBytes));
+  }
+
+  while (level.length > 1) {
+    const parentLevel: Uint8Array[] = [];
+    for (let index = 0; index < level.length; index += 2) {
+      parentLevel.push(
+        index + 1 < level.length
+          ? digestBytes(NODE_DOMAIN_BYTES, level[index], level[index + 1])
+          : digestBytes(ODD_DOMAIN_BYTES, level[index]),
+      );
+    }
+    level = parentLevel;
+  }
+  return digestBytesToLowerHex(level[0]);
+}
+
+/** Exact domain-separated root of an empty tree; no valid v1 transfer uses it. */
+export function computeEmptyKaChunkTreeRootV1(): Digest32V1 {
+  return digestBytesToLowerHex(digestBytes(EMPTY_DOMAIN_BYTES));
+}
+
+function assertOwnedFixedUint8Array(
+  value: unknown,
+  label: string,
+): asserts value is Uint8Array {
+  if (!(value instanceof Uint8Array)) {
+    throw new TypeError(`${label} must be a Uint8Array`);
+  }
+  if (!(value.buffer instanceof ArrayBuffer)) {
+    throw new TypeError(`${label} must not use shared backing memory`);
+  }
+  if ((value.buffer as ArrayBuffer & { readonly resizable?: boolean }).resizable === true) {
+    throw new TypeError(`${label} must not use resizable backing memory`);
+  }
+}
+
+function encodeU64Be(value: bigint): Uint8Array {
+  const encoded = new Uint8Array(U64_BYTES);
+  let remaining = value;
+  for (let index = encoded.length - 1; index >= 0; index -= 1) {
+    encoded[index] = Number(remaining & 0xffn);
+    remaining >>= 8n;
+  }
+  if (remaining !== 0n) fail('chunk-index', 'u64be value exceeds the unsigned 64-bit range');
+  return encoded;
+}
+
+function digestBytes(domain: Uint8Array, ...chunks: readonly Uint8Array[]): Uint8Array {
+  const hasher = sha256.create();
+  hasher.update(domain);
+  for (const chunk of chunks) hasher.update(chunk);
+  return hasher.digest();
+}
+
+function digestBytesToLowerHex(digest: Uint8Array): Digest32V1 {
+  let result = '0x';
+  for (const byte of digest) result += byte.toString(16).padStart(2, '0');
+  assertCanonicalDigest(result);
+  return result;
+}
+
+function fail(code: KaChunkTreeV1ErrorCode, message: string): never {
+  throw new KaChunkTreeV1Error(code, message);
+}

--- a/packages/core/src/ka-chunk-tree.ts
+++ b/packages/core/src/ka-chunk-tree.ts
@@ -40,6 +40,24 @@ export class KaChunkTreeV1Error extends Error {
 }
 
 /**
+ * Validate a complete transfer length before any transfer-sized buffer is
+ * allocated or hashed. Callers that learn the declared length from a
+ * descriptor can therefore reject an over-limit transfer up front.
+ */
+export function assertKaChunkTreeByteLengthV1(byteLength: bigint): void {
+  if (
+    typeof byteLength !== 'bigint'
+    || byteLength < MIN_KA_TRANSFER_BYTES_V1
+    || byteLength > MAX_KA_TRANSFER_BYTES_V1
+  ) {
+    fail(
+      'chunk-tree-byte-length',
+      `bundle length must be ${MIN_KA_TRANSFER_BYTES_V1}-${MAX_KA_TRANSFER_BYTES_V1} bytes`,
+    );
+  }
+}
+
+/**
  * Compute the exact index- and length-bound RFC-64 leaf digest for one non-empty
  * transfer chunk. This is a dormant structural primitive; it makes no RDF or seal claim.
  */
@@ -84,12 +102,7 @@ function computeLeafDigestBytes(chunkIndex: bigint, chunkBytes: Uint8Array): Uin
 export function computeKaChunkTreeRootV1(bundleBytes: Uint8Array): Digest32V1 {
   assertOwnedFixedUint8Array(bundleBytes, 'bundleBytes');
   const byteLength = BigInt(bundleBytes.byteLength);
-  if (byteLength < MIN_KA_TRANSFER_BYTES_V1 || byteLength > MAX_KA_TRANSFER_BYTES_V1) {
-    fail(
-      'chunk-tree-byte-length',
-      `bundle length must be ${MIN_KA_TRANSFER_BYTES_V1}-${MAX_KA_TRANSFER_BYTES_V1} bytes`,
-    );
-  }
+  assertKaChunkTreeByteLengthV1(byteLength);
 
   const chunkCount = ((byteLength - 1n) / KA_TRANSFER_CHUNK_SIZE_BYTES_V1) + 1n;
   if (chunkCount < 1n || chunkCount > MAX_KA_TRANSFER_CHUNKS_V1) {

--- a/packages/core/test/ka-chunk-tree.test.ts
+++ b/packages/core/test/ka-chunk-tree.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  assertKaChunkTreeByteLengthV1,
   computeEmptyKaChunkTreeRootV1,
   computeKaChunkLeafDigestV1,
   computeKaChunkTreeRootV1,
@@ -62,6 +63,10 @@ describe('RFC-64 dormant KA chunk tree', () => {
   });
 
   it('rejects transfer lengths outside 16..1 GiB and empty leaves', () => {
+    expectFailureCode(
+      () => assertKaChunkTreeByteLengthV1(1_073_741_825n),
+      'chunk-tree-byte-length',
+    );
     expectFailureCode(
       () => computeKaChunkTreeRootV1(new Uint8Array(15)),
       'chunk-tree-byte-length',

--- a/packages/core/test/ka-chunk-tree.test.ts
+++ b/packages/core/test/ka-chunk-tree.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  computeEmptyKaChunkTreeRootV1,
+  computeKaChunkLeafDigestV1,
+  computeKaChunkTreeRootV1,
+  type KaChunkTreeV1ErrorCode,
+} from '../src/ka-chunk-tree.js';
+
+const EMPTY_EMPTY_BUNDLE = fromHex('00000000000000000000000000000000');
+
+describe('RFC-64 dormant KA chunk tree', () => {
+  it('matches the empty-tree and one-bundle-chunk conformance roots', () => {
+    expect(computeEmptyKaChunkTreeRootV1()).toBe(
+      '0x558df3a0a75720f66c27b95906ed3992256105f43694c9d7f592cd334662f0f1',
+    );
+    expect(computeKaChunkTreeRootV1(EMPTY_EMPTY_BUNDLE)).toBe(
+      '0xfb8fec167dc39ee7bc316afaff45d2d259e8a183af31a97a7cb736fc41c5b12f',
+    );
+  });
+
+  it('binds every leaf to its zero-based index and exact byte length', () => {
+    const bytes = fromHex('616263');
+    expect(computeKaChunkLeafDigestV1(0n, bytes)).toBe(
+      '0xcad222080b737db774460c9e8618ff9dc4537917a44715b8804fe73915562f6c',
+    );
+    expect(computeKaChunkLeafDigestV1(1n, bytes)).not.toBe(
+      computeKaChunkLeafDigestV1(0n, bytes),
+    );
+    expect(computeKaChunkLeafDigestV1(0n, fromHex('6162'))).not.toBe(
+      computeKaChunkLeafDigestV1(0n, bytes),
+    );
+  });
+
+  it('matches deterministic two-, three-, and five-chunk odd-tree vectors', () => {
+    const chunks = Array.from({ length: 5 }, (_, index) => {
+      const chunk = new Uint8Array(262_144);
+      chunk.fill(index);
+      return chunk;
+    });
+    const final = fromHex('a0a1a2a3a4a5a6');
+
+    expect(computeKaChunkTreeRootV1(concat(chunks[0], final))).toBe(
+      '0xdff4f667510303304a1fa0fab500d5f889089ce3baac72c213fdb4df9b5c5493',
+    );
+    expect(computeKaChunkTreeRootV1(concat(chunks[0], chunks[1], final))).toBe(
+      '0x80f90776eb169f7d125c41fb842f00c8a6d08093ef522ef8c5015bf169898338',
+    );
+    expect(
+      computeKaChunkTreeRootV1(
+        concat(chunks[0], chunks[1], chunks[2], chunks[3], final),
+      ),
+    ).toBe('0x1177b2daacaca40ff38bc21641ae3f729956708f22c9485e9854f5343692ce2d');
+  });
+
+  it('uses exact consecutive 256 KiB slices and a shorter final chunk', () => {
+    const bytes = new Uint8Array(262_145);
+    bytes[262_144] = 0xff;
+    const twoChunkRoot = computeKaChunkTreeRootV1(bytes);
+    bytes[262_143] = 0xff;
+    expect(computeKaChunkTreeRootV1(bytes)).not.toBe(twoChunkRoot);
+  });
+
+  it('rejects transfer lengths outside 16..1 GiB and empty leaves', () => {
+    expectFailureCode(
+      () => computeKaChunkTreeRootV1(new Uint8Array(15)),
+      'chunk-tree-byte-length',
+    );
+    expectFailureCode(
+      () => computeKaChunkLeafDigestV1(0n, new Uint8Array()),
+      'chunk-byte-length',
+    );
+    expectFailureCode(
+      () => computeKaChunkLeafDigestV1(0n, new Uint8Array(262_145)),
+      'chunk-byte-length',
+    );
+  });
+
+  it('rejects chunk indexes outside 0..4095', () => {
+    expectFailureCode(
+      () => computeKaChunkLeafDigestV1(-1n, fromHex('00')),
+      'chunk-index',
+    );
+    expectFailureCode(
+      () => computeKaChunkLeafDigestV1(4096n, fromHex('00')),
+      'chunk-index',
+    );
+  });
+
+  it('rejects shared or resizable backing memory before hashing', () => {
+    expect(() => computeKaChunkTreeRootV1(new Uint8Array(new SharedArrayBuffer(16))))
+      .toThrow(/shared backing memory/);
+    expect(() => computeKaChunkLeafDigestV1(0n, new Uint8Array(new SharedArrayBuffer(1))))
+      .toThrow(/shared backing memory/);
+
+    const ResizableArrayBuffer = ArrayBuffer as unknown as new (
+      byteLength: number,
+      options: { maxByteLength: number },
+    ) => ArrayBuffer;
+    let backing: ArrayBuffer;
+    try {
+      backing = new ResizableArrayBuffer(16, { maxByteLength: 32 });
+    } catch {
+      return;
+    }
+    if ((backing as ArrayBuffer & { readonly resizable?: boolean }).resizable !== true) return;
+    expect(() => computeKaChunkTreeRootV1(new Uint8Array(backing)))
+      .toThrow(/resizable backing memory/);
+  });
+});
+
+function expectFailureCode(operation: () => unknown, expected: KaChunkTreeV1ErrorCode): void {
+  try {
+    operation();
+  } catch (error) {
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error & { code?: unknown }).code).toBe(expected);
+    return;
+  }
+  throw new Error(`expected operation to fail with ${expected}`);
+}
+
+function concat(...chunks: readonly Uint8Array[]): Uint8Array {
+  const byteLength = chunks.reduce((sum, chunk) => sum + chunk.byteLength, 0);
+  const bytes = new Uint8Array(byteLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes;
+}
+
+function fromHex(hex: string): Uint8Array {
+  if (hex.length % 2 !== 0 || !/^[0-9a-f]*$/.test(hex)) throw new Error('invalid test hex');
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let index = 0; index < bytes.length; index += 1) {
+    bytes[index] = Number.parseInt(hex.slice(index * 2, index * 2 + 2), 16);
+  }
+  return bytes;
+}


### PR DESCRIPTION
## Summary

Adds the dormant, store-agnostic RFC-64 chunk-tree primitive used by resumable KA transfer. It freezes 256 KiB index/length-bound leaves, domain-separated SHA-256 parent and odd-node reduction, exact transfer-size/chunk-count limits, and deterministic conformance vectors. It does not wire runtime networking or persistence yet.

This is a small stacked slice on top of #1792 and follows the frozen contract in OriginTrail/dkgv10-spec#144.

## Verification

- focused chunk-tree tests: 7/7
- full core suite (with the next proof slice applied): 90 files / 1,336 tests
- `pnpm --filter @origintrail-official/dkg-core build`
- independent vector/code audit: clean