### PR TITLE
feat(chain): route RFC-64 current-finalized calls

### DIFF
--- a/packages/chain/src/current-finalized-evm-call.ts
+++ b/packages/chain/src/current-finalized-evm-call.ts
@@ -10,6 +10,7 @@ import {
   CONTROL_EIP1271_GAS_LIMIT_V1,
   CONTROL_EIP1271_MAX_ATTEMPTS_V1,
   CONTROL_EIP1271_MAX_CONCURRENT_CALLS_PER_CHAIN_V1,
+  CONTROL_EIP1271_MAX_RPC_RESPONSE_BYTES_V1,
   CONTROL_EIP1271_MAX_RETURN_BYTES_V1,
   CONTROL_EIP1271_TOTAL_DEADLINE_MS_V1,
   CURRENT_FINALIZED_EVM_CALL_ERROR_CODES_V1,
@@ -30,6 +31,7 @@ const REQUEST_KEYS = Object.freeze([
   'maxAttempts',
   'maxConcurrentCallsPerChain',
   'maxReturnBytes',
+  'maxRpcResponseBytes',
   'signal',
   'to',
   'totalDeadlineMs',
@@ -76,7 +78,7 @@ export function createCurrentFinalizedEvmCallRouterV1(
     const active = inFlightByChain.get(request.chainId) ?? 0;
     if (active >= CONTROL_EIP1271_MAX_CONCURRENT_CALLS_PER_CHAIN_V1) {
       throw new CurrentFinalizedEvmCallErrorV1(
-        'resource-limit',
+        'concurrency-saturated',
         `Chain ${request.chainId} already has ${active} current-finalized calls in flight`,
       );
     }
@@ -205,15 +207,14 @@ function snapshotAndValidateRequest(input: unknown): CurrentFinalizedEvmCallRequ
       throw new Error('to is not a canonical nonzero EVM address');
     }
     if (record.from !== CONTROL_EIP1271_CALL_FROM_V1) throw new Error('wrong from');
-    if (
-      typeof record.data !== 'string'
-      || !/^0x(?:[0-9a-f]{2})+$/.test(record.data)
-    ) {
-      throw new Error('call data is not canonical non-empty lowercase bytes');
-    }
+    if (typeof record.data !== 'string') throw new Error('call data is not a string');
+    assertCanonicalEip1271CallData(record.data);
     if (record.gasLimit !== CONTROL_EIP1271_GAS_LIMIT_V1) throw new Error('wrong gas limit');
     if (record.maxReturnBytes !== CONTROL_EIP1271_MAX_RETURN_BYTES_V1) {
       throw new Error('wrong return cap');
+    }
+    if (record.maxRpcResponseBytes !== CONTROL_EIP1271_MAX_RPC_RESPONSE_BYTES_V1) {
+      throw new Error('wrong RPC response cap');
     }
     if (record.attemptTimeoutMs !== CONTROL_EIP1271_ATTEMPT_TIMEOUT_MS_V1) {
       throw new Error('wrong attempt timeout');
@@ -243,6 +244,7 @@ function snapshotAndValidateRequest(input: unknown): CurrentFinalizedEvmCallRequ
       data: record.data,
       gasLimit: record.gasLimit,
       maxReturnBytes: record.maxReturnBytes,
+      maxRpcResponseBytes: record.maxRpcResponseBytes,
       attemptTimeoutMs: record.attemptTimeoutMs,
       maxAttempts: record.maxAttempts,
       endpointAttemptPolicy: record.endpointAttemptPolicy,
@@ -256,6 +258,42 @@ function snapshotAndValidateRequest(input: unknown): CurrentFinalizedEvmCallRequ
       'rpc-unavailable',
       'Current-finalized EVM call request failed the fixed local profile',
     );
+  }
+}
+
+function assertCanonicalEip1271CallData(data: string): void {
+  if (!/^0x[0-9a-f]+$/.test(data)) {
+    throw new Error('call data is not canonical lowercase hex');
+  }
+  const bytes = data.slice(2);
+  const selectorLength = 8;
+  const wordLength = 64;
+  const fixedLength = selectorLength + (wordLength * 3);
+  if (
+    bytes.slice(0, selectorLength) !== '1626ba7e'
+    || bytes.length < fixedLength
+    || bytes.slice(selectorLength + wordLength, selectorLength + (wordLength * 2))
+      !== `${'0'.repeat(62)}40`
+  ) {
+    throw new Error('call data is not canonical isValidSignature(bytes32,bytes) ABI');
+  }
+
+  const signatureLengthWord = bytes.slice(
+    selectorLength + (wordLength * 2),
+    fixedLength,
+  );
+  const signatureLength = BigInt(`0x${signatureLengthWord}`);
+  if (signatureLength < 1n || signatureLength > 4096n) {
+    throw new Error('EIP-1271 signature length is outside 1..4096 bytes');
+  }
+  const paddedSignatureHexLength = Math.ceil(Number(signatureLength) / 32) * wordLength;
+  const tail = bytes.slice(fixedLength);
+  if (tail.length !== paddedSignatureHexLength) {
+    throw new Error('EIP-1271 signature tail has noncanonical length');
+  }
+  const signatureHexLength = Number(signatureLength) * 2;
+  if (!/^0*$/.test(tail.slice(signatureHexLength))) {
+    throw new Error('EIP-1271 signature tail has nonzero ABI padding');
   }
 }
 

--- a/packages/chain/src/current-finalized-evm-call.ts
+++ b/packages/chain/src/current-finalized-evm-call.ts
@@ -1,0 +1,326 @@
+import {
+  assertCanonicalChainId,
+  type ChainIdV1,
+} from '@origintrail-official/dkg-core';
+
+import {
+  CONTROL_EIP1271_ATTEMPT_TIMEOUT_MS_V1,
+  CONTROL_EIP1271_CALL_FROM_V1,
+  CONTROL_EIP1271_ENDPOINT_ATTEMPT_POLICY_V1,
+  CONTROL_EIP1271_GAS_LIMIT_V1,
+  CONTROL_EIP1271_MAX_ATTEMPTS_V1,
+  CONTROL_EIP1271_MAX_CONCURRENT_CALLS_PER_CHAIN_V1,
+  CONTROL_EIP1271_MAX_RETURN_BYTES_V1,
+  CONTROL_EIP1271_TOTAL_DEADLINE_MS_V1,
+  CURRENT_FINALIZED_EVM_CALL_ERROR_CODES_V1,
+  CurrentFinalizedEvmCallErrorV1,
+  type CurrentFinalizedEvmCallRequestV1,
+  type CurrentFinalizedEvmCallResultV1,
+  type CurrentFinalizedEvmCallV1,
+} from './control-object-signature-verifier.js';
+
+const REQUEST_KEYS = Object.freeze([
+  'attemptTimeoutMs',
+  'ccipReadEnabled',
+  'chainId',
+  'data',
+  'endpointAttemptPolicy',
+  'from',
+  'gasLimit',
+  'maxAttempts',
+  'maxConcurrentCallsPerChain',
+  'maxReturnBytes',
+  'signal',
+  'to',
+  'totalDeadlineMs',
+] as const);
+const CANONICAL_NONZERO_EVM_ADDRESS = /^0x(?!0{40}$)[0-9a-f]{40}$/;
+
+/**
+ * Per-chain trusted-local adapter seam. A later transport implementation owns
+ * configured endpoint selection and the exact current-finalized block lookup.
+ */
+export interface CurrentFinalizedEvmChainAdapterV1 {
+  (request: CurrentFinalizedEvmCallRequestV1): Promise<CurrentFinalizedEvmCallResultV1>;
+}
+
+export interface CurrentFinalizedEvmChainAdapterRegistrationV1 {
+  readonly chainId: ChainIdV1;
+  readonly adapter: CurrentFinalizedEvmChainAdapterV1;
+}
+
+/**
+ * Build an immutable, non-queueing current-finalized call router.
+ *
+ * Registrations are snapshotted once. Peer-controlled data can select only a
+ * canonical chain ID already present in this local registry; it can never
+ * supply an RPC endpoint or block selector.
+ */
+export function createCurrentFinalizedEvmCallRouterV1(
+  registrations: readonly CurrentFinalizedEvmChainAdapterRegistrationV1[],
+): CurrentFinalizedEvmCallV1 {
+  const adapters = snapshotAdapterRegistry(registrations);
+  const inFlightByChain = new Map<ChainIdV1, number>();
+  for (const chainId of adapters.keys()) inFlightByChain.set(chainId, 0);
+
+  const route: CurrentFinalizedEvmCallV1 = async (input) => {
+    const request = snapshotAndValidateRequest(input);
+    const adapter = adapters.get(request.chainId);
+    if (adapter === undefined) {
+      throw new CurrentFinalizedEvmCallErrorV1(
+        'unsupported-chain',
+        `No current-finalized EVM adapter is configured for chain ${request.chainId}`,
+      );
+    }
+
+    const active = inFlightByChain.get(request.chainId) ?? 0;
+    if (active >= CONTROL_EIP1271_MAX_CONCURRENT_CALLS_PER_CHAIN_V1) {
+      throw new CurrentFinalizedEvmCallErrorV1(
+        'resource-limit',
+        `Chain ${request.chainId} already has ${active} current-finalized calls in flight`,
+      );
+    }
+    inFlightByChain.set(request.chainId, active + 1);
+
+    // Do not race this operation with request.signal. The verifier may stop
+    // awaiting after caller cancellation, but this permit remains held until
+    // the actual adapter operation settles (including adapters that ignore
+    // abort), so abandoned work cannot evade the four-call ceiling.
+    const operation = Promise.resolve()
+      .then(() => adapter(request))
+      .catch((cause: unknown) => {
+        throw snapshotAdapterFailure(cause);
+      });
+
+    try {
+      return await operation;
+    } finally {
+      const remaining = (inFlightByChain.get(request.chainId) ?? 1) - 1;
+      inFlightByChain.set(request.chainId, Math.max(0, remaining));
+    }
+  };
+
+  return Object.freeze(route);
+}
+
+function snapshotAdapterRegistry(
+  input: unknown,
+): ReadonlyMap<ChainIdV1, CurrentFinalizedEvmChainAdapterV1> {
+  const registrations = snapshotDenseArray(input);
+  const adapters = new Map<ChainIdV1, CurrentFinalizedEvmChainAdapterV1>();
+
+  for (const registration of registrations) {
+    const snapshot = snapshotRegistration(registration);
+    if (adapters.has(snapshot.chainId)) {
+      throw new TypeError(`Duplicate current-finalized adapter for chain ${snapshot.chainId}`);
+    }
+    adapters.set(snapshot.chainId, snapshot.adapter);
+  }
+  return adapters;
+}
+
+function snapshotDenseArray(input: unknown): readonly unknown[] {
+  try {
+    if (!Array.isArray(input)) throw new Error('not an array');
+    const lengthDescriptor = Object.getOwnPropertyDescriptor(input, 'length');
+    if (
+      lengthDescriptor === undefined
+      || !Object.prototype.hasOwnProperty.call(lengthDescriptor, 'value')
+      || typeof lengthDescriptor.value !== 'number'
+      || !Number.isSafeInteger(lengthDescriptor.value)
+      || lengthDescriptor.value < 0
+    ) {
+      throw new Error('invalid array length');
+    }
+
+    const length = lengthDescriptor.value;
+    const ownKeys = Reflect.ownKeys(input);
+    if (
+      ownKeys.length !== length + 1
+      || ownKeys.some((key) => (
+        typeof key !== 'string'
+        || (key !== 'length' && !isCanonicalArrayIndex(key, length))
+      ))
+    ) {
+      throw new Error('registrations must be a dense ordinary array');
+    }
+
+    const snapshot: unknown[] = [];
+    for (let index = 0; index < length; index += 1) {
+      const descriptor = Object.getOwnPropertyDescriptor(input, String(index));
+      if (
+        descriptor === undefined
+        || !descriptor.enumerable
+        || !Object.prototype.hasOwnProperty.call(descriptor, 'value')
+      ) {
+        throw new Error('registration entry must be an enumerable data property');
+      }
+      snapshot.push(descriptor.value);
+    }
+    return Object.freeze(snapshot);
+  } catch {
+    throw new TypeError('Current-finalized adapter registrations must be a dense data-only array');
+  }
+}
+
+function isCanonicalArrayIndex(key: string, length: number): boolean {
+  if (!/^(?:0|[1-9][0-9]*)$/.test(key)) return false;
+  const index = Number(key);
+  return Number.isSafeInteger(index) && index >= 0 && index < length && String(index) === key;
+}
+
+function snapshotRegistration(input: unknown): Readonly<CurrentFinalizedEvmChainAdapterRegistrationV1> {
+  let chainId: unknown;
+  let adapter: unknown;
+  try {
+    const record = snapshotExactDataRecord(input, ['adapter', 'chainId']);
+    chainId = record.chainId;
+    adapter = record.adapter;
+  } catch {
+    throw new TypeError('Current-finalized adapter registration must be a plain data-only record');
+  }
+
+  try {
+    assertCanonicalChainId(chainId, 'current-finalized adapter chainId');
+  } catch {
+    throw new TypeError('Current-finalized adapter chainId must be canonical decimal u256');
+  }
+  if (typeof adapter !== 'function') {
+    throw new TypeError(`Current-finalized adapter for chain ${chainId} must be callable`);
+  }
+  return Object.freeze({
+    chainId,
+    adapter: adapter as CurrentFinalizedEvmChainAdapterV1,
+  });
+}
+
+function snapshotAndValidateRequest(input: unknown): CurrentFinalizedEvmCallRequestV1 {
+  try {
+    const record = snapshotExactDataRecord(input, REQUEST_KEYS);
+    assertCanonicalChainId(record.chainId, 'current-finalized request chainId');
+    if (
+      typeof record.to !== 'string'
+      || !CANONICAL_NONZERO_EVM_ADDRESS.test(record.to)
+    ) {
+      throw new Error('to is not a canonical nonzero EVM address');
+    }
+    if (record.from !== CONTROL_EIP1271_CALL_FROM_V1) throw new Error('wrong from');
+    if (
+      typeof record.data !== 'string'
+      || !/^0x(?:[0-9a-f]{2})+$/.test(record.data)
+    ) {
+      throw new Error('call data is not canonical non-empty lowercase bytes');
+    }
+    if (record.gasLimit !== CONTROL_EIP1271_GAS_LIMIT_V1) throw new Error('wrong gas limit');
+    if (record.maxReturnBytes !== CONTROL_EIP1271_MAX_RETURN_BYTES_V1) {
+      throw new Error('wrong return cap');
+    }
+    if (record.attemptTimeoutMs !== CONTROL_EIP1271_ATTEMPT_TIMEOUT_MS_V1) {
+      throw new Error('wrong attempt timeout');
+    }
+    if (record.maxAttempts !== CONTROL_EIP1271_MAX_ATTEMPTS_V1) {
+      throw new Error('wrong attempt count');
+    }
+    if (record.endpointAttemptPolicy !== CONTROL_EIP1271_ENDPOINT_ATTEMPT_POLICY_V1) {
+      throw new Error('wrong endpoint policy');
+    }
+    if (
+      record.maxConcurrentCallsPerChain
+      !== CONTROL_EIP1271_MAX_CONCURRENT_CALLS_PER_CHAIN_V1
+    ) {
+      throw new Error('wrong concurrency ceiling');
+    }
+    if (record.totalDeadlineMs !== CONTROL_EIP1271_TOTAL_DEADLINE_MS_V1) {
+      throw new Error('wrong total deadline');
+    }
+    if (record.ccipReadEnabled !== false) throw new Error('CCIP Read must be disabled');
+    if (!isAbortSignal(record.signal)) throw new Error('signal is not an AbortSignal');
+
+    return Object.freeze({
+      chainId: record.chainId,
+      to: record.to,
+      from: record.from,
+      data: record.data,
+      gasLimit: record.gasLimit,
+      maxReturnBytes: record.maxReturnBytes,
+      attemptTimeoutMs: record.attemptTimeoutMs,
+      maxAttempts: record.maxAttempts,
+      endpointAttemptPolicy: record.endpointAttemptPolicy,
+      maxConcurrentCallsPerChain: record.maxConcurrentCallsPerChain,
+      totalDeadlineMs: record.totalDeadlineMs,
+      ccipReadEnabled: record.ccipReadEnabled,
+      signal: record.signal,
+    }) as CurrentFinalizedEvmCallRequestV1;
+  } catch {
+    throw new CurrentFinalizedEvmCallErrorV1(
+      'rpc-unavailable',
+      'Current-finalized EVM call request failed the fixed local profile',
+    );
+  }
+}
+
+function snapshotExactDataRecord(
+  input: unknown,
+  expectedKeys: readonly string[],
+): Record<string, unknown> {
+  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
+    throw new Error('not a record');
+  }
+  const prototype = Object.getPrototypeOf(input);
+  if (prototype !== Object.prototype && prototype !== null) throw new Error('not plain');
+  const actualKeys = Reflect.ownKeys(input);
+  if (
+    actualKeys.some((key) => typeof key !== 'string')
+    || actualKeys.length !== expectedKeys.length
+    || (actualKeys as string[]).sort().some((key, index) => key !== expectedKeys[index])
+  ) {
+    throw new Error('unknown or missing fields');
+  }
+
+  const snapshot: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
+  for (const key of expectedKeys) {
+    const descriptor = Object.getOwnPropertyDescriptor(input, key);
+    if (
+      descriptor === undefined
+      || !descriptor.enumerable
+      || !Object.prototype.hasOwnProperty.call(descriptor, 'value')
+    ) {
+      throw new Error('fields must be enumerable data properties');
+    }
+    snapshot[key] = descriptor.value;
+  }
+  return snapshot;
+}
+
+function isAbortSignal(value: unknown): value is AbortSignal {
+  if (value === null || typeof value !== 'object') return false;
+  try {
+    const abortedGetter = Object.getOwnPropertyDescriptor(AbortSignal.prototype, 'aborted')?.get;
+    if (abortedGetter === undefined) return false;
+    abortedGetter.call(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function snapshotAdapterFailure(cause: unknown): CurrentFinalizedEvmCallErrorV1 {
+  try {
+    if (cause instanceof CurrentFinalizedEvmCallErrorV1) {
+      const code = cause.code;
+      const message = cause.message;
+      if (
+        CURRENT_FINALIZED_EVM_CALL_ERROR_CODES_V1.includes(code)
+        && typeof message === 'string'
+      ) {
+        return new CurrentFinalizedEvmCallErrorV1(code, message);
+      }
+    }
+  } catch {
+    // Hostile error objects cannot select a verifier disposition.
+  }
+  return new CurrentFinalizedEvmCallErrorV1(
+    'rpc-unavailable',
+    'Current-finalized EVM chain adapter failed closed',
+  );
+}

--- a/packages/chain/src/index.ts
+++ b/packages/chain/src/index.ts
@@ -26,6 +26,11 @@ export {
   type VerifyControlEnvelopeIssuerSignatureOptionsV1,
 } from './control-object-signature-verifier.js';
 export {
+  createCurrentFinalizedEvmCallRouterV1,
+  type CurrentFinalizedEvmChainAdapterRegistrationV1,
+  type CurrentFinalizedEvmChainAdapterV1,
+} from './current-finalized-evm-call.js';
+export {
   resolveQuotedPublisherCandidatePricing,
   resolveLegacyPublisherCandidatePricing,
   type QuotedPublisherCandidatePricing,

--- a/packages/chain/test/current-finalized-evm-call.unit.test.ts
+++ b/packages/chain/test/current-finalized-evm-call.unit.test.ts
@@ -1,0 +1,290 @@
+import {
+  type ChainIdV1,
+  type EvmAddressV1,
+} from '@origintrail-official/dkg-core';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  CONTROL_EIP1271_ATTEMPT_TIMEOUT_MS_V1,
+  CONTROL_EIP1271_CALL_FROM_V1,
+  CONTROL_EIP1271_ENDPOINT_ATTEMPT_POLICY_V1,
+  CONTROL_EIP1271_GAS_LIMIT_V1,
+  CONTROL_EIP1271_MAX_ATTEMPTS_V1,
+  CONTROL_EIP1271_MAX_CONCURRENT_CALLS_PER_CHAIN_V1,
+  CONTROL_EIP1271_MAX_RETURN_BYTES_V1,
+  CONTROL_EIP1271_TOTAL_DEADLINE_MS_V1,
+  CurrentFinalizedEvmCallErrorV1,
+  type CurrentFinalizedEvmCallRequestV1,
+  type CurrentFinalizedEvmCallResultV1,
+} from '../src/control-object-signature-verifier.js';
+import {
+  createCurrentFinalizedEvmCallRouterV1,
+  type CurrentFinalizedEvmChainAdapterRegistrationV1,
+  type CurrentFinalizedEvmChainAdapterV1,
+} from '../src/current-finalized-evm-call.js';
+
+const CHAIN_A = '20430' as ChainIdV1;
+const CHAIN_B = '100' as ChainIdV1;
+const TO = '0x1111111111111111111111111111111111111111' as EvmAddressV1;
+const BLOCK_HASH = `0x${'22'.repeat(32)}`;
+const RESULT_A = Object.freeze({
+  chainId: CHAIN_A,
+  blockNumber: '123',
+  blockHash: BLOCK_HASH,
+  returnData: `0x${'00'.repeat(32)}`,
+} as CurrentFinalizedEvmCallResultV1);
+
+describe('RFC-64 current-finalized EVM call router', () => {
+  it('snapshots an immutable local registry and routes a frozen exact request', async () => {
+    const firstAdapter = vi.fn(async () => RESULT_A);
+    const replacementAdapter = vi.fn(async () => RESULT_A);
+    const registration = {
+      chainId: CHAIN_A,
+      adapter: firstAdapter,
+    } satisfies CurrentFinalizedEvmChainAdapterRegistrationV1;
+    const registrations = [registration];
+    const router = createCurrentFinalizedEvmCallRouterV1(registrations);
+
+    registration.chainId = CHAIN_B;
+    registration.adapter = replacementAdapter;
+    registrations[0] = { chainId: CHAIN_B, adapter: replacementAdapter };
+
+    await expect(router(request())).resolves.toBe(RESULT_A);
+    expect(firstAdapter).toHaveBeenCalledTimes(1);
+    expect(replacementAdapter).not.toHaveBeenCalled();
+    expect(Object.isFrozen(router)).toBe(true);
+    expect(Object.isFrozen(firstAdapter.mock.calls[0]![0])).toBe(true);
+  });
+
+  it('rejects duplicate, non-canonical, sparse, accessor, and hostile registrations', () => {
+    const adapter = vi.fn(async () => RESULT_A);
+    const valid = { chainId: CHAIN_A, adapter };
+
+    expect(() => createCurrentFinalizedEvmCallRouterV1([valid, valid]))
+      .toThrow(/Duplicate current-finalized adapter/);
+    expect(() => createCurrentFinalizedEvmCallRouterV1([
+      { chainId: '020430' as ChainIdV1, adapter },
+    ])).toThrow(/canonical decimal u256/);
+
+    const sparse = new Array(1) as CurrentFinalizedEvmChainAdapterRegistrationV1[];
+    expect(() => createCurrentFinalizedEvmCallRouterV1(sparse)).toThrow(/dense data-only array/);
+
+    const accessor = { chainId: CHAIN_A } as Record<string, unknown>;
+    Object.defineProperty(accessor, 'adapter', {
+      enumerable: true,
+      get() {
+        throw new Error('must not execute');
+      },
+    });
+    expect(() => createCurrentFinalizedEvmCallRouterV1([
+      accessor as unknown as CurrentFinalizedEvmChainAdapterRegistrationV1,
+    ])).toThrow(/plain data-only record/);
+
+    const hostile = new Proxy([], {
+      ownKeys() {
+        throw new CurrentFinalizedEvmCallErrorV1('resource-limit', 'forged');
+      },
+    });
+    expect(() => createCurrentFinalizedEvmCallRouterV1(
+      hostile as CurrentFinalizedEvmChainAdapterRegistrationV1[],
+    )).toThrow(TypeError);
+    expect(() => createCurrentFinalizedEvmCallRouterV1(
+      hostile as CurrentFinalizedEvmChainAdapterRegistrationV1[],
+    )).not.toThrow(CurrentFinalizedEvmCallErrorV1);
+  });
+
+  it('rejects unsupported chains before any adapter call', async () => {
+    const adapter = vi.fn(async () => RESULT_A);
+    const router = createCurrentFinalizedEvmCallRouterV1([{ chainId: CHAIN_A, adapter }]);
+
+    await expect(router(request({ chainId: CHAIN_B }))).rejects.toMatchObject({
+      name: 'CurrentFinalizedEvmCallErrorV1',
+      code: 'unsupported-chain',
+    });
+    expect(adapter).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['from', '0x2222222222222222222222222222222222222222'],
+    ['gasLimit', CONTROL_EIP1271_GAS_LIMIT_V1 + 1n],
+    ['maxReturnBytes', CONTROL_EIP1271_MAX_RETURN_BYTES_V1 + 1],
+    ['attemptTimeoutMs', CONTROL_EIP1271_ATTEMPT_TIMEOUT_MS_V1 + 1],
+    ['maxAttempts', CONTROL_EIP1271_MAX_ATTEMPTS_V1 + 1],
+    ['endpointAttemptPolicy', 'retry-same-peer-endpoint'],
+    ['maxConcurrentCallsPerChain', CONTROL_EIP1271_MAX_CONCURRENT_CALLS_PER_CHAIN_V1 + 1],
+    ['totalDeadlineMs', CONTROL_EIP1271_TOTAL_DEADLINE_MS_V1 + 1],
+    ['ccipReadEnabled', true],
+  ] as const)('rejects a request with a non-frozen %s profile field', async (key, value) => {
+    const adapter = vi.fn(async () => RESULT_A);
+    const router = createCurrentFinalizedEvmCallRouterV1([{ chainId: CHAIN_A, adapter }]);
+
+    await expect(router(request({ [key]: value }))).rejects.toMatchObject({
+      code: 'rpc-unavailable',
+    });
+    expect(adapter).not.toHaveBeenCalled();
+  });
+
+  it('rejects malformed routing fields and any peer URL or block selector', async () => {
+    const adapter = vi.fn(async () => RESULT_A);
+    const router = createCurrentFinalizedEvmCallRouterV1([{ chainId: CHAIN_A, adapter }]);
+
+    for (const malformed of [
+      request({ chainId: '020430' as ChainIdV1 }),
+      request({ to: '0xABC' as EvmAddressV1 }),
+      request({ data: '0xABC' }),
+      request({ signal: {} as AbortSignal }),
+      { ...request(), rpcUrl: 'https://peer.invalid' },
+      { ...request(), blockTag: 'latest' },
+    ]) {
+      await expect(router(malformed as CurrentFinalizedEvmCallRequestV1))
+        .rejects.toMatchObject({ code: 'rpc-unavailable' });
+    }
+    expect(adapter).not.toHaveBeenCalled();
+  });
+
+  it('admits four calls per chain and rejects the fifth immediately without queueing', async () => {
+    const pending = Array.from({ length: 5 }, () => deferred<CurrentFinalizedEvmCallResultV1>());
+    let callIndex = 0;
+    const adapter = vi.fn(async () => pending[callIndex++]!.promise);
+    const router = createCurrentFinalizedEvmCallRouterV1([{ chainId: CHAIN_A, adapter }]);
+
+    const active = Array.from({ length: 4 }, () => router(request()));
+    await Promise.resolve();
+    expect(adapter).toHaveBeenCalledTimes(4);
+    await expect(router(request())).rejects.toMatchObject({ code: 'resource-limit' });
+    expect(adapter).toHaveBeenCalledTimes(4);
+
+    pending[0]!.resolve(RESULT_A);
+    await active[0];
+    const admitted = router(request());
+    await Promise.resolve();
+    expect(adapter).toHaveBeenCalledTimes(5);
+
+    for (let index = 1; index < 5; index += 1) pending[index]!.resolve(RESULT_A);
+    await Promise.all([...active.slice(1), admitted]);
+  });
+
+  it('holds a permit after caller abort until the underlying adapter promise settles', async () => {
+    const pending = Array.from({ length: 5 }, () => deferred<CurrentFinalizedEvmCallResultV1>());
+    let callIndex = 0;
+    const adapter = vi.fn(async () => pending[callIndex++]!.promise);
+    const router = createCurrentFinalizedEvmCallRouterV1([{ chainId: CHAIN_A, adapter }]);
+    const controller = new AbortController();
+    const active = [
+      router(request({ signal: controller.signal })),
+      router(request()),
+      router(request()),
+      router(request()),
+    ];
+    await Promise.resolve();
+
+    controller.abort();
+    await expect(router(request())).rejects.toMatchObject({ code: 'resource-limit' });
+    expect(adapter).toHaveBeenCalledTimes(4);
+
+    pending[0]!.resolve(RESULT_A);
+    await active[0];
+    const admitted = router(request());
+    await Promise.resolve();
+    expect(adapter).toHaveBeenCalledTimes(5);
+
+    for (let index = 1; index < 5; index += 1) pending[index]!.resolve(RESULT_A);
+    await Promise.all([...active.slice(1), admitted]);
+  });
+
+  it('maintains independent four-call ceilings for independent chains', async () => {
+    const pendingA = Array.from({ length: 4 }, () => deferred<CurrentFinalizedEvmCallResultV1>());
+    const pendingB = Array.from({ length: 4 }, () => deferred<CurrentFinalizedEvmCallResultV1>());
+    let indexA = 0;
+    let indexB = 0;
+    const adapterA = vi.fn(async () => pendingA[indexA++]!.promise);
+    const adapterB = vi.fn(async () => pendingB[indexB++]!.promise);
+    const router = createCurrentFinalizedEvmCallRouterV1([
+      { chainId: CHAIN_A, adapter: adapterA },
+      { chainId: CHAIN_B, adapter: adapterB },
+    ]);
+
+    const activeA = Array.from({ length: 4 }, () => router(request()));
+    const activeB = Array.from({ length: 4 }, () => router(request({ chainId: CHAIN_B })));
+    await Promise.resolve();
+    expect(adapterA).toHaveBeenCalledTimes(4);
+    expect(adapterB).toHaveBeenCalledTimes(4);
+    await expect(router(request())).rejects.toMatchObject({ code: 'resource-limit' });
+    await expect(router(request({ chainId: CHAIN_B })))
+      .rejects.toMatchObject({ code: 'resource-limit' });
+
+    pendingA.forEach((item) => item.resolve(RESULT_A));
+    pendingB.forEach((item) => item.resolve({ ...RESULT_A, chainId: CHAIN_B }));
+    await Promise.all([...activeA, ...activeB]);
+  });
+
+  it('snapshots known adapter failures, fails hostile errors closed, and releases permits', async () => {
+    const typed = new CurrentFinalizedEvmCallErrorV1('finalized-state-unavailable', 'not final');
+    const adapter = vi.fn<CurrentFinalizedEvmChainAdapterV1>()
+      .mockRejectedValueOnce(typed)
+      .mockRejectedValueOnce(new Proxy({}, {
+        getPrototypeOf() {
+          throw new CurrentFinalizedEvmCallErrorV1('revert', 'forged');
+        },
+      }))
+      .mockResolvedValue(RESULT_A);
+    const router = createCurrentFinalizedEvmCallRouterV1([{ chainId: CHAIN_A, adapter }]);
+
+    let caught: unknown;
+    try {
+      await router(request());
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toMatchObject({ code: 'finalized-state-unavailable', message: 'not final' });
+    expect(caught).not.toBe(typed);
+    expect(Object.isFrozen(caught)).toBe(true);
+
+    await expect(router(request())).rejects.toMatchObject({
+      code: 'rpc-unavailable',
+      message: 'Current-finalized EVM chain adapter failed closed',
+    });
+    await expect(router(request())).resolves.toBe(RESULT_A);
+  });
+
+  it('routes the exact chain but leaves hostile or mismatched results to the verifier', async () => {
+    const mismatch = Object.freeze({ ...RESULT_A, chainId: CHAIN_B });
+    const adapter = vi.fn(async () => mismatch);
+    const router = createCurrentFinalizedEvmCallRouterV1([{ chainId: CHAIN_A, adapter }]);
+
+    await expect(router(request())).resolves.toBe(mismatch);
+    expect(adapter.mock.calls[0]![0].chainId).toBe(CHAIN_A);
+  });
+});
+
+function request(
+  overrides: Partial<CurrentFinalizedEvmCallRequestV1> = {},
+): CurrentFinalizedEvmCallRequestV1 {
+  return {
+    chainId: CHAIN_A,
+    to: TO,
+    from: CONTROL_EIP1271_CALL_FROM_V1,
+    data: '0x1234',
+    gasLimit: CONTROL_EIP1271_GAS_LIMIT_V1,
+    maxReturnBytes: CONTROL_EIP1271_MAX_RETURN_BYTES_V1,
+    attemptTimeoutMs: CONTROL_EIP1271_ATTEMPT_TIMEOUT_MS_V1,
+    maxAttempts: CONTROL_EIP1271_MAX_ATTEMPTS_V1,
+    endpointAttemptPolicy: CONTROL_EIP1271_ENDPOINT_ATTEMPT_POLICY_V1,
+    maxConcurrentCallsPerChain: CONTROL_EIP1271_MAX_CONCURRENT_CALLS_PER_CHAIN_V1,
+    totalDeadlineMs: CONTROL_EIP1271_TOTAL_DEADLINE_MS_V1,
+    ccipReadEnabled: false,
+    signal: new AbortController().signal,
+    ...overrides,
+  };
+}
+
+function deferred<T>(): {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((fulfill) => {
+    resolve = fulfill;
+  });
+  return { promise, resolve };
+}

--- a/packages/chain/test/current-finalized-evm-call.unit.test.ts
+++ b/packages/chain/test/current-finalized-evm-call.unit.test.ts
@@ -11,6 +11,7 @@ import {
   CONTROL_EIP1271_GAS_LIMIT_V1,
   CONTROL_EIP1271_MAX_ATTEMPTS_V1,
   CONTROL_EIP1271_MAX_CONCURRENT_CALLS_PER_CHAIN_V1,
+  CONTROL_EIP1271_MAX_RPC_RESPONSE_BYTES_V1,
   CONTROL_EIP1271_MAX_RETURN_BYTES_V1,
   CONTROL_EIP1271_TOTAL_DEADLINE_MS_V1,
   CurrentFinalizedEvmCallErrorV1,
@@ -27,6 +28,8 @@ const CHAIN_A = '20430' as ChainIdV1;
 const CHAIN_B = '100' as ChainIdV1;
 const TO = '0x1111111111111111111111111111111111111111' as EvmAddressV1;
 const BLOCK_HASH = `0x${'22'.repeat(32)}`;
+const OBJECT_DIGEST = `${'33'.repeat(32)}`;
+const CANONICAL_CALL_DATA = `0x1626ba7e${OBJECT_DIGEST}${'0'.repeat(62)}40${'0'.repeat(63)}1aa${'0'.repeat(62)}`;
 const RESULT_A = Object.freeze({
   chainId: CHAIN_A,
   blockNumber: '123',
@@ -54,6 +57,21 @@ describe('RFC-64 current-finalized EVM call router', () => {
     expect(replacementAdapter).not.toHaveBeenCalled();
     expect(Object.isFrozen(router)).toBe(true);
     expect(Object.isFrozen(firstAdapter.mock.calls[0]![0])).toBe(true);
+  });
+
+  it('snapshots request data before the deferred adapter invocation', async () => {
+    const adapter = vi.fn(async () => RESULT_A);
+    const router = createCurrentFinalizedEvmCallRouterV1([{ chainId: CHAIN_A, adapter }]);
+    const mutable = request() as { -readonly [K in keyof CurrentFinalizedEvmCallRequestV1]: CurrentFinalizedEvmCallRequestV1[K] };
+
+    const result = router(mutable);
+    mutable.chainId = CHAIN_B;
+    mutable.data = `0x${'00'.repeat(100)}`;
+    await expect(result).resolves.toBe(RESULT_A);
+    expect(adapter.mock.calls[0]![0]).toMatchObject({
+      chainId: CHAIN_A,
+      data: CANONICAL_CALL_DATA,
+    });
   });
 
   it('rejects duplicate, non-canonical, sparse, accessor, and hostile registrations', () => {
@@ -108,6 +126,7 @@ describe('RFC-64 current-finalized EVM call router', () => {
     ['from', '0x2222222222222222222222222222222222222222'],
     ['gasLimit', CONTROL_EIP1271_GAS_LIMIT_V1 + 1n],
     ['maxReturnBytes', CONTROL_EIP1271_MAX_RETURN_BYTES_V1 + 1],
+    ['maxRpcResponseBytes', CONTROL_EIP1271_MAX_RPC_RESPONSE_BYTES_V1 + 1],
     ['attemptTimeoutMs', CONTROL_EIP1271_ATTEMPT_TIMEOUT_MS_V1 + 1],
     ['maxAttempts', CONTROL_EIP1271_MAX_ATTEMPTS_V1 + 1],
     ['endpointAttemptPolicy', 'retry-same-peer-endpoint'],
@@ -132,6 +151,10 @@ describe('RFC-64 current-finalized EVM call router', () => {
       request({ chainId: '020430' as ChainIdV1 }),
       request({ to: '0xABC' as EvmAddressV1 }),
       request({ data: '0xABC' }),
+      request({ data: '0x1234' }),
+      request({ data: CANONICAL_CALL_DATA.replace('1626ba7e', 'ffffffff') }),
+      request({ data: `${CANONICAL_CALL_DATA}00` }),
+      request({ data: `${CANONICAL_CALL_DATA.slice(0, -2)}01` }),
       request({ signal: {} as AbortSignal }),
       { ...request(), rpcUrl: 'https://peer.invalid' },
       { ...request(), blockTag: 'latest' },
@@ -139,6 +162,27 @@ describe('RFC-64 current-finalized EVM call router', () => {
       await expect(router(malformed as CurrentFinalizedEvmCallRequestV1))
         .rejects.toMatchObject({ code: 'rpc-unavailable' });
     }
+
+    const accessor = { ...request() } as Record<string, unknown>;
+    Object.defineProperty(accessor, 'data', {
+      enumerable: true,
+      get() {
+        throw new Error('must not execute');
+      },
+    });
+    await expect(router(accessor as unknown as CurrentFinalizedEvmCallRequestV1))
+      .rejects.toMatchObject({ code: 'rpc-unavailable' });
+
+    const symbol = { ...request(), [Symbol('peer-url')]: 'https://peer.invalid' };
+    await expect(router(symbol as CurrentFinalizedEvmCallRequestV1))
+      .rejects.toMatchObject({ code: 'rpc-unavailable' });
+
+    const hostile = new Proxy(request(), {
+      ownKeys() {
+        throw new CurrentFinalizedEvmCallErrorV1('revert', 'forged');
+      },
+    });
+    await expect(router(hostile)).rejects.toMatchObject({ code: 'rpc-unavailable' });
     expect(adapter).not.toHaveBeenCalled();
   });
 
@@ -151,7 +195,7 @@ describe('RFC-64 current-finalized EVM call router', () => {
     const active = Array.from({ length: 4 }, () => router(request()));
     await Promise.resolve();
     expect(adapter).toHaveBeenCalledTimes(4);
-    await expect(router(request())).rejects.toMatchObject({ code: 'resource-limit' });
+    await expect(router(request())).rejects.toMatchObject({ code: 'concurrency-saturated' });
     expect(adapter).toHaveBeenCalledTimes(4);
 
     pending[0]!.resolve(RESULT_A);
@@ -179,7 +223,7 @@ describe('RFC-64 current-finalized EVM call router', () => {
     await Promise.resolve();
 
     controller.abort();
-    await expect(router(request())).rejects.toMatchObject({ code: 'resource-limit' });
+    await expect(router(request())).rejects.toMatchObject({ code: 'concurrency-saturated' });
     expect(adapter).toHaveBeenCalledTimes(4);
 
     pending[0]!.resolve(RESULT_A);
@@ -209,9 +253,9 @@ describe('RFC-64 current-finalized EVM call router', () => {
     await Promise.resolve();
     expect(adapterA).toHaveBeenCalledTimes(4);
     expect(adapterB).toHaveBeenCalledTimes(4);
-    await expect(router(request())).rejects.toMatchObject({ code: 'resource-limit' });
+    await expect(router(request())).rejects.toMatchObject({ code: 'concurrency-saturated' });
     await expect(router(request({ chainId: CHAIN_B })))
-      .rejects.toMatchObject({ code: 'resource-limit' });
+      .rejects.toMatchObject({ code: 'concurrency-saturated' });
 
     pendingA.forEach((item) => item.resolve(RESULT_A));
     pendingB.forEach((item) => item.resolve({ ...RESULT_A, chainId: CHAIN_B }));
@@ -264,9 +308,10 @@ function request(
     chainId: CHAIN_A,
     to: TO,
     from: CONTROL_EIP1271_CALL_FROM_V1,
-    data: '0x1234',
+    data: CANONICAL_CALL_DATA,
     gasLimit: CONTROL_EIP1271_GAS_LIMIT_V1,
     maxReturnBytes: CONTROL_EIP1271_MAX_RETURN_BYTES_V1,
+    maxRpcResponseBytes: CONTROL_EIP1271_MAX_RPC_RESPONSE_BYTES_V1,
     attemptTimeoutMs: CONTROL_EIP1271_ATTEMPT_TIMEOUT_MS_V1,
     maxAttempts: CONTROL_EIP1271_MAX_ATTEMPTS_V1,
     endpointAttemptPolicy: CONTROL_EIP1271_ENDPOINT_ATTEMPT_POLICY_V1,


### PR DESCRIPTION
## Summary

- add an immutable trusted-local adapter registry keyed by canonical chain ID
- freeze and validate the exact EIP-1271 request profile and canonical ABI calldata before trusted-adapter invocation; peer-supplied endpoints and block selectors are impossible
- validate the adapter result envelope and bounded 32-byte return before the base signature verifier may mint its opaque capability
- apply a non-queueing four-call ceiling per chain while retaining permits until underlying I/O settles
- distinguish retryable concurrency saturation and local gateway mismatch from cryptographic invalidity

Stacked on #1806. This is a dormant router/admission boundary, not the finalized RPC transport. The later trusted-local adapter must still implement endpoint selection, current-finalized hash pinning, EIP-1898 or hash-sandwich fallback, reorg/freshness handling, code-at-anchor, gas and 64 KiB pre-parse response enforcement, attempt budgets, and failover. The resulting token proves generic EIP-1271 validity at the adapter-reported anchor only; it proves no object authority, policy, catalog authority, placement, or semantic admission. Runtime must construct one router per node/trust domain because the four-call ceiling is per router instance.

## Verification

- chain build: passed
- focused signature + router tests: 59/59 passed
- full chain unit suite: 712 passed, 1 skipped
- independent end-to-end verifier -> router -> opaque capability test: passed
- 4,096-byte signature boundary accepted and 4,097 rejected before adapter invocation
- independent blocker audit: GO
- `git diff --check`: passed