### PR TITLE
feat(core): verify CG shared semantic projections

### DIFF
--- a/packages/core/src/absolute-rfc3987-iri.ts
+++ b/packages/core/src/absolute-rfc3987-iri.ts
@@ -1,0 +1,279 @@
+/**
+ * Validate the RFC 3987 `IRI` production without normalizing its bytes.
+ *
+ * This deliberately validates only syntax. It does not apply scheme-specific
+ * equivalence, case folding, Unicode normalization, percent normalization, or
+ * network resolution.
+ */
+export function isAbsoluteRfc3987IriV1(value: string): boolean {
+  const schemeEnd = value.indexOf(':');
+  if (schemeEnd <= 0 || !isScheme(value.slice(0, schemeEnd))) return false;
+
+  const remainder = value.slice(schemeEnd + 1);
+  const fragmentAt = remainder.indexOf('#');
+  const beforeFragment = fragmentAt < 0
+    ? remainder
+    : remainder.slice(0, fragmentAt);
+  const fragment = fragmentAt < 0
+    ? undefined
+    : remainder.slice(fragmentAt + 1);
+  if (fragment !== undefined && !isIFragment(fragment)) return false;
+
+  const queryAt = beforeFragment.indexOf('?');
+  const hierarchy = queryAt < 0
+    ? beforeFragment
+    : beforeFragment.slice(0, queryAt);
+  const query = queryAt < 0
+    ? undefined
+    : beforeFragment.slice(queryAt + 1);
+  if (query !== undefined && !isIQuery(query)) return false;
+
+  return isIHierPart(hierarchy);
+}
+
+function isScheme(value: string): boolean {
+  if (value.length === 0 || !isAsciiAlpha(value.charCodeAt(0))) return false;
+  for (let index = 1; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (
+      !isAsciiAlpha(code)
+      && !isAsciiDigit(code)
+      && code !== 0x2b
+      && code !== 0x2d
+      && code !== 0x2e
+    ) return false;
+  }
+  return true;
+}
+
+function isIHierPart(value: string): boolean {
+  if (value.startsWith('//')) {
+    const slashAt = value.indexOf('/', 2);
+    const authority = slashAt < 0
+      ? value.slice(2)
+      : value.slice(2, slashAt);
+    const path = slashAt < 0 ? '' : value.slice(slashAt);
+    return isIAuthority(authority) && scanIChars(path, '/');
+  }
+  if (value.length === 0) return true;
+  if (value[0] === '/') {
+    // `//` is consumed by the authority branch. An authority-free absolute
+    // path cannot start with an empty first segment.
+    return value.length === 1
+      || (value[1] !== '/' && scanIChars(value, '/'));
+  }
+  return scanIChars(value, '/');
+}
+
+function isIAuthority(value: string): boolean {
+  const at = value.lastIndexOf('@');
+  if (at >= 0) {
+    if (
+      value.indexOf('@') !== at
+      || !scanIChars(value.slice(0, at), '', false, true, false)
+    ) {
+      return false;
+    }
+  }
+  const hostAndPort = value.slice(at + 1);
+  if (hostAndPort.startsWith('[')) {
+    const close = hostAndPort.indexOf(']');
+    if (close < 0) return false;
+    const literal = hostAndPort.slice(1, close);
+    const suffix = hostAndPort.slice(close + 1);
+    if (suffix.length > 0 && (suffix[0] !== ':' || !isPort(suffix.slice(1)))) {
+      return false;
+    }
+    return isIpv6Address(literal) || isIpvFuture(literal);
+  }
+
+  const colon = hostAndPort.lastIndexOf(':');
+  const host = colon < 0 ? hostAndPort : hostAndPort.slice(0, colon);
+  const port = colon < 0 ? undefined : hostAndPort.slice(colon + 1);
+  if (host.includes(':') || host.includes('[') || host.includes(']')) return false;
+  return scanIChars(host, '', false, false, false)
+    && (port === undefined || isPort(port));
+}
+
+function isPort(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    if (!isAsciiDigit(value.charCodeAt(index))) return false;
+  }
+  return true;
+}
+
+function isIpvFuture(value: string): boolean {
+  if (value.length < 4 || (value[0] !== 'v' && value[0] !== 'V')) return false;
+  const dot = value.indexOf('.', 1);
+  if (dot <= 1 || dot === value.length - 1) return false;
+  for (let index = 1; index < dot; index += 1) {
+    if (!isAsciiHex(value.charCodeAt(index))) return false;
+  }
+  for (let index = dot + 1; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (!isAsciiUnreserved(code) && !isSubDelimiter(code) && code !== 0x3a) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function isIpv6Address(value: string): boolean {
+  if (value.length === 0 || value.includes('%')) return false;
+  const compression = value.indexOf('::');
+  if (compression !== value.lastIndexOf('::')) return false;
+
+  const leftText = compression < 0 ? value : value.slice(0, compression);
+  const rightText = compression < 0 ? '' : value.slice(compression + 2);
+  const left = leftText.length === 0 ? [] : leftText.split(':');
+  const right = rightText.length === 0 ? [] : rightText.split(':');
+  if (left.some((part) => part.length === 0) || right.some((part) => part.length === 0)) {
+    return false;
+  }
+
+  const all = [...left, ...right];
+  const dotted = all.findIndex((part) => part.includes('.'));
+  if (
+    dotted >= 0
+    && (
+      dotted !== all.length - 1
+      // An embedded IPv4 address is the final `ls32`; `::` cannot follow it.
+      || (compression >= 0 && right.length === 0)
+    )
+  ) return false;
+  let units = 0;
+  for (let index = 0; index < all.length; index += 1) {
+    const part = all[index];
+    if (part.includes('.')) {
+      if (!isIpv4Address(part)) return false;
+      units += 2;
+      continue;
+    }
+    if (part.length < 1 || part.length > 4) return false;
+    for (let digit = 0; digit < part.length; digit += 1) {
+      if (!isAsciiHex(part.charCodeAt(digit))) return false;
+    }
+    units += 1;
+  }
+  return compression < 0 ? units === 8 : units < 8;
+}
+
+function isIpv4Address(value: string): boolean {
+  const parts = value.split('.');
+  if (parts.length !== 4) return false;
+  return parts.every((part) => {
+    if (part.length === 0 || part.length > 3) return false;
+    if (part.length > 1 && part[0] === '0') return false;
+    for (let index = 0; index < part.length; index += 1) {
+      if (!isAsciiDigit(part.charCodeAt(index))) return false;
+    }
+    return Number(part) <= 255;
+  });
+}
+
+function isIQuery(value: string): boolean {
+  return scanIChars(value, '/?', true);
+}
+
+function isIFragment(value: string): boolean {
+  return scanIChars(value, '/?');
+}
+
+function scanIChars(
+  value: string,
+  asciiExtra: string,
+  allowPrivate = false,
+  allowColon = true,
+  allowAt = true,
+): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code === 0x25) {
+      if (
+        index + 2 >= value.length
+        || !isAsciiHex(value.charCodeAt(index + 1))
+        || !isAsciiHex(value.charCodeAt(index + 2))
+      ) return false;
+      index += 2;
+      continue;
+    }
+    const codePoint = value.codePointAt(index)!;
+    if (
+      isAsciiUnreserved(codePoint)
+      || isSubDelimiter(codePoint)
+      || (allowColon && codePoint === 0x3a)
+      || (allowAt && codePoint === 0x40)
+      || asciiExtra.includes(String.fromCodePoint(codePoint))
+      || isUcsChar(codePoint)
+      || (allowPrivate && isIPrivate(codePoint))
+    ) {
+      if (codePoint > 0xffff) index += 1;
+      continue;
+    }
+    return false;
+  }
+  return true;
+}
+
+function isAsciiUnreserved(code: number): boolean {
+  return isAsciiAlpha(code)
+    || isAsciiDigit(code)
+    || code === 0x2d
+    || code === 0x2e
+    || code === 0x5f
+    || code === 0x7e;
+}
+
+function isSubDelimiter(code: number): boolean {
+  return code === 0x21
+    || code === 0x24
+    || code === 0x26
+    || code === 0x27
+    || code === 0x28
+    || code === 0x29
+    || code === 0x2a
+    || code === 0x2b
+    || code === 0x2c
+    || code === 0x3b
+    || code === 0x3d;
+}
+
+function isUcsChar(code: number): boolean {
+  return (code >= 0x00a0 && code <= 0xd7ff)
+    || (code >= 0xf900 && code <= 0xfdcf)
+    || (code >= 0xfdf0 && code <= 0xffef)
+    || (code >= 0x10000 && code <= 0x1fffd)
+    || (code >= 0x20000 && code <= 0x2fffd)
+    || (code >= 0x30000 && code <= 0x3fffd)
+    || (code >= 0x40000 && code <= 0x4fffd)
+    || (code >= 0x50000 && code <= 0x5fffd)
+    || (code >= 0x60000 && code <= 0x6fffd)
+    || (code >= 0x70000 && code <= 0x7fffd)
+    || (code >= 0x80000 && code <= 0x8fffd)
+    || (code >= 0x90000 && code <= 0x9fffd)
+    || (code >= 0xa0000 && code <= 0xafffd)
+    || (code >= 0xb0000 && code <= 0xbfffd)
+    || (code >= 0xc0000 && code <= 0xcfffd)
+    || (code >= 0xd0000 && code <= 0xdfffd)
+    || (code >= 0xe1000 && code <= 0xefffd);
+}
+
+function isIPrivate(code: number): boolean {
+  return (code >= 0xe000 && code <= 0xf8ff)
+    || (code >= 0xf0000 && code <= 0xffffd)
+    || (code >= 0x100000 && code <= 0x10fffd);
+}
+
+function isAsciiAlpha(code: number): boolean {
+  return (code >= 0x41 && code <= 0x5a) || (code >= 0x61 && code <= 0x7a);
+}
+
+function isAsciiDigit(code: number): boolean {
+  return code >= 0x30 && code <= 0x39;
+}
+
+function isAsciiHex(code: number): boolean {
+  return isAsciiDigit(code)
+    || (code >= 0x41 && code <= 0x46)
+    || (code >= 0x61 && code <= 0x66);
+}

--- a/packages/core/src/cg-shared-projection.ts
+++ b/packages/core/src/cg-shared-projection.ts
@@ -1,0 +1,805 @@
+import {
+  parseRdfLiteralLexicalTerm,
+} from '@origintrail-official/dkg-rdf-utils';
+import { sha256 } from '@noble/hashes/sha2.js';
+
+import type { AuthorCatalogRowV1 } from './author-catalog-codec.js';
+import type { SignedAuthorCatalogHeadEnvelopeV1 } from './author-catalog-objects.js';
+import {
+  readVerifiedCatalogSealBindingV1,
+  type CatalogSealDeploymentProfileV1,
+} from './catalog-seal-binding.js';
+import {
+  type CanonicalGraphScopedAuthorSealV1,
+  type SealTripleCountV1,
+} from './canonical-graph-scoped-author-seal.js';
+import {
+  KA_BUNDLE_PROJECTION_DIGEST_DOMAIN_V1,
+} from './ka-bundle-v1.js';
+import {
+  V10MerkleTree,
+} from './crypto/v10-merkle.js';
+import {
+  canonicalizeObjectTermForHash,
+} from './crypto/term-canon.js';
+import {
+  hashTripleV10,
+  tripleContentV10,
+} from './crypto/canonicalize.js';
+import { isAbsoluteRfc3987IriV1 } from './absolute-rfc3987-iri.js';
+import type {
+  ByteLengthV1,
+  Digest32V1,
+} from './sync-wire-scalars.js';
+import {
+  assertVerifiedTransferredCatalogBundleForInputsV1,
+  readVerifiedTransferredCatalogBundleMetadataV1,
+  readVerifiedTransferredCatalogProjectionBytesV1,
+  type VerifiedTransferredCatalogBundleV1,
+} from './transferred-catalog-bundle.js';
+
+declare const VERIFIED_CG_SHARED_PROJECTION_BRAND_V1: unique symbol;
+
+export const CG_SHARED_PROJECTION_ID_V1 = 'cg-shared-v1' as const;
+export const CG_SHARED_PRIVATE_COMMITMENT_SUFFIX_V1 = '/_cg-shared-v1' as const;
+export const CG_SHARED_PRIVATE_ANCHOR_PREDICATE_V1 =
+  'http://dkg.io/ontology/privateDataAnchor' as const;
+export const CG_SHARED_PRIVATE_HASH_PREDICATE_V1 =
+  'http://dkg.io/ontology/privateDataHash' as const;
+
+const PRIVATE_COMMITMENT_PREDICATE_PREFIX =
+  'http://dkg.io/ontology/privateData';
+const XSD_HEX_BINARY_IRI = 'http://www.w3.org/2001/XMLSchema#hexBinary';
+const UTF8 = new TextEncoder();
+const STRICT_UTF8 = new TextDecoder('utf-8', { fatal: true, ignoreBOM: true });
+const PROJECTION_DIGEST_DOMAIN = UTF8.encode(
+  KA_BUNDLE_PROJECTION_DIGEST_DOMAIN_V1,
+);
+const SENTINEL_NO_PRIVATE_DIGEST_V10 =
+  '0xdfba2a3576c2aa2d73ecd8c55d1c27cfb15691ca9d3237b86434a06592f160ee' as Digest32V1;
+const LOWER_LANGUAGE_TAG = /^[a-z]{1,8}(?:-[a-z0-9]{1,8})*$/;
+const HEX_ESCAPE = /^[0-9A-Fa-f]{2}$/;
+
+/**
+ * Safe defaults for this in-memory verifier. Exceeding them is a local
+ * resource refusal, not proof that otherwise canonical projection bytes are
+ * invalid. A streaming/external-sort verifier is required for larger inputs.
+ */
+export const DEFAULT_CG_SHARED_PROJECTION_VERIFICATION_LIMITS_V1 = Object.freeze({
+  maxProjectionBytes: 64 * 1024 * 1024,
+  maxPublicTriples: 262_144,
+  maxLineBytes: 64 * 1024 * 1024,
+});
+
+export interface CgSharedProjectionVerificationLimitsV1 {
+  readonly maxProjectionBytes: number;
+  readonly maxPublicTriples: number;
+  readonly maxLineBytes: number;
+}
+
+/**
+ * Process-local proof that one structurally verified transferred bundle carries
+ * the exact canonical `cg-shared-v1` projection committed by its author seal.
+ *
+ * This is precommit evidence only. It grants no catalog authority, policy,
+ * author-attestation, VM-finality, semantic-store, or activation authority.
+ */
+export interface VerifiedCgSharedProjectionV1 {
+  readonly [VERIFIED_CG_SHARED_PROJECTION_BRAND_V1]: true;
+}
+
+export interface VerifiedCgSharedProjectionSnapshotV1 {
+  readonly headObjectDigest: Digest32V1;
+  readonly catalogScopeDigest: Digest32V1;
+  readonly catalogRowDigest: Digest32V1;
+  readonly transferIdentityDigest: Digest32V1;
+  readonly projectionId: typeof CG_SHARED_PROJECTION_ID_V1;
+  readonly projectionDigest: Digest32V1;
+  readonly projectionByteLength: ByteLengthV1;
+  readonly publicTripleCount: SealTripleCountV1;
+  readonly privateTripleCount: SealTripleCountV1;
+  readonly publicRoot: Digest32V1;
+  readonly privateDataHash: Digest32V1;
+  readonly assertionMerkleRoot: Digest32V1;
+  readonly privateMerkleRoot: Digest32V1 | null;
+  readonly kaUal: string;
+  /** Local in-memory verifier limits used for this successful proof. */
+  readonly verificationLimits: Readonly<CgSharedProjectionVerificationLimitsV1>;
+  /** Fresh caller-owned copy of the exact canonical projection bytes. */
+  readonly projectionBytes: Uint8Array;
+}
+
+export type VerifiedCgSharedProjectionMetadataV1 = Omit<
+  VerifiedCgSharedProjectionSnapshotV1,
+  'projectionBytes'
+>;
+
+export type CgSharedProjectionErrorCode =
+  | 'projection-input'
+  | 'projection-empty'
+  | 'projection-utf8'
+  | 'projection-line-ending'
+  | 'projection-line'
+  | 'projection-order'
+  | 'projection-duplicate'
+  | 'projection-iri'
+  | 'projection-literal'
+  | 'projection-private-predicate'
+  | 'projection-private-cardinality'
+  | 'projection-private-subject'
+  | 'projection-private-root-mismatch'
+  | 'projection-public-count'
+  | 'projection-digest'
+  | 'projection-structured-root'
+  | 'projection-resource-refused'
+  | 'projection-capability'
+  | 'projection-binding';
+
+export class CgSharedProjectionError extends Error {
+  constructor(
+    readonly code: CgSharedProjectionErrorCode,
+    message: string,
+    options: ErrorOptions = {},
+  ) {
+    super(`[${code}] ${message}`, options);
+    this.name = 'CgSharedProjectionError';
+  }
+}
+
+interface CanonicalProjectionTripleV1 {
+  readonly subject: string;
+  readonly predicate: string;
+  readonly object: string;
+  readonly leaf: Uint8Array;
+}
+
+interface VerifiedCgSharedProjectionStateV1 {
+  readonly transferredBundle: VerifiedTransferredCatalogBundleV1;
+  readonly snapshot: Omit<VerifiedCgSharedProjectionSnapshotV1, 'projectionBytes'>;
+}
+
+const VERIFIED_CG_SHARED_PROJECTIONS_V1 = new WeakMap<
+  object,
+  VerifiedCgSharedProjectionStateV1
+>();
+
+/** Verify canonical bytes, private commitment, counts, and structured V10 root. */
+export function verifyCgSharedProjectionV1(
+  transferredBundle: VerifiedTransferredCatalogBundleV1,
+  signedHead: SignedAuthorCatalogHeadEnvelopeV1,
+  row: AuthorCatalogRowV1,
+  deployment: CatalogSealDeploymentProfileV1,
+  limits: CgSharedProjectionVerificationLimitsV1 =
+    DEFAULT_CG_SHARED_PROJECTION_VERIFICATION_LIMITS_V1,
+): VerifiedCgSharedProjectionV1 {
+  let metadata: ReturnType<typeof readVerifiedTransferredCatalogBundleMetadataV1>;
+  try {
+    metadata = readVerifiedTransferredCatalogBundleMetadataV1(
+      transferredBundle,
+      signedHead,
+      row,
+      deployment,
+    );
+  } catch (cause) {
+    fail(
+      'projection-input',
+      'projection input is not an exact verified transferred catalog bundle',
+      cause,
+    );
+  }
+
+  const sealBinding = readVerifiedCatalogSealBindingV1(
+    metadata.catalogSealBinding,
+  );
+  if (
+    sealBinding.catalogScopeDigest !== metadata.catalogScopeDigest
+    || sealBinding.catalogRowDigest !== metadata.catalogRowDigest
+  ) {
+    fail('projection-binding', 'seal binding and transferred bundle identify different rows');
+  }
+  if (metadata.transfer.projectionId !== CG_SHARED_PROJECTION_ID_V1) {
+    fail('projection-binding', 'transferred row does not advertise cg-shared-v1');
+  }
+  const verificationLimits = normalizeVerificationLimits(limits);
+  assertProjectionWithinLocalLimits(
+    metadata.projectionByteLength,
+    sealBinding.seal.publicTripleCount,
+    verificationLimits,
+  );
+
+  let projectionBytes: Uint8Array;
+  try {
+    projectionBytes = readVerifiedTransferredCatalogProjectionBytesV1(
+      transferredBundle,
+      signedHead,
+      row,
+      deployment,
+    );
+  } catch (cause) {
+    fail(
+      'projection-input',
+      'verified transferred projection bytes could not be read',
+      cause,
+    );
+  }
+  if (projectionBytes.byteLength > verificationLimits.maxProjectionBytes) {
+    fail(
+      'projection-resource-refused',
+      'projection exceeds the local in-memory byte limit',
+    );
+  }
+
+  const projectionDigest = computeProjectionDigest(projectionBytes);
+  if (
+    projectionDigest !== metadata.projectionDigest
+    || projectionDigest !== metadata.transfer.projectionDigest
+  ) {
+    fail('projection-digest', 'canonical projection bytes differ from the transferred digest');
+  }
+
+  const semantic = verifyCanonicalProjectionBytes(
+    projectionBytes,
+    sealBinding.seal,
+    verificationLimits,
+  );
+  const snapshot = Object.freeze({
+    headObjectDigest: metadata.headObjectDigest,
+    catalogScopeDigest: metadata.catalogScopeDigest,
+    catalogRowDigest: metadata.catalogRowDigest,
+    transferIdentityDigest: metadata.transferIdentityDigest,
+    projectionId: CG_SHARED_PROJECTION_ID_V1,
+    projectionDigest,
+    projectionByteLength: String(projectionBytes.byteLength) as ByteLengthV1,
+    publicTripleCount: sealBinding.seal.publicTripleCount,
+    privateTripleCount: sealBinding.seal.privateTripleCount,
+    publicRoot: semantic.publicRoot,
+    privateDataHash: semantic.privateDataHash,
+    assertionMerkleRoot: semantic.assertionMerkleRoot,
+    privateMerkleRoot: sealBinding.seal.privateMerkleRoot,
+    kaUal: sealBinding.seal.kaUal,
+    verificationLimits,
+  });
+  const capability = Object.freeze(
+    Object.create(null),
+  ) as VerifiedCgSharedProjectionV1;
+  VERIFIED_CG_SHARED_PROJECTIONS_V1.set(capability as object, Object.freeze({
+    transferredBundle,
+    snapshot,
+  }));
+  return capability;
+}
+
+export function assertVerifiedCgSharedProjectionV1(
+  value: unknown,
+): asserts value is VerifiedCgSharedProjectionV1 {
+  if ((typeof value !== 'object' && typeof value !== 'function') || value === null) {
+    fail('projection-capability', 'projection proof was not minted by this verifier');
+  }
+  if (!VERIFIED_CG_SHARED_PROJECTIONS_V1.has(value as object)) {
+    fail('projection-capability', 'projection proof was not minted by this verifier');
+  }
+}
+
+export function assertVerifiedCgSharedProjectionForTransferV1(
+  value: unknown,
+  transferredBundle: VerifiedTransferredCatalogBundleV1,
+  signedHead: SignedAuthorCatalogHeadEnvelopeV1,
+  row: AuthorCatalogRowV1,
+  deployment: CatalogSealDeploymentProfileV1,
+): asserts value is VerifiedCgSharedProjectionV1 {
+  assertVerifiedCgSharedProjectionV1(value);
+  try {
+    assertVerifiedTransferredCatalogBundleForInputsV1(
+      transferredBundle,
+      signedHead,
+      row,
+      deployment,
+    );
+  } catch (cause) {
+    fail('projection-binding', 'transferred bundle context is not canonical', cause);
+  }
+  const state = VERIFIED_CG_SHARED_PROJECTIONS_V1.get(value as object)!;
+  if (state.transferredBundle !== transferredBundle) {
+    fail('projection-binding', 'projection proof belongs to another transferred bundle');
+  }
+}
+
+export function readVerifiedCgSharedProjectionV1(
+  value: unknown,
+  transferredBundle: VerifiedTransferredCatalogBundleV1,
+  signedHead: SignedAuthorCatalogHeadEnvelopeV1,
+  row: AuthorCatalogRowV1,
+  deployment: CatalogSealDeploymentProfileV1,
+): VerifiedCgSharedProjectionSnapshotV1 {
+  const metadata = readVerifiedCgSharedProjectionMetadataV1(
+    value,
+    transferredBundle,
+    signedHead,
+    row,
+    deployment,
+  );
+  return Object.freeze({
+    ...metadata,
+    projectionBytes: readVerifiedCgSharedProjectionBytesV1(
+      value,
+      transferredBundle,
+      signedHead,
+      row,
+      deployment,
+    ),
+  });
+}
+
+/** Read verified scalar/root metadata without allocating projection bytes. */
+export function readVerifiedCgSharedProjectionMetadataV1(
+  value: unknown,
+  transferredBundle: VerifiedTransferredCatalogBundleV1,
+  signedHead: SignedAuthorCatalogHeadEnvelopeV1,
+  row: AuthorCatalogRowV1,
+  deployment: CatalogSealDeploymentProfileV1,
+): VerifiedCgSharedProjectionMetadataV1 {
+  assertVerifiedCgSharedProjectionForTransferV1(
+    value,
+    transferredBundle,
+    signedHead,
+    row,
+    deployment,
+  );
+  const state = VERIFIED_CG_SHARED_PROJECTIONS_V1.get(value as object)!;
+  return Object.freeze({ ...state.snapshot });
+}
+
+/** Read one fresh caller-owned copy of the verified canonical projection. */
+export function readVerifiedCgSharedProjectionBytesV1(
+  value: unknown,
+  transferredBundle: VerifiedTransferredCatalogBundleV1,
+  signedHead: SignedAuthorCatalogHeadEnvelopeV1,
+  row: AuthorCatalogRowV1,
+  deployment: CatalogSealDeploymentProfileV1,
+): Uint8Array {
+  assertVerifiedCgSharedProjectionForTransferV1(
+    value,
+    transferredBundle,
+    signedHead,
+    row,
+    deployment,
+  );
+  return readVerifiedTransferredCatalogProjectionBytesV1(
+    transferredBundle,
+    signedHead,
+    row,
+    deployment,
+  );
+}
+
+function verifyCanonicalProjectionBytes(
+  projectionBytes: Uint8Array,
+  seal: Readonly<CanonicalGraphScopedAuthorSealV1>,
+  limits: Readonly<CgSharedProjectionVerificationLimitsV1>,
+): {
+  readonly publicRoot: Digest32V1;
+  readonly privateDataHash: Digest32V1;
+  readonly assertionMerkleRoot: Digest32V1;
+} {
+  if (projectionBytes.byteLength === 0) {
+    fail('projection-empty', 'cg-shared-v1 projection must not be empty');
+  }
+  if (
+    projectionBytes.byteLength >= 3
+    && projectionBytes[0] === 0xef
+    && projectionBytes[1] === 0xbb
+    && projectionBytes[2] === 0xbf
+  ) {
+    fail('projection-utf8', 'cg-shared-v1 projection must not start with a UTF-8 BOM');
+  }
+  if (projectionBytes[projectionBytes.byteLength - 1] !== 0x0a) {
+    fail('projection-line-ending', 'cg-shared-v1 projection must end with one LF');
+  }
+
+  const leaves: Uint8Array[] = [];
+  let anchor: CanonicalProjectionTripleV1 | undefined;
+  let privateHash: CanonicalProjectionTripleV1 | undefined;
+  let previousLine: Uint8Array | undefined;
+  let lineStart = 0;
+  let lineNumber = 0;
+  const signedPublicTripleCount = BigInt(seal.publicTripleCount);
+  const reservedCommitmentSubject =
+    `${seal.kaUal}${CG_SHARED_PRIVATE_COMMITMENT_SUFFIX_V1}`;
+  for (let cursor = 0; cursor < projectionBytes.byteLength; cursor += 1) {
+    const byte = projectionBytes[cursor];
+    if (byte === 0x0d) {
+      fail('projection-line-ending', 'raw CR is forbidden in cg-shared-v1 bytes');
+    }
+    if (byte !== 0x0a) continue;
+    const line = projectionBytes.subarray(lineStart, cursor);
+    lineNumber += 1;
+    if (BigInt(lineNumber) > signedPublicTripleCount) {
+      fail(
+        'projection-public-count',
+        'projection contains more lines than the signed publicTripleCount',
+      );
+    }
+    if (line.byteLength === 0) {
+      fail('projection-line', `projection line ${lineNumber} is empty`);
+    }
+    if (line.byteLength > limits.maxLineBytes) {
+      fail(
+        'projection-resource-refused',
+        `projection line ${lineNumber} exceeds the local in-memory line limit`,
+      );
+    }
+    if (previousLine !== undefined) {
+      const ordering = compareBytes(previousLine, line);
+      if (ordering === 0) {
+        fail('projection-duplicate', `projection line ${lineNumber} duplicates its predecessor`);
+      }
+      if (ordering > 0) {
+        fail('projection-order', `projection line ${lineNumber} is not in raw UTF-8 order`);
+      }
+    }
+    const triple = parseCanonicalProjectionLine(line, lineNumber);
+    if (
+      triple.subject === reservedCommitmentSubject
+      && triple.predicate !== CG_SHARED_PRIVATE_ANCHOR_PREDICATE_V1
+      && triple.predicate !== CG_SHARED_PRIVATE_HASH_PREDICATE_V1
+    ) {
+      fail(
+        'projection-private-subject',
+        `projection line ${lineNumber} reuses the reserved commitment subject`,
+      );
+    }
+    if (triple.predicate === CG_SHARED_PRIVATE_ANCHOR_PREDICATE_V1) {
+      if (anchor !== undefined) {
+        fail('projection-private-cardinality', 'projection contains duplicate private anchors');
+      }
+      anchor = triple;
+    } else if (triple.predicate === CG_SHARED_PRIVATE_HASH_PREDICATE_V1) {
+      if (privateHash !== undefined) {
+        fail('projection-private-cardinality', 'projection contains duplicate private hashes');
+      }
+      privateHash = triple;
+    } else if (triple.predicate.startsWith(PRIVATE_COMMITMENT_PREDICATE_PREFIX)) {
+      fail(
+        'projection-private-predicate',
+        `projection line ${lineNumber} uses an unknown reserved private-data predicate`,
+      );
+    }
+    leaves.push(triple.leaf);
+    previousLine = line;
+    lineStart = cursor + 1;
+  }
+  if (lineStart !== projectionBytes.byteLength) {
+    fail('projection-line-ending', 'projection contains bytes after its final complete line');
+  }
+
+  if (BigInt(lineNumber) !== BigInt(seal.publicTripleCount)) {
+    fail(
+      'projection-public-count',
+      'canonical projection line count differs from seal publicTripleCount',
+    );
+  }
+  assertPrivateCommitment(anchor, privateHash, seal);
+
+  const publicTree = new V10MerkleTree(leaves);
+  const publicRoot = bytesToDigest(publicTree.root);
+  const privateDataHash = seal.privateMerkleRoot ?? SENTINEL_NO_PRIVATE_DIGEST_V10;
+  const assertionMerkleRoot = bytesToDigest(V10MerkleTree.computeKARoot(
+    publicTree.root,
+    digestToBytes(privateDataHash),
+  ));
+  if (assertionMerkleRoot !== seal.assertionMerkleRoot) {
+    fail(
+      'projection-structured-root',
+      'recomputed structured assertion root differs from the author seal',
+    );
+  }
+  return Object.freeze({ publicRoot, privateDataHash, assertionMerkleRoot });
+}
+
+function assertPrivateCommitment(
+  anchor: CanonicalProjectionTripleV1 | undefined,
+  privateHash: CanonicalProjectionTripleV1 | undefined,
+  seal: Readonly<CanonicalGraphScopedAuthorSealV1>,
+): void {
+  const privateCount = BigInt(seal.privateTripleCount);
+  if (privateCount === 0n) {
+    if (seal.privateMerkleRoot !== null || anchor !== undefined || privateHash !== undefined) {
+      fail(
+        'projection-private-cardinality',
+        'public-only projection must not contain a private commitment',
+      );
+    }
+    return;
+  }
+  if (
+    seal.privateMerkleRoot === null
+    || anchor === undefined
+    || privateHash === undefined
+  ) {
+    fail(
+      'projection-private-cardinality',
+      'private-bearing projection requires exactly one anchor and one hash statement',
+    );
+  }
+  const expectedSubject = `${seal.kaUal}${CG_SHARED_PRIVATE_COMMITMENT_SUFFIX_V1}`;
+  if (anchor.subject !== expectedSubject || privateHash.subject !== expectedSubject) {
+    fail(
+      'projection-private-subject',
+      'private commitment subject is not derived from the canonical author-seal UAL',
+    );
+  }
+  if (anchor.object !== '"true"') {
+    fail('projection-private-cardinality', 'privateDataAnchor must be the plain literal "true"');
+  }
+  const expectedHash =
+    `"${seal.privateMerkleRoot.slice(2)}"^^<${XSD_HEX_BINARY_IRI}>`;
+  if (privateHash.object !== expectedHash) {
+    fail(
+      'projection-private-root-mismatch',
+      'privateDataHash does not reproduce the seal privateMerkleRoot',
+    );
+  }
+}
+
+function parseCanonicalProjectionLine(
+  lineBytes: Uint8Array,
+  lineNumber: number,
+): CanonicalProjectionTripleV1 {
+  let line: string;
+  try {
+    line = STRICT_UTF8.decode(lineBytes);
+  } catch (cause) {
+    fail('projection-utf8', `projection line ${lineNumber} is not valid UTF-8`, cause);
+  }
+  if (line.codePointAt(0) === 0xfeff) {
+    fail('projection-utf8', `projection line ${lineNumber} starts with a BOM`);
+  }
+  if (!line.endsWith(' .')) {
+    fail('projection-line', `projection line ${lineNumber} must end with exactly " ."`);
+  }
+
+  const objectEnd = line.length - 2;
+  const subject = parseCanonicalIriTerm(line, 0, lineNumber, 'subject');
+  if (line[subject.end] !== ' ') {
+    fail('projection-line', `projection line ${lineNumber} must contain one subject separator`);
+  }
+  const predicate = parseCanonicalIriTerm(
+    line,
+    subject.end + 1,
+    lineNumber,
+    'predicate',
+  );
+  if (line[predicate.end] !== ' ') {
+    fail('projection-line', `projection line ${lineNumber} must contain one predicate separator`);
+  }
+  const objectStart = predicate.end + 1;
+  if (objectStart >= objectEnd) {
+    fail('projection-line', `projection line ${lineNumber} has no object`);
+  }
+  const object = line.slice(objectStart, objectEnd);
+  assertCanonicalObjectTerm(object, lineNumber);
+
+  const reconstructed = tripleContentV10(
+    subject.value,
+    predicate.value,
+    object,
+  );
+  if (!equalBytes(reconstructed, lineBytes)) {
+    fail(
+      object.startsWith('"') ? 'projection-literal' : 'projection-line',
+      `projection line ${lineNumber} is not a canonical V10 fixed point`,
+    );
+  }
+  return Object.freeze({
+    subject: subject.value,
+    predicate: predicate.value,
+    object,
+    leaf: hashTripleV10(subject.value, predicate.value, object),
+  });
+}
+
+function parseCanonicalIriTerm(
+  input: string,
+  start: number,
+  lineNumber: number,
+  label: 'subject' | 'predicate' | 'object',
+): { readonly value: string; readonly end: number } {
+  if (input[start] !== '<') {
+    fail('projection-iri', `projection line ${lineNumber} ${label} must be an IRI`);
+  }
+  const endBracket = input.indexOf('>', start + 1);
+  if (endBracket < 0) {
+    fail('projection-iri', `projection line ${lineNumber} ${label} IRI is unterminated`);
+  }
+  const value = input.slice(start + 1, endBracket);
+  assertCanonicalIriValue(value, lineNumber, label);
+  return Object.freeze({ value, end: endBracket + 1 });
+}
+
+function assertCanonicalObjectTerm(object: string, lineNumber: number): void {
+  if (object.startsWith('<')) {
+    const parsed = parseCanonicalIriTerm(object, 0, lineNumber, 'object');
+    if (parsed.end !== object.length) {
+      fail('projection-iri', `projection line ${lineNumber} object has trailing bytes`);
+    }
+    return;
+  }
+  if (!object.startsWith('"')) {
+    fail(
+      'projection-line',
+      `projection line ${lineNumber} object must be a named node or literal`,
+    );
+  }
+  const literal = parseRdfLiteralLexicalTerm(object);
+  if (!literal) {
+    fail('projection-literal', `projection line ${lineNumber} literal is malformed`);
+  }
+  assertCanonicalLiteralBody(literal.body, lineNumber);
+  if (literal.suffix.kind === 'language') {
+    if (!LOWER_LANGUAGE_TAG.test(literal.suffix.language)) {
+      fail(
+        'projection-literal',
+        `projection line ${lineNumber} language tag is not canonical lowercase BCP47`,
+      );
+    }
+  } else if (literal.suffix.kind === 'datatype') {
+    if (literal.suffix.syntax !== 'bracketed') {
+      fail('projection-literal', `projection line ${lineNumber} datatype IRI is not bracketed`);
+    }
+    assertCanonicalIriValue(literal.suffix.datatype, lineNumber, 'object');
+  }
+  if (canonicalizeObjectTermForHash(object) !== object) {
+    fail(
+      'projection-literal',
+      `projection line ${lineNumber} literal is not the canonical V10 fixed point`,
+    );
+  }
+}
+
+function assertCanonicalLiteralBody(body: string, lineNumber: number): void {
+  for (let index = 0; index < body.length; index += 1) {
+    const code = body.charCodeAt(index);
+    if (code <= 0x1f || code === 0x7f) {
+      fail('projection-literal', `projection line ${lineNumber} literal contains a raw control`);
+    }
+    if (body[index] !== '\\') continue;
+    const escaped = body[index + 1];
+    if (escaped !== '\\' && escaped !== '"' && escaped !== 'n' && escaped !== 'r') {
+      fail(
+        'projection-literal',
+        `projection line ${lineNumber} literal uses a noncanonical escape`,
+      );
+    }
+    index += 1;
+  }
+}
+
+function assertCanonicalIriValue(
+  value: string,
+  lineNumber: number,
+  label: string,
+): void {
+  if (!isAbsoluteRfc3987IriV1(value)) {
+    fail('projection-iri', `projection line ${lineNumber} ${label} IRI is not absolute and safe`);
+  }
+  for (let index = 0; index < value.length; index += 1) {
+    if (value[index] === '%') {
+      if (!HEX_ESCAPE.test(value.slice(index + 1, index + 3))) {
+        fail('projection-iri', `projection line ${lineNumber} ${label} IRI has a bad percent escape`);
+      }
+      index += 2;
+      continue;
+    }
+    const codePoint = value.codePointAt(index)!;
+    if (
+      codePoint <= 0x20
+      || (codePoint >= 0x7f && codePoint <= 0x9f)
+      || (codePoint >= 0xd800 && codePoint <= 0xdfff)
+    ) {
+      fail('projection-iri', `projection line ${lineNumber} ${label} IRI has a forbidden code point`);
+    }
+    if (codePoint > 0xffff) index += 1;
+  }
+}
+
+function normalizeVerificationLimits(
+  value: CgSharedProjectionVerificationLimitsV1,
+): Readonly<CgSharedProjectionVerificationLimitsV1> {
+  const hard = DEFAULT_CG_SHARED_PROJECTION_VERIFICATION_LIMITS_V1;
+  for (const [name, member, ceiling] of [
+    ['maxProjectionBytes', value?.maxProjectionBytes, hard.maxProjectionBytes],
+    ['maxPublicTriples', value?.maxPublicTriples, hard.maxPublicTriples],
+    ['maxLineBytes', value?.maxLineBytes, hard.maxLineBytes],
+  ] as const) {
+    if (
+      !Number.isSafeInteger(member)
+      || member < 1
+      || member > ceiling
+    ) {
+      fail(
+        'projection-resource-refused',
+        `${name} is outside this in-memory verifier's supported range`,
+      );
+    }
+  }
+  if (value.maxLineBytes > value.maxProjectionBytes) {
+    fail(
+      'projection-resource-refused',
+      'maxLineBytes cannot exceed maxProjectionBytes',
+    );
+  }
+  return Object.freeze({
+    maxProjectionBytes: value.maxProjectionBytes,
+    maxPublicTriples: value.maxPublicTriples,
+    maxLineBytes: value.maxLineBytes,
+  });
+}
+
+function assertProjectionWithinLocalLimits(
+  projectionByteLength: ByteLengthV1,
+  publicTripleCount: SealTripleCountV1,
+  limits: Readonly<CgSharedProjectionVerificationLimitsV1>,
+): void {
+  if (BigInt(projectionByteLength) > BigInt(limits.maxProjectionBytes)) {
+    fail(
+      'projection-resource-refused',
+      'projection exceeds the local in-memory byte limit',
+    );
+  }
+  if (BigInt(publicTripleCount) > BigInt(limits.maxPublicTriples)) {
+    fail(
+      'projection-resource-refused',
+      'signed publicTripleCount exceeds the local in-memory leaf limit',
+    );
+  }
+}
+
+function computeProjectionDigest(projectionBytes: Uint8Array): Digest32V1 {
+  const hasher = sha256.create();
+  hasher.update(PROJECTION_DIGEST_DOMAIN);
+  hasher.update(projectionBytes);
+  return bytesToDigest(hasher.digest());
+}
+
+function digestToBytes(value: Digest32V1): Uint8Array {
+  const bytes = new Uint8Array(32);
+  for (let index = 0; index < bytes.length; index += 1) {
+    bytes[index] = Number.parseInt(value.slice(2 + index * 2, 4 + index * 2), 16);
+  }
+  return bytes;
+}
+
+function bytesToDigest(bytes: Uint8Array): Digest32V1 {
+  let value = '0x';
+  for (const byte of bytes) value += byte.toString(16).padStart(2, '0');
+  return value as Digest32V1;
+}
+
+function compareBytes(left: Uint8Array, right: Uint8Array): number {
+  const length = Math.min(left.byteLength, right.byteLength);
+  for (let index = 0; index < length; index += 1) {
+    if (left[index] !== right[index]) return left[index] - right[index];
+  }
+  return left.byteLength - right.byteLength;
+}
+
+function equalBytes(left: Uint8Array, right: Uint8Array): boolean {
+  if (left.byteLength !== right.byteLength) return false;
+  let difference = 0;
+  for (let index = 0; index < left.byteLength; index += 1) {
+    difference |= left[index] ^ right[index];
+  }
+  return difference === 0;
+}
+
+function fail(
+  code: CgSharedProjectionErrorCode,
+  message: string,
+  cause?: unknown,
+): never {
+  throw new CgSharedProjectionError(
+    code,
+    message,
+    cause === undefined ? {} : { cause },
+  );
+}

--- a/packages/core/src/cg-shared-projection.ts
+++ b/packages/core/src/cg-shared-projection.ts
@@ -706,10 +706,18 @@ function normalizeVerificationLimits(
   value: CgSharedProjectionVerificationLimitsV1,
 ): Readonly<CgSharedProjectionVerificationLimitsV1> {
   const hard = DEFAULT_CG_SHARED_PROJECTION_VERIFICATION_LIMITS_V1;
+  // Capture each caller-controlled limit exactly once. A stateful getter or
+  // Proxy could otherwise return a safe value during validation and an
+  // oversized value when the frozen result is built, smuggling a limit past
+  // the hard resource ceilings. Every check and the returned object below read
+  // only these captured scalars, never `value` a second time.
+  const maxProjectionBytes = value?.maxProjectionBytes;
+  const maxPublicTriples = value?.maxPublicTriples;
+  const maxLineBytes = value?.maxLineBytes;
   for (const [name, member, ceiling] of [
-    ['maxProjectionBytes', value?.maxProjectionBytes, hard.maxProjectionBytes],
-    ['maxPublicTriples', value?.maxPublicTriples, hard.maxPublicTriples],
-    ['maxLineBytes', value?.maxLineBytes, hard.maxLineBytes],
+    ['maxProjectionBytes', maxProjectionBytes, hard.maxProjectionBytes],
+    ['maxPublicTriples', maxPublicTriples, hard.maxPublicTriples],
+    ['maxLineBytes', maxLineBytes, hard.maxLineBytes],
   ] as const) {
     if (
       !Number.isSafeInteger(member)
@@ -722,16 +730,16 @@ function normalizeVerificationLimits(
       );
     }
   }
-  if (value.maxLineBytes > value.maxProjectionBytes) {
+  if (maxLineBytes > maxProjectionBytes) {
     fail(
       'projection-resource-refused',
       'maxLineBytes cannot exceed maxProjectionBytes',
     );
   }
   return Object.freeze({
-    maxProjectionBytes: value.maxProjectionBytes,
-    maxPublicTriples: value.maxPublicTriples,
-    maxLineBytes: value.maxLineBytes,
+    maxProjectionBytes,
+    maxPublicTriples,
+    maxLineBytes,
   });
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -51,6 +51,7 @@ export * from './ka-transfer-descriptor.js';
 export * from './ka-bundle-v1.js';
 export * from './ka-chunk-tree.js';
 export * from './ka-chunk-proof.js';
+export * from './cg-shared-projection.js';
 export * from './author-catalog-codec.js';
 export * from './author-catalog-objects.js';
 export * from './author-catalog-directory.js';

--- a/packages/core/src/transferred-catalog-bundle.ts
+++ b/packages/core/src/transferred-catalog-bundle.ts
@@ -72,6 +72,11 @@ export interface VerifiedTransferredCatalogBundleSnapshotV1 {
   readonly bundleBytes: Uint8Array;
 }
 
+export type VerifiedTransferredCatalogBundleMetadataV1 = Omit<
+  VerifiedTransferredCatalogBundleSnapshotV1,
+  'bundleBytes'
+>;
+
 export type TransferredCatalogBundleErrorCode =
   | 'transferred-bundle-head'
   | 'transferred-bundle-row'
@@ -315,7 +320,7 @@ export function readVerifiedTransferredCatalogBundleV1(
   row: AuthorCatalogRowV1,
   deployment: CatalogSealDeploymentProfileV1,
 ): VerifiedTransferredCatalogBundleSnapshotV1 {
-  assertVerifiedTransferredCatalogBundleForInputsV1(
+  const metadata = readVerifiedTransferredCatalogBundleMetadataV1(
     value,
     signedHead,
     row,
@@ -323,9 +328,51 @@ export function readVerifiedTransferredCatalogBundleV1(
   );
   const state = VERIFIED_TRANSFERRED_CATALOG_BUNDLES_V1.get(value as object)!;
   return Object.freeze({
-    ...state.snapshot,
+    ...metadata,
     bundleBytes: new Uint8Array(state.bundleBytes),
   });
+}
+
+/**
+ * Read only immutable scalar/capability metadata without copying a potentially
+ * one-gibibyte bundle. Exact input rebinding remains mandatory.
+ */
+export function readVerifiedTransferredCatalogBundleMetadataV1(
+  value: unknown,
+  signedHead: SignedAuthorCatalogHeadEnvelopeV1,
+  row: AuthorCatalogRowV1,
+  deployment: CatalogSealDeploymentProfileV1,
+): VerifiedTransferredCatalogBundleMetadataV1 {
+  assertVerifiedTransferredCatalogBundleForInputsV1(
+    value,
+    signedHead,
+    row,
+    deployment,
+  );
+  const state = VERIFIED_TRANSFERRED_CATALOG_BUNDLES_V1.get(value as object)!;
+  return Object.freeze({ ...state.snapshot });
+}
+
+/**
+ * Return only the canonical projection component as a fresh caller-owned copy.
+ * This avoids copying the seal and framing bytes when the semantic projection
+ * verifier consumes a large, already-verified transfer.
+ */
+export function readVerifiedTransferredCatalogProjectionBytesV1(
+  value: unknown,
+  signedHead: SignedAuthorCatalogHeadEnvelopeV1,
+  row: AuthorCatalogRowV1,
+  deployment: CatalogSealDeploymentProfileV1,
+): Uint8Array {
+  assertVerifiedTransferredCatalogBundleForInputsV1(
+    value,
+    signedHead,
+    row,
+    deployment,
+  );
+  const state = VERIFIED_TRANSFERRED_CATALOG_BUNDLES_V1.get(value as object)!;
+  const decoded = decodeOpaqueKaBundleV1(state.bundleBytes);
+  return new Uint8Array(decoded.projectionBytes);
 }
 
 function snapshotTransferredBundleInputs(

--- a/packages/core/test/absolute-rfc3987-iri.test.ts
+++ b/packages/core/test/absolute-rfc3987-iri.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import { isAbsoluteRfc3987IriV1 } from '../src/absolute-rfc3987-iri.js';
+
+describe('RFC 3987 absolute IRI syntax', () => {
+  it.each([
+    'a:',
+    'https://example.org/a/b?x=1#part',
+    'https://例え.テスト/路径',
+    'urn:example:animal:ferret:nose',
+    'did:dkg:otp:20430/0x3333333333333333333333333333333333333333/7',
+    'tag:example.org,2026:fixture',
+    'mailto:user@example.org',
+    'file:///tmp/example',
+    'http://[2001:db8::1]/a',
+    'http://[::192.0.2.1]/a',
+    'http://[v1.fe80]/a',
+    'urn:test:%E2%82%AC',
+    'urn:test:\u00A0',
+  ])('accepts %s', (value) => {
+    expect(isAbsoluteRfc3987IriV1(value)).toBe(true);
+  });
+
+  it.each([
+    '',
+    'relative/path',
+    '1bad:scheme',
+    'http://[',
+    'http://[]/',
+    'http://[2001:::1]/',
+    'http://[2001:db8::1',
+    'http://[192.0.2.1::]/',
+    'http://[1:192.0.2.1::]/',
+    'http://example.org/[x',
+    'http://example.org/a\\b',
+    'http://example.org/a b',
+    'http://example.org/%zz',
+    'http://example.org/%0',
+    'urn:test:\uFFFF',
+    'urn:test:\u{1FFFF}',
+    'urn:test:{x}',
+    'urn:test:#fragment#again',
+    'http://user@@example.org/',
+    'http://example.org:bad/',
+  ])('rejects %s', (value) => {
+    expect(isAbsoluteRfc3987IriV1(value)).toBe(false);
+  });
+
+  it('permits RFC3987 private-use code points only in the query component', () => {
+    expect(isAbsoluteRfc3987IriV1('urn:test:value?x=\uE000')).toBe(true);
+    expect(isAbsoluteRfc3987IriV1('urn:test:\uE000')).toBe(false);
+    expect(isAbsoluteRfc3987IriV1('urn:test:value#\uE000')).toBe(false);
+  });
+});

--- a/packages/core/test/cg-shared-projection.test.ts
+++ b/packages/core/test/cg-shared-projection.test.ts
@@ -500,6 +500,49 @@ describe('RFC-64 canonical cg-shared-v1 projection verification', () => {
       );
     }
   });
+
+  it('reads each caller-controlled limit exactly once (stateful-getter safe)', () => {
+    const fixture = publicFixture();
+    const hard = DEFAULT_CG_SHARED_PROJECTION_VERIFICATION_LIMITS_V1;
+    const reads = { maxProjectionBytes: 0, maxPublicTriples: 0, maxLineBytes: 0 };
+    const limits: CgSharedProjectionVerificationLimitsV1 = {
+      get maxProjectionBytes() {
+        reads.maxProjectionBytes += 1;
+        return hard.maxProjectionBytes;
+      },
+      get maxPublicTriples() {
+        reads.maxPublicTriples += 1;
+        return hard.maxPublicTriples;
+      },
+      get maxLineBytes() {
+        reads.maxLineBytes += 1;
+        return hard.maxLineBytes;
+      },
+    };
+    const verified = verifyProjection(fixture, limits);
+    // A stateful getter must be consulted exactly once per property so a later
+    // read cannot diverge from the validated value.
+    expect(reads).toEqual({ maxProjectionBytes: 1, maxPublicTriples: 1, maxLineBytes: 1 });
+    expect(readProjection(verified, fixture).verificationLimits).toEqual(hard);
+  });
+
+  it('cannot be tricked by a getter that turns oversized after validation', () => {
+    const fixture = publicFixture();
+    const safeBelowProjection = UTF8.encode(PUBLIC).byteLength - 1;
+    let projectionByteReads = 0;
+    // First read returns a safe value that passes validation; every later read
+    // returns an oversized value. A second read leaking into the effective
+    // ceiling would accept this over-limit projection instead of refusing it.
+    const limits: CgSharedProjectionVerificationLimitsV1 = {
+      get maxProjectionBytes() {
+        projectionByteReads += 1;
+        return projectionByteReads === 1 ? safeBelowProjection : Number.MAX_SAFE_INTEGER;
+      },
+      maxPublicTriples: 2,
+      maxLineBytes: safeBelowProjection,
+    };
+    expectFailure(() => verifyProjection(fixture, limits), 'projection-resource-refused');
+  });
 });
 
 interface Fixture {

--- a/packages/core/test/cg-shared-projection.test.ts
+++ b/packages/core/test/cg-shared-projection.test.ts
@@ -1,0 +1,726 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  assertAuthorCatalogRowV1,
+  type AuthorCatalogRowV1,
+} from '../src/author-catalog-codec.js';
+import {
+  AUTHOR_CATALOG_HEAD_OBJECT_TYPE_V1,
+  assertSignedAuthorCatalogHeadEnvelopeV1,
+  computeAuthorCatalogHeadObjectDigestV1,
+  type AuthorCatalogHeadV1,
+  type SignedAuthorCatalogHeadEnvelopeV1,
+} from '../src/author-catalog-objects.js';
+import {
+  CG_SHARED_PRIVATE_ANCHOR_PREDICATE_V1,
+  DEFAULT_CG_SHARED_PROJECTION_VERIFICATION_LIMITS_V1,
+  CgSharedProjectionError,
+  assertVerifiedCgSharedProjectionForTransferV1,
+  assertVerifiedCgSharedProjectionV1,
+  readVerifiedCgSharedProjectionBytesV1,
+  readVerifiedCgSharedProjectionMetadataV1,
+  readVerifiedCgSharedProjectionV1,
+  verifyCgSharedProjectionV1,
+  type CgSharedProjectionErrorCode,
+  type CgSharedProjectionVerificationLimitsV1,
+} from '../src/cg-shared-projection.js';
+import type { CatalogSealDeploymentProfileV1 } from '../src/catalog-seal-binding.js';
+import {
+  assertCanonicalGraphScopedAuthorSealV1,
+  canonicalizeCanonicalGraphScopedAuthorSealBytesV1,
+  computeCanonicalGraphScopedAuthorSealDigestV1,
+  type CanonicalGraphScopedAuthorSealV1,
+} from '../src/canonical-graph-scoped-author-seal.js';
+import { hashTripleV10 } from '../src/crypto/canonicalize.js';
+import {
+  SENTINEL_NO_PRIVATE_V10,
+  V10MerkleTree,
+} from '../src/crypto/v10-merkle.js';
+import { encodeOpaqueKaBundleV1 } from '../src/ka-bundle-v1.js';
+import { computeKaChunkTreeRootV1 } from '../src/ka-chunk-tree.js';
+import type { UnsignedControlEnvelopeV1 } from '../src/sync-control-object.js';
+import {
+  readVerifiedTransferredCatalogBundleMetadataV1,
+  readVerifiedTransferredCatalogProjectionBytesV1,
+  verifyTransferredCatalogBundleV1,
+  type VerifiedTransferredCatalogBundleV1,
+} from '../src/transferred-catalog-bundle.js';
+
+const AUTHOR = '0x3333333333333333333333333333333333333333';
+const ISSUER = '0x5555555555555555555555555555555555555555';
+const KAV10 = '0x4444444444444444444444444444444444444444';
+const KA_ID =
+  '23158417847463239084714197001737581570653996933112267175388663934063917137927';
+const UAL = `did:dkg:otp:20430/${AUTHOR}/7`;
+const COMMITMENT = `${UAL}/_cg-shared-v1`;
+const EIP191_SIGNATURE = `0x${'77'.repeat(65)}`;
+const ZERO_DIGEST = `0x${'00'.repeat(32)}`;
+const UTF8 = new TextEncoder();
+
+const PROFILE = {
+  networkId: 'otp:20430',
+  assertedAtChainId: '20430',
+  assertedAtKav10Address: KAV10,
+} as CatalogSealDeploymentProfileV1;
+
+const PUBLIC =
+  '<https://example.org/alice> <https://schema.org/age> "42"^^<http://www.w3.org/2001/XMLSchema#integer> .\n'
+  + '<https://example.org/alice> <https://schema.org/name> "Alice" .\n';
+const MIXED =
+  `<${COMMITMENT}> <http://dkg.io/ontology/privateDataAnchor> "true" .\n`
+  + `<${COMMITMENT}> <http://dkg.io/ontology/privateDataHash> "95f31b6b9c7ac80554b3808b2cef2f6542c89a28947ede43d194bb8022398e2c"^^<http://www.w3.org/2001/XMLSchema#hexBinary> .\n`
+  + '<https://example.org/alice> <https://schema.org/name> "Alice" .\n';
+const FULLY_WITHHELD =
+  `<${COMMITMENT}> <http://dkg.io/ontology/privateDataAnchor> "true" .\n`
+  + `<${COMMITMENT}> <http://dkg.io/ontology/privateDataHash> "034349e1ac2b108ba81720c55dff02bcae22762921f5c8354db83e687015872c"^^<http://www.w3.org/2001/XMLSchema#hexBinary> .\n`;
+
+describe('RFC-64 canonical cg-shared-v1 projection verification', () => {
+  it.each([
+    {
+      name: 'public',
+      projection: PUBLIC,
+      seal: {
+        assertionMerkleRoot: '0x8d7a7be6029c98db1a7300bf47008c90084d5de4a3b97a68c043c0ea4773609f',
+        publicTripleCount: '2',
+        privateTripleCount: '0',
+        privateMerkleRoot: null,
+      },
+      projectionDigest: '0x11e4d5cf843a836e3500a4a8d9bdc4495708056976247ad996f3497f5ff82e3d',
+      publicRoot: '0x0ff81162102568cf16401e4beebc03561950e6bb5b19ac686b9fa0e4132637ba',
+      privateDataHash: '0xdfba2a3576c2aa2d73ecd8c55d1c27cfb15691ca9d3237b86434a06592f160ee',
+    },
+    {
+      name: 'mixed',
+      projection: MIXED,
+      seal: {
+        assertionMerkleRoot: '0xb775676d78d72f9038ba726111b5f64c40f1cad159e7cada86dd7de16dbb6fa1',
+        publicTripleCount: '3',
+        privateTripleCount: '1',
+        privateMerkleRoot: '0x95f31b6b9c7ac80554b3808b2cef2f6542c89a28947ede43d194bb8022398e2c',
+      },
+      projectionDigest: '0xc45c59668c441426519220914ebeb59694ed60b2e502c7bff2548f3a8a3bcc4f',
+      publicRoot: '0xe3181c31fc57bed6862d86136c3f50b7c854ecfd602196a3862877bac2469e23',
+      privateDataHash: '0x95f31b6b9c7ac80554b3808b2cef2f6542c89a28947ede43d194bb8022398e2c',
+    },
+    {
+      name: 'fully withheld',
+      projection: FULLY_WITHHELD,
+      seal: {
+        assertionMerkleRoot: '0xe0f1eb9ec6ed3efe806b900cf738b81277c28e68a669b345318bf825e51f4378',
+        publicTripleCount: '2',
+        privateTripleCount: '2',
+        privateMerkleRoot: '0x034349e1ac2b108ba81720c55dff02bcae22762921f5c8354db83e687015872c',
+      },
+      projectionDigest: '0x508144f5a405975107fb0977fe7efb0554b63615b293ef8472b805fcded525fa',
+      publicRoot: '0x7758136bc9fbf2e668b694c0b4dae7188d559eaad1ccd7d1fbc062de16360e92',
+      privateDataHash: '0x034349e1ac2b108ba81720c55dff02bcae22762921f5c8354db83e687015872c',
+    },
+  ])('accepts the normative $name vector', (vector) => {
+    const fixture = makeFixture(vector.projection, vector.seal);
+    const verified = verifyProjection(fixture);
+    expect(Object.getPrototypeOf(verified)).toBeNull();
+    expect(Object.isFrozen(verified)).toBe(true);
+    expect(Reflect.ownKeys(verified as object)).toEqual([]);
+    const snapshot = readProjection(verified, fixture);
+    expect(snapshot).toMatchObject({
+      projectionDigest: vector.projectionDigest,
+      projectionByteLength: String(UTF8.encode(vector.projection).byteLength),
+      publicRoot: vector.publicRoot,
+      privateDataHash: vector.privateDataHash,
+      assertionMerkleRoot: vector.seal.assertionMerkleRoot,
+      publicTripleCount: vector.seal.publicTripleCount,
+      privateTripleCount: vector.seal.privateTripleCount,
+      privateMerkleRoot: vector.seal.privateMerkleRoot,
+      kaUal: UAL,
+      verificationLimits: DEFAULT_CG_SHARED_PROJECTION_VERIFICATION_LIMITS_V1,
+    });
+    expect(snapshot.projectionBytes).toEqual(UTF8.encode(vector.projection));
+  });
+
+  it('sorts by raw UTF-8 bytes rather than JavaScript UTF-16 code units', () => {
+    const first = '<https://example.org/\uF900> <https://schema.org/name> "bmp" .';
+    const second = '<https://example.org/\u{10000}> <https://schema.org/name> "astral" .';
+    expect([first, second].sort()).toEqual([second, first]);
+    const canonical = `${first}\n${second}\n`;
+    const fixture = makeFixture(canonical, sealForProjection(canonical, '0', null));
+    expect(() => verifyProjection(fixture)).not.toThrow();
+
+    const wrongOrder = `${second}\n${first}\n`;
+    const wrong = makeFixture(wrongOrder, sealForProjection(wrongOrder, '0', null));
+    expectFailure(() => verifyProjection(wrong), 'projection-order');
+  });
+
+  it.each([
+    '<a:> <https://schema.org/name> "empty hierarchy" .\n',
+    '<urn:test:\u00A0> <https://schema.org/name> "RFC3987 non-ASCII space" .\n',
+  ])('accepts valid RFC3987 boundary IRIs without legacy regex narrowing', (projection) => {
+    const fixture = makeFixture(projection, sealForProjection(projection, '0', null));
+    expect(() => verifyProjection(fixture)).not.toThrow();
+  });
+
+  it('returns only fresh projection copies from both verification boundaries', () => {
+    const fixture = makeFixture(PUBLIC, {
+      assertionMerkleRoot: '0x8d7a7be6029c98db1a7300bf47008c90084d5de4a3b97a68c043c0ea4773609f',
+      publicTripleCount: '2',
+      privateTripleCount: '0',
+      privateMerkleRoot: null,
+    });
+    const metadata = readVerifiedTransferredCatalogBundleMetadataV1(
+      fixture.transferred,
+      fixture.head,
+      fixture.row,
+      PROFILE,
+    );
+    expect('bundleBytes' in metadata).toBe(false);
+    const firstTransferRead = readVerifiedTransferredCatalogProjectionBytesV1(
+      fixture.transferred,
+      fixture.head,
+      fixture.row,
+      PROFILE,
+    );
+    firstTransferRead.fill(0);
+    expect(readVerifiedTransferredCatalogProjectionBytesV1(
+      fixture.transferred,
+      fixture.head,
+      fixture.row,
+      PROFILE,
+    )).toEqual(UTF8.encode(PUBLIC));
+
+    const verified = verifyProjection(fixture);
+    const projectionMetadata = readVerifiedCgSharedProjectionMetadataV1(
+      verified,
+      fixture.transferred,
+      fixture.head,
+      fixture.row,
+      PROFILE,
+    );
+    expect('projectionBytes' in projectionMetadata).toBe(false);
+    expect(projectionMetadata.projectionByteLength).toBe(String(UTF8.encode(PUBLIC).byteLength));
+    const explicitBytes = readVerifiedCgSharedProjectionBytesV1(
+      verified,
+      fixture.transferred,
+      fixture.head,
+      fixture.row,
+      PROFILE,
+    );
+    explicitBytes.fill(0);
+    expect(readVerifiedCgSharedProjectionBytesV1(
+      verified,
+      fixture.transferred,
+      fixture.head,
+      fixture.row,
+      PROFILE,
+    )).toEqual(UTF8.encode(PUBLIC));
+    const first = readProjection(verified, fixture);
+    first.projectionBytes.fill(0);
+    expect(readProjection(verified, fixture).projectionBytes).toEqual(UTF8.encode(PUBLIC));
+  });
+
+  it('rejects forged capabilities and cross-transfer replay', () => {
+    const fixture = publicFixture();
+    const verified = verifyProjection(fixture);
+    for (const forged of [
+      Object.freeze({}),
+      Object.freeze({ ...verified as object }),
+      JSON.parse(JSON.stringify(verified)),
+    ]) {
+      expectFailure(() => assertVerifiedCgSharedProjectionV1(forged), 'projection-capability');
+    }
+    const secondTransfer = verifyTransferredCatalogBundleV1(
+      fixture.head,
+      fixture.row,
+      fixture.encoded.bundleBytes,
+      PROFILE,
+    );
+    expectFailure(
+      () => assertVerifiedCgSharedProjectionForTransferV1(
+        verified,
+        secondTransfer,
+        fixture.head,
+        fixture.row,
+        PROFILE,
+      ),
+      'projection-binding',
+    );
+  });
+
+  it.each([
+    {
+      name: 'random private anchor',
+      projection: FULLY_WITHHELD.replaceAll(COMMITMENT, 'urn:dkg:private:00000000-0000-4000-8000-000000000000'),
+      seal: {
+        assertionMerkleRoot: '0x05eea89e80cb5eb80720e2ae005ab8a7df9baa4e3a3abdd5cd8af0c9185dc096',
+        publicTripleCount: '2', privateTripleCount: '2',
+        privateMerkleRoot: '0x034349e1ac2b108ba81720c55dff02bcae22762921f5c8354db83e687015872c',
+      },
+      code: 'projection-private-subject',
+    },
+    {
+      name: 'missing private hash',
+      projection: FULLY_WITHHELD.split('\n')[0] + '\n',
+      seal: {
+        assertionMerkleRoot: '0x68c726f6225b11c09ee3d6b591a2a6c1fae140c976b73f285fd47d62d629370b',
+        publicTripleCount: '1', privateTripleCount: '2',
+        privateMerkleRoot: '0x034349e1ac2b108ba81720c55dff02bcae22762921f5c8354db83e687015872c',
+      },
+      code: 'projection-private-cardinality',
+    },
+    {
+      name: 'wrong private hash',
+      projection: FULLY_WITHHELD.replace(
+        '034349e1ac2b108ba81720c55dff02bcae22762921f5c8354db83e687015872c',
+        'f'.repeat(64),
+      ),
+      seal: {
+        assertionMerkleRoot: '0x4b521d726668cc2d6cdd4427690c3e47e92cf6733d850e3303feb0fca0b68e31',
+        publicTripleCount: '2', privateTripleCount: '2',
+        privateMerkleRoot: '0x034349e1ac2b108ba81720c55dff02bcae22762921f5c8354db83e687015872c',
+      },
+      code: 'projection-private-root-mismatch',
+    },
+    {
+      name: 'unsorted public lines',
+      projection: PUBLIC.split('\n').filter(Boolean).reverse().join('\n') + '\n',
+      seal: {
+        assertionMerkleRoot: '0x8d7a7be6029c98db1a7300bf47008c90084d5de4a3b97a68c043c0ea4773609f',
+        publicTripleCount: '2', privateTripleCount: '0', privateMerkleRoot: null,
+      },
+      code: 'projection-order',
+    },
+    {
+      name: 'duplicate public line',
+      projection: PUBLIC.split('\n')[0] + '\n' + PUBLIC,
+      seal: {
+        assertionMerkleRoot: '0x8d7a7be6029c98db1a7300bf47008c90084d5de4a3b97a68c043c0ea4773609f',
+        publicTripleCount: '3', privateTripleCount: '0', privateMerkleRoot: null,
+      },
+      code: 'projection-duplicate',
+    },
+    {
+      name: 'CRLF',
+      projection: PUBLIC.replaceAll('\n', '\r\n'),
+      seal: {
+        assertionMerkleRoot: '0x8d7a7be6029c98db1a7300bf47008c90084d5de4a3b97a68c043c0ea4773609f',
+        publicTripleCount: '2', privateTripleCount: '0', privateMerkleRoot: null,
+      },
+      code: 'projection-line-ending',
+    },
+  ] as const)('rejects the normative $name vector', (vector) => {
+    const fixture = makeFixture(vector.projection, vector.seal);
+    expectFailure(() => verifyProjection(fixture), vector.code);
+  });
+
+  it.each([
+    ['missing final LF', PUBLIC.slice(0, -1), 'projection-line-ending'],
+    ['leading BOM', `\uFEFF${PUBLIC}`, 'projection-utf8'],
+    ['leading space', ` ${PUBLIC}`, 'projection-iri'],
+    ['blank-node subject', '_:b0 <https://schema.org/name> "Alice" .\n', 'projection-iri'],
+    ['relative IRI', '<relative> <https://schema.org/name> "Alice" .\n', 'projection-iri'],
+    ['bad percent escape', '<https://example.org/%zz> <https://schema.org/name> "Alice" .\n', 'projection-iri'],
+    ['malformed IP literal', '<http://[> <https://schema.org/name> "Alice" .\n', 'projection-iri'],
+    ['forbidden bracket in path', '<http://example.org/[x> <https://schema.org/name> "Alice" .\n', 'projection-iri'],
+    ['RFC3987 noncharacter', '<urn:test:\uFFFF> <https://schema.org/name> "Alice" .\n', 'projection-iri'],
+    ['fourth graph term', '<https://example.org/s> <https://example.org/p> "x" <https://example.org/g> .\n', 'projection-literal'],
+    ['blank-node object', '<https://example.org/s> <https://example.org/p> _:b0 .\n', 'projection-line'],
+    ['RDF-star object', '<https://example.org/s> <https://example.org/p> << <https://example.org/a> <https://example.org/b> "x" >> .\n', 'projection-iri'],
+    ['doubled separator', '<https://example.org/s>  <https://example.org/p> "x" .\n', 'projection-iri'],
+    ['trailing space', '<https://example.org/s> <https://example.org/p> "x" . \n', 'projection-line'],
+    ['explicit xsd:string', '<https://example.org/s> <https://example.org/p> "x"^^<http://www.w3.org/2001/XMLSchema#string> .\n', 'projection-literal'],
+    ['uppercase language', '<https://example.org/s> <https://example.org/p> "x"@EN .\n', 'projection-literal'],
+    ['noncanonical integer', '<https://example.org/s> <https://example.org/p> "+042"^^<http://www.w3.org/2001/XMLSchema#integer> .\n', 'projection-literal'],
+    ['unknown reserved predicate', '<https://example.org/s> <http://dkg.io/ontology/privateDataOther> "x" .\n', 'projection-private-predicate'],
+  ] as const)('rejects %s', (_name, projection, code) => {
+    const fixture = makeFixture(
+      projection,
+      sealForProjection(projection, '0', null),
+    );
+    expectFailure(() => verifyProjection(fixture), code);
+  });
+
+  it('rejects an empty projection before root work', () => {
+    const fixture = makeFixture('', {
+      assertionMerkleRoot: ZERO_DIGEST,
+      publicTripleCount: '1',
+      privateTripleCount: '0',
+      privateMerkleRoot: null,
+    });
+    expectFailure(() => verifyProjection(fixture), 'projection-empty');
+  });
+
+  it('rejects invalid UTF-8 before term work', () => {
+    const bytes = UTF8.encode(PUBLIC);
+    bytes[1] = 0xff;
+    const fixture = makeFixtureBytes(bytes, {
+      assertionMerkleRoot: '0x8d7a7be6029c98db1a7300bf47008c90084d5de4a3b97a68c043c0ea4773609f',
+      publicTripleCount: '2', privateTripleCount: '0', privateMerkleRoot: null,
+    });
+    expectFailure(() => verifyProjection(fixture), 'projection-utf8');
+  });
+
+  it('rejects public count and structured-root mismatches independently', () => {
+    const wrongCount = makeFixture(PUBLIC, {
+      assertionMerkleRoot: '0x8d7a7be6029c98db1a7300bf47008c90084d5de4a3b97a68c043c0ea4773609f',
+      publicTripleCount: '3', privateTripleCount: '0', privateMerkleRoot: null,
+    });
+    expectFailure(() => verifyProjection(wrongCount), 'projection-public-count');
+
+    const wrongRoot = makeFixture(PUBLIC, {
+      assertionMerkleRoot: ZERO_DIGEST,
+      publicTripleCount: '2', privateTripleCount: '0', privateMerkleRoot: null,
+    });
+    expectFailure(() => verifyProjection(wrongRoot), 'projection-structured-root');
+  });
+
+  it('rejects private commitment predicates in a public-only projection', () => {
+    const projection =
+      `<${COMMITMENT}> <${CG_SHARED_PRIVATE_ANCHOR_PREDICATE_V1}> "true" .\n`;
+    const fixture = makeFixture(projection, sealForProjection(projection, '0', null));
+    expectFailure(() => verifyProjection(fixture), 'projection-private-cardinality');
+  });
+
+  it('rejects an xsd:boolean private anchor even when the alternate root is signed', () => {
+    const projection = FULLY_WITHHELD.replace(
+      '"true" .',
+      '"true"^^<http://www.w3.org/2001/XMLSchema#boolean> .',
+    );
+    const fixture = makeFixture(
+      projection,
+      sealForProjection(
+        projection,
+        '2',
+        '0x034349e1ac2b108ba81720c55dff02bcae22762921f5c8354db83e687015872c',
+      ),
+    );
+    expectFailure(() => verifyProjection(fixture), 'projection-private-cardinality');
+  });
+
+  it('does not inherit mutation of the exported V10 no-private sentinel', () => {
+    const fixture = publicFixture();
+    const original = new Uint8Array(SENTINEL_NO_PRIVATE_V10);
+    try {
+      SENTINEL_NO_PRIVATE_V10.fill(0);
+      const verified = verifyProjection(fixture);
+      expect(readProjection(verified, fixture).assertionMerkleRoot).toBe(
+        '0x8d7a7be6029c98db1a7300bf47008c90084d5de4a3b97a68c043c0ea4773609f',
+      );
+    } finally {
+      SENTINEL_NO_PRIVATE_V10.set(original);
+    }
+  });
+
+  it('reserves the deterministic commitment subject exclusively for codec rows', () => {
+    const projection =
+      `<${COMMITMENT}> <https://example.org/not-a-commitment> "x" .\n`;
+    const fixture = makeFixture(projection, sealForProjection(projection, '0', null));
+    expectFailure(() => verifyProjection(fixture), 'projection-private-subject');
+  });
+
+  it.each([
+    {
+      name: 'uppercase private hash',
+      projection: FULLY_WITHHELD.replace('034349e1', 'A34349e1'),
+    },
+    {
+      name: '0x-prefixed private hash',
+      projection: FULLY_WITHHELD.replace('"034349e1', '"0x034349e1'),
+    },
+  ])('rejects $name even when the alternate bytes are sealed', ({ projection }) => {
+    const fixture = makeFixture(
+      projection,
+      sealForProjection(
+        projection,
+        '2',
+        '0x034349e1ac2b108ba81720c55dff02bcae22762921f5c8354db83e687015872c',
+      ),
+    );
+    expectFailure(() => verifyProjection(fixture), 'projection-private-root-mismatch');
+  });
+
+  it('rejects distinct duplicate commitment predicates', () => {
+    const duplicate =
+      `<${COMMITMENT}> <${CG_SHARED_PRIVATE_ANCHOR_PREDICATE_V1}> "false" .\n`;
+    const projection = [
+      ...FULLY_WITHHELD.trimEnd().split('\n'),
+      duplicate.trimEnd(),
+    ].sort((left, right) => Buffer.from(left).compare(Buffer.from(right))).join('\n') + '\n';
+    const fixture = makeFixture(
+      projection,
+      sealForProjection(
+        projection,
+        '2',
+        '0x034349e1ac2b108ba81720c55dff02bcae22762921f5c8354db83e687015872c',
+      ),
+    );
+    expectFailure(() => verifyProjection(fixture), 'projection-private-cardinality');
+  });
+
+  it('distinguishes local resource refusal from malformed projection bytes', () => {
+    const fixture = publicFixture();
+    expectFailure(
+      () => verifyProjection(fixture, {
+        maxProjectionBytes: UTF8.encode(PUBLIC).byteLength - 1,
+        maxPublicTriples: 2,
+        maxLineBytes: UTF8.encode(PUBLIC).byteLength - 1,
+      }),
+      'projection-resource-refused',
+    );
+    expectFailure(
+      () => verifyProjection(fixture, {
+        maxProjectionBytes: UTF8.encode(PUBLIC).byteLength,
+        maxPublicTriples: 1,
+        maxLineBytes: UTF8.encode(PUBLIC).byteLength,
+      }),
+      'projection-resource-refused',
+    );
+    expectFailure(
+      () => verifyProjection(fixture, {
+        maxProjectionBytes: UTF8.encode(PUBLIC).byteLength,
+        maxPublicTriples: 2,
+        maxLineBytes: 32,
+      }),
+      'projection-resource-refused',
+    );
+  });
+
+  it('rejects unsupported or internally inconsistent verifier limits', () => {
+    const fixture = publicFixture();
+    for (const limits of [
+      { maxProjectionBytes: 0, maxPublicTriples: 2, maxLineBytes: 1 },
+      {
+        maxProjectionBytes:
+          DEFAULT_CG_SHARED_PROJECTION_VERIFICATION_LIMITS_V1.maxProjectionBytes + 1,
+        maxPublicTriples: 2,
+        maxLineBytes: 1,
+      },
+      { maxProjectionBytes: 64, maxPublicTriples: 2, maxLineBytes: 65 },
+    ]) {
+      expectFailure(
+        () => verifyProjection(fixture, limits),
+        'projection-resource-refused',
+      );
+    }
+  });
+});
+
+interface Fixture {
+  readonly head: SignedAuthorCatalogHeadEnvelopeV1;
+  readonly row: AuthorCatalogRowV1;
+  readonly encoded: ReturnType<typeof encodeOpaqueKaBundleV1>;
+  readonly transferred: VerifiedTransferredCatalogBundleV1;
+}
+
+function publicFixture(): Fixture {
+  return makeFixture(PUBLIC, {
+    assertionMerkleRoot: '0x8d7a7be6029c98db1a7300bf47008c90084d5de4a3b97a68c043c0ea4773609f',
+    publicTripleCount: '2', privateTripleCount: '0', privateMerkleRoot: null,
+  });
+}
+
+function makeFixture(
+  projection: string,
+  sealFields: Pick<
+    CanonicalGraphScopedAuthorSealV1,
+    'assertionMerkleRoot' | 'publicTripleCount' | 'privateTripleCount' | 'privateMerkleRoot'
+  >,
+): Fixture {
+  return makeFixtureBytes(UTF8.encode(projection), sealFields);
+}
+
+function makeFixtureBytes(
+  projectionBytes: Uint8Array,
+  sealFields: Pick<
+    CanonicalGraphScopedAuthorSealV1,
+    'assertionMerkleRoot' | 'publicTripleCount' | 'privateTripleCount' | 'privateMerkleRoot'
+  >,
+): Fixture {
+  const seal = validSeal({
+    assertionMerkleRoot: sealFields.assertionMerkleRoot,
+    authorAddress: AUTHOR,
+    authorAttestationR: `0x${'11'.repeat(32)}`,
+    authorAttestationVS: `0x${'22'.repeat(32)}`,
+    authorSchemeVersion: '1',
+    assertedAtChainId: '20430',
+    assertedAtKav10Address: KAV10,
+    reservedKaId: KA_ID,
+    assertionFinalizedAt: '2026-07-19T12:34:56.789Z',
+    contentScopeVersion: '2',
+    kaUal: UAL,
+    assertionVersion: '2',
+    publicTripleCount: sealFields.publicTripleCount,
+    privateTripleCount: sealFields.privateTripleCount,
+    privateMerkleRoot: sealFields.privateMerkleRoot,
+  });
+  const sealBytes = canonicalizeCanonicalGraphScopedAuthorSealBytesV1(seal);
+  const encoded = encodeOpaqueKaBundleV1(projectionBytes, sealBytes);
+  const row = rowForBundle(
+    encoded.bundleBytes,
+    encoded.projectionDigest,
+    encoded.blobDigest,
+    computeCanonicalGraphScopedAuthorSealDigestV1(seal),
+  );
+  const head = signedHead({
+    networkId: 'otp:20430',
+    contextGraphId: 'a/b',
+    governanceChainId: '20430',
+    governanceContractAddress: '0x6666666666666666666666666666666666666666',
+    ownershipTransitionDigest: null,
+    subGraphName: null,
+    authorAddress: AUTHOR,
+    catalogIssuerDelegationDigest: `0x${'77'.repeat(32)}`,
+    era: '0',
+    version: '1',
+    previousHeadDigest: null,
+    bucketCount: '1',
+    totalRows: '1',
+    directoryHeight: '0',
+    directoryRootDigest: `0x${'88'.repeat(32)}`,
+    issuedAt: '1700000000123',
+  });
+  const transferred = verifyTransferredCatalogBundleV1(
+    head,
+    row,
+    encoded.bundleBytes,
+    PROFILE,
+  );
+  return { head, row, encoded, transferred };
+}
+
+function sealForProjection(
+  projection: string,
+  privateTripleCount: string,
+  privateMerkleRoot: string | null,
+): Pick<
+  CanonicalGraphScopedAuthorSealV1,
+  'assertionMerkleRoot' | 'publicTripleCount' | 'privateTripleCount' | 'privateMerkleRoot'
+> {
+  const lines = projection.endsWith('\n')
+    ? projection.slice(0, -1).split('\n')
+    : projection.split('\n');
+  const leaves = lines.filter(Boolean).map((line) => {
+    const match = /^(<[^>]+>) (<[^>]+>) (.+) \.$/.exec(line);
+    if (!match) return hashTripleV10('https://invalid.example/s', 'https://invalid.example/p', '"x"');
+    return hashTripleV10(match[1].slice(1, -1), match[2].slice(1, -1), match[3]);
+  });
+  const publicRoot = leaves.length === 0 ? new Uint8Array(32) : new V10MerkleTree(leaves).root;
+  const privateDataHash = privateMerkleRoot === null
+    ? SENTINEL_NO_PRIVATE_V10
+    : hexToBytes(privateMerkleRoot);
+  return {
+    assertionMerkleRoot: bytesToHex(V10MerkleTree.computeKARoot(publicRoot, privateDataHash)),
+    publicTripleCount: String(lines.filter(Boolean).length),
+    privateTripleCount,
+    privateMerkleRoot,
+  } as Pick<
+    CanonicalGraphScopedAuthorSealV1,
+    'assertionMerkleRoot' | 'publicTripleCount' | 'privateTripleCount' | 'privateMerkleRoot'
+  >;
+}
+
+function verifyProjection(
+  fixture: Fixture,
+  limits?: CgSharedProjectionVerificationLimitsV1,
+) {
+  return verifyCgSharedProjectionV1(
+    fixture.transferred,
+    fixture.head,
+    fixture.row,
+    PROFILE,
+    limits,
+  );
+}
+
+function readProjection(
+  verified: ReturnType<typeof verifyCgSharedProjectionV1>,
+  fixture: Fixture,
+) {
+  return readVerifiedCgSharedProjectionV1(
+    verified,
+    fixture.transferred,
+    fixture.head,
+    fixture.row,
+    PROFILE,
+  );
+}
+
+function rowForBundle(
+  bundleBytes: Uint8Array,
+  projectionDigest: string,
+  blobDigest: string,
+  sealDigest: string,
+): AuthorCatalogRowV1 {
+  const byteLength = BigInt(bundleBytes.byteLength);
+  return validRow({
+    kaId: KA_ID,
+    assertionCoordinate: 'name λ',
+    assertionVersion: '2',
+    projectionId: 'cg-shared-v1',
+    projectionDigest,
+    sealDigest,
+    transfer: {
+      codec: 'dkg-ka-bundle-v1',
+      projectionId: 'cg-shared-v1',
+      projectionDigest,
+      byteLength: byteLength.toString(),
+      chunkSize: '262144',
+      chunkCount: (((byteLength - 1n) / 262_144n) + 1n).toString(),
+      blobDigest,
+      chunkTreeRoot: computeKaChunkTreeRootV1(bundleBytes),
+    },
+  });
+}
+
+function signedHead(head: AuthorCatalogHeadV1): SignedAuthorCatalogHeadEnvelopeV1 {
+  const unsigned = {
+    issuer: ISSUER,
+    objectType: AUTHOR_CATALOG_HEAD_OBJECT_TYPE_V1,
+    payload: head,
+    signatureEvidence: { kind: 'none' },
+    signatureSuite: 'eip191-personal-sign-digest-v1',
+  } as UnsignedControlEnvelopeV1;
+  return validatedSignedHead({
+    ...unsigned,
+    objectDigest: computeAuthorCatalogHeadObjectDigestV1(unsigned),
+    signature: EIP191_SIGNATURE,
+  });
+}
+
+function validRow(value: unknown): AuthorCatalogRowV1 {
+  assertAuthorCatalogRowV1(value);
+  return value;
+}
+
+function validSeal(value: unknown): CanonicalGraphScopedAuthorSealV1 {
+  assertCanonicalGraphScopedAuthorSealV1(value);
+  return value;
+}
+
+function validatedSignedHead(value: unknown): SignedAuthorCatalogHeadEnvelopeV1 {
+  assertSignedAuthorCatalogHeadEnvelopeV1(value as SignedAuthorCatalogHeadEnvelopeV1);
+  return value as SignedAuthorCatalogHeadEnvelopeV1;
+}
+
+function hexToBytes(value: string): Uint8Array {
+  const bytes = new Uint8Array(32);
+  for (let index = 0; index < bytes.length; index += 1) {
+    bytes[index] = Number.parseInt(value.slice(2 + index * 2, 4 + index * 2), 16);
+  }
+  return bytes;
+}
+
+function bytesToHex(value: Uint8Array): string {
+  return `0x${[...value].map((byte) => byte.toString(16).padStart(2, '0')).join('')}`;
+}
+
+function expectFailure(
+  operation: () => unknown,
+  code: CgSharedProjectionErrorCode,
+): void {
+  try {
+    operation();
+  } catch (error) {
+    expect(error).toBeInstanceOf(CgSharedProjectionError);
+    expect((error as CgSharedProjectionError).code).toBe(code);
+    return;
+  }
+  throw new Error(`expected ${code}`);
+}


### PR DESCRIPTION
## Summary

Implements the receiver-side OT-RFC-64 semantic projection verifier on top of a fully verified transferred catalog bundle.

- validates canonical public/private projection bytes, ordering, uniqueness, ground N-Triples-like syntax, and absolute RFC 3987 IRIs
- verifies the UAL-derived commitment triple, public/private triple counts, immutable private sentinel, and V10 public/private/structured roots
- mints an opaque input-bound capability only after the complete projection closes
- adds metadata-only and projection-only readers to avoid unnecessary full-bundle copies
- fails locally with `projection-resource-refused` before large allocations; streaming verification remains a later slice

This is intentionally receiver-side verification only. It does not claim publication serialization, private graph source isolation, policy authority, finality, store admission, or activation.

## Verification

- focused projection and IRI suites: 78/78
- full `@origintrail-official/dkg-core` suite: 1,559/1,559
- core TypeScript build
- `git diff --check`
- independent strict audit: GO

## Stack

- Base: #1807
- RFC: OriginTrail/dkgv10-spec#144