### PR TITLE
feat(chain): add strict finalized RPC transport

### DIFF
--- a/packages/chain/package.json
+++ b/packages/chain/package.json
@@ -5,9 +5,10 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && pnpm run test:types",
     "test": "vitest run",
     "test:unit": "vitest run --config vitest.unit.config.ts",
+    "test:types": "tsc --project tsconfig.type-tests.json",
     "test:coverage": "vitest run --coverage",
     "clean": "rm -rf dist tsconfig.tsbuildinfo"
   },

--- a/packages/chain/src/current-finalized-evm-call.ts
+++ b/packages/chain/src/current-finalized-evm-call.ts
@@ -66,7 +66,7 @@ export function createCurrentFinalizedEvmCallRouterV1(
   for (const chainId of adapters.keys()) inFlightByChain.set(chainId, 0);
 
   const route: CurrentFinalizedEvmCallV1 = async (input) => {
-    const request = snapshotAndValidateRequest(input);
+    const request = snapshotCurrentFinalizedEvmCallRequestV1(input);
     const adapter = adapters.get(request.chainId);
     if (adapter === undefined) {
       throw new CurrentFinalizedEvmCallErrorV1(
@@ -196,7 +196,10 @@ function snapshotRegistration(input: unknown): Readonly<CurrentFinalizedEvmChain
   });
 }
 
-function snapshotAndValidateRequest(input: unknown): CurrentFinalizedEvmCallRequestV1 {
+/** Package-internal strict snapshot shared by the router and raw transport. */
+export function snapshotCurrentFinalizedEvmCallRequestV1(
+  input: unknown,
+): CurrentFinalizedEvmCallRequestV1 {
   try {
     const record = snapshotExactDataRecord(input, REQUEST_KEYS);
     assertCanonicalChainId(record.chainId, 'current-finalized request chainId');

--- a/packages/chain/src/current-finalized-evm-call.ts
+++ b/packages/chain/src/current-finalized-evm-call.ts
@@ -4,39 +4,18 @@ import {
 } from '@origintrail-official/dkg-core';
 
 import {
-  CONTROL_EIP1271_ATTEMPT_TIMEOUT_MS_V1,
-  CONTROL_EIP1271_CALL_FROM_V1,
-  CONTROL_EIP1271_ENDPOINT_ATTEMPT_POLICY_V1,
-  CONTROL_EIP1271_GAS_LIMIT_V1,
-  CONTROL_EIP1271_MAX_ATTEMPTS_V1,
   CONTROL_EIP1271_MAX_CONCURRENT_CALLS_PER_CHAIN_V1,
-  CONTROL_EIP1271_MAX_RPC_RESPONSE_BYTES_V1,
-  CONTROL_EIP1271_MAX_RETURN_BYTES_V1,
-  CONTROL_EIP1271_TOTAL_DEADLINE_MS_V1,
   CURRENT_FINALIZED_EVM_CALL_ERROR_CODES_V1,
   CurrentFinalizedEvmCallErrorV1,
   type CurrentFinalizedEvmCallRequestV1,
   type CurrentFinalizedEvmCallResultV1,
   type CurrentFinalizedEvmCallV1,
 } from './control-object-signature-verifier.js';
-
-const REQUEST_KEYS = Object.freeze([
-  'attemptTimeoutMs',
-  'ccipReadEnabled',
-  'chainId',
-  'data',
-  'endpointAttemptPolicy',
-  'from',
-  'gasLimit',
-  'maxAttempts',
-  'maxConcurrentCallsPerChain',
-  'maxReturnBytes',
-  'maxRpcResponseBytes',
-  'signal',
-  'to',
-  'totalDeadlineMs',
-] as const);
-const CANONICAL_NONZERO_EVM_ADDRESS = /^0x(?!0{40}$)[0-9a-f]{40}$/;
+import {
+  snapshotCurrentFinalizedEvmCallRequestV1,
+  snapshotDenseDataArray,
+  snapshotExactDataRecord,
+} from './current-finalized-strict-snapshot.js';
 
 /**
  * Per-chain trusted-local adapter seam. A later transport implementation owns
@@ -108,7 +87,10 @@ export function createCurrentFinalizedEvmCallRouterV1(
 function snapshotAdapterRegistry(
   input: unknown,
 ): ReadonlyMap<ChainIdV1, CurrentFinalizedEvmChainAdapterV1> {
-  const registrations = snapshotDenseArray(input);
+  const registrations = snapshotDenseDataArray(
+    input,
+    'Current-finalized adapter registrations must be a dense data-only array',
+  );
   const adapters = new Map<ChainIdV1, CurrentFinalizedEvmChainAdapterV1>();
 
   for (const registration of registrations) {
@@ -119,56 +101,6 @@ function snapshotAdapterRegistry(
     adapters.set(snapshot.chainId, snapshot.adapter);
   }
   return adapters;
-}
-
-function snapshotDenseArray(input: unknown): readonly unknown[] {
-  try {
-    if (!Array.isArray(input)) throw new Error('not an array');
-    const lengthDescriptor = Object.getOwnPropertyDescriptor(input, 'length');
-    if (
-      lengthDescriptor === undefined
-      || !Object.prototype.hasOwnProperty.call(lengthDescriptor, 'value')
-      || typeof lengthDescriptor.value !== 'number'
-      || !Number.isSafeInteger(lengthDescriptor.value)
-      || lengthDescriptor.value < 0
-    ) {
-      throw new Error('invalid array length');
-    }
-
-    const length = lengthDescriptor.value;
-    const ownKeys = Reflect.ownKeys(input);
-    if (
-      ownKeys.length !== length + 1
-      || ownKeys.some((key) => (
-        typeof key !== 'string'
-        || (key !== 'length' && !isCanonicalArrayIndex(key, length))
-      ))
-    ) {
-      throw new Error('registrations must be a dense ordinary array');
-    }
-
-    const snapshot: unknown[] = [];
-    for (let index = 0; index < length; index += 1) {
-      const descriptor = Object.getOwnPropertyDescriptor(input, String(index));
-      if (
-        descriptor === undefined
-        || !descriptor.enumerable
-        || !Object.prototype.hasOwnProperty.call(descriptor, 'value')
-      ) {
-        throw new Error('registration entry must be an enumerable data property');
-      }
-      snapshot.push(descriptor.value);
-    }
-    return Object.freeze(snapshot);
-  } catch {
-    throw new TypeError('Current-finalized adapter registrations must be a dense data-only array');
-  }
-}
-
-function isCanonicalArrayIndex(key: string, length: number): boolean {
-  if (!/^(?:0|[1-9][0-9]*)$/.test(key)) return false;
-  const index = Number(key);
-  return Number.isSafeInteger(index) && index >= 0 && index < length && String(index) === key;
 }
 
 function snapshotRegistration(input: unknown): Readonly<CurrentFinalizedEvmChainAdapterRegistrationV1> {
@@ -194,155 +126,6 @@ function snapshotRegistration(input: unknown): Readonly<CurrentFinalizedEvmChain
     chainId,
     adapter: adapter as CurrentFinalizedEvmChainAdapterV1,
   });
-}
-
-/** Package-internal strict snapshot shared by the router and raw transport. */
-export function snapshotCurrentFinalizedEvmCallRequestV1(
-  input: unknown,
-): CurrentFinalizedEvmCallRequestV1 {
-  try {
-    const record = snapshotExactDataRecord(input, REQUEST_KEYS);
-    assertCanonicalChainId(record.chainId, 'current-finalized request chainId');
-    if (
-      typeof record.to !== 'string'
-      || !CANONICAL_NONZERO_EVM_ADDRESS.test(record.to)
-    ) {
-      throw new Error('to is not a canonical nonzero EVM address');
-    }
-    if (record.from !== CONTROL_EIP1271_CALL_FROM_V1) throw new Error('wrong from');
-    if (typeof record.data !== 'string') throw new Error('call data is not a string');
-    assertCanonicalEip1271CallData(record.data);
-    if (record.gasLimit !== CONTROL_EIP1271_GAS_LIMIT_V1) throw new Error('wrong gas limit');
-    if (record.maxReturnBytes !== CONTROL_EIP1271_MAX_RETURN_BYTES_V1) {
-      throw new Error('wrong return cap');
-    }
-    if (record.maxRpcResponseBytes !== CONTROL_EIP1271_MAX_RPC_RESPONSE_BYTES_V1) {
-      throw new Error('wrong RPC response cap');
-    }
-    if (record.attemptTimeoutMs !== CONTROL_EIP1271_ATTEMPT_TIMEOUT_MS_V1) {
-      throw new Error('wrong attempt timeout');
-    }
-    if (record.maxAttempts !== CONTROL_EIP1271_MAX_ATTEMPTS_V1) {
-      throw new Error('wrong attempt count');
-    }
-    if (record.endpointAttemptPolicy !== CONTROL_EIP1271_ENDPOINT_ATTEMPT_POLICY_V1) {
-      throw new Error('wrong endpoint policy');
-    }
-    if (
-      record.maxConcurrentCallsPerChain
-      !== CONTROL_EIP1271_MAX_CONCURRENT_CALLS_PER_CHAIN_V1
-    ) {
-      throw new Error('wrong concurrency ceiling');
-    }
-    if (record.totalDeadlineMs !== CONTROL_EIP1271_TOTAL_DEADLINE_MS_V1) {
-      throw new Error('wrong total deadline');
-    }
-    if (record.ccipReadEnabled !== false) throw new Error('CCIP Read must be disabled');
-    if (!isAbortSignal(record.signal)) throw new Error('signal is not an AbortSignal');
-
-    return Object.freeze({
-      chainId: record.chainId,
-      to: record.to,
-      from: record.from,
-      data: record.data,
-      gasLimit: record.gasLimit,
-      maxReturnBytes: record.maxReturnBytes,
-      maxRpcResponseBytes: record.maxRpcResponseBytes,
-      attemptTimeoutMs: record.attemptTimeoutMs,
-      maxAttempts: record.maxAttempts,
-      endpointAttemptPolicy: record.endpointAttemptPolicy,
-      maxConcurrentCallsPerChain: record.maxConcurrentCallsPerChain,
-      totalDeadlineMs: record.totalDeadlineMs,
-      ccipReadEnabled: record.ccipReadEnabled,
-      signal: record.signal,
-    }) as CurrentFinalizedEvmCallRequestV1;
-  } catch {
-    throw new CurrentFinalizedEvmCallErrorV1(
-      'rpc-unavailable',
-      'Current-finalized EVM call request failed the fixed local profile',
-    );
-  }
-}
-
-function assertCanonicalEip1271CallData(data: string): void {
-  if (!/^0x[0-9a-f]+$/.test(data)) {
-    throw new Error('call data is not canonical lowercase hex');
-  }
-  const bytes = data.slice(2);
-  const selectorLength = 8;
-  const wordLength = 64;
-  const fixedLength = selectorLength + (wordLength * 3);
-  if (
-    bytes.slice(0, selectorLength) !== '1626ba7e'
-    || bytes.length < fixedLength
-    || bytes.slice(selectorLength + wordLength, selectorLength + (wordLength * 2))
-      !== `${'0'.repeat(62)}40`
-  ) {
-    throw new Error('call data is not canonical isValidSignature(bytes32,bytes) ABI');
-  }
-
-  const signatureLengthWord = bytes.slice(
-    selectorLength + (wordLength * 2),
-    fixedLength,
-  );
-  const signatureLength = BigInt(`0x${signatureLengthWord}`);
-  if (signatureLength < 1n || signatureLength > 4096n) {
-    throw new Error('EIP-1271 signature length is outside 1..4096 bytes');
-  }
-  const paddedSignatureHexLength = Math.ceil(Number(signatureLength) / 32) * wordLength;
-  const tail = bytes.slice(fixedLength);
-  if (tail.length !== paddedSignatureHexLength) {
-    throw new Error('EIP-1271 signature tail has noncanonical length');
-  }
-  const signatureHexLength = Number(signatureLength) * 2;
-  if (!/^0*$/.test(tail.slice(signatureHexLength))) {
-    throw new Error('EIP-1271 signature tail has nonzero ABI padding');
-  }
-}
-
-function snapshotExactDataRecord(
-  input: unknown,
-  expectedKeys: readonly string[],
-): Record<string, unknown> {
-  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
-    throw new Error('not a record');
-  }
-  const prototype = Object.getPrototypeOf(input);
-  if (prototype !== Object.prototype && prototype !== null) throw new Error('not plain');
-  const actualKeys = Reflect.ownKeys(input);
-  if (
-    actualKeys.some((key) => typeof key !== 'string')
-    || actualKeys.length !== expectedKeys.length
-    || (actualKeys as string[]).sort().some((key, index) => key !== expectedKeys[index])
-  ) {
-    throw new Error('unknown or missing fields');
-  }
-
-  const snapshot: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
-  for (const key of expectedKeys) {
-    const descriptor = Object.getOwnPropertyDescriptor(input, key);
-    if (
-      descriptor === undefined
-      || !descriptor.enumerable
-      || !Object.prototype.hasOwnProperty.call(descriptor, 'value')
-    ) {
-      throw new Error('fields must be enumerable data properties');
-    }
-    snapshot[key] = descriptor.value;
-  }
-  return snapshot;
-}
-
-function isAbortSignal(value: unknown): value is AbortSignal {
-  if (value === null || typeof value !== 'object') return false;
-  try {
-    const abortedGetter = Object.getOwnPropertyDescriptor(AbortSignal.prototype, 'aborted')?.get;
-    if (abortedGetter === undefined) return false;
-    abortedGetter.call(value);
-    return true;
-  } catch {
-    return false;
-  }
 }
 
 function snapshotAdapterFailure(cause: unknown): CurrentFinalizedEvmCallErrorV1 {

--- a/packages/chain/src/current-finalized-strict-snapshot.ts
+++ b/packages/chain/src/current-finalized-strict-snapshot.ts
@@ -1,0 +1,260 @@
+import { assertCanonicalChainId } from '@origintrail-official/dkg-core';
+
+import {
+  CONTROL_EIP1271_ATTEMPT_TIMEOUT_MS_V1,
+  CONTROL_EIP1271_CALL_FROM_V1,
+  CONTROL_EIP1271_ENDPOINT_ATTEMPT_POLICY_V1,
+  CONTROL_EIP1271_GAS_LIMIT_V1,
+  CONTROL_EIP1271_MAX_ATTEMPTS_V1,
+  CONTROL_EIP1271_MAX_CONCURRENT_CALLS_PER_CHAIN_V1,
+  CONTROL_EIP1271_MAX_RPC_RESPONSE_BYTES_V1,
+  CONTROL_EIP1271_MAX_RETURN_BYTES_V1,
+  CONTROL_EIP1271_TOTAL_DEADLINE_MS_V1,
+  CurrentFinalizedEvmCallErrorV1,
+  type CurrentFinalizedEvmCallRequestV1,
+} from './control-object-signature-verifier.js';
+
+// Package-internal strict data-only snapshot boundary shared by the
+// current-finalized router and the strict raw-RPC transport. One canonical
+// definition of "plain data record", "dense data-only array", "exact data-only
+// record", and the fixed current-finalized request profile, instead of
+// near-duplicate reflective validators drifting across feature modules. This
+// module is intentionally NOT re-exported from the package barrel (src/index.ts).
+
+const REQUEST_KEYS = Object.freeze([
+  'attemptTimeoutMs',
+  'ccipReadEnabled',
+  'chainId',
+  'data',
+  'endpointAttemptPolicy',
+  'from',
+  'gasLimit',
+  'maxAttempts',
+  'maxConcurrentCallsPerChain',
+  'maxReturnBytes',
+  'maxRpcResponseBytes',
+  'signal',
+  'to',
+  'totalDeadlineMs',
+] as const);
+const CANONICAL_NONZERO_EVM_ADDRESS = /^0x(?!0{40}$)[0-9a-f]{40}$/;
+
+export function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function isCanonicalArrayIndex(key: string, length: number): boolean {
+  if (!/^(?:0|[1-9][0-9]*)$/.test(key)) return false;
+  const index = Number(key);
+  return Number.isSafeInteger(index) && index >= 0 && index < length && String(index) === key;
+}
+
+/**
+ * Snapshot a dense, data-only ordinary array (own keys are exactly the indices
+ * 0..length-1 plus `length`, every element an enumerable data property). Any
+ * deviation — including a hostile length/index accessor that throws — fails
+ * closed with `invalidMessage`, letting callers keep their exact domain message
+ * while sharing one validator.
+ */
+export function snapshotDenseDataArray(
+  input: unknown,
+  invalidMessage: string,
+): readonly unknown[] {
+  try {
+    if (!Array.isArray(input)) throw new Error('not an array');
+    const lengthDescriptor = Object.getOwnPropertyDescriptor(input, 'length');
+    if (
+      lengthDescriptor === undefined
+      || !Object.prototype.hasOwnProperty.call(lengthDescriptor, 'value')
+      || typeof lengthDescriptor.value !== 'number'
+      || !Number.isSafeInteger(lengthDescriptor.value)
+      || lengthDescriptor.value < 0
+    ) {
+      throw new Error('invalid array length');
+    }
+
+    const length = lengthDescriptor.value;
+    const ownKeys = Reflect.ownKeys(input);
+    if (
+      ownKeys.length !== length + 1
+      || ownKeys.some((key) => (
+        typeof key !== 'string'
+        || (key !== 'length' && !isCanonicalArrayIndex(key, length))
+      ))
+    ) {
+      throw new Error('not a dense ordinary array');
+    }
+
+    const snapshot: unknown[] = [];
+    for (let index = 0; index < length; index += 1) {
+      const descriptor = Object.getOwnPropertyDescriptor(input, String(index));
+      if (
+        descriptor === undefined
+        || !descriptor.enumerable
+        || !Object.prototype.hasOwnProperty.call(descriptor, 'value')
+      ) {
+        throw new Error('entry must be an enumerable data property');
+      }
+      snapshot.push(descriptor.value);
+    }
+    return Object.freeze(snapshot);
+  } catch {
+    throw new TypeError(invalidMessage);
+  }
+}
+
+/**
+ * Snapshot a plain data-only record whose own string keys are EXACTLY
+ * `expectedKeys`, each an enumerable data property. Throws a plain Error on any
+ * deviation so callers can map it to their domain-specific disposition.
+ */
+export function snapshotExactDataRecord(
+  input: unknown,
+  expectedKeys: readonly string[],
+): Record<string, unknown> {
+  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
+    throw new Error('not a record');
+  }
+  const prototype = Object.getPrototypeOf(input);
+  if (prototype !== Object.prototype && prototype !== null) throw new Error('not plain');
+  const actualKeys = Reflect.ownKeys(input);
+  if (
+    actualKeys.some((key) => typeof key !== 'string')
+    || actualKeys.length !== expectedKeys.length
+    || (actualKeys as string[]).sort().some((key, index) => key !== expectedKeys[index])
+  ) {
+    throw new Error('unknown or missing fields');
+  }
+
+  const snapshot: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
+  for (const key of expectedKeys) {
+    const descriptor = Object.getOwnPropertyDescriptor(input, key);
+    if (
+      descriptor === undefined
+      || !descriptor.enumerable
+      || !Object.prototype.hasOwnProperty.call(descriptor, 'value')
+    ) {
+      throw new Error('fields must be enumerable data properties');
+    }
+    snapshot[key] = descriptor.value;
+  }
+  return snapshot;
+}
+
+function isAbortSignal(value: unknown): value is AbortSignal {
+  if (value === null || typeof value !== 'object') return false;
+  try {
+    const abortedGetter = Object.getOwnPropertyDescriptor(AbortSignal.prototype, 'aborted')?.get;
+    if (abortedGetter === undefined) return false;
+    abortedGetter.call(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function assertCanonicalEip1271CallData(data: string): void {
+  if (!/^0x[0-9a-f]+$/.test(data)) {
+    throw new Error('call data is not canonical lowercase hex');
+  }
+  const bytes = data.slice(2);
+  const selectorLength = 8;
+  const wordLength = 64;
+  const fixedLength = selectorLength + (wordLength * 3);
+  if (
+    bytes.slice(0, selectorLength) !== '1626ba7e'
+    || bytes.length < fixedLength
+    || bytes.slice(selectorLength + wordLength, selectorLength + (wordLength * 2))
+      !== `${'0'.repeat(62)}40`
+  ) {
+    throw new Error('call data is not canonical isValidSignature(bytes32,bytes) ABI');
+  }
+
+  const signatureLengthWord = bytes.slice(
+    selectorLength + (wordLength * 2),
+    fixedLength,
+  );
+  const signatureLength = BigInt(`0x${signatureLengthWord}`);
+  if (signatureLength < 1n || signatureLength > 4096n) {
+    throw new Error('EIP-1271 signature length is outside 1..4096 bytes');
+  }
+  const paddedSignatureHexLength = Math.ceil(Number(signatureLength) / 32) * wordLength;
+  const tail = bytes.slice(fixedLength);
+  if (tail.length !== paddedSignatureHexLength) {
+    throw new Error('EIP-1271 signature tail has noncanonical length');
+  }
+  const signatureHexLength = Number(signatureLength) * 2;
+  if (!/^0*$/.test(tail.slice(signatureHexLength))) {
+    throw new Error('EIP-1271 signature tail has nonzero ABI padding');
+  }
+}
+
+/** Package-internal strict snapshot shared by the router and raw transport. */
+export function snapshotCurrentFinalizedEvmCallRequestV1(
+  input: unknown,
+): CurrentFinalizedEvmCallRequestV1 {
+  try {
+    const record = snapshotExactDataRecord(input, REQUEST_KEYS);
+    assertCanonicalChainId(record.chainId, 'current-finalized request chainId');
+    if (
+      typeof record.to !== 'string'
+      || !CANONICAL_NONZERO_EVM_ADDRESS.test(record.to)
+    ) {
+      throw new Error('to is not a canonical nonzero EVM address');
+    }
+    if (record.from !== CONTROL_EIP1271_CALL_FROM_V1) throw new Error('wrong from');
+    if (typeof record.data !== 'string') throw new Error('call data is not a string');
+    assertCanonicalEip1271CallData(record.data);
+    if (record.gasLimit !== CONTROL_EIP1271_GAS_LIMIT_V1) throw new Error('wrong gas limit');
+    if (record.maxReturnBytes !== CONTROL_EIP1271_MAX_RETURN_BYTES_V1) {
+      throw new Error('wrong return cap');
+    }
+    if (record.maxRpcResponseBytes !== CONTROL_EIP1271_MAX_RPC_RESPONSE_BYTES_V1) {
+      throw new Error('wrong RPC response cap');
+    }
+    if (record.attemptTimeoutMs !== CONTROL_EIP1271_ATTEMPT_TIMEOUT_MS_V1) {
+      throw new Error('wrong attempt timeout');
+    }
+    if (record.maxAttempts !== CONTROL_EIP1271_MAX_ATTEMPTS_V1) {
+      throw new Error('wrong attempt count');
+    }
+    if (record.endpointAttemptPolicy !== CONTROL_EIP1271_ENDPOINT_ATTEMPT_POLICY_V1) {
+      throw new Error('wrong endpoint policy');
+    }
+    if (
+      record.maxConcurrentCallsPerChain
+      !== CONTROL_EIP1271_MAX_CONCURRENT_CALLS_PER_CHAIN_V1
+    ) {
+      throw new Error('wrong concurrency ceiling');
+    }
+    if (record.totalDeadlineMs !== CONTROL_EIP1271_TOTAL_DEADLINE_MS_V1) {
+      throw new Error('wrong total deadline');
+    }
+    if (record.ccipReadEnabled !== false) throw new Error('CCIP Read must be disabled');
+    if (!isAbortSignal(record.signal)) throw new Error('signal is not an AbortSignal');
+
+    return Object.freeze({
+      chainId: record.chainId,
+      to: record.to,
+      from: record.from,
+      data: record.data,
+      gasLimit: record.gasLimit,
+      maxReturnBytes: record.maxReturnBytes,
+      maxRpcResponseBytes: record.maxRpcResponseBytes,
+      attemptTimeoutMs: record.attemptTimeoutMs,
+      maxAttempts: record.maxAttempts,
+      endpointAttemptPolicy: record.endpointAttemptPolicy,
+      maxConcurrentCallsPerChain: record.maxConcurrentCallsPerChain,
+      totalDeadlineMs: record.totalDeadlineMs,
+      ccipReadEnabled: record.ccipReadEnabled,
+      signal: record.signal,
+    }) as CurrentFinalizedEvmCallRequestV1;
+  } catch {
+    throw new CurrentFinalizedEvmCallErrorV1(
+      'rpc-unavailable',
+      'Current-finalized EVM call request failed the fixed local profile',
+    );
+  }
+}

--- a/packages/chain/src/index.ts
+++ b/packages/chain/src/index.ts
@@ -35,6 +35,12 @@ export {
   type CurrentFinalizedEvmChainAdapterV1,
 } from './current-finalized-evm-call.js';
 export {
+  CURRENT_FINALIZED_EVM_BLOCK_REFERENCE_PROFILES_V1,
+  createStrictCurrentFinalizedEvmChainAdapterV1,
+  type CurrentFinalizedEvmBlockReferenceProfileV1,
+  type StrictCurrentFinalizedEvmRpcConfigV1,
+} from './strict-current-finalized-evm-rpc.js';
+export {
   resolveQuotedPublisherCandidatePricing,
   resolveLegacyPublisherCandidatePricing,
   type QuotedPublisherCandidatePricing,

--- a/packages/chain/src/strict-current-finalized-evm-rpc.ts
+++ b/packages/chain/src/strict-current-finalized-evm-rpc.ts
@@ -71,7 +71,6 @@ const MAX_U64 = 18_446_744_073_709_551_615n;
 const MAX_U256 =
   115_792_089_237_316_195_423_570_985_008_687_907_853_269_984_665_640_564_039_457_584_007_913_129_639_935n;
 const RPC_CALL_GAS_QUANTITY = `0x${CONTROL_EIP1271_GAS_LIMIT_V1.toString(16)}`;
-const ANCHOR_DEPENDENT_RESOURCE_LIMITS_V1 = new WeakSet<object>();
 
 /**
  * Build one strict raw-JSON-RPC adapter from trusted local chain configuration.
@@ -172,6 +171,36 @@ export function createStrictCurrentFinalizedEvmChainAdapterV1(
   return Object.freeze(adapter);
 }
 
+/**
+ * Result of a numbered-block contract read that is held across the post-read
+ * hash sandwich: either the decoded return, or an anchor-dependent failure that
+ * is only re-thrown once the sandwich confirms the finalized anchor.
+ */
+type NumberedContractOutcomeV1 =
+  | { readonly kind: 'return'; readonly data: string }
+  | { readonly kind: 'held-failure'; readonly error: CurrentFinalizedEvmCallErrorV1 };
+
+/**
+ * Numbered-block reads are anchor-dependent: `no-code`, `revert`,
+ * `malformed-return`, and an execution-cap `resource-limit` can all be
+ * manufactured by a reorg, so the fallback holds exactly these until the
+ * post-read hash sandwich confirms the anchor. A transport or local
+ * `resource-limit` is not anchor-dependent and must propagate immediately.
+ */
+function isAnchorDependentNumberedFailure(
+  cause: unknown,
+): cause is CurrentFinalizedEvmCallErrorV1 {
+  return (
+    cause instanceof CurrentFinalizedEvmCallErrorV1
+    && (
+      cause.code === 'no-code'
+      || cause.code === 'revert'
+      || cause.code === 'malformed-return'
+      || cause instanceof AnchorDependentResourceLimitErrorV1
+    )
+  );
+}
+
 async function executeEndpointAttempt(
   config: StrictRpcConfigSnapshotV1,
   endpoint: string,
@@ -220,32 +249,23 @@ async function executeEndpointAttempt(
     // same-endpoint post-read closes the hash sandwich. Hold anchor-dependent
     // outcomes until then, so a reorg cannot manufacture no-code/revert, a
     // malformed return, or an execution-cap failure and poison admission.
-    let anchorDependentFailure: CurrentFinalizedEvmCallErrorV1 | undefined;
-    let provisionalReturnData: string | undefined;
+    let numbered: NumberedContractOutcomeV1;
     try {
       const code = await rpc(
         'eth_getCode',
         Object.freeze([request.to, anchor.blockNumberQuantity]),
       );
       assertDeployedCode(code);
-      provisionalReturnData = parseContractReturn(
-        await rpc('eth_call', Object.freeze([callObject, anchor.blockNumberQuantity])),
-        request.maxReturnBytes,
-      );
+      numbered = {
+        kind: 'return',
+        data: parseContractReturn(
+          await rpc('eth_call', Object.freeze([callObject, anchor.blockNumberQuantity])),
+          request.maxReturnBytes,
+        ),
+      };
     } catch (cause) {
-      if (
-        cause instanceof CurrentFinalizedEvmCallErrorV1
-        && (
-          cause.code === 'no-code'
-          || cause.code === 'revert'
-          || cause.code === 'malformed-return'
-          || isAnchorDependentResourceLimit(cause)
-        )
-      ) {
-        anchorDependentFailure = cause;
-      } else {
-        throw cause;
-      }
+      if (!isAnchorDependentNumberedFailure(cause)) throw cause;
+      numbered = { kind: 'held-failure', error: cause };
     }
 
     const postAnchor = parseFinalizedAnchor(
@@ -261,11 +281,8 @@ async function executeEndpointAttempt(
         'Block-number fallback hash sandwich did not preserve the resolved finalized anchor',
       );
     }
-    if (anchorDependentFailure !== undefined) throw anchorDependentFailure;
-    if (provisionalReturnData === undefined) {
-      throw unavailable('Block-number fallback produced no contract result');
-    }
-    returnData = provisionalReturnData;
+    if (numbered.kind === 'held-failure') throw numbered.error;
+    returnData = numbered.data;
   }
 
   return Object.freeze({
@@ -708,17 +725,22 @@ function resourceLimited(message: string): CurrentFinalizedEvmCallErrorV1 {
   return new CurrentFinalizedEvmCallErrorV1('resource-limit', message);
 }
 
-function anchorDependentResourceLimited(message: string): CurrentFinalizedEvmCallErrorV1 {
-  const error = resourceLimited(message);
-  ANCHOR_DEPENDENT_RESOURCE_LIMITS_V1.add(error);
-  return error;
+/**
+ * A `resource-limit` produced by numbered-block `eth_call` execution (the fixed
+ * gas cap). Unlike a transport or local resource limit it is anchor-dependent,
+ * so the block-number fallback must hold it until the same-endpoint post-read
+ * confirms the finalized anchor did not reorg. Encoding this as a distinct error
+ * type keeps the classification on the error object itself rather than a global
+ * side-channel tag consulted far from where the error is produced.
+ */
+class AnchorDependentResourceLimitErrorV1 extends CurrentFinalizedEvmCallErrorV1 {
+  constructor(message: string) {
+    super('resource-limit', message);
+  }
 }
 
-function isAnchorDependentResourceLimit(
-  error: CurrentFinalizedEvmCallErrorV1,
-): boolean {
-  return error.code === 'resource-limit'
-    && ANCHOR_DEPENDENT_RESOURCE_LIMITS_V1.has(error);
+function anchorDependentResourceLimited(message: string): CurrentFinalizedEvmCallErrorV1 {
+  return new AnchorDependentResourceLimitErrorV1(message);
 }
 
 function cancelled(message: string): CurrentFinalizedEvmCallErrorV1 {

--- a/packages/chain/src/strict-current-finalized-evm-rpc.ts
+++ b/packages/chain/src/strict-current-finalized-evm-rpc.ts
@@ -477,6 +477,18 @@ function classifyJsonRpcError(
   error: RpcErrorEnvelopeV1,
 ): CurrentFinalizedEvmCallErrorV1 {
   const message = error.message.toLowerCase();
+  // Explicit revert evidence is deterministic even when a gateway decorates
+  // the message with gas-related text (for example, code 3 plus
+  // "execution reverted: out of gas"). A fixed-cap exhaustion that did not
+  // execute a REVERT remains a resource refusal below, but a proven REVERT
+  // must win so callers cannot misclassify invalid EIP-1271 evidence as merely
+  // unsupported.
+  if (method === 'eth_call' && (error.code === 3 || message.includes('revert'))) {
+    return new CurrentFinalizedEvmCallErrorV1(
+      'revert',
+      'EIP-1271 contract call reverted at the resolved finalized anchor',
+    );
+  }
   if (
     method === 'eth_call'
     && (
@@ -489,12 +501,6 @@ function classifyJsonRpcError(
   ) {
     return anchorDependentResourceLimited(
       'EIP-1271 execution could not complete within the fixed gas cap',
-    );
-  }
-  if (method === 'eth_call' && (error.code === 3 || message.includes('revert'))) {
-    return new CurrentFinalizedEvmCallErrorV1(
-      'revert',
-      'EIP-1271 contract call reverted at the resolved finalized anchor',
     );
   }
   if (message.includes('timeout') || message.includes('timed out')) {

--- a/packages/chain/src/strict-current-finalized-evm-rpc.ts
+++ b/packages/chain/src/strict-current-finalized-evm-rpc.ts
@@ -1,0 +1,720 @@
+import {
+  assertCanonicalChainId,
+  type BlockNumberV1,
+  type ChainIdV1,
+  type Digest32V1,
+} from '@origintrail-official/dkg-core';
+
+import {
+  CONTROL_EIP1271_ATTEMPT_TIMEOUT_MS_V1,
+  CONTROL_EIP1271_GAS_LIMIT_V1,
+  CONTROL_EIP1271_MAX_ATTEMPTS_V1,
+  CONTROL_EIP1271_TOTAL_DEADLINE_MS_V1,
+  CurrentFinalizedEvmCallErrorV1,
+  type CurrentFinalizedEvmCallRequestV1,
+  type CurrentFinalizedEvmCallResultV1,
+} from './control-object-signature-verifier.js';
+import {
+  snapshotCurrentFinalizedEvmCallRequestV1,
+  type CurrentFinalizedEvmChainAdapterV1,
+} from './current-finalized-evm-call.js';
+
+export const CURRENT_FINALIZED_EVM_BLOCK_REFERENCE_PROFILES_V1 = Object.freeze([
+  'eip1898',
+  'trusted-block-number-hash-sandwich',
+] as const);
+
+export type CurrentFinalizedEvmBlockReferenceProfileV1 =
+  (typeof CURRENT_FINALIZED_EVM_BLOCK_REFERENCE_PROFILES_V1)[number];
+
+export interface StrictCurrentFinalizedEvmRpcConfigV1 {
+  /** Canonical decimal chain ID permanently bound to this adapter. */
+  readonly chainId: ChainIdV1;
+  /** Trusted local configuration, in canonical failover order. */
+  readonly endpoints: readonly string[];
+  /**
+   * EIP-1898 is the default. The number/hash sandwich is an explicit trusted
+   * chain profile for deployments whose RPC endpoints cannot execute EIP-1898.
+   */
+  readonly blockReferenceProfile?: CurrentFinalizedEvmBlockReferenceProfileV1;
+}
+
+interface StrictRpcConfigSnapshotV1 {
+  readonly chainId: ChainIdV1;
+  readonly endpoints: readonly string[];
+  readonly blockReferenceProfile: CurrentFinalizedEvmBlockReferenceProfileV1;
+}
+
+interface FinalizedAnchorV1 {
+  readonly blockNumber: BlockNumberV1;
+  readonly blockNumberQuantity: string;
+  readonly blockHash: Digest32V1;
+}
+
+interface DeadlineScope {
+  readonly signal: AbortSignal;
+  readonly timedOut: () => boolean;
+  readonly close: () => void;
+}
+
+interface RpcErrorEnvelopeV1 {
+  readonly code: number;
+  readonly message: string;
+}
+
+const CONFIG_REQUIRED_KEYS = Object.freeze(['chainId', 'endpoints'] as const);
+const CONFIG_OPTIONAL_KEYS = Object.freeze(['blockReferenceProfile'] as const);
+const CANONICAL_LOWER_HEX_BYTES = /^0x(?:[0-9a-f]{2})*$/;
+const CANONICAL_LOWER_QUANTITY = /^0x(?:0|[1-9a-f][0-9a-f]*)$/;
+const CANONICAL_DIGEST_32 = /^0x[0-9a-f]{64}$/;
+const MAX_U64 = 18_446_744_073_709_551_615n;
+const MAX_U256 =
+  115_792_089_237_316_195_423_570_985_008_687_907_853_269_984_665_640_564_039_457_584_007_913_129_639_935n;
+const RPC_CALL_GAS_QUANTITY = `0x${CONTROL_EIP1271_GAS_LIMIT_V1.toString(16)}`;
+const ANCHOR_DEPENDENT_RESOURCE_LIMITS_V1 = new WeakSet<object>();
+
+/**
+ * Build one strict raw-JSON-RPC adapter from trusted local chain configuration.
+ *
+ * This transport intentionally bypasses JsonRpcProvider, RpcFailoverClient,
+ * and generic timeout wrappers: native fetch gives this lane a streamed
+ * pre-parse body cap and an AbortSignal that cancels the actual HTTP I/O. POST
+ * requests are never retried, redirected, reordered, or made sticky.
+ */
+export function createStrictCurrentFinalizedEvmChainAdapterV1(
+  input: StrictCurrentFinalizedEvmRpcConfigV1,
+): CurrentFinalizedEvmChainAdapterV1 {
+  const config = snapshotConfig(input);
+
+  const adapter: CurrentFinalizedEvmChainAdapterV1 = async (inputRequest) => {
+    const request = snapshotCurrentFinalizedEvmCallRequestV1(inputRequest);
+    if (request.chainId !== config.chainId) {
+      throw new CurrentFinalizedEvmCallErrorV1(
+        'chain-mismatch',
+        `Adapter is configured for chain ${config.chainId}, not ${request.chainId}`,
+      );
+    }
+    if (request.signal.aborted) {
+      throw cancelled('Current-finalized EVM call was cancelled before transport admission');
+    }
+
+    const totalDeadline = createDeadlineScope(
+      request.signal,
+      request.totalDeadlineMs,
+      'current-finalized total deadline',
+    );
+    let lastRetryableFailure: CurrentFinalizedEvmCallErrorV1 | undefined;
+
+    try {
+      for (let index = 0; index < config.endpoints.length; index += 1) {
+        if (request.signal.aborted) {
+          throw cancelled('Current-finalized EVM call was cancelled');
+        }
+        if (totalDeadline.timedOut()) {
+          throw timedOut(`Current-finalized total deadline exceeded ${request.totalDeadlineMs}ms`);
+        }
+
+        const attemptDeadline = createDeadlineScope(
+          totalDeadline.signal,
+          request.attemptTimeoutMs,
+          `current-finalized endpoint attempt ${index + 1}`,
+        );
+        try {
+          const result = await executeEndpointAttempt(
+            config,
+            config.endpoints[index]!,
+            request,
+            attemptDeadline.signal,
+          );
+          // Close races where transport completion and abort/deadline become
+          // observable in the same turn. A late response never escapes merely
+          // because its promise callback ran before the timer callback.
+          if (request.signal.aborted) {
+            throw cancelled('Current-finalized EVM call was cancelled');
+          }
+          if (totalDeadline.timedOut()) {
+            throw timedOut(
+              `Current-finalized total deadline exceeded ${request.totalDeadlineMs}ms`,
+            );
+          }
+          if (attemptDeadline.timedOut()) {
+            throw timedOut(
+              `Current-finalized endpoint attempt exceeded ${request.attemptTimeoutMs}ms`,
+            );
+          }
+          return result;
+        } catch (cause) {
+          const failure = classifyAttemptFailure(
+            cause,
+            request.signal,
+            totalDeadline,
+            attemptDeadline,
+          );
+          if (isTerminalAttemptFailure(failure)) throw failure;
+          lastRetryableFailure = failure;
+        } finally {
+          attemptDeadline.close();
+        }
+      }
+
+      if (request.signal.aborted) {
+        throw cancelled('Current-finalized EVM call was cancelled');
+      }
+      if (totalDeadline.timedOut()) {
+        throw timedOut(`Current-finalized total deadline exceeded ${request.totalDeadlineMs}ms`);
+      }
+      throw lastRetryableFailure ?? unavailable('No configured current-finalized endpoint succeeded');
+    } finally {
+      totalDeadline.close();
+    }
+  };
+
+  return Object.freeze(adapter);
+}
+
+async function executeEndpointAttempt(
+  config: StrictRpcConfigSnapshotV1,
+  endpoint: string,
+  request: CurrentFinalizedEvmCallRequestV1,
+  signal: AbortSignal,
+): Promise<CurrentFinalizedEvmCallResultV1> {
+  let requestId = 0;
+  const rpc = async (method: string, params: readonly unknown[]): Promise<unknown> => {
+    requestId += 1;
+    return postJsonRpc(endpoint, requestId, method, params, request.maxRpcResponseBytes, signal);
+  };
+
+  const remoteChainId = parseChainId(await rpc('eth_chainId', Object.freeze([])));
+  if (remoteChainId !== config.chainId) {
+    throw new CurrentFinalizedEvmCallErrorV1(
+      'chain-mismatch',
+      `Configured endpoint attempt reported chain ${remoteChainId}, expected ${config.chainId}`,
+    );
+  }
+
+  const anchor = parseFinalizedAnchor(
+    await rpc('eth_getBlockByNumber', Object.freeze(['finalized', false])),
+    'current finalized header',
+  );
+  const callObject = Object.freeze({
+    from: request.from,
+    to: request.to,
+    data: request.data,
+    gas: RPC_CALL_GAS_QUANTITY,
+  });
+
+  let returnData: string;
+  if (config.blockReferenceProfile === 'eip1898') {
+    const blockReference = Object.freeze({
+      blockHash: anchor.blockHash,
+      requireCanonical: true as const,
+    });
+    const code = await rpc('eth_getCode', Object.freeze([request.to, blockReference]));
+    assertDeployedCode(code);
+    returnData = parseContractReturn(
+      await rpc('eth_call', Object.freeze([callObject, blockReference])),
+      request.maxReturnBytes,
+    );
+  } else {
+    // Number-selected code/call evidence is not deterministic until the
+    // same-endpoint post-read closes the hash sandwich. Hold anchor-dependent
+    // outcomes until then, so a reorg cannot manufacture no-code/revert, a
+    // malformed return, or an execution-cap failure and poison admission.
+    let anchorDependentFailure: CurrentFinalizedEvmCallErrorV1 | undefined;
+    let provisionalReturnData: string | undefined;
+    try {
+      const code = await rpc(
+        'eth_getCode',
+        Object.freeze([request.to, anchor.blockNumberQuantity]),
+      );
+      assertDeployedCode(code);
+      provisionalReturnData = parseContractReturn(
+        await rpc('eth_call', Object.freeze([callObject, anchor.blockNumberQuantity])),
+        request.maxReturnBytes,
+      );
+    } catch (cause) {
+      if (
+        cause instanceof CurrentFinalizedEvmCallErrorV1
+        && (
+          cause.code === 'no-code'
+          || cause.code === 'revert'
+          || cause.code === 'malformed-return'
+          || isAnchorDependentResourceLimit(cause)
+        )
+      ) {
+        anchorDependentFailure = cause;
+      } else {
+        throw cause;
+      }
+    }
+
+    const postAnchor = parseFinalizedAnchor(
+      await rpc('eth_getBlockByNumber', Object.freeze([anchor.blockNumberQuantity, false])),
+      'post-call numbered header',
+    );
+    if (
+      postAnchor.blockNumber !== anchor.blockNumber
+      || postAnchor.blockHash !== anchor.blockHash
+    ) {
+      throw new CurrentFinalizedEvmCallErrorV1(
+        'finalized-state-unavailable',
+        'Block-number fallback hash sandwich did not preserve the resolved finalized anchor',
+      );
+    }
+    if (anchorDependentFailure !== undefined) throw anchorDependentFailure;
+    if (provisionalReturnData === undefined) {
+      throw unavailable('Block-number fallback produced no contract result');
+    }
+    returnData = provisionalReturnData;
+  }
+
+  return Object.freeze({
+    chainId: config.chainId,
+    blockNumber: anchor.blockNumber,
+    blockHash: anchor.blockHash,
+    returnData,
+  });
+}
+
+async function postJsonRpc(
+  endpoint: string,
+  id: number,
+  method: string,
+  params: readonly unknown[],
+  maxResponseBytes: number,
+  signal: AbortSignal,
+): Promise<unknown> {
+  let response: Response;
+  try {
+    response = await fetch(endpoint, {
+      method: 'POST',
+      headers: Object.freeze({
+        accept: 'application/json',
+        'content-type': 'application/json',
+      }),
+      body: JSON.stringify({ jsonrpc: '2.0', id, method, params }),
+      redirect: 'error',
+      signal,
+    });
+  } catch (cause) {
+    if (signal.aborted) throw cause;
+    throw unavailable(`JSON-RPC ${method} transport failed`, cause);
+  }
+
+  const body = await readResponseBodyBounded(response, maxResponseBytes);
+  if (!response.ok) {
+    // An HTTP intermediary/provider failure is transport availability, even if
+    // its untrusted body happens to mimic a deterministic JSON-RPC revert. Only
+    // a successful JSON-RPC transport response may select an invalidity code.
+    throw unavailable(`JSON-RPC ${method} returned HTTP ${response.status}`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body) as unknown;
+  } catch (cause) {
+    throw unavailable(`JSON-RPC ${method} returned malformed JSON`, cause);
+  }
+  if (!isPlainRecord(parsed) || parsed.jsonrpc !== '2.0' || parsed.id !== id) {
+    throw unavailable(`JSON-RPC ${method} returned a mismatched response envelope`);
+  }
+  const hasResult = Object.prototype.hasOwnProperty.call(parsed, 'result');
+  const hasError = Object.prototype.hasOwnProperty.call(parsed, 'error');
+  if (hasResult === hasError) {
+    throw unavailable(`JSON-RPC ${method} response must contain exactly one of result or error`);
+  }
+  if (hasError) {
+    const error = parseRpcError(parsed.error);
+    if (error === undefined) throw unavailable(`JSON-RPC ${method} returned a malformed error`);
+    throw classifyJsonRpcError(method, error);
+  }
+  return parsed.result;
+}
+
+async function readResponseBodyBounded(response: Response, maxBytes: number): Promise<string> {
+  const contentLength = response.headers.get('content-length');
+  if (contentLength !== null && /^\d+$/.test(contentLength)) {
+    const declared = BigInt(contentLength);
+    if (declared > BigInt(maxBytes)) {
+      await response.body?.cancel().catch(() => undefined);
+      throw resourceLimited(
+        `Raw JSON-RPC response declared ${declared.toString()} bytes, limit ${maxBytes}`,
+      );
+    }
+  }
+
+  if (response.body === null) return '';
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > maxBytes) {
+        await reader.cancel().catch(() => undefined);
+        throw resourceLimited(`Raw JSON-RPC response exceeded ${maxBytes} bytes before parsing`);
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  try {
+    return new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+  } catch (cause) {
+    throw unavailable('JSON-RPC response body is not valid UTF-8', cause);
+  }
+}
+
+function parseChainId(input: unknown): ChainIdV1 {
+  let parsed: bigint;
+  try {
+    parsed = parseCanonicalQuantity(input, MAX_U256);
+  } catch (cause) {
+    throw unavailable('eth_chainId returned a malformed chain ID', cause);
+  }
+  return parsed.toString(10) as ChainIdV1;
+}
+
+function parseFinalizedAnchor(input: unknown, label: string): FinalizedAnchorV1 {
+  if (input === null) {
+    throw new CurrentFinalizedEvmCallErrorV1(
+      'finalized-state-unavailable',
+      `${label} is unavailable`,
+    );
+  }
+  if (!isPlainRecord(input)) {
+    throw new CurrentFinalizedEvmCallErrorV1(
+      'finalized-state-unavailable',
+      `${label} is malformed`,
+    );
+  }
+
+  let blockNumber: bigint;
+  try {
+    blockNumber = parseCanonicalQuantity(input.number, MAX_U64);
+  } catch (cause) {
+    throw new CurrentFinalizedEvmCallErrorV1(
+      'finalized-state-unavailable',
+      `${label} has a malformed block number`,
+      { cause },
+    );
+  }
+  if (typeof input.hash !== 'string' || !CANONICAL_DIGEST_32.test(input.hash)) {
+    throw new CurrentFinalizedEvmCallErrorV1(
+      'finalized-state-unavailable',
+      `${label} has a malformed block hash`,
+    );
+  }
+  return Object.freeze({
+    blockNumber: blockNumber.toString(10) as BlockNumberV1,
+    blockNumberQuantity: input.number as string,
+    blockHash: input.hash as Digest32V1,
+  });
+}
+
+function assertDeployedCode(input: unknown): void {
+  if (typeof input !== 'string' || !CANONICAL_LOWER_HEX_BYTES.test(input)) {
+    throw unavailable('eth_getCode returned malformed code bytes');
+  }
+  if (input === '0x') {
+    throw new CurrentFinalizedEvmCallErrorV1(
+      'no-code',
+      'EIP-1271 issuer has no deployed code at the resolved finalized anchor',
+    );
+  }
+}
+
+function parseContractReturn(input: unknown, maxBytes: number): string {
+  if (typeof input !== 'string' || !CANONICAL_LOWER_HEX_BYTES.test(input)) {
+    throw new CurrentFinalizedEvmCallErrorV1(
+      'malformed-return',
+      'EIP-1271 eth_call returned malformed bytes',
+    );
+  }
+  const byteLength = (input.length - 2) / 2;
+  if (byteLength > maxBytes || byteLength !== 32) {
+    throw new CurrentFinalizedEvmCallErrorV1(
+      'malformed-return',
+      `EIP-1271 eth_call returned ${byteLength} bytes; exactly 32 are required`,
+    );
+  }
+  return input;
+}
+
+function parseCanonicalQuantity(input: unknown, maximum: bigint): bigint {
+  if (typeof input !== 'string' || !CANONICAL_LOWER_QUANTITY.test(input)) {
+    throw new Error('not a canonical lowercase JSON-RPC quantity');
+  }
+  const parsed = BigInt(input);
+  if (parsed > maximum) throw new Error('JSON-RPC quantity is out of range');
+  return parsed;
+}
+
+function parseRpcError(input: unknown): RpcErrorEnvelopeV1 | undefined {
+  if (
+    !isPlainRecord(input)
+    || typeof input.code !== 'number'
+    || !Number.isSafeInteger(input.code)
+    || typeof input.message !== 'string'
+  ) {
+    return undefined;
+  }
+  return Object.freeze({ code: input.code, message: input.message });
+}
+
+function classifyJsonRpcError(
+  method: string,
+  error: RpcErrorEnvelopeV1,
+): CurrentFinalizedEvmCallErrorV1 {
+  const message = error.message.toLowerCase();
+  if (
+    method === 'eth_call'
+    && (
+      message.includes('out of gas')
+      || message.includes('gas limit')
+      || message.includes('gas required')
+      || message.includes('exceeds allowance')
+      || message.includes('intrinsic gas')
+    )
+  ) {
+    return anchorDependentResourceLimited(
+      'EIP-1271 execution could not complete within the fixed gas cap',
+    );
+  }
+  if (method === 'eth_call' && (error.code === 3 || message.includes('revert'))) {
+    return new CurrentFinalizedEvmCallErrorV1(
+      'revert',
+      'EIP-1271 contract call reverted at the resolved finalized anchor',
+    );
+  }
+  if (message.includes('timeout') || message.includes('timed out')) {
+    return timedOut(`JSON-RPC ${method} timed out`);
+  }
+  if (
+    method === 'eth_getBlockByNumber'
+    || message.includes('header not found')
+    || message.includes('unknown block')
+    || message.includes('block not found')
+    || message.includes('canonical')
+  ) {
+    return new CurrentFinalizedEvmCallErrorV1(
+      'finalized-state-unavailable',
+      `JSON-RPC ${method} could not prove the required finalized anchor`,
+    );
+  }
+  return unavailable(`JSON-RPC ${method} failed with code ${error.code}`);
+}
+
+function classifyAttemptFailure(
+  cause: unknown,
+  callerSignal: AbortSignal,
+  totalDeadline: DeadlineScope,
+  attemptDeadline: DeadlineScope,
+): CurrentFinalizedEvmCallErrorV1 {
+  if (callerSignal.aborted) return cancelled('Current-finalized EVM call was cancelled');
+  if (totalDeadline.timedOut()) {
+    return timedOut(`Current-finalized total deadline exceeded ${CONTROL_EIP1271_TOTAL_DEADLINE_MS_V1}ms`);
+  }
+  if (attemptDeadline.timedOut()) {
+    return timedOut(`Current-finalized endpoint attempt exceeded ${CONTROL_EIP1271_ATTEMPT_TIMEOUT_MS_V1}ms`);
+  }
+  if (cause instanceof CurrentFinalizedEvmCallErrorV1) return cause;
+  return unavailable('Current-finalized endpoint attempt failed closed', cause);
+}
+
+function isTerminalAttemptFailure(error: CurrentFinalizedEvmCallErrorV1): boolean {
+  return error.code === 'unsupported-chain'
+    || error.code === 'resource-limit'
+    || error.code === 'revert'
+    || error.code === 'no-code'
+    || error.code === 'malformed-return';
+}
+
+function createDeadlineScope(
+  parent: AbortSignal,
+  timeoutMs: number,
+  label: string,
+): DeadlineScope {
+  const controller = new AbortController();
+  let didTimeOut = false;
+  const expiresAt = performance.now() + timeoutMs;
+  const parentAbort = (): void => controller.abort(parent.reason);
+  if (parent.aborted) parentAbort();
+  else parent.addEventListener('abort', parentAbort, { once: true });
+  const timer = setTimeout(() => {
+    didTimeOut = true;
+    controller.abort(new Error(`${label} exceeded ${timeoutMs}ms`));
+  }, timeoutMs);
+  timer.unref?.();
+  return Object.freeze({
+    signal: controller.signal,
+    timedOut: () => didTimeOut || performance.now() >= expiresAt,
+    close: () => {
+      clearTimeout(timer);
+      parent.removeEventListener('abort', parentAbort);
+    },
+  });
+}
+
+function snapshotConfig(input: StrictCurrentFinalizedEvmRpcConfigV1): StrictRpcConfigSnapshotV1 {
+  if (!isPlainRecord(input)) {
+    throw new TypeError('Strict current-finalized RPC config must be a plain data record');
+  }
+  assertConfigDataProperties(input);
+  try {
+    assertCanonicalChainId(input.chainId, 'strict current-finalized chainId');
+  } catch {
+    throw new TypeError('Strict current-finalized chainId must be canonical decimal u256');
+  }
+
+  const endpoints = snapshotNormalizedEndpoints(input.endpoints);
+  const blockReferenceProfile = input.blockReferenceProfile ?? 'eip1898';
+  if (!CURRENT_FINALIZED_EVM_BLOCK_REFERENCE_PROFILES_V1.includes(blockReferenceProfile)) {
+    throw new TypeError('Unsupported strict current-finalized block reference profile');
+  }
+  return Object.freeze({
+    chainId: input.chainId,
+    endpoints,
+    blockReferenceProfile,
+  });
+}
+
+function assertConfigDataProperties(input: Record<string, unknown>): void {
+  const keys = Reflect.ownKeys(input);
+  if (keys.some((key) => typeof key !== 'string')) {
+    throw new TypeError('Strict current-finalized RPC config cannot contain symbol keys');
+  }
+  const allowed = new Set<string>([...CONFIG_REQUIRED_KEYS, ...CONFIG_OPTIONAL_KEYS]);
+  if (
+    !CONFIG_REQUIRED_KEYS.every((key) => keys.includes(key))
+    || (keys as string[]).some((key) => !allowed.has(key))
+  ) {
+    throw new TypeError('Strict current-finalized RPC config has unknown or missing fields');
+  }
+  for (const key of keys as string[]) {
+    const descriptor = Object.getOwnPropertyDescriptor(input, key);
+    if (!descriptor?.enumerable || !Object.prototype.hasOwnProperty.call(descriptor, 'value')) {
+      throw new TypeError('Strict current-finalized RPC config fields must be enumerable data properties');
+    }
+  }
+}
+
+function snapshotNormalizedEndpoints(input: unknown): readonly string[] {
+  const normalized: string[] = [];
+  try {
+    if (!Array.isArray(input)) throw new Error('not an array');
+    const lengthDescriptor = Object.getOwnPropertyDescriptor(input, 'length');
+    if (
+      lengthDescriptor === undefined
+      || !Object.prototype.hasOwnProperty.call(lengthDescriptor, 'value')
+      || typeof lengthDescriptor.value !== 'number'
+      || !Number.isSafeInteger(lengthDescriptor.value)
+      || lengthDescriptor.value < 0
+    ) {
+      throw new Error('invalid length');
+    }
+    const length = lengthDescriptor.value;
+    const ownKeys = Reflect.ownKeys(input);
+    if (
+      ownKeys.length !== length + 1
+      || ownKeys.some((key) => (
+        typeof key !== 'string'
+        || (key !== 'length' && !isCanonicalArrayIndex(key, length))
+      ))
+    ) {
+      throw new Error('not a dense ordinary array');
+    }
+    for (let index = 0; index < length; index += 1) {
+      const descriptor = Object.getOwnPropertyDescriptor(input, String(index));
+      if (!descriptor?.enumerable || !Object.prototype.hasOwnProperty.call(descriptor, 'value')) {
+        throw new Error('entry is not a data property');
+      }
+      const endpoint = normalizeEndpoint(descriptor.value);
+      if (!normalized.includes(endpoint)) normalized.push(endpoint);
+    }
+  } catch (cause) {
+    if (cause instanceof TypeError) throw cause;
+    throw new TypeError('Strict current-finalized endpoints must be a dense data-only array');
+  }
+  if (normalized.length === 0 || normalized.length > CONTROL_EIP1271_MAX_ATTEMPTS_V1) {
+    throw new TypeError(
+      `Strict current-finalized RPC requires 1..${CONTROL_EIP1271_MAX_ATTEMPTS_V1} distinct endpoints`,
+    );
+  }
+  return Object.freeze(normalized);
+}
+
+function isCanonicalArrayIndex(key: string, length: number): boolean {
+  if (!/^(?:0|[1-9][0-9]*)$/.test(key)) return false;
+  const index = Number(key);
+  return Number.isSafeInteger(index) && index >= 0 && index < length && String(index) === key;
+}
+
+function normalizeEndpoint(input: unknown): string {
+  if (typeof input !== 'string' || input.trim() === '') {
+    throw new TypeError('Strict current-finalized RPC endpoint must be a nonempty URL string');
+  }
+  let url: URL;
+  try {
+    url = new URL(input.trim());
+  } catch {
+    throw new TypeError('Strict current-finalized RPC endpoint must be an absolute URL');
+  }
+  if ((url.protocol !== 'http:' && url.protocol !== 'https:') || url.hash !== '') {
+    throw new TypeError('Strict current-finalized RPC endpoint must use HTTP(S) without a fragment');
+  }
+  return url.href;
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function unavailable(message: string, cause?: unknown): CurrentFinalizedEvmCallErrorV1 {
+  return new CurrentFinalizedEvmCallErrorV1(
+    'rpc-unavailable',
+    message,
+    cause === undefined ? undefined : { cause },
+  );
+}
+
+function timedOut(message: string): CurrentFinalizedEvmCallErrorV1 {
+  return new CurrentFinalizedEvmCallErrorV1('rpc-timeout', message);
+}
+
+function resourceLimited(message: string): CurrentFinalizedEvmCallErrorV1 {
+  return new CurrentFinalizedEvmCallErrorV1('resource-limit', message);
+}
+
+function anchorDependentResourceLimited(message: string): CurrentFinalizedEvmCallErrorV1 {
+  const error = resourceLimited(message);
+  ANCHOR_DEPENDENT_RESOURCE_LIMITS_V1.add(error);
+  return error;
+}
+
+function isAnchorDependentResourceLimit(
+  error: CurrentFinalizedEvmCallErrorV1,
+): boolean {
+  return error.code === 'resource-limit'
+    && ANCHOR_DEPENDENT_RESOURCE_LIMITS_V1.has(error);
+}
+
+function cancelled(message: string): CurrentFinalizedEvmCallErrorV1 {
+  // Caller intent is authenticated by the verifier-owned AbortSignal. Keep
+  // the adapter error retryable so a foreign gateway cannot forge a cancelled
+  // disposition merely by throwing a public error code; the verifier observes
+  // its caller signal first and maps this exact path to `cancelled`.
+  return new CurrentFinalizedEvmCallErrorV1('rpc-unavailable', message);
+}

--- a/packages/chain/src/strict-current-finalized-evm-rpc.ts
+++ b/packages/chain/src/strict-current-finalized-evm-rpc.ts
@@ -14,10 +14,12 @@ import {
   type CurrentFinalizedEvmCallRequestV1,
   type CurrentFinalizedEvmCallResultV1,
 } from './control-object-signature-verifier.js';
+import type { CurrentFinalizedEvmChainAdapterV1 } from './current-finalized-evm-call.js';
 import {
+  isPlainRecord,
   snapshotCurrentFinalizedEvmCallRequestV1,
-  type CurrentFinalizedEvmChainAdapterV1,
-} from './current-finalized-evm-call.js';
+  snapshotDenseDataArray,
+} from './current-finalized-strict-snapshot.js';
 
 export const CURRENT_FINALIZED_EVM_BLOCK_REFERENCE_PROFILES_V1 = Object.freeze([
   'eip1898',
@@ -637,41 +639,19 @@ function assertConfigDataProperties(input: Record<string, unknown>): void {
 }
 
 function snapshotNormalizedEndpoints(input: unknown): readonly string[] {
+  // Structural validation (dense data-only array) is shared with the router via
+  // snapshotDenseDataArray; endpoint normalization and the distinct-count policy
+  // stay local to this transport. A structurally invalid array fails closed with
+  // the endpoints message; a malformed endpoint string throws normalizeEndpoint's
+  // own TypeError, exactly as before.
+  const values = snapshotDenseDataArray(
+    input,
+    'Strict current-finalized endpoints must be a dense data-only array',
+  );
   const normalized: string[] = [];
-  try {
-    if (!Array.isArray(input)) throw new Error('not an array');
-    const lengthDescriptor = Object.getOwnPropertyDescriptor(input, 'length');
-    if (
-      lengthDescriptor === undefined
-      || !Object.prototype.hasOwnProperty.call(lengthDescriptor, 'value')
-      || typeof lengthDescriptor.value !== 'number'
-      || !Number.isSafeInteger(lengthDescriptor.value)
-      || lengthDescriptor.value < 0
-    ) {
-      throw new Error('invalid length');
-    }
-    const length = lengthDescriptor.value;
-    const ownKeys = Reflect.ownKeys(input);
-    if (
-      ownKeys.length !== length + 1
-      || ownKeys.some((key) => (
-        typeof key !== 'string'
-        || (key !== 'length' && !isCanonicalArrayIndex(key, length))
-      ))
-    ) {
-      throw new Error('not a dense ordinary array');
-    }
-    for (let index = 0; index < length; index += 1) {
-      const descriptor = Object.getOwnPropertyDescriptor(input, String(index));
-      if (!descriptor?.enumerable || !Object.prototype.hasOwnProperty.call(descriptor, 'value')) {
-        throw new Error('entry is not a data property');
-      }
-      const endpoint = normalizeEndpoint(descriptor.value);
-      if (!normalized.includes(endpoint)) normalized.push(endpoint);
-    }
-  } catch (cause) {
-    if (cause instanceof TypeError) throw cause;
-    throw new TypeError('Strict current-finalized endpoints must be a dense data-only array');
+  for (const value of values) {
+    const endpoint = normalizeEndpoint(value);
+    if (!normalized.includes(endpoint)) normalized.push(endpoint);
   }
   if (normalized.length === 0 || normalized.length > CONTROL_EIP1271_MAX_ATTEMPTS_V1) {
     throw new TypeError(
@@ -679,12 +659,6 @@ function snapshotNormalizedEndpoints(input: unknown): readonly string[] {
     );
   }
   return Object.freeze(normalized);
-}
-
-function isCanonicalArrayIndex(key: string, length: number): boolean {
-  if (!/^(?:0|[1-9][0-9]*)$/.test(key)) return false;
-  const index = Number(key);
-  return Number.isSafeInteger(index) && index >= 0 && index < length && String(index) === key;
 }
 
 function normalizeEndpoint(input: unknown): string {
@@ -701,12 +675,6 @@ function normalizeEndpoint(input: unknown): string {
     throw new TypeError('Strict current-finalized RPC endpoint must use HTTP(S) without a fragment');
   }
   return url.href;
-}
-
-function isPlainRecord(value: unknown): value is Record<string, unknown> {
-  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
-  const prototype = Object.getPrototypeOf(value);
-  return prototype === Object.prototype || prototype === null;
 }
 
 function unavailable(message: string, cause?: unknown): CurrentFinalizedEvmCallErrorV1 {

--- a/packages/chain/src/strict-current-finalized-evm-rpc.ts
+++ b/packages/chain/src/strict-current-finalized-evm-rpc.ts
@@ -301,14 +301,18 @@ async function postJsonRpc(
     throw unavailable(`JSON-RPC ${method} transport failed`, cause);
   }
 
-  const body = await readResponseBodyBounded(response, maxResponseBytes);
   if (!response.ok) {
     // An HTTP intermediary/provider failure is transport availability, even if
     // its untrusted body happens to mimic a deterministic JSON-RPC revert. Only
     // a successful JSON-RPC transport response may select an invalidity code.
+    // Discard the untrusted error body without reading it through the bounded
+    // cap: a large 5xx HTML page must stay `rpc-unavailable` (failover-eligible)
+    // rather than becoming a terminal `resource-limit` that halts the loop.
+    await response.body?.cancel().catch(() => undefined);
     throw unavailable(`JSON-RPC ${method} returned HTTP ${response.status}`);
   }
 
+  const body = await readResponseBodyBounded(response, maxResponseBytes);
   let parsed: unknown;
   try {
     parsed = JSON.parse(body) as unknown;

--- a/packages/chain/test/rfc64-strict-rpc-public-api.typecheck.ts
+++ b/packages/chain/test/rfc64-strict-rpc-public-api.typecheck.ts
@@ -1,0 +1,43 @@
+// Compile-time proof that the strict finalized RPC public API — both values and
+// types — is reachable through the package barrel `src/index.ts`. This runs via
+// `pnpm --filter @origintrail-official/dkg-chain run test:types`, which is wired
+// into `build`. vitest alone cannot protect the type re-exports: type-only
+// imports and annotations are erased before runtime, so a Vitest assertion still
+// passes after a type export is dropped. `tsc` over this file does not.
+//
+// Removing `type CurrentFinalizedEvmBlockReferenceProfileV1` or
+// `type StrictCurrentFinalizedEvmRpcConfigV1`, or either value export, from
+// `src/index.ts` makes this file fail to typecheck ("has no exported member").
+
+import {
+  CURRENT_FINALIZED_EVM_BLOCK_REFERENCE_PROFILES_V1,
+  createStrictCurrentFinalizedEvmChainAdapterV1,
+  type CurrentFinalizedEvmBlockReferenceProfileV1,
+  type StrictCurrentFinalizedEvmRpcConfigV1,
+} from '../src/index.js';
+
+type IsTrue<T extends true> = T;
+type Equals<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+
+// The exported block-reference profile union must remain exactly the two
+// supported profiles, reachable through the barrel.
+export type ProfileExportIsCanonical = IsTrue<
+  Equals<
+    CurrentFinalizedEvmBlockReferenceProfileV1,
+    'eip1898' | 'trusted-block-number-hash-sandwich'
+  >
+>;
+
+// The exported config type must stay structurally usable by consumers.
+export type ConfigExportCarriesEndpoints = IsTrue<
+  StrictCurrentFinalizedEvmRpcConfigV1 extends { readonly endpoints: readonly string[] }
+    ? true
+    : false
+>;
+
+// The value re-exports must be present with their real implementation types.
+export const strictAdapterFactoryExport: typeof createStrictCurrentFinalizedEvmChainAdapterV1 =
+  createStrictCurrentFinalizedEvmChainAdapterV1;
+export const blockReferenceProfilesExport: readonly CurrentFinalizedEvmBlockReferenceProfileV1[] =
+  CURRENT_FINALIZED_EVM_BLOCK_REFERENCE_PROFILES_V1;

--- a/packages/chain/test/strict-current-finalized-evm-rpc.unit.test.ts
+++ b/packages/chain/test/strict-current-finalized-evm-rpc.unit.test.ts
@@ -23,6 +23,12 @@ import {
   createStrictCurrentFinalizedEvmChainAdapterV1,
   type StrictCurrentFinalizedEvmRpcConfigV1,
 } from '../src/strict-current-finalized-evm-rpc.js';
+import {
+  CURRENT_FINALIZED_EVM_BLOCK_REFERENCE_PROFILES_V1 as ENTRY_BLOCK_REFERENCE_PROFILES,
+  createStrictCurrentFinalizedEvmChainAdapterV1 as entryCreateStrictAdapter,
+  type CurrentFinalizedEvmBlockReferenceProfileV1 as EntryBlockReferenceProfile,
+  type StrictCurrentFinalizedEvmRpcConfigV1 as EntryRpcConfig,
+} from '../src/index.js';
 
 const CHAIN_ID = '20430' as ChainIdV1;
 const CHAIN_QUANTITY = '0x4fce';
@@ -507,6 +513,26 @@ describe('RFC-64 strict current-finalized raw JSON-RPC transport', () => {
         config as StrictCurrentFinalizedEvmRpcConfigV1,
       )).toThrow(TypeError);
     }
+  });
+
+  it('exposes the strict finalized RPC public API through the chain package entry point', () => {
+    // Consumers import from the package barrel, not the implementation module,
+    // so a dropped or miswired export in src/index.ts would break them while
+    // the impl-module tests above stay green.
+    expect(entryCreateStrictAdapter).toBe(createStrictCurrentFinalizedEvmChainAdapterV1);
+    expect(ENTRY_BLOCK_REFERENCE_PROFILES).toEqual([
+      'eip1898',
+      'trusted-block-number-hash-sandwich',
+    ]);
+    // The two type exports must also be reachable through the barrel; using them
+    // here fails the typecheck if src/index.ts drops either type re-export.
+    const profile: EntryBlockReferenceProfile = 'trusted-block-number-hash-sandwich';
+    const config: EntryRpcConfig = {
+      chainId: CHAIN_ID,
+      endpoints: ['http://127.0.0.1:1'],
+      blockReferenceProfile: profile,
+    };
+    expect(Object.isFrozen(entryCreateStrictAdapter(config))).toBe(true);
   });
 });
 

--- a/packages/chain/test/strict-current-finalized-evm-rpc.unit.test.ts
+++ b/packages/chain/test/strict-current-finalized-evm-rpc.unit.test.ts
@@ -297,6 +297,48 @@ describe('RFC-64 strict current-finalized raw JSON-RPC transport', () => {
     expect(second.calls).toHaveLength(0);
   });
 
+  it('treats explicit revert evidence as terminal when its message also mentions gas', async () => {
+    const first = await startRpcServer(successfulHandler({
+      callError: { code: 3, message: 'execution reverted: out of gas' },
+    }));
+    const second = await startRpcServer(successfulHandler());
+    const adapter = createStrictCurrentFinalizedEvmChainAdapterV1({
+      chainId: CHAIN_ID,
+      endpoints: [first.url, second.url],
+    });
+
+    await expect(adapter(fixedRequest())).rejects.toMatchObject({ code: 'revert' });
+    expect(first.calls.map(({ method }) => method)).toEqual([
+      'eth_chainId',
+      'eth_getBlockByNumber',
+      'eth_getCode',
+      'eth_call',
+    ]);
+    expect(second.calls).toHaveLength(0);
+  });
+
+  it('keeps mixed revert-and-gas evidence terminal after a stable fallback post-read', async () => {
+    const first = await startRpcServer(successfulHandler({
+      callError: { code: 3, message: 'execution reverted: gas required exceeds allowance' },
+    }));
+    const second = await startRpcServer(successfulHandler());
+    const adapter = createStrictCurrentFinalizedEvmChainAdapterV1({
+      chainId: CHAIN_ID,
+      endpoints: [first.url, second.url],
+      blockReferenceProfile: 'trusted-block-number-hash-sandwich',
+    });
+
+    await expect(adapter(fixedRequest())).rejects.toMatchObject({ code: 'revert' });
+    expect(first.calls.map(({ method }) => method)).toEqual([
+      'eth_chainId',
+      'eth_getBlockByNumber',
+      'eth_getCode',
+      'eth_call',
+      'eth_getBlockByNumber',
+    ]);
+    expect(second.calls).toHaveLength(0);
+  });
+
   it('rejects malformed contract returns but preserves exact wrong magic for the verifier', async () => {
     const malformed = await startRpcServer(successfulHandler({ returnData: '0x1626ba7e' }));
     const malformedAdapter = createStrictCurrentFinalizedEvmChainAdapterV1({
@@ -411,6 +453,7 @@ describe('RFC-64 strict current-finalized raw JSON-RPC transport', () => {
 
 interface SuccessfulHandlerOptions {
   readonly blockHash?: string | (() => string);
+  readonly callError?: { readonly code: number; readonly message: string };
   readonly code?: string;
   readonly outOfGas?: boolean;
   readonly returnData?: string;
@@ -434,7 +477,9 @@ function successfulHandler(options: SuccessfulHandlerOptions = {}): LoopbackHand
         sendResult(response, call, options.code ?? '0x6000');
         return;
       case 'eth_call':
-        if (options.outOfGas) {
+        if (options.callError) {
+          sendError(response, call, options.callError.code, options.callError.message);
+        } else if (options.outOfGas) {
           sendError(response, call, -32000, 'out of gas');
         } else if (options.revert) {
           sendError(response, call, 3, 'execution reverted');

--- a/packages/chain/test/strict-current-finalized-evm-rpc.unit.test.ts
+++ b/packages/chain/test/strict-current-finalized-evm-rpc.unit.test.ts
@@ -378,6 +378,28 @@ describe('RFC-64 strict current-finalized raw JSON-RPC transport', () => {
     expect(second.calls).toHaveLength(0);
   });
 
+  it('fails over past a large HTTP error body instead of a terminal resource limit', async () => {
+    const first = await startRpcServer((_call, response) => {
+      // A transient 5xx whose error page far exceeds the JSON-RPC body cap must
+      // stay failover-eligible, not be reclassified as a terminal resource-limit.
+      response.writeHead(503, {
+        'content-type': 'text/html',
+        'transfer-encoding': 'chunked',
+      });
+      response.write(' '.repeat(40_000));
+      response.end(' '.repeat(30_000));
+    });
+    const second = await startRpcServer(successfulHandler());
+    const adapter = createStrictCurrentFinalizedEvmChainAdapterV1({
+      chainId: CHAIN_ID,
+      endpoints: [first.url, second.url],
+    });
+
+    await expect(adapter(fixedRequest())).resolves.toMatchObject({ blockHash: BLOCK_HASH });
+    expect(first.calls).toHaveLength(1);
+    expect(second.calls.length).toBeGreaterThan(0);
+  });
+
   it('cancels the actual loopback HTTP operation and does not fail over', async () => {
     const received = deferred<void>();
     const connectionClosed = deferred<void>();

--- a/packages/chain/test/strict-current-finalized-evm-rpc.unit.test.ts
+++ b/packages/chain/test/strict-current-finalized-evm-rpc.unit.test.ts
@@ -1,0 +1,545 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+import {
+  type ChainIdV1,
+  type EvmAddressV1,
+} from '@origintrail-official/dkg-core';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  CONTROL_EIP1271_ATTEMPT_TIMEOUT_MS_V1,
+  CONTROL_EIP1271_CALL_FROM_V1,
+  CONTROL_EIP1271_ENDPOINT_ATTEMPT_POLICY_V1,
+  CONTROL_EIP1271_GAS_LIMIT_V1,
+  CONTROL_EIP1271_MAX_ATTEMPTS_V1,
+  CONTROL_EIP1271_MAX_CONCURRENT_CALLS_PER_CHAIN_V1,
+  CONTROL_EIP1271_MAX_RETURN_BYTES_V1,
+  CONTROL_EIP1271_MAX_RPC_RESPONSE_BYTES_V1,
+  CONTROL_EIP1271_TOTAL_DEADLINE_MS_V1,
+  type CurrentFinalizedEvmCallRequestV1,
+} from '../src/control-object-signature-verifier.js';
+import {
+  createStrictCurrentFinalizedEvmChainAdapterV1,
+  type StrictCurrentFinalizedEvmRpcConfigV1,
+} from '../src/strict-current-finalized-evm-rpc.js';
+
+const CHAIN_ID = '20430' as ChainIdV1;
+const CHAIN_QUANTITY = '0x4fce';
+const TO = '0x1111111111111111111111111111111111111111' as EvmAddressV1;
+const BLOCK_HASH = `0x${'22'.repeat(32)}`;
+const OTHER_BLOCK_HASH = `0x${'23'.repeat(32)}`;
+const OBJECT_DIGEST = `${'33'.repeat(32)}`;
+const CANONICAL_CALL_DATA = `0x1626ba7e${OBJECT_DIGEST}${'0'.repeat(62)}40${'0'.repeat(63)}1aa${'0'.repeat(62)}`;
+const MAGIC_RETURN = `0x1626ba7e${'00'.repeat(28)}`;
+const WRONG_MAGIC_RETURN = `0xffffffff${'00'.repeat(28)}`;
+
+interface JsonRpcRequest {
+  readonly jsonrpc: '2.0';
+  readonly id: number;
+  readonly method: string;
+  readonly params: readonly unknown[];
+}
+
+interface LoopbackRpcServer {
+  readonly url: string;
+  readonly calls: JsonRpcRequest[];
+  readonly stop: () => Promise<void>;
+}
+
+type LoopbackHandler = (
+  call: JsonRpcRequest,
+  response: ServerResponse,
+  request: IncomingMessage,
+) => void | Promise<void>;
+
+const activeServers: LoopbackRpcServer[] = [];
+
+afterEach(async () => {
+  await Promise.all(activeServers.splice(0).map((server) => server.stop()));
+});
+
+describe('RFC-64 strict current-finalized raw JSON-RPC transport', () => {
+  it('uses the configured endpoint once, in exact EIP-1898 request order and shape', async () => {
+    const server = await startRpcServer(successfulHandler());
+    const configuredEndpoints = [server.url];
+    const adapter = createStrictCurrentFinalizedEvmChainAdapterV1({
+      chainId: CHAIN_ID,
+      endpoints: configuredEndpoints,
+    });
+    configuredEndpoints[0] = 'http://peer-controlled.invalid';
+
+    await expect(adapter(fixedRequest())).resolves.toEqual({
+      chainId: CHAIN_ID,
+      blockNumber: '123',
+      blockHash: BLOCK_HASH,
+      returnData: MAGIC_RETURN,
+    });
+    expect(Object.isFrozen(adapter)).toBe(true);
+    expect(server.calls.map(({ method }) => method)).toEqual([
+      'eth_chainId',
+      'eth_getBlockByNumber',
+      'eth_getCode',
+      'eth_call',
+    ]);
+    expect(server.calls.map(({ id }) => id)).toEqual([1, 2, 3, 4]);
+    expect(server.calls[0]!.params).toEqual([]);
+    expect(server.calls[1]!.params).toEqual(['finalized', false]);
+    const hashReference = { blockHash: BLOCK_HASH, requireCanonical: true };
+    expect(server.calls[2]!.params).toEqual([TO, hashReference]);
+    expect(server.calls[3]!.params).toEqual([{
+      from: CONTROL_EIP1271_CALL_FROM_V1,
+      to: TO,
+      data: CANONICAL_CALL_DATA,
+      gas: '0xf4240',
+    }, hashReference]);
+  });
+
+  it('uses the explicit trusted number profile with a same-endpoint post-hash sandwich', async () => {
+    const server = await startRpcServer(successfulHandler());
+    const adapter = createStrictCurrentFinalizedEvmChainAdapterV1({
+      chainId: CHAIN_ID,
+      endpoints: [server.url],
+      blockReferenceProfile: 'trusted-block-number-hash-sandwich',
+    });
+
+    await expect(adapter(fixedRequest())).resolves.toMatchObject({
+      blockNumber: '123',
+      blockHash: BLOCK_HASH,
+    });
+    expect(server.calls.map(({ method }) => method)).toEqual([
+      'eth_chainId',
+      'eth_getBlockByNumber',
+      'eth_getCode',
+      'eth_call',
+      'eth_getBlockByNumber',
+    ]);
+    expect(server.calls[2]!.params).toEqual([TO, '0x7b']);
+    expect(server.calls[3]!.params[1]).toBe('0x7b');
+    expect(server.calls[4]!.params).toEqual(['0x7b', false]);
+  });
+
+  it('fails over in canonical order after wrong-chain evidence without endpoint stickiness', async () => {
+    const first = await startRpcServer((call, response) => {
+      sendResult(response, call, '0x1');
+    });
+    const second = await startRpcServer(successfulHandler());
+    const adapter = createStrictCurrentFinalizedEvmChainAdapterV1({
+      chainId: CHAIN_ID,
+      endpoints: [first.url, `${second.url}/`],
+    });
+
+    await expect(adapter(fixedRequest())).resolves.toMatchObject({ chainId: CHAIN_ID });
+    await expect(adapter(fixedRequest())).resolves.toMatchObject({ chainId: CHAIN_ID });
+    expect(first.calls.map(({ method }) => method)).toEqual(['eth_chainId', 'eth_chainId']);
+    expect(second.calls.map(({ method }) => method)).toEqual([
+      'eth_chainId',
+      'eth_getBlockByNumber',
+      'eth_getCode',
+      'eth_call',
+      'eth_chainId',
+      'eth_getBlockByNumber',
+      'eth_getCode',
+      'eth_call',
+    ]);
+  });
+
+  it('deduplicates normalized endpoints and performs no hidden same-endpoint retry', async () => {
+    const server = await startRpcServer((call, response) => {
+      response.writeHead(503, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({
+        jsonrpc: '2.0',
+        id: call.id,
+        error: { code: -32000, message: 'temporarily unavailable' },
+      }));
+    });
+    const adapter = createStrictCurrentFinalizedEvmChainAdapterV1({
+      chainId: CHAIN_ID,
+      endpoints: [server.url, `${server.url}/`],
+    });
+
+    await expect(adapter(fixedRequest())).rejects.toMatchObject({ code: 'rpc-unavailable' });
+    expect(server.calls).toHaveLength(1);
+  });
+
+  it('never follows a redirect to an endpoint outside trusted local configuration', async () => {
+    const unconfigured = await startRpcServer(successfulHandler());
+    const configured = await startRpcServer((_call, response) => {
+      response.writeHead(307, { location: unconfigured.url });
+      response.end();
+    });
+    const adapter = createStrictCurrentFinalizedEvmChainAdapterV1({
+      chainId: CHAIN_ID,
+      endpoints: [configured.url],
+    });
+
+    await expect(adapter(fixedRequest())).rejects.toMatchObject({ code: 'rpc-unavailable' });
+    expect(configured.calls).toHaveLength(1);
+    expect(unconfigured.calls).toHaveLength(0);
+  });
+
+  it('advances after a fallback hash mismatch and never accepts mixed-anchor evidence', async () => {
+    let finalizedReads = 0;
+    const first = await startRpcServer(successfulHandler({
+      blockHash: () => (++finalizedReads === 1 ? BLOCK_HASH : OTHER_BLOCK_HASH),
+    }));
+    const second = await startRpcServer(successfulHandler());
+    const adapter = createStrictCurrentFinalizedEvmChainAdapterV1({
+      chainId: CHAIN_ID,
+      endpoints: [first.url, second.url],
+      blockReferenceProfile: 'trusted-block-number-hash-sandwich',
+    });
+
+    await expect(adapter(fixedRequest())).resolves.toMatchObject({ blockHash: BLOCK_HASH });
+    expect(first.calls.map(({ method }) => method)).toEqual([
+      'eth_chainId',
+      'eth_getBlockByNumber',
+      'eth_getCode',
+      'eth_call',
+      'eth_getBlockByNumber',
+    ]);
+    expect(second.calls).toHaveLength(5);
+  });
+
+  it('does not turn reorg-produced fallback no-code into deterministic invalidity', async () => {
+    let finalizedReads = 0;
+    const first = await startRpcServer(successfulHandler({
+      blockHash: () => (++finalizedReads === 1 ? BLOCK_HASH : OTHER_BLOCK_HASH),
+      code: '0x',
+    }));
+    const second = await startRpcServer(successfulHandler());
+    const adapter = createStrictCurrentFinalizedEvmChainAdapterV1({
+      chainId: CHAIN_ID,
+      endpoints: [first.url, second.url],
+      blockReferenceProfile: 'trusted-block-number-hash-sandwich',
+    });
+
+    await expect(adapter(fixedRequest())).resolves.toMatchObject({ blockHash: BLOCK_HASH });
+    expect(first.calls.map(({ method }) => method)).toEqual([
+      'eth_chainId',
+      'eth_getBlockByNumber',
+      'eth_getCode',
+      'eth_getBlockByNumber',
+    ]);
+    expect(second.calls).toHaveLength(5);
+  });
+
+  it('does not turn reorg-produced fallback out-of-gas into a terminal resource limit', async () => {
+    let finalizedReads = 0;
+    const first = await startRpcServer(successfulHandler({
+      blockHash: () => (++finalizedReads === 1 ? BLOCK_HASH : OTHER_BLOCK_HASH),
+      outOfGas: true,
+    }));
+    const second = await startRpcServer(successfulHandler());
+    const adapter = createStrictCurrentFinalizedEvmChainAdapterV1({
+      chainId: CHAIN_ID,
+      endpoints: [first.url, second.url],
+      blockReferenceProfile: 'trusted-block-number-hash-sandwich',
+    });
+
+    await expect(adapter(fixedRequest())).resolves.toMatchObject({ blockHash: BLOCK_HASH });
+    expect(first.calls.map(({ method }) => method)).toEqual([
+      'eth_chainId',
+      'eth_getBlockByNumber',
+      'eth_getCode',
+      'eth_call',
+      'eth_getBlockByNumber',
+    ]);
+    expect(second.calls).toHaveLength(5);
+  });
+
+  it('keeps fallback out-of-gas terminal after the same-anchor post-read succeeds', async () => {
+    const first = await startRpcServer(successfulHandler({ outOfGas: true }));
+    const second = await startRpcServer(successfulHandler());
+    const adapter = createStrictCurrentFinalizedEvmChainAdapterV1({
+      chainId: CHAIN_ID,
+      endpoints: [first.url, second.url],
+      blockReferenceProfile: 'trusted-block-number-hash-sandwich',
+    });
+
+    await expect(adapter(fixedRequest())).rejects.toMatchObject({ code: 'resource-limit' });
+    expect(first.calls.map(({ method }) => method)).toEqual([
+      'eth_chainId',
+      'eth_getBlockByNumber',
+      'eth_getCode',
+      'eth_call',
+      'eth_getBlockByNumber',
+    ]);
+    expect(second.calls).toHaveLength(0);
+  });
+
+  it('stops on terminal no-code evidence without contacting a later endpoint', async () => {
+    const first = await startRpcServer(successfulHandler({ code: '0x' }));
+    const second = await startRpcServer(successfulHandler());
+    const adapter = createStrictCurrentFinalizedEvmChainAdapterV1({
+      chainId: CHAIN_ID,
+      endpoints: [first.url, second.url],
+    });
+
+    await expect(adapter(fixedRequest())).rejects.toMatchObject({ code: 'no-code' });
+    expect(first.calls.map(({ method }) => method)).toEqual([
+      'eth_chainId',
+      'eth_getBlockByNumber',
+      'eth_getCode',
+    ]);
+    expect(second.calls).toHaveLength(0);
+  });
+
+  it('stops on a deterministic contract revert without contacting a later endpoint', async () => {
+    const first = await startRpcServer(successfulHandler({ revert: true }));
+    const second = await startRpcServer(successfulHandler());
+    const adapter = createStrictCurrentFinalizedEvmChainAdapterV1({
+      chainId: CHAIN_ID,
+      endpoints: [first.url, second.url],
+    });
+
+    await expect(adapter(fixedRequest())).rejects.toMatchObject({ code: 'revert' });
+    expect(second.calls).toHaveLength(0);
+  });
+
+  it('rejects malformed contract returns but preserves exact wrong magic for the verifier', async () => {
+    const malformed = await startRpcServer(successfulHandler({ returnData: '0x1626ba7e' }));
+    const malformedAdapter = createStrictCurrentFinalizedEvmChainAdapterV1({
+      chainId: CHAIN_ID,
+      endpoints: [malformed.url],
+    });
+    await expect(malformedAdapter(fixedRequest()))
+      .rejects.toMatchObject({ code: 'malformed-return' });
+
+    const wrong = await startRpcServer(successfulHandler({ returnData: WRONG_MAGIC_RETURN }));
+    const wrongAdapter = createStrictCurrentFinalizedEvmChainAdapterV1({
+      chainId: CHAIN_ID,
+      endpoints: [wrong.url],
+    });
+    await expect(wrongAdapter(fixedRequest())).resolves.toMatchObject({
+      returnData: WRONG_MAGIC_RETURN,
+    });
+  });
+
+  it('enforces the 65,536-byte cap while streaming, before JSON parsing or failover', async () => {
+    const first = await startRpcServer((_call, response) => {
+      response.writeHead(200, {
+        'content-type': 'application/json',
+        'transfer-encoding': 'chunked',
+      });
+      response.write(' '.repeat(40_000));
+      response.end(' '.repeat(30_000));
+    });
+    const second = await startRpcServer(successfulHandler());
+    const adapter = createStrictCurrentFinalizedEvmChainAdapterV1({
+      chainId: CHAIN_ID,
+      endpoints: [first.url, second.url],
+    });
+
+    await expect(adapter(fixedRequest())).rejects.toMatchObject({ code: 'resource-limit' });
+    expect(first.calls).toHaveLength(1);
+    expect(second.calls).toHaveLength(0);
+  });
+
+  it('cancels the actual loopback HTTP operation and does not fail over', async () => {
+    const received = deferred<void>();
+    const connectionClosed = deferred<void>();
+    const first = await startRpcServer((_call, response) => {
+      response.on('close', () => connectionClosed.resolve());
+      received.resolve();
+      // Deliberately leave the response open until AbortSignal cancels fetch.
+    });
+    const second = await startRpcServer(successfulHandler());
+    const adapter = createStrictCurrentFinalizedEvmChainAdapterV1({
+      chainId: CHAIN_ID,
+      endpoints: [first.url, second.url],
+    });
+    const controller = new AbortController();
+    const operation = adapter(fixedRequest({ signal: controller.signal }));
+
+    await received.promise;
+    controller.abort(new Error('caller stopped'));
+    // The transport closes as rpc-unavailable; the verifier-owned caller
+    // signal maps this path to the public `cancelled` disposition.
+    await expect(operation).rejects.toMatchObject({ code: 'rpc-unavailable' });
+    await connectionClosed.promise;
+    expect(second.calls).toHaveLength(0);
+  });
+
+  it('enforces one four-second whole-attempt budget, cancels it, then advances', async () => {
+    const firstClosed = deferred<void>();
+    const delayedSuccess = successfulHandler();
+    const first = await startRpcServer(async (call, response, request) => {
+      if (call.method === 'eth_call') response.on('close', () => firstClosed.resolve());
+      // Each RPC is individually under four seconds, but the chain/header/code
+      // work consumes most of the one shared attempt budget. The call is then
+      // cancelled by that original timer (a per-RPC timer would wrongly pass).
+      await new Promise((resolve) => setTimeout(resolve, 1_100));
+      if (!response.destroyed) await delayedSuccess(call, response, request);
+    });
+    const second = await startRpcServer(successfulHandler());
+    const adapter = createStrictCurrentFinalizedEvmChainAdapterV1({
+      chainId: CHAIN_ID,
+      endpoints: [first.url, second.url],
+    });
+    const started = Date.now();
+
+    await expect(adapter(fixedRequest())).resolves.toMatchObject({ chainId: CHAIN_ID });
+    const elapsed = Date.now() - started;
+    expect(elapsed).toBeGreaterThanOrEqual(CONTROL_EIP1271_ATTEMPT_TIMEOUT_MS_V1 - 200);
+    expect(elapsed).toBeLessThan(CONTROL_EIP1271_TOTAL_DEADLINE_MS_V1);
+    await firstClosed.promise;
+    expect(first.calls).toHaveLength(4);
+    expect(second.calls).toHaveLength(4);
+  }, 12_000);
+
+  it('rejects unsafe configuration and more than two distinct normalized endpoints', () => {
+    const third = 'http://127.0.0.1:3';
+    for (const config of [
+      { chainId: '020430', endpoints: ['http://127.0.0.1:1'] },
+      { chainId: CHAIN_ID, endpoints: [] },
+      { chainId: CHAIN_ID, endpoints: ['ftp://127.0.0.1/a'] },
+      { chainId: CHAIN_ID, endpoints: ['http://127.0.0.1/a#fragment'] },
+      { chainId: CHAIN_ID, endpoints: [
+        'http://127.0.0.1:1',
+        'http://127.0.0.1:2',
+        third,
+      ] },
+      { chainId: CHAIN_ID, endpoints: ['http://127.0.0.1:1'], peerEndpoint: third },
+    ]) {
+      expect(() => createStrictCurrentFinalizedEvmChainAdapterV1(
+        config as StrictCurrentFinalizedEvmRpcConfigV1,
+      )).toThrow(TypeError);
+    }
+  });
+});
+
+interface SuccessfulHandlerOptions {
+  readonly blockHash?: string | (() => string);
+  readonly code?: string;
+  readonly outOfGas?: boolean;
+  readonly returnData?: string;
+  readonly revert?: boolean;
+}
+
+function successfulHandler(options: SuccessfulHandlerOptions = {}): LoopbackHandler {
+  return (call, response) => {
+    switch (call.method) {
+      case 'eth_chainId':
+        sendResult(response, call, CHAIN_QUANTITY);
+        return;
+      case 'eth_getBlockByNumber': {
+        const selectedHash = typeof options.blockHash === 'function'
+          ? options.blockHash()
+          : (options.blockHash ?? BLOCK_HASH);
+        sendResult(response, call, { number: '0x7b', hash: selectedHash });
+        return;
+      }
+      case 'eth_getCode':
+        sendResult(response, call, options.code ?? '0x6000');
+        return;
+      case 'eth_call':
+        if (options.outOfGas) {
+          sendError(response, call, -32000, 'out of gas');
+        } else if (options.revert) {
+          sendError(response, call, 3, 'execution reverted');
+        } else {
+          sendResult(response, call, options.returnData ?? MAGIC_RETURN);
+        }
+        return;
+      default:
+        sendError(response, call, -32601, 'method not found');
+    }
+  };
+}
+
+async function startRpcServer(handler: LoopbackHandler): Promise<LoopbackRpcServer> {
+  const calls: JsonRpcRequest[] = [];
+  const server = createServer(async (request, response) => {
+    try {
+      const body = await readRequestBody(request);
+      const parsed = JSON.parse(body) as JsonRpcRequest;
+      calls.push(parsed);
+      await handler(parsed, response, request);
+    } catch (cause) {
+      if (!response.headersSent) response.writeHead(500, { 'content-type': 'text/plain' });
+      if (!response.writableEnded) response.end(cause instanceof Error ? cause.message : 'failure');
+    }
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject);
+      resolve();
+    });
+  });
+  const address = server.address() as AddressInfo;
+  let stopped = false;
+  const loopback = Object.freeze({
+    url: `http://127.0.0.1:${address.port}`,
+    calls,
+    stop: async () => {
+      if (stopped) return;
+      stopped = true;
+      await closeServer(server);
+    },
+  });
+  activeServers.push(loopback);
+  return loopback;
+}
+
+async function readRequestBody(request: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) chunks.push(Buffer.from(chunk));
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+function sendResult(response: ServerResponse, request: JsonRpcRequest, result: unknown): void {
+  response.writeHead(200, { 'content-type': 'application/json' });
+  response.end(JSON.stringify({ jsonrpc: '2.0', id: request.id, result }));
+}
+
+function sendError(
+  response: ServerResponse,
+  request: JsonRpcRequest,
+  code: number,
+  message: string,
+): void {
+  response.writeHead(200, { 'content-type': 'application/json' });
+  response.end(JSON.stringify({ jsonrpc: '2.0', id: request.id, error: { code, message } }));
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve) => {
+    server.close(() => resolve());
+    server.closeAllConnections();
+  });
+}
+
+function fixedRequest(
+  overrides: Partial<CurrentFinalizedEvmCallRequestV1> = {},
+): CurrentFinalizedEvmCallRequestV1 {
+  return {
+    chainId: CHAIN_ID,
+    to: TO,
+    from: CONTROL_EIP1271_CALL_FROM_V1,
+    data: CANONICAL_CALL_DATA,
+    gasLimit: CONTROL_EIP1271_GAS_LIMIT_V1,
+    maxReturnBytes: CONTROL_EIP1271_MAX_RETURN_BYTES_V1,
+    maxRpcResponseBytes: CONTROL_EIP1271_MAX_RPC_RESPONSE_BYTES_V1,
+    attemptTimeoutMs: CONTROL_EIP1271_ATTEMPT_TIMEOUT_MS_V1,
+    maxAttempts: CONTROL_EIP1271_MAX_ATTEMPTS_V1,
+    endpointAttemptPolicy: CONTROL_EIP1271_ENDPOINT_ATTEMPT_POLICY_V1,
+    maxConcurrentCallsPerChain: CONTROL_EIP1271_MAX_CONCURRENT_CALLS_PER_CHAIN_V1,
+    totalDeadlineMs: CONTROL_EIP1271_TOTAL_DEADLINE_MS_V1,
+    ccipReadEnabled: false,
+    signal: new AbortController().signal,
+    ...overrides,
+  };
+}
+
+function deferred<T>(): {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T | PromiseLike<T>) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((fulfill) => {
+    resolve = fulfill;
+  });
+  return { promise, resolve };
+}

--- a/packages/chain/test/strict-current-finalized-evm-rpc.unit.test.ts
+++ b/packages/chain/test/strict-current-finalized-evm-rpc.unit.test.ts
@@ -83,6 +83,10 @@ describe('RFC-64 strict current-finalized raw JSON-RPC transport', () => {
       'eth_call',
     ]);
     expect(server.calls.map(({ id }) => id)).toEqual([1, 2, 3, 4]);
+    // The raw transport must emit valid JSON-RPC 2.0 request envelopes. The
+    // loopback records the parsed request body verbatim, so this fails at
+    // runtime if postJsonRpc drops or changes the version field.
+    expect(server.calls.map(({ jsonrpc }) => jsonrpc)).toEqual(['2.0', '2.0', '2.0', '2.0']);
     expect(server.calls[0]!.params).toEqual([]);
     expect(server.calls[1]!.params).toEqual(['finalized', false]);
     const hashReference = { blockHash: BLOCK_HASH, requireCanonical: true };
@@ -264,6 +268,39 @@ describe('RFC-64 strict current-finalized raw JSON-RPC transport', () => {
       'eth_getCode',
       'eth_call',
       'eth_getBlockByNumber',
+    ]);
+    expect(second.calls).toHaveLength(0);
+  });
+
+  it('propagates a transport resource-limit from the number profile without the post-read sandwich', async () => {
+    const base = successfulHandler();
+    const first = await startRpcServer((call, response, request) => {
+      if (call.method !== 'eth_call') return base(call, response, request);
+      // A transport/local body-cap resource-limit is NOT anchor-dependent, so it
+      // must propagate immediately rather than be held for the hash sandwich the
+      // way an execution (out-of-gas) resource-limit is.
+      response.writeHead(200, {
+        'content-type': 'application/json',
+        'transfer-encoding': 'chunked',
+      });
+      response.write(' '.repeat(40_000));
+      response.end(' '.repeat(30_000));
+    });
+    const second = await startRpcServer(successfulHandler());
+    const adapter = createStrictCurrentFinalizedEvmChainAdapterV1({
+      chainId: CHAIN_ID,
+      endpoints: [first.url, second.url],
+      blockReferenceProfile: 'trusted-block-number-hash-sandwich',
+    });
+
+    await expect(adapter(fixedRequest())).rejects.toMatchObject({ code: 'resource-limit' });
+    // No fifth post-read eth_getBlockByNumber: the transport resource-limit was
+    // not held, unlike the anchor-dependent execution resource-limit above.
+    expect(first.calls.map(({ method }) => method)).toEqual([
+      'eth_chainId',
+      'eth_getBlockByNumber',
+      'eth_getCode',
+      'eth_call',
     ]);
     expect(second.calls).toHaveLength(0);
   });

--- a/packages/chain/test/strict-current-finalized-evm-rpc.unit.test.ts
+++ b/packages/chain/test/strict-current-finalized-evm-rpc.unit.test.ts
@@ -26,8 +26,6 @@ import {
 import {
   CURRENT_FINALIZED_EVM_BLOCK_REFERENCE_PROFILES_V1 as ENTRY_BLOCK_REFERENCE_PROFILES,
   createStrictCurrentFinalizedEvmChainAdapterV1 as entryCreateStrictAdapter,
-  type CurrentFinalizedEvmBlockReferenceProfileV1 as EntryBlockReferenceProfile,
-  type StrictCurrentFinalizedEvmRpcConfigV1 as EntryRpcConfig,
 } from '../src/index.js';
 
 const CHAIN_ID = '20430' as ChainIdV1;
@@ -515,24 +513,23 @@ describe('RFC-64 strict current-finalized raw JSON-RPC transport', () => {
     }
   });
 
-  it('exposes the strict finalized RPC public API through the chain package entry point', () => {
-    // Consumers import from the package barrel, not the implementation module,
-    // so a dropped or miswired export in src/index.ts would break them while
-    // the impl-module tests above stay green.
+  it('exposes the strict finalized RPC public API values through the chain package entry point', () => {
+    // Runtime proof that consumers reach the strict RPC VALUES through the
+    // barrel, not the implementation module. The TYPE re-exports are proven
+    // separately at compile time in rfc64-strict-rpc-public-api.typecheck.ts
+    // (run via `test:types`, wired into `build`): type-only imports erase
+    // before runtime, so vitest alone cannot protect them.
     expect(entryCreateStrictAdapter).toBe(createStrictCurrentFinalizedEvmChainAdapterV1);
     expect(ENTRY_BLOCK_REFERENCE_PROFILES).toEqual([
       'eip1898',
       'trusted-block-number-hash-sandwich',
     ]);
-    // The two type exports must also be reachable through the barrel; using them
-    // here fails the typecheck if src/index.ts drops either type re-export.
-    const profile: EntryBlockReferenceProfile = 'trusted-block-number-hash-sandwich';
-    const config: EntryRpcConfig = {
+    const adapter = entryCreateStrictAdapter({
       chainId: CHAIN_ID,
       endpoints: ['http://127.0.0.1:1'],
-      blockReferenceProfile: profile,
-    };
-    expect(Object.isFrozen(entryCreateStrictAdapter(config))).toBe(true);
+      blockReferenceProfile: 'trusted-block-number-hash-sandwich',
+    });
+    expect(Object.isFrozen(adapter)).toBe(true);
   });
 });
 

--- a/packages/chain/tsconfig.type-tests.json
+++ b/packages/chain/tsconfig.type-tests.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "noEmit": true,
+    "rootDir": ".",
+    "sourceMap": false
+  },
+  "include": ["test/**/*.typecheck.ts"]
+}


### PR DESCRIPTION
Implements the strict RFC-64 raw JSON-RPC transport behind the current-finalized EVM call adapter seam.

- binds every adapter to one canonical chain and at most two trusted endpoints
- enforces streamed 64 KiB response caps, native cancellation, per-attempt and total deadlines, and redirect rejection
- supports EIP-1898 plus an explicit same-endpoint block-number/hash sandwich fallback
- keeps reorg-dependent no-code, revert, malformed-return, and execution-cap outcomes provisional until the post-anchor check
- classifies endpoint availability separately from deterministic admission invalidity

Verification: chain build passed; focused strict transport tests 16/16; full chain unit suite 728 passed, 1 skipped; diff check passed.

Stacked on #1808.