### PR TITLE
feat(agent): own RFC-64 inventory lifecycle

### DIFF
--- a/.github/workflows/rfc64-inventory-windows.yml
+++ b/.github/workflows/rfc64-inventory-windows.yml
@@ -6,7 +6,9 @@ on:
       - '.github/workflows/rfc64-inventory-windows.yml'
       - 'packages/agent/src/rfc64/inventory-v1/**'
       - 'packages/agent/test/rfc64-inventory-v1-*.test.ts'
+      - 'packages/agent/test/rfc64-agent-inventory-lifecycle.test.ts'
       - 'packages/agent/test/fixtures/rfc64-inventory-v1-child.ts'
+      - 'packages/agent/test/fixtures/rfc64-agent-inventory-lifecycle-child.ts'
       - 'packages/agent/vitest.unit.config.ts'
       - 'packages/agent/package.json'
       - 'packages/core/**'
@@ -59,3 +61,4 @@ jobs:
           pnpm --filter @origintrail-official/dkg-agent exec vitest run
           --config vitest.unit.config.ts
           test/rfc64-inventory-v1
+          test/rfc64-agent-inventory-lifecycle.test.ts

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -11,6 +11,10 @@
  */
 import { createHash, randomUUID } from 'node:crypto';
 import { performance } from 'node:perf_hooks';
+import {
+  openInventoryV1,
+  type Rfc64InventoryV1Foundation,
+} from './rfc64/inventory-v1/index.js';
 import { resolveVmReconcileStartupMaxDelayMs } from './startup-jitter.js';
 import {
   DKGNode, ProtocolRouter, GossipSubManager, TypedEventBus, DKGEvent,
@@ -983,6 +987,12 @@ export class DKGAgentBase {
   protected profileProvisioningInFlight = false;
   protected readonly config: ResolvedDKGAgentConfig;
   protected started = false;
+  /**
+   * OT-RFC-64 durable inventory ownership. Persistent agents hold exactly one
+   * production foundation for their data directory; agents without dataDir
+   * are deliberately dormant and never substitute an in-memory inventory.
+   */
+  protected rfc64InventoryV1?: Rfc64InventoryV1Foundation;
   protected readonly subscribedContextGraphs = new Map<string, ContextGraphSub>();
   protected contextGraphSubscriptionRehydrationStatus: ContextGraphSubscriptionRehydrationStatus | null = null;
   protected readonly contextGraphSubscriptionRehydrationAccountedIds = new Set<string>();
@@ -1552,6 +1562,49 @@ export class DKGAgentBase {
     this.publisher.setWorkspaceSenderKeyEncryptor((input) => (this as unknown as DKGAgent).encryptWorkspacePayloadWithSenderKey(input));
     this.syncCheckpoints = config.syncCheckpointStore ?? this.syncCheckpoints;
     this.changelogCursors = config.changelogCursorStore ?? this.changelogCursors;
+  }
+
+  /**
+   * Acquire the RFC-64 inventory and finish bounded stale-candidate cleanup
+   * before any network consumer can observe or mutate inventory state.
+   */
+  protected async prepareRfc64InventoryV1(): Promise<void> {
+    if (!this.config.dataDir || this.rfc64InventoryV1 !== undefined) return;
+
+    const inventory = await openInventoryV1(this.config.dataDir);
+    try {
+      for (;;) {
+        const batch = inventory.purgeNextStartupStaleCandidateBatch();
+        if (batch.done) break;
+        await this.yieldRfc64InventoryV1StartupBatch();
+      }
+    } catch (cause) {
+      try {
+        inventory.close();
+      } catch (closeCause) {
+        throw new AggregateError(
+          [cause, closeCause],
+          'RFC-64 inventory startup purge and cleanup both failed',
+        );
+      }
+      throw cause;
+    }
+    this.rfc64InventoryV1 = inventory;
+  }
+
+  /** Yield between fixed-size adapter batches so startup cannot monopolize the event loop. */
+  protected async yieldRfc64InventoryV1StartupBatch(): Promise<void> {
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  }
+
+  /**
+   * Relinquish the single inventory foundation. Clear the local reference
+   * before closing so a fail-stop close error cannot be retried accidentally.
+   */
+  protected closeRfc64InventoryV1(): void {
+    const inventory = this.rfc64InventoryV1;
+    this.rfc64InventoryV1 = undefined;
+    inventory?.close();
   }
 
   /**

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -932,19 +932,35 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     const ctx = createOperationContext('connect');
     this.log.info(ctx, `Starting DKG node`);
 
-    // One-shot resident-poison sweep (OT-RFC-56 §4.4) — BEFORE networking, so
-    // the local store is clean before this node serves or syncs anything.
-    // Marker-gated (runs once per data dir), never throws, no-op on stores
-    // that never accepted oversized literals (Blazegraph).
-    await runOversizeSweep({
-      store: this.store,
-      dataDir: this.config.dataDir,
-      recordDrops: (drops, seam) => this.oversizeTombstoneLog.record(drops, seam),
-      logInfo: (message) => this.log.info(ctx, message),
-      logWarn: (message) => this.log.warn(ctx, message),
-    });
+    // OT-RFC-64: persistent inventory ownership and the complete bounded
+    // startup purge precede node.start(), protocol registration, and every
+    // network consumer. No dataDir intentionally leaves the feature dormant.
+    await this.prepareRfc64InventoryV1();
+    try {
+      // One-shot resident-poison sweep (OT-RFC-56 §4.4) — BEFORE networking,
+      // so the local store is clean before this node serves or syncs anything.
+      // Marker-gated (runs once per data dir), never throws, no-op on stores
+      // that never accepted oversized literals (Blazegraph).
+      await runOversizeSweep({
+        store: this.store,
+        dataDir: this.config.dataDir,
+        recordDrops: (drops, seam) => this.oversizeTombstoneLog.record(drops, seam),
+        logInfo: (message) => this.log.info(ctx, message),
+        logWarn: (message) => this.log.warn(ctx, message),
+      });
 
-    await this.node.start();
+      await this.node.start();
+    } catch (cause) {
+      try {
+        this.closeRfc64InventoryV1();
+      } catch (closeCause) {
+        throw new AggregateError(
+          [cause, closeCause],
+          'DKG node startup and RFC-64 inventory cleanup both failed',
+        );
+      }
+      throw cause;
+    }
     this.started = true;
     this.log.info(ctx, `Node started, peer ID: ${this.node.peerId.toString()}`);
 

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1713,6 +1713,19 @@ export class DKGAgent extends DKGAgentBase {
       await this.syncVerifyWorker.close();
       this.syncVerifyWorker = undefined;
     }
+    // OT-RFC-64 inventory consumers are now stopped. Release the exclusive
+    // inventory foundation before the triple store closes, but finish the
+    // remaining teardown even when close enters its deliberate fail-stop
+    // state. The original close failure is re-thrown after teardown so the
+    // operator receives a failed shutdown rather than a false success.
+    let inventoryCloseFailed = false;
+    let inventoryCloseFailure: unknown;
+    try {
+      this.closeRfc64InventoryV1();
+    } catch (error) {
+      inventoryCloseFailed = true;
+      inventoryCloseFailure = error;
+    }
     // Flush WM to disk before exit so the debounced 50ms flush in the
     // Oxigraph adapter can't lose the latest inserts when the process
     // exits. See docs/bugs/wm-persistence-regression.md.
@@ -1734,6 +1747,7 @@ export class DKGAgent extends DKGAgentBase {
       );
     }
     this.started = false;
+    if (inventoryCloseFailed) throw inventoryCloseFailure;
   }
 
   /**

--- a/packages/agent/test/fixtures/rfc64-agent-inventory-lifecycle-child.ts
+++ b/packages/agent/test/fixtures/rfc64-agent-inventory-lifecycle-child.ts
@@ -1,0 +1,33 @@
+import { DKGAgent } from '../../src/dkg-agent.js';
+
+const dataDirectory = process.env.DKG_RFC64_AGENT_INVENTORY_DATA_DIR;
+if (!dataDirectory) {
+  throw new Error('missing DKG_RFC64_AGENT_INVENTORY_DATA_DIR');
+}
+
+// Exercise the production DKGAgent-owned lifecycle without starting libp2p.
+// The parent uses SIGTERM to invoke the real close path and SIGKILL to prove
+// that the operating-system lease is recoverable without JavaScript cleanup.
+const agent = Object.create(DKGAgent.prototype) as any;
+Object.assign(agent, {
+  config: { dataDir: dataDirectory },
+  rfc64InventoryV1: undefined,
+});
+
+await agent.prepareRfc64InventoryV1();
+
+let terminating = false;
+process.once('SIGTERM', () => {
+  if (terminating) return;
+  terminating = true;
+  try {
+    agent.closeRfc64InventoryV1();
+    process.stdout.write('CLOSED\n', () => process.exit(0));
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.stack : String(error)}\n`);
+    process.exit(1);
+  }
+});
+
+process.stdout.write('READY\n');
+setInterval(() => undefined, 60_000);

--- a/packages/agent/test/rfc64-agent-inventory-lifecycle.test.ts
+++ b/packages/agent/test/rfc64-agent-inventory-lifecycle.test.ts
@@ -290,25 +290,31 @@ describe('DKGAgent RFC-64 inventory lifecycle', () => {
     await expect(agent.stop()).resolves.toBeUndefined();
   });
 
-  it('restarts after graceful SIGTERM inventory release', async () => {
-    const dataDirectory = temporaryDataDirectory();
-    const first = spawnLifecycleHolder(dataDirectory);
-    await waitForReady(first);
-    expect(await terminate(first, 'SIGTERM')).toEqual({ code: 0, signal: null });
+  it.runIf(process.platform !== 'win32')(
+    'restarts after graceful SIGTERM inventory release',
+    async () => {
+      const dataDirectory = temporaryDataDirectory();
+      const first = spawnLifecycleHolder(dataDirectory);
+      await waitForReady(first);
+      expect(await terminate(first, 'SIGTERM')).toEqual({ code: 0, signal: null });
 
-    const restarted = spawnLifecycleHolder(dataDirectory);
-    await waitForReady(restarted);
-    expect(await terminate(restarted, 'SIGTERM')).toEqual({ code: 0, signal: null });
-  });
+      const restarted = spawnLifecycleHolder(dataDirectory);
+      await waitForReady(restarted);
+      expect(await terminate(restarted, 'SIGTERM')).toEqual({ code: 0, signal: null });
+    },
+  );
 
-  it('recovers the operating-system lease after SIGKILL without cleanup', async () => {
-    const dataDirectory = temporaryDataDirectory();
-    const first = spawnLifecycleHolder(dataDirectory);
-    await waitForReady(first);
-    expect(await terminate(first, 'SIGKILL')).toEqual({ code: null, signal: 'SIGKILL' });
+  it.runIf(process.platform !== 'win32')(
+    'recovers the operating-system lease after SIGKILL without cleanup',
+    async () => {
+      const dataDirectory = temporaryDataDirectory();
+      const first = spawnLifecycleHolder(dataDirectory);
+      await waitForReady(first);
+      expect(await terminate(first, 'SIGKILL')).toEqual({ code: null, signal: 'SIGKILL' });
 
-    const restarted = spawnLifecycleHolder(dataDirectory);
-    await waitForReady(restarted);
-    expect(await terminate(restarted, 'SIGTERM')).toEqual({ code: 0, signal: null });
-  });
+      const restarted = spawnLifecycleHolder(dataDirectory);
+      await waitForReady(restarted);
+      expect(await terminate(restarted, 'SIGTERM')).toEqual({ code: 0, signal: null });
+    },
+  );
 });

--- a/packages/agent/test/rfc64-agent-inventory-lifecycle.test.ts
+++ b/packages/agent/test/rfc64-agent-inventory-lifecycle.test.ts
@@ -1,0 +1,314 @@
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { mkdtempSync, realpathSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { DKGAgent } from '../src/dkg-agent.js';
+import {
+  INVENTORY_V1_RELATIVE_PATH,
+  openInventoryV1,
+} from '../src/rfc64/inventory-v1/index.js';
+
+const temporaryDirectories: string[] = [];
+const childProcesses = new Set<ChildProcessWithoutNullStreams>();
+const CHILD_FIXTURE = resolve(
+  import.meta.dirname,
+  'fixtures/rfc64-agent-inventory-lifecycle-child.ts',
+);
+
+function temporaryDataDirectory(): string {
+  const directory = realpathSync(mkdtempSync(join(tmpdir(), 'dkg-rfc64-agent-')));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+function syntheticAgent(dataDirectory?: string): any {
+  const agent = Object.create(DKGAgent.prototype) as any;
+  Object.assign(agent, {
+    config: dataDirectory === undefined ? {} : { dataDir: dataDirectory },
+    rfc64InventoryV1: undefined,
+  });
+  return agent;
+}
+
+function u64be(value: bigint): Buffer {
+  const encoded = Buffer.alloc(8);
+  encoded.writeBigUInt64BE(value);
+  return encoded;
+}
+
+async function seedStaleCandidateLoads(dataDirectory: string, count: number): Promise<void> {
+  const foundation = await openInventoryV1(dataDirectory);
+  foundation.close();
+
+  const database = new DatabaseSync(join(dataDirectory, INVENTORY_V1_RELATIVE_PATH));
+  try {
+    const insert = database.prepare(`
+      INSERT INTO rfc64_candidate_bucket_loads_v1 (
+        session_id, catalog_scope_digest, author_address,
+        target_catalog_head_digest, subgraph_name, catalog_era_u64be,
+        bucket_count_u64be, bucket_id_u64be, bucket_object_digest,
+        row_count_u64be, payload_byte_length_u64be
+      ) VALUES (?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?)
+    `);
+    for (let index = 0; index < count; index += 1) {
+      const session = Buffer.alloc(32);
+      session.writeUInt32BE(index + 1, 28);
+      insert.run(
+        session,
+        Buffer.alloc(32, 0x22),
+        Buffer.alloc(20, 0x33),
+        Buffer.alloc(32, 0x44),
+        u64be(0n),
+        u64be(1n),
+        u64be(0n),
+        Buffer.alloc(32),
+        u64be(0n),
+        u64be(0n),
+      );
+    }
+  } finally {
+    database.close();
+  }
+}
+
+function candidateLoadCount(dataDirectory: string): number {
+  const database = new DatabaseSync(join(dataDirectory, INVENTORY_V1_RELATIVE_PATH));
+  try {
+    const row = database.prepare(
+      'SELECT count(*) AS count FROM rfc64_candidate_bucket_loads_v1',
+    ).get() as { count: number };
+    return row.count;
+  } finally {
+    database.close();
+  }
+}
+
+function minimalStartedAgent(
+  order: string[],
+  inventoryClose: () => void,
+): any {
+  const agent = syntheticAgent();
+  Object.assign(agent, {
+    started: true,
+    chainPoller: null,
+    coreHostRecordingsClosed: false,
+    drainCoreHostRecordings: vi.fn(async () => {}),
+    messenger: { stopOutboxDrain: vi.fn(async () => {}) },
+    clearRandomSamplingBindRetry: vi.fn(),
+    clearStorageACKRegistrationRetry: vi.fn(),
+    storageACKRegistrationRetryInFlight: false,
+    randomSamplingHandle: null,
+    inFlightSubstrateFanOutCount: () => 0,
+    router: { closePooling: vi.fn(async () => {}) },
+    node: { stop: vi.fn(async () => { order.push('node'); }) },
+    syncVerifyWorker: { close: vi.fn(async () => { order.push('sync-worker'); }) },
+    rfc64InventoryV1: { close: inventoryClose },
+    store: { close: vi.fn(async () => { order.push('store'); }) },
+    log: { warn: vi.fn() },
+  });
+  return agent;
+}
+
+function spawnLifecycleHolder(dataDirectory: string): ChildProcessWithoutNullStreams {
+  const child = spawn(
+    process.execPath,
+    ['--experimental-sqlite', '--import', 'tsx', CHILD_FIXTURE],
+    {
+      cwd: resolve(import.meta.dirname, '../../..'),
+      env: {
+        ...process.env,
+        NODE_ENV: 'test',
+        DKG_RFC64_AGENT_INVENTORY_DATA_DIR: dataDirectory,
+      },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    },
+  );
+  childProcesses.add(child);
+  child.once('exit', () => childProcesses.delete(child));
+  return child;
+}
+
+async function waitForReady(child: ChildProcessWithoutNullStreams): Promise<void> {
+  let stdout = '';
+  let stderr = '';
+  child.stdout.setEncoding('utf8');
+  child.stderr.setEncoding('utf8');
+  child.stdout.on('data', (chunk: string) => { stdout += chunk; });
+  child.stderr.on('data', (chunk: string) => { stderr += chunk; });
+  await new Promise<void>((resolveReady, rejectReady) => {
+    const timeout = setTimeout(() => {
+      rejectReady(new Error(`agent inventory holder did not become ready: ${stderr}`));
+    }, 20_000);
+    const onData = (): void => {
+      if (!stdout.includes('READY\n')) return;
+      clearTimeout(timeout);
+      resolveReady();
+    };
+    child.stdout.on('data', onData);
+    child.once('error', (error) => {
+      clearTimeout(timeout);
+      rejectReady(error);
+    });
+    child.once('exit', (code, signal) => {
+      clearTimeout(timeout);
+      rejectReady(new Error(
+        `agent inventory holder exited before ready: code=${code} signal=${signal} stderr=${stderr}`,
+      ));
+    });
+  });
+}
+
+async function terminate(
+  child: ChildProcessWithoutNullStreams,
+  signal: 'SIGTERM' | 'SIGKILL',
+): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
+  const exit = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
+    (resolveExit) => child.once('exit', (code, exitSignal) => resolveExit({
+      code,
+      signal: exitSignal,
+    })),
+  );
+  child.kill(signal);
+  return await exit;
+}
+
+afterEach(async () => {
+  await Promise.all([...childProcesses].map(async (child) => {
+    if (child.exitCode === null && child.signalCode === null) {
+      await terminate(child, 'SIGKILL');
+    }
+  }));
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe('DKGAgent RFC-64 inventory lifecycle', () => {
+  it('stays dormant without dataDir and performs no in-memory fallback', async () => {
+    const agent = syntheticAgent();
+
+    await agent.prepareRfc64InventoryV1();
+    await agent.prepareRfc64InventoryV1();
+
+    expect(agent.rfc64InventoryV1).toBeUndefined();
+    expect(() => agent.closeRfc64InventoryV1()).not.toThrow();
+    expect(() => agent.closeRfc64InventoryV1()).not.toThrow();
+  });
+
+  it('owns one persistent foundation and purges every stale candidate in bounded yielding batches', async () => {
+    const dataDirectory = temporaryDataDirectory();
+    await seedStaleCandidateLoads(dataDirectory, 17);
+    const agent = syntheticAgent(dataDirectory);
+    const yieldBatch = vi.fn(async () => {});
+    agent.yieldRfc64InventoryV1StartupBatch = yieldBatch;
+
+    await agent.prepareRfc64InventoryV1();
+    const ownedFoundation = agent.rfc64InventoryV1;
+    await agent.prepareRfc64InventoryV1();
+
+    expect(agent.rfc64InventoryV1).toBe(ownedFoundation);
+    expect(ownedFoundation.databasePath).toBe(
+      join(dataDirectory, INVENTORY_V1_RELATIVE_PATH),
+    );
+    expect(yieldBatch).toHaveBeenCalledTimes(3);
+    expect(() => ownedFoundation.createCandidateSession()).not.toThrow();
+
+    agent.closeRfc64InventoryV1();
+    expect(agent.rfc64InventoryV1).toBeUndefined();
+    expect(candidateLoadCount(dataDirectory)).toBe(0);
+    expect(() => agent.closeRfc64InventoryV1()).not.toThrow();
+  });
+
+  it('fails startup before node.start when inventory acquisition or recovery fails', async () => {
+    const failure = new Error('inventory unavailable');
+    const nodeStart = vi.fn(async () => {});
+    const agent = syntheticAgent();
+    Object.assign(agent, {
+      started: false,
+      coreHostRecordingGeneration: 0,
+      prepareRfc64InventoryV1: vi.fn(async () => { throw failure; }),
+      node: { start: nodeStart },
+      log: { info: vi.fn(), warn: vi.fn() },
+    });
+
+    await expect(agent.start()).rejects.toBe(failure);
+    expect(nodeStart).not.toHaveBeenCalled();
+    expect(agent.started).toBe(false);
+  });
+
+  it('releases an acquired inventory when node startup fails', async () => {
+    const failure = new Error('node start failed');
+    const close = vi.fn();
+    const agent = syntheticAgent();
+    Object.assign(agent, {
+      started: false,
+      coreHostRecordingGeneration: 0,
+      prepareRfc64InventoryV1: vi.fn(async () => {
+        agent.rfc64InventoryV1 = { close };
+      }),
+      node: { start: vi.fn(async () => { throw failure; }) },
+      log: { info: vi.fn(), warn: vi.fn() },
+    });
+
+    await expect(agent.start()).rejects.toBe(failure);
+    expect(close).toHaveBeenCalledOnce();
+    expect(agent.rfc64InventoryV1).toBeUndefined();
+    expect(agent.started).toBe(false);
+  });
+
+  it('closes after network consumers and before the triple store, with idempotent stop', async () => {
+    const order: string[] = [];
+    const inventoryClose = vi.fn(() => { order.push('inventory'); });
+    const agent = minimalStartedAgent(order, inventoryClose);
+
+    await agent.stop();
+    await agent.stop();
+
+    expect(order).toEqual(['node', 'sync-worker', 'inventory', 'store']);
+    expect(inventoryClose).toHaveBeenCalledOnce();
+    expect(agent.rfc64InventoryV1).toBeUndefined();
+    expect(agent.started).toBe(false);
+  });
+
+  it('finishes store teardown but rejects shutdown when inventory close fails', async () => {
+    const order: string[] = [];
+    const failure = new Error('inventory close failed');
+    const agent = minimalStartedAgent(order, () => {
+      order.push('inventory');
+      throw failure;
+    });
+
+    await expect(agent.stop()).rejects.toBe(failure);
+
+    expect(order).toEqual(['node', 'sync-worker', 'inventory', 'store']);
+    expect(agent.rfc64InventoryV1).toBeUndefined();
+    expect(agent.started).toBe(false);
+    await expect(agent.stop()).resolves.toBeUndefined();
+  });
+
+  it('restarts after graceful SIGTERM inventory release', async () => {
+    const dataDirectory = temporaryDataDirectory();
+    const first = spawnLifecycleHolder(dataDirectory);
+    await waitForReady(first);
+    expect(await terminate(first, 'SIGTERM')).toEqual({ code: 0, signal: null });
+
+    const restarted = spawnLifecycleHolder(dataDirectory);
+    await waitForReady(restarted);
+    expect(await terminate(restarted, 'SIGTERM')).toEqual({ code: 0, signal: null });
+  });
+
+  it('recovers the operating-system lease after SIGKILL without cleanup', async () => {
+    const dataDirectory = temporaryDataDirectory();
+    const first = spawnLifecycleHolder(dataDirectory);
+    await waitForReady(first);
+    expect(await terminate(first, 'SIGKILL')).toEqual({ code: null, signal: 'SIGKILL' });
+
+    const restarted = spawnLifecycleHolder(dataDirectory);
+    await waitForReady(restarted);
+    expect(await terminate(restarted, 'SIGTERM')).toEqual({ code: 0, signal: null });
+  });
+});

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -113,6 +113,7 @@ export default defineConfig({
       "test/rfc64-inventory-v1-candidate-faults.test.ts",
       "test/rfc64-candidate-transfer-admission.test.ts",
       "test/rfc64-catalog-row-authorship.test.ts",
+      "test/rfc64-agent-inventory-lifecycle.test.ts",
     ],
     testTimeout: 60_000,
     maxWorkers: 1,


### PR DESCRIPTION
## Summary

- make persistent DKGAgent instances own the RFC-64 inventory at `<dataDir>/rfc64-sync/inventory-v1.sqlite3`
- acquire and completely purge stale candidate loads in bounded yielding batches before node startup; keep no-dataDir agents dormant
- release inventory after network consumers stop and before the triple store closes, while propagating close failures after teardown
- cover idempotence, startup failures, shutdown ordering, SIGTERM restart, and SIGKILL OS-lease recovery

## Validation

- `pnpm --filter @origintrail-official/dkg-agent build`
- `pnpm --filter @origintrail-official/dkg-agent test:unit` (99 files; 1305 passed, 4 skipped)
- focused RFC-64 cluster (173 passed, 4 skipped)
- outbox shutdown lifecycle (4 passed)

## Integration

Targets `integration/rfc64-devnet`; this does not merge RFC-64 work into `main`.