### PR TITLE
feat(agent): mint RFC-64 verified candidate row capabilities

### DIFF
--- a/packages/agent/src/rfc64/inventory-v1/candidate.ts
+++ b/packages/agent/src/rfc64/inventory-v1/candidate.ts
@@ -1666,8 +1666,13 @@ function snapshotEncodedHeader(
   row: SqlRowV1,
   key: EncodedLoadKeyV1,
 ): EncodedHeaderV1 {
-  const subgraphName = row.subgraph_name;
-  if (subgraphName !== null && typeof subgraphName !== 'string') {
+  const rawSubgraphName = row.subgraph_name;
+  let subgraphName: string | null;
+  if (rawSubgraphName === null) {
+    subgraphName = null;
+  } else if (typeof rawSubgraphName === 'string') {
+    subgraphName = rawSubgraphName;
+  } else {
     throw new InventoryV1CandidateError(
       'candidate-database-corrupt',
       'stored candidate subgraph_name is neither text nor NULL',

--- a/packages/agent/src/rfc64/inventory-v1/candidate.ts
+++ b/packages/agent/src/rfc64/inventory-v1/candidate.ts
@@ -60,6 +60,7 @@ declare const CANDIDATE_SESSION_BRAND: unique symbol;
 declare const CANDIDATE_LOAD_KEY_BRAND: unique symbol;
 declare const CANDIDATE_ROWS_TRAVERSAL_BRAND: unique symbol;
 declare const CANDIDATE_DIFF_TRAVERSAL_BRAND: unique symbol;
+declare const VERIFIED_CANDIDATE_CATALOG_ROW_BRAND: unique symbol;
 
 /** Opaque, adapter-local session. No raw session bytes are exposed or accepted. */
 export interface CandidateSessionV1 {
@@ -77,6 +78,15 @@ export interface CandidateBucketRowsTraversalV1 {
 
 export interface CandidateBucketDiffTraversalV1 {
   readonly [CANDIDATE_DIFF_TRAVERSAL_BRAND]: true;
+}
+
+/**
+ * Process-local proof that a row was decoded through a live, pinned traversal
+ * rooted in an opaque verified head/directory/bucket load. SQLite bytes alone
+ * can never construct this capability.
+ */
+export interface VerifiedCandidateCatalogRowV1 {
+  readonly [VERIFIED_CANDIDATE_CATALOG_ROW_BRAND]: true;
 }
 
 export interface VerifiedCandidateBucketLoadV1 {
@@ -100,10 +110,20 @@ export interface CandidateBucketHeaderV1 {
   readonly payloadByteLength: ByteLengthV1;
 }
 
-export interface CandidateBucketRowV1 {
+export interface CandidateBucketRowSnapshotV1 {
+  /** Full canonical catalog scope needed by every later digest/admission check. */
+  readonly catalogScope: AuthorCatalogScopeV1;
+  /** The exact verified bucket/head scope from which this row was traversed. */
+  readonly header: CandidateBucketHeaderV1;
+  /** `removed` rows are deletion candidates, never transfer/admission candidates. */
+  readonly disposition: 'present' | 'removed';
   readonly row: AuthorCatalogRowV1;
   readonly catalogKeyDigest: Digest32V1;
   readonly expectedCatalogRowDigest: Digest32V1;
+}
+
+export interface CandidateBucketRowV1 extends CandidateBucketRowSnapshotV1 {
+  readonly verifiedRow: VerifiedCandidateCatalogRowV1;
 }
 
 export interface CandidateBucketPutResultV1 {
@@ -133,6 +153,8 @@ export type InventoryV1CandidateErrorCode =
   | 'candidate-invalid-load-key'
   | 'candidate-invalid-traversal'
   | 'candidate-traversal-closed'
+  | 'candidate-invalid-row-proof'
+  | 'candidate-stale-row-proof'
   | 'candidate-cursor-mismatch'
   | 'candidate-stream-complete'
   | 'candidate-in-use'
@@ -176,6 +198,9 @@ export interface Rfc64InventoryV1CandidateApi {
     cursor: KaIdV1 | null | undefined,
     limit: number,
   ): CandidateBucketPageV1;
+  readVerifiedCandidateCatalogRow(
+    verifiedRow: VerifiedCandidateCatalogRowV1,
+  ): CandidateBucketRowSnapshotV1;
   closeCandidateTraversal(
     traversal: CandidateBucketRowsTraversalV1 | CandidateBucketDiffTraversalV1,
   ): void;
@@ -211,6 +236,7 @@ interface LoadKeyRecordV1 {
   readonly session: SessionRecordV1;
   readonly encoded: EncodedLoadKeyV1;
   readonly expectedHeader: EncodedHeaderV1;
+  readonly publicHeader: CandidateBucketHeaderV1;
   readonly scope: AuthorCatalogScopeV1;
   readonly pinKey: string;
 }
@@ -277,6 +303,24 @@ interface TraversalBaseV1 {
   closeReason: 'normal' | 'poisoned' | 'reopen' | null;
 }
 
+interface VerifiedCandidateCatalogRowRecordV1 {
+  readonly traversalHandle: CandidateBucketRowsTraversalV1 | CandidateBucketDiffTraversalV1;
+  readonly traversal: TraversalRecordV1;
+  readonly load: LoadKeyRecordV1;
+  readonly snapshot: CandidateBucketRowSnapshotV1;
+}
+
+interface DecodedCandidateBucketRowV1 {
+  readonly row: AuthorCatalogRowV1;
+  readonly catalogKeyDigest: Digest32V1;
+  readonly expectedCatalogRowDigest: Digest32V1;
+}
+
+interface CandidateBucketDecodedPageV1 {
+  readonly rows: readonly DecodedCandidateBucketRowV1[];
+  readonly resumeAfter: KaIdV1 | null;
+}
+
 interface RowsTraversalRecordV1 extends TraversalBaseV1 {
   readonly kind: 'rows';
   readonly load: LoadKeyRecordV1;
@@ -304,6 +348,7 @@ export class CandidateInventoryV1 implements Rfc64InventoryV1CandidateApi {
   readonly #sessionRecords = new Set<SessionRecordV1>();
   readonly #loadKeys = new WeakMap<object, LoadKeyRecordV1>();
   readonly #traversals = new WeakMap<object, TraversalRecordV1>();
+  readonly #verifiedRows = new WeakMap<object, VerifiedCandidateCatalogRowRecordV1>();
   readonly #pins = new Map<string, number>();
   #startupPurgeDone = false;
   #committedOverruns = 0;
@@ -495,13 +540,14 @@ export class CandidateInventoryV1 implements Rfc64InventoryV1CandidateApi {
         this.requireHeader(record.load);
         return this.queryRowsPage(record.load, canonicalCursor, limit);
       });
+      const verifiedPage = this.mintVerifiedPage(page, traversal, record, record.load);
       if (page.rows.length === 0) {
         record.terminal = true;
         this.closeTraversalRecord(record);
       } else {
         record.expectedCursor = page.resumeAfter;
       }
-      return page;
+      return verifiedPage;
     } catch (cause) {
       this.closeTraversalRecord(record);
       throw normalizeCandidateError('candidate row page failed', cause);
@@ -522,6 +568,31 @@ export class CandidateInventoryV1 implements Rfc64InventoryV1CandidateApi {
     limit: number,
   ): CandidateBucketPageV1 {
     return this.pageDiff(traversal, cursor, limit, 'removed');
+  }
+
+  readVerifiedCandidateCatalogRow(
+    verifiedRow: VerifiedCandidateCatalogRowV1,
+  ): CandidateBucketRowSnapshotV1 {
+    this.assertOpen();
+    if (typeof verifiedRow !== 'object' || verifiedRow === null) {
+      throw invalidRowProof();
+    }
+    const proof = this.#verifiedRows.get(verifiedRow as object);
+    if (proof === undefined) throw invalidRowProof();
+    const current = this.#traversals.get(proof.traversalHandle as object);
+    if (
+      current !== proof.traversal
+      || current.closed
+      || current.closeReason !== null
+      || current.sessions.some((session) => session.poisoned)
+      || !current.pins.some((pin) => pin.pinKey === proof.load.pinKey)
+    ) {
+      throw new InventoryV1CandidateError(
+        'candidate-stale-row-proof',
+        'verified candidate row proof no longer belongs to a live pinned traversal',
+      );
+    }
+    return proof.snapshot;
   }
 
   closeCandidateTraversal(
@@ -655,6 +726,14 @@ export class CandidateInventoryV1 implements Rfc64InventoryV1CandidateApi {
         assertDiffCompatible(oldHeader, newHeader);
         return this.queryDiffPage(record, canonicalCursor, limit, stream);
       });
+      const load = stream === 'added' ? record.newLoad : record.oldLoad;
+      const verifiedPage = this.mintVerifiedPage(
+        page,
+        traversal,
+        record,
+        load,
+        stream === 'removed' ? 'removed' : 'present',
+      );
       if (page.rows.length === 0) {
         if (stream === 'added') record.addedTerminal = true;
         else record.removedTerminal = true;
@@ -664,7 +743,7 @@ export class CandidateInventoryV1 implements Rfc64InventoryV1CandidateApi {
       } else {
         record.removedExpectedCursor = page.resumeAfter;
       }
-      return page;
+      return verifiedPage;
     } catch (cause) {
       this.closeTraversalRecord(record);
       throw normalizeCandidateError(`candidate ${stream} diff page failed`, cause);
@@ -675,7 +754,7 @@ export class CandidateInventoryV1 implements Rfc64InventoryV1CandidateApi {
     load: LoadKeyRecordV1,
     cursor: KaIdV1 | null,
     limit: number,
-  ): CandidateBucketPageV1 {
+  ): CandidateBucketDecodedPageV1 {
     assertPageLimit(limit);
     const sql = cursor === null
       ? INVENTORY_V1_STATEMENT_SQL.getRowsFirst
@@ -695,7 +774,7 @@ export class CandidateInventoryV1 implements Rfc64InventoryV1CandidateApi {
     cursor: KaIdV1 | null,
     limit: number,
     stream: 'added' | 'removed',
-  ): CandidateBucketPageV1 {
+  ): CandidateBucketDecodedPageV1 {
     assertPageLimit(limit);
     const sql = stream === 'added'
       ? (cursor === null
@@ -718,6 +797,40 @@ export class CandidateInventoryV1 implements Rfc64InventoryV1CandidateApi {
     const query = this.prepare(sql);
     const rows = this.statement(() => query.all(parameters) as SqlRowV1[]);
     return decodePage(rows, stream === 'added' ? traversal.newLoad : traversal.oldLoad);
+  }
+
+  private mintVerifiedPage(
+    page: CandidateBucketDecodedPageV1,
+    traversalHandle: CandidateBucketRowsTraversalV1 | CandidateBucketDiffTraversalV1,
+    traversal: TraversalRecordV1,
+    load: LoadKeyRecordV1,
+    disposition: CandidateBucketRowSnapshotV1['disposition'] = 'present',
+  ): CandidateBucketPageV1 {
+    const rows = page.rows.map((decoded): CandidateBucketRowV1 => {
+      const snapshot: CandidateBucketRowSnapshotV1 = Object.freeze({
+        catalogScope: load.scope,
+        header: load.publicHeader,
+        disposition,
+        ...decoded,
+      });
+      const verifiedRow = Object.freeze(
+        Object.create(null),
+      ) as VerifiedCandidateCatalogRowV1;
+      this.#verifiedRows.set(verifiedRow as object, {
+        traversalHandle,
+        traversal,
+        load,
+        snapshot,
+      });
+      return Object.freeze({
+        ...snapshot,
+        verifiedRow,
+      });
+    });
+    return Object.freeze({
+      rows: Object.freeze(rows),
+      resumeAfter: page.resumeAfter,
+    });
   }
 
   private encodeAndVerifyLoad(load: VerifiedCandidateBucketLoadV1): EncodedCandidateLoadV1 {
@@ -870,6 +983,7 @@ export class CandidateInventoryV1 implements Rfc64InventoryV1CandidateApi {
       session: load.session,
       encoded,
       expectedHeader: cloneHeader(load.header),
+      publicHeader: load.publicHeader,
       scope: Object.freeze({ ...load.scope }),
       pinKey: pinKey(encoded),
     });
@@ -1728,7 +1842,10 @@ function assertVerifiedHeaderScopeBinding(
   }
 }
 
-function decodePage(rows: readonly SqlRowV1[], key: LoadKeyRecordV1): CandidateBucketPageV1 {
+function decodePage(
+  rows: readonly SqlRowV1[],
+  key: LoadKeyRecordV1,
+): CandidateBucketDecodedPageV1 {
   const decoded = rows.map((row) => decodeRow(row, key));
   return Object.freeze({
     rows: Object.freeze(decoded),
@@ -1736,7 +1853,7 @@ function decodePage(rows: readonly SqlRowV1[], key: LoadKeyRecordV1): CandidateB
   });
 }
 
-function decodeRow(row: SqlRowV1, key: LoadKeyRecordV1): CandidateBucketRowV1 {
+function decodeRow(row: SqlRowV1, key: LoadKeyRecordV1): DecodedCandidateBucketRowV1 {
   try {
     if (
       !sqlBlobsEqualV1(row.session_id, key.encoded.session)
@@ -1757,24 +1874,27 @@ function decodeRow(row: SqlRowV1, key: LoadKeyRecordV1): CandidateBucketRowV1 {
       throw new Error('stored assertionCoordinate is not text');
     }
     assertAssertionCoordinateV1(row.assertion_coordinate);
-    const candidate: AuthorCatalogRowV1 = {
+    const transfer = Object.freeze({
+      codec: KA_TRANSFER_CODEC_V1,
+      projectionId: KA_TRANSFER_PROJECTION_V1,
+      projectionDigest: sqlBlobToDigest32V1(row.projection_digest),
+      byteLength: sqlBlobToDecimalU64V1(row.transfer_byte_length_u64be) as ByteLengthV1,
+      chunkSize: sqlBlobToDecimalU64V1(
+        row.transfer_chunk_size_u64be,
+      ) as typeof KA_TRANSFER_CHUNK_SIZE_V1,
+      chunkCount: sqlBlobToDecimalU64V1(row.transfer_chunk_count_u64be) as CountV1,
+      blobDigest: sqlBlobToDigest32V1(row.transfer_blob_digest),
+      chunkTreeRoot: sqlBlobToDigest32V1(row.transfer_chunk_tree_root),
+    });
+    const candidate: AuthorCatalogRowV1 = Object.freeze({
       kaId: sqlBlobToDecimalU256V1(row.ka_id_u256be) as KaIdV1,
       assertionCoordinate: row.assertion_coordinate,
       assertionVersion: sqlBlobToDecimalU64V1(row.assertion_version_u64be),
       projectionId: KA_TRANSFER_PROJECTION_V1,
       projectionDigest: sqlBlobToDigest32V1(row.projection_digest),
       sealDigest: sqlBlobToDigest32V1(row.seal_digest),
-      transfer: {
-        codec: KA_TRANSFER_CODEC_V1,
-        projectionId: KA_TRANSFER_PROJECTION_V1,
-        projectionDigest: sqlBlobToDigest32V1(row.projection_digest),
-        byteLength: sqlBlobToDecimalU64V1(row.transfer_byte_length_u64be) as ByteLengthV1,
-        chunkSize: sqlBlobToDecimalU64V1(row.transfer_chunk_size_u64be) as typeof KA_TRANSFER_CHUNK_SIZE_V1,
-        chunkCount: sqlBlobToDecimalU64V1(row.transfer_chunk_count_u64be) as CountV1,
-        blobDigest: sqlBlobToDigest32V1(row.transfer_blob_digest),
-        chunkTreeRoot: sqlBlobToDigest32V1(row.transfer_chunk_tree_root),
-      },
-    };
+      transfer,
+    });
     assertAuthorCatalogRowV1(candidate);
     const catalogScopeDigest = sqlBlobToDigest32V1(row.catalog_scope_digest);
     const catalogKeyDigest = sqlBlobToDigest32V1(row.catalog_key_digest);
@@ -1789,7 +1909,7 @@ function decodeRow(row: SqlRowV1, key: LoadKeyRecordV1): CandidateBucketRowV1 {
       throw new Error('stored expectedCatalogRowDigest does not match the row');
     }
     return Object.freeze({
-      row: Object.freeze(candidate),
+      row: candidate,
       catalogKeyDigest,
       expectedCatalogRowDigest,
     });
@@ -2012,6 +2132,13 @@ function invalidSession(): InventoryV1CandidateError {
   return new InventoryV1CandidateError(
     'candidate-invalid-session',
     'candidate session is not an adapter-local opaque handle',
+  );
+}
+
+function invalidRowProof(): InventoryV1CandidateError {
+  return new InventoryV1CandidateError(
+    'candidate-invalid-row-proof',
+    'verified candidate row proof is not an adapter-local opaque handle',
   );
 }
 

--- a/packages/agent/src/rfc64/inventory-v1/index.ts
+++ b/packages/agent/src/rfc64/inventory-v1/index.ts
@@ -8,6 +8,7 @@ export {
   type CandidateBucketLoadKeyV1,
   type CandidateBucketPageV1,
   type CandidateBucketPutResultV1,
+  type CandidateBucketRowSnapshotV1,
   type CandidateBucketRowV1,
   type CandidateBucketRowsTraversalV1,
   type CandidateSessionGcBatchResultV1,
@@ -15,6 +16,7 @@ export {
   type InventoryV1CandidateErrorCode,
   type Rfc64InventoryV1CandidateApi,
   type VerifiedCandidateBucketLoadV1,
+  type VerifiedCandidateCatalogRowV1,
 } from './candidate.js';
 export {
   INVENTORY_V1_POSIX_QUARANTINE_CAPABILITY,

--- a/packages/agent/src/rfc64/inventory-v1/open.ts
+++ b/packages/agent/src/rfc64/inventory-v1/open.ts
@@ -45,11 +45,13 @@ import {
   type CandidateBucketLoadKeyV1,
   type CandidateBucketPageV1,
   type CandidateBucketPutResultV1,
+  type CandidateBucketRowSnapshotV1,
   type CandidateBucketRowsTraversalV1,
   type CandidateSessionV1,
   type CandidateSessionGcBatchResultV1,
   type Rfc64InventoryV1CandidateApi,
   type VerifiedCandidateBucketLoadV1,
+  type VerifiedCandidateCatalogRowV1,
 } from './candidate.js';
 import type { KaIdV1 } from '@origintrail-official/dkg-core';
 import {
@@ -378,6 +380,13 @@ class InventoryV1Foundation implements Rfc64InventoryV1Foundation {
   ): CandidateBucketPageV1 {
     this.requireOpen();
     return this.#candidate.pageCandidateBucketRemoved(traversal, cursor, limit);
+  }
+
+  readVerifiedCandidateCatalogRow(
+    verifiedRow: VerifiedCandidateCatalogRowV1,
+  ): CandidateBucketRowSnapshotV1 {
+    this.requireOpen();
+    return this.#candidate.readVerifiedCandidateCatalogRow(verifiedRow);
   }
 
   closeCandidateTraversal(

--- a/packages/agent/test/rfc64-inventory-v1-candidates.test.ts
+++ b/packages/agent/test/rfc64-inventory-v1-candidates.test.ts
@@ -158,6 +158,11 @@ describe('RFC-64 SQL-1 verified candidate buckets', () => {
     const serializedClone = JSON.parse(
       JSON.stringify(candidate.verifiedRow),
     ) as typeof candidate.verifiedRow;
+    for (const primitive of [null, undefined, false, 0, 'proof']) {
+      expect(() => inventory.readVerifiedCandidateCatalogRow(
+        primitive as unknown as typeof candidate.verifiedRow,
+      )).toThrowError(expect.objectContaining({ code: 'candidate-invalid-row-proof' }));
+    }
     expect(() => inventory.readVerifiedCandidateCatalogRow(forged)).toThrowError(
       expect.objectContaining({ code: 'candidate-invalid-row-proof' }),
     );
@@ -169,6 +174,15 @@ describe('RFC-64 SQL-1 verified candidate buckets', () => {
     )).toThrowError(expect.objectContaining({ code: 'candidate-invalid-row-proof' }));
     expect(() => otherInventory.readVerifiedCandidateCatalogRow(candidate.verifiedRow))
       .toThrowError(expect.objectContaining({ code: 'candidate-invalid-row-proof' }));
+
+    const tamperedWrapper = {
+      ...candidate,
+      disposition: 'removed',
+      catalogKeyDigest: ZERO_DIGEST32_V1,
+    } as const;
+    expect(inventory.readVerifiedCandidateCatalogRow(tamperedWrapper.verifiedRow)).toEqual(
+      snapshot,
+    );
 
     expect(inventory.pageCandidateBucketRows(traversal, page.resumeAfter, 1)).toEqual({
       rows: [],

--- a/packages/agent/test/rfc64-inventory-v1-candidates.test.ts
+++ b/packages/agent/test/rfc64-inventory-v1-candidates.test.ts
@@ -118,6 +118,74 @@ describe('RFC-64 SQL-1 verified candidate buckets', () => {
       .toThrowError(expect.objectContaining({ code: 'candidate-traversal-closed' }));
   });
 
+  it('mints unforgeable row capabilities only for live pinned traversals', async () => {
+    const inventory = await readyInventory();
+    const otherInventory = await readyInventory();
+    const session = inventory.createCandidateSession();
+    const sourceRow = makeRow(1n, 'verified-row-capability');
+    const head = makeHead('1', '60');
+    const loaded = inventory.putVerifiedCandidateBucket(
+      makeNonEmptyLoad(session, head, [sourceRow]),
+    );
+
+    const traversal = inventory.beginCandidateBucketRows(loaded.loadKey);
+    const page = inventory.pageCandidateBucketRows(traversal, null, 1);
+    const candidate = page.rows[0];
+    expect(candidate).toBeDefined();
+    expect(Object.getPrototypeOf(candidate.verifiedRow)).toBeNull();
+    expect(Object.isFrozen(candidate.verifiedRow)).toBe(true);
+    expect(Object.keys(candidate.verifiedRow)).toEqual([]);
+    expect(Object.isFrozen(candidate)).toBe(true);
+    expect(Object.isFrozen(candidate.row)).toBe(true);
+    expect(Object.isFrozen(candidate.row.transfer)).toBe(true);
+    expect(Object.isFrozen(candidate.catalogScope)).toBe(true);
+    expect(candidate.catalogScope).toEqual(deriveAuthorCatalogScopeFromHeadV1(head.payload));
+    expect(computeAuthorCatalogScopeDigestV1(candidate.catalogScope))
+      .toBe(candidate.header.catalogScopeDigest);
+
+    const snapshot = inventory.readVerifiedCandidateCatalogRow(candidate.verifiedRow);
+    expect(snapshot).toEqual({
+      catalogScope: candidate.catalogScope,
+      header: candidate.header,
+      disposition: 'present',
+      row: candidate.row,
+      catalogKeyDigest: candidate.catalogKeyDigest,
+      expectedCatalogRowDigest: candidate.expectedCatalogRowDigest,
+    });
+    expect(Object.isFrozen(snapshot)).toBe(true);
+
+    const forged = Object.freeze(Object.create(null)) as typeof candidate.verifiedRow;
+    const serializedClone = JSON.parse(
+      JSON.stringify(candidate.verifiedRow),
+    ) as typeof candidate.verifiedRow;
+    expect(() => inventory.readVerifiedCandidateCatalogRow(forged)).toThrowError(
+      expect.objectContaining({ code: 'candidate-invalid-row-proof' }),
+    );
+    expect(() => inventory.readVerifiedCandidateCatalogRow(serializedClone)).toThrowError(
+      expect.objectContaining({ code: 'candidate-invalid-row-proof' }),
+    );
+    expect(() => inventory.readVerifiedCandidateCatalogRow(
+      candidate.row as unknown as typeof candidate.verifiedRow,
+    )).toThrowError(expect.objectContaining({ code: 'candidate-invalid-row-proof' }));
+    expect(() => otherInventory.readVerifiedCandidateCatalogRow(candidate.verifiedRow))
+      .toThrowError(expect.objectContaining({ code: 'candidate-invalid-row-proof' }));
+
+    expect(inventory.pageCandidateBucketRows(traversal, page.resumeAfter, 1)).toEqual({
+      rows: [],
+      resumeAfter: null,
+    });
+    expect(() => inventory.readVerifiedCandidateCatalogRow(candidate.verifiedRow)).toThrowError(
+      expect.objectContaining({ code: 'candidate-stale-row-proof' }),
+    );
+
+    const explicitlyClosed = inventory.beginCandidateBucketRows(loaded.loadKey);
+    const explicitlyClosedPage = inventory.pageCandidateBucketRows(explicitlyClosed, null, 1);
+    inventory.closeCandidateTraversal(explicitlyClosed);
+    expect(() => inventory.readVerifiedCandidateCatalogRow(
+      explicitlyClosedPage.rows[0].verifiedRow,
+    )).toThrowError(expect.objectContaining({ code: 'candidate-stale-row-proof' }));
+  });
+
   it('reopens the low-level database, retains the opaque session, and exact-key retries', () => {
     const directory = temporaryDataDirectory();
     const path = join(directory, 'commit-retry.sqlite3');
@@ -154,6 +222,11 @@ describe('RFC-64 SQL-1 verified candidate buckets', () => {
         makeNonEmptyLoad(session, makeHead('1', '1'), [makeRow(1n, 'fixture')]),
       );
       const invalidatedTraversal = inventory.beginCandidateBucketRows(firstLoad.loadKey);
+      const invalidatedPage = inventory.pageCandidateBucketRows(
+        invalidatedTraversal,
+        null,
+        1,
+      );
 
       failAfterCommittedOnce = true;
       const retried = inventory.putVerifiedCandidateBucket(
@@ -165,6 +238,9 @@ describe('RFC-64 SQL-1 verified candidate buckets', () => {
         .toBe(retried.header.targetCatalogHeadDigest);
       expect(() => inventory.pageCandidateBucketRows(invalidatedTraversal, null, 1))
         .toThrowError(expect.objectContaining({ code: 'candidate-traversal-closed' }));
+      expect(() => inventory.readVerifiedCandidateCatalogRow(
+        invalidatedPage.rows[0].verifiedRow,
+      )).toThrowError(expect.objectContaining({ code: 'candidate-stale-row-proof' }));
       expect(inventory.putVerifiedCandidateBucket(
         makeNonEmptyLoad(session, makeHead('1', '1'), [makeRow(1n, 'fixture')]),
       ).status).toBe('existing');
@@ -727,10 +803,15 @@ describe('RFC-64 SQL-1 verified candidate buckets', () => {
       },
     ]);
     const loaded = inventory.putVerifiedCandidateBucket(original);
+    const traversal = inventory.beginCandidateBucketRows(loaded.loadKey);
+    const verifiedPage = inventory.pageCandidateBucketRows(traversal, null, 1);
 
     expect(() => inventory.putVerifiedCandidateBucket(mutation)).toThrowError(
       expect.objectContaining({ code: 'candidate-conflict' }),
     );
+    expect(() => inventory.readVerifiedCandidateCatalogRow(
+      verifiedPage.rows[0].verifiedRow,
+    )).toThrowError(expect.objectContaining({ code: 'candidate-stale-row-proof' }));
     expect(() => inventory.getCandidateBucket(loaded.loadKey)).toThrowError(
       expect.objectContaining({ code: 'candidate-session-poisoned' }),
     );
@@ -856,13 +937,30 @@ describe('RFC-64 SQL-1 verified candidate buckets', () => {
       added2.resumeAfter,
       1,
     )).toEqual({ rows: [], resumeAfter: null });
+    expect(inventory.readVerifiedCandidateCatalogRow(added1.rows[0].verifiedRow))
+      .toMatchObject({
+        disposition: 'present',
+        header: { targetCatalogHeadDigest: newLoad.header.targetCatalogHeadDigest },
+      });
 
     const removed = inventory.pageCandidateBucketRemoved(traversal, null, 1);
     expect(removed.rows.map((entry) => entry.row.kaId)).toEqual([three.kaId]);
+    expect(removed.rows[0]).toMatchObject({
+      disposition: 'removed',
+      header: { targetCatalogHeadDigest: oldLoad.header.targetCatalogHeadDigest },
+    });
+    expect(added1.rows[0]).toMatchObject({
+      disposition: 'present',
+      header: { targetCatalogHeadDigest: newLoad.header.targetCatalogHeadDigest },
+    });
     expect(inventory.pageCandidateBucketRemoved(traversal, removed.resumeAfter, 1)).toEqual({
       rows: [],
       resumeAfter: null,
     });
+    expect(() => inventory.readVerifiedCandidateCatalogRow(added1.rows[0].verifiedRow))
+      .toThrowError(expect.objectContaining({ code: 'candidate-stale-row-proof' }));
+    expect(() => inventory.readVerifiedCandidateCatalogRow(removed.rows[0].verifiedRow))
+      .toThrowError(expect.objectContaining({ code: 'candidate-stale-row-proof' }));
   });
 
   it('pins loads, rejects cursor skipping, and releases pins on explicit early close', async () => {
@@ -879,6 +977,8 @@ describe('RFC-64 SQL-1 verified candidate buckets', () => {
     );
     expect(() => inventory.pageCandidateBucketRows(traversal, makeRow(2n, 'x').kaId, 1))
       .toThrowError(expect.objectContaining({ code: 'candidate-cursor-mismatch' }));
+    expect(() => inventory.readVerifiedCandidateCatalogRow(first.rows[0].verifiedRow))
+      .toThrowError(expect.objectContaining({ code: 'candidate-stale-row-proof' }));
     expect(() => inventory.pageCandidateBucketRows(traversal, first.resumeAfter, 1))
       .toThrowError(expect.objectContaining({ code: 'candidate-traversal-closed' }));
 


### PR DESCRIPTION
## Summary

- mint an opaque adapter-local proof for each row returned by a live pinned SQL-1 traversal
- bind the full catalog scope, exact head and bucket, immutable row digests, and present versus removed disposition
- invalidate proofs on terminal completion, explicit close, page error, session poison, reopen, or cross-inventory use
- expose proof resolution through the owned inventory foundation without granting semantic admission or completion authority

This is a stacked RFC-64 implementation slice based on #1805. Later transfer and semantic admission work must accept this opaque proof; plain SQLite rows or copied snapshots cannot authorize those steps.

## Verification

- 53 focused inventory tests pass, including the 500k-row query-plan gate
- agent build and type tests pass
- independent adversarial capability review: GO
- git diff --check passes