### PR TITLE
feat(core): bind RFC-64 catalog rows to author seals

### DIFF
--- a/packages/core/src/canonical-graph-scoped-author-seal.ts
+++ b/packages/core/src/canonical-graph-scoped-author-seal.ts
@@ -67,9 +67,13 @@ export const CANONICAL_GRAPH_SCOPED_AUTHOR_SEAL_DIGEST_DOMAIN_V1 =
 export const MAX_CANONICAL_GRAPH_SCOPED_AUTHOR_SEAL_BYTES_V1 = 16 * 1024;
 export const MAX_SEAL_TRIPLE_COUNT_V1 = 9_007_199_254_740_991n;
 
-const XSD_HEX_BINARY = '<http://www.w3.org/2001/XMLSchema#hexBinary>';
-const XSD_INTEGER = '<http://www.w3.org/2001/XMLSchema#integer>';
-const XSD_DATE_TIME = '<http://www.w3.org/2001/XMLSchema#dateTime>';
+const XSD_STRING_IRI = 'http://www.w3.org/2001/XMLSchema#string';
+const XSD_HEX_BINARY_IRI = 'http://www.w3.org/2001/XMLSchema#hexBinary';
+const XSD_INTEGER_IRI = 'http://www.w3.org/2001/XMLSchema#integer';
+const XSD_DATE_TIME_IRI = 'http://www.w3.org/2001/XMLSchema#dateTime';
+const XSD_HEX_BINARY = `<${XSD_HEX_BINARY_IRI}>`;
+const XSD_INTEGER = `<${XSD_INTEGER_IRI}>`;
+const XSD_DATE_TIME = `<${XSD_DATE_TIME_IRI}>`;
 const UTF8 = new TextEncoder();
 const SEAL_DIGEST_DOMAIN_BYTES = UTF8.encode(
   CANONICAL_GRAPH_SCOPED_AUTHOR_SEAL_DIGEST_DOMAIN_V1,
@@ -443,6 +447,57 @@ export function projectCanonicalGraphScopedAuthorSealRowsV1(
     );
   }
   return exactRows;
+}
+
+/**
+ * Project transferred canonical seal bytes into the backend-neutral typed RDF
+ * rows consumed by the strict inverse decoder and the PR #1780 classifier.
+ *
+ * This is an in-memory projection only. It performs no triple-store read or
+ * write and gives callers no authority to treat the seal as semantically
+ * admitted.
+ */
+export function projectCanonicalGraphScopedAuthorSealStoreRowsV1(
+  payload: CanonicalGraphScopedAuthorSealV1,
+  coordinate: CanonicalGraphScopedAuthorSealCoordinateV1,
+): readonly CanonicalAuthorSealStoreRowV1[] {
+  const rows = projectCanonicalGraphScopedAuthorSealRowsV1(payload, coordinate);
+  const literal = (
+    value: string,
+    datatypeIri: string,
+  ): CanonicalAuthorSealStoreObjectV1 => Object.freeze({
+    kind: 'literal' as const,
+    value,
+    datatypeIri,
+  });
+  const objects: readonly CanonicalAuthorSealStoreObjectV1[] = [
+    literal(payload.assertionMerkleRoot.slice(2), XSD_HEX_BINARY_IRI),
+    literal(payload.authorAddress, XSD_STRING_IRI),
+    literal(payload.authorAttestationR.slice(2), XSD_HEX_BINARY_IRI),
+    literal(payload.authorAttestationVS.slice(2), XSD_HEX_BINARY_IRI),
+    literal('1', XSD_INTEGER_IRI),
+    literal(payload.assertedAtChainId, XSD_INTEGER_IRI),
+    literal(payload.assertedAtKav10Address, XSD_STRING_IRI),
+    literal(payload.reservedKaId, XSD_INTEGER_IRI),
+    literal(payload.assertionFinalizedAt, XSD_DATE_TIME_IRI),
+    literal('2', XSD_INTEGER_IRI),
+    Object.freeze({ kind: 'named-node' as const, value: payload.kaUal }),
+    literal(payload.assertionVersion, XSD_INTEGER_IRI),
+    literal(payload.publicTripleCount, XSD_INTEGER_IRI),
+    literal(payload.privateTripleCount, XSD_INTEGER_IRI),
+    ...(payload.privateMerkleRoot === null
+      ? []
+      : [literal(payload.privateMerkleRoot.slice(2), XSD_HEX_BINARY_IRI)]),
+  ];
+  if (objects.length !== rows.length) {
+    fail('canonical-seal-row-cardinality', 'typed projection cardinality is inconsistent');
+  }
+  return Object.freeze(rows.map((row, index) => Object.freeze({
+    subjectIri: row.subject,
+    predicateIri: row.predicate,
+    graphIri: row.graph,
+    object: objects[index],
+  })));
 }
 
 /** Render one typed store row to the exact canonical parser-row representation. */

--- a/packages/core/src/catalog-seal-binding.ts
+++ b/packages/core/src/catalog-seal-binding.ts
@@ -1,0 +1,357 @@
+import {
+  assertAuthorCatalogRowScopeBindingV1,
+  assertAuthorCatalogRowV1,
+  assertAuthorCatalogScopeV1,
+  assertNetworkIdV1,
+  buildCatalogAssertionScopeV1,
+  canonicalizeAuthorCatalogRowV1,
+  canonicalizeAuthorCatalogScopeV1,
+  computeAuthorCatalogRowDigestV1,
+  computeAuthorCatalogScopeDigestV1,
+  iriComponentV1,
+  parseCanonicalAuthorCatalogRowV1,
+  parseCanonicalAuthorCatalogScopeV1,
+  type AssertionCoordinateV1,
+  type AuthorCatalogRowV1,
+  type AuthorCatalogScopeV1,
+  type NetworkIdV1,
+} from './author-catalog-codec.js';
+import {
+  MAX_CANONICAL_GRAPH_SCOPED_AUTHOR_SEAL_BYTES_V1,
+  classifyCanonicalGraphScopedAuthorSealRowsV1,
+  parseCanonicalGraphScopedAuthorSealV1,
+  projectCanonicalGraphScopedAuthorSealStoreRowsV1,
+  type CanonicalGraphScopedAuthorSealPlacementV1,
+  type CanonicalGraphScopedAuthorSealRowV1,
+  type CanonicalGraphScopedAuthorSealV1,
+} from './canonical-graph-scoped-author-seal.js';
+import { parseDeterministicKnowledgeAssetUal } from './ka-content-scope.js';
+import {
+  assertCanonicalChainId,
+  assertCanonicalEvmAddress,
+  type ChainIdV1,
+  type DecimalU64V1,
+  type Digest32V1,
+  type EvmAddressV1,
+  type KaIdV1,
+} from './sync-wire-scalars.js';
+import { assertExactKeys, isPlainRecord } from './sync-wire-objects.js';
+
+declare const VERIFIED_CATALOG_SEAL_BINDING_BRAND_V1: unique symbol;
+
+/** Pinned v10 lane mapping supplied by local subscription configuration. */
+export interface CatalogSealDeploymentProfileV1 {
+  readonly networkId: NetworkIdV1;
+  readonly assertedAtChainId: ChainIdV1;
+  readonly assertedAtKav10Address: EvmAddressV1;
+}
+
+/**
+ * Unforgeable process-local proof that transferred canonical seal bytes match
+ * one exact catalog row and locally pinned deployment profile.
+ *
+ * This is intentionally not `SemanticallyAdmittedCatalogRowV1`: KA projection
+ * RDFC/structured-root verification, author-signature recovery, finalized VM
+ * evidence, semantic-store commit, and post-read verification remain mandatory.
+ */
+export interface VerifiedCatalogSealBindingV1 {
+  readonly [VERIFIED_CATALOG_SEAL_BINDING_BRAND_V1]: true;
+}
+
+export interface VerifiedCatalogSealBindingSnapshotV1 {
+  readonly catalogScopeDigest: Digest32V1;
+  readonly catalogRowDigest: Digest32V1;
+  readonly networkId: NetworkIdV1;
+  readonly authorAddress: EvmAddressV1;
+  readonly kaId: KaIdV1;
+  readonly assertionCoordinate: AssertionCoordinateV1;
+  readonly assertionVersion: DecimalU64V1;
+  readonly sealDigest: Digest32V1;
+  readonly placement: Readonly<CanonicalGraphScopedAuthorSealPlacementV1>;
+  readonly seal: Readonly<CanonicalGraphScopedAuthorSealV1>;
+  readonly sealRows: readonly Readonly<CanonicalGraphScopedAuthorSealRowV1>[];
+  /** Caller-owned copy; mutating it cannot alter the verifier's retained state. */
+  readonly canonicalSealBytes: Uint8Array;
+}
+
+export type CatalogSealBindingErrorCode =
+  | 'catalog-seal-input'
+  | 'catalog-seal-profile'
+  | 'catalog-seal-classifier'
+  | 'catalog-seal-coordinate'
+  | 'catalog-seal-ual'
+  | 'catalog-seal-ka-id'
+  | 'catalog-seal-version'
+  | 'catalog-seal-digest'
+  | 'catalog-seal-deployment'
+  | 'catalog-seal-capability';
+
+export class CatalogSealBindingError extends Error {
+  constructor(
+    readonly code: CatalogSealBindingErrorCode,
+    message: string,
+    options: ErrorOptions = {},
+  ) {
+    super(`[${code}] ${message}`, options);
+    this.name = 'CatalogSealBindingError';
+  }
+}
+
+interface CatalogSealBindingStateV1 {
+  readonly snapshot: Omit<VerifiedCatalogSealBindingSnapshotV1, 'canonicalSealBytes'>;
+  readonly canonicalSealBytes: Uint8Array;
+}
+
+const VERIFIED_CATALOG_SEAL_BINDINGS_V1 = new WeakMap<
+  object,
+  CatalogSealBindingStateV1
+>();
+const TYPED_ARRAY_PROTOTYPE = Object.getPrototypeOf(Uint8Array.prototype) as object;
+const GET_TYPED_ARRAY_BUFFER = Object.getOwnPropertyDescriptor(
+  TYPED_ARRAY_PROTOTYPE,
+  'buffer',
+)!.get!;
+const GET_TYPED_ARRAY_BYTE_LENGTH = Object.getOwnPropertyDescriptor(
+  TYPED_ARRAY_PROTOTYPE,
+  'byteLength',
+)!.get!;
+const GET_TYPED_ARRAY_TAG = Object.getOwnPropertyDescriptor(
+  TYPED_ARRAY_PROTOTYPE,
+  Symbol.toStringTag,
+)!.get!;
+
+/**
+ * Bind one transferred canonical author seal to a staged catalog row.
+ *
+ * The strict typed-row reconstruction invokes PR #1780's canonical classifier
+ * exactly once. This function performs no RDF payload parsing or persistence.
+ */
+export function verifyCatalogSealBindingV1(
+  catalogScope: AuthorCatalogScopeV1,
+  row: AuthorCatalogRowV1,
+  canonicalSealBytes: Uint8Array,
+  deployment: CatalogSealDeploymentProfileV1,
+): VerifiedCatalogSealBindingV1 {
+  let scope: AuthorCatalogScopeV1;
+  let catalogRow: AuthorCatalogRowV1;
+  try {
+    assertAuthorCatalogScopeV1(catalogScope);
+    assertAuthorCatalogRowV1(row);
+    scope = parseCanonicalAuthorCatalogScopeV1(
+      canonicalizeAuthorCatalogScopeV1(catalogScope),
+    );
+    catalogRow = parseCanonicalAuthorCatalogRowV1(
+      canonicalizeAuthorCatalogRowV1(row),
+    );
+    assertAuthorCatalogRowScopeBindingV1(catalogRow, scope);
+  } catch (cause) {
+    fail('catalog-seal-input', 'catalog scope or row is not structurally bound', cause);
+  }
+  assertDeploymentProfile(deployment);
+  const pinnedDeployment = Object.freeze({
+    networkId: deployment.networkId,
+    assertedAtChainId: deployment.assertedAtChainId,
+    assertedAtKav10Address: deployment.assertedAtKav10Address,
+  });
+  if (pinnedDeployment.networkId !== scope.networkId) {
+    fail('catalog-seal-deployment', 'deployment networkId differs from catalog scope');
+  }
+  const receivedSealBytes = snapshotCanonicalBytes(canonicalSealBytes);
+  let seal: CanonicalGraphScopedAuthorSealV1;
+  try {
+    seal = parseCanonicalGraphScopedAuthorSealV1(receivedSealBytes);
+  } catch (cause) {
+    fail('catalog-seal-input', 'canonicalSealBytes are not a canonical graph-scoped seal', cause);
+  }
+
+  const coordinate = {
+    contextGraphId: scope.contextGraphId,
+    subGraphName: scope.subGraphName,
+    authorAddress: scope.authorAddress,
+    assertionCoordinate: catalogRow.assertionCoordinate,
+  };
+  let classified: ReturnType<typeof classifyCanonicalGraphScopedAuthorSealRowsV1>;
+  try {
+    const storeRows = projectCanonicalGraphScopedAuthorSealStoreRowsV1(seal, coordinate);
+    classified = classifyCanonicalGraphScopedAuthorSealRowsV1(storeRows, coordinate);
+  } catch (cause) {
+    fail(
+      'catalog-seal-classifier',
+      'strict typed-row reconstruction or PR #1780 classification failed',
+      cause,
+    );
+  }
+
+  if (!equalBytes(receivedSealBytes, classified.canonicalSealBytes)) {
+    fail('catalog-seal-digest', 'classifier reconstruction changed canonical seal bytes');
+  }
+  const expectedScope = buildCatalogAssertionScopeV1(scope);
+  if (
+    classified.candidate.coordinate.scope !== expectedScope
+    || classified.candidate.coordinate.agentAddress !== scope.authorAddress
+    || classified.candidate.coordinate.name !== iriComponentV1(catalogRow.assertionCoordinate)
+  ) {
+    fail('catalog-seal-coordinate', 'PR #1780 coordinate differs from the catalog row');
+  }
+
+  let ual: ReturnType<typeof parseDeterministicKnowledgeAssetUal>;
+  try {
+    ual = parseDeterministicKnowledgeAssetUal(seal.kaUal);
+  } catch (cause) {
+    fail('catalog-seal-ual', 'seal UAL is not a canonical packed graph identity', cause);
+  }
+  if (
+    ual.chainId !== pinnedDeployment.networkId
+    || ual.agentAddress !== scope.authorAddress
+    || classified.candidate.seal.kaUal !== seal.kaUal
+  ) {
+    fail('catalog-seal-ual', 'seal UAL namespace or author differs from the pinned catalog lane');
+  }
+
+  const expectedKaId = (BigInt(ual.agentAddress) << 96n) | BigInt(ual.kaNumber);
+  if (
+    BigInt(catalogRow.kaId) !== expectedKaId
+    || BigInt(seal.reservedKaId) !== expectedKaId
+    || classified.candidate.seal.reservedKaId !== expectedKaId
+  ) {
+    fail('catalog-seal-ka-id', 'UAL, row kaId, and reservedKaId do not identify one KA');
+  }
+  if (
+    seal.assertionVersion !== catalogRow.assertionVersion
+    || classified.candidate.seal.assertionVersion !== catalogRow.assertionVersion
+  ) {
+    fail('catalog-seal-version', 'seal assertionVersion differs from the catalog row');
+  }
+  if (classified.sealDigest !== catalogRow.sealDigest) {
+    fail('catalog-seal-digest', 'canonical seal digest differs from the catalog row');
+  }
+  if (
+    seal.assertedAtChainId !== pinnedDeployment.assertedAtChainId
+    || seal.assertedAtKav10Address !== pinnedDeployment.assertedAtKav10Address
+    || classified.candidate.seal.chainId !== BigInt(pinnedDeployment.assertedAtChainId)
+    || classified.candidate.seal.kav10Address !== pinnedDeployment.assertedAtKav10Address
+  ) {
+    fail('catalog-seal-deployment', 'seal chain or KAv10 deployment differs from local pins');
+  }
+
+  const placement = Object.freeze({ ...classified.placement });
+  const sealSnapshot = Object.freeze({ ...classified.payload });
+  const sealRows = Object.freeze(classified.rows.map((sealRow) => Object.freeze({ ...sealRow })));
+  const catalogScopeDigest = computeAuthorCatalogScopeDigestV1(scope);
+  const snapshot = Object.freeze({
+    catalogScopeDigest,
+    catalogRowDigest: computeAuthorCatalogRowDigestV1(
+      catalogScopeDigest,
+      catalogRow,
+    ),
+    networkId: pinnedDeployment.networkId,
+    authorAddress: scope.authorAddress,
+    kaId: catalogRow.kaId,
+    assertionCoordinate: catalogRow.assertionCoordinate,
+    assertionVersion: catalogRow.assertionVersion,
+    sealDigest: classified.sealDigest,
+    placement,
+    seal: sealSnapshot,
+    sealRows,
+  });
+  const capability = Object.freeze(Object.create(null)) as VerifiedCatalogSealBindingV1;
+  VERIFIED_CATALOG_SEAL_BINDINGS_V1.set(capability as object, Object.freeze({
+    snapshot,
+    canonicalSealBytes: receivedSealBytes,
+  }));
+  return capability;
+}
+
+export function assertVerifiedCatalogSealBindingV1(
+  value: unknown,
+): asserts value is VerifiedCatalogSealBindingV1 {
+  if ((typeof value !== 'object' && typeof value !== 'function') || value === null) {
+    fail('catalog-seal-capability', 'catalog seal binding was not minted by this verifier');
+  }
+  if (!VERIFIED_CATALOG_SEAL_BINDINGS_V1.has(value as object)) {
+    fail('catalog-seal-capability', 'catalog seal binding was not minted by this verifier');
+  }
+}
+
+/** Return immutable scalar state plus a fresh caller-owned canonical byte copy. */
+export function readVerifiedCatalogSealBindingV1(
+  value: unknown,
+): VerifiedCatalogSealBindingSnapshotV1 {
+  assertVerifiedCatalogSealBindingV1(value);
+  const state = VERIFIED_CATALOG_SEAL_BINDINGS_V1.get(value as object)!;
+  return Object.freeze({
+    ...state.snapshot,
+    canonicalSealBytes: new Uint8Array(state.canonicalSealBytes),
+  });
+}
+
+function assertDeploymentProfile(
+  deployment: unknown,
+): asserts deployment is CatalogSealDeploymentProfileV1 {
+  try {
+    if (!isPlainRecord(deployment)) throw new Error('profile must be a plain object');
+    assertExactKeys(
+      deployment,
+      ['assertedAtChainId', 'assertedAtKav10Address', 'networkId'],
+      'catalog seal deployment profile',
+    );
+    assertNetworkIdV1(deployment.networkId);
+    assertCanonicalChainId(deployment.assertedAtChainId, 'assertedAtChainId');
+    assertCanonicalEvmAddress(deployment.assertedAtKav10Address, 'assertedAtKav10Address');
+  } catch (cause) {
+    fail('catalog-seal-profile', 'deployment profile is not canonical', cause);
+  }
+}
+
+function snapshotCanonicalBytes(value: unknown): Uint8Array {
+  let backingBuffer: ArrayBufferLike;
+  let byteLength: number;
+  let typedArrayTag: string | undefined;
+  try {
+    backingBuffer = Reflect.apply(GET_TYPED_ARRAY_BUFFER, value, []);
+    byteLength = Reflect.apply(GET_TYPED_ARRAY_BYTE_LENGTH, value, []);
+    typedArrayTag = Reflect.apply(GET_TYPED_ARRAY_TAG, value, []);
+  } catch (cause) {
+    fail('catalog-seal-input', 'canonicalSealBytes must be a genuine Uint8Array', cause);
+  }
+  if (typedArrayTag !== 'Uint8Array') {
+    fail('catalog-seal-input', 'canonicalSealBytes must be a Uint8Array');
+  }
+  if (!(backingBuffer instanceof ArrayBuffer)) {
+    fail('catalog-seal-input', 'canonicalSealBytes must not use shared backing memory');
+  }
+  if ((backingBuffer as ArrayBuffer & { readonly resizable?: boolean }).resizable === true) {
+    fail('catalog-seal-input', 'canonicalSealBytes must not use resizable backing memory');
+  }
+  if (byteLength > MAX_CANONICAL_GRAPH_SCOPED_AUTHOR_SEAL_BYTES_V1) {
+    fail(
+      'catalog-seal-input',
+      `canonicalSealBytes exceed ${MAX_CANONICAL_GRAPH_SCOPED_AUTHOR_SEAL_BYTES_V1} bytes`,
+    );
+  }
+  try {
+    // Always normalize Buffer and typed-array subclasses to an ordinary,
+    // independently backed Uint8Array. Buffer.prototype.slice() returns a
+    // shared view, so retaining a Buffer here would make later reads mutable.
+    return new Uint8Array(value as Uint8Array);
+  } catch (cause) {
+    fail('catalog-seal-input', 'canonicalSealBytes could not be snapshotted safely', cause);
+  }
+}
+
+function equalBytes(left: Uint8Array, right: Uint8Array): boolean {
+  if (left.byteLength !== right.byteLength) return false;
+  let difference = 0;
+  for (let index = 0; index < left.byteLength; index += 1) {
+    difference |= left[index] ^ right[index];
+  }
+  return difference === 0;
+}
+
+function fail(
+  code: CatalogSealBindingErrorCode,
+  message: string,
+  cause?: unknown,
+): never {
+  throw new CatalogSealBindingError(code, message, cause === undefined ? {} : { cause });
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -355,6 +355,7 @@ export {
   assertCanonicalGraphScopedAuthorSealCoordinateV1,
   deriveCanonicalGraphScopedAuthorSealPlacementV1,
   projectCanonicalGraphScopedAuthorSealRowsV1,
+  projectCanonicalGraphScopedAuthorSealStoreRowsV1,
   renderCanonicalAuthorSealStoreRowV1,
   decodeCanonicalGraphScopedAuthorSealRowsV1,
   classifyCanonicalGraphScopedAuthorSealRowsV1,
@@ -373,3 +374,4 @@ export {
   type ClassifiedCanonicalGraphScopedAuthorSealRowsV1,
   type CanonicalGraphScopedAuthorSealErrorCode,
 } from './canonical-graph-scoped-author-seal.js';
+export * from './catalog-seal-binding.js';

--- a/packages/core/test/canonical-graph-scoped-author-seal.test.ts
+++ b/packages/core/test/canonical-graph-scoped-author-seal.test.ts
@@ -13,6 +13,7 @@ import {
   deriveCanonicalGraphScopedAuthorSealPlacementV1,
   parseCanonicalGraphScopedAuthorSealV1,
   projectCanonicalGraphScopedAuthorSealRowsV1,
+  projectCanonicalGraphScopedAuthorSealStoreRowsV1,
   renderCanonicalAuthorSealStoreRowV1,
   type CanonicalAuthorSealStoreRowV1,
   type CanonicalGraphScopedAuthorSealCoordinateV1,
@@ -90,6 +91,13 @@ describe('CanonicalGraphScopedAuthorSealV1 bytes and projection', () => {
     expect(rows.map((row) => row.predicate)).toEqual(EXPECTED_PREDICATES);
     expect(rows.map((row) => row.object)).toEqual(EXPECTED_OBJECTS);
     expect(rows.every((row) => row.subject === SUBJECT && row.graph === META_GRAPH)).toBe(true);
+
+    const typedRows = projectCanonicalGraphScopedAuthorSealStoreRowsV1(PAYLOAD, COORDINATE);
+    expect(Object.isFrozen(typedRows)).toBe(true);
+    expect(typedRows).toHaveLength(rows.length);
+    expect(typedRows.map(renderCanonicalAuthorSealStoreRowV1)).toEqual(rows);
+    expect(typedRows.every((row) => Object.isFrozen(row) && Object.isFrozen(row.object)))
+      .toBe(true);
   });
 
   it('emits the optional private-root row only for positive private content', () => {

--- a/packages/core/test/catalog-seal-binding.test.ts
+++ b/packages/core/test/catalog-seal-binding.test.ts
@@ -1,0 +1,305 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  assertAuthorCatalogRowV1,
+  assertAuthorCatalogScopeV1,
+  computeAuthorCatalogRowDigestV1,
+  type AuthorCatalogRowV1,
+  type AuthorCatalogScopeV1,
+} from '../src/author-catalog-codec.js';
+import {
+  CatalogSealBindingError,
+  assertVerifiedCatalogSealBindingV1,
+  readVerifiedCatalogSealBindingV1,
+  verifyCatalogSealBindingV1,
+  type CatalogSealBindingErrorCode,
+  type CatalogSealDeploymentProfileV1,
+} from '../src/catalog-seal-binding.js';
+import {
+  MAX_CANONICAL_GRAPH_SCOPED_AUTHOR_SEAL_BYTES_V1,
+  assertCanonicalGraphScopedAuthorSealV1,
+  canonicalizeCanonicalGraphScopedAuthorSealBytesV1,
+  type CanonicalGraphScopedAuthorSealV1,
+} from '../src/canonical-graph-scoped-author-seal.js';
+
+const AUTHOR = '0x3333333333333333333333333333333333333333';
+const KAV10 = '0x4444444444444444444444444444444444444444';
+const KA_ID =
+  '23158417847463239084714197001737581570653996933112267175388663934063917137927';
+const NEXT_KA_ID =
+  '23158417847463239084714197001737581570653996933112267175388663934063917137928';
+const SEAL_DIGEST =
+  '0x8fc37c7f66831aea9b2a0ed35aac26bb6eec2eb3042ed0dcdd2e023d3087632a';
+const ZERO_DIGEST = `0x${'00'.repeat(32)}`;
+
+const SCOPE = validScope({
+  networkId: 'otp:20430',
+  contextGraphId: 'a/b',
+  governanceChainId: '20430',
+  governanceContractAddress: '0x5555555555555555555555555555555555555555',
+  ownershipTransitionDigest: null,
+  subGraphName: null,
+  authorAddress: AUTHOR,
+  era: '0',
+  bucketCount: '1',
+});
+const ROW = validRow({
+  kaId: KA_ID,
+  assertionCoordinate: 'name λ',
+  assertionVersion: '2',
+  projectionId: 'cg-shared-v1',
+  projectionDigest: ZERO_DIGEST,
+  sealDigest: SEAL_DIGEST,
+  transfer: {
+    codec: 'dkg-ka-bundle-v1',
+    projectionId: 'cg-shared-v1',
+    projectionDigest: ZERO_DIGEST,
+    byteLength: '16',
+    chunkSize: '262144',
+    chunkCount: '1',
+    blobDigest: `0x${'11'.repeat(32)}`,
+    chunkTreeRoot: `0x${'22'.repeat(32)}`,
+  },
+});
+const PROFILE = {
+  networkId: 'otp:20430',
+  assertedAtChainId: '20430',
+  assertedAtKav10Address: KAV10,
+} as CatalogSealDeploymentProfileV1;
+const SEAL = validSeal({
+  assertionMerkleRoot: `0x${'aa'.repeat(32)}`,
+  authorAddress: AUTHOR,
+  authorAttestationR: `0x${'11'.repeat(32)}`,
+  authorAttestationVS: `0x${'22'.repeat(32)}`,
+  authorSchemeVersion: '1',
+  assertedAtChainId: '20430',
+  assertedAtKav10Address: KAV10,
+  reservedKaId: KA_ID,
+  assertionFinalizedAt: '2026-07-19T12:34:56.789Z',
+  contentScopeVersion: '2',
+  kaUal: `did:dkg:otp:20430/${AUTHOR}/7`,
+  assertionVersion: '2',
+  publicTripleCount: '12977',
+  privateTripleCount: '0',
+  privateMerkleRoot: null,
+});
+const SEAL_BYTES = canonicalizeCanonicalGraphScopedAuthorSealBytesV1(SEAL);
+
+describe('RFC-64 transferred catalog seal binding', () => {
+  it('binds one exact row through typed reconstruction and the #1780 classifier', () => {
+    const verified = verifyCatalogSealBindingV1(SCOPE, ROW, SEAL_BYTES, PROFILE);
+    expect(Object.getPrototypeOf(verified)).toBeNull();
+    expect(Object.isFrozen(verified)).toBe(true);
+    expect(Reflect.ownKeys(verified as object)).toEqual([]);
+    expect(() => assertVerifiedCatalogSealBindingV1(verified)).not.toThrow();
+
+    const snapshot = readVerifiedCatalogSealBindingV1(verified);
+    expect(snapshot).toMatchObject({
+      networkId: 'otp:20430',
+      authorAddress: AUTHOR,
+      kaId: KA_ID,
+      assertionCoordinate: 'name λ',
+      assertionVersion: '2',
+      sealDigest: SEAL_DIGEST,
+      placement: {
+        subject: `did:dkg:context-graph:v1/root/a%2Fb/assertion/${AUTHOR}/name%20%CE%BB`,
+        metaGraph: 'did:dkg:context-graph:v1/root/a%2Fb/_meta',
+      },
+      seal: SEAL,
+    });
+    expect(snapshot.catalogRowDigest).toBe(
+      computeAuthorCatalogRowDigestV1(snapshot.catalogScopeDigest, ROW),
+    );
+    expect(snapshot.sealRows).toHaveLength(14);
+    expect(new TextDecoder().decode(snapshot.canonicalSealBytes)).toBe(
+      new TextDecoder().decode(SEAL_BYTES),
+    );
+    expect(Object.isFrozen(snapshot)).toBe(true);
+    expect(Object.isFrozen(snapshot.seal)).toBe(true);
+    expect(Object.isFrozen(snapshot.placement)).toBe(true);
+    expect(Object.isFrozen(snapshot.sealRows)).toBe(true);
+  });
+
+  it('retains immutable verifier state while returning caller-owned byte copies', () => {
+    const source = SEAL_BYTES.slice();
+    const verified = verifyCatalogSealBindingV1(SCOPE, ROW, source, PROFILE);
+    source.fill(0);
+    const first = readVerifiedCatalogSealBindingV1(verified);
+    first.canonicalSealBytes.fill(0);
+    const second = readVerifiedCatalogSealBindingV1(verified);
+    expect(new TextDecoder().decode(second.canonicalSealBytes)).toBe(
+      new TextDecoder().decode(SEAL_BYTES),
+    );
+  });
+
+  it('normalizes Buffer and typed-array subclasses without exposing retained bytes', () => {
+    class SealBytes extends Uint8Array {}
+    for (const source of [
+      Buffer.from(SEAL_BYTES),
+      new SealBytes(SEAL_BYTES),
+    ]) {
+      const verified = verifyCatalogSealBindingV1(SCOPE, ROW, source, PROFILE);
+      source.fill(0);
+      const first = readVerifiedCatalogSealBindingV1(verified);
+      expect(first.canonicalSealBytes.constructor).toBe(Uint8Array);
+      expect(Buffer.isBuffer(first.canonicalSealBytes)).toBe(false);
+      first.canonicalSealBytes.fill(0);
+      const second = readVerifiedCatalogSealBindingV1(verified);
+      expect(second.canonicalSealBytes.constructor).toBe(Uint8Array);
+      expect(Buffer.isBuffer(second.canonicalSealBytes)).toBe(false);
+      expect(new TextDecoder().decode(second.canonicalSealBytes)).toBe(
+        new TextDecoder().decode(SEAL_BYTES),
+      );
+    }
+  });
+
+  it('rejects over-cap byte inputs before attempting semantic parsing', () => {
+    const spoofedOversized = Buffer.alloc(
+      MAX_CANONICAL_GRAPH_SCOPED_AUTHOR_SEAL_BYTES_V1 + 1,
+    );
+    Object.defineProperties(spoofedOversized, {
+      buffer: { value: new ArrayBuffer(1) },
+      byteLength: { value: 1 },
+    });
+    expectFailure(
+      () => verifyCatalogSealBindingV1(
+        SCOPE,
+        ROW,
+        Buffer.alloc(MAX_CANONICAL_GRAPH_SCOPED_AUTHOR_SEAL_BYTES_V1 + 1),
+        PROFILE,
+      ),
+      'catalog-seal-input',
+    );
+    expectFailure(
+      () => verifyCatalogSealBindingV1(SCOPE, ROW, spoofedOversized, PROFILE),
+      'catalog-seal-input',
+    );
+  });
+
+  it('rejects structural casts, frozen clones, and JSON round trips', () => {
+    const verified = verifyCatalogSealBindingV1(SCOPE, ROW, SEAL_BYTES, PROFILE);
+    for (const forged of [
+      Object.freeze({}),
+      Object.freeze({ ...verified as object }),
+      JSON.parse(JSON.stringify(verified)),
+    ]) {
+      expectFailure(
+        () => assertVerifiedCatalogSealBindingV1(forged),
+        'catalog-seal-capability',
+      );
+      expectFailure(
+        () => readVerifiedCatalogSealBindingV1(forged),
+        'catalog-seal-capability',
+      );
+    }
+  });
+
+  it('fails closed on row identity, version, digest, UAL, and deployment mismatches', () => {
+    expectFailure(
+      () => verifyCatalogSealBindingV1(
+        SCOPE,
+        validRow({ ...ROW, kaId: NEXT_KA_ID }),
+        SEAL_BYTES,
+        PROFILE,
+      ),
+      'catalog-seal-ka-id',
+    );
+    expectFailure(
+      () => verifyCatalogSealBindingV1(
+        SCOPE,
+        validRow({ ...ROW, assertionVersion: '3' }),
+        SEAL_BYTES,
+        PROFILE,
+      ),
+      'catalog-seal-version',
+    );
+    expectFailure(
+      () => verifyCatalogSealBindingV1(
+        SCOPE,
+        validRow({ ...ROW, sealDigest: ZERO_DIGEST }),
+        SEAL_BYTES,
+        PROFILE,
+      ),
+      'catalog-seal-digest',
+    );
+    const otherLaneSeal = validSeal({
+      ...SEAL,
+      kaUal: `did:dkg:base:8453/${AUTHOR}/7`,
+    });
+    expectFailure(
+      () => verifyCatalogSealBindingV1(
+        SCOPE,
+        ROW,
+        canonicalizeCanonicalGraphScopedAuthorSealBytesV1(otherLaneSeal),
+        PROFILE,
+      ),
+      'catalog-seal-ual',
+    );
+    expectFailure(
+      () => verifyCatalogSealBindingV1(SCOPE, ROW, SEAL_BYTES, {
+        ...PROFILE,
+        assertedAtChainId: '20431',
+      }),
+      'catalog-seal-deployment',
+    );
+    expectFailure(
+      () => verifyCatalogSealBindingV1(SCOPE, ROW, SEAL_BYTES, {
+        ...PROFILE,
+        assertedAtKav10Address: '0x6666666666666666666666666666666666666666',
+      }),
+      'catalog-seal-deployment',
+    );
+    expectFailure(
+      () => verifyCatalogSealBindingV1(SCOPE, ROW, SEAL_BYTES, {
+        ...PROFILE,
+        networkId: 'base:8453',
+      }),
+      'catalog-seal-deployment',
+    );
+  });
+
+  it('rejects malformed profile records and mutable-memory classes before classification', () => {
+    expectFailure(
+      () => verifyCatalogSealBindingV1(SCOPE, ROW, SEAL_BYTES, {
+        ...PROFILE,
+        extra: true,
+      } as unknown as CatalogSealDeploymentProfileV1),
+      'catalog-seal-profile',
+    );
+    expectFailure(
+      () => verifyCatalogSealBindingV1(
+        SCOPE,
+        ROW,
+        new Uint8Array(new SharedArrayBuffer(SEAL_BYTES.byteLength)),
+        PROFILE,
+      ),
+      'catalog-seal-input',
+    );
+  });
+});
+
+function validScope(value: unknown): AuthorCatalogScopeV1 {
+  assertAuthorCatalogScopeV1(value);
+  return value;
+}
+
+function validRow(value: unknown): AuthorCatalogRowV1 {
+  assertAuthorCatalogRowV1(value);
+  return value;
+}
+
+function validSeal(value: unknown): CanonicalGraphScopedAuthorSealV1 {
+  assertCanonicalGraphScopedAuthorSealV1(value);
+  return value;
+}
+
+function expectFailure(operation: () => unknown, code: CatalogSealBindingErrorCode): void {
+  try {
+    operation();
+  } catch (error) {
+    expect(error).toBeInstanceOf(CatalogSealBindingError);
+    expect((error as CatalogSealBindingError).code).toBe(code);
+    return;
+  }
+  throw new Error(`expected ${code}`);
+}


### PR DESCRIPTION
## Summary

- project canonical graph-scoped author seals into exact typed RDF rows
- reconstruct those rows through the strict inverse decoder and PR #1780 classifier
- bind catalog identity, coordinate, UAL, packed KA ID, assertion version, seal digest, and pinned deployment into an unforgeable process-local capability
- deliberately stop short of semantic admission; payload/root/signature/finality/store-commit verification remains a later gate

## Safety

- rejects shared/resizable/oversized byte inputs before copying
- normalizes Buffer and typed-array subclasses into ordinary isolated Uint8Array storage
- rejects cloned, serialized, cast, or otherwise forged capabilities

## Verification

- focused catalog/seal tests: 21 passed
- full core suite: 98 files, 1466 tests passed
- core TypeScript build passed
- git diff check passed

Stacked on #1802.