### PR TITLE
feat(core): verify complete RFC-64 transferred bundles

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -375,3 +375,4 @@ export {
   type CanonicalGraphScopedAuthorSealErrorCode,
 } from './canonical-graph-scoped-author-seal.js';
 export * from './catalog-seal-binding.js';
+export * from './transferred-catalog-bundle.js';

--- a/packages/core/src/transferred-catalog-bundle.ts
+++ b/packages/core/src/transferred-catalog-bundle.ts
@@ -1,0 +1,461 @@
+import {
+  assertAuthorCatalogRowScopeBindingV1,
+  assertAuthorCatalogRowV1,
+  assertNetworkIdV1,
+  canonicalizeAuthorCatalogRowV1,
+  computeAuthorCatalogRowDigestV1,
+  computeAuthorCatalogScopeDigestV1,
+  parseCanonicalAuthorCatalogRowV1,
+  type AuthorCatalogRowV1,
+  type NetworkIdV1,
+} from './author-catalog-codec.js';
+import {
+  canonicalizeSignedAuthorCatalogHeadEnvelopeBytesV1,
+  deriveAuthorCatalogScopeFromHeadV1,
+  parseCanonicalSignedAuthorCatalogHeadEnvelopeV1,
+  type SignedAuthorCatalogHeadEnvelopeV1,
+} from './author-catalog-objects.js';
+import {
+  readVerifiedCatalogSealBindingV1,
+  verifyCatalogSealBindingV1,
+  type CatalogSealDeploymentProfileV1,
+  type VerifiedCatalogSealBindingV1,
+} from './catalog-seal-binding.js';
+import { decodeOpaqueKaBundleV1 } from './ka-bundle-v1.js';
+import { computeKaChunkTreeRootV1 } from './ka-chunk-tree.js';
+import {
+  MAX_KA_TRANSFER_BYTES_V1,
+  MIN_KA_TRANSFER_BYTES_V1,
+  assertKaTransferDescriptorV1,
+  computeKaTransferIdentityDigestV1,
+  type KaTransferDescriptorV1,
+} from './ka-transfer-descriptor.js';
+import {
+  assertCanonicalChainId,
+  assertCanonicalEvmAddress,
+  type ByteLengthV1,
+  type Digest32V1,
+  type EvmAddressV1,
+} from './sync-wire-scalars.js';
+import { assertExactKeys, isPlainRecord } from './sync-wire-objects.js';
+
+declare const VERIFIED_TRANSFERRED_CATALOG_BUNDLE_BRAND_V1: unique symbol;
+
+/**
+ * Unforgeable process-local proof that one complete received byte string matches
+ * one exact catalog row, signed head, and locally pinned deployment profile.
+ *
+ * This is a structural pre-admission capability only. It grants no RDF semantic,
+ * structured-root, author-signature, VM-finality, triple-store, catalog-authority,
+ * or activation authority.
+ */
+export interface VerifiedTransferredCatalogBundleV1 {
+  readonly [VERIFIED_TRANSFERRED_CATALOG_BUNDLE_BRAND_V1]: true;
+}
+
+export interface VerifiedTransferredCatalogBundleSnapshotV1 {
+  readonly headObjectDigest: Digest32V1;
+  readonly headIssuer: EvmAddressV1;
+  readonly catalogScopeDigest: Digest32V1;
+  readonly catalogRowDigest: Digest32V1;
+  readonly transferIdentityDigest: Digest32V1;
+  readonly deployment: Readonly<CatalogSealDeploymentProfileV1>;
+  readonly transfer: Readonly<KaTransferDescriptorV1>;
+  readonly projectionByteLength: ByteLengthV1;
+  readonly sealByteLength: ByteLengthV1;
+  readonly projectionDigest: Digest32V1;
+  readonly blobDigest: Digest32V1;
+  readonly chunkTreeRoot: Digest32V1;
+  /** Structural seal/row binding only; it is not semantic admission. */
+  readonly catalogSealBinding: VerifiedCatalogSealBindingV1;
+  /** Fresh caller-owned copy of the complete received bundle. */
+  readonly bundleBytes: Uint8Array;
+}
+
+export type TransferredCatalogBundleErrorCode =
+  | 'transferred-bundle-head'
+  | 'transferred-bundle-row'
+  | 'transferred-bundle-profile'
+  | 'transferred-bundle-input'
+  | 'transferred-bundle-length'
+  | 'transferred-bundle-codec'
+  | 'transferred-bundle-projection-digest'
+  | 'transferred-bundle-blob-digest'
+  | 'transferred-bundle-chunk-tree'
+  | 'transferred-bundle-seal'
+  | 'transferred-bundle-capability'
+  | 'transferred-bundle-binding';
+
+export class TransferredCatalogBundleError extends Error {
+  constructor(
+    readonly code: TransferredCatalogBundleErrorCode,
+    message: string,
+    options: ErrorOptions = {},
+  ) {
+    super(`[${code}] ${message}`, options);
+    this.name = 'TransferredCatalogBundleError';
+  }
+}
+
+interface TransferredCatalogBundleInputsV1 {
+  readonly signedHead: SignedAuthorCatalogHeadEnvelopeV1;
+  readonly row: AuthorCatalogRowV1;
+  readonly deployment: Readonly<CatalogSealDeploymentProfileV1>;
+  readonly signedHeadBytes: Uint8Array;
+  readonly rowBytes: Uint8Array;
+}
+
+interface TransferredCatalogBundleStateV1 {
+  readonly signedHeadBytes: Uint8Array;
+  readonly rowBytes: Uint8Array;
+  readonly deployment: Readonly<CatalogSealDeploymentProfileV1>;
+  readonly snapshot: Omit<VerifiedTransferredCatalogBundleSnapshotV1, 'bundleBytes'>;
+  readonly bundleBytes: Uint8Array;
+}
+
+const VERIFIED_TRANSFERRED_CATALOG_BUNDLES_V1 = new WeakMap<
+  object,
+  TransferredCatalogBundleStateV1
+>();
+const UTF8 = new TextEncoder();
+const TYPED_ARRAY_PROTOTYPE = Object.getPrototypeOf(Uint8Array.prototype) as object;
+const GET_TYPED_ARRAY_BUFFER = Object.getOwnPropertyDescriptor(
+  TYPED_ARRAY_PROTOTYPE,
+  'buffer',
+)!.get!;
+const GET_TYPED_ARRAY_BYTE_LENGTH = Object.getOwnPropertyDescriptor(
+  TYPED_ARRAY_PROTOTYPE,
+  'byteLength',
+)!.get!;
+const GET_TYPED_ARRAY_TAG = Object.getOwnPropertyDescriptor(
+  TYPED_ARRAY_PROTOTYPE,
+  Symbol.toStringTag,
+)!.get!;
+
+/**
+ * Verify the complete structural transfer boundary for one catalog row.
+ *
+ * The received byte view is copied in full before the decoder returns any
+ * borrowed projection/seal views. The seal view is consumed only by
+ * {@link verifyCatalogSealBindingV1}, which is the sole PR #1780 path.
+ */
+export function verifyTransferredCatalogBundleV1(
+  signedHead: SignedAuthorCatalogHeadEnvelopeV1,
+  row: AuthorCatalogRowV1,
+  receivedBundleBytes: Uint8Array,
+  deployment: CatalogSealDeploymentProfileV1,
+): VerifiedTransferredCatalogBundleV1 {
+  const inputs = snapshotTransferredBundleInputs(
+    signedHead,
+    row,
+    deployment,
+  );
+  const transfer = inputs.row.transfer;
+  // Snapshot before decode: no borrowed projection or seal view can outlive the
+  // complete independently owned received-byte snapshot.
+  const bundleBytes = snapshotCompleteBundleBytes(receivedBundleBytes);
+  const receivedByteLength = BigInt(bundleBytes.byteLength);
+  if (receivedByteLength !== BigInt(transfer.byteLength)) {
+    fail(
+      'transferred-bundle-length',
+      'complete received byte length differs from row.transfer.byteLength',
+    );
+  }
+
+  let decoded: ReturnType<typeof decodeOpaqueKaBundleV1>;
+  try {
+    decoded = decodeOpaqueKaBundleV1(bundleBytes);
+  } catch (cause) {
+    fail('transferred-bundle-codec', 'received bytes are not one strict opaque KA bundle', cause);
+  }
+  if (
+    decoded.projectionDigest !== transfer.projectionDigest
+    || decoded.projectionDigest !== inputs.row.projectionDigest
+  ) {
+    fail(
+      'transferred-bundle-projection-digest',
+      'decoded projection digest differs from the descriptor or catalog row',
+    );
+  }
+  if (decoded.blobDigest !== transfer.blobDigest) {
+    fail(
+      'transferred-bundle-blob-digest',
+      'complete bundle digest differs from row.transfer.blobDigest',
+    );
+  }
+
+  let chunkTreeRoot: Digest32V1;
+  try {
+    chunkTreeRoot = computeKaChunkTreeRootV1(bundleBytes);
+  } catch (cause) {
+    fail(
+      'transferred-bundle-chunk-tree',
+      'complete received bytes could not produce the canonical chunk tree',
+      cause,
+    );
+  }
+  if (chunkTreeRoot !== transfer.chunkTreeRoot) {
+    fail(
+      'transferred-bundle-chunk-tree',
+      'recomputed complete chunk-tree root differs from the descriptor',
+    );
+  }
+
+  const scope = deriveAuthorCatalogScopeFromHeadV1(inputs.signedHead.payload);
+  let catalogSealBinding: VerifiedCatalogSealBindingV1;
+  try {
+    catalogSealBinding = verifyCatalogSealBindingV1(
+      scope,
+      inputs.row,
+      decoded.sealBytes,
+      inputs.deployment,
+    );
+  } catch (cause) {
+    fail(
+      'transferred-bundle-seal',
+      'decoded seal bytes do not bind to the exact catalog row and deployment',
+      cause,
+    );
+  }
+  const sealBindingSnapshot = readVerifiedCatalogSealBindingV1(catalogSealBinding);
+  const catalogScopeDigest = computeAuthorCatalogScopeDigestV1(scope);
+  const transferSnapshot = Object.freeze({ ...transfer });
+  const deploymentSnapshot = inputs.deployment;
+  const snapshot = Object.freeze({
+    headObjectDigest: inputs.signedHead.objectDigest as Digest32V1,
+    headIssuer: inputs.signedHead.issuer as EvmAddressV1,
+    catalogScopeDigest,
+    catalogRowDigest: computeAuthorCatalogRowDigestV1(catalogScopeDigest, inputs.row),
+    transferIdentityDigest: computeKaTransferIdentityDigestV1(transfer),
+    deployment: deploymentSnapshot,
+    transfer: transferSnapshot,
+    projectionByteLength: String(decoded.projectionBytes.byteLength) as ByteLengthV1,
+    sealByteLength: String(decoded.sealBytes.byteLength) as ByteLengthV1,
+    projectionDigest: decoded.projectionDigest,
+    blobDigest: decoded.blobDigest,
+    chunkTreeRoot,
+    catalogSealBinding,
+  });
+
+  // Defensive internal consistency check: the nested structural proof must refer
+  // to the same canonical scope/row values bound above.
+  if (
+    sealBindingSnapshot.catalogScopeDigest !== snapshot.catalogScopeDigest
+    || sealBindingSnapshot.catalogRowDigest !== snapshot.catalogRowDigest
+  ) {
+    fail('transferred-bundle-seal', 'nested catalog seal binding changed row identity');
+  }
+
+  const capability = Object.freeze(Object.create(null)) as VerifiedTransferredCatalogBundleV1;
+  VERIFIED_TRANSFERRED_CATALOG_BUNDLES_V1.set(capability as object, Object.freeze({
+    signedHeadBytes: inputs.signedHeadBytes,
+    rowBytes: inputs.rowBytes,
+    deployment: deploymentSnapshot,
+    snapshot,
+    bundleBytes,
+  }));
+  return capability;
+}
+
+export function assertVerifiedTransferredCatalogBundleV1(
+  value: unknown,
+): asserts value is VerifiedTransferredCatalogBundleV1 {
+  if ((typeof value !== 'object' && typeof value !== 'function') || value === null) {
+    fail(
+      'transferred-bundle-capability',
+      'transferred bundle proof was not minted by this verifier',
+    );
+  }
+  if (!VERIFIED_TRANSFERRED_CATALOG_BUNDLES_V1.has(value as object)) {
+    fail(
+      'transferred-bundle-capability',
+      'transferred bundle proof was not minted by this verifier',
+    );
+  }
+}
+
+/** Require this capability to be consumed with the exact canonical inputs it bound. */
+export function assertVerifiedTransferredCatalogBundleForInputsV1(
+  value: unknown,
+  signedHead: SignedAuthorCatalogHeadEnvelopeV1,
+  row: AuthorCatalogRowV1,
+  deployment: CatalogSealDeploymentProfileV1,
+): asserts value is VerifiedTransferredCatalogBundleV1 {
+  assertVerifiedTransferredCatalogBundleV1(value);
+  const state = VERIFIED_TRANSFERRED_CATALOG_BUNDLES_V1.get(value as object)!;
+  let inputs: TransferredCatalogBundleInputsV1;
+  try {
+    inputs = snapshotTransferredBundleInputs(signedHead, row, deployment);
+  } catch (cause) {
+    fail(
+      'transferred-bundle-binding',
+      'supplied bundle-binding context is not canonical',
+      cause,
+    );
+  }
+  if (
+    !equalBytes(inputs.signedHeadBytes, state.signedHeadBytes)
+    || !equalBytes(inputs.rowBytes, state.rowBytes)
+    || !equalDeployment(inputs.deployment, state.deployment)
+  ) {
+    fail(
+      'transferred-bundle-binding',
+      'transferred bundle capability is not bound to the supplied head, row, and deployment',
+    );
+  }
+}
+
+/**
+ * Return immutable scalar state plus one fresh caller-owned copy of the complete
+ * bundle. Decode that copy if projection/seal byte views are needed.
+ */
+export function readVerifiedTransferredCatalogBundleV1(
+  value: unknown,
+  signedHead: SignedAuthorCatalogHeadEnvelopeV1,
+  row: AuthorCatalogRowV1,
+  deployment: CatalogSealDeploymentProfileV1,
+): VerifiedTransferredCatalogBundleSnapshotV1 {
+  assertVerifiedTransferredCatalogBundleForInputsV1(
+    value,
+    signedHead,
+    row,
+    deployment,
+  );
+  const state = VERIFIED_TRANSFERRED_CATALOG_BUNDLES_V1.get(value as object)!;
+  return Object.freeze({
+    ...state.snapshot,
+    bundleBytes: new Uint8Array(state.bundleBytes),
+  });
+}
+
+function snapshotTransferredBundleInputs(
+  signedHead: SignedAuthorCatalogHeadEnvelopeV1,
+  row: AuthorCatalogRowV1,
+  deployment: CatalogSealDeploymentProfileV1,
+): TransferredCatalogBundleInputsV1 {
+  let signedHeadBytes: Uint8Array;
+  let headSnapshot: SignedAuthorCatalogHeadEnvelopeV1;
+  try {
+    signedHeadBytes = canonicalizeSignedAuthorCatalogHeadEnvelopeBytesV1(signedHead);
+    headSnapshot = parseCanonicalSignedAuthorCatalogHeadEnvelopeV1(signedHeadBytes);
+  } catch (cause) {
+    fail('transferred-bundle-head', 'signed catalog head is not canonical', cause);
+  }
+  let rowBytes: Uint8Array;
+  let rowSnapshot: AuthorCatalogRowV1;
+  try {
+    assertAuthorCatalogRowV1(row);
+    assertKaTransferDescriptorV1(row.transfer);
+    rowBytes = UTF8.encode(canonicalizeAuthorCatalogRowV1(row));
+    rowSnapshot = parseCanonicalAuthorCatalogRowV1(rowBytes);
+    assertAuthorCatalogRowScopeBindingV1(
+      rowSnapshot,
+      deriveAuthorCatalogScopeFromHeadV1(headSnapshot.payload),
+    );
+  } catch (cause) {
+    fail(
+      'transferred-bundle-row',
+      'catalog row or row.transfer is not structurally bound to the signed head',
+      cause,
+    );
+  }
+  const deploymentSnapshot = snapshotDeploymentProfile(deployment);
+  return Object.freeze({
+    signedHead: headSnapshot,
+    row: rowSnapshot,
+    deployment: deploymentSnapshot,
+    signedHeadBytes,
+    rowBytes,
+  });
+}
+
+function snapshotDeploymentProfile(
+  deployment: unknown,
+): Readonly<CatalogSealDeploymentProfileV1> {
+  try {
+    if (!isPlainRecord(deployment)) throw new Error('profile must be a plain object');
+    assertExactKeys(
+      deployment,
+      ['assertedAtChainId', 'assertedAtKav10Address', 'networkId'],
+      'transferred bundle deployment profile',
+    );
+    assertNetworkIdV1(deployment.networkId);
+    assertCanonicalChainId(deployment.assertedAtChainId, 'assertedAtChainId');
+    assertCanonicalEvmAddress(deployment.assertedAtKav10Address, 'assertedAtKav10Address');
+    return Object.freeze({
+      networkId: deployment.networkId as NetworkIdV1,
+      assertedAtChainId: deployment.assertedAtChainId,
+      assertedAtKav10Address: deployment.assertedAtKav10Address,
+    });
+  } catch (cause) {
+    fail('transferred-bundle-profile', 'deployment profile is not canonical', cause);
+  }
+}
+
+function snapshotCompleteBundleBytes(value: unknown): Uint8Array {
+  let backingBuffer: ArrayBufferLike;
+  let byteLength: number;
+  let typedArrayTag: string | undefined;
+  try {
+    backingBuffer = Reflect.apply(GET_TYPED_ARRAY_BUFFER, value, []);
+    byteLength = Reflect.apply(GET_TYPED_ARRAY_BYTE_LENGTH, value, []);
+    typedArrayTag = Reflect.apply(GET_TYPED_ARRAY_TAG, value, []);
+  } catch (cause) {
+    fail('transferred-bundle-input', 'receivedBundleBytes must be a genuine Uint8Array', cause);
+  }
+  if (typedArrayTag !== 'Uint8Array') {
+    fail('transferred-bundle-input', 'receivedBundleBytes must be a Uint8Array');
+  }
+  if (!(backingBuffer instanceof ArrayBuffer)) {
+    fail('transferred-bundle-input', 'receivedBundleBytes must not use shared backing memory');
+  }
+  if ((backingBuffer as ArrayBuffer & { readonly resizable?: boolean }).resizable === true) {
+    fail('transferred-bundle-input', 'receivedBundleBytes must not use resizable backing memory');
+  }
+  const boundedLength = BigInt(byteLength);
+  if (
+    boundedLength < MIN_KA_TRANSFER_BYTES_V1
+    || boundedLength > MAX_KA_TRANSFER_BYTES_V1
+  ) {
+    fail(
+      'transferred-bundle-input',
+      `receivedBundleBytes must contain ${MIN_KA_TRANSFER_BYTES_V1}-${MAX_KA_TRANSFER_BYTES_V1} bytes`,
+    );
+  }
+  try {
+    // Normalize Buffer and subclasses to an ordinary, independently backed view.
+    return new Uint8Array(value as Uint8Array);
+  } catch (cause) {
+    fail('transferred-bundle-input', 'receivedBundleBytes could not be snapshotted safely', cause);
+  }
+}
+
+function equalDeployment(
+  left: Readonly<CatalogSealDeploymentProfileV1>,
+  right: Readonly<CatalogSealDeploymentProfileV1>,
+): boolean {
+  return left.networkId === right.networkId
+    && left.assertedAtChainId === right.assertedAtChainId
+    && left.assertedAtKav10Address === right.assertedAtKav10Address;
+}
+
+function equalBytes(left: Uint8Array, right: Uint8Array): boolean {
+  if (left.byteLength !== right.byteLength) return false;
+  let difference = 0;
+  for (let index = 0; index < left.byteLength; index += 1) {
+    difference |= left[index] ^ right[index];
+  }
+  return difference === 0;
+}
+
+function fail(
+  code: TransferredCatalogBundleErrorCode,
+  message: string,
+  cause?: unknown,
+): never {
+  throw new TransferredCatalogBundleError(
+    code,
+    message,
+    cause === undefined ? {} : { cause },
+  );
+}

--- a/packages/core/test/transferred-catalog-bundle.test.ts
+++ b/packages/core/test/transferred-catalog-bundle.test.ts
@@ -1,0 +1,409 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  assertAuthorCatalogRowV1,
+  type AuthorCatalogRowV1,
+} from '../src/author-catalog-codec.js';
+import {
+  AUTHOR_CATALOG_HEAD_OBJECT_TYPE_V1,
+  assertSignedAuthorCatalogHeadEnvelopeV1,
+  computeAuthorCatalogHeadObjectDigestV1,
+  type AuthorCatalogHeadV1,
+  type SignedAuthorCatalogHeadEnvelopeV1,
+} from '../src/author-catalog-objects.js';
+import {
+  assertVerifiedCatalogSealBindingV1,
+  type CatalogSealDeploymentProfileV1,
+} from '../src/catalog-seal-binding.js';
+import {
+  assertCanonicalGraphScopedAuthorSealV1,
+  canonicalizeCanonicalGraphScopedAuthorSealBytesV1,
+  computeCanonicalGraphScopedAuthorSealDigestV1,
+  type CanonicalGraphScopedAuthorSealV1,
+} from '../src/canonical-graph-scoped-author-seal.js';
+import { encodeOpaqueKaBundleV1 } from '../src/ka-bundle-v1.js';
+import { computeKaChunkTreeRootV1 } from '../src/ka-chunk-tree.js';
+import type { UnsignedControlEnvelopeV1 } from '../src/sync-control-object.js';
+import {
+  TransferredCatalogBundleError,
+  assertVerifiedTransferredCatalogBundleForInputsV1,
+  assertVerifiedTransferredCatalogBundleV1,
+  readVerifiedTransferredCatalogBundleV1,
+  verifyTransferredCatalogBundleV1,
+  type TransferredCatalogBundleErrorCode,
+} from '../src/transferred-catalog-bundle.js';
+
+const AUTHOR = '0x3333333333333333333333333333333333333333';
+const ISSUER = '0x5555555555555555555555555555555555555555';
+const KAV10 = '0x4444444444444444444444444444444444444444';
+const KA_ID =
+  '23158417847463239084714197001737581570653996933112267175388663934063917137927';
+const ZERO_DIGEST = `0x${'00'.repeat(32)}`;
+const EIP191_SIGNATURE = `0x${'77'.repeat(65)}`;
+const PROJECTION_BYTES = new TextEncoder().encode(
+  '<did:example:s> <did:example:p> "opaque structural fixture" .\n',
+);
+
+const PROFILE = {
+  networkId: 'otp:20430',
+  assertedAtChainId: '20430',
+  assertedAtKav10Address: KAV10,
+} as CatalogSealDeploymentProfileV1;
+const SEAL = validSeal({
+  assertionMerkleRoot: `0x${'aa'.repeat(32)}`,
+  authorAddress: AUTHOR,
+  authorAttestationR: `0x${'11'.repeat(32)}`,
+  authorAttestationVS: `0x${'22'.repeat(32)}`,
+  authorSchemeVersion: '1',
+  assertedAtChainId: '20430',
+  assertedAtKav10Address: KAV10,
+  reservedKaId: KA_ID,
+  assertionFinalizedAt: '2026-07-19T12:34:56.789Z',
+  contentScopeVersion: '2',
+  kaUal: `did:dkg:otp:20430/${AUTHOR}/7`,
+  assertionVersion: '2',
+  publicTripleCount: '12977',
+  privateTripleCount: '0',
+  privateMerkleRoot: null,
+});
+const SEAL_BYTES = canonicalizeCanonicalGraphScopedAuthorSealBytesV1(SEAL);
+const ENCODED = encodeOpaqueKaBundleV1(PROJECTION_BYTES, SEAL_BYTES);
+const ROW = rowForBundle(
+  ENCODED.bundleBytes,
+  ENCODED.projectionDigest,
+  ENCODED.blobDigest,
+  computeCanonicalGraphScopedAuthorSealDigestV1(SEAL),
+);
+const HEAD = signedHead({
+  networkId: 'otp:20430',
+  contextGraphId: 'a/b',
+  governanceChainId: '20430',
+  governanceContractAddress: '0x6666666666666666666666666666666666666666',
+  ownershipTransitionDigest: null,
+  subGraphName: null,
+  authorAddress: AUTHOR,
+  catalogIssuerDelegationDigest: `0x${'77'.repeat(32)}`,
+  era: '0',
+  version: '1',
+  previousHeadDigest: null,
+  bucketCount: '1',
+  totalRows: '1',
+  directoryHeight: '0',
+  directoryRootDigest: `0x${'88'.repeat(32)}`,
+  issuedAt: '1700000000123',
+});
+
+describe('RFC-64 complete transferred catalog bundle binding', () => {
+  it('binds complete bytes to the exact row, signed head, deployment, tree, and sole seal path', () => {
+    const verified = verifyTransferredCatalogBundleV1(
+      HEAD,
+      ROW,
+      ENCODED.bundleBytes,
+      PROFILE,
+    );
+    expect(Object.getPrototypeOf(verified)).toBeNull();
+    expect(Object.isFrozen(verified)).toBe(true);
+    expect(Reflect.ownKeys(verified as object)).toEqual([]);
+    expect(() => assertVerifiedTransferredCatalogBundleV1(verified)).not.toThrow();
+    expect(() => assertVerifiedTransferredCatalogBundleForInputsV1(
+      verified,
+      clone(HEAD),
+      clone(ROW),
+      clone(PROFILE),
+    )).not.toThrow();
+
+    const snapshot = readVerifiedTransferredCatalogBundleV1(
+      verified,
+      HEAD,
+      ROW,
+      PROFILE,
+    );
+    expect(snapshot).toMatchObject({
+      headObjectDigest: HEAD.objectDigest,
+      headIssuer: ISSUER,
+      transfer: ROW.transfer,
+      projectionByteLength: String(PROJECTION_BYTES.byteLength),
+      sealByteLength: String(SEAL_BYTES.byteLength),
+      projectionDigest: ENCODED.projectionDigest,
+      blobDigest: ENCODED.blobDigest,
+      chunkTreeRoot: ROW.transfer.chunkTreeRoot,
+    });
+    expect(snapshot.bundleBytes).toEqual(ENCODED.bundleBytes);
+    expect(Object.isFrozen(snapshot)).toBe(true);
+    expect(Object.isFrozen(snapshot.transfer)).toBe(true);
+    expect(Object.isFrozen(snapshot.deployment)).toBe(true);
+    expect(() => assertVerifiedCatalogSealBindingV1(snapshot.catalogSealBinding))
+      .not.toThrow();
+    expect('semanticAdmission' in snapshot).toBe(false);
+    expect('finality' in snapshot).toBe(false);
+    expect('storeAuthority' in snapshot).toBe(false);
+  });
+
+  it('snapshots the complete visible view before retaining decoder views', () => {
+    const original = ENCODED.bundleBytes.slice();
+    const padded = Buffer.concat([
+      Buffer.from([0xff]),
+      Buffer.from(original),
+      Buffer.from([0xee]),
+    ]);
+    const visible = padded.subarray(1, padded.byteLength - 1);
+    const verified = verifyTransferredCatalogBundleV1(HEAD, ROW, visible, PROFILE);
+    visible.fill(0);
+
+    const first = readVerifiedTransferredCatalogBundleV1(verified, HEAD, ROW, PROFILE);
+    expect(first.bundleBytes.constructor).toBe(Uint8Array);
+    expect(Buffer.isBuffer(first.bundleBytes)).toBe(false);
+    expect(first.bundleBytes).toEqual(original);
+    first.bundleBytes.fill(0);
+    const second = readVerifiedTransferredCatalogBundleV1(verified, HEAD, ROW, PROFILE);
+    expect(second.bundleBytes).toEqual(original);
+  });
+
+  it('rejects forged capabilities, frozen clones, and JSON round trips', () => {
+    const verified = verifyTransferredCatalogBundleV1(HEAD, ROW, ENCODED.bundleBytes, PROFILE);
+    for (const forged of [
+      Object.freeze({}),
+      Object.freeze({ ...verified as object }),
+      JSON.parse(JSON.stringify(verified)),
+    ]) {
+      expectFailure(
+        () => assertVerifiedTransferredCatalogBundleV1(forged),
+        'transferred-bundle-capability',
+      );
+      expectFailure(
+        () => readVerifiedTransferredCatalogBundleV1(forged, HEAD, ROW, PROFILE),
+        'transferred-bundle-capability',
+      );
+    }
+  });
+
+  it('rejects cross-head, cross-row, and cross-deployment consumption', () => {
+    const verified = verifyTransferredCatalogBundleV1(HEAD, ROW, ENCODED.bundleBytes, PROFILE);
+    const otherSignature = validatedSignedHead({
+      ...HEAD,
+      signature: `0x${'99'.repeat(65)}`,
+    });
+    const otherRow = validRow({ ...ROW, assertionCoordinate: 'other' });
+    for (const [head, row, deployment] of [
+      [otherSignature, ROW, PROFILE],
+      [HEAD, otherRow, PROFILE],
+      [HEAD, ROW, { ...PROFILE, assertedAtChainId: '20431' }],
+    ] as const) {
+      expectFailure(
+        () => assertVerifiedTransferredCatalogBundleForInputsV1(
+          verified,
+          head as SignedAuthorCatalogHeadEnvelopeV1,
+          row as AuthorCatalogRowV1,
+          deployment as CatalogSealDeploymentProfileV1,
+        ),
+        'transferred-bundle-binding',
+      );
+    }
+  });
+
+  it('requires a valid row.transfer and exact advertised/received length', () => {
+    expectFailure(
+      () => verifyTransferredCatalogBundleV1(HEAD, {
+        ...ROW,
+        transfer: { ...ROW.transfer, codec: 'other' },
+      } as unknown as AuthorCatalogRowV1, ENCODED.bundleBytes, PROFILE),
+      'transferred-bundle-row',
+    );
+    const advertisedLonger = validRow({
+      ...ROW,
+      transfer: {
+        ...ROW.transfer,
+        byteLength: String(ENCODED.bundleBytes.byteLength + 1),
+      },
+    });
+    expectFailure(
+      () => verifyTransferredCatalogBundleV1(
+        HEAD,
+        advertisedLonger,
+        ENCODED.bundleBytes,
+        PROFILE,
+      ),
+      'transferred-bundle-length',
+    );
+  });
+
+  it('strictly decodes the complete opaque frame before digest work', () => {
+    const malformed = ENCODED.bundleBytes.slice();
+    malformed.fill(0xff, 0, 8);
+    const malformedRow = rowForBundle(
+      malformed,
+      ROW.projectionDigest,
+      ROW.transfer.blobDigest,
+      ROW.sealDigest,
+    );
+    expectFailure(
+      () => verifyTransferredCatalogBundleV1(HEAD, malformedRow, malformed, PROFILE),
+      'transferred-bundle-codec',
+    );
+  });
+
+  it('rejects projection and whole-blob digest mismatches independently', () => {
+    const wrongProjection = validRow({
+      ...ROW,
+      projectionDigest: ZERO_DIGEST,
+      transfer: { ...ROW.transfer, projectionDigest: ZERO_DIGEST },
+    });
+    expectFailure(
+      () => verifyTransferredCatalogBundleV1(
+        HEAD,
+        wrongProjection,
+        ENCODED.bundleBytes,
+        PROFILE,
+      ),
+      'transferred-bundle-projection-digest',
+    );
+    const wrongBlob = validRow({
+      ...ROW,
+      transfer: { ...ROW.transfer, blobDigest: ZERO_DIGEST },
+    });
+    expectFailure(
+      () => verifyTransferredCatalogBundleV1(
+        HEAD,
+        wrongBlob,
+        ENCODED.bundleBytes,
+        PROFILE,
+      ),
+      'transferred-bundle-blob-digest',
+    );
+  });
+
+  it('recomputes the complete chunk-tree root and rejects a descriptor mismatch', () => {
+    const wrongTree = validRow({
+      ...ROW,
+      transfer: { ...ROW.transfer, chunkTreeRoot: ZERO_DIGEST },
+    });
+    expectFailure(
+      () => verifyTransferredCatalogBundleV1(
+        HEAD,
+        wrongTree,
+        ENCODED.bundleBytes,
+        PROFILE,
+      ),
+      'transferred-bundle-chunk-tree',
+    );
+  });
+
+  it('routes decoded seal bytes through the catalog seal binding and fails closed', () => {
+    const otherSeal = validSeal({ ...SEAL, assertionVersion: '3' });
+    const otherEncoded = encodeOpaqueKaBundleV1(
+      PROJECTION_BYTES,
+      canonicalizeCanonicalGraphScopedAuthorSealBytesV1(otherSeal),
+    );
+    const mismatchedSealRow = rowForBundle(
+      otherEncoded.bundleBytes,
+      otherEncoded.projectionDigest,
+      otherEncoded.blobDigest,
+      ROW.sealDigest,
+    );
+    expectFailure(
+      () => verifyTransferredCatalogBundleV1(
+        HEAD,
+        mismatchedSealRow,
+        otherEncoded.bundleBytes,
+        PROFILE,
+      ),
+      'transferred-bundle-seal',
+    );
+  });
+
+  it('rejects shared backing memory and spoofed Uint8Array properties', () => {
+    expectFailure(
+      () => verifyTransferredCatalogBundleV1(
+        HEAD,
+        ROW,
+        new Uint8Array(new SharedArrayBuffer(ENCODED.bundleBytes.byteLength)),
+        PROFILE,
+      ),
+      'transferred-bundle-input',
+    );
+    const short = Buffer.alloc(15);
+    Object.defineProperties(short, {
+      buffer: { value: new ArrayBuffer(ENCODED.bundleBytes.byteLength) },
+      byteLength: { value: ENCODED.bundleBytes.byteLength },
+    });
+    expectFailure(
+      () => verifyTransferredCatalogBundleV1(HEAD, ROW, short, PROFILE),
+      'transferred-bundle-input',
+    );
+  });
+});
+
+function rowForBundle(
+  bundleBytes: Uint8Array,
+  projectionDigest: string,
+  blobDigest: string,
+  sealDigest: string,
+): AuthorCatalogRowV1 {
+  const byteLength = BigInt(bundleBytes.byteLength);
+  return validRow({
+    kaId: KA_ID,
+    assertionCoordinate: 'name λ',
+    assertionVersion: '2',
+    projectionId: 'cg-shared-v1',
+    projectionDigest,
+    sealDigest,
+    transfer: {
+      codec: 'dkg-ka-bundle-v1',
+      projectionId: 'cg-shared-v1',
+      projectionDigest,
+      byteLength: byteLength.toString(),
+      chunkSize: '262144',
+      chunkCount: (((byteLength - 1n) / 262_144n) + 1n).toString(),
+      blobDigest,
+      chunkTreeRoot: computeKaChunkTreeRootV1(bundleBytes),
+    },
+  });
+}
+
+function signedHead(head: AuthorCatalogHeadV1): SignedAuthorCatalogHeadEnvelopeV1 {
+  const unsigned = {
+    issuer: ISSUER,
+    objectType: AUTHOR_CATALOG_HEAD_OBJECT_TYPE_V1,
+    payload: head,
+    signatureEvidence: { kind: 'none' },
+    signatureSuite: 'eip191-personal-sign-digest-v1',
+  } as UnsignedControlEnvelopeV1;
+  return validatedSignedHead({
+    ...unsigned,
+    objectDigest: computeAuthorCatalogHeadObjectDigestV1(unsigned),
+    signature: EIP191_SIGNATURE,
+  });
+}
+
+function validRow(value: unknown): AuthorCatalogRowV1 {
+  assertAuthorCatalogRowV1(value);
+  return value;
+}
+
+function validSeal(value: unknown): CanonicalGraphScopedAuthorSealV1 {
+  assertCanonicalGraphScopedAuthorSealV1(value);
+  return value;
+}
+
+function validatedSignedHead(value: unknown): SignedAuthorCatalogHeadEnvelopeV1 {
+  assertSignedAuthorCatalogHeadEnvelopeV1(value as SignedAuthorCatalogHeadEnvelopeV1);
+  return value as SignedAuthorCatalogHeadEnvelopeV1;
+}
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function expectFailure(
+  operation: () => unknown,
+  code: TransferredCatalogBundleErrorCode,
+): void {
+  try {
+    operation();
+  } catch (error) {
+    expect(error).toBeInstanceOf(TransferredCatalogBundleError);
+    expect((error as TransferredCatalogBundleError).code).toBe(code);
+    return;
+  }
+  throw new Error(`expected ${code}`);
+}


### PR DESCRIPTION
## Summary

- verify one complete received `dkg-ka-bundle-v1` byte string against the exact catalog row, signed head bytes, and locally pinned deployment profile
- take an independently owned genuine `Uint8Array` snapshot under the protocol size cap before exposing decoder views
- enforce exact advertised length, strict opaque framing, projection digest, whole-blob digest, canonical chunk-tree root, and structural seal/row binding
- mint an opaque, frozen, process-local `VerifiedTransferredCatalogBundleV1` capability that must be consumed with the exact canonical head, row, and deployment inputs
- return fresh byte copies so caller mutation cannot alter retained verifier state

This is a stacked PR on #1804. PR #1780 is reached exactly once and only through `verifyCatalogSealBindingV1` from that base. This slice does **not** prove directory membership, catalog-head signature or authority, policy, author attestation, VM finality, RDF projection/root semantics, semantic-store commit, or activation.

## Verification

- focused transferred-bundle suite: 10/10 passed
- full core unit suite: 1,481/1,481 passed
- core build/typecheck: passed
- independent blocker audit: GO
- `git diff --check`: passed

## Security regression coverage

The focused suite rejects forged/cloned/serialized capabilities, cross-head/row/deployment consumption, malformed or truncated frames, length mismatches, independent projection/blob/tree failures, seal mismatches, shared or resizable backing memory, and spoofed typed-array properties.