### PR TITLE
feat(agent): verify RFC-64 catalog row authorship

### DIFF
--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -34,6 +34,7 @@ export {
   type SignAgentDelegationParams,
   type VerifyAgentDelegationOptions,
 } from './auth/agent-delegation.js';
+export * from './rfc64/catalog-row-authorship.js';
 export { encrypt, decrypt, ed25519ToX25519Private, ed25519ToX25519Public, x25519SharedSecret } from './encryption.js';
 export { MessageHandler, type SkillRequest, type SkillResponse, type SkillHandler, type ChatHandler, type ChatAclCheck } from './messaging.js';
 export {

--- a/packages/agent/src/rfc64/catalog-row-authorship.ts
+++ b/packages/agent/src/rfc64/catalog-row-authorship.ts
@@ -1,0 +1,1145 @@
+import { sha256 } from '@noble/hashes/sha2.js';
+import {
+  AuthorCatalogAuthorityCodecError,
+  AuthorCatalogObjectCodecError,
+  assertAuthorCatalogBucketScopeBindingV1,
+  assertCanonicalChainId,
+  assertCanonicalDigest,
+  assertCanonicalKaId,
+  assertContextGraphIdV1,
+  assertNetworkIdV1,
+  assertSubGraphNameV1,
+  canonicalizeAuthorCatalogBucketPayloadBytesV1,
+  canonicalizeAuthorCatalogRowV1,
+  canonicalizeSignedAuthorCatalogBucketEnvelopeBytesV1,
+  canonicalizeSignedAuthorCatalogDirectoryNodeEnvelopeBytesV1,
+  canonicalizeSignedAuthorCatalogHeadEnvelopeBytesV1,
+  canonicalizeSignedAuthorCatalogIssuerDelegationEnvelopeBytesV1,
+  catalogKeyToBucketIdV1,
+  computeAuthorCatalogRowDigestV1,
+  computeAuthorCatalogScopeDigestV1,
+  computeControlSignatureVariantDigestHex,
+  computeKaTransferIdentityDigestV1,
+  deriveAuthorCatalogScopeFromHeadV1,
+  parseCanonicalAuthorCatalogRowV1,
+  parseCanonicalDecimalU64,
+  parseCanonicalSignedAuthorCatalogBucketEnvelopeV1,
+  parseCanonicalSignedAuthorCatalogDirectoryNodeEnvelopeV1,
+  parseCanonicalSignedAuthorCatalogHeadEnvelopeV1,
+  parseCanonicalSignedAuthorCatalogIssuerDelegationEnvelopeV1,
+  readVerifiedAuthorCatalogBucketDescriptorV1,
+  verifyAuthorCatalogDirectoryPathV1,
+  type AuthorCatalogRowV1,
+  type ChainIdV1,
+  type ContextGraphIdV1,
+  type Digest32V1,
+  type EvmAddressV1,
+  type KaIdV1,
+  type NetworkIdV1,
+  type SignedAuthorCatalogBucketEnvelopeV1,
+  type SignedAuthorCatalogDirectoryNodeEnvelopeV1,
+  type SignedAuthorCatalogHeadEnvelopeV1,
+  type SignedAuthorCatalogIssuerDelegationEnvelopeV1,
+  type SubGraphNameV1,
+  type TimestampMsV1,
+  type VerifiedAuthorCatalogDirectoryPathV1,
+} from '@origintrail-official/dkg-core';
+import {
+  readVerifiedControlEnvelopeIssuerSignatureV1,
+  type VerifiedControlEnvelopeIssuerSignatureV1,
+  type VerifiedControlEnvelopeIssuerSignatureSnapshotV1,
+} from '@origintrail-official/dkg-chain';
+import { ethers } from 'ethers';
+
+import { computeDelegationDigest } from '../auth/agent-delegation.js';
+
+export const AUTHOR_CATALOG_AGENT_SCOPE_DIGEST_DOMAIN_V1 =
+  'dkg-author-catalog-agent-scope-v1\n' as const;
+export const AUTHOR_AGENT_DELEGATION_EVIDENCE_DIGEST_DOMAIN_V1 =
+  'dkg-author-agent-delegation-evidence-v1\n' as const;
+export const AUTHOR_CATALOG_AGENT_SCOPE_PREFIX_V1 =
+  'dkg:rfc64:author-catalog-issuer-v1:' as const;
+export const MAX_AUTHOR_AGENT_DELEGATION_EVIDENCE_BYTES_V1 = 4_096;
+export const MAX_AUTHOR_AGENT_DELEGATEE_PEER_ID_BYTES_V1 = 256;
+export const MAX_AUTHOR_AGENT_DELEGATION_TIMESTAMP_V1 = 9_007_199_254_740_991n;
+
+const UTF8 = new TextEncoder();
+const AUTHOR_CATALOG_AGENT_SCOPE_DOMAIN_BYTES_V1 = UTF8.encode(
+  AUTHOR_CATALOG_AGENT_SCOPE_DIGEST_DOMAIN_V1,
+);
+const AUTHOR_AGENT_EVIDENCE_DOMAIN_BYTES_V1 = UTF8.encode(
+  AUTHOR_AGENT_DELEGATION_EVIDENCE_DIGEST_DOMAIN_V1,
+);
+const SECP256K1_N = BigInt(
+  '0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141',
+);
+const SECP256K1_HALF_N = BigInt(
+  '0x7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0',
+);
+
+export interface AuthorCatalogAgentScopeV1 {
+  readonly networkId: NetworkIdV1;
+  readonly contextGraphId: ContextGraphIdV1;
+  readonly governanceChainId: ChainIdV1 | null;
+  readonly governanceContractAddress: EvmAddressV1 | null;
+  readonly ownershipTransitionDigest: Digest32V1 | null;
+  readonly subGraphName: SubGraphNameV1 | null;
+  readonly authorAddress: EvmAddressV1;
+}
+
+export interface AuthorAgentDelegationEvidenceV1 {
+  readonly authorAddress: EvmAddressV1;
+  readonly delegateeOpKey: EvmAddressV1;
+  readonly delegateePeerId: string | null;
+  readonly expiresAt: TimestampMsV1;
+  readonly issuedAt: TimestampMsV1;
+  readonly scope: string;
+  readonly signature: string;
+}
+
+export interface VerifyAuthorCatalogRowAuthorshipInputV1 {
+  readonly catalogIssuerDelegation: SignedAuthorCatalogIssuerDelegationEnvelopeV1;
+  readonly catalogIssuerDelegationSignature: VerifiedControlEnvelopeIssuerSignatureV1;
+  readonly parentAuthorAgentEvidence: AuthorAgentDelegationEvidenceV1 | null;
+  readonly catalogHead: SignedAuthorCatalogHeadEnvelopeV1;
+  readonly catalogHeadSignature: VerifiedControlEnvelopeIssuerSignatureV1;
+  readonly directoryPathEnvelopes: readonly SignedAuthorCatalogDirectoryNodeEnvelopeV1[];
+  readonly directoryPathSignatures: readonly VerifiedControlEnvelopeIssuerSignatureV1[];
+  readonly directoryPathProof: VerifiedAuthorCatalogDirectoryPathV1;
+  readonly catalogBucket: SignedAuthorCatalogBucketEnvelopeV1;
+  readonly catalogBucketSignature: VerifiedControlEnvelopeIssuerSignatureV1;
+  readonly targetKaId: KaIdV1;
+}
+
+declare const VERIFIED_AUTHOR_CATALOG_ROW_AUTHORSHIP_BRAND_V1: unique symbol;
+
+/**
+ * Process-local proof of only the exact author/catalog-key/signed-row closure.
+ * The phantom type brand is not present on the runtime token.
+ */
+export interface VerifiedAuthorCatalogRowAuthorshipV1 {
+  readonly [VERIFIED_AUTHOR_CATALOG_ROW_AUTHORSHIP_BRAND_V1]: true;
+}
+
+export interface VerifiedAuthorCatalogRowAuthorshipSnapshotV1 {
+  readonly authorCatalogAgentScopeDigest: Digest32V1;
+  readonly authorAuthorityEvidenceDigest: Digest32V1 | null;
+  readonly catalogIssuerDelegationObjectDigest: Digest32V1;
+  readonly catalogIssuerDelegationSignatureVariantDigest: Digest32V1;
+  readonly catalogHeadObjectDigest: Digest32V1;
+  readonly catalogHeadSignatureVariantDigest: Digest32V1;
+  readonly directoryPathObjectDigests: readonly Digest32V1[];
+  readonly directoryPathSignatureVariantDigests: readonly Digest32V1[];
+  readonly bucketObjectDigest: Digest32V1;
+  readonly bucketSignatureVariantDigest: Digest32V1;
+  readonly catalogScopeDigest: Digest32V1;
+  readonly catalogRowDigest: Digest32V1;
+  readonly transferIdentityDigest: Digest32V1;
+  readonly networkId: NetworkIdV1;
+  readonly contextGraphId: ContextGraphIdV1;
+  readonly governanceChainId: ChainIdV1 | null;
+  readonly governanceContractAddress: EvmAddressV1 | null;
+  readonly ownershipTransitionDigest: Digest32V1 | null;
+  readonly subGraphName: SubGraphNameV1 | null;
+  readonly authorAddress: EvmAddressV1;
+  readonly catalogIssuerKey: EvmAddressV1;
+  readonly era: SignedAuthorCatalogHeadEnvelopeV1['payload']['era'];
+  readonly version: SignedAuthorCatalogHeadEnvelopeV1['payload']['version'];
+  readonly bucketId: SignedAuthorCatalogBucketEnvelopeV1['payload']['bucketId'];
+  readonly effectiveAt: TimestampMsV1;
+  readonly expiresAt: TimestampMsV1;
+  readonly headIssuedAt: TimestampMsV1;
+  readonly row: Readonly<AuthorCatalogRowV1>;
+}
+
+export const AUTHOR_CATALOG_ROW_AUTHORSHIP_ERROR_CODES_V1 = Object.freeze([
+  'AUTHORSHIP_INPUT_INVALID',
+  'AUTHORSHIP_DEPENDENCY_MISSING',
+  'AUTHORSHIP_SIGNATURE_PROOF_INVALID',
+  'AUTHORSHIP_PARENT_EVIDENCE_INVALID',
+  'AUTHORSHIP_PARENT_DIGEST_MISMATCH',
+  'AUTHORSHIP_PARENT_SCOPE_MISMATCH',
+  'AUTHORSHIP_ISSUER_CLOSURE_MISMATCH',
+  'AUTHORSHIP_INTERVAL_MISMATCH',
+  'AUTHORSHIP_HEAD_BINDING_MISMATCH',
+  'AUTHORSHIP_PATH_BINDING_MISMATCH',
+  'AUTHORSHIP_BUCKET_BINDING_MISMATCH',
+  'AUTHORSHIP_ROW_BINDING_MISMATCH',
+  'AUTHORSHIP_CAPABILITY_INVALID',
+] as const);
+
+export type AuthorCatalogRowAuthorshipErrorCodeV1 =
+  (typeof AUTHOR_CATALOG_ROW_AUTHORSHIP_ERROR_CODES_V1)[number];
+
+export class AuthorCatalogRowAuthorshipErrorV1 extends Error {
+  readonly code: AuthorCatalogRowAuthorshipErrorCodeV1;
+
+  constructor(
+    code: AuthorCatalogRowAuthorshipErrorCodeV1,
+    message: string,
+    options: { readonly cause?: unknown } = {},
+  ) {
+    if (!AUTHOR_CATALOG_ROW_AUTHORSHIP_ERROR_CODES_V1.includes(code)) {
+      throw new TypeError(`Unsupported catalog-row authorship error code: ${String(code)}`);
+    }
+    super(message, options.cause === undefined ? undefined : { cause: options.cause });
+    this.name = 'AuthorCatalogRowAuthorshipErrorV1';
+    this.code = code;
+    Object.freeze(this);
+  }
+}
+
+const VERIFIED_AUTHOR_CATALOG_ROW_AUTHORSHIPS_V1 = new WeakMap<
+  object,
+  VerifiedAuthorCatalogRowAuthorshipSnapshotV1
+>();
+
+/** Derive the exact seven-key logical lane scoped by a parent author delegation. */
+export function deriveAuthorCatalogAgentScopeV1(
+  delegation: SignedAuthorCatalogIssuerDelegationEnvelopeV1,
+): Readonly<AuthorCatalogAgentScopeV1> {
+  const snapshot = snapshotCatalogIssuerDelegation(delegation);
+  const payload = snapshot.payload;
+  return Object.freeze({
+    authorAddress: payload.authorAddress,
+    contextGraphId: payload.contextGraphId,
+    governanceChainId: payload.governanceChainId,
+    governanceContractAddress: payload.governanceContractAddress,
+    networkId: payload.networkId,
+    ownershipTransitionDigest: payload.ownershipTransitionDigest,
+    subGraphName: payload.subGraphName,
+  });
+}
+
+export function computeAuthorCatalogAgentScopeDigestV1(
+  scope: AuthorCatalogAgentScopeV1,
+): Digest32V1 {
+  const snapshot = snapshotAuthorCatalogAgentScope(scope);
+  return digestWithDomain(
+    AUTHOR_CATALOG_AGENT_SCOPE_DOMAIN_BYTES_V1,
+    UTF8.encode(canonicalizeStringRecord(snapshot)),
+  );
+}
+
+export function buildAuthorCatalogAgentScopeV1(
+  scope: AuthorCatalogAgentScopeV1,
+): string {
+  return `${AUTHOR_CATALOG_AGENT_SCOPE_PREFIX_V1}${computeAuthorCatalogAgentScopeDigestV1(scope).slice(2)}`;
+}
+
+export function computeAuthorAgentDelegationEvidenceDigestV1(
+  evidence: AuthorAgentDelegationEvidenceV1,
+): Digest32V1 {
+  const snapshot = snapshotParentEvidence(evidence);
+  return computeParentEvidenceDigestAfterSnapshot(snapshot);
+}
+
+/**
+ * Close one exact signed catalog row under its author-authorized catalog key.
+ * No policy, timeliness, history, finality, persistence, RDF, or activation work
+ * is performed here.
+ */
+export function verifyAuthorCatalogRowAuthorshipV1(
+  untrustedInput: VerifyAuthorCatalogRowAuthorshipInputV1,
+): VerifiedAuthorCatalogRowAuthorshipV1 {
+  const input = snapshotTopLevelInput(untrustedInput);
+  const delegation = snapshotCatalogIssuerDelegation(input.catalogIssuerDelegation);
+  const head = snapshotCatalogHead(input.catalogHead);
+  const bucket = snapshotCatalogBucket(input.catalogBucket);
+  const targetKaId = snapshotTargetKaId(input.targetKaId);
+
+  // A canonical head caps directoryHeight at seven, so its exact root-to-leaf
+  // path contains 1..8 nodes. Preflight BOTH attacker-controlled arrays before
+  // canonicalizing a single envelope or opening a signature capability. This
+  // keeps an oversized dense array from turning a structurally invalid proof
+  // into unbounded parser/signature work before the core path verifier rejects
+  // it.
+  const expectedDirectoryPathLength = Number(BigInt(head.payload.directoryHeight) + 1n);
+  assertOrdinaryArrayExactLength(
+    input.directoryPathEnvelopes,
+    'directoryPathEnvelopes',
+    'AUTHORSHIP_PATH_BINDING_MISMATCH',
+    expectedDirectoryPathLength,
+  );
+  assertOrdinaryArrayExactLength(
+    input.directoryPathSignatures,
+    'directoryPathSignatures',
+    'AUTHORSHIP_PATH_BINDING_MISMATCH',
+    expectedDirectoryPathLength,
+  );
+
+  const directoryEnvelopes = snapshotDirectoryPath(
+    input.directoryPathEnvelopes,
+    head.payload.bucketCount,
+    expectedDirectoryPathLength,
+  );
+  const directorySignatureProofs = snapshotProofArray(
+    input.directoryPathSignatures,
+    'directoryPathSignatures',
+    expectedDirectoryPathLength,
+  );
+
+  const delegationSignature = bindExactSignatureProof(
+    input.catalogIssuerDelegationSignature,
+    delegation,
+  );
+  const headSignature = bindExactSignatureProof(input.catalogHeadSignature, head);
+  const bucketSignature = bindExactSignatureProof(input.catalogBucketSignature, bucket);
+  const directorySignatures = directoryEnvelopes.map((envelope, index) => {
+    try {
+      return bindExactSignatureProof(directorySignatureProofs[index], envelope);
+    } catch (cause) {
+      if (
+        cause instanceof AuthorCatalogRowAuthorshipErrorV1
+        && cause.code === 'AUTHORSHIP_SIGNATURE_PROOF_INVALID'
+      ) {
+        fail(
+          'AUTHORSHIP_PATH_BINDING_MISMATCH',
+          `directory path signature proof ${index} is not bound to its exact node`,
+          cause,
+        );
+      }
+      throw cause;
+    }
+  });
+
+  const delegationPayload = delegation.payload;
+  const agentScope = snapshotAuthorCatalogAgentScope({
+    authorAddress: delegationPayload.authorAddress,
+    contextGraphId: delegationPayload.contextGraphId,
+    governanceChainId: delegationPayload.governanceChainId,
+    governanceContractAddress: delegationPayload.governanceContractAddress,
+    networkId: delegationPayload.networkId,
+    ownershipTransitionDigest: delegationPayload.ownershipTransitionDigest,
+    subGraphName: delegationPayload.subGraphName,
+  });
+  const authorCatalogAgentScopeDigest = computeAuthorCatalogAgentScopeDigestV1(agentScope);
+  const expectedAgentScope =
+    `${AUTHOR_CATALOG_AGENT_SCOPE_PREFIX_V1}${authorCatalogAgentScopeDigest.slice(2)}`;
+
+  const issuerIsAuthor = delegation.issuer === delegationPayload.authorAddress;
+  const evidenceDigest = delegationPayload.authorAuthorityEvidenceDigest;
+  if (issuerIsAuthor) {
+    if (evidenceDigest !== null || input.parentAuthorAgentEvidence !== null) {
+      fail(
+        'AUTHORSHIP_ISSUER_CLOSURE_MISMATCH',
+        'direct author issuance requires null evidence and no parent evidence object',
+      );
+    }
+  } else {
+    if (evidenceDigest === null) {
+      fail(
+        'AUTHORSHIP_ISSUER_CLOSURE_MISMATCH',
+        'delegated issuance must name exact parent author-agent evidence',
+      );
+    }
+    if (input.parentAuthorAgentEvidence === null) {
+      fail(
+        'AUTHORSHIP_DEPENDENCY_MISSING',
+        'the referenced parent author-agent evidence object is unavailable',
+      );
+    }
+    const parent = snapshotParentEvidence(input.parentAuthorAgentEvidence);
+    if (computeParentEvidenceDigestAfterSnapshot(parent) !== evidenceDigest) {
+      fail(
+        'AUTHORSHIP_PARENT_DIGEST_MISMATCH',
+        'parent author-agent evidence does not hash to the delegated reference',
+      );
+    }
+    verifyParentEvidenceSignature(parent);
+    if (
+      parent.authorAddress !== delegationPayload.authorAddress
+      || parent.scope !== expectedAgentScope
+    ) {
+      fail(
+        'AUTHORSHIP_PARENT_SCOPE_MISMATCH',
+        'parent evidence is not scoped to the exact author, CG, governance tuple, and lane',
+      );
+    }
+    if (
+      parent.delegateeOpKey !== delegation.issuer
+      || parent.delegateeOpKey !== delegationPayload.catalogIssuerKey
+    ) {
+      fail(
+        'AUTHORSHIP_ISSUER_CLOSURE_MISMATCH',
+        'parent operational key, delegation issuer, and selected catalog key must match',
+      );
+    }
+    if (
+      BigInt(parent.issuedAt) > BigInt(delegationPayload.effectiveAt)
+      || BigInt(delegationPayload.effectiveAt) >= BigInt(delegationPayload.expiresAt)
+      || BigInt(delegationPayload.expiresAt) > BigInt(parent.expiresAt)
+    ) {
+      fail(
+        'AUTHORSHIP_INTERVAL_MISMATCH',
+        'catalog issuer interval is not contained in the parent half-open interval',
+      );
+    }
+  }
+
+  if (!issuerIsAuthor && delegation.issuer !== delegationPayload.catalogIssuerKey) {
+    fail(
+      'AUTHORSHIP_ISSUER_CLOSURE_MISMATCH',
+      'a delegated issuer may nominate only its own operational key as catalogIssuerKey',
+    );
+  }
+
+  assertHeadBinding(delegation, head);
+  const catalogIssuerKey = delegationPayload.catalogIssuerKey;
+  if (
+    head.issuer !== catalogIssuerKey
+    || bucket.issuer !== catalogIssuerKey
+    || directoryEnvelopes.some((envelope) => envelope.issuer !== catalogIssuerKey)
+  ) {
+    fail(
+      'AUTHORSHIP_HEAD_BINDING_MISMATCH',
+      'head, directory path, and bucket must all be signed by the exact catalog issuer key',
+    );
+  }
+
+  const headIssuedAt = BigInt(head.payload.issuedAt);
+  if (
+    headIssuedAt < BigInt(delegationPayload.effectiveAt)
+    || headIssuedAt >= BigInt(delegationPayload.expiresAt)
+  ) {
+    fail(
+      'AUTHORSHIP_INTERVAL_MISMATCH',
+      'catalog head issuedAt is outside the child half-open interval',
+    );
+  }
+
+  const scope = deriveAuthorCatalogScopeFromHeadV1(head.payload);
+  const catalogScopeDigest = computeAuthorCatalogScopeDigestV1(scope);
+  const selectedBucketId = catalogKeyToBucketIdV1(targetKaId, scope.bucketCount);
+  const descriptor = readBoundPathDescriptor(
+    input.directoryPathProof,
+    head,
+    directoryEnvelopes,
+    selectedBucketId,
+  );
+  if (descriptor.rowCount === '0' || descriptor.byteLength === '0') {
+    fail(
+      'AUTHORSHIP_BUCKET_BINDING_MISMATCH',
+      'an authorship proof requires a non-empty selected bucket descriptor',
+    );
+  }
+
+  const bucketPayloadBytes = canonicalizeAuthorCatalogBucketPayloadBytesV1(bucket.payload);
+  if (
+    descriptor.bucketDigest !== bucket.objectDigest
+    || descriptor.bucketId !== bucket.payload.bucketId
+    || descriptor.bucketId !== selectedBucketId
+    || BigInt(descriptor.byteLength) !== BigInt(bucketPayloadBytes.byteLength)
+    || BigInt(descriptor.rowCount) !== BigInt(bucket.payload.rows.length)
+  ) {
+    fail(
+      'AUTHORSHIP_BUCKET_BINDING_MISMATCH',
+      'signed leaf descriptor does not exactly describe the supplied signed bucket',
+    );
+  }
+  try {
+    assertAuthorCatalogBucketScopeBindingV1(bucket.payload, scope);
+  } catch (cause) {
+    fail(
+      isPackedAuthorFailure(cause)
+        ? 'AUTHORSHIP_ROW_BINDING_MISMATCH'
+        : 'AUTHORSHIP_BUCKET_BINDING_MISMATCH',
+      'signed bucket does not match the head-derived scope or packed author lane',
+      cause,
+    );
+  }
+
+  const matchingRows = bucket.payload.rows.filter((row) => row.kaId === targetKaId);
+  if (matchingRows.length !== 1) {
+    fail(
+      'AUTHORSHIP_ROW_BINDING_MISMATCH',
+      'target kaId must occur exactly once in its mathematically derived bucket',
+    );
+  }
+  const row = snapshotCatalogRow(matchingRows[0]);
+  if ((BigInt(row.kaId) >> 96n) !== BigInt(head.payload.authorAddress)) {
+    fail(
+      'AUTHORSHIP_ROW_BINDING_MISMATCH',
+      'target kaId high 160 bits do not equal the signed head author',
+    );
+  }
+  const catalogRowDigest = computeAuthorCatalogRowDigestV1(catalogScopeDigest, row);
+  const transferIdentityDigest = computeKaTransferIdentityDigestV1(row.transfer);
+
+  return mintVerifiedAuthorship({
+    authorCatalogAgentScopeDigest,
+    authorAuthorityEvidenceDigest: evidenceDigest,
+    catalogIssuerDelegationObjectDigest: delegation.objectDigest as Digest32V1,
+    catalogIssuerDelegationSignatureVariantDigest: delegationSignature.signatureVariantDigest,
+    catalogHeadObjectDigest: head.objectDigest as Digest32V1,
+    catalogHeadSignatureVariantDigest: headSignature.signatureVariantDigest,
+    directoryPathObjectDigests: Object.freeze(
+      directoryEnvelopes.map((envelope) => envelope.objectDigest as Digest32V1),
+    ),
+    directoryPathSignatureVariantDigests: Object.freeze(
+      directorySignatures.map((signature) => signature.signatureVariantDigest),
+    ),
+    bucketObjectDigest: bucket.objectDigest as Digest32V1,
+    bucketSignatureVariantDigest: bucketSignature.signatureVariantDigest,
+    catalogScopeDigest,
+    catalogRowDigest,
+    transferIdentityDigest,
+    networkId: head.payload.networkId,
+    contextGraphId: head.payload.contextGraphId,
+    governanceChainId: head.payload.governanceChainId,
+    governanceContractAddress: head.payload.governanceContractAddress,
+    ownershipTransitionDigest: head.payload.ownershipTransitionDigest,
+    subGraphName: head.payload.subGraphName,
+    authorAddress: head.payload.authorAddress,
+    catalogIssuerKey,
+    era: head.payload.era,
+    version: head.payload.version,
+    bucketId: bucket.payload.bucketId,
+    effectiveAt: delegationPayload.effectiveAt,
+    expiresAt: delegationPayload.expiresAt,
+    headIssuedAt: head.payload.issuedAt,
+    row,
+  });
+}
+
+export function assertVerifiedAuthorCatalogRowAuthorshipV1(
+  value: unknown,
+): asserts value is VerifiedAuthorCatalogRowAuthorshipV1 {
+  if (
+    (typeof value !== 'object' && typeof value !== 'function')
+    || value === null
+    || !VERIFIED_AUTHOR_CATALOG_ROW_AUTHORSHIPS_V1.has(value as object)
+  ) {
+    fail(
+      'AUTHORSHIP_CAPABILITY_INVALID',
+      'catalog-row authorship capability was not minted by this verifier',
+    );
+  }
+}
+
+export function assertVerifiedAuthorCatalogRowAuthorshipForTargetV1(
+  value: unknown,
+  catalogRowDigest: Digest32V1,
+  transferIdentityDigest: Digest32V1,
+): asserts value is VerifiedAuthorCatalogRowAuthorshipV1 {
+  assertVerifiedAuthorCatalogRowAuthorshipV1(value);
+  try {
+    assertCanonicalDigest(catalogRowDigest, 'catalogRowDigest');
+    assertCanonicalDigest(transferIdentityDigest, 'transferIdentityDigest');
+  } catch (cause) {
+    fail('AUTHORSHIP_CAPABILITY_INVALID', 'authorship target digests are not canonical', cause);
+  }
+  const snapshot = VERIFIED_AUTHOR_CATALOG_ROW_AUTHORSHIPS_V1.get(value as object)!;
+  if (
+    snapshot.catalogRowDigest !== catalogRowDigest
+    || snapshot.transferIdentityDigest !== transferIdentityDigest
+  ) {
+    fail(
+      'AUTHORSHIP_CAPABILITY_INVALID',
+      'catalog-row authorship capability is bound to different target digests',
+    );
+  }
+}
+
+export function readVerifiedAuthorCatalogRowAuthorshipV1(
+  value: unknown,
+): VerifiedAuthorCatalogRowAuthorshipSnapshotV1 {
+  assertVerifiedAuthorCatalogRowAuthorshipV1(value);
+  return VERIFIED_AUTHOR_CATALOG_ROW_AUTHORSHIPS_V1.get(value as object)!;
+}
+
+function snapshotTopLevelInput(
+  input: VerifyAuthorCatalogRowAuthorshipInputV1,
+): VerifyAuthorCatalogRowAuthorshipInputV1 {
+  if (!isPlainRecord(input)) {
+    fail('AUTHORSHIP_INPUT_INVALID', 'authorship input must be a plain object');
+  }
+  const expected = [
+    'catalogBucket',
+    'catalogBucketSignature',
+    'catalogHead',
+    'catalogHeadSignature',
+    'catalogIssuerDelegation',
+    'catalogIssuerDelegationSignature',
+    'directoryPathEnvelopes',
+    'directoryPathProof',
+    'directoryPathSignatures',
+    'parentAuthorAgentEvidence',
+    'targetKaId',
+  ];
+  const actual = Reflect.ownKeys(input);
+  if (actual.some((key) => typeof key !== 'string')) {
+    fail('AUTHORSHIP_INPUT_INVALID', 'authorship input must not contain symbol fields');
+  }
+  const actualStrings = actual as string[];
+  if (actualStrings.some((key) => !expected.includes(key))) {
+    fail('AUTHORSHIP_INPUT_INVALID', 'authorship input contains unknown fields');
+  }
+  const missing = expected.filter((key) => !actualStrings.includes(key));
+  if (missing.length > 0) {
+    const code = missing.every((key) => key !== 'targetKaId')
+      ? 'AUTHORSHIP_DEPENDENCY_MISSING'
+      : 'AUTHORSHIP_INPUT_INVALID';
+    fail(code, `authorship input is missing ${missing.join(', ')}`);
+  }
+  const snapshot: Record<string, unknown> = Object.create(null);
+  for (const key of expected) {
+    const descriptor = Object.getOwnPropertyDescriptor(input, key);
+    if (!descriptor?.enumerable || !Object.prototype.hasOwnProperty.call(descriptor, 'value')) {
+      fail('AUTHORSHIP_INPUT_INVALID', `authorship input ${key} must be an enumerable data field`);
+    }
+    snapshot[key] = descriptor.value;
+  }
+  for (const key of expected) {
+    if (key !== 'parentAuthorAgentEvidence' && key !== 'targetKaId' && snapshot[key] == null) {
+      fail('AUTHORSHIP_DEPENDENCY_MISSING', `authorship dependency ${key} is unavailable`);
+    }
+  }
+  return Object.freeze(snapshot) as unknown as VerifyAuthorCatalogRowAuthorshipInputV1;
+}
+
+function snapshotCatalogIssuerDelegation(
+  input: SignedAuthorCatalogIssuerDelegationEnvelopeV1,
+): SignedAuthorCatalogIssuerDelegationEnvelopeV1 {
+  try {
+    return deepFreezeJson(parseCanonicalSignedAuthorCatalogIssuerDelegationEnvelopeV1(
+      canonicalizeSignedAuthorCatalogIssuerDelegationEnvelopeBytesV1(input),
+    )) as SignedAuthorCatalogIssuerDelegationEnvelopeV1;
+  } catch (cause) {
+    if (
+      cause instanceof AuthorCatalogAuthorityCodecError
+      && cause.code === 'catalog-authority-authority'
+    ) {
+      fail(
+        'AUTHORSHIP_ISSUER_CLOSURE_MISMATCH',
+        'catalog issuer delegation has an invalid direct/delegated evidence branch',
+        cause,
+      );
+    }
+    if (
+      cause instanceof AuthorCatalogAuthorityCodecError
+      && cause.code === 'catalog-authority-time'
+    ) {
+      fail('AUTHORSHIP_INTERVAL_MISMATCH', 'catalog issuer interval is invalid', cause);
+    }
+    fail('AUTHORSHIP_INPUT_INVALID', 'catalog issuer delegation is invalid', cause);
+  }
+}
+
+function snapshotCatalogHead(
+  input: SignedAuthorCatalogHeadEnvelopeV1,
+): SignedAuthorCatalogHeadEnvelopeV1 {
+  try {
+    return deepFreezeJson(parseCanonicalSignedAuthorCatalogHeadEnvelopeV1(
+      canonicalizeSignedAuthorCatalogHeadEnvelopeBytesV1(input),
+    )) as SignedAuthorCatalogHeadEnvelopeV1;
+  } catch (cause) {
+    fail('AUTHORSHIP_INPUT_INVALID', 'catalog head is invalid', cause);
+  }
+}
+
+function snapshotCatalogBucket(
+  input: SignedAuthorCatalogBucketEnvelopeV1,
+): SignedAuthorCatalogBucketEnvelopeV1 {
+  try {
+    return deepFreezeJson(parseCanonicalSignedAuthorCatalogBucketEnvelopeV1(
+      canonicalizeSignedAuthorCatalogBucketEnvelopeBytesV1(input),
+    )) as SignedAuthorCatalogBucketEnvelopeV1;
+  } catch (cause) {
+    if (
+      cause instanceof AuthorCatalogObjectCodecError
+      && [
+        'catalog-object-bucket-mapping',
+        'catalog-object-duplicate',
+        'catalog-object-row-order',
+      ].includes(cause.code)
+    ) {
+      fail('AUTHORSHIP_ROW_BINDING_MISMATCH', 'catalog bucket row closure is invalid', cause);
+    }
+    fail('AUTHORSHIP_INPUT_INVALID', 'catalog bucket is invalid', cause);
+  }
+}
+
+function snapshotDirectoryPath(
+  input: readonly SignedAuthorCatalogDirectoryNodeEnvelopeV1[],
+  bucketCount: SignedAuthorCatalogHeadEnvelopeV1['payload']['bucketCount'],
+  expectedLength: number,
+): readonly SignedAuthorCatalogDirectoryNodeEnvelopeV1[] {
+  const values = snapshotDenseOrdinaryArray(
+    input,
+    'directoryPathEnvelopes',
+    'AUTHORSHIP_PATH_BINDING_MISMATCH',
+    expectedLength,
+  );
+  const snapshots = values.map((envelope) => {
+    try {
+      return deepFreezeJson(parseCanonicalSignedAuthorCatalogDirectoryNodeEnvelopeV1(
+        canonicalizeSignedAuthorCatalogDirectoryNodeEnvelopeBytesV1(
+          envelope as SignedAuthorCatalogDirectoryNodeEnvelopeV1,
+          bucketCount,
+        ),
+        bucketCount,
+      )) as SignedAuthorCatalogDirectoryNodeEnvelopeV1;
+    } catch (cause) {
+      fail('AUTHORSHIP_PATH_BINDING_MISMATCH', 'directory path envelope is invalid', cause);
+    }
+  });
+  return Object.freeze(snapshots);
+}
+
+function snapshotProofArray(
+  input: readonly VerifiedControlEnvelopeIssuerSignatureV1[],
+  label: string,
+  expectedLength: number,
+): readonly VerifiedControlEnvelopeIssuerSignatureV1[] {
+  return Object.freeze(snapshotDenseOrdinaryArray(
+    input,
+    label,
+    'AUTHORSHIP_PATH_BINDING_MISMATCH',
+    expectedLength,
+  ) as VerifiedControlEnvelopeIssuerSignatureV1[]);
+}
+
+function snapshotTargetKaId(input: KaIdV1): KaIdV1 {
+  try {
+    assertCanonicalKaId(input, 'targetKaId');
+    return input;
+  } catch (cause) {
+    fail('AUTHORSHIP_INPUT_INVALID', 'targetKaId is not canonical', cause);
+  }
+}
+
+function snapshotCatalogRow(row: AuthorCatalogRowV1): Readonly<AuthorCatalogRowV1> {
+  try {
+    return deepFreezeJson(
+      parseCanonicalAuthorCatalogRowV1(canonicalizeAuthorCatalogRowV1(row)),
+    ) as Readonly<AuthorCatalogRowV1>;
+  } catch (cause) {
+    fail('AUTHORSHIP_ROW_BINDING_MISMATCH', 'target row is invalid', cause);
+  }
+}
+
+function snapshotAuthorCatalogAgentScope(
+  input: AuthorCatalogAgentScopeV1,
+): Readonly<AuthorCatalogAgentScopeV1> {
+  if (!isPlainRecord(input)) {
+    fail('AUTHORSHIP_INPUT_INVALID', 'author catalog agent scope must be a plain object');
+  }
+  const values = exactPrimitiveDataSnapshot(input, [
+    'authorAddress',
+    'contextGraphId',
+    'governanceChainId',
+    'governanceContractAddress',
+    'networkId',
+    'ownershipTransitionDigest',
+    'subGraphName',
+  ], 'author catalog agent scope', 'AUTHORSHIP_INPUT_INVALID');
+  try {
+    assertEvmAddress(values.authorAddress, 'authorAddress');
+    assertNetworkIdV1(values.networkId, 'networkId');
+    assertContextGraphIdV1(values.contextGraphId, 'contextGraphId');
+    const chainIsNull = values.governanceChainId === null;
+    const contractIsNull = values.governanceContractAddress === null;
+    if (chainIsNull !== contractIsNull) throw new Error('governance tuple must be jointly null');
+    if (!contractIsNull) {
+      assertCanonicalChainId(values.governanceChainId, 'governanceChainId');
+      assertEvmAddress(values.governanceContractAddress, 'governanceContractAddress');
+    }
+    if (values.ownershipTransitionDigest !== null) {
+      assertCanonicalDigest(values.ownershipTransitionDigest, 'ownershipTransitionDigest');
+    }
+    if (values.subGraphName !== null) assertSubGraphNameV1(values.subGraphName, 'subGraphName');
+  } catch (cause) {
+    fail('AUTHORSHIP_INPUT_INVALID', 'author catalog agent scope is invalid', cause);
+  }
+  return Object.freeze(values) as unknown as Readonly<AuthorCatalogAgentScopeV1>;
+}
+
+function snapshotParentEvidence(
+  input: AuthorAgentDelegationEvidenceV1,
+): Readonly<AuthorAgentDelegationEvidenceV1> {
+  if (!isPlainRecord(input)) {
+    fail('AUTHORSHIP_PARENT_EVIDENCE_INVALID', 'parent evidence must be a plain object');
+  }
+  const values = exactPrimitiveDataSnapshot(input, [
+    'authorAddress',
+    'delegateeOpKey',
+    'delegateePeerId',
+    'expiresAt',
+    'issuedAt',
+    'scope',
+    'signature',
+  ], 'parent author-agent evidence', 'AUTHORSHIP_PARENT_EVIDENCE_INVALID');
+  try {
+    assertEvmAddress(values.authorAddress, 'authorAddress');
+    assertEvmAddress(values.delegateeOpKey, 'delegateeOpKey');
+    if (values.delegateePeerId !== null) {
+      assertPeerId(values.delegateePeerId);
+    }
+    if (typeof values.scope !== 'string' || values.scope.length === 0) {
+      throw new Error('scope must be a non-empty string');
+    }
+    if (values.scope.length > MAX_AUTHOR_AGENT_DELEGATION_EVIDENCE_BYTES_V1) {
+      throw new Error('scope exceeds the parent evidence byte ceiling');
+    }
+    assertWellFormedUnicode(values.scope, 'scope');
+    if (typeof values.signature !== 'string' || !/^0x[0-9a-f]{130}$/.test(values.signature)) {
+      throw new Error('signature must be a canonical lowercase 65-byte hex string');
+    }
+    const issuedAt = assertFinitePositiveTimestamp(values.issuedAt, 'issuedAt');
+    const expiresAt = assertFinitePositiveTimestamp(values.expiresAt, 'expiresAt');
+    if (issuedAt >= expiresAt) throw new Error('issuedAt must be strictly earlier than expiresAt');
+  } catch (cause) {
+    fail('AUTHORSHIP_PARENT_EVIDENCE_INVALID', 'parent evidence is invalid', cause);
+  }
+  const snapshot = Object.freeze(values) as unknown as Readonly<AuthorAgentDelegationEvidenceV1>;
+  if (UTF8.encode(canonicalizeStringRecord(snapshot)).byteLength > MAX_AUTHOR_AGENT_DELEGATION_EVIDENCE_BYTES_V1) {
+    fail(
+      'AUTHORSHIP_PARENT_EVIDENCE_INVALID',
+      `parent evidence exceeds ${MAX_AUTHOR_AGENT_DELEGATION_EVIDENCE_BYTES_V1} canonical bytes`,
+    );
+  }
+  return snapshot;
+}
+
+function computeParentEvidenceDigestAfterSnapshot(
+  evidence: Readonly<AuthorAgentDelegationEvidenceV1>,
+): Digest32V1 {
+  return digestWithDomain(
+    AUTHOR_AGENT_EVIDENCE_DOMAIN_BYTES_V1,
+    UTF8.encode(canonicalizeStringRecord(evidence)),
+  );
+}
+
+function verifyParentEvidenceSignature(
+  evidence: Readonly<AuthorAgentDelegationEvidenceV1>,
+): void {
+  try {
+    const r = BigInt(`0x${evidence.signature.slice(2, 66)}`);
+    const s = BigInt(`0x${evidence.signature.slice(66, 130)}`);
+    const v = evidence.signature.slice(130, 132);
+    if (
+      (v !== '1b' && v !== '1c')
+      || r < 1n
+      || r >= SECP256K1_N
+      || s < 1n
+      || s > SECP256K1_HALF_N
+    ) {
+      throw new Error('parent signature must use canonical r, low-s, and v=27/28');
+    }
+    const digest = computeDelegationDigest({
+      agentAddress: evidence.authorAddress,
+      scope: evidence.scope,
+      issuedAtMs: Number(evidence.issuedAt),
+      expiresAtMs: Number(evidence.expiresAt),
+      delegateePeerId: evidence.delegateePeerId ?? undefined,
+      delegateeOpKey: evidence.delegateeOpKey,
+    });
+    const recovered = ethers.verifyMessage(digest, evidence.signature).toLowerCase();
+    if (recovered !== evidence.authorAddress) {
+      throw new Error('parent signature does not recover the canonical author');
+    }
+  } catch (cause) {
+    fail(
+      'AUTHORSHIP_PARENT_EVIDENCE_INVALID',
+      'parent author-agent evidence signature is invalid',
+      cause,
+    );
+  }
+}
+
+function bindExactSignatureProof(
+  proof: VerifiedControlEnvelopeIssuerSignatureV1,
+  envelope: {
+    readonly objectDigest: string;
+    readonly issuer: string;
+    readonly signatureSuite: string;
+    readonly signature: string;
+  },
+): VerifiedControlEnvelopeIssuerSignatureSnapshotV1 {
+  let snapshot: VerifiedControlEnvelopeIssuerSignatureSnapshotV1;
+  try {
+    snapshot = readVerifiedControlEnvelopeIssuerSignatureV1(proof);
+  } catch (cause) {
+    fail(
+      'AUTHORSHIP_SIGNATURE_PROOF_INVALID',
+      'signature proof was not minted by the generic verifier',
+      cause,
+    );
+  }
+  if (
+    snapshot.objectDigest !== envelope.objectDigest
+    || snapshot.issuer !== envelope.issuer
+    || snapshot.signatureSuite !== envelope.signatureSuite
+    || snapshot.signatureVariantDigest
+      !== computeControlSignatureVariantDigestHex(envelope.objectDigest, envelope.signature)
+  ) {
+    fail(
+      'AUTHORSHIP_SIGNATURE_PROOF_INVALID',
+      'signature proof is bound to another control envelope',
+    );
+  }
+  return snapshot;
+}
+
+function assertHeadBinding(
+  delegation: SignedAuthorCatalogIssuerDelegationEnvelopeV1,
+  head: SignedAuthorCatalogHeadEnvelopeV1,
+): void {
+  const left = delegation.payload;
+  const right = head.payload;
+  if (
+    right.networkId !== left.networkId
+    || right.contextGraphId !== left.contextGraphId
+    || right.governanceChainId !== left.governanceChainId
+    || right.governanceContractAddress !== left.governanceContractAddress
+    || right.ownershipTransitionDigest !== left.ownershipTransitionDigest
+    || right.subGraphName !== left.subGraphName
+    || right.authorAddress !== left.authorAddress
+    || right.era !== left.catalogEra
+    || right.catalogIssuerDelegationDigest !== delegation.objectDigest
+  ) {
+    fail(
+      'AUTHORSHIP_HEAD_BINDING_MISMATCH',
+      'catalog head does not bind the exact issuer delegation scope, era, and digest',
+    );
+  }
+}
+
+function readBoundPathDescriptor(
+  proof: VerifiedAuthorCatalogDirectoryPathV1,
+  head: SignedAuthorCatalogHeadEnvelopeV1,
+  path: readonly SignedAuthorCatalogDirectoryNodeEnvelopeV1[],
+  selectedBucketId: SignedAuthorCatalogBucketEnvelopeV1['payload']['bucketId'],
+) {
+  try {
+    const supplied = readVerifiedAuthorCatalogBucketDescriptorV1(proof, head);
+    const recomputedProof = verifyAuthorCatalogDirectoryPathV1(head, path, selectedBucketId);
+    const recomputed = readVerifiedAuthorCatalogBucketDescriptorV1(recomputedProof, head);
+    if (
+      supplied.bucketDigest !== recomputed.bucketDigest
+      || supplied.bucketId !== recomputed.bucketId
+      || supplied.byteLength !== recomputed.byteLength
+      || supplied.rowCount !== recomputed.rowCount
+      || supplied.bucketId !== selectedBucketId
+    ) {
+      fail(
+        'AUTHORSHIP_PATH_BINDING_MISMATCH',
+        'structural path proof is not bound to the supplied head, path, and selected bucket',
+      );
+    }
+    return supplied;
+  } catch (cause) {
+    if (cause instanceof AuthorCatalogRowAuthorshipErrorV1) throw cause;
+    fail(
+      'AUTHORSHIP_PATH_BINDING_MISMATCH',
+      'directory path proof or root-to-leaf closure is invalid',
+      cause,
+    );
+  }
+}
+
+function mintVerifiedAuthorship(
+  snapshot: VerifiedAuthorCatalogRowAuthorshipSnapshotV1,
+): VerifiedAuthorCatalogRowAuthorshipV1 {
+  const immutable = deepFreezeJson({ ...snapshot }) as VerifiedAuthorCatalogRowAuthorshipSnapshotV1;
+  const capability = Object.freeze(
+    Object.create(null),
+  ) as VerifiedAuthorCatalogRowAuthorshipV1;
+  VERIFIED_AUTHOR_CATALOG_ROW_AUTHORSHIPS_V1.set(capability as object, immutable);
+  return capability;
+}
+
+function exactPrimitiveDataSnapshot(
+  input: Record<string, unknown>,
+  expectedKeys: readonly string[],
+  label: string,
+  code: AuthorCatalogRowAuthorshipErrorCodeV1,
+): Readonly<Record<string, unknown>> {
+  const keys = Reflect.ownKeys(input);
+  if (
+    keys.some((key) => typeof key !== 'string')
+    || keys.length !== expectedKeys.length
+    || (keys as string[]).sort().some((key, index) => key !== [...expectedKeys].sort()[index])
+  ) {
+    fail(code, `${label} has unknown or missing fields`);
+  }
+  const snapshot: Record<string, unknown> = Object.create(null);
+  for (const key of expectedKeys) {
+    const descriptor = Object.getOwnPropertyDescriptor(input, key);
+    if (!descriptor?.enumerable || !Object.prototype.hasOwnProperty.call(descriptor, 'value')) {
+      fail(code, `${label} fields must be enumerable data properties`);
+    }
+    const value = descriptor.value;
+    if (value !== null && typeof value !== 'string') {
+      fail(code, `${label}.${key} must be a string or null`);
+    }
+    snapshot[key] = value;
+  }
+  return Object.freeze(snapshot);
+}
+
+function canonicalizeStringRecord(value: Readonly<Record<string, unknown>>): string {
+  const ordered: Record<string, string | null> = {};
+  for (const key of Object.keys(value).sort()) {
+    const item = value[key];
+    if (item !== null && typeof item !== 'string') {
+      throw new TypeError('canonical authorship records contain only strings and null');
+    }
+    ordered[key] = item;
+  }
+  return JSON.stringify(ordered);
+}
+
+function snapshotDenseOrdinaryArray(
+  value: unknown,
+  label: string,
+  code: AuthorCatalogRowAuthorshipErrorCodeV1,
+  expectedLength?: number,
+): unknown[] {
+  assertOrdinaryArrayExactLength(value, label, code, expectedLength);
+  const length = (Object.getOwnPropertyDescriptor(value, 'length')!.value as number);
+  const keys = Reflect.ownKeys(value);
+  if (
+    keys.some((key) => typeof key !== 'string')
+    || keys.length !== length + 1
+  ) {
+    fail(code, `${label} must be dense and contain no custom fields`);
+  }
+  const snapshot: unknown[] = new Array(length);
+  for (let index = 0; index < length; index += 1) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
+    if (!descriptor?.enumerable || !Object.prototype.hasOwnProperty.call(descriptor, 'value')) {
+      fail(code, `${label}[${index}] must be an enumerable data field`);
+    }
+    snapshot[index] = descriptor.value;
+  }
+  return snapshot;
+}
+
+function assertOrdinaryArrayExactLength(
+  value: unknown,
+  label: string,
+  code: AuthorCatalogRowAuthorshipErrorCodeV1,
+  expectedLength?: number,
+): asserts value is unknown[] {
+  if (!Array.isArray(value) || Object.getPrototypeOf(value) !== Array.prototype) {
+    fail(code, `${label} must be an ordinary dense array`);
+  }
+  const lengthDescriptor = Object.getOwnPropertyDescriptor(value, 'length');
+  if (
+    !lengthDescriptor
+    || lengthDescriptor.enumerable
+    || !Object.prototype.hasOwnProperty.call(lengthDescriptor, 'value')
+    || typeof lengthDescriptor.value !== 'number'
+    || !Number.isSafeInteger(lengthDescriptor.value)
+    || lengthDescriptor.value < 0
+  ) {
+    fail(code, `${label}.length must be an ordinary array data field`);
+  }
+  const length = lengthDescriptor.value;
+  if (expectedLength !== undefined && length !== expectedLength) {
+    fail(
+      code,
+      `${label} must contain exactly ${expectedLength} values for the signed directory height`,
+    );
+  }
+}
+
+function assertFinitePositiveTimestamp(value: unknown, label: string): bigint {
+  const parsed = parseCanonicalDecimalU64(value, label);
+  if (parsed < 1n || parsed > MAX_AUTHOR_AGENT_DELEGATION_TIMESTAMP_V1) {
+    throw new Error(`${label} must be in 1..${MAX_AUTHOR_AGENT_DELEGATION_TIMESTAMP_V1}`);
+  }
+  return parsed;
+}
+
+function assertPeerId(value: unknown): asserts value is string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error('delegateePeerId must be null or a non-empty string');
+  }
+  assertWellFormedUnicode(value, 'delegateePeerId');
+  const bytes = UTF8.encode(value).byteLength;
+  if (bytes < 1 || bytes > MAX_AUTHOR_AGENT_DELEGATEE_PEER_ID_BYTES_V1) {
+    throw new Error('delegateePeerId exceeds its UTF-8 byte limit');
+  }
+  for (const character of value) {
+    const codePoint = character.codePointAt(0)!;
+    if (codePoint <= 0x1f || codePoint === 0x7f) {
+      throw new Error('delegateePeerId contains C0/DEL control data');
+    }
+  }
+}
+
+function assertEvmAddress(value: unknown, label: string): asserts value is EvmAddressV1 {
+  if (
+    typeof value !== 'string'
+    || !/^0x[0-9a-f]{40}$/.test(value)
+    || value === '0x0000000000000000000000000000000000000000'
+  ) {
+    throw new Error(`${label} is not a canonical nonzero EVM address`);
+  }
+}
+
+function assertWellFormedUnicode(value: string, label: string): void {
+  for (let index = 0; index < value.length; index += 1) {
+    const unit = value.charCodeAt(index);
+    if (unit >= 0xd800 && unit <= 0xdbff) {
+      if (index + 1 >= value.length) throw new Error(`${label} contains an unpaired surrogate`);
+      const next = value.charCodeAt(index + 1);
+      if (next < 0xdc00 || next > 0xdfff) {
+        throw new Error(`${label} contains an unpaired surrogate`);
+      }
+      index += 1;
+    } else if (unit >= 0xdc00 && unit <= 0xdfff) {
+      throw new Error(`${label} contains an unpaired surrogate`);
+    }
+  }
+}
+
+function digestWithDomain(domain: Uint8Array, payload: Uint8Array): Digest32V1 {
+  const hasher = sha256.create();
+  hasher.update(domain);
+  hasher.update(payload);
+  const digest = `0x${Array.from(hasher.digest(), (byte) =>
+    byte.toString(16).padStart(2, '0')).join('')}`;
+  assertCanonicalDigest(digest, 'authorship digest');
+  return digest;
+}
+
+function deepFreezeJson<T>(value: T): T {
+  if (value === null || typeof value !== 'object' || Object.isFrozen(value)) return value;
+  if (Array.isArray(value)) {
+    for (const item of value) deepFreezeJson(item);
+  } else {
+    for (const item of Object.values(value)) deepFreezeJson(item);
+  }
+  return Object.freeze(value);
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function isPackedAuthorFailure(cause: unknown): boolean {
+  return (
+    cause !== null
+    && typeof cause === 'object'
+    && 'code' in cause
+    && cause.code === 'catalog-packed-author-mismatch'
+  );
+}
+
+function fail(
+  code: AuthorCatalogRowAuthorshipErrorCodeV1,
+  message: string,
+  cause?: unknown,
+): never {
+  throw new AuthorCatalogRowAuthorshipErrorV1(
+    code,
+    message,
+    cause === undefined ? {} : { cause },
+  );
+}

--- a/packages/agent/test/rfc64-catalog-row-authorship.test.ts
+++ b/packages/agent/test/rfc64-catalog-row-authorship.test.ts
@@ -1,0 +1,846 @@
+import { describe, expect, it } from 'vitest';
+import { ethers } from 'ethers';
+
+import {
+  AUTHOR_CATALOG_BUCKET_OBJECT_TYPE_V1,
+  AUTHOR_CATALOG_DIRECTORY_NODE_OBJECT_TYPE_V1,
+  AUTHOR_CATALOG_HEAD_OBJECT_TYPE_V1,
+  AUTHOR_CATALOG_ISSUER_DELEGATION_OBJECT_TYPE_V1,
+  canonicalizeAuthorCatalogBucketPayloadBytesV1,
+  canonicalizeAuthorCatalogRowV1,
+  computeAuthorCatalogScopeDigestV1,
+  computeControlObjectDigestHex,
+  verifyAuthorCatalogDirectoryPathV1,
+  type AuthorCatalogRowV1,
+  type AuthorCatalogScopeV1,
+  type KaIdV1,
+  type SignedAuthorCatalogBucketEnvelopeV1,
+  type SignedAuthorCatalogDirectoryNodeEnvelopeV1,
+  type SignedAuthorCatalogHeadEnvelopeV1,
+  type SignedAuthorCatalogIssuerDelegationEnvelopeV1,
+  type SignedControlEnvelopeV1,
+  type UnsignedControlEnvelopeV1,
+} from '@origintrail-official/dkg-core';
+import {
+  verifyControlEnvelopeIssuerSignatureV1,
+} from '@origintrail-official/dkg-chain';
+
+import { computeDelegationDigest } from '../src/auth/agent-delegation.js';
+import {
+  AUTHOR_CATALOG_ROW_AUTHORSHIP_ERROR_CODES_V1,
+  AuthorCatalogRowAuthorshipErrorV1,
+  assertVerifiedAuthorCatalogRowAuthorshipForTargetV1,
+  assertVerifiedAuthorCatalogRowAuthorshipV1,
+  buildAuthorCatalogAgentScopeV1,
+  computeAuthorAgentDelegationEvidenceDigestV1,
+  computeAuthorCatalogAgentScopeDigestV1,
+  readVerifiedAuthorCatalogRowAuthorshipV1,
+  verifyAuthorCatalogRowAuthorshipV1,
+  type AuthorAgentDelegationEvidenceV1,
+  type AuthorCatalogAgentScopeV1,
+  type VerifyAuthorCatalogRowAuthorshipInputV1,
+} from '../src/rfc64/catalog-row-authorship.js';
+
+const AUTHOR_PRIVATE_KEY = `0x${'11'.repeat(32)}`;
+const CATALOG_PRIVATE_KEY = `0x${'22'.repeat(32)}`;
+const THIRD_PRIVATE_KEY = `0x${'33'.repeat(32)}`;
+const AUTHOR = '0x19e7e376e7c213b7e7e7e46cc70a5dd086daff2a';
+const CATALOG_ISSUER = '0x1563915e194d8cfba1943570603f7606a3115508';
+const CONTEXT_GRAPH_ID = '0x1111111111111111111111111111111111111111/catalog-fixture';
+const GOVERNANCE_CONTRACT = '0x2222222222222222222222222222222222222222';
+const ZERO_DIGEST = `0x${'00'.repeat(32)}`;
+const BLOB_DIGEST = `0x${'11'.repeat(32)}`;
+const CHUNK_ROOT = `0x${'22'.repeat(32)}`;
+const SEAL_DIGEST = `0x${'44'.repeat(32)}`;
+const TARGET_KA_ID =
+  '11717532788646872703907650691873846707067843023881409494733446432351458426881';
+const TARGET_KA_ID_2 =
+  '11717532788646872703907650691873846707067843023881409494733446432351458426882';
+const WRONG_AUTHOR_KA_ID =
+  ((BigInt(`0x${'44'.repeat(20)}`) << 96n) | 1n).toString();
+const PARENT_SIGNATURE =
+  '0xa2d72565e1a9dabdbac0c1311d8d65fe74d377bb965ea8fd9d0f0df522e995400bea5baaae6fe2288035a5af5e5c93dc7d176bcadabc99dadf4d0f41394334231b';
+const EXPECTED_PARENT_DIGEST =
+  '0xb50ae153356ec5fa420a4db1ad78a92c8a1445e975c30f6fd64df9faba043dd5';
+const EXPECTED_AGENT_SCOPE_DIGEST =
+  '0x962893b5aeb2981d0d3cbbd1b95a7ec8ace1ee468d57de635e4bada99e1c9a83';
+const EXPECTED_DELEGATED_DELEGATION_DIGEST =
+  '0xeab310c15a84618f0eaf9a6eb2e094a64789c407d1f984a0aea918b284b64143';
+const EXPECTED_DIRECT_DELEGATION_DIGEST =
+  '0x7b53f3fcf0d5b9c4d49da6ae8bdc9d0b99e893c588ebacbf6d8267d55458bacf';
+const EXPECTED_SCOPE_DIGEST =
+  '0x8bea420829cdde5cf1e5258895619ac1d484784d2b3998cd8a45e6c8eabbf832';
+const EXPECTED_BUCKET_DIGEST =
+  '0x82db48bc0cadf93a3803300348464d04d2d91b335426ba86b6fca83623bd25f5';
+const EXPECTED_DIRECTORY_DIGEST =
+  '0x5774cf8df10e1fe3421b87fa907bd403323c6ac11d71728e2e52dc6319d3f35d';
+const EXPECTED_DELEGATED_HEAD_DIGEST =
+  '0xa3964f6671e1c015276c692d75d6dd6250f77e4ec32aaf22c2481cf05bd111e1';
+const EXPECTED_DIRECT_HEAD_DIGEST =
+  '0x808232803f3d8f928c88287dff20ffdc2ad9488e2dc12e08b1bf633ccdc0e57b';
+const EXPECTED_ROW_DIGEST =
+  '0x0a8cb39f5593176e2eedf8a31b0b96465cc371115340f4f037e58610f04265bd';
+const EXPECTED_TRANSFER_DIGEST =
+  '0x007c995fd7d001736d39af9f2d3c79177c99b55682a1ff4d002fbc3e0345db25';
+
+const authorWallet = new ethers.Wallet(AUTHOR_PRIVATE_KEY);
+const catalogWallet = new ethers.Wallet(CATALOG_PRIVATE_KEY);
+const thirdWallet = new ethers.Wallet(THIRD_PRIVATE_KEY);
+
+interface FixtureOptions {
+  readonly mode?: 'direct' | 'delegated';
+  readonly contextGraphId?: string;
+  readonly subGraphName?: string | null;
+  readonly effectiveAt?: string;
+  readonly delegationExpiresAt?: string;
+  readonly headIssuedAt?: string;
+  readonly parentIssuedAt?: string;
+  readonly parentExpiresAt?: string;
+  readonly parentEvidence?: AuthorAgentDelegationEvidenceV1;
+  readonly evidenceDigestOverride?: string | null;
+  readonly delegationSigner?: ethers.Wallet;
+  readonly catalogIssuerKey?: string;
+  readonly headSigner?: ethers.Wallet;
+  readonly directorySigner?: ethers.Wallet;
+  readonly bucketSigner?: ethers.Wallet;
+  readonly kaId?: string;
+  readonly targetKaId?: string;
+  readonly assertionCoordinate?: string;
+  readonly duplicateTarget?: boolean;
+  readonly bucketIdOverride?: string;
+  readonly delegationPayloadOverride?: Record<string, unknown>;
+  readonly headPayloadOverride?: Record<string, unknown>;
+}
+
+interface Fixture {
+  readonly input: VerifyAuthorCatalogRowAuthorshipInputV1;
+  readonly parentEvidence: AuthorAgentDelegationEvidenceV1 | null;
+  readonly delegation: SignedAuthorCatalogIssuerDelegationEnvelopeV1;
+  readonly head: SignedAuthorCatalogHeadEnvelopeV1;
+  readonly directory: SignedAuthorCatalogDirectoryNodeEnvelopeV1;
+  readonly bucket: SignedAuthorCatalogBucketEnvelopeV1;
+}
+
+describe('RFC-64 catalog-row authorship normative closure', () => {
+  it('pins the delegated parent, object, path, row, and transfer vectors', async () => {
+    const fixture = await buildFixture();
+    const token = verifyAuthorCatalogRowAuthorshipV1(fixture.input);
+    const snapshot = readVerifiedAuthorCatalogRowAuthorshipV1(token);
+
+    expect(computeAuthorAgentDelegationEvidenceDigestV1(fixture.parentEvidence!)).toBe(
+      EXPECTED_PARENT_DIGEST,
+    );
+    expect(snapshot.authorCatalogAgentScopeDigest).toBe(EXPECTED_AGENT_SCOPE_DIGEST);
+    expect(snapshot.catalogIssuerDelegationObjectDigest).toBe(
+      EXPECTED_DELEGATED_DELEGATION_DIGEST,
+    );
+    expect(snapshot.catalogScopeDigest).toBe(EXPECTED_SCOPE_DIGEST);
+    expect(snapshot.bucketObjectDigest).toBe(EXPECTED_BUCKET_DIGEST);
+    expect(snapshot.directoryPathObjectDigests).toEqual([EXPECTED_DIRECTORY_DIGEST]);
+    expect(snapshot.catalogHeadObjectDigest).toBe(EXPECTED_DELEGATED_HEAD_DIGEST);
+    expect(snapshot.catalogRowDigest).toBe(EXPECTED_ROW_DIGEST);
+    expect(snapshot.transferIdentityDigest).toBe(EXPECTED_TRANSFER_DIGEST);
+    expect(snapshot.row.kaId).toBe(TARGET_KA_ID);
+    expect(canonicalizeAuthorCatalogBucketPayloadBytesV1(fixture.bucket.payload).byteLength)
+      .toBe(868);
+    expect(() => assertVerifiedAuthorCatalogRowAuthorshipForTargetV1(
+      token,
+      EXPECTED_ROW_DIGEST,
+      EXPECTED_TRANSFER_DIGEST,
+    )).not.toThrow();
+  });
+
+  it('pins the direct-author delegation/head variant while retaining the same row target', async () => {
+    const fixture = await buildFixture({ mode: 'direct' });
+    const snapshot = readVerifiedAuthorCatalogRowAuthorshipV1(
+      verifyAuthorCatalogRowAuthorshipV1(fixture.input),
+    );
+    expect(snapshot.authorAuthorityEvidenceDigest).toBeNull();
+    expect(snapshot.catalogIssuerDelegationObjectDigest).toBe(
+      EXPECTED_DIRECT_DELEGATION_DIGEST,
+    );
+    expect(snapshot.catalogHeadObjectDigest).toBe(EXPECTED_DIRECT_HEAD_DIGEST);
+    expect(snapshot.catalogRowDigest).toBe(EXPECTED_ROW_DIGEST);
+    expect(snapshot.transferIdentityDigest).toBe(EXPECTED_TRANSFER_DIGEST);
+  });
+
+  it('derives the exact seven-key scope and deployed v10 legacy digest', async () => {
+    const fixture = await buildFixture();
+    const payload = fixture.delegation.payload;
+    const scope: AuthorCatalogAgentScopeV1 = {
+      authorAddress: payload.authorAddress,
+      contextGraphId: payload.contextGraphId,
+      governanceChainId: payload.governanceChainId,
+      governanceContractAddress: payload.governanceContractAddress,
+      networkId: payload.networkId,
+      ownershipTransitionDigest: payload.ownershipTransitionDigest,
+      subGraphName: payload.subGraphName,
+    };
+    expect(computeAuthorCatalogAgentScopeDigestV1(scope)).toBe(EXPECTED_AGENT_SCOPE_DIGEST);
+    expect(new TextEncoder().encode(canonicalizeFixtureJson(scope)).byteLength).toBe(318);
+    expect(buildAuthorCatalogAgentScopeV1(scope)).toBe(
+      `dkg:rfc64:author-catalog-issuer-v1:${EXPECTED_AGENT_SCOPE_DIGEST.slice(2)}`,
+    );
+    expect(new TextEncoder().encode(
+      canonicalizeFixtureJson(fixture.parentEvidence),
+    ).byteLength).toBe(459);
+    expect(ethers.hexlify(computeDelegationDigest({
+      agentAddress: AUTHOR,
+      scope: buildAuthorCatalogAgentScopeV1(scope),
+      issuedAtMs: 1_700_000_000_000,
+      expiresAtMs: 1_700_000_121_000,
+      delegateeOpKey: CATALOG_ISSUER,
+    }))).toBe('0x341e615362648661f46ba3adbe3d9e748d54e147a5e22212025d4d210d4bb43e');
+  });
+
+  it('is D26-neutral and mints fresh process-local tokens in all four policy cells', async () => {
+    const fixture = await buildFixture();
+    const policyCells = [
+      ['open', 'open'],
+      ['open', 'curated'],
+      ['invite-only', 'open'],
+      ['invite-only', 'curated'],
+    ] as const;
+    const tokens = policyCells.map(() => verifyAuthorCatalogRowAuthorshipV1(fixture.input));
+    expect(new Set(tokens).size).toBe(4);
+    for (const token of tokens) {
+      const snapshot = readVerifiedAuthorCatalogRowAuthorshipV1(token);
+      expect(snapshot.catalogRowDigest).toBe(EXPECTED_ROW_DIGEST);
+      expect('accessPolicy' in snapshot).toBe(false);
+      expect('publishPolicy' in snapshot).toBe(false);
+      expect('membership' in snapshot).toBe(false);
+      expect(Object.isFrozen(snapshot)).toBe(true);
+      expect(Object.isFrozen(snapshot.row)).toBe(true);
+      expect(Object.isFrozen(snapshot.row.transfer)).toBe(true);
+    }
+  });
+});
+
+describe('RFC-64 direct/delegated parent closure failures', () => {
+  it('rejects direct issuance with supplied parent evidence', async () => {
+    const direct = await buildFixture({ mode: 'direct' });
+    const delegated = await buildFixture();
+    expectCode(() => verifyAuthorCatalogRowAuthorshipV1({
+      ...direct.input,
+      parentAuthorAgentEvidence: delegated.parentEvidence,
+    } as VerifyAuthorCatalogRowAuthorshipInputV1), 'AUTHORSHIP_ISSUER_CLOSURE_MISMATCH');
+  });
+
+  it('rejects structurally inconsistent direct/delegated evidence branches', async () => {
+    const fixture = await buildFixture({
+      evidenceDigestOverride: null,
+    });
+    expectCode(
+      () => verifyAuthorCatalogRowAuthorshipV1(fixture.input),
+      'AUTHORSHIP_ISSUER_CLOSURE_MISMATCH',
+    );
+  });
+
+  it('rejects a catalog key that differs from the parent operational signer', async () => {
+    const scope = defaultAgentScope();
+    const thirdEvidence = await signParentEvidence({
+      authorAddress: AUTHOR,
+      delegateeOpKey: thirdWallet.address.toLowerCase(),
+      delegateePeerId: null,
+      expiresAt: '1700000121000',
+      issuedAt: '1700000000000',
+      scope: buildAuthorCatalogAgentScopeV1(scope),
+    }, authorWallet);
+    const fixture = await buildFixture({
+      parentEvidence: thirdEvidence,
+      delegationSigner: thirdWallet,
+      catalogIssuerKey: CATALOG_ISSUER,
+    });
+    expectCode(
+      () => verifyAuthorCatalogRowAuthorshipV1(fixture.input),
+      'AUTHORSHIP_ISSUER_CLOSURE_MISMATCH',
+    );
+  });
+
+  it('rejects a one-byte parent mutation before treating its signature as authority', async () => {
+    const fixture = await buildFixture();
+    const mutated = {
+      ...fixture.parentEvidence!,
+      delegateePeerId: 'x',
+    };
+    expectCode(() => verifyAuthorCatalogRowAuthorshipV1({
+      ...fixture.input,
+      parentAuthorAgentEvidence: mutated,
+    }), 'AUTHORSHIP_PARENT_DIGEST_MISMATCH');
+  });
+
+  it('rejects a valid root-lane parent replayed into a named lane', async () => {
+    const root = await buildFixture();
+    const named = await buildFixture({
+      subGraphName: 'named',
+      parentEvidence: root.parentEvidence!,
+    });
+    expectCode(
+      () => verifyAuthorCatalogRowAuthorshipV1(named.input),
+      'AUTHORSHIP_PARENT_SCOPE_MISMATCH',
+    );
+  });
+
+  it.each([
+    ['missing operational key', (parent: AuthorAgentDelegationEvidenceV1) => ({
+      ...parent,
+      delegateeOpKey: undefined,
+    })],
+    ['zero expiry', (parent: AuthorAgentDelegationEvidenceV1) => ({
+      ...parent,
+      expiresAt: '0',
+    })],
+  ])('rejects invalid parent evidence: %s', async (_label, mutate) => {
+    const fixture = await buildFixture();
+    expectCode(() => verifyAuthorCatalogRowAuthorshipV1({
+      ...fixture.input,
+      parentAuthorAgentEvidence: mutate(fixture.parentEvidence!) as AuthorAgentDelegationEvidenceV1,
+    }), 'AUTHORSHIP_PARENT_EVIDENCE_INVALID');
+  });
+
+  it('rejects high-s and wrong-recovered-author parent signatures', async () => {
+    const base = await buildFixture();
+    const highS = makeHighS(base.parentEvidence!);
+    const highSFixture = await buildFixture({ parentEvidence: highS });
+    expectCode(
+      () => verifyAuthorCatalogRowAuthorshipV1(highSFixture.input),
+      'AUTHORSHIP_PARENT_EVIDENCE_INVALID',
+    );
+
+    const unsigned = withoutSignature(base.parentEvidence!);
+    const wrongSignature = await thirdWallet.signMessage(computeDelegationDigest({
+      agentAddress: unsigned.authorAddress,
+      scope: unsigned.scope,
+      issuedAtMs: Number(unsigned.issuedAt),
+      expiresAtMs: Number(unsigned.expiresAt),
+      delegateePeerId: undefined,
+      delegateeOpKey: unsigned.delegateeOpKey,
+    }));
+    const wrong = { ...unsigned, signature: wrongSignature } as AuthorAgentDelegationEvidenceV1;
+    const wrongFixture = await buildFixture({ parentEvidence: wrong });
+    expectCode(
+      () => verifyAuthorCatalogRowAuthorshipV1(wrongFixture.input),
+      'AUTHORSHIP_PARENT_EVIDENCE_INVALID',
+    );
+  });
+});
+
+describe('RFC-64 half-open interval closure', () => {
+  it('accepts equality at parent containment boundaries', async () => {
+    const fixture = await buildFixture({
+      effectiveAt: '1700000000000',
+      delegationExpiresAt: '1700000121000',
+      headIssuedAt: '1700000000000',
+    });
+    expect(() => verifyAuthorCatalogRowAuthorshipV1(fixture.input)).not.toThrow();
+  });
+
+  it.each([
+    ['child starts before parent', {
+      effectiveAt: '1699999999999',
+      headIssuedAt: '1700000000000',
+    }],
+    ['child ends after parent', {
+      delegationExpiresAt: '1700000121001',
+    }],
+    ['empty child interval', {
+      effectiveAt: '1700000120000',
+      delegationExpiresAt: '1700000120000',
+    }],
+    ['head is exactly at child expiry', {
+      headIssuedAt: '1700000120000',
+    }],
+  ])('rejects %s', async (_label, options) => {
+    const fixture = await buildFixture(options);
+    expectCode(
+      () => verifyAuthorCatalogRowAuthorshipV1(fixture.input),
+      'AUTHORSHIP_INTERVAL_MISMATCH',
+    );
+  });
+});
+
+describe('RFC-64 signed object and path closure failures', () => {
+  it('rejects a head that names another exact delegation', async () => {
+    const delegated = await buildFixture();
+    const direct = await buildFixture({ mode: 'direct' });
+    expectCode(() => verifyAuthorCatalogRowAuthorshipV1({
+      ...direct.input,
+      catalogHead: delegated.input.catalogHead,
+      catalogHeadSignature: delegated.input.catalogHeadSignature,
+      directoryPathEnvelopes: delegated.input.directoryPathEnvelopes,
+      directoryPathSignatures: delegated.input.directoryPathSignatures,
+      directoryPathProof: delegated.input.directoryPathProof,
+      catalogBucket: delegated.input.catalogBucket,
+      catalogBucketSignature: delegated.input.catalogBucketSignature,
+    }), 'AUTHORSHIP_HEAD_BINDING_MISMATCH');
+  });
+
+  it('rejects a catalog object signed by another issuer', async () => {
+    const fixture = await buildFixture({ bucketSigner: thirdWallet });
+    expectCode(
+      () => verifyAuthorCatalogRowAuthorshipV1(fixture.input),
+      'AUTHORSHIP_HEAD_BINDING_MISMATCH',
+    );
+  });
+
+  it('rejects omitted, cloned, foreign-head, and wrong-signature path dependencies', async () => {
+    const delegated = await buildFixture();
+    const direct = await buildFixture({ mode: 'direct' });
+    expectCode(() => verifyAuthorCatalogRowAuthorshipV1({
+      ...delegated.input,
+      directoryPathEnvelopes: [],
+      directoryPathSignatures: [],
+    }), 'AUTHORSHIP_PATH_BINDING_MISMATCH');
+    expectCode(() => verifyAuthorCatalogRowAuthorshipV1({
+      ...delegated.input,
+      directoryPathProof: { ...delegated.input.directoryPathProof },
+    } as VerifyAuthorCatalogRowAuthorshipInputV1), 'AUTHORSHIP_PATH_BINDING_MISMATCH');
+    expectCode(() => verifyAuthorCatalogRowAuthorshipV1({
+      ...delegated.input,
+      directoryPathProof: direct.input.directoryPathProof,
+    }), 'AUTHORSHIP_PATH_BINDING_MISMATCH');
+    expectCode(() => verifyAuthorCatalogRowAuthorshipV1({
+      ...delegated.input,
+      directoryPathSignatures: [delegated.input.catalogBucketSignature],
+    }), 'AUTHORSHIP_PATH_BINDING_MISMATCH');
+  });
+
+  it('bounds both directory arrays before touching attacker-controlled elements', async () => {
+    const fixture = await buildFixture();
+
+    let oversizedEnvelopeTailTouched = false;
+    const oversizedEnvelopes = new Array(2);
+    oversizedEnvelopes[0] = fixture.input.directoryPathEnvelopes[0];
+    Object.defineProperty(oversizedEnvelopes, '1', {
+      enumerable: true,
+      configurable: true,
+      get() {
+        oversizedEnvelopeTailTouched = true;
+        throw new Error('oversized envelope tail must not be inspected');
+      },
+    });
+    expectCode(() => verifyAuthorCatalogRowAuthorshipV1({
+      ...fixture.input,
+      directoryPathEnvelopes: oversizedEnvelopes,
+    }), 'AUTHORSHIP_PATH_BINDING_MISMATCH');
+    expect(oversizedEnvelopeTailTouched).toBe(false);
+
+    let validLengthEnvelopeTouched = false;
+    const trappedValidLengthEnvelopes = new Array(1);
+    Object.defineProperty(trappedValidLengthEnvelopes, '0', {
+      enumerable: true,
+      configurable: true,
+      get() {
+        validLengthEnvelopeTouched = true;
+        throw new Error('envelope must not be inspected before signature-array preflight');
+      },
+    });
+    let oversizedSignatureTailTouched = false;
+    const oversizedSignatures = new Array(2);
+    oversizedSignatures[0] = fixture.input.directoryPathSignatures[0];
+    Object.defineProperty(oversizedSignatures, '1', {
+      enumerable: true,
+      configurable: true,
+      get() {
+        oversizedSignatureTailTouched = true;
+        throw new Error('oversized signature tail must not be inspected');
+      },
+    });
+    expectCode(() => verifyAuthorCatalogRowAuthorshipV1({
+      ...fixture.input,
+      directoryPathEnvelopes: trappedValidLengthEnvelopes,
+      directoryPathSignatures: oversizedSignatures,
+    }), 'AUTHORSHIP_PATH_BINDING_MISMATCH');
+    expect(validLengthEnvelopeTouched).toBe(false);
+    expect(oversizedSignatureTailTouched).toBe(false);
+  });
+
+  it('rejects a signed bucket that differs from the selected leaf descriptor', async () => {
+    const first = await buildFixture();
+    const other = await buildFixture({ assertionCoordinate: 'other' });
+    expectCode(() => verifyAuthorCatalogRowAuthorshipV1({
+      ...first.input,
+      catalogBucket: other.input.catalogBucket,
+      catalogBucketSignature: other.input.catalogBucketSignature,
+    }), 'AUTHORSHIP_BUCKET_BINDING_MISMATCH');
+  });
+
+  it('rejects wrong-object generic signature capabilities', async () => {
+    const fixture = await buildFixture();
+    expectCode(() => verifyAuthorCatalogRowAuthorshipV1({
+      ...fixture.input,
+      catalogHeadSignature: fixture.input.catalogBucketSignature,
+    }), 'AUTHORSHIP_SIGNATURE_PROOF_INVALID');
+  });
+});
+
+describe('RFC-64 exact target row and capability closure', () => {
+  it('rejects an absent target row', async () => {
+    const fixture = await buildFixture({ targetKaId: TARGET_KA_ID_2 });
+    expectCode(
+      () => verifyAuthorCatalogRowAuthorshipV1(fixture.input),
+      'AUTHORSHIP_ROW_BINDING_MISMATCH',
+    );
+  });
+
+  it('rejects duplicate and wrong-bucket target rows', async () => {
+    const duplicate = await buildFixture({ duplicateTarget: true });
+    expectCode(
+      () => verifyAuthorCatalogRowAuthorshipV1(duplicate.input),
+      'AUTHORSHIP_ROW_BINDING_MISMATCH',
+    );
+    const wrongBucket = await buildFixture({ bucketIdOverride: '1' });
+    expectCode(
+      () => verifyAuthorCatalogRowAuthorshipV1(wrongBucket.input),
+      'AUTHORSHIP_ROW_BINDING_MISMATCH',
+    );
+  });
+
+  it('rejects a fully re-signed self-consistent row whose high 160 bits name another author', async () => {
+    const fixture = await buildFixture({
+      kaId: WRONG_AUTHOR_KA_ID,
+      targetKaId: WRONG_AUTHOR_KA_ID,
+    });
+    expectCode(
+      () => verifyAuthorCatalogRowAuthorshipV1(fixture.input),
+      'AUTHORSHIP_ROW_BINDING_MISMATCH',
+    );
+  });
+
+  it('snapshots source objects and cannot be retargeted after verification', async () => {
+    const fixture = await buildFixture();
+    const token = verifyAuthorCatalogRowAuthorshipV1(fixture.input);
+    const snapshot = readVerifiedAuthorCatalogRowAuthorshipV1(token);
+    (fixture.input.catalogBucket.payload.rows[0] as { assertionCoordinate: string })
+      .assertionCoordinate = 'mutated';
+    expect(snapshot.row.assertionCoordinate).toBe('fixture');
+    expect(snapshot.catalogRowDigest).toBe(EXPECTED_ROW_DIGEST);
+    expectCode(
+      () => assertVerifiedAuthorCatalogRowAuthorshipForTargetV1(
+        token,
+        `0x${'99'.repeat(32)}`,
+        snapshot.transferIdentityDigest,
+      ),
+      'AUTHORSHIP_CAPABILITY_INVALID',
+    );
+  });
+
+  it('rejects cast, spread, JSON, and structured clones of the opaque token', async () => {
+    const fixture = await buildFixture();
+    const token = verifyAuthorCatalogRowAuthorshipV1(fixture.input);
+    const clones: unknown[] = [
+      {},
+      { ...token },
+      JSON.parse(JSON.stringify(token)),
+      structuredClone(token),
+    ];
+    for (const clone of clones) {
+      expectCode(
+        () => assertVerifiedAuthorCatalogRowAuthorshipV1(clone),
+        'AUTHORSHIP_CAPABILITY_INVALID',
+      );
+    }
+  });
+
+  it('preserves Unicode scalar sequence as raw UTF-8 bytes without UTF-16 reordering', async () => {
+    const bmpThenAstral = await buildFixture({ assertionCoordinate: '\ue000\u{10000}' });
+    const astralThenBmp = await buildFixture({ assertionCoordinate: '\u{10000}\ue000' });
+    const first = readVerifiedAuthorCatalogRowAuthorshipV1(
+      verifyAuthorCatalogRowAuthorshipV1(bmpThenAstral.input),
+    );
+    const second = readVerifiedAuthorCatalogRowAuthorshipV1(
+      verifyAuthorCatalogRowAuthorshipV1(astralThenBmp.input),
+    );
+    expect(first.row.assertionCoordinate).toBe('\ue000\u{10000}');
+    expect(second.row.assertionCoordinate).toBe('\u{10000}\ue000');
+    expect(first.catalogRowDigest).not.toBe(second.catalogRowDigest);
+    const raw = Buffer.from(canonicalizeAuthorCatalogRowV1(first.row)).toString('hex');
+    expect(raw.indexOf('ee8080')).toBeLessThan(raw.indexOf('f0908080'));
+  });
+
+  it('exposes only the frozen closed error-code registry', () => {
+    expect(AUTHOR_CATALOG_ROW_AUTHORSHIP_ERROR_CODES_V1).toHaveLength(13);
+    expect(Object.isFrozen(AUTHOR_CATALOG_ROW_AUTHORSHIP_ERROR_CODES_V1)).toBe(true);
+    expect(() => new AuthorCatalogRowAuthorshipErrorV1(
+      'NOT_CLOSED' as never,
+      'bad',
+    )).toThrow(/Unsupported catalog-row authorship error code/);
+  });
+});
+
+async function buildFixture(options: FixtureOptions = {}): Promise<Fixture> {
+  const mode = options.mode ?? 'delegated';
+  const contextGraphId = options.contextGraphId ?? CONTEXT_GRAPH_ID;
+  const subGraphName = options.subGraphName ?? null;
+  const effectiveAt = options.effectiveAt ?? '1700000000000';
+  const delegationExpiresAt = options.delegationExpiresAt ?? '1700000120000';
+  const headIssuedAt = options.headIssuedAt ?? '1700000000123';
+  const delegationSigner = options.delegationSigner
+    ?? (mode === 'direct' ? authorWallet : catalogWallet);
+  const catalogIssuerKey = (options.catalogIssuerKey ?? CATALOG_ISSUER).toLowerCase();
+
+  const agentScope = defaultAgentScope({ contextGraphId, subGraphName });
+  let parentEvidence: AuthorAgentDelegationEvidenceV1 | null = null;
+  if (mode === 'delegated') {
+    parentEvidence = options.parentEvidence ?? await signParentEvidence({
+      authorAddress: AUTHOR,
+      delegateeOpKey: delegationSigner.address.toLowerCase(),
+      delegateePeerId: null,
+      expiresAt: options.parentExpiresAt ?? '1700000121000',
+      issuedAt: options.parentIssuedAt ?? '1700000000000',
+      scope: buildAuthorCatalogAgentScopeV1(agentScope),
+    }, authorWallet);
+  }
+  const evidenceDigest = options.evidenceDigestOverride !== undefined
+    ? options.evidenceDigestOverride
+    : parentEvidence === null
+      ? null
+      : computeAuthorAgentDelegationEvidenceDigestV1(parentEvidence);
+
+  const delegationPayload = {
+    authorAddress: AUTHOR,
+    authorAuthorityEvidenceDigest: evidenceDigest,
+    catalogEra: '0',
+    catalogIssuerKey,
+    contextGraphId,
+    effectiveAt,
+    expiresAt: delegationExpiresAt,
+    governanceChainId: '20430',
+    governanceContractAddress: GOVERNANCE_CONTRACT,
+    networkId: 'otp:20430',
+    ownershipTransitionDigest: null,
+    previousDelegationDigest: null,
+    subGraphName,
+    ...options.delegationPayloadOverride,
+  };
+  const delegation = await signControlEnvelope({
+    issuer: delegationSigner.address.toLowerCase(),
+    objectType: AUTHOR_CATALOG_ISSUER_DELEGATION_OBJECT_TYPE_V1,
+    payload: delegationPayload,
+    signatureEvidence: { kind: 'none' },
+    signatureSuite: 'eip191-personal-sign-digest-v1',
+  }, delegationSigner) as SignedAuthorCatalogIssuerDelegationEnvelopeV1;
+
+  const scope = {
+    authorAddress: AUTHOR,
+    bucketCount: '1',
+    contextGraphId,
+    era: '0',
+    governanceChainId: '20430',
+    governanceContractAddress: GOVERNANCE_CONTRACT,
+    networkId: 'otp:20430',
+    ownershipTransitionDigest: null,
+    subGraphName,
+  } as AuthorCatalogScopeV1;
+  const scopeDigest = computeAuthorCatalogScopeDigestV1(scope);
+  const kaId = (options.kaId ?? TARGET_KA_ID) as KaIdV1;
+  const row: AuthorCatalogRowV1 = {
+    assertionCoordinate: (options.assertionCoordinate ?? 'fixture') as AuthorCatalogRowV1['assertionCoordinate'],
+    assertionVersion: '1',
+    kaId,
+    projectionDigest: ZERO_DIGEST,
+    projectionId: 'cg-shared-v1',
+    sealDigest: SEAL_DIGEST,
+    transfer: {
+      blobDigest: BLOB_DIGEST,
+      byteLength: '16',
+      chunkCount: '1',
+      chunkSize: '262144',
+      chunkTreeRoot: CHUNK_ROOT,
+      codec: 'dkg-ka-bundle-v1',
+      projectionDigest: ZERO_DIGEST,
+      projectionId: 'cg-shared-v1',
+    },
+  };
+  const rows = options.duplicateTarget ? [row, structuredClone(row)] : [row];
+  const bucketPayload = {
+    bucketCount: '1',
+    bucketId: options.bucketIdOverride ?? '0',
+    catalogScopeDigest: scopeDigest,
+    era: '0',
+    rows,
+  };
+  const bucketSigner = options.bucketSigner ?? catalogWallet;
+  const bucket = await signControlEnvelope({
+    issuer: bucketSigner.address.toLowerCase(),
+    objectType: AUTHOR_CATALOG_BUCKET_OBJECT_TYPE_V1,
+    payload: bucketPayload,
+    signatureEvidence: { kind: 'none' },
+    signatureSuite: 'eip191-personal-sign-digest-v1',
+  }, bucketSigner) as SignedAuthorCatalogBucketEnvelopeV1;
+
+  const bucketPayloadBytes = canonicalPayloadBytes(bucketPayload);
+  const directoryPayload = {
+    catalogScopeDigest: scopeDigest,
+    entries: [{
+      bucketDigest: bucket.objectDigest,
+      bucketId: '0',
+      byteLength: String(bucketPayloadBytes.byteLength),
+      rowCount: String(rows.length),
+    }],
+    era: '0',
+    firstBucketId: '0',
+    level: '0',
+  };
+  const directorySigner = options.directorySigner ?? catalogWallet;
+  const directory = await signControlEnvelope({
+    issuer: directorySigner.address.toLowerCase(),
+    objectType: AUTHOR_CATALOG_DIRECTORY_NODE_OBJECT_TYPE_V1,
+    payload: directoryPayload,
+    signatureEvidence: { kind: 'none' },
+    signatureSuite: 'eip191-personal-sign-digest-v1',
+  }, directorySigner) as SignedAuthorCatalogDirectoryNodeEnvelopeV1;
+
+  const headPayload = {
+    authorAddress: AUTHOR,
+    bucketCount: '1',
+    catalogIssuerDelegationDigest: delegation.objectDigest,
+    contextGraphId,
+    directoryHeight: '0',
+    directoryRootDigest: directory.objectDigest,
+    era: '0',
+    governanceChainId: '20430',
+    governanceContractAddress: GOVERNANCE_CONTRACT,
+    issuedAt: headIssuedAt,
+    networkId: 'otp:20430',
+    ownershipTransitionDigest: null,
+    previousHeadDigest: null,
+    subGraphName,
+    totalRows: String(rows.length),
+    version: '0',
+    ...options.headPayloadOverride,
+  };
+  const headSigner = options.headSigner ?? catalogWallet;
+  const head = await signControlEnvelope({
+    issuer: headSigner.address.toLowerCase(),
+    objectType: AUTHOR_CATALOG_HEAD_OBJECT_TYPE_V1,
+    payload: headPayload,
+    signatureEvidence: { kind: 'none' },
+    signatureSuite: 'eip191-personal-sign-digest-v1',
+  }, headSigner) as SignedAuthorCatalogHeadEnvelopeV1;
+
+  const delegationProof = await verifyControlEnvelopeIssuerSignatureV1(delegation);
+  const headProof = await verifyControlEnvelopeIssuerSignatureV1(head);
+  const directoryProof = await verifyControlEnvelopeIssuerSignatureV1(directory);
+  const bucketProof = await verifyControlEnvelopeIssuerSignatureV1(bucket);
+  let pathProof: ReturnType<typeof verifyAuthorCatalogDirectoryPathV1>;
+  try {
+    pathProof = verifyAuthorCatalogDirectoryPathV1(head, [directory], '0');
+  } catch {
+    // Some negative fixtures are intentionally structurally invalid before the
+    // authorship verifier maps their closed error. Borrow a valid opaque proof;
+    // verification will fail before it can grant authority.
+    const valid = await buildFixture();
+    pathProof = valid.input.directoryPathProof;
+  }
+
+  return {
+    parentEvidence,
+    delegation,
+    head,
+    directory,
+    bucket,
+    input: {
+      catalogBucket: bucket,
+      catalogBucketSignature: bucketProof,
+      catalogHead: head,
+      catalogHeadSignature: headProof,
+      catalogIssuerDelegation: delegation,
+      catalogIssuerDelegationSignature: delegationProof,
+      directoryPathEnvelopes: [directory],
+      directoryPathProof: pathProof,
+      directoryPathSignatures: [directoryProof],
+      parentAuthorAgentEvidence: parentEvidence,
+      targetKaId: (options.targetKaId ?? kaId) as KaIdV1,
+    },
+  };
+}
+
+async function signControlEnvelope(
+  unsigned: UnsignedControlEnvelopeV1,
+  wallet: ethers.Wallet,
+): Promise<SignedControlEnvelopeV1> {
+  const objectDigest = computeControlObjectDigestHex(unsigned);
+  return {
+    ...unsigned,
+    objectDigest,
+    signature: await wallet.signMessage(ethers.getBytes(objectDigest)),
+  };
+}
+
+async function signParentEvidence(
+  unsigned: Omit<AuthorAgentDelegationEvidenceV1, 'signature'>,
+  wallet: ethers.Wallet,
+): Promise<AuthorAgentDelegationEvidenceV1> {
+  const signature = await wallet.signMessage(computeDelegationDigest({
+    agentAddress: unsigned.authorAddress,
+    scope: unsigned.scope,
+    issuedAtMs: Number(unsigned.issuedAt),
+    expiresAtMs: Number(unsigned.expiresAt),
+    delegateePeerId: unsigned.delegateePeerId ?? undefined,
+    delegateeOpKey: unsigned.delegateeOpKey,
+  }));
+  return { ...unsigned, signature };
+}
+
+function defaultAgentScope(
+  options: { readonly contextGraphId?: string; readonly subGraphName?: string | null } = {},
+): AuthorCatalogAgentScopeV1 {
+  return {
+    authorAddress: AUTHOR,
+    contextGraphId: (options.contextGraphId ?? CONTEXT_GRAPH_ID) as AuthorCatalogAgentScopeV1['contextGraphId'],
+    governanceChainId: '20430',
+    governanceContractAddress: GOVERNANCE_CONTRACT,
+    networkId: 'otp:20430' as AuthorCatalogAgentScopeV1['networkId'],
+    ownershipTransitionDigest: null,
+    subGraphName: (options.subGraphName ?? null) as AuthorCatalogAgentScopeV1['subGraphName'],
+  };
+}
+
+function withoutSignature(
+  evidence: AuthorAgentDelegationEvidenceV1,
+): Omit<AuthorAgentDelegationEvidenceV1, 'signature'> {
+  const { signature: _signature, ...unsigned } = evidence;
+  return unsigned;
+}
+
+function makeHighS(
+  evidence: AuthorAgentDelegationEvidenceV1,
+): AuthorAgentDelegationEvidenceV1 {
+  const n = BigInt('0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141');
+  const r = evidence.signature.slice(2, 66);
+  const lowS = BigInt(`0x${evidence.signature.slice(66, 130)}`);
+  const highS = (n - lowS).toString(16).padStart(64, '0');
+  return {
+    ...evidence,
+    signature: `0x${r}${highS}${evidence.signature.slice(130)}`,
+  };
+}
+
+function canonicalPayloadBytes(payload: unknown): Uint8Array {
+  // Every fixture payload contains only canonical JSON strings/null/arrays.
+  // The production codec independently revalidates the exact JCS byte length.
+  return new TextEncoder().encode(canonicalizeFixtureJson(payload));
+}
+
+function canonicalizeFixtureJson(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonicalizeFixtureJson).join(',')}]`;
+  const record = value as Record<string, unknown>;
+  return `{${Object.keys(record).sort().map((key) =>
+    `${JSON.stringify(key)}:${canonicalizeFixtureJson(record[key])}`).join(',')}}`;
+}
+
+function expectCode(
+  operation: () => unknown,
+  code: (typeof AUTHOR_CATALOG_ROW_AUTHORSHIP_ERROR_CODES_V1)[number],
+): void {
+  try {
+    operation();
+  } catch (error) {
+    expect(error).toBeInstanceOf(AuthorCatalogRowAuthorshipErrorV1);
+    expect((error as AuthorCatalogRowAuthorshipErrorV1).code).toBe(code);
+    return;
+  }
+  throw new Error(`Expected ${code}`);
+}

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -107,6 +107,7 @@ export default defineConfig({
       "test/workspace-crypto-delegatee-filter.test.ts",
       "test/rfc64-inventory-v1-scalars.test.ts",
       "test/rfc64-inventory-v1-lifecycle.test.ts",
+      "test/rfc64-catalog-row-authorship.test.ts",
     ],
     testTimeout: 60_000,
     maxWorkers: 1,


### PR DESCRIPTION
Implements the frozen OT-RFC-64 §4.4.3 catalog-row authorship boundary as an opaque process-local capability. It closes direct/delegated author authority, the deployed v10 agent-delegation proof, exact control-envelope signature capabilities, head/directory/bucket/row/transfer binding, half-open validity intervals, and packed author identity without claiming policy, timeliness, chain ownership, projection validity, or semantic admission.

Security hardening includes canonical snapshots, unforgeable WeakMap tokens, closed errors, exact target-digest assertions, and an up-front directoryHeight + 1 path bound before any attacker-controlled element is parsed or signature-bound.

Validation:
- focused RFC-64 authorship: 30/30
- complete agent unit suite: 1,226 passed, 4 skipped
- agent build and type tests
- git diff check

Spec: OriginTrail/dkgv10-spec#144
Integration target: integration/rfc64-devnet