### PR TITLE
feat(rfc64): add finalized VM-set accumulator

### DIFF
--- a/packages/core/src/author-catalog-codec.ts
+++ b/packages/core/src/author-catalog-codec.ts
@@ -25,16 +25,20 @@ import {
   type EvmAddressV1,
   type KaIdV1,
 } from './sync-wire-scalars.js';
+import {
+  MAX_NETWORK_ID_BYTES_V1,
+  assertNetworkIdV1 as assertSharedNetworkIdV1,
+  type NetworkIdV1,
+} from './sync-wire-identifiers.js';
 import { assertExactKeys, isPlainRecord } from './sync-wire-objects.js';
 
-declare const NETWORK_ID_V1_BRAND: unique symbol;
 declare const CONTEXT_GRAPH_ID_V1_BRAND: unique symbol;
 declare const SUBGRAPH_NAME_V1_BRAND: unique symbol;
 declare const ASSERTION_COORDINATE_V1_BRAND: unique symbol;
 declare const CATALOG_ASSERTION_SCOPE_V1_BRAND: unique symbol;
 declare const CATALOG_ASSERTION_SUBJECT_V1_BRAND: unique symbol;
 
-export type NetworkIdV1 = string & { readonly [NETWORK_ID_V1_BRAND]: true };
+export type { NetworkIdV1 } from './sync-wire-identifiers.js';
 export type ContextGraphIdV1 = string & { readonly [CONTEXT_GRAPH_ID_V1_BRAND]: true };
 export type SubGraphNameV1 = string & { readonly [SUBGRAPH_NAME_V1_BRAND]: true };
 export type AssertionCoordinateV1 = string & {
@@ -54,7 +58,7 @@ export const AUTHOR_CATALOG_KEY_DIGEST_DOMAIN_V1 =
 export const AUTHOR_CATALOG_ROW_DIGEST_DOMAIN_V1 =
   'dkg-author-catalog-row-v1\n' as const;
 
-export const MAX_AUTHOR_CATALOG_NETWORK_ID_BYTES_V1 = 128;
+export const MAX_AUTHOR_CATALOG_NETWORK_ID_BYTES_V1 = MAX_NETWORK_ID_BYTES_V1;
 export const MAX_AUTHOR_CATALOG_IDENTIFIER_BYTES_V1 = 256;
 export const MAX_AUTHOR_CATALOG_SCOPE_BYTES_V1 = 2048;
 export const MAX_AUTHOR_CATALOG_ROW_BYTES_V1 = 2048;
@@ -62,7 +66,6 @@ export const MAX_AUTHOR_CATALOG_ROW_DIGEST_INPUT_BYTES_V1 = 4096;
 export const MAX_AUTHOR_CATALOG_BUCKET_COUNT_V1 = 9_223_372_036_854_775_808n;
 export const PACKED_KA_NUMBER_BITS_V1 = 96n;
 
-const NETWORK_ID_PATTERN = /^[A-Za-z0-9._:-]+$/;
 const CONTEXT_GRAPH_ID_PATTERN = /^[A-Za-z0-9_:/\.@-]+$/;
 const CATALOG_IDENTIFIER_ASCII_FORBIDDEN = new Set([
   '<',
@@ -133,13 +136,13 @@ export function assertNetworkIdV1(
   value: unknown,
   label = 'networkId',
 ): asserts value is NetworkIdV1 {
-  const identifier = assertNfcUtf8Identifier(
-    value,
-    label,
-    MAX_AUTHOR_CATALOG_NETWORK_ID_BYTES_V1,
-  );
-  if (!NETWORK_ID_PATTERN.test(identifier)) {
-    fail('catalog-identifier', `${label} contains a character outside the networkId grammar`);
+  try {
+    assertSharedNetworkIdV1(value, label);
+  } catch (cause) {
+    const message = cause instanceof Error
+      ? cause.message
+      : `${label} is not a canonical networkId`;
+    fail('catalog-identifier', message, cause);
   }
 }
 

--- a/packages/core/src/finalized-vm-set-v1.ts
+++ b/packages/core/src/finalized-vm-set-v1.ts
@@ -82,6 +82,15 @@ export interface FinalizedVmSetEvidenceV1 {
   readonly highestFinalizedOrdinal: DecimalU64V1 | null;
 }
 
+type CanonicalFinalizedVmSetRowV1 = Readonly<FinalizedVmSetRowV1>
+  & Readonly<Record<string, CanonicalJsonValue>>;
+
+interface ValidatedFinalizedVmSetRowV1 {
+  readonly row: CanonicalFinalizedVmSetRowV1;
+  readonly ordinalValue: bigint;
+  readonly assertionVersionValue: bigint;
+}
+
 export type FinalizedVmSetV1ErrorCode =
   | 'finalized-vm-set-schema'
   | 'finalized-vm-set-scalar'
@@ -151,21 +160,28 @@ export function snapshotFinalizedVmSetRowV1(
   input: FinalizedVmSetRowV1,
 ): Readonly<FinalizedVmSetRowV1> {
   const scope = snapshotFinalizedVmSetScopeV1(scopeInput);
-  return snapshotFinalizedVmSetRowForScopeV1(scope, input);
+  return snapshotFinalizedVmSetRowForScopeV1(scope, input).row;
 }
 
 function snapshotFinalizedVmSetRowForScopeV1(
   scope: Readonly<FinalizedVmSetScopeV1>,
   input: FinalizedVmSetRowV1,
-): Readonly<FinalizedVmSetRowV1> {
+): ValidatedFinalizedVmSetRowV1 {
   const record = snapshotRecord(input, FINALIZED_VM_SET_ROW_KEYS, 'finalized VM row');
+  let ordinalValue: bigint;
+  let assertionVersionValue: bigint;
   try {
     assertCanonicalChainId(record.chainId, 'row.chainId');
     assertCanonicalEvmAddress(record.contractAddress, 'row.contractAddress');
     assertCanonicalDecimalU64(record.ordinal, 'row.ordinal');
+    ordinalValue = parseCanonicalDecimalU64(record.ordinal, 'row.ordinal');
     assertCanonicalEvmAddress(record.authorAddress, 'row.authorAddress');
     assertCanonicalDecimalU64(record.assertionVersion, 'row.assertionVersion');
-    if (parseCanonicalDecimalU64(record.assertionVersion, 'row.assertionVersion') === 0n) {
+    assertionVersionValue = parseCanonicalDecimalU64(
+      record.assertionVersion,
+      'row.assertionVersion',
+    );
+    if (assertionVersionValue === 0n) {
       fail('finalized-vm-set-scalar', 'row.assertionVersion must be positive');
     }
     assertCanonicalDigest(record.assertionRoot, 'row.assertionRoot');
@@ -206,7 +222,7 @@ function snapshotFinalizedVmSetRowForScopeV1(
     fail('finalized-vm-set-lane', 'finalized VM row differs from the trusted scope lane');
   }
 
-  return Object.freeze({
+  const row = Object.freeze({
     chainId: record.chainId,
     contractAddress: record.contractAddress,
     ordinal: record.ordinal,
@@ -217,7 +233,8 @@ function snapshotFinalizedVmSetRowForScopeV1(
     finalizedBlockNumber: record.finalizedBlockNumber,
     finalizedBlockHash: record.finalizedBlockHash,
     placementEvidenceDigest: record.placementEvidenceDigest,
-  }) as Readonly<FinalizedVmSetRowV1>;
+  }) as CanonicalFinalizedVmSetRowV1;
+  return Object.freeze({ row, ordinalValue, assertionVersionValue });
 }
 
 /** Compute the exact domain-separated RFC-64 leaf digest for one placed row. */
@@ -226,8 +243,8 @@ export function computeFinalizedVmSetLeafDigestV1(
   row: FinalizedVmSetRowV1,
 ): Digest32V1 {
   const trustedScope = snapshotFinalizedVmSetScopeV1(scope);
-  const snapshot = snapshotFinalizedVmSetRowForScopeV1(trustedScope, row);
-  return digestBytesToLowerHex(computeFinalizedVmSetLeafDigestBytesV1(snapshot));
+  const validated = snapshotFinalizedVmSetRowForScopeV1(trustedScope, row);
+  return digestBytesToLowerHex(computeFinalizedVmSetLeafDigestBytesV1(validated.row));
 }
 
 /** The canonical finalized-VM empty accumulator root. */
@@ -244,7 +261,11 @@ export function computeEmptyFinalizedVmSetRootV1(): Digest32V1 {
  */
 export class FinalizedVmSetAccumulatorV1 {
   readonly #scope: Readonly<FinalizedVmSetScopeV1>;
-  readonly #levels: Array<Uint8Array | undefined> = [];
+  readonly #frontier = new DomainSeparatedMerkleFrontier(
+    NODE_DOMAIN_BYTES,
+    ODD_DOMAIN_BYTES,
+    EMPTY_DOMAIN_BYTES,
+  );
   #rowCount = 0n;
   #highestFinalizedOrdinal: DecimalU64V1 | null = null;
   #highestOrdinalValue: bigint | null = null;
@@ -268,23 +289,18 @@ export class FinalizedVmSetAccumulatorV1 {
         fail('finalized-vm-set-state', 'finalized VM row count exceeds the u64 range');
       }
 
-      const row = snapshotFinalizedVmSetRowForScopeV1(this.#scope, rowInput);
-      const ordinal = parseCanonicalDecimalU64(row.ordinal, 'row.ordinal');
-      if (this.#highestOrdinalValue !== null && ordinal <= this.#highestOrdinalValue) {
+      const validated = snapshotFinalizedVmSetRowForScopeV1(this.#scope, rowInput);
+      if (
+        this.#highestOrdinalValue !== null
+        && validated.ordinalValue <= this.#highestOrdinalValue
+      ) {
         fail('finalized-vm-set-order', 'finalized VM rows must have unique increasing ordinals');
       }
 
-      let current = computeFinalizedVmSetLeafDigestBytesV1(row);
-      let level = 0;
-      while (this.#levels[level] !== undefined) {
-        current = digestBytes(NODE_DOMAIN_BYTES, this.#levels[level]!, current);
-        this.#levels[level] = undefined;
-        level += 1;
-      }
-      this.#levels[level] = current;
+      this.#frontier.append(computeFinalizedVmSetLeafDigestBytesV1(validated.row));
       this.#rowCount += 1n;
-      this.#highestOrdinalValue = ordinal;
-      this.#highestFinalizedOrdinal = row.ordinal;
+      this.#highestOrdinalValue = validated.ordinalValue;
+      this.#highestFinalizedOrdinal = validated.row.ordinal;
     } finally {
       this.#appendInProgress = false;
     }
@@ -296,30 +312,9 @@ export class FinalizedVmSetAccumulatorV1 {
     }
     if (this.#finalEvidence !== undefined) return this.#finalEvidence;
 
-    let pending: Uint8Array | undefined;
-    let pendingLevel = -1;
-    for (let level = 0; level < this.#levels.length; level += 1) {
-      const left = this.#levels[level];
-      if (left === undefined) continue;
-      if (pending === undefined) {
-        pending = left;
-        pendingLevel = level;
-        continue;
-      }
-      while (pendingLevel < level) {
-        pending = digestBytes(ODD_DOMAIN_BYTES, pending);
-        pendingLevel += 1;
-      }
-      pending = digestBytes(NODE_DOMAIN_BYTES, left, pending);
-      pendingLevel = level + 1;
-    }
-
-    const rootDigest = pending === undefined
-      ? computeEmptyFinalizedVmSetRootV1()
-      : digestBytesToLowerHex(pending);
     this.#finalEvidence = Object.freeze({
       scope: this.#scope,
-      rootDigest,
+      rootDigest: digestBytesToLowerHex(this.#frontier.finalizeRoot()),
       rowCount: this.#rowCount.toString() as DecimalU64V1,
       highestFinalizedOrdinal: this.#highestFinalizedOrdinal,
     });
@@ -338,15 +333,64 @@ export function computeFinalizedVmSetEvidenceV1(
 }
 
 function computeFinalizedVmSetLeafDigestBytesV1(
-  row: Readonly<FinalizedVmSetRowV1>,
+  row: CanonicalFinalizedVmSetRowV1,
 ): Uint8Array {
   return digestBytes(
     LEAF_DOMAIN_BYTES,
-    canonicalizeJsonBytes(row as unknown as CanonicalJsonValue, {
+    canonicalizeJsonBytes(row, {
       maxBytes: 2 * 1024,
       maxDepth: 2,
     }),
   );
+}
+
+class DomainSeparatedMerkleFrontier {
+  readonly #levels: Array<Uint8Array | undefined> = [];
+  #finalRoot: Uint8Array | undefined;
+
+  constructor(
+    private readonly nodeDomain: Uint8Array,
+    private readonly oddDomain: Uint8Array,
+    private readonly emptyDomain: Uint8Array,
+  ) {}
+
+  append(leafDigest: Uint8Array): void {
+    if (this.#finalRoot !== undefined) {
+      fail('finalized-vm-set-state', 'cannot append to a finalized Merkle frontier');
+    }
+    let current = leafDigest;
+    let level = 0;
+    while (this.#levels[level] !== undefined) {
+      current = digestBytes(this.nodeDomain, this.#levels[level]!, current);
+      this.#levels[level] = undefined;
+      level += 1;
+    }
+    this.#levels[level] = current;
+  }
+
+  finalizeRoot(): Uint8Array {
+    if (this.#finalRoot !== undefined) return this.#finalRoot;
+
+    let pending: Uint8Array | undefined;
+    let pendingLevel = -1;
+    for (let level = 0; level < this.#levels.length; level += 1) {
+      const left = this.#levels[level];
+      if (left === undefined) continue;
+      if (pending === undefined) {
+        pending = left;
+        pendingLevel = level;
+        continue;
+      }
+      while (pendingLevel < level) {
+        pending = digestBytes(this.oddDomain, pending);
+        pendingLevel += 1;
+      }
+      pending = digestBytes(this.nodeDomain, left, pending);
+      pendingLevel = level + 1;
+    }
+    this.#finalRoot = pending ?? digestBytes(this.emptyDomain);
+    return this.#finalRoot;
+  }
 }
 
 function snapshotRecord<const Keys extends readonly string[]>(

--- a/packages/core/src/finalized-vm-set-v1.ts
+++ b/packages/core/src/finalized-vm-set-v1.ts
@@ -1,8 +1,8 @@
 import { sha256 } from '@noble/hashes/sha2.js';
 
-import { assertNetworkIdV1, type NetworkIdV1 } from './author-catalog-codec.js';
 import { canonicalizeJsonBytes, type CanonicalJsonValue } from './canonical-json.js';
 import { parseDeterministicKnowledgeAssetUal } from './ka-content-scope.js';
+import { assertNetworkIdV1, type NetworkIdV1 } from './sync-wire-identifiers.js';
 import { snapshotExactDataRecord } from './sync-wire-objects.js';
 import {
   MAX_DECIMAL_U64,
@@ -209,7 +209,8 @@ function snapshotFinalizedVmSetRowForScopeV1(
     if (parsed.agentAddress !== record.authorAddress) {
       fail('finalized-vm-set-ual', 'row.ual author differs from row.authorAddress');
     }
-    if (parsed.chainId !== scope.networkId) {
+    const ualNetworkId = parsed.chainId;
+    if (ualNetworkId !== scope.networkId) {
       fail('finalized-vm-set-ual', 'row.ual namespace differs from the trusted network profile');
     }
   } catch (cause) {

--- a/packages/core/src/finalized-vm-set-v1.ts
+++ b/packages/core/src/finalized-vm-set-v1.ts
@@ -3,6 +3,7 @@ import { sha256 } from '@noble/hashes/sha2.js';
 import { assertNetworkIdV1, type NetworkIdV1 } from './author-catalog-codec.js';
 import { canonicalizeJsonBytes, type CanonicalJsonValue } from './canonical-json.js';
 import { parseDeterministicKnowledgeAssetUal } from './ka-content-scope.js';
+import { snapshotExactDataRecord } from './sync-wire-objects.js';
 import {
   MAX_DECIMAL_U64,
   assertCanonicalChainId,
@@ -105,7 +106,7 @@ export const MAX_FINALIZED_VM_SET_UAL_BYTES_V1 = 209;
 
 /** Snapshot and validate the exact chain/contract lane before any row callbacks run. */
 export function snapshotFinalizedVmLaneV1(input: FinalizedVmLaneV1): Readonly<FinalizedVmLaneV1> {
-  const record = snapshotExactDataRecord(input, FINALIZED_VM_LANE_KEYS, 'finalized VM lane');
+  const record = snapshotRecord(input, FINALIZED_VM_LANE_KEYS, 'finalized VM lane');
   try {
     assertCanonicalChainId(record.chainId, 'lane.chainId');
     assertCanonicalEvmAddress(record.contractAddress, 'lane.contractAddress');
@@ -122,7 +123,7 @@ export function snapshotFinalizedVmLaneV1(input: FinalizedVmLaneV1): Readonly<Fi
 export function snapshotFinalizedVmSetScopeV1(
   input: FinalizedVmSetScopeV1,
 ): Readonly<FinalizedVmSetScopeV1> {
-  const record = snapshotExactDataRecord(
+  const record = snapshotRecord(
     input,
     FINALIZED_VM_SET_SCOPE_KEYS,
     'finalized VM-set scope',
@@ -142,19 +143,22 @@ export function snapshotFinalizedVmSetScopeV1(
 }
 
 /**
- * Snapshot one row exactly once, rejecting accessors and non-canonical aliases.
- * The returned object is safe to retain across hashing or I/O callbacks.
+ * Snapshot one row against the complete trusted scope, rejecting accessors,
+ * non-canonical aliases, UAL namespace drift, and cross-lane rows in one boundary.
  */
 export function snapshotFinalizedVmSetRowV1(
+  scopeInput: FinalizedVmSetScopeV1,
   input: FinalizedVmSetRowV1,
-  expectedNetworkId: NetworkIdV1,
 ): Readonly<FinalizedVmSetRowV1> {
-  try {
-    assertNetworkIdV1(expectedNetworkId, 'expectedNetworkId');
-  } catch (cause) {
-    fail('finalized-vm-set-scalar', 'trusted network profile is not canonical', cause);
-  }
-  const record = snapshotExactDataRecord(input, FINALIZED_VM_SET_ROW_KEYS, 'finalized VM row');
+  const scope = snapshotFinalizedVmSetScopeV1(scopeInput);
+  return snapshotFinalizedVmSetRowForScopeV1(scope, input);
+}
+
+function snapshotFinalizedVmSetRowForScopeV1(
+  scope: Readonly<FinalizedVmSetScopeV1>,
+  input: FinalizedVmSetRowV1,
+): Readonly<FinalizedVmSetRowV1> {
+  const record = snapshotRecord(input, FINALIZED_VM_SET_ROW_KEYS, 'finalized VM row');
   try {
     assertCanonicalChainId(record.chainId, 'row.chainId');
     assertCanonicalEvmAddress(record.contractAddress, 'row.contractAddress');
@@ -190,12 +194,16 @@ export function snapshotFinalizedVmSetRowV1(
     if (parsed.agentAddress !== record.authorAddress) {
       fail('finalized-vm-set-ual', 'row.ual author differs from row.authorAddress');
     }
-    if (parsed.chainId !== expectedNetworkId) {
+    if (parsed.chainId !== scope.networkId) {
       fail('finalized-vm-set-ual', 'row.ual namespace differs from the trusted network profile');
     }
   } catch (cause) {
     if (cause instanceof FinalizedVmSetV1Error) throw cause;
     fail('finalized-vm-set-ual', 'row.ual is not a canonical deterministic KA UAL', cause);
+  }
+
+  if (record.chainId !== scope.chainId || record.contractAddress !== scope.contractAddress) {
+    fail('finalized-vm-set-lane', 'finalized VM row differs from the trusted scope lane');
   }
 
   return Object.freeze({
@@ -218,13 +226,7 @@ export function computeFinalizedVmSetLeafDigestV1(
   row: FinalizedVmSetRowV1,
 ): Digest32V1 {
   const trustedScope = snapshotFinalizedVmSetScopeV1(scope);
-  const snapshot = snapshotFinalizedVmSetRowV1(row, trustedScope.networkId);
-  if (
-    snapshot.chainId !== trustedScope.chainId
-    || snapshot.contractAddress !== trustedScope.contractAddress
-  ) {
-    fail('finalized-vm-set-lane', 'finalized VM row differs from the trusted scope lane');
-  }
+  const snapshot = snapshotFinalizedVmSetRowForScopeV1(trustedScope, row);
   return digestBytesToLowerHex(computeFinalizedVmSetLeafDigestBytesV1(snapshot));
 }
 
@@ -266,13 +268,7 @@ export class FinalizedVmSetAccumulatorV1 {
         fail('finalized-vm-set-state', 'finalized VM row count exceeds the u64 range');
       }
 
-      const row = snapshotFinalizedVmSetRowV1(rowInput, this.#scope.networkId);
-      if (
-        row.chainId !== this.#scope.chainId
-        || row.contractAddress !== this.#scope.contractAddress
-      ) {
-        fail('finalized-vm-set-lane', 'finalized VM row differs from the accumulator lane');
-      }
+      const row = snapshotFinalizedVmSetRowForScopeV1(this.#scope, rowInput);
       const ordinal = parseCanonicalDecimalU64(row.ordinal, 'row.ordinal');
       if (this.#highestOrdinalValue !== null && ordinal <= this.#highestOrdinalValue) {
         fail('finalized-vm-set-order', 'finalized VM rows must have unique increasing ordinals');
@@ -353,38 +349,20 @@ function computeFinalizedVmSetLeafDigestBytesV1(
   );
 }
 
-function snapshotExactDataRecord<const Keys extends readonly string[]>(
+function snapshotRecord<const Keys extends readonly string[]>(
   input: unknown,
   expectedKeys: Keys,
   label: string,
 ): Readonly<Record<Keys[number], unknown>> {
-  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
-    fail('finalized-vm-set-schema', `${label} must be a plain data object`);
+  try {
+    return snapshotExactDataRecord(input, expectedKeys, label);
+  } catch (cause) {
+    fail(
+      'finalized-vm-set-schema',
+      cause instanceof Error ? cause.message : `${label} is not an exact data record`,
+      cause,
+    );
   }
-  const prototype = Object.getPrototypeOf(input);
-  if (prototype !== Object.prototype && prototype !== null) {
-    fail('finalized-vm-set-schema', `${label} must be a plain data object`);
-  }
-  const keys = Reflect.ownKeys(input);
-  if (keys.some((key) => typeof key !== 'string')) {
-    fail('finalized-vm-set-schema', `${label} must not contain symbol fields`);
-  }
-  const strings = keys as string[];
-  if (
-    strings.length !== expectedKeys.length
-    || expectedKeys.some((key) => !strings.includes(key))
-  ) {
-    fail('finalized-vm-set-schema', `${label} has unknown or missing fields`);
-  }
-  const snapshot: Record<string, unknown> = Object.create(null);
-  for (const key of expectedKeys) {
-    const descriptor = Object.getOwnPropertyDescriptor(input, key);
-    if (!descriptor?.enumerable || !Object.prototype.hasOwnProperty.call(descriptor, 'value')) {
-      fail('finalized-vm-set-schema', `${label}.${key} must be an enumerable data field`);
-    }
-    snapshot[key] = descriptor.value;
-  }
-  return Object.freeze(snapshot) as Readonly<Record<Keys[number], unknown>>;
 }
 
 function digestBytes(domain: Uint8Array, ...chunks: readonly Uint8Array[]): Uint8Array {

--- a/packages/core/src/finalized-vm-set-v1.ts
+++ b/packages/core/src/finalized-vm-set-v1.ts
@@ -1,0 +1,410 @@
+import { sha256 } from '@noble/hashes/sha2.js';
+
+import { assertNetworkIdV1, type NetworkIdV1 } from './author-catalog-codec.js';
+import { canonicalizeJsonBytes, type CanonicalJsonValue } from './canonical-json.js';
+import { parseDeterministicKnowledgeAssetUal } from './ka-content-scope.js';
+import {
+  MAX_DECIMAL_U64,
+  assertCanonicalChainId,
+  assertCanonicalDecimalU64,
+  assertCanonicalDigest,
+  assertCanonicalEvmAddress,
+  parseCanonicalDecimalU64,
+  type ChainIdV1,
+  type DecimalU64V1,
+  type Digest32V1,
+  type EvmAddressV1,
+} from './sync-wire-scalars.js';
+
+export const FINALIZED_VM_SET_LEAF_DIGEST_DOMAIN_V1 =
+  'dkg-finalized-vm-set-leaf-v1\n' as const;
+export const FINALIZED_VM_SET_NODE_DIGEST_DOMAIN_V1 =
+  'dkg-finalized-vm-set-node-v1\n' as const;
+export const FINALIZED_VM_SET_ODD_DIGEST_DOMAIN_V1 =
+  'dkg-finalized-vm-set-odd-v1\n' as const;
+export const FINALIZED_VM_SET_EMPTY_DIGEST_DOMAIN_V1 =
+  'dkg-finalized-vm-set-empty-v1\n' as const;
+
+const UTF8 = new TextEncoder();
+const LEAF_DOMAIN_BYTES = UTF8.encode(FINALIZED_VM_SET_LEAF_DIGEST_DOMAIN_V1);
+const NODE_DOMAIN_BYTES = UTF8.encode(FINALIZED_VM_SET_NODE_DIGEST_DOMAIN_V1);
+const ODD_DOMAIN_BYTES = UTF8.encode(FINALIZED_VM_SET_ODD_DIGEST_DOMAIN_V1);
+const EMPTY_DOMAIN_BYTES = UTF8.encode(FINALIZED_VM_SET_EMPTY_DIGEST_DOMAIN_V1);
+
+const FINALIZED_VM_LANE_KEYS = ['chainId', 'contractAddress'] as const;
+const FINALIZED_VM_SET_SCOPE_KEYS = ['networkId', 'chainId', 'contractAddress'] as const;
+const FINALIZED_VM_SET_ROW_KEYS = [
+  'assertionRoot',
+  'assertionVersion',
+  'authorAddress',
+  'chainId',
+  'contractAddress',
+  'finalizedBlockHash',
+  'finalizedBlockNumber',
+  'ordinal',
+  'placementEvidenceDigest',
+  'ual',
+] as const;
+
+export interface FinalizedVmLaneV1 {
+  readonly chainId: ChainIdV1;
+  readonly contractAddress: EvmAddressV1;
+}
+
+/** Subscription-pinned v10.0.8 network profile for one finalized VM set. */
+export interface FinalizedVmSetScopeV1 extends FinalizedVmLaneV1 {
+  readonly networkId: NetworkIdV1;
+}
+
+/**
+ * Exact placed finalized-chain row committed by one RFC-64 subgraph VM lane.
+ *
+ * This is deliberately structural evidence only. Constructing or hashing one
+ * of these rows does not establish finality, publisher authorization, author
+ * authority, subgraph placement authority, or semantic activation.
+ */
+export interface FinalizedVmSetRowV1 extends FinalizedVmLaneV1 {
+  readonly ordinal: DecimalU64V1;
+  readonly ual: string;
+  readonly authorAddress: EvmAddressV1;
+  readonly assertionVersion: DecimalU64V1;
+  readonly assertionRoot: Digest32V1;
+  readonly finalizedBlockNumber: DecimalU64V1;
+  readonly finalizedBlockHash: Digest32V1;
+  readonly placementEvidenceDigest: Digest32V1;
+}
+
+export interface FinalizedVmSetEvidenceV1 {
+  readonly scope: Readonly<FinalizedVmSetScopeV1>;
+  readonly rootDigest: Digest32V1;
+  readonly rowCount: DecimalU64V1;
+  readonly highestFinalizedOrdinal: DecimalU64V1 | null;
+}
+
+export type FinalizedVmSetV1ErrorCode =
+  | 'finalized-vm-set-schema'
+  | 'finalized-vm-set-scalar'
+  | 'finalized-vm-set-lane'
+  | 'finalized-vm-set-order'
+  | 'finalized-vm-set-ual'
+  | 'finalized-vm-set-state';
+
+export class FinalizedVmSetV1Error extends Error {
+  constructor(
+    readonly code: FinalizedVmSetV1ErrorCode,
+    message: string,
+    options: ErrorOptions = {},
+  ) {
+    super(`[${code}] ${message}`, options);
+    this.name = 'FinalizedVmSetV1Error';
+  }
+}
+
+/** Maximum v10.0.8 deterministic UAL bytes under the frozen network/id bounds. */
+export const MAX_FINALIZED_VM_SET_UAL_BYTES_V1 = 209;
+
+/** Snapshot and validate the exact chain/contract lane before any row callbacks run. */
+export function snapshotFinalizedVmLaneV1(input: FinalizedVmLaneV1): Readonly<FinalizedVmLaneV1> {
+  const record = snapshotExactDataRecord(input, FINALIZED_VM_LANE_KEYS, 'finalized VM lane');
+  try {
+    assertCanonicalChainId(record.chainId, 'lane.chainId');
+    assertCanonicalEvmAddress(record.contractAddress, 'lane.contractAddress');
+  } catch (cause) {
+    fail('finalized-vm-set-scalar', 'finalized VM lane contains a non-canonical scalar', cause);
+  }
+  return Object.freeze({
+    chainId: record.chainId,
+    contractAddress: record.contractAddress,
+  }) as Readonly<FinalizedVmLaneV1>;
+}
+
+/** Snapshot the trusted single-lane network profile before row iteration begins. */
+export function snapshotFinalizedVmSetScopeV1(
+  input: FinalizedVmSetScopeV1,
+): Readonly<FinalizedVmSetScopeV1> {
+  const record = snapshotExactDataRecord(
+    input,
+    FINALIZED_VM_SET_SCOPE_KEYS,
+    'finalized VM-set scope',
+  );
+  try {
+    assertNetworkIdV1(record.networkId, 'scope.networkId');
+    assertCanonicalChainId(record.chainId, 'scope.chainId');
+    assertCanonicalEvmAddress(record.contractAddress, 'scope.contractAddress');
+  } catch (cause) {
+    fail('finalized-vm-set-scalar', 'finalized VM-set scope contains a non-canonical scalar', cause);
+  }
+  return Object.freeze({
+    networkId: record.networkId,
+    chainId: record.chainId,
+    contractAddress: record.contractAddress,
+  }) as Readonly<FinalizedVmSetScopeV1>;
+}
+
+/**
+ * Snapshot one row exactly once, rejecting accessors and non-canonical aliases.
+ * The returned object is safe to retain across hashing or I/O callbacks.
+ */
+export function snapshotFinalizedVmSetRowV1(
+  input: FinalizedVmSetRowV1,
+  expectedNetworkId: NetworkIdV1,
+): Readonly<FinalizedVmSetRowV1> {
+  try {
+    assertNetworkIdV1(expectedNetworkId, 'expectedNetworkId');
+  } catch (cause) {
+    fail('finalized-vm-set-scalar', 'trusted network profile is not canonical', cause);
+  }
+  const record = snapshotExactDataRecord(input, FINALIZED_VM_SET_ROW_KEYS, 'finalized VM row');
+  try {
+    assertCanonicalChainId(record.chainId, 'row.chainId');
+    assertCanonicalEvmAddress(record.contractAddress, 'row.contractAddress');
+    assertCanonicalDecimalU64(record.ordinal, 'row.ordinal');
+    assertCanonicalEvmAddress(record.authorAddress, 'row.authorAddress');
+    assertCanonicalDecimalU64(record.assertionVersion, 'row.assertionVersion');
+    if (parseCanonicalDecimalU64(record.assertionVersion, 'row.assertionVersion') === 0n) {
+      fail('finalized-vm-set-scalar', 'row.assertionVersion must be positive');
+    }
+    assertCanonicalDigest(record.assertionRoot, 'row.assertionRoot');
+    assertCanonicalDecimalU64(record.finalizedBlockNumber, 'row.finalizedBlockNumber');
+    assertCanonicalDigest(record.finalizedBlockHash, 'row.finalizedBlockHash');
+    assertCanonicalDigest(record.placementEvidenceDigest, 'row.placementEvidenceDigest');
+  } catch (cause) {
+    if (cause instanceof FinalizedVmSetV1Error) throw cause;
+    fail('finalized-vm-set-scalar', 'finalized VM row contains a non-canonical scalar', cause);
+  }
+
+  if (typeof record.ual !== 'string') {
+    fail('finalized-vm-set-ual', 'row.ual must be a canonical deterministic KA UAL');
+  }
+  if (
+    record.ual.length > MAX_FINALIZED_VM_SET_UAL_BYTES_V1
+    || UTF8.encode(record.ual).byteLength > MAX_FINALIZED_VM_SET_UAL_BYTES_V1
+  ) {
+    fail('finalized-vm-set-ual', 'row.ual exceeds the v10.0.8 deterministic UAL byte bound');
+  }
+  try {
+    const parsed = parseDeterministicKnowledgeAssetUal(record.ual);
+    if (parsed.ual !== record.ual) {
+      fail('finalized-vm-set-ual', 'row.ual must not use a non-canonical identity alias');
+    }
+    if (parsed.agentAddress !== record.authorAddress) {
+      fail('finalized-vm-set-ual', 'row.ual author differs from row.authorAddress');
+    }
+    if (parsed.chainId !== expectedNetworkId) {
+      fail('finalized-vm-set-ual', 'row.ual namespace differs from the trusted network profile');
+    }
+  } catch (cause) {
+    if (cause instanceof FinalizedVmSetV1Error) throw cause;
+    fail('finalized-vm-set-ual', 'row.ual is not a canonical deterministic KA UAL', cause);
+  }
+
+  return Object.freeze({
+    chainId: record.chainId,
+    contractAddress: record.contractAddress,
+    ordinal: record.ordinal,
+    ual: record.ual,
+    authorAddress: record.authorAddress,
+    assertionVersion: record.assertionVersion,
+    assertionRoot: record.assertionRoot,
+    finalizedBlockNumber: record.finalizedBlockNumber,
+    finalizedBlockHash: record.finalizedBlockHash,
+    placementEvidenceDigest: record.placementEvidenceDigest,
+  }) as Readonly<FinalizedVmSetRowV1>;
+}
+
+/** Compute the exact domain-separated RFC-64 leaf digest for one placed row. */
+export function computeFinalizedVmSetLeafDigestV1(
+  scope: FinalizedVmSetScopeV1,
+  row: FinalizedVmSetRowV1,
+): Digest32V1 {
+  const trustedScope = snapshotFinalizedVmSetScopeV1(scope);
+  const snapshot = snapshotFinalizedVmSetRowV1(row, trustedScope.networkId);
+  if (
+    snapshot.chainId !== trustedScope.chainId
+    || snapshot.contractAddress !== trustedScope.contractAddress
+  ) {
+    fail('finalized-vm-set-lane', 'finalized VM row differs from the trusted scope lane');
+  }
+  return digestBytesToLowerHex(computeFinalizedVmSetLeafDigestBytesV1(snapshot));
+}
+
+/** The canonical finalized-VM empty accumulator root. */
+export function computeEmptyFinalizedVmSetRootV1(): Digest32V1 {
+  return digestBytesToLowerHex(digestBytes(EMPTY_DOMAIN_BYTES));
+}
+
+/**
+ * Streaming per-lane VM-set accumulator.
+ *
+ * Rows must arrive in strictly increasing unsigned ordinal order, matching an
+ * indexed planner stream. Memory stays O(log rowCount); the helper never sorts
+ * or buffers the VM inventory and therefore cannot hide duplicate ordinals.
+ */
+export class FinalizedVmSetAccumulatorV1 {
+  readonly #scope: Readonly<FinalizedVmSetScopeV1>;
+  readonly #levels: Array<Uint8Array | undefined> = [];
+  #rowCount = 0n;
+  #highestFinalizedOrdinal: DecimalU64V1 | null = null;
+  #highestOrdinalValue: bigint | null = null;
+  #finalEvidence: FinalizedVmSetEvidenceV1 | undefined;
+  #appendInProgress = false;
+
+  constructor(scope: FinalizedVmSetScopeV1) {
+    this.#scope = snapshotFinalizedVmSetScopeV1(scope);
+  }
+
+  append(rowInput: FinalizedVmSetRowV1): void {
+    if (this.#finalEvidence !== undefined) {
+      fail('finalized-vm-set-state', 'cannot append after the VM-set accumulator is finalized');
+    }
+    if (this.#appendInProgress) {
+      fail('finalized-vm-set-state', 'cannot re-enter a finalized VM-set append');
+    }
+    this.#appendInProgress = true;
+    try {
+      if (this.#rowCount >= MAX_DECIMAL_U64) {
+        fail('finalized-vm-set-state', 'finalized VM row count exceeds the u64 range');
+      }
+
+      const row = snapshotFinalizedVmSetRowV1(rowInput, this.#scope.networkId);
+      if (
+        row.chainId !== this.#scope.chainId
+        || row.contractAddress !== this.#scope.contractAddress
+      ) {
+        fail('finalized-vm-set-lane', 'finalized VM row differs from the accumulator lane');
+      }
+      const ordinal = parseCanonicalDecimalU64(row.ordinal, 'row.ordinal');
+      if (this.#highestOrdinalValue !== null && ordinal <= this.#highestOrdinalValue) {
+        fail('finalized-vm-set-order', 'finalized VM rows must have unique increasing ordinals');
+      }
+
+      let current = computeFinalizedVmSetLeafDigestBytesV1(row);
+      let level = 0;
+      while (this.#levels[level] !== undefined) {
+        current = digestBytes(NODE_DOMAIN_BYTES, this.#levels[level]!, current);
+        this.#levels[level] = undefined;
+        level += 1;
+      }
+      this.#levels[level] = current;
+      this.#rowCount += 1n;
+      this.#highestOrdinalValue = ordinal;
+      this.#highestFinalizedOrdinal = row.ordinal;
+    } finally {
+      this.#appendInProgress = false;
+    }
+  }
+
+  finalize(): FinalizedVmSetEvidenceV1 {
+    if (this.#appendInProgress) {
+      fail('finalized-vm-set-state', 'cannot finalize during a finalized VM-set append');
+    }
+    if (this.#finalEvidence !== undefined) return this.#finalEvidence;
+
+    let pending: Uint8Array | undefined;
+    let pendingLevel = -1;
+    for (let level = 0; level < this.#levels.length; level += 1) {
+      const left = this.#levels[level];
+      if (left === undefined) continue;
+      if (pending === undefined) {
+        pending = left;
+        pendingLevel = level;
+        continue;
+      }
+      while (pendingLevel < level) {
+        pending = digestBytes(ODD_DOMAIN_BYTES, pending);
+        pendingLevel += 1;
+      }
+      pending = digestBytes(NODE_DOMAIN_BYTES, left, pending);
+      pendingLevel = level + 1;
+    }
+
+    const rootDigest = pending === undefined
+      ? computeEmptyFinalizedVmSetRootV1()
+      : digestBytesToLowerHex(pending);
+    this.#finalEvidence = Object.freeze({
+      scope: this.#scope,
+      rootDigest,
+      rowCount: this.#rowCount.toString() as DecimalU64V1,
+      highestFinalizedOrdinal: this.#highestFinalizedOrdinal,
+    });
+    return this.#finalEvidence;
+  }
+}
+
+/** Convenience wrapper over the streaming accumulator; input order remains authoritative. */
+export function computeFinalizedVmSetEvidenceV1(
+  scope: FinalizedVmSetScopeV1,
+  rows: Iterable<FinalizedVmSetRowV1>,
+): FinalizedVmSetEvidenceV1 {
+  const accumulator = new FinalizedVmSetAccumulatorV1(scope);
+  for (const row of rows) accumulator.append(row);
+  return accumulator.finalize();
+}
+
+function computeFinalizedVmSetLeafDigestBytesV1(
+  row: Readonly<FinalizedVmSetRowV1>,
+): Uint8Array {
+  return digestBytes(
+    LEAF_DOMAIN_BYTES,
+    canonicalizeJsonBytes(row as unknown as CanonicalJsonValue, {
+      maxBytes: 2 * 1024,
+      maxDepth: 2,
+    }),
+  );
+}
+
+function snapshotExactDataRecord<const Keys extends readonly string[]>(
+  input: unknown,
+  expectedKeys: Keys,
+  label: string,
+): Readonly<Record<Keys[number], unknown>> {
+  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
+    fail('finalized-vm-set-schema', `${label} must be a plain data object`);
+  }
+  const prototype = Object.getPrototypeOf(input);
+  if (prototype !== Object.prototype && prototype !== null) {
+    fail('finalized-vm-set-schema', `${label} must be a plain data object`);
+  }
+  const keys = Reflect.ownKeys(input);
+  if (keys.some((key) => typeof key !== 'string')) {
+    fail('finalized-vm-set-schema', `${label} must not contain symbol fields`);
+  }
+  const strings = keys as string[];
+  if (
+    strings.length !== expectedKeys.length
+    || expectedKeys.some((key) => !strings.includes(key))
+  ) {
+    fail('finalized-vm-set-schema', `${label} has unknown or missing fields`);
+  }
+  const snapshot: Record<string, unknown> = Object.create(null);
+  for (const key of expectedKeys) {
+    const descriptor = Object.getOwnPropertyDescriptor(input, key);
+    if (!descriptor?.enumerable || !Object.prototype.hasOwnProperty.call(descriptor, 'value')) {
+      fail('finalized-vm-set-schema', `${label}.${key} must be an enumerable data field`);
+    }
+    snapshot[key] = descriptor.value;
+  }
+  return Object.freeze(snapshot) as Readonly<Record<Keys[number], unknown>>;
+}
+
+function digestBytes(domain: Uint8Array, ...chunks: readonly Uint8Array[]): Uint8Array {
+  const hasher = sha256.create();
+  hasher.update(domain);
+  for (const chunk of chunks) hasher.update(chunk);
+  return hasher.digest();
+}
+
+function digestBytesToLowerHex(bytes: Uint8Array): Digest32V1 {
+  let value = '0x';
+  for (const byte of bytes) value += byte.toString(16).padStart(2, '0');
+  assertCanonicalDigest(value);
+  return value;
+}
+
+function fail(
+  code: FinalizedVmSetV1ErrorCode,
+  message: string,
+  cause?: unknown,
+): never {
+  throw new FinalizedVmSetV1Error(code, message, cause === undefined ? {} : { cause });
+}

--- a/packages/core/src/finalized-vm-set-v1.ts
+++ b/packages/core/src/finalized-vm-set-v1.ts
@@ -88,7 +88,6 @@ type CanonicalFinalizedVmSetRowV1 = Readonly<FinalizedVmSetRowV1>
 interface ValidatedFinalizedVmSetRowV1 {
   readonly row: CanonicalFinalizedVmSetRowV1;
   readonly ordinalValue: bigint;
-  readonly assertionVersionValue: bigint;
 }
 
 export type FinalizedVmSetV1ErrorCode =
@@ -234,7 +233,7 @@ function snapshotFinalizedVmSetRowForScopeV1(
     finalizedBlockHash: record.finalizedBlockHash,
     placementEvidenceDigest: record.placementEvidenceDigest,
   }) as CanonicalFinalizedVmSetRowV1;
-  return Object.freeze({ row, ordinalValue, assertionVersionValue });
+  return Object.freeze({ row, ordinalValue });
 }
 
 /** Compute the exact domain-separated RFC-64 leaf digest for one placed row. */
@@ -261,11 +260,7 @@ export function computeEmptyFinalizedVmSetRootV1(): Digest32V1 {
  */
 export class FinalizedVmSetAccumulatorV1 {
   readonly #scope: Readonly<FinalizedVmSetScopeV1>;
-  readonly #frontier = new DomainSeparatedMerkleFrontier(
-    NODE_DOMAIN_BYTES,
-    ODD_DOMAIN_BYTES,
-    EMPTY_DOMAIN_BYTES,
-  );
+  readonly #frontier = new FinalizedVmSetMerkleFrontier();
   #rowCount = 0n;
   #highestFinalizedOrdinal: DecimalU64V1 | null = null;
   #highestOrdinalValue: bigint | null = null;
@@ -344,15 +339,10 @@ function computeFinalizedVmSetLeafDigestBytesV1(
   );
 }
 
-class DomainSeparatedMerkleFrontier {
+/** Feature-local frontier for the fixed finalized-VM set digest domains. */
+class FinalizedVmSetMerkleFrontier {
   readonly #levels: Array<Uint8Array | undefined> = [];
   #finalRoot: Uint8Array | undefined;
-
-  constructor(
-    private readonly nodeDomain: Uint8Array,
-    private readonly oddDomain: Uint8Array,
-    private readonly emptyDomain: Uint8Array,
-  ) {}
 
   append(leafDigest: Uint8Array): void {
     if (this.#finalRoot !== undefined) {
@@ -361,7 +351,7 @@ class DomainSeparatedMerkleFrontier {
     let current = leafDigest;
     let level = 0;
     while (this.#levels[level] !== undefined) {
-      current = digestBytes(this.nodeDomain, this.#levels[level]!, current);
+      current = digestBytes(NODE_DOMAIN_BYTES, this.#levels[level]!, current);
       this.#levels[level] = undefined;
       level += 1;
     }
@@ -382,13 +372,13 @@ class DomainSeparatedMerkleFrontier {
         continue;
       }
       while (pendingLevel < level) {
-        pending = digestBytes(this.oddDomain, pending);
+        pending = digestBytes(ODD_DOMAIN_BYTES, pending);
         pendingLevel += 1;
       }
-      pending = digestBytes(this.nodeDomain, left, pending);
+      pending = digestBytes(NODE_DOMAIN_BYTES, left, pending);
       pendingLevel = level + 1;
     }
-    this.#finalRoot = pending ?? digestBytes(this.emptyDomain);
+    this.#finalRoot = pending ?? digestBytes(EMPTY_DOMAIN_BYTES);
     return this.#finalRoot;
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -52,7 +52,17 @@ export * from './ka-bundle-v1.js';
 export * from './ka-chunk-tree.js';
 export * from './ka-chunk-proof.js';
 export * from './cg-shared-projection.js';
-export * from './finalized-vm-set-v1.js';
+export {
+  FinalizedVmSetAccumulatorV1,
+  FinalizedVmSetV1Error,
+  computeFinalizedVmSetEvidenceV1,
+  computeFinalizedVmSetLeafDigestV1,
+  type FinalizedVmLaneV1,
+  type FinalizedVmSetEvidenceV1,
+  type FinalizedVmSetRowV1,
+  type FinalizedVmSetScopeV1,
+  type FinalizedVmSetV1ErrorCode,
+} from './finalized-vm-set-v1.js';
 export * from './author-catalog-codec.js';
 export * from './author-catalog-objects.js';
 export * from './author-catalog-directory.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -52,6 +52,7 @@ export * from './ka-bundle-v1.js';
 export * from './ka-chunk-tree.js';
 export * from './ka-chunk-proof.js';
 export * from './cg-shared-projection.js';
+export * from './finalized-vm-set-v1.js';
 export * from './author-catalog-codec.js';
 export * from './author-catalog-objects.js';
 export * from './author-catalog-directory.js';

--- a/packages/core/src/sync-wire-identifiers.ts
+++ b/packages/core/src/sync-wire-identifiers.ts
@@ -1,0 +1,27 @@
+/** Cross-protocol network identifier used by RFC-64 wire objects. */
+declare const NETWORK_ID_V1_BRAND: unique symbol;
+
+export type NetworkIdV1 = string & { readonly [NETWORK_ID_V1_BRAND]: true };
+
+export const MAX_NETWORK_ID_BYTES_V1 = 128;
+
+const NETWORK_ID_PATTERN = /^[A-Za-z0-9._:-]+$/;
+const UTF8 = new TextEncoder();
+
+export function assertNetworkIdV1(
+  value: unknown,
+  label = 'networkId',
+): asserts value is NetworkIdV1 {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+  if (
+    value.length > MAX_NETWORK_ID_BYTES_V1
+    || UTF8.encode(value).byteLength > MAX_NETWORK_ID_BYTES_V1
+  ) {
+    throw new Error(`${label} exceeds ${MAX_NETWORK_ID_BYTES_V1} UTF-8 bytes`);
+  }
+  if (!NETWORK_ID_PATTERN.test(value)) {
+    throw new Error(`${label} contains a character outside the networkId grammar`);
+  }
+}

--- a/packages/core/src/sync-wire-objects.ts
+++ b/packages/core/src/sync-wire-objects.ts
@@ -5,13 +5,17 @@ export function isPlainRecord(value: unknown): value is Record<string, unknown> 
   return prototype === Object.prototype || prototype === null;
 }
 
-/** Require one plain record to contain exactly enumerable string data fields. */
-export function assertExactKeys(
-  record: Record<string, unknown>,
-  expected: readonly string[],
+/** Snapshot one closed plain record without invoking accessors or re-reading fields. */
+export function snapshotExactDataRecord<const Keys extends readonly string[]>(
+  value: unknown,
+  expected: Keys,
   label: string,
-): void {
-  const actual = Reflect.ownKeys(record);
+): Readonly<Record<Keys[number], unknown>> {
+  if (!isPlainRecord(value)) {
+    throw new Error(`${label} must be a plain data object`);
+  }
+
+  const actual = Reflect.ownKeys(value);
   if (actual.some((key) => typeof key !== 'string')) {
     throw new Error(`${label} must not contain symbol properties`);
   }
@@ -23,10 +27,23 @@ export function assertExactKeys(
   ) {
     throw new Error(`${label} has unknown or missing fields`);
   }
-  for (const key of strings) {
-    const descriptor = Object.getOwnPropertyDescriptor(record, key);
+
+  const snapshot: Record<string, unknown> = Object.create(null);
+  for (const key of expected) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
     if (!descriptor?.enumerable || !Object.prototype.hasOwnProperty.call(descriptor, 'value')) {
       throw new Error(`${label} fields must be enumerable data properties`);
     }
+    snapshot[key] = descriptor.value;
   }
+  return Object.freeze(snapshot) as Readonly<Record<Keys[number], unknown>>;
+}
+
+/** Require one plain record to contain exactly enumerable string data fields. */
+export function assertExactKeys(
+  record: Record<string, unknown>,
+  expected: readonly string[],
+  label: string,
+): void {
+  snapshotExactDataRecord(record, expected, label);
 }

--- a/packages/core/test/finalized-vm-set-v1.test.ts
+++ b/packages/core/test/finalized-vm-set-v1.test.ts
@@ -72,11 +72,11 @@ describe('RFC-64 finalized VM-set accumulator', () => {
   });
 
   it('streams ordered rows with logarithmic retained tree state and finalizes idempotently', () => {
+    const rows = [row(0), row(3), row(9)];
     const accumulator = new FinalizedVmSetAccumulatorV1(SCOPE);
-    accumulator.append(row(0));
-    accumulator.append(row(3));
-    accumulator.append(row(9));
+    for (const value of rows) accumulator.append(value);
     const first = accumulator.finalize();
+    expect(first.rootDigest).toBe(computeReferenceRoot(rows));
     expect(first.rowCount).toBe('3');
     expect(first.highestFinalizedOrdinal).toBe('9');
     expect(accumulator.finalize()).toBe(first);

--- a/packages/core/test/finalized-vm-set-v1.test.ts
+++ b/packages/core/test/finalized-vm-set-v1.test.ts
@@ -15,6 +15,7 @@ import {
 const AUTHOR = '0x1111111111111111111111111111111111111111';
 const CONTRACT = '0x2222222222222222222222222222222222222222';
 const OTHER_CONTRACT = '0x3333333333333333333333333333333333333333';
+const OTHER_CHAIN = '20431';
 const SCOPE = Object.freeze({
   networkId: 'otp:20430',
   chainId: '20430',
@@ -22,6 +23,26 @@ const SCOPE = Object.freeze({
 }) as FinalizedVmSetScopeV1;
 
 describe('RFC-64 finalized VM-set accumulator', () => {
+  it('returns the complete frozen empty-set evidence contract', () => {
+    const mutableScope = {
+      networkId: SCOPE.networkId,
+      chainId: SCOPE.chainId,
+      contractAddress: SCOPE.contractAddress,
+    } as FinalizedVmSetScopeV1;
+    const evidence = new FinalizedVmSetAccumulatorV1(mutableScope).finalize();
+    mutableScope.contractAddress = OTHER_CONTRACT as never;
+
+    expect(evidence).toEqual({
+      scope: SCOPE,
+      rootDigest: '0x900f13ea9b9bfc985dfd4beedf0ae0a6f01ff3a5a211943e18a751187dd9a09d',
+      rowCount: '0',
+      highestFinalizedOrdinal: null,
+    });
+    expect(Object.isFrozen(evidence)).toBe(true);
+    expect(Object.isFrozen(evidence.scope)).toBe(true);
+    expect(evidence.scope).not.toBe(mutableScope);
+  });
+
   it('matches independent empty, one, even, and odd tree vectors', () => {
     expect(computeEmptyFinalizedVmSetRootV1()).toBe(
       '0x900f13ea9b9bfc985dfd4beedf0ae0a6f01ff3a5a211943e18a751187dd9a09d',
@@ -86,6 +107,13 @@ describe('RFC-64 finalized VM-set accumulator', () => {
       'finalized-vm-set-lane',
     );
     expectFailureCode(
+      () => snapshotFinalizedVmSetRowV1(
+        SCOPE,
+        { ...row(0), chainId: OTHER_CHAIN } as FinalizedVmSetRowV1,
+      ),
+      'finalized-vm-set-lane',
+    );
+    expectFailureCode(
       () => computeFinalizedVmSetLeafDigestV1(
         SCOPE,
         { ...row(0), contractAddress: OTHER_CONTRACT } as FinalizedVmSetRowV1,
@@ -96,31 +124,31 @@ describe('RFC-64 finalized VM-set accumulator', () => {
 
   it('rejects UAL aliases and author mismatches before hashing', () => {
     expectFailureCode(
-      () => snapshotFinalizedVmSetRowV1({
+      () => snapshotFinalizedVmSetRowV1(SCOPE, {
         ...row(0),
         ual: `did:dkg:otp:20430/${AUTHOR.toUpperCase()}/1`,
-      } as FinalizedVmSetRowV1, SCOPE.networkId),
+      } as FinalizedVmSetRowV1),
       'finalized-vm-set-ual',
     );
     expectFailureCode(
-      () => snapshotFinalizedVmSetRowV1({
+      () => snapshotFinalizedVmSetRowV1(SCOPE, {
         ...row(0),
         ual: `did:dkg:otp:20430/${OTHER_CONTRACT}/1`,
-      } as FinalizedVmSetRowV1, SCOPE.networkId),
+      } as FinalizedVmSetRowV1),
       'finalized-vm-set-ual',
     );
     expectFailureCode(
-      () => snapshotFinalizedVmSetRowV1({
+      () => snapshotFinalizedVmSetRowV1(SCOPE, {
         ...row(0),
         assertionVersion: '0',
-      } as FinalizedVmSetRowV1, SCOPE.networkId),
+      } as FinalizedVmSetRowV1),
       'finalized-vm-set-scalar',
     );
     expectFailureCode(
-      () => snapshotFinalizedVmSetRowV1({
+      () => snapshotFinalizedVmSetRowV1(SCOPE, {
         ...row(0),
         ual: `did:dkg:wrong-lane/${AUTHOR}/1`,
-      } as FinalizedVmSetRowV1, SCOPE.networkId),
+      } as FinalizedVmSetRowV1),
       'finalized-vm-set-ual',
     );
   });
@@ -145,8 +173,8 @@ describe('RFC-64 finalized VM-set accumulator', () => {
     });
 
     const snapshot = snapshotFinalizedVmSetRowV1(
+      SCOPE,
       proxy as FinalizedVmSetRowV1,
-      SCOPE.networkId,
     );
     expect(snapshot).toEqual(row(0));
     expect([...descriptorReads.values()].every((count) => count === 1)).toBe(true);

--- a/packages/core/test/finalized-vm-set-v1.test.ts
+++ b/packages/core/test/finalized-vm-set-v1.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it } from 'vitest';
+import { sha256 } from '@noble/hashes/sha2.js';
+
+import {
+  FinalizedVmSetAccumulatorV1,
+  computeEmptyFinalizedVmSetRootV1,
+  computeFinalizedVmSetEvidenceV1,
+  computeFinalizedVmSetLeafDigestV1,
+  snapshotFinalizedVmSetRowV1,
+  type FinalizedVmSetScopeV1,
+  type FinalizedVmSetRowV1,
+  type FinalizedVmSetV1ErrorCode,
+} from '../src/finalized-vm-set-v1.js';
+
+const AUTHOR = '0x1111111111111111111111111111111111111111';
+const CONTRACT = '0x2222222222222222222222222222222222222222';
+const OTHER_CONTRACT = '0x3333333333333333333333333333333333333333';
+const SCOPE = Object.freeze({
+  networkId: 'otp:20430',
+  chainId: '20430',
+  contractAddress: CONTRACT,
+}) as FinalizedVmSetScopeV1;
+
+describe('RFC-64 finalized VM-set accumulator', () => {
+  it('matches independent empty, one, even, and odd tree vectors', () => {
+    expect(computeEmptyFinalizedVmSetRootV1()).toBe(
+      '0x900f13ea9b9bfc985dfd4beedf0ae0a6f01ff3a5a211943e18a751187dd9a09d',
+    );
+    expect(computeFinalizedVmSetLeafDigestV1(SCOPE, row(0))).toBe(
+      '0x45304bfc182887862fe36825a90aa37787e885d3c0cf7ee700264ff0fcdbd4d2',
+    );
+
+    const roots = new Map<number, string>([
+      [1, '0x45304bfc182887862fe36825a90aa37787e885d3c0cf7ee700264ff0fcdbd4d2'],
+      [2, '0x6c432a76137e037ae3feb0b838ad7c9f49c62b46f9c75727cd128aa4db95d0be'],
+      [3, '0x94b06b80d4f8f386b71cb48d8b98394a41319a06d611ee14e3ccb8069a491ec6'],
+      [5, '0x1f99dd55651c7942351eeef93b1662fa2795f745e460910b4b199b349689ef7d'],
+    ]);
+    for (const [count, expectedRoot] of roots) {
+      const evidence = computeFinalizedVmSetEvidenceV1(
+        SCOPE,
+        Array.from({ length: count }, (_, ordinal) => row(ordinal)),
+      );
+      expect(evidence).toEqual({
+        scope: SCOPE,
+        rootDigest: expectedRoot,
+        rowCount: String(count),
+        highestFinalizedOrdinal: String(count - 1),
+      });
+    }
+  });
+
+  it('streams ordered rows with logarithmic retained tree state and finalizes idempotently', () => {
+    const accumulator = new FinalizedVmSetAccumulatorV1(SCOPE);
+    accumulator.append(row(0));
+    accumulator.append(row(3));
+    accumulator.append(row(9));
+    const first = accumulator.finalize();
+    expect(first.rowCount).toBe('3');
+    expect(first.highestFinalizedOrdinal).toBe('9');
+    expect(accumulator.finalize()).toBe(first);
+    expectFailureCode(() => accumulator.append(row(10)), 'finalized-vm-set-state');
+  });
+
+  it('matches a direct level-by-level tree for every boundary through 129 rows', () => {
+    for (let count = 0; count <= 129; count += 1) {
+      const rows = Array.from({ length: count }, (_, ordinal) => row(ordinal));
+      expect(computeFinalizedVmSetEvidenceV1(SCOPE, rows).rootDigest).toBe(
+        computeReferenceRoot(rows),
+      );
+    }
+  });
+
+  it('rejects duplicate, descending, and cross-lane rows instead of sorting them', () => {
+    const duplicate = new FinalizedVmSetAccumulatorV1(SCOPE);
+    duplicate.append(row(2));
+    expectFailureCode(() => duplicate.append(row(2)), 'finalized-vm-set-order');
+
+    const descending = new FinalizedVmSetAccumulatorV1(SCOPE);
+    descending.append(row(2));
+    expectFailureCode(() => descending.append(row(1)), 'finalized-vm-set-order');
+
+    const crossLane = new FinalizedVmSetAccumulatorV1(SCOPE);
+    expectFailureCode(
+      () => crossLane.append({ ...row(0), contractAddress: OTHER_CONTRACT } as FinalizedVmSetRowV1),
+      'finalized-vm-set-lane',
+    );
+    expectFailureCode(
+      () => computeFinalizedVmSetLeafDigestV1(
+        SCOPE,
+        { ...row(0), contractAddress: OTHER_CONTRACT } as FinalizedVmSetRowV1,
+      ),
+      'finalized-vm-set-lane',
+    );
+  });
+
+  it('rejects UAL aliases and author mismatches before hashing', () => {
+    expectFailureCode(
+      () => snapshotFinalizedVmSetRowV1({
+        ...row(0),
+        ual: `did:dkg:otp:20430/${AUTHOR.toUpperCase()}/1`,
+      } as FinalizedVmSetRowV1, SCOPE.networkId),
+      'finalized-vm-set-ual',
+    );
+    expectFailureCode(
+      () => snapshotFinalizedVmSetRowV1({
+        ...row(0),
+        ual: `did:dkg:otp:20430/${OTHER_CONTRACT}/1`,
+      } as FinalizedVmSetRowV1, SCOPE.networkId),
+      'finalized-vm-set-ual',
+    );
+    expectFailureCode(
+      () => snapshotFinalizedVmSetRowV1({
+        ...row(0),
+        assertionVersion: '0',
+      } as FinalizedVmSetRowV1, SCOPE.networkId),
+      'finalized-vm-set-scalar',
+    );
+    expectFailureCode(
+      () => snapshotFinalizedVmSetRowV1({
+        ...row(0),
+        ual: `did:dkg:wrong-lane/${AUTHOR}/1`,
+      } as FinalizedVmSetRowV1, SCOPE.networkId),
+      'finalized-vm-set-ual',
+    );
+  });
+
+  it('snapshots every caller field once and never re-reads a switching Proxy', () => {
+    const source = row(0) as unknown as Record<string, unknown>;
+    const descriptorReads = new Map<PropertyKey, number>();
+    const proxy = new Proxy(source, {
+      getOwnPropertyDescriptor(target, key) {
+        const reads = (descriptorReads.get(key) ?? 0) + 1;
+        descriptorReads.set(key, reads);
+        if (reads > 1) throw new Error(`field ${String(key)} was re-read`);
+        const descriptor = Reflect.getOwnPropertyDescriptor(target, key);
+        if (key === 'ordinal' && descriptor) {
+          return { ...descriptor, value: '0' };
+        }
+        return descriptor;
+      },
+      get(_target, key) {
+        throw new Error(`unsafe property read: ${String(key)}`);
+      },
+    });
+
+    const snapshot = snapshotFinalizedVmSetRowV1(
+      proxy as FinalizedVmSetRowV1,
+      SCOPE.networkId,
+    );
+    expect(snapshot).toEqual(row(0));
+    expect([...descriptorReads.values()].every((count) => count === 1)).toBe(true);
+  });
+
+  it('rejects Proxy re-entry instead of caching evidence during an unfinished append', () => {
+    const accumulator = new FinalizedVmSetAccumulatorV1(SCOPE);
+    let reentryCode: unknown;
+    const proxy = new Proxy(row(0), {
+      getPrototypeOf(target) {
+        try {
+          accumulator.finalize();
+        } catch (error) {
+          reentryCode = (error as Error & { code?: unknown }).code;
+        }
+        return Reflect.getPrototypeOf(target);
+      },
+    });
+
+    accumulator.append(proxy);
+    expect(reentryCode).toBe('finalized-vm-set-state');
+    expect(accumulator.finalize()).toEqual({
+      scope: SCOPE,
+      rootDigest: computeFinalizedVmSetLeafDigestV1(SCOPE, row(0)),
+      rowCount: '1',
+      highestFinalizedOrdinal: '0',
+    });
+  });
+
+  it('snapshots the lane before an input iterator can mutate its source object', () => {
+    const mutableScope = {
+      networkId: 'otp:20430',
+      chainId: '20430',
+      contractAddress: CONTRACT,
+    } as FinalizedVmSetScopeV1;
+    function* rows(): Generator<FinalizedVmSetRowV1> {
+      mutableScope.contractAddress = OTHER_CONTRACT as never;
+      yield row(0);
+    }
+    const evidence = computeFinalizedVmSetEvidenceV1(mutableScope, rows());
+    expect(evidence.scope).toEqual(SCOPE);
+  });
+});
+
+function row(ordinal: number): FinalizedVmSetRowV1 {
+  const scalar = BigInt(ordinal);
+  return Object.freeze({
+    chainId: '20430',
+    contractAddress: CONTRACT,
+    ordinal: scalar.toString(),
+    ual: `did:dkg:otp:20430/${AUTHOR}/${scalar + 1n}`,
+    authorAddress: AUTHOR,
+    assertionVersion: (scalar + 1n).toString(),
+    assertionRoot: digest(scalar + 1n),
+    finalizedBlockNumber: (100n + scalar).toString(),
+    finalizedBlockHash: digest(1000n + scalar),
+    placementEvidenceDigest: digest(2000n + scalar),
+  }) as FinalizedVmSetRowV1;
+}
+
+function digest(value: bigint): `0x${string}` {
+  return `0x${value.toString(16).padStart(64, '0')}`;
+}
+
+function computeReferenceRoot(rows: readonly FinalizedVmSetRowV1[]): `0x${string}` {
+  if (rows.length === 0) return computeEmptyFinalizedVmSetRootV1();
+  let level = rows.map((value) => hexToBytes(computeFinalizedVmSetLeafDigestV1(SCOPE, value)));
+  const encoder = new TextEncoder();
+  const nodeDomain = encoder.encode('dkg-finalized-vm-set-node-v1\n');
+  const oddDomain = encoder.encode('dkg-finalized-vm-set-odd-v1\n');
+  while (level.length > 1) {
+    const next: Uint8Array[] = [];
+    for (let index = 0; index < level.length; index += 2) {
+      next.push(index + 1 < level.length
+        ? sha256(concat(nodeDomain, level[index]!, level[index + 1]!))
+        : sha256(concat(oddDomain, level[index]!)));
+    }
+    level = next;
+  }
+  return bytesToHex(level[0]!);
+}
+
+function concat(...chunks: readonly Uint8Array[]): Uint8Array {
+  const output = new Uint8Array(chunks.reduce((total, chunk) => total + chunk.length, 0));
+  let offset = 0;
+  for (const chunk of chunks) {
+    output.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return output;
+}
+
+function hexToBytes(value: string): Uint8Array {
+  return Uint8Array.from(value.slice(2).match(/../g)!, (byte) => Number.parseInt(byte, 16));
+}
+
+function bytesToHex(value: Uint8Array): `0x${string}` {
+  return `0x${[...value].map((byte) => byte.toString(16).padStart(2, '0')).join('')}`;
+}
+
+function expectFailureCode(operation: () => unknown, expected: FinalizedVmSetV1ErrorCode): void {
+  try {
+    operation();
+  } catch (error) {
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error & { code?: unknown }).code).toBe(expected);
+    return;
+  }
+  throw new Error(`expected operation to fail with ${expected}`);
+}

--- a/packages/core/test/sync-wire-identifiers.test.ts
+++ b/packages/core/test/sync-wire-identifiers.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  MAX_NETWORK_ID_BYTES_V1,
+  assertNetworkIdV1,
+} from '../src/sync-wire-identifiers.js';
+
+describe('RFC-64 shared wire identifiers', () => {
+  it('preserves the canonical network-id grammar and byte ceiling', () => {
+    expect(() => assertNetworkIdV1('otp:20430')).not.toThrow();
+    expect(() => assertNetworkIdV1('otp/20430')).toThrow(/networkId grammar/);
+    expect(() => assertNetworkIdV1('')).toThrow(/non-empty string/);
+    expect(() => assertNetworkIdV1('a'.repeat(MAX_NETWORK_ID_BYTES_V1))).not.toThrow();
+    expect(() => assertNetworkIdV1('a'.repeat(MAX_NETWORK_ID_BYTES_V1 + 1))).toThrow(
+      /128 UTF-8 bytes/,
+    );
+  });
+});


### PR DESCRIPTION
## Scope

- Adds the exact RFC-64 finalized VM-set accumulator.
- Implements canonical domains, JCS leaves, odd-node promotion, sparse ordered rows, and O(log n) streaming state.
- Enforces network, lane, UAL-author, scalar, Proxy, and re-entry boundaries.

## Evidence

- Full core suite: 102 files, 1,570 passed.
- Focused accumulator tests: 8 passed.
- Core build, TypeScript, and diff checks passed.
- Independent review found and fixed Proxy re-entry and UAL namespace binding defects.

## Review status

Ready structural seam for review against integration/rfc64-devnet. It does not yet grant finality, publisher authority, placement authority, or semantic activation, and does not claim Gate 6 completion. No RFC-64 work targets main.