### PR TITLE
feat(core): add RFC-64 author catalog primitives

### DIFF
--- a/packages/core/src/author-catalog-codec.ts
+++ b/packages/core/src/author-catalog-codec.ts
@@ -233,7 +233,7 @@ export function buildCatalogAssertionSubjectV1(
   assertionCoordinate: AssertionCoordinateV1,
 ): CatalogAssertionSubjectV1 {
   assertCatalogLaneV1(lane);
-  assertCatalogScalar(() => assertCanonicalEvmAddress(authorAddress, 'authorAddress'));
+  assertCatalogEvmAddress(authorAddress, 'authorAddress');
   assertAssertionCoordinateV1(assertionCoordinate);
   return (
     `did:dkg:context-graph:${buildCatalogAssertionScopeV1(lane)}`
@@ -263,7 +263,7 @@ export function assertAuthorCatalogScopeV1(
   assertNetworkIdV1(scope.networkId);
   assertContextGraphIdV1(scope.contextGraphId);
   if (scope.subGraphName !== null) assertSubGraphNameV1(scope.subGraphName);
-  assertCatalogScalar(() => assertCanonicalEvmAddress(scope.authorAddress, 'authorAddress'));
+  assertCatalogEvmAddress(scope.authorAddress, 'authorAddress');
   assertCatalogU64(scope.era, 'era');
   assertAuthorCatalogBucketCountV1(scope.bucketCount);
 
@@ -276,17 +276,17 @@ export function assertAuthorCatalogScopeV1(
     );
   }
   if (!chainIsNull) {
-    assertCatalogScalar(() => assertCanonicalChainId(scope.governanceChainId, 'governanceChainId'));
-    assertCatalogScalar(() => assertCanonicalEvmAddress(
+    assertCatalogChainId(scope.governanceChainId, 'governanceChainId');
+    assertCatalogEvmAddress(
       scope.governanceContractAddress,
       'governanceContractAddress',
-    ));
+    );
   }
   if (scope.ownershipTransitionDigest !== null) {
-    assertCatalogScalar(() => assertCanonicalDigest(
+    assertCatalogDigest(
       scope.ownershipTransitionDigest,
       'ownershipTransitionDigest',
-    ));
+    );
   }
 }
 
@@ -325,7 +325,7 @@ export function computeAuthorCatalogScopeDigestV1(
 }
 
 export function computeAuthorCatalogKeyDigestV1(kaId: KaIdV1): Digest32V1 {
-  assertCatalogScalar(() => assertCanonicalKaId(kaId, 'kaId'));
+  assertCatalogKaId(kaId, 'kaId');
   const canonical = canonicalizeJson({ kaId } as CanonicalJsonValue, {
     maxBytes: 128,
     maxDepth: 1,
@@ -364,7 +364,7 @@ export function catalogKeyDigestToBucketIdV1(
   catalogKeyDigest: Digest32V1,
   bucketCount: CountV1,
 ): DecimalU64V1 {
-  assertCatalogScalar(() => assertCanonicalDigest(catalogKeyDigest, 'catalogKeyDigest'));
+  assertCatalogDigest(catalogKeyDigest, 'catalogKeyDigest');
   assertAuthorCatalogBucketCountV1(bucketCount);
   const count = BigInt(bucketCount);
   if (count === 1n) return '0' as DecimalU64V1;
@@ -404,14 +404,14 @@ export function assertAuthorCatalogRowV1(
     'transfer',
   ], 'author catalog row');
 
-  assertCatalogScalar(() => assertCanonicalKaId(row.kaId, 'kaId'));
+  assertCatalogKaId(row.kaId, 'kaId');
   assertAssertionCoordinateV1(row.assertionCoordinate);
   assertCatalogPositiveU64(row.assertionVersion, 'assertionVersion');
   if (row.projectionId !== KA_TRANSFER_PROJECTION_V1) {
     fail('catalog-schema', `projectionId must be ${KA_TRANSFER_PROJECTION_V1}`);
   }
-  assertCatalogScalar(() => assertCanonicalDigest(row.projectionDigest, 'projectionDigest'));
-  assertCatalogScalar(() => assertCanonicalDigest(row.sealDigest, 'sealDigest'));
+  assertCatalogDigest(row.projectionDigest, 'projectionDigest');
+  assertCatalogDigest(row.sealDigest, 'sealDigest');
 
   try {
     assertKaTransferDescriptorV1(row.transfer);
@@ -458,7 +458,7 @@ export function computeAuthorCatalogRowDigestV1(
   catalogScopeDigest: Digest32V1,
   row: AuthorCatalogRowV1,
 ): Digest32V1 {
-  assertCatalogScalar(() => assertCanonicalDigest(catalogScopeDigest, 'catalogScopeDigest'));
+  assertCatalogDigest(catalogScopeDigest, 'catalogScopeDigest');
   assertAuthorCatalogRowV1(row);
   const canonical = canonicalizeJson(
     { catalogScopeDigest, row } as unknown as CanonicalJsonValue,
@@ -476,7 +476,7 @@ export function assertPackedKaIdAuthorBindingV1(
   authorAddress: EvmAddressV1,
 ): void {
   const packedKaId = parseCatalogU256(kaId, 'kaId');
-  assertCatalogScalar(() => assertCanonicalEvmAddress(authorAddress, 'authorAddress'));
+  assertCatalogEvmAddress(authorAddress, 'authorAddress');
   const packedAuthor = packedKaId >> PACKED_KA_NUMBER_BITS_V1;
   if (packedAuthor !== BigInt(authorAddress)) {
     fail(
@@ -594,9 +594,30 @@ function assertClosedKeys(
   }
 }
 
-function assertCatalogScalar(operation: () => void): void {
+function assertCatalogEvmAddress(value: unknown, label: string): void {
   try {
-    operation();
+    assertCanonicalEvmAddress(value, label);
+  } catch (cause) {
+    fail('catalog-scalar', 'catalog scalar is not canonical', cause);
+  }
+}
+function assertCatalogChainId(value: unknown, label: string): void {
+  try {
+    assertCanonicalChainId(value, label);
+  } catch (cause) {
+    fail('catalog-scalar', 'catalog scalar is not canonical', cause);
+  }
+}
+function assertCatalogDigest(value: unknown, label: string): void {
+  try {
+    assertCanonicalDigest(value, label);
+  } catch (cause) {
+    fail('catalog-scalar', 'catalog scalar is not canonical', cause);
+  }
+}
+function assertCatalogKaId(value: unknown, label: string): void {
+  try {
+    assertCanonicalKaId(value, label);
   } catch (cause) {
     fail('catalog-scalar', 'catalog scalar is not canonical', cause);
   }

--- a/packages/core/src/author-catalog-codec.ts
+++ b/packages/core/src/author-catalog-codec.ts
@@ -319,25 +319,20 @@ export function parseCanonicalAuthorCatalogScopeV1(
   input: string | Uint8Array,
   options: StrictJsonParseOptions = {},
 ): AuthorCatalogScopeV1 {
-  rejectOversizedWireInput(input, MAX_AUTHOR_CATALOG_SCOPE_BYTES_V1, 'author catalog scope');
-  const parsed = parseCanonicalJson(input, {
-    ...options,
-    maxBytes: Math.min(
-      options.maxBytes ?? MAX_AUTHOR_CATALOG_SCOPE_BYTES_V1,
-      MAX_AUTHOR_CATALOG_SCOPE_BYTES_V1,
-    ),
-    maxDepth: Math.min(options.maxDepth ?? 1, 1),
-  });
-  assertAuthorCatalogScopeV1(parsed);
-  return parsed;
+  return parseBoundedCatalogCanonicalV1<AuthorCatalogScopeV1>(
+    input,
+    options,
+    { maxBytes: MAX_AUTHOR_CATALOG_SCOPE_BYTES_V1, maxDepth: 1, label: 'author catalog scope' },
+    (value) => assertAuthorCatalogScopeV1(value),
+  );
 }
 
 export function computeAuthorCatalogScopeDigestV1(
   scope: AuthorCatalogScopeV1,
 ): Digest32V1 {
-  return digestWithDomain(
+  return digestCatalogCanonicalV1(
     SCOPE_DOMAIN_BYTES,
-    UTF8.encode(canonicalizeAuthorCatalogScopeV1(scope)),
+    canonicalizeAuthorCatalogScopeV1(scope),
   );
 }
 
@@ -347,7 +342,7 @@ export function computeAuthorCatalogKeyDigestV1(kaId: KaIdV1): Digest32V1 {
     maxBytes: 128,
     maxDepth: 1,
   });
-  return digestWithDomain(KEY_DOMAIN_BYTES, UTF8.encode(canonical));
+  return digestCatalogCanonicalV1(KEY_DOMAIN_BYTES, canonical);
 }
 
 /** Compare canonical u256 KA identifiers by mathematical value, never lexically. */
@@ -458,17 +453,12 @@ export function parseCanonicalAuthorCatalogRowV1(
   input: string | Uint8Array,
   options: StrictJsonParseOptions = {},
 ): AuthorCatalogRowV1 {
-  rejectOversizedWireInput(input, MAX_AUTHOR_CATALOG_ROW_BYTES_V1, 'author catalog row');
-  const parsed = parseCanonicalJson(input, {
-    ...options,
-    maxBytes: Math.min(
-      options.maxBytes ?? MAX_AUTHOR_CATALOG_ROW_BYTES_V1,
-      MAX_AUTHOR_CATALOG_ROW_BYTES_V1,
-    ),
-    maxDepth: Math.min(options.maxDepth ?? 2, 2),
-  });
-  assertAuthorCatalogRowV1(parsed);
-  return parsed;
+  return parseBoundedCatalogCanonicalV1<AuthorCatalogRowV1>(
+    input,
+    options,
+    { maxBytes: MAX_AUTHOR_CATALOG_ROW_BYTES_V1, maxDepth: 2, label: 'author catalog row' },
+    (value) => assertAuthorCatalogRowV1(value),
+  );
 }
 
 export function computeAuthorCatalogRowDigestV1(
@@ -481,7 +471,7 @@ export function computeAuthorCatalogRowDigestV1(
     { catalogScopeDigest, row } as unknown as CanonicalJsonValue,
     { maxBytes: MAX_AUTHOR_CATALOG_ROW_DIGEST_INPUT_BYTES_V1, maxDepth: 3 },
   );
-  return digestWithDomain(ROW_DOMAIN_BYTES, UTF8.encode(canonical));
+  return digestCatalogCanonicalV1(ROW_DOMAIN_BYTES, canonical);
 }
 
 /**
@@ -672,6 +662,41 @@ function digestWithDomain(domain: Uint8Array, canonicalBytes: Uint8Array): Diges
   for (const byte of hasher.digest()) result += byte.toString(16).padStart(2, '0');
   assertCanonicalDigest(result, 'computed catalog digest');
   return result;
+}
+
+/**
+ * Domain-separated digest of an ALREADY-canonicalized catalog payload string.
+ * A pure tail wrapper over digestWithDomain — canonicalization (with each
+ * object's own byte/depth limits) stays at the call site, so this changes no
+ * digest input.
+ */
+function digestCatalogCanonicalV1(domain: Uint8Array, canonicalString: string): Digest32V1 {
+  return digestWithDomain(domain, UTF8.encode(canonicalString));
+}
+
+/**
+ * Shared bounded-canonical parse choreography for catalog wire objects: reject
+ * oversized wire input, clamp caller parse options to the object's limits, parse
+ * canonical JSON, then run the schema assertion. Limits, error codes, and
+ * canonical behavior are identical to the previous per-object copies; callers
+ * supply their own {maxBytes, maxDepth, label} and validator. Kept local to this
+ * module — a package-wide extraction into canonical-json.ts belongs to that
+ * codec's own PR.
+ */
+function parseBoundedCatalogCanonicalV1<T>(
+  input: string | Uint8Array,
+  options: StrictJsonParseOptions,
+  limits: { maxBytes: number; maxDepth: number; label: string },
+  assert: (value: unknown) => void,
+): T {
+  rejectOversizedWireInput(input, limits.maxBytes, limits.label);
+  const parsed = parseCanonicalJson(input, {
+    ...options,
+    maxBytes: Math.min(options.maxBytes ?? limits.maxBytes, limits.maxBytes),
+    maxDepth: Math.min(options.maxDepth ?? limits.maxDepth, limits.maxDepth),
+  });
+  assert(parsed);
+  return parsed as T;
 }
 
 function rejectOversizedWireInput(

--- a/packages/core/src/author-catalog-codec.ts
+++ b/packages/core/src/author-catalog-codec.ts
@@ -86,16 +86,27 @@ export interface CatalogLaneV1 {
   readonly subGraphName: SubGraphNameV1 | null;
 }
 
-/** Exact nine-key scope committed by every author-catalog era. */
-export interface AuthorCatalogScopeV1 extends CatalogLaneV1 {
+/**
+ * Governance tuple for an author-catalog scope: either both fields identify the
+ * registering contract, or both are null (unregistered). Expressing the
+ * paired-null invariant in the type makes the impossible mixed state
+ * unrepresentable; the canonical wire object always carries both keys.
+ */
+export type AuthorCatalogGovernanceV1 =
+  | { readonly governanceChainId: null; readonly governanceContractAddress: null }
+  | { readonly governanceChainId: ChainIdV1; readonly governanceContractAddress: EvmAddressV1 };
+
+/** Common author-catalog scope fields shared by both governance variants. */
+export interface AuthorCatalogScopeFieldsV1 extends CatalogLaneV1 {
   readonly networkId: NetworkIdV1;
-  readonly governanceChainId: ChainIdV1 | null;
-  readonly governanceContractAddress: EvmAddressV1 | null;
   readonly ownershipTransitionDigest: Digest32V1 | null;
   readonly authorAddress: EvmAddressV1;
   readonly era: DecimalU64V1;
   readonly bucketCount: CountV1;
 }
+
+/** Exact nine-key scope committed by every author-catalog era. */
+export type AuthorCatalogScopeV1 = AuthorCatalogScopeFieldsV1 & AuthorCatalogGovernanceV1;
 
 /** Exact seven-key live author-catalog row. */
 export interface AuthorCatalogRowV1 {
@@ -197,8 +208,14 @@ export function isCatalogForbiddenCodePointV1(codePoint: number): boolean {
   );
 }
 
-/** Percent-encode one already canonical catalog-v1 identifier component. */
-export function iriComponentV1(value: string): string {
+/**
+ * Low-level UTF-8 percent-encoder for one catalog path component. Kept private:
+ * it validates only NFC/byte-length, not the catalog identifier grammar, so it
+ * must only be called with values already checked by the component validators
+ * (context-graph id, subgraph name, assertion coordinate). Public callers go
+ * through the higher-level builders below.
+ */
+function percentEncodeUtf8Component(value: string): string {
   const identifier = assertNfcUtf8Identifier(
     value,
     'IRI component',
@@ -219,10 +236,10 @@ export function iriComponentV1(value: string): string {
 /** Build the prefix-free root/subgraph assertion scope used by catalog-v1 seals. */
 export function buildCatalogAssertionScopeV1(lane: CatalogLaneV1): CatalogAssertionScopeV1 {
   assertCatalogLaneV1(lane);
-  const context = iriComponentV1(lane.contextGraphId);
+  const context = percentEncodeUtf8Component(lane.contextGraphId);
   const result = lane.subGraphName === null
     ? `v1/root/${context}`
-    : `v1/subgraph/${context}/${iriComponentV1(lane.subGraphName)}`;
+    : `v1/subgraph/${context}/${percentEncodeUtf8Component(lane.subGraphName)}`;
   return result as CatalogAssertionScopeV1;
 }
 
@@ -237,7 +254,7 @@ export function buildCatalogAssertionSubjectV1(
   assertAssertionCoordinateV1(assertionCoordinate);
   return (
     `did:dkg:context-graph:${buildCatalogAssertionScopeV1(lane)}`
-    + `/assertion/${authorAddress}/${iriComponentV1(assertionCoordinate)}`
+    + `/assertion/${authorAddress}/${percentEncodeUtf8Component(assertionCoordinate)}`
   ) as CatalogAssertionSubjectV1;
 }
 

--- a/packages/core/src/author-catalog-codec.ts
+++ b/packages/core/src/author-catalog-codec.ts
@@ -1,0 +1,657 @@
+import { sha256 } from '@noble/hashes/sha2.js';
+
+import {
+  canonicalizeJson,
+  parseCanonicalJson,
+  type CanonicalJsonValue,
+  type StrictJsonParseOptions,
+} from './canonical-json.js';
+import {
+  KA_TRANSFER_PROJECTION_V1,
+  assertKaTransferDescriptorV1,
+  type KaTransferDescriptorV1,
+} from './ka-transfer-descriptor.js';
+import {
+  assertCanonicalChainId,
+  assertCanonicalDigest,
+  assertCanonicalEvmAddress,
+  assertCanonicalKaId,
+  parseCanonicalDecimalU64,
+  parseCanonicalDecimalU256,
+  type ChainIdV1,
+  type CountV1,
+  type DecimalU64V1,
+  type Digest32V1,
+  type EvmAddressV1,
+  type KaIdV1,
+} from './sync-wire-scalars.js';
+import { assertExactKeys, isPlainRecord } from './sync-wire-objects.js';
+
+declare const NETWORK_ID_V1_BRAND: unique symbol;
+declare const CONTEXT_GRAPH_ID_V1_BRAND: unique symbol;
+declare const SUBGRAPH_NAME_V1_BRAND: unique symbol;
+declare const ASSERTION_COORDINATE_V1_BRAND: unique symbol;
+declare const CATALOG_ASSERTION_SCOPE_V1_BRAND: unique symbol;
+declare const CATALOG_ASSERTION_SUBJECT_V1_BRAND: unique symbol;
+
+export type NetworkIdV1 = string & { readonly [NETWORK_ID_V1_BRAND]: true };
+export type ContextGraphIdV1 = string & { readonly [CONTEXT_GRAPH_ID_V1_BRAND]: true };
+export type SubGraphNameV1 = string & { readonly [SUBGRAPH_NAME_V1_BRAND]: true };
+export type AssertionCoordinateV1 = string & {
+  readonly [ASSERTION_COORDINATE_V1_BRAND]: true;
+};
+export type CatalogAssertionScopeV1 = string & {
+  readonly [CATALOG_ASSERTION_SCOPE_V1_BRAND]: true;
+};
+export type CatalogAssertionSubjectV1 = string & {
+  readonly [CATALOG_ASSERTION_SUBJECT_V1_BRAND]: true;
+};
+
+export const AUTHOR_CATALOG_SCOPE_DIGEST_DOMAIN_V1 =
+  'dkg-author-catalog-scope-v1\n' as const;
+export const AUTHOR_CATALOG_KEY_DIGEST_DOMAIN_V1 =
+  'dkg-author-catalog-key-v1\n' as const;
+export const AUTHOR_CATALOG_ROW_DIGEST_DOMAIN_V1 =
+  'dkg-author-catalog-row-v1\n' as const;
+
+export const MAX_AUTHOR_CATALOG_NETWORK_ID_BYTES_V1 = 128;
+export const MAX_AUTHOR_CATALOG_IDENTIFIER_BYTES_V1 = 256;
+export const MAX_AUTHOR_CATALOG_SCOPE_BYTES_V1 = 2048;
+export const MAX_AUTHOR_CATALOG_ROW_BYTES_V1 = 2048;
+export const MAX_AUTHOR_CATALOG_ROW_DIGEST_INPUT_BYTES_V1 = 4096;
+export const MAX_AUTHOR_CATALOG_BUCKET_COUNT_V1 = 9_223_372_036_854_775_808n;
+export const PACKED_KA_NUMBER_BITS_V1 = 96n;
+
+const NETWORK_ID_PATTERN = /^[A-Za-z0-9._:-]+$/;
+const CONTEXT_GRAPH_ID_PATTERN = /^[A-Za-z0-9_:/\.@-]+$/;
+const CATALOG_IDENTIFIER_ASCII_FORBIDDEN = new Set([
+  '<',
+  '>',
+  '"',
+  '{',
+  '}',
+  '|',
+  '^',
+  '`',
+  '\\',
+]);
+const RESERVED_SUBGRAPH_NAMES = new Set(['context', 'assertion', 'draft']);
+const UTF8 = new TextEncoder();
+const SCOPE_DOMAIN_BYTES = UTF8.encode(AUTHOR_CATALOG_SCOPE_DIGEST_DOMAIN_V1);
+const KEY_DOMAIN_BYTES = UTF8.encode(AUTHOR_CATALOG_KEY_DIGEST_DOMAIN_V1);
+const ROW_DOMAIN_BYTES = UTF8.encode(AUTHOR_CATALOG_ROW_DIGEST_DOMAIN_V1);
+
+export interface CatalogLaneV1 {
+  readonly contextGraphId: ContextGraphIdV1;
+  readonly subGraphName: SubGraphNameV1 | null;
+}
+
+/** Exact nine-key scope committed by every author-catalog era. */
+export interface AuthorCatalogScopeV1 extends CatalogLaneV1 {
+  readonly networkId: NetworkIdV1;
+  readonly governanceChainId: ChainIdV1 | null;
+  readonly governanceContractAddress: EvmAddressV1 | null;
+  readonly ownershipTransitionDigest: Digest32V1 | null;
+  readonly authorAddress: EvmAddressV1;
+  readonly era: DecimalU64V1;
+  readonly bucketCount: CountV1;
+}
+
+/** Exact seven-key live author-catalog row. */
+export interface AuthorCatalogRowV1 {
+  readonly kaId: KaIdV1;
+  readonly assertionCoordinate: AssertionCoordinateV1;
+  readonly assertionVersion: DecimalU64V1;
+  readonly projectionId: typeof KA_TRANSFER_PROJECTION_V1;
+  readonly projectionDigest: Digest32V1;
+  readonly sealDigest: Digest32V1;
+  readonly transfer: KaTransferDescriptorV1;
+}
+
+export type AuthorCatalogCodecErrorCode =
+  | 'catalog-schema'
+  | 'catalog-identifier'
+  | 'catalog-scalar'
+  | 'catalog-governance-tuple'
+  | 'catalog-bucket-count'
+  | 'catalog-transfer-mismatch'
+  | 'catalog-packed-author-mismatch'
+  | 'object-too-large';
+
+export class AuthorCatalogCodecError extends Error {
+  constructor(
+    readonly code: AuthorCatalogCodecErrorCode,
+    message: string,
+    options: ErrorOptions = {},
+  ) {
+    super(`[${code}] ${message}`, options);
+    this.name = 'AuthorCatalogCodecError';
+  }
+}
+
+export function assertNetworkIdV1(
+  value: unknown,
+  label = 'networkId',
+): asserts value is NetworkIdV1 {
+  const identifier = assertNfcUtf8Identifier(
+    value,
+    label,
+    MAX_AUTHOR_CATALOG_NETWORK_ID_BYTES_V1,
+  );
+  if (!NETWORK_ID_PATTERN.test(identifier)) {
+    fail('catalog-identifier', `${label} contains a character outside the networkId grammar`);
+  }
+}
+
+export function assertContextGraphIdV1(
+  value: unknown,
+  label = 'contextGraphId',
+): asserts value is ContextGraphIdV1 {
+  const identifier = assertNfcUtf8Identifier(
+    value,
+    label,
+    MAX_AUTHOR_CATALOG_IDENTIFIER_BYTES_V1,
+  );
+  if (!CONTEXT_GRAPH_ID_PATTERN.test(identifier)) {
+    fail(
+      'catalog-identifier',
+      `${label} contains a character outside the contextGraphId grammar`,
+    );
+  }
+}
+
+export function assertSubGraphNameV1(
+  value: unknown,
+  label = 'subGraphName',
+): asserts value is SubGraphNameV1 {
+  const identifier = assertCatalogLaneIdentifier(value, label);
+  if (identifier.startsWith('_')) {
+    fail('catalog-identifier', `${label} must not start with underscore`);
+  }
+  if (RESERVED_SUBGRAPH_NAMES.has(identifier)) {
+    fail('catalog-identifier', `${label} is a reserved subgraph name`);
+  }
+}
+
+export function assertAssertionCoordinateV1(
+  value: unknown,
+  label = 'assertionCoordinate',
+): asserts value is AssertionCoordinateV1 {
+  assertCatalogLaneIdentifier(value, label);
+}
+
+/** Exact RFC-64 forbidden-code-point predicate, intentionally permitting U+200C. */
+export function isCatalogForbiddenCodePointV1(codePoint: number): boolean {
+  return (
+    (codePoint >= 0x0000 && codePoint <= 0x001f)
+    || (codePoint >= 0x007f && codePoint <= 0x009f)
+    || codePoint === 0x00a0
+    || codePoint === 0x1680
+    || (codePoint >= 0x2000 && codePoint <= 0x200b)
+    || codePoint === 0x2028
+    || codePoint === 0x2029
+    || codePoint === 0x202f
+    || codePoint === 0x205f
+    || codePoint === 0x3000
+    || codePoint === 0xfeff
+  );
+}
+
+/** Percent-encode one already canonical catalog-v1 identifier component. */
+export function iriComponentV1(value: string): string {
+  const identifier = assertNfcUtf8Identifier(
+    value,
+    'IRI component',
+    MAX_AUTHOR_CATALOG_IDENTIFIER_BYTES_V1,
+  );
+  const bytes = UTF8.encode(identifier);
+  let encoded = '';
+  for (const byte of bytes) {
+    if (isUnescapedIriComponentByte(byte)) {
+      encoded += String.fromCharCode(byte);
+    } else {
+      encoded += `%${byte.toString(16).toUpperCase().padStart(2, '0')}`;
+    }
+  }
+  return encoded;
+}
+
+/** Build the prefix-free root/subgraph assertion scope used by catalog-v1 seals. */
+export function buildCatalogAssertionScopeV1(lane: CatalogLaneV1): CatalogAssertionScopeV1 {
+  assertCatalogLaneV1(lane);
+  const context = iriComponentV1(lane.contextGraphId);
+  const result = lane.subGraphName === null
+    ? `v1/root/${context}`
+    : `v1/subgraph/${context}/${iriComponentV1(lane.subGraphName)}`;
+  return result as CatalogAssertionScopeV1;
+}
+
+/** Build the exact graph-scoped author-seal subject for one catalog row. */
+export function buildCatalogAssertionSubjectV1(
+  lane: CatalogLaneV1,
+  authorAddress: EvmAddressV1,
+  assertionCoordinate: AssertionCoordinateV1,
+): CatalogAssertionSubjectV1 {
+  assertCatalogLaneV1(lane);
+  assertCatalogScalar(() => assertCanonicalEvmAddress(authorAddress, 'authorAddress'));
+  assertAssertionCoordinateV1(assertionCoordinate);
+  return (
+    `did:dkg:context-graph:${buildCatalogAssertionScopeV1(lane)}`
+    + `/assertion/${authorAddress}/${iriComponentV1(assertionCoordinate)}`
+  ) as CatalogAssertionSubjectV1;
+}
+
+/** Validate the complete in-memory catalog scope without signing or authority checks. */
+export function assertAuthorCatalogScopeV1(
+  scope: unknown,
+): asserts scope is AuthorCatalogScopeV1 {
+  if (!isPlainRecord(scope)) {
+    fail('catalog-schema', 'author catalog scope must be a plain JSON object');
+  }
+  assertClosedKeys(scope, [
+    'authorAddress',
+    'bucketCount',
+    'contextGraphId',
+    'era',
+    'governanceChainId',
+    'governanceContractAddress',
+    'networkId',
+    'ownershipTransitionDigest',
+    'subGraphName',
+  ], 'author catalog scope');
+
+  assertNetworkIdV1(scope.networkId);
+  assertContextGraphIdV1(scope.contextGraphId);
+  if (scope.subGraphName !== null) assertSubGraphNameV1(scope.subGraphName);
+  assertCatalogScalar(() => assertCanonicalEvmAddress(scope.authorAddress, 'authorAddress'));
+  assertCatalogU64(scope.era, 'era');
+  assertAuthorCatalogBucketCountV1(scope.bucketCount);
+
+  const chainIsNull = scope.governanceChainId === null;
+  const contractIsNull = scope.governanceContractAddress === null;
+  if (chainIsNull !== contractIsNull) {
+    fail(
+      'catalog-governance-tuple',
+      'governanceChainId and governanceContractAddress must both be null or both be non-null',
+    );
+  }
+  if (!chainIsNull) {
+    assertCatalogScalar(() => assertCanonicalChainId(scope.governanceChainId, 'governanceChainId'));
+    assertCatalogScalar(() => assertCanonicalEvmAddress(
+      scope.governanceContractAddress,
+      'governanceContractAddress',
+    ));
+  }
+  if (scope.ownershipTransitionDigest !== null) {
+    assertCatalogScalar(() => assertCanonicalDigest(
+      scope.ownershipTransitionDigest,
+      'ownershipTransitionDigest',
+    ));
+  }
+}
+
+export function canonicalizeAuthorCatalogScopeV1(scope: AuthorCatalogScopeV1): string {
+  assertAuthorCatalogScopeV1(scope);
+  return canonicalizeJson(scope as unknown as CanonicalJsonValue, {
+    maxBytes: MAX_AUTHOR_CATALOG_SCOPE_BYTES_V1,
+    maxDepth: 1,
+  });
+}
+
+export function parseCanonicalAuthorCatalogScopeV1(
+  input: string | Uint8Array,
+  options: StrictJsonParseOptions = {},
+): AuthorCatalogScopeV1 {
+  rejectOversizedWireInput(input, MAX_AUTHOR_CATALOG_SCOPE_BYTES_V1, 'author catalog scope');
+  const parsed = parseCanonicalJson(input, {
+    ...options,
+    maxBytes: Math.min(
+      options.maxBytes ?? MAX_AUTHOR_CATALOG_SCOPE_BYTES_V1,
+      MAX_AUTHOR_CATALOG_SCOPE_BYTES_V1,
+    ),
+    maxDepth: Math.min(options.maxDepth ?? 1, 1),
+  });
+  assertAuthorCatalogScopeV1(parsed);
+  return parsed;
+}
+
+export function computeAuthorCatalogScopeDigestV1(
+  scope: AuthorCatalogScopeV1,
+): Digest32V1 {
+  return digestWithDomain(
+    SCOPE_DOMAIN_BYTES,
+    UTF8.encode(canonicalizeAuthorCatalogScopeV1(scope)),
+  );
+}
+
+export function computeAuthorCatalogKeyDigestV1(kaId: KaIdV1): Digest32V1 {
+  assertCatalogScalar(() => assertCanonicalKaId(kaId, 'kaId'));
+  const canonical = canonicalizeJson({ kaId } as CanonicalJsonValue, {
+    maxBytes: 128,
+    maxDepth: 1,
+  });
+  return digestWithDomain(KEY_DOMAIN_BYTES, UTF8.encode(canonical));
+}
+
+/** Compare canonical u256 KA identifiers by mathematical value, never lexically. */
+export function compareAuthorCatalogKaIdsV1(left: KaIdV1, right: KaIdV1): -1 | 0 | 1 {
+  const leftValue = parseCatalogU256(left, 'left kaId');
+  const rightValue = parseCatalogU256(right, 'right kaId');
+  if (leftValue < rightValue) return -1;
+  if (leftValue > rightValue) return 1;
+  return 0;
+}
+
+export function assertAuthorCatalogBucketCountV1(
+  value: unknown,
+  label = 'bucketCount',
+): asserts value is CountV1 {
+  const count = assertCatalogU64(value, label);
+  if (
+    count < 1n
+    || count > MAX_AUTHOR_CATALOG_BUCKET_COUNT_V1
+    || (count & (count - 1n)) !== 0n
+  ) {
+    fail(
+      'catalog-bucket-count',
+      `${label} must be a power of two in 1..${MAX_AUTHOR_CATALOG_BUCKET_COUNT_V1}`,
+    );
+  }
+}
+
+/** Map a key digest to the unsigned integer formed by its first log2(bucketCount) bits. */
+export function catalogKeyDigestToBucketIdV1(
+  catalogKeyDigest: Digest32V1,
+  bucketCount: CountV1,
+): DecimalU64V1 {
+  assertCatalogScalar(() => assertCanonicalDigest(catalogKeyDigest, 'catalogKeyDigest'));
+  assertAuthorCatalogBucketCountV1(bucketCount);
+  const count = BigInt(bucketCount);
+  if (count === 1n) return '0' as DecimalU64V1;
+
+  let prefixBits = 0n;
+  for (let remaining = count; remaining > 1n; remaining >>= 1n) prefixBits += 1n;
+  const bucketId = BigInt(catalogKeyDigest) >> (256n - prefixBits);
+  const result = bucketId.toString();
+  parseCanonicalDecimalU64(result, 'bucketId');
+  return result as DecimalU64V1;
+}
+
+export function catalogKeyToBucketIdV1(
+  kaId: KaIdV1,
+  bucketCount: CountV1,
+): DecimalU64V1 {
+  return catalogKeyDigestToBucketIdV1(
+    computeAuthorCatalogKeyDigestV1(kaId),
+    bucketCount,
+  );
+}
+
+/** Validate the complete in-memory row, including transfer/row projection equality. */
+export function assertAuthorCatalogRowV1(
+  row: unknown,
+): asserts row is AuthorCatalogRowV1 {
+  if (!isPlainRecord(row)) {
+    fail('catalog-schema', 'author catalog row must be a plain JSON object');
+  }
+  assertClosedKeys(row, [
+    'assertionCoordinate',
+    'assertionVersion',
+    'kaId',
+    'projectionDigest',
+    'projectionId',
+    'sealDigest',
+    'transfer',
+  ], 'author catalog row');
+
+  assertCatalogScalar(() => assertCanonicalKaId(row.kaId, 'kaId'));
+  assertAssertionCoordinateV1(row.assertionCoordinate);
+  assertCatalogU64(row.assertionVersion, 'assertionVersion');
+  if (row.projectionId !== KA_TRANSFER_PROJECTION_V1) {
+    fail('catalog-schema', `projectionId must be ${KA_TRANSFER_PROJECTION_V1}`);
+  }
+  assertCatalogScalar(() => assertCanonicalDigest(row.projectionDigest, 'projectionDigest'));
+  assertCatalogScalar(() => assertCanonicalDigest(row.sealDigest, 'sealDigest'));
+
+  try {
+    assertKaTransferDescriptorV1(row.transfer);
+  } catch (cause) {
+    fail('catalog-schema', 'transfer is not a structurally valid KaTransferDescriptorV1', cause);
+  }
+  if (
+    row.transfer.projectionId !== row.projectionId
+    || row.transfer.projectionDigest !== row.projectionDigest
+  ) {
+    fail(
+      'catalog-transfer-mismatch',
+      'transfer projectionId and projectionDigest must equal the row values',
+    );
+  }
+}
+
+export function canonicalizeAuthorCatalogRowV1(row: AuthorCatalogRowV1): string {
+  assertAuthorCatalogRowV1(row);
+  return canonicalizeJson(row as unknown as CanonicalJsonValue, {
+    maxBytes: MAX_AUTHOR_CATALOG_ROW_BYTES_V1,
+    maxDepth: 2,
+  });
+}
+
+export function parseCanonicalAuthorCatalogRowV1(
+  input: string | Uint8Array,
+  options: StrictJsonParseOptions = {},
+): AuthorCatalogRowV1 {
+  rejectOversizedWireInput(input, MAX_AUTHOR_CATALOG_ROW_BYTES_V1, 'author catalog row');
+  const parsed = parseCanonicalJson(input, {
+    ...options,
+    maxBytes: Math.min(
+      options.maxBytes ?? MAX_AUTHOR_CATALOG_ROW_BYTES_V1,
+      MAX_AUTHOR_CATALOG_ROW_BYTES_V1,
+    ),
+    maxDepth: Math.min(options.maxDepth ?? 2, 2),
+  });
+  assertAuthorCatalogRowV1(parsed);
+  return parsed;
+}
+
+export function computeAuthorCatalogRowDigestV1(
+  catalogScopeDigest: Digest32V1,
+  row: AuthorCatalogRowV1,
+): Digest32V1 {
+  assertCatalogScalar(() => assertCanonicalDigest(catalogScopeDigest, 'catalogScopeDigest'));
+  assertAuthorCatalogRowV1(row);
+  const canonical = canonicalizeJson(
+    { catalogScopeDigest, row } as unknown as CanonicalJsonValue,
+    { maxBytes: MAX_AUTHOR_CATALOG_ROW_DIGEST_INPUT_BYTES_V1, maxDepth: 3 },
+  );
+  return digestWithDomain(ROW_DOMAIN_BYTES, UTF8.encode(canonical));
+}
+
+/**
+ * Check the structural portion of Option-1 identity available without parsing a
+ * seal/UAL: the high 160 bits of the packed u256 KA id must equal the scope author.
+ */
+export function assertPackedKaIdAuthorBindingV1(
+  kaId: KaIdV1,
+  authorAddress: EvmAddressV1,
+): void {
+  const packedKaId = parseCatalogU256(kaId, 'kaId');
+  assertCatalogScalar(() => assertCanonicalEvmAddress(authorAddress, 'authorAddress'));
+  const packedAuthor = packedKaId >> PACKED_KA_NUMBER_BITS_V1;
+  if (packedAuthor !== BigInt(authorAddress)) {
+    fail(
+      'catalog-packed-author-mismatch',
+      'the high 160 bits of kaId must equal authorAddress',
+    );
+  }
+}
+
+/** Validate all structural row/scope bindings available before RDF seal admission. */
+export function assertAuthorCatalogRowScopeBindingV1(
+  row: AuthorCatalogRowV1,
+  scope: AuthorCatalogScopeV1,
+): void {
+  assertAuthorCatalogRowV1(row);
+  assertAuthorCatalogScopeV1(scope);
+  assertPackedKaIdAuthorBindingV1(row.kaId, scope.authorAddress);
+}
+
+function assertCatalogLaneV1(lane: unknown): asserts lane is CatalogLaneV1 {
+  if (!isPlainRecord(lane)) {
+    fail('catalog-schema', 'catalog lane must be a plain JSON object');
+  }
+  // AuthorCatalogScopeV1 is itself a CatalogLaneV1, so these helpers must admit
+  // that structural superset. Still require the two consumed fields to be own,
+  // enumerable data properties before reading them.
+  for (const key of ['contextGraphId', 'subGraphName']) {
+    const descriptor = Object.getOwnPropertyDescriptor(lane, key);
+    if (!descriptor?.enumerable || !Object.prototype.hasOwnProperty.call(descriptor, 'value')) {
+      fail('catalog-schema', `catalog lane ${key} must be an enumerable data property`);
+    }
+  }
+  assertContextGraphIdV1(lane.contextGraphId);
+  if (lane.subGraphName !== null) assertSubGraphNameV1(lane.subGraphName);
+}
+
+function assertCatalogLaneIdentifier(value: unknown, label: string): string {
+  const identifier = assertNfcUtf8Identifier(
+    value,
+    label,
+    MAX_AUTHOR_CATALOG_IDENTIFIER_BYTES_V1,
+  );
+  for (const character of identifier) {
+    const codePoint = character.codePointAt(0) as number;
+    if (
+      character === '/'
+      || CATALOG_IDENTIFIER_ASCII_FORBIDDEN.has(character)
+      || isCatalogForbiddenCodePointV1(codePoint)
+    ) {
+      fail('catalog-identifier', `${label} contains a forbidden character or code point`);
+    }
+  }
+  return identifier;
+}
+
+function assertNfcUtf8Identifier(
+  value: unknown,
+  label: string,
+  maxBytes: number,
+): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    fail('catalog-identifier', `${label} must be a non-empty string`);
+  }
+  // UTF-8 byte length is never less than UTF-16 code-unit length. Reject a
+  // hostile oversized input before normalization or encoding allocates a copy.
+  if (value.length > maxBytes) {
+    fail('catalog-identifier', `${label} exceeds ${maxBytes} UTF-8 bytes`);
+  }
+  assertWellFormedUnicode(value, label);
+  if (value.normalize('NFC') !== value) {
+    fail('catalog-identifier', `${label} must already be NFC-normalized`);
+  }
+  if (UTF8.encode(value).byteLength > maxBytes) {
+    fail('catalog-identifier', `${label} exceeds ${maxBytes} UTF-8 bytes`);
+  }
+  return value;
+}
+
+function assertWellFormedUnicode(value: string, label: string): void {
+  for (let index = 0; index < value.length; index += 1) {
+    const unit = value.charCodeAt(index);
+    if (unit >= 0xd800 && unit <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+        fail('catalog-identifier', `${label} contains an unpaired UTF-16 surrogate`);
+      }
+      index += 1;
+    } else if (unit >= 0xdc00 && unit <= 0xdfff) {
+      fail('catalog-identifier', `${label} contains an unpaired UTF-16 surrogate`);
+    }
+  }
+}
+
+function isUnescapedIriComponentByte(byte: number): boolean {
+  return (
+    (byte >= 0x41 && byte <= 0x5a)
+    || (byte >= 0x61 && byte <= 0x7a)
+    || (byte >= 0x30 && byte <= 0x39)
+    || byte === 0x2d
+    || byte === 0x2e
+    || byte === 0x5f
+    || byte === 0x7e
+  );
+}
+
+function assertClosedKeys(
+  record: Record<string, unknown>,
+  keys: readonly string[],
+  label: string,
+): void {
+  try {
+    assertExactKeys(record, keys, label);
+  } catch (cause) {
+    fail('catalog-schema', `${label} has an invalid field set`, cause);
+  }
+}
+
+function assertCatalogScalar(operation: () => void): void {
+  try {
+    operation();
+  } catch (cause) {
+    fail('catalog-scalar', 'catalog scalar is not canonical', cause);
+  }
+}
+
+function assertCatalogU64(value: unknown, label: string): bigint {
+  try {
+    return parseCanonicalDecimalU64(value, label);
+  } catch (cause) {
+    fail('catalog-scalar', `${label} is not a canonical DecimalU64V1`, cause);
+  }
+}
+
+function parseCatalogU256(value: unknown, label: string): bigint {
+  try {
+    return parseCanonicalDecimalU256(value, label);
+  } catch (cause) {
+    fail('catalog-scalar', `${label} is not a canonical DecimalU256V1`, cause);
+  }
+}
+
+function digestWithDomain(domain: Uint8Array, canonicalBytes: Uint8Array): Digest32V1 {
+  const hasher = sha256.create();
+  hasher.update(domain);
+  hasher.update(canonicalBytes);
+  let result = '0x';
+  for (const byte of hasher.digest()) result += byte.toString(16).padStart(2, '0');
+  assertCanonicalDigest(result, 'computed catalog digest');
+  return result;
+}
+
+function rejectOversizedWireInput(
+  input: string | Uint8Array,
+  maxBytes: number,
+  label: string,
+): void {
+  if (typeof input !== 'string') {
+    if (input.byteLength > maxBytes) {
+      fail('object-too-large', `${label} exceeds ${maxBytes} bytes`);
+    }
+    return;
+  }
+  if (input.length > maxBytes || UTF8.encode(input).byteLength > maxBytes) {
+    fail('object-too-large', `${label} exceeds ${maxBytes} bytes`);
+  }
+}
+
+function fail(
+  code: AuthorCatalogCodecErrorCode,
+  message: string,
+  cause?: unknown,
+): never {
+  throw new AuthorCatalogCodecError(
+    code,
+    message,
+    cause === undefined ? {} : { cause },
+  );
+}

--- a/packages/core/src/author-catalog-codec.ts
+++ b/packages/core/src/author-catalog-codec.ts
@@ -406,7 +406,7 @@ export function assertAuthorCatalogRowV1(
 
   assertCatalogScalar(() => assertCanonicalKaId(row.kaId, 'kaId'));
   assertAssertionCoordinateV1(row.assertionCoordinate);
-  assertCatalogU64(row.assertionVersion, 'assertionVersion');
+  assertCatalogPositiveU64(row.assertionVersion, 'assertionVersion');
   if (row.projectionId !== KA_TRANSFER_PROJECTION_V1) {
     fail('catalog-schema', `projectionId must be ${KA_TRANSFER_PROJECTION_V1}`);
   }
@@ -608,6 +608,14 @@ function assertCatalogU64(value: unknown, label: string): bigint {
   } catch (cause) {
     fail('catalog-scalar', `${label} is not a canonical DecimalU64V1`, cause);
   }
+}
+
+function assertCatalogPositiveU64(value: unknown, label: string): bigint {
+  const parsed = assertCatalogU64(value, label);
+  if (parsed < 1n) {
+    fail('catalog-scalar', `${label} must be a positive DecimalU64V1`);
+  }
+  return parsed;
 }
 
 function parseCatalogU256(value: unknown, label: string): bigint {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -48,6 +48,7 @@ export * from './ka-transfer-descriptor.js';
 export * from './ka-bundle-v1.js';
 export * from './ka-chunk-tree.js';
 export * from './ka-chunk-proof.js';
+export * from './author-catalog-codec.js';
 export * from './event-bus.js';
 export {
   Logger,

--- a/packages/core/test/author-catalog-codec.test.ts
+++ b/packages/core/test/author-catalog-codec.test.ts
@@ -1,0 +1,334 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  MAX_AUTHOR_CATALOG_BUCKET_COUNT_V1,
+  MAX_AUTHOR_CATALOG_ROW_BYTES_V1,
+  MAX_AUTHOR_CATALOG_ROW_DIGEST_INPUT_BYTES_V1,
+  MAX_AUTHOR_CATALOG_SCOPE_BYTES_V1,
+  assertAssertionCoordinateV1,
+  assertAuthorCatalogBucketCountV1,
+  assertAuthorCatalogRowScopeBindingV1,
+  assertAuthorCatalogRowV1,
+  assertAuthorCatalogScopeV1,
+  assertContextGraphIdV1,
+  assertNetworkIdV1,
+  assertPackedKaIdAuthorBindingV1,
+  assertSubGraphNameV1,
+  buildCatalogAssertionScopeV1,
+  buildCatalogAssertionSubjectV1,
+  canonicalizeAuthorCatalogRowV1,
+  canonicalizeAuthorCatalogScopeV1,
+  catalogKeyDigestToBucketIdV1,
+  catalogKeyToBucketIdV1,
+  compareAuthorCatalogKaIdsV1,
+  computeAuthorCatalogKeyDigestV1,
+  computeAuthorCatalogRowDigestV1,
+  computeAuthorCatalogScopeDigestV1,
+  iriComponentV1,
+  parseCanonicalAuthorCatalogRowV1,
+  parseCanonicalAuthorCatalogScopeV1,
+  type AssertionCoordinateV1,
+  type AuthorCatalogRowV1,
+  type AuthorCatalogScopeV1,
+  type CatalogLaneV1,
+  type ContextGraphIdV1,
+  type EvmAddressV1,
+  type KaIdV1,
+  type SubGraphNameV1,
+} from '../src/index.js';
+
+const ZERO_DIGEST = `0x${'00'.repeat(32)}`;
+const BLOB_DIGEST = `0x${'11'.repeat(32)}`;
+const CHUNK_TREE_ROOT = `0x${'22'.repeat(32)}`;
+const SEAL_DIGEST = `0x${'44'.repeat(32)}`;
+const AUTHOR = `0x${'33'.repeat(20)}`;
+const GOVERNANCE_CONTRACT = `0x${'22'.repeat(20)}`;
+
+const SCOPE_CANONICAL =
+  '{"authorAddress":"0x3333333333333333333333333333333333333333","bucketCount":"1","contextGraphId":"0x1111111111111111111111111111111111111111/catalog-fixture","era":"0","governanceChainId":"20430","governanceContractAddress":"0x2222222222222222222222222222222222222222","networkId":"otp:20430","ownershipTransitionDigest":null,"subGraphName":null}';
+const SCOPE_DIGEST =
+  '0x7b18d141cbb6af4e7fdabe2e4d7d0b9512b042eb079b89a4797d3a0a7f1d4537';
+
+const ROW_CANONICAL =
+  '{"assertionCoordinate":"fixture","assertionVersion":"1","kaId":"1","projectionDigest":"0x0000000000000000000000000000000000000000000000000000000000000000","projectionId":"cg-shared-v1","sealDigest":"0x4444444444444444444444444444444444444444444444444444444444444444","transfer":{"blobDigest":"0x1111111111111111111111111111111111111111111111111111111111111111","byteLength":"16","chunkCount":"1","chunkSize":"262144","chunkTreeRoot":"0x2222222222222222222222222222222222222222222222222222222222222222","codec":"dkg-ka-bundle-v1","projectionDigest":"0x0000000000000000000000000000000000000000000000000000000000000000","projectionId":"cg-shared-v1"}}';
+const ROW_DIGEST =
+  '0x14820ff6ae773dc2e6496419e059f3a423bd99572b8f828de01deedbec76aad7';
+const KEY_DIGEST =
+  '0x3e8dfe2886837263349072315b5308d53ed04a8593c7c74124bcf56b218037de';
+
+const VALID_SCOPE = validatedScope(JSON.parse(SCOPE_CANONICAL));
+const VALID_ROW = validatedRow(JSON.parse(ROW_CANONICAL));
+
+describe('RFC-64 author catalog identifiers and graph names', () => {
+  it('pins the prefix-free root/subgraph names and exact UTF-8 IRI encoding', () => {
+    const rootLane = validatedLane({ contextGraphId: 'a/b', subGraphName: null });
+    const subgraphLane = validatedLane({ contextGraphId: 'a', subGraphName: 'b' });
+    expect(buildCatalogAssertionScopeV1(rootLane)).toBe('v1/root/a%2Fb');
+    expect(buildCatalogAssertionScopeV1(subgraphLane)).toBe('v1/subgraph/a/b');
+    expect(buildCatalogAssertionScopeV1(rootLane)).not.toBe(
+      buildCatalogAssertionScopeV1(subgraphLane),
+    );
+
+    const unicodeLane = validatedLane({ contextGraphId: 'cg', subGraphName: 'café' });
+    const coordinate = validatedCoordinate('name λ');
+    expect(iriComponentV1('AZaz09-._~ /é')).toBe('AZaz09-._~%20%2F%C3%A9');
+    expect(buildCatalogAssertionSubjectV1(unicodeLane, AUTHOR as EvmAddressV1, coordinate))
+      .toBe(
+        `did:dkg:context-graph:v1/subgraph/cg/caf%C3%A9/assertion/${AUTHOR}/name%20%CE%BB`,
+      );
+  });
+
+  it('enforces exact network/context grammar, NFC, and UTF-8 byte ceilings', () => {
+    expect(() => assertNetworkIdV1('otp:20430')).not.toThrow();
+    expect(() => assertContextGraphIdV1('owner/cg.name@v1')).not.toThrow();
+    expect(() => assertNetworkIdV1('otp/20430')).toThrow(/catalog-identifier/);
+    expect(() => assertContextGraphIdV1('café')).toThrow(/catalog-identifier/);
+    expect(() => assertSubGraphNameV1('e\u0301')).toThrow(/NFC-normalized/);
+    expect(() => assertSubGraphNameV1('é')).not.toThrow();
+    expect(() => assertAssertionCoordinateV1('\ud800')).toThrow(/unpaired/);
+    expect(() => assertNetworkIdV1('a'.repeat(129))).toThrow(/128 UTF-8 bytes/);
+    expect(() => assertSubGraphNameV1('é'.repeat(129))).toThrow(/256 UTF-8 bytes/);
+  });
+
+  it.each(['\u00a0', '\u2028', '\u2029', '\u200b', '\ufeff'])
+  ('rejects catalog-forbidden code point %j', (codePoint) => {
+    expect(() => assertSubGraphNameV1(`a${codePoint}b`)).toThrow(/forbidden/);
+    expect(() => assertAssertionCoordinateV1(`a${codePoint}b`)).toThrow(/forbidden/);
+  });
+
+  it('accepts U+200C while rejecting slash, forbidden ASCII, and reserved lanes', () => {
+    expect(() => assertSubGraphNameV1('a\u200cb')).not.toThrow();
+    expect(() => assertAssertionCoordinateV1('a\u200cb')).not.toThrow();
+    for (const value of ['a/b', 'a<b', 'a>b', 'a"b', 'a{b', 'a}b', 'a|b', 'a^b', 'a`b', 'a\\b']) {
+      expect(() => assertSubGraphNameV1(value)).toThrow(/forbidden/);
+      expect(() => assertAssertionCoordinateV1(value)).toThrow(/forbidden/);
+    }
+    for (const value of ['_private', 'context', 'assertion', 'draft']) {
+      expect(() => assertSubGraphNameV1(value)).toThrow(/catalog-identifier/);
+    }
+    expect(() => assertAssertionCoordinateV1('_private')).not.toThrow();
+  });
+});
+
+describe('AuthorCatalogScopeV1', () => {
+  it('pins the exact 346-byte canonical fixture and scope digest', () => {
+    expect(canonicalizeAuthorCatalogScopeV1(VALID_SCOPE)).toBe(SCOPE_CANONICAL);
+    expect(new TextEncoder().encode(SCOPE_CANONICAL).byteLength).toBe(346);
+    expect(computeAuthorCatalogScopeDigestV1(VALID_SCOPE)).toBe(SCOPE_DIGEST);
+    expect(parseCanonicalAuthorCatalogScopeV1(SCOPE_CANONICAL)).toEqual(VALID_SCOPE);
+    expect(buildCatalogAssertionScopeV1(VALID_SCOPE)).toBe(
+      'v1/root/0x1111111111111111111111111111111111111111%2Fcatalog-fixture',
+    );
+  });
+
+  it('accepts only paired governance fields and exact closed scalar fields', () => {
+    const unregistered = validatedScope({
+      ...VALID_SCOPE,
+      governanceChainId: null,
+      governanceContractAddress: null,
+    });
+    expect(() => assertAuthorCatalogScopeV1(unregistered)).not.toThrow();
+    expect(() => assertAuthorCatalogScopeV1({
+      ...VALID_SCOPE,
+      governanceContractAddress: null,
+    })).toThrow(/catalog-governance-tuple/);
+    expect(() => assertAuthorCatalogScopeV1({ ...VALID_SCOPE, era: 0 })).toThrow(
+      /catalog-scalar/,
+    );
+    expect(() => assertAuthorCatalogScopeV1({
+      ...VALID_SCOPE,
+      ownershipTransitionDigest: `0x${'AA'.repeat(32)}`,
+    })).toThrow(/catalog-scalar/);
+    expect(() => assertAuthorCatalogScopeV1({
+      ...VALID_SCOPE,
+      governanceContractAddress: `0x${'00'.repeat(20)}`,
+    })).toThrow(/catalog-scalar/);
+  });
+
+  it('requires a canonical power-of-two bucket count through 2^63', () => {
+    for (const value of ['1', '2', '256', MAX_AUTHOR_CATALOG_BUCKET_COUNT_V1.toString()]) {
+      expect(() => assertAuthorCatalogBucketCountV1(value)).not.toThrow();
+    }
+    for (const value of ['0', '3', '9223372036854775809', 1, '01']) {
+      expect(() => assertAuthorCatalogBucketCountV1(value)).toThrow();
+    }
+  });
+
+  it('rejects missing, extra, symbol, accessor, noncanonical, and duplicate wire fields', () => {
+    const missing = { ...VALID_SCOPE } as Record<string, unknown>;
+    delete missing.era;
+    expect(() => assertAuthorCatalogScopeV1(missing)).toThrow(/catalog-schema/);
+    expect(() => assertAuthorCatalogScopeV1({ ...VALID_SCOPE, tier: 'swm' })).toThrow(
+      /catalog-schema/,
+    );
+    const symbol = { ...VALID_SCOPE } as Record<PropertyKey, unknown>;
+    symbol[Symbol('hidden')] = true;
+    expect(() => assertAuthorCatalogScopeV1(symbol)).toThrow(/catalog-schema/);
+    const accessor = { ...VALID_SCOPE };
+    Object.defineProperty(accessor, 'era', { enumerable: true, get: () => '0' });
+    expect(() => assertAuthorCatalogScopeV1(accessor)).toThrow(/catalog-schema/);
+    expect(() => parseCanonicalAuthorCatalogScopeV1(
+      SCOPE_CANONICAL.replace('"era":"0"', '"era":"0","era":"0"'),
+    )).toThrow(/Duplicate object key/);
+    expect(() => parseCanonicalAuthorCatalogScopeV1(` ${SCOPE_CANONICAL}`)).toThrow(
+      /not RFC 8785 canonical/,
+    );
+  });
+});
+
+describe('AuthorCatalogRowV1 and key placement', () => {
+  it('pins the exact key and seven-key row digest fixtures', () => {
+    expect(new TextEncoder().encode('{"kaId":"1"}').byteLength).toBe(12);
+    expect(computeAuthorCatalogKeyDigestV1('1' as KaIdV1)).toBe(KEY_DIGEST);
+    expect(canonicalizeAuthorCatalogRowV1(VALID_ROW)).toBe(ROW_CANONICAL);
+    expect(new TextEncoder().encode(
+      `{"catalogScopeDigest":"${SCOPE_DIGEST}","row":${ROW_CANONICAL}}`,
+    ).byteLength).toBe(746);
+    expect(computeAuthorCatalogRowDigestV1(SCOPE_DIGEST, VALID_ROW)).toBe(ROW_DIGEST);
+    expect(parseCanonicalAuthorCatalogRowV1(ROW_CANONICAL)).toEqual(VALID_ROW);
+  });
+
+  it('requires exact row/transfer projection equality', () => {
+    expect(() => assertAuthorCatalogRowV1({
+      ...VALID_ROW,
+      transfer: { ...VALID_ROW.transfer, projectionDigest: BLOB_DIGEST },
+    })).toThrow(/catalog-transfer-mismatch/);
+    expect(() => assertAuthorCatalogRowV1({
+      ...VALID_ROW,
+      projectionId: 'private-v1',
+    })).toThrow(/catalog-schema/);
+    expect(() => assertAuthorCatalogRowV1({
+      ...VALID_ROW,
+      transfer: { ...VALID_ROW.transfer, chunkCount: '2' },
+    })).toThrow(/catalog-schema/);
+  });
+
+  it('rejects hostile row shape, scalars, coordinate, and oversized wire input', () => {
+    const missing = { ...VALID_ROW } as Record<string, unknown>;
+    delete missing.sealDigest;
+    expect(() => assertAuthorCatalogRowV1(missing)).toThrow(/catalog-schema/);
+    expect(() => assertAuthorCatalogRowV1({ ...VALID_ROW, tier: 'swm' })).toThrow(
+      /catalog-schema/,
+    );
+    const symbol = { ...VALID_ROW } as Record<PropertyKey, unknown>;
+    symbol[Symbol('hidden')] = true;
+    expect(() => assertAuthorCatalogRowV1(symbol)).toThrow(/catalog-schema/);
+    const accessor = { ...VALID_ROW };
+    Object.defineProperty(accessor, 'sealDigest', {
+      enumerable: true,
+      get: () => SEAL_DIGEST,
+    });
+    expect(() => assertAuthorCatalogRowV1(accessor)).toThrow(/catalog-schema/);
+    expect(() => assertAuthorCatalogRowV1({ ...VALID_ROW, kaId: 1 })).toThrow(
+      /catalog-scalar/,
+    );
+    expect(() => assertAuthorCatalogRowV1({ ...VALID_ROW, assertionVersion: '01' })).toThrow(
+      /catalog-scalar/,
+    );
+    expect(() => assertAuthorCatalogRowV1({
+      ...VALID_ROW,
+      assertionCoordinate: 'bad/name',
+    })).toThrow(/catalog-identifier/);
+    expect(() => parseCanonicalAuthorCatalogRowV1(
+      '{'.padEnd(MAX_AUTHOR_CATALOG_ROW_BYTES_V1 + 1, 'x'),
+    )).toThrow(/object-too-large/);
+  });
+
+  it('compares full u256 KA ids numerically and maps key prefixes to buckets', () => {
+    expect(compareAuthorCatalogKaIdsV1('2' as KaIdV1, '10' as KaIdV1)).toBe(-1);
+    expect(compareAuthorCatalogKaIdsV1('10' as KaIdV1, '2' as KaIdV1)).toBe(1);
+    expect(compareAuthorCatalogKaIdsV1('10' as KaIdV1, '10' as KaIdV1)).toBe(0);
+    expect(compareAuthorCatalogKaIdsV1(
+      '115792089237316195423570985008687907853269984665640564039457584007913129639935' as KaIdV1,
+      '10' as KaIdV1,
+    )).toBe(1);
+
+    expect(catalogKeyDigestToBucketIdV1(KEY_DIGEST, '1')).toBe('0');
+    expect(catalogKeyDigestToBucketIdV1(KEY_DIGEST, '8')).toBe('1');
+    expect(catalogKeyDigestToBucketIdV1(KEY_DIGEST, '16')).toBe('3');
+    expect(catalogKeyDigestToBucketIdV1(KEY_DIGEST, '256')).toBe('62');
+    expect(catalogKeyDigestToBucketIdV1(
+      KEY_DIGEST,
+      MAX_AUTHOR_CATALOG_BUCKET_COUNT_V1.toString() as AuthorCatalogScopeV1['bucketCount'],
+    )).toBe('2253769126038321457');
+    expect(catalogKeyToBucketIdV1('1' as KaIdV1, '256')).toBe('62');
+  });
+
+  it('keeps defensive codec ceilings above maximum-width valid scope and row values', () => {
+    const maximumScope = validatedScope({
+      ...VALID_SCOPE,
+      networkId: 'n'.repeat(128),
+      contextGraphId: 'c'.repeat(256),
+      governanceChainId:
+        '115792089237316195423570985008687907853269984665640564039457584007913129639935',
+      ownershipTransitionDigest: ZERO_DIGEST,
+      subGraphName: 'é'.repeat(128),
+      era: '18446744073709551615',
+      bucketCount: MAX_AUTHOR_CATALOG_BUCKET_COUNT_V1.toString(),
+    });
+    const maximumRow = validatedRow({
+      ...VALID_ROW,
+      kaId:
+        '115792089237316195423570985008687907853269984665640564039457584007913129639935',
+      assertionCoordinate: 'é'.repeat(128),
+      assertionVersion: '18446744073709551615',
+      transfer: {
+        ...VALID_ROW.transfer,
+        byteLength: '1073741824',
+        chunkCount: '4096',
+      },
+    });
+
+    expect(new TextEncoder().encode(canonicalizeAuthorCatalogScopeV1(maximumScope)).byteLength)
+      .toBeLessThanOrEqual(MAX_AUTHOR_CATALOG_SCOPE_BYTES_V1);
+    expect(new TextEncoder().encode(canonicalizeAuthorCatalogRowV1(maximumRow)).byteLength)
+      .toBeLessThanOrEqual(MAX_AUTHOR_CATALOG_ROW_BYTES_V1);
+    expect(() => computeAuthorCatalogRowDigestV1(SCOPE_DIGEST, maximumRow)).not.toThrow();
+    expect(MAX_AUTHOR_CATALOG_ROW_DIGEST_INPUT_BYTES_V1).toBeGreaterThan(
+      MAX_AUTHOR_CATALOG_ROW_BYTES_V1,
+    );
+  });
+
+  it('checks the safely derivable packed high-160 author binding', () => {
+    const packed = ((BigInt(AUTHOR) << 96n) | 7n).toString() as KaIdV1;
+    expect(() => assertPackedKaIdAuthorBindingV1(packed, AUTHOR as EvmAddressV1))
+      .not.toThrow();
+    expect(() => assertPackedKaIdAuthorBindingV1(
+      packed,
+      `0x${'55'.repeat(20)}` as EvmAddressV1,
+    )).toThrow(/catalog-packed-author-mismatch/);
+
+    const boundRow = validatedRow({ ...VALID_ROW, kaId: packed });
+    expect(() => assertAuthorCatalogRowScopeBindingV1(boundRow, VALID_SCOPE)).not.toThrow();
+    expect(() => assertAuthorCatalogRowScopeBindingV1(VALID_ROW, VALID_SCOPE)).toThrow(
+      /catalog-packed-author-mismatch/,
+    );
+  });
+});
+
+function validatedScope(value: unknown): AuthorCatalogScopeV1 {
+  assertAuthorCatalogScopeV1(value);
+  return value;
+}
+
+function validatedRow(value: unknown): AuthorCatalogRowV1 {
+  assertAuthorCatalogRowV1(value);
+  return value;
+}
+
+function validatedCoordinate(value: unknown): AssertionCoordinateV1 {
+  assertAssertionCoordinateV1(value);
+  return value;
+}
+
+function validatedLane(value: {
+  contextGraphId: string;
+  subGraphName: string | null;
+}): CatalogLaneV1 {
+  assertContextGraphIdV1(value.contextGraphId);
+  if (value.subGraphName !== null) assertSubGraphNameV1(value.subGraphName);
+  return value as {
+    contextGraphId: ContextGraphIdV1;
+    subGraphName: SubGraphNameV1 | null;
+  };
+}

--- a/packages/core/test/author-catalog-codec.test.ts
+++ b/packages/core/test/author-catalog-codec.test.ts
@@ -25,7 +25,6 @@ import {
   computeAuthorCatalogKeyDigestV1,
   computeAuthorCatalogRowDigestV1,
   computeAuthorCatalogScopeDigestV1,
-  iriComponentV1,
   parseCanonicalAuthorCatalogRowV1,
   parseCanonicalAuthorCatalogScopeV1,
   type AssertionCoordinateV1,
@@ -72,7 +71,9 @@ describe('RFC-64 author catalog identifiers and graph names', () => {
 
     const unicodeLane = validatedLane({ contextGraphId: 'cg', subGraphName: 'café' });
     const coordinate = validatedCoordinate('name λ');
-    expect(iriComponentV1('AZaz09-._~ /é')).toBe('AZaz09-._~%20%2F%C3%A9');
+    // The percent-encoding contract (%2F for '/', %20 for space, %C3%A9 for 'é')
+    // is proven through the public builders above and the subject below; the raw
+    // encoder is intentionally private.
     expect(buildCatalogAssertionSubjectV1(unicodeLane, AUTHOR as EvmAddressV1, coordinate))
       .toBe(
         `did:dkg:context-graph:v1/subgraph/cg/caf%C3%A9/assertion/${AUTHOR}/name%20%CE%BB`,

--- a/packages/core/test/author-catalog-codec.test.ts
+++ b/packages/core/test/author-catalog-codec.test.ts
@@ -225,6 +225,12 @@ describe('AuthorCatalogRowV1 and key placement', () => {
     expect(() => assertAuthorCatalogRowV1({ ...VALID_ROW, assertionVersion: '01' })).toThrow(
       /catalog-scalar/,
     );
+    expect(() => assertAuthorCatalogRowV1({ ...VALID_ROW, assertionVersion: '0' })).toThrow(
+      /positive DecimalU64V1/,
+    );
+    expect(() => parseCanonicalAuthorCatalogRowV1(
+      ROW_CANONICAL.replace('"assertionVersion":"1"', '"assertionVersion":"0"'),
+    )).toThrow(/positive DecimalU64V1/);
     expect(() => assertAuthorCatalogRowV1({
       ...VALID_ROW,
       assertionCoordinate: 'bad/name',

--- a/packages/core/test/author-catalog-codec.test.ts
+++ b/packages/core/test/author-catalog-codec.test.ts
@@ -14,6 +14,7 @@ import {
   assertNetworkIdV1,
   assertPackedKaIdAuthorBindingV1,
   assertSubGraphNameV1,
+  isCatalogForbiddenCodePointV1,
   buildCatalogAssertionScopeV1,
   buildCatalogAssertionSubjectV1,
   canonicalizeAuthorCatalogRowV1,
@@ -107,6 +108,44 @@ describe('RFC-64 author catalog identifiers and graph names', () => {
       expect(() => assertSubGraphNameV1(value)).toThrow(/catalog-identifier/);
     }
     expect(() => assertAssertionCoordinateV1('_private')).not.toThrow();
+  });
+
+  it('pins isCatalogForbiddenCodePointV1 at every forbidden endpoint and adjacent allowed value', () => {
+    // Every range endpoint and singleton the predicate forbids. A regression
+    // dropping any branch (e.g. the C1 range or a singleton) is caught here.
+    for (const cp of [
+      0x0000, 0x001f, // C0 range endpoints
+      0x007f, 0x009f, // C1 range endpoints
+      0x00a0,
+      0x1680,
+      0x2000, 0x200b, // 0x2000..0x200b range endpoints
+      0x2028, 0x2029, 0x202f, 0x205f, 0x3000, 0xfeff,
+    ]) {
+      expect(isCatalogForbiddenCodePointV1(cp)).toBe(true);
+    }
+    // Values immediately adjacent to each forbidden range/singleton stay allowed,
+    // including U+200C (ZWNJ) right after the 0x2000..0x200b block.
+    for (const cp of [
+      0x0020, 0x007e, 0x00a1, 0x167f, 0x1681, 0x1fff, 0x200c, 0x2027,
+      0x202a, 0x202e, 0x2030, 0x205e, 0x2060, 0x2fff, 0x3001, 0xfefe, 0xff00,
+    ]) {
+      expect(isCatalogForbiddenCodePointV1(cp)).toBe(false);
+    }
+  });
+
+  it('rejects every forbidden endpoint through the lane identifier validators', () => {
+    // NFC-stable forbidden code points only: U+2000/U+2001 have canonical
+    // decompositions and would trip the earlier NFC guard, so the 0x2000..0x200b
+    // range is represented here by its NFC-stable endpoint U+200B (the predicate
+    // boundary test above proves 0x2000 itself is forbidden).
+    for (const cp of [
+      0x0000, 0x001f, 0x007f, 0x009f, 0x00a0, 0x1680,
+      0x200b, 0x2028, 0x2029, 0x202f, 0x205f, 0x3000, 0xfeff,
+    ]) {
+      const identifier = `a${String.fromCodePoint(cp)}b`;
+      expect(() => assertSubGraphNameV1(identifier)).toThrow(/forbidden character or code point/);
+      expect(() => assertAssertionCoordinateV1(identifier)).toThrow(/forbidden character or code point/);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Adds the dormant RFC-64 author-catalog scope, key, and row primitive codec as the next small stacked implementation slice.

- freezes canonical network, CG, subgraph, and assertion-coordinate validation
- derives prefix-free tagged assertion scopes and subjects
- validates and hashes the exact nine-key catalog scope and seven-key catalog row
- enforces transfer projection equality, numeric u256 ordering, high-bit bucket mapping, and packed high-160 author binding
- pins normative RFC vectors and hostile-input/boundary cases

This PR intentionally does not add head, bucket, directory, persistence, network handlers, or runtime activation. PR #1780 is not called during structural candidate staging; its graph-scoped seal parser remains the post-transfer semantic-admission seam on the integration branch.

## Validation

- focused author-catalog tests: 18 passed
- full core suite: 91 files, 1,355 tests passed
- core TypeScript build passed
- git diff --check passed

## Stack

Base: #1794
Integration branch: integration/rfc64-devnet
