### PR TITLE
feat(core): add RFC-64 chunk proofs

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -45,6 +45,9 @@ export type {
   TimestampMsV1,
 } from './sync-wire-scalars.js';
 export * from './ka-transfer-descriptor.js';
+export * from './ka-bundle-v1.js';
+export * from './ka-chunk-tree.js';
+export * from './ka-chunk-proof.js';
 export * from './event-bus.js';
 export {
   Logger,

--- a/packages/core/src/ka-chunk-proof.ts
+++ b/packages/core/src/ka-chunk-proof.ts
@@ -1,0 +1,443 @@
+import { sha256 } from '@noble/hashes/sha2.js';
+
+import {
+  canonicalizeJson,
+  parseCanonicalJson,
+  type CanonicalJsonValue,
+  type StrictJsonParseOptions,
+} from './canonical-json.js';
+import {
+  KA_CHUNK_NODE_DIGEST_DOMAIN_V1,
+  KA_CHUNK_ODD_DIGEST_DOMAIN_V1,
+  computeKaChunkLeafDigestV1,
+} from './ka-chunk-tree.js';
+import {
+  KA_TRANSFER_CHUNK_SIZE_BYTES_V1,
+  MAX_KA_TRANSFER_BYTES_V1,
+  MAX_KA_TRANSFER_CHUNKS_V1,
+  MIN_KA_TRANSFER_BYTES_V1,
+} from './ka-transfer-descriptor.js';
+import { assertExactKeys, isPlainRecord } from './sync-wire-objects.js';
+import {
+  assertCanonicalDecimalU64,
+  assertCanonicalDigest,
+  parseCanonicalDecimalU64,
+  type Digest32V1,
+  type IndexV1,
+} from './sync-wire-scalars.js';
+
+export const MAX_KA_CHUNK_PROOF_BYTES_V1 = 1280;
+export const MAX_KA_CHUNK_PROOF_DEPTH_V1 = 3;
+export const MAX_KA_CHUNK_PROOF_STEPS_V1 = 12;
+export const MAX_KA_CHUNK_PROOFS_PER_REQUEST_V1 = 16;
+
+const UTF8 = new TextEncoder();
+const NODE_DOMAIN_BYTES = UTF8.encode(KA_CHUNK_NODE_DIGEST_DOMAIN_V1);
+const ODD_DOMAIN_BYTES = UTF8.encode(KA_CHUNK_ODD_DIGEST_DOMAIN_V1);
+const DIGEST_BYTES = 32;
+
+export type KaChunkProofStepV1 =
+  | { readonly kind: 'left'; readonly digest: Digest32V1 }
+  | { readonly kind: 'right'; readonly digest: Digest32V1 }
+  | { readonly kind: 'odd' };
+
+export interface KaChunkProofV1 {
+  readonly chunkIndex: IndexV1;
+  readonly steps: readonly KaChunkProofStepV1[];
+}
+
+export type KaChunkProofV1ErrorCode =
+  | 'proof-schema'
+  | 'proof-object-too-large'
+  | 'proof-chunk-count'
+  | 'proof-chunk-index'
+  | 'proof-request-indexes'
+  | 'proof-topology'
+  | 'proof-chunk-byte-length'
+  | 'proof-root-mismatch';
+
+export class KaChunkProofV1Error extends Error {
+  constructor(
+    readonly code: KaChunkProofV1ErrorCode,
+    message: string,
+    options: ErrorOptions = {},
+  ) {
+    super(`[${code}] ${message}`, options);
+    this.name = 'KaChunkProofV1Error';
+  }
+}
+
+/** Validate a proof's exact closed schema and descriptor-derived topology. */
+export function assertKaChunkProofV1(
+  proof: unknown,
+  chunkCount: bigint,
+): asserts proof is KaChunkProofV1 {
+  assertChunkCount(chunkCount);
+  if (!isPlainRecord(proof)) fail('proof-schema', 'chunk proof must be a plain JSON object');
+  try {
+    assertExactKeys(proof, ['chunkIndex', 'steps'], 'chunk proof');
+  } catch (cause) {
+    fail('proof-schema', 'chunk proof has an invalid field set', cause);
+  }
+
+  try {
+    assertCanonicalDecimalU64(proof.chunkIndex, 'chunkIndex');
+  } catch (cause) {
+    fail('proof-chunk-index', 'chunkIndex must be a canonical DecimalU64V1', cause);
+  }
+  const chunkIndex = parseCanonicalDecimalU64(proof.chunkIndex, 'chunkIndex');
+  if (chunkIndex >= chunkCount) {
+    fail('proof-chunk-index', `chunkIndex must be less than chunkCount ${chunkCount}`);
+  }
+  if (!Array.isArray(proof.steps) || proof.steps.length > MAX_KA_CHUNK_PROOF_STEPS_V1) {
+    fail(
+      'proof-schema',
+      `steps must be an array of at most ${MAX_KA_CHUNK_PROOF_STEPS_V1} entries`,
+    );
+  }
+  assertClosedDenseArray(proof.steps, 'steps', 'proof-schema');
+
+  let position = chunkIndex;
+  let width = chunkCount;
+  let stepIndex = 0;
+  while (width > 1n) {
+    if (stepIndex >= proof.steps.length) {
+      fail('proof-topology', 'proof omits a required tree level');
+    }
+    const step = proof.steps[stepIndex];
+    const expectedKind = position % 2n === 1n
+      ? 'left'
+      : position + 1n < width
+        ? 'right'
+        : 'odd';
+    assertProofStep(step, expectedKind, stepIndex);
+    position /= 2n;
+    width = (width + 1n) / 2n;
+    stepIndex += 1;
+  }
+  if (stepIndex !== proof.steps.length) {
+    fail('proof-topology', 'proof contains steps after the tree root');
+  }
+}
+
+/** Return the exact bounded RFC 8785 JCS proof string. */
+export function canonicalizeKaChunkProofV1(
+  proof: KaChunkProofV1,
+  chunkCount: bigint,
+): string {
+  assertKaChunkProofV1(proof, chunkCount);
+  return canonicalizeJson(proof as unknown as CanonicalJsonValue, {
+    maxBytes: MAX_KA_CHUNK_PROOF_BYTES_V1,
+    maxDepth: MAX_KA_CHUNK_PROOF_DEPTH_V1,
+  });
+}
+
+/** Strictly decode one canonical proof using the descriptor-derived chunk count. */
+export function parseCanonicalKaChunkProofV1(
+  input: string | Uint8Array,
+  chunkCount: bigint,
+  options: StrictJsonParseOptions = {},
+): KaChunkProofV1 {
+  if (wireByteLength(input) > MAX_KA_CHUNK_PROOF_BYTES_V1) {
+    fail(
+      'proof-object-too-large',
+      `chunk proof exceeds ${MAX_KA_CHUNK_PROOF_BYTES_V1} bytes`,
+    );
+  }
+  const parsed = parseCanonicalJson(input, {
+    ...options,
+    maxBytes: Math.min(
+      options.maxBytes ?? MAX_KA_CHUNK_PROOF_BYTES_V1,
+      MAX_KA_CHUNK_PROOF_BYTES_V1,
+    ),
+    maxDepth: Math.min(
+      options.maxDepth ?? MAX_KA_CHUNK_PROOF_DEPTH_V1,
+      MAX_KA_CHUNK_PROOF_DEPTH_V1,
+    ),
+  });
+  assertKaChunkProofV1(parsed, chunkCount);
+  return parsed;
+}
+
+/** Build the one canonical proof for `chunkIndex` from a complete bounded bundle. */
+export function buildKaChunkProofV1(
+  bundleBytes: Uint8Array,
+  chunkIndex: bigint,
+): KaChunkProofV1 {
+  return buildKaChunkProofsV1(bundleBytes, [chunkIndex])[0];
+}
+
+/**
+ * Build one logical request's sorted unique proofs while hashing the bundle tree once.
+ * This is the provider-side primitive used to avoid O(request indexes × bundle bytes).
+ */
+export function buildKaChunkProofsV1(
+  bundleBytes: Uint8Array,
+  chunkIndexes: readonly bigint[],
+): readonly KaChunkProofV1[] {
+  assertOwnedFixedUint8Array(bundleBytes, 'bundleBytes');
+  const byteLength = BigInt(bundleBytes.byteLength);
+  if (byteLength < MIN_KA_TRANSFER_BYTES_V1 || byteLength > MAX_KA_TRANSFER_BYTES_V1) {
+    fail(
+      'proof-chunk-byte-length',
+      `bundle length must be ${MIN_KA_TRANSFER_BYTES_V1}-${MAX_KA_TRANSFER_BYTES_V1}`,
+    );
+  }
+  const chunkCount = expectedChunkCount(byteLength);
+  if (
+    !Array.isArray(chunkIndexes)
+    || chunkIndexes.length < 1
+    || chunkIndexes.length > MAX_KA_CHUNK_PROOFS_PER_REQUEST_V1
+  ) {
+    fail(
+      'proof-request-indexes',
+      `chunkIndexes must contain 1..${MAX_KA_CHUNK_PROOFS_PER_REQUEST_V1} entries`,
+    );
+  }
+  assertClosedDenseArray(chunkIndexes, 'chunkIndexes', 'proof-request-indexes');
+  let previous = -1n;
+  for (let requestIndex = 0; requestIndex < chunkIndexes.length; requestIndex += 1) {
+    const chunkIndex = chunkIndexes[requestIndex];
+    if (
+      typeof chunkIndex !== 'bigint'
+      || chunkIndex < 0n
+      || chunkIndex >= chunkCount
+      || chunkIndex <= previous
+    ) {
+      fail(
+        'proof-request-indexes',
+        `chunkIndexes must be strictly increasing unique values in 0..${chunkCount - 1n}`,
+      );
+    }
+    previous = chunkIndex;
+  }
+
+  const chunkSize = Number(KA_TRANSFER_CHUNK_SIZE_BYTES_V1);
+  let level: Digest32V1[] = [];
+  for (let index = 0; index < Number(chunkCount); index += 1) {
+    const start = index * chunkSize;
+    const end = Math.min(start + chunkSize, bundleBytes.byteLength);
+    level.push(computeKaChunkLeafDigestV1(BigInt(index), bundleBytes.subarray(start, end)));
+  }
+
+  const levels: Digest32V1[][] = [];
+  while (level.length > 1) {
+    levels.push(level);
+    const parentLevel: Digest32V1[] = [];
+    for (let index = 0; index < level.length; index += 2) {
+      parentLevel.push(
+        index + 1 < level.length
+          ? combineNodeDigests(level[index], level[index + 1])
+          : combineOddDigest(level[index]),
+      );
+    }
+    level = parentLevel;
+  }
+
+  const proofs: KaChunkProofV1[] = [];
+  for (let requestIndex = 0; requestIndex < chunkIndexes.length; requestIndex += 1) {
+    const chunkIndex = chunkIndexes[requestIndex];
+    const steps: KaChunkProofStepV1[] = [];
+    let position = Number(chunkIndex);
+    for (const proofLevel of levels) {
+      if (position % 2 === 1) {
+        steps.push({ kind: 'left', digest: proofLevel[position - 1] });
+      } else if (position + 1 < proofLevel.length) {
+        steps.push({ kind: 'right', digest: proofLevel[position + 1] });
+      } else {
+        steps.push({ kind: 'odd' });
+      }
+      position = Math.floor(position / 2);
+    }
+    const proof = {
+      chunkIndex: chunkIndex.toString() as IndexV1,
+      steps,
+    };
+    assertKaChunkProofV1(proof, chunkCount);
+    proofs.push(proof);
+  }
+  return proofs;
+}
+
+/**
+ * Verify one exact chunk against a structurally valid descriptor tuple. A malformed
+ * proof throws a stable reason; a well-shaped proof for the wrong bytes/root also fails.
+ */
+export function assertValidKaChunkProofV1(
+  proof: KaChunkProofV1,
+  chunkBytes: Uint8Array,
+  transferByteLength: bigint,
+  expectedRoot: Digest32V1,
+): void {
+  assertOwnedFixedUint8Array(chunkBytes, 'chunkBytes');
+  if (
+    typeof transferByteLength !== 'bigint'
+    || transferByteLength < MIN_KA_TRANSFER_BYTES_V1
+    || transferByteLength > MAX_KA_TRANSFER_BYTES_V1
+  ) {
+    fail(
+      'proof-chunk-byte-length',
+      `transferByteLength must be ${MIN_KA_TRANSFER_BYTES_V1}-${MAX_KA_TRANSFER_BYTES_V1}`,
+    );
+  }
+  try {
+    assertCanonicalDigest(expectedRoot, 'chunkTreeRoot');
+  } catch (cause) {
+    fail('proof-schema', 'chunkTreeRoot must be a canonical Digest32V1', cause);
+  }
+
+  const chunkCount = expectedChunkCount(transferByteLength);
+  assertKaChunkProofV1(proof, chunkCount);
+  const chunkIndex = parseCanonicalDecimalU64(proof.chunkIndex, 'chunkIndex');
+  const expectedLength = chunkIndex + 1n < chunkCount
+    ? KA_TRANSFER_CHUNK_SIZE_BYTES_V1
+    : transferByteLength - (chunkCount - 1n) * KA_TRANSFER_CHUNK_SIZE_BYTES_V1;
+  if (BigInt(chunkBytes.byteLength) !== expectedLength) {
+    fail(
+      'proof-chunk-byte-length',
+      `chunk ${chunkIndex} must contain exactly ${expectedLength} bytes`,
+    );
+  }
+
+  let digest = computeKaChunkLeafDigestV1(chunkIndex, chunkBytes);
+  for (let stepIndex = 0; stepIndex < proof.steps.length; stepIndex += 1) {
+    const step = proof.steps[stepIndex];
+    if (step.kind === 'left') digest = combineNodeDigests(step.digest, digest);
+    else if (step.kind === 'right') digest = combineNodeDigests(digest, step.digest);
+    else digest = combineOddDigest(digest);
+  }
+  if (digest !== expectedRoot) {
+    fail(
+      'proof-root-mismatch',
+      "chunk proof does not produce the exact descriptor's chunkTreeRoot",
+    );
+  }
+}
+
+function assertProofStep(
+  step: unknown,
+  expectedKind: KaChunkProofStepV1['kind'],
+  index: number,
+): void {
+  if (!isPlainRecord(step)) fail('proof-schema', `steps[${index}] must be a plain object`);
+  try {
+    assertExactKeys(
+      step,
+      expectedKind === 'odd' ? ['kind'] : ['digest', 'kind'],
+      `steps[${index}]`,
+    );
+  } catch (cause) {
+    fail('proof-schema', `steps[${index}] has an invalid field set`, cause);
+  }
+  if (step.kind !== expectedKind) {
+    fail(
+      'proof-topology',
+      `steps[${index}] must be ${expectedKind} for this chunk position and tree width`,
+    );
+  }
+  if (expectedKind !== 'odd') {
+    try {
+      assertCanonicalDigest(step.digest, `steps[${index}].digest`);
+    } catch (cause) {
+      fail('proof-schema', `steps[${index}].digest is not a canonical Digest32V1`, cause);
+    }
+  }
+}
+
+function assertChunkCount(chunkCount: bigint): void {
+  if (
+    typeof chunkCount !== 'bigint'
+    || chunkCount < 1n
+    || chunkCount > MAX_KA_TRANSFER_CHUNKS_V1
+  ) {
+    fail('proof-chunk-count', `chunkCount must be in 1..${MAX_KA_TRANSFER_CHUNKS_V1}`);
+  }
+}
+
+function assertClosedDenseArray(
+  value: readonly unknown[],
+  label: string,
+  code: KaChunkProofV1ErrorCode,
+): void {
+  if (Object.getPrototypeOf(value) !== Array.prototype) {
+    fail(code, `${label} must use the ordinary Array prototype`);
+  }
+  const keys = Reflect.ownKeys(value);
+  if (keys.some((key) => typeof key !== 'string')) {
+    fail(code, `${label} must not contain symbol properties`);
+  }
+  const expected = new Set(['length']);
+  for (let index = 0; index < value.length; index += 1) expected.add(String(index));
+  if (keys.length !== expected.size || keys.some((key) => !expected.has(key as string))) {
+    fail(code, `${label} must be a dense array without custom properties`);
+  }
+  for (let index = 0; index < value.length; index += 1) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
+    if (!descriptor?.enumerable || !Object.prototype.hasOwnProperty.call(descriptor, 'value')) {
+      fail(code, `${label}[${index}] must be an enumerable data property`);
+    }
+  }
+}
+
+function expectedChunkCount(byteLength: bigint): bigint {
+  const chunkCount = ((byteLength - 1n) / KA_TRANSFER_CHUNK_SIZE_BYTES_V1) + 1n;
+  assertChunkCount(chunkCount);
+  return chunkCount;
+}
+
+function combineNodeDigests(left: Digest32V1, right: Digest32V1): Digest32V1 {
+  return digestToLowerHex(NODE_DOMAIN_BYTES, digestFromLowerHex(left), digestFromLowerHex(right));
+}
+
+function combineOddDigest(child: Digest32V1): Digest32V1 {
+  return digestToLowerHex(ODD_DOMAIN_BYTES, digestFromLowerHex(child));
+}
+
+function digestFromLowerHex(digest: Digest32V1): Uint8Array {
+  assertCanonicalDigest(digest);
+  const bytes = new Uint8Array(DIGEST_BYTES);
+  for (let index = 0; index < bytes.length; index += 1) {
+    bytes[index] = Number.parseInt(digest.slice(2 + index * 2, 4 + index * 2), 16);
+  }
+  return bytes;
+}
+
+function digestToLowerHex(domain: Uint8Array, ...chunks: readonly Uint8Array[]): Digest32V1 {
+  const hasher = sha256.create();
+  hasher.update(domain);
+  for (const chunk of chunks) hasher.update(chunk);
+  const digest = hasher.digest();
+  let result = '0x';
+  for (const byte of digest) result += byte.toString(16).padStart(2, '0');
+  assertCanonicalDigest(result);
+  return result;
+}
+
+function assertOwnedFixedUint8Array(
+  value: unknown,
+  label: string,
+): asserts value is Uint8Array {
+  if (!(value instanceof Uint8Array)) throw new TypeError(`${label} must be a Uint8Array`);
+  if (!(value.buffer instanceof ArrayBuffer)) {
+    throw new TypeError(`${label} must not use shared backing memory`);
+  }
+  if ((value.buffer as ArrayBuffer & { readonly resizable?: boolean }).resizable === true) {
+    throw new TypeError(`${label} must not use resizable backing memory`);
+  }
+}
+
+function wireByteLength(input: string | Uint8Array): number {
+  if (typeof input !== 'string') return input.byteLength;
+  if (input.length > MAX_KA_CHUNK_PROOF_BYTES_V1) {
+    return MAX_KA_CHUNK_PROOF_BYTES_V1 + 1;
+  }
+  return UTF8.encode(input).byteLength;
+}
+
+function fail(
+  code: KaChunkProofV1ErrorCode,
+  message: string,
+  cause?: unknown,
+): never {
+  throw new KaChunkProofV1Error(code, message, cause === undefined ? {} : { cause });
+}

--- a/packages/core/src/ka-transfer-descriptor.ts
+++ b/packages/core/src/ka-transfer-descriptor.ts
@@ -1,3 +1,5 @@
+import { sha256 } from '@noble/hashes/sha2.js';
+
 import {
   canonicalizeJson,
   parseCanonicalJson,
@@ -22,7 +24,10 @@ export const MAX_KA_TRANSFER_BYTES_V1 = 1_073_741_824n;
 export const MAX_KA_TRANSFER_CHUNKS_V1 = 4096n;
 export const MAX_KA_TRANSFER_DESCRIPTOR_BYTES_V1 = 512;
 export const MAX_KA_TRANSFER_DESCRIPTOR_DEPTH_V1 = 1;
+export const KA_TRANSFER_IDENTITY_DIGEST_DOMAIN_V1 =
+  'dkg-ka-transfer-descriptor-v1\n' as const;
 const UTF8 = new TextEncoder();
+const IDENTITY_DOMAIN_BYTES = UTF8.encode(KA_TRANSFER_IDENTITY_DIGEST_DOMAIN_V1);
 
 /**
  * Exact nested author-catalog transfer value. It is not a signed control object
@@ -139,6 +144,22 @@ export function canonicalizeKaTransferDescriptorBytesV1(
   descriptor: KaTransferDescriptorV1,
 ): Uint8Array {
   return UTF8.encode(canonicalizeKaTransferDescriptorV1(descriptor));
+}
+
+/**
+ * Bind verified partial chunks to every canonical descriptor field rather than
+ * merely to the final blob digest. This is the exact durable-resume/cache key.
+ */
+export function computeKaTransferIdentityDigestV1(
+  descriptor: KaTransferDescriptorV1,
+): Digest32V1 {
+  const hasher = sha256.create();
+  hasher.update(IDENTITY_DOMAIN_BYTES);
+  hasher.update(canonicalizeKaTransferDescriptorBytesV1(descriptor));
+  let result = '0x';
+  for (const byte of hasher.digest()) result += byte.toString(16).padStart(2, '0');
+  assertCanonicalDigest(result, 'transferIdentityDigest');
+  return result;
 }
 
 /**

--- a/packages/core/test/ka-chunk-proof.test.ts
+++ b/packages/core/test/ka-chunk-proof.test.ts
@@ -1,0 +1,306 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  MAX_KA_CHUNK_PROOF_BYTES_V1,
+  assertKaChunkProofV1,
+  assertValidKaChunkProofV1,
+  buildKaChunkProofV1,
+  buildKaChunkProofsV1,
+  canonicalizeKaChunkProofV1,
+  parseCanonicalKaChunkProofV1,
+  type KaChunkProofV1,
+  type KaChunkProofV1ErrorCode,
+} from '../src/ka-chunk-proof.js';
+import { computeKaChunkTreeRootV1 } from '../src/ka-chunk-tree.js';
+import type { Digest32V1, IndexV1 } from '../src/sync-wire-scalars.js';
+
+const ZERO_DIGEST = `0x${'00'.repeat(32)}` as Digest32V1;
+const THREE_CHUNK_ROOT =
+  '0x80f90776eb169f7d125c41fb842f00c8a6d08093ef522ef8c5015bf169898338' as Digest32V1;
+const THREE_CHUNK_PROOF =
+  '{"chunkIndex":"2","steps":[{"kind":"odd"},{"digest":"0x12b230a0573621cb375b62f8f3f46cc6e8c05d3d0a84a50cd5d097132f86f58e","kind":"left"}]}';
+
+describe('RFC-64 dormant KA chunk proof codec', () => {
+  it('builds, canonicalizes, parses, and verifies the exact three-chunk vector', () => {
+    const bundle = fixtureBundle(3);
+    const proof = buildKaChunkProofV1(bundle, 2n);
+    expect(canonicalizeKaChunkProofV1(proof, 3n)).toBe(THREE_CHUNK_PROOF);
+    expect(new TextEncoder().encode(THREE_CHUNK_PROOF).byteLength).toBe(137);
+    expect(computeKaChunkTreeRootV1(bundle)).toBe(THREE_CHUNK_ROOT);
+
+    const parsed = parseCanonicalKaChunkProofV1(THREE_CHUNK_PROOF, 3n);
+    expect(parsed).toEqual(proof);
+    expect(() => assertValidKaChunkProofV1(
+      parsed,
+      finalChunk(),
+      524_295n,
+      THREE_CHUNK_ROOT,
+    )).not.toThrow();
+  });
+
+  it('builds and verifies every leaf in two-, three-, and five-chunk trees', () => {
+    for (const chunkCount of [2, 3, 5]) {
+      const bundle = fixtureBundle(chunkCount);
+      const root = computeKaChunkTreeRootV1(bundle);
+      const proofs = buildKaChunkProofsV1(
+        bundle,
+        Array.from({ length: chunkCount }, (_, index) => BigInt(index)),
+      );
+      for (let index = 0; index < chunkCount; index += 1) {
+        const proof = proofs[index];
+        const chunk = index + 1 === chunkCount ? finalChunk() : fullChunk(index);
+        expect(() => assertValidKaChunkProofV1(
+          proof,
+          chunk,
+          BigInt(bundle.byteLength),
+          root,
+        )).not.toThrow();
+      }
+    }
+  });
+
+  it('requires a bounded strictly increasing unique logical index request', () => {
+    const bundle = fixtureBundle(5);
+    expectFailureCode(() => buildKaChunkProofsV1(bundle, []), 'proof-request-indexes');
+    expectFailureCode(
+      () => buildKaChunkProofsV1(bundle, [0n, 0n]),
+      'proof-request-indexes',
+    );
+    expectFailureCode(
+      () => buildKaChunkProofsV1(bundle, [1n, 0n]),
+      'proof-request-indexes',
+    );
+    expectFailureCode(
+      () => buildKaChunkProofsV1(bundle, [0n, 5n]),
+      'proof-request-indexes',
+    );
+    const many = new Uint8Array(17 * 262_144);
+    expectFailureCode(
+      () => buildKaChunkProofsV1(many, Array.from({ length: 17 }, (_, index) => BigInt(index))),
+      'proof-request-indexes',
+    );
+  });
+
+  it('rejects custom or symbolic array properties in the closed schema', () => {
+    const proof = parseCanonicalKaChunkProofV1(THREE_CHUNK_PROOF, 3n);
+    const steps = [...proof.steps] as KaChunkProofV1['steps'] & { extra?: boolean };
+    steps.extra = true;
+    expectFailureCode(
+      () => assertKaChunkProofV1({ ...proof, steps }, 3n),
+      'proof-schema',
+    );
+    const symbolic = [...proof.steps];
+    Object.defineProperty(symbolic, Symbol('extra'), { value: true });
+    expectFailureCode(
+      () => assertKaChunkProofV1({ ...proof, steps: symbolic }, 3n),
+      'proof-schema',
+    );
+  });
+
+  it('rejects inherited iterators that differ from the validated indexed elements', () => {
+    const proof = parseCanonicalKaChunkProofV1(THREE_CHUNK_PROOF, 3n);
+    const indexedSteps = [
+      { kind: 'odd' as const },
+      { kind: 'left' as const, digest: ZERO_DIGEST },
+    ];
+    Object.setPrototypeOf(indexedSteps, {
+      *[Symbol.iterator]() {
+        yield* proof.steps;
+      },
+    });
+    expectFailureCode(
+      () => assertValidKaChunkProofV1(
+        { ...proof, steps: indexedSteps },
+        finalChunk(),
+        524_295n,
+        THREE_CHUNK_ROOT,
+      ),
+      'proof-schema',
+    );
+
+    const indexes = [1n, 0n];
+    Object.setPrototypeOf(indexes, {
+      *[Symbol.iterator]() {
+        yield 0n;
+        yield 1n;
+      },
+    });
+    expectFailureCode(
+      () => buildKaChunkProofsV1(fixtureBundle(3), indexes),
+      'proof-request-indexes',
+    );
+  });
+
+  it('requires topology-derived kind, direction, and exact step count', () => {
+    const valid = parseCanonicalKaChunkProofV1(THREE_CHUNK_PROOF, 3n);
+    const reversed = { ...valid, steps: [...valid.steps].reverse() };
+    expectFailureCode(() => assertKaChunkProofV1(reversed, 3n), 'proof-schema');
+    expectFailureCode(
+      () => assertKaChunkProofV1({ ...valid, steps: valid.steps.slice(0, 1) }, 3n),
+      'proof-topology',
+    );
+    expectFailureCode(
+      () => assertKaChunkProofV1({
+        ...valid,
+        steps: [{ kind: 'odd' }, { kind: 'right', digest: valid.steps[1].kind === 'left'
+          ? valid.steps[1].digest
+          : ZERO_DIGEST }],
+      }, 3n),
+      'proof-topology',
+    );
+    expectFailureCode(
+      () => assertKaChunkProofV1({ ...valid, steps: [...valid.steps, { kind: 'odd' }] }, 3n),
+      'proof-topology',
+    );
+  });
+
+  it('rejects odd steps with a digest and sibling steps without one', () => {
+    expectFailureCode(
+      () => assertKaChunkProofV1({
+        chunkIndex: '2',
+        steps: [{ kind: 'odd', digest: ZERO_DIGEST }, { kind: 'left', digest: ZERO_DIGEST }],
+      }, 3n),
+      'proof-schema',
+    );
+    expectFailureCode(
+      () => assertKaChunkProofV1({
+        chunkIndex: '1',
+        steps: [{ kind: 'left' }, { kind: 'right', digest: ZERO_DIGEST }],
+      }, 3n),
+      'proof-schema',
+    );
+  });
+
+  it('rejects wrong bytes, root, index, and final-chunk length', () => {
+    const proof = parseCanonicalKaChunkProofV1(THREE_CHUNK_PROOF, 3n);
+    const wrongBytes = finalChunk();
+    wrongBytes[0] ^= 0xff;
+    expectFailureCode(
+      () => assertValidKaChunkProofV1(proof, wrongBytes, 524_295n, THREE_CHUNK_ROOT),
+      'proof-root-mismatch',
+    );
+    expectFailureCode(
+      () => assertValidKaChunkProofV1(proof, finalChunk(), 524_295n, ZERO_DIGEST),
+      'proof-root-mismatch',
+    );
+    expectFailureCode(
+      () => assertKaChunkProofV1({ ...proof, chunkIndex: '3' }, 3n),
+      'proof-chunk-index',
+    );
+    expectFailureCode(
+      () => assertValidKaChunkProofV1(
+        proof,
+        new Uint8Array(262_144),
+        524_295n,
+        THREE_CHUNK_ROOT,
+      ),
+      'proof-chunk-byte-length',
+    );
+  });
+
+  it('rejects noncanonical/unknown fields and inputs over the proof byte cap', () => {
+    expectFailureCode(
+      () => parseCanonicalKaChunkProofV1(` ${THREE_CHUNK_PROOF}`, 3n),
+      'proof-schema',
+      /not RFC 8785 canonical/,
+    );
+    expectFailureCode(
+      () => assertKaChunkProofV1({
+        chunkIndex: '00',
+        steps: [{ kind: 'odd' }, { kind: 'left', digest: ZERO_DIGEST }],
+      }, 3n),
+      'proof-chunk-index',
+    );
+    expectFailureCode(
+      () => assertKaChunkProofV1({
+        chunkIndex: '2',
+        steps: [{ kind: 'odd' }, { kind: 'left', digest: ZERO_DIGEST, extra: true }],
+      }, 3n),
+      'proof-schema',
+    );
+    expectFailureCode(
+      () => parseCanonicalKaChunkProofV1('x'.repeat(MAX_KA_CHUNK_PROOF_BYTES_V1 + 1), 1n),
+      'proof-object-too-large',
+    );
+  });
+
+  it('accepts the largest topology under the 1,280-byte proof cap', () => {
+    const proof: KaChunkProofV1 = {
+      chunkIndex: '4095' as IndexV1,
+      steps: Array.from({ length: 12 }, () => ({ kind: 'left', digest: ZERO_DIGEST })),
+    };
+    assertKaChunkProofV1(proof, 4096n);
+    const canonical = canonicalizeKaChunkProofV1(proof, 4096n);
+    expect(new TextEncoder().encode(canonical).byteLength).toBe(1159);
+    expect(parseCanonicalKaChunkProofV1(canonical, 4096n)).toEqual(proof);
+  });
+
+  it('rejects invalid chunk-count bounds and hostile backing memory', () => {
+    expectFailureCode(
+      () => assertKaChunkProofV1({ chunkIndex: '0', steps: [] }, 0n),
+      'proof-chunk-count',
+    );
+    expectFailureCode(
+      () => assertKaChunkProofV1({ chunkIndex: '0', steps: [] }, 4097n),
+      'proof-chunk-count',
+    );
+    const shared = new Uint8Array(new SharedArrayBuffer(7));
+    expect(() => assertValidKaChunkProofV1(
+      parseCanonicalKaChunkProofV1(THREE_CHUNK_PROOF, 3n),
+      shared,
+      524_295n,
+      THREE_CHUNK_ROOT,
+    )).toThrow(/shared backing memory/);
+  });
+});
+
+function fixtureBundle(chunkCount: number): Uint8Array {
+  const chunks = Array.from({ length: chunkCount - 1 }, (_, index) => fullChunk(index));
+  chunks.push(finalChunk());
+  return concat(...chunks);
+}
+
+function fullChunk(index: number): Uint8Array {
+  const chunk = new Uint8Array(262_144);
+  chunk.fill(index);
+  return chunk;
+}
+
+function finalChunk(): Uint8Array {
+  return fromHex('a0a1a2a3a4a5a6');
+}
+
+function concat(...chunks: readonly Uint8Array[]): Uint8Array {
+  const bytes = new Uint8Array(chunks.reduce((sum, chunk) => sum + chunk.byteLength, 0));
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes;
+}
+
+function expectFailureCode(
+  operation: () => unknown,
+  expected: KaChunkProofV1ErrorCode,
+  message?: RegExp,
+): void {
+  try {
+    operation();
+  } catch (error) {
+    expect(error).toBeInstanceOf(Error);
+    if (message?.test((error as Error).message)) return;
+    expect((error as Error & { code?: unknown }).code).toBe(expected);
+    return;
+  }
+  throw new Error(`expected operation to fail with ${expected}`);
+}
+
+function fromHex(hex: string): Uint8Array {
+  if (hex.length % 2 !== 0 || !/^[0-9a-f]*$/.test(hex)) throw new Error('invalid test hex');
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let index = 0; index < bytes.length; index += 1) {
+    bytes[index] = Number.parseInt(hex.slice(index * 2, index * 2 + 2), 16);
+  }
+  return bytes;
+}

--- a/packages/core/test/ka-chunk-proof.test.ts
+++ b/packages/core/test/ka-chunk-proof.test.ts
@@ -21,6 +21,17 @@ const THREE_CHUNK_PROOF =
   '{"chunkIndex":"2","steps":[{"kind":"odd"},{"digest":"0x12b230a0573621cb375b62f8f3f46cc6e8c05d3d0a84a50cd5d097132f86f58e","kind":"left"}]}';
 
 describe('RFC-64 dormant KA chunk proof codec', () => {
+  it('builds and verifies the canonical single-chunk empty proof', () => {
+    const bundle = new Uint8Array(16);
+    const root = computeKaChunkTreeRootV1(bundle);
+    const proof = buildKaChunkProofV1(bundle, 0n);
+    expect(canonicalizeKaChunkProofV1(proof, 1n))
+      .toBe('{"chunkIndex":"0","steps":[]}');
+    expect(proof).toEqual({ chunkIndex: '0', steps: [] });
+    const parsed = parseCanonicalKaChunkProofV1('{"chunkIndex":"0","steps":[]}', 1n);
+    expect(() => assertValidKaChunkProofV1(parsed, bundle, 16n, root)).not.toThrow();
+  });
+
   it('builds, canonicalizes, parses, and verifies the exact three-chunk vector', () => {
     const bundle = fixtureBundle(3);
     const proof = buildKaChunkProofV1(bundle, 2n);

--- a/packages/core/test/ka-transfer-descriptor.test.ts
+++ b/packages/core/test/ka-transfer-descriptor.test.ts
@@ -6,6 +6,7 @@ import {
   assertKaTransferDescriptorV1,
   canonicalizeKaTransferDescriptorBytesV1,
   canonicalizeKaTransferDescriptorV1,
+  computeKaTransferIdentityDigestV1,
   parseCanonicalKaTransferDescriptorV1,
   type KaTransferDescriptorV1,
 } from '../src/ka-transfer-descriptor.js';
@@ -30,6 +31,8 @@ const VALID_MIN_CANONICAL =
   '{"blobDigest":"0x1111111111111111111111111111111111111111111111111111111111111111","byteLength":"16","chunkCount":"1","chunkSize":"262144","chunkTreeRoot":"0x2222222222222222222222222222222222222222222222222222222222222222","codec":"dkg-ka-bundle-v1","projectionDigest":"0x0000000000000000000000000000000000000000000000000000000000000000","projectionId":"cg-shared-v1"}';
 const VALID_MIN_FIXTURE_SHA256 =
   'd3f1088dd50f7077865e8cf49e4e22d0aedba63720faa025ec8c89537cb7c80a';
+const VALID_MIN_TRANSFER_IDENTITY_DIGEST =
+  '0x007c995fd7d001736d39af9f2d3c79177c99b55682a1ff4d002fbc3e0345db25';
 
 describe('KaTransferDescriptorV1', () => {
   it('pins the exact canonical valid-min fixture and independent fixture digest', () => {
@@ -37,6 +40,9 @@ describe('KaTransferDescriptorV1', () => {
     const bytes = canonicalizeKaTransferDescriptorBytesV1(VALID_MIN);
     expect(bytes.byteLength).toBe(369);
     expect(lowerHex(sha256(bytes))).toBe(VALID_MIN_FIXTURE_SHA256);
+    expect(computeKaTransferIdentityDigestV1(VALID_MIN)).toBe(
+      VALID_MIN_TRANSFER_IDENTITY_DIGEST,
+    );
     expect(parseCanonicalKaTransferDescriptorV1(bytes)).toEqual(VALID_MIN);
   });
 


### PR DESCRIPTION
## Summary

Adds the dormant RFC-64 proof and resume-identity layer on top of #1793:

- exact closed `KaChunkProofV1` schema and topology-derived verification
- bounded canonical proof decoding and 1-16 sorted unique proof requests
- one-pass batched provider proof construction
- descriptor-exact `transferIdentityDigest` for safe persisted chunk reuse
- public core exports for bundle, tree, and proof primitives
- fail-closed handling of hostile arrays and inherited iterators

It does not wire network handlers or persistence yet.

## Verification

- focused descriptor/tree/proof tests: 43/43
- full core suite: 90 files / 1,337 tests
- `pnpm --filter @origintrail-official/dkg-core build`
- independent security/code audit: clean

Contract: OriginTrail/dkgv10-spec#144 at e27fd39.