### PR TITLE
feat(agent): remove omitted RFC-64 catalog assets

### DIFF
--- a/packages/agent/src/rfc64/public-catalog-native-receiver-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-native-receiver-v1.ts
@@ -27,12 +27,14 @@ import {
   assertNetworkIdV1,
   assertSignedAuthorCatalogBucketEnvelopeV1,
   assertSignedAuthorCatalogDirectoryNodeEnvelopeV1,
+  assertSignedAuthorCatalogHeadEnvelopeV1,
   assertSignedAuthorCatalogIssuerDelegationEnvelopeV1,
   buildAuthorAttestationTypedData,
   canonicalizeAuthorCatalogBucketPayloadBytesV1,
   computeAuthorCatalogScopeDigestV1,
   computeControlSignatureVariantDigestHex,
   contextGraphWorkspaceGraphUri,
+  deriveCanonicalGraphScopedAuthorSealPlacementV1,
   deriveAuthorCatalogScopeFromHeadV1,
   readVerifiedCatalogSealBindingV1,
   readVerifiedAuthorCatalogBucketDescriptorV1,
@@ -46,13 +48,16 @@ import {
   type AuthorCatalogScopeV1,
   type CatalogSealDeploymentProfileV1,
   type CountV1,
+  type ContextGraphIdV1,
   type Digest32V1,
+  type KaIdV1,
   type SignedAuthorCatalogBucketEnvelopeV1,
   type SignedAuthorCatalogDirectoryNodeEnvelopeV1,
   type SignedAuthorCatalogHeadEnvelopeV1,
   type SignedAuthorCatalogIssuerDelegationEnvelopeV1,
   type VerifiedCatalogSealBindingSnapshotV1,
 } from '@origintrail-official/dkg-core';
+import { verifyControlEnvelopeIssuerSignatureV1 } from '@origintrail-official/dkg-chain';
 import { sha256 } from '@noble/hashes/sha2.js';
 import {
   quadsToNQuads,
@@ -103,7 +108,10 @@ export interface Rfc64PublicCatalogNativeReceiverOptionsV1 {
     Rfc64PublicCatalogNativeTransportV1,
     'fetchCatalogObject' | 'fetchKaBundle'
   >;
-  readonly controlObjects: Pick<Rfc64ControlObjectOperationsV1, 'stageVerifiedObjects'>;
+  readonly controlObjects: Pick<
+    Rfc64ControlObjectOperationsV1,
+    'stageVerifiedObjects' | 'getVerifiedObjectByDigest'
+  >;
   readonly inventory: Pick<
     Rfc64InventoryV1OperationsV1,
     'readAppliedCatalogHeadV1' | 'compareAndSwapAppliedCatalogHeadV1'
@@ -125,7 +133,17 @@ export interface Rfc64PublicCatalogNativeActivationEvidenceV1 {
   readonly swmGraph: string;
   /** Exact signed delegation/head/path/bucket/row authorization closure. */
   readonly authorship: VerifiedAuthorCatalogRowAuthorshipSnapshotV1;
+  /** Exact predecessor rows absent from this head and physically deactivated before its CAS. */
+  readonly removedRows: readonly Readonly<Rfc64PublicCatalogNativeRemovedRowEvidenceV1>[];
+  readonly removedRowCount: number;
   readonly appliedHeadStatus: 'applied' | 'existing';
+}
+
+export interface Rfc64PublicCatalogNativeRemovedRowEvidenceV1 {
+  readonly kaId: KaIdV1;
+  readonly swmGraph: string;
+  readonly sealMetaGraph: string;
+  readonly sealSubject: string;
 }
 
 export interface Rfc64PublicCatalogNativeActivatedRowEvidenceV1
@@ -143,6 +161,9 @@ export interface Rfc64PublicCatalogNativeMultiAssetActivationEvidenceV1 {
   readonly activatedTripleCount: number;
   /** Strictly increasing by mathematical KA ID. */
   readonly rows: readonly Readonly<Rfc64PublicCatalogNativeActivatedRowEvidenceV1>[];
+  /** Exact predecessor rows absent from this head and physically deactivated before its CAS. */
+  readonly removedRows: readonly Readonly<Rfc64PublicCatalogNativeRemovedRowEvidenceV1>[];
+  readonly removedRowCount: number;
   readonly appliedHeadStatus: 'applied' | 'existing';
 }
 
@@ -196,6 +217,7 @@ export class Rfc64PublicCatalogNativeReceiverV1 {
       || typeof options?.contentTransport?.fetchCatalogObject !== 'function'
       || typeof options?.contentTransport?.fetchKaBundle !== 'function'
       || typeof options.controlObjects?.stageVerifiedObjects !== 'function'
+      || typeof options.controlObjects?.getVerifiedObjectByDigest !== 'function'
       || typeof options.inventory?.readAppliedCatalogHeadV1 !== 'function'
       || typeof options.inventory?.compareAndSwapAppliedCatalogHeadV1 !== 'function'
       || typeof options.store?.query !== 'function'
@@ -702,6 +724,21 @@ export class Rfc64PublicCatalogNativeReceiverV1 {
       );
     }
 
+    // The durable applied-head points at the only catalog closure allowed to
+    // own materialization removals. Reconstruct and re-authorize that exact
+    // predecessor after every target row/bundle has verified, but before the
+    // first semantic mutation. This also makes exact-head replay a repair path
+    // for a prior indeterminate removal failure.
+    const predecessorRows = await loadExactAppliedPredecessorRows(
+      this.options.controlObjects,
+      head,
+      trustedCatalogScope,
+    );
+    const targetKaIds = new Set(preparedRows.map(({ row }) => row.kaId));
+    const plannedRemovals = predecessorRows
+      .filter((row) => !targetKaIds.has(row.kaId))
+      .map((row) => planOwnedRowRemoval(trustedCatalogScope, row));
+
     try {
       await this.options.controlObjects.stageVerifiedObjects([
         fetchedDelegation,
@@ -711,6 +748,13 @@ export class Rfc64PublicCatalogNativeReceiverV1 {
       ]);
     } catch (cause) {
       fail('catalog-native-receiver-catalog', 'verified catalog objects could not be staged', cause);
+    }
+
+    const removedRows: Rfc64PublicCatalogNativeRemovedRowEvidenceV1[] = [];
+    for (const removal of plannedRemovals) {
+      throwIfAborted(signal);
+      await deactivateExactOwnedPublicProjection(this.options.store, removal);
+      removedRows.push(removal);
     }
 
     const activatedRows: Rfc64PublicCatalogNativeActivatedRowEvidenceV1[] = [];
@@ -837,6 +881,8 @@ export class Rfc64PublicCatalogNativeReceiverV1 {
         activatedTripleCount: only.activatedTripleCount,
         swmGraph: only.swmGraph,
         authorship: only.authorship,
+        removedRows: Object.freeze(removedRows),
+        removedRowCount: removedRows.length,
         appliedHeadStatus,
       });
     }
@@ -846,6 +892,8 @@ export class Rfc64PublicCatalogNativeReceiverV1 {
       inventoryRowCount: activatedRows.length,
       activatedTripleCount,
       rows: Object.freeze(activatedRows),
+      removedRows: Object.freeze(removedRows),
+      removedRowCount: removedRows.length,
       appliedHeadStatus,
     });
   }
@@ -1206,6 +1254,220 @@ function assertDirectAuthorCatalogIssuerDelegationBindingV1(
   }
 }
 
+async function loadExactAppliedPredecessorRows(
+  controlObjects: Pick<Rfc64ControlObjectOperationsV1, 'getVerifiedObjectByDigest'>,
+  targetHead: SignedAuthorCatalogHeadEnvelopeV1,
+  trustedCatalogScope: Readonly<AuthorCatalogScopeV1>,
+): Promise<readonly Readonly<AuthorCatalogRowV1>[]> {
+  const predecessorDigest = targetHead.payload.previousHeadDigest;
+  if (predecessorDigest === null) {
+    fail('catalog-native-receiver-history', 'successor has no predecessor digest');
+  }
+  try {
+    const storedHead = await controlObjects.getVerifiedObjectByDigest({
+      objectDigest: predecessorDigest,
+      verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
+    });
+    if (storedHead === null) throw new Error('applied predecessor head is not staged');
+    assertSignedAuthorCatalogHeadEnvelopeV1(storedHead.envelope);
+    const predecessorHead = storedHead.envelope;
+    if (
+      predecessorHead.objectDigest !== predecessorDigest
+      || predecessorHead.payload.version === targetHead.payload.version
+      || BigInt(predecessorHead.payload.version) + 1n !== BigInt(targetHead.payload.version)
+      || BigInt(predecessorHead.payload.totalRows) > BigInt(MAX_AUTHOR_CATALOG_BUCKET_ROWS_V1)
+    ) {
+      throw new Error('predecessor identity, version, or row bound differs from target history');
+    }
+    assertAuthorCatalogHeadScopeBindingV1(predecessorHead.payload, trustedCatalogScope);
+
+    const storedDelegation = await controlObjects.getVerifiedObjectByDigest({
+      objectDigest: predecessorHead.payload.catalogIssuerDelegationDigest,
+      verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
+    });
+    if (storedDelegation === null) throw new Error('predecessor delegation is not staged');
+    assertSignedAuthorCatalogIssuerDelegationEnvelopeV1(storedDelegation.envelope);
+    assertDirectAuthorCatalogIssuerDelegationBindingV1(
+      storedDelegation.envelope,
+      predecessorHead,
+      trustedCatalogScope,
+    );
+
+    const storedDirectory = await controlObjects.getVerifiedObjectByDigest({
+      objectDigest: predecessorHead.payload.directoryRootDigest,
+      verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
+    });
+    if (storedDirectory === null) throw new Error('predecessor directory root is not staged');
+    assertSignedAuthorCatalogDirectoryNodeEnvelopeV1(
+      storedDirectory.envelope,
+      predecessorHead.payload.bucketCount,
+    );
+    const directory = storedDirectory.envelope;
+    assertAuthorCatalogDirectoryNodeScopeBindingV1(
+      directory.payload,
+      deriveAuthorCatalogScopeFromHeadV1(predecessorHead.payload),
+    );
+    if (
+      directory.objectDigest !== predecessorHead.payload.directoryRootDigest
+      || directory.issuer !== predecessorHead.issuer
+    ) {
+      throw new Error('predecessor directory identity or issuer differs from its head');
+    }
+    const directoryPathProof = verifyAuthorCatalogDirectoryPathV1(
+      predecessorHead,
+      [directory],
+      '0' as never,
+    );
+    const descriptor = readVerifiedAuthorCatalogBucketDescriptorV1(
+      directoryPathProof,
+      predecessorHead,
+    );
+    if (descriptor.rowCount !== predecessorHead.payload.totalRows) {
+      throw new Error('predecessor directory row count differs from its head');
+    }
+    if (predecessorHead.payload.totalRows === '0') {
+      if (
+        descriptor.bucketDigest !== ZERO_DIGEST32_V1
+        || descriptor.byteLength !== '0'
+        || descriptor.rowCount !== '0'
+      ) {
+        throw new Error('empty predecessor descriptor is not canonical');
+      }
+      return Object.freeze([]);
+    }
+    if (descriptor.bucketDigest === ZERO_DIGEST32_V1) {
+      throw new Error('non-empty predecessor has an empty bucket digest');
+    }
+
+    const storedBucket = await controlObjects.getVerifiedObjectByDigest({
+      objectDigest: descriptor.bucketDigest,
+      verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
+    });
+    if (storedBucket === null) throw new Error('predecessor bucket is not staged');
+    assertSignedAuthorCatalogBucketEnvelopeV1(storedBucket.envelope);
+    const bucket = storedBucket.envelope;
+    assertAuthorCatalogBucketScopeBindingV1(
+      bucket.payload,
+      deriveAuthorCatalogScopeFromHeadV1(predecessorHead.payload),
+    );
+    if (
+      bucket.objectDigest !== descriptor.bucketDigest
+      || bucket.issuer !== predecessorHead.issuer
+      || bucket.payload.bucketId !== descriptor.bucketId
+      || bucket.payload.rows.length.toString() !== descriptor.rowCount
+      || canonicalizeAuthorCatalogBucketPayloadBytesV1(bucket.payload).byteLength.toString()
+        !== descriptor.byteLength
+    ) {
+      throw new Error('predecessor bucket differs from its verified descriptor');
+    }
+
+    for (const row of bucket.payload.rows) {
+      verifyAuthorCatalogRowAuthorshipV1({
+        catalogIssuerDelegation: storedDelegation.envelope,
+        catalogIssuerDelegationSignature: storedDelegation.issuerSignature,
+        parentAuthorAgentEvidence: null,
+        catalogHead: predecessorHead,
+        catalogHeadSignature: storedHead.issuerSignature,
+        directoryPathEnvelopes: [directory],
+        directoryPathSignatures: [storedDirectory.issuerSignature],
+        directoryPathProof,
+        catalogBucket: bucket,
+        catalogBucketSignature: storedBucket.issuerSignature,
+        targetKaId: row.kaId,
+      });
+    }
+    return Object.freeze(bucket.payload.rows.map((row) => Object.freeze({ ...row })));
+  } catch (cause) {
+    fail(
+      'catalog-native-receiver-history',
+      'exact applied predecessor catalog closure could not authorize removals',
+      cause,
+    );
+  }
+}
+
+function planOwnedRowRemoval(
+  trustedCatalogScope: Readonly<AuthorCatalogScopeV1>,
+  row: Readonly<AuthorCatalogRowV1>,
+): Readonly<Rfc64PublicCatalogNativeRemovedRowEvidenceV1> {
+  const placement = deriveCanonicalGraphScopedAuthorSealPlacementV1({
+    contextGraphId: trustedCatalogScope.contextGraphId,
+    subGraphName: trustedCatalogScope.subGraphName,
+    authorAddress: trustedCatalogScope.authorAddress,
+    assertionCoordinate: row.assertionCoordinate,
+  });
+  return Object.freeze({
+    kaId: row.kaId,
+    swmGraph: derivePublicSwmGraph(trustedCatalogScope.contextGraphId, row.kaId),
+    sealMetaGraph: placement.metaGraph,
+    sealSubject: placement.subject,
+  });
+}
+
+async function deactivateExactOwnedPublicProjection(
+  store: TripleStore,
+  removal: Readonly<Rfc64PublicCatalogNativeRemovedRowEvidenceV1>,
+): Promise<void> {
+  let replaced: boolean;
+  try {
+    replaced = await tryReplaceGraphAndSubjectAtomically(
+      store,
+      removal.swmGraph,
+      [],
+      removal.sealMetaGraph,
+      removal.sealSubject,
+      [],
+      { source: 'rfc64-public-catalog-native-deactivation' },
+    );
+  } catch (cause) {
+    fail(
+      'catalog-native-receiver-activation',
+      `atomic SWM projection and author-seal removal failed for KA ${removal.kaId}`,
+      cause,
+    );
+  }
+  if (!replaced) {
+    fail(
+      'catalog-native-receiver-activation',
+      'store lacks atomic named-graph and author-seal replacement for catalog removal',
+    );
+  }
+
+  let graphExists: boolean;
+  let sealRows;
+  try {
+    graphExists = await store.hasGraph(removal.swmGraph, {
+      source: 'rfc64-public-catalog-native-removal-post-read',
+    });
+    sealRows = await store.query(
+      `SELECT ?p ?o WHERE { GRAPH <${removal.sealMetaGraph}> { `
+        + `<${removal.sealSubject}> ?p ?o } } LIMIT 1`,
+      {
+        source: 'rfc64-public-catalog-native-removal-post-read',
+        maxResponseBytes: 4 * 1024,
+      },
+    );
+  } catch (cause) {
+    fail('catalog-native-receiver-activation', 'removed-row exact post-read failed', cause);
+  }
+  if (
+    graphExists
+    || sealRows.type !== 'bindings'
+    || sealRows.bindings.length !== 0
+  ) {
+    fail(
+      'catalog-native-receiver-activation',
+      `removed KA ${removal.kaId} projection or author seal remains present`,
+    );
+  }
+}
+
+function derivePublicSwmGraph(contextGraphId: ContextGraphIdV1, kaId: KaIdV1): string {
+  const identity = unpackKnowledgeAssetId(BigInt(kaId));
+  return `${contextGraphWorkspaceGraphUri(contextGraphId)}`
+    + `/${identity.agentAddress}/${identity.kaNumber.toString()}`;
+}
+
 async function activateExactPublicProjection(
   store: TripleStore,
   head: SignedAuthorCatalogHeadEnvelopeV1,
@@ -1234,9 +1496,7 @@ async function activateExactPublicProjection(
   ) {
     fail('catalog-native-receiver-activation', 'projection/parser triple count or graph scope changed');
   }
-  const identity = unpackKnowledgeAssetId(BigInt(row.kaId));
-  const swmGraph = `${contextGraphWorkspaceGraphUri(head.payload.contextGraphId)}`
-    + `/${identity.agentAddress}/${identity.kaNumber.toString()}`;
+  const swmGraph = derivePublicSwmGraph(head.payload.contextGraphId, row.kaId);
   const graphQuads = quads.map((quad) => ({ ...quad, graph: swmGraph }));
   let replaced: boolean;
   try {

--- a/packages/agent/test/rfc64-public-catalog-native-gate1.integration.test.ts
+++ b/packages/agent/test/rfc64-public-catalog-native-gate1.integration.test.ts
@@ -18,6 +18,7 @@ import {
   computeCanonicalGraphScopedAuthorSealDigestV1,
   computeControlObjectDigestHex,
   computeKaChunkTreeRootV1,
+  deriveCanonicalGraphScopedAuthorSealPlacementV1,
   deriveAuthorCatalogScopeFromHeadV1,
   encodeOpaqueKaBundleV1,
   type AuthorCatalogRowV1,
@@ -36,7 +37,7 @@ import {
   type UnsignedControlEnvelopeV1,
 } from '@origintrail-official/dkg-core';
 import { verifyControlEnvelopeIssuerSignatureV1 } from '@origintrail-official/dkg-chain';
-import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import { OxigraphStore, type TripleStore } from '@origintrail-official/dkg-storage';
 import { ethers } from 'ethers';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -78,6 +79,7 @@ const KA_NUMBER = 7n;
 const KA_ID = ((BigInt(AUTHOR) << 96n) | KA_NUMBER).toString();
 const UAL = `did:dkg:${NETWORK_ID}/${AUTHOR}/${KA_NUMBER}`;
 const SECOND_KA_NUMBER = 8n;
+const SECOND_KA_ID = ((BigInt(AUTHOR) << 96n) | SECOND_KA_NUMBER).toString();
 const SECOND_UAL = `did:dkg:${NETWORK_ID}/${AUTHOR}/${SECOND_KA_NUMBER}`;
 const PROJECTION =
   '<https://example.org/alice> <https://schema.org/age> "42"^^<http://www.w3.org/2001/XMLSchema#integer> .\n'
@@ -320,6 +322,196 @@ describe('RFC-64 Gate 1 native successor to public SWM', () => {
       inventoryRowCount: '2',
     });
     await expect(fixture.receiverStore.countQuads()).resolves.toBe(32);
+  }, 30_000);
+
+  it('converges a valid two-to-one successor by removing the omitted SWM projection and seal before CAS', async () => {
+    const fixture = await setupLiveReceiver();
+    await fixture.bootstrap();
+    await fixture.synchronize();
+    await fixture.synchronizeAny(fixture.multiAssetAnnouncement);
+    const observed = fixture.createCasObservedReceiver();
+
+    const evidence = await fixture.synchronizeAny(
+      fixture.removalAnnouncement,
+      observed.receiver,
+    );
+    if (!('catalogRowDigest' in evidence)) throw new Error('one-row removal returned non-one-row evidence');
+    const removedSwmGraph =
+      `did:dkg:context-graph:${CONTEXT_GRAPH_ID}/_shared_memory/${AUTHOR}/${SECOND_KA_NUMBER}`;
+    const removedSeal = deriveCanonicalGraphScopedAuthorSealPlacementV1({
+      contextGraphId: CONTEXT_GRAPH_ID,
+      subGraphName: null,
+      authorAddress: AUTHOR,
+      assertionCoordinate: 'gate-2-object' as never,
+    });
+    expect(evidence).toMatchObject({
+      catalogHeadDigest: fixture.removalSuccessor.head.objectDigest,
+      inventoryRowCount: 1,
+      removedRowCount: 1,
+      removedRows: [{
+        kaId: SECOND_KA_ID,
+        swmGraph: removedSwmGraph,
+        sealMetaGraph: removedSeal.metaGraph,
+        sealSubject: removedSeal.subject,
+      }],
+      kaUal: UAL,
+      appliedHeadStatus: 'applied',
+    });
+    expect(Object.isFrozen(evidence.removedRows)).toBe(true);
+    await expect(fixture.receiverStore.hasGraph(removedSwmGraph)).resolves.toBe(false);
+    await expect(fixture.receiverStore.hasGraph(
+      `did:dkg:context-graph:${CONTEXT_GRAPH_ID}/_shared_memory/${AUTHOR}/${KA_NUMBER}`,
+    )).resolves.toBe(true);
+    const removedSealRows = await fixture.receiverStore.query(
+      `SELECT ?p ?o WHERE { GRAPH <${removedSeal.metaGraph}> { `
+        + `<${removedSeal.subject}> ?p ?o } }`,
+    );
+    expect(removedSealRows).toEqual({ type: 'bindings', bindings: [] });
+    expect(observed.compareAndSwapAppliedCatalogHeadV1).toHaveBeenCalledOnce();
+    expect(fixture.receiverPersistence.inventory.readAppliedCatalogHeadV1(
+      fixture.scopeDigest,
+      AUTHOR,
+    )).toMatchObject({
+      currentCatalogHeadDigest: fixture.removalSuccessor.head.objectDigest,
+      inventoryRowCount: '1',
+    });
+    await expect(fixture.receiverStore.countQuads()).resolves.toBe(16);
+  }, 30_000);
+
+  it('verifies a removal target completely before an omitted predecessor row can be mutated', async () => {
+    const fixture = await setupLiveReceiver();
+    await fixture.bootstrap();
+    await fixture.synchronize();
+    await fixture.synchronizeAny(fixture.multiAssetAnnouncement);
+    const omittedSwmGraph =
+      `did:dkg:context-graph:${CONTEXT_GRAPH_ID}/_shared_memory/${AUTHOR}/${SECOND_KA_NUMBER}`;
+    const fetchKaBundle: Rfc64PublicCatalogNativeTransportV1['fetchKaBundle'] =
+      async (...args) => {
+        const bundle = await fixture.receiverBundleFetch(...args);
+        if (bundle === null) return null;
+        const forged = bundle.slice();
+        forged[forged.length - 1] ^= 0x01;
+        return forged;
+      };
+    const observed = fixture.createCasObservedReceiver({
+      fetchCatalogObject: fixture.receiverObjectFetch,
+      fetchKaBundle,
+    });
+
+    await expect(fixture.synchronizeAny(
+      fixture.removalAnnouncement,
+      observed.receiver,
+    )).rejects.toMatchObject({ code: 'catalog-native-receiver-transfer' });
+    expect(observed.stageVerifiedObjects).not.toHaveBeenCalled();
+    expect(observed.compareAndSwapAppliedCatalogHeadV1).not.toHaveBeenCalled();
+    await expect(fixture.receiverStore.hasGraph(omittedSwmGraph)).resolves.toBe(true);
+    await expect(fixture.receiverStore.countQuads()).resolves.toBe(32);
+    expect(fixture.receiverPersistence.inventory.readAppliedCatalogHeadV1(
+      fixture.scopeDigest,
+      AUTHOR,
+    )?.currentCatalogHeadDigest).toBe(fixture.multiAssetSuccessor.head.objectDigest);
+  }, 30_000);
+
+  it('never removes projection or seal state owned by another catalog author scope', async () => {
+    const fixture = await setupLiveReceiver();
+    await fixture.bootstrap();
+    await fixture.synchronize();
+    await fixture.synchronizeAny(fixture.multiAssetAnnouncement);
+    const foreignAuthor = '0x9999999999999999999999999999999999999999' as EvmAddressV1;
+    const foreignGraph =
+      `did:dkg:context-graph:${CONTEXT_GRAPH_ID}/_shared_memory/${foreignAuthor}/${SECOND_KA_NUMBER}`;
+    const foreignSeal = deriveCanonicalGraphScopedAuthorSealPlacementV1({
+      contextGraphId: CONTEXT_GRAPH_ID,
+      subGraphName: null,
+      authorAddress: foreignAuthor,
+      assertionCoordinate: 'foreign-object' as never,
+    });
+    await fixture.receiverStore.insert([
+      {
+        subject: 'https://example.org/foreign',
+        predicate: 'https://schema.org/name',
+        object: '"Foreign"',
+        graph: foreignGraph,
+      },
+      {
+        subject: foreignSeal.subject,
+        predicate: 'https://example.org/foreignSeal',
+        object: '"owned elsewhere"',
+        graph: foreignSeal.metaGraph,
+      },
+    ]);
+
+    await fixture.synchronizeAny(fixture.removalAnnouncement);
+
+    await expect(fixture.receiverStore.hasGraph(foreignGraph)).resolves.toBe(true);
+    const foreignSealRows = await fixture.receiverStore.query(
+      `SELECT ?p ?o WHERE { GRAPH <${foreignSeal.metaGraph}> { `
+        + `<${foreignSeal.subject}> ?p ?o } }`,
+    );
+    expect(foreignSealRows).toMatchObject({
+      type: 'bindings',
+      bindings: [{
+        p: 'https://example.org/foreignSeal',
+        o: '"owned elsewhere"',
+      }],
+    });
+  }, 30_000);
+
+  it('withholds the head CAS after an indeterminate removal and converges on a new receiver instance', async () => {
+    const fixture = await setupLiveReceiver();
+    await fixture.bootstrap();
+    await fixture.synchronize();
+    await fixture.synchronizeAny(fixture.multiAssetAnnouncement);
+    const omittedSwmGraph =
+      `did:dkg:context-graph:${CONTEXT_GRAPH_ID}/_shared_memory/${AUTHOR}/${SECOND_KA_NUMBER}`;
+    let injectAfterCommittedRemoval = true;
+    const faultStore = new Proxy(fixture.receiverStore, {
+      get(target, property) {
+        if (property === 'replaceGraphAndSubject') {
+          return async (...args: Parameters<NonNullable<TripleStore['replaceGraphAndSubject']>>) => {
+            await target.replaceGraphAndSubject!(...args);
+            if (args[1].length === 0 && injectAfterCommittedRemoval) {
+              injectAfterCommittedRemoval = false;
+              throw new Error('injected indeterminate post-commit removal failure');
+            }
+          };
+        }
+        const value = Reflect.get(target, property, target) as unknown;
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    }) as TripleStore;
+    const failed = fixture.createCasObservedReceiver(undefined, faultStore);
+
+    await expect(fixture.synchronizeAny(
+      fixture.removalAnnouncement,
+      failed.receiver,
+    )).rejects.toMatchObject({ code: 'catalog-native-receiver-activation' });
+    expect(failed.compareAndSwapAppliedCatalogHeadV1).not.toHaveBeenCalled();
+    expect(fixture.receiverPersistence.inventory.readAppliedCatalogHeadV1(
+      fixture.scopeDigest,
+      AUTHOR,
+    )?.currentCatalogHeadDigest).toBe(fixture.multiAssetSuccessor.head.objectDigest);
+    await expect(fixture.receiverStore.hasGraph(omittedSwmGraph)).resolves.toBe(false);
+
+    const restartedReceiver = fixture.createReceiver(fixture.receiverPersistence.inventory);
+    const repaired = await fixture.synchronizeAny(
+      fixture.removalAnnouncement,
+      restartedReceiver,
+    );
+    expect(repaired).toMatchObject({
+      catalogHeadDigest: fixture.removalSuccessor.head.objectDigest,
+      removedRowCount: 1,
+      appliedHeadStatus: 'applied',
+    });
+    await expect(fixture.receiverStore.hasGraph(omittedSwmGraph)).resolves.toBe(false);
+    await expect(fixture.receiverStore.countQuads()).resolves.toBe(16);
+    expect(fixture.receiverPersistence.inventory.readAppliedCatalogHeadV1(
+      fixture.scopeDigest,
+      AUTHOR,
+    )).toMatchObject({
+      currentCatalogHeadDigest: fixture.removalSuccessor.head.objectDigest,
+      inventoryRowCount: '1',
+    });
   }, 30_000);
 
   it('verifies all multi-asset bundles before staging, SWM mutation, or applied-head CAS', async () => {
@@ -842,6 +1034,15 @@ async function setupLiveReceiver(signingWallet = AUTHOR_WALLET) {
     issuedAt: '1773900001002' as never,
     signer,
   });
+  const removalSuccessor = await produceSparseAuthorCatalogSuccessorV1({
+    previousHead: multiAssetSuccessor.head,
+    previousDirectoryPath: multiAssetSuccessor.directoryPath,
+    previousBucket: multiAssetSuccessor.bucket,
+    selectedBucketId: '0' as never,
+    nextRows: [rowBundle.row],
+    issuedAt: '1773900001003' as never,
+    signer,
+  });
   const governedSuccessor = await produceSparseAuthorCatalogSuccessorV1({
     previousHead: governedGenesis.head,
     previousDirectoryPath: governedGenesis.directoryPath,
@@ -887,6 +1088,7 @@ async function setupLiveReceiver(signingWallet = AUTHOR_WALLET) {
       ...invalidGenesis.stagedObjects,
       ...successor.stagedObjects,
       ...multiAssetSuccessor.stagedObjects,
+      ...removalSuccessor.stagedObjects,
       ...governedSuccessor.stagedObjects,
       ...competingSuccessor.stagedObjects,
       crossLaneHead,
@@ -914,6 +1116,7 @@ async function setupLiveReceiver(signingWallet = AUTHOR_WALLET) {
       ...invalidGenesis.stagedObjects,
       ...successor.stagedObjects,
       ...multiAssetSuccessor.stagedObjects,
+      ...removalSuccessor.stagedObjects,
       ...governedSuccessor.stagedObjects,
       ...competingSuccessor.stagedObjects,
       crossLaneHead,
@@ -945,6 +1148,9 @@ async function setupLiveReceiver(signingWallet = AUTHOR_WALLET) {
   const multiAssetHeadKeys = staged.objects.find(
     (keys) => keys.objectDigest === multiAssetSuccessor.head.objectDigest,
   );
+  const removalHeadKeys = staged.objects.find(
+    (keys) => keys.objectDigest === removalSuccessor.head.objectDigest,
+  );
   const governedGenesisHeadKeys = staged.objects.find(
     (keys) => keys.objectDigest === governedGenesis.head.objectDigest,
   );
@@ -969,6 +1175,7 @@ async function setupLiveReceiver(signingWallet = AUTHOR_WALLET) {
   if (headKeys === undefined) throw new Error('successor head was not staged');
   if (genesisHeadKeys === undefined) throw new Error('genesis head was not staged');
   if (multiAssetHeadKeys === undefined) throw new Error('multi-asset successor head was not staged');
+  if (removalHeadKeys === undefined) throw new Error('removal successor head was not staged');
   if (governedGenesisHeadKeys === undefined) throw new Error('governed genesis head was not staged');
   if (governedSuccessorHeadKeys === undefined) throw new Error('governed successor head was not staged');
   if (invalidGenesisHeadKeys === undefined) throw new Error('invalid genesis head was not staged');
@@ -1049,6 +1256,12 @@ async function setupLiveReceiver(signingWallet = AUTHOR_WALLET) {
     catalogHeadObjectDigest: multiAssetHeadKeys.objectDigest,
     signatureVariantDigest: multiAssetHeadKeys.signatureVariantDigest,
   }) satisfies Rfc64PublicCatalogHeadAnnouncementV1;
+  const removalAnnouncement = Object.freeze({
+    ...announcement,
+    catalogVersion: removalSuccessor.head.payload.version,
+    catalogHeadObjectDigest: removalHeadKeys.objectDigest,
+    signatureVariantDigest: removalHeadKeys.signatureVariantDigest,
+  }) satisfies Rfc64PublicCatalogHeadAnnouncementV1;
   const competingAnnouncement = Object.freeze({
     ...announcement,
     catalogHeadObjectDigest: competingHeadKeys.objectDigest,
@@ -1103,7 +1316,7 @@ async function setupLiveReceiver(signingWallet = AUTHOR_WALLET) {
     >,
     controlObjects: Pick<
       Rfc64PersistenceV1['controlObjects'],
-      'stageVerifiedObjects'
+      'stageVerifiedObjects' | 'getVerifiedObjectByDigest'
     > = receiverPersistence.controlObjects,
     contentTransport: Pick<
       Rfc64PublicCatalogNativeTransportV1,
@@ -1112,17 +1325,18 @@ async function setupLiveReceiver(signingWallet = AUTHOR_WALLET) {
       fetchCatalogObject: receiverObjectFetch,
       fetchKaBundle: receiverBundleFetch,
     },
+    store: TripleStore = receiverStore,
   ) => new Rfc64PublicCatalogNativeReceiverV1({
     headTransport: { fetchCatalogHead: receiverHeadFetch },
     contentTransport,
     controlObjects,
     inventory,
-    store: receiverStore,
+    store,
   });
   const createCasObservedReceiver = (contentTransport?: Pick<
     Rfc64PublicCatalogNativeTransportV1,
     'fetchCatalogObject' | 'fetchKaBundle'
-  >) => {
+  >, store: TripleStore = receiverStore) => {
     const compareAndSwapAppliedCatalogHeadV1 = vi.fn(
       receiverPersistence.inventory.compareAndSwapAppliedCatalogHeadV1.bind(
         receiverPersistence.inventory,
@@ -1133,6 +1347,10 @@ async function setupLiveReceiver(signingWallet = AUTHOR_WALLET) {
         receiverPersistence.controlObjects,
       ),
     );
+    const getVerifiedObjectByDigest =
+      receiverPersistence.controlObjects.getVerifiedObjectByDigest.bind(
+        receiverPersistence.controlObjects,
+      );
     return Object.freeze({
       compareAndSwapAppliedCatalogHeadV1,
       stageVerifiedObjects,
@@ -1142,7 +1360,7 @@ async function setupLiveReceiver(signingWallet = AUTHOR_WALLET) {
             receiverPersistence.inventory,
           ),
         compareAndSwapAppliedCatalogHeadV1,
-      }, { stageVerifiedObjects }, contentTransport),
+      }, { stageVerifiedObjects, getVerifiedObjectByDigest }, contentTransport, store),
     });
   };
   const receiver = createReceiver(receiverPersistence.inventory);
@@ -1170,6 +1388,8 @@ async function setupLiveReceiver(signingWallet = AUTHOR_WALLET) {
     missingDelegationAnnouncement,
     multiAssetAnnouncement,
     multiAssetSuccessor,
+    removalAnnouncement,
+    removalSuccessor,
     receiverDirectory: receiverOpened.directory,
     receiverHeadFetch,
     receiverObjectFetch,


### PR DESCRIPTION
## Scope\n\nAdds exact stale-asset removal for Gate 2 successor inventories as a bounded stacked review over PR #1818.\n\n## Behavior\n\n- reconstructs and cryptographically re-verifies the exact durable predecessor closure\n- computes omissions only within the applied author/catalog scope\n- removes each omitted SWM graph and seal subject atomically\n- proves graph and seal absence before target activation and applied-head CAS\n- preserves foreign-author scope state\n- withholds the head CAS on indeterminate removal failure and proves retry convergence\n- exposes frozen removed-row evidence\n\n## Verification\n\n- native integration: 23/23\n- adjacent Gate 2 producer/completeness/reconciler/DKGAgent lane: 36/36\n- agent build, strict TypeScript, type tests, and package-root checks: passed\n- git diff --check: passed\n\n## Review boundary\n\nThis is a stacked PR whose base is codex/rfc64-gate2-composed-euler. It does not claim Gate 2 pass by itself. Cross-row crash atomicity remains part of the Gate 4 recovery proof.