### PR TITLE
[RFC-64] Add catalog authority codecs

### DIFF
--- a/packages/core/src/author-catalog-authority-objects.ts
+++ b/packages/core/src/author-catalog-authority-objects.ts
@@ -1,0 +1,629 @@
+import {
+  canonicalizeJson,
+  parseCanonicalJson,
+  type CanonicalJsonValue,
+  type StrictJsonParseOptions,
+} from './canonical-json.js';
+import {
+  assertContextGraphIdV1,
+  assertNetworkIdV1,
+  assertSubGraphNameV1,
+  type ContextGraphIdV1,
+  type NetworkIdV1,
+  type SubGraphNameV1,
+} from './author-catalog-codec.js';
+import {
+  assertSignedControlEnvelope,
+  assertUnsignedControlEnvelope,
+  canonicalizeSignedControlEnvelopeBytes,
+  canonicalizeUnsignedControlEnvelopeBytes,
+  computeControlObjectDigestHex,
+  parseCanonicalSignedControlEnvelope,
+  parseCanonicalUnsignedControlEnvelope,
+  type SignedControlEnvelopeV1,
+  type UnsignedControlEnvelopeV1,
+} from './sync-control-object.js';
+import {
+  assertCanonicalChainId,
+  assertCanonicalDigest,
+  assertCanonicalEvmAddress,
+  assertCanonicalTimestampMs,
+  parseCanonicalDecimalU64,
+  type ChainIdV1,
+  type DecimalU64V1,
+  type Digest32V1,
+  type EvmAddressV1,
+  type TimestampMsV1,
+} from './sync-wire-scalars.js';
+import { assertExactKeys, isPlainRecord } from './sync-wire-objects.js';
+
+export const AUTHOR_CATALOG_ISSUER_DELEGATION_OBJECT_TYPE_V1 =
+  'AuthorCatalogIssuerDelegationV1' as const;
+export const CATALOG_HEAD_TIMELINESS_RECEIPT_OBJECT_TYPE_V1 =
+  'CatalogHeadTimelinessReceiptV1' as const;
+export const MAX_AUTHOR_CATALOG_AUTHORITY_PAYLOAD_BYTES_V1 = 16 * 1024;
+
+const UTF8 = new TextEncoder();
+
+export interface AuthorCatalogIssuerDelegationV1 {
+  readonly networkId: NetworkIdV1;
+  readonly contextGraphId: ContextGraphIdV1;
+  readonly governanceChainId: ChainIdV1 | null;
+  readonly governanceContractAddress: EvmAddressV1 | null;
+  readonly ownershipTransitionDigest: Digest32V1 | null;
+  readonly subGraphName: SubGraphNameV1 | null;
+  readonly authorAddress: EvmAddressV1;
+  readonly catalogEra: DecimalU64V1;
+  readonly previousDelegationDigest: Digest32V1 | null;
+  readonly catalogIssuerKey: EvmAddressV1;
+  readonly authorAuthorityEvidenceDigest: Digest32V1 | null;
+  readonly effectiveAt: TimestampMsV1;
+  readonly expiresAt: TimestampMsV1;
+}
+
+export interface CatalogHeadTimelinessReceiptV1 {
+  readonly networkId: NetworkIdV1;
+  readonly contextGraphId: ContextGraphIdV1;
+  readonly governanceChainId: ChainIdV1 | null;
+  readonly governanceContractAddress: EvmAddressV1 | null;
+  readonly ownershipTransitionDigest: Digest32V1 | null;
+  readonly subGraphName: SubGraphNameV1 | null;
+  readonly checkpointAuthorityDelegationDigest: Digest32V1;
+  readonly authorAddress: EvmAddressV1;
+  readonly catalogIssuerDelegationDigest: Digest32V1;
+  readonly catalogHeadDigest: Digest32V1;
+  readonly observedAt: TimestampMsV1;
+}
+
+export type UnsignedAuthorCatalogIssuerDelegationEnvelopeV1 = UnsignedControlEnvelopeV1 & {
+  readonly objectType: typeof AUTHOR_CATALOG_ISSUER_DELEGATION_OBJECT_TYPE_V1;
+  readonly payload: AuthorCatalogIssuerDelegationV1;
+};
+export type SignedAuthorCatalogIssuerDelegationEnvelopeV1 = SignedControlEnvelopeV1 & {
+  readonly objectType: typeof AUTHOR_CATALOG_ISSUER_DELEGATION_OBJECT_TYPE_V1;
+  readonly payload: AuthorCatalogIssuerDelegationV1;
+};
+export type UnsignedCatalogHeadTimelinessReceiptEnvelopeV1 = UnsignedControlEnvelopeV1 & {
+  readonly objectType: typeof CATALOG_HEAD_TIMELINESS_RECEIPT_OBJECT_TYPE_V1;
+  readonly payload: CatalogHeadTimelinessReceiptV1;
+};
+export type SignedCatalogHeadTimelinessReceiptEnvelopeV1 = SignedControlEnvelopeV1 & {
+  readonly objectType: typeof CATALOG_HEAD_TIMELINESS_RECEIPT_OBJECT_TYPE_V1;
+  readonly payload: CatalogHeadTimelinessReceiptV1;
+};
+
+export type AuthorCatalogAuthorityCodecErrorCode =
+  | 'catalog-authority-schema'
+  | 'catalog-authority-scalar'
+  | 'catalog-authority-type'
+  | 'catalog-authority-governance'
+  | 'catalog-authority-history'
+  | 'catalog-authority-authority'
+  | 'catalog-authority-time'
+  | 'catalog-authority-payload-too-large';
+
+export class AuthorCatalogAuthorityCodecError extends Error {
+  constructor(
+    readonly code: AuthorCatalogAuthorityCodecErrorCode,
+    message: string,
+    options: ErrorOptions = {},
+  ) {
+    super(`[${code}] ${message}`, options);
+    this.name = 'AuthorCatalogAuthorityCodecError';
+  }
+}
+
+export function assertAuthorCatalogIssuerDelegationV1(
+  value: unknown,
+): asserts value is AuthorCatalogIssuerDelegationV1 {
+  validateDelegationSnapshot(value);
+}
+
+export function assertCatalogHeadTimelinessReceiptV1(
+  value: unknown,
+): asserts value is CatalogHeadTimelinessReceiptV1 {
+  validateReceiptSnapshot(value);
+}
+
+export function canonicalizeAuthorCatalogIssuerDelegationPayloadV1(
+  value: AuthorCatalogIssuerDelegationV1,
+): string {
+  return validateDelegationSnapshot(value).canonical;
+}
+
+export function canonicalizeAuthorCatalogIssuerDelegationPayloadBytesV1(
+  value: AuthorCatalogIssuerDelegationV1,
+): Uint8Array {
+  return UTF8.encode(canonicalizeAuthorCatalogIssuerDelegationPayloadV1(value));
+}
+
+export function canonicalizeCatalogHeadTimelinessReceiptPayloadV1(
+  value: CatalogHeadTimelinessReceiptV1,
+): string {
+  return validateReceiptSnapshot(value).canonical;
+}
+
+export function canonicalizeCatalogHeadTimelinessReceiptPayloadBytesV1(
+  value: CatalogHeadTimelinessReceiptV1,
+): Uint8Array {
+  return UTF8.encode(canonicalizeCatalogHeadTimelinessReceiptPayloadV1(value));
+}
+
+export function parseCanonicalAuthorCatalogIssuerDelegationPayloadV1(
+  input: string | Uint8Array,
+  options: StrictJsonParseOptions = {},
+): AuthorCatalogIssuerDelegationV1 {
+  rejectOversizedInput(input, 'author catalog issuer delegation');
+  return validateDelegationSnapshot(parseCanonicalJson(input, {
+    ...options,
+    maxBytes: Math.min(
+      options.maxBytes ?? MAX_AUTHOR_CATALOG_AUTHORITY_PAYLOAD_BYTES_V1,
+      MAX_AUTHOR_CATALOG_AUTHORITY_PAYLOAD_BYTES_V1,
+    ),
+    maxDepth: Math.min(options.maxDepth ?? 1, 1),
+  })).snapshot;
+}
+
+export function parseCanonicalCatalogHeadTimelinessReceiptPayloadV1(
+  input: string | Uint8Array,
+  options: StrictJsonParseOptions = {},
+): CatalogHeadTimelinessReceiptV1 {
+  rejectOversizedInput(input, 'catalog head timeliness receipt');
+  return validateReceiptSnapshot(parseCanonicalJson(input, {
+    ...options,
+    maxBytes: Math.min(
+      options.maxBytes ?? MAX_AUTHOR_CATALOG_AUTHORITY_PAYLOAD_BYTES_V1,
+      MAX_AUTHOR_CATALOG_AUTHORITY_PAYLOAD_BYTES_V1,
+    ),
+    maxDepth: Math.min(options.maxDepth ?? 1, 1),
+  })).snapshot;
+}
+
+export function assertUnsignedAuthorCatalogIssuerDelegationEnvelopeV1(
+  value: UnsignedControlEnvelopeV1,
+): asserts value is UnsignedAuthorCatalogIssuerDelegationEnvelopeV1 {
+  validateUnsignedDelegationEnvelopeSnapshot(value);
+}
+
+export function assertSignedAuthorCatalogIssuerDelegationEnvelopeV1(
+  value: SignedControlEnvelopeV1,
+): asserts value is SignedAuthorCatalogIssuerDelegationEnvelopeV1 {
+  validateSignedDelegationEnvelopeSnapshot(value);
+}
+
+export function assertUnsignedCatalogHeadTimelinessReceiptEnvelopeV1(
+  value: UnsignedControlEnvelopeV1,
+): asserts value is UnsignedCatalogHeadTimelinessReceiptEnvelopeV1 {
+  validateUnsignedReceiptEnvelopeSnapshot(value);
+}
+
+export function assertSignedCatalogHeadTimelinessReceiptEnvelopeV1(
+  value: SignedControlEnvelopeV1,
+): asserts value is SignedCatalogHeadTimelinessReceiptEnvelopeV1 {
+  validateSignedReceiptEnvelopeSnapshot(value);
+}
+
+export function canonicalizeUnsignedAuthorCatalogIssuerDelegationEnvelopeBytesV1(
+  value: UnsignedControlEnvelopeV1,
+): Uint8Array {
+  return canonicalizeUnsignedControlEnvelopeBytes(validateUnsignedDelegationEnvelopeSnapshot(value));
+}
+
+export function canonicalizeSignedAuthorCatalogIssuerDelegationEnvelopeBytesV1(
+  value: SignedControlEnvelopeV1,
+): Uint8Array {
+  return canonicalizeSignedControlEnvelopeBytes(validateSignedDelegationEnvelopeSnapshot(value));
+}
+
+export function canonicalizeUnsignedCatalogHeadTimelinessReceiptEnvelopeBytesV1(
+  value: UnsignedControlEnvelopeV1,
+): Uint8Array {
+  return canonicalizeUnsignedControlEnvelopeBytes(validateUnsignedReceiptEnvelopeSnapshot(value));
+}
+
+export function canonicalizeSignedCatalogHeadTimelinessReceiptEnvelopeBytesV1(
+  value: SignedControlEnvelopeV1,
+): Uint8Array {
+  return canonicalizeSignedControlEnvelopeBytes(validateSignedReceiptEnvelopeSnapshot(value));
+}
+
+export function computeAuthorCatalogIssuerDelegationObjectDigestV1(
+  value: UnsignedControlEnvelopeV1,
+): Digest32V1 {
+  return asDigest(computeControlObjectDigestHex(validateUnsignedDelegationEnvelopeSnapshot(value)));
+}
+
+export function computeCatalogHeadTimelinessReceiptObjectDigestV1(
+  value: UnsignedControlEnvelopeV1,
+): Digest32V1 {
+  return asDigest(computeControlObjectDigestHex(validateUnsignedReceiptEnvelopeSnapshot(value)));
+}
+
+export function parseCanonicalUnsignedAuthorCatalogIssuerDelegationEnvelopeV1(
+  input: string | Uint8Array,
+  options: StrictJsonParseOptions = {},
+): UnsignedAuthorCatalogIssuerDelegationEnvelopeV1 {
+  return validateUnsignedDelegationEnvelopeSnapshot(
+    parseCanonicalUnsignedControlEnvelope(input, options),
+  );
+}
+
+export function parseCanonicalSignedAuthorCatalogIssuerDelegationEnvelopeV1(
+  input: string | Uint8Array,
+  options: StrictJsonParseOptions = {},
+): SignedAuthorCatalogIssuerDelegationEnvelopeV1 {
+  return validateSignedDelegationEnvelopeSnapshot(
+    parseCanonicalSignedControlEnvelope(input, options),
+  );
+}
+
+export function parseCanonicalUnsignedCatalogHeadTimelinessReceiptEnvelopeV1(
+  input: string | Uint8Array,
+  options: StrictJsonParseOptions = {},
+): UnsignedCatalogHeadTimelinessReceiptEnvelopeV1 {
+  return validateUnsignedReceiptEnvelopeSnapshot(
+    parseCanonicalUnsignedControlEnvelope(input, options),
+  );
+}
+
+export function parseCanonicalSignedCatalogHeadTimelinessReceiptEnvelopeV1(
+  input: string | Uint8Array,
+  options: StrictJsonParseOptions = {},
+): SignedCatalogHeadTimelinessReceiptEnvelopeV1 {
+  return validateSignedReceiptEnvelopeSnapshot(
+    parseCanonicalSignedControlEnvelope(input, options),
+  );
+}
+
+function validateUnsignedDelegationEnvelopeSnapshot(
+  value: unknown,
+): UnsignedAuthorCatalogIssuerDelegationEnvelopeV1 {
+  assertUnsignedControlEnvelope(value as UnsignedControlEnvelopeV1);
+  const envelope = value as UnsignedControlEnvelopeV1;
+  assertObjectType(envelope.objectType, AUTHOR_CATALOG_ISSUER_DELEGATION_OBJECT_TYPE_V1);
+  validateDelegationPlain(envelope.payload);
+  const snapshot = clonePlainData(envelope, 'unsigned catalog issuer delegation envelope');
+  assertUnsignedControlEnvelope(snapshot);
+  assertObjectType(snapshot.objectType, AUTHOR_CATALOG_ISSUER_DELEGATION_OBJECT_TYPE_V1);
+  validateDelegationPlain(snapshot.payload);
+  const typedSnapshot = snapshot as UnsignedAuthorCatalogIssuerDelegationEnvelopeV1;
+  assertDelegationAuthorPairing(typedSnapshot);
+  return typedSnapshot;
+}
+
+function validateSignedDelegationEnvelopeSnapshot(
+  value: unknown,
+): SignedAuthorCatalogIssuerDelegationEnvelopeV1 {
+  assertSignedControlEnvelope(value as SignedControlEnvelopeV1);
+  const envelope = value as SignedControlEnvelopeV1;
+  assertObjectType(envelope.objectType, AUTHOR_CATALOG_ISSUER_DELEGATION_OBJECT_TYPE_V1);
+  validateDelegationPlain(envelope.payload);
+  const snapshot = clonePlainData(envelope, 'signed catalog issuer delegation envelope');
+  assertSignedControlEnvelope(snapshot);
+  assertObjectType(snapshot.objectType, AUTHOR_CATALOG_ISSUER_DELEGATION_OBJECT_TYPE_V1);
+  validateDelegationPlain(snapshot.payload);
+  const typedSnapshot = snapshot as SignedAuthorCatalogIssuerDelegationEnvelopeV1;
+  assertDelegationAuthorPairing(typedSnapshot);
+  return typedSnapshot;
+}
+
+/**
+ * Close the structural direct/delegated issuer branch on the stable envelope
+ * snapshot. A non-null evidence digest is only a reference here: resolving and
+ * verifying the referenced author/agent delegation remains a runtime authority
+ * check, outside this wire codec.
+ */
+function assertDelegationAuthorPairing(
+  envelope:
+    | UnsignedAuthorCatalogIssuerDelegationEnvelopeV1
+    | SignedAuthorCatalogIssuerDelegationEnvelopeV1,
+): void {
+  const issuerIsAuthor = envelope.issuer === envelope.payload.authorAddress;
+  const evidenceIsNull = envelope.payload.authorAuthorityEvidenceDigest === null;
+  if (issuerIsAuthor !== evidenceIsNull) {
+    fail(
+      'catalog-authority-authority',
+      'the author must issue directly without authority evidence, and every other issuer must name authority evidence',
+    );
+  }
+}
+
+function validateUnsignedReceiptEnvelopeSnapshot(
+  value: unknown,
+): UnsignedCatalogHeadTimelinessReceiptEnvelopeV1 {
+  assertUnsignedControlEnvelope(value as UnsignedControlEnvelopeV1);
+  const envelope = value as UnsignedControlEnvelopeV1;
+  assertObjectType(envelope.objectType, CATALOG_HEAD_TIMELINESS_RECEIPT_OBJECT_TYPE_V1);
+  validateReceiptPlain(envelope.payload);
+  const snapshot = clonePlainData(envelope, 'unsigned catalog timeliness receipt envelope');
+  assertUnsignedControlEnvelope(snapshot);
+  assertObjectType(snapshot.objectType, CATALOG_HEAD_TIMELINESS_RECEIPT_OBJECT_TYPE_V1);
+  validateReceiptPlain(snapshot.payload);
+  return snapshot as UnsignedCatalogHeadTimelinessReceiptEnvelopeV1;
+}
+
+function validateSignedReceiptEnvelopeSnapshot(
+  value: unknown,
+): SignedCatalogHeadTimelinessReceiptEnvelopeV1 {
+  assertSignedControlEnvelope(value as SignedControlEnvelopeV1);
+  const envelope = value as SignedControlEnvelopeV1;
+  assertObjectType(envelope.objectType, CATALOG_HEAD_TIMELINESS_RECEIPT_OBJECT_TYPE_V1);
+  validateReceiptPlain(envelope.payload);
+  const snapshot = clonePlainData(envelope, 'signed catalog timeliness receipt envelope');
+  assertSignedControlEnvelope(snapshot);
+  assertObjectType(snapshot.objectType, CATALOG_HEAD_TIMELINESS_RECEIPT_OBJECT_TYPE_V1);
+  validateReceiptPlain(snapshot.payload);
+  return snapshot as SignedCatalogHeadTimelinessReceiptEnvelopeV1;
+}
+
+function validateDelegationSnapshot(value: unknown): {
+  readonly snapshot: AuthorCatalogIssuerDelegationV1;
+  readonly canonical: string;
+} {
+  const bounded = validateDelegationPlain(value);
+  return validateDelegationPlain(clonePlainData(bounded.snapshot, 'catalog issuer delegation'));
+}
+
+function validateDelegationPlain(value: unknown): {
+  readonly snapshot: AuthorCatalogIssuerDelegationV1;
+  readonly canonical: string;
+} {
+  if (!isPlainRecord(value)) fail('catalog-authority-schema', 'delegation must be a plain object');
+  closed(value, [
+    'authorAddress',
+    'authorAuthorityEvidenceDigest',
+    'catalogEra',
+    'catalogIssuerKey',
+    'contextGraphId',
+    'effectiveAt',
+    'expiresAt',
+    'governanceChainId',
+    'governanceContractAddress',
+    'networkId',
+    'ownershipTransitionDigest',
+    'previousDelegationDigest',
+    'subGraphName',
+  ], 'catalog issuer delegation');
+  scalar(() => assertNetworkIdV1(value.networkId));
+  scalar(() => assertContextGraphIdV1(value.contextGraphId));
+  assertGovernanceScope(
+    value.governanceChainId,
+    value.governanceContractAddress,
+    value.ownershipTransitionDigest,
+  );
+  if (value.subGraphName !== null) scalar(() => assertSubGraphNameV1(value.subGraphName));
+  scalar(() => assertCanonicalEvmAddress(value.authorAddress, 'authorAddress'));
+  const era = u64(value.catalogEra, 'catalogEra');
+  optionalDigest(value.previousDelegationDigest, 'previousDelegationDigest');
+  if ((era === 0n) !== (value.previousDelegationDigest === null)) {
+    fail(
+      'catalog-authority-history',
+      'catalog era zero requires a null predecessor and later eras require one',
+    );
+  }
+  scalar(() => assertCanonicalEvmAddress(value.catalogIssuerKey, 'catalogIssuerKey'));
+  optionalDigest(value.authorAuthorityEvidenceDigest, 'authorAuthorityEvidenceDigest');
+  const effectiveAt = timestamp(value.effectiveAt, 'effectiveAt');
+  const expiresAt = timestamp(value.expiresAt, 'expiresAt');
+  if (effectiveAt >= expiresAt) {
+    fail('catalog-authority-time', 'effectiveAt must be strictly earlier than expiresAt');
+  }
+  const snapshot = value as unknown as AuthorCatalogIssuerDelegationV1;
+  return { snapshot, canonical: canonicalizeBounded(snapshot, 'catalog issuer delegation') };
+}
+
+function validateReceiptSnapshot(value: unknown): {
+  readonly snapshot: CatalogHeadTimelinessReceiptV1;
+  readonly canonical: string;
+} {
+  const bounded = validateReceiptPlain(value);
+  return validateReceiptPlain(clonePlainData(bounded.snapshot, 'catalog head timeliness receipt'));
+}
+
+function validateReceiptPlain(value: unknown): {
+  readonly snapshot: CatalogHeadTimelinessReceiptV1;
+  readonly canonical: string;
+} {
+  if (!isPlainRecord(value)) fail('catalog-authority-schema', 'receipt must be a plain object');
+  closed(value, [
+    'authorAddress',
+    'catalogHeadDigest',
+    'catalogIssuerDelegationDigest',
+    'checkpointAuthorityDelegationDigest',
+    'contextGraphId',
+    'governanceChainId',
+    'governanceContractAddress',
+    'networkId',
+    'observedAt',
+    'ownershipTransitionDigest',
+    'subGraphName',
+  ], 'catalog head timeliness receipt');
+  scalar(() => assertNetworkIdV1(value.networkId));
+  scalar(() => assertContextGraphIdV1(value.contextGraphId));
+  assertGovernanceScope(
+    value.governanceChainId,
+    value.governanceContractAddress,
+    value.ownershipTransitionDigest,
+  );
+  if (value.subGraphName !== null) scalar(() => assertSubGraphNameV1(value.subGraphName));
+  scalar(() => assertCanonicalDigest(
+    value.checkpointAuthorityDelegationDigest,
+    'checkpointAuthorityDelegationDigest',
+  ));
+  scalar(() => assertCanonicalEvmAddress(value.authorAddress, 'authorAddress'));
+  scalar(() => assertCanonicalDigest(
+    value.catalogIssuerDelegationDigest,
+    'catalogIssuerDelegationDigest',
+  ));
+  scalar(() => assertCanonicalDigest(value.catalogHeadDigest, 'catalogHeadDigest'));
+  timestamp(value.observedAt, 'observedAt');
+  const snapshot = value as unknown as CatalogHeadTimelinessReceiptV1;
+  return { snapshot, canonical: canonicalizeBounded(snapshot, 'catalog head timeliness receipt') };
+}
+
+function assertGovernanceScope(
+  chainId: unknown,
+  contractAddress: unknown,
+  ownershipTransitionDigest: unknown,
+): void {
+  if ((chainId === null) !== (contractAddress === null)) {
+    fail('catalog-authority-governance', 'governance tuple must be jointly null/non-null');
+  }
+  if (chainId === null) {
+    if (ownershipTransitionDigest !== null) {
+      fail('catalog-authority-governance', 'unregistered scope cannot name a transition');
+    }
+    return;
+  }
+  scalar(() => assertCanonicalChainId(chainId));
+  scalar(() => assertCanonicalEvmAddress(contractAddress, 'governanceContractAddress'));
+  optionalDigest(ownershipTransitionDigest, 'ownershipTransitionDigest');
+}
+
+function canonicalizeBounded(
+  value: AuthorCatalogIssuerDelegationV1 | CatalogHeadTimelinessReceiptV1,
+  label: string,
+): string {
+  try {
+    return canonicalizeJson(value as unknown as CanonicalJsonValue, {
+      maxBytes: MAX_AUTHOR_CATALOG_AUTHORITY_PAYLOAD_BYTES_V1,
+      maxDepth: 1,
+    });
+  } catch (cause) {
+    fail('catalog-authority-payload-too-large', `${label} exceeds its canonical cap`, cause);
+  }
+}
+
+function clonePlainData<T>(value: T, label: string): T {
+  assertStablePlainData(value, label, 0, new Set<object>());
+  try {
+    return structuredClone(value);
+  } catch (cause) {
+    fail('catalog-authority-schema', `${label} must be structured-cloneable JSON data`, cause);
+  }
+}
+
+function assertStablePlainData(
+  value: unknown,
+  label: string,
+  depth: number,
+  ancestors: Set<object>,
+): void {
+  if (depth > 64) fail('catalog-authority-schema', `${label} exceeds nesting safety cap`);
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') return;
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) fail('catalog-authority-schema', `${label} has a non-JSON number`);
+    return;
+  }
+  if (typeof value !== 'object') {
+    fail('catalog-authority-schema', `${label} has a non-JSON implementation value`);
+  }
+  if (ancestors.has(value)) fail('catalog-authority-schema', `${label} contains a cycle`);
+  ancestors.add(value);
+  try {
+    if (Array.isArray(value)) {
+      if (Object.getPrototypeOf(value) !== Array.prototype) {
+        fail('catalog-authority-schema', `${label} contains a non-ordinary array`);
+      }
+      const keys = Reflect.ownKeys(value);
+      if (keys.some((key) => typeof key !== 'string') || keys.length !== value.length + 1) {
+        fail('catalog-authority-schema', `${label} contains a sparse or custom array`);
+      }
+      for (let index = 0; index < value.length; index += 1) {
+        const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
+        if (!descriptor?.enumerable || !Object.prototype.hasOwnProperty.call(descriptor, 'value')) {
+          fail('catalog-authority-schema', `${label} contains an array accessor`);
+        }
+        assertStablePlainData(descriptor.value, `${label}[${index}]`, depth + 1, ancestors);
+      }
+      return;
+    }
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      fail('catalog-authority-schema', `${label} contains a non-plain object`);
+    }
+    for (const key of Reflect.ownKeys(value)) {
+      if (typeof key !== 'string') fail('catalog-authority-schema', `${label} contains a symbol`);
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      if (!descriptor?.enumerable || !Object.prototype.hasOwnProperty.call(descriptor, 'value')) {
+        fail('catalog-authority-schema', `${label} contains an object accessor`);
+      }
+      assertStablePlainData(descriptor.value, `${label}.${key}`, depth + 1, ancestors);
+    }
+  } finally {
+    ancestors.delete(value);
+  }
+}
+
+function optionalDigest(value: unknown, label: string): void {
+  if (value !== null) scalar(() => assertCanonicalDigest(value, label));
+}
+
+function u64(value: unknown, label: string): bigint {
+  try {
+    return parseCanonicalDecimalU64(value, label);
+  } catch (cause) {
+    fail('catalog-authority-scalar', `${label} must be canonical DecimalU64V1`, cause);
+  }
+}
+
+function timestamp(value: unknown, label: string): bigint {
+  scalar(() => assertCanonicalTimestampMs(value, label));
+  return BigInt(value as string);
+}
+
+function scalar(operation: () => void): void {
+  try {
+    operation();
+  } catch (cause) {
+    fail('catalog-authority-scalar', 'catalog authority scalar is not canonical', cause);
+  }
+}
+
+function closed(record: Record<string, unknown>, keys: readonly string[], label: string): void {
+  try {
+    assertExactKeys(record, keys, label);
+  } catch (cause) {
+    fail('catalog-authority-schema', `${label} has an invalid field set`, cause);
+  }
+}
+
+function assertObjectType(actual: string, expected: string): void {
+  if (actual !== expected) fail('catalog-authority-type', `objectType must be exactly ${expected}`);
+}
+
+function asDigest(value: string): Digest32V1 {
+  assertCanonicalDigest(value, 'objectDigest');
+  return value;
+}
+
+function rejectOversizedInput(input: string | Uint8Array, label: string): void {
+  if (
+    typeof input === 'string'
+    && input.length > MAX_AUTHOR_CATALOG_AUTHORITY_PAYLOAD_BYTES_V1
+  ) {
+    fail(
+      'catalog-authority-payload-too-large',
+      `${label} exceeds ${MAX_AUTHOR_CATALOG_AUTHORITY_PAYLOAD_BYTES_V1} bytes`,
+    );
+  }
+  const bytes = typeof input === 'string' ? UTF8.encode(input).byteLength : input.byteLength;
+  if (bytes > MAX_AUTHOR_CATALOG_AUTHORITY_PAYLOAD_BYTES_V1) {
+    fail(
+      'catalog-authority-payload-too-large',
+      `${label} exceeds ${MAX_AUTHOR_CATALOG_AUTHORITY_PAYLOAD_BYTES_V1} bytes`,
+    );
+  }
+}
+
+function fail(
+  code: AuthorCatalogAuthorityCodecErrorCode,
+  message: string,
+  cause?: unknown,
+): never {
+  throw new AuthorCatalogAuthorityCodecError(
+    code,
+    message,
+    cause === undefined ? {} : { cause },
+  );
+}

--- a/packages/core/src/author-catalog-authority-objects.ts
+++ b/packages/core/src/author-catalog-authority-objects.ts
@@ -42,6 +42,7 @@ export const AUTHOR_CATALOG_ISSUER_DELEGATION_OBJECT_TYPE_V1 =
 export const CATALOG_HEAD_TIMELINESS_RECEIPT_OBJECT_TYPE_V1 =
   'CatalogHeadTimelinessReceiptV1' as const;
 export const MAX_AUTHOR_CATALOG_AUTHORITY_PAYLOAD_BYTES_V1 = 16 * 1024;
+export const MAX_AUTHOR_CATALOG_AUTHORITY_PAYLOAD_DEPTH_V1 = 1;
 
 const UTF8 = new TextEncoder();
 
@@ -160,7 +161,10 @@ export function parseCanonicalAuthorCatalogIssuerDelegationPayloadV1(
       options.maxBytes ?? MAX_AUTHOR_CATALOG_AUTHORITY_PAYLOAD_BYTES_V1,
       MAX_AUTHOR_CATALOG_AUTHORITY_PAYLOAD_BYTES_V1,
     ),
-    maxDepth: Math.min(options.maxDepth ?? 1, 1),
+    maxDepth: Math.min(
+      options.maxDepth ?? MAX_AUTHOR_CATALOG_AUTHORITY_PAYLOAD_DEPTH_V1,
+      MAX_AUTHOR_CATALOG_AUTHORITY_PAYLOAD_DEPTH_V1,
+    ),
   })).snapshot;
 }
 
@@ -175,7 +179,10 @@ export function parseCanonicalCatalogHeadTimelinessReceiptPayloadV1(
       options.maxBytes ?? MAX_AUTHOR_CATALOG_AUTHORITY_PAYLOAD_BYTES_V1,
       MAX_AUTHOR_CATALOG_AUTHORITY_PAYLOAD_BYTES_V1,
     ),
-    maxDepth: Math.min(options.maxDepth ?? 1, 1),
+    maxDepth: Math.min(
+      options.maxDepth ?? MAX_AUTHOR_CATALOG_AUTHORITY_PAYLOAD_DEPTH_V1,
+      MAX_AUTHOR_CATALOG_AUTHORITY_PAYLOAD_DEPTH_V1,
+    ),
   })).snapshot;
 }
 
@@ -487,7 +494,7 @@ function canonicalizeBounded(
   try {
     return canonicalizeJson(value as unknown as CanonicalJsonValue, {
       maxBytes: MAX_AUTHOR_CATALOG_AUTHORITY_PAYLOAD_BYTES_V1,
-      maxDepth: 1,
+      maxDepth: MAX_AUTHOR_CATALOG_AUTHORITY_PAYLOAD_DEPTH_V1,
     });
   } catch (cause) {
     fail('catalog-authority-payload-too-large', `${label} exceeds its canonical cap`, cause);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,6 +15,7 @@ export * from './imported-artifact-bytes.js';
 export * from './imported-artifact-metadata.js';
 export * from './sync-control-object.js';
 export * from './cg-policy-objects.js';
+export * from './author-catalog-authority-objects.js';
 export {
   MAX_DECIMAL_U64,
   MAX_DECIMAL_U256,

--- a/packages/core/test/author-catalog-authority-objects.test.ts
+++ b/packages/core/test/author-catalog-authority-objects.test.ts
@@ -1,0 +1,325 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  AUTHOR_CATALOG_ISSUER_DELEGATION_OBJECT_TYPE_V1,
+  CATALOG_HEAD_TIMELINESS_RECEIPT_OBJECT_TYPE_V1,
+  MAX_AUTHOR_CATALOG_AUTHORITY_PAYLOAD_BYTES_V1,
+  assertAuthorCatalogIssuerDelegationV1,
+  assertCatalogHeadTimelinessReceiptV1,
+  assertSignedAuthorCatalogIssuerDelegationEnvelopeV1,
+  assertSignedCatalogHeadTimelinessReceiptEnvelopeV1,
+  assertUnsignedAuthorCatalogIssuerDelegationEnvelopeV1,
+  assertUnsignedCatalogHeadTimelinessReceiptEnvelopeV1,
+  canonicalizeAuthorCatalogIssuerDelegationPayloadV1,
+  canonicalizeCatalogHeadTimelinessReceiptPayloadV1,
+  canonicalizeSignedAuthorCatalogIssuerDelegationEnvelopeBytesV1,
+  canonicalizeSignedCatalogHeadTimelinessReceiptEnvelopeBytesV1,
+  canonicalizeUnsignedAuthorCatalogIssuerDelegationEnvelopeBytesV1,
+  canonicalizeUnsignedCatalogHeadTimelinessReceiptEnvelopeBytesV1,
+  computeAuthorCatalogIssuerDelegationObjectDigestV1,
+  computeCatalogHeadTimelinessReceiptObjectDigestV1,
+  parseCanonicalAuthorCatalogIssuerDelegationPayloadV1,
+  parseCanonicalCatalogHeadTimelinessReceiptPayloadV1,
+  parseCanonicalSignedAuthorCatalogIssuerDelegationEnvelopeV1,
+  parseCanonicalSignedCatalogHeadTimelinessReceiptEnvelopeV1,
+  parseCanonicalUnsignedAuthorCatalogIssuerDelegationEnvelopeV1,
+  parseCanonicalUnsignedCatalogHeadTimelinessReceiptEnvelopeV1,
+  type AuthorCatalogIssuerDelegationV1,
+  type CatalogHeadTimelinessReceiptV1,
+} from '../src/author-catalog-authority-objects.js';
+import type {
+  SignedControlEnvelopeV1,
+  UnsignedControlEnvelopeV1,
+} from '../src/sync-control-object.js';
+
+const AUTHOR = '0x3333333333333333333333333333333333333333';
+const ISSUER = '0x5555555555555555555555555555555555555555';
+const CHECKPOINT = '0x7777777777777777777777777777777777777777';
+const SIGNATURE = `0x${'99'.repeat(65)}`;
+const AUTHOR_AUTHORITY_EVIDENCE_DIGEST = `0x${'44'.repeat(32)}`;
+const DELEGATION_DIGEST = '0x00884f491e9e1725cc41b7b74dfc00fca65f7fdd247d75345f99e55a8546541b';
+const DELEGATED_DELEGATION_DIGEST = '0x4a5a93a82cc7fa3aec78b082d3423d21c3e355ef9052ce41420d4c458014af85';
+const RECEIPT_DIGEST = '0x0ecaa8f7835d1006f7a1f16c0682e8172fa634da7ea7fe7521ef8dd8ddb7b8d8';
+
+const DELEGATION = validatedDelegation({
+  networkId: 'otp:20430',
+  contextGraphId: '0x1111111111111111111111111111111111111111/catalog-fixture',
+  governanceChainId: '20430',
+  governanceContractAddress: '0x2222222222222222222222222222222222222222',
+  ownershipTransitionDigest: null,
+  subGraphName: null,
+  authorAddress: AUTHOR,
+  catalogEra: '0',
+  previousDelegationDigest: null,
+  catalogIssuerKey: ISSUER,
+  authorAuthorityEvidenceDigest: null,
+  effectiveAt: '1700000000000',
+  expiresAt: '1700000120000',
+});
+
+const RECEIPT = validatedReceipt({
+  networkId: DELEGATION.networkId,
+  contextGraphId: DELEGATION.contextGraphId,
+  governanceChainId: DELEGATION.governanceChainId,
+  governanceContractAddress: DELEGATION.governanceContractAddress,
+  ownershipTransitionDigest: DELEGATION.ownershipTransitionDigest,
+  subGraphName: DELEGATION.subGraphName,
+  checkpointAuthorityDelegationDigest: `0x${'77'.repeat(32)}`,
+  authorAddress: AUTHOR,
+  catalogIssuerDelegationDigest: DELEGATION_DIGEST,
+  catalogHeadDigest: `0x${'66'.repeat(32)}`,
+  observedAt: '1700000060000',
+});
+
+const DELEGATION_CANONICAL = '{"authorAddress":"0x3333333333333333333333333333333333333333","authorAuthorityEvidenceDigest":null,"catalogEra":"0","catalogIssuerKey":"0x5555555555555555555555555555555555555555","contextGraphId":"0x1111111111111111111111111111111111111111/catalog-fixture","effectiveAt":"1700000000000","expiresAt":"1700000120000","governanceChainId":"20430","governanceContractAddress":"0x2222222222222222222222222222222222222222","networkId":"otp:20430","ownershipTransitionDigest":null,"previousDelegationDigest":null,"subGraphName":null}';
+const RECEIPT_CANONICAL = '{"authorAddress":"0x3333333333333333333333333333333333333333","catalogHeadDigest":"0x6666666666666666666666666666666666666666666666666666666666666666","catalogIssuerDelegationDigest":"0x00884f491e9e1725cc41b7b74dfc00fca65f7fdd247d75345f99e55a8546541b","checkpointAuthorityDelegationDigest":"0x7777777777777777777777777777777777777777777777777777777777777777","contextGraphId":"0x1111111111111111111111111111111111111111/catalog-fixture","governanceChainId":"20430","governanceContractAddress":"0x2222222222222222222222222222222222222222","networkId":"otp:20430","observedAt":"1700000060000","ownershipTransitionDigest":null,"subGraphName":null}';
+
+const DELEGATION_UNSIGNED = unsigned(
+  AUTHOR_CATALOG_ISSUER_DELEGATION_OBJECT_TYPE_V1,
+  AUTHOR,
+  DELEGATION,
+);
+const DELEGATED_DELEGATION = validatedDelegation({
+  ...DELEGATION,
+  authorAuthorityEvidenceDigest: AUTHOR_AUTHORITY_EVIDENCE_DIGEST,
+});
+const DELEGATED_DELEGATION_UNSIGNED = unsigned(
+  AUTHOR_CATALOG_ISSUER_DELEGATION_OBJECT_TYPE_V1,
+  ISSUER,
+  DELEGATED_DELEGATION,
+);
+const RECEIPT_UNSIGNED = unsigned(
+  CATALOG_HEAD_TIMELINESS_RECEIPT_OBJECT_TYPE_V1,
+  CHECKPOINT,
+  RECEIPT,
+);
+const DELEGATION_SIGNED = signed(DELEGATION_UNSIGNED, DELEGATION_DIGEST);
+const DELEGATED_DELEGATION_SIGNED = signed(
+  DELEGATED_DELEGATION_UNSIGNED,
+  DELEGATED_DELEGATION_DIGEST,
+);
+const RECEIPT_SIGNED = signed(RECEIPT_UNSIGNED, RECEIPT_DIGEST);
+
+describe('AuthorCatalogIssuerDelegationV1 codec', () => {
+  it('pins canonical payload bytes, envelope digest, and signed round trips', () => {
+    expect(canonicalizeAuthorCatalogIssuerDelegationPayloadV1(DELEGATION))
+      .toBe(DELEGATION_CANONICAL);
+    expect(new TextEncoder().encode(DELEGATION_CANONICAL)).toHaveLength(526);
+    expect(parseCanonicalAuthorCatalogIssuerDelegationPayloadV1(DELEGATION_CANONICAL))
+      .toEqual(DELEGATION);
+    expect(computeAuthorCatalogIssuerDelegationObjectDigestV1(DELEGATION_UNSIGNED))
+      .toBe(DELEGATION_DIGEST);
+
+    const unsignedBytes = canonicalizeUnsignedAuthorCatalogIssuerDelegationEnvelopeBytesV1(
+      DELEGATION_UNSIGNED,
+    );
+    expect(unsignedBytes).toHaveLength(725);
+    expect(parseCanonicalUnsignedAuthorCatalogIssuerDelegationEnvelopeV1(unsignedBytes))
+      .toEqual(DELEGATION_UNSIGNED);
+    expect(parseCanonicalSignedAuthorCatalogIssuerDelegationEnvelopeV1(
+      canonicalizeSignedAuthorCatalogIssuerDelegationEnvelopeBytesV1(DELEGATION_SIGNED),
+    )).toEqual(DELEGATION_SIGNED);
+    expect(() => assertUnsignedAuthorCatalogIssuerDelegationEnvelopeV1(DELEGATION_UNSIGNED))
+      .not.toThrow();
+    expect(() => assertSignedAuthorCatalogIssuerDelegationEnvelopeV1(DELEGATION_SIGNED))
+      .not.toThrow();
+  });
+
+  it('closes governance, era/predecessor, validity, and scalar branches', () => {
+    expect(() => assertAuthorCatalogIssuerDelegationV1({
+      ...DELEGATION,
+      governanceContractAddress: null,
+    })).toThrow(/catalog-authority-governance/);
+    expect(() => assertAuthorCatalogIssuerDelegationV1({
+      ...DELEGATION,
+      governanceChainId: null,
+      governanceContractAddress: null,
+      ownershipTransitionDigest: `0x${'44'.repeat(32)}`,
+    })).toThrow(/catalog-authority-governance/);
+    expect(() => assertAuthorCatalogIssuerDelegationV1({
+      ...DELEGATION,
+      catalogEra: '1',
+    })).toThrow(/catalog-authority-history/);
+    expect(() => assertAuthorCatalogIssuerDelegationV1({
+      ...DELEGATION,
+      previousDelegationDigest: `0x${'11'.repeat(32)}`,
+    })).toThrow(/catalog-authority-history/);
+    expect(() => assertAuthorCatalogIssuerDelegationV1({
+      ...DELEGATION,
+      expiresAt: DELEGATION.effectiveAt,
+    })).toThrow(/catalog-authority-time/);
+    expect(() => assertAuthorCatalogIssuerDelegationV1({ ...DELEGATION, catalogEra: 0 }))
+      .toThrow(/catalog-authority-scalar/);
+    expect(() => assertAuthorCatalogIssuerDelegationV1({ ...DELEGATION, extra: true }))
+      .toThrow(/catalog-authority-schema/);
+  });
+
+  it('enforces exact direct/delegated author pairing on the cloned envelope', () => {
+    // Direct-author positive: direct issuance carries no delegation evidence.
+    expect(() => assertUnsignedAuthorCatalogIssuerDelegationEnvelopeV1(DELEGATION_UNSIGNED))
+      .not.toThrow();
+
+    // Delegated positive: the structural codec retains, but deliberately does not
+    // resolve, the exact evidence digest; the authority resolver verifies it later.
+    expect(() => assertUnsignedAuthorCatalogIssuerDelegationEnvelopeV1(
+      DELEGATED_DELEGATION_UNSIGNED,
+    )).not.toThrow();
+    expect(() => assertSignedAuthorCatalogIssuerDelegationEnvelopeV1(
+      DELEGATED_DELEGATION_SIGNED,
+    )).not.toThrow();
+    expect(computeAuthorCatalogIssuerDelegationObjectDigestV1(DELEGATED_DELEGATION_UNSIGNED))
+      .toBe(DELEGATED_DELEGATION_DIGEST);
+
+    // An arbitrary non-author issuer cannot masquerade as direct issuance.
+    expect(() => assertUnsignedAuthorCatalogIssuerDelegationEnvelopeV1(unsigned(
+      AUTHOR_CATALOG_ISSUER_DELEGATION_OBJECT_TYPE_V1,
+      ISSUER,
+      DELEGATION,
+    ))).toThrow(/catalog-authority-authority/);
+
+    // Conversely, the author cannot attach spurious delegated-authority evidence.
+    expect(() => assertUnsignedAuthorCatalogIssuerDelegationEnvelopeV1(unsigned(
+      AUTHOR_CATALOG_ISSUER_DELEGATION_OBJECT_TYPE_V1,
+      AUTHOR,
+      DELEGATED_DELEGATION,
+    ))).toThrow(/catalog-authority-authority/);
+  });
+
+  it('accepts registered pre-transfer and unregistered scope but rejects replay between them', () => {
+    expect(() => assertAuthorCatalogIssuerDelegationV1(DELEGATION)).not.toThrow();
+    expect(() => assertAuthorCatalogIssuerDelegationV1({
+      ...DELEGATION,
+      governanceChainId: null,
+      governanceContractAddress: null,
+    })).not.toThrow();
+    expect(() => assertAuthorCatalogIssuerDelegationV1({
+      ...DELEGATION,
+      governanceChainId: null,
+      governanceContractAddress: null,
+      ownershipTransitionDigest: `0x${'88'.repeat(32)}`,
+    })).toThrow(/catalog-authority-governance/);
+  });
+
+  it('rejects noncanonical wire, oversize input, accessors, and stateful values', () => {
+    expect(() => parseCanonicalAuthorCatalogIssuerDelegationPayloadV1(
+      DELEGATION_CANONICAL.replace('"catalogEra":"0"', '"catalogEra": "0"'),
+    )).toThrow();
+    const oversized = `{"x":"${'a'.repeat(MAX_AUTHOR_CATALOG_AUTHORITY_PAYLOAD_BYTES_V1)}"}`;
+    expect(() => parseCanonicalAuthorCatalogIssuerDelegationPayloadV1(oversized))
+      .toThrow(/payload-too-large/);
+
+    let getterCalls = 0;
+    const hostile = { ...DELEGATION } as Record<string, unknown>;
+    Object.defineProperty(hostile, 'catalogIssuerKey', {
+      enumerable: true,
+      get() {
+        getterCalls += 1;
+        return ISSUER;
+      },
+    });
+    expect(() => assertAuthorCatalogIssuerDelegationV1(hostile))
+      .toThrow(/catalog-authority-schema/);
+    expect(getterCalls).toBe(0);
+  });
+
+  it('rejects wrong object types and signed digest substitution', () => {
+    expect(() => assertUnsignedAuthorCatalogIssuerDelegationEnvelopeV1({
+      ...DELEGATION_UNSIGNED,
+      objectType: CATALOG_HEAD_TIMELINESS_RECEIPT_OBJECT_TYPE_V1,
+    })).toThrow(/catalog-authority-type/);
+    expect(() => assertSignedAuthorCatalogIssuerDelegationEnvelopeV1({
+      ...DELEGATION_SIGNED,
+      objectDigest: `0x${'00'.repeat(32)}`,
+    })).toThrow(/digest mismatch/i);
+  });
+});
+
+describe('CatalogHeadTimelinessReceiptV1 codec', () => {
+  it('pins canonical payload bytes, envelope digest, and signed round trips', () => {
+    expect(canonicalizeCatalogHeadTimelinessReceiptPayloadV1(RECEIPT))
+      .toBe(RECEIPT_CANONICAL);
+    expect(new TextEncoder().encode(RECEIPT_CANONICAL)).toHaveLength(644);
+    expect(parseCanonicalCatalogHeadTimelinessReceiptPayloadV1(RECEIPT_CANONICAL))
+      .toEqual(RECEIPT);
+    expect(computeCatalogHeadTimelinessReceiptObjectDigestV1(RECEIPT_UNSIGNED))
+      .toBe(RECEIPT_DIGEST);
+
+    const unsignedBytes = canonicalizeUnsignedCatalogHeadTimelinessReceiptEnvelopeBytesV1(
+      RECEIPT_UNSIGNED,
+    );
+    expect(unsignedBytes).toHaveLength(842);
+    expect(parseCanonicalUnsignedCatalogHeadTimelinessReceiptEnvelopeV1(unsignedBytes))
+      .toEqual(RECEIPT_UNSIGNED);
+    expect(parseCanonicalSignedCatalogHeadTimelinessReceiptEnvelopeV1(
+      canonicalizeSignedCatalogHeadTimelinessReceiptEnvelopeBytesV1(RECEIPT_SIGNED),
+    )).toEqual(RECEIPT_SIGNED);
+    expect(() => assertUnsignedCatalogHeadTimelinessReceiptEnvelopeV1(RECEIPT_UNSIGNED))
+      .not.toThrow();
+    expect(() => assertSignedCatalogHeadTimelinessReceiptEnvelopeV1(RECEIPT_SIGNED))
+      .not.toThrow();
+  });
+
+  it('closes governance, field set, digest, address, and timestamp encodings', () => {
+    expect(() => assertCatalogHeadTimelinessReceiptV1({
+      ...RECEIPT,
+      governanceChainId: null,
+      governanceContractAddress: null,
+    })).not.toThrow();
+    expect(() => assertCatalogHeadTimelinessReceiptV1({
+      ...RECEIPT,
+      governanceChainId: null,
+      governanceContractAddress: null,
+      ownershipTransitionDigest: `0x${'88'.repeat(32)}`,
+    })).toThrow(/catalog-authority-governance/);
+    expect(() => assertCatalogHeadTimelinessReceiptV1({ ...RECEIPT, observedAt: 0 }))
+      .toThrow(/catalog-authority-scalar/);
+    expect(() => assertCatalogHeadTimelinessReceiptV1({ ...RECEIPT, authorAddress: AUTHOR.toUpperCase() }))
+      .toThrow(/catalog-authority-scalar/);
+    expect(() => assertCatalogHeadTimelinessReceiptV1({ ...RECEIPT, catalogHeadDigest: '0x00' }))
+      .toThrow(/catalog-authority-scalar/);
+    expect(() => assertCatalogHeadTimelinessReceiptV1({ ...RECEIPT, retryAfter: null }))
+      .toThrow(/catalog-authority-schema/);
+  });
+
+  it('rejects wrong object types and signed digest substitution', () => {
+    expect(() => assertUnsignedCatalogHeadTimelinessReceiptEnvelopeV1({
+      ...RECEIPT_UNSIGNED,
+      objectType: AUTHOR_CATALOG_ISSUER_DELEGATION_OBJECT_TYPE_V1,
+    })).toThrow(/catalog-authority-type/);
+    expect(() => assertSignedCatalogHeadTimelinessReceiptEnvelopeV1({
+      ...RECEIPT_SIGNED,
+      objectDigest: `0x${'00'.repeat(32)}`,
+    })).toThrow(/digest mismatch/i);
+  });
+});
+
+function validatedDelegation(value: unknown): AuthorCatalogIssuerDelegationV1 {
+  assertAuthorCatalogIssuerDelegationV1(value);
+  return value;
+}
+
+function validatedReceipt(value: unknown): CatalogHeadTimelinessReceiptV1 {
+  assertCatalogHeadTimelinessReceiptV1(value);
+  return value;
+}
+
+function unsigned(
+  objectType: string,
+  issuer: string,
+  payload: AuthorCatalogIssuerDelegationV1 | CatalogHeadTimelinessReceiptV1,
+): UnsignedControlEnvelopeV1 {
+  return {
+    issuer,
+    objectType,
+    payload,
+    signatureEvidence: { kind: 'none' },
+    signatureSuite: 'eip191-personal-sign-digest-v1',
+  } as UnsignedControlEnvelopeV1;
+}
+
+function signed(
+  envelope: UnsignedControlEnvelopeV1,
+  objectDigest: string,
+): SignedControlEnvelopeV1 {
+  return { ...envelope, objectDigest, signature: SIGNATURE } as SignedControlEnvelopeV1;
+}

--- a/packages/core/test/author-catalog-authority-objects.test.ts
+++ b/packages/core/test/author-catalog-authority-objects.test.ts
@@ -4,6 +4,7 @@ import {
   AUTHOR_CATALOG_ISSUER_DELEGATION_OBJECT_TYPE_V1,
   CATALOG_HEAD_TIMELINESS_RECEIPT_OBJECT_TYPE_V1,
   MAX_AUTHOR_CATALOG_AUTHORITY_PAYLOAD_BYTES_V1,
+  MAX_AUTHOR_CATALOG_AUTHORITY_PAYLOAD_DEPTH_V1,
   assertAuthorCatalogIssuerDelegationV1,
   assertCatalogHeadTimelinessReceiptV1,
   assertSignedAuthorCatalogIssuerDelegationEnvelopeV1,
@@ -31,6 +32,7 @@ import type {
   SignedControlEnvelopeV1,
   UnsignedControlEnvelopeV1,
 } from '../src/sync-control-object.js';
+import { computeControlObjectDigestHex } from '../src/sync-control-object.js';
 
 const AUTHOR = '0x3333333333333333333333333333333333333333';
 const ISSUER = '0x5555555555555555555555555555555555555555';
@@ -177,6 +179,16 @@ describe('AuthorCatalogIssuerDelegationV1 codec', () => {
       DELEGATION,
     ))).toThrow(/catalog-authority-authority/);
 
+    const redigestedWrongIssuer = unsigned(
+      AUTHOR_CATALOG_ISSUER_DELEGATION_OBJECT_TYPE_V1,
+      ISSUER,
+      DELEGATION,
+    );
+    expect(() => assertSignedAuthorCatalogIssuerDelegationEnvelopeV1(signed(
+      redigestedWrongIssuer,
+      computeControlObjectDigestHex(redigestedWrongIssuer),
+    ))).toThrow(/catalog-authority-authority/);
+
     // Conversely, the author cannot attach spurious delegated-authority evidence.
     expect(() => assertUnsignedAuthorCatalogIssuerDelegationEnvelopeV1(unsigned(
       AUTHOR_CATALOG_ISSUER_DELEGATION_OBJECT_TYPE_V1,
@@ -220,6 +232,41 @@ describe('AuthorCatalogIssuerDelegationV1 codec', () => {
     expect(() => assertAuthorCatalogIssuerDelegationV1(hostile))
       .toThrow(/catalog-authority-schema/);
     expect(getterCalls).toBe(0);
+  });
+
+  it('freezes the depth/byte caps and accepts structurally legal zero digests', () => {
+    expect(MAX_AUTHOR_CATALOG_AUTHORITY_PAYLOAD_DEPTH_V1).toBe(1);
+    expect(() => assertAuthorCatalogIssuerDelegationV1({
+      ...DELEGATION,
+      ownershipTransitionDigest: `0x${'00'.repeat(32)}`,
+      authorAuthorityEvidenceDigest: `0x${'00'.repeat(32)}`,
+    })).not.toThrow();
+
+    const exactCapUnknownPayload = `{"x":"${'a'.repeat(
+      MAX_AUTHOR_CATALOG_AUTHORITY_PAYLOAD_BYTES_V1 - 8,
+    )}"}`;
+    expect(new TextEncoder().encode(exactCapUnknownPayload)).toHaveLength(
+      MAX_AUTHOR_CATALOG_AUTHORITY_PAYLOAD_BYTES_V1,
+    );
+    expect(() => parseCanonicalAuthorCatalogIssuerDelegationPayloadV1(exactCapUnknownPayload))
+      .toThrow(/catalog-authority-schema/);
+
+    const capPlusOne = `{"x":"${'a'.repeat(
+      MAX_AUTHOR_CATALOG_AUTHORITY_PAYLOAD_BYTES_V1 - 7,
+    )}"}`;
+    expect(() => parseCanonicalAuthorCatalogIssuerDelegationPayloadV1(capPlusOne))
+      .toThrow(/payload-too-large/);
+    const multibyteOverCap = `{"x":"${'é'.repeat(
+      Math.ceil(MAX_AUTHOR_CATALOG_AUTHORITY_PAYLOAD_BYTES_V1 / 2),
+    )}"}`;
+    expect(multibyteOverCap.length).toBeLessThan(MAX_AUTHOR_CATALOG_AUTHORITY_PAYLOAD_BYTES_V1);
+    expect(() => parseCanonicalAuthorCatalogIssuerDelegationPayloadV1(multibyteOverCap))
+      .toThrow(/payload-too-large/);
+    expect(() => parseCanonicalAuthorCatalogIssuerDelegationPayloadV1(
+      new Uint8Array(MAX_AUTHOR_CATALOG_AUTHORITY_PAYLOAD_BYTES_V1 + 1),
+    )).toThrow(/payload-too-large/);
+    expect(() => parseCanonicalAuthorCatalogIssuerDelegationPayloadV1('{"x":{"y":{}}}'))
+      .toThrow(/nesting/i);
   });
 
   it('rejects wrong object types and signed digest substitution', () => {
@@ -278,6 +325,43 @@ describe('CatalogHeadTimelinessReceiptV1 codec', () => {
     expect(() => assertCatalogHeadTimelinessReceiptV1({ ...RECEIPT, catalogHeadDigest: '0x00' }))
       .toThrow(/catalog-authority-scalar/);
     expect(() => assertCatalogHeadTimelinessReceiptV1({ ...RECEIPT, retryAfter: null }))
+      .toThrow(/catalog-authority-schema/);
+    expect(() => assertCatalogHeadTimelinessReceiptV1({
+      ...RECEIPT,
+      ownershipTransitionDigest: `0x${'00'.repeat(32)}`,
+      checkpointAuthorityDelegationDigest: `0x${'00'.repeat(32)}`,
+      catalogIssuerDelegationDigest: `0x${'00'.repeat(32)}`,
+      catalogHeadDigest: `0x${'00'.repeat(32)}`,
+    })).not.toThrow();
+  });
+
+  it('rejects stateful receipt payloads and whole envelopes before reading accessors', () => {
+    let payloadGetterCalls = 0;
+    const hostileReceipt = { ...RECEIPT } as Record<string, unknown>;
+    Object.defineProperty(hostileReceipt, 'observedAt', {
+      enumerable: true,
+      get() {
+        payloadGetterCalls += 1;
+        return RECEIPT.observedAt;
+      },
+    });
+    expect(() => assertCatalogHeadTimelinessReceiptV1(hostileReceipt))
+      .toThrow(/catalog-authority-schema/);
+    expect(payloadGetterCalls).toBe(0);
+
+    let envelopeGetterCalls = 0;
+    const hostileEnvelope = { ...RECEIPT_UNSIGNED } as Record<string, unknown>;
+    Object.defineProperty(hostileEnvelope, 'issuer', {
+      enumerable: true,
+      get() {
+        envelopeGetterCalls += 1;
+        return CHECKPOINT;
+      },
+    });
+    expect(() => assertUnsignedCatalogHeadTimelinessReceiptEnvelopeV1(hostileEnvelope))
+      .toThrow();
+    expect(envelopeGetterCalls).toBe(0);
+    expect(() => assertCatalogHeadTimelinessReceiptV1(new Proxy({ ...RECEIPT }, {})))
       .toThrow(/catalog-authority-schema/);
   });
 


### PR DESCRIPTION
Implements the frozen RFC-64 author-catalog issuer delegation and catalog-head timeliness receipt wire objects. The codecs enforce exact schemas, governance scope, predecessor and time branches, canonical bytes and digests, stable snapshots, and the exact direct-author versus delegated-author issuer/evidence pairing; referenced authority resolution remains a runtime concern. Includes exact conformance vectors and negative authority-branch coverage.\n\nDepends on #1801.\n\nValidation: focused 9/9 tests, core build, and diff checks.