### PR TITLE
feat(agent): produce sparse RFC-64 author catalogs

### DIFF
--- a/.github/workflows/rfc64-inventory-windows.yml
+++ b/.github/workflows/rfc64-inventory-windows.yml
@@ -5,8 +5,10 @@ on:
     paths:
       - '.github/workflows/rfc64-inventory-windows.yml'
       - 'packages/agent/src/rfc64/inventory-v1/**'
+      - 'packages/agent/src/rfc64/author-catalog-producer.ts'
       - 'packages/agent/test/rfc64-inventory-v1-*.test.ts'
       - 'packages/agent/test/rfc64-agent-inventory-lifecycle.test.ts'
+      - 'packages/agent/test/rfc64-author-catalog-producer.test.ts'
       - 'packages/agent/test/fixtures/rfc64-inventory-v1-child.ts'
       - 'packages/agent/test/fixtures/rfc64-agent-inventory-lifecycle-child.ts'
       - 'packages/agent/vitest.unit.config.ts'
@@ -62,3 +64,4 @@ jobs:
           --config vitest.unit.config.ts
           test/rfc64-inventory-v1
           test/rfc64-agent-inventory-lifecycle.test.ts
+          test/rfc64-author-catalog-producer.test.ts

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -35,6 +35,7 @@ export {
   type VerifyAgentDelegationOptions,
 } from './auth/agent-delegation.js';
 export * from './rfc64/catalog-row-authorship.js';
+export * from './rfc64/author-catalog-producer.js';
 export { encrypt, decrypt, ed25519ToX25519Private, ed25519ToX25519Public, x25519SharedSecret } from './encryption.js';
 export { MessageHandler, type SkillRequest, type SkillResponse, type SkillHandler, type ChatHandler, type ChatAclCheck } from './messaging.js';
 export {

--- a/packages/agent/src/rfc64/author-catalog-producer.ts
+++ b/packages/agent/src/rfc64/author-catalog-producer.ts
@@ -1,0 +1,912 @@
+import {
+  AUTHOR_CATALOG_BUCKET_OBJECT_TYPE_V1,
+  AUTHOR_CATALOG_DIRECTORY_FANOUT_V1,
+  AUTHOR_CATALOG_DIRECTORY_NODE_OBJECT_TYPE_V1,
+  AUTHOR_CATALOG_HEAD_OBJECT_TYPE_V1,
+  MAX_DECIMAL_U64,
+  ZERO_DIGEST32_V1,
+  assertAuthorCatalogBucketScopeBindingV1,
+  assertAuthorCatalogHeadScopeBindingV1,
+  assertAuthorCatalogScopeV1,
+  assertSignedAuthorCatalogBucketEnvelopeV1,
+  assertSignedAuthorCatalogDirectoryNodeEnvelopeV1,
+  assertSignedAuthorCatalogHeadEnvelopeV1,
+  canonicalizeAuthorCatalogBucketPayloadBytesV1,
+  canonicalizeAuthorCatalogDirectoryNodePayloadBytesV1,
+  canonicalizeAuthorCatalogRowV1,
+  canonicalizeSignedAuthorCatalogBucketEnvelopeBytesV1,
+  canonicalizeSignedAuthorCatalogDirectoryNodeEnvelopeBytesV1,
+  canonicalizeSignedAuthorCatalogHeadEnvelopeBytesV1,
+  computeAuthorCatalogBucketObjectDigestV1,
+  computeAuthorCatalogDirectoryNodeObjectDigestV1,
+  computeAuthorCatalogHeadObjectDigestV1,
+  computeAuthorCatalogScopeDigestV1,
+  deriveAuthorCatalogScopeFromHeadV1,
+  parseCanonicalAuthorCatalogBucketPayloadV1,
+  parseCanonicalAuthorCatalogRowV1,
+  parseCanonicalSignedAuthorCatalogBucketEnvelopeV1,
+  parseCanonicalSignedAuthorCatalogDirectoryNodeEnvelopeV1,
+  parseCanonicalSignedAuthorCatalogHeadEnvelopeV1,
+  readVerifiedAuthorCatalogBucketDescriptorV1,
+  verifyAuthorCatalogDirectoryPathV1,
+  type AuthorCatalogBucketDescriptorV1,
+  type AuthorCatalogBucketV1,
+  type AuthorCatalogChildDescriptorV1,
+  type AuthorCatalogDirectoryEntryV1,
+  type AuthorCatalogDirectoryNodeV1,
+  type AuthorCatalogHeadV1,
+  type AuthorCatalogRowV1,
+  type AuthorCatalogScopeV1,
+  type DecimalU64V1,
+  type Digest32V1,
+  type EvmAddressV1,
+  type SignedAuthorCatalogBucketEnvelopeV1,
+  type SignedAuthorCatalogDirectoryNodeEnvelopeV1,
+  type SignedAuthorCatalogHeadEnvelopeV1,
+  type SignedControlEnvelopeV1,
+  type TimestampMsV1,
+  type UnsignedControlEnvelopeV1,
+} from '@origintrail-official/dkg-core';
+import { verifyControlEnvelopeIssuerSignatureV1 } from '@origintrail-official/dkg-chain';
+import { ethers } from 'ethers';
+
+export const RFC64_AUTHOR_CATALOG_PRODUCTION_ERROR_CODES_V1 = Object.freeze([
+  'catalog-production-input',
+  'catalog-production-history',
+  'catalog-production-path',
+  'catalog-production-delta',
+  'catalog-production-noop',
+  'catalog-production-signer',
+] as const);
+
+export type Rfc64AuthorCatalogProductionErrorCodeV1 =
+  (typeof RFC64_AUTHOR_CATALOG_PRODUCTION_ERROR_CODES_V1)[number];
+
+export class Rfc64AuthorCatalogProductionErrorV1 extends Error {
+  constructor(
+    readonly code: Rfc64AuthorCatalogProductionErrorCodeV1,
+    message: string,
+    options: ErrorOptions = {},
+  ) {
+    super(`[${code}] ${message}`, options);
+    if (!RFC64_AUTHOR_CATALOG_PRODUCTION_ERROR_CODES_V1.includes(code)) {
+      throw new TypeError(`Unsupported RFC-64 author catalog production error code: ${code}`);
+    }
+    this.name = 'Rfc64AuthorCatalogProductionErrorV1';
+  }
+}
+
+/**
+ * Local EOA signer used for catalog production. The callback signs the raw
+ * 32-byte control-object digest with EIP-191 personal-sign framing.
+ */
+export interface Rfc64AuthorCatalogEip191SignerV1 {
+  readonly issuer: EvmAddressV1;
+  readonly signDigest: (objectDigest: Uint8Array) => Promise<string>;
+}
+
+export interface ProduceEmptyAuthorCatalogGenesisInputV1 {
+  readonly scope: AuthorCatalogScopeV1;
+  readonly catalogIssuerDelegationDigest: Digest32V1;
+  readonly issuedAt: TimestampMsV1;
+  readonly signer: Rfc64AuthorCatalogEip191SignerV1;
+}
+
+export interface ProduceSparseAuthorCatalogSuccessorInputV1 {
+  readonly previousHead: SignedAuthorCatalogHeadEnvelopeV1;
+  readonly previousDirectoryPath: readonly SignedAuthorCatalogDirectoryNodeEnvelopeV1[];
+  /** Exact prior bucket object, or null when the selected descriptor is empty. */
+  readonly previousBucket: SignedAuthorCatalogBucketEnvelopeV1 | null;
+  readonly selectedBucketId: DecimalU64V1;
+  /** Complete replacement live set for the selected bucket. */
+  readonly nextRows: readonly AuthorCatalogRowV1[];
+  readonly issuedAt: TimestampMsV1;
+  readonly signer: Rfc64AuthorCatalogEip191SignerV1;
+}
+
+export interface ProducedAuthorCatalogPublicationV1 {
+  /** Signed candidate only; this grants no durable-staging or semantic-ref authority. */
+  readonly head: SignedAuthorCatalogHeadEnvelopeV1;
+  /** Root-to-leaf path under {@link head}. */
+  readonly directoryPath: readonly SignedAuthorCatalogDirectoryNodeEnvelopeV1[];
+  /** Null denotes the selected bucket's canonical empty descriptor. */
+  readonly bucket: SignedAuthorCatalogBucketEnvelopeV1 | null;
+  /** Immutable objects in required staging order: bucket, leaf-to-root path, head. */
+  readonly stagedObjects: readonly SignedControlEnvelopeV1[];
+}
+
+interface SnapshotEip191SignerV1 {
+  readonly issuer: EvmAddressV1;
+  readonly signDigest: (objectDigest: Uint8Array) => Promise<string>;
+}
+
+/** Produce the canonical scoped empty catalog used to bootstrap later sparse writes. */
+export async function produceEmptyAuthorCatalogGenesisV1(
+  input: ProduceEmptyAuthorCatalogGenesisInputV1,
+): Promise<ProducedAuthorCatalogPublicationV1> {
+  try {
+    return await produceEmptyAuthorCatalogGenesisUncheckedV1(input);
+  } catch (cause) {
+    normalizePublicError('empty author catalog genesis production failed', cause);
+  }
+}
+
+async function produceEmptyAuthorCatalogGenesisUncheckedV1(
+  input: ProduceEmptyAuthorCatalogGenesisInputV1,
+): Promise<ProducedAuthorCatalogPublicationV1> {
+  const scopeInput = input.scope;
+  const delegationDigest = input.catalogIssuerDelegationDigest;
+  const issuedAt = input.issuedAt;
+  const signer = snapshotSigner(input.signer);
+
+  const scope = snapshotScope(scopeInput);
+  if (scope.era !== '0' || scope.bucketCount !== '1') {
+    fail(
+      'catalog-production-history',
+      'empty genesis requires era=0 and bucketCount=1',
+    );
+  }
+
+  const catalogScopeDigest = computeAuthorCatalogScopeDigestV1(scope);
+  const rootPayload: AuthorCatalogDirectoryNodeV1 = {
+    catalogScopeDigest,
+    entries: [{
+      bucketDigest: ZERO_DIGEST32_V1,
+      bucketId: '0' as DecimalU64V1,
+      byteLength: '0' as DecimalU64V1,
+      rowCount: '0' as DecimalU64V1,
+    }],
+    era: '0' as DecimalU64V1,
+    firstBucketId: '0' as DecimalU64V1,
+    level: '0' as DecimalU64V1,
+  };
+  const root = await signDirectoryNode(rootPayload, scope.bucketCount, signer);
+  const headPayload: AuthorCatalogHeadV1 = {
+    networkId: scope.networkId,
+    contextGraphId: scope.contextGraphId,
+    governanceChainId: scope.governanceChainId,
+    governanceContractAddress: scope.governanceContractAddress,
+    ownershipTransitionDigest: scope.ownershipTransitionDigest,
+    subGraphName: scope.subGraphName,
+    authorAddress: scope.authorAddress,
+    catalogIssuerDelegationDigest: delegationDigest,
+    era: '0' as DecimalU64V1,
+    version: '0' as DecimalU64V1,
+    previousHeadDigest: null,
+    bucketCount: '1' as DecimalU64V1,
+    totalRows: '0' as DecimalU64V1,
+    directoryHeight: '0' as DecimalU64V1,
+    directoryRootDigest: root.objectDigest as Digest32V1,
+    issuedAt,
+  };
+  const head = await signHead(headPayload, signer);
+
+  try {
+    assertAuthorCatalogHeadScopeBindingV1(head.payload, scope);
+    const verifiedPath = verifyAuthorCatalogDirectoryPathV1(
+      head,
+      [root],
+      '0' as DecimalU64V1,
+    );
+    const descriptor = readVerifiedAuthorCatalogBucketDescriptorV1(verifiedPath, head);
+    if (descriptor.bucketDigest !== ZERO_DIGEST32_V1 || descriptor.rowCount !== '0') {
+      throw new Error('empty genesis selected a non-empty descriptor');
+    }
+  } catch (cause) {
+    fail('catalog-production-path', 'produced empty genesis is not self-consistent', cause);
+  }
+
+  return freezePublication(head, [root], null, [root, head]);
+}
+
+/**
+ * Change exactly one KA row, replace its complete bucket, and rebuild only the
+ * leaf-to-root path.
+ * This is the ordinary same-era update path; capacity/key/ownership transitions
+ * deliberately require a different producer.
+ */
+export async function produceSparseAuthorCatalogSuccessorV1(
+  input: ProduceSparseAuthorCatalogSuccessorInputV1,
+): Promise<ProducedAuthorCatalogPublicationV1> {
+  try {
+    return await produceSparseAuthorCatalogSuccessorUncheckedV1(input);
+  } catch (cause) {
+    normalizePublicError('sparse author catalog successor production failed', cause);
+  }
+}
+
+async function produceSparseAuthorCatalogSuccessorUncheckedV1(
+  input: ProduceSparseAuthorCatalogSuccessorInputV1,
+): Promise<ProducedAuthorCatalogPublicationV1> {
+  const previousHeadInput = input.previousHead;
+  const previousPathInput = input.previousDirectoryPath;
+  const previousBucketInput = input.previousBucket;
+  const selectedBucketId = input.selectedBucketId;
+  const nextRowsInput = input.nextRows;
+  const issuedAt = input.issuedAt;
+  const signer = snapshotSigner(input.signer);
+
+  const previousHead = snapshotHead(previousHeadInput);
+  assertEip191Issuer(previousHead, signer.issuer, 'previous head');
+  await verifyExistingSignature(previousHead, 'previous head');
+  const scope = deriveAuthorCatalogScopeFromHeadV1(previousHead.payload);
+  const previousPath = snapshotDirectoryPath(previousPathInput, scope.bucketCount);
+  for (let index = 0; index < previousPath.length; index += 1) {
+    assertEip191Issuer(previousPath[index], signer.issuer, `previous path node ${index}`);
+    await verifyExistingSignature(previousPath[index], `previous path node ${index}`);
+  }
+
+  let previousDescriptor: Readonly<AuthorCatalogBucketDescriptorV1>;
+  try {
+    const verifiedPath = verifyAuthorCatalogDirectoryPathV1(
+      previousHead,
+      previousPath,
+      selectedBucketId,
+    );
+    previousDescriptor = readVerifiedAuthorCatalogBucketDescriptorV1(
+      verifiedPath,
+      previousHead,
+    );
+  } catch (cause) {
+    fail('catalog-production-path', 'previous directory path is not bound to the selected bucket', cause);
+  }
+  const previousBucket = await snapshotPreviousBucket(
+    previousBucketInput,
+    previousDescriptor,
+    scope,
+    signer.issuer,
+  );
+
+  const preparedBucket = prepareReplacementBucket(
+    scope,
+    selectedBucketId,
+    nextRowsInput,
+    signer.issuer,
+  );
+  const nextDescriptor = preparedBucket.descriptor;
+  if (sameBucketDescriptor(previousDescriptor, nextDescriptor)) {
+    fail('catalog-production-noop', 'ordinary catalog successor must change its selected bucket');
+  }
+  assertOneKaBucketDelta(previousBucket, preparedBucket);
+
+  const previousTotal = BigInt(previousHead.payload.totalRows);
+  const removedRows = BigInt(previousDescriptor.rowCount);
+  const addedRows = BigInt(nextDescriptor.rowCount);
+  const nextTotal = previousTotal - removedRows + addedRows;
+  if (nextTotal < 0n || nextTotal > MAX_DECIMAL_U64) {
+    fail('catalog-production-history', 'successor totalRows is outside DecimalU64V1');
+  }
+  const previousVersion = BigInt(previousHead.payload.version);
+  if (previousVersion >= MAX_DECIMAL_U64) {
+    fail('catalog-production-history', 'ordinary catalog version cannot overflow DecimalU64V1');
+  }
+  const nextBucket = await signPreparedReplacementBucket(preparedBucket, signer);
+
+  const nextPath = new Array<SignedAuthorCatalogDirectoryNodeEnvelopeV1>(
+    previousPath.length,
+  );
+  for (let pathIndex = previousPath.length - 1; pathIndex >= 0; pathIndex -= 1) {
+    const previousNode = previousPath[pathIndex].payload;
+    const entries = cloneEntries(previousNode.entries);
+    const entryIndex = selectedEntryIndex(previousNode, selectedBucketId);
+    if (BigInt(previousNode.level) === 0n) {
+      entries[entryIndex] = nextDescriptor;
+    } else {
+      const child = nextPath[pathIndex + 1];
+      entries[entryIndex] = childDescriptor(child, scope.bucketCount);
+    }
+    nextPath[pathIndex] = await signDirectoryNode({
+      catalogScopeDigest: previousNode.catalogScopeDigest,
+      entries,
+      era: previousNode.era,
+      firstBucketId: previousNode.firstBucketId,
+      level: previousNode.level,
+    }, scope.bucketCount, signer);
+  }
+
+  const nextHead = await signHead({
+    networkId: previousHead.payload.networkId,
+    contextGraphId: previousHead.payload.contextGraphId,
+    governanceChainId: previousHead.payload.governanceChainId,
+    governanceContractAddress: previousHead.payload.governanceContractAddress,
+    ownershipTransitionDigest: previousHead.payload.ownershipTransitionDigest,
+    subGraphName: previousHead.payload.subGraphName,
+    authorAddress: previousHead.payload.authorAddress,
+    catalogIssuerDelegationDigest: previousHead.payload.catalogIssuerDelegationDigest,
+    era: previousHead.payload.era,
+    version: (previousVersion + 1n).toString() as DecimalU64V1,
+    previousHeadDigest: previousHead.objectDigest as Digest32V1,
+    bucketCount: previousHead.payload.bucketCount,
+    totalRows: nextTotal.toString() as DecimalU64V1,
+    directoryHeight: previousHead.payload.directoryHeight,
+    directoryRootDigest: nextPath[0].objectDigest as Digest32V1,
+    issuedAt,
+  }, signer);
+
+  try {
+    assertAuthorCatalogHeadScopeBindingV1(nextHead.payload, scope);
+    const verifiedPath = verifyAuthorCatalogDirectoryPathV1(
+      nextHead,
+      nextPath,
+      selectedBucketId,
+    );
+    const producedDescriptor = readVerifiedAuthorCatalogBucketDescriptorV1(
+      verifiedPath,
+      nextHead,
+    );
+    if (!sameBucketDescriptor(producedDescriptor, nextDescriptor)) {
+      throw new Error('produced directory descriptor changed during construction');
+    }
+    if (nextBucket !== null) {
+      assertAuthorCatalogBucketScopeBindingV1(nextBucket.payload, scope);
+    }
+  } catch (cause) {
+    fail('catalog-production-path', 'produced sparse successor is not self-consistent', cause);
+  }
+
+  const stagedObjects: SignedControlEnvelopeV1[] = [];
+  if (nextBucket !== null) stagedObjects.push(nextBucket);
+  for (let index = nextPath.length - 1; index >= 0; index -= 1) {
+    stagedObjects.push(nextPath[index]);
+  }
+  stagedObjects.push(nextHead);
+  return freezePublication(nextHead, nextPath, nextBucket, stagedObjects);
+}
+
+type PreparedReplacementBucketV1 =
+  | {
+      readonly bucket: null;
+      readonly descriptor: AuthorCatalogBucketDescriptorV1;
+      readonly rows: readonly AuthorCatalogRowV1[];
+    }
+  | {
+      readonly bucket: {
+        readonly unsigned: UnsignedControlEnvelopeV1;
+        readonly objectDigest: Digest32V1;
+      };
+      readonly descriptor: AuthorCatalogBucketDescriptorV1;
+      readonly rows: readonly AuthorCatalogRowV1[];
+    };
+
+function prepareReplacementBucket(
+  scope: AuthorCatalogScopeV1,
+  selectedBucketId: DecimalU64V1,
+  rowsInput: readonly AuthorCatalogRowV1[],
+  issuer: EvmAddressV1,
+): PreparedReplacementBucketV1 {
+  if (!Array.isArray(rowsInput) || Object.getPrototypeOf(rowsInput) !== Array.prototype) {
+    fail('catalog-production-input', 'nextRows must be an ordinary dense Array');
+  }
+  const rows = snapshotRows(rowsInput);
+  if (rows.length === 0) {
+    return Object.freeze({
+      bucket: null,
+      descriptor: emptyBucketDescriptor(selectedBucketId),
+      rows: Object.freeze([]),
+    });
+  }
+
+  let payload: AuthorCatalogBucketV1;
+  try {
+    const candidate: AuthorCatalogBucketV1 = {
+      catalogScopeDigest: computeAuthorCatalogScopeDigestV1(scope),
+      era: scope.era,
+      bucketCount: scope.bucketCount,
+      bucketId: selectedBucketId,
+      rows,
+    };
+    payload = parseCanonicalAuthorCatalogBucketPayloadV1(
+      canonicalizeAuthorCatalogBucketPayloadBytesV1(candidate),
+    );
+    assertAuthorCatalogBucketScopeBindingV1(payload, scope);
+  } catch (cause) {
+    fail('catalog-production-input', 'replacement bucket is not canonical for this scope', cause);
+  }
+
+  const unsigned = eip191Unsigned(
+    issuer,
+    AUTHOR_CATALOG_BUCKET_OBJECT_TYPE_V1,
+    freezePlainSnapshot(payload),
+  );
+  const objectDigest = computeAuthorCatalogBucketObjectDigestV1(unsigned);
+  return Object.freeze({
+    bucket: Object.freeze({ unsigned, objectDigest }),
+    descriptor: Object.freeze({
+      bucketDigest: objectDigest,
+      bucketId: selectedBucketId,
+      byteLength: canonicalizeAuthorCatalogBucketPayloadBytesV1(payload)
+        .byteLength.toString() as DecimalU64V1,
+      rowCount: payload.rows.length.toString() as DecimalU64V1,
+    }),
+    rows: payload.rows,
+  });
+}
+
+async function snapshotPreviousBucket(
+  input: SignedAuthorCatalogBucketEnvelopeV1 | null,
+  descriptor: Readonly<AuthorCatalogBucketDescriptorV1>,
+  scope: AuthorCatalogScopeV1,
+  issuer: EvmAddressV1,
+): Promise<SignedAuthorCatalogBucketEnvelopeV1 | null> {
+  if (descriptor.bucketDigest === ZERO_DIGEST32_V1) {
+    if (input !== null) {
+      fail('catalog-production-path', 'empty previous descriptor must not carry a bucket object');
+    }
+    return null;
+  }
+  if (input === null) {
+    fail('catalog-production-path', 'non-empty previous descriptor requires its exact bucket object');
+  }
+
+  let bucket: SignedAuthorCatalogBucketEnvelopeV1;
+  try {
+    bucket = freezePlainSnapshot(parseCanonicalSignedAuthorCatalogBucketEnvelopeV1(
+      canonicalizeSignedAuthorCatalogBucketEnvelopeBytesV1(input),
+    )) as SignedAuthorCatalogBucketEnvelopeV1;
+    assertAuthorCatalogBucketScopeBindingV1(bucket.payload, scope);
+  } catch (cause) {
+    fail('catalog-production-input', 'previous bucket is not one canonical scoped snapshot', cause);
+  }
+  assertEip191Issuer(bucket, issuer, 'previous bucket');
+  await verifyExistingSignature(bucket, 'previous bucket');
+  const byteLength = canonicalizeAuthorCatalogBucketPayloadBytesV1(bucket.payload).byteLength;
+  if (
+    bucket.objectDigest !== descriptor.bucketDigest
+    || bucket.payload.bucketId !== descriptor.bucketId
+    || bucket.payload.rows.length.toString() !== descriptor.rowCount
+    || byteLength.toString() !== descriptor.byteLength
+  ) {
+    fail('catalog-production-path', 'previous bucket does not match its verified descriptor');
+  }
+  return bucket;
+}
+
+function assertOneKaBucketDelta(
+  previousBucket: SignedAuthorCatalogBucketEnvelopeV1 | null,
+  nextBucket: PreparedReplacementBucketV1,
+): void {
+  const previousRows = previousBucket?.payload.rows ?? [];
+  const nextRows = nextBucket.rows;
+  const previousCanonical = canonicalRows(previousRows);
+  const nextCanonical = canonicalRows(nextRows);
+  const lengthDelta = nextRows.length - previousRows.length;
+  if (lengthDelta === 1) {
+    assertSingleInsertion(previousCanonical, nextCanonical);
+    return;
+  }
+  if (lengthDelta === -1) {
+    assertSingleRemoval(previousCanonical, nextCanonical);
+    return;
+  }
+  if (lengthDelta !== 0) {
+    fail('catalog-production-delta', 'ordinary successor must change exactly one KA row');
+  }
+
+  let changedIndex = -1;
+  for (let index = 0; index < previousCanonical.length; index += 1) {
+    if (previousCanonical[index] === nextCanonical[index]) continue;
+    if (changedIndex !== -1) {
+      fail('catalog-production-delta', 'ordinary successor changed more than one KA row');
+    }
+    changedIndex = index;
+  }
+  if (changedIndex === -1) {
+    fail('catalog-production-noop', 'ordinary successor did not change a KA row');
+  }
+  const previousRow = previousRows[changedIndex];
+  const nextRow = nextRows[changedIndex];
+  if (
+    previousRow.kaId !== nextRow.kaId
+    || previousRow.assertionCoordinate !== nextRow.assertionCoordinate
+    || BigInt(nextRow.assertionVersion) !== BigInt(previousRow.assertionVersion) + 1n
+  ) {
+    fail(
+      'catalog-production-delta',
+      'one-row replacement must preserve KA/coordinate and increment assertionVersion by one',
+    );
+  }
+}
+
+function canonicalRows(rows: readonly AuthorCatalogRowV1[]): string[] {
+  const result = new Array<string>(rows.length);
+  for (let index = 0; index < rows.length; index += 1) {
+    result[index] = canonicalizeAuthorCatalogRowV1(rows[index]);
+  }
+  return result;
+}
+
+function assertSingleInsertion(previous: readonly string[], next: readonly string[]): void {
+  let insertionIndex = 0;
+  while (
+    insertionIndex < previous.length
+    && previous[insertionIndex] === next[insertionIndex]
+  ) {
+    insertionIndex += 1;
+  }
+  for (let index = insertionIndex; index < previous.length; index += 1) {
+    if (previous[index] !== next[index + 1]) {
+      fail('catalog-production-delta', 'ordinary successor inserted more than one KA row');
+    }
+  }
+}
+
+function assertSingleRemoval(previous: readonly string[], next: readonly string[]): void {
+  let removalIndex = 0;
+  while (
+    removalIndex < next.length
+    && previous[removalIndex] === next[removalIndex]
+  ) {
+    removalIndex += 1;
+  }
+  for (let index = removalIndex; index < next.length; index += 1) {
+    if (previous[index + 1] !== next[index]) {
+      fail('catalog-production-delta', 'ordinary successor removed more than one KA row');
+    }
+  }
+}
+
+async function signPreparedReplacementBucket(
+  prepared: PreparedReplacementBucketV1,
+  signer: SnapshotEip191SignerV1,
+): Promise<SignedAuthorCatalogBucketEnvelopeV1 | null> {
+  if (prepared.bucket === null) return null;
+  const signed = await signEnvelope(
+    prepared.bucket.unsigned,
+    prepared.bucket.objectDigest,
+    signer,
+    (value) => {
+      assertSignedAuthorCatalogBucketEnvelopeV1(value);
+    },
+  );
+  return freezePlainSnapshot(parseCanonicalSignedAuthorCatalogBucketEnvelopeV1(
+    canonicalizeSignedAuthorCatalogBucketEnvelopeBytesV1(signed),
+  )) as SignedAuthorCatalogBucketEnvelopeV1;
+}
+
+async function signDirectoryNode(
+  payload: AuthorCatalogDirectoryNodeV1,
+  bucketCount: AuthorCatalogScopeV1['bucketCount'],
+  signer: SnapshotEip191SignerV1,
+): Promise<SignedAuthorCatalogDirectoryNodeEnvelopeV1> {
+  const unsigned = eip191Unsigned(
+    signer.issuer,
+    AUTHOR_CATALOG_DIRECTORY_NODE_OBJECT_TYPE_V1,
+    freezePlainSnapshot(payload),
+  );
+  const digest = computeAuthorCatalogDirectoryNodeObjectDigestV1(unsigned, bucketCount);
+  const signed = await signEnvelope(unsigned, digest, signer, (value) => {
+    assertSignedAuthorCatalogDirectoryNodeEnvelopeV1(value, bucketCount);
+  });
+  return freezePlainSnapshot(parseCanonicalSignedAuthorCatalogDirectoryNodeEnvelopeV1(
+    canonicalizeSignedAuthorCatalogDirectoryNodeEnvelopeBytesV1(signed, bucketCount),
+    bucketCount,
+  )) as SignedAuthorCatalogDirectoryNodeEnvelopeV1;
+}
+
+async function signHead(
+  payload: AuthorCatalogHeadV1,
+  signer: SnapshotEip191SignerV1,
+): Promise<SignedAuthorCatalogHeadEnvelopeV1> {
+  const unsigned = eip191Unsigned(
+    signer.issuer,
+    AUTHOR_CATALOG_HEAD_OBJECT_TYPE_V1,
+    freezePlainSnapshot(payload),
+  );
+  const digest = computeAuthorCatalogHeadObjectDigestV1(unsigned);
+  const signed = await signEnvelope(unsigned, digest, signer, (value) => {
+    assertSignedAuthorCatalogHeadEnvelopeV1(value);
+  });
+  return freezePlainSnapshot(parseCanonicalSignedAuthorCatalogHeadEnvelopeV1(
+    canonicalizeSignedAuthorCatalogHeadEnvelopeBytesV1(signed),
+  )) as SignedAuthorCatalogHeadEnvelopeV1;
+}
+
+async function signEnvelope(
+  unsigned: UnsignedControlEnvelopeV1,
+  objectDigest: Digest32V1,
+  signer: SnapshotEip191SignerV1,
+  assertSpecific: (value: SignedControlEnvelopeV1) => void,
+): Promise<SignedControlEnvelopeV1> {
+  let signature: string;
+  try {
+    signature = await signer.signDigest(ethers.getBytes(objectDigest));
+  } catch (cause) {
+    fail('catalog-production-signer', `signer failed for ${unsigned.objectType}`, cause);
+  }
+  const signed = {
+    ...unsigned,
+    objectDigest,
+    signature,
+  } as SignedControlEnvelopeV1;
+  try {
+    assertSpecific(signed);
+    await verifyControlEnvelopeIssuerSignatureV1(signed);
+  } catch (cause) {
+    fail(
+      'catalog-production-signer',
+      `signer did not produce a canonical ${unsigned.objectType} signature for ${signer.issuer}`,
+      cause,
+    );
+  }
+  return signed;
+}
+
+function snapshotHead(
+  input: SignedAuthorCatalogHeadEnvelopeV1,
+): SignedAuthorCatalogHeadEnvelopeV1 {
+  try {
+    return freezePlainSnapshot(parseCanonicalSignedAuthorCatalogHeadEnvelopeV1(
+      canonicalizeSignedAuthorCatalogHeadEnvelopeBytesV1(input),
+    )) as SignedAuthorCatalogHeadEnvelopeV1;
+  } catch (cause) {
+    fail('catalog-production-input', 'previous head is not one canonical snapshot', cause);
+  }
+}
+
+function snapshotDirectoryPath(
+  input: readonly SignedAuthorCatalogDirectoryNodeEnvelopeV1[],
+  bucketCount: AuthorCatalogScopeV1['bucketCount'],
+): readonly SignedAuthorCatalogDirectoryNodeEnvelopeV1[] {
+  if (!Array.isArray(input) || Object.getPrototypeOf(input) !== Array.prototype) {
+    fail('catalog-production-input', 'previousDirectoryPath must be an ordinary dense Array');
+  }
+  const length = input.length;
+  if (!Number.isSafeInteger(length) || length < 1 || length > 8) {
+    fail('catalog-production-input', 'previousDirectoryPath must contain 1..8 nodes');
+  }
+  const snapshot = new Array<SignedAuthorCatalogDirectoryNodeEnvelopeV1>(length);
+  try {
+    for (let index = 0; index < length; index += 1) {
+      snapshot[index] = freezePlainSnapshot(
+        parseCanonicalSignedAuthorCatalogDirectoryNodeEnvelopeV1(
+          canonicalizeSignedAuthorCatalogDirectoryNodeEnvelopeBytesV1(
+            input[index],
+            bucketCount,
+          ),
+          bucketCount,
+        ),
+      ) as SignedAuthorCatalogDirectoryNodeEnvelopeV1;
+    }
+  } catch (cause) {
+    fail('catalog-production-input', 'previous directory path is not one canonical snapshot', cause);
+  }
+  return Object.freeze(snapshot);
+}
+
+function snapshotRows(input: readonly AuthorCatalogRowV1[]): readonly AuthorCatalogRowV1[] {
+  const length = input.length;
+  if (!Number.isSafeInteger(length) || length < 0 || length > 1024) {
+    fail('catalog-production-input', 'nextRows is outside the 0..1024 bucket-row bound');
+  }
+  const snapshot = new Array<AuthorCatalogRowV1>(length);
+  try {
+    for (let index = 0; index < length; index += 1) {
+      const rowInput = input[index];
+      const transferInput = rowInput.transfer;
+      const row = {
+        kaId: rowInput.kaId,
+        assertionCoordinate: rowInput.assertionCoordinate,
+        assertionVersion: rowInput.assertionVersion,
+        projectionId: rowInput.projectionId,
+        projectionDigest: rowInput.projectionDigest,
+        sealDigest: rowInput.sealDigest,
+        transfer: {
+          codec: transferInput.codec,
+          projectionId: transferInput.projectionId,
+          projectionDigest: transferInput.projectionDigest,
+          byteLength: transferInput.byteLength,
+          chunkSize: transferInput.chunkSize,
+          chunkCount: transferInput.chunkCount,
+          blobDigest: transferInput.blobDigest,
+          chunkTreeRoot: transferInput.chunkTreeRoot,
+        },
+      } as AuthorCatalogRowV1;
+      snapshot[index] = freezePlainSnapshot(parseCanonicalAuthorCatalogRowV1(
+        canonicalizeAuthorCatalogRowV1(row),
+      ));
+    }
+  } catch (cause) {
+    fail('catalog-production-input', 'nextRows is not one canonical row snapshot', cause);
+  }
+  return Object.freeze(snapshot);
+}
+
+function snapshotSigner(input: Rfc64AuthorCatalogEip191SignerV1): SnapshotEip191SignerV1 {
+  const issuer = input.issuer;
+  const signDigest = input.signDigest;
+  if (typeof signDigest !== 'function') {
+    fail('catalog-production-input', 'catalog signer must expose signDigest');
+  }
+  return Object.freeze({ issuer, signDigest });
+}
+
+function assertEip191Issuer(
+  envelope: SignedControlEnvelopeV1,
+  issuer: EvmAddressV1,
+  label: string,
+): void {
+  if (
+    envelope.issuer !== issuer
+    || envelope.signatureSuite !== 'eip191-personal-sign-digest-v1'
+    || envelope.signatureEvidence.kind !== 'none'
+  ) {
+    fail(
+      'catalog-production-history',
+      `${label} must use the same EIP-191 catalog issuer as the successor signer`,
+    );
+  }
+}
+
+async function verifyExistingSignature(
+  envelope: SignedControlEnvelopeV1,
+  label: string,
+): Promise<void> {
+  try {
+    await verifyControlEnvelopeIssuerSignatureV1(envelope);
+  } catch (cause) {
+    fail('catalog-production-history', `${label} signature is not valid`, cause);
+  }
+}
+
+function eip191Unsigned(
+  issuer: EvmAddressV1,
+  objectType: string,
+  payload: unknown,
+): UnsignedControlEnvelopeV1 {
+  return freezePlainSnapshot({
+    issuer,
+    objectType,
+    payload: payload as UnsignedControlEnvelopeV1['payload'],
+    signatureEvidence: { kind: 'none' },
+    signatureSuite: 'eip191-personal-sign-digest-v1',
+  }) as UnsignedControlEnvelopeV1;
+}
+
+function emptyBucketDescriptor(
+  bucketId: DecimalU64V1,
+): AuthorCatalogBucketDescriptorV1 {
+  return Object.freeze({
+    bucketDigest: ZERO_DIGEST32_V1,
+    bucketId,
+    byteLength: '0' as DecimalU64V1,
+    rowCount: '0' as DecimalU64V1,
+  });
+}
+
+function cloneEntries(
+  input: readonly AuthorCatalogDirectoryEntryV1[],
+): AuthorCatalogDirectoryEntryV1[] {
+  const result = new Array<AuthorCatalogDirectoryEntryV1>(input.length);
+  for (let index = 0; index < input.length; index += 1) {
+    result[index] = { ...input[index] } as AuthorCatalogDirectoryEntryV1;
+  }
+  return result;
+}
+
+function selectedEntryIndex(
+  node: AuthorCatalogDirectoryNodeV1,
+  bucketIdValue: DecimalU64V1,
+): number {
+  const bucketId = BigInt(bucketIdValue);
+  const firstBucketId = BigInt(node.firstBucketId);
+  const entryWidth = directoryPower(BigInt(node.level));
+  const relative = bucketId - firstBucketId;
+  if (relative < 0n) {
+    fail('catalog-production-path', 'selected bucket is outside the rebuilt directory node');
+  }
+  const index = relative / entryWidth;
+  if (index < 0n || index >= BigInt(node.entries.length)) {
+    fail('catalog-production-path', 'selected bucket is outside the rebuilt directory node');
+  }
+  return Number(index);
+}
+
+function childDescriptor(
+  child: SignedAuthorCatalogDirectoryNodeEnvelopeV1,
+  bucketCount: AuthorCatalogScopeV1['bucketCount'],
+): AuthorCatalogChildDescriptorV1 {
+  let rowCount = 0n;
+  for (let index = 0; index < child.payload.entries.length; index += 1) {
+    rowCount += BigInt(child.payload.entries[index].rowCount);
+    if (rowCount > MAX_DECIMAL_U64) {
+      fail('catalog-production-path', 'rebuilt child rowCount exceeds DecimalU64V1');
+    }
+  }
+  const firstBucketId = BigInt(child.payload.firstBucketId);
+  const childCoverage = directoryPower(BigInt(child.payload.level) + 1n);
+  const remaining = BigInt(bucketCount) - firstBucketId;
+  const bucketSpan = remaining < childCoverage ? remaining : childCoverage;
+  return Object.freeze({
+    firstBucketId: child.payload.firstBucketId,
+    bucketSpan: bucketSpan.toString() as DecimalU64V1,
+    rowCount: rowCount.toString() as DecimalU64V1,
+    byteLength: canonicalizeAuthorCatalogDirectoryNodePayloadBytesV1(
+      child.payload,
+      bucketCount,
+    ).byteLength.toString() as DecimalU64V1,
+    childDigest: child.objectDigest as Digest32V1,
+  });
+}
+
+function directoryPower(exponent: bigint): bigint {
+  let result = 1n;
+  for (let index = 0n; index < exponent; index += 1n) {
+    result *= AUTHOR_CATALOG_DIRECTORY_FANOUT_V1;
+  }
+  return result;
+}
+
+function sameBucketDescriptor(
+  left: Readonly<AuthorCatalogBucketDescriptorV1>,
+  right: Readonly<AuthorCatalogBucketDescriptorV1>,
+): boolean {
+  return left.bucketId === right.bucketId
+    && left.rowCount === right.rowCount
+    && left.byteLength === right.byteLength
+    && left.bucketDigest === right.bucketDigest;
+}
+
+function freezePublication(
+  head: SignedAuthorCatalogHeadEnvelopeV1,
+  directoryPath: readonly SignedAuthorCatalogDirectoryNodeEnvelopeV1[],
+  bucket: SignedAuthorCatalogBucketEnvelopeV1 | null,
+  stagedObjects: readonly SignedControlEnvelopeV1[],
+): ProducedAuthorCatalogPublicationV1 {
+  return Object.freeze({
+    head,
+    directoryPath: Object.freeze(Array.from(directoryPath)),
+    bucket,
+    stagedObjects: Object.freeze(Array.from(stagedObjects)),
+  });
+}
+
+function snapshotScope(input: AuthorCatalogScopeV1): AuthorCatalogScopeV1 {
+  const candidate = {
+    networkId: input.networkId,
+    contextGraphId: input.contextGraphId,
+    governanceChainId: input.governanceChainId,
+    governanceContractAddress: input.governanceContractAddress,
+    ownershipTransitionDigest: input.ownershipTransitionDigest,
+    subGraphName: input.subGraphName,
+    authorAddress: input.authorAddress,
+    era: input.era,
+    bucketCount: input.bucketCount,
+  };
+  try {
+    assertAuthorCatalogScopeV1(candidate);
+  } catch (cause) {
+    fail('catalog-production-input', 'empty genesis scope is not canonical', cause);
+  }
+  return freezePlainSnapshot(candidate) as AuthorCatalogScopeV1;
+}
+
+function freezePlainSnapshot<T>(value: T): T {
+  if (value === null || typeof value !== 'object') return value;
+  if (Array.isArray(value)) {
+    for (let index = 0; index < value.length; index += 1) {
+      freezePlainSnapshot(value[index]);
+    }
+    return Object.freeze(value);
+  }
+  for (const key of Object.keys(value)) {
+    freezePlainSnapshot((value as Record<string, unknown>)[key]);
+  }
+  return Object.freeze(value);
+}
+
+function normalizePublicError(message: string, cause: unknown): never {
+  if (cause instanceof Rfc64AuthorCatalogProductionErrorV1) throw cause;
+  fail('catalog-production-input', message, cause);
+}
+
+function fail(
+  code: Rfc64AuthorCatalogProductionErrorCodeV1,
+  message: string,
+  cause?: unknown,
+): never {
+  throw new Rfc64AuthorCatalogProductionErrorV1(
+    code,
+    message,
+    cause === undefined ? {} : { cause },
+  );
+}

--- a/packages/agent/test/rfc64-author-catalog-producer.test.ts
+++ b/packages/agent/test/rfc64-author-catalog-producer.test.ts
@@ -1,0 +1,795 @@
+import { describe, expect, it } from 'vitest';
+import { ethers } from 'ethers';
+
+import {
+  AUTHOR_CATALOG_DIRECTORY_NODE_OBJECT_TYPE_V1,
+  AUTHOR_CATALOG_HEAD_OBJECT_TYPE_V1,
+  KA_TRANSFER_CHUNK_SIZE_V1,
+  KA_TRANSFER_CODEC_V1,
+  KA_TRANSFER_PROJECTION_V1,
+  MAX_DECIMAL_U64,
+  ZERO_DIGEST32_V1,
+  assertAuthorCatalogRowV1,
+  assertSignedAuthorCatalogDirectoryNodeEnvelopeV1,
+  assertSignedAuthorCatalogHeadEnvelopeV1,
+  canonicalizeAuthorCatalogDirectoryNodePayloadBytesV1,
+  catalogKeyToBucketIdV1,
+  computeAuthorCatalogDirectoryNodeObjectDigestV1,
+  computeAuthorCatalogHeadObjectDigestV1,
+  computeAuthorCatalogScopeDigestV1,
+  readVerifiedAuthorCatalogBucketDescriptorV1,
+  verifyAuthorCatalogDirectoryPathV1,
+  type AuthorCatalogBucketDescriptorV1,
+  type AuthorCatalogChildDescriptorV1,
+  type AuthorCatalogDirectoryNodeV1,
+  type AuthorCatalogHeadV1,
+  type AuthorCatalogRowV1,
+  type AuthorCatalogScopeV1,
+  type CountV1,
+  type DecimalU64V1,
+  type Digest32V1,
+  type EvmAddressV1,
+  type SignedAuthorCatalogDirectoryNodeEnvelopeV1,
+  type SignedAuthorCatalogHeadEnvelopeV1,
+  type SignedControlEnvelopeV1,
+  type TimestampMsV1,
+  type UnsignedControlEnvelopeV1,
+} from '@origintrail-official/dkg-core';
+import { verifyControlEnvelopeIssuerSignatureV1 } from '@origintrail-official/dkg-chain';
+
+import {
+  Rfc64AuthorCatalogProductionErrorV1,
+  produceEmptyAuthorCatalogGenesisV1,
+  produceSparseAuthorCatalogSuccessorV1,
+  type Rfc64AuthorCatalogEip191SignerV1,
+} from '../src/rfc64/author-catalog-producer.js';
+
+const CATALOG_PRIVATE_KEY = `0x${'22'.repeat(32)}`;
+const OTHER_PRIVATE_KEY = `0x${'33'.repeat(32)}`;
+const AUTHOR = '0x19e7e376e7c213b7e7e7e46cc70a5dd086daff2a' as EvmAddressV1;
+const CONTEXT_GRAPH_ID =
+  '0x1111111111111111111111111111111111111111/catalog-production';
+const GOVERNANCE_CONTRACT =
+  '0x2222222222222222222222222222222222222222' as EvmAddressV1;
+const DELEGATION_DIGEST = `0x${'66'.repeat(32)}` as Digest32V1;
+const SEAL_DIGEST = `0x${'44'.repeat(32)}` as Digest32V1;
+
+const catalogWallet = new ethers.Wallet(CATALOG_PRIVATE_KEY);
+const otherWallet = new ethers.Wallet(OTHER_PRIVATE_KEY);
+
+describe('RFC-64 author catalog producer', () => {
+  it('produces a signed immutable empty genesis with canonical staging order', async () => {
+    const produced = await produceEmptyAuthorCatalogGenesisV1({
+      scope: scope('1'),
+      catalogIssuerDelegationDigest: DELEGATION_DIGEST,
+      issuedAt: '1700000000000' as TimestampMsV1,
+      signer: signer(catalogWallet),
+    });
+
+    expect(produced.bucket).toBeNull();
+    expect(produced.head.payload).toMatchObject({
+      era: '0',
+      version: '0',
+      previousHeadDigest: null,
+      bucketCount: '1',
+      totalRows: '0',
+      directoryHeight: '0',
+    });
+    expect(produced.directoryPath).toHaveLength(1);
+    expect(produced.stagedObjects.map((object) => object.objectType)).toEqual([
+      AUTHOR_CATALOG_DIRECTORY_NODE_OBJECT_TYPE_V1,
+      AUTHOR_CATALOG_HEAD_OBJECT_TYPE_V1,
+    ]);
+    const proof = verifyAuthorCatalogDirectoryPathV1(
+      produced.head,
+      produced.directoryPath,
+      '0' as DecimalU64V1,
+    );
+    expect(readVerifiedAuthorCatalogBucketDescriptorV1(proof, produced.head)).toEqual({
+      bucketDigest: ZERO_DIGEST32_V1,
+      bucketId: '0',
+      byteLength: '0',
+      rowCount: '0',
+    });
+    expect(Object.isFrozen(produced)).toBe(true);
+    expect(Object.isFrozen(produced.head.payload)).toBe(true);
+    expect(Object.isFrozen(produced.directoryPath[0].payload.entries)).toBe(true);
+    await expectAllSignatures(produced.stagedObjects);
+  });
+
+  it('adds one row by replacing one bucket, path, and constant-size head', async () => {
+    const genesis = await emptyGenesis();
+    const row = makeRow(1n, 'first');
+    const produced = await produceSparseAuthorCatalogSuccessorV1({
+      previousHead: genesis.head,
+      previousDirectoryPath: genesis.directoryPath,
+      previousBucket: null,
+      selectedBucketId: '0' as DecimalU64V1,
+      nextRows: [row],
+      issuedAt: '1700000000001' as TimestampMsV1,
+      signer: signer(catalogWallet),
+    });
+
+    expect(produced.bucket?.payload.rows).toEqual([row]);
+    expect(produced.head.payload.version).toBe('1');
+    expect(produced.head.payload.previousHeadDigest).toBe(genesis.head.objectDigest);
+    expect(produced.head.payload.totalRows).toBe('1');
+    expect(produced.stagedObjects.map((object) => object.objectType)).toEqual([
+      'AuthorCatalogBucketV1',
+      'AuthorCatalogDirectoryNodeV1',
+      'AuthorCatalogHeadV1',
+    ]);
+    const proof = verifyAuthorCatalogDirectoryPathV1(
+      produced.head,
+      produced.directoryPath,
+      '0' as DecimalU64V1,
+    );
+    expect(readVerifiedAuthorCatalogBucketDescriptorV1(proof, produced.head))
+      .toMatchObject({ bucketDigest: produced.bucket?.objectDigest, rowCount: '1' });
+    await expectAllSignatures(produced.stagedObjects);
+  });
+
+  it('rebuilds only one leaf-to-root path in a two-level 512-bucket catalog', async () => {
+    const selectedBucketId = '300' as DecimalU64V1;
+    const previous = await twoLevelEmptyCatalog(selectedBucketId);
+    const unchangedSibling = previous.path[0].payload.entries[0];
+    const row = rowForBucket(selectedBucketId, '512' as CountV1, 1n, 'bucket-300');
+
+    const produced = await produceSparseAuthorCatalogSuccessorV1({
+      previousHead: previous.head,
+      previousDirectoryPath: previous.path,
+      previousBucket: null,
+      selectedBucketId,
+      nextRows: [row],
+      issuedAt: '1700000000100' as TimestampMsV1,
+      signer: signer(catalogWallet),
+    });
+
+    expect(produced.directoryPath).toHaveLength(2);
+    expect(produced.stagedObjects.map((object) => object.objectType)).toEqual([
+      'AuthorCatalogBucketV1',
+      'AuthorCatalogDirectoryNodeV1',
+      'AuthorCatalogDirectoryNodeV1',
+      'AuthorCatalogHeadV1',
+    ]);
+    expect(produced.directoryPath[0].payload.entries[0]).toEqual(unchangedSibling);
+    expect(produced.directoryPath[0].payload.entries[1]).toMatchObject({ rowCount: '1' });
+    expect(produced.head.payload.totalRows).toBe('1');
+    expect(produced.head.payload.version).toBe('8');
+    await expectAllSignatures(produced.stagedObjects);
+  });
+
+  it('keeps a sparse update bounded at the maximum eight-node directory height', async () => {
+    const bucketCount = (1n << 63n).toString() as CountV1;
+    const row = makeRow(77n, 'maximum-height');
+    const selectedBucketId = catalogKeyToBucketIdV1(row.kaId, bucketCount);
+    const previous = await maximumHeightEmptyCatalog(selectedBucketId);
+
+    const produced = await produceSparseAuthorCatalogSuccessorV1({
+      previousHead: previous.head,
+      previousDirectoryPath: previous.path,
+      previousBucket: null,
+      selectedBucketId,
+      nextRows: [row],
+      issuedAt: '1700000000200' as TimestampMsV1,
+      signer: signer(catalogWallet),
+    });
+
+    expect(produced.directoryPath).toHaveLength(8);
+    expect(produced.stagedObjects).toHaveLength(10);
+    expect(produced.stagedObjects[0].objectType).toBe('AuthorCatalogBucketV1');
+    expect(produced.stagedObjects.at(-1)?.objectType).toBe('AuthorCatalogHeadV1');
+    expect(produced.head.payload).toMatchObject({
+      bucketCount,
+      directoryHeight: '7',
+      totalRows: '1',
+      version: '1',
+    });
+    await expectAllSignatures(produced.stagedObjects);
+  });
+
+  it('removes the last selected row through a canonical empty descriptor', async () => {
+    const selectedBucketId = '300' as DecimalU64V1;
+    const previous = await twoLevelEmptyCatalog(selectedBucketId);
+    const row = rowForBucket(selectedBucketId, '512' as CountV1, 1n, 'bucket-300');
+    const populated = await produceSparseAuthorCatalogSuccessorV1({
+      previousHead: previous.head,
+      previousDirectoryPath: previous.path,
+      previousBucket: null,
+      selectedBucketId,
+      nextRows: [row],
+      issuedAt: '1700000000100' as TimestampMsV1,
+      signer: signer(catalogWallet),
+    });
+
+    const removed = await produceSparseAuthorCatalogSuccessorV1({
+      previousHead: populated.head,
+      previousDirectoryPath: populated.directoryPath,
+      previousBucket: populated.bucket,
+      selectedBucketId,
+      nextRows: [],
+      issuedAt: '1700000000101' as TimestampMsV1,
+      signer: signer(catalogWallet),
+    });
+
+    expect(removed.bucket).toBeNull();
+    expect(removed.head.payload.totalRows).toBe('0');
+    expect(removed.head.payload.version).toBe('9');
+    expect(removed.stagedObjects.map((object) => object.objectType)).toEqual([
+      'AuthorCatalogDirectoryNodeV1',
+      'AuthorCatalogDirectoryNodeV1',
+      'AuthorCatalogHeadV1',
+    ]);
+    const proof = verifyAuthorCatalogDirectoryPathV1(
+      removed.head,
+      removed.directoryPath,
+      selectedBucketId,
+    );
+    expect(readVerifiedAuthorCatalogBucketDescriptorV1(proof, removed.head))
+      .toMatchObject({ bucketDigest: ZERO_DIGEST32_V1, rowCount: '0', byteLength: '0' });
+  });
+
+  it('snapshots rows and the previous path before invoking the signer', async () => {
+    const genesis = await emptyGenesis();
+    const originalRow = makeRow(1n, 'stable');
+    const rows = [originalRow];
+    const path = Array.from(genesis.directoryPath);
+    let calls = 0;
+    const mutatingSigner: Rfc64AuthorCatalogEip191SignerV1 = {
+      issuer: catalogWallet.address.toLowerCase() as EvmAddressV1,
+      signDigest: async (digest) => {
+        calls += 1;
+        if (calls === 1) {
+          rows[0] = makeRow(2n, 'switched');
+          path.length = 0;
+        }
+        return catalogWallet.signMessage(digest);
+      },
+    };
+
+    const produced = await produceSparseAuthorCatalogSuccessorV1({
+      previousHead: genesis.head,
+      previousDirectoryPath: path,
+      previousBucket: null,
+      selectedBucketId: '0' as DecimalU64V1,
+      nextRows: rows,
+      issuedAt: '1700000000001' as TimestampMsV1,
+      signer: mutatingSigner,
+    });
+
+    expect(produced.bucket?.payload.rows).toEqual([originalRow]);
+    expect(produced.directoryPath).toHaveLength(1);
+  });
+
+  it('reads adversarial path and row array lengths exactly once', async () => {
+    const genesis = await emptyGenesis();
+    const row = makeRow(1n, 'stable');
+    let pathLengthReads = 0;
+    let rowLengthReads = 0;
+    const path = new Proxy(Array.from(genesis.directoryPath), {
+      get(target, property, receiver) {
+        if (property === 'length') {
+          pathLengthReads += 1;
+          return pathLengthReads === 1 ? 1 : 0;
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+    const rows = new Proxy([row], {
+      get(target, property, receiver) {
+        if (property === 'length') {
+          rowLengthReads += 1;
+          return rowLengthReads === 1 ? 1 : 0;
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+
+    const produced = await produceSparseAuthorCatalogSuccessorV1({
+      previousHead: genesis.head,
+      previousDirectoryPath: path,
+      previousBucket: null,
+      selectedBucketId: '0' as DecimalU64V1,
+      nextRows: rows,
+      issuedAt: '1700000000001' as TimestampMsV1,
+      signer: signer(catalogWallet),
+    });
+
+    expect(produced.bucket?.payload.rows).toEqual([row]);
+    expect(pathLengthReads).toBe(1);
+    expect(rowLengthReads).toBe(1);
+  });
+
+  it('rejects no-op successors and rows assigned to a different bucket', async () => {
+    const genesis = await emptyGenesis();
+    const row = makeRow(1n, 'first');
+    const populated = await produceSparseAuthorCatalogSuccessorV1({
+      previousHead: genesis.head,
+      previousDirectoryPath: genesis.directoryPath,
+      previousBucket: null,
+      selectedBucketId: '0' as DecimalU64V1,
+      nextRows: [row],
+      issuedAt: '1700000000001' as TimestampMsV1,
+      signer: signer(catalogWallet),
+    });
+
+    let noOpSignCalls = 0;
+    await expect(produceSparseAuthorCatalogSuccessorV1({
+      previousHead: populated.head,
+      previousDirectoryPath: populated.directoryPath,
+      previousBucket: populated.bucket,
+      selectedBucketId: '0' as DecimalU64V1,
+      nextRows: [row],
+      issuedAt: '1700000000002' as TimestampMsV1,
+      signer: {
+        issuer: catalogWallet.address.toLowerCase() as EvmAddressV1,
+        signDigest: (digest) => {
+          noOpSignCalls += 1;
+          return catalogWallet.signMessage(digest);
+        },
+      },
+    })).rejects.toMatchObject({ code: 'catalog-production-noop' });
+    expect(noOpSignCalls).toBe(0);
+
+    const previous = await twoLevelEmptyCatalog('300' as DecimalU64V1);
+    const wrongRow = rowForBucket('301' as DecimalU64V1, '512' as CountV1, 1n, 'wrong');
+    await expect(produceSparseAuthorCatalogSuccessorV1({
+      previousHead: previous.head,
+      previousDirectoryPath: previous.path,
+      previousBucket: null,
+      selectedBucketId: '300' as DecimalU64V1,
+      nextRows: [wrongRow],
+      issuedAt: '1700000000100' as TimestampMsV1,
+      signer: signer(catalogWallet),
+    })).rejects.toMatchObject({ code: 'catalog-production-input' });
+  });
+
+  it('requires the exact prior bucket and permits only one KA delta per head', async () => {
+    const genesis = await emptyGenesis();
+    const row1 = makeRow(1n, 'first');
+    const row2 = makeRow(2n, 'second');
+
+    await expect(produceSparseAuthorCatalogSuccessorV1({
+      previousHead: genesis.head,
+      previousDirectoryPath: genesis.directoryPath,
+      previousBucket: null,
+      selectedBucketId: '0' as DecimalU64V1,
+      nextRows: [row1, row2],
+      issuedAt: '1700000000001' as TimestampMsV1,
+      signer: signer(catalogWallet),
+    })).rejects.toMatchObject({ code: 'catalog-production-delta' });
+
+    const oneRow = await produceSparseAuthorCatalogSuccessorV1({
+      previousHead: genesis.head,
+      previousDirectoryPath: genesis.directoryPath,
+      previousBucket: null,
+      selectedBucketId: '0' as DecimalU64V1,
+      nextRows: [row1],
+      issuedAt: '1700000000001' as TimestampMsV1,
+      signer: signer(catalogWallet),
+    });
+    await expect(produceSparseAuthorCatalogSuccessorV1({
+      previousHead: oneRow.head,
+      previousDirectoryPath: oneRow.directoryPath,
+      previousBucket: null,
+      selectedBucketId: '0' as DecimalU64V1,
+      nextRows: [row1, row2],
+      issuedAt: '1700000000002' as TimestampMsV1,
+      signer: signer(catalogWallet),
+    })).rejects.toMatchObject({ code: 'catalog-production-path' });
+
+    const twoRows = await produceSparseAuthorCatalogSuccessorV1({
+      previousHead: oneRow.head,
+      previousDirectoryPath: oneRow.directoryPath,
+      previousBucket: oneRow.bucket,
+      selectedBucketId: '0' as DecimalU64V1,
+      nextRows: [row1, row2],
+      issuedAt: '1700000000002' as TimestampMsV1,
+      signer: signer(catalogWallet),
+    });
+    await expect(produceSparseAuthorCatalogSuccessorV1({
+      previousHead: twoRows.head,
+      previousDirectoryPath: twoRows.directoryPath,
+      previousBucket: twoRows.bucket,
+      selectedBucketId: '0' as DecimalU64V1,
+      nextRows: [],
+      issuedAt: '1700000000003' as TimestampMsV1,
+      signer: signer(catalogWallet),
+    })).rejects.toMatchObject({ code: 'catalog-production-delta' });
+  });
+
+  it('requires a one-step assertion version and stable coordinate for row replacement', async () => {
+    const genesis = await emptyGenesis();
+    const rowV1 = makeRow(1n, 'stable', '1', 0);
+    const oneRow = await produceSparseAuthorCatalogSuccessorV1({
+      previousHead: genesis.head,
+      previousDirectoryPath: genesis.directoryPath,
+      previousBucket: null,
+      selectedBucketId: '0' as DecimalU64V1,
+      nextRows: [rowV1],
+      issuedAt: '1700000000001' as TimestampMsV1,
+      signer: signer(catalogWallet),
+    });
+    const rowV2 = makeRow(1n, 'stable', '2', 1);
+    const updated = await produceSparseAuthorCatalogSuccessorV1({
+      previousHead: oneRow.head,
+      previousDirectoryPath: oneRow.directoryPath,
+      previousBucket: oneRow.bucket,
+      selectedBucketId: '0' as DecimalU64V1,
+      nextRows: [rowV2],
+      issuedAt: '1700000000002' as TimestampMsV1,
+      signer: signer(catalogWallet),
+    });
+    expect(updated.bucket?.payload.rows).toEqual([rowV2]);
+    expect(updated.head.payload.totalRows).toBe('1');
+
+    await expect(produceSparseAuthorCatalogSuccessorV1({
+      previousHead: updated.head,
+      previousDirectoryPath: updated.directoryPath,
+      previousBucket: updated.bucket,
+      selectedBucketId: '0' as DecimalU64V1,
+      nextRows: [makeRow(1n, 'changed-coordinate', '3', 2)],
+      issuedAt: '1700000000003' as TimestampMsV1,
+      signer: signer(catalogWallet),
+    })).rejects.toMatchObject({ code: 'catalog-production-delta' });
+
+    await expect(produceSparseAuthorCatalogSuccessorV1({
+      previousHead: updated.head,
+      previousDirectoryPath: updated.directoryPath,
+      previousBucket: updated.bucket,
+      selectedBucketId: '0' as DecimalU64V1,
+      nextRows: [makeRow(1n, 'stable', '4', 2)],
+      issuedAt: '1700000000003' as TimestampMsV1,
+      signer: signer(catalogWallet),
+    })).rejects.toMatchObject({ code: 'catalog-production-delta' });
+  });
+
+  it('fails closed on an invalid predecessor or a signer for another issuer', async () => {
+    const genesis = await emptyGenesis();
+    const row = makeRow(1n, 'first');
+    const forgedHead = {
+      ...genesis.head,
+      signature: await otherWallet.signMessage(ethers.getBytes(genesis.head.objectDigest)),
+    } as SignedAuthorCatalogHeadEnvelopeV1;
+
+    await expect(produceSparseAuthorCatalogSuccessorV1({
+      previousHead: forgedHead,
+      previousDirectoryPath: genesis.directoryPath,
+      previousBucket: null,
+      selectedBucketId: '0' as DecimalU64V1,
+      nextRows: [row],
+      issuedAt: '1700000000001' as TimestampMsV1,
+      signer: signer(catalogWallet),
+    })).rejects.toMatchObject({ code: 'catalog-production-history' });
+
+    await expect(produceSparseAuthorCatalogSuccessorV1({
+      previousHead: genesis.head,
+      previousDirectoryPath: genesis.directoryPath,
+      previousBucket: null,
+      selectedBucketId: '0' as DecimalU64V1,
+      nextRows: [row],
+      issuedAt: '1700000000001' as TimestampMsV1,
+      signer: {
+        issuer: catalogWallet.address.toLowerCase() as EvmAddressV1,
+        signDigest: (digest) => otherWallet.signMessage(digest),
+      },
+    })).rejects.toMatchObject({ code: 'catalog-production-signer' });
+  });
+
+  it('rejects ordinary history overflow before producing a successor head', async () => {
+    const previous = await twoLevelEmptyCatalog(
+      '300' as DecimalU64V1,
+      MAX_DECIMAL_U64.toString() as DecimalU64V1,
+    );
+    const row = rowForBucket('300' as DecimalU64V1, '512' as CountV1, 1n, 'overflow');
+    await expect(produceSparseAuthorCatalogSuccessorV1({
+      previousHead: previous.head,
+      previousDirectoryPath: previous.path,
+      previousBucket: null,
+      selectedBucketId: '300' as DecimalU64V1,
+      nextRows: [row],
+      issuedAt: '1700000000100' as TimestampMsV1,
+      signer: signer(catalogWallet),
+    })).rejects.toMatchObject({ code: 'catalog-production-history' });
+  });
+
+  it('uses a closed typed error registry', () => {
+    const error = new Rfc64AuthorCatalogProductionErrorV1(
+      'catalog-production-input',
+      'fixture',
+    );
+    expect(error).toMatchObject({
+      name: 'Rfc64AuthorCatalogProductionErrorV1',
+      code: 'catalog-production-input',
+    });
+    expect(() => new Rfc64AuthorCatalogProductionErrorV1(
+      'not-a-production-code' as never,
+      'fixture',
+    )).toThrow(TypeError);
+  });
+});
+
+async function emptyGenesis() {
+  return produceEmptyAuthorCatalogGenesisV1({
+    scope: scope('1'),
+    catalogIssuerDelegationDigest: DELEGATION_DIGEST,
+    issuedAt: '1700000000000' as TimestampMsV1,
+    signer: signer(catalogWallet),
+  });
+}
+
+function signer(wallet: ethers.Wallet): Rfc64AuthorCatalogEip191SignerV1 {
+  return {
+    issuer: wallet.address.toLowerCase() as EvmAddressV1,
+    signDigest: (digest) => wallet.signMessage(digest),
+  };
+}
+
+function scope(bucketCount: string): AuthorCatalogScopeV1 {
+  return {
+    networkId: 'otp:20430',
+    contextGraphId: CONTEXT_GRAPH_ID,
+    governanceChainId: '20430',
+    governanceContractAddress: GOVERNANCE_CONTRACT,
+    ownershipTransitionDigest: null,
+    subGraphName: null,
+    authorAddress: AUTHOR,
+    era: '0',
+    bucketCount,
+  } as AuthorCatalogScopeV1;
+}
+
+function makeRow(
+  number: bigint,
+  assertionCoordinate: string,
+  assertionVersion = '1',
+  variant = 0,
+): AuthorCatalogRowV1 {
+  const projectionDigest = digest(Number(number % 1000n) + 1000 + variant * 10_000);
+  const row = {
+    kaId: ((BigInt(AUTHOR) << 96n) | number).toString(),
+    assertionCoordinate,
+    assertionVersion,
+    projectionId: KA_TRANSFER_PROJECTION_V1,
+    projectionDigest,
+    sealDigest: SEAL_DIGEST,
+    transfer: {
+      codec: KA_TRANSFER_CODEC_V1,
+      projectionId: KA_TRANSFER_PROJECTION_V1,
+      projectionDigest,
+      byteLength: '16',
+      chunkSize: KA_TRANSFER_CHUNK_SIZE_V1,
+      chunkCount: '1',
+      blobDigest: digest(Number(number % 1000n) + 2000 + variant * 10_000),
+      chunkTreeRoot: digest(Number(number % 1000n) + 3000 + variant * 10_000),
+    },
+  } as unknown as AuthorCatalogRowV1;
+  assertAuthorCatalogRowV1(row);
+  return row;
+}
+
+function rowForBucket(
+  bucketId: DecimalU64V1,
+  bucketCount: CountV1,
+  start: bigint,
+  coordinate: string,
+): AuthorCatalogRowV1 {
+  for (let number = start; number < start + 1_000_000n; number += 1n) {
+    const row = makeRow(number, coordinate);
+    if (catalogKeyToBucketIdV1(row.kaId, bucketCount) === bucketId) return row;
+  }
+  throw new Error(`unable to find a row for bucket ${bucketId}`);
+}
+
+async function twoLevelEmptyCatalog(
+  selectedBucketId: DecimalU64V1,
+  version: DecimalU64V1 = '7' as DecimalU64V1,
+): Promise<{
+  readonly head: SignedAuthorCatalogHeadEnvelopeV1;
+  readonly path: readonly SignedAuthorCatalogDirectoryNodeEnvelopeV1[];
+}> {
+  const catalogScope = scope('512');
+  const scopeDigest = computeAuthorCatalogScopeDigestV1(catalogScope);
+  const leafFirst = 256n;
+  const leafPayload: AuthorCatalogDirectoryNodeV1 = {
+    catalogScopeDigest: scopeDigest,
+    entries: emptyDescriptors(256, leafFirst),
+    era: '0' as DecimalU64V1,
+    firstBucketId: leafFirst.toString() as DecimalU64V1,
+    level: '0' as DecimalU64V1,
+  };
+  const leaf = await signedDirectory(leafPayload, '512' as CountV1);
+  const leafBytes = canonicalizeAuthorCatalogDirectoryNodePayloadBytesV1(
+    leaf.payload,
+    '512' as CountV1,
+  ).byteLength;
+  const rootPayload: AuthorCatalogDirectoryNodeV1 = {
+    catalogScopeDigest: scopeDigest,
+    entries: [
+      {
+        firstBucketId: '0' as DecimalU64V1,
+        bucketSpan: '256' as CountV1,
+        rowCount: '0' as CountV1,
+        byteLength: '1' as CountV1,
+        childDigest: digest(99),
+      },
+      {
+        firstBucketId: '256' as DecimalU64V1,
+        bucketSpan: '256' as CountV1,
+        rowCount: '0' as CountV1,
+        byteLength: leafBytes.toString() as CountV1,
+        childDigest: leaf.objectDigest as Digest32V1,
+      },
+    ] satisfies readonly AuthorCatalogChildDescriptorV1[],
+    era: '0' as DecimalU64V1,
+    firstBucketId: '0' as DecimalU64V1,
+    level: '1' as DecimalU64V1,
+  };
+  const root = await signedDirectory(rootPayload, '512' as CountV1);
+  const headPayload = {
+    networkId: catalogScope.networkId,
+    contextGraphId: catalogScope.contextGraphId,
+    governanceChainId: catalogScope.governanceChainId,
+    governanceContractAddress: catalogScope.governanceContractAddress,
+    ownershipTransitionDigest: catalogScope.ownershipTransitionDigest,
+    subGraphName: catalogScope.subGraphName,
+    authorAddress: catalogScope.authorAddress,
+    catalogIssuerDelegationDigest: DELEGATION_DIGEST,
+    era: catalogScope.era,
+    version,
+    previousHeadDigest: digest(98),
+    bucketCount: catalogScope.bucketCount,
+    totalRows: '0' as CountV1,
+    directoryHeight: '1' as DecimalU64V1,
+    directoryRootDigest: root.objectDigest as Digest32V1,
+    issuedAt: '1700000000000' as TimestampMsV1,
+  } satisfies AuthorCatalogHeadV1;
+  const head = await signedHead(headPayload);
+  verifyAuthorCatalogDirectoryPathV1(head, [root, leaf], selectedBucketId);
+  return { head, path: [root, leaf] };
+}
+
+async function maximumHeightEmptyCatalog(
+  selectedBucketId: DecimalU64V1,
+): Promise<{
+  readonly head: SignedAuthorCatalogHeadEnvelopeV1;
+  readonly path: readonly SignedAuthorCatalogDirectoryNodeEnvelopeV1[];
+}> {
+  const bucketCount = 1n << 63n;
+  const bucketCountWire = bucketCount.toString() as CountV1;
+  const catalogScope = scope(bucketCountWire);
+  const scopeDigest = computeAuthorCatalogScopeDigestV1(catalogScope);
+  const selected = BigInt(selectedBucketId);
+  const leafFirst = (selected / 256n) * 256n;
+  const leafCoverage = minimum(256n, bucketCount - leafFirst);
+  let child = await signedDirectory({
+    catalogScopeDigest: scopeDigest,
+    entries: emptyDescriptors(Number(leafCoverage), leafFirst),
+    era: '0' as DecimalU64V1,
+    firstBucketId: leafFirst.toString() as DecimalU64V1,
+    level: '0' as DecimalU64V1,
+  }, bucketCountWire);
+  const leafToRoot = [child];
+
+  for (let level = 1n; level <= 7n; level += 1n) {
+    const entryWidth = 256n ** level;
+    const nodeWidth = entryWidth * 256n;
+    const firstBucketId = (selected / nodeWidth) * nodeWidth;
+    const coverage = minimum(nodeWidth, bucketCount - firstBucketId);
+    const entryCount = Number((coverage + entryWidth - 1n) / entryWidth);
+    const selectedIndex = Number(
+      (BigInt(child.payload.firstBucketId) - firstBucketId) / entryWidth,
+    );
+    const childBytes = canonicalizeAuthorCatalogDirectoryNodePayloadBytesV1(
+      child.payload,
+      bucketCountWire,
+    ).byteLength;
+    const entries = new Array<AuthorCatalogChildDescriptorV1>(entryCount);
+    for (let index = 0; index < entryCount; index += 1) {
+      const entryFirst = firstBucketId + BigInt(index) * entryWidth;
+      entries[index] = {
+        firstBucketId: entryFirst.toString() as DecimalU64V1,
+        bucketSpan: minimum(entryWidth, bucketCount - entryFirst).toString() as CountV1,
+        rowCount: '0' as CountV1,
+        byteLength: (index === selectedIndex ? childBytes.toString() : '1') as CountV1,
+        childDigest: index === selectedIndex
+          ? child.objectDigest as Digest32V1
+          : digest(Number(level) * 1000 + index + 10_000),
+      };
+    }
+    child = await signedDirectory({
+      catalogScopeDigest: scopeDigest,
+      entries,
+      era: '0' as DecimalU64V1,
+      firstBucketId: firstBucketId.toString() as DecimalU64V1,
+      level: level.toString() as DecimalU64V1,
+    }, bucketCountWire);
+    leafToRoot.push(child);
+  }
+  const path = leafToRoot.reverse();
+  const head = await signedHead({
+    networkId: catalogScope.networkId,
+    contextGraphId: catalogScope.contextGraphId,
+    governanceChainId: catalogScope.governanceChainId,
+    governanceContractAddress: catalogScope.governanceContractAddress,
+    ownershipTransitionDigest: catalogScope.ownershipTransitionDigest,
+    subGraphName: catalogScope.subGraphName,
+    authorAddress: catalogScope.authorAddress,
+    catalogIssuerDelegationDigest: DELEGATION_DIGEST,
+    era: catalogScope.era,
+    version: '0' as DecimalU64V1,
+    previousHeadDigest: null,
+    bucketCount: bucketCountWire,
+    totalRows: '0' as CountV1,
+    directoryHeight: '7' as DecimalU64V1,
+    directoryRootDigest: path[0].objectDigest as Digest32V1,
+    issuedAt: '1700000000000' as TimestampMsV1,
+  });
+  verifyAuthorCatalogDirectoryPathV1(head, path, selectedBucketId);
+  return { head, path };
+}
+
+async function signedDirectory(
+  payload: AuthorCatalogDirectoryNodeV1,
+  bucketCount: CountV1,
+): Promise<SignedAuthorCatalogDirectoryNodeEnvelopeV1> {
+  const unsigned = {
+    issuer: catalogWallet.address.toLowerCase(),
+    objectType: AUTHOR_CATALOG_DIRECTORY_NODE_OBJECT_TYPE_V1,
+    payload,
+    signatureEvidence: { kind: 'none' },
+    signatureSuite: 'eip191-personal-sign-digest-v1',
+  } as UnsignedControlEnvelopeV1;
+  const objectDigest = computeAuthorCatalogDirectoryNodeObjectDigestV1(unsigned, bucketCount);
+  const signed = {
+    ...unsigned,
+    objectDigest,
+    signature: await catalogWallet.signMessage(ethers.getBytes(objectDigest)),
+  } as SignedControlEnvelopeV1;
+  assertSignedAuthorCatalogDirectoryNodeEnvelopeV1(signed, bucketCount);
+  return signed as SignedAuthorCatalogDirectoryNodeEnvelopeV1;
+}
+
+async function signedHead(payload: AuthorCatalogHeadV1): Promise<SignedAuthorCatalogHeadEnvelopeV1> {
+  const unsigned = {
+    issuer: catalogWallet.address.toLowerCase(),
+    objectType: AUTHOR_CATALOG_HEAD_OBJECT_TYPE_V1,
+    payload,
+    signatureEvidence: { kind: 'none' },
+    signatureSuite: 'eip191-personal-sign-digest-v1',
+  } as UnsignedControlEnvelopeV1;
+  const objectDigest = computeAuthorCatalogHeadObjectDigestV1(unsigned);
+  const signed = {
+    ...unsigned,
+    objectDigest,
+    signature: await catalogWallet.signMessage(ethers.getBytes(objectDigest)),
+  } as SignedControlEnvelopeV1;
+  assertSignedAuthorCatalogHeadEnvelopeV1(signed);
+  return signed as SignedAuthorCatalogHeadEnvelopeV1;
+}
+
+function emptyDescriptors(
+  count: number,
+  firstBucketId: bigint,
+): AuthorCatalogBucketDescriptorV1[] {
+  return Array.from({ length: count }, (_, index) => ({
+    bucketDigest: ZERO_DIGEST32_V1,
+    bucketId: (firstBucketId + BigInt(index)).toString() as DecimalU64V1,
+    byteLength: '0' as CountV1,
+    rowCount: '0' as CountV1,
+  }));
+}
+
+async function expectAllSignatures(objects: readonly SignedControlEnvelopeV1[]): Promise<void> {
+  for (const object of objects) {
+    await expect(verifyControlEnvelopeIssuerSignatureV1(object)).resolves.toBeDefined();
+  }
+}
+
+function digest(value: number): Digest32V1 {
+  return `0x${value.toString(16).padStart(64, '0')}` as Digest32V1;
+}
+
+function minimum(left: bigint, right: bigint): bigint {
+  return left < right ? left : right;
+}

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -114,6 +114,7 @@ export default defineConfig({
       "test/rfc64-candidate-transfer-admission.test.ts",
       "test/rfc64-catalog-row-authorship.test.ts",
       "test/rfc64-agent-inventory-lifecycle.test.ts",
+      "test/rfc64-author-catalog-producer.test.ts",
     ],
     testTimeout: 60_000,
     maxWorkers: 1,


### PR DESCRIPTION
## Scope

Adds the bounded RFC-64 EIP-191 author-catalog producer primitive:

- canonical empty era-0/version-0 genesis
- exact predecessor head, selected path, and prior bucket verification
- exactly one KA add/remove/update per ordinary successor
- complete selected-bucket replacement with sparse leaf-to-root rebuild
- checked version/row-count arithmetic and canonical empty deletion
- immutable bucket -> leaf-to-root path -> head staging order
- closed typed failures and one-read snapshots before signer callbacks

This slice does **not** persist objects, switch semantic refs, produce capacity/key/ownership transitions, or grant receiver authority.

## Verification

- `pnpm --filter @origintrail-official/dkg-agent build`
- `pnpm --filter @origintrail-official/dkg-agent test:unit`
  - 100 files passed
  - 1,318 tests passed, 4 skipped
- focused producer suite: 13 tests passed
- Windows RFC-64 workflow expanded to cover the producer