### PR TITLE
feat(core): add RFC-64 catalog bucket and head codecs

### DIFF
--- a/packages/core/src/author-catalog-objects.ts
+++ b/packages/core/src/author-catalog-objects.ts
@@ -1,0 +1,710 @@
+import {
+  canonicalizeJson,
+  parseCanonicalJson,
+  type CanonicalJsonValue,
+  type StrictJsonParseOptions,
+} from './canonical-json.js';
+import {
+  assertAuthorCatalogBucketCountV1,
+  assertAuthorCatalogRowScopeBindingV1,
+  assertAuthorCatalogRowV1,
+  assertAuthorCatalogScopeV1,
+  assertContextGraphIdV1,
+  assertNetworkIdV1,
+  assertSubGraphNameV1,
+  canonicalizeAuthorCatalogScopeV1,
+  catalogKeyToBucketIdV1,
+  compareAuthorCatalogKaIdsV1,
+  computeAuthorCatalogKeyDigestV1,
+  computeAuthorCatalogScopeDigestV1,
+  type AuthorCatalogRowV1,
+  type AuthorCatalogScopeV1,
+  type ContextGraphIdV1,
+  type NetworkIdV1,
+  type SubGraphNameV1,
+} from './author-catalog-codec.js';
+import {
+  assertSignedControlEnvelope,
+  assertUnsignedControlEnvelope,
+  canonicalizeSignedControlEnvelopeBytes,
+  canonicalizeUnsignedControlEnvelopeBytes,
+  computeControlObjectDigestHex,
+  parseCanonicalSignedControlEnvelope,
+  parseCanonicalUnsignedControlEnvelope,
+  type SignedControlEnvelopeV1,
+  type UnsignedControlEnvelopeV1,
+} from './sync-control-object.js';
+import {
+  assertCanonicalChainId,
+  assertCanonicalDigest,
+  assertCanonicalEvmAddress,
+  assertCanonicalTimestampMs,
+  parseCanonicalDecimalU64,
+  type ChainIdV1,
+  type CountV1,
+  type DecimalU64V1,
+  type Digest32V1,
+  type EvmAddressV1,
+  type TimestampMsV1,
+} from './sync-wire-scalars.js';
+import { assertExactKeys, isPlainRecord } from './sync-wire-objects.js';
+
+export const AUTHOR_CATALOG_BUCKET_OBJECT_TYPE_V1 = 'AuthorCatalogBucketV1' as const;
+export const AUTHOR_CATALOG_HEAD_OBJECT_TYPE_V1 = 'AuthorCatalogHeadV1' as const;
+export const MAX_AUTHOR_CATALOG_BUCKET_ROWS_V1 = 1024;
+export const MAX_AUTHOR_CATALOG_BUCKET_PAYLOAD_BYTES_V1 = 1024 * 1024;
+export const MAX_AUTHOR_CATALOG_HEAD_PAYLOAD_BYTES_V1 = 4 * 1024;
+export const MAX_AUTHOR_CATALOG_DIRECTORY_HEIGHT_V1 = 7n;
+export const AUTHOR_CATALOG_DIRECTORY_FANOUT_V1 = 256n;
+export const ZERO_DIGEST32_V1 = `0x${'00'.repeat(32)}` as Digest32V1;
+
+const UTF8 = new TextEncoder();
+
+/** Exact five-key immutable non-empty bucket payload. */
+export interface AuthorCatalogBucketV1 {
+  readonly catalogScopeDigest: Digest32V1;
+  readonly era: DecimalU64V1;
+  readonly bucketCount: CountV1;
+  readonly bucketId: DecimalU64V1;
+  readonly rows: readonly AuthorCatalogRowV1[];
+}
+
+/** Exact sixteen-key constant-size author-catalog head payload. */
+export interface AuthorCatalogHeadV1 {
+  readonly networkId: NetworkIdV1;
+  readonly contextGraphId: ContextGraphIdV1;
+  readonly governanceChainId: ChainIdV1 | null;
+  readonly governanceContractAddress: EvmAddressV1 | null;
+  readonly ownershipTransitionDigest: Digest32V1 | null;
+  readonly subGraphName: SubGraphNameV1 | null;
+  readonly authorAddress: EvmAddressV1;
+  readonly catalogIssuerDelegationDigest: Digest32V1;
+  readonly era: DecimalU64V1;
+  readonly version: DecimalU64V1;
+  readonly previousHeadDigest: Digest32V1 | null;
+  readonly bucketCount: CountV1;
+  readonly totalRows: CountV1;
+  readonly directoryHeight: DecimalU64V1;
+  readonly directoryRootDigest: Digest32V1;
+  readonly issuedAt: TimestampMsV1;
+}
+
+export type UnsignedAuthorCatalogBucketEnvelopeV1 = UnsignedControlEnvelopeV1 & {
+  readonly objectType: typeof AUTHOR_CATALOG_BUCKET_OBJECT_TYPE_V1;
+  readonly payload: AuthorCatalogBucketV1;
+};
+export type SignedAuthorCatalogBucketEnvelopeV1 = SignedControlEnvelopeV1 & {
+  readonly objectType: typeof AUTHOR_CATALOG_BUCKET_OBJECT_TYPE_V1;
+  readonly payload: AuthorCatalogBucketV1;
+};
+export type UnsignedAuthorCatalogHeadEnvelopeV1 = UnsignedControlEnvelopeV1 & {
+  readonly objectType: typeof AUTHOR_CATALOG_HEAD_OBJECT_TYPE_V1;
+  readonly payload: AuthorCatalogHeadV1;
+};
+export type SignedAuthorCatalogHeadEnvelopeV1 = SignedControlEnvelopeV1 & {
+  readonly objectType: typeof AUTHOR_CATALOG_HEAD_OBJECT_TYPE_V1;
+  readonly payload: AuthorCatalogHeadV1;
+};
+
+export type AuthorCatalogObjectCodecErrorCode =
+  | 'catalog-object-schema'
+  | 'catalog-object-scalar'
+  | 'catalog-object-type'
+  | 'catalog-object-array'
+  | 'catalog-object-row-order'
+  | 'catalog-object-duplicate'
+  | 'catalog-object-bucket-mapping'
+  | 'catalog-object-scope-mismatch'
+  | 'catalog-object-directory-height'
+  | 'catalog-object-payload-too-large';
+
+export class AuthorCatalogObjectCodecError extends Error {
+  constructor(
+    readonly code: AuthorCatalogObjectCodecErrorCode,
+    message: string,
+    options: ErrorOptions = {},
+  ) {
+    super(`[${code}] ${message}`, options);
+    this.name = 'AuthorCatalogObjectCodecError';
+  }
+}
+
+/** Validate one complete non-empty bucket, including its canonical 1 MiB cap. */
+export function assertAuthorCatalogBucketV1(
+  bucket: unknown,
+): asserts bucket is AuthorCatalogBucketV1 {
+  assertAuthorCatalogBucketStructureV1(bucket);
+  canonicalizeBucketAfterStructure(bucket);
+}
+
+/**
+ * Bind a structurally valid bucket to the exact scope carried by its enclosing
+ * head. This is candidate staging only; it deliberately performs no RDF/seal work.
+ */
+export function assertAuthorCatalogBucketScopeBindingV1(
+  bucket: AuthorCatalogBucketV1,
+  scope: AuthorCatalogScopeV1,
+): void {
+  assertAuthorCatalogBucketV1(bucket);
+  assertAuthorCatalogScopeV1(scope);
+  const expectedScopeDigest = computeAuthorCatalogScopeDigestV1(scope);
+  if (bucket.catalogScopeDigest !== expectedScopeDigest) {
+    fail(
+      'catalog-object-scope-mismatch',
+      'bucket catalogScopeDigest does not match the contextual author catalog scope',
+    );
+  }
+  if (bucket.era !== scope.era || bucket.bucketCount !== scope.bucketCount) {
+    fail(
+      'catalog-object-scope-mismatch',
+      'bucket era and bucketCount must equal the contextual scope',
+    );
+  }
+  for (let index = 0; index < bucket.rows.length; index += 1) {
+    assertAuthorCatalogRowScopeBindingV1(bucket.rows[index], scope);
+  }
+}
+
+/** Return exact RFC 8785 payload bytes and enforce the bucket's 1 MiB cap. */
+export function canonicalizeAuthorCatalogBucketPayloadBytesV1(
+  bucket: AuthorCatalogBucketV1,
+): Uint8Array {
+  assertAuthorCatalogBucketStructureV1(bucket);
+  return UTF8.encode(canonicalizeBucketAfterStructure(bucket));
+}
+
+export function canonicalizeAuthorCatalogBucketPayloadV1(
+  bucket: AuthorCatalogBucketV1,
+): string {
+  assertAuthorCatalogBucketStructureV1(bucket);
+  return canonicalizeBucketAfterStructure(bucket);
+}
+
+/** Strict direct-payload decoder; envelope decoders intentionally use the generic cap first. */
+export function parseCanonicalAuthorCatalogBucketPayloadV1(
+  input: string | Uint8Array,
+  options: StrictJsonParseOptions = {},
+): AuthorCatalogBucketV1 {
+  rejectOversizedWireInput(
+    input,
+    MAX_AUTHOR_CATALOG_BUCKET_PAYLOAD_BYTES_V1,
+    'author catalog bucket payload',
+  );
+  const parsed = parseCanonicalJson(input, {
+    ...options,
+    maxBytes: Math.min(
+      options.maxBytes ?? MAX_AUTHOR_CATALOG_BUCKET_PAYLOAD_BYTES_V1,
+      MAX_AUTHOR_CATALOG_BUCKET_PAYLOAD_BYTES_V1,
+    ),
+    maxDepth: Math.min(options.maxDepth ?? 4, 4),
+  });
+  assertAuthorCatalogBucketV1(parsed);
+  return parsed;
+}
+
+/** Validate one head, its self-derived scope, height formula, and 4 KiB cap. */
+export function assertAuthorCatalogHeadV1(
+  head: unknown,
+): asserts head is AuthorCatalogHeadV1 {
+  assertAuthorCatalogHeadStructureV1(head);
+  canonicalizeHeadAfterStructure(head);
+}
+
+/** Derive the exact nine-key catalog scope committed by this head. */
+export function deriveAuthorCatalogScopeFromHeadV1(
+  head: AuthorCatalogHeadV1,
+): AuthorCatalogScopeV1 {
+  assertAuthorCatalogHeadV1(head);
+  return deriveScopeAfterHeadStructure(head);
+}
+
+/** Require a head to be in exactly the externally pinned catalog scope. */
+export function assertAuthorCatalogHeadScopeBindingV1(
+  head: AuthorCatalogHeadV1,
+  expectedScope: AuthorCatalogScopeV1,
+): void {
+  assertAuthorCatalogHeadV1(head);
+  assertAuthorCatalogScopeV1(expectedScope);
+  const derived = deriveScopeAfterHeadStructure(head);
+  if (
+    canonicalizeAuthorCatalogScopeV1(derived)
+    !== canonicalizeAuthorCatalogScopeV1(expectedScope)
+  ) {
+    fail(
+      'catalog-object-scope-mismatch',
+      'head fields do not equal the externally pinned author catalog scope',
+    );
+  }
+}
+
+/** Return the canonical zero-based directory height for a valid bucket count. */
+export function computeAuthorCatalogDirectoryHeightV1(
+  bucketCount: CountV1,
+): DecimalU64V1 {
+  assertAuthorCatalogBucketCountV1(bucketCount);
+  const count = BigInt(bucketCount);
+  let height = 0n;
+  let coveredBuckets = AUTHOR_CATALOG_DIRECTORY_FANOUT_V1;
+  while (count > coveredBuckets) {
+    coveredBuckets *= AUTHOR_CATALOG_DIRECTORY_FANOUT_V1;
+    height += 1n;
+  }
+  if (height > MAX_AUTHOR_CATALOG_DIRECTORY_HEIGHT_V1) {
+    fail('catalog-object-directory-height', 'derived directory height exceeds v1');
+  }
+  return height.toString() as DecimalU64V1;
+}
+
+export function canonicalizeAuthorCatalogHeadPayloadBytesV1(
+  head: AuthorCatalogHeadV1,
+): Uint8Array {
+  assertAuthorCatalogHeadStructureV1(head);
+  return UTF8.encode(canonicalizeHeadAfterStructure(head));
+}
+
+export function canonicalizeAuthorCatalogHeadPayloadV1(
+  head: AuthorCatalogHeadV1,
+): string {
+  assertAuthorCatalogHeadStructureV1(head);
+  return canonicalizeHeadAfterStructure(head);
+}
+
+export function parseCanonicalAuthorCatalogHeadPayloadV1(
+  input: string | Uint8Array,
+  options: StrictJsonParseOptions = {},
+): AuthorCatalogHeadV1 {
+  rejectOversizedWireInput(
+    input,
+    MAX_AUTHOR_CATALOG_HEAD_PAYLOAD_BYTES_V1,
+    'author catalog head payload',
+  );
+  const parsed = parseCanonicalJson(input, {
+    ...options,
+    maxBytes: Math.min(
+      options.maxBytes ?? MAX_AUTHOR_CATALOG_HEAD_PAYLOAD_BYTES_V1,
+      MAX_AUTHOR_CATALOG_HEAD_PAYLOAD_BYTES_V1,
+    ),
+    maxDepth: Math.min(options.maxDepth ?? 1, 1),
+  });
+  assertAuthorCatalogHeadV1(parsed);
+  return parsed;
+}
+
+export function assertUnsignedAuthorCatalogBucketEnvelopeV1(
+  envelope: UnsignedControlEnvelopeV1,
+): asserts envelope is UnsignedAuthorCatalogBucketEnvelopeV1 {
+  assertUnsignedControlEnvelope(envelope);
+  assertEnvelopeObjectType(envelope.objectType, AUTHOR_CATALOG_BUCKET_OBJECT_TYPE_V1);
+  assertAuthorCatalogBucketV1(envelope.payload);
+}
+
+export function assertSignedAuthorCatalogBucketEnvelopeV1(
+  envelope: SignedControlEnvelopeV1,
+): asserts envelope is SignedAuthorCatalogBucketEnvelopeV1 {
+  assertSignedControlEnvelope(envelope);
+  assertEnvelopeObjectType(envelope.objectType, AUTHOR_CATALOG_BUCKET_OBJECT_TYPE_V1);
+  assertAuthorCatalogBucketV1(envelope.payload);
+}
+
+export function assertUnsignedAuthorCatalogHeadEnvelopeV1(
+  envelope: UnsignedControlEnvelopeV1,
+): asserts envelope is UnsignedAuthorCatalogHeadEnvelopeV1 {
+  assertUnsignedControlEnvelope(envelope);
+  assertEnvelopeObjectType(envelope.objectType, AUTHOR_CATALOG_HEAD_OBJECT_TYPE_V1);
+  assertAuthorCatalogHeadV1(envelope.payload);
+}
+
+export function assertSignedAuthorCatalogHeadEnvelopeV1(
+  envelope: SignedControlEnvelopeV1,
+): asserts envelope is SignedAuthorCatalogHeadEnvelopeV1 {
+  assertSignedControlEnvelope(envelope);
+  assertEnvelopeObjectType(envelope.objectType, AUTHOR_CATALOG_HEAD_OBJECT_TYPE_V1);
+  assertAuthorCatalogHeadV1(envelope.payload);
+}
+
+export function canonicalizeUnsignedAuthorCatalogBucketEnvelopeBytesV1(
+  envelope: UnsignedControlEnvelopeV1,
+): Uint8Array {
+  assertUnsignedAuthorCatalogBucketEnvelopeV1(envelope);
+  return canonicalizeUnsignedControlEnvelopeBytes(envelope);
+}
+
+export function canonicalizeSignedAuthorCatalogBucketEnvelopeBytesV1(
+  envelope: SignedControlEnvelopeV1,
+): Uint8Array {
+  assertSignedAuthorCatalogBucketEnvelopeV1(envelope);
+  return canonicalizeSignedControlEnvelopeBytes(envelope);
+}
+
+export function canonicalizeUnsignedAuthorCatalogHeadEnvelopeBytesV1(
+  envelope: UnsignedControlEnvelopeV1,
+): Uint8Array {
+  assertUnsignedAuthorCatalogHeadEnvelopeV1(envelope);
+  return canonicalizeUnsignedControlEnvelopeBytes(envelope);
+}
+
+export function canonicalizeSignedAuthorCatalogHeadEnvelopeBytesV1(
+  envelope: SignedControlEnvelopeV1,
+): Uint8Array {
+  assertSignedAuthorCatalogHeadEnvelopeV1(envelope);
+  return canonicalizeSignedControlEnvelopeBytes(envelope);
+}
+
+export function computeAuthorCatalogBucketObjectDigestV1(
+  envelope: UnsignedControlEnvelopeV1,
+): Digest32V1 {
+  assertUnsignedAuthorCatalogBucketEnvelopeV1(envelope);
+  const digest = computeControlObjectDigestHex(envelope);
+  assertCanonicalDigest(digest, 'bucket objectDigest');
+  return digest;
+}
+
+export function computeAuthorCatalogHeadObjectDigestV1(
+  envelope: UnsignedControlEnvelopeV1,
+): Digest32V1 {
+  assertUnsignedAuthorCatalogHeadEnvelopeV1(envelope);
+  const digest = computeControlObjectDigestHex(envelope);
+  assertCanonicalDigest(digest, 'head objectDigest');
+  return digest;
+}
+
+/** Parse the generic envelope first, then enforce the lower payload cap and schema. */
+export function parseCanonicalUnsignedAuthorCatalogBucketEnvelopeV1(
+  input: string | Uint8Array,
+  options: StrictJsonParseOptions = {},
+): UnsignedAuthorCatalogBucketEnvelopeV1 {
+  const envelope = parseCanonicalUnsignedControlEnvelope(input, options);
+  assertUnsignedAuthorCatalogBucketEnvelopeV1(envelope);
+  return envelope;
+}
+
+export function parseCanonicalSignedAuthorCatalogBucketEnvelopeV1(
+  input: string | Uint8Array,
+  options: StrictJsonParseOptions = {},
+): SignedAuthorCatalogBucketEnvelopeV1 {
+  const envelope = parseCanonicalSignedControlEnvelope(input, options);
+  assertSignedAuthorCatalogBucketEnvelopeV1(envelope);
+  return envelope;
+}
+
+export function parseCanonicalUnsignedAuthorCatalogHeadEnvelopeV1(
+  input: string | Uint8Array,
+  options: StrictJsonParseOptions = {},
+): UnsignedAuthorCatalogHeadEnvelopeV1 {
+  const envelope = parseCanonicalUnsignedControlEnvelope(input, options);
+  assertUnsignedAuthorCatalogHeadEnvelopeV1(envelope);
+  return envelope;
+}
+
+export function parseCanonicalSignedAuthorCatalogHeadEnvelopeV1(
+  input: string | Uint8Array,
+  options: StrictJsonParseOptions = {},
+): SignedAuthorCatalogHeadEnvelopeV1 {
+  const envelope = parseCanonicalSignedControlEnvelope(input, options);
+  assertSignedAuthorCatalogHeadEnvelopeV1(envelope);
+  return envelope;
+}
+
+function assertAuthorCatalogBucketStructureV1(
+  bucket: unknown,
+): asserts bucket is AuthorCatalogBucketV1 {
+  if (!isPlainRecord(bucket)) {
+    fail('catalog-object-schema', 'author catalog bucket must be a plain JSON object');
+  }
+  assertClosedKeys(bucket, [
+    'bucketCount',
+    'bucketId',
+    'catalogScopeDigest',
+    'era',
+    'rows',
+  ], 'author catalog bucket');
+  assertObjectScalar(() => assertCanonicalDigest(
+    bucket.catalogScopeDigest,
+    'catalogScopeDigest',
+  ));
+  assertObjectU64(bucket.era, 'era');
+  assertAuthorCatalogBucketCountV1(bucket.bucketCount);
+  const bucketId = assertObjectU64(bucket.bucketId, 'bucketId');
+  if (bucketId >= BigInt(bucket.bucketCount)) {
+    fail('catalog-object-bucket-mapping', 'bucketId must be less than bucketCount');
+  }
+
+  assertDenseOrdinaryRowsArray(bucket.rows);
+  const seenKaIds = new Set<string>();
+  const seenKeyDigests = new Set<string>();
+  const seenCoordinates = new Set<string>();
+  let previousRow: AuthorCatalogRowV1 | undefined;
+  for (let index = 0; index < bucket.rows.length; index += 1) {
+    const row = bucket.rows[index];
+    assertAuthorCatalogRowV1(row);
+    if (seenKaIds.has(row.kaId)) {
+      fail('catalog-object-duplicate', `duplicate kaId ${row.kaId}`);
+    }
+    seenKaIds.add(row.kaId);
+
+    const keyDigest = computeAuthorCatalogKeyDigestV1(row.kaId);
+    if (seenKeyDigests.has(keyDigest)) {
+      fail('catalog-object-duplicate', `duplicate catalogKeyDigest ${keyDigest}`);
+    }
+    seenKeyDigests.add(keyDigest);
+    if (seenCoordinates.has(row.assertionCoordinate)) {
+      fail(
+        'catalog-object-duplicate',
+        `duplicate assertionCoordinate ${row.assertionCoordinate}`,
+      );
+    }
+    seenCoordinates.add(row.assertionCoordinate);
+
+    if (previousRow !== undefined && compareAuthorCatalogKaIdsV1(previousRow.kaId, row.kaId) >= 0) {
+      fail('catalog-object-row-order', 'bucket rows must be strictly increasing by numeric kaId');
+    }
+    previousRow = row;
+
+    if (catalogKeyToBucketIdV1(row.kaId, bucket.bucketCount) !== bucket.bucketId) {
+      fail(
+        'catalog-object-bucket-mapping',
+        `row kaId ${row.kaId} does not map to bucketId ${bucket.bucketId}`,
+      );
+    }
+  }
+}
+
+function assertAuthorCatalogHeadStructureV1(
+  head: unknown,
+): asserts head is AuthorCatalogHeadV1 {
+  if (!isPlainRecord(head)) {
+    fail('catalog-object-schema', 'author catalog head must be a plain JSON object');
+  }
+  assertClosedKeys(head, [
+    'authorAddress',
+    'bucketCount',
+    'catalogIssuerDelegationDigest',
+    'contextGraphId',
+    'directoryHeight',
+    'directoryRootDigest',
+    'era',
+    'governanceChainId',
+    'governanceContractAddress',
+    'issuedAt',
+    'networkId',
+    'ownershipTransitionDigest',
+    'previousHeadDigest',
+    'subGraphName',
+    'totalRows',
+    'version',
+  ], 'author catalog head');
+
+  // Scope derivation performs the identifier, governance-pair, author, era, and
+  // bucket-count checks once over the exact same values committed by the head.
+  const derivedScope = deriveScopeAfterHeadKeys(head);
+  assertObjectScalar(() => assertCanonicalDigest(
+    head.catalogIssuerDelegationDigest,
+    'catalogIssuerDelegationDigest',
+  ));
+  assertObjectU64(head.version, 'version');
+  if (head.previousHeadDigest !== null) {
+    assertObjectScalar(() => assertCanonicalDigest(head.previousHeadDigest, 'previousHeadDigest'));
+  }
+  assertObjectU64(head.totalRows, 'totalRows');
+  const height = assertObjectU64(head.directoryHeight, 'directoryHeight');
+  if (height > MAX_AUTHOR_CATALOG_DIRECTORY_HEIGHT_V1) {
+    fail('catalog-object-directory-height', 'directoryHeight must be in 0..7');
+  }
+  const expectedHeight = computeAuthorCatalogDirectoryHeightV1(derivedScope.bucketCount);
+  if (head.directoryHeight !== expectedHeight) {
+    fail(
+      'catalog-object-directory-height',
+      `directoryHeight must be ${expectedHeight} for bucketCount ${head.bucketCount}`,
+    );
+  }
+  assertObjectScalar(() => assertCanonicalDigest(head.directoryRootDigest, 'directoryRootDigest'));
+  if (head.directoryRootDigest === ZERO_DIGEST32_V1) {
+    fail('catalog-object-schema', 'directoryRootDigest must name a nonzero directory object');
+  }
+  assertObjectScalar(() => assertCanonicalTimestampMs(head.issuedAt, 'issuedAt'));
+}
+
+function deriveScopeAfterHeadKeys(
+  head: Record<string, unknown>,
+): AuthorCatalogScopeV1 {
+  assertNetworkIdV1(head.networkId);
+  assertContextGraphIdV1(head.contextGraphId);
+  if (head.subGraphName !== null) assertSubGraphNameV1(head.subGraphName);
+  assertObjectScalar(() => assertCanonicalEvmAddress(head.authorAddress, 'authorAddress'));
+  assertObjectU64(head.era, 'era');
+  assertAuthorCatalogBucketCountV1(head.bucketCount);
+
+  const chainIsNull = head.governanceChainId === null;
+  const contractIsNull = head.governanceContractAddress === null;
+  if (chainIsNull !== contractIsNull) {
+    fail(
+      'catalog-object-schema',
+      'governanceChainId and governanceContractAddress must both be null or both non-null',
+    );
+  }
+  if (!chainIsNull) {
+    assertObjectScalar(() => assertCanonicalChainId(head.governanceChainId, 'governanceChainId'));
+    assertObjectScalar(() => assertCanonicalEvmAddress(
+      head.governanceContractAddress,
+      'governanceContractAddress',
+    ));
+  }
+  if (head.ownershipTransitionDigest !== null) {
+    assertObjectScalar(() => assertCanonicalDigest(
+      head.ownershipTransitionDigest,
+      'ownershipTransitionDigest',
+    ));
+  }
+
+  const scope = {
+    networkId: head.networkId,
+    contextGraphId: head.contextGraphId,
+    governanceChainId: head.governanceChainId,
+    governanceContractAddress: head.governanceContractAddress,
+    ownershipTransitionDigest: head.ownershipTransitionDigest,
+    subGraphName: head.subGraphName,
+    authorAddress: head.authorAddress,
+    era: head.era,
+    bucketCount: head.bucketCount,
+  };
+  assertAuthorCatalogScopeV1(scope);
+  return scope;
+}
+
+function deriveScopeAfterHeadStructure(head: AuthorCatalogHeadV1): AuthorCatalogScopeV1 {
+  return {
+    networkId: head.networkId,
+    contextGraphId: head.contextGraphId,
+    governanceChainId: head.governanceChainId,
+    governanceContractAddress: head.governanceContractAddress,
+    ownershipTransitionDigest: head.ownershipTransitionDigest,
+    subGraphName: head.subGraphName,
+    authorAddress: head.authorAddress,
+    era: head.era,
+    bucketCount: head.bucketCount,
+  };
+}
+
+function assertDenseOrdinaryRowsArray(
+  value: unknown,
+): asserts value is AuthorCatalogRowV1[] {
+  if (!Array.isArray(value) || Object.getPrototypeOf(value) !== Array.prototype) {
+    fail('catalog-object-array', 'rows must be an ordinary Array');
+  }
+  if (value.length < 1 || value.length > MAX_AUTHOR_CATALOG_BUCKET_ROWS_V1) {
+    fail(
+      'catalog-object-array',
+      `rows must contain 1..${MAX_AUTHOR_CATALOG_BUCKET_ROWS_V1} entries`,
+    );
+  }
+
+  const ownKeys = Reflect.ownKeys(value);
+  if (ownKeys.some((key) => typeof key !== 'string')) {
+    fail('catalog-object-array', 'rows must not contain symbol properties');
+  }
+  if (ownKeys.length !== value.length + 1 || !ownKeys.includes('length')) {
+    fail('catalog-object-array', 'rows must be dense and contain no custom properties');
+  }
+  const lengthDescriptor = Object.getOwnPropertyDescriptor(value, 'length');
+  if (!lengthDescriptor || !Object.prototype.hasOwnProperty.call(lengthDescriptor, 'value')) {
+    fail('catalog-object-array', 'rows length must be an ordinary data property');
+  }
+  for (let index = 0; index < value.length; index += 1) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
+    if (!descriptor?.enumerable || !Object.prototype.hasOwnProperty.call(descriptor, 'value')) {
+      fail('catalog-object-array', 'rows must be a dense array of enumerable data properties');
+    }
+  }
+}
+
+function canonicalizeBucketAfterStructure(bucket: AuthorCatalogBucketV1): string {
+  try {
+    return canonicalizeJson(bucket as unknown as CanonicalJsonValue, {
+      maxBytes: MAX_AUTHOR_CATALOG_BUCKET_PAYLOAD_BYTES_V1,
+      maxDepth: 4,
+    });
+  } catch (cause) {
+    fail(
+      'catalog-object-payload-too-large',
+      `author catalog bucket payload exceeds ${MAX_AUTHOR_CATALOG_BUCKET_PAYLOAD_BYTES_V1} bytes or depth`,
+      cause,
+    );
+  }
+}
+
+function canonicalizeHeadAfterStructure(head: AuthorCatalogHeadV1): string {
+  try {
+    return canonicalizeJson(head as unknown as CanonicalJsonValue, {
+      maxBytes: MAX_AUTHOR_CATALOG_HEAD_PAYLOAD_BYTES_V1,
+      maxDepth: 1,
+    });
+  } catch (cause) {
+    fail(
+      'catalog-object-payload-too-large',
+      `author catalog head payload exceeds ${MAX_AUTHOR_CATALOG_HEAD_PAYLOAD_BYTES_V1} bytes or depth`,
+      cause,
+    );
+  }
+}
+
+function assertEnvelopeObjectType(actual: string, expected: string): void {
+  if (actual !== expected) {
+    fail('catalog-object-type', `objectType must be exactly ${expected}`);
+  }
+}
+
+function assertClosedKeys(
+  record: Record<string, unknown>,
+  keys: readonly string[],
+  label: string,
+): void {
+  try {
+    assertExactKeys(record, keys, label);
+  } catch (cause) {
+    fail('catalog-object-schema', `${label} has an invalid field set`, cause);
+  }
+}
+
+function assertObjectScalar(operation: () => void): void {
+  try {
+    operation();
+  } catch (cause) {
+    fail('catalog-object-scalar', 'catalog object scalar is not canonical', cause);
+  }
+}
+
+function assertObjectU64(value: unknown, label: string): bigint {
+  try {
+    return parseCanonicalDecimalU64(value, label);
+  } catch (cause) {
+    fail('catalog-object-scalar', `${label} is not a canonical DecimalU64V1`, cause);
+  }
+}
+
+function rejectOversizedWireInput(
+  input: string | Uint8Array,
+  maxBytes: number,
+  label: string,
+): void {
+  if (typeof input !== 'string') {
+    if (input.byteLength > maxBytes) {
+      fail('catalog-object-payload-too-large', `${label} exceeds ${maxBytes} bytes`);
+    }
+    return;
+  }
+  if (input.length > maxBytes || UTF8.encode(input).byteLength > maxBytes) {
+    fail('catalog-object-payload-too-large', `${label} exceeds ${maxBytes} bytes`);
+  }
+}
+
+function fail(
+  code: AuthorCatalogObjectCodecErrorCode,
+  message: string,
+  cause?: unknown,
+): never {
+  throw new AuthorCatalogObjectCodecError(
+    code,
+    message,
+    cause === undefined ? {} : { cause },
+  );
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -49,6 +49,7 @@ export * from './ka-bundle-v1.js';
 export * from './ka-chunk-tree.js';
 export * from './ka-chunk-proof.js';
 export * from './author-catalog-codec.js';
+export * from './author-catalog-objects.js';
 export * from './event-bus.js';
 export {
   Logger,

--- a/packages/core/test/author-catalog-objects.test.ts
+++ b/packages/core/test/author-catalog-objects.test.ts
@@ -235,6 +235,26 @@ describe('AuthorCatalogBucketV1 structural codec', () => {
     })).toThrow(/catalog-object-type/);
   });
 
+  it('rejects assertion version zero through bucket and envelope admission', () => {
+    expect(() => assertAuthorCatalogBucketV1({
+      ...VALID_BUCKET,
+      rows: [{ ...VALID_ROW, assertionVersion: '0' }],
+    })).toThrow(/positive DecimalU64V1/);
+    const zeroVersionBucket = BUCKET_CANONICAL.replace(
+      '"assertionVersion":"1"',
+      '"assertionVersion":"0"',
+    );
+    expect(() => parseCanonicalAuthorCatalogBucketPayloadV1(zeroVersionBucket)).toThrow(
+      /positive DecimalU64V1/,
+    );
+    expect(() => parseCanonicalUnsignedAuthorCatalogBucketEnvelopeV1(
+      BUCKET_UNSIGNED_CANONICAL.replace(
+        '"assertionVersion":"1"',
+        '"assertionVersion":"0"',
+      ),
+    )).toThrow(/positive DecimalU64V1/);
+  });
+
   it('wraps and strictly parses the generic signed envelope without authority checks', () => {
     expect(() => assertSignedAuthorCatalogBucketEnvelopeV1(BUCKET_SIGNED)).not.toThrow();
     const bytes = canonicalizeSignedAuthorCatalogBucketEnvelopeBytesV1(BUCKET_SIGNED);

--- a/packages/core/test/author-catalog-objects.test.ts
+++ b/packages/core/test/author-catalog-objects.test.ts
@@ -4,6 +4,8 @@ import {
   AUTHOR_CATALOG_BUCKET_OBJECT_TYPE_V1,
   AUTHOR_CATALOG_HEAD_OBJECT_TYPE_V1,
   MAX_AUTHOR_CATALOG_BUCKET_PAYLOAD_BYTES_V1,
+  MAX_AUTHOR_CATALOG_BUCKET_ROWS_V1,
+  MAX_AUTHOR_CATALOG_HEAD_PAYLOAD_BYTES_V1,
   assertAuthorCatalogBucketScopeBindingV1,
   assertAuthorCatalogBucketV1,
   assertAuthorCatalogHeadScopeBindingV1,
@@ -34,11 +36,16 @@ import {
 import {
   assertAuthorCatalogRowV1,
   assertAuthorCatalogScopeV1,
+  canonicalizeAuthorCatalogRowV1,
   computeAuthorCatalogKeyDigestV1,
   computeAuthorCatalogRowDigestV1,
   type AuthorCatalogRowV1,
   type AuthorCatalogScopeV1,
 } from '../src/author-catalog-codec.js';
+import {
+  MAX_DECIMAL_U64,
+  MAX_DECIMAL_U256,
+} from '../src/sync-wire-scalars.js';
 import {
   type SignedControlEnvelopeV1,
   type UnsignedControlEnvelopeV1,
@@ -235,6 +242,51 @@ describe('AuthorCatalogBucketV1 structural codec', () => {
     })).toThrow(/catalog-object-type/);
   });
 
+  it('keeps the structurally maximal 1024-row payload below the 1 MiB cap', () => {
+    const maximalRows = Array.from(
+      { length: MAX_AUTHOR_CATALOG_BUCKET_ROWS_V1 },
+      (_, index) => ({
+        ...VALID_ROW,
+        kaId: (
+          MAX_DECIMAL_U256
+          - BigInt(MAX_AUTHOR_CATALOG_BUCKET_ROWS_V1 - 1 - index)
+        ).toString(),
+        assertionCoordinate: `${'x'.repeat(252)}${index.toString(16).padStart(4, '0')}`,
+        assertionVersion: MAX_DECIMAL_U64.toString(),
+        transfer: {
+          ...VALID_ROW.transfer,
+          byteLength: '1073741824',
+          chunkCount: '4096',
+        },
+      }),
+    );
+    const maximalCountOneBucket = {
+      ...VALID_BUCKET,
+      era: MAX_DECIMAL_U64.toString(),
+      rows: maximalRows,
+    };
+
+    expect(() => assertAuthorCatalogBucketV1(maximalCountOneBucket)).not.toThrow();
+    expect(new TextEncoder().encode(
+      canonicalizeAuthorCatalogRowV1(maximalRows[0]),
+    ).byteLength).toBe(1_004);
+    const canonical = canonicalizeAuthorCatalogBucketPayloadV1(maximalCountOneBucket);
+    expect(new TextEncoder().encode(canonical).byteLength).toBe(1_029_282);
+
+    // Each row is at its exact field-width maximum (1,004 bytes). Replacing
+    // the one-digit bucketCount/bucketId with their widest permitted 19-digit
+    // forms adds at most 36 bytes, so no structurally valid v1 bucket can reach
+    // the 1 MiB cap even before the bucket-mapping invariant is considered.
+    const absolutePayloadUpperBound = canonical.length + (2 * (19 - 1));
+    expect(absolutePayloadUpperBound).toBe(1_029_318);
+    expect(absolutePayloadUpperBound).toBeLessThan(
+      MAX_AUTHOR_CATALOG_BUCKET_PAYLOAD_BYTES_V1,
+    );
+    expect(parseCanonicalAuthorCatalogBucketPayloadV1(canonical).rows).toHaveLength(
+      MAX_AUTHOR_CATALOG_BUCKET_ROWS_V1,
+    );
+  });
+
   it('rejects assertion version zero through bucket and envelope admission', () => {
     expect(() => assertAuthorCatalogBucketV1({
       ...VALID_BUCKET,
@@ -340,6 +392,37 @@ describe('AuthorCatalogHeadV1 structural codec', () => {
       ...HEAD_UNSIGNED,
       objectType: AUTHOR_CATALOG_BUCKET_OBJECT_TYPE_V1,
     })).toThrow(/catalog-object-type/);
+  });
+
+  it('pins the maximum valid head below 4 KiB and rejects over-cap wire input', () => {
+    const maximalHead = {
+      ...VALID_HEAD,
+      networkId: 'n'.repeat(128),
+      contextGraphId: 'c'.repeat(256),
+      governanceChainId: MAX_DECIMAL_U256.toString(),
+      governanceContractAddress: `0x${'f'.repeat(40)}`,
+      ownershipTransitionDigest: `0x${'f'.repeat(64)}`,
+      subGraphName: 's'.repeat(256),
+      authorAddress: `0x${'f'.repeat(40)}`,
+      catalogIssuerDelegationDigest: `0x${'f'.repeat(64)}`,
+      era: MAX_DECIMAL_U64.toString(),
+      version: MAX_DECIMAL_U64.toString(),
+      previousHeadDigest: `0x${'f'.repeat(64)}`,
+      bucketCount: '9223372036854775808',
+      totalRows: MAX_DECIMAL_U64.toString(),
+      directoryHeight: '7',
+      directoryRootDigest: `0x${'f'.repeat(64)}`,
+      issuedAt: MAX_DECIMAL_U64.toString(),
+    };
+
+    expect(() => assertAuthorCatalogHeadV1(maximalHead)).not.toThrow();
+    const canonical = canonicalizeAuthorCatalogHeadPayloadV1(maximalHead);
+    expect(new TextEncoder().encode(canonical).byteLength).toBe(1_497);
+    expect(canonical.length).toBeLessThan(MAX_AUTHOR_CATALOG_HEAD_PAYLOAD_BYTES_V1);
+    expect(parseCanonicalAuthorCatalogHeadPayloadV1(canonical)).toEqual(maximalHead);
+    expect(() => parseCanonicalAuthorCatalogHeadPayloadV1(
+      '{'.padEnd(MAX_AUTHOR_CATALOG_HEAD_PAYLOAD_BYTES_V1 + 1, 'x'),
+    )).toThrow(/catalog-object-payload-too-large/);
   });
 
   it('wraps and strictly parses the generic signed envelope without authority checks', () => {

--- a/packages/core/test/author-catalog-objects.test.ts
+++ b/packages/core/test/author-catalog-objects.test.ts
@@ -136,13 +136,25 @@ describe('AuthorCatalogBucketV1 structural codec', () => {
   });
 
   it('requires strictly numeric row order and rejects duplicate KA/key/coordinate', () => {
-    const second = rowForNumber(2n, 'fixture-2');
-    const ordered = { ...VALID_BUCKET, rows: [VALID_ROW, second] };
-    expect(() => assertAuthorCatalogBucketV1(ordered)).not.toThrow();
+    const numericTwo = validatedRow({
+      ...VALID_ROW,
+      kaId: '2',
+      assertionCoordinate: 'numeric-2',
+    });
+    const numericTen = validatedRow({
+      ...VALID_ROW,
+      kaId: '10',
+      assertionCoordinate: 'numeric-10',
+    });
     expect(() => assertAuthorCatalogBucketV1({
       ...VALID_BUCKET,
-      rows: [second, VALID_ROW],
+      rows: [numericTwo, numericTen],
+    })).not.toThrow();
+    expect(() => assertAuthorCatalogBucketV1({
+      ...VALID_BUCKET,
+      rows: [numericTen, numericTwo],
     })).toThrow(/catalog-object-row-order/);
+    const second = rowForNumber(2n, 'fixture-2');
     expect(() => assertAuthorCatalogBucketV1({
       ...VALID_BUCKET,
       rows: [VALID_ROW, VALID_ROW],
@@ -154,6 +166,26 @@ describe('AuthorCatalogBucketV1 structural codec', () => {
   });
 
   it('requires every row to map to the signed bucket and bucketId to be in range', () => {
+    const bucketZeroRows = [
+      validatedRow({ ...VALID_ROW, kaId: '2', assertionCoordinate: 'bucket-0-2' }),
+      validatedRow({ ...VALID_ROW, kaId: '10', assertionCoordinate: 'bucket-0-10' }),
+    ];
+    const bucketOneRows = [
+      validatedRow({ ...VALID_ROW, kaId: '4', assertionCoordinate: 'bucket-1-4' }),
+      validatedRow({ ...VALID_ROW, kaId: '6', assertionCoordinate: 'bucket-1-6' }),
+    ];
+    expect(() => assertAuthorCatalogBucketV1({
+      ...VALID_BUCKET,
+      bucketCount: '2',
+      bucketId: '0',
+      rows: bucketZeroRows,
+    })).not.toThrow();
+    expect(() => assertAuthorCatalogBucketV1({
+      ...VALID_BUCKET,
+      bucketCount: '2',
+      bucketId: '1',
+      rows: bucketOneRows,
+    })).not.toThrow();
     expect(() => assertAuthorCatalogBucketV1({
       ...VALID_BUCKET,
       bucketCount: '2',

--- a/packages/core/test/author-catalog-objects.test.ts
+++ b/packages/core/test/author-catalog-objects.test.ts
@@ -1,0 +1,358 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  AUTHOR_CATALOG_BUCKET_OBJECT_TYPE_V1,
+  AUTHOR_CATALOG_HEAD_OBJECT_TYPE_V1,
+  MAX_AUTHOR_CATALOG_BUCKET_PAYLOAD_BYTES_V1,
+  assertAuthorCatalogBucketScopeBindingV1,
+  assertAuthorCatalogBucketV1,
+  assertAuthorCatalogHeadScopeBindingV1,
+  assertAuthorCatalogHeadV1,
+  assertSignedAuthorCatalogBucketEnvelopeV1,
+  assertSignedAuthorCatalogHeadEnvelopeV1,
+  assertUnsignedAuthorCatalogBucketEnvelopeV1,
+  assertUnsignedAuthorCatalogHeadEnvelopeV1,
+  canonicalizeAuthorCatalogBucketPayloadV1,
+  canonicalizeAuthorCatalogHeadPayloadV1,
+  canonicalizeSignedAuthorCatalogBucketEnvelopeBytesV1,
+  canonicalizeSignedAuthorCatalogHeadEnvelopeBytesV1,
+  canonicalizeUnsignedAuthorCatalogBucketEnvelopeBytesV1,
+  canonicalizeUnsignedAuthorCatalogHeadEnvelopeBytesV1,
+  computeAuthorCatalogBucketObjectDigestV1,
+  computeAuthorCatalogDirectoryHeightV1,
+  computeAuthorCatalogHeadObjectDigestV1,
+  deriveAuthorCatalogScopeFromHeadV1,
+  parseCanonicalAuthorCatalogBucketPayloadV1,
+  parseCanonicalAuthorCatalogHeadPayloadV1,
+  parseCanonicalSignedAuthorCatalogBucketEnvelopeV1,
+  parseCanonicalSignedAuthorCatalogHeadEnvelopeV1,
+  parseCanonicalUnsignedAuthorCatalogBucketEnvelopeV1,
+  parseCanonicalUnsignedAuthorCatalogHeadEnvelopeV1,
+  type AuthorCatalogBucketV1,
+  type AuthorCatalogHeadV1,
+} from '../src/author-catalog-objects.js';
+import {
+  assertAuthorCatalogRowV1,
+  assertAuthorCatalogScopeV1,
+  computeAuthorCatalogKeyDigestV1,
+  computeAuthorCatalogRowDigestV1,
+  type AuthorCatalogRowV1,
+  type AuthorCatalogScopeV1,
+} from '../src/author-catalog-codec.js';
+import {
+  type SignedControlEnvelopeV1,
+  type UnsignedControlEnvelopeV1,
+} from '../src/sync-control-object.js';
+
+const SCOPE_DIGEST =
+  '0x7b18d141cbb6af4e7fdabe2e4d7d0b9512b042eb079b89a4797d3a0a7f1d4537';
+const DIRECTORY_ROOT_DIGEST =
+  '0x0163c048997ddaeb984d10a06f98064739a95546cf71d142c0d0a3de19f65f52';
+const HEAD_DIGEST =
+  '0x1c5e2fffa5c62a3d4c00e879c31e9b36e9d4c419b41ad124e30a23f082635af6';
+const BUCKET_DIGEST =
+  '0xddedcd25a1fd2afb797f146b04fec735fd3b341d2f10293a1db9fd915e701866';
+const AUTHOR_BOUND_KA_ID =
+  '23158417847463239084714197001737581570653996933112267175388663934063917137921';
+const AUTHOR = '0x3333333333333333333333333333333333333333';
+const ISSUER = '0x5555555555555555555555555555555555555555';
+const EIP191_SIGNATURE = `0x${'77'.repeat(65)}`;
+
+const SCOPE_CANONICAL =
+  '{"authorAddress":"0x3333333333333333333333333333333333333333","bucketCount":"1","contextGraphId":"0x1111111111111111111111111111111111111111/catalog-fixture","era":"0","governanceChainId":"20430","governanceContractAddress":"0x2222222222222222222222222222222222222222","networkId":"otp:20430","ownershipTransitionDigest":null,"subGraphName":null}';
+const ROW_CANONICAL =
+  '{"assertionCoordinate":"fixture","assertionVersion":"1","kaId":"23158417847463239084714197001737581570653996933112267175388663934063917137921","projectionDigest":"0x0000000000000000000000000000000000000000000000000000000000000000","projectionId":"cg-shared-v1","sealDigest":"0x4444444444444444444444444444444444444444444444444444444444444444","transfer":{"blobDigest":"0x1111111111111111111111111111111111111111111111111111111111111111","byteLength":"16","chunkCount":"1","chunkSize":"262144","chunkTreeRoot":"0x2222222222222222222222222222222222222222222222222222222222222222","codec":"dkg-ka-bundle-v1","projectionDigest":"0x0000000000000000000000000000000000000000000000000000000000000000","projectionId":"cg-shared-v1"}}';
+const BUCKET_CANONICAL =
+  `{"bucketCount":"1","bucketId":"0","catalogScopeDigest":"${SCOPE_DIGEST}","era":"0","rows":[${ROW_CANONICAL}]}`;
+const BUCKET_UNSIGNED_CANONICAL =
+  `{"issuer":"${ISSUER}","objectType":"AuthorCatalogBucketV1","payload":${BUCKET_CANONICAL},"signatureEvidence":{"kind":"none"},"signatureSuite":"eip191-personal-sign-digest-v1"}`;
+
+const HEAD_CANONICAL =
+  '{"authorAddress":"0x3333333333333333333333333333333333333333","bucketCount":"1","catalogIssuerDelegationDigest":"0x6666666666666666666666666666666666666666666666666666666666666666","contextGraphId":"0x1111111111111111111111111111111111111111/catalog-fixture","directoryHeight":"0","directoryRootDigest":"0x0163c048997ddaeb984d10a06f98064739a95546cf71d142c0d0a3de19f65f52","era":"0","governanceChainId":"20430","governanceContractAddress":"0x2222222222222222222222222222222222222222","issuedAt":"1700000000123","networkId":"otp:20430","ownershipTransitionDigest":null,"previousHeadDigest":null,"subGraphName":null,"totalRows":"0","version":"0"}';
+const HEAD_UNSIGNED_CANONICAL =
+  `{"issuer":"${ISSUER}","objectType":"AuthorCatalogHeadV1","payload":${HEAD_CANONICAL},"signatureEvidence":{"kind":"none"},"signatureSuite":"eip191-personal-sign-digest-v1"}`;
+
+const VALID_SCOPE = validatedScope(JSON.parse(SCOPE_CANONICAL));
+const VALID_ROW = validatedRow(JSON.parse(ROW_CANONICAL));
+const VALID_BUCKET = validatedBucket(JSON.parse(BUCKET_CANONICAL));
+const VALID_HEAD = validatedHead(JSON.parse(HEAD_CANONICAL));
+const BUCKET_UNSIGNED = JSON.parse(BUCKET_UNSIGNED_CANONICAL) as UnsignedControlEnvelopeV1;
+const HEAD_UNSIGNED = JSON.parse(HEAD_UNSIGNED_CANONICAL) as UnsignedControlEnvelopeV1;
+const BUCKET_SIGNED = {
+  ...BUCKET_UNSIGNED,
+  objectDigest: BUCKET_DIGEST,
+  signature: EIP191_SIGNATURE,
+} as SignedControlEnvelopeV1;
+const HEAD_SIGNED = {
+  ...HEAD_UNSIGNED,
+  objectDigest: HEAD_DIGEST,
+  signature: EIP191_SIGNATURE,
+} as SignedControlEnvelopeV1;
+
+describe('AuthorCatalogBucketV1 structural codec', () => {
+  it('pins the exact author-bound SQL-1 payload, envelope, key, row, and object vectors', () => {
+    expect(canonicalizeAuthorCatalogBucketPayloadV1(VALID_BUCKET)).toBe(BUCKET_CANONICAL);
+    expect(new TextEncoder().encode(BUCKET_CANONICAL).byteLength).toBe(868);
+    expect(computeAuthorCatalogKeyDigestV1(VALID_ROW.kaId)).toBe(
+      '0x5f49f03c5a2480a80ee4b7dadff8b7c8e18a69358bfdf64a1420dddf513de2e5',
+    );
+    expect(computeAuthorCatalogRowDigestV1(SCOPE_DIGEST, VALID_ROW)).toBe(
+      '0x893392ecdfbf47fac3eb3290bc6f69b9472952439b9233555c523ed8e28f3179',
+    );
+    expect(new TextDecoder().decode(
+      canonicalizeUnsignedAuthorCatalogBucketEnvelopeBytesV1(BUCKET_UNSIGNED),
+    )).toBe(BUCKET_UNSIGNED_CANONICAL);
+    expect(new TextEncoder().encode(BUCKET_UNSIGNED_CANONICAL).byteLength).toBe(1057);
+    expect(computeAuthorCatalogBucketObjectDigestV1(BUCKET_UNSIGNED)).toBe(BUCKET_DIGEST);
+    expect(parseCanonicalAuthorCatalogBucketPayloadV1(BUCKET_CANONICAL)).toEqual(
+      VALID_BUCKET,
+    );
+    expect(parseCanonicalUnsignedAuthorCatalogBucketEnvelopeV1(BUCKET_UNSIGNED_CANONICAL))
+      .toEqual(BUCKET_UNSIGNED);
+  });
+
+  it('validates the exact contextual scope and high-160 author binding', () => {
+    expect(() => assertAuthorCatalogBucketScopeBindingV1(VALID_BUCKET, VALID_SCOPE))
+      .not.toThrow();
+    const unboundRow = validatedRow({ ...VALID_ROW, kaId: '1' });
+    const unboundBucket = validatedBucket({ ...VALID_BUCKET, rows: [unboundRow] });
+    expect(() => assertAuthorCatalogBucketScopeBindingV1(unboundBucket, VALID_SCOPE))
+      .toThrow(/catalog-packed-author-mismatch/);
+    expect(() => assertAuthorCatalogBucketScopeBindingV1(
+      { ...VALID_BUCKET, catalogScopeDigest: `0x${'99'.repeat(32)}` },
+      VALID_SCOPE,
+    )).toThrow(/catalog-object-scope-mismatch/);
+    expect(() => assertAuthorCatalogBucketScopeBindingV1(
+      { ...VALID_BUCKET, era: '1' },
+      VALID_SCOPE,
+    )).toThrow(/catalog-object-scope-mismatch/);
+  });
+
+  it('requires strictly numeric row order and rejects duplicate KA/key/coordinate', () => {
+    const second = rowForNumber(2n, 'fixture-2');
+    const ordered = { ...VALID_BUCKET, rows: [VALID_ROW, second] };
+    expect(() => assertAuthorCatalogBucketV1(ordered)).not.toThrow();
+    expect(() => assertAuthorCatalogBucketV1({
+      ...VALID_BUCKET,
+      rows: [second, VALID_ROW],
+    })).toThrow(/catalog-object-row-order/);
+    expect(() => assertAuthorCatalogBucketV1({
+      ...VALID_BUCKET,
+      rows: [VALID_ROW, VALID_ROW],
+    })).toThrow(/catalog-object-duplicate/);
+    expect(() => assertAuthorCatalogBucketV1({
+      ...VALID_BUCKET,
+      rows: [VALID_ROW, { ...second, assertionCoordinate: VALID_ROW.assertionCoordinate }],
+    })).toThrow(/catalog-object-duplicate/);
+  });
+
+  it('requires every row to map to the signed bucket and bucketId to be in range', () => {
+    expect(() => assertAuthorCatalogBucketV1({
+      ...VALID_BUCKET,
+      bucketCount: '2',
+      bucketId: '1',
+    })).toThrow(/catalog-object-bucket-mapping/);
+    expect(() => assertAuthorCatalogBucketV1({
+      ...VALID_BUCKET,
+      bucketCount: '1',
+      bucketId: '1',
+    })).toThrow(/catalog-object-bucket-mapping/);
+  });
+
+  it('rejects empty, sparse, subclassed, accessor, symbol, and custom-property arrays', () => {
+    expect(() => assertAuthorCatalogBucketV1({ ...VALID_BUCKET, rows: [] })).toThrow(
+      /catalog-object-array/,
+    );
+    expect(() => assertAuthorCatalogBucketV1({
+      ...VALID_BUCKET,
+      rows: new Array(1),
+    })).toThrow(/catalog-object-array/);
+
+    class Rows extends Array<AuthorCatalogRowV1> {}
+    const subclassed = new Rows(VALID_ROW);
+    expect(() => assertAuthorCatalogBucketV1({ ...VALID_BUCKET, rows: subclassed }))
+      .toThrow(/catalog-object-array/);
+
+    const accessor = [VALID_ROW];
+    Object.defineProperty(accessor, '0', { enumerable: true, get: () => VALID_ROW });
+    expect(() => assertAuthorCatalogBucketV1({ ...VALID_BUCKET, rows: accessor }))
+      .toThrow(/catalog-object-array/);
+
+    const withSymbol = [VALID_ROW] as Array<AuthorCatalogRowV1> & Record<PropertyKey, unknown>;
+    withSymbol[Symbol('hidden')] = true;
+    expect(() => assertAuthorCatalogBucketV1({ ...VALID_BUCKET, rows: withSymbol }))
+      .toThrow(/catalog-object-array/);
+
+    const withCustom = [VALID_ROW] as Array<AuthorCatalogRowV1> & { extra?: boolean };
+    withCustom.extra = true;
+    expect(() => assertAuthorCatalogBucketV1({ ...VALID_BUCKET, rows: withCustom }))
+      .toThrow(/catalog-object-array/);
+  });
+
+  it('never consumes a poisoned inherited rows iterator', () => {
+    const rows = [VALID_ROW];
+    const originalIterator = Array.prototype[Symbol.iterator];
+    Object.defineProperty(Array.prototype, Symbol.iterator, {
+      configurable: true,
+      writable: true,
+      value(this: unknown[]) {
+        if (this === rows) throw new Error('poisoned rows iterator was consumed');
+        return originalIterator.call(this);
+      },
+    });
+    try {
+      const bucket = { ...VALID_BUCKET, rows };
+      expect(() => assertAuthorCatalogBucketV1(bucket)).not.toThrow();
+      expect(() => assertAuthorCatalogBucketScopeBindingV1(bucket, VALID_SCOPE)).not.toThrow();
+    } finally {
+      Object.defineProperty(Array.prototype, Symbol.iterator, {
+        configurable: true,
+        writable: true,
+        value: originalIterator,
+      });
+    }
+  });
+
+  it('rejects hostile payload fields, row count, wire cap, and wrong object type', () => {
+    expect(() => assertAuthorCatalogBucketV1({ ...VALID_BUCKET, headDigest: SCOPE_DIGEST }))
+      .toThrow(/catalog-object-schema/);
+    const accessor = { ...VALID_BUCKET };
+    Object.defineProperty(accessor, 'era', { enumerable: true, get: () => '0' });
+    expect(() => assertAuthorCatalogBucketV1(accessor)).toThrow(/catalog-object-schema/);
+    const symbol = { ...VALID_BUCKET } as Record<PropertyKey, unknown>;
+    symbol[Symbol('hidden')] = true;
+    expect(() => assertAuthorCatalogBucketV1(symbol)).toThrow(/catalog-object-schema/);
+    expect(() => assertAuthorCatalogBucketV1({
+      ...VALID_BUCKET,
+      rows: Array.from({ length: 1025 }, () => VALID_ROW),
+    })).toThrow(/catalog-object-array/);
+    expect(() => parseCanonicalAuthorCatalogBucketPayloadV1(
+      '{'.padEnd(MAX_AUTHOR_CATALOG_BUCKET_PAYLOAD_BYTES_V1 + 1, 'x'),
+    )).toThrow(/catalog-object-payload-too-large/);
+    expect(() => assertUnsignedAuthorCatalogBucketEnvelopeV1({
+      ...BUCKET_UNSIGNED,
+      objectType: AUTHOR_CATALOG_HEAD_OBJECT_TYPE_V1,
+    })).toThrow(/catalog-object-type/);
+  });
+
+  it('wraps and strictly parses the generic signed envelope without authority checks', () => {
+    expect(() => assertSignedAuthorCatalogBucketEnvelopeV1(BUCKET_SIGNED)).not.toThrow();
+    const bytes = canonicalizeSignedAuthorCatalogBucketEnvelopeBytesV1(BUCKET_SIGNED);
+    expect(parseCanonicalSignedAuthorCatalogBucketEnvelopeV1(bytes)).toEqual(BUCKET_SIGNED);
+    expect(() => parseCanonicalUnsignedAuthorCatalogBucketEnvelopeV1(
+      ` ${BUCKET_UNSIGNED_CANONICAL}`,
+    )).toThrow(/not RFC 8785 canonical/);
+  });
+});
+
+describe('AuthorCatalogHeadV1 structural codec', () => {
+  it('pins the exact empty-genesis payload, unsigned envelope, and object digest', () => {
+    expect(canonicalizeAuthorCatalogHeadPayloadV1(VALID_HEAD)).toBe(HEAD_CANONICAL);
+    expect(new TextEncoder().encode(HEAD_CANONICAL).byteLength).toBe(643);
+    expect(new TextDecoder().decode(
+      canonicalizeUnsignedAuthorCatalogHeadEnvelopeBytesV1(HEAD_UNSIGNED),
+    )).toBe(HEAD_UNSIGNED_CANONICAL);
+    expect(new TextEncoder().encode(HEAD_UNSIGNED_CANONICAL).byteLength).toBe(830);
+    expect(computeAuthorCatalogHeadObjectDigestV1(HEAD_UNSIGNED)).toBe(HEAD_DIGEST);
+    expect(parseCanonicalAuthorCatalogHeadPayloadV1(HEAD_CANONICAL)).toEqual(VALID_HEAD);
+    expect(parseCanonicalUnsignedAuthorCatalogHeadEnvelopeV1(HEAD_UNSIGNED_CANONICAL))
+      .toEqual(HEAD_UNSIGNED);
+  });
+
+  it('derives and binds the exact nine-key scope', () => {
+    expect(deriveAuthorCatalogScopeFromHeadV1(VALID_HEAD)).toEqual(VALID_SCOPE);
+    expect(() => assertAuthorCatalogHeadScopeBindingV1(VALID_HEAD, VALID_SCOPE)).not.toThrow();
+    const otherScope = validatedScope({ ...VALID_SCOPE, era: '1' });
+    expect(() => assertAuthorCatalogHeadScopeBindingV1(VALID_HEAD, otherScope)).toThrow(
+      /catalog-object-scope-mismatch/,
+    );
+  });
+
+  it.each([
+    ['1', '0'],
+    ['256', '0'],
+    ['512', '1'],
+    ['65536', '1'],
+    ['131072', '2'],
+    ['9223372036854775808', '7'],
+  ])('derives directory height %s -> %s', (bucketCount, expectedHeight) => {
+    expect(computeAuthorCatalogDirectoryHeightV1(bucketCount)).toBe(expectedHeight);
+    expect(() => assertAuthorCatalogHeadV1({
+      ...VALID_HEAD,
+      bucketCount,
+      directoryHeight: expectedHeight,
+    })).not.toThrow();
+  });
+
+  it('rejects a mismatched height, zero root, malformed scalar, and half-null governance tuple', () => {
+    expect(() => assertAuthorCatalogHeadV1({
+      ...VALID_HEAD,
+      bucketCount: '512',
+      directoryHeight: '0',
+    })).toThrow(/catalog-object-directory-height/);
+    expect(() => assertAuthorCatalogHeadV1({
+      ...VALID_HEAD,
+      directoryRootDigest: `0x${'00'.repeat(32)}`,
+    })).toThrow(/nonzero directory object/);
+    expect(() => assertAuthorCatalogHeadV1({ ...VALID_HEAD, totalRows: 0 })).toThrow(
+      /catalog-object-scalar/,
+    );
+    expect(() => assertAuthorCatalogHeadV1({
+      ...VALID_HEAD,
+      governanceContractAddress: null,
+    })).toThrow(/both be null or both non-null/);
+  });
+
+  it('rejects missing, extra, accessor, symbol, and wrong object-type fields', () => {
+    const missing = { ...VALID_HEAD } as Record<string, unknown>;
+    delete missing.version;
+    expect(() => assertAuthorCatalogHeadV1(missing)).toThrow(/catalog-object-schema/);
+    expect(() => assertAuthorCatalogHeadV1({ ...VALID_HEAD, tier: 'swm' })).toThrow(
+      /catalog-object-schema/,
+    );
+    const accessor = { ...VALID_HEAD };
+    Object.defineProperty(accessor, 'version', { enumerable: true, get: () => '0' });
+    expect(() => assertAuthorCatalogHeadV1(accessor)).toThrow(/catalog-object-schema/);
+    const symbol = { ...VALID_HEAD } as Record<PropertyKey, unknown>;
+    symbol[Symbol('hidden')] = true;
+    expect(() => assertAuthorCatalogHeadV1(symbol)).toThrow(/catalog-object-schema/);
+    expect(() => assertUnsignedAuthorCatalogHeadEnvelopeV1({
+      ...HEAD_UNSIGNED,
+      objectType: AUTHOR_CATALOG_BUCKET_OBJECT_TYPE_V1,
+    })).toThrow(/catalog-object-type/);
+  });
+
+  it('wraps and strictly parses the generic signed envelope without authority checks', () => {
+    expect(() => assertSignedAuthorCatalogHeadEnvelopeV1(HEAD_SIGNED)).not.toThrow();
+    const bytes = canonicalizeSignedAuthorCatalogHeadEnvelopeBytesV1(HEAD_SIGNED);
+    expect(parseCanonicalSignedAuthorCatalogHeadEnvelopeV1(bytes)).toEqual(HEAD_SIGNED);
+    expect(() => parseCanonicalUnsignedAuthorCatalogHeadEnvelopeV1(
+      HEAD_UNSIGNED_CANONICAL.replace('"version":"0"', '"version":"0","version":"0"'),
+    )).toThrow(/Duplicate object key/);
+  });
+});
+
+function rowForNumber(number: bigint, coordinate: string): AuthorCatalogRowV1 {
+  const kaId = ((BigInt(AUTHOR) << 96n) | number).toString();
+  return validatedRow({ ...VALID_ROW, kaId, assertionCoordinate: coordinate });
+}
+
+function validatedScope(value: unknown): AuthorCatalogScopeV1 {
+  assertAuthorCatalogScopeV1(value);
+  return value;
+}
+
+function validatedRow(value: unknown): AuthorCatalogRowV1 {
+  assertAuthorCatalogRowV1(value);
+  return value;
+}
+
+function validatedBucket(value: unknown): AuthorCatalogBucketV1 {
+  assertAuthorCatalogBucketV1(value);
+  return value;
+}
+
+function validatedHead(value: unknown): AuthorCatalogHeadV1 {
+  assertAuthorCatalogHeadV1(value);
+  return value;
+}


### PR DESCRIPTION
## Summary

Adds the dormant RFC-64 author-catalog bucket and head structural codecs as the next small stacked implementation slice.

- freezes the exact nonempty bucket and catalog-head object schemas
- validates numeric row ordering, duplicate identities, high-bit bucket mapping, and author-bound packed KA identifiers
- enforces the 1..1024-row, 1 MiB bucket, 4 KiB head, and generic envelope ceilings in layers
- derives the exact directory height from the frozen power-of-two bucket count
- rejects hostile sparse, subclassed, accessor-bearing, symbol-bearing, and iterator-poisoned arrays
- pins the canonical empty-head and positive author-bound bucket vectors

This PR intentionally does not add directory nodes, persistence, network handlers, authority/history transitions, complete catalog closure, or runtime activation. PR #1780 remains the canonical post-transfer graph-scoped seal admission seam on the integration branch; structural catalog staging has no payload `_meta` rows and therefore does not invoke it.

## Validation

- focused author-catalog tests: 38 passed
- full core suite passed
- core TypeScript build passed
- two independent hostile-input audits found no P0/P1/P2 issue
- git diff --check passed

## Stack

Base: #1795
Integration branch: `integration/rfc64-devnet`
