### PR TITLE
feat(rfc64): classify policy privacy cells

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -29,6 +29,7 @@
     "./dist/rfc64/persistence-layout-v1.js": null,
     "./dist/rfc64/persistence-root-ownership-v1-internal.js": null,
     "./dist/rfc64/persistence-v1.js": null,
+    "./dist/rfc64/policy-cell-v1.js": null,
     "./dist/rfc64/public-catalog-native-receiver-v1.js": null,
     "./dist/rfc64/public-catalog-native-reconciler-v1.js": null,
     "./dist/rfc64/public-catalog-native-transport-v1.js": null,

--- a/packages/agent/scripts/test-package-root.mjs
+++ b/packages/agent/scripts/test-package-root.mjs
@@ -39,6 +39,7 @@ const blockedRfc64Modules = [
   'persistence-layout-v1.js',
   'persistence-root-ownership-v1-internal.js',
   'persistence-v1.js',
+  'policy-cell-v1.js',
   'public-catalog-native-reconciler-v1.js',
   'public-catalog-native-receiver-v1.js',
   'public-catalog-native-transport-v1.js',

--- a/packages/agent/scripts/test-package-root.mjs
+++ b/packages/agent/scripts/test-package-root.mjs
@@ -7,13 +7,30 @@ const root = await import('@origintrail-official/dkg-agent');
 const legacyAgent = await import('@origintrail-official/dkg-agent/dist/dkg-agent.js');
 const require = createRequire(import.meta.url);
 const packageManifest = require('@origintrail-official/dkg-agent/package.json');
+const expectedRfc64PolicyCells = [
+  'public-open',
+  'public-curated',
+  'private-open',
+  'private-curated',
+];
 
 if (
   typeof root.DKGAgent !== 'function'
   || typeof legacyAgent.DKGAgent !== 'function'
   || typeof root.Rfc64PublicCatalogSuccessorProducerV1 !== 'function'
+  || typeof root.classifyRfc64PolicyCellV1 !== 'function'
 ) {
   throw new Error('published agent entry points did not expose required root APIs');
+}
+if (
+  !Array.isArray(root.RFC64_POLICY_CELLS_V1)
+  || !Object.isFrozen(root.RFC64_POLICY_CELLS_V1)
+  || root.RFC64_POLICY_CELLS_V1.length !== expectedRfc64PolicyCells.length
+  || root.RFC64_POLICY_CELLS_V1.some(
+    (cell, index) => cell !== expectedRfc64PolicyCells[index]
+  )
+) {
+  throw new Error('package root did not expose the closed RFC-64 policy-cell list');
 }
 if (packageManifest.name !== '@origintrail-official/dkg-agent') {
   throw new Error('historical package.json subpath no longer resolves');

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -45,6 +45,7 @@ export * from './rfc64/public-catalog-native-transport-v1.js';
 export * from './rfc64/public-catalog-native-receiver-v1.js';
 export * from './rfc64/public-catalog-successor-producer-v1.js';
 export * from './rfc64/public-catalog-native-reconciler-v1.js';
+export * from './rfc64/policy-cell-v1.js';
 export { encrypt, decrypt, ed25519ToX25519Private, ed25519ToX25519Public, x25519SharedSecret } from './encryption.js';
 export { MessageHandler, type SkillRequest, type SkillResponse, type SkillHandler, type ChatHandler, type ChatAclCheck } from './messaging.js';
 export {

--- a/packages/agent/src/rfc64/policy-cell-v1.ts
+++ b/packages/agent/src/rfc64/policy-cell-v1.ts
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Pure OT-RFC-64 D26 policy-cell classification.
+ *
+ * This helper deliberately does not authorize a principal. It only converts one
+ * already-canonical ContextGraphPolicyV1 into the closed operation modes that
+ * policy-aware transports, reconcilers, and evidence collectors must implement.
+ * Signatures, policy history/finality, roster freshness, peer-to-agent binding,
+ * VM inclusion-time authority, and ingress capabilities remain separate proofs.
+ */
+
+import {
+  assertContextGraphPolicyV1,
+  canonicalizeContextGraphPolicyPayloadV1,
+  parseCanonicalContextGraphPolicyPayloadV1,
+  type ContextGraphPolicyV1,
+  type EvmAddressV1,
+} from '@origintrail-official/dkg-core';
+
+export const RFC64_POLICY_CELLS_V1 = Object.freeze([
+  'public-open',
+  'public-curated',
+  'private-open',
+  'private-curated',
+] as const);
+
+export type Rfc64PolicyCellV1 = (typeof RFC64_POLICY_CELLS_V1)[number];
+
+export type Rfc64VmPublisherAuthorizationModeV1 =
+  | 'any-wallet'
+  | 'direct-eoa-or-safe'
+  | 'pca-owner-or-registered-agent';
+
+export interface Rfc64PolicyCellDescriptorV1 {
+  readonly cell: Rfc64PolicyCellV1;
+  readonly sharing: 'open' | 'invite-only';
+  readonly contribution: 'open' | 'curated';
+  /** Open sharing forbids an exhaustive member roster; invite-only requires one. */
+  readonly rosterMode: 'forbidden' | 'required';
+  readonly catalogDisclosure: 'open-authenticated' | 'current-member-only';
+  readonly swmSubmission: 'open-authenticated' | 'current-member-only';
+  readonly ordinaryPayloadFetch: 'open-authenticated' | 'current-member-only';
+  readonly providerEligibility:
+    | 'authenticated-exact-bundle-holder'
+    | 'current-member-with-provider-role';
+  readonly vmPublisherAuthorization: Rfc64VmPublisherAuthorizationModeV1;
+  /** Null for open contribution; exact policy value for curated contribution. */
+  readonly publishAuthority: EvmAddressV1 | null;
+  readonly publishAuthorityAccountId: ContextGraphPolicyV1['publishAuthorityAccountId'];
+  /** Unregistered policy has no VM expected set; a registered policy follows chain ordinals. */
+  readonly vmExpectedSet: 'none-unregistered' | 'finalized-chain-ordinals';
+  /**
+   * The exceptional nonmember upload path. Inclusion-time policy still decides
+   * eligibility, so current curated policy cannot reject a historical ordinal
+   * that was finalized while contribution was open.
+   */
+  readonly writeOnlyVmIngress:
+    | 'not-applicable-open-sharing'
+    | 'not-applicable-unregistered'
+    | 'finalized-open-inclusion-only'
+    | 'historical-open-inclusion-only';
+}
+
+/**
+ * Snapshot and classify both D26 axes without inferring either from the other.
+ * The canonical round trip owns the snapshot before any field is consulted.
+ */
+export function classifyRfc64PolicyCellV1(
+  policyInput: ContextGraphPolicyV1,
+): Readonly<Rfc64PolicyCellDescriptorV1> {
+  assertContextGraphPolicyV1(policyInput);
+  const policy = parseCanonicalContextGraphPolicyPayloadV1(
+    canonicalizeContextGraphPolicyPayloadV1(policyInput),
+  );
+
+  const openSharing = policy.accessPolicy === 0;
+  const openContribution = policy.publishPolicy === 1;
+  const registered = policy.source.kind === 'finalized-chain';
+  const vmPublisherAuthorization: Rfc64VmPublisherAuthorizationModeV1 =
+    openContribution
+      ? 'any-wallet'
+      : policy.publishAuthorityAccountId === '0'
+        ? 'direct-eoa-or-safe'
+        : 'pca-owner-or-registered-agent';
+
+  const writeOnlyVmIngress: Rfc64PolicyCellDescriptorV1['writeOnlyVmIngress'] =
+    openSharing
+      ? 'not-applicable-open-sharing'
+      : !registered
+        ? 'not-applicable-unregistered'
+        : openContribution
+          ? 'finalized-open-inclusion-only'
+          : 'historical-open-inclusion-only';
+
+  return Object.freeze({
+    cell: policyCell(policy.accessPolicy, policy.publishPolicy),
+    sharing: openSharing ? 'open' : 'invite-only',
+    contribution: openContribution ? 'open' : 'curated',
+    rosterMode: openSharing ? 'forbidden' : 'required',
+    catalogDisclosure: openSharing ? 'open-authenticated' : 'current-member-only',
+    swmSubmission: openSharing ? 'open-authenticated' : 'current-member-only',
+    ordinaryPayloadFetch: openSharing ? 'open-authenticated' : 'current-member-only',
+    providerEligibility: openSharing
+      ? 'authenticated-exact-bundle-holder'
+      : 'current-member-with-provider-role',
+    vmPublisherAuthorization,
+    publishAuthority: policy.publishAuthority,
+    publishAuthorityAccountId: policy.publishAuthorityAccountId,
+    vmExpectedSet: registered ? 'finalized-chain-ordinals' : 'none-unregistered',
+    writeOnlyVmIngress,
+  });
+}
+
+function policyCell(
+  accessPolicy: ContextGraphPolicyV1['accessPolicy'],
+  publishPolicy: ContextGraphPolicyV1['publishPolicy'],
+): Rfc64PolicyCellV1 {
+  if (accessPolicy === 0) return publishPolicy === 1 ? 'public-open' : 'public-curated';
+  return publishPolicy === 1 ? 'private-open' : 'private-curated';
+}

--- a/packages/agent/src/rfc64/policy-cell-v1.ts
+++ b/packages/agent/src/rfc64/policy-cell-v1.ts
@@ -18,22 +18,12 @@ import {
   type EvmAddressV1,
 } from '@origintrail-official/dkg-core';
 
-export const RFC64_POLICY_CELLS_V1 = Object.freeze([
-  'public-open',
-  'public-curated',
-  'private-open',
-  'private-curated',
-] as const);
-
-export type Rfc64PolicyCellV1 = (typeof RFC64_POLICY_CELLS_V1)[number];
-
 export type Rfc64VmPublisherAuthorizationModeV1 =
   | 'any-wallet'
   | 'direct-eoa-or-safe'
   | 'pca-owner-or-registered-agent';
 
-export interface Rfc64PolicyCellDescriptorV1 {
-  readonly cell: Rfc64PolicyCellV1;
+interface Rfc64PolicyCellStaticDescriptorV1 {
   readonly sharing: 'open' | 'invite-only';
   readonly contribution: 'open' | 'curated';
   /** Open sharing forbids an exhaustive member roster; invite-only requires one. */
@@ -44,6 +34,78 @@ export interface Rfc64PolicyCellDescriptorV1 {
   readonly providerEligibility:
     | 'authenticated-exact-bundle-holder'
     | 'current-member-with-provider-role';
+}
+
+interface Rfc64PolicyCellTableEntryV1 {
+  readonly accessPolicy: ContextGraphPolicyV1['accessPolicy'];
+  readonly publishPolicy: ContextGraphPolicyV1['publishPolicy'];
+  readonly descriptor: Readonly<Rfc64PolicyCellStaticDescriptorV1>;
+}
+
+function definePolicyCellV1(
+  accessPolicy: ContextGraphPolicyV1['accessPolicy'],
+  publishPolicy: ContextGraphPolicyV1['publishPolicy'],
+  descriptor: Rfc64PolicyCellStaticDescriptorV1,
+): Readonly<Rfc64PolicyCellTableEntryV1> {
+  return Object.freeze({
+    accessPolicy,
+    publishPolicy,
+    descriptor: Object.freeze({ ...descriptor }),
+  });
+}
+
+/** One closed source of truth for both D26 axes and every cell-static mode. */
+const RFC64_POLICY_CELL_TABLE_V1 = Object.freeze({
+  'public-open': definePolicyCellV1(0, 1, {
+    sharing: 'open',
+    contribution: 'open',
+    rosterMode: 'forbidden',
+    catalogDisclosure: 'open-authenticated',
+    swmSubmission: 'open-authenticated',
+    ordinaryPayloadFetch: 'open-authenticated',
+    providerEligibility: 'authenticated-exact-bundle-holder',
+  }),
+  'public-curated': definePolicyCellV1(0, 0, {
+    sharing: 'open',
+    contribution: 'curated',
+    rosterMode: 'forbidden',
+    catalogDisclosure: 'open-authenticated',
+    swmSubmission: 'open-authenticated',
+    ordinaryPayloadFetch: 'open-authenticated',
+    providerEligibility: 'authenticated-exact-bundle-holder',
+  }),
+  'private-open': definePolicyCellV1(1, 1, {
+    sharing: 'invite-only',
+    contribution: 'open',
+    rosterMode: 'required',
+    catalogDisclosure: 'current-member-only',
+    swmSubmission: 'current-member-only',
+    ordinaryPayloadFetch: 'current-member-only',
+    providerEligibility: 'current-member-with-provider-role',
+  }),
+  'private-curated': definePolicyCellV1(1, 0, {
+    sharing: 'invite-only',
+    contribution: 'curated',
+    rosterMode: 'required',
+    catalogDisclosure: 'current-member-only',
+    swmSubmission: 'current-member-only',
+    ordinaryPayloadFetch: 'current-member-only',
+    providerEligibility: 'current-member-with-provider-role',
+  }),
+} satisfies Record<string, Rfc64PolicyCellTableEntryV1>);
+
+export type Rfc64PolicyCellV1 = keyof typeof RFC64_POLICY_CELL_TABLE_V1;
+
+export const RFC64_POLICY_CELLS_V1: readonly Rfc64PolicyCellV1[] = Object.freeze(
+  Object.keys(RFC64_POLICY_CELL_TABLE_V1) as Rfc64PolicyCellV1[],
+);
+
+type Rfc64PolicyAxesKeyV1 = `${ContextGraphPolicyV1['accessPolicy']}:${ContextGraphPolicyV1['publishPolicy']}`;
+
+const RFC64_POLICY_CELL_BY_AXES_V1 = buildPolicyCellLookupV1();
+
+export interface Rfc64PolicyCellDescriptorV1 extends Rfc64PolicyCellStaticDescriptorV1 {
+  readonly cell: Rfc64PolicyCellV1;
   readonly vmPublisherAuthorization: Rfc64VmPublisherAuthorizationModeV1;
   /** Null for open contribution; exact policy value for curated contribution. */
   readonly publishAuthority: EvmAddressV1 | null;
@@ -74,36 +136,30 @@ export function classifyRfc64PolicyCellV1(
     canonicalizeContextGraphPolicyPayloadV1(policyInput),
   );
 
-  const openSharing = policy.accessPolicy === 0;
-  const openContribution = policy.publishPolicy === 1;
+  const cell = RFC64_POLICY_CELL_BY_AXES_V1[
+    `${policy.accessPolicy}:${policy.publishPolicy}` as Rfc64PolicyAxesKeyV1
+  ];
+  const cellDescriptor = RFC64_POLICY_CELL_TABLE_V1[cell].descriptor;
   const registered = policy.source.kind === 'finalized-chain';
   const vmPublisherAuthorization: Rfc64VmPublisherAuthorizationModeV1 =
-    openContribution
+    cellDescriptor.contribution === 'open'
       ? 'any-wallet'
       : policy.publishAuthorityAccountId === '0'
         ? 'direct-eoa-or-safe'
         : 'pca-owner-or-registered-agent';
 
   const writeOnlyVmIngress: Rfc64PolicyCellDescriptorV1['writeOnlyVmIngress'] =
-    openSharing
+    cellDescriptor.sharing === 'open'
       ? 'not-applicable-open-sharing'
       : !registered
         ? 'not-applicable-unregistered'
-        : openContribution
+        : cellDescriptor.contribution === 'open'
           ? 'finalized-open-inclusion-only'
           : 'historical-open-inclusion-only';
 
   return Object.freeze({
-    cell: policyCell(policy.accessPolicy, policy.publishPolicy),
-    sharing: openSharing ? 'open' : 'invite-only',
-    contribution: openContribution ? 'open' : 'curated',
-    rosterMode: openSharing ? 'forbidden' : 'required',
-    catalogDisclosure: openSharing ? 'open-authenticated' : 'current-member-only',
-    swmSubmission: openSharing ? 'open-authenticated' : 'current-member-only',
-    ordinaryPayloadFetch: openSharing ? 'open-authenticated' : 'current-member-only',
-    providerEligibility: openSharing
-      ? 'authenticated-exact-bundle-holder'
-      : 'current-member-with-provider-role',
+    cell,
+    ...cellDescriptor,
     vmPublisherAuthorization,
     publishAuthority: policy.publishAuthority,
     publishAuthorityAccountId: policy.publishAuthorityAccountId,
@@ -112,10 +168,17 @@ export function classifyRfc64PolicyCellV1(
   });
 }
 
-function policyCell(
-  accessPolicy: ContextGraphPolicyV1['accessPolicy'],
-  publishPolicy: ContextGraphPolicyV1['publishPolicy'],
-): Rfc64PolicyCellV1 {
-  if (accessPolicy === 0) return publishPolicy === 1 ? 'public-open' : 'public-curated';
-  return publishPolicy === 1 ? 'private-open' : 'private-curated';
+function buildPolicyCellLookupV1(): Readonly<Record<Rfc64PolicyAxesKeyV1, Rfc64PolicyCellV1>> {
+  const lookup = Object.create(null) as Record<string, Rfc64PolicyCellV1>;
+  for (const cell of RFC64_POLICY_CELLS_V1) {
+    const entry = RFC64_POLICY_CELL_TABLE_V1[cell];
+    const key = `${entry.accessPolicy}:${entry.publishPolicy}`;
+    if (Object.hasOwn(lookup, key)) {
+      throw new Error(`duplicate RFC-64 policy axes in canonical table: ${key}`);
+    }
+    lookup[key] = cell;
+  }
+  return Object.freeze(lookup) as Readonly<
+    Record<Rfc64PolicyAxesKeyV1, Rfc64PolicyCellV1>
+  >;
 }

--- a/packages/agent/test/rfc64-policy-cell-v1.test.ts
+++ b/packages/agent/test/rfc64-policy-cell-v1.test.ts
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest';
+import type { ContextGraphPolicyV1 } from '@origintrail-official/dkg-core';
+
+import {
+  RFC64_POLICY_CELLS_V1,
+  classifyRfc64PolicyCellV1,
+} from '../src/rfc64/policy-cell-v1.js';
+
+const OWNER = '0x1111111111111111111111111111111111111111' as const;
+const CURATOR = '0x2222222222222222222222222222222222222222' as const;
+const GOVERNANCE = '0x3333333333333333333333333333333333333333' as const;
+
+function policy(
+  accessPolicy: 0 | 1,
+  publishPolicy: 0 | 1,
+  options: { registered?: boolean; pca?: boolean } = {},
+): ContextGraphPolicyV1 {
+  const registered = options.registered ?? true;
+  return {
+    networkId: 'otp:20430',
+    contextGraphId: '0x1111111111111111111111111111111111111111/policy-cell',
+    governanceChainId: registered ? '20430' : null,
+    governanceContractAddress: registered ? GOVERNANCE : null,
+    ownershipTransitionDigest: null,
+    era: '0',
+    version: '0',
+    previousPolicyDigest: null,
+    accessPolicy,
+    publishPolicy,
+    publishAuthority: publishPolicy === 0 ? CURATOR : null,
+    publishAuthorityAccountId: publishPolicy === 0 && options.pca ? '7' : '0',
+    projectionId: 'cg-shared-v1',
+    administrativeDelegationDigest: null,
+    source: registered
+      ? {
+          kind: 'finalized-chain',
+          chainId: '20430',
+          contractAddress: GOVERNANCE,
+          blockNumber: '42',
+          blockHash: `0x${'44'.repeat(32)}`,
+        }
+      : {
+          kind: 'owner-signed-unregistered',
+          ownerAddress: OWNER,
+          ownerAuthorityEra: '0',
+        },
+    effectiveAt: '1700000000000',
+    issuedAt: '1700000000000',
+  };
+}
+
+describe('RFC-64 D26 policy cell classification', () => {
+  it('keeps the four sharing/contribution cells closed and orthogonal', () => {
+    expect(RFC64_POLICY_CELLS_V1).toEqual([
+      'public-open',
+      'public-curated',
+      'private-open',
+      'private-curated',
+    ]);
+    const cells = [
+      classifyRfc64PolicyCellV1(policy(0, 1)),
+      classifyRfc64PolicyCellV1(policy(0, 0)),
+      classifyRfc64PolicyCellV1(policy(1, 1)),
+      classifyRfc64PolicyCellV1(policy(1, 0)),
+    ];
+    expect(cells.map((cell) => cell.cell)).toEqual(RFC64_POLICY_CELLS_V1);
+    expect(cells.map((cell) => cell.rosterMode)).toEqual([
+      'forbidden',
+      'forbidden',
+      'required',
+      'required',
+    ]);
+    expect(cells.map((cell) => cell.vmPublisherAuthorization)).toEqual([
+      'any-wallet',
+      'direct-eoa-or-safe',
+      'any-wallet',
+      'direct-eoa-or-safe',
+    ]);
+    expect(cells.map((cell) => cell.catalogDisclosure)).toEqual([
+      'open-authenticated',
+      'open-authenticated',
+      'current-member-only',
+      'current-member-only',
+    ]);
+  });
+
+  it('classifies direct and PCA curator domains without granting authority', () => {
+    expect(classifyRfc64PolicyCellV1(policy(0, 0)).vmPublisherAuthorization)
+      .toBe('direct-eoa-or-safe');
+    expect(classifyRfc64PolicyCellV1(policy(0, 0, { pca: true })).vmPublisherAuthorization)
+      .toBe('pca-owner-or-registered-agent');
+  });
+
+  it('makes write-only ingress inclusion-time and registration aware', () => {
+    expect(classifyRfc64PolicyCellV1(policy(1, 1)).writeOnlyVmIngress)
+      .toBe('finalized-open-inclusion-only');
+    expect(classifyRfc64PolicyCellV1(policy(1, 0)).writeOnlyVmIngress)
+      .toBe('historical-open-inclusion-only');
+    expect(classifyRfc64PolicyCellV1(policy(1, 1, { registered: false })).writeOnlyVmIngress)
+      .toBe('not-applicable-unregistered');
+    expect(classifyRfc64PolicyCellV1(policy(0, 1)).writeOnlyVmIngress)
+      .toBe('not-applicable-open-sharing');
+  });
+
+  it('returns a detached immutable descriptor', () => {
+    const source = policy(1, 0, { pca: true });
+    const descriptor = classifyRfc64PolicyCellV1(source);
+    (source as { accessPolicy: 0 | 1 }).accessPolicy = 0;
+    expect(descriptor.cell).toBe('private-curated');
+    expect(Object.isFrozen(descriptor)).toBe(true);
+  });
+
+  it('rejects malformed policy input instead of inferring a permissive cell', () => {
+    expect(() => classifyRfc64PolicyCellV1({
+      ...policy(1, 0),
+      publishAuthority: null,
+    })).toThrow(/cg-policy-publish-domain/);
+  });
+});

--- a/packages/agent/test/rfc64-policy-cell-v1.test.ts
+++ b/packages/agent/test/rfc64-policy-cell-v1.test.ts
@@ -65,43 +65,114 @@ describe('RFC-64 D26 policy cell classification', () => {
       classifyRfc64PolicyCellV1(policy(1, 1)),
       classifyRfc64PolicyCellV1(policy(1, 0)),
     ];
-    expect(cells.map((cell) => cell.cell)).toEqual(RFC64_POLICY_CELLS_V1);
-    expect(cells.map((cell) => cell.rosterMode)).toEqual([
-      'forbidden',
-      'forbidden',
-      'required',
-      'required',
+    expect(cells).toEqual([
+      {
+        cell: 'public-open',
+        sharing: 'open',
+        contribution: 'open',
+        rosterMode: 'forbidden',
+        catalogDisclosure: 'open-authenticated',
+        swmSubmission: 'open-authenticated',
+        ordinaryPayloadFetch: 'open-authenticated',
+        providerEligibility: 'authenticated-exact-bundle-holder',
+        vmPublisherAuthorization: 'any-wallet',
+        publishAuthority: null,
+        publishAuthorityAccountId: '0',
+        vmExpectedSet: 'finalized-chain-ordinals',
+        writeOnlyVmIngress: 'not-applicable-open-sharing',
+      },
+      {
+        cell: 'public-curated',
+        sharing: 'open',
+        contribution: 'curated',
+        rosterMode: 'forbidden',
+        catalogDisclosure: 'open-authenticated',
+        swmSubmission: 'open-authenticated',
+        ordinaryPayloadFetch: 'open-authenticated',
+        providerEligibility: 'authenticated-exact-bundle-holder',
+        vmPublisherAuthorization: 'direct-eoa-or-safe',
+        publishAuthority: CURATOR,
+        publishAuthorityAccountId: '0',
+        vmExpectedSet: 'finalized-chain-ordinals',
+        writeOnlyVmIngress: 'not-applicable-open-sharing',
+      },
+      {
+        cell: 'private-open',
+        sharing: 'invite-only',
+        contribution: 'open',
+        rosterMode: 'required',
+        catalogDisclosure: 'current-member-only',
+        swmSubmission: 'current-member-only',
+        ordinaryPayloadFetch: 'current-member-only',
+        providerEligibility: 'current-member-with-provider-role',
+        vmPublisherAuthorization: 'any-wallet',
+        publishAuthority: null,
+        publishAuthorityAccountId: '0',
+        vmExpectedSet: 'finalized-chain-ordinals',
+        writeOnlyVmIngress: 'finalized-open-inclusion-only',
+      },
+      {
+        cell: 'private-curated',
+        sharing: 'invite-only',
+        contribution: 'curated',
+        rosterMode: 'required',
+        catalogDisclosure: 'current-member-only',
+        swmSubmission: 'current-member-only',
+        ordinaryPayloadFetch: 'current-member-only',
+        providerEligibility: 'current-member-with-provider-role',
+        vmPublisherAuthorization: 'direct-eoa-or-safe',
+        publishAuthority: CURATOR,
+        publishAuthorityAccountId: '0',
+        vmExpectedSet: 'finalized-chain-ordinals',
+        writeOnlyVmIngress: 'historical-open-inclusion-only',
+      },
     ]);
-    expect(cells.map((cell) => cell.vmPublisherAuthorization)).toEqual([
-      'any-wallet',
-      'direct-eoa-or-safe',
-      'any-wallet',
-      'direct-eoa-or-safe',
-    ]);
-    expect(cells.map((cell) => cell.catalogDisclosure)).toEqual([
-      'open-authenticated',
-      'open-authenticated',
-      'current-member-only',
-      'current-member-only',
-    ]);
+    expect(Object.isFrozen(RFC64_POLICY_CELLS_V1)).toBe(true);
+    expect(cells.every(Object.isFrozen)).toBe(true);
   });
 
   it('classifies direct and PCA curator domains without granting authority', () => {
-    expect(classifyRfc64PolicyCellV1(policy(0, 0)).vmPublisherAuthorization)
-      .toBe('direct-eoa-or-safe');
-    expect(classifyRfc64PolicyCellV1(policy(0, 0, { pca: true })).vmPublisherAuthorization)
-      .toBe('pca-owner-or-registered-agent');
+    expect(classifyRfc64PolicyCellV1(policy(1, 0, { pca: true }))).toEqual({
+      cell: 'private-curated',
+      sharing: 'invite-only',
+      contribution: 'curated',
+      rosterMode: 'required',
+      catalogDisclosure: 'current-member-only',
+      swmSubmission: 'current-member-only',
+      ordinaryPayloadFetch: 'current-member-only',
+      providerEligibility: 'current-member-with-provider-role',
+      vmPublisherAuthorization: 'pca-owner-or-registered-agent',
+      publishAuthority: CURATOR,
+      publishAuthorityAccountId: '7',
+      vmExpectedSet: 'finalized-chain-ordinals',
+      writeOnlyVmIngress: 'historical-open-inclusion-only',
+    });
   });
 
   it('makes write-only ingress inclusion-time and registration aware', () => {
-    expect(classifyRfc64PolicyCellV1(policy(1, 1)).writeOnlyVmIngress)
-      .toBe('finalized-open-inclusion-only');
-    expect(classifyRfc64PolicyCellV1(policy(1, 0)).writeOnlyVmIngress)
-      .toBe('historical-open-inclusion-only');
-    expect(classifyRfc64PolicyCellV1(policy(1, 1, { registered: false })).writeOnlyVmIngress)
-      .toBe('not-applicable-unregistered');
-    expect(classifyRfc64PolicyCellV1(policy(0, 1)).writeOnlyVmIngress)
-      .toBe('not-applicable-open-sharing');
+    expect(classifyRfc64PolicyCellV1(policy(1, 0, {
+      registered: false,
+      pca: true,
+    }))).toEqual({
+      cell: 'private-curated',
+      sharing: 'invite-only',
+      contribution: 'curated',
+      rosterMode: 'required',
+      catalogDisclosure: 'current-member-only',
+      swmSubmission: 'current-member-only',
+      ordinaryPayloadFetch: 'current-member-only',
+      providerEligibility: 'current-member-with-provider-role',
+      vmPublisherAuthorization: 'pca-owner-or-registered-agent',
+      publishAuthority: CURATOR,
+      publishAuthorityAccountId: '7',
+      vmExpectedSet: 'none-unregistered',
+      writeOnlyVmIngress: 'not-applicable-unregistered',
+    });
+    expect(classifyRfc64PolicyCellV1(policy(0, 1, { registered: false })))
+      .toMatchObject({
+        vmExpectedSet: 'none-unregistered',
+        writeOnlyVmIngress: 'not-applicable-open-sharing',
+      });
   });
 
   it('returns a detached immutable descriptor', () => {

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -133,6 +133,7 @@ export default defineConfig({
       "test/rfc64-persistent-catalog-provider-v1.test.ts",
       "test/rfc64-public-catalog-successor-producer-v1.test.ts",
       "test/rfc64-dkg-agent-successor-publication.integration.test.ts",
+      "test/rfc64-policy-cell-v1.test.ts",
     ],
     testTimeout: 60_000,
     maxWorkers: 1,


### PR DESCRIPTION
## Scope

- Adds one exact orthogonal classifier for public/private and open/curated policy cells.
- Freezes the shared vocabulary required by the Gate 5 authorization lanes.
- Grants no authority and does not weaken the current public-open runtime.

## Evidence

- Focused classifier tests: 5 passed.
- Complete agent build, type tests, and package-root checks passed.
- Worktree is clean and the change is isolated.

## Review status

Ready foundational seam for review against integration/rfc64-devnet. Gate 5 still requires finalized policy snapshots, roster and peer capabilities, private transport, VM authority, redaction, and the full policy matrix harness. No RFC-64 work targets main.