### PR TITLE
[RFC-64] Add crash-safe inventory SQL foundation

### DIFF
--- a/.github/workflows/rfc64-inventory-windows.yml
+++ b/.github/workflows/rfc64-inventory-windows.yml
@@ -1,0 +1,61 @@
+name: RFC-64 inventory Windows gate
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/rfc64-inventory-windows.yml'
+      - 'packages/agent/src/rfc64/inventory-v1/**'
+      - 'packages/agent/test/rfc64-inventory-v1-*.test.ts'
+      - 'packages/agent/test/fixtures/rfc64-inventory-v1-child.ts'
+      - 'packages/agent/vitest.unit.config.ts'
+      - 'packages/agent/package.json'
+      - 'packages/core/**'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+  workflow_dispatch:
+
+concurrency:
+  group: rfc64-inventory-windows-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  inventory-lifecycle:
+    name: SQLite lifecycle (Windows)
+    runs-on: windows-latest
+    timeout-minutes: 25
+    steps:
+      - name: Checkout candidate
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build agent dependency closure
+        run: pnpm --filter @origintrail-official/dkg-agent... run build
+
+      - name: Typecheck the lifecycle crash harness
+        run: >-
+          pnpm exec tsc --noEmit --target ES2022 --module NodeNext
+          --moduleResolution NodeNext --types node,vitest/globals --skipLibCheck
+          packages/agent/test/rfc64-inventory-v1-lifecycle.test.ts
+          packages/agent/test/fixtures/rfc64-inventory-v1-child.ts
+
+      - name: Run RFC-64 inventory tests
+        run: >-
+          pnpm --filter @origintrail-official/dkg-agent exec vitest run
+          --config vitest.unit.config.ts
+          test/rfc64-inventory-v1

--- a/packages/agent/src/rfc64/inventory-v1/index.ts
+++ b/packages/agent/src/rfc64/inventory-v1/index.ts
@@ -1,3 +1,13 @@
-export * from './open.js';
+export {
+  INVENTORY_V1_POSIX_QUARANTINE_CAPABILITY,
+  InventoryV1OpenError,
+  openInventoryV1,
+} from './open.js';
+export type {
+  InventoryV1OpenErrorCode,
+  InventoryV1OpenOptions,
+  InventoryV1QuarantineCapability,
+  Rfc64InventoryV1Foundation,
+} from './open.js';
 export * from './scalars.js';
 export * from './sql.js';

--- a/packages/agent/src/rfc64/inventory-v1/index.ts
+++ b/packages/agent/src/rfc64/inventory-v1/index.ts
@@ -1,0 +1,3 @@
+export * from './open.js';
+export * from './scalars.js';
+export * from './sql.js';

--- a/packages/agent/src/rfc64/inventory-v1/lifecycle-adapter.ts
+++ b/packages/agent/src/rfc64/inventory-v1/lifecycle-adapter.ts
@@ -1,0 +1,61 @@
+/**
+ * Internal lifecycle adapter for the RFC-64 SQL-A namespace protocol.
+ *
+ * Production callers receive a hook-free frozen adapter. Tests may construct
+ * a distinct frozen adapter per opener; there is deliberately no mutable
+ * process-global registry that shipped code could activate at runtime.
+ */
+
+export const INVENTORY_V1_POSIX_QUARANTINE_CAPABILITY =
+  'posix-atomic-rename-directory-fsync-v1' as const;
+
+export type InventoryV1QuarantineCapability =
+  typeof INVENTORY_V1_POSIX_QUARANTINE_CAPABILITY;
+
+export type InventoryV1QuarantineBoundary =
+  | 'target-exclusivity-proven'
+  | `begin.source.${'wal' | 'shm' | 'main'}.file-fsync`
+  | 'begin.inventory-directory.fsync-after-quarantine-root'
+  | 'begin.quarantine-root.fsync-after-generation'
+  | 'begin.marker.write'
+  | 'begin.marker.file-fsync'
+  | 'begin.inventory-directory.fsync-after-marker'
+  | `resume.prefix.${'wal' | 'shm' | 'main'}.file-fsync`
+  | `resume.prefix.${'wal' | 'shm' | 'main'}.generation-directory-fsync`
+  | `resume.prefix.${'wal' | 'shm' | 'main'}.inventory-directory-fsync`
+  | `resume.source.${'wal' | 'shm' | 'main'}.file-fsync-after-quiescence`
+  | `resume.member.${'wal' | 'shm' | 'main'}.rename`
+  | `resume.member.${'wal' | 'shm' | 'main'}.file-fsync`
+  | `resume.member.${'wal' | 'shm' | 'main'}.generation-directory-fsync`
+  | `resume.member.${'wal' | 'shm' | 'main'}.inventory-directory-fsync`
+  | 'resume.marker.unlink'
+  | 'resume.inventory-directory.fsync-after-marker-unlink';
+
+export type InventoryV1TargetCloseReason =
+  | 'automatic-schema-quarantine'
+  | 'automatic-corrupt-quarantine'
+  | 'failed-open-cleanup'
+  | 'foundation-close'
+  | 'explicit-quarantine'
+  | 'pending-quarantine-probe';
+
+export interface InventoryV1LifecycleAdapter {
+  readonly quarantineCapability: InventoryV1QuarantineCapability | null;
+  readonly boundary: (boundary: InventoryV1QuarantineBoundary) => void;
+  readonly closeTarget: (
+    close: () => void,
+    reason: InventoryV1TargetCloseReason,
+  ) => void;
+}
+
+export function createProductionInventoryV1LifecycleAdapter(
+  quarantineCapability: InventoryV1QuarantineCapability | null,
+): InventoryV1LifecycleAdapter {
+  return Object.freeze({
+    quarantineCapability,
+    boundary: (_boundary: InventoryV1QuarantineBoundary): void => {},
+    closeTarget: (close: () => void, _reason: InventoryV1TargetCloseReason): void => {
+      close();
+    },
+  });
+}

--- a/packages/agent/src/rfc64/inventory-v1/lifecycle-adapter.ts
+++ b/packages/agent/src/rfc64/inventory-v1/lifecycle-adapter.ts
@@ -14,20 +14,20 @@ export type InventoryV1QuarantineCapability =
 
 export type InventoryV1QuarantineBoundary =
   | 'target-exclusivity-proven'
-  | `begin.source.${'wal' | 'shm' | 'main'}.file-fsync`
+  | `begin.source.${'journal' | 'wal' | 'shm' | 'main'}.file-fsync`
   | 'begin.inventory-directory.fsync-after-quarantine-root'
   | 'begin.quarantine-root.fsync-after-generation'
   | 'begin.marker.write'
   | 'begin.marker.file-fsync'
   | 'begin.inventory-directory.fsync-after-marker'
-  | `resume.prefix.${'wal' | 'shm' | 'main'}.file-fsync`
-  | `resume.prefix.${'wal' | 'shm' | 'main'}.generation-directory-fsync`
-  | `resume.prefix.${'wal' | 'shm' | 'main'}.inventory-directory-fsync`
-  | `resume.source.${'wal' | 'shm' | 'main'}.file-fsync-after-quiescence`
-  | `resume.member.${'wal' | 'shm' | 'main'}.rename`
-  | `resume.member.${'wal' | 'shm' | 'main'}.file-fsync`
-  | `resume.member.${'wal' | 'shm' | 'main'}.generation-directory-fsync`
-  | `resume.member.${'wal' | 'shm' | 'main'}.inventory-directory-fsync`
+  | `resume.prefix.${'journal' | 'wal' | 'shm' | 'main'}.file-fsync`
+  | `resume.prefix.${'journal' | 'wal' | 'shm' | 'main'}.generation-directory-fsync`
+  | `resume.prefix.${'journal' | 'wal' | 'shm' | 'main'}.inventory-directory-fsync`
+  | `resume.source.${'journal' | 'wal' | 'shm' | 'main'}.file-fsync-after-quiescence`
+  | `resume.member.${'journal' | 'wal' | 'shm' | 'main'}.rename`
+  | `resume.member.${'journal' | 'wal' | 'shm' | 'main'}.file-fsync`
+  | `resume.member.${'journal' | 'wal' | 'shm' | 'main'}.generation-directory-fsync`
+  | `resume.member.${'journal' | 'wal' | 'shm' | 'main'}.inventory-directory-fsync`
   | 'resume.marker.unlink'
   | 'resume.inventory-directory.fsync-after-marker-unlink';
 

--- a/packages/agent/src/rfc64/inventory-v1/open.ts
+++ b/packages/agent/src/rfc64/inventory-v1/open.ts
@@ -2,11 +2,12 @@ import {
   chmodSync,
   closeSync,
   existsSync,
+  fstatSync,
   fsyncSync,
   lstatSync,
   mkdirSync,
   openSync,
-  readFileSync,
+  readdirSync,
   readSync,
   renameSync,
   statSync,
@@ -24,6 +25,8 @@ import {
 } from 'node:path';
 import { randomBytes } from 'node:crypto';
 import { spawnSync } from 'node:child_process';
+import { setTimeout as delay } from 'node:timers/promises';
+import { TextDecoder } from 'node:util';
 
 import {
   INVENTORY_V1_APPLICATION_ID,
@@ -35,6 +38,14 @@ import {
   INVENTORY_V1_USER_VERSION,
   normalizeInventoryV1SchemaSql,
 } from './sql.js';
+import {
+  createProductionInventoryV1LifecycleAdapter,
+  INVENTORY_V1_POSIX_QUARANTINE_CAPABILITY,
+  type InventoryV1LifecycleAdapter,
+  type InventoryV1QuarantineBoundary,
+  type InventoryV1QuarantineCapability,
+  type InventoryV1TargetCloseReason,
+} from './lifecycle-adapter.js';
 
 type SqliteModuleV1 = typeof import('node:sqlite');
 type DatabaseSyncV1 = InstanceType<SqliteModuleV1['DatabaseSync']>;
@@ -42,6 +53,13 @@ type DatabaseSyncV1 = InstanceType<SqliteModuleV1['DatabaseSync']>;
 const RECOVERY_MARKER_SUFFIX = '.rebuild-required';
 const QUARANTINE_DIRECTORY = 'quarantine';
 const OWNED_FILE_SUFFIXES = ['', '-wal', '-shm'] as const;
+const LEASE_DATABASE_NAME = 'inventory-v1.lease.sqlite3';
+const LEASE_FILE_SUFFIXES = ['', '-journal'] as const;
+const LEASE_APPLICATION_ID = 0x444b364c;
+const LEASE_USER_VERSION = 1;
+const LEASE_CREATION_RACE_TIMEOUT_MS = 1_000;
+const LEASE_CREATION_RACE_RETRY_MS = 10;
+const RECOVERY_MARKER_MAX_BYTES = 4_096;
 
 export type InventoryV1OpenErrorCode =
   | 'sqlite-unavailable'
@@ -51,6 +69,7 @@ export type InventoryV1OpenErrorCode =
   | 'unsafe-path'
   | 'pragma-mismatch'
   | 'database-busy'
+  | 'durability-unavailable'
   | 'database-closed'
   | 'database-io';
 
@@ -65,6 +84,21 @@ export class InventoryV1OpenError extends Error {
   }
 }
 
+class InventoryV1TargetCloseError extends InventoryV1OpenError {
+  constructor(
+    readonly target: DatabaseSyncV1,
+    readonly reason: InventoryV1TargetCloseReason,
+    cause: unknown,
+  ) {
+    super(
+      'database-io',
+      `failed to close the RFC-64 inventory target during ${reason}; the DK6L lease remains held in fail-stop`,
+      { cause },
+    );
+    this.name = 'InventoryV1TargetCloseError';
+  }
+}
+
 export interface Rfc64InventoryV1Foundation {
   readonly databasePath: string;
   readonly closed: boolean;
@@ -72,16 +106,130 @@ export interface Rfc64InventoryV1Foundation {
   close(): void;
 }
 
-export async function openInventoryV1(dataDir: string): Promise<Rfc64InventoryV1Foundation> {
+export interface InventoryV1OpenOptions {
+  /**
+   * Explicit deployment attestation for namespace quarantine. Omit this for
+   * the fail-closed default. Fresh and valid databases do not need it.
+   */
+  readonly quarantineCapability?: InventoryV1QuarantineCapability;
+}
+
+export { INVENTORY_V1_POSIX_QUARANTINE_CAPABILITY };
+export type { InventoryV1QuarantineCapability };
+
+export async function openInventoryV1(
+  dataDir: string,
+  options: InventoryV1OpenOptions = {},
+): Promise<Rfc64InventoryV1Foundation> {
+  return openInventoryV1WithLifecycleAdapter(
+    dataDir,
+    createProductionInventoryV1LifecycleAdapter(
+      options.quarantineCapability ?? null,
+    ),
+  );
+}
+
+/** @internal Source-test utility; not exported from the package entry point. */
+export interface InventoryV1TestOpenerIo {
+  readonly quarantineCapability?: InventoryV1QuarantineCapability | null;
+  readonly boundary?: (boundary: InventoryV1QuarantineBoundary) => void;
+  readonly closeTarget?: (
+    close: () => void,
+    reason: InventoryV1TargetCloseReason,
+  ) => void;
+}
+
+/** @internal Source-test utility; not exported from the package entry point. */
+export type InventoryV1TestOpener = (
+  dataDir: string,
+) => Promise<Rfc64InventoryV1Foundation>;
+
+/**
+ * Test-only lifecycle seam. This symbol is deliberately omitted from the
+ * package entry point; direct source tests must also remain in NODE_ENV=test
+ * for factory creation, every open, and every callback invocation.
+ * @internal
+ */
+export function createInventoryV1TestOpener(
+  io: InventoryV1TestOpenerIo = {},
+): InventoryV1TestOpener {
+  assertInventoryV1TestEnvironment();
+  const quarantineCapability = io.quarantineCapability ?? null;
+  const boundaryCallback = io.boundary;
+  const closeTargetCallback = io.closeTarget;
+  const lifecycle = Object.freeze({
+    get quarantineCapability(): InventoryV1QuarantineCapability | null {
+      return process.env.NODE_ENV === 'test'
+        ? quarantineCapability
+        : null;
+    },
+    boundary(boundary: InventoryV1QuarantineBoundary): void {
+      if (process.env.NODE_ENV === 'test') boundaryCallback?.(boundary);
+    },
+    closeTarget(close: () => void, reason: InventoryV1TargetCloseReason): void {
+      if (process.env.NODE_ENV === 'test' && closeTargetCallback !== undefined) {
+        closeTargetCallback(close, reason);
+        return;
+      }
+      close();
+    },
+  }) satisfies InventoryV1LifecycleAdapter;
+  return async (dataDir: string): Promise<Rfc64InventoryV1Foundation> => {
+    assertInventoryV1TestEnvironment();
+    return openInventoryV1WithLifecycleAdapter(dataDir, lifecycle);
+  };
+}
+
+function assertInventoryV1TestEnvironment(): void {
+  if (process.env.NODE_ENV !== 'test') {
+    throw new InventoryV1OpenError(
+      'database-io',
+      'RFC-64 inventory lifecycle test injection is unavailable outside NODE_ENV=test',
+    );
+  }
+}
+
+async function openInventoryV1WithLifecycleAdapter(
+  dataDir: string,
+  lifecycle: InventoryV1LifecycleAdapter,
+): Promise<Rfc64InventoryV1Foundation> {
+  if (!Object.isFrozen(lifecycle)) {
+    throw new InventoryV1OpenError(
+      'database-io',
+      'RFC-64 inventory lifecycle adapter must be immutable',
+    );
+  }
   const sqlite = await loadSqliteModule();
   const resolvedDataDir = resolve(dataDir);
   const databasePath = resolve(resolvedDataDir, INVENTORY_V1_RELATIVE_PATH);
+  let lease: InventoryV1Lease | null = null;
   try {
+    if (pathEntryExists(recoveryMarkerPath(databasePath))) {
+      preflightExistingRecoveryMarker(resolvedDataDir, databasePath);
+    }
     prepareSecureDirectory(resolvedDataDir, dirname(databasePath));
-    finishPendingQuarantine(databasePath);
-    const database = openOrRebuildOwnedDatabase(sqlite, databasePath);
-    return new InventoryV1Foundation(sqlite, databasePath, database);
+    rejectOrphanedSqliteSidecars(
+      inventoryLeasePath(databasePath),
+      'inventory lifetime lease',
+    );
+    // A pending recovery marker owns target-side evidence and must be parsed
+    // before classifying its source topology. Without such a marker, reject
+    // every orphan sidecar before creating even the independent lease unit so
+    // opening cannot mutate the directory around ambiguous evidence.
+    if (!pathEntryExists(recoveryMarkerPath(databasePath))) {
+      rejectOrphanedSqliteSidecars(databasePath, 'inventory database');
+    }
+    lease = await acquireInventoryLease(sqlite, databasePath);
+    finishPendingQuarantine(sqlite, databasePath, lifecycle);
+    const database = openOrRebuildOwnedDatabase(sqlite, databasePath, lifecycle);
+    return new InventoryV1Foundation(sqlite, databasePath, database, lease, lifecycle);
   } catch (cause) {
+    if (cause instanceof InventoryV1TargetCloseError && lease !== null) {
+      retainInventoryFailStop(lease, cause);
+      lease = null;
+      throw cause;
+    }
+    releaseInventoryLease(lease);
     if (cause instanceof InventoryV1OpenError) throw cause;
     throw new InventoryV1OpenError(
       'database-io',
@@ -93,13 +241,17 @@ export async function openInventoryV1(dataDir: string): Promise<Rfc64InventoryV1
 
 class InventoryV1Foundation implements Rfc64InventoryV1Foundation {
   #database: DatabaseSyncV1 | null;
+  #lease: InventoryV1Lease | null;
 
   constructor(
     private readonly sqlite: SqliteModuleV1,
     readonly databasePath: string,
     database: DatabaseSyncV1,
+    lease: InventoryV1Lease,
+    private readonly lifecycle: InventoryV1LifecycleAdapter,
   ) {
     this.#database = database;
+    this.#lease = lease;
   }
 
   get closed(): boolean {
@@ -108,14 +260,26 @@ class InventoryV1Foundation implements Rfc64InventoryV1Foundation {
 
   quarantineAndRebuild(): void {
     const database = this.requireOpen();
-    assertDatabaseQuiescent(database);
-    database.close();
+    assertQuarantineDurabilityAvailable(this.lifecycle);
+    assertDatabaseQuiescent(database, this.lifecycle);
+    try {
+      closeInventoryTarget(database, 'explicit-quarantine', this.lifecycle);
+    } catch (error) {
+      this.retainFailStop(error);
+    }
     this.#database = null;
     try {
-      beginQuarantine(this.databasePath);
-      finishPendingQuarantine(this.databasePath);
-      this.#database = openOrRebuildOwnedDatabase(this.sqlite, this.databasePath);
+      beginQuarantine(this.databasePath, this.lifecycle);
+      finishPendingQuarantine(this.sqlite, this.databasePath, this.lifecycle);
+      this.#database = openOrRebuildOwnedDatabase(
+        this.sqlite,
+        this.databasePath,
+        this.lifecycle,
+      );
     } catch (error) {
+      if (error instanceof InventoryV1TargetCloseError) this.retainFailStop(error);
+      this.releaseLease();
+      if (error instanceof InventoryV1OpenError) throw error;
       throw new InventoryV1OpenError(
         'database-io',
         'failed to quarantine and rebuild the RFC-64 inventory database',
@@ -125,8 +289,16 @@ class InventoryV1Foundation implements Rfc64InventoryV1Foundation {
   }
 
   close(): void {
-    this.#database?.close();
-    this.#database = null;
+    const database = this.#database;
+    if (database !== null) {
+      try {
+        closeInventoryTarget(database, 'foundation-close', this.lifecycle);
+      } catch (error) {
+        this.retainFailStop(error);
+      }
+      this.#database = null;
+    }
+    this.releaseLease();
   }
 
   private requireOpen(): DatabaseSyncV1 {
@@ -134,6 +306,20 @@ class InventoryV1Foundation implements Rfc64InventoryV1Foundation {
       throw new InventoryV1OpenError('database-closed', 'inventory database is closed');
     }
     return this.#database;
+  }
+
+  private releaseLease(): void {
+    releaseInventoryLease(this.#lease);
+    this.#lease = null;
+  }
+
+  private retainFailStop(error: unknown): never {
+    if (!(error instanceof InventoryV1TargetCloseError)) throw error;
+    if (this.#lease !== null) {
+      retainInventoryFailStop(this.#lease, error);
+      this.#lease = null;
+    }
+    throw error;
   }
 }
 
@@ -150,18 +336,302 @@ async function loadSqliteModule(): Promise<SqliteModuleV1> {
   }
 }
 
+interface InventoryV1Lease {
+  readonly database: DatabaseSyncV1;
+}
+
+interface InventoryV1FailStopResources {
+  readonly lease: InventoryV1Lease;
+  readonly targetCloseError: InventoryV1TargetCloseError;
+}
+
+// A target close failure is an in-process fail-stop. Keeping both handles
+// strongly reachable prevents GC from silently releasing either side of the
+// ownership pair and admitting a second conforming adapter after an ambiguous
+// target teardown.
+const RETAINED_INVENTORY_FAIL_STOPS = new Set<InventoryV1FailStopResources>();
+
+function retainInventoryFailStop(
+  lease: InventoryV1Lease,
+  targetCloseError: InventoryV1TargetCloseError,
+): void {
+  RETAINED_INVENTORY_FAIL_STOPS.add({ lease, targetCloseError });
+}
+
+function closeInventoryTarget(
+  target: DatabaseSyncV1,
+  reason: InventoryV1TargetCloseReason,
+  lifecycle: InventoryV1LifecycleAdapter,
+): void {
+  try {
+    lifecycle.closeTarget(() => target.close(), reason);
+  } catch (cause) {
+    if (cause instanceof InventoryV1TargetCloseError) throw cause;
+    throw new InventoryV1TargetCloseError(target, reason, cause);
+  }
+}
+
+function inventoryLeasePath(databasePath: string): string {
+  return join(dirname(databasePath), LEASE_DATABASE_NAME);
+}
+
+async function acquireInventoryLease(
+  sqlite: SqliteModuleV1,
+  databasePath: string,
+): Promise<InventoryV1Lease> {
+  const path = inventoryLeasePath(databasePath);
+  const existedAtEntry = pathEntryExists(path);
+  if (!existedAtEntry) {
+    rejectOrphanedSqliteSidecars(path, 'inventory lifetime lease');
+  }
+  let createdByThisOpen = false;
+  if (existedAtEntry) {
+    assertLeaseUnitOwnersAndTypes(path);
+    assertCommittedLeaseHeaderBeforeOpen(path);
+  } else {
+    try {
+      createSecureEmptyFile(path);
+      createdByThisOpen = true;
+    } catch (cause) {
+      if ((cause as NodeJS.ErrnoException).code !== 'EEXIST') throw cause;
+      // Only an opener that lost this exact wx race may briefly wait for the
+      // winner to publish a committed DK6L/v1 header. A lease that existed at
+      // entry never gets this grace period: headerless and zero/zero remnants
+      // fail closed for offline removal.
+      await waitForCommittedRacingLease(path);
+    }
+  }
+  applySecurePermissions(path, INVENTORY_V1_FILE_MODE, false);
+
+  let database: DatabaseSyncV1 | null = null;
+  let transactionOpen = false;
+  try {
+    database = new sqlite.DatabaseSync(path);
+    database.exec(`
+      PRAGMA busy_timeout = 0;
+      PRAGMA synchronous = FULL;
+      PRAGMA locking_mode = EXCLUSIVE;
+    `);
+    const journalMode = database.prepare(
+      createdByThisOpen ? 'PRAGMA journal_mode = DELETE' : 'PRAGMA journal_mode',
+    ).get();
+    if (
+      journalMode === undefined
+      || String(journalMode.journal_mode).toLowerCase() !== 'delete'
+    ) {
+      throw new InventoryV1OpenError(
+        'ambiguous-database',
+        'inventory lifetime lease must use SQLite rollback-journal mode',
+      );
+    }
+    database.exec('BEGIN EXCLUSIVE');
+    transactionOpen = true;
+    const identity = readIdentity(database);
+    if (createdByThisOpen) {
+      if (!isFreshIdentity(identity) || identity.userObjects.length !== 0) {
+        throw new InventoryV1OpenError(
+          'ambiguous-database',
+          'new inventory lease lost its pristine identity before initialization',
+        );
+      }
+      database.exec(`
+        PRAGMA application_id = ${LEASE_APPLICATION_ID};
+        PRAGMA user_version = ${LEASE_USER_VERSION};
+        COMMIT;
+        BEGIN EXCLUSIVE;
+      `);
+    } else {
+      assertLeaseIdentity(identity);
+    }
+    assertLeaseIdentity(readIdentity(database));
+    verifyLeasePragmas(database);
+    if (!database.isTransaction) {
+      throw new InventoryV1OpenError(
+        'database-io',
+        'inventory lifetime lease lost its exclusive transaction before publication',
+      );
+    }
+    tightenOwnedFileMode(path);
+    return { database };
+  } catch (cause) {
+    if (transactionOpen) {
+      try { database?.exec('ROLLBACK'); } catch { /* retain the lease acquisition failure */ }
+    }
+    try { database?.close(); } catch { /* retain the lease acquisition failure */ }
+    if (cause instanceof InventoryV1OpenError) throw cause;
+    if (isBusySqliteError(cause)) {
+      throw new InventoryV1OpenError(
+        'database-busy',
+        'another process holds the RFC-64 inventory lifetime lease',
+        { cause },
+      );
+    }
+    if (isCorruptSqliteError(cause)) {
+      const identity = readValidSqliteHeaderIdentity(path);
+      if (identity?.applicationId === LEASE_APPLICATION_ID && identity.userVersion > LEASE_USER_VERSION) {
+        throw new InventoryV1OpenError(
+          'newer-schema',
+          'corrupt inventory lease has a newer user_version and will not be modified',
+          { cause },
+        );
+      }
+      if (identity !== null && identity.applicationId !== 0 && identity.applicationId !== LEASE_APPLICATION_ID) {
+        throw new InventoryV1OpenError(
+          'foreign-database',
+          'corrupt inventory lease has a foreign application_id and will not be modified',
+          { cause },
+        );
+      }
+      throw new InventoryV1OpenError(
+        'ambiguous-database',
+        'corrupt inventory lifetime lease will not be modified or quarantined',
+        { cause },
+      );
+    }
+    throw new InventoryV1OpenError(
+      'database-io',
+      'failed to acquire the RFC-64 inventory lifetime lease',
+      { cause },
+    );
+  }
+}
+
+function assertLeaseUnitOwnersAndTypes(path: string): void {
+  for (const suffix of LEASE_FILE_SUFFIXES) {
+    const member = `${path}${suffix}`;
+    if (!pathEntryExists(member)) continue;
+    assertOwnedRegularFile(member, `inventory lifetime lease${suffix}`);
+  }
+  for (const suffix of ['-wal', '-shm'] as const) {
+    const member = `${path}${suffix}`;
+    if (!pathEntryExists(member)) continue;
+    assertOwnedRegularFile(member, `inventory lifetime lease${suffix}`);
+    throw new InventoryV1OpenError(
+      'ambiguous-database',
+      'inventory lifetime lease has unexpected WAL sidecars and will not be modified',
+    );
+  }
+}
+
+function assertCommittedLeaseHeaderBeforeOpen(path: string): void {
+  const identity = readValidSqliteHeaderIdentity(path);
+  if (identity === null) {
+    throw new InventoryV1OpenError(
+      'ambiguous-database',
+      'pre-existing headerless inventory lifetime lease will not be initialized or modified',
+    );
+  }
+  if (identity.applicationId !== LEASE_APPLICATION_ID) {
+    throw new InventoryV1OpenError(
+      identity.applicationId === 0 ? 'ambiguous-database' : 'foreign-database',
+      'inventory lifetime lease application_id is not the frozen DK6L identity',
+    );
+  }
+  if (identity.userVersion > LEASE_USER_VERSION) {
+    throw new InventoryV1OpenError(
+      'newer-schema',
+      'inventory lifetime lease user_version is newer than supported version 1',
+    );
+  }
+  if (identity.userVersion !== LEASE_USER_VERSION) {
+    throw new InventoryV1OpenError(
+      'ambiguous-database',
+      'inventory lifetime lease is not a committed v1 lease',
+    );
+  }
+}
+
+async function waitForCommittedRacingLease(path: string): Promise<void> {
+  const deadline = Date.now() + LEASE_CREATION_RACE_TIMEOUT_MS;
+  while (true) {
+    assertLeaseUnitOwnersAndTypes(path);
+    const identity = readValidSqliteHeaderIdentity(path);
+    if (
+      identity?.applicationId === LEASE_APPLICATION_ID
+      && identity.userVersion === LEASE_USER_VERSION
+    ) {
+      return;
+    }
+    if (
+      identity !== null
+      && (
+        identity.applicationId !== 0
+        || identity.userVersion !== 0
+      )
+    ) {
+      assertCommittedLeaseHeaderBeforeOpen(path);
+    }
+    if (Date.now() >= deadline) {
+      throw new InventoryV1OpenError(
+        'ambiguous-database',
+        'racing lease creator did not publish a committed DK6L/v1 identity',
+      );
+    }
+    await delay(LEASE_CREATION_RACE_RETRY_MS);
+  }
+}
+
+function assertLeaseIdentity(identity: DatabaseIdentityV1): void {
+  if (identity.applicationId !== LEASE_APPLICATION_ID) {
+    throw new InventoryV1OpenError(
+      identity.applicationId === 0 ? 'ambiguous-database' : 'foreign-database',
+      'inventory lifetime lease application_id is not the frozen DK6L identity',
+    );
+  }
+  if (identity.userVersion > LEASE_USER_VERSION) {
+    throw new InventoryV1OpenError(
+      'newer-schema',
+      'inventory lifetime lease user_version is newer than supported version 1',
+    );
+  }
+  if (identity.userVersion !== LEASE_USER_VERSION || identity.userObjects.length !== 0) {
+    throw new InventoryV1OpenError(
+      'ambiguous-database',
+      'inventory lifetime lease schema is not the frozen empty v1 schema',
+    );
+  }
+}
+
+function verifyLeasePragmas(database: DatabaseSyncV1): void {
+  const journalMode = database.prepare('PRAGMA journal_mode').get();
+  const lockingMode = database.prepare('PRAGMA locking_mode').get();
+  if (String(journalMode?.journal_mode).toLowerCase() !== 'delete') {
+    throw new InventoryV1OpenError('pragma-mismatch', 'inventory lease refused journal_mode=DELETE');
+  }
+  if (String(lockingMode?.locking_mode).toLowerCase() !== 'exclusive') {
+    throw new InventoryV1OpenError('pragma-mismatch', 'inventory lease refused locking_mode=EXCLUSIVE');
+  }
+  if (readPragmaInteger(database, 'synchronous') !== 2) {
+    throw new InventoryV1OpenError('pragma-mismatch', 'inventory lease refused synchronous=FULL');
+  }
+  if (readPragmaInteger(database, 'busy_timeout') !== 0) {
+    throw new InventoryV1OpenError('pragma-mismatch', 'inventory lease refused busy_timeout=0');
+  }
+}
+
+function releaseInventoryLease(lease: InventoryV1Lease | null): void {
+  if (lease === null) return;
+  try {
+    lease.database.exec('ROLLBACK');
+  } finally {
+    lease.database.close();
+  }
+}
+
 function openOrRebuildOwnedDatabase(
   sqlite: SqliteModuleV1,
   databasePath: string,
+  lifecycle: InventoryV1LifecycleAdapter,
 ): DatabaseSyncV1 {
   rejectOwnedFileSymlinks(databasePath);
-  rejectOrphanedSidecars(databasePath);
-  const existed = existsSync(databasePath);
-  if (existed) {
-    refuseValidForeignSqliteHeader(databasePath);
+  rejectOrphanedSqliteSidecars(databasePath, 'inventory database');
+  const created = !existsSync(databasePath);
+  if (created) {
+    createSecureEmptyFile(databasePath);
+  } else {
     assertOwnedUnitOwners(databasePath);
+    assertExistingTargetHeader(databasePath);
   }
-  if (!existed) createSecureEmptyFile(databasePath);
 
   let database: DatabaseSyncV1 | null = null;
   try {
@@ -169,85 +639,43 @@ function openOrRebuildOwnedDatabase(
     // extensions is disabled by default; every statement below is fixed SQL,
     // so double-quoted-string compatibility cannot affect parsing.
     database = new sqlite.DatabaseSync(databasePath);
-    database.exec(`
-      PRAGMA foreign_keys = ON;
-      PRAGMA trusted_schema = OFF;
-      PRAGMA busy_timeout = 5000;
-    `);
-    const identity = readIdentity(database);
 
-    if (isFreshIdentity(identity)) {
-      if (identity.userObjects.length !== 0) {
-        database.close();
-        database = null;
-        throw new InventoryV1OpenError(
-          'ambiguous-database',
-          'application_id=0/user_version=0 database contains user objects and will not be modified',
-        );
-      }
+    if (created) {
       tightenOwnedFileMode(databasePath);
-      applyAndVerifyPragmas(database);
-      initializeFreshDatabase(database);
+      initializeFreshDatabase(database, databasePath);
       verifyOwnedSchema(database);
+      applyAndVerifyPragmas(database);
       tightenOwnedFileMode(databasePath);
       return database;
     }
 
-    if (identity.applicationId !== INVENTORY_V1_APPLICATION_ID) {
-      database.close();
-      database = null;
-      throw new InventoryV1OpenError(
-        identity.applicationId === 0 ? 'ambiguous-database' : 'foreign-database',
-        'database application_id does not identify RFC-64 SQL-1 and will not be modified',
-      );
-    }
-    if (identity.userVersion < INVENTORY_V1_USER_VERSION) {
-      database.close();
-      database = null;
-      throw new InventoryV1OpenError(
-        'ambiguous-database',
-        `inventory application_id is DK64 but user_version ${identity.userVersion} is not a committed v1 database`,
-      );
-    }
-    if (identity.userVersion > INVENTORY_V1_USER_VERSION) {
-      database.close();
-      database = null;
-      throw new InventoryV1OpenError(
-        'newer-schema',
-        `inventory user_version ${identity.userVersion} is newer than supported version 1`,
-      );
-    }
-
-    tightenOwnedFileMode(databasePath);
-    if (identity.userVersion !== INVENTORY_V1_USER_VERSION || !schemaMatches(identity.userObjects)) {
-      assertDatabaseQuiescent(database);
-      database.close();
-      database = null;
-      beginQuarantine(databasePath);
-      finishPendingQuarantine(databasePath);
-      return openOrRebuildOwnedDatabase(sqlite, databasePath);
-    }
-
-    applyAndVerifyPragmas(database);
+    // Existing exact-owned targets receive identity, schema, and FK reads
+    // before any target PRAGMA assignment. This no-create classifier must not
+    // convert or "repair" a pre-existing unit merely by opening it.
+    const identity = readIdentity(database);
+    assertCommittedTargetIdentity(identity);
     try {
       verifyOwnedSchema(database);
     } catch (error) {
       if (!(error instanceof OwnedInventoryV1SchemaError)) throw error;
-      assertDatabaseQuiescent(database);
-      database.close();
+      assertDatabaseQuiescent(database, lifecycle);
+      closeInventoryTarget(database, 'automatic-schema-quarantine', lifecycle);
       database = null;
-      beginQuarantine(databasePath);
-      finishPendingQuarantine(databasePath);
-      return openOrRebuildOwnedDatabase(sqlite, databasePath);
+      assertQuarantineDurabilityAvailable(lifecycle);
+      beginQuarantine(databasePath, lifecycle);
+      finishPendingQuarantine(sqlite, databasePath, lifecycle);
+      return openOrRebuildOwnedDatabase(sqlite, databasePath, lifecycle);
     }
+    applyAndVerifyPragmas(database);
     tightenOwnedFileMode(databasePath);
     return database;
   } catch (error) {
     const closeProbe = (): void => {
       if (database === null) return;
-      try { database.close(); } catch { /* retain the original failure */ }
+      closeInventoryTarget(database, 'failed-open-cleanup', lifecycle);
       database = null;
     };
+    if (error instanceof InventoryV1TargetCloseError) throw error;
     if (error instanceof InventoryV1OpenError) {
       closeProbe();
       throw error;
@@ -292,7 +720,7 @@ function openOrRebuildOwnedDatabase(
         );
       }
       try {
-        assertCorruptDatabaseQuiescent(database);
+        assertCorruptDatabaseQuiescent(database, lifecycle);
       } catch (cause) {
         closeProbe();
         if (cause instanceof InventoryV1OpenError) throw cause;
@@ -302,20 +730,15 @@ function openOrRebuildOwnedDatabase(
           { cause },
         );
       }
-      try {
-        database.close();
-      } catch (cause) {
-        database = null;
-        throw new InventoryV1OpenError(
-          'database-io',
-          'failed to close the corrupt DK64 database after proving quiescence; it will not be quarantined',
-          { cause },
-        );
-      }
+      closeInventoryTarget(database, 'automatic-corrupt-quarantine', lifecycle);
       database = null;
-      beginQuarantine(databasePath);
-      finishPendingQuarantine(databasePath);
-      return openOrRebuildOwnedDatabase(sqlite, databasePath);
+      // The corrupt target handle is deliberately closed before this platform
+      // gate can reject quarantine. The caller may release DK6L only after that
+      // target close has succeeded.
+      assertQuarantineDurabilityAvailable(lifecycle);
+      beginQuarantine(databasePath, lifecycle);
+      finishPendingQuarantine(sqlite, databasePath, lifecycle);
+      return openOrRebuildOwnedDatabase(sqlite, databasePath, lifecycle);
     }
     closeProbe();
     if (isBusySqliteError(error)) {
@@ -327,8 +750,48 @@ function openOrRebuildOwnedDatabase(
     }
     throw new InventoryV1OpenError(
       'database-io',
-      existed ? 'failed to open RFC-64 inventory database' : 'failed to initialize RFC-64 inventory database',
+      created ? 'failed to initialize RFC-64 inventory database' : 'failed to open RFC-64 inventory database',
       { cause: error },
+    );
+  }
+}
+
+function assertExistingTargetHeader(databasePath: string): void {
+  const identity = readValidSqliteHeaderIdentity(databasePath);
+  if (identity === null || identity.applicationId === 0) {
+    throw new InventoryV1OpenError(
+      'ambiguous-database',
+      'pre-existing inventory database lacks the committed DK64 identity and will not be opened',
+    );
+  }
+  if (identity.applicationId !== INVENTORY_V1_APPLICATION_ID) {
+    throw new InventoryV1OpenError(
+      'foreign-database',
+      'database header has a foreign application_id and will not be opened or modified',
+    );
+  }
+  if (identity.userVersion > INVENTORY_V1_USER_VERSION) {
+    throw new InventoryV1OpenError(
+      'newer-schema',
+      `inventory user_version ${identity.userVersion} is newer than supported version 1`,
+    );
+  }
+  if (identity.userVersion !== INVENTORY_V1_USER_VERSION) {
+    throw new InventoryV1OpenError(
+      'ambiguous-database',
+      `inventory application_id is DK64 but user_version ${identity.userVersion} is not committed v1`,
+    );
+  }
+}
+
+function assertCommittedTargetIdentity(identity: DatabaseIdentityV1): void {
+  if (
+    identity.applicationId !== INVENTORY_V1_APPLICATION_ID
+    || identity.userVersion !== INVENTORY_V1_USER_VERSION
+  ) {
+    throw new InventoryV1OpenError(
+      'ambiguous-database',
+      'inventory identity changed after the no-create header preflight',
     );
   }
 }
@@ -366,16 +829,62 @@ function schemaMatches(objects: DatabaseIdentityV1['userObjects']): boolean {
   });
 }
 
-function initializeFreshDatabase(database: DatabaseSyncV1): void {
-  database.exec('BEGIN IMMEDIATE');
+function initializeFreshDatabase(database: DatabaseSyncV1, databasePath: string): void {
+  const journalMode = database.prepare('PRAGMA journal_mode = DELETE').get();
+  database.exec(`
+    PRAGMA synchronous = FULL;
+    PRAGMA busy_timeout = 5000;
+  `);
+  if (String(journalMode?.journal_mode).toLowerCase() !== 'delete') {
+    throw new InventoryV1OpenError(
+      'pragma-mismatch',
+      'new inventory database refused rollback-journal bootstrap mode',
+    );
+  }
+  if (readPragmaInteger(database, 'synchronous') !== 2) {
+    throw new InventoryV1OpenError('pragma-mismatch', 'new inventory database refused synchronous=FULL');
+  }
+  if (readPragmaInteger(database, 'busy_timeout') !== 5000) {
+    throw new InventoryV1OpenError('pragma-mismatch', 'new inventory database refused busy_timeout=5000');
+  }
+
+  let transactionOpen = false;
   try {
+    database.exec('BEGIN IMMEDIATE');
+    transactionOpen = true;
+    const identity = readIdentity(database);
+    if (!isFreshIdentity(identity) || identity.userObjects.length !== 0) {
+      throw new InventoryV1OpenError(
+        'ambiguous-database',
+        'new inventory file lost its pristine identity before initialization',
+      );
+    }
     database.exec(INVENTORY_V1_DDL);
     database.exec(`PRAGMA application_id = ${INVENTORY_V1_APPLICATION_ID}`);
     database.exec(`PRAGMA user_version = ${INVENTORY_V1_USER_VERSION}`);
     database.exec('COMMIT');
+    transactionOpen = false;
   } catch (error) {
-    try { database.exec('ROLLBACK'); } catch { /* retain the initialization error */ }
+    if (transactionOpen) {
+      try { database.exec('ROLLBACK'); } catch { /* retain the initialization error */ }
+    }
     throw error;
+  }
+
+  // Publish the committed DK64/v1 identity through the rollback-journal main
+  // file before WAL is ever enabled. A crash therefore cannot leave a valid
+  // identity that is visible only through an uncheckpointed WAL.
+  fsyncRegularFile(databasePath, 'new inventory database');
+  fsyncDirectory(dirname(databasePath));
+  const committed = readValidSqliteHeaderIdentity(databasePath);
+  if (
+    committed?.applicationId !== INVENTORY_V1_APPLICATION_ID
+    || committed.userVersion !== INVENTORY_V1_USER_VERSION
+  ) {
+    throw new InventoryV1OpenError(
+      'database-io',
+      'committed inventory database identity was not durable in the raw main header',
+    );
   }
 }
 
@@ -401,7 +910,10 @@ function verifyOwnedSchema(database: DatabaseSyncV1): void {
   }
 }
 
-function assertDatabaseQuiescent(database: DatabaseSyncV1): void {
+function assertDatabaseQuiescent(
+  database: DatabaseSyncV1,
+  lifecycle: InventoryV1LifecycleAdapter,
+): void {
   let transactionOpen = false;
   try {
     database.exec('PRAGMA busy_timeout = 0');
@@ -419,6 +931,10 @@ function assertDatabaseQuiescent(database: DatabaseSyncV1): void {
     transactionOpen = true;
     database.exec('ROLLBACK');
     transactionOpen = false;
+    // A conforming contender must still be fenced by the independently held
+    // DK6L lease in the interval after this target proof releases its target
+    // lock and before quarantine namespace mutation starts.
+    lifecycle.boundary('target-exclusivity-proven');
   } catch (cause) {
     if (transactionOpen) {
       try { database.exec('ROLLBACK'); } catch { /* retain the quiescence failure */ }
@@ -441,7 +957,10 @@ function assertDatabaseQuiescent(database: DatabaseSyncV1): void {
   }
 }
 
-function assertCorruptDatabaseQuiescent(database: DatabaseSyncV1): void {
+function assertCorruptDatabaseQuiescent(
+  database: DatabaseSyncV1,
+  lifecycle: InventoryV1LifecycleAdapter,
+): void {
   let transactionOpen = false;
   try {
     // Probe the writer lock before corruption-sensitive schema/checkpoint work
@@ -471,7 +990,7 @@ function assertCorruptDatabaseQuiescent(database: DatabaseSyncV1): void {
   } finally {
     try { database.exec('PRAGMA busy_timeout = 5000'); } catch { /* best-effort connection restore */ }
   }
-  assertDatabaseQuiescent(database);
+  assertDatabaseQuiescent(database, lifecycle);
 }
 
 function applyAndVerifyPragmas(database: DatabaseSyncV1): void {
@@ -549,6 +1068,41 @@ function prepareSecureDirectory(dataDirectory: string, directoryPath: string): v
     currentDirectory = nextDirectory;
   }
   applySecurePermissions(directoryPath, INVENTORY_V1_DIRECTORY_MODE, true);
+}
+
+function preflightExistingRecoveryMarker(
+  dataDirectory: string,
+  databasePath: string,
+): void {
+  const inventoryDirectory = dirname(databasePath);
+  const relativeDirectory = relative(dataDirectory, inventoryDirectory);
+  if (
+    relativeDirectory === '..'
+    || relativeDirectory.startsWith(`..${sep}`)
+    || isAbsolute(relativeDirectory)
+  ) {
+    throw new InventoryV1OpenError(
+      'unsafe-path',
+      'inventory recovery marker is outside the declared DKG data directory',
+    );
+  }
+
+  assertOwnedDirectory(dataDirectory, 'DKG data directory');
+  let currentDirectory = dataDirectory;
+  for (const component of relativeDirectory.split(sep).filter((value) => value.length !== 0)) {
+    currentDirectory = join(currentDirectory, component);
+    assertOwnedDirectory(currentDirectory, 'inventory directory path component');
+  }
+
+  const markerPath = recoveryMarkerPath(databasePath);
+  assertOwnedRegularFile(markerPath, 'inventory recovery marker');
+  // Parse before chmod, lease creation, SQLite open, lifecycle boundaries, or
+  // any recovery namespace mutation. The marker is parsed again under DK6L in
+  // finishPendingQuarantine to close the read/lock TOCTOU window.
+  parseRecoveryMarker(
+    readBoundedRecoveryMarker(markerPath),
+    inventoryDirectory,
+  );
 }
 
 function createSecureEmptyFile(databasePath: string): void {
@@ -695,12 +1249,13 @@ function rejectOwnedFileSymlinks(databasePath: string): void {
   }
 }
 
-function rejectOrphanedSidecars(databasePath: string): void {
-  if (existsSync(databasePath)) return;
-  if (pathEntryExists(`${databasePath}-wal`) || pathEntryExists(`${databasePath}-shm`)) {
+function rejectOrphanedSqliteSidecars(mainPath: string, label: string): void {
+  if (pathEntryExists(mainPath)) return;
+  for (const suffix of ['-journal', '-wal', '-shm'] as const) {
+    if (!pathEntryExists(`${mainPath}${suffix}`)) continue;
     throw new InventoryV1OpenError(
       'ambiguous-database',
-      'orphaned inventory sidecars exist without a database and will not be modified',
+      `orphaned ${label} sidecars exist without a main database and will not be modified`,
     );
   }
 }
@@ -708,6 +1263,53 @@ function rejectOrphanedSidecars(databasePath: string): void {
 function rejectSymlink(path: string, label: string): void {
   if (lstatSync(path).isSymbolicLink()) {
     throw new InventoryV1OpenError('unsafe-path', `${label} must not be a symbolic link`);
+  }
+}
+
+function assertOwnedRegularFile(path: string, label: string): void {
+  rejectSymlink(path, label);
+  if (!lstatSync(path).isFile()) {
+    throw new InventoryV1OpenError('unsafe-path', `${label} must be a regular file`);
+  }
+  assertFilesystemOwner(path);
+}
+
+function assertOwnedDirectory(path: string, label: string): void {
+  rejectSymlink(path, label);
+  if (!lstatSync(path).isDirectory()) {
+    throw new InventoryV1OpenError('unsafe-path', `${label} must be a directory`);
+  }
+  assertFilesystemOwner(path);
+}
+
+function assertSameFilesystem(path: string, directoryPath: string, label: string): void {
+  try {
+    if (statSync(path).dev !== statSync(directoryPath).dev) {
+      throw new InventoryV1OpenError(
+        'unsafe-path',
+        `${label} is not on the quarantine generation filesystem`,
+      );
+    }
+  } catch (cause) {
+    if (cause instanceof InventoryV1OpenError) throw cause;
+    throw new InventoryV1OpenError(
+      'database-io',
+      `failed to verify same-filesystem recovery for ${label}`,
+      { cause },
+    );
+  }
+}
+
+function fsyncRegularFile(path: string, label: string): void {
+  assertOwnedRegularFile(path, label);
+  let descriptor: number | undefined;
+  try {
+    descriptor = openSync(path, 'r');
+    fsyncSync(descriptor);
+  } catch (cause) {
+    throw new InventoryV1OpenError('database-io', `failed to fsync ${label}`, { cause });
+  } finally {
+    if (descriptor !== undefined) closeSync(descriptor);
   }
 }
 
@@ -721,77 +1323,432 @@ function pathEntryExists(path: string): boolean {
   }
 }
 
+type RecoveryMemberV1 = 'wal' | 'shm' | 'main';
+type RecoveryMembersV1 =
+  | readonly ['main']
+  | readonly ['wal', 'main']
+  | readonly ['shm', 'main']
+  | readonly ['wal', 'shm', 'main'];
+
+const ALL_RECOVERY_MEMBERS = ['wal', 'shm', 'main'] as const satisfies readonly RecoveryMemberV1[];
+const RECOVERY_MEMBER_ARRAYS = new Set([
+  '["main"]',
+  '["wal","main"]',
+  '["shm","main"]',
+  '["wal","shm","main"]',
+]);
+
 interface RecoveryMarkerV1 {
-  version: 1;
-  quarantineDirectory: string;
+  readonly version: 1;
+  readonly quarantineDirectory: string;
+  readonly members: RecoveryMembersV1;
 }
 
-function beginQuarantine(databasePath: string): void {
+type RecoveryMemberLocationV1 = 'source' | 'destination';
+
+interface RecoveryTopologyV1 {
+  readonly locations: ReadonlyMap<RecoveryMemberV1, RecoveryMemberLocationV1>;
+  readonly movedCount: number;
+}
+
+function assertQuarantineDurabilityAvailable(
+  lifecycle: InventoryV1LifecycleAdapter,
+): void {
+  if (
+    process.platform === 'win32'
+    || lifecycle.quarantineCapability
+      !== INVENTORY_V1_POSIX_QUARANTINE_CAPABILITY
+  ) {
+    throw new InventoryV1OpenError(
+      'durability-unavailable',
+      'RFC-64 inventory quarantine requires the explicit certified POSIX namespace capability',
+    );
+  }
+}
+
+function beginQuarantine(
+  databasePath: string,
+  lifecycle: InventoryV1LifecycleAdapter,
+): void {
+  assertQuarantineDurabilityAvailable(lifecycle);
   const markerPath = recoveryMarkerPath(databasePath);
   if (pathEntryExists(markerPath)) {
     rejectSymlink(markerPath, 'inventory recovery marker');
     return;
   }
-  const inventoryDirectory = dirname(databasePath);
-  const quarantineRoot = join(inventoryDirectory, QUARANTINE_DIRECTORY);
-  if (pathEntryExists(quarantineRoot)) rejectSymlink(quarantineRoot, 'inventory quarantine directory');
-  mkdirSync(quarantineRoot, { recursive: true, mode: INVENTORY_V1_DIRECTORY_MODE });
-  rejectSymlink(quarantineRoot, 'inventory quarantine directory');
-  applySecurePermissions(quarantineRoot, INVENTORY_V1_DIRECTORY_MODE, true);
-  fsyncDirectory(inventoryDirectory);
-  const suffix = `${Date.now()}-${randomBytes(8).toString('hex')}`;
-  const quarantineDirectory = join(quarantineRoot, `inventory-v1-${suffix}`);
-  mkdirSync(quarantineDirectory, { mode: INVENTORY_V1_DIRECTORY_MODE });
-  rejectSymlink(quarantineDirectory, 'inventory quarantine generation');
-  applySecurePermissions(quarantineDirectory, INVENTORY_V1_DIRECTORY_MODE, true);
-  fsyncDirectory(quarantineRoot);
-  const marker: RecoveryMarkerV1 = { version: 1, quarantineDirectory };
-  writeFileSync(markerPath, JSON.stringify(marker), { encoding: 'utf8', flag: 'wx', mode: INVENTORY_V1_FILE_MODE });
-  applySecurePermissions(markerPath, INVENTORY_V1_FILE_MODE, false);
-  const descriptor = openSync(markerPath, 'r');
-  try { fsyncSync(descriptor); } finally { closeSync(descriptor); }
-  fsyncDirectory(inventoryDirectory);
-}
+  const members = inspectSourceMembersForNewMarker(databasePath);
+  for (const member of members) {
+    fsyncRegularFile(recoverySourcePath(databasePath, member), `inventory ${member} evidence`);
+    lifecycle.boundary(`begin.source.${member}.file-fsync`);
+  }
 
-function finishPendingQuarantine(databasePath: string): void {
-  const markerPath = recoveryMarkerPath(databasePath);
-  if (!pathEntryExists(markerPath)) return;
-  rejectSymlink(markerPath, 'inventory recovery marker');
-  assertFilesystemOwner(markerPath);
   const inventoryDirectory = dirname(databasePath);
   const quarantineRoot = join(inventoryDirectory, QUARANTINE_DIRECTORY);
   if (pathEntryExists(quarantineRoot)) {
-    rejectSymlink(quarantineRoot, 'inventory quarantine directory');
-    assertFilesystemOwner(quarantineRoot);
+    assertOwnedDirectory(quarantineRoot, 'inventory quarantine directory');
+  } else {
+    mkdirSync(quarantineRoot, { mode: INVENTORY_V1_DIRECTORY_MODE });
   }
-  const marker = parseRecoveryMarker(readFileSync(markerPath, 'utf8'), inventoryDirectory);
-  mkdirSync(marker.quarantineDirectory, { recursive: true, mode: INVENTORY_V1_DIRECTORY_MODE });
-  rejectSymlink(quarantineRoot, 'inventory quarantine directory');
+  assertOwnedDirectory(quarantineRoot, 'inventory quarantine directory');
   applySecurePermissions(quarantineRoot, INVENTORY_V1_DIRECTORY_MODE, true);
-  rejectSymlink(marker.quarantineDirectory, 'inventory quarantine generation');
-  assertFilesystemOwner(marker.quarantineDirectory);
-  applySecurePermissions(marker.quarantineDirectory, INVENTORY_V1_DIRECTORY_MODE, true);
-  // Make both levels of the quarantine destination durable before evidence is
-  // moved under the recovery marker.
   fsyncDirectory(inventoryDirectory);
-  fsyncDirectory(quarantineRoot);
-  for (const suffix of OWNED_FILE_SUFFIXES) {
-    const source = `${databasePath}${suffix}`;
-    if (!pathEntryExists(source)) continue;
-    rejectSymlink(source, `inventory database${suffix}`);
-    assertFilesystemOwner(source);
-    const target = join(marker.quarantineDirectory, `inventory-v1.sqlite3${suffix}`);
-    if (pathEntryExists(target)) {
-      throw new InventoryV1OpenError('database-io', `quarantine target already exists: ${target}`);
+  lifecycle.boundary('begin.inventory-directory.fsync-after-quarantine-root');
+  const suffix = `${Date.now()}-${randomBytes(8).toString('hex')}`;
+  const quarantineDirectory = join(quarantineRoot, `inventory-v1-${suffix}`);
+  mkdirSync(quarantineDirectory, { mode: INVENTORY_V1_DIRECTORY_MODE });
+  assertOwnedDirectory(quarantineDirectory, 'inventory quarantine generation');
+  applySecurePermissions(quarantineDirectory, INVENTORY_V1_DIRECTORY_MODE, true);
+  assertSameFilesystem(inventoryDirectory, quarantineDirectory, 'inventory quarantine generation');
+  for (const member of members) {
+    const source = recoverySourcePath(databasePath, member);
+    assertOwnedRegularFile(source, `inventory ${member} evidence`);
+    assertSameFilesystem(source, quarantineDirectory, `inventory ${member} evidence`);
+    const destination = recoveryDestinationPath(quarantineDirectory, member);
+    if (pathEntryExists(destination)) {
+      throw new InventoryV1OpenError(
+        'database-io',
+        `new quarantine generation already contains ${member} evidence`,
+      );
     }
-    renameSync(source, target);
   }
-  // Persist destination names and source removals before deleting the marker.
-  // A crash before either fsync leaves the durable marker to resume safely.
-  fsyncDirectory(marker.quarantineDirectory);
+  fsyncDirectory(quarantineRoot);
+  lifecycle.boundary('begin.quarantine-root.fsync-after-generation');
+  const marker: RecoveryMarkerV1 = { version: 1, quarantineDirectory, members };
+  writeFileSync(markerPath, JSON.stringify(marker), { encoding: 'utf8', flag: 'wx', mode: INVENTORY_V1_FILE_MODE });
+  lifecycle.boundary('begin.marker.write');
+  applySecurePermissions(markerPath, INVENTORY_V1_FILE_MODE, false);
+  fsyncRegularFile(markerPath, 'inventory recovery marker');
+  lifecycle.boundary('begin.marker.file-fsync');
   fsyncDirectory(inventoryDirectory);
+  lifecycle.boundary('begin.inventory-directory.fsync-after-marker');
+}
+
+function finishPendingQuarantine(
+  sqlite: SqliteModuleV1,
+  databasePath: string,
+  lifecycle: InventoryV1LifecycleAdapter,
+): void {
+  const markerPath = recoveryMarkerPath(databasePath);
+  if (!pathEntryExists(markerPath)) return;
+  // This check precedes marker parsing, directory creation, permission changes,
+  // SQLite probes, and evidence moves. Unsupported platforms leave the whole
+  // pending unit byte-for-byte untouched for an offline operator procedure.
+  assertQuarantineDurabilityAvailable(lifecycle);
+  assertOwnedRegularFile(markerPath, 'inventory recovery marker');
+  const inventoryDirectory = dirname(databasePath);
+  const quarantineRoot = join(inventoryDirectory, QUARANTINE_DIRECTORY);
+  if (!pathEntryExists(quarantineRoot)) {
+    throw new InventoryV1OpenError(
+      'database-io',
+      'pending inventory recovery marker names a missing quarantine root',
+    );
+  }
+  assertOwnedDirectory(quarantineRoot, 'inventory quarantine directory');
+  const marker = parseRecoveryMarker(
+    readBoundedRecoveryMarker(markerPath),
+    inventoryDirectory,
+  );
+  if (!pathEntryExists(marker.quarantineDirectory)) {
+    throw new InventoryV1OpenError(
+      'database-io',
+      'pending inventory recovery marker names a missing quarantine generation',
+    );
+  }
+  assertOwnedDirectory(marker.quarantineDirectory, 'inventory quarantine generation');
+  assertSameFilesystem(inventoryDirectory, marker.quarantineDirectory, 'inventory quarantine generation');
+
+  let topology = inspectRecoveryTopology(marker, databasePath);
+  // A crash may have occurred after rename but before that move's file or
+  // directory barriers. Re-establish durability for the observed moved prefix
+  // before either continuing or deleting the marker.
+  fsyncMovedRecoveryPrefix(marker, topology, inventoryDirectory, lifecycle);
+  if (topology.movedCount === 0) {
+    // Only a complete source unit may be reopened. Once even one member has
+    // moved, SQLite must never see the partial source topology.
+    assertPendingUnitQuiescent(sqlite, databasePath, lifecycle);
+    topology = inspectRecoveryTopology(marker, databasePath);
+    if (topology.movedCount !== 0) {
+      throw new InventoryV1OpenError(
+        'database-io',
+        'inventory recovery topology changed while re-proving source quiescence',
+      );
+    }
+    // The re-probe may checkpoint or perform ordinary exact-owned recovery.
+    // Re-fsync the complete manifest after closing that handle so the pending
+    // marker never vouches for bytes dirtied by the restart proof.
+    for (const member of marker.members) {
+      fsyncRegularFile(recoverySourcePath(databasePath, member), `inventory ${member} evidence`);
+      lifecycle.boundary(`resume.source.${member}.file-fsync-after-quiescence`);
+    }
+  }
+
+  for (const member of marker.members) {
+    if (topology.locations.get(member) === 'destination') continue;
+    const source = recoverySourcePath(databasePath, member);
+    const destination = recoveryDestinationPath(marker.quarantineDirectory, member);
+    assertOwnedRegularFile(source, `inventory ${member} evidence`);
+    assertSameFilesystem(source, marker.quarantineDirectory, `inventory ${member} evidence`);
+    renameNoOverwriteUnderLease(source, destination);
+    lifecycle.boundary(`resume.member.${member}.rename`);
+    fsyncRegularFile(destination, `moved inventory ${member} evidence`);
+    lifecycle.boundary(`resume.member.${member}.file-fsync`);
+    fsyncDirectory(marker.quarantineDirectory);
+    lifecycle.boundary(`resume.member.${member}.generation-directory-fsync`);
+    fsyncDirectory(inventoryDirectory);
+    lifecycle.boundary(`resume.member.${member}.inventory-directory-fsync`);
+  }
+
+  topology = inspectRecoveryTopology(marker, databasePath);
+  if (topology.movedCount !== marker.members.length) {
+    throw new InventoryV1OpenError(
+      'database-io',
+      'inventory recovery did not durably move every manifest member',
+    );
+  }
   unlinkSync(markerPath);
+  lifecycle.boundary('resume.marker.unlink');
   fsyncDirectory(inventoryDirectory);
+  lifecycle.boundary('resume.inventory-directory.fsync-after-marker-unlink');
+}
+
+function fsyncMovedRecoveryPrefix(
+  marker: RecoveryMarkerV1,
+  topology: RecoveryTopologyV1,
+  inventoryDirectory: string,
+  lifecycle: InventoryV1LifecycleAdapter,
+): void {
+  for (const member of marker.members) {
+    if (topology.locations.get(member) !== 'destination') break;
+    fsyncRegularFile(
+      recoveryDestinationPath(marker.quarantineDirectory, member),
+      `moved inventory ${member} evidence`,
+    );
+    lifecycle.boundary(`resume.prefix.${member}.file-fsync`);
+    fsyncDirectory(marker.quarantineDirectory);
+    lifecycle.boundary(`resume.prefix.${member}.generation-directory-fsync`);
+    fsyncDirectory(inventoryDirectory);
+    lifecycle.boundary(`resume.prefix.${member}.inventory-directory-fsync`);
+  }
+}
+
+function inspectSourceMembersForNewMarker(databasePath: string): RecoveryMembersV1 {
+  const present: RecoveryMemberV1[] = [];
+  for (const member of ALL_RECOVERY_MEMBERS) {
+    const source = recoverySourcePath(databasePath, member);
+    if (!pathEntryExists(source)) continue;
+    assertOwnedRegularFile(source, `inventory ${member} evidence`);
+    present.push(member);
+  }
+  return assertRecoveryMembers(present);
+}
+
+function inspectRecoveryTopology(
+  marker: RecoveryMarkerV1,
+  databasePath: string,
+): RecoveryTopologyV1 {
+  const listed = new Set<RecoveryMemberV1>(marker.members);
+  const knownDestinationNames = new Set(
+    ALL_RECOVERY_MEMBERS.map((member) => basename(recoveryDestinationPath(marker.quarantineDirectory, member))),
+  );
+  for (const name of readdirSync(marker.quarantineDirectory)) {
+    if (!knownDestinationNames.has(name)) {
+      throw new InventoryV1OpenError(
+        'database-io',
+        `quarantine generation contains an unknown entry: ${name}`,
+      );
+    }
+  }
+
+  const locations = new Map<RecoveryMemberV1, RecoveryMemberLocationV1>();
+  for (const member of ALL_RECOVERY_MEMBERS) {
+    const source = recoverySourcePath(databasePath, member);
+    const destination = recoveryDestinationPath(marker.quarantineDirectory, member);
+    const sourceExists = pathEntryExists(source);
+    const destinationExists = pathEntryExists(destination);
+    if (!listed.has(member)) {
+      if (sourceExists || destinationExists) {
+        throw new InventoryV1OpenError(
+          'database-io',
+          `unlisted inventory recovery member exists: ${member}`,
+        );
+      }
+      continue;
+    }
+    if (sourceExists === destinationExists) {
+      throw new InventoryV1OpenError(
+        'database-io',
+        sourceExists
+          ? `inventory recovery member exists at both source and destination: ${member}`
+          : `inventory recovery member is missing from both source and destination: ${member}`,
+      );
+    }
+    const path = sourceExists ? source : destination;
+    assertOwnedRegularFile(path, `inventory ${member} recovery member`);
+    assertSameFilesystem(path, marker.quarantineDirectory, `inventory ${member} recovery member`);
+    locations.set(member, sourceExists ? 'source' : 'destination');
+  }
+
+  let movedCount = 0;
+  let sawSource = false;
+  for (const member of marker.members) {
+    const location = locations.get(member);
+    if (location === 'source') {
+      sawSource = true;
+    } else {
+      if (sawSource) {
+        throw new InventoryV1OpenError(
+          'database-io',
+          'inventory recovery members are not in a prefix-moved topology',
+        );
+      }
+      movedCount += 1;
+    }
+  }
+  return { locations, movedCount };
+}
+
+function recoverySourcePath(databasePath: string, member: RecoveryMemberV1): string {
+  if (member === 'main') return databasePath;
+  return `${databasePath}-${member}`;
+}
+
+function recoveryDestinationPath(
+  quarantineDirectory: string,
+  member: RecoveryMemberV1,
+): string {
+  return join(
+    quarantineDirectory,
+    member === 'main' ? 'inventory-v1.sqlite3' : `inventory-v1.sqlite3-${member}`,
+  );
+}
+
+function renameNoOverwriteUnderLease(source: string, destination: string): void {
+  // Node 22.5 exposes no renameat2/RENAME_NOREPLACE binding. Under the frozen
+  // dedicated-directory plus all-conforming-adapter invariant, the DK6L lease
+  // excludes every permitted namespace writer between this check and rename.
+  // A deployment with any nonconforming path writer must disable quarantine.
+  if (pathEntryExists(destination)) {
+    throw new InventoryV1OpenError(
+      'database-io',
+      `quarantine destination already exists: ${destination}`,
+    );
+  }
+  renameSync(source, destination);
+}
+
+function assertPendingUnitQuiescent(
+  sqlite: SqliteModuleV1,
+  databasePath: string,
+  lifecycle: InventoryV1LifecycleAdapter,
+): void {
+  if (!pathEntryExists(databasePath)) {
+    throw new InventoryV1OpenError(
+      'database-io',
+      'pending quarantine has no complete source main and will not create a database',
+    );
+  }
+  rejectOwnedFileSymlinks(databasePath);
+  assertOwnedUnitOwners(databasePath);
+  let database: DatabaseSyncV1 | null = null;
+  try {
+    database = new sqlite.DatabaseSync(databasePath);
+    database.exec('PRAGMA busy_timeout = 0');
+    assertCorruptDatabaseQuiescent(database, lifecycle);
+  } catch (cause) {
+    if (cause instanceof InventoryV1OpenError) throw cause;
+    if (isBusySqliteError(cause)) {
+      throw new InventoryV1OpenError(
+        'database-busy',
+        'pending inventory quarantine still has an active SQLite holder',
+        { cause },
+      );
+    }
+    throw new InventoryV1OpenError(
+      'database-io',
+      'cannot re-prove exclusive access before resuming inventory quarantine',
+      { cause },
+    );
+  } finally {
+    if (database !== null) {
+      closeInventoryTarget(database, 'pending-quarantine-probe', lifecycle);
+    }
+  }
+}
+
+function readBoundedRecoveryMarker(markerPath: string): string {
+  let descriptor: number | undefined;
+  let bytes: Buffer;
+  try {
+    descriptor = openSync(markerPath, 'r');
+    const descriptorStat = fstatSync(descriptor);
+    const pathStat = lstatSync(markerPath);
+    if (
+      !descriptorStat.isFile()
+      || !pathStat.isFile()
+      || descriptorStat.dev !== pathStat.dev
+      || descriptorStat.ino !== pathStat.ino
+    ) {
+      throw new InventoryV1OpenError(
+        'database-io',
+        'inventory recovery marker changed before it was read',
+      );
+    }
+    if (descriptorStat.size > RECOVERY_MARKER_MAX_BYTES) {
+      throw new InventoryV1OpenError(
+        'database-io',
+        `inventory recovery marker exceeds ${RECOVERY_MARKER_MAX_BYTES} bytes`,
+      );
+    }
+    const boundedBuffer = Buffer.allocUnsafe(RECOVERY_MARKER_MAX_BYTES + 1);
+    const bytesRead = readSync(
+      descriptor,
+      boundedBuffer,
+      0,
+      boundedBuffer.byteLength,
+      0,
+    );
+    const finalStat = fstatSync(descriptor);
+    if (
+      bytesRead > RECOVERY_MARKER_MAX_BYTES
+      || bytesRead !== descriptorStat.size
+      || finalStat.size !== descriptorStat.size
+      || finalStat.mtimeMs !== descriptorStat.mtimeMs
+    ) {
+      throw new InventoryV1OpenError(
+        'database-io',
+        'inventory recovery marker changed while it was read',
+      );
+    }
+    bytes = boundedBuffer.subarray(0, bytesRead);
+  } catch (cause) {
+    if (cause instanceof InventoryV1OpenError) throw cause;
+    throw new InventoryV1OpenError(
+      'database-io',
+      'inventory recovery marker could not be read safely',
+      { cause },
+    );
+  } finally {
+    if (descriptor !== undefined) closeSync(descriptor);
+  }
+  if (
+    (bytes[0] === 0xef && bytes[1] === 0xbb && bytes[2] === 0xbf)
+    || (bytes[0] === 0xff && bytes[1] === 0xfe)
+    || (bytes[0] === 0xfe && bytes[1] === 0xff)
+  ) {
+    throw new InventoryV1OpenError(
+      'database-io',
+      'inventory recovery marker must not contain a Unicode byte-order mark',
+    );
+  }
+  try {
+    return new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+  } catch (cause) {
+    throw new InventoryV1OpenError(
+      'database-io',
+      'inventory recovery marker is not valid UTF-8',
+      { cause },
+    );
+  }
 }
 
 function parseRecoveryMarker(value: string, inventoryDirectory: string): RecoveryMarkerV1 {
@@ -802,24 +1759,76 @@ function parseRecoveryMarker(value: string, inventoryDirectory: string): Recover
   if (
     typeof parsed !== 'object'
     || parsed === null
+    || Array.isArray(parsed)
+    || Object.keys(parsed).length !== 3
+    || !['members', 'quarantineDirectory', 'version'].every((key) => Object.hasOwn(parsed, key))
     || (parsed as { version?: unknown }).version !== 1
     || typeof (parsed as { quarantineDirectory?: unknown }).quarantineDirectory !== 'string'
+    || !Array.isArray((parsed as { members?: unknown }).members)
   ) {
     throw new InventoryV1OpenError('database-io', 'inventory recovery marker has an invalid shape');
   }
-  const quarantineDirectory = resolve((parsed as RecoveryMarkerV1).quarantineDirectory);
-  const quarantineRoot = resolve(inventoryDirectory, QUARANTINE_DIRECTORY);
-  const relativePath = relative(quarantineRoot, quarantineDirectory);
-  if (
-    relativePath.length === 0
-    || relativePath.startsWith('..')
-    || isAbsolute(relativePath)
-    || basename(relativePath) !== relativePath
-    || !/^inventory-v1-[0-9]+-[0-9a-f]{16}$/.test(relativePath)
-  ) {
-    throw new InventoryV1OpenError('unsafe-path', 'inventory recovery marker escapes the quarantine directory');
+  const members = assertRecoveryMembers((parsed as { members: unknown[] }).members);
+  const encodedDirectory = (parsed as RecoveryMarkerV1).quarantineDirectory;
+  if (hasLoneUtf16Surrogate(encodedDirectory)) {
+    throw new InventoryV1OpenError(
+      'database-io',
+      'inventory recovery marker path contains an unpaired UTF-16 surrogate',
+    );
   }
-  return { version: 1, quarantineDirectory };
+  const serializedMarker = JSON.stringify({
+    version: 1,
+    quarantineDirectory: encodedDirectory,
+    members,
+  });
+  if (serializedMarker !== value) {
+    // Markers are private crash-recovery state emitted only by beginQuarantine.
+    // Requiring its exact local encoding rejects duplicate textual JSON keys,
+    // alternate key order, insignificant whitespace, and escape aliases that
+    // JSON.parse alone would otherwise collapse before shape validation.
+    throw new InventoryV1OpenError(
+      'database-io',
+      'inventory recovery marker is not in the frozen local serialization',
+    );
+  }
+  const quarantineRoot = join(inventoryDirectory, QUARANTINE_DIRECTORY);
+  const generationName = basename(encodedDirectory);
+  const canonicalDirectory = join(quarantineRoot, generationName);
+  if (
+    !isAbsolute(encodedDirectory)
+    || encodedDirectory !== canonicalDirectory
+    || !/^inventory-v1-[0-9]+-[0-9a-f]{16}$/.test(generationName)
+  ) {
+    throw new InventoryV1OpenError(
+      'unsafe-path',
+      'inventory recovery marker path is not the exact canonical quarantine generation path',
+    );
+  }
+  return { version: 1, quarantineDirectory: canonicalDirectory, members };
+}
+
+function hasLoneUtf16Surrogate(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (next < 0xdc00 || next > 0xdfff) return true;
+      index += 1;
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function assertRecoveryMembers(value: readonly unknown[]): RecoveryMembersV1 {
+  if (!RECOVERY_MEMBER_ARRAYS.has(JSON.stringify(value))) {
+    throw new InventoryV1OpenError(
+      'database-io',
+      'inventory recovery marker has an invalid or reordered members manifest',
+    );
+  }
+  return [...value] as unknown as RecoveryMembersV1;
 }
 
 function recoveryMarkerPath(databasePath: string): string {
@@ -851,20 +1860,6 @@ function classifyCorruptDatabaseOwnership(databasePath: string): CorruptDatabase
   if (identity.applicationId !== INVENTORY_V1_APPLICATION_ID) return 'foreign';
   if (identity.userVersion > INVENTORY_V1_USER_VERSION) return 'newer';
   return identity.userVersion === INVENTORY_V1_USER_VERSION ? 'owned' : 'ambiguous';
-}
-
-function refuseValidForeignSqliteHeader(databasePath: string): void {
-  const identity = readValidSqliteHeaderIdentity(databasePath);
-  if (
-    identity !== null
-    && identity.applicationId !== 0
-    && identity.applicationId !== INVENTORY_V1_APPLICATION_ID
-  ) {
-    throw new InventoryV1OpenError(
-      'foreign-database',
-      'database header has a foreign application_id and will not be opened or modified',
-    );
-  }
 }
 
 function readValidSqliteHeaderIdentity(databasePath: string): SqliteHeaderIdentityV1 | null {

--- a/packages/agent/src/rfc64/inventory-v1/open.ts
+++ b/packages/agent/src/rfc64/inventory-v1/open.ts
@@ -13,7 +13,15 @@ import {
   unlinkSync,
   writeFileSync,
 } from 'node:fs';
-import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path';
+import {
+  basename,
+  dirname,
+  isAbsolute,
+  join,
+  relative,
+  resolve,
+  sep,
+} from 'node:path';
 import { randomBytes } from 'node:crypto';
 import { spawnSync } from 'node:child_process';
 
@@ -66,9 +74,10 @@ export interface Rfc64InventoryV1Foundation {
 
 export async function openInventoryV1(dataDir: string): Promise<Rfc64InventoryV1Foundation> {
   const sqlite = await loadSqliteModule();
-  const databasePath = resolve(dataDir, INVENTORY_V1_RELATIVE_PATH);
+  const resolvedDataDir = resolve(dataDir);
+  const databasePath = resolve(resolvedDataDir, INVENTORY_V1_RELATIVE_PATH);
   try {
-    prepareSecureDirectory(dirname(databasePath));
+    prepareSecureDirectory(resolvedDataDir, dirname(databasePath));
     finishPendingQuarantine(databasePath);
     const database = openOrRebuildOwnedDatabase(sqlite, databasePath);
     return new InventoryV1Foundation(sqlite, databasePath, database);
@@ -192,6 +201,14 @@ function openOrRebuildOwnedDatabase(
         'database application_id does not identify RFC-64 SQL-1 and will not be modified',
       );
     }
+    if (identity.userVersion < INVENTORY_V1_USER_VERSION) {
+      database.close();
+      database = null;
+      throw new InventoryV1OpenError(
+        'ambiguous-database',
+        `inventory application_id is DK64 but user_version ${identity.userVersion} is not a committed v1 database`,
+      );
+    }
     if (identity.userVersion > INVENTORY_V1_USER_VERSION) {
       database.close();
       database = null;
@@ -226,23 +243,81 @@ function openOrRebuildOwnedDatabase(
     tightenOwnedFileMode(databasePath);
     return database;
   } catch (error) {
-    if (database !== null) {
+    const closeProbe = (): void => {
+      if (database === null) return;
       try { database.close(); } catch { /* retain the original failure */ }
+      database = null;
+    };
+    if (error instanceof InventoryV1OpenError) {
+      closeProbe();
+      throw error;
     }
-    if (error instanceof InventoryV1OpenError) throw error;
     if (isCorruptSqliteError(error)) {
-      const ownership = classifyCorruptDatabaseOwnership(databasePath);
-      if (ownership === 'owned') {
-        beginQuarantine(databasePath);
-        finishPendingQuarantine(databasePath);
-        return openOrRebuildOwnedDatabase(sqlite, databasePath);
+      let ownership: CorruptDatabaseOwnershipV1;
+      try {
+        ownership = classifyCorruptDatabaseOwnership(databasePath);
+      } catch (cause) {
+        closeProbe();
+        throw cause;
       }
-      throw new InventoryV1OpenError(
-        'foreign-database',
-        'corrupt SQLite database has a foreign application_id and will not be modified',
-        { cause: error },
-      );
+      if (ownership === 'ambiguous') {
+        closeProbe();
+        throw new InventoryV1OpenError(
+          'ambiguous-database',
+          'corrupt database does not have a readable DK64 ownership identity and will not be modified',
+          { cause: error },
+        );
+      }
+      if (ownership === 'newer') {
+        closeProbe();
+        throw new InventoryV1OpenError(
+          'newer-schema',
+          'corrupt DK64 database has a newer user_version and will not be modified',
+          { cause: error },
+        );
+      }
+      if (ownership === 'foreign') {
+        closeProbe();
+        throw new InventoryV1OpenError(
+          'foreign-database',
+          'corrupt SQLite database has a foreign application_id and will not be modified',
+          { cause: error },
+        );
+      }
+      if (database === null) {
+        throw new InventoryV1OpenError(
+          'database-io',
+          'cannot prove exclusive access to the corrupt DK64 database; it will not be quarantined',
+          { cause: error },
+        );
+      }
+      try {
+        assertCorruptDatabaseQuiescent(database);
+      } catch (cause) {
+        closeProbe();
+        if (cause instanceof InventoryV1OpenError) throw cause;
+        throw new InventoryV1OpenError(
+          'database-io',
+          'cannot prove exclusive access to the corrupt DK64 database; it will not be quarantined',
+          { cause },
+        );
+      }
+      try {
+        database.close();
+      } catch (cause) {
+        database = null;
+        throw new InventoryV1OpenError(
+          'database-io',
+          'failed to close the corrupt DK64 database after proving quiescence; it will not be quarantined',
+          { cause },
+        );
+      }
+      database = null;
+      beginQuarantine(databasePath);
+      finishPendingQuarantine(databasePath);
+      return openOrRebuildOwnedDatabase(sqlite, databasePath);
     }
+    closeProbe();
     if (isBusySqliteError(error)) {
       throw new InventoryV1OpenError(
         'database-busy',
@@ -366,6 +441,39 @@ function assertDatabaseQuiescent(database: DatabaseSyncV1): void {
   }
 }
 
+function assertCorruptDatabaseQuiescent(database: DatabaseSyncV1): void {
+  let transactionOpen = false;
+  try {
+    // Probe the writer lock before corruption-sensitive schema/checkpoint work
+    // so a live WAL writer is reported as busy and is never split from the
+    // database file during quarantine.
+    database.exec('PRAGMA busy_timeout = 0');
+    database.exec('BEGIN EXCLUSIVE');
+    transactionOpen = true;
+    database.exec('ROLLBACK');
+    transactionOpen = false;
+  } catch (cause) {
+    if (transactionOpen) {
+      try { database.exec('ROLLBACK'); } catch { /* retain the probe failure */ }
+    }
+    if (isBusySqliteError(cause)) {
+      throw new InventoryV1OpenError(
+        'database-busy',
+        'corrupt inventory database has an active writer and will not be quarantined',
+        { cause },
+      );
+    }
+    throw new InventoryV1OpenError(
+      'database-io',
+      'cannot prove exclusive access to the corrupt inventory database; it will not be quarantined',
+      { cause },
+    );
+  } finally {
+    try { database.exec('PRAGMA busy_timeout = 5000'); } catch { /* best-effort connection restore */ }
+  }
+  assertDatabaseQuiescent(database);
+}
+
 function applyAndVerifyPragmas(database: DatabaseSyncV1): void {
   database.exec(`
     PRAGMA foreign_keys = ON;
@@ -402,10 +510,44 @@ function readPragmaInteger(database: DatabaseSyncV1, pragma: string): number {
   return value;
 }
 
-function prepareSecureDirectory(directoryPath: string): void {
-  if (pathEntryExists(directoryPath)) rejectSymlink(directoryPath, 'inventory directory');
-  mkdirSync(directoryPath, { recursive: true, mode: INVENTORY_V1_DIRECTORY_MODE });
-  rejectSymlink(directoryPath, 'inventory directory');
+function prepareSecureDirectory(dataDirectory: string, directoryPath: string): void {
+  const relativeDirectory = relative(dataDirectory, directoryPath);
+  if (
+    relativeDirectory === '..'
+    || relativeDirectory.startsWith(`..${sep}`)
+    || isAbsolute(relativeDirectory)
+  ) {
+    throw new InventoryV1OpenError(
+      'unsafe-path',
+      'inventory database directory must remain within the declared DKG data directory',
+    );
+  }
+
+  if (pathEntryExists(dataDirectory)) {
+    rejectSymlink(dataDirectory, 'DKG data directory');
+    assertFilesystemOwner(dataDirectory);
+  } else {
+    // The declared data-directory boundary may itself be new. Components above
+    // that caller-selected boundary are intentionally outside adapter policy.
+    mkdirSync(dataDirectory, { recursive: true, mode: INVENTORY_V1_DIRECTORY_MODE });
+    rejectSymlink(dataDirectory, 'DKG data directory');
+    assertFilesystemOwner(dataDirectory);
+  }
+
+  let currentDirectory = dataDirectory;
+  for (const component of relativeDirectory.split(sep).filter((value) => value.length !== 0)) {
+    // The current parent was owner-checked before this content mutation.
+    const nextDirectory = join(currentDirectory, component);
+    if (pathEntryExists(nextDirectory)) {
+      rejectSymlink(nextDirectory, 'inventory directory path component');
+      assertFilesystemOwner(nextDirectory);
+    } else {
+      mkdirSync(nextDirectory, { mode: INVENTORY_V1_DIRECTORY_MODE });
+      rejectSymlink(nextDirectory, 'inventory directory path component');
+      assertFilesystemOwner(nextDirectory);
+    }
+    currentDirectory = nextDirectory;
+  }
   applySecurePermissions(directoryPath, INVENTORY_V1_DIRECTORY_MODE, true);
 }
 
@@ -467,6 +609,10 @@ function assertOwnedUnitOwners(databasePath: string): void {
 }
 
 function applySecurePermissions(path: string, mode: number, directory: boolean): void {
+  // Never let chmod or Set-Acl turn a foreign existing entry into an owned one.
+  // Newly created entries are also checked because they must already be owned
+  // by this process before their permissions are tightened.
+  assertFilesystemOwner(path);
   if (process.platform === 'win32') {
     applyWindowsOwnerOnlyAcl(path, directory);
     return;
@@ -586,22 +732,25 @@ function beginQuarantine(databasePath: string): void {
     rejectSymlink(markerPath, 'inventory recovery marker');
     return;
   }
-  const quarantineRoot = join(dirname(databasePath), QUARANTINE_DIRECTORY);
+  const inventoryDirectory = dirname(databasePath);
+  const quarantineRoot = join(inventoryDirectory, QUARANTINE_DIRECTORY);
   if (pathEntryExists(quarantineRoot)) rejectSymlink(quarantineRoot, 'inventory quarantine directory');
   mkdirSync(quarantineRoot, { recursive: true, mode: INVENTORY_V1_DIRECTORY_MODE });
   rejectSymlink(quarantineRoot, 'inventory quarantine directory');
   applySecurePermissions(quarantineRoot, INVENTORY_V1_DIRECTORY_MODE, true);
+  fsyncDirectory(inventoryDirectory);
   const suffix = `${Date.now()}-${randomBytes(8).toString('hex')}`;
   const quarantineDirectory = join(quarantineRoot, `inventory-v1-${suffix}`);
   mkdirSync(quarantineDirectory, { mode: INVENTORY_V1_DIRECTORY_MODE });
   rejectSymlink(quarantineDirectory, 'inventory quarantine generation');
   applySecurePermissions(quarantineDirectory, INVENTORY_V1_DIRECTORY_MODE, true);
+  fsyncDirectory(quarantineRoot);
   const marker: RecoveryMarkerV1 = { version: 1, quarantineDirectory };
   writeFileSync(markerPath, JSON.stringify(marker), { encoding: 'utf8', flag: 'wx', mode: INVENTORY_V1_FILE_MODE });
   applySecurePermissions(markerPath, INVENTORY_V1_FILE_MODE, false);
   const descriptor = openSync(markerPath, 'r');
   try { fsyncSync(descriptor); } finally { closeSync(descriptor); }
-  fsyncDirectory(dirname(databasePath));
+  fsyncDirectory(inventoryDirectory);
 }
 
 function finishPendingQuarantine(databasePath: string): void {
@@ -622,6 +771,10 @@ function finishPendingQuarantine(databasePath: string): void {
   rejectSymlink(marker.quarantineDirectory, 'inventory quarantine generation');
   assertFilesystemOwner(marker.quarantineDirectory);
   applySecurePermissions(marker.quarantineDirectory, INVENTORY_V1_DIRECTORY_MODE, true);
+  // Make both levels of the quarantine destination durable before evidence is
+  // moved under the recovery marker.
+  fsyncDirectory(inventoryDirectory);
+  fsyncDirectory(quarantineRoot);
   for (const suffix of OWNED_FILE_SUFFIXES) {
     const source = `${databasePath}${suffix}`;
     if (!pathEntryExists(source)) continue;
@@ -633,9 +786,12 @@ function finishPendingQuarantine(databasePath: string): void {
     }
     renameSync(source, target);
   }
+  // Persist destination names and source removals before deleting the marker.
+  // A crash before either fsync leaves the durable marker to resume safely.
   fsyncDirectory(marker.quarantineDirectory);
+  fsyncDirectory(inventoryDirectory);
   unlinkSync(markerPath);
-  fsyncDirectory(dirname(databasePath));
+  fsyncDirectory(inventoryDirectory);
 }
 
 function parseRecoveryMarker(value: string, inventoryDirectory: string): RecoveryMarkerV1 {
@@ -682,22 +838,27 @@ function isBusySqliteError(error: unknown): boolean {
   return errcode === 5 || errcode === 6;
 }
 
-type CorruptDatabaseOwnershipV1 = 'owned' | 'foreign';
+type CorruptDatabaseOwnershipV1 = 'owned' | 'ambiguous' | 'foreign' | 'newer';
+
+interface SqliteHeaderIdentityV1 {
+  applicationId: number;
+  userVersion: number;
+}
 
 function classifyCorruptDatabaseOwnership(databasePath: string): CorruptDatabaseOwnershipV1 {
-  const applicationId = readValidSqliteHeaderApplicationId(databasePath);
-  if (applicationId === null || applicationId === INVENTORY_V1_APPLICATION_ID || applicationId === 0) {
-    return 'owned';
-  }
-  return 'foreign';
+  const identity = readValidSqliteHeaderIdentity(databasePath);
+  if (identity === null || identity.applicationId === 0) return 'ambiguous';
+  if (identity.applicationId !== INVENTORY_V1_APPLICATION_ID) return 'foreign';
+  if (identity.userVersion > INVENTORY_V1_USER_VERSION) return 'newer';
+  return identity.userVersion === INVENTORY_V1_USER_VERSION ? 'owned' : 'ambiguous';
 }
 
 function refuseValidForeignSqliteHeader(databasePath: string): void {
-  const applicationId = readValidSqliteHeaderApplicationId(databasePath);
+  const identity = readValidSqliteHeaderIdentity(databasePath);
   if (
-    applicationId !== null
-    && applicationId !== 0
-    && applicationId !== INVENTORY_V1_APPLICATION_ID
+    identity !== null
+    && identity.applicationId !== 0
+    && identity.applicationId !== INVENTORY_V1_APPLICATION_ID
   ) {
     throw new InventoryV1OpenError(
       'foreign-database',
@@ -706,7 +867,7 @@ function refuseValidForeignSqliteHeader(databasePath: string): void {
   }
 }
 
-function readValidSqliteHeaderApplicationId(databasePath: string): number | null {
+function readValidSqliteHeaderIdentity(databasePath: string): SqliteHeaderIdentityV1 | null {
   let descriptor: number | undefined;
   try {
     descriptor = openSync(databasePath, 'r');
@@ -715,7 +876,10 @@ function readValidSqliteHeaderApplicationId(databasePath: string): number | null
     if (bytesRead < header.byteLength || header.subarray(0, 16).toString('binary') !== 'SQLite format 3\u0000') {
       return null;
     }
-    return header.readUInt32BE(68);
+    return {
+      applicationId: header.readUInt32BE(68),
+      userVersion: header.readUInt32BE(60),
+    };
   } catch (cause) {
     throw new InventoryV1OpenError(
       'database-io',

--- a/packages/agent/src/rfc64/inventory-v1/open.ts
+++ b/packages/agent/src/rfc64/inventory-v1/open.ts
@@ -1127,7 +1127,14 @@ function assertFilesystemOwner(path: string): void {
   if (process.platform === 'win32') {
     const script = String.raw`
 $ErrorActionPreference = 'Stop'
-$sid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User
+$identity = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+$userSid = $identity.User
+$defaultOwnerSid = $identity.Owner
+$administratorsSid = [System.Security.Principal.SecurityIdentifier]::new(
+  [System.Security.Principal.WellKnownSidType]::BuiltinAdministratorsSid,
+  $null
+)
+$principal = [System.Security.Principal.WindowsPrincipal]::new($identity)
 $target = [System.IO.Path]::GetFullPath($env:DKG_RFC64_ACL_PATH)
 $acl = if ([System.IO.Directory]::Exists($target)) {
   [System.IO.Directory]::GetAccessControl(
@@ -1141,7 +1148,26 @@ $acl = if ([System.IO.Directory]::Exists($target)) {
   )
 }
 $owner = $acl.GetOwner([System.Security.Principal.SecurityIdentifier])
-if ($owner.Value -ne $sid.Value) { exit 40 }
+# An elevated Windows token may create entries with its distinct default-owner
+# SID (normally BUILTIN\Administrators) even though the process account SID is
+# the user. GitHub-hosted and service runners may also pre-create the caller's
+# temp root with BUILTIN\Administrators as owner while the active token is an
+# administrator. Accept that one exact well-known group only when it is active
+# in this token; arbitrary token groups are deliberately not accepted.
+$isActiveAdministratorsOwner = (
+  $owner.Value -eq $administratorsSid.Value -and
+  $principal.IsInRole($administratorsSid)
+)
+if (
+  $owner.Value -ne $userSid.Value -and
+  $owner.Value -ne $defaultOwnerSid.Value -and
+  -not $isActiveAdministratorsOwner
+) {
+  [Console]::Error.WriteLine(
+    "owner SID $($owner.Value) is neither token user $($userSid.Value) nor token default owner $($defaultOwnerSid.Value)"
+  )
+  exit 40
+}
 `;
     const result = spawnSync(
       'powershell.exe',

--- a/packages/agent/src/rfc64/inventory-v1/open.ts
+++ b/packages/agent/src/rfc64/inventory-v1/open.ts
@@ -52,7 +52,7 @@ type DatabaseSyncV1 = InstanceType<SqliteModuleV1['DatabaseSync']>;
 
 const RECOVERY_MARKER_SUFFIX = '.rebuild-required';
 const QUARANTINE_DIRECTORY = 'quarantine';
-const OWNED_FILE_SUFFIXES = ['', '-wal', '-shm'] as const;
+const OWNED_FILE_SUFFIXES = ['', '-journal', '-wal', '-shm'] as const;
 const LEASE_DATABASE_NAME = 'inventory-v1.lease.sqlite3';
 const LEASE_FILE_SUFFIXES = ['', '-journal'] as const;
 const LEASE_APPLICATION_ID = 0x444b364c;
@@ -630,6 +630,7 @@ function openOrRebuildOwnedDatabase(
     createSecureEmptyFile(databasePath);
   } else {
     assertOwnedUnitOwners(databasePath);
+    assertTargetJournalModeCoherence(databasePath);
     assertExistingTargetHeader(databasePath);
   }
 
@@ -760,6 +761,21 @@ function openOrRebuildOwnedDatabase(
       'database-io',
       created ? 'failed to initialize RFC-64 inventory database' : 'failed to open RFC-64 inventory database',
       { cause: error },
+    );
+  }
+}
+
+function assertTargetJournalModeCoherence(databasePath: string): void {
+  if (
+    pathEntryExists(`${databasePath}-journal`)
+    && (
+      pathEntryExists(`${databasePath}-wal`)
+      || pathEntryExists(`${databasePath}-shm`)
+    )
+  ) {
+    throw new InventoryV1OpenError(
+      'ambiguous-database',
+      'inventory target mixes rollback-journal and WAL evidence and will not be opened or modified',
     );
   }
 }
@@ -1130,11 +1146,6 @@ $ErrorActionPreference = 'Stop'
 $identity = [System.Security.Principal.WindowsIdentity]::GetCurrent()
 $userSid = $identity.User
 $defaultOwnerSid = $identity.Owner
-$administratorsSid = [System.Security.Principal.SecurityIdentifier]::new(
-  [System.Security.Principal.WellKnownSidType]::BuiltinAdministratorsSid,
-  $null
-)
-$principal = [System.Security.Principal.WindowsPrincipal]::new($identity)
 $target = [System.IO.Path]::GetFullPath($env:DKG_RFC64_ACL_PATH)
 $acl = if ([System.IO.Directory]::Exists($target)) {
   [System.IO.Directory]::GetAccessControl(
@@ -1148,20 +1159,9 @@ $acl = if ([System.IO.Directory]::Exists($target)) {
   )
 }
 $owner = $acl.GetOwner([System.Security.Principal.SecurityIdentifier])
-# An elevated Windows token may create entries with its distinct default-owner
-# SID (normally BUILTIN\Administrators) even though the process account SID is
-# the user. GitHub-hosted and service runners may also pre-create the caller's
-# temp root with BUILTIN\Administrators as owner while the active token is an
-# administrator. Accept that one exact well-known group only when it is active
-# in this token; arbitrary token groups are deliberately not accepted.
-$isActiveAdministratorsOwner = (
-  $owner.Value -eq $administratorsSid.Value -and
-  $principal.IsInRole($administratorsSid)
-)
 if (
   $owner.Value -ne $userSid.Value -and
-  $owner.Value -ne $defaultOwnerSid.Value -and
-  -not $isActiveAdministratorsOwner
+  $owner.Value -ne $defaultOwnerSid.Value
 ) {
   [Console]::Error.WriteLine(
     "owner SID $($owner.Value) is neither token user $($userSid.Value) nor token default owner $($defaultOwnerSid.Value)"
@@ -1204,7 +1204,9 @@ if (
 function assertOwnedUnitOwners(databasePath: string): void {
   for (const suffix of OWNED_FILE_SUFFIXES) {
     const path = `${databasePath}${suffix}`;
-    if (pathEntryExists(path)) assertFilesystemOwner(path);
+    if (pathEntryExists(path)) {
+      assertOwnedRegularFile(path, `inventory database${suffix}`);
+    }
   }
 }
 
@@ -1355,7 +1357,11 @@ function fsyncRegularFile(path: string, label: string): void {
   assertOwnedRegularFile(path, label);
   let descriptor: number | undefined;
   try {
-    descriptor = openSync(path, 'r');
+    // Windows implements fsync with FlushFileBuffers, which rejects a handle
+    // opened for read-only access with EPERM. The entry is already an owned
+    // regular file; opening r+ grants the required handle access without
+    // changing bytes, while POSIX retains its narrower read-only descriptor.
+    descriptor = openSync(path, process.platform === 'win32' ? 'r+' : 'r');
     fsyncSync(descriptor);
   } catch (cause) {
     throw new InventoryV1OpenError('database-io', `failed to fsync ${label}`, { cause });
@@ -1374,16 +1380,18 @@ function pathEntryExists(path: string): boolean {
   }
 }
 
-type RecoveryMemberV1 = 'wal' | 'shm' | 'main';
+type RecoveryMemberV1 = 'journal' | 'wal' | 'shm' | 'main';
 type RecoveryMembersV1 =
   | readonly ['main']
+  | readonly ['journal', 'main']
   | readonly ['wal', 'main']
   | readonly ['shm', 'main']
   | readonly ['wal', 'shm', 'main'];
 
-const ALL_RECOVERY_MEMBERS = ['wal', 'shm', 'main'] as const satisfies readonly RecoveryMemberV1[];
+const ALL_RECOVERY_MEMBERS = ['journal', 'wal', 'shm', 'main'] as const satisfies readonly RecoveryMemberV1[];
 const RECOVERY_MEMBER_ARRAYS = new Set([
   '["main"]',
+  '["journal","main"]',
   '["wal","main"]',
   '["shm","main"]',
   '["wal","shm","main"]',
@@ -1514,9 +1522,17 @@ function finishPendingQuarantine(
   // before either continuing or deleting the marker.
   fsyncMovedRecoveryPrefix(marker, topology, inventoryDirectory, lifecycle);
   if (topology.movedCount === 0) {
-    // Only a complete source unit may be reopened. Once even one member has
-    // moved, SQLite must never see the partial source topology.
-    assertPendingUnitQuiescent(sqlite, databasePath, lifecycle);
+    // A zero-move marker never authorizes namespace mutation by itself. Prove
+    // zero-timeout exclusivity while the complete source unit, including any
+    // rollback journal, remains at its original pathname. A live raw SQLite
+    // holder therefore leaves every source member, destination, and marker
+    // untouched. Once the first prefix member has moved, that durable prefix
+    // is the restart witness that this proof completed before any rename.
+    if (marker.members[0] === 'journal') {
+      assertPendingRollbackJournalUnitQuiescent(sqlite, databasePath, lifecycle);
+    } else {
+      assertPendingUnitQuiescent(sqlite, databasePath, lifecycle);
+    }
     topology = inspectRecoveryTopology(marker, databasePath);
     if (topology.movedCount !== 0) {
       throw new InventoryV1OpenError(
@@ -1535,18 +1551,13 @@ function finishPendingQuarantine(
 
   for (const member of marker.members) {
     if (topology.locations.get(member) === 'destination') continue;
-    const source = recoverySourcePath(databasePath, member);
-    const destination = recoveryDestinationPath(marker.quarantineDirectory, member);
-    assertOwnedRegularFile(source, `inventory ${member} evidence`);
-    assertSameFilesystem(source, marker.quarantineDirectory, `inventory ${member} evidence`);
-    renameNoOverwriteUnderLease(source, destination);
-    lifecycle.boundary(`resume.member.${member}.rename`);
-    fsyncRegularFile(destination, `moved inventory ${member} evidence`);
-    lifecycle.boundary(`resume.member.${member}.file-fsync`);
-    fsyncDirectory(marker.quarantineDirectory);
-    lifecycle.boundary(`resume.member.${member}.generation-directory-fsync`);
-    fsyncDirectory(inventoryDirectory);
-    lifecycle.boundary(`resume.member.${member}.inventory-directory-fsync`);
+    moveRecoveryMember(
+      marker,
+      databasePath,
+      member,
+      inventoryDirectory,
+      lifecycle,
+    );
   }
 
   topology = inspectRecoveryTopology(marker, databasePath);
@@ -1560,6 +1571,27 @@ function finishPendingQuarantine(
   lifecycle.boundary('resume.marker.unlink');
   fsyncDirectory(inventoryDirectory);
   lifecycle.boundary('resume.inventory-directory.fsync-after-marker-unlink');
+}
+
+function moveRecoveryMember(
+  marker: RecoveryMarkerV1,
+  databasePath: string,
+  member: RecoveryMemberV1,
+  inventoryDirectory: string,
+  lifecycle: InventoryV1LifecycleAdapter,
+): void {
+  const source = recoverySourcePath(databasePath, member);
+  const destination = recoveryDestinationPath(marker.quarantineDirectory, member);
+  assertOwnedRegularFile(source, `inventory ${member} evidence`);
+  assertSameFilesystem(source, marker.quarantineDirectory, `inventory ${member} evidence`);
+  renameNoOverwriteUnderLease(source, destination);
+  lifecycle.boundary(`resume.member.${member}.rename`);
+  fsyncRegularFile(destination, `moved inventory ${member} evidence`);
+  lifecycle.boundary(`resume.member.${member}.file-fsync`);
+  fsyncDirectory(marker.quarantineDirectory);
+  lifecycle.boundary(`resume.member.${member}.generation-directory-fsync`);
+  fsyncDirectory(inventoryDirectory);
+  lifecycle.boundary(`resume.member.${member}.inventory-directory-fsync`);
 }
 
 function fsyncMovedRecoveryPrefix(
@@ -1723,6 +1755,117 @@ function assertPendingUnitQuiescent(
     if (database !== null) {
       closeInventoryTarget(database, 'pending-quarantine-probe', lifecycle);
     }
+  }
+}
+
+function assertPendingRollbackJournalUnitQuiescent(
+  sqlite: SqliteModuleV1,
+  databasePath: string,
+  lifecycle: InventoryV1LifecycleAdapter,
+): void {
+  if (!pathEntryExists(databasePath)) {
+    throw new InventoryV1OpenError(
+      'database-io',
+      'pending rollback-journal quarantine has no source main',
+    );
+  }
+  rejectOwnedFileSymlinks(databasePath);
+  assertOwnedUnitOwners(databasePath);
+
+  // Opening the main database by its ordinary pathname can recover or delete
+  // its rollback journal before SQLite reports whether another process owns a
+  // writer lock. Instead, open the already-validated main inode through this
+  // process's descriptor namespace. SQLite locks the same inode, while its
+  // derived journal pathname is the descriptor alias and therefore cannot
+  // consume or rename the source `-journal` evidence. Quarantine is available
+  // only under the certified POSIX capability, where /dev/fd (or Linux's
+  // equivalent /proc/self/fd) provides this same-inode alias.
+  let descriptor: number | undefined;
+  let database: DatabaseSyncV1 | null = null;
+  let transactionOpen = false;
+  try {
+    descriptor = openSync(databasePath, 'r+');
+    const sourceIdentity = fstatSync(descriptor);
+    if (!sourceIdentity.isFile()) {
+      throw new InventoryV1OpenError(
+        'database-io',
+        'pending rollback-journal source main is not a regular file',
+      );
+    }
+    const aliasCandidates = [
+      `/dev/fd/${descriptor}`,
+      ...(process.platform === 'linux' ? [`/proc/self/fd/${descriptor}`] : []),
+    ];
+    let descriptorAlias: string | undefined;
+    for (const candidate of aliasCandidates) {
+      let aliasDescriptor: number | undefined;
+      try {
+        aliasDescriptor = openSync(candidate, 'r+');
+        const aliasIdentity = fstatSync(aliasDescriptor);
+        if (
+          aliasIdentity.isFile()
+          && aliasIdentity.dev === sourceIdentity.dev
+          && aliasIdentity.ino === sourceIdentity.ino
+        ) {
+          descriptorAlias = candidate;
+          break;
+        }
+      } catch {
+        // Try the next fixed descriptor namespace alias.
+      } finally {
+        if (aliasDescriptor !== undefined) closeSync(aliasDescriptor);
+      }
+    }
+    if (descriptorAlias === undefined) {
+      throw new InventoryV1OpenError(
+        'durability-unavailable',
+        'certified POSIX quarantine cannot address the source main through a same-inode descriptor alias',
+      );
+    }
+
+    database = new sqlite.DatabaseSync(descriptorAlias);
+    database.exec('PRAGMA busy_timeout = 0');
+    database.exec('BEGIN EXCLUSIVE');
+    transactionOpen = true;
+    database.exec('ROLLBACK');
+    transactionOpen = false;
+    database.close();
+    database = null;
+
+    const finalIdentity = fstatSync(descriptor);
+    if (
+      !finalIdentity.isFile()
+      || finalIdentity.dev !== sourceIdentity.dev
+      || finalIdentity.ino !== sourceIdentity.ino
+    ) {
+      throw new InventoryV1OpenError(
+        'database-io',
+        'pending rollback-journal source main changed during the exclusivity proof',
+      );
+    }
+    lifecycle.boundary('target-exclusivity-proven');
+  } catch (cause) {
+    if (transactionOpen && database !== null) {
+      try { database.exec('ROLLBACK'); } catch { /* retain the proof failure */ }
+    }
+    if (cause instanceof InventoryV1OpenError) throw cause;
+    if (isBusySqliteError(cause)) {
+      throw new InventoryV1OpenError(
+        'database-busy',
+        'pending rollback-journal quarantine still has an active SQLite holder',
+        { cause },
+      );
+    }
+    throw new InventoryV1OpenError(
+      'database-io',
+      'cannot prove exclusive access to the pending rollback-journal unit',
+      { cause },
+    );
+  } finally {
+    if (database !== null) {
+      try { database.close(); } catch { /* retain any primary proof failure */ }
+    }
+    if (descriptor !== undefined) closeSync(descriptor);
   }
 }
 

--- a/packages/agent/src/rfc64/inventory-v1/open.ts
+++ b/packages/agent/src/rfc64/inventory-v1/open.ts
@@ -1,0 +1,741 @@
+import {
+  chmodSync,
+  closeSync,
+  existsSync,
+  fsyncSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  readSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path';
+import { randomBytes } from 'node:crypto';
+import { spawnSync } from 'node:child_process';
+
+import {
+  INVENTORY_V1_APPLICATION_ID,
+  INVENTORY_V1_DDL,
+  INVENTORY_V1_DIRECTORY_MODE,
+  INVENTORY_V1_FILE_MODE,
+  INVENTORY_V1_RELATIVE_PATH,
+  INVENTORY_V1_USER_OBJECTS,
+  INVENTORY_V1_USER_VERSION,
+  normalizeInventoryV1SchemaSql,
+} from './sql.js';
+
+type SqliteModuleV1 = typeof import('node:sqlite');
+type DatabaseSyncV1 = InstanceType<SqliteModuleV1['DatabaseSync']>;
+
+const RECOVERY_MARKER_SUFFIX = '.rebuild-required';
+const QUARANTINE_DIRECTORY = 'quarantine';
+const OWNED_FILE_SUFFIXES = ['', '-wal', '-shm'] as const;
+
+export type InventoryV1OpenErrorCode =
+  | 'sqlite-unavailable'
+  | 'foreign-database'
+  | 'newer-schema'
+  | 'ambiguous-database'
+  | 'unsafe-path'
+  | 'pragma-mismatch'
+  | 'database-busy'
+  | 'database-closed'
+  | 'database-io';
+
+export class InventoryV1OpenError extends Error {
+  constructor(
+    readonly code: InventoryV1OpenErrorCode,
+    message: string,
+    options: ErrorOptions = {},
+  ) {
+    super(`[${code}] ${message}`, options);
+    this.name = 'InventoryV1OpenError';
+  }
+}
+
+export interface Rfc64InventoryV1Foundation {
+  readonly databasePath: string;
+  readonly closed: boolean;
+  quarantineAndRebuild(): void;
+  close(): void;
+}
+
+export async function openInventoryV1(dataDir: string): Promise<Rfc64InventoryV1Foundation> {
+  const sqlite = await loadSqliteModule();
+  const databasePath = resolve(dataDir, INVENTORY_V1_RELATIVE_PATH);
+  try {
+    prepareSecureDirectory(dirname(databasePath));
+    finishPendingQuarantine(databasePath);
+    const database = openOrRebuildOwnedDatabase(sqlite, databasePath);
+    return new InventoryV1Foundation(sqlite, databasePath, database);
+  } catch (cause) {
+    if (cause instanceof InventoryV1OpenError) throw cause;
+    throw new InventoryV1OpenError(
+      'database-io',
+      'failed to prepare or open the RFC-64 inventory database',
+      { cause },
+    );
+  }
+}
+
+class InventoryV1Foundation implements Rfc64InventoryV1Foundation {
+  #database: DatabaseSyncV1 | null;
+
+  constructor(
+    private readonly sqlite: SqliteModuleV1,
+    readonly databasePath: string,
+    database: DatabaseSyncV1,
+  ) {
+    this.#database = database;
+  }
+
+  get closed(): boolean {
+    return this.#database === null;
+  }
+
+  quarantineAndRebuild(): void {
+    const database = this.requireOpen();
+    assertDatabaseQuiescent(database);
+    database.close();
+    this.#database = null;
+    try {
+      beginQuarantine(this.databasePath);
+      finishPendingQuarantine(this.databasePath);
+      this.#database = openOrRebuildOwnedDatabase(this.sqlite, this.databasePath);
+    } catch (error) {
+      throw new InventoryV1OpenError(
+        'database-io',
+        'failed to quarantine and rebuild the RFC-64 inventory database',
+        { cause: error },
+      );
+    }
+  }
+
+  close(): void {
+    this.#database?.close();
+    this.#database = null;
+  }
+
+  private requireOpen(): DatabaseSyncV1 {
+    if (this.#database === null) {
+      throw new InventoryV1OpenError('database-closed', 'inventory database is closed');
+    }
+    return this.#database;
+  }
+}
+
+async function loadSqliteModule(): Promise<SqliteModuleV1> {
+  try {
+    const moduleName = 'node:sqlite';
+    return await import(moduleName);
+  } catch (cause) {
+    throw new InventoryV1OpenError(
+      'sqlite-unavailable',
+      'RFC-64 SQL-1 requires Node runtime support for node:sqlite',
+      { cause },
+    );
+  }
+}
+
+function openOrRebuildOwnedDatabase(
+  sqlite: SqliteModuleV1,
+  databasePath: string,
+): DatabaseSyncV1 {
+  rejectOwnedFileSymlinks(databasePath);
+  rejectOrphanedSidecars(databasePath);
+  const existed = existsSync(databasePath);
+  if (existed) {
+    refuseValidForeignSqliteHeader(databasePath);
+    assertOwnedUnitOwners(databasePath);
+  }
+  if (!existed) createSecureEmptyFile(databasePath);
+
+  let database: DatabaseSyncV1 | null = null;
+  try {
+    // Keep SQL-1 on the original Node 22.5 node:sqlite surface. Loading
+    // extensions is disabled by default; every statement below is fixed SQL,
+    // so double-quoted-string compatibility cannot affect parsing.
+    database = new sqlite.DatabaseSync(databasePath);
+    database.exec(`
+      PRAGMA foreign_keys = ON;
+      PRAGMA trusted_schema = OFF;
+      PRAGMA busy_timeout = 5000;
+    `);
+    const identity = readIdentity(database);
+
+    if (isFreshIdentity(identity)) {
+      if (identity.userObjects.length !== 0) {
+        database.close();
+        database = null;
+        throw new InventoryV1OpenError(
+          'ambiguous-database',
+          'application_id=0/user_version=0 database contains user objects and will not be modified',
+        );
+      }
+      tightenOwnedFileMode(databasePath);
+      applyAndVerifyPragmas(database);
+      initializeFreshDatabase(database);
+      verifyOwnedSchema(database);
+      tightenOwnedFileMode(databasePath);
+      return database;
+    }
+
+    if (identity.applicationId !== INVENTORY_V1_APPLICATION_ID) {
+      database.close();
+      database = null;
+      throw new InventoryV1OpenError(
+        identity.applicationId === 0 ? 'ambiguous-database' : 'foreign-database',
+        'database application_id does not identify RFC-64 SQL-1 and will not be modified',
+      );
+    }
+    if (identity.userVersion > INVENTORY_V1_USER_VERSION) {
+      database.close();
+      database = null;
+      throw new InventoryV1OpenError(
+        'newer-schema',
+        `inventory user_version ${identity.userVersion} is newer than supported version 1`,
+      );
+    }
+
+    tightenOwnedFileMode(databasePath);
+    if (identity.userVersion !== INVENTORY_V1_USER_VERSION || !schemaMatches(identity.userObjects)) {
+      assertDatabaseQuiescent(database);
+      database.close();
+      database = null;
+      beginQuarantine(databasePath);
+      finishPendingQuarantine(databasePath);
+      return openOrRebuildOwnedDatabase(sqlite, databasePath);
+    }
+
+    applyAndVerifyPragmas(database);
+    try {
+      verifyOwnedSchema(database);
+    } catch (error) {
+      if (!(error instanceof OwnedInventoryV1SchemaError)) throw error;
+      assertDatabaseQuiescent(database);
+      database.close();
+      database = null;
+      beginQuarantine(databasePath);
+      finishPendingQuarantine(databasePath);
+      return openOrRebuildOwnedDatabase(sqlite, databasePath);
+    }
+    tightenOwnedFileMode(databasePath);
+    return database;
+  } catch (error) {
+    if (database !== null) {
+      try { database.close(); } catch { /* retain the original failure */ }
+    }
+    if (error instanceof InventoryV1OpenError) throw error;
+    if (isCorruptSqliteError(error)) {
+      const ownership = classifyCorruptDatabaseOwnership(databasePath);
+      if (ownership === 'owned') {
+        beginQuarantine(databasePath);
+        finishPendingQuarantine(databasePath);
+        return openOrRebuildOwnedDatabase(sqlite, databasePath);
+      }
+      throw new InventoryV1OpenError(
+        'foreign-database',
+        'corrupt SQLite database has a foreign application_id and will not be modified',
+        { cause: error },
+      );
+    }
+    if (isBusySqliteError(error)) {
+      throw new InventoryV1OpenError(
+        'database-busy',
+        'inventory database is busy or locked and will not be quarantined',
+        { cause: error },
+      );
+    }
+    throw new InventoryV1OpenError(
+      'database-io',
+      existed ? 'failed to open RFC-64 inventory database' : 'failed to initialize RFC-64 inventory database',
+      { cause: error },
+    );
+  }
+}
+
+interface DatabaseIdentityV1 {
+  applicationId: number;
+  userVersion: number;
+  userObjects: Array<{ name: string; sql: string | null }>;
+}
+
+function readIdentity(database: DatabaseSyncV1): DatabaseIdentityV1 {
+  return {
+    applicationId: readPragmaInteger(database, 'application_id'),
+    userVersion: readPragmaInteger(database, 'user_version'),
+    userObjects: database.prepare(
+      `SELECT name, sql FROM sqlite_schema WHERE name NOT LIKE 'sqlite_%' ORDER BY name`,
+    ).all().map((row) => ({
+      name: assertString(row.name, 'sqlite_schema.name'),
+      sql: row.sql === null ? null : assertString(row.sql, 'sqlite_schema.sql'),
+    })),
+  };
+}
+
+function isFreshIdentity(identity: DatabaseIdentityV1): boolean {
+  return identity.applicationId === 0 && identity.userVersion === 0;
+}
+
+function schemaMatches(objects: DatabaseIdentityV1['userObjects']): boolean {
+  if (objects.length !== Object.keys(INVENTORY_V1_USER_OBJECTS).length) return false;
+  return objects.every((object) => {
+    const expected = INVENTORY_V1_USER_OBJECTS[object.name];
+    return expected !== undefined
+      && object.sql !== null
+      && normalizeInventoryV1SchemaSql(object.sql) === expected;
+  });
+}
+
+function initializeFreshDatabase(database: DatabaseSyncV1): void {
+  database.exec('BEGIN IMMEDIATE');
+  try {
+    database.exec(INVENTORY_V1_DDL);
+    database.exec(`PRAGMA application_id = ${INVENTORY_V1_APPLICATION_ID}`);
+    database.exec(`PRAGMA user_version = ${INVENTORY_V1_USER_VERSION}`);
+    database.exec('COMMIT');
+  } catch (error) {
+    try { database.exec('ROLLBACK'); } catch { /* retain the initialization error */ }
+    throw error;
+  }
+}
+
+class OwnedInventoryV1SchemaError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'OwnedInventoryV1SchemaError';
+  }
+}
+
+function verifyOwnedSchema(database: DatabaseSyncV1): void {
+  const identity = readIdentity(database);
+  if (
+    identity.applicationId !== INVENTORY_V1_APPLICATION_ID
+    || identity.userVersion !== INVENTORY_V1_USER_VERSION
+    || !schemaMatches(identity.userObjects)
+  ) {
+    throw new OwnedInventoryV1SchemaError('RFC-64 inventory schema verification failed');
+  }
+  const foreignKeyRows = database.prepare('PRAGMA foreign_key_check').all();
+  if (foreignKeyRows.length !== 0) {
+    throw new OwnedInventoryV1SchemaError('RFC-64 inventory foreign-key check failed');
+  }
+}
+
+function assertDatabaseQuiescent(database: DatabaseSyncV1): void {
+  let transactionOpen = false;
+  try {
+    database.exec('PRAGMA busy_timeout = 0');
+    const checkpoint = database.prepare('PRAGMA wal_checkpoint(TRUNCATE)').get();
+    const busy = checkpoint?.busy;
+    if (typeof busy !== 'number' || busy !== 0) {
+      throw new InventoryV1OpenError(
+        busy === 1 ? 'database-busy' : 'database-io',
+        busy === 1
+          ? 'inventory database has active WAL readers and will not be quarantined'
+          : 'SQLite returned an invalid WAL checkpoint result',
+      );
+    }
+    database.exec('BEGIN EXCLUSIVE');
+    transactionOpen = true;
+    database.exec('ROLLBACK');
+    transactionOpen = false;
+  } catch (cause) {
+    if (transactionOpen) {
+      try { database.exec('ROLLBACK'); } catch { /* retain the quiescence failure */ }
+    }
+    if (cause instanceof InventoryV1OpenError) throw cause;
+    if (isBusySqliteError(cause)) {
+      throw new InventoryV1OpenError(
+        'database-busy',
+        'inventory database is busy and will not be quarantined',
+        { cause },
+      );
+    }
+    throw new InventoryV1OpenError(
+      'database-io',
+      'could not prove exclusive access; inventory database will not be quarantined',
+      { cause },
+    );
+  } finally {
+    try { database.exec('PRAGMA busy_timeout = 5000'); } catch { /* best-effort connection restore */ }
+  }
+}
+
+function applyAndVerifyPragmas(database: DatabaseSyncV1): void {
+  database.exec(`
+    PRAGMA foreign_keys = ON;
+    PRAGMA trusted_schema = OFF;
+    PRAGMA synchronous = FULL;
+    PRAGMA busy_timeout = 5000;
+    PRAGMA journal_size_limit = 67108864;
+  `);
+  const journalMode = database.prepare('PRAGMA journal_mode = WAL').get();
+  if (journalMode === undefined || String(journalMode.journal_mode).toLowerCase() !== 'wal') {
+    throw new InventoryV1OpenError('pragma-mismatch', 'SQLite refused journal_mode=WAL');
+  }
+  const expected = new Map<string, number>([
+    ['foreign_keys', 1],
+    ['trusted_schema', 0],
+    ['synchronous', 2],
+    ['busy_timeout', 5000],
+    ['journal_size_limit', 67_108_864],
+  ]);
+  for (const [pragma, expectedValue] of expected) {
+    if (readPragmaInteger(database, pragma) !== expectedValue) {
+      throw new InventoryV1OpenError('pragma-mismatch', `SQLite refused PRAGMA ${pragma}=${expectedValue}`);
+    }
+  }
+}
+
+function readPragmaInteger(database: DatabaseSyncV1, pragma: string): number {
+  const row = database.prepare(`PRAGMA ${pragma}`).get();
+  if (row === undefined) throw new InventoryV1OpenError('database-io', `PRAGMA ${pragma} returned no row`);
+  const value = Object.values(row)[0];
+  if (typeof value !== 'number' || !Number.isSafeInteger(value)) {
+    throw new InventoryV1OpenError('database-io', `PRAGMA ${pragma} returned a non-integer value`);
+  }
+  return value;
+}
+
+function prepareSecureDirectory(directoryPath: string): void {
+  if (pathEntryExists(directoryPath)) rejectSymlink(directoryPath, 'inventory directory');
+  mkdirSync(directoryPath, { recursive: true, mode: INVENTORY_V1_DIRECTORY_MODE });
+  rejectSymlink(directoryPath, 'inventory directory');
+  applySecurePermissions(directoryPath, INVENTORY_V1_DIRECTORY_MODE, true);
+}
+
+function createSecureEmptyFile(databasePath: string): void {
+  const descriptor = openSync(databasePath, 'wx', INVENTORY_V1_FILE_MODE);
+  try { fsyncSync(descriptor); } finally { closeSync(descriptor); }
+  applySecurePermissions(databasePath, INVENTORY_V1_FILE_MODE, false);
+}
+
+function tightenOwnedFileMode(databasePath: string): void {
+  applySecurePermissions(databasePath, INVENTORY_V1_FILE_MODE, false);
+}
+
+function assertFilesystemOwner(path: string): void {
+  if (process.platform === 'win32') {
+    const script = String.raw`
+$ErrorActionPreference = 'Stop'
+$sid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User
+$owner = (Get-Acl -LiteralPath $env:DKG_RFC64_ACL_PATH).GetOwner([System.Security.Principal.SecurityIdentifier])
+if ($owner.Value -ne $sid.Value) { exit 40 }
+`;
+    const result = spawnSync(
+      'powershell.exe',
+      ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', script],
+      {
+        encoding: 'utf8',
+        windowsHide: true,
+        env: { ...process.env, DKG_RFC64_ACL_PATH: path },
+      },
+    );
+    if (result.error !== undefined || result.status !== 0) {
+      throw new InventoryV1OpenError(
+        'database-io',
+        `inventory path is not owned by the current Windows identity: ${path}`,
+        { cause: result.error ?? new Error(result.stderr.trim() || `PowerShell exited ${result.status}`) },
+      );
+    }
+    return;
+  }
+  try {
+    const processUid = process.getuid?.();
+    if (processUid !== undefined && statSync(path).uid !== processUid) {
+      throw new Error('filesystem entry is not owned by the current process uid');
+    }
+  } catch (cause) {
+    throw new InventoryV1OpenError(
+      'database-io',
+      `inventory path is not owned by the current process: ${path}`,
+      { cause },
+    );
+  }
+}
+
+function assertOwnedUnitOwners(databasePath: string): void {
+  for (const suffix of OWNED_FILE_SUFFIXES) {
+    const path = `${databasePath}${suffix}`;
+    if (pathEntryExists(path)) assertFilesystemOwner(path);
+  }
+}
+
+function applySecurePermissions(path: string, mode: number, directory: boolean): void {
+  if (process.platform === 'win32') {
+    applyWindowsOwnerOnlyAcl(path, directory);
+    return;
+  }
+  try {
+    chmodSync(path, mode);
+    const stat = statSync(path);
+    const processUid = process.getuid?.();
+    if (processUid !== undefined && stat.uid !== processUid) {
+      throw new Error(`path owner uid ${stat.uid} does not match process uid ${processUid}`);
+    }
+    if ((stat.mode & 0o777) !== mode) {
+      throw new Error(`path mode ${(stat.mode & 0o777).toString(8)} does not match ${mode.toString(8)}`);
+    }
+  } catch (cause) {
+    throw new InventoryV1OpenError('database-io', `failed to set secure permissions on ${path}`, { cause });
+  }
+}
+
+function applyWindowsOwnerOnlyAcl(path: string, directory: boolean): void {
+  const script = String.raw`
+$ErrorActionPreference = 'Stop'
+$target = $env:DKG_RFC64_ACL_PATH
+$isDirectory = [System.Convert]::ToBoolean($env:DKG_RFC64_ACL_DIRECTORY)
+$sid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User
+$acl = if ($isDirectory) {
+  [System.Security.AccessControl.DirectorySecurity]::new()
+} else {
+  [System.Security.AccessControl.FileSecurity]::new()
+}
+$acl.SetOwner($sid)
+$acl.SetAccessRuleProtection($true, $false)
+$inheritance = if ($isDirectory) {
+  [System.Security.AccessControl.InheritanceFlags]'ContainerInherit, ObjectInherit'
+} else {
+  [System.Security.AccessControl.InheritanceFlags]::None
+}
+$rule = [System.Security.AccessControl.FileSystemAccessRule]::new(
+  $sid,
+  [System.Security.AccessControl.FileSystemRights]::FullControl,
+  $inheritance,
+  [System.Security.AccessControl.PropagationFlags]::None,
+  [System.Security.AccessControl.AccessControlType]::Allow
+)
+$acl.AddAccessRule($rule)
+Set-Acl -LiteralPath $target -AclObject $acl
+$verified = Get-Acl -LiteralPath $target
+$rules = @($verified.GetAccessRules($true, $true, [System.Security.Principal.SecurityIdentifier]))
+if (-not $verified.AreAccessRulesProtected -or $rules.Count -ne 1) { exit 41 }
+if ($rules[0].IdentityReference.Value -ne $sid.Value) { exit 42 }
+if ($rules[0].AccessControlType -ne [System.Security.AccessControl.AccessControlType]::Allow) { exit 43 }
+if (($rules[0].FileSystemRights -band [System.Security.AccessControl.FileSystemRights]::FullControl) -ne [System.Security.AccessControl.FileSystemRights]::FullControl) { exit 44 }
+`;
+  const result = spawnSync(
+    'powershell.exe',
+    ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', script],
+    {
+      encoding: 'utf8',
+      windowsHide: true,
+      env: {
+        ...process.env,
+        DKG_RFC64_ACL_PATH: path,
+        DKG_RFC64_ACL_DIRECTORY: String(directory),
+      },
+    },
+  );
+  if (result.error !== undefined || result.status !== 0) {
+    throw new InventoryV1OpenError(
+      'database-io',
+      `failed to establish owner-only Windows ACL on ${path}`,
+      { cause: result.error ?? new Error(result.stderr.trim() || `PowerShell exited ${result.status}`) },
+    );
+  }
+}
+
+function rejectOwnedFileSymlinks(databasePath: string): void {
+  for (const suffix of OWNED_FILE_SUFFIXES) {
+    const path = `${databasePath}${suffix}`;
+    if (pathEntryExists(path)) rejectSymlink(path, `inventory database${suffix}`);
+  }
+}
+
+function rejectOrphanedSidecars(databasePath: string): void {
+  if (existsSync(databasePath)) return;
+  if (pathEntryExists(`${databasePath}-wal`) || pathEntryExists(`${databasePath}-shm`)) {
+    throw new InventoryV1OpenError(
+      'ambiguous-database',
+      'orphaned inventory sidecars exist without a database and will not be modified',
+    );
+  }
+}
+
+function rejectSymlink(path: string, label: string): void {
+  if (lstatSync(path).isSymbolicLink()) {
+    throw new InventoryV1OpenError('unsafe-path', `${label} must not be a symbolic link`);
+  }
+}
+
+function pathEntryExists(path: string): boolean {
+  try {
+    lstatSync(path);
+    return true;
+  } catch (cause) {
+    if ((cause as NodeJS.ErrnoException).code === 'ENOENT') return false;
+    throw new InventoryV1OpenError('database-io', `failed to inspect filesystem entry ${path}`, { cause });
+  }
+}
+
+interface RecoveryMarkerV1 {
+  version: 1;
+  quarantineDirectory: string;
+}
+
+function beginQuarantine(databasePath: string): void {
+  const markerPath = recoveryMarkerPath(databasePath);
+  if (pathEntryExists(markerPath)) {
+    rejectSymlink(markerPath, 'inventory recovery marker');
+    return;
+  }
+  const quarantineRoot = join(dirname(databasePath), QUARANTINE_DIRECTORY);
+  if (pathEntryExists(quarantineRoot)) rejectSymlink(quarantineRoot, 'inventory quarantine directory');
+  mkdirSync(quarantineRoot, { recursive: true, mode: INVENTORY_V1_DIRECTORY_MODE });
+  rejectSymlink(quarantineRoot, 'inventory quarantine directory');
+  applySecurePermissions(quarantineRoot, INVENTORY_V1_DIRECTORY_MODE, true);
+  const suffix = `${Date.now()}-${randomBytes(8).toString('hex')}`;
+  const quarantineDirectory = join(quarantineRoot, `inventory-v1-${suffix}`);
+  mkdirSync(quarantineDirectory, { mode: INVENTORY_V1_DIRECTORY_MODE });
+  rejectSymlink(quarantineDirectory, 'inventory quarantine generation');
+  applySecurePermissions(quarantineDirectory, INVENTORY_V1_DIRECTORY_MODE, true);
+  const marker: RecoveryMarkerV1 = { version: 1, quarantineDirectory };
+  writeFileSync(markerPath, JSON.stringify(marker), { encoding: 'utf8', flag: 'wx', mode: INVENTORY_V1_FILE_MODE });
+  applySecurePermissions(markerPath, INVENTORY_V1_FILE_MODE, false);
+  const descriptor = openSync(markerPath, 'r');
+  try { fsyncSync(descriptor); } finally { closeSync(descriptor); }
+  fsyncDirectory(dirname(databasePath));
+}
+
+function finishPendingQuarantine(databasePath: string): void {
+  const markerPath = recoveryMarkerPath(databasePath);
+  if (!pathEntryExists(markerPath)) return;
+  rejectSymlink(markerPath, 'inventory recovery marker');
+  assertFilesystemOwner(markerPath);
+  const inventoryDirectory = dirname(databasePath);
+  const quarantineRoot = join(inventoryDirectory, QUARANTINE_DIRECTORY);
+  if (pathEntryExists(quarantineRoot)) {
+    rejectSymlink(quarantineRoot, 'inventory quarantine directory');
+    assertFilesystemOwner(quarantineRoot);
+  }
+  const marker = parseRecoveryMarker(readFileSync(markerPath, 'utf8'), inventoryDirectory);
+  mkdirSync(marker.quarantineDirectory, { recursive: true, mode: INVENTORY_V1_DIRECTORY_MODE });
+  rejectSymlink(quarantineRoot, 'inventory quarantine directory');
+  applySecurePermissions(quarantineRoot, INVENTORY_V1_DIRECTORY_MODE, true);
+  rejectSymlink(marker.quarantineDirectory, 'inventory quarantine generation');
+  assertFilesystemOwner(marker.quarantineDirectory);
+  applySecurePermissions(marker.quarantineDirectory, INVENTORY_V1_DIRECTORY_MODE, true);
+  for (const suffix of OWNED_FILE_SUFFIXES) {
+    const source = `${databasePath}${suffix}`;
+    if (!pathEntryExists(source)) continue;
+    rejectSymlink(source, `inventory database${suffix}`);
+    assertFilesystemOwner(source);
+    const target = join(marker.quarantineDirectory, `inventory-v1.sqlite3${suffix}`);
+    if (pathEntryExists(target)) {
+      throw new InventoryV1OpenError('database-io', `quarantine target already exists: ${target}`);
+    }
+    renameSync(source, target);
+  }
+  fsyncDirectory(marker.quarantineDirectory);
+  unlinkSync(markerPath);
+  fsyncDirectory(dirname(databasePath));
+}
+
+function parseRecoveryMarker(value: string, inventoryDirectory: string): RecoveryMarkerV1 {
+  let parsed: unknown;
+  try { parsed = JSON.parse(value); } catch (cause) {
+    throw new InventoryV1OpenError('database-io', 'inventory recovery marker is malformed', { cause });
+  }
+  if (
+    typeof parsed !== 'object'
+    || parsed === null
+    || (parsed as { version?: unknown }).version !== 1
+    || typeof (parsed as { quarantineDirectory?: unknown }).quarantineDirectory !== 'string'
+  ) {
+    throw new InventoryV1OpenError('database-io', 'inventory recovery marker has an invalid shape');
+  }
+  const quarantineDirectory = resolve((parsed as RecoveryMarkerV1).quarantineDirectory);
+  const quarantineRoot = resolve(inventoryDirectory, QUARANTINE_DIRECTORY);
+  const relativePath = relative(quarantineRoot, quarantineDirectory);
+  if (
+    relativePath.length === 0
+    || relativePath.startsWith('..')
+    || isAbsolute(relativePath)
+    || basename(relativePath) !== relativePath
+    || !/^inventory-v1-[0-9]+-[0-9a-f]{16}$/.test(relativePath)
+  ) {
+    throw new InventoryV1OpenError('unsafe-path', 'inventory recovery marker escapes the quarantine directory');
+  }
+  return { version: 1, quarantineDirectory };
+}
+
+function recoveryMarkerPath(databasePath: string): string {
+  return `${databasePath}${RECOVERY_MARKER_SUFFIX}`;
+}
+
+function isCorruptSqliteError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) return false;
+  const errcode = (error as { errcode?: unknown }).errcode;
+  return errcode === 11 || errcode === 26;
+}
+
+function isBusySqliteError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) return false;
+  const errcode = (error as { errcode?: unknown }).errcode;
+  return errcode === 5 || errcode === 6;
+}
+
+type CorruptDatabaseOwnershipV1 = 'owned' | 'foreign';
+
+function classifyCorruptDatabaseOwnership(databasePath: string): CorruptDatabaseOwnershipV1 {
+  const applicationId = readValidSqliteHeaderApplicationId(databasePath);
+  if (applicationId === null || applicationId === INVENTORY_V1_APPLICATION_ID || applicationId === 0) {
+    return 'owned';
+  }
+  return 'foreign';
+}
+
+function refuseValidForeignSqliteHeader(databasePath: string): void {
+  const applicationId = readValidSqliteHeaderApplicationId(databasePath);
+  if (
+    applicationId !== null
+    && applicationId !== 0
+    && applicationId !== INVENTORY_V1_APPLICATION_ID
+  ) {
+    throw new InventoryV1OpenError(
+      'foreign-database',
+      'database header has a foreign application_id and will not be opened or modified',
+    );
+  }
+}
+
+function readValidSqliteHeaderApplicationId(databasePath: string): number | null {
+  let descriptor: number | undefined;
+  try {
+    descriptor = openSync(databasePath, 'r');
+    const header = Buffer.alloc(100);
+    const bytesRead = readSync(descriptor, header, 0, header.byteLength, 0);
+    if (bytesRead < header.byteLength || header.subarray(0, 16).toString('binary') !== 'SQLite format 3\u0000') {
+      return null;
+    }
+    return header.readUInt32BE(68);
+  } catch (cause) {
+    throw new InventoryV1OpenError(
+      'database-io',
+      'failed to read the inventory database header; it will not be quarantined',
+      { cause },
+    );
+  } finally {
+    if (descriptor !== undefined) closeSync(descriptor);
+  }
+}
+
+function fsyncDirectory(path: string): void {
+  if (process.platform === 'win32') return;
+  const descriptor = openSync(path, 'r');
+  try { fsyncSync(descriptor); } finally { closeSync(descriptor); }
+}
+
+function assertString(value: unknown, label: string): string {
+  if (typeof value !== 'string') {
+    throw new InventoryV1OpenError('database-io', `${label} is not text`);
+  }
+  return value;
+}

--- a/packages/agent/src/rfc64/inventory-v1/open.ts
+++ b/packages/agent/src/rfc64/inventory-v1/open.ts
@@ -658,10 +658,13 @@ function openOrRebuildOwnedDatabase(
       verifyOwnedSchema(database);
     } catch (error) {
       if (!(error instanceof OwnedInventoryV1SchemaError)) throw error;
+      // Eligibility is a precondition for even the zero-timeout/checkpoint
+      // quarantine proof. In particular, do not checkpoint or truncate a
+      // crashed WAL on a deployment that cannot durably rename the namespace.
+      assertQuarantineDurabilityAvailable(lifecycle);
       assertDatabaseQuiescent(database, lifecycle);
       closeInventoryTarget(database, 'automatic-schema-quarantine', lifecycle);
       database = null;
-      assertQuarantineDurabilityAvailable(lifecycle);
       beginQuarantine(databasePath, lifecycle);
       finishPendingQuarantine(sqlite, databasePath, lifecycle);
       return openOrRebuildOwnedDatabase(sqlite, databasePath, lifecycle);
@@ -719,6 +722,15 @@ function openOrRebuildOwnedDatabase(
           { cause: error },
         );
       }
+      // Refuse before BEGIN EXCLUSIVE or wal_checkpoint(TRUNCATE) can alter a
+      // corrupt unit on an uncertified deployment. The ordinary cleanup close
+      // may still perform SQLite's normal recovery, which the RFC permits.
+      try {
+        assertQuarantineDurabilityAvailable(lifecycle);
+      } catch (cause) {
+        closeProbe();
+        throw cause;
+      }
       try {
         assertCorruptDatabaseQuiescent(database, lifecycle);
       } catch (cause) {
@@ -732,10 +744,6 @@ function openOrRebuildOwnedDatabase(
       }
       closeInventoryTarget(database, 'automatic-corrupt-quarantine', lifecycle);
       database = null;
-      // The corrupt target handle is deliberately closed before this platform
-      // gate can reject quarantine. The caller may release DK6L only after that
-      // target close has succeeded.
-      assertQuarantineDurabilityAvailable(lifecycle);
       beginQuarantine(databasePath, lifecycle);
       finishPendingQuarantine(sqlite, databasePath, lifecycle);
       return openOrRebuildOwnedDatabase(sqlite, databasePath, lifecycle);
@@ -1120,7 +1128,19 @@ function assertFilesystemOwner(path: string): void {
     const script = String.raw`
 $ErrorActionPreference = 'Stop'
 $sid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User
-$owner = (Get-Acl -LiteralPath $env:DKG_RFC64_ACL_PATH).GetOwner([System.Security.Principal.SecurityIdentifier])
+$target = [System.IO.Path]::GetFullPath($env:DKG_RFC64_ACL_PATH)
+$acl = if ([System.IO.Directory]::Exists($target)) {
+  [System.IO.Directory]::GetAccessControl(
+    $target,
+    [System.Security.AccessControl.AccessControlSections]::Owner
+  )
+} else {
+  [System.IO.File]::GetAccessControl(
+    $target,
+    [System.Security.AccessControl.AccessControlSections]::Owner
+  )
+}
+$owner = $acl.GetOwner([System.Security.Principal.SecurityIdentifier])
 if ($owner.Value -ne $sid.Value) { exit 40 }
 `;
     const result = spawnSync(
@@ -1212,8 +1232,13 @@ $rule = [System.Security.AccessControl.FileSystemAccessRule]::new(
   [System.Security.AccessControl.AccessControlType]::Allow
 )
 $acl.AddAccessRule($rule)
-Set-Acl -LiteralPath $target -AclObject $acl
-$verified = Get-Acl -LiteralPath $target
+if ($isDirectory) {
+  [System.IO.Directory]::SetAccessControl($target, $acl)
+  $verified = [System.IO.Directory]::GetAccessControl($target)
+} else {
+  [System.IO.File]::SetAccessControl($target, $acl)
+  $verified = [System.IO.File]::GetAccessControl($target)
+}
 $rules = @($verified.GetAccessRules($true, $true, [System.Security.Principal.SecurityIdentifier]))
 if (-not $verified.AreAccessRulesProtected -or $rules.Count -ne 1) { exit 41 }
 if ($rules[0].IdentityReference.Value -ne $sid.Value) { exit 42 }

--- a/packages/agent/src/rfc64/inventory-v1/open.ts
+++ b/packages/agent/src/rfc64/inventory-v1/open.ts
@@ -269,8 +269,13 @@ class InventoryV1Foundation implements Rfc64InventoryV1Foundation {
     }
     this.#database = null;
     try {
-      beginQuarantine(this.databasePath, this.lifecycle);
-      finishPendingQuarantine(this.sqlite, this.databasePath, this.lifecycle);
+      const freshMarker = beginQuarantine(this.databasePath, this.lifecycle);
+      finishPendingQuarantine(
+        this.sqlite,
+        this.databasePath,
+        this.lifecycle,
+        freshMarker,
+      );
       this.#database = openOrRebuildOwnedDatabase(
         this.sqlite,
         this.databasePath,
@@ -666,8 +671,8 @@ function openOrRebuildOwnedDatabase(
       assertDatabaseQuiescent(database, lifecycle);
       closeInventoryTarget(database, 'automatic-schema-quarantine', lifecycle);
       database = null;
-      beginQuarantine(databasePath, lifecycle);
-      finishPendingQuarantine(sqlite, databasePath, lifecycle);
+      const freshMarker = beginQuarantine(databasePath, lifecycle);
+      finishPendingQuarantine(sqlite, databasePath, lifecycle, freshMarker);
       return openOrRebuildOwnedDatabase(sqlite, databasePath, lifecycle);
     }
     applyAndVerifyPragmas(database);
@@ -745,8 +750,8 @@ function openOrRebuildOwnedDatabase(
       }
       closeInventoryTarget(database, 'automatic-corrupt-quarantine', lifecycle);
       database = null;
-      beginQuarantine(databasePath, lifecycle);
-      finishPendingQuarantine(sqlite, databasePath, lifecycle);
+      const freshMarker = beginQuarantine(databasePath, lifecycle);
+      finishPendingQuarantine(sqlite, databasePath, lifecycle, freshMarker);
       return openOrRebuildOwnedDatabase(sqlite, databasePath, lifecycle);
     }
     closeProbe();
@@ -1410,6 +1415,13 @@ interface RecoveryTopologyV1 {
   readonly movedCount: number;
 }
 
+interface FreshRecoveryMarkerAuthorizationV1 {
+  readonly databasePath: string;
+  readonly markerPath: string;
+  readonly quarantineDirectory: string;
+  readonly members: RecoveryMembersV1;
+}
+
 function assertQuarantineDurabilityAvailable(
   lifecycle: InventoryV1LifecycleAdapter,
 ): void {
@@ -1428,12 +1440,12 @@ function assertQuarantineDurabilityAvailable(
 function beginQuarantine(
   databasePath: string,
   lifecycle: InventoryV1LifecycleAdapter,
-): void {
+): FreshRecoveryMarkerAuthorizationV1 | null {
   assertQuarantineDurabilityAvailable(lifecycle);
   const markerPath = recoveryMarkerPath(databasePath);
   if (pathEntryExists(markerPath)) {
     rejectSymlink(markerPath, 'inventory recovery marker');
-    return;
+    return null;
   }
   const members = inspectSourceMembersForNewMarker(databasePath);
   for (const member of members) {
@@ -1480,12 +1492,19 @@ function beginQuarantine(
   lifecycle.boundary('begin.marker.file-fsync');
   fsyncDirectory(inventoryDirectory);
   lifecycle.boundary('begin.inventory-directory.fsync-after-marker');
+  return Object.freeze({
+    databasePath,
+    markerPath,
+    quarantineDirectory,
+    members,
+  });
 }
 
 function finishPendingQuarantine(
   sqlite: SqliteModuleV1,
   databasePath: string,
   lifecycle: InventoryV1LifecycleAdapter,
+  freshMarkerAuthorization: FreshRecoveryMarkerAuthorizationV1 | null = null,
 ): void {
   const markerPath = recoveryMarkerPath(databasePath);
   if (!pathEntryExists(markerPath)) return;
@@ -1507,6 +1526,14 @@ function finishPendingQuarantine(
     readBoundedRecoveryMarker(markerPath),
     inventoryDirectory,
   );
+  const sourceQuiescenceAlreadyProven = freshMarkerAuthorization !== null
+    && freshMarkerAuthorization.databasePath === databasePath
+    && freshMarkerAuthorization.markerPath === markerPath
+    && freshMarkerAuthorization.quarantineDirectory === marker.quarantineDirectory
+    && freshMarkerAuthorization.members.length === marker.members.length
+    && freshMarkerAuthorization.members.every(
+      (member, index) => marker.members[index] === member,
+    );
   if (!pathEntryExists(marker.quarantineDirectory)) {
     throw new InventoryV1OpenError(
       'database-io',
@@ -1517,6 +1544,12 @@ function finishPendingQuarantine(
   assertSameFilesystem(inventoryDirectory, marker.quarantineDirectory, 'inventory quarantine generation');
 
   let topology = inspectRecoveryTopology(marker, databasePath);
+  if (
+    marker.members[0] === 'journal'
+    && topology.movedCount < marker.members.length
+  ) {
+    assertRollbackJournalMainHeader(databasePath);
+  }
   // A crash may have occurred after rename but before that move's file or
   // directory barriers. Re-establish durability for the observed moved prefix
   // before either continuing or deleting the marker.
@@ -1529,7 +1562,20 @@ function finishPendingQuarantine(
     // untouched. Once the first prefix member has moved, that durable prefix
     // is the restart witness that this proof completed before any rename.
     if (marker.members[0] === 'journal') {
-      assertPendingRollbackJournalUnitQuiescent(sqlite, databasePath, lifecycle);
+      // SQLite 3.39+ canonicalizes /dev/fd and /proc/self/fd aliases before
+      // opening the database. An alias probe can therefore derive the real
+      // source journal pathname and recover, zero, or delete the evidence it
+      // is meant to protect. A freshly created marker may continue because
+      // its caller proved target exclusivity before close and still holds the
+      // lifetime DK6L lease. A zero-move marker reached after restart has no
+      // equally non-mutating proof primitive in Node 22.5, so preserve the
+      // complete unit and require offline recovery.
+      if (!sourceQuiescenceAlreadyProven) {
+        throw new InventoryV1OpenError(
+          'durability-unavailable',
+          'zero-move rollback-journal recovery requires offline exclusivity proof',
+        );
+      }
     } else {
       assertPendingUnitQuiescent(sqlite, databasePath, lifecycle);
     }
@@ -1622,7 +1668,24 @@ function inspectSourceMembersForNewMarker(databasePath: string): RecoveryMembers
     assertOwnedRegularFile(source, `inventory ${member} evidence`);
     present.push(member);
   }
+  if (present[0] === 'journal') {
+    assertRollbackJournalMainHeader(databasePath);
+  }
   return assertRecoveryMembers(present);
+}
+
+function assertRollbackJournalMainHeader(databasePath: string): void {
+  const identity = readValidSqliteHeaderIdentity(databasePath);
+  if (
+    identity === null
+    || identity.writeVersion !== 1
+    || identity.readVersion !== 1
+  ) {
+    throw new InventoryV1OpenError(
+      'ambiguous-database',
+      'rollback-journal evidence with a non-rollback main header requires offline recovery',
+    );
+  }
 }
 
 function inspectRecoveryTopology(
@@ -1755,117 +1818,6 @@ function assertPendingUnitQuiescent(
     if (database !== null) {
       closeInventoryTarget(database, 'pending-quarantine-probe', lifecycle);
     }
-  }
-}
-
-function assertPendingRollbackJournalUnitQuiescent(
-  sqlite: SqliteModuleV1,
-  databasePath: string,
-  lifecycle: InventoryV1LifecycleAdapter,
-): void {
-  if (!pathEntryExists(databasePath)) {
-    throw new InventoryV1OpenError(
-      'database-io',
-      'pending rollback-journal quarantine has no source main',
-    );
-  }
-  rejectOwnedFileSymlinks(databasePath);
-  assertOwnedUnitOwners(databasePath);
-
-  // Opening the main database by its ordinary pathname can recover or delete
-  // its rollback journal before SQLite reports whether another process owns a
-  // writer lock. Instead, open the already-validated main inode through this
-  // process's descriptor namespace. SQLite locks the same inode, while its
-  // derived journal pathname is the descriptor alias and therefore cannot
-  // consume or rename the source `-journal` evidence. Quarantine is available
-  // only under the certified POSIX capability, where /dev/fd (or Linux's
-  // equivalent /proc/self/fd) provides this same-inode alias.
-  let descriptor: number | undefined;
-  let database: DatabaseSyncV1 | null = null;
-  let transactionOpen = false;
-  try {
-    descriptor = openSync(databasePath, 'r+');
-    const sourceIdentity = fstatSync(descriptor);
-    if (!sourceIdentity.isFile()) {
-      throw new InventoryV1OpenError(
-        'database-io',
-        'pending rollback-journal source main is not a regular file',
-      );
-    }
-    const aliasCandidates = [
-      `/dev/fd/${descriptor}`,
-      ...(process.platform === 'linux' ? [`/proc/self/fd/${descriptor}`] : []),
-    ];
-    let descriptorAlias: string | undefined;
-    for (const candidate of aliasCandidates) {
-      let aliasDescriptor: number | undefined;
-      try {
-        aliasDescriptor = openSync(candidate, 'r+');
-        const aliasIdentity = fstatSync(aliasDescriptor);
-        if (
-          aliasIdentity.isFile()
-          && aliasIdentity.dev === sourceIdentity.dev
-          && aliasIdentity.ino === sourceIdentity.ino
-        ) {
-          descriptorAlias = candidate;
-          break;
-        }
-      } catch {
-        // Try the next fixed descriptor namespace alias.
-      } finally {
-        if (aliasDescriptor !== undefined) closeSync(aliasDescriptor);
-      }
-    }
-    if (descriptorAlias === undefined) {
-      throw new InventoryV1OpenError(
-        'durability-unavailable',
-        'certified POSIX quarantine cannot address the source main through a same-inode descriptor alias',
-      );
-    }
-
-    database = new sqlite.DatabaseSync(descriptorAlias);
-    database.exec('PRAGMA busy_timeout = 0');
-    database.exec('BEGIN EXCLUSIVE');
-    transactionOpen = true;
-    database.exec('ROLLBACK');
-    transactionOpen = false;
-    database.close();
-    database = null;
-
-    const finalIdentity = fstatSync(descriptor);
-    if (
-      !finalIdentity.isFile()
-      || finalIdentity.dev !== sourceIdentity.dev
-      || finalIdentity.ino !== sourceIdentity.ino
-    ) {
-      throw new InventoryV1OpenError(
-        'database-io',
-        'pending rollback-journal source main changed during the exclusivity proof',
-      );
-    }
-    lifecycle.boundary('target-exclusivity-proven');
-  } catch (cause) {
-    if (transactionOpen && database !== null) {
-      try { database.exec('ROLLBACK'); } catch { /* retain the proof failure */ }
-    }
-    if (cause instanceof InventoryV1OpenError) throw cause;
-    if (isBusySqliteError(cause)) {
-      throw new InventoryV1OpenError(
-        'database-busy',
-        'pending rollback-journal quarantine still has an active SQLite holder',
-        { cause },
-      );
-    }
-    throw new InventoryV1OpenError(
-      'database-io',
-      'cannot prove exclusive access to the pending rollback-journal unit',
-      { cause },
-    );
-  } finally {
-    if (database !== null) {
-      try { database.close(); } catch { /* retain any primary proof failure */ }
-    }
-    if (descriptor !== undefined) closeSync(descriptor);
   }
 }
 
@@ -2046,6 +1998,8 @@ type CorruptDatabaseOwnershipV1 = 'owned' | 'ambiguous' | 'foreign' | 'newer';
 interface SqliteHeaderIdentityV1 {
   applicationId: number;
   userVersion: number;
+  writeVersion: number;
+  readVersion: number;
 }
 
 function classifyCorruptDatabaseOwnership(databasePath: string): CorruptDatabaseOwnershipV1 {
@@ -2068,6 +2022,8 @@ function readValidSqliteHeaderIdentity(databasePath: string): SqliteHeaderIdenti
     return {
       applicationId: header.readUInt32BE(68),
       userVersion: header.readUInt32BE(60),
+      writeVersion: header[18],
+      readVersion: header[19],
     };
   } catch (cause) {
     throw new InventoryV1OpenError(

--- a/packages/agent/src/rfc64/inventory-v1/scalars.ts
+++ b/packages/agent/src/rfc64/inventory-v1/scalars.ts
@@ -1,0 +1,152 @@
+import {
+  MAX_DECIMAL_U64,
+  MAX_DECIMAL_U256,
+  assertCanonicalDecimalU64,
+  assertCanonicalDecimalU256,
+  assertCanonicalDigest,
+  type DecimalU64V1,
+  type DecimalU256V1,
+  type Digest32V1,
+  type EvmAddressV1,
+} from '@origintrail-official/dkg-core';
+
+const EVM_ADDRESS_V1 = /^0x[0-9a-f]{40}$/;
+const ZERO_EVM_ADDRESS_V1 = `0x${'00'.repeat(20)}`;
+
+export class InventoryV1ScalarError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InventoryV1ScalarError';
+  }
+}
+
+export function decimalU64ToSqlBlobV1(value: DecimalU64V1): Uint8Array {
+  assertCanonicalDecimalU64(value, 'u64');
+  return unsignedBigIntToFixedWidth(BigInt(value), 8, MAX_DECIMAL_U64, 'u64');
+}
+
+export function decimalU256ToSqlBlobV1(value: DecimalU256V1): Uint8Array {
+  assertCanonicalDecimalU256(value, 'u256');
+  return unsignedBigIntToFixedWidth(BigInt(value), 32, MAX_DECIMAL_U256, 'u256');
+}
+
+export function sqlBlobToDecimalU64V1(value: unknown): DecimalU64V1 {
+  const decoded = fixedWidthToUnsignedBigInt(value, 8, 'u64').toString();
+  assertCanonicalDecimalU64(decoded, 'u64');
+  return decoded as DecimalU64V1;
+}
+
+export function sqlBlobToDecimalU256V1(value: unknown): DecimalU256V1 {
+  const decoded = fixedWidthToUnsignedBigInt(value, 32, 'u256').toString();
+  assertCanonicalDecimalU256(decoded, 'u256');
+  return decoded as DecimalU256V1;
+}
+
+export function digest32ToSqlBlobV1(value: Digest32V1): Uint8Array {
+  assertCanonicalDigest(value, 'digest');
+  return lowerHexToBytes(value.slice(2), 32, 'digest');
+}
+
+export function sqlBlobToDigest32V1(value: unknown): Digest32V1 {
+  const digest = `0x${bytesToLowerHex(assertSqlBlobWidthV1(value, 32, 'digest'))}`;
+  assertCanonicalDigest(digest, 'digest');
+  return digest;
+}
+
+export function evmAddressToSqlBlobV1(value: EvmAddressV1): Uint8Array {
+  assertEvmAddressV1(value);
+  return lowerHexToBytes(value.slice(2), 20, 'address');
+}
+
+export function sqlBlobToEvmAddressV1(value: unknown): EvmAddressV1 {
+  const address = `0x${bytesToLowerHex(assertSqlBlobWidthV1(value, 20, 'address'))}`;
+  assertEvmAddressV1(address);
+  return address;
+}
+
+export function nullableIdentifierToSqlTextV1(
+  value: string | null,
+  assertIdentifier: (candidate: unknown) => void,
+): string | null {
+  if (value === null) return null;
+  assertIdentifier(value);
+  if (value.normalize('NFC') !== value) {
+    throw new InventoryV1ScalarError('identifier must already be NFC normalized');
+  }
+  return value;
+}
+
+export function assertSqlBlobWidthV1(
+  value: unknown,
+  width: number,
+  label: string,
+): Uint8Array {
+  if (!(value instanceof Uint8Array) || value.byteLength !== width) {
+    throw new InventoryV1ScalarError(`${label} must be an exact ${width}-byte SQL BLOB`);
+  }
+  return new Uint8Array(value.buffer, value.byteOffset, value.byteLength).slice();
+}
+
+export function sqlBlobsEqualV1(left: unknown, right: unknown): boolean {
+  if (!(left instanceof Uint8Array)) return false;
+  if (!(right instanceof Uint8Array)) return false;
+  if (left.byteLength !== right.byteLength) return false;
+  const leftBytes = new Uint8Array(left.buffer, left.byteOffset, left.byteLength);
+  const rightBytes = new Uint8Array(right.buffer, right.byteOffset, right.byteLength);
+  for (let index = 0; index < leftBytes.byteLength; index += 1) {
+    if (leftBytes[index] !== rightBytes[index]) return false;
+  }
+  return true;
+}
+
+function unsignedBigIntToFixedWidth(
+  value: bigint,
+  width: number,
+  maximum: bigint,
+  label: string,
+): Uint8Array {
+  if (value < 0n || value > maximum) {
+    throw new InventoryV1ScalarError(`${label} is outside its unsigned range`);
+  }
+  const result = new Uint8Array(width);
+  let remaining = value;
+  for (let index = width - 1; index >= 0; index -= 1) {
+    result[index] = Number(remaining & 0xffn);
+    remaining >>= 8n;
+  }
+  return result;
+}
+
+function fixedWidthToUnsignedBigInt(value: unknown, width: number, label: string): bigint {
+  const bytes = assertSqlBlobWidthV1(value, width, label);
+  let result = 0n;
+  for (const byte of bytes) result = (result << 8n) | BigInt(byte);
+  return result;
+}
+
+function lowerHexToBytes(value: string, width: number, label: string): Uint8Array {
+  if (value.length !== width * 2 || !/^[0-9a-f]+$/.test(value)) {
+    throw new InventoryV1ScalarError(`${label} must be ${width} lowercase hex bytes`);
+  }
+  const result = new Uint8Array(width);
+  for (let index = 0; index < width; index += 1) {
+    result[index] = Number.parseInt(value.slice(index * 2, index * 2 + 2), 16);
+  }
+  return result;
+}
+
+function bytesToLowerHex(value: Uint8Array): string {
+  let result = '';
+  for (const byte of value) result += byte.toString(16).padStart(2, '0');
+  return result;
+}
+
+function assertEvmAddressV1(value: unknown): asserts value is EvmAddressV1 {
+  if (
+    typeof value !== 'string'
+    || !EVM_ADDRESS_V1.test(value)
+    || value === ZERO_EVM_ADDRESS_V1
+  ) {
+    throw new InventoryV1ScalarError('address must be a lowercase nonzero 20-byte EVM address');
+  }
+}

--- a/packages/agent/src/rfc64/inventory-v1/sql.ts
+++ b/packages/agent/src/rfc64/inventory-v1/sql.ts
@@ -4,6 +4,31 @@ export const INVENTORY_V1_RELATIVE_PATH = 'rfc64-sync/inventory-v1.sqlite3';
 export const INVENTORY_V1_DIRECTORY_MODE = 0o700;
 export const INVENTORY_V1_FILE_MODE = 0o600;
 
+// SQL-1 stores protocol integers only as canonical fixed-width big-endian
+// BLOBs. Decode the bounded low hexadecimal suffix with SQLite core built-ins
+// solely inside the relational CHECK below; no redundant numeric authority,
+// extension function, trigger, or connection-local UDF is introduced.
+function unsignedHexSuffixIntegerSql(column: string, nibbles: number): string {
+  const firstPosition = 17 - nibbles;
+  return Array.from({ length: nibbles }, (_unused, index) => {
+    const position = firstPosition + index;
+    const multiplier = 16 ** (nibbles - index - 1);
+    return `((instr('0123456789ABCDEF', substr(hex(${column}), ${position}, 1)) - 1) * ${multiplier})`;
+  }).join(' + ');
+}
+
+const TRANSFER_BYTE_LENGTH_INTEGER_SQL = unsignedHexSuffixIntegerSql(
+  'transfer_byte_length_u64be',
+  8,
+);
+const TRANSFER_CHUNK_COUNT_INTEGER_SQL = unsignedHexSuffixIntegerSql(
+  'transfer_chunk_count_u64be',
+  4,
+);
+const TRANSFER_CHUNK_GEOMETRY_CHECK_SQL =
+  `((${TRANSFER_BYTE_LENGTH_INTEGER_SQL}) + 262143) / 262144`
+  + ` = (${TRANSFER_CHUNK_COUNT_INTEGER_SQL})`;
+
 export const INVENTORY_V1_LOADS_TABLE_SQL = `
 CREATE TABLE rfc64_candidate_bucket_loads_v1 (
   session_id BLOB NOT NULL
@@ -183,6 +208,7 @@ CREATE TABLE rfc64_candidate_bucket_rows_v1 (
   transfer_chunk_count_u64be BLOB NOT NULL CHECK (
     typeof(transfer_chunk_count_u64be) = 'blob' AND length(transfer_chunk_count_u64be) = 8
     AND transfer_chunk_count_u64be >= x'0000000000000001' AND transfer_chunk_count_u64be <= x'0000000000001000'
+    AND ${TRANSFER_CHUNK_GEOMETRY_CHECK_SQL}
   ),
 
   transfer_blob_digest BLOB NOT NULL

--- a/packages/agent/src/rfc64/inventory-v1/sql.ts
+++ b/packages/agent/src/rfc64/inventory-v1/sql.ts
@@ -1,0 +1,270 @@
+export const INVENTORY_V1_APPLICATION_ID = 0x444b3634;
+export const INVENTORY_V1_USER_VERSION = 1;
+export const INVENTORY_V1_RELATIVE_PATH = 'rfc64-sync/inventory-v1.sqlite3';
+export const INVENTORY_V1_DIRECTORY_MODE = 0o700;
+export const INVENTORY_V1_FILE_MODE = 0o600;
+
+export const INVENTORY_V1_LOADS_TABLE_SQL = `
+CREATE TABLE rfc64_candidate_bucket_loads_v1 (
+  session_id BLOB NOT NULL
+    CHECK (
+      typeof(session_id) = 'blob'
+      AND length(session_id) = 32
+      AND session_id <> zeroblob(32)
+    ),
+
+  catalog_scope_digest BLOB NOT NULL
+    CHECK (
+      typeof(catalog_scope_digest) = 'blob'
+      AND length(catalog_scope_digest) = 32
+    ),
+
+  author_address BLOB NOT NULL
+    CHECK (
+      typeof(author_address) = 'blob'
+      AND length(author_address) = 20
+      AND author_address <> zeroblob(20)
+    ),
+
+  target_catalog_head_digest BLOB NOT NULL
+    CHECK (
+      typeof(target_catalog_head_digest) = 'blob'
+      AND length(target_catalog_head_digest) = 32
+    ),
+
+  subgraph_name TEXT
+    CHECK (
+      subgraph_name IS NULL
+      OR (typeof(subgraph_name) = 'text' AND length(subgraph_name) > 0)
+    ),
+
+  catalog_era_u64be BLOB NOT NULL
+    CHECK (
+      typeof(catalog_era_u64be) = 'blob'
+      AND length(catalog_era_u64be) = 8
+    ),
+
+  bucket_count_u64be BLOB NOT NULL CHECK (
+    typeof(bucket_count_u64be) = 'blob' AND length(bucket_count_u64be) = 8
+    AND bucket_count_u64be >= x'0000000000000001' AND bucket_count_u64be <= x'8000000000000000'
+  ),
+
+  bucket_id_u64be BLOB NOT NULL CHECK (
+    typeof(bucket_id_u64be) = 'blob' AND length(bucket_id_u64be) = 8 AND bucket_id_u64be < bucket_count_u64be
+  ),
+
+  bucket_object_digest BLOB NOT NULL
+    CHECK (
+      typeof(bucket_object_digest) = 'blob'
+      AND length(bucket_object_digest) = 32
+    ),
+
+  row_count_u64be BLOB NOT NULL
+    CHECK (
+      typeof(row_count_u64be) = 'blob'
+      AND length(row_count_u64be) = 8
+    ),
+
+  payload_byte_length_u64be BLOB NOT NULL CHECK (
+    typeof(payload_byte_length_u64be) = 'blob' AND length(payload_byte_length_u64be) = 8
+  ),
+
+  CHECK (
+    (
+      bucket_object_digest = zeroblob(32)
+      AND row_count_u64be = zeroblob(8)
+      AND payload_byte_length_u64be = zeroblob(8)
+    )
+    OR
+    (
+      bucket_object_digest <> zeroblob(32)
+      AND row_count_u64be >= x'0000000000000001'
+      AND row_count_u64be <= x'0000000000000400'
+      AND payload_byte_length_u64be >= x'0000000000000001'
+      AND payload_byte_length_u64be <= x'0000000000100000'
+    )
+  ),
+
+  PRIMARY KEY (
+    session_id,
+    catalog_scope_digest,
+    author_address,
+    target_catalog_head_digest,
+    bucket_id_u64be
+  )
+) WITHOUT ROWID, STRICT`;
+
+export const INVENTORY_V1_ROWS_TABLE_SQL = `
+CREATE TABLE rfc64_candidate_bucket_rows_v1 (
+  session_id BLOB NOT NULL
+    CHECK (
+      typeof(session_id) = 'blob'
+      AND length(session_id) = 32
+      AND session_id <> zeroblob(32)
+    ),
+
+  catalog_scope_digest BLOB NOT NULL
+    CHECK (
+      typeof(catalog_scope_digest) = 'blob'
+      AND length(catalog_scope_digest) = 32
+    ),
+
+  author_address BLOB NOT NULL
+    CHECK (
+      typeof(author_address) = 'blob'
+      AND length(author_address) = 20
+      AND author_address <> zeroblob(20)
+    ),
+
+  target_catalog_head_digest BLOB NOT NULL
+    CHECK (
+      typeof(target_catalog_head_digest) = 'blob'
+      AND length(target_catalog_head_digest) = 32
+    ),
+
+  bucket_id_u64be BLOB NOT NULL
+    CHECK (
+      typeof(bucket_id_u64be) = 'blob'
+      AND length(bucket_id_u64be) = 8
+    ),
+
+  ka_id_u256be BLOB NOT NULL
+    CHECK (
+      typeof(ka_id_u256be) = 'blob'
+      AND length(ka_id_u256be) = 32
+    ),
+
+  catalog_key_digest BLOB NOT NULL
+    CHECK (
+      typeof(catalog_key_digest) = 'blob'
+      AND length(catalog_key_digest) = 32
+    ),
+
+  assertion_coordinate TEXT NOT NULL COLLATE BINARY
+    CHECK (
+      typeof(assertion_coordinate) = 'text'
+      AND length(assertion_coordinate) > 0
+    ),
+
+  assertion_version_u64be BLOB NOT NULL
+    CHECK (
+      typeof(assertion_version_u64be) = 'blob'
+      AND length(assertion_version_u64be) = 8
+    ),
+
+  projection_id TEXT NOT NULL
+    CHECK (projection_id = 'cg-shared-v1'),
+
+  projection_digest BLOB NOT NULL
+    CHECK (
+      typeof(projection_digest) = 'blob'
+      AND length(projection_digest) = 32
+    ),
+
+  seal_digest BLOB NOT NULL
+    CHECK (
+      typeof(seal_digest) = 'blob'
+      AND length(seal_digest) = 32
+    ),
+
+  transfer_codec TEXT NOT NULL
+    CHECK (transfer_codec = 'dkg-ka-bundle-v1'),
+
+  transfer_byte_length_u64be BLOB NOT NULL CHECK (
+    typeof(transfer_byte_length_u64be) = 'blob' AND length(transfer_byte_length_u64be) = 8
+    AND transfer_byte_length_u64be >= x'0000000000000010' AND transfer_byte_length_u64be <= x'0000000040000000'
+  ),
+
+  transfer_chunk_size_u64be BLOB NOT NULL
+    CHECK (
+      transfer_chunk_size_u64be = x'0000000000040000'
+    ),
+
+  transfer_chunk_count_u64be BLOB NOT NULL CHECK (
+    typeof(transfer_chunk_count_u64be) = 'blob' AND length(transfer_chunk_count_u64be) = 8
+    AND transfer_chunk_count_u64be >= x'0000000000000001' AND transfer_chunk_count_u64be <= x'0000000000001000'
+  ),
+
+  transfer_blob_digest BLOB NOT NULL
+    CHECK (
+      typeof(transfer_blob_digest) = 'blob'
+      AND length(transfer_blob_digest) = 32
+    ),
+
+  transfer_chunk_tree_root BLOB NOT NULL
+    CHECK (
+      typeof(transfer_chunk_tree_root) = 'blob'
+      AND length(transfer_chunk_tree_root) = 32
+    ),
+
+  expected_catalog_row_digest BLOB NOT NULL CHECK (
+    typeof(expected_catalog_row_digest) = 'blob' AND length(expected_catalog_row_digest) = 32
+  ),
+
+  PRIMARY KEY (
+    session_id,
+    catalog_scope_digest,
+    author_address,
+    target_catalog_head_digest,
+    ka_id_u256be
+  ),
+
+  UNIQUE (
+    session_id,
+    catalog_scope_digest,
+    author_address,
+    target_catalog_head_digest,
+    catalog_key_digest
+  ),
+
+  UNIQUE (
+    session_id,
+    catalog_scope_digest,
+    author_address,
+    target_catalog_head_digest,
+    assertion_coordinate
+  ),
+
+  FOREIGN KEY (
+    session_id,
+    catalog_scope_digest,
+    author_address,
+    target_catalog_head_digest,
+    bucket_id_u64be
+  )
+  REFERENCES rfc64_candidate_bucket_loads_v1 (
+    session_id,
+    catalog_scope_digest,
+    author_address,
+    target_catalog_head_digest,
+    bucket_id_u64be
+  )
+  ON DELETE CASCADE
+) WITHOUT ROWID, STRICT`;
+
+export const INVENTORY_V1_BUCKET_INDEX_SQL = `
+CREATE INDEX rfc64_candidate_bucket_rows_by_bucket_v1
+ON rfc64_candidate_bucket_rows_v1 (
+  session_id,
+  catalog_scope_digest,
+  author_address,
+  target_catalog_head_digest,
+  bucket_id_u64be,
+  ka_id_u256be
+)`;
+
+export const INVENTORY_V1_DDL = [
+  INVENTORY_V1_LOADS_TABLE_SQL,
+  INVENTORY_V1_ROWS_TABLE_SQL,
+  INVENTORY_V1_BUCKET_INDEX_SQL,
+].join(';\n\n').concat(';');
+
+export const INVENTORY_V1_USER_OBJECTS: Readonly<Record<string, string>> = Object.freeze({
+  rfc64_candidate_bucket_loads_v1: normalizeInventoryV1SchemaSql(INVENTORY_V1_LOADS_TABLE_SQL),
+  rfc64_candidate_bucket_rows_v1: normalizeInventoryV1SchemaSql(INVENTORY_V1_ROWS_TABLE_SQL),
+  rfc64_candidate_bucket_rows_by_bucket_v1: normalizeInventoryV1SchemaSql(INVENTORY_V1_BUCKET_INDEX_SQL),
+});
+
+export function normalizeInventoryV1SchemaSql(sql: string): string {
+  return sql.replace(/\s+/g, ' ').trim().replace(/;$/, '');
+}

--- a/packages/agent/test/fixtures/rfc64-inventory-v1-child.ts
+++ b/packages/agent/test/fixtures/rfc64-inventory-v1-child.ts
@@ -1,0 +1,168 @@
+import {
+  appendFileSync,
+  chmodSync,
+  existsSync,
+  lstatSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+  writeSync,
+} from 'node:fs';
+import { createHash } from 'node:crypto';
+import { DatabaseSync } from 'node:sqlite';
+import { dirname, join, relative, resolve } from 'node:path';
+
+import {
+  INVENTORY_V1_POSIX_QUARANTINE_CAPABILITY,
+  InventoryV1OpenError,
+  createInventoryV1TestOpener,
+  openInventoryV1,
+} from '../../src/rfc64/inventory-v1/open.js';
+import {
+  type InventoryV1QuarantineBoundary,
+} from '../../src/rfc64/inventory-v1/lifecycle-adapter.js';
+import { INVENTORY_V1_RELATIVE_PATH } from '../../src/rfc64/inventory-v1/sql.js';
+
+const mode = requiredEnvironment('DKG_RFC64_CHILD_MODE');
+const dataDirectory = requiredEnvironment('DKG_RFC64_CHILD_DATA_DIR');
+
+if (mode === 'fault') {
+  const targetBoundary = requiredEnvironment(
+    'DKG_RFC64_CHILD_BOUNDARY',
+  ) as InventoryV1QuarantineBoundary;
+  const tracePath = requiredEnvironment('DKG_RFC64_CHILD_TRACE');
+  const targetPath = resolve(dataDirectory, INVENTORY_V1_RELATIVE_PATH);
+  const openForFault = createInventoryV1TestOpener({
+    quarantineCapability: INVENTORY_V1_POSIX_QUARANTINE_CAPABILITY,
+    boundary: (boundary) => {
+      appendFileSync(
+        tracePath,
+        `${JSON.stringify({ boundary, topology: snapshotTopology(dataDirectory) })}\n`,
+      );
+      if (boundary !== targetBoundary) return;
+      if (process.env.DKG_RFC64_CHILD_PROTECT_EVIDENCE === '1') {
+        // Synthetic empty WAL/SHM fixtures are not owned by a live SQLite
+        // connection. Make their names stable across forced process teardown;
+        // the parent restores the production directory mode before recovery.
+        chmodSync(dirname(targetPath), 0o500);
+      }
+      writeSync(process.stdout.fd, `BOUNDARY:${boundary}\n`);
+      // Deliberately pause inside the real lifecycle adapter. The parent must
+      // terminate this process with SIGKILL; no JavaScript cleanup runs.
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0);
+    },
+    closeTarget: (close, reason) => {
+      close();
+      if (
+        process.env.DKG_RFC64_CHILD_SYNTHETIC_FULL_MANIFEST !== undefined
+        && reason === 'automatic-schema-quarantine'
+      ) {
+        const hostile = process.env.DKG_RFC64_CHILD_SYNTHETIC_FULL_MANIFEST === 'hostile';
+        writeFileSync(
+          `${targetPath}-wal`,
+          hostile
+            ? Buffer.from('hostile-rfc64-wal-evidence\0\u0001\u0002', 'utf8')
+            : Buffer.alloc(0),
+        );
+        writeFileSync(
+          `${targetPath}-shm`,
+          hostile
+            ? Buffer.from('hostile-rfc64-shm-evidence\0\u0003\u0004', 'utf8')
+            : Buffer.alloc(0),
+        );
+      }
+    },
+  });
+  await openForFault(dataDirectory);
+  throw new Error(`fault boundary was not reached: ${targetBoundary}`);
+} else if (mode === 'reopen') {
+  const foundation = await openInventoryV1(dataDirectory, {
+    quarantineCapability: INVENTORY_V1_POSIX_QUARANTINE_CAPABILITY,
+  });
+  foundation.close();
+  process.stdout.write('OPEN\n');
+} else if (mode === 'contender') {
+  const targetPath = resolve(dataDirectory, INVENTORY_V1_RELATIVE_PATH);
+  const leasePath = join(dirname(targetPath), 'inventory-v1.lease.sqlite3');
+  let directLease = 'OPEN';
+  const directLeaseDatabase = new DatabaseSync(leasePath);
+  try {
+    directLeaseDatabase.exec('PRAGMA busy_timeout = 0; BEGIN EXCLUSIVE; ROLLBACK');
+  } catch (error) {
+    if ((error as { errcode?: unknown }).errcode === 5) directLease = 'BUSY';
+    else throw error;
+  } finally {
+    directLeaseDatabase.close();
+  }
+  const target = new DatabaseSync(targetPath);
+  let targetTransaction = 'BUSY';
+  try {
+    target.exec('PRAGMA busy_timeout = 0; BEGIN IMMEDIATE; ROLLBACK');
+    targetTransaction = 'FREE';
+  } finally {
+    target.close();
+  }
+
+  let lease = 'OPEN';
+  try {
+    const foundation = await openInventoryV1(dataDirectory, {
+      quarantineCapability: INVENTORY_V1_POSIX_QUARANTINE_CAPABILITY,
+    });
+    foundation.close();
+  } catch (error) {
+    if (error instanceof InventoryV1OpenError && error.code === 'database-busy') {
+      lease = 'BUSY';
+    } else {
+      throw error;
+    }
+  }
+  process.stdout.write(`${JSON.stringify({ directLease, targetTransaction, lease })}\n`);
+} else {
+  throw new Error(`unsupported RFC-64 inventory child mode: ${mode}`);
+}
+
+function requiredEnvironment(name: string): string {
+  const value = process.env[name];
+  if (value === undefined || value.length === 0) {
+    throw new Error(`missing required environment variable ${name}`);
+  }
+  return value;
+}
+
+interface TopologyEntry {
+  readonly path: string;
+  readonly kind: 'file' | 'directory' | 'other';
+  readonly size: number;
+  readonly dev: number;
+  readonly ino: number;
+  readonly sha256?: string;
+}
+
+function snapshotTopology(dataDir: string): TopologyEntry[] {
+  const database = resolve(dataDir, INVENTORY_V1_RELATIVE_PATH);
+  const root = dirname(database);
+  if (!existsSync(root)) return [];
+  const entries: TopologyEntry[] = [];
+  const visit = (path: string): void => {
+    const stat = lstatSync(path);
+    const kind = stat.isFile() ? 'file' : stat.isDirectory() ? 'directory' : 'other';
+    entries.push({
+      path: relative(root, path) || '.',
+      kind,
+      size: stat.size,
+      dev: stat.dev,
+      ino: stat.ino,
+      // POSIX advisory locks are process-associated and closing any extra FD
+      // for the same inode can release this process's SQLite lease locks.
+      // Never open/hash the live DK6L unit from the observation adapter.
+      ...(kind === 'file' && !path.includes('inventory-v1.lease.sqlite3')
+        ? { sha256: createHash('sha256').update(readFileSync(path)).digest('hex') }
+        : {}),
+    });
+    if (kind === 'directory') {
+      for (const name of readdirSync(path).sort()) visit(join(path, name));
+    }
+  };
+  visit(root);
+  return entries.sort((left, right) => left.path.localeCompare(right.path));
+}

--- a/packages/agent/test/fixtures/rfc64-inventory-v1-child.ts
+++ b/packages/agent/test/fixtures/rfc64-inventory-v1-child.ts
@@ -71,6 +71,15 @@ if (mode === 'fault') {
             : Buffer.alloc(0),
         );
       }
+      if (
+        process.env.DKG_RFC64_CHILD_SYNTHETIC_JOURNAL === '1'
+        && reason === 'automatic-schema-quarantine'
+      ) {
+        writeFileSync(
+          `${targetPath}-journal`,
+          Buffer.from('hostile-rfc64-journal-evidence\0\u0000\u0001', 'utf8'),
+        );
+      }
     },
   });
   await openForFault(dataDirectory);

--- a/packages/agent/test/rfc64-inventory-v1-lifecycle.test.ts
+++ b/packages/agent/test/rfc64-inventory-v1-lifecycle.test.ts
@@ -1,0 +1,419 @@
+import {
+  chmodSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  truncateSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  INVENTORY_V1_APPLICATION_ID,
+  INVENTORY_V1_DDL,
+  INVENTORY_V1_RELATIVE_PATH,
+  INVENTORY_V1_USER_OBJECTS,
+  InventoryV1OpenError,
+  normalizeInventoryV1SchemaSql,
+  openInventoryV1,
+} from '../src/rfc64/inventory-v1/index.js';
+
+const temporaryDirectories: string[] = [];
+
+function temporaryDataDirectory(): string {
+  const directory = mkdtempSync(join(tmpdir(), 'dkg-rfc64-sql1-'));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+function databasePath(dataDirectory: string): string {
+  return join(dataDirectory, INVENTORY_V1_RELATIVE_PATH);
+}
+
+function pragmaInteger(database: DatabaseSync, pragma: string): number {
+  const row = database.prepare(`PRAGMA ${pragma}`).get();
+  if (row === undefined) throw new Error(`missing PRAGMA ${pragma}`);
+  const value = Object.values(row)[0];
+  if (typeof value !== 'number') throw new Error(`invalid PRAGMA ${pragma}`);
+  return value;
+}
+
+function expectOpenErrorCode(error: unknown, code: InventoryV1OpenError['code']): boolean {
+  expect(error).toBeInstanceOf(InventoryV1OpenError);
+  expect((error as InventoryV1OpenError).code).toBe(code);
+  return true;
+}
+
+function expectNoQuarantine(path: string): void {
+  expect(existsSync(`${path}.rebuild-required`)).toBe(false);
+  expect(existsSync(join(dirname(path), 'quarantine'))).toBe(false);
+}
+
+function quarantineGenerations(path: string): string[] {
+  const root = join(dirname(path), 'quarantine');
+  if (!existsSync(root)) return [];
+  return readdirSync(root).map((name) => join(root, name));
+}
+
+function assertInitializedInventory(path: string): void {
+  const database = new DatabaseSync(path, { readOnly: true });
+  try {
+    expect(pragmaInteger(database, 'application_id')).toBe(INVENTORY_V1_APPLICATION_ID);
+    expect(pragmaInteger(database, 'user_version')).toBe(1);
+    const rows = database.prepare(
+      `SELECT name, sql FROM sqlite_schema WHERE name NOT LIKE 'sqlite_%' ORDER BY name`,
+    ).all();
+    expect(rows).toHaveLength(Object.keys(INVENTORY_V1_USER_OBJECTS).length);
+    for (const row of rows) {
+      expect(typeof row.name).toBe('string');
+      expect(typeof row.sql).toBe('string');
+      expect(normalizeInventoryV1SchemaSql(String(row.sql))).toBe(
+        INVENTORY_V1_USER_OBJECTS[String(row.name)],
+      );
+    }
+    expect(database.prepare('PRAGMA journal_mode').get()?.journal_mode).toBe('wal');
+  } finally {
+    database.close();
+  }
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe('RFC-64 inventory v1 SQLite lifecycle', () => {
+  it('initializes the exact owned schema, identity, WAL mode, and private POSIX paths', async () => {
+    const dataDirectory = temporaryDataDirectory();
+    const foundation = await openInventoryV1(dataDirectory);
+    const path = databasePath(dataDirectory);
+
+    expect(foundation.databasePath).toBe(path);
+    expect(foundation.closed).toBe(false);
+    assertInitializedInventory(path);
+    if (process.platform !== 'win32') {
+      expect(statSync(dirname(path)).mode & 0o777).toBe(0o700);
+      expect(statSync(path).mode & 0o777).toBe(0o600);
+    }
+
+    foundation.close();
+    foundation.close();
+    expect(foundation.closed).toBe(true);
+    if (process.platform !== 'win32') chmodSync(path, 0o666);
+
+    const reopened = await openInventoryV1(dataDirectory);
+    assertInitializedInventory(path);
+    if (process.platform !== 'win32') expect(statSync(path).mode & 0o777).toBe(0o600);
+    reopened.close();
+    try {
+      reopened.quarantineAndRebuild();
+      expect.unreachable('closed foundation unexpectedly rebuilt');
+    } catch (error) {
+      expectOpenErrorCode(error, 'database-closed');
+    }
+  });
+
+  it('executes the frozen DDL as STRICT tables with the named bucket index', () => {
+    const database = new DatabaseSync(':memory:');
+    try {
+      database.exec('PRAGMA foreign_keys = ON');
+      database.exec(INVENTORY_V1_DDL);
+      const objects = database.prepare(
+        `SELECT name, sql FROM sqlite_schema WHERE name NOT LIKE 'sqlite_%' ORDER BY name`,
+      ).all();
+      expect(objects).toHaveLength(3);
+      for (const object of objects) {
+        expect(normalizeInventoryV1SchemaSql(String(object.sql))).toBe(
+          INVENTORY_V1_USER_OBJECTS[String(object.name)],
+        );
+      }
+      expect(database.prepare(
+        `SELECT strict FROM pragma_table_list WHERE name = 'rfc64_candidate_bucket_loads_v1'`,
+      ).get()?.strict).toBe(1);
+      expect(database.prepare(
+        `SELECT strict FROM pragma_table_list WHERE name = 'rfc64_candidate_bucket_rows_v1'`,
+      ).get()?.strict).toBe(1);
+    } finally {
+      database.close();
+    }
+  });
+
+  it('refuses a valid foreign application_id without modifying or quarantining it', async () => {
+    const dataDirectory = temporaryDataDirectory();
+    const path = databasePath(dataDirectory);
+    mkdirSync(dirname(path), { recursive: true });
+    const foreign = new DatabaseSync(path);
+    foreign.exec('CREATE TABLE foreign_data (value TEXT); PRAGMA application_id = 305419896;');
+    foreign.close();
+    if (process.platform !== 'win32') chmodSync(path, 0o640);
+    const before = readFileSync(path);
+
+    await expect(openInventoryV1(dataDirectory)).rejects.toSatisfy((error: unknown) =>
+      expectOpenErrorCode(error, 'foreign-database'));
+
+    expect(readFileSync(path)).toEqual(before);
+    if (process.platform !== 'win32') expect(statSync(path).mode & 0o777).toBe(0o640);
+    expectNoQuarantine(path);
+    const check = new DatabaseSync(path, { readOnly: true });
+    expect(check.prepare(
+      `SELECT count(*) AS count FROM sqlite_schema WHERE name = 'foreign_data'`,
+    ).get()?.count).toBe(1);
+    check.close();
+  });
+
+  it('refuses an application_id=0 database with user objects as ambiguous', async () => {
+    const dataDirectory = temporaryDataDirectory();
+    const path = databasePath(dataDirectory);
+    mkdirSync(dirname(path), { recursive: true });
+    const ambiguous = new DatabaseSync(path);
+    ambiguous.exec('CREATE TABLE existing_data (value TEXT)');
+    ambiguous.close();
+    if (process.platform !== 'win32') chmodSync(path, 0o640);
+    const before = readFileSync(path);
+
+    await expect(openInventoryV1(dataDirectory)).rejects.toSatisfy((error: unknown) =>
+      expectOpenErrorCode(error, 'ambiguous-database'));
+    expect(readFileSync(path)).toEqual(before);
+    if (process.platform !== 'win32') expect(statSync(path).mode & 0o777).toBe(0o640);
+    expectNoQuarantine(path);
+  });
+
+  it('refuses a newer owned user_version without quarantine', async () => {
+    const dataDirectory = temporaryDataDirectory();
+    const path = databasePath(dataDirectory);
+    mkdirSync(dirname(path), { recursive: true });
+    const newer = new DatabaseSync(path);
+    newer.exec(`
+      CREATE TABLE future_schema (value TEXT);
+      PRAGMA application_id = ${INVENTORY_V1_APPLICATION_ID};
+      PRAGMA user_version = 2;
+    `);
+    newer.close();
+
+    await expect(openInventoryV1(dataDirectory)).rejects.toSatisfy((error: unknown) =>
+      expectOpenErrorCode(error, 'newer-schema'));
+    expectNoQuarantine(path);
+  });
+
+  it('quarantines an incompatible owned v1 schema and rebuilds exact v1', async () => {
+    const dataDirectory = temporaryDataDirectory();
+    const path = databasePath(dataDirectory);
+    mkdirSync(dirname(path), { recursive: true });
+    const incompatible = new DatabaseSync(path);
+    incompatible.exec(`
+      CREATE TABLE wrong_v1 (value TEXT);
+      PRAGMA application_id = ${INVENTORY_V1_APPLICATION_ID};
+      PRAGMA user_version = 1;
+    `);
+    incompatible.close();
+
+    const foundation = await openInventoryV1(dataDirectory);
+    try {
+      assertInitializedInventory(path);
+      const generations = quarantineGenerations(path);
+      expect(generations).toHaveLength(1);
+      const oldPath = join(generations[0]!, 'inventory-v1.sqlite3');
+      const old = new DatabaseSync(oldPath, { readOnly: true });
+      expect(old.prepare(
+        `SELECT count(*) AS count FROM sqlite_schema WHERE name = 'wrong_v1'`,
+      ).get()?.count).toBe(1);
+      old.close();
+      expect(existsSync(`${path}.rebuild-required`)).toBe(false);
+    } finally {
+      foundation.close();
+    }
+  });
+
+  it('quarantines NOTADB bytes at the dedicated path and preserves them as evidence', async () => {
+    const dataDirectory = temporaryDataDirectory();
+    const path = databasePath(dataDirectory);
+    mkdirSync(dirname(path), { recursive: true });
+    const corruptBytes = Buffer.from('not-a-sqlite-database\n');
+    writeFileSync(path, corruptBytes);
+
+    const foundation = await openInventoryV1(dataDirectory);
+    try {
+      assertInitializedInventory(path);
+      const generations = quarantineGenerations(path);
+      expect(generations).toHaveLength(1);
+      expect(readFileSync(join(generations[0]!, 'inventory-v1.sqlite3'))).toEqual(corruptBytes);
+    } finally {
+      foundation.close();
+    }
+  });
+
+  it('does not quarantine a corrupt SQLite file whose readable header has a foreign app id', async () => {
+    const dataDirectory = temporaryDataDirectory();
+    const path = databasePath(dataDirectory);
+    mkdirSync(dirname(path), { recursive: true });
+    const foreign = new DatabaseSync(path);
+    foreign.exec('CREATE TABLE foreign_data (value TEXT); PRAGMA application_id = 305419896;');
+    foreign.close();
+    truncateSync(path, 100);
+    const before = readFileSync(path);
+
+    await expect(openInventoryV1(dataDirectory)).rejects.toSatisfy((error: unknown) =>
+      expectOpenErrorCode(error, 'foreign-database'));
+    expect(readFileSync(path)).toEqual(before);
+    expectNoQuarantine(path);
+  });
+
+  it.runIf(process.platform !== 'win32')(
+    'refuses database, sidecar, recovery-marker, and parent symlinks without quarantine',
+    async () => {
+      const databaseLinkData = temporaryDataDirectory();
+      const databaseLinkPath = databasePath(databaseLinkData);
+      mkdirSync(dirname(databaseLinkPath), { recursive: true });
+      const databaseTarget = join(databaseLinkData, 'target.sqlite3');
+      writeFileSync(databaseTarget, 'target');
+      symlinkSync(databaseTarget, databaseLinkPath);
+      await expect(openInventoryV1(databaseLinkData)).rejects.toSatisfy((error: unknown) =>
+        expectOpenErrorCode(error, 'unsafe-path'));
+      expect(readFileSync(databaseTarget, 'utf8')).toBe('target');
+      expectNoQuarantine(databaseLinkPath);
+
+      const danglingData = temporaryDataDirectory();
+      const danglingPath = databasePath(danglingData);
+      mkdirSync(dirname(danglingPath), { recursive: true });
+      symlinkSync(join(danglingData, 'missing-target'), danglingPath);
+      await expect(openInventoryV1(danglingData)).rejects.toSatisfy((error: unknown) =>
+        expectOpenErrorCode(error, 'unsafe-path'));
+
+      const sidecarData = temporaryDataDirectory();
+      const sidecarPath = databasePath(sidecarData);
+      mkdirSync(dirname(sidecarPath), { recursive: true });
+      const database = new DatabaseSync(sidecarPath);
+      database.close();
+      const sidecarTarget = join(sidecarData, 'sidecar-target');
+      writeFileSync(sidecarTarget, 'sidecar');
+      symlinkSync(sidecarTarget, `${sidecarPath}-wal`);
+      await expect(openInventoryV1(sidecarData)).rejects.toSatisfy((error: unknown) =>
+        expectOpenErrorCode(error, 'unsafe-path'));
+      expectNoQuarantine(sidecarPath);
+
+      const directoryLinkData = temporaryDataDirectory();
+      const directoryTarget = join(directoryLinkData, 'target-directory');
+      mkdirSync(directoryTarget);
+      symlinkSync(directoryTarget, join(directoryLinkData, 'rfc64-sync'));
+      await expect(openInventoryV1(directoryLinkData)).rejects.toSatisfy((error: unknown) =>
+        expectOpenErrorCode(error, 'unsafe-path'));
+      expect(readdirSync(directoryTarget)).toEqual([]);
+
+      const markerLinkData = temporaryDataDirectory();
+      const markerLinkPath = databasePath(markerLinkData);
+      mkdirSync(dirname(markerLinkPath), { recursive: true });
+      symlinkSync(join(markerLinkData, 'missing-marker'), `${markerLinkPath}.rebuild-required`);
+      await expect(openInventoryV1(markerLinkData)).rejects.toSatisfy((error: unknown) =>
+        expectOpenErrorCode(error, 'unsafe-path'));
+    },
+  );
+
+  it('refuses orphaned sidecars without deleting them', async () => {
+    const dataDirectory = temporaryDataDirectory();
+    const path = databasePath(dataDirectory);
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(`${path}-wal`, 'orphan');
+    await expect(openInventoryV1(dataDirectory)).rejects.toSatisfy((error: unknown) =>
+      expectOpenErrorCode(error, 'ambiguous-database'));
+    expect(readFileSync(`${path}-wal`, 'utf8')).toBe('orphan');
+    expectNoQuarantine(path);
+  });
+
+  it.runIf(process.platform !== 'win32' && process.getuid?.() !== 0)(
+    'fails closed on file-permission errors without quarantine',
+    async () => {
+      const dataDirectory = temporaryDataDirectory();
+      const path = databasePath(dataDirectory);
+      mkdirSync(dirname(path), { recursive: true });
+      const database = new DatabaseSync(path);
+      database.exec(`PRAGMA application_id = ${INVENTORY_V1_APPLICATION_ID}; PRAGMA user_version = 1;`);
+      database.close();
+      chmodSync(path, 0o000);
+      try {
+        await expect(openInventoryV1(dataDirectory)).rejects.toSatisfy((error: unknown) =>
+          expectOpenErrorCode(error, 'database-io'));
+        expectNoQuarantine(path);
+      } finally {
+        chmodSync(path, 0o600);
+      }
+    },
+  );
+
+  it('refuses a busy incompatible owned database without quarantine', async () => {
+    const dataDirectory = temporaryDataDirectory();
+    const path = databasePath(dataDirectory);
+    mkdirSync(dirname(path), { recursive: true });
+    const holder = new DatabaseSync(path);
+    holder.exec(`
+      PRAGMA journal_mode = WAL;
+      CREATE TABLE wrong_v1 (value TEXT);
+      PRAGMA application_id = ${INVENTORY_V1_APPLICATION_ID};
+      PRAGMA user_version = 1;
+      BEGIN IMMEDIATE;
+    `);
+    try {
+      await expect(openInventoryV1(dataDirectory)).rejects.toSatisfy((error: unknown) =>
+        expectOpenErrorCode(error, 'database-busy'));
+      expectNoQuarantine(path);
+    } finally {
+      holder.exec('ROLLBACK');
+      holder.close();
+    }
+  });
+
+  it('resumes a partial recovery-marker move before rebuilding', async () => {
+    const dataDirectory = temporaryDataDirectory();
+    const path = databasePath(dataDirectory);
+    const inventoryDirectory = dirname(path);
+    const generation = join(
+      inventoryDirectory,
+      'quarantine',
+      'inventory-v1-1234567890-aaaaaaaaaaaaaaaa',
+    );
+    mkdirSync(generation, { recursive: true });
+    writeFileSync(join(generation, 'inventory-v1.sqlite3'), 'main-before-crash');
+    writeFileSync(`${path}-wal`, 'wal-before-crash');
+    writeFileSync(`${path}-shm`, 'shm-before-crash');
+    writeFileSync(
+      `${path}.rebuild-required`,
+      JSON.stringify({ version: 1, quarantineDirectory: generation }),
+    );
+
+    const foundation = await openInventoryV1(dataDirectory);
+    try {
+      assertInitializedInventory(path);
+      expect(readFileSync(join(generation, 'inventory-v1.sqlite3'), 'utf8')).toBe('main-before-crash');
+      expect(readFileSync(join(generation, 'inventory-v1.sqlite3-wal'), 'utf8')).toBe('wal-before-crash');
+      expect(readFileSync(join(generation, 'inventory-v1.sqlite3-shm'), 'utf8')).toBe('shm-before-crash');
+      expect(existsSync(`${path}.rebuild-required`)).toBe(false);
+    } finally {
+      foundation.close();
+    }
+  });
+
+  it('explicitly quarantines and rebuilds an open owned database', async () => {
+    const dataDirectory = temporaryDataDirectory();
+    const path = databasePath(dataDirectory);
+    const foundation = await openInventoryV1(dataDirectory);
+    foundation.quarantineAndRebuild();
+    try {
+      expect(foundation.closed).toBe(false);
+      assertInitializedInventory(path);
+      expect(quarantineGenerations(path)).toHaveLength(1);
+      expect(lstatSync(join(quarantineGenerations(path)[0]!, 'inventory-v1.sqlite3')).isFile()).toBe(true);
+    } finally {
+      foundation.close();
+    }
+  });
+});

--- a/packages/agent/test/rfc64-inventory-v1-lifecycle.test.ts
+++ b/packages/agent/test/rfc64-inventory-v1-lifecycle.test.ts
@@ -106,8 +106,20 @@ const MOVED_PREFIX_FAULT_BOUNDARIES = FULL_RECOVERY_MANIFEST.flatMap((member) =>
   `resume.prefix.${member}.inventory-directory-fsync`,
 ] as const) satisfies readonly InventoryV1QuarantineBoundary[];
 
-const JOURNAL_RESTART_FAULT_BOUNDARIES = [
-  'target-exclusivity-proven',
+const JOURNAL_PREFIX_FAULT_BOUNDARIES = [
+  'resume.prefix.journal.file-fsync',
+  'resume.prefix.journal.generation-directory-fsync',
+  'resume.prefix.journal.inventory-directory-fsync',
+] as const satisfies readonly InventoryV1QuarantineBoundary[];
+
+const JOURNAL_AUTOMATIC_FAULT_BOUNDARIES = [
+  'begin.source.journal.file-fsync',
+  'begin.source.main.file-fsync',
+  'begin.inventory-directory.fsync-after-quarantine-root',
+  'begin.quarantine-root.fsync-after-generation',
+  'begin.marker.write',
+  'begin.marker.file-fsync',
+  'begin.inventory-directory.fsync-after-marker',
   'resume.source.journal.file-fsync-after-quiescence',
   'resume.source.main.file-fsync-after-quiescence',
   'resume.member.journal.rename',
@@ -120,12 +132,6 @@ const JOURNAL_RESTART_FAULT_BOUNDARIES = [
   'resume.member.main.inventory-directory-fsync',
   'resume.marker.unlink',
   'resume.inventory-directory.fsync-after-marker-unlink',
-] as const satisfies readonly InventoryV1QuarantineBoundary[];
-
-const JOURNAL_PREFIX_FAULT_BOUNDARIES = [
-  'resume.prefix.journal.file-fsync',
-  'resume.prefix.journal.generation-directory-fsync',
-  'resume.prefix.journal.inventory-directory-fsync',
 ] as const satisfies readonly InventoryV1QuarantineBoundary[];
 
 function expectedFullManifestTrace(
@@ -1221,6 +1227,33 @@ describe.runIf(process.platform !== 'win32')('RFC-64 inventory v1 SQLite lifecyc
     }
   });
 
+  it('fails closed on rollback-journal evidence beside a WAL-mode main header', async () => {
+    const dataDirectory = temporaryDataDirectory();
+    const path = databasePath(dataDirectory);
+    createIncompatibleOwnedInventory(path, 'wal-header-journal');
+    const wal = new DatabaseSync(path);
+    wal.exec('PRAGMA journal_mode = WAL; PRAGMA wal_checkpoint(TRUNCATE);');
+    wal.close();
+    expect(readFileSync(path).subarray(18, 20)).toEqual(Buffer.from([2, 2]));
+
+    const journalEvidence = HOSTILE_SIDECAR_BYTES.journal;
+    const opener = createInventoryV1TestOpener({
+      quarantineCapability: INVENTORY_V1_POSIX_QUARANTINE_CAPABILITY,
+      closeTarget: (close, reason) => {
+        close();
+        if (reason === 'automatic-schema-quarantine') {
+          writeFileSync(`${path}-journal`, journalEvidence);
+        }
+      },
+    });
+    await expect(opener(dataDirectory)).rejects.toSatisfy(
+      (error: unknown) => expectOpenErrorCode(error, 'ambiguous-database'),
+    );
+    expect(readFileSync(`${path}-journal`)).toEqual(journalEvidence);
+    expect(existsSync(`${path}.rebuild-required`)).toBe(false);
+    expect(quarantineGenerations(path)).toEqual([]);
+  });
+
   it('rejects pre-existing mixed journal modes before SQLite can mutate either sidecar', async () => {
     for (const mixedMember of ['wal', 'shm'] as const) {
       const dataDirectory = temporaryDataDirectory();
@@ -2056,7 +2089,7 @@ describe.runIf(process.platform !== 'win32')('RFC-64 inventory v1 SQLite lifecyc
     }
   });
 
-  it('does not move a zero-prefix journal manifest before proving a raw SQLite holder is gone', async () => {
+  it('fails closed without opening or moving a restarted zero-prefix journal manifest', async () => {
     const dataDirectory = temporaryDataDirectory();
     const path = databasePath(dataDirectory);
     const generation = join(
@@ -2091,7 +2124,7 @@ describe.runIf(process.platform !== 'win32')('RFC-64 inventory v1 SQLite lifecyc
     try {
       for (let attempt = 0; attempt < 2; attempt += 1) {
         await expect(openInventoryV1(dataDirectory)).rejects.toSatisfy(
-          (error: unknown) => expectOpenErrorCode(error, 'database-busy'),
+          (error: unknown) => expectOpenErrorCode(error, 'durability-unavailable'),
         );
         expect(fileOracle(path)).toEqual(before.main);
         expect(fileOracle(`${path}-journal`)).toEqual(before.journal);
@@ -2106,6 +2139,42 @@ describe.runIf(process.platform !== 'win32')('RFC-64 inventory v1 SQLite lifecyc
       holder.exec('ROLLBACK');
       holder.close();
     }
+  });
+
+  it('leaves a zero-prefix journal marker with a WAL-mode main untouched', async () => {
+    const dataDirectory = temporaryDataDirectory();
+    const path = databasePath(dataDirectory);
+    const generation = join(
+      dirname(path),
+      'quarantine',
+      'inventory-v1-1234567890-9797979797979797',
+    );
+    mkdirSync(generation, { recursive: true });
+    createIncompatibleOwnedInventory(path, 'wal-marker-journal');
+    const wal = new DatabaseSync(path);
+    wal.exec('PRAGMA journal_mode = WAL; PRAGMA wal_checkpoint(TRUNCATE);');
+    wal.close();
+    writeFileSync(`${path}-journal`, HOSTILE_SIDECAR_BYTES.journal);
+    const marker = Buffer.from(JSON.stringify({
+      version: 1,
+      quarantineDirectory: generation,
+      members: ['journal', 'main'],
+    }));
+    writeFileSync(`${path}.rebuild-required`, marker);
+    const before = {
+      main: fileOracle(path),
+      journal: fileOracle(`${path}-journal`),
+      marker: fileOracle(`${path}.rebuild-required`),
+      destinationNames: readdirSync(generation).sort(),
+    };
+
+    await expect(openInventoryV1(dataDirectory)).rejects.toSatisfy(
+      (error: unknown) => expectOpenErrorCode(error, 'ambiguous-database'),
+    );
+    expect(fileOracle(path)).toEqual(before.main);
+    expect(fileOracle(`${path}-journal`)).toEqual(before.journal);
+    expect(fileOracle(`${path}.rebuild-required`)).toEqual(before.marker);
+    expect(readdirSync(generation).sort()).toEqual(before.destinationNames);
   });
 
   it('resumes a partial recovery-marker move before rebuilding', async () => {
@@ -2286,6 +2355,22 @@ describe.runIf(process.platform !== 'win32')('RFC-64 inventory v1 SQLite lifecyc
         );
         const path = databasePath(dataDirectory);
 
+        if (members[0] === 'journal' && movedPrefix === 0) {
+          const before = new Map(members.map((member) => {
+            const evidence = recoverySourcePath(path, member);
+            return [evidence, fileOracle(evidence)] as const;
+          }));
+          const markerBefore = fileOracle(`${path}.rebuild-required`);
+          await expect(openInventoryV1(dataDirectory)).rejects.toSatisfy(
+            (error: unknown) => expectOpenErrorCode(error, 'durability-unavailable'),
+          );
+          expect(fileOracle(`${path}.rebuild-required`)).toEqual(markerBefore);
+          for (const [evidence, oracle] of before) {
+            expect(fileOracle(evidence)).toEqual(oracle);
+          }
+          continue;
+        }
+
         const foundation = await openInventoryV1(dataDirectory);
         try {
           assertInitializedInventory(path);
@@ -2384,56 +2469,6 @@ describe.runIf(process.platform !== 'win32')('RFC-64 inventory v1 SQLite lifecyc
     }
   }, 180_000);
 
-  it('recovers journal evidence in a fresh process after SIGKILL at every restart-proof and move boundary', async () => {
-    for (const boundary of JOURNAL_RESTART_FAULT_BOUNDARIES) {
-      const dataDirectory = temporaryDataDirectory();
-      const path = databasePath(dataDirectory);
-      const label = `journal-fault-${boundary}`;
-      const seeded = seedPendingRecoveryTopology(
-        dataDirectory,
-        JOURNAL_RECOVERY_MANIFEST,
-        0,
-        label,
-      );
-      const tracePath = join(dataDirectory, `trace-${boundary}.jsonl`);
-      const trace = await killAtInventoryBoundary(dataDirectory, boundary, tracePath, {
-        DKG_RFC64_CHILD_PROTECT_EVIDENCE: '1',
-      });
-      expect(trace.map((entry) => entry.boundary)).toEqual(
-        JOURNAL_RESTART_FAULT_BOUNDARIES.slice(
-          0,
-          JOURNAL_RESTART_FAULT_BOUNDARIES.indexOf(boundary) + 1,
-        ),
-      );
-      const killedEvidence = new Map<RecoveryMember, FileOracle>();
-      for (const member of JOURNAL_RECOVERY_MANIFEST) {
-        const source = recoverySourcePath(path, member);
-        const destination = recoveryDestinationPath(seeded.generation, member);
-        expect(existsSync(source) || existsSync(destination)).toBe(true);
-        killedEvidence.set(member, fileOracle(existsSync(source) ? source : destination));
-      }
-
-      try {
-        await reopenInventoryInFreshProcess(dataDirectory);
-      } catch (cause) {
-        throw new Error(`fresh-process journal recovery failed after ${boundary}`, { cause });
-      }
-      assertInitializedInventory(path);
-      assertRecoveredManifestEvidence(
-        path,
-        JOURNAL_RECOVERY_MANIFEST,
-        label,
-        seeded.generation,
-        seeded.hashes,
-      );
-      for (const member of JOURNAL_RECOVERY_MANIFEST) {
-        expect(fileOracle(recoveryDestinationPath(seeded.generation, member))).toEqual(
-          killedEvidence.get(member),
-        );
-      }
-    }
-  }, 120_000);
-
   it('recovers a journal moved-prefix in a fresh process after SIGKILL at every prefix durability boundary', async () => {
     for (const boundary of JOURNAL_PREFIX_FAULT_BOUNDARIES) {
       const dataDirectory = temporaryDataDirectory();
@@ -2478,6 +2513,77 @@ describe.runIf(process.platform !== 'win32')('RFC-64 inventory v1 SQLite lifecyc
       );
     }
   }, 60_000);
+
+  it('preserves or resumes automatic journal quarantine at every crash boundary', async () => {
+    for (const boundary of JOURNAL_AUTOMATIC_FAULT_BOUNDARIES) {
+      const dataDirectory = temporaryDataDirectory();
+      const path = databasePath(dataDirectory);
+      const label = `automatic-journal-fault-${boundary}`;
+      createIncompatibleOwnedInventory(path, label);
+      const tracePath = join(dataDirectory, `trace-${boundary}.jsonl`);
+      const trace = await killAtInventoryBoundary(dataDirectory, boundary, tracePath, {
+        DKG_RFC64_CHILD_SYNTHETIC_JOURNAL: '1',
+      });
+      expect(trace.map((entry) => entry.boundary)).toEqual([
+        'target-exclusivity-proven',
+        ...JOURNAL_AUTOMATIC_FAULT_BOUNDARIES.slice(
+          0,
+          JOURNAL_AUTOMATIC_FAULT_BOUNDARIES.indexOf(boundary) + 1,
+        ),
+      ]);
+
+      const markerPath = `${path}.rebuild-required`;
+      const generation = quarantineGenerations(path).find((candidate) =>
+        existsSync(recoveryDestinationPath(candidate, 'journal'))
+        || existsSync(recoveryDestinationPath(candidate, 'main'))
+        || existsSync(markerPath));
+      const journalAtDestination = generation !== undefined
+        && existsSync(recoveryDestinationPath(generation, 'journal'));
+
+      if (existsSync(markerPath) && !journalAtDestination) {
+        const before = {
+          main: fileOracle(path),
+          journal: fileOracle(`${path}-journal`),
+          marker: fileOracle(markerPath),
+          destinationNames: generation === undefined ? [] : readdirSync(generation).sort(),
+        };
+        for (let attempt = 0; attempt < 2; attempt += 1) {
+          await expect(openInventoryV1(dataDirectory)).rejects.toSatisfy(
+            (error: unknown) => expectOpenErrorCode(error, 'durability-unavailable'),
+          );
+          expect(fileOracle(path)).toEqual(before.main);
+          expect(fileOracle(`${path}-journal`)).toEqual(before.journal);
+          expect(fileOracle(markerPath)).toEqual(before.marker);
+          if (generation !== undefined) {
+            expect(readdirSync(generation).sort()).toEqual(before.destinationNames);
+          }
+        }
+        continue;
+      }
+
+      const killedEvidence = new Map<RecoveryMember, FileOracle>();
+      const committedMembers = journalAtDestination
+        ? JOURNAL_RECOVERY_MANIFEST
+        : (['main'] as const);
+      for (const member of committedMembers) {
+        const source = recoverySourcePath(path, member);
+        const destination = generation === undefined
+          ? undefined
+          : recoveryDestinationPath(generation, member);
+        const evidence = existsSync(source) ? source : destination;
+        if (evidence !== undefined && existsSync(evidence)) {
+          killedEvidence.set(member, fileOracle(evidence));
+        }
+      }
+
+      await reopenInventoryInFreshProcess(dataDirectory);
+      assertInitializedInventory(path);
+      const recoveredGeneration = evidenceGeneration(path);
+      for (const [member, oracle] of killedEvidence) {
+        expect(fileOracle(recoveryDestinationPath(recoveredGeneration, member))).toEqual(oracle);
+      }
+    }
+  }, 120_000);
 
   it('recovers in a fresh process after SIGKILL at every moved-prefix re-fsync boundary', async () => {
     for (const boundary of MOVED_PREFIX_FAULT_BOUNDARIES) {

--- a/packages/agent/test/rfc64-inventory-v1-lifecycle.test.ts
+++ b/packages/agent/test/rfc64-inventory-v1-lifecycle.test.ts
@@ -7,14 +7,20 @@ import {
   readFileSync,
   readdirSync,
   realpathSync,
+  renameSync,
   rmSync,
   statSync,
   symlinkSync,
   truncateSync,
   writeFileSync,
 } from 'node:fs';
+import {
+  spawn,
+  type ChildProcessWithoutNullStreams,
+} from 'node:child_process';
+import { createHash } from 'node:crypto';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -24,12 +30,98 @@ import {
   INVENTORY_V1_DDL,
   INVENTORY_V1_RELATIVE_PATH,
   INVENTORY_V1_USER_OBJECTS,
+  INVENTORY_V1_POSIX_QUARANTINE_CAPABILITY,
   InventoryV1OpenError,
   normalizeInventoryV1SchemaSql,
-  openInventoryV1,
+  openInventoryV1 as openProductionInventoryV1,
 } from '../src/rfc64/inventory-v1/index.js';
+import {
+  type InventoryV1QuarantineBoundary,
+} from '../src/rfc64/inventory-v1/lifecycle-adapter.js';
+import { createInventoryV1TestOpener } from '../src/rfc64/inventory-v1/open.js';
 
 const temporaryDirectories: string[] = [];
+const CHILD_FIXTURE = resolve(
+  import.meta.dirname,
+  'fixtures/rfc64-inventory-v1-child.ts',
+);
+const HOSTILE_SIDECAR_BYTES = Object.freeze({
+  wal: Buffer.from('hostile-rfc64-wal-evidence\0\u0001\u0002', 'utf8'),
+  shm: Buffer.from('hostile-rfc64-shm-evidence\0\u0003\u0004', 'utf8'),
+});
+
+const openInventoryV1 = (dataDirectory: string) => openProductionInventoryV1(
+  dataDirectory,
+  { quarantineCapability: INVENTORY_V1_POSIX_QUARANTINE_CAPABILITY },
+);
+
+type RecoveryMember = 'wal' | 'shm' | 'main';
+type RecoveryManifest =
+  | readonly ['main']
+  | readonly ['wal', 'main']
+  | readonly ['shm', 'main']
+  | readonly ['wal', 'shm', 'main'];
+type EvidenceHashes = Readonly<Partial<Record<RecoveryMember, string>>>;
+type SeededRecoveryTopology = Readonly<{
+  generation: string;
+  hashes: EvidenceHashes;
+}>;
+
+const FULL_RECOVERY_MANIFEST = ['wal', 'shm', 'main'] as const;
+const FULL_MANIFEST_FAULT_BOUNDARIES = [
+  'begin.source.wal.file-fsync',
+  'begin.source.shm.file-fsync',
+  'begin.source.main.file-fsync',
+  'begin.inventory-directory.fsync-after-quarantine-root',
+  'begin.quarantine-root.fsync-after-generation',
+  'begin.marker.write',
+  'begin.marker.file-fsync',
+  'begin.inventory-directory.fsync-after-marker',
+  'resume.source.wal.file-fsync-after-quiescence',
+  'resume.source.shm.file-fsync-after-quiescence',
+  'resume.source.main.file-fsync-after-quiescence',
+  'resume.member.wal.rename',
+  'resume.member.wal.file-fsync',
+  'resume.member.wal.generation-directory-fsync',
+  'resume.member.wal.inventory-directory-fsync',
+  'resume.member.shm.rename',
+  'resume.member.shm.file-fsync',
+  'resume.member.shm.generation-directory-fsync',
+  'resume.member.shm.inventory-directory-fsync',
+  'resume.member.main.rename',
+  'resume.member.main.file-fsync',
+  'resume.member.main.generation-directory-fsync',
+  'resume.member.main.inventory-directory-fsync',
+  'resume.marker.unlink',
+  'resume.inventory-directory.fsync-after-marker-unlink',
+] as const satisfies readonly InventoryV1QuarantineBoundary[];
+
+const MOVED_PREFIX_FAULT_BOUNDARIES = FULL_RECOVERY_MANIFEST.flatMap((member) => [
+  `resume.prefix.${member}.file-fsync`,
+  `resume.prefix.${member}.generation-directory-fsync`,
+  `resume.prefix.${member}.inventory-directory-fsync`,
+] as const) satisfies readonly InventoryV1QuarantineBoundary[];
+
+function expectedFullManifestTrace(
+  boundary: (typeof FULL_MANIFEST_FAULT_BOUNDARIES)[number],
+): InventoryV1QuarantineBoundary[] {
+  const prefix = FULL_MANIFEST_FAULT_BOUNDARIES.slice(
+    0,
+    FULL_MANIFEST_FAULT_BOUNDARIES.indexOf(boundary) + 1,
+  );
+  const resumeStart = FULL_MANIFEST_FAULT_BOUNDARIES.indexOf(
+    'resume.source.wal.file-fsync-after-quiescence',
+  );
+  if (FULL_MANIFEST_FAULT_BOUNDARIES.indexOf(boundary) < resumeStart) {
+    return ['target-exclusivity-proven', ...prefix];
+  }
+  return [
+    'target-exclusivity-proven',
+    ...prefix.slice(0, resumeStart),
+    'target-exclusivity-proven',
+    ...prefix.slice(resumeStart),
+  ];
+}
 
 function temporaryDataDirectory(): string {
   // macOS exposes /var as a symlink to /private/var. Use the canonical test
@@ -42,6 +134,10 @@ function temporaryDataDirectory(): string {
 
 function databasePath(dataDirectory: string): string {
   return join(dataDirectory, INVENTORY_V1_RELATIVE_PATH);
+}
+
+function leasePath(dataDirectory: string): string {
+  return join(dirname(databasePath(dataDirectory)), 'inventory-v1.lease.sqlite3');
 }
 
 function pragmaInteger(database: DatabaseSync, pragma: string): number {
@@ -69,6 +165,120 @@ function quarantineGenerations(path: string): string[] {
   return readdirSync(root).map((name) => join(root, name));
 }
 
+function recoverySourcePath(path: string, member: RecoveryMember): string {
+  return member === 'main' ? path : `${path}-${member}`;
+}
+
+function recoveryDestinationPath(generation: string, member: RecoveryMember): string {
+  return join(
+    generation,
+    member === 'main' ? 'inventory-v1.sqlite3' : `inventory-v1.sqlite3-${member}`,
+  );
+}
+
+function createIncompatibleOwnedInventory(path: string, label: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  const database = new DatabaseSync(path);
+  try {
+    database.exec(`
+      CREATE TABLE wrong_v1 (value TEXT NOT NULL);
+      INSERT INTO wrong_v1 VALUES ('${label}');
+      PRAGMA application_id = ${INVENTORY_V1_APPLICATION_ID};
+      PRAGMA user_version = 1;
+    `);
+  } finally {
+    database.close();
+  }
+}
+
+function sha256File(path: string): string {
+  return createHash('sha256').update(readFileSync(path)).digest('hex');
+}
+
+function sourceEvidenceHashes(
+  path: string,
+  members: RecoveryManifest,
+): EvidenceHashes {
+  return Object.fromEntries(members.map((member) => [
+    member,
+    sha256File(recoverySourcePath(path, member)),
+  ])) as EvidenceHashes;
+}
+
+function seedPendingRecoveryTopology(
+  dataDirectory: string,
+  members: RecoveryManifest,
+  movedPrefix: number,
+  label: string,
+  hostileSidecars = false,
+): SeededRecoveryTopology {
+  const path = databasePath(dataDirectory);
+  const generation = join(
+    dirname(path),
+    'quarantine',
+    `inventory-v1-1234567890-${String(movedPrefix).padStart(16, '0')}`,
+  );
+  mkdirSync(generation, { recursive: true });
+  createIncompatibleOwnedInventory(path, label);
+  for (const member of members) {
+    if (member !== 'main') {
+      writeFileSync(
+        recoverySourcePath(path, member),
+        hostileSidecars ? HOSTILE_SIDECAR_BYTES[member] : Buffer.alloc(0),
+      );
+    }
+  }
+  const hashes = sourceEvidenceHashes(path, members);
+  for (const [index, member] of members.entries()) {
+    if (index >= movedPrefix) continue;
+    renameSync(recoverySourcePath(path, member), recoveryDestinationPath(generation, member));
+  }
+  writeFileSync(
+    `${path}.rebuild-required`,
+    JSON.stringify({ version: 1, quarantineDirectory: generation, members }),
+  );
+  return { generation, hashes };
+}
+
+function evidenceGeneration(path: string): string {
+  const generations = quarantineGenerations(path).filter((generation) =>
+    existsSync(join(generation, 'inventory-v1.sqlite3')));
+  expect(generations).toHaveLength(1);
+  return generations[0]!;
+}
+
+function assertRecoveredManifestEvidence(
+  path: string,
+  members: RecoveryManifest,
+  label: string,
+  expectedGeneration?: string,
+  expectedHashes?: EvidenceHashes,
+): void {
+  expect(existsSync(`${path}.rebuild-required`)).toBe(false);
+  const generation = evidenceGeneration(path);
+  if (expectedGeneration !== undefined) expect(generation).toBe(expectedGeneration);
+  for (const member of members) {
+    const destination = recoveryDestinationPath(generation, member);
+    expect(lstatSync(destination).isFile()).toBe(true);
+    if (expectedHashes?.[member] !== undefined) {
+      expect(sha256File(destination)).toBe(expectedHashes[member]);
+    } else if (member !== 'main') {
+      expect(readFileSync(destination)).toEqual(Buffer.alloc(0));
+    }
+  }
+  if (expectedHashes === undefined) {
+    const evidence = new DatabaseSync(
+      recoveryDestinationPath(generation, 'main'),
+      { readOnly: true },
+    );
+    try {
+      expect(evidence.prepare('SELECT value FROM wrong_v1').get()?.value).toBe(label);
+    } finally {
+      evidence.close();
+    }
+  }
+}
+
 function assertInitializedInventory(path: string): void {
   const database = new DatabaseSync(path, { readOnly: true });
   try {
@@ -91,13 +301,206 @@ function assertInitializedInventory(path: string): void {
   }
 }
 
+async function startLeaseHolder(path: string): Promise<ChildProcessWithoutNullStreams> {
+  const script = String.raw`
+const { DatabaseSync } = require('node:sqlite');
+const database = new DatabaseSync(process.env.DKG_RFC64_LEASE_PATH);
+database.exec('PRAGMA busy_timeout = 0; BEGIN EXCLUSIVE');
+process.stdout.write('READY\n');
+setInterval(() => {}, 60_000);
+`;
+  const child = spawn(process.execPath, ['--experimental-sqlite', '-e', script], {
+    env: { ...process.env, DKG_RFC64_LEASE_PATH: path },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  await new Promise<void>((resolveReady, rejectReady) => {
+    let stdout = '';
+    let stderr = '';
+    const timeout = setTimeout(() => {
+      rejectReady(new Error(`lease holder did not become ready: ${stderr}`));
+    }, 10_000);
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stderr.on('data', (chunk: string) => { stderr += chunk; });
+    child.stdout.on('data', (chunk: string) => {
+      stdout += chunk;
+      if (!stdout.includes('READY\n')) return;
+      clearTimeout(timeout);
+      resolveReady();
+    });
+    child.once('error', (error) => {
+      clearTimeout(timeout);
+      rejectReady(error);
+    });
+    child.once('exit', (code, signal) => {
+      clearTimeout(timeout);
+      rejectReady(new Error(`lease holder exited before ready: code=${code} signal=${signal} stderr=${stderr}`));
+    });
+  });
+  return child;
+}
+
+async function killLeaseHolder(child: ChildProcessWithoutNullStreams): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  child.kill('SIGKILL');
+  await new Promise<void>((resolveExit) => child.once('exit', () => resolveExit()));
+}
+
+interface ChildResult {
+  readonly code: number | null;
+  readonly signal: NodeJS.Signals | null;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+function spawnInventoryChild(
+  mode: 'fault' | 'reopen' | 'contender',
+  dataDirectory: string,
+  extraEnvironment: Readonly<Record<string, string>> = {},
+): ChildProcessWithoutNullStreams {
+  return spawn(
+    process.execPath,
+    ['--experimental-sqlite', '--import', 'tsx', CHILD_FIXTURE],
+    {
+      cwd: resolve(import.meta.dirname, '../../..'),
+      env: {
+        ...process.env,
+        NODE_ENV: 'test',
+        DKG_RFC64_CHILD_MODE: mode,
+        DKG_RFC64_CHILD_DATA_DIR: dataDirectory,
+        ...extraEnvironment,
+      },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    },
+  );
+}
+
+async function collectChild(child: ChildProcessWithoutNullStreams): Promise<ChildResult> {
+  let stdout = '';
+  let stderr = '';
+  child.stdout.setEncoding('utf8');
+  child.stderr.setEncoding('utf8');
+  child.stdout.on('data', (chunk: string) => { stdout += chunk; });
+  child.stderr.on('data', (chunk: string) => { stderr += chunk; });
+  return await new Promise<ChildResult>((resolveResult, rejectResult) => {
+    child.once('error', rejectResult);
+    child.once('exit', (code, signal) => resolveResult({ code, signal, stdout, stderr }));
+  });
+}
+
+async function waitForChildBoundary(
+  child: ChildProcessWithoutNullStreams,
+  boundary: InventoryV1QuarantineBoundary,
+): Promise<void> {
+  child.stdout.setEncoding('utf8');
+  child.stderr.setEncoding('utf8');
+  let stdout = '';
+  let stderr = '';
+  await new Promise<void>((resolveBoundary, rejectBoundary) => {
+    const timeout = setTimeout(() => {
+      rejectBoundary(new Error(
+        `child did not reach ${boundary}; stdout=${stdout} stderr=${stderr}`,
+      ));
+    }, 15_000);
+    child.stdout.on('data', (chunk: string) => {
+      stdout += chunk;
+      if (!stdout.includes(`BOUNDARY:${boundary}\n`)) return;
+      clearTimeout(timeout);
+      resolveBoundary();
+    });
+    child.stderr.on('data', (chunk: string) => { stderr += chunk; });
+    child.once('error', (error) => {
+      clearTimeout(timeout);
+      rejectBoundary(error);
+    });
+    child.once('exit', (code, signal) => {
+      clearTimeout(timeout);
+      rejectBoundary(new Error(
+        `child exited before ${boundary}: code=${code} signal=${signal} stderr=${stderr}`,
+      ));
+    });
+  });
+}
+
+async function killAtInventoryBoundary(
+  dataDirectory: string,
+  boundary: InventoryV1QuarantineBoundary,
+  tracePath: string,
+  extraEnvironment: Readonly<Record<string, string>> = {},
+): Promise<Array<{ boundary: InventoryV1QuarantineBoundary; topology: unknown[] }>> {
+  const child = spawnInventoryChild('fault', dataDirectory, {
+    DKG_RFC64_CHILD_BOUNDARY: boundary,
+    DKG_RFC64_CHILD_TRACE: tracePath,
+    ...extraEnvironment,
+  });
+  await waitForChildBoundary(child, boundary);
+  const exitResult = new Promise<ChildResult>((resolveResult, rejectResult) => {
+    let stderr = '';
+    child.stderr.on('data', (chunk: Buffer | string) => { stderr += String(chunk); });
+    child.once('error', rejectResult);
+    child.once('exit', (code, signal) => resolveResult({ code, signal, stdout: '', stderr }));
+  });
+  child.kill('SIGKILL');
+  const result = await exitResult;
+  expect(result.code).toBeNull();
+  expect(result.signal).toBe('SIGKILL');
+  if (extraEnvironment.DKG_RFC64_CHILD_PROTECT_EVIDENCE === '1') {
+    chmodSync(dirname(databasePath(dataDirectory)), 0o700);
+  }
+  const trace = readFileSync(tracePath, 'utf8').trim().split('\n').filter(Boolean)
+    .map((line) => JSON.parse(line) as {
+      boundary: InventoryV1QuarantineBoundary;
+      topology: unknown[];
+    });
+  expect(trace.at(-1)?.boundary).toBe(boundary);
+  expect(trace.every((entry) => entry.topology.length > 0)).toBe(true);
+  return trace;
+}
+
+async function reopenInventoryInFreshProcess(dataDirectory: string): Promise<void> {
+  const result = await collectChild(spawnInventoryChild('reopen', dataDirectory));
+  expect(result, result.stderr).toMatchObject({ code: 0, signal: null });
+  expect(result.stdout).toContain('OPEN\n');
+}
+
+async function runContender(dataDirectory: string): Promise<{
+  directLease: 'OPEN' | 'BUSY';
+  targetTransaction: 'FREE' | 'BUSY';
+  lease: 'OPEN' | 'BUSY';
+}> {
+  const result = await collectChild(spawnInventoryChild('contender', dataDirectory));
+  expect(result, result.stderr).toMatchObject({ code: 0, signal: null });
+  return JSON.parse(result.stdout.trim()) as {
+    directLease: 'OPEN' | 'BUSY';
+    targetTransaction: 'FREE' | 'BUSY';
+    lease: 'OPEN' | 'BUSY';
+  };
+}
+
+interface FileOracle {
+  readonly dev: number;
+  readonly ino: number;
+  readonly size: number;
+  readonly sha256: string;
+}
+
+function fileOracle(path: string): FileOracle {
+  const stat = lstatSync(path);
+  return {
+    dev: stat.dev,
+    ino: stat.ino,
+    size: stat.size,
+    sha256: createHash('sha256').update(readFileSync(path)).digest('hex'),
+  };
+}
+
 afterEach(() => {
   for (const directory of temporaryDirectories.splice(0)) {
     rmSync(directory, { recursive: true, force: true });
   }
 });
 
-describe('RFC-64 inventory v1 SQLite lifecycle', () => {
+describe.runIf(process.platform !== 'win32')('RFC-64 inventory v1 SQLite lifecycle', () => {
   it('initializes the exact owned schema, identity, WAL mode, and private POSIX paths', async () => {
     const dataDirectory = temporaryDataDirectory();
     const foundation = await openInventoryV1(dataDirectory);
@@ -106,9 +509,14 @@ describe('RFC-64 inventory v1 SQLite lifecycle', () => {
     expect(foundation.databasePath).toBe(path);
     expect(foundation.closed).toBe(false);
     assertInitializedInventory(path);
+    const committedHeader = readFileSync(path).subarray(0, 100);
+    expect(committedHeader.subarray(0, 16).toString('binary')).toBe('SQLite format 3\u0000');
+    expect(committedHeader.readUInt32BE(68)).toBe(INVENTORY_V1_APPLICATION_ID);
+    expect(committedHeader.readUInt32BE(60)).toBe(1);
     if (process.platform !== 'win32') {
       expect(statSync(dirname(path)).mode & 0o777).toBe(0o700);
       expect(statSync(path).mode & 0o777).toBe(0o600);
+      expect(statSync(leasePath(dataDirectory)).mode & 0o777).toBe(0o600);
     }
 
     foundation.close();
@@ -125,6 +533,221 @@ describe('RFC-64 inventory v1 SQLite lifecycle', () => {
       expect.unreachable('closed foundation unexpectedly rebuilt');
     } catch (error) {
       expectOpenErrorCode(error, 'database-closed');
+    }
+  });
+
+  it('initializes the exact DK6L lease identity and holds it for the foundation lifetime', async () => {
+    const dataDirectory = temporaryDataDirectory();
+    const foundation = await openInventoryV1(dataDirectory);
+    try {
+      await expect(openInventoryV1(dataDirectory)).rejects.toSatisfy((error: unknown) =>
+        expectOpenErrorCode(error, 'database-busy'));
+    } finally {
+      foundation.close();
+    }
+
+    const lease = new DatabaseSync(leasePath(dataDirectory));
+    try {
+      expect(pragmaInteger(lease, 'application_id')).toBe(0x444b364c);
+      expect(pragmaInteger(lease, 'user_version')).toBe(1);
+      expect(String(lease.prepare('PRAGMA journal_mode').get()?.journal_mode).toLowerCase()).toBe('delete');
+      expect(lease.prepare(
+        `SELECT count(*) AS count FROM sqlite_schema WHERE name NOT LIKE 'sqlite_%'`,
+      ).get()?.count).toBe(0);
+    } finally {
+      lease.close();
+    }
+
+    const reopened = await openInventoryV1(dataDirectory);
+    reopened.close();
+  });
+
+  it('retains DK6L in fail-stop when the owned target cannot close', async () => {
+    const dataDirectory = temporaryDataDirectory();
+    const openWithCloseFailure = createInventoryV1TestOpener({
+      quarantineCapability: INVENTORY_V1_POSIX_QUARANTINE_CAPABILITY,
+      closeTarget: (_close, reason) => {
+        if (reason === 'foundation-close') throw new Error('injected target close failure');
+        _close();
+      },
+    });
+    const foundation = await openWithCloseFailure(dataDirectory);
+
+    expect(() => foundation.close()).toThrowError(
+      expect.objectContaining({ code: 'database-io' }),
+    );
+    expect(foundation.closed).toBe(false);
+    await expect(openInventoryV1(dataDirectory)).rejects.toSatisfy((error: unknown) =>
+      expectOpenErrorCode(error, 'database-busy'));
+  });
+
+  it('closes a corrupt owned target before reporting unavailable durability', async () => {
+    const dataDirectory = temporaryDataDirectory();
+    const path = databasePath(dataDirectory);
+    const initialized = await openInventoryV1(dataDirectory);
+    initialized.close();
+    const seed = new DatabaseSync(path);
+    const zeroU64 = Buffer.alloc(8);
+    const oneU64 = Buffer.from([0, 0, 0, 0, 0, 0, 0, 1]);
+    const sixteenU64 = Buffer.from([0, 0, 0, 0, 0, 0, 0, 16]);
+    const chunkSizeU64 = Buffer.from([0, 0, 0, 0, 0, 4, 0, 0]);
+    const session = Buffer.alloc(32, 1);
+    const scope = Buffer.alloc(32, 2);
+    const author = Buffer.alloc(20, 3);
+    const head = Buffer.alloc(32, 4);
+    seed.prepare('INSERT INTO rfc64_candidate_bucket_loads_v1 VALUES (?,?,?,?,?,?,?,?,?,?,?)')
+      .run(
+        session, scope, author, head, null, zeroU64, oneU64, zeroU64,
+        Buffer.alloc(32), zeroU64, zeroU64,
+      );
+    seed.prepare('INSERT INTO rfc64_candidate_bucket_rows_v1 VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)')
+      .run(
+        session, scope, author, head, zeroU64, Buffer.alloc(32, 5),
+        Buffer.alloc(32, 6), 'coordinate', zeroU64, 'cg-shared-v1',
+        Buffer.alloc(32, 7), Buffer.alloc(32, 8), 'dkg-ka-bundle-v1',
+        sixteenU64, chunkSizeU64, oneU64, Buffer.alloc(32, 9),
+        Buffer.alloc(32, 10), Buffer.alloc(32, 11),
+      );
+    const pageSize = pragmaInteger(seed, 'page_size');
+    const rowRootPage = seed.prepare(
+      "SELECT rootpage FROM sqlite_schema WHERE name = 'rfc64_candidate_bucket_rows_v1'",
+    ).get()?.rootpage;
+    expect(typeof rowRootPage).toBe('number');
+    seed.close();
+    const corruptBytes = readFileSync(path);
+    corruptBytes[(Number(rowRootPage) - 1) * pageSize] = 0xff;
+    writeFileSync(path, corruptBytes);
+    const closeReasons: string[] = [];
+    const openWithoutDurability = createInventoryV1TestOpener({
+      quarantineCapability: null,
+      closeTarget: (close, reason) => {
+        close();
+        closeReasons.push(reason);
+      },
+    });
+
+    await expect(openWithoutDurability(dataDirectory)).rejects.toSatisfy(
+      (error: unknown) => expectOpenErrorCode(error, 'durability-unavailable'),
+    );
+    expect(closeReasons).toContain('automatic-corrupt-quarantine');
+    await expect(openWithoutDurability(dataDirectory)).rejects.toSatisfy(
+      (error: unknown) => expectOpenErrorCode(error, 'durability-unavailable'),
+    );
+  });
+
+  it('keeps the test seam and legacy durability override inert outside current test mode', async () => {
+    const previousNodeEnvironment = process.env.NODE_ENV;
+    const overrideName = 'DKG_RFC64_TEST_DISABLE_QUARANTINE_DURABILITY';
+    const previousOverride = process.env[overrideName];
+    const unopenedDataDirectory = temporaryDataDirectory();
+    let closeHookCalls = 0;
+    const guardedOpen = createInventoryV1TestOpener({
+      quarantineCapability: INVENTORY_V1_POSIX_QUARANTINE_CAPABILITY,
+      closeTarget: () => { closeHookCalls += 1; },
+    });
+    const openForClose = createInventoryV1TestOpener({
+      quarantineCapability: INVENTORY_V1_POSIX_QUARANTINE_CAPABILITY,
+      closeTarget: (_close) => {
+        closeHookCalls += 1;
+        throw new Error('test close hook must be inert');
+      },
+    });
+    const closeFoundation = await openForClose(temporaryDataDirectory());
+    try {
+      process.env.NODE_ENV = 'production';
+      process.env[overrideName] = '1';
+      expect(() => createInventoryV1TestOpener()).toThrowError(
+        expect.objectContaining({ code: 'database-io' }),
+      );
+      await expect(guardedOpen(unopenedDataDirectory)).rejects.toSatisfy(
+        (error: unknown) => expectOpenErrorCode(error, 'database-io'),
+      );
+      expect(existsSync(dirname(databasePath(unopenedDataDirectory)))).toBe(false);
+
+      closeFoundation.close();
+      expect(closeHookCalls).toBe(0);
+
+      const productionDataDirectory = temporaryDataDirectory();
+      const productionPath = databasePath(productionDataDirectory);
+      createIncompatibleOwnedInventory(productionPath, 'production-override-inert');
+      const productionFoundation = await openProductionInventoryV1(
+        productionDataDirectory,
+        { quarantineCapability: INVENTORY_V1_POSIX_QUARANTINE_CAPABILITY },
+      );
+      productionFoundation.close();
+      assertInitializedInventory(productionPath);
+    } finally {
+      if (previousNodeEnvironment === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = previousNodeEnvironment;
+      if (previousOverride === undefined) delete process.env[overrideName];
+      else process.env[overrideName] = previousOverride;
+    }
+  });
+
+  it('releases the OS-backed lease when a holder process is killed', async () => {
+    const dataDirectory = temporaryDataDirectory();
+    const initialized = await openInventoryV1(dataDirectory);
+    initialized.close();
+    const child = await startLeaseHolder(leasePath(dataDirectory));
+    try {
+      await expect(openInventoryV1(dataDirectory)).rejects.toSatisfy((error: unknown) =>
+        expectOpenErrorCode(error, 'database-busy'));
+    } finally {
+      await killLeaseHolder(child);
+    }
+
+    const reopened = await openInventoryV1(dataDirectory);
+    reopened.close();
+  });
+
+  it('fails closed on foreign, newer, and corrupt lease identities without quarantine', async () => {
+    for (const kind of ['foreign', 'newer', 'corrupt'] as const) {
+      const dataDirectory = temporaryDataDirectory();
+      const path = databasePath(dataDirectory);
+      const leaseFile = leasePath(dataDirectory);
+      mkdirSync(dirname(path), { recursive: true });
+      const lease = new DatabaseSync(leaseFile);
+      lease.exec(kind === 'foreign'
+        ? 'PRAGMA application_id = 305419896; PRAGMA user_version = 1;'
+        : `PRAGMA application_id = ${0x444b364c}; PRAGMA user_version = ${kind === 'newer' ? 2 : 1};`);
+      lease.close();
+      if (kind === 'corrupt') truncateSync(leaseFile, 100);
+      const before = readFileSync(leaseFile);
+
+      await expect(openInventoryV1(dataDirectory)).rejects.toSatisfy((error: unknown) =>
+        expectOpenErrorCode(
+          error,
+          kind === 'foreign' ? 'foreign-database' : kind === 'newer' ? 'newer-schema' : 'ambiguous-database',
+        ));
+      expect(readFileSync(leaseFile)).toEqual(before);
+      expect(existsSync(path)).toBe(false);
+      expectNoQuarantine(path);
+    }
+  });
+
+  it('never initializes a pre-existing headerless or zero-zero lease remnant', async () => {
+    for (const kind of ['empty', 'zero-zero'] as const) {
+      const dataDirectory = temporaryDataDirectory();
+      const path = databasePath(dataDirectory);
+      const leaseFile = leasePath(dataDirectory);
+      mkdirSync(dirname(path), { recursive: true });
+      if (kind === 'empty') {
+        writeFileSync(leaseFile, Buffer.alloc(0));
+      } else {
+        const lease = new DatabaseSync(leaseFile);
+        lease.exec('VACUUM');
+        lease.close();
+      }
+      const before = readFileSync(leaseFile);
+      const beforeMode = statSync(leaseFile).mode & 0o777;
+
+      await expect(openInventoryV1(dataDirectory)).rejects.toSatisfy((error: unknown) =>
+        expectOpenErrorCode(error, 'ambiguous-database'));
+
+      expect(readFileSync(leaseFile)).toEqual(before);
+      if (process.platform !== 'win32') expect(statSync(leaseFile).mode & 0o777).toBe(beforeMode);
+      expect(existsSync(path)).toBe(false);
+      expectNoQuarantine(path);
     }
   });
 
@@ -268,6 +891,31 @@ describe('RFC-64 inventory v1 SQLite lifecycle', () => {
     }
   });
 
+  it('fails closed before automatic quarantine when namespace durability is unavailable', async () => {
+    const dataDirectory = temporaryDataDirectory();
+    const path = databasePath(dataDirectory);
+    mkdirSync(dirname(path), { recursive: true });
+    const incompatible = new DatabaseSync(path);
+    incompatible.exec(`
+      CREATE TABLE wrong_v1 (value TEXT);
+      INSERT INTO wrong_v1 VALUES ('must-survive');
+      PRAGMA application_id = ${INVENTORY_V1_APPLICATION_ID};
+      PRAGMA user_version = 1;
+    `);
+    incompatible.close();
+    const before = readFileSync(path);
+
+    await expect(openProductionInventoryV1(dataDirectory)).rejects.toSatisfy(
+      (error: unknown) => expectOpenErrorCode(error, 'durability-unavailable'),
+    );
+
+    expect(readFileSync(path)).toEqual(before);
+    expectNoQuarantine(path);
+    const check = new DatabaseSync(path, { readOnly: true });
+    expect(check.prepare('SELECT value FROM wrong_v1').get()?.value).toBe('must-survive');
+    check.close();
+  });
+
   it('refuses NOTADB bytes without manufacturing DK64 ownership or quarantine', async () => {
     const dataDirectory = temporaryDataDirectory();
     const path = databasePath(dataDirectory);
@@ -279,6 +927,28 @@ describe('RFC-64 inventory v1 SQLite lifecycle', () => {
       expectOpenErrorCode(error, 'ambiguous-database'));
     expect(readFileSync(path)).toEqual(corruptBytes);
     expectNoQuarantine(path);
+  });
+
+  it('never initializes a pre-existing empty or zero-zero target remnant', async () => {
+    for (const kind of ['empty', 'zero-zero'] as const) {
+      const dataDirectory = temporaryDataDirectory();
+      const path = databasePath(dataDirectory);
+      mkdirSync(dirname(path), { recursive: true });
+      if (kind === 'empty') {
+        writeFileSync(path, Buffer.alloc(0));
+      } else {
+        const target = new DatabaseSync(path);
+        target.exec('VACUUM');
+        target.close();
+      }
+      const before = readFileSync(path);
+
+      await expect(openInventoryV1(dataDirectory)).rejects.toSatisfy((error: unknown) =>
+        expectOpenErrorCode(error, 'ambiguous-database'));
+
+      expect(readFileSync(path)).toEqual(before);
+      expectNoQuarantine(path);
+    }
   });
 
   it('refuses a corrupt application_id=0 database with user data as ambiguous', async () => {
@@ -438,15 +1108,32 @@ describe('RFC-64 inventory v1 SQLite lifecycle', () => {
     },
   );
 
-  it('refuses orphaned sidecars without deleting them', async () => {
-    const dataDirectory = temporaryDataDirectory();
-    const path = databasePath(dataDirectory);
-    mkdirSync(dirname(path), { recursive: true });
-    writeFileSync(`${path}-wal`, 'orphan');
-    await expect(openInventoryV1(dataDirectory)).rejects.toSatisfy((error: unknown) =>
-      expectOpenErrorCode(error, 'ambiguous-database'));
-    expect(readFileSync(`${path}-wal`, 'utf8')).toBe('orphan');
-    expectNoQuarantine(path);
+  it('refuses every orphan target and lease sidecar without mutating the unit', async () => {
+    for (const unit of ['target', 'lease'] as const) {
+      for (const suffix of ['-journal', '-wal', '-shm'] as const) {
+        const dataDirectory = temporaryDataDirectory();
+        const path = databasePath(dataDirectory);
+        const mainPath = unit === 'target' ? path : leasePath(dataDirectory);
+        mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+        if (process.platform !== 'win32') chmodSync(dirname(path), 0o700);
+        const sidecarPath = `${mainPath}${suffix}`;
+        const evidence = Buffer.from(`orphan-${unit}${suffix}-evidence`);
+        writeFileSync(sidecarPath, evidence);
+        const beforeMode = statSync(sidecarPath).mode & 0o777;
+        const beforeEntries = readdirSync(dirname(path)).sort();
+
+        await expect(openInventoryV1(dataDirectory)).rejects.toSatisfy((error: unknown) =>
+          expectOpenErrorCode(error, 'ambiguous-database'));
+
+        expect(existsSync(mainPath)).toBe(false);
+        expect(readFileSync(sidecarPath)).toEqual(evidence);
+        expect(statSync(sidecarPath).mode & 0o777).toBe(beforeMode);
+        expect(readdirSync(dirname(path)).sort()).toEqual(beforeEntries);
+        expect(existsSync(path)).toBe(false);
+        expect(existsSync(leasePath(dataDirectory))).toBe(false);
+        expectNoQuarantine(path);
+      }
+    }
   });
 
   it.runIf(process.platform !== 'win32' && process.getuid?.() !== 0)(
@@ -473,12 +1160,16 @@ describe('RFC-64 inventory v1 SQLite lifecycle', () => {
     const dataDirectory = temporaryDataDirectory();
     const path = databasePath(dataDirectory);
     mkdirSync(dirname(path), { recursive: true });
-    const holder = new DatabaseSync(path);
-    holder.exec(`
-      PRAGMA journal_mode = WAL;
+    const seed = new DatabaseSync(path);
+    seed.exec(`
       CREATE TABLE wrong_v1 (value TEXT);
       PRAGMA application_id = ${INVENTORY_V1_APPLICATION_ID};
       PRAGMA user_version = 1;
+    `);
+    seed.close();
+    const holder = new DatabaseSync(path);
+    holder.exec(`
+      PRAGMA journal_mode = WAL;
       BEGIN IMMEDIATE;
     `);
     try {
@@ -523,6 +1214,431 @@ describe('RFC-64 inventory v1 SQLite lifecycle', () => {
     }
   });
 
+  it('rejects recovery markers with unknown keys or a non-frozen members manifest', async () => {
+    const invalidMarkers: unknown[] = [
+      { version: 1, quarantineDirectory: 'placeholder' },
+      { version: 1, quarantineDirectory: 'placeholder', members: ['main'], extra: true },
+      { version: 1, quarantineDirectory: 'placeholder', members: ['main', 'wal'] },
+      { version: 1, quarantineDirectory: 'placeholder', members: ['wal', 'wal', 'main'] },
+      { version: 1, quarantineDirectory: 'placeholder', members: ['unknown', 'main'] },
+    ];
+
+    for (let index = 0; index < invalidMarkers.length; index += 1) {
+      const dataDirectory = temporaryDataDirectory();
+      const path = databasePath(dataDirectory);
+      createIncompatibleOwnedInventory(path, `invalid-shape-${index}`);
+      const sourceBefore = fileOracle(path);
+      const generation = join(
+        dirname(path),
+        'quarantine',
+        `inventory-v1-1234567890-${String(index).padStart(16, 'a')}`,
+      );
+      mkdirSync(generation, { recursive: true });
+      const markerObject = invalidMarkers[index] as Record<string, unknown>;
+      markerObject.quarantineDirectory = generation;
+      const marker = JSON.stringify(markerObject);
+      writeFileSync(`${path}.rebuild-required`, marker);
+      const inventoryDirectory = dirname(path);
+      const directoryModeBefore = statSync(inventoryDirectory).mode;
+      const entriesBefore = readdirSync(inventoryDirectory).sort();
+      const reached: InventoryV1QuarantineBoundary[] = [];
+      const openMalformedMarker = createInventoryV1TestOpener({
+        quarantineCapability: INVENTORY_V1_POSIX_QUARANTINE_CAPABILITY,
+        boundary: (boundary) => reached.push(boundary),
+      });
+
+      await expect(openMalformedMarker(dataDirectory)).rejects.toSatisfy((error: unknown) =>
+        expectOpenErrorCode(error, 'database-io'));
+
+      expect(reached).toEqual([]);
+      expect(readFileSync(`${path}.rebuild-required`, 'utf8')).toBe(marker);
+      expect(fileOracle(path)).toEqual(sourceBefore);
+      expect(readdirSync(generation)).toEqual([]);
+      expect(statSync(inventoryDirectory).mode).toBe(directoryModeBefore);
+      expect(readdirSync(inventoryDirectory).sort()).toEqual(entriesBefore);
+      expect(existsSync(leasePath(dataDirectory))).toBe(false);
+    }
+  });
+
+  it('rejects duplicate-key and non-canonical recovery marker encodings without mutation', async () => {
+    for (const kind of ['duplicate-version', 'duplicate-directory', 'duplicate-members', 'whitespace', 'reordered'] as const) {
+      const dataDirectory = temporaryDataDirectory();
+      const path = databasePath(dataDirectory);
+      createIncompatibleOwnedInventory(path, `invalid-encoding-${kind}`);
+      const sourceBefore = fileOracle(path);
+      const generation = join(
+        dirname(path),
+        'quarantine',
+        'inventory-v1-1234567890-cacacacacacacaca',
+      );
+      mkdirSync(generation, { recursive: true });
+      const encodedGeneration = JSON.stringify(generation);
+      const marker = kind === 'duplicate-version'
+        ? `{"version":1,"version":1,"quarantineDirectory":${encodedGeneration},"members":["main"]}`
+        : kind === 'duplicate-directory'
+          ? `{"version":1,"quarantineDirectory":${encodedGeneration},"quarantineDirectory":${encodedGeneration},"members":["main"]}`
+          : kind === 'duplicate-members'
+            ? `{"version":1,"quarantineDirectory":${encodedGeneration},"members":["main"],"members":["main"]}`
+            : kind === 'whitespace'
+              ? `{"version":1, "quarantineDirectory":${encodedGeneration},"members":["main"]}`
+              : `{"members":["main"],"quarantineDirectory":${encodedGeneration},"version":1}`;
+      writeFileSync(`${path}.rebuild-required`, marker);
+      const inventoryDirectory = dirname(path);
+      const directoryModeBefore = statSync(inventoryDirectory).mode;
+      const entriesBefore = readdirSync(inventoryDirectory).sort();
+      const reached: InventoryV1QuarantineBoundary[] = [];
+      const openMalformedMarker = createInventoryV1TestOpener({
+        quarantineCapability: INVENTORY_V1_POSIX_QUARANTINE_CAPABILITY,
+        boundary: (boundary) => reached.push(boundary),
+      });
+
+      await expect(openMalformedMarker(dataDirectory)).rejects.toSatisfy((error: unknown) =>
+        expectOpenErrorCode(error, 'database-io'));
+
+      expect(reached).toEqual([]);
+      expect(readFileSync(`${path}.rebuild-required`, 'utf8')).toBe(marker);
+      expect(fileOracle(path)).toEqual(sourceBefore);
+      expect(readdirSync(generation)).toEqual([]);
+      expect(statSync(inventoryDirectory).mode).toBe(directoryModeBefore);
+      expect(readdirSync(inventoryDirectory).sort()).toEqual(entriesBefore);
+      expect(existsSync(leasePath(dataDirectory))).toBe(false);
+    }
+  });
+
+  it('bounds and strictly decodes recovery markers and rejects every path alias before exclusivity or movement', async () => {
+    const variants = [
+      'cap-plus-one',
+      'invalid-utf8',
+      'utf8-bom',
+      'relative',
+      'normalized-alias',
+      'trailing-separator',
+      'escape',
+      'lone-surrogate',
+    ] as const;
+    for (const [index, variant] of variants.entries()) {
+      const dataDirectory = temporaryDataDirectory();
+      const path = databasePath(dataDirectory);
+      createIncompatibleOwnedInventory(path, `marker-${variant}`);
+      const sourceBefore = fileOracle(path);
+      const generationName = `inventory-v1-1234567890-${String(index).padStart(16, 'a')}`;
+      const quarantineRoot = join(dirname(path), 'quarantine');
+      const generation = join(quarantineRoot, generationName);
+      mkdirSync(generation, { recursive: true });
+      const canonical = JSON.stringify({
+        version: 1,
+        quarantineDirectory: generation,
+        members: ['main'],
+      });
+      const markerBytes = variant === 'cap-plus-one'
+        ? Buffer.alloc(4_097, 0x20)
+        : variant === 'invalid-utf8'
+          ? Buffer.from([0x7b, 0x22, 0xff, 0x22, 0x7d])
+          : variant === 'utf8-bom'
+            ? Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), Buffer.from(canonical)])
+            : Buffer.from(variant === 'lone-surrogate'
+              ? `{"version":1,"quarantineDirectory":"\\ud800","members":["main"]}`
+              : JSON.stringify({
+                version: 1,
+                quarantineDirectory: variant === 'relative'
+                  ? join('quarantine', generationName)
+                  : variant === 'normalized-alias'
+                    ? `${quarantineRoot}/nested/../${generationName}`
+                    : variant === 'trailing-separator'
+                      ? `${generation}/`
+                      : join(quarantineRoot, '..', generationName),
+                members: ['main'],
+              }));
+      writeFileSync(`${path}.rebuild-required`, markerBytes);
+      const inventoryDirectory = dirname(path);
+      const directoryModeBefore = statSync(inventoryDirectory).mode;
+      const entriesBefore = readdirSync(inventoryDirectory).sort();
+      let exclusivityBoundaries = 0;
+      const openForMarkerTest = createInventoryV1TestOpener({
+        quarantineCapability: INVENTORY_V1_POSIX_QUARANTINE_CAPABILITY,
+        boundary: (boundary) => {
+          if (boundary === 'target-exclusivity-proven') exclusivityBoundaries += 1;
+        },
+      });
+
+      await expect(
+        openForMarkerTest(dataDirectory),
+      ).rejects.toBeInstanceOf(InventoryV1OpenError);
+      expect(exclusivityBoundaries).toBe(0);
+      expect(fileOracle(path)).toEqual(sourceBefore);
+      expect(readFileSync(`${path}.rebuild-required`)).toEqual(markerBytes);
+      expect(readdirSync(generation)).toEqual([]);
+      expect(statSync(inventoryDirectory).mode).toBe(directoryModeBefore);
+      expect(readdirSync(inventoryDirectory).sort()).toEqual(entriesBefore);
+      expect(existsSync(leasePath(dataDirectory))).toBe(false);
+    }
+  });
+
+  it('round-trips a canonical marker beneath a hostile but valid data-directory name', async () => {
+    const container = temporaryDataDirectory();
+    const dataDirectory = join(container, 'hostile [] ž\n☃');
+    const path = databasePath(dataDirectory);
+    createIncompatibleOwnedInventory(path, 'hostile-data-directory');
+    const foundation = await openInventoryV1(dataDirectory);
+    try {
+      assertInitializedInventory(path);
+      assertRecoveredManifestEvidence(path, ['main'], 'hostile-data-directory');
+    } finally {
+      foundation.close();
+    }
+  });
+
+  it('resumes a prefix-moved manifest without reopening the partial SQLite source', async () => {
+    const dataDirectory = temporaryDataDirectory();
+    const path = databasePath(dataDirectory);
+    const generation = join(
+      dirname(path),
+      'quarantine',
+      'inventory-v1-1234567890-eeeeeeeeeeeeeeee',
+    );
+    mkdirSync(generation, { recursive: true });
+    writeFileSync(join(generation, 'inventory-v1.sqlite3-wal'), 'wal-moved-before-crash');
+    writeFileSync(`${path}-shm`, 'shm-still-at-source');
+    // This is intentionally not SQLite. Because WAL already moved, reopening
+    // or checkpointing the partial source would fail; manifest resume must
+    // treat the remaining bytes as evidence and continue under the lease.
+    writeFileSync(path, 'not-a-sqlite-main-but-marker-owned');
+    writeFileSync(
+      `${path}.rebuild-required`,
+      JSON.stringify({
+        version: 1,
+        quarantineDirectory: generation,
+        members: ['wal', 'shm', 'main'],
+      }),
+    );
+
+    const foundation = await openInventoryV1(dataDirectory);
+    try {
+      assertInitializedInventory(path);
+      expect(readFileSync(join(generation, 'inventory-v1.sqlite3-wal'), 'utf8')).toBe(
+        'wal-moved-before-crash',
+      );
+      expect(readFileSync(join(generation, 'inventory-v1.sqlite3-shm'), 'utf8')).toBe(
+        'shm-still-at-source',
+      );
+      expect(readFileSync(join(generation, 'inventory-v1.sqlite3'), 'utf8')).toBe(
+        'not-a-sqlite-main-but-marker-owned',
+      );
+      expect(existsSync(`${path}.rebuild-required`)).toBe(false);
+    } finally {
+      foundation.close();
+    }
+  });
+
+  it('finishes an all-destination crash topology without recreating or reopening the source', async () => {
+    const dataDirectory = temporaryDataDirectory();
+    const path = databasePath(dataDirectory);
+    const generation = join(
+      dirname(path),
+      'quarantine',
+      'inventory-v1-1234567890-abababababababab',
+    );
+    mkdirSync(generation, { recursive: true });
+    writeFileSync(join(generation, 'inventory-v1.sqlite3'), 'main-moved-before-crash');
+    writeFileSync(
+      `${path}.rebuild-required`,
+      JSON.stringify({ version: 1, quarantineDirectory: generation, members: ['main'] }),
+    );
+
+    const foundation = await openInventoryV1(dataDirectory);
+    try {
+      assertInitializedInventory(path);
+      expect(readFileSync(join(generation, 'inventory-v1.sqlite3'), 'utf8')).toBe(
+        'main-moved-before-crash',
+      );
+      expect(existsSync(`${path}.rebuild-required`)).toBe(false);
+    } finally {
+      foundation.close();
+    }
+  });
+
+  it('fails closed on a reordered partial recovery topology without moving evidence', async () => {
+    const dataDirectory = temporaryDataDirectory();
+    const path = databasePath(dataDirectory);
+    const generation = join(
+      dirname(path),
+      'quarantine',
+      'inventory-v1-1234567890-ffffffffffffffff',
+    );
+    mkdirSync(generation, { recursive: true });
+    writeFileSync(`${path}-wal`, 'wal-source');
+    writeFileSync(join(generation, 'inventory-v1.sqlite3-shm'), 'shm-destination');
+    writeFileSync(path, 'main-source');
+    const marker = JSON.stringify({
+      version: 1,
+      quarantineDirectory: generation,
+      members: ['wal', 'shm', 'main'],
+    });
+    writeFileSync(`${path}.rebuild-required`, marker);
+
+    await expect(openInventoryV1(dataDirectory)).rejects.toSatisfy((error: unknown) =>
+      expectOpenErrorCode(error, 'database-io'));
+
+    expect(readFileSync(`${path}-wal`, 'utf8')).toBe('wal-source');
+    expect(readFileSync(join(generation, 'inventory-v1.sqlite3-shm'), 'utf8')).toBe(
+      'shm-destination',
+    );
+    expect(readFileSync(path, 'utf8')).toBe('main-source');
+    expect(readFileSync(`${path}.rebuild-required`, 'utf8')).toBe(marker);
+  });
+
+  it('fails closed on duplicate, missing, unlisted, or unknown recovery evidence', async () => {
+    for (const kind of ['duplicate', 'missing', 'unlisted', 'unknown-entry'] as const) {
+      const dataDirectory = temporaryDataDirectory();
+      const path = databasePath(dataDirectory);
+      const generation = join(
+        dirname(path),
+        'quarantine',
+        `inventory-v1-1234567890-${kind === 'duplicate' ? '1111111111111111'
+          : kind === 'missing' ? '2222222222222222'
+            : kind === 'unlisted' ? '3333333333333333' : '4444444444444444'}`,
+      );
+      mkdirSync(generation, { recursive: true });
+      if (kind !== 'missing') writeFileSync(path, 'source-main-evidence');
+      if (kind === 'duplicate') {
+        writeFileSync(join(generation, 'inventory-v1.sqlite3'), 'destination-main-evidence');
+      }
+      if (kind === 'unlisted') writeFileSync(`${path}-wal`, 'unlisted-wal-evidence');
+      if (kind === 'unknown-entry') writeFileSync(join(generation, 'unexpected-file'), 'unknown');
+      const marker = JSON.stringify({
+        version: 1,
+        quarantineDirectory: generation,
+        members: ['main'],
+      });
+      writeFileSync(`${path}.rebuild-required`, marker);
+
+      await expect(openInventoryV1(dataDirectory)).rejects.toSatisfy((error: unknown) =>
+        expectOpenErrorCode(error, 'database-io'));
+
+      expect(readFileSync(`${path}.rebuild-required`, 'utf8')).toBe(marker);
+      if (kind !== 'missing') expect(readFileSync(path, 'utf8')).toBe('source-main-evidence');
+      if (kind === 'duplicate') {
+        expect(readFileSync(join(generation, 'inventory-v1.sqlite3'), 'utf8')).toBe(
+          'destination-main-evidence',
+        );
+      }
+      if (kind === 'unlisted') {
+        expect(readFileSync(`${path}-wal`, 'utf8')).toBe('unlisted-wal-evidence');
+      }
+      if (kind === 'unknown-entry') {
+        expect(readFileSync(join(generation, 'unexpected-file'), 'utf8')).toBe('unknown');
+      }
+    }
+  });
+
+  it('exhaustively rejects every non-prefix source/destination/missing/duplicate manifest topology without mutation', async () => {
+    const manifests = [
+      ['main'],
+      ['wal', 'main'],
+      ['shm', 'main'],
+      ['wal', 'shm', 'main'],
+    ] as const satisfies readonly RecoveryManifest[];
+    const locations = ['source', 'destination', 'missing', 'both'] as const;
+    for (const members of manifests) {
+      let combinations: Array<Array<typeof locations[number]>> = [[]];
+      for (let index = 0; index < members.length; index += 1) {
+        combinations = combinations.flatMap((row) =>
+          locations.map((location) => [...row, location]));
+      }
+      for (const [caseIndex, topology] of combinations.entries()) {
+        const isValidPrefix = topology.every((location) =>
+          location === 'source' || location === 'destination')
+          && !topology.some((location, index) =>
+            location === 'destination' && topology.slice(0, index).includes('source'));
+        if (isValidPrefix) continue;
+
+        const dataDirectory = temporaryDataDirectory();
+        const path = databasePath(dataDirectory);
+        const generation = join(
+          dirname(path),
+          'quarantine',
+          `inventory-v1-1234567890-${caseIndex.toString(16).padStart(16, '0')}`,
+        );
+        mkdirSync(generation, { recursive: true });
+        const evidencePaths: string[] = [];
+        for (const [index, member] of members.entries()) {
+          const location = topology[index]!;
+          const source = recoverySourcePath(path, member);
+          const destination = recoveryDestinationPath(generation, member);
+          if (location === 'source' || location === 'both') {
+            writeFileSync(source, `source-${member}-${caseIndex}`);
+            evidencePaths.push(source);
+          }
+          if (location === 'destination' || location === 'both') {
+            writeFileSync(destination, `destination-${member}-${caseIndex}`);
+            evidencePaths.push(destination);
+          }
+        }
+        const marker = Buffer.from(JSON.stringify({
+          version: 1,
+          quarantineDirectory: generation,
+          members,
+        }));
+        writeFileSync(`${path}.rebuild-required`, marker);
+        const before = new Map(evidencePaths.map((evidence) => [evidence, fileOracle(evidence)]));
+
+        await expect(openInventoryV1(dataDirectory)).rejects.toSatisfy(
+          (error: unknown) => expectOpenErrorCode(error, 'database-io'),
+        );
+
+        expect(readFileSync(`${path}.rebuild-required`)).toEqual(marker);
+        for (const evidence of evidencePaths) {
+          expect(fileOracle(evidence)).toEqual(before.get(evidence));
+        }
+      }
+    }
+  }, 60_000);
+
+  it('re-probes a zero-move marker and refuses an active raw SQLite holder', async () => {
+    const dataDirectory = temporaryDataDirectory();
+    const path = databasePath(dataDirectory);
+    const generation = join(
+      dirname(path),
+      'quarantine',
+      'inventory-v1-1234567890-9999999999999999',
+    );
+    mkdirSync(generation, { recursive: true });
+    const seed = new DatabaseSync(path);
+    seed.exec(`
+      CREATE TABLE wrong_v1 (value TEXT);
+      PRAGMA application_id = ${INVENTORY_V1_APPLICATION_ID};
+      PRAGMA user_version = 1;
+    `);
+    seed.close();
+    const marker = JSON.stringify({
+      version: 1,
+      quarantineDirectory: generation,
+      members: ['main'],
+    });
+    writeFileSync(`${path}.rebuild-required`, marker);
+    const holder = new DatabaseSync(path);
+    holder.exec('BEGIN IMMEDIATE');
+    try {
+      await expect(openInventoryV1(dataDirectory)).rejects.toSatisfy((error: unknown) =>
+        expectOpenErrorCode(error, 'database-busy'));
+      expect(existsSync(path)).toBe(true);
+      expect(readdirSync(generation)).toEqual([]);
+      expect(readFileSync(`${path}.rebuild-required`, 'utf8')).toBe(marker);
+    } finally {
+      holder.exec('ROLLBACK');
+      holder.close();
+    }
+
+    const foundation = await openInventoryV1(dataDirectory);
+    try {
+      assertInitializedInventory(path);
+      expect(existsSync(`${path}.rebuild-required`)).toBe(false);
+      expect(existsSync(join(generation, 'inventory-v1.sqlite3'))).toBe(true);
+    } finally {
+      foundation.close();
+    }
+  });
+
   it('resumes a partial recovery-marker move before rebuilding', async () => {
     const dataDirectory = temporaryDataDirectory();
     const path = databasePath(dataDirectory);
@@ -533,24 +1649,106 @@ describe('RFC-64 inventory v1 SQLite lifecycle', () => {
       'inventory-v1-1234567890-aaaaaaaaaaaaaaaa',
     );
     mkdirSync(generation, { recursive: true });
-    writeFileSync(join(generation, 'inventory-v1.sqlite3'), 'main-before-crash');
-    writeFileSync(`${path}-wal`, 'wal-before-crash');
-    writeFileSync(`${path}-shm`, 'shm-before-crash');
+    const incompatible = new DatabaseSync(path);
+    incompatible.exec(`
+      CREATE TABLE wrong_v1 (value TEXT);
+      INSERT INTO wrong_v1 VALUES ('main-before-crash');
+      PRAGMA application_id = ${INVENTORY_V1_APPLICATION_ID};
+      PRAGMA user_version = 1;
+    `);
+    incompatible.close();
+    // A supported crash after both sidecars moved leaves the valid source
+    // main in place. Resume must prove that main quiescent, move it last, and
+    // then rebuild a fresh inventory at the source pathname.
+    writeFileSync(join(generation, 'inventory-v1.sqlite3-wal'), 'wal-before-crash');
+    writeFileSync(join(generation, 'inventory-v1.sqlite3-shm'), 'shm-before-crash');
     writeFileSync(
       `${path}.rebuild-required`,
-      JSON.stringify({ version: 1, quarantineDirectory: generation }),
+      JSON.stringify({
+        version: 1,
+        quarantineDirectory: generation,
+        members: ['wal', 'shm', 'main'],
+      }),
     );
 
     const foundation = await openInventoryV1(dataDirectory);
     try {
       assertInitializedInventory(path);
-      expect(readFileSync(join(generation, 'inventory-v1.sqlite3'), 'utf8')).toBe('main-before-crash');
       expect(readFileSync(join(generation, 'inventory-v1.sqlite3-wal'), 'utf8')).toBe('wal-before-crash');
       expect(readFileSync(join(generation, 'inventory-v1.sqlite3-shm'), 'utf8')).toBe('shm-before-crash');
       expect(existsSync(`${path}.rebuild-required`)).toBe(false);
+      // Remove the synthetic sidecar evidence only after verifying it, so the
+      // quarantined main can be inspected independently.
+      rmSync(join(generation, 'inventory-v1.sqlite3-wal'));
+      rmSync(join(generation, 'inventory-v1.sqlite3-shm'));
+      const old = new DatabaseSync(join(generation, 'inventory-v1.sqlite3'), { readOnly: true });
+      expect(old.prepare('SELECT value FROM wrong_v1').get()?.value).toBe('main-before-crash');
+      old.close();
     } finally {
       foundation.close();
     }
+  });
+
+  it('refuses a pending recovery unit with sidecars but no main without creating a source database', async () => {
+    const dataDirectory = temporaryDataDirectory();
+    const path = databasePath(dataDirectory);
+    const generation = join(
+      dirname(path),
+      'quarantine',
+      'inventory-v1-1234567890-dddddddddddddddd',
+    );
+    mkdirSync(generation, { recursive: true });
+    writeFileSync(`${path}-wal`, 'orphaned-wal-evidence');
+    const marker = JSON.stringify({
+      version: 1,
+      quarantineDirectory: generation,
+      members: ['wal', 'main'],
+    });
+    writeFileSync(`${path}.rebuild-required`, marker);
+
+    await expect(openInventoryV1(dataDirectory)).rejects.toSatisfy((error: unknown) =>
+      expectOpenErrorCode(error, 'database-io'));
+
+    expect(existsSync(path)).toBe(false);
+    expect(readFileSync(`${path}-wal`, 'utf8')).toBe('orphaned-wal-evidence');
+    expect(readFileSync(`${path}.rebuild-required`, 'utf8')).toBe(marker);
+    expect(readdirSync(generation)).toEqual([]);
+  });
+
+  it('leaves a pending marker and every evidence byte untouched when durability is unavailable', async () => {
+    const dataDirectory = temporaryDataDirectory();
+    const path = databasePath(dataDirectory);
+    const inventoryDirectory = dirname(path);
+    const generation = join(
+      inventoryDirectory,
+      'quarantine',
+      'inventory-v1-1234567890-cccccccccccccccc',
+    );
+    mkdirSync(generation, { recursive: true });
+    writeFileSync(path, 'main-before-resume');
+    writeFileSync(`${path}-wal`, 'wal-before-resume');
+    writeFileSync(join(generation, 'inventory-v1.sqlite3-shm'), 'destination-before-resume');
+    const marker = JSON.stringify({
+      version: 1,
+      quarantineDirectory: generation,
+      members: ['wal', 'shm', 'main'],
+    });
+    writeFileSync(`${path}.rebuild-required`, marker);
+    const before = {
+      main: readFileSync(path),
+      wal: readFileSync(`${path}-wal`),
+      destination: readFileSync(join(generation, 'inventory-v1.sqlite3-shm')),
+      marker: readFileSync(`${path}.rebuild-required`),
+    };
+
+    await expect(openProductionInventoryV1(dataDirectory)).rejects.toSatisfy(
+      (error: unknown) => expectOpenErrorCode(error, 'durability-unavailable'),
+    );
+
+    expect(readFileSync(path)).toEqual(before.main);
+    expect(readFileSync(`${path}-wal`)).toEqual(before.wal);
+    expect(readFileSync(join(generation, 'inventory-v1.sqlite3-shm'))).toEqual(before.destination);
+    expect(readFileSync(`${path}.rebuild-required`)).toEqual(before.marker);
   });
 
   it('retains the recovery marker across an interrupted evidence move and resumes', async () => {
@@ -563,31 +1761,253 @@ describe('RFC-64 inventory v1 SQLite lifecycle', () => {
       'inventory-v1-1234567890-bbbbbbbbbbbbbbbb',
     );
     mkdirSync(generation, { recursive: true });
-    writeFileSync(path, 'main-before-crash');
-    writeFileSync(`${path}-wal`, 'wal-before-crash');
-    writeFileSync(join(generation, 'inventory-v1.sqlite3-wal'), 'conflicting-target');
+    const incompatible = new DatabaseSync(path);
+    incompatible.exec(`
+      CREATE TABLE wrong_v1 (value TEXT);
+      INSERT INTO wrong_v1 VALUES ('main-before-crash');
+      PRAGMA application_id = ${INVENTORY_V1_APPLICATION_ID};
+      PRAGMA user_version = 1;
+    `);
+    incompatible.close();
+    writeFileSync(join(generation, 'inventory-v1.sqlite3'), 'conflicting-target');
     writeFileSync(
       `${path}.rebuild-required`,
-      JSON.stringify({ version: 1, quarantineDirectory: generation }),
+      JSON.stringify({ version: 1, quarantineDirectory: generation, members: ['main'] }),
     );
 
     await expect(openInventoryV1(dataDirectory)).rejects.toSatisfy((error: unknown) =>
       expectOpenErrorCode(error, 'database-io'));
     expect(existsSync(`${path}.rebuild-required`)).toBe(true);
-    expect(readFileSync(join(generation, 'inventory-v1.sqlite3'), 'utf8')).toBe('main-before-crash');
-    expect(readFileSync(`${path}-wal`, 'utf8')).toBe('wal-before-crash');
+    expect(readFileSync(join(generation, 'inventory-v1.sqlite3'), 'utf8')).toBe('conflicting-target');
+    const source = new DatabaseSync(path, { readOnly: true });
+    expect(source.prepare('SELECT value FROM wrong_v1').get()?.value).toBe('main-before-crash');
+    source.close();
 
-    rmSync(join(generation, 'inventory-v1.sqlite3-wal'));
+    rmSync(join(generation, 'inventory-v1.sqlite3'));
     const foundation = await openInventoryV1(dataDirectory);
     try {
       assertInitializedInventory(path);
       expect(existsSync(`${path}.rebuild-required`)).toBe(false);
-      expect(readFileSync(join(generation, 'inventory-v1.sqlite3'), 'utf8')).toBe('main-before-crash');
-      expect(readFileSync(join(generation, 'inventory-v1.sqlite3-wal'), 'utf8')).toBe('wal-before-crash');
+      const old = new DatabaseSync(join(generation, 'inventory-v1.sqlite3'), { readOnly: true });
+      expect(old.prepare('SELECT value FROM wrong_v1').get()?.value).toBe('main-before-crash');
+      old.close();
     } finally {
       foundation.close();
     }
   });
+
+  it('converges every frozen recovery manifest and valid moved-prefix topology', async () => {
+    const manifests = [
+      ['main'],
+      ['wal', 'main'],
+      ['shm', 'main'],
+      ['wal', 'shm', 'main'],
+    ] as const satisfies readonly RecoveryManifest[];
+
+    for (const members of manifests) {
+      for (let movedPrefix = 0; movedPrefix <= members.length; movedPrefix += 1) {
+        const dataDirectory = temporaryDataDirectory();
+        const label = `topology-${members.join('-')}-${movedPrefix}`;
+        const seeded = seedPendingRecoveryTopology(
+          dataDirectory,
+          members,
+          movedPrefix,
+          label,
+        );
+        const path = databasePath(dataDirectory);
+
+        const foundation = await openInventoryV1(dataDirectory);
+        try {
+          assertInitializedInventory(path);
+          assertRecoveredManifestEvidence(
+            path,
+            members,
+            label,
+            seeded.generation,
+            seeded.hashes,
+          );
+        } finally {
+          foundation.close();
+        }
+      }
+    }
+  });
+
+  it('recovers in a fresh process after SIGKILL at every full-manifest durability boundary', async () => {
+    for (const boundary of FULL_MANIFEST_FAULT_BOUNDARIES) {
+      const dataDirectory = temporaryDataDirectory();
+      const path = databasePath(dataDirectory);
+      const label = `fault-${boundary}`;
+      createIncompatibleOwnedInventory(path, label);
+      // Before marker creation the source member set is not committed crash
+      // state. A fresh adapter may normalize empty SQLite auxiliaries and then
+      // start a main-only generation; once the marker exists, every listed
+      // member must retain its exact inode/device/size/digest through recovery.
+      const markerExistsAtBoundary = FULL_MANIFEST_FAULT_BOUNDARIES.indexOf(boundary)
+        >= FULL_MANIFEST_FAULT_BOUNDARIES.indexOf('begin.marker.write');
+      const walEvidence = Buffer.alloc(0);
+      const shmEvidence = Buffer.alloc(0);
+      const expectedHashes: EvidenceHashes = {
+        main: sha256File(path),
+        wal: createHash('sha256').update(walEvidence).digest('hex'),
+        shm: createHash('sha256').update(shmEvidence).digest('hex'),
+      };
+      const tracePath = join(dataDirectory, `trace-${boundary}.jsonl`);
+      const trace = await killAtInventoryBoundary(dataDirectory, boundary, tracePath, {
+        DKG_RFC64_CHILD_SYNTHETIC_FULL_MANIFEST: 'empty',
+        DKG_RFC64_CHILD_PROTECT_EVIDENCE: '1',
+      });
+      expect(trace.map((entry) => entry.boundary)).toEqual(
+        expectedFullManifestTrace(boundary),
+      );
+      const killedTopology = trace.at(-1)!.topology as Array<{
+        path: string;
+        kind: string;
+        dev: number;
+        ino: number;
+        size: number;
+        sha256?: string;
+      }>;
+      const killedEvidence = new Map<RecoveryMember, FileOracle>();
+      for (const member of FULL_RECOVERY_MANIFEST) {
+        const sourceName = member === 'main'
+          ? 'inventory-v1.sqlite3'
+          : `inventory-v1.sqlite3-${member}`;
+        const destinationSuffix = `/inventory-v1.sqlite3${member === 'main' ? '' : `-${member}`}`;
+        const entry = killedTopology.find((candidate) =>
+          candidate.path === sourceName || candidate.path.endsWith(destinationSuffix));
+        expect(entry, `missing ${member} oracle at ${boundary}`).toBeDefined();
+        expect(entry!.kind).toBe('file');
+        expect(entry!.sha256).toBe(expectedHashes[member]);
+        killedEvidence.set(member, {
+          dev: entry!.dev,
+          ino: entry!.ino,
+          size: entry!.size,
+          sha256: entry!.sha256!,
+        });
+      }
+      expect(killedEvidence.get('wal')!.ino).not.toBe(killedEvidence.get('shm')!.ino);
+
+      try {
+        await reopenInventoryInFreshProcess(dataDirectory);
+      } catch (cause) {
+        throw new Error(`fresh-process recovery failed after ${boundary}`, { cause });
+      }
+      assertInitializedInventory(path);
+      try {
+        assertRecoveredManifestEvidence(
+          path,
+          markerExistsAtBoundary ? FULL_RECOVERY_MANIFEST : ['main'],
+          label,
+          undefined,
+          markerExistsAtBoundary ? expectedHashes : { main: expectedHashes.main },
+        );
+      } catch (cause) {
+        throw new Error(`evidence verification failed after ${boundary}`, { cause });
+      }
+      const generation = evidenceGeneration(path);
+      for (const member of markerExistsAtBoundary ? FULL_RECOVERY_MANIFEST : ['main'] as const) {
+        expect(fileOracle(recoveryDestinationPath(generation, member))).toEqual(
+          killedEvidence.get(member),
+        );
+      }
+    }
+  }, 180_000);
+
+  it('recovers in a fresh process after SIGKILL at every moved-prefix re-fsync boundary', async () => {
+    for (const boundary of MOVED_PREFIX_FAULT_BOUNDARIES) {
+      const member = boundary.split('.')[2] as RecoveryMember;
+      const movedPrefix = FULL_RECOVERY_MANIFEST.indexOf(member) + 1;
+      const dataDirectory = temporaryDataDirectory();
+      const path = databasePath(dataDirectory);
+      const label = `prefix-fault-${boundary}`;
+      const seeded = seedPendingRecoveryTopology(
+        dataDirectory,
+        FULL_RECOVERY_MANIFEST,
+        movedPrefix,
+        label,
+        true,
+      );
+      expect(Object.values(seeded.hashes)).toHaveLength(FULL_RECOVERY_MANIFEST.length);
+      expect(new Set(Object.values(seeded.hashes)).size).toBe(FULL_RECOVERY_MANIFEST.length);
+      for (const evidenceMember of FULL_RECOVERY_MANIFEST) {
+        const evidencePath = FULL_RECOVERY_MANIFEST.indexOf(evidenceMember) < movedPrefix
+          ? recoveryDestinationPath(seeded.generation, evidenceMember)
+          : recoverySourcePath(path, evidenceMember);
+        expect(lstatSync(evidencePath).size).toBeGreaterThan(0);
+      }
+      const { generation } = seeded;
+      expect(seeded.hashes.wal).not.toBe(seeded.hashes.shm);
+      expect(fileOracle(recoveryDestinationPath(generation, member)).size).toBeGreaterThan(0);
+      const tracePath = join(dataDirectory, `trace-${boundary}.jsonl`);
+      const trace = await killAtInventoryBoundary(dataDirectory, boundary, tracePath);
+      expect(trace.map((entry) => entry.boundary)).toEqual(
+        MOVED_PREFIX_FAULT_BOUNDARIES.slice(
+          0,
+          MOVED_PREFIX_FAULT_BOUNDARIES.indexOf(boundary) + 1,
+        ),
+      );
+      const before = new Map(
+        FULL_RECOVERY_MANIFEST.map((evidenceMember) => [
+          evidenceMember,
+          fileOracle(
+            FULL_RECOVERY_MANIFEST.indexOf(evidenceMember) < movedPrefix
+              ? recoveryDestinationPath(generation, evidenceMember)
+              : recoverySourcePath(path, evidenceMember),
+          ),
+        ]),
+      );
+
+      await reopenInventoryInFreshProcess(dataDirectory);
+      assertInitializedInventory(path);
+      assertRecoveredManifestEvidence(
+        path,
+        FULL_RECOVERY_MANIFEST,
+        label,
+        generation,
+        seeded.hashes,
+      );
+      for (const evidenceMember of FULL_RECOVERY_MANIFEST) {
+        expect(fileOracle(recoveryDestinationPath(generation, evidenceMember))).toEqual(
+          before.get(evidenceMember),
+        );
+      }
+    }
+  }, 120_000);
+
+  it('fences a separate-process conforming contender after target exclusivity until holder SIGKILL', async () => {
+    const dataDirectory = temporaryDataDirectory();
+    const path = databasePath(dataDirectory);
+    createIncompatibleOwnedInventory(path, 'separate-process-contender');
+    const tracePath = join(dataDirectory, 'contender-holder-trace.jsonl');
+    const holder = spawnInventoryChild('fault', dataDirectory, {
+      DKG_RFC64_CHILD_BOUNDARY: 'target-exclusivity-proven',
+      DKG_RFC64_CHILD_TRACE: tracePath,
+    });
+    await waitForChildBoundary(holder, 'target-exclusivity-proven');
+    const targetBefore = fileOracle(path);
+    const namespaceBefore = readdirSync(dirname(path)).sort();
+    expect(await runContender(dataDirectory)).toEqual({
+      directLease: 'BUSY',
+      targetTransaction: 'FREE',
+      lease: 'BUSY',
+    });
+    expect(fileOracle(path)).toEqual(targetBefore);
+    expect(readdirSync(dirname(path)).sort()).toEqual(namespaceBefore);
+
+    const holderExitPromise = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
+      (resolveExit) => holder.once('exit', (code, signal) => resolveExit({ code, signal })),
+    );
+    holder.kill('SIGKILL');
+    const holderExit = await holderExitPromise;
+    expect(holderExit).toEqual({ code: null, signal: 'SIGKILL' });
+    expect(await runContender(dataDirectory)).toEqual({
+      directLease: 'OPEN',
+      targetTransaction: 'FREE',
+      lease: 'OPEN',
+    });
+    assertInitializedInventory(path);
+  }, 30_000);
 
   it('explicitly quarantines and rebuilds an open owned database', async () => {
     const dataDirectory = temporaryDataDirectory();
@@ -602,5 +2022,90 @@ describe('RFC-64 inventory v1 SQLite lifecycle', () => {
     } finally {
       foundation.close();
     }
+  });
+
+  it('rejects explicit quarantine before closing a valid foundation when durability is unavailable', async () => {
+    const dataDirectory = temporaryDataDirectory();
+    const foundation = await openProductionInventoryV1(dataDirectory);
+    try {
+      expect(() => foundation.quarantineAndRebuild()).toThrowError(
+        expect.objectContaining({ code: 'durability-unavailable' }),
+      );
+      expect(foundation.closed).toBe(false);
+      expectNoQuarantine(databasePath(dataDirectory));
+    } finally {
+      foundation.close();
+    }
+
+    const reopened = await openInventoryV1(dataDirectory);
+    reopened.close();
+  });
+});
+
+describe.runIf(process.platform === 'win32')('RFC-64 inventory v1 native Windows gate', () => {
+  it('opens a fresh inventory and reopens the exact valid database without quarantine capability', async () => {
+    const dataDirectory = temporaryDataDirectory();
+    const path = databasePath(dataDirectory);
+    const foundation = await openProductionInventoryV1(dataDirectory);
+    foundation.close();
+    const before = fileOracle(path);
+    const reopened = await openProductionInventoryV1(dataDirectory);
+    reopened.close();
+    expect(fileOracle(path)).toEqual(before);
+    assertInitializedInventory(path);
+  });
+
+  it('leaves an automatic-quarantine candidate byte-for-byte untouched', async () => {
+    const dataDirectory = temporaryDataDirectory();
+    const path = databasePath(dataDirectory);
+    createIncompatibleOwnedInventory(path, 'windows-automatic');
+    const before = fileOracle(path);
+    await expect(openInventoryV1(dataDirectory)).rejects.toSatisfy(
+      (error: unknown) => expectOpenErrorCode(error, 'durability-unavailable'),
+    );
+    expect(fileOracle(path)).toEqual(before);
+    expectNoQuarantine(path);
+  });
+
+  it('leaves an explicitly quarantined valid target open and mutation-free', async () => {
+    const dataDirectory = temporaryDataDirectory();
+    const path = databasePath(dataDirectory);
+    const foundation = await openProductionInventoryV1(dataDirectory);
+    const before = fileOracle(path);
+    try {
+      expect(() => foundation.quarantineAndRebuild()).toThrowError(
+        expect.objectContaining({ code: 'durability-unavailable' }),
+      );
+      expect(foundation.closed).toBe(false);
+      expect(fileOracle(path)).toEqual(before);
+      expectNoQuarantine(path);
+    } finally {
+      foundation.close();
+    }
+  });
+
+  it('leaves pending marker-resume evidence and namespace byte-for-byte untouched', async () => {
+    const dataDirectory = temporaryDataDirectory();
+    const path = databasePath(dataDirectory);
+    createIncompatibleOwnedInventory(path, 'windows-resume');
+    const generation = join(
+      dirname(path),
+      'quarantine',
+      'inventory-v1-1234567890-9999999999999999',
+    );
+    mkdirSync(generation, { recursive: true });
+    const marker = Buffer.from(JSON.stringify({
+      version: 1,
+      quarantineDirectory: generation,
+      members: ['main'],
+    }));
+    writeFileSync(`${path}.rebuild-required`, marker);
+    const before = fileOracle(path);
+    await expect(openInventoryV1(dataDirectory)).rejects.toSatisfy(
+      (error: unknown) => expectOpenErrorCode(error, 'durability-unavailable'),
+    );
+    expect(fileOracle(path)).toEqual(before);
+    expect(readFileSync(`${path}.rebuild-required`)).toEqual(marker);
+    expect(readdirSync(generation)).toEqual([]);
   });
 });

--- a/packages/agent/test/rfc64-inventory-v1-lifecycle.test.ts
+++ b/packages/agent/test/rfc64-inventory-v1-lifecycle.test.ts
@@ -191,6 +191,57 @@ function createIncompatibleOwnedInventory(path: string, label: string): void {
   }
 }
 
+async function createCrashedWalIncompatibleOwnedInventory(
+  path: string,
+  label: string,
+): Promise<void> {
+  createIncompatibleOwnedInventory(path, label);
+  const script = String.raw`
+const { DatabaseSync } = require('node:sqlite');
+const database = new DatabaseSync(process.env.DKG_RFC64_CRASHED_WAL_PATH);
+database.exec('PRAGMA journal_mode=WAL; PRAGMA wal_autocheckpoint=0; BEGIN; INSERT INTO wrong_v1 VALUES (\'wal-row\'); COMMIT');
+process.stdout.write('READY\n');
+setInterval(() => {}, 60_000);
+`;
+  const child = spawn(process.execPath, ['--experimental-sqlite', '-e', script], {
+    env: { ...process.env, DKG_RFC64_CRASHED_WAL_PATH: path },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  let stderr = '';
+  child.stderr.setEncoding('utf8');
+  child.stderr.on('data', (chunk: string) => { stderr += chunk; });
+  await new Promise<void>((resolveReady, rejectReady) => {
+    let stdout = '';
+    const timeout = setTimeout(() => {
+      rejectReady(new Error(`crashed-WAL child did not become ready: ${stderr}`));
+    }, 10_000);
+    child.stdout.setEncoding('utf8');
+    child.stdout.on('data', (chunk: string) => {
+      stdout += chunk;
+      if (!stdout.includes('READY\n')) return;
+      clearTimeout(timeout);
+      resolveReady();
+    });
+    child.once('error', (error) => {
+      clearTimeout(timeout);
+      rejectReady(error);
+    });
+    child.once('exit', (code, signal) => {
+      clearTimeout(timeout);
+      rejectReady(new Error(
+        `crashed-WAL child exited before ready: code=${code} signal=${signal} stderr=${stderr}`,
+      ));
+    });
+  });
+  const exit = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
+    (resolveExit) => child.once('exit', (code, signal) => resolveExit({ code, signal })),
+  );
+  child.kill('SIGKILL');
+  expect(await exit).toEqual({ code: null, signal: 'SIGKILL' });
+  expect(existsSync(`${path}-wal`)).toBe(true);
+  expect(existsSync(`${path}-shm`)).toBe(true);
+}
+
 function sha256File(path: string): string {
   return createHash('sha256').update(readFileSync(path)).digest('hex');
 }
@@ -581,7 +632,7 @@ describe.runIf(process.platform !== 'win32')('RFC-64 inventory v1 SQLite lifecyc
       expectOpenErrorCode(error, 'database-busy'));
   });
 
-  it('closes a corrupt owned target before reporting unavailable durability', async () => {
+  it('rejects corrupt quarantine before its exclusivity proof and closes as ordinary cleanup', async () => {
     const dataDirectory = temporaryDataDirectory();
     const path = databasePath(dataDirectory);
     const initialized = await openInventoryV1(dataDirectory);
@@ -629,7 +680,7 @@ describe.runIf(process.platform !== 'win32')('RFC-64 inventory v1 SQLite lifecyc
     await expect(openWithoutDurability(dataDirectory)).rejects.toSatisfy(
       (error: unknown) => expectOpenErrorCode(error, 'durability-unavailable'),
     );
-    expect(closeReasons).toContain('automatic-corrupt-quarantine');
+    expect(closeReasons).toEqual(['failed-open-cleanup']);
     await expect(openWithoutDurability(dataDirectory)).rejects.toSatisfy(
       (error: unknown) => expectOpenErrorCode(error, 'durability-unavailable'),
     );
@@ -914,6 +965,37 @@ describe.runIf(process.platform !== 'win32')('RFC-64 inventory v1 SQLite lifecyc
     const check = new DatabaseSync(path, { readOnly: true });
     expect(check.prepare('SELECT value FROM wrong_v1').get()?.value).toBe('must-survive');
     check.close();
+  });
+
+  it('does not enter the quarantine proof for an unsupported crashed-WAL candidate', async () => {
+    const dataDirectory = temporaryDataDirectory();
+    const path = databasePath(dataDirectory);
+    await createCrashedWalIncompatibleOwnedInventory(path, 'main-row');
+    const boundaries: InventoryV1QuarantineBoundary[] = [];
+    const closeReasons: string[] = [];
+    const openWithoutDurability = createInventoryV1TestOpener({
+      quarantineCapability: null,
+      boundary: (boundary) => { boundaries.push(boundary); },
+      closeTarget: (close, reason) => {
+        close();
+        closeReasons.push(reason);
+      },
+    });
+
+    await expect(openWithoutDurability(dataDirectory)).rejects.toSatisfy(
+      (error: unknown) => expectOpenErrorCode(error, 'durability-unavailable'),
+    );
+
+    expect(boundaries).not.toContain('target-exclusivity-proven');
+    expect(closeReasons).toEqual(['failed-open-cleanup']);
+    expectNoQuarantine(path);
+    const recovered = new DatabaseSync(path, { readOnly: true });
+    try {
+      expect(recovered.prepare('SELECT value FROM wrong_v1 ORDER BY rowid').all())
+        .toEqual([{ value: 'main-row' }, { value: 'wal-row' }]);
+    } finally {
+      recovered.close();
+    }
   });
 
   it('refuses NOTADB bytes without manufacturing DK64 ownership or quarantine', async () => {

--- a/packages/agent/test/rfc64-inventory-v1-lifecycle.test.ts
+++ b/packages/agent/test/rfc64-inventory-v1-lifecycle.test.ts
@@ -46,6 +46,7 @@ const CHILD_FIXTURE = resolve(
   'fixtures/rfc64-inventory-v1-child.ts',
 );
 const HOSTILE_SIDECAR_BYTES = Object.freeze({
+  journal: Buffer.from('hostile-rfc64-journal-evidence\0\u0000\u0001', 'utf8'),
   wal: Buffer.from('hostile-rfc64-wal-evidence\0\u0001\u0002', 'utf8'),
   shm: Buffer.from('hostile-rfc64-shm-evidence\0\u0003\u0004', 'utf8'),
 });
@@ -55,9 +56,10 @@ const openInventoryV1 = (dataDirectory: string) => openProductionInventoryV1(
   { quarantineCapability: INVENTORY_V1_POSIX_QUARANTINE_CAPABILITY },
 );
 
-type RecoveryMember = 'wal' | 'shm' | 'main';
+type RecoveryMember = 'journal' | 'wal' | 'shm' | 'main';
 type RecoveryManifest =
   | readonly ['main']
+  | readonly ['journal', 'main']
   | readonly ['wal', 'main']
   | readonly ['shm', 'main']
   | readonly ['wal', 'shm', 'main'];
@@ -68,6 +70,8 @@ type SeededRecoveryTopology = Readonly<{
 }>;
 
 const FULL_RECOVERY_MANIFEST = ['wal', 'shm', 'main'] as const;
+type FullRecoveryMember = (typeof FULL_RECOVERY_MANIFEST)[number];
+const JOURNAL_RECOVERY_MANIFEST = ['journal', 'main'] as const;
 const FULL_MANIFEST_FAULT_BOUNDARIES = [
   'begin.source.wal.file-fsync',
   'begin.source.shm.file-fsync',
@@ -101,6 +105,28 @@ const MOVED_PREFIX_FAULT_BOUNDARIES = FULL_RECOVERY_MANIFEST.flatMap((member) =>
   `resume.prefix.${member}.generation-directory-fsync`,
   `resume.prefix.${member}.inventory-directory-fsync`,
 ] as const) satisfies readonly InventoryV1QuarantineBoundary[];
+
+const JOURNAL_RESTART_FAULT_BOUNDARIES = [
+  'target-exclusivity-proven',
+  'resume.source.journal.file-fsync-after-quiescence',
+  'resume.source.main.file-fsync-after-quiescence',
+  'resume.member.journal.rename',
+  'resume.member.journal.file-fsync',
+  'resume.member.journal.generation-directory-fsync',
+  'resume.member.journal.inventory-directory-fsync',
+  'resume.member.main.rename',
+  'resume.member.main.file-fsync',
+  'resume.member.main.generation-directory-fsync',
+  'resume.member.main.inventory-directory-fsync',
+  'resume.marker.unlink',
+  'resume.inventory-directory.fsync-after-marker-unlink',
+] as const satisfies readonly InventoryV1QuarantineBoundary[];
+
+const JOURNAL_PREFIX_FAULT_BOUNDARIES = [
+  'resume.prefix.journal.file-fsync',
+  'resume.prefix.journal.generation-directory-fsync',
+  'resume.prefix.journal.inventory-directory-fsync',
+] as const satisfies readonly InventoryV1QuarantineBoundary[];
 
 function expectedFullManifestTrace(
   boundary: (typeof FULL_MANIFEST_FAULT_BOUNDARIES)[number],
@@ -146,6 +172,12 @@ function pragmaInteger(database: DatabaseSync, pragma: string): number {
   const value = Object.values(row)[0];
   if (typeof value !== 'number') throw new Error(`invalid PRAGMA ${pragma}`);
   return value;
+}
+
+function u64be(value: bigint): Buffer {
+  const encoded = Buffer.alloc(8);
+  encoded.writeBigUInt64BE(value);
+  return encoded;
 }
 
 function expectOpenErrorCode(error: unknown, code: InventoryV1OpenError['code']): boolean {
@@ -240,6 +272,61 @@ setInterval(() => {}, 60_000);
   expect(await exit).toEqual({ code: null, signal: 'SIGKILL' });
   expect(existsSync(`${path}-wal`)).toBe(true);
   expect(existsSync(`${path}-shm`)).toBe(true);
+}
+
+async function leaveHotRollbackJournal(
+  path: string,
+  transactionSql: string,
+): Promise<void> {
+  const script = String.raw`
+const { DatabaseSync } = require('node:sqlite');
+const database = new DatabaseSync(process.env.DKG_RFC64_HOT_JOURNAL_PATH);
+database.exec('PRAGMA journal_mode=DELETE; BEGIN IMMEDIATE');
+database.exec(process.env.DKG_RFC64_HOT_JOURNAL_SQL);
+process.stdout.write('READY\n');
+setInterval(() => {}, 60_000);
+`;
+  const child = spawn(process.execPath, ['--experimental-sqlite', '-e', script], {
+    env: {
+      ...process.env,
+      DKG_RFC64_HOT_JOURNAL_PATH: path,
+      DKG_RFC64_HOT_JOURNAL_SQL: transactionSql,
+    },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  let stderr = '';
+  child.stderr.setEncoding('utf8');
+  child.stderr.on('data', (chunk: string) => { stderr += chunk; });
+  await new Promise<void>((resolveReady, rejectReady) => {
+    let stdout = '';
+    const timeout = setTimeout(() => {
+      rejectReady(new Error(`hot-journal child did not become ready: ${stderr}`));
+    }, 10_000);
+    child.stdout.setEncoding('utf8');
+    child.stdout.on('data', (chunk: string) => {
+      stdout += chunk;
+      if (!stdout.includes('READY\n')) return;
+      clearTimeout(timeout);
+      resolveReady();
+    });
+    child.once('error', (error) => {
+      clearTimeout(timeout);
+      rejectReady(error);
+    });
+    child.once('exit', (code, signal) => {
+      clearTimeout(timeout);
+      rejectReady(new Error(
+        `hot-journal child exited before ready: code=${code} signal=${signal} stderr=${stderr}`,
+      ));
+    });
+  });
+  const exit = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
+    (resolveExit) => child.once('exit', (code, signal) => resolveExit({ code, signal })),
+  );
+  child.kill('SIGKILL');
+  expect(await exit).toEqual({ code: null, signal: 'SIGKILL' });
+  expect(lstatSync(`${path}-journal`).isFile()).toBe(true);
+  expect(lstatSync(`${path}-journal`).size).toBeGreaterThan(512);
 }
 
 function sha256File(path: string): string {
@@ -838,6 +925,113 @@ describe.runIf(process.platform !== 'win32')('RFC-64 inventory v1 SQLite lifecyc
     }
   });
 
+  it('rejects hostile transfer geometry while accepting every exact chunk boundary', () => {
+    const database = new DatabaseSync(':memory:');
+    try {
+      database.exec('PRAGMA foreign_keys = ON');
+      database.exec(INVENTORY_V1_DDL);
+      const session = Buffer.alloc(32, 1);
+      const scope = Buffer.alloc(32, 2);
+      const author = Buffer.alloc(20, 3);
+      const head = Buffer.alloc(32, 4);
+      database.prepare(
+        'INSERT INTO rfc64_candidate_bucket_loads_v1 VALUES (?,?,?,?,?,?,?,?,?,?,?)',
+      ).run(
+        session,
+        scope,
+        author,
+        head,
+        null,
+        u64be(0n),
+        u64be(1n),
+        u64be(0n),
+        Buffer.alloc(32, 5),
+        u64be(4n),
+        u64be(512n),
+      );
+      const insert = database.prepare(
+        'INSERT INTO rfc64_candidate_bucket_rows_v1 VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)',
+      );
+      let nonce = 1;
+      const insertGeometry = (byteLength: bigint, chunkCount: bigint): void => {
+        const unique = nonce;
+        nonce += 1;
+        const kaId = Buffer.alloc(32);
+        kaId.writeUInt32BE(unique, 28);
+        insert.run(
+          session,
+          scope,
+          author,
+          head,
+          u64be(0n),
+          kaId,
+          Buffer.from(kaId),
+          `coordinate-${unique}`,
+          u64be(1n),
+          'cg-shared-v1',
+          Buffer.alloc(32, 6),
+          Buffer.alloc(32, 7),
+          'dkg-ka-bundle-v1',
+          u64be(byteLength),
+          u64be(262_144n),
+          u64be(chunkCount),
+          Buffer.alloc(32, 8),
+          Buffer.alloc(32, 9),
+          Buffer.alloc(32, 10),
+        );
+      };
+
+      for (let chunkCount = 1n; chunkCount <= 4_096n; chunkCount += 1n) {
+        const lowerBoundary = chunkCount === 1n
+          ? 16n
+          : ((chunkCount - 1n) * 262_144n) + 1n;
+        const upperBoundary = chunkCount * 262_144n;
+        expect(() => insertGeometry(lowerBoundary, chunkCount)).not.toThrow();
+        expect(() => insertGeometry(upperBoundary, chunkCount)).not.toThrow();
+      }
+      for (const [byteLength, chunkCount] of [
+        [0n, 0n],
+        [16n, 0n],
+        [16n, 4_096n],
+        [262_144n, 2n],
+        [262_145n, 1n],
+        [262_145n, 3n],
+        [1_073_741_824n, 4_095n],
+      ] as const) {
+        expect(() => insertGeometry(byteLength, chunkCount)).toThrow(/constraint/i);
+      }
+
+      expect(database.prepare(
+        'SELECT count(*) AS count FROM rfc64_candidate_bucket_rows_v1',
+      ).get()?.count).toBe(8_192);
+      const plan = database.prepare(`
+        EXPLAIN QUERY PLAN
+        SELECT ka_id_u256be
+        FROM rfc64_candidate_bucket_rows_v1
+        WHERE session_id = ?
+          AND catalog_scope_digest = ?
+          AND author_address = ?
+          AND target_catalog_head_digest = ?
+          AND bucket_id_u64be = ?
+          AND ka_id_u256be > ?
+        ORDER BY ka_id_u256be
+        LIMIT 256
+      `).all(
+        session,
+        scope,
+        author,
+        head,
+        u64be(0n),
+        Buffer.alloc(32),
+      );
+      expect(plan.map((row) => String(row.detail)).join('\n')).toMatch(
+        /USING COVERING INDEX rfc64_candidate_bucket_rows_by_bucket_v1 \(session_id=\? AND catalog_scope_digest=\? AND author_address=\? AND target_catalog_head_digest=\? AND bucket_id_u64be=\? AND ka_id_u256be>\?\)/,
+      );
+    } finally {
+      database.close();
+    }
+  });
+
   it('refuses a valid foreign application_id without modifying or quarantining it', async () => {
     const dataDirectory = temporaryDataDirectory();
     const path = databasePath(dataDirectory);
@@ -940,6 +1134,141 @@ describe.runIf(process.platform !== 'win32')('RFC-64 inventory v1 SQLite lifecyc
     } finally {
       foundation.close();
     }
+  });
+
+  it('classifies and safely recovers a main-plus-hot-journal unit before enabling WAL', async () => {
+    const dataDirectory = temporaryDataDirectory();
+    const path = databasePath(dataDirectory);
+    const initialized = await openInventoryV1(dataDirectory);
+    initialized.close();
+    await leaveHotRollbackJournal(
+      path,
+      "CREATE TABLE uncommitted_intruder (value TEXT); INSERT INTO uncommitted_intruder VALUES ('lost')",
+    );
+    const journalBefore = fileOracle(`${path}-journal`);
+
+    const reopened = await openInventoryV1(dataDirectory);
+    try {
+      assertInitializedInventory(path);
+      const database = new DatabaseSync(path, { readOnly: true });
+      try {
+        expect(database.prepare(
+          "SELECT count(*) AS count FROM sqlite_schema WHERE name = 'uncommitted_intruder'",
+        ).get()?.count).toBe(0);
+      } finally {
+        database.close();
+      }
+      expect(journalBefore.size).toBeGreaterThan(512);
+      expect(existsSync(`${path}-journal`)).toBe(false);
+    } finally {
+      reopened.close();
+    }
+  });
+
+  it('recovers a hot journal before automatically quarantining its incompatible main', async () => {
+    const dataDirectory = temporaryDataDirectory();
+    const path = databasePath(dataDirectory);
+    createIncompatibleOwnedInventory(path, 'committed-before-hot-journal');
+    await leaveHotRollbackJournal(
+      path,
+      "INSERT INTO wrong_v1 VALUES ('uncommitted-before-crash')",
+    );
+
+    const foundation = await openInventoryV1(dataDirectory);
+    try {
+      assertInitializedInventory(path);
+      const generation = evidenceGeneration(path);
+      expect(lstatSync(join(generation, 'inventory-v1.sqlite3-journal')).isFile()).toBe(true);
+      const quarantined = new DatabaseSync(
+        join(generation, 'inventory-v1.sqlite3'),
+        { readOnly: true },
+      );
+      try {
+        expect(quarantined.prepare('SELECT value FROM wrong_v1 ORDER BY rowid').all()).toEqual([
+          { value: 'committed-before-hot-journal' },
+        ]);
+      } finally {
+        quarantined.close();
+      }
+    } finally {
+      foundation.close();
+    }
+  });
+
+  it('moves residual rollback-journal evidence in the automatic quarantine manifest', async () => {
+    const dataDirectory = temporaryDataDirectory();
+    const path = databasePath(dataDirectory);
+    createIncompatibleOwnedInventory(path, 'residual-journal');
+    const evidence = HOSTILE_SIDECAR_BYTES.journal;
+    const openWithResidualJournal = createInventoryV1TestOpener({
+      quarantineCapability: INVENTORY_V1_POSIX_QUARANTINE_CAPABILITY,
+      closeTarget: (close, reason) => {
+        close();
+        if (reason === 'automatic-schema-quarantine') {
+          writeFileSync(`${path}-journal`, evidence);
+        }
+      },
+    });
+
+    const foundation = await openWithResidualJournal(dataDirectory);
+    try {
+      assertInitializedInventory(path);
+      const generation = evidenceGeneration(path);
+      expect(readFileSync(join(generation, 'inventory-v1.sqlite3-journal'))).toEqual(evidence);
+      expect(existsSync(`${path}-journal`)).toBe(false);
+    } finally {
+      foundation.close();
+    }
+  });
+
+  it('rejects pre-existing mixed journal modes before SQLite can mutate either sidecar', async () => {
+    for (const mixedMember of ['wal', 'shm'] as const) {
+      const dataDirectory = temporaryDataDirectory();
+      const path = databasePath(dataDirectory);
+      const initialized = await openInventoryV1(dataDirectory);
+      initialized.close();
+      writeFileSync(`${path}-journal`, HOSTILE_SIDECAR_BYTES.journal);
+      writeFileSync(`${path}-${mixedMember}`, HOSTILE_SIDECAR_BYTES[mixedMember]);
+      const before = {
+        main: fileOracle(path),
+        journal: fileOracle(`${path}-journal`),
+        mixed: fileOracle(`${path}-${mixedMember}`),
+      };
+
+      await expect(openInventoryV1(dataDirectory)).rejects.toSatisfy(
+        (error: unknown) => expectOpenErrorCode(error, 'ambiguous-database'),
+      );
+      expect(fileOracle(path)).toEqual(before.main);
+      expect(fileOracle(`${path}-journal`)).toEqual(before.journal);
+      expect(fileOracle(`${path}-${mixedMember}`)).toEqual(before.mixed);
+      expectNoQuarantine(path);
+    }
+  });
+
+  it('fails closed on mixed rollback-journal and WAL evidence without starting quarantine', async () => {
+    const dataDirectory = temporaryDataDirectory();
+    const path = databasePath(dataDirectory);
+    createIncompatibleOwnedInventory(path, 'mixed-journal-mode-evidence');
+    const journalEvidence = HOSTILE_SIDECAR_BYTES.journal;
+    const walEvidence = HOSTILE_SIDECAR_BYTES.wal;
+    const openWithMixedEvidence = createInventoryV1TestOpener({
+      quarantineCapability: INVENTORY_V1_POSIX_QUARANTINE_CAPABILITY,
+      closeTarget: (close, reason) => {
+        close();
+        if (reason === 'automatic-schema-quarantine') {
+          writeFileSync(`${path}-journal`, journalEvidence);
+          writeFileSync(`${path}-wal`, walEvidence);
+        }
+      },
+    });
+
+    await expect(openWithMixedEvidence(dataDirectory)).rejects.toSatisfy(
+      (error: unknown) => expectOpenErrorCode(error, 'database-io'),
+    );
+    expect(readFileSync(`${path}-journal`)).toEqual(journalEvidence);
+    expect(readFileSync(`${path}-wal`)).toEqual(walEvidence);
+    expect(existsSync(`${path}.rebuild-required`)).toBe(false);
+    expect(quarantineGenerations(path)).toEqual([]);
   });
 
   it('fails closed before automatic quarantine when namespace durability is unavailable', async () => {
@@ -1132,7 +1461,7 @@ describe.runIf(process.platform !== 'win32')('RFC-64 inventory v1 SQLite lifecyc
       database.close();
       const sidecarTarget = join(sidecarData, 'sidecar-target');
       writeFileSync(sidecarTarget, 'sidecar');
-      symlinkSync(sidecarTarget, `${sidecarPath}-wal`);
+      symlinkSync(sidecarTarget, `${sidecarPath}-journal`);
       await expect(openInventoryV1(sidecarData)).rejects.toSatisfy((error: unknown) =>
         expectOpenErrorCode(error, 'unsafe-path'));
       expectNoQuarantine(sidecarPath);
@@ -1176,7 +1505,7 @@ describe.runIf(process.platform !== 'win32')('RFC-64 inventory v1 SQLite lifecyc
       const dataDirectory = temporaryDataDirectory();
       const path = databasePath(dataDirectory);
       const originalMode = statSync(dataDirectory).mode & 0o777;
-      const actualUid = process.getuid();
+      const actualUid = process.getuid!();
       const uid = vi.spyOn(process, 'getuid').mockReturnValue(actualUid + 1);
       try {
         await expect(openInventoryV1(dataDirectory)).rejects.toSatisfy((error: unknown) =>
@@ -1301,6 +1630,11 @@ describe.runIf(process.platform !== 'win32')('RFC-64 inventory v1 SQLite lifecyc
       { version: 1, quarantineDirectory: 'placeholder' },
       { version: 1, quarantineDirectory: 'placeholder', members: ['main'], extra: true },
       { version: 1, quarantineDirectory: 'placeholder', members: ['main', 'wal'] },
+      { version: 1, quarantineDirectory: 'placeholder', members: ['main', 'journal'] },
+      { version: 1, quarantineDirectory: 'placeholder', members: ['journal', 'journal', 'main'] },
+      { version: 1, quarantineDirectory: 'placeholder', members: ['journal', 'wal', 'main'] },
+      { version: 1, quarantineDirectory: 'placeholder', members: ['journal', 'shm', 'main'] },
+      { version: 1, quarantineDirectory: 'placeholder', members: ['journal', 'wal', 'shm', 'main'] },
       { version: 1, quarantineDirectory: 'placeholder', members: ['wal', 'wal', 'main'] },
       { version: 1, quarantineDirectory: 'placeholder', members: ['unknown', 'main'] },
     ];
@@ -1616,6 +1950,7 @@ describe.runIf(process.platform !== 'win32')('RFC-64 inventory v1 SQLite lifecyc
   it('exhaustively rejects every non-prefix source/destination/missing/duplicate manifest topology without mutation', async () => {
     const manifests = [
       ['main'],
+      ['journal', 'main'],
       ['wal', 'main'],
       ['shm', 'main'],
       ['wal', 'shm', 'main'],
@@ -1718,6 +2053,58 @@ describe.runIf(process.platform !== 'win32')('RFC-64 inventory v1 SQLite lifecyc
       expect(existsSync(join(generation, 'inventory-v1.sqlite3'))).toBe(true);
     } finally {
       foundation.close();
+    }
+  });
+
+  it('does not move a zero-prefix journal manifest before proving a raw SQLite holder is gone', async () => {
+    const dataDirectory = temporaryDataDirectory();
+    const path = databasePath(dataDirectory);
+    const generation = join(
+      dirname(path),
+      'quarantine',
+      'inventory-v1-1234567890-9898989898989898',
+    );
+    mkdirSync(generation, { recursive: true });
+    createIncompatibleOwnedInventory(path, 'journal-zero-prefix-holder');
+    const holder = new DatabaseSync(path);
+    holder.exec(`
+      PRAGMA journal_mode = DELETE;
+      BEGIN IMMEDIATE;
+      INSERT INTO wrong_v1 VALUES ('uncommitted-live-holder');
+    `);
+    expect(lstatSync(`${path}-journal`).size).toBeGreaterThan(512);
+    const marker = Buffer.from(JSON.stringify({
+      version: 1,
+      quarantineDirectory: generation,
+      members: ['journal', 'main'],
+    }));
+    writeFileSync(`${path}.rebuild-required`, marker);
+    const before = {
+      main: fileOracle(path),
+      journal: fileOracle(`${path}-journal`),
+      marker: fileOracle(`${path}.rebuild-required`),
+      sourceNames: readdirSync(dirname(path))
+        .filter((name) => name.startsWith('inventory-v1.sqlite3'))
+        .sort(),
+      destinationNames: readdirSync(generation).sort(),
+    };
+    try {
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        await expect(openInventoryV1(dataDirectory)).rejects.toSatisfy(
+          (error: unknown) => expectOpenErrorCode(error, 'database-busy'),
+        );
+        expect(fileOracle(path)).toEqual(before.main);
+        expect(fileOracle(`${path}-journal`)).toEqual(before.journal);
+        expect(fileOracle(`${path}.rebuild-required`)).toEqual(before.marker);
+        expect(readdirSync(dirname(path))
+          .filter((name) => name.startsWith('inventory-v1.sqlite3'))
+          .sort()).toEqual(before.sourceNames);
+        expect(readdirSync(generation).sort()).toEqual(before.destinationNames);
+        expect(readFileSync(`${path}.rebuild-required`)).toEqual(marker);
+      }
+    } finally {
+      holder.exec('ROLLBACK');
+      holder.close();
     }
   });
 
@@ -1881,6 +2268,7 @@ describe.runIf(process.platform !== 'win32')('RFC-64 inventory v1 SQLite lifecyc
   it('converges every frozen recovery manifest and valid moved-prefix topology', async () => {
     const manifests = [
       ['main'],
+      ['journal', 'main'],
       ['wal', 'main'],
       ['shm', 'main'],
       ['wal', 'shm', 'main'],
@@ -1996,9 +2384,104 @@ describe.runIf(process.platform !== 'win32')('RFC-64 inventory v1 SQLite lifecyc
     }
   }, 180_000);
 
+  it('recovers journal evidence in a fresh process after SIGKILL at every restart-proof and move boundary', async () => {
+    for (const boundary of JOURNAL_RESTART_FAULT_BOUNDARIES) {
+      const dataDirectory = temporaryDataDirectory();
+      const path = databasePath(dataDirectory);
+      const label = `journal-fault-${boundary}`;
+      const seeded = seedPendingRecoveryTopology(
+        dataDirectory,
+        JOURNAL_RECOVERY_MANIFEST,
+        0,
+        label,
+      );
+      const tracePath = join(dataDirectory, `trace-${boundary}.jsonl`);
+      const trace = await killAtInventoryBoundary(dataDirectory, boundary, tracePath, {
+        DKG_RFC64_CHILD_PROTECT_EVIDENCE: '1',
+      });
+      expect(trace.map((entry) => entry.boundary)).toEqual(
+        JOURNAL_RESTART_FAULT_BOUNDARIES.slice(
+          0,
+          JOURNAL_RESTART_FAULT_BOUNDARIES.indexOf(boundary) + 1,
+        ),
+      );
+      const killedEvidence = new Map<RecoveryMember, FileOracle>();
+      for (const member of JOURNAL_RECOVERY_MANIFEST) {
+        const source = recoverySourcePath(path, member);
+        const destination = recoveryDestinationPath(seeded.generation, member);
+        expect(existsSync(source) || existsSync(destination)).toBe(true);
+        killedEvidence.set(member, fileOracle(existsSync(source) ? source : destination));
+      }
+
+      try {
+        await reopenInventoryInFreshProcess(dataDirectory);
+      } catch (cause) {
+        throw new Error(`fresh-process journal recovery failed after ${boundary}`, { cause });
+      }
+      assertInitializedInventory(path);
+      assertRecoveredManifestEvidence(
+        path,
+        JOURNAL_RECOVERY_MANIFEST,
+        label,
+        seeded.generation,
+        seeded.hashes,
+      );
+      for (const member of JOURNAL_RECOVERY_MANIFEST) {
+        expect(fileOracle(recoveryDestinationPath(seeded.generation, member))).toEqual(
+          killedEvidence.get(member),
+        );
+      }
+    }
+  }, 120_000);
+
+  it('recovers a journal moved-prefix in a fresh process after SIGKILL at every prefix durability boundary', async () => {
+    for (const boundary of JOURNAL_PREFIX_FAULT_BOUNDARIES) {
+      const dataDirectory = temporaryDataDirectory();
+      const path = databasePath(dataDirectory);
+      const label = `journal-prefix-fault-${boundary}`;
+      const seeded = seedPendingRecoveryTopology(
+        dataDirectory,
+        JOURNAL_RECOVERY_MANIFEST,
+        1,
+        label,
+        true,
+      );
+      const journalBefore = fileOracle(
+        recoveryDestinationPath(seeded.generation, 'journal'),
+      );
+      const mainBefore = fileOracle(path);
+      const tracePath = join(dataDirectory, `trace-${boundary}.jsonl`);
+      const trace = await killAtInventoryBoundary(dataDirectory, boundary, tracePath, {
+        DKG_RFC64_CHILD_PROTECT_EVIDENCE: '1',
+      });
+      expect(trace.map((entry) => entry.boundary)).toEqual(
+        JOURNAL_PREFIX_FAULT_BOUNDARIES.slice(
+          0,
+          JOURNAL_PREFIX_FAULT_BOUNDARIES.indexOf(boundary) + 1,
+        ),
+      );
+
+      await reopenInventoryInFreshProcess(dataDirectory);
+      assertInitializedInventory(path);
+      assertRecoveredManifestEvidence(
+        path,
+        JOURNAL_RECOVERY_MANIFEST,
+        label,
+        seeded.generation,
+        seeded.hashes,
+      );
+      expect(fileOracle(recoveryDestinationPath(seeded.generation, 'journal'))).toEqual(
+        journalBefore,
+      );
+      expect(fileOracle(recoveryDestinationPath(seeded.generation, 'main'))).toEqual(
+        mainBefore,
+      );
+    }
+  }, 60_000);
+
   it('recovers in a fresh process after SIGKILL at every moved-prefix re-fsync boundary', async () => {
     for (const boundary of MOVED_PREFIX_FAULT_BOUNDARIES) {
-      const member = boundary.split('.')[2] as RecoveryMember;
+      const member = boundary.split('.')[2] as FullRecoveryMember;
       const movedPrefix = FULL_RECOVERY_MANIFEST.indexOf(member) + 1;
       const dataDirectory = temporaryDataDirectory();
       const path = databasePath(dataDirectory);

--- a/packages/agent/test/rfc64-inventory-v1-lifecycle.test.ts
+++ b/packages/agent/test/rfc64-inventory-v1-lifecycle.test.ts
@@ -6,6 +6,7 @@ import {
   mkdtempSync,
   readFileSync,
   readdirSync,
+  realpathSync,
   rmSync,
   statSync,
   symlinkSync,
@@ -16,7 +17,7 @@ import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   INVENTORY_V1_APPLICATION_ID,
@@ -31,7 +32,10 @@ import {
 const temporaryDirectories: string[] = [];
 
 function temporaryDataDirectory(): string {
-  const directory = mkdtempSync(join(tmpdir(), 'dkg-rfc64-sql1-'));
+  // macOS exposes /var as a symlink to /private/var. Use the canonical test
+  // root so the production component-wise no-symlink rule is exercised only
+  // by symlinks intentionally created by each test.
+  const directory = realpathSync(mkdtempSync(join(tmpdir(), 'dkg-rfc64-sql1-')));
   temporaryDirectories.push(directory);
   return directory;
 }
@@ -124,6 +128,17 @@ describe('RFC-64 inventory v1 SQLite lifecycle', () => {
     }
   });
 
+  it('initializes beneath a previously nonexistent declared dataDir suffix', async () => {
+    const container = temporaryDataDirectory();
+    const dataDirectory = join(container, 'new-data', 'nested');
+    const foundation = await openInventoryV1(dataDirectory);
+    try {
+      assertInitializedInventory(databasePath(dataDirectory));
+    } finally {
+      foundation.close();
+    }
+  });
+
   it('executes the frozen DDL as STRICT tables with the named bucket index', () => {
     const database = new DatabaseSync(':memory:');
     try {
@@ -189,6 +204,24 @@ describe('RFC-64 inventory v1 SQLite lifecycle', () => {
     expectNoQuarantine(path);
   });
 
+  it('refuses an uncommitted DK64 user_version=0 database as ambiguous', async () => {
+    const dataDirectory = temporaryDataDirectory();
+    const path = databasePath(dataDirectory);
+    mkdirSync(dirname(path), { recursive: true });
+    const partial = new DatabaseSync(path);
+    partial.exec(`
+      CREATE TABLE partial_data (value TEXT);
+      PRAGMA application_id = ${INVENTORY_V1_APPLICATION_ID};
+    `);
+    partial.close();
+    const before = readFileSync(path);
+
+    await expect(openInventoryV1(dataDirectory)).rejects.toSatisfy((error: unknown) =>
+      expectOpenErrorCode(error, 'ambiguous-database'));
+    expect(readFileSync(path)).toEqual(before);
+    expectNoQuarantine(path);
+  });
+
   it('refuses a newer owned user_version without quarantine', async () => {
     const dataDirectory = temporaryDataDirectory();
     const path = databasePath(dataDirectory);
@@ -235,22 +268,72 @@ describe('RFC-64 inventory v1 SQLite lifecycle', () => {
     }
   });
 
-  it('quarantines NOTADB bytes at the dedicated path and preserves them as evidence', async () => {
+  it('refuses NOTADB bytes without manufacturing DK64 ownership or quarantine', async () => {
     const dataDirectory = temporaryDataDirectory();
     const path = databasePath(dataDirectory);
     mkdirSync(dirname(path), { recursive: true });
     const corruptBytes = Buffer.from('not-a-sqlite-database\n');
     writeFileSync(path, corruptBytes);
 
-    const foundation = await openInventoryV1(dataDirectory);
-    try {
-      assertInitializedInventory(path);
-      const generations = quarantineGenerations(path);
-      expect(generations).toHaveLength(1);
-      expect(readFileSync(join(generations[0]!, 'inventory-v1.sqlite3'))).toEqual(corruptBytes);
-    } finally {
-      foundation.close();
-    }
+    await expect(openInventoryV1(dataDirectory)).rejects.toSatisfy((error: unknown) =>
+      expectOpenErrorCode(error, 'ambiguous-database'));
+    expect(readFileSync(path)).toEqual(corruptBytes);
+    expectNoQuarantine(path);
+  });
+
+  it('refuses a corrupt application_id=0 database with user data as ambiguous', async () => {
+    const dataDirectory = temporaryDataDirectory();
+    const path = databasePath(dataDirectory);
+    mkdirSync(dirname(path), { recursive: true });
+    const ambiguous = new DatabaseSync(path);
+    ambiguous.exec('CREATE TABLE existing_data (value TEXT)');
+    ambiguous.close();
+    truncateSync(path, 100);
+    const before = readFileSync(path);
+
+    await expect(openInventoryV1(dataDirectory)).rejects.toSatisfy((error: unknown) =>
+      expectOpenErrorCode(error, 'ambiguous-database'));
+    expect(readFileSync(path)).toEqual(before);
+    expectNoQuarantine(path);
+  });
+
+  it('refuses a corrupt owned database with a newer header user_version', async () => {
+    const dataDirectory = temporaryDataDirectory();
+    const path = databasePath(dataDirectory);
+    mkdirSync(dirname(path), { recursive: true });
+    const newer = new DatabaseSync(path);
+    newer.exec(`
+      CREATE TABLE future_schema (value TEXT);
+      PRAGMA application_id = ${INVENTORY_V1_APPLICATION_ID};
+      PRAGMA user_version = 2;
+    `);
+    newer.close();
+    truncateSync(path, 100);
+    const before = readFileSync(path);
+
+    await expect(openInventoryV1(dataDirectory)).rejects.toSatisfy((error: unknown) =>
+      expectOpenErrorCode(error, 'newer-schema'));
+    expect(readFileSync(path)).toEqual(before);
+    expectNoQuarantine(path);
+  });
+
+  it('refuses a corrupt uncommitted DK64 user_version=0 database as ambiguous', async () => {
+    const dataDirectory = temporaryDataDirectory();
+    const path = databasePath(dataDirectory);
+    mkdirSync(dirname(path), { recursive: true });
+    const partial = new DatabaseSync(path);
+    partial.exec(`
+      CREATE TABLE partial_data (value TEXT);
+      PRAGMA application_id = ${INVENTORY_V1_APPLICATION_ID};
+    `);
+    partial.close();
+    truncateSync(path, 100);
+    const before = readFileSync(path);
+
+    await expect(openInventoryV1(dataDirectory)).rejects.toSatisfy((error: unknown) =>
+      expectOpenErrorCode(error, 'ambiguous-database'));
+    expect(readFileSync(path)).toEqual(before);
+    expectNoQuarantine(path);
   });
 
   it('does not quarantine a corrupt SQLite file whose readable header has a foreign app id', async () => {
@@ -319,6 +402,42 @@ describe('RFC-64 inventory v1 SQLite lifecycle', () => {
     },
   );
 
+  it.runIf(process.platform !== 'win32')(
+    'refuses a symlinked dataDir before creating anything through it',
+    async () => {
+      const realDataDirectory = temporaryDataDirectory();
+      const linkContainer = temporaryDataDirectory();
+      const linkedDataDirectory = join(linkContainer, 'data-dir-link');
+      symlinkSync(realDataDirectory, linkedDataDirectory);
+
+      await expect(openInventoryV1(linkedDataDirectory)).rejects.toSatisfy((error: unknown) =>
+        expectOpenErrorCode(error, 'unsafe-path'));
+      expect(readdirSync(realDataDirectory)).toEqual([]);
+      expect(existsSync(databasePath(realDataDirectory))).toBe(false);
+      expectNoQuarantine(databasePath(linkedDataDirectory));
+    },
+  );
+
+  it.runIf(process.platform !== 'win32')(
+    'refuses a foreign-owned dataDir before creating its inventory child',
+    async () => {
+      const dataDirectory = temporaryDataDirectory();
+      const path = databasePath(dataDirectory);
+      const originalMode = statSync(dataDirectory).mode & 0o777;
+      const actualUid = process.getuid();
+      const uid = vi.spyOn(process, 'getuid').mockReturnValue(actualUid + 1);
+      try {
+        await expect(openInventoryV1(dataDirectory)).rejects.toSatisfy((error: unknown) =>
+          expectOpenErrorCode(error, 'database-io'));
+      } finally {
+        uid.mockRestore();
+      }
+      expect(existsSync(dirname(path))).toBe(false);
+      expect(statSync(dataDirectory).mode & 0o777).toBe(originalMode);
+      expectNoQuarantine(path);
+    },
+  );
+
   it('refuses orphaned sidecars without deleting them', async () => {
     const dataDirectory = temporaryDataDirectory();
     const path = databasePath(dataDirectory);
@@ -372,6 +491,38 @@ describe('RFC-64 inventory v1 SQLite lifecycle', () => {
     }
   });
 
+  it('does not split a corrupt owned database from a live WAL writer', async () => {
+    const dataDirectory = temporaryDataDirectory();
+    const path = databasePath(dataDirectory);
+    mkdirSync(dirname(path), { recursive: true });
+    const seed = new DatabaseSync(path);
+    seed.exec(`
+      PRAGMA journal_mode = WAL;
+      CREATE TABLE owned_data (value TEXT);
+      PRAGMA application_id = ${INVENTORY_V1_APPLICATION_ID};
+      PRAGMA user_version = 1;
+    `);
+    seed.close();
+    const holder = new DatabaseSync(path);
+    holder.exec(`
+      PRAGMA journal_mode = WAL;
+      BEGIN IMMEDIATE;
+      INSERT INTO owned_data VALUES ('live-writer');
+    `);
+    truncateSync(path, 100);
+    const before = readFileSync(path);
+    try {
+      await expect(openInventoryV1(dataDirectory)).rejects.toSatisfy((error: unknown) =>
+        expectOpenErrorCode(error, 'database-io'));
+      expect(readFileSync(path)).toEqual(before);
+      expect(existsSync(`${path}-wal`)).toBe(true);
+      expectNoQuarantine(path);
+    } finally {
+      try { holder.exec('ROLLBACK'); } catch { /* the main file is intentionally corrupt */ }
+      try { holder.close(); } catch { /* the main file is intentionally corrupt */ }
+    }
+  });
+
   it('resumes a partial recovery-marker move before rebuilding', async () => {
     const dataDirectory = temporaryDataDirectory();
     const path = databasePath(dataDirectory);
@@ -397,6 +548,42 @@ describe('RFC-64 inventory v1 SQLite lifecycle', () => {
       expect(readFileSync(join(generation, 'inventory-v1.sqlite3-wal'), 'utf8')).toBe('wal-before-crash');
       expect(readFileSync(join(generation, 'inventory-v1.sqlite3-shm'), 'utf8')).toBe('shm-before-crash');
       expect(existsSync(`${path}.rebuild-required`)).toBe(false);
+    } finally {
+      foundation.close();
+    }
+  });
+
+  it('retains the recovery marker across an interrupted evidence move and resumes', async () => {
+    const dataDirectory = temporaryDataDirectory();
+    const path = databasePath(dataDirectory);
+    const inventoryDirectory = dirname(path);
+    const generation = join(
+      inventoryDirectory,
+      'quarantine',
+      'inventory-v1-1234567890-bbbbbbbbbbbbbbbb',
+    );
+    mkdirSync(generation, { recursive: true });
+    writeFileSync(path, 'main-before-crash');
+    writeFileSync(`${path}-wal`, 'wal-before-crash');
+    writeFileSync(join(generation, 'inventory-v1.sqlite3-wal'), 'conflicting-target');
+    writeFileSync(
+      `${path}.rebuild-required`,
+      JSON.stringify({ version: 1, quarantineDirectory: generation }),
+    );
+
+    await expect(openInventoryV1(dataDirectory)).rejects.toSatisfy((error: unknown) =>
+      expectOpenErrorCode(error, 'database-io'));
+    expect(existsSync(`${path}.rebuild-required`)).toBe(true);
+    expect(readFileSync(join(generation, 'inventory-v1.sqlite3'), 'utf8')).toBe('main-before-crash');
+    expect(readFileSync(`${path}-wal`, 'utf8')).toBe('wal-before-crash');
+
+    rmSync(join(generation, 'inventory-v1.sqlite3-wal'));
+    const foundation = await openInventoryV1(dataDirectory);
+    try {
+      assertInitializedInventory(path);
+      expect(existsSync(`${path}.rebuild-required`)).toBe(false);
+      expect(readFileSync(join(generation, 'inventory-v1.sqlite3'), 'utf8')).toBe('main-before-crash');
+      expect(readFileSync(join(generation, 'inventory-v1.sqlite3-wal'), 'utf8')).toBe('wal-before-crash');
     } finally {
       foundation.close();
     }

--- a/packages/agent/test/rfc64-inventory-v1-scalars.test.ts
+++ b/packages/agent/test/rfc64-inventory-v1-scalars.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+import { DatabaseSync } from 'node:sqlite';
+
+import type {
+  DecimalU64V1,
+  DecimalU256V1,
+  Digest32V1,
+  EvmAddressV1,
+} from '@origintrail-official/dkg-core';
+
+import {
+  InventoryV1ScalarError,
+  assertSqlBlobWidthV1,
+  decimalU64ToSqlBlobV1,
+  decimalU256ToSqlBlobV1,
+  digest32ToSqlBlobV1,
+  evmAddressToSqlBlobV1,
+  nullableIdentifierToSqlTextV1,
+  sqlBlobToDecimalU64V1,
+  sqlBlobToDecimalU256V1,
+  sqlBlobToDigest32V1,
+  sqlBlobToEvmAddressV1,
+  sqlBlobsEqualV1,
+} from '../src/rfc64/inventory-v1/index.js';
+
+const u64 = (value: string) => value as DecimalU64V1;
+const u256 = (value: string) => value as DecimalU256V1;
+const digest = (value: string) => value as Digest32V1;
+const address = (value: string) => value as EvmAddressV1;
+const hex = (value: Uint8Array) => Buffer.from(value).toString('hex');
+
+describe('RFC-64 inventory v1 SQL scalar codecs', () => {
+  it.each([
+    ['0', '0000000000000000'],
+    ['1', '0000000000000001'],
+    ['262144', '0000000000040000'],
+    ['4096', '0000000000001000'],
+    ['18446744073709551615', 'ffffffffffffffff'],
+  ])('encodes u64 %s as the exact eight-byte big-endian BLOB', (value, expected) => {
+    const encoded = decimalU64ToSqlBlobV1(u64(value));
+    expect(hex(encoded)).toBe(expected);
+    expect(sqlBlobToDecimalU64V1(encoded)).toBe(value);
+  });
+
+  it.each([
+    ['1', `${'00'.repeat(31)}01`],
+    ['18446744073709551616', '0000000000000000000000000000000000000000000000010000000000000000'],
+    [
+      '57896044618658097711785492504343953926634992332820282019728792003956564819968',
+      `80${'00'.repeat(31)}`,
+    ],
+    [
+      '115792089237316195423570985008687907853269984665640564039457584007913129639935',
+      'ff'.repeat(32),
+    ],
+  ])('encodes u256 %s as the exact 32-byte big-endian BLOB', (value, expected) => {
+    const encoded = decimalU256ToSqlBlobV1(u256(value));
+    expect(hex(encoded)).toBe(expected);
+    expect(sqlBlobToDecimalU256V1(encoded)).toBe(value);
+  });
+
+  it('sorts fixed-width u256 BLOBs in SQLite unsigned mathematical order', () => {
+    const values = [
+      '0',
+      '1',
+      '9',
+      '10',
+      '18446744073709551615',
+      '18446744073709551616',
+      '57896044618658097711785492504343953926634992332820282019728792003956564819968',
+      '115792089237316195423570985008687907853269984665640564039457584007913129639935',
+    ];
+    const database = new DatabaseSync(':memory:');
+    try {
+      database.exec(`CREATE TABLE values_v1 (value BLOB PRIMARY KEY) WITHOUT ROWID, STRICT`);
+      const insert = database.prepare('INSERT INTO values_v1 (value) VALUES (?)');
+      for (const value of [...values].reverse()) insert.run(decimalU256ToSqlBlobV1(u256(value)));
+      const rows = database.prepare('SELECT value FROM values_v1 ORDER BY value').all();
+      expect(rows.map((row) => sqlBlobToDecimalU256V1(row.value))).toEqual(values);
+    } finally {
+      database.close();
+    }
+  });
+
+  it('round-trips exact digest and nonzero EVM-address bytes', () => {
+    const root = digest(`0x${'ab'.repeat(32)}`);
+    const author = address(`0x${'33'.repeat(20)}`);
+    expect(hex(digest32ToSqlBlobV1(root))).toBe('ab'.repeat(32));
+    expect(sqlBlobToDigest32V1(Buffer.from('ab'.repeat(32), 'hex'))).toBe(root);
+    expect(hex(evmAddressToSqlBlobV1(author))).toBe('33'.repeat(20));
+    expect(sqlBlobToEvmAddressV1(Buffer.from('33'.repeat(20), 'hex'))).toBe(author);
+  });
+
+  it('rejects noncanonical decimals, widths, typed views, digests, and addresses', () => {
+    expect(() => decimalU64ToSqlBlobV1(u64('01'))).toThrow();
+    expect(() => decimalU64ToSqlBlobV1(u64('18446744073709551616'))).toThrow();
+    expect(() => decimalU256ToSqlBlobV1(u256('-1'))).toThrow();
+    expect(() => sqlBlobToDecimalU64V1(new Uint8Array(7))).toThrow(InventoryV1ScalarError);
+    expect(() => sqlBlobToDecimalU256V1(new Uint16Array(16))).toThrow(InventoryV1ScalarError);
+    expect(() => assertSqlBlobWidthV1(new DataView(new ArrayBuffer(8)), 8, 'u64')).toThrow(
+      InventoryV1ScalarError,
+    );
+    expect(() => digest32ToSqlBlobV1(digest(`0x${'AB'.repeat(32)}`))).toThrow();
+    expect(() => evmAddressToSqlBlobV1(address(`0x${'00'.repeat(20)}`))).toThrow(
+      InventoryV1ScalarError,
+    );
+    expect(() => sqlBlobToEvmAddressV1(new Uint8Array(20))).toThrow(InventoryV1ScalarError);
+  });
+
+  it('copies accepted BLOB views and compares byte values without coercion', () => {
+    const source = Buffer.from('01020304', 'hex');
+    const copy = assertSqlBlobWidthV1(source, 4, 'fixture');
+    source[0] = 0xff;
+    expect(hex(copy)).toBe('01020304');
+    expect(sqlBlobsEqualV1(copy, Buffer.from('01020304', 'hex'))).toBe(true);
+    expect(sqlBlobsEqualV1(copy, Buffer.from('01020305', 'hex'))).toBe(false);
+    expect(sqlBlobsEqualV1(copy, new Uint16Array(2))).toBe(false);
+  });
+
+  it('maps root identifiers only to SQL NULL and requires pre-normalized text', () => {
+    const assertIdentifier = (candidate: unknown) => {
+      if (typeof candidate !== 'string' || candidate.length === 0) throw new Error('invalid identifier');
+    };
+    expect(nullableIdentifierToSqlTextV1(null, assertIdentifier)).toBeNull();
+    expect(nullableIdentifierToSqlTextV1('rootless', assertIdentifier)).toBe('rootless');
+    expect(() => nullableIdentifierToSqlTextV1('', assertIdentifier)).toThrow('invalid identifier');
+    expect(() => nullableIdentifierToSqlTextV1('e\u0301', assertIdentifier)).toThrow(
+      InventoryV1ScalarError,
+    );
+  });
+});

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -103,6 +103,8 @@ export default defineConfig({
       "test/cg-resolve-refresh.test.ts",
       "test/private-cg-membership-bootstrap.test.ts",
       "test/workspace-crypto-delegatee-filter.test.ts",
+      "test/rfc64-inventory-v1-scalars.test.ts",
+      "test/rfc64-inventory-v1-lifecycle.test.ts",
     ],
     testTimeout: 60_000,
     maxWorkers: 1,


### PR DESCRIPTION
## Summary

Adds the dormant SQL-A foundation for OT-RFC-64 inventory synchronization. It owns the dedicated SQLite namespace, strict scalar/identity checks, cross-process DK6L lifetime lease, fail-closed quarantine/recovery protocol, and deterministic lifecycle error surface without yet discovering, transferring, or applying any KA.

## Safety properties

- retains the DK6L lease for the full foundation lifetime and proves target exclusivity before quarantine
- requires explicit certified POSIX durability before entering any schema/corrupt quarantine proof
- fails closed on foreign/newer/corrupt/headerless lease or target identities and orphan sidecars
- on any target-close failure, retains the possibly live target and DK6L lease in process fail-stop
- recovers exact full-manifest and moved-prefix quarantine states after real SIGKILL/new-process reopen
- rejects malformed markers before lease creation, permission changes, lifecycle callbacks, or filesystem mutation
- keeps lifecycle fault injection internal, immutable, test-only, and absent from the package entry point
- uses direct .NET ACL APIs on Windows and adds a native Windows CI lane

## Verification

- focused RFC-64 inventory tests: 64 passed, 4 Windows-only skipped locally
- real persisted-WAL rejection proves the unsupported path never enters the quarantine proof and preserves both committed rows
- full agent unit suite: 1,168 passed, 4 platform-only skipped before the final focused hardening
- agent build and type tests: passed
- dependency build closure: passed
- crash-harness standalone typecheck: passed
- git diff check: passed

## Stack

Base: #1802 (feat/rfc64-catalog-authority-codecs). Candidate CRUD/diff, discovery, transfer, semantic admission (#1780), and activation are intentionally separate follow-up slices.
