### PR TITLE
feat(core): add RFC-64 policy and roster codecs

### DIFF
--- a/packages/core/src/cg-policy-objects.ts
+++ b/packages/core/src/cg-policy-objects.ts
@@ -555,23 +555,26 @@ function assertMemberRosterStructureV1(value: unknown): asserts value is MemberR
     }
     previousAddress = agentAddress;
     assertDenseArray(member.roles, `members[${index}].roles`, MEMBER_ROSTER_ROLES_V1.length);
-    let previousRole: string | undefined;
+    let previousRole: MemberRosterRoleV1 | undefined;
+    let previousRoleIndex = -1;
     for (let roleIndex = 0; roleIndex < member.roles.length; roleIndex += 1) {
       const roleValue = member.roles[roleIndex];
       if (typeof roleValue !== 'string') {
         fail('cg-policy-role', 'member role must be a string');
       }
-      if (!isMemberRosterRoleV1(roleValue)) {
+      const canonicalRoleIndex = memberRosterRoleIndexV1(roleValue);
+      if (canonicalRoleIndex < 0) {
         fail('cg-policy-role', `unknown member role ${roleValue}`);
       }
       const role = roleValue as MemberRosterRoleV1;
-      if (previousRole !== undefined && previousRole >= role) {
+      if (previousRole !== undefined && previousRoleIndex >= canonicalRoleIndex) {
         fail(
           previousRole === role ? 'cg-policy-duplicate' : 'cg-policy-order',
           'member roles must be strictly sorted',
         );
       }
       previousRole = role;
+      previousRoleIndex = canonicalRoleIndex;
     }
   }
   scalar(() => assertCanonicalTimestampMs(value.issuedAt, 'issuedAt'));
@@ -673,8 +676,11 @@ function assertStablePlainDataShape(
   }
 }
 
-function isMemberRosterRoleV1(value: string): value is MemberRosterRoleV1 {
-  return value === 'holder' || value === 'ingress-host' || value === 'provider';
+function memberRosterRoleIndexV1(value: string): number {
+  for (let index = 0; index < MEMBER_ROSTER_ROLES_V1.length; index += 1) {
+    if (MEMBER_ROSTER_ROLES_V1[index] === value) return index;
+  }
+  return -1;
 }
 
 function assertGovernancePair(chainId: unknown, contractAddress: unknown): void {
@@ -770,7 +776,12 @@ function asDigest(value: string): Digest32V1 {
 }
 
 function rejectOversizedInput(input: string | Uint8Array, maxBytes: number, label: string): void {
-  const bytes = typeof input === 'string' ? new TextEncoder().encode(input).byteLength : input.byteLength;
+  if (typeof input === 'string' && input.length > maxBytes) {
+    fail('cg-policy-payload-too-large', `${label} exceeds ${maxBytes} bytes`);
+  }
+  const bytes = typeof input === 'string'
+    ? new TextEncoder().encode(input).byteLength
+    : input.byteLength;
   if (bytes > maxBytes) fail('cg-policy-payload-too-large', `${label} exceeds ${maxBytes} bytes`);
 }
 

--- a/packages/core/src/cg-policy-objects.ts
+++ b/packages/core/src/cg-policy-objects.ts
@@ -51,6 +51,11 @@ export const MEMBER_ROSTER_ROLES_V1 = Object.freeze([
 
 export type ContextGraphAccessPolicyV1 = 0 | 1;
 export type ContextGraphPublishPolicyV1 = 0 | 1;
+
+// Numeric publish-policy wire states: 0 = curated, 1 = open. Named here so the
+// cross-field validator does not branch on a bare `=== 1`. The JSON wire value
+// stays the raw number.
+const CONTEXT_GRAPH_PUBLISH_POLICY_OPEN_V1 = 1;
 export type MemberRosterRoleV1 = (typeof MEMBER_ROSTER_ROLES_V1)[number];
 
 export interface FinalizedChainPolicySourceV1 {
@@ -420,7 +425,7 @@ function assertContextGraphPolicyStructureV1(
     value.publishAuthorityAccountId,
     'publishAuthorityAccountId',
   ));
-  if (value.publishPolicy === 1) {
+  if (value.publishPolicy === CONTEXT_GRAPH_PUBLISH_POLICY_OPEN_V1) {
     if (value.publishAuthority !== null || value.publishAuthorityAccountId !== '0') {
       fail(
         'cg-policy-publish-domain',
@@ -428,6 +433,7 @@ function assertContextGraphPolicyStructureV1(
       );
     }
   } else if (value.publishAuthority === null) {
+    // else: publishPolicy is 0 (curated) — a curated CG requires a publish authority.
     fail('cg-policy-publish-domain', 'curated contribution requires publishAuthority');
   }
   if (value.projectionId !== CONTEXT_GRAPH_SHARED_PROJECTION_ID_V1) {

--- a/packages/core/src/cg-policy-objects.ts
+++ b/packages/core/src/cg-policy-objects.ts
@@ -1,0 +1,779 @@
+import {
+  canonicalizeJson,
+  parseCanonicalJson,
+  type CanonicalJsonValue,
+  type StrictJsonParseOptions,
+} from './canonical-json.js';
+import {
+  assertContextGraphIdV1,
+  assertNetworkIdV1,
+  type ContextGraphIdV1,
+  type NetworkIdV1,
+} from './author-catalog-codec.js';
+import {
+  assertSignedControlEnvelope,
+  assertUnsignedControlEnvelope,
+  canonicalizeSignedControlEnvelopeBytes,
+  canonicalizeUnsignedControlEnvelopeBytes,
+  computeControlObjectDigestHex,
+  parseCanonicalSignedControlEnvelope,
+  parseCanonicalUnsignedControlEnvelope,
+  type SignedControlEnvelopeV1,
+  type UnsignedControlEnvelopeV1,
+} from './sync-control-object.js';
+import {
+  assertCanonicalChainId,
+  assertCanonicalDecimalU256,
+  assertCanonicalDigest,
+  assertCanonicalEvmAddress,
+  assertCanonicalTimestampMs,
+  parseCanonicalDecimalU64,
+  type ChainIdV1,
+  type DecimalU256V1,
+  type DecimalU64V1,
+  type Digest32V1,
+  type EvmAddressV1,
+  type TimestampMsV1,
+} from './sync-wire-scalars.js';
+import { assertExactKeys, isPlainRecord } from './sync-wire-objects.js';
+
+export const CONTEXT_GRAPH_POLICY_OBJECT_TYPE_V1 = 'ContextGraphPolicyV1' as const;
+export const MEMBER_ROSTER_OBJECT_TYPE_V1 = 'MemberRosterV1' as const;
+export const CONTEXT_GRAPH_SHARED_PROJECTION_ID_V1 = 'cg-shared-v1' as const;
+export const MAX_CONTEXT_GRAPH_POLICY_PAYLOAD_BYTES_V1 = 8 * 1024;
+export const MAX_MEMBER_ROSTER_PAYLOAD_BYTES_V1 = 4 * 1024 * 1024;
+export const MAX_MEMBER_ROSTER_ENTRIES_V1 = 16_384;
+export const MEMBER_ROSTER_ROLES_V1 = Object.freeze([
+  'holder',
+  'ingress-host',
+  'provider',
+] as const);
+
+export type ContextGraphAccessPolicyV1 = 0 | 1;
+export type ContextGraphPublishPolicyV1 = 0 | 1;
+export type MemberRosterRoleV1 = (typeof MEMBER_ROSTER_ROLES_V1)[number];
+
+export interface FinalizedChainPolicySourceV1 {
+  readonly kind: 'finalized-chain';
+  readonly chainId: ChainIdV1;
+  readonly contractAddress: EvmAddressV1;
+  readonly blockNumber: DecimalU64V1;
+  readonly blockHash: Digest32V1;
+}
+
+export interface OwnerSignedUnregisteredPolicySourceV1 {
+  readonly kind: 'owner-signed-unregistered';
+  readonly ownerAddress: EvmAddressV1;
+  readonly ownerAuthorityEra: DecimalU64V1;
+}
+
+export type ContextGraphPolicySourceV1 =
+  | FinalizedChainPolicySourceV1
+  | OwnerSignedUnregisteredPolicySourceV1;
+
+export interface ContextGraphPolicyV1 {
+  readonly networkId: NetworkIdV1;
+  readonly contextGraphId: ContextGraphIdV1;
+  readonly governanceChainId: ChainIdV1 | null;
+  readonly governanceContractAddress: EvmAddressV1 | null;
+  readonly ownershipTransitionDigest: Digest32V1 | null;
+  readonly era: DecimalU64V1;
+  readonly version: DecimalU64V1;
+  readonly previousPolicyDigest: Digest32V1 | null;
+  readonly accessPolicy: ContextGraphAccessPolicyV1;
+  readonly publishPolicy: ContextGraphPublishPolicyV1;
+  readonly publishAuthority: EvmAddressV1 | null;
+  readonly publishAuthorityAccountId: DecimalU256V1;
+  readonly projectionId: typeof CONTEXT_GRAPH_SHARED_PROJECTION_ID_V1;
+  readonly administrativeDelegationDigest: Digest32V1 | null;
+  readonly source: ContextGraphPolicySourceV1;
+  readonly effectiveAt: TimestampMsV1;
+  readonly issuedAt: TimestampMsV1;
+}
+
+export interface MemberRosterEntryV1 {
+  readonly agentAddress: EvmAddressV1;
+  readonly roles: readonly MemberRosterRoleV1[];
+}
+
+export interface MemberRosterV1 {
+  readonly networkId: NetworkIdV1;
+  readonly contextGraphId: ContextGraphIdV1;
+  readonly ownershipTransitionDigest: Digest32V1 | null;
+  readonly era: DecimalU64V1;
+  readonly version: DecimalU64V1;
+  readonly previousRosterDigest: Digest32V1 | null;
+  readonly policyDigest: Digest32V1;
+  readonly administrativeDelegationDigest: Digest32V1 | null;
+  readonly members: readonly MemberRosterEntryV1[];
+  readonly issuedAt: TimestampMsV1;
+}
+
+export type UnsignedContextGraphPolicyEnvelopeV1 = UnsignedControlEnvelopeV1 & {
+  readonly objectType: typeof CONTEXT_GRAPH_POLICY_OBJECT_TYPE_V1;
+  readonly payload: ContextGraphPolicyV1;
+};
+export type SignedContextGraphPolicyEnvelopeV1 = SignedControlEnvelopeV1 & {
+  readonly objectType: typeof CONTEXT_GRAPH_POLICY_OBJECT_TYPE_V1;
+  readonly payload: ContextGraphPolicyV1;
+};
+export type UnsignedMemberRosterEnvelopeV1 = UnsignedControlEnvelopeV1 & {
+  readonly objectType: typeof MEMBER_ROSTER_OBJECT_TYPE_V1;
+  readonly payload: MemberRosterV1;
+};
+export type SignedMemberRosterEnvelopeV1 = SignedControlEnvelopeV1 & {
+  readonly objectType: typeof MEMBER_ROSTER_OBJECT_TYPE_V1;
+  readonly payload: MemberRosterV1;
+};
+
+export type CgPolicyObjectCodecErrorCode =
+  | 'cg-policy-schema'
+  | 'cg-policy-scalar'
+  | 'cg-policy-type'
+  | 'cg-policy-governance'
+  | 'cg-policy-publish-domain'
+  | 'cg-policy-array'
+  | 'cg-policy-order'
+  | 'cg-policy-duplicate'
+  | 'cg-policy-role'
+  | 'cg-policy-payload-too-large';
+
+export class CgPolicyObjectCodecError extends Error {
+  constructor(
+    readonly code: CgPolicyObjectCodecErrorCode,
+    message: string,
+    options: ErrorOptions = {},
+  ) {
+    super(`[${code}] ${message}`, options);
+    this.name = 'CgPolicyObjectCodecError';
+  }
+}
+
+export function assertContextGraphPolicyV1(
+  value: unknown,
+): asserts value is ContextGraphPolicyV1 {
+  validateContextGraphPolicySnapshotV1(value);
+}
+
+export function canonicalizeContextGraphPolicyPayloadV1(
+  policy: ContextGraphPolicyV1,
+): string {
+  return validateContextGraphPolicySnapshotV1(policy).canonical;
+}
+
+export function canonicalizeContextGraphPolicyPayloadBytesV1(
+  policy: ContextGraphPolicyV1,
+): Uint8Array {
+  return new TextEncoder().encode(canonicalizeContextGraphPolicyPayloadV1(policy));
+}
+
+export function parseCanonicalContextGraphPolicyPayloadV1(
+  input: string | Uint8Array,
+  options: StrictJsonParseOptions = {},
+): ContextGraphPolicyV1 {
+  rejectOversizedInput(input, MAX_CONTEXT_GRAPH_POLICY_PAYLOAD_BYTES_V1, 'CG policy');
+  const value = parseCanonicalJson(input, {
+    ...options,
+    maxBytes: Math.min(
+      options.maxBytes ?? MAX_CONTEXT_GRAPH_POLICY_PAYLOAD_BYTES_V1,
+      MAX_CONTEXT_GRAPH_POLICY_PAYLOAD_BYTES_V1,
+    ),
+    maxDepth: Math.min(options.maxDepth ?? 2, 2),
+  });
+  return validateContextGraphPolicySnapshotV1(value).snapshot;
+}
+
+export function assertMemberRosterV1(value: unknown): asserts value is MemberRosterV1 {
+  validateMemberRosterSnapshotV1(value);
+}
+
+export function canonicalizeMemberRosterPayloadV1(roster: MemberRosterV1): string {
+  return validateMemberRosterSnapshotV1(roster).canonical;
+}
+
+export function canonicalizeMemberRosterPayloadBytesV1(roster: MemberRosterV1): Uint8Array {
+  return new TextEncoder().encode(canonicalizeMemberRosterPayloadV1(roster));
+}
+
+export function parseCanonicalMemberRosterPayloadV1(
+  input: string | Uint8Array,
+  options: StrictJsonParseOptions = {},
+): MemberRosterV1 {
+  rejectOversizedInput(input, MAX_MEMBER_ROSTER_PAYLOAD_BYTES_V1, 'member roster');
+  const value = parseCanonicalJson(input, {
+    ...options,
+    maxBytes: Math.min(
+      options.maxBytes ?? MAX_MEMBER_ROSTER_PAYLOAD_BYTES_V1,
+      MAX_MEMBER_ROSTER_PAYLOAD_BYTES_V1,
+    ),
+    maxDepth: Math.min(options.maxDepth ?? 4, 4),
+  });
+  return validateMemberRosterSnapshotV1(value).snapshot;
+}
+
+export function assertUnsignedContextGraphPolicyEnvelopeV1(
+  envelope: UnsignedControlEnvelopeV1,
+): asserts envelope is UnsignedContextGraphPolicyEnvelopeV1 {
+  validateUnsignedContextGraphPolicyEnvelopeSnapshotV1(envelope);
+}
+
+export function assertSignedContextGraphPolicyEnvelopeV1(
+  envelope: SignedControlEnvelopeV1,
+): asserts envelope is SignedContextGraphPolicyEnvelopeV1 {
+  validateSignedContextGraphPolicyEnvelopeSnapshotV1(envelope);
+}
+
+export function assertUnsignedMemberRosterEnvelopeV1(
+  envelope: UnsignedControlEnvelopeV1,
+): asserts envelope is UnsignedMemberRosterEnvelopeV1 {
+  validateUnsignedMemberRosterEnvelopeSnapshotV1(envelope);
+}
+
+export function assertSignedMemberRosterEnvelopeV1(
+  envelope: SignedControlEnvelopeV1,
+): asserts envelope is SignedMemberRosterEnvelopeV1 {
+  validateSignedMemberRosterEnvelopeSnapshotV1(envelope);
+}
+
+export function canonicalizeUnsignedContextGraphPolicyEnvelopeBytesV1(
+  envelope: UnsignedControlEnvelopeV1,
+): Uint8Array {
+  const snapshot = validateUnsignedContextGraphPolicyEnvelopeSnapshotV1(envelope);
+  return canonicalizeUnsignedControlEnvelopeBytes(snapshot);
+}
+
+export function canonicalizeSignedContextGraphPolicyEnvelopeBytesV1(
+  envelope: SignedControlEnvelopeV1,
+): Uint8Array {
+  const snapshot = validateSignedContextGraphPolicyEnvelopeSnapshotV1(envelope);
+  return canonicalizeSignedControlEnvelopeBytes(snapshot);
+}
+
+export function canonicalizeUnsignedMemberRosterEnvelopeBytesV1(
+  envelope: UnsignedControlEnvelopeV1,
+): Uint8Array {
+  const snapshot = validateUnsignedMemberRosterEnvelopeSnapshotV1(envelope);
+  return canonicalizeUnsignedControlEnvelopeBytes(snapshot);
+}
+
+export function canonicalizeSignedMemberRosterEnvelopeBytesV1(
+  envelope: SignedControlEnvelopeV1,
+): Uint8Array {
+  const snapshot = validateSignedMemberRosterEnvelopeSnapshotV1(envelope);
+  return canonicalizeSignedControlEnvelopeBytes(snapshot);
+}
+
+export function computeContextGraphPolicyObjectDigestV1(
+  envelope: UnsignedControlEnvelopeV1,
+): Digest32V1 {
+  const snapshot = validateUnsignedContextGraphPolicyEnvelopeSnapshotV1(envelope);
+  return asDigest(computeControlObjectDigestHex(snapshot));
+}
+
+export function computeMemberRosterObjectDigestV1(
+  envelope: UnsignedControlEnvelopeV1,
+): Digest32V1 {
+  const snapshot = validateUnsignedMemberRosterEnvelopeSnapshotV1(envelope);
+  return asDigest(computeControlObjectDigestHex(snapshot));
+}
+
+export function parseCanonicalUnsignedContextGraphPolicyEnvelopeV1(
+  input: string | Uint8Array,
+  options: StrictJsonParseOptions = {},
+): UnsignedContextGraphPolicyEnvelopeV1 {
+  const envelope = parseCanonicalUnsignedControlEnvelope(input, options);
+  return validateUnsignedContextGraphPolicyEnvelopeSnapshotV1(envelope);
+}
+
+export function parseCanonicalSignedContextGraphPolicyEnvelopeV1(
+  input: string | Uint8Array,
+  options: StrictJsonParseOptions = {},
+): SignedContextGraphPolicyEnvelopeV1 {
+  const envelope = parseCanonicalSignedControlEnvelope(input, options);
+  return validateSignedContextGraphPolicyEnvelopeSnapshotV1(envelope);
+}
+
+export function parseCanonicalUnsignedMemberRosterEnvelopeV1(
+  input: string | Uint8Array,
+  options: StrictJsonParseOptions = {},
+): UnsignedMemberRosterEnvelopeV1 {
+  const envelope = parseCanonicalUnsignedControlEnvelope(input, options);
+  return validateUnsignedMemberRosterEnvelopeSnapshotV1(envelope);
+}
+
+export function parseCanonicalSignedMemberRosterEnvelopeV1(
+  input: string | Uint8Array,
+  options: StrictJsonParseOptions = {},
+): SignedMemberRosterEnvelopeV1 {
+  const envelope = parseCanonicalSignedControlEnvelope(input, options);
+  return validateSignedMemberRosterEnvelopeSnapshotV1(envelope);
+}
+
+function validateUnsignedContextGraphPolicyEnvelopeSnapshotV1(
+  value: unknown,
+): UnsignedContextGraphPolicyEnvelopeV1 {
+  assertUnsignedContextGraphPolicyEnvelopePlainV1(value);
+  const snapshot = clonePlainData(value, 'unsigned CG policy envelope');
+  assertUnsignedContextGraphPolicyEnvelopePlainV1(snapshot);
+  return snapshot;
+}
+
+function validateSignedContextGraphPolicyEnvelopeSnapshotV1(
+  value: unknown,
+): SignedContextGraphPolicyEnvelopeV1 {
+  assertSignedContextGraphPolicyEnvelopePlainV1(value);
+  const snapshot = clonePlainData(value, 'signed CG policy envelope');
+  assertSignedContextGraphPolicyEnvelopePlainV1(snapshot);
+  return snapshot;
+}
+
+function validateUnsignedMemberRosterEnvelopeSnapshotV1(
+  value: unknown,
+): UnsignedMemberRosterEnvelopeV1 {
+  assertUnsignedMemberRosterEnvelopePlainV1(value);
+  const snapshot = clonePlainData(value, 'unsigned member roster envelope');
+  assertUnsignedMemberRosterEnvelopePlainV1(snapshot);
+  return snapshot;
+}
+
+function validateSignedMemberRosterEnvelopeSnapshotV1(
+  value: unknown,
+): SignedMemberRosterEnvelopeV1 {
+  assertSignedMemberRosterEnvelopePlainV1(value);
+  const snapshot = clonePlainData(value, 'signed member roster envelope');
+  assertSignedMemberRosterEnvelopePlainV1(snapshot);
+  return snapshot;
+}
+
+function assertUnsignedContextGraphPolicyEnvelopePlainV1(
+  value: unknown,
+): asserts value is UnsignedContextGraphPolicyEnvelopeV1 {
+  const envelope = value as UnsignedControlEnvelopeV1;
+  assertUnsignedControlEnvelope(envelope);
+  assertObjectType(envelope.objectType, CONTEXT_GRAPH_POLICY_OBJECT_TYPE_V1);
+  validateContextGraphPolicyPlainV1(envelope.payload);
+}
+
+function assertSignedContextGraphPolicyEnvelopePlainV1(
+  value: unknown,
+): asserts value is SignedContextGraphPolicyEnvelopeV1 {
+  const envelope = value as SignedControlEnvelopeV1;
+  assertSignedControlEnvelope(envelope);
+  assertObjectType(envelope.objectType, CONTEXT_GRAPH_POLICY_OBJECT_TYPE_V1);
+  validateContextGraphPolicyPlainV1(envelope.payload);
+}
+
+function assertUnsignedMemberRosterEnvelopePlainV1(
+  value: unknown,
+): asserts value is UnsignedMemberRosterEnvelopeV1 {
+  const envelope = value as UnsignedControlEnvelopeV1;
+  assertUnsignedControlEnvelope(envelope);
+  assertObjectType(envelope.objectType, MEMBER_ROSTER_OBJECT_TYPE_V1);
+  validateMemberRosterPlainV1(envelope.payload);
+}
+
+function assertSignedMemberRosterEnvelopePlainV1(
+  value: unknown,
+): asserts value is SignedMemberRosterEnvelopeV1 {
+  const envelope = value as SignedControlEnvelopeV1;
+  assertSignedControlEnvelope(envelope);
+  assertObjectType(envelope.objectType, MEMBER_ROSTER_OBJECT_TYPE_V1);
+  validateMemberRosterPlainV1(envelope.payload);
+}
+
+function assertContextGraphPolicyStructureV1(
+  value: unknown,
+): asserts value is ContextGraphPolicyV1 {
+  if (!isPlainRecord(value)) fail('cg-policy-schema', 'CG policy must be a plain object');
+  closed(value, [
+    'accessPolicy',
+    'administrativeDelegationDigest',
+    'contextGraphId',
+    'effectiveAt',
+    'era',
+    'governanceChainId',
+    'governanceContractAddress',
+    'issuedAt',
+    'networkId',
+    'ownershipTransitionDigest',
+    'previousPolicyDigest',
+    'projectionId',
+    'publishAuthority',
+    'publishAuthorityAccountId',
+    'publishPolicy',
+    'source',
+    'version',
+  ], 'CG policy');
+  scalar(() => assertNetworkIdV1(value.networkId));
+  scalar(() => assertContextGraphIdV1(value.contextGraphId));
+  assertGovernancePair(value.governanceChainId, value.governanceContractAddress);
+  optionalDigest(value.ownershipTransitionDigest, 'ownershipTransitionDigest');
+  u64(value.era, 'era');
+  u64(value.version, 'version');
+  optionalDigest(value.previousPolicyDigest, 'previousPolicyDigest');
+  assertPolicyEnum(value.accessPolicy, 'accessPolicy');
+  assertPolicyEnum(value.publishPolicy, 'publishPolicy');
+  if (value.publishAuthority !== null) {
+    scalar(() => assertCanonicalEvmAddress(value.publishAuthority, 'publishAuthority'));
+  }
+  scalar(() => assertCanonicalDecimalU256(
+    value.publishAuthorityAccountId,
+    'publishAuthorityAccountId',
+  ));
+  if (value.publishPolicy === 1) {
+    if (value.publishAuthority !== null || value.publishAuthorityAccountId !== '0') {
+      fail(
+        'cg-policy-publish-domain',
+        'open contribution requires null publishAuthority and account ID zero',
+      );
+    }
+  } else if (value.publishAuthority === null) {
+    fail('cg-policy-publish-domain', 'curated contribution requires publishAuthority');
+  }
+  if (value.projectionId !== CONTEXT_GRAPH_SHARED_PROJECTION_ID_V1) {
+    fail('cg-policy-scalar', 'projectionId must be cg-shared-v1');
+  }
+  optionalDigest(value.administrativeDelegationDigest, 'administrativeDelegationDigest');
+  assertPolicySource(
+    value.source,
+    value.governanceChainId,
+    value.governanceContractAddress,
+    value.ownershipTransitionDigest,
+  );
+  scalar(() => assertCanonicalTimestampMs(value.effectiveAt, 'effectiveAt'));
+  scalar(() => assertCanonicalTimestampMs(value.issuedAt, 'issuedAt'));
+}
+
+function validateContextGraphPolicySnapshotV1(value: unknown): {
+  readonly snapshot: ContextGraphPolicyV1;
+  readonly canonical: string;
+} {
+  const bounded = validateContextGraphPolicyPlainV1(value);
+  const snapshot = clonePlainData(bounded.snapshot, 'CG policy');
+  return validateContextGraphPolicyPlainV1(snapshot);
+}
+
+function validateContextGraphPolicyPlainV1(value: unknown): {
+  readonly snapshot: ContextGraphPolicyV1;
+  readonly canonical: string;
+} {
+  assertContextGraphPolicyStructureV1(value);
+  return { snapshot: value, canonical: canonicalizePolicyAfterStructure(value) };
+}
+
+function assertPolicySource(
+  source: unknown,
+  governanceChainId: unknown,
+  governanceContractAddress: unknown,
+  ownershipTransitionDigest: unknown,
+): void {
+  if (!isPlainRecord(source)) {
+    fail('cg-policy-schema', 'policy source must be a closed object');
+  }
+  const kindDescriptor = Object.getOwnPropertyDescriptor(source, 'kind');
+  if (
+    !kindDescriptor?.enumerable
+    || !Object.prototype.hasOwnProperty.call(kindDescriptor, 'value')
+    || typeof kindDescriptor.value !== 'string'
+  ) {
+    fail('cg-policy-schema', 'policy source kind must be an enumerable data field');
+  }
+  const kind = kindDescriptor.value;
+  if (kind === 'finalized-chain') {
+    closed(source, [
+      'blockHash',
+      'blockNumber',
+      'chainId',
+      'contractAddress',
+      'kind',
+    ], 'finalized-chain policy source');
+    scalar(() => assertCanonicalChainId(source.chainId));
+    scalar(() => assertCanonicalEvmAddress(source.contractAddress, 'contractAddress'));
+    u64(source.blockNumber, 'blockNumber');
+    scalar(() => assertCanonicalDigest(source.blockHash, 'blockHash'));
+    if (
+      governanceChainId === null
+      || governanceContractAddress === null
+      || governanceChainId !== source.chainId
+      || governanceContractAddress !== source.contractAddress
+    ) {
+      fail('cg-policy-governance', 'finalized source must equal the governance tuple');
+    }
+    return;
+  }
+  if (kind === 'owner-signed-unregistered') {
+    closed(source, ['kind', 'ownerAddress', 'ownerAuthorityEra'], 'owner policy source');
+    scalar(() => assertCanonicalEvmAddress(source.ownerAddress, 'ownerAddress'));
+    u64(source.ownerAuthorityEra, 'ownerAuthorityEra');
+    if (governanceChainId !== null || governanceContractAddress !== null) {
+      fail('cg-policy-governance', 'unregistered source requires a null governance tuple');
+    }
+    if (ownershipTransitionDigest !== null) {
+      fail('cg-policy-governance', 'unregistered source requires a null ownership transition');
+    }
+    return;
+  }
+  fail('cg-policy-schema', 'policy source kind is not supported by v1');
+}
+
+function assertMemberRosterStructureV1(value: unknown): asserts value is MemberRosterV1 {
+  if (!isPlainRecord(value)) fail('cg-policy-schema', 'member roster must be a plain object');
+  closed(value, [
+    'administrativeDelegationDigest',
+    'contextGraphId',
+    'era',
+    'issuedAt',
+    'members',
+    'networkId',
+    'ownershipTransitionDigest',
+    'policyDigest',
+    'previousRosterDigest',
+    'version',
+  ], 'member roster');
+  scalar(() => assertNetworkIdV1(value.networkId));
+  scalar(() => assertContextGraphIdV1(value.contextGraphId));
+  optionalDigest(value.ownershipTransitionDigest, 'ownershipTransitionDigest');
+  u64(value.era, 'era');
+  u64(value.version, 'version');
+  optionalDigest(value.previousRosterDigest, 'previousRosterDigest');
+  scalar(() => assertCanonicalDigest(value.policyDigest, 'policyDigest'));
+  optionalDigest(value.administrativeDelegationDigest, 'administrativeDelegationDigest');
+  assertDenseArray(value.members, 'members', MAX_MEMBER_ROSTER_ENTRIES_V1);
+  let previousAddress: string | undefined;
+  for (let index = 0; index < value.members.length; index += 1) {
+    const member = value.members[index];
+    if (!isPlainRecord(member)) fail('cg-policy-schema', `member ${index} must be an object`);
+    closed(member, ['agentAddress', 'roles'], `member ${index}`);
+    const agentAddressValue = member.agentAddress;
+    scalar(() => assertCanonicalEvmAddress(agentAddressValue, `members[${index}].agentAddress`));
+    const agentAddress = agentAddressValue as EvmAddressV1;
+    if (previousAddress !== undefined && previousAddress >= agentAddress) {
+      fail(
+        previousAddress === agentAddress ? 'cg-policy-duplicate' : 'cg-policy-order',
+        'members must be strictly sorted by agentAddress',
+      );
+    }
+    previousAddress = agentAddress;
+    assertDenseArray(member.roles, `members[${index}].roles`, MEMBER_ROSTER_ROLES_V1.length);
+    let previousRole: string | undefined;
+    for (let roleIndex = 0; roleIndex < member.roles.length; roleIndex += 1) {
+      const roleValue = member.roles[roleIndex];
+      if (typeof roleValue !== 'string') {
+        fail('cg-policy-role', 'member role must be a string');
+      }
+      if (!isMemberRosterRoleV1(roleValue)) {
+        fail('cg-policy-role', `unknown member role ${roleValue}`);
+      }
+      const role = roleValue as MemberRosterRoleV1;
+      if (previousRole !== undefined && previousRole >= role) {
+        fail(
+          previousRole === role ? 'cg-policy-duplicate' : 'cg-policy-order',
+          'member roles must be strictly sorted',
+        );
+      }
+      previousRole = role;
+    }
+  }
+  scalar(() => assertCanonicalTimestampMs(value.issuedAt, 'issuedAt'));
+}
+
+function validateMemberRosterSnapshotV1(value: unknown): {
+  readonly snapshot: MemberRosterV1;
+  readonly canonical: string;
+} {
+  const bounded = validateMemberRosterPlainV1(value);
+  const snapshot = clonePlainData(bounded.snapshot, 'member roster');
+  return validateMemberRosterPlainV1(snapshot);
+}
+
+function validateMemberRosterPlainV1(value: unknown): {
+  readonly snapshot: MemberRosterV1;
+  readonly canonical: string;
+} {
+  assertMemberRosterStructureV1(value);
+  return { snapshot: value, canonical: canonicalizeRosterAfterStructure(value) };
+}
+
+function clonePlainData<T>(value: T, label: string): T {
+  assertStablePlainDataShape(value, label, 0, new Set<object>());
+  try {
+    return structuredClone(value);
+  } catch (cause) {
+    fail('cg-policy-schema', `${label} must be stable structured-cloneable JSON data`, cause);
+  }
+}
+
+function assertStablePlainDataShape(
+  value: unknown,
+  label: string,
+  depth: number,
+  ancestors: Set<object>,
+): void {
+  if (depth > 64) fail('cg-policy-schema', `${label} exceeds the generic nesting cap`);
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') return;
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) fail('cg-policy-schema', `${label} contains a non-JSON number`);
+    return;
+  }
+  if (typeof value !== 'object') {
+    fail('cg-policy-schema', `${label} contains a non-JSON implementation value`);
+  }
+  if (ancestors.has(value)) fail('cg-policy-schema', `${label} contains a cycle`);
+  ancestors.add(value);
+  try {
+    if (Array.isArray(value)) {
+      if (Object.getPrototypeOf(value) !== Array.prototype) {
+        fail('cg-policy-schema', `${label} contains a non-ordinary array`);
+      }
+      const keys = Reflect.ownKeys(value);
+      if (
+        keys.some((key) => typeof key !== 'string')
+        || keys.length !== value.length + 1
+      ) {
+        fail('cg-policy-schema', `${label} contains a sparse or custom array`);
+      }
+      for (let index = 0; index < value.length; index += 1) {
+        const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
+        if (!descriptor?.enumerable || !Object.prototype.hasOwnProperty.call(descriptor, 'value')) {
+          fail('cg-policy-schema', `${label} contains an array accessor`);
+        }
+        assertStablePlainDataShape(
+          descriptor.value,
+          `${label}[${index}]`,
+          depth + 1,
+          ancestors,
+        );
+      }
+      return;
+    }
+
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      fail('cg-policy-schema', `${label} contains a non-plain object`);
+    }
+    const keys = Reflect.ownKeys(value);
+    for (let index = 0; index < keys.length; index += 1) {
+      const key = keys[index];
+      if (typeof key !== 'string') {
+        fail('cg-policy-schema', `${label} contains a symbol property`);
+      }
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      if (!descriptor?.enumerable || !Object.prototype.hasOwnProperty.call(descriptor, 'value')) {
+        fail('cg-policy-schema', `${label} contains an object accessor`);
+      }
+      assertStablePlainDataShape(
+        descriptor.value,
+        `${label}.${key}`,
+        depth + 1,
+        ancestors,
+      );
+    }
+  } finally {
+    ancestors.delete(value);
+  }
+}
+
+function isMemberRosterRoleV1(value: string): value is MemberRosterRoleV1 {
+  return value === 'holder' || value === 'ingress-host' || value === 'provider';
+}
+
+function assertGovernancePair(chainId: unknown, contractAddress: unknown): void {
+  if ((chainId === null) !== (contractAddress === null)) {
+    fail('cg-policy-governance', 'governance chain and contract must be jointly null/non-null');
+  }
+  if (chainId !== null) scalar(() => assertCanonicalChainId(chainId));
+  if (contractAddress !== null) {
+    scalar(() => assertCanonicalEvmAddress(contractAddress, 'governanceContractAddress'));
+  }
+}
+
+function assertPolicyEnum(value: unknown, label: string): asserts value is 0 | 1 {
+  if (value !== 0 && value !== 1) fail('cg-policy-scalar', `${label} must be JSON number 0 or 1`);
+}
+
+function optionalDigest(value: unknown, label: string): void {
+  if (value !== null) scalar(() => assertCanonicalDigest(value, label));
+}
+
+function u64(value: unknown, label: string): bigint {
+  try {
+    return parseCanonicalDecimalU64(value, label);
+  } catch (cause) {
+    fail('cg-policy-scalar', `${label} must be canonical DecimalU64V1`, cause);
+  }
+}
+
+function scalar(operation: () => void): void {
+  try {
+    operation();
+  } catch (cause) {
+    fail('cg-policy-scalar', 'policy/roster scalar is not canonical', cause);
+  }
+}
+
+function closed(record: Record<string, unknown>, keys: readonly string[], label: string): void {
+  try {
+    assertExactKeys(record, keys, label);
+  } catch (cause) {
+    fail('cg-policy-schema', `${label} has an invalid field set`, cause);
+  }
+}
+
+function assertDenseArray(value: unknown, label: string, maxLength: number): asserts value is unknown[] {
+  if (!Array.isArray(value) || Object.getPrototypeOf(value) !== Array.prototype) {
+    fail('cg-policy-array', `${label} must be an ordinary array`);
+  }
+  if (value.length > maxLength) {
+    fail('cg-policy-array', `${label} exceeds ${maxLength} entries`);
+  }
+  const keys = Reflect.ownKeys(value);
+  if (keys.some((key) => typeof key !== 'string') || keys.length !== value.length + 1) {
+    fail('cg-policy-array', `${label} must be dense and contain no custom properties`);
+  }
+  for (let index = 0; index < value.length; index += 1) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
+    if (!descriptor?.enumerable || !Object.prototype.hasOwnProperty.call(descriptor, 'value')) {
+      fail('cg-policy-array', `${label} must contain ordinary enumerable values`);
+    }
+  }
+}
+
+function canonicalizePolicyAfterStructure(policy: ContextGraphPolicyV1): string {
+  try {
+    return canonicalizeJson(policy as unknown as CanonicalJsonValue, {
+      maxBytes: MAX_CONTEXT_GRAPH_POLICY_PAYLOAD_BYTES_V1,
+      maxDepth: 2,
+    });
+  } catch (cause) {
+    fail('cg-policy-payload-too-large', 'CG policy exceeds its canonical cap', cause);
+  }
+}
+
+function canonicalizeRosterAfterStructure(roster: MemberRosterV1): string {
+  try {
+    return canonicalizeJson(roster as unknown as CanonicalJsonValue, {
+      maxBytes: MAX_MEMBER_ROSTER_PAYLOAD_BYTES_V1,
+      maxDepth: 4,
+    });
+  } catch (cause) {
+    fail('cg-policy-payload-too-large', 'member roster exceeds its canonical cap', cause);
+  }
+}
+
+function assertObjectType(actual: string, expected: string): void {
+  if (actual !== expected) fail('cg-policy-type', `objectType must be exactly ${expected}`);
+}
+
+function asDigest(value: string): Digest32V1 {
+  assertCanonicalDigest(value, 'objectDigest');
+  return value;
+}
+
+function rejectOversizedInput(input: string | Uint8Array, maxBytes: number, label: string): void {
+  const bytes = typeof input === 'string' ? new TextEncoder().encode(input).byteLength : input.byteLength;
+  if (bytes > maxBytes) fail('cg-policy-payload-too-large', `${label} exceeds ${maxBytes} bytes`);
+}
+
+function fail(code: CgPolicyObjectCodecErrorCode, message: string, cause?: unknown): never {
+  throw new CgPolicyObjectCodecError(code, message, cause === undefined ? {} : { cause });
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,7 @@ export * from './publisher-extension.js';
 export * from './imported-artifact-bytes.js';
 export * from './imported-artifact-metadata.js';
 export * from './sync-control-object.js';
+export * from './cg-policy-objects.js';
 export {
   MAX_DECIMAL_U64,
   MAX_DECIMAL_U256,

--- a/packages/core/test/cg-policy-objects.test.ts
+++ b/packages/core/test/cg-policy-objects.test.ts
@@ -148,6 +148,17 @@ describe('ContextGraphPolicyV1 codec', () => {
       ...POLICY,
       governanceContractAddress: null,
     })).toThrow(/cg-policy-governance/);
+    // Unregistered source must reject a non-null governance tuple: keep the base
+    // POLICY's finalized governance chain/contract and change only source.kind.
+    // Covers the governanceChainId/governanceContractAddress !== null arm.
+    expect(() => assertContextGraphPolicyV1({
+      ...POLICY,
+      source: {
+        kind: 'owner-signed-unregistered',
+        ownerAddress: ISSUER,
+        ownerAuthorityEra: '0',
+      },
+    })).toThrow(/cg-policy-governance/);
   });
 
   it('keeps contribution policy independent and closes its authority branch', () => {

--- a/packages/core/test/cg-policy-objects.test.ts
+++ b/packages/core/test/cg-policy-objects.test.ts
@@ -1,0 +1,445 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  CONTEXT_GRAPH_POLICY_OBJECT_TYPE_V1,
+  MAX_CONTEXT_GRAPH_POLICY_PAYLOAD_BYTES_V1,
+  MAX_MEMBER_ROSTER_PAYLOAD_BYTES_V1,
+  MAX_MEMBER_ROSTER_ENTRIES_V1,
+  MEMBER_ROSTER_ROLES_V1,
+  MEMBER_ROSTER_OBJECT_TYPE_V1,
+  assertContextGraphPolicyV1,
+  assertMemberRosterV1,
+  assertSignedContextGraphPolicyEnvelopeV1,
+  assertSignedMemberRosterEnvelopeV1,
+  assertUnsignedContextGraphPolicyEnvelopeV1,
+  assertUnsignedMemberRosterEnvelopeV1,
+  canonicalizeContextGraphPolicyPayloadV1,
+  canonicalizeMemberRosterPayloadV1,
+  canonicalizeSignedContextGraphPolicyEnvelopeBytesV1,
+  canonicalizeSignedMemberRosterEnvelopeBytesV1,
+  canonicalizeUnsignedContextGraphPolicyEnvelopeBytesV1,
+  canonicalizeUnsignedMemberRosterEnvelopeBytesV1,
+  computeContextGraphPolicyObjectDigestV1,
+  computeMemberRosterObjectDigestV1,
+  parseCanonicalContextGraphPolicyPayloadV1,
+  parseCanonicalMemberRosterPayloadV1,
+  parseCanonicalSignedContextGraphPolicyEnvelopeV1,
+  parseCanonicalSignedMemberRosterEnvelopeV1,
+  parseCanonicalUnsignedContextGraphPolicyEnvelopeV1,
+  parseCanonicalUnsignedMemberRosterEnvelopeV1,
+  type ContextGraphPolicyV1,
+  type MemberRosterV1,
+} from '../src/cg-policy-objects.js';
+import {
+  CONTROL_OBJECT_SIGNATURE_SUITES,
+  type SignedControlEnvelopeV1,
+  type UnsignedControlEnvelopeV1,
+} from '../src/sync-control-object.js';
+
+const ISSUER = '0x5555555555555555555555555555555555555555';
+const SIGNATURE = `0x${'77'.repeat(65)}`;
+const POLICY_DIGEST = '0x757a6c30157d416fc7f15e20a2ea4b4ccb57fb4d06000861d5c2bd47102a6db6';
+const ROSTER_DIGEST = '0x38bcd20907a5df67651bee6df47d774e4345f907a8e23ddf34a3b32c0933b02d';
+
+const POLICY = validatedPolicy({
+  networkId: 'otp:20430',
+  contextGraphId: '0x1111111111111111111111111111111111111111/policy-fixture',
+  governanceChainId: '20430',
+  governanceContractAddress: '0x2222222222222222222222222222222222222222',
+  ownershipTransitionDigest: null,
+  era: '0',
+  version: '0',
+  previousPolicyDigest: null,
+  accessPolicy: 0,
+  publishPolicy: 1,
+  publishAuthority: null,
+  publishAuthorityAccountId: '0',
+  projectionId: 'cg-shared-v1',
+  administrativeDelegationDigest: null,
+  source: {
+    kind: 'finalized-chain',
+    chainId: '20430',
+    contractAddress: '0x2222222222222222222222222222222222222222',
+    blockNumber: '123',
+    blockHash: `0x${'33'.repeat(32)}`,
+  },
+  effectiveAt: '1700000000000',
+  issuedAt: '1700000000123',
+});
+
+const ROSTER = validatedRoster({
+  networkId: POLICY.networkId,
+  contextGraphId: POLICY.contextGraphId,
+  ownershipTransitionDigest: null,
+  era: '0',
+  version: '0',
+  previousRosterDigest: null,
+  policyDigest: POLICY_DIGEST,
+  administrativeDelegationDigest: null,
+  members: [
+    {
+      agentAddress: '0x1111111111111111111111111111111111111111',
+      roles: ['holder', 'provider'],
+    },
+    {
+      agentAddress: '0x2222222222222222222222222222222222222222',
+      roles: [],
+    },
+  ],
+  issuedAt: '1700000000123',
+});
+
+const POLICY_CANONICAL = '{"accessPolicy":0,"administrativeDelegationDigest":null,"contextGraphId":"0x1111111111111111111111111111111111111111/policy-fixture","effectiveAt":"1700000000000","era":"0","governanceChainId":"20430","governanceContractAddress":"0x2222222222222222222222222222222222222222","issuedAt":"1700000000123","networkId":"otp:20430","ownershipTransitionDigest":null,"previousPolicyDigest":null,"projectionId":"cg-shared-v1","publishAuthority":null,"publishAuthorityAccountId":"0","publishPolicy":1,"source":{"blockHash":"0x3333333333333333333333333333333333333333333333333333333333333333","blockNumber":"123","chainId":"20430","contractAddress":"0x2222222222222222222222222222222222222222","kind":"finalized-chain"},"version":"0"}';
+const ROSTER_CANONICAL = '{"administrativeDelegationDigest":null,"contextGraphId":"0x1111111111111111111111111111111111111111/policy-fixture","era":"0","issuedAt":"1700000000123","members":[{"agentAddress":"0x1111111111111111111111111111111111111111","roles":["holder","provider"]},{"agentAddress":"0x2222222222222222222222222222222222222222","roles":[]}],"networkId":"otp:20430","ownershipTransitionDigest":null,"policyDigest":"0x757a6c30157d416fc7f15e20a2ea4b4ccb57fb4d06000861d5c2bd47102a6db6","previousRosterDigest":null,"version":"0"}';
+const POLICY_UNSIGNED = unsigned(CONTEXT_GRAPH_POLICY_OBJECT_TYPE_V1, POLICY);
+const ROSTER_UNSIGNED = unsigned(MEMBER_ROSTER_OBJECT_TYPE_V1, ROSTER);
+const POLICY_UNSIGNED_CANONICAL = '{"issuer":"0x5555555555555555555555555555555555555555","objectType":"ContextGraphPolicyV1","payload":{"accessPolicy":0,"administrativeDelegationDigest":null,"contextGraphId":"0x1111111111111111111111111111111111111111/policy-fixture","effectiveAt":"1700000000000","era":"0","governanceChainId":"20430","governanceContractAddress":"0x2222222222222222222222222222222222222222","issuedAt":"1700000000123","networkId":"otp:20430","ownershipTransitionDigest":null,"previousPolicyDigest":null,"projectionId":"cg-shared-v1","publishAuthority":null,"publishAuthorityAccountId":"0","publishPolicy":1,"source":{"blockHash":"0x3333333333333333333333333333333333333333333333333333333333333333","blockNumber":"123","chainId":"20430","contractAddress":"0x2222222222222222222222222222222222222222","kind":"finalized-chain"},"version":"0"},"signatureEvidence":{"kind":"none"},"signatureSuite":"eip191-personal-sign-digest-v1"}';
+const ROSTER_UNSIGNED_CANONICAL = '{"issuer":"0x5555555555555555555555555555555555555555","objectType":"MemberRosterV1","payload":{"administrativeDelegationDigest":null,"contextGraphId":"0x1111111111111111111111111111111111111111/policy-fixture","era":"0","issuedAt":"1700000000123","members":[{"agentAddress":"0x1111111111111111111111111111111111111111","roles":["holder","provider"]},{"agentAddress":"0x2222222222222222222222222222222222222222","roles":[]}],"networkId":"otp:20430","ownershipTransitionDigest":null,"policyDigest":"0x757a6c30157d416fc7f15e20a2ea4b4ccb57fb4d06000861d5c2bd47102a6db6","previousRosterDigest":null,"version":"0"},"signatureEvidence":{"kind":"none"},"signatureSuite":"eip191-personal-sign-digest-v1"}';
+const POLICY_SIGNED = signed(POLICY_UNSIGNED, POLICY_DIGEST);
+const ROSTER_SIGNED = signed(ROSTER_UNSIGNED, ROSTER_DIGEST);
+
+describe('ContextGraphPolicyV1 codec', () => {
+  it('pins canonical payload/envelope bytes and digest', () => {
+    const canonical = canonicalizeContextGraphPolicyPayloadV1(POLICY);
+    expect(canonical).toBe(POLICY_CANONICAL);
+    expect(new TextEncoder().encode(canonical)).toHaveLength(722);
+    expect(parseCanonicalContextGraphPolicyPayloadV1(canonical)).toEqual(POLICY);
+    const unsignedCanonical = new TextDecoder().decode(
+      canonicalizeUnsignedContextGraphPolicyEnvelopeBytesV1(POLICY_UNSIGNED),
+    );
+    expect(unsignedCanonical).toBe(POLICY_UNSIGNED_CANONICAL);
+    expect(new TextEncoder().encode(unsignedCanonical)).toHaveLength(910);
+    expect(computeContextGraphPolicyObjectDigestV1(POLICY_UNSIGNED)).toBe(POLICY_DIGEST);
+    expect(parseCanonicalUnsignedContextGraphPolicyEnvelopeV1(
+      canonicalUnsigned(POLICY_UNSIGNED),
+    )).toEqual(POLICY_UNSIGNED);
+    expect(parseCanonicalSignedContextGraphPolicyEnvelopeV1(
+      new TextDecoder().decode(canonicalizeSignedContextGraphPolicyEnvelopeBytesV1(POLICY_SIGNED)),
+    )).toEqual(POLICY_SIGNED);
+  });
+
+  it('enforces finalized and unregistered governance source branches', () => {
+    expect(() => assertContextGraphPolicyV1({
+      ...POLICY,
+      source: { ...POLICY.source, chainId: '1' },
+    })).toThrow(/cg-policy-governance/);
+    expect(() => assertContextGraphPolicyV1({
+      ...POLICY,
+      governanceChainId: null,
+      governanceContractAddress: null,
+      source: {
+        kind: 'owner-signed-unregistered',
+        ownerAddress: ISSUER,
+        ownerAuthorityEra: '0',
+      },
+    })).not.toThrow();
+    expect(() => assertContextGraphPolicyV1({
+      ...POLICY,
+      governanceChainId: null,
+      governanceContractAddress: null,
+      ownershipTransitionDigest: `0x${'44'.repeat(32)}`,
+      source: {
+        kind: 'owner-signed-unregistered',
+        ownerAddress: ISSUER,
+        ownerAuthorityEra: '0',
+      },
+    })).toThrow(/cg-policy-governance/);
+    expect(() => assertContextGraphPolicyV1({
+      ...POLICY,
+      governanceContractAddress: null,
+    })).toThrow(/cg-policy-governance/);
+  });
+
+  it('keeps contribution policy independent and closes its authority branch', () => {
+    for (const cell of [
+      { accessPolicy: 0, publishPolicy: 1, publishAuthority: null, publishAuthorityAccountId: '0' },
+      { accessPolicy: 1, publishPolicy: 1, publishAuthority: null, publishAuthorityAccountId: '0' },
+      { accessPolicy: 0, publishPolicy: 0, publishAuthority: ISSUER, publishAuthorityAccountId: '0' },
+      { accessPolicy: 1, publishPolicy: 0, publishAuthority: ISSUER, publishAuthorityAccountId: '0' },
+      { accessPolicy: 1, publishPolicy: 0, publishAuthority: ISSUER, publishAuthorityAccountId: '7' },
+    ]) {
+      expect(() => assertContextGraphPolicyV1({ ...POLICY, ...cell })).not.toThrow();
+    }
+    expect(() => assertContextGraphPolicyV1({ ...POLICY, publishAuthority: ISSUER }))
+      .toThrow(/cg-policy-publish-domain/);
+    expect(() => assertContextGraphPolicyV1({ ...POLICY, publishPolicy: 0 }))
+      .toThrow(/cg-policy-publish-domain/);
+    for (const value of [2, '0', null]) {
+      expect(() => assertContextGraphPolicyV1({ ...POLICY, accessPolicy: value }))
+        .toThrow(/cg-policy-scalar/);
+    }
+    expect(() => assertContextGraphPolicyV1({ ...POLICY, publishPolicy: 2 }))
+      .toThrow(/cg-policy-scalar/);
+  });
+
+  it('rejects unknown fields, wrong projection, malformed scalars, and noncanonical wire', () => {
+    expect(() => assertContextGraphPolicyV1({ ...POLICY, subGraphName: null }))
+      .toThrow(/cg-policy-schema/);
+    expect(() => assertContextGraphPolicyV1({ ...POLICY, projectionId: 'other' }))
+      .toThrow(/cg-policy-scalar/);
+    expect(() => assertContextGraphPolicyV1({ ...POLICY, version: 0 }))
+      .toThrow(/cg-policy-scalar/);
+    expect(() => parseCanonicalContextGraphPolicyPayloadV1(
+      canonicalizeContextGraphPolicyPayloadV1(POLICY).replace('"accessPolicy":0', '"accessPolicy": 0'),
+    )).toThrow();
+  });
+
+  it('rejects source accessors without invoking them', () => {
+    let getterCalls = 0;
+    const source = { ...POLICY.source } as Record<string, unknown>;
+    Object.defineProperty(source, 'kind', {
+      enumerable: true,
+      get() {
+        getterCalls += 1;
+        return 'finalized-chain';
+      },
+    });
+    expect(() => assertContextGraphPolicyV1({ ...POLICY, source }))
+      .toThrow(/cg-policy-schema/);
+    expect(getterCalls).toBe(0);
+  });
+
+  it('enforces the object-specific policy byte and nesting caps before schema use', () => {
+    const oversized = `{"x":"${'a'.repeat(MAX_CONTEXT_GRAPH_POLICY_PAYLOAD_BYTES_V1)}"}`;
+    expect(() => parseCanonicalContextGraphPolicyPayloadV1(oversized))
+      .toThrow(/cg-policy-payload-too-large/);
+    expect(() => parseCanonicalContextGraphPolicyPayloadV1('{"a":{"b":{}}}'))
+      .toThrow(/nesting exceeds 2/);
+  });
+
+  it('enforces exact envelope type and validates signed and unsigned variants', () => {
+    expect(Object.isFrozen(CONTROL_OBJECT_SIGNATURE_SUITES)).toBe(true);
+    expect(() => (CONTROL_OBJECT_SIGNATURE_SUITES as unknown as string[]).push('evil-suite'))
+      .toThrow();
+    expect(() => assertUnsignedContextGraphPolicyEnvelopeV1(POLICY_UNSIGNED)).not.toThrow();
+    expect(() => assertSignedContextGraphPolicyEnvelopeV1(POLICY_SIGNED)).not.toThrow();
+    expect(() => assertUnsignedContextGraphPolicyEnvelopeV1({
+      ...POLICY_UNSIGNED,
+      objectType: MEMBER_ROSTER_OBJECT_TYPE_V1,
+    })).toThrow(/cg-policy-type/);
+    expect(() => assertUnsignedContextGraphPolicyEnvelopeV1({
+      ...POLICY_UNSIGNED,
+      signatureSuite: 'evil-suite',
+      signatureEvidence: {
+        kind: 'eip1271-current-finalized',
+        chainId: '20430',
+        contractAddress: ISSUER,
+      },
+    } as unknown as UnsignedControlEnvelopeV1)).toThrow(/Unsupported control-object signature suite/);
+  });
+
+  it('snapshots the complete envelope once and rejects stateful proxies', () => {
+    let payloadReads = 0;
+    const envelopeProxy = new Proxy(POLICY_UNSIGNED, {
+      get(target, property, receiver) {
+        if (property === 'payload') {
+          payloadReads += 1;
+          return payloadReads <= 2 ? POLICY : { evil: true };
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+    expect(() => canonicalizeUnsignedContextGraphPolicyEnvelopeBytesV1(envelopeProxy))
+      .toThrow(/cg-policy-schema/);
+    expect(payloadReads).toBe(2);
+  });
+});
+
+describe('MemberRosterV1 codec', () => {
+  it('pins canonical payload/envelope bytes and digest', () => {
+    expect(canonicalizeMemberRosterPayloadV1(ROSTER)).toBe(ROSTER_CANONICAL);
+    expect(new TextEncoder().encode(ROSTER_CANONICAL)).toHaveLength(513);
+    expect(parseCanonicalMemberRosterPayloadV1(ROSTER_CANONICAL)).toEqual(ROSTER);
+    const unsignedCanonical = new TextDecoder().decode(
+      canonicalizeUnsignedMemberRosterEnvelopeBytesV1(ROSTER_UNSIGNED),
+    );
+    expect(unsignedCanonical).toBe(ROSTER_UNSIGNED_CANONICAL);
+    expect(new TextEncoder().encode(unsignedCanonical)).toHaveLength(695);
+    expect(computeMemberRosterObjectDigestV1(ROSTER_UNSIGNED)).toBe(ROSTER_DIGEST);
+    expect(parseCanonicalUnsignedMemberRosterEnvelopeV1(canonicalUnsigned(ROSTER_UNSIGNED)))
+      .toEqual(ROSTER_UNSIGNED);
+    expect(parseCanonicalSignedMemberRosterEnvelopeV1(
+      new TextDecoder().decode(canonicalizeSignedMemberRosterEnvelopeBytesV1(ROSTER_SIGNED)),
+    )).toEqual(ROSTER_SIGNED);
+  });
+
+  it('requires strictly sorted unique members and the closed sorted role registry', () => {
+    expect(Object.isFrozen(MEMBER_ROSTER_ROLES_V1)).toBe(true);
+    expect(() => (MEMBER_ROSTER_ROLES_V1 as unknown as string[]).push('administrator'))
+      .toThrow();
+    expect(() => assertMemberRosterV1({
+      ...ROSTER,
+      members: [...ROSTER.members].reverse(),
+    })).toThrow(/cg-policy-order/);
+    expect(() => assertMemberRosterV1({
+      ...ROSTER,
+      members: [ROSTER.members[0], ROSTER.members[0]],
+    })).toThrow(/cg-policy-duplicate/);
+    expect(() => assertMemberRosterV1({
+      ...ROSTER,
+      members: [{ ...ROSTER.members[0], roles: ['provider', 'holder'] }],
+    })).toThrow(/cg-policy-order/);
+    expect(() => assertMemberRosterV1({
+      ...ROSTER,
+      members: [{ ...ROSTER.members[0], roles: ['holder', 'holder'] }],
+    })).toThrow(/cg-policy-duplicate/);
+    expect(() => assertMemberRosterV1({
+      ...ROSTER,
+      members: [{ ...ROSTER.members[0], roles: ['administrator'] }],
+    })).toThrow(/cg-policy-role/);
+  });
+
+  it('never consumes a poisoned inherited roles iterator', () => {
+    const roles = ['administrator'];
+    const originalIterator = Array.prototype[Symbol.iterator];
+    Object.defineProperty(Array.prototype, Symbol.iterator, {
+      configurable: true,
+      writable: true,
+      value(this: unknown[]) {
+        if (this === roles) return [][Symbol.iterator]();
+        return originalIterator.call(this);
+      },
+    });
+    try {
+      expect(() => assertMemberRosterV1({
+        ...ROSTER,
+        members: [{ ...ROSTER.members[0], roles }],
+      })).toThrow(/cg-policy-role/);
+    } finally {
+      Object.defineProperty(Array.prototype, Symbol.iterator, {
+        configurable: true,
+        writable: true,
+        value: originalIterator,
+      });
+    }
+  });
+
+  it('rejects stateful proxies and non-string roles without coercing them', () => {
+    let proxyReads = 0;
+    const roles = new Proxy(['holder'], {
+      get(target, property, receiver) {
+        if (property === '0') {
+          proxyReads += 1;
+          return proxyReads === 1 ? 'holder' : 'administrator';
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+    expect(() => assertMemberRosterV1({
+      ...ROSTER,
+      members: [{ ...ROSTER.members[0], roles }],
+    })).toThrow(/cg-policy-schema/);
+
+    let coercions = 0;
+    const hostileRole = {
+      [Symbol.toPrimitive]() {
+        coercions += 1;
+        return 'provider';
+      },
+    };
+    expect(() => assertMemberRosterV1({
+      ...ROSTER,
+      members: [{ ...ROSTER.members[0], roles: [hostileRole] }],
+    })).toThrow(/cg-policy-role/);
+    expect(coercions).toBe(0);
+  });
+
+  it('rejects subgraph scope and hostile array shapes', () => {
+    expect(() => assertMemberRosterV1({ ...ROSTER, subGraphName: 'forbidden' }))
+      .toThrow(/cg-policy-schema/);
+    expect(() => assertMemberRosterV1({ ...ROSTER, members: new Array(1) }))
+      .toThrow(/cg-policy-array/);
+    const custom = [...ROSTER.members];
+    Object.defineProperty(custom, 'extra', { value: true, enumerable: true });
+    expect(() => assertMemberRosterV1({ ...ROSTER, members: custom }))
+      .toThrow(/cg-policy-array/);
+    const symbol = [...ROSTER.members];
+    Object.defineProperty(symbol, Symbol('x'), { value: true, enumerable: true });
+    expect(() => assertMemberRosterV1({ ...ROSTER, members: symbol }))
+      .toThrow(/cg-policy-array/);
+
+    let getterCalls = 0;
+    const roles = [...ROSTER.members[0].roles];
+    Object.defineProperty(roles, '0', {
+      enumerable: true,
+      get() {
+        getterCalls += 1;
+        return 'holder';
+      },
+    });
+    expect(() => assertMemberRosterV1({
+      ...ROSTER,
+      members: [{ ...ROSTER.members[0], roles }],
+    })).toThrow(/cg-policy-array/);
+    expect(getterCalls).toBe(0);
+  });
+
+  it('accepts an empty roster but enforces the 16,384-entry hard cap', () => {
+    expect(() => assertMemberRosterV1({ ...ROSTER, members: [] })).not.toThrow();
+    const atCap = Array.from({ length: MAX_MEMBER_ROSTER_ENTRIES_V1 }, (_, index) => ({
+      agentAddress: `0x${(index + 1).toString(16).padStart(40, '0')}`,
+      roles: ['holder', 'ingress-host', 'provider'] as const,
+    }));
+    const atCapCanonical = canonicalizeMemberRosterPayloadV1({ ...ROSTER, members: atCap });
+    expect(new TextEncoder().encode(atCapCanonical).byteLength)
+      .toBeLessThanOrEqual(MAX_MEMBER_ROSTER_PAYLOAD_BYTES_V1);
+    const tooMany = [
+      ...atCap,
+      {
+        agentAddress: `0x${(MAX_MEMBER_ROSTER_ENTRIES_V1 + 1).toString(16).padStart(40, '0')}`,
+        roles: [],
+      },
+    ];
+    expect(() => assertMemberRosterV1({ ...ROSTER, members: tooMany }))
+      .toThrow(/cg-policy-array/);
+  });
+
+  it('enforces the object-specific roster byte and nesting caps before schema use', () => {
+    const oversized = `{"x":"${'a'.repeat(MAX_MEMBER_ROSTER_PAYLOAD_BYTES_V1)}"}`;
+    expect(() => parseCanonicalMemberRosterPayloadV1(oversized))
+      .toThrow(/cg-policy-payload-too-large/);
+    expect(() => parseCanonicalMemberRosterPayloadV1('{"a":[{"b":[{}]}]}'))
+      .toThrow(/nesting exceeds 4/);
+  });
+
+  it('enforces exact envelope type and signed digest', () => {
+    expect(() => assertUnsignedMemberRosterEnvelopeV1(ROSTER_UNSIGNED)).not.toThrow();
+    expect(() => assertSignedMemberRosterEnvelopeV1(ROSTER_SIGNED)).not.toThrow();
+    expect(() => assertSignedMemberRosterEnvelopeV1({
+      ...ROSTER_SIGNED,
+      objectDigest: `0x${'00'.repeat(32)}`,
+    })).toThrow(/digest mismatch/i);
+  });
+});
+
+function validatedPolicy(value: unknown): ContextGraphPolicyV1 {
+  assertContextGraphPolicyV1(value);
+  return value;
+}
+
+function validatedRoster(value: unknown): MemberRosterV1 {
+  assertMemberRosterV1(value);
+  return value;
+}
+
+function unsigned(objectType: string, payload: ContextGraphPolicyV1 | MemberRosterV1) {
+  return {
+    issuer: ISSUER,
+    objectType,
+    payload,
+    signatureEvidence: { kind: 'none' },
+    signatureSuite: 'eip191-personal-sign-digest-v1',
+  } as UnsignedControlEnvelopeV1;
+}
+
+function signed(envelope: UnsignedControlEnvelopeV1, objectDigest: string) {
+  return { ...envelope, objectDigest, signature: SIGNATURE } as SignedControlEnvelopeV1;
+}
+
+function canonicalUnsigned(envelope: UnsignedControlEnvelopeV1): string {
+  return new TextDecoder().decode(
+    envelope.objectType === CONTEXT_GRAPH_POLICY_OBJECT_TYPE_V1
+      ? canonicalizeUnsignedContextGraphPolicyEnvelopeBytesV1(envelope)
+      : canonicalizeUnsignedMemberRosterEnvelopeBytesV1(envelope),
+  );
+}

--- a/packages/core/test/cg-policy-objects.test.ts
+++ b/packages/core/test/cg-policy-objects.test.ts
@@ -172,6 +172,22 @@ describe('ContextGraphPolicyV1 codec', () => {
       .toThrow(/cg-policy-scalar/);
   });
 
+  it('independently enforces the second half of each paired cross-field invariant', () => {
+    // Governance tuple: the source.chainId half is covered above; prove the
+    // source.contractAddress half by diverging only the finalized contract.
+    expect(() => assertContextGraphPolicyV1({
+      ...POLICY,
+      source: { ...POLICY.source, contractAddress: ISSUER },
+    })).toThrow(/cg-policy-governance/);
+    // Publish domain: the publishAuthority half is covered above; prove the
+    // publishAuthorityAccountId half with a nonzero id on an open (publishPolicy 1)
+    // policy, where authority must be null and the account id must be zero.
+    expect(() => assertContextGraphPolicyV1({
+      ...POLICY,
+      publishAuthorityAccountId: '7',
+    })).toThrow(/cg-policy-publish-domain/);
+  });
+
   it('rejects unknown fields, wrong projection, malformed scalars, and noncanonical wire', () => {
     expect(() => assertContextGraphPolicyV1({ ...POLICY, subGraphName: null }))
       .toThrow(/cg-policy-schema/);

--- a/packages/core/test/cg-policy-objects.test.ts
+++ b/packages/core/test/cg-policy-objects.test.ts
@@ -432,6 +432,18 @@ describe('MemberRosterV1 codec', () => {
   it('enforces exact envelope type and signed digest', () => {
     expect(() => assertUnsignedMemberRosterEnvelopeV1(ROSTER_UNSIGNED)).not.toThrow();
     expect(() => assertSignedMemberRosterEnvelopeV1(ROSTER_SIGNED)).not.toThrow();
+    // Wrong-type rejection: a valid roster payload under a non-roster objectType
+    // must be rejected by the envelope discriminator, in memory and on the wire.
+    expect(() => assertUnsignedMemberRosterEnvelopeV1({
+      ...ROSTER_UNSIGNED,
+      objectType: CONTEXT_GRAPH_POLICY_OBJECT_TYPE_V1,
+    })).toThrow(/cg-policy-type/);
+    expect(() => parseCanonicalUnsignedMemberRosterEnvelopeV1(
+      ROSTER_UNSIGNED_CANONICAL.replace(
+        '"objectType":"MemberRosterV1"',
+        `"objectType":"${CONTEXT_GRAPH_POLICY_OBJECT_TYPE_V1}"`,
+      ),
+    )).toThrow(/cg-policy-type/);
     expect(() => assertSignedMemberRosterEnvelopeV1({
       ...ROSTER_SIGNED,
       objectDigest: `0x${'00'.repeat(32)}`,


### PR DESCRIPTION
## Summary
- add closed canonical codecs for `ContextGraphPolicyV1` and CG-wide `MemberRosterV1`
- preserve D26 orthogonality across all four sharing/contribution policy cells
- enforce governance/source null branches, exact projection and authority fields, sorted unique members, and the frozen role registry
- enforce the 8 KiB/depth-2 policy and 16,384-member/4 MiB/depth-4 roster bounds
- validate one stable plain-data snapshot so accessors, custom arrays, stateful proxies, cycles, and non-JSON values fail closed
- pin canonical payload/envelope bytes and object digests

## Verification
- focused policy/control tests: 42 passed
- full `@origintrail-official/dkg-core` suite: 95 files / 1,426 tests passed
- core TypeScript build: passed
- independent vector/digest audit: passed
- `git diff --check`: passed

## Scope
This is the RFC-64 dormant structural-codec slice only. Signature recovery, owner/delegate authorization, finalized-chain lookup, history activation, roster membership decisions, persistence, networking, checkpointing, and protocol activation remain intentionally excluded.