### PR TITLE
fix(core): freeze RFC-64 control signature suites

### DIFF
--- a/packages/core/src/sync-control-object.ts
+++ b/packages/core/src/sync-control-object.ts
@@ -318,10 +318,7 @@ function assertUnsignedControlEnvelopeFields(
   if (/[ -]/u.test(envelope.objectType)) {
     throw new Error('Control-object type is outside the canonical string bounds');
   }
-  if (
-    envelope.signatureSuite !== 'eip191-personal-sign-digest-v1'
-    && envelope.signatureSuite !== 'eip1271-current-finalized-v1'
-  ) {
+  if (!isControlObjectSignatureSuite(envelope.signatureSuite)) {
     throw new Error('Unsupported control-object signature suite');
   }
   assertCanonicalEvmAddress(envelope.issuer, 'issuer');
@@ -357,6 +354,13 @@ function assertUnsignedControlEnvelopeFields(
       throw new Error('EIP-1271 evidence contract must equal the envelope issuer');
     }
   }
+}
+
+function isControlObjectSignatureSuite(
+  value: unknown,
+): value is ControlObjectSignatureSuite {
+  return typeof value === 'string'
+    && CONTROL_OBJECT_SIGNATURE_SUITES.includes(value as ControlObjectSignatureSuite);
 }
 
 function assertSignatureForSuite(

--- a/packages/core/src/sync-control-object.ts
+++ b/packages/core/src/sync-control-object.ts
@@ -25,10 +25,10 @@ export const EIP191_SIGNATURE_BYTES = 65;
 export const MAX_EIP1271_SIGNATURE_BYTES = 4096;
 export const MAX_CONTROL_SIGNATURE_VARIANT_BYTES = 16 * 1024;
 
-export const CONTROL_OBJECT_SIGNATURE_SUITES = [
+export const CONTROL_OBJECT_SIGNATURE_SUITES = Object.freeze([
   'eip191-personal-sign-digest-v1',
   'eip1271-current-finalized-v1',
-] as const;
+] as const);
 
 export type ControlObjectSignatureSuite = (typeof CONTROL_OBJECT_SIGNATURE_SUITES)[number];
 
@@ -318,8 +318,11 @@ function assertUnsignedControlEnvelopeFields(
   if (/[ -]/u.test(envelope.objectType)) {
     throw new Error('Control-object type is outside the canonical string bounds');
   }
-  if (!CONTROL_OBJECT_SIGNATURE_SUITES.includes(envelope.signatureSuite)) {
-    throw new Error(`Unsupported control-object signature suite: ${String(envelope.signatureSuite)}`);
+  if (
+    envelope.signatureSuite !== 'eip191-personal-sign-digest-v1'
+    && envelope.signatureSuite !== 'eip1271-current-finalized-v1'
+  ) {
+    throw new Error('Unsupported control-object signature suite');
   }
   assertCanonicalEvmAddress(envelope.issuer, 'issuer');
 

--- a/packages/core/test/sync-control-object.test.ts
+++ b/packages/core/test/sync-control-object.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  CONTROL_OBJECT_SIGNATURE_SUITES,
   MAX_CONTROL_OBJECT_BYTES,
   MAX_EIP1271_SIGNATURE_BYTES,
   assertControlObjectDigest,
@@ -176,6 +177,18 @@ describe('Track-2 control-object envelopes', () => {
       ...SAFE_VECTOR,
       signatureEvidence: { kind: 'none' },
     })).toThrow(/EIP-1271 signature evidence|unknown or missing fields/);
+  });
+
+  it('keeps the exact signature-suite registry immutable and non-authoritative', () => {
+    expect(Object.isFrozen(CONTROL_OBJECT_SIGNATURE_SUITES)).toBe(true);
+    expect(() => (CONTROL_OBJECT_SIGNATURE_SUITES as unknown as string[]).push('evil-suite'))
+      .toThrow();
+    expect(() => assertUnsignedControlEnvelope({
+      ...SAFE_VECTOR,
+      signatureSuite: 'evil-suite',
+    } as unknown as UnsignedControlEnvelopeV1)).toThrow(
+      /Unsupported control-object signature suite/,
+    );
   });
 
   it.each(['01', '+1', '-1', '1.0', '1e3', ''])('rejects non-canonical chainId %j', (chainId) => {

--- a/packages/core/test/sync-control-object.test.ts
+++ b/packages/core/test/sync-control-object.test.ts
@@ -14,6 +14,7 @@ import {
   parseCanonicalControlSignatureVariant,
   parseCanonicalSignedControlEnvelope,
   parseCanonicalUnsignedControlEnvelope,
+  type ControlObjectSignatureSuite,
   type SignedControlEnvelopeV1,
   type UnsignedControlEnvelopeV1,
 } from '../src/sync-control-object.js';
@@ -179,10 +180,18 @@ describe('Track-2 control-object envelopes', () => {
     })).toThrow(/EIP-1271 signature evidence|unknown or missing fields/);
   });
 
-  it('keeps the exact signature-suite registry immutable and non-authoritative', () => {
+  it('keeps the immutable signature-suite registry authoritative', () => {
     expect(Object.isFrozen(CONTROL_OBJECT_SIGNATURE_SUITES)).toBe(true);
     expect(() => (CONTROL_OBJECT_SIGNATURE_SUITES as unknown as string[]).push('evil-suite'))
       .toThrow();
+    const validEnvelopeBySuite = {
+      'eip191-personal-sign-digest-v1': EOA_VECTOR,
+      'eip1271-current-finalized-v1': SAFE_VECTOR,
+    } satisfies Record<ControlObjectSignatureSuite, UnsignedControlEnvelopeV1>;
+    for (const suite of CONTROL_OBJECT_SIGNATURE_SUITES) {
+      expect(validEnvelopeBySuite[suite].signatureSuite).toBe(suite);
+      expect(() => assertUnsignedControlEnvelope(validEnvelopeBySuite[suite])).not.toThrow();
+    }
     expect(() => assertUnsignedControlEnvelope({
       ...SAFE_VECTOR,
       signatureSuite: 'evil-suite',


### PR DESCRIPTION
## Summary
- freeze the exported RFC-64 control-object signature-suite registry
- validate signature suites with exact literal branches instead of trusting mutable registry state
- avoid coercing hostile invalid values while formatting validation errors
- add a regression proving registry mutation cannot expand accepted suites

## Verification
- focused RFC-64 control and policy tests: 42 passed
- `@dkg/core` build: passed
- `git diff --check`: passed

Stacked on the canonical author-seal slice; the policy/roster codec PR will build on this hardening.