### PR TITLE
feat(rfc64): add applied-head discovery seam

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -43,6 +43,7 @@
     "./dist/rfc64/public-catalog-native-receiver-v1.js": null,
     "./dist/rfc64/public-catalog-native-reconciler-v1.js": null,
     "./dist/rfc64/public-catalog-native-transport-v1.js": null,
+    "./dist/rfc64/public-open-catalog-scope-v1.js": null,
     "./dist/rfc64/public-catalog-reconciliation-failure-v1.js": null,
     "./dist/rfc64/public-catalog-receiver-v1.js": null,
     "./dist/rfc64/public-catalog-service-v1.js": null,

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -37,6 +37,7 @@
     "./dist/rfc64/persistence-root-ownership-v1-internal.js": null,
     "./dist/rfc64/persistence-v1.js": null,
     "./dist/rfc64/policy-cell-v1.js": null,
+    "./dist/rfc64/public-catalog-current-head-discovery-v1.js": null,
     "./dist/rfc64/public-catalog-inventory-completeness-v1.js": null,
     "./dist/rfc64/public-catalog-native-receiver-v1.js": null,
     "./dist/rfc64/public-catalog-native-reconciler-v1.js": null,

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -25,6 +25,7 @@
     "./dist/rfc64/catalog-access-policy-v1.js": null,
     "./dist/rfc64/catalog-authority-config-v1.js": null,
     "./dist/rfc64/catalog-transport-authorization-v1.js": null,
+    "./dist/rfc64/catalog-transport-wire-v1-internal.js": null,
     "./dist/rfc64/durable-file-store-v1.js": null,
     "./dist/rfc64/finalized-vm-agent-precommit-v1.js": null,
     "./dist/rfc64/finalized-vm-composer-v1.js": null,

--- a/packages/agent/scripts/test-package-root.mjs
+++ b/packages/agent/scripts/test-package-root.mjs
@@ -112,6 +112,7 @@ const blockedRfc64Modules = [
   'persistence-root-ownership-v1-internal.js',
   'persistence-v1.js',
   'policy-cell-v1.js',
+  'public-catalog-current-head-discovery-v1.js',
   'public-catalog-inventory-completeness-v1.js',
   'public-catalog-native-reconciler-v1.js',
   'public-catalog-native-receiver-v1.js',

--- a/packages/agent/scripts/test-package-root.mjs
+++ b/packages/agent/scripts/test-package-root.mjs
@@ -98,6 +98,7 @@ const blockedRfc64Modules = [
   'catalog-access-policy-v1.js',
   'catalog-authority-config-v1.js',
   'catalog-transport-authorization-v1.js',
+  'catalog-transport-wire-v1-internal.js',
   'control-object-store-v1-internal.js',
   'control-object-store-v1.js',
   'durable-file-store-v1.js',

--- a/packages/agent/scripts/test-package-root.mjs
+++ b/packages/agent/scripts/test-package-root.mjs
@@ -118,6 +118,7 @@ const blockedRfc64Modules = [
   'public-catalog-native-reconciler-v1.js',
   'public-catalog-native-receiver-v1.js',
   'public-catalog-native-transport-v1.js',
+  'public-open-catalog-scope-v1.js',
   'public-catalog-reconciliation-failure-v1.js',
   'public-catalog-receiver-v1.js',
   'public-catalog-service-v1.js',

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -41,6 +41,7 @@ export {
 } from './rfc64/recoverable-author-attestation-v1.js';
 export * from './rfc64/author-catalog-producer.js';
 export * from './rfc64/public-catalog-transport-v1.js';
+export * from './rfc64/public-catalog-current-head-discovery-v1.js';
 export * from './rfc64/open-catalog-policy-v1.js';
 export * from './rfc64/public-catalog-receiver-v1.js';
 export * from './rfc64/public-catalog-service-v1.js';

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -54,6 +54,7 @@ export {
   type Rfc64AppliedInventoryDigestRowV1,
 } from './rfc64/public-catalog-inventory-completeness-v1.js';
 export * from './rfc64/public-catalog-successor-producer-v1.js';
+export * from './rfc64/public-open-catalog-scope-v1.js';
 export * from './rfc64/public-catalog-native-reconciler-v1.js';
 export * from './rfc64/policy-cell-v1.js';
 export { encrypt, decrypt, ed25519ToX25519Private, ed25519ToX25519Public, x25519SharedSecret } from './encryption.js';

--- a/packages/agent/src/rfc64/catalog-transport-wire-v1-internal.ts
+++ b/packages/agent/src/rfc64/catalog-transport-wire-v1-internal.ts
@@ -1,0 +1,263 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Shared, package-private RFC-64 catalog transport wire primitives.
+ *
+ * Protocol modules retain their own typed validators, byte ceilings, and
+ * public error classes. This module owns only byte-identical framing and the
+ * security-sensitive scalar/proof checks that must not drift between catalog
+ * protocols.
+ */
+
+import {
+  computeControlSignatureVariantDigestHex,
+  type EvmAddressV1,
+  type SignedControlEnvelopeV1,
+} from '@origintrail-official/dkg-core';
+import {
+  readVerifiedControlEnvelopeIssuerSignatureV1,
+  type VerifiedControlEnvelopeIssuerSignatureV1,
+} from '@origintrail-official/dkg-chain';
+
+const MAX_PEER_ID_BYTES_V1 = 256;
+const UTF8 = new TextEncoder();
+// Keep a leading BOM visible so canonical re-encoding rejects it.
+const UTF8_FATAL = new TextDecoder('utf-8', { fatal: true, ignoreBOM: true });
+
+export type Rfc64CatalogTransportWireUtilityErrorReasonV1 =
+  | 'plain-object'
+  | 'field-shape'
+  | 'oversized'
+  | 'strict-json'
+  | 'exact-keys'
+  | 'noncanonical'
+  | 'evm-address'
+  | 'peer-id-type'
+  | 'peer-id-canonical'
+  | 'issuer-proof-unminted'
+  | 'issuer-proof-mismatch'
+  | 'response-size'
+  | 'response-trailing'
+  | 'response-status';
+
+export class Rfc64CatalogTransportWireUtilityErrorV1 extends Error {
+  constructor(
+    readonly reason: Rfc64CatalogTransportWireUtilityErrorReasonV1,
+    message: string,
+    options: ErrorOptions = {},
+  ) {
+    super(message, options);
+    this.name = 'Rfc64CatalogTransportWireUtilityErrorV1';
+  }
+}
+
+export function encodeRfc64FlatCanonicalJsonV1(
+  value: object,
+  maxBytes: number,
+): Uint8Array {
+  const snapshot = snapshotRfc64ExactWireRecordV1(value, undefined);
+  const fields: string[] = [];
+  for (const key of Object.keys(snapshot).sort()) {
+    const field = snapshot[key];
+    if (field !== null && typeof field !== 'string') {
+      utilityFail('field-shape', 'RFC-64 flat canonical JSON accepts only string or null fields');
+    }
+    fields.push(`${JSON.stringify(key)}:${JSON.stringify(field)}`);
+  }
+  const bytes = UTF8.encode(`{${fields.join(',')}}`);
+  if (bytes.byteLength > maxBytes) {
+    utilityFail('oversized', `RFC-64 flat canonical JSON exceeds ${maxBytes} bytes`);
+  }
+  return bytes;
+}
+
+export function parseRfc64FlatCanonicalJsonV1(
+  input: Uint8Array,
+  expectedKeys: readonly string[],
+  maxBytes: number,
+): Readonly<Record<string, unknown>> {
+  if (!(input instanceof Uint8Array) || input.byteLength < 2 || input.byteLength > maxBytes) {
+    utilityFail('oversized', 'RFC-64 flat canonical JSON is empty or oversized');
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(UTF8_FATAL.decode(input));
+  } catch (cause) {
+    utilityFail('strict-json', 'RFC-64 flat canonical JSON is not strict UTF-8 JSON', cause);
+  }
+  const snapshot = snapshotRfc64ExactWireRecordV1(parsed, expectedKeys);
+  if (!rfc64WireBytesEqualV1(encodeRfc64FlatCanonicalJsonV1(snapshot, maxBytes), input)) {
+    utilityFail('noncanonical', 'RFC-64 flat JSON bytes are not canonical JCS');
+  }
+  return snapshot;
+}
+
+/**
+ * Snapshot own enumerable data properties exactly once. This rejects accessor
+ * and Proxy switching attacks without invoking caller-controlled getters.
+ */
+export function snapshotRfc64ExactWireRecordV1(
+  value: unknown,
+  expectedKeys: readonly string[] | undefined,
+): Readonly<Record<string, unknown>> {
+  if (!isPlainRecord(value)) {
+    utilityFail('plain-object', 'RFC-64 wire value must be a plain object');
+  }
+  let ownKeys: readonly PropertyKey[];
+  try {
+    ownKeys = Reflect.ownKeys(value);
+  } catch (cause) {
+    utilityFail('exact-keys', 'RFC-64 wire fields could not be inspected', cause);
+  }
+  if (ownKeys.some((key) => typeof key !== 'string')) {
+    utilityFail('exact-keys', 'RFC-64 wire value has symbol fields');
+  }
+  const actual = [...ownKeys as readonly string[]].sort();
+  if (
+    expectedKeys !== undefined
+    && (
+      actual.length !== expectedKeys.length
+      || actual.some((key, index) => key !== expectedKeys[index])
+    )
+  ) {
+    utilityFail('exact-keys', 'RFC-64 wire value has missing or unknown fields');
+  }
+  const snapshot: Record<string, unknown> = Object.create(null);
+  for (const key of actual) {
+    let descriptor: PropertyDescriptor | undefined;
+    try {
+      descriptor = Object.getOwnPropertyDescriptor(value, key);
+    } catch (cause) {
+      utilityFail('exact-keys', 'RFC-64 wire field descriptor could not be inspected', cause);
+    }
+    if (
+      descriptor === undefined
+      || !descriptor.enumerable
+      || !Object.prototype.hasOwnProperty.call(descriptor, 'value')
+    ) {
+      utilityFail('exact-keys', 'RFC-64 wire fields must be enumerable data properties');
+    }
+    snapshot[key] = descriptor.value;
+  }
+  return Object.freeze(snapshot);
+}
+
+export function assertRfc64CanonicalEvmAddressV1(
+  value: unknown,
+  label: string,
+): asserts value is EvmAddressV1 {
+  if (
+    typeof value !== 'string'
+    || !/^0x[0-9a-f]{40}$/.test(value)
+    || value === '0x0000000000000000000000000000000000000000'
+  ) {
+    utilityFail(
+      'evm-address',
+      `${label} must be a canonical lowercase nonzero EVM address`,
+    );
+  }
+}
+
+export function snapshotRfc64PeerIdV1(value: unknown): string {
+  if (typeof value !== 'string') {
+    utilityFail('peer-id-type', 'remotePeerId must be a string');
+  }
+  const byteLength = UTF8.encode(value).byteLength;
+  if (byteLength < 1 || byteLength > MAX_PEER_ID_BYTES_V1 || value.trim() !== value) {
+    utilityFail('peer-id-canonical', 'remotePeerId is empty, oversized, or noncanonical');
+  }
+  return value;
+}
+
+export function assertRfc64ExactIssuerSignatureProofV1(
+  envelope: SignedControlEnvelopeV1,
+  proof: VerifiedControlEnvelopeIssuerSignatureV1,
+): void {
+  let snapshot;
+  try {
+    snapshot = readVerifiedControlEnvelopeIssuerSignatureV1(proof);
+  } catch (cause) {
+    utilityFail('issuer-proof-unminted', 'issuer signature proof was not minted by the verifier', cause);
+  }
+  const expectedVariant = computeControlSignatureVariantDigestHex(
+    envelope.objectDigest,
+    envelope.signature,
+  );
+  if (
+    snapshot.objectDigest !== envelope.objectDigest
+    || snapshot.signatureVariantDigest !== expectedVariant
+    || snapshot.issuer !== envelope.issuer
+    || snapshot.signatureSuite !== envelope.signatureSuite
+  ) {
+    utilityFail('issuer-proof-mismatch', 'issuer signature proof is not bound to the exact envelope');
+  }
+}
+
+export function encodeRfc64FoundStatusResponseV1(
+  payload: Uint8Array,
+  maxBytes?: number,
+): Uint8Array {
+  const result = new Uint8Array(payload.byteLength + 1);
+  result[0] = 1;
+  result.set(payload, 1);
+  if (maxBytes !== undefined && result.byteLength > maxBytes) {
+    utilityFail('response-size', 'RFC-64 found response exceeds its byte ceiling');
+  }
+  return result;
+}
+
+export type Rfc64StatusResponsePayloadV1 =
+  | { readonly status: 'not-found' }
+  | { readonly status: 'found'; readonly payload: Uint8Array }
+  | { readonly status: 'denied' };
+
+export function parseRfc64StatusResponsePayloadV1(
+  input: Uint8Array,
+  maxBytes: number,
+): Rfc64StatusResponsePayloadV1 {
+  if (!(input instanceof Uint8Array) || input.byteLength < 1 || input.byteLength > maxBytes) {
+    utilityFail('response-size', 'RFC-64 status response is empty or oversized');
+  }
+  const status = input[0];
+  if (status === 0 || status === 2) {
+    if (input.byteLength !== 1) {
+      utilityFail('response-trailing', 'RFC-64 status-only response has trailing bytes');
+    }
+    return Object.freeze({ status: status === 0 ? 'not-found' : 'denied' });
+  }
+  if (status !== 1 || input.byteLength === 1) {
+    utilityFail('response-status', 'RFC-64 status response has an invalid status');
+  }
+  return Object.freeze({ status: 'found', payload: input.subarray(1) });
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+  let prototype: object | null;
+  try {
+    prototype = Object.getPrototypeOf(value);
+  } catch (cause) {
+    utilityFail('plain-object', 'RFC-64 wire value prototype could not be inspected', cause);
+  }
+  return prototype === Object.prototype || prototype === null;
+}
+
+function rfc64WireBytesEqualV1(left: Uint8Array, right: Uint8Array): boolean {
+  if (left.byteLength !== right.byteLength) return false;
+  for (let index = 0; index < left.byteLength; index += 1) {
+    if (left[index] !== right[index]) return false;
+  }
+  return true;
+}
+
+function utilityFail(
+  reason: Rfc64CatalogTransportWireUtilityErrorReasonV1,
+  message: string,
+  cause?: unknown,
+): never {
+  throw new Rfc64CatalogTransportWireUtilityErrorV1(
+    reason,
+    message,
+    cause === undefined ? {} : { cause },
+  );
+}

--- a/packages/agent/src/rfc64/catalog-transport-wire-v1-internal.ts
+++ b/packages/agent/src/rfc64/catalog-transport-wire-v1-internal.ts
@@ -113,11 +113,12 @@ export function snapshotRfc64ExactWireRecordV1(
     utilityFail('exact-keys', 'RFC-64 wire value has symbol fields');
   }
   const actual = [...ownKeys as readonly string[]].sort();
+  const expected = expectedKeys === undefined ? undefined : [...expectedKeys].sort();
   if (
-    expectedKeys !== undefined
+    expected !== undefined
     && (
-      actual.length !== expectedKeys.length
-      || actual.some((key, index) => key !== expectedKeys[index])
+      actual.length !== expected.length
+      || actual.some((key, index) => key !== expected[index])
     )
   ) {
     utilityFail('exact-keys', 'RFC-64 wire value has missing or unknown fields');

--- a/packages/agent/src/rfc64/catalog-transport-wire-v1-internal.ts
+++ b/packages/agent/src/rfc64/catalog-transport-wire-v1-internal.ts
@@ -51,6 +51,143 @@ export class Rfc64CatalogTransportWireUtilityErrorV1 extends Error {
   }
 }
 
+export interface Rfc64CatalogTransportWireErrorMappingV1<Code extends string> {
+  readonly code: Code;
+  readonly message: string | ((cause: Rfc64CatalogTransportWireUtilityErrorV1) => string);
+}
+
+/**
+ * Central adapter from package-private wire failures to one protocol's public
+ * error vocabulary. Protocol modules declare a compact reason table instead
+ * of duplicating catch ladders whenever the shared wire taxonomy evolves.
+ */
+export function rethrowRfc64CatalogTransportWireUtilityErrorV1<Code extends string>(
+  cause: unknown,
+  fail: (code: Code, message: string, cause?: unknown) => never,
+  mappings: Partial<Record<
+    Rfc64CatalogTransportWireUtilityErrorReasonV1,
+    Rfc64CatalogTransportWireErrorMappingV1<Code>
+  >>,
+  fallback?: Rfc64CatalogTransportWireErrorMappingV1<Code>,
+): never {
+  if (!(cause instanceof Rfc64CatalogTransportWireUtilityErrorV1)) throw cause;
+  const mapping = mappings[cause.reason] ?? fallback;
+  if (mapping === undefined) throw cause;
+  fail(
+    mapping.code,
+    typeof mapping.message === 'function' ? mapping.message(cause) : mapping.message,
+    cause,
+  );
+}
+
+export interface Rfc64CatalogTransportWireAdapterMessagesV1 {
+  readonly encodePlainObject: string;
+  readonly encodeFieldShape: string;
+  readonly encodeOversized: (maxBytes: number) => string;
+  readonly parseOversized: string;
+  readonly parseStrictJson: string;
+  readonly parsePlainObject: string;
+  readonly parseExactKeys: string;
+  readonly parseNoncanonical: string;
+  readonly snapshot: string | ((cause: Rfc64CatalogTransportWireUtilityErrorV1) => string);
+  readonly evmAddress: (label: string) => string;
+  readonly peerIdType: string;
+  readonly peerIdCanonical: string;
+}
+
+export interface Rfc64CatalogTransportWireAdapterV1 {
+  encodeFlatCanonicalJson(value: object, maxBytes: number): Uint8Array;
+  parseFlatCanonicalJson(
+    input: Uint8Array,
+    expectedKeys: readonly string[],
+    maxBytes: number,
+  ): Readonly<Record<string, unknown>>;
+  snapshotExactWireRecord(
+    value: unknown,
+    expectedKeys: readonly string[],
+  ): Readonly<Record<string, unknown>>;
+  assertCanonicalEvmAddress(value: unknown, label: string): asserts value is EvmAddressV1;
+  snapshotPeerId(value: unknown): string;
+}
+
+/** Build one protocol-family adapter around the shared catalog wire codec. */
+export function createRfc64CatalogTransportWireAdapterV1<Code extends string>(options: {
+  readonly fail: (code: Code, message: string, cause?: unknown) => never;
+  readonly wireCode: Code;
+  readonly inputCode: Code;
+  readonly messages: Rfc64CatalogTransportWireAdapterMessagesV1;
+}): Rfc64CatalogTransportWireAdapterV1 {
+  const { fail, wireCode, inputCode, messages } = options;
+  return Object.freeze({
+    encodeFlatCanonicalJson(value: object, maxBytes: number): Uint8Array {
+      try {
+        return encodeRfc64FlatCanonicalJsonV1(value, maxBytes);
+      } catch (cause) {
+        rethrowRfc64CatalogTransportWireUtilityErrorV1(cause, fail, {
+          'plain-object': { code: wireCode, message: messages.encodePlainObject },
+          'field-shape': { code: wireCode, message: messages.encodeFieldShape },
+          oversized: { code: wireCode, message: messages.encodeOversized(maxBytes) },
+        });
+      }
+    },
+    parseFlatCanonicalJson(
+      input: Uint8Array,
+      expectedKeys: readonly string[],
+      maxBytes: number,
+    ): Readonly<Record<string, unknown>> {
+      try {
+        return parseRfc64FlatCanonicalJsonV1(input, expectedKeys, maxBytes);
+      } catch (cause) {
+        rethrowRfc64CatalogTransportWireUtilityErrorV1(cause, fail, {
+          oversized: { code: wireCode, message: messages.parseOversized },
+          'strict-json': { code: wireCode, message: messages.parseStrictJson },
+          'plain-object': { code: wireCode, message: messages.parsePlainObject },
+          'exact-keys': { code: wireCode, message: messages.parseExactKeys },
+          noncanonical: { code: wireCode, message: messages.parseNoncanonical },
+        });
+      }
+    },
+    snapshotExactWireRecord(
+      value: unknown,
+      expectedKeys: readonly string[],
+    ): Readonly<Record<string, unknown>> {
+      try {
+        return snapshotRfc64ExactWireRecordV1(value, expectedKeys);
+      } catch (cause) {
+        rethrowRfc64CatalogTransportWireUtilityErrorV1(cause, fail, {}, {
+          code: wireCode,
+          message: messages.snapshot,
+        });
+      }
+    },
+    assertCanonicalEvmAddress(
+      value: unknown,
+      label: string,
+    ): asserts value is EvmAddressV1 {
+      try {
+        assertRfc64CanonicalEvmAddressV1(value, label);
+      } catch (cause) {
+        rethrowRfc64CatalogTransportWireUtilityErrorV1(cause, fail, {}, {
+          code: wireCode,
+          message: messages.evmAddress(label),
+        });
+      }
+    },
+    snapshotPeerId(value: unknown): string {
+      try {
+        return snapshotRfc64PeerIdV1(value);
+      } catch (cause) {
+        rethrowRfc64CatalogTransportWireUtilityErrorV1(cause, fail, {
+          'peer-id-type': { code: inputCode, message: messages.peerIdType },
+        }, {
+          code: inputCode,
+          message: messages.peerIdCanonical,
+        });
+      }
+    },
+  });
+}
+
 export function encodeRfc64FlatCanonicalJsonV1(
   value: object,
   maxBytes: number,

--- a/packages/agent/src/rfc64/public-catalog-current-head-discovery-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-current-head-discovery-v1.ts
@@ -1,0 +1,673 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * RFC-64 public/open current-head discovery transport.
+ *
+ * Discovery is deliberately a narrow hint protocol. A requester names one
+ * independently accepted public/open catalog scope and a provider resolves it
+ * through a trusted semantic-current-head reader. Before advertising the
+ * result, the provider re-reads and verifies the exact signed head object. The
+ * requester must still exact-fetch and verify that object before treating the
+ * metadata as authenticated; {@link Rfc64PublicCatalogServiceV1} owns that
+ * composition.
+ *
+ * This transport does not stage control objects, schedule reconciliation,
+ * choose peers, walk predecessor history, or activate semantic state.
+ */
+
+import {
+  AUTHOR_CATALOG_HEAD_OBJECT_TYPE_V1,
+  ProtocolRouter,
+  assertCanonicalDecimalU64,
+  assertCanonicalDigest,
+  assertContextGraphIdV1,
+  assertNetworkIdV1,
+  assertSignedAuthorCatalogHeadEnvelopeV1,
+  assertSubGraphNameV1,
+  computeControlSignatureVariantDigestHex,
+  type ContextGraphAccessPolicyV1,
+  type ContextGraphIdV1,
+  type DecimalU64V1,
+  type Digest32V1,
+  type EvmAddressV1,
+  type NetworkIdV1,
+  type SendOptions,
+  type SignedAuthorCatalogHeadEnvelopeV1,
+  type SignedControlEnvelopeV1,
+  type SubGraphNameV1,
+} from '@origintrail-official/dkg-core';
+import {
+  readVerifiedControlEnvelopeIssuerSignatureV1,
+  type VerifiedControlEnvelopeIssuerSignatureV1,
+} from '@origintrail-official/dkg-chain';
+
+import type { Rfc64PublicCatalogHeadAnnouncementV1 } from './public-catalog-transport-v1.js';
+import {
+  RFC64_PUBLIC_CATALOG_HEAD_ANNOUNCEMENT_KIND_V1,
+  encodeRfc64PublicCatalogHeadAnnouncementV1,
+  parseRfc64PublicCatalogHeadAnnouncementV1,
+} from './public-catalog-transport-v1.js';
+
+export const RFC64_PUBLIC_CATALOG_CURRENT_HEAD_DISCOVERY_PROTOCOL_V1 =
+  '/dkg/catalog/1/author-head/current' as const;
+export const RFC64_PUBLIC_CATALOG_CURRENT_HEAD_QUERY_KIND_V1 =
+  'rfc64-author-catalog-current-head-query-v1' as const;
+
+export const RFC64_PUBLIC_CATALOG_CURRENT_HEAD_QUERY_MAX_BYTES_V1 = 2 * 1024;
+export const RFC64_PUBLIC_CATALOG_CURRENT_HEAD_RESPONSE_MAX_BYTES_V1 = 2 * 1024 + 1;
+
+const CURRENT_HEAD_NOT_FOUND = 0;
+const CURRENT_HEAD_FOUND = 1;
+const CURRENT_HEAD_DENIED = 2;
+const CURRENT_HEAD_SNAPSHOT_MAX_ATTEMPTS = 2;
+const MAX_PEER_ID_BYTES = 256;
+const UTF8 = new TextEncoder();
+// Keep a leading BOM visible so canonical re-encoding rejects it.
+const UTF8_FATAL = new TextDecoder('utf-8', { fatal: true, ignoreBOM: true });
+
+const QUERY_KEYS = Object.freeze([
+  'authorAddress',
+  'catalogEra',
+  'contextGraphId',
+  'kind',
+  'networkId',
+  'policyDigest',
+  'subGraphName',
+] as const);
+
+export interface Rfc64PublicCatalogCurrentHeadScopeV1 {
+  readonly networkId: NetworkIdV1;
+  readonly contextGraphId: ContextGraphIdV1;
+  readonly subGraphName: SubGraphNameV1 | null;
+  readonly authorAddress: EvmAddressV1;
+  readonly catalogEra: DecimalU64V1;
+}
+
+export interface Rfc64PublicCatalogCurrentHeadQueryV1
+  extends Rfc64PublicCatalogCurrentHeadScopeV1 {
+  readonly kind: typeof RFC64_PUBLIC_CATALOG_CURRENT_HEAD_QUERY_KIND_V1;
+  readonly policyDigest: Digest32V1;
+}
+
+export type Rfc64PublicCatalogCurrentHeadDiscoveryOperationV1 =
+  | 'current-head-discovery-outbound'
+  | 'current-head-discovery-inbound';
+
+export interface Rfc64PublicCatalogCurrentHeadAuthorizationInputV1
+  extends Rfc64PublicCatalogCurrentHeadScopeV1 {
+  readonly operation: Rfc64PublicCatalogCurrentHeadDiscoveryOperationV1;
+  readonly remotePeerId: string;
+  readonly policyDigest: Digest32V1;
+  readonly objectType: typeof AUTHOR_CATALOG_HEAD_OBJECT_TYPE_V1;
+}
+
+export interface Rfc64PublicCatalogCurrentHeadAuthorizationV1 {
+  readonly accessPolicy: ContextGraphAccessPolicyV1;
+  readonly policyDigest: Digest32V1;
+}
+
+export interface Rfc64PublicCatalogCurrentHeadControlObjectReaderV1 {
+  getVerifiedObjectByDigest(input: {
+    readonly objectDigest: Digest32V1;
+    readonly verifyIssuerSignature: (
+      envelope: SignedControlEnvelopeV1,
+    ) => Promise<VerifiedControlEnvelopeIssuerSignatureV1>;
+  }): Promise<{
+    readonly envelope: SignedControlEnvelopeV1;
+    readonly issuerSignature: VerifiedControlEnvelopeIssuerSignatureV1;
+  } | null>;
+}
+
+export interface Rfc64PublicCatalogCurrentHeadDiscoveryTransportOptionsV1 {
+  readonly controlObjects: Rfc64PublicCatalogCurrentHeadControlObjectReaderV1;
+  /**
+   * Resolve only a durable, semantically applied current-head pointer for the
+   * trusted query scope. A staged-only or candidate pointer violates this
+   * capability contract.
+   */
+  readonly readCurrentAppliedCatalogHeadDigest: (
+    query: Rfc64PublicCatalogCurrentHeadQueryV1,
+  ) => Promise<Digest32V1 | null>;
+  /** Must consult accepted current policy state, never echo the wire digest. */
+  readonly authorizeOpenCatalogOperation: (
+    input: Rfc64PublicCatalogCurrentHeadAuthorizationInputV1,
+  ) => Promise<Rfc64PublicCatalogCurrentHeadAuthorizationV1 | null>;
+  readonly verifyIssuerSignature: (
+    envelope: SignedControlEnvelopeV1,
+  ) => Promise<VerifiedControlEnvelopeIssuerSignatureV1>;
+}
+
+export const RFC64_PUBLIC_CATALOG_CURRENT_HEAD_DISCOVERY_ERROR_CODES_V1 = Object.freeze([
+  'catalog-discovery-input',
+  'catalog-discovery-wire',
+  'catalog-discovery-policy-denied',
+  'catalog-discovery-object-mismatch',
+  'catalog-discovery-signature',
+  'catalog-discovery-state',
+] as const);
+
+export type Rfc64PublicCatalogCurrentHeadDiscoveryErrorCodeV1 =
+  (typeof RFC64_PUBLIC_CATALOG_CURRENT_HEAD_DISCOVERY_ERROR_CODES_V1)[number];
+
+export class Rfc64PublicCatalogCurrentHeadDiscoveryErrorV1 extends Error {
+  constructor(
+    readonly code: Rfc64PublicCatalogCurrentHeadDiscoveryErrorCodeV1,
+    message: string,
+    options: ErrorOptions = {},
+  ) {
+    super(`[${code}] ${message}`, options);
+    this.name = 'Rfc64PublicCatalogCurrentHeadDiscoveryErrorV1';
+  }
+}
+
+/**
+ * Policy-gated current-head query/response on a production ProtocolRouter.
+ * Returned announcements remain hints until the caller exact-fetches and
+ * verifies the signed head named by both digests.
+ */
+export class Rfc64PublicCatalogCurrentHeadDiscoveryTransportV1 {
+  #started = false;
+
+  constructor(
+    private readonly router: ProtocolRouter,
+    private readonly options: Rfc64PublicCatalogCurrentHeadDiscoveryTransportOptionsV1,
+  ) {
+    if (typeof options?.controlObjects?.getVerifiedObjectByDigest !== 'function') {
+      fail('catalog-discovery-input', 'controlObjects.getVerifiedObjectByDigest must be a function');
+    }
+    if (typeof options.readCurrentAppliedCatalogHeadDigest !== 'function') {
+      fail('catalog-discovery-input', 'readCurrentAppliedCatalogHeadDigest must be a function');
+    }
+    if (typeof options.authorizeOpenCatalogOperation !== 'function') {
+      fail('catalog-discovery-input', 'authorizeOpenCatalogOperation must be a function');
+    }
+    if (typeof options.verifyIssuerSignature !== 'function') {
+      fail('catalog-discovery-input', 'verifyIssuerSignature must be a function');
+    }
+  }
+
+  get started(): boolean {
+    return this.#started;
+  }
+
+  start(): void {
+    if (this.#started) return;
+    this.#started = true;
+    try {
+      this.router.register(
+        RFC64_PUBLIC_CATALOG_CURRENT_HEAD_DISCOVERY_PROTOCOL_V1,
+        async (data, peerId) => this.handleQuery(data, peerId.toString()),
+        { maxReadBytes: RFC64_PUBLIC_CATALOG_CURRENT_HEAD_QUERY_MAX_BYTES_V1 },
+      );
+    } catch (cause) {
+      this.#started = false;
+      this.router.unregister(RFC64_PUBLIC_CATALOG_CURRENT_HEAD_DISCOVERY_PROTOCOL_V1);
+      throw cause;
+    }
+  }
+
+  stop(): void {
+    if (!this.#started) return;
+    this.#started = false;
+    this.router.unregister(RFC64_PUBLIC_CATALOG_CURRENT_HEAD_DISCOVERY_PROTOCOL_V1);
+  }
+
+  async discoverCurrentCatalogHead(
+    remotePeerIdInput: string,
+    queryInput: Rfc64PublicCatalogCurrentHeadQueryV1,
+    sendOptions?: SendOptions,
+  ): Promise<Rfc64PublicCatalogHeadAnnouncementV1 | null> {
+    this.requireStarted();
+    const remotePeerId = snapshotPeerId(remotePeerIdInput);
+    const query = parseQuery(encodeQuery(queryInput));
+    await this.requireOpenPolicy('current-head-discovery-outbound', remotePeerId, query);
+    const response = await this.router.send(
+      remotePeerId,
+      RFC64_PUBLIC_CATALOG_CURRENT_HEAD_DISCOVERY_PROTOCOL_V1,
+      encodeQuery(query),
+      sendOptions,
+    );
+    const announcement = parseResponse(response);
+    await this.requireOpenPolicy('current-head-discovery-outbound', remotePeerId, query);
+    if (announcement === null) return null;
+    assertAnnouncementMatchesQuery(announcement, query);
+    return announcement;
+  }
+
+  private async handleQuery(
+    data: Uint8Array,
+    remotePeerIdInput: string,
+  ): Promise<Uint8Array> {
+    this.requireStarted();
+    const remotePeerId = snapshotPeerId(remotePeerIdInput);
+    const query = parseQuery(data);
+    for (let attempt = 0; attempt < CURRENT_HEAD_SNAPSHOT_MAX_ATTEMPTS; attempt += 1) {
+      if (!await this.isOpenPolicy('current-head-discovery-inbound', remotePeerId, query)) {
+        return Uint8Array.of(CURRENT_HEAD_DENIED);
+      }
+
+      const currentDigest = await this.readCurrentAppliedCatalogHeadDigest(query);
+      const announcement = currentDigest === null
+        ? null
+        : await this.readCurrentAnnouncement(currentDigest, query);
+
+      // A semantic ref can advance while its immutable object is read. Confirm
+      // the pointer immediately before responding so discovery never knowingly
+      // advertises a superseded or transient snapshot. One retry admits the
+      // common single-writer CAS race while keeping work per request bounded.
+      const confirmedDigest = await this.readCurrentAppliedCatalogHeadDigest(query);
+      if (confirmedDigest !== currentDigest) continue;
+
+      if (!await this.isOpenPolicy('current-head-discovery-inbound', remotePeerId, query)) {
+        return Uint8Array.of(CURRENT_HEAD_DENIED);
+      }
+      return announcement === null
+        ? Uint8Array.of(CURRENT_HEAD_NOT_FOUND)
+        : foundResponse(announcement);
+    }
+
+    fail(
+      'catalog-discovery-state',
+      'current applied catalog-head pointer changed during bounded discovery',
+    );
+  }
+
+  private async readCurrentAppliedCatalogHeadDigest(
+    query: Rfc64PublicCatalogCurrentHeadQueryV1,
+  ): Promise<Digest32V1 | null> {
+    try {
+      const currentDigest = await this.options.readCurrentAppliedCatalogHeadDigest(query);
+      if (currentDigest !== null) {
+        assertCanonicalDigest(currentDigest, 'current catalog head digest');
+      }
+      return currentDigest;
+    } catch (cause) {
+      fail('catalog-discovery-state', 'current applied catalog-head lookup failed', cause);
+    }
+  }
+
+  private async readCurrentAnnouncement(
+    currentDigest: Digest32V1,
+    query: Rfc64PublicCatalogCurrentHeadQueryV1,
+  ): Promise<Rfc64PublicCatalogHeadAnnouncementV1> {
+    let stored: Awaited<ReturnType<
+      Rfc64PublicCatalogCurrentHeadControlObjectReaderV1['getVerifiedObjectByDigest']
+    >>;
+    try {
+      stored = await this.options.controlObjects.getVerifiedObjectByDigest({
+        objectDigest: currentDigest,
+        verifyIssuerSignature: this.options.verifyIssuerSignature,
+      });
+    } catch (cause) {
+      fail('catalog-discovery-state', 'current catalog-head object lookup failed', cause);
+    }
+    if (stored === null) {
+      fail(
+        'catalog-discovery-state',
+        'durable current catalog-head pointer has no exact verified control object',
+      );
+    }
+
+    let envelope: SignedAuthorCatalogHeadEnvelopeV1;
+    try {
+      assertSignedAuthorCatalogHeadEnvelopeV1(stored.envelope);
+      envelope = stored.envelope;
+      assertHeadMatchesQuery(envelope, currentDigest, query);
+      assertExactIssuerSignatureProof(envelope, stored.issuerSignature);
+    } catch (cause) {
+      if (cause instanceof Rfc64PublicCatalogCurrentHeadDiscoveryErrorV1) throw cause;
+      fail(
+        'catalog-discovery-object-mismatch',
+        'current catalog-head pointer does not resolve to the exact queried signed head',
+        cause,
+      );
+    }
+    return announcementFromHead(envelope, query.policyDigest);
+  }
+
+  private async isOpenPolicy(
+    operation: Rfc64PublicCatalogCurrentHeadDiscoveryOperationV1,
+    remotePeerId: string,
+    query: Rfc64PublicCatalogCurrentHeadQueryV1,
+  ): Promise<boolean> {
+    try {
+      await this.requireOpenPolicy(operation, remotePeerId, query);
+      return true;
+    } catch (cause) {
+      if (
+        cause instanceof Rfc64PublicCatalogCurrentHeadDiscoveryErrorV1
+        && cause.code === 'catalog-discovery-policy-denied'
+      ) return false;
+      throw cause;
+    }
+  }
+
+  private async requireOpenPolicy(
+    operation: Rfc64PublicCatalogCurrentHeadDiscoveryOperationV1,
+    remotePeerId: string,
+    query: Rfc64PublicCatalogCurrentHeadQueryV1,
+  ): Promise<void> {
+    const input = Object.freeze({
+      operation,
+      remotePeerId,
+      networkId: query.networkId,
+      contextGraphId: query.contextGraphId,
+      subGraphName: query.subGraphName,
+      authorAddress: query.authorAddress,
+      catalogEra: query.catalogEra,
+      policyDigest: query.policyDigest,
+      objectType: AUTHOR_CATALOG_HEAD_OBJECT_TYPE_V1,
+    }) satisfies Rfc64PublicCatalogCurrentHeadAuthorizationInputV1;
+    let authorization: Rfc64PublicCatalogCurrentHeadAuthorizationV1 | null;
+    try {
+      authorization = await this.options.authorizeOpenCatalogOperation(input);
+    } catch (cause) {
+      fail('catalog-discovery-policy-denied', 'open catalog discovery authorization failed', cause);
+    }
+    if (authorization === null || authorization.accessPolicy !== 0) {
+      fail('catalog-discovery-policy-denied', 'current-head discovery is not authorized by open policy');
+    }
+    try {
+      assertCanonicalDigest(authorization.policyDigest, 'authorized policyDigest');
+    } catch (cause) {
+      fail('catalog-discovery-policy-denied', 'discovery authorization returned an invalid digest', cause);
+    }
+    if (authorization.policyDigest !== query.policyDigest) {
+      fail('catalog-discovery-policy-denied', 'current-head discovery policy generation is stale or mismatched');
+    }
+  }
+
+  private requireStarted(): void {
+    if (!this.#started) {
+      fail('catalog-discovery-state', 'RFC-64 current-head discovery transport is not started');
+    }
+  }
+}
+
+export function encodeRfc64PublicCatalogCurrentHeadQueryV1(
+  input: Rfc64PublicCatalogCurrentHeadQueryV1,
+): Uint8Array {
+  return encodeQuery(input);
+}
+
+export function parseRfc64PublicCatalogCurrentHeadQueryV1(
+  input: Uint8Array,
+): Rfc64PublicCatalogCurrentHeadQueryV1 {
+  return parseQuery(input);
+}
+
+function encodeQuery(input: Rfc64PublicCatalogCurrentHeadQueryV1): Uint8Array {
+  const snapshot = validateQuery(input);
+  return encodeFlatCanonicalJson(snapshot, RFC64_PUBLIC_CATALOG_CURRENT_HEAD_QUERY_MAX_BYTES_V1);
+}
+
+function parseQuery(input: Uint8Array): Rfc64PublicCatalogCurrentHeadQueryV1 {
+  const parsed = parseFlatCanonicalJson(
+    input,
+    QUERY_KEYS,
+    RFC64_PUBLIC_CATALOG_CURRENT_HEAD_QUERY_MAX_BYTES_V1,
+  );
+  return validateQuery(parsed);
+}
+
+function validateQuery(value: unknown): Rfc64PublicCatalogCurrentHeadQueryV1 {
+  if (!isPlainRecord(value)) {
+    fail('catalog-discovery-wire', 'RFC-64 current-head query must be a plain object');
+  }
+  assertExactWireKeys(value, QUERY_KEYS);
+  if (value.kind !== RFC64_PUBLIC_CATALOG_CURRENT_HEAD_QUERY_KIND_V1) {
+    fail(
+      'catalog-discovery-wire',
+      `RFC-64 current-head query kind must be ${RFC64_PUBLIC_CATALOG_CURRENT_HEAD_QUERY_KIND_V1}`,
+    );
+  }
+  try {
+    assertNetworkIdV1(value.networkId);
+    assertContextGraphIdV1(value.contextGraphId);
+    if (value.subGraphName !== null) assertSubGraphNameV1(value.subGraphName);
+    assertCanonicalEvmAddressV1(value.authorAddress, 'authorAddress');
+    assertCanonicalDecimalU64(value.catalogEra, 'catalogEra');
+    assertCanonicalDigest(value.policyDigest, 'policyDigest');
+    return Object.freeze({
+      kind: RFC64_PUBLIC_CATALOG_CURRENT_HEAD_QUERY_KIND_V1,
+      networkId: value.networkId,
+      contextGraphId: value.contextGraphId,
+      subGraphName: value.subGraphName,
+      authorAddress: value.authorAddress,
+      catalogEra: value.catalogEra,
+      policyDigest: value.policyDigest,
+    });
+  } catch (cause) {
+    if (cause instanceof Rfc64PublicCatalogCurrentHeadDiscoveryErrorV1) throw cause;
+    fail('catalog-discovery-wire', 'RFC-64 current-head query contains an invalid scalar', cause);
+  }
+}
+
+function foundResponse(announcement: Rfc64PublicCatalogHeadAnnouncementV1): Uint8Array {
+  const bytes = encodeRfc64PublicCatalogHeadAnnouncementV1(announcement);
+  const response = new Uint8Array(bytes.byteLength + 1);
+  response[0] = CURRENT_HEAD_FOUND;
+  response.set(bytes, 1);
+  if (response.byteLength > RFC64_PUBLIC_CATALOG_CURRENT_HEAD_RESPONSE_MAX_BYTES_V1) {
+    fail('catalog-discovery-wire', 'current-head discovery response exceeds its v1 cap');
+  }
+  return response;
+}
+
+function parseResponse(input: Uint8Array): Rfc64PublicCatalogHeadAnnouncementV1 | null {
+  if (
+    !(input instanceof Uint8Array)
+    || input.byteLength < 1
+    || input.byteLength > RFC64_PUBLIC_CATALOG_CURRENT_HEAD_RESPONSE_MAX_BYTES_V1
+  ) {
+    fail('catalog-discovery-wire', 'current-head discovery response is empty or oversized');
+  }
+  if (input[0] === CURRENT_HEAD_NOT_FOUND) {
+    if (input.byteLength !== 1) {
+      fail('catalog-discovery-wire', 'not-found current-head response has trailing bytes');
+    }
+    return null;
+  }
+  if (input[0] === CURRENT_HEAD_DENIED) {
+    if (input.byteLength !== 1) {
+      fail('catalog-discovery-wire', 'denied current-head response has trailing bytes');
+    }
+    fail('catalog-discovery-policy-denied', 'remote peer denied current-head discovery');
+  }
+  if (input[0] !== CURRENT_HEAD_FOUND || input.byteLength === 1) {
+    fail('catalog-discovery-wire', 'current-head discovery response has an invalid status');
+  }
+  try {
+    return parseRfc64PublicCatalogHeadAnnouncementV1(input.subarray(1));
+  } catch (cause) {
+    fail('catalog-discovery-wire', 'current-head discovery response is not canonical', cause);
+  }
+}
+
+function assertAnnouncementMatchesQuery(
+  announcement: Rfc64PublicCatalogHeadAnnouncementV1,
+  query: Rfc64PublicCatalogCurrentHeadQueryV1,
+): void {
+  if (
+    announcement.networkId !== query.networkId
+    || announcement.contextGraphId !== query.contextGraphId
+    || announcement.subGraphName !== query.subGraphName
+    || announcement.authorAddress !== query.authorAddress
+    || announcement.catalogEra !== query.catalogEra
+    || announcement.policyDigest !== query.policyDigest
+  ) {
+    fail(
+      'catalog-discovery-object-mismatch',
+      'discovered catalog-head metadata does not match the exact requested scope',
+    );
+  }
+}
+
+function assertHeadMatchesQuery(
+  envelope: SignedAuthorCatalogHeadEnvelopeV1,
+  currentDigest: Digest32V1,
+  query: Rfc64PublicCatalogCurrentHeadQueryV1,
+): void {
+  const payload = envelope.payload;
+  if (
+    envelope.objectDigest !== currentDigest
+    || payload.networkId !== query.networkId
+    || payload.contextGraphId !== query.contextGraphId
+    || payload.subGraphName !== query.subGraphName
+    || payload.authorAddress !== query.authorAddress
+    || payload.era !== query.catalogEra
+  ) {
+    fail(
+      'catalog-discovery-object-mismatch',
+      'current catalog-head object does not match the exact requested scope and digest',
+    );
+  }
+}
+
+function announcementFromHead(
+  envelope: SignedAuthorCatalogHeadEnvelopeV1,
+  policyDigest: Digest32V1,
+): Rfc64PublicCatalogHeadAnnouncementV1 {
+  return Object.freeze({
+    kind: RFC64_PUBLIC_CATALOG_HEAD_ANNOUNCEMENT_KIND_V1,
+    networkId: envelope.payload.networkId,
+    contextGraphId: envelope.payload.contextGraphId,
+    subGraphName: envelope.payload.subGraphName,
+    authorAddress: envelope.payload.authorAddress,
+    catalogEra: envelope.payload.era,
+    catalogVersion: envelope.payload.version,
+    policyDigest,
+    catalogHeadObjectDigest: envelope.objectDigest as Digest32V1,
+    signatureVariantDigest: computeControlSignatureVariantDigestHex(
+      envelope.objectDigest,
+      envelope.signature,
+    ) as Digest32V1,
+  });
+}
+
+function assertExactIssuerSignatureProof(
+  envelope: SignedAuthorCatalogHeadEnvelopeV1,
+  proof: VerifiedControlEnvelopeIssuerSignatureV1,
+): void {
+  let snapshot;
+  try {
+    snapshot = readVerifiedControlEnvelopeIssuerSignatureV1(proof);
+  } catch (cause) {
+    fail('catalog-discovery-signature', 'issuer signature proof was not minted by the verifier', cause);
+  }
+  const expectedVariant = computeControlSignatureVariantDigestHex(
+    envelope.objectDigest,
+    envelope.signature,
+  );
+  if (
+    snapshot.objectDigest !== envelope.objectDigest
+    || snapshot.signatureVariantDigest !== expectedVariant
+    || snapshot.issuer !== envelope.issuer
+    || snapshot.signatureSuite !== envelope.signatureSuite
+  ) {
+    fail('catalog-discovery-signature', 'issuer signature proof is not bound to the exact head envelope');
+  }
+}
+
+function encodeFlatCanonicalJson(value: object, maxBytes: number): Uint8Array {
+  if (!isPlainRecord(value)) {
+    fail('catalog-discovery-wire', 'RFC-64 current-head query must be a plain object');
+  }
+  const fields: string[] = [];
+  for (const key of Object.keys(value).sort()) {
+    const field = value[key];
+    if (field !== null && typeof field !== 'string') {
+      fail('catalog-discovery-wire', 'RFC-64 current-head query accepts only string or null fields');
+    }
+    fields.push(`${JSON.stringify(key)}:${JSON.stringify(field)}`);
+  }
+  const bytes = UTF8.encode(`{${fields.join(',')}}`);
+  if (bytes.byteLength > maxBytes) {
+    fail('catalog-discovery-wire', `RFC-64 current-head query exceeds ${maxBytes} bytes`);
+  }
+  return bytes;
+}
+
+function parseFlatCanonicalJson(
+  input: Uint8Array,
+  expectedKeys: readonly string[],
+  maxBytes: number,
+): Record<string, unknown> {
+  if (!(input instanceof Uint8Array) || input.byteLength < 2 || input.byteLength > maxBytes) {
+    fail('catalog-discovery-wire', 'RFC-64 current-head query is empty or oversized');
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(UTF8_FATAL.decode(input));
+  } catch (cause) {
+    fail('catalog-discovery-wire', 'RFC-64 current-head query is not strict UTF-8 JSON', cause);
+  }
+  if (!isPlainRecord(parsed)) {
+    fail('catalog-discovery-wire', 'RFC-64 current-head query must be a plain JSON object');
+  }
+  assertExactWireKeys(parsed, expectedKeys);
+  if (!bytesEqual(encodeFlatCanonicalJson(parsed, maxBytes), input)) {
+    fail('catalog-discovery-wire', 'RFC-64 current-head query bytes are not canonical JCS');
+  }
+  return parsed;
+}
+
+function assertExactWireKeys(
+  value: Record<string, unknown>,
+  expectedKeys: readonly string[],
+): void {
+  const actual = Object.keys(value).sort();
+  if (
+    actual.length !== expectedKeys.length
+    || actual.some((key, index) => key !== expectedKeys[index])
+  ) {
+    fail('catalog-discovery-wire', 'RFC-64 current-head query has missing or unknown fields');
+  }
+}
+
+function assertCanonicalEvmAddressV1(value: unknown, label: string): asserts value is EvmAddressV1 {
+  if (
+    typeof value !== 'string'
+    || !/^0x[0-9a-f]{40}$/.test(value)
+    || value === '0x0000000000000000000000000000000000000000'
+  ) {
+    fail('catalog-discovery-wire', `${label} must be a canonical lowercase nonzero EVM address`);
+  }
+}
+
+function snapshotPeerId(value: unknown): string {
+  if (typeof value !== 'string') {
+    fail('catalog-discovery-input', 'remotePeerId must be a string');
+  }
+  const byteLength = UTF8.encode(value).byteLength;
+  if (byteLength < 1 || byteLength > MAX_PEER_ID_BYTES || value.trim() !== value) {
+    fail('catalog-discovery-input', 'remotePeerId is empty, oversized, or noncanonical');
+  }
+  return value;
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function bytesEqual(left: Uint8Array, right: Uint8Array): boolean {
+  if (left.byteLength !== right.byteLength) return false;
+  for (let index = 0; index < left.byteLength; index += 1) {
+    if (left[index] !== right[index]) return false;
+  }
+  return true;
+}
+
+function fail(
+  code: Rfc64PublicCatalogCurrentHeadDiscoveryErrorCodeV1,
+  message: string,
+  cause?: unknown,
+): never {
+  throw new Rfc64PublicCatalogCurrentHeadDiscoveryErrorV1(
+    code,
+    message,
+    cause === undefined ? {} : { cause },
+  );
+}

--- a/packages/agent/src/rfc64/public-catalog-current-head-discovery-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-current-head-discovery-v1.ts
@@ -25,6 +25,7 @@ import {
   assertSignedAuthorCatalogHeadEnvelopeV1,
   assertSubGraphNameV1,
   computeControlSignatureVariantDigestHex,
+  type AuthorCatalogScopeV1,
   type ContextGraphAccessPolicyV1,
   type ContextGraphIdV1,
   type DecimalU64V1,
@@ -41,15 +42,12 @@ import {
 } from '@origintrail-official/dkg-chain';
 
 import {
-  Rfc64CatalogTransportWireUtilityErrorV1,
-  assertRfc64CanonicalEvmAddressV1,
   assertRfc64ExactIssuerSignatureProofV1,
-  encodeRfc64FlatCanonicalJsonV1,
+  createRfc64CatalogTransportWireAdapterV1,
   encodeRfc64FoundStatusResponseV1,
-  parseRfc64FlatCanonicalJsonV1,
   parseRfc64StatusResponsePayloadV1,
-  snapshotRfc64ExactWireRecordV1,
-  snapshotRfc64PeerIdV1,
+  rethrowRfc64CatalogTransportWireUtilityErrorV1,
+  type Rfc64CatalogTransportWireAdapterV1,
 } from './catalog-transport-wire-v1-internal.js';
 
 import type { Rfc64PublicCatalogHeadAnnouncementV1 } from './public-catalog-transport-v1.js';
@@ -81,6 +79,30 @@ const QUERY_KEYS = Object.freeze([
   'subGraphName',
 ] as const);
 
+const DISCOVERY_WIRE: Rfc64CatalogTransportWireAdapterV1 =
+  createRfc64CatalogTransportWireAdapterV1({
+    fail,
+    wireCode: 'catalog-discovery-wire',
+    inputCode: 'catalog-discovery-input',
+    messages: {
+      encodePlainObject: 'RFC-64 current-head query must be a plain object',
+      encodeFieldShape: 'RFC-64 current-head query accepts only string or null fields',
+      encodeOversized: (maxBytes) => `RFC-64 current-head query exceeds ${maxBytes} bytes`,
+      parseOversized: 'RFC-64 current-head query is empty or oversized',
+      parseStrictJson: 'RFC-64 current-head query is not strict UTF-8 JSON',
+      parsePlainObject: 'RFC-64 current-head query must be a plain JSON object',
+      parseExactKeys: 'RFC-64 current-head query has missing or unknown fields',
+      parseNoncanonical: 'RFC-64 current-head query bytes are not canonical JCS',
+      snapshot: (wireError) => wireError.message.replace(
+        'RFC-64 wire',
+        'RFC-64 current-head query',
+      ),
+      evmAddress: (label) => `${label} must be a canonical lowercase nonzero EVM address`,
+      peerIdType: 'remotePeerId must be a string',
+      peerIdCanonical: 'remotePeerId is empty, oversized, or noncanonical',
+    },
+  });
+
 export interface Rfc64PublicCatalogCurrentHeadScopeV1 {
   readonly networkId: NetworkIdV1;
   readonly contextGraphId: ContextGraphIdV1;
@@ -110,6 +132,8 @@ export interface Rfc64PublicCatalogCurrentHeadAuthorizationInputV1
 export interface Rfc64PublicCatalogCurrentHeadAuthorizationV1 {
   readonly accessPolicy: ContextGraphAccessPolicyV1;
   readonly policyDigest: Digest32V1;
+  /** Exact semantic scope derived from independently accepted local policy. */
+  readonly trustedCatalogScope: Readonly<AuthorCatalogScopeV1>;
 }
 
 export interface Rfc64PublicCatalogCurrentHeadControlObjectReaderV1 {
@@ -132,7 +156,7 @@ export interface Rfc64PublicCatalogCurrentHeadDiscoveryTransportOptionsV1 {
    * capability contract.
    */
   readonly readCurrentAppliedCatalogHeadDigest: (
-    query: Rfc64PublicCatalogCurrentHeadQueryV1,
+    trustedCatalogScope: Readonly<AuthorCatalogScopeV1>,
   ) => Promise<Digest32V1 | null>;
   /** Must consult accepted current policy state, never echo the wire digest. */
   readonly authorizeOpenCatalogOperation: (
@@ -251,12 +275,19 @@ export class Rfc64PublicCatalogCurrentHeadDiscoveryTransportV1 {
     const remotePeerId = snapshotPeerId(remotePeerIdInput);
     const query = parseQuery(data);
     for (let attempt = 0; attempt < CURRENT_HEAD_SNAPSHOT_MAX_ATTEMPTS; attempt += 1) {
-      if (!await this.isOpenPolicy('current-head-discovery-inbound', remotePeerId, query)) {
+      const authorization = await this.openPolicyOrNull(
+        'current-head-discovery-inbound',
+        remotePeerId,
+        query,
+      );
+      if (authorization === null) {
         return Uint8Array.of(CURRENT_HEAD_DENIED);
       }
       throwIfAborted(signal);
 
-      const currentDigest = await this.readCurrentAppliedCatalogHeadDigest(query);
+      const currentDigest = await this.readCurrentAppliedCatalogHeadDigest(
+        authorization.trustedCatalogScope,
+      );
       throwIfAborted(signal);
       const announcement = currentDigest === null
         ? null
@@ -267,11 +298,17 @@ export class Rfc64PublicCatalogCurrentHeadDiscoveryTransportV1 {
       // the pointer immediately before responding so discovery never knowingly
       // advertises a superseded or transient snapshot. One retry admits the
       // common single-writer CAS race while keeping work per request bounded.
-      const confirmedDigest = await this.readCurrentAppliedCatalogHeadDigest(query);
+      const confirmedDigest = await this.readCurrentAppliedCatalogHeadDigest(
+        authorization.trustedCatalogScope,
+      );
       throwIfAborted(signal);
       if (confirmedDigest !== currentDigest) continue;
 
-      if (!await this.isOpenPolicy('current-head-discovery-inbound', remotePeerId, query)) {
+      if (await this.openPolicyOrNull(
+        'current-head-discovery-inbound',
+        remotePeerId,
+        query,
+      ) === null) {
         return Uint8Array.of(CURRENT_HEAD_DENIED);
       }
       throwIfAborted(signal);
@@ -287,10 +324,12 @@ export class Rfc64PublicCatalogCurrentHeadDiscoveryTransportV1 {
   }
 
   private async readCurrentAppliedCatalogHeadDigest(
-    query: Rfc64PublicCatalogCurrentHeadQueryV1,
+    trustedCatalogScope: Readonly<AuthorCatalogScopeV1>,
   ): Promise<Digest32V1 | null> {
     try {
-      const currentDigest = await this.options.readCurrentAppliedCatalogHeadDigest(query);
+      const currentDigest = await this.options.readCurrentAppliedCatalogHeadDigest(
+        trustedCatalogScope,
+      );
       if (currentDigest !== null) {
         assertCanonicalDigest(currentDigest, 'current catalog head digest');
       }
@@ -339,19 +378,18 @@ export class Rfc64PublicCatalogCurrentHeadDiscoveryTransportV1 {
     return announcementFromHead(envelope, query.policyDigest);
   }
 
-  private async isOpenPolicy(
+  private async openPolicyOrNull(
     operation: Rfc64PublicCatalogCurrentHeadDiscoveryOperationV1,
     remotePeerId: string,
     query: Rfc64PublicCatalogCurrentHeadQueryV1,
-  ): Promise<boolean> {
+  ): Promise<Rfc64PublicCatalogCurrentHeadAuthorizationV1 | null> {
     try {
-      await this.requireOpenPolicy(operation, remotePeerId, query);
-      return true;
+      return await this.requireOpenPolicy(operation, remotePeerId, query);
     } catch (cause) {
       if (
         cause instanceof Rfc64PublicCatalogCurrentHeadDiscoveryErrorV1
         && cause.code === 'catalog-discovery-policy-denied'
-      ) return false;
+      ) return null;
       throw cause;
     }
   }
@@ -360,7 +398,7 @@ export class Rfc64PublicCatalogCurrentHeadDiscoveryTransportV1 {
     operation: Rfc64PublicCatalogCurrentHeadDiscoveryOperationV1,
     remotePeerId: string,
     query: Rfc64PublicCatalogCurrentHeadQueryV1,
-  ): Promise<void> {
+  ): Promise<Rfc64PublicCatalogCurrentHeadAuthorizationV1> {
     const input = Object.freeze({
       operation,
       remotePeerId,
@@ -389,6 +427,7 @@ export class Rfc64PublicCatalogCurrentHeadDiscoveryTransportV1 {
     if (authorization.policyDigest !== query.policyDigest) {
       fail('catalog-discovery-policy-denied', 'current-head discovery policy generation is stale or mismatched');
     }
+    return authorization;
   }
 
   private requireStarted(): void {
@@ -481,25 +520,21 @@ function parseResponse(input: Uint8Array): Rfc64PublicCatalogHeadAnnouncementV1 
       RFC64_PUBLIC_CATALOG_CURRENT_HEAD_RESPONSE_MAX_BYTES_V1,
     );
   } catch (cause) {
-    if (
-      cause instanceof Rfc64CatalogTransportWireUtilityErrorV1
-      && cause.reason === 'response-trailing'
-    ) {
-      fail(
-        'catalog-discovery-wire',
-        input[0] === CURRENT_HEAD_NOT_FOUND
+    rethrowRfc64CatalogTransportWireUtilityErrorV1(cause, fail, {
+      'response-trailing': {
+        code: 'catalog-discovery-wire',
+        message: input[0] === CURRENT_HEAD_NOT_FOUND
           ? 'not-found current-head response has trailing bytes'
           : 'denied current-head response has trailing bytes',
-        cause,
-      );
-    }
-    if (
-      cause instanceof Rfc64CatalogTransportWireUtilityErrorV1
-      && cause.reason === 'response-status'
-    ) {
-      fail('catalog-discovery-wire', 'current-head discovery response has an invalid status', cause);
-    }
-    fail('catalog-discovery-wire', 'current-head discovery response is empty or oversized', cause);
+      },
+      'response-status': {
+        code: 'catalog-discovery-wire',
+        message: 'current-head discovery response has an invalid status',
+      },
+    }, {
+      code: 'catalog-discovery-wire',
+      message: 'current-head discovery response is empty or oversized',
+    });
   }
   if (framed.status === 'not-found') return null;
   if (framed.status === 'denied') {
@@ -580,38 +615,20 @@ function assertExactIssuerSignatureProof(
   try {
     assertRfc64ExactIssuerSignatureProofV1(envelope, proof);
   } catch (cause) {
-    fail(
-      'catalog-discovery-signature',
-      cause instanceof Rfc64CatalogTransportWireUtilityErrorV1
-        && cause.reason === 'issuer-proof-unminted'
-        ? 'issuer signature proof was not minted by the verifier'
-        : 'issuer signature proof is not bound to the exact head envelope',
-      cause,
-    );
+    rethrowRfc64CatalogTransportWireUtilityErrorV1(cause, fail, {
+      'issuer-proof-unminted': {
+        code: 'catalog-discovery-signature',
+        message: 'issuer signature proof was not minted by the verifier',
+      },
+    }, {
+      code: 'catalog-discovery-signature',
+      message: 'issuer signature proof is not bound to the exact head envelope',
+    });
   }
 }
 
 function encodeFlatCanonicalJson(value: object, maxBytes: number): Uint8Array {
-  try {
-    return encodeRfc64FlatCanonicalJsonV1(value, maxBytes);
-  } catch (cause) {
-    if (cause instanceof Rfc64CatalogTransportWireUtilityErrorV1) {
-      if (cause.reason === 'plain-object') {
-        fail('catalog-discovery-wire', 'RFC-64 current-head query must be a plain object', cause);
-      }
-      if (cause.reason === 'field-shape') {
-        fail(
-          'catalog-discovery-wire',
-          'RFC-64 current-head query accepts only string or null fields',
-          cause,
-        );
-      }
-      if (cause.reason === 'oversized') {
-        fail('catalog-discovery-wire', `RFC-64 current-head query exceeds ${maxBytes} bytes`, cause);
-      }
-    }
-    throw cause;
-  }
+  return DISCOVERY_WIRE.encodeFlatCanonicalJson(value, maxBytes);
 }
 
 function parseFlatCanonicalJson(
@@ -619,69 +636,22 @@ function parseFlatCanonicalJson(
   expectedKeys: readonly string[],
   maxBytes: number,
 ): Record<string, unknown> {
-  try {
-    return parseRfc64FlatCanonicalJsonV1(input, expectedKeys, maxBytes);
-  } catch (cause) {
-    if (cause instanceof Rfc64CatalogTransportWireUtilityErrorV1) {
-      if (cause.reason === 'oversized') {
-        fail('catalog-discovery-wire', 'RFC-64 current-head query is empty or oversized', cause);
-      }
-      if (cause.reason === 'strict-json') {
-        fail('catalog-discovery-wire', 'RFC-64 current-head query is not strict UTF-8 JSON', cause);
-      }
-      if (cause.reason === 'plain-object') {
-        fail('catalog-discovery-wire', 'RFC-64 current-head query must be a plain JSON object', cause);
-      }
-      if (cause.reason === 'exact-keys') {
-        fail('catalog-discovery-wire', 'RFC-64 current-head query has missing or unknown fields', cause);
-      }
-      if (cause.reason === 'noncanonical') {
-        fail('catalog-discovery-wire', 'RFC-64 current-head query bytes are not canonical JCS', cause);
-      }
-    }
-    throw cause;
-  }
+  return DISCOVERY_WIRE.parseFlatCanonicalJson(input, expectedKeys, maxBytes);
 }
 
 function snapshotExactWireRecord(
   value: Record<string, unknown>,
   expectedKeys: readonly string[],
 ): Readonly<Record<string, unknown>> {
-  try {
-    return snapshotRfc64ExactWireRecordV1(value, expectedKeys);
-  } catch (cause) {
-    if (cause instanceof Rfc64CatalogTransportWireUtilityErrorV1) {
-      fail('catalog-discovery-wire', cause.message.replace('RFC-64 wire', 'RFC-64 current-head query'), cause);
-    }
-    throw cause;
-  }
+  return DISCOVERY_WIRE.snapshotExactWireRecord(value, expectedKeys);
 }
 
 function assertCanonicalEvmAddressV1(value: unknown, label: string): asserts value is EvmAddressV1 {
-  try {
-    assertRfc64CanonicalEvmAddressV1(value, label);
-  } catch (cause) {
-    fail(
-      'catalog-discovery-wire',
-      `${label} must be a canonical lowercase nonzero EVM address`,
-      cause,
-    );
-  }
+  DISCOVERY_WIRE.assertCanonicalEvmAddress(value, label);
 }
 
 function snapshotPeerId(value: unknown): string {
-  try {
-    return snapshotRfc64PeerIdV1(value);
-  } catch (cause) {
-    fail(
-      'catalog-discovery-input',
-      cause instanceof Rfc64CatalogTransportWireUtilityErrorV1
-        && cause.reason === 'peer-id-type'
-        ? 'remotePeerId must be a string'
-        : 'remotePeerId is empty, oversized, or noncanonical',
-      cause,
-    );
-  }
+  return DISCOVERY_WIRE.snapshotPeerId(value);
 }
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/agent/src/rfc64/public-catalog-current-head-discovery-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-current-head-discovery-v1.ts
@@ -37,9 +37,20 @@ import {
   type SubGraphNameV1,
 } from '@origintrail-official/dkg-core';
 import {
-  readVerifiedControlEnvelopeIssuerSignatureV1,
   type VerifiedControlEnvelopeIssuerSignatureV1,
 } from '@origintrail-official/dkg-chain';
+
+import {
+  Rfc64CatalogTransportWireUtilityErrorV1,
+  assertRfc64CanonicalEvmAddressV1,
+  assertRfc64ExactIssuerSignatureProofV1,
+  encodeRfc64FlatCanonicalJsonV1,
+  encodeRfc64FoundStatusResponseV1,
+  parseRfc64FlatCanonicalJsonV1,
+  parseRfc64StatusResponsePayloadV1,
+  snapshotRfc64ExactWireRecordV1,
+  snapshotRfc64PeerIdV1,
+} from './catalog-transport-wire-v1-internal.js';
 
 import type { Rfc64PublicCatalogHeadAnnouncementV1 } from './public-catalog-transport-v1.js';
 import {
@@ -57,13 +68,8 @@ export const RFC64_PUBLIC_CATALOG_CURRENT_HEAD_QUERY_MAX_BYTES_V1 = 2 * 1024;
 export const RFC64_PUBLIC_CATALOG_CURRENT_HEAD_RESPONSE_MAX_BYTES_V1 = 2 * 1024 + 1;
 
 const CURRENT_HEAD_NOT_FOUND = 0;
-const CURRENT_HEAD_FOUND = 1;
 const CURRENT_HEAD_DENIED = 2;
 const CURRENT_HEAD_SNAPSHOT_MAX_ATTEMPTS = 2;
-const MAX_PEER_ID_BYTES = 256;
-const UTF8 = new TextEncoder();
-// Keep a leading BOM visible so canonical re-encoding rejects it.
-const UTF8_FATAL = new TextDecoder('utf-8', { fatal: true, ignoreBOM: true });
 
 const QUERY_KEYS = Object.freeze([
   'authorAddress',
@@ -457,40 +463,50 @@ function validateQuery(value: unknown): Rfc64PublicCatalogCurrentHeadQueryV1 {
 
 function foundResponse(announcement: Rfc64PublicCatalogHeadAnnouncementV1): Uint8Array {
   const bytes = encodeRfc64PublicCatalogHeadAnnouncementV1(announcement);
-  const response = new Uint8Array(bytes.byteLength + 1);
-  response[0] = CURRENT_HEAD_FOUND;
-  response.set(bytes, 1);
-  if (response.byteLength > RFC64_PUBLIC_CATALOG_CURRENT_HEAD_RESPONSE_MAX_BYTES_V1) {
+  try {
+    return encodeRfc64FoundStatusResponseV1(
+      bytes,
+      RFC64_PUBLIC_CATALOG_CURRENT_HEAD_RESPONSE_MAX_BYTES_V1,
+    );
+  } catch (cause) {
     fail('catalog-discovery-wire', 'current-head discovery response exceeds its v1 cap');
   }
-  return response;
 }
 
 function parseResponse(input: Uint8Array): Rfc64PublicCatalogHeadAnnouncementV1 | null {
-  if (
-    !(input instanceof Uint8Array)
-    || input.byteLength < 1
-    || input.byteLength > RFC64_PUBLIC_CATALOG_CURRENT_HEAD_RESPONSE_MAX_BYTES_V1
-  ) {
-    fail('catalog-discovery-wire', 'current-head discovery response is empty or oversized');
-  }
-  if (input[0] === CURRENT_HEAD_NOT_FOUND) {
-    if (input.byteLength !== 1) {
-      fail('catalog-discovery-wire', 'not-found current-head response has trailing bytes');
+  let framed;
+  try {
+    framed = parseRfc64StatusResponsePayloadV1(
+      input,
+      RFC64_PUBLIC_CATALOG_CURRENT_HEAD_RESPONSE_MAX_BYTES_V1,
+    );
+  } catch (cause) {
+    if (
+      cause instanceof Rfc64CatalogTransportWireUtilityErrorV1
+      && cause.reason === 'response-trailing'
+    ) {
+      fail(
+        'catalog-discovery-wire',
+        input[0] === CURRENT_HEAD_NOT_FOUND
+          ? 'not-found current-head response has trailing bytes'
+          : 'denied current-head response has trailing bytes',
+        cause,
+      );
     }
-    return null;
-  }
-  if (input[0] === CURRENT_HEAD_DENIED) {
-    if (input.byteLength !== 1) {
-      fail('catalog-discovery-wire', 'denied current-head response has trailing bytes');
+    if (
+      cause instanceof Rfc64CatalogTransportWireUtilityErrorV1
+      && cause.reason === 'response-status'
+    ) {
+      fail('catalog-discovery-wire', 'current-head discovery response has an invalid status', cause);
     }
+    fail('catalog-discovery-wire', 'current-head discovery response is empty or oversized', cause);
+  }
+  if (framed.status === 'not-found') return null;
+  if (framed.status === 'denied') {
     fail('catalog-discovery-policy-denied', 'remote peer denied current-head discovery');
   }
-  if (input[0] !== CURRENT_HEAD_FOUND || input.byteLength === 1) {
-    fail('catalog-discovery-wire', 'current-head discovery response has an invalid status');
-  }
   try {
-    return parseRfc64PublicCatalogHeadAnnouncementV1(input.subarray(1));
+    return parseRfc64PublicCatalogHeadAnnouncementV1(framed.payload);
   } catch (cause) {
     fail('catalog-discovery-wire', 'current-head discovery response is not canonical', cause);
   }
@@ -561,43 +577,41 @@ function assertExactIssuerSignatureProof(
   envelope: SignedAuthorCatalogHeadEnvelopeV1,
   proof: VerifiedControlEnvelopeIssuerSignatureV1,
 ): void {
-  let snapshot;
   try {
-    snapshot = readVerifiedControlEnvelopeIssuerSignatureV1(proof);
+    assertRfc64ExactIssuerSignatureProofV1(envelope, proof);
   } catch (cause) {
-    fail('catalog-discovery-signature', 'issuer signature proof was not minted by the verifier', cause);
-  }
-  const expectedVariant = computeControlSignatureVariantDigestHex(
-    envelope.objectDigest,
-    envelope.signature,
-  );
-  if (
-    snapshot.objectDigest !== envelope.objectDigest
-    || snapshot.signatureVariantDigest !== expectedVariant
-    || snapshot.issuer !== envelope.issuer
-    || snapshot.signatureSuite !== envelope.signatureSuite
-  ) {
-    fail('catalog-discovery-signature', 'issuer signature proof is not bound to the exact head envelope');
+    fail(
+      'catalog-discovery-signature',
+      cause instanceof Rfc64CatalogTransportWireUtilityErrorV1
+        && cause.reason === 'issuer-proof-unminted'
+        ? 'issuer signature proof was not minted by the verifier'
+        : 'issuer signature proof is not bound to the exact head envelope',
+      cause,
+    );
   }
 }
 
 function encodeFlatCanonicalJson(value: object, maxBytes: number): Uint8Array {
-  if (!isPlainRecord(value)) {
-    fail('catalog-discovery-wire', 'RFC-64 current-head query must be a plain object');
-  }
-  const fields: string[] = [];
-  for (const key of Object.keys(value).sort()) {
-    const field = value[key];
-    if (field !== null && typeof field !== 'string') {
-      fail('catalog-discovery-wire', 'RFC-64 current-head query accepts only string or null fields');
+  try {
+    return encodeRfc64FlatCanonicalJsonV1(value, maxBytes);
+  } catch (cause) {
+    if (cause instanceof Rfc64CatalogTransportWireUtilityErrorV1) {
+      if (cause.reason === 'plain-object') {
+        fail('catalog-discovery-wire', 'RFC-64 current-head query must be a plain object', cause);
+      }
+      if (cause.reason === 'field-shape') {
+        fail(
+          'catalog-discovery-wire',
+          'RFC-64 current-head query accepts only string or null fields',
+          cause,
+        );
+      }
+      if (cause.reason === 'oversized') {
+        fail('catalog-discovery-wire', `RFC-64 current-head query exceeds ${maxBytes} bytes`, cause);
+      }
     }
-    fields.push(`${JSON.stringify(key)}:${JSON.stringify(field)}`);
+    throw cause;
   }
-  const bytes = UTF8.encode(`{${fields.join(',')}}`);
-  if (bytes.byteLength > maxBytes) {
-    fail('catalog-discovery-wire', `RFC-64 current-head query exceeds ${maxBytes} bytes`);
-  }
-  return bytes;
 }
 
 function parseFlatCanonicalJson(
@@ -605,112 +619,75 @@ function parseFlatCanonicalJson(
   expectedKeys: readonly string[],
   maxBytes: number,
 ): Record<string, unknown> {
-  if (!(input instanceof Uint8Array) || input.byteLength < 2 || input.byteLength > maxBytes) {
-    fail('catalog-discovery-wire', 'RFC-64 current-head query is empty or oversized');
-  }
-  let parsed: unknown;
   try {
-    parsed = JSON.parse(UTF8_FATAL.decode(input));
+    return parseRfc64FlatCanonicalJsonV1(input, expectedKeys, maxBytes);
   } catch (cause) {
-    fail('catalog-discovery-wire', 'RFC-64 current-head query is not strict UTF-8 JSON', cause);
+    if (cause instanceof Rfc64CatalogTransportWireUtilityErrorV1) {
+      if (cause.reason === 'oversized') {
+        fail('catalog-discovery-wire', 'RFC-64 current-head query is empty or oversized', cause);
+      }
+      if (cause.reason === 'strict-json') {
+        fail('catalog-discovery-wire', 'RFC-64 current-head query is not strict UTF-8 JSON', cause);
+      }
+      if (cause.reason === 'plain-object') {
+        fail('catalog-discovery-wire', 'RFC-64 current-head query must be a plain JSON object', cause);
+      }
+      if (cause.reason === 'exact-keys') {
+        fail('catalog-discovery-wire', 'RFC-64 current-head query has missing or unknown fields', cause);
+      }
+      if (cause.reason === 'noncanonical') {
+        fail('catalog-discovery-wire', 'RFC-64 current-head query bytes are not canonical JCS', cause);
+      }
+    }
+    throw cause;
   }
-  if (!isPlainRecord(parsed)) {
-    fail('catalog-discovery-wire', 'RFC-64 current-head query must be a plain JSON object');
-  }
-  assertExactWireKeys(parsed, expectedKeys);
-  if (!bytesEqual(encodeFlatCanonicalJson(parsed, maxBytes), input)) {
-    fail('catalog-discovery-wire', 'RFC-64 current-head query bytes are not canonical JCS');
-  }
-  return parsed;
-}
-
-function assertExactWireKeys(
-  value: Record<string, unknown>,
-  expectedKeys: readonly string[],
-): void {
-  void snapshotExactWireRecord(value, expectedKeys);
 }
 
 function snapshotExactWireRecord(
   value: Record<string, unknown>,
   expectedKeys: readonly string[],
 ): Readonly<Record<string, unknown>> {
-  let ownKeys: readonly PropertyKey[];
   try {
-    ownKeys = Reflect.ownKeys(value);
+    return snapshotRfc64ExactWireRecordV1(value, expectedKeys);
   } catch (cause) {
-    fail('catalog-discovery-wire', 'RFC-64 current-head query fields could not be inspected', cause);
-  }
-  if (ownKeys.some((key) => typeof key !== 'string')) {
-    fail('catalog-discovery-wire', 'RFC-64 current-head query has symbol fields');
-  }
-  const actual = [...ownKeys as readonly string[]].sort();
-  if (
-    actual.length !== expectedKeys.length
-    || actual.some((key, index) => key !== expectedKeys[index])
-  ) {
-    fail('catalog-discovery-wire', 'RFC-64 current-head query has missing or unknown fields');
-  }
-  const snapshot: Record<string, unknown> = Object.create(null);
-  for (const key of expectedKeys) {
-    let descriptor: PropertyDescriptor | undefined;
-    try {
-      descriptor = Object.getOwnPropertyDescriptor(value, key);
-    } catch (cause) {
-      fail(
-        'catalog-discovery-wire',
-        'RFC-64 current-head query field descriptor could not be inspected',
-        cause,
-      );
+    if (cause instanceof Rfc64CatalogTransportWireUtilityErrorV1) {
+      fail('catalog-discovery-wire', cause.message.replace('RFC-64 wire', 'RFC-64 current-head query'), cause);
     }
-    if (
-      descriptor === undefined
-      || !descriptor.enumerable
-      || !Object.prototype.hasOwnProperty.call(descriptor, 'value')
-    ) {
-      fail(
-        'catalog-discovery-wire',
-        'RFC-64 current-head query fields must be enumerable data properties',
-      );
-    }
-    snapshot[key] = descriptor.value;
+    throw cause;
   }
-  return Object.freeze(snapshot);
 }
 
 function assertCanonicalEvmAddressV1(value: unknown, label: string): asserts value is EvmAddressV1 {
-  if (
-    typeof value !== 'string'
-    || !/^0x[0-9a-f]{40}$/.test(value)
-    || value === '0x0000000000000000000000000000000000000000'
-  ) {
-    fail('catalog-discovery-wire', `${label} must be a canonical lowercase nonzero EVM address`);
+  try {
+    assertRfc64CanonicalEvmAddressV1(value, label);
+  } catch (cause) {
+    fail(
+      'catalog-discovery-wire',
+      `${label} must be a canonical lowercase nonzero EVM address`,
+      cause,
+    );
   }
 }
 
 function snapshotPeerId(value: unknown): string {
-  if (typeof value !== 'string') {
-    fail('catalog-discovery-input', 'remotePeerId must be a string');
+  try {
+    return snapshotRfc64PeerIdV1(value);
+  } catch (cause) {
+    fail(
+      'catalog-discovery-input',
+      cause instanceof Rfc64CatalogTransportWireUtilityErrorV1
+        && cause.reason === 'peer-id-type'
+        ? 'remotePeerId must be a string'
+        : 'remotePeerId is empty, oversized, or noncanonical',
+      cause,
+    );
   }
-  const byteLength = UTF8.encode(value).byteLength;
-  if (byteLength < 1 || byteLength > MAX_PEER_ID_BYTES || value.trim() !== value) {
-    fail('catalog-discovery-input', 'remotePeerId is empty, oversized, or noncanonical');
-  }
-  return value;
 }
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
   const prototype = Object.getPrototypeOf(value);
   return prototype === Object.prototype || prototype === null;
-}
-
-function bytesEqual(left: Uint8Array, right: Uint8Array): boolean {
-  if (left.byteLength !== right.byteLength) return false;
-  for (let index = 0; index < left.byteLength; index += 1) {
-    if (left[index] !== right[index]) return false;
-  }
-  return true;
 }
 
 function throwIfAborted(signal: AbortSignal | undefined): void {

--- a/packages/agent/src/rfc64/public-catalog-current-head-discovery-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-current-head-discovery-v1.ts
@@ -196,7 +196,8 @@ export class Rfc64PublicCatalogCurrentHeadDiscoveryTransportV1 {
     try {
       this.router.register(
         RFC64_PUBLIC_CATALOG_CURRENT_HEAD_DISCOVERY_PROTOCOL_V1,
-        async (data, peerId) => this.handleQuery(data, peerId.toString()),
+        async (data, peerId, handlerOptions) =>
+          this.handleQuery(data, peerId.toString(), handlerOptions?.signal),
         { maxReadBytes: RFC64_PUBLIC_CATALOG_CURRENT_HEAD_QUERY_MAX_BYTES_V1 },
       );
     } catch (cause) {
@@ -237,7 +238,9 @@ export class Rfc64PublicCatalogCurrentHeadDiscoveryTransportV1 {
   private async handleQuery(
     data: Uint8Array,
     remotePeerIdInput: string,
+    signal?: AbortSignal,
   ): Promise<Uint8Array> {
+    throwIfAborted(signal);
     this.requireStarted();
     const remotePeerId = snapshotPeerId(remotePeerIdInput);
     const query = parseQuery(data);
@@ -245,22 +248,27 @@ export class Rfc64PublicCatalogCurrentHeadDiscoveryTransportV1 {
       if (!await this.isOpenPolicy('current-head-discovery-inbound', remotePeerId, query)) {
         return Uint8Array.of(CURRENT_HEAD_DENIED);
       }
+      throwIfAborted(signal);
 
       const currentDigest = await this.readCurrentAppliedCatalogHeadDigest(query);
+      throwIfAborted(signal);
       const announcement = currentDigest === null
         ? null
         : await this.readCurrentAnnouncement(currentDigest, query);
+      throwIfAborted(signal);
 
       // A semantic ref can advance while its immutable object is read. Confirm
       // the pointer immediately before responding so discovery never knowingly
       // advertises a superseded or transient snapshot. One retry admits the
       // common single-writer CAS race while keeping work per request bounded.
       const confirmedDigest = await this.readCurrentAppliedCatalogHeadDigest(query);
+      throwIfAborted(signal);
       if (confirmedDigest !== currentDigest) continue;
 
       if (!await this.isOpenPolicy('current-head-discovery-inbound', remotePeerId, query)) {
         return Uint8Array.of(CURRENT_HEAD_DENIED);
       }
+      throwIfAborted(signal);
       return announcement === null
         ? Uint8Array.of(CURRENT_HEAD_NOT_FOUND)
         : foundResponse(announcement);
@@ -414,28 +422,32 @@ function validateQuery(value: unknown): Rfc64PublicCatalogCurrentHeadQueryV1 {
   if (!isPlainRecord(value)) {
     fail('catalog-discovery-wire', 'RFC-64 current-head query must be a plain object');
   }
-  assertExactWireKeys(value, QUERY_KEYS);
-  if (value.kind !== RFC64_PUBLIC_CATALOG_CURRENT_HEAD_QUERY_KIND_V1) {
+  // Consume caller-owned JavaScript values exactly once through own data
+  // descriptors. Reading fields once for validation and again for assembly
+  // would let a switching Proxy emit bytes that were never validated. It also
+  // avoids invoking accessors that can re-enter policy or lifecycle code.
+  const snapshot = snapshotExactWireRecord(value, QUERY_KEYS);
+  if (snapshot.kind !== RFC64_PUBLIC_CATALOG_CURRENT_HEAD_QUERY_KIND_V1) {
     fail(
       'catalog-discovery-wire',
       `RFC-64 current-head query kind must be ${RFC64_PUBLIC_CATALOG_CURRENT_HEAD_QUERY_KIND_V1}`,
     );
   }
   try {
-    assertNetworkIdV1(value.networkId);
-    assertContextGraphIdV1(value.contextGraphId);
-    if (value.subGraphName !== null) assertSubGraphNameV1(value.subGraphName);
-    assertCanonicalEvmAddressV1(value.authorAddress, 'authorAddress');
-    assertCanonicalDecimalU64(value.catalogEra, 'catalogEra');
-    assertCanonicalDigest(value.policyDigest, 'policyDigest');
+    assertNetworkIdV1(snapshot.networkId);
+    assertContextGraphIdV1(snapshot.contextGraphId);
+    if (snapshot.subGraphName !== null) assertSubGraphNameV1(snapshot.subGraphName);
+    assertCanonicalEvmAddressV1(snapshot.authorAddress, 'authorAddress');
+    assertCanonicalDecimalU64(snapshot.catalogEra, 'catalogEra');
+    assertCanonicalDigest(snapshot.policyDigest, 'policyDigest');
     return Object.freeze({
       kind: RFC64_PUBLIC_CATALOG_CURRENT_HEAD_QUERY_KIND_V1,
-      networkId: value.networkId,
-      contextGraphId: value.contextGraphId,
-      subGraphName: value.subGraphName,
-      authorAddress: value.authorAddress,
-      catalogEra: value.catalogEra,
-      policyDigest: value.policyDigest,
+      networkId: snapshot.networkId,
+      contextGraphId: snapshot.contextGraphId,
+      subGraphName: snapshot.subGraphName,
+      authorAddress: snapshot.authorAddress,
+      catalogEra: snapshot.catalogEra,
+      policyDigest: snapshot.policyDigest,
     });
   } catch (cause) {
     if (cause instanceof Rfc64PublicCatalogCurrentHeadDiscoveryErrorV1) throw cause;
@@ -616,13 +628,54 @@ function assertExactWireKeys(
   value: Record<string, unknown>,
   expectedKeys: readonly string[],
 ): void {
-  const actual = Object.keys(value).sort();
+  void snapshotExactWireRecord(value, expectedKeys);
+}
+
+function snapshotExactWireRecord(
+  value: Record<string, unknown>,
+  expectedKeys: readonly string[],
+): Readonly<Record<string, unknown>> {
+  let ownKeys: readonly PropertyKey[];
+  try {
+    ownKeys = Reflect.ownKeys(value);
+  } catch (cause) {
+    fail('catalog-discovery-wire', 'RFC-64 current-head query fields could not be inspected', cause);
+  }
+  if (ownKeys.some((key) => typeof key !== 'string')) {
+    fail('catalog-discovery-wire', 'RFC-64 current-head query has symbol fields');
+  }
+  const actual = [...ownKeys as readonly string[]].sort();
   if (
     actual.length !== expectedKeys.length
     || actual.some((key, index) => key !== expectedKeys[index])
   ) {
     fail('catalog-discovery-wire', 'RFC-64 current-head query has missing or unknown fields');
   }
+  const snapshot: Record<string, unknown> = Object.create(null);
+  for (const key of expectedKeys) {
+    let descriptor: PropertyDescriptor | undefined;
+    try {
+      descriptor = Object.getOwnPropertyDescriptor(value, key);
+    } catch (cause) {
+      fail(
+        'catalog-discovery-wire',
+        'RFC-64 current-head query field descriptor could not be inspected',
+        cause,
+      );
+    }
+    if (
+      descriptor === undefined
+      || !descriptor.enumerable
+      || !Object.prototype.hasOwnProperty.call(descriptor, 'value')
+    ) {
+      fail(
+        'catalog-discovery-wire',
+        'RFC-64 current-head query fields must be enumerable data properties',
+      );
+    }
+    snapshot[key] = descriptor.value;
+  }
+  return Object.freeze(snapshot);
 }
 
 function assertCanonicalEvmAddressV1(value: unknown, label: string): asserts value is EvmAddressV1 {
@@ -658,6 +711,14 @@ function bytesEqual(left: Uint8Array, right: Uint8Array): boolean {
     if (left[index] !== right[index]) return false;
   }
   return true;
+}
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (!signal?.aborted) return;
+  if (signal.reason instanceof Error) throw signal.reason;
+  throw new Error('RFC-64 current-head discovery request was aborted', {
+    cause: signal.reason,
+  });
 }
 
 function fail(

--- a/packages/agent/src/rfc64/public-catalog-native-reconciler-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-native-reconciler-v1.ts
@@ -16,7 +16,6 @@ import {
   type AuthorCatalogScopeV1,
   type CatalogSealDeploymentProfileV1,
   type CountV1,
-  type ContextGraphPolicyV1,
   type Digest32V1,
   type SignedAuthorCatalogHeadEnvelopeV1,
 } from '@origintrail-official/dkg-core';
@@ -30,18 +29,7 @@ import type {
   Rfc64PublicCatalogReceiverReconcilerV1,
   Rfc64PublicCatalogReconcileResultV1,
 } from './public-catalog-receiver-v1.js';
-import type {
-  Rfc64PublicCatalogHeadAnnouncementV1,
-} from './public-catalog-transport-v1.js';
-
-/** Wire fields that identify one claimed public/open root author-catalog scope. */
-export interface Rfc64PublicOpenCatalogScopeClaimV1 {
-  readonly networkId: Rfc64PublicCatalogHeadAnnouncementV1['networkId'];
-  readonly contextGraphId: Rfc64PublicCatalogHeadAnnouncementV1['contextGraphId'];
-  readonly subGraphName: Rfc64PublicCatalogHeadAnnouncementV1['subGraphName'];
-  readonly authorAddress: Rfc64PublicCatalogHeadAnnouncementV1['authorAddress'];
-  readonly catalogEra: Rfc64PublicCatalogHeadAnnouncementV1['catalogEra'];
-}
+import type { Rfc64PublicCatalogHeadAnnouncementV1 } from './public-catalog-transport-v1.js';
 
 export type Rfc64BoundedPublicRootCatalogNativeReceiverClientV1 = Pick<
   Rfc64PublicCatalogNativeReceiverV1,
@@ -80,45 +68,6 @@ export interface Rfc64BoundedPublicRootCatalogNativeReconcilerOptionsV1 {
    * Optional only for Gate-1 compatibility; a multi-row lane must provide it.
    */
   readonly readStagedCatalogHead?: Rfc64BoundedPublicRootCatalogStagedHeadReaderV1;
-}
-
-/**
- * Derive the one fixed Gate-1 public/open scope from accepted local policy and
- * require the announcement to name that exact owner/network/CG/era/root lane.
- * Policy and signature-variant digests are transport/authentication context,
- * not semantic catalog identity, and therefore do not participate.
- */
-export function deriveRfc64PublicOpenCatalogScopeV1(
-  claim: Rfc64PublicOpenCatalogScopeClaimV1,
-  acceptedPolicy: ContextGraphPolicyV1,
-): AuthorCatalogScopeV1 {
-  if (
-    acceptedPolicy.accessPolicy !== 0
-    || acceptedPolicy.source.kind !== 'owner-signed-unregistered'
-    || acceptedPolicy.networkId !== claim.networkId
-    || acceptedPolicy.contextGraphId !== claim.contextGraphId
-    || acceptedPolicy.governanceChainId !== null
-    || acceptedPolicy.governanceContractAddress !== null
-    || acceptedPolicy.ownershipTransitionDigest !== null
-    || acceptedPolicy.era !== claim.catalogEra
-    || claim.subGraphName !== null
-    || acceptedPolicy.source.ownerAddress !== claim.authorAddress
-  ) {
-    throw new Error(
-      'RFC-64 public/open catalog claim is not bound to the accepted null-governance owner policy',
-    );
-  }
-  return Object.freeze({
-    networkId: acceptedPolicy.networkId,
-    contextGraphId: acceptedPolicy.contextGraphId,
-    governanceChainId: acceptedPolicy.governanceChainId,
-    governanceContractAddress: acceptedPolicy.governanceContractAddress,
-    ownershipTransitionDigest: acceptedPolicy.ownershipTransitionDigest,
-    subGraphName: null,
-    authorAddress: acceptedPolicy.source.ownerAddress,
-    era: acceptedPolicy.era,
-    bucketCount: '1' as CountV1,
-  });
 }
 
 export class Rfc64BoundedPublicRootCatalogNativeReconcilerV1

--- a/packages/agent/src/rfc64/public-catalog-native-reconciler-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-native-reconciler-v1.ts
@@ -34,6 +34,15 @@ import type {
   Rfc64PublicCatalogHeadAnnouncementV1,
 } from './public-catalog-transport-v1.js';
 
+/** Wire fields that identify one claimed public/open root author-catalog scope. */
+export interface Rfc64PublicOpenCatalogScopeClaimV1 {
+  readonly networkId: Rfc64PublicCatalogHeadAnnouncementV1['networkId'];
+  readonly contextGraphId: Rfc64PublicCatalogHeadAnnouncementV1['contextGraphId'];
+  readonly subGraphName: Rfc64PublicCatalogHeadAnnouncementV1['subGraphName'];
+  readonly authorAddress: Rfc64PublicCatalogHeadAnnouncementV1['authorAddress'];
+  readonly catalogEra: Rfc64PublicCatalogHeadAnnouncementV1['catalogEra'];
+}
+
 export type Rfc64BoundedPublicRootCatalogNativeReceiverClientV1 = Pick<
   Rfc64PublicCatalogNativeReceiverV1,
   'synchronizeBoundedPublicRootCatalog'
@@ -80,23 +89,23 @@ export interface Rfc64BoundedPublicRootCatalogNativeReconcilerOptionsV1 {
  * not semantic catalog identity, and therefore do not participate.
  */
 export function deriveRfc64PublicOpenCatalogScopeV1(
-  announcement: Rfc64PublicCatalogHeadAnnouncementV1,
+  claim: Rfc64PublicOpenCatalogScopeClaimV1,
   acceptedPolicy: ContextGraphPolicyV1,
 ): AuthorCatalogScopeV1 {
   if (
     acceptedPolicy.accessPolicy !== 0
     || acceptedPolicy.source.kind !== 'owner-signed-unregistered'
-    || acceptedPolicy.networkId !== announcement.networkId
-    || acceptedPolicy.contextGraphId !== announcement.contextGraphId
+    || acceptedPolicy.networkId !== claim.networkId
+    || acceptedPolicy.contextGraphId !== claim.contextGraphId
     || acceptedPolicy.governanceChainId !== null
     || acceptedPolicy.governanceContractAddress !== null
     || acceptedPolicy.ownershipTransitionDigest !== null
-    || acceptedPolicy.era !== announcement.catalogEra
-    || announcement.subGraphName !== null
-    || acceptedPolicy.source.ownerAddress !== announcement.authorAddress
+    || acceptedPolicy.era !== claim.catalogEra
+    || claim.subGraphName !== null
+    || acceptedPolicy.source.ownerAddress !== claim.authorAddress
   ) {
     throw new Error(
-      'RFC-64 Gate 1 announcement is not bound to the accepted null-governance owner policy',
+      'RFC-64 public/open catalog claim is not bound to the accepted null-governance owner policy',
     );
   }
   return Object.freeze({

--- a/packages/agent/src/rfc64/public-catalog-native-transport-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-native-transport-v1.ts
@@ -24,7 +24,6 @@ import {
   assertSignedControlEnvelope,
   assertSubGraphNameV1,
   canonicalizeSignedControlEnvelopeBytes,
-  computeControlSignatureVariantDigestHex,
   decodeOpaqueKaBundleV1,
   parseCanonicalDecimalU64,
   parseCanonicalSignedControlEnvelope,
@@ -38,7 +37,6 @@ import {
   type SubGraphNameV1,
 } from '@origintrail-official/dkg-core';
 import {
-  readVerifiedControlEnvelopeIssuerSignatureV1,
   type VerifiedControlEnvelopeIssuerSignatureV1,
 } from '@origintrail-official/dkg-chain';
 
@@ -53,6 +51,17 @@ import {
   withCurrentRfc64CatalogPolicyV1,
 } from './catalog-transport-authorization-v1.js';
 import type { Rfc64AuthorizedCatalogWorkResultV1 } from './catalog-transport-authorization-v1.js';
+import {
+  Rfc64CatalogTransportWireUtilityErrorV1,
+  assertRfc64CanonicalEvmAddressV1,
+  assertRfc64ExactIssuerSignatureProofV1,
+  encodeRfc64FlatCanonicalJsonV1,
+  encodeRfc64FoundStatusResponseV1,
+  parseRfc64FlatCanonicalJsonV1,
+  parseRfc64StatusResponsePayloadV1,
+  snapshotRfc64ExactWireRecordV1,
+  snapshotRfc64PeerIdV1,
+} from './catalog-transport-wire-v1-internal.js';
 
 export const RFC64_PUBLIC_CATALOG_OBJECT_FETCH_PROTOCOL_V1 =
   '/dkg/catalog/1/control-object/by-digest' as const;
@@ -112,11 +121,8 @@ export function assertRfc64PublicCatalogExactSetBundleBytesV1(
 }
 
 const FETCH_NOT_FOUND = 0;
-const FETCH_FOUND = 1;
 const FETCH_DENIED = 2;
-const MAX_PEER_ID_BYTES = 256;
 const UTF8 = new TextEncoder();
-const UTF8_FATAL = new TextDecoder('utf-8', { fatal: true, ignoreBOM: true });
 
 const SCOPE_KEYS = Object.freeze([
   'authorAddress',
@@ -496,18 +502,7 @@ export class Rfc64PublicCatalogNativeTransportV1 {
   ): Promise<VerifiedControlEnvelopeIssuerSignatureV1> {
     try {
       const proof = await this.options.verifyIssuerSignature(envelope);
-      const snapshot = readVerifiedControlEnvelopeIssuerSignatureV1(proof);
-      if (
-        snapshot.objectDigest !== envelope.objectDigest
-        || snapshot.signatureVariantDigest !== computeControlSignatureVariantDigestHex(
-          envelope.objectDigest,
-          envelope.signature,
-        )
-        || snapshot.issuer !== envelope.issuer
-        || snapshot.signatureSuite !== envelope.signatureSuite
-      ) {
-        throw new Error('issuer-signature proof identifies another envelope');
-      }
+      assertRfc64ExactIssuerSignatureProofV1(envelope, proof);
       return proof;
     } catch (cause) {
       fail('catalog-native-signature', 'catalog object issuer signature is invalid', cause);
@@ -554,39 +549,39 @@ function parseBundleRequest(input: Uint8Array): Rfc64PublicCatalogBundleFetchReq
 }
 
 function validateObjectRequest(value: unknown): Rfc64PublicCatalogObjectFetchRequestV1 {
-  const scope = validateScope(value, RFC64_PUBLIC_CATALOG_OBJECT_FETCH_KIND_V1);
-  if (!isPlainRecord(value)) throw new Error('unreachable');
-  if (typeof value.targetObjectType !== 'string' || value.targetObjectType.length < 1
-    || UTF8.encode(value.targetObjectType).byteLength > 256) {
+  const snapshot = snapshotExactWireRecord(value, OBJECT_REQUEST_KEYS);
+  const scope = validateScope(snapshot, RFC64_PUBLIC_CATALOG_OBJECT_FETCH_KIND_V1);
+  if (typeof snapshot.targetObjectType !== 'string' || snapshot.targetObjectType.length < 1
+    || UTF8.encode(snapshot.targetObjectType).byteLength > 256) {
     fail('catalog-native-wire', 'targetObjectType is empty or oversized');
   }
   try {
-    assertCanonicalDigest(value.targetObjectDigest, 'targetObjectDigest');
+    assertCanonicalDigest(snapshot.targetObjectDigest, 'targetObjectDigest');
   } catch (cause) {
     fail('catalog-native-wire', 'targetObjectDigest is invalid', cause);
   }
   return Object.freeze({
     ...scope,
     kind: RFC64_PUBLIC_CATALOG_OBJECT_FETCH_KIND_V1,
-    targetObjectType: value.targetObjectType,
-    targetObjectDigest: value.targetObjectDigest,
+    targetObjectType: snapshot.targetObjectType,
+    targetObjectDigest: snapshot.targetObjectDigest,
   }) as Rfc64PublicCatalogObjectFetchRequestV1;
 }
 
 function validateBundleRequest(value: unknown): Rfc64PublicCatalogBundleFetchRequestV1 {
-  const scope = validateScope(value, RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_KIND_V1);
-  if (!isPlainRecord(value)) throw new Error('unreachable');
+  const snapshot = snapshotExactWireRecord(value, BUNDLE_REQUEST_KEYS);
+  const scope = validateScope(snapshot, RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_KIND_V1);
   try {
-    assertCanonicalDigest(value.blobDigest, 'blobDigest');
-    assertCanonicalDecimalU64(value.byteLength, 'byteLength');
+    assertCanonicalDigest(snapshot.blobDigest, 'blobDigest');
+    assertCanonicalDecimalU64(snapshot.byteLength, 'byteLength');
   } catch (cause) {
     fail('catalog-native-wire', 'bundle request contains an invalid digest or length', cause);
   }
   return Object.freeze({
     ...scope,
     kind: RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_KIND_V1,
-    blobDigest: value.blobDigest,
-    byteLength: value.byteLength,
+    blobDigest: snapshot.blobDigest,
+    byteLength: snapshot.byteLength,
   }) as Rfc64PublicCatalogBundleFetchRequestV1;
 }
 
@@ -623,51 +618,58 @@ function validateScope(
 }
 
 function encodeRequest(value: object): Uint8Array {
-  if (!isPlainRecord(value)) {
-    fail('catalog-native-wire', 'catalog native request must be a plain object');
-  }
-  const fields: string[] = [];
-  for (const key of Object.keys(value).sort()) {
-    const field = value[key];
-    if (field !== null && typeof field !== 'string') {
-      fail('catalog-native-wire', 'catalog native requests accept only string or null fields');
+  try {
+    return encodeRfc64FlatCanonicalJsonV1(
+      value,
+      RFC64_PUBLIC_CATALOG_NATIVE_FETCH_REQUEST_MAX_BYTES_V1,
+    );
+  } catch (cause) {
+    if (cause instanceof Rfc64CatalogTransportWireUtilityErrorV1) {
+      if (cause.reason === 'plain-object') {
+        fail('catalog-native-wire', 'catalog native request must be a plain object', cause);
+      }
+      if (cause.reason === 'field-shape') {
+        fail(
+          'catalog-native-wire',
+          'catalog native requests accept only string or null fields',
+          cause,
+        );
+      }
+      if (cause.reason === 'oversized') {
+        fail('catalog-native-wire', 'catalog native request exceeds its byte ceiling', cause);
+      }
     }
-    fields.push(`${JSON.stringify(key)}:${JSON.stringify(field)}`);
+    throw cause;
   }
-  const bytes = UTF8.encode(`{${fields.join(',')}}`);
-  if (bytes.byteLength > RFC64_PUBLIC_CATALOG_NATIVE_FETCH_REQUEST_MAX_BYTES_V1) {
-    fail('catalog-native-wire', 'catalog native request exceeds its byte ceiling');
-  }
-  return bytes;
 }
 
 function parseRequest(input: Uint8Array, expectedKeys: readonly string[]): Record<string, unknown> {
-  if (
-    !(input instanceof Uint8Array)
-    || input.byteLength < 2
-    || input.byteLength > RFC64_PUBLIC_CATALOG_NATIVE_FETCH_REQUEST_MAX_BYTES_V1
-  ) {
-    fail('catalog-native-wire', 'catalog native request is empty or oversized');
-  }
-  let parsed: unknown;
   try {
-    parsed = JSON.parse(UTF8_FATAL.decode(input));
+    return parseRfc64FlatCanonicalJsonV1(
+      input,
+      expectedKeys,
+      RFC64_PUBLIC_CATALOG_NATIVE_FETCH_REQUEST_MAX_BYTES_V1,
+    );
   } catch (cause) {
-    fail('catalog-native-wire', 'catalog native request is not strict UTF-8 JSON', cause);
+    if (cause instanceof Rfc64CatalogTransportWireUtilityErrorV1) {
+      if (cause.reason === 'oversized') {
+        fail('catalog-native-wire', 'catalog native request is empty or oversized', cause);
+      }
+      if (cause.reason === 'strict-json') {
+        fail('catalog-native-wire', 'catalog native request is not strict UTF-8 JSON', cause);
+      }
+      if (cause.reason === 'plain-object') {
+        fail('catalog-native-wire', 'catalog native request must be an object', cause);
+      }
+      if (cause.reason === 'exact-keys') {
+        fail('catalog-native-wire', 'catalog native request has missing or unknown fields', cause);
+      }
+      if (cause.reason === 'noncanonical') {
+        fail('catalog-native-wire', 'catalog native request bytes are not canonical JCS', cause);
+      }
+    }
+    throw cause;
   }
-  if (!isPlainRecord(parsed)) fail('catalog-native-wire', 'catalog native request must be an object');
-  const actual = Object.keys(parsed).sort();
-  if (
-    actual.length !== expectedKeys.length
-    || actual.some((key, index) => key !== expectedKeys[index])
-  ) {
-    fail('catalog-native-wire', 'catalog native request has missing or unknown fields');
-  }
-  const canonical = encodeRequest(parsed);
-  if (!bytesEqual(canonical, input)) {
-    fail('catalog-native-wire', 'catalog native request bytes are not canonical JCS');
-  }
-  return parsed;
 }
 
 function parseCatalogObjectResponse(input: Uint8Array): SignedControlEnvelopeV1 | null {
@@ -696,21 +698,35 @@ function parseBundleResponse(
 }
 
 function responsePayload(input: Uint8Array, maxBytes: number): Uint8Array | null {
-  if (!(input instanceof Uint8Array) || input.byteLength < 1 || input.byteLength > maxBytes) {
-    fail('catalog-native-wire', 'catalog native response is empty or oversized');
+  let framed;
+  try {
+    framed = parseRfc64StatusResponsePayloadV1(input, maxBytes);
+  } catch (cause) {
+    if (
+      cause instanceof Rfc64CatalogTransportWireUtilityErrorV1
+      && cause.reason === 'response-trailing'
+    ) {
+      fail(
+        'catalog-native-wire',
+        input[0] === FETCH_NOT_FOUND
+          ? 'not-found response has trailing bytes'
+          : 'denied response has trailing bytes',
+        cause,
+      );
+    }
+    if (
+      cause instanceof Rfc64CatalogTransportWireUtilityErrorV1
+      && cause.reason === 'response-status'
+    ) {
+      fail('catalog-native-wire', 'catalog native response has an invalid status', cause);
+    }
+    fail('catalog-native-wire', 'catalog native response is empty or oversized', cause);
   }
-  if (input[0] === FETCH_NOT_FOUND) {
-    if (input.byteLength !== 1) fail('catalog-native-wire', 'not-found response has trailing bytes');
-    return null;
-  }
-  if (input[0] === FETCH_DENIED) {
-    if (input.byteLength !== 1) fail('catalog-native-wire', 'denied response has trailing bytes');
+  if (framed.status === 'not-found') return null;
+  if (framed.status === 'denied') {
     fail('catalog-native-policy-denied', 'remote peer denied the catalog native fetch');
   }
-  if (input[0] !== FETCH_FOUND || input.byteLength === 1) {
-    fail('catalog-native-wire', 'catalog native response has an invalid status');
-  }
-  return input.subarray(1);
+  return framed.payload;
 }
 
 function assertCatalogObjectMatchesRequest(
@@ -750,29 +766,41 @@ function assertExactBundle(
 }
 
 function foundResponse(payload: Uint8Array): Uint8Array {
-  const result = new Uint8Array(payload.byteLength + 1);
-  result[0] = FETCH_FOUND;
-  result.set(payload, 1);
-  return result;
+  return encodeRfc64FoundStatusResponseV1(payload);
 }
 
 function assertCanonicalEvmAddress(value: unknown, label: string): asserts value is EvmAddressV1 {
-  if (
-    typeof value !== 'string'
-    || !/^0x[0-9a-f]{40}$/.test(value)
-    || value === '0x0000000000000000000000000000000000000000'
-  ) {
-    fail('catalog-native-wire', `${label} must be a lowercase nonzero EVM address`);
+  try {
+    assertRfc64CanonicalEvmAddressV1(value, label);
+  } catch (cause) {
+    fail('catalog-native-wire', `${label} must be a lowercase nonzero EVM address`, cause);
   }
 }
 
 function snapshotPeerId(value: unknown): string {
-  if (typeof value !== 'string') fail('catalog-native-input', 'remotePeerId must be a string');
-  const byteLength = UTF8.encode(value).byteLength;
-  if (byteLength < 1 || byteLength > MAX_PEER_ID_BYTES || value.trim() !== value) {
-    fail('catalog-native-input', 'remotePeerId is empty, oversized, or noncanonical');
+  try {
+    return snapshotRfc64PeerIdV1(value);
+  } catch (cause) {
+    fail(
+      'catalog-native-input',
+      cause instanceof Rfc64CatalogTransportWireUtilityErrorV1
+        && cause.reason === 'peer-id-type'
+        ? 'remotePeerId must be a string'
+        : 'remotePeerId is empty, oversized, or noncanonical',
+      cause,
+    );
   }
-  return value;
+}
+
+function snapshotExactWireRecord(
+  value: unknown,
+  expectedKeys: readonly string[],
+): Readonly<Record<string, unknown>> {
+  try {
+    return snapshotRfc64ExactWireRecordV1(value, expectedKeys);
+  } catch (cause) {
+    fail('catalog-native-wire', 'catalog native request has missing or unknown fields', cause);
+  }
 }
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {
@@ -785,14 +813,6 @@ function deepFreeze<T>(value: T): T {
   if (typeof value !== 'object' || value === null || Object.isFrozen(value)) return value;
   for (const nested of Object.values(value as Record<string, unknown>)) deepFreeze(nested);
   return Object.freeze(value);
-}
-
-function bytesEqual(left: Uint8Array, right: Uint8Array): boolean {
-  if (left.byteLength !== right.byteLength) return false;
-  for (let index = 0; index < left.byteLength; index += 1) {
-    if (left[index] !== right[index]) return false;
-  }
-  return true;
 }
 
 function fail(

--- a/packages/agent/src/rfc64/public-catalog-native-transport-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-native-transport-v1.ts
@@ -52,15 +52,12 @@ import {
 } from './catalog-transport-authorization-v1.js';
 import type { Rfc64AuthorizedCatalogWorkResultV1 } from './catalog-transport-authorization-v1.js';
 import {
-  Rfc64CatalogTransportWireUtilityErrorV1,
-  assertRfc64CanonicalEvmAddressV1,
   assertRfc64ExactIssuerSignatureProofV1,
-  encodeRfc64FlatCanonicalJsonV1,
+  createRfc64CatalogTransportWireAdapterV1,
   encodeRfc64FoundStatusResponseV1,
-  parseRfc64FlatCanonicalJsonV1,
   parseRfc64StatusResponsePayloadV1,
-  snapshotRfc64ExactWireRecordV1,
-  snapshotRfc64PeerIdV1,
+  rethrowRfc64CatalogTransportWireUtilityErrorV1,
+  type Rfc64CatalogTransportWireAdapterV1,
 } from './catalog-transport-wire-v1-internal.js';
 
 export const RFC64_PUBLIC_CATALOG_OBJECT_FETCH_PROTOCOL_V1 =
@@ -122,6 +119,27 @@ export function assertRfc64PublicCatalogExactSetBundleBytesV1(
 
 const FETCH_NOT_FOUND = 0;
 const FETCH_DENIED = 2;
+
+const NATIVE_WIRE: Rfc64CatalogTransportWireAdapterV1 =
+  createRfc64CatalogTransportWireAdapterV1({
+    fail,
+    wireCode: 'catalog-native-wire',
+    inputCode: 'catalog-native-input',
+    messages: {
+      encodePlainObject: 'catalog native request must be a plain object',
+      encodeFieldShape: 'catalog native requests accept only string or null fields',
+      encodeOversized: () => 'catalog native request exceeds its byte ceiling',
+      parseOversized: 'catalog native request is empty or oversized',
+      parseStrictJson: 'catalog native request is not strict UTF-8 JSON',
+      parsePlainObject: 'catalog native request must be an object',
+      parseExactKeys: 'catalog native request has missing or unknown fields',
+      parseNoncanonical: 'catalog native request bytes are not canonical JCS',
+      snapshot: 'catalog native request has missing or unknown fields',
+      evmAddress: (label) => `${label} must be a lowercase nonzero EVM address`,
+      peerIdType: 'remotePeerId must be a string',
+      peerIdCanonical: 'remotePeerId is empty, oversized, or noncanonical',
+    },
+  });
 const UTF8 = new TextEncoder();
 
 const SCOPE_KEYS = Object.freeze([
@@ -618,58 +636,18 @@ function validateScope(
 }
 
 function encodeRequest(value: object): Uint8Array {
-  try {
-    return encodeRfc64FlatCanonicalJsonV1(
-      value,
-      RFC64_PUBLIC_CATALOG_NATIVE_FETCH_REQUEST_MAX_BYTES_V1,
-    );
-  } catch (cause) {
-    if (cause instanceof Rfc64CatalogTransportWireUtilityErrorV1) {
-      if (cause.reason === 'plain-object') {
-        fail('catalog-native-wire', 'catalog native request must be a plain object', cause);
-      }
-      if (cause.reason === 'field-shape') {
-        fail(
-          'catalog-native-wire',
-          'catalog native requests accept only string or null fields',
-          cause,
-        );
-      }
-      if (cause.reason === 'oversized') {
-        fail('catalog-native-wire', 'catalog native request exceeds its byte ceiling', cause);
-      }
-    }
-    throw cause;
-  }
+  return NATIVE_WIRE.encodeFlatCanonicalJson(
+    value,
+    RFC64_PUBLIC_CATALOG_NATIVE_FETCH_REQUEST_MAX_BYTES_V1,
+  );
 }
 
 function parseRequest(input: Uint8Array, expectedKeys: readonly string[]): Record<string, unknown> {
-  try {
-    return parseRfc64FlatCanonicalJsonV1(
-      input,
-      expectedKeys,
-      RFC64_PUBLIC_CATALOG_NATIVE_FETCH_REQUEST_MAX_BYTES_V1,
-    );
-  } catch (cause) {
-    if (cause instanceof Rfc64CatalogTransportWireUtilityErrorV1) {
-      if (cause.reason === 'oversized') {
-        fail('catalog-native-wire', 'catalog native request is empty or oversized', cause);
-      }
-      if (cause.reason === 'strict-json') {
-        fail('catalog-native-wire', 'catalog native request is not strict UTF-8 JSON', cause);
-      }
-      if (cause.reason === 'plain-object') {
-        fail('catalog-native-wire', 'catalog native request must be an object', cause);
-      }
-      if (cause.reason === 'exact-keys') {
-        fail('catalog-native-wire', 'catalog native request has missing or unknown fields', cause);
-      }
-      if (cause.reason === 'noncanonical') {
-        fail('catalog-native-wire', 'catalog native request bytes are not canonical JCS', cause);
-      }
-    }
-    throw cause;
-  }
+  return NATIVE_WIRE.parseFlatCanonicalJson(
+    input,
+    expectedKeys,
+    RFC64_PUBLIC_CATALOG_NATIVE_FETCH_REQUEST_MAX_BYTES_V1,
+  );
 }
 
 function parseCatalogObjectResponse(input: Uint8Array): SignedControlEnvelopeV1 | null {
@@ -702,25 +680,21 @@ function responsePayload(input: Uint8Array, maxBytes: number): Uint8Array | null
   try {
     framed = parseRfc64StatusResponsePayloadV1(input, maxBytes);
   } catch (cause) {
-    if (
-      cause instanceof Rfc64CatalogTransportWireUtilityErrorV1
-      && cause.reason === 'response-trailing'
-    ) {
-      fail(
-        'catalog-native-wire',
-        input[0] === FETCH_NOT_FOUND
+    rethrowRfc64CatalogTransportWireUtilityErrorV1(cause, fail, {
+      'response-trailing': {
+        code: 'catalog-native-wire',
+        message: input[0] === FETCH_NOT_FOUND
           ? 'not-found response has trailing bytes'
           : 'denied response has trailing bytes',
-        cause,
-      );
-    }
-    if (
-      cause instanceof Rfc64CatalogTransportWireUtilityErrorV1
-      && cause.reason === 'response-status'
-    ) {
-      fail('catalog-native-wire', 'catalog native response has an invalid status', cause);
-    }
-    fail('catalog-native-wire', 'catalog native response is empty or oversized', cause);
+      },
+      'response-status': {
+        code: 'catalog-native-wire',
+        message: 'catalog native response has an invalid status',
+      },
+    }, {
+      code: 'catalog-native-wire',
+      message: 'catalog native response is empty or oversized',
+    });
   }
   if (framed.status === 'not-found') return null;
   if (framed.status === 'denied') {
@@ -770,37 +744,18 @@ function foundResponse(payload: Uint8Array): Uint8Array {
 }
 
 function assertCanonicalEvmAddress(value: unknown, label: string): asserts value is EvmAddressV1 {
-  try {
-    assertRfc64CanonicalEvmAddressV1(value, label);
-  } catch (cause) {
-    fail('catalog-native-wire', `${label} must be a lowercase nonzero EVM address`, cause);
-  }
+  NATIVE_WIRE.assertCanonicalEvmAddress(value, label);
 }
 
 function snapshotPeerId(value: unknown): string {
-  try {
-    return snapshotRfc64PeerIdV1(value);
-  } catch (cause) {
-    fail(
-      'catalog-native-input',
-      cause instanceof Rfc64CatalogTransportWireUtilityErrorV1
-        && cause.reason === 'peer-id-type'
-        ? 'remotePeerId must be a string'
-        : 'remotePeerId is empty, oversized, or noncanonical',
-      cause,
-    );
-  }
+  return NATIVE_WIRE.snapshotPeerId(value);
 }
 
 function snapshotExactWireRecord(
   value: unknown,
   expectedKeys: readonly string[],
 ): Readonly<Record<string, unknown>> {
-  try {
-    return snapshotRfc64ExactWireRecordV1(value, expectedKeys);
-  } catch (cause) {
-    fail('catalog-native-wire', 'catalog native request has missing or unknown fields', cause);
-  }
+  return NATIVE_WIRE.snapshotExactWireRecord(value, expectedKeys);
 }
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/agent/src/rfc64/public-catalog-service-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-service-v1.ts
@@ -84,9 +84,9 @@ import {
   produceDirectAuthorCatalogIssuerDelegationV1,
 } from './public-catalog-issuer-delegation-v1.js';
 import {
-  deriveRfc64PublicOpenCatalogScopeV1,
   type Rfc64BoundedPublicRootCatalogTrustedScopeResolverV1,
 } from './public-catalog-native-reconciler-v1.js';
+import { deriveRfc64PublicOpenCatalogScopeV1 } from './public-open-catalog-scope-v1.js';
 import type {
   Rfc64PublicCatalogIssuerAuthorizationV1,
 } from './public-catalog-successor-producer-v1.js';

--- a/packages/agent/src/rfc64/public-catalog-service-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-service-v1.ts
@@ -271,10 +271,8 @@ export class Rfc64PublicCatalogServiceV1 {
       ? undefined
       : new Rfc64PublicCatalogCurrentHeadDiscoveryTransportV1(options.router, {
         controlObjects: this.#controlObjects,
-        readCurrentAppliedCatalogHeadDigest: (query) =>
-          options.currentHeadDiscovery!.readCurrentAppliedCatalogHeadDigest(
-            this.#resolveTrustedCurrentHeadScope(query),
-          ),
+        readCurrentAppliedCatalogHeadDigest:
+          options.currentHeadDiscovery.readCurrentAppliedCatalogHeadDigest,
         authorizeOpenCatalogOperation: (input) =>
           this.#authorizeCurrentHeadDiscovery(input),
         verifyIssuerSignature: this.#verifyIssuerSignature,
@@ -669,8 +667,9 @@ export class Rfc64PublicCatalogServiceV1 {
   async #authorizeCurrentHeadDiscovery(
     input: Rfc64PublicCatalogCurrentHeadAuthorizationInputV1,
   ): Promise<Rfc64PublicCatalogCurrentHeadAuthorizationV1 | null> {
+    let trustedCatalogScope: Readonly<AuthorCatalogScopeV1>;
     try {
-      this.#resolveTrustedCurrentHeadScope(input);
+      trustedCatalogScope = this.#resolveTrustedCurrentHeadScope(input);
     } catch {
       return null;
     }
@@ -679,6 +678,7 @@ export class Rfc64PublicCatalogServiceV1 {
     return Object.freeze({
       accessPolicy: 0,
       policyDigest: record.policyDigest,
+      trustedCatalogScope,
     });
   }
 

--- a/packages/agent/src/rfc64/public-catalog-service-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-service-v1.ts
@@ -30,7 +30,6 @@ import {
   type SignedControlEnvelopeV1,
   type AuthorCatalogScopeV1,
   type ContextGraphIdV1,
-  type CountV1,
   type Digest32V1,
   type NetworkIdV1,
   type TimestampMsV1,
@@ -85,6 +84,7 @@ import {
   produceDirectAuthorCatalogIssuerDelegationV1,
 } from './public-catalog-issuer-delegation-v1.js';
 import {
+  deriveRfc64PublicOpenCatalogScopeV1,
   type Rfc64BoundedPublicRootCatalogTrustedScopeResolverV1,
 } from './public-catalog-native-reconciler-v1.js';
 import type {
@@ -581,7 +581,7 @@ export class Rfc64PublicCatalogServiceV1 {
       this.#sendOptions(signal),
     );
     if (announcement === null) return null;
-    this.#assertAcceptedOpenAnnouncement(announcement);
+    this.#assertAcceptedCatalogAnnouncement(announcement);
     const currentTrustedScope = this.#resolveTrustedCatalogScope(announcement);
     const head = await this.#transport.fetchCatalogHead(
       remotePeerId,
@@ -713,38 +713,19 @@ export class Rfc64PublicCatalogServiceV1 {
     input: Rfc64PublicCatalogCurrentHeadScopeV1,
   ): Readonly<AuthorCatalogScopeV1> {
     const record = this.#policies.lookup(input.networkId, input.contextGraphId);
-    const policy = record?.policy;
-    if (
-      record === null
-      || policy === undefined
-      || policy.accessPolicy !== 0
-      || policy.source.kind !== 'owner-signed-unregistered'
-      || policy.networkId !== input.networkId
-      || policy.contextGraphId !== input.contextGraphId
-      || policy.governanceChainId !== null
-      || policy.governanceContractAddress !== null
-      || policy.ownershipTransitionDigest !== null
-      || policy.era !== input.catalogEra
-      || input.subGraphName !== null
-      || policy.source.ownerAddress !== input.authorAddress
-    ) {
+    if (record === null) {
       throw new Error(
         'RFC-64 current-head query is not bound to the accepted public/open root policy',
       );
     }
-    const scope = Object.freeze({
-      networkId: policy.networkId,
-      contextGraphId: policy.contextGraphId,
-      governanceChainId: policy.governanceChainId,
-      governanceContractAddress: policy.governanceContractAddress,
-      ownershipTransitionDigest: policy.ownershipTransitionDigest,
-      subGraphName: null,
-      authorAddress: policy.source.ownerAddress,
-      era: policy.era,
-      bucketCount: '1' as CountV1,
-    });
-    assertAuthorCatalogScopeV1(scope);
-    return scope;
+    try {
+      return deriveRfc64PublicOpenCatalogScopeV1(input, record.policy);
+    } catch (cause) {
+      throw new Error(
+        'RFC-64 current-head query is not bound to the accepted public/open root policy',
+        { cause },
+      );
+    }
   }
 
   async #stageHeadOnly(

--- a/packages/agent/src/rfc64/public-catalog-service-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-service-v1.ts
@@ -558,6 +558,12 @@ export class Rfc64PublicCatalogServiceV1 {
     if (discovery === undefined) {
       throw new Error('RFC-64 current-head discovery is not configured');
     }
+    // Detach caller-owned fields before the first await. In particular, the
+    // same immutable peer-id primitive must drive both the hint query and its
+    // exact-head fetch; a mutable object or switching accessor must not rebind
+    // those two halves to different providers.
+    const remotePeerId = input.remotePeerId;
+    const signal = input.signal;
     const trustedScope = this.#resolveTrustedCurrentHeadScope(input.scope);
     const held = this.#policies.lookup(trustedScope.networkId, trustedScope.contextGraphId)!;
     const query: Rfc64PublicCatalogCurrentHeadQueryV1 = Object.freeze({
@@ -570,17 +576,17 @@ export class Rfc64PublicCatalogServiceV1 {
       policyDigest: held.policyDigest,
     });
     const announcement = await discovery.discoverCurrentCatalogHead(
-      input.remotePeerId,
+      remotePeerId,
       query,
-      this.#sendOptions(input.signal),
+      this.#sendOptions(signal),
     );
     if (announcement === null) return null;
     this.#assertAcceptedOpenAnnouncement(announcement);
     const currentTrustedScope = this.#resolveTrustedCatalogScope(announcement);
     const head = await this.#transport.fetchCatalogHead(
-      input.remotePeerId,
+      remotePeerId,
       announcement,
-      this.#sendOptions(input.signal),
+      this.#sendOptions(signal),
     );
     if (head === null) {
       throw new Error('RFC-64 discovered current head is no longer available by exact digest');

--- a/packages/agent/src/rfc64/public-catalog-service-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-service-v1.ts
@@ -30,6 +30,7 @@ import {
   type SignedControlEnvelopeV1,
   type AuthorCatalogScopeV1,
   type ContextGraphIdV1,
+  type CountV1,
   type Digest32V1,
   type NetworkIdV1,
   type TimestampMsV1,
@@ -67,6 +68,14 @@ import {
   type Rfc64PublicCatalogReceiverStatsV1,
 } from './public-catalog-receiver-v1.js';
 import {
+  RFC64_PUBLIC_CATALOG_CURRENT_HEAD_QUERY_KIND_V1,
+  Rfc64PublicCatalogCurrentHeadDiscoveryTransportV1,
+  type Rfc64PublicCatalogCurrentHeadAuthorizationInputV1,
+  type Rfc64PublicCatalogCurrentHeadAuthorizationV1,
+  type Rfc64PublicCatalogCurrentHeadQueryV1,
+  type Rfc64PublicCatalogCurrentHeadScopeV1,
+} from './public-catalog-current-head-discovery-v1.js';
+import {
   Rfc64PublicCatalogNativeTransportV1,
   type Rfc64PublicCatalogNativeAuthorizationInputV1,
   type Rfc64PublicCatalogNativeAuthorizationV1,
@@ -86,6 +95,7 @@ import {
   Rfc64PublicCatalogTransportV1,
   encodeRfc64PublicCatalogHeadAnnouncementV1,
   parseRfc64PublicCatalogHeadAnnouncementV1,
+  type FetchedRfc64PublicCatalogHeadV1,
   type Rfc64PublicCatalogHeadAnnouncementV1,
 } from './public-catalog-transport-v1.js';
 
@@ -104,6 +114,8 @@ export interface Rfc64PublicCatalogServiceOptionsV1 {
   readonly receiver?: Rfc64PublicCatalogReceiverOptionsV1;
   /** Full production native content/reconciliation path. Omission is diagnostic-only. */
   readonly native?: Rfc64PublicCatalogServiceNativeOptionsV1;
+  /** Optional Gate-3 pull-discovery capability; no automatic lifecycle trigger. */
+  readonly currentHeadDiscovery?: Rfc64PublicCatalogServiceCurrentHeadDiscoveryOptionsV1;
   /** Per-peer announce/fetch timeout (ms). */
   readonly transportTimeoutMs?: number;
   /**
@@ -144,6 +156,16 @@ export interface Rfc64PublicCatalogServiceNativeOptionsV1 extends Pick<
   readonly createReconciler: (
     clients: Readonly<Rfc64PublicCatalogReconcilerClientsV1>,
   ) => Rfc64PublicCatalogReceiverReconcilerV1;
+}
+
+export interface Rfc64PublicCatalogServiceCurrentHeadDiscoveryOptionsV1 {
+  /**
+   * Resolve the durable semantically applied head for one locally trusted
+   * public/open root scope. Staged-only and candidate heads must not be returned.
+   */
+  readonly readCurrentAppliedCatalogHeadDigest: (
+    trustedScope: Readonly<AuthorCatalogScopeV1>,
+  ) => Promise<Digest32V1 | null>;
 }
 
 export interface PublishAuthorCatalogGenesisInputV1 {
@@ -194,6 +216,18 @@ export interface AnnounceRfc64PublicCatalogHeadResultV1 {
   readonly failedPeers: ReadonlyArray<{ readonly peerId: string; readonly error: string }>;
 }
 
+export interface DiscoverRfc64PublicCatalogCurrentHeadInputV1 {
+  readonly remotePeerId: string;
+  readonly scope: Rfc64PublicCatalogCurrentHeadScopeV1;
+  readonly signal?: AbortSignal;
+}
+
+/** Verified discovery result. Returning it never stages or activates the head. */
+export interface DiscoveredRfc64PublicCatalogCurrentHeadV1 {
+  readonly announcement: Rfc64PublicCatalogHeadAnnouncementV1;
+  readonly head: FetchedRfc64PublicCatalogHeadV1;
+}
+
 export interface Rfc64PublicCatalogServiceStatsV1 {
   readonly started: boolean;
   readonly acceptedPolicies: number;
@@ -208,6 +242,8 @@ export class Rfc64PublicCatalogServiceV1 {
   readonly #policies: Rfc64CatalogAccessPolicyRegistryV1;
   readonly #receiver: Rfc64PublicCatalogReceiverV1;
   readonly #transport: Rfc64PublicCatalogTransportV1;
+  readonly #currentHeadDiscoveryTransport:
+    Rfc64PublicCatalogCurrentHeadDiscoveryTransportV1 | undefined;
   readonly #nativeTransport: Rfc64PublicCatalogNativeTransportV1 | undefined;
   readonly #transportTimeoutMs: number;
   #started = false;
@@ -230,6 +266,19 @@ export class Rfc64PublicCatalogServiceV1 {
         this.#receiver.schedule(announcement, remotePeerId);
       },
     });
+
+    this.#currentHeadDiscoveryTransport = options.currentHeadDiscovery === undefined
+      ? undefined
+      : new Rfc64PublicCatalogCurrentHeadDiscoveryTransportV1(options.router, {
+        controlObjects: this.#controlObjects,
+        readCurrentAppliedCatalogHeadDigest: (query) =>
+          options.currentHeadDiscovery!.readCurrentAppliedCatalogHeadDigest(
+            this.#resolveTrustedCurrentHeadScope(query),
+          ),
+        authorizeOpenCatalogOperation: (input) =>
+          this.#authorizeCurrentHeadDiscovery(input),
+        verifyIssuerSignature: this.#verifyIssuerSignature,
+      });
 
     this.#nativeTransport = options.native === undefined
       ? undefined
@@ -332,11 +381,13 @@ export class Rfc64PublicCatalogServiceV1 {
     if (this.#started) return;
     this.#nativeTransport?.start();
     try {
+      this.#currentHeadDiscoveryTransport?.start();
       // Register the announcement protocol last so no callback can schedule
-      // reconciliation before the content-fetch protocols are live.
+      // reconciliation before content-fetch and pull-discovery are live.
       this.#transport.start();
       this.#started = true;
     } catch (cause) {
+      this.#currentHeadDiscoveryTransport?.stop();
       this.#nativeTransport?.stop();
       throw cause;
     }
@@ -353,6 +404,7 @@ export class Rfc64PublicCatalogServiceV1 {
       await this.#receiver.close();
     } finally {
       this.#transport.stop();
+      this.#currentHeadDiscoveryTransport?.stop();
       this.#nativeTransport?.stop();
     }
   }
@@ -492,6 +544,58 @@ export class Rfc64PublicCatalogServiceV1 {
     return this.#announceCatalogHeadSnapshot(announcement, peers);
   }
 
+  /**
+   * Pull and authenticate one provider's semantically current public/open head.
+   * The discovery response is treated as a hint: this method exact-fetches the
+   * named signed head, re-verifies it, and binds it to local accepted policy
+   * before returning. It intentionally does not stage, schedule, or activate.
+   */
+  async discoverCurrentCatalogHead(
+    input: DiscoverRfc64PublicCatalogCurrentHeadInputV1,
+  ): Promise<DiscoveredRfc64PublicCatalogCurrentHeadV1 | null> {
+    this.#requireStarted();
+    const discovery = this.#currentHeadDiscoveryTransport;
+    if (discovery === undefined) {
+      throw new Error('RFC-64 current-head discovery is not configured');
+    }
+    const trustedScope = this.#resolveTrustedCurrentHeadScope(input.scope);
+    const held = this.#policies.lookup(trustedScope.networkId, trustedScope.contextGraphId)!;
+    const query: Rfc64PublicCatalogCurrentHeadQueryV1 = Object.freeze({
+      kind: RFC64_PUBLIC_CATALOG_CURRENT_HEAD_QUERY_KIND_V1,
+      networkId: trustedScope.networkId,
+      contextGraphId: trustedScope.contextGraphId,
+      subGraphName: trustedScope.subGraphName,
+      authorAddress: trustedScope.authorAddress,
+      catalogEra: trustedScope.era,
+      policyDigest: held.policyDigest,
+    });
+    const announcement = await discovery.discoverCurrentCatalogHead(
+      input.remotePeerId,
+      query,
+      this.#sendOptions(input.signal),
+    );
+    if (announcement === null) return null;
+    this.#assertAcceptedOpenAnnouncement(announcement);
+    const currentTrustedScope = this.#resolveTrustedCatalogScope(announcement);
+    const head = await this.#transport.fetchCatalogHead(
+      input.remotePeerId,
+      announcement,
+      this.#sendOptions(input.signal),
+    );
+    if (head === null) {
+      throw new Error('RFC-64 discovered current head is no longer available by exact digest');
+    }
+    try {
+      assertAuthorCatalogHeadScopeBindingV1(head.envelope.payload, currentTrustedScope);
+    } catch (cause) {
+      throw new Error(
+        'RFC-64 discovered head differs from the accepted public/open policy scope',
+        { cause },
+      );
+    }
+    return Object.freeze({ announcement, head });
+  }
+
   /** Idle-await the receiver (tests / graceful shutdown coordination). */
   whenReceiverIdle(): Promise<void> {
     return this.#receiver.whenIdle();
@@ -555,6 +659,23 @@ export class Rfc64PublicCatalogServiceV1 {
     }
     return held;
   }
+
+  async #authorizeCurrentHeadDiscovery(
+    input: Rfc64PublicCatalogCurrentHeadAuthorizationInputV1,
+  ): Promise<Rfc64PublicCatalogCurrentHeadAuthorizationV1 | null> {
+    try {
+      this.#resolveTrustedCurrentHeadScope(input);
+    } catch {
+      return null;
+    }
+    const record = this.#policies.lookup(input.networkId, input.contextGraphId);
+    if (record === null || record.policy.accessPolicy !== 0) return null;
+    return Object.freeze({
+      accessPolicy: 0,
+      policyDigest: record.policyDigest,
+    });
+  }
+
   async #authorizeNativeOperation(
     input: Rfc64PublicCatalogNativeAuthorizationInputV1,
   ): Promise<Rfc64PublicCatalogNativeAuthorizationV1 | null> {
@@ -580,6 +701,44 @@ export class Rfc64PublicCatalogServiceV1 {
       era: announcement.catalogEra,
       bucketCount: '1',
     }) as Readonly<AuthorCatalogScopeV1>;
+  }
+
+  #resolveTrustedCurrentHeadScope(
+    input: Rfc64PublicCatalogCurrentHeadScopeV1,
+  ): Readonly<AuthorCatalogScopeV1> {
+    const record = this.#policies.lookup(input.networkId, input.contextGraphId);
+    const policy = record?.policy;
+    if (
+      record === null
+      || policy === undefined
+      || policy.accessPolicy !== 0
+      || policy.source.kind !== 'owner-signed-unregistered'
+      || policy.networkId !== input.networkId
+      || policy.contextGraphId !== input.contextGraphId
+      || policy.governanceChainId !== null
+      || policy.governanceContractAddress !== null
+      || policy.ownershipTransitionDigest !== null
+      || policy.era !== input.catalogEra
+      || input.subGraphName !== null
+      || policy.source.ownerAddress !== input.authorAddress
+    ) {
+      throw new Error(
+        'RFC-64 current-head query is not bound to the accepted public/open root policy',
+      );
+    }
+    const scope = Object.freeze({
+      networkId: policy.networkId,
+      contextGraphId: policy.contextGraphId,
+      governanceChainId: policy.governanceChainId,
+      governanceContractAddress: policy.governanceContractAddress,
+      ownershipTransitionDigest: policy.ownershipTransitionDigest,
+      subGraphName: null,
+      authorAddress: policy.source.ownerAddress,
+      era: policy.era,
+      bucketCount: '1' as CountV1,
+    });
+    assertAuthorCatalogScopeV1(scope);
+    return scope;
   }
 
   async #stageHeadOnly(

--- a/packages/agent/src/rfc64/public-catalog-transport-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-transport-v1.ts
@@ -21,7 +21,6 @@ import {
   type SubGraphNameV1,
 } from '@origintrail-official/dkg-core';
 import {
-  readVerifiedControlEnvelopeIssuerSignatureV1,
   type VerifiedControlEnvelopeIssuerSignatureV1,
 } from '@origintrail-official/dkg-chain';
 
@@ -36,6 +35,17 @@ import {
   withCurrentRfc64CatalogPolicyV1,
 } from './catalog-transport-authorization-v1.js';
 import type { Rfc64AuthorizedCatalogWorkResultV1 } from './catalog-transport-authorization-v1.js';
+import {
+  Rfc64CatalogTransportWireUtilityErrorV1,
+  assertRfc64CanonicalEvmAddressV1,
+  assertRfc64ExactIssuerSignatureProofV1,
+  encodeRfc64FlatCanonicalJsonV1,
+  encodeRfc64FoundStatusResponseV1,
+  parseRfc64FlatCanonicalJsonV1,
+  parseRfc64StatusResponsePayloadV1,
+  snapshotRfc64ExactWireRecordV1,
+  snapshotRfc64PeerIdV1,
+} from './catalog-transport-wire-v1-internal.js';
 
 /**
  * Additive RFC-64 protocol IDs. Their `/catalog/1` component is the wire
@@ -59,12 +69,7 @@ export const RFC64_PUBLIC_CATALOG_HEAD_FETCH_RESPONSE_MAX_BYTES_V1 = 32 * 1024;
 const ACK = Uint8Array.of(1);
 const ANNOUNCEMENT_DENIED = 0;
 const FETCH_NOT_FOUND = 0;
-const FETCH_FOUND = 1;
 const FETCH_DENIED = 2;
-const MAX_PEER_ID_BYTES = 256;
-const UTF8 = new TextEncoder();
-// Keep a leading BOM visible so canonical re-encoding rejects it.
-const UTF8_FATAL = new TextDecoder('utf-8', { fatal: true, ignoreBOM: true });
 
 const ANNOUNCEMENT_KEYS = Object.freeze([
   'authorAddress',
@@ -368,13 +373,14 @@ export class Rfc64PublicCatalogTransportV1 {
           );
         }
         const envelopeBytes = canonicalizeSignedAuthorCatalogHeadEnvelopeBytesV1(envelope);
-        const response = new Uint8Array(1 + envelopeBytes.byteLength);
-        response[0] = FETCH_FOUND;
-        response.set(envelopeBytes, 1);
-        if (response.byteLength > RFC64_PUBLIC_CATALOG_HEAD_FETCH_RESPONSE_MAX_BYTES_V1) {
+        try {
+          return encodeRfc64FoundStatusResponseV1(
+            envelopeBytes,
+            RFC64_PUBLIC_CATALOG_HEAD_FETCH_RESPONSE_MAX_BYTES_V1,
+          );
+        } catch (cause) {
           fail('catalog-transport-wire', 'author-catalog head exceeds the v1 fetch response cap');
         }
-        return response;
       },
     );
     if (!served.authorized) {
@@ -555,33 +561,36 @@ function validateWireScope<Kind extends
   if (!isPlainRecord(value)) {
     fail('catalog-transport-wire', 'RFC-64 catalog message must be a plain object');
   }
-  assertExactWireKeys(value, expectedKind === RFC64_PUBLIC_CATALOG_HEAD_ANNOUNCEMENT_KIND_V1
+  const snapshot = snapshotExactWireRecord(
+    value,
+    expectedKind === RFC64_PUBLIC_CATALOG_HEAD_ANNOUNCEMENT_KIND_V1
     ? ANNOUNCEMENT_KEYS
-    : FETCH_REQUEST_KEYS);
-  if (value.kind !== expectedKind) {
+    : FETCH_REQUEST_KEYS,
+  );
+  if (snapshot.kind !== expectedKind) {
     fail('catalog-transport-wire', `RFC-64 catalog message kind must be ${expectedKind}`);
   }
   try {
-    assertNetworkIdV1(value.networkId);
-    assertContextGraphIdV1(value.contextGraphId);
-    if (value.subGraphName !== null) assertSubGraphNameV1(value.subGraphName);
-    assertCanonicalEvmAddressV1(value.authorAddress, 'authorAddress');
-    assertCanonicalDecimalU64(value.catalogEra, 'catalogEra');
-    assertCanonicalDecimalU64(value.catalogVersion, 'catalogVersion');
-    assertCanonicalDigest(value.policyDigest, 'policyDigest');
-    assertCanonicalDigest(value.catalogHeadObjectDigest, 'catalogHeadObjectDigest');
-    assertCanonicalDigest(value.signatureVariantDigest, 'signatureVariantDigest');
+    assertNetworkIdV1(snapshot.networkId);
+    assertContextGraphIdV1(snapshot.contextGraphId);
+    if (snapshot.subGraphName !== null) assertSubGraphNameV1(snapshot.subGraphName);
+    assertCanonicalEvmAddressV1(snapshot.authorAddress, 'authorAddress');
+    assertCanonicalDecimalU64(snapshot.catalogEra, 'catalogEra');
+    assertCanonicalDecimalU64(snapshot.catalogVersion, 'catalogVersion');
+    assertCanonicalDigest(snapshot.policyDigest, 'policyDigest');
+    assertCanonicalDigest(snapshot.catalogHeadObjectDigest, 'catalogHeadObjectDigest');
+    assertCanonicalDigest(snapshot.signatureVariantDigest, 'signatureVariantDigest');
     return Object.freeze({
-      authorAddress: value.authorAddress,
-      catalogEra: value.catalogEra,
-      catalogHeadObjectDigest: value.catalogHeadObjectDigest,
-      catalogVersion: value.catalogVersion,
-      contextGraphId: value.contextGraphId,
+      authorAddress: snapshot.authorAddress,
+      catalogEra: snapshot.catalogEra,
+      catalogHeadObjectDigest: snapshot.catalogHeadObjectDigest,
+      catalogVersion: snapshot.catalogVersion,
+      contextGraphId: snapshot.contextGraphId,
       kind: expectedKind,
-      networkId: value.networkId,
-      policyDigest: value.policyDigest,
-      signatureVariantDigest: value.signatureVariantDigest,
-      subGraphName: value.subGraphName,
+      networkId: snapshot.networkId,
+      policyDigest: snapshot.policyDigest,
+      signatureVariantDigest: snapshot.signatureVariantDigest,
+      subGraphName: snapshot.subGraphName,
     }) as never;
   } catch (cause) {
     if (cause instanceof Rfc64PublicCatalogTransportErrorV1) throw cause;
@@ -590,29 +599,39 @@ function validateWireScope<Kind extends
 }
 
 function parseFetchResponse(input: Uint8Array): SignedAuthorCatalogHeadEnvelopeV1 | null {
-  if (
-    input.byteLength < 1
-    || input.byteLength > RFC64_PUBLIC_CATALOG_HEAD_FETCH_RESPONSE_MAX_BYTES_V1
-  ) {
-    fail('catalog-transport-wire', 'author-catalog head response is empty or oversized');
-  }
-  if (input[0] === FETCH_NOT_FOUND) {
-    if (input.byteLength !== 1) {
-      fail('catalog-transport-wire', 'not-found author-catalog response has trailing bytes');
+  let framed;
+  try {
+    framed = parseRfc64StatusResponsePayloadV1(
+      input,
+      RFC64_PUBLIC_CATALOG_HEAD_FETCH_RESPONSE_MAX_BYTES_V1,
+    );
+  } catch (cause) {
+    if (
+      cause instanceof Rfc64CatalogTransportWireUtilityErrorV1
+      && cause.reason === 'response-trailing'
+    ) {
+      fail(
+        'catalog-transport-wire',
+        input[0] === FETCH_NOT_FOUND
+          ? 'not-found author-catalog response has trailing bytes'
+          : 'denied author-catalog response has trailing bytes',
+        cause,
+      );
     }
-    return null;
-  }
-  if (input[0] === FETCH_DENIED) {
-    if (input.byteLength !== 1) {
-      fail('catalog-transport-wire', 'denied author-catalog response has trailing bytes');
+    if (
+      cause instanceof Rfc64CatalogTransportWireUtilityErrorV1
+      && cause.reason === 'response-status'
+    ) {
+      fail('catalog-transport-wire', 'author-catalog head response has an invalid status', cause);
     }
+    fail('catalog-transport-wire', 'author-catalog head response is empty or oversized', cause);
+  }
+  if (framed.status === 'not-found') return null;
+  if (framed.status === 'denied') {
     fail('catalog-transport-policy-denied', 'remote peer denied the author-catalog fetch');
   }
-  if (input[0] !== FETCH_FOUND || input.byteLength === 1) {
-    fail('catalog-transport-wire', 'author-catalog head response has an invalid status');
-  }
   try {
-    return parseCanonicalSignedAuthorCatalogHeadEnvelopeV1(input.subarray(1), {
+    return parseCanonicalSignedAuthorCatalogHeadEnvelopeV1(framed.payload, {
       maxBytes: RFC64_PUBLIC_CATALOG_HEAD_FETCH_RESPONSE_MAX_BYTES_V1 - 1,
     });
   } catch (cause) {
@@ -671,23 +690,17 @@ function assertExactIssuerSignatureProof(
   envelope: SignedControlEnvelopeV1,
   proof: VerifiedControlEnvelopeIssuerSignatureV1,
 ): void {
-  let snapshot;
   try {
-    snapshot = readVerifiedControlEnvelopeIssuerSignatureV1(proof);
+    assertRfc64ExactIssuerSignatureProofV1(envelope, proof);
   } catch (cause) {
-    fail('catalog-transport-signature', 'issuer signature proof was not minted by the verifier', cause);
-  }
-  const expectedVariant = computeControlSignatureVariantDigestHex(
-    envelope.objectDigest,
-    envelope.signature,
-  );
-  if (
-    snapshot.objectDigest !== envelope.objectDigest
-    || snapshot.signatureVariantDigest !== expectedVariant
-    || snapshot.issuer !== envelope.issuer
-    || snapshot.signatureSuite !== envelope.signatureSuite
-  ) {
-    fail('catalog-transport-signature', 'issuer signature proof is not bound to the exact envelope');
+    fail(
+      'catalog-transport-signature',
+      cause instanceof Rfc64CatalogTransportWireUtilityErrorV1
+        && cause.reason === 'issuer-proof-unminted'
+        ? 'issuer signature proof was not minted by the verifier'
+        : 'issuer signature proof is not bound to the exact envelope',
+      cause,
+    );
   }
 }
 
@@ -695,23 +708,26 @@ function encodeFlatCanonicalJson(
   value: object,
   maxBytes: number,
 ): Uint8Array {
-  if (!isPlainRecord(value)) {
-    fail('catalog-transport-wire', 'RFC-64 catalog message must be a plain object');
-  }
-  const keys = Object.keys(value).sort();
-  const fields: string[] = [];
-  for (const key of keys) {
-    const field = value[key];
-    if (field !== null && typeof field !== 'string') {
-      fail('catalog-transport-wire', 'RFC-64 catalog messages accept only string or null fields');
+  try {
+    return encodeRfc64FlatCanonicalJsonV1(value, maxBytes);
+  } catch (cause) {
+    if (cause instanceof Rfc64CatalogTransportWireUtilityErrorV1) {
+      if (cause.reason === 'plain-object') {
+        fail('catalog-transport-wire', 'RFC-64 catalog message must be a plain object', cause);
+      }
+      if (cause.reason === 'field-shape') {
+        fail(
+          'catalog-transport-wire',
+          'RFC-64 catalog messages accept only string or null fields',
+          cause,
+        );
+      }
+      if (cause.reason === 'oversized') {
+        fail('catalog-transport-wire', `RFC-64 catalog message exceeds ${maxBytes} bytes`, cause);
+      }
     }
-    fields.push(`${JSON.stringify(key)}:${JSON.stringify(field)}`);
+    throw cause;
   }
-  const bytes = UTF8.encode(`{${fields.join(',')}}`);
-  if (bytes.byteLength > maxBytes) {
-    fail('catalog-transport-wire', `RFC-64 catalog message exceeds ${maxBytes} bytes`);
-  }
-  return bytes;
 }
 
 function parseFlatCanonicalJson(
@@ -719,74 +735,72 @@ function parseFlatCanonicalJson(
   expectedKeys: readonly string[],
   maxBytes: number,
 ): Record<string, unknown> {
-  if (!(input instanceof Uint8Array) || input.byteLength < 2 || input.byteLength > maxBytes) {
-    fail('catalog-transport-wire', 'RFC-64 catalog message is empty or oversized');
-  }
-  let text: string;
-  let parsed: unknown;
   try {
-    text = UTF8_FATAL.decode(input);
-    parsed = JSON.parse(text);
+    return parseRfc64FlatCanonicalJsonV1(input, expectedKeys, maxBytes);
   } catch (cause) {
-    fail('catalog-transport-wire', 'RFC-64 catalog message is not strict UTF-8 JSON', cause);
+    if (cause instanceof Rfc64CatalogTransportWireUtilityErrorV1) {
+      if (cause.reason === 'oversized') {
+        fail('catalog-transport-wire', 'RFC-64 catalog message is empty or oversized', cause);
+      }
+      if (cause.reason === 'strict-json') {
+        fail('catalog-transport-wire', 'RFC-64 catalog message is not strict UTF-8 JSON', cause);
+      }
+      if (cause.reason === 'plain-object') {
+        fail('catalog-transport-wire', 'RFC-64 catalog message must be a plain JSON object', cause);
+      }
+      if (cause.reason === 'exact-keys') {
+        fail('catalog-transport-wire', 'RFC-64 catalog message has missing or unknown fields', cause);
+      }
+      if (cause.reason === 'noncanonical') {
+        fail('catalog-transport-wire', 'RFC-64 catalog message bytes are not canonical JCS', cause);
+      }
+    }
+    throw cause;
   }
-  if (!isPlainRecord(parsed)) {
-    fail('catalog-transport-wire', 'RFC-64 catalog message must be a plain JSON object');
-  }
-  assertExactWireKeys(parsed, expectedKeys);
-  const canonical = encodeFlatCanonicalJson(parsed, maxBytes);
-  if (!bytesEqual(canonical, input)) {
-    fail('catalog-transport-wire', 'RFC-64 catalog message bytes are not canonical JCS');
-  }
-  return parsed;
 }
 
-function assertExactWireKeys(
-  value: Record<string, unknown>,
+function snapshotExactWireRecord(
+  value: unknown,
   expectedKeys: readonly string[],
-): void {
-  const actual = Object.keys(value).sort();
-  if (
-    actual.length !== expectedKeys.length
-    || actual.some((key, index) => key !== expectedKeys[index])
-  ) {
-    fail('catalog-transport-wire', 'RFC-64 catalog message has missing or unknown fields');
+): Readonly<Record<string, unknown>> {
+  try {
+    return snapshotRfc64ExactWireRecordV1(value, expectedKeys);
+  } catch (cause) {
+    fail('catalog-transport-wire', 'RFC-64 catalog message has missing or unknown fields', cause);
   }
 }
 
 function assertCanonicalEvmAddressV1(value: unknown, label: string): asserts value is EvmAddressV1 {
-  if (
-    typeof value !== 'string'
-    || !/^0x[0-9a-f]{40}$/.test(value)
-    || value === '0x0000000000000000000000000000000000000000'
-  ) {
-    fail('catalog-transport-wire', `${label} must be a canonical lowercase nonzero EVM address`);
+  try {
+    assertRfc64CanonicalEvmAddressV1(value, label);
+  } catch (cause) {
+    fail(
+      'catalog-transport-wire',
+      `${label} must be a canonical lowercase nonzero EVM address`,
+      cause,
+    );
   }
 }
 
 function snapshotPeerId(value: unknown): string {
-  if (typeof value !== 'string') {
-    fail('catalog-transport-input', 'remotePeerId must be a string');
+  try {
+    return snapshotRfc64PeerIdV1(value);
+  } catch (cause) {
+    fail(
+      'catalog-transport-input',
+      cause instanceof Rfc64CatalogTransportWireUtilityErrorV1
+        && cause.reason === 'peer-id-type'
+        ? 'remotePeerId must be a string'
+        : 'remotePeerId is empty, oversized, or noncanonical',
+      cause,
+    );
   }
-  const byteLength = UTF8.encode(value).byteLength;
-  if (byteLength < 1 || byteLength > MAX_PEER_ID_BYTES || value.trim() !== value) {
-    fail('catalog-transport-input', 'remotePeerId is empty, oversized, or noncanonical');
-  }
-  return value;
 }
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
   const prototype = Object.getPrototypeOf(value);
   return prototype === Object.prototype || prototype === null;
-}
-
-function bytesEqual(left: Uint8Array, right: Uint8Array): boolean {
-  if (left.byteLength !== right.byteLength) return false;
-  for (let index = 0; index < left.byteLength; index += 1) {
-    if (left[index] !== right[index]) return false;
-  }
-  return true;
 }
 
 function deepFreeze<T>(value: T): T {

--- a/packages/agent/src/rfc64/public-catalog-transport-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-transport-v1.ts
@@ -36,15 +36,12 @@ import {
 } from './catalog-transport-authorization-v1.js';
 import type { Rfc64AuthorizedCatalogWorkResultV1 } from './catalog-transport-authorization-v1.js';
 import {
-  Rfc64CatalogTransportWireUtilityErrorV1,
-  assertRfc64CanonicalEvmAddressV1,
   assertRfc64ExactIssuerSignatureProofV1,
-  encodeRfc64FlatCanonicalJsonV1,
+  createRfc64CatalogTransportWireAdapterV1,
   encodeRfc64FoundStatusResponseV1,
-  parseRfc64FlatCanonicalJsonV1,
   parseRfc64StatusResponsePayloadV1,
-  snapshotRfc64ExactWireRecordV1,
-  snapshotRfc64PeerIdV1,
+  rethrowRfc64CatalogTransportWireUtilityErrorV1,
+  type Rfc64CatalogTransportWireAdapterV1,
 } from './catalog-transport-wire-v1-internal.js';
 
 /**
@@ -70,6 +67,27 @@ const ACK = Uint8Array.of(1);
 const ANNOUNCEMENT_DENIED = 0;
 const FETCH_NOT_FOUND = 0;
 const FETCH_DENIED = 2;
+
+const CATALOG_WIRE: Rfc64CatalogTransportWireAdapterV1 =
+  createRfc64CatalogTransportWireAdapterV1({
+    fail,
+    wireCode: 'catalog-transport-wire',
+    inputCode: 'catalog-transport-input',
+    messages: {
+      encodePlainObject: 'RFC-64 catalog message must be a plain object',
+      encodeFieldShape: 'RFC-64 catalog messages accept only string or null fields',
+      encodeOversized: (maxBytes) => `RFC-64 catalog message exceeds ${maxBytes} bytes`,
+      parseOversized: 'RFC-64 catalog message is empty or oversized',
+      parseStrictJson: 'RFC-64 catalog message is not strict UTF-8 JSON',
+      parsePlainObject: 'RFC-64 catalog message must be a plain JSON object',
+      parseExactKeys: 'RFC-64 catalog message has missing or unknown fields',
+      parseNoncanonical: 'RFC-64 catalog message bytes are not canonical JCS',
+      snapshot: 'RFC-64 catalog message has missing or unknown fields',
+      evmAddress: (label) => `${label} must be a canonical lowercase nonzero EVM address`,
+      peerIdType: 'remotePeerId must be a string',
+      peerIdCanonical: 'remotePeerId is empty, oversized, or noncanonical',
+    },
+  });
 
 const ANNOUNCEMENT_KEYS = Object.freeze([
   'authorAddress',
@@ -606,25 +624,21 @@ function parseFetchResponse(input: Uint8Array): SignedAuthorCatalogHeadEnvelopeV
       RFC64_PUBLIC_CATALOG_HEAD_FETCH_RESPONSE_MAX_BYTES_V1,
     );
   } catch (cause) {
-    if (
-      cause instanceof Rfc64CatalogTransportWireUtilityErrorV1
-      && cause.reason === 'response-trailing'
-    ) {
-      fail(
-        'catalog-transport-wire',
-        input[0] === FETCH_NOT_FOUND
+    rethrowRfc64CatalogTransportWireUtilityErrorV1(cause, fail, {
+      'response-trailing': {
+        code: 'catalog-transport-wire',
+        message: input[0] === FETCH_NOT_FOUND
           ? 'not-found author-catalog response has trailing bytes'
           : 'denied author-catalog response has trailing bytes',
-        cause,
-      );
-    }
-    if (
-      cause instanceof Rfc64CatalogTransportWireUtilityErrorV1
-      && cause.reason === 'response-status'
-    ) {
-      fail('catalog-transport-wire', 'author-catalog head response has an invalid status', cause);
-    }
-    fail('catalog-transport-wire', 'author-catalog head response is empty or oversized', cause);
+      },
+      'response-status': {
+        code: 'catalog-transport-wire',
+        message: 'author-catalog head response has an invalid status',
+      },
+    }, {
+      code: 'catalog-transport-wire',
+      message: 'author-catalog head response is empty or oversized',
+    });
   }
   if (framed.status === 'not-found') return null;
   if (framed.status === 'denied') {
@@ -693,14 +707,15 @@ function assertExactIssuerSignatureProof(
   try {
     assertRfc64ExactIssuerSignatureProofV1(envelope, proof);
   } catch (cause) {
-    fail(
-      'catalog-transport-signature',
-      cause instanceof Rfc64CatalogTransportWireUtilityErrorV1
-        && cause.reason === 'issuer-proof-unminted'
-        ? 'issuer signature proof was not minted by the verifier'
-        : 'issuer signature proof is not bound to the exact envelope',
-      cause,
-    );
+    rethrowRfc64CatalogTransportWireUtilityErrorV1(cause, fail, {
+      'issuer-proof-unminted': {
+        code: 'catalog-transport-signature',
+        message: 'issuer signature proof was not minted by the verifier',
+      },
+    }, {
+      code: 'catalog-transport-signature',
+      message: 'issuer signature proof is not bound to the exact envelope',
+    });
   }
 }
 
@@ -708,26 +723,7 @@ function encodeFlatCanonicalJson(
   value: object,
   maxBytes: number,
 ): Uint8Array {
-  try {
-    return encodeRfc64FlatCanonicalJsonV1(value, maxBytes);
-  } catch (cause) {
-    if (cause instanceof Rfc64CatalogTransportWireUtilityErrorV1) {
-      if (cause.reason === 'plain-object') {
-        fail('catalog-transport-wire', 'RFC-64 catalog message must be a plain object', cause);
-      }
-      if (cause.reason === 'field-shape') {
-        fail(
-          'catalog-transport-wire',
-          'RFC-64 catalog messages accept only string or null fields',
-          cause,
-        );
-      }
-      if (cause.reason === 'oversized') {
-        fail('catalog-transport-wire', `RFC-64 catalog message exceeds ${maxBytes} bytes`, cause);
-      }
-    }
-    throw cause;
-  }
+  return CATALOG_WIRE.encodeFlatCanonicalJson(value, maxBytes);
 }
 
 function parseFlatCanonicalJson(
@@ -735,66 +731,22 @@ function parseFlatCanonicalJson(
   expectedKeys: readonly string[],
   maxBytes: number,
 ): Record<string, unknown> {
-  try {
-    return parseRfc64FlatCanonicalJsonV1(input, expectedKeys, maxBytes);
-  } catch (cause) {
-    if (cause instanceof Rfc64CatalogTransportWireUtilityErrorV1) {
-      if (cause.reason === 'oversized') {
-        fail('catalog-transport-wire', 'RFC-64 catalog message is empty or oversized', cause);
-      }
-      if (cause.reason === 'strict-json') {
-        fail('catalog-transport-wire', 'RFC-64 catalog message is not strict UTF-8 JSON', cause);
-      }
-      if (cause.reason === 'plain-object') {
-        fail('catalog-transport-wire', 'RFC-64 catalog message must be a plain JSON object', cause);
-      }
-      if (cause.reason === 'exact-keys') {
-        fail('catalog-transport-wire', 'RFC-64 catalog message has missing or unknown fields', cause);
-      }
-      if (cause.reason === 'noncanonical') {
-        fail('catalog-transport-wire', 'RFC-64 catalog message bytes are not canonical JCS', cause);
-      }
-    }
-    throw cause;
-  }
+  return CATALOG_WIRE.parseFlatCanonicalJson(input, expectedKeys, maxBytes);
 }
 
 function snapshotExactWireRecord(
   value: unknown,
   expectedKeys: readonly string[],
 ): Readonly<Record<string, unknown>> {
-  try {
-    return snapshotRfc64ExactWireRecordV1(value, expectedKeys);
-  } catch (cause) {
-    fail('catalog-transport-wire', 'RFC-64 catalog message has missing or unknown fields', cause);
-  }
+  return CATALOG_WIRE.snapshotExactWireRecord(value, expectedKeys);
 }
 
 function assertCanonicalEvmAddressV1(value: unknown, label: string): asserts value is EvmAddressV1 {
-  try {
-    assertRfc64CanonicalEvmAddressV1(value, label);
-  } catch (cause) {
-    fail(
-      'catalog-transport-wire',
-      `${label} must be a canonical lowercase nonzero EVM address`,
-      cause,
-    );
-  }
+  CATALOG_WIRE.assertCanonicalEvmAddress(value, label);
 }
 
 function snapshotPeerId(value: unknown): string {
-  try {
-    return snapshotRfc64PeerIdV1(value);
-  } catch (cause) {
-    fail(
-      'catalog-transport-input',
-      cause instanceof Rfc64CatalogTransportWireUtilityErrorV1
-        && cause.reason === 'peer-id-type'
-        ? 'remotePeerId must be a string'
-        : 'remotePeerId is empty, oversized, or noncanonical',
-      cause,
-    );
-  }
+  return CATALOG_WIRE.snapshotPeerId(value);
 }
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/agent/src/rfc64/public-open-catalog-scope-v1.ts
+++ b/packages/agent/src/rfc64/public-open-catalog-scope-v1.ts
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Shared policy primitive for the RFC-64 public/open root author-catalog lane.
+ *
+ * This module deliberately sits below transport, service, and reconciliation:
+ * each caller derives catalog authority from independently accepted local
+ * policy state rather than reconstructing it from peer-controlled wire data.
+ */
+
+import {
+  type AuthorCatalogScopeV1,
+  type ContextGraphPolicyV1,
+  type CountV1,
+} from '@origintrail-official/dkg-core';
+
+import type {
+  Rfc64PublicCatalogHeadAnnouncementV1,
+} from './public-catalog-transport-v1.js';
+
+/** Wire fields that identify one claimed public/open root author-catalog scope. */
+export interface Rfc64PublicOpenCatalogScopeClaimV1 {
+  readonly networkId: Rfc64PublicCatalogHeadAnnouncementV1['networkId'];
+  readonly contextGraphId: Rfc64PublicCatalogHeadAnnouncementV1['contextGraphId'];
+  readonly subGraphName: Rfc64PublicCatalogHeadAnnouncementV1['subGraphName'];
+  readonly authorAddress: Rfc64PublicCatalogHeadAnnouncementV1['authorAddress'];
+  readonly catalogEra: Rfc64PublicCatalogHeadAnnouncementV1['catalogEra'];
+}
+
+/**
+ * Derive the one fixed Gate-1 public/open scope from accepted local policy and
+ * require the peer claim to name that exact owner/network/CG/era/root lane.
+ * Policy and signature-variant digests are transport/authentication context,
+ * not semantic catalog identity, and therefore do not participate.
+ */
+export function deriveRfc64PublicOpenCatalogScopeV1(
+  claim: Rfc64PublicOpenCatalogScopeClaimV1,
+  acceptedPolicy: ContextGraphPolicyV1,
+): AuthorCatalogScopeV1 {
+  if (
+    acceptedPolicy.accessPolicy !== 0
+    || acceptedPolicy.source.kind !== 'owner-signed-unregistered'
+    || acceptedPolicy.networkId !== claim.networkId
+    || acceptedPolicy.contextGraphId !== claim.contextGraphId
+    || acceptedPolicy.governanceChainId !== null
+    || acceptedPolicy.governanceContractAddress !== null
+    || acceptedPolicy.ownershipTransitionDigest !== null
+    || acceptedPolicy.era !== claim.catalogEra
+    || claim.subGraphName !== null
+    || acceptedPolicy.source.ownerAddress !== claim.authorAddress
+  ) {
+    throw new Error(
+      'RFC-64 public/open catalog claim is not bound to the accepted null-governance owner policy',
+    );
+  }
+  return Object.freeze({
+    networkId: acceptedPolicy.networkId,
+    contextGraphId: acceptedPolicy.contextGraphId,
+    governanceChainId: acceptedPolicy.governanceChainId,
+    governanceContractAddress: acceptedPolicy.governanceContractAddress,
+    ownershipTransitionDigest: acceptedPolicy.ownershipTransitionDigest,
+    subGraphName: null,
+    authorAddress: acceptedPolicy.source.ownerAddress,
+    era: acceptedPolicy.era,
+    bucketCount: '1' as CountV1,
+  });
+}

--- a/packages/agent/src/rfc64/public-open-catalog-scope-v1.ts
+++ b/packages/agent/src/rfc64/public-open-catalog-scope-v1.ts
@@ -10,21 +10,22 @@
 
 import {
   type AuthorCatalogScopeV1,
+  type ContextGraphIdV1,
   type ContextGraphPolicyV1,
   type CountV1,
+  type DecimalU64V1,
+  type EvmAddressV1,
+  type NetworkIdV1,
+  type SubGraphNameV1,
 } from '@origintrail-official/dkg-core';
 
-import type {
-  Rfc64PublicCatalogHeadAnnouncementV1,
-} from './public-catalog-transport-v1.js';
-
-/** Wire fields that identify one claimed public/open root author-catalog scope. */
+/** Neutral fields that identify one claimed public/open root author-catalog scope. */
 export interface Rfc64PublicOpenCatalogScopeClaimV1 {
-  readonly networkId: Rfc64PublicCatalogHeadAnnouncementV1['networkId'];
-  readonly contextGraphId: Rfc64PublicCatalogHeadAnnouncementV1['contextGraphId'];
-  readonly subGraphName: Rfc64PublicCatalogHeadAnnouncementV1['subGraphName'];
-  readonly authorAddress: Rfc64PublicCatalogHeadAnnouncementV1['authorAddress'];
-  readonly catalogEra: Rfc64PublicCatalogHeadAnnouncementV1['catalogEra'];
+  readonly networkId: NetworkIdV1;
+  readonly contextGraphId: ContextGraphIdV1;
+  readonly subGraphName: SubGraphNameV1 | null;
+  readonly authorAddress: EvmAddressV1;
+  readonly catalogEra: DecimalU64V1;
 }
 
 /**

--- a/packages/agent/test/rfc64-public-catalog-current-head-discovery-v1.test.ts
+++ b/packages/agent/test/rfc64-public-catalog-current-head-discovery-v1.test.ts
@@ -30,6 +30,9 @@ import {
   Rfc64PublicCatalogServiceV1,
 } from '../src/rfc64/public-catalog-service-v1.js';
 import {
+  encodeRfc64PublicCatalogHeadAnnouncementV1,
+} from '../src/rfc64/public-catalog-transport-v1.js';
+import {
   openRfc64PersistenceV1,
   type Rfc64PersistenceV1,
 } from '../src/rfc64/persistence-v1.js';
@@ -165,6 +168,14 @@ function discoveryScope() {
     authorAddress: AUTHOR,
     catalogEra: '0',
   }) as const;
+}
+
+function directAuthorization(scope = catalogScope()) {
+  return Object.freeze({
+    accessPolicy: 0 as const,
+    policyDigest: POLICY_DIGEST,
+    trustedCatalogScope: scope,
+  });
 }
 
 describe('RFC-64 public catalog current-head discovery v1', () => {
@@ -388,6 +399,62 @@ describe('RFC-64 public catalog current-head discovery v1', () => {
     expect(requester.stats().receiver.scheduled).toBe(0);
   }, 20_000);
 
+  it('reports denial when provider policy changes after initial authorization', async () => {
+    const [providerNode, requesterNode, providerPersistence, requesterPersistence] =
+      await Promise.all([
+        startNode(),
+        startNode(),
+        openPersistence('revoked-provider'),
+        openPersistence('revoked-requester'),
+      ]);
+    await connect(requesterNode, providerNode);
+    let provider!: Rfc64PublicCatalogServiceV1;
+    let providerHeadReads = 0;
+    const readCurrentAppliedCatalogHeadDigest = vi.fn(async (
+      trustedCatalogScope: Readonly<AuthorCatalogScopeV1>,
+    ) => {
+      expect(trustedCatalogScope).toEqual(catalogScope());
+      providerHeadReads += 1;
+      if (providerHeadReads === 1) {
+        const current = provider.acceptedPolicySnapshot(NETWORK_ID, CONTEXT_GRAPH_ID)!;
+        const successor = Object.freeze({
+          ...current.policy,
+          version: '1' as const,
+          previousPolicyDigest: current.policyDigest,
+        });
+        const advanced = provider.acceptPolicySnapshot({
+          policy: successor,
+          policyDigest: `0x${'34'.repeat(32)}` as Digest32V1,
+        });
+        expect(advanced.policyDigest).not.toBe(current.policyDigest);
+      }
+      return null;
+    });
+    provider = new Rfc64PublicCatalogServiceV1({
+      router: new ProtocolRouter(providerNode),
+      controlObjects: providerPersistence.controlObjects,
+      currentHeadDiscovery: { readCurrentAppliedCatalogHeadDigest },
+      transportTimeoutMs: 4_000,
+    });
+    const requester = new Rfc64PublicCatalogServiceV1({
+      router: new ProtocolRouter(requesterNode),
+      controlObjects: requesterPersistence.controlObjects,
+      currentHeadDiscovery: { readCurrentAppliedCatalogHeadDigest: async () => null },
+      transportTimeoutMs: 4_000,
+    });
+    services.push(provider, requester);
+    acceptPolicy(provider, '0' as TimestampMsV1);
+    acceptPolicy(requester, '0' as TimestampMsV1);
+    provider.start();
+    requester.start();
+
+    await expect(requester.discoverCurrentCatalogHead({
+      remotePeerId: providerNode.peerId,
+      scope: discoveryScope(),
+    })).rejects.toMatchObject({ code: 'catalog-discovery-policy-denied' });
+    expect(readCurrentAppliedCatalogHeadDigest).toHaveBeenCalledTimes(2);
+  }, 20_000);
+
   it('fails closed when an applied-head pointer has no verified control object', async () => {
     const [providerNode, requesterNode, providerPersistence, requesterPersistence] =
       await Promise.all([
@@ -453,8 +520,7 @@ describe('RFC-64 public catalog current-head discovery v1', () => {
       readCurrentAppliedCatalogHeadDigest: vi.fn(async () =>
         stored.head.objectDigest as Digest32V1),
       authorizeOpenCatalogOperation: vi.fn(async () => ({
-        accessPolicy: 0 as const,
-        policyDigest: POLICY_DIGEST,
+        ...directAuthorization(),
       })),
       verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
     });
@@ -502,8 +568,7 @@ describe('RFC-64 public catalog current-head discovery v1', () => {
       readCurrentAppliedCatalogHeadDigest: vi.fn(async () =>
         stored.head.objectDigest as Digest32V1),
       authorizeOpenCatalogOperation: vi.fn(async () => ({
-        accessPolicy: 0 as const,
-        policyDigest: POLICY_DIGEST,
+        ...directAuthorization(),
       })),
       verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
     });
@@ -523,7 +588,7 @@ describe('RFC-64 public catalog current-head discovery v1', () => {
 
   it('rechecks outbound policy after the awaited remote response', async () => {
     const authorizeOpenCatalogOperation = vi.fn()
-      .mockResolvedValueOnce({ accessPolicy: 0 as const, policyDigest: POLICY_DIGEST })
+      .mockResolvedValueOnce(directAuthorization())
       .mockResolvedValueOnce(null);
     const send = vi.fn(async () => Uint8Array.of(0));
     const router = {
@@ -558,7 +623,7 @@ describe('RFC-64 public catalog current-head discovery v1', () => {
       options?: { signal?: AbortSignal },
     ) => Promise<Uint8Array>) | undefined;
     const authorizeOpenCatalogOperation = vi.fn()
-      .mockResolvedValueOnce({ accessPolicy: 0 as const, policyDigest: POLICY_DIGEST })
+      .mockResolvedValueOnce(directAuthorization())
       .mockResolvedValueOnce(null);
     const readCurrentAppliedCatalogHeadDigest = vi.fn(async () => null);
     const router = {
@@ -608,6 +673,47 @@ describe('RFC-64 public catalog current-head discovery v1', () => {
       remotePeerId: 'unreachable-peer',
       scope: Object.freeze({ ...discoveryScope(), subGraphName: 'nested' as const }),
     })).rejects.toThrow(/accepted public\/open root policy/);
+  });
+
+  it('rejects a canonical requester-side response outside the exact query scope', async () => {
+    const stored = await produceHeadWithProof();
+    const mismatchedAnnouncement = Object.freeze({
+      kind: 'rfc64-author-catalog-head-availability-v1' as const,
+      ...discoveryScope(),
+      subGraphName: 'nested' as const,
+      catalogVersion: '0' as const,
+      policyDigest: POLICY_DIGEST,
+      catalogHeadObjectDigest: stored.head.objectDigest as Digest32V1,
+      signatureVariantDigest: computeControlSignatureVariantDigestHex(
+        stored.head.objectDigest,
+        stored.head.signature,
+      ) as Digest32V1,
+    });
+    const payload = encodeRfc64PublicCatalogHeadAnnouncementV1(mismatchedAnnouncement);
+    const response = new Uint8Array(payload.byteLength + 1);
+    response[0] = 1;
+    response.set(payload, 1);
+    const router = {
+      register() {},
+      unregister() {},
+      send: vi.fn(async () => response),
+    } as unknown as ProtocolRouter;
+    const transport = new Rfc64PublicCatalogCurrentHeadDiscoveryTransportV1(router, {
+      controlObjects: { getVerifiedObjectByDigest: vi.fn(async () => null) },
+      readCurrentAppliedCatalogHeadDigest: vi.fn(async () => null),
+      authorizeOpenCatalogOperation: vi.fn(async () => directAuthorization()),
+      verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
+    });
+    transport.start();
+    const query = Object.freeze({
+      kind: RFC64_PUBLIC_CATALOG_CURRENT_HEAD_QUERY_KIND_V1,
+      ...discoveryScope(),
+      policyDigest: POLICY_DIGEST,
+    }) satisfies Rfc64PublicCatalogCurrentHeadQueryV1;
+
+    await expect(transport.discoverCurrentCatalogHead('provider-peer', query))
+      .rejects.toMatchObject({ code: 'catalog-discovery-object-mismatch' });
+    transport.stop();
   });
 
   it('round-trips only exact canonical query fields', () => {
@@ -681,8 +787,7 @@ describe('RFC-64 public catalog current-head discovery v1', () => {
     } as unknown as ProtocolRouter;
     const readCurrentAppliedCatalogHeadDigest = vi.fn(async () => null);
     const authorizeOpenCatalogOperation = vi.fn(async () => ({
-      accessPolicy: 0 as const,
-      policyDigest: POLICY_DIGEST,
+      ...directAuthorization(),
     }));
     const transport = new Rfc64PublicCatalogCurrentHeadDiscoveryTransportV1(router, {
       controlObjects: {

--- a/packages/agent/test/rfc64-public-catalog-current-head-discovery-v1.test.ts
+++ b/packages/agent/test/rfc64-public-catalog-current-head-discovery-v1.test.ts
@@ -39,6 +39,7 @@ const CONTEXT_GRAPH_ID =
 const AUTHOR_WALLET = new ethers.Wallet(`0x${'64'.repeat(32)}`);
 const AUTHOR = AUTHOR_WALLET.address.toLowerCase() as EvmAddressV1;
 const DELEGATION_DIGEST = `0x${'72'.repeat(32)}` as Digest32V1;
+const POLICY_DIGEST = `0x${'71'.repeat(32)}` as Digest32V1;
 
 const temporaryDirectories: string[] = [];
 const nodes: DKGNode[] = [];
@@ -122,6 +123,25 @@ async function stageHead(
   })));
   await persistence.controlObjects.stageVerifiedObjects(verified);
   return produced.head;
+}
+
+async function produceHeadWithProof(
+  scope = catalogScope(),
+  issuedAt: TimestampMsV1 = '1773900000000' as TimestampMsV1,
+) {
+  const produced = await produceEmptyAuthorCatalogGenesisV1({
+    scope,
+    catalogIssuerDelegationDigest: DELEGATION_DIGEST,
+    issuedAt,
+    signer: {
+      issuer: AUTHOR,
+      signDigest: (digest) => AUTHOR_WALLET.signMessage(digest),
+    },
+  });
+  return Object.freeze({
+    head: produced.head,
+    issuerSignature: await verifyControlEnvelopeIssuerSignatureV1(produced.head),
+  });
 }
 
 function acceptPolicy(
@@ -400,11 +420,193 @@ describe('RFC-64 public catalog current-head discovery v1', () => {
     expect(requester.stats().receiver.scheduled).toBe(0);
   }, 20_000);
 
+  it('rejects a durable current pointer bound to a different context graph', async () => {
+    let handler: ((
+      data: Uint8Array,
+      peerId: { toString(): string },
+      options?: { signal?: AbortSignal },
+    ) => Promise<Uint8Array>) | undefined;
+    const wrongContextGraphId =
+      '0x1111111111111111111111111111111111111111/other-graph' as const;
+    const stored = await produceHeadWithProof(catalogScope(wrongContextGraphId));
+    const router = {
+      register(_protocol: string, registered: typeof handler) {
+        handler = registered;
+      },
+      unregister() {},
+    } as unknown as ProtocolRouter;
+    const transport = new Rfc64PublicCatalogCurrentHeadDiscoveryTransportV1(router, {
+      controlObjects: {
+        getVerifiedObjectByDigest: vi.fn(async () => ({
+          envelope: stored.head,
+          issuerSignature: stored.issuerSignature,
+        })),
+      },
+      readCurrentAppliedCatalogHeadDigest: vi.fn(async () =>
+        stored.head.objectDigest as Digest32V1),
+      authorizeOpenCatalogOperation: vi.fn(async () => ({
+        accessPolicy: 0 as const,
+        policyDigest: POLICY_DIGEST,
+      })),
+      verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
+    });
+    transport.start();
+    const query = Object.freeze({
+      kind: RFC64_PUBLIC_CATALOG_CURRENT_HEAD_QUERY_KIND_V1,
+      ...discoveryScope(),
+      policyDigest: POLICY_DIGEST,
+    }) satisfies Rfc64PublicCatalogCurrentHeadQueryV1;
+
+    await expect(handler!(
+      encodeRfc64PublicCatalogCurrentHeadQueryV1(query),
+      { toString: () => 'requester-peer' },
+    )).rejects.toMatchObject({ code: 'catalog-discovery-object-mismatch' });
+    transport.stop();
+  });
+
+  it('rejects an issuer proof minted for a different head envelope', async () => {
+    let handler: ((
+      data: Uint8Array,
+      peerId: { toString(): string },
+      options?: { signal?: AbortSignal },
+    ) => Promise<Uint8Array>) | undefined;
+    const stored = await produceHeadWithProof(
+      catalogScope(),
+      '1773900000000' as TimestampMsV1,
+    );
+    const other = await produceHeadWithProof(
+      catalogScope(),
+      '1773900000001' as TimestampMsV1,
+    );
+    const router = {
+      register(_protocol: string, registered: typeof handler) {
+        handler = registered;
+      },
+      unregister() {},
+    } as unknown as ProtocolRouter;
+    const transport = new Rfc64PublicCatalogCurrentHeadDiscoveryTransportV1(router, {
+      controlObjects: {
+        getVerifiedObjectByDigest: vi.fn(async () => ({
+          envelope: stored.head,
+          issuerSignature: other.issuerSignature,
+        })),
+      },
+      readCurrentAppliedCatalogHeadDigest: vi.fn(async () =>
+        stored.head.objectDigest as Digest32V1),
+      authorizeOpenCatalogOperation: vi.fn(async () => ({
+        accessPolicy: 0 as const,
+        policyDigest: POLICY_DIGEST,
+      })),
+      verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
+    });
+    transport.start();
+    const query = Object.freeze({
+      kind: RFC64_PUBLIC_CATALOG_CURRENT_HEAD_QUERY_KIND_V1,
+      ...discoveryScope(),
+      policyDigest: POLICY_DIGEST,
+    }) satisfies Rfc64PublicCatalogCurrentHeadQueryV1;
+
+    await expect(handler!(
+      encodeRfc64PublicCatalogCurrentHeadQueryV1(query),
+      { toString: () => 'requester-peer' },
+    )).rejects.toMatchObject({ code: 'catalog-discovery-signature' });
+    transport.stop();
+  });
+
+  it('rechecks outbound policy after the awaited remote response', async () => {
+    const authorizeOpenCatalogOperation = vi.fn()
+      .mockResolvedValueOnce({ accessPolicy: 0 as const, policyDigest: POLICY_DIGEST })
+      .mockResolvedValueOnce(null);
+    const send = vi.fn(async () => Uint8Array.of(0));
+    const router = {
+      register() {},
+      unregister() {},
+      send,
+    } as unknown as ProtocolRouter;
+    const transport = new Rfc64PublicCatalogCurrentHeadDiscoveryTransportV1(router, {
+      controlObjects: { getVerifiedObjectByDigest: vi.fn(async () => null) },
+      readCurrentAppliedCatalogHeadDigest: vi.fn(async () => null),
+      authorizeOpenCatalogOperation,
+      verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
+    });
+    transport.start();
+    const query = Object.freeze({
+      kind: RFC64_PUBLIC_CATALOG_CURRENT_HEAD_QUERY_KIND_V1,
+      ...discoveryScope(),
+      policyDigest: POLICY_DIGEST,
+    }) satisfies Rfc64PublicCatalogCurrentHeadQueryV1;
+
+    await expect(transport.discoverCurrentCatalogHead('provider-peer', query))
+      .rejects.toMatchObject({ code: 'catalog-discovery-policy-denied' });
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(authorizeOpenCatalogOperation).toHaveBeenCalledTimes(2);
+    transport.stop();
+  });
+
+  it('returns denied when inbound policy changes after awaited state reads', async () => {
+    let handler: ((
+      data: Uint8Array,
+      peerId: { toString(): string },
+      options?: { signal?: AbortSignal },
+    ) => Promise<Uint8Array>) | undefined;
+    const authorizeOpenCatalogOperation = vi.fn()
+      .mockResolvedValueOnce({ accessPolicy: 0 as const, policyDigest: POLICY_DIGEST })
+      .mockResolvedValueOnce(null);
+    const readCurrentAppliedCatalogHeadDigest = vi.fn(async () => null);
+    const router = {
+      register(_protocol: string, registered: typeof handler) {
+        handler = registered;
+      },
+      unregister() {},
+    } as unknown as ProtocolRouter;
+    const transport = new Rfc64PublicCatalogCurrentHeadDiscoveryTransportV1(router, {
+      controlObjects: { getVerifiedObjectByDigest: vi.fn(async () => null) },
+      readCurrentAppliedCatalogHeadDigest,
+      authorizeOpenCatalogOperation,
+      verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
+    });
+    transport.start();
+    const query = Object.freeze({
+      kind: RFC64_PUBLIC_CATALOG_CURRENT_HEAD_QUERY_KIND_V1,
+      ...discoveryScope(),
+      policyDigest: POLICY_DIGEST,
+    }) satisfies Rfc64PublicCatalogCurrentHeadQueryV1;
+
+    await expect(handler!(
+      encodeRfc64PublicCatalogCurrentHeadQueryV1(query),
+      { toString: () => 'requester-peer' },
+    )).resolves.toEqual(Uint8Array.of(2));
+    expect(readCurrentAppliedCatalogHeadDigest).toHaveBeenCalledTimes(2);
+    expect(authorizeOpenCatalogOperation).toHaveBeenCalledTimes(2);
+    transport.stop();
+  });
+
+  it('rejects a non-root discovery claim through the shared public scope derivation', async () => {
+    const [node, persistence] = await Promise.all([
+      startNode(),
+      openPersistence('scope-derivation'),
+    ]);
+    const service = new Rfc64PublicCatalogServiceV1({
+      router: new ProtocolRouter(node),
+      controlObjects: persistence.controlObjects,
+      currentHeadDiscovery: { readCurrentAppliedCatalogHeadDigest: async () => null },
+      transportTimeoutMs: 1_000,
+    });
+    services.push(service);
+    acceptPolicy(service);
+    service.start();
+
+    await expect(service.discoverCurrentCatalogHead({
+      remotePeerId: 'unreachable-peer',
+      scope: Object.freeze({ ...discoveryScope(), subGraphName: 'nested' as const }),
+    })).rejects.toThrow(/accepted public\/open root policy/);
+  });
+
   it('round-trips only exact canonical query fields', () => {
     const query = Object.freeze({
       kind: RFC64_PUBLIC_CATALOG_CURRENT_HEAD_QUERY_KIND_V1,
       ...discoveryScope(),
-      policyDigest: `0x${'71'.repeat(32)}` as Digest32V1,
+      policyDigest: POLICY_DIGEST,
     }) satisfies Rfc64PublicCatalogCurrentHeadQueryV1;
     const encoded = encodeRfc64PublicCatalogCurrentHeadQueryV1(query);
     expect(parseRfc64PublicCatalogCurrentHeadQueryV1(encoded)).toEqual(query);
@@ -425,7 +627,7 @@ describe('RFC-64 public catalog current-head discovery v1', () => {
     const query = Object.freeze({
       kind: RFC64_PUBLIC_CATALOG_CURRENT_HEAD_QUERY_KIND_V1,
       ...discoveryScope(),
-      policyDigest: `0x${'71'.repeat(32)}` as Digest32V1,
+      policyDigest: POLICY_DIGEST,
     }) satisfies Rfc64PublicCatalogCurrentHeadQueryV1;
     const expected = encodeRfc64PublicCatalogCurrentHeadQueryV1(query);
     let switchedReads = 0;
@@ -472,7 +674,7 @@ describe('RFC-64 public catalog current-head discovery v1', () => {
     const readCurrentAppliedCatalogHeadDigest = vi.fn(async () => null);
     const authorizeOpenCatalogOperation = vi.fn(async () => ({
       accessPolicy: 0 as const,
-      policyDigest: `0x${'71'.repeat(32)}` as Digest32V1,
+      policyDigest: POLICY_DIGEST,
     }));
     const transport = new Rfc64PublicCatalogCurrentHeadDiscoveryTransportV1(router, {
       controlObjects: {
@@ -486,7 +688,7 @@ describe('RFC-64 public catalog current-head discovery v1', () => {
     const query = Object.freeze({
       kind: RFC64_PUBLIC_CATALOG_CURRENT_HEAD_QUERY_KIND_V1,
       ...discoveryScope(),
-      policyDigest: `0x${'71'.repeat(32)}` as Digest32V1,
+      policyDigest: POLICY_DIGEST,
     }) satisfies Rfc64PublicCatalogCurrentHeadQueryV1;
     const controller = new AbortController();
     const reason = new Error('test stream closed');

--- a/packages/agent/test/rfc64-public-catalog-current-head-discovery-v1.test.ts
+++ b/packages/agent/test/rfc64-public-catalog-current-head-discovery-v1.test.ts
@@ -1,0 +1,410 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { multiaddr } from '@multiformats/multiaddr';
+import {
+  DKGNode,
+  ProtocolRouter,
+  computeControlSignatureVariantDigestHex,
+  type AuthorCatalogScopeV1,
+  type Digest32V1,
+  type EvmAddressV1,
+  type TimestampMsV1,
+} from '@origintrail-official/dkg-core';
+import { verifyControlEnvelopeIssuerSignatureV1 } from '@origintrail-official/dkg-chain';
+import { ethers } from 'ethers';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { produceEmptyAuthorCatalogGenesisV1 } from '../src/rfc64/author-catalog-producer.js';
+import {
+  RFC64_PUBLIC_CATALOG_CURRENT_HEAD_DISCOVERY_PROTOCOL_V1,
+  RFC64_PUBLIC_CATALOG_CURRENT_HEAD_QUERY_KIND_V1,
+  encodeRfc64PublicCatalogCurrentHeadQueryV1,
+  parseRfc64PublicCatalogCurrentHeadQueryV1,
+  type Rfc64PublicCatalogCurrentHeadQueryV1,
+} from '../src/rfc64/public-catalog-current-head-discovery-v1.js';
+import {
+  Rfc64PublicCatalogServiceV1,
+} from '../src/rfc64/public-catalog-service-v1.js';
+import {
+  openRfc64PersistenceV1,
+  type Rfc64PersistenceV1,
+} from '../src/rfc64/persistence-v1.js';
+
+const NETWORK_ID = 'otp:20430' as const;
+const CONTEXT_GRAPH_ID =
+  '0x1111111111111111111111111111111111111111/gate-3-discovery' as const;
+const AUTHOR_WALLET = new ethers.Wallet(`0x${'64'.repeat(32)}`);
+const AUTHOR = AUTHOR_WALLET.address.toLowerCase() as EvmAddressV1;
+const DELEGATION_DIGEST = `0x${'72'.repeat(32)}` as Digest32V1;
+
+const temporaryDirectories: string[] = [];
+const nodes: DKGNode[] = [];
+const persistences: Rfc64PersistenceV1[] = [];
+const services: Rfc64PublicCatalogServiceV1[] = [];
+
+afterEach(async () => {
+  for (const service of services.splice(0)) {
+    try { await service.close(); } catch {}
+  }
+  for (const persistence of persistences.splice(0)) {
+    try { await persistence.close(); } catch {}
+  }
+  for (const node of nodes.splice(0)) {
+    try { await node.stop(); } catch {}
+  }
+  await Promise.all(temporaryDirectories.splice(0).map(async (path) => {
+    await rm(path, { recursive: true, force: true });
+  }));
+});
+
+async function startNode(): Promise<DKGNode> {
+  const node = new DKGNode({
+    listenAddresses: ['/ip4/127.0.0.1/tcp/0'],
+    enableMdns: false,
+  });
+  nodes.push(node);
+  await node.start();
+  return node;
+}
+
+async function connect(from: DKGNode, to: DKGNode): Promise<void> {
+  const address = to.multiaddrs.find((candidate) => candidate.includes('/tcp/'));
+  if (address === undefined) throw new Error('test node has no TCP multiaddr');
+  await from.libp2p.dial(multiaddr(address));
+}
+
+async function openPersistence(label: string): Promise<Rfc64PersistenceV1> {
+  const path = await mkdtemp(join(tmpdir(), `dkg-rfc64-gate3-${label}-`));
+  temporaryDirectories.push(path);
+  const persistence = await openRfc64PersistenceV1(path, {
+    yieldAfterPurgeBatch: async () => {},
+  });
+  persistences.push(persistence);
+  return persistence;
+}
+
+function catalogScope(
+  contextGraphId = CONTEXT_GRAPH_ID,
+): AuthorCatalogScopeV1 {
+  return Object.freeze({
+    networkId: NETWORK_ID,
+    contextGraphId,
+    governanceChainId: null,
+    governanceContractAddress: null,
+    ownershipTransitionDigest: null,
+    subGraphName: null,
+    authorAddress: AUTHOR,
+    era: '0',
+    bucketCount: '1',
+  }) as AuthorCatalogScopeV1;
+}
+
+async function stageHead(
+  persistence: Rfc64PersistenceV1,
+  scope = catalogScope(),
+  issuedAt: TimestampMsV1 = '1773900000000' as TimestampMsV1,
+) {
+  const produced = await produceEmptyAuthorCatalogGenesisV1({
+    scope,
+    catalogIssuerDelegationDigest: DELEGATION_DIGEST,
+    issuedAt,
+    signer: {
+      issuer: AUTHOR,
+      signDigest: (digest) => AUTHOR_WALLET.signMessage(digest),
+    },
+  });
+  const verified = await Promise.all(produced.stagedObjects.map(async (envelope) => ({
+    envelope,
+    issuerSignature: await verifyControlEnvelopeIssuerSignatureV1(envelope),
+  })));
+  await persistence.controlObjects.stageVerifiedObjects(verified);
+  return produced.head;
+}
+
+function acceptPolicy(
+  service: Rfc64PublicCatalogServiceV1,
+  issuedAt?: TimestampMsV1,
+) {
+  return service.acceptOpenPolicy({
+    networkId: NETWORK_ID,
+    contextGraphId: CONTEXT_GRAPH_ID,
+    ownerAddress: AUTHOR,
+    issuedAt,
+  });
+}
+
+function discoveryScope() {
+  return Object.freeze({
+    networkId: NETWORK_ID,
+    contextGraphId: CONTEXT_GRAPH_ID,
+    subGraphName: null,
+    authorAddress: AUTHOR,
+    catalogEra: '0',
+  }) as const;
+}
+
+describe('RFC-64 public catalog current-head discovery v1', () => {
+  it('discovers and exact-verifies one applied head without staging or scheduling it', async () => {
+    const [providerNode, requesterNode, providerPersistence, requesterPersistence] =
+      await Promise.all([
+        startNode(),
+        startNode(),
+        openPersistence('provider'),
+        openPersistence('requester'),
+      ]);
+    await connect(requesterNode, providerNode);
+    const head = await stageHead(providerPersistence);
+    const readCurrentAppliedCatalogHeadDigest = vi.fn(async () =>
+      head.objectDigest as Digest32V1);
+
+    const provider = new Rfc64PublicCatalogServiceV1({
+      router: new ProtocolRouter(providerNode),
+      controlObjects: providerPersistence.controlObjects,
+      currentHeadDiscovery: { readCurrentAppliedCatalogHeadDigest },
+      transportTimeoutMs: 4_000,
+    });
+    const requester = new Rfc64PublicCatalogServiceV1({
+      router: new ProtocolRouter(requesterNode),
+      controlObjects: requesterPersistence.controlObjects,
+      currentHeadDiscovery: { readCurrentAppliedCatalogHeadDigest: async () => null },
+      transportTimeoutMs: 4_000,
+    });
+    services.push(provider, requester);
+    const providerPolicy = acceptPolicy(provider);
+    const requesterPolicy = acceptPolicy(requester);
+    expect(providerPolicy.policyDigest).toBe(requesterPolicy.policyDigest);
+    provider.start();
+    requester.start();
+
+    expect(RFC64_PUBLIC_CATALOG_CURRENT_HEAD_DISCOVERY_PROTOCOL_V1)
+      .toBe('/dkg/catalog/1/author-head/current');
+    const result = await requester.discoverCurrentCatalogHead({
+      remotePeerId: providerNode.peerId,
+      scope: discoveryScope(),
+    });
+
+    expect(result?.announcement).toEqual({
+      kind: 'rfc64-author-catalog-head-availability-v1',
+      networkId: NETWORK_ID,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      subGraphName: null,
+      authorAddress: AUTHOR,
+      catalogEra: '0',
+      catalogVersion: '0',
+      policyDigest: requesterPolicy.policyDigest,
+      catalogHeadObjectDigest: head.objectDigest,
+      signatureVariantDigest: computeControlSignatureVariantDigestHex(
+        head.objectDigest,
+        head.signature,
+      ),
+    });
+    expect(result?.head.envelope).toEqual(head);
+    expect(readCurrentAppliedCatalogHeadDigest).toHaveBeenCalledTimes(2);
+    for (const [scope] of readCurrentAppliedCatalogHeadDigest.mock.calls) {
+      expect(scope).toEqual(catalogScope());
+    }
+    expect(Object.isFrozen(result)).toBe(true);
+    expect(requester.stats().receiver).toMatchObject({
+      scheduled: 0,
+      applied: 0,
+      stagedOnly: 0,
+    });
+    await expect(requesterPersistence.controlObjects.getVerifiedObject({
+      objectDigest: head.objectDigest as Digest32V1,
+      signatureVariantDigest: computeControlSignatureVariantDigestHex(
+        head.objectDigest,
+        head.signature,
+      ) as Digest32V1,
+      verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
+    })).resolves.toBeNull();
+  }, 30_000);
+
+  it('retries once when the applied ref advances while the old immutable head is read', async () => {
+    const [providerNode, requesterNode, providerPersistence, requesterPersistence] =
+      await Promise.all([
+        startNode(),
+        startNode(),
+        openPersistence('advancing-provider'),
+        openPersistence('advancing-requester'),
+      ]);
+    await connect(requesterNode, providerNode);
+    const oldHead = await stageHead(
+      providerPersistence,
+      catalogScope(),
+      '1773900000000' as TimestampMsV1,
+    );
+    const currentHead = await stageHead(
+      providerPersistence,
+      catalogScope(),
+      '1773900000001' as TimestampMsV1,
+    );
+    expect(oldHead.objectDigest).not.toBe(currentHead.objectDigest);
+    const readCurrentAppliedCatalogHeadDigest = vi.fn()
+      .mockResolvedValueOnce(oldHead.objectDigest as Digest32V1)
+      .mockResolvedValue(currentHead.objectDigest as Digest32V1);
+
+    const provider = new Rfc64PublicCatalogServiceV1({
+      router: new ProtocolRouter(providerNode),
+      controlObjects: providerPersistence.controlObjects,
+      currentHeadDiscovery: { readCurrentAppliedCatalogHeadDigest },
+      transportTimeoutMs: 4_000,
+    });
+    const requester = new Rfc64PublicCatalogServiceV1({
+      router: new ProtocolRouter(requesterNode),
+      controlObjects: requesterPersistence.controlObjects,
+      currentHeadDiscovery: { readCurrentAppliedCatalogHeadDigest: async () => null },
+      transportTimeoutMs: 4_000,
+    });
+    services.push(provider, requester);
+    acceptPolicy(provider);
+    acceptPolicy(requester);
+    provider.start();
+    requester.start();
+
+    const result = await requester.discoverCurrentCatalogHead({
+      remotePeerId: providerNode.peerId,
+      scope: discoveryScope(),
+    });
+
+    expect(result?.announcement.catalogHeadObjectDigest).toBe(currentHead.objectDigest);
+    expect(result?.head.envelope).toEqual(currentHead);
+    expect(readCurrentAppliedCatalogHeadDigest).toHaveBeenCalledTimes(4);
+    expect(requester.stats().receiver.scheduled).toBe(0);
+  }, 30_000);
+
+  it('returns not-found only after a stable applied-ref snapshot', async () => {
+    const [providerNode, requesterNode, providerPersistence, requesterPersistence] =
+      await Promise.all([
+        startNode(),
+        startNode(),
+        openPersistence('empty-provider'),
+        openPersistence('empty-requester'),
+      ]);
+    await connect(requesterNode, providerNode);
+    const readCurrentAppliedCatalogHeadDigest = vi.fn(async () => null);
+    const provider = new Rfc64PublicCatalogServiceV1({
+      router: new ProtocolRouter(providerNode),
+      controlObjects: providerPersistence.controlObjects,
+      currentHeadDiscovery: { readCurrentAppliedCatalogHeadDigest },
+      transportTimeoutMs: 4_000,
+    });
+    const requester = new Rfc64PublicCatalogServiceV1({
+      router: new ProtocolRouter(requesterNode),
+      controlObjects: requesterPersistence.controlObjects,
+      currentHeadDiscovery: { readCurrentAppliedCatalogHeadDigest: async () => null },
+      transportTimeoutMs: 4_000,
+    });
+    services.push(provider, requester);
+    acceptPolicy(provider);
+    acceptPolicy(requester);
+    provider.start();
+    requester.start();
+
+    await expect(requester.discoverCurrentCatalogHead({
+      remotePeerId: providerNode.peerId,
+      scope: discoveryScope(),
+    })).resolves.toBeNull();
+    expect(readCurrentAppliedCatalogHeadDigest).toHaveBeenCalledTimes(2);
+    expect(requester.stats().receiver.scheduled).toBe(0);
+  }, 20_000);
+
+  it('denies a mismatched policy generation before consulting provider head state', async () => {
+    const [providerNode, requesterNode, providerPersistence, requesterPersistence] =
+      await Promise.all([
+        startNode(),
+        startNode(),
+        openPersistence('policy-provider'),
+        openPersistence('policy-requester'),
+      ]);
+    await connect(requesterNode, providerNode);
+    const readCurrentAppliedCatalogHeadDigest = vi.fn(async () => null);
+    const provider = new Rfc64PublicCatalogServiceV1({
+      router: new ProtocolRouter(providerNode),
+      controlObjects: providerPersistence.controlObjects,
+      currentHeadDiscovery: { readCurrentAppliedCatalogHeadDigest },
+      transportTimeoutMs: 4_000,
+    });
+    const requester = new Rfc64PublicCatalogServiceV1({
+      router: new ProtocolRouter(requesterNode),
+      controlObjects: requesterPersistence.controlObjects,
+      currentHeadDiscovery: { readCurrentAppliedCatalogHeadDigest: async () => null },
+      transportTimeoutMs: 4_000,
+    });
+    services.push(provider, requester);
+    const providerPolicy = acceptPolicy(provider, '1' as TimestampMsV1);
+    const requesterPolicy = acceptPolicy(requester, '0' as TimestampMsV1);
+    expect(providerPolicy.policyDigest).not.toBe(requesterPolicy.policyDigest);
+    provider.start();
+    requester.start();
+
+    await expect(requester.discoverCurrentCatalogHead({
+      remotePeerId: providerNode.peerId,
+      scope: discoveryScope(),
+    })).rejects.toMatchObject({ code: 'catalog-discovery-policy-denied' });
+    expect(readCurrentAppliedCatalogHeadDigest).not.toHaveBeenCalled();
+    expect(requester.stats().receiver.scheduled).toBe(0);
+  }, 20_000);
+
+  it('fails closed when an applied-head pointer has no verified control object', async () => {
+    const [providerNode, requesterNode, providerPersistence, requesterPersistence] =
+      await Promise.all([
+        startNode(),
+        startNode(),
+        openPersistence('dangling-provider'),
+        openPersistence('dangling-requester'),
+      ]);
+    await connect(requesterNode, providerNode);
+    const danglingDigest = `0x${'dd'.repeat(32)}` as Digest32V1;
+    const readCurrentAppliedCatalogHeadDigest = vi.fn(async () => danglingDigest);
+    const provider = new Rfc64PublicCatalogServiceV1({
+      router: new ProtocolRouter(providerNode),
+      controlObjects: providerPersistence.controlObjects,
+      currentHeadDiscovery: { readCurrentAppliedCatalogHeadDigest },
+      transportTimeoutMs: 4_000,
+    });
+    const requester = new Rfc64PublicCatalogServiceV1({
+      router: new ProtocolRouter(requesterNode),
+      controlObjects: requesterPersistence.controlObjects,
+      currentHeadDiscovery: { readCurrentAppliedCatalogHeadDigest: async () => null },
+      transportTimeoutMs: 4_000,
+    });
+    services.push(provider, requester);
+    acceptPolicy(provider);
+    acceptPolicy(requester);
+    provider.start();
+    requester.start();
+
+    await expect(requester.discoverCurrentCatalogHead({
+      remotePeerId: providerNode.peerId,
+      scope: discoveryScope(),
+    })).rejects.toThrow();
+    expect(readCurrentAppliedCatalogHeadDigest).toHaveBeenCalled();
+    for (const [scope] of readCurrentAppliedCatalogHeadDigest.mock.calls) {
+      expect(scope).toEqual(catalogScope());
+    }
+    expect(requester.stats().receiver.scheduled).toBe(0);
+  }, 20_000);
+
+  it('round-trips only exact canonical query fields', () => {
+    const query = Object.freeze({
+      kind: RFC64_PUBLIC_CATALOG_CURRENT_HEAD_QUERY_KIND_V1,
+      ...discoveryScope(),
+      policyDigest: `0x${'71'.repeat(32)}` as Digest32V1,
+    }) satisfies Rfc64PublicCatalogCurrentHeadQueryV1;
+    const encoded = encodeRfc64PublicCatalogCurrentHeadQueryV1(query);
+    expect(parseRfc64PublicCatalogCurrentHeadQueryV1(encoded)).toEqual(query);
+
+    const parsed = JSON.parse(new TextDecoder().decode(encoded));
+    const noncanonical = new TextEncoder().encode(JSON.stringify(
+      Object.fromEntries(Object.entries(parsed).reverse()),
+    ));
+    expect(() => parseRfc64PublicCatalogCurrentHeadQueryV1(noncanonical))
+      .toThrow(/canonical JCS/);
+
+    const withUnknown = new TextEncoder().encode(JSON.stringify({ ...parsed, surprise: 'x' }));
+    expect(() => parseRfc64PublicCatalogCurrentHeadQueryV1(withUnknown))
+      .toThrow(/missing or unknown fields/);
+  });
+});

--- a/packages/agent/test/rfc64-public-catalog-current-head-discovery-v1.test.ts
+++ b/packages/agent/test/rfc64-public-catalog-current-head-discovery-v1.test.ts
@@ -17,6 +17,7 @@ import { ethers } from 'ethers';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { produceEmptyAuthorCatalogGenesisV1 } from '../src/rfc64/author-catalog-producer.js';
+import { snapshotRfc64ExactWireRecordV1 } from '../src/rfc64/catalog-transport-wire-v1-internal.js';
 import {
   RFC64_PUBLIC_CATALOG_CURRENT_HEAD_DISCOVERY_PROTOCOL_V1,
   RFC64_PUBLIC_CATALOG_CURRENT_HEAD_QUERY_KIND_V1,
@@ -167,6 +168,13 @@ function discoveryScope() {
 }
 
 describe('RFC-64 public catalog current-head discovery v1', () => {
+  it('treats an unsorted expected-key declaration as an exact key set', () => {
+    expect(snapshotRfc64ExactWireRecordV1(
+      { alpha: '1', beta: '2' },
+      ['beta', 'alpha'],
+    )).toEqual({ alpha: '1', beta: '2' });
+  });
+
   it('discovers and exact-verifies one applied head without staging or scheduling it', async () => {
     const [providerNode, requesterNode, providerPersistence, requesterPersistence] =
       await Promise.all([

--- a/packages/agent/test/rfc64-public-catalog-current-head-discovery-v1.test.ts
+++ b/packages/agent/test/rfc64-public-catalog-current-head-discovery-v1.test.ts
@@ -20,6 +20,7 @@ import { produceEmptyAuthorCatalogGenesisV1 } from '../src/rfc64/author-catalog-
 import {
   RFC64_PUBLIC_CATALOG_CURRENT_HEAD_DISCOVERY_PROTOCOL_V1,
   RFC64_PUBLIC_CATALOG_CURRENT_HEAD_QUERY_KIND_V1,
+  Rfc64PublicCatalogCurrentHeadDiscoveryTransportV1,
   encodeRfc64PublicCatalogCurrentHeadQueryV1,
   parseRfc64PublicCatalogCurrentHeadQueryV1,
   type Rfc64PublicCatalogCurrentHeadQueryV1,
@@ -180,10 +181,21 @@ describe('RFC-64 public catalog current-head discovery v1', () => {
 
     expect(RFC64_PUBLIC_CATALOG_CURRENT_HEAD_DISCOVERY_PROTOCOL_V1)
       .toBe('/dkg/catalog/1/author-head/current');
-    const result = await requester.discoverCurrentCatalogHead({
-      remotePeerId: providerNode.peerId,
+    let remotePeerIdReads = 0;
+    const discoveryInput = {
       scope: discoveryScope(),
+    } as {
+      remotePeerId: string;
+      scope: ReturnType<typeof discoveryScope>;
+    };
+    Object.defineProperty(discoveryInput, 'remotePeerId', {
+      enumerable: true,
+      get() {
+        remotePeerIdReads += 1;
+        return remotePeerIdReads === 1 ? providerNode.peerId : requesterNode.peerId;
+      },
     });
+    const result = await requester.discoverCurrentCatalogHead(discoveryInput);
 
     expect(result?.announcement).toEqual({
       kind: 'rfc64-author-catalog-head-availability-v1',
@@ -202,6 +214,7 @@ describe('RFC-64 public catalog current-head discovery v1', () => {
     });
     expect(result?.head.envelope).toEqual(head);
     expect(readCurrentAppliedCatalogHeadDigest).toHaveBeenCalledTimes(2);
+    expect(remotePeerIdReads).toBe(1);
     for (const [scope] of readCurrentAppliedCatalogHeadDigest.mock.calls) {
       expect(scope).toEqual(catalogScope());
     }
@@ -406,5 +419,86 @@ describe('RFC-64 public catalog current-head discovery v1', () => {
     const withUnknown = new TextEncoder().encode(JSON.stringify({ ...parsed, surprise: 'x' }));
     expect(() => parseRfc64PublicCatalogCurrentHeadQueryV1(withUnknown))
       .toThrow(/missing or unknown fields/);
+  });
+
+  it('snapshots switching Proxies and rejects accessors without invoking them', () => {
+    const query = Object.freeze({
+      kind: RFC64_PUBLIC_CATALOG_CURRENT_HEAD_QUERY_KIND_V1,
+      ...discoveryScope(),
+      policyDigest: `0x${'71'.repeat(32)}` as Digest32V1,
+    }) satisfies Rfc64PublicCatalogCurrentHeadQueryV1;
+    const expected = encodeRfc64PublicCatalogCurrentHeadQueryV1(query);
+    let switchedReads = 0;
+    const switching = new Proxy({ ...query }, {
+      get(target, property, receiver) {
+        if (property === 'networkId') {
+          switchedReads += 1;
+          return switchedReads === 1 ? NETWORK_ID : '';
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+
+    expect(encodeRfc64PublicCatalogCurrentHeadQueryV1(switching)).toEqual(expected);
+    expect(switchedReads).toBe(0);
+
+    let accessorCalls = 0;
+    const accessorQuery = { ...query } as Record<string, unknown>;
+    Object.defineProperty(accessorQuery, 'networkId', {
+      enumerable: true,
+      get() {
+        accessorCalls += 1;
+        return NETWORK_ID;
+      },
+    });
+    expect(() => encodeRfc64PublicCatalogCurrentHeadQueryV1(
+      accessorQuery as unknown as Rfc64PublicCatalogCurrentHeadQueryV1,
+    )).toThrow(/enumerable data properties/);
+    expect(accessorCalls).toBe(0);
+  });
+
+  it('honors the router stream abort before authorization or applied-head work', async () => {
+    let handler: ((
+      data: Uint8Array,
+      peerId: { toString(): string },
+      options: { signal?: AbortSignal },
+    ) => Promise<Uint8Array>) | undefined;
+    const router = {
+      register(_protocol: string, registered: typeof handler) {
+        handler = registered;
+      },
+      unregister() {},
+    } as unknown as ProtocolRouter;
+    const readCurrentAppliedCatalogHeadDigest = vi.fn(async () => null);
+    const authorizeOpenCatalogOperation = vi.fn(async () => ({
+      accessPolicy: 0 as const,
+      policyDigest: `0x${'71'.repeat(32)}` as Digest32V1,
+    }));
+    const transport = new Rfc64PublicCatalogCurrentHeadDiscoveryTransportV1(router, {
+      controlObjects: {
+        getVerifiedObjectByDigest: vi.fn(async () => null),
+      },
+      readCurrentAppliedCatalogHeadDigest,
+      authorizeOpenCatalogOperation,
+      verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
+    });
+    transport.start();
+    const query = Object.freeze({
+      kind: RFC64_PUBLIC_CATALOG_CURRENT_HEAD_QUERY_KIND_V1,
+      ...discoveryScope(),
+      policyDigest: `0x${'71'.repeat(32)}` as Digest32V1,
+    }) satisfies Rfc64PublicCatalogCurrentHeadQueryV1;
+    const controller = new AbortController();
+    const reason = new Error('test stream closed');
+    controller.abort(reason);
+
+    await expect(handler!(
+      encodeRfc64PublicCatalogCurrentHeadQueryV1(query),
+      { toString: () => 'test-peer' },
+      { signal: controller.signal },
+    )).rejects.toBe(reason);
+    expect(authorizeOpenCatalogOperation).not.toHaveBeenCalled();
+    expect(readCurrentAppliedCatalogHeadDigest).not.toHaveBeenCalled();
+    transport.stop();
   });
 });

--- a/packages/agent/test/rfc64-public-catalog-native-reconciler-v1.test.ts
+++ b/packages/agent/test/rfc64-public-catalog-native-reconciler-v1.test.ts
@@ -10,10 +10,10 @@ import type { AppliedCatalogHeadSnapshotV1 } from '../src/rfc64/inventory-v1/ind
 import { buildOpenOwnerContextGraphPolicyV1 } from '../src/rfc64/open-catalog-policy-v1.js';
 import {
   createRfc64BoundedPublicRootCatalogNativeReconcilerV1,
-  deriveRfc64PublicOpenCatalogScopeV1,
   type Rfc64BoundedPublicRootCatalogNativeReceiverClientV1,
   type Rfc64BoundedPublicRootCatalogStagedHeadV1,
 } from '../src/rfc64/public-catalog-native-reconciler-v1.js';
+import { deriveRfc64PublicOpenCatalogScopeV1 } from '../src/rfc64/public-open-catalog-scope-v1.js';
 import {
   Rfc64PublicCatalogNativeReceiverErrorV1,
 } from '../src/rfc64/public-catalog-native-receiver-v1.js';

--- a/packages/agent/test/rfc64-public-catalog-service-v1.test.ts
+++ b/packages/agent/test/rfc64-public-catalog-service-v1.test.ts
@@ -28,6 +28,9 @@ import {
   type Rfc64PublicCatalogReconcilerClientsV1,
 } from '../src/rfc64/public-catalog-service-v1.js';
 import {
+  RFC64_PUBLIC_CATALOG_CURRENT_HEAD_DISCOVERY_PROTOCOL_V1,
+} from '../src/rfc64/public-catalog-current-head-discovery-v1.js';
+import {
   RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_KIND_V1,
   RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_PROTOCOL_V1,
   RFC64_PUBLIC_CATALOG_OBJECT_FETCH_PROTOCOL_V1,
@@ -99,10 +102,11 @@ class RecordingRouter {
   }
 }
 
-function controlObjects(): Rfc64ControlObjectOperationsV1 {
+function controlObjects() {
   return {
     namespaceDurability: 'posix-hardlink-no-replace-directory-fsync-v1',
     getVerifiedObject: vi.fn(async () => null),
+    getVerifiedObjectByDigest: vi.fn(async () => null),
     stageVerifiedObjects: vi.fn(async (input) => ({
       durable: true,
       namespaceDurability: 'posix-hardlink-no-replace-directory-fsync-v1',
@@ -809,6 +813,7 @@ describe('RFC-64 public catalog service v1 lifecycle ownership', () => {
       controlObjects: controlObjects(),
       accessPolicyAuthority: accessPolicyAuthority(),
       native: nativeOptions(() => inertReconciler()),
+      currentHeadDiscovery: { readCurrentAppliedCatalogHeadDigest: async () => null },
     });
 
     expect(() => service.start()).toThrow('registration failed');
@@ -821,6 +826,10 @@ describe('RFC-64 public catalog service v1 lifecycle ownership', () => {
     expect(countEvent(
       router,
       `unregister:${RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_PROTOCOL_V1}`,
+    )).toBe(1);
+    expect(countEvent(
+      router,
+      `unregister:${RFC64_PUBLIC_CATALOG_CURRENT_HEAD_DISCOVERY_PROTOCOL_V1}`,
     )).toBe(1);
     await service.close();
   });

--- a/packages/agent/vitest.rfc64-unit-tests.ts
+++ b/packages/agent/vitest.rfc64-unit-tests.ts
@@ -18,6 +18,7 @@ export const RFC64_UNIT_TESTS = [
   "test/rfc64-durable-file-store-v1.test.ts",
   "test/rfc64-secure-filesystem-policy-v1.test.ts",
   "test/rfc64-public-catalog-transport-v1.test.ts",
+  "test/rfc64-public-catalog-current-head-discovery-v1.test.ts",
   "test/rfc64-public-catalog-receiver-v1.test.ts",
   "test/rfc64-public-catalog-reconciliation-failure-v1.test.ts",
   "test/rfc64-public-catalog-service-v1.test.ts",


### PR DESCRIPTION
## Scope

- Adds a bounded canonical current-applied-head discovery protocol.
- Requires public-open policy generation and exact scope binding.
- Reads only durable semantically applied heads.
- Re-verifies the exact signature variant on the requester.
- Double-reads the applied ref with one bounded retry to close a TOCTOU race.
- Propagates inbound stream abort and snapshots caller-owned inputs.

## Evidence

- Discovery, service, transport, and native integration: 26 passed.
- Agent build, type tests, and package-root checks passed.
- Malformed, oversized, BOM, trailing-byte, duplicate-field, Proxy, stale-ref, and abort cases fail closed.

## Review status

Ready seam for review against integration/rfc64-devnet. This is not Gate 3 completion: lifecycle triggers, peer selection, predecessor bootstrap, timeliness, and anti-rollback remain separate work. No RFC-64 work targets main.